### PR TITLE
docs(readme): truth sweep — receipts to roadmap; console trim; drop v1.2.5 pin (QW-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # MacProvider
 
-**Make any Apple Silicon Mac a remote-addressable MLX inference endpoint.** Built on `mlx-lm`. OpenAI-compatible API. Every response carries a signed receipt binding (prompt, output, provider) — verifiable inference, without a datacenter.
+**Make any Apple Silicon Mac a remote-addressable MLX inference endpoint.** Built on `mlx-lm`. OpenAI-compatible API. Every response will carry a signed receipt binding (prompt, output, provider) — verifiable inference, without a datacenter (planned, not yet implemented; see [Roadmap](#roadmap)).
 
 A lot of the most interesting LLM applications — long-running personal agents, privacy-sensitive tooling, dev workflows that hammer a model thousands of times a day — don't really belong in a cloud datacenter. But the moment you want your Mac's MLX endpoint to be reachable from somewhere that isn't localhost, you fall off a cliff: auth, tunneling, multi-tenant routing, observability, none of it exists out of the box. MacProvider is a thin layer over `mlx-lm` that fills that gap.
 
@@ -32,12 +32,10 @@ A lot of the most interesting LLM applications — long-running personal agents,
 
 ## Console
 
-**[console.streamvc.live](https://console.streamvc.live)** is the front end for MacProvider. Use it to chat with the network, manage your provider node, or monitor the pool:
+**[console.streamvc.live](https://console.streamvc.live)** is the front end for MacProvider. Today it ships two views:
 
-- Send requests to the network directly from the browser
-- View session history and per-request logs
-- Manage provider status and pool visibility
-- Review billing and earnings
+- **Browser chat.** Send requests to the network directly from the browser, with session history.
+- **Pool dashboard.** Monitor live provider pool status and which models are warm.
 
 ## Architecture
 
@@ -54,33 +52,7 @@ Provider Mac (MLX)
 
 New public installs join as **provisional providers** over outbound WebSocket tunneling and can be promoted to pinned by the operator after observation. No inbound port-forwarding is required on the provider Mac.
 
-**Trust model — what the coordinator sees:** prompts and responses pass through the gateway to enable routing, billing, and receipt issuance. Model weights stay on the provider Mac and never leave. A self-hosted coordinator is on the roadmap for buyers who need local-only trust.
-
-## Verifiable inference
-
-Every request through MacProvider returns a signed receipt that lets the caller later prove which provider ran their inference. The receipt is issued by the gateway and signed with the provider's key:
-
-```json
-{
-  "model": "mlx-community/Llama-3.2-3B-Instruct-4bit",
-  "prompt_hash": "sha256:7c3f...",
-  "output_hash": "sha256:9b2a...",
-  "provider_id": "m1-anon",
-  "provider_pubkey": "ed25519:...",
-  "ttft_ms": 646,
-  "tokens_out": 142,
-  "ts": "2026-06-04T12:34:56Z",
-  "sig": "ed25519:..."
-}
-```
-
-What this enables:
-
-- **Audit trail.** A buyer can prove an inference happened, on which model, at which provider — without trusting the gateway to be honest after the fact.
-- **Provider accountability.** Disputes over output quality or downtime become resolvable from receipts rather than from memory.
-- **New compositions.** Receipts can be replayed into systems that don't trust the issuer but trust the signature (escrow, reputation, on-chain settlement).
-
-This is the primitive that makes "inference outside a datacenter" something you can build on rather than just hope works. The schema above is the v1 shape — feedback welcome via Issues.
+**Trust model — what the coordinator sees:** prompts and responses pass through the gateway to enable routing and billing. Model weights stay on the provider Mac and never leave. Buyer prompts and provider responses are processed as plaintext on provider hardware — providers can technically observe prompts and outputs that route through their machine. This is acceptable for cooperative deployments where buyer and provider have an established trust relationship; it is NOT a private-inference guarantee. A self-hosted coordinator is on the roadmap for buyers who need local-only trust.
 
 ## For Providers
 
@@ -134,5 +106,32 @@ API reference → [api.streamvc.live/docs#api-reference](https://api.streamvc.li
 
 ## Releases
 
-Current release: **[v1.2.5](https://github.com/augustas11/macprovider/releases/latest)**  
-Full changelog and signed binaries: [github.com/augustas11/macprovider/releases](https://github.com/augustas11/macprovider/releases)
+Latest release and signed binaries: [github.com/augustas11/macprovider/releases](https://github.com/augustas11/macprovider/releases) (badge above auto-updates).
+
+## Roadmap
+
+**Signed inference receipts — planned, not implemented.** The product surface described below is a design proposal preserved here so it isn't lost; no service in this repo currently issues, signs, or verifies receipts. Tracked as Open Question 1 in `audits/2026-06-10/REPO_AUDIT.md`.
+
+The intent is that every request through MacProvider eventually returns a signed receipt that lets the caller later prove which provider ran their inference. The receipt would be issued by the gateway and signed with the provider's key:
+
+```json
+{
+  "model": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+  "prompt_hash": "sha256:7c3f...",
+  "output_hash": "sha256:9b2a...",
+  "provider_id": "m1-anon",
+  "provider_pubkey": "ed25519:...",
+  "ttft_ms": 646,
+  "tokens_out": 142,
+  "ts": "2026-06-04T12:34:56Z",
+  "sig": "ed25519:..."
+}
+```
+
+What this would enable:
+
+- **Audit trail.** A buyer could prove an inference happened, on which model, at which provider — without trusting the gateway to be honest after the fact.
+- **Provider accountability.** Disputes over output quality or downtime become resolvable from receipts rather than from memory.
+- **New compositions.** Receipts could be replayed into systems that don't trust the issuer but trust the signature (escrow, reputation, on-chain settlement).
+
+The schema above is the v1 proposal. Feedback welcome via Issues.


### PR DESCRIPTION
## Summary

Closes **QW-4 / M1-3** (DOCS-1, DOCS-2, DOCS-7) from [audits/2026-06-10/REPO_AUDIT.md](audits/2026-06-10/REPO_AUDIT.md).

Docs-only sweep so the public README no longer makes claims the deployed product doesn't back up — cross-checked against the `/docs` tier-1 disclosure language at [phase5-gateway/internal/router/templates/docs.md:119-124](phase5-gateway/internal/router/templates/docs.md).

- **Receipts → Roadmap.** Headline verb tense softened (`"carries"` → `"will carry (planned)"`). Schema and product-surface description moved under a new `## Roadmap` heading framed as a design proposal, preserved so the work isn't lost; links to Open Question 1 in the audit.
- **Console list trimmed** to the two views that exist today (browser chat at `frontdoor/console/index.html:493`, pool dashboard at `:530`). The "earnings" and "management" bullets were imaginary.
- **Trust-model paragraph rewritten** to mirror `docs.md:119-124` (plaintext-on-provider, cooperative-deployment caveat); drops the receipt-issuance assertion that contradicted `/docs`.
- **Hardcoded `v1.2.5`** dropped from Releases — the shields.io badge above already renders the current release.

## Test plan

- [x] Cross-checked against `phase5-gateway/internal/router/templates/docs.md:119-124` — no contradiction
- [x] Manually verified `viewArm64golf` (`frontdoor/console/index.html:539`) is not user-facing in the console nav; only chat + dashboard remain in the trimmed list
- [ ] Visual diff on README rendering on GitHub

Docs-only — no code paths touched.
