### PR TITLE
audit+ops: land 2026-06-10 audit corpus + OPS_HEALTHCHECK_SETUP (QW-3)

### DIFF
--- a/audits/2026-06-10/INDEX.md
+++ b/audits/2026-06-10/INDEX.md
@@ -1,0 +1,8 @@
+# Audit 2026-06-10 — Full-repository principal-level audit
+
+- **[REPO_AUDIT.md](REPO_AUDIT.md)** — the deliverable: executive summary (grade B−), repo map, 57 verified findings across 8 dimensions (0 Critical / 7 High / 27+1 Medium / 21 Low), improvement strategy (5 themes), milestone task plan with quick wins, 7 open questions.
+- **[findings-raw.json](findings-raw.json)** — structured output of the multi-agent workflow: discovery maps, per-dimension health summaries and strengths, every finding with its adversarial-verifier verdict, completeness-critic report.
+
+Method: 5 discovery readers → 8 dimension auditors → one adversarial verifier per finding (all 55 confirmed, 9 severity adjustments) → completeness critic (added 2 cross-component findings, including the top finding: provider identity unauthenticated end-to-end).
+
+Headline items: XSEC-1 provider-identity gap (High), no test CI (High), `handleChatCompletions` god-function with two confirmed live divergences (High), alerting single-channel-on-watched-host (High), README signed-receipt claim unimplemented (High), coordinator `/ws/provider` nginx rate-limit bypass (High), no current ops runbook (High).

--- a/audits/2026-06-10/OPS_HEALTHCHECK_SETUP.md
+++ b/audits/2026-06-10/OPS_HEALTHCHECK_SETUP.md
@@ -1,0 +1,106 @@
+# External Healthcheck Setup — coordinator + gateway
+
+Closes **QW-3 / M0-4** from `audits/2026-06-10/REPO_AUDIT.md`.
+
+**Why this matters.** Today the only alerting on Pearl is one Gmail channel
+inside `macprovider-monitor.py` running *on* the VPS it watches. If Pearl,
+nginx, or the monitor itself dies, no one knows until a user complains
+(audit finding **DEVE-2**). An external healthchecker on free tier fixes
+this in 15 minutes.
+
+This document is a checklist for the operator. Claude cannot register
+external accounts; everything below is a human action.
+
+---
+
+## What we monitor
+
+| Endpoint | URL | What it proves |
+|---|---|---|
+| Coordinator | `https://coordinator.streamvc.live/healthz` | Pearl up + nginx up + coordinator process up + can serve a request |
+| Gateway     | `https://api.streamvc.live/healthz`         | Pearl up + nginx up + gateway process up + can serve a request |
+
+Both must be up to serve any buyer traffic. If only the gateway is up, every
+inference 502s downstream; if only the coordinator is up, no buyer can reach
+it. Two distinct checks let the alert text tell you *which* component fell over.
+
+## Provider choice — UptimeRobot
+
+**Recommendation: UptimeRobot, free tier.**
+
+- 50 monitors free; we use 2.
+- 5-minute minimum interval on the free tier (matches our needs).
+- Both email and mobile-app push notifications, free.
+- Status pages free if you ever want a public one.
+- Has been stable on free-tier business for ~10 years; no recent re-pricing
+  surprises. Lower switching cost than healthchecks.io for two simple URL
+  pings (which is what we have — we don't need cron-style "expect a ping"
+  semantics; we're checking that *we* respond to a poll).
+- healthchecks.io is also fine — pick it instead if you already have an
+  account there. The interval and notification config below translates 1:1.
+
+## Configuration
+
+In UptimeRobot dashboard, **Add New Monitor** for each endpoint:
+
+| Field | Value |
+|---|---|
+| Monitor Type | `HTTP(s)` |
+| Friendly Name | `MacProvider coordinator` / `MacProvider gateway` |
+| URL (or IP) | (see table above) |
+| Monitoring Interval | **5 minutes** |
+| Monitor Timeout | **30 seconds** *(UptimeRobot caps at 30s on free; close enough to 1 min for the SLO we care about. If you want the spec'd "1-minute timeout" exactly, use a paid plan or healthchecks.io free)* |
+| HTTP Method | `GET` |
+| Expected Status | `200` |
+
+**Alert Contacts** (configure both):
+
+1. **Email** — your primary inbox (the same one that already gets
+   `macprovider-monitor.py` alerts; receiving on two channels for the same
+   incident is intentional belt-and-suspenders).
+2. **Push** — install the UptimeRobot mobile app, enable push notifications.
+   Push survives email outages and is meaningfully faster on incidents that
+   happen overnight.
+
+Set alert thresholds:
+
+- **Down threshold:** 1 failure (don't wait for "x out of y" — at our
+  traffic level a single failed probe is signal worth waking up to).
+- **Up notification:** enabled (so you know when the system self-recovered
+  vs needs intervention).
+
+## Verification (do this once, end-to-end)
+
+In a maintenance window — pick a quiet slot, post the window in whatever
+channel the team uses, then:
+
+1. SSH to Pearl: `ssh pearl`
+2. Stop nginx: `sudo systemctl stop nginx`
+3. Wait for UptimeRobot to detect — within ~5 min for both monitors.
+4. Confirm: an email arrives in your inbox; the push notification fires on
+   your phone; the UptimeRobot dashboard shows both monitors red.
+5. Restart nginx: `sudo systemctl start nginx`
+6. Confirm: both URLs return 200 within ~30s; UptimeRobot sends the "up"
+   notification within ~5 min; dashboard is green.
+
+If any step fails, the most common cause is alert contacts not actually
+saved against the monitor (UptimeRobot requires explicit per-monitor
+assignment — adding a contact globally is not enough).
+
+## Out of scope for this task
+
+- The monitor delivery fix inside `macprovider-monitor.py:159-195` (the
+  "save_state regardless of delivery" bug) — that is the in-repo half of
+  M0-4 and ships separately.
+- A public status page — defer to after M2-8 (OPS.md).
+- Synthetic-traffic alerting (the `beta/` harness already runs synthetic
+  inference; alerting on its failures is a separate larger task).
+
+## After setup
+
+Once both monitors are green and the verification round-trip worked:
+
+- Save the UptimeRobot account credentials in the team password manager
+  under "MacProvider ops".
+- Add a line to `beta/DECISION_CRITERIA.md` noting the external check is
+  live and which provider (so the next operator doesn't re-debate it).

--- a/audits/2026-06-10/REPO_AUDIT.md
+++ b/audits/2026-06-10/REPO_AUDIT.md
@@ -1,0 +1,298 @@
+# MacProvider Repository Audit — 2026-06-10
+
+**Method.** Four-phase multi-agent audit: 5 discovery readers mapped the subsystems; 8 dimension auditors (architecture, code quality, security, testing, performance, dependencies, devex/ops, docs) produced findings with file:line citations; every finding was re-read and adversarially verified by an independent verifier (citations re-checked against the actual files, severities recalibrated); a completeness critic then swept for cross-cutting gaps. 69 agents, ~1,060 tool calls. 55/55 findings survived verification (9 with severity adjustments); the critic added 2 cross-component findings the per-dimension auditors missed. Raw structured findings: `findings-raw.json` in this directory.
+
+**Scope note.** Depth went to the core: coordinator (buyer path, ws, pool, billing), gateway (router, storage, auth), Swift binary (coordinator client, relay, self-update), deploy/ops scripts, and docs. Lighter review: explorer static JS internals, `tools/mockprovider`, `cmd/tier2-mda-artifact`, the *content* of the 176-file spec corpus (structure and version headers were checked; prose was not re-audited), and the beta harness internals. The critic spot-checked SelfUpdate, ControlSocket, install.sh, tier-2 attestation, CORS, demo/API-key crypto, the billing formula, and the earnings endpoint and found them sound.
+
+---
+
+## 1. Executive Summary
+
+**Overall health: B−.** The engineering inside the services is well above PoC norm — integer-only overflow-checked billing math, constant-time auth comparisons, hashed credentials, parameterized SQL, signature-verified self-update, deep behavior-oriented test suites — but the *control loop around* that code is below the minimum bar for a system with live users and a live money path: nothing runs the tests automatically, production binaries are hand-built with no provenance, alerting can silently be a no-op, and the public README makes a cryptographic claim the product does not implement. Zero Critical findings; 7 distinct High findings; 27 Medium; 21 Low.
+
+**Top 3 risks:**
+1. **Provider identity is effectively unauthenticated end-to-end on the live network** (completeness-critic finding, High). The installer ships no token, the Swift binary never sends an `Authorization` header, so production must run `require_provider_tokens=false` — which also disables the pinned-provider impersonation guard. Anyone can connect claiming any `provider_id`, including a pinned one ([install.sh:464-469](../../phase3-binary/dist/install.sh), [CoordinatorClient.swift:111-137](../../phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift), [ws/server.go:602-619](../../phase4-coordinator/internal/ws/server.go), [admission.go:78-81](../../phase4-coordinator/internal/ws/admission.go)).
+2. **Zero CI on the money path** — the only workflow is the release build; billing/auth regressions can squash-merge looking green ([release.yml](../../.github/workflows/release.yml)). Compounded by hand-built unversioned production binaries and one silently-optional email alert channel co-hosted on the VPS it watches.
+3. **Public trust claims drift** — README advertises signed receipts (zero implementation anywhere) and console billing/management features that don't exist, directly contradicting the deployed `/docs` tier-1 disclosure mandate ([README.md:22,59-83](../../README.md), [docs.md:119-124](../../phase5-gateway/internal/router/templates/docs.md)).
+
+**Top 3 opportunities:** a ~20-line CI workflow + one test fix makes the entire 17k-line test corpus a real gate (a day); the provider-token machinery already exists (store, hashing, CLI, ws validation) and only needs wiring through installer + binary; a one-day docs-truth sweep aligns every public claim with the deployed disclosure language the team already wrote.
+
+---
+
+## 2. Repo Map
+
+**Purpose.** MacProvider turns Apple Silicon Macs into remote-addressable MLX inference endpoints: OpenAI-compatible API, provider pool with routing/failover, per-request credit ledger and payouts. Two-sided users: providers (Mac owners, curl-installed binary, outbound-WS only) and buyers (drop-in OpenAI client). ~6-week-old 2-person spec-driven PoC now in **live public beta**: coordinator + gateway co-hosted on one RAM-constrained VPS ("Pearl"), N=3 real providers, real (small) money.
+
+**Stack.** Go 1.26 (two independent modules, no cross-imports), Swift 6 / SwiftPM (provider CLI, MLX), SQLite via modernc.org/sqlite (CGO-free — load-bearing for laptop→linux cross-compile deploys), bash ops scripts, Python stdlib monitor/harness, nginx + systemd + Let's Encrypt on the VPS, GitHub Actions (release only).
+
+**Architecture & data flow.**
+
+```
+Provider Mac (Swift binary, MLX)            Buyer (OpenAI client)
+  │ outbound WSS (v1 hello | v2 ECDH+AEAD)    │ Bearer API key / demo token
+  ▼                                           ▼
+phase4-coordinator ◀──── proxy ───── phase5-gateway (api.streamvc.live)
+  pool registry (in-mem, 1 RWMutex)     GitHub OAuth, API keys (HMAC-SHA256)
+  routing/failover/breakers             quota reserve→settle→refund (SQLite)
+  billing ledger (SQLite, BEGIN         kill switch, capacity, /docs, /account
+    IMMEDIATE, integer credit math)
+  explorer UI, admin/ledger endpoints  console.streamvc.live (static console)
+```
+
+**Key directories.**
+
+| Path | What it is |
+|---|---|
+| `phase4-coordinator/` | The hub (~25k LOC Go): provider WS lifecycle, buyer API, money path (`internal/billing/`), pool, tier-2 trust, explorer. No README. |
+| `phase5-gateway/` | Buyer-facing gateway (~12k LOC Go, stdlib-first): identity, quotas, proxy, admin plane. Model README. |
+| `phase3-binary/` | Swift provider CLI (~11k LOC + 4.3k test LOC): ModelRuntime, CoordinatorClient, InferenceRelay, SelfUpdate, ControlSocket. |
+| `beta/` | Ops harness, cron synthetic traffic, `DECISION_CRITERIA.md` (57-entry append-only decision log). |
+| `scripts/`, `frontdoor/`, `*/dist/` | Release signing, install chain (get.streamvc.live → raw main → signed GitHub Releases), deploy scripts, nginx/systemd units, VPS monitor. |
+| `specs/` | 176 files, 12 SPEC families with version-pinned headers and audit-finding-cited changelogs — the authoritative design record. |
+| `.github/workflows/release.yml` | The only CI: tag-triggered Swift release build + sign + verify. |
+
+**Surprises from discovery** (verified): the "signed receipts" pitch has zero implementation in any service; v1-plaintext and v2-encrypted provider protocols are both live and the security posture is config-dependent (`RequireEncryptedLeg` defaults false); operator auth predicates fail *open* on empty keys (masked by config validation); the gitignored laptop `coordinator.yaml` is the de facto production source of truth; the coordinator buyer port has no buyer auth at all (by design — loopback + gateway-only, worth re-verifying on the VPS); `handleChatCompletions` is a 510-line function with three near-duplicate failover loops; gateway billing estimate when provider omits usage is `bytes/4` including JSON envelope overhead.
+
+---
+
+## 3. Audit Report
+
+Severities below are **post-verification** (verifier adjustments noted). "fact" = verifiable in code; "judgment" = design opinion. Overlapping findings from different auditors are merged.
+
+### 3.1 The ugly parts — what needs utmost priority
+
+1. **[High · fact] XSEC-1 — Provider identity unauthenticated end-to-end** (completeness critic). Installer writes config with no token field (`phase3-binary/dist/install.sh:464-469`); the binary never sets an Authorization header (`CoordinatorClient.swift:111-137`); coordinator defaults `require_provider_tokens=true` (`config.go:357-359`) and would *reject* every curl|bash provider — so the live tokenless beta necessarily runs with it false, and with it false `prepareProviderAdmission` skips the `pinned && !auth.validated` impersonation guard entirely (`ws/server.go:602-619`); `pinned` derives from the attacker-controlled hello `provider_id` and `admission.Admit` returns `TierPinned` with no credential (`admission.go:78-81`). **Consequence:** a remote attacker can be admitted as a pinned provider, receive buyer inference attributed to a trusted Mac, serve arbitrary responses under its identity, and poison its billing/fault stats. The entire `internal/auth/tokens.go` token system is dead code for real providers. This also worsens SECU-6: billing trusts token counts from providers whose identity is itself self-asserted.
+2. **[High · fact] DEVE-1 — No test/lint/vet CI.** Only `release.yml` exists (tag-triggered build+sign; even it runs no tests). 26+13 Go test files and 16 Swift test files run only when someone remembers. AGENTS.md mandates PR review for billing/auth paths but a PR has zero required checks (`release.yml:3-12`, `AGENTS.md:32-42`). In an AI-agent-authored codebase this is the single highest-leverage fix available.
+3. **[High · fact] ARCH-1/CODE-1 — `handleChatCompletions` is a 510-line god-function with three diverging copies of the failover state machine** (`buyer/server.go:840-1350`; loops at 1056-1153, 1154-1245, 1246-1349; six inline closures at 851-1045). Verifiers confirmed the drift is **already real, not theoretical**: a streaming-WS provider returning queue-full is never marked `StateBusy` (the non-streaming loop does this at :1229), and the QueueFull path at :1233 omits the `explicitRetries++` the other paths perform. This is the hottest money-path code in the system; every retry-semantics change must be hand-synced across three copies.
+4. **[High · fact] DEVE-2 — The 3am story.** Alerting is one Gmail channel that silently degrades to journald-only without creds (`macprovider-monitor.py:174-180`), permanently drops an alert if one SMTP send fails (state saved regardless of delivery, :159-171, :194-195), and runs on the same VPS it watches. No external uptime check exists anywhere. A Pearl outage is structurally invisible until a user complains.
+5. **[High · fact] DOCS-1/SECU-2 — README advertises an unimplemented cryptographic feature.** "Every response carries a signed receipt" + full v1 receipt schema (`README.md:22,57,59-83`); grep for receipt issuance across all three services: zero. The deployed buyer docs honestly disclaim it and *mandate* front-door consistency (`docs.md:119-124`) — the README violates the project's own SPEC-006 rule. Verifier kept High on the README finding (public, present-tense, false) while rating the security-dimension duplicate Low because the account-page disclosure partially self-corrects.
+6. **[High · fact, verifier upgraded from Medium] SECU-1 — Unrate-limited public `/ws/provider` on the coordinator hostname** bypasses the rate limits the api hostname applies (`nginx-coordinator.streamvc.live.conf:65-84` has none; `nginx-api.streamvc.live.conf:10-11,124-134` has both). The only backstop is a single *global* 64-slot unauthenticated-conn semaphore with no per-IP dimension (`config.go:273`, `ws/server.go:220-224,824-831`) — one host can starve all provider (re)admissions; at N=3 that is a full inference outage.
+7. **[High · judgment] DOCS-3 — No ops runbook exists for the live system.** The files *named* RUNBOOK/CONTINUE_RUNBOOK/HANDOFF are frozen Phase-1 artifacts that actively misdirect (wrong VPS IP, `mlx_lm.server` instructions, "Awaiting M4 user before going live"); real ops knowledge lives in deploy-script comments and the decision log. Incidents are routine in this beta; recovery depends on one person's memory.
+
+### 3.2 Architecture & design (6 findings; healthy boundaries, two structural risks)
+
+Health: better than the file sizes suggest. Service-level boundaries are sound (two Go modules, no cross-imports, no import cycles, composition-root DI via functional options, money math correctly isolated). The problems are intra-service.
+
+- **[High] ARCH-1** — see §3.1 item 3.
+- **[Medium · fact] ARCH-2 + CODE-2 + PERF-2 — Synchronous SQLite write under the global pool lock.** `ApplyHeartbeat` holds `Registry.mu` while invoking the swap-audit emitter (`pool/provider.go:483-484,542-554`), wired to a direct `auditStore.EmitSwap` INSERT (`main.go:94-111`) on a DB with `busy_timeout=5000`. A contention event can freeze *all* routing/liveness for up to ~5s. The contract is enforced only by a comment (:446-457). Rare today (swap-completion only), pool-wide blast radius when it hits. Also the documented single-coordinator scalability ceiling (one RWMutex over all pool state) — a known wall, acceptable to leave documented.
+- **[Medium · fact] ARCH-3 — Uncapped `*sql.DB` handles on one SQLite file while the money path takes `BEGIN IMMEDIATE`.** Three handles opened in `main.go:47-59`, none with `SetMaxOpenConns(1)`; the gateway deliberately caps at 1 (`store.go:38-39`) — the team knows the pattern; the coordinator omits it. Latent until concurrency rises: busy-timeout tail latency or `request_log_failed` 500s after inference already ran (`buyer/server.go:1286-1290`).
+- **[Medium · judgment] ARCH-4 — Gateway `router/server.go` is a 2,495-line god-file** (~10 responsibility clusters on one Server type; route table at :134-164; the self-contained disclosure-synthesis block at :831-1249 is the strongest extraction candidate). Maintainability cost, not correctness.
+- **[Low · judgment] ARCH-5 — Cross-service duplication is mostly justified domain separation**; the byte-identical SQLite DSN helper (`sqliteutil/dsn.go:8-23` vs gateway `dsn.go:8-23`) and constant-time bearer compare are conscious-debt copies to document.
+- **[Low · judgment] ARCH-6 — Billing/request-log persistence orchestration lives inline in handler closures** (`buyer/server.go:851-945`) vs the gateway's interface-clean pattern; money *math* is correctly isolated in `formula.go`.
+
+**Strengths:** explorer handlers have zero direct SQL (all behind `explorer/store.go`); acyclic dependency graph with interface wiring at the composition root; `WriteHotPath` atomic request_log+ledger tx with quarantine-don't-lose fallback; gateway's role-segregated storage interfaces.
+
+### 3.3 Code quality (6 findings; good-to-strong, disciplined money path)
+
+Health: `go vet` clean in both modules; Swift has zero empty catches and correctly-scoped `try?`; the apparent swallowed-refund errors in the gateway are deliberate reaper-reconciled design, not carelessness.
+
+- **[High] CODE-1** — merged into §3.1 item 3.
+- **[Medium] CODE-2** — merged into ARCH-2 above.
+- **[Low · judgment, verifier downgraded from Medium] CODE-3 — Buyer-facing tier-2 trust disclosure parsed from untyped `map[string]any` with silent zero-fallbacks** (`server.go:1020-1080`). Verifier found the typed `/internal/routing` metadata path dominates (:930-943) and three golden tests pin the shape; residual risk is only the Phase-1 fallback path.
+- **[Low · fact] CODE-4 — Copy-pasted HTTP helpers diverging:** `readLimitedBody` identical in both services; **three** `writeError` variants with different envelope shapes (4-field vs 3-field vs 2-field at `buyer/server.go:3111`, gateway `:2304`, `billing/endpoints.go:524`) — a real client-facing inconsistency.
+- **[Low · fact] CODE-5 — Dead code on the Swift connect path:** unreachable `wsTunneledMode` branch in `connectAndRunLegacy` (`CoordinatorClient.swift:280-291`, provably dead — caller gates on `!wsTunneledMode` at :236-239) plus a no-op `do/catch` rethrow (:254-257).
+- **[Low · fact] CODE-6 — Hand-rolled `fmt.Sscanf`/`Sprintf` JSON serializer for capacity tier** (`store.go:767,778`) where the sibling kill-switch correctly uses `encoding/json`.
+
+**Strengths:** fully-typed WS wire protocol with graceful unknown-frame handling on both Go and Swift sides; reserve→settle→refund covered on every traced branch with reaper backstop; fault injection isolated behind `//go:build testfaults`; load-bearing concurrency invariants documented in code.
+
+### 3.4 Security (6 findings + XSEC-1; strongest dimension in-code, weakest at the boundaries)
+
+Health: **no exploitable-today critical in the audited code.** Secrets clean in git (full-tree entropy scan: zero hits); API keys/tokens hashed with constant-time compares; SQL fully parameterized; OAuth CSRF/scope/redirect correct; self-update verifies signature *before* download with traversal guards; config validation fails closed on secrets. The issues are posture and trust-boundary level.
+
+- **[High] XSEC-1** — see §3.1 item 1. **[High] SECU-1** — see §3.1 item 6.
+- **[Medium · judgment] SECU-3 — Tier-2 posture defaults fully permissive** (all five enforcement flags false, `config.go:287-297`; v1 plaintext hello accepted unless `RequireEncryptedLeg`, `ws/server.go:320-323`). Actual production posture lives only in the gitignored `coordinator.yaml`; no deploy gate asserts it. (Verifier note: external transport is TLS via the tunnel — the gap is payload-level encryption + hash/attestation enforcement, not raw cleartext.)
+- **[Medium · fact] SECU-4 — One shared operator key spans three planes:** gateway admin endpoints (`server.go:2061-2067`), the coordinator operator API, and — when sticky routing is on — the hot buyer path itself (`server.go:1394-1405`). One leak compromises everything; no service-vs-human credential separation.
+- **[Low · fact] SECU-5 + TEST-5 — Auth predicates fail open on empty keys** (`ws/server.go:1717-1718`, `billing/endpoints.go:63`), masked solely by `config.Validate()` in a different file; no test locks the behavior. (Verifier: `AuthorizedBearer` is dead code; explorer is already fail-closed; SIGHUP reload cannot zero the key — risk is future entry points bypassing Validate.)
+- **[Low · judgment] SECU-6 — Provider-reported token counts trusted for billing within a cap.** Buyer over-charge is correctly impossible (`usageFromJSON` caps at `promptEstimate+max_tokens`, `server.go:2356-2369`); the coordinator additionally clamps completion to byte-estimate (`formula.go:214`); the gateway settlement path lacks that cross-check. Residual: provider revenue gaming — compounded by XSEC-1.
+
+**Strengths (preserve these):** HMAC-SHA256 key storage with show-once delivery; single-use session-bound OAuth state in `BEGIN IMMEDIATE` tx; signature→hash→traversal→self-test→atomic-replace update ordering; trusted-proxy-CIDR-gated client IP derivation; strict exact-origin CORS with credentials=false; nginx 404-ing operator surfaces on public vhosts as defense-in-depth; CI release workflow with SHA-pinned actions and key deleted after signing.
+
+### 3.5 Testing (7 findings; above-average suite, broken-by-default right now)
+
+Health: billing store tests are the standout (25 scenarios: ACID, quarantine, clamps, idempotent recovery, settlement thresholds, terminal-status immutability). WS/buyer tests exercise real WebSocket lifecycles, not mocks. Gateway integration tests cover OAuth→key→chat→settle.
+
+- **[Medium · fact, downgraded from High] TEST-1 — The gateway suite fails right now:** `TestConsoleStaticContracts` bans `innerHTML`; the arm64golf feature added four usages (`frontdoor/console/index.html:1200,1378,1413,1432`; static literals, no XSS — verified). Suite exits non-zero on every run. (Downgrade rationale: there is no CI to turn red — see DEVE-1.)
+- **[Medium · fact] TEST-3 — Wall-clock-coupled WS tests:** unconditional sleeps (`ws/server_test.go:1493,1715,1759`), package runtime ~48s vs 6-14s for all others; project memory documents prior load-dependent flakes here. (Verifier corrected the flake mechanism — server-side goroutine starvation, not the sleep itself.)
+- **[Medium · fact] TEST-4 — tier2 catalog package-global singleton** (`catalog.go:81-84`) forces `ResetForTest` everywhere, blocks `t.Parallel()`, shared across at least three test packages, and carries a SIGHUP-reload race by design.
+- **[Medium · judgment] TEST-6 — No cross-service integration test** between gateway and coordinator; the sticky-route header contract (`server.go:1401-1405` ↔ coordinator `internalBearerAuthorized`) has zero cross-boundary coverage; `beta/harness.py` bypasses the gateway entirely (verified against its configs).
+- **[Low, downgraded from Medium] TEST-2 — `TestAuthLookupP95` 1ms hard assertion** flakes under parallel load (observed 13ms failure; 222-518µs isolated). **[Low, downgraded] TEST-5** — merged into SECU-5. **[Low · fact] TEST-7 — Swift tests (4,264 LOC, incl. self-update security regression locks) never run in CI.**
+
+**Strengths:** behavior-named money tests (`TestWriteHotPath_503_NoLedgerRows`); `eventually()` helpers done right; `t.TempDir()` SQLite isolation everywhere; security-regression pinning in `SelfUpdateTests.swift`; the account-scoping regression lock `TestConversationKeyIsAccountScoped`.
+
+### 3.6 Performance & resource safety (6 findings; good shape today, growth-shaped debt)
+
+Health: body caps, bounded channels, TTL caches, fail-fast backpressure, and outbound timeouts are present essentially everywhere; coordinator retention is fail-closed with 90-day defaults. Nothing on fire at N=3. The ~25-30% coordinator overhead appears to be inherent hop/relay cost — no hidden hot-path blocking I/O found beyond the intentional durable-log-before-respond writes.
+
+- **[Medium · fact] PERF-1 — The gateway DB can never shrink:** `RAISE(ABORT)` BEFORE-DELETE triggers on all 8 event tables + `concurrency_reservations` (`migrate.go:184-251`); the reaper only flips `quota_reservations` status (`store.go:847-860`). ≥3 permanent rows per request, forever, on a disk/RAM-constrained VPS. Deliberate tamper-evidence design with **no archival story** — must be designed before tables are big. (Verifier: hot quota queries are indexed; the per-request scan concern was overstated.)
+- **[Medium] PERF-2** — merged into ARCH-2. **[Medium · fact] PERF-3 — Non-sargable unbatched retention DELETEs** (`julianday(ts_utc)` defeats the index, `requestlog/store.go:185-188`) sharing the write lock with billing's 6s hot-path budget; trivial fix (RFC3339 strings sort lexicographically).
+- **[Medium · judgment] PERF-4 — Money path and explorer analytics serialize through the gateway's single SQLite connection** (`store.go:38-39`; explorer 3s budgets, `explorer.go:17`): operator opens dashboard → buyers stall at `ReserveQuota`. Cheap fix: second read-only handle (WAL).
+- **[Medium · fact, upgraded from Low] PERF-6 — Demo traffic bypasses the concurrency limiter** (`if !authn.Demo`, `server.go:1362-1381`). Paying accounts cap at 2 concurrent; demo has no cap; 3 parallel demo requests saturate the N=3 MLX-serialized pool for up to `CoordinatorTimeout` — an accidental DoS path against paying buyers.
+- **[Low · fact] PERF-5 — `pool.Registry.seenModels` grows unbounded and is writable by provisional providers** (`provider.go:133,194,519`; never deleted) — the one unbounded in-memory structure, writable by the least-trusted parties.
+- **[Medium · fact] XPERF-2 (critic) — Provisional admission state never pruned and rewritten as one full JSON blob per provisional request** (`admission.go:99-152,209-221`; whole-state `json.Marshal` per mutation under the admission mutex). `ProvisionalRetentionDays` is configured (`config.go:281`) but **implemented nowhere** — direct evidence pruning was specified and dropped. Compounds XSEC-1 (unauthenticated callers mint provider_ids).
+
+**Strengths:** bounded relay channels with `ErrRelayBackpressure` fail-fast; 1MB/16MB caps on every read path; universal outbound timeouts; sticky map TTL+10k sweep; goroutine exit paths verified clean; purpose-built indexes matching query patterns in both stores.
+
+### 3.7 Dependencies (8 findings; excellent posture, zero process)
+
+Health: among the best dependency *postures* at this maturity — gateway has two direct deps, everything exact-pinned and lock-filed, zero vendored/CDN code, deliberate shared CGO-free SQLite driver enabling the cross-compile deploy model. The *process* is set-and-forget, and it already let a retracted driver sit in production.
+
+- **[Medium · fact, downgraded from High] DEPE-1 — Both services run modernc.org/sqlite v1.33.0, retracted by its authors ("breaks clients"), 19 minors behind** (`go.mod:12`/`:7`; verified live via `go list -m -u all`). Downgrade rationale: the retraction was *known and deliberately held* (documented in `implementation-notes.html` as OQ-1) and 320k-request stress runs showed zero driver pathology — operator-acknowledged debt, not a surprise. Still the top dependency action.
+- **[Medium · fact] DEPE-2 — No update process at all** (no dependabot/renovate; `go mod tidy` drift proven by goldmark mislabeled `// indirect` while directly imported, `pages.go:11` vs `go.mod:17`). This is the systemic cause of DEPE-1.
+- **[Medium · fact] DEPE-4 — Publicly distributed binary ships zero third-party license attribution** despite statically linking Apache-2.0 deps whose NOTICE reproduction is required (`package.sh:52-60`; verified absent in shipped v1.2.4-v1.2.6 tarballs).
+- **[Low, downgraded] DEPE-3 — swift-nio exact-pinned at 2.65.0 (~36 minors behind, security fixes upstream)** — downgraded because the NIO server binds 127.0.0.1 unconditionally (`HTTPServer.swift:36`) and the coordinator WS leg uses URLSession, not NIO. Bump on next release cycle. **[Low] DEPE-5 — yaml.v3 officially archived/unmaintained** (operator-config-only input; note and move on). **[Low] DEPE-6 — swift-log is a declared, linked, never-imported dead dependency.** **[Low] DEPE-7 — No Python manifest; cron runtime is an EOL-Python-3.9 venv** (verifier: `harness.py` imports `requests`+`yaml` too — the "stdlib-only" claim was wrong). **[Low] DEPE-8 — gobwas/ws upstream dormant since May 2024** (current version; contingency note only — and `admission.go` leaks its `StatusCode` type in a signature, so a swap is slightly more than `internal/ws`-contained).
+
+### 3.8 DevEx & operations (8 findings; great artifacts, broken control loop)
+
+Health: lopsided. What exists is unusually good (incident-encoding fail-closed deploy gates, SHA-pinned release CI with key hygiene, hardened systemd units, curated `.gitignore` with rationale). What's *missing* sits below the bar for live money: see §3.1 items 2 and 4, plus:
+
+- **[Medium · fact] DEVE-3 — Production Go binaries are hand-built with no script, no commit provenance, no rollback.** The only build documentation is a comment (`deploy-pearl-vps.sh:9`); `/healthz` reports a hardcoded `"0.1.0"` (`buyer/server.go:576`), so nobody can answer "which commit runs on Pearl?"; rollback = remembering an untracked `.bak` exists.
+- **[Medium · fact] DEVE-4 — The gateway (money service) is the only component with no scripted deploy and no config gate**, and the one cross-component safety check (C2 timer ordering — a *real past production incident*) is structurally skipped on every standard deploy because the coordinator script never passes the gateway config (`deploy-pearl-vps.sh:50`, `check-deploy-config.sh:18-19,62-74`).
+- **[Medium · fact] DEVE-5 — The production coordinator config's single source of truth is a gitignored laptop file, and deploys clobber the VPS copy unconditionally** (`coordinator.yaml.example:79-83` documents the lesson; `deploy-pearl-vps.sh:73,79` scp with no diff/backup). Project memory records a near-miss where an agent session sanitized the local file.
+- **[Medium · judgment] DEVE-6 + DOCS-8 — No Makefile/canonical dev commands; the 25k-LOC coordinator has no README at all.** Fresh agent sessions re-derive the dev loop each time; the gateway README proves the standard is achievable.
+- **[Low · fact] DEVE-7 — Coordinator secret handling is the weak half of an asymmetric pattern:** plaintext `operator_key` in YAML regex-parsed by a root-running monitor, vs the gateway's env-file indirection. **[Low · fact] DEVE-8 — 45 Phase-1 log/result artifacts git-tracked**; everything else hygiene-suspect (profraw, build-release/, .venv, dist binaries, secret configs) verified properly ignored.
+
+**Strengths:** `check-deploy-config.sh` encodes actual incidents and hard-fails; idempotent coordinator deploy with provider-connected restart refusal + FORCE_RESTART escape; release workflow SHA-pins actions, validates tag format, deletes the signing key, re-verifies post-publish; uniform systemd hardening with RAM caps sized to the host; transition-based (not poll-spam) monitor design.
+
+### 3.9 Documentation (8 findings; sharply bimodal)
+
+Health: the machine-facing layer (spec corpus version discipline, AGENTS.md, the deployed `/docs` honesty) is far above PoC norm. The human-facing summary layer has decayed: see §3.1 items 5 and 7, plus:
+
+- **[Medium · fact] DOCS-2 — README claims console management/billing features that don't exist** (three views in the actual console; zero matches for earnings/billing/manage — `README.md:31,35-40` vs `frontdoor/console/index.html:493,530,539`).
+- **[Medium · fact] DOCS-4 — `specs/README.md` indexes 3 of 12 spec families at versions ~6 revisions stale** — the only discoverability layer over the authoritative corpus is wrong, in a project whose whole methodology is version-pinned specs.
+- **[Medium · fact] DOCS-5 — Project CLAUDE.md feeds every agent session stale "locked" baselines** (binary v1.2.3 / SPEC-001 v1.2.2 / SPEC-002 v1.1.3 vs actual 1.3.0 / v1.3 / v1.3.5; `CLAUDE.md:151-153`, and AGENTS.md routes all agents to it).
+- **[Medium · judgment] DOCS-6 — Provider economics (rates, share, payout threshold, earnings endpoint, promotion criteria, reaping rules) documented on zero provider-visible surfaces** — money disputes are currently unresolvable by reference, and seller recruitment's first question has no public answer.
+- **[Low · fact] DOCS-7 — Version-drift cluster:** README says v1.2.5 while its own badge and link say v1.3.0; gateway README pins SPEC-006 v0.5 (actual v0.8.3); SPEC-002's header self-contradicts on its SPEC-001 dependency.
+
+**Strengths:** the tier-1 disclosure in `docs.md:115-126` is the gold standard the README should be held to; gateway README is a model component doc; spec headers with audit-finding-cited changelogs; `DECISION_CRITERIA.md`'s 57 dated append-only entries are genuine institutional memory.
+
+---
+
+## 4. Improvement Strategy
+
+### Theme 1 — Close the control loop around the code (CI, alerting, provenance)
+**Explains:** DEVE-1, DEVE-2, DEVE-3, DEVE-4, TEST-1, TEST-7, DEPE-2.
+**Target state / principle:** *every change to the money path passes an automated gate, and every production failure reaches a human through a channel that doesn't live on the failing host.* Concretely: PR-triggered `go vet`+`go test` for both modules as required checks; suites green; external uptime check on both `/healthz` endpoints; version-stamped builds with a scripted gateway deploy; Dependabot at monthly cadence.
+**Done when:** CI is a required check and red blocks merge; `curl healthz` failure produces a phone notification within 5 minutes from a non-Pearl service; `--version` on the VPS binaries answers "which commit"; the C2 cross-check runs on every deploy.
+
+### Theme 2 — Make trust boundaries fail closed and code-enforced, not config-dependent
+**Explains:** XSEC-1, SECU-1, SECU-3, SECU-4, SECU-5/TEST-5, PERF-6, XPERF-2.
+**Target state / principle:** *provider identity is authenticated; security posture is asserted at deploy time; empty credentials deny.* Wire the existing token machinery through installer+binary; rate-limit the coordinator WS vhost; add tier-2/auth posture assertions to the deploy gate; invert fail-open predicates; cap demo concurrency.
+**Done when:** production runs `require_provider_tokens=true` with all N=3 providers connected via tokens; both `/ws/provider` vhosts carry identical limits; a deploy with permissive tier-2 flags or empty operator key fails loudly; a test locks fail-closed behavior.
+
+### Theme 3 — Public claims must match delivered reality
+**Explains:** DOCS-1/SECU-2, DOCS-2, DOCS-3, DOCS-4, DOCS-5, DOCS-6, DOCS-7.
+**Target state / principle:** *the README is held to the same honesty standard as the deployed `/docs` disclosure (the project's own SPEC-006 mandate).* Receipts → explicit roadmap section or implemented; console claims trimmed to reality; one current OPS.md; index/CLAUDE.md versions regenerated or replaced with pointers; a short provider-economics page.
+**Done when:** every present-tense capability claim in README/console copy has a corresponding code path; RUNBOOK/HANDOFF carry superseded banners; specs index lists all 12 families at correct versions.
+
+### Theme 4 — De-risk the money-path hot spot structurally
+**Explains:** ARCH-1/CODE-1, ARCH-2/CODE-2/PERF-2, ARCH-3, ARCH-6.
+**Target state / principle:** *one failover state machine, no I/O under the global lock, serialized SQLite writers.* Fix the two confirmed loop divergences immediately; then extract a single `forwardWithFailover` skeleton behind the existing 4,400-line test suite; emit swap audits after unlock; `SetMaxOpenConns(1)`.
+**Done when:** the three loops are one; queue-full handling is identical across transports (with a regression test); no SQLite call executes under `Registry.mu`; coordinator stores are capped like the gateway's.
+
+### Theme 5 — Decide growth-shaped resource debt now, while tables are small
+**Explains:** PERF-1, PERF-3, PERF-4, PERF-5, XPERF-2, DEPE-1.
+**Target state / principle:** *every persistent store has a designed retention/archival story; nothing grows monotonically unbounded.* Archive-rotate (or aged-delete) design for the gateway DB; reservation cleanup; sargable batched prunes; admission-state pruning implementing the already-configured `ProvisionalRetentionDays`; sqlite driver bump.
+**Done when:** a written retention decision exists per table (kept-forever must be explicit); prune queries use the index; admission blob size is bounded; driver is current and suites pass.
+
+### Explicitly NOT recommended (effort/payoff judgment)
+- **Don't restructure the phase-numbered repo layout** — historical artifact, harmless, renaming would break the spec corpus's cross-references.
+- **Don't merge the two Go services or build a shared module yet** — the duplication is mostly justified domain separation; document the 3 cloned helpers as conscious debt; revisit only if a third service appears.
+- **Don't chase the ~25-30% coordinator overhead** — it's inherent hop cost; no code defect found.
+- **Don't shard/replace the single in-memory pool Registry** — known ceiling, fine at this scale; document it.
+- **Don't adopt enterprise observability (Prometheus/Grafana/etc.)** — one external pinger + the existing monitor with delivery fixed is the right size.
+- **Don't migrate off yaml.v3 or gobwas/ws now** — decision-log notes only.
+- **Don't rush receipt implementation** — it's a product decision (Open Question 1); the immediate fix is honest copy.
+
+---
+
+## 5. Task Plan
+
+### Quick wins (high impact, S effort — do immediately)
+| ID | Task | Why it's a quick win |
+|---|---|---|
+| QW-1 (=M0-1) | Add `ci.yml`: vet+test both Go modules on PR/push | ~20 lines, free runners, activates 17k LOC of existing tests |
+| QW-2 (=M0-2) | Fix `TestConsoleStaticContracts` (DOM methods for 4 arm64golf blocks) | Unbreaks the gateway suite so QW-1 is green |
+| QW-3 (=M0-4) | External healthcheck (healthchecks.io/UptimeRobot) on both `/healthz` | Free, 30 min, covers VPS/nginx/monitor death |
+| QW-4 (=M1-3) | README truth sweep (receipts→roadmap, console claims, version pins) | Pure copy edit; removes a false public cryptographic claim |
+| QW-5 (=M2-3) | `SetMaxOpenConns(1)` on coordinator store handles | 3 lines, matches gateway's proven pattern |
+| QW-6 (=M2-7) | `dependabot.yml` (gomod ×2, swift, monthly) + `go mod tidy` | 15 min; fixes the systemic cause of the retracted-driver miss |
+| QW-7 (=M3-7) | Regenerate `specs/README.md`; replace CLAUDE.md hardcoded versions with pointers | 30 min; stops feeding agents stale baselines |
+
+### Milestone 0 — Safety net (before touching anything else)
+| ID | Task | Files/areas | Acceptance criteria | Effort | Risk | Deps |
+|---|---|---|---|---|---|---|
+| M0-1 | **Test/vet CI for both Go modules** on PR + push to main; mark as required checks | `.github/workflows/ci.yml` | PR with failing billing test cannot merge; runtime <5 min | S | None | M0-2 |
+| M0-2 | **Fix the broken console contract test** — rewrite 4 innerHTML blocks via `createElement`/`textContent` (keep the blanket ban) | `frontdoor/console/index.html:1200,1378,1413,1432` | `go test ./internal/router/...` green; console renders identically | S | Low (static UI) | — |
+| M0-3 | **De-flake load-sensitive tests:** convert `TestAuthLookupP95` to a Benchmark; replace `ws` sleep-then-assert at :1493 with eventually-loop | `store_test.go:729-765`, `ws/server_test.go:1493` | `go test ./... -count=5` green under parallel load | S | None | — |
+| M0-4 | **External uptime monitoring** + monitor delivery fix: only `save_state()` after ≥1 non-journald delivery (or re-alert while condition persists); confirm Gmail app password set in prod | external service; `macprovider-monitor.py:159-195` | Kill nginx on a test window → notification arrives; SMTP failure no longer drops a transition | S | Low | — |
+| M0-5 | **Version-stamped build + rollback:** per-service build script (`-ldflags -X main.version=$(git describe --dirty)`, refuse dirty tree), deploy keeps `coordinator.prev`, `/healthz` reports real version | new `build-linux.sh` ×2; `deploy-pearl-vps.sh`; `buyer/server.go:576` | `curl healthz` on Pearl names the deployed commit; documented one-command rollback | M | Low | — |
+
+### Milestone 1 — Critical fixes (security & correctness)
+| ID | Task | Files/areas | Acceptance criteria | Effort | Risk | Deps |
+|---|---|---|---|---|---|---|
+| M1-1 | **Wire provider tokens end-to-end** (closes XSEC-1; sketch below): binary sends Bearer; installer/onboarding provisions token; migrate N=3 providers; flip `require_provider_tokens=true` in prod | `CoordinatorClient.swift`, `Config.swift`, `install.sh`, coordinator config/runbook; spec patch (SPEC-001/002/003) | Prod runs require=true; tokenless connect rejected (verified live); pinned impersonation guard active; all 3 providers connected | XL → break down | **High** (can disconnect the live pool; staged rollout required) | M0-1 |
+| M1-2 | **Fix the two confirmed failover divergences** *ahead of* the big refactor: streaming queue-full must mark `StateBusy`; QueueFull path must count `explicitRetries++` — each with a regression test | `buyer/server.go` streaming loop (~1066-1152), :1233 | New tests fail on old code, pass on new; behavior matches non-streaming loop | S | Medium (money path — PR + review per AGENTS.md) | M0-1 |
+| M1-3 | **README/console truth sweep** (DOCS-1/2/7, SECU-2): receipts → "Roadmap — not yet implemented"; trim console feature list; drop hardcoded release version; align with `docs.md` tier-1 language | `README.md`, frontdoor copy | No present-tense claim without a code path; reviewed against `docs.md:119-124` mandate | S | None | — |
+| M1-4 | **Rate-limit coordinator `/ws/provider`** identically to api vhost; make the unauthenticated-conn semaphore per-IP (or drop the coordinator-hostname WS path entirely) | `nginx-coordinator.streamvc.live.conf:65-84`; `ws/server.go:220-224,824-831` | Burst test from one IP cannot exhaust admission slots; legit provider reconnect unaffected | M | Medium (nginx prod change; test on staging window) | — |
+| M1-5 | **Fail-closed auth predicates** + regression test (SECU-5/TEST-5): empty operator key denies; delete dead `AuthorizedBearer` | `ws/server.go:1717-1718`, `billing/endpoints.go:63`, `auth/tokens.go:37-38` | Test constructing a server with empty key gets 401 on `/poolz`; prod config unchanged | S | Low | M0-1 |
+| M1-6 | **Deploy-gate hardening** (DEVE-4, SECU-3, DEVE-5): script the gateway deploy (clone coordinator script shape); make C2 cross-check mandatory (fail if gateway.yaml missing); assert tier-2/auth posture flags; remote-config diff+backup before overwrite | `phase5-gateway/dist/`, `check-deploy-config.sh`, `deploy-pearl-vps.sh` | Standard deploy runs C2; permissive-posture or diverged-config deploy fails loudly with FORCE escape | M | Low | — |
+| M1-7 | **Bump modernc.org/sqlite → current** in both modules; full suites incl. `-race` and ACID/concurrency tests; deploy via PR path | both `go.mod` | Suites green; one canary day on Pearl with no SQLITE errors in logs | M | Medium (driver under the ledger — but strong test coverage) | M0-1 |
+| M1-8 | **Cap demo concurrency** (PERF-6): small fixed cap keyed on demo identity via existing reservation machinery | `server.go:1362-1381` | 3 parallel demo requests no longer saturate the pool; paying-buyer p99 unaffected by demo bursts | S | Low | — |
+
+### Milestone 2 — High-leverage improvements
+| ID | Task | Files/areas | Acceptance criteria | Effort | Risk | Deps |
+|---|---|---|---|---|---|---|
+| M2-1 | **Extract single `forwardWithFailover`** from `handleChatCompletions` (sketch below) | `buyer/server.go:840-1350` | Three loops become one skeleton + per-transport dispatch; full suite green; zero behavior diff on logged fields | L | High (hottest money path — one transport per PR, behind M0-1 + M1-2) | M0-1, M1-2 |
+| M2-2 | **Move swap-audit emit off the pool lock** (ARCH-2/CODE-2/PERF-2): collect under lock, dispatch via buffered channel after unlock | `pool/provider.go:482-554`, `main.go:94-111` | No SQL under `Registry.mu` (assert via test hook); exactly-once gate preserved | S | Low | M0-1 |
+| M2-3 | `SetMaxOpenConns(1)` on coordinator stores (ARCH-3) | `main.go:47-59` | Concurrent-write test shows serialization, no SQLITE_BUSY | S | Low | M0-1 |
+| M2-4 | **Gateway retention/archival design** (PERF-1) + read-only second DB handle (PERF-4): decide archive-rotate vs aged-delete per table (Open Q4); delete terminal-state reservations >N days; route explorer/status reads through RO handle | `migrate.go`, `store.go`, `main.go` | Written retention decision per table; explorer query under load no longer blocks `ReserveQuota` (measured) | M | Medium (touches money tables — migration + tests) | Open Q4 |
+| M2-5 | **Implement `ProvisionalRetentionDays`** + per-record admission persistence (XPERF-2); bound `seenModels` per provider (PERF-5) | `ws/admission.go`, `admission_store.go`, `pool/provider.go` | Admission state size bounded under churn test; config knob actually consumed | M | Low | M0-1 |
+| M2-6 | **Coordinator README + root Makefile** (DEVE-6/DOCS-8): build/test/mockprovider/cross-compile/deploy-pointer; `make test|build-linux|check` | new `phase4-coordinator/README.md`, root `Makefile` | A fresh session builds+tests the coordinator from docs alone; CI uses `make test` | M | None | — |
+| M2-7 | Dependabot + tidy (DEPE-2) | `.github/dependabot.yml`, gateway `go.mod` | goldmark classified direct; monthly PRs arrive | S | None | M0-1 |
+| M2-8 | **Write OPS.md; archive Phase-1 runbooks** (DOCS-3): topology, safe restart (FORCE_RESTART semantics), settlement, monitor response, key rotation, gateway deploy; superseded banners on RUNBOOK/CONTINUE_RUNBOOK | new `OPS.md`; root runbooks | A non-author can execute a coordinator restart + rollback from OPS.md alone | M | None | M0-5, M1-6 |
+| M2-9 | **Cross-service integration test** (TEST-6): both services via httptest + mockprovider; OAuth→key→chat→settle; assert sticky-header contract + both stores' rows | new `test/integration/` | Runs in CI <2 min; fails on a sticky-header rename | M/L | Low | M0-1 |
+
+### Milestone 3 — Quality & polish
+| ID | Task | Effort | Notes |
+|---|---|---|---|
+| M3-1 | Sargable, batched retention DELETEs (PERF-3) | S | `WHERE ts_utc < ?` + LIMIT loop |
+| M3-2 | Split operator key into service-to-service vs human-admin (SECU-4); coordinator env-file secret indirection + de-root the monitor (DEVE-7) | M | Rotate independently |
+| M3-3 | THIRD-PARTY-NOTICES.txt in release tarball (DEPE-4) | S | Script over Package.resolved checkouts |
+| M3-4 | swift-nio bump + drop dead swift-log (DEPE-3/6); Swift test job in CI on macos runner (TEST-7) | M | Fold into next binary release |
+| M3-5 | `git rm` Phase-1 `logs/`+`results/` raw artifacts, keep REPORT.md in place (cross-referenced widely); delete stale profraw; `beta/requirements.txt` (DEVE-8, DEPE-7) | S | |
+| M3-6 | Provider economics & lifecycle doc on a provider-visible surface (DOCS-6) | M | Formula in plain language, share, payout threshold, earnings endpoint usage, promotion criteria, sleep/reaping behavior |
+| M3-7 | Specs index regen + CLAUDE.md/AGENTS version pointers; fix SPEC-002 depends-on self-contradiction (DOCS-4/5, DOCS-7) | S | Add "grep old version" to release checklist |
+| M3-8 | Code polish: unify 3 `writeError` envelope variants; delete dead Swift branch + no-op catch; `Sscanf`→`encoding/json`; tier2 catalog DI instead of global (CODE-4/5/6, TEST-4) | M | Each is S alone |
+| M3-9 | Gateway `server.go` file split by concern; extract disclosure synthesis (ARCH-4) | M | Pure file moves within package first |
+| M3-10 | Hoist `logRowWithBilling` into a billing-recorder type (ARCH-6) | S/M | Pairs naturally with M2-1 |
+
+### Implementation sketches — top 3 tasks
+
+**M1-1 Provider tokens end-to-end (the one XL).**
+Approach: all server-side machinery exists (`auth/tokens.go` store + hashing + constant-time compare; `coordinator-cli issue-token`; ws validation at `server.go:236-262`). The work is client-side wiring plus migration choreography.
+Steps: (1) Spec patch first per house rule (SPEC-001 token config key + auth header; SPEC-003 onboarding flow). (2) Swift: add `provider_token` to `Config.swift` (flag/env/yaml triple-exposure per house convention); set `Authorization: Bearer` on the WS request in `CoordinatorClient` (both v1 and v2 paths). (3) Installer: accept a token interactively or via env; write it into config (decide Open Q2 for strangers — operator-issued vs self-serve provisional tokens). (4) Migration: issue tokens for M1/M4/air8gb; ship binary release; update each provider's config (relaunch txt-file pattern per past practice); verify all three connected *with* tokens while `require_provider_tokens` still false. (5) Flip to true; verify a tokenless connect is rejected; confirm the pinned-impersonation guard now executes (`ws/server.go:603-619`).
+Gotchas: don't flip the flag until every provider heartbeats with a validated token or you orphan the pool (the deploy script's provider-connected restart guard will fight you — plan a window); provisional/open-onboarding tier needs a product decision on token issuance (Q2); keep the v1.2.x-binary compatibility story explicit — old binaries can't send tokens, so the flag flip is the compatibility cutoff.
+
+**M0-1/M0-2 CI + suite green.**
+Approach: one workflow, two ubuntu jobs (`cd phase4-coordinator && go vet ./... && go test ./...`; same for gateway), `timeout-minutes: 10`. Fix the console test first or CI is born red: rewrite the four arm64golf innerHTML sites with `document.createElement` + `textContent` (data already escaped via `escArm`, so it's mechanical), keeping the test's blanket ban as the simpler contract.
+Gotchas: the `ws` package costs ~48s (fine); keep `TestAuthLookupP95` out of the gate (M0-3) or it flakes on loaded runners; defer `swift test` to a separate non-required macos job (cost/latency); mark both Go jobs required in branch protection or the gate has no teeth — that's the actual deliverable.
+
+**M2-1 `forwardWithFailover` extraction.**
+Approach: strangle, don't rewrite. First land M1-2's divergence fixes with tests so the refactor target is *correct* behavior. Then: (a) extract the 5×-duplicated advance-to-next-provider tail (`selectProviderExcluding` + `routingDone` + counters + `logRoutingDecision`) into one helper — pure mechanical, zero risk; (b) define `transportResult` normalizing `wsForwardResult`/HTTP outcomes into one classification (retryable? failover? mark-busy? billable?); (c) one loop: `for { dispatch(transport); classify; record; advance }` with per-transport dispatch closures; migrate HTTP-forwarding first (simplest), non-streaming WS second, streaming last (SSE lifecycle is the tricky one — first-chunk-received commits the attempt).
+Gotchas: billing attempt numbering (`attempt_n`) and `logAttempt` ordering must stay byte-identical — the ledger and its quarantine logic key off them; the 4,400-line `server_test.go` is the safety net, so run it per-commit, one transport per PR; preserve the subtle intentional differences (per-attempt context timeout is HTTP-only) as explicit transport parameters, not lost behavior.
+
+---
+
+## 6. Open Questions (need a human decision)
+
+1. **Receipts: build or retract?** The README's signed-receipt schema is the product's headline differentiator and has zero implementation. Implementing it properly touches binary signing, gateway pass-through, and key distribution (~weeks). Until decided, M1-3 ships honest copy. Which is it, and on what timeline?
+2. **Provider token issuance model for open onboarding.** Pinned providers clearly need operator-issued tokens. For curl|bash strangers (provisional tier): operator-issued (friction, but authenticated) or self-serve provisional tokens minted at first admission (preserves open onboarding, still kills pinned impersonation)? SPEC-003's intent here needs an explicit ruling.
+3. **Target tier-2 posture for this beta.** Which of the five enforcement flags (encrypted leg, hash verification, attestation, behavioral safety, encoding validation) should production assert *now* vs at scale? M1-6's deploy gate needs the answer to know what to assert.
+4. **Gateway append-only-forever: requirement or default?** Is tamper-evidence-in-place a deliberate compliance posture (→ archive-rotate with cold storage), or is aged-out deletion of event rows acceptable (→ trigger amendment)? Determines M2-4's design.
+5. **Deprecation candidates:** `beta/web` legacy demo (currently 410-gated — delete?), the ~10 historical release tarballs in `phase3-binary/dist/`, Phase-1 `logs/`+`results/` artifacts, the root `.venv`. Any objections to removal?
+6. **Performance target.** Is the ~25-30% coordinator-path overhead acceptable as a standing property of the product, or does a buyer-facing latency SLO exist that would force optimization work the audit found no easy wins for?
+7. **Console roadmap vs copy.** DOCS-2's fix trims README claims to the three real views — unless provider management/earnings views are imminent, in which case keep the copy and build the views. Which way?
+
+---
+
+*Generated by a four-phase multi-agent audit (discovery → dimension audits → per-finding adversarial verification → completeness critic), 2026-06-10. All citations verified against working-tree state at commit `5b34f8c`.*

--- a/audits/2026-06-10/findings-raw.json
+++ b/audits/2026-06-10/findings-raw.json
@@ -5,71 +5,71 @@
    "area": "phase4-coordinator (Go 1.26 coordinator service)",
    "purpose": "The coordinator is the hub of the MacProvider network: it terminates outbound WebSocket connections from provider Macs (admission, auth, heartbeats, liveness, warm-up gating), exposes an OpenAI-compatible buyer API (/v1/chat/completions, /v1/models) that routes requests to providers either over the WS tunnel or via HTTP forwarding to pinned endpoints, and writes the money path \u2014 a SQLite credit ledger (request credits, operator credits, payout windows, reconciliation runs) computed per request attempt. It also serves an operator explorer UI, admin/ledger endpoints, and tier-2 trust features (signed model-hash catalog, encrypted leg AEAD key exchange, device attestation).",
    "entryPoints": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/cmd/coordinator/main.go \u2014 the service. Wires config -> stores -> ws.Server (provider port) + buyer.Server (buyer port); two http.Servers (main.go:138-172); signal loop with SIGHUP hot-reload of tier2/rewards config (main.go:176-208, 285-320); retention pruners for request_log and audit_log (main.go:215-273)",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/cmd/coordinator-cli/main.go \u2014 operator CLI: issue-token / revoke-token / list-tokens / revoke-and-kick against the same SQLite DB (main.go:16-38)",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/cmd/tier2-mda-artifact/main.go \u2014 offline tool to build Apple managed-device-attestation artifacts",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/tools/mockprovider/main.go \u2014 test mock provider",
+    "phase4-coordinator/cmd/coordinator/main.go \u2014 the service. Wires config -> stores -> ws.Server (provider port) + buyer.Server (buyer port); two http.Servers (main.go:138-172); signal loop with SIGHUP hot-reload of tier2/rewards config (main.go:176-208, 285-320); retention pruners for request_log and audit_log (main.go:215-273)",
+    "phase4-coordinator/cmd/coordinator-cli/main.go \u2014 operator CLI: issue-token / revoke-token / list-tokens / revoke-and-kick against the same SQLite DB (main.go:16-38)",
+    "phase4-coordinator/cmd/tier2-mda-artifact/main.go \u2014 offline tool to build Apple managed-device-attestation artifacts",
+    "phase4-coordinator/tools/mockprovider/main.go \u2014 test mock provider",
     "HTTP surfaces: provider port mux (main.go:140-152) = /ws/provider, /healthz, /poolz, /admin/* (ws/server.go:196-211), /internal/* (buyer InternalHandler), /admin/ledger/* + /providers/*/earnings (billing/endpoints.go:43-56), explorer at cfg.Explorer.BindPath; buyer port = /healthz, /v1/models, /v1/pool/check, /v1/chat/completions (buyer/server.go:350-357)"
    ],
    "keyModules": [
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/ws/server.go",
+     "path": "phase4-coordinator/internal/ws/server.go",
      "role": "Provider WS lifecycle (1747 lines). Upgrade -> unauthenticated-conn semaphore (line 220-224) -> Bearer token validation (236-262) -> v1 'hello' or v2 'auth_request' handshake (296-304). v2 adds X25519 ECDH + AEAD negotiation + attestation challenge/proof with a bounded (1024) auth-attempt retention store (356-592). prepareProviderAdmission (594-690) enforces required binary version, pinned-vs-provisional tier, endpoint_url policy. readProviderLoop dispatches heartbeat/state_update/preflight_ack/inference chunks/NAK/drain_status (933-966). monitorHeartbeat reaps providers with no inbound frame past HeartbeatMissThreshold (1449-1485), using LastActivityAt (any frame counts, the v1.1.7 liveness fix). Warm-up gate sends a tiny real inference before marking ready (1018-1101)."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go",
+     "path": "phase4-coordinator/internal/pool/provider.go",
      "role": "In-memory provider registry (single RWMutex over maps keyed by providerID and assignedID). State machine ready/busy/degraded/draining/unavailable with two deliberately asymmetric guards: coordinator-initiated (line 354-362) vs provider-reported transitions (377-385) so a breaker-held provider cannot self-launder back to routable. Breaker fault windows (304-346), heartbeat application incl. SPEC-011 model-swap detection + audit emitter invoked under the registry lock (482-561)."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/buyer/server.go",
+     "path": "phase4-coordinator/internal/buyer/server.go",
      "role": "Buyer API (3183 lines). handleChatCompletions (840-1350) is the spine: body limit -> validateChatRequest -> Idempotency-Key reservation (998-1026) -> selectProvider (scoring, model classes, sticky sessions, epsilon tiebreak, provisional tier weight) -> three forwarding paths (WS streaming, WS non-streaming, HTTP forwarding 1246-1349) with retry/failover/breaker bookkeeping. logRowWithBilling closure (851-945) writes request_log + ledger atomically per attempt."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/ws/relay.go",
+     "path": "phase4-coordinator/internal/ws/relay.go",
      "role": "providerSession: per-provider writer goroutine with bounded channel (backpressure = ErrRelayBackpressure, relay.go:125-137), active request map, optional tier2 AEAD encryption of inference frames, RelayStream (Chunks/Done/Errors) consumed by buyer.forwardWS."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/billing/",
+     "path": "phase4-coordinator/internal/billing/",
      "role": "Money path. formula.go: integer credit math, ppm/bps fixed point, RoundHalfEven banker's rounding (54-81), overflow-checked mul/add, fault flags zero credits. hotpath.go WriteHotPath: BEGIN IMMEDIATE transaction inserting request_log row + ledger_request_credits + ledger_operator_credits + identity snapshot atomically; ambiguous attempt_n rows are quarantined with zeroed credits (55-89). store.go: full ledger schema with CHECK constraints and a trigger making payout status terminal (121-126). settlement.go RunSettlement: quarantine inconsistent rows, aggregate unsettled credits per provider over min-payout threshold into ledger_payout_ready, mark settled in same tx. endpoints.go: /admin/ledger/* (operator key) and /providers/{id}/earnings (provider token + rate limit)."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/auth/tokens.go",
+     "path": "phase4-coordinator/internal/auth/tokens.go",
      "role": "Provider token store (SQLite provider_tokens): 32-byte random hex tokens stored as SHA-256 hashes, 12-char display prefix, revoke-by-prefix with ambiguity check (206-252). BearerTokenMatchesHeader does constant-time compare via sha256+hmac.Equal (41-55)."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/ws/admission.go",
+     "path": "phase4-coordinator/internal/ws/admission.go",
      "role": "Provisional-tier admission: per-hour admission rate, pool max, per-provider request quota; records persisted via AdmissionStateStore (SQLite) and reloaded on boot (38-63). Pinned providers bypass everything (78-81)."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/tier2/",
+     "path": "phase4-coordinator/internal/tier2/",
      "role": "Tier-2 trust: catalog.go loads an ed25519-signed model-hash catalog into a package-global singleton (catalog.go:81-86); pillar_b (X25519/HKDF AEAD keys), pillar_c (behavioral safety: output caps, encoding validation, response-time anomaly), pillar_d (attestation verification)."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/requestlog/store.go",
+     "path": "phase4-coordinator/internal/requestlog/store.go",
      "role": "request_log table + request_idempotency_keys (ReserveIdempotencyKey tx: replay returns prior request_id, body-hash mismatch returns ErrIdempotencyConflict, 137-178); shared *sql.DB handed to admission, billing, and explorer."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/explorer/handlers.go",
+     "path": "phase4-coordinator/internal/explorer/handlers.go",
      "role": "Operator console JSON API + embedded static UI (static.go go:embed). Operator-key auth on everything except static assets (46-73); proxies /buyers to the phase5 gateway; per-endpoint windowed queries against the shared SQLite."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/config/config.go",
+     "path": "phase4-coordinator/internal/config/config.go",
      "role": "Single YAML config (708 lines): listen/pool/routing/ws/admission/tier2/auth/storage/rewards/settlement/explorer/providers; Default() provides fallbacks that call sites re-apply defensively when fields are <=0."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/audit/store.go",
+     "path": "phase4-coordinator/internal/audit/store.go",
      "role": "audit_log SQLite store for operator_model_swap events, emitted from pool.ApplyHeartbeat via the swapEmitter wired in main.go:94-114."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/providerhttp/client.go",
+     "path": "phase4-coordinator/internal/providerhttp/client.go",
      "role": "Package-global *http.Client for provider HTTP forwarding, timeout set once via Init() at startup (main.go:38); redirects disabled."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/sqliteutil/dsn.go",
+     "path": "phase4-coordinator/internal/sqliteutil/dsn.go",
      "role": "DSN pragma helper (busy_timeout, foreign_keys, WAL, synchronous NORMAL) shared by all stores."
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/testfaults/relay.go",
+     "path": "phase4-coordinator/internal/testfaults/relay.go",
      "role": "//go:build testfaults \u2014 build-tag-gated fault injection (dead-WS-mid-inference relay, slow reader) so production binaries cannot contain the fault paths."
     }
    ],
@@ -101,62 +101,62 @@
    "area": "phase5-gateway \u2014 buyer-facing OpenAI-compatible API gateway (api.streamvc.live)",
    "purpose": "Go (stdlib-only HTTP) service that sits between buyers and the phase4 coordinator. It owns buyer identity (GitHub OAuth signup, API keys, demo tokens), token quotas/concurrency limits with reserve-settle-refund accounting in SQLite, and proxies /v1/chat/completions and /v1/models to the coordinator's buyer URL. It also serves the /account and /docs HTML pages, an operator admin plane (kill switch, capacity tiers, feedback summary, explorer), and a buyer-anonymized /v1/status aggregated from the coordinator's /poolz. Notably, despite the project's \"signed inference receipts\" pitch, there is NO receipt issuance/verification code anywhere in this module (grep for \"receipt\" across phase5-gateway/*.go returns zero hits; same for phase4-coordinator/internal and phase3-binary/Sources) \u2014 receipts are aspirational, not implemented here.",
    "entryPoints": [
-    "/Users/augstar/macprovider-poc/phase5-gateway/cmd/gateway/main.go:19 \u2014 main(): flags -config (gateway.yaml) and -check (migrate-and-exit); opens sqlite store, builds router.New(...), starts HTTP server with graceful shutdown",
-    "/Users/augstar/macprovider-poc/phase5-gateway/cmd/gateway/main.go:49,96-121 \u2014 background reservation reaper goroutine (hourly default) expiring stale quota reservations",
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/server.go:134-164 \u2014 Handler(): full route table (auth/*, /account, /docs, /v1/*, /healthz, /admin/*, optional /admin/explorer/*)",
-    "/Users/augstar/macprovider-poc/phase5-gateway/dist/ \u2014 deploy surface: gateway-linux-amd64 binary, macprovider-gateway.service systemd unit, nginx-api.streamvc.live.conf, deploy-pearl-vps.md"
+    "phase5-gateway/cmd/gateway/main.go:19 \u2014 main(): flags -config (gateway.yaml) and -check (migrate-and-exit); opens sqlite store, builds router.New(...), starts HTTP server with graceful shutdown",
+    "phase5-gateway/cmd/gateway/main.go:49,96-121 \u2014 background reservation reaper goroutine (hourly default) expiring stale quota reservations",
+    "phase5-gateway/internal/router/server.go:134-164 \u2014 Handler(): full route table (auth/*, /account, /docs, /v1/*, /healthz, /admin/*, optional /admin/explorer/*)",
+    "phase5-gateway/dist/ \u2014 deploy surface: gateway-linux-amd64 binary, macprovider-gateway.service systemd unit, nginx-api.streamvc.live.conf, deploy-pearl-vps.md"
    ],
    "keyModules": [
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/server.go",
+     "path": "phase5-gateway/internal/router/server.go",
      "role": "2495-line monolith: middleware (request-ID, panic recovery, internal-header stripping at 166-195), GitHub OAuth start/callback (197-330), signup with per-IP rate limit + capacity gate (332-371), demo sessions (373-403), API key rotate/revoke (405-451), /v1/models + tier1/tier2 trust disclosure synthesis (453-490, 887-1249), chat-completions proxy with quota reserve/settle/refund and SSE streaming (1251-1712), /v1/status poolz aggregation with anonymization (1809-1978), admin kill-switch/capacity handlers (696-815), operator bearer auth (2061-2090), client-IP trusted-proxy logic (2270-2296)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/auth/keys.go",
+     "path": "phase5-gateway/internal/auth/keys.go",
      "role": "API key lifecycle: keys are 'mp_' + base64url(32 random bytes); stored only as HMAC-SHA256 (or plain SHA256) hash + 12-char display prefix (lines 38-71); Validate looks up by hash. RandomID/StateToken helpers"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/auth/oauth.go",
+     "path": "phase5-gateway/internal/auth/oauth.go",
      "role": "GitHub OAuth code exchange (50-106): token POST then /user fetch; scope allowlist enforced (read:user, user:email only \u2014 108-119); 10-min state expiry (134-136)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/auth/demo.go",
+     "path": "phase5-gateway/internal/auth/demo.go",
      "role": "Demo tokens: HMAC-SHA256-signed JSON payload bound to client IP (IPv6 normalized to /64, lines 79-88), max 24h TTL, no DB row \u2014 stateless validation (46-71)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/types.go",
+     "path": "phase5-gateway/internal/storage/types.go",
      "role": "All storage structs: Account, APIKey, OAuthState (with single-use Action field, 50-64), quota ReservationRequest/Settlement, UsageEvent, FeedbackEvent, AuditEvent, CapacityTier, KillSwitchState, Explorer* DTOs"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/interfaces.go",
+     "path": "phase5-gateway/internal/storage/interfaces.go",
      "role": "Role-segregated store interfaces (AuthStore, UsageStore, CapacityStore, ExplorerStore...); router.Server.Store composes seven of them (server.go:62-70)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/store.go",
+     "path": "phase5-gateway/internal/storage/sqlite/store.go",
      "role": "SQLite (modernc, CGO-free) store: single connection (SetMaxOpenConns(1), line 38), WAL + busy_timeout pragmas, hand-rolled BEGIN IMMEDIATE transactions (immediateTx, 880-926) for quota reserve/settle/refund and concurrency acquire/release; atomic ConsumeOAuthState (328-356)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/migrate.go",
+     "path": "phase5-gateway/internal/storage/sqlite/migrate.go",
      "role": "Single schemaSQL string: 14 tables incl. accounts, api_keys, oauth_states, quota_reservations, concurrency_reservations, usage_events, audit_events, runtime_config; append-only enforced by RAISE(ABORT) triggers on usage/feedback/audit/api_key/demo/capacity/signup event tables (184-251)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/explorer.go",
+     "path": "phase5-gateway/internal/storage/sqlite/explorer.go",
      "role": "Read-only operator explorer queries (buyers, sessions, activity feed, health rollups) backing /admin/explorer/*"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/config/config.go",
+     "path": "phase5-gateway/internal/config/config.go",
      "role": "YAML config with hardcoded production defaults (Default() at 132-177: api.streamvc.live, coordinator on localhost 8443/8444, 100k daily tokens, 4096 max_tokens); 'env:NAME' secret indirection (195-208); strict fail-closed Validate() (210-329)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/pages.go",
+     "path": "phase5-gateway/internal/router/pages.go",
      "role": "/account (show-once API key from mp_new_api_key cookie, CSP nonce, embedded html template) and /docs (goldmark-rendered embedded markdown). tier1DisclosureText hardcodes the honest no-privacy/no-attestation claims (27-44)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/cors.go",
+     "path": "phase5-gateway/internal/router/cors.go",
      "role": "Exact-origin CORS allowlist (console.streamvc.live, streamvc.live by default), credentials=false, applied per-route via withCORS"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/explorer.go",
+     "path": "phase5-gateway/internal/router/explorer.go",
      "role": "Operator-only explorer HTTP handlers: window/cursor parsing, 3s query timeout, limit cap 200"
     }
    ],
@@ -189,60 +189,60 @@
    "area": "phase3-binary (Swift provider CLI)",
    "purpose": "phase3-binary is the Swift 6 CLI (`macprovider-cli`) that runs on provider Macs and turns them into MLX inference endpoints. It loads an MLX model, serves an OpenAI-compatible HTTP API on localhost, maintains an outbound WebSocket session to the coordinator (tier-2 encrypted by default), relays coordinator-tunneled inference requests to the MLX runtime, and handles signed self-update, operator-driven warm model swaps over a Unix control socket, and managed-device attestation. SwiftPM package with two targets: `MacProviderCore` (pure library: config, request parsing, stop-token filter, model catalog) and the `macprovider-cli` executable (Package.swift lines 41-68, platform macOS 14, StrictConcurrency enabled).",
    "entryPoints": [
-    "@main MacProviderCLI with subcommands serve (default), self-test, status, update, uninstall, models \u2014 /Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:7-16",
-    "ServeCommand.run() \u2014 the long-running provider daemon path \u2014 /Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:88-172",
-    "UpdateCommand.run() \u2192 SelfUpdate.run(checkOnly:) \u2014 /Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:228-246",
-    "models list/switch/status subcommands talking to the control socket \u2014 /Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:5-55",
-    "Acceptance/ops harness: /Users/augstar/macprovider-poc/phase3-binary/scripts/ (run-acceptance.sh, test-ac11..15.sh, soak-test.sh, harness-*.sh) and mock coordinator at /Users/augstar/macprovider-poc/phase3-binary/tools/mock-coordinator/mock_coordinator.py",
-    "Install/relaunch shell surface for partner Macs: /Users/augstar/macprovider-poc/phase3-binary/dist/install.sh, relaunch-m1.sh, relaunch-m4.sh, launchd-plist-template.plist"
+    "@main MacProviderCLI with subcommands serve (default), self-test, status, update, uninstall, models \u2014 phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:7-16",
+    "ServeCommand.run() \u2014 the long-running provider daemon path \u2014 phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:88-172",
+    "UpdateCommand.run() \u2192 SelfUpdate.run(checkOnly:) \u2014 phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:228-246",
+    "models list/switch/status subcommands talking to the control socket \u2014 phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:5-55",
+    "Acceptance/ops harness: phase3-binary/scripts/ (run-acceptance.sh, test-ac11..15.sh, soak-test.sh, harness-*.sh) and mock coordinator at phase3-binary/tools/mock-coordinator/mock_coordinator.py",
+    "Install/relaunch shell surface for partner Macs: phase3-binary/dist/install.sh, relaunch-m1.sh, relaunch-m4.sh, launchd-plist-template.plist"
    ],
    "keyModules": [
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift",
+     "path": "phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift",
      "role": "CLI entry; ServeCommand wires Config \u2192 ModelRuntime \u2192 ProviderStatus \u2192 CoordinatorClient \u2192 optional ControlSocketServer \u2192 HTTPServer; installs SIGTERM/SIGINT drain handlers (lines 248-265)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/MacProviderCore/Config.swift",
+     "path": "phase3-binary/Sources/MacProviderCore/Config.swift",
      "role": "AppConfig + ConfigLoader; precedence defaults < YAML (~/.config/macprovider/config.yaml) < MACPROVIDER_* env < CLI flags (lines 139-161); typed assign() validators"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift",
+     "path": "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift",
      "role": "Actor owning the coordinator WS session: reconnect loop w/ 1\u219260s exponential backoff (189-221), tier-2 auth handshake (251-276), heartbeat task w/ WS ping (505-524), preflight acks (536-578), drain flows (580-625), caffeinate sleep assertion (33-65); holds binaryVersion = \"1.3.0\" (line 70)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/Tier2ProviderSession.swift",
+     "path": "phase3-binary/Sources/macprovider-cli/Tier2ProviderSession.swift",
      "role": "Tier-2 crypto: X25519 ECDH + HKDF-SHA256 directional keys, transcript-bound keyID (58-96); AES-256-GCM seal/open with strict per-direction seq counters, deterministic nonce = 4-byte base + 8-byte BE seq, AAD binding type/direction/request_id/stream/provider_id/assigned_id/seq (104-189, 259-304, 363-385)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift",
+     "path": "phase3-binary/Sources/macprovider-cli/InferenceRelay.swift",
      "role": "Actor relaying coordinator inference_request frames to ModelRuntime; enforces encrypted frames in tier-2 (50-60), duplicate-id NAK, queue-full and body-size end frames (68-93); streaming via BlockingChunkBuffer backpressure (capacity 256 / resume 128, lines 303, 616-681); emits OpenAI SSE chunks wrapped in WS frames"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift",
+     "path": "phase3-binary/Sources/macprovider-cli/ModelRuntime.swift",
      "role": "Actor over MLX (LLMModelFactory/ModelContainer): synchronous boot load (99-118), AsyncSemaphore(1) inference gate (56), complete/stream with stop-token + request-stop filtering and streaming-safe holdback (659-714), prompt-length 413 enforcement (534-544), warm-swap state machine ready\u2192loading\u2192draining\u2192ready (167-262), safetensors manifest SHA-256 model hash (609-640)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/HTTPServer.swift",
+     "path": "phase3-binary/Sources/macprovider-cli/HTTPServer.swift",
      "role": "SwiftNIO HTTP/1.1 server bound to 127.0.0.1 only (line 36); routes GET /v1/models, /v1/health, /v1/status, POST /v1/chat/completions (116-135); SSE streaming; every response sends connection: close (509, 585)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift",
+     "path": "phase3-binary/Sources/macprovider-cli/SelfUpdate.swift",
      "role": "Signed self-update: pinned repo api.github.com/repos/Augustas11/macprovider (line 6), embedded P-256 key verifies checksums.txt.sig before tarball download (7-12, 73-82, 258-270), HTTPS host allowlists (232-245), tar path-traversal check (247-256), runs new binary self-test (90), atomic rename + launchd restart (166-219)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ControlSocket.swift",
+     "path": "phase3-binary/Sources/macprovider-cli/ControlSocket.swift",
      "role": "Warm-swap control plane: Unix socket (default $TMPDIR/macprovider-cli/ctl.sock, 178-186) created 0600 in 0700 dir (254-281), refuses stale socket; JSON-lines codec, 64KB frame cap (544); frames switch_request/status_request/switch_ack/switch_progress/status_response (19-25); switch validated against supported_models (439-455)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/Tier2Attestation.swift",
+     "path": "phase3-binary/Sources/macprovider-cli/Tier2Attestation.swift",
      "role": "ManagedDeviceAttestationGenerator: reads MDA ACME artifact JSON from configured path, builds attestation token envelope with hardware/RAM/model claims and optional ES256 binding signature with Go-compatible JSON escaping (187-308); returns nil with WARN if artifact absent \u2014 attestation is optional"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ProviderStatus.swift",
+     "path": "phase3-binary/Sources/macprovider-cli/ProviderStatus.swift",
      "role": "Actor tracking health state, in-flight counts, per-heartbeat metrics window; ProviderCapacity maps RAM tiers to context caps 20k/50k/120k/200k (24-37); waitUntilDrained polling (213-222)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/MacProviderCore/SupportedModels.swift",
+     "path": "phase3-binary/Sources/MacProviderCore/SupportedModels.swift",
      "role": "Catalog validation: CSV parse, 256-byte entry / 64-entry caps, case-insensitive model-in-catalog check (38-73)"
     }
    ],
@@ -265,7 +265,7 @@
     "fact: heartbeat interval is coordinator-controlled with a floor of 1s (CoordinatorClient.swift:484: max(interval, 1)) \u2014 a misbehaving coordinator could request 1Hz heartbeats",
     "fact: SelfUpdate verifies checksums.txt + its ECDSA signature BEFORE downloading the tarball, then executes the downloaded binary's `self-test` before atomic replace (SelfUpdate.swift:73-91) \u2014 strong ordering, but sha256(file:) loads the whole tarball into memory (SelfUpdate.swift:309-313) while model hashing streams in 1MB chunks (ModelRuntime.swift:642-653)",
     "judgment: drainAndExit calls Darwin.exit(0) from inside the actor after the drain sequence (CoordinatorClient.swift:580-594), so HTTPServer/NIO shutdown is skipped on SIGTERM \u2014 acceptable for a launchd-managed daemon but worth knowing",
-    "fact: dist/ ships ~10 historical release tarballs (v1.1.2 through v1.2.6) checked into the repo alongside install/relaunch scripts (ls of /Users/augstar/macprovider-poc/phase3-binary/dist)",
+    "fact: dist/ ships ~10 historical release tarballs (v1.1.2 through v1.2.6) checked into the repo alongside install/relaunch scripts (ls of phase3-binary/dist)",
     "fact: Tier2 attestation degrades silently to nil (token omitted) with only a WARN print when the MDA artifact path is unset or invalid (Tier2Attestation.swift:51-84) \u2014 tier assignment is thus entirely coordinator-side policy"
    ]
   },
@@ -274,68 +274,68 @@
    "area": "Operational surface: beta/ harness + cron, scripts/ (release signing + tier-2 ops), frontdoor/ (console + install front door), .github/workflows/release.yml, phase4-coordinator/dist+scripts, phase5-gateway/dist",
    "purpose": "This is the deploy/upgrade/monitoring layer of MacProvider. Provider Macs get the Swift binary via a curl-pipe-bash installer chain (get.streamvc.live -> raw GitHub main -> signed GitHub Releases built by the one CI workflow). The coordinator and console are pushed from the operator's laptop to a single root-SSH VPS (159.223.165.194 \"Pearl\") by idempotent bash deploy scripts; the gateway is deployed by hand from a markdown runbook. Monitoring is a 3-minute systemd-timer Python poller on the VPS plus an operator-side cron harness that fires synthetic buyer traffic through the production coordinator every 15 minutes.",
    "entryPoints": [
-    "/Users/augstar/macprovider-poc/phase3-binary/dist/install.sh \u2014 public provider installer served at get.streamvc.live/install.sh (828 lines; main() at lines 766-826)",
-    "/Users/augstar/macprovider-poc/.github/workflows/release.yml \u2014 the ONLY CI workflow; builds/signs/publishes the darwin-arm64 provider binary on v*.*.* tag push or workflow_dispatch",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh \u2014 coordinator deploy: scp binary+config to root@159.223.165.194, systemd + nginx + certbot (9 steps, idempotent)",
-    "/Users/augstar/macprovider-poc/frontdoor/console/dist/deploy-console.sh \u2014 console.streamvc.live static-site deploy incl. Cloudflare DNS record creation",
-    "/Users/augstar/macprovider-poc/phase5-gateway/dist/deploy-pearl-vps.md \u2014 gateway deploy is a MANUAL runbook, no script",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py \u2014 Pearl-side observability poller, run by macprovider-monitor.timer every 3 min",
-    "/Users/augstar/macprovider-poc/beta/CRON_TEMPLATE.txt \u2014 operator-M1 crontab: coord-cooperative.sh every 15 min 9am-10pm, coord-adversarial.sh daily 16:00 (lines 31, 40)",
-    "/Users/augstar/macprovider-poc/beta/harness.py \u2014 synthetic buyer harness writing per-request metrics to beta/runs.sqlite",
-    "/Users/augstar/macprovider-poc/scripts/activate-tier2-*.sh + enforce-tier2-hash.sh \u2014 guarded --plan/--apply production config flips (SSH + single-key YAML edit + SIGHUP + verify + auto-rollback)",
-    "/Users/augstar/macprovider-poc/phase3-binary/dist/package.sh \u2014 operator-side release build (xcodebuild Release + tarball of binary + Metal .bundle dirs)"
+    "phase3-binary/dist/install.sh \u2014 public provider installer served at get.streamvc.live/install.sh (828 lines; main() at lines 766-826)",
+    ".github/workflows/release.yml \u2014 the ONLY CI workflow; builds/signs/publishes the darwin-arm64 provider binary on v*.*.* tag push or workflow_dispatch",
+    "phase4-coordinator/dist/deploy-pearl-vps.sh \u2014 coordinator deploy: scp binary+config to root@159.223.165.194, systemd + nginx + certbot (9 steps, idempotent)",
+    "frontdoor/console/dist/deploy-console.sh \u2014 console.streamvc.live static-site deploy incl. Cloudflare DNS record creation",
+    "phase5-gateway/dist/deploy-pearl-vps.md \u2014 gateway deploy is a MANUAL runbook, no script",
+    "phase4-coordinator/dist/monitor/macprovider-monitor.py \u2014 Pearl-side observability poller, run by macprovider-monitor.timer every 3 min",
+    "beta/CRON_TEMPLATE.txt \u2014 operator-M1 crontab: coord-cooperative.sh every 15 min 9am-10pm, coord-adversarial.sh daily 16:00 (lines 31, 40)",
+    "beta/harness.py \u2014 synthetic buyer harness writing per-request metrics to beta/runs.sqlite",
+    "scripts/activate-tier2-*.sh + enforce-tier2-hash.sh \u2014 guarded --plan/--apply production config flips (SSH + single-key YAML edit + SIGHUP + verify + auto-rollback)",
+    "phase3-binary/dist/package.sh \u2014 operator-side release build (xcodebuild Release + tarball of binary + Metal .bundle dirs)"
    ],
    "keyModules": [
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/dist/install.sh",
+     "path": "phase3-binary/dist/install.sh",
      "role": "Provider onboarding: platform gate (Darwin arm64, macOS>=14), RAM-tiered model pick, fetch latest GitHub Release, openssl signature-verify checksums.txt against embedded P-256 public key (lines 396-413), SHA-256 verify, tarball-path safety validation (lines 425-452), install real binary + .bundle dirs to ~/macprovider with ~/.local/bin symlink (Metal bundle adjacency, lines 484-504), quarantine clear after prompt (lines 534-546), launchd plist render+bootstrap, 5/20-min model self-test, coordinator /v1/pool/check"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/.github/workflows/release.yml",
+     "path": ".github/workflows/release.yml",
      "role": "Release CI: macos-15 runner, pinned actions/checkout SHA (line 25), package.sh build, tier-2 artifact preflight (skipped for pre-v1.2.6 tags, lines 68-73), signs checksums.txt with MACPROVIDER_RELEASE_SIGNING_KEY_PEM secret then deletes the key file (lines 96-99), gh release create, post-publish verify-tier2-provider-release.sh"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh",
+     "path": "phase4-coordinator/dist/deploy-pearl-vps.sh",
      "role": "Coordinator deploy from laptop: step-0 config-drift gate, root SSH to hardcoded VPS_HOST=159.223.165.194 (lines 25-27), installs /opt/macprovider/coordinator + 0600 coordinator.yaml, stub-then-full nginx for ACME, refuses restart with connected providers unless FORCE_RESTART=1 (lines 143-160), verifies /v1/models returns 404 on coordinator host (lines 177-182)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/dist/check-deploy-config.sh",
+     "path": "phase4-coordinator/dist/check-deploy-config.sh",
      "role": "Pre-deploy gate: hard-fails placeholder/non-64-hex operator_key (lines 37-46), heartbeat_miss <= heartbeat_interval (lines 49-57), warns on C2 coordinator-vs-gateway timer ordering (lines 62-72)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py",
+     "path": "phase4-coordinator/dist/monitor/macprovider-monitor.py",
      "role": "Only production alerting: polls loopback /healthz, /poolz (bearer = operator_key regex-parsed from coordinator.yaml, lines 56-62), gateway /v1/status; transition-based alerts (pool ready==0 CRITICAL, provider degraded/unavailable WARN, lines 131-157); journald always + Gmail app-password email if /etc/macprovider/monitor.env configured (lines 174-195)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase5-gateway/dist/nginx-api.streamvc.live.conf",
+     "path": "phase5-gateway/dist/nginx-api.streamvc.live.conf",
      "role": "Public buyer edge: rate/conn-limit zones (lines 10-12), blanks client-supplied internal affinity headers (lines 58-59), explicit 404 for /admin/, /poolz, /v1/pool/check (lines 46-49, 106-114), /ws/provider proxied to coordinator 8444 with 10r/m + 5-conn limits (lines 124-134)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/scripts/sign-catalog.go",
+     "path": "scripts/sign-catalog.go",
      "role": "Tier-2 model-catalog signer/verifier: Ed25519 over canonical JSON body (lines 305-314), strict catalog validation (expiry, dup model ids, 64-hex sha256, hash_scope whitelist, lines 231-279), keygen writes 0600 private key (lines 90-99)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/scripts/hash-model-weights.go",
+     "path": "scripts/hash-model-weights.go",
      "role": "Produces catalog entries: sorted manifest of .safetensors files (name+sha256+size) hashed as canonical JSON (lines 74-113); derives model id from HF cache models--org--repo path (lines 129-142)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/frontdoor/console/dist/deploy-console.sh",
+     "path": "frontdoor/console/dist/deploy-console.sh",
      "role": "Console deploy: Cloudflare API DNS-record creation from ~/.config/macprovider/cloudflare-api-token (lines 65-92), certbot webroot, static /var/www/console install"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/frontdoor/console/dist/nginx-console.streamvc.live.conf",
+     "path": "frontdoor/console/dist/nginx-console.streamvc.live.conf",
      "role": "Console vhost: strict CSP connect-src limited to api.streamvc.live (line 27), 5-min cache"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/beta/web/api/chat.js",
+     "path": "beta/web/api/chat.js",
      "role": "Legacy Vercel demo proxy \u2014 kill-switched: returns 410 unless MACPROVIDER_ENABLE_LEGACY_BETA_PROXY=1 (lines 21-23)"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/beta/DECISION_CRITERIA.md",
+     "path": "beta/DECISION_CRITERIA.md",
      "role": "Decision log: 344-line doc with locked pre-launch facts, day-2/day-3 go-no-go gates, hard/soft-stop triggers, and an append-only '## Decision log' table (line 248) \u2014 the project's operational memory"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/phase3-binary/dist/relaunch-m4.sh",
+     "path": "phase3-binary/dist/relaunch-m4.sh",
      "role": "Partner-Mac recovery script (kill + nohup restart with hardcoded model/provider-id/coordinator args, lines 12-18) \u2014 pre-launchd era ops for the two known partner Macs"
     }
    ],
@@ -363,71 +363,71 @@
   {
    "key": "specsdocs",
    "area": "Documentation and spec corpus (README, runbooks, AGENTS.md, specs/, beta/DECISION_CRITERIA.md)",
-   "purpose": "As documented in /Users/augstar/macprovider-poc/README.md:20-31, MacProvider makes any Apple Silicon Mac (M1+, macOS 14+) a remote-addressable MLX inference endpoint: OpenAI-compatible /v1/chat/completions at api.streamvc.live, with every response carrying an ed25519-signed receipt binding (prompt, output, provider). Intended users are two-sided: Providers (Mac owners installing via curl get.streamvc.live/install.sh, outbound-WS only, managed at console.streamvc.live) and Buyers (drop-in OpenAI client swap, pay-per-compute). The docs corpus shows a spec-driven, multi-round-audited 2-person PoC that has outgrown its own human-facing documentation: the normative specs are current and rigorous, while README/HANDOFF/specs-index lag by 2-6 versions.",
+   "purpose": "As documented in README.md:20-31, MacProvider makes any Apple Silicon Mac (M1+, macOS 14+) a remote-addressable MLX inference endpoint: OpenAI-compatible /v1/chat/completions at api.streamvc.live, with every response carrying an ed25519-signed receipt binding (prompt, output, provider). Intended users are two-sided: Providers (Mac owners installing via curl get.streamvc.live/install.sh, outbound-WS only, managed at console.streamvc.live) and Buyers (drop-in OpenAI client swap, pay-per-compute). The docs corpus shows a spec-driven, multi-round-audited 2-person PoC that has outgrown its own human-facing documentation: the normative specs are current and rigorous, while README/HANDOFF/specs-index lag by 2-6 versions.",
    "entryPoints": [
-    "/Users/augstar/macprovider-poc/README.md \u2014 public-facing front door: provider install, buyer API, receipt schema, architecture diagram",
-    "/Users/augstar/macprovider-poc/HANDOFF.md:5-7 \u2014 declares itself 'Next session entry point: This document', but status is frozen at 2026-05-26 ('Phase 1 PoC complete... Awaiting M4 user')",
-    "/Users/augstar/macprovider-poc/RUNBOOK.md:1-19 \u2014 NOT an ops runbook: it is the original Phase 1 falsifiability test script addressed to 'a Codex agent executing Phase 1' (mlx-lm venv + cloudflared tunnel validation)",
-    "/Users/augstar/macprovider-poc/CONTINUE_RUNBOOK.md:1-9 \u2014 Phase 1 continuation pass (Steps 6.5/6.7/7.5), same era",
-    "/Users/augstar/macprovider-poc/AGENTS.md \u2014 AI-agent rules digest: PR workflow, git identity, sensitive paths (billing/buyer/auth/requestlog/router) require PR, d-inference clean-room boundary, spec naming conventions",
-    "/Users/augstar/macprovider-poc/specs/README.md \u2014 the spec index (severely stale, see surprises)",
-    "/Users/augstar/macprovider-poc/beta/DECISION_CRITERIA.md \u2014 pre-committed go/no-go criteria + append-only decision log"
+    "README.md \u2014 public-facing front door: provider install, buyer API, receipt schema, architecture diagram",
+    "HANDOFF.md:5-7 \u2014 declares itself 'Next session entry point: This document', but status is frozen at 2026-05-26 ('Phase 1 PoC complete... Awaiting M4 user')",
+    "RUNBOOK.md:1-19 \u2014 NOT an ops runbook: it is the original Phase 1 falsifiability test script addressed to 'a Codex agent executing Phase 1' (mlx-lm venv + cloudflared tunnel validation)",
+    "CONTINUE_RUNBOOK.md:1-9 \u2014 Phase 1 continuation pass (Steps 6.5/6.7/7.5), same era",
+    "AGENTS.md \u2014 AI-agent rules digest: PR workflow, git identity, sensitive paths (billing/buyer/auth/requestlog/router) require PR, d-inference clean-room boundary, spec naming conventions",
+    "specs/README.md \u2014 the spec index (severely stale, see surprises)",
+    "beta/DECISION_CRITERIA.md \u2014 pre-committed go/no-go criteria + append-only decision log"
    ],
    "keyModules": [
     {
-     "path": "/Users/augstar/macprovider-poc/specs/",
+     "path": "specs/",
      "role": "176 files. By prefix: 45 AUDIT_* (audit prompts), 42 BUILD_* (build/commission prompts), 38 SPEC-* (normative docs + their audit reports), 29 FIX_* (fix-pass prompts), remainder = phase build reports (PHASE5/6/7_*), JOINT/INTEGRATION audits, GOAL/SCOPE/REGRESSION/HARDENING one-offs, README.md index"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md",
+     "path": "specs/SPEC-001-phase3-binary.md",
      "role": "Normative spec, Swift provider binary. Version 1.3 (2026-06-06, SPEC-010 v1.5 + SPEC-011 v0.5 absorption) per line 3"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-002-coordinator.md",
+     "path": "specs/SPEC-002-coordinator.md",
      "role": "Normative spec, Go coordinator. Version 1.3.5 (2026-06-06) per line 3; note line 4 still declares dependency on SPEC-001 v1.2.4"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-003-open-onboarding.md",
+     "path": "specs/SPEC-003-open-onboarding.md",
      "role": "Normative spec, distribution/install.sh/onboarding. Version 0.7 (2026-05-29) per line 3"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-004-smart-router.md",
+     "path": "specs/SPEC-004-smart-router.md",
      "role": "Normative spec, routing. Version 0.3.1 (2026-05-30) per header"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-005-billing.md",
+     "path": "specs/SPEC-005-billing.md",
      "role": "Normative spec, billing/settlement/rewards. Version 0.3 (2026-05-31) per header"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-006-buyer-api.md",
+     "path": "specs/SPEC-006-buyer-api.md",
      "role": "Normative spec, buyer API/gateway. Version 0.8.3 (2026-05-31) per header"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-007-explorer.md",
+     "path": "specs/SPEC-007-explorer.md",
      "role": "Normative spec, internal read-only operator explorer (v0.2, RFC 2119 language, explicitly 'not a control plane')"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-008-tier2.md",
+     "path": "specs/SPEC-008-tier2.md",
      "role": "Normative spec, tier-2 trust/attestation layer. Version 0.3 (2026-05-31) per header"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-009-console-v2.md",
+     "path": "specs/SPEC-009-console-v2.md",
      "role": "Normative spec, console v2. Version 0.1 (early draft) per header"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-010-model-catalog.md",
+     "path": "specs/SPEC-010-model-catalog.md",
      "role": "Normative spec, provider model catalog. Version 1.5 (LOCKED per SPEC-001 v1.3 absorption note) per header"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-011-operator-pushed-warm-swap.md",
+     "path": "specs/SPEC-011-operator-pushed-warm-swap.md",
      "role": "Normative spec, warm model swap. Version 0.5 ('post round-3 polish pass \u2014 LOCK candidate') per header"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/specs/SPEC-012-source.md",
+     "path": "specs/SPEC-012-source.md",
      "role": "Normative spec (source/audit-history pairing with SPEC-012-source-audit-history.md). Version 0.3 per header"
     },
     {
-     "path": "/Users/augstar/macprovider-poc/beta/DECISION_CRITERIA.md",
+     "path": "beta/DECISION_CRITERIA.md",
      "role": "Pre-committed Phase 2 go/no-go criteria (signed-header pattern, hard-stop triggers, pivot menu) + append-only decision log table at line 248; 57 dated decision rows (grep '^| 2026-'), each with Observation / Decision / Phase-3-implication columns"
     }
    ],
@@ -442,9 +442,9 @@
     "Runbooks are written as self-contained prompts addressed to an executing agent ('You are a Codex agent...', RUNBOOK.md:3, CONTINUE_RUNBOOK.md:3) with PASS/FAIL gates and HALT.md escape hatches"
    ],
    "surprises": [
-    "[fact, Medium] specs/README.md (the spec index) is severely stale: lines 5-7 list only three specs \u2014 SPEC-001 'v1.1.1 Build-ready', SPEC-002 'v1.0.3', SPEC-005 'v0.3' \u2014 while the corpus actually has 12 SPEC families and SPEC-001 is at v1.3 (SPEC-001-phase3-binary.md:3), SPEC-002 at v1.3.5 (SPEC-002-coordinator.md:3). Anyone (human or agent) trusting the index gets versions ~6 revisions old. Cite: /Users/augstar/macprovider-poc/specs/README.md:5-7",
+    "[fact, Medium] specs/README.md (the spec index) is severely stale: lines 5-7 list only three specs \u2014 SPEC-001 'v1.1.1 Build-ready', SPEC-002 'v1.0.3', SPEC-005 'v0.3' \u2014 while the corpus actually has 12 SPEC families and SPEC-001 is at v1.3 (SPEC-001-phase3-binary.md:3), SPEC-002 at v1.3.5 (SPEC-002-coordinator.md:3). Anyone (human or agent) trusting the index gets versions ~6 revisions old. Cite: specs/README.md:5-7",
     "[fact, Low] README.md:137 hardcodes 'Current release: **v1.2.5**' but git tags include v1.3.0 and the shipped binary identifies as 1.3.0 (phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:70 'static let binaryVersion = \"1.3.0\"'). The same line links to /releases/latest, so the text and the link target silently disagree.",
-    "[fact, Low] Project CLAUDE.md (/Users/augstar/macprovider-poc/CLAUDE.md, 'Other repo conventions' section) states 'v1.2.3 is the current phase3-binary release. SPEC-001 v1.2.2, SPEC-002 v1.1.3, SPEC-003 v0.5 are locked' \u2014 every one of those is stale (actual: binary 1.3.0, SPEC-001 v1.3, SPEC-002 v1.3.5, SPEC-003 v0.7 per SPEC-003-open-onboarding.md:3). Agents are told these are locked baselines.",
+    "[fact, Low] Project CLAUDE.md (CLAUDE.md, 'Other repo conventions' section) states 'v1.2.3 is the current phase3-binary release. SPEC-001 v1.2.2, SPEC-002 v1.1.3, SPEC-003 v0.5 are locked' \u2014 every one of those is stale (actual: binary 1.3.0, SPEC-001 v1.3, SPEC-002 v1.3.5, SPEC-003 v0.7 per SPEC-003-open-onboarding.md:3). Agents are told these are locked baselines.",
     "[judgment, Medium] There is no current operations runbook despite live production. Root RUNBOOK.md:1-19 is the original Phase 1 falsifiability script ('You are a Codex agent executing Phase 1... This is a falsifiability test'), and CONTINUE_RUNBOOK.md:1-9 is its continuation. Ops knowledge for the live coordinator/gateway/console exists only scattered across phase reports in specs/ and memory files.",
     "[fact, Low] HANDOFF.md:5-7 status frozen at 2026-05-26: 'Phase 1 PoC complete. Phase 2 buyer-harness scaffold built... Awaiting M4 user before going live' \u2014 two weeks and roughly four phases behind reality (live beta, N=3 providers, money path). It carries a superseded-warning banner at line 3 but still names itself the session entry point.",
     "[fact, Low] beta/DECISION_CRITERIA.md:28 \u2014 the commitment signature line is still blank ('Signed (commit hash on this file is the timestamp): `_______________`') even though the header at lines 3-6 demands stamping BEFORE day 1 and the log below it has 57 dated decision rows through Phase 4+. The discipline held in practice but the ceremonial lock never happened.",
@@ -523,8 +523,8 @@
    "dimension": "dependencies",
    "healthSummary": "The dependency POSTURE is genuinely good \u2014 among the best I have seen at this maturity: tiny stdlib-first trees (the gateway has two direct deps), everything lock-filed and exact-pinned, the same CGO-free SQLite driver deliberately shared across both Go services to enable the laptop-to-Linux cross-compile deploy model, and zero vendored or CDN-loaded code. The dependency PROCESS, however, is set-and-forget: there is no Dependabot/Renovate/test CI (.github contains only the release workflow), `go mod tidy` has not been run since the gateway docs feature landed, and every manifest is frozen at roughly mid-2024 vintage. That process gap has already produced one real problem hiding in plain sight: both money-path services run modernc.org/sqlite v1.33.0, a version its own authors retracted as breaking clients, 19 minor versions behind current \u2014 the single highest-priority dependency action in the repo. The rest is cheap hygiene: bump the two-year-stale exact-pinned swift-nio, add a third-party license notice file to the publicly distributed provider tarball, note that gopkg.in/yaml.v3 is officially unmaintained, and drop the never-imported swift-log. Method note: Go version recency was checked live via `go list -m -u all` (network was available); upstream maintenance statuses (go-yaml archived 2025-04-01, gobwas/ws latest release 2024-05-03, swift-nio latest 2.101.0) were verified against the live GitHub pages, not memory.",
    "strengths": [
-    "Exceptionally small, stdlib-first dependency trees for money-path services: phase5-gateway has exactly TWO direct dependencies (gopkg.in/yaml.v3 and modernc.org/sqlite \u2014 /Users/augstar/macprovider-poc/phase5-gateway/go.mod:5-8) and phase4-coordinator only seven (/Users/augstar/macprovider-poc/phase4-coordinator/go.mod:5-13). No framework sprawl, no ORM, no HTTP client libs \u2014 minimal supply-chain surface where it matters most.",
-    "Full reproducibility discipline: go.sum committed for both modules, Package.resolved committed and git-tracked (verified via git ls-files), and every Swift dependency pinned with `exact:` version requirements (/Users/augstar/macprovider-poc/phase3-binary/Package.swift:20-39) \u2014 no version ranges anywhere, so the signed release pipeline can never silently pick up a different dependency than what was tested.",
+    "Exceptionally small, stdlib-first dependency trees for money-path services: phase5-gateway has exactly TWO direct dependencies (gopkg.in/yaml.v3 and modernc.org/sqlite \u2014 phase5-gateway/go.mod:5-8) and phase4-coordinator only seven (phase4-coordinator/go.mod:5-13). No framework sprawl, no ORM, no HTTP client libs \u2014 minimal supply-chain surface where it matters most.",
+    "Full reproducibility discipline: go.sum committed for both modules, Package.resolved committed and git-tracked (verified via git ls-files), and every Swift dependency pinned with `exact:` version requirements (phase3-binary/Package.swift:20-39) \u2014 no version ranges anywhere, so the signed release pipeline can never silently pick up a different dependency than what was tested.",
     "The duplicated modernc.org/sqlite choice across both Go services is the RIGHT duplication: same driver, same version in both (coordinator go.mod:12, gateway go.mod:7), and the pure-Go/CGO-free property is load-bearing \u2014 it is what allows cross-compiling the linux-amd64 production binaries (phase4-coordinator/dist/coordinator-linux-amd64, phase5-gateway/dist/gateway-linux-amd64, both properly gitignored) from the operator's macOS laptop with no Linux build infrastructure. One driver to reason about for WAL/busy_timeout semantics across the whole backend. The performance tradeoff vs CGo mattn is irrelevant at current request volume.",
     "Zero vendored or copied third-party code: a copyright/SPDX-header sweep across all first-party Go/Swift/JS sources found nothing foreign, and the embedded web UIs are small hand-written assets (explorer dashboard.js 228 lines, console index.html 1544 lines) with no CDN-loaded or bundled JS libraries \u2014 the only CDN reference in the tree is a test asserting their absence.",
     "Production ops scripts deliberately avoid third-party Python: the VPS monitor (phase4-coordinator/dist/monitor/macprovider-monitor.py) and the cron harness (beta/harness.py) import stdlib only (urllib/smtplib/sqlite3), so the deployed alerting path and synthetic-traffic path have no pip dependency at all."
@@ -1151,9 +1151,9 @@
    "kind": "fact",
    "what": "The gateway has no retention path for any table. usage_events, feedback_events, audit_events, api_key_events, demo_usage_events, capacity_signal_events, signup_events, and demo_session_events all have BEFORE DELETE triggers that RAISE(ABORT) (migrate.go:184-251), and concurrency_reservations has its own no-delete trigger (migrate.go:248-251). quota_reservations has no trigger but the only cleanup mechanism \u2014 the hourly reaper \u2014 issues an UPDATE that flips status to 'expired' rather than deleting rows (store.go:847-860; wired in main.go:96-121). Net effect: every non-demo chat request permanently adds at least 3 rows (quota_reservations, concurrency_reservations, usage_events), and pruning is impossible without a schema migration because the triggers forbid DELETE.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/migrate.go:184-251",
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/store.go:847-860",
-    "/Users/augstar/macprovider-poc/phase5-gateway/cmd/gateway/main.go:96-121"
+    "phase5-gateway/internal/storage/sqlite/migrate.go:184-251",
+    "phase5-gateway/internal/storage/sqlite/store.go:847-860",
+    "phase5-gateway/cmd/gateway/main.go:96-121"
    ],
    "why": "On the RAM- and disk-constrained Pearl VPS (already swapping), the gateway DB grows monotonically with traffic forever. Per-request quota math (dailyUsageTx SUM over usage_events + quota_reservations, store.go:862-878) and explorer analytics scan these growing tables on every request. The append-only triggers are a deliberate tamper-evidence design for money data, which is good \u2014 but it means there is no sanctioned cleanup story at all, and the eventual fix (periodic archive + DB rotation, or trigger amendment to allow aged-out deletes) needs to be designed before the tables are large, not after.",
    "confidence": "high",
@@ -1174,11 +1174,11 @@
    "kind": "fact",
    "what": "pool.Registry.ApplyHeartbeat invokes the SwapEventEmitter while holding Registry.mu (provider.go:482-484 takes the lock, emitter fires at 542-554). Production wiring makes that emitter a synchronous SQLite INSERT: main.go:94-111 calls auditStore.EmitSwap inline. The code's own concurrency contract comment (provider.go:446-457) says implementations 'MUST NOT block for long', but the production implementation is a DB write on a database opened with busy_timeout=5000 (sqliteutil/dsn.go:11), shared with request_log/billing/idempotency writes.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:446-457",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:482-484",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:542-554",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/cmd/coordinator/main.go:94-111",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/sqliteutil/dsn.go:11"
+    "phase4-coordinator/internal/pool/provider.go:446-457",
+    "phase4-coordinator/internal/pool/provider.go:482-484",
+    "phase4-coordinator/internal/pool/provider.go:542-554",
+    "phase4-coordinator/cmd/coordinator/main.go:94-111",
+    "phase4-coordinator/internal/sqliteutil/dsn.go:11"
    ],
    "why": "Registry.mu guards everything: Touch() liveness updates for every inbound WS frame from every provider, ApplyHeartbeat, Snapshot() used by selectProvider on every buyer request. If the audit INSERT lands while another writer (billing hot path, retention prune, nightly reconcile) holds the SQLite write lock, the heartbeat goroutine can stall up to ~5s inside the registry lock \u2014 freezing routing and liveness for the whole pool. Swaps are operator-initiated and rare, which is why this is Medium not High, but the blast radius when it does collide is pool-wide.",
    "confidence": "high",
@@ -1198,11 +1198,11 @@
    "kind": "fact",
    "what": "PruneBefore wraps the indexed column in a function: `DELETE FROM request_log WHERE julianday(ts_utc) < julianday(?)` (requestlog/store.go:188, same pattern for request_idempotency_keys at :185 and audit_log at audit/store.go:122). julianday(ts_utc) defeats idx_request_log_ts_utc (created at requestlog/store.go:114-115), so each daily prune is a full-table scan, and the DELETE is a single unbatched statement holding the SQLite write lock for its entire duration.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/requestlog/store.go:185-188",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/requestlog/store.go:114-115",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/audit/store.go:118-126",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/buyer/server.go:123",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/buyer/server.go:1286-1290"
+    "phase4-coordinator/internal/requestlog/store.go:185-188",
+    "phase4-coordinator/internal/requestlog/store.go:114-115",
+    "phase4-coordinator/internal/audit/store.go:118-126",
+    "phase4-coordinator/internal/buyer/server.go:123",
+    "phase4-coordinator/internal/buyer/server.go:1286-1290"
    ],
    "why": "This DB is the money path. Billing's WriteHotPath uses BEGIN IMMEDIATE with a 6s budget (requestLogWriteTimeout, buyer/server.go:123) and the HTTP-forward success path returns buyer-visible HTTP 500 'request_log_failed' if the durable write fails (buyer/server.go:1286-1290). At today's ~10-20k retained rows the scan is milliseconds; at 100x beta traffic with 90-day retention, a multi-second full-scan DELETE once a day overlaps live requests and busy_timeout=5000 turns it into hot-path failures. Timestamps are RFC3339Nano text which sorts lexicographically, so the fix is trivial.",
    "confidence": "high",
@@ -1224,8 +1224,8 @@
    "kind": "judgment",
    "what": "The gateway store opens its DB with SetMaxOpenConns(1)/SetMaxIdleConns(1) (store.go:38-39), so every operation \u2014 quota reserve (BEGIN IMMEDIATE), settle, refund, concurrency acquire/release, auth key lookup \u2014 queues behind whatever currently holds the one connection. Explorer/admin analytics share that same connection with a 3-second per-query budget (explorerQueryTimeoutMs=3000, router/explorer.go:17,35) and result limits up to 200 rows over windows up to 31 days (explorer.go:15-23).",
    "where": [
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/store.go:38-39",
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/explorer.go:14-43"
+    "phase5-gateway/internal/storage/sqlite/store.go:38-39",
+    "phase5-gateway/internal/router/explorer.go:14-43"
    ],
    "why": "The single connection is a deliberate simplicity/SQLITE_BUSY-avoidance choice and is fine at beta volume. But it couples two growth curves: as the never-pruned event tables (finding above) grow, explorer window queries slow toward their 3s budget, and during those 3 seconds every concurrent buyer chat request blocks at ReserveQuota before any token is streamed. Operator opens console dashboard \u2192 all buyers stall. This will surface as mysterious p99 latency spikes correlated with console use.",
    "confidence": "high",
@@ -1245,10 +1245,10 @@
    "kind": "fact",
    "what": "seenModels (map[string]struct{}, provider.go:133,156) gains an entry on every Register (provider.go:194) and every heartbeat (provider.go:519) keyed by whatever model_id the provider reports. Entries are never deleted \u2014 not on provider removal, not on TTL \u2014 and the map is iterated at provider.go:589 to answer model-known queries.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:133",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:194",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:519",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:589"
+    "phase4-coordinator/internal/pool/provider.go:133",
+    "phase4-coordinator/internal/pool/provider.go:194",
+    "phase4-coordinator/internal/pool/provider.go:519",
+    "phase4-coordinator/internal/pool/provider.go:589"
    ],
    "why": "With open provisional-tier onboarding, an admitted stranger Mac can heartbeat a new random model_id every few seconds, growing coordinator memory under the global registry lock indefinitely (~4MB/day/provider at 1Hz) on a VPS with ~180MiB free, and polluting ModelKnown()/model listing with garbage entries. Honest pool members never trigger it, hence Low \u2014 but it is the only unbounded in-memory structure I found in the coordinator, and the writers are the least-trusted parties in the system.",
    "confidence": "high",
@@ -1268,8 +1268,8 @@
    "kind": "fact",
    "what": "AcquireConcurrency is only called for non-demo subjects (`if !authn.Demo`, server.go:1362-1381), so demo requests are bounded by daily per-IP token quota but not by concurrent in-flight count. Each in-flight demo request holds a gateway goroutine, an upstream coordinator connection for up to CoordinatorTimeout (server.go:1383), and competes for the MLX-serialized provider slots.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/server.go:1362-1381",
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/server.go:1383"
+    "phase5-gateway/internal/router/server.go:1362-1381",
+    "phase5-gateway/internal/router/server.go:1383"
    ],
    "why": "A burst of parallel demo requests from one or a few IPs can occupy the provider pool (MLX serializes per provider; N=3) and hold many concurrent upstream streams on the RAM-capped gateway, degrading paying buyers, until the daily demo token budget runs out. Damage is capped by demo max_tokens and the IP-bound token quota, hence Low \u2014 but it is the one admission path with no concurrency bound.",
    "confidence": "high",
@@ -1291,8 +1291,8 @@
    "kind": "fact",
    "what": "phase4-coordinator and phase5-gateway both pin modernc.org/sqlite v1.33.0. The module's own current go.mod carries `retract v1.33.0 // intended to resolve #177 but breaks clients`, and `go list -m -u all` (run live in both modules \u2014 network was available) prints `modernc.org/sqlite v1.33.0 (retracted) [v1.52.0]`. The deployed services are 19 minor versions behind current (v1.52.0), missing roughly two years of driver fixes plus newer bundled SQLite upstream releases. This is the single most load-bearing dependency in the system: the billing ledger, request_log, idempotency keys, gateway API keys, quota reservations, and audit logs all live in SQLite through this driver in both services.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/go.mod:12",
-    "/Users/augstar/macprovider-poc/phase5-gateway/go.mod:7"
+    "phase4-coordinator/go.mod:12",
+    "phase5-gateway/go.mod:7"
    ],
    "why": "The driver authors explicitly declared this exact version broken for clients \u2014 a status nobody on the project has noticed because nothing checks for updates. Running a known-retracted DB driver under a live credit ledger and payout pipeline is exactly the kind of latent correctness risk that bites in beta: if the v1.33.0 regression (or any of 19 versions of subsequent fixes, including bundled SQLite engine updates) ever manifests, it manifests as ledger/locking misbehavior on the money path. The fix is cheap and both services have strong test suites to validate the bump.",
    "suggestedFix": "Bump modernc.org/sqlite to v1.52.0 in both go.mod files (one line each), run `go mod tidy`, run both modules' full test suites (billing store/ACID tests, gateway store tests, -race variants), then redeploy via the normal PR path. Verify WAL/busy_timeout behavior under the existing concurrent-load tests before shipping.",
@@ -1314,10 +1314,10 @@
    "kind": "fact",
    "what": ".github/ contains exactly one file \u2014 workflows/release.yml (the Swift release build). There is no dependabot.yml, no Renovate, no test CI, and no scheduled update pass. Concrete drift evidence: github.com/yuin/goldmark is directly imported by the gateway (pages.go:11-12, used at line 20 to render the public /docs page) yet go.mod line 17 still lists it as `// indirect`, meaning `go mod tidy` has not been run since the docs feature landed. Version lag is uniform: chi v5.1.0 (current v5.3.0), zerolog v1.33.0 (current v1.35.1), golang.org/x/sys v0.22.0 (current v0.46.0) per the live `go list -m -u all` runs.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/pages.go:11",
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/pages.go:20",
-    "/Users/augstar/macprovider-poc/phase5-gateway/go.mod:17",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/go.mod:6"
+    "phase5-gateway/internal/router/pages.go:11",
+    "phase5-gateway/internal/router/pages.go:20",
+    "phase5-gateway/go.mod:17",
+    "phase4-coordinator/go.mod:6"
    ],
    "why": "This is the systemic cause of the retracted-driver finding: with no automation and no tidy discipline, a publicly flagged-as-broken dependency sat in production unnoticed. As real users and money are live, the project needs at minimum a low-friction signal when a dependency is retracted or has a security release \u2014 not enterprise tooling, just a Dependabot config or a monthly `go list -m -u all` habit.",
    "suggestedFix": "Add a minimal .github/dependabot.yml covering gomod (both module dirs) and swift, monthly cadence to keep noise low. Run `go mod tidy` in phase5-gateway to correct the goldmark classification. Optionally add `go list -m -u -retracted all` to the pre-deploy check script.",
@@ -1337,8 +1337,8 @@
    "kind": "fact",
    "what": "Package.swift pins swift-nio with `exact: \"2.65.0\"` and Package.resolved confirms 2.65.0 resolved. Upstream's latest is 2.101.0 (checked via the GitHub releases page), and visible release notes for 2.100.0/2.101.0 include security-relevant fixes: HTTP request URI/method byte validation, ByteBuffer capacity-overflow prevention, and rejection of WebSocket 8-byte payload lengths exceeding Int.max. NIOHTTP1 serves the provider binary's local OpenAI-compatible HTTP API. Mitigation: that server binds 127.0.0.1 only (HTTPServer.swift), so exposure requires a local attacker or a tunnel misconfiguration.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase3-binary/Package.swift:24",
-    "/Users/augstar/macprovider-poc/phase3-binary/Package.resolved:76"
+    "phase3-binary/Package.swift:24",
+    "phase3-binary/Package.resolved:76"
    ],
    "why": "Exact pins with no update cadence means the network-parsing code in a publicly distributed signed binary is frozen at March-2024 vintage forever. The loopback-only binding keeps this from being High today, but every provider Mac on the network runs this HTTP parser, and the project's own architecture docs contemplate tunneled access to it. A two-year-stale NIO will also eventually block Swift toolchain upgrades.",
    "suggestedFix": "Bump swift-nio to the current 2.x release in Package.swift (exact pin is fine \u2014 just move it), rebuild, run the XCTest suite and acceptance scripts, and cut a binary release through the existing signed-release pipeline. Fold dependency bumps into the existing release rhythm rather than adding new infrastructure.",
@@ -1360,9 +1360,9 @@
    "kind": "fact",
    "what": "package.sh builds the release tarball containing only the binary plus Metal/NIO resource bundles (lines 52-60: `macprovider-cli`, `mlx-swift_Cmlx.bundle`, `swift-nio_NIOPosix.bundle`) \u2014 no LICENSE, NOTICE, or third-party attribution files. The binary statically links Apache-2.0 dependencies (swift-nio, swift-argument-parser, swift-log per Package.swift:24-35, plus transitive swift-transformers, swift-collections, swift-atomics per Package.resolved) and MIT dependencies (mlx-swift, mlx-swift-examples, Yams, GzipSwift). Apache-2.0 \u00a74 requires providing a copy of the license with binary redistributions; MIT requires notice retention. This tarball is distributed to strangers via GitHub Releases and the public curl|bash installer chain (get.streamvc.live).",
    "where": [
-    "/Users/augstar/macprovider-poc/phase3-binary/dist/package.sh:52",
-    "/Users/augstar/macprovider-poc/phase3-binary/Package.swift:19",
-    "/Users/augstar/macprovider-poc/phase3-binary/Package.resolved:76"
+    "phase3-binary/dist/package.sh:52",
+    "phase3-binary/Package.swift:19",
+    "phase3-binary/Package.resolved:76"
    ],
    "why": "Open onboarding means this is genuine public distribution, not a two-person handoff anymore. License non-compliance is trivial to fix now and increasingly awkward later \u2014 it is the kind of thing a future partner, acquirer, or hostile community member checks first. (Contrast: the project is scrupulously careful about the d-inference clean-room boundary, so the intent to be license-clean clearly exists.)",
    "suggestedFix": "Generate a THIRD-PARTY-NOTICES.txt aggregating the LICENSE files of all resolved packages (a 20-line script over Package.resolved checkouts) and add it to the tarball in package.sh. One-time, ~30 minutes.",
@@ -1382,8 +1382,8 @@
    "kind": "fact",
    "what": "Both Go services depend on gopkg.in/yaml.v3 v3.0.1 for config parsing. The upstream repository (go-yaml/yaml) was archived by its owner on April 1, 2025 and its README carries an explicit 'THIS PROJECT IS UNMAINTAINED' section (verified via web fetch). v3.0.1 is the final release; no bug or security fixes will ever ship.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/go.mod:11",
-    "/Users/augstar/macprovider-poc/phase5-gateway/go.mod:6"
+    "phase4-coordinator/go.mod:11",
+    "phase5-gateway/go.mod:6"
    ],
    "why": "Risk is low today because all YAML input is operator-controlled config files (coordinator.yaml, gateway.yaml), not untrusted data. But YAML parsers have a history of DoS-class bugs, and an unmaintained parser in both services is a slow-burning liability. Worth a note in the decision log and a planned migration (goccy/go-yaml is the common successor) next time config code is touched \u2014 not urgent.",
    "suggestedFix": "No immediate action. Record in beta/DECISION_CRITERIA.md; migrate to goccy/go-yaml opportunistically during a future config refactor. Never feed buyer-controlled input through this parser.",
@@ -1403,8 +1403,8 @@
    "kind": "fact",
    "what": "Package.swift declares swift-log exact 1.6.0 (lines 28-31) and links the Logging product into the macprovider-cli executable target (line 60), but a grep across all of phase3-binary/Sources/ finds zero `import Logging` statements \u2014 the codebase logs via print()/stderr writes instead. The library is declared, resolved, linked, and never used.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase3-binary/Package.swift:28",
-    "/Users/augstar/macprovider-poc/phase3-binary/Package.swift:60"
+    "phase3-binary/Package.swift:28",
+    "phase3-binary/Package.swift:60"
    ],
    "why": "Minor dead weight and one unnecessary supply-chain node in a signed, publicly distributed binary. Also a small signal to future contributors that structured logging was intended but never adopted \u2014 either use it or drop it.",
    "suggestedFix": "Remove the swift-log dependency and the Logging product from Package.swift, or adopt it deliberately if structured logging on the provider is wanted for beta debugging.",
@@ -1424,8 +1424,8 @@
    "kind": "fact",
    "what": "There is no requirements.txt, pyproject.toml, or lockfile anywhere in the repo (find across the tree, excluding .venv). The root .venv runs Python 3.9.6 from macOS CommandLineTools (pyvenv.cfg:3) \u2014 Python 3.9 reached end-of-life in October 2025 \u2014 and contains the Phase-1 mlx_lm serving stack (transformers 4.57.6, mlx 0.29.3, huggingface_hub) that current production no longer uses (providers run the Swift binary now). Of the live ops scripts: beta/harness.py and the VPS monitor (macprovider-monitor.py) are stdlib-only (good), but beta/report.py imports third-party `yaml` at line 26 with no documented way to recreate its environment.",
    "where": [
-    "/Users/augstar/macprovider-poc/.venv/pyvenv.cfg:3",
-    "/Users/augstar/macprovider-poc/beta/report.py:26"
+    ".venv/pyvenv.cfg:3",
+    "beta/report.py:26"
    ],
    "why": "Beta-grade impact only: the cron harness keeps working, but report.py silently depends on whatever Python/PyYAML happens to be on the operator laptop \u2014 on a fresh machine or after an OS update, report generation breaks with no manifest to rebuild from. The stale 2GB-class venv also invites confusion about what production actually depends on.",
    "suggestedFix": "Add a 3-line beta/requirements.txt (pyyaml) plus a README note on which python runs the cron scripts; delete or rebuild the Phase-1 .venv on a supported Python when convenient.",
@@ -1447,7 +1447,7 @@
    "kind": "judgment",
    "what": "The coordinator's provider WebSocket leg is built on github.com/gobwas/ws v1.4.0. That is the latest available version (`go list -m -u all` offers no update), and the upstream releases page shows v1.4.0 was published May 3, 2024 \u2014 over two years without a release as of June 2026, with v1.3.2 (Jan 2024) and v1.3.1 (Nov 2023) before it.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/go.mod:7"
+    "phase4-coordinator/go.mod:7"
    ],
    "why": "The library is stable, widely deployed, and the project is current on it \u2014 this is not a today problem. But every provider connection (auth handshake, encrypted-leg frames, inference relay) flows through a parser whose upstream may be slow or unresponsive if a protocol-level vulnerability is ever found. Worth knowing the contingency (e.g. coder/websocket) before an incident forces the question; the WS server code is well-isolated in internal/ws which would make a swap tractable.",
    "suggestedFix": "No action now. Note the dormancy in the decision log and keep the internal/ws abstraction boundary clean so a driver swap stays a contained change.",
@@ -1468,10 +1468,10 @@
    "kind": "fact",
    "what": "The only CI workflow in the repo is the release build: .github/workflows/release.yml triggers solely on v*.*.* tag push or manual dispatch and runs build \u2192 sign \u2192 publish, never `go test`, `go vet`, `swift test`, or any linter. Even the release path runs no tests: package.sh (invoked at release.yml:56-61) does xcodebuild + tar only. Meanwhile the repo carries large test suites that nothing executes automatically (26 *_test.go files in phase4-coordinator, 13 in phase5-gateway, 16 Swift test files), and AGENTS.md:32-42 mandates that billing/buyer/auth/router changes go through 'PR with review' \u2014 but a PR here has no required checks, no hooks (.git/hooks has zero non-sample entries), no .golangci.yml, no Makefile target. The PR gate for the money path is purely human eyeballs.",
    "where": [
-    "/Users/augstar/macprovider-poc/.github/workflows/release.yml:3-12 (tag/dispatch triggers only)",
-    "/Users/augstar/macprovider-poc/.github/workflows/release.yml:56-99 (build\u2192sign steps, no test step)",
-    "/Users/augstar/macprovider-poc/phase3-binary/dist/package.sh:25-60 (xcodebuild + tar, no tests)",
-    "/Users/augstar/macprovider-poc/AGENTS.md:32-42 (sensitive paths 'require PR with review')"
+    ".github/workflows/release.yml:3-12 (tag/dispatch triggers only)",
+    ".github/workflows/release.yml:56-99 (build\u2192sign steps, no test step)",
+    "phase3-binary/dist/package.sh:25-60 (xcodebuild + tar, no tests)",
+    "AGENTS.md:32-42 (sensitive paths 'require PR with review')"
    ],
    "why": "This project is explicitly AI-agent-authored (AGENTS.md is addressed to agents) with a 2-person review bench, and billing/quota correctness is guarded by tests that only run when someone remembers. A regression in phase4 billing or phase5 quota settlement can squash-merge to main looking green and ship to production in the next hand-deploy. The phase5 README even names the exact critical test sets (README.md:118-124) \u2014 they are one 20-line ubuntu workflow away from running on every PR, at zero cost. This is the single highest-leverage ops fix available.",
    "suggestedFix": "Add one .github/workflows/ci.yml: on pull_request + push to main, two ubuntu-latest jobs running `go vet ./... && go test ./...` in phase4-coordinator and phase5-gateway (~2-3 min, free). Optionally a macos job for `swift test` on phase3-binary paths, or defer that to release time. Mark the Go jobs as required checks on main.",
@@ -1491,11 +1491,11 @@
    "kind": "fact",
    "what": "Production alerting is exactly one mechanism: macprovider-monitor.py on a 3-minute systemd timer on Pearl, polling loopback /healthz, /poolz, /v1/status. Three compounding weaknesses: (1) email is silently optional \u2014 without Gmail creds in /etc/macprovider/monitor.env it degrades to journald-only with an INFO line (monitor.py:174-180), and per the monitor README:33-36 it runs journal-only 'until the password is filled in'; (2) alert delivery is single-shot \u2014 main() emits alerts, attempts email, then unconditionally save_state()s the new state (monitor.py:159-171), and send_email swallows failures with a printed WARN (monitor.py:194-195), so a transient SMTP failure permanently drops that transition alert; (3) the monitor runs on the same RAM-constrained VPS as the coordinator and gateway, so VPS death, OOM, or nginx failure kills the watcher along with the watched \u2014 and a repo-wide grep for uptimerobot/healthchecks/pingdom/statuscake/dead-man patterns returns nothing: there is no monitoring independent of Pearl.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py:159-171 (state saved regardless of email outcome)",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py:174-180 (silent degrade to journal-only)",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py:188-195 (email failure swallowed)",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/README.md:33-36 (email pending until app password configured)",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.timer:1-11 (3-min timer)"
+    "phase4-coordinator/dist/monitor/macprovider-monitor.py:159-171 (state saved regardless of email outcome)",
+    "phase4-coordinator/dist/monitor/macprovider-monitor.py:174-180 (silent degrade to journal-only)",
+    "phase4-coordinator/dist/monitor/macprovider-monitor.py:188-195 (email failure swallowed)",
+    "phase4-coordinator/dist/monitor/README.md:33-36 (email pending until app password configured)",
+    "phase4-coordinator/dist/monitor/macprovider-monitor.timer:1-11 (3-min timer)"
    ],
    "why": "Real buyers and a real money path now depend on one swap-pressured VPS. If Pearl goes down at 3am \u2014 the one failure mode the monitor structurally cannot report \u2014 the operator learns about it from a user complaint. Even a provider-pool-empty CRITICAL may reach no human if the Gmail app password was never configured (the code's silent-degrade design makes that state invisible), and if the one email send fails, the alert is gone forever. The minimum bar for live money is one alerting path that does not live on the monitored host.",
    "suggestedFix": "Two cheap moves: (1) add a free external uptime check (healthchecks.io or UptimeRobot) on https://coordinator.streamvc.live/healthz and https://api.streamvc.live/healthz with email/push \u2014 this covers VPS-down, nginx-down, and monitor-dead in one stroke; (2) in monitor.py, only save_state() for a transition after the alert was delivered to at least one channel beyond journald (or retry on next poll while the condition persists), and confirm the Gmail app password is actually set in production.",
@@ -1515,9 +1515,9 @@
    "kind": "fact",
    "what": "The linux binaries that run the money path are produced by an undocumented manual cross-compile: the only trace in the entire repo is the comment 'coordinator-linux-amd64 cross-compiled into dist/' (deploy-pearl-vps.sh:9); a grep for GOOS=linux across both Go modules' scripts and docs finds no build command anywhere. deploy-pearl-vps.sh then ships whatever file currently sits at dist/coordinator-linux-amd64 (referenced at lines 32, installed at 72-78) with no version stamp, no commit linkage, and no post-deploy 'which build is this' verification. There is no rollback step in the script; the de facto rollback artifact is an untracked coordinator-linux-amd64.pre-phase6.bak sitting in dist/ (covered by .gitignore:38 '*.bak'). The Swift binary, by contrast, gets a full tagged-release pipeline with signing and post-publish verification.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:9 (comment is the only build documentation)",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:31-39,71-82 (ships whatever is in dist/, no provenance check)",
-    "/Users/augstar/macprovider-poc/.gitignore:36-41 (binaries and .bak rebuilt locally, untracked)"
+    "phase4-coordinator/dist/deploy-pearl-vps.sh:9 (comment is the only build documentation)",
+    "phase4-coordinator/dist/deploy-pearl-vps.sh:31-39,71-82 (ships whatever is in dist/, no provenance check)",
+    ".gitignore:36-41 (binaries and .bak rebuilt locally, untracked)"
    ],
    "why": "Combined with the absence of CI, the binary scp'd to production may have been built from uncommitted or never-tested code, and nobody can later answer 'which commit is running on Pearl?'. During an incident, rollback means remembering that a .bak file exists and hand-restoring it over SSH. For two rarely-deployed services this hasn't bitten yet, but the first bad deploy to the billing path will be diagnosed blind.",
    "suggestedFix": "Add a 15-line build script per Go service (GOOS=linux GOARCH=amd64 go build -ldflags \"-X main.version=$(git describe --always --dirty)\") that refuses to build from a dirty tree without an override; have deploy-pearl-vps.sh keep the previous binary as coordinator.prev on the VPS and print the deployed version from a --version flag or /healthz field as a final step.",
@@ -1538,9 +1538,9 @@
    "kind": "fact",
    "what": "Coordinator and console deploys are idempotent fail-closed scripts; the gateway's deploy is a manual markdown checklist that opens with 'This is an operator runbook draft' (deploy-pearl-vps.md:1-3) and whose rollback is three manual nginx/systemctl steps (lines 34-38). No pre-deploy gate validates gateway.yaml. Worse, the one cross-component safety check that exists \u2014 check-deploy-config.sh's C2 assertion that coordinator request_timeout_s < gateway coordinator_request_seconds \u2014 only executes if the operator passes gateway.yaml as a second argument (check-deploy-config.sh:18-19, 62-74), and the coordinator deploy script invokes it with only the coordinator config (deploy-pearl-vps.sh:50: `check-deploy-config.sh \"$CONFIG\"`), so every standard deploy prints 'skipped C2 timer cross-check'. Memory of this project records a real production drift on exactly this timer pair.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase5-gateway/dist/deploy-pearl-vps.md:1-3,34-38",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/check-deploy-config.sh:18-19,62-74",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:46-52 (gate invoked with coordinator.yaml only)"
+    "phase5-gateway/dist/deploy-pearl-vps.md:1-3,34-38",
+    "phase4-coordinator/dist/check-deploy-config.sh:18-19,62-74",
+    "phase4-coordinator/dist/deploy-pearl-vps.sh:46-52 (gate invoked with coordinator.yaml only)"
    ],
    "why": "Manual checklists drift and skip steps under incident pressure \u2014 and this is the service holding buyer auth, quotas, and usage accounting. The C2 check being structurally skipped means a known breaker-attribution hazard (documented in the script's own header, lines 8-12) can silently re-enter production on any coordinator timeout change.",
    "suggestedFix": "Script the gateway deploy by cloning the coordinator script's shape (gate \u2192 scp \u2192 install \u2192 restart \u2192 verify), and change deploy-pearl-vps.sh:50 to pass the gateway config when present, e.g. `check-deploy-config.sh \"$CONFIG\" \"$DIST_DIR/../../phase5-gateway/dist/gateway.yaml\"`, failing loudly if it is missing rather than noting and continuing.",
@@ -1560,9 +1560,9 @@
    "kind": "fact",
    "what": "coordinator.yaml (containing the plaintext operator_key and the authoritative provider enrollment list) is gitignored (.gitignore:43-45) and lives only in the laptop working tree. The template itself instructs: 'Edit this list locally \u2014 DO NOT add providers by SSHing to the VPS... because the next deploy run will overwrite your changes from this file. (Lesson learned 2026-05-28.)' (coordinator.yaml.example:79-83). deploy-pearl-vps.sh:73,79 scp's and installs the laptop file over /opt/macprovider/coordinator.yaml with no pull-and-diff against what is currently running and no backup of the VPS copy. check-deploy-config.sh validates the laptop file in isolation (placeholder key, thresholds) but cannot detect that it is stale relative to production.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/coordinator.yaml.example:79-83",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:71-82",
-    "/Users/augstar/macprovider-poc/.gitignore:43-45"
+    "phase4-coordinator/dist/coordinator.yaml.example:79-83",
+    "phase4-coordinator/dist/deploy-pearl-vps.sh:71-82",
+    ".gitignore:43-45"
    ],
    "why": "Two realistic failure modes for this exact setup: (a) laptop loss or an AI-agent session 'sanitizing' the local file (this repo runs many agent sessions in that worktree; the project's own notes record a near-miss) followed by a deploy clobbers production provider enrollment; (b) an emergency VPS-side edit made during an incident is silently reverted by the next routine deploy. With N=3 live providers, a clobbered provider list is a visible outage.",
    "suggestedFix": "Add a step 4a to deploy-pearl-vps.sh: scp the current VPS coordinator.yaml down, diff against the candidate, and require interactive confirmation (or a FORCE flag) when the remote copy differs in the providers: block or operator_key. Keep a dated backup of the remote file on the VPS before overwrite. Separately, keep an encrypted off-laptop copy of the real coordinator.yaml.",
@@ -1582,8 +1582,8 @@
    "kind": "judgment",
    "what": "There is no Makefile, justfile, or task runner anywhere in the repo (find across the tree returns nothing), and the three components have wildly different dev-loop documentation: phase5-gateway/README.md:26-39 and 115-127 give a complete copy-pasteable loop (env vars, go test ./..., -check mode, named critical test sets); phase3-binary has a README plus scripts/; phase4-coordinator \u2014 25k LOC including the billing engine \u2014 has no README whatsoever (the file does not exist), and its build, test, and cross-compile commands are written down nowhere.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase5-gateway/README.md:26-39,115-127 (the good pattern that proves the standard is achievable)",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:8-10 (build step exists only as a prose prerequisite)"
+    "phase5-gateway/README.md:26-39,115-127 (the good pattern that proves the standard is achievable)",
+    "phase4-coordinator/dist/deploy-pearl-vps.sh:8-10 (build step exists only as a prose prerequisite)"
    ],
    "why": "This repo's de facto contributors are fresh AI-agent sessions (per AGENTS.md and the project's own workflow), which re-derive the dev loop from scratch every session. Missing canonical commands for the biggest, most money-sensitive module increases per-session variance \u2014 an agent that doesn't know to run the billing tests before committing won't run them, and nothing else will either (see the CI finding). A 30-line phase4-coordinator/README.md plus a root Makefile with test/build/cross-compile targets closes this.",
    "suggestedFix": "Write phase4-coordinator/README.md modeled on the gateway's (build, test, mockprovider usage, cross-compile command, deploy pointer), and add a root Makefile with `make test` (both Go modules), `make build-linux` (both binaries, version-stamped), and `make check` (config gates) so agents and CI share one entry point.",
@@ -1605,11 +1605,11 @@
    "kind": "fact",
    "what": "The gateway does deployment secrets right: gateway.yaml carries env:NAME indirection and real values live in /etc/macprovider/gateway.env loaded via EnvironmentFile (macprovider-gateway.service:12; deploy-pearl-vps.md:6-11). The coordinator instead embeds operator_key in plaintext in coordinator.yaml (coordinator.yaml.example:65-68), which is scp'd from the laptop and installed 0600 (deploy-pearl-vps.sh:79). The monitor then extracts that key by regexing the YAML (macprovider-monitor.py:56-62) and runs as root (macprovider-monitor.service:8) although it only needs loopback HTTP plus read access to one file \u2014 while the coordinator and gateway themselves run as the unprivileged macprovider user.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/coordinator.yaml.example:65-68",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py:56-62",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.service:6-10",
-    "/Users/augstar/macprovider-poc/phase5-gateway/dist/macprovider-gateway.service:7-12",
-    "/Users/augstar/macprovider-poc/phase5-gateway/dist/deploy-pearl-vps.md:6-11"
+    "phase4-coordinator/dist/coordinator.yaml.example:65-68",
+    "phase4-coordinator/dist/monitor/macprovider-monitor.py:56-62",
+    "phase4-coordinator/dist/monitor/macprovider-monitor.service:6-10",
+    "phase5-gateway/dist/macprovider-gateway.service:7-12",
+    "phase5-gateway/dist/deploy-pearl-vps.md:6-11"
    ],
    "why": "Acceptable at beta scale (0600, gitignored, root-only VPS), but the operator_key is the highest-blast-radius secret in the system (it authenticates the admin plane of BOTH services), and the plaintext laptop copy sits inside a worktree where AI agents operate constantly. The asymmetry also means anyone following the gateway pattern as the house style will be surprised by the coordinator. Cheap to converge now, annoying to converge after more providers join.",
    "suggestedFix": "Support env-indirection for auth.operator_key in the coordinator config (matching the gateway's env:NAME convention), move the value to /etc/macprovider/coordinator.env, drop the monitor to User=macprovider (or a dedicated user with group-read on the env file), and have the monitor read the key from the env file instead of regexing YAML.",
@@ -1631,9 +1631,9 @@
    "kind": "fact",
    "what": "git ls-files confirms 13 files under logs/ and 32 under results/ (curl outputs, tunnel logs, stress-test dumps dated 2026-05-26) are tracked. Everything else flagged as suspect is properly handled: default.profraw (5.3MB on disk) is ignored by .gitignore:34; phase3-binary/build-release/ (1.3GB) and .venv/ (241MB) exist on disk but have zero tracked files; the dist binaries, .bak, and the secret-bearing coordinator.yaml are explicitly ignored with a rationale comment (.gitignore:36-45). The only load-bearing tracked artifact is results/REPORT.md, which beta/harness.py references as the Phase 1 record.",
    "where": [
-    "/Users/augstar/macprovider-poc/.gitignore:1-45 (full coverage verified)",
-    "/Users/augstar/macprovider-poc/.gitignore:34 (default.profraw)",
-    "/Users/augstar/macprovider-poc/.gitignore:36-45 (dist binaries, .bak, secret config with rationale)"
+    ".gitignore:1-45 (full coverage verified)",
+    ".gitignore:34 (default.profraw)",
+    ".gitignore:36-45 (dist binaries, .bak, secret config with rationale)"
    ],
    "why": "Pure clutter, not risk: the raw logs bloat clones slightly and confuse new readers/agents about what is current ('06-tunnel.log' looks operational but is 2-week-old archaeology). Worth a 10-minute sweep, nothing more.",
    "suggestedFix": "Keep results/REPORT.md (move it to doc/ or specs/ as the Phase 1 record), `git rm -r` the raw logs/ and remaining results/ files, and add both directories to .gitignore. Delete the stale on-disk default.profraw while there.",
@@ -1654,10 +1654,10 @@
    "kind": "fact",
    "what": "README.md line 22 states 'Every response carries a signed receipt binding (prompt, output, provider) \u2014 verifiable inference'; line 57 claims the gateway performs 'receipt issuance'; lines 59-83 present a full v1 receipt JSON schema ('issued by the gateway and signed with the provider's key', fields: model, prompt_hash, output_hash, provider_id, provider_pubkey, ttft_ms, tokens_out, ts, sig) and three capability claims including 'a buyer can prove an inference happened... without trusting the gateway to be honest after the fact'. Grep for 'receipt' across phase5-gateway/**/*.go, phase4-coordinator/internal/**/*.go, and phase3-binary/Sources returns zero matches \u2014 there is no receipt issuance, signing, or verification code anywhere in the production stack (the only code matches are the legacy beta demo and the unrelated arm64golf benchmark-receipt UI in frontdoor/console/index.html:1350-1451). Meanwhile the LIVE buyer docs served by the gateway say the opposite: phase5-gateway/internal/router/templates/docs.md:119-124 (tier-1 disclosure) states 'There is no hardware attestation or runtime integrity check', 'The product makes NO privacy, attestation, integrity... claims', and item 4 explicitly mandates that 'Any buyer-facing language, including front-door copy... MUST be consistent with properties 1-3.' The README is exactly that front-door copy.",
    "where": [
-    "/Users/augstar/macprovider-poc/README.md:22",
-    "/Users/augstar/macprovider-poc/README.md:57",
-    "/Users/augstar/macprovider-poc/README.md:59-83",
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/templates/docs.md:119-124"
+    "README.md:22",
+    "README.md:57",
+    "README.md:59-83",
+    "phase5-gateway/internal/router/templates/docs.md:119-124"
    ],
    "why": "This is a live public beta with real buyers. The repo's public front page promises a cryptographic verifiability primitive the product does not deliver, while the deployed /docs page honestly disclaims it. A buyer who signed up on the receipt promise has been materially misled; a security researcher who notices will (correctly) frame it as a false cryptographic claim. It also violates the project's own SPEC-006 consistency rule, which the team otherwise enforces rigorously.",
    "suggestedFix": "Either move the receipt section under an explicit 'Roadmap \u2014 not yet implemented' heading (one-line edit preserving the schema as a design proposal), or delete lines 59-83 and soften lines 22/57 until receipts ship. Align with docs.md tier-1 disclosure language.",
@@ -1677,11 +1677,11 @@
    "kind": "fact",
    "what": "README.md:31 says providers 'Manage your node at console.streamvc.live' and README.md:35-40 lists console capabilities including 'Manage provider status and pool visibility' and 'Review billing and earnings'. The actual console (frontdoor/console/index.html) contains exactly three views \u2014 viewChat (line 493), viewDashboard (line 530), viewArm64golf (line 539). Grep over the file finds zero occurrences of 'earnings', 'payout', 'credits', 'billing', 'manage', 'pool visibility', or 'provider status'. Browser chat and pool monitoring are real; node management and billing review are not.",
    "where": [
-    "/Users/augstar/macprovider-poc/README.md:31",
-    "/Users/augstar/macprovider-poc/README.md:35-40",
-    "/Users/augstar/macprovider-poc/frontdoor/console/index.html:493",
-    "/Users/augstar/macprovider-poc/frontdoor/console/index.html:530",
-    "/Users/augstar/macprovider-poc/frontdoor/console/index.html:539-544"
+    "README.md:31",
+    "README.md:35-40",
+    "frontdoor/console/index.html:493",
+    "frontdoor/console/index.html:530",
+    "frontdoor/console/index.html:539-544"
    ],
    "why": "A provider who installs expecting to manage their node and review earnings at the console finds neither, eroding trust at exactly the moment the project is trying to recruit and retain N>3 providers. Same overclaim pattern as the receipts finding, on a softer axis.",
    "suggestedFix": "Trim README.md:35-40 to the two features that exist (browser chat, pool/dashboard monitoring) and mark management/billing views as planned.",
@@ -1701,13 +1701,13 @@
    "kind": "judgment",
    "what": "Root RUNBOOK.md:1-19 is the original Phase 1 falsifiability script addressed to 'a Codex agent executing Phase 1'; its operational content is obsolete: lines 157-172 instruct launching `python3 -m mlx_lm.server` on port 8080 (replaced by the Swift phase3-binary), line 33 references the antseed VPS 165.22.182.207 (production is Pearl 159.223.165.194 per phase4-coordinator/dist/deploy-pearl-vps.sh:18,26). CONTINUE_RUNBOOK.md:1-9 is its continuation pass, same era. HANDOFF.md:5-7 declares 'Status: Phase 1 PoC complete... Awaiting M4 user before going live' and names itself 'Next session entry point: This document' \u2014 frozen at 2026-05-26, four phases behind a live beta with a money path; HANDOFF.md:54 still describes Antseed as 'the initial billing/demand layer' when billing is now native. Actual ops knowledge (safe coordinator restart with the FORCE_RESTART provider-connected guard, settlement runs, monitor alert response, key rotation, gateway deploy) lives only in deploy-script comments, phase5-gateway/dist/deploy-pearl-vps.md, specs/ phase reports, and the 200KB beta/DECISION_CRITERIA.md decision log.",
    "where": [
-    "/Users/augstar/macprovider-poc/RUNBOOK.md:1-19",
-    "/Users/augstar/macprovider-poc/RUNBOOK.md:33",
-    "/Users/augstar/macprovider-poc/RUNBOOK.md:157-172",
-    "/Users/augstar/macprovider-poc/CONTINUE_RUNBOOK.md:1-9",
-    "/Users/augstar/macprovider-poc/HANDOFF.md:3-7",
-    "/Users/augstar/macprovider-poc/HANDOFF.md:54",
-    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:18-26"
+    "RUNBOOK.md:1-19",
+    "RUNBOOK.md:33",
+    "RUNBOOK.md:157-172",
+    "CONTINUE_RUNBOOK.md:1-9",
+    "HANDOFF.md:3-7",
+    "HANDOFF.md:54",
+    "phase4-coordinator/dist/deploy-pearl-vps.sh:18-26"
    ],
    "why": "This is a 2-person project with live users and live money. If the operator is unavailable during an incident \u2014 or returns after a gap \u2014 the documents whose names promise operational guidance point at an architecture that no longer exists (mlx_lm.server, cloudflared tunnels, the wrong VPS). Incident history in this beta (provider flapping, coordinator restarts, config drift) shows incidents are routine; recovery currently depends entirely on one person's memory plus a decision log that records 'why' but not 'how'.",
    "suggestedFix": "Rename RUNBOOK.md/CONTINUE_RUNBOOK.md to docs/history/PHASE1_*.md (or add a superseded banner like HANDOFF.md has), and write a 1-2 page OPS.md covering: production topology, safe coordinator/gateway restart, monitor alert response, settlement, and key rotation \u2014 most content already exists in deploy-script comments and can be lifted.",
@@ -1729,10 +1729,10 @@
    "kind": "fact",
    "what": "specs/README.md:1-8 (the entire file) indexes only SPEC-001 ('v1.1.1, Build-ready'), SPEC-002 ('v1.0.3'), and SPEC-005 ('v0.3'). The actual corpus has 176 files including 38 SPEC-* documents across 12 families (SPEC-001 through SPEC-012, verified by directory listing). Actual current versions: SPEC-001 v1.3 (SPEC-001-phase3-binary.md:3), SPEC-002 v1.3.5 (SPEC-002-coordinator.md:3), SPEC-006 v0.8.3 (SPEC-006-buyer-api.md:3). The project's whole methodology is version-pinned spec-driven development, making a stale index an active hazard rather than mere clutter.",
    "where": [
-    "/Users/augstar/macprovider-poc/specs/README.md:1-8",
-    "/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md:3",
-    "/Users/augstar/macprovider-poc/specs/SPEC-002-coordinator.md:3",
-    "/Users/augstar/macprovider-poc/specs/SPEC-006-buyer-api.md:3"
+    "specs/README.md:1-8",
+    "specs/SPEC-001-phase3-binary.md:3",
+    "specs/SPEC-002-coordinator.md:3",
+    "specs/SPEC-006-buyer-api.md:3"
    ],
    "why": "Humans and AI agents commissioning the next BUILD/AUDIT/FIX pass use the index to find the current normative baseline. Trusting it yields versions 5-6 revisions old, and the 9 unlisted spec families (router, buyer API, explorer, tier2, catalog, warm swap...) are undiscoverable except by directory listing. In a project where audits cite exact spec versions, this is how baseline drift starts.",
    "suggestedFix": "Regenerate the table to cover all 12 SPEC families with current version + status, and add one line of guidance ('version of record is line 3 of each spec'). ~15 minutes; consider a tiny script that greps line 3 of each SPEC-*.md.",
@@ -1752,11 +1752,11 @@
    "kind": "fact",
    "what": "CLAUDE.md:151-153 states 'v1.2.3 is the current phase3-binary release. SPEC-001 v1.2.2, SPEC-002 v1.1.3, SPEC-003 v0.5 are locked. SPEC-006 v0.2 is in regression-audit pending.' Actual: the shipped binary is 1.3.0 (phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:70 'static let binaryVersion = \"1.3.0\"'; git tag v1.3.0 exists), SPEC-001 is v1.3, SPEC-002 is v1.3.5, SPEC-006 is v0.8.3. AGENTS.md:3-6 directs ALL AI agents (Claude, Codex, Cursor) to read CLAUDE.md as the canonical rules document, so every coding session ingests these wrong baselines as ground truth.",
    "where": [
-    "/Users/augstar/macprovider-poc/CLAUDE.md:151-153",
-    "/Users/augstar/macprovider-poc/AGENTS.md:3-6",
-    "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:70",
-    "/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md:3",
-    "/Users/augstar/macprovider-poc/specs/SPEC-002-coordinator.md:3"
+    "CLAUDE.md:151-153",
+    "AGENTS.md:3-6",
+    "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:70",
+    "specs/SPEC-001-phase3-binary.md:3",
+    "specs/SPEC-002-coordinator.md:3"
    ],
    "why": "This project's development model is agent-executed, spec-pinned builds. An agent told SPEC-002 v1.1.3 is the locked baseline can write a FIX prompt, audit, or compatibility check against a contract that is four versions behind the code it sits next to. Given how much process discipline the team invests in version pinning, the agent-facing memory being wrong undermines exactly that discipline.",
    "suggestedFix": "Either update the version lines now and on each release, or (better) replace hardcoded versions in CLAUDE.md with a pointer: 'current versions of record: line 3 of each specs/SPEC-NNN-*.md and the binaryVersion constant \u2014 do not trust this file for versions.'",
@@ -1776,10 +1776,10 @@
    "kind": "judgment",
    "what": "Real providers accrue real credits through the ledger, and a provider-token-authenticated earnings endpoint exists (/providers/{id}/earnings, phase4-coordinator/internal/billing/endpoints.go:51-52), but no surface a provider can see documents any of it: frontdoor/console/index.html has zero matches for earnings/payout/credits/billing; phase3-binary/dist/install.sh has zero matches for earn/payout; phase3-binary/README.md (read in full, 51 lines) covers install and trust caveats only; README.md's sole mention of the provider lifecycle is one clause at line 55 ('can be promoted to pinned by the operator after observation') with no criteria. The earnings endpoint is referenced only in internal specs (SPEC-005 family). Liveness/reaping rules (silent providers reaped after the heartbeat-miss window; sleeping Macs flap) are similarly spec-internal \u2014 buyers get one sentence (docs.md:130 'provider availability can change as Macs sleep') and providers get nothing.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/billing/endpoints.go:43-56",
-    "/Users/augstar/macprovider-poc/README.md:55",
-    "/Users/augstar/macprovider-poc/phase3-binary/README.md:1-51",
-    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/templates/docs.md:130"
+    "phase4-coordinator/internal/billing/endpoints.go:43-56",
+    "README.md:55",
+    "phase3-binary/README.md:1-51",
+    "phase5-gateway/internal/router/templates/docs.md:130"
    ],
    "why": "Money disputes without documentation land on the operator and are unresolvable by reference ('what rate? what share? when do I get paid? why did my Mac drop from the pool?'). The project's own growth plan is recruiting benchmark golfers as sellers; the first question a prospective seller asks \u2014 what do I earn and under what rules \u2014 currently has no answer anywhere public. Provider flapping due to sleep has already been a real support burden in this beta, and a paragraph of provider-facing explanation would deflect most of it.",
    "suggestedFix": "Add a short 'Provider economics & lifecycle' section to phase3-binary/README.md (or a console page): credit formula in plain language, provider share, payout threshold/window, how to call /providers/{id}/earnings with the provider token, promotion criteria, and a note that the Mac must stay awake (the binary holds a sleep assertion, but lid-closed sleep still drops you).",
@@ -1799,11 +1799,11 @@
    "kind": "fact",
    "what": "Three independent stale pins: (1) README.md:137 'Current release: **[v1.2.5]**' \u2014 but the hyperlink target is /releases/latest and git tags include v1.3.0 (also commit 2ace6d6 'bump binaryVersion 1.2.6 \u2192 1.3.0'), so the text and its own link target disagree, and the shields.io badge at README.md:13 auto-displays the real latest, contradicting line 137 on the same page. (2) phase5-gateway/README.md:3 says 'Phase 5 gateway implementation for SPEC-006 v0.5' while SPEC-006-buyer-api.md:3 is v0.8.3. (3) SPEC-002-coordinator.md:4 declares 'Depends on: SPEC-001 v1.2.4 (locked)' while its own line 3/changelog says v1.3.5 absorbs 'SPEC-001 v1.3' \u2014 a self-contradiction within the otherwise rigorous spec header discipline.",
    "where": [
-    "/Users/augstar/macprovider-poc/README.md:13",
-    "/Users/augstar/macprovider-poc/README.md:137",
-    "/Users/augstar/macprovider-poc/phase5-gateway/README.md:3",
-    "/Users/augstar/macprovider-poc/specs/SPEC-002-coordinator.md:3-7",
-    "/Users/augstar/macprovider-poc/specs/SPEC-006-buyer-api.md:3"
+    "README.md:13",
+    "README.md:137",
+    "phase5-gateway/README.md:3",
+    "specs/SPEC-002-coordinator.md:3-7",
+    "specs/SPEC-006-buyer-api.md:3"
    ],
    "why": "Each instance is cosmetic alone, but together they show hardcoded version strings are never swept at release time. The README one is public-facing and visibly self-contradictory (badge says one version, text says another); the SPEC-002 depends-on pin could mislead an audit pass into checking compatibility against the wrong SPEC-001 revision.",
    "suggestedFix": "Drop the hardcoded version from README.md:137 (the badge and /releases/latest link already carry it); fix gateway README to v0.8.3; correct SPEC-002:4's depends-on line. Add 'grep for old version string' to the release checklist.",
@@ -1823,9 +1823,9 @@
    "kind": "judgment",
    "what": "phase5-gateway/README.md:26-41 gives a complete copy-paste local dev path (env vars, yaml example, test/run commands) plus smoke curls (43-55), deployment layout (64-92), and a troubleshooting table (104-113) \u2014 a contributor can build and run it from docs alone. phase3-binary/README.md:1-51 documents the installed product and dist/ files but contains no source-build instructions (no swift build/test invocation; buildable only by inferring SwiftPM conventions or reading dist/package.sh). phase4-coordinator/ has no README whatsoever (verified by directory listing: cmd, internal, dist, coordinator.yaml.example, go.mod \u2014 no markdown doc); its only documentation is SPEC-002 (a 1.3.5-version normative wire-contract spec, not a build/run guide) and an implementation-notes.html.",
    "where": [
-    "/Users/augstar/macprovider-poc/phase5-gateway/README.md:26-55",
-    "/Users/augstar/macprovider-poc/phase5-gateway/README.md:104-127",
-    "/Users/augstar/macprovider-poc/phase3-binary/README.md:1-51"
+    "phase5-gateway/README.md:26-55",
+    "phase5-gateway/README.md:104-127",
+    "phase3-binary/README.md:1-51"
    ],
    "why": "The coordinator is the largest component, holds the billing ledger and provider auth, and is the piece a second contributor (or future hire, or the other half of this 2-person team) would most need to run locally to be useful. Today that requires reverse-engineering main.go and coordinator.yaml.example. The gateway README proves the team can write this doc well \u2014 the gap is just that the hub never got one.",
    "suggestedFix": "Write a phase4-coordinator/README.md modeled on the gateway's: build (go build ./cmd/coordinator), minimal local config from coordinator.yaml.example, how to run with the mockprovider tool, the two-port layout (provider 8444 / buyer 8443), and the key test invocations. Half a day, mostly transcription.",

--- a/audits/2026-06-10/findings-raw.json
+++ b/audits/2026-06-10/findings-raw.json
@@ -1,0 +1,1891 @@
+{
+ "discovery": [
+  {
+   "key": "coordinator",
+   "area": "phase4-coordinator (Go 1.26 coordinator service)",
+   "purpose": "The coordinator is the hub of the MacProvider network: it terminates outbound WebSocket connections from provider Macs (admission, auth, heartbeats, liveness, warm-up gating), exposes an OpenAI-compatible buyer API (/v1/chat/completions, /v1/models) that routes requests to providers either over the WS tunnel or via HTTP forwarding to pinned endpoints, and writes the money path \u2014 a SQLite credit ledger (request credits, operator credits, payout windows, reconciliation runs) computed per request attempt. It also serves an operator explorer UI, admin/ledger endpoints, and tier-2 trust features (signed model-hash catalog, encrypted leg AEAD key exchange, device attestation).",
+   "entryPoints": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/cmd/coordinator/main.go \u2014 the service. Wires config -> stores -> ws.Server (provider port) + buyer.Server (buyer port); two http.Servers (main.go:138-172); signal loop with SIGHUP hot-reload of tier2/rewards config (main.go:176-208, 285-320); retention pruners for request_log and audit_log (main.go:215-273)",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/cmd/coordinator-cli/main.go \u2014 operator CLI: issue-token / revoke-token / list-tokens / revoke-and-kick against the same SQLite DB (main.go:16-38)",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/cmd/tier2-mda-artifact/main.go \u2014 offline tool to build Apple managed-device-attestation artifacts",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/tools/mockprovider/main.go \u2014 test mock provider",
+    "HTTP surfaces: provider port mux (main.go:140-152) = /ws/provider, /healthz, /poolz, /admin/* (ws/server.go:196-211), /internal/* (buyer InternalHandler), /admin/ledger/* + /providers/*/earnings (billing/endpoints.go:43-56), explorer at cfg.Explorer.BindPath; buyer port = /healthz, /v1/models, /v1/pool/check, /v1/chat/completions (buyer/server.go:350-357)"
+   ],
+   "keyModules": [
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/ws/server.go",
+     "role": "Provider WS lifecycle (1747 lines). Upgrade -> unauthenticated-conn semaphore (line 220-224) -> Bearer token validation (236-262) -> v1 'hello' or v2 'auth_request' handshake (296-304). v2 adds X25519 ECDH + AEAD negotiation + attestation challenge/proof with a bounded (1024) auth-attempt retention store (356-592). prepareProviderAdmission (594-690) enforces required binary version, pinned-vs-provisional tier, endpoint_url policy. readProviderLoop dispatches heartbeat/state_update/preflight_ack/inference chunks/NAK/drain_status (933-966). monitorHeartbeat reaps providers with no inbound frame past HeartbeatMissThreshold (1449-1485), using LastActivityAt (any frame counts, the v1.1.7 liveness fix). Warm-up gate sends a tiny real inference before marking ready (1018-1101)."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go",
+     "role": "In-memory provider registry (single RWMutex over maps keyed by providerID and assignedID). State machine ready/busy/degraded/draining/unavailable with two deliberately asymmetric guards: coordinator-initiated (line 354-362) vs provider-reported transitions (377-385) so a breaker-held provider cannot self-launder back to routable. Breaker fault windows (304-346), heartbeat application incl. SPEC-011 model-swap detection + audit emitter invoked under the registry lock (482-561)."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/buyer/server.go",
+     "role": "Buyer API (3183 lines). handleChatCompletions (840-1350) is the spine: body limit -> validateChatRequest -> Idempotency-Key reservation (998-1026) -> selectProvider (scoring, model classes, sticky sessions, epsilon tiebreak, provisional tier weight) -> three forwarding paths (WS streaming, WS non-streaming, HTTP forwarding 1246-1349) with retry/failover/breaker bookkeeping. logRowWithBilling closure (851-945) writes request_log + ledger atomically per attempt."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/ws/relay.go",
+     "role": "providerSession: per-provider writer goroutine with bounded channel (backpressure = ErrRelayBackpressure, relay.go:125-137), active request map, optional tier2 AEAD encryption of inference frames, RelayStream (Chunks/Done/Errors) consumed by buyer.forwardWS."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/billing/",
+     "role": "Money path. formula.go: integer credit math, ppm/bps fixed point, RoundHalfEven banker's rounding (54-81), overflow-checked mul/add, fault flags zero credits. hotpath.go WriteHotPath: BEGIN IMMEDIATE transaction inserting request_log row + ledger_request_credits + ledger_operator_credits + identity snapshot atomically; ambiguous attempt_n rows are quarantined with zeroed credits (55-89). store.go: full ledger schema with CHECK constraints and a trigger making payout status terminal (121-126). settlement.go RunSettlement: quarantine inconsistent rows, aggregate unsettled credits per provider over min-payout threshold into ledger_payout_ready, mark settled in same tx. endpoints.go: /admin/ledger/* (operator key) and /providers/{id}/earnings (provider token + rate limit)."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/auth/tokens.go",
+     "role": "Provider token store (SQLite provider_tokens): 32-byte random hex tokens stored as SHA-256 hashes, 12-char display prefix, revoke-by-prefix with ambiguity check (206-252). BearerTokenMatchesHeader does constant-time compare via sha256+hmac.Equal (41-55)."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/ws/admission.go",
+     "role": "Provisional-tier admission: per-hour admission rate, pool max, per-provider request quota; records persisted via AdmissionStateStore (SQLite) and reloaded on boot (38-63). Pinned providers bypass everything (78-81)."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/tier2/",
+     "role": "Tier-2 trust: catalog.go loads an ed25519-signed model-hash catalog into a package-global singleton (catalog.go:81-86); pillar_b (X25519/HKDF AEAD keys), pillar_c (behavioral safety: output caps, encoding validation, response-time anomaly), pillar_d (attestation verification)."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/requestlog/store.go",
+     "role": "request_log table + request_idempotency_keys (ReserveIdempotencyKey tx: replay returns prior request_id, body-hash mismatch returns ErrIdempotencyConflict, 137-178); shared *sql.DB handed to admission, billing, and explorer."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/explorer/handlers.go",
+     "role": "Operator console JSON API + embedded static UI (static.go go:embed). Operator-key auth on everything except static assets (46-73); proxies /buyers to the phase5 gateway; per-endpoint windowed queries against the shared SQLite."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/config/config.go",
+     "role": "Single YAML config (708 lines): listen/pool/routing/ws/admission/tier2/auth/storage/rewards/settlement/explorer/providers; Default() provides fallbacks that call sites re-apply defensively when fields are <=0."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/audit/store.go",
+     "role": "audit_log SQLite store for operator_model_swap events, emitted from pool.ApplyHeartbeat via the swapEmitter wired in main.go:94-114."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/providerhttp/client.go",
+     "role": "Package-global *http.Client for provider HTTP forwarding, timeout set once via Init() at startup (main.go:38); redirects disabled."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/sqliteutil/dsn.go",
+     "role": "DSN pragma helper (busy_timeout, foreign_keys, WAL, synchronous NORMAL) shared by all stores."
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/internal/testfaults/relay.go",
+     "role": "//go:build testfaults \u2014 build-tag-gated fault injection (dead-WS-mid-inference relay, slow reader) so production binaries cannot contain the fault paths."
+    }
+   ],
+   "dataFlow": "Provider side: Mac binary dials /ws/provider with Bearer token -> handshake (v1 hello or v2 ECDH+attestation) -> pool.Registry.Register (in-memory; replaces old conn) -> heartbeats update capacity/model/hash status; any inbound frame Touch()es liveness; monitorHeartbeat closes silent sockets; disconnect marks unavailable then removes after grace. Buyer side: POST /v1/chat/completions -> validate -> optional idempotency reservation (SQLite) -> selectProvider over Registry snapshot (model class, hash/tier2 eligibility, sticky, scoring) -> preflight for large prompts -> forward via WS relay (chunks streamed as SSE) or direct HTTP to pinned endpoint_url -> on completion logRowWithBilling computes credits (rate card x tokens, ppm multiplier, bps provider share) and writes request_log + ledger rows in one BEGIN IMMEDIATE tx; failure paths log with fault flags, trip breakers, and retry/failover to excluded-set candidates. Background: startup scan, nightly reconcile, weekly settlement aggregate unsettled credits into payout-ready windows; daily pruners enforce retention. State: provider pool, sticky map, breaker windows, auth attempts = memory; tokens, request log, idempotency keys, ledger, admission records, audit log = one SQLite file (multiple *sql.DB handles, WAL).",
+   "conventions": [
+    "Functional options pattern everywhere (buyer.With*, ws.Option, pool.RegistryOption); NewServer(cfg, deps, opts...)",
+    "zerolog structured logging: lowercase snake_case fields, lowercase messages, Warn for recoverable, Error/Fatal only in main; every WS close logged at Warn with close_code+reason (ws/server.go:817-822)",
+    "Errors returned up the stack; sentinel errors per package (ws.ErrRelayClosed/ErrRelayBackpressure/..., requestlog.ErrIdempotencyConflict); best-effort writes get `_ =`",
+    "Money math is integer-only with fixed-point ppm/bps, checked overflow, banker's rounding (billing/formula.go:54-81); SQLite schema carries CHECK constraints + UNIQUE keys + a terminal-status trigger as last-line invariants (billing/store.go:44-126)",
+    "Spec-citation comments are pervasive and load-bearing: code blocks reference SPEC-002 v1.3.5 \u00a7x.y / R-x.y.z requirement IDs and even locked test-oracle substrings (e.g. ws/server.go:489-501)",
+    "Config defaults re-applied defensively at call sites via config.Default() when a field is <=0 (ws/server.go:1496-1542)",
+    "Tests: stdlib testing only, no assertion libs; names like TestWriteHotPath_503_NoLedgerRows / TestWriteHotPath_ACID (billing/store_test.go); both internal (server_internal_test.go) and external test files; fault injection isolated behind //go:build testfaults",
+    "Auth pattern: operator endpoints gated by a single shared operator_key bearer token compared in constant time; provider tokens stored hashed (sha256) with show-once raw value from the CLI"
+   ],
+   "surprises": [
+    "fact \u2014 fail-open operator auth when operator_key is unset: ws/server.go:1717-1719 (`return s.cfg.Auth.OperatorKey == \"\" || ...`) opens /poolz, /admin/blacklist, /admin/promote etc.; same pattern in billing/endpoints.go:63 (`if h.operatorKey != \"\" && !auth...`) and auth/tokens.go:37-39 (AuthorizedBearer). Whether production is safe depends entirely on the deployed coordinator.yaml having a key set (local dist/coordinator.yaml is gitignored, so not verifiable from the repo).",
+    "fact \u2014 tier2 catalog state is a package-level global singleton (internal/tier2/catalog.go:81-86), mutated by tier2.Configure at startup and SIGHUP; pool and ws call tier2.VerifyProviderHash against it. Makes the package untestable in parallel and is an unusual choice next to the otherwise DI-heavy design.",
+    "fact \u2014 the SwapEventEmitter is invoked while Registry.mu is held, and the contract is enforced only by comment: pool/provider.go:445-457 explicitly warns a callback that re-enters the Registry deadlocks, and a panic crashes the heartbeat handler. main.go:94-111 wires a SQLite write into it (best-effort, but still I/O under the global pool lock on every completed swap heartbeat).",
+    "fact \u2014 three separate *sql.DB handles are opened on the same SQLite file (auth.OpenStore main.go:47, requestlog.OpenStore main.go:53, audit.OpenStore main.go:59) while billing/admission share the requestlog handle (main.go:65-74). Works under WAL+busy_timeout but means cross-store transactions are impossible and lock contention shows up as busy errors.",
+    "fact \u2014 durable-log-before-respond on the money path: if the post-success billing/request-log write fails, the buyer gets HTTP 500 `request_log_failed` even though the provider already did the inference (buyer/server.go:1286-1290); a one-shot fallback write (WriteRequestLogWithIdentity) softens hot-path failures at buyer/server.go:929-937 so billing can be recovered by reconcile later.",
+    "fact \u2014 billing attempt_n is partly derived from `SELECT COUNT(*) FROM request_log WHERE request_id = ?` inside the hot-path transaction (billing/hotpath.go:55-88); mismatched derivations are written as quarantined zero-credit rows with reason `ambiguous_attempt_n` rather than rejected \u2014 deliberate quarantine-don't-lose design, but it means quarantine volume is a metric someone must watch.",
+    "fact \u2014 v1 (plaintext hello) and v2 (encrypted/attested auth_request) provider protocols are both live in the same handler (ws/server.go:296-304); v1 is only blocked when tier2.RequireEncryptedLeg is set (ws/server.go:320-323), so the security posture of the provider leg is config-dependent, not code-dependent.",
+    "judgment \u2014 buyer-side /v1/chat/completions has no buyer authentication at all in the coordinator (buyer/server.go:350-357 registers no auth middleware); the design clearly assumes phase5-gateway is the only client plus network isolation (bind_address default 127.0.0.1, config.go:229). Anyone auditing exposure should verify the buyer port is not directly reachable from the internet.",
+    "fact \u2014 handleChatCompletions is a 510-line function (buyer/server.go:840-1350) with three near-duplicate retry/failover loops (stream-WS, non-stream-WS, HTTP); correctness currently relies on the large internal test suite rather than structure."
+   ]
+  },
+  {
+   "key": "gateway",
+   "area": "phase5-gateway \u2014 buyer-facing OpenAI-compatible API gateway (api.streamvc.live)",
+   "purpose": "Go (stdlib-only HTTP) service that sits between buyers and the phase4 coordinator. It owns buyer identity (GitHub OAuth signup, API keys, demo tokens), token quotas/concurrency limits with reserve-settle-refund accounting in SQLite, and proxies /v1/chat/completions and /v1/models to the coordinator's buyer URL. It also serves the /account and /docs HTML pages, an operator admin plane (kill switch, capacity tiers, feedback summary, explorer), and a buyer-anonymized /v1/status aggregated from the coordinator's /poolz. Notably, despite the project's \"signed inference receipts\" pitch, there is NO receipt issuance/verification code anywhere in this module (grep for \"receipt\" across phase5-gateway/*.go returns zero hits; same for phase4-coordinator/internal and phase3-binary/Sources) \u2014 receipts are aspirational, not implemented here.",
+   "entryPoints": [
+    "/Users/augstar/macprovider-poc/phase5-gateway/cmd/gateway/main.go:19 \u2014 main(): flags -config (gateway.yaml) and -check (migrate-and-exit); opens sqlite store, builds router.New(...), starts HTTP server with graceful shutdown",
+    "/Users/augstar/macprovider-poc/phase5-gateway/cmd/gateway/main.go:49,96-121 \u2014 background reservation reaper goroutine (hourly default) expiring stale quota reservations",
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/server.go:134-164 \u2014 Handler(): full route table (auth/*, /account, /docs, /v1/*, /healthz, /admin/*, optional /admin/explorer/*)",
+    "/Users/augstar/macprovider-poc/phase5-gateway/dist/ \u2014 deploy surface: gateway-linux-amd64 binary, macprovider-gateway.service systemd unit, nginx-api.streamvc.live.conf, deploy-pearl-vps.md"
+   ],
+   "keyModules": [
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/server.go",
+     "role": "2495-line monolith: middleware (request-ID, panic recovery, internal-header stripping at 166-195), GitHub OAuth start/callback (197-330), signup with per-IP rate limit + capacity gate (332-371), demo sessions (373-403), API key rotate/revoke (405-451), /v1/models + tier1/tier2 trust disclosure synthesis (453-490, 887-1249), chat-completions proxy with quota reserve/settle/refund and SSE streaming (1251-1712), /v1/status poolz aggregation with anonymization (1809-1978), admin kill-switch/capacity handlers (696-815), operator bearer auth (2061-2090), client-IP trusted-proxy logic (2270-2296)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/auth/keys.go",
+     "role": "API key lifecycle: keys are 'mp_' + base64url(32 random bytes); stored only as HMAC-SHA256 (or plain SHA256) hash + 12-char display prefix (lines 38-71); Validate looks up by hash. RandomID/StateToken helpers"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/auth/oauth.go",
+     "role": "GitHub OAuth code exchange (50-106): token POST then /user fetch; scope allowlist enforced (read:user, user:email only \u2014 108-119); 10-min state expiry (134-136)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/auth/demo.go",
+     "role": "Demo tokens: HMAC-SHA256-signed JSON payload bound to client IP (IPv6 normalized to /64, lines 79-88), max 24h TTL, no DB row \u2014 stateless validation (46-71)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/types.go",
+     "role": "All storage structs: Account, APIKey, OAuthState (with single-use Action field, 50-64), quota ReservationRequest/Settlement, UsageEvent, FeedbackEvent, AuditEvent, CapacityTier, KillSwitchState, Explorer* DTOs"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/interfaces.go",
+     "role": "Role-segregated store interfaces (AuthStore, UsageStore, CapacityStore, ExplorerStore...); router.Server.Store composes seven of them (server.go:62-70)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/store.go",
+     "role": "SQLite (modernc, CGO-free) store: single connection (SetMaxOpenConns(1), line 38), WAL + busy_timeout pragmas, hand-rolled BEGIN IMMEDIATE transactions (immediateTx, 880-926) for quota reserve/settle/refund and concurrency acquire/release; atomic ConsumeOAuthState (328-356)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/migrate.go",
+     "role": "Single schemaSQL string: 14 tables incl. accounts, api_keys, oauth_states, quota_reservations, concurrency_reservations, usage_events, audit_events, runtime_config; append-only enforced by RAISE(ABORT) triggers on usage/feedback/audit/api_key/demo/capacity/signup event tables (184-251)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/explorer.go",
+     "role": "Read-only operator explorer queries (buyers, sessions, activity feed, health rollups) backing /admin/explorer/*"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/config/config.go",
+     "role": "YAML config with hardcoded production defaults (Default() at 132-177: api.streamvc.live, coordinator on localhost 8443/8444, 100k daily tokens, 4096 max_tokens); 'env:NAME' secret indirection (195-208); strict fail-closed Validate() (210-329)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/pages.go",
+     "role": "/account (show-once API key from mp_new_api_key cookie, CSP nonce, embedded html template) and /docs (goldmark-rendered embedded markdown). tier1DisclosureText hardcodes the honest no-privacy/no-attestation claims (27-44)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/cors.go",
+     "role": "Exact-origin CORS allowlist (console.streamvc.live, streamvc.live by default), credentials=false, applied per-route via withCORS"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/explorer.go",
+     "role": "Operator-only explorer HTTP handlers: window/cursor parsing, 3s query timeout, limit cap 200"
+    }
+   ],
+   "dataFlow": "Buyer request \u2192 middleware (assigns/validates X-Request-ID, strips X-MacProvider-Internal-* headers with audit, checks AllPublicAPI kill switch) \u2192 authenticateAny: X-Demo-Token (HMAC, IP-bound) else Bearer API key (HMAC-SHA256 hash lookup joining accounts; rejects revoked key / blocked account, server.go:2184-2208). For chat completions: body capped (1MB default) \u2192 ReserveQuota inserts an 'active' quota_reservations row for max_tokens against the UTC-day window inside BEGIN IMMEDIATE \u2192 AcquireConcurrency (non-demo only) \u2192 proxy POST to coordinator BuyerURL forwarding only Accept/X-MacProvider-Retry/Idempotency-Key plus a fresh internal X-Request-ID; if sticky routing is on, the gateway attaches the coordinator OPERATOR bearer plus HMAC-derived conversation key (server.go:1401-1405). Response: non-stream bodies capped at 16MB and usage validated against max; streams re-emitted line-by-line, parsing usage chunks. Settlement (provider_reported or gateway_estimated bytes/4) updates the reservation and appends an immutable usage_events row; every failure path refunds. Admin plane and explorer authenticate with the shared coordinator operator key.",
+   "conventions": [
+    "Errors: every response uses the OpenAI envelope {error:{message,type,code}} via writeError(w, status, type, code, msg) (server.go:2304-2306); snake_case machine codes like 'quota_exhausted', 'oauth_state_invalid'",
+    "Logging: stdlib log/slog key-value pairs; one summary log line per chat completion via statusWriter wrapper (server.go:1251-1270, 2233-2261); no zerolog here (unlike phase4-coordinator)",
+    "Secrets never stored raw: API keys hashed (HMAC-SHA256), OAuth state stored as SHA-256 hash, demo tokens stateless HMAC; show-once delivery via short-lived HttpOnly cookie + Cache-Control no-store",
+    "Money-adjacent invariants enforced in BOTH layers: usage token sanity (non-negative, sum check, max cap) validated in router (usageFromJSON, server.go:2329-2371) and again in store (normalizeSettlementTokens, store.go:646-663); append-only triggers as third backstop",
+    "SQLite discipline: single connection, WAL, BEGIN IMMEDIATE for read-modify-write, RFC3339Nano TEXT timestamps, in-place column migration via PRAGMA table_info (store.go:75-103)",
+    "Tests: extensive table-driven _test.go beside every file (server_test.go is 2522 lines, larger than the source); fake stores via the segregated interfaces; raceflag test files for -race builds",
+    "Config: fail-closed Validate() rejects wildcard CORS, missing secrets, non-positive limits; 'env:VAR' indirection for secrets so YAML can be committed",
+    "Audit trail: InsertAuditEvent for security-relevant events (oauth_scope_rejected, kill_switch_toggled, api_key_minted_via_oauth, internal_header_injection_stripped) \u2014 errors deliberately ignored with _ =",
+    "Comments cite spec IDs (SPEC-004 audit findings, SPEC-006 v0.8 \u00a75.6, G3 guardrail) \u2014 code-to-spec traceability is a house norm"
+   ],
+   "surprises": [
+    "fact \u2014 No receipts anywhere: 'signed inference receipts' (project pitch) have zero implementation in the gateway; grep for 'receipt' over phase5-gateway/**/*.go, templates/docs.md, README.md, and also phase4-coordinator/internal and phase3-binary/Sources returned no matches. Severity: Medium (marketing/spec vs code drift, not a runtime bug).",
+    "fact \u2014 Single shared secret for two planes: the gateway's own admin endpoints (/admin/kill-switch, /admin/explorer/*, /admin/capacity-*) authenticate against cfg.Coordinator.OperatorKey (server.go:2061-2067), the same token used as upstream credential to the coordinator's operator API (server.go:1821, 1229). Compromise of either service's config exposes both planes. Severity: Medium for a 2-person beta.",
+    "fact \u2014 Buyer chat requests can carry the operator bearer upstream: when sticky routing is enabled, the gateway sets Authorization: Bearer <operator_key> on the proxied /v1/chat/completions request (server.go:1401-1405), elevating a buyer-path request to operator-authenticated at the coordinator. Judgment: intentional (sticky headers require it) but it widens the operator-key blast radius to the hottest code path.",
+    "fact \u2014 Demo users bypass the concurrency limiter: AcquireConcurrency is wrapped in `if !authn.Demo` (server.go:1362-1381), so demo traffic is bounded only by daily demo tokens per IP, not concurrency. Severity: Low (demo max_tokens=512 caps damage).",
+    "fact \u2014 POST /auth/api-keys is a rotation, not a creation: it revokes the authenticating key and issues a replacement in one transaction (server.go:405-425; RotateAPIKey store.go:273-311); fresh additional keys are only mintable via the OAuth ?action=mint flow (server.go:301-328). Judgment: deliberate (comments explain), but surprising vs the endpoint name.",
+    "fact \u2014 GetCapacityTier parses its JSON value with fmt.Sscanf format string `{\"tier\":%d,\"signals\":%q}` (store.go:767) instead of json.Unmarshal \u2014 brittle if the writer format ever changes (writer at store.go:778 must stay byte-compatible).",
+    "fact \u2014 Gateway-estimated billing is bytes/4: when the provider omits usage, completion tokens are estimated as ceil(emitted_SSE_bytes/4) and prompt as ceil(request_body_bytes/4) (server.go:1604, 1611, 2385-2390) \u2014 the request-body estimate includes JSON envelope overhead, systematically overcounting prompt tokens for quota purposes. Severity: Low at current scale; matters when quota = money.",
+    "fact \u2014 Kill switch pauses everything public except /admin/, /v1/status, /healthz (server.go:2092-2099) \u2014 including /account and /auth/github/callback, so an account-page visit mid-pause loses the show-once key cookie window. Severity: Low.",
+    "judgment \u2014 Code quality is well above PoC norm for the money path: reserve\u2192settle\u2192refund covers every branch I traced (including client-disconnect-during-stream at server.go:1554-1592 and commit-boundary races at 1345-1360), with append-only SQL triggers as a tamper backstop (migrate.go:184-251)."
+   ]
+  },
+  {
+   "key": "binary",
+   "area": "phase3-binary (Swift provider CLI)",
+   "purpose": "phase3-binary is the Swift 6 CLI (`macprovider-cli`) that runs on provider Macs and turns them into MLX inference endpoints. It loads an MLX model, serves an OpenAI-compatible HTTP API on localhost, maintains an outbound WebSocket session to the coordinator (tier-2 encrypted by default), relays coordinator-tunneled inference requests to the MLX runtime, and handles signed self-update, operator-driven warm model swaps over a Unix control socket, and managed-device attestation. SwiftPM package with two targets: `MacProviderCore` (pure library: config, request parsing, stop-token filter, model catalog) and the `macprovider-cli` executable (Package.swift lines 41-68, platform macOS 14, StrictConcurrency enabled).",
+   "entryPoints": [
+    "@main MacProviderCLI with subcommands serve (default), self-test, status, update, uninstall, models \u2014 /Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:7-16",
+    "ServeCommand.run() \u2014 the long-running provider daemon path \u2014 /Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:88-172",
+    "UpdateCommand.run() \u2192 SelfUpdate.run(checkOnly:) \u2014 /Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:228-246",
+    "models list/switch/status subcommands talking to the control socket \u2014 /Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:5-55",
+    "Acceptance/ops harness: /Users/augstar/macprovider-poc/phase3-binary/scripts/ (run-acceptance.sh, test-ac11..15.sh, soak-test.sh, harness-*.sh) and mock coordinator at /Users/augstar/macprovider-poc/phase3-binary/tools/mock-coordinator/mock_coordinator.py",
+    "Install/relaunch shell surface for partner Macs: /Users/augstar/macprovider-poc/phase3-binary/dist/install.sh, relaunch-m1.sh, relaunch-m4.sh, launchd-plist-template.plist"
+   ],
+   "keyModules": [
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift",
+     "role": "CLI entry; ServeCommand wires Config \u2192 ModelRuntime \u2192 ProviderStatus \u2192 CoordinatorClient \u2192 optional ControlSocketServer \u2192 HTTPServer; installs SIGTERM/SIGINT drain handlers (lines 248-265)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/MacProviderCore/Config.swift",
+     "role": "AppConfig + ConfigLoader; precedence defaults < YAML (~/.config/macprovider/config.yaml) < MACPROVIDER_* env < CLI flags (lines 139-161); typed assign() validators"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift",
+     "role": "Actor owning the coordinator WS session: reconnect loop w/ 1\u219260s exponential backoff (189-221), tier-2 auth handshake (251-276), heartbeat task w/ WS ping (505-524), preflight acks (536-578), drain flows (580-625), caffeinate sleep assertion (33-65); holds binaryVersion = \"1.3.0\" (line 70)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/Tier2ProviderSession.swift",
+     "role": "Tier-2 crypto: X25519 ECDH + HKDF-SHA256 directional keys, transcript-bound keyID (58-96); AES-256-GCM seal/open with strict per-direction seq counters, deterministic nonce = 4-byte base + 8-byte BE seq, AAD binding type/direction/request_id/stream/provider_id/assigned_id/seq (104-189, 259-304, 363-385)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift",
+     "role": "Actor relaying coordinator inference_request frames to ModelRuntime; enforces encrypted frames in tier-2 (50-60), duplicate-id NAK, queue-full and body-size end frames (68-93); streaming via BlockingChunkBuffer backpressure (capacity 256 / resume 128, lines 303, 616-681); emits OpenAI SSE chunks wrapped in WS frames"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift",
+     "role": "Actor over MLX (LLMModelFactory/ModelContainer): synchronous boot load (99-118), AsyncSemaphore(1) inference gate (56), complete/stream with stop-token + request-stop filtering and streaming-safe holdback (659-714), prompt-length 413 enforcement (534-544), warm-swap state machine ready\u2192loading\u2192draining\u2192ready (167-262), safetensors manifest SHA-256 model hash (609-640)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/HTTPServer.swift",
+     "role": "SwiftNIO HTTP/1.1 server bound to 127.0.0.1 only (line 36); routes GET /v1/models, /v1/health, /v1/status, POST /v1/chat/completions (116-135); SSE streaming; every response sends connection: close (509, 585)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift",
+     "role": "Signed self-update: pinned repo api.github.com/repos/Augustas11/macprovider (line 6), embedded P-256 key verifies checksums.txt.sig before tarball download (7-12, 73-82, 258-270), HTTPS host allowlists (232-245), tar path-traversal check (247-256), runs new binary self-test (90), atomic rename + launchd restart (166-219)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ControlSocket.swift",
+     "role": "Warm-swap control plane: Unix socket (default $TMPDIR/macprovider-cli/ctl.sock, 178-186) created 0600 in 0700 dir (254-281), refuses stale socket; JSON-lines codec, 64KB frame cap (544); frames switch_request/status_request/switch_ack/switch_progress/status_response (19-25); switch validated against supported_models (439-455)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/Tier2Attestation.swift",
+     "role": "ManagedDeviceAttestationGenerator: reads MDA ACME artifact JSON from configured path, builds attestation token envelope with hardware/RAM/model claims and optional ES256 binding signature with Go-compatible JSON escaping (187-308); returns nil with WARN if artifact absent \u2014 attestation is optional"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ProviderStatus.swift",
+     "role": "Actor tracking health state, in-flight counts, per-heartbeat metrics window; ProviderCapacity maps RAM tiers to context caps 20k/50k/120k/200k (24-37); waitUntilDrained polling (213-222)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/Sources/MacProviderCore/SupportedModels.swift",
+     "role": "Catalog validation: CSV parse, 256-byte entry / 64-entry caps, case-insensitive model-in-catalog check (38-73)"
+    }
+   ],
+   "dataFlow": "serve resolves config, synchronously loads the MLX model, then opens an outbound WSS to the coordinator. Default mode is WS-tunneled tier-2: auth_request (X25519 pubkey + capabilities) \u2192 auth_challenge \u2192 Tier2ProviderSession key derivation \u2192 proof with optional MDA attestation \u2192 auth_response with encrypted_leg verification. The coordinator then pushes inference_request frames; InferenceRelay decrypts (AES-GCM, seq/AAD-checked), parses the OpenAI chat body, and runs it through ModelRuntime behind a single-permit semaphore. Streaming tokens flow through a bounded BlockingChunkBuffer into encrypted inference_response_chunk frames, terminated by inference_response_end with usage. In parallel, a NIO HTTP server serves the same OpenAI API on 127.0.0.1 for direct/tunneled buyers. Heartbeats (WS ping + JSON) carry status, capacity, and windowed metrics; failures close the WS and trigger reconnect with backoff. Warm swap (opt-in) loads the new model, drains in-flight, swaps atomically, reporting progress over the control socket and a fresh heartbeat.",
+   "conventions": [
+    "Concurrency: actors everywhere (CoordinatorClient, ModelRuntime, InferenceRelay, ProviderStatus, ControlSocketServer/Connection); shared mutable classes are @unchecked Sendable guarded by NSLock/NSCondition (DrainCancelToken ModelRuntime.swift:722, RelayRequestState InferenceRelay.swift:537, BlockingChunkBuffer:616); StrictConcurrency experimental feature on both targets (Package.swift:48-50,65-67)",
+    "Wire protocol is hand-built [String: Any] dictionaries via JSONSerialization with snake_case keys \u2014 not Codable \u2014 on both WS and control-socket legs; NSNull() for explicit nulls (e.g. CoordinatorClient.swift:755, HTTPServer.swift:462-464)",
+    "Test seams via dependency-injection closures (webSocketFactory, sleepAssertionFactory, sendOverride, connectAndRunOverride in CoordinatorClient.swift:100-110; loader/testLoader/testCompletion in ModelRuntime.swift:120-142; readFile in Tier2Attestation.swift:30) plus explicit `...ForTest` methods (CoordinatorClient.swift:231,391,396; Tier2ProviderSession.swift:98,191)",
+    "Errors are enums conforming to Error + CustomStringConvertible + often Equatable (UpdateError SelfUpdate.swift:353, ControlSocketError, Tier2ProviderError, ConfigError); buyer-facing errors use APIError with OpenAI-style envelope (status/type/code)",
+    "Spec-traceable comments citing SPEC-001/002/008/010/011 with versions and section numbers (e.g. MacProviderCLI.swift:45-61, CoordinatorClient.swift:117-120, 600-606; key-derivation info strings embed spec paths Tier2ProviderSession.swift:91-94)",
+    "Config precedence CLI > env > YAML > defaults, every key triple-exposed (flag, MACPROVIDER_* env, yaml key) (Config.swift:139-250)",
+    "Logging is plain print()/stderr writes, no swift-log usage in practice despite the dependency; opt-in keepalive debug via MACPROVIDER_KEEPALIVE_DEBUG=1 to stderr (CoordinatorClient.swift:71, 829-833)",
+    "Tests: XCTest in Tests/macprovider-cliTests (17 files, ~4,264 LOC total), @testable import macprovider_cli, security-regression style tests (SelfUpdateTests.swift:7-32 pin the release repo URL and reject untrusted overrides); black-box acceptance via bash scripts in scripts/ and a Python mock coordinator in tools/mock-coordinator/"
+   ],
+   "surprises": [
+    "fact: dead branch in legacy connect path \u2014 connectAndRunLegacy's `if wsTunneledMode { inferenceRelay = ... }` (CoordinatorClient.swift:280-291) can never be true because connectAndRun only calls it when wsTunneledMode is false (CoordinatorClient.swift:235-241); legacy (endpoint_url) mode therefore never constructs an InferenceRelay, by design or leftover",
+    "fact: advertised max_concurrency is hardcoded to 1 regardless of RAM tier (which would default up to 8) because MLX generation is gated by a process-local semaphore of 1 \u2014 explicit comment at MacProviderCLI.swift:118-124, gate at ModelRuntime.swift:56",
+    "fact: /v1/health and /v1/status report \"memory_rss_mb\" from ru_maxrss, which is peak RSS, not current RSS (ProviderStatus.swift:231-237) \u2014 this is the root of the previously-noted soak-test AC-3 'memory growth' measurement caveat",
+    "fact: ProviderStatus.modelLoaded is an immutable `let` set at boot (ProviderStatus.swift:105,122-128); after a warm swap it is never updated, so coordinator preflight 'model_not_loaded' rejection (CoordinatorClient.swift:556-562) always reflects boot-time state (heartbeats compensate by overriding model_id from the runtime snapshot when warmSwapEnabled, CoordinatorClient.swift:644-651)",
+    "fact: heartbeat interval is coordinator-controlled with a floor of 1s (CoordinatorClient.swift:484: max(interval, 1)) \u2014 a misbehaving coordinator could request 1Hz heartbeats",
+    "fact: SelfUpdate verifies checksums.txt + its ECDSA signature BEFORE downloading the tarball, then executes the downloaded binary's `self-test` before atomic replace (SelfUpdate.swift:73-91) \u2014 strong ordering, but sha256(file:) loads the whole tarball into memory (SelfUpdate.swift:309-313) while model hashing streams in 1MB chunks (ModelRuntime.swift:642-653)",
+    "judgment: drainAndExit calls Darwin.exit(0) from inside the actor after the drain sequence (CoordinatorClient.swift:580-594), so HTTPServer/NIO shutdown is skipped on SIGTERM \u2014 acceptable for a launchd-managed daemon but worth knowing",
+    "fact: dist/ ships ~10 historical release tarballs (v1.1.2 through v1.2.6) checked into the repo alongside install/relaunch scripts (ls of /Users/augstar/macprovider-poc/phase3-binary/dist)",
+    "fact: Tier2 attestation degrades silently to nil (token omitted) with only a WARN print when the MDA artifact path is unset or invalid (Tier2Attestation.swift:51-84) \u2014 tier assignment is thus entirely coordinator-side policy"
+   ]
+  },
+  {
+   "key": "ops",
+   "area": "Operational surface: beta/ harness + cron, scripts/ (release signing + tier-2 ops), frontdoor/ (console + install front door), .github/workflows/release.yml, phase4-coordinator/dist+scripts, phase5-gateway/dist",
+   "purpose": "This is the deploy/upgrade/monitoring layer of MacProvider. Provider Macs get the Swift binary via a curl-pipe-bash installer chain (get.streamvc.live -> raw GitHub main -> signed GitHub Releases built by the one CI workflow). The coordinator and console are pushed from the operator's laptop to a single root-SSH VPS (159.223.165.194 \"Pearl\") by idempotent bash deploy scripts; the gateway is deployed by hand from a markdown runbook. Monitoring is a 3-minute systemd-timer Python poller on the VPS plus an operator-side cron harness that fires synthetic buyer traffic through the production coordinator every 15 minutes.",
+   "entryPoints": [
+    "/Users/augstar/macprovider-poc/phase3-binary/dist/install.sh \u2014 public provider installer served at get.streamvc.live/install.sh (828 lines; main() at lines 766-826)",
+    "/Users/augstar/macprovider-poc/.github/workflows/release.yml \u2014 the ONLY CI workflow; builds/signs/publishes the darwin-arm64 provider binary on v*.*.* tag push or workflow_dispatch",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh \u2014 coordinator deploy: scp binary+config to root@159.223.165.194, systemd + nginx + certbot (9 steps, idempotent)",
+    "/Users/augstar/macprovider-poc/frontdoor/console/dist/deploy-console.sh \u2014 console.streamvc.live static-site deploy incl. Cloudflare DNS record creation",
+    "/Users/augstar/macprovider-poc/phase5-gateway/dist/deploy-pearl-vps.md \u2014 gateway deploy is a MANUAL runbook, no script",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py \u2014 Pearl-side observability poller, run by macprovider-monitor.timer every 3 min",
+    "/Users/augstar/macprovider-poc/beta/CRON_TEMPLATE.txt \u2014 operator-M1 crontab: coord-cooperative.sh every 15 min 9am-10pm, coord-adversarial.sh daily 16:00 (lines 31, 40)",
+    "/Users/augstar/macprovider-poc/beta/harness.py \u2014 synthetic buyer harness writing per-request metrics to beta/runs.sqlite",
+    "/Users/augstar/macprovider-poc/scripts/activate-tier2-*.sh + enforce-tier2-hash.sh \u2014 guarded --plan/--apply production config flips (SSH + single-key YAML edit + SIGHUP + verify + auto-rollback)",
+    "/Users/augstar/macprovider-poc/phase3-binary/dist/package.sh \u2014 operator-side release build (xcodebuild Release + tarball of binary + Metal .bundle dirs)"
+   ],
+   "keyModules": [
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/dist/install.sh",
+     "role": "Provider onboarding: platform gate (Darwin arm64, macOS>=14), RAM-tiered model pick, fetch latest GitHub Release, openssl signature-verify checksums.txt against embedded P-256 public key (lines 396-413), SHA-256 verify, tarball-path safety validation (lines 425-452), install real binary + .bundle dirs to ~/macprovider with ~/.local/bin symlink (Metal bundle adjacency, lines 484-504), quarantine clear after prompt (lines 534-546), launchd plist render+bootstrap, 5/20-min model self-test, coordinator /v1/pool/check"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/.github/workflows/release.yml",
+     "role": "Release CI: macos-15 runner, pinned actions/checkout SHA (line 25), package.sh build, tier-2 artifact preflight (skipped for pre-v1.2.6 tags, lines 68-73), signs checksums.txt with MACPROVIDER_RELEASE_SIGNING_KEY_PEM secret then deletes the key file (lines 96-99), gh release create, post-publish verify-tier2-provider-release.sh"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh",
+     "role": "Coordinator deploy from laptop: step-0 config-drift gate, root SSH to hardcoded VPS_HOST=159.223.165.194 (lines 25-27), installs /opt/macprovider/coordinator + 0600 coordinator.yaml, stub-then-full nginx for ACME, refuses restart with connected providers unless FORCE_RESTART=1 (lines 143-160), verifies /v1/models returns 404 on coordinator host (lines 177-182)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/dist/check-deploy-config.sh",
+     "role": "Pre-deploy gate: hard-fails placeholder/non-64-hex operator_key (lines 37-46), heartbeat_miss <= heartbeat_interval (lines 49-57), warns on C2 coordinator-vs-gateway timer ordering (lines 62-72)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py",
+     "role": "Only production alerting: polls loopback /healthz, /poolz (bearer = operator_key regex-parsed from coordinator.yaml, lines 56-62), gateway /v1/status; transition-based alerts (pool ready==0 CRITICAL, provider degraded/unavailable WARN, lines 131-157); journald always + Gmail app-password email if /etc/macprovider/monitor.env configured (lines 174-195)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase5-gateway/dist/nginx-api.streamvc.live.conf",
+     "role": "Public buyer edge: rate/conn-limit zones (lines 10-12), blanks client-supplied internal affinity headers (lines 58-59), explicit 404 for /admin/, /poolz, /v1/pool/check (lines 46-49, 106-114), /ws/provider proxied to coordinator 8444 with 10r/m + 5-conn limits (lines 124-134)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/scripts/sign-catalog.go",
+     "role": "Tier-2 model-catalog signer/verifier: Ed25519 over canonical JSON body (lines 305-314), strict catalog validation (expiry, dup model ids, 64-hex sha256, hash_scope whitelist, lines 231-279), keygen writes 0600 private key (lines 90-99)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/scripts/hash-model-weights.go",
+     "role": "Produces catalog entries: sorted manifest of .safetensors files (name+sha256+size) hashed as canonical JSON (lines 74-113); derives model id from HF cache models--org--repo path (lines 129-142)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/frontdoor/console/dist/deploy-console.sh",
+     "role": "Console deploy: Cloudflare API DNS-record creation from ~/.config/macprovider/cloudflare-api-token (lines 65-92), certbot webroot, static /var/www/console install"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/frontdoor/console/dist/nginx-console.streamvc.live.conf",
+     "role": "Console vhost: strict CSP connect-src limited to api.streamvc.live (line 27), 5-min cache"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/beta/web/api/chat.js",
+     "role": "Legacy Vercel demo proxy \u2014 kill-switched: returns 410 unless MACPROVIDER_ENABLE_LEGACY_BETA_PROXY=1 (lines 21-23)"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/beta/DECISION_CRITERIA.md",
+     "role": "Decision log: 344-line doc with locked pre-launch facts, day-2/day-3 go-no-go gates, hard/soft-stop triggers, and an append-only '## Decision log' table (line 248) \u2014 the project's operational memory"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/phase3-binary/dist/relaunch-m4.sh",
+     "role": "Partner-Mac recovery script (kill + nohup restart with hardcoded model/provider-id/coordinator args, lines 12-18) \u2014 pre-launchd era ops for the two known partner Macs"
+    }
+   ],
+   "dataFlow": "Release: operator tags v*.*.* -> release.yml builds on macos-15 via package.sh, signs checksums.txt with the GitHub-secret PEM, publishes GitHub Release, then re-downloads and verifies it (verify-tier2-provider-release.sh). Provider install: stranger runs curl get.streamvc.live/install.sh | bash; get.streamvc.live redirects to raw.githubusercontent.com main (SPEC-003 FR-C1a \u2014 mutable installer, immutable signed binaries); install.sh fetches latest release, verifies signature+hash, installs, launchd-bootstraps, self-tests, confirms pool membership. Coordinator/console: laptop cross-compiles, deploy scripts scp to root@Pearl, systemd restart behind nginx/Let's Encrypt; gateway deployed manually per runbook with secrets in /etc/macprovider/gateway.env. Production config changes (tier-2 flips) SSH in, mutate one YAML key, SIGHUP, verify, auto-rollback. Monitoring: monitor.py (3-min timer) polls loopback endpoints and emails transitions; operator cron fires harness batches through coordinator into beta/runs.sqlite -> report.py HTML.",
+   "conventions": [
+    "Deploy scripts are idempotent and gate-first: check-deploy-config.sh runs as step 0 of deploy-pearl-vps.sh (lines 46-52); tier-2 scripts default to --plan and require --apply plus DEMO_TOKEN/OPERATOR_KEY env (scripts/enforce-tier2-hash.sh lines 1-37)",
+    "Secrets never in git: root .gitignore lines 43-45 ignore the real coordinator.yaml (plaintext operator_key); beta/.gitignore line 10 ignores CONTRIBUTOR_TUNNEL_TOKENS.txt; gateway secrets injected via EnvironmentFile=/etc/macprovider/gateway.env (macprovider-gateway.service line 12); release private key exists only as a GitHub secret and is rm'd after signing (release.yml lines 96-99)",
+    "systemd units are hardened uniformly: NoNewPrivileges, ProtectSystem=strict, MemoryMax caps sized for the RAM-constrained VPS (coordinator 512M line 36, gateway 384M line 35)",
+    "Defense-in-depth nginx: every public vhost explicitly 404s operator surfaces (/admin/, /poolz, /internal/) rather than relying on app auth alone (nginx-coordinator.streamvc.live.conf lines 114-135, nginx-api.streamvc.live.conf lines 106-114)",
+    "Failure-mode comments cite spec finding IDs (F-603-V7-*, FR-P11a C2, SPEC-002 \u00a76.5) directly in shell scripts \u2014 scripts double as the incident record (install.sh lines 46-48, 126, deploy-pearl-vps.sh lines 143-150)",
+    "Ops lessons get encoded as guards: port-collision upgrade-in-place detection (install.sh lines 127-169), provider-connected restart refusal, stub-then-full nginx to avoid the in-place-sed corruption from v1 (deploy-pearl-vps.sh lines 84-93)"
+   ],
+   "surprises": [
+    "fact (Low): logs/ (13 files) and results/ (32 files) are git-tracked one-time Phase 1 bring-up artifacts dated 2026-05-26 (verified via git ls-files; e.g. results/REPORT.md, logs/03-mlx-server.log). harness.py line 15 references results/REPORT.md as the Phase 1 record, so REPORT.md is load-bearing, but the raw curl/tunnel logs are clutter. Everything else suspect is correctly ignored: runs.sqlite/cron.log/reports (beta/.gitignore lines 1-7), default.profraw (.gitignore line 34), dist binaries (.gitignore lines 37-41), release tarballs (phase3-binary/.gitignore line 6 per git check-ignore).",
+    "fact (Medium): the gateway \u2014 the money-path service \u2014 is the only component with NO scripted deploy or pre-deploy config gate; phase5-gateway/dist/deploy-pearl-vps.md lines 1-30 is a manual checklist ('operator runbook draft'), while coordinator and console both have idempotent scripts with fail-closed checks. check-deploy-config.sh's C2 timer cross-check is also skipped unless the operator remembers to pass gateway.yaml as arg 2 (check-deploy-config.sh lines 18-19, 73-74).",
+    "fact (judgment-adjacent, Medium): there are two public WebSocket entry points for providers \u2014 coordinator.streamvc.live/ws/provider (nginx-coordinator.streamvc.live.conf lines 65-84, no rate limit) and api.streamvc.live/ws/provider (nginx-api.streamvc.live.conf lines 124-134, rate-limited 10r/m + 5 conns). The unlimited coordinator-domain path undercuts the PG-2 limits applied on the api domain; an abuser would simply use the coordinator hostname.",
+    "fact (Low): macprovider-monitor.service runs as root (macprovider-monitor.service line 8) while coordinator/gateway run as the macprovider system user; the monitor only needs read access to coordinator.yaml and loopback HTTP. Also alerting silently degrades to journal-only until a Gmail app password is configured (macprovider-monitor.py lines 178-180) \u2014 consistent with memory that email was still pending.",
+    "fact: the install chain's trust root is an ECDSA P-256 public key hardcoded inside install.sh (lines 396-402), overridable via MACPROVIDER_CHECKSUM_PUBLIC_KEY_PEM env (lines 392-395), while the tier-2 model catalog uses a separate Ed25519 key (scripts/sign-catalog.go lines 86-99). Since install.sh is served from mutable main (SPEC-003-open-onboarding.md lines 261-275), compromise of the repo's main branch = compromise of both installer and its pinned key; this is an accepted PoC trade-off documented in the spec, worth re-examining as provider count grows.",
+    "fact (Low): release.yml's tier-2 preflight passes PROVIDER_SHA256=\"\" (line 76), and scripts/check-tier2-provider-artifact.sh line 11 has a hardcoded v1.2.6 default SHA \u2014 CI relies on the empty override to skip pin-matching for new tags; the hardcoded pin only protects local manual runs.",
+    "fact: production coordinator restarts are deliberately dangerous-by-default: deploy-pearl-vps.sh lines 151-160 refuses to restart while any provider is connected (phase3-binary <= v1.1.2 exits on drain, killing buyer traffic) unless FORCE_RESTART=1 \u2014 an unusual but well-reasoned guard encoding a real incident.",
+    "fact: beta/web (Vercel demo, the old public 'anyone can drive M1/M4' surface) is kill-switched server-side \u2014 both edge functions return HTTP 410 unless MACPROVIDER_ENABLE_LEGACY_BETA_PROXY=1 (beta/web/api/chat.js lines 21-23), closing the open-compute-spend hole previously flagged in memory.",
+    "fact: beta/CONTRIBUTOR_TUNNEL_TOKENS.txt (cloudflared tokens, mode 0600) and phase4-coordinator/dist/coordinator.yaml (plaintext operator_key) both live untracked in the working tree \u2014 properly gitignored (beta/.gitignore line 10, .gitignore line 45) but present on the operator laptop; coordinator.yaml.example lines 79-90 documents that providers must be edited in this local file because deploys overwrite the VPS copy, making the gitignored local file the de facto production source of truth."
+   ]
+  },
+  {
+   "key": "specsdocs",
+   "area": "Documentation and spec corpus (README, runbooks, AGENTS.md, specs/, beta/DECISION_CRITERIA.md)",
+   "purpose": "As documented in /Users/augstar/macprovider-poc/README.md:20-31, MacProvider makes any Apple Silicon Mac (M1+, macOS 14+) a remote-addressable MLX inference endpoint: OpenAI-compatible /v1/chat/completions at api.streamvc.live, with every response carrying an ed25519-signed receipt binding (prompt, output, provider). Intended users are two-sided: Providers (Mac owners installing via curl get.streamvc.live/install.sh, outbound-WS only, managed at console.streamvc.live) and Buyers (drop-in OpenAI client swap, pay-per-compute). The docs corpus shows a spec-driven, multi-round-audited 2-person PoC that has outgrown its own human-facing documentation: the normative specs are current and rigorous, while README/HANDOFF/specs-index lag by 2-6 versions.",
+   "entryPoints": [
+    "/Users/augstar/macprovider-poc/README.md \u2014 public-facing front door: provider install, buyer API, receipt schema, architecture diagram",
+    "/Users/augstar/macprovider-poc/HANDOFF.md:5-7 \u2014 declares itself 'Next session entry point: This document', but status is frozen at 2026-05-26 ('Phase 1 PoC complete... Awaiting M4 user')",
+    "/Users/augstar/macprovider-poc/RUNBOOK.md:1-19 \u2014 NOT an ops runbook: it is the original Phase 1 falsifiability test script addressed to 'a Codex agent executing Phase 1' (mlx-lm venv + cloudflared tunnel validation)",
+    "/Users/augstar/macprovider-poc/CONTINUE_RUNBOOK.md:1-9 \u2014 Phase 1 continuation pass (Steps 6.5/6.7/7.5), same era",
+    "/Users/augstar/macprovider-poc/AGENTS.md \u2014 AI-agent rules digest: PR workflow, git identity, sensitive paths (billing/buyer/auth/requestlog/router) require PR, d-inference clean-room boundary, spec naming conventions",
+    "/Users/augstar/macprovider-poc/specs/README.md \u2014 the spec index (severely stale, see surprises)",
+    "/Users/augstar/macprovider-poc/beta/DECISION_CRITERIA.md \u2014 pre-committed go/no-go criteria + append-only decision log"
+   ],
+   "keyModules": [
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/",
+     "role": "176 files. By prefix: 45 AUDIT_* (audit prompts), 42 BUILD_* (build/commission prompts), 38 SPEC-* (normative docs + their audit reports), 29 FIX_* (fix-pass prompts), remainder = phase build reports (PHASE5/6/7_*), JOINT/INTEGRATION audits, GOAL/SCOPE/REGRESSION/HARDENING one-offs, README.md index"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md",
+     "role": "Normative spec, Swift provider binary. Version 1.3 (2026-06-06, SPEC-010 v1.5 + SPEC-011 v0.5 absorption) per line 3"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-002-coordinator.md",
+     "role": "Normative spec, Go coordinator. Version 1.3.5 (2026-06-06) per line 3; note line 4 still declares dependency on SPEC-001 v1.2.4"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-003-open-onboarding.md",
+     "role": "Normative spec, distribution/install.sh/onboarding. Version 0.7 (2026-05-29) per line 3"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-004-smart-router.md",
+     "role": "Normative spec, routing. Version 0.3.1 (2026-05-30) per header"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-005-billing.md",
+     "role": "Normative spec, billing/settlement/rewards. Version 0.3 (2026-05-31) per header"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-006-buyer-api.md",
+     "role": "Normative spec, buyer API/gateway. Version 0.8.3 (2026-05-31) per header"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-007-explorer.md",
+     "role": "Normative spec, internal read-only operator explorer (v0.2, RFC 2119 language, explicitly 'not a control plane')"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-008-tier2.md",
+     "role": "Normative spec, tier-2 trust/attestation layer. Version 0.3 (2026-05-31) per header"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-009-console-v2.md",
+     "role": "Normative spec, console v2. Version 0.1 (early draft) per header"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-010-model-catalog.md",
+     "role": "Normative spec, provider model catalog. Version 1.5 (LOCKED per SPEC-001 v1.3 absorption note) per header"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-011-operator-pushed-warm-swap.md",
+     "role": "Normative spec, warm model swap. Version 0.5 ('post round-3 polish pass \u2014 LOCK candidate') per header"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/specs/SPEC-012-source.md",
+     "role": "Normative spec (source/audit-history pairing with SPEC-012-source-audit-history.md). Version 0.3 per header"
+    },
+    {
+     "path": "/Users/augstar/macprovider-poc/beta/DECISION_CRITERIA.md",
+     "role": "Pre-committed Phase 2 go/no-go criteria (signed-header pattern, hard-stop triggers, pivot menu) + append-only decision log table at line 248; 57 dated decision rows (grep '^| 2026-'), each with Observation / Decision / Phase-3-implication columns"
+    }
+   ],
+   "dataFlow": "The documented development loop: a BUILD_SPEC_* prompt commissions a normative SPEC-NNN-*.md (or an implementation phase of one); an external-model AUDIT_SPEC_* prompt produces a SPEC-NNN-*-audit.md report; FIX_SPEC_*_VX_Y prompts drive version bumps with explicit change logs in the spec header (e.g. SPEC-001-phase3-binary.md:6-33 logs v1.2.1 through v1.3 changes, each citing audit finding IDs like H-003, C3, M7). Locked companion specs get \"absorbed\" into the two anchor specs (SPEC-001 binary, SPEC-002 coordinator) \u2014 SPEC-010/011 were absorbed into both on 2026-06-06. Operational decisions flow into beta/DECISION_CRITERIA.md as dated table rows that explicitly name downstream spec implications. Human-facing docs (README, HANDOFF, specs/README.md) sit outside this loop and are updated manually \u2014 which is exactly where the drift accumulates.",
+   "conventions": [
+    "Spec naming house style (AGENTS.md:52-54, confirmed in specs/ listing): BUILD_SPEC_*, AUDIT_SPEC_*, FIX_SPEC_*_VX_Y for prompts; SPEC-NNN-*.md for normative docs; audits land as SPEC-NNN-audit.md / SPEC-NNN-vX-Y-audit.md beside the spec",
+    "Every normative spec carries a **Version:** line with date + reason at line 3, a 'Depends on:' line pinning exact versions of sibling specs, and a cumulative change log citing audit finding IDs",
+    "RFC 2119 normative language (MUST/SHOULD/MAY) used in specs, declared explicitly in SPEC-007-explorer.md:3-4",
+    "Multi-round cross-model audit cadence: per-spec audit prompt versions go up to V1_5 (SPEC-010) and R2V/R3V re-verification rounds (SPEC-002 v1.3.5 impl audits)",
+    "Decision log is append-only table rows with pre-committed criteria signed before kickoff (DECISION_CRITERIA.md:3-6)",
+    "Sensitive paths (billing, buyer, auth, requestlog, router) require PR + review per AGENTS.md:33-42; never develop on local main",
+    "Runbooks are written as self-contained prompts addressed to an executing agent ('You are a Codex agent...', RUNBOOK.md:3, CONTINUE_RUNBOOK.md:3) with PASS/FAIL gates and HALT.md escape hatches"
+   ],
+   "surprises": [
+    "[fact, Medium] specs/README.md (the spec index) is severely stale: lines 5-7 list only three specs \u2014 SPEC-001 'v1.1.1 Build-ready', SPEC-002 'v1.0.3', SPEC-005 'v0.3' \u2014 while the corpus actually has 12 SPEC families and SPEC-001 is at v1.3 (SPEC-001-phase3-binary.md:3), SPEC-002 at v1.3.5 (SPEC-002-coordinator.md:3). Anyone (human or agent) trusting the index gets versions ~6 revisions old. Cite: /Users/augstar/macprovider-poc/specs/README.md:5-7",
+    "[fact, Low] README.md:137 hardcodes 'Current release: **v1.2.5**' but git tags include v1.3.0 and the shipped binary identifies as 1.3.0 (phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:70 'static let binaryVersion = \"1.3.0\"'). The same line links to /releases/latest, so the text and the link target silently disagree.",
+    "[fact, Low] Project CLAUDE.md (/Users/augstar/macprovider-poc/CLAUDE.md, 'Other repo conventions' section) states 'v1.2.3 is the current phase3-binary release. SPEC-001 v1.2.2, SPEC-002 v1.1.3, SPEC-003 v0.5 are locked' \u2014 every one of those is stale (actual: binary 1.3.0, SPEC-001 v1.3, SPEC-002 v1.3.5, SPEC-003 v0.7 per SPEC-003-open-onboarding.md:3). Agents are told these are locked baselines.",
+    "[judgment, Medium] There is no current operations runbook despite live production. Root RUNBOOK.md:1-19 is the original Phase 1 falsifiability script ('You are a Codex agent executing Phase 1... This is a falsifiability test'), and CONTINUE_RUNBOOK.md:1-9 is its continuation. Ops knowledge for the live coordinator/gateway/console exists only scattered across phase reports in specs/ and memory files.",
+    "[fact, Low] HANDOFF.md:5-7 status frozen at 2026-05-26: 'Phase 1 PoC complete. Phase 2 buyer-harness scaffold built... Awaiting M4 user before going live' \u2014 two weeks and roughly four phases behind reality (live beta, N=3 providers, money path). It carries a superseded-warning banner at line 3 but still names itself the session entry point.",
+    "[fact, Low] beta/DECISION_CRITERIA.md:28 \u2014 the commitment signature line is still blank ('Signed (commit hash on this file is the timestamp): `_______________`') even though the header at lines 3-6 demands stamping BEFORE day 1 and the log below it has 57 dated decision rows through Phase 4+. The discipline held in practice but the ceremonial lock never happened.",
+    "[fact, Low] SPEC-002-coordinator.md:4 declares 'Depends on: SPEC-001 v1.2.4 (locked)' while SPEC-001 itself is at v1.3 (and SPEC-002 v1.3.5 explicitly absorbed SPEC-001 v1.3 per its own line 3) \u2014 internal cross-pin drift inside the otherwise rigorous spec corpus.",
+    "[judgment] Maturity read: the spec corpus (176 files, 45 audit prompts, multi-round cross-model audits, finding-ID-cited change logs) is unusually disciplined for a 6-week 2-person PoC \u2014 production-grade process on the money/auth path. The drift is concentrated entirely in the human-facing summary layer (README version, specs index, HANDOFF, CLAUDE.md version claims), which is cheap to fix and worth fixing now that real users read the README."
+   ]
+  }
+ ],
+ "dimensions": [
+  {
+   "dimension": "architecture",
+   "healthSummary": "Architecturally this is a healthier codebase than its raw file sizes suggest, but it has two structural problems that matter at beta scale. The service-level boundaries are sound: two independent Go modules (gateway = public buyer/quota plane, coordinator = internal pool/routing/payout plane) with no cross-imports and no import cycles, assembled via functional options at a single composition root, with money math correctly isolated and atomic. The 'duplication' of storage/auth/explorer across the two services is mostly justified domain separation (the billing concepts are genuinely different \u2014 provider payouts vs buyer quotas), with only minor copy-paste drift (an identical SQLite DSN helper cloned in both modules). The real concerns are intra-service. First, the coordinator's buyer handleChatCompletions is a 510-line god-function containing three near-duplicated retry/failover loops on the hottest money path, where correctness depends on three hand-maintained copies staying in sync and is backstopped only by tests, not structure. Second, the coordinator pulls all pool state into one in-memory Registry behind a single RWMutex and then performs a synchronous SQLite audit write WHILE that lock is held, and it opens multiple uncapped *sql.DB handles to one SQLite file where the money path takes an exclusive BEGIN IMMEDIATE write lock \u2014 the gateway, tellingly, caps its store at one connection but the coordinator does not. Together these define the single-coordinator scalability ceiling and a latent write-contention/latency risk. None are live-bug Critical at N=3 providers, but the buyer-handler complexity and the I/O-under-lock + uncapped-pool combination are the things to address before traffic grows. The phase-numbered top-level layout is a harmless historical artifact, not a real boundary problem.",
+   "strengths": [
+    "Clean store-abstraction in the coordinator explorer: handlers.go has ZERO direct SQL (grep for h.db. returns 0; SELECT count is 0), with all queries isolated in explorer/store.go behind a Store type and a ReadDB interface (store.go:31-321). This is exactly the layering the buyer handler lacks, and proves the team knows the pattern. Cite: phase4-coordinator/internal/explorer/handlers.go:1-100 vs phase4-coordinator/internal/explorer/store.go:31-555.",
+    "No import cycles despite tight sibling coupling: buyer imports ws (server.go:30) and main.go wires ws with buyer.InternalHandler(), but ws does NOT import buyer (grep confirms empty), so the dependency graph stays acyclic \u2014 the cross-wiring is done via interfaces/handlers at the composition root (main.go) rather than mutual package imports.",
+    "The two-service module boundary is a genuinely sound architectural choice: phase5-gateway (public buyer identity/OAuth/quota, internet-facing) and phase4-coordinator (internal provider pool/routing/payout, loopback-bound) are separate Go modules with no cross-imports, giving real deployment and blast-radius isolation between the money-quota plane and the provider-routing plane.",
+    "Money-path persistence is correctly atomic and isolated: billing.WriteHotPath wraps the request_log row + ledger credit rows in one BEGIN IMMEDIATE transaction (billing/hotpath.go:31-53) with a quarantine-don't-lose fallback (WriteRequestLogWithIdentity), and the integer credit math lives entirely in billing/formula.go separate from any HTTP code. The gateway mirrors this with reserve/settle/refund under BEGIN IMMEDIATE and append-only triggers.",
+    "Functional-options + composition-root wiring is applied consistently (buyer.With*, ws.Option, pool.RegistryOption; all dependencies injected in main.go:82-137), so the packages are constructor-injected and the concrete dependency graph is assembled in exactly one place \u2014 making the system testable and the boundaries explicit even where individual files are large.",
+    "Role-segregated storage interfaces in the gateway (storage/interfaces.go composed into router.Server) keep the chat handler talking to abstractions (ReserveQuota/AcquireConcurrency) rather than raw SQL \u2014 the gateway is the reference example of the layering the coordinator's buyer handler should adopt."
+   ]
+  },
+  {
+   "dimension": "codequality",
+   "healthSummary": "Code quality is good-to-strong for a 6-week 2-person PoC, and notably disciplined on the money path. go vet is clean in both Go modules, Swift has no empty catches and only well-scoped try? usage, the WS wire protocol is properly typed with graceful unknown-type handling on both sides, and the apparent swallowed-error pattern in the gateway is actually deliberate reserve/refund-with-reaper reconciliation rather than carelessness. The real weaknesses are structural, not safety: (1) the coordinator's handleChatCompletions is a 511-line function with three near-duplicate retry/failover/billing-log loops where correctness leans entirely on the test suite \u2014 the single biggest maintainability risk in the repo; (2) a synchronous SQLite audit write runs under the global pool RWMutex on swap-completion heartbeats, which can stall all routing under SQLite contention on the constrained single VPS; (3) the buyer-facing tier2 trust disclosure is parsed from deeply-nested untyped map[string]any with silent zero-fallbacks, so cross-service schema drift could quietly misrepresent trust. The remainder (cross-module copy-paste of HTTP helpers, a dead legacy branch in CoordinatorClient, and a hand-rolled Sprintf/Sscanf JSON serializer) are low-severity polish. None of these is a live security or money-loss defect; the two that most deserve attention before scaling are the under-lock audit write and the disclosure-parsing fragility.\"",
+   "strengths": [
+    "Wire-protocol type safety is strong on the Go side: ws/messages.go (lines 8-126) defines fully-typed structs with json tags for every provider frame (Hello, AuthRequest, AuthChallenge, AuthResponse, Heartbeat...), and the dispatch in ws/server.go:948-965 has a default case that logs+drops unknown types rather than panicking. The Swift side mirrors this with a graceful default NAK for unknown message types (CoordinatorClient.swift:382-388) and guarded JSON parsing that NAKs malformed frames (337-344).",
+    "Money-path error handling is genuinely defense-in-depth, not sloppy. The many `_ = s.store.RefundReservation(...)` calls in the gateway (server.go:1336, 1351, 1367, 1387, 1410...) look like swallowed errors but are backstopped by the hourly reservation reaper (cmd/gateway/main.go:96-120) that sweeps expired 'active' reservations \u2014 so a failed refund self-heals rather than permanently consuming a buyer's quota. The coordinator's billing hot path similarly has a fallback write (buyer/server.go:929-937) so durable logging failures are recoverable by reconcile.",
+    "Swift error handling is clean: zero empty catch blocks across all Sources, and the moderate `try?` usage is correctly scoped \u2014 every `try?` site I read is either Task.sleep (only throws on cancellation, CoordinatorClient.swift:208/217/510), best-effort drain-status sends during shutdown (583-616), or defensive JSON parsing already guarded by a subsequent guard/else (338, 807).",
+    "Both Go modules pass `go vet ./...` cleanly (exit 0), and tests are extensive and behavior-named (e.g. billing TestWriteHotPath_503_NoLedgerRows / TestWriteHotPath_ACID; gateway server_test.go is larger than the source it tests). Fault injection is correctly isolated behind //go:build testfaults so production binaries cannot contain the fault paths (internal/testfaults/relay.go).",
+    "Concurrency contracts are documented where they matter: the dangerous under-lock swap emitter is preceded by an explicit CONCURRENCY CONTRACT comment (pool/provider.go:446-456) spelling out the deadlock/panic hazards, and the liveness Touch() semantics (ws/server.go:941-947) explain exactly why unparseable frames deliberately do NOT count toward liveness. This is well above PoC norm for documenting load-bearing invariants."
+   ]
+  },
+  {
+   "dimension": "security",
+   "healthSummary": "Security on the money-path and auth code is genuinely strong for a 6-week 2-person PoC and is the most disciplined dimension of this codebase. Secrets are clean in git, API keys and provider tokens are hashed with constant-time compares, SQL is fully parameterized, OAuth CSRF/scope/redirect handling is correct, the self-update/install supply chain verifies signatures before download with path-traversal guards, and config validation fails closed on every secret. I found no 'exploitable-today' critical or high vulnerability. The real issues are at the architecture/posture layer, all Medium-or-below: (1) the public coordinator hostname leaves /ws/provider unrate-limited, undercutting the gateway's provider-connection limits and exposing a DoS on the 3-provider pool; (2) the marquee 'signed inference receipt' trust claim is entirely unimplemented; (3) tier-2 enforcement (encrypted leg, model-hash verification, attestation) defaults fully permissive and depends on an out-of-band gitignored config with no deploy-time gate; (4) one shared operator key spans the gateway admin plane, the coordinator operator API, and the hot buyer path. The auth predicates also fail open on empty keys, currently masked by config validation but worth inverting to fail-closed. Overall risk level: MEDIUM \u2014 acceptable for the current beta scale, but the WS rate-limit asymmetry and the receipt-claim gap should be closed before scaling provider/buyer count.",
+   "strengths": [
+    "Secret hygiene is clean: a full-tree scan of git-tracked files for high-entropy secret patterns (ghp_/gho_/github_pat_, AWS AKIA, PEM PRIVATE KEY, slack xox*, sk-*) returned zero hits. The only embedded keys are intentionally-public verification keys (P-256 checksum public key in install.sh:397-400 and SelfUpdate.swift:7-12; Ed25519 catalog key is generated, not committed). Real secrets (coordinator.yaml operator_key, CONTRIBUTOR_TUNNEL_TOKENS.txt) are correctly gitignored and injected via systemd EnvironmentFile.",
+    "API key and token handling is production-grade: gateway keys are 32 random bytes, stored only as HMAC-SHA256 hashes with a 12-char display prefix (keys.go:38-71), validated by hash lookup, and validation rejects both revoked keys AND blocked accounts (store.go:191). Coordinator provider tokens are 32-byte random hex stored as SHA-256 hashes (tokens.go:150-167). All bearer comparisons are constant-time via hmac.Equal over SHA-256 digests (tokens.go:52-54, server.go:2087-2089).",
+    "GitHub OAuth is correctly implemented: CSRF state is single-use, session-bound, and expiry-checked atomically in a BEGIN IMMEDIATE transaction (oauth.go:134-136, store.go:328-356); scope is enforced against a strict allowlist (oauth.go:108-119); redirect/callback URLs are validated against an allowlist on both start and callback (server.go:206,268); the privileged 'mint a new key' action is bound to the state row, not a sibling cookie, so it can't leak across tabs.",
+    "All SQL across both sqlite layers is parameterized \u2014 every query I read in auth/tokens.go, billing/hotpath.go, and storage/sqlite/store.go uses ? placeholders with bound args; no string concatenation into SQL. Append-only audit/usage tables are additionally enforced by RAISE(ABORT) triggers as a tamper backstop (per migrate.go).",
+    "The supply chain is well-defended: SelfUpdate.swift verifies the ECDSA-P256 signature over checksums.txt BEFORE downloading the tarball (SelfUpdate.swift:73-82), then verifies SHA-256, then validates tarball entries against path traversal (validateTarball:247-256), runs the new binary's self-test, and only then atomically replaces \u2014 with HTTPS host allowlists on every URL (validateDownloadURL:232-239). install.sh mirrors this ordering (install.sh:404-452). Release CI deletes the signing key after use.",
+    "Input/abuse hardening is thorough on the buyer edge: request bodies capped (1MB), upstream responses capped (16MB), per-IP signup and demo-session rate limits (server.go:348,389), token quota reserve/settle/refund on every branch, and client-IP derivation that only honors X-Real-IP from trusted-proxy CIDRs (server.go:2270-2296) so per-IP limits can't be spoofed via header injection. CORS is a strict exact-origin allowlist with credentials=false and wildcard rejected at config-validation time (cors.go:32-49, config.go:319-327).",
+    "Config validation fails closed on secrets and footguns: the gateway's Validate() requires operator key, demo signing secret, HMAC key secret (when sticky/hmac modes are on), trusted-proxy CIDRs, and a non-wildcard CORS allowlist before the service will start (config.go:210-329); the coordinator requires operator_key and defaults RequireProviderTokens=true. Defense-in-depth nginx 404s every operator surface (/admin, /poolz, /internal, /v1/pool/check) on the public buyer vhost, and the gateway strips+audit-logs client-supplied X-MacProvider-Internal-* headers before authentication (server.go:172-180)."
+   ]
+  },
+  {
+   "dimension": "testing",
+   "healthSummary": "The test suite is above average for a 6-week two-person PoC, particularly on the money path. The billing store tests are the standout: 25 scenario tests covering quarantine, clamp, idempotency, recovery, and settlement in detail. The coordinator's WS and buyer server tests are deep and behavior-oriented, exercising real WebSocket connections rather than mocks. The gateway's integration tests cover the full OAuth-to-chat-completion cycle with fake coordinators.\n\nThe suite has three concrete problems worth fixing before beta solidifies. First, TestConsoleStaticContracts is broken right now \u2014 the arm64golf feature shipped innerHTML usages that the existing XSS-prevention test bans, and the gateway test suite exits non-zero as a result. Second, TestAuthLookupP95 is a flaky latency assertion that failed once during the parallel test run at 13ms; it is skipped under -race but not under load. Third, the ws package's three unconditional time.Sleep calls (1.1s + repeated 150-200ms) make that package take 47s versus 6-14s for all others and are load-dependent flake candidates.\n\nTwo structural gaps matter for beta: no test exercises the fail-open operator-key path (empty key equals all access), and no test exercises the coordinator-gateway money path together \u2014 those two services share a billing contract that is currently only validated by the live harness.py. The Swift test suite is high-quality but entirely absent from CI, meaning provider-side regressions in crypto, self-update, or heartbeat behavior are only caught during manual testing on physical hardware.",
+   "strengths": [
+    "Billing money-path tests are comprehensive and behavior-oriented. billing/store_test.go covers 25 named scenarios including ACID atomicity (TestWriteHotPath_ACID), quarantine invariants for ambiguous attempts, clamp-and-preserve for inflated provider usage, idempotent recovery, settlement threshold enforcement, roll-forward of below-threshold credits, and terminal-status immutability \u2014 all verified in this session at billing/store_test.go:90-840.",
+    "billing/formula_test.go:5-83 tests the integer credit math with worked examples, negative/overflow token inputs, banker's rounding, and fixed-point parsing \u2014 the exact inputs that guard against money miscalculation.",
+    "ws/server_test.go exercises the full provider lifecycle end-to-end against a real httptest WebSocket server: v1/v2 auth handshake, ECDH key derivation, attestation acceptance, heartbeat liveness, blacklist/drain two-phase shutdown, warm-up gate, model-swap detection, and breaker faults \u2014 all verified at ws/server_test.go:30-2250.",
+    "buyer/server_test.go covers the entire hot path including idempotency-key replay/mismatch rejection (server_test.go:1086-1119), streaming buyer-cancel billing correctness (server_test.go:1121-1191), model class routing, failover/retry loops, and the 510-line handleChatCompletions function path from multiple angles.",
+    "Gateway server_test.go and integration_test.go are thorough on auth: CSRF state validation (TestOAuthStateCSRF), scope allowlist enforcement, demo-token IP binding, API key rotation semantics, quota reserve/settle/refund, concurrency limiter, kill-switch behavior, and the CRITICAL TestConversationKeyIsAccountScoped test (server_test.go:2425-2453) which guards against the HMAC account-scoping regression identified in audit MED-3.",
+    "The `eventually`/`eventuallyWithin` polling helpers (ws/server_test.go:2554-2571) are correctly implemented with a 10ms polling interval and configurable deadline, avoiding the common anti-pattern of sleeping a fixed duration for async assertions.",
+    "Security-regression pinning is explicit in Swift tests: SelfUpdateTests.swift:7-47 hard-pins the release API URL and rejects environment override, pins the signing key, and verifies that an untrusted override errors before any network fetch \u2014 these are regression-lock tests with clear intent.",
+    "Test isolation is consistently strong: every Go test uses t.TempDir() for SQLite databases, httptest.NewServer for HTTP surfaces, and dependency injection (WithRelay, WithRequestLog, WithBillingStore) rather than global state. The `//go:build testfaults` tag on testfaults/relay.go ensures fault injection cannot leak into production binaries.",
+    "The TestAuthLookupP95UnderOneMillisecondWith10KKeys test (store_test.go:729-765) demonstrates performance-aware testing \u2014 it verifies that the idx_api_keys_hash index is not just present (TestAPIKeyHashIndexExists) but actually fast under load, and correctly skips under -race to avoid false failures."
+   ]
+  },
+  {
+   "dimension": "performance",
+   "healthSummary": "For a 6-week two-person PoC, performance and resource safety are in genuinely good shape \u2014 clearly the product of the audit-loop process: body caps, bounded channels, TTL caches, fail-fast backpressure, and outbound timeouts are present essentially everywhere they need to be, and the coordinator's request/audit log retention is fail-closed with sane 90-day defaults. Nothing I found is on fire today at N=3 providers and beta traffic. The risks are growth-shaped and concentrated in two places: (1) the gateway database is structurally incapable of shrinking \u2014 append-only DELETE triggers on all event tables plus reservation rows that are only ever status-flipped \u2014 which compounds with its single serialized SQLite connection shared between the money path and 3-second-budget explorer analytics; and (2) two SQLite contention seams in the coordinator: a synchronous audit INSERT performed while holding the global pool registry lock, and daily retention DELETEs that are non-sargable full scans sharing a write lock with billing's 6-second hot-path budget. All four are cheap to fix now and expensive to fix after the tables and traffic grow; the two Low items (unbounded seenModels writable by provisional providers, demo concurrency bypass) are worth a line each in the backlog. The known ~25-30% coordinator path overhead appears to be inherent hop/relay cost, not a defect visible in this code \u2014 I found no per-request hot-path blocking I/O beyond the intentional durable-log-before-respond billing writes.",
+   "strengths": [
+    "Fail-closed retention on the coordinator: request_log and audit_log pruners default to 90 days (config.go:309-310), config validation rejects non-positive retention (config.go:589-594), and pruners run at boot then daily (main.go:215-273) \u2014 the request-log growth question this audit was asked to check is affirmatively handled.",
+    "Bounded relay memory with fail-fast backpressure: per-provider write channel is bounded and overflow returns ErrRelayBackpressure instead of blocking (relay.go:125-137); per-request chunk channels are capped at 256 and overflow kills that one request rather than buffering (relay.go:154, 520-530); the per-dispatch watchdog goroutine has a guaranteed exit via request-context cancellation (relay.go:447-455).",
+    "Body limits on every read path: 1MB chat request cap with explicit over-limit rejection (buyer/server.go:977-988), 16MB upstream response caps on both coordinator (buyer/server.go:122, enforced for buffered WS streams at 1441-1459) and gateway (router/server.go:33, 1426), and the gateway SSE re-emitter uses a bounded 1MB scanner buffer with per-line flush \u2014 no whole-stream buffering (router/server.go:1536-1585).",
+    "Outbound timeouts are universal in production wiring: gateway coordinator client gets Timeout + ResponseHeaderTimeout for fast 503s during coordinator restarts (gateway main.go:51-61), OAuth client 30s (main.go:62), coordinator provider-forwarding client timeout set once at startup (providerhttp/client.go:14-22), warm-up gate attempts are context-bounded (ws/server.go:1065), explorer queries are budget-capped (router/explorer.go:17,35).",
+    "In-memory maps that matter are all bounded or evicted: sticky-session map has TTL eviction on lookup AND a 10k max-entries sweep on store (buyer/server.go:333-335, 2489-2524); breaker fault windows and recovery holds are deleted on provider removal (pool/provider.go:195-197); unauthenticated WS connections are semaphore-gated before handshake work begins (ws/server.go:220-224).",
+    "TTL caches specifically added to kill per-request upstream roundtrips, citing the audit finding that motivated them: routing-metadata cache 5s (router/server.go:47-52, 1203-1218) and /v1/status poolz cache 10s (router/server.go:1809-1841).",
+    "Index coverage matches the query patterns in both SQLite layers: coordinator billing has purpose-built composite indexes for settlement and quarantine scans (billing/store.go:76-98), the hot-path attempt_n COUNT(*) is covered by idx_request_log_request_id_id (requestlog/store.go:116-117), and every gateway per-account/per-window query I traced has a matching index (migrate.go:81-97, 97-110, 133, 152).",
+    "Goroutine hygiene is clean in the WS layer: monitorHeartbeat exits when the provider leaves the pool or the threshold trips (ws/server.go:1460-1484), runWriter exits on channel close or write error (relay.go:104-113), warm-up gates self-clear with bounded retries (ws/server.go:1023-1050), and the gateway stream-cancel watchdog exits via a done channel (router/server.go:1542-1550)."
+   ]
+  },
+  {
+   "dimension": "dependencies",
+   "healthSummary": "The dependency POSTURE is genuinely good \u2014 among the best I have seen at this maturity: tiny stdlib-first trees (the gateway has two direct deps), everything lock-filed and exact-pinned, the same CGO-free SQLite driver deliberately shared across both Go services to enable the laptop-to-Linux cross-compile deploy model, and zero vendored or CDN-loaded code. The dependency PROCESS, however, is set-and-forget: there is no Dependabot/Renovate/test CI (.github contains only the release workflow), `go mod tidy` has not been run since the gateway docs feature landed, and every manifest is frozen at roughly mid-2024 vintage. That process gap has already produced one real problem hiding in plain sight: both money-path services run modernc.org/sqlite v1.33.0, a version its own authors retracted as breaking clients, 19 minor versions behind current \u2014 the single highest-priority dependency action in the repo. The rest is cheap hygiene: bump the two-year-stale exact-pinned swift-nio, add a third-party license notice file to the publicly distributed provider tarball, note that gopkg.in/yaml.v3 is officially unmaintained, and drop the never-imported swift-log. Method note: Go version recency was checked live via `go list -m -u all` (network was available); upstream maintenance statuses (go-yaml archived 2025-04-01, gobwas/ws latest release 2024-05-03, swift-nio latest 2.101.0) were verified against the live GitHub pages, not memory.",
+   "strengths": [
+    "Exceptionally small, stdlib-first dependency trees for money-path services: phase5-gateway has exactly TWO direct dependencies (gopkg.in/yaml.v3 and modernc.org/sqlite \u2014 /Users/augstar/macprovider-poc/phase5-gateway/go.mod:5-8) and phase4-coordinator only seven (/Users/augstar/macprovider-poc/phase4-coordinator/go.mod:5-13). No framework sprawl, no ORM, no HTTP client libs \u2014 minimal supply-chain surface where it matters most.",
+    "Full reproducibility discipline: go.sum committed for both modules, Package.resolved committed and git-tracked (verified via git ls-files), and every Swift dependency pinned with `exact:` version requirements (/Users/augstar/macprovider-poc/phase3-binary/Package.swift:20-39) \u2014 no version ranges anywhere, so the signed release pipeline can never silently pick up a different dependency than what was tested.",
+    "The duplicated modernc.org/sqlite choice across both Go services is the RIGHT duplication: same driver, same version in both (coordinator go.mod:12, gateway go.mod:7), and the pure-Go/CGO-free property is load-bearing \u2014 it is what allows cross-compiling the linux-amd64 production binaries (phase4-coordinator/dist/coordinator-linux-amd64, phase5-gateway/dist/gateway-linux-amd64, both properly gitignored) from the operator's macOS laptop with no Linux build infrastructure. One driver to reason about for WAL/busy_timeout semantics across the whole backend. The performance tradeoff vs CGo mattn is irrelevant at current request volume.",
+    "Zero vendored or copied third-party code: a copyright/SPDX-header sweep across all first-party Go/Swift/JS sources found nothing foreign, and the embedded web UIs are small hand-written assets (explorer dashboard.js 228 lines, console index.html 1544 lines) with no CDN-loaded or bundled JS libraries \u2014 the only CDN reference in the tree is a test asserting their absence.",
+    "Production ops scripts deliberately avoid third-party Python: the VPS monitor (phase4-coordinator/dist/monitor/macprovider-monitor.py) and the cron harness (beta/harness.py) import stdlib only (urllib/smtplib/sqlite3), so the deployed alerting path and synthetic-traffic path have no pip dependency at all."
+   ]
+  },
+  {
+   "dimension": "devexops",
+   "healthSummary": "DevEx/Ops here is lopsided in an interesting way: the artifacts that exist are unusually good for a 6-week 2-person PoC \u2014 an idempotent coordinator deploy with a fail-closed config gate encoding real incidents, SHA-pinned and key-hygienic release CI, hardened systemd units, a thoughtfully transition-based monitor, and disciplined .gitignore/secret separation \u2014 but the control loop AROUND those artifacts has three holes that sit below the minimum bar for a live money path. First, nothing ever runs the (extensive, well-named) test suites automatically: no test/lint/vet CI exists, and the AGENTS.md rule that billing/auth changes 'require PR + review' has no enforcement teeth in an AI-agent-authored codebase. Second, the 3am story is bad: alerting is one Gmail channel that silently degrades to journal-only, drops alerts permanently on a failed send, and runs on the same VPS it watches, with no external uptime check anywhere \u2014 a Pearl outage is structurally invisible. Third, the production Go binaries are hand-cross-compiled with no script, no commit provenance, and (for the coordinator) no rollback step, and the gateway \u2014 the money service \u2014 is the only component deployed from a manual checklist with no config gate; the one cross-component timer check is structurally skipped on every standard deploy. All three gaps are cheap at this scale (one ~20-line CI workflow, one free external healthcheck ping, one 15-line version-stamping build script + a scripted gateway deploy) and would buy disproportionate protection for the money path. Repo hygiene is a non-issue beyond 45 tracked Phase-1 log artifacts.",
+   "strengths": [
+    "Fail-closed pre-deploy config gate encoding real incidents: check-deploy-config.sh:4-12 lists the exact hazards the project has actually hit (placeholder operator_key, heartbeat-miss < interval, C2 timer ordering) and hard-fails on them (lines 37-57); it runs unconditionally as step 0 of every coordinator deploy (deploy-pearl-vps.sh:46-52). This is incident-derived automation most 2-person teams never build.",
+    "The coordinator deploy script is genuinely production-grade for its size: idempotent end-to-end, stub-then-full nginx sequencing with an explanatory comment about the in-place-sed corruption it replaced (deploy-pearl-vps.sh:84-94), a provider-connected restart refusal gate with FORCE_RESTART escape hatch encoding a real drain incident (lines 143-161), and post-deploy verification including a negative check that /v1/models is NOT exposed on the coordinator host (lines 177-182).",
+    "Release CI supply-chain hygiene is well above PoC norm: actions/checkout pinned to a full SHA with a comment explaining why (release.yml:22-27), persist-credentials disabled, strict tag-format validation (43-46), the signing key materialized 0600 and deleted immediately after use (96-99), and a post-publish re-download verification step (136-150).",
+    "Uniform systemd hardening on the VPS: both services run as an unprivileged user with NoNewPrivileges, ProtectSystem=strict, PrivateTmp/Devices, and MemoryMax caps sized for the RAM-constrained host (macprovider-gateway.service:24-36; equivalent block in macprovider-coordinator.service), with graceful-shutdown timeouts matched to the drain semantics.",
+    "The monitor's design (as opposed to its delivery channel) is right-sized and thoughtful: transition-based alerting rather than poll-spam, zero provider load by reading only /healthz//poolz//v1/status (macprovider-monitor.py:1-14), atomic state replacement via os.replace (lines 81-86), and per-provider state-machine transitions mapped to breaker/warm-up semantics (lines 136-149).",
+    ".gitignore is curated with rationale, not accumulated: production-secret and rebuilt-artifact exclusions carry explanatory comments (.gitignore:36-45), and spot-checks confirm it works \u2014 default.profraw, build-release/ (1.3GB), .venv/ (241MB), dist binaries, and the secret coordinator.yaml are all present on disk and all untracked.",
+    "phase5-gateway/README.md is a model dev-loop document: copy-pasteable local setup with dev secrets (lines 26-39), deployment layout, and a Verification section that names the exact critical security/money test selectors to run (lines 115-127) \u2014 the template the other modules should copy.",
+    "Gateway deployment secrets use env-file indirection end-to-end: config supports env:NAME references, real values live in /etc/macprovider/gateway.env, loaded via EnvironmentFile (deploy-pearl-vps.md:6-11; macprovider-gateway.service:12), so the YAML itself is committable."
+   ]
+  },
+  {
+   "dimension": "docs",
+   "healthSummary": "Documentation health is sharply bimodal. The machine-facing layer \u2014 the 176-file spec corpus with version-pinned headers and audit-finding-cited change logs, the agent rules in AGENTS.md, the deployed buyer /docs page with its rigorously honest tier-1 disclosure \u2014 is current, disciplined, and well above what a 6-week 2-person PoC normally produces. The human-facing summary layer is the opposite: the public README affirmatively advertises a signed-receipt cryptographic feature that has zero implementation anywhere in the codebase (directly violating the product's own buyer-language consistency mandate) and claims console management/billing features that don't exist; the files named RUNBOOK/HANDOFF/CONTINUE_RUNBOOK are frozen Phase 1 artifacts that would misdirect anyone operating today's production system; the specs index, project CLAUDE.md, and three other version pins lag reality by 2-6 revisions; and there is no ops runbook for a live money-path system nor any provider-visible documentation of how earnings work. The good news: every finding here is a documentation-only fix \u2014 roughly two focused days of writing, with the README receipt section being the one item that should be corrected immediately because real buyers are reading a false cryptographic claim on the front door of a live beta.",
+   "strengths": [
+    "The deployed buyer documentation is exceptionally honest for a beta product: the tier-1 disclosure (phase5-gateway/internal/router/templates/docs.md:115-126) explicitly states prompts are plaintext on provider hardware, that there is no attestation or integrity verification, that model identity is provider-reported, and tells buyers plainly not to send secrets \u2014 with a mandate that all buyer-facing language stay consistent. Quotas, limits, and machine-readable error codes are documented precisely (docs.md:104-156). This is the gold standard the README should be held to.",
+    "phase5-gateway/README.md is a model component README: copy-paste local dev with explicit env vars (26-41), API smoke curls (43-55), production layout and nginx/proxy trust semantics (64-92), storage/quota behavior (94-102), a troubleshooting table mapping every error code to a cause (104-113), and named verification test suites (115-127).",
+    "Spec corpus version discipline is far above PoC norm: every normative spec carries a version+date+reason header at line 3 and a cumulative change log citing specific audit finding IDs (SPEC-001-phase3-binary.md:3-14; SPEC-002-coordinator.md:3-10) \u2014 code-to-spec traceability that most production teams lack.",
+    "AGENTS.md:1-58 is a tight, priority-ordered contract for AI agents: PR workflow, git identity routing, an explicit list of sensitive money/auth paths requiring PR review (lines 33-43), the d-inference clean-room boundary, and spec naming conventions \u2014 exactly the right doc for this project's agent-executed development model.",
+    "Operational scripts double as documentation: deploy-pearl-vps.sh:1-22 self-documents prerequisites, env knobs, and idempotency, and encodes past incidents as guards; phase3-binary/README.md:45-51 honestly documents the unsigned-binary trust caveat rather than hiding it.",
+    "beta/DECISION_CRITERIA.md is genuine institutional memory: 57 dated, append-only decision rows (verified count) recording observation, decision, and downstream implication \u2014 rare operational discipline for a 6-week project."
+   ]
+  }
+ ],
+ "confirmed": [
+  {
+   "title": "Coordinator buyer handler is a 510-line god-function with three near-duplicated retry/failover loops",
+   "severity": "High",
+   "kind": "fact",
+   "what": "handleChatCompletions spans buyer/server.go:840-1350 (510 lines). It inlines: closure-based request-log+billing writers (851-976), body/idempotency validation (977-1031), provider selection, and THREE separate copy-pasted forward+failover+retry loops \u2014 streaming-WS (1056-1153), non-streaming-WS (1154-1245), and HTTP-forwarding (1246-1349). The three loops re-implement the same excluded-set bookkeeping, selectProviderExcluding retry, explicitRetries/faultedProviders counters, and logAttempt calls with subtly different branch conditions (e.g. failover is attempted in the stream loop at 1087 and the non-stream loop at 1212 but the control flow and the set of handled wsForwardResult cases differ between them).",
+   "where": [
+    "phase4-coordinator/internal/buyer/server.go:840-1350",
+    "phase4-coordinator/internal/buyer/server.go:1056-1153",
+    "phase4-coordinator/internal/buyer/server.go:1154-1245",
+    "phase4-coordinator/internal/buyer/server.go:1246-1349"
+   ],
+   "why": "This is the single hottest money-path code in the system (every buyer inference) and it is the function most likely to harbor a divergent-branch bug, because correctness depends on three hand-maintained copies of the same failover state machine staying in sync. The repo map's own note that 'correctness currently relies on the large internal test suite rather than structure' is accurate: a change to retry semantics must be made in three places, and the 40+-field Server struct (server.go:38-83) gives the function access to everything, so there is no compiler-enforced boundary preventing a fix in one loop from being forgotten in another. At beta scale with real payouts keyed off these log rows, a divergence here mis-bills or double-logs silently.",
+   "confidence": "high",
+   "suggestedFix": "Extract a single forwardWithFailover(ctx, req, firstProvider, mode) helper that owns the excluded-set/retry/failover loop once and takes a per-mode dispatch callback, collapsing the three loops. This is a structural refactor only (no behavior change) and should be done behind the existing test suite, on a feature branch per the repo's money-path PR rule.",
+   "id": "ARCH-1",
+   "dimension": "architecture",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All citations check out. handleChatCompletions runs exactly lines 840\u20131350 (510 lines). Three distinct loops are present: streaming-WS (1066\u20131152), non-streaming-WS (1154\u20131244), and HTTP-forward (1246\u20131349). The structural divergence is real and consequential: the non-streaming WS loop handles wsForwardTimedOut (line 1170) and wsForwardQueueFull (1228) with distinct branches \u2014 including a pool.MarkState(StateBusy) call at 1229 \u2014 that have no equivalents in the streaming-WS sub-loop (1066\u20131118). A streaming WS provider returning queue-full is never marked busy, so future routing continues sending it traffic. The 40-field Server struct (lines 38\u201383) gives the function unconstrained access to all state. The \"divergent branch\" concern is not theoretical: the streaming loop silently skips the StateBusy mark that the non-streaming loop applies. High severity for a live money-path function is calibrated correctly.",
+    "correctedSeverity": "High"
+   }
+  },
+  {
+   "title": "Single in-process pool Registry behind one RWMutex is the hard single-coordinator ceiling; SQLite writes run under that lock",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "All provider state lives in one in-memory pool.Registry guarded by a single sync.RWMutex (pool/provider.go:128-140). Every state transition, heartbeat, breaker update, and snapshot takes r.mu (Register 174, MarkState 241, RecordBreakerFault 304, ApplyHeartbeat 482, Snapshot 676). Worse, the SPEC-011 swap audit emitter is invoked WHILE r.mu is held (ApplyHeartbeat at provider.go:542-554), and main.go wires that emitter to a synchronous SQLite write (auditStore.EmitSwap at main.go:94-111). The concurrency contract is enforced only by a comment (provider.go:446-457) warning that re-entering the Registry deadlocks and a panic crashes the heartbeat handler.",
+   "where": [
+    "phase4-coordinator/internal/pool/provider.go:128-140",
+    "phase4-coordinator/internal/pool/provider.go:482-554",
+    "phase4-coordinator/cmd/coordinator/main.go:94-114"
+   ],
+   "why": "Two coupled consequences. (1) Scalability: pool state cannot be sharded or moved to a second coordinator process without a rewrite \u2014 there is exactly one writer for all providers, and routing snapshots, heartbeats, and breaker logic all serialize through it. For N=3 providers this is fine; it is a known wall, not a present bug. (2) Latency/availability: a slow SQLite EmitSwap (e.g. during a WAL checkpoint or busy-timeout stall) blocks the global pool lock, which in turn stalls heartbeat processing AND buyer routing for every provider, since both paths need r.mu. The comment correctly identifies the deadlock/panic hazard but the I/O-under-lock coupling means an audit-DB hiccup degrades the live serving path.",
+   "confidence": "high",
+   "suggestedFix": "Decouple the emitter from the lock: in ApplyHeartbeat, collect the SwapEvent under the lock and dispatch it to a buffered channel / goroutine AFTER r.mu is released, so the SQLite write never blocks pool mutation. This preserves the exactly-once gate while removing I/O from the critical section. The single-Registry scalability wall is acceptable to leave documented for now.",
+   "id": "ARCH-2",
+   "dimension": "architecture",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three cited locations confirm the finding. provider.go:128-140 shows the single RWMutex; provider.go:482-484 shows ApplyHeartbeat taking r.mu.Lock(); lines 542-554 show swapEmitter called synchronously while the lock is held. main.go:94-111 wires a plain closure with a direct auditStore.EmitSwap call (no goroutine, no channel). The audit store uses busy_timeout=5000 (5s), meaning a SQLite contention event blocks r.mu for up to 5 seconds, which would also stall buyer Snapshot() calls. One partial nuance the finding understates: the swapCompleted gate (4-condition guard at lines 538-541) means the emitter only fires during actual model swaps, which are rare at N=3. This makes the latency impact low-probability in practice, supporting Medium rather than High. The scalability wall observation is accurate and correctly labeled as a design ceiling not a present bug. Medium severity is well-calibrated."
+   }
+  },
+  {
+   "title": "Coordinator opens multiple uncapped *sql.DB handles to one SQLite file while the money path holds BEGIN IMMEDIATE",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "main.go opens three separate *sql.DB handles on the same file (auth.OpenStore main.go:47, requestlog.OpenStore main.go:53, audit.OpenStore main.go:59) and then shares the requestlog handle into admission, billing, and the explorer via reqLogStore.DB() (main.go:65, 70, 91). None of these handles call SetMaxOpenConns(1). The money-path write WriteHotPath acquires a connection and runs BEGIN IMMEDIATE \u2014 an exclusive write lock \u2014 on every successful buyer request (billing/hotpath.go:32-37, and again at hotpath.go:151). Contrast the gateway, which deliberately caps its store at SetMaxOpenConns(1)/SetMaxIdleConns(1) (phase5-gateway/internal/storage/sqlite/store.go:38-39) to serialize writers in-process.",
+   "where": [
+    "phase4-coordinator/cmd/coordinator/main.go:47-91",
+    "phase4-coordinator/internal/billing/hotpath.go:32-37",
+    "phase5-gateway/internal/storage/sqlite/store.go:38-39"
+   ],
+   "why": "SQLite (WAL) permits exactly one writer at a time. With uncapped connection pools across three handles, concurrent BEGIN IMMEDIATE writers (e.g. simultaneous billing writes from parallel buyer requests, plus admission/audit writes) collide and either block on busy_timeout=5000 (adding up to 5s of tail latency to a buyer request) or return SQLITE_BUSY and fail the post-success request-log write \u2014 which the handler surfaces as HTTP 500 request_log_failed even though the provider already did the inference (buyer/server.go:1286-1290). The gateway's explicit single-connection cap shows the team knows the correct pattern; the coordinator's omission is an inconsistency that will bite as request concurrency rises in beta. At N=3 providers and low QPS it is latent.",
+   "confidence": "high",
+   "suggestedFix": "Apply SetMaxOpenConns(1) to the coordinator stores' DB handles (or consolidate to a single shared handle with the cap), matching the gateway's proven pattern, so writers serialize in-process instead of racing for the SQLite write lock and timing out under load.",
+   "id": "ARCH-3",
+   "dimension": "architecture",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All cited locations verified by Read. main.go:47/53/59 opens three *sql.DB handles on the same DBPath. Zero calls to SetMaxOpenConns anywhere in the coordinator codebase. billing.Store shares reqLogStore.DB() (confirmed in billing/store.go:24-28), so the money-path BEGIN IMMEDIATE at hotpath.go:37 and hotpath.go:151 contends via the same pool as requestlog writes while auth and audit pools are separate and uncapped. Gateway does cap at 1 (store.go:38-39). HTTP 500 on log failure post-inference confirmed at buyer/server.go:1288. busy_timeout=5000 means contention adds tail latency rather than immediately erroring. At N=3 and low QPS the risk is latent but the structural defect and inconsistency with the gateway pattern are real. Medium severity is correctly calibrated."
+   }
+  },
+  {
+   "title": "Gateway router.Server is a god-file carrying ~10 unrelated responsibility clusters",
+   "severity": "Medium",
+   "kind": "judgment",
+   "what": "router/server.go is 2495 lines and the single Server type is the handler for: GitHub OAuth (handleGitHubStart/Callback 197-330), signup (332-371), demo sessions (373-403), API-key rotate/revoke (405-451), account/docs HTML pages (wired 141-142), /v1/models with tier1/tier2 trust-disclosure synthesis (453-490 plus ~360 lines of disclosure-metadata structs and helpers 887-1249), chat-completions proxy with quota reserve/settle/refund + SSE (1251-1712), usage (510), sticky delete (550), /v1/status poolz aggregation+anonymization (585, 1809-1978), feedback + admin feedback-summary (601-695), admin kill-switch/capacity (696-815), and the operator-bearer auth + trusted-proxy IP logic (2061-2296). The route table at Handler() (server.go:134-164) registers all of them on one mux.",
+   "where": [
+    "phase5-gateway/internal/router/server.go:134-164",
+    "phase5-gateway/internal/router/server.go:887-1249",
+    "phase5-gateway/internal/router/server.go:1251-1423"
+   ],
+   "why": "Unlike the coordinator's buyer god-function (a correctness risk), this is primarily a maintainability/navigability cost: every concern shares one Server struct and one 2495-line file, so the trust-disclosure synthesis logic, OAuth, and the money-path proxy are all one edit away from each other and one test file (server_test.go is 2522 lines). For a 2-person team this raises the cost of onboarding and of reasoning about blast radius when touching, say, the admin plane. It is well-organized internally (clear function boundaries, OpenAI error envelope discipline) so it is drift-of-size rather than spaghetti \u2014 but it is past the point where the file should be split by concern (auth/, disclosure/, proxy/, admin/).",
+   "confidence": "high",
+   "suggestedFix": "Split router/server.go by responsibility into separate files within the package (oauth.go, disclosure.go, chat_proxy.go, admin.go) sharing the Server type, then consider extracting the tier1/tier2 disclosure synthesis (887-1249) into its own package since it is self-contained value-transformation logic with no HTTP coupling.",
+   "id": "ARCH-4",
+   "dimension": "architecture",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "correctedSeverity": "Medium",
+    "correction": "The finding is accurate but slightly overstates the concentration: explorer handler implementations are already extracted to explorer.go (282 lines) and page handlers to pages.go (110 lines). The route table does register all routes on one mux (confirmed at 134-164), but 8 of the explorer handler implementations are not in server.go. The remaining clusters \u2014 OAuth (197-371), disclosure synthesis types and helpers (831-1249), chat-completions proxy (1251-1712), admin kill-switch/capacity (696-815), and auth/proxy utilities \u2014 are genuinely co-resident in server.go alongside 104 top-level function declarations. The disclosure synthesis block (types at 831-885, helpers at 887-1249) is confirmed to be self-contained value-transformation logic with no HTTP coupling, making it the strongest candidate for extraction.",
+    "reasoning": "Verified all cited ranges directly. Handler() at 134-164 registers ~20 routes on one mux \u2014 confirmed. Disclosure structs (831-885) and synthesis helpers (887-1249) are in server.go and are indeed self-contained (operate on map[string]any, return structs, no w/r HTTP params). handleChatCompletions at 1251-1423 contains the full quota/concurrency/proxy/SSE money path. Admin handlers at 696-815 confirmed. Counter-evidence: explorer.go already splits out 8 explorer admin handler implementations (282 lines); pages.go splits out 2 page handlers (110 lines). Partial separation exists but the core clusters remain. Severity Medium is correct for a 2-person beta \u2014 no correctness or security risk, pure navigability/blast-radius cost."
+   }
+  },
+  {
+   "title": "Two independent Go services duplicate storage/auth/explorer scaffolding with no shared module \u2014 partly justified, partly copy-paste drift",
+   "severity": "Low",
+   "kind": "judgment",
+   "what": "phase4-coordinator and phase5-gateway are separate Go modules (go.mod: macprovider-coordinator vs macprovider-gateway) with zero code sharing \u2014 only a doc comment in the gateway references the coordinator (store.go:73). Each reimplements: a SQLite DSN-pragma helper that is byte-for-byte identical except the function name (coordinator sqliteutil/dsn.go:8-23 WithPragmas vs gateway storage/sqlite/dsn.go:8-23 sqliteDSN \u2014 same four pragmas, same separator logic), a hashed-secret auth store, an operator-bearer constant-time check, and an operator explorer (read-only SQLite queries + JSON API). The billing concepts, by contrast, are genuinely DIFFERENT domains \u2014 coordinator owns the provider-payout ledger (ledger_request_credits/operator_credits/payout_ready, billing/store.go:44-159) while the gateway owns buyer-side quota reservations \u2014 so that is correct separation, not duplication.",
+   "where": [
+    "phase4-coordinator/internal/sqliteutil/dsn.go:8-23",
+    "phase5-gateway/internal/storage/sqlite/dsn.go:8-23",
+    "phase5-gateway/internal/storage/sqlite/store.go:73"
+   ],
+   "why": "The two-service split itself is a sound boundary (public buyer-identity/OAuth/quota plane vs internal provider-pool/routing/payout plane, deployable and blast-radius-isolated). The cost is small, duplicated infrastructure code that must be patched twice: the identical DSN helper is the clearest example \u2014 if the team ever changes a pragma (e.g. busy_timeout) for a production incident, they must remember to change it in both modules, and there is no compiler or test linking them. At 2-person/6-week scale this is an acceptable trade (a shared module adds versioning overhead), but it is worth naming as conscious debt rather than letting the copies silently diverge.",
+   "confidence": "high",
+   "suggestedFix": "Either accept the duplication explicitly (document it in AGENTS.md as 'these helpers are intentionally cloned, keep in sync') or, if a third Go service ever appears, promote the truly-generic bits (DSN pragmas, operator-bearer compare, BEGIN IMMEDIATE tx helper) into a small internal shared module. Do not merge the billing/quota layers \u2014 they are correctly distinct.",
+   "id": "ARCH-5",
+   "dimension": "architecture",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three citations check out. phase4-coordinator/internal/sqliteutil/dsn.go:8-23 and phase5-gateway/internal/storage/sqlite/dsn.go:8-23 are byte-for-byte identical in logic (same four pragmas, same separator check, same url.Values encoding). The operator-bearer constant-time compare is also duplicated verbatim (coordinator auth/tokens.go:41-54 vs gateway router/server.go:2076-2089). No go.work file exists \u2014 the modules are fully isolated with no shared dependency. The store.go:73 reference correctly points to a doc comment cross-referencing the coordinator, not actual sharing. The billing-domain distinction (ledger_request_credits/payout_ready in coordinator vs buyer quota in gateway) is correctly characterized as intentionally separate. Low severity is correctly calibrated: the only real risk is a missed pragma patch in one service during a production incident, which is unlikely at N=3/2-person scale but worth naming as conscious debt."
+   }
+  },
+  {
+   "title": "Coordinator buyer handler embeds billing/request-log persistence wiring directly in HTTP-handler closures",
+   "severity": "Low",
+   "kind": "judgment",
+   "what": "Inside handleChatCompletions, the logRowWithBilling closure (buyer/server.go:851-945) directly constructs requestlog.Row and billing.HotPathInput, calls billing.RateFor / ParseMultiplierPPM / ParseShareBps, picks between billingStore.WriteHotPath and the WriteRequestLogWithIdentity fallback, and resolves stable provider identity by scanning s.pool.Snapshot() (894-901) \u2014 all inline in the request handler. The handler thus owns persistence-orchestration logic, not just HTTP concerns. The gateway shows the cleaner alternative: its chat handler talks only to the s.store interface (ReserveQuota/AcquireConcurrency/RefundReservation at server.go:1325-1380), keeping persistence behind a role-segregated interface (storage/interfaces.go).",
+   "where": [
+    "phase4-coordinator/internal/buyer/server.go:851-945",
+    "phase4-coordinator/internal/buyer/server.go:317-349",
+    "phase5-gateway/internal/router/server.go:1325-1380"
+   ],
+   "why": "Business/persistence logic living in the HTTP handler closure means the billing computation cannot be unit-tested independently of the HTTP path, and the buyer.Server struct couples directly to concrete *billing.Store and *requestlog.Store (server.go:69-81) rather than to interfaces (only requestLogInserter at 104-106 is abstracted). This is the layering inconsistency between the two services: the gateway is interface-clean, the coordinator's hottest handler is not. Consequence is testability and the difficulty of changing the billing write strategy without editing the 510-line handler. Note this is a real but second-order issue \u2014 the money math itself is correctly isolated in billing/formula.go.",
+   "confidence": "high",
+   "suggestedFix": "Hoist the logRowWithBilling closure into a method on a small billing-recorder type (or onto Server) that takes a struct of inputs, so the persistence orchestration is testable in isolation and the handler just calls recorder.Record(...). Pair with the loop-extraction refactor from the first finding.",
+   "id": "ARCH-6",
+   "dimension": "architecture",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All cited lines verified. The logRowWithBilling closure at buyer/server.go:851-945 does directly construct requestlog.Row and billing.HotPathInput, call billing.RateFor/ParseMultiplierPPM/ParseShareBps, manage the WriteHotPath/WriteRequestLogWithIdentity fallback, and scan pool.Snapshot() for stable provider identity. Server holds concrete *billing.Store (line 79) and *requestlog.Store (line 70) vs the gateway's interface-backed store (server.go:38). The testability claim is partially softened by full integration tests in server_test.go (e.g. TestSuccessfulNonStreamingBillingClampsInflatedProviderCompletion) that do exercise the billing path end-to-end \u2014 but they require spinning up the full server, confirming the isolation gap is real. Low severity is appropriate: money math is correctly isolated in billing/formula.go, tests cover outcomes, and this is second-order architectural debt.",
+    "correction": "The \"cannot be unit-tested\" framing is slightly too strong \u2014 the billing path is covered by integration tests in server_test.go that exercise the full HTTP handler. The accurate statement is that the billing orchestration cannot be tested *in isolation* without the full server setup, not that it is untested entirely."
+   }
+  },
+  {
+   "title": "handleChatCompletions is a 511-line function with three near-duplicate retry/failover loops",
+   "severity": "High",
+   "kind": "judgment",
+   "what": "phase4-coordinator buyer/server.go handleChatCompletions spans lines 840-1350 (511 lines). It contains three separate, structurally near-identical retry/failover loops: the streaming-WS path (~1080-1152), the non-streaming-WS path (1154-1245), and the HTTP-forwarding path (1246-1349). Each loop independently repeats the same logic: dispatchBodyForProvider, forward, classify result, exclude routeKey, call shouldRetry, selectProviderExcluding, log the attempt, increment explicitRetries/faultedProviders, and continue. The same selectProviderExcluding + routeErr handling + routingDone = s.now() + explicitRetries++ block appears verbatim at least 5 times (1105-1118, 1138-1151, 1179-1195, 1233-1243, 1335-1348). Roughly six closures (logRowWithBilling, logRow, logBuyerFailure, logProviderRow, logProviderRowWithEstimate, logAttempt) are defined inline at 851-1031 before the routing logic even starts.",
+   "where": [
+    "phase4-coordinator/internal/buyer/server.go:840",
+    "phase4-coordinator/internal/buyer/server.go:1080-1152",
+    "phase4-coordinator/internal/buyer/server.go:1154-1245",
+    "phase4-coordinator/internal/buyer/server.go:1246-1349",
+    "phase4-coordinator/internal/buyer/server.go:1105-1118",
+    "phase4-coordinator/internal/buyer/server.go:1335-1348"
+   ],
+   "why": "This is the money-path + routing spine of the live coordinator. Three copies of the retry/failover/billing-log dance mean a correctness fix (e.g. a breaker-bookkeeping or billing-attempt-counter bug) must be applied identically in three places, and the repo map already notes 'correctness currently relies on the large internal test suite rather than structure.' In a 2-person beta touching billing, the high edit-divergence risk here is the single biggest maintainability hazard in the Go codebase. The three loops already differ subtly (only the WS-non-streaming path does failoverCandidate at 1212; only HTTP does per-attempt context timeouts at 1262) \u2014 exactly the kind of drift that hides bugs.",
+   "confidence": "high",
+   "suggestedFix": "Extract the shared retry skeleton into a single helper that takes a per-transport forward closure and a result classifier, so the three transports differ only in their forward function. At minimum, factor the duplicated selectProviderExcluding/routeErr/explicitRetries++/logRoutingDecision tail (appears 5x) into one advanceToNextProvider(...) helper. Do it behind the existing test suite, one transport at a time.",
+   "id": "CODE-1",
+   "dimension": "codequality",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All cited lines check out. handleChatCompletions runs from line 840 to 1350 (511 lines). Six closures are defined at 851-1045 before routing logic. Three structurally distinct retry segments exist with the selectProviderExcluding + routingDone + explicitRetries++ + faultedProviders++ + excluded + logRoutingDecision tail appearing at 1105-1118, 1138-1152, 1179-1195, 1335-1348. Auditor's subtle-drift observation is confirmed: the QueueFull path at line 1233 calls selectProviderExcluding but omits explicitRetries++ \u2014 already a real divergence. failoverCandidate is WS-non-streaming only (line 1212); per-attempt context timeout is HTTP-only (line 1263). High severity is calibrated correctly for a live money-path handler where billing counter bugs must be fixed identically in three places.",
+    "correction": "Minor boundary correction: the streaming section (1056-1153) is a single for-loop containing both WS-streaming and HTTP-streaming in branches, not two separate loops. The auditor's loop-count is slightly off in description but the duplicated retry-tail count and the structural duplication claim are accurate."
+   }
+  },
+  {
+   "title": "Synchronous SQLite audit write runs while the global pool RWMutex is held on every model-swap heartbeat",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "pool.Registry.ApplyHeartbeat takes r.mu.Lock() with defer Unlock() at the top (provider.go:483-484) and, at line 542-543, invokes r.swapEmitter(...) while still holding that lock when a swap completes. The wired emitter in main.go:94-111 calls auditStore.EmitSwap(shutdownCtx, event) \u2014 a synchronous SQLite INSERT \u2014 inside that callback. So a completed-swap heartbeat performs blocking database I/O while holding the single registry lock that also serializes selectProvider, Snapshot, and every other provider's heartbeat. The concurrency contract comment at provider.go:446-456 explicitly documents and accepts this (and notes a panic in the emitter crashes the heartbeat handler).",
+   "where": [
+    "phase4-coordinator/internal/pool/provider.go:483-484",
+    "phase4-coordinator/internal/pool/provider.go:542-543",
+    "phase4-coordinator/internal/pool/provider.go:446-456",
+    "phase4-coordinator/cmd/coordinator/main.go:94-111"
+   ],
+   "why": "On the RAM-constrained single VPS where the coordinator and gateway co-host and SQLite is under WAL busy_timeout contention from multiple *sql.DB handles, a slow audit INSERT during a model swap stalls ALL routing decisions and heartbeat processing for the duration of the lock hold. It only fires on swap-completion heartbeats (rare today), which keeps it Medium, but warm-swap is a beta feature being exercised, and the failure mode is a coordinator-wide routing stall \u2014 the kind of thing that looks like a mysterious latency spike in production.",
+   "confidence": "high",
+   "suggestedFix": "Capture the SwapEvent under the lock, then emit it after r.mu.Unlock() (e.g. collect into a slice and fire emitters in a deferred-after-unlock step, or hand off to a small buffered channel drained by a dedicated goroutine). This keeps the audit write off the hot lock while preserving best-effort semantics.",
+   "id": "CODE-2",
+   "dimension": "codequality",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All four cited locations were confirmed by direct reading. provider.go:483-484 takes r.mu.Lock() with defer Unlock(). Lines 542-543 invoke r.swapEmitter() synchronously while still inside that lock. main.go:94-111 wires swapEmitter directly to auditStore.EmitSwap(), which is a real db.ExecContext INSERT (audit/store.go:103-115). No goroutine dispatch wraps the call anywhere \u2014 handleHeartbeat calls ApplyHeartbeat synchronously (ws/server.go:950). The audit and requestlog stores both open against cfg.Storage.DBPath (same SQLite file, different *sql.DB handles). sqliteutil.WithPragmas sets busy_timeout=5000 \u2014 so a contention event can block the lock for up to 5 seconds. The concurrency-contract comment explicitly states the emitter MUST NOT block for long but provides no enforcement. Medium severity is accurate: swap events are rare but the failure mode (full routing stall) is real."
+   }
+  },
+  {
+   "title": "Buyer-facing tier2 trust disclosure is synthesized from deeply-nested untyped map[string]any with silent fallbacks",
+   "severity": "Medium",
+   "kind": "judgment",
+   "what": "phase5-gateway tier2ModelHashState (server.go:1020-1068) parses the coordinator's /v1/models response by walking map[string]any / []any with unchecked type assertions and silent defaults: data, _ := body[\"data\"].([]any) (1022), entry, _ := item.(map[string]any) (1025), hv, ok := entry[\"hash_verification\"].(map[string]any) (1030), plus intFromModelField returning 0 on any non-numeric (1070-1080). If the coordinator changes any of these field names/shapes, the function silently returns active=false / state=\"none\" with no error \u2014 and that value feeds the buyer-facing trust disclosure. Tellingly, the same file uses a properly-typed struct (coordinatorRoutingMetadata, server.go:1082-1097) for the routing metadata immediately below, so both patterns coexist; the untyped one happens to be on the trust-claim path.",
+   "where": [
+    "phase5-gateway/internal/router/server.go:1020-1068",
+    "phase5-gateway/internal/router/server.go:1070-1080",
+    "phase5-gateway/internal/router/server.go:1082-1097"
+   ],
+   "why": "This synthesizes the hash-verification trust state shown to buyers (the project's 'signed/verified' value proposition). A silent parse degradation doesn't error or alert \u2014 it just downgrades displayed trust to 'none', or (worse, if a count field is renamed) miscounts verified vs non-verified providers and shows 'all'/'partial' incorrectly. Because the two services version independently (SPEC-002 vs SPEC-006) and the disclosure is exactly the surface a buyer relies on, a quiet cross-service schema drift here misrepresents trust with no signal to operators.",
+   "confidence": "medium",
+   "suggestedFix": "Deserialize the coordinator /v1/models payload into typed structs (as already done for coordinatorRoutingMetadata) with json.RawMessage where polymorphism is genuinely needed, and emit a slog warning when an expected field is absent/unparseable rather than defaulting to zero silently. Add a single golden-fixture test pinning the coordinator response shape.",
+   "id": "CODE-3",
+   "dimension": "codequality",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "downgrade",
+    "correctedSeverity": "Low",
+    "correction": "The finding correctly identifies the untyped map[string]any parse pattern and the typed/untyped coexistence. However, it misses the critical fallback architecture at server.go:930-943: when `coordinatorRoutingMetadataFresh` succeeds and has active tier2 dimensions, the typed `metadata.Tier2.ModelHash.State` overrides the body parse result (line 942: `if !bodyActive { state = disclosureStateFromMetadata(metadata.Tier2.ModelHash.State) }`). Silent body-parse degradation only becomes the final word when the `/internal/routing` endpoint is also unreachable \u2014 and in that case the function returns early with limited disclosure (line 935). Three integration tests (TestModelsDisclosureReflectsTier2HashState, TestModelsDisclosureFailsClosedWhenHashRowsLackFreshActiveMetadata, TestModelsDisclosureUsesPhase1FallbackWhenRoutingUnavailableButBodyHasHashRows) provide golden-fixture coverage of exactly this field. The real residual concern is that when routing metadata is unavailable but body hash rows ARE present (Phase 1 fallback path), the body parse becomes load-bearing with no typed validation \u2014 a schema rename there would miscalculate provider counts with no error. This is a real but narrow gap (2-provider production pool, single coordinator version in lockstep) \u2014 Low severity for this beta, not Medium.",
+    "reasoning": "The untyped parse at 1022-1055 is real code, citations accurate. But the auditor missed the dominant code path: tier1DisclosureForModels (line 930) first fetches typed /internal/routing metadata; when that succeeds and has active tier2, line 942 replaces any body-parse result with the typed metadata state. Silent body-parse degradation only determines the final output in the Phase 1 fallback (routing endpoint down but body has hash rows) \u2014 a narrow failure mode. Three tests pin the coordinator response shape. Severity downgrade to Low is warranted for a 2-provider beta where both services are co-deployed."
+   }
+  },
+  {
+   "title": "readLimitedBody and the OpenAI writeError envelope are copy-pasted across the coordinator and gateway modules",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "readLimitedBody is byte-for-byte identical in phase4-coordinator/internal/buyer/server.go:3139-3152 and phase5-gateway/internal/router/server.go:2169-2182 (only the error message text differs). The OpenAI {error:{message,type,code}} envelope writer exists in three copies with two different signatures: buyer/server.go:3111/3123 (writeError/writeErrorTyped), billing/endpoints.go:524 (a third writeError with a different/leaner shape), and gateway router/server.go:2304. The operator-bearer constant-time check (hmac.Equal over sha256 of the token) is independently reimplemented in auth/tokens.go:54 and gateway router/server.go:2089.",
+   "where": [
+    "phase4-coordinator/internal/buyer/server.go:3139-3152",
+    "phase5-gateway/internal/router/server.go:2169-2182",
+    "phase4-coordinator/internal/buyer/server.go:3111-3137",
+    "phase4-coordinator/internal/billing/endpoints.go:524",
+    "phase5-gateway/internal/router/server.go:2304",
+    "phase4-coordinator/internal/auth/tokens.go:54"
+   ],
+   "why": "These two services share a wire contract (the same OpenAI error envelope must be emitted to buyers from both layers), yet there is no shared package, so the envelope shape can and does already diverge \u2014 billing/endpoints.go:524 omits the type/param fields the buyer/gateway writers include. For a beta this is low severity, but the divergent error shapes are a real client-facing inconsistency, and the duplicated security-sensitive constant-time auth check is the kind of thing you want defined once.",
+   "confidence": "high",
+   "suggestedFix": "Promote the shared HTTP helpers (limited-body reader, OpenAI error envelope, operator-bearer check) into a small shared module (e.g. a common go module or a vendored internal/httpx) imported by both services, or at minimum unify the three writeError variants within the coordinator so the envelope shape is identical everywhere.",
+   "id": "CODE-4",
+   "dimension": "codequality",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three claims verified by reading the cited lines. readLimitedBody is structurally identical across both files (lines 3139-3152 and 2169-2182), differing only in the over-limit error value. The writeError envelope does diverge: buyer/server.go emits 4 fields (message/type/param/code), gateway/router/server.go emits 3 (no param), and billing/endpoints.go emits 2 (code+message only). The HMAC bearer check in auth/tokens.go:41-54 and gateway/router/server.go:2076-2089 are byte-for-byte identical; confirmed gateway go.mod has no coordinator dependency so the duplication is real. Low severity is well-calibrated \u2014 the billing/endpoints.go shape divergence is a real client-facing inconsistency but not money-loss or exploitable today."
+   }
+  },
+  {
+   "title": "Dead/unreachable branch in CoordinatorClient legacy connect path",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "connectAndRun (CoordinatorClient.swift:235-241) calls connectAndRunLegacy ONLY in the else branch where wsTunneledMode == false (line 238-239). But connectAndRunLegacy's body opens with `if wsTunneledMode { inferenceRelay = InferenceRelay(...) } else { inferenceRelay = nil }` (lines 280-293). Since the function is unreachable when wsTunneledMode is true, the entire true-branch InferenceRelay construction at 281-291 is dead code. Separately, receiveAuthChallenge is wrapped in a no-op `do { challenge = try await ... } catch { throw error }` (lines 255-257) that rethrows without adding any handling.",
+   "where": [
+    "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:235-241",
+    "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:278-293",
+    "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:255-257"
+   ],
+   "why": "Dead code on the connection path is misleading to the next maintainer: a reader debugging legacy (endpoint_url) mode will reasonably assume an InferenceRelay is constructed there, when by control flow it never is (the repo map's own note). The no-op do/catch adds visual noise suggesting error handling that does nothing. Both are harmless at runtime but cost reading time on a load-bearing actor.",
+   "confidence": "high",
+   "suggestedFix": "Delete the unreachable `if wsTunneledMode` true-branch in connectAndRunLegacy (set inferenceRelay = nil unconditionally and add a comment that this path is endpoint_url-only), and remove the redundant do { } catch { throw error } wrapper around receiveAuthChallenge.",
+   "id": "CODE-5",
+   "dimension": "codequality",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three cited locations check out exactly. connectAndRun (line 236-239) calls connectAndRunLegacy only when wsTunneledMode==false. wsTunneledMode is a let (line 78) set once at init (line 123) and never mutated, so the if wsTunneledMode true-branch inside connectAndRunLegacy (lines 280-291) is provably dead at compile time. The no-op do/catch at lines 254-257 in connectAndRunTier2 is also confirmed. No counter-evidence found in callers or config. Low severity is correctly calibrated \u2014 purely a code clarity issue, zero runtime consequence on a 2-person beta."
+   }
+  },
+  {
+   "title": "Capacity tier is persisted/parsed via hand-rolled fmt.Sprintf/Sscanf JSON instead of encoding/json",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "GetCapacityTier reads the runtime_config 'capacity_tier' value with fmt.Sscanf(value, `{\"tier\":%d,\"signals\":%q}`, ...) (store.go:767), and SetCapacityTier writes it with the matching fmt.Sprintf(`{\"tier\":%d,\"signals\":%q}`, ...) (store.go:778). The two format strings must stay byte-compatible, and the reader will error out on any value that doesn't match the exact format (including a value written by a future json.Marshal, a reordered key, or a signals string containing characters that round-trip differently through %q vs JSON string escaping).",
+   "where": [
+    "phase5-gateway/internal/storage/sqlite/store.go:756-772",
+    "phase5-gateway/internal/storage/sqlite/store.go:774-785"
+   ],
+   "why": "It's a fragile DIY serializer for a value that drives the capacity/kill-switch admin plane. The reader and writer are paired and tested, so it works today, but %q's Go-string quoting is not guaranteed JSON-equivalent for all inputs, and the format-string coupling is an easy thing to break in a future edit. Low severity because the input (operator-supplied signals string + small int) is narrow.",
+   "confidence": "high",
+   "suggestedFix": "Use json.Marshal/json.Unmarshal into the CapacityTier struct (or a small DTO) instead of Sprintf/Sscanf. It removes the format-string coupling and the %q-vs-JSON edge cases for one tiny serializer.",
+   "id": "CODE-6",
+   "dimension": "codequality",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "Lines 767 and 778 of store.go match the claim exactly: GetCapacityTier uses fmt.Sscanf with a hand-rolled format string and SetCapacityTier uses the matching fmt.Sprintf. The sibling KillSwitchState correctly uses json.Unmarshal/json.Marshal. All actual Signals values in callers are short ASCII identifiers (\"cpu\", \"monthly_cost\", \"provider_drop\", etc.), so %q vs JSON escaping does not bite today, but the format-string coupling is real. The test at store_test.go:700 only covers \"cpu\" \u2014 no edge-case inputs. Low severity is calibrated correctly: this is operator/admin-plane only, inputs are narrow, and both sides of the serializer are internal and consistent."
+   }
+  },
+  {
+   "title": "Public coordinator hostname exposes an unrate-limited /ws/provider path that bypasses the gateway's PG-2 connection limits",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "Two public nginx vhosts proxy WebSocket provider upgrades to the same coordinator port 8444. api.streamvc.live/ws/provider is rate-limited (limit_req 10r/m burst 5, limit_conn 5 per IP) at nginx-api.streamvc.live.conf:10-11,124-134. But coordinator.streamvc.live/ws/provider has NO limit_req or limit_conn directives at all (nginx-coordinator.streamvc.live.conf:65-84). An abuser simply uses the coordinator hostname to bypass every nginx-layer provider-connection limit. The only remaining backstop is the coordinator's global unauthenticated-connection semaphore (default 64, config.go:273, ws/server.go:148,220-224) \u2014 which is a single global counter with no per-IP dimension, so one source can hold all 64 slots and starve legitimate provider admissions.",
+   "where": [
+    "phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:65-84",
+    "phase5-gateway/dist/nginx-api.streamvc.live.conf:10-11",
+    "phase5-gateway/dist/nginx-api.streamvc.live.conf:124-134",
+    "phase4-coordinator/internal/ws/server.go:220-224",
+    "phase4-coordinator/internal/config/config.go:273"
+   ],
+   "why": "A single abusive host can open up to 64 concurrent half-open handshakes against coordinator.streamvc.live and exhaust the global unauthenticated-connection pool, blocking the N=3 real providers from (re)connecting. With only 3 providers, losing admission capacity is a full inference outage \u2014 directly money-affecting in the live beta.",
+   "confidence": "high",
+   "suggestedFix": "Add the same limit_req zone=ws_provider_rate and limit_conn ws_provider_conn directives to the coordinator.streamvc.live /ws/provider location that already exist on api.streamvc.live; or stop exposing /ws/provider on the coordinator hostname entirely and route all provider WS through the rate-limited api path. Additionally, make the coordinator's unauthenticated-conn cap per-IP rather than a single global counter.",
+   "id": "SECU-1",
+   "dimension": "security",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "upgrade",
+    "correctedSeverity": "High",
+    "correction": "The finding is accurate as stated. The only correction is to the severity: Medium understates the risk for a live 3-provider beta. Exhausting the 64-slot global unauthenticated semaphore blocks all provider reconnects \u2014 with only 3 providers, that is a complete inference outage affecting real billing today, which meets the High bar (real correctness/security risk likely to bite in beta). The nginx-coordinator.streamvc.live.conf:65-84 block is confirmed to have no limit_req or limit_conn; the api.streamvc.live conf:124-134 is confirmed to have both; config.go:273 confirms MaxUnauthenticatedConn default of 64; ws/server.go:148 and 820-831 confirm the semaphore is a single buffered channel with no per-IP tracking.",
+    "reasoning": "Every cited file and line was read and confirmed. nginx-coordinator.streamvc.live.conf:65-84 has the /ws/provider location with zero rate-limiting directives. nginx-api.streamvc.live.conf:10-11 defines the zones; lines 124-134 apply limit_req and limit_conn to /ws/provider on the api hostname only. config.go:273 sets MaxUnauthenticatedConn=64. ws/server.go:148 creates a buffered channel of that capacity; lines 824-831 show reserveUnauthenticatedConn is a non-blocking channel send with no IP accounting. No counter-evidence found in middleware, deploy scripts, or admission logic. The bypass path is real and exploitable with a plain TLS connection to the coordinator hostname."
+   }
+  },
+  {
+   "title": "Headline product claim 'every response carries a signed inference receipt' has zero implementation in any service",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "README.md:22,61-81 advertise, as the core differentiator, that 'Every response carries a signed receipt binding (prompt, output, provider) \u2014 verifiable inference' and document a concrete receipt schema signed with the provider's key. A grep for 'receipt' across all .go files in phase5-gateway and phase4-coordinator/internal, and all Swift sources in phase3-binary, returns zero matches. No receipt is generated, signed, returned in any response header/body, or persisted anywhere.",
+   "where": [
+    "README.md:22",
+    "README.md:61-81",
+    "phase5-gateway/internal/router/server.go:1416-1422",
+    "phase4-coordinator/internal/billing/hotpath.go:1-249"
+   ],
+   "why": "In a live public beta whose entire trust pitch is 'verifiable inference without a datacenter', buyers are told they receive a cryptographic proof of which provider ran their inference and can later resolve disputes / replay receipts into escrow or on-chain settlement. None of that exists. This is a trust-integrity gap: the security property users are paying for and relying on is absent, and the gap is invisible until someone tries to verify a receipt. Either ship a minimal signed receipt or correct the README before more users onboard.",
+   "confidence": "high",
+   "suggestedFix": "Either (a) implement the documented receipt: have the provider sign a canonical (request_id, prompt_hash, output_hash, provider_id, model) tuple with its key and surface it as a response header the gateway passes through, or (b) immediately downgrade the README language from 'every response carries a signed receipt' to a roadmap item, matching the honest tier-1 disclosure already present in pages.go:27-44.",
+   "id": "SECU-2",
+   "dimension": "security",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "downgrade",
+    "correctedSeverity": "Low",
+    "correction": "The receipt gap is real \u2014 zero production implementation exists in any Go or Swift source file. However, the severity is overstated. The system itself contradicts the README claim in two places visible to users: (1) pages.go:27-44 (tier1DisclosureText) explicitly tells buyers on the account page that \"The product makes NO privacy, attestation, integrity, untrusted-provider, or malicious-provider claims. Any buyer-facing language \u2026 MUST be consistent with properties 1-3.\" (2) beta/web/index.html:164 says directly in the demo UI: \"Signed receipts land in Phase 3.\" The README is aspirational marketing copy that contradicts the system's own honest disclosure page \u2014 this is a documentation inconsistency, not a hidden security gap that buyers are silently relying on. For a 2-person beta with 3 providers and users who see the disclosure panel on signup, this is Low, not Medium.",
+    "reasoning": "Read README.md:22,61-83 \u2014 confirms the claim verbatim. Grep across all .go/.swift confirmed zero receipt implementation. Checked pages.go:27-44: tier1DisclosureText explicitly disclaims all attestation/receipt properties and is rendered on the account page at signup. beta/web/index.html:164 explicitly says \"Signed receipts land in Phase 3.\" The gap is real but partially self-disclosed in two user-facing surfaces. Buyers who read the disclosure panel (enforced present per pages_test.go:39-44) see the correct no-attestation claim before getting an API key. README copy is stale marketing text inconsistent with the live disclosure."
+   }
+  },
+  {
+   "title": "Default tier-2 security posture is fully permissive: plaintext provider protocol, no model-hash verification, no attestation",
+   "severity": "Medium",
+   "kind": "judgment",
+   "what": "Every tier-2 trust enforcement toggle defaults to false in config.Default(): RequireEncryptedLeg=false, RequireHashVerified=false, RequireAttestation=false, BehavioralSafetyEnabled=false, EncodingValidationEnabled=false (config.go:287-297, verified block at lines 284-297). Because RequireEncryptedLeg defaults false, the v1 plaintext 'hello' provider protocol is accepted unconditionally (ws/server.go:296-323 only blocks v1 when RequireEncryptedLeg is set). So out of the box: providers can connect in cleartext, served model weights are never hash-verified against the signed catalog, and managed-device attestation is optional (provider silently omits the token with only a WARN per the repo map's Tier2Attestation note). The actual production posture is entirely dependent on the gitignored, deploy-only coordinator.yaml \u2014 not verifiable from the repo.",
+   "where": [
+    "phase4-coordinator/internal/config/config.go:287-297",
+    "phase4-coordinator/internal/ws/server.go:296-304",
+    "phase4-coordinator/internal/ws/server.go:320-323"
+   ],
+   "why": "The marketed trust guarantees (encrypted leg, model integrity, hardware attestation) are off unless an operator remembered to flip them in a file that is not in version control and has no pre-deploy gate enforcing them (check-deploy-config.sh validates operator_key and timer ordering but not tier-2 flags). A misconfigured or default-config redeploy silently downgrades a 'tier-2 verified' network to plaintext, unverified providers, and nothing in CI or the deploy gate catches it.",
+   "confidence": "medium",
+   "suggestedFix": "Add a tier-2 posture assertion to check-deploy-config.sh / deploy-pearl-vps.sh that fails the deploy if the production coordinator.yaml does not set the tier-2 enforcement flags the network claims to provide; or change the production-profile defaults to fail-closed (require_encrypted_leg=true) and document local-dev as the explicit opt-out.",
+   "id": "SECU-3",
+   "dimension": "security",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three cited locations hold up exactly. config.go:283-305 shows all five tier-2 flags defaulting false. ws/server.go:320-323 confirms v1 plaintext providers are only rejected when RequireEncryptedLeg is set. The gitignored production coordinator.yaml on disk (phase4-coordinator/dist/coordinator.yaml) sets only require_hash_verified: false under tier2 \u2014 no encrypted-leg, attestation, or behavioral-safety keys present. check-deploy-config.sh checks operator_key, heartbeat thresholds, and C2 timers but no tier-2 flags. The activate-tier2 scripts are gated runbooks for future intentional activation, confirming current production state is pre-activation. The finding's consequence is real: a default-config redeploy silently drops all tier-2 guarantees and the deploy gate won't catch it. Medium is correctly calibrated \u2014 nginx TLS terminates the external leg; the three current providers are known/trusted; this is not exploitable today but becomes a genuine risk as the network scales to anonymous provisioned providers.",
+    "correction": "Minor clarification only: the \"plaintext provider protocol\" concern applies to the coordinator WebSocket leg (provider\u2194coordinator), which traverses an encrypted Cloudflare tunnel (providers use wss:// to coordinator.streamvc.live), so end-to-end transport is not cleartext. The risk is specifically about per-session payload encryption (Pillar B encrypted leg) and the absence of hash/attestation enforcement, not raw TCP plaintext."
+   }
+  },
+  {
+   "title": "Gateway admin plane and coordinator-upstream credential are the same single shared operator key, used on the hot buyer path",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "The gateway authenticates its own admin endpoints (/admin/kill-switch, /admin/explorer/*, /admin/capacity-*) against cfg.Coordinator.OperatorKey (server.go:2061-2067), the identical token it also presents as the upstream credential to the coordinator's operator API (server.go:1402, used on the per-request sticky chat path). When sticky routing is enabled, that operator bearer is attached to proxied /v1/chat/completions requests (server.go:1394-1405), placing the operator key in the single hottest code path in the system.",
+   "where": [
+    "phase5-gateway/internal/router/server.go:2061-2067",
+    "phase5-gateway/internal/router/server.go:1394-1405",
+    "phase4-coordinator/internal/ws/server.go:1717-1718"
+   ],
+   "why": "One leaked operator key compromises three things at once: the coordinator operator API (blacklist/promote/ledger), the gateway admin plane (kill switch, capacity, buyer explorer), and \u2014 via sticky routing \u2014 the ability to forge operator-authenticated requests on the buyer path. There is no privilege separation between 'service-to-service credential' and 'human admin credential'. For a 2-person beta a shared key is defensible, but it is worth knowing the blast radius before provider/buyer count grows.",
+   "confidence": "high",
+   "suggestedFix": "Split into two secrets: a service-to-service token the gateway uses for coordinator /internal and sticky calls, and a separate human-admin token for the gateway's own /admin plane. Rotate independently.",
+   "id": "SECU-4",
+   "dimension": "security",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three cited locations confirm the claim. phase5-gateway/internal/router/server.go:2062 uses cfg.Coordinator.OperatorKey for admin-plane authorization (operatorAuthorized helper, guarding /admin/kill-switch, /admin/capacity-*, /admin/explorer/*). The same field is injected as the upstream bearer at line 1402 on the sticky chat path, and at lines 566 and 1229 for other coordinator operator-API calls. phase4-coordinator/internal/ws/server.go:1717-1718 confirms the coordinator has exactly one OperatorKey (cfg.Auth.OperatorKey). Neither service defines a separate admin or service-to-service credential in config or code. Sticky is off by default but the structural coupling exists regardless. Medium is calibrated correctly: blast radius is real but threat requires key leakage, which is low-probability with 2 operators today."
+   }
+  },
+  {
+   "title": "Operator/provider auth helpers fail OPEN when the configured key is empty (defense-in-depth gap, currently masked by config validation)",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "Three auth predicates treat an unset key as 'allow everyone': coordinator authorizedOperator returns true when OperatorKey=='' (ws/server.go:1717-1718); auth.AuthorizedBearer returns true when expected=='' (auth/tokens.go:37-38); billing endpoints gate only 'if operatorKey != \"\" && !authorized' so an empty key skips the check. This fail-open pattern is currently unreachable in a validated production config because config.Validate() requires auth.operator_key to be set (config.go:445-446) and RequireProviderTokens defaults true (config.go:358). So the runtime risk today is low, but the auth layer itself is written to fail open rather than fail closed.",
+   "where": [
+    "phase4-coordinator/internal/ws/server.go:1717-1718",
+    "phase4-coordinator/internal/auth/tokens.go:37-38",
+    "phase4-coordinator/internal/config/config.go:445-446"
+   ],
+   "why": "The safety of every operator endpoint depends on a config-validation invariant living in a different file. Any future code path that constructs a Server or calls these predicates without running full Config.Validate() (a test harness promoted to prod, a new CLI entrypoint, a partial config reload) silently opens /admin/blacklist, /admin/promote, /poolz, and the ledger to anyone. Fail-closed auth would make the invariant local and unbreakable.",
+   "confidence": "high",
+   "suggestedFix": "Invert the predicates to fail closed: an empty expected key should deny, not allow. The config-validation requirement then becomes belt-and-suspenders rather than the sole line of defense.",
+   "id": "SECU-5",
+   "dimension": "security",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "correctedSeverity": "Low",
+    "correction": "The core observation holds but one of the three cited patterns is overstated. `auth.AuthorizedBearer` (tokens.go:37-38) is declared but never called anywhere in the codebase \u2014 it is dead code, not a live auth path. The two live fail-open patterns are: (1) `authorizedOperator` in ws/server.go:1717-1718 (guards /admin/blacklist, /admin/promote, /admin/reject, /admin/provisional in ws/ and admin_endpoints.go); and (2) the billing `admin()` helper in billing/endpoints.go:63 which uses `if h.operatorKey != \"\" && !auth.BearerTokenMatchesHeader(...)` \u2014 the same semantic fail-open. The explorer's `authorized()` at handlers.go:503 uses `BearerTokenMatchesHeader` directly, which returns false when expected is empty, so the explorer is already fail-closed. The safety today genuinely depends on config.Load() calling Validate() and Validate() rejecting empty OperatorKey \u2014 that invariant is enforced at the single main.go entry point, so current production risk is low. The design-level concern (future test harness or second CLI entrypoint bypassing Validate()) is real but speculative for a 2-person beta. Low severity is correct.",
+    "reasoning": "Verified: ws/server.go:1717-1718 confirms fail-open when OperatorKey is empty. billing/endpoints.go:63 confirms the same pattern. config.go:444-446 confirms Validate() requires non-empty OperatorKey. config.Load() always calls Validate(); main.go line 33 is the sole entry point. AuthorizedBearer at tokens.go:37-38 is declared but has zero callers (grep confirmed). Explorer uses BearerTokenMatchesHeader directly \u2014 fail-closed. The finding's substance is real but the AuthorizedBearer citation is dead code, not a live attack surface. Low severity is calibrated correctly for this 2-person beta."
+   }
+  },
+  {
+   "title": "Provider-reported token counts are trusted for billing (capped, not verified)",
+   "severity": "Low",
+   "kind": "judgment",
+   "what": "On settlement the gateway prefers provider/coordinator-reported usage when present (server.go:1607-1608) and the coordinator billing hot path computes credits from the provider-supplied prompt/completion token counts (hotpath.go:96-128, ComputeCredits over in.PromptTokens/in.CompletionTokens). The gateway does bound the trust: usageFromJSON rejects negative values, enforces prompt+completion <= maxUsageTokens (= promptEstimate + buyer's max_tokens), and validates total==sum (server.go:2356-2369). So a provider cannot bill a buyer for MORE than the buyer authorized. But within that cap the counts are taken on faith \u2014 a provider can under-report (cheaper for the buyer, less revenue for itself) or report up to the cap regardless of actual work.",
+   "where": [
+    "phase5-gateway/internal/router/server.go:1607-1611",
+    "phase5-gateway/internal/router/server.go:2356-2369",
+    "phase4-coordinator/internal/billing/hotpath.go:96-128"
+   ],
+   "why": "The money path trusts a remote, semi-anonymous provisional provider's self-reported usage as the billing input. The maxUsageTokens cap correctly prevents a malicious provider from over-charging a buyer beyond their authorization, so the buyer is protected \u2014 this is why it's Low, not High. The residual risk is provider-side revenue gaming and the absence of any independent token-count attestation, which compounds finding #2 (no receipt to cross-check against).",
+   "confidence": "high",
+   "suggestedFix": "Cross-check reported completion_tokens against the gateway's own emitted-byte estimate and flag/quarantine large divergences (the quarantine machinery already exists in hotpath.go). Longer term, the signed receipt (#2) should bind the token counts so billing inputs are attestable rather than self-reported.",
+   "id": "SECU-6",
+   "dimension": "security",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three cited locations confirmed. server.go:1607-1608 does prefer provider-reported usage when `reported != nil && !invalidReportedUsage`. server.go:2356-2369 implements the cap guards (negative rejection, sum > maxUsageTokens rejection, total!=sum rejection). hotpath.go:96-128 calls ComputeCredits with provider-supplied PromptTokens/CompletionTokens. One partial mitigator exists that the finding doesn't mention: coordinator billing's billableCompletion (formula.go:214) clamps completion tokens to an independently-computed byte estimate when the estimate is lower \u2014 this limits over-reporting of completion tokens at the coordinator layer. However, the gateway's own settlement path (settleRequest at 1697) passes provider-reported counts straight through without any equivalent byte-estimate cross-check. The core trust-then-cap architecture is exactly as described. Severity Low is appropriate: the buyer-cap prevents over-charging buyers, the residual risk is provider revenue gaming within that cap, and at N=3 known providers the practical attack surface is minimal for a 2-person beta."
+   }
+  },
+  {
+   "title": "Gateway test suite has a reproducible broken test: TestConsoleStaticContracts",
+   "severity": "High",
+   "kind": "fact",
+   "what": "The test at phase5-gateway/internal/router/pages_test.go:145-147 asserts that the console HTML must not use innerHTML. The console at frontdoor/console/index.html uses innerHTML at lines 1200, 1378, 1413, and 1432 \u2014 all added by the arm64golf feature. The test fails with 'console must build status/dashboard DOM with textContent, not innerHTML' on every run. The full gateway test suite exits non-zero.",
+   "where": [
+    "phase5-gateway/internal/router/pages_test.go:145-147",
+    "frontdoor/console/index.html:1200",
+    "frontdoor/console/index.html:1378",
+    "frontdoor/console/index.html:1413",
+    "frontdoor/console/index.html:1432"
+   ],
+   "why": "A broken test suite means the CI signal is red. New regressions in the gateway router will not be caught during review because the suite is already failing. The innerHTML usages at lines 1378 and 1413 inject static HTML-literal strings and pose no XSS risk (escArm at line 1368 sanitizes the data at line 1444-1453), but the test was written to prohibit innerHTML entirely and it was not updated when the arm64golf feature landed the new usages. The test contract and the code are now inconsistent.",
+   "confidence": "high",
+   "suggestedFix": "Either (a) update the test assertion to be more specific \u2014 allow innerHTML for static literal template strings while still rejecting it for user-controlled data, or (b) rewrite the four arm64golf innerHTML blocks to use DOM methods and keep the blanket ban. Option (b) is safer long-term.",
+   "id": "TEST-1",
+   "dimension": "testing",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "downgrade",
+    "correctedSeverity": "Medium",
+    "correction": "The test failure is real and exactly as described, but the severity framing contains one factual error that affects the calibration: there is no Go test CI. The only GitHub Actions workflow is release.yml, which builds the Swift binary on tag push and never runs `go test`. The \"CI signal is red / new regressions won't be caught during review\" claim implies a green CI baseline that was broken \u2014 in reality the test suite was never run in CI to begin with. The broken test matters for local development and for any future CI adoption, but it is not blocking review today because there is no automated gate. For a 2-person beta this is Medium: a test contract that drifted from the code and will silently stay broken, but it is not causing active harm to the money path or security posture right now.",
+    "reasoning": "Verified live: go test ./internal/router/... fails at pages_test.go:146 with the exact message cited. All four innerHTML sites (lines 1200, 1378, 1413, 1432) are confirmed in frontdoor/console/index.html and are static template-literal strings with no user-controlled data interpolated. The test reads the correct file via filepath.Join(\"../../..\", \"frontdoor\", \"console\", \"index.html\"). Counter-evidence check: only one CI workflow exists (.github/workflows/release.yml), which is Swift-only and never calls go test, so the \"CI is red\" framing overstates impact. The finding is real but High overstates consequence for this project's current CI posture."
+   }
+  },
+  {
+   "title": "Latency benchmark test TestAuthLookupP95 is environment-sensitive and causes intermittent CI failure",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "phase5-gateway/internal/storage/sqlite/store_test.go:729-765 asserts that a SQLite key lookup p95 over 10,000 rows is under 1ms. The test skips under -race (raceflag_test.go:4), but under parallel test-suite load on the same machine it observed 13ms and failed (seen in the test run at 12:28:36). Three isolated re-runs of the test alone pass at 222\u00b5s, 386\u00b5s, 518\u00b5s. The test is not marked t.Skip under any other load indicator.",
+   "where": [
+    "phase5-gateway/internal/storage/sqlite/store_test.go:729-765",
+    "phase5-gateway/internal/storage/sqlite/raceflag_test.go:1-5"
+   ],
+   "why": "A performance-assertion test that can fail under CI load produces spurious red builds, eroding trust in the test suite. The 1ms budget is tight for a test that populates 10,000 rows via per-row INSERT and then benchmarks reads; on a loaded developer machine or a constrained CI runner this will flake. The project already has notes in memory about load-dependent test flakes.",
+   "confidence": "high",
+   "suggestedFix": "Either raise the threshold (10ms is still very fast for an indexed SQLite lookup) or gate it with a softer t.Log + t.Skip rather than t.Fatalf when running alongside other packages. Alternatively, move it to a named benchmark (BenchmarkAuthLookup) which is not run by default.",
+   "id": "TEST-2",
+   "dimension": "testing",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "downgrade",
+    "correctedSeverity": "Low",
+    "correction": "The test code is exactly as cited \u2014 a hard 1ms t.Fatalf threshold, skipped only under -race, with no other load guard. However, the stated consequence (\"spurious red builds, eroding trust in the test suite\") does not apply: the repo has exactly one CI workflow (/.github/workflows/release.yml) which builds the Swift binary only and never invokes go test. There is no Go test CI. The flake risk is confined to local developer runs. The finding is real as a code-quality observation (the threshold is tight enough to fail under parallel local load), but Medium severity requires a CI or production impact that does not exist here. Downgrade to Low.",
+    "reasoning": "Read store_test.go:729-765, raceflag_test.go, and raceflag_norace_test.go \u2014 all exactly as claimed. The test uses t.Fatalf with a 1ms hard ceiling, skipped under -race only. Checked .github/workflows/ \u2014 only release.yml exists; it builds the Swift CLI and runs no Go tests at all. \"Spurious red builds\" cannot happen with no Go test CI. The underlying code quality issue (tight threshold, no load guard) is real but the consequence is local-only flakiness for a 2-person team, making this Low rather than Medium."
+   }
+  },
+  {
+   "title": "ws/server_test.go uses unconditional time.Sleep for timing-sensitive liveness tests",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "Three time.Sleep calls in ws/server_test.go tie test correctness to wall-clock timing: line 1493 sleeps 1100ms to exceed a 1-second WakeGapThresholdS; lines 1715 and 1759 sleep 200ms and 150ms in a loop to simulate streaming activity. These tests set HeartbeatMissThresholdS=1, DisconnectGracePeriodS=5, WakeGapThresholdS=1 \u2014 configuration that makes the tests pass in 1-second real wall time. The ws package takes 47.8s to complete versus 6-14s for all other packages.",
+   "where": [
+    "phase4-coordinator/internal/ws/server_test.go:1493",
+    "phase4-coordinator/internal/ws/server_test.go:1715",
+    "phase4-coordinator/internal/ws/server_test.go:1759"
+   ],
+   "why": "The 1100ms sleep at line 1493 will fail on slow CI machines where the scheduler doesn't wake the goroutine before the server's 1-second threshold fires. The 47.8-second runtime for this package makes it the dominant cost of `go test ./...` by 3-5x. The project's memory already documents load-dependent flakes in this file. While the `eventually` helper (lines 2554-2571) is correct for async assertions, the unconditional sleeps cannot adapt to machine load.",
+   "confidence": "high",
+   "suggestedFix": "Replace the sleep-then-check pattern at line 1493 with a short sleep of 50ms followed by an eventually() loop checking the pool state. The liveness tests at 1715/1759 use the sleep inside a timing loop; inject a fake clock or use a configurable mock timer rather than real wall time.",
+   "id": "TEST-3",
+   "dimension": "testing",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "correctedSeverity": "Medium",
+    "correction": "The three cited sleeps exist exactly as described. However, the stated flake mechanism for line 1493 is backwards: `time.Sleep(1100ms)` guarantees the goroutine sleeps at *least* 1100ms, so on a slow/loaded machine the gap grows larger \u2014 reliably exceeding the 1s WakeGapThreshold, not failing to exceed it. The actual flake risk at line 1493 is server-side: if the liveness-monitor goroutine is starved, it may not process the gap and emit warm_up within the downstream `eventually` 2-second window. The sleeps at lines 1715/1759 are setup pacing inside a deadline loop and a 3-iteration burst; they feed `eventually()` assertions and are not themselves the correctness boundary. The \"47.8s runtime\" claim is plausible but the dominant contributor is the 3-second wall-clock loop at line 1704 and multiple 2-second `eventually` timeouts, not the three cited sleeps alone. The project memory confirms prior load-dependent flakes in this file (AfterFunc version, 14/15 failures under load). Finding is real: the package is legitimately slow due to wall-clock-coupled tests, with a real (if differently-mechanised) flake risk on loaded machines \u2014 and there is no Go test CI to catch regressions. Medium severity is appropriate for a 2-person beta.",
+    "reasoning": "Read server_test.go lines 1477-1517, 1700-1767, 2289-2337, 2554-2571, and config defaults (HeartbeatMissThresholdS=90, WakeGapThresholdS=120). All three sleeps confirmed at cited lines. The 1493 sleep creates a >1s gap between heartbeats to trigger WakeGap; time.Sleep guarantees minimum duration so the flake direction claimed is wrong. Lines 1715/1759 are loop-pacing sleeps followed by eventually(). The test package has 62 test functions, a 3s wall-clock loop, and many 2s eventually timeouts contributing to slow runtime. Project memory confirms load-dependent flakes historically. No Go test CI exists (release.yml only builds Swift)."
+   }
+  },
+  {
+   "title": "tier2 catalog global state makes tests order-dependent; ResetForTest is a workaround, not a fix",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "internal/tier2/catalog.go:81-84 declares a package-global `var global` singleton mutated by Configure() and ConfigureStrict(). Every test in catalog_test.go calls `defer ResetForTest()` to clean it up (confirmed at catalog_test.go:22, 38, 63, 80, 91, 123, etc.). No test in the file uses `t.Parallel()`. If any test runs in parallel with another that calls Configure(), the global state becomes shared mutable state and the test will see a different catalog than expected.",
+   "where": [
+    "phase4-coordinator/internal/tier2/catalog.go:81-84",
+    "phase4-coordinator/internal/tier2/catalog.go:169-174",
+    "phase4-coordinator/internal/tier2/catalog_test.go:22",
+    "phase4-coordinator/internal/tier2/catalog_test.go:38",
+    "phase4-coordinator/internal/tier2/catalog_test.go:91"
+   ],
+   "why": "Currently safe because no t.Parallel() is used, but the design prevents parallelization of this test package. More seriously, any future test that imports tier2 and calls Configure() (e.g., integration-style tests) will silently corrupt the state seen by catalog tests if they run concurrently. The design repo map already flags this as untestable in parallel. At beta scale this is Medium; it will become a flake when the test suite grows.",
+   "confidence": "high",
+   "suggestedFix": "Pass a catalog instance directly through to callers instead of via package-global state. ws/server.go and pool/provider.go call tier2.VerifyProviderHash() \u2014 these could accept a catalog dependency. This also removes the SIGHUP reload race on the global singleton.",
+   "id": "TEST-4",
+   "dimension": "testing",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All cited lines check out: catalog.go:81-84 declares the package-global `var global` struct; ResetForTest at 169-174 resets it; catalog_test.go has `defer ResetForTest()` at lines 22, 38, 63, 80, 91, 123, 156, 174, etc. No `t.Parallel()` calls exist anywhere in the package or in the other packages (main_test.go, buyer/server_test.go, ws/server_test.go) that also call `tier2.Configure` and `tier2.ResetForTest`. The pattern spreads across at least three separate test packages. The SIGHUP reload via `ConfigureStrict` on the same global is confirmed in main.go:179/295. Medium is correctly calibrated \u2014 no current flakes, but the design actively prevents parallelization across packages that already share this global."
+   }
+  },
+  {
+   "title": "No test covers the fail-open operator-key path (empty OperatorKey allows any caller on /poolz, /admin/*)",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "ws/server.go:1717-1718 reads: `return s.cfg.Auth.OperatorKey == \"\" || auth.BearerTokenMatchesHeader(...)`. All ws/server_test.go tests set `cfg.Auth.OperatorKey = \"test-operator-key\"` at line 2312 \u2014 so every test is run with auth enabled. TestPoolzRequiresOperatorKey at line 1769 only verifies that a missing bearer returns 401 when a key IS configured. There is no test verifying (or blocking) the fail-open behavior when OperatorKey is empty. config.Validate() at config.go:445-447 does reject empty keys, but that is a separate code path that tests could bypass.",
+   "where": [
+    "phase4-coordinator/internal/ws/server.go:1717-1718",
+    "phase4-coordinator/internal/ws/server_test.go:2312",
+    "phase4-coordinator/internal/ws/server_test.go:1769-1781",
+    "phase4-coordinator/internal/config/config.go:445-447"
+   ],
+   "why": "The actual production safety relies entirely on coordinator.yaml having `operator_key` set \u2014 which is a deploy-time property not verifiable from the repo. A test that calls `newProviderServer` without setting the key would expose the fail-open behavior directly. With real money at stake, a security regression that re-enables fail-open (e.g., a config reload bug zeroing the key) would be undetected by any existing test.",
+   "confidence": "high",
+   "suggestedFix": "Add a test: construct a server with an empty OperatorKey (bypassing Validate()), confirm /poolz returns 200, then add a regression-lock comment noting this is the documented fail-open behavior and must remain guarded by Validate(). Alternatively, change authorizedOperator to return false (fail-closed) when OperatorKey is empty, which is the safer invariant.",
+   "id": "TEST-5",
+   "dimension": "testing",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "downgrade",
+    "correctedSeverity": "Low",
+    "correction": "The fail-open behavior at ws/server.go:1718 is real and no test exercises it. However, the threat vector given in the \"why\" is wrong: the SIGHUP reload path (reloadTier2Config in main.go:285) only replaces Tier2Config fields \u2014 it never touches Auth.OperatorKey. The OperatorKey is immutable after startup. The \"config reload bug zeroing the key\" scenario does not exist in the current code. The actual risk is that a future unit test constructing a server directly (bypassing config.Load/Validate) could unknowingly exercise the fail-open branch and pass a false security signal. For a live 2-person beta where the OperatorKey is set in YAML and validated at startup, this is a test-hygiene issue rather than a production security gap. Suggested fix in the finding (add a regression-lock test, or change authorizedOperator to fail-closed when key is empty) remains sound, but the severity is Low, not Medium.",
+    "reasoning": "All four citations verify exactly as described. ws/server.go:1718 has `OperatorKey==\"\" || BearerTokenMatchesHeader(...)` (fail-open). config.go:445-447 rejects empty keys in Validate(). server_test.go:2312 always sets a non-empty key; line 1769-1781 only tests the auth-enabled path. Counter-evidence: BearerTokenMatchesHeader itself returns false for empty expected (auth/tokens.go:43-44), so the fail-open is purely the explicit `||` short-circuit. The SIGHUP reload path (reloadTier2Config) never mutates Auth.OperatorKey, invalidating the \"reload bug\" threat vector. The gap is real but confined to test hygiene."
+   }
+  },
+  {
+   "title": "No cross-service integration test exists between coordinator and gateway",
+   "severity": "Medium",
+   "kind": "judgment",
+   "what": "All tests in phase4-coordinator and phase5-gateway test each service in isolation. The gateway's integration_test.go (e.g., TestStrangerKeyOpenAIChatUsageFlow) uses a round-trip HTTP mock (roundTripFunc) that stubs the coordinator response. The coordinator's buyer/server_test.go mocks the provider relay. There is no test that runs both HTTP services against each other \u2014 for example, verifying that the gateway's quota reservation + coordinator's billing write stay consistent, or that the operator-key forwarding on sticky routes (gateway server.go:1401-1405) is accepted by the coordinator's buyer port.",
+   "where": [
+    "phase5-gateway/internal/router/integration_test.go:19-82",
+    "phase4-coordinator/internal/buyer/server_test.go:1-30"
+   ],
+   "why": "The two services share a money path: gateway reserves quota \u2192 coordinator writes ledger. A protocol drift between them (e.g., a header name change, a JSON field rename, or a token format change) would not be caught until a production request fails. The harness.py in beta/ exercises this end-to-end but it requires live infrastructure and is not part of `go test`. At beta scale with N=3 providers and real money, a regression here directly affects billing.",
+   "confidence": "high",
+   "suggestedFix": "Add a test package (e.g., test/integration/) that starts both services with httptest.NewServer, performs a full OAuth signup \u2192 API key issue \u2192 chat request \u2192 settlement cycle, and asserts the ledger rows in the coordinator's SQLite. A mock provider (tools/mockprovider) already exists to complete the triangle.",
+   "id": "TEST-6",
+   "dimension": "testing",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "correctedSeverity": "Medium",
+    "correction": "The finding is real and the citations hold, but the description of the money path is imprecise. The gateway and coordinator do NOT share a ledger; they maintain independent SQLite stores (gateway: quota_reservations/usage_events for buyer-quota; coordinator: billing store for provider payouts). The protocol-drift risk is real \u2014 the sticky-route path at gateway/server.go:1401-1405 forwards Authorization: Bearer + X-MacProvider-Account + X-MacProvider-Internal-Conv to the coordinator, and neither service's unit tests cover the cross-service contract for these headers. The harness.py in beta/ does NOT exercise the gateway\u2192coordinator path: config.yaml targets a direct provider tunnel and config-coord.yaml targets coordinator.streamvc.live directly, bypassing the gateway entirely. The tools/mockprovider exists in the coordinator repo and could complete a triangle test. Severity Medium is correct: a protocol drift would not cause immediate money loss (stores are independent and append-only), but could cause billing discrepancy or silent sticky-route failure during the beta.",
+    "reasoning": "Read integration_test.go:19-82 (gateway uses roundTripFunc stub for coordinator) and buyer/server_test.go:1-30 (coordinator mocks provider relay) \u2014 both citations accurate. Searched entire repo: no cross-service test directory exists. Confirmed gateway settles to its own SQLite store (store.go:435-477) and coordinator has its own billing.Store. The sticky-route operator-key forwarding at server.go:1401-1405 writes Authorization + account headers that coordinator's internalBearerAuthorized (server.go:2694) must validate \u2014 zero test coverage across the boundary. harness.py targets tunnel directly, not the full gateway stack."
+   }
+  },
+  {
+   "title": "Swift test suite cannot be run in CI and has no counterpart in the release workflow",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "The only CI workflow is .github/workflows/release.yml, which builds a release binary and signs it. It does not run `swift test`. The 16 Swift test files (4,264 LOC total) cover CoordinatorClient, InferenceRelay, ModelRuntime swap, tier-2 crypto, self-update security, and end-to-end acceptance \u2014 all critical provider-side behavior. These tests are runnable locally but are never verified on a commit-by-commit basis.",
+   "where": [
+    ".github/workflows/release.yml:1-120",
+    "phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift:1-1057",
+    "phase3-binary/Tests/macprovider-cliTests/SelfUpdateTests.swift:1-180"
+   ],
+   "why": "A regression in the Swift binary (wrong auth handshake, broken AEAD framing, self-update security bypass) would only be caught when the binary is manually tested on a physical Mac. At beta scale, a broken binary pushed to providers would disconnect all N=3 providers simultaneously. `swift test` takes several minutes on macos-15 but GitHub Actions supports it with caching.",
+   "confidence": "high",
+   "suggestedFix": "Add a separate CI job to release.yml (or a new push/PR workflow) that runs `swift test --parallel` on a macos-15 runner before the release build step, gated so it does not block release on tag pushes if latency is a concern.",
+   "id": "TEST-7",
+   "dimension": "testing",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All cited facts confirmed: release.yml (lines 1-151) has exactly one job \u2014 build + sign + publish, no `swift test` step. The only other workflow file does not exist (only release.yml is in .github/workflows/). The 16 Swift test files exist with a verified 4,264 total LOC, including Tier2ProviderSessionTests (AEAD replay tests), SelfUpdateTests (signing bypass guards), and CoordinatorClientTests (1,057 lines). package.sh runs xcodebuild clean build only. No Makefile, no pre-commit hook, no other CI mechanism runs the tests. Severity \"Low\" is calibrated correctly for a 2-person beta: releases are manually tag-gated (not every commit), the team can run tests locally before tagging, and a broken binary causing provider disconnects is recoverable, not a money-loss or security hole."
+   }
+  },
+  {
+   "title": "Gateway SQLite database can never shrink: append-only DELETE triggers plus reservations that are never deleted",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "The gateway has no retention path for any table. usage_events, feedback_events, audit_events, api_key_events, demo_usage_events, capacity_signal_events, signup_events, and demo_session_events all have BEFORE DELETE triggers that RAISE(ABORT) (migrate.go:184-251), and concurrency_reservations has its own no-delete trigger (migrate.go:248-251). quota_reservations has no trigger but the only cleanup mechanism \u2014 the hourly reaper \u2014 issues an UPDATE that flips status to 'expired' rather than deleting rows (store.go:847-860; wired in main.go:96-121). Net effect: every non-demo chat request permanently adds at least 3 rows (quota_reservations, concurrency_reservations, usage_events), and pruning is impossible without a schema migration because the triggers forbid DELETE.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/migrate.go:184-251",
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/store.go:847-860",
+    "/Users/augstar/macprovider-poc/phase5-gateway/cmd/gateway/main.go:96-121"
+   ],
+   "why": "On the RAM- and disk-constrained Pearl VPS (already swapping), the gateway DB grows monotonically with traffic forever. Per-request quota math (dailyUsageTx SUM over usage_events + quota_reservations, store.go:862-878) and explorer analytics scan these growing tables on every request. The append-only triggers are a deliberate tamper-evidence design for money data, which is good \u2014 but it means there is no sanctioned cleanup story at all, and the eventual fix (periodic archive + DB rotation, or trigger amendment to allow aged-out deletes) needs to be designed before the tables are large, not after.",
+   "confidence": "high",
+   "suggestedFix": "Decide the archival story now while tables are small: either a periodic export-then-rotate of the gateway DB file (preserves tamper evidence in cold storage), or amend the triggers to allow DELETE of rows older than N days while keeping UPDATE forbidden. Also add a DELETE for quota_reservations/concurrency_reservations rows in terminal states older than a few days \u2014 they carry no audit value the usage_events row doesn't already have.",
+   "id": "PERF-1",
+   "dimension": "performance",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three citations verified exactly: migrate.go:184-251 has BEFORE DELETE RAISE(ABORT) triggers on all 8 event tables plus concurrency_reservations; store.go:847-860 shows the reaper does UPDATE (not DELETE) on quota_reservations only; main.go:96-121 wires the reaper to only ReapExpiredReservations (quota_reservations only). One counter-claim: the per-request quota scan concern is overstated \u2014 migrate.go:81,97,110 define compound indexes on (account_id,window_date) for usage_events and quota_reservations, and (account_id,status,expires_at) for concurrency_reservations, so dailyUsageTx uses indexed lookups, not full-table scans. But the core finding \u2014 no sanctioned deletion path exists, tables grow monotonically forever \u2014 is real and accurate. Medium severity is correct for a 2-person beta with low current traffic.",
+    "correction": "The per-request performance concern is weaker than stated: migrate.go:81,97,110 define compound indexes covering the hot query paths in dailyUsageTx, so per-request quota math does not scan growing tables. The disk-growth and lack of archival story remain real concerns."
+   }
+  },
+  {
+   "title": "SQLite write executes while holding the global pool registry lock (swap audit emitter)",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "pool.Registry.ApplyHeartbeat invokes the SwapEventEmitter while holding Registry.mu (provider.go:482-484 takes the lock, emitter fires at 542-554). Production wiring makes that emitter a synchronous SQLite INSERT: main.go:94-111 calls auditStore.EmitSwap inline. The code's own concurrency contract comment (provider.go:446-457) says implementations 'MUST NOT block for long', but the production implementation is a DB write on a database opened with busy_timeout=5000 (sqliteutil/dsn.go:11), shared with request_log/billing/idempotency writes.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:446-457",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:482-484",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:542-554",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/cmd/coordinator/main.go:94-111",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/sqliteutil/dsn.go:11"
+   ],
+   "why": "Registry.mu guards everything: Touch() liveness updates for every inbound WS frame from every provider, ApplyHeartbeat, Snapshot() used by selectProvider on every buyer request. If the audit INSERT lands while another writer (billing hot path, retention prune, nightly reconcile) holds the SQLite write lock, the heartbeat goroutine can stall up to ~5s inside the registry lock \u2014 freezing routing and liveness for the whole pool. Swaps are operator-initiated and rare, which is why this is Medium not High, but the blast radius when it does collide is pool-wide.",
+   "confidence": "high",
+   "suggestedFix": "Make the emitter enqueue the SwapEvent onto a small buffered channel drained by a dedicated goroutine that performs the SQLite write outside the lock (best-effort semantics already permit dropping on overflow per R-7.10.8).",
+   "id": "PERF-2",
+   "dimension": "performance",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All cited lines hold up exactly. provider.go:483-484 takes r.mu.Lock() with defer; 542-554 fires the emitter inside that lock. main.go:94-111 wires a synchronous EmitSwap call with no goroutine or channel wrapper. audit/store.go:133-145 does a real INSERT. Both audit and billing/reqlog open separate sql.DB instances to the same cfg.Storage.DBPath (main.go:53,59) with busy_timeout=5000 each (requestlog/store.go:66, audit/store.go:42). Snapshot() uses RLock (provider.go:677), which is blocked by the held write lock, confirming pool-wide blast radius. Swaps are rare and operator-gated, so Medium is correctly calibrated for a 3-provider beta."
+   }
+  },
+  {
+   "title": "Retention pruning runs non-sargable, unbatched DELETEs on the same SQLite file as the billing hot path",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "PruneBefore wraps the indexed column in a function: `DELETE FROM request_log WHERE julianday(ts_utc) < julianday(?)` (requestlog/store.go:188, same pattern for request_idempotency_keys at :185 and audit_log at audit/store.go:122). julianday(ts_utc) defeats idx_request_log_ts_utc (created at requestlog/store.go:114-115), so each daily prune is a full-table scan, and the DELETE is a single unbatched statement holding the SQLite write lock for its entire duration.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/requestlog/store.go:185-188",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/requestlog/store.go:114-115",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/audit/store.go:118-126",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/buyer/server.go:123",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/buyer/server.go:1286-1290"
+   ],
+   "why": "This DB is the money path. Billing's WriteHotPath uses BEGIN IMMEDIATE with a 6s budget (requestLogWriteTimeout, buyer/server.go:123) and the HTTP-forward success path returns buyer-visible HTTP 500 'request_log_failed' if the durable write fails (buyer/server.go:1286-1290). At today's ~10-20k retained rows the scan is milliseconds; at 100x beta traffic with 90-day retention, a multi-second full-scan DELETE once a day overlaps live requests and busy_timeout=5000 turns it into hot-path failures. Timestamps are RFC3339Nano text which sorts lexicographically, so the fix is trivial.",
+   "confidence": "high",
+   "suggestedFix": "Compare the column directly (`WHERE ts_utc < ?` with the RFC3339Nano cutoff string) so the index is used, and batch the delete (`... LIMIT 5000` in a loop, or DELETE by rowid ranges) so the write lock is released between batches.",
+   "id": "PERF-3",
+   "dimension": "performance",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "correctedSeverity": "Medium",
+    "correction": "The finding is real and the citations hold exactly. One nuance the auditor missed: both stores open with `PRAGMA journal_mode=WAL` (requestlog/store.go:62, audit/store.go:38, also set via WithPragmas DSN in sqliteutil/dsn.go). Under WAL, readers never block writers, so the prune DELETE does not block concurrent INSERTs by themselves. The actual contention path is narrower: billing's hot path uses `BEGIN IMMEDIATE` (billing/hotpath.go:37,151), which competes for the same write lock that the prune DELETE holds. Under WAL, BEGIN IMMEDIATE still needs the write lock, so a multi-second full-scan DELETE can force billing's BEGIN IMMEDIATE to spin against busy_timeout=5000ms, and the 6s requestLogWriteTimeout (buyer/server.go:123) is the hard deadline before HTTP 500 'request_log_failed' surfaces to the buyer. At today's row counts (10-20k) the scan is sub-millisecond and the risk is negligible; the severity becomes real at 100x traffic with 90-day retention. The non-sargability claim is correct and the fix (direct `WHERE ts_utc < ?` string comparison) is valid since RFC3339Nano sorts lexicographically. Medium is the right severity for a 2-person beta.",
+    "reasoning": "Every cited location was verified with Read: julianday() wrapping at requestlog/store.go:185-188 and audit/store.go:122 confirmed; idx_request_log_ts_utc at lines 114-115 confirmed; requestLogWriteTimeout=6s at buyer/server.go:123 confirmed; HTTP 500 path at buyer/server.go:1286-1290 confirmed. Counter-evidence checked: WAL mode is active (both OpenStore PRAGMAs and WithPragmas DSN), which means readers never block \u2014 but billing/hotpath.go:37,151 uses BEGIN IMMEDIATE, which does compete for the same write lock as the prune DELETE. The threat is real but only materialises at much larger row counts than today's N=3 beta has. Medium is correctly calibrated."
+   }
+  },
+  {
+   "title": "Gateway money path and operator analytics serialize through a single SQLite connection",
+   "severity": "Medium",
+   "kind": "judgment",
+   "what": "The gateway store opens its DB with SetMaxOpenConns(1)/SetMaxIdleConns(1) (store.go:38-39), so every operation \u2014 quota reserve (BEGIN IMMEDIATE), settle, refund, concurrency acquire/release, auth key lookup \u2014 queues behind whatever currently holds the one connection. Explorer/admin analytics share that same connection with a 3-second per-query budget (explorerQueryTimeoutMs=3000, router/explorer.go:17,35) and result limits up to 200 rows over windows up to 31 days (explorer.go:15-23).",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/storage/sqlite/store.go:38-39",
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/explorer.go:14-43"
+   ],
+   "why": "The single connection is a deliberate simplicity/SQLITE_BUSY-avoidance choice and is fine at beta volume. But it couples two growth curves: as the never-pruned event tables (finding above) grow, explorer window queries slow toward their 3s budget, and during those 3 seconds every concurrent buyer chat request blocks at ReserveQuota before any token is streamed. Operator opens console dashboard \u2192 all buyers stall. This will surface as mysterious p99 latency spikes correlated with console use.",
+   "confidence": "high",
+   "suggestedFix": "Cheapest first step: open a second read-only *sql.DB handle (WAL allows concurrent readers) and route explorer/status/usage GET queries through it, keeping all writes on the single serialized connection.",
+   "id": "PERF-4",
+   "dimension": "performance",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "store.go:38-39 confirmed SetMaxOpenConns(1)/SetMaxIdleConns(1). explorer.go:17 confirmed explorerQueryTimeoutMs=3000. ReserveQuota and AcquireConcurrency both use beginImmediate (BEGIN IMMEDIATE) through that same single-slot pool (store.go:916-925). Only one sqlite.Open call exists in the entire gateway (cmd/gateway/main.go:33) \u2014 no separate read-only handle exists. WAL mode is set but provides no benefit here because SetMaxOpenConns(1) means all queries (reads and writes) queue for the same one connection slot at the Go database/sql level. The blocking mechanism is real. Medium is correct for a 2-person beta with low traffic: real but not yet a money-loss path."
+   }
+  },
+  {
+   "title": "pool.Registry.seenModels grows without bound and is writable by provisional providers",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "seenModels (map[string]struct{}, provider.go:133,156) gains an entry on every Register (provider.go:194) and every heartbeat (provider.go:519) keyed by whatever model_id the provider reports. Entries are never deleted \u2014 not on provider removal, not on TTL \u2014 and the map is iterated at provider.go:589 to answer model-known queries.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:133",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:194",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:519",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/pool/provider.go:589"
+   ],
+   "why": "With open provisional-tier onboarding, an admitted stranger Mac can heartbeat a new random model_id every few seconds, growing coordinator memory under the global registry lock indefinitely (~4MB/day/provider at 1Hz) on a VPS with ~180MiB free, and polluting ModelKnown()/model listing with garbage entries. Honest pool members never trigger it, hence Low \u2014 but it is the only unbounded in-memory structure I found in the coordinator, and the writers are the least-trusted parties in the system.",
+   "confidence": "high",
+   "suggestedFix": "Track seen models per provider (cleared on removal) and derive the global set from live providers, or cap the map and evict entries not reported by any currently-connected provider.",
+   "id": "PERF-5",
+   "dimension": "performance",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All four cited lines are accurate. provider.go:133 declares seenModels, :194 writes to it in Register, :519 writes to it in ApplyHeartbeat with no model_id length or rate guard, and :589 iterates it in ModelKnown. RemoveIfSession/RemoveIfSessionState (lines 623\u2013647) never touch seenModels \u2014 confirmed. No counter-evidence found: no model_id validation in ParseHeartbeat, no per-frame rate-limit in readProviderLoop. ProvisionalPoolMax:100 bounds simultaneous provisionals but not their heartbeat rate. ModelKnown pollution lets garbage IDs bypass the 404 check but still fail at selectProvider, so no direct money path impact. Low severity is correctly calibrated: real but adversarial, no financial consequence, bounded by N=3 at present."
+   }
+  },
+  {
+   "title": "Demo traffic bypasses the gateway concurrency limiter",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "AcquireConcurrency is only called for non-demo subjects (`if !authn.Demo`, server.go:1362-1381), so demo requests are bounded by daily per-IP token quota but not by concurrent in-flight count. Each in-flight demo request holds a gateway goroutine, an upstream coordinator connection for up to CoordinatorTimeout (server.go:1383), and competes for the MLX-serialized provider slots.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/server.go:1362-1381",
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/server.go:1383"
+   ],
+   "why": "A burst of parallel demo requests from one or a few IPs can occupy the provider pool (MLX serializes per provider; N=3) and hold many concurrent upstream streams on the RAM-capped gateway, degrading paying buyers, until the daily demo token budget runs out. Damage is capped by demo max_tokens and the IP-bound token quota, hence Low \u2014 but it is the one admission path with no concurrency bound.",
+   "confidence": "high",
+   "suggestedFix": "Apply a small fixed concurrency cap for demo subjects keyed on the demo identity (client IP /64), e.g. 2 concurrent, using the existing concurrency_reservations machinery.",
+   "id": "PERF-6",
+   "dimension": "performance",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "upgrade",
+    "correctedSeverity": "Medium",
+    "correction": "The finding is accurate but the \"Low\" severity is under-calibrated for the N=3 provider context. The paying-account concurrency cap defaults to 2 (config line 158). A single IP holding one demo token (24h lifetime) faces no equivalent cap and can dispatch concurrent requests freely. With N=3 MLX-serialized providers, just 3 simultaneous demo requests fully saturate the pool and block every paying buyer until CoordinatorTimeout (default 300s; may be 120s in production per SPEC-006 guardrails). The daily token budget is the only brake. This is plausible as an unintentional denial-of-service against paying users \u2014 Medium is the right label for a live beta with real money.",
+    "reasoning": "server.go:1362-1381 confirmed: AcquireConcurrency is called only under !authn.Demo. No demo-specific concurrency cap exists anywhere in the gateway (config.go, server.go, storage) or coordinator. DemoSessionsPerIPPerHour (10/hr, config line 157) only gates token issuance, not in-flight request count per already-issued token. AccountConcurrency defaults to 2. With N=3 providers all using MLX (serial per provider), 3 concurrent demo requests starve the pool. Daily token budget caps total damage but not burst depth or duration per request (up to CoordinatorTimeout)."
+   }
+  },
+  {
+   "title": "Both Go services run a retracted version of the SQLite driver (modernc.org/sqlite v1.33.0) under the money path",
+   "severity": "High",
+   "kind": "fact",
+   "what": "phase4-coordinator and phase5-gateway both pin modernc.org/sqlite v1.33.0. The module's own current go.mod carries `retract v1.33.0 // intended to resolve #177 but breaks clients`, and `go list -m -u all` (run live in both modules \u2014 network was available) prints `modernc.org/sqlite v1.33.0 (retracted) [v1.52.0]`. The deployed services are 19 minor versions behind current (v1.52.0), missing roughly two years of driver fixes plus newer bundled SQLite upstream releases. This is the single most load-bearing dependency in the system: the billing ledger, request_log, idempotency keys, gateway API keys, quota reservations, and audit logs all live in SQLite through this driver in both services.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/go.mod:12",
+    "/Users/augstar/macprovider-poc/phase5-gateway/go.mod:7"
+   ],
+   "why": "The driver authors explicitly declared this exact version broken for clients \u2014 a status nobody on the project has noticed because nothing checks for updates. Running a known-retracted DB driver under a live credit ledger and payout pipeline is exactly the kind of latent correctness risk that bites in beta: if the v1.33.0 regression (or any of 19 versions of subsequent fixes, including bundled SQLite engine updates) ever manifests, it manifests as ledger/locking misbehavior on the money path. The fix is cheap and both services have strong test suites to validate the bump.",
+   "suggestedFix": "Bump modernc.org/sqlite to v1.52.0 in both go.mod files (one line each), run `go mod tidy`, run both modules' full test suites (billing store/ACID tests, gateway store tests, -race variants), then redeploy via the normal PR path. Verify WAL/busy_timeout behavior under the existing concurrent-load tests before shipping.",
+   "confidence": "high",
+   "id": "DEPE-1",
+   "dimension": "dependencies",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "downgrade",
+    "correctedSeverity": "Medium",
+    "correction": "The retraction is real and the version is confirmed under the money path, but the severity is overstated. The retraction was already known to the implementation session (documented in phase4-coordinator/implementation-notes.html:888-893 as OQ-1: \"go get reports modernc.org/sqlite v1.33.0 is retracted by its module author\u2026 Operator should decide whether a future spec patch should replace this pin before production hardening\"). It was a deliberate hold to preserve the SPEC-002 pin, not an unnoticed gap. The stress tests (Phase C 320k requests with zero SQLite contention errors, Phase D 50-account concurrent load at p99=56ms with zero lock errors) ran on v1.33.0 without triggering any driver pathology. The retraction message (\"intended to resolve #177 but breaks clients\") describes a behavioral regression in some edge case, not a data-loss or corruption bug. For a 2-person beta with working production evidence and existing operator awareness, this is Medium (will hurt as the project grows, should be resolved before traffic scales) rather than High (likely to bite during beta).",
+    "reasoning": "Both go.mod citations confirmed: phase4-coordinator/go.mod:12 and phase5-gateway/go.mod:7 both pin modernc.org/sqlite v1.33.0. Retraction is real per implementation-notes.html:888-893 (OQ-1 logged by the implementation session). Driver is imported in billing/store.go, audit/store.go, requestlog/store.go, auth/tokens.go, and gateway storage \u2014 squarely on the money path. However: (1) the retraction was KNOWN and deliberately held per the spec pin; (2) Phase C and D stress tests ran successfully on v1.33.0 with zero SQLite errors; (3) no evidence of data-corruption semantics in the retraction. Real finding, but operator-acknowledged, not a latent surprise."
+   }
+  },
+  {
+   "title": "No dependency-update process exists anywhere; go.mod hygiene already drifting (goldmark direct import marked indirect)",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": ".github/ contains exactly one file \u2014 workflows/release.yml (the Swift release build). There is no dependabot.yml, no Renovate, no test CI, and no scheduled update pass. Concrete drift evidence: github.com/yuin/goldmark is directly imported by the gateway (pages.go:11-12, used at line 20 to render the public /docs page) yet go.mod line 17 still lists it as `// indirect`, meaning `go mod tidy` has not been run since the docs feature landed. Version lag is uniform: chi v5.1.0 (current v5.3.0), zerolog v1.33.0 (current v1.35.1), golang.org/x/sys v0.22.0 (current v0.46.0) per the live `go list -m -u all` runs.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/pages.go:11",
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/pages.go:20",
+    "/Users/augstar/macprovider-poc/phase5-gateway/go.mod:17",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/go.mod:6"
+   ],
+   "why": "This is the systemic cause of the retracted-driver finding: with no automation and no tidy discipline, a publicly flagged-as-broken dependency sat in production unnoticed. As real users and money are live, the project needs at minimum a low-friction signal when a dependency is retracted or has a security release \u2014 not enterprise tooling, just a Dependabot config or a monthly `go list -m -u all` habit.",
+   "suggestedFix": "Add a minimal .github/dependabot.yml covering gomod (both module dirs) and swift, monthly cadence to keep noise low. Run `go mod tidy` in phase5-gateway to correct the goldmark classification. Optionally add `go list -m -u -retracted all` to the pre-deploy check script.",
+   "confidence": "high",
+   "id": "DEPE-2",
+   "dimension": "dependencies",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All four cited locations check out exactly as described. pages.go:11-12 imports github.com/yuin/goldmark and github.com/yuin/goldmark/parser; line 20 uses goldmark.New(). It is the only .go file in the gateway that imports goldmark, making it a direct dependency. go.mod:17 classifies it as `// indirect` \u2014 a concrete `go mod tidy` gap confirmed by reading the file. .github/ contains exactly one file (release.yml); no dependabot.yml, Renovate config, or dep-update script exists anywhere in .github/, scripts/, or beta/. Coordinator go.mod shows chi v5.1.0, zerolog v1.33.0, sys v0.22.0 confirming version lag. Medium severity is correct for a 2-person beta: no CVE or live exploit, but a real, verifiable process gap with a direct code artifact (the misclassified indirect marker)."
+   }
+  },
+  {
+   "title": "swift-nio exact-pinned at 2.65.0, ~36 minor releases behind, with security-relevant hardening in newer releases",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "Package.swift pins swift-nio with `exact: \"2.65.0\"` and Package.resolved confirms 2.65.0 resolved. Upstream's latest is 2.101.0 (checked via the GitHub releases page), and visible release notes for 2.100.0/2.101.0 include security-relevant fixes: HTTP request URI/method byte validation, ByteBuffer capacity-overflow prevention, and rejection of WebSocket 8-byte payload lengths exceeding Int.max. NIOHTTP1 serves the provider binary's local OpenAI-compatible HTTP API. Mitigation: that server binds 127.0.0.1 only (HTTPServer.swift), so exposure requires a local attacker or a tunnel misconfiguration.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase3-binary/Package.swift:24",
+    "/Users/augstar/macprovider-poc/phase3-binary/Package.resolved:76"
+   ],
+   "why": "Exact pins with no update cadence means the network-parsing code in a publicly distributed signed binary is frozen at March-2024 vintage forever. The loopback-only binding keeps this from being High today, but every provider Mac on the network runs this HTTP parser, and the project's own architecture docs contemplate tunneled access to it. A two-year-stale NIO will also eventually block Swift toolchain upgrades.",
+   "suggestedFix": "Bump swift-nio to the current 2.x release in Package.swift (exact pin is fine \u2014 just move it), rebuild, run the XCTest suite and acceptance scripts, and cut a binary release through the existing signed-release pipeline. Fold dependency bumps into the existing release rhythm rather than adding new infrastructure.",
+   "confidence": "high",
+   "id": "DEPE-3",
+   "dimension": "dependencies",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "downgrade",
+    "correctedSeverity": "Low",
+    "correction": "The pin and version gap are confirmed real. However, the \"tunneled access\" risk is overstated: the NIO HTTP server binds unconditionally to 127.0.0.1 (HTTPServer.swift:36) with no config knob to override the host \u2014 only the port is configurable. The outbound coordinator WebSocket uses URLSessionWebSocketTask (Apple Foundation), not NIO, so NIO's network-parsing surface is limited to inbound loopback-only HTTP. The 2.100/2.101 security fixes (URI byte validation, ByteBuffer overflow) are only reachable via a local attacker or a Cloudflare tunnel misconfiguration that forwards arbitrary traffic to 127.0.0.1:port, neither of which is a realistic beta-phase threat for a 3-provider PoC. The real residual risk is Swift toolchain upgrade friction as NIO advances. Severity should be Low: worth bumping on the next release cycle for toolchain hygiene, not a beta-blocking issue.",
+    "reasoning": "Package.swift:24-27 and Package.resolved:76-82 both confirm exact 2.65.0 pin. HTTPServer.swift:36 shows bootstrap.bind(host: \"127.0.0.1\", ...) hard-coded \u2014 no config path overrides the host. CoordinatorClient.swift:1-27 shows the external WebSocket uses URLSessionWebSocketTask, not NIO. The loopback binding is structural and unconditional, eliminating the \"tunneled access\" attack path that the finding uses to justify Medium. The version gap and toolchain compat concern are real but the security consequence is near-zero under this architecture."
+   }
+  },
+  {
+   "title": "Publicly distributed provider binary ships with zero third-party license attribution despite Apache-2.0 static linking",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "package.sh builds the release tarball containing only the binary plus Metal/NIO resource bundles (lines 52-60: `macprovider-cli`, `mlx-swift_Cmlx.bundle`, `swift-nio_NIOPosix.bundle`) \u2014 no LICENSE, NOTICE, or third-party attribution files. The binary statically links Apache-2.0 dependencies (swift-nio, swift-argument-parser, swift-log per Package.swift:24-35, plus transitive swift-transformers, swift-collections, swift-atomics per Package.resolved) and MIT dependencies (mlx-swift, mlx-swift-examples, Yams, GzipSwift). Apache-2.0 \u00a74 requires providing a copy of the license with binary redistributions; MIT requires notice retention. This tarball is distributed to strangers via GitHub Releases and the public curl|bash installer chain (get.streamvc.live).",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase3-binary/dist/package.sh:52",
+    "/Users/augstar/macprovider-poc/phase3-binary/Package.swift:19",
+    "/Users/augstar/macprovider-poc/phase3-binary/Package.resolved:76"
+   ],
+   "why": "Open onboarding means this is genuine public distribution, not a two-person handoff anymore. License non-compliance is trivial to fix now and increasingly awkward later \u2014 it is the kind of thing a future partner, acquirer, or hostile community member checks first. (Contrast: the project is scrupulously careful about the d-inference clean-room boundary, so the intent to be license-clean clearly exists.)",
+   "suggestedFix": "Generate a THIRD-PARTY-NOTICES.txt aggregating the LICENSE files of all resolved packages (a 20-line script over Package.resolved checkouts) and add it to the tarball in package.sh. One-time, ~30 minutes.",
+   "confidence": "high",
+   "id": "DEPE-4",
+   "dimension": "dependencies",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "package.sh lines 52-60 confirmed: tarballs contain only macprovider-cli + two bundles. All three shipped tarballs (v1.2.4, v1.2.5, v1.2.6) verified to contain no LICENSE/NOTICE/THIRD-PARTY files. swift-nio is confirmed Apache-2.0 and ships a NOTICE.txt that Apache-2.0 \u00a74(d) requires reproducing in binary distributions \u2014 that file is absent. No counter-evidence found: release.yml calls only package.sh with no license-gathering step, and no script in scripts/ touches attribution. Medium is correctly calibrated: real non-compliance today, but no money-path or security impact; risk is future partner/acquirer friction, not beta-day loss."
+   }
+  },
+  {
+   "title": "gopkg.in/yaml.v3 is officially archived and unmaintained upstream",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "Both Go services depend on gopkg.in/yaml.v3 v3.0.1 for config parsing. The upstream repository (go-yaml/yaml) was archived by its owner on April 1, 2025 and its README carries an explicit 'THIS PROJECT IS UNMAINTAINED' section (verified via web fetch). v3.0.1 is the final release; no bug or security fixes will ever ship.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/go.mod:11",
+    "/Users/augstar/macprovider-poc/phase5-gateway/go.mod:6"
+   ],
+   "why": "Risk is low today because all YAML input is operator-controlled config files (coordinator.yaml, gateway.yaml), not untrusted data. But YAML parsers have a history of DoS-class bugs, and an unmaintained parser in both services is a slow-burning liability. Worth a note in the decision log and a planned migration (goccy/go-yaml is the common successor) next time config code is touched \u2014 not urgent.",
+   "suggestedFix": "No immediate action. Record in beta/DECISION_CRITERIA.md; migrate to goccy/go-yaml opportunistically during a future config refactor. Never feed buyer-controlled input through this parser.",
+   "confidence": "high",
+   "id": "DEPE-5",
+   "dimension": "dependencies",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "Both citations confirmed: coordinator go.mod:11 and gateway go.mod:6 both declare gopkg.in/yaml.v3 v3.0.1. GitHub API confirms go-yaml/yaml is archived (archived: true, last push 2025-04-01). yaml.Unmarshal is called exactly once per service at startup in Load() (coordinator config.go:369, gateway config.go:185), reading an operator-supplied file path from a CLI flag. No request-path or buyer-controlled yaml parsing exists anywhere in either service. Severity Low is correctly calibrated: the only parse surface is operator config files loaded once at process start."
+   }
+  },
+  {
+   "title": "swift-log is a dead dependency compiled into the shipped provider binary",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "Package.swift declares swift-log exact 1.6.0 (lines 28-31) and links the Logging product into the macprovider-cli executable target (line 60), but a grep across all of phase3-binary/Sources/ finds zero `import Logging` statements \u2014 the codebase logs via print()/stderr writes instead. The library is declared, resolved, linked, and never used.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase3-binary/Package.swift:28",
+    "/Users/augstar/macprovider-poc/phase3-binary/Package.swift:60"
+   ],
+   "why": "Minor dead weight and one unnecessary supply-chain node in a signed, publicly distributed binary. Also a small signal to future contributors that structured logging was intended but never adopted \u2014 either use it or drop it.",
+   "suggestedFix": "Remove the swift-log dependency and the Logging product from Package.swift, or adopt it deliberately if structured logging on the provider is wanted for beta debugging.",
+   "confidence": "high",
+   "id": "DEPE-6",
+   "dimension": "dependencies",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "Package.swift lines 28-31 declare swift-log exact 1.6.0, and line 60 links the Logging product into macprovider-cli. A full scan of all 19 Swift source files across both targets (macprovider-cli/ and MacProviderCore/) finds zero `import Logging` statements. The codebase uses a home-grown `LogLevel` enum in Config.swift and print()/stderr writes. NIO 2.65.0 (the cached Package.swift confirms) does not depend on swift-log, so removing the explicit declaration would eliminate swift-log entirely from the build graph \u2014 it is not disguised as a transitive dep. Low severity is correct: no security, correctness, or money-path impact; just dead supply-chain weight in a publicly distributed signed binary."
+   }
+  },
+  {
+   "title": "Python ops tooling has no dependency manifest; lone venv is on EOL Python 3.9 with an obsolete Phase-1 package set",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "There is no requirements.txt, pyproject.toml, or lockfile anywhere in the repo (find across the tree, excluding .venv). The root .venv runs Python 3.9.6 from macOS CommandLineTools (pyvenv.cfg:3) \u2014 Python 3.9 reached end-of-life in October 2025 \u2014 and contains the Phase-1 mlx_lm serving stack (transformers 4.57.6, mlx 0.29.3, huggingface_hub) that current production no longer uses (providers run the Swift binary now). Of the live ops scripts: beta/harness.py and the VPS monitor (macprovider-monitor.py) are stdlib-only (good), but beta/report.py imports third-party `yaml` at line 26 with no documented way to recreate its environment.",
+   "where": [
+    "/Users/augstar/macprovider-poc/.venv/pyvenv.cfg:3",
+    "/Users/augstar/macprovider-poc/beta/report.py:26"
+   ],
+   "why": "Beta-grade impact only: the cron harness keeps working, but report.py silently depends on whatever Python/PyYAML happens to be on the operator laptop \u2014 on a fresh machine or after an OS update, report generation breaks with no manifest to rebuild from. The stale 2GB-class venv also invites confusion about what production actually depends on.",
+   "suggestedFix": "Add a 3-line beta/requirements.txt (pyyaml) plus a README note on which python runs the cron scripts; delete or rebuild the Phase-1 .venv on a supported Python when convenient.",
+   "confidence": "high",
+   "id": "DEPE-7",
+   "dimension": "dependencies",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "correctedSeverity": "Low",
+    "correction": "The auditor's characterization of harness.py as \"stdlib-only\" is factually wrong. beta/harness.py imports both `requests` and `yaml` (lines 35-36), making it equally undocumented as report.py. The rest of the finding stands: no requirements.txt exists in the project tree, the .venv is Python 3.9.6 (EOL), and run-scheduled.sh explicitly activates that .venv before running both harness.py and report.py, meaning the .venv is the production cron runtime. PyYAML 6.0.3 and requests are present in the .venv so nothing is broken today \u2014 the gap is only on a fresh machine rebuild. The stale Phase-1 mlx/transformers packages (mlx 0.29.3, mlx_lm 0.29.1, transformers 4.57.6) are confirmed present and unused in production.",
+    "reasoning": "All citations verified by direct file reads. pyvenv.cfg:3 shows version = 3.9.6. report.py:26 shows `import yaml`. run-scheduled.sh:13 confirms the .venv is the active cron runtime. PyYAML 6.0.3 exists in .venv/lib/python3.9/site-packages so import yaml is currently satisfied. The auditor's only error was claiming harness.py is stdlib-only \u2014 it imports requests and yaml at lines 35-36. No requirements.txt found anywhere in the project tree (Swift package checkouts have their own, which are unrelated). Low severity is correct: the venv satisfies deps today, risk is only on fresh environment rebuild."
+   }
+  },
+  {
+   "title": "gobwas/ws upstream is dormant \u2014 latest release May 2024 \u2014 while terminating every provider connection",
+   "severity": "Low",
+   "kind": "judgment",
+   "what": "The coordinator's provider WebSocket leg is built on github.com/gobwas/ws v1.4.0. That is the latest available version (`go list -m -u all` offers no update), and the upstream releases page shows v1.4.0 was published May 3, 2024 \u2014 over two years without a release as of June 2026, with v1.3.2 (Jan 2024) and v1.3.1 (Nov 2023) before it.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/go.mod:7"
+   ],
+   "why": "The library is stable, widely deployed, and the project is current on it \u2014 this is not a today problem. But every provider connection (auth handshake, encrypted-leg frames, inference relay) flows through a parser whose upstream may be slow or unresponsive if a protocol-level vulnerability is ever found. Worth knowing the contingency (e.g. coder/websocket) before an incident forces the question; the WS server code is well-isolated in internal/ws which would make a swap tractable.",
+   "suggestedFix": "No action now. Note the dormancy in the decision log and keep the internal/ws abstraction boundary clean so a driver swap stays a contained change.",
+   "confidence": "high",
+   "id": "DEPE-8",
+   "dimension": "dependencies",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "go.mod line 7 confirms gobwas/ws v1.4.0. Usage is in 3 production files all within internal/ws/ (server.go, admission.go, relay.go), plus a dev-only mockprovider \u2014 the \"well-isolated in internal/ws\" claim is substantively correct, though admission.go does expose gobwas.StatusCode in its Admit() signature, making a driver swap slightly more involved than claimed. The finding's severity of Low is appropriate: this is a forward-looking contingency note about upstream dormancy, not an exploitable bug. The library is stable and the project is current on the latest release. No counter-evidence found.",
+    "correction": "The \"well-isolated\" characterization is slightly overstated: admission.go's Admit() returns a gobwas.StatusCode, leaking the type outside the core server.go. A driver swap would require touching that signature as well. This does not change the severity or the recommendation."
+   }
+  },
+  {
+   "title": "No test, lint, or vet CI exists \u2014 money-path PRs merge with zero automated checks",
+   "severity": "High",
+   "kind": "fact",
+   "what": "The only CI workflow in the repo is the release build: .github/workflows/release.yml triggers solely on v*.*.* tag push or manual dispatch and runs build \u2192 sign \u2192 publish, never `go test`, `go vet`, `swift test`, or any linter. Even the release path runs no tests: package.sh (invoked at release.yml:56-61) does xcodebuild + tar only. Meanwhile the repo carries large test suites that nothing executes automatically (26 *_test.go files in phase4-coordinator, 13 in phase5-gateway, 16 Swift test files), and AGENTS.md:32-42 mandates that billing/buyer/auth/router changes go through 'PR with review' \u2014 but a PR here has no required checks, no hooks (.git/hooks has zero non-sample entries), no .golangci.yml, no Makefile target. The PR gate for the money path is purely human eyeballs.",
+   "where": [
+    "/Users/augstar/macprovider-poc/.github/workflows/release.yml:3-12 (tag/dispatch triggers only)",
+    "/Users/augstar/macprovider-poc/.github/workflows/release.yml:56-99 (build\u2192sign steps, no test step)",
+    "/Users/augstar/macprovider-poc/phase3-binary/dist/package.sh:25-60 (xcodebuild + tar, no tests)",
+    "/Users/augstar/macprovider-poc/AGENTS.md:32-42 (sensitive paths 'require PR with review')"
+   ],
+   "why": "This project is explicitly AI-agent-authored (AGENTS.md is addressed to agents) with a 2-person review bench, and billing/quota correctness is guarded by tests that only run when someone remembers. A regression in phase4 billing or phase5 quota settlement can squash-merge to main looking green and ship to production in the next hand-deploy. The phase5 README even names the exact critical test sets (README.md:118-124) \u2014 they are one 20-line ubuntu workflow away from running on every PR, at zero cost. This is the single highest-leverage ops fix available.",
+   "suggestedFix": "Add one .github/workflows/ci.yml: on pull_request + push to main, two ubuntu-latest jobs running `go vet ./... && go test ./...` in phase4-coordinator and phase5-gateway (~2-3 min, free). Optionally a macos job for `swift test` on phase3-binary paths, or defer that to release time. Mark the Go jobs as required checks on main.",
+   "confidence": "high",
+   "id": "DEVE-1",
+   "dimension": "devexops",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All cited facts confirmed. release.yml (lines 3-12) triggers only on v*.*.* tag or manual dispatch. Lines 56-99 run build/sign/publish with zero test step. package.sh (lines 25-60) is xcodebuild + tar only. AGENTS.md lines 32-42 mandate PR-with-review for billing/buyer/auth/router paths. .github/workflows/ contains exactly one file (release.yml). .git/hooks/ has only .sample files \u2014 no active hooks. No .golangci.yml, no Makefile anywhere in the repo. Test file counts are accurate: 26 Go test files in phase4-coordinator, 13 in phase5-gateway, 16 Swift test files in phase3-binary/Tests. phase5-gateway README:118-124 explicitly names critical money-path test runs that nothing executes automatically. The severity of High is calibrated correctly for a 2-person beta with live money: billing/quota regressions can merge looking green with no automated gate."
+   }
+  },
+  {
+   "title": "The 3am story: alerting is one silently-optional email channel, co-hosted on the VPS it watches, with no external uptime check",
+   "severity": "High",
+   "kind": "fact",
+   "what": "Production alerting is exactly one mechanism: macprovider-monitor.py on a 3-minute systemd timer on Pearl, polling loopback /healthz, /poolz, /v1/status. Three compounding weaknesses: (1) email is silently optional \u2014 without Gmail creds in /etc/macprovider/monitor.env it degrades to journald-only with an INFO line (monitor.py:174-180), and per the monitor README:33-36 it runs journal-only 'until the password is filled in'; (2) alert delivery is single-shot \u2014 main() emits alerts, attempts email, then unconditionally save_state()s the new state (monitor.py:159-171), and send_email swallows failures with a printed WARN (monitor.py:194-195), so a transient SMTP failure permanently drops that transition alert; (3) the monitor runs on the same RAM-constrained VPS as the coordinator and gateway, so VPS death, OOM, or nginx failure kills the watcher along with the watched \u2014 and a repo-wide grep for uptimerobot/healthchecks/pingdom/statuscake/dead-man patterns returns nothing: there is no monitoring independent of Pearl.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py:159-171 (state saved regardless of email outcome)",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py:174-180 (silent degrade to journal-only)",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py:188-195 (email failure swallowed)",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/README.md:33-36 (email pending until app password configured)",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.timer:1-11 (3-min timer)"
+   ],
+   "why": "Real buyers and a real money path now depend on one swap-pressured VPS. If Pearl goes down at 3am \u2014 the one failure mode the monitor structurally cannot report \u2014 the operator learns about it from a user complaint. Even a provider-pool-empty CRITICAL may reach no human if the Gmail app password was never configured (the code's silent-degrade design makes that state invisible), and if the one email send fails, the alert is gone forever. The minimum bar for live money is one alerting path that does not live on the monitored host.",
+   "suggestedFix": "Two cheap moves: (1) add a free external uptime check (healthchecks.io or UptimeRobot) on https://coordinator.streamvc.live/healthz and https://api.streamvc.live/healthz with email/push \u2014 this covers VPS-down, nginx-down, and monitor-dead in one stroke; (2) in monitor.py, only save_state() for a transition after the alert was delivered to at least one channel beyond journald (or retry on next poll while the condition persists), and confirm the Gmail app password is actually set in production.",
+   "confidence": "high",
+   "id": "DEVE-2",
+   "dimension": "devexops",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three structural weaknesses hold on direct inspection. Lines 174-180 confirm silent journal-only degradation when credentials absent. Lines 165-171 confirm save_state() fires unconditionally after send_email() returns, regardless of delivery outcome. Lines 194-195 confirm the bare except swallows SMTP failures. README.md:33-36 explicitly documents the journal-only fallback. The timer runs every 3 minutes on Pearl (confirmed macprovider-monitor.timer). A repo-wide grep for uptimerobot/healthchecks/pingdom/statuscake/dead-man returned zero hits. DECISION_CRITERIA.md Entry 36 confirms the design is intentional (\"Gmail SMTP if monitor.env configured\"), not a bug. No retry logic, no alternative alerting channel, no external uptime check exists anywhere. High is correct for a live money-path 2-person beta."
+   }
+  },
+  {
+   "title": "Production Go binaries are hand-built with no script, no provenance, and no rollback path for the coordinator",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "The linux binaries that run the money path are produced by an undocumented manual cross-compile: the only trace in the entire repo is the comment 'coordinator-linux-amd64 cross-compiled into dist/' (deploy-pearl-vps.sh:9); a grep for GOOS=linux across both Go modules' scripts and docs finds no build command anywhere. deploy-pearl-vps.sh then ships whatever file currently sits at dist/coordinator-linux-amd64 (referenced at lines 32, installed at 72-78) with no version stamp, no commit linkage, and no post-deploy 'which build is this' verification. There is no rollback step in the script; the de facto rollback artifact is an untracked coordinator-linux-amd64.pre-phase6.bak sitting in dist/ (covered by .gitignore:38 '*.bak'). The Swift binary, by contrast, gets a full tagged-release pipeline with signing and post-publish verification.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:9 (comment is the only build documentation)",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:31-39,71-82 (ships whatever is in dist/, no provenance check)",
+    "/Users/augstar/macprovider-poc/.gitignore:36-41 (binaries and .bak rebuilt locally, untracked)"
+   ],
+   "why": "Combined with the absence of CI, the binary scp'd to production may have been built from uncommitted or never-tested code, and nobody can later answer 'which commit is running on Pearl?'. During an incident, rollback means remembering that a .bak file exists and hand-restoring it over SSH. For two rarely-deployed services this hasn't bitten yet, but the first bad deploy to the billing path will be diagnosed blind.",
+   "suggestedFix": "Add a 15-line build script per Go service (GOOS=linux GOARCH=amd64 go build -ldflags \"-X main.version=$(git describe --always --dirty)\") that refuses to build from a dirty tree without an override; have deploy-pearl-vps.sh keep the previous binary as coordinator.prev on the VPS and print the deployed version from a --version flag or /healthz field as a final step.",
+   "confidence": "high",
+   "id": "DEVE-3",
+   "dimension": "devexops",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All cited lines check out. deploy-pearl-vps.sh:9 is literally the only documentation of the cross-compile. Lines 32/72/78 confirm the binary is SCP'd without any git-commit linkage or version check. The healthz endpoint (buyer/server.go:576) returns a hardcoded \"0.1.0\" string \u2014 no ldflags version embedding exists anywhere in the codebase. The .bak file is confirmed present in dist/ and covered by .gitignore:38. The deploy script has no \"backup existing binary to .prev before overwrite\" step. One nuance: step 8 does hit /healthz as a liveness check, but it cannot verify provenance since the version is hardcoded. Severity Medium is correct for a live-money 2-person beta \u2014 real risk on first bad deploy, not exploitable today.",
+    "correction": "Minor nuance only: the deploy script does run a post-deploy healthz liveness check (step 8/line 176), but since the coordinator's version field is a hardcoded string \"0.1.0\" rather than a git-embedded build tag, this check confirms the process started \u2014 not which commit is running. The finding's characterization of \"no post-deploy verification\" is slightly overstated; the more precise statement is \"no provenance verification\" \u2014 liveness is checked, commit identity is not."
+   }
+  },
+  {
+   "title": "The gateway \u2014 the money-path service \u2014 is the only component with no scripted deploy and no config gate; the C2 timer cross-check never runs in practice",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "Coordinator and console deploys are idempotent fail-closed scripts; the gateway's deploy is a manual markdown checklist that opens with 'This is an operator runbook draft' (deploy-pearl-vps.md:1-3) and whose rollback is three manual nginx/systemctl steps (lines 34-38). No pre-deploy gate validates gateway.yaml. Worse, the one cross-component safety check that exists \u2014 check-deploy-config.sh's C2 assertion that coordinator request_timeout_s < gateway coordinator_request_seconds \u2014 only executes if the operator passes gateway.yaml as a second argument (check-deploy-config.sh:18-19, 62-74), and the coordinator deploy script invokes it with only the coordinator config (deploy-pearl-vps.sh:50: `check-deploy-config.sh \"$CONFIG\"`), so every standard deploy prints 'skipped C2 timer cross-check'. Memory of this project records a real production drift on exactly this timer pair.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase5-gateway/dist/deploy-pearl-vps.md:1-3,34-38",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/check-deploy-config.sh:18-19,62-74",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:46-52 (gate invoked with coordinator.yaml only)"
+   ],
+   "why": "Manual checklists drift and skip steps under incident pressure \u2014 and this is the service holding buyer auth, quotas, and usage accounting. The C2 check being structurally skipped means a known breaker-attribution hazard (documented in the script's own header, lines 8-12) can silently re-enter production on any coordinator timeout change.",
+   "suggestedFix": "Script the gateway deploy by cloning the coordinator script's shape (gate \u2192 scp \u2192 install \u2192 restart \u2192 verify), and change deploy-pearl-vps.sh:50 to pass the gateway config when present, e.g. `check-deploy-config.sh \"$CONFIG\" \"$DIST_DIR/../../phase5-gateway/dist/gateway.yaml\"`, failing loudly if it is missing rather than noting and continuing.",
+   "confidence": "high",
+   "id": "DEVE-4",
+   "dimension": "devexops",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All five cited locations were read and confirm exactly what is claimed. deploy-pearl-vps.md:1-3 opens with the \"operator runbook draft\" disclaimer; lines 34-38 are three manual rollback steps. check-deploy-config.sh:18-19 shows GW is optional (empty default). Lines 62-74 confirm C2 only runs if gw is non-empty. deploy-pearl-vps.sh:50 passes only $CONFIG \u2014 no gateway path \u2014 so every standard coordinator deploy prints the \"skipped C2 timer cross-check\" note. The gateway dist/ directory contains zero shell scripts; only the markdown checklist exists. No counter-evidence was found elsewhere. Medium severity is correct for a 2-person beta: the C2 skip is a structural gap on a money-path service, but it does not expose an immediately exploitable hole \u2014 it re-enables a known timer-race condition that could cause breaker misattribution, not direct fund loss."
+   }
+  },
+  {
+   "title": "Production coordinator config's single source of truth is a gitignored file on the operator's laptop, and deploys overwrite the VPS copy unconditionally",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "coordinator.yaml (containing the plaintext operator_key and the authoritative provider enrollment list) is gitignored (.gitignore:43-45) and lives only in the laptop working tree. The template itself instructs: 'Edit this list locally \u2014 DO NOT add providers by SSHing to the VPS... because the next deploy run will overwrite your changes from this file. (Lesson learned 2026-05-28.)' (coordinator.yaml.example:79-83). deploy-pearl-vps.sh:73,79 scp's and installs the laptop file over /opt/macprovider/coordinator.yaml with no pull-and-diff against what is currently running and no backup of the VPS copy. check-deploy-config.sh validates the laptop file in isolation (placeholder key, thresholds) but cannot detect that it is stale relative to production.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/coordinator.yaml.example:79-83",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:71-82",
+    "/Users/augstar/macprovider-poc/.gitignore:43-45"
+   ],
+   "why": "Two realistic failure modes for this exact setup: (a) laptop loss or an AI-agent session 'sanitizing' the local file (this repo runs many agent sessions in that worktree; the project's own notes record a near-miss) followed by a deploy clobbers production provider enrollment; (b) an emergency VPS-side edit made during an incident is silently reverted by the next routine deploy. With N=3 live providers, a clobbered provider list is a visible outage.",
+   "suggestedFix": "Add a step 4a to deploy-pearl-vps.sh: scp the current VPS coordinator.yaml down, diff against the candidate, and require interactive confirmation (or a FORCE flag) when the remote copy differs in the providers: block or operator_key. Keep a dated backup of the remote file on the VPS before overwrite. Separately, keep an encrypted off-laptop copy of the real coordinator.yaml.",
+   "confidence": "high",
+   "id": "DEVE-5",
+   "dimension": "devexops",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three citations check out exactly. .gitignore:43-45 gitignores coordinator.yaml with an explicit plaintext-key comment. coordinator.yaml.example:79-83 contains the verbatim warning against VPS-side edits. deploy-pearl-vps.sh:73,79 SCPs the laptop file unconditionally with no prior pull, no diff, and no backup of the remote copy. check-deploy-config.sh validates only the local file in isolation. The project's own session memory (dist-coordinator-yaml-deploy-hazard.md) confirms the hazard materialized: a Codex session sanitized the local file, requiring the operator to bypass deploy-pearl-vps.sh entirely. The tier2 activation scripts do make coordinator.yaml backups, but those are unrelated to the standard deploy path. Medium is calibrated correctly: the placeholder-key guard in check-deploy-config.sh partially mitigates the \"fully sanitized\" variant, but partial staleness (e.g., wrong provider list, missing Phase 7 keys) passes that check silently and can still cause a visible outage."
+   }
+  },
+  {
+   "title": "No Makefile or canonical dev commands; phase4-coordinator \u2014 the largest service \u2014 has no README at all",
+   "severity": "Medium",
+   "kind": "judgment",
+   "what": "There is no Makefile, justfile, or task runner anywhere in the repo (find across the tree returns nothing), and the three components have wildly different dev-loop documentation: phase5-gateway/README.md:26-39 and 115-127 give a complete copy-pasteable loop (env vars, go test ./..., -check mode, named critical test sets); phase3-binary has a README plus scripts/; phase4-coordinator \u2014 25k LOC including the billing engine \u2014 has no README whatsoever (the file does not exist), and its build, test, and cross-compile commands are written down nowhere.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase5-gateway/README.md:26-39,115-127 (the good pattern that proves the standard is achievable)",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:8-10 (build step exists only as a prose prerequisite)"
+   ],
+   "why": "This repo's de facto contributors are fresh AI-agent sessions (per AGENTS.md and the project's own workflow), which re-derive the dev loop from scratch every session. Missing canonical commands for the biggest, most money-sensitive module increases per-session variance \u2014 an agent that doesn't know to run the billing tests before committing won't run them, and nothing else will either (see the CI finding). A 30-line phase4-coordinator/README.md plus a root Makefile with test/build/cross-compile targets closes this.",
+   "suggestedFix": "Write phase4-coordinator/README.md modeled on the gateway's (build, test, mockprovider usage, cross-compile command, deploy pointer), and add a root Makefile with `make test` (both Go modules), `make build-linux` (both binaries, version-stamped), and `make check` (config gates) so agents and CI share one entry point.",
+   "confidence": "high",
+   "id": "DEVE-6",
+   "dimension": "devexops",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "correctedSeverity": "Medium",
+    "correction": "The finding is accurate with one partial mitigation the auditor missed: phase4-coordinator/scripts/ contains 19 shell scripts (test-auth-flow.sh, test-pool-check.sh, etc.) that each invoke specific `go test` commands, and run-local-pool.sh contains `go build` invocations. This means test commands are technically discoverable \u2014 but only by reading 19 individual scripts, not via any entry-point README or Makefile. The cross-compile command (GOOS=linux GOARCH=amd64 go build) appears only in specs/BUILD_PHASE4_COORDINATOR_PROMPT.md:103 and specs/SPEC-002-coordinator.md:2973 \u2014 build-prompt archives, not operative dev docs. The core finding stands: no README, no canonical `go test ./...` entry point, and no cross-compile command in any operative location for the largest, most money-sensitive module.",
+    "reasoning": "All citations verified by Read tool. phase4-coordinator/ directory listing confirms no README exists. phase5-gateway/README.md lines 26-39 and 115-127 confirmed to contain the complete dev loop and named test sets exactly as claimed. deploy-pearl-vps.sh lines 8-10 confirmed as prose prerequisite with no cross-compile command. Counter-evidence: 19 scripts in phase4-coordinator/scripts/ contain go test invocations, partially substituting for a README, but no discoverable `go test ./...` entry point or cross-compile command exists in any operative doc. Severity Medium is correctly calibrated \u2014 this is a session-variance risk, not a live money-loss risk."
+   }
+  },
+  {
+   "title": "Coordinator secret handling is the weak half of an asymmetric pattern: plaintext operator_key in YAML, regex-parsed by a root-running monitor",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "The gateway does deployment secrets right: gateway.yaml carries env:NAME indirection and real values live in /etc/macprovider/gateway.env loaded via EnvironmentFile (macprovider-gateway.service:12; deploy-pearl-vps.md:6-11). The coordinator instead embeds operator_key in plaintext in coordinator.yaml (coordinator.yaml.example:65-68), which is scp'd from the laptop and installed 0600 (deploy-pearl-vps.sh:79). The monitor then extracts that key by regexing the YAML (macprovider-monitor.py:56-62) and runs as root (macprovider-monitor.service:8) although it only needs loopback HTTP plus read access to one file \u2014 while the coordinator and gateway themselves run as the unprivileged macprovider user.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/coordinator.yaml.example:65-68",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.py:56-62",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/monitor/macprovider-monitor.service:6-10",
+    "/Users/augstar/macprovider-poc/phase5-gateway/dist/macprovider-gateway.service:7-12",
+    "/Users/augstar/macprovider-poc/phase5-gateway/dist/deploy-pearl-vps.md:6-11"
+   ],
+   "why": "Acceptable at beta scale (0600, gitignored, root-only VPS), but the operator_key is the highest-blast-radius secret in the system (it authenticates the admin plane of BOTH services), and the plaintext laptop copy sits inside a worktree where AI agents operate constantly. The asymmetry also means anyone following the gateway pattern as the house style will be surprised by the coordinator. Cheap to converge now, annoying to converge after more providers join.",
+   "suggestedFix": "Support env-indirection for auth.operator_key in the coordinator config (matching the gateway's env:NAME convention), move the value to /etc/macprovider/coordinator.env, drop the monitor to User=macprovider (or a dedicated user with group-read on the env file), and have the monitor read the key from the env file instead of regexing YAML.",
+   "confidence": "high",
+   "id": "DEVE-7",
+   "dimension": "devexops",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All citations hold up on direct read. coordinator.yaml.example:65-68 shows plaintext operator_key. The live coordinator.yaml (gitignored, 0600 per deploy-pearl-vps.sh:79) also has a plaintext placeholder at line 45. macprovider-monitor.py:56-62 regexes coordinator.yaml to extract that key. macprovider-monitor.service:8 confirms User=root. The gateway contrast is real: macprovider-gateway.service:12 uses EnvironmentFile and deploy-pearl-vps.md:6-11 directs secrets to /etc/macprovider/gateway.env. The asymmetry is genuine. The coordinator service itself runs as macprovider (not root), but the monitor reads the coordinator's config file as root unnecessarily. The finding is accurate. Low severity is correct: the file is gitignored and 0600 on VPS, so there is no live exposure today, but the structural gap (plaintext key + root reader vs. env-file indirection elsewhere) is real and worth noting.",
+    "correction": "No correction needed. All cited facts are accurate. The severity of Low is calibrated correctly for a 2-person beta: the key is gitignored and the file is 0600 on the VPS, so there is no active exposure, but the structural asymmetry with the gateway pattern is a real hygiene gap worth fixing before more contributors join.",
+    "correctedSeverity": "Low"
+   }
+  },
+  {
+   "title": "45 one-time Phase-1 bring-up artifacts (logs/ and results/) are git-tracked at the repo root; all other hygiene suspects are clean",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "git ls-files confirms 13 files under logs/ and 32 under results/ (curl outputs, tunnel logs, stress-test dumps dated 2026-05-26) are tracked. Everything else flagged as suspect is properly handled: default.profraw (5.3MB on disk) is ignored by .gitignore:34; phase3-binary/build-release/ (1.3GB) and .venv/ (241MB) exist on disk but have zero tracked files; the dist binaries, .bak, and the secret-bearing coordinator.yaml are explicitly ignored with a rationale comment (.gitignore:36-45). The only load-bearing tracked artifact is results/REPORT.md, which beta/harness.py references as the Phase 1 record.",
+   "where": [
+    "/Users/augstar/macprovider-poc/.gitignore:1-45 (full coverage verified)",
+    "/Users/augstar/macprovider-poc/.gitignore:34 (default.profraw)",
+    "/Users/augstar/macprovider-poc/.gitignore:36-45 (dist binaries, .bak, secret config with rationale)"
+   ],
+   "why": "Pure clutter, not risk: the raw logs bloat clones slightly and confuse new readers/agents about what is current ('06-tunnel.log' looks operational but is 2-week-old archaeology). Worth a 10-minute sweep, nothing more.",
+   "suggestedFix": "Keep results/REPORT.md (move it to doc/ or specs/ as the Phase 1 record), `git rm -r` the raw logs/ and remaining results/ files, and add both directories to .gitignore. Delete the stale on-disk default.profraw while there.",
+   "confidence": "high",
+   "id": "DEVE-8",
+   "dimension": "devexops",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All cited facts verified: git ls-files confirms exactly 13 files in logs/ and 32 in results/. .gitignore line 34 ignores default.profraw (5.3MB on disk, not tracked); lines 36-45 ignore dist binaries, .bak, and the secret coordinator.yaml with a rationale comment. phase3-binary/build-release/ and .venv/ have zero tracked files. One minor imprecision: the finding characterizes results/REPORT.md as referenced by harness.py \"as the Phase 1 record,\" but that reference is a docstring comment (line 15), not runtime code. However, REPORT.md is genuinely load-bearing \u2014 referenced across HANDOFF.md, CONTINUE_RUNBOOK.md, multiple specs, and BUILD prompts. This doesn't affect severity; Low is correctly calibrated for pure clutter with no security or money-path risk.",
+    "correction": "The claim that harness.py \"references\" results/REPORT.md as the Phase 1 record is accurate but understates its breadth \u2014 it is a docstring comment in harness.py (line 15), but REPORT.md is also referenced as a live design record across HANDOFF.md, CONTINUE_RUNBOOK.md, RUNBOOK.md, and multiple spec files. The suggested fix to move it to doc/ or specs/ would require updating numerous references across those files."
+   }
+  },
+  {
+   "title": "Public README documents a signed-receipt feature that has zero implementation, contradicting the product's own disclosure mandate",
+   "severity": "High",
+   "kind": "fact",
+   "what": "README.md line 22 states 'Every response carries a signed receipt binding (prompt, output, provider) \u2014 verifiable inference'; line 57 claims the gateway performs 'receipt issuance'; lines 59-83 present a full v1 receipt JSON schema ('issued by the gateway and signed with the provider's key', fields: model, prompt_hash, output_hash, provider_id, provider_pubkey, ttft_ms, tokens_out, ts, sig) and three capability claims including 'a buyer can prove an inference happened... without trusting the gateway to be honest after the fact'. Grep for 'receipt' across phase5-gateway/**/*.go, phase4-coordinator/internal/**/*.go, and phase3-binary/Sources returns zero matches \u2014 there is no receipt issuance, signing, or verification code anywhere in the production stack (the only code matches are the legacy beta demo and the unrelated arm64golf benchmark-receipt UI in frontdoor/console/index.html:1350-1451). Meanwhile the LIVE buyer docs served by the gateway say the opposite: phase5-gateway/internal/router/templates/docs.md:119-124 (tier-1 disclosure) states 'There is no hardware attestation or runtime integrity check', 'The product makes NO privacy, attestation, integrity... claims', and item 4 explicitly mandates that 'Any buyer-facing language, including front-door copy... MUST be consistent with properties 1-3.' The README is exactly that front-door copy.",
+   "where": [
+    "/Users/augstar/macprovider-poc/README.md:22",
+    "/Users/augstar/macprovider-poc/README.md:57",
+    "/Users/augstar/macprovider-poc/README.md:59-83",
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/templates/docs.md:119-124"
+   ],
+   "why": "This is a live public beta with real buyers. The repo's public front page promises a cryptographic verifiability primitive the product does not deliver, while the deployed /docs page honestly disclaims it. A buyer who signed up on the receipt promise has been materially misled; a security researcher who notices will (correctly) frame it as a false cryptographic claim. It also violates the project's own SPEC-006 consistency rule, which the team otherwise enforces rigorously.",
+   "suggestedFix": "Either move the receipt section under an explicit 'Roadmap \u2014 not yet implemented' heading (one-line edit preserving the schema as a design proposal), or delete lines 59-83 and soften lines 22/57 until receipts ship. Align with docs.md tier-1 disclosure language.",
+   "confidence": "high",
+   "id": "DOCS-1",
+   "dimension": "docs",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All cited lines confirmed by direct Read. README.md lines 22, 57, and 59-83 present signed receipts (ed25519, prompt_hash, output_hash, provider_pubkey, sig) as a live present-tense feature with no roadmap qualifier. Exhaustive grep across phase3-binary Swift, phase4-coordinator Go, and phase5-gateway Go returns zero receipt-issuance code. The only receipt code is beta/demo.html (internal, itself says \"Signed receipts land in Phase 3\") and frontdoor arm64golf benchmark receipts (unrelated concept). docs.md lines 119-124 confirmed: property 4 explicitly forbids inconsistent front-door copy. The repo is public. No counter-evidence found in any middleware, config, or deploy path. High severity is correctly calibrated: a live public beta with real buyers whose public front page asserts a cryptographic verifiability primitive that does not exist while the deployed /docs page honestly disclaims it."
+   }
+  },
+  {
+   "title": "README console feature list claims management and billing features the deployed console does not have",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "README.md:31 says providers 'Manage your node at console.streamvc.live' and README.md:35-40 lists console capabilities including 'Manage provider status and pool visibility' and 'Review billing and earnings'. The actual console (frontdoor/console/index.html) contains exactly three views \u2014 viewChat (line 493), viewDashboard (line 530), viewArm64golf (line 539). Grep over the file finds zero occurrences of 'earnings', 'payout', 'credits', 'billing', 'manage', 'pool visibility', or 'provider status'. Browser chat and pool monitoring are real; node management and billing review are not.",
+   "where": [
+    "/Users/augstar/macprovider-poc/README.md:31",
+    "/Users/augstar/macprovider-poc/README.md:35-40",
+    "/Users/augstar/macprovider-poc/frontdoor/console/index.html:493",
+    "/Users/augstar/macprovider-poc/frontdoor/console/index.html:530",
+    "/Users/augstar/macprovider-poc/frontdoor/console/index.html:539-544"
+   ],
+   "why": "A provider who installs expecting to manage their node and review earnings at the console finds neither, eroding trust at exactly the moment the project is trying to recruit and retain N>3 providers. Same overclaim pattern as the receipts finding, on a softer axis.",
+   "suggestedFix": "Trim README.md:35-40 to the two features that exist (browser chat, pool/dashboard monitoring) and mark management/billing views as planned.",
+   "confidence": "high",
+   "id": "DOCS-2",
+   "dimension": "docs",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "README.md:31 and :35-40 were read directly and exactly match the claimed overclaims. frontdoor/console/index.html:493/530/539 confirmed only three views (viewChat, viewDashboard, viewArm64golf) with zero occurrences of billing/management terms. The nginx config (frontdoor/console/dist/nginx-console.streamvc.live.conf:29) confirms console.streamvc.live serves /var/www/console (the static index.html), not the coordinator's internal explorer which does have ledger/settlement handlers. The gap is real: billing/payout data exists server-side but no UI surfaces it at the advertised URL. Medium severity is correctly calibrated \u2014 not exploitable, but materially misleads providers at onboarding time."
+   }
+  },
+  {
+   "title": "No operations runbook exists for the live production system; the files named RUNBOOK.md / CONTINUE_RUNBOOK.md / HANDOFF.md are frozen Phase 1 artifacts that actively misdirect",
+   "severity": "High",
+   "kind": "judgment",
+   "what": "Root RUNBOOK.md:1-19 is the original Phase 1 falsifiability script addressed to 'a Codex agent executing Phase 1'; its operational content is obsolete: lines 157-172 instruct launching `python3 -m mlx_lm.server` on port 8080 (replaced by the Swift phase3-binary), line 33 references the antseed VPS 165.22.182.207 (production is Pearl 159.223.165.194 per phase4-coordinator/dist/deploy-pearl-vps.sh:18,26). CONTINUE_RUNBOOK.md:1-9 is its continuation pass, same era. HANDOFF.md:5-7 declares 'Status: Phase 1 PoC complete... Awaiting M4 user before going live' and names itself 'Next session entry point: This document' \u2014 frozen at 2026-05-26, four phases behind a live beta with a money path; HANDOFF.md:54 still describes Antseed as 'the initial billing/demand layer' when billing is now native. Actual ops knowledge (safe coordinator restart with the FORCE_RESTART provider-connected guard, settlement runs, monitor alert response, key rotation, gateway deploy) lives only in deploy-script comments, phase5-gateway/dist/deploy-pearl-vps.md, specs/ phase reports, and the 200KB beta/DECISION_CRITERIA.md decision log.",
+   "where": [
+    "/Users/augstar/macprovider-poc/RUNBOOK.md:1-19",
+    "/Users/augstar/macprovider-poc/RUNBOOK.md:33",
+    "/Users/augstar/macprovider-poc/RUNBOOK.md:157-172",
+    "/Users/augstar/macprovider-poc/CONTINUE_RUNBOOK.md:1-9",
+    "/Users/augstar/macprovider-poc/HANDOFF.md:3-7",
+    "/Users/augstar/macprovider-poc/HANDOFF.md:54",
+    "/Users/augstar/macprovider-poc/phase4-coordinator/dist/deploy-pearl-vps.sh:18-26"
+   ],
+   "why": "This is a 2-person project with live users and live money. If the operator is unavailable during an incident \u2014 or returns after a gap \u2014 the documents whose names promise operational guidance point at an architecture that no longer exists (mlx_lm.server, cloudflared tunnels, the wrong VPS). Incident history in this beta (provider flapping, coordinator restarts, config drift) shows incidents are routine; recovery currently depends entirely on one person's memory plus a decision log that records 'why' but not 'how'.",
+   "suggestedFix": "Rename RUNBOOK.md/CONTINUE_RUNBOOK.md to docs/history/PHASE1_*.md (or add a superseded banner like HANDOFF.md has), and write a 1-2 page OPS.md covering: production topology, safe coordinator/gateway restart, monitor alert response, settlement, and key rotation \u2014 most content already exists in deploy-script comments and can be lifted.",
+   "confidence": "high",
+   "id": "DOCS-3",
+   "dimension": "docs",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "correctedSeverity": "High",
+    "reasoning": "Every cited line holds up. RUNBOOK.md:1-3 is explicitly addressed to \"a Codex agent executing Phase 1.\" Line 33 names VPS 165.22.182.207. Lines 157-172 instruct launching mlx_lm.server on port 8080. CONTINUE_RUNBOOK.md:1-9 is its continuation. HANDOFF.md:5-7 declares Phase 1 complete and itself as the entry point. HANDOFF.md:54 names Antseed as billing layer. deploy-pearl-vps.sh:18,26 shows Pearl (159.223.165.194) as the real VPS. Neither RUNBOOK.md nor CONTINUE_RUNBOOK.md carry a superseded banner. Some ops knowledge exists in phase5-gateway/dist/deploy-pearl-vps.md and deploy-pearl-vps.sh comments (FORCE_RESTART guard), but no unified current-state ops document exists. Slightly overstated in that scattered ops content does exist outside the decision log, but the core finding \u2014 misleading named artifacts with no current runbook \u2014 is accurate and High is calibrated correctly for a live-money 2-person system.",
+    "correction": "The finding is accurate. Minor softening: some ops knowledge does exist in phase5-gateway/dist/deploy-pearl-vps.md (deployment steps, rollback) and deploy-pearl-vps.sh (FORCE_RESTART guard with explanation). The claim that ops knowledge \"lives only in deploy-script comments and the decision log\" is essentially correct \u2014 these are the right places to look, but they require knowing to look there. The stated gap (no current named runbook, misdirecting Phase 1 artifacts with no superseded banner) stands."
+   }
+  },
+  {
+   "title": "specs/README.md index lists 3 of 12 spec families at versions ~6 revisions stale \u2014 the only discoverability layer over a 176-file authoritative corpus is wrong",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "specs/README.md:1-8 (the entire file) indexes only SPEC-001 ('v1.1.1, Build-ready'), SPEC-002 ('v1.0.3'), and SPEC-005 ('v0.3'). The actual corpus has 176 files including 38 SPEC-* documents across 12 families (SPEC-001 through SPEC-012, verified by directory listing). Actual current versions: SPEC-001 v1.3 (SPEC-001-phase3-binary.md:3), SPEC-002 v1.3.5 (SPEC-002-coordinator.md:3), SPEC-006 v0.8.3 (SPEC-006-buyer-api.md:3). The project's whole methodology is version-pinned spec-driven development, making a stale index an active hazard rather than mere clutter.",
+   "where": [
+    "/Users/augstar/macprovider-poc/specs/README.md:1-8",
+    "/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md:3",
+    "/Users/augstar/macprovider-poc/specs/SPEC-002-coordinator.md:3",
+    "/Users/augstar/macprovider-poc/specs/SPEC-006-buyer-api.md:3"
+   ],
+   "why": "Humans and AI agents commissioning the next BUILD/AUDIT/FIX pass use the index to find the current normative baseline. Trusting it yields versions 5-6 revisions old, and the 9 unlisted spec families (router, buyer API, explorer, tier2, catalog, warm swap...) are undiscoverable except by directory listing. In a project where audits cite exact spec versions, this is how baseline drift starts.",
+   "suggestedFix": "Regenerate the table to cover all 12 SPEC families with current version + status, and add one line of guidance ('version of record is line 3 of each spec'). ~15 minutes; consider a tiny script that greps line 3 of each SPEC-*.md.",
+   "confidence": "high",
+   "id": "DOCS-4",
+   "dimension": "docs",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "specs/README.md is confirmed 8 lines: only SPEC-001 v1.1.1, SPEC-002 v1.0.3, SPEC-005 v0.3 are listed. Actual versions per line 3 of each file: SPEC-001 v1.3, SPEC-002 v1.3.5, SPEC-006 v0.8.3. Directory listing confirms exactly 176 files and 12 distinct SPEC families (SPEC-001 through SPEC-012), of which only 3 appear in the index. No other file (build scripts, CLAUDE.md, AGENTS.md) compensates \u2014 the index is the only discoverability layer and it is materially wrong. Medium is correctly calibrated: no live money or security risk, but a real hazard for audit commissioning workflows in a spec-driven project."
+   }
+  },
+  {
+   "title": "Project CLAUDE.md feeds every agent session stale 'locked' baselines (binary v1.2.3, SPEC-001 v1.2.2, SPEC-002 v1.1.3, SPEC-003 v0.5)",
+   "severity": "Medium",
+   "kind": "fact",
+   "what": "CLAUDE.md:151-153 states 'v1.2.3 is the current phase3-binary release. SPEC-001 v1.2.2, SPEC-002 v1.1.3, SPEC-003 v0.5 are locked. SPEC-006 v0.2 is in regression-audit pending.' Actual: the shipped binary is 1.3.0 (phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:70 'static let binaryVersion = \"1.3.0\"'; git tag v1.3.0 exists), SPEC-001 is v1.3, SPEC-002 is v1.3.5, SPEC-006 is v0.8.3. AGENTS.md:3-6 directs ALL AI agents (Claude, Codex, Cursor) to read CLAUDE.md as the canonical rules document, so every coding session ingests these wrong baselines as ground truth.",
+   "where": [
+    "/Users/augstar/macprovider-poc/CLAUDE.md:151-153",
+    "/Users/augstar/macprovider-poc/AGENTS.md:3-6",
+    "/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:70",
+    "/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md:3",
+    "/Users/augstar/macprovider-poc/specs/SPEC-002-coordinator.md:3"
+   ],
+   "why": "This project's development model is agent-executed, spec-pinned builds. An agent told SPEC-002 v1.1.3 is the locked baseline can write a FIX prompt, audit, or compatibility check against a contract that is four versions behind the code it sits next to. Given how much process discipline the team invests in version pinning, the agent-facing memory being wrong undermines exactly that discipline.",
+   "suggestedFix": "Either update the version lines now and on each release, or (better) replace hardcoded versions in CLAUDE.md with a pointer: 'current versions of record: line 3 of each specs/SPEC-NNN-*.md and the binaryVersion constant \u2014 do not trust this file for versions.'",
+   "confidence": "high",
+   "id": "DOCS-5",
+   "dimension": "docs",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All citations verified directly. CLAUDE.md:151-153 states exactly the stale versions (binary v1.2.3, SPEC-001 v1.2.2, SPEC-002 v1.1.3, SPEC-006 v0.2). Actual state: CoordinatorClient.swift:70 shows binaryVersion = \"1.3.0\", git tag v1.3.0 exists, SPEC-001-phase3-binary.md:3 shows v1.3, SPEC-002-coordinator.md:3 shows v1.3.5, SPEC-006-buyer-api.md:3 shows v0.8.3. AGENTS.md:3-6 confirms all AI agents are directed to CLAUDE.md as canonical. No mitigating mechanism found elsewhere. Medium is calibrated correctly \u2014 an agent acting on these baselines wastes effort or produces wrong spec artifacts, but no direct money-loss path today."
+   }
+  },
+  {
+   "title": "Provider economics and lifecycle rules (earnings formula, payout, promotion criteria, liveness reaping) are documented on zero provider-visible surfaces",
+   "severity": "Medium",
+   "kind": "judgment",
+   "what": "Real providers accrue real credits through the ledger, and a provider-token-authenticated earnings endpoint exists (/providers/{id}/earnings, phase4-coordinator/internal/billing/endpoints.go:51-52), but no surface a provider can see documents any of it: frontdoor/console/index.html has zero matches for earnings/payout/credits/billing; phase3-binary/dist/install.sh has zero matches for earn/payout; phase3-binary/README.md (read in full, 51 lines) covers install and trust caveats only; README.md's sole mention of the provider lifecycle is one clause at line 55 ('can be promoted to pinned by the operator after observation') with no criteria. The earnings endpoint is referenced only in internal specs (SPEC-005 family). Liveness/reaping rules (silent providers reaped after the heartbeat-miss window; sleeping Macs flap) are similarly spec-internal \u2014 buyers get one sentence (docs.md:130 'provider availability can change as Macs sleep') and providers get nothing.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase4-coordinator/internal/billing/endpoints.go:43-56",
+    "/Users/augstar/macprovider-poc/README.md:55",
+    "/Users/augstar/macprovider-poc/phase3-binary/README.md:1-51",
+    "/Users/augstar/macprovider-poc/phase5-gateway/internal/router/templates/docs.md:130"
+   ],
+   "why": "Money disputes without documentation land on the operator and are unresolvable by reference ('what rate? what share? when do I get paid? why did my Mac drop from the pool?'). The project's own growth plan is recruiting benchmark golfers as sellers; the first question a prospective seller asks \u2014 what do I earn and under what rules \u2014 currently has no answer anywhere public. Provider flapping due to sleep has already been a real support burden in this beta, and a paragraph of provider-facing explanation would deflect most of it.",
+   "suggestedFix": "Add a short 'Provider economics & lifecycle' section to phase3-binary/README.md (or a console page): credit formula in plain language, provider share, payout threshold/window, how to call /providers/{id}/earnings with the provider token, promotion criteria, and a note that the Mac must stay awake (the binary holds a sleep assertion, but lid-closed sleep still drops you).",
+   "confidence": "high",
+   "id": "DOCS-6",
+   "dimension": "docs",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All four cited locations were read and confirm the claim. The /providers/{id}/earnings endpoint exists at billing/endpoints.go:51-52 with real provider_share_bps and payout data, but: frontdoor/console/index.html has zero references to earnings/payout/credits (confirmed by grep); phase3-binary/README.md (all 51 lines) covers only installation and trust caveats; README.md:55 has exactly the single \"can be promoted to pinned\" clause with no criteria; docs.md:130 gives buyers one sentence on availability. No counter-evidence found in dist/install.sh, RUNBOOK.md, HANDOFF.md, or any other public surface. The README \"Review billing and earnings\" bullet (line 40) is aspirational UI copy pointing at console.streamvc.live, but the console HTML itself contains no earnings UI whatsoever. Medium severity is correctly calibrated for a 3-provider beta \u2014 not Critical since disputes are manual today, but a real friction point for provider recruitment."
+   }
+  },
+  {
+   "title": "Version-claim drift cluster across human-facing docs: README pins v1.2.5 against a v1.3.0 reality; gateway README pins SPEC-006 v0.5; SPEC-002 header pins SPEC-001 v1.2.4 while absorbing v1.3",
+   "severity": "Low",
+   "kind": "fact",
+   "what": "Three independent stale pins: (1) README.md:137 'Current release: **[v1.2.5]**' \u2014 but the hyperlink target is /releases/latest and git tags include v1.3.0 (also commit 2ace6d6 'bump binaryVersion 1.2.6 \u2192 1.3.0'), so the text and its own link target disagree, and the shields.io badge at README.md:13 auto-displays the real latest, contradicting line 137 on the same page. (2) phase5-gateway/README.md:3 says 'Phase 5 gateway implementation for SPEC-006 v0.5' while SPEC-006-buyer-api.md:3 is v0.8.3. (3) SPEC-002-coordinator.md:4 declares 'Depends on: SPEC-001 v1.2.4 (locked)' while its own line 3/changelog says v1.3.5 absorbs 'SPEC-001 v1.3' \u2014 a self-contradiction within the otherwise rigorous spec header discipline.",
+   "where": [
+    "/Users/augstar/macprovider-poc/README.md:13",
+    "/Users/augstar/macprovider-poc/README.md:137",
+    "/Users/augstar/macprovider-poc/phase5-gateway/README.md:3",
+    "/Users/augstar/macprovider-poc/specs/SPEC-002-coordinator.md:3-7",
+    "/Users/augstar/macprovider-poc/specs/SPEC-006-buyer-api.md:3"
+   ],
+   "why": "Each instance is cosmetic alone, but together they show hardcoded version strings are never swept at release time. The README one is public-facing and visibly self-contradictory (badge says one version, text says another); the SPEC-002 depends-on pin could mislead an audit pass into checking compatibility against the wrong SPEC-001 revision.",
+   "suggestedFix": "Drop the hardcoded version from README.md:137 (the badge and /releases/latest link already carry it); fix gateway README to v0.8.3; correct SPEC-002:4's depends-on line. Add 'grep for old version string' to the release checklist.",
+   "confidence": "high",
+   "id": "DOCS-7",
+   "dimension": "docs",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three sub-claims verified by direct reads. README.md:137 hardcodes \"v1.2.5\" linking to /releases/latest while the shields.io badge at line 13 auto-fetches live \u2014 text and link target contradict. phase5-gateway/README.md:3 says \"SPEC-006 v0.5\" while SPEC-006-buyer-api.md:3 is \"0.8.3\". SPEC-002:3 says v1.3.5 absorbs \"SPEC-001 v1.3\" while line 4 says \"Depends on: SPEC-001 v1.2.4 (locked)\" \u2014 genuine same-header self-contradiction. Low severity is correctly calibrated: all three are pure documentation drift with no money-path or security impact on a 2-person beta."
+   }
+  },
+  {
+   "title": "Contributor onboarding is one-third complete: gateway buildable from docs, binary partially, coordinator (the 25k-LOC money-path hub) has no README at all",
+   "severity": "Medium",
+   "kind": "judgment",
+   "what": "phase5-gateway/README.md:26-41 gives a complete copy-paste local dev path (env vars, yaml example, test/run commands) plus smoke curls (43-55), deployment layout (64-92), and a troubleshooting table (104-113) \u2014 a contributor can build and run it from docs alone. phase3-binary/README.md:1-51 documents the installed product and dist/ files but contains no source-build instructions (no swift build/test invocation; buildable only by inferring SwiftPM conventions or reading dist/package.sh). phase4-coordinator/ has no README whatsoever (verified by directory listing: cmd, internal, dist, coordinator.yaml.example, go.mod \u2014 no markdown doc); its only documentation is SPEC-002 (a 1.3.5-version normative wire-contract spec, not a build/run guide) and an implementation-notes.html.",
+   "where": [
+    "/Users/augstar/macprovider-poc/phase5-gateway/README.md:26-55",
+    "/Users/augstar/macprovider-poc/phase5-gateway/README.md:104-127",
+    "/Users/augstar/macprovider-poc/phase3-binary/README.md:1-51"
+   ],
+   "why": "The coordinator is the largest component, holds the billing ledger and provider auth, and is the piece a second contributor (or future hire, or the other half of this 2-person team) would most need to run locally to be useful. Today that requires reverse-engineering main.go and coordinator.yaml.example. The gateway README proves the team can write this doc well \u2014 the gap is just that the hub never got one.",
+   "suggestedFix": "Write a phase4-coordinator/README.md modeled on the gateway's: build (go build ./cmd/coordinator), minimal local config from coordinator.yaml.example, how to run with the mockprovider tool, the two-port layout (provider 8444 / buyer 8443), and the key test invocations. Half a day, mostly transcription.",
+   "confidence": "high",
+   "id": "DOCS-8",
+   "dimension": "docs",
+   "verdict": {
+    "isReal": true,
+    "citationAccurate": true,
+    "severityVerdict": "keep",
+    "reasoning": "All three citations verified directly. phase5-gateway/README.md:26-55 contains exactly the claimed local dev block (env vars, yaml copy, go test/run, smoke curls). phase3-binary/README.md:1-51 covers only the installed product and dist/ files \u2014 no swift build/test invocation. phase4-coordinator/ has no root README; only two deeply nested READMEs exist (dist/monitor/README.md for ops deploy, internal/testfaults/README.md for test helpers). Counter-evidence checked across RUNBOOK.md, HANDOFF.md, CONTINUE_RUNBOOK.md, AGENTS.md, root README.md, and SPEC-002: the closest thing is a cross-compile one-liner at SPEC-002:2973 buried in dependency tables and build-session step prompts at 3856+, neither of which serves as contributor onboarding. Medium severity is calibrated correctly for a 2-person beta \u2014 real gap, not an immediate security or money risk."
+   }
+  }
+ ],
+ "refuted": [],
+ "critic": {
+  "missedAreas": [
+   "Swift self-update path (phase3-binary/Sources/macprovider-cli/SelfUpdate.swift) \u2014 examined; robust: ECDSA P256 signature over checksums.txt, download-URL host allowlist (github.com/objects.githubusercontent.com), tarball entry traversal validation, atomic rename, self-test before swap. No finding needed.",
+   "Swift control socket (phase3-binary/Sources/macprovider-cli/ControlSocket.swift) \u2014 examined; AF_UNIX only, parent dir chmod 0700 and socket chmod 0600, 64KB frame cap, idle timeout. No finding.",
+   "Public installer frontdoor/install.sh (== phase3-binary/dist/install.sh) \u2014 examined; verifies signature THEN sha256 THEN tarball members before install; ordering and input sanitization are sound.",
+   "beta/web demo proxy (beta/web/api/chat.js, providers.js) \u2014 examined; hard-disabled behind MACPROVIDER_ENABLE_LEGACY_BETA_PROXY!='1' returning 410, so the M1/M4 tunnel passthrough is not live.",
+   "tier2 attestation verification (phase4-coordinator/internal/tier2/pillar_c.go VerifyAttestationToken) \u2014 examined; fail-CLOSED when RequireAttestation=true at every branch. The risk is the permissive default (already SECU-3), not a verification fail-open.",
+   "Coordinator explorer static JS + auth gating (phase4-coordinator/internal/explorer/handlers.go) \u2014 examined; only /, /css/, /js/ served unauthenticated; all data endpoints pass through h.authorized() before the route switch (line 57). No data leak.",
+   "Gateway CORS (phase5-gateway/internal/router/cors.go) \u2014 examined; strict allowlist, Allow-Credentials:false, reflects only configured origins. Sound.",
+   "Gateway demo token (phase5-gateway/internal/auth/demo.go) and API-key hashing (keys.go) \u2014 examined; HMAC-SHA256 with hmac.Equal constant-time compare, IP-bound demo tokens, 24h TTL clamp. Sound.",
+   "Coordinator billing formula (phase4-coordinator/internal/billing/formula.go) \u2014 examined; checkedMul/checkedAdd overflow guards, RoundHalfEven banker's rounding, byte-estimate clamping. Money math is carefully done.",
+   "Provider earnings endpoint (phase4-coordinator/internal/billing/endpoints.go earnings()) \u2014 examined; enforces token subject == path providerID (line 339), so no cross-provider IDOR. Admin ledger endpoints operator-key gated.",
+   "Signing script (scripts/sign-catalog.go) \u2014 examined; ed25519 keygen/sign over a canonical body. Standard.",
+   "Provider-token onboarding wiring across the binary, installer, and coordinator \u2014 examined; produced finding 1 below."
+  ],
+  "additionalFindings": [
+   {
+    "title": "Provider identity is unauthenticated end-to-end on the live network: binary/installer ship no provider token, contradicting the coordinator's default require_provider_tokens=true and disabling the pinned-provider impersonation check when set false",
+    "severity": "High",
+    "what": "The public installer writes a config with only model/coordinator_url/provider_id/port and no token field (phase3-binary/dist/install.sh:464-469). The provider binary opens the coordinator WebSocket with a URL-only factory and sets no Authorization header anywhere (phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:111-137; the file contains no Bearer/Authorization send). The coordinator defaults auth.require_provider_tokens=true (phase4-coordinator/internal/config/config.go:357-359), and the token validator is wired ONLY when that flag is true (phase4-coordinator/cmd/coordinator/main.go:84-89). With it true, an empty Authorization header is rejected with CloseInvalidToken (phase4-coordinator/internal/ws/server.go:242-247) \u2014 so a default-config coordinator rejects every provider produced by the documented curl|bash flow. The only way the live tokenless beta works is with require_provider_tokens=false (as in committed phase4-coordinator/coordinator.local-explorer.yaml:8). But when false, s.tokens==nil, so prepareProviderAdmission skips the entire token block including the `if pinned && !auth.validated { reject }` impersonation guard (phase4-coordinator/internal/ws/server.go:603-619). 'pinned' is derived directly from the attacker-controlled hello.ProviderID (server.go:602) and passed to admission.Admit, which returns TierPinned with no authentication (phase4-coordinator/internal/ws/admission.go:78-81).",
+    "where": [
+     "phase3-binary/dist/install.sh:464-469",
+     "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:111-137",
+     "phase4-coordinator/internal/ws/server.go:236-247",
+     "phase4-coordinator/internal/ws/server.go:602-619",
+     "phase4-coordinator/internal/ws/admission.go:78-81",
+     "phase4-coordinator/cmd/coordinator/main.go:84-89",
+     "phase4-coordinator/internal/config/config.go:357-359"
+    ],
+    "why": "A trust-boundary contradiction single-dimension auditors missed (security reviewed tier-2 posture in SECU-3/4/5 but not the binary<->installer<->coordinator token wiring; devex reviewed config drift but not this). It forces require_provider_tokens=false, meaning provider identity on a network that attributes billing/earnings by provider_id is entirely self-asserted. If any provider is pinned in the production config (dist/coordinator.yaml comments reference M1/M4 as pinned), a remote attacker can connect claiming that provider_id and be admitted at pinned tier with no credential \u2014 receiving buyer inference routed to a trusted provider and serving arbitrary responses under its identity, or poisoning its fault/quarantine stats. Even absent pinned providers, every provisional handle is spoofable. The token system (internal/auth/tokens.go) is dead code for real providers."
+   },
+   {
+    "title": "Coordinator provisional-admission state grows unbounded and is rewritten as one full JSON blob to SQLite on every provisional request; the configured ProvisionalRetentionDays knob is never implemented",
+    "severity": "Medium",
+    "what": "AdmissionManager.records (keyed by provider_id) is inserted on first admission and NEVER deleted (phase4-coordinator/internal/ws/admission.go:99-108); requestWindows keeps a map key per provider_id forever. The whole state \u2014 admissions slice, records map, rejected map, requestWindows map \u2014 is serialized in full and written to a single SQLite row on every mutation via persistLocked -> SaveAdmissionState (admission.go:209-221 and admission_store.go:61-75, which json.Marshal's the entire AdmissionState into one value column). persistLocked is invoked not only on admission but on EVERY provisional request reservation (TryReserveRequest, admission.go:133-152). The config field AdmissionConfig.ProvisionalRetentionDays is set to 30 (config.go:281) but is referenced nowhere in the ws package \u2014 no pruning code exists.",
+    "where": [
+     "phase4-coordinator/internal/ws/admission.go:99-114",
+     "phase4-coordinator/internal/ws/admission.go:133-152",
+     "phase4-coordinator/internal/ws/admission.go:209-221",
+     "phase4-coordinator/internal/ws/admission_store.go:61-75",
+     "phase4-coordinator/internal/config/config.go:281"
+    ],
+    "why": "Distinct from PERF-5 (pool.seenModels) and PERF-1/PERF-3 (gateway retention): this is the coordinator's admission state on the provisional hot path. Because the entire blob is rewritten on each provisional inference reservation, write cost is O(N) in all-time unique provider_ids plus accumulated request timestamps, and that write is held under the admission mutex serializing all provisional traffic. Combined with the tokenless model (finding 1), any unauthenticated caller can mint new provider_ids (rate-limited to 10/hr for new IDs but unbounded over time) and grow the persisted blob indefinitely. The presence of an unused ProvisionalRetentionDays config is direct evidence pruning was specified and dropped."
+   }
+  ],
+  "overallGaps": "The 8-dimension audit is broad and its confirmed findings are accurate; the surfaces it skipped (Swift self-update, control socket, installer, tier-2 attestation verification, explorer auth gating, CORS, demo/API-key crypto, billing formula, earnings IDOR, signing script) are genuinely sound and correctly went unflagged. The audit's main blind spot is the cross-component trust boundary between the provider binary, the public installer, and the coordinator's admission path: it reviewed each service in isolation (SECU-3/4/5) but never connected that the installer/binary ship no provider token while the coordinator's default config and pinned-impersonation guard both assume one exists. That is the most security-relevant gap (finding 1, High). On the severity-distribution question: zero Critical is defensible \u2014 the live money path is unusually well-guarded for a 2-person PoC (overflow-checked banker's-rounding billing, token-subject-bound earnings with no IDOR, demo traffic quota-capped per IP, constant-time auth comparisons, signature-verified self-update and install, and config validation that forces operator_key non-empty so the SECU-5 fail-open is masked in production). I found no verified path to direct money theft or data loss that is live today, so I am not asserting a Critical. The genuine elevation is provider-identity integrity (finding 1), which I would place above the audit's current top security item SECU-1 because it is exploitable remotely with no credential whenever a pinned provider exists. Two omissions also compound existing findings: provider_id is attacker-asserted, so SECU-6 (trusting provider-reported token counts for billing) is worse than rated because the provider those tokens are attributed to is itself unauthenticated."
+ }
+}


### PR DESCRIPTION
## Summary

Closes **QW-3 / M0-4** (external half) from [audits/2026-06-10/REPO_AUDIT.md](audits/2026-06-10/REPO_AUDIT.md).

- Lands the 2026-06-10 multi-agent repo audit corpus (`REPO_AUDIT.md`, `INDEX.md`, `findings-raw.json`) so the other Quick-Win PRs can cite finding IDs against a file that lives on `main`.
- Adds `audits/2026-06-10/OPS_HEALTHCHECK_SETUP.md` — a 15-minute checklist a non-author can execute to wire UptimeRobot (free tier) against both `https://coordinator.streamvc.live/healthz` and `https://api.streamvc.live/healthz`, with email + push notifications and an end-to-end test procedure (kill nginx on Pearl in a maintenance window, verify the alert arrives).

UptimeRobot picked over healthchecks.io for the URL-poll shape; either works and the config translates 1:1.

## Out of scope

- The in-repo half of M0-4 (`macprovider-monitor.py:159-195` save_state ordering fix) ships in its own PR.
- No code change in this repo; nothing to deploy.

## Test plan

- [ ] Operator follows the doc end-to-end during a quiet window
- [ ] Both monitors green in UptimeRobot dashboard
- [ ] `sudo systemctl stop nginx` on Pearl triggers email + push within 5 min
- [ ] `sudo systemctl start nginx` triggers up-notification within 5 min
