### PR TITLE
fix(console): per-model availability badges + Send preflight

### DIFF
--- a/frontdoor/console/index.html
+++ b/frontdoor/console/index.html
@@ -245,6 +245,8 @@ svg{display:block;flex-shrink:0}
 .model-option-name{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:var(--text)}
 .model-option-status{font-size:11px;padding:1px 6px;border-radius:3px}
 .model-option-status.avail{background:rgba(34,197,94,.12);color:var(--ok)}
+.model-option-status.warn{background:rgba(245,158,11,.12);color:var(--warn)}
+.model-option-status.offline{background:rgba(148,163,184,.1);color:var(--muted)}
 .model-option-status.unavail{background:rgba(239,68,68,.1);color:var(--bad)}
 .model-sleep-note{padding:8px 12px 10px;font-size:11px;color:var(--hint);border-top:1px solid var(--border)}
 .input-right{display:flex;align-items:center;gap:8px}
@@ -487,6 +489,7 @@ let demoToken = null
 let mintingPromise = null
 let currentView = 'chat'
 let usage = {}
+let availabilityInputNote = ''
 
 // ── localStorage ─────────────────────────────────────
 function load() {
@@ -726,6 +729,31 @@ function renderModelChip() {
   label.textContent = selectedModel ? shortModel(selectedModel) : 'no model'
 }
 
+function modelAvailability(model) {
+  if (!poolStatus) return { available: true, label: 'ready', className: 'avail', note: '' }
+
+  const entry = Array.isArray(poolStatus.models)
+    ? poolStatus.models.find(m => (typeof m === 'string' ? m : m && m.id) === model)
+    : null
+  if (typeof entry === 'string') return { available: true, label: 'ready', className: 'avail', note: '' }
+  if (!entry) {
+    return { available: false, label: 'offline', className: 'offline', note: shortModel(model) + ' is offline — pick another model.' }
+  }
+  if (entry.available === true) return { available: true, label: 'ready', className: 'avail', note: '' }
+  if (entry.availability === 'no_awake_provider' && Number(entry.provider_count) > 0) {
+    return { available: false, label: 'warming', className: 'warn', note: shortModel(model) + ' is warming up — try again in ~30s, or pick another model.' }
+  }
+  if (entry.availability === 'no_free_slots') {
+    return { available: false, label: 'busy', className: 'warn', note: shortModel(model) + ' is busy — try again shortly, or pick another model.' }
+  }
+  return { available: false, label: 'offline', className: 'offline', note: shortModel(model) + ' is offline — pick another model.' }
+}
+
+function selectedModelAvailability() {
+  const model = selectedModel || (models[0]) || 'mlx-community/Llama-3.2-3B-Instruct-4bit'
+  return { model, status: modelAvailability(model) }
+}
+
 function renderModelMenu() {
   const menu = document.getElementById('modelMenu')
   menu.replaceChildren()
@@ -751,25 +779,20 @@ function renderModelMenu() {
     name.textContent = shortModel(m)
     name.title = m
     const status = document.createElement('span')
-    status.className = 'model-option-status avail'
-    status.textContent = 'ready'
+    const availability = modelAvailability(m)
+    status.className = 'model-option-status ' + availability.className
+    status.textContent = availability.label
     item.appendChild(name)
     item.appendChild(status)
     item.addEventListener('click', () => {
       selectedModel = m
       save()
       renderModelChip()
+      updateSendBtn()
       closeModelMenu()
     })
     menu.appendChild(item)
   })
-
-  if (poolStatus && poolStatus.status === 'idle') {
-    const note = document.createElement('div')
-    note.className = 'model-sleep-note'
-    note.textContent = 'Provider warming up — ready shortly.'
-    menu.appendChild(note)
-  }
 }
 
 function toggleModelMenu() {
@@ -805,6 +828,8 @@ async function fetchStatus() {
       save()
     }
     renderModelChip()
+    if (!document.getElementById('modelMenu').classList.contains('hidden')) renderModelMenu()
+    updateSendBtn()
   } catch(e) {
     const dot = document.getElementById('sbPoolDot')
     dot.className = 'pool-dot bad'
@@ -838,6 +863,14 @@ async function send() {
   if (!currentId) newChat()
   if (!currentId) return
 
+  const { model, status } = selectedModelAvailability()
+  if (!status.available) {
+    appendMessage({ role: 'assistant', content: status.note, model, ts: new Date().toISOString() })
+    setInputNote(status.note)
+    updateSendBtn()
+    return
+  }
+
   promptEl.value = ''
   promptEl.style.height = ''
   updateSendBtn()
@@ -845,7 +878,6 @@ async function send() {
 
   appendMessage({ role: 'user', content, ts: new Date().toISOString() })
 
-  const model = selectedModel || (models[0]) || 'mlx-community/Llama-3.2-3B-Instruct-4bit'
   const msgId = uid()
   const asstMsg = { id: msgId, role: 'assistant', content: '', model, tokens: 0, latencyMs: 0, ts: new Date().toISOString() }
   appendMessage(asstMsg)
@@ -974,6 +1006,7 @@ function buildMessages() {
 function updateSendBtn() {
   const btn = document.getElementById('sendBtn')
   const val = document.getElementById('prompt').value.trim()
+  const { status } = selectedModelAvailability()
   if (streaming) {
     btn.textContent = 'Stop'
     btn.classList.add('stop')
@@ -981,11 +1014,20 @@ function updateSendBtn() {
   } else {
     btn.textContent = 'Send'
     btn.classList.remove('stop')
-    btn.disabled = !val
+    btn.disabled = !val || !status.available
+    const noteEl = document.getElementById('inputNote')
+    if (!status.available) {
+      availabilityInputNote = status.note
+      noteEl.textContent = status.note
+    } else if (availabilityInputNote && noteEl.textContent === availabilityInputNote) {
+      availabilityInputNote = ''
+      noteEl.textContent = ''
+    }
   }
 }
 
 function setInputNote(msg) {
+  availabilityInputNote = ''
   document.getElementById('inputNote').textContent = msg
 }
 


### PR DESCRIPTION
## Summary
- Model menu now renders a per-model pill (`ready`/`warming`/`busy`/`offline`) derived from `/v1/status` instead of hardcoding "ready" on every model — the gateway already publishes per-model `available`/`availability` (`available` | `no_awake_provider` | `no_free_slots`), the console just was not using it.
- `send()` preflights the selected model and drops an inline assistant notice ("Qwen2.5-Coder-7B is warming up — try again in ~30s, or pick another model") instead of letting the request 503 with "No provider available".
- `updateSendBtn()` disables Send and surfaces the reason in the input-dock note while the selected model is unavailable.
- Permissive when `poolStatus` is null (initial load) — assumes available so the UI is not locked out before the first `/v1/status` returns.

## Why
Reproduced on console.streamvc.live: model menu showed Qwen2.5-Coder-7B with a green "ready" pill, typing a prompt and clicking Send returned "No provider available". The provider for that model was registered but not in `ready` state — `ready_provider_count = 0`. Picker lied; coordinator told the truth.

## Test plan
- [ ] Load console, model menu shows correct pill per model when only some providers are awake
- [ ] Pick a `warming` / `busy` / `offline` model → Send is disabled, dock note shows reason
- [ ] Pick a `ready` model → Send works as before
- [ ] Initial load (before first `/v1/status` round-trip) → Send not blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code) (codex via `omc ask`)
