### PR TITLE
m0: deploy snapshot + post-restart provenance assertion (M0-5 Phase 2)

### DIFF
--- a/audits/2026-06-10/ROLLBACK_PROCEDURE.md
+++ b/audits/2026-06-10/ROLLBACK_PROCEDURE.md
@@ -27,7 +27,7 @@ ssh -i ~/.ssh/pearl_operator_ed25519 root@159.223.165.194 '
     exit 1
   fi
   mv /opt/macprovider/coordinator /opt/macprovider/coordinator.bad
-  cp -p /opt/macprovider/coordinator.prev /opt/macprovider/coordinator
+  install -o macprovider -g macprovider -m 0755 /opt/macprovider/coordinator.prev /opt/macprovider/coordinator
   systemctl restart macprovider-coordinator
   sleep 2
   systemctl is-active macprovider-coordinator
@@ -45,13 +45,23 @@ curl -fsS https://coordinator.streamvc.live/healthz \
 If `is-active` returns `active` and the version field matches the
 previous build, the rollback is complete. Total wall-clock: ~10–20s.
 
-## Why `cp -p` not `mv` for the restore
+## Why `install` not `mv` for the restore
 
 Keeping `coordinator.prev` in place after the restore lets the next
 rollback (if the operator pushes a third build that also fails) still
 have the same known-good snapshot to fall back to. The "bad" binary
 goes to `coordinator.bad` rather than being deleted so a post-mortem
 can `strings` / `nm` / re-run it locally.
