### PR TITLE
feat(phase3-binary): SPEC-001 v1.3 implementation (Phases 1A-1E)

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -38,6 +38,8 @@ public struct AppConfig: Equatable, Sendable {
     public var publishesSupportedModels: Bool
     public var enableWarmSwap: Bool
     public var swapDrainTimeoutSeconds: Int
+    public var ctlSocketPath: String?
+    public var switchStatePath: String?
 
     public static let defaultConfigPath = "~/.config/macprovider/config.yaml"
 
@@ -63,7 +65,9 @@ public struct AppConfig: Equatable, Sendable {
             supportedModels: nil,
             publishesSupportedModels: false,
             enableWarmSwap: false,
-            swapDrainTimeoutSeconds: 30
+            swapDrainTimeoutSeconds: 30,
+            ctlSocketPath: nil,
+            switchStatePath: nil
         )
     }
 }
@@ -80,6 +84,8 @@ public struct CLIOverrides: Equatable, Sendable {
     public var publishesSupportedModels: Bool?
     public var enableWarmSwap: Bool?
     public var swapDrainTimeoutSeconds: Int?
+    public var ctlSocketPath: String?
+    public var switchStatePath: String?
 
     public init(
         port: Int? = nil,
@@ -92,7 +98,9 @@ public struct CLIOverrides: Equatable, Sendable {
         supportedModels: [String]? = nil,
         publishesSupportedModels: Bool? = nil,
         enableWarmSwap: Bool? = nil,
-        swapDrainTimeoutSeconds: Int? = nil
+        swapDrainTimeoutSeconds: Int? = nil,
+        ctlSocketPath: String? = nil,
+        switchStatePath: String? = nil
     ) {
         self.port = port
         self.model = model
@@ -105,6 +113,8 @@ public struct CLIOverrides: Equatable, Sendable {
         self.publishesSupportedModels = publishesSupportedModels
         self.enableWarmSwap = enableWarmSwap
         self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
+        self.ctlSocketPath = ctlSocketPath
+        self.switchStatePath = switchStatePath
     }
 }
 
@@ -204,6 +214,8 @@ public enum ConfigLoader {
         try assign(&config.publishesSupportedModels, from: dict, key: "publishes_supported_models", expected: "boolean")
         try assign(&config.enableWarmSwap, from: dict, key: "enable_warm_swap", expected: "boolean")
         try assign(&config.swapDrainTimeoutSeconds, from: dict, key: "swap_drain_timeout_s", expected: "integer")
+        try assign(&config.ctlSocketPath, from: dict, key: "ctl_socket_path", expected: "string")
+        try assign(&config.switchStatePath, from: dict, key: "switch_state_path", expected: "string")
         return config
     }
 
@@ -232,6 +244,8 @@ public enum ConfigLoader {
         try assign(&config.publishesSupportedModels, from: environment, env: "MACPROVIDER_PUBLISHES_SUPPORTED_MODELS", expected: "boolean")
         try assign(&config.enableWarmSwap, from: environment, env: "MACPROVIDER_ENABLE_WARM_SWAP", expected: "boolean")
         try assign(&config.swapDrainTimeoutSeconds, from: environment, env: "MACPROVIDER_SWAP_DRAIN_TIMEOUT_S", expected: "integer")
+        try assign(&config.ctlSocketPath, from: environment, env: "MACPROVIDER_CTL_SOCKET_PATH", expected: "string")
+        try assign(&config.switchStatePath, from: environment, env: "MACPROVIDER_SWITCH_STATE_PATH", expected: "string")
         return config
     }
 
@@ -269,6 +283,12 @@ public enum ConfigLoader {
         }
         if let swapDrainTimeoutSeconds = cli.swapDrainTimeoutSeconds {
             config.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
+        }
+        if let ctlSocketPath = cli.ctlSocketPath {
+            config.ctlSocketPath = ctlSocketPath
+        }
+        if let switchStatePath = cli.switchStatePath {
+            config.switchStatePath = switchStatePath
         }
         return config
     }

--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -36,6 +36,8 @@ public struct AppConfig: Equatable, Sendable {
     public var tier2MDAArtifactPath: String?
     public var supportedModels: [String]?
     public var publishesSupportedModels: Bool
+    public var enableWarmSwap: Bool
+    public var swapDrainTimeoutSeconds: Int
 
     public static let defaultConfigPath = "~/.config/macprovider/config.yaml"
 
@@ -59,7 +61,9 @@ public struct AppConfig: Equatable, Sendable {
             maxRequestBodyBytes: 10 * 1024 * 1024,
             tier2MDAArtifactPath: nil,
             supportedModels: nil,
-            publishesSupportedModels: false
+            publishesSupportedModels: false,
+            enableWarmSwap: false,
+            swapDrainTimeoutSeconds: 30
         )
     }
 }
@@ -74,6 +78,8 @@ public struct CLIOverrides: Equatable, Sendable {
     public var logLevel: String?
     public var supportedModels: [String]?
     public var publishesSupportedModels: Bool?
+    public var enableWarmSwap: Bool?
+    public var swapDrainTimeoutSeconds: Int?
 
     public init(
         port: Int? = nil,
@@ -84,7 +90,9 @@ public struct CLIOverrides: Equatable, Sendable {
         configPath: String? = nil,
         logLevel: String? = nil,
         supportedModels: [String]? = nil,
-        publishesSupportedModels: Bool? = nil
+        publishesSupportedModels: Bool? = nil,
+        enableWarmSwap: Bool? = nil,
+        swapDrainTimeoutSeconds: Int? = nil
     ) {
         self.port = port
         self.model = model
@@ -95,6 +103,8 @@ public struct CLIOverrides: Equatable, Sendable {
         self.logLevel = logLevel
         self.supportedModels = supportedModels
         self.publishesSupportedModels = publishesSupportedModels
+        self.enableWarmSwap = enableWarmSwap
+        self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
     }
 }
 
@@ -192,6 +202,8 @@ public enum ConfigLoader {
         try assign(&config.tier2MDAArtifactPath, from: dict, key: "tier2_mda_artifact_path", expected: "string")
         try assign(&config.supportedModels, from: dict, key: "supported_models", expected: "array of strings or comma-separated string")
         try assign(&config.publishesSupportedModels, from: dict, key: "publishes_supported_models", expected: "boolean")
+        try assign(&config.enableWarmSwap, from: dict, key: "enable_warm_swap", expected: "boolean")
+        try assign(&config.swapDrainTimeoutSeconds, from: dict, key: "swap_drain_timeout_s", expected: "integer")
         return config
     }
 
@@ -218,6 +230,8 @@ public enum ConfigLoader {
         try assign(&config.tier2MDAArtifactPath, from: environment, env: "MACPROVIDER_TIER2_MDA_ARTIFACT_PATH", expected: "string")
         config.supportedModels = SupportedModels.parseCSV(environment["MACPROVIDER_SUPPORTED_MODELS"]) ?? config.supportedModels
         try assign(&config.publishesSupportedModels, from: environment, env: "MACPROVIDER_PUBLISHES_SUPPORTED_MODELS", expected: "boolean")
+        try assign(&config.enableWarmSwap, from: environment, env: "MACPROVIDER_ENABLE_WARM_SWAP", expected: "boolean")
+        try assign(&config.swapDrainTimeoutSeconds, from: environment, env: "MACPROVIDER_SWAP_DRAIN_TIMEOUT_S", expected: "integer")
         return config
     }
 
@@ -249,6 +263,12 @@ public enum ConfigLoader {
         }
         if let publishesSupportedModels = cli.publishesSupportedModels {
             config.publishesSupportedModels = publishesSupportedModels
+        }
+        if let enableWarmSwap = cli.enableWarmSwap {
+            config.enableWarmSwap = enableWarmSwap
+        }
+        if let swapDrainTimeoutSeconds = cli.swapDrainTimeoutSeconds {
+            config.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
         }
         return config
     }

--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -34,6 +34,8 @@ public struct AppConfig: Equatable, Sendable {
     public var warmupEnabled: Bool
     public var maxRequestBodyBytes: Int
     public var tier2MDAArtifactPath: String?
+    public var supportedModels: [String]?
+    public var publishesSupportedModels: Bool
 
     public static let defaultConfigPath = "~/.config/macprovider/config.yaml"
 
@@ -55,7 +57,9 @@ public struct AppConfig: Equatable, Sendable {
             drainTimeoutSeconds: 30,
             warmupEnabled: true,
             maxRequestBodyBytes: 10 * 1024 * 1024,
-            tier2MDAArtifactPath: nil
+            tier2MDAArtifactPath: nil,
+            supportedModels: nil,
+            publishesSupportedModels: false
         )
     }
 }
@@ -68,6 +72,8 @@ public struct CLIOverrides: Equatable, Sendable {
     public var endpointURL: String?
     public var configPath: String?
     public var logLevel: String?
+    public var supportedModels: [String]?
+    public var publishesSupportedModels: Bool?
 
     public init(
         port: Int? = nil,
@@ -76,7 +82,9 @@ public struct CLIOverrides: Equatable, Sendable {
         providerID: String? = nil,
         endpointURL: String? = nil,
         configPath: String? = nil,
-        logLevel: String? = nil
+        logLevel: String? = nil,
+        supportedModels: [String]? = nil,
+        publishesSupportedModels: Bool? = nil
     ) {
         self.port = port
         self.model = model
@@ -85,6 +93,8 @@ public struct CLIOverrides: Equatable, Sendable {
         self.endpointURL = endpointURL
         self.configPath = configPath
         self.logLevel = logLevel
+        self.supportedModels = supportedModels
+        self.publishesSupportedModels = publishesSupportedModels
     }
 }
 
@@ -180,6 +190,8 @@ public enum ConfigLoader {
         try assign(&config.warmupEnabled, from: dict, key: "warmup_enabled", expected: "boolean")
         try assign(&config.maxRequestBodyBytes, from: dict, key: "max_request_body_bytes", expected: "integer")
         try assign(&config.tier2MDAArtifactPath, from: dict, key: "tier2_mda_artifact_path", expected: "string")
+        try assign(&config.supportedModels, from: dict, key: "supported_models", expected: "array of strings or comma-separated string")
+        try assign(&config.publishesSupportedModels, from: dict, key: "publishes_supported_models", expected: "boolean")
         return config
     }
 
@@ -204,6 +216,8 @@ public enum ConfigLoader {
         try assign(&config.warmupEnabled, from: environment, env: "MACPROVIDER_WARMUP_ENABLED", expected: "boolean")
         try assign(&config.maxRequestBodyBytes, from: environment, env: "MACPROVIDER_MAX_REQUEST_BODY_BYTES", expected: "integer")
         try assign(&config.tier2MDAArtifactPath, from: environment, env: "MACPROVIDER_TIER2_MDA_ARTIFACT_PATH", expected: "string")
+        config.supportedModels = SupportedModels.parseCSV(environment["MACPROVIDER_SUPPORTED_MODELS"]) ?? config.supportedModels
+        try assign(&config.publishesSupportedModels, from: environment, env: "MACPROVIDER_PUBLISHES_SUPPORTED_MODELS", expected: "boolean")
         return config
     }
 
@@ -229,6 +243,12 @@ public enum ConfigLoader {
                 throw ConfigError.invalidValue(key: "--log-level", value: logLevel, expected: "valid log level")
             }
             config.logLevel = value
+        }
+        if let supportedModels = cli.supportedModels {
+            config.supportedModels = supportedModels
+        }
+        if let publishesSupportedModels = cli.publishesSupportedModels {
+            config.publishesSupportedModels = publishesSupportedModels
         }
         return config
     }
@@ -265,6 +285,19 @@ public enum ConfigLoader {
             throw ConfigError.invalidValue(key: key, value: String(describing: value), expected: expected)
         }
         field = string
+    }
+
+    private static func assign(_ field: inout [String]?, from dict: [String: Any], key: String, expected: String) throws {
+        guard let value = dict[key], !(value is NSNull) else { return }
+        if let strings = value as? [String] {
+            field = strings
+            return
+        }
+        if let string = value as? String {
+            field = SupportedModels.parseCSV(string)
+            return
+        }
+        throw ConfigError.invalidValue(key: key, value: String(describing: value), expected: expected)
     }
 
     private static func assign(_ field: inout Bool, from dict: [String: Any], key: String, expected: String) throws {

--- a/phase3-binary/Sources/MacProviderCore/SupportedModels.swift
+++ b/phase3-binary/Sources/MacProviderCore/SupportedModels.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+public enum SupportedModelsValidationError: Error, CustomStringConvertible, Equatable {
+    case modelMissing
+    case modelNotInCatalog(model: String, catalog: [String])
+    case entryTooLong(entry: String, byteCount: Int)
+    case catalogTooLarge(count: Int)
+
+    public var description: String {
+        switch self {
+        case .modelMissing:
+            return "--supported-models requires --model to be set"
+        case let .modelNotInCatalog(model, _):
+            return "--model \(model) not in --supported-models"
+        case let .entryTooLong(entry, byteCount):
+            return "--supported-models entry exceeds 256 UTF-8 bytes: \(entry) (\(byteCount) bytes)"
+        case let .catalogTooLarge(count):
+            return "--supported-models exceeds 64 entries (got \(count))"
+        }
+    }
+}
+
+public enum SupportedModels {
+    public static let maxEntryByteLength = 256
+    public static let maxCatalogEntries = 64
+
+    public static func parseCSV(_ raw: String?) -> [String]? {
+        guard let raw else {
+            return nil
+        }
+        let entries = raw
+            .split(separator: ",", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return entries.isEmpty ? nil : entries
+    }
+
+    public static func validate(
+        model: String,
+        supportedModels: [String]?
+    ) throws -> [String] {
+        guard !model.isEmpty else {
+            throw SupportedModelsValidationError.modelMissing
+        }
+
+        let catalog = supportedModels?
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } ?? []
+        guard !catalog.isEmpty else {
+            return [model]
+        }
+
+        for entry in catalog {
+            let byteCount = entry.utf8.count
+            if byteCount > maxEntryByteLength {
+                throw SupportedModelsValidationError.entryTooLong(entry: entry, byteCount: byteCount)
+            }
+        }
+
+        if catalog.count > maxCatalogEntries {
+            throw SupportedModelsValidationError.catalogTooLarge(count: catalog.count)
+        }
+
+        let foldedModel = model.lowercased(with: nil)
+        let containsModel = catalog.contains { entry in
+            entry.lowercased(with: nil) == foldedModel
+        }
+        guard containsModel else {
+            throw SupportedModelsValidationError.modelNotInCatalog(model: model, catalog: catalog)
+        }
+
+        return catalog
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/ControlSocket.swift
+++ b/phase3-binary/Sources/macprovider-cli/ControlSocket.swift
@@ -235,7 +235,7 @@ actor ControlSocketServer {
     private let tracker = ControlSocketSwitchTracker()
     private var listenerFD: Int32?
     private var acceptTask: Task<Void, Never>?
-    private var clientTasks: [Task<Void, Never>] = []
+    private var clientTasks: [UUID: Task<Void, Never>] = [:]
     private var clientFDs: [Int32] = []
 
     init(
@@ -306,7 +306,7 @@ actor ControlSocketServer {
     func stop() async {
         acceptTask?.cancel()
         acceptTask = nil
-        for task in clientTasks {
+        for task in clientTasks.values {
             task.cancel()
         }
         clientTasks.removeAll()
@@ -322,9 +322,16 @@ actor ControlSocketServer {
         await tracker.clear()
     }
 
-    private func appendClientTask(_ task: Task<Void, Never>) {
-        clientTasks = clientTasks.filter { !$0.isCancelled }
-        clientTasks.append(task)
+    func clientTasksCountForTest() -> Int {
+        clientTasks.count
+    }
+
+    private func appendClientTask(id: UUID, task: Task<Void, Never>) {
+        clientTasks[id] = task
+    }
+
+    private func removeClientTask(_ id: UUID) {
+        clientTasks.removeValue(forKey: id)
     }
 
     private func appendClientFD(_ fd: Int32) {
@@ -352,7 +359,11 @@ actor ControlSocketServer {
                 break
             }
             await server.appendClientFD(clientFD)
-            let task = Task.detached(priority: .userInitiated) {
+            let taskID = UUID()
+            let task = Task.detached(priority: .userInitiated) { [server] in
+                defer {
+                    Task { await server.removeClientTask(taskID) }
+                }
                 await handleClient(
                     fd: clientFD,
                     modelRuntime: modelRuntime,
@@ -362,7 +373,7 @@ actor ControlSocketServer {
                 )
                 await server.removeClientFD(clientFD)
             }
-            await server.appendClientTask(task)
+            await server.appendClientTask(id: taskID, task: task)
         }
     }
 

--- a/phase3-binary/Sources/macprovider-cli/ControlSocket.swift
+++ b/phase3-binary/Sources/macprovider-cli/ControlSocket.swift
@@ -1,0 +1,568 @@
+import Darwin
+import Foundation
+
+public enum SwitchAckReason: String, Sendable, Equatable {
+    case loadingInProgress = "loading_in_progress"
+    case cooldown
+    case notInSupportedModels = "not_in_supported_models"
+    case other
+}
+
+public enum SwitchProgressState: String, Sendable, Equatable {
+    case loading
+    case draining
+    case loaded
+    case failed
+}
+
+public enum ControlSocketFrame: Equatable, Sendable {
+    case switchRequest(targetModelID: String, requestedAtMs: Int64)
+    case statusRequest
+    case switchAck(accepted: Bool, reason: SwitchAckReason?, currentTarget: String?, secondsRemaining: Int?)
+    case switchProgress(state: SwitchProgressState, elapsedMs: Int, reason: String?)
+    case statusResponse(currentModelID: String, runtimeState: SwapState)
+}
+
+public enum ControlSocketCodec {
+    public static func encode(_ frame: ControlSocketFrame) throws -> Data {
+        let object: [String: Any]
+        switch frame {
+        case let .switchRequest(targetModelID, requestedAtMs):
+            object = [
+                "type": "switch_request",
+                "target_model_id": targetModelID,
+                "requested_at_ms": requestedAtMs,
+            ]
+        case .statusRequest:
+            object = ["type": "status_request"]
+        case let .switchAck(accepted, reason, currentTarget, secondsRemaining):
+            var frame: [String: Any] = [
+                "type": "switch_ack",
+                "accepted": accepted,
+            ]
+            if !accepted, let reason {
+                frame["reason"] = reason.rawValue
+                if reason == .loadingInProgress, let currentTarget {
+                    frame["current_target"] = currentTarget
+                }
+                if reason == .cooldown, let secondsRemaining {
+                    frame["seconds_remaining"] = secondsRemaining
+                }
+            }
+            object = frame
+        case let .switchProgress(state, elapsedMs, reason):
+            var frame: [String: Any] = [
+                "type": "switch_progress",
+                "state": state.rawValue,
+                "elapsed_ms": elapsedMs,
+            ]
+            if state == .failed, let reason {
+                frame["reason"] = reason
+            }
+            object = frame
+        case let .statusResponse(currentModelID, runtimeState):
+            object = [
+                "type": "status_response",
+                "current_model_id": currentModelID,
+                "runtime_state": runtimeState.rawValue,
+            ]
+        }
+
+        var data = try JSONSerialization.data(withJSONObject: object, options: [.withoutEscapingSlashes])
+        data.append(0x0A)
+        return data
+    }
+
+    public static func decode(_ line: Data) throws -> ControlSocketFrame {
+        let trimmed = line.last == 0x0A ? line.dropLast() : line[...]
+        let raw = try JSONSerialization.jsonObject(with: Data(trimmed))
+        guard let object = raw as? [String: Any] else {
+            throw ControlSocketError.missingType
+        }
+        guard let type = object["type"] as? String else {
+            throw ControlSocketError.missingType
+        }
+
+        switch type {
+        case "switch_request":
+            return .switchRequest(
+                targetModelID: try stringField("target_model_id", in: object),
+                requestedAtMs: try int64Field("requested_at_ms", in: object)
+            )
+        case "status_request":
+            return .statusRequest
+        case "switch_ack":
+            let accepted = try boolField("accepted", in: object)
+            if accepted {
+                return .switchAck(accepted: true, reason: nil, currentTarget: nil, secondsRemaining: nil)
+            }
+            let reasonRaw = try stringField("reason", in: object)
+            guard let reason = SwitchAckReason(rawValue: reasonRaw) else {
+                throw ControlSocketError.invalidEnumValue(field: "reason", value: reasonRaw)
+            }
+            let currentTarget = reason == .loadingInProgress ? try stringField("current_target", in: object) : nil
+            let secondsRemaining = reason == .cooldown ? try intField("seconds_remaining", in: object) : nil
+            return .switchAck(
+                accepted: false,
+                reason: reason,
+                currentTarget: currentTarget,
+                secondsRemaining: secondsRemaining
+            )
+        case "switch_progress":
+            let stateRaw = try stringField("state", in: object)
+            guard let state = SwitchProgressState(rawValue: stateRaw) else {
+                throw ControlSocketError.invalidEnumValue(field: "state", value: stateRaw)
+            }
+            let reason = state == .failed ? try stringField("reason", in: object) : nil
+            return .switchProgress(state: state, elapsedMs: try intField("elapsed_ms", in: object), reason: reason)
+        case "status_response":
+            let stateRaw = try stringField("runtime_state", in: object)
+            guard let state = SwapState(rawValue: stateRaw), state != .failed else {
+                throw ControlSocketError.invalidEnumValue(field: "runtime_state", value: stateRaw)
+            }
+            return .statusResponse(
+                currentModelID: try stringField("current_model_id", in: object),
+                runtimeState: state
+            )
+        default:
+            throw ControlSocketError.unknownType(type)
+        }
+    }
+
+    private static func stringField(_ field: String, in object: [String: Any]) throws -> String {
+        guard let value = object[field] as? String else {
+            throw ControlSocketError.missingRequiredField(field)
+        }
+        return value
+    }
+
+    private static func boolField(_ field: String, in object: [String: Any]) throws -> Bool {
+        guard let value = object[field] as? Bool else {
+            throw ControlSocketError.missingRequiredField(field)
+        }
+        return value
+    }
+
+    private static func intField(_ field: String, in object: [String: Any]) throws -> Int {
+        if let value = object[field] as? Int {
+            return value
+        }
+        if let value = object[field] as? NSNumber {
+            return value.intValue
+        }
+        throw ControlSocketError.missingRequiredField(field)
+    }
+
+    private static func int64Field(_ field: String, in object: [String: Any]) throws -> Int64 {
+        if let value = object[field] as? Int64 {
+            return value
+        }
+        if let value = object[field] as? Int {
+            return Int64(value)
+        }
+        if let value = object[field] as? NSNumber {
+            return value.int64Value
+        }
+        throw ControlSocketError.missingRequiredField(field)
+    }
+}
+
+public enum ControlSocketError: Error, Equatable {
+    case missingType
+    case unknownType(String)
+    case missingRequiredField(String)
+    case invalidEnumValue(field: String, value: String)
+}
+
+public enum ControlSocketPaths {
+    public static func resolve(ctlSocketPath: String?) -> URL {
+        if let ctlSocketPath, !ctlSocketPath.isEmpty {
+            return URL(fileURLWithPath: (ctlSocketPath as NSString).expandingTildeInPath)
+        }
+        return FileManager.default.temporaryDirectory
+            .appendingPathComponent("macprovider-cli")
+            .appendingPathComponent("ctl.sock")
+    }
+
+    public static func defaultSwitchStatePath(_ switchStatePath: String?) -> URL {
+        if let switchStatePath, !switchStatePath.isEmpty {
+            return URL(fileURLWithPath: (switchStatePath as NSString).expandingTildeInPath)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/macprovider-cli/last-switch.ts")
+    }
+}
+
+public enum ControlSocketConnectError: Error, Equatable {
+    case socketAbsent(path: String)
+    case connectionRefused(path: String)
+    case handshakeTimeout(path: String)
+    case other(underlying: String)
+}
+
+public enum ControlSocketServerError: Error, CustomStringConvertible, Equatable {
+    case staleSocket(path: String)
+    case bindFailed(path: String, errno: Int32)
+    case listenFailed(errno: Int32)
+    case socketFailed(errno: Int32)
+
+    public var description: String {
+        switch self {
+        case let .staleSocket(path):
+            return "control socket \(path) already exists; remove the stale file and restart serve"
+        case let .bindFailed(path, errno):
+            return "control socket \(path) bind failed: \(String(cString: strerror(errno)))"
+        case let .listenFailed(errno):
+            return "control socket listen failed: \(String(cString: strerror(errno)))"
+        case let .socketFailed(errno):
+            return "control socket creation failed: \(String(cString: strerror(errno)))"
+        }
+    }
+}
+
+public enum ControlSocketConnectionError: Error, Equatable {
+    case closed
+    case timedOut
+}
+
+actor ControlSocketServer {
+    private let socketPath: URL
+    private let modelRuntime: ModelRuntime
+    private let tracker = ControlSocketSwitchTracker()
+    private var listenerFD: Int32?
+    private var acceptTask: Task<Void, Never>?
+
+    init(socketPath: URL, modelRuntime: ModelRuntime) {
+        self.socketPath = socketPath
+        self.modelRuntime = modelRuntime
+    }
+
+    func start() async throws {
+        let parent = socketPath.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        chmod(parent.path, S_IRWXU)
+
+        if FileManager.default.fileExists(atPath: socketPath.path) {
+            let error = ControlSocketServerError.staleSocket(path: socketPath.path)
+            FileHandle.standardError.write(Data(("\(error.description)\n").utf8))
+            throw error
+        }
+
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw ControlSocketServerError.socketFailed(errno: errno)
+        }
+
+        do {
+            try bindUnixSocket(fd: fd, path: socketPath.path)
+        } catch let error as ControlSocketServerError {
+            close(fd)
+            if case let .bindFailed(_, err) = error, err == EADDRINUSE {
+                let stale = ControlSocketServerError.staleSocket(path: socketPath.path)
+                FileHandle.standardError.write(Data(("\(stale.description)\n").utf8))
+                throw stale
+            }
+            throw error
+        }
+
+        chmod(socketPath.path, S_IRUSR | S_IWUSR)
+        guard Darwin.listen(fd, 128) == 0 else {
+            let err = errno
+            close(fd)
+            try? FileManager.default.removeItem(at: socketPath)
+            throw ControlSocketServerError.listenFailed(errno: err)
+        }
+
+        listenerFD = fd
+        let runtime = modelRuntime
+        let tracker = tracker
+        acceptTask = Task.detached(priority: .userInitiated) {
+            await Self.acceptLoop(listenerFD: fd, modelRuntime: runtime, tracker: tracker)
+        }
+    }
+
+    func stop() async {
+        acceptTask?.cancel()
+        acceptTask = nil
+        if let listenerFD {
+            close(listenerFD)
+            self.listenerFD = nil
+        }
+        try? FileManager.default.removeItem(at: socketPath)
+        await tracker.clear()
+    }
+
+    private nonisolated static func acceptLoop(
+        listenerFD: Int32,
+        modelRuntime: ModelRuntime,
+        tracker: ControlSocketSwitchTracker
+    ) async {
+        while !Task.isCancelled {
+            let clientFD = Darwin.accept(listenerFD, nil, nil)
+            if clientFD < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                break
+            }
+            Task.detached(priority: .userInitiated) {
+                await handleClient(fd: clientFD, modelRuntime: modelRuntime, tracker: tracker)
+            }
+        }
+    }
+
+    private nonisolated static func handleClient(
+        fd: Int32,
+        modelRuntime: ModelRuntime,
+        tracker: ControlSocketSwitchTracker
+    ) async {
+        let connection = ControlSocketConnection(fd: fd)
+        while !Task.isCancelled {
+            do {
+                let frame = try await connection.receive()
+                switch frame {
+                case .statusRequest:
+                    let snapshot = await modelRuntime.currentSnapshot()
+                    let state = snapshot.state == .failed ? SwapState.ready : snapshot.state
+                    try await connection.send(.statusResponse(currentModelID: snapshot.modelID ?? "", runtimeState: state))
+                case let .switchRequest(targetModelID, requestedAtMs):
+                    await handleSwitchRequest(
+                        targetModelID: targetModelID,
+                        requestedAtMs: requestedAtMs,
+                        connection: connection,
+                        modelRuntime: modelRuntime,
+                        tracker: tracker
+                    )
+                    await connection.close()
+                    return
+                default:
+                    FileHandle.standardError.write(Data("control socket received unexpected frame type; closing connection\n".utf8))
+                    await connection.close()
+                    return
+                }
+            } catch let error as ControlSocketError {
+                FileHandle.standardError.write(Data("control socket decode error: \(error); closing connection\n".utf8))
+                await connection.close()
+                return
+            } catch ControlSocketConnectionError.closed {
+                await connection.close()
+                return
+            } catch {
+                FileHandle.standardError.write(Data("control socket error: \(error); closing connection\n".utf8))
+                await connection.close()
+                return
+            }
+        }
+        await connection.close()
+    }
+
+    private nonisolated static func handleSwitchRequest(
+        targetModelID: String,
+        requestedAtMs: Int64,
+        connection: ControlSocketConnection,
+        modelRuntime: ModelRuntime,
+        tracker: ControlSocketSwitchTracker
+    ) async {
+        let stream = await modelRuntime.swapSignals()
+        do {
+            _ = try await modelRuntime.beginSwap(targetModelID: targetModelID)
+            await tracker.start(targetModelID)
+            try await connection.send(.switchAck(accepted: true, reason: nil, currentTarget: nil, secondsRemaining: nil))
+            try await connection.send(.switchProgress(state: .loading, elapsedMs: elapsedMs(since: requestedAtMs), reason: nil))
+
+            var iterator = stream.makeAsyncIterator()
+            while let signal = await iterator.next() {
+                guard signal.targetModelID == targetModelID else {
+                    continue
+                }
+                switch signal.outcome {
+                case .completed:
+                    try await connection.send(.switchProgress(state: .draining, elapsedMs: elapsedMs(since: requestedAtMs), reason: nil))
+                    try await connection.send(.switchProgress(state: .loaded, elapsedMs: elapsedMs(since: requestedAtMs), reason: nil))
+                case let .failed(reason):
+                    try await connection.send(.switchProgress(state: .failed, elapsedMs: elapsedMs(since: requestedAtMs), reason: reason))
+                }
+                await tracker.clear()
+                return
+            }
+        } catch RuntimeStateMachineError.notReady {
+            let currentTarget = await tracker.currentTarget() ?? targetModelID
+            try? await connection.send(.switchAck(
+                accepted: false,
+                reason: .loadingInProgress,
+                currentTarget: currentTarget,
+                secondsRemaining: nil
+            ))
+        } catch is WarmSwapDisabledError {
+            try? await connection.send(.switchAck(accepted: false, reason: .other, currentTarget: nil, secondsRemaining: nil))
+        } catch {
+            try? await connection.send(.switchAck(accepted: false, reason: .other, currentTarget: nil, secondsRemaining: nil))
+        }
+    }
+
+    private nonisolated static func elapsedMs(since requestedAtMs: Int64) -> Int {
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        return max(0, Int(now - requestedAtMs))
+    }
+}
+
+private actor ControlSocketSwitchTracker {
+    private var targetModelID: String?
+
+    func start(_ targetModelID: String) {
+        self.targetModelID = targetModelID
+    }
+
+    func currentTarget() -> String? {
+        targetModelID
+    }
+
+    func clear() {
+        targetModelID = nil
+    }
+}
+
+public enum ControlSocketClient {
+    public static func connect(socketPath: URL, timeout _: TimeInterval = 2.0) async throws -> ControlSocketConnection {
+        let path = socketPath.path
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw ControlSocketConnectError.socketAbsent(path: path)
+        }
+
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw ControlSocketConnectError.other(underlying: String(cString: strerror(errno)))
+        }
+
+        do {
+            try connectUnixSocket(fd: fd, path: path)
+            return ControlSocketConnection(fd: fd)
+        } catch {
+            let err = errno
+            close(fd)
+            if err == ECONNREFUSED || err == ENOTSOCK || err == EPROTOTYPE {
+                throw ControlSocketConnectError.connectionRefused(path: path)
+            }
+            throw ControlSocketConnectError.other(underlying: String(cString: strerror(err)))
+        }
+    }
+}
+
+public actor ControlSocketConnection {
+    private var fd: Int32?
+    private var receiveBuffer = Data()
+
+    init(fd: Int32) {
+        self.fd = fd
+    }
+
+    public func send(_ frame: ControlSocketFrame) async throws {
+        let data = try ControlSocketCodec.encode(frame)
+        try writeAll(data)
+    }
+
+    public func receive(timeout: TimeInterval? = nil) async throws -> ControlSocketFrame {
+        while true {
+            if let newline = receiveBuffer.firstIndex(of: 0x0A) {
+                let line = receiveBuffer.prefix(through: newline)
+                receiveBuffer.removeSubrange(...newline)
+                return try ControlSocketCodec.decode(Data(line))
+            }
+
+            guard let fd else {
+                throw ControlSocketConnectionError.closed
+            }
+            if let timeout, !waitForReadable(fd: fd, timeout: timeout) {
+                throw ControlSocketConnectionError.timedOut
+            }
+            var byte: UInt8 = 0
+            let count = Darwin.read(fd, &byte, 1)
+            if count == 0 {
+                throw ControlSocketConnectionError.closed
+            }
+            if count < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                throw ControlSocketConnectError.other(underlying: String(cString: strerror(errno)))
+            }
+            receiveBuffer.append(byte)
+        }
+    }
+
+    public func close() async {
+        if let fd {
+            Darwin.close(fd)
+            self.fd = nil
+        }
+    }
+
+    private func writeAll(_ data: Data) throws {
+        guard let fd else {
+            throw ControlSocketConnectionError.closed
+        }
+        try data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.baseAddress else { return }
+            var sent = 0
+            while sent < rawBuffer.count {
+                let count = Darwin.write(fd, base.advanced(by: sent), rawBuffer.count - sent)
+                if count < 0 {
+                    if errno == EINTR {
+                        continue
+                    }
+                    throw ControlSocketConnectError.other(underlying: String(cString: strerror(errno)))
+                }
+                sent += count
+            }
+        }
+    }
+
+    private func waitForReadable(fd: Int32, timeout: TimeInterval) -> Bool {
+        var pollFD = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+        let timeoutMs = Int32((timeout * 1000).rounded())
+        let result = Darwin.poll(&pollFD, 1, timeoutMs)
+        return result > 0
+    }
+}
+
+private func bindUnixSocket(fd: Int32, path: String) throws {
+    var address = try unixAddress(path: path)
+    let result = withUnsafePointer(to: &address.sockaddr) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            Darwin.bind(fd, $0, address.length)
+        }
+    }
+    guard result == 0 else {
+        throw ControlSocketServerError.bindFailed(path: path, errno: errno)
+    }
+}
+
+private func connectUnixSocket(fd: Int32, path: String) throws {
+    var address = try unixAddress(path: path)
+    let result = withUnsafePointer(to: &address.sockaddr) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            Darwin.connect(fd, $0, address.length)
+        }
+    }
+    guard result == 0 else {
+        throw ControlSocketConnectError.other(underlying: String(cString: strerror(errno)))
+    }
+}
+
+private func unixAddress(path: String) throws -> (sockaddr: sockaddr_un, length: socklen_t) {
+    let pathBytes = Array(path.utf8)
+    var address = sockaddr_un()
+    let capacity = MemoryLayout.size(ofValue: address.sun_path)
+    guard pathBytes.count < capacity else {
+        throw ControlSocketConnectError.other(underlying: "socket path too long")
+    }
+    address.sun_len = UInt8(MemoryLayout<sockaddr_un>.offset(of: \.sun_path)! + pathBytes.count + 1)
+    address.sun_family = sa_family_t(AF_UNIX)
+    withUnsafeMutableBytes(of: &address.sun_path) { bytes in
+        for (index, byte) in pathBytes.enumerated() {
+            bytes[index] = byte
+        }
+        bytes[pathBytes.count] = 0
+    }
+    return (address, socklen_t(address.sun_len))
+}

--- a/phase3-binary/Sources/macprovider-cli/ControlSocket.swift
+++ b/phase3-binary/Sources/macprovider-cli/ControlSocket.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import MacProviderCore
 
 public enum SwitchAckReason: String, Sendable, Equatable {
     case loadingInProgress = "loading_in_progress"
@@ -223,18 +224,30 @@ public enum ControlSocketServerError: Error, CustomStringConvertible, Equatable 
 public enum ControlSocketConnectionError: Error, Equatable {
     case closed
     case timedOut
+    case frameTooLarge(size: Int)
 }
 
 actor ControlSocketServer {
     private let socketPath: URL
     private let modelRuntime: ModelRuntime
+    private let supportedModels: [String]?
+    private let idleTimeoutSeconds: TimeInterval
     private let tracker = ControlSocketSwitchTracker()
     private var listenerFD: Int32?
     private var acceptTask: Task<Void, Never>?
+    private var clientTasks: [Task<Void, Never>] = []
+    private var clientFDs: [Int32] = []
 
-    init(socketPath: URL, modelRuntime: ModelRuntime) {
+    init(
+        socketPath: URL,
+        modelRuntime: ModelRuntime,
+        supportedModels: [String]? = nil,
+        idleTimeoutSeconds: TimeInterval = 30.0
+    ) {
         self.socketPath = socketPath
         self.modelRuntime = modelRuntime
+        self.supportedModels = supportedModels
+        self.idleTimeoutSeconds = idleTimeoutSeconds
     }
 
     func start() async throws {
@@ -276,14 +289,31 @@ actor ControlSocketServer {
         listenerFD = fd
         let runtime = modelRuntime
         let tracker = tracker
+        let supportedModels = supportedModels
+        let idleTimeoutSeconds = idleTimeoutSeconds
         acceptTask = Task.detached(priority: .userInitiated) {
-            await Self.acceptLoop(listenerFD: fd, modelRuntime: runtime, tracker: tracker)
+            await Self.acceptLoop(
+                listenerFD: fd,
+                modelRuntime: runtime,
+                tracker: tracker,
+                supportedModels: supportedModels,
+                idleTimeoutSeconds: idleTimeoutSeconds,
+                server: self
+            )
         }
     }
 
     func stop() async {
         acceptTask?.cancel()
         acceptTask = nil
+        for task in clientTasks {
+            task.cancel()
+        }
+        clientTasks.removeAll()
+        for fd in clientFDs {
+            close(fd)
+        }
+        clientFDs.removeAll()
         if let listenerFD {
             close(listenerFD)
             self.listenerFD = nil
@@ -292,10 +322,26 @@ actor ControlSocketServer {
         await tracker.clear()
     }
 
+    private func appendClientTask(_ task: Task<Void, Never>) {
+        clientTasks = clientTasks.filter { !$0.isCancelled }
+        clientTasks.append(task)
+    }
+
+    private func appendClientFD(_ fd: Int32) {
+        clientFDs.append(fd)
+    }
+
+    private func removeClientFD(_ fd: Int32) {
+        clientFDs.removeAll { $0 == fd }
+    }
+
     private nonisolated static func acceptLoop(
         listenerFD: Int32,
         modelRuntime: ModelRuntime,
-        tracker: ControlSocketSwitchTracker
+        tracker: ControlSocketSwitchTracker,
+        supportedModels: [String]?,
+        idleTimeoutSeconds: TimeInterval,
+        server: ControlSocketServer
     ) async {
         while !Task.isCancelled {
             let clientFD = Darwin.accept(listenerFD, nil, nil)
@@ -305,21 +351,32 @@ actor ControlSocketServer {
                 }
                 break
             }
-            Task.detached(priority: .userInitiated) {
-                await handleClient(fd: clientFD, modelRuntime: modelRuntime, tracker: tracker)
+            await server.appendClientFD(clientFD)
+            let task = Task.detached(priority: .userInitiated) {
+                await handleClient(
+                    fd: clientFD,
+                    modelRuntime: modelRuntime,
+                    tracker: tracker,
+                    supportedModels: supportedModels,
+                    idleTimeoutSeconds: idleTimeoutSeconds
+                )
+                await server.removeClientFD(clientFD)
             }
+            await server.appendClientTask(task)
         }
     }
 
     private nonisolated static func handleClient(
         fd: Int32,
         modelRuntime: ModelRuntime,
-        tracker: ControlSocketSwitchTracker
+        tracker: ControlSocketSwitchTracker,
+        supportedModels: [String]?,
+        idleTimeoutSeconds: TimeInterval
     ) async {
         let connection = ControlSocketConnection(fd: fd)
         while !Task.isCancelled {
             do {
-                let frame = try await connection.receive()
+                let frame = try await connection.receive(timeout: idleTimeoutSeconds)
                 switch frame {
                 case .statusRequest:
                     let snapshot = await modelRuntime.currentSnapshot()
@@ -331,7 +388,8 @@ actor ControlSocketServer {
                         requestedAtMs: requestedAtMs,
                         connection: connection,
                         modelRuntime: modelRuntime,
-                        tracker: tracker
+                        tracker: tracker,
+                        supportedModels: supportedModels
                     )
                     await connection.close()
                     return
@@ -345,6 +403,9 @@ actor ControlSocketServer {
                 await connection.close()
                 return
             } catch ControlSocketConnectionError.closed {
+                await connection.close()
+                return
+            } catch ControlSocketConnectError.other(let underlying) where Task.isCancelled && underlying == "Bad file descriptor" {
                 await connection.close()
                 return
             } catch {
@@ -361,10 +422,28 @@ actor ControlSocketServer {
         requestedAtMs: Int64,
         connection: ControlSocketConnection,
         modelRuntime: ModelRuntime,
-        tracker: ControlSocketSwitchTracker
+        tracker: ControlSocketSwitchTracker,
+        supportedModels: [String]?
     ) async {
-        let stream = await modelRuntime.swapSignals()
         do {
+            do {
+                _ = try SupportedModels.validate(model: targetModelID, supportedModels: supportedModels)
+            } catch SupportedModelsValidationError.modelNotInCatalog {
+                try? await connection.send(.switchAck(
+                    accepted: false,
+                    reason: .notInSupportedModels,
+                    currentTarget: nil,
+                    secondsRemaining: nil
+                ))
+                await connection.close()
+                return
+            } catch {
+                try? await connection.send(.switchAck(accepted: false, reason: .other, currentTarget: nil, secondsRemaining: nil))
+                await connection.close()
+                return
+            }
+
+            let stream = await modelRuntime.swapSignals()
             _ = try await modelRuntime.beginSwap(targetModelID: targetModelID)
             await tracker.start(targetModelID)
             try await connection.send(.switchAck(accepted: true, reason: nil, currentTarget: nil, secondsRemaining: nil))
@@ -376,8 +455,10 @@ actor ControlSocketServer {
                     continue
                 }
                 switch signal.outcome {
-                case .completed:
+                case .loadFinished:
                     try await connection.send(.switchProgress(state: .draining, elapsedMs: elapsedMs(since: requestedAtMs), reason: nil))
+                    continue
+                case .completed:
                     try await connection.send(.switchProgress(state: .loaded, elapsedMs: elapsedMs(since: requestedAtMs), reason: nil))
                 case let .failed(reason):
                     try await connection.send(.switchProgress(state: .failed, elapsedMs: elapsedMs(since: requestedAtMs), reason: reason))
@@ -449,6 +530,8 @@ public enum ControlSocketClient {
 }
 
 public actor ControlSocketConnection {
+    public static let maxFrameBytes = 64 * 1024
+
     private var fd: Int32?
     private var receiveBuffer = Data()
 
@@ -464,6 +547,10 @@ public actor ControlSocketConnection {
     public func receive(timeout: TimeInterval? = nil) async throws -> ControlSocketFrame {
         while true {
             if let newline = receiveBuffer.firstIndex(of: 0x0A) {
+                let frameSize = receiveBuffer.distance(from: receiveBuffer.startIndex, to: newline) + 1
+                if frameSize > Self.maxFrameBytes {
+                    throw ControlSocketConnectionError.frameTooLarge(size: frameSize)
+                }
                 let line = receiveBuffer.prefix(through: newline)
                 receiveBuffer.removeSubrange(...newline)
                 return try ControlSocketCodec.decode(Data(line))
@@ -475,8 +562,10 @@ public actor ControlSocketConnection {
             if let timeout, !waitForReadable(fd: fd, timeout: timeout) {
                 throw ControlSocketConnectionError.timedOut
             }
-            var byte: UInt8 = 0
-            let count = Darwin.read(fd, &byte, 1)
+            var bytes = [UInt8](repeating: 0, count: 4096)
+            let count = bytes.withUnsafeMutableBytes { rawBuffer in
+                Darwin.read(fd, rawBuffer.baseAddress, rawBuffer.count)
+            }
             if count == 0 {
                 throw ControlSocketConnectionError.closed
             }
@@ -486,7 +575,15 @@ public actor ControlSocketConnection {
                 }
                 throw ControlSocketConnectError.other(underlying: String(cString: strerror(errno)))
             }
-            receiveBuffer.append(byte)
+            receiveBuffer.append(contentsOf: bytes.prefix(count))
+            if let newline = receiveBuffer.firstIndex(of: 0x0A) {
+                let frameSize = receiveBuffer.distance(from: receiveBuffer.startIndex, to: newline) + 1
+                if frameSize > Self.maxFrameBytes {
+                    throw ControlSocketConnectionError.frameTooLarge(size: frameSize)
+                }
+            } else if receiveBuffer.count > Self.maxFrameBytes {
+                throw ControlSocketConnectionError.frameTooLarge(size: receiveBuffer.count)
+            }
         }
     }
 

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -80,6 +80,7 @@ actor CoordinatorClient {
     private let maxActiveRequests: Int
     private let supportedModels: [String]?
     private let publishesSupportedModels: Bool
+    private let warmSwapEnabled: Bool
     private let reconnectGraceNanoseconds: UInt64
     private let connectAndRunOverride: (() async throws -> Void)?
     private let attestationGenerator: Tier2AttestationTokenGenerating
@@ -90,6 +91,7 @@ actor CoordinatorClient {
     private var webSocket: ProviderWebSocketTask?
     private var runTask: Task<Void, Never>?
     private var heartbeatTask: Task<Void, Never>?
+    private var swapHeartbeatTask: Task<Void, Never>?
     private var sleepAssertion: ProviderSleepAssertion?
     private let sendOverride: (([String: Any]) async throws -> Void)?
 
@@ -123,6 +125,7 @@ actor CoordinatorClient {
         self.maxActiveRequests = 1
         self.supportedModels = config.supportedModels
         self.publishesSupportedModels = config.publishesSupportedModels
+        self.warmSwapEnabled = config.enableWarmSwap
         self.reconnectGraceNanoseconds = reconnectGraceNanoseconds
         self.attestationGenerator = attestationGenerator
         self.webSocketFactory = webSocketFactory
@@ -136,11 +139,17 @@ actor CoordinatorClient {
         runTask = Task { [weak self] in
             await self?.runReconnectLoop()
         }
+        if warmSwapEnabled {
+            swapHeartbeatTask = Task { [weak self] in
+                await self?.consumeSwapSignals()
+            }
+        }
     }
 
     func stop() async {
         runTask?.cancel()
         heartbeatTask?.cancel()
+        swapHeartbeatTask?.cancel()
         sleepAssertion?.stop()
         sleepAssertion = nil
         await inferenceRelay?.cancelAllAndClear()
@@ -150,7 +159,27 @@ actor CoordinatorClient {
         await providerStatus.setCoordinatorSession(connected: false)
         runTask = nil
         heartbeatTask = nil
+        swapHeartbeatTask = nil
         webSocket = nil
+    }
+
+    private func consumeSwapSignals() async {
+        let stream = await modelRuntime.swapSignals()
+        for await signal in stream {
+            if Task.isCancelled {
+                return
+            }
+            switch signal.outcome {
+            case .completed:
+                do {
+                    try await sendHeartbeat()
+                } catch {
+                    Self.keepaliveDebug("warm_swap_heartbeat_send_error error=\(error)")
+                }
+            case let .failed(reason):
+                Self.keepaliveDebug("coordinator.warmSwap.swapFailed reason=\(reason)")
+            }
+        }
     }
 
     private func runReconnectLoop() async {
@@ -356,6 +385,10 @@ actor CoordinatorClient {
     func handleCoordinatorPayloadForTest(_ payload: [String: Any]) async throws {
         let data = try JSONSerialization.data(withJSONObject: payload)
         try await handle(.string(String(decoding: data, as: UTF8.self)))
+    }
+
+    func sendHeartbeatForTest() async throws {
+        try await sendHeartbeat()
     }
 
     private func receiveAuthChallenge(from socket: ProviderWebSocketTask) async throws -> [String: Any] {
@@ -587,7 +620,7 @@ actor CoordinatorClient {
 
     private func sendHeartbeat() async throws {
         let snapshot = await providerStatus.snapshot(resetWindow: true)
-        try await send([
+        var payload: [String: Any] = [
             "type": "heartbeat",
             "status": snapshot.status.rawValue,
             "model_id": snapshot.modelID ?? "",
@@ -601,7 +634,15 @@ actor CoordinatorClient {
             "requests_served_since_last": snapshot.requestsServedSinceLast,
             "avg_latency_ms_since_last": nullableNumber(snapshot.avgLatencyMSSinceLast),
             "throughput_tps_since_last": nullableNumber(snapshot.throughputTPSSinceLast),
-        ])
+        ]
+        if warmSwapEnabled {
+            let runtimeSnapshot = await modelRuntime.currentSnapshot()
+            if let modelHash = runtimeSnapshot.modelHash {
+                payload["model_hash"] = modelHash
+            }
+            payload["loading"] = runtimeSnapshot.state == .loading || runtimeSnapshot.state == .draining
+        }
+        try await send(payload)
     }
 
     private func sendStateUpdate(state newState: ProviderHealthState?, reason: String) async throws {
@@ -709,8 +750,14 @@ actor CoordinatorClient {
         if let endpointURL {
             message["endpoint_url"] = endpointURL
         }
-        if let modelHash = snapshot.modelHash {
-            message["model_hash"] = modelHash
+        let hashForHello: String?
+        if warmSwapEnabled {
+            hashForHello = await modelRuntime.currentSnapshot().modelHash
+        } else {
+            hashForHello = snapshot.modelHash
+        }
+        if let hashForHello {
+            message["model_hash"] = hashForHello
         }
         return message
     }

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -170,6 +170,8 @@ actor CoordinatorClient {
                 return
             }
             switch signal.outcome {
+            case .loadFinished:
+                continue
             case .completed:
                 do {
                     try await sendHeartbeat()

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -78,6 +78,8 @@ actor CoordinatorClient {
     private let loadedModelID: String?
     private let maxBodyBytes: Int
     private let maxActiveRequests: Int
+    private let supportedModels: [String]?
+    private let publishesSupportedModels: Bool
     private let reconnectGraceNanoseconds: UInt64
     private let connectAndRunOverride: (() async throws -> Void)?
     private let attestationGenerator: Tier2AttestationTokenGenerating
@@ -119,6 +121,8 @@ actor CoordinatorClient {
         self.loadedModelID = config.model
         self.maxBodyBytes = config.maxRequestBodyBytes
         self.maxActiveRequests = 1
+        self.supportedModels = config.supportedModels
+        self.publishesSupportedModels = config.publishesSupportedModels
         self.reconnectGraceNanoseconds = reconnectGraceNanoseconds
         self.attestationGenerator = attestationGenerator
         self.webSocketFactory = webSocketFactory
@@ -663,6 +667,19 @@ actor CoordinatorClient {
                 "aead_suites": [Tier2ProviderSession.aeadSuite],
             ],
         ]
+        let resolvedCatalog: [String]
+        do {
+            resolvedCatalog = try SupportedModels.validate(
+                model: snapshot.modelID ?? "",
+                supportedModels: supportedModels
+            )
+        } catch {
+            resolvedCatalog = [snapshot.modelID ?? ""]
+        }
+        message["supported_models"] = resolvedCatalog
+        if publishesSupportedModels {
+            message["publishes_supported_models"] = true
+        }
         if let endpointURL {
             message["endpoint_url"] = endpointURL
         }

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -262,6 +262,7 @@ actor CoordinatorClient {
             modelRuntime: modelRuntime,
             providerStatus: providerStatus,
             loadedModelID: loadedModelID,
+            warmSwapEnabled: warmSwapEnabled,
             maxActiveRequests: maxActiveRequests,
             maxBodyBytes: maxBodyBytes,
             tier2Session: session,
@@ -279,6 +280,7 @@ actor CoordinatorClient {
                 modelRuntime: modelRuntime,
                 providerStatus: providerStatus,
                 loadedModelID: loadedModelID,
+                warmSwapEnabled: warmSwapEnabled,
                 maxActiveRequests: maxActiveRequests,
                 maxBodyBytes: maxBodyBytes,
                 sendFrame: { payload in
@@ -639,6 +641,7 @@ actor CoordinatorClient {
         ]
         if warmSwapEnabled {
             let runtimeSnapshot = await modelRuntime.currentSnapshot()
+            payload["model_id"] = runtimeSnapshot.modelID ?? ""
             if let modelHash = runtimeSnapshot.modelHash {
                 payload["model_hash"] = modelHash
             }
@@ -752,12 +755,17 @@ actor CoordinatorClient {
         if let endpointURL {
             message["endpoint_url"] = endpointURL
         }
+        let modelIDForHello: String
         let hashForHello: String?
         if warmSwapEnabled {
-            hashForHello = await modelRuntime.currentSnapshot().modelHash
+            let runtimeSnapshot = await modelRuntime.currentSnapshot()
+            modelIDForHello = runtimeSnapshot.modelID ?? ""
+            hashForHello = runtimeSnapshot.modelHash
         } else {
+            modelIDForHello = snapshot.modelID ?? ""
             hashForHello = snapshot.modelHash
         }
+        message["model_id"] = modelIDForHello
         if let hashForHello {
             message["model_hash"] = hashForHello
         }

--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -38,7 +38,7 @@ struct HTTPServer {
     }
 }
 
-private final class RouterHandler: ChannelInboundHandler {
+final class RouterHandler: ChannelInboundHandler {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
 
@@ -196,6 +196,10 @@ private final class RouterHandler: ChannelInboundHandler {
             Task.detached { @Sendable [modelRuntime, providerStatus, request, writer] in
                 let startedAt = await providerStatus.beginRequest()
                 do {
+                    let snapshot = await modelRuntime.currentSnapshot()
+                    if let error = Self.warmSwapRejectionError(for: snapshot) {
+                        throw error
+                    }
                     let completion = try await modelRuntime.complete(request)
                     await providerStatus.finishRequest(startedAt: startedAt, completion: completion, failed: false)
                     let response = Self.chatCompletionResponse(request: request, completion: completion)
@@ -238,6 +242,10 @@ private final class RouterHandler: ChannelInboundHandler {
         Task.detached { @Sendable [modelRuntime, providerStatus, request, writer] in
             let startedAt = await providerStatus.beginRequest()
             do {
+                let snapshot = await modelRuntime.currentSnapshot()
+                if let error = Self.warmSwapRejectionError(for: snapshot) {
+                    throw error
+                }
                 try await modelRuntime.preflight(request)
             } catch let error as APIError {
                 await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
@@ -317,6 +325,10 @@ private final class RouterHandler: ChannelInboundHandler {
                 writer.writeSSEDone()
             }
         }
+    }
+
+    static func warmSwapRejectionError(for snapshot: RuntimeSnapshot) -> APIError? {
+        snapshot.state == .ready ? nil : ModelRuntime.providerLoadingError()
     }
 
     private static func chatCompletionResponse(request: ChatCompletionRequest, completion: CompletionResult) -> [String: Any] {

--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -266,6 +266,7 @@ final class RouterHandler: ChannelInboundHandler {
         let providerStatus = providerStatus
         Task.detached { @Sendable [modelRuntime, providerStatus, request, writer, warmSwapEnabled] in
             let startedAt = await providerStatus.beginRequest()
+            var sseStarted = false
             do {
                 let snapshot = await modelRuntime.currentSnapshot()
                 if let error = Self.warmSwapRejectionError(for: snapshot) {
@@ -274,32 +275,25 @@ final class RouterHandler: ChannelInboundHandler {
                 if warmSwapEnabled {
                     try request.validateModelMatches(snapshot.modelID)
                 }
-                try await modelRuntime.preflight(request)
-            } catch let error as APIError {
-                await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
-                writer.writeAPIError(error)
-                return
-            } catch {
-                await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
-                writer.writeAPIError(
-                    APIError(status: 503, message: "Model inference failed", type: "server_error", code: "model_not_loaded")
-                )
-                return
-            }
+                let handle = try await modelRuntime.acquireRequestHandle(request)
+                defer {
+                    Task { await modelRuntime.unregisterInFlight(handle.registrationID) }
+                }
+                try await modelRuntime.preflight(request, with: handle)
 
-            writer.startSSE()
-            writer.writeSSEJSON(
-                Self.chatCompletionChunk(
-                    id: id,
-                    created: created,
-                    model: request.model,
-                    delta: ["role": "assistant", "content": ""],
-                    finishReason: NSNull()
+                writer.startSSE()
+                sseStarted = true
+                writer.writeSSEJSON(
+                    Self.chatCompletionChunk(
+                        id: id,
+                        created: created,
+                        model: request.model,
+                        delta: ["role": "assistant", "content": ""],
+                        finishReason: NSNull()
+                    )
                 )
-            )
 
-            do {
-                let completion = try await modelRuntime.stream(request) { chunk in
+                let completion = try await modelRuntime.stream(request, with: handle) { chunk in
                     writer.writeSSEJSON(
                         Self.chatCompletionChunk(
                             id: id,
@@ -338,23 +332,37 @@ final class RouterHandler: ChannelInboundHandler {
                 writer.writeSSEDone()
             } catch let error as APIError {
                 await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
-                writer.writeSSEJSON(error.envelope)
-                writer.writeSSEDone()
+                if sseStarted {
+                    writer.writeSSEJSON(error.envelope)
+                    writer.writeSSEDone()
+                } else {
+                    writer.writeAPIError(error)
+                }
             } catch is DrainCancelledError {
                 await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
-                writer.writeSSEJSON(Self.swapDrainTimeoutEnvelope())
-                writer.writeSSEDone()
+                if sseStarted {
+                    writer.writeSSEJSON(Self.swapDrainTimeoutEnvelope())
+                    writer.writeSSEDone()
+                } else {
+                    writer.writeJSON(status: .serviceUnavailable, body: Self.swapDrainTimeoutEnvelope())
+                }
             } catch {
                 await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
-                writer.writeSSEJSON(
-                    APIError(
-                        status: 500,
-                        message: "Inference engine error",
-                        type: "server_error",
-                        code: "internal_error"
-                    ).envelope
-                )
-                writer.writeSSEDone()
+                if sseStarted {
+                    writer.writeSSEJSON(
+                        APIError(
+                            status: 500,
+                            message: "Inference engine error",
+                            type: "server_error",
+                            code: "internal_error"
+                        ).envelope
+                    )
+                    writer.writeSSEDone()
+                } else {
+                    writer.writeAPIError(
+                        APIError(status: 503, message: "Model inference failed", type: "server_error", code: "model_not_loaded")
+                    )
+                }
             }
         }
     }

--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -25,6 +25,7 @@ struct HTTPServer {
                             coordinatorURL: config.coordinatorURL,
                             modelRuntime: modelRuntime,
                             providerStatus: providerStatus,
+                            warmSwapEnabled: config.enableWarmSwap,
                             maxBodyBytes: config.maxRequestBodyBytes
                         )
                     )
@@ -46,16 +47,25 @@ final class RouterHandler: ChannelInboundHandler {
     private let coordinatorURL: String?
     private let modelRuntime: ModelRuntime
     private let providerStatus: ProviderStatus
+    private let warmSwapEnabled: Bool
     private let maxBodyBytes: Int
     private var requestHead: HTTPRequestHead?
     private var bodyBuffer: ByteBuffer?
     private var bodyTooLarge = false
 
-    init(modelID: String?, coordinatorURL: String?, modelRuntime: ModelRuntime, providerStatus: ProviderStatus, maxBodyBytes: Int) {
+    init(
+        modelID: String?,
+        coordinatorURL: String?,
+        modelRuntime: ModelRuntime,
+        providerStatus: ProviderStatus,
+        warmSwapEnabled: Bool,
+        maxBodyBytes: Int
+    ) {
         self.modelID = modelID
         self.coordinatorURL = coordinatorURL
         self.modelRuntime = modelRuntime
         self.providerStatus = providerStatus
+        self.warmSwapEnabled = warmSwapEnabled
         self.maxBodyBytes = maxBodyBytes
     }
 
@@ -182,28 +192,42 @@ final class RouterHandler: ChannelInboundHandler {
         let data = Data(body.readBytes(length: body.readableBytes) ?? [])
         let writer = ResponseWriter(context: context)
         let modelRuntime = modelRuntime
+        let warmSwapEnabled = warmSwapEnabled
 
         do {
             let request = try ChatCompletionRequest.parse(data: data)
-            try request.validateModelMatches(modelID)
+            if !warmSwapEnabled {
+                try request.validateModelMatches(modelID)
+            }
 
             if request.stream {
-                handleStreamingChatCompletions(request: request, writer: writer, modelRuntime: modelRuntime)
+                handleStreamingChatCompletions(
+                    request: request,
+                    writer: writer,
+                    modelRuntime: modelRuntime,
+                    warmSwapEnabled: warmSwapEnabled
+                )
                 return
             }
 
             let providerStatus = providerStatus
-            Task.detached { @Sendable [modelRuntime, providerStatus, request, writer] in
+            Task.detached { @Sendable [modelRuntime, providerStatus, request, writer, warmSwapEnabled] in
                 let startedAt = await providerStatus.beginRequest()
                 do {
                     let snapshot = await modelRuntime.currentSnapshot()
                     if let error = Self.warmSwapRejectionError(for: snapshot) {
                         throw error
                     }
+                    if warmSwapEnabled {
+                        try request.validateModelMatches(snapshot.modelID)
+                    }
                     let completion = try await modelRuntime.complete(request)
                     await providerStatus.finishRequest(startedAt: startedAt, completion: completion, failed: false)
                     let response = Self.chatCompletionResponse(request: request, completion: completion)
                     writer.writeJSON(status: .ok, body: response)
+                } catch is DrainCancelledError {
+                    await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
+                    writer.writeJSON(status: .serviceUnavailable, body: Self.swapDrainTimeoutEnvelope())
                 } catch let error as APIError {
                     await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
                     writer.writeAPIError(error)
@@ -233,18 +257,22 @@ final class RouterHandler: ChannelInboundHandler {
     private func handleStreamingChatCompletions(
         request: ChatCompletionRequest,
         writer: ResponseWriter,
-        modelRuntime: ModelRuntime
+        modelRuntime: ModelRuntime,
+        warmSwapEnabled: Bool
     ) {
         let created = Int(Date().timeIntervalSince1970)
         let id = "chatcmpl-\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
 
         let providerStatus = providerStatus
-        Task.detached { @Sendable [modelRuntime, providerStatus, request, writer] in
+        Task.detached { @Sendable [modelRuntime, providerStatus, request, writer, warmSwapEnabled] in
             let startedAt = await providerStatus.beginRequest()
             do {
                 let snapshot = await modelRuntime.currentSnapshot()
                 if let error = Self.warmSwapRejectionError(for: snapshot) {
                     throw error
+                }
+                if warmSwapEnabled {
+                    try request.validateModelMatches(snapshot.modelID)
                 }
                 try await modelRuntime.preflight(request)
             } catch let error as APIError {
@@ -312,6 +340,10 @@ final class RouterHandler: ChannelInboundHandler {
                 await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
                 writer.writeSSEJSON(error.envelope)
                 writer.writeSSEDone()
+            } catch is DrainCancelledError {
+                await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
+                writer.writeSSEJSON(Self.swapDrainTimeoutEnvelope())
+                writer.writeSSEDone()
             } catch {
                 await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
                 writer.writeSSEJSON(
@@ -329,6 +361,19 @@ final class RouterHandler: ChannelInboundHandler {
 
     static func warmSwapRejectionError(for snapshot: RuntimeSnapshot) -> APIError? {
         snapshot.state == .ready ? nil : ModelRuntime.providerLoadingError()
+    }
+
+    static func modelIDForValidation(warmSwapEnabled: Bool, bootModelID: String?, runtimeSnapshot: RuntimeSnapshot) -> String? {
+        warmSwapEnabled ? runtimeSnapshot.modelID : bootModelID
+    }
+
+    static func swapDrainTimeoutEnvelope() -> [String: Any] {
+        [
+            "error": [
+                "type": "service_unavailable",
+                "code": "swap_drain_timeout",
+            ]
+        ]
     }
 
     private static func chatCompletionResponse(request: ChatCompletionRequest, completion: CompletionResult) -> [String: Any] {

--- a/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
+++ b/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
@@ -316,6 +316,10 @@ actor InferenceRelay {
         }
 
         do {
+            let handle = try await modelRuntime.acquireRequestHandle(request)
+            defer {
+                Task { await modelRuntime.unregisterInFlight(handle.registrationID) }
+            }
             _ = buffer.enqueue(sseEvent(chatCompletionChunk(
                 id: id,
                 created: created,
@@ -324,7 +328,7 @@ actor InferenceRelay {
                 finishReason: NSNull()
             )))
 
-            let completion = try await modelRuntime.stream(request, shouldCancel: { state.isCancelled }) { chunk in
+            let completion = try await modelRuntime.stream(request, with: handle, shouldCancel: { state.isCancelled }) { chunk in
                 _ = buffer.enqueue(sseEvent(chatCompletionChunk(
                     id: id,
                     created: created,

--- a/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
+++ b/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
@@ -12,6 +12,7 @@ actor InferenceRelay {
     private let modelRuntime: any ModelRuntimeServing
     private let providerStatus: ProviderStatus
     private let loadedModelID: String?
+    private let warmSwapEnabled: Bool
     private let maxActiveRequests: Int
     private let maxBodyBytes: Int
     private let sendFrame: SendFrame
@@ -22,6 +23,7 @@ actor InferenceRelay {
         modelRuntime: any ModelRuntimeServing,
         providerStatus: ProviderStatus,
         loadedModelID: String?,
+        warmSwapEnabled: Bool = false,
         maxActiveRequests: Int,
         maxBodyBytes: Int,
         tier2Session: Tier2ProviderSession? = nil,
@@ -30,6 +32,7 @@ actor InferenceRelay {
         self.modelRuntime = modelRuntime
         self.providerStatus = providerStatus
         self.loadedModelID = loadedModelID
+        self.warmSwapEnabled = warmSwapEnabled
         self.maxActiveRequests = max(1, maxActiveRequests)
         self.maxBodyBytes = max(1, maxBodyBytes)
         self.tier2Session = tier2Session
@@ -90,7 +93,7 @@ actor InferenceRelay {
         }
 
         let state = RelayRequestState()
-        let task = Task { [modelRuntime, providerStatus, loadedModelID, sendFrame, tier2Session, state] in
+        let task = Task { [modelRuntime, providerStatus, loadedModelID, warmSwapEnabled, sendFrame, tier2Session, state] in
             await Self.process(
                 requestID: requestID,
                 body: body,
@@ -99,6 +102,7 @@ actor InferenceRelay {
                 modelRuntime: modelRuntime,
                 providerStatus: providerStatus,
                 loadedModelID: loadedModelID,
+                warmSwapEnabled: warmSwapEnabled,
                 tier2Session: tier2Session,
                 sendFrame: sendFrame
             )
@@ -176,6 +180,7 @@ actor InferenceRelay {
         modelRuntime: any ModelRuntimeServing,
         providerStatus: ProviderStatus,
         loadedModelID: String?,
+        warmSwapEnabled: Bool,
         tier2Session: Tier2ProviderSession?,
         sendFrame: @escaping SendFrame
     ) async {
@@ -186,7 +191,10 @@ actor InferenceRelay {
         do {
             let requestData = Data(body.utf8)
             let request = try ChatCompletionRequest.parse(data: requestData)
-            try request.validateModelMatches(loadedModelID)
+            let validationModelID = warmSwapEnabled
+                ? await modelRuntime.currentSnapshot().modelID
+                : loadedModelID
+            try request.validateModelMatches(validationModelID)
             if stream {
                 completionResult = try await processStreaming(
                     requestID: requestID,

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -10,7 +10,7 @@ struct MacProviderCLI: AsyncParsableCommand {
         commandName: "macprovider-cli",
         abstract: "OpenAI-compatible Mac Provider inference CLI.",
         version: CoordinatorClient.binaryVersion,
-        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, UpdateCommand.self, UninstallCommand.self],
+        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self],
         defaultSubcommand: ServeCommand.self
     )
 }
@@ -54,6 +54,13 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "Drain timeout in seconds for an in-flight warm swap (SPEC-011 v0.5 §3.4 / §3.9). Default 30. Only meaningful when --enable-warm-swap is set.")
     var swapDrainTimeoutSeconds: Int?
 
+    @Option(help: "Control socket path. Overrides MACPROVIDER_CTL_SOCKET_PATH and config ctl_socket_path. Default $TMPDIR/macprovider-cli/ctl.sock. Only meaningful when --enable-warm-swap is set.")
+    var ctlSocketPath: String?
+
+    // Phase 1E reads/writes this path for the cooldown soft guard; Phase 1C only plumbs it.
+    @Option(help: "CLI-side cooldown state file. Overrides MACPROVIDER_SWITCH_STATE_PATH and config switch_state_path. Default $HOME/Library/Application Support/macprovider-cli/last-switch.ts. Cooldown soft guard lands in Phase 1E.")
+    var switchStatePath: String?
+
     static func runSupportedModelsPreflight(_ resolved: inout AppConfig) throws {
         if resolved.supportedModels != nil {
             do {
@@ -82,7 +89,9 @@ struct ServeCommand: AsyncParsableCommand {
                 supportedModels: SupportedModels.parseCSV(supportedModels),
                 publishesSupportedModels: publishSupportedModels,
                 enableWarmSwap: enableWarmSwap,
-                swapDrainTimeoutSeconds: swapDrainTimeoutSeconds
+                swapDrainTimeoutSeconds: swapDrainTimeoutSeconds,
+                ctlSocketPath: ctlSocketPath,
+                switchStatePath: switchStatePath
             )
         )
 
@@ -116,16 +125,33 @@ struct ServeCommand: AsyncParsableCommand {
             providerStatus: providerStatus,
             attestationGenerator: ManagedDeviceAttestationGenerator(artifactPath: resolved.tier2MDAArtifactPath)
         )
+        let controlSocket: ControlSocketServer?
+        if resolved.enableWarmSwap {
+            let socketURL = ControlSocketPaths.resolve(ctlSocketPath: resolved.ctlSocketPath)
+            controlSocket = ControlSocketServer(socketPath: socketURL, modelRuntime: modelRuntime)
+            do {
+                try await controlSocket?.start()
+            } catch {
+                if let serverError = error as? ControlSocketServerError,
+                   serverError != .staleSocket(path: socketURL.path) {
+                    FileHandle.standardError.write(Data(("\(serverError.description)\n").utf8))
+                }
+                throw ExitCode(1)
+            }
+        } else {
+            controlSocket = nil
+        }
         await coordinatorClient?.start()
         let server = HTTPServer(config: resolved, modelRuntime: modelRuntime, providerStatus: providerStatus)
-        let terminationHandler = installTerminationHandler(coordinatorClient: coordinatorClient)
+        let terminationHandlers = installTerminationHandlers(coordinatorClient: coordinatorClient, controlSocket: controlSocket)
         defer {
             Task {
+                await controlSocket?.stop()
                 await coordinatorClient?.stop()
             }
-            terminationHandler.cancel()
+            terminationHandlers.forEach { $0.cancel() }
         }
-        try withExtendedLifetime(terminationHandler) {
+        try withExtendedLifetime(terminationHandlers) {
             try server.run()
         }
     }
@@ -204,17 +230,34 @@ struct UpdateCommand: AsyncParsableCommand {
     }
 }
 
-private func installTerminationHandler(coordinatorClient: CoordinatorClient?) -> DispatchSourceSignal {
-    signal(SIGTERM, SIG_IGN)
-    let source = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .global(qos: .userInitiated))
-    source.setEventHandler {
-        Task {
-            await coordinatorClient?.drainAndExit(reason: "SIGTERM received")
-            Darwin.exit(0)
+private func installTerminationHandlers(
+    coordinatorClient: CoordinatorClient?,
+    controlSocket: ControlSocketServer?
+) -> [DispatchSourceSignal] {
+    [SIGTERM, SIGINT].map { signalNumber in
+        signal(signalNumber, SIG_IGN)
+        let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global(qos: .userInitiated))
+        source.setEventHandler {
+            Task {
+                await controlSocket?.stop()
+                await coordinatorClient?.drainAndExit(reason: "\(signalName(signalNumber)) received")
+                Darwin.exit(0)
+            }
         }
+        source.resume()
+        return source
     }
-    source.resume()
-    return source
+}
+
+private func signalName(_ signalNumber: Int32) -> String {
+    switch signalNumber {
+    case SIGTERM:
+        return "SIGTERM"
+    case SIGINT:
+        return "SIGINT"
+    default:
+        return "signal \(signalNumber)"
+    }
 }
 
 private func printResolvedConfiguration(_ config: AppConfig) {

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -48,6 +48,12 @@ struct ServeCommand: AsyncParsableCommand {
     @Flag(name: .customLong("publish-supported-models"), inversion: .prefixedNo, help: "Opt into publishing the supported_models catalog to the coordinator's /v1/status echo (SPEC-010 v1.5 R-3.6.4). Default off.")
     var publishSupportedModels: Bool?
 
+    @Flag(name: .customLong("enable-warm-swap"), inversion: .prefixedNo, help: "Opt into the operator-pushed warm model swap workflow (SPEC-011 v0.5). Default off. When off, the binary follows the SPEC-001 v1.2.4 synchronous-load path; no control socket is opened.")
+    var enableWarmSwap: Bool?
+
+    @Option(help: "Drain timeout in seconds for an in-flight warm swap (SPEC-011 v0.5 §3.4 / §3.9). Default 30. Only meaningful when --enable-warm-swap is set.")
+    var swapDrainTimeoutSeconds: Int?
+
     static func runSupportedModelsPreflight(_ resolved: inout AppConfig) throws {
         if resolved.supportedModels != nil {
             do {
@@ -74,7 +80,9 @@ struct ServeCommand: AsyncParsableCommand {
                 configPath: config,
                 logLevel: logLevel,
                 supportedModels: SupportedModels.parseCSV(supportedModels),
-                publishesSupportedModels: publishSupportedModels
+                publishesSupportedModels: publishSupportedModels,
+                enableWarmSwap: enableWarmSwap,
+                swapDrainTimeoutSeconds: swapDrainTimeoutSeconds
             )
         )
 
@@ -84,7 +92,9 @@ struct ServeCommand: AsyncParsableCommand {
 
         let modelRuntime = try await ModelRuntime(
             modelID: resolved.model,
-            maxContextTokensOverride: resolved.maxContextOverride
+            maxContextTokensOverride: resolved.maxContextOverride,
+            warmSwapEnabled: resolved.enableWarmSwap,
+            swapDrainTimeoutSeconds: resolved.swapDrainTimeoutSeconds
         )
         // MLX generation is currently guarded by a process-local semaphore of 1.
         // Advertise the real runtime concurrency until the runtime is proven safe

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -42,8 +42,29 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "Log level: trace, debug, info, notice, warning, error, critical.")
     var logLevel: String?
 
+    @Option(help: "Comma-separated list of HuggingFace model IDs (or local paths) this provider can serve. Overrides MACPROVIDER_SUPPORTED_MODELS and config key supported_models. When unset, the binary publishes supported_models: [model_id] (single-entry, per SPEC-010 v1.5 R-3.6.2).")
+    var supportedModels: String?
+
+    @Flag(name: .customLong("publish-supported-models"), inversion: .prefixedNo, help: "Opt into publishing the supported_models catalog to the coordinator's /v1/status echo (SPEC-010 v1.5 R-3.6.4). Default off.")
+    var publishSupportedModels: Bool?
+
+    static func runSupportedModelsPreflight(_ resolved: inout AppConfig) throws {
+        if resolved.supportedModels != nil {
+            do {
+                let catalog = try SupportedModels.validate(
+                    model: resolved.model ?? "",
+                    supportedModels: resolved.supportedModels
+                )
+                resolved.supportedModels = catalog
+            } catch let error as SupportedModelsValidationError {
+                FileHandle.standardError.write(Data(("\(error)\n").utf8))
+                throw ExitCode(2)
+            }
+        }
+    }
+
     func run() async throws {
-        let resolved = try ConfigLoader.load(
+        var resolved = try ConfigLoader.load(
             cli: CLIOverrides(
                 port: port,
                 model: model,
@@ -51,9 +72,13 @@ struct ServeCommand: AsyncParsableCommand {
                 providerID: providerID,
                 endpointURL: endpointURL,
                 configPath: config,
-                logLevel: logLevel
+                logLevel: logLevel,
+                supportedModels: SupportedModels.parseCSV(supportedModels),
+                publishesSupportedModels: publishSupportedModels
             )
         )
+
+        try Self.runSupportedModelsPreflight(&resolved)
 
         printResolvedConfiguration(resolved)
 

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -76,6 +76,15 @@ struct ServeCommand: AsyncParsableCommand {
         }
     }
 
+    static func runDrainTimeoutPreflight(_ resolved: AppConfig) throws {
+        if !(5...600).contains(resolved.swapDrainTimeoutSeconds) {
+            FileHandle.standardError.write(Data((
+                "--swap-drain-timeout-seconds \(resolved.swapDrainTimeoutSeconds) out of range 5...600\n"
+            ).utf8))
+            throw ExitCode(2)
+        }
+    }
+
     func run() async throws {
         var resolved = try ConfigLoader.load(
             cli: CLIOverrides(
@@ -96,6 +105,7 @@ struct ServeCommand: AsyncParsableCommand {
         )
 
         try Self.runSupportedModelsPreflight(&resolved)
+        try Self.runDrainTimeoutPreflight(resolved)
 
         printResolvedConfiguration(resolved)
 
@@ -119,6 +129,7 @@ struct ServeCommand: AsyncParsableCommand {
             capacity: capacityDefaults.withThroughputEstimate(throughputEstimate),
             modelHash: await modelRuntime.loadedModelHash
         )
+        await modelRuntime.setProviderStatus(providerStatus)
         let coordinatorClient = CoordinatorClient(
             config: resolved,
             modelRuntime: modelRuntime,
@@ -128,7 +139,11 @@ struct ServeCommand: AsyncParsableCommand {
         let controlSocket: ControlSocketServer?
         if resolved.enableWarmSwap {
             let socketURL = ControlSocketPaths.resolve(ctlSocketPath: resolved.ctlSocketPath)
-            controlSocket = ControlSocketServer(socketPath: socketURL, modelRuntime: modelRuntime)
+            controlSocket = ControlSocketServer(
+                socketPath: socketURL,
+                modelRuntime: modelRuntime,
+                supportedModels: resolved.supportedModels
+            )
             do {
                 try await controlSocket?.start()
             } catch {

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -4,9 +4,12 @@ import MLXLLM
 import MLXLMCommon
 import MacProviderCore
 
-protocol ModelRuntimeServing: Sendable {
+protocol ModelRuntimeServing: Actor {
     func complete(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool) async throws -> CompletionResult
-    func stream(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool, onChunk: @escaping @Sendable (String) -> Void) async throws -> CompletionResult
+    func stream(_ request: ChatCompletionRequest, with handle: RequestHandle, shouldCancel: @escaping @Sendable () -> Bool, onChunk: @escaping @Sendable (String) -> Void) async throws -> CompletionResult
+    func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws
+    func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle
+    func unregisterInFlight(_ id: Int)
     func currentSnapshot() async -> RuntimeSnapshot
 }
 
@@ -19,12 +22,6 @@ extension ModelRuntimeServing {
         try await complete(request, shouldCancel: { false })
     }
 
-    func stream(
-        _ request: ChatCompletionRequest,
-        onChunk: @escaping @Sendable (String) -> Void
-    ) async throws -> CompletionResult {
-        try await stream(request, shouldCancel: { false }, onChunk: onChunk)
-    }
 }
 
 public struct RuntimeSnapshot: @unchecked Sendable {
@@ -32,6 +29,12 @@ public struct RuntimeSnapshot: @unchecked Sendable {
     public let container: ModelContainer?
     public let modelID: String?
     public let modelHash: String?
+}
+
+public struct RequestHandle: @unchecked Sendable {
+    public let snapshot: RuntimeSnapshot
+    public let registrationID: Int
+    let drainCancelled: DrainCancelToken
 }
 
 public struct WarmSwapDisabledError: Error, CustomStringConvertible {
@@ -287,11 +290,26 @@ actor ModelRuntime: ModelRuntimeServing {
         signalContinuations.removeValue(forKey: id)
     }
 
-    func preflight(_ request: ChatCompletionRequest) async throws {
-        let snapshot = await currentSnapshot()
+    func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle {
+        let snapshot = RuntimeSnapshot(
+            state: state,
+            container: currentContainer,
+            modelID: currentModelID,
+            modelHash: currentModelHash
+        )
         try Self.validateReady(snapshot.state)
         try request.validateModelMatches(snapshot.modelID)
-        guard let container = snapshot.container else {
+        let drainCancelled = DrainCancelToken()
+        let registrationID = registerInFlight { drainCancelled.fire() }
+        return RequestHandle(
+            snapshot: snapshot,
+            registrationID: registrationID,
+            drainCancelled: drainCancelled
+        )
+    }
+
+    func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
+        guard let container = handle.snapshot.container else {
             if testCompletion != nil {
                 return
             }
@@ -380,15 +398,12 @@ actor ModelRuntime: ModelRuntimeServing {
 
     func stream(
         _ request: ChatCompletionRequest,
+        with handle: RequestHandle,
         shouldCancel: @escaping @Sendable () -> Bool = { false },
         onChunk: @escaping @Sendable (String) -> Void
     ) async throws -> CompletionResult {
-        let snapshot = await currentSnapshot()
-        try Self.validateReady(snapshot.state)
-        try request.validateModelMatches(snapshot.modelID)
-        let drainCancelled = DrainCancelToken()
-        let registrationID = registerInFlight { drainCancelled.fire() }
-        defer { unregisterInFlight(registrationID) }
+        let snapshot = handle.snapshot
+        let drainCancelled = handle.drainCancelled
         if let testCompletion {
             let completion = try await Self.withDrainCancellation(drainCancelled) {
                 try await testCompletion(snapshot, request)
@@ -704,7 +719,7 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 }
 
-private final class DrainCancelToken: @unchecked Sendable {
+final class DrainCancelToken: @unchecked Sendable {
     private var _fired = false
     private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
     private let lock = NSLock()

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -22,40 +22,76 @@ extension ModelRuntimeServing {
     }
 }
 
+public struct RuntimeSnapshot: @unchecked Sendable {
+    public let state: SwapState
+    public let container: ModelContainer?
+    public let modelID: String?
+    public let modelHash: String?
+}
+
+public struct WarmSwapDisabledError: Error, CustomStringConvertible {
+    public var description: String {
+        "warm swap is not enabled (start serve with --enable-warm-swap)"
+    }
+}
+
 actor ModelRuntime: ModelRuntimeServing {
-    private let modelID: String?
-    private let container: ModelContainer?
+    private var currentModelID: String?
+    private var currentContainer: ModelContainer?
     private let stopTokenFilter: StopTokenFilter
-    private let modelHash: String?
+    private var currentModelHash: String?
     private let maxContextTokens: Int
     private let inferenceGate = AsyncSemaphore(value: 1)
+    private let stateMachine: RuntimeStateMachine
+    private let warmSwapEnabled: Bool
+    private let swapDrainTimeoutSeconds: Int
+    private let loader: @Sendable (String) async throws -> (ModelContainer, String, String?)
+    private let testLoader: (@Sendable (String) async throws -> (String, String?))?
+    private let testCompletion: (@Sendable (RuntimeSnapshot, ChatCompletionRequest) async throws -> CompletionResult)?
 
     var loadedModelID: String? {
-        modelID
+        currentModelID
     }
 
     var loadedModelHash: String? {
-        modelHash
+        currentModelHash
     }
 
     var isLoaded: Bool {
-        container != nil
+        currentContainer != nil
     }
 
-    init(modelID: String?, maxContextTokensOverride: Int? = nil) async throws {
-        self.modelID = modelID
+    init(
+        modelID: String?,
+        maxContextTokensOverride: Int? = nil,
+        warmSwapEnabled: Bool = false,
+        swapDrainTimeoutSeconds: Int = 30
+    ) async throws {
+        self.currentModelID = modelID
         self.maxContextTokens = maxContextTokensOverride ?? Self.defaultMaxContextTokens()
+        self.stateMachine = RuntimeStateMachine()
+        self.warmSwapEnabled = warmSwapEnabled
+        self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
+        self.loader = { targetModelID in
+            let configuration = Self.configuration(for: targetModelID)
+            let container = try await LLMModelFactory.shared.loadContainer(configuration: configuration)
+            let directory = configuration.modelDirectory()
+            let modelHash = try? Self.modelWeightArtifactManifestHash(in: directory)
+            return (container, targetModelID, modelHash)
+        }
+        self.testLoader = nil
+        self.testCompletion = nil
 
         guard let modelID else {
-            self.container = nil
+            self.currentContainer = nil
             self.stopTokenFilter = StopTokenFilter(tokens: [])
-            self.modelHash = nil
+            self.currentModelHash = nil
             return
         }
 
         let configuration = Self.configuration(for: modelID)
         let container = try await LLMModelFactory.shared.loadContainer(configuration: configuration)
-        self.container = container
+        self.currentContainer = container
 
         let directory = configuration.modelDirectory()
         let tokenizerConfigURL = directory.appendingPathComponent("tokenizer_config.json")
@@ -64,12 +100,83 @@ actor ModelRuntime: ModelRuntimeServing {
         } else {
             self.stopTokenFilter = StopTokenFilter(tokens: [])
         }
-        self.modelHash = try? Self.modelWeightArtifactManifestHash(in: directory)
+        self.currentModelHash = try? Self.modelWeightArtifactManifestHash(in: directory)
+    }
+
+    init(
+        modelID: String?,
+        modelHash: String? = nil,
+        maxContextTokensOverride: Int? = nil,
+        warmSwapEnabled: Bool,
+        swapDrainTimeoutSeconds: Int = 30,
+        stateMachine: RuntimeStateMachine = RuntimeStateMachine(),
+        loader: @escaping @Sendable (String) async throws -> (ModelContainer, String, String?),
+        testLoader: (@Sendable (String) async throws -> (String, String?))? = nil,
+        testCompletion: (@Sendable (RuntimeSnapshot, ChatCompletionRequest) async throws -> CompletionResult)? = nil
+    ) {
+        self.currentModelID = modelID
+        self.currentContainer = nil
+        self.currentModelHash = modelHash
+        self.stopTokenFilter = StopTokenFilter(tokens: [])
+        self.maxContextTokens = maxContextTokensOverride ?? Self.defaultMaxContextTokens()
+        self.stateMachine = stateMachine
+        self.warmSwapEnabled = warmSwapEnabled
+        self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
+        self.loader = loader
+        self.testLoader = testLoader
+        self.testCompletion = testCompletion
+    }
+
+    func currentSnapshot() async -> RuntimeSnapshot {
+        RuntimeSnapshot(
+            state: await stateMachine.current(),
+            container: currentContainer,
+            modelID: currentModelID,
+            modelHash: currentModelHash
+        )
+    }
+
+    func swapSignals() async -> AsyncStream<SwapSignal> {
+        await stateMachine.signalStream()
+    }
+
+    func beginSwap(targetModelID: String) async throws -> Task<Void, Error> {
+        guard warmSwapEnabled else { throw WarmSwapDisabledError() }
+        try await stateMachine.transitionToLoading(target: targetModelID)
+        return Task.detached { [stateMachine, loader, testLoader] in
+            do {
+                if let testLoader {
+                    let (modelID, modelHash) = try await testLoader(targetModelID)
+                    await self.applySwap(container: nil, modelID: modelID, modelHash: modelHash)
+                } else {
+                    let (container, modelID, modelHash) = try await loader(targetModelID)
+                    await self.applySwap(container: container, modelID: modelID, modelHash: modelHash)
+                }
+            } catch {
+                await stateMachine.failSwap(reason: String(describing: error))
+            }
+        }
+    }
+
+    nonisolated func swapDrainTimeoutForTest() -> Int {
+        swapDrainTimeoutSeconds
+    }
+
+    private func applySwap(container: ModelContainer?, modelID: String, modelHash: String?) async {
+        currentContainer = container
+        currentModelID = modelID
+        currentModelHash = modelHash
+        await stateMachine.completeSwap(newModelID: modelID, newModelHash: modelHash)
     }
 
     func preflight(_ request: ChatCompletionRequest) async throws {
-        try request.validateModelMatches(modelID)
-        guard let container else {
+        let snapshot = await currentSnapshot()
+        try Self.validateReady(snapshot.state)
+        try request.validateModelMatches(snapshot.modelID)
+        guard let container = snapshot.container else {
+            if testCompletion != nil {
+                return
+            }
             throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
         }
 
@@ -87,8 +194,13 @@ actor ModelRuntime: ModelRuntimeServing {
         _ request: ChatCompletionRequest,
         shouldCancel: @escaping @Sendable () -> Bool = { false }
     ) async throws -> CompletionResult {
-        try request.validateModelMatches(modelID)
-        guard let container else {
+        let snapshot = await currentSnapshot()
+        try Self.validateReady(snapshot.state)
+        try request.validateModelMatches(snapshot.modelID)
+        if let testCompletion {
+            return try await testCompletion(snapshot, request)
+        }
+        guard let container = snapshot.container else {
             throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
         }
 
@@ -141,8 +253,17 @@ actor ModelRuntime: ModelRuntimeServing {
         shouldCancel: @escaping @Sendable () -> Bool = { false },
         onChunk: @escaping @Sendable (String) -> Void
     ) async throws -> CompletionResult {
-        try request.validateModelMatches(modelID)
-        guard let container else {
+        let snapshot = await currentSnapshot()
+        try Self.validateReady(snapshot.state)
+        try request.validateModelMatches(snapshot.modelID)
+        if let testCompletion {
+            let completion = try await testCompletion(snapshot, request)
+            if !completion.content.isEmpty {
+                onChunk(completion.content)
+            }
+            return completion
+        }
+        guard let container = snapshot.container else {
             throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
         }
 
@@ -220,7 +341,7 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 
     func measureStartupThroughput(maxTokens: Int = 8) async -> Double {
-        guard let container else {
+        guard let container = currentContainer else {
             return 0.0
         }
 
@@ -263,6 +384,21 @@ actor ModelRuntime: ModelRuntimeServing {
                 param: "messages"
             )
         }
+    }
+
+    static func validateReady(_ state: SwapState) throws {
+        guard state == .ready else {
+            throw providerLoadingError()
+        }
+    }
+
+    static func providerLoadingError() -> APIError {
+        APIError(
+            status: 503,
+            message: "Provider is loading a new model and is temporarily unavailable. Retry after the indicated interval.",
+            type: "service_unavailable",
+            code: "provider_loading"
+        )
     }
 
     private static func defaultMaxContextTokens() -> Int {

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -7,9 +7,14 @@ import MacProviderCore
 protocol ModelRuntimeServing: Sendable {
     func complete(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool) async throws -> CompletionResult
     func stream(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool, onChunk: @escaping @Sendable (String) -> Void) async throws -> CompletionResult
+    func currentSnapshot() async -> RuntimeSnapshot
 }
 
 extension ModelRuntimeServing {
+    func currentSnapshot() async -> RuntimeSnapshot {
+        RuntimeSnapshot(state: .ready, container: nil, modelID: nil, modelHash: nil)
+    }
+
     func complete(_ request: ChatCompletionRequest) async throws -> CompletionResult {
         try await complete(request, shouldCancel: { false })
     }
@@ -35,6 +40,8 @@ public struct WarmSwapDisabledError: Error, CustomStringConvertible {
     }
 }
 
+public struct DrainCancelledError: Error { }
+
 actor ModelRuntime: ModelRuntimeServing {
     private var state: SwapState = .ready
     private var targetModelID: String?
@@ -47,7 +54,9 @@ actor ModelRuntime: ModelRuntimeServing {
     private let warmSwapEnabled: Bool
     private let swapDrainTimeoutSeconds: Int
     private var providerStatus: ProviderStatus?
-    private var signalContinuations: [AsyncStream<SwapSignal>.Continuation] = []
+    private var signalContinuations: [UUID: AsyncStream<SwapSignal>.Continuation] = [:]
+    private var nextInFlightID: Int = 0
+    private var inFlightCancellations: [Int: @Sendable () -> Void] = [:]
     private let loader: @Sendable (String) async throws -> (ModelContainer, String, String?)
     private let testLoader: (@Sendable (String) async throws -> (String, String?))?
     private let testCompletion: (@Sendable (RuntimeSnapshot, ChatCompletionRequest) async throws -> CompletionResult)?
@@ -133,7 +142,7 @@ actor ModelRuntime: ModelRuntimeServing {
         self.providerStatus = providerStatus
     }
 
-    func currentSnapshot() -> RuntimeSnapshot {
+    func currentSnapshot() async -> RuntimeSnapshot {
         RuntimeSnapshot(
             state: state,
             container: currentContainer,
@@ -144,7 +153,11 @@ actor ModelRuntime: ModelRuntimeServing {
 
     func swapSignals() -> AsyncStream<SwapSignal> {
         let pair = AsyncStream<SwapSignal>.makeStream(of: SwapSignal.self)
-        signalContinuations.append(pair.continuation)
+        let id = UUID()
+        signalContinuations[id] = pair.continuation
+        pair.continuation.onTermination = { @Sendable [weak self] _ in
+            Task { await self?.removeSignalContinuation(id) }
+        }
         return pair.stream
     }
 
@@ -173,7 +186,10 @@ actor ModelRuntime: ModelRuntimeServing {
                     modelHash = loaded.2
                 }
                 try await self.enterDrainPhase()
-                await Self.waitForDrainOrTimeout(providerStatus: providerStatus, timeoutSeconds: drainTimeoutSeconds)
+                let didTimeout = await Self.waitForDrainOrTimeout(providerStatus: providerStatus, timeoutSeconds: drainTimeoutSeconds)
+                if didTimeout {
+                    await self.cancelAllInFlightForDrainTimeout()
+                }
                 await self.completeSwapAtomically(container: container, modelID: modelID, modelHash: modelHash)
             } catch {
                 await self.failSwap(reason: String(describing: error))
@@ -201,23 +217,24 @@ actor ModelRuntime: ModelRuntimeServing {
         signal(SwapSignal(targetModelID: targetModelID ?? "", outcome: .loadFinished))
     }
 
-    private nonisolated static func waitForDrainOrTimeout(providerStatus: ProviderStatus?, timeoutSeconds: Int) async {
+    private nonisolated static func waitForDrainOrTimeout(providerStatus: ProviderStatus?, timeoutSeconds: Int) async -> Bool {
         guard let providerStatus else {
-            return
+            return false
         }
         let drainStartMs = Int64(Date().timeIntervalSince1970 * 1000)
         let timeoutMs = Int64(timeoutSeconds * 1000)
         while !Task.isCancelled {
             let snapshot = await providerStatus.snapshot()
             if snapshot.requestsInFlight == 0 {
-                return
+                return false
             }
             let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
-            if nowMs - drainStartMs > timeoutMs {
-                return
+            if nowMs - drainStartMs >= timeoutMs {
+                return true
             }
             try? await Task.sleep(nanoseconds: 50_000_000)
         }
+        return false
     }
 
     private func completeSwapAtomically(container: ModelContainer?, modelID: String, modelHash: String?) {
@@ -242,13 +259,36 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 
     private func signal(_ signal: SwapSignal) {
-        for continuation in signalContinuations {
+        for continuation in signalContinuations.values {
             continuation.yield(signal)
         }
     }
 
+    func registerInFlight(_ cancel: @escaping @Sendable () -> Void) -> Int {
+        nextInFlightID += 1
+        let id = nextInFlightID
+        inFlightCancellations[id] = cancel
+        return id
+    }
+
+    func unregisterInFlight(_ id: Int) {
+        inFlightCancellations.removeValue(forKey: id)
+    }
+
+    private func cancelAllInFlightForDrainTimeout() {
+        let cancels = Array(inFlightCancellations.values)
+        inFlightCancellations.removeAll()
+        for cancel in cancels {
+            cancel()
+        }
+    }
+
+    private func removeSignalContinuation(_ id: UUID) {
+        signalContinuations.removeValue(forKey: id)
+    }
+
     func preflight(_ request: ChatCompletionRequest) async throws {
-        let snapshot = currentSnapshot()
+        let snapshot = await currentSnapshot()
         try Self.validateReady(snapshot.state)
         try request.validateModelMatches(snapshot.modelID)
         guard let container = snapshot.container else {
@@ -272,56 +312,68 @@ actor ModelRuntime: ModelRuntimeServing {
         _ request: ChatCompletionRequest,
         shouldCancel: @escaping @Sendable () -> Bool = { false }
     ) async throws -> CompletionResult {
-        let snapshot = currentSnapshot()
+        let snapshot = await currentSnapshot()
         try Self.validateReady(snapshot.state)
         try request.validateModelMatches(snapshot.modelID)
+        let drainCancelled = DrainCancelToken()
+        let registrationID = registerInFlight { drainCancelled.fire() }
+        defer { unregisterInFlight(registrationID) }
         if let testCompletion {
-            return try await testCompletion(snapshot, request)
+            return try await Self.withDrainCancellation(drainCancelled) {
+                try await testCompletion(snapshot, request)
+            }
         }
         guard let container = snapshot.container else {
             throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
         }
 
         let maxContextTokens = maxContextTokens
-        return try await inferenceGate.withPermit {
-            try Task.checkCancellation()
-            return try await container.perform { context in
+        let inferenceGate = inferenceGate
+        let stopTokenFilter = stopTokenFilter
+        return try await Self.withDrainCancellation(drainCancelled) {
+            try await inferenceGate.withPermit {
+                try drainCancelled.check()
                 try Task.checkCancellation()
-                let input = UserInput(chat: request.messages.map { $0.mlxMessage })
-                let lmInput = try await context.processor.prepare(input: input)
-                try Self.validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
-                let parameters = GenerateParameters(
-                    maxTokens: request.maxTokens,
-                    temperature: Float(request.temperature),
-                    topP: Float(request.topP)
-                )
-                let result: GenerateResult = try generate(input: lmInput, parameters: parameters, context: context) { (_: [Int]) in
-                    if Task.isCancelled || shouldCancel() {
-                        return GenerateDisposition.stop
+                return try await container.perform { context in
+                    try drainCancelled.check()
+                    try Task.checkCancellation()
+                    let input = UserInput(chat: request.messages.map { $0.mlxMessage })
+                    let lmInput = try await context.processor.prepare(input: input)
+                    try Self.validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
+                    let parameters = GenerateParameters(
+                        maxTokens: request.maxTokens,
+                        temperature: Float(request.temperature),
+                        topP: Float(request.topP)
+                    )
+                    let result: GenerateResult = try generate(input: lmInput, parameters: parameters, context: context) { (_: [Int]) in
+                        if Task.isCancelled || shouldCancel() || drainCancelled.isFired {
+                            return GenerateDisposition.stop
+                        }
+                        return GenerateDisposition.more
                     }
-                    return GenerateDisposition.more
+                    try drainCancelled.check()
+                    try Task.checkCancellation()
+
+                    let filtered = Self.applyOutputFilters(
+                        result.output,
+                        stopTokenFilter: stopTokenFilter,
+                        requestStops: request.stop
+                    )
+
+                    let finishReason: String
+                    if let maxTokens = request.maxTokens, result.generationTokenCount >= maxTokens, !filtered.hitStop {
+                        finishReason = "length"
+                    } else {
+                        finishReason = "stop"
+                    }
+
+                    return CompletionResult(
+                        content: filtered.text,
+                        finishReason: finishReason,
+                        promptTokens: result.promptTokenCount,
+                        completionTokens: result.generationTokenCount
+                    )
                 }
-                try Task.checkCancellation()
-
-                let filtered = Self.applyOutputFilters(
-                    result.output,
-                    stopTokenFilter: stopTokenFilter,
-                    requestStops: request.stop
-                )
-
-                let finishReason: String
-                if let maxTokens = request.maxTokens, result.generationTokenCount >= maxTokens, !filtered.hitStop {
-                    finishReason = "length"
-                } else {
-                    finishReason = "stop"
-                }
-
-                return CompletionResult(
-                    content: filtered.text,
-                    finishReason: finishReason,
-                    promptTokens: result.promptTokenCount,
-                    completionTokens: result.generationTokenCount
-                )
             }
         }
     }
@@ -331,11 +383,16 @@ actor ModelRuntime: ModelRuntimeServing {
         shouldCancel: @escaping @Sendable () -> Bool = { false },
         onChunk: @escaping @Sendable (String) -> Void
     ) async throws -> CompletionResult {
-        let snapshot = currentSnapshot()
+        let snapshot = await currentSnapshot()
         try Self.validateReady(snapshot.state)
         try request.validateModelMatches(snapshot.modelID)
+        let drainCancelled = DrainCancelToken()
+        let registrationID = registerInFlight { drainCancelled.fire() }
+        defer { unregisterInFlight(registrationID) }
         if let testCompletion {
-            let completion = try await testCompletion(snapshot, request)
+            let completion = try await Self.withDrainCancellation(drainCancelled) {
+                try await testCompletion(snapshot, request)
+            }
             if !completion.content.isEmpty {
                 onChunk(completion.content)
             }
@@ -346,74 +403,81 @@ actor ModelRuntime: ModelRuntimeServing {
         }
 
         let maxContextTokens = maxContextTokens
-        return try await inferenceGate.withPermit {
-            try Task.checkCancellation()
-            return try await container.perform { context in
+        let inferenceGate = inferenceGate
+        let stopTokenFilter = stopTokenFilter
+        return try await Self.withDrainCancellation(drainCancelled) {
+            try await inferenceGate.withPermit {
+                try drainCancelled.check()
                 try Task.checkCancellation()
-                let input = UserInput(chat: request.messages.map { $0.mlxMessage })
-                let lmInput = try await context.processor.prepare(input: input)
-                try Self.validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
-                let parameters = GenerateParameters(
-                    maxTokens: request.maxTokens,
-                    temperature: Float(request.temperature),
-                    topP: Float(request.topP)
-                )
+                return try await container.perform { context in
+                    try drainCancelled.check()
+                    try Task.checkCancellation()
+                    let input = UserInput(chat: request.messages.map { $0.mlxMessage })
+                    let lmInput = try await context.processor.prepare(input: input)
+                    try Self.validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
+                    let parameters = GenerateParameters(
+                        maxTokens: request.maxTokens,
+                        temperature: Float(request.temperature),
+                        topP: Float(request.topP)
+                    )
 
-                var emittedText = ""
-                var stoppedByRequestStop = false
+                    var emittedText = ""
+                    var stoppedByRequestStop = false
 
-                let result: GenerateResult = try generate(input: lmInput, parameters: parameters, context: context) { tokens in
-                    if Task.isCancelled || shouldCancel() {
-                        return .stop
+                    let result: GenerateResult = try generate(input: lmInput, parameters: parameters, context: context) { tokens in
+                        if Task.isCancelled || shouldCancel() || drainCancelled.isFired {
+                            return .stop
+                        }
+                        let decoded = context.tokenizer.decode(tokens: tokens)
+                        let candidate = Self.streamingSafePrefix(
+                            decoded,
+                            stopTokenFilter: stopTokenFilter,
+                            requestStops: request.stop
+                        )
+
+                        let delta = Self.delta(from: emittedText, to: candidate.text)
+                        if !delta.isEmpty {
+                            emittedText = candidate.text
+                            onChunk(delta)
+                        }
+
+                        if candidate.hitStop {
+                            stoppedByRequestStop = true
+                            return .stop
+                        }
+                        return .more
                     }
-                    let decoded = context.tokenizer.decode(tokens: tokens)
-                    let candidate = Self.streamingSafePrefix(
-                        decoded,
+                    try drainCancelled.check()
+                    try Task.checkCancellation()
+
+                    let final = Self.applyOutputFilters(
+                        result.output,
                         stopTokenFilter: stopTokenFilter,
                         requestStops: request.stop
                     )
-
-                    let delta = Self.delta(from: emittedText, to: candidate.text)
-                    if !delta.isEmpty {
-                        emittedText = candidate.text
-                        onChunk(delta)
+                    let finalDelta = Self.delta(from: emittedText, to: final.text)
+                    if !finalDelta.isEmpty {
+                        onChunk(finalDelta)
                     }
 
-                    if candidate.hitStop {
-                        stoppedByRequestStop = true
-                        return .stop
+                    let finishReason: String
+                    if let maxTokens = request.maxTokens,
+                       result.generationTokenCount >= maxTokens,
+                       !stoppedByRequestStop,
+                       !final.hitStop
+                    {
+                        finishReason = "length"
+                    } else {
+                        finishReason = "stop"
                     }
-                    return .more
-                }
-                try Task.checkCancellation()
 
-                let final = Self.applyOutputFilters(
-                    result.output,
-                    stopTokenFilter: stopTokenFilter,
-                    requestStops: request.stop
-                )
-                let finalDelta = Self.delta(from: emittedText, to: final.text)
-                if !finalDelta.isEmpty {
-                    onChunk(finalDelta)
+                    return CompletionResult(
+                        content: final.text,
+                        finishReason: finishReason,
+                        promptTokens: result.promptTokenCount,
+                        completionTokens: result.generationTokenCount
+                    )
                 }
-
-                let finishReason: String
-                if let maxTokens = request.maxTokens,
-                   result.generationTokenCount >= maxTokens,
-                   !stoppedByRequestStop,
-                   !final.hitStop
-                {
-                    finishReason = "length"
-                } else {
-                    finishReason = "stop"
-                }
-
-                return CompletionResult(
-                    content: final.text,
-                    finishReason: finishReason,
-                    promptTokens: result.promptTokenCount,
-                    completionTokens: result.generationTokenCount
-                )
             }
         }
     }
@@ -477,6 +541,28 @@ actor ModelRuntime: ModelRuntimeServing {
             type: "service_unavailable",
             code: "provider_loading"
         )
+    }
+
+    private nonisolated static func withDrainCancellation<T: Sendable>(
+        _ token: DrainCancelToken,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            group.addTask {
+                while !token.isFired {
+                    try await Task.sleep(nanoseconds: 10_000_000)
+                }
+                throw DrainCancelledError()
+            }
+            guard let result = try await group.next() else {
+                throw DrainCancelledError()
+            }
+            group.cancelAll()
+            return result
+        }
     }
 
     private static func defaultMaxContextTokens() -> Int {
@@ -618,6 +704,62 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 }
 
+private final class DrainCancelToken: @unchecked Sendable {
+    private var _fired = false
+    private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
+    private let lock = NSLock()
+
+    var isFired: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _fired
+    }
+
+    func check() throws {
+        if isFired {
+            throw DrainCancelledError()
+        }
+    }
+
+    func fire() {
+        let continuations: [CheckedContinuation<Void, Never>]
+        lock.lock()
+        if _fired {
+            lock.unlock()
+            return
+        }
+        _fired = true
+        continuations = Array(waiters.values)
+        waiters.removeAll()
+        lock.unlock()
+
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+
+    func waitUntilFired() async {
+        if isFired {
+            return
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            var shouldResume = false
+            let id = UUID()
+            lock.lock()
+            if _fired {
+                shouldResume = true
+            } else {
+                waiters[id] = continuation
+            }
+            lock.unlock()
+
+            if shouldResume {
+                continuation.resume()
+            }
+        }
+    }
+}
+
 private struct ModelWeightManifest: Encodable {
     let files: [ModelWeightManifestFile]
 }
@@ -628,7 +770,7 @@ private struct ModelWeightManifestFile: Encodable {
     let size: UInt64
 }
 
-struct CompletionResult {
+struct CompletionResult: Sendable {
     let content: String
     let finishReason: String
     let promptTokens: Int

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -36,15 +36,18 @@ public struct WarmSwapDisabledError: Error, CustomStringConvertible {
 }
 
 actor ModelRuntime: ModelRuntimeServing {
+    private var state: SwapState = .ready
+    private var targetModelID: String?
     private var currentModelID: String?
     private var currentContainer: ModelContainer?
     private let stopTokenFilter: StopTokenFilter
     private var currentModelHash: String?
     private let maxContextTokens: Int
     private let inferenceGate = AsyncSemaphore(value: 1)
-    private let stateMachine: RuntimeStateMachine
     private let warmSwapEnabled: Bool
     private let swapDrainTimeoutSeconds: Int
+    private var providerStatus: ProviderStatus?
+    private var signalContinuations: [AsyncStream<SwapSignal>.Continuation] = []
     private let loader: @Sendable (String) async throws -> (ModelContainer, String, String?)
     private let testLoader: (@Sendable (String) async throws -> (String, String?))?
     private let testCompletion: (@Sendable (RuntimeSnapshot, ChatCompletionRequest) async throws -> CompletionResult)?
@@ -69,7 +72,6 @@ actor ModelRuntime: ModelRuntimeServing {
     ) async throws {
         self.currentModelID = modelID
         self.maxContextTokens = maxContextTokensOverride ?? Self.defaultMaxContextTokens()
-        self.stateMachine = RuntimeStateMachine()
         self.warmSwapEnabled = warmSwapEnabled
         self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
         self.loader = { targetModelID in
@@ -109,7 +111,7 @@ actor ModelRuntime: ModelRuntimeServing {
         maxContextTokensOverride: Int? = nil,
         warmSwapEnabled: Bool,
         swapDrainTimeoutSeconds: Int = 30,
-        stateMachine: RuntimeStateMachine = RuntimeStateMachine(),
+        providerStatus: ProviderStatus? = nil,
         loader: @escaping @Sendable (String) async throws -> (ModelContainer, String, String?),
         testLoader: (@Sendable (String) async throws -> (String, String?))? = nil,
         testCompletion: (@Sendable (RuntimeSnapshot, ChatCompletionRequest) async throws -> CompletionResult)? = nil
@@ -119,41 +121,62 @@ actor ModelRuntime: ModelRuntimeServing {
         self.currentModelHash = modelHash
         self.stopTokenFilter = StopTokenFilter(tokens: [])
         self.maxContextTokens = maxContextTokensOverride ?? Self.defaultMaxContextTokens()
-        self.stateMachine = stateMachine
         self.warmSwapEnabled = warmSwapEnabled
         self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
+        self.providerStatus = providerStatus
         self.loader = loader
         self.testLoader = testLoader
         self.testCompletion = testCompletion
     }
 
-    func currentSnapshot() async -> RuntimeSnapshot {
+    func setProviderStatus(_ providerStatus: ProviderStatus) {
+        self.providerStatus = providerStatus
+    }
+
+    func currentSnapshot() -> RuntimeSnapshot {
         RuntimeSnapshot(
-            state: await stateMachine.current(),
+            state: state,
             container: currentContainer,
             modelID: currentModelID,
             modelHash: currentModelHash
         )
     }
 
-    func swapSignals() async -> AsyncStream<SwapSignal> {
-        await stateMachine.signalStream()
+    func swapSignals() -> AsyncStream<SwapSignal> {
+        let pair = AsyncStream<SwapSignal>.makeStream(of: SwapSignal.self)
+        signalContinuations.append(pair.continuation)
+        return pair.stream
     }
 
     func beginSwap(targetModelID: String) async throws -> Task<Void, Error> {
         guard warmSwapEnabled else { throw WarmSwapDisabledError() }
-        try await stateMachine.transitionToLoading(target: targetModelID)
-        return Task.detached { [stateMachine, loader, testLoader] in
+        try transitionToLoading(target: targetModelID)
+        let drainTimeoutSeconds = swapDrainTimeoutSeconds
+        let providerStatus = providerStatus
+        let loader = loader
+        let testLoader = testLoader
+        return Task.detached { [weak self, loader, testLoader, drainTimeoutSeconds, providerStatus] in
+            guard let self else { return }
             do {
+                let container: ModelContainer?
+                let modelID: String
+                let modelHash: String?
                 if let testLoader {
-                    let (modelID, modelHash) = try await testLoader(targetModelID)
-                    await self.applySwap(container: nil, modelID: modelID, modelHash: modelHash)
+                    let loaded = try await testLoader(targetModelID)
+                    container = nil
+                    modelID = loaded.0
+                    modelHash = loaded.1
                 } else {
-                    let (container, modelID, modelHash) = try await loader(targetModelID)
-                    await self.applySwap(container: container, modelID: modelID, modelHash: modelHash)
+                    let loaded = try await loader(targetModelID)
+                    container = loaded.0
+                    modelID = loaded.1
+                    modelHash = loaded.2
                 }
+                try await self.enterDrainPhase()
+                await Self.waitForDrainOrTimeout(providerStatus: providerStatus, timeoutSeconds: drainTimeoutSeconds)
+                await self.completeSwapAtomically(container: container, modelID: modelID, modelHash: modelHash)
             } catch {
-                await stateMachine.failSwap(reason: String(describing: error))
+                await self.failSwap(reason: String(describing: error))
             }
         }
     }
@@ -162,15 +185,70 @@ actor ModelRuntime: ModelRuntimeServing {
         swapDrainTimeoutSeconds
     }
 
-    private func applySwap(container: ModelContainer?, modelID: String, modelHash: String?) async {
+    private func transitionToLoading(target: String) throws {
+        guard state == .ready else {
+            throw RuntimeStateMachineError.notReady(current: state)
+        }
+        state = .loading
+        targetModelID = target
+    }
+
+    private func enterDrainPhase() throws {
+        guard state == .loading else {
+            throw RuntimeStateMachineError.notReady(current: state)
+        }
+        state = .draining
+        signal(SwapSignal(targetModelID: targetModelID ?? "", outcome: .loadFinished))
+    }
+
+    private nonisolated static func waitForDrainOrTimeout(providerStatus: ProviderStatus?, timeoutSeconds: Int) async {
+        guard let providerStatus else {
+            return
+        }
+        let drainStartMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let timeoutMs = Int64(timeoutSeconds * 1000)
+        while !Task.isCancelled {
+            let snapshot = await providerStatus.snapshot()
+            if snapshot.requestsInFlight == 0 {
+                return
+            }
+            let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            if nowMs - drainStartMs > timeoutMs {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+
+    private func completeSwapAtomically(container: ModelContainer?, modelID: String, modelHash: String?) {
+        let target = targetModelID ?? modelID
         currentContainer = container
         currentModelID = modelID
         currentModelHash = modelHash
-        await stateMachine.completeSwap(newModelID: modelID, newModelHash: modelHash)
+        state = .ready
+        targetModelID = nil
+        signal(SwapSignal(targetModelID: target, outcome: .completed(newModelID: modelID, newModelHash: modelHash)))
+    }
+
+    private func failSwap(reason: String) {
+        guard state == .loading || state == .draining else {
+            return
+        }
+        let target = targetModelID ?? ""
+        state = .failed
+        signal(SwapSignal(targetModelID: target, outcome: .failed(reason: reason)))
+        state = .ready
+        targetModelID = nil
+    }
+
+    private func signal(_ signal: SwapSignal) {
+        for continuation in signalContinuations {
+            continuation.yield(signal)
+        }
     }
 
     func preflight(_ request: ChatCompletionRequest) async throws {
-        let snapshot = await currentSnapshot()
+        let snapshot = currentSnapshot()
         try Self.validateReady(snapshot.state)
         try request.validateModelMatches(snapshot.modelID)
         guard let container = snapshot.container else {
@@ -194,7 +272,7 @@ actor ModelRuntime: ModelRuntimeServing {
         _ request: ChatCompletionRequest,
         shouldCancel: @escaping @Sendable () -> Bool = { false }
     ) async throws -> CompletionResult {
-        let snapshot = await currentSnapshot()
+        let snapshot = currentSnapshot()
         try Self.validateReady(snapshot.state)
         try request.validateModelMatches(snapshot.modelID)
         if let testCompletion {
@@ -253,7 +331,7 @@ actor ModelRuntime: ModelRuntimeServing {
         shouldCancel: @escaping @Sendable () -> Bool = { false },
         onChunk: @escaping @Sendable (String) -> Void
     ) async throws -> CompletionResult {
-        let snapshot = await currentSnapshot()
+        let snapshot = currentSnapshot()
         try Self.validateReady(snapshot.state)
         try request.validateModelMatches(snapshot.modelID)
         if let testCompletion {

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -135,6 +135,9 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
             case .cooldown:
                 writeStderr("swap on cooldown for \(secondsRemaining ?? 0)s. Re-issue with --force to bypass")
                 throw ExitCode(6)
+            case .notInSupportedModels:
+                writeStderr("switch target \(targetModelID) not in --supported-models (rejected by serve)")
+                throw ExitCode(2)
             default:
                 writeStderr("switch rejected")
                 throw ExitCode(4)

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -1,0 +1,266 @@
+import ArgumentParser
+import Foundation
+import MacProviderCore
+
+struct ModelsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "models",
+        abstract: "Inspect or switch the provider warm model.",
+        subcommands: [
+            ModelsListCommand.self,
+            ModelsSwitchCommand.self,
+            ModelsStatusCommand.self,
+        ]
+    )
+}
+
+struct ModelsListCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List models known to this provider (warm/idle)."
+    )
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG.")
+    var config: String?
+
+    @Option(help: "HuggingFace model identifier or local model path. Overrides MACPROVIDER_MODEL and config file model.")
+    var model: String?
+
+    @Option(help: "Comma-separated list of HuggingFace model IDs (or local paths). Overrides MACPROVIDER_SUPPORTED_MODELS and config supported_models.")
+    var supportedModels: String?
+
+    @Option(help: "Control socket path override. Overrides MACPROVIDER_CTL_SOCKET_PATH and config ctl_socket_path. Default $TMPDIR/macprovider-cli/ctl.sock.")
+    var ctlSocketPath: String?
+
+    func run() async throws {
+        let resolved = try loadModelsConfig(config: config, model: model, supportedModels: supportedModels, ctlSocketPath: ctlSocketPath)
+        let socketPath = ControlSocketPaths.resolve(ctlSocketPath: resolved.ctlSocketPath)
+        do {
+            let (connection, status) = try await connectAndReadStatus(socketPath: socketPath)
+            await connection.close()
+            printModelsTable(currentModelID: status.currentModelID, supportedModels: resolved.supportedModels ?? [status.currentModelID])
+        } catch ControlSocketConnectError.socketAbsent(let path) {
+            print("serve not running; warm-swap disabled")
+            writeStderr("macprovider-cli serve is not running on this host (no control socket at \(path))")
+            printModelsTable(currentModelID: nil, supportedModels: idleCatalog(from: resolved))
+            return
+        } catch ControlSocketConnectError.connectionRefused(let path) {
+            writeStderr("stale control socket at \(path) (no listener); remove the file and restart serve")
+            throw ExitCode(4)
+        } catch ControlSocketConnectError.handshakeTimeout {
+            writeStderr("serve is running but warm-swap is not enabled (or serve is unresponsive); restart serve with --enable-warm-swap")
+            throw ExitCode(4)
+        }
+    }
+}
+
+struct ModelsSwitchCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "switch",
+        abstract: "Switch the provider to another supported model."
+    )
+
+    @Argument(help: "Target HuggingFace model ID or local path.")
+    var targetModelID: String
+
+    @Flag(help: "Accepted in Phase 1C; cooldown bypass behavior lands in Phase 1E.")
+    var force = false
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG.")
+    var config: String?
+
+    @Option(help: "Current HuggingFace model identifier or local model path. Overrides MACPROVIDER_MODEL and config file model.")
+    var model: String?
+
+    @Option(help: "Comma-separated list of HuggingFace model IDs (or local paths). Overrides MACPROVIDER_SUPPORTED_MODELS and config supported_models.")
+    var supportedModels: String?
+
+    @Option(help: "Control socket path override. Overrides MACPROVIDER_CTL_SOCKET_PATH and config ctl_socket_path. Default $TMPDIR/macprovider-cli/ctl.sock.")
+    var ctlSocketPath: String?
+
+    // Phase 1E reads/writes this path for the cooldown soft guard; Phase 1C only stores it.
+    @Option(help: "CLI-side cooldown state file. Overrides MACPROVIDER_SWITCH_STATE_PATH and config switch_state_path. Default $HOME/Library/Application Support/macprovider-cli/last-switch.ts. Cooldown soft guard lands in Phase 1E.")
+    var switchStatePath: String?
+
+    func run() async throws {
+        // Stored for Phase 1E cooldown bypass/read-write behavior; intentionally unused in 1C.
+        _ = ModelsSwitchOptions(force: force, switchStatePath: switchStatePath)
+        let resolved = try loadModelsConfig(
+            config: config,
+            model: model,
+            supportedModels: supportedModels,
+            ctlSocketPath: ctlSocketPath,
+            switchStatePath: switchStatePath
+        )
+
+        do {
+            _ = try SupportedModels.validate(model: targetModelID, supportedModels: resolved.supportedModels)
+        } catch SupportedModelsValidationError.modelNotInCatalog {
+            writeStderr("switch target \(targetModelID) not in --supported-models")
+            throw ExitCode(2)
+        } catch let error as SupportedModelsValidationError {
+            writeStderr("\(error)")
+            throw ExitCode(2)
+        }
+
+        let socketPath = ControlSocketPaths.resolve(ctlSocketPath: resolved.ctlSocketPath)
+        let (connection, _) = try await connectAndReadStatusOrExit(socketPath: socketPath)
+        let requestedAtMs = Int64(Date().timeIntervalSince1970 * 1000)
+        try await connection.send(.switchRequest(targetModelID: targetModelID, requestedAtMs: requestedAtMs))
+        let ack = try await connection.receive()
+        guard case let .switchAck(accepted, reason, currentTarget, secondsRemaining) = ack else {
+            writeStderr("expected switch_ack")
+            await connection.close()
+            throw ExitCode(4)
+        }
+
+        guard accepted else {
+            await connection.close()
+            switch reason {
+            case .loadingInProgress:
+                let currentTarget = currentTarget ?? "<unknown>"
+                writeStderr("provider is already loading \(currentTarget); refusing to start a second swap. Wait for current switch to complete (macprovider-cli models status)")
+                throw ExitCode(3)
+            case .cooldown:
+                writeStderr("swap on cooldown for \(secondsRemaining ?? 0)s. Re-issue with --force to bypass")
+                throw ExitCode(6)
+            default:
+                writeStderr("switch rejected")
+                throw ExitCode(4)
+            }
+        }
+
+        while true {
+            let frame = try await connection.receive()
+            guard case let .switchProgress(state, elapsedMs, reason) = frame else {
+                continue
+            }
+            writeStderr("switch_progress state=\(state.rawValue) elapsed_ms=\(elapsedMs)")
+            switch state {
+            case .loaded:
+                await connection.close()
+                return
+            case .failed:
+                await connection.close()
+                writeStderr("swap failed: \(reason ?? "unknown")")
+                throw ExitCode(5)
+            case .loading, .draining:
+                continue
+            }
+        }
+    }
+}
+
+struct ModelsStatusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Show the running provider warm-swap status."
+    )
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG.")
+    var config: String?
+
+    @Option(help: "HuggingFace model identifier or local model path. Overrides MACPROVIDER_MODEL and config file model.")
+    var model: String?
+
+    @Option(help: "Comma-separated list of HuggingFace model IDs (or local paths). Overrides MACPROVIDER_SUPPORTED_MODELS and config supported_models.")
+    var supportedModels: String?
+
+    @Option(help: "Control socket path override. Overrides MACPROVIDER_CTL_SOCKET_PATH and config ctl_socket_path. Default $TMPDIR/macprovider-cli/ctl.sock.")
+    var ctlSocketPath: String?
+
+    func run() async throws {
+        let resolved = try loadModelsConfig(config: config, model: model, supportedModels: supportedModels, ctlSocketPath: ctlSocketPath)
+        let socketPath = ControlSocketPaths.resolve(ctlSocketPath: resolved.ctlSocketPath)
+        let (connection, status) = try await connectAndReadStatusOrExit(socketPath: socketPath)
+        await connection.close()
+        let data = try ControlSocketCodec.encode(.statusResponse(currentModelID: status.currentModelID, runtimeState: status.runtimeState))
+        print(String(decoding: data.dropLast(), as: UTF8.self))
+    }
+}
+
+struct ModelsSwitchOptions: Sendable, Equatable {
+    let force: Bool
+    // Phase 1E reads/writes this path for the cooldown soft guard; Phase 1C only preserves it.
+    let switchStatePath: String?
+}
+
+private struct ModelsStatus: Sendable, Equatable {
+    let currentModelID: String
+    let runtimeState: SwapState
+}
+
+private func loadModelsConfig(
+    config: String?,
+    model: String?,
+    supportedModels: String?,
+    ctlSocketPath: String?,
+    switchStatePath: String? = nil
+) throws -> AppConfig {
+    try ConfigLoader.load(
+        cli: CLIOverrides(
+            model: model,
+            configPath: config,
+            supportedModels: SupportedModels.parseCSV(supportedModels),
+            ctlSocketPath: ctlSocketPath,
+            switchStatePath: switchStatePath
+        )
+    )
+}
+
+private func connectAndReadStatusOrExit(socketPath: URL) async throws -> (ControlSocketConnection, ModelsStatus) {
+    do {
+        return try await connectAndReadStatus(socketPath: socketPath)
+    } catch ControlSocketConnectError.socketAbsent(let path) {
+        writeStderr("macprovider-cli serve is not running on this host (no control socket at \(path))")
+        throw ExitCode(4)
+    } catch ControlSocketConnectError.connectionRefused(let path) {
+        writeStderr("stale control socket at \(path) (no listener); remove the file and restart serve")
+        throw ExitCode(4)
+    } catch ControlSocketConnectError.handshakeTimeout {
+        writeStderr("serve is running but warm-swap is not enabled (or serve is unresponsive); restart serve with --enable-warm-swap")
+        throw ExitCode(4)
+    }
+}
+
+private func connectAndReadStatus(socketPath: URL) async throws -> (ControlSocketConnection, ModelsStatus) {
+    let connection = try await ControlSocketClient.connect(socketPath: socketPath)
+    try await connection.send(.statusRequest)
+    do {
+        let frame = try await connection.receive(timeout: 2.0)
+        guard case let .statusResponse(currentModelID, runtimeState) = frame else {
+            await connection.close()
+            throw ControlSocketConnectError.handshakeTimeout(path: socketPath.path)
+        }
+        return (connection, ModelsStatus(currentModelID: currentModelID, runtimeState: runtimeState))
+    } catch ControlSocketConnectionError.timedOut {
+        await connection.close()
+        throw ControlSocketConnectError.handshakeTimeout(path: socketPath.path)
+    }
+}
+
+private func idleCatalog(from config: AppConfig) -> [String] {
+    if let supportedModels = config.supportedModels, !supportedModels.isEmpty {
+        return supportedModels
+    }
+    if let model = config.model {
+        return [model]
+    }
+    return []
+}
+
+private func printModelsTable(currentModelID: String?, supportedModels: [String]) {
+    print("model_id\tstate")
+    var rows = supportedModels
+    if let currentModelID, !rows.contains(where: { $0.lowercased(with: nil) == currentModelID.lowercased(with: nil) }) {
+        rows.insert(currentModelID, at: 0)
+    }
+    for modelID in rows {
+        let state = currentModelID != nil && modelID.lowercased(with: nil) == currentModelID?.lowercased(with: nil) ? "warm" : "idle"
+        print("\(modelID)\t\(state)")
+    }
+}
+
+private func writeStderr(_ line: String) {
+    FileHandle.standardError.write(Data((line + "\n").utf8))
+}

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -63,7 +63,7 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
     @Argument(help: "Target HuggingFace model ID or local path.")
     var targetModelID: String
 
-    @Flag(help: "Accepted in Phase 1C; cooldown bypass behavior lands in Phase 1E.")
+    @Flag(help: "Bypass the CLI-side cooldown soft guard.")
     var force = false
 
     @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG.")
@@ -78,13 +78,11 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
     @Option(help: "Control socket path override. Overrides MACPROVIDER_CTL_SOCKET_PATH and config ctl_socket_path. Default $TMPDIR/macprovider-cli/ctl.sock.")
     var ctlSocketPath: String?
 
-    // Phase 1E reads/writes this path for the cooldown soft guard; Phase 1C only stores it.
-    @Option(help: "CLI-side cooldown state file. Overrides MACPROVIDER_SWITCH_STATE_PATH and config switch_state_path. Default $HOME/Library/Application Support/macprovider-cli/last-switch.ts. Cooldown soft guard lands in Phase 1E.")
+    @Option(help: "CLI-side cooldown state file. Overrides MACPROVIDER_SWITCH_STATE_PATH and config switch_state_path. Default $HOME/Library/Application Support/macprovider-cli/last-switch.ts.")
     var switchStatePath: String?
 
     func run() async throws {
-        // Stored for Phase 1E cooldown bypass/read-write behavior; intentionally unused in 1C.
-        _ = ModelsSwitchOptions(force: force, switchStatePath: switchStatePath)
+        let options = ModelsSwitchOptions(force: force, switchStatePath: switchStatePath)
         let resolved = try loadModelsConfig(
             config: config,
             model: model,
@@ -101,6 +99,19 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
         } catch let error as SupportedModelsValidationError {
             writeStderr("\(error)")
             throw ExitCode(2)
+        }
+
+        if !options.force {
+            let storePath = ControlSocketPaths.defaultSwitchStatePath(resolved.switchStatePath)
+            let store = SwitchStateStore(path: storePath)
+            let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            switch store.cooldownDecision(now: nowMs) {
+            case .clear:
+                break
+            case .cooldown(let secondsRemaining):
+                writeStderr("swap on cooldown for \(secondsRemaining)s. Re-issue with --force to bypass")
+                throw ExitCode(6)
+            }
         }
 
         let socketPath = ControlSocketPaths.resolve(ctlSocketPath: resolved.ctlSocketPath)
@@ -128,6 +139,14 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
                 writeStderr("switch rejected")
                 throw ExitCode(4)
             }
+        }
+
+        let storePath = ControlSocketPaths.defaultSwitchStatePath(resolved.switchStatePath)
+        let store = SwitchStateStore(path: storePath)
+        do {
+            try store.writeLastSwitchMs(requestedAtMs)
+        } catch {
+            writeStderr("warning: could not write switch state file at \(storePath.path): \(error)")
         }
 
         while true {

--- a/phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift
+++ b/phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift
@@ -9,66 +9,13 @@ public enum SwapState: String, Sendable, Equatable {
 
 public struct SwapSignal: Sendable {
     public enum Outcome: Sendable {
+        case loadFinished
         case completed(newModelID: String, newModelHash: String?)
         case failed(reason: String)
     }
 
     public let targetModelID: String
     public let outcome: Outcome
-}
-
-public actor RuntimeStateMachine {
-    private var state: SwapState = .ready
-    private var targetModelID: String?
-    private var signalContinuations: [AsyncStream<SwapSignal>.Continuation] = []
-
-    public init() {}
-
-    public func current() -> SwapState { state }
-
-    public func currentTargetModelID() -> String? { targetModelID }
-
-    public func transitionToLoading(target: String) throws {
-        guard state == .ready else {
-            throw RuntimeStateMachineError.notReady(current: state)
-        }
-        state = .loading
-        targetModelID = target
-    }
-
-    public func transitionToDraining() throws {
-        guard state == .loading else {
-            throw RuntimeStateMachineError.notReady(current: state)
-        }
-        state = .draining
-    }
-
-    public func completeSwap(newModelID: String, newModelHash: String?) {
-        let target = targetModelID ?? newModelID
-        state = .ready
-        targetModelID = nil
-        signal(SwapSignal(targetModelID: target, outcome: .completed(newModelID: newModelID, newModelHash: newModelHash)))
-    }
-
-    public func failSwap(reason: String) {
-        let target = targetModelID ?? ""
-        state = .failed
-        signal(SwapSignal(targetModelID: target, outcome: .failed(reason: reason)))
-        state = .ready
-        targetModelID = nil
-    }
-
-    public func signalStream() -> AsyncStream<SwapSignal> {
-        let pair = AsyncStream<SwapSignal>.makeStream(of: SwapSignal.self)
-        signalContinuations.append(pair.continuation)
-        return pair.stream
-    }
-
-    private func signal(_ signal: SwapSignal) {
-        for continuation in signalContinuations {
-            continuation.yield(signal)
-        }
-    }
 }
 
 public enum RuntimeStateMachineError: Error, Equatable {

--- a/phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift
+++ b/phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+public enum SwapState: String, Sendable, Equatable {
+    case ready
+    case loading
+    case draining
+    case failed
+}
+
+public struct SwapSignal: Sendable {
+    public enum Outcome: Sendable {
+        case completed(newModelID: String, newModelHash: String?)
+        case failed(reason: String)
+    }
+
+    public let targetModelID: String
+    public let outcome: Outcome
+}
+
+public actor RuntimeStateMachine {
+    private var state: SwapState = .ready
+    private var targetModelID: String?
+    private var signalContinuations: [AsyncStream<SwapSignal>.Continuation] = []
+
+    public init() {}
+
+    public func current() -> SwapState { state }
+
+    public func currentTargetModelID() -> String? { targetModelID }
+
+    public func transitionToLoading(target: String) throws {
+        guard state == .ready else {
+            throw RuntimeStateMachineError.notReady(current: state)
+        }
+        state = .loading
+        targetModelID = target
+    }
+
+    public func transitionToDraining() throws {
+        guard state == .loading else {
+            throw RuntimeStateMachineError.notReady(current: state)
+        }
+        state = .draining
+    }
+
+    public func completeSwap(newModelID: String, newModelHash: String?) {
+        let target = targetModelID ?? newModelID
+        state = .ready
+        targetModelID = nil
+        signal(SwapSignal(targetModelID: target, outcome: .completed(newModelID: newModelID, newModelHash: newModelHash)))
+    }
+
+    public func failSwap(reason: String) {
+        let target = targetModelID ?? ""
+        state = .failed
+        signal(SwapSignal(targetModelID: target, outcome: .failed(reason: reason)))
+        state = .ready
+        targetModelID = nil
+    }
+
+    public func signalStream() -> AsyncStream<SwapSignal> {
+        let pair = AsyncStream<SwapSignal>.makeStream(of: SwapSignal.self)
+        signalContinuations.append(pair.continuation)
+        return pair.stream
+    }
+
+    private func signal(_ signal: SwapSignal) {
+        for continuation in signalContinuations {
+            continuation.yield(signal)
+        }
+    }
+}
+
+public enum RuntimeStateMachineError: Error, Equatable {
+    case notReady(current: SwapState)
+}

--- a/phase3-binary/Sources/macprovider-cli/SwitchStateStore.swift
+++ b/phase3-binary/Sources/macprovider-cli/SwitchStateStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public struct SwitchStateStore: Sendable {
+    /// Default cooldown window per SPEC-011 v0.5 R-3.1.4.
+    public static let defaultCooldownWindowMs: Int64 = 10_000
+
+    public let path: URL
+    public let cooldownWindowMs: Int64
+
+    public init(path: URL, cooldownWindowMs: Int64 = SwitchStateStore.defaultCooldownWindowMs) {
+        self.path = path
+        self.cooldownWindowMs = cooldownWindowMs
+    }
+
+    /// Returns the recorded last-switch timestamp (epoch ms), or nil
+    /// if the file does not exist OR cannot be parsed as Int64.
+    public func readLastSwitchMs() -> Int64? {
+        guard let text = try? String(contentsOf: path, encoding: .utf8) else {
+            return nil
+        }
+        return Int64(text.trimmingCharacters(in: .newlines))
+    }
+
+    /// Writes the given timestamp atomically (write-to-temp-then-rename).
+    /// Creates the parent directory if missing. Throws on filesystem
+    /// errors that prevent the write.
+    public func writeLastSwitchMs(_ value: Int64) throws {
+        let parent = path.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        let tmpURL = URL(fileURLWithPath: path.path + ".tmp")
+        try? FileManager.default.removeItem(at: tmpURL)
+        try String(value).write(to: tmpURL, atomically: false, encoding: .utf8)
+
+        if FileManager.default.fileExists(atPath: path.path) {
+            _ = try FileManager.default.replaceItemAt(path, withItemAt: tmpURL)
+        } else {
+            try FileManager.default.moveItem(at: tmpURL, to: path)
+        }
+    }
+
+    /// Returns the cooldown decision:
+    /// - .clear        — no recent switch (file missing or > window)
+    /// - .cooldown(s)  — within the window; `secondsRemaining` is
+    ///                   ceil((window - elapsed) / 1000), clamped to
+    ///                   [1, cooldownWindowMs / 1000]
+    public func cooldownDecision(now: Int64) -> CooldownDecision {
+        guard let lastSwitchMs = readLastSwitchMs() else {
+            return .clear
+        }
+
+        let elapsed = now - lastSwitchMs
+        guard elapsed >= 0, elapsed < cooldownWindowMs else {
+            return .clear
+        }
+
+        let remainingMs = cooldownWindowMs - elapsed
+        let ceilingSeconds = Int((remainingMs + 999) / 1000)
+        let maxSeconds = max(1, Int((cooldownWindowMs + 999) / 1000))
+        return .cooldown(secondsRemaining: min(max(ceilingSeconds, 1), maxSeconds))
+    }
+
+    public enum CooldownDecision: Equatable, Sendable {
+        case clear
+        case cooldown(secondsRemaining: Int)
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
@@ -48,6 +48,15 @@ final class ControlSocketTests: XCTestCase {
         ))
     }
 
+    func testEncodeDecodeSwitchAckNotInSupportedModels() throws {
+        try assertRoundTrip(.switchAck(
+            accepted: false,
+            reason: .notInSupportedModels,
+            currentTarget: nil,
+            secondsRemaining: nil
+        ))
+    }
+
     func testEncodeDecodeSwitchProgressLoading() throws {
         try assertRoundTrip(.switchProgress(state: .loading, elapsedMs: 11, reason: nil))
     }
@@ -102,7 +111,7 @@ final class ControlSocketTests: XCTestCase {
     func testServerBindsAndAcceptsConnection() async throws {
         let socketPath = try makeSocketPath()
         let runtime = makeRuntime(modelID: "ready-model")
-        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: runtime)
+        let server = makeServer(socketPath: socketPath, modelRuntime: runtime)
         try await server.start()
 
         let connection = try await ControlSocketClient.connect(socketPath: socketPath)
@@ -118,7 +127,7 @@ final class ControlSocketTests: XCTestCase {
         let socketPath = try makeSocketPath()
         try FileManager.default.createDirectory(at: socketPath.deletingLastPathComponent(), withIntermediateDirectories: true)
         FileManager.default.createFile(atPath: socketPath.path, contents: Data())
-        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
+        let server = makeServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
 
         do {
             try await server.start()
@@ -132,7 +141,7 @@ final class ControlSocketTests: XCTestCase {
 
     func testServerSocketParentDirIs0700AndSocketIs0600() async throws {
         let socketPath = try makeSocketPath()
-        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
+        let server = makeServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
         try await server.start()
 
         XCTAssertEqual(mode(path: socketPath.deletingLastPathComponent().path), 0o700)
@@ -143,13 +152,56 @@ final class ControlSocketTests: XCTestCase {
 
     func testServerStopUnlinksSocket() async throws {
         let socketPath = try makeSocketPath()
-        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
+        let server = makeServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
         try await server.start()
         XCTAssertTrue(FileManager.default.fileExists(atPath: socketPath.path))
 
         await server.stop()
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: socketPath.path))
+    }
+
+    func testReceiveRejectsFramesLargerThan64KB() async throws {
+        let socketPath = try makeSocketPath()
+        let server = makeServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
+        try await server.start()
+        let fd = try rawConnect(socketPath: socketPath)
+        defer { close(fd) }
+
+        let oversized = Data(repeating: 0x61, count: ControlSocketConnection.maxFrameBytes + 1)
+        try writeAll(oversized, to: fd)
+
+        XCTAssertTrue(try waitForEOF(fd: fd, timeout: 2.0))
+        await server.stop()
+    }
+
+    func testReceiveTimesOutAfterConfiguredIdleTimeout() async throws {
+        let socketPath = try makeSocketPath()
+        let server = ControlSocketServer(
+            socketPath: socketPath,
+            modelRuntime: makeRuntime(modelID: "ready-model"),
+            idleTimeoutSeconds: 0.2
+        )
+        try await server.start()
+        let fd = try rawConnect(socketPath: socketPath)
+        defer { close(fd) }
+
+        XCTAssertTrue(try waitForEOF(fd: fd, timeout: 1.0))
+        await server.stop()
+    }
+
+    func testServerStopCancelsActiveClientTasks() async throws {
+        let socketPath = try makeSocketPath()
+        let server = makeServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
+        try await server.start()
+        let fd = try rawConnect(socketPath: socketPath)
+        defer { close(fd) }
+        try writeAll(Data(#"{"type":"status_request""#.utf8), to: fd)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        await server.stop()
+
+        XCTAssertTrue(try waitForEOF(fd: fd, timeout: 1.0))
     }
 
     private func assertRoundTrip(_ frame: ControlSocketFrame) throws {
@@ -166,6 +218,79 @@ final class ControlSocketTests: XCTestCase {
         var status = stat()
         XCTAssertEqual(lstat(path, &status), 0)
         return status.st_mode & mode_t(0o777)
+    }
+
+    private func makeServer(socketPath: URL, modelRuntime: ModelRuntime) -> ControlSocketServer {
+        ControlSocketServer(socketPath: socketPath, modelRuntime: modelRuntime, idleTimeoutSeconds: 0.2)
+    }
+
+    private func rawConnect(socketPath: URL) throws -> Int32 {
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(fd, 0)
+        var address = try unixAddress(path: socketPath.path)
+        let result = withUnsafePointer(to: &address.sockaddr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fd, $0, address.length)
+            }
+        }
+        if result != 0 {
+            let err = errno
+            close(fd)
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(err))
+        }
+        return fd
+    }
+
+    private func unixAddress(path: String) throws -> (sockaddr: sockaddr_un, length: socklen_t) {
+        let pathBytes = Array(path.utf8)
+        var address = sockaddr_un()
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard pathBytes.count < capacity else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(ENAMETOOLONG))
+        }
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.offset(of: \.sun_path)! + pathBytes.count + 1)
+        address.sun_family = sa_family_t(AF_UNIX)
+        withUnsafeMutableBytes(of: &address.sun_path) { bytes in
+            for (index, byte) in pathBytes.enumerated() {
+                bytes[index] = byte
+            }
+            bytes[pathBytes.count] = 0
+        }
+        return (address, socklen_t(address.sun_len))
+    }
+
+    private func writeAll(_ data: Data, to fd: Int32) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.baseAddress else { return }
+            var sent = 0
+            while sent < rawBuffer.count {
+                let count = Darwin.write(fd, base.advanced(by: sent), rawBuffer.count - sent)
+                if count < 0 {
+                    if errno == EINTR {
+                        continue
+                    }
+                    throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+                }
+                sent += count
+            }
+        }
+    }
+
+    private func waitForEOF(fd: Int32, timeout: TimeInterval) throws -> Bool {
+        var pollFD = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+        let result = Darwin.poll(&pollFD, 1, Int32((timeout * 1000).rounded()))
+        guard result > 0 else {
+            return false
+        }
+        var byte: UInt8 = 0
+        let count = Darwin.read(fd, &byte, 1)
+        if count == 0 {
+            return true
+        }
+        if count < 0 {
+            return errno == ECONNRESET || errno == EBADF
+        }
+        return false
     }
 
     private func makeRuntime(modelID: String?) -> ModelRuntime {

--- a/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
@@ -204,6 +204,27 @@ final class ControlSocketTests: XCTestCase {
         XCTAssertTrue(try waitForEOF(fd: fd, timeout: 1.0))
     }
 
+    func testClientTasksDoNotLeakOnCompletion() async throws {
+        let socketPath = try makeSocketPath()
+        let server = makeServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
+        try await server.start()
+
+        for _ in 0 ..< 50 {
+            let connection = try await ControlSocketClient.connect(socketPath: socketPath)
+            try await connection.send(.statusRequest)
+            _ = try await connection.receive(timeout: 1)
+            await connection.close()
+        }
+
+        try await waitUntil(timeoutNanoseconds: 500_000_000) {
+            await server.clientTasksCountForTest() <= 2
+        }
+        let taskCount = await server.clientTasksCountForTest()
+        await server.stop()
+
+        XCTAssertLessThanOrEqual(taskCount, 2)
+    }
+
     private func assertRoundTrip(_ frame: ControlSocketFrame) throws {
         XCTAssertEqual(try ControlSocketCodec.decode(try ControlSocketCodec.encode(frame)), frame)
     }
@@ -291,6 +312,20 @@ final class ControlSocketTests: XCTestCase {
             return errno == ECONNRESET || errno == EBADF
         }
         return false
+    }
+
+    private func waitUntil(
+        timeoutNanoseconds: UInt64,
+        _ predicate: () async -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if await predicate() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for condition")
     }
 
     private func makeRuntime(modelID: String?) -> ModelRuntime {

--- a/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
@@ -1,0 +1,183 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class ControlSocketTests: XCTestCase {
+    func testEncodeDecodeSwitchRequest() throws {
+        try assertRoundTrip(.switchRequest(targetModelID: "model-A", requestedAtMs: 123))
+    }
+
+    func testEncodeDecodeStatusRequest() throws {
+        try assertRoundTrip(.statusRequest)
+    }
+
+    func testEncodeDecodeSwitchAckAccepted() throws {
+        try assertRoundTrip(.switchAck(accepted: true, reason: nil, currentTarget: nil, secondsRemaining: nil))
+    }
+
+    func testEncodeDecodeSwitchAckLoadingInProgress() throws {
+        let data = try ControlSocketCodec.encode(.switchAck(
+            accepted: false,
+            reason: .loadingInProgress,
+            currentTarget: "model-B",
+            secondsRemaining: nil
+        ))
+        XCTAssertTrue(String(decoding: data, as: UTF8.self).contains(#""current_target":"model-B""#))
+        XCTAssertEqual(try ControlSocketCodec.decode(data), .switchAck(
+            accepted: false,
+            reason: .loadingInProgress,
+            currentTarget: "model-B",
+            secondsRemaining: nil
+        ))
+    }
+
+    func testEncodeDecodeSwitchAckCooldown() throws {
+        let data = try ControlSocketCodec.encode(.switchAck(
+            accepted: false,
+            reason: .cooldown,
+            currentTarget: nil,
+            secondsRemaining: 7
+        ))
+        XCTAssertTrue(String(decoding: data, as: UTF8.self).contains(#""seconds_remaining":7"#))
+        XCTAssertEqual(try ControlSocketCodec.decode(data), .switchAck(
+            accepted: false,
+            reason: .cooldown,
+            currentTarget: nil,
+            secondsRemaining: 7
+        ))
+    }
+
+    func testEncodeDecodeSwitchProgressLoading() throws {
+        try assertRoundTrip(.switchProgress(state: .loading, elapsedMs: 11, reason: nil))
+    }
+
+    func testEncodeDecodeSwitchProgressFailed() throws {
+        let data = try ControlSocketCodec.encode(.switchProgress(state: .failed, elapsedMs: 22, reason: "oom"))
+        XCTAssertTrue(String(decoding: data, as: UTF8.self).contains(#""reason":"oom""#))
+        XCTAssertEqual(
+            try ControlSocketCodec.decode(data),
+            .switchProgress(state: .failed, elapsedMs: 22, reason: "oom")
+        )
+    }
+
+    func testEncodeDecodeStatusResponseReady() throws {
+        try assertRoundTrip(.statusResponse(currentModelID: "model-A", runtimeState: .ready))
+    }
+
+    func testDecodeRejectsMissingType() {
+        XCTAssertThrowsError(try ControlSocketCodec.decode(Data(#"{"target_model_id":"X"}"#.utf8))) { error in
+            XCTAssertEqual(error as? ControlSocketError, .missingType)
+        }
+    }
+
+    func testDecodeRejectsUnknownType() {
+        XCTAssertThrowsError(try ControlSocketCodec.decode(Data(#"{"type":"wat"}"#.utf8))) { error in
+            XCTAssertEqual(error as? ControlSocketError, .unknownType("wat"))
+        }
+    }
+
+    func testDecodeRejectsSwitchRequestMissingTarget() {
+        XCTAssertThrowsError(try ControlSocketCodec.decode(Data(#"{"type":"switch_request","requested_at_ms":1}"#.utf8))) { error in
+            XCTAssertEqual(error as? ControlSocketError, .missingRequiredField("target_model_id"))
+        }
+    }
+
+    func testDecodeRejectsSwitchAckUnknownReason() {
+        XCTAssertThrowsError(try ControlSocketCodec.decode(Data(#"{"type":"switch_ack","accepted":false,"reason":"xyz"}"#.utf8))) { error in
+            XCTAssertEqual(error as? ControlSocketError, .invalidEnumValue(field: "reason", value: "xyz"))
+        }
+    }
+
+    func testEncodedBytesHaveNoForwardSlashEscaping() throws {
+        let data = try ControlSocketCodec.encode(.switchRequest(
+            targetModelID: "mlx-community/Llama",
+            requestedAtMs: 123
+        ))
+        let text = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(text.contains("mlx-community/Llama"))
+        XCTAssertFalse(text.contains("mlx-community\\/Llama"))
+    }
+
+    func testServerBindsAndAcceptsConnection() async throws {
+        let socketPath = try makeSocketPath()
+        let runtime = makeRuntime(modelID: "ready-model")
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: runtime)
+        try await server.start()
+
+        let connection = try await ControlSocketClient.connect(socketPath: socketPath)
+        try await connection.send(.statusRequest)
+        let response = try await connection.receive(timeout: 1)
+        await connection.close()
+        await server.stop()
+
+        XCTAssertEqual(response, .statusResponse(currentModelID: "ready-model", runtimeState: .ready))
+    }
+
+    func testServerRefusesStartIfSocketAlreadyExists() async throws {
+        let socketPath = try makeSocketPath()
+        try FileManager.default.createDirectory(at: socketPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: socketPath.path, contents: Data())
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
+
+        do {
+            try await server.start()
+            XCTFail("expected stale socket rejection")
+        } catch let error as ControlSocketServerError {
+            XCTAssertEqual(error, .staleSocket(path: socketPath.path))
+            XCTAssertEqual(error.description, "control socket \(socketPath.path) already exists; remove the stale file and restart serve")
+        }
+        try? FileManager.default.removeItem(at: socketPath.deletingLastPathComponent())
+    }
+
+    func testServerSocketParentDirIs0700AndSocketIs0600() async throws {
+        let socketPath = try makeSocketPath()
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
+        try await server.start()
+
+        XCTAssertEqual(mode(path: socketPath.deletingLastPathComponent().path), 0o700)
+        XCTAssertEqual(mode(path: socketPath.path), 0o600)
+
+        await server.stop()
+    }
+
+    func testServerStopUnlinksSocket() async throws {
+        let socketPath = try makeSocketPath()
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "ready-model"))
+        try await server.start()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socketPath.path))
+
+        await server.stop()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: socketPath.path))
+    }
+
+    private func assertRoundTrip(_ frame: ControlSocketFrame) throws {
+        XCTAssertEqual(try ControlSocketCodec.decode(try ControlSocketCodec.encode(frame)), frame)
+    }
+
+    private func makeSocketPath() throws -> URL {
+        let dir = URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent("mpcs-\(getpid())-\(Int.random(in: 0 ... 999_999))")
+        return dir.appendingPathComponent("ctl.sock")
+    }
+
+    private func mode(path: String) -> mode_t {
+        var status = stat()
+        XCTAssertEqual(lstat(path, &status), 0)
+        return status.st_mode & mode_t(0o777)
+    }
+
+    private func makeRuntime(modelID: String?) -> ModelRuntime {
+        ModelRuntime(
+            modelID: modelID,
+            warmSwapEnabled: true,
+            loader: { _ in throw ControlSocketTestError.unexpectedContainerLoader },
+            testLoader: { target in (target, "hash") }
+        )
+    }
+}
+
+private enum ControlSocketTestError: Error {
+    case unexpectedContainerLoader
+}

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -197,6 +197,114 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertEqual(caps["aead_suites"] as? [String], [Tier2ProviderSession.aeadSuite])
     }
 
+    func testAuthInitialDefaultsToSingleEntryCatalog() async throws {
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = "model-id-from-snapshot"
+        config.supportedModels = nil
+        config.publishesSupportedModels = false
+        let status = ProviderStatus(
+            modelID: "model-id-from-snapshot",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            sleepAssertionFactory: { nil }
+        ))
+
+        let auth = await client.authInitialMessage(attempt: Tier2AuthAttempt())
+        let json = Self.jsonString(auth)
+
+        XCTAssertTrue(json.contains("\"supported_models\":[\"model-id-from-snapshot\"]"), json)
+        XCTAssertFalse(json.contains("\"publishes_supported_models\""), json)
+    }
+
+    func testAuthInitialEmitsExplicitCatalogWhenSet() async throws {
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = "A"
+        config.supportedModels = ["A", "B"]
+        config.publishesSupportedModels = true
+        let status = ProviderStatus(
+            modelID: "A",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            sleepAssertionFactory: { nil }
+        ))
+
+        let auth = await client.authInitialMessage(attempt: Tier2AuthAttempt())
+        let json = Self.jsonString(auth)
+
+        XCTAssertTrue(json.contains("\"supported_models\":[\"A\",\"B\"]"), json)
+        XCTAssertTrue(json.contains("\"publishes_supported_models\":true"), json)
+    }
+
+    func testAuthInitialOmitsPublishesWhenFalse() async throws {
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = "A"
+        config.supportedModels = ["A", "B"]
+        config.publishesSupportedModels = false
+        let status = ProviderStatus(
+            modelID: "A",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            sleepAssertionFactory: { nil }
+        ))
+
+        let auth = await client.authInitialMessage(attempt: Tier2AuthAttempt())
+        let json = Self.jsonString(auth)
+
+        XCTAssertTrue(json.contains("\"supported_models\":[\"A\",\"B\"]"), json)
+        XCTAssertFalse(json.contains("\"publishes_supported_models\""), json)
+    }
+
+    func testHelloMessageUnchangedByPhase1A() async throws {
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = "A"
+        config.supportedModels = ["A", "B"]
+        config.publishesSupportedModels = true
+        let status = ProviderStatus(
+            modelID: "A",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            sleepAssertionFactory: { nil }
+        ))
+
+        let hello = await client.helloMessage()
+        let json = Self.jsonString(hello)
+
+        XCTAssertFalse(json.contains("\"supported_models\""), json)
+        XCTAssertFalse(json.contains("\"publishes_supported_models\""), json)
+    }
+
     func testWsTunneledV2ChallengeFailureFailsClosed() async throws {
         let firstSocket = FakeProviderWebSocketTask(receiveResults: [
             .failure(CoordinatorAuthError.invalidMessage("unrecognized auth message")),

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -168,6 +168,220 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertNil(hello["model_hash"])
     }
 
+    func testHeartbeatDisabledModeOmitsBothFields() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let capacity = ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: capacity,
+            modelHash: String(repeating: "a", count: 64)
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: false)
+
+        try await client.sendHeartbeatForTest()
+        let frames = await recorder.frames
+        let heartbeat = try XCTUnwrap(frames.first)
+        let heartbeatJSON = Self.jsonString(heartbeat)
+        let helloJSON = Self.jsonString(await client.helloMessage())
+        let expectedHeartbeat = """
+        {"avg_latency_ms_since_last":null,"max_concurrency":1,"max_context_tokens":20000,"model_id":"model-a","model_params_b":0,"ram_gb":\(capacity.ramGB),"requests_served_since_last":0,"slots_free":1,"slots_total":1,"status":"ready","throughput_tps_estimate":0,"throughput_tps_since_last":null,"type":"heartbeat"}
+        """
+        let expectedHello = """
+        {"attestation":null,"binary_version":"\(CoordinatorClient.binaryVersion)","hostname":"\(Host.current().localizedName ?? "unknown")","max_concurrency":1,"max_context_tokens":20000,"model_hash":"\(String(repeating: "a", count: 64))","model_id":"model-a","model_params_b":0,"provider_id":"provider-test","ram_gb":\(capacity.ramGB),"throughput_tps_estimate":0,"tier":1,"type":"hello","version":1}
+        """
+
+        XCTAssertFalse(heartbeatJSON.contains("\"model_hash\""), heartbeatJSON)
+        XCTAssertFalse(heartbeatJSON.contains("\"loading\""), heartbeatJSON)
+        XCTAssertFalse(helloJSON.contains("\"loading\""), helloJSON)
+        XCTAssertEqual(heartbeatJSON, expectedHeartbeat)
+        XCTAssertEqual(helloJSON, expectedHello)
+    }
+
+    func testHeartbeatEnabledModeReadyEmitsLoadingFalse() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let runtimeHash = String(repeating: "1", count: 64)
+        let runtime = makeRuntime(modelID: "model-a", modelHash: runtimeHash, warmSwapEnabled: true)
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: true, modelRuntime: runtime)
+
+        try await client.sendHeartbeatForTest()
+        let frames = await recorder.frames
+        let heartbeat = try XCTUnwrap(frames.first)
+        let json = Self.jsonString(heartbeat)
+
+        XCTAssertEqual(heartbeat["model_hash"] as? String, runtimeHash)
+        XCTAssertEqual(heartbeat["loading"] as? Bool, false)
+        XCTAssertTrue(json.contains("\"\(runtimeHash)\""), json)
+        XCTAssertTrue(json.contains("\"loading\":false"), json)
+        XCTAssertNotNil(runtimeHash.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression))
+    }
+
+    func testHeartbeatEnabledModeLoadingEmitsLoadingTrue() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let gate = SwapLoaderGate()
+        let oldHash = String(repeating: "2", count: 64)
+        let newHash = String(repeating: "3", count: 64)
+        let runtime = makeRuntime(modelID: "model-a", modelHash: oldHash, warmSwapEnabled: true) { target in
+            try await gate.waitForRelease()
+            return (target, newHash)
+        }
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: true, modelRuntime: runtime)
+
+        let swapTask = try await runtime.beginSwap(targetModelID: "model-b")
+        try await Self.waitUntil {
+            await runtime.currentSnapshot().state == .loading
+        }
+        try await client.sendHeartbeatForTest()
+        await gate.release()
+        try await swapTask.value
+        let frames = await recorder.frames
+        let heartbeat = try XCTUnwrap(frames.first)
+        let json = Self.jsonString(heartbeat)
+
+        XCTAssertEqual(heartbeat["model_hash"] as? String, oldHash)
+        XCTAssertEqual(heartbeat["loading"] as? Bool, true)
+        XCTAssertTrue(json.contains("\"loading\":true"), json)
+    }
+
+    func testHeartbeatEnabledModeOmitsModelHashWhenNil() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let runtime = makeRuntime(modelID: nil, modelHash: nil, warmSwapEnabled: true)
+        let status = ProviderStatus(
+            modelID: nil,
+            modelLoaded: false,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: true, modelRuntime: runtime)
+
+        try await client.sendHeartbeatForTest()
+        let frames = await recorder.frames
+        let heartbeat = try XCTUnwrap(frames.first)
+        let json = Self.jsonString(heartbeat)
+
+        XCTAssertNil(heartbeat["model_hash"])
+        XCTAssertEqual(heartbeat["loading"] as? Bool, false)
+        XCTAssertFalse(json.contains("\"model_hash\""), json)
+        XCTAssertTrue(json.contains("\"loading\":false"), json)
+    }
+
+    func testHelloDisabledModeReadsFromProviderStatus() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let runtime = makeRuntime(modelID: "model-a", modelHash: "runtime-hash", warmSwapEnabled: true)
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1),
+            modelHash: "boot-hash"
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: false, modelRuntime: runtime)
+
+        let hello = await client.helloMessage()
+        let json = Self.jsonString(hello)
+
+        XCTAssertEqual(hello["model_hash"] as? String, "boot-hash")
+        XCTAssertTrue(json.contains("\"model_hash\":\"boot-hash\""), json)
+        XCTAssertFalse(json.contains("runtime-hash"), json)
+    }
+
+    func testHelloEnabledModeReadsFromModelRuntime() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let runtime = makeRuntime(modelID: "model-a", modelHash: "runtime-hash", warmSwapEnabled: true)
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1),
+            modelHash: "boot-hash"
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: true, modelRuntime: runtime)
+
+        let hello = await client.helloMessage()
+        let json = Self.jsonString(hello)
+
+        XCTAssertEqual(hello["model_hash"] as? String, "runtime-hash")
+        XCTAssertTrue(json.contains("\"model_hash\":\"runtime-hash\""), json)
+        XCTAssertFalse(json.contains("boot-hash"), json)
+    }
+
+    func testHelloDuringInFlightSwapReturnsOldHash() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let gate = SwapLoaderGate()
+        let runtime = makeRuntime(modelID: "A", modelHash: "old-hash", warmSwapEnabled: true) { target in
+            try await gate.waitForRelease()
+            return (target, "new-hash")
+        }
+        let status = ProviderStatus(
+            modelID: "A",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1),
+            modelHash: "boot-hash"
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: true, modelRuntime: runtime)
+
+        let swapTask = try await runtime.beginSwap(targetModelID: "B")
+        try await Self.waitUntil {
+            await runtime.currentSnapshot().state == .loading
+        }
+        let inFlightHello = await client.helloMessage()
+        await gate.release()
+        try await swapTask.value
+        let completedHello = await client.helloMessage()
+
+        XCTAssertEqual(inFlightHello["model_hash"] as? String, "old-hash")
+        XCTAssertNotEqual(inFlightHello["model_hash"] as? String, "new-hash")
+        XCTAssertEqual(completedHello["model_hash"] as? String, "new-hash")
+    }
+
+    func testSwapCompletionTriggersImmediateHeartbeat() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let newHash = String(repeating: "4", count: 64)
+        let runtime = makeRuntime(modelID: "model-a", modelHash: String(repeating: "5", count: 64), warmSwapEnabled: true) { target in
+            (target, newHash)
+        }
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            enableWarmSwap: true,
+            modelRuntime: runtime,
+            connectAndRunOverride: {
+                while !Task.isCancelled {
+                    try await Task.sleep(nanoseconds: 100_000_000)
+                }
+            }
+        )
+
+        await client.start()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let swapTask = try await runtime.beginSwap(targetModelID: "model-b")
+        try await swapTask.value
+        try await Self.waitUntil(timeoutNanoseconds: 500_000_000) {
+            let frames = await recorder.frames
+            return frames.contains { frame in
+                frame["type"] as? String == "heartbeat"
+                    && frame["model_hash"] as? String == newHash
+                    && frame["loading"] as? Bool == false
+            }
+        }
+        await client.stop()
+
+        let frames = await recorder.frames
+        XCTAssertTrue(frames.contains { $0["type"] as? String == "heartbeat" && $0["model_hash"] as? String == newHash })
+    }
+
     func testAuthInitialUsesV2EncryptedLegCapabilitiesAndModelHash() async throws {
         let recorder = CoordinatorFrameRecorder()
         let modelHash = String(repeating: "b", count: 64)
@@ -575,7 +789,7 @@ final class CoordinatorClientTests: XCTestCase {
     }
 
     private static func jsonString(_ object: [String: Any]) -> String {
-        let data = try! JSONSerialization.data(withJSONObject: object, options: [.withoutEscapingSlashes])
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
         return String(decoding: data, as: UTF8.self)
     }
 
@@ -600,6 +814,8 @@ final class CoordinatorClientTests: XCTestCase {
         recorder: CoordinatorFrameRecorder,
         drainTimeoutSeconds: Int = 1,
         reconnectGraceNanoseconds: UInt64 = 10 * 1_000_000_000,
+        enableWarmSwap: Bool = false,
+        modelRuntime: ModelRuntime? = nil,
         attestationGenerator: Tier2AttestationTokenGenerating = StaticAttestationGenerator(token: nil),
         connectAndRunOverride: (() async throws -> Void)? = nil
     ) async throws -> CoordinatorClient {
@@ -608,7 +824,13 @@ final class CoordinatorClientTests: XCTestCase {
         config.providerID = "provider-test"
         config.model = "model-a"
         config.drainTimeoutSeconds = drainTimeoutSeconds
-        let runtime = try await ModelRuntime(modelID: nil)
+        config.enableWarmSwap = enableWarmSwap
+        let runtime: ModelRuntime
+        if let modelRuntime {
+            runtime = modelRuntime
+        } else {
+            runtime = try await ModelRuntime(modelID: nil)
+        }
         return try XCTUnwrap(CoordinatorClient(
             config: config,
             modelRuntime: runtime,
@@ -621,6 +843,53 @@ final class CoordinatorClientTests: XCTestCase {
             sleepAssertionFactory: { nil },
             connectAndRunOverride: connectAndRunOverride
         ))
+    }
+
+    private func makeRuntime(
+        modelID: String?,
+        modelHash: String? = nil,
+        warmSwapEnabled: Bool,
+        loader: @escaping @Sendable (String) async throws -> (String, String?) = { target in (target, nil) }
+    ) -> ModelRuntime {
+        ModelRuntime(
+            modelID: modelID,
+            modelHash: modelHash,
+            warmSwapEnabled: warmSwapEnabled,
+            loader: { _ in throw CoordinatorClientTestError.unexpectedContainerLoader },
+            testLoader: loader
+        )
+    }
+
+    private static func waitUntil(
+        timeoutNanoseconds: UInt64 = 2_000_000_000,
+        _ predicate: () async -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if await predicate() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for condition")
+    }
+}
+
+private enum CoordinatorClientTestError: Error {
+    case unexpectedContainerLoader
+}
+
+private actor SwapLoaderGate {
+    private var released = false
+
+    func waitForRelease() async throws {
+        while !released {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    func release() {
+        released = true
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -201,7 +201,7 @@ final class CoordinatorClientTests: XCTestCase {
     func testHeartbeatEnabledModeReadyEmitsLoadingFalse() async throws {
         let recorder = CoordinatorFrameRecorder()
         let runtimeHash = String(repeating: "1", count: 64)
-        let runtime = makeRuntime(modelID: "model-a", modelHash: runtimeHash, warmSwapEnabled: true)
+        let runtime = makeRuntime(modelID: "model-b", modelHash: runtimeHash, warmSwapEnabled: true)
         let status = ProviderStatus(
             modelID: "model-a",
             modelLoaded: true,
@@ -214,6 +214,7 @@ final class CoordinatorClientTests: XCTestCase {
         let heartbeat = try XCTUnwrap(frames.first)
         let json = Self.jsonString(heartbeat)
 
+        XCTAssertEqual(heartbeat["model_id"] as? String, "model-b")
         XCTAssertEqual(heartbeat["model_hash"] as? String, runtimeHash)
         XCTAssertEqual(heartbeat["loading"] as? Bool, false)
         XCTAssertTrue(json.contains("\"\(runtimeHash)\""), json)
@@ -293,9 +294,45 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertFalse(json.contains("runtime-hash"), json)
     }
 
+    func testHeartbeatDisabledModeKeepsProviderStatusModelIDWhenRuntimeDiffers() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let runtime = makeRuntime(modelID: "model-b", modelHash: "runtime-hash", warmSwapEnabled: true)
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1),
+            modelHash: "boot-hash"
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: false, modelRuntime: runtime)
+
+        try await client.sendHeartbeatForTest()
+        let frames = await recorder.frames
+        let heartbeat = try XCTUnwrap(frames.first)
+
+        XCTAssertEqual(heartbeat["model_id"] as? String, "model-a")
+        XCTAssertNil(heartbeat["loading"])
+    }
+
+    func testHelloDisabledModeKeepsProviderStatusModelIDWhenRuntimeDiffers() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let runtime = makeRuntime(modelID: "model-b", modelHash: "runtime-hash", warmSwapEnabled: true)
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1),
+            modelHash: "boot-hash"
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: false, modelRuntime: runtime)
+
+        let hello = await client.helloMessage()
+
+        XCTAssertEqual(hello["model_id"] as? String, "model-a")
+        XCTAssertEqual(hello["model_hash"] as? String, "boot-hash")
+    }
+
     func testHelloEnabledModeReadsFromModelRuntime() async throws {
         let recorder = CoordinatorFrameRecorder()
-        let runtime = makeRuntime(modelID: "model-a", modelHash: "runtime-hash", warmSwapEnabled: true)
+        let runtime = makeRuntime(modelID: "model-b", modelHash: "runtime-hash", warmSwapEnabled: true)
         let status = ProviderStatus(
             modelID: "model-a",
             modelLoaded: true,
@@ -307,7 +344,9 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let json = Self.jsonString(hello)
 
+        XCTAssertEqual(hello["model_id"] as? String, "model-b")
         XCTAssertEqual(hello["model_hash"] as? String, "runtime-hash")
+        XCTAssertTrue(json.contains("\"model_id\":\"model-b\""), json)
         XCTAssertTrue(json.contains("\"model_hash\":\"runtime-hash\""), json)
         XCTAssertFalse(json.contains("boot-hash"), json)
     }

--- a/phase3-binary/Tests/macprovider-cliTests/EndToEndAcceptanceTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/EndToEndAcceptanceTests.swift
@@ -1,0 +1,638 @@
+import ArgumentParser
+import Darwin
+import Foundation
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+final class EndToEndAcceptanceTests: XCTestCase {
+    func testAC_N_0_L1ByteIdenticalDefault_WireSurface() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let client = try await makeClient(modelID: "model-a", enableWarmSwap: false, recorder: recorder)
+
+        let authJSON = jsonString(await client.authInitialMessage(attempt: Tier2AuthAttempt()))
+        let helloJSON = jsonString(await client.helloMessage())
+        try await client.sendHeartbeatForTest()
+        let frames = await recorder.frames
+        let heartbeat = try XCTUnwrap(frames.first)
+        let heartbeatJSON = jsonString(heartbeat)
+
+        XCTAssertTrue(authJSON.contains("\"supported_models\":[\"model-a\"]"), authJSON)
+        XCTAssertFalse(authJSON.contains("\"publishes_supported_models\""), authJSON)
+        XCTAssertFalse(helloJSON.contains("\"loading\""), helloJSON)
+        XCTAssertFalse(heartbeatJSON.contains("\"model_hash\""), heartbeatJSON)
+        XCTAssertFalse(heartbeatJSON.contains("\"loading\""), heartbeatJSON)
+    }
+
+    func testAC_N_1_SPEC010_OptIn_ExplicitCatalog() async throws {
+        let client = try await makeClient(
+            modelID: "A",
+            supportedModels: ["A", "B", "C"],
+            publishesSupportedModels: true
+        )
+
+        let authJSON = jsonString(await client.authInitialMessage(attempt: Tier2AuthAttempt()))
+
+        XCTAssertTrue(authJSON.contains("\"model_id\":\"A\""), authJSON)
+        XCTAssertTrue(authJSON.contains("\"supported_models\":[\"A\",\"B\",\"C\"]"), authJSON)
+        XCTAssertTrue(authJSON.contains("\"publishes_supported_models\":true"), authJSON)
+    }
+
+    func testAC_N_2_SPEC010_PreFlight_ExitCode2() async throws {
+        let socketPath = try makeSocketPath()
+        let statePath = try makeStatePath()
+        let command = try ModelsSwitchCommand.parse([
+            "C",
+            "--supported-models", "A,B",
+            "--model", "A",
+            "--ctl-socket-path", socketPath.path,
+            "--switch-state-path", statePath.path,
+        ])
+
+        let capture = await captureOutput {
+            try await command.run()
+        }
+
+        XCTAssertEqual(capture.error as? ExitCode, ExitCode(2))
+        XCTAssertTrue(capture.stderr.contains("switch target C not in --supported-models"), capture.stderr)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: socketPath.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: statePath.path))
+    }
+
+    func testAC_N_3_SPEC011_OptInGate_DisabledMode() async throws {
+        var disabledConfig = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        disabledConfig.enableWarmSwap = false
+        let socketPath = try makeSocketPath()
+
+        let list = try ModelsListCommand.parse([
+            "--ctl-socket-path", socketPath.path,
+            "--model", "old-model",
+        ])
+        let listCapture = await captureOutput {
+            try await list.run()
+        }
+        let switchCommand = try ModelsSwitchCommand.parse([
+            "new-model",
+            "--supported-models", "old-model,new-model",
+            "--model", "old-model",
+            "--ctl-socket-path", socketPath.path,
+            "--switch-state-path", try makeStatePath().path,
+        ])
+        let switchCapture = await captureOutput {
+            try await switchCommand.run()
+        }
+
+        XCTAssertFalse(disabledConfig.enableWarmSwap)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: socketPath.path))
+        XCTAssertNil(listCapture.error)
+        XCTAssertTrue(listCapture.stdout.contains("serve not running; warm-swap disabled"), listCapture.stdout)
+        XCTAssertEqual(switchCapture.error as? ExitCode, ExitCode(4))
+        XCTAssertTrue(switchCapture.stderr.contains("is not running on this host"), switchCapture.stderr)
+    }
+
+    func testAC_N_4_SPEC011_OptInGate_EnabledMode_FilePermissions() async throws {
+        let socketPath = try makeSocketPath()
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "old-model"))
+
+        try await server.start()
+
+        XCTAssertEqual(octalMode(socketPath.deletingLastPathComponent()), 0o700)
+        XCTAssertEqual(octalMode(socketPath), 0o600)
+        await server.stop()
+    }
+
+    func testAC_N_5_MacOSNativePath() throws {
+        let ctlPath = ControlSocketPaths.resolve(ctlSocketPath: nil)
+        let statePath = ControlSocketPaths.defaultSwitchStatePath(nil)
+        let source = try String(contentsOfFile: "Sources/macprovider-cli/ControlSocket.swift", encoding: .utf8)
+
+        XCTAssertTrue(ctlPath.path.hasPrefix(FileManager.default.temporaryDirectory.path), ctlPath.path)
+        XCTAssertTrue(ctlPath.path.contains("macprovider-cli/ctl.sock"), ctlPath.path)
+        XCTAssertTrue(statePath.path.hasPrefix(FileManager.default.homeDirectoryForCurrentUser.path), statePath.path)
+        XCTAssertTrue(statePath.path.contains("Library/Application Support/macprovider-cli/last-switch.ts"), statePath.path)
+        XCTAssertFalse(source.contains("XDG_RUNTIME_DIR"))
+    }
+
+    func testAC_N_6_AtomicSwap_InFlightVsNewRequest() async throws {
+        let probe = InFlightProbe()
+        let runtime = makeRuntime(
+            modelID: "old-model",
+            modelHash: "old-hash",
+            loader: { target in
+                try await Task.sleep(nanoseconds: 50_000_000)
+                return (target, "new-hash")
+            },
+            completion: { snapshot, _ in
+                await probe.markStarted(modelID: snapshot.modelID)
+                while await !probe.canFinish {
+                    try await Task.sleep(nanoseconds: 5_000_000)
+                }
+                return CompletionResult(content: snapshot.modelID ?? "<nil>", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        let socketPath = try makeSocketPath()
+        let statePath = try makeStatePath()
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: runtime)
+        try await server.start()
+
+        let inFlight = Task {
+            try await runtime.complete(try makeRequest(model: "old-model"))
+        }
+        try await waitUntil {
+            await probe.startedModelID != nil
+        }
+
+        let command = try ModelsSwitchCommand.parse([
+            "new-model",
+            "--supported-models", "old-model,new-model",
+            "--model", "old-model",
+            "--ctl-socket-path", socketPath.path,
+            "--switch-state-path", statePath.path,
+        ])
+        let capture = await captureOutput {
+            try await command.run()
+        }
+        await probe.allowFinish()
+        let oldCompletion = try await inFlight.value
+        let newCompletion = try await runtime.complete(try makeRequest(model: "new-model"))
+        await server.stop()
+
+        XCTAssertNil(capture.error)
+        XCTAssertEqual(oldCompletion.content, "old-model")
+        XCTAssertEqual(newCompletion.content, "new-model")
+    }
+
+    func testAC_N_7_NoStarveHeartbeat() async throws {
+        let gate = SwapLoaderGate()
+        let oldHash = String(repeating: "1", count: 64)
+        let runtime = makeRuntime(modelID: "model-a", modelHash: oldHash) { target in
+            try await gate.waitForRelease()
+            return (target, String(repeating: "2", count: 64))
+        }
+        let recorder = CoordinatorFrameRecorder()
+        let client = try await makeClient(modelID: "model-a", enableWarmSwap: true, modelRuntime: runtime, recorder: recorder)
+
+        let swapTask = try await runtime.beginSwap(targetModelID: "model-b")
+        try await waitUntil {
+            await runtime.currentSnapshot().state == .loading
+        }
+        try await client.sendHeartbeatForTest()
+        await gate.release()
+        try await swapTask.value
+
+        let frames = await recorder.frames
+        XCTAssertTrue(frames.contains { $0["type"] as? String == "heartbeat" && $0["loading"] as? Bool == true })
+    }
+
+    func testAC_N_8_HeartbeatHashFormat() async throws {
+        let hash = String(repeating: "a", count: 64)
+        let recorder = CoordinatorFrameRecorder()
+        let client = try await makeClient(modelID: "model-a", modelHash: hash, enableWarmSwap: true, recorder: recorder)
+
+        try await client.sendHeartbeatForTest()
+        let frames = await recorder.frames
+        let heartbeat = try XCTUnwrap(frames.first)
+        let modelHash = try XCTUnwrap(heartbeat["model_hash"] as? String)
+
+        XCTAssertEqual(modelHash.count, 64)
+        XCTAssertNotNil(modelHash.range(of: #"^[a-f0-9]{64}$"#, options: .regularExpression))
+        XCTAssertFalse(modelHash.contains("sha256:"))
+    }
+
+    func testAC_N_9_FourMatrixCells_AuthInitial() async throws {
+        let cells: [(supported: [String]?, publishes: Bool, warm: Bool, expectedCatalog: [String], expectedPublish: Bool, expectedWarmFields: Bool)] = [
+            (nil, false, false, ["model-a"], false, false),
+            (["model-a", "model-b"], true, false, ["model-a", "model-b"], true, false),
+            (nil, false, true, ["model-a"], false, true),
+            (["model-a", "model-b"], true, true, ["model-a", "model-b"], true, true),
+        ]
+
+        for cell in cells {
+            let recorder = CoordinatorFrameRecorder()
+            let client = try await makeClient(
+                modelID: "model-a",
+                modelHash: String(repeating: "b", count: 64),
+                supportedModels: cell.supported,
+                publishesSupportedModels: cell.publishes,
+                enableWarmSwap: cell.warm,
+                recorder: recorder
+            )
+            let auth = await client.authInitialMessage(attempt: Tier2AuthAttempt())
+            try await client.sendHeartbeatForTest()
+            let frames = await recorder.frames
+            let heartbeat = try XCTUnwrap(frames.first)
+
+            XCTAssertEqual(auth["supported_models"] as? [String], cell.expectedCatalog)
+            XCTAssertEqual(auth["publishes_supported_models"] as? Bool, cell.expectedPublish ? true : nil)
+            XCTAssertEqual(heartbeat["loading"] != nil, cell.expectedWarmFields)
+            XCTAssertEqual(heartbeat["model_hash"] != nil, cell.expectedWarmFields)
+        }
+    }
+
+    func testAC_N_10_V2HandshakeFieldsMatchSPEC010_3_1_A() async throws {
+        let client = try await makeClient(
+            modelID: "X",
+            supportedModels: ["X", "Y"],
+            publishesSupportedModels: true
+        )
+
+        let auth = await client.authInitialMessage(attempt: Tier2AuthAttempt())
+        let expectedKeys: Set<String> = [
+            "type",
+            "version",
+            "stage",
+            "provider_id",
+            "hostname",
+            "model_id",
+            "model_params_b",
+            "ram_gb",
+            "max_context_tokens",
+            "max_concurrency",
+            "throughput_tps_estimate",
+            "binary_version",
+            "provider_ecdh_public_key",
+            "tier2_capabilities",
+            "supported_models",
+            "publishes_supported_models",
+        ]
+
+        for key in expectedKeys {
+            XCTAssertNotNil(auth[key], "missing \(key)")
+        }
+    }
+
+    func testAC_N_11_LegacyHelloByteIdenticalToV124() async throws {
+        let client = try await makeClient(modelID: "A", modelHash: String(repeating: "c", count: 64), enableWarmSwap: false)
+
+        let hello = await client.helloMessage()
+        let allowedKeys: Set<String> = [
+            "type",
+            "version",
+            "tier",
+            "provider_id",
+            "hostname",
+            "model_id",
+            "model_params_b",
+            "ram_gb",
+            "max_context_tokens",
+            "max_concurrency",
+            "throughput_tps_estimate",
+            "binary_version",
+            "attestation",
+            "endpoint_url",
+            "model_hash",
+        ]
+
+        XCTAssertEqual(Set(hello.keys), Set(hello.keys).intersection(allowedKeys))
+        XCTAssertNil(hello["supported_models"])
+        XCTAssertNil(hello["publishes_supported_models"])
+        XCTAssertNil(hello["loading"])
+    }
+
+    func testCooldownSoftGuardWritesStateExits6AndForceBypasses() async throws {
+        let socketPath = try makeSocketPath()
+        let statePath = try makeStatePath()
+        let runtime = makeRuntime(modelID: "old-model") { target in
+            (target, "hash-\(target)")
+        }
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: runtime)
+        try await server.start()
+
+        let first = try ModelsSwitchCommand.parse([
+            "new-model",
+            "--supported-models", "old-model,new-model,other-model",
+            "--model", "old-model",
+            "--ctl-socket-path", socketPath.path,
+            "--switch-state-path", statePath.path,
+        ])
+        let firstCapture = await captureOutput {
+            try await first.run()
+        }
+        let second = try ModelsSwitchCommand.parse([
+            "other-model",
+            "--supported-models", "old-model,new-model,other-model",
+            "--model", "new-model",
+            "--ctl-socket-path", socketPath.path,
+            "--switch-state-path", statePath.path,
+        ])
+        let secondCapture = await captureOutput {
+            try await second.run()
+        }
+        let forced = try ModelsSwitchCommand.parse([
+            "other-model",
+            "--force",
+            "--supported-models", "old-model,new-model,other-model",
+            "--model", "new-model",
+            "--ctl-socket-path", socketPath.path,
+            "--switch-state-path", statePath.path,
+        ])
+        let forcedCapture = await captureOutput {
+            try await forced.run()
+        }
+        await server.stop()
+
+        XCTAssertNil(firstCapture.error)
+        XCTAssertNotNil(SwitchStateStore(path: statePath).readLastSwitchMs())
+        XCTAssertFalse(FileManager.default.fileExists(atPath: statePath.path + ".tmp"))
+        XCTAssertEqual(secondCapture.error as? ExitCode, ExitCode(6))
+        XCTAssertTrue(secondCapture.stderr.contains("swap on cooldown for"), secondCapture.stderr)
+        XCTAssertTrue(secondCapture.stderr.contains("Re-issue with --force to bypass"), secondCapture.stderr)
+        XCTAssertNil(forcedCapture.error)
+    }
+
+    func testForceDoesNotBypassExitCodes2_3_4_5() async throws {
+        let preflight = try ModelsSwitchCommand.parse([
+            "C",
+            "--force",
+            "--supported-models", "A,B",
+            "--model", "A",
+            "--ctl-socket-path", try makeSocketPath().path,
+            "--switch-state-path", try makeStatePath().path,
+        ])
+        let preflightCapture = await captureOutput {
+            try await preflight.run()
+        }
+
+        let absent = try ModelsSwitchCommand.parse([
+            "B",
+            "--force",
+            "--supported-models", "A,B",
+            "--model", "A",
+            "--ctl-socket-path", try makeSocketPath().path,
+            "--switch-state-path", try makeStatePath().path,
+        ])
+        let absentCapture = await captureOutput {
+            try await absent.run()
+        }
+
+        let concurrentSocket = try makeSocketPath()
+        let concurrentServer = ControlSocketServer(socketPath: concurrentSocket, modelRuntime: makeRuntime(modelID: "A") { target in
+            try await Task.sleep(nanoseconds: 300_000_000)
+            return (target, "hash")
+        })
+        try await concurrentServer.start()
+        let first = try await ControlSocketClient.connect(socketPath: concurrentSocket)
+        try await first.send(.statusRequest)
+        _ = try await first.receive(timeout: 1)
+        try await first.send(.switchRequest(targetModelID: "B", requestedAtMs: nowMs()))
+        _ = try await first.receive(timeout: 1)
+        _ = try await first.receive(timeout: 1)
+        let concurrent = try ModelsSwitchCommand.parse([
+            "C",
+            "--force",
+            "--supported-models", "A,B,C",
+            "--model", "A",
+            "--ctl-socket-path", concurrentSocket.path,
+            "--switch-state-path", try makeStatePath().path,
+        ])
+        let concurrentCapture = await captureOutput {
+            try await concurrent.run()
+        }
+        _ = try? await first.receive(timeout: 1)
+        _ = try? await first.receive(timeout: 1)
+        await first.close()
+        await concurrentServer.stop()
+
+        let failedSocket = try makeSocketPath()
+        let failedServer = ControlSocketServer(socketPath: failedSocket, modelRuntime: makeRuntime(modelID: "A") { _ in
+            throw EndToEndTestError.loadFailed
+        })
+        try await failedServer.start()
+        let failed = try ModelsSwitchCommand.parse([
+            "B",
+            "--force",
+            "--supported-models", "A,B",
+            "--model", "A",
+            "--ctl-socket-path", failedSocket.path,
+            "--switch-state-path", try makeStatePath().path,
+        ])
+        let failedCapture = await captureOutput {
+            try await failed.run()
+        }
+        await failedServer.stop()
+
+        XCTAssertEqual(preflightCapture.error as? ExitCode, ExitCode(2))
+        XCTAssertEqual(absentCapture.error as? ExitCode, ExitCode(4))
+        XCTAssertEqual(concurrentCapture.error as? ExitCode, ExitCode(3))
+        XCTAssertEqual(failedCapture.error as? ExitCode, ExitCode(5))
+    }
+
+    func testCorruptCooldownStateDoesNotExit() async throws {
+        let socketPath = try makeSocketPath()
+        let statePath = try makeStatePath()
+        try FileManager.default.createDirectory(at: statePath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "not a number".write(to: statePath, atomically: false, encoding: .utf8)
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "A") { target in
+            (target, "hash")
+        })
+        try await server.start()
+
+        let command = try ModelsSwitchCommand.parse([
+            "B",
+            "--supported-models", "A,B",
+            "--model", "A",
+            "--ctl-socket-path", socketPath.path,
+            "--switch-state-path", statePath.path,
+        ])
+        let capture = await captureOutput {
+            try await command.run()
+        }
+        await server.stop()
+
+        XCTAssertNil(capture.error)
+    }
+
+    private func makeClient(
+        modelID: String?,
+        modelHash: String? = nil,
+        supportedModels: [String]? = nil,
+        publishesSupportedModels: Bool = false,
+        enableWarmSwap: Bool = false,
+        modelRuntime: ModelRuntime? = nil,
+        recorder: CoordinatorFrameRecorder = CoordinatorFrameRecorder()
+    ) async throws -> CoordinatorClient {
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = modelID
+        config.supportedModels = supportedModels
+        config.publishesSupportedModels = publishesSupportedModels
+        config.enableWarmSwap = enableWarmSwap
+        let status = ProviderStatus(
+            modelID: modelID,
+            modelLoaded: modelID != nil,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1),
+            modelHash: modelHash
+        )
+        let runtime = modelRuntime ?? makeRuntime(modelID: modelID, modelHash: modelHash, warmSwapEnabled: enableWarmSwap)
+        return try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            sendOverride: { frame in
+                await recorder.append(frame)
+            },
+            sleepAssertionFactory: { nil }
+        ))
+    }
+
+    private func makeRuntime(
+        modelID: String?,
+        modelHash: String? = nil,
+        warmSwapEnabled: Bool = true,
+        loader: @escaping @Sendable (String) async throws -> (String, String?) = { target in (target, nil) },
+        completion: (@Sendable (RuntimeSnapshot, ChatCompletionRequest) async throws -> CompletionResult)? = nil
+    ) -> ModelRuntime {
+        ModelRuntime(
+            modelID: modelID,
+            modelHash: modelHash,
+            warmSwapEnabled: warmSwapEnabled,
+            loader: { _ in throw EndToEndTestError.unexpectedContainerLoader },
+            testLoader: loader,
+            testCompletion: completion
+        )
+    }
+
+    private func makeSocketPath() throws -> URL {
+        try makeTempDirectory().appendingPathComponent("ctl.sock")
+    }
+
+    private func makeStatePath() throws -> URL {
+        try makeTempDirectory().appendingPathComponent("last-switch.ts")
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let dir = URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent("mpm-e2e-\(getpid())-\(Int.random(in: 0 ... 999_999))")
+        try? FileManager.default.removeItem(at: dir)
+        return dir
+    }
+
+    private func makeRequest(model: String) throws -> ChatCompletionRequest {
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                [
+                    "role": "user",
+                    "content": "hello",
+                ],
+            ],
+        ]
+        return try ChatCompletionRequest.parse(data: try JSONSerialization.data(withJSONObject: body))
+    }
+
+    private func octalMode(_ url: URL) -> Int {
+        var statBuffer = stat()
+        guard lstat(url.path, &statBuffer) == 0 else {
+            return -1
+        }
+        return Int(statBuffer.st_mode & S_IRWXU)
+    }
+
+    private func nowMs() -> Int64 {
+        Int64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private func jsonString(_ object: [String: Any]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func waitUntil(
+        timeoutNanoseconds: UInt64 = 2_000_000_000,
+        _ predicate: () async -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if await predicate() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for condition")
+    }
+}
+
+private struct CapturedOutput {
+    let stdout: String
+    let stderr: String
+    let error: Error?
+}
+
+private func captureOutput(_ body: () async throws -> Void) async -> CapturedOutput {
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    let savedStdout = dup(STDOUT_FILENO)
+    let savedStderr = dup(STDERR_FILENO)
+    dup2(stdoutPipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+    dup2(stderrPipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
+
+    let error: Error?
+    do {
+        try await body()
+        error = nil
+    } catch let caught {
+        error = caught
+    }
+
+    fflush(stdout)
+    fflush(stderr)
+    dup2(savedStdout, STDOUT_FILENO)
+    dup2(savedStderr, STDERR_FILENO)
+    close(savedStdout)
+    close(savedStderr)
+    stdoutPipe.fileHandleForWriting.closeFile()
+    stderrPipe.fileHandleForWriting.closeFile()
+
+    let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+    return CapturedOutput(
+        stdout: String(decoding: stdoutData, as: UTF8.self),
+        stderr: String(decoding: stderrData, as: UTF8.self),
+        error: error
+    )
+}
+
+private actor CoordinatorFrameRecorder {
+    private(set) var frames: [[String: Any]] = []
+
+    func append(_ frame: [String: Any]) {
+        frames.append(frame)
+    }
+}
+
+private actor InFlightProbe {
+    private var _startedModelID: String?
+    private var _canFinish = false
+
+    var startedModelID: String? { _startedModelID }
+    var canFinish: Bool { _canFinish }
+
+    func markStarted(modelID: String?) {
+        _startedModelID = modelID
+    }
+
+    func allowFinish() {
+        _canFinish = true
+    }
+}
+
+private actor SwapLoaderGate {
+    private var released = false
+
+    func waitForRelease() async throws {
+        while !released {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    func release() {
+        released = true
+    }
+}
+
+private enum EndToEndTestError: Error {
+    case unexpectedContainerLoader
+    case loadFailed
+    case noHeartbeatCapture
+}

--- a/phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift
@@ -132,6 +132,65 @@ final class HTTPServerSwapTests: XCTestCase {
         XCTAssertEqual(modelID, "B")
     }
 
+    func testStreamingRequestAdmittedInReadyDoesNotGetProviderLoading() async throws {
+        let probe = HTTPCompletionProbe()
+        let chunks = LockedStringArray()
+        let runtime = ModelRuntime(
+            modelID: "old-model",
+            modelHash: "old-hash",
+            warmSwapEnabled: true,
+            loader: { _ in throw HTTPServerSwapTestError.unexpectedContainerLoader },
+            testLoader: { target in
+                try await Task.sleep(nanoseconds: 150_000_000)
+                return (target, "new-hash")
+            },
+            testCompletion: { snapshot, _ in
+                await probe.record(modelID: snapshot.modelID)
+                while await !probe.canFinish {
+                    try await Task.sleep(nanoseconds: 5_000_000)
+                }
+                return CompletionResult(content: snapshot.modelID ?? "<nil>", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        let request = try makeRequest(model: "old-model")
+        let snapshot = await runtime.currentSnapshot()
+        XCTAssertNil(RouterHandler.warmSwapRejectionError(for: snapshot))
+        try request.validateModelMatches(RouterHandler.modelIDForValidation(
+            warmSwapEnabled: true,
+            bootModelID: "old-model",
+            runtimeSnapshot: snapshot
+        ))
+
+        let handle = try await runtime.acquireRequestHandle(request)
+        do {
+            try await runtime.preflight(request, with: handle)
+            let streamTask = Task {
+                try await runtime.stream(request, with: handle) { chunk in
+                    chunks.append(chunk)
+                }
+            }
+            try await waitUntil {
+                !(await probe.modelIDs.isEmpty)
+            }
+
+            let swapTask = try await runtime.beginSwap(targetModelID: "new-model")
+            let loadingSnapshot = await runtime.currentSnapshot()
+            XCTAssertEqual(loadingSnapshot.state, .loading)
+            await probe.allowFinish()
+            let completion = try await streamTask.value
+            await runtime.unregisterInFlight(handle.registrationID)
+            try await swapTask.value
+            let reachedModelIDs = await probe.modelIDs
+
+            XCTAssertEqual(completion.content, "old-model")
+            XCTAssertEqual(chunks.values, ["old-model"])
+            XCTAssertEqual(reachedModelIDs, ["old-model"])
+        } catch {
+            await runtime.unregisterInFlight(handle.registrationID)
+            throw error
+        }
+    }
+
     private func makeRequest(model: String) throws -> ChatCompletionRequest {
         let body: [String: Any] = [
             "model": model,
@@ -153,9 +212,33 @@ private enum HTTPServerSwapTestError: Error {
 
 private actor HTTPCompletionProbe {
     private(set) var modelIDs: [String?] = []
+    private var _canFinish = false
+
+    var canFinish: Bool { _canFinish }
 
     func record(modelID: String?) {
         modelIDs.append(modelID)
+    }
+
+    func allowFinish() {
+        _canFinish = true
+    }
+}
+
+private final class LockedStringArray: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _values: [String] = []
+
+    var values: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _values
+    }
+
+    func append(_ value: String) {
+        lock.lock()
+        _values.append(value)
+        lock.unlock()
     }
 }
 
@@ -164,4 +247,18 @@ private extension APIError {
         let data = try! JSONSerialization.data(withJSONObject: envelope, options: [.sortedKeys, .withoutEscapingSlashes])
         return String(decoding: data, as: UTF8.self)
     }
+}
+
+private func waitUntil(
+    timeoutNanoseconds: UInt64 = 2_000_000_000,
+    _ predicate: () async -> Bool
+) async throws {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while DispatchTime.now().uptimeNanoseconds < deadline {
+        if await predicate() {
+            return
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    XCTFail("Timed out waiting for condition")
 }

--- a/phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import MLXLMCommon
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+final class HTTPServerSwapTests: XCTestCase {
+    func testInferenceReturns503WhenLoading() {
+        let snapshot = RuntimeSnapshot(state: .loading, container: nil, modelID: "old-model", modelHash: "old-hash")
+
+        let error = RouterHandler.warmSwapRejectionError(for: snapshot)
+
+        XCTAssertEqual(error?.status, 503)
+        XCTAssertEqual(error?.code, "provider_loading")
+        XCTAssertEqual(error?.type, "service_unavailable")
+        XCTAssertEqual(error?.envelopeJSONString, #"{"error":{"code":"provider_loading","message":"Provider is loading a new model and is temporarily unavailable. Retry after the indicated interval.","param":null,"type":"service_unavailable"}}"#)
+    }
+
+    func testInferenceReturns503WhenDraining() {
+        let snapshot = RuntimeSnapshot(state: .draining, container: nil, modelID: "old-model", modelHash: "old-hash")
+
+        let error = RouterHandler.warmSwapRejectionError(for: snapshot)
+
+        XCTAssertEqual(error?.status, 503)
+        XCTAssertEqual(error?.code, "provider_loading")
+        XCTAssertEqual(error?.type, "service_unavailable")
+    }
+
+    func testInferenceProceedsWhenReady() async throws {
+        let runtime = ModelRuntime(
+            modelID: "ready-model",
+            warmSwapEnabled: true,
+            loader: { _ in throw HTTPServerSwapTestError.unexpectedContainerLoader },
+            testLoader: { target in (target, "hash") },
+            testCompletion: { _, _ in
+                CompletionResult(content: "ready", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        let snapshot = await runtime.currentSnapshot()
+
+        XCTAssertNil(RouterHandler.warmSwapRejectionError(for: snapshot))
+        let completion = try await runtime.complete(try makeRequest(model: "ready-model"))
+        XCTAssertEqual(completion.content, "ready")
+    }
+
+    private func makeRequest(model: String) throws -> ChatCompletionRequest {
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                [
+                    "role": "user",
+                    "content": "hello",
+                ]
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: body)
+        return try ChatCompletionRequest.parse(data: data)
+    }
+}
+
+private enum HTTPServerSwapTestError: Error {
+    case unexpectedContainerLoader
+}
+
+private extension APIError {
+    var envelopeJSONString: String {
+        let data = try! JSONSerialization.data(withJSONObject: envelope, options: [.sortedKeys, .withoutEscapingSlashes])
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift
@@ -43,6 +43,95 @@ final class HTTPServerSwapTests: XCTestCase {
         XCTAssertEqual(completion.content, "ready")
     }
 
+    func testHTTPReturns503SwapDrainTimeoutEnvelope() throws {
+        let data = try JSONSerialization.data(
+            withJSONObject: RouterHandler.swapDrainTimeoutEnvelope(),
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        let json = String(decoding: data, as: UTF8.self)
+
+        XCTAssertEqual(json, #"{"error":{"code":"swap_drain_timeout","type":"service_unavailable"}}"#)
+    }
+
+    func testInferenceForNewModelSucceedsAfterSwap() async throws {
+        let probe = HTTPCompletionProbe()
+        let runtime = ModelRuntime(
+            modelID: "A",
+            modelHash: "hash-a",
+            warmSwapEnabled: true,
+            loader: { _ in throw HTTPServerSwapTestError.unexpectedContainerLoader },
+            testLoader: { target in (target, "hash-b") },
+            testCompletion: { snapshot, _ in
+                await probe.record(modelID: snapshot.modelID)
+                return CompletionResult(content: snapshot.modelID ?? "<nil>", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+
+        let swapTask = try await runtime.beginSwap(targetModelID: "B")
+        try await swapTask.value
+        let snapshot = await runtime.currentSnapshot()
+        let request = try makeRequest(model: "B")
+        try request.validateModelMatches(RouterHandler.modelIDForValidation(
+            warmSwapEnabled: true,
+            bootModelID: "A",
+            runtimeSnapshot: snapshot
+        ))
+        let completion = try await runtime.complete(request)
+        let reachedModelIDs = await probe.modelIDs
+
+        XCTAssertEqual(completion.content, "B")
+        XCTAssertEqual(reachedModelIDs, ["B"])
+    }
+
+    func testInferenceForOldModelRejectedAfterSwap() async throws {
+        let runtime = ModelRuntime(
+            modelID: "A",
+            modelHash: "hash-a",
+            warmSwapEnabled: true,
+            loader: { _ in throw HTTPServerSwapTestError.unexpectedContainerLoader },
+            testLoader: { target in (target, "hash-b") }
+        )
+
+        let swapTask = try await runtime.beginSwap(targetModelID: "B")
+        try await swapTask.value
+        let snapshot = await runtime.currentSnapshot()
+        let request = try makeRequest(model: "A")
+
+        XCTAssertThrowsError(try request.validateModelMatches(RouterHandler.modelIDForValidation(
+            warmSwapEnabled: true,
+            bootModelID: "A",
+            runtimeSnapshot: snapshot
+        ))) { error in
+            let apiError = error as? APIError
+            XCTAssertEqual(apiError?.status, 404)
+            XCTAssertEqual(apiError?.code, "model_not_found")
+        }
+    }
+
+    func testDisabledValidationUsesBootModelWhenRuntimeDiffers() throws {
+        let snapshot = RuntimeSnapshot(state: .ready, container: nil, modelID: "B", modelHash: "hash-b")
+
+        let modelID = RouterHandler.modelIDForValidation(
+            warmSwapEnabled: false,
+            bootModelID: "A",
+            runtimeSnapshot: snapshot
+        )
+
+        XCTAssertEqual(modelID, "A")
+    }
+
+    func testEnabledValidationUsesRuntimeModelWhenBootDiffers() throws {
+        let snapshot = RuntimeSnapshot(state: .ready, container: nil, modelID: "B", modelHash: "hash-b")
+
+        let modelID = RouterHandler.modelIDForValidation(
+            warmSwapEnabled: true,
+            bootModelID: "A",
+            runtimeSnapshot: snapshot
+        )
+
+        XCTAssertEqual(modelID, "B")
+    }
+
     private func makeRequest(model: String) throws -> ChatCompletionRequest {
         let body: [String: Any] = [
             "model": model,
@@ -60,6 +149,14 @@ final class HTTPServerSwapTests: XCTestCase {
 
 private enum HTTPServerSwapTestError: Error {
     case unexpectedContainerLoader
+}
+
+private actor HTTPCompletionProbe {
+    private(set) var modelIDs: [String?] = []
+
+    func record(modelID: String?) {
+        modelIDs.append(modelID)
+    }
 }
 
 private extension APIError {

--- a/phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift
@@ -243,8 +243,19 @@ private actor FakeStreamingRuntime: ModelRuntimeServing {
         CompletionResult(content: "", finishReason: "stop", promptTokens: 7, completionTokens: 0)
     }
 
+    func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle {
+        RequestHandle(
+            snapshot: RuntimeSnapshot(state: .ready, container: nil, modelID: request.model, modelHash: nil),
+            registrationID: 0,
+            drainCancelled: DrainCancelToken()
+        )
+    }
+
+    func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws { }
+
     func stream(
         _ request: ChatCompletionRequest,
+        with handle: RequestHandle,
         shouldCancel: @escaping @Sendable () -> Bool,
         onChunk: @escaping @Sendable (String) -> Void
     ) async throws -> CompletionResult {
@@ -256,6 +267,8 @@ private actor FakeStreamingRuntime: ModelRuntimeServing {
         }
         return CompletionResult(content: "onetwo", finishReason: "stop", promptTokens: 7, completionTokens: 2)
     }
+
+    func unregisterInFlight(_ id: Int) { }
 }
 
 private actor FakeCompletionRuntime: ModelRuntimeServing {
@@ -266,14 +279,27 @@ private actor FakeCompletionRuntime: ModelRuntimeServing {
         CompletionResult(content: "encrypted answer", finishReason: "stop", promptTokens: 5, completionTokens: 2)
     }
 
+    func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle {
+        RequestHandle(
+            snapshot: RuntimeSnapshot(state: .ready, container: nil, modelID: request.model, modelHash: nil),
+            registrationID: 0,
+            drainCancelled: DrainCancelToken()
+        )
+    }
+
+    func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws { }
+
     func stream(
         _ request: ChatCompletionRequest,
+        with handle: RequestHandle,
         shouldCancel: @escaping @Sendable () -> Bool,
         onChunk: @escaping @Sendable (String) -> Void
     ) async throws -> CompletionResult {
         onChunk("encrypted answer")
         return CompletionResult(content: "encrypted answer", finishReason: "stop", promptTokens: 5, completionTokens: 2)
     }
+
+    func unregisterInFlight(_ id: Int) { }
 }
 
 private func testTier2Session() throws -> Tier2ProviderSession {

--- a/phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import MLXLMCommon
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+final class ModelRuntimeSwapTests: XCTestCase {
+    func testDisabledModeRejectsSwap() async throws {
+        let runtime = try await ModelRuntime(modelID: nil, warmSwapEnabled: false)
+
+        do {
+            _ = try await runtime.beginSwap(targetModelID: "new-model")
+            XCTFail("Expected warm-swap disabled error")
+        } catch let error as WarmSwapDisabledError {
+            XCTAssertEqual(error.description, "warm swap is not enabled (start serve with --enable-warm-swap)")
+        }
+    }
+
+    func testEnabledModeAcceptsSwap() async throws {
+        let runtime = makeRuntime(modelID: nil, warmSwapEnabled: true) { target in
+            try await Task.sleep(nanoseconds: 50_000_000)
+            return (target, "new-hash")
+        }
+
+        let task = try await runtime.beginSwap(targetModelID: "new-model")
+        try await task.value
+        let snapshot = await runtime.currentSnapshot()
+
+        XCTAssertEqual(snapshot.state, .ready)
+        XCTAssertEqual(snapshot.modelID, "new-model")
+        XCTAssertEqual(snapshot.modelHash, "new-hash")
+    }
+
+    func testInFlightInferenceUsesOldSnapshot() async throws {
+        let probe = InFlightProbe()
+        let runtime = makeRuntime(modelID: "old-model", modelHash: "old-hash", warmSwapEnabled: true, loader: { target in
+            (target, "new-hash")
+        }, completion: { snapshot, _ in
+            await probe.markStarted(modelID: snapshot.modelID)
+            while await !probe.canFinish {
+                try await Task.sleep(nanoseconds: 5_000_000)
+            }
+            return CompletionResult(content: snapshot.modelID ?? "<nil>", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+        })
+
+        let request = try makeRequest(model: "old-model")
+        let completionTask = Task {
+            try await runtime.complete(request)
+        }
+        try await waitUntil {
+            await probe.startedModelID != nil
+        }
+
+        let swapTask = try await runtime.beginSwap(targetModelID: "new-model")
+        try await swapTask.value
+        let postSwap = await runtime.currentSnapshot()
+        await probe.allowFinish()
+        let completion = try await completionTask.value
+        let startedModelID = await probe.startedModelID
+
+        XCTAssertEqual(startedModelID, "old-model")
+        XCTAssertEqual(postSwap.modelID, "new-model")
+        XCTAssertEqual(completion.content, "old-model")
+    }
+
+    func testLoadFailureRollsBack() async throws {
+        let runtime = makeRuntime(modelID: "old-model", modelHash: "old-hash", warmSwapEnabled: true) { _ in
+            try await Task.sleep(nanoseconds: 50_000_000)
+            throw TestError.loadFailed
+        }
+        var signals = await runtime.swapSignals().makeAsyncIterator()
+
+        let task = try await runtime.beginSwap(targetModelID: "new-model")
+        try await task.value
+        let snapshot = await runtime.currentSnapshot()
+        let signal = await signals.next()
+
+        XCTAssertEqual(snapshot.state, .ready)
+        XCTAssertEqual(snapshot.modelID, "old-model")
+        XCTAssertEqual(snapshot.modelHash, "old-hash")
+        guard case let .failed(reason) = signal?.outcome else {
+            XCTFail("Expected failed signal")
+            return
+        }
+        XCTAssertTrue(reason.contains("loadFailed"))
+    }
+
+    func testNoStarveSnapshotRespondsDuringLoad() async throws {
+        let runtime = makeRuntime(modelID: "old-model", warmSwapEnabled: true) { target in
+            try await Task.sleep(nanoseconds: 100_000_000)
+            return (target, "new-hash")
+        }
+
+        let task = try await runtime.beginSwap(targetModelID: "new-model")
+        for _ in 0 ..< 20 {
+            let start = DispatchTime.now().uptimeNanoseconds
+            _ = await runtime.currentSnapshot()
+            let elapsed = DispatchTime.now().uptimeNanoseconds - start
+            XCTAssertLessThan(elapsed, 10_000_000)
+        }
+        try await task.value
+    }
+
+    func testBootPathDoesNotPassThroughLoading() async throws {
+        let runtime = try await ModelRuntime(modelID: nil)
+
+        let snapshot = await runtime.currentSnapshot()
+
+        XCTAssertEqual(snapshot.state, .ready)
+        XCTAssertNil(snapshot.container)
+        XCTAssertNil(snapshot.modelID)
+    }
+
+    func testSwapDrainTimeoutSurvivesPlumbing() {
+        let runtime = makeRuntime(modelID: nil, warmSwapEnabled: true, swapDrainTimeoutSeconds: 42)
+
+        XCTAssertEqual(runtime.swapDrainTimeoutForTest(), 42)
+    }
+
+    func testWarmSwapConfigUsesCLIOverEnvironmentOverYAML() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(enableWarmSwap: false, swapDrainTimeoutSeconds: 44),
+            environment: [
+                "MACPROVIDER_ENABLE_WARM_SWAP": "true",
+                "MACPROVIDER_SWAP_DRAIN_TIMEOUT_S": "33",
+            ],
+            fileExists: { _ in true },
+            readFile: { _ in "enable_warm_swap: false\nswap_drain_timeout_s: 22\n" }
+        )
+
+        XCTAssertEqual(config.enableWarmSwap, false)
+        XCTAssertEqual(config.swapDrainTimeoutSeconds, 44)
+    }
+
+    func testWarmSwapConfigReadsEnvironmentBeforeYAML() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [
+                "MACPROVIDER_ENABLE_WARM_SWAP": "true",
+                "MACPROVIDER_SWAP_DRAIN_TIMEOUT_S": "33",
+            ],
+            fileExists: { _ in true },
+            readFile: { _ in "enable_warm_swap: false\nswap_drain_timeout_s: 22\n" }
+        )
+
+        XCTAssertEqual(config.enableWarmSwap, true)
+        XCTAssertEqual(config.swapDrainTimeoutSeconds, 33)
+    }
+
+    private func makeRuntime(
+        modelID: String?,
+        modelHash: String? = nil,
+        warmSwapEnabled: Bool,
+        swapDrainTimeoutSeconds: Int = 30,
+        loader: @escaping @Sendable (String) async throws -> (String, String?) = { target in (target, nil) },
+        completion: (@Sendable (RuntimeSnapshot, ChatCompletionRequest) async throws -> CompletionResult)? = nil
+    ) -> ModelRuntime {
+        ModelRuntime(
+            modelID: modelID,
+            modelHash: modelHash,
+            warmSwapEnabled: warmSwapEnabled,
+            swapDrainTimeoutSeconds: swapDrainTimeoutSeconds,
+            loader: { _ in throw TestError.unexpectedContainerLoader },
+            testLoader: loader,
+            testCompletion: completion
+        )
+    }
+
+    private func makeRequest(model: String) throws -> ChatCompletionRequest {
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                [
+                    "role": "user",
+                    "content": "hello",
+                ]
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: body)
+        return try ChatCompletionRequest.parse(data: data)
+    }
+}
+
+private actor InFlightProbe {
+    private var _startedModelID: String?
+    private var _canFinish = false
+
+    var startedModelID: String? { _startedModelID }
+    var canFinish: Bool { _canFinish }
+
+    func markStarted(modelID: String?) {
+        _startedModelID = modelID
+    }
+
+    func allowFinish() {
+        _canFinish = true
+    }
+}
+
+private enum TestError: Error {
+    case unexpectedContainerLoader
+    case loadFailed
+}
+
+private func waitUntil(
+    timeoutNanoseconds: UInt64 = 2_000_000_000,
+    _ predicate: () async -> Bool
+) async throws {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while DispatchTime.now().uptimeNanoseconds < deadline {
+        if await predicate() {
+            return
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    XCTFail("Timed out waiting for condition")
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift
@@ -296,6 +296,113 @@ final class ModelRuntimeSwapTests: XCTestCase {
         XCTAssertEqual(snapshot.modelHash, "new-hash")
     }
 
+    func testHandleAcquiredInReadyStateSurvivesSwapToLoading() async throws {
+        let probe = InFlightProbe()
+        let runtime = makeRuntime(
+            modelID: "old-model",
+            modelHash: "old-hash",
+            warmSwapEnabled: true,
+            loader: { target in
+                try await Task.sleep(nanoseconds: 150_000_000)
+                return (target, "new-hash")
+            },
+            completion: { snapshot, _ in
+                await probe.markStarted(modelID: snapshot.modelID)
+                return CompletionResult(content: snapshot.modelID ?? "<nil>", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        let request = try makeRequest(model: "old-model")
+        let handle = try await runtime.acquireRequestHandle(request)
+
+        do {
+            let swapTask = try await runtime.beginSwap(targetModelID: "new-model")
+            let loadingSnapshot = await runtime.currentSnapshot()
+            XCTAssertEqual(loadingSnapshot.state, .loading)
+
+            try await runtime.preflight(request, with: handle)
+            let completion = try await runtime.stream(request, with: handle) { _ in }
+            let startedModelID = await probe.startedModelID
+
+            await runtime.unregisterInFlight(handle.registrationID)
+            try await swapTask.value
+            XCTAssertEqual(startedModelID, "old-model")
+            XCTAssertEqual(completion.content, "old-model")
+        } catch {
+            await runtime.unregisterInFlight(handle.registrationID)
+            throw error
+        }
+    }
+
+    func testHandleAcquiredInLoadingStateFails() async throws {
+        let runtime = makeRuntime(modelID: "old-model", modelHash: "old-hash", warmSwapEnabled: true) { target in
+            try await Task.sleep(nanoseconds: 100_000_000)
+            return (target, "new-hash")
+        }
+        let swapTask = try await runtime.beginSwap(targetModelID: "new-model")
+        let loadingSnapshot = await runtime.currentSnapshot()
+        XCTAssertEqual(loadingSnapshot.state, .loading)
+
+        do {
+            _ = try await runtime.acquireRequestHandle(try makeRequest(model: "old-model"))
+            XCTFail("Expected provider_loading")
+        } catch let error as APIError {
+            XCTAssertEqual(error.status, 503)
+            XCTAssertEqual(error.code, "provider_loading")
+        }
+
+        try await swapTask.value
+    }
+
+    func testHandleDrainCancellationStillFiresEvenIfStateAlreadyChanged() async throws {
+        let probe = InFlightProbe()
+        let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
+        let runtime = makeRuntime(
+            modelID: "old-model",
+            modelHash: "old-hash",
+            warmSwapEnabled: true,
+            swapDrainTimeoutSeconds: 0,
+            loader: { target in (target, "new-hash") },
+            completion: { snapshot, _ in
+                await probe.markStarted(modelID: snapshot.modelID)
+                try await Task.sleep(nanoseconds: 15_000_000_000)
+                return CompletionResult(content: "too-late", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        await runtime.setProviderStatus(providerStatus)
+        let startedAt = await providerStatus.beginRequest()
+        let request = try makeRequest(model: "old-model")
+        let handle = try await runtime.acquireRequestHandle(request)
+        let streamTask = Task {
+            try await runtime.stream(request, with: handle) { _ in }
+        }
+
+        do {
+            try await waitUntil {
+                await probe.startedModelID != nil
+            }
+            let swapTask = try await runtime.beginSwap(targetModelID: "new-model")
+            try await swapTask.value
+
+            do {
+                _ = try await streamTask.value
+                XCTFail("Expected drain-timeout cancellation")
+            } catch is DrainCancelledError {
+                await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
+            }
+
+            await runtime.unregisterInFlight(handle.registrationID)
+            let snapshot = await runtime.currentSnapshot()
+            XCTAssertEqual(snapshot.state, .ready)
+            XCTAssertEqual(snapshot.modelID, "new-model")
+            XCTAssertEqual(snapshot.modelHash, "new-hash")
+        } catch {
+            await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
+            await runtime.unregisterInFlight(handle.registrationID)
+            streamTask.cancel()
+            throw error
+        }
+    }
+
     func testConcurrentSnapshotsDoNotObserveMixedSwapState() async throws {
         let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
         let runtime = makeRuntime(modelID: "old-model", modelHash: "old-hash", warmSwapEnabled: true) { target in

--- a/phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift
@@ -33,6 +33,7 @@ final class ModelRuntimeSwapTests: XCTestCase {
 
     func testInFlightInferenceUsesOldSnapshot() async throws {
         let probe = InFlightProbe()
+        let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
         let runtime = makeRuntime(modelID: "old-model", modelHash: "old-hash", warmSwapEnabled: true, loader: { target in
             (target, "new-hash")
         }, completion: { snapshot, _ in
@@ -42,6 +43,7 @@ final class ModelRuntimeSwapTests: XCTestCase {
             }
             return CompletionResult(content: snapshot.modelID ?? "<nil>", finishReason: "stop", promptTokens: 1, completionTokens: 1)
         })
+        await runtime.setProviderStatus(providerStatus)
 
         let request = try makeRequest(model: "old-model")
         let completionTask = Task {
@@ -117,6 +119,122 @@ final class ModelRuntimeSwapTests: XCTestCase {
         XCTAssertEqual(runtime.swapDrainTimeoutForTest(), 42)
     }
 
+    func testDrainWaitsForRequestsInFlightBeforeAtomicSwap() async throws {
+        let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
+        let runtime = makeRuntime(modelID: "old-model", modelHash: "old-hash", warmSwapEnabled: true) { target in
+            (target, "new-hash")
+        }
+        await runtime.setProviderStatus(providerStatus)
+        var signals = await runtime.swapSignals().makeAsyncIterator()
+        let requestStartedAt = await providerStatus.beginRequest()
+
+        let task = try await runtime.beginSwap(targetModelID: "new-model")
+        let loadSignal = await signals.next()
+        try await Task.sleep(nanoseconds: 120_000_000)
+        let drainingSnapshot = await runtime.currentSnapshot()
+
+        guard case .loadFinished = loadSignal?.outcome else {
+            XCTFail("Expected loadFinished signal")
+            return
+        }
+        XCTAssertEqual(drainingSnapshot.state, .draining)
+        XCTAssertEqual(drainingSnapshot.modelID, "old-model")
+        XCTAssertEqual(drainingSnapshot.modelHash, "old-hash")
+
+        await providerStatus.finishRequest(startedAt: requestStartedAt, completion: nil, failed: false)
+        try await task.value
+        let completedSignal = await signals.next()
+        let finalSnapshot = await runtime.currentSnapshot()
+
+        guard case let .completed(newModelID, newModelHash) = completedSignal?.outcome else {
+            XCTFail("Expected completed signal")
+            return
+        }
+        XCTAssertEqual(newModelID, "new-model")
+        XCTAssertEqual(newModelHash, "new-hash")
+        XCTAssertEqual(finalSnapshot.state, .ready)
+        XCTAssertEqual(finalSnapshot.modelID, "new-model")
+        XCTAssertEqual(finalSnapshot.modelHash, "new-hash")
+    }
+
+    func testDrainWithNoRequestsInFlightCompletesImmediately() async throws {
+        let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
+        let runtime = makeRuntime(modelID: "old-model", modelHash: "old-hash", warmSwapEnabled: true) { target in
+            (target, "new-hash")
+        }
+        await runtime.setProviderStatus(providerStatus)
+        var signals = await runtime.swapSignals().makeAsyncIterator()
+
+        let task = try await runtime.beginSwap(targetModelID: "new-model")
+        try await task.value
+        let loadSignal = await signals.next()
+        let completedSignal = await signals.next()
+        let finalSnapshot = await runtime.currentSnapshot()
+
+        guard case .loadFinished = loadSignal?.outcome else {
+            XCTFail("Expected loadFinished signal")
+            return
+        }
+        guard case .completed = completedSignal?.outcome else {
+            XCTFail("Expected completed signal")
+            return
+        }
+        XCTAssertEqual(finalSnapshot.state, .ready)
+        XCTAssertEqual(finalSnapshot.modelID, "new-model")
+    }
+
+    func testDrainTimeoutProceedsWithAtomicSwap() async throws {
+        let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
+        let runtime = makeRuntime(
+            modelID: "old-model",
+            modelHash: "old-hash",
+            warmSwapEnabled: true,
+            swapDrainTimeoutSeconds: 0
+        ) { target in
+            (target, "new-hash")
+        }
+        await runtime.setProviderStatus(providerStatus)
+        _ = await providerStatus.beginRequest()
+
+        let task = try await runtime.beginSwap(targetModelID: "new-model")
+        try await task.value
+        let snapshot = await runtime.currentSnapshot()
+
+        XCTAssertEqual(snapshot.state, .ready)
+        XCTAssertEqual(snapshot.modelID, "new-model")
+        XCTAssertEqual(snapshot.modelHash, "new-hash")
+    }
+
+    func testConcurrentSnapshotsDoNotObserveMixedSwapState() async throws {
+        let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
+        let runtime = makeRuntime(modelID: "old-model", modelHash: "old-hash", warmSwapEnabled: true) { target in
+            try await Task.sleep(nanoseconds: 100_000_000)
+            return (target, "new-hash")
+        }
+        await runtime.setProviderStatus(providerStatus)
+        let requestStartedAt = await providerStatus.beginRequest()
+
+        let task = try await runtime.beginSwap(targetModelID: "new-model")
+        var observedMixedSnapshots: [RuntimeSnapshot] = []
+        for _ in 0 ..< 1000 {
+            let snapshot = await runtime.currentSnapshot()
+            if snapshot.state != .ready && snapshot.modelID == "new-model" {
+                observedMixedSnapshots.append(snapshot)
+            }
+            if snapshot.state == .ready && snapshot.modelID == "old-model" {
+                observedMixedSnapshots.append(snapshot)
+            }
+        }
+
+        await providerStatus.finishRequest(startedAt: requestStartedAt, completion: nil, failed: false)
+        try await task.value
+        let finalSnapshot = await runtime.currentSnapshot()
+
+        XCTAssertTrue(observedMixedSnapshots.isEmpty)
+        XCTAssertEqual(finalSnapshot.state, .ready)
+        XCTAssertEqual(finalSnapshot.modelID, "new-model")
+    }
+
     func testWarmSwapConfigUsesCLIOverEnvironmentOverYAML() throws {
         let config = try ConfigLoader.load(
             cli: CLIOverrides(enableWarmSwap: false, swapDrainTimeoutSeconds: 44),
@@ -178,6 +296,15 @@ final class ModelRuntimeSwapTests: XCTestCase {
         ]
         let data = try JSONSerialization.data(withJSONObject: body)
         return try ChatCompletionRequest.parse(data: data)
+    }
+
+    private func makeProviderStatus(modelID: String?, modelHash: String?) -> ProviderStatus {
+        ProviderStatus(
+            modelID: modelID,
+            modelLoaded: modelID != nil,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: 1),
+            modelHash: modelHash
+        )
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift
@@ -205,6 +205,97 @@ final class ModelRuntimeSwapTests: XCTestCase {
         XCTAssertEqual(snapshot.modelHash, "new-hash")
     }
 
+    func testDrainTimeoutCancelsInFlightRequests() async throws {
+        let probe = InFlightProbe()
+        let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
+        let runtime = makeRuntime(
+            modelID: "old-model",
+            modelHash: "old-hash",
+            warmSwapEnabled: true,
+            swapDrainTimeoutSeconds: 5,
+            loader: { target in (target, "new-hash") },
+            completion: { snapshot, _ in
+                await probe.markStarted(modelID: snapshot.modelID)
+                try await Task.sleep(nanoseconds: 15_000_000_000)
+                return CompletionResult(content: "too-late", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        await runtime.setProviderStatus(providerStatus)
+        let startedAt = await providerStatus.beginRequest()
+        let request = try makeRequest(model: "old-model")
+        let completionTask = Task {
+            do {
+                let completion = try await runtime.complete(request)
+                await providerStatus.finishRequest(startedAt: startedAt, completion: completion, failed: false)
+                return completion
+            } catch {
+                await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
+                throw error
+            }
+        }
+        try await waitUntil {
+            await probe.startedModelID != nil
+        }
+
+        let began = Date()
+        let swapTask = try await runtime.beginSwap(targetModelID: "new-model")
+        try await swapTask.value
+
+        do {
+            _ = try await completionTask.value
+            XCTFail("Expected drain-timeout cancellation")
+        } catch is DrainCancelledError {
+            XCTAssertLessThan(Date().timeIntervalSince(began), 5.4)
+        }
+        let snapshot = await runtime.currentSnapshot()
+        XCTAssertEqual(snapshot.state, .ready)
+        XCTAssertEqual(snapshot.modelID, "new-model")
+        XCTAssertEqual(snapshot.modelHash, "new-hash")
+    }
+
+    func testInFlightCompletesIfWithinDrainWindow() async throws {
+        let probe = InFlightProbe()
+        let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
+        let runtime = makeRuntime(
+            modelID: "old-model",
+            modelHash: "old-hash",
+            warmSwapEnabled: true,
+            swapDrainTimeoutSeconds: 5,
+            loader: { target in (target, "new-hash") },
+            completion: { snapshot, _ in
+                await probe.markStarted(modelID: snapshot.modelID)
+                try await Task.sleep(nanoseconds: 2_000_000_000)
+                return CompletionResult(content: snapshot.modelID ?? "<nil>", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        await runtime.setProviderStatus(providerStatus)
+        let startedAt = await providerStatus.beginRequest()
+        let request = try makeRequest(model: "old-model")
+        let completionTask = Task {
+            do {
+                let completion = try await runtime.complete(request)
+                await providerStatus.finishRequest(startedAt: startedAt, completion: completion, failed: false)
+                return completion
+            } catch {
+                await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
+                throw error
+            }
+        }
+        try await waitUntil {
+            await probe.startedModelID != nil
+        }
+
+        let swapTask = try await runtime.beginSwap(targetModelID: "new-model")
+        let completion = try await completionTask.value
+        try await swapTask.value
+        let snapshot = await runtime.currentSnapshot()
+
+        XCTAssertEqual(completion.content, "old-model")
+        XCTAssertEqual(snapshot.state, .ready)
+        XCTAssertEqual(snapshot.modelID, "new-model")
+        XCTAssertEqual(snapshot.modelHash, "new-hash")
+    }
+
     func testConcurrentSnapshotsDoNotObserveMixedSwapState() async throws {
         let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
         let runtime = makeRuntime(modelID: "old-model", modelHash: "old-hash", warmSwapEnabled: true) { target in

--- a/phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift
@@ -1,0 +1,209 @@
+import ArgumentParser
+import Darwin
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class ModelsSubcommandTests: XCTestCase {
+    func testModelsStatusReturnsStatusResponse() async throws {
+        let socketPath = try makeSocketPath()
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "old-model"))
+        try await server.start()
+
+        let command = try ModelsStatusCommand.parse(["--ctl-socket-path", socketPath.path])
+        let capture = await captureOutput {
+            try await command.run()
+        }
+        await server.stop()
+
+        XCTAssertNil(capture.error)
+        XCTAssertTrue(capture.stdout.contains("old-model"))
+        XCTAssertTrue(capture.stdout.contains("status_response"))
+    }
+
+    func testModelsStatusCase1ENOENT() async throws {
+        let socketPath = try makeSocketPath()
+        let command = try ModelsStatusCommand.parse(["--ctl-socket-path", socketPath.path])
+
+        let capture = await captureOutput {
+            try await command.run()
+        }
+
+        XCTAssertEqual(capture.error as? ExitCode, ExitCode(4))
+        XCTAssertTrue(capture.stderr.contains("is not running on this host"))
+        XCTAssertTrue(capture.stderr.contains(socketPath.path))
+    }
+
+    func testModelsStatusCase2ECONNREFUSED() async throws {
+        let socketPath = try makeSocketPath()
+        try FileManager.default.createDirectory(at: socketPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: socketPath.path, contents: Data())
+        let command = try ModelsStatusCommand.parse(["--ctl-socket-path", socketPath.path])
+
+        let capture = await captureOutput {
+            try await command.run()
+        }
+
+        XCTAssertEqual(capture.error as? ExitCode, ExitCode(4))
+        XCTAssertTrue(capture.stderr.contains("stale control socket"))
+    }
+
+    func testModelsListDisabledModePrintsIdleTableAndExitsZero() async throws {
+        let socketPath = try makeSocketPath()
+        let command = try ModelsListCommand.parse([
+            "--ctl-socket-path", socketPath.path,
+            "--model", "old-model",
+        ])
+
+        let capture = await captureOutput {
+            try await command.run()
+        }
+
+        XCTAssertNil(capture.error)
+        XCTAssertTrue(capture.stdout.contains("serve not running; warm-swap disabled"))
+        XCTAssertTrue(capture.stdout.contains("old-model\tidle"))
+        XCTAssertTrue(capture.stderr.contains("macprovider-cli serve is not running on this host"))
+    }
+
+    func testModelsSwitchSuccess() async throws {
+        let socketPath = try makeSocketPath()
+        let runtime = makeRuntime(modelID: "old-model") { target in
+            try await Task.sleep(nanoseconds: 50_000_000)
+            return (target, "hash")
+        }
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: runtime)
+        try await server.start()
+
+        let command = try ModelsSwitchCommand.parse([
+            "new-model",
+            "--supported-models", "old-model,new-model",
+            "--model", "old-model",
+            "--ctl-socket-path", socketPath.path,
+        ])
+        let capture = await captureOutput {
+            try await command.run()
+        }
+        await server.stop()
+
+        XCTAssertNil(capture.error)
+        XCTAssertTrue(capture.stderr.contains("state=loading"))
+        XCTAssertTrue(capture.stderr.contains("state=loaded"))
+    }
+
+    func testModelsSwitchPreFlightRejection() async throws {
+        let socketPath = try makeSocketPath()
+        let command = try ModelsSwitchCommand.parse([
+            "C",
+            "--supported-models", "A,B",
+            "--model", "A",
+            "--ctl-socket-path", socketPath.path,
+        ])
+
+        let capture = await captureOutput {
+            try await command.run()
+        }
+
+        XCTAssertEqual(capture.error as? ExitCode, ExitCode(2))
+        XCTAssertTrue(capture.stderr.contains("switch target C not in --supported-models"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: socketPath.path))
+    }
+
+    func testModelsSwitchConcurrentRejection() async throws {
+        let socketPath = try makeSocketPath()
+        let runtime = makeRuntime(modelID: "old-model") { target in
+            try await Task.sleep(nanoseconds: 300_000_000)
+            return (target, "hash")
+        }
+        let server = ControlSocketServer(socketPath: socketPath, modelRuntime: runtime)
+        try await server.start()
+
+        let first = try await ControlSocketClient.connect(socketPath: socketPath)
+        try await first.send(.statusRequest)
+        _ = try await first.receive(timeout: 1)
+        try await first.send(.switchRequest(targetModelID: "slow-model", requestedAtMs: nowMs()))
+        _ = try await first.receive(timeout: 1)
+        _ = try await first.receive(timeout: 1)
+
+        let command = try ModelsSwitchCommand.parse([
+            "other-model",
+            "--supported-models", "old-model,slow-model,other-model",
+            "--model", "old-model",
+            "--ctl-socket-path", socketPath.path,
+        ])
+        let capture = await captureOutput {
+            try await command.run()
+        }
+
+        await first.close()
+        await server.stop()
+
+        XCTAssertEqual(capture.error as? ExitCode, ExitCode(3))
+        XCTAssertTrue(capture.stderr.contains("provider is already loading slow-model"))
+    }
+
+    private func makeSocketPath() throws -> URL {
+        let dir = URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent("mpm-\(getpid())-\(Int.random(in: 0 ... 999_999))")
+        return dir.appendingPathComponent("ctl.sock")
+    }
+
+    private func makeRuntime(
+        modelID: String?,
+        loader: @escaping @Sendable (String) async throws -> (String, String?) = { target in (target, "hash") }
+    ) -> ModelRuntime {
+        ModelRuntime(
+            modelID: modelID,
+            warmSwapEnabled: true,
+            loader: { _ in throw ModelsSubcommandTestError.unexpectedContainerLoader },
+            testLoader: loader
+        )
+    }
+
+    private func nowMs() -> Int64 {
+        Int64(Date().timeIntervalSince1970 * 1000)
+    }
+}
+
+private enum ModelsSubcommandTestError: Error {
+    case unexpectedContainerLoader
+}
+
+private struct CapturedOutput {
+    let stdout: String
+    let stderr: String
+    let error: Error?
+}
+
+private func captureOutput(_ body: () async throws -> Void) async -> CapturedOutput {
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    let savedStdout = dup(STDOUT_FILENO)
+    let savedStderr = dup(STDERR_FILENO)
+    dup2(stdoutPipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+    dup2(stderrPipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
+
+    let error: Error?
+    do {
+        try await body()
+        error = nil
+    } catch let caught {
+        error = caught
+    }
+
+    fflush(stdout)
+    fflush(stderr)
+    dup2(savedStdout, STDOUT_FILENO)
+    dup2(savedStderr, STDERR_FILENO)
+    close(savedStdout)
+    close(savedStderr)
+    stdoutPipe.fileHandleForWriting.closeFile()
+    stderrPipe.fileHandleForWriting.closeFile()
+
+    let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+    return CapturedOutput(
+        stdout: String(decoding: stdoutData, as: UTF8.self),
+        stderr: String(decoding: stderrData, as: UTF8.self),
+        error: error
+    )
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift
@@ -79,6 +79,7 @@ final class ModelsSubcommandTests: XCTestCase {
             "--supported-models", "old-model,new-model",
             "--model", "old-model",
             "--ctl-socket-path", socketPath.path,
+            "--switch-state-path", makeStatePath().path,
         ])
         let capture = await captureOutput {
             try await command.run()
@@ -87,7 +88,46 @@ final class ModelsSubcommandTests: XCTestCase {
 
         XCTAssertNil(capture.error)
         XCTAssertTrue(capture.stderr.contains("state=loading"))
+        XCTAssertTrue(capture.stderr.contains("state=draining"))
         XCTAssertTrue(capture.stderr.contains("state=loaded"))
+    }
+
+    func testModelsSwitchReportsDrainingWhileInFlightRequestFinishes() async throws {
+        let socketPath = try makeSocketPath()
+        let providerStatus = makeProviderStatus(modelID: "old-model", modelHash: "old-hash")
+        let requestStartedAt = await providerStatus.beginRequest()
+        let runtime = makeRuntime(modelID: "old-model") { target in
+            (target, "hash")
+        }
+        await runtime.setProviderStatus(providerStatus)
+        let server = ControlSocketServer(
+            socketPath: socketPath,
+            modelRuntime: runtime,
+            supportedModels: ["old-model", "new-model"]
+        )
+        try await server.start()
+
+        let command = try ModelsSwitchCommand.parse([
+            "new-model",
+            "--supported-models", "old-model,new-model",
+            "--model", "old-model",
+            "--ctl-socket-path", socketPath.path,
+            "--switch-state-path", makeStatePath().path,
+        ])
+        let release = Task {
+            try await Task.sleep(nanoseconds: 250_000_000)
+            await providerStatus.finishRequest(startedAt: requestStartedAt, completion: nil, failed: false)
+        }
+        let capture = await captureOutput {
+            try await command.run()
+        }
+        try await release.value
+        await server.stop()
+
+        XCTAssertNil(capture.error)
+        XCTAssertTrue(capture.stderr.contains("switch_progress state=loading"))
+        XCTAssertTrue(capture.stderr.contains("switch_progress state=draining"))
+        XCTAssertTrue(capture.stderr.contains("switch_progress state=loaded"))
     }
 
     func testModelsSwitchPreFlightRejection() async throws {
@@ -106,6 +146,27 @@ final class ModelsSubcommandTests: XCTestCase {
         XCTAssertEqual(capture.error as? ExitCode, ExitCode(2))
         XCTAssertTrue(capture.stderr.contains("switch target C not in --supported-models"))
         XCTAssertFalse(FileManager.default.fileExists(atPath: socketPath.path))
+    }
+
+    func testServerSideRejectsSwitchWhenNotInSupportedModels() async throws {
+        let socketPath = try makeSocketPath()
+        let server = ControlSocketServer(
+            socketPath: socketPath,
+            modelRuntime: makeRuntime(modelID: "A"),
+            supportedModels: ["A", "B"]
+        )
+        try await server.start()
+
+        let connection = try await ControlSocketClient.connect(socketPath: socketPath)
+        try await connection.send(.switchRequest(targetModelID: "C", requestedAtMs: nowMs()))
+        let response = try await connection.receive(timeout: 1)
+        await connection.close()
+        await server.stop()
+
+        XCTAssertEqual(
+            response,
+            .switchAck(accepted: false, reason: .notInSupportedModels, currentTarget: nil, secondsRemaining: nil)
+        )
     }
 
     func testModelsSwitchConcurrentRejection() async throws {
@@ -147,6 +208,12 @@ final class ModelsSubcommandTests: XCTestCase {
         return dir.appendingPathComponent("ctl.sock")
     }
 
+    private func makeStatePath() -> URL {
+        URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent("mpm-state-\(getpid())-\(Int.random(in: 0 ... 999_999))")
+            .appendingPathComponent("last-switch.ts")
+    }
+
     private func makeRuntime(
         modelID: String?,
         loader: @escaping @Sendable (String) async throws -> (String, String?) = { target in (target, "hash") }
@@ -156,6 +223,15 @@ final class ModelsSubcommandTests: XCTestCase {
             warmSwapEnabled: true,
             loader: { _ in throw ModelsSubcommandTestError.unexpectedContainerLoader },
             testLoader: loader
+        )
+    }
+
+    private func makeProviderStatus(modelID: String?, modelHash: String?) -> ProviderStatus {
+        ProviderStatus(
+            modelID: modelID,
+            modelLoaded: modelID != nil,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: 1),
+            modelHash: modelHash
         )
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/RuntimeStateMachineTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/RuntimeStateMachineTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import macprovider_cli
+
+final class RuntimeStateMachineTests: XCTestCase {
+    func testInitialStateIsReady() async {
+        let machine = RuntimeStateMachine()
+
+        let state = await machine.current()
+
+        XCTAssertEqual(state, .ready)
+    }
+
+    func testTransitionToLoadingFromReady() async throws {
+        let machine = RuntimeStateMachine()
+
+        try await machine.transitionToLoading(target: "mlx-community/Test")
+
+        let state = await machine.current()
+        let target = await machine.currentTargetModelID()
+        XCTAssertEqual(state, .loading)
+        XCTAssertEqual(target, "mlx-community/Test")
+    }
+
+    func testTransitionToLoadingFromLoadingRejected() async throws {
+        let machine = RuntimeStateMachine()
+        try await machine.transitionToLoading(target: "first")
+
+        do {
+            try await machine.transitionToLoading(target: "second")
+            XCTFail("Expected notReady")
+        } catch let error as RuntimeStateMachineError {
+            XCTAssertEqual(error, .notReady(current: .loading))
+        }
+    }
+
+    func testCompleteSwapTransitionsToReady() async throws {
+        let machine = RuntimeStateMachine()
+        try await machine.transitionToLoading(target: "target")
+
+        await machine.completeSwap(newModelID: "target", newModelHash: "hash")
+
+        let state = await machine.current()
+        let target = await machine.currentTargetModelID()
+        XCTAssertEqual(state, .ready)
+        XCTAssertNil(target)
+    }
+
+    func testFailSwapTransitionsToReadyViaFailed() async throws {
+        let machine = RuntimeStateMachine()
+        var signals = await machine.signalStream().makeAsyncIterator()
+        try await machine.transitionToLoading(target: "target")
+
+        await machine.failSwap(reason: "load failed")
+
+        let signal = await signals.next()
+        let state = await machine.current()
+        XCTAssertEqual(state, .ready)
+        guard case let .failed(reason) = signal?.outcome, reason == "load failed" else {
+            XCTFail("Expected failed signal")
+            return
+        }
+    }
+
+    func testSignalCompleted() async throws {
+        let machine = RuntimeStateMachine()
+        var signals = await machine.signalStream().makeAsyncIterator()
+        try await machine.transitionToLoading(target: "target")
+
+        await machine.completeSwap(newModelID: "target", newModelHash: "hash")
+
+        let signal = await signals.next()
+        XCTAssertEqual(signal?.targetModelID, "target")
+        guard case let .completed(newModelID, newModelHash) = signal?.outcome,
+              newModelID == "target",
+              newModelHash == "hash"
+        else {
+            XCTFail("Expected completed signal")
+            return
+        }
+    }
+
+    func testSignalFailed() async throws {
+        let machine = RuntimeStateMachine()
+        var signals = await machine.signalStream().makeAsyncIterator()
+        try await machine.transitionToLoading(target: "target")
+
+        await machine.failSwap(reason: "boom")
+
+        let signal = await signals.next()
+        XCTAssertEqual(signal?.targetModelID, "target")
+        guard case let .failed(reason) = signal?.outcome, reason == "boom" else {
+            XCTFail("Expected failed signal")
+            return
+        }
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/RuntimeStateMachineTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/RuntimeStateMachineTests.swift
@@ -3,94 +3,151 @@ import XCTest
 
 final class RuntimeStateMachineTests: XCTestCase {
     func testInitialStateIsReady() async {
-        let machine = RuntimeStateMachine()
+        let runtime = makeRuntime(modelID: "ready-model", warmSwapEnabled: true)
 
-        let state = await machine.current()
+        let snapshot = await runtime.currentSnapshot()
 
-        XCTAssertEqual(state, .ready)
+        XCTAssertEqual(snapshot.state, .ready)
+        XCTAssertEqual(snapshot.modelID, "ready-model")
     }
 
-    func testTransitionToLoadingFromReady() async throws {
-        let machine = RuntimeStateMachine()
+    func testBeginSwapTransitionsToLoading() async throws {
+        let gate = RuntimeStateGate()
+        let runtime = makeRuntime(modelID: "old-model", warmSwapEnabled: true) { target in
+            await gate.markLoaderStarted()
+            try await gate.waitUntilReleased()
+            return (target, "hash")
+        }
 
-        try await machine.transitionToLoading(target: "mlx-community/Test")
+        let task = try await runtime.beginSwap(targetModelID: "new-model")
+        try await waitUntil { await gate.loaderStarted }
 
-        let state = await machine.current()
-        let target = await machine.currentTargetModelID()
-        XCTAssertEqual(state, .loading)
-        XCTAssertEqual(target, "mlx-community/Test")
+        let snapshot = await runtime.currentSnapshot()
+        XCTAssertEqual(snapshot.state, .loading)
+        XCTAssertEqual(snapshot.modelID, "old-model")
+
+        await gate.release()
+        try await task.value
     }
 
-    func testTransitionToLoadingFromLoadingRejected() async throws {
-        let machine = RuntimeStateMachine()
-        try await machine.transitionToLoading(target: "first")
+    func testBeginSwapRejectsWhenLoading() async throws {
+        let gate = RuntimeStateGate()
+        let runtime = makeRuntime(modelID: "old-model", warmSwapEnabled: true) { target in
+            await gate.markLoaderStarted()
+            try await gate.waitUntilReleased()
+            return (target, "hash")
+        }
+
+        let task = try await runtime.beginSwap(targetModelID: "first")
+        try await waitUntil { await gate.loaderStarted }
 
         do {
-            try await machine.transitionToLoading(target: "second")
+            _ = try await runtime.beginSwap(targetModelID: "second")
             XCTFail("Expected notReady")
         } catch let error as RuntimeStateMachineError {
             XCTAssertEqual(error, .notReady(current: .loading))
         }
+
+        await gate.release()
+        try await task.value
     }
 
-    func testCompleteSwapTransitionsToReady() async throws {
-        let machine = RuntimeStateMachine()
-        try await machine.transitionToLoading(target: "target")
+    func testLoadFinishedAndCompletedSignals() async throws {
+        let runtime = makeRuntime(modelID: "old-model", warmSwapEnabled: true) { target in
+            (target, "hash")
+        }
+        var signals = await runtime.swapSignals().makeAsyncIterator()
 
-        await machine.completeSwap(newModelID: "target", newModelHash: "hash")
+        let task = try await runtime.beginSwap(targetModelID: "target")
+        let first = await signals.next()
+        let second = await signals.next()
+        try await task.value
 
-        let state = await machine.current()
-        let target = await machine.currentTargetModelID()
-        XCTAssertEqual(state, .ready)
-        XCTAssertNil(target)
-    }
-
-    func testFailSwapTransitionsToReadyViaFailed() async throws {
-        let machine = RuntimeStateMachine()
-        var signals = await machine.signalStream().makeAsyncIterator()
-        try await machine.transitionToLoading(target: "target")
-
-        await machine.failSwap(reason: "load failed")
-
-        let signal = await signals.next()
-        let state = await machine.current()
-        XCTAssertEqual(state, .ready)
-        guard case let .failed(reason) = signal?.outcome, reason == "load failed" else {
-            XCTFail("Expected failed signal")
+        XCTAssertEqual(first?.targetModelID, "target")
+        guard case .loadFinished = first?.outcome else {
+            XCTFail("Expected loadFinished signal")
             return
         }
-    }
-
-    func testSignalCompleted() async throws {
-        let machine = RuntimeStateMachine()
-        var signals = await machine.signalStream().makeAsyncIterator()
-        try await machine.transitionToLoading(target: "target")
-
-        await machine.completeSwap(newModelID: "target", newModelHash: "hash")
-
-        let signal = await signals.next()
-        XCTAssertEqual(signal?.targetModelID, "target")
-        guard case let .completed(newModelID, newModelHash) = signal?.outcome,
-              newModelID == "target",
-              newModelHash == "hash"
-        else {
+        guard case let .completed(newModelID, newModelHash) = second?.outcome else {
             XCTFail("Expected completed signal")
             return
         }
+        XCTAssertEqual(newModelID, "target")
+        XCTAssertEqual(newModelHash, "hash")
     }
 
-    func testSignalFailed() async throws {
-        let machine = RuntimeStateMachine()
-        var signals = await machine.signalStream().makeAsyncIterator()
-        try await machine.transitionToLoading(target: "target")
+    func testFailSwapTransitionsToReadyAndSignalsFailure() async throws {
+        let runtime = makeRuntime(modelID: "old-model", modelHash: "old-hash", warmSwapEnabled: true) { _ in
+            throw RuntimeStateTestError.loadFailed
+        }
+        var signals = await runtime.swapSignals().makeAsyncIterator()
 
-        await machine.failSwap(reason: "boom")
+        let task = try await runtime.beginSwap(targetModelID: "target")
+        try await task.value
 
+        let snapshot = await runtime.currentSnapshot()
         let signal = await signals.next()
-        XCTAssertEqual(signal?.targetModelID, "target")
-        guard case let .failed(reason) = signal?.outcome, reason == "boom" else {
+        XCTAssertEqual(snapshot.state, .ready)
+        XCTAssertEqual(snapshot.modelID, "old-model")
+        XCTAssertEqual(snapshot.modelHash, "old-hash")
+        guard case let .failed(reason) = signal?.outcome, reason.contains("loadFailed") else {
             XCTFail("Expected failed signal")
             return
         }
     }
+
+    private func makeRuntime(
+        modelID: String?,
+        modelHash: String? = nil,
+        warmSwapEnabled: Bool,
+        loader: @escaping @Sendable (String) async throws -> (String, String?) = { target in (target, nil) }
+    ) -> ModelRuntime {
+        ModelRuntime(
+            modelID: modelID,
+            modelHash: modelHash,
+            warmSwapEnabled: warmSwapEnabled,
+            loader: { _ in throw RuntimeStateTestError.unexpectedContainerLoader },
+            testLoader: loader
+        )
+    }
+}
+
+private actor RuntimeStateGate {
+    private var started = false
+    private var released = false
+
+    var loaderStarted: Bool { started }
+
+    func markLoaderStarted() {
+        started = true
+    }
+
+    func release() {
+        released = true
+    }
+
+    func waitUntilReleased() async throws {
+        while !released {
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+}
+
+private enum RuntimeStateTestError: Error {
+    case unexpectedContainerLoader
+    case loadFailed
+}
+
+private func waitUntil(
+    timeoutNanoseconds: UInt64 = 2_000_000_000,
+    _ predicate: () async -> Bool
+) async throws {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while DispatchTime.now().uptimeNanoseconds < deadline {
+        if await predicate() {
+            return
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    XCTFail("Timed out waiting for condition")
 }

--- a/phase3-binary/Tests/macprovider-cliTests/SupportedModelsTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/SupportedModelsTests.swift
@@ -1,0 +1,124 @@
+import ArgumentParser
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+final class SupportedModelsTests: XCTestCase {
+    func testParseCSVNilInput() {
+        XCTAssertNil(SupportedModels.parseCSV(nil))
+        XCTAssertNil(SupportedModels.parseCSV(""))
+        XCTAssertNil(SupportedModels.parseCSV("   \n\t  "))
+    }
+
+    func testParseCSVTrimsAndDropsEmpty() {
+        XCTAssertEqual(SupportedModels.parseCSV(" A , ,B,  "), ["A", "B"])
+    }
+
+    func testValidateDefaultsToSingleEntry() throws {
+        XCTAssertEqual(try SupportedModels.validate(model: "A", supportedModels: nil), ["A"])
+    }
+
+    func testValidateDefaultSingleEntryPreservesCase() throws {
+        XCTAssertEqual(try SupportedModels.validate(model: "MlX/Foo", supportedModels: nil), ["MlX/Foo"])
+    }
+
+    func testValidateRejectsMissingModel() {
+        XCTAssertThrowsError(try SupportedModels.validate(model: "", supportedModels: nil)) { error in
+            XCTAssertEqual(error as? SupportedModelsValidationError, .modelMissing)
+        }
+    }
+
+    func testValidateAcceptsCaseFoldedMatch() throws {
+        XCTAssertEqual(
+            try SupportedModels.validate(model: "MLX/FOO", supportedModels: ["mlx/foo", "B"]),
+            ["mlx/foo", "B"]
+        )
+    }
+
+    func testValidateRejectsModelNotInCatalog() {
+        XCTAssertThrowsError(try SupportedModels.validate(model: "C", supportedModels: ["A", "B"])) { error in
+            XCTAssertEqual(
+                error as? SupportedModelsValidationError,
+                .modelNotInCatalog(model: "C", catalog: ["A", "B"])
+            )
+            XCTAssertTrue("\(error)".contains("--model C not in --supported-models"))
+        }
+    }
+
+    func testValidateRejectsTooLongEntry() {
+        let entry = String(repeating: "a", count: 257)
+        XCTAssertThrowsError(try SupportedModels.validate(model: "A", supportedModels: ["A", entry])) { error in
+            XCTAssertEqual(
+                error as? SupportedModelsValidationError,
+                .entryTooLong(entry: entry, byteCount: 257)
+            )
+            XCTAssertTrue("\(error)".contains("--supported-models entry exceeds 256 UTF-8 bytes"))
+        }
+    }
+
+    func testValidateRejectsTooManyEntries() {
+        let catalog = (0..<65).map { "model-\($0)" }
+        XCTAssertThrowsError(try SupportedModels.validate(model: "model-0", supportedModels: catalog)) { error in
+            XCTAssertEqual(error as? SupportedModelsValidationError, .catalogTooLarge(count: 65))
+            XCTAssertTrue("\(error)".contains("exceeds 64 entries"))
+        }
+    }
+
+    func testValidateCountsUTF8BytesNotCharacters() {
+        let entry = String(repeating: "😀", count: 65)
+        XCTAssertThrowsError(try SupportedModels.validate(model: "A", supportedModels: ["A", entry])) { error in
+            XCTAssertEqual(
+                error as? SupportedModelsValidationError,
+                .entryTooLong(entry: entry, byteCount: 260)
+            )
+        }
+    }
+
+    func testServeCommandSkipsPreflightWhenSupportedModelsUnset() throws {
+        // SPEC-001 v1.3 AC-N.0: bare `serve` must not trip the SPEC-010
+        // operator-provided catalog pre-flight when supported_models is unset.
+        var config = AppConfig.defaults()
+        config.model = nil
+        config.supportedModels = nil
+
+        try ServeCommand.runSupportedModelsPreflight(&config)
+
+        XCTAssertNil(config.model)
+        XCTAssertNil(config.supportedModels)
+    }
+
+    func testServeCommandPreflightExits2WhenSupportedModelsSetWithoutModel() {
+        var config = AppConfig.defaults()
+        config.model = nil
+        config.supportedModels = ["A"]
+
+        XCTAssertThrowsError(try ServeCommand.runSupportedModelsPreflight(&config)) { error in
+            XCTAssertEqual(error as? ExitCode, ExitCode(2))
+        }
+    }
+
+    func testServeCommandPreflightSkipsWhenOnlyModelSet() throws {
+        var config = AppConfig.defaults()
+        config.model = "A"
+        config.supportedModels = nil
+
+        try ServeCommand.runSupportedModelsPreflight(&config)
+
+        XCTAssertEqual(config.model, "A")
+        XCTAssertNil(config.supportedModels)
+    }
+
+    func testServeCommandExits2WhenModelNotInSupportedModels() async throws {
+        let command = try ServeCommand.parse([
+            "--model", "C",
+            "--supported-models", "A,B",
+        ])
+
+        do {
+            try await command.run()
+            XCTFail("expected pre-flight validation to fail before runtime startup")
+        } catch let error as ExitCode {
+            XCTAssertEqual(error, ExitCode(2))
+        }
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/SupportedModelsTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/SupportedModelsTests.swift
@@ -121,4 +121,44 @@ final class SupportedModelsTests: XCTestCase {
             XCTAssertEqual(error, ExitCode(2))
         }
     }
+
+    func testServeCommandExits2WhenDrainTimeoutBelowMinimum() {
+        assertDrainTimeoutRejected(4)
+    }
+
+    func testServeCommandExits2WhenDrainTimeoutAboveMaximum() {
+        assertDrainTimeoutRejected(601)
+    }
+
+    func testServeCommandExits2WhenDrainTimeoutIsNegative() {
+        assertDrainTimeoutRejected(-1)
+    }
+
+    func testServeCommandAllowsDrainTimeoutMinimumBoundary() throws {
+        try assertDrainTimeoutAccepted(5)
+    }
+
+    func testServeCommandAllowsDrainTimeoutDefault() throws {
+        try assertDrainTimeoutAccepted(30)
+    }
+
+    func testServeCommandAllowsDrainTimeoutMaximumBoundary() throws {
+        try assertDrainTimeoutAccepted(600)
+    }
+
+    private func assertDrainTimeoutRejected(_ value: Int) {
+        var config = AppConfig.defaults()
+        config.swapDrainTimeoutSeconds = value
+
+        XCTAssertThrowsError(try ServeCommand.runDrainTimeoutPreflight(config)) { error in
+            XCTAssertEqual(error as? ExitCode, ExitCode(2))
+        }
+    }
+
+    private func assertDrainTimeoutAccepted(_ value: Int) throws {
+        var config = AppConfig.defaults()
+        config.swapDrainTimeoutSeconds = value
+
+        try ServeCommand.runDrainTimeoutPreflight(config)
+    }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/SwitchStateStoreTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/SwitchStateStoreTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class SwitchStateStoreTests: XCTestCase {
+    func testReadReturnsNilWhenFileMissing() throws {
+        let store = SwitchStateStore(path: try makeStatePath())
+
+        XCTAssertNil(store.readLastSwitchMs())
+    }
+
+    func testReadReturnsNilWhenFileCorrupt() throws {
+        let path = try makeStatePath()
+        try FileManager.default.createDirectory(at: path.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "not a number".write(to: path, atomically: false, encoding: .utf8)
+
+        XCTAssertNil(SwitchStateStore(path: path).readLastSwitchMs())
+    }
+
+    func testWriteAndReadRoundTrip() throws {
+        let store = SwitchStateStore(path: try makeStatePath())
+
+        try store.writeLastSwitchMs(1_717_696_989_123)
+
+        XCTAssertEqual(store.readLastSwitchMs(), 1_717_696_989_123)
+    }
+
+    func testWriteCreatesParentDirectory() throws {
+        let dir = try makeTempDirectory().appendingPathComponent("missing/grandparent")
+        let store = SwitchStateStore(path: dir.appendingPathComponent("last-switch.ts"))
+
+        try store.writeLastSwitchMs(42)
+
+        XCTAssertEqual(store.readLastSwitchMs(), 42)
+    }
+
+    func testWriteIsAtomic() throws {
+        let path = try makeStatePath()
+        let store = SwitchStateStore(path: path)
+
+        try store.writeLastSwitchMs(1)
+        try store.writeLastSwitchMs(2)
+
+        XCTAssertEqual(store.readLastSwitchMs(), 2)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path.path + ".tmp"))
+    }
+
+    func testCooldownDecisionClearWhenNeverSet() throws {
+        let store = SwitchStateStore(path: try makeStatePath())
+
+        XCTAssertEqual(store.cooldownDecision(now: 1_000), .clear)
+    }
+
+    func testCooldownDecisionClearWhenWellOutsideWindow() throws {
+        let store = SwitchStateStore(path: try makeStatePath())
+        try store.writeLastSwitchMs(0)
+
+        XCTAssertEqual(store.cooldownDecision(now: 1_000_000), .clear)
+    }
+
+    func testCooldownDecisionCooldownWhenInsideWindow() throws {
+        let store = SwitchStateStore(path: try makeStatePath())
+        try store.writeLastSwitchMs(1_000_000)
+
+        XCTAssertEqual(store.cooldownDecision(now: 1_005_000), .cooldown(secondsRemaining: 5))
+    }
+
+    func testCooldownDecisionCooldownWhenJustInsideWindow() throws {
+        let store = SwitchStateStore(path: try makeStatePath())
+        try store.writeLastSwitchMs(1_000_000)
+
+        XCTAssertEqual(store.cooldownDecision(now: 1_009_999), .cooldown(secondsRemaining: 1))
+    }
+
+    func testCooldownDecisionClearAtExactlyWindowBoundary() throws {
+        let store = SwitchStateStore(path: try makeStatePath())
+        try store.writeLastSwitchMs(1_000_000)
+
+        XCTAssertEqual(store.cooldownDecision(now: 1_010_000), .clear)
+    }
+
+    func testCustomCooldownWindow() throws {
+        let store = SwitchStateStore(path: try makeStatePath(), cooldownWindowMs: 5_000)
+        try store.writeLastSwitchMs(1_000_000)
+
+        XCTAssertEqual(store.cooldownDecision(now: 1_004_999), .cooldown(secondsRemaining: 1))
+        XCTAssertEqual(store.cooldownDecision(now: 1_005_000), .clear)
+    }
+
+    private func makeStatePath() throws -> URL {
+        try makeTempDirectory().appendingPathComponent("last-switch.ts")
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let dir = URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent("mpm-switch-state-\(getpid())-\(Int.random(in: 0 ... 999_999))")
+        try? FileManager.default.removeItem(at: dir)
+        return dir
+    }
+}

--- a/specs/AUDIT_SPEC_001_v1_3_IMPL_PR5_PROMPT.md
+++ b/specs/AUDIT_SPEC_001_v1_3_IMPL_PR5_PROMPT.md
@@ -1,0 +1,434 @@
+# Pre-merge audit prompt — PR #5 (SPEC-001 v1.3 Phase 1A-1E implementation)
+
+Operator-paste prompt for Codex GPT-5 to perform an end-to-end
+**code review + security review + architecture review** on
+[Augustas11/macprovider#5](https://github.com/Augustas11/macprovider/pull/5)
+before squash-merge. This is the external adversarial pass that
+complements the per-phase internal audits Claude Opus ran during
+implementation.
+
+PR #5 carries five commits implementing SPEC-001 v1.3 Phase 1
+(binary surface):
+
+| Commit | Phase | Scope |
+|---|---|---|
+| 6744d7c | 1A | SPEC-010 catalog flags + `SupportedModels` + v2 `auth_request` field plumbing |
+| 5c03e88 | 1B | Warm-swap gate + `RuntimeStateMachine` + `ModelRuntime` actor refactor + HTTP 503 wiring |
+| 9a4a6c5 | 1C | `ControlSocket` (NDJSON on Unix-domain socket) + `models` subcommand + R-3.1.5.x detection precedence |
+| 3c1da34 | 1D | Heartbeat opt-in fields (`model_hash` + `loading`) + `hello.model_hash` source-of-truth on WS reconnect |
+| 5d013f5 | 1E | Cooldown soft guard + `--force` semantics + end-to-end AC matrix |
+
+131 tests pass. Internal audits surfaced only one finding (M.1 on
+1A R1, fixed in R2). The operator wants an independent
+adversarial pass before merging — looking for what the internal
+audit may have missed.
+
+Run via `omc ask codex` from session root
+`/Users/augstar/macprovider-poc`. Expected wall-clock: ~30-60 min.
+This is a READ-ONLY review — Codex MUST NOT modify any file. Do
+not commit, do not push, do not create branches.
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are performing an adversarial pre-merge review of PR #5 in
+the Augustas11/macprovider repository. The PR implements SPEC-001
+v1.3 binary surface across five commits on branch
+`fix/spec-001-v1-3-binary`. The branch is already checked out at
+`/Users/augstar/macprovider-poc`.
+
+This is a **read-only review**. You MUST NOT edit any file,
+commit, push, or modify the git state in any way. Your only
+output is the structured findings report at the end.
+
+## Context
+
+The repository hosts the Mac Provider stack for AntFeed (the P2P
+AI marketplace on Base). The codebase under `phase3-binary/`
+ships as a signed macOS binary to operator hardware (Mac Minis,
+Mac Studios). Operators run this binary to serve inference
+requests from buyers and earn USDC on Base.
+
+This PR adds:
+- SPEC-010 v1.5 capability advertisement (which models a provider
+  can serve)
+- SPEC-011 v0.5 operator-pushed warm model swap (change the served
+  model without a multi-minute restart loop)
+
+The binary's threat model:
+- Operator is trusted (they own the hardware)
+- Coordinator (`coordinator.streamvc.live`) is trusted
+- Buyers are UNTRUSTED (they send arbitrary inference requests
+  over the WS-tunneled path)
+- Local processes other than `macprovider-cli` are UNTRUSTED
+  (the control socket is local-only at
+  `$TMPDIR/macprovider-cli/ctl.sock`)
+- Filesystem state files (`last-switch.ts`) are NOT
+  security-sensitive (no secrets, no auth tokens)
+
+The binary handles money-path-adjacent code (heartbeats and hellos
+to the coordinator determine billing eligibility; a malformed
+heartbeat could cost an operator real USDC).
+
+## Required reading (in this order)
+
+1. The five commits via `git log --oneline main..HEAD` and
+   `git show <commit>` for each. Read the full diff of each
+   commit; the commit messages contain the binding R-rules.
+
+2. The five BUILD prompts that produced the code:
+   - `specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1A_PROMPT.md`
+   - `specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1A_R2_PROMPT.md` (the
+     M.1 fix prompt)
+   - `specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1B_PROMPT.md`
+   - `specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1C_PROMPT.md`
+   - `specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1D_PROMPT.md`
+   - `specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1E_PROMPT.md`
+
+3. The locked specs (READ-ONLY, do not edit):
+   - `specs/SPEC-001-phase3-binary.md` v1.3 — full file
+   - `specs/SPEC-010-model-catalog.md` v1.5 — full file
+   - `specs/SPEC-011-operator-pushed-warm-swap.md` v0.5 — full
+     file
+   - `specs/SPEC-002-coordinator.md` v1.3.5 — focus on §3, §7.1,
+     §7.8, §7.10 to verify the binary-side doesn't contradict
+     coordinator expectations
+
+4. The implementation files under `phase3-binary/`:
+   - `Sources/MacProviderCore/SupportedModels.swift`
+   - `Sources/MacProviderCore/Config.swift`
+   - `Sources/macprovider-cli/RuntimeStateMachine.swift`
+   - `Sources/macprovider-cli/ModelRuntime.swift`
+   - `Sources/macprovider-cli/CoordinatorClient.swift`
+   - `Sources/macprovider-cli/HTTPServer.swift`
+   - `Sources/macprovider-cli/ControlSocket.swift`
+   - `Sources/macprovider-cli/ModelsSubcommand.swift`
+   - `Sources/macprovider-cli/MacProviderCLI.swift`
+   - `Sources/macprovider-cli/SwitchStateStore.swift`
+
+5. The test files:
+   - `Tests/macprovider-cliTests/*.swift` — all of them
+
+6. The repo's per-project guidance:
+   - `CLAUDE.md` at the repo root
+
+DO NOT inspect any file under `phase3-binary/.build/checkouts/`
+(d-inference and other third-party code is strictly clean-room
+per the CLAUDE.md rule).
+
+## Three review dimensions
+
+You will produce findings in three distinct categories. A single
+issue may surface in multiple categories — list it once in the
+PRIMARY category and cross-reference from the others.
+
+### Dimension 1: CODE REVIEW
+
+Focus areas:
+- **Correctness** — does the code do what the spec rules say it
+  should? Look for bugs the unit tests may have missed.
+- **Concurrency** — Swift actor isolation, `Task.detached`
+  discipline, cancellation propagation, suspension points,
+  reentrancy issues. The `ModelRuntime` actor is the hottest
+  surface; check that `currentSnapshot()` never blocks the
+  serial executor for long, that the load `Task.detached` in
+  `beginSwap` doesn't accidentally close over actor state in a
+  racy way, that `swapHeartbeatTask` and `ControlSocketServer`'s
+  accept loop don't compete for the same actor.
+- **Error handling** — are throws caught at the right layer?
+  Are non-fatal errors logged-and-continued vs surfaced to the
+  caller correctly? (E.g., `SwitchStateStore.writeLastSwitchMs`
+  failure is non-fatal per the spec — verify.)
+- **Resource lifecycle** — file descriptors (Unix-domain socket
+  fds), `Task` cleanup on `stop()` / cancellation, `AsyncStream`
+  continuation teardown, MLX `ModelContainer` releases on swap.
+  Look for fd leaks, task leaks, retain cycles via
+  `[weak self]` discipline.
+- **Idiom violations** — Swift `actor` reentrancy gotchas,
+  `Sendable` conformance correctness (look for
+  `@unchecked Sendable` and verify it's justified),
+  `JSONSerialization` vs `Codable` consistency.
+- **Test quality** — do the tests actually exercise the
+  invariants their names suggest, or are they
+  passing-by-coincidence? Look for tests that only assert on
+  the *implementation* rather than the *observable behavior*.
+  Look for sleep-based timing assertions that could flake.
+
+Findings format:
+```
+[code:N.M] [SEVERITY] <short title>
+  File: <path>:<line>
+  What: <one-paragraph description of the issue>
+  Why: <impact — what breaks, when, and how bad>
+  Fix: <suggested remediation; cite the binding spec rule if
+        applicable>
+```
+
+### Dimension 2: SECURITY REVIEW
+
+Threat model recap:
+- Trust boundaries: operator (trusted), coordinator (trusted),
+  buyer / inference requests (untrusted), other local processes
+  (untrusted)
+- High-value secrets: ECDH private key (in-memory only via
+  `Tier2ProviderSession`), MDA artifact (read-only, on disk),
+  the operator's USDC-earning wallet (NOT touched by this
+  binary)
+- Asset categories:
+  - Wire bytes to coordinator (could enable billing manipulation
+    if forgeable)
+  - Inference traffic (could leak operator data if the path is
+    coerced)
+  - Local control socket (could enable an unauthorized local
+    process to push swap commands)
+  - Cooldown state file (low value; no secrets)
+
+Focus areas:
+- **Path traversal / TOCTOU** — `--ctl-socket-path` and
+  `--switch-state-path` are operator-supplied; what if they
+  contain `..`, are symlinks, or point to attacker-controlled
+  paths? Does the binary follow the symlink and write through
+  it? Is the operator-CLI vs serve-side identity gap exploitable?
+- **Unix-domain socket permissions** — the spec mandates parent
+  dir `0700` and socket `0600`. Verify:
+  - The parent dir is chmod 0700 even if it pre-existed with
+    laxer permissions (`mkdir -p` followed by `chmod 0700`).
+  - The socket file itself is `0600` after bind (Codex uses
+    `chmod(socketPath.path, S_IRUSR | S_IWUSR)` after bind —
+    is there a window where the socket is `0666` for other
+    processes to grab? umask matters here).
+- **Frame injection / parser confusion** — the NDJSON control
+  socket parser accepts JSON dicts; what about:
+  - Extremely long lines (DoS via memory)
+  - Embedded newlines in strings (line framing confusion)
+  - Type confusion (`"requested_at_ms": "12345"` as string vs
+    int)
+  - Unicode tricks in `target_model_id` (HF model IDs have a
+    specific shape; is validation enforced?)
+- **Heartbeat / hello forgery surface** — can a malicious peer
+  trigger the binary to emit a heartbeat with a hash it
+  shouldn't? The hash source is the operator's local container —
+  not directly controllable by buyer requests, but if a buyer's
+  request can drive the state machine into `.loading`...
+  actually no, buyer requests trigger HTTP 503 in
+  `.loading`/`.draining`. Verify the inverse: can a buyer
+  inference request trigger any state machine transition?
+- **Tier-2 attestation paths** — 1A's `authInitialMessage`
+  changes don't touch attestation, but the
+  `provider_ecdh_public_key` and `tier2_capabilities` fields
+  remain. Are they still emitted exactly as before? A
+  regression here breaks SPEC-008 Pillar A.
+- **Coordinator-side trust** — the coordinator-generated
+  `auth_attempt_id` is echoed back on proof. Does the binary
+  validate it survives serialization round-trips
+  byte-identically? A subtle string encoding bug (NFC vs NFD)
+  could break the contract.
+- **Local privilege escalation via stale socket** — the spec
+  says the binary refuses to bind if the socket file already
+  exists. Verify there's no race window where a malicious local
+  process could create the socket file between the existence
+  check and the bind.
+- **`--switch-state-path` write target** — could an operator
+  attacker (or compromised user-mode process) point
+  `--switch-state-path` at a system file (e.g.,
+  `/etc/passwd`) and get the binary to write to it? The CLI
+  runs as the operator user, so file mode permissions limit
+  the blast radius — but verify no privilege escalation.
+- **Authentication scope check** — does the
+  `ControlSocketServer` perform any authentication on
+  connecting clients? The spec relies on Unix-domain socket
+  permissions (`0600`) for authorization — verify this is
+  actually the only gate (no `getpeereid`-based check is
+  needed since the FS perms enforce it, but the code should
+  match that assumption explicitly in a comment or assertion).
+- **Heartbeat extension info leak** — `model_hash` is the
+  SHA-256 of the model weights manifest. The coordinator is
+  trusted with this. But is the WS connection guaranteed
+  TLS-only? Yes — `coordinator.streamvc.live` is HTTPS-only.
+  Verify the WS scheme is `wss://` not `ws://`.
+
+Findings format:
+```
+[sec:N.M] [SEVERITY] <short title>
+  Asset: <what's at risk>
+  Vector: <how an attacker exploits it>
+  File: <path>:<line>
+  Fix: <suggested remediation, e.g., add a check, change a
+        permission, validate input>
+```
+
+### Dimension 3: ARCHITECTURE REVIEW
+
+Focus areas:
+- **Layering** — does the new `models` subcommand correctly
+  reuse `ConfigLoader.load`? Are `CoordinatorClient` and
+  `ControlSocketServer` correctly isolated from each other
+  (they should communicate only through `ModelRuntime`)?
+- **State machine completeness** — `RuntimeStateMachine` has
+  four states (`ready`, `loading`, `draining`, `failed`). Is
+  every reachable transition covered? Is there an unreachable
+  `(loading, transitionToLoading)` path that could deadlock?
+  What if `stop()` is called mid-swap (state is `.loading`)?
+- **Coupling between phases** — the audit-trail BUILD prompts
+  documented "out of scope" deferrals per phase. Verify none
+  of those deferrals leaked: e.g., 1B's `swap_drain_timeout`
+  field is "parked" until 1E, but 1E doesn't actually wire it
+  to the drain timeout. Is that OK or a latent gap?
+- **Surface area discipline** — 1B added `WarmSwapDisabledError`,
+  1C added `ControlSocketError` /
+  `ControlSocketConnectError` / `ControlSocketServerError` /
+  `ControlSocketConnectionError`, 1A added
+  `SupportedModelsValidationError`. Are these consistently
+  used? Is there error-type proliferation that suggests a
+  refactor opportunity?
+- **Reentrancy in `ModelRuntime`** — actor methods that `await`
+  release the serial executor. The `complete` / `stream`
+  methods grab a `snapshot` at entry and use the snapshot's
+  container ref for the rest of the call. Verify this pattern
+  is consistent — does ANY actor method re-read mutable state
+  AFTER an `await`?
+- **The 1A R2 helper refactor (`runSupportedModelsPreflight`)**
+  — is this static helper pattern carried through 1E (cooldown
+  preflight)? Or did 1E inline the check directly in `run()`?
+  Consistency matters.
+- **Test architecture** — `EndToEndAcceptanceTests.swift` is
+  638 lines (per Codex's report). Is it organized by AC
+  number? Does it duplicate setup code across tests that
+  could share a fixture? Is the `captureOutput` dup2 helper
+  safe under XCTest parallel execution (it mucks with
+  process-global stdout/stderr fds)?
+- **The 1B `testLoader` / `testCompletion` injection points**
+  — does the production init path also expose these or are
+  they internal-only? If internal-only, is `@testable import`
+  required to use them?
+- **Documentation / discoverability** — for a future
+  contributor reading just the code without the spec, are
+  the binding spec rule citations visible in code comments?
+  (Or is the code self-explanatory enough?)
+
+Findings format:
+```
+[arch:N.M] [SEVERITY] <short title>
+  What: <one-paragraph description>
+  Trade-off: <what's gained vs lost by the current choice>
+  Suggestion: <a concrete refactor or follow-up; NOT required
+              for merge unless the severity says so>
+```
+
+## Severity scale (consistent across all three dimensions)
+
+- **CRITICAL** — must be fixed before merge. Breaks an invariant
+  the spec relies on (L-1 byte-identical default, atomic swap
+  isolation, money-path billing correctness), creates a
+  security hole that's exploitable by a realistic adversary,
+  or crashes the binary on a happy path.
+- **MAJOR** — should be fixed before merge OR explicitly
+  deferred with a follow-up issue. Real bug, real impact,
+  but not on the critical path; OR a security finding that
+  requires unusual conditions to exploit.
+- **MINOR** — would improve the code but does not block merge.
+  Style, test-flakiness, idiom drift, sub-optimal but
+  functional. Note for future polish.
+
+## Output format
+
+Return your findings as a single Markdown document with the
+following structure:
+
+```
+# PR #5 pre-merge audit — Codex GPT-5
+
+## Verdict
+
+<one-line summary: MERGE-READY | MERGE-WITH-FIXES |
+BLOCK-MERGE>
+
+## Counts
+
+| Dimension | CRITICAL | MAJOR | MINOR |
+|---|---|---|---|
+| Code        | <N> | <N> | <N> |
+| Security    | <N> | <N> | <N> |
+| Architecture| <N> | <N> | <N> |
+| **Total**   | <N> | <N> | <N> |
+
+## Findings
+
+### Code review
+
+[code:1.1] [SEVERITY] ...
+[code:1.2] [SEVERITY] ...
+...
+
+### Security review
+
+[sec:1.1] [SEVERITY] ...
+...
+
+### Architecture review
+
+[arch:1.1] [SEVERITY] ...
+...
+
+## What I didn't review
+
+<list of files/areas you intentionally skipped, with rationale>
+
+## Cross-cutting observations
+
+<any patterns that span multiple findings; e.g., "three
+findings all stem from the same `@unchecked Sendable` choice
+on RuntimeSnapshot — addressing that root cause closes all
+three">
+```
+
+## Discipline
+
+- Be specific. Cite `<file>:<line>` for every finding.
+- Be conservative on CRITICAL. A finding is only CRITICAL if
+  you can describe the concrete failure mode in one sentence.
+- Be honest about uncertainty. If you suspect an issue but
+  cannot confirm without running the code, mark it as MAJOR
+  with a "needs verification" tag rather than CRITICAL.
+- Do not invent findings to fill quota. If a dimension yields
+  zero findings, report zero. The internal audit was thorough;
+  finding nothing new IS a valid result.
+- Cite the binding SPEC rule when claiming a violation. "This
+  violates SPEC-011 R-3.2.5" beats "this looks wrong" by a
+  mile.
+- For security findings, model the attacker explicitly:
+  "A local UID-0 attacker can ..." or "A buyer sending a
+  crafted inference request can ..." Without the attacker
+  model, the finding is just a code smell.
+
+You may run shell commands to explore the repo (git log,
+grep, find, file inspection). You MUST NOT run swift build,
+swift test, or anything that mutates state. Cap shell
+output at a reasonable volume; if you find a large file,
+read the specific lines you need rather than dumping the
+whole thing.
+
+You may take up to 60 minutes wall-clock. If you finish
+earlier with a clean report, that's fine; do not pad.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (out-of-band)
+
+- Expected wall-clock: 30-60 min for Codex GPT-5 reading ~7000
+  LOC of new Swift across five commits plus tests plus specs.
+- The findings document is the input to the operator's
+  merge/no-merge decision. If Codex returns CRITICAL findings,
+  the operator drafts an R6 fix prompt (one per finding) and
+  re-dispatches; otherwise PR #5 squash-merges.
+- This is the equivalent of the SPEC-010 / SPEC-011 audit
+  discipline but at the implementation layer rather than the
+  spec layer. The same R1/R2 pattern applies if findings
+  emerge.
+- Result artifact lives under
+  `.omc/artifacts/ask/codex-execute-the-pre-merge-audit-prompt-*`.

--- a/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1A_PROMPT.md
+++ b/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1A_PROMPT.md
@@ -1,0 +1,526 @@
+# Implementation BUILD prompt — SPEC-001 v1.3 Phase 1A (SPEC-010 catalog surface)
+
+Operator-paste prompt for Codex GPT-5 to land the **first** of five
+implementation sub-phases of SPEC-001 v1.3 in `phase3-binary/`. This
+phase is purely additive, defaults preserve byte-identical wire
+behavior, and unblocks Phases 1B-1E (which build on the warm-swap
+state machine and control socket).
+
+**Scope: SPEC-010 v1.5 binary surface only.** No SPEC-011 warm-swap,
+no state machine, no control socket, no heartbeat extension, no
+`models` subcommand. Those are 1B-1E.
+
+**One-line summary.** Add the two SPEC-010 CLI flags
+(`--supported-models`, `--publish-supported-models`) plumbed through
+the existing CLI > ENV > YAML config priority; create a new
+`SupportedModels.swift` library with pre-flight validation per
+SPEC-010 v1.5 R-3.6.1 / R-3.6.3; wire the two optional fields onto
+the v2 `auth_request` initial-stage frame at
+`phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:644`
+per SPEC-001 v1.3 §6.7.1 / R-6.7.3. Add tests proving (a) the L-1
+byte-identical default (R-6.7.3: `supported_models: [model_id]`
+single-entry; `publishes_supported_models` omitted), (b) pre-flight
+exit-code-2 on `--model` not in `--supported-models`, (c) explicit
+catalog emitted when flag set.
+
+**Locked-spec dependencies (DO NOT contradict).**
+- SPEC-001 v1.3 (the spec this implements — read §6.2 CLI flag
+  additions and §6.7 v2 `auth_request` handshake)
+- SPEC-010 v1.5 (binding source for §3.1.A field table, §3.6 CLI
+  flags, R-3.1.1-R-3.1.10 wire rules, R-3.6.1-R-3.6.4 binary CLI
+  rules, §4.1 observable-indistinguishability lemma)
+- SPEC-002 v1.3.5 (coordinator parser truth — do not edit; this
+  phase emits fields that v1.3.5 already accepts)
+
+This is a **code-only** session. No spec edits. Verify with
+`git diff specs/` after edits — must be empty.
+
+Run in **Codex CLI** via `omc ask codex` from session root
+`/Users/augstar/macprovider-poc`. Expected wall-clock: ~60-90 min
+(2 new Swift files, 1 file modified, 1 file extended with flag
+plumbing, 1 test file new, 1 test file extended).
+
+Branch: `fix/spec-001-v1-3-binary` (already checked out by
+operator). Codex MUST NOT create a new branch.
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are implementing Phase 1A of SPEC-001 v1.3 in the Swift binary
+at /Users/augstar/macprovider-poc/phase3-binary/. SPEC-001 v1.3 is
+LOCKED (merged to main in PR #4 commit b4d87b5). SPEC-010 v1.5 is
+LOCKED. SPEC-011 v0.5 is LOCKED but OUT OF SCOPE for this phase.
+
+You will edit/create the following files (and ONLY these):
+
+  phase3-binary/Sources/MacProviderCore/Config.swift          (extend)
+  phase3-binary/Sources/MacProviderCore/SupportedModels.swift (NEW)
+  phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift  (extend)
+  phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift (extend)
+  phase3-binary/Tests/macprovider-cliTests/SupportedModelsTests.swift (NEW)
+  phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift (extend)
+
+You will NOT edit any file under specs/, phase4-coordinator/,
+phase5-gateway/, or any other Swift file. Verify with
+`git diff specs/ phase4-coordinator/ phase5-gateway/` — must be
+empty before you finish.
+
+## Critical constraints
+
+**1. L-1 byte-identical default per SPEC-001 v1.3 R-6.7.3.**
+With neither `--supported-models` nor `--publish-supported-models`
+set, the v2 `auth_request` initial-stage frame MUST carry
+`supported_models: [model_id]` (single-entry, lower-cased exactly
+as `--model`) and MUST OMIT `publishes_supported_models` entirely
+(field absent from the JSON object, not `null` / not `false`).
+Tests MUST prove this by reading the serialized JSON.
+
+**2. SPEC-010 fields are NOT gated by `--enable-warm-swap`.** Per
+SPEC-001 v1.3 §6.7.3 + SPEC-010 v1.5 R-3.6.1 / R-3.6.4, the two
+SPEC-010 fields are controlled by their own flags, independent of
+the SPEC-011 warm-swap opt-in. Do not introduce
+`--enable-warm-swap` in this phase. (It lands in Phase 1B.)
+
+**3. CLI > ENV > YAML priority.** Mirror the existing
+`AppConfig` / `ConfigLoader` pattern in
+`phase3-binary/Sources/MacProviderCore/Config.swift`. Add YAML
+keys `supported_models: [string]` and `publishes_supported_models:
+bool`. Add ENV vars `MACPROVIDER_SUPPORTED_MODELS` (comma-
+separated) and `MACPROVIDER_PUBLISHES_SUPPORTED_MODELS` (bool).
+Add CLI flags `--supported-models <ids>` (comma-separated) and
+`--publish-supported-models <bool>` on the `ServeCommand` struct
+in `MacProviderCLI.swift`. CLI overrides ENV; ENV overrides YAML;
+default is unset.
+
+**4. Pre-flight validation per SPEC-010 v1.5 R-3.6.3.** Inside a
+new pure module `MacProviderCore/SupportedModels.swift`,
+implement:
+
+  - `func validate(model: String, supportedModels: [String]?)
+     throws -> [String]`
+    - Returns the RESOLVED catalog (the array to put on the wire).
+    - Default rule (R-3.6.2 + R-6.7.3): if `supportedModels` is
+      nil OR empty after parsing, return `[model]` (single-entry,
+      preserving `model` case verbatim).
+    - When `supportedModels` is non-empty:
+      - Trim whitespace from each entry.
+      - Drop empty entries after trimming.
+      - Reject (throw) if any entry length > 256 UTF-8 bytes
+        (R-3.6.3).
+      - Reject (throw) if total entry count > 64 (R-3.6.3).
+      - Reject (throw) if `model` is not present in the list under
+        a CASE-FOLDED comparison (R-3.6.3 — Swift
+        `.lowercased(with: nil)` is fine for this; the comparison
+        is canonical lower-case folding, NOT Unicode NFKC).
+      - On success return the original (pre-trim NOT, post-trim
+        YES; preserve entry case as the operator provided it).
+    - The throw type is a new public enum
+      `SupportedModelsValidationError` with the cases:
+      - `.modelNotInCatalog(model: String, catalog: [String])`
+      - `.entryTooLong(entry: String, byteCount: Int)`
+      - `.catalogTooLarge(count: Int)`
+      - `.modelMissing` (caller passes empty string for model)
+    - Each case's `CustomStringConvertible` message MUST match
+      these exact patterns (acceptance tests will assert on
+      substring match):
+      - `"--model <X> not in --supported-models"`
+      - `"--supported-models entry exceeds 256 UTF-8 bytes: ..."`
+      - `"--supported-models exceeds 64 entries (got N)"`
+      - `"--supported-models requires --model to be set"`
+
+  - `static func parseCSV(_ raw: String?) -> [String]?` —
+    parses comma-separated CLI/ENV input. Returns nil for
+    nil/whitespace-only; returns the trimmed-non-empty list
+    otherwise. Preserves entry case.
+
+**5. Pre-flight runs BEFORE WS connection.** Per SPEC-010 v1.5
+R-3.6.3 / AC-N.2: a validation failure MUST exit code 2 BEFORE
+the coordinator WebSocket is opened. Wire this into
+`ServeCommand.run()` in `MacProviderCLI.swift` between
+`ConfigLoader.load(...)` and `ModelRuntime(...)` instantiation.
+On `SupportedModelsValidationError`, print the error description
+to stderr (`FileHandle.standardError`) and call `throw
+ExitCode(2)` (ArgumentParser's exit-code wrapper) so the process
+exits 2.
+
+**6. v2 `auth_request` initial-stage emission.** In
+`CoordinatorClient.authInitialMessage(attempt:)` at
+`phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:644`,
+ALWAYS set `supported_models` and conditionally set
+`publishes_supported_models`:
+
+  - Carry the resolved catalog through `AppConfig` (add fields
+    `var supportedModels: [String]?` and `var
+    publishesSupportedModels: Bool` to `AppConfig`; default the
+    bool to `false`; the array stays Optional<[String]>).
+  - Plumb both into `CoordinatorClient` via its existing
+    `config: AppConfig` field (no new init args).
+  - In `authInitialMessage`, after the existing dictionary
+    construction:
+    - Compute `resolvedCatalog` via
+      `SupportedModels.validate(model: snapshot.modelID ?? "",
+      supportedModels: config.supportedModels)`. If this throws
+      at runtime, that is a programmer error (pre-flight should
+      have caught it); the WS connect attempt that produced the
+      auth_request should NEVER have started. Use `try?` and fall
+      back to `[snapshot.modelID ?? ""]` so the wire frame is
+      well-formed even in the impossible case.
+    - Set `message["supported_models"] = resolvedCatalog`.
+    - If `config.publishesSupportedModels == true`, set
+      `message["publishes_supported_models"] = true`. Otherwise
+      do NOT touch the key (per constraint 1).
+
+**7. v2 `auth_request` proof-stage.** Per SPEC-001 v1.3 R-6.7.6,
+if the binary re-sends the SPEC-010 fields on the proof stage
+they MUST be byte-identical to the initial stage. For Phase 1A,
+do NOT re-send them on the proof stage. The proof stage emits
+only the existing fields. (We may add proof-stage re-send in a
+later phase if a CRITICAL audit finding requires it; SPEC-010
+v1.5 §3.1.C marks both fields "optional, absent is not a
+mismatch".)
+
+**8. Legacy `hello` UNTOUCHED.** Per SPEC-001 v1.3 AC-N.11 and
+§6.5 byte-identical guarantee, do NOT modify
+`CoordinatorClient.helloMessage()` at line 675 in this phase.
+Phase 1D will revisit `hello` for SPEC-011 heartbeat reconnect
+source-of-truth.
+
+**9. No d-inference inspection.** Do not read any file under
+`phase3-binary/.build/checkouts/`. Use only the public SPEC + the
+in-repo Swift sources for grounding.
+
+**10. Compile + tests pass.** After your edits:
+  - `cd phase3-binary && swift build` MUST succeed.
+  - `cd phase3-binary && swift test` MUST succeed (existing
+    tests untouched + your new tests).
+  - The macOS Swift toolchain is the only target; do not add
+    Linux conditionals.
+
+## Required reading (in this order — read fully before writing)
+
+1. `/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md`
+   §6.7 (lines 1594-1747) — the v2 `auth_request` handshake
+   normative section. R-6.7.1 through R-6.7.10 are binding.
+
+2. `/Users/augstar/macprovider-poc/specs/SPEC-010-model-catalog.md`
+   - §3.1.A (parser-required field table)
+   - §3.1.B (wire example)
+   - §3.6 R-3.6.1 through R-3.6.4 (binary CLI rules)
+   - §4.1 (observable-indistinguishability lemma — explains why
+     single-entry default preserves L-1)
+
+3. `/Users/augstar/macprovider-poc/phase3-binary/Sources/MacProviderCore/Config.swift`
+   — full file. Mirror the existing `assign(...)` helper pattern
+   exactly for the two new YAML keys and two new ENV vars. Do
+   NOT introduce a new pattern.
+
+4. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+   lines 1-120 — the `ServeCommand` struct. Add the two new
+   `@Option` fields at the end of the existing options list,
+   mirroring the existing help-string style. Pass them through
+   `CLIOverrides` to `ConfigLoader.load(...)`.
+
+5. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+   - `authInitialMessage(attempt:)` at line 644 — the v2 initial-
+     stage builder
+   - `authProofMessage(challenge:attempt:)` at line 397 — the
+     proof-stage builder (DO NOT modify in this phase)
+   - `helloMessage()` at line 675 — legacy hello (DO NOT modify
+     in this phase)
+
+6. `/Users/augstar/macprovider-poc/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift`
+   — existing test patterns; mirror them for your new assertions.
+
+7. `/Users/augstar/macprovider-poc/CLAUDE.md` — repo conventions
+   (commit identity is already correct on this branch; do NOT
+   change git config).
+
+## Required edits — exact shape
+
+### A. `Config.swift` — extend `AppConfig` + `CLIOverrides` + loader
+
+In `AppConfig` (after `tier2MDAArtifactPath`):
+
+```swift
+public var supportedModels: [String]?
+public var publishesSupportedModels: Bool
+```
+
+In `AppConfig.defaults(...)`:
+- `supportedModels: nil`
+- `publishesSupportedModels: false`
+
+In `CLIOverrides`:
+
+```swift
+public var supportedModels: [String]?
+public var publishesSupportedModels: Bool?
+```
+
+Extend `CLIOverrides.init(...)` accordingly (new params at the
+end of the param list; default to nil).
+
+In `applyYAMLConfig`: handle keys `supported_models` (array of
+strings) and `publishes_supported_models` (bool). Add a new
+`assign` overload for `inout [String]?` from a YAML dictionary
+if one does not already exist; it MUST accept a YAML sequence of
+strings or a single string (split on `,`). Reject other shapes
+with `ConfigError.invalidValue`.
+
+In `applyEnvironment`: handle `MACPROVIDER_SUPPORTED_MODELS`
+(parsed via `SupportedModels.parseCSV`) and
+`MACPROVIDER_PUBLISHES_SUPPORTED_MODELS` (bool).
+
+In `applyCLI`: assign from `cli.supportedModels` and
+`cli.publishesSupportedModels` if non-nil.
+
+### B. `SupportedModels.swift` — NEW file under MacProviderCore
+
+```swift
+import Foundation
+
+public enum SupportedModelsValidationError: Error,
+    CustomStringConvertible, Equatable
+{
+    case modelMissing
+    case modelNotInCatalog(model: String, catalog: [String])
+    case entryTooLong(entry: String, byteCount: Int)
+    case catalogTooLarge(count: Int)
+
+    public var description: String { /* per constraint 4 */ }
+}
+
+public enum SupportedModels {
+    public static let maxEntryByteLength = 256
+    public static let maxCatalogEntries = 64
+
+    public static func parseCSV(_ raw: String?) -> [String]? {
+        // returns nil for nil / whitespace-only input;
+        // returns trimmed non-empty entries otherwise
+    }
+
+    public static func validate(
+        model: String,
+        supportedModels: [String]?
+    ) throws -> [String] {
+        // per constraint 4
+    }
+}
+```
+
+The exact wording of the `description` strings is asserted by
+tests — match constraint 4 literally.
+
+### C. `MacProviderCLI.swift` — extend `ServeCommand`
+
+After `var logLevel: String?` (line ~43), add:
+
+```swift
+@Option(parsing: .singleValue, help: "Comma-separated list of HuggingFace model IDs (or local paths) this provider can serve. Overrides MACPROVIDER_SUPPORTED_MODELS and config key supported_models. When unset, the binary publishes supported_models: [model_id] (single-entry, per SPEC-010 v1.5 R-3.6.2).")
+var supportedModels: String?
+
+@Flag(name: .customLong("publish-supported-models"), inversion: .prefixedNo, help: "Opt into publishing the supported_models catalog to the coordinator's /v1/status echo (SPEC-010 v1.5 R-3.6.4). Default off.")
+var publishSupportedModels: Bool?
+```
+
+Note the `Bool?` (tri-state) so that unset means "fall through to
+ENV / YAML / default-false". `ArgumentParser` `@Flag` with
+`inversion: .prefixedNo` accepts `--publish-supported-models` /
+`--no-publish-supported-models`. If unset, the value is `nil`.
+
+In `ServeCommand.run()`:
+- Build `CLIOverrides` with
+  `supportedModels: SupportedModels.parseCSV(supportedModels)`
+  and `publishesSupportedModels: publishSupportedModels`.
+- After `ConfigLoader.load(...)` returns `resolved`:
+  - Call `let catalog = try SupportedModels.validate(model:
+    resolved.model ?? "", supportedModels:
+    resolved.supportedModels)`.
+  - On `SupportedModelsValidationError`, do:
+    `FileHandle.standardError.write(Data(("\(error)\n").utf8))`
+    then `throw ExitCode(2)`.
+  - Store the resolved catalog back into a local variable, OR
+    overwrite `resolved.supportedModels` with the validated
+    catalog. (Either is fine; downstream
+    `CoordinatorClient.authInitialMessage` re-validates with
+    `try?`.)
+
+### D. `CoordinatorClient.swift` — extend `authInitialMessage`
+
+After the existing dictionary literal (around line 665), before
+the existing `if let endpointURL` block:
+
+```swift
+let resolvedCatalog: [String]
+do {
+    resolvedCatalog = try SupportedModels.validate(
+        model: snapshot.modelID ?? "",
+        supportedModels: config.supportedModels
+    )
+} catch {
+    resolvedCatalog = [snapshot.modelID ?? ""]
+}
+message["supported_models"] = resolvedCatalog
+if config.publishesSupportedModels {
+    message["publishes_supported_models"] = true
+}
+```
+
+DO NOT modify `helloMessage()` or `authProofMessage(...)`.
+
+### E. `SupportedModelsTests.swift` — NEW test target file
+
+Cover (each as a separate XCTest):
+
+- `testParseCSVNilInput` — nil/empty/whitespace yields nil.
+- `testParseCSVTrimsAndDropsEmpty` — `" A , ,B,  "` → `["A","B"]`.
+- `testValidateDefaultsToSingleEntry` —
+  `validate(model: "A", supportedModels: nil) == ["A"]`.
+- `testValidateDefaultSingleEntryPreservesCase` —
+  `validate(model: "MlX/Foo", supportedModels: nil) ==
+  ["MlX/Foo"]`.
+- `testValidateRejectsMissingModel` —
+  `validate(model: "", supportedModels: nil)` throws
+  `.modelMissing`.
+- `testValidateAcceptsCaseFoldedMatch` —
+  `validate(model: "MLX/FOO", supportedModels: ["mlx/foo",
+  "B"])` returns `["mlx/foo", "B"]` (entry case preserved).
+- `testValidateRejectsModelNotInCatalog` —
+  `validate(model: "C", supportedModels: ["A","B"])` throws
+  `.modelNotInCatalog`; description contains `"--model C not
+  in --supported-models"`.
+- `testValidateRejectsTooLongEntry` — 257-byte entry throws
+  `.entryTooLong`; description contains
+  `"--supported-models entry exceeds 256 UTF-8 bytes"`.
+- `testValidateRejectsTooManyEntries` — 65 entries throws
+  `.catalogTooLarge`; description contains `"exceeds 64
+  entries"`.
+- `testValidateCountsUTF8BytesNotCharacters` — a 130-character
+  string of emoji (e.g. `String(repeating: "😀", count: 65)` is
+  260 UTF-8 bytes) MUST throw `.entryTooLong`.
+
+### F. `CoordinatorClientTests.swift` — extend
+
+Add four new XCTests. Each constructs a `CoordinatorClient`
+with a hand-rolled `AppConfig`, calls
+`authInitialMessage(attempt:)` with a dummy `Tier2AuthAttempt`,
+serializes the returned dictionary to JSON, and asserts on the
+JSON.
+
+- `testAuthInitialDefaultsToSingleEntryCatalog` —
+  `AppConfig.supportedModels = nil`,
+  `publishesSupportedModels = false`. The JSON MUST contain
+  `"supported_models":["model-id-from-snapshot"]` AND MUST NOT
+  contain the substring `"publishes_supported_models"`.
+- `testAuthInitialEmitsExplicitCatalogWhenSet` —
+  `AppConfig.supportedModels = ["A","B"]`,
+  `model = "A"`,
+  `publishesSupportedModels = true`. The JSON MUST contain
+  `"supported_models":["A","B"]` AND
+  `"publishes_supported_models":true`.
+- `testAuthInitialOmitsPublishesWhenFalse` —
+  `supportedModels = ["A","B"]`,
+  `publishesSupportedModels = false`. The JSON MUST contain
+  `"supported_models":["A","B"]` AND MUST NOT contain
+  `"publishes_supported_models"`.
+- `testHelloMessageUnchangedByPhase1A` — call
+  `helloMessage()`, serialize to JSON, assert that the substring
+  `"supported_models"` does NOT appear and
+  `"publishes_supported_models"` does NOT appear. This pins
+  AC-N.11 byte-identical §6.5 guarantee.
+
+If `CoordinatorClient` initialization requires fixtures (mock
+`ProviderStatus`, mock attestation generator, etc.), reuse what
+`CoordinatorClientTests.swift` already does. DO NOT change
+production code to make testing easier.
+
+## Done criteria
+
+You are done when:
+
+- `git diff specs/ phase4-coordinator/ phase5-gateway/` is empty.
+- `git diff phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+  phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
+  phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+  phase3-binary/Sources/macprovider-cli/ProviderStatus.swift
+  phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+  phase3-binary/Sources/macprovider-cli/Tier2Attestation.swift
+  phase3-binary/Sources/macprovider-cli/Tier2ProviderSession.swift
+  phase3-binary/Sources/macprovider-cli/UninstallCommand.swift
+  phase3-binary/Sources/macprovider-cli/AsyncSemaphore.swift` is
+  empty.
+- `cd phase3-binary && swift build` exits 0.
+- `cd phase3-binary && swift test` exits 0 with all new tests
+  GREEN and all pre-existing tests still GREEN.
+- The new `SupportedModels.swift` file has no `import` other
+  than `Foundation`.
+- `grep -rn "XDG_RUNTIME_DIR" phase3-binary/Sources/` returns
+  zero matches.
+- `grep -rn "enable-warm-swap\|enableWarmSwap" phase3-binary/
+  Sources/` returns zero matches (Phase 1B introduces that flag,
+  not 1A).
+
+## Out of scope (do NOT do these in Phase 1A)
+
+- `--enable-warm-swap`, `--swap-drain-timeout-seconds`,
+  `--ctl-socket-path`, `--switch-state-path` — Phase 1B.
+- `ModelRuntime` refactor from `let container` to actor-isolated
+  `current_container` — Phase 1B.
+- `RuntimeStateMachine.swift` — Phase 1B.
+- `ControlSocket.swift` — Phase 1C.
+- `ModelsSubcommand.swift` (`models list / switch / status`) —
+  Phase 1C.
+- Heartbeat `model_hash` / `loading` fields — Phase 1D.
+- `helloMessage()` source-of-truth rule for WS-drop reconnect —
+  Phase 1D.
+- Modifying `phase4-coordinator/` for SPEC-002 v1.3.5 — Phase 2.
+
+## Self-check before reporting done
+
+Run this command and confirm all checks pass:
+
+```bash
+cd /Users/augstar/macprovider-poc && \
+  git diff --stat specs/ phase4-coordinator/ phase5-gateway/ && \
+  echo "----" && \
+  (cd phase3-binary && swift build 2>&1 | tail -5) && \
+  echo "----" && \
+  (cd phase3-binary && swift test 2>&1 | tail -20) && \
+  echo "----" && \
+  grep -rn "XDG_RUNTIME_DIR" phase3-binary/Sources/ || echo "no XDG_RUNTIME_DIR (correct)" && \
+  echo "----" && \
+  grep -rn "enable-warm-swap\|enableWarmSwap" phase3-binary/Sources/ || echo "no warm-swap surface (correct)"
+```
+
+Return:
+- A brief diff summary (files touched, +/- lines).
+- The output of `swift test` final summary line.
+- Any spec rule you were unable to satisfy exactly, with the
+  binding rule number and your interpretation.
+
+Do NOT commit. Do NOT push. The operator audits the working tree
+before commit.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (out-of-band)
+
+- Expected wall-clock: 60-90 min for Codex GPT-5 on a fresh
+  context. Phase 1B (state machine + ModelRuntime refactor) is
+  the heavy phase; 1A is intentionally small to validate the
+  draft-build-audit loop before scaling up.
+- Audit pass (Claude Opus) reads the diff, asserts the 10
+  constraints + 11 done-criteria items, and reports findings as
+  `R1` (round 1) verdict: `0 CRITICAL / 0 MAJOR / 0 MINOR` is
+  LOCK; non-zero spawns a round-2 Codex prompt that cites the
+  open findings.
+- After LOCK, operator commits the diff with a conventional
+  message and opens the PR via the per-repo `Augustas11` credential
+  helper (per project CLAUDE.md).
+- Phase 1B prompt is drafted only after Phase 1A LOCKs and
+  merges, mirroring the SPEC-010 / SPEC-011 sequential discipline.

--- a/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1A_R2_PROMPT.md
+++ b/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1A_R2_PROMPT.md
@@ -1,0 +1,131 @@
+# R2 BUILD prompt — Phase 1A fix for finding M.1
+
+Round-1 audit verdict on the Phase 1A implementation: 0 CRITICAL / **1 MAJOR** / 0 MINOR.
+
+**M.1 (MAJOR) — Pre-flight gate fires on bare `serve`, regressing L-1 byte-identical default.**
+
+- Location: `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:64-72` (the `do { let catalog = try SupportedModels.validate(...) } catch ...` block in `ServeCommand.run()`).
+- Repro: `macprovider-cli serve` with neither `--model` nor `--supported-models` calls `SupportedModels.validate(model: "", supportedModels: nil)` which throws `.modelMissing`, the catch writes "--supported-models requires --model to be set" to stderr, and the process exits code 2.
+- Why MAJOR: SPEC-001 v1.3 AC-N.0 mandates that a v1.3 binary invoked WITHOUT `--supported-models` AND WITHOUT `--enable-warm-swap` must exhibit byte-identical on-the-wire AND off-the-wire behavior to a v1.2.4 binary. v1.2.4 had no SPEC-010 pre-flight gate. v1.3 introduces one only for the case where the operator OPTED INTO `--supported-models`. The current code fires the gate even when the operator did not opt in.
+- Binding rules: SPEC-001 v1.3 AC-N.0 (L-1 byte-identical default), SPEC-010 v1.5 R-3.6.3 (pre-flight is the validation gate for the OPERATOR-PROVIDED catalog; default `[model_id]` is a wire-emit-time fallback, not subject to pre-flight).
+
+## Required fix
+
+Gate the pre-flight on `resolved.supportedModels != nil`. Skip pre-flight entirely when the operator did not pass `--supported-models` (and ENV / YAML did not set it either).
+
+### Patch — `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+
+Locate the block introduced by Phase 1A R1:
+
+```swift
+do {
+    let catalog = try SupportedModels.validate(
+        model: resolved.model ?? "",
+        supportedModels: resolved.supportedModels
+    )
+    resolved.supportedModels = catalog
+} catch let error as SupportedModelsValidationError {
+    FileHandle.standardError.write(Data(("\(error)\n").utf8))
+    throw ExitCode(2)
+}
+```
+
+Replace it with the gated form:
+
+```swift
+if resolved.supportedModels != nil {
+    do {
+        let catalog = try SupportedModels.validate(
+            model: resolved.model ?? "",
+            supportedModels: resolved.supportedModels
+        )
+        resolved.supportedModels = catalog
+    } catch let error as SupportedModelsValidationError {
+        FileHandle.standardError.write(Data(("\(error)\n").utf8))
+        throw ExitCode(2)
+    }
+}
+```
+
+### Required new test — `phase3-binary/Tests/macprovider-cliTests/SupportedModelsTests.swift`
+
+Add an XCTest that pins the L-1 invariant: when `--supported-models` is unset, pre-flight does NOT fire even if `--model` is also unset.
+
+```swift
+func testServeCommandSkipsPreflightWhenSupportedModelsUnset() async throws {
+    // SPEC-001 v1.3 AC-N.0: a v1.3 binary invoked without --supported-models
+    // must not exit code 2 from the SPEC-010 pre-flight gate even when --model
+    // is also unset. (v1.2.4 surfaces missing-model elsewhere, not via
+    // SPEC-010 exit 2.) Without this gate, Phase 1A regressed bare `serve`.
+
+    let command = try ServeCommand.parse([])
+
+    do {
+        try await command.run()
+        // run() will fail downstream (no coordinator, no model runtime in test
+        // environment); that's expected. The only thing this test pins is that
+        // the failure is NOT an ExitCode(2) thrown from the pre-flight gate.
+        XCTFail("expected downstream failure, not clean exit")
+    } catch let error as ExitCode {
+        XCTAssertNotEqual(
+            error, ExitCode(2),
+            "pre-flight gate must NOT exit code 2 when --supported-models is unset"
+        )
+    } catch {
+        // Any non-ExitCode error (config error, model runtime error, network
+        // error, etc.) is fine — it proves we got past the pre-flight gate.
+    }
+}
+```
+
+If `ServeCommand.run()` blocks indefinitely in the test environment (e.g.
+waits on a coordinator connection), wrap the call in a `Task` with a
+2-second timeout and treat timeout as "got past pre-flight" (success).
+A simpler alternative: factor the pre-flight block into a static helper
+`static func runSupportedModelsPreflight(_ resolved: inout AppConfig)
+throws` and test that helper directly with the three cases:
+
+1. `model = nil, supportedModels = nil` → no throw
+2. `model = nil, supportedModels = ["A"]` → throws `ExitCode(2)`
+3. `model = "A", supportedModels = nil` → no throw
+
+The static-helper refactor is preferred because it isolates the gate
+from the rest of `ServeCommand.run()` and makes the regression test
+deterministic. If you take that path, also update the existing
+`testServeCommandExits2WhenModelNotInSupportedModels` to call the helper
+directly (or keep both — helper test + end-to-end test).
+
+## Out of scope for R2
+
+- DO NOT change `SupportedModels.validate` semantics. The behavior of
+  validate(model: "", supportedModels: nil) throwing `.modelMissing`
+  is correct — that case represents a programmer error in the pre-flight
+  caller, not a user-facing condition. The fix is in the CALLER, not
+  the library.
+- DO NOT change `Config.swift`, `CoordinatorClient.swift`, or any other
+  file from R1. Only `MacProviderCLI.swift` (one block) and the test
+  file (one new test, optionally a refactor).
+- DO NOT introduce new CLI flags, ENV vars, or YAML keys.
+
+## Done criteria
+
+- The new test `testServeCommandSkipsPreflightWhenSupportedModelsUnset`
+  (or the equivalent static-helper test trio) is GREEN.
+- All pre-R1 tests still GREEN (52/52 including the new one, or
+  more if you chose the helper-trio).
+- `cd phase3-binary && swift build` exits 0.
+- `cd phase3-binary && swift test` exits 0.
+- `git diff specs/ phase4-coordinator/ phase5-gateway/` shows only the
+  pre-existing `specs/FOLLOWUP_COORDINATOR_HA_2026_06_03.md` unstaged
+  edit and the operator-authored `specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1A_*` files.
+  No NEW spec edits.
+- The grep checks from R1 still hold:
+  - `grep -rn "XDG_RUNTIME_DIR" phase3-binary/Sources/` → zero
+  - `grep -rn "enable-warm-swap\|enableWarmSwap" phase3-binary/Sources/` → zero
+
+Report back with: (a) the resulting diff, (b) the final `swift test`
+summary line, (c) confirmation that
+`testServeCommandSkipsPreflightWhenSupportedModelsUnset` (or its
+helper-trio equivalent) is in the suite and green.
+
+Do NOT commit. Do NOT push.

--- a/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1B_PROMPT.md
+++ b/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1B_PROMPT.md
@@ -1,0 +1,666 @@
+# Implementation BUILD prompt — SPEC-001 v1.3 Phase 1B (warm-swap gate + state machine + ModelRuntime refactor)
+
+Operator-paste prompt for Codex GPT-5 to land the **second** of five
+implementation sub-phases of SPEC-001 v1.3 in `phase3-binary/`. This
+phase is the foundational SPEC-011 refactor: it introduces the
+warm-swap opt-in gate, the 4-state runtime state machine, the
+`ModelRuntime` actor refactor from immutable container to actor-
+isolated mutable `current_container`, and inference-rejection wiring
+when the runtime is loading or draining. Phases 1C (control socket +
+`models` subcommand) and 1D (heartbeat extension) consume the state
+machine and `swap(...)` API that 1B establishes.
+
+**Scope: SPEC-011 v0.5 binary runtime surface only (no operator-facing
+wire yet).** No control socket, no `models` subcommand, no heartbeat
+extension, no WS drop policies. Those are 1C-1E.
+
+**One-line summary.** Add `--enable-warm-swap` and
+`--swap-drain-timeout-seconds` CLI flags plumbed through CLI > ENV >
+YAML; create `RuntimeStateMachine.swift` (a thread-safe actor holding
+`SwapState`); refactor `ModelRuntime` from immutable `let container`
+to actor-isolated mutable `currentContainer` exposing
+`currentSnapshot()` (snapshot read) and `beginSwap(targetModelID:
+loader:)` (atomic four-step replacement per SPEC-011 R-3.2.4) without
+blocking the actor's serial executor (the load task runs detached
+per no-starve R-3.2.5); wire `HTTPServer` to consult the state
+machine and reject NEW inference with HTTP 503 +
+`{error: {type: "service_unavailable", code: "provider_loading"}}`
+when state is `loading` or `draining`. L-1 byte-identical default
+preserved literally: in disabled mode the binary follows the
+SPEC-001 v1.2.4 synchronous-load boot path and never opens the new
+state-machine surface to operator-observable behavior.
+
+**Locked-spec dependencies (DO NOT contradict).**
+- SPEC-001 v1.3 §6.8 (this phase's normative section) and SPEC-001
+  v1.3 AC-N.0 / AC-N.3 / AC-N.6 / AC-N.7
+- SPEC-011 v0.5 §2 L-1 / L-2, §3.2 R-3.2.1 through R-3.2.7, §3.4
+  R-3.4.4, §3.7 R-3.7.x, §3.9 config additions
+- SPEC-001 v1.2.4 §6 (existing) — must remain byte-identical in
+  disabled mode
+
+This is a **code-only** session. No spec edits. Verify with
+`git diff specs/` after edits — must be empty (excluding operator-
+authored BUILD prompts under `specs/BUILD_SPEC_001_v1_3_IMPL_*`).
+
+Run in **Codex CLI** via `omc ask codex` from session root
+`/Users/augstar/macprovider-poc`. Expected wall-clock: ~90-120 min
+(3 new Swift files, ~3 files modified, ~2 test files extended /
+created).
+
+Branch: `fix/spec-001-v1-3-binary` already carries Phase 1A. Codex
+MUST commit on this branch, not create a new one, and MUST NOT
+commit or push (operator audits before commit).
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are implementing Phase 1B of SPEC-001 v1.3 in the Swift binary
+at /Users/augstar/macprovider-poc/phase3-binary/. SPEC-001 v1.3 is
+LOCKED. SPEC-011 v0.5 is LOCKED. Phase 1A (SPEC-010 catalog surface)
+is already on this branch as commit 6744d7c.
+
+You will edit/create the following files (and ONLY these):
+
+  phase3-binary/Sources/MacProviderCore/Config.swift                       (extend)
+  phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift          (NEW)
+  phase3-binary/Sources/macprovider-cli/ModelRuntime.swift                 (REFACTOR)
+  phase3-binary/Sources/macprovider-cli/HTTPServer.swift                   (extend)
+  phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift               (extend)
+  phase3-binary/Tests/macprovider-cliTests/RuntimeStateMachineTests.swift  (NEW)
+  phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift     (NEW)
+  phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift       (NEW)
+
+You will NOT edit any file under specs/, phase4-coordinator/,
+phase5-gateway/, or any other Swift file. Verify with
+`git diff -- specs/ phase4-coordinator/ phase5-gateway/` — must be
+empty before you finish.
+
+You will NOT touch any 1A-introduced surface:
+- `Sources/MacProviderCore/SupportedModels.swift` (DO NOT MODIFY)
+- `Sources/macprovider-cli/CoordinatorClient.swift`
+  `authInitialMessage(attempt:)` SPEC-010 emission block
+  (DO NOT MODIFY; you may add unrelated state-machine plumbing
+  elsewhere in the same file IF strictly necessary, but prefer
+  routing state through `ProviderStatus` or `ModelRuntime`)
+- The `ServeCommand.runSupportedModelsPreflight(_:)` helper
+- The 1A tests
+
+## Critical constraints
+
+**1. L-1 byte-identical default per SPEC-001 v1.3 AC-N.0.**
+A v1.3 binary started with `serve` and WITHOUT `--enable-warm-swap`
+MUST behave byte-identical to a SPEC-001 v1.2.4 binary on the
+following axes:
+  - `ModelRuntime` boot is synchronous (R-6.8.7) — populate
+    `currentContainer` once at init, transition directly to
+    `ready` without ever passing through `loading`
+  - No state-machine observation hooks fire on operator-facing
+    surfaces (no heartbeat field changes, no `/v1/status` changes,
+    no log lines)
+  - HTTPServer inference behavior is unchanged (existing tests
+    still green)
+  - No control socket file is created (control socket is 1C, NOT
+    1B; do not even add the placeholder)
+The four-state machine still EXISTS in the process (the
+`RuntimeStateMachine` instance is owned by `ModelRuntime`), but in
+disabled mode it stays in `ready` from boot to shutdown and the
+`swap(...)` API is either unreachable from production callers or
+returns an error.
+
+**2. SPEC-011 R-3.2.1 — mutable actor-isolated current_container.**
+Refactor `ModelRuntime` such that:
+  - `private var currentContainer: ModelContainer?`
+  - `private var currentModelID: String?`
+  - `private var currentModelHash: String?`
+  - These three fields are written ONLY by `init(...)` (boot path,
+    synchronous) and by the atomic-swap completion step inside
+    `applySwap(...)`. They are READ by `currentSnapshot()` (a new
+    actor method that returns an immutable `RuntimeSnapshot`
+    struct) and by the existing `complete / stream / preflight`
+    methods.
+  - The existing `let modelID: String?`, `let container:
+    ModelContainer?`, `let modelHash: String?` declarations are
+    REPLACED by their `var` equivalents. The existing
+    `loadedModelID`, `loadedModelHash`, `isLoaded` computed
+    properties continue to work by reading the `var` fields.
+  - All call sites of `modelRuntime.loadedModelID`,
+    `.loadedModelHash`, `.isLoaded` continue to compile without
+    changes.
+
+**3. SPEC-011 R-3.2.4 — atomic four-step swap.** The
+`beginSwap(...)` API on `ModelRuntime` MUST implement the
+SPEC-011 R-3.2.4 four-step replacement:
+  Step 1: transition state to `loading` and stamp the
+    `target_model_id`
+  Step 2: kick off the load on a DETACHED `Task` (per R-3.2.5
+    no-starve isolation; the load MUST NOT run on the
+    ModelRuntime actor's serial executor)
+  Step 3: when load completes, ACQUIRE the actor and atomically:
+    swap `currentContainer`, `currentModelID`, `currentModelHash`
+    to the new values; transition state to `ready`; release any
+    references to the OLD container
+  Step 4: signal observers (a single `AsyncStream`-style channel
+    or a continuation callback) that a new heartbeat MUST be
+    emitted (the signal hook exists in 1B but is NOT consumed
+    until Phase 1D; tests assert the signal fires)
+
+The four-step contract MUST hold even if the swap is initiated
+when in-flight inference requests are still running with the OLD
+container. Those in-flight requests continue using their
+snapshot reference per R-3.2.2 (constraint 6 below).
+
+**4. SPEC-011 R-3.2.5 — no-starve isolation.** The load task
+inside `beginSwap` MUST be a `Task.detached { ... }` (or an
+equivalent unstructured task on a non-actor executor). The
+`ModelRuntime` actor's serial executor MUST remain unblocked
+throughout `loading` and `draining` so that:
+  - `currentSnapshot()` reads return promptly
+  - `complete / stream` for in-flight requests using their
+    OLD-container snapshot proceed without contention with the
+    load task
+  - Heartbeat emission (in Phase 1D) can read `currentSnapshot()`
+    on cadence without waiting for the load to finish
+Tests MUST prove this with a deliberately-slow stub loader
+(`Task.sleep(nanoseconds: 100_000_000)` = 100ms) AND a concurrent
+`currentSnapshot()` call that MUST return in < 10ms.
+
+**5. SPEC-011 R-3.2.6 — rollback semantics.** If the load task
+throws an error, `beginSwap` MUST:
+  - NOT swap `currentContainer` (it stays as the OLD value)
+  - Transition state `loading → failed → ready` (R-3.2.6 the
+    `failed` state is observable for ONE state read, then
+    immediately becomes `ready`; in 1B the `failed` state is
+    transient — 1C will add the `switch_progress` CLI emission
+    that reads `failed` exactly once)
+  - Signal observers that the swap failed (with the error
+    propagated) — same channel as step 4 above; the payload
+    differentiates success vs failure
+Tests MUST cover both the success path (state ends `ready` with
+NEW container) and the failure path (state ends `ready` with OLD
+container, observers got a `failed` signal).
+
+**6. SPEC-011 R-3.2.2 — snapshot reads for in-flight inference.**
+The existing `complete(_:shouldCancel:)` and
+`stream(_:shouldCancel:onChunk:)` methods on `ModelRuntime` MUST
+be refactored to grab a `RuntimeSnapshot` value (capturing
+`(ModelContainer, String?, String?)` for current container /
+model ID / model hash) AT THE START of the request, then perform
+all subsequent work against that snapshot. A swap that completes
+DURING an in-flight request MUST NOT affect the in-flight
+request's container reference; the in-flight request finishes
+with the OLD weights. Tests MUST prove this with a stub
+`ModelContainer.perform` that signals "still running" while a
+concurrent `beginSwap` completes.
+
+**7. SPEC-011 R-3.2.3 / R-3.4.4 — inference rejection during
+loading / draining.** The HTTP request entry point in
+`HTTPServer.swift` (find the existing chat completions handler
+around line 184-232) MUST consult `modelRuntime.currentSnapshot()`
+(or an equivalent state probe) BEFORE accepting the request:
+  - If state is `loading` or `draining`: respond HTTP 503 with
+    body
+    `{"error": {"type": "service_unavailable",
+                "code": "provider_loading"}}`
+    and DO NOT enter `complete` / `stream`. Note the exact
+    `code` is `provider_loading` per SPEC-001 v1.3 §6.8.3 — NOT
+    `model_loading`, NOT `service_loading`.
+  - If state is `failed`: this case is transient and SHOULD NOT
+    be observable to HTTP. If it ever happens, treat as
+    `loading` (503).
+  - If state is `ready`: proceed as today.
+This check happens INSIDE the actor (call `currentSnapshot()`
+to also retrieve the state). The state field on
+`RuntimeSnapshot` is the source of truth.
+
+**8. SPEC-011 R-3.2.7 — boot path UNCHANGED.** The existing
+synchronous-load boot path in `ModelRuntime.init(modelID:
+maxContextTokensOverride:)` is preserved. The init still calls
+`LLMModelFactory.shared.loadContainer(...)` synchronously,
+assigns `currentContainer` / `currentModelID` / `currentModelHash`
+once, and the state machine is created already in `ready`
+(NEVER transitions through `loading` on boot). Tests MUST
+verify that for a fresh `ModelRuntime(modelID: nil)`, the
+post-init state is `ready` and the snapshot has `nil`
+container — matching the current v1.2.4 "no model" boot
+behavior.
+
+**9. SPEC-011 R-3.1.0 — `--enable-warm-swap` flag.** Add the
+flag on `ServeCommand`. CLI > ENV
+(`MACPROVIDER_ENABLE_WARM_SWAP`) > YAML (`enable_warm_swap:
+bool`). Default DISABLED.
+  - When disabled: `ModelRuntime.beginSwap(...)` MUST throw
+    `WarmSwapDisabledError` (a new public Error with description
+    `"warm swap is not enabled (start serve with
+    --enable-warm-swap)"`). Tests MUST cover this.
+  - When enabled: `beginSwap` proceeds per R-3.2.4. Tests MUST
+    cover this with a stub loader (do NOT actually load MLX
+    weights in tests).
+The flag value MUST flow into `ModelRuntime` via the existing
+init signature OR a new property setter — Codex chooses, but
+the resolution MUST happen in `ServeCommand.run()` BEFORE
+constructing the `ModelRuntime` instance.
+
+**10. SPEC-011 §3.9 — `--swap-drain-timeout-seconds` flag.**
+Add the flag on `ServeCommand`. CLI > ENV
+(`MACPROVIDER_SWAP_DRAIN_TIMEOUT_S`) > YAML
+(`swap_drain_timeout_s: int`). Default 30 seconds. The value
+is stored on `AppConfig` and on `ModelRuntime`; in 1B the value
+is parked (used only by tests to verify it survives the
+plumbing). 1E will wire it into actual drain logic.
+
+**11. Test-only loader injection point.** Add an init overload
+on `ModelRuntime` (test-only, marked `internal` or
+`@testable internal`) that takes a
+`loader: @Sendable (String) async throws -> (ModelContainer,
+String, String?)` closure. The production init uses the real
+`LLMModelFactory.shared.loadContainer`; tests inject a stub
+that returns a fake `ModelContainer` (or a `nil`-equivalent
+sentinel that the test code handles without actually invoking
+`container.perform`). DO NOT use Swift `#if DEBUG` /
+`#if TESTING` guards; just expose the overload with
+`internal` visibility.
+
+**12. d-inference clean-room.** Do NOT read any file under
+`phase3-binary/.build/checkouts/`. Use only the public SPEC +
+the in-repo Swift sources for grounding.
+
+**13. Compile + tests pass.** `swift build` and `swift test`
+MUST both exit 0. The cumulative test count after this phase
+SHOULD be around 70-75 (54 from 1A + 16-21 new in 1B). All
+pre-existing tests still GREEN.
+
+**14. NO control socket, NO models subcommand, NO heartbeat
+extension.** Those are 1C/1D. If a test convenience would
+benefit from a control socket file, DO NOT add one — drive the
+test via direct `modelRuntime.beginSwap(...)` calls instead.
+
+## Required reading (in this order — read fully before writing)
+
+1. `/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md`
+   §6.8 (lines 1748-1809) — the warm-swap state machine normative
+   section. R-6.8.1 through R-6.8.7 are binding.
+
+2. `/Users/augstar/macprovider-poc/specs/SPEC-011-operator-pushed-warm-swap.md`
+   v0.5 — focus on:
+   - §2 L-1 / L-2 (byte-identical default, opt-in gate)
+   - §3.2 R-3.2.1 through R-3.2.7 (state machine, atomic swap,
+     in-flight snapshot, no-starve, rollback, boot)
+   - §3.4 R-3.4.4 (drain HTTP 503 envelope)
+   - §3.9 config additions (drain timeout default)
+
+3. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+   — full file (lines 1-437). The refactor MUST preserve:
+   - The `ModelRuntimeServing` protocol surface
+   - `loadedModelID`, `loadedModelHash`, `isLoaded` computed
+     properties
+   - `complete / stream / preflight` semantics for in-flight
+     requests (R-3.2.2 snapshot reads)
+   - The existing `Self.configuration(for:)`,
+     `Self.modelWeightArtifactManifestHash(...)`,
+     `Self.defaultMaxContextTokens()`, output filters, etc.
+
+4. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/HTTPServer.swift`
+   — focus on the chat completions handler (around lines 184-232)
+   and the streaming handler. Inference rejection wiring goes
+   here.
+
+5. `/Users/augstar/macprovider-poc/phase3-binary/Sources/MacProviderCore/Config.swift`
+   — mirror the existing `assign(...)` helper pattern for the two
+   new YAML / ENV / CLI keys, matching Phase 1A's plumbing style.
+
+6. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+   — `ServeCommand`. Add the two new `@Flag` / `@Option` fields
+   after the existing 1A `--supported-models` /
+   `--publish-supported-models` flags, mirroring their style.
+
+7. `/Users/augstar/macprovider-poc/phase3-binary/Tests/macprovider-cliTests/ModelRuntimeHashTests.swift`
+   — existing test patterns for `ModelRuntime`. Mirror the
+   fixture style.
+
+8. `/Users/augstar/macprovider-poc/CLAUDE.md` — repo conventions.
+
+## Required edits — exact shape
+
+### A. `RuntimeStateMachine.swift` — NEW file
+
+```swift
+import Foundation
+
+public enum SwapState: String, Sendable, Equatable {
+    case ready
+    case loading
+    case draining
+    case failed
+}
+
+public struct SwapSignal: Sendable {
+    public enum Outcome: Sendable {
+        case completed(newModelID: String, newModelHash: String?)
+        case failed(reason: String)
+    }
+    public let targetModelID: String
+    public let outcome: Outcome
+}
+
+public actor RuntimeStateMachine {
+    private var state: SwapState = .ready
+    private var targetModelID: String?
+    private var signalContinuations: [AsyncStream<SwapSignal>.Continuation] = []
+
+    public init() {}
+
+    public func current() -> SwapState { state }
+    public func currentTargetModelID() -> String? { targetModelID }
+
+    public func transitionToLoading(target: String) throws {
+        guard state == .ready else {
+            throw RuntimeStateMachineError.notReady(current: state)
+        }
+        state = .loading
+        targetModelID = target
+    }
+
+    public func transitionToDraining() throws { /* state == .loading guard */ }
+    public func completeSwap(newModelID: String, newModelHash: String?) { /* state -> ready, signal completed */ }
+    public func failSwap(reason: String) { /* state loading -> failed -> ready, signal failed */ }
+
+    public func signalStream() -> AsyncStream<SwapSignal> {
+        AsyncStream { continuation in
+            signalContinuations.append(continuation)
+        }
+    }
+}
+
+public enum RuntimeStateMachineError: Error, Equatable {
+    case notReady(current: SwapState)
+}
+```
+
+(The exact body is your responsibility; the public surface must
+match the above.)
+
+### B. `WarmSwapDisabledError` — public Error in ModelRuntime.swift
+
+```swift
+public struct WarmSwapDisabledError: Error, CustomStringConvertible {
+    public var description: String {
+        "warm swap is not enabled (start serve with --enable-warm-swap)"
+    }
+}
+```
+
+### C. `ModelRuntime.swift` — refactor
+
+Change the three `let` fields to `var`. Add:
+
+```swift
+private let stateMachine: RuntimeStateMachine
+private let warmSwapEnabled: Bool
+private let loader: @Sendable (String) async throws -> (ModelContainer, String, String?)
+```
+
+The default loader (used by production init) wraps
+`LLMModelFactory.shared.loadContainer`. The test init overload
+injects an arbitrary loader.
+
+Add two new actor methods:
+
+```swift
+public struct RuntimeSnapshot: Sendable {
+    public let state: SwapState
+    public let container: ModelContainer?
+    public let modelID: String?
+    public let modelHash: String?
+}
+
+func currentSnapshot() async -> RuntimeSnapshot {
+    RuntimeSnapshot(
+        state: await stateMachine.current(),
+        container: currentContainer,
+        modelID: currentModelID,
+        modelHash: currentModelHash
+    )
+}
+
+func beginSwap(targetModelID: String) async throws -> Task<Void, Error> {
+    guard warmSwapEnabled else { throw WarmSwapDisabledError() }
+    try await stateMachine.transitionToLoading(target: targetModelID)
+    return Task.detached { [stateMachine, loader] in
+        do {
+            let (container, modelID, modelHash) = try await loader(targetModelID)
+            await self.applySwap(container: container, modelID: modelID, modelHash: modelHash)
+        } catch {
+            await stateMachine.failSwap(reason: String(describing: error))
+        }
+    }
+}
+
+private func applySwap(container: ModelContainer, modelID: String, modelHash: String?) async {
+    currentContainer = container
+    currentModelID = modelID
+    currentModelHash = modelHash
+    await stateMachine.completeSwap(newModelID: modelID, newModelHash: modelHash)
+}
+```
+
+Refactor `complete / stream / preflight` to grab `let snapshot =
+await currentSnapshot()` at the start and check
+`snapshot.state == .ready`; if not, throw `APIError(status: 503,
+message: "Model loading", type: "service_unavailable", code:
+"provider_loading")`. The existing `container` reference inside
+these methods becomes `snapshot.container`.
+
+### D. `HTTPServer.swift` — inference rejection wiring
+
+In the chat completions handler at around line 184, BEFORE the
+existing dispatch to `modelRuntime.complete(...)` / `.stream(...)`,
+add a state check:
+
+```swift
+let snapshot = await modelRuntime.currentSnapshot()
+if snapshot.state != .ready {
+    // emit HTTP 503 with body
+    // {"error": {"type": "service_unavailable", "code": "provider_loading"}}
+    return
+}
+```
+
+(Exact location and dispatch shape is your responsibility; check
+both the non-streaming `Task.detached` branch at line 196 and the
+`handleStreamingChatCompletions` branch at line 191.)
+
+### E. `Config.swift` — extend
+
+Add to `AppConfig`:
+
+```swift
+public var enableWarmSwap: Bool
+public var swapDrainTimeoutSeconds: Int
+```
+
+Defaults: `false` and `30`. Plumb YAML keys `enable_warm_swap:
+bool` and `swap_drain_timeout_s: int`. ENV vars
+`MACPROVIDER_ENABLE_WARM_SWAP` and
+`MACPROVIDER_SWAP_DRAIN_TIMEOUT_S`. Add to `CLIOverrides` and
+`applyCLI` per existing pattern.
+
+(NOTE: there's an existing `drainTimeoutSeconds: Int` on AppConfig
+default 30 — that's the GENERAL drain timeout for shutdown, NOT
+the SPEC-011 swap drain timeout. Add `swapDrainTimeoutSeconds` as
+a separate field; do NOT reuse `drainTimeoutSeconds`.)
+
+### F. `MacProviderCLI.swift` — extend ServeCommand
+
+Add two new fields after the Phase 1A SPEC-010 flags:
+
+```swift
+@Flag(name: .customLong("enable-warm-swap"), inversion: .prefixedNo,
+      help: "Opt into the operator-pushed warm model swap workflow (SPEC-011 v0.5). Default off. When off, the binary follows the SPEC-001 v1.2.4 synchronous-load path; no control socket is opened.")
+var enableWarmSwap: Bool?
+
+@Option(help: "Drain timeout in seconds for an in-flight warm swap (SPEC-011 v0.5 §3.4 / §3.9). Default 30. Only meaningful when --enable-warm-swap is set.")
+var swapDrainTimeoutSeconds: Int?
+```
+
+Plumb both through `CLIOverrides` and into `ConfigLoader.load`. The
+resolved `AppConfig.enableWarmSwap` and `swapDrainTimeoutSeconds`
+flow into `ModelRuntime(modelID:..., warmSwapEnabled:
+resolved.enableWarmSwap, ...)`.
+
+### G. `RuntimeStateMachineTests.swift` — NEW
+
+Cover:
+- `testInitialStateIsReady` — fresh machine reports `.ready`
+- `testTransitionToLoadingFromReady` — succeeds, current returns
+  `.loading`, target reflects argument
+- `testTransitionToLoadingFromLoadingRejected` — throws
+  `.notReady`
+- `testCompleteSwapTransitionsToReady` — `.loading → .ready`
+- `testFailSwapTransitionsToReadyViaFailed` — `.loading →
+  .failed → .ready` (observable via signal stream)
+- `testSignalCompleted` — completion emits `Outcome.completed`
+  with new model ID + hash on the stream
+- `testSignalFailed` — failure emits `Outcome.failed` with the
+  reason string
+
+### H. `ModelRuntimeSwapTests.swift` — NEW
+
+Cover (all using `ModelRuntime` with the test-injected loader;
+do NOT touch real MLX):
+- `testDisabledModeRejectsSwap` —
+  `ModelRuntime(modelID: nil, warmSwapEnabled: false)`, call
+  `beginSwap(...)` → throws `WarmSwapDisabledError`
+- `testEnabledModeAcceptsSwap` — start enabled, beginSwap with
+  a 50ms stub loader, await the returned Task, snapshot state
+  ends `.ready` with new model ID + hash
+- `testInFlightInferenceUsesOldSnapshot` — start enabled with
+  an initial fake container, begin a slow `complete(...)`
+  call that holds a snapshot, concurrently call `beginSwap` to
+  a new container, the `complete` call observes the OLD container
+- `testLoadFailureRollsBack` — beginSwap with a loader that
+  throws after 50ms, await, snapshot state ends `.ready`,
+  container / modelID / modelHash unchanged from pre-swap
+- `testNoStarveSnapshotRespondsDuringLoad` — beginSwap with
+  100ms loader, concurrently call `currentSnapshot()` 20 times
+  in a tight loop, each call MUST return in < 10ms wall-clock
+  (assert `Date()` measurements)
+- `testBootPathDoesNotPassThroughLoading` — instantiate
+  `ModelRuntime(modelID: nil)`, immediately call
+  `currentSnapshot()`, state MUST be `.ready` (NEVER observed
+  `.loading` during init)
+
+### I. `HTTPServerSwapTests.swift` — NEW
+
+Cover:
+- `testInferenceReturns503WhenLoading` — set state machine to
+  `.loading`, POST a chat completions request, response is
+  HTTP 503 with body containing
+  `"code":"provider_loading"` AND
+  `"type":"service_unavailable"`
+- `testInferenceReturns503WhenDraining` — same with draining
+- `testInferenceProceedsWhenReady` — state `.ready`, request
+  passes through to `modelRuntime.complete` (mocked to return
+  a canned response)
+
+(If wiring an HTTP-level test is too heavyweight for the in-
+process server, fall back to driving the dispatcher directly
+with a fake request/response pair — but the assertion remains
+on the 503 + body shape.)
+
+## Done criteria
+
+You are done when:
+
+- `git diff -- specs/ phase4-coordinator/ phase5-gateway/` shows
+  only the operator-authored BUILD prompts under
+  `specs/BUILD_SPEC_001_v1_3_IMPL_*` (those are NOT your edits)
+  and the pre-existing
+  `specs/FOLLOWUP_COORDINATOR_HA_2026_06_03.md` unstaged edit.
+- `cd phase3-binary && swift build` exits 0.
+- `cd phase3-binary && swift test` exits 0 with ≥ 70 tests
+  green (54 from 1A + ≥ 16 new in 1B).
+- All Phase 1A tests still GREEN (54 from R2).
+- `grep -rn "XDG_RUNTIME_DIR" phase3-binary/Sources/` returns
+  zero matches.
+- `grep -rn "ctl.sock\|ControlSocket\|ModelsSubcommand\|models switch"
+  phase3-binary/Sources/` returns zero matches (those are 1C).
+- `grep -rn "model_hash.*loading\|loading.*model_hash"
+  phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+  returns zero matches (heartbeat extension is 1D).
+- A new `ModelRuntime` instantiated without `--enable-warm-swap`
+  exhibits `currentSnapshot().state == .ready` immediately and
+  `beginSwap(...)` throws `WarmSwapDisabledError`.
+- A `ModelRuntime` instantiated with `--enable-warm-swap` and a
+  stub loader can complete a swap (state ends `.ready` with new
+  model ID).
+
+## Out of scope (do NOT do these in Phase 1B)
+
+- Control socket / NDJSON protocol — Phase 1C
+- `models list / switch / status` subcommand — Phase 1C
+- `--ctl-socket-path` and `--switch-state-path` flags — Phase 1C
+- Heartbeat `model_hash` / `loading` fields on the wire — Phase 1D
+- `helloMessage()` source-of-truth rule on WS reconnect — Phase 1D
+- Concurrent switch policy (typed switch_ack with `loading_in_progress`)
+  — Phase 1E
+- WS drop mid-load policies — Phase 1E
+- Cooldown soft guard + `--force` flag — Phase 1E
+- Modifying `phase4-coordinator/` — Phase 2
+
+## Self-check before reporting done
+
+Run this command and confirm all checks pass:
+
+```bash
+cd /Users/augstar/macprovider-poc && \
+  git diff --stat -- specs/ phase4-coordinator/ phase5-gateway/ && \
+  echo "----" && \
+  (cd phase3-binary && swift build 2>&1 | tail -5) && \
+  echo "----" && \
+  (cd phase3-binary && swift test 2>&1 | grep "Executed.*tests" | tail -3) && \
+  echo "----" && \
+  grep -rn "XDG_RUNTIME_DIR" phase3-binary/Sources/ || echo "no XDG_RUNTIME_DIR (correct)" && \
+  echo "----" && \
+  grep -rn "ctl.sock\|ControlSocket\|ModelsSubcommand" phase3-binary/Sources/ || echo "no control socket / models subcommand (correct)"
+```
+
+Return:
+- A brief diff summary (files touched, +/- lines).
+- The final `swift test` summary line (Executed N tests, ...).
+- Any spec rule you were unable to satisfy exactly, with the
+  binding rule number and your interpretation.
+
+Do NOT commit. Do NOT push. The operator audits the working tree
+before commit.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (out-of-band)
+
+- Expected wall-clock: 90-120 min. 1B is the heaviest phase: the
+  ModelRuntime refactor touches the hot path and the no-starve
+  isolation invariant is subtle.
+- Audit pass (Claude Opus) reads the diff and tests against the
+  14 constraints + done criteria. Key audit foci:
+  - **Constraint 4 (no-starve)** — verify the load runs on a
+    detached task, not on the actor's executor. Look for
+    `Task.detached` and confirm the actor isn't blocked.
+  - **Constraint 6 (in-flight snapshot)** — verify `complete` /
+    `stream` capture a snapshot at request start and don't re-
+    read the actor's mutable state mid-request.
+  - **Constraint 8 (boot path)** — verify state machine starts
+    in `.ready` and `init` never calls `transitionToLoading`.
+  - **L-1** — run the full test suite with all Phase 1A tests
+    and confirm they're untouched; spot-check the wire emission
+    of `authInitialMessage` and `helloMessage` against R1
+    snapshots.
+- R2 prompt is drafted only if R1 audit surfaces findings.
+- After 1B LOCKs and commits to the branch, draft 1C
+  (control socket + `models` subcommand) referencing the actual
+  `RuntimeStateMachine` and `ModelRuntime.beginSwap` API
+  signatures as they landed.

--- a/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1C_PROMPT.md
+++ b/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1C_PROMPT.md
@@ -1,0 +1,786 @@
+# Implementation BUILD prompt — SPEC-001 v1.3 Phase 1C (control socket + `models` subcommand)
+
+Operator-paste prompt for Codex GPT-5 to land the **third** of five
+implementation sub-phases of SPEC-001 v1.3 in `phase3-binary/`.
+This phase wires the operator-facing surfaces for warm swap: a
+macOS-native Unix-domain control socket protocol (`$TMPDIR/macprovider-cli/ctl.sock`,
+NDJSON, typed frames) and a new `models` CLI subcommand with
+`list / switch <id> [--force] / status` actions.
+
+**Scope: SPEC-011 v0.5 §3.1.5 control socket protocol + §3.1.1 /
+§3.1.2 / §3.1.6 `models` subcommand surface.** No heartbeat extension
+(1D), no cooldown soft guard (1E), no WS drop policies (1E).
+`--force` is parsed and accepted but is a no-op in 1C — its only
+real effect (bypassing cooldown) lands in 1E.
+
+**One-line summary.** Create `ControlSocket.swift` (Unix-domain
+socket server hosted by `serve` when `--enable-warm-swap` is set,
+parent dir 0700, socket 0600, NDJSON frames with REQUIRED `type`
+field per SPEC-011 R-3.1.5); create `ModelsSubcommand.swift`
+(`models list / switch <id> [--force] / status` per SPEC-011
+R-3.1.1 / R-3.1.2 / R-3.1.6); plumb `--ctl-socket-path` and
+`--switch-state-path` flags (the latter only stored, used in 1E);
+wire the socket server to `ModelRuntime.beginSwap` (consume the
+`RuntimeStateMachine.signalStream()` from 1B to translate swap
+signals into `switch_progress` frames per SPEC-011 R-3.1.5). L-1
+byte-identical default preserved: in disabled mode the socket is
+absent and `models <any>` exits code 4 with the R-3.1.5.x case-1
+stderr.
+
+**Locked-spec dependencies (DO NOT contradict).**
+- SPEC-001 v1.3 §6.9 (lines 1811-1865) — this phase's normative
+  section, citing SPEC-011 R-3.1.5 / R-3.1.5.x / R-3.7.3
+- SPEC-011 v0.5 §3.1 R-3.1.0 through R-3.1.6 (CLI + control
+  socket), §3.7 R-3.7.x (concurrent switch policy — only the
+  *server reply* side, not the queue/retry policy which is 1E)
+- SPEC-010 v1.5 R-3.6.1 / R-3.6.3 (pre-flight reuse — 1C calls
+  the existing `SupportedModels.validate` from Phase 1A)
+- 1A (commit 6744d7c) — `SupportedModels` library + flag plumbing
+- 1B (commit 5c03e88) — `RuntimeStateMachine`, `ModelRuntime.beginSwap`,
+  `swapSignals()`, `currentSnapshot()`
+
+Spec-text-only edits are FORBIDDEN. No edits under `specs/`
+(operator-authored BUILD prompts are exceptions; you don't edit
+them). Verify with `git diff -- specs/` after edits.
+
+Run in **Codex CLI** via `omc ask codex` from session root
+`/Users/augstar/macprovider-poc`. Expected wall-clock: ~120-150 min
+(2 new Swift files of nontrivial size, ~2 files modified, ~3 test
+files new).
+
+Branch: `fix/spec-001-v1-3-binary` already carries Phases 1A + 1B.
+Codex MUST commit on this branch, not create a new one, and MUST
+NOT commit or push (operator audits before commit).
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are implementing Phase 1C of SPEC-001 v1.3 in the Swift binary
+at /Users/augstar/macprovider-poc/phase3-binary/. SPEC-001 v1.3 is
+LOCKED. SPEC-011 v0.5 is LOCKED. Phases 1A (commit 6744d7c) and 1B
+(commit 5c03e88) are already on this branch.
+
+You will edit/create the following files (and ONLY these):
+
+  phase3-binary/Sources/MacProviderCore/Config.swift                    (extend)
+  phase3-binary/Sources/macprovider-cli/ControlSocket.swift             (NEW)
+  phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift          (NEW)
+  phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift            (extend)
+  phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift     (NEW)
+  phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift  (NEW)
+
+You will NOT edit any file under `specs/`, `phase4-coordinator/`,
+`phase5-gateway/`, or any other Swift file beyond the list above.
+You will NOT touch:
+- `Sources/MacProviderCore/SupportedModels.swift` (1A)
+- `Sources/macprovider-cli/CoordinatorClient.swift` (1A / 1D)
+- `Sources/macprovider-cli/ModelRuntime.swift` (1B; the swap API is
+  consumed unchanged via existing `beginSwap`, `currentSnapshot`,
+  `swapSignals` methods)
+- `Sources/macprovider-cli/RuntimeStateMachine.swift` (1B)
+- `Sources/macprovider-cli/HTTPServer.swift` (1B)
+- Any 1A/1B test file
+
+Verify with `git diff -- specs/ phase4-coordinator/ phase5-gateway/`
+— must be empty (excluding operator-authored
+`specs/BUILD_SPEC_001_v1_3_IMPL_*` prompts and the pre-existing
+`specs/FOLLOWUP_COORDINATOR_HA_2026_06_03.md` unstaged edit).
+
+## Critical constraints
+
+**1. L-1 byte-identical default per SPEC-001 v1.3 AC-N.0 + AC-N.3.**
+A v1.3 binary started with `serve` WITHOUT `--enable-warm-swap`
+MUST NOT create any file at `$TMPDIR/macprovider-cli/ctl.sock`
+(or anywhere on disk for control-socket purposes). A
+`macprovider-cli models list / switch / status` invocation against
+such a binary MUST exit code 4 via the R-3.1.5.x case-1 path:
+`stat()` returns ENOENT → stderr
+`"macprovider-cli serve is not running on this host (no control
+socket at <socket_path>)"`. There is NO secondary disabled-mode
+detection that requires the binary to acknowledge "you didn't pass
+--enable-warm-swap"; the socket's *absence* is the signal.
+
+**2. macOS-native paths.** The default control socket path is
+`$TMPDIR/macprovider-cli/ctl.sock`, resolved via
+`FileManager.default.temporaryDirectory.appendingPathComponent("macprovider-cli/ctl.sock")`.
+NEVER use `$XDG_RUNTIME_DIR` (that's a Linux/freedesktop
+convention; unset on macOS). `grep -rn "XDG_RUNTIME_DIR"
+phase3-binary/Sources/` MUST return zero matches.
+
+**3. Permissions.** Parent directory mode MUST be `0700` and
+socket mode MUST be `0600` per SPEC-011 R-3.1.5 and SPEC-001 v1.3
+R-6.9.6. If the parent directory already exists with a different
+mode, the serve process MUST chmod it to 0700 before binding.
+If the socket file already exists (stale from a previous run
+that died), `bind()` will fail with EADDRINUSE; the serve process
+MUST NOT silently unlink the stale file and re-bind — instead it
+MUST log an error and exit non-zero with stderr
+`"control socket <path> already exists; remove the stale file
+and restart serve"`. Rationale: silent unlink masks a
+diagnostically-important condition (a second `serve` running on
+the same socket path). Tests cover this case.
+
+**4. NDJSON wire format with REQUIRED `type` field per SPEC-011
+R-3.1.5.** Every frame is one line of JSON terminated by `\n`.
+Every frame MUST include a `type` field. Receivers MUST discard
+frames with missing/unknown `type` AND close the connection with
+an error log line. JSON serialization MUST use
+`[.withoutEscapingSlashes]` to keep wire bytes minimal and avoid
+gratuitous `\/` escapes; tests assert on exact wire bytes.
+
+**5. Frame schemas (SPEC-011 R-3.1.5 verbatim).** Implement all
+seven schemas:
+
+  CLI → serve:
+  - `{"type": "switch_request", "target_model_id": "<X>",
+     "requested_at_ms": <epoch-ms>}`
+  - `{"type": "status_request"}`
+
+  serve → CLI:
+  - `{"type": "switch_ack", "accepted": true}`
+  - `{"type": "switch_ack", "accepted": false,
+     "reason": "loading_in_progress",
+     "current_target": "<Y>"}`
+  - `{"type": "switch_ack", "accepted": false,
+     "reason": "cooldown", "seconds_remaining": <N>}`
+    NOTE: 1C does NOT emit this `cooldown` ack from the serve
+    side (cooldown is CLI-side per L-7, lands in 1E). The
+    Swift type MUST nonetheless model the case so 1E can wire
+    it without an additional type change.
+  - `{"type": "switch_progress", "state": "loading",
+     "elapsed_ms": <N>}`
+  - `{"type": "switch_progress", "state": "draining",
+     "elapsed_ms": <N>}`
+  - `{"type": "switch_progress", "state": "loaded",
+     "elapsed_ms": <N>}`
+  - `{"type": "switch_progress", "state": "failed",
+     "elapsed_ms": <N>, "reason": "<reason-text>"}`
+  - `{"type": "status_response",
+     "current_model_id": "<X>",
+     "runtime_state": "ready" | "loading" | "draining"}`
+
+  Notes:
+  - `target_model_id` and `current_model_id` are HuggingFace IDs
+    or local paths per SPEC-001 §6.1.
+  - `requested_at_ms` is `Int64` epoch ms (CLI clock).
+  - `elapsed_ms` is `Int` ms since the CLI's
+    `requested_at_ms`.
+  - `reason` enum on `switch_ack`: `loading_in_progress`,
+    `cooldown`, `not_in_supported_models`, `other`. 1C only
+    emits `loading_in_progress` from the serve side
+    (`not_in_supported_models` is CLI-side pre-flight before
+    the socket is even contacted; `cooldown` is 1E; `other`
+    is reserved). All four MUST be representable.
+  - `state` enum on `switch_progress`: `loading`, `draining`,
+    `loaded`, `failed`. 1C emits all four.
+  - `runtime_state` enum on `status_response`: `ready`,
+    `loading`, `draining` (no `failed` — that state is
+    transient per 1B's RuntimeStateMachine.failSwap).
+
+**6. Detection precedence (SPEC-011 R-3.1.5.x).** The CLI side
+of `models <subcommand>` MUST distinguish three connect failure
+modes:
+  - **Case 1 — ENOENT** (`stat(socketPath)` returns ENOENT,
+    or `FileManager.default.fileExists(atPath:)` returns
+    false): exit code 4, stderr `"macprovider-cli serve is
+    not running on this host (no control socket at
+    <socket_path>)"`.
+  - **Case 2 — ECONNREFUSED** (socket file exists but
+    `connect()` returns ECONNREFUSED): exit code 4, stderr
+    `"stale control socket at <socket_path> (no listener);
+    remove the file and restart serve"`.
+  - **Case 3 — handshake timeout** (`connect` succeeds but no
+    `status_response` arrives within 2 seconds of sending
+    `status_request`): exit code 4, stderr `"serve is
+    running but warm-swap is not enabled (or serve is
+    unresponsive); restart serve with --enable-warm-swap"`.
+
+The CLI MUST send a `status_request` frame IMMEDIATELY upon
+successful connect to drive Case 3 detection; only AFTER receiving
+the `status_response` is the connection considered healthy and the
+CLI proceeds with the subcommand-specific frame (e.g.,
+`switch_request` for `models switch`).
+
+**7. `models switch <model-id> [--force]` (SPEC-011 R-3.1.2).**
+The sequence is:
+  Step 1 — Resolve effective `supported_models` via existing
+    `ConfigLoader.load` from
+    `Sources/MacProviderCore/Config.swift` (CLI > ENV > YAML).
+    The `models switch` subcommand MUST accept the SAME
+    `--supported-models` / `--config` flags as `serve` to drive
+    this resolution.
+  Step 2 — Call existing `SupportedModels.validate(model:
+    <X>, supportedModels: resolved.supportedModels)` (from 1A);
+    on `.modelNotInCatalog`, exit code 2 with stderr
+    `"switch target <X> not in --supported-models"` BEFORE
+    contacting the socket.
+  Step 3 — Connect via R-3.1.5.x detection precedence; exit 4
+    on Case 1 / 2 / 3 with the prescribed stderr.
+  Step 4 — Send `switch_request` frame. Read the `switch_ack`
+    reply.
+    - `{accepted: true}` → proceed to Step 5.
+    - `{accepted: false, reason: "loading_in_progress",
+       current_target: "<Y>"}` → exit code 3 with stderr
+       `"provider is already loading <Y>; refusing to start a
+       second swap. Wait for current switch to complete
+       (macprovider-cli models status)"`.
+    - `{accepted: false, reason: "cooldown", seconds_remaining:
+       <N>}` → exit code 6 with stderr `"swap on cooldown for
+       <N>s. Re-issue with --force to bypass"`. (1C will not
+       emit this ack from the server side, but the CLI MUST
+       handle it correctly in case a future server/coordinator
+       does.)
+  Step 5 — Stream `switch_progress` frames to stderr as they
+    arrive. Exit code 0 on receipt of `{state: "loaded"}`;
+    exit code 5 on `{state: "failed", reason: "<R>"}` with
+    stderr `"swap failed: <R>"`.
+
+The CLI MUST set a `requested_at_ms` based on its own clock
+(`Int64(Date().timeIntervalSince1970 * 1000)`). The serve side
+echoes this back in `elapsed_ms` calculations.
+
+`--force` is parsed and ACCEPTED in 1C but has NO observable
+behavior (cooldown bypass is 1E). The CLI flag is plumbed into
+a `ModelsSwitchOptions` struct; the struct field is unused in
+1C beyond storage. A comment near the field MUST cite the
+deferral to Phase 1E.
+
+**8. `models list` (SPEC-011 R-3.1.1).** Implement a minimal
+version:
+  - Attempt R-3.1.5.x case-1 connect to the socket.
+  - If Case 1 (ENOENT) — print `"serve not running; warm-swap
+    disabled"` to stdout and a single-row table indicating only
+    the YAML / ENV / CLI-resolved `model_id` with `state: idle`
+    (no warm). Exit code 0.
+  - If connected and `status_response` received — print a
+    two-column table: `model_id`, `state`. `state` is `warm`
+    for the currently-loaded model (from `status_response.
+    current_model_id`); other entries from
+    `--supported-models` (resolved) are `idle`. Exit code 0.
+
+The full HF-cache directory inspection (R-3.1.1 `disk_size_gb`
+column) is OUT OF SCOPE for 1C (deferred to a future polish
+pass; the spec lists `disk_size_gb` as "optional"). Tests cover
+the two cases above only.
+
+**9. `models status` (SPEC-011 R-3.1.6).** Print the
+`status_response` JSON-ish summary to stdout. Cite the
+detection-precedence stderr verbatim if connect fails.
+
+**10. Serve-side socket lifecycle.** When `serve` is invoked
+with `--enable-warm-swap`:
+  - On startup, BEFORE returning from `ServeCommand.run`'s
+    boot phase, create the parent dir at the resolved socket
+    path with `mkdir -p` + chmod 0700, then bind a Unix-
+    domain stream socket at the path, listen, and accept
+    connections in a long-running task.
+  - On shutdown (sigterm / sigint received by the existing
+    `installTerminationHandler` machinery), close the listener
+    and `unlink(socketPath)`.
+  - On each accepted connection, spawn a task that:
+    1. Reads NDJSON frames line-by-line.
+    2. Dispatches based on `type`.
+    3. For `status_request` → reply with `status_response`
+       from a fresh `currentSnapshot()` call.
+    4. For `switch_request` → call `modelRuntime.beginSwap(...)`;
+       on success, reply `switch_ack accepted:true` and stream
+       `switch_progress` frames driven by the `swapSignals()`
+       AsyncStream; on `RuntimeStateMachineError.notReady` →
+       reply `switch_ack accepted:false reason:loading_in_progress
+       current_target:<X>`; on `WarmSwapDisabledError` → this
+       should be UNREACHABLE because the socket only exists when
+       warm-swap is enabled, but if hit, reply
+       `switch_ack accepted:false reason:other`.
+    5. For unknown / malformed `type` → log + close connection.
+    6. On `\n`-delimited stream end (peer closed) → close.
+
+The serve-side socket accept loop MUST run on a `Task.detached`
+(NOT on the `ModelRuntime` actor's executor) per the SPEC-011
+R-3.2.5 no-starve discipline carried forward from 1B. Tests
+verify that the accept loop survives a slow inference and a
+slow swap.
+
+**11. `--ctl-socket-path` flag (serve-side override).** Plumbed
+via existing CLI > ENV > YAML pattern. ENV var
+`MACPROVIDER_CTL_SOCKET_PATH`; YAML key `ctl_socket_path`.
+Default: `nil`, which resolves to
+`$TMPDIR/macprovider-cli/ctl.sock` at use time. Only meaningful
+when `--enable-warm-swap` is set.
+
+**12. `--switch-state-path` flag (CLI-side cooldown file path).**
+Plumbed via the same pattern. ENV
+`MACPROVIDER_SWITCH_STATE_PATH`; YAML `switch_state_path`.
+Default: `nil`, which resolves to
+`$HOME/Library/Application Support/macprovider-cli/last-switch.ts`
+at use time. The cooldown file itself is NOT read or written in
+1C; only the flag is plumbed. 1E will implement the cooldown
+soft-guard logic. A comment near each flag MUST cite the
+deferral.
+
+**13. `models` subcommand reuses `--config`, `--supported-models`,
+`--ctl-socket-path` from `ServeCommand` config.** The pattern is:
+the `models` subcommand parses the same flags as `serve` for
+config-resolution purposes (so the operator can `macprovider-cli
+models switch foo --supported-models a,b` and have the same
+priority chain as `serve`). Only the cooldown / socket-path flags
+make sense on `models` subcommands; do NOT add `--enable-warm-swap`
+to `models` subcommands (it's a serve-only flag — `models`
+subcommands ALWAYS act as if warm-swap is the goal, and detection
+precedence handles the disabled case).
+
+**14. d-inference clean-room.** Do NOT read any file under
+`phase3-binary/.build/checkouts/`.
+
+**15. Compile + tests pass.** `swift build` and `swift test` MUST
+both exit 0. Cumulative test count after this phase SHOULD be
+≥ 90 (73 from 1A+1B + ≥ 17 new in 1C). All pre-existing tests
+still GREEN.
+
+**16. No drift in 1A/1B surfaces.** Do NOT modify any 1A/1B file
+listed in the constraint preamble. If a 1C requirement seems to
+need a 1A/1B change, STOP and surface the conflict at the top of
+your final report — DO NOT modify those files without operator
+acknowledgement.
+
+## Required reading (in this order — read fully before writing)
+
+1. `/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md`
+   §6.9 (lines 1811-1865) — control socket protocol normative.
+   R-6.9.1 through R-6.9.6 are binding.
+
+2. `/Users/augstar/macprovider-poc/specs/SPEC-011-operator-pushed-warm-swap.md`
+   - §3.1 R-3.1.0 through R-3.1.6 (full text of the `models`
+     subcommand rules, including R-3.1.2 exit codes and stderr
+     messages)
+   - §3.1.5 (control socket protocol — full frame schemas + field
+     reference table)
+   - §3.1.5.x (detection precedence three-case table)
+   - §3.7 R-3.7.x (concurrent switch reply — serve-side only)
+
+3. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+   — full file. Add `ModelsCommand` (parent) and three child
+   subcommands (`ModelsListCommand`, `ModelsSwitchCommand`,
+   `ModelsStatusCommand`) following the existing
+   `AsyncParsableCommand` patterns. The parent is registered on
+   `MacProviderCLI.configuration.subcommands` alongside the
+   existing `ServeCommand`, etc.
+
+4. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+   — actor surface from 1B. You will call:
+   - `beginSwap(targetModelID:) async throws -> Task<Void, Error>`
+   - `currentSnapshot() async -> RuntimeSnapshot`
+   - `swapSignals() async -> AsyncStream<SwapSignal>`
+   You do NOT modify this file.
+
+5. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift`
+   — `SwapState`, `SwapSignal`, `SwapSignal.Outcome` types from 1B.
+
+6. `/Users/augstar/macprovider-poc/phase3-binary/Sources/MacProviderCore/SupportedModels.swift`
+   — pre-flight library from 1A; used unchanged by `models switch`
+   step 2.
+
+7. `/Users/augstar/macprovider-poc/phase3-binary/Sources/MacProviderCore/Config.swift`
+   — extend with `ctlSocketPath: String?` and `switchStatePath:
+   String?` per constraints 11/12.
+
+8. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/HTTPServer.swift`
+   — DO NOT MODIFY. Read only to understand how the serve loop is
+   structured; the control socket accept loop runs alongside, NOT
+   inside the HTTPServer.
+
+## Required edits — exact shape
+
+### A. `ControlSocket.swift` — NEW
+
+Public types and one server class. Suggested skeleton:
+
+```swift
+import Foundation
+
+public enum ControlSocketFrame: Equatable, Sendable {
+    case switchRequest(targetModelID: String, requestedAtMs: Int64)
+    case statusRequest
+    case switchAck(accepted: Bool, reason: SwitchAckReason?, currentTarget: String?, secondsRemaining: Int?)
+    case switchProgress(state: SwitchProgressState, elapsedMs: Int, reason: String?)
+    case statusResponse(currentModelID: String, runtimeState: SwapState)
+}
+
+public enum SwitchAckReason: String, Sendable, Equatable {
+    case loadingInProgress = "loading_in_progress"
+    case cooldown
+    case notInSupportedModels = "not_in_supported_models"
+    case other
+}
+
+public enum SwitchProgressState: String, Sendable, Equatable {
+    case loading, draining, loaded, failed
+}
+
+public enum ControlSocketCodec {
+    public static func encode(_ frame: ControlSocketFrame) throws -> Data
+    public static func decode(_ line: Data) throws -> ControlSocketFrame
+}
+
+public enum ControlSocketError: Error, Equatable {
+    case missingType
+    case unknownType(String)
+    case missingRequiredField(String)
+    case invalidEnumValue(field: String, value: String)
+}
+
+actor ControlSocketServer {
+    init(socketPath: URL, modelRuntime: ModelRuntime) { ... }
+    func start() async throws { ... }   // bind + listen + accept loop on Task.detached
+    func stop() async { ... }           // close listener + unlink socket
+}
+
+public enum ControlSocketClient {
+    public static func connect(socketPath: URL, timeout: TimeInterval = 2.0)
+        async throws -> ControlSocketConnection
+}
+
+public actor ControlSocketConnection {
+    func send(_ frame: ControlSocketFrame) async throws { ... }
+    func receive() async throws -> ControlSocketFrame { ... }
+    func close() async { ... }
+}
+
+public enum ControlSocketConnectError: Error, Equatable {
+    case socketAbsent(path: String)         // R-3.1.5.x case 1
+    case connectionRefused(path: String)    // R-3.1.5.x case 2
+    case handshakeTimeout(path: String)     // R-3.1.5.x case 3
+    case other(underlying: String)
+}
+```
+
+Choose the Unix-domain socket primitive that's already on the
+project's allowed import path. Options, in preference order:
+  1. `SwiftNIO` `NIOPosix.ServerBootstrap` with
+     `.serverChannelInitializer` + `NIOPipeBootstrap` — heavyweight
+     but already a transitive dep via `HTTPServer.swift`.
+  2. Raw Darwin POSIX (`Darwin.socket`, `Darwin.bind`,
+     `Darwin.listen`, `Darwin.accept`) wrapped in async — minimal
+     deps but more code.
+Prefer option 2 if it keeps the file under ~500 lines; the surface
+is small enough to handle directly. The `Foundation.Process` /
+`FileHandle` route does NOT support Unix-domain sockets cleanly
+on macOS.
+
+Encoding rules:
+- Serialize each frame as a single line: `{...}\n`.
+- Use `JSONSerialization.data(withJSONObject: ..., options:
+  [.withoutEscapingSlashes])` to match the project's other JSON
+  wire bytes (CoordinatorClient uses these options).
+- For `switchAck`, fields are conditional per the schema:
+  - `reason` present iff `accepted == false`
+  - `currentTarget` present iff `reason == loadingInProgress`
+  - `secondsRemaining` present iff `reason == cooldown`
+- For `switchProgress`, `reason` present iff `state == failed`.
+
+Decoding rules:
+- Reject frames with missing `type` → throw `.missingType`.
+- Reject unknown `type` strings → throw `.unknownType(...)`.
+- Reject missing required fields → throw `.missingRequiredField(...)`.
+- Reject malformed enum values → throw `.invalidEnumValue(...)`.
+
+### B. `ModelsSubcommand.swift` — NEW
+
+Define `ModelsCommand` (parent) and three subcommands. The
+parent has no `run()` — it delegates via
+`CommandConfiguration(subcommands:)`. Each subcommand:
+
+```swift
+struct ModelsListCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List models known to this provider (warm/idle)."
+    )
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG.")
+    var config: String?
+
+    @Option(help: "Comma-separated list of HuggingFace model IDs (or local paths). Overrides MACPROVIDER_SUPPORTED_MODELS and config supported_models.")
+    var supportedModels: String?
+
+    @Option(help: "Control socket path override. Overrides MACPROVIDER_CTL_SOCKET_PATH and config ctl_socket_path. Default $TMPDIR/macprovider-cli/ctl.sock.")
+    var ctlSocketPath: String?
+
+    func run() async throws {
+        let resolved = try ConfigLoader.load(cli: CLIOverrides(
+            configPath: config,
+            supportedModels: SupportedModels.parseCSV(supportedModels),
+            ctlSocketPath: ctlSocketPath
+        ))
+        let socketPath = ControlSocketPaths.resolve(ctlSocketPath: resolved.ctlSocketPath)
+        do {
+            let connection = try await ControlSocketClient.connect(socketPath: socketPath)
+            try await connection.send(.statusRequest)
+            let response = try await connection.receive()
+            guard case let .statusResponse(currentModelID, runtimeState) = response else {
+                FileHandle.standardError.write(Data(("expected status_response\n").utf8))
+                throw ExitCode(4)
+            }
+            await connection.close()
+            printTable(currentModelID: currentModelID, runtimeState: runtimeState,
+                       supportedModels: resolved.supportedModels)
+        } catch ControlSocketConnectError.socketAbsent(let path) {
+            print("serve not running; warm-swap disabled")
+            FileHandle.standardError.write(Data(
+                ("macprovider-cli serve is not running on this host (no control socket at \(path))\n").utf8))
+            printTable(currentModelID: nil, runtimeState: nil,
+                       supportedModels: resolved.supportedModels)
+            // NOTE: per spec R-3.1.1 — exit 0 in disabled case (table still printed)
+            return
+        } catch ControlSocketConnectError.connectionRefused(let path) {
+            FileHandle.standardError.write(Data(
+                ("stale control socket at \(path) (no listener); remove the file and restart serve\n").utf8))
+            throw ExitCode(4)
+        } catch ControlSocketConnectError.handshakeTimeout(let path) {
+            FileHandle.standardError.write(Data(
+                ("serve is running but warm-swap is not enabled (or serve is unresponsive); restart serve with --enable-warm-swap\n").utf8))
+            throw ExitCode(4)
+        }
+    }
+}
+```
+
+(`ModelsSwitchCommand` and `ModelsStatusCommand` follow the same
+pattern; each handles the three R-3.1.5.x error cases identically.)
+
+The static helper `ControlSocketPaths.resolve(...)` lives in
+`ControlSocket.swift` and applies the default
+`$TMPDIR/macprovider-cli/ctl.sock` when `nil` is passed.
+
+### C. `MacProviderCLI.swift` — extend
+
+After the existing 1A/1B flags on `ServeCommand`, add:
+
+```swift
+@Option(help: "Control socket path. Overrides MACPROVIDER_CTL_SOCKET_PATH and config ctl_socket_path. Default $TMPDIR/macprovider-cli/ctl.sock. Only meaningful when --enable-warm-swap is set.")
+var ctlSocketPath: String?
+
+@Option(help: "CLI-side cooldown state file. Overrides MACPROVIDER_SWITCH_STATE_PATH and config switch_state_path. Default $HOME/Library/Application Support/macprovider-cli/last-switch.ts. Cooldown soft guard lands in Phase 1E.")
+var switchStatePath: String?
+```
+
+Plumb both into `CLIOverrides` and `ConfigLoader.load`. The
+resolved `AppConfig.ctlSocketPath` flows into `ControlSocketServer`
+instantiation in `ServeCommand.run` when `resolved.enableWarmSwap`
+is true:
+
+```swift
+let controlSocket: ControlSocketServer?
+if resolved.enableWarmSwap {
+    let socketURL = ControlSocketPaths.resolve(ctlSocketPath: resolved.ctlSocketPath)
+    controlSocket = ControlSocketServer(socketPath: socketURL, modelRuntime: modelRuntime)
+    try await controlSocket?.start()
+} else {
+    controlSocket = nil
+}
+// ... defer { Task { await controlSocket?.stop() } }
+```
+
+Register `ModelsCommand` as a subcommand of `MacProviderCLI`:
+
+```swift
+subcommands: [
+    ServeCommand.self,
+    SelfTestCommand.self,
+    StatusCommand.self,
+    UpdateCommand.self,
+    UninstallCommand.self,
+    ModelsCommand.self,
+],
+```
+
+### D. `Config.swift` — extend
+
+Add to `AppConfig`:
+
+```swift
+public var ctlSocketPath: String?
+public var switchStatePath: String?
+```
+
+Both default `nil`. Plumb YAML keys `ctl_socket_path` and
+`switch_state_path` (strings), ENV vars
+`MACPROVIDER_CTL_SOCKET_PATH` and `MACPROVIDER_SWITCH_STATE_PATH`,
+and CLI overrides per existing pattern.
+
+### E. `ControlSocketTests.swift` — NEW
+
+Cover frame round-trip and decode rejection cases. Each test
+encodes a frame, decodes the bytes back, and asserts equality
+on the value. Plus the decode-side rejections:
+
+- `testEncodeDecodeSwitchRequest`
+- `testEncodeDecodeStatusRequest`
+- `testEncodeDecodeSwitchAckAccepted`
+- `testEncodeDecodeSwitchAckLoadingInProgress` — verifies
+  `current_target` field present
+- `testEncodeDecodeSwitchAckCooldown` — verifies
+  `seconds_remaining` field present
+- `testEncodeDecodeSwitchProgressLoading`
+- `testEncodeDecodeSwitchProgressFailed` — verifies `reason`
+  field present
+- `testEncodeDecodeStatusResponseReady`
+- `testDecodeRejectsMissingType` — `{"target_model_id": "X"}`
+  throws `.missingType`
+- `testDecodeRejectsUnknownType` — `{"type": "wat"}` throws
+  `.unknownType("wat")`
+- `testDecodeRejectsSwitchRequestMissingTarget` — throws
+  `.missingRequiredField("target_model_id")`
+- `testDecodeRejectsSwitchAckUnknownReason` — throws
+  `.invalidEnumValue(field: "reason", value: "xyz")`
+- `testEncodedBytesHaveNoForwardSlashEscaping` — encodes a
+  switchRequest with `target_model_id: "mlx-community/Llama"`,
+  asserts the resulting bytes contain `mlx-community/Llama`
+  literally (NOT `mlx-community\/Llama`)
+
+Plus serve-side socket lifecycle tests (using a temp directory):
+- `testServerBindsAndAcceptsConnection` — start a server on a
+  tmp socket path, connect via Darwin POSIX from the test,
+  send `status_request`, receive `status_response`, assert
+  current_model_id matches
+- `testServerRefusesStartIfSocketAlreadyExists` — pre-create
+  the socket file path with empty content, attempt
+  `server.start()`, assert it throws and the stderr message
+  matches constraint 3
+- `testServerSocketParentDirIs0700AndSocketIs0600` — after
+  `start()`, `stat` the parent dir and socket file and
+  assert modes
+- `testServerStopUnlinksSocket` — start, stop, assert
+  socket file no longer exists
+
+### F. `ModelsSubcommandTests.swift` — NEW
+
+Cover the CLI side. Each test stands up a `ControlSocketServer`
+on a tmp path against a stub `ModelRuntime` (use 1B's test
+loader injection), then runs the parsed subcommand and asserts
+on exit code + stdout/stderr.
+
+- `testModelsStatusReturnsStatusResponse` — connect to a
+  running server, receive status_response, assert stdout
+  contains the model ID
+- `testModelsStatusCase1ENOENT` — point ctl-socket-path at a
+  non-existent file, run `models status`, expect ExitCode(4)
+  and stderr containing `"is not running on this host"`
+- `testModelsStatusCase2ECONNREFUSED` — create a regular
+  file at the socket path (not a real listener), run
+  `models status`, expect ExitCode(4) and stderr containing
+  `"stale control socket"`
+- `testModelsSwitchSuccess` — start a server with warm-swap-
+  enabled stub runtime + 50ms stub loader, run `models switch
+  new-model --supported-models old,new --model old`, expect
+  ExitCode(0), stderr contains a `switch_progress` ladder
+  (loading → loaded), stdout/stderr contains "loaded"
+- `testModelsSwitchPreFlightRejection` — run `models switch
+  C --supported-models A,B --model A`, expect ExitCode(2) and
+  stderr containing `"switch target C not in
+  --supported-models"`, AND assert NO socket connection
+  occurred (e.g., point ctl-socket-path at a non-existent
+  file and verify it's still absent after the command)
+- `testModelsSwitchConcurrentRejection` — start a server,
+  drive a slow swap to put state in loading, then run a
+  second `models switch other-model`, expect ExitCode(3)
+  and stderr containing `"provider is already loading"`
+
+## Done criteria
+
+You are done when:
+
+- `git diff -- specs/ phase4-coordinator/ phase5-gateway/` shows
+  only the operator-authored BUILD prompts under
+  `specs/BUILD_SPEC_001_v1_3_IMPL_*` and the pre-existing
+  `specs/FOLLOWUP_COORDINATOR_HA_2026_06_03.md` unstaged edit.
+- `cd phase3-binary && swift build` exits 0.
+- `cd phase3-binary && swift test` exits 0 with ≥ 90 tests
+  green.
+- All Phase 1A + 1B tests still GREEN (no regressions).
+- `grep -rn "XDG_RUNTIME_DIR" phase3-binary/Sources/` returns
+  zero matches.
+- `grep -rn "ctl.sock" phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+  returns zero matches (the control socket is NOT wired into
+  the WS coordinator client; they are independent surfaces).
+- A v1.3 binary started with `serve` WITHOUT
+  `--enable-warm-swap` does NOT create any file at
+  `$TMPDIR/macprovider-cli/ctl.sock` (verifiable by checking
+  the `ControlSocketServer` is only instantiated when
+  `resolved.enableWarmSwap == true`).
+- `models <subcommand>` invoked against a non-existent socket
+  exits 4 with the R-3.1.5.x case-1 stderr.
+
+## Out of scope (do NOT do these in Phase 1C)
+
+- Cooldown soft guard + cooldown state file read/write —
+  Phase 1E (1C plumbs the `--switch-state-path` flag only;
+  no read/write logic)
+- `--force` cooldown bypass logic — Phase 1E (1C accepts the
+  flag as a no-op)
+- Server-side `switch_ack accepted:false reason:cooldown`
+  emission — Phase 1E
+- Heartbeat extension (`model_hash` / `loading`) — Phase 1D
+- `helloMessage()` source-of-truth rule on WS reconnect —
+  Phase 1D
+- WS drop policies mid-load — Phase 1E
+- HF cache `disk_size_gb` column in `models list` — out of
+  scope for 1C (spec marks `disk_size_gb` as optional;
+  future polish)
+- Modifying `phase4-coordinator/` — Phase 2
+
+## Self-check before reporting done
+
+Run this command and confirm all checks pass:
+
+```bash
+cd /Users/augstar/macprovider-poc && \
+  git diff --stat -- specs/ phase4-coordinator/ phase5-gateway/ && \
+  echo "----" && \
+  (cd phase3-binary && swift build 2>&1 | tail -5) && \
+  echo "----" && \
+  (cd phase3-binary && swift test 2>&1 | grep "Executed.*tests" | tail -3) && \
+  echo "----" && \
+  grep -rn "XDG_RUNTIME_DIR" phase3-binary/Sources/ || echo "no XDG_RUNTIME_DIR (correct)" && \
+  echo "----" && \
+  grep -rn "model_hash.*loading\|loading.*model_hash" phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift || echo "no heartbeat extension wired (correct — 1D)"
+```
+
+Return:
+- A brief diff summary (files touched, +/- lines).
+- The final `swift test` summary line (Executed N tests, ...).
+- Any spec rule you were unable to satisfy exactly, with the
+  binding rule number and your interpretation.
+
+Do NOT commit. Do NOT push. The operator audits the working tree
+before commit.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (out-of-band)
+
+- Expected wall-clock: 120-150 min. 1C touches the operator-facing
+  surface (socket protocol + CLI subcommand) and the integration
+  surface (serve-side accept loop + signal-stream → progress
+  frame translation).
+- Audit pass (Claude Opus) reads the diff and tests against the
+  16 constraints + done criteria. Key audit foci:
+  - **Constraint 1 (L-1)** — verify the `ControlSocketServer` is
+    only instantiated when `resolved.enableWarmSwap == true`.
+  - **Constraint 3 (stale socket)** — verify the `bind()` failure
+    is surfaced rather than silently unlinking.
+  - **Constraint 4 (NDJSON)** — verify frames are line-terminated
+    and rejected on missing `type`.
+  - **Constraint 6 (detection precedence)** — verify all three
+    R-3.1.5.x cases match the prescribed stderr exactly.
+  - **Constraint 7 (switch exit codes)** — verify all five exit
+    codes (0/2/3/4/5/6) are reachable in tests.
+- R2 prompt is drafted only if R1 audit surfaces findings.
+- After 1C LOCKs and commits to the branch, draft 1D (heartbeat
+  extension + `hello.model_hash` source-of-truth on reconnect)
+  referencing the actual signal-stream consumption pattern from
+  1C.

--- a/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1D_PROMPT.md
+++ b/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1D_PROMPT.md
@@ -1,0 +1,628 @@
+# Implementation BUILD prompt — SPEC-001 v1.3 Phase 1D (heartbeat extension + hello.model_hash source-of-truth)
+
+Operator-paste prompt for Codex GPT-5 to land the **fourth** of five
+implementation sub-phases of SPEC-001 v1.3 in `phase3-binary/`.
+This phase wires the operator-observable warm-swap signal onto the
+coordinator WebSocket: opt-in `model_hash` (raw 64-char lowercase
+hex) and `loading: bool` fields on the heartbeat frame, plus the
+`hello.model_hash` source-of-truth rule when reconnecting mid-swap.
+Consumes the `swapSignals()` AsyncStream from Phase 1B to drive an
+immediate heartbeat after the atomic swap completes.
+
+**Scope: SPEC-011 v0.5 §3.3 heartbeat extension + §3.8.3 hello
+reconnect rule.** No CLI changes, no new flags, no control socket
+work, no cooldown logic (1E), no concurrent-switch-policy
+elaboration beyond what 1C already implements.
+
+**One-line summary.** Extend `CoordinatorClient.sendHeartbeat`
+(`phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:588`)
+to emit `model_hash` (raw lowercase hex) and `loading: bool` ONLY
+when `--enable-warm-swap` is set, sourced from
+`modelRuntime.currentSnapshot()` rather than the stale
+`providerStatus.modelHash` boot snapshot. Extend
+`helloMessage()` (line 692) to source `model_hash` from
+`modelRuntime.currentSnapshot()` when warm-swap is enabled,
+preserving byte-identical behavior in disabled mode. Consume the
+`RuntimeStateMachine.signalStream()` from 1B and translate
+`SwapSignal.Outcome.completed` into an immediate heartbeat per
+SPEC-011 R-3.2.4 step 4. L-1 byte-identical default preserved
+literally: with `--enable-warm-swap` unset, the heartbeat frame
+and hello frame are byte-identical to v1.2.4.
+
+**Locked-spec dependencies (DO NOT contradict).**
+- SPEC-001 v1.3 §6.10 (lines 1867-1916) — this phase's normative
+  section, citing SPEC-011 R-3.3.0 through R-3.3.3, R-3.2.4 step 4,
+  R-3.8.3
+- SPEC-001 v1.3 §6.11.2 (lines 1930-1940) — WS drop mid-load rule,
+  citing SPEC-011 R-3.8.1, R-3.8.3, R-3.8.5
+- SPEC-011 v0.5 §3.3 (heartbeat extension), §3.8 (WS drop), R-3.2.5
+  (no-starve isolation — preserved from 1B)
+- 1A (commit 6744d7c) — `Config.enableWarmSwap` plumbing
+- 1B (commit 5c03e88) — `ModelRuntime.currentSnapshot`,
+  `swapSignals`, `RuntimeStateMachine`
+- 1C (commit 9a4a6c5) — already consumes `swapSignals` in
+  `ControlSocketServer.handleSwitchRequest`; 1D adds a *second*
+  consumer (heartbeat task) and the two streams MUST NOT interfere
+
+Spec-text-only edits are FORBIDDEN. No edits under `specs/`
+(operator-authored BUILD prompts excepted). Verify with
+`git diff -- specs/` after edits.
+
+Run in **Codex CLI** via `omc ask codex` from session root
+`/Users/augstar/macprovider-poc`. Expected wall-clock: ~60-90 min
+(one file modified heavily, one test file extended; no new files).
+
+Branch: `fix/spec-001-v1-3-binary` already carries Phases 1A + 1B + 1C.
+Codex MUST commit on this branch, MUST NOT create a new one, and
+MUST NOT commit or push (operator audits before commit).
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are implementing Phase 1D of SPEC-001 v1.3 in the Swift binary
+at /Users/augstar/macprovider-poc/phase3-binary/. SPEC-001 v1.3 is
+LOCKED. SPEC-011 v0.5 is LOCKED. Phases 1A (6744d7c), 1B (5c03e88),
+and 1C (9a4a6c5) are already on this branch.
+
+You will edit the following files (and ONLY these):
+
+  phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift           (extend)
+  phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift   (extend)
+
+You will NOT edit any other Swift file, any file under `specs/`,
+`phase4-coordinator/`, or `phase5-gateway/`. You will NOT touch:
+- `Sources/MacProviderCore/SupportedModels.swift` (1A)
+- `Sources/MacProviderCore/Config.swift` (1A/1B/1C)
+- `Sources/macprovider-cli/RuntimeStateMachine.swift` (1B)
+- `Sources/macprovider-cli/ModelRuntime.swift` (1B)
+- `Sources/macprovider-cli/HTTPServer.swift` (1B)
+- `Sources/macprovider-cli/ControlSocket.swift` (1C)
+- `Sources/macprovider-cli/ModelsSubcommand.swift` (1C)
+- `Sources/macprovider-cli/MacProviderCLI.swift` (extended in 1A/1B/1C)
+- Any 1A/1B/1C test file beyond `CoordinatorClientTests.swift`
+
+Verify with `git diff -- specs/ phase4-coordinator/ phase5-gateway/`
+— must be empty (excluding operator-authored
+`specs/BUILD_SPEC_001_v1_3_IMPL_*` prompts).
+
+## Critical constraints
+
+**1. L-1 byte-identical default per SPEC-001 v1.3 AC-N.0.**
+With `--enable-warm-swap` UNSET, the heartbeat frame emitted by
+`sendHeartbeat()` and the hello frame emitted by `helloMessage()`
+MUST be byte-identical to the SPEC-001 v1.2.4 baseline. This
+means:
+  - `model_hash` key MUST NOT appear in the heartbeat frame
+    JSON (not present, not null, not empty string)
+  - `loading` key MUST NOT appear in the heartbeat frame JSON
+  - `helloMessage()` continues to read `modelHash` from
+    `providerStatus.snapshot().modelHash` (the boot-time value)
+    as it does today — DO NOT switch the disabled-mode hello
+    path to `modelRuntime.currentSnapshot()`. The disabled
+    code path is byte-frozen.
+
+A new test MUST pin this invariant by JSON-serializing both
+frames in disabled mode and asserting on the absence of the
+two field names AND on byte-equality against a captured-in-test
+canonical baseline string.
+
+**2. SPEC-011 R-3.3.0 opt-in gating.** Both new fields are
+emitted ONLY when the operator started `serve` with
+`--enable-warm-swap`. The gating signal is
+`config.enableWarmSwap` (from 1B's `AppConfig`). Add a private
+`let warmSwapEnabled: Bool` field to `CoordinatorClient`,
+populated from `config.enableWarmSwap` in the existing init.
+
+**3. SPEC-011 R-3.3.1 + SPEC-001 v1.3 R-6.10.2 — `model_hash`
+field format.** When emitted, `model_hash` MUST be:
+  - A raw 64-character lowercase hex string
+  - NO `sha256:` prefix
+  - NO uppercase characters
+  - The exact output of `modelWeightArtifactManifestHash()` at
+    `ModelRuntime.swift:294-325` (which already returns
+    lowercase hex via the `hexString()` helper at line 340)
+The source-of-truth for the value is
+`await modelRuntime.currentSnapshot().modelHash` (a `String?`).
+If nil (model not loaded), the `model_hash` field MUST be
+OMITTED entirely (not null, not empty string) from the
+heartbeat frame.
+
+**4. SPEC-011 R-3.3.3 + SPEC-001 v1.3 R-6.10.3 — `loading`
+field semantics.** When emitted, `loading: Bool` MUST be:
+  - `true` when `modelRuntime.currentSnapshot().state == .loading`
+    or `.draining`
+  - `false` when `.ready`
+  - `.failed` is transient (see 1B's `RuntimeStateMachine`);
+    if observed treat as `false` (the rollback brings state
+    back to `.ready` before any heartbeat tick)
+The field MUST always be emitted when warm-swap is enabled —
+even when state is `.ready`, the field is present as `false`
+(unlike `model_hash` which is omitted when nil). This is the
+spec's distinction: `model_hash` is informational and conditional
+on having a loaded model; `loading` is a state probe and always
+present.
+
+**5. SPEC-011 R-3.2.4 step 4 — immediate heartbeat after swap.**
+When the swap completes (atomic-swap step 3 finishes and state
+returns to `.ready`), the binary MUST emit a heartbeat as
+quickly as possible carrying the NEW `model_hash` and
+`loading: false`. The mechanism: a background task (spawned
+in `start()` and torn down in `stop()`) consumes
+`await modelRuntime.swapSignals()` and, on
+`SwapSignal.Outcome.completed`, triggers `sendHeartbeat()`
+out-of-cadence WITHOUT cancelling the regular heartbeat
+schedule.
+
+Implementation guidance:
+  - Add a `swapHeartbeatTask: Task<Void, Never>?` field
+  - In `start()` (when warm-swap is enabled), spawn the task
+    that iterates `swapSignals()` and calls `try await
+    sendHeartbeat()` on `.completed` outcomes
+  - On `.failed` outcomes, do NOT emit a special heartbeat
+    here (the state has already returned to `.ready` per 1B
+    `failSwap`, and the regular heartbeat tick will reflect
+    `loading: false` + OLD `model_hash`); however log an
+    informational line `coordinator.warmSwap.swapFailed
+    reason=<X>` for operator diagnostics
+  - In `stop()` and `closeWebSocketAfterKeepaliveFailure()`,
+    cancel the task
+  - The task MUST be resilient to send failures — if
+    `sendHeartbeat()` throws (WS dropped), log and continue
+    iterating; the next signal triggers another attempt
+
+The signal-driven heartbeat MUST share the same suspension
+discipline as the regular heartbeat — both run as
+`Task { ... }` against the actor's serial executor — so that
+WS send ordering is preserved.
+
+**6. SPEC-011 R-3.8.3 + SPEC-001 v1.3 R-6.10.5 — hello
+reconnect source-of-truth.** The `helloMessage()` function
+MUST be extended to:
+  - When `warmSwapEnabled == true`: source `model_hash` from
+    `await modelRuntime.currentSnapshot().modelHash` (the LIVE
+    container hash, which is the OLD hash during in-flight
+    loads because `applySwap` writes only AFTER load
+    succeeds per 1B R-3.2.4 step 3)
+  - When `warmSwapEnabled == false`: keep reading
+    `snapshot.modelHash` from `providerStatus.snapshot()` as
+    today (the existing line:
+    `if let modelHash = snapshot.modelHash { message["model_hash"] = modelHash }`)
+    — this preserves L-1 byte-identical default
+
+A new test MUST construct a scenario where:
+  1. ModelRuntime has OLD model_id "A" with OLD hash "old-hash"
+  2. A swap to "B" is in-flight (state == .loading); the OLD
+     container has NOT been replaced yet (1B R-3.2.2 / R-3.2.4)
+  3. `helloMessage()` is called (simulating a WS reconnect)
+  4. The returned message MUST contain `model_hash: "old-hash"`,
+     NOT some new value, NOT empty, NOT missing
+
+This is the "source-of-truth rule" the spec is naming.
+
+**7. authProofMessage UNTOUCHED.** Per Phase 1A's deferral (the
+prompt that produced 1A noted the proof-stage re-send of SPEC-010
+fields is byte-frozen unless a CRITICAL audit finding forces it),
+do NOT modify `authProofMessage` in 1D either. The proof-stage
+heartbeat extension is OUT OF SCOPE; SPEC-011 R-3.3 covers
+ongoing heartbeats, not the proof handshake.
+
+**8. authInitialMessage UNTOUCHED.** The Phase 1A SPEC-010
+emission block at line 670-682 is locked. 1D does NOT add
+`model_hash` or `loading` to the v2 `auth_request` initial-stage
+frame. The auth path already has its own optional `model_hash`
+field (line 686-688) sourced from `providerStatus.snapshot()`;
+that path is BOOT-TIME and operates BEFORE warm-swap is even
+relevant. Leave it as is.
+
+**9. ProviderStatus untouched.** Do NOT add a swap-aware update
+to `ProviderStatus.modelHash` (the boot-time field). The
+warm-swap signal flows through `ModelRuntime.currentSnapshot()`
+exclusively. `ProviderStatus.modelHash` remains the
+boot-snapshot reference used by disabled-mode paths and by the
+SPEC-008 attestation hooks. Tests verify this isolation.
+
+**10. d-inference clean-room.** Do NOT read any file under
+`phase3-binary/.build/checkouts/`.
+
+**11. Compile + tests pass.** `swift build` and `swift test` MUST
+both exit 0. Cumulative test count after this phase SHOULD be
+≥ 105 (97 from 1A+1B+1C + ≥ 8 new in 1D). All pre-existing
+tests still GREEN.
+
+**12. No drift in 1A/1B/1C surfaces.** Do NOT modify any 1A/1B/1C
+file outside the two listed targets above. If a 1D requirement
+seems to need a 1B/1C change, STOP and surface the conflict at
+the top of your final report.
+
+**13. authInitialMessage line numbers.** The SPEC-010 emission
+block in `authInitialMessage` currently lives at lines 670-682
+of `CoordinatorClient.swift`. The heartbeat extension lives in
+`sendHeartbeat` at lines 588-605. The `helloMessage()` function
+is at lines 692-720. These line numbers are reference anchors
+for the audit — DO NOT refactor that part of the file in ways
+that shift them (you may add lines at the end of `sendHeartbeat`
+and inside `helloMessage` — that's normal — but do not introduce
+unrelated refactors that move the existing handlers around).
+
+## Required reading (in this order — read fully before writing)
+
+1. `/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md`
+   §6.10 (lines 1867-1916) — heartbeat extension and reconnect
+   source-of-truth normative section. R-6.10.1 through R-6.10.5
+   are binding.
+
+2. `/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md`
+   §6.11.2 (lines 1930-1940) — WS drop mid-load policy. R-6.11.3
+   and R-6.11.4 are binding (1D enforces the reconnect path; 1E
+   handles operator-side concurrent-switch policy on the CLI
+   side).
+
+3. `/Users/augstar/macprovider-poc/specs/SPEC-011-operator-pushed-warm-swap.md`
+   §3.3 (heartbeat extension R-3.3.0 through R-3.3.3) and §3.8
+   (WS drop R-3.8.1, R-3.8.3, R-3.8.5) — full text.
+
+4. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+   - Lines 78-132 (`init`) — add `warmSwapEnabled` and the swap
+     signal task field
+   - Lines 134-154 (`start` + `stop`) — wire the swap signal task
+     lifecycle
+   - Lines 465-481 (`startHeartbeat`) — existing heartbeat loop
+   - Lines 588-605 (`sendHeartbeat`) — extend the JSON dict
+   - Lines 648-690 (`authInitialMessage`) — DO NOT MODIFY
+   - Lines 692-720 (`helloMessage`) — extend the model_hash
+     source
+
+5. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+   lines 130-141 — `currentSnapshot()` and `swapSignals()` actor
+   surface from 1B. Consumed unchanged.
+
+6. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift`
+   — `SwapSignal`, `SwapSignal.Outcome` types from 1B.
+
+7. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ControlSocket.swift`
+   handleSwitchRequest at lines 359-401 — the OTHER consumer of
+   `swapSignals()`. 1D's consumer MUST be a separate
+   `swapSignals()` call (each call returns a NEW AsyncStream;
+   they don't share state). Verify by reading 1B's
+   `RuntimeStateMachine.signalStream()` at lines 61-65:
+   each call appends a new continuation to `signalContinuations`,
+   so multiple consumers each get their own stream. Good.
+
+8. `/Users/augstar/macprovider-poc/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift`
+   — existing test patterns including 1A's `authInitialMessage`
+   and `helloMessage` tests. Mirror their fixture style for the
+   new heartbeat / hello tests.
+
+## Required edits — exact shape
+
+### A. `CoordinatorClient.swift` — extend init
+
+Add field:
+
+```swift
+private let warmSwapEnabled: Bool
+private var swapHeartbeatTask: Task<Void, Never>?
+```
+
+In `init` (around line 121, after `self.publishesSupportedModels`),
+assign:
+
+```swift
+self.warmSwapEnabled = config.enableWarmSwap
+self.swapHeartbeatTask = nil
+```
+
+### B. `start()` and `stop()` — lifecycle the swap signal task
+
+In `start()` (line 134), after the existing
+`runTask = Task { ... }` block, spawn the swap signal consumer
+when warm-swap is enabled. Suggested skeleton:
+
+```swift
+func start() {
+    guard runTask == nil else { return }
+    runTask = Task { [weak self] in
+        await self?.runReconnectLoop()
+    }
+    if warmSwapEnabled {
+        swapHeartbeatTask = Task { [weak self] in
+            await self?.consumeSwapSignals()
+        }
+    }
+}
+```
+
+Add a new private method:
+
+```swift
+private func consumeSwapSignals() async {
+    let stream = await modelRuntime.swapSignals()
+    for await signal in stream {
+        if Task.isCancelled { return }
+        switch signal.outcome {
+        case .completed:
+            do {
+                try await sendHeartbeat()
+            } catch {
+                Self.keepaliveDebug("warm_swap_heartbeat_send_error error=\(error)")
+            }
+        case let .failed(reason):
+            Self.keepaliveDebug("warm_swap_swap_failed reason=\(reason)")
+        }
+    }
+}
+```
+
+In `stop()` (line 141), cancel the task:
+
+```swift
+func stop() async {
+    runTask?.cancel()
+    heartbeatTask?.cancel()
+    swapHeartbeatTask?.cancel()
+    // ... existing cleanup ...
+    swapHeartbeatTask = nil
+}
+```
+
+Also cancel in `closeWebSocketAfterKeepaliveFailure()` (line
+489) IF the existing structure ties it to disconnect cleanup —
+read the existing flow and match the discipline. The
+`swapHeartbeatTask` MUST survive WS reconnect attempts (per
+R-3.8.5 the in-process load is independent of WS connectivity).
+
+### C. `sendHeartbeat()` — extend with conditional fields
+
+Locate `sendHeartbeat()` at line 588. AFTER the existing
+`providerStatus.snapshot(resetWindow: true)` and BEFORE the
+`try await send(...)` call, add a conditional block that
+augments the dict when warm-swap is enabled:
+
+```swift
+private func sendHeartbeat() async throws {
+    let snapshot = await providerStatus.snapshot(resetWindow: true)
+    var payload: [String: Any] = [
+        "type": "heartbeat",
+        "status": snapshot.status.rawValue,
+        "model_id": snapshot.modelID ?? "",
+        // ... existing fields ...
+    ]
+    if warmSwapEnabled {
+        let runtimeSnapshot = await modelRuntime.currentSnapshot()
+        if let hash = runtimeSnapshot.modelHash {
+            payload["model_hash"] = hash
+        }
+        payload["loading"] = (runtimeSnapshot.state == .loading
+                              || runtimeSnapshot.state == .draining)
+    }
+    try await send(payload)
+}
+```
+
+Key points:
+- `model_hash` only added if `runtimeSnapshot.modelHash != nil`
+- `loading` ALWAYS added when warm-swap enabled (true or false)
+- Both fields ABSENT when warm-swap disabled (L-1 invariant)
+
+### D. `helloMessage()` — extend source-of-truth
+
+Locate `helloMessage()` at line 692. Find the existing line
+(around 715):
+
+```swift
+if let modelHash = snapshot.modelHash {
+    message["model_hash"] = modelHash
+}
+```
+
+REPLACE it with conditional source-of-truth:
+
+```swift
+let hashForHello: String? = await {
+    if warmSwapEnabled {
+        return await modelRuntime.currentSnapshot().modelHash
+    }
+    return snapshot.modelHash
+}()
+if let hashForHello {
+    message["model_hash"] = hashForHello
+}
+```
+
+(or equivalently, use an explicit `if warmSwapEnabled` /
+`else` branch — whichever reads cleaner in context. The
+KEY semantic: warm-swap enabled → read from modelRuntime;
+warm-swap disabled → read from providerStatus.)
+
+### E. `CoordinatorClientTests.swift` — extend
+
+Reuse the existing test fixture style (the 1A
+`testAuthInitialDefaultsToSingleEntryCatalog` and
+`testHelloMessageUnchangedByPhase1A` tests are the model). Add
+the following XCTests. Each constructs a `CoordinatorClient`
+via the test init, calls the relevant frame builder, serializes
+the result to JSON, and asserts on the JSON.
+
+Required new tests:
+
+- `testHeartbeatDisabledModeOmitsBothFields` — construct with
+  `AppConfig.enableWarmSwap = false`, capture the serialized
+  heartbeat JSON via the `sendOverride` mechanism (already in
+  CoordinatorClient init), assert the JSON does NOT contain
+  the substring `"model_hash"` AND does NOT contain `"loading"`.
+
+- `testHeartbeatEnabledModeReadyEmitsLoadingFalse` — construct
+  with `enableWarmSwap = true`, a `ModelRuntime` in `.ready`
+  state with a known modelHash "test-hash", assert the JSON
+  contains `"model_hash":"test-hash"` AND `"loading":false`.
+
+- `testHeartbeatEnabledModeLoadingEmitsLoadingTrue` — construct
+  with warm-swap enabled, drive the state machine to `.loading`
+  (via 1B's `beginSwap` with a slow stub loader), capture a
+  heartbeat WHILE the state is still `.loading`, assert
+  `"loading":true`. Also assert `model_hash` is the OLD hash
+  (because the swap hasn't completed yet, `currentSnapshot()`
+  still returns the old container's hash).
+
+- `testHeartbeatEnabledModeOmitsModelHashWhenNil` — construct
+  with warm-swap enabled and a `ModelRuntime` constructed with
+  `modelID: nil` (no model loaded), assert the heartbeat JSON
+  contains `"loading":false` but does NOT contain the substring
+  `"model_hash"`.
+
+- `testHelloDisabledModeReadsFromProviderStatus` — construct
+  with `enableWarmSwap = false`, a `ProviderStatus` carrying
+  `modelHash: "boot-hash"`, a `ModelRuntime` with a DIFFERENT
+  hash "runtime-hash" (e.g., a stub that has been swapped),
+  call `helloMessage()`, assert the JSON contains
+  `"model_hash":"boot-hash"` (the providerStatus value, NOT
+  the runtime value). This pins the L-1 disabled-mode source
+  invariant.
+
+- `testHelloEnabledModeReadsFromModelRuntime` — construct
+  with `enableWarmSwap = true`, ProviderStatus has
+  `modelHash: "boot-hash"`, ModelRuntime has hash
+  "runtime-hash", call `helloMessage()`, assert the JSON
+  contains `"model_hash":"runtime-hash"`.
+
+- `testHelloDuringInFlightSwapReturnsOldHash` — this is the
+  source-of-truth invariant (R-6.10.5). Construct with
+  warm-swap enabled. Drive `beginSwap` to a NEW model with
+  a slow stub loader. WHILE state is `.loading`, call
+  `helloMessage()`. Assert the JSON's `model_hash` value
+  matches the OLD container's hash (because `applySwap`
+  hasn't run yet per 1B R-3.2.4 step 3). After awaiting the
+  swap task, call `helloMessage()` again — assert the JSON's
+  `model_hash` now matches the NEW hash.
+
+- `testSwapCompletionTriggersImmediateHeartbeat` — construct
+  with warm-swap enabled, capture heartbeats via
+  `sendOverride`, drive a swap to completion, assert that
+  WITHIN 500ms of the swap's `Task.value` returning, a
+  heartbeat appeared in the capture buffer carrying the NEW
+  `model_hash`. This pins R-3.2.4 step 4 "signal heartbeat
+  task to emit a new heartbeat".
+
+- (Optional but recommended) `testSwapFailureLogsAndContinues`
+  — drive a failing swap with a throwing stub loader; assert
+  the regular heartbeat cadence continues; no special heartbeat
+  is emitted on `.failed`; if your implementation logs to a
+  test-observable channel, assert the log line is present.
+
+If `CoordinatorClient` initialization in these tests requires
+the same fixture pattern as 1A (`ModelRuntime` with the test
+init overload, a stubbed `Tier2AttestationGenerator`, etc.),
+mirror that pattern. The `sendOverride` parameter on
+`CoordinatorClient.init` is the standard way to capture frame
+emissions in tests — use it.
+
+## Done criteria
+
+You are done when:
+
+- `git diff -- specs/ phase4-coordinator/ phase5-gateway/` shows
+  only the operator-authored BUILD prompts under
+  `specs/BUILD_SPEC_001_v1_3_IMPL_*` and the pre-existing
+  `specs/FOLLOWUP_COORDINATOR_HA_2026_06_03.md` unstaged edit.
+- `git diff -- phase3-binary/Sources/MacProviderCore/
+  phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift
+  phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+  phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+  phase3-binary/Sources/macprovider-cli/ControlSocket.swift
+  phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+  phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+  is empty (1D does not touch any of these).
+- `cd phase3-binary && swift build` exits 0.
+- `cd phase3-binary && swift test` exits 0 with ≥ 105 tests
+  green.
+- All Phase 1A + 1B + 1C tests still GREEN (no regressions).
+- In disabled mode: heartbeat JSON does NOT contain `model_hash`
+  or `loading` keys (verified by
+  `testHeartbeatDisabledModeOmitsBothFields`).
+- In disabled mode: hello JSON `model_hash` value matches
+  `providerStatus.modelHash` (verified by
+  `testHelloDisabledModeReadsFromProviderStatus`).
+- In enabled mode: heartbeat carries `model_hash` (raw 64-char
+  lowercase hex when non-nil; omitted when nil) and `loading:
+  Bool` (always present).
+- In enabled mode: `helloMessage()` reads `model_hash` from
+  `modelRuntime.currentSnapshot()`, NOT from
+  `providerStatus.snapshot()`.
+- Swap completion triggers an immediate heartbeat carrying the
+  new hash (verified by
+  `testSwapCompletionTriggersImmediateHeartbeat`).
+
+## Out of scope (do NOT do these in Phase 1D)
+
+- CLI-side cooldown soft guard read/write — Phase 1E
+- `--force` cooldown bypass behavior — Phase 1E
+- Server-side `switch_ack accepted:false reason:cooldown`
+  emission — Phase 1E
+- WS drop reconnect path other than the `model_hash` source-of-
+  truth rule (the actual reconnect machinery is already in
+  CoordinatorClient.runReconnectLoop and is unchanged)
+- Concurrent-switch policy beyond what 1C already implements
+- `authProofMessage` SPEC-010 re-send — out of scope for 1D
+  (would only matter if a CRITICAL audit on SPEC-010 forced it)
+- Modifying `phase4-coordinator/` — Phase 2
+
+## Self-check before reporting done
+
+Run this command and confirm all checks pass:
+
+```bash
+cd /Users/augstar/macprovider-poc && \
+  git diff --stat -- specs/ phase4-coordinator/ phase5-gateway/ && \
+  echo "----" && \
+  git diff --stat -- phase3-binary/Sources/MacProviderCore/ phase3-binary/Sources/macprovider-cli/ModelRuntime.swift phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift phase3-binary/Sources/macprovider-cli/HTTPServer.swift phase3-binary/Sources/macprovider-cli/ControlSocket.swift phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift && \
+  echo "----" && \
+  (cd phase3-binary && swift build 2>&1 | tail -5) && \
+  echo "----" && \
+  (cd phase3-binary && swift test 2>&1 | grep "Executed.*tests" | tail -3) && \
+  echo "----" && \
+  grep -n "model_hash\|\"loading\"" phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift | head -10
+```
+
+The second diff stat MUST show 0 files changed (no out-of-scope
+edits).
+
+Return:
+- A brief diff summary (files touched, +/- lines).
+- The final `swift test` summary line (Executed N tests, ...).
+- Any spec rule you were unable to satisfy exactly, with the
+  binding rule number and your interpretation.
+
+Do NOT commit. Do NOT push. The operator audits the working tree
+before commit.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (out-of-band)
+
+- Expected wall-clock: 60-90 min. 1D is smaller than 1B/1C —
+  one file modified, one test file extended, no new files.
+- Audit pass (Claude Opus) reads the diff and tests against the
+  13 constraints + done criteria. Key audit foci:
+  - **Constraint 1 (L-1)** — verify both heartbeat and hello
+    frames are byte-identical to v1.2.4 in disabled mode.
+    The disabled-mode hello must source `model_hash` from
+    `providerStatus`, NOT `modelRuntime` — a regression here
+    breaks L-1.
+  - **Constraint 5 (immediate heartbeat after swap)** —
+    verify the `swapHeartbeatTask` is correctly spawned in
+    `start()` AND torn down in `stop()`. Test the
+    swap-completion trigger end-to-end with timing assertions.
+  - **Constraint 6 (hello source-of-truth)** — verify the
+    enabled-mode hello reads `currentSnapshot().modelHash`
+    and that the test pinning the in-flight case actually
+    captures the OLD hash (not nil, not the new hash).
+- R2 prompt is drafted only if R1 audit surfaces findings.
+- After 1D LOCKs and commits to the branch, draft 1E
+  (cooldown soft guard + `--force` bypass + concurrent-switch
+  policy elaboration + end-to-end ACs) — the final phase of
+  SPEC-001 v1.3 binary implementation.

--- a/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1E_PROMPT.md
+++ b/specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1E_PROMPT.md
@@ -1,0 +1,647 @@
+# Implementation BUILD prompt — SPEC-001 v1.3 Phase 1E (cooldown soft guard + --force bypass + AC matrix)
+
+Operator-paste prompt for Codex GPT-5 to land the **final** of five
+implementation sub-phases of SPEC-001 v1.3 in `phase3-binary/`.
+This phase activates the CLI-side cooldown soft guard
+(`last-switch.ts` read/write), wires `--force` to bypass it, and
+adds end-to-end AC coverage that exercises the full SPEC-001 v1.3
+binary surface (Phases 1A through 1E together).
+
+**Scope: SPEC-001 v1.3 R-6.11.3 + SPEC-011 R-3.1.3 / R-3.1.4 +
+end-to-end AC matrix.** No coordinator-side changes, no new
+control-socket frame types, no heartbeat changes.
+
+**One-line summary.** Implement `SwitchStateStore` (a tiny
+read/write wrapper around the macOS-native
+`$HOME/Library/Application Support/macprovider-cli/last-switch.ts`
+file) and wire it into `ModelsSwitchCommand` between the pre-flight
+validation (1A path) and the socket connect (1C path). On `now -
+last_switch < 10s`, exit code 6 with the cooldown stderr UNLESS
+`--force` is passed. On any successful or in-flight switch, write
+the current timestamp. Add an `EndToEndAcceptanceTests.swift` file
+that exercises AC-N.0 through AC-N.11 in a single hermetic test
+matrix, treating the prior four phases as a unit under test.
+
+**Locked-spec dependencies (DO NOT contradict).**
+- SPEC-001 v1.3 §6.11.3 R-6.11.5 — cooldown soft guard
+- SPEC-001 v1.3 §6.2 `--switch-state-path` flag (added in 1C)
+- SPEC-001 v1.3 §9 AC-N.0 through AC-N.11 (the AC matrix this
+  phase pins end-to-end)
+- SPEC-011 v0.5 §3.1 R-3.1.3 (`--force` semantics) + R-3.1.4 (CLI
+  cooldown state file + default 10s window)
+- 1A (commit 6744d7c) — `SupportedModels.validate`
+- 1B (commit 5c03e88) — `RuntimeStateMachine`, `ModelRuntime.beginSwap`
+- 1C (commit 9a4a6c5) — `ControlSocketServer`, `ModelsSwitchCommand`,
+  `--switch-state-path` flag plumbing; `--force` accepted as no-op
+- 1D (commit 3c1da34) — heartbeat / hello surface
+
+Spec-text-only edits are FORBIDDEN. No edits under `specs/`
+(operator-authored BUILD prompts excepted). Verify with
+`git diff -- specs/` after edits.
+
+Run in **Codex CLI** via `omc ask codex` from session root
+`/Users/augstar/macprovider-poc`. Expected wall-clock: ~75-100 min
+(one new small file, one file modified, one new end-to-end test
+file).
+
+Branch: `fix/spec-001-v1-3-binary` carries Phases 1A + 1B + 1C + 1D.
+Codex MUST commit on this branch, MUST NOT create a new one, and
+MUST NOT commit or push (operator audits before commit).
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are implementing Phase 1E of SPEC-001 v1.3 in the Swift binary
+at /Users/augstar/macprovider-poc/phase3-binary/. SPEC-001 v1.3 is
+LOCKED. SPEC-011 v0.5 is LOCKED. Phases 1A (6744d7c), 1B (5c03e88),
+1C (9a4a6c5), and 1D (3c1da34) are already on this branch.
+
+You will edit/create the following files (and ONLY these):
+
+  phase3-binary/Sources/macprovider-cli/SwitchStateStore.swift           (NEW)
+  phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift           (extend)
+  phase3-binary/Tests/macprovider-cliTests/SwitchStateStoreTests.swift   (NEW)
+  phase3-binary/Tests/macprovider-cliTests/EndToEndAcceptanceTests.swift (NEW)
+
+You will NOT edit any file under `specs/`, `phase4-coordinator/`,
+`phase5-gateway/`, or any other Swift file beyond the list above.
+You will NOT touch:
+- `Sources/MacProviderCore/SupportedModels.swift` (1A)
+- `Sources/MacProviderCore/Config.swift` (1A/1B/1C)
+- `Sources/macprovider-cli/CoordinatorClient.swift` (1A/1D)
+- `Sources/macprovider-cli/MacProviderCLI.swift` (1A/1B/1C)
+- `Sources/macprovider-cli/RuntimeStateMachine.swift` (1B)
+- `Sources/macprovider-cli/ModelRuntime.swift` (1B)
+- `Sources/macprovider-cli/HTTPServer.swift` (1B)
+- `Sources/macprovider-cli/ControlSocket.swift` (1C)
+- Any 1A/1B/1C/1D test file beyond the two new files listed above
+
+Verify with `git diff -- specs/ phase4-coordinator/ phase5-gateway/`
+— must be empty (excluding operator-authored
+`specs/BUILD_SPEC_001_v1_3_IMPL_*` prompts and the pre-existing
+`specs/FOLLOWUP_COORDINATOR_HA_2026_06_03.md` unstaged edit).
+
+## Critical constraints
+
+**1. L-1 byte-identical default per SPEC-001 v1.3 AC-N.0.** Phase 1E
+adds no new wire behavior. The cooldown soft guard lives entirely
+CLI-side in `models switch`; the running `serve` process is
+unaffected. A v1.3 binary started with `serve` WITHOUT
+`--enable-warm-swap` continues to exhibit byte-identical on-the-wire
+behavior to v1.2.4. The cooldown state file is read/written ONLY
+during `models switch` invocations, never by `serve`.
+
+**2. SPEC-011 R-3.1.4 — cooldown state file format.** The
+`last-switch.ts` file contains a single line of UTF-8 text: the
+epoch milliseconds of the most recent successful or in-flight
+`models switch` invocation, as a base-10 integer string. No JSON,
+no whitespace, no trailing newline (or a single optional trailing
+`\n` — the reader MUST tolerate both). Example contents:
+`1717696989123`. The reader returns nil if the file is missing OR
+the file's content fails to parse as Int64 (resilient: do NOT
+exit with an error if the file is corrupt; treat as "no recent
+switch" and proceed).
+
+**3. SPEC-011 R-3.1.4 — default cooldown window.** 10 seconds
+(10_000 ms). The check is `now - last_switch < 10_000`. Equal-to
+10_000 is NOT cooldown. The window value MUST live as a public
+constant on `SwitchStateStore` so the AC test can introspect it.
+
+**4. SPEC-011 R-3.1.4 — write timing.** The CLI writes the
+timestamp AFTER pre-flight validation passes AND AFTER the
+control-socket connect succeeds AND AFTER receiving
+`switch_ack accepted: true`, but BEFORE waiting for the
+`switch_progress` ladder. Rationale: the spec says "last successful
+or in-flight" — by the time we have an accepted switch_ack, the
+in-process state machine has transitioned to `.loading` (per 1B
+R-3.2.4 step 1), making it "in-flight". Writing earlier would
+falsely register a cooldown for a switch that was rejected at
+pre-flight or by `switch_ack accepted:false`.
+
+**5. SPEC-011 R-3.1.3 — `--force` semantics.** `--force` MUST
+suppress ONLY the cooldown soft-guard check. It MUST NOT suppress:
+  - The Phase 1A SPEC-010 pre-flight validation
+    (`SupportedModels.validate` exit code 2)
+  - The Phase 1C `loading_in_progress` server-side rejection
+    (exit code 3)
+  - The Phase 1C R-3.1.5.x detection precedence (exit code 4)
+  - The Phase 1B atomic-swap rollback (exit code 5)
+
+Tests MUST prove that `--force` lets cooldown through but does
+NOT alter exits 2/3/4/5/6 behavior when their underlying
+conditions hold.
+
+**6. SPEC-011 R-3.1.4 cooldown exit code + stderr.** When the
+cooldown soft guard fires (without `--force`), exit code 6 with
+stderr `"swap on cooldown for <N>s. Re-issue with --force to
+bypass"` where `<N>` is `ceil((10_000 - (now - last_switch)) /
+1000)` (a positive integer 1-10 seconds). This stderr matches the
+existing Phase 1C handler for the (currently unreachable)
+server-side cooldown ack at
+`phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift`
+around line 125. The 1E CLI-side soft guard reuses the SAME
+stderr message so the operator UX is consistent regardless of
+which side detected the cooldown.
+
+**7. Cooldown state file path — macOS native.** Default per
+SPEC-011 R-3.1.4 and SPEC-001 v1.3 §6.2:
+`$HOME/Library/Application Support/macprovider-cli/last-switch.ts`.
+Resolved via
+`FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support/macprovider-cli/last-switch.ts")`.
+Override via `--switch-state-path <path>` (the flag already exists
+in 1C's `ModelsSwitchCommand`; only the *behavior* attached to it
+is new in 1E). The parent directory is created with
+`createDirectory(at:withIntermediateDirectories:true)` on write
+(no special mode); the cooldown file itself is created with
+default mode (no chmod needed — the file contains no secrets).
+
+**8. SPEC-011 R-3.1.4 — atomic-ish write.** The write MUST use
+the write-to-temp-then-rename pattern to avoid leaving a
+half-written file if the process is killed mid-write. Suggested
+implementation: write to `<path>.tmp`, then `rename(<path>.tmp,
+<path>)`. The reader MUST be resilient to the rename being
+interrupted (file missing → nil; corrupt → nil).
+
+**9. d-inference clean-room.** Do NOT read any file under
+`phase3-binary/.build/checkouts/`.
+
+**10. Compile + tests pass.** `swift build` and `swift test` MUST
+both exit 0. Cumulative test count after this phase SHOULD be
+≥ 120 (105 from 1A+1B+1C+1D + ≥ 15 new in 1E). All pre-existing
+tests still GREEN.
+
+**11. No drift in 1A/1B/1C/1D surfaces.** Do NOT modify any prior-
+phase file beyond the two new files and the extension to
+`ModelsSubcommand.swift`. If a 1E requirement seems to need a
+prior-phase change, STOP and surface the conflict at the top of
+your final report.
+
+**12. End-to-end AC matrix uses the existing test infra.** The
+`EndToEndAcceptanceTests.swift` file builds on the patterns from
+1B (`ModelRuntime` test loader injection), 1C (`ControlSocketServer`
+hermetic socket on a tmp path, `captureOutput` stdout/stderr
+trapping), and 1D (`CoordinatorFrameRecorder` for heartbeat shape
+assertions). Each AC test asserts the OBSERVABLE invariant (wire
+bytes, exit codes, file presence/absence) — NOT the internal
+implementation choice. Tests are hermetic (no network, no real
+MLX, no real coordinator).
+
+## Required reading (in this order — read fully before writing)
+
+1. `/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md`
+   - §6.11.3 R-6.11.5 (cooldown soft guard normative)
+   - §9 AC-N.0 through AC-N.11 — the AC matrix (locate by
+     `grep -n "AC-N\." specs/SPEC-001-phase3-binary.md`)
+
+2. `/Users/augstar/macprovider-poc/specs/SPEC-011-operator-pushed-warm-swap.md`
+   - §3.1 R-3.1.3 (`--force` semantics) and R-3.1.4 (state file +
+     default 10s window) — full text
+
+3. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift`
+   - Full file. Extension goes into `ModelsSwitchCommand.run()`
+     between the existing pre-flight validation (line ~96) and
+     the existing socket connect (line ~106). Also wire the
+     timestamp write after `switch_ack accepted: true` is
+     received (line ~117).
+   - The `--force` flag at line ~67 currently is a no-op; wire
+     it to skip the cooldown check.
+   - The `--switch-state-path` flag at line ~83 is currently
+     stored only; wire it to feed `SwitchStateStore`.
+
+4. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ControlSocket.swift`
+   - `ControlSocketPaths.defaultSwitchStatePath(...)` static
+     helper at line ~187 exists from 1C; use it (or extend if it
+     doesn't have a `resolve(:)` form similar to the
+     `ctlSocketPath` resolver).
+
+5. `/Users/augstar/macprovider-poc/phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift`
+   - `captureOutput` helper at line ~177 — reuse for 1E tests.
+   - `makeSocketPath` / `makeRuntime` helpers at lines ~144-160.
+
+6. `/Users/augstar/macprovider-poc/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift`
+   - `CoordinatorFrameRecorder` (or equivalent record-on-
+     sendOverride pattern) — locate via grep.
+
+## Required edits — exact shape
+
+### A. `SwitchStateStore.swift` — NEW
+
+A small Foundation-only module. Public surface:
+
+```swift
+import Foundation
+
+public struct SwitchStateStore: Sendable {
+    /// Default cooldown window per SPEC-011 v0.5 R-3.1.4.
+    public static let defaultCooldownWindowMs: Int64 = 10_000
+
+    public let path: URL
+    public let cooldownWindowMs: Int64
+
+    public init(path: URL, cooldownWindowMs: Int64 = SwitchStateStore.defaultCooldownWindowMs) {
+        self.path = path
+        self.cooldownWindowMs = cooldownWindowMs
+    }
+
+    /// Returns the recorded last-switch timestamp (epoch ms), or nil
+    /// if the file does not exist OR cannot be parsed as Int64.
+    public func readLastSwitchMs() -> Int64? { ... }
+
+    /// Writes the given timestamp atomically (write-to-temp-then-rename).
+    /// Creates the parent directory if missing. Throws on filesystem
+    /// errors that prevent the write.
+    public func writeLastSwitchMs(_ value: Int64) throws { ... }
+
+    /// Returns the cooldown decision:
+    /// - .clear        — no recent switch (file missing or > window)
+    /// - .cooldown(s)  — within the window; `secondsRemaining` is
+    ///                   ceil((window - elapsed) / 1000), clamped to
+    ///                   [1, cooldownWindowMs / 1000]
+    public func cooldownDecision(now: Int64) -> CooldownDecision { ... }
+
+    public enum CooldownDecision: Equatable, Sendable {
+        case clear
+        case cooldown(secondsRemaining: Int)
+    }
+}
+```
+
+Key implementation notes:
+- `writeLastSwitchMs` creates the parent dir with
+  `createDirectory(at:withIntermediateDirectories:true)`. Does NOT
+  chmod (no secrets in the file).
+- The temp file path is `<path>.tmp`. Use
+  `FileManager.default.removeItem(at: tmpURL)` to clean a stale
+  temp before writing, then write the new content, then
+  `FileManager.default.moveItem(at: tmpURL, to: path)`. If `path`
+  already exists, `moveItem` fails — use
+  `FileManager.default.replaceItem(at: path, withItemAt: tmpURL,
+  backupItemName: nil, options: [], resultingItemURL: nil)` for the
+  atomic replace, OR fall back to a remove-then-move pattern if
+  `replaceItem` is unavailable on the target macOS API level.
+- `readLastSwitchMs` MUST NOT throw. File-not-found → nil. Read
+  error → nil. Parse error → nil. The caller treats nil as "no
+  recent switch".
+
+### B. `ModelsSubcommand.swift` — extend `ModelsSwitchCommand.run()`
+
+Add the cooldown check + timestamp write. The full target shape
+of `ModelsSwitchCommand.run()`:
+
+```swift
+func run() async throws {
+    let options = ModelsSwitchOptions(force: force, switchStatePath: switchStatePath)
+    let resolved = try loadModelsConfig(
+        config: config,
+        model: model,
+        supportedModels: supportedModels,
+        ctlSocketPath: ctlSocketPath,
+        switchStatePath: switchStatePath
+    )
+
+    // Step 2 — SPEC-010 pre-flight (unchanged from Phase 1C)
+    do {
+        _ = try SupportedModels.validate(
+            model: targetModelID,
+            supportedModels: resolved.supportedModels
+        )
+    } catch SupportedModelsValidationError.modelNotInCatalog {
+        writeStderr("switch target \(targetModelID) not in --supported-models")
+        throw ExitCode(2)
+    } catch let error as SupportedModelsValidationError {
+        writeStderr("\(error)")
+        throw ExitCode(2)
+    }
+
+    // Step 2.5 — SPEC-011 R-3.1.4 cooldown soft guard (NEW in 1E)
+    if !options.force {
+        let storePath = ControlSocketPaths.defaultSwitchStatePath(resolved.switchStatePath)
+        let store = SwitchStateStore(path: storePath)
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        switch store.cooldownDecision(now: nowMs) {
+        case .clear:
+            break
+        case .cooldown(let secondsRemaining):
+            writeStderr("swap on cooldown for \(secondsRemaining)s. Re-issue with --force to bypass")
+            throw ExitCode(6)
+        }
+    }
+
+    // Step 3 — connect (unchanged)
+    let socketPath = ControlSocketPaths.resolve(ctlSocketPath: resolved.ctlSocketPath)
+    let (connection, _) = try await connectAndReadStatusOrExit(socketPath: socketPath)
+    let requestedAtMs = Int64(Date().timeIntervalSince1970 * 1000)
+
+    // Step 4 — switch_request + switch_ack (unchanged for branches;
+    //          NEW for the accepted branch: record the timestamp)
+    try await connection.send(.switchRequest(targetModelID: targetModelID, requestedAtMs: requestedAtMs))
+    let ack = try await connection.receive()
+    guard case let .switchAck(accepted, reason, currentTarget, secondsRemaining) = ack else {
+        writeStderr("expected switch_ack")
+        await connection.close()
+        throw ExitCode(4)
+    }
+
+    guard accepted else {
+        await connection.close()
+        switch reason {
+        case .loadingInProgress:
+            let currentTarget = currentTarget ?? "<unknown>"
+            writeStderr("provider is already loading \(currentTarget); refusing to start a second swap. Wait for current switch to complete (macprovider-cli models status)")
+            throw ExitCode(3)
+        case .cooldown:
+            writeStderr("swap on cooldown for \(secondsRemaining ?? 0)s. Re-issue with --force to bypass")
+            throw ExitCode(6)
+        default:
+            writeStderr("switch rejected")
+            throw ExitCode(4)
+        }
+    }
+
+    // Step 4.5 — record the in-flight switch timestamp (NEW in 1E)
+    let storePath = ControlSocketPaths.defaultSwitchStatePath(resolved.switchStatePath)
+    let store = SwitchStateStore(path: storePath)
+    do {
+        try store.writeLastSwitchMs(requestedAtMs)
+    } catch {
+        // Non-fatal: log to stderr but proceed with the switch.
+        // A swap that succeeds without writing the timestamp will
+        // simply not gate the next attempt's cooldown.
+        writeStderr("warning: could not write switch state file at \(storePath.path): \(error)")
+    }
+
+    // Step 5 — stream switch_progress (unchanged)
+    while true {
+        // ... existing 1C code unchanged ...
+    }
+}
+```
+
+The KEY semantic additions:
+- New "Step 2.5" cooldown check between pre-flight and connect
+- New "Step 4.5" timestamp write between accepted ack and progress stream
+- The `--force` flag now actually bypasses Step 2.5 (and ONLY Step 2.5)
+
+### C. `SwitchStateStoreTests.swift` — NEW
+
+Cover the store in isolation. Each test uses a hermetic tmp file
+path so tests don't interfere.
+
+- `testReadReturnsNilWhenFileMissing` — fresh tmp path; read
+  returns nil
+- `testReadReturnsNilWhenFileCorrupt` — write `"not a number"`
+  to path; read returns nil
+- `testWriteAndReadRoundTrip` — write 1717696989123; read returns
+  1717696989123
+- `testWriteCreatesParentDirectory` — tmp path under a non-
+  existent grandparent; write succeeds
+- `testWriteIsAtomic` — write 1, then write 2; assert no `.tmp`
+  file remains in the parent dir after both writes; assert read
+  returns 2
+- `testCooldownDecisionClearWhenNeverSet` — fresh tmp path;
+  decision(now: 1000) returns .clear
+- `testCooldownDecisionClearWhenWellOutsideWindow` — write `0`,
+  decision(now: 1_000_000) returns .clear
+- `testCooldownDecisionCooldownWhenInsideWindow` — write
+  `1_000_000`, decision(now: 1_005_000) returns
+  `.cooldown(secondsRemaining: 5)`
+- `testCooldownDecisionCooldownWhenJustInsideWindow` — write
+  `1_000_000`, decision(now: 1_009_999) returns
+  `.cooldown(secondsRemaining: 1)`
+- `testCooldownDecisionClearAtExactlyWindowBoundary` — write
+  `1_000_000`, decision(now: 1_010_000) returns .clear (the
+  boundary is exclusive: `<` not `<=`)
+- `testCustomCooldownWindow` — construct with
+  `cooldownWindowMs: 5_000`; verify boundary is at 5_000
+
+### D. `EndToEndAcceptanceTests.swift` — NEW
+
+End-to-end matrix tests pinning SPEC-001 v1.3 AC-N.0 through
+AC-N.11. Each test is hermetic (no real MLX, no real WS, no real
+filesystem outside `/tmp`).
+
+Use these conventions:
+- Tmp socket path under `/tmp/mpm-<pid>-<random>/ctl.sock`
+- Tmp cooldown state path under `/tmp/mpm-<pid>-<random>/last-switch.ts`
+- `ModelRuntime` via the 1B test init with `loader` + `testLoader`
+- `ControlSocketServer` from 1C hosted on the tmp socket path
+- `CoordinatorClient` with `sendOverride` + `connectAndRunOverride`
+  for heartbeat / hello capture (1A/1D pattern)
+- `captureOutput` for stdout/stderr from `ModelsSubcommand` runs
+
+Required tests (mapping to AC numbers per SPEC-001 v1.3 §9):
+
+- `testAC_N_0_L1ByteIdenticalDefault_WireSurface` — instantiate a
+  `CoordinatorClient` with `AppConfig` defaults (no flags set),
+  capture the `authInitialMessage` and `helloMessage` and the
+  first `heartbeat` via `sendOverride`. Assert: the JSON byte-
+  strings contain `supported_models: [model_id]` (single-entry),
+  do NOT contain `publishes_supported_models`, do NOT contain
+  `model_hash` on heartbeat, do NOT contain `loading` on
+  heartbeat. This is the canonical L-1 assertion.
+
+- `testAC_N_1_SPEC010_OptIn_ExplicitCatalog` — `enableWarmSwap =
+  false` (irrelevant), `supportedModels = ["A","B","C"]`,
+  `model = "A"`, `publishesSupportedModels = true`. Assert
+  `authInitialMessage` contains both fields with the expected
+  values.
+
+- `testAC_N_2_SPEC010_PreFlight_ExitCode2` — invoke
+  `ModelsSwitchCommand` parse + run with `--model A
+  --supported-models A,B`, target `C`. Capture output, assert
+  `ExitCode(2)` and stderr containing `"switch target C not in
+  --supported-models"`. Verify the socket path is NOT touched
+  (no socket file created).
+
+- `testAC_N_3_SPEC011_OptInGate_DisabledMode` — start a `serve`
+  scenario WITHOUT `--enable-warm-swap` (i.e., construct a
+  `ServeCommand`-like setup; for the test, just verify that
+  `ControlSocketServer` is NOT instantiated when
+  `AppConfig.enableWarmSwap == false`, and a `ModelsListCommand`
+  pointed at the absent socket path exits 0 with the disabled-
+  mode message). Verify `models switch` against the same setup
+  exits 4 with R-3.1.5.x case-1 stderr.
+
+- `testAC_N_4_SPEC011_OptInGate_EnabledMode_FilePermissions` —
+  start a `ControlSocketServer` on a tmp path; assert the parent
+  dir mode is `0700` and the socket file mode is `0600` via
+  `stat()`.
+
+- `testAC_N_5_MacOSNativePath` — verify
+  `ControlSocketPaths.resolve(ctlSocketPath: nil)` resolves under
+  `FileManager.default.temporaryDirectory` (and that the path
+  contains `macprovider-cli/ctl.sock`). Verify
+  `ControlSocketPaths.defaultSwitchStatePath(nil)` resolves
+  under `FileManager.default.homeDirectoryForCurrentUser` and
+  contains `Library/Application Support/macprovider-cli/last-switch.ts`.
+  Verify the source code contains zero matches for
+  `XDG_RUNTIME_DIR` (this is a meta-check; assert via a string
+  search of the file contents OR delegate to a shell-out).
+
+- `testAC_N_6_AtomicSwap_InFlightVsNewRequest` — start a
+  `ControlSocketServer` with a stub runtime + 100ms loader.
+  Begin a long-running stub `complete(...)` call against the
+  runtime (using `testCompletion`); concurrently drive a
+  `models switch` to a new model; assert the in-flight call
+  returns the OLD model's content; a fresh inference after the
+  swap completes returns NEW model's content. (Reuses the 1B
+  `testInFlightInferenceUsesOldSnapshot` pattern but driven
+  through the control-socket path.)
+
+- `testAC_N_7_NoStarveHeartbeat` — start a `CoordinatorClient`
+  with `enableWarmSwap = true` and `sendOverride` capture; begin
+  a 200ms swap; assert that AT LEAST one regular `heartbeat`
+  frame appears in the capture buffer during the load (proving
+  the heartbeat cadence is not paused).
+
+- `testAC_N_8_HeartbeatHashFormat` — with warm-swap enabled and
+  a known `model_hash = "abc...64chars..."` (the test sets a
+  raw lowercase hex string via the runtime's modelHash field),
+  capture a heartbeat, parse the JSON, assert
+  `model_hash` value is exactly 64 chars, all lowercase hex,
+  no `sha256:` prefix. Regex: `^[a-f0-9]{64}$`.
+
+- `testAC_N_9_FourMatrixCells_AuthInitial` — for each of the
+  four cells of the SPEC-010 × SPEC-011 opt-in matrix
+  (unset/unset, set/unset, unset/set, set/set), construct an
+  `AppConfig`, instantiate `CoordinatorClient`, call
+  `authInitialMessage`, and assert on the expected wire fields:
+  - cell 1: `supported_models: [model_id]`, no
+    `publishes_supported_models`
+  - cell 2: explicit `supported_models`,
+    `publishes_supported_models: true` (when bool flag set)
+  - cell 3: same as cell 1 (warm-swap doesn't change SPEC-010
+    field shape — the warm-swap fields go on heartbeat, not
+    auth_request)
+  - cell 4: explicit `supported_models` +
+    `publishes_supported_models: true`
+  Plus a heartbeat capture per cell asserting the model_hash /
+  loading presence/absence according to the matrix.
+
+- `testAC_N_10_V2HandshakeFieldsMatchSPEC010_3_1_A` — invoke
+  `authInitialMessage` with `enableWarmSwap = false`,
+  `supportedModels = ["X","Y"]`, `publishesSupportedModels =
+  true`. Serialize to JSON. Assert every parser-required field
+  from SPEC-010 §3.1.A is present: `type`, `version`, `stage`,
+  `provider_id`, `hostname`, `model_id`, `model_params_b`,
+  `ram_gb`, `max_context_tokens`, `max_concurrency`,
+  `throughput_tps_estimate`, `binary_version`,
+  `provider_ecdh_public_key`, `tier2_capabilities`,
+  `supported_models`, `publishes_supported_models`. List the
+  expected keys explicitly in the test and iterate.
+
+- `testAC_N_11_LegacyHelloByteIdenticalToV124` — call
+  `helloMessage()` with `enableWarmSwap = false` and capture
+  the JSON. Compare against a canonical hardcoded baseline
+  string (or assert key-by-key that ONLY the v1.2.4 fields are
+  present — `type`, `version`, `tier`, `provider_id`,
+  `hostname`, `model_id`, `model_params_b`, `ram_gb`,
+  `max_context_tokens`, `max_concurrency`,
+  `throughput_tps_estimate`, `binary_version`, `attestation`,
+  and conditionally `endpoint_url`, `model_hash`). Assert NO
+  v1.3 fields (`supported_models`, `publishes_supported_models`,
+  `loading`) appear in the hello frame.
+
+If the test file grows beyond ~600 lines, you may split into
+two files (`EndToEndAcceptanceTests.swift` for AC-N.0 through
+AC-N.5 and `EndToEndAcceptanceTestsWireMatrix.swift` for
+AC-N.6 through AC-N.11), but the prompt's preference is one
+file.
+
+## Done criteria
+
+You are done when:
+
+- `git diff -- specs/ phase4-coordinator/ phase5-gateway/` shows
+  only operator-authored BUILD prompts and the pre-existing
+  `specs/FOLLOWUP_COORDINATOR_HA_2026_06_03.md` unstaged edit.
+- `git diff -- phase3-binary/Sources/MacProviderCore/
+  phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+  phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+  phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift
+  phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+  phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+  phase3-binary/Sources/macprovider-cli/ControlSocket.swift`
+  is empty (1E does not touch any of these).
+- `cd phase3-binary && swift build` exits 0.
+- `cd phase3-binary && swift test` exits 0 with ≥ 120 tests
+  green.
+- All Phase 1A + 1B + 1C + 1D tests still GREEN (no regressions).
+- A `models switch` invocation within 10s of a prior accepted
+  switch exits 6 with the cooldown stderr.
+- The same invocation with `--force` proceeds past the cooldown
+  check.
+- The cooldown file is written atomically (no `.tmp` file
+  remnants on success).
+- The CLI does NOT exit on a corrupt `last-switch.ts` — it
+  treats the corruption as "no recent switch" and proceeds.
+
+## Out of scope (do NOT do these in Phase 1E)
+
+- Server-side `switch_ack accepted:false reason:cooldown`
+  emission — cooldown is CLI-side only per SPEC-011 L-7
+- Coordinator-side `phase4-coordinator/` changes — Phase 2
+- HF cache `disk_size_gb` column on `models list` — out of
+  scope (spec marks optional)
+- Any new CLI flags, ENV vars, or YAML keys
+- Any modification to the wire protocol (heartbeat, hello,
+  auth_request, control socket frames)
+
+## Self-check before reporting done
+
+Run this command and confirm all checks pass:
+
+```bash
+cd /Users/augstar/macprovider-poc && \
+  git diff --stat -- specs/ phase4-coordinator/ phase5-gateway/ && \
+  echo "----" && \
+  git diff --stat -- phase3-binary/Sources/MacProviderCore/ phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift phase3-binary/Sources/macprovider-cli/ModelRuntime.swift phase3-binary/Sources/macprovider-cli/HTTPServer.swift phase3-binary/Sources/macprovider-cli/ControlSocket.swift && \
+  echo "----" && \
+  (cd phase3-binary && swift build 2>&1 | tail -5) && \
+  echo "----" && \
+  (cd phase3-binary && swift test 2>&1 | grep "Executed.*tests" | tail -3) && \
+  echo "----" && \
+  grep -rn "XDG_RUNTIME_DIR" phase3-binary/Sources/ || echo "no XDG_RUNTIME_DIR (correct)"
+```
+
+The second diff stat MUST show 0 files changed (no out-of-scope
+edits).
+
+Return:
+- A brief diff summary (files touched, +/- lines).
+- The final `swift test` summary line (Executed N tests, ...).
+- Any spec rule you were unable to satisfy exactly, with the
+  binding rule number and your interpretation.
+
+Do NOT commit. Do NOT push. The operator audits the working tree
+before commit.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (out-of-band)
+
+- Expected wall-clock: 75-100 min. 1E is the smallest scope (one
+  small new module + one extension to ModelsSubcommand) but the
+  end-to-end AC matrix file is the largest test artifact yet.
+- Audit pass (Claude Opus) reads the diff and tests against the
+  12 constraints + done criteria. Key audit foci:
+  - **Constraint 4 (write timing)** — verify the timestamp write
+    happens AFTER `switch_ack accepted: true`, not earlier.
+  - **Constraint 5 (--force semantics)** — verify --force does
+    NOT suppress pre-flight (exit 2), concurrent reject (exit 3),
+    or socket detection (exit 4).
+  - **Constraint 8 (atomic write)** — verify the
+    write-to-temp-then-rename pattern and no stale `.tmp` file
+    on success.
+  - **AC matrix coverage** — verify each AC-N.X test actually
+    asserts on the observable invariant, not just the
+    implementation detail.
+- R2 prompt is drafted only if R1 audit surfaces findings.
+- After 1E LOCKs, PR #5 is the final reviewable artifact for
+  SPEC-001 v1.3 binary implementation. Operator reviews and
+  squash-merges; main gets one tidy commit with all five phases.

--- a/specs/BUILD_SPEC_001_v1_3_IMPL_PR5_PREMERGE_FIX_PROMPT.md
+++ b/specs/BUILD_SPEC_001_v1_3_IMPL_PR5_PREMERGE_FIX_PROMPT.md
@@ -1,0 +1,760 @@
+# PR #5 pre-merge fix prompt — 5 blocking findings (1 CRITICAL + 4 MAJOR)
+
+Operator-paste prompt for Codex GPT-5 to land the **pre-merge fixes**
+for findings surfaced by the external audit at
+`.omc/artifacts/ask/codex-execute-the-audit-prompt-at-users-augstar-macprovider-poc-sp-2026-06-07T00-27-31-529Z.md`.
+
+The audit verdict on PR #5 was **BLOCK-MERGE** (1 CRITICAL / 4 MAJOR /
+1 MINOR). The MINOR (arch:1.1 — test fd dup2 race) is deferred to a
+later cleanup PR; this prompt addresses the 5 blockers.
+
+**Scope:** real drain semantics + snapshot atomicity refactor +
+`--swap-drain-timeout-seconds` range validation + server-side
+`supported_models` enforcement on the control socket + bounded
+control-socket reads with per-read timeout.
+
+This is the **R1 fix prompt** for the pre-merge audit. After Codex
+returns, Claude Opus re-audits the diff; if clean, the same external
+Codex audit re-runs as R2 to confirm; if findings remain, R3 prompt is
+drafted.
+
+Run via `omc ask codex` from session root
+`/Users/augstar/macprovider-poc`. Expected wall-clock: ~120-180 min
+(the drain implementation + snapshot refactor are non-trivial; the
+remaining fixes are smaller).
+
+Branch: `fix/spec-001-v1-3-binary` carries Phases 1A-1E. Codex MUST
+commit on this branch, MUST NOT create a new one, MUST NOT commit or
+push (operator audits before commit).
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are landing the pre-merge audit fixes for PR #5 in the Swift
+binary at /Users/augstar/macprovider-poc/phase3-binary/. PR #5
+carries five commits implementing SPEC-001 v1.3 Phase 1A-1E
+(6744d7c, 5c03e88, 9a4a6c5, 3c1da34, 5d013f5). An external Codex
+audit on the branch returned BLOCK-MERGE with 5 blocking findings.
+
+Your job is to land all 5 blocking fixes in a single working-tree
+session. The operator will commit + push.
+
+You will edit/create the following files (and ONLY these):
+
+  phase3-binary/Sources/MacProviderCore/Config.swift                          (extend)
+  phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift             (REFACTOR — significant)
+  phase3-binary/Sources/macprovider-cli/ModelRuntime.swift                    (REFACTOR — significant)
+  phase3-binary/Sources/macprovider-cli/ControlSocket.swift                   (extend — server-side validation + bounded reads + per-read timeout)
+  phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift                  (extend — drain timeout range validation, pass supportedModels into ControlSocketServer)
+  phase3-binary/Tests/macprovider-cliTests/RuntimeStateMachineTests.swift     (extend OR rewrite to match the demoted-state shape)
+  phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift        (extend with drain + snapshot atomicity tests)
+  phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift           (extend with bounded-read + per-read-timeout tests)
+  phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift        (extend with server-side rejection test)
+
+You will NOT edit any file under `specs/`, `phase4-coordinator/`,
+`phase5-gateway/`, or any other Swift file. Verify with
+`git diff -- specs/ phase4-coordinator/ phase5-gateway/` after edits
+(must be empty excluding operator-authored BUILD/AUDIT prompts).
+
+## Findings to fix
+
+### Finding 1 — CRITICAL [code:1.1] — Real `draining` semantics + `swap_drain_timeout` not implemented
+
+**Spec reference:** SPEC-011 v0.5 §3.4 (drain semantics, R-3.4.1
+through R-3.4.5); SPEC-001 v1.3 §6.8 (incorporates draining state
+into HTTP 503 contract at R-6.8.4); SPEC-011 §3.9 (drain timeout
+default 30s, range 5...600).
+
+**Current bug:** `ModelRuntime.beginSwap` transitions
+`.loading → .ready` directly via `applySwap()` after the load
+completes. The `draining` state exists in `SwapState` but no
+production code path enters it. The `swap_drain_timeout_seconds`
+flag is stored in `ModelRuntime` but never read. The control
+socket emits a synthetic `draining` progress frame
+(`ControlSocket.swift:379`) before `loaded` but the runtime has
+already swapped.
+
+**Required behavior (per SPEC-011 §3.4):**
+
+The four-state machine MUST be:
+- `.ready` → `.loading` (on `beginSwap` call)
+- `.loading` → `.draining` (when async load completes, BEFORE atomic
+  swap) — emit a SwapSignal so the control socket can publish a
+  real `draining` switch_progress frame
+- `.draining` → `.ready` (after drain window closes AND atomic
+  swap is applied) — emit the existing completion signal
+- `.loading` → `.failed` → `.ready` (on load failure — unchanged from 1B)
+
+**Drain window enforcement:** After entering `.draining`, the
+detached load task MUST:
+
+1. Note the drain start time (`drainStartMs`)
+2. Poll until either:
+   a. `providerStatus.requestsInFlight == 0` — all in-flight
+      requests against the OLD container have completed; safe to
+      swap immediately
+   b. `now - drainStartMs > swapDrainTimeoutSeconds * 1000` —
+      drain window expired; proceed with the atomic swap regardless
+      (in-flight requests continue to hold their snapshot
+      reference to the OLD container per R-3.2.2; they complete
+      normally even after the field is swapped)
+3. Apply the atomic swap (write new container/modelID/modelHash)
+4. Transition `.draining → .ready`
+5. Signal completion (`SwapSignal.Outcome.completed`)
+
+The poll interval is 50ms (`Task.sleep(nanoseconds: 50_000_000)`)
+— short enough to be responsive, long enough to not burn CPU.
+
+**Inference rejection during draining is ALREADY handled** by the
+existing `validateReady(_:)` check in `complete`/`stream`/`preflight`
+— it throws on any state != `.ready`. No change needed there.
+
+**Signal stream for control socket:** Currently `SwapSignal` has
+two outcomes: `.completed` and `.failed`. To support the real
+`draining` frame, ADD a new outcome:
+
+```swift
+public enum Outcome: Sendable {
+    case loadCompleted(newModelID: String, newModelHash: String?)    // RENAMED from .completed
+    case drainStarted(elapsedMs: Int)                                  // NEW
+    case completed(newModelID: String, newModelHash: String?)          // KEPT (post-swap completion)
+    case failed(reason: String)                                         // KEPT
+}
+```
+
+Wait — renaming `.completed` is a breaking change for the
+CoordinatorClient swap-heartbeat task ([CoordinatorClient.swift:162](phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:162)).
+Instead, KEEP `.completed` as the final "post-swap, state is ready"
+signal AND add a new outcome for the draining-started moment:
+
+```swift
+public enum Outcome: Sendable {
+    case loadFinished                              // NEW — load done, draining started
+    case completed(newModelID: String, newModelHash: String?)  // KEPT — atomic swap done, state .ready
+    case failed(reason: String)                     // KEPT
+}
+```
+
+The control socket `handleSwitchRequest` consumes the signal
+stream and emits `switch_progress` frames mapped to states:
+- On `.loadFinished` signal → emit `switch_progress state: draining`
+- On `.completed` signal → emit `switch_progress state: loaded`
+- On `.failed` signal → emit `switch_progress state: failed reason: X`
+
+The CoordinatorClient's `consumeSwapSignals` continues to react only
+to `.completed` (immediate heartbeat) and `.failed` (log); it ignores
+`.loadFinished`.
+
+**Drain timeout source:** `ModelRuntime.swapDrainTimeoutSeconds`
+already plumbed via init from `AppConfig.swapDrainTimeoutSeconds`.
+Read it in the detached drain task. Default 30. Range 5...600
+enforced by Finding 3 below.
+
+### Finding 2 — MAJOR [code:1.2] — Mixed state/container observable during swap
+
+**Spec reference:** SPEC-011 R-3.2.4 (atomic four-step swap).
+
+**Current bug:** `applySwap` writes `currentContainer` /
+`currentModelID` / `currentModelHash` THEN awaits
+`stateMachine.completeSwap()`. The await yields actor isolation.
+A concurrent `currentSnapshot()` can call `stateMachine.current()`
+(returns `.loading`), then read `currentContainer` (already new).
+Result: snapshot reports `state == .loading` with the new
+container — inconsistent state.
+
+**Required behavior:** `currentSnapshot()` MUST be an atomic
+read returning a consistent view of `(state, container, modelID,
+modelHash)`. No interleaving between the state read and the field
+reads.
+
+**Required refactor:** Move state ownership INTO `ModelRuntime`.
+Demote `RuntimeStateMachine` to a stateless transition-rule
+validator (or remove it entirely and inline its logic into
+`ModelRuntime`).
+
+Concretely:
+
+1. Add `private var state: SwapState` to `ModelRuntime`. Initialize
+   to `.ready` in the production init.
+
+2. Add `private var signalContinuations: [AsyncStream<SwapSignal>.Continuation] = []`
+   to `ModelRuntime`. The signal stream moves with the state.
+
+3. Add the transition methods directly to `ModelRuntime`:
+   - `private func transitionToLoading(target: String) throws` —
+     guards `state == .ready`, sets `state = .loading`
+   - `private func transitionToDraining()` — guards `state == .loading`,
+     sets `state = .draining`, emits `.loadFinished` signal
+   - `private func completeSwapAtomically(container: ModelContainer?, modelID: String, modelHash: String?)` —
+     SINGLE non-await actor method that writes ALL FOUR fields
+     (state, container, modelID, modelHash) and emits the
+     `.completed` signal. This is THE atomic step.
+   - `private func failSwap(reason: String)` — guards
+     `state == .loading || .draining`, transitions through
+     `.failed → .ready`, emits `.failed` signal
+
+4. `RuntimeStateMachine.swift` — choose one:
+   - (a) Remove the file entirely (state owned by ModelRuntime now;
+     SwapState enum and SwapSignal types stay but move into
+     ModelRuntime.swift or stay in their own file as pure types)
+   - (b) Keep the file but reduce it to TYPE DECLARATIONS only
+     (`SwapState`, `SwapSignal`, `RuntimeStateMachineError`).
+     Remove the `RuntimeStateMachine` actor entirely.
+
+   Prefer option (b) — keep `RuntimeStateMachine.swift` as a
+   types-only file. Update `RuntimeStateMachineTests.swift` to
+   test the transitions via `ModelRuntime`'s actor methods rather
+   than the now-removed RuntimeStateMachine actor.
+
+5. `currentSnapshot()` becomes a NON-await actor method:
+
+   ```swift
+   func currentSnapshot() -> RuntimeSnapshot {
+       RuntimeSnapshot(
+           state: state,
+           container: currentContainer,
+           modelID: currentModelID,
+           modelHash: currentModelHash
+       )
+   }
+   ```
+
+   Callers that previously did `await modelRuntime.currentSnapshot()`
+   still work — Swift actor methods are implicitly async to non-
+   isolated callers. The KEY change: there's only ONE suspension
+   point per snapshot call (the actor hop), not two.
+
+6. `beginSwap` becomes (sketch):
+
+   ```swift
+   func beginSwap(targetModelID: String) async throws -> Task<Void, Error> {
+       guard warmSwapEnabled else { throw WarmSwapDisabledError() }
+       try transitionToLoading(target: targetModelID)  // actor-local, atomic
+       let drainTimeoutSeconds = swapDrainTimeoutSeconds
+       return Task.detached { [weak self] in
+           guard let self else { return }
+           do {
+               let (container, modelID, modelHash): (ModelContainer?, String, String?)
+               if let testLoader = await self.testLoader {
+                   let (id, hash) = try await testLoader(targetModelID)
+                   (container, modelID, modelHash) = (nil, id, hash)
+               } else {
+                   let (c, id, hash) = try await self.loader(targetModelID)
+                   (container, modelID, modelHash) = (c, id, hash)
+               }
+               // Drain phase per SPEC-011 §3.4
+               try await self.enterDrainPhase()
+               try await self.waitForDrainOrTimeout(timeoutSeconds: drainTimeoutSeconds)
+               // Atomic swap
+               await self.completeSwapAtomically(container: container, modelID: modelID, modelHash: modelHash)
+           } catch {
+               await self.failSwap(reason: String(describing: error))
+           }
+       }
+   }
+   ```
+
+   Where:
+   - `enterDrainPhase()` is an actor method that does
+     `transitionToDraining()` (guarded, emits `.loadFinished` signal)
+   - `waitForDrainOrTimeout(timeoutSeconds:)` is the polling
+     loop. It MUST NOT run on the actor's executor (use
+     `Task.detached` or run inside the existing detached task) so
+     it doesn't block other actor calls like `currentSnapshot`.
+
+   The detached task is the safe place for the wait loop — it
+   already runs off the actor. The wait body calls
+   `await providerStatus.snapshot()` to read `requestsInFlight`
+   each poll.
+
+7. Tests in `RuntimeStateMachineTests.swift` need rewriting.
+   Since `RuntimeStateMachine` actor is gone, the tests now
+   exercise transitions via `ModelRuntime`. Either:
+   - Rename the file to `ModelRuntimeStateTests.swift`, OR
+   - Keep the filename and have tests use `ModelRuntime` instances
+     to drive transitions (e.g., test that `beginSwap` rejects
+     when state is `.loading`).
+
+### Finding 3 — MAJOR [code:1.3] — `--swap-drain-timeout-seconds` range validation missing
+
+**Spec reference:** SPEC-011 v0.5 §3.9 (drain timeout range
+5...600); SPEC-001 v1.3 AC-25 (validation exit code 2).
+
+**Current bug:** `AppConfig.swapDrainTimeoutSeconds` accepts any
+Int from YAML / ENV / CLI without bounds checking.
+
+**Required behavior:** In `ServeCommand.run()`, AFTER
+`ConfigLoader.load(...)` returns and BEFORE constructing
+`ModelRuntime`, validate:
+
+```swift
+if !(5...600).contains(resolved.swapDrainTimeoutSeconds) {
+    FileHandle.standardError.write(Data((
+        "--swap-drain-timeout-seconds \(resolved.swapDrainTimeoutSeconds) out of range 5...600\n"
+    ).utf8))
+    throw ExitCode(2)
+}
+```
+
+The check goes right after the existing SPEC-010 preflight
+(`runSupportedModelsPreflight`). Add a test
+`testServeCommandExits2OnDrainTimeoutOutOfRange` in
+`SupportedModelsTests.swift` (which already houses the static
+preflight helper tests) or a new file
+`DrainTimeoutValidationTests.swift` — Codex chooses.
+
+Required test cases:
+- `swapDrainTimeoutSeconds: 4` → ExitCode(2)
+- `swapDrainTimeoutSeconds: 5` → passes (boundary inclusive)
+- `swapDrainTimeoutSeconds: 30` (default) → passes
+- `swapDrainTimeoutSeconds: 600` → passes (boundary inclusive)
+- `swapDrainTimeoutSeconds: 601` → ExitCode(2)
+- `swapDrainTimeoutSeconds: -1` → ExitCode(2)
+
+### Finding 4 — MAJOR [sec:1.1] — Server-side switch bypasses CLI policy
+
+**Spec reference:** SPEC-011 v0.5 R-3.1.2 step 2 (supported_models
+validation); SPEC-010 v1.5 R-3.6.3 (pre-flight per validate);
+threat model in audit prompt (same-UID local processes are
+UNTRUSTED for the control socket).
+
+**Current bug:** `ControlSocketServer.handleSwitchRequest`
+([ControlSocket.swift:359](phase3-binary/Sources/macprovider-cli/ControlSocket.swift:359))
+calls `modelRuntime.beginSwap(targetModelID:)` directly. It does
+NOT validate `target_model_id` against the resolved
+`supported_models` list. A same-UID local process can connect to
+the `0600` socket, send a `switch_request` with any arbitrary
+model string, and bypass the CLI's pre-flight.
+
+**Required behavior:** ControlSocketServer MUST enforce the
+same `supported_models` validation that the CLI does. On
+validation failure, the server emits
+`switch_ack accepted: false reason: not_in_supported_models`
+(this reason value already exists in the `SwitchAckReason` enum
+from Phase 1C).
+
+**Required refactor:**
+
+1. Add a parameter to `ControlSocketServer.init`:
+   ```swift
+   init(
+       socketPath: URL,
+       modelRuntime: ModelRuntime,
+       supportedModels: [String]?   // NEW — the resolved catalog
+   )
+   ```
+   Store it as `private let supportedModels: [String]?`.
+
+2. In `ServeCommand.run()`, pass `resolved.supportedModels` into
+   the `ControlSocketServer(...)` construction
+   ([MacProviderCLI.swift:128](phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:128)).
+
+3. In `handleSwitchRequest`, BEFORE calling `beginSwap`, validate:
+   ```swift
+   do {
+       _ = try SupportedModels.validate(
+           model: targetModelID,
+           supportedModels: supportedModels
+       )
+   } catch SupportedModelsValidationError.modelNotInCatalog {
+       try? await connection.send(.switchAck(
+           accepted: false,
+           reason: .notInSupportedModels,
+           currentTarget: nil,
+           secondsRemaining: nil
+       ))
+       await connection.close()
+       return
+   } catch {
+       // Other validation errors (entry too long, etc.) shouldn't
+       // happen here since the catalog was already validated at
+       // ServeCommand startup. Treat as `.other` defensively.
+       try? await connection.send(.switchAck(
+           accepted: false,
+           reason: .other,
+           currentTarget: nil,
+           secondsRemaining: nil
+       ))
+       await connection.close()
+       return
+   }
+   ```
+
+4. The CLI side (`ModelsSwitchCommand.run()`) ALREADY handles
+   `not_in_supported_models` in the switch_ack rejection branch
+   (currently only `loading_in_progress` and `cooldown` branches
+   are explicit; the `default` falls through to exit 4 with
+   "switch rejected"). Extend the switch over `reason` to add a
+   case for `.notInSupportedModels` that exits code 2 with stderr
+   `"switch target <X> not in --supported-models (rejected by serve)"`
+   (the "(rejected by serve)" suffix distinguishes from the
+   CLI-side pre-flight rejection at the same exit code).
+
+5. Required test
+   `testServerSideRejectsSwitchWhenNotInSupportedModels` in
+   `ModelsSubcommandTests.swift`: start a ControlSocketServer
+   with `supportedModels: ["A", "B"]` and a runtime with no
+   client-side pre-flight (use a raw socket client that bypasses
+   `ModelsSwitchCommand`). Send a `switch_request` for `"C"`.
+   Assert the response is
+   `.switchAck(accepted: false, reason: .notInSupportedModels, ...)`.
+
+   Also: a CLI-side test that exercises the full flow with
+   `ModelsSwitchCommand` parsing `--supported-models A,B` and
+   targeting `C` should still exit 2 via the existing CLI
+   pre-flight, NOT via the new server-side rejection (the CLI
+   path catches it first). The audit cited this expectation.
+
+### Finding 5 — MAJOR [sec:1.2] — Unbounded socket reads enable same-UID DoS
+
+**Spec reference:** Audit threat model — local non-CLI same-UID
+processes are in-scope adversaries for the control socket.
+
+**Current bug:**
+[ControlSocket.swift:464](phase3-binary/Sources/macprovider-cli/ControlSocket.swift:464)
+`ControlSocketConnection.receive()` appends bytes into
+`receiveBuffer` until it sees `0x0A`, with no max frame size and
+no per-read timeout. Server-side calls don't pass a timeout
+([ControlSocket.swift:320](phase3-binary/Sources/macprovider-cli/ControlSocket.swift:320)),
+and accepted client tasks are detached without tracking, so the
+server cannot cancel them on shutdown.
+
+**Required behavior:**
+
+1. Add a max frame size constant:
+   ```swift
+   public static let maxFrameBytes = 64 * 1024  // 64 KB
+   ```
+   on `ControlSocketConnection`. Inside the read loop, if
+   `receiveBuffer.count > maxFrameBytes`, throw
+   `ControlSocketConnectionError.frameTooLarge(size: Int)` (add
+   this new case to the enum) and close the connection.
+
+2. Add a per-connection idle timeout. In `handleClient`, wrap
+   the receive in a 30s timeout:
+   ```swift
+   let frame = try await connection.receive(timeout: 30.0)
+   ```
+   The existing `receive(timeout:)` overload already supports
+   this; the server just needs to pass a value instead of nil.
+
+   30 seconds is the IDLE timeout — time between accept and
+   first frame, or between sequential frames the server expects
+   to read. Note that AFTER the server sends the switch_ack and
+   enters the switch_progress streaming phase, it does NOT read
+   from the client (only writes). The 30s timeout matters for
+   the initial frame read.
+
+3. Track accepted client tasks so the server can cancel them on
+   `stop()`. Add a private field:
+   ```swift
+   private var clientTasks: [Task<Void, Never>] = []
+   ```
+   In the accept loop, when spawning a client task, append it
+   to `clientTasks`. Periodically prune completed tasks (or
+   simply rebuild the array as `clientTasks = clientTasks.filter
+   { !$0.isCancelled }` on each accept iteration; the array
+   stays bounded by the concurrent connection count). In
+   `stop()`, before unlinking the socket, cancel all:
+   ```swift
+   for task in clientTasks {
+       task.cancel()
+   }
+   clientTasks.removeAll()
+   ```
+
+4. Required tests in `ControlSocketTests.swift`:
+   - `testReceiveRejectsFramesLargerThan64KB` — start a server,
+     connect a raw socket, send a single line of 65536 bytes
+     (no newline yet — or with newline at byte 65537), assert
+     the server closes the connection and the test client gets
+     EOF or `.closed`
+   - `testReceiveTimesOutAfter30sIdle` — start a server, connect
+     but never send anything, await up to 35 seconds, assert
+     the server-side connection was closed. (You may use a
+     shorter timeout for the test by adding a test-only init
+     overload to `ControlSocketServer` that accepts a custom
+     idle timeout — say, 200ms — and use that in the test. The
+     production code path still uses 30s.)
+   - `testServerStopCancelsActiveClientTasks` — start a server,
+     connect a client that sits in receive (sends only a partial
+     line), call `server.stop()`, assert the client gets EOF
+     within 1 second.
+
+## L-1 byte-identical default invariant
+
+The drain phase and snapshot-atomicity refactor MUST NOT change
+the L-1 baseline:
+- A v1.3 binary started WITHOUT `--enable-warm-swap` still has
+  `state == .ready` throughout its lifetime; no drain phase ever
+  runs (because `beginSwap` is gated and never called)
+- HTTPServer inference behavior in disabled mode unchanged
+- Heartbeat / hello frames in disabled mode unchanged (no
+  `model_hash` / `loading` fields)
+- Control socket file is still NEVER created in disabled mode
+- All Phase 1A-1E tests that pin L-1 must remain green
+
+The EndToEndAcceptanceTests AC matrix tests are the canonical
+pins. If any of those break, you have introduced a regression.
+
+## Constraints that apply across all 5 fixes
+
+**1. d-inference clean-room.** Do NOT read any file under
+`phase3-binary/.build/checkouts/`.
+
+**2. Existing tests stay green.** All 131 tests from Phase 1A-1E
+must continue to pass. New tests added by this fix add to the
+cumulative count. Final count after fixes should be ≥ 145.
+
+**3. Backwards compatibility of public types.** The
+`RuntimeStateMachine` refactor IS a breaking change to that
+file's actor surface. Other Swift files that import the type
+(test files use `@testable import`) are allowed to break and be
+fixed in this PR. External callers do not exist (the binary is
+self-contained).
+
+**4. No new CLI flags, no new YAML keys, no new ENV vars.** The
+existing surface is sufficient to implement all 5 fixes.
+
+**5. No spec edits.** Do NOT modify any file under `specs/`.
+
+**6. Compile + tests pass.** `swift build` and `swift test` MUST
+both exit 0.
+
+**7. Macro discipline.** No `#if DEBUG` / `#if TESTING` guards
+introduced. The test-only injection points use `internal`
+visibility and `@testable import`.
+
+## Required reading (in this order — read fully before writing)
+
+1. The audit findings document — read this entirely first:
+   `/Users/augstar/macprovider-poc/.omc/artifacts/ask/codex-execute-the-audit-prompt-at-users-augstar-macprovider-poc-sp-2026-06-07T00-27-31-529Z.md`
+   (search for "## Raw output" — your findings are below that
+   marker)
+
+2. `/Users/augstar/macprovider-poc/specs/SPEC-011-operator-pushed-warm-swap.md`
+   - §3.2 (state machine + atomic swap) — re-read R-3.2.4 to
+     confirm the four-step contract
+   - §3.4 (drain semantics R-3.4.1 through R-3.4.5) — the
+     binding source for Finding 1
+   - §3.9 (config additions — drain timeout range 5...600)
+   - §3.1 R-3.1.2 step 2 (supported_models pre-flight — binding
+     source for Finding 4)
+
+3. `/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md`
+   - §6.8 (lines 1748-1809) — incorporates SPEC-011 R-3.2.x and
+     R-3.4.x; R-6.8.4 has the HTTP 503 rejection for
+     loading/draining
+   - §9 AC-25 — the drain timeout range validation AC
+
+4. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift`
+   — full file (77 lines). You are demoting this actor.
+
+5. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+   — full file (~437 lines). Read carefully — this is the
+   biggest refactor target.
+
+6. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ControlSocket.swift`
+   - `ControlSocketServer.handleSwitchRequest` at line 359 — add
+     the server-side `SupportedModels.validate` check
+   - `ControlSocketServer.start` / `stop` — track and cancel
+     client tasks
+   - `ControlSocketServer.handleClient` at line 314 — pass a
+     timeout to `receive()`
+   - `ControlSocketConnection.receive` at line 464 — add max
+     frame size check
+
+7. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+   - `ServeCommand.run` — add the drain timeout range check
+     after the existing SPEC-010 preflight; pass
+     `resolved.supportedModels` into `ControlSocketServer`
+
+8. The existing test files. Mirror their fixture style.
+
+## Required edits — exact shape
+
+### Finding 1 (drain semantics)
+
+Per the analysis above. Key files: `ModelRuntime.swift`,
+`RuntimeStateMachine.swift` (demoted), `ControlSocket.swift`
+(handleSwitchRequest signal mapping).
+
+Code-level constraints:
+- The drain wait loop MUST run inside the detached task spawned
+  by `beginSwap`, NOT on the actor's serial executor (no-starve
+  rule from 1B carried forward)
+- The drain wait loop polls every 50ms
+- The drain wait loop reads
+  `await providerStatus.snapshot().requestsInFlight` per poll;
+  exits when 0
+- The drain wait loop exits if `(now - drainStartMs) >
+  drainTimeoutSeconds * 1000`
+- After drain exits (either condition), call
+  `await self.completeSwapAtomically(container:modelID:modelHash:)`
+- The atomic swap method MUST be a single actor-isolated method
+  that writes all four mutable fields (state, container, modelID,
+  modelHash) in one synchronous block, then emits the `.completed`
+  SwapSignal
+
+### Finding 2 (snapshot atomicity)
+
+Per the analysis above. The refactor:
+- Move `state` ownership from `RuntimeStateMachine` into
+  `ModelRuntime`
+- Move signal continuations into `ModelRuntime`
+- Demote `RuntimeStateMachine.swift` to pure type declarations
+- `currentSnapshot()` becomes a single non-await actor read
+
+### Finding 3 (drain timeout range validation)
+
+Per the analysis above. In `MacProviderCLI.swift` `ServeCommand.run`,
+add:
+
+```swift
+if !(5...600).contains(resolved.swapDrainTimeoutSeconds) {
+    FileHandle.standardError.write(Data((
+        "--swap-drain-timeout-seconds \(resolved.swapDrainTimeoutSeconds) out of range 5...600\n"
+    ).utf8))
+    throw ExitCode(2)
+}
+```
+
+Place it AFTER `Self.runSupportedModelsPreflight(&resolved)` and
+BEFORE `printResolvedConfiguration(resolved)`.
+
+### Finding 4 (server-side supported_models check)
+
+Per the analysis above. Key files: `ControlSocket.swift` (server
+init + handleSwitchRequest), `MacProviderCLI.swift` (pass
+catalog), `ModelsSubcommand.swift` (CLI handles `.notInSupportedModels`
+ack reason).
+
+The `SwitchAckReason.notInSupportedModels` enum case already
+exists from Phase 1C — no enum changes needed.
+
+### Finding 5 (bounded reads + per-read timeout + task tracking)
+
+Per the analysis above. Key file: `ControlSocket.swift`.
+
+Add:
+- `ControlSocketConnection.maxFrameBytes = 64 * 1024`
+- `ControlSocketConnectionError.frameTooLarge(size: Int)` case
+- In `receive()`'s inner loop, after `receiveBuffer.append(byte)`:
+  ```swift
+  if receiveBuffer.count > Self.maxFrameBytes {
+      throw ControlSocketConnectionError.frameTooLarge(size: receiveBuffer.count)
+  }
+  ```
+- A 30s default idle timeout on the server-side
+  `connection.receive()` call in `handleClient`
+- A test-only init parameter `idleTimeoutSeconds: TimeInterval = 30.0`
+  on `ControlSocketServer` so the bounded-read test can use 0.2s
+- `clientTasks` array tracking + cancellation on `stop()`
+
+## Done criteria
+
+You are done when:
+
+- `git diff -- specs/ phase4-coordinator/ phase5-gateway/` shows
+  only operator-authored BUILD prompts and the pre-existing
+  `specs/FOLLOWUP_COORDINATOR_HA_2026_06_03.md` unstaged edit.
+- `cd phase3-binary && swift build` exits 0.
+- `cd phase3-binary && swift test` exits 0 with ≥ 145 tests
+  green.
+- All Phase 1A-1E tests still GREEN (131 from the prior commits
+  remain unchanged in PASS status).
+- A `models switch` against a runtime with `swap_drain_timeout: 5`
+  and a long-running in-flight inference triggers a real `draining`
+  switch_progress frame (visible via stderr capture in the new
+  test).
+- A direct control-socket client sending `switch_request` with a
+  target NOT in `supported_models` gets a
+  `switch_ack accepted:false reason:not_in_supported_models`
+  response.
+- A direct control-socket client sending a 65537-byte frame gets
+  the connection closed by the server with
+  `ControlSocketConnectionError.frameTooLarge`.
+- A direct control-socket client that connects but never sends a
+  frame gets disconnected by the server within the configured idle
+  timeout.
+- `serve --swap-drain-timeout-seconds 4` exits code 2 with stderr
+  matching `"out of range 5...600"`.
+- `currentSnapshot()` is a non-await actor method (no
+  `await stateMachine.current()` call anywhere); a concurrent
+  test driving 1000 snapshots during a 100ms swap shows NO
+  observed `(state == .loading, container == NEW)` or
+  `(state == .ready, container == OLD)` pairs (atomicity invariant).
+
+## Out of scope for this fix
+
+- The MINOR arch:1.1 finding (test `captureOutput` dup2 race) —
+  defer to a separate cleanup PR; do NOT change the test
+  harness in this fix
+- Any other audit findings — only the 5 listed above
+- Modifying `phase4-coordinator/` — separate Phase 2 PR
+- Any new CLI flags, ENV vars, or YAML keys
+- Refactoring `CoordinatorClient` beyond what's strictly needed
+  to consume the new SwapSignal outcome variants (one-line
+  switch-case change at most)
+
+## Self-check before reporting done
+
+Run this command and confirm all checks pass:
+
+```bash
+cd /Users/augstar/macprovider-poc && \
+  git diff --stat -- specs/ phase4-coordinator/ phase5-gateway/ && \
+  echo "----" && \
+  (cd phase3-binary && swift build 2>&1 | tail -10) && \
+  echo "----" && \
+  (cd phase3-binary && swift test 2>&1 | grep "Executed.*tests" | tail -3) && \
+  echo "----" && \
+  grep -rn "XDG_RUNTIME_DIR" phase3-binary/Sources/ || echo "no XDG_RUNTIME_DIR (correct)" && \
+  echo "----" && \
+  grep -c "await stateMachine" phase3-binary/Sources/macprovider-cli/ModelRuntime.swift || echo "no await stateMachine refs (correct — stateMachine actor demoted)" && \
+  echo "----" && \
+  grep -n "transitionToDraining\|enterDrainPhase" phase3-binary/Sources/macprovider-cli/ModelRuntime.swift | head -5
+```
+
+Return:
+- A brief diff summary (files touched, +/- lines).
+- The final `swift test` summary line (Executed N tests, ...).
+- Any spec rule you were unable to satisfy exactly, with the
+  binding rule number and your interpretation.
+- A one-paragraph note on the snapshot-atomicity refactor
+  approach you took (option (a) RuntimeStateMachine deleted vs
+  option (b) types-only file).
+
+Do NOT commit. Do NOT push. The operator audits the working tree
+before commit.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (out-of-band)
+
+- Expected wall-clock: 120-180 min. The drain refactor + snapshot
+  atomicity together rewrite a significant portion of
+  ModelRuntime; the security fixes are smaller surface but
+  require new tests with raw-socket plumbing.
+- Audit pass (Claude Opus) re-reads the 5 fixes against:
+  - The locked SPEC-011 §3.2 + §3.4 + §3.9 rules
+  - The atomicity invariant test (no mixed snapshots)
+  - The 131-test baseline regression check
+  - The L-1 byte-identical guarantee in disabled mode
+- If R1 produces a clean diff and Claude's re-audit yields zero
+  new findings, re-dispatch the **external** Codex audit prompt
+  at `specs/AUDIT_SPEC_001_v1_3_IMPL_PR5_PROMPT.md` to confirm
+  the original 5 findings are now resolved AND no new findings
+  emerged. That re-audit is the merge gate.
+- If R1 surfaces findings, an R2 fix prompt is drafted naming
+  the specific R1 findings and citing the new file:line.
+- After audits converge to 0/0/0, commit the fixes onto
+  `fix/spec-001-v1-3-binary` and force-push PR #5 (or land as
+  a separate commit on the same branch — operator decides). PR
+  #5 then merges to main; release tag waits for SPEC-002 v1.3.5
+  coordinator implementation per Entry 58.

--- a/specs/BUILD_SPEC_001_v1_3_IMPL_PR5_PREMERGE_FIX_R2_PROMPT.md
+++ b/specs/BUILD_SPEC_001_v1_3_IMPL_PR5_PREMERGE_FIX_R2_PROMPT.md
@@ -1,0 +1,611 @@
+# PR #5 pre-merge fix R2 prompt — 3 remaining findings (2 CRITICAL + 1 MAJOR)
+
+Operator-paste prompt for Codex GPT-5 to land the **R2 fixes** for
+findings surfaced by the external audit at
+`.omc/artifacts/ask/codex-execute-the-audit-prompt-at-users-augstar-macprovider-poc-sp-2026-06-07T00-57-08-696Z.md`
+(re-audit on commit aacf09a).
+
+The R2 verdict on PR #5 is still **BLOCK-MERGE** (2 CRITICAL / 1 MAJOR /
+1 MINOR). Three of the original 5 R1 findings are RESOLVED:
+
+- ✅ [code:1.2] Snapshot atomicity (RuntimeStateMachine demoted)
+- ✅ [code:1.3] `--swap-drain-timeout-seconds` range validation
+- ✅ [sec:1.1] Server-side `supported_models` check on control socket
+
+Two findings remain or are new:
+
+- ❌ [code:1.1] Drain timeout cancellation (PARTIAL — drain phase exists
+  but per-request cancellation contract per SPEC-011 R-3.4.2 missing)
+- ❌ [code:1.2] Post-swap `model_id` still reads boot `ProviderStatus`
+  on heartbeat / hello / HTTPServer / InferenceRelay (NEW finding)
+- ❌ [sec:1.1] `clientTasks` array grows unboundedly because the R1 fix
+  only filters by `isCancelled` (NEW — introduced by R1)
+
+The MINOR (arch:1.1 captureOutput) remains deferred.
+
+Run via `omc ask codex` from session root
+`/Users/augstar/macprovider-poc`. Expected wall-clock: ~90-120 min.
+Branch: `fix/spec-001-v1-3-binary` carries Phases 1A-1E + the R1 fix
+commit aacf09a. Codex MUST commit on this branch, MUST NOT create a
+new one, MUST NOT commit or push.
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are landing the R2 pre-merge audit fixes for PR #5 in the Swift
+binary at /Users/augstar/macprovider-poc/phase3-binary/. The R1 fix
+commit aacf09a addressed 3 of 5 original findings cleanly. The R2
+external audit returned BLOCK-MERGE with 2 CRITICAL + 1 MAJOR
+remaining. Your job is to land all 3 R2 fixes in a single working-tree
+session.
+
+You will edit the following files (and ONLY these):
+
+  phase3-binary/Sources/macprovider-cli/ModelRuntime.swift                       (extend — drain cancellation)
+  phase3-binary/Sources/macprovider-cli/HTTPServer.swift                         (extend — swap_drain_timeout error mapping + live model_id validation)
+  phase3-binary/Sources/macprovider-cli/InferenceRelay.swift                     (extend — live model_id validation)
+  phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift                  (extend — model_id source switch in heartbeat + hello)
+  phase3-binary/Sources/macprovider-cli/ControlSocket.swift                      (extend — clientTasks lifecycle cleanup)
+  phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift           (extend — drain cancellation tests)
+  phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift             (extend — swap_drain_timeout envelope + live model_id validation)
+  phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift          (extend — post-swap model_id heartbeat + hello tests)
+  phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift              (extend — task lifecycle leak regression)
+
+You will NOT edit any other Swift file, any file under `specs/`,
+`phase4-coordinator/`, `phase5-gateway/`, or the prior phase test
+files beyond the four listed above.
+
+Verify with `git diff -- specs/ phase4-coordinator/ phase5-gateway/`
+— must be empty (excluding operator-authored BUILD/AUDIT prompts and
+the pre-existing FOLLOWUP_COORDINATOR_HA_2026_06_03.md edit).
+
+## Findings to fix
+
+### Finding 1 — CRITICAL [code:1.1] — Drain timeout doesn't cancel in-flight requests
+
+**Spec reference:** SPEC-011 v0.5 R-3.4.2; the audit cites SPEC-011
+lines 1216-1224 ("Cancellation contract on drain timeout").
+
+**Current bug:** `waitForDrainOrTimeout` polls
+`providerStatus.requestsInFlight` and exits when either it reaches 0
+OR the configured timeout elapses. On timeout exit, the impl proceeds
+to `completeSwapAtomically` and lets the in-flight requests continue
+holding their OLD-container snapshot reference. The R1 fix prompt
+explicitly told Codex this was OK; the spec disagrees.
+
+Per SPEC-011 R-3.4.2: when drain timeout elapses, still-in-flight
+requests against the OLD container MUST be cancelled. The cancelled
+requests MUST receive an HTTP 503 response with the OpenAI error
+envelope shape:
+
+```json
+{
+  "error": {
+    "type": "service_unavailable",
+    "code": "swap_drain_timeout"
+  }
+}
+```
+
+(Note: this is a DIFFERENT `code` than the `provider_loading` code
+used for "rejected before entry into ready" requests. The
+`swap_drain_timeout` code is specifically for "started in ready,
+killed by drain timeout".)
+
+**Required behavior:**
+
+The cleanest mechanism is to give `ModelRuntime` a per-request
+cancellation hook list that the drain timeout walks. Concretely:
+
+1. Add a private actor-isolated counter to `ModelRuntime`:
+   ```swift
+   private var nextInFlightID: Int = 0
+   private var inFlightCancellations: [Int: @Sendable () -> Void] = [:]
+   ```
+
+2. Add two actor methods:
+   ```swift
+   func registerInFlight(_ cancel: @escaping @Sendable () -> Void) -> Int {
+       nextInFlightID += 1
+       let id = nextInFlightID
+       inFlightCancellations[id] = cancel
+       return id
+   }
+
+   func unregisterInFlight(_ id: Int) {
+       inFlightCancellations.removeValue(forKey: id)
+   }
+   ```
+
+3. Add the drain-timeout cancellation method:
+   ```swift
+   private func cancelAllInFlightForDrainTimeout() {
+       let cancels = Array(inFlightCancellations.values)
+       inFlightCancellations.removeAll()
+       for cancel in cancels {
+           cancel()
+       }
+   }
+   ```
+
+4. Modify `waitForDrainOrTimeout` to return a `didTimeout: Bool`
+   so the caller knows which exit branch fired. After return, if
+   `didTimeout == true`, call `cancelAllInFlightForDrainTimeout()`
+   BEFORE `completeSwapAtomically`. The cancelled requests then
+   throw their cancellation; the swap proceeds atomically.
+
+5. The actor method `complete(_:shouldCancel:)` and
+   `stream(_:shouldCancel:onChunk:)` MUST register themselves at
+   entry and unregister at exit via `defer`:
+
+   ```swift
+   func complete(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool = { false }) async throws -> CompletionResult {
+       let snapshot = currentSnapshot()
+       try Self.validateReady(snapshot.state)
+       // ... existing validation ...
+
+       // R-3.4.2 drain cancellation hook
+       let drainCancelled = DrainCancelToken()
+       let registrationID = registerInFlight { drainCancelled.fire() }
+       defer { Task { await self.unregisterInFlight(registrationID) } }
+
+       // ... existing inferenceGate.withPermit / container.perform body ...
+       // Inside the generate closure, augment the existing
+       // `shouldCancel()` check to ALSO check drainCancelled.isFired:
+       if Task.isCancelled || shouldCancel() || drainCancelled.isFired {
+           if drainCancelled.isFired {
+               throw DrainCancelledError()  // new error type
+           }
+           return GenerateDisposition.stop
+       }
+   }
+   ```
+
+   Where `DrainCancelToken` is a small Sendable class that flips a
+   single Bool:
+   ```swift
+   final class DrainCancelToken: @unchecked Sendable {
+       private var _fired = false
+       private let lock = NSLock()
+       var isFired: Bool {
+           lock.lock(); defer { lock.unlock() }
+           return _fired
+       }
+       func fire() {
+           lock.lock(); defer { lock.unlock() }
+           _fired = true
+       }
+   }
+   ```
+   `@unchecked Sendable` is justified because the Bool is guarded by
+   the lock.
+
+   `DrainCancelledError` is a new struct:
+   ```swift
+   public struct DrainCancelledError: Error { }
+   ```
+
+6. The caller (HTTPServer) catches `DrainCancelledError` and maps it
+   to HTTP 503 with the spec-mandated envelope:
+
+   ```swift
+   } catch is DrainCancelledError {
+       // SPEC-011 R-3.4.2 / R-6.8.4 swap_drain_timeout envelope
+       try await writer.write(status: 503, body: [
+           "error": [
+               "type": "service_unavailable",
+               "code": "swap_drain_timeout"
+           ]
+       ])
+   }
+   ```
+
+   Add this catch to BOTH the non-streaming dispatcher at
+   `HTTPServer.swift` around line 196-232 AND the streaming dispatcher
+   at `:238-260`.
+
+7. Required tests in `ModelRuntimeSwapTests.swift`:
+   - `testDrainTimeoutCancelsInFlightRequests` — start a runtime with
+     warm-swap enabled, swap-drain-timeout = 5s. Begin a long-running
+     `complete` call (use `testCompletion` returning after a
+     `Task.sleep(15s)`). Call `beginSwap`, await the swap Task. The
+     long-running call MUST throw `DrainCancelledError` within
+     ~5.2 seconds (slack: 200ms). Assert post-swap snapshot is
+     `.ready` with NEW model.
+   - `testInFlightCompletesIfWithinDrainWindow` — same setup but
+     completion returns after 2s (well within 5s drain). The
+     `complete` call MUST return normally with OLD model content;
+     no cancellation thrown.
+
+8. Required tests in `HTTPServerSwapTests.swift`:
+   - `testHTTPReturns503SwapDrainTimeoutEnvelope` — drive the
+     dispatcher with a `DrainCancelledError` thrown from
+     modelRuntime; assert response body matches
+     `{"error":{"type":"service_unavailable","code":"swap_drain_timeout"}}`
+     (sortedKeys / withoutEscapingSlashes serialization).
+
+### Finding 2 — CRITICAL [code:1.2] — Post-swap `model_id` source-of-truth
+
+**Spec reference:** SPEC-011 v0.5 AC-10 + R-3.3.5; SPEC-002 v1.3.5
+R-7.10.6.
+
+**Current bug:** After a swap A→B, several code paths still emit or
+validate against the BOOT model ID (immutable
+`providerStatus.modelID`):
+
+- `CoordinatorClient.sendHeartbeat()` at line 588 — reads
+  `snapshot.modelID` from `providerStatus.snapshot()`. The warm-swap
+  block at line ~628 adds `model_hash` and `loading` from
+  `modelRuntime.currentSnapshot()` but does NOT override `model_id`.
+  Result: heartbeat carries `model_id: A`, `model_hash: hash(B)`,
+  `loading: false` — incoherent.
+- `CoordinatorClient.helloMessage()` at line 692-720 — same split.
+  `model_id` comes from `providerStatus`; only `model_hash` comes
+  from `modelRuntime` (added in Phase 1D).
+- `HTTPServer.swift` outer validation at line 188 (look for
+  `validateModelMatches`) — validates the buyer's request `model`
+  field against the BOOT model ID, NOT the live runtime model. After
+  a swap, requests for the NEW model are rejected at the outer gate;
+  requests for the OLD model pass the outer gate but fail
+  `ModelRuntime.complete`'s inner `validateModelMatches(snapshot.modelID)`
+  check (Phase 1B).
+- `InferenceRelay.swift` line ~189 — same validation issue on the
+  WS-tunneled path.
+
+**Required behavior:** When `warmSwapEnabled == true`, ALL FOUR call
+sites MUST source the model ID from `modelRuntime.currentSnapshot()`
+instead of `providerStatus.snapshot()`. When `warmSwapEnabled ==
+false`, the boot `providerStatus` source is preserved (L-1
+byte-identical default).
+
+This mirrors the pattern Phase 1D already established for
+`model_hash`. Extend it to `model_id`.
+
+**Required edits:**
+
+1. `CoordinatorClient.sendHeartbeat` — augment the existing
+   warm-swap block:
+
+   ```swift
+   if warmSwapEnabled {
+       let runtimeSnapshot = await modelRuntime.currentSnapshot()
+       payload["model_id"] = runtimeSnapshot.modelID ?? ""  // override boot value
+       if let modelHash = runtimeSnapshot.modelHash {
+           payload["model_hash"] = modelHash
+       }
+       payload["loading"] = runtimeSnapshot.state == .loading
+                              || runtimeSnapshot.state == .draining
+   }
+   ```
+
+   Note: the existing `payload["model_id"] = snapshot.modelID ?? ""`
+   is set in the dict literal earlier; the warm-swap block reassigns.
+
+2. `CoordinatorClient.helloMessage` — extend the existing
+   source-of-truth conditional to ALSO cover `model_id`:
+
+   ```swift
+   let modelIDForHello: String
+   let hashForHello: String?
+   if warmSwapEnabled {
+       let rs = await modelRuntime.currentSnapshot()
+       modelIDForHello = rs.modelID ?? ""
+       hashForHello = rs.modelHash
+   } else {
+       modelIDForHello = snapshot.modelID ?? ""
+       hashForHello = snapshot.modelHash
+   }
+   message["model_id"] = modelIDForHello
+   if let hashForHello {
+       message["model_hash"] = hashForHello
+   }
+   ```
+
+   The earlier `"model_id": snapshot.modelID ?? ""` in the dict
+   literal is overwritten by this assignment.
+
+3. `HTTPServer.swift` line ~188 (the chat-completions handler outer
+   validation) — read modelRuntime's current snapshot for the
+   validator when warm-swap is enabled. Concretely, find the
+   `try request.validateModelMatches(...)` call (or whatever the
+   outer validation function is) and replace the immutable model ID
+   source with the live one.
+
+   Suggested helper on `RouterHandler`:
+   ```swift
+   private static func effectiveModelID(
+       warmSwapEnabled: Bool,
+       providerStatus: ProviderStatus,
+       runtimeSnapshot: RuntimeSnapshot
+   ) -> String? {
+       if warmSwapEnabled {
+           return runtimeSnapshot.modelID
+       }
+       // Disabled-mode L-1 path: boot source unchanged
+       return providerStatus.snapshot... // TODO: providerStatus is an actor; in disabled mode, the existing immutable path is already correct
+   }
+   ```
+
+   The right approach in disabled mode: keep the existing immutable
+   field (the HTTPServer holds `modelID: String?` at construction
+   from the boot resolved config). In enabled mode, call
+   `await modelRuntime.currentSnapshot()` and use its modelID. The
+   warm-swap flag is in `AppConfig.enableWarmSwap` — plumb it into
+   `RouterHandler` at construction (HTTPServer.swift line 47-58
+   already holds `modelRuntime`; add a `warmSwapEnabled: Bool`
+   field).
+
+4. `InferenceRelay.swift` line ~189 — same fix as HTTPServer. The
+   inference relay validates the request's `model` field against
+   the binary's current served model. Same warm-swap source-of-truth
+   rule applies.
+
+5. `helloMessage()` test — the existing
+   `testHelloEnabledModeReadsFromModelRuntime` from Phase 1D
+   asserts on `model_hash`. EXTEND it (or add a sibling test) to
+   also assert on `model_id`:
+
+   ```swift
+   func testHelloEnabledModeReadsModelIDAndHashFromModelRuntime() async throws {
+       // ProviderStatus has modelID = "A", modelHash = "boot-hash"
+       // ModelRuntime has been swapped to modelID = "B", modelHash = "runtime-hash"
+       let hello = await client.helloMessage()
+       XCTAssertEqual(hello["model_id"] as? String, "B")
+       XCTAssertEqual(hello["model_hash"] as? String, "runtime-hash")
+   }
+   ```
+
+6. `sendHeartbeat()` test — same shape. Capture the heartbeat via
+   `sendOverride`; assert `model_id == "B"` post-swap.
+
+7. New end-to-end test in `HTTPServerSwapTests.swift`:
+   - `testInferenceForNewModelSucceedsAfterSwap` — start
+     ModelRuntime with model "A", warm-swap enabled. Begin and
+     complete a swap to "B" (via `beginSwap` + await Task). Drive
+     the HTTPServer dispatcher with a chat completions request for
+     model "B"; assert the request reaches `modelRuntime.complete`
+     (use `testCompletion` to confirm) WITHOUT rejection at the
+     outer validator.
+   - `testInferenceForOldModelRejectedAfterSwap` — same setup;
+     drive a request for "A"; assert it's rejected with 4xx
+     "model not loaded" or similar (whatever the existing
+     mismatch error path emits).
+
+### Finding 3 — MAJOR [sec:1.1] — `clientTasks` array grows unboundedly
+
+**Spec reference:** Audit threat model — same-UID local DoS.
+
+**Current bug:** My R1 fix added
+`clientTasks: [Task<Void, Never>] = []` to track accepted client
+tasks for cancellation on `stop()`. The append path
+(`appendClientTask`) filters by `isCancelled` only. A successfully
+COMPLETED task (not cancelled) is NEVER removed. A same-UID process
+that repeatedly opens short-lived connections grows the array
+indefinitely — eventual OOM.
+
+**Required behavior:** Each tracked task MUST be removed from the
+collection when it completes (success OR cancellation OR error).
+
+**Required edit:**
+
+Change the tracking to be UUID-keyed and have each task remove
+itself in a `defer`:
+
+```swift
+// ControlSocketServer state
+private var clientTasks: [UUID: Task<Void, Never>] = [:]
+
+// in the accept loop, when spawning a client task:
+let taskID = UUID()
+let task = Task.detached(priority: .userInitiated) { [weak self] in
+    defer {
+        Task { await self?.removeClientTask(taskID) }
+    }
+    await Self.handleClient(...)
+}
+clientTasks[taskID] = task
+
+// new actor method
+private func removeClientTask(_ id: UUID) {
+    clientTasks.removeValue(forKey: id)
+}
+
+// stop() iterates values
+for task in clientTasks.values {
+    task.cancel()
+}
+clientTasks.removeAll()
+```
+
+Also: `ModelRuntime.swapSignals()` creates AsyncStream continuations
+appended to `signalContinuations` ([ModelRuntime.swift:145](phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:145))
+but never cleans them up when the consumer drops the stream. Add
+`onTermination` cleanup:
+
+```swift
+func swapSignals() -> AsyncStream<SwapSignal> {
+    let pair = AsyncStream<SwapSignal>.makeStream(of: SwapSignal.self)
+    let id = UUID()
+    signalContinuations[id] = pair.continuation
+    pair.continuation.onTermination = { [weak self] _ in
+        Task { await self?.removeSignalContinuation(id) }
+    }
+    return pair.stream
+}
+
+private var signalContinuations: [UUID: AsyncStream<SwapSignal>.Continuation] = [:]
+
+private func removeSignalContinuation(_ id: UUID) {
+    signalContinuations.removeValue(forKey: id)
+}
+
+// signal() iterates values
+private func signal(_ signal: SwapSignal) {
+    for continuation in signalContinuations.values {
+        continuation.yield(signal)
+    }
+}
+```
+
+**Required test:** `testClientTasksDoNotLeakOnCompletion` in
+`ControlSocketTests.swift` — start a server, expose
+`clientTasksCountForTest()` via a test-only accessor on
+`ControlSocketServer`. Open and close 50 connections sequentially.
+Assert the count returns to 0 (or small constant) within 500ms of
+the last close.
+
+## L-1 byte-identical default invariant
+
+The fixes MUST NOT change L-1 baseline. Specifically:
+- In disabled mode (no `--enable-warm-swap`), heartbeat and hello
+  frames continue to source `model_id` from `providerStatus` — this
+  is the v1.2.4 baseline path
+- HTTPServer / InferenceRelay outer validation in disabled mode
+  continues to use the boot `modelID` (immutable startup value)
+- Drain cancellation is unreachable in disabled mode because
+  `beginSwap` is gated on `warmSwapEnabled`
+- All 145 tests from R1 must remain green
+
+## Constraints across all 3 fixes
+
+**1. d-inference clean-room.** Do NOT read any file under
+`phase3-binary/.build/checkouts/`.
+
+**2. Existing tests stay green.** All 145 tests from the R1 fix
+must continue to pass. New tests added by this fix add to the
+cumulative count. Final count after fixes should be ≥ 155.
+
+**3. No new CLI flags, no new YAML keys, no new ENV vars.**
+
+**4. No spec edits.** Do NOT modify any file under `specs/`.
+
+**5. Compile + tests pass.** `swift build` and `swift test` MUST
+both exit 0.
+
+**6. The MINOR arch:1.1 (captureOutput dup2) is STILL deferred.**
+Do not change the test harness.
+
+## Required reading (in this order — read fully before writing)
+
+1. The R2 audit findings document:
+   `/Users/augstar/macprovider-poc/.omc/artifacts/ask/codex-execute-the-audit-prompt-at-users-augstar-macprovider-poc-sp-2026-06-07T00-57-08-696Z.md`
+   (search for "## Raw output")
+
+2. `/Users/augstar/macprovider-poc/specs/SPEC-011-operator-pushed-warm-swap.md`
+   - §3.4 (drain semantics — focus on R-3.4.2 cancellation contract
+     and AC-7)
+   - §3.3 (heartbeat extension R-3.3.5 — `model_id` source-of-truth)
+
+3. `/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md`
+   - §6.8.3 (R-6.8.4 — HTTP 503 envelope; verify `swap_drain_timeout`
+     code is documented)
+   - §6.10 (heartbeat extension — confirm `model_id` source)
+
+4. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+   - `complete` / `stream` methods — add registration/unregistration
+   - `waitForDrainOrTimeout` — return didTimeout boolean
+   - `beginSwap` — call `cancelAllInFlightForDrainTimeout` on timeout
+     exit
+
+5. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+   - `sendHeartbeat` lines 588-635 — model_id override in warm-swap block
+   - `helloMessage` lines 692-720 — model_id source switch
+
+6. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/HTTPServer.swift`
+   - The chat-completions outer validator (around line 188)
+   - Plumb `warmSwapEnabled` into RouterHandler
+
+7. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift`
+   - The validator at line 189
+
+8. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ControlSocket.swift`
+   - `clientTasks` array (line 238)
+   - `appendClientTask` (line 325)
+   - `start` / `stop` lifecycle
+
+## Done criteria
+
+You are done when:
+
+- `git diff -- specs/ phase4-coordinator/ phase5-gateway/` shows
+  only operator-authored prompts and the pre-existing FOLLOWUP edit.
+- `cd phase3-binary && swift build` exits 0.
+- `cd phase3-binary && swift test` exits 0 with ≥ 155 tests green.
+- A drain-timeout-cancelled in-flight inference request returns
+  HTTP 503 with body matching exactly
+  `{"error":{"code":"swap_drain_timeout","type":"service_unavailable"}}`
+  (sortedKeys serialization).
+- A heartbeat captured AFTER a swap A→B carries `"model_id":"B"` AND
+  `"model_hash":"hash(B)"` AND `"loading":false`.
+- A hello frame captured AFTER a swap A→B carries `"model_id":"B"`.
+- An HTTP chat completion request for "B" AFTER a swap A→B reaches
+  `modelRuntime.complete` (passes both outer and inner validators);
+  a request for "A" is rejected at one of the validators (the spec
+  is satisfied either way as long as A is no longer servable).
+- Opening and closing 50 control-socket connections sequentially
+  leaves `clientTasksCountForTest()` at 0 (or a small constant ≤ 2
+  to account for in-flight cleanup) within 500ms of the last close.
+- All 145 tests from R1 still GREEN.
+
+## Out of scope for this fix
+
+- The MINOR arch:1.1 finding (test `captureOutput` dup2 race) —
+  still deferred to a separate cleanup PR
+- Any other audit findings or speculative improvements
+- Modifying `phase4-coordinator/` — separate Phase 2 PR
+- Any new CLI flags, ENV vars, or YAML keys
+
+## Self-check before reporting done
+
+```bash
+cd /Users/augstar/macprovider-poc && \
+  git diff --stat -- specs/ phase4-coordinator/ phase5-gateway/ && \
+  echo "----" && \
+  (cd phase3-binary && swift build 2>&1 | tail -10) && \
+  echo "----" && \
+  (cd phase3-binary && swift test 2>&1 | grep "Executed.*tests" | tail -3) && \
+  echo "----" && \
+  grep -n "swap_drain_timeout" phase3-binary/Sources/macprovider-cli/HTTPServer.swift phase3-binary/Sources/macprovider-cli/ModelRuntime.swift | head -5 && \
+  echo "----" && \
+  grep -n "modelRuntime.currentSnapshot\|warmSwapEnabled" phase3-binary/Sources/macprovider-cli/HTTPServer.swift phase3-binary/Sources/macprovider-cli/InferenceRelay.swift phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift | head -10
+```
+
+Return:
+- Diff summary (files touched, +/- lines).
+- Final `swift test` summary line.
+- Any spec rule you were unable to satisfy exactly with rationale.
+- Confirmation that the three R2 findings are addressed and no new
+  regressions introduced.
+
+Do NOT commit. Do NOT push. The operator audits before commit.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (out-of-band)
+
+- Expected wall-clock: 90-120 min. Finding 1 (drain cancellation)
+  is the heaviest — touches the actor surface, the generate
+  closure check, and the HTTP error mapping. Finding 2 is wider
+  (4 files) but each edit is small. Finding 3 is small and local.
+- Audit pass (Claude Opus) re-audits the diff against the 3
+  remaining findings:
+  - **Drain cancellation:** verify `DrainCancelledError` propagates
+    cleanly from generate closure → complete/stream → HTTPServer →
+    HTTP 503 with the exact envelope shape
+  - **Model ID source:** verify all 4 sites (heartbeat / hello /
+    HTTPServer / InferenceRelay) source from modelRuntime in
+    enabled mode and providerStatus in disabled mode
+  - **Task lifecycle:** verify `defer { removeClientTask(id) }`
+    fires on success, cancellation, and error paths
+- If R3 clears Claude's internal audit, re-dispatch the external
+  Codex audit (third pass) to confirm 0 CRITICAL / 0 MAJOR. That
+  is the final merge gate.
+- After audits converge, commit the R2 fix onto
+  `fix/spec-001-v1-3-binary`. PR #5 then merges to main; release
+  tag still gated on SPEC-002 v1.3.5 coordinator implementation
+  per Entry 58.

--- a/specs/BUILD_SPEC_001_v1_3_IMPL_PR5_PREMERGE_FIX_R3_PROMPT.md
+++ b/specs/BUILD_SPEC_001_v1_3_IMPL_PR5_PREMERGE_FIX_R3_PROMPT.md
@@ -1,0 +1,496 @@
+# PR #5 pre-merge fix R3 prompt — 1 remaining MAJOR
+
+Operator-paste prompt for Codex GPT-5 to land the **R3 fix** for the
+remaining streaming preflight/stream race surfaced by the external audit
+at `.omc/artifacts/ask/codex-execute-the-audit-prompt-at-users-augstar-macprovider-poc-sp-2026-06-07T01-19-56-152Z.md`.
+
+R3 verdict: **MERGE-WITH-FIXES** (0 CRITICAL / 1 MAJOR / 0 MINOR). The
+2 CRITICAL + 1 MAJOR fixed in R2 (commit 7826007) are resolved cleanly.
+One new MAJOR surfaced: a race between streaming preflight and stream
+that can return `provider_loading` for a request originally admitted
+in `.ready` state.
+
+Scope: refactor the streaming path to use a **request handle** that
+atomically captures snapshot + drain registration in a single actor
+call, then carries that handle through preflight and stream so the
+window between admit and stream commitment can never see a state
+change.
+
+Run via `omc ask codex` from session root
+`/Users/augstar/macprovider-poc`. Expected wall-clock: ~60-90 min.
+Branch: `fix/spec-001-v1-3-binary` carries the 5 phase commits +
+R1 fix (aacf09a) + R2 fix (7826007). Codex MUST commit on this
+branch, MUST NOT create a new one, MUST NOT commit or push.
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are landing the R3 pre-merge audit fix for PR #5 in the Swift
+binary at /Users/augstar/macprovider-poc/phase3-binary/. The R2 fix
+commit 7826007 addressed the two CRITICAL + one MAJOR findings from
+the second external audit cleanly. The third external audit returned
+MERGE-WITH-FIXES with one new MAJOR finding: a streaming-path race
+between preflight and stream.
+
+You will edit the following files (and ONLY these):
+
+  phase3-binary/Sources/macprovider-cli/ModelRuntime.swift                       (extend — RequestHandle + handle-based preflight/stream)
+  phase3-binary/Sources/macprovider-cli/HTTPServer.swift                         (extend — streaming dispatcher uses the handle)
+  phase3-binary/Tests/macprovider-cliTests/ModelRuntimeSwapTests.swift           (extend — handle race regression test)
+  phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift             (extend — end-to-end streaming race test)
+
+You will NOT edit any other Swift file, any file under `specs/`,
+`phase4-coordinator/`, `phase5-gateway/`, or any prior test files
+beyond the two listed above.
+
+Verify with `git diff -- specs/ phase4-coordinator/ phase5-gateway/`
+— must be empty (excluding operator-authored prompts and the
+pre-existing FOLLOWUP edit).
+
+## Finding to fix
+
+### [code:1.1] MAJOR — Streaming preflight/stream race window
+
+**Spec reference:** SPEC-001 v1.3 R-6.8.4 (HTTP 503 envelope for
+inference rejection); SPEC-011 v0.5 R-3.2.2 (in-flight snapshot
+isolation), R-3.4.1 (drain state semantics), R-3.4.2 (drain timeout
+cancellation contract).
+
+**Current bug:** The streaming dispatcher in
+`HTTPServer.handleStreamingChatCompletions` (around
+`HTTPServer.swift:277`) calls:
+  1. `await modelRuntime.preflight(request)` — tokenizes the prompt
+     to validate context length. Internally captures a snapshot,
+     calls `validateReady(state)`, registers a drain cancel token.
+  2. `await modelRuntime.stream(request, ...)` — captures a FRESH
+     snapshot, calls `validateReady` again, registers ANOTHER drain
+     cancel token.
+
+Between (1) returning and (2) starting, the actor's serial executor
+is free. If a `models switch` arrives and the swap's
+`transitionToLoading` runs in that window, the second `validateReady`
+inside `stream()` sees `.loading` and throws
+`provider_loading` — but the request was originally admitted in
+`.ready` state. Per SPEC-011 R-3.2.2 / R-3.4.1 / R-3.4.2, requests
+admitted in `.ready` MUST either complete using their captured
+snapshot OR receive `swap_drain_timeout` 503 — never
+`provider_loading`.
+
+The race window is the preflight tokenization duration (typically
+sub-millisecond but grows with prompt length and CPU load). It is
+exploitable by an operator timing concurrent `models switch` calls
+against an in-flight buyer request.
+
+**Required behavior:** Move the snapshot capture + drain registration
+to a SINGLE atomic actor call at request admission. Carry the
+resulting handle through both preflight and stream so neither needs
+to re-capture state or re-register.
+
+### Required design
+
+Introduce a `RequestHandle` value type and refactor the streaming
+path to use it. The non-streaming path is NOT affected — `complete()`
+already does its registration in a single actor invocation and has
+no preflight separation.
+
+#### A. `ModelRuntime.swift` — new types and refactored methods
+
+Add to `ModelRuntime.swift` (NOT to RuntimeStateMachine.swift —
+keep that file types-only):
+
+```swift
+public struct RequestHandle: @unchecked Sendable {
+    public let snapshot: RuntimeSnapshot
+    public let registrationID: Int
+    let drainCancelled: DrainCancelToken
+}
+```
+
+(`@unchecked Sendable` is justified because the constituents are
+captured-by-value or thread-safe by construction —
+`DrainCancelToken` is already `@unchecked Sendable` with internal
+locking from the R2 fix.)
+
+Add an actor method that atomically captures snapshot + validates +
+registers:
+
+```swift
+func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle {
+    let snapshot = currentSnapshot()
+    try Self.validateReady(snapshot.state)
+    try request.validateModelMatches(snapshot.modelID)
+    let drainCancelled = DrainCancelToken()
+    let registrationID = registerInFlight { drainCancelled.fire() }
+    return RequestHandle(
+        snapshot: snapshot,
+        registrationID: registrationID,
+        drainCancelled: drainCancelled
+    )
+}
+```
+
+Note: this method is NOT async because every operation inside it is
+synchronous within the actor. The whole body runs as one
+non-interrupting actor invocation. This is the key correctness
+property — between `currentSnapshot()` and `registerInFlight()` there
+is NO actor yield, so no other actor method (including
+`transitionToLoading`) can interleave.
+
+Refactor `preflight(_:)` to a handle-based variant:
+
+```swift
+func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
+    // No snapshot capture; no validateReady; no registration.
+    // The handle owns those.
+    guard let container = handle.snapshot.container else {
+        if testCompletion != nil {
+            return
+        }
+        throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
+    }
+
+    let maxContextTokens = maxContextTokens
+    try await inferenceGate.withPermit {
+        return try await container.perform { context in
+            let input = UserInput(chat: request.messages.map { $0.mlxMessage })
+            let lmInput = try await context.processor.prepare(input: input)
+            try Self.validatePromptTokenCount(
+                lmInput.text.tokens.size,
+                maxContextTokens: maxContextTokens
+            )
+        }
+    }
+}
+```
+
+Refactor `stream(_:shouldCancel:onChunk:)` to a handle-based variant:
+
+```swift
+func stream(
+    _ request: ChatCompletionRequest,
+    with handle: RequestHandle,
+    shouldCancel: @escaping @Sendable () -> Bool = { false },
+    onChunk: @escaping @Sendable (String) -> Void
+) async throws -> CompletionResult {
+    // No snapshot capture; no validateReady; no registration.
+    // Use handle.snapshot for container / model ID, handle.drainCancelled
+    // for the drain abort check inside the generate closure.
+
+    if let testCompletion {
+        let completion = try await testCompletion(handle.snapshot, request)
+        if !completion.content.isEmpty {
+            onChunk(completion.content)
+        }
+        return completion
+    }
+    guard let container = handle.snapshot.container else {
+        throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
+    }
+
+    let maxContextTokens = maxContextTokens
+    let drainToken = handle.drainCancelled
+    return try await inferenceGate.withPermit {
+        try Self.checkDrainOrCancellation(drainToken, shouldCancel: shouldCancel)
+        return try await container.perform { context in
+            try Self.checkDrainOrCancellation(drainToken, shouldCancel: shouldCancel)
+            // ... existing generate logic using `if Task.isCancelled || shouldCancel() || drainToken.isFired { ... }`
+            // is unchanged below ...
+        }
+    }
+}
+```
+
+(`Self.checkDrainOrCancellation` already exists from the R2 fix at
+ModelRuntime.swift:547 — reuse it.)
+
+The OLD `preflight(_:)` and `stream(_:shouldCancel:onChunk:)`
+signatures WITHOUT handle parameters MUST be REMOVED (not kept for
+back-compat). Their callers — HTTPServer streaming path — are
+updated in step B below. Removing them prevents future drift.
+
+The `ModelRuntimeServing` protocol at `ModelRuntime.swift:7-10`
+currently has:
+
+```swift
+protocol ModelRuntimeServing: Sendable {
+    func complete(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool) async throws -> CompletionResult
+    func stream(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool, onChunk: @escaping @Sendable (String) -> Void) async throws -> CompletionResult
+}
+```
+
+The protocol's `stream(...)` signature MUST be updated to require
+the handle:
+
+```swift
+protocol ModelRuntimeServing: Sendable {
+    func complete(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool) async throws -> CompletionResult
+    func stream(_ request: ChatCompletionRequest, with handle: RequestHandle, shouldCancel: @escaping @Sendable () -> Bool, onChunk: @escaping @Sendable (String) -> Void) async throws -> CompletionResult
+    func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws
+    func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle
+}
+```
+
+And the extension's convenience overload for stream
+(`ModelRuntime.swift:17-22`) MUST be removed (it lacked the handle
+parameter).
+
+`complete(_:shouldCancel:)` is UNCHANGED in signature. It does its
+snapshot capture + registration internally as today; non-streaming
+HTTPServer continues to call it as a single actor invocation, so
+there is no race window. Adding a handle parameter to `complete()`
+is OUT OF SCOPE for this fix.
+
+#### B. `HTTPServer.swift` — streaming dispatcher refactor
+
+Locate `handleStreamingChatCompletions` (around line 277). The
+current flow is approximately:
+
+```swift
+// existing
+do {
+    let snapshot = await modelRuntime.currentSnapshot()
+    if let error = Self.warmSwapRejectionError(for: snapshot) {
+        throw error
+    }
+    try await modelRuntime.preflight(request)
+    // commit 200 OK with headers
+    let result = try await modelRuntime.stream(request, shouldCancel: ..., onChunk: ...)
+    // emit final chunk + done
+} catch is DrainCancelledError {
+    // emit swap_drain_timeout envelope
+} catch ... { ... }
+```
+
+Refactor to use the handle (after the optional admit-time warm-swap
+rejection check):
+
+```swift
+do {
+    let snapshot = await modelRuntime.currentSnapshot()
+    if let error = Self.warmSwapRejectionError(for: snapshot) {
+        throw error
+    }
+    // CRITICAL: acquire handle atomically here — snapshot + register in one actor call.
+    let handle = try await modelRuntime.acquireRequestHandle(request)
+    defer {
+        Task { await modelRuntime.unregisterInFlight(handle.registrationID) }
+    }
+    try await modelRuntime.preflight(request, with: handle)
+    // commit 200 OK with headers
+    let result = try await modelRuntime.stream(
+        request,
+        with: handle,
+        shouldCancel: ...,
+        onChunk: ...
+    )
+    // emit final chunk + done
+} catch is DrainCancelledError {
+    // existing swap_drain_timeout envelope handler stays as is
+} catch ... { ... }
+```
+
+Key invariants the refactored flow MUST satisfy:
+
+1. The `warmSwapRejectionError` admit-time check stays — it lets the
+   dispatcher reject `loading`/`draining` requests BEFORE attempting
+   to acquire a handle. Without this, every request would try to
+   acquire and fail on `validateReady`, which is wasteful (though
+   not incorrect).
+
+2. `acquireRequestHandle` throws `provider_loading` if the state
+   has somehow already moved off `.ready` between the admit check
+   and the acquire — this catches the small window between the two
+   actor calls. The existing dispatcher's catch-all handles this
+   correctly.
+
+3. Once `acquireRequestHandle` returns the handle, the registration
+   is LIVE. Subsequent state changes (a swap entering `.loading`)
+   CANNOT cause this request to be rejected with `provider_loading`
+   — it will either complete with the handle's captured snapshot,
+   or get `DrainCancelledError` on drain timeout.
+
+4. The `defer { Task { await modelRuntime.unregisterInFlight(...) } }`
+   pattern MUST fire on ALL exit paths (success, throw, cancellation).
+   Swift `defer` runs on scope exit, so this is automatic.
+
+#### C. Required tests
+
+Add to `ModelRuntimeSwapTests.swift`:
+
+- `testHandleAcquiredInReadyStateSurvivesSwapToLoading` — start a
+  runtime in `.ready` with warm-swap enabled and a slow stub loader.
+  Call `acquireRequestHandle` (await). Concurrently kick off
+  `beginSwap` to a new model. Wait until state transitions to
+  `.loading` (poll `currentSnapshot().state`). Now call
+  `preflight(request, with: handle)` — assert it DOES NOT throw
+  `provider_loading` (it may throw token-too-long if that's the
+  test setup, but that's a different error). Then call
+  `stream(request, with: handle, onChunk: ...)` — assert it
+  completes normally with the OLD-snapshot model content (NOT
+  rejected). Cleanup: unregister, await the swap task to
+  completion.
+
+- `testHandleAcquiredInLoadingStateFails` — start a runtime, drive
+  it into `.loading` via `beginSwap` with a slow stub loader. Call
+  `acquireRequestHandle` — assert it throws an APIError with
+  `code: "provider_loading"`. This pins the admit-time gate.
+
+- `testHandleDrainCancellationStillFiresEvenIfStateAlreadyChanged`
+  — acquire handle in `.ready`. Concurrently drive a swap that
+  transitions through `.loading` → `.draining` and hits the drain
+  timeout. The in-flight stream call (a long-running test loop)
+  MUST be cancelled with `DrainCancelledError`. This pins the
+  R2 R-3.4.2 contract still works through the handle.
+
+Add to `HTTPServerSwapTests.swift`:
+
+- `testStreamingRequestAdmittedInReadyDoesNotGetProviderLoading` —
+  the end-to-end version. Drive the streaming dispatcher with a
+  fake request and a `testCompletion` closure that sleeps for 200ms.
+  Concurrently (after the dispatcher has acquired the handle but
+  BEFORE the testCompletion sleep returns), trigger a swap. Assert
+  the streaming response writer received tokens from the testCompletion
+  (proving stream succeeded), NOT a swap_drain_timeout envelope, NOT
+  a provider_loading envelope.
+
+  The timing coordination is delicate. Use a probe / barrier pattern
+  (see existing `InFlightProbe` in `ModelRuntimeSwapTests.swift`)
+  to wait for the dispatcher to be inside `stream()` before
+  triggering the swap. If wiring the full HTTPServer is too
+  heavyweight, drive the equivalent via direct ModelRuntime calls
+  that mimic the dispatcher's flow.
+
+## L-1 byte-identical default invariant
+
+The R3 fix MUST NOT change L-1 baseline:
+- In disabled mode (no `--enable-warm-swap`), the handle is still
+  acquired and used, but the runtime never transitions out of
+  `.ready`, so the handle is effectively trivial. No observable
+  wire behavior change.
+- The streaming path's existing token-count validation behavior
+  is preserved.
+- All 155 tests from R2 must remain green.
+
+## Constraints
+
+1. **d-inference clean-room.** No file under
+   `phase3-binary/.build/checkouts/`.
+
+2. **All 155 R2 tests stay green.** Final count ≥ 159.
+
+3. **No new CLI flags, no new YAML keys, no new ENV vars.**
+
+4. **No spec edits.**
+
+5. **Compile + tests pass.** `swift build` and `swift test` exit 0.
+
+6. **MINOR arch:1.1 (captureOutput dup2) still deferred.**
+
+## Required reading (in order)
+
+1. The R3 audit findings document:
+   `/Users/augstar/macprovider-poc/.omc/artifacts/ask/codex-execute-the-audit-prompt-at-users-augstar-macprovider-poc-sp-2026-06-07T01-19-56-152Z.md`
+   (search for "## Raw output"; the single finding is below the
+   "### Code review" header)
+
+2. `/Users/augstar/macprovider-poc/specs/SPEC-011-operator-pushed-warm-swap.md`
+   - §3.2 R-3.2.2 (in-flight snapshot isolation)
+   - §3.4 R-3.4.1, R-3.4.2 (drain semantics + cancellation)
+
+3. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+   - The `ModelRuntimeServing` protocol at lines 7-10
+   - `preflight(_:)` (current shape — to be refactored)
+   - `complete(_:shouldCancel:)` (UNCHANGED)
+   - `stream(_:shouldCancel:onChunk:)` (current shape — to be
+     refactored)
+   - `registerInFlight` / `unregisterInFlight` actor methods (from R2)
+   - `DrainCancelToken` and `DrainCancelledError` (from R2)
+   - `checkDrainOrCancellation` helper (from R2)
+
+4. `/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/HTTPServer.swift`
+   - `handleStreamingChatCompletions` (around line 277)
+   - The non-streaming dispatcher (lines 196-232) — DO NOT MODIFY
+
+5. The existing test fixtures in `ModelRuntimeSwapTests.swift` —
+   reuse `makeRuntime`, `InFlightProbe`, `waitUntil`.
+
+## Done criteria
+
+You are done when:
+
+- `git diff -- specs/ phase4-coordinator/ phase5-gateway/` is clean.
+- `cd phase3-binary && swift build` exits 0.
+- `cd phase3-binary && swift test` exits 0 with ≥ 159 tests green.
+- All 155 R2-baseline tests still GREEN.
+- `acquireRequestHandle(_:)` exists as a synchronous (non-async)
+  actor method on `ModelRuntime` that returns `RequestHandle` and
+  performs the atomic capture+validate+register.
+- `preflight(_:)` and `stream(_:onChunk:)` WITHOUT handle parameters
+  no longer exist on `ModelRuntime` (the old signatures are
+  removed; the handle-based variants are the only path).
+- `HTTPServer.handleStreamingChatCompletions` calls
+  `acquireRequestHandle` BEFORE `preflight(request, with: handle)`
+  and uses the same handle for `stream(request, with: handle, ...)`.
+- The new regression test
+  `testHandleAcquiredInReadyStateSurvivesSwapToLoading` asserts
+  that a handle acquired in `.ready` produces neither
+  `provider_loading` nor `DrainCancelledError` for a request that
+  completes within the drain window AFTER a concurrent swap to
+  `.loading`.
+
+## Out of scope
+
+- `complete(_:shouldCancel:)` refactoring (not racy — single
+  actor invocation).
+- MINOR arch:1.1 (captureOutput dup2 race) — still deferred.
+- Any new CLI flags, ENV vars, YAML keys.
+- Modifying `phase4-coordinator/`.
+
+## Self-check before reporting done
+
+```bash
+cd /Users/augstar/macprovider-poc && \
+  git diff --stat -- specs/ phase4-coordinator/ phase5-gateway/ && \
+  echo "----" && \
+  (cd phase3-binary && swift build 2>&1 | tail -10) && \
+  echo "----" && \
+  (cd phase3-binary && swift test 2>&1 | grep "Executed.*tests" | tail -3) && \
+  echo "----" && \
+  grep -n "acquireRequestHandle\|RequestHandle" phase3-binary/Sources/macprovider-cli/ModelRuntime.swift | head -10 && \
+  echo "----" && \
+  grep -n "acquireRequestHandle\|with: handle" phase3-binary/Sources/macprovider-cli/HTTPServer.swift | head -10
+```
+
+Return:
+- Diff summary (files touched, +/- lines).
+- Final `swift test` summary line.
+- Any spec rule you were unable to satisfy with rationale.
+
+Do NOT commit. Do NOT push.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (out-of-band)
+
+- Expected wall-clock: 60-90 min. Scope is small (1 production file
+  refactor + 1 test file refactor + 2 new tests) but the design
+  must be precise: `acquireRequestHandle` MUST be a non-async
+  actor method to close the race; the streaming dispatcher MUST use
+  the handle through both preflight and stream.
+- Audit pass (Claude Opus) re-verifies:
+  - `acquireRequestHandle` is non-async (synchronous actor method)
+  - The handle's snapshot is used throughout preflight and stream
+    (no re-acquire)
+  - `defer { unregister }` fires on all exit paths
+  - The regression test successfully demonstrates a swap during the
+    handle's lifetime does NOT produce `provider_loading`
+- If R3 fix audit returns clean, re-dispatch the external Codex
+  audit (fourth pass) for the final merge gate.
+- After 0 CRITICAL / 0 MAJOR external audit, commit the R3 fix
+  and PR #5 is merge-ready. Release tag still gated on Phase 2
+  (SPEC-002 v1.3.5 coordinator) per Entry 58.


### PR DESCRIPTION
## Summary

Implements the full **SPEC-001 v1.3 binary surface** in `phase3-binary/` across five draft-build-audit phases. Spec was LOCKED in PR #4 (commit b4d87b5). Each phase is a separate commit on this branch; the final squash-merge collapses them into one main commit.

### Phase tracker — all locked

| Phase | Scope | Status | Commit | Tests |
|---|---|---|---|---|
| **1A** | SPEC-010 catalog surface (`--supported-models`, `--publish-supported-models`, `SupportedModels` library, v2 `auth_request` field plumbing) | LOCKED (R1 1 MAJOR M.1 -> R2 -> 0/0/0) | 6744d7c | 54 |
| **1B** | Warm-swap opt-in gate, `RuntimeStateMachine.swift`, `ModelRuntime` actor refactor (immutable -> mutable currentContainer), HTTP 503 inference rejection | LOCKED (R1 0/0/0) | 5c03e88 | 73 |
| **1C** | `ControlSocket.swift` (NDJSON on `$TMPDIR/macprovider-cli/ctl.sock`, parent 0700 / socket 0600), `models list / switch / status` subcommand with R-3.1.5.x detection precedence | LOCKED (R1 0/0/0) | 9a4a6c5 | 97 |
| **1D** | Heartbeat extension (opt-in `model_hash` raw lowercase hex + `loading: bool`), `hello.model_hash` source-of-truth rule on WS reconnect, immediate-heartbeat-on-swap-completion task | LOCKED (R1 0/0/0) | 3c1da34 | 105 |
| **1E** | Cooldown soft guard (`SwitchStateStore`, atomic `last-switch.ts` read/write), `--force` bypass behavior (cooldown only, NOT exits 2/3/4/5), end-to-end AC matrix pinning AC-N.0 through AC-N.11 | LOCKED (R1 0/0/0) | 5d013f5 | **131** |

**131 tests green. 1A -> 1E green on first or second audit round each.**

### Workflow per phase

Mirrors the SPEC-010/011 audit discipline at the implementation layer. For each phase:

1. Claude Opus drafted `specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_<N>_PROMPT.md`
2. Codex GPT-5 ran the prompt via `omc ask codex` and wrote Swift code
3. Claude Opus audited the working-tree diff against the binding SPEC rules
4. If findings emerged (only happened on 1A R1 -- M.1): drafted R2 prompt, Codex re-ran, re-audit, loop until 0/0/0
5. Committed phase commit on this branch
6. Moved to the next phase, citing the actual API signatures the prior phase landed

### L-1 byte-identical default

Across all five phases the invariant holds: a v1.3 binary invoked with **neither** `--supported-models` **nor** `--enable-warm-swap` exhibits byte-identical on-the-wire behavior to a SPEC-001 v1.2.4 binary. Each phase pins this invariant from its own angle:

- **1A** `testHelloMessageUnchangedByPhase1A` (no SPEC-010 fields leak into legacy hello)
- **1B** `testBootPathDoesNotPassThroughLoading` plus 1A's 54 tests untouched
- **1C** disabled-mode `serve` does NOT create any socket file (`ControlSocketServer` only instantiated when `resolved.enableWarmSwap == true`)
- **1D** `testHeartbeatDisabledModeOmitsBothFields` plus `testHelloDisabledModeReadsFromProviderStatus`
- **1E** `testAC_N_0_L1ByteIdenticalDefault_WireSurface` plus `testAC_N_11_LegacyHelloByteIdenticalToV124`

### Full file inventory

| Category | Files |
|---|---|
| **New Swift (binary)** | `phase3-binary/Sources/MacProviderCore/SupportedModels.swift` (1A), `phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift` (1B), `phase3-binary/Sources/macprovider-cli/ControlSocket.swift` (1C), `phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift` (1C), `phase3-binary/Sources/macprovider-cli/SwitchStateStore.swift` (1E) |
| **Modified Swift (binary)** | `phase3-binary/Sources/MacProviderCore/Config.swift` (1A/1B/1C), `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift` (1A/1B/1C), `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift` (1A/1D), `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift` (1B), `phase3-binary/Sources/macprovider-cli/HTTPServer.swift` (1B) |
| **New tests** | `SupportedModelsTests.swift` (1A), `RuntimeStateMachineTests.swift` / `ModelRuntimeSwapTests.swift` / `HTTPServerSwapTests.swift` (1B), `ControlSocketTests.swift` / `ModelsSubcommandTests.swift` (1C), `SwitchStateStoreTests.swift` / `EndToEndAcceptanceTests.swift` (1E) |
| **Modified tests** | `CoordinatorClientTests.swift` (1A/1D) |
| **Audit trail** | `specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_1A_PROMPT.md`, `_1A_R2_PROMPT.md`, `_1B_PROMPT.md`, `_1C_PROMPT.md`, `_1D_PROMPT.md`, `_1E_PROMPT.md` (under `specs/` -- historical artifacts, not normative spec edits) |

### Out of scope for this PR

- `phase4-coordinator/` SPEC-002 v1.3.5 implementation -- separate Phase 2 PR
- `phase5-gateway/` -- untouched
- SPEC-012 (deferred per Entry 54/55 followups, blocked on SPEC-008 v0.4)
- `beta/DECISION_CRITERIA.md` Entry 58 summarizing implementation lessons -- drafted in a follow-up

## Test plan

- [ ] Reviewer confirms `cd phase3-binary && swift build && swift test` exits 0 with **131/131 green**
- [ ] Reviewer confirms `git diff main -- phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift` shows `helloMessage()` body unchanged for the v1.2.4 disabled-mode path (AC-N.11)
- [ ] Reviewer confirms `grep -rn "XDG_RUNTIME_DIR" phase3-binary/Sources/` returns zero matches (SPEC-011 R-3.1.5 macOS-native enforcement)
- [ ] Reviewer reads each phase's `specs/BUILD_SPEC_001_v1_3_IMPL_PHASE_<N>_*_PROMPT.md` audit history (R1 verdicts, R2 fix for 1A's M.1) and confirms the binding spec rules cited each landed cleanly
- [ ] Reviewer spot-checks `EndToEndAcceptanceTests.swift` AC-N.0 through AC-N.11 against SPEC-001 v1.3 section 9 AC numbering
- [ ] Reviewer confirms `--force` bypasses ONLY the cooldown gate (not exits 2/3/4/5) via `testForceDoesNotBypassExitCodes2_3_4_5`
