### PR TITLE
deps: dependabot + go mod tidy (promote goldmark to direct) — QW-6 / DEPE-2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/phase4-coordinator"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "gomod"
+    directory: "/phase5-gateway"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "swift"
+    directory: "/phase3-binary"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2

--- a/phase5-gateway/go.mod
+++ b/phase5-gateway/go.mod
@@ -3,6 +3,7 @@ module github.com/augstar/macprovider-gateway
 go 1.26
 
 require (
+	github.com/yuin/goldmark v1.7.8
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.33.0
 )
@@ -14,7 +15,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/yuin/goldmark v1.7.8 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 // indirect
 	modernc.org/mathutil v1.6.0 // indirect


### PR DESCRIPTION
## Summary

Closes **QW-6 / M2-7** (DEPE-2) from [audits/2026-06-10/REPO_AUDIT.md](audits/2026-06-10/REPO_AUDIT.md).

- `cd phase5-gateway && go mod tidy` — promotes `github.com/yuin/goldmark` to the direct `require` block. It is imported directly in [`internal/router/pages.go:11-12`](phase5-gateway/internal/router/pages.go), so the previous `// indirect` classification would have hidden it from dependabot proposals. `go.sum` delta is empty (no-op beyond the promotion).
- Adds `.github/dependabot.yml` with monthly cadence, max 2 open PRs per ecosystem, covering:
  - `gomod` against `/phase4-coordinator`
  - `gomod` against `/phase5-gateway`
  - `swift` against `/phase3-binary`
  - `github-actions` against `/` (release.yml + new ci.yml SHA-pin actions; dependabot can re-propose SHAs when point releases ship)

Per audit, this fixes "the systemic cause of the retracted-driver miss." Out of scope: bumping `modernc.org/sqlite` — that is M1-7 with its own canary day.

## Test plan

- [x] `cd phase5-gateway && go mod tidy` — only diff is goldmark promotion
- [x] `cd phase5-gateway && go test ./...` — all-but-router green; router failure is the pre-existing console-contract failure that PR #10 fixes (not introduced by this PR)
- [ ] dependabot.yml lints (GitHub validates on push)
- [ ] First scheduled run of dependabot creates ≤8 PRs in the following month