+
+We use `install -o macprovider -g macprovider -m 0755` rather than
+`cp -p` so the restored binary's ownership is set explicitly per
+invocation. A `cp -p` would propagate whatever owner/mode the
+`.prev` file happens to carry, which is normally fine — but if the
+`.prev` was ever recreated from a root-owned binary (the "rebuilding
+from scratch" path below, run incorrectly without `chown`), the next
+rollback would silently place a root-owned binary at the live path
+and break systemd's expectation that the service runs as
+`macprovider`.
 
 ## When the fast path is wrong
 
@@ -94,10 +104,12 @@ about to be replaced. To populate it WITHOUT a new deploy:
 
 ```bash
 ssh -i ~/.ssh/pearl_operator_ed25519 root@159.223.165.194 '
-  cp -p /opt/macprovider/coordinator /opt/macprovider/coordinator.prev
+  install -o macprovider -g macprovider -m 0755 /opt/macprovider/coordinator /opt/macprovider/coordinator.prev
 '
 ```
 
 This makes the *current* binary the rollback target. Useful right
 before a risky maintenance window: take the snapshot when you know
-the system is healthy.
+the system is healthy. Using `install(1)` (rather than `cp -p`)
+keeps ownership explicit even if the running binary on this VPS
+happens to be root-owned for any reason.

--- a/audits/2026-06-10/ROLLBACK_PROCEDURE.md
+++ b/audits/2026-06-10/ROLLBACK_PROCEDURE.md
@@ -1,0 +1,103 @@
+# Coordinator rollback procedure
+
+**Scope**: swap the live `/opt/macprovider/coordinator` binary on the Pearl
+VPS (`coordinator.streamvc.live`) back to the previous build, in under
+30 seconds, when the deploy script's provenance check shows the wrong
+version or when a smoke test against the new binary fails.
+
+**Prerequisites**:
+- SSH access to the VPS as `root` (e.g. `ssh -i ~/.ssh/pearl_operator_ed25519 root@159.223.165.194`).
+- The `.prev` snapshot exists at `/opt/macprovider/coordinator.prev`. The
+  deploy script (`phase4-coordinator/dist/deploy-pearl-vps.sh`) creates
+  this in step 4/9, before installing the new binary. If you are
+  rolling back a deploy that did **not** go through this script, check
+  for the snapshot first — without it you'll need to re-deploy a known-
+  good build from your laptop instead.
+
+## Fast path (binary swap, no config change)
+
+Use this when the **new binary** is the problem and the previous
+`coordinator.yaml`/service unit are still fine.
+
+```bash
+ssh -i ~/.ssh/pearl_operator_ed25519 root@159.223.165.194 '
+  set -e
+  if [ ! -x /opt/macprovider/coordinator.prev ]; then
+    echo "no .prev snapshot — fast rollback not possible" >&2
+    exit 1
+  fi
+  mv /opt/macprovider/coordinator /opt/macprovider/coordinator.bad
+  cp -p /opt/macprovider/coordinator.prev /opt/macprovider/coordinator
+  systemctl restart macprovider-coordinator
+  sleep 2
+  systemctl is-active macprovider-coordinator
+'
+```
+
+Verify from the operator Mac:
+
+```bash
+curl -fsS https://coordinator.streamvc.live/healthz \
+  | python3 -m json.tool
+# Expect:  "version": "<previous git-describe>"
+```
+
+If `is-active` returns `active` and the version field matches the
+previous build, the rollback is complete. Total wall-clock: ~10–20s.
+
+## Why `cp -p` not `mv` for the restore
+
+Keeping `coordinator.prev` in place after the restore lets the next
+rollback (if the operator pushes a third build that also fails) still
+have the same known-good snapshot to fall back to. The "bad" binary
+goes to `coordinator.bad` rather than being deleted so a post-mortem
+can `strings` / `nm` / re-run it locally.
+
+## When the fast path is wrong
+
+The `.prev` snapshot only covers the binary. If the deploy that broke
+prod **also** changed `coordinator.yaml` (operator key rotation,
+routing tier flip, tier-2 catalog change), restoring the binary alone
+leaves you on the new YAML with the old binary's expectations — which
+may be a *different* broken state. In that case:
+
+1. Stop the service: `systemctl stop macprovider-coordinator`.
+2. From your operator Mac, check out the commit that produced the
+   known-good build (`git log --oneline phase4-coordinator/`), and run
+   `phase4-coordinator/dist/deploy-pearl-vps.sh` against that tree.
+   The deploy script's provenance check at step 8/9 will confirm the
+   restored version matches.
+
+## Auto-rollback is not wired up
+
+The deploy script's step 8/9 provenance assertion is non-fatal by
+design — it prints a `WARN` line on mismatch but does not auto-swap
+the `.prev` binary back. Reasoning:
+
+- Auto-rollback hides drift. An operator who sees the WARN line and
+  decides to keep the new build (e.g. because the mismatch is benign
+  from a `git stash` they forgot) is making an informed decision; an
+  auto-rollback would have already reverted and the operator would
+  not know they had drifted.
+- Auto-rollback in the failure mode where the new binary's `/healthz`
+  returns the *expected* version but is silently broken on a code
+  path the script doesn't probe would not have helped anyway.
+
+The full version-pin / blue-green path is a future M-tier item.
+
+## Rebuilding the `.prev` snapshot from scratch
+
+If `/opt/macprovider/coordinator.prev` is missing (manual deploys,
+disk wipe), populate it from the next deploy by re-running
+`deploy-pearl-vps.sh` — its step 4/9 will snapshot the binary that is
+about to be replaced. To populate it WITHOUT a new deploy:
+
+```bash
+ssh -i ~/.ssh/pearl_operator_ed25519 root@159.223.165.194 '
+  cp -p /opt/macprovider/coordinator /opt/macprovider/coordinator.prev
+'
+```
+
+This makes the *current* binary the rollback target. Useful right
+before a risky maintenance window: take the snapshot when you know
+the system is healthy.

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -68,7 +68,16 @@ $SSH 'set -e
   install -d -o macprovider -g macprovider -m 0750 /var/log/macprovider
 '
 
-log "step 4/9: upload binary + config + nginx site"
+log "step 4/9: upload binary + config + nginx site (with rollback snapshot)"
+# Backup the live binary BEFORE the install so a rollback is one mv away.
+# See audits/2026-06-10/ROLLBACK_PROCEDURE.md for the swap-back steps.
+$SSH 'if [ -x /opt/macprovider/coordinator ]; then
+        cp -p /opt/macprovider/coordinator /opt/macprovider/coordinator.prev
+        echo "  snapshot saved at /opt/macprovider/coordinator.prev"
+      else
+        echo "  no live binary at /opt/macprovider/coordinator — first deploy"
+      fi'
+
 $SCP "$BINARY" "$VPS_USER@$VPS_HOST:/tmp/coordinator-linux-amd64"
 $SCP "$CONFIG" "$VPS_USER@$VPS_HOST:/tmp/coordinator.yaml"
 $SCP "$SERVICE" "$VPS_USER@$VPS_HOST:/tmp/macprovider-coordinator.service"
@@ -173,7 +182,22 @@ $SSH 'set -e
 log "step 8/9: verify public endpoints"
 sleep 2
 echo "  GET https://$DOMAIN/healthz"
-curl -fsS --max-time 10 "https://$DOMAIN/healthz" | python3 -m json.tool || { echo "healthz failed"; exit 1; }
+HEALTHZ_BODY=$(curl -fsS --max-time 10 "https://$DOMAIN/healthz" || { echo "healthz failed"; exit 1; })
+printf '%s\n' "$HEALTHZ_BODY" | python3 -m json.tool
+
+# Provenance check: compare the deployed version (from /healthz) against
+# what the local working tree would have built. Non-fatal — a warning is
+# enough to surface a mismatched binary without blocking the deploy.
+# See audits/2026-06-10/ROLLBACK_PROCEDURE.md for the rollback path.
+DEPLOYED_VERSION=$(printf '%s' "$HEALTHZ_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version', '?'))" 2>/dev/null || echo "?")
+EXPECTED_VERSION=$(git describe --always --dirty --tags 2>/dev/null || git rev-parse --short HEAD)
+if [ "$DEPLOYED_VERSION" = "$EXPECTED_VERSION" ]; then
+  echo "  provenance OK: deployed=$DEPLOYED_VERSION | expected=$EXPECTED_VERSION"
+else
+  echo "  WARN provenance mismatch: deployed=$DEPLOYED_VERSION | expected=$EXPECTED_VERSION" >&2
+  echo "       (build artifact does not match the local working tree — investigate before relying on this deploy)" >&2
+fi
+
 echo "  GET https://$DOMAIN/v1/models -> expect 404 (buyer API is gateway-only)"
 STATUS=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "https://$DOMAIN/v1/models")
 if [ "$STATUS" != "404" ]; then

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -70,9 +70,14 @@ $SSH 'set -e
 
 log "step 4/9: upload binary + config + nginx site (with rollback snapshot)"
 # Backup the live binary BEFORE the install so a rollback is one mv away.
+# Use install(1) instead of cp -p so ownership (macprovider:macprovider)
+# is explicit per-invocation rather than inherited from the source —
+# protects against a future "rebuild snapshot from scratch" recovery that
+# would otherwise drift the .prev to root:root and then propagate that
+# back into /opt/macprovider/coordinator on rollback.
 # See audits/2026-06-10/ROLLBACK_PROCEDURE.md for the swap-back steps.
 $SSH 'if [ -x /opt/macprovider/coordinator ]; then
-        cp -p /opt/macprovider/coordinator /opt/macprovider/coordinator.prev
+        install -o macprovider -g macprovider -m 0755 /opt/macprovider/coordinator /opt/macprovider/coordinator.prev
         echo "  snapshot saved at /opt/macprovider/coordinator.prev"
       else
         echo "  no live binary at /opt/macprovider/coordinator — first deploy"
@@ -157,7 +162,7 @@ log "step 6c/9: pre-restart safeguard (check for connected providers)"
 # kills tunnel-direct buyer traffic. Until you can guarantee every
 # connected provider is on v1.1.3+, refuse to auto-restart with
 # connected providers unless the operator passes --force-restart.
-CONNECTED_COUNT=$(curl -fsS --max-time 5 "https://$DOMAIN/healthz" 2>/dev/null \
+CONNECTED_COUNT=$(curl -fsS --max-time 5 --max-filesize 65536 "https://$DOMAIN/healthz" 2>/dev/null \
   | python3 -c "import sys,json; print(json.load(sys.stdin).get('pool_size', 0))" 2>/dev/null \
   || echo 0)
 if [ "${CONNECTED_COUNT:-0}" -gt 0 ] && [ "${FORCE_RESTART:-0}" != "1" ]; then
@@ -182,7 +187,11 @@ $SSH 'set -e
 log "step 8/9: verify public endpoints"
 sleep 2
 echo "  GET https://$DOMAIN/healthz"
-HEALTHZ_BODY=$(curl -fsS --max-time 10 "https://$DOMAIN/healthz" || { echo "healthz failed"; exit 1; })
+# --max-filesize bounds bytes (--max-time only bounds wall-clock); /healthz
+# is a few hundred bytes in practice, so 64 KiB is a generous cap that
+# protects the operator Mac from a malicious or misbehaving upstream
+# streaming gigabytes inside the 10s window.
+HEALTHZ_BODY=$(curl -fsS --max-time 10 --max-filesize 65536 "https://$DOMAIN/healthz" || { echo "healthz failed"; exit 1; })
 printf '%s\n' "$HEALTHZ_BODY" | python3 -m json.tool
 
 # Provenance check: compare the deployed version (from /healthz) against


### PR DESCRIPTION
## Summary

Milestone 0 M0-5 Phase 2 from `audits/2026-06-10/REPO_AUDIT.md`. Builds on Phase 1 ([#18](https://github.com/Augustas11/macprovider/pull/18)) which made `/healthz` report the `git describe` version stamped into the binary. This PR consumes that surface from the deploy script and adds the rollback playbook.

This PR does NOT deploy anything. The first deploy that exercises the new step 4/9 snapshot and step 8/9 assertion is operator-driven in a maintenance window.

## `phase4-coordinator/dist/deploy-pearl-vps.sh`

- **Step 4/9** — before `scp` + `install`, snapshot the live binary at `/opt/macprovider/coordinator.prev` (`cp -p` to preserve permissions). First-time deploys skip the snapshot gracefully. This is the file the fast-path rollback in `ROLLBACK_PROCEDURE.md` swaps back.
- **Step 8/9** — after the public `/healthz` smoke, extract the deployed `version` field from the response and compare against `git describe --always --dirty --tags` from the deploying laptop. On mismatch print a `WARN` line referencing the rollback doc; non-fatal so the operator can keep an intentional divergence (e.g. an unstaged debug build) and is informed of it.

## `audits/2026-06-10/ROLLBACK_PROCEDURE.md`

One-page playbook:
- Prerequisites (SSH access, `.prev` snapshot exists).
- Fast path (binary swap, `mv`/`cp -p`, restart, verify), target wall-clock under 30s.
- Verification with a `/healthz` curl that proves the right version is live.
- When the fast path is wrong (config drift in same deploy).
- "Auto-rollback is not wired up" — explaining why the provenance assertion is non-fatal, so a future contributor doesn't add an auto-rollback shim without thinking about hidden-drift failure modes.
- Rebuilding the `.prev` snapshot from scratch on hosts where the deploy script never ran.

## Follow-up actions for human

- [ ] Schedule a maintenance window for the first deploy that uses this script. Per existing deploy-script guard (step 6c/9), the restart still refuses with connected providers unless `FORCE_RESTART=1`, so the M-tier providers should be drained or warned first.
- [ ] On Pearl during the first deploy, confirm that `/opt/macprovider/coordinator.prev` lands at step 4/9 and that the step 8/9 provenance line shows `deployed=<X> | expected=<X>` matching.

Generated with Claude Code.
