### PR TITLE
m0: build-linux.sh — stamp -dirty-forced when overriding untracked-only dirty

### DIFF
--- a/phase4-coordinator/scripts/build-linux.sh
+++ b/phase4-coordinator/scripts/build-linux.sh
@@ -3,25 +3,39 @@
 #
 # Refuses to build with uncommitted changes by default; set FORCE_DIRTY=1
 # to override (the resulting binary's version string will end in "-dirty"
-# via `git describe --dirty`, so the deploy gate can still tell).
+# via `git describe --dirty` for modified-tracked dirty, or
+# "-dirty-forced" appended below for untracked-only dirty, so the deploy
+# gate can still tell either way).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-if [ -z "${FORCE_DIRTY:-}" ]; then
-  # `git status --porcelain` catches BOTH modified-tracked AND untracked
-  # files (relative to this module's pwd). `git diff --quiet` would miss a
-  # new .go file dropped in by an emergency hotfix, which would then ship
-  # in a binary whose -ldflags-stamped version still reports "clean" via
-  # `git describe` (which also ignores untracked files for its --dirty
-  # suffix). See M0-5 Phase 1 follow-up.
-  if [ -n "$(git status --porcelain -- .)" ]; then
-    echo "refusing to build with uncommitted or untracked changes (set FORCE_DIRTY=1 to override)" >&2
-    git status --short -- . >&2
-    exit 1
-  fi
+# `git status --porcelain` catches BOTH modified-tracked AND untracked
+# files (relative to this module's pwd). `git diff --quiet` would miss a
+# new .go file dropped in by an emergency hotfix, which would then ship
+# in a binary whose -ldflags-stamped version still reports "clean" via
+# `git describe` (which also ignores untracked files for its --dirty
+# suffix). See M0-5 Phase 1 follow-up.
+DIRTY_STATE="$(git status --porcelain -- .)"
+if [ -z "${FORCE_DIRTY:-}" ] && [ -n "$DIRTY_STATE" ]; then
+  echo "refusing to build with uncommitted or untracked changes (set FORCE_DIRTY=1 to override)" >&2
+  git status --short -- . >&2
+  exit 1
 fi
 
 VERSION="$(git describe --always --dirty --tags 2>/dev/null || git rev-parse --short HEAD)"
+# `git describe --dirty` only marks modifications to tracked files. If
+# FORCE_DIRTY=1 overrode an UNTRACKED-only dirty state (a brand-new file
+# the operator hasn't `git add`'d yet), the version stamp would otherwise
+# look clean — defeating the rollback gate's ability to spot a forced
+# build. Append "-dirty-forced" in that case so the binary's /healthz
+# response self-identifies as an override build.
+if [ -n "${FORCE_DIRTY:-}" ] && [ -n "$DIRTY_STATE" ]; then
+  case "$VERSION" in
+    *-dirty) ;;  # git describe already marked the modified-tracked path
+    *) VERSION="${VERSION}-dirty-forced" ;;
+  esac
+fi
+
 OUT="dist/$(basename "$PWD")-linux-amd64"
 mkdir -p dist
 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o "$OUT" ./cmd/coordinator

--- a/phase5-gateway/scripts/build-linux.sh
+++ b/phase5-gateway/scripts/build-linux.sh
@@ -3,25 +3,39 @@
 #
 # Refuses to build with uncommitted changes by default; set FORCE_DIRTY=1
 # to override (the resulting binary's version string will end in "-dirty"
-# via `git describe --dirty`, so the deploy gate can still tell).
+# via `git describe --dirty` for modified-tracked dirty, or
+# "-dirty-forced" appended below for untracked-only dirty, so the deploy
+# gate can still tell either way).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-if [ -z "${FORCE_DIRTY:-}" ]; then
-  # `git status --porcelain` catches BOTH modified-tracked AND untracked
-  # files (relative to this module's pwd). `git diff --quiet` would miss a
-  # new .go file dropped in by an emergency hotfix, which would then ship
-  # in a binary whose -ldflags-stamped version still reports "clean" via
-  # `git describe` (which also ignores untracked files for its --dirty
-  # suffix). See M0-5 Phase 1 follow-up.
-  if [ -n "$(git status --porcelain -- .)" ]; then
-    echo "refusing to build with uncommitted or untracked changes (set FORCE_DIRTY=1 to override)" >&2
-    git status --short -- . >&2
-    exit 1
-  fi
+# `git status --porcelain` catches BOTH modified-tracked AND untracked
+# files (relative to this module's pwd). `git diff --quiet` would miss a
+# new .go file dropped in by an emergency hotfix, which would then ship
+# in a binary whose -ldflags-stamped version still reports "clean" via
+# `git describe` (which also ignores untracked files for its --dirty
+# suffix). See M0-5 Phase 1 follow-up.
+DIRTY_STATE="$(git status --porcelain -- .)"
+if [ -z "${FORCE_DIRTY:-}" ] && [ -n "$DIRTY_STATE" ]; then
+  echo "refusing to build with uncommitted or untracked changes (set FORCE_DIRTY=1 to override)" >&2
+  git status --short -- . >&2
+  exit 1
 fi
 
 VERSION="$(git describe --always --dirty --tags 2>/dev/null || git rev-parse --short HEAD)"
+# `git describe --dirty` only marks modifications to tracked files. If
+# FORCE_DIRTY=1 overrode an UNTRACKED-only dirty state (a brand-new file
+# the operator hasn't `git add`'d yet), the version stamp would otherwise
+# look clean — defeating the rollback gate's ability to spot a forced
+# build. Append "-dirty-forced" in that case so the binary's /healthz
+# response self-identifies as an override build.
+if [ -n "${FORCE_DIRTY:-}" ] && [ -n "$DIRTY_STATE" ]; then
+  case "$VERSION" in
+    *-dirty) ;;  # git describe already marked the modified-tracked path
+    *) VERSION="${VERSION}-dirty-forced" ;;
+  esac
+fi
+
 OUT="dist/$(basename "$PWD")-linux-amd64"
 mkdir -p dist
 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o "$OUT" ./cmd/gateway


### PR DESCRIPTION
## Summary

Follow-up on [PR #18](https://github.com/Augustas11/macprovider/pull/18) (M0-5 Phase 1) code-review finding.

The dirty-check refusal gate in #18 catches untracked files. The version stamp itself, however, still relied on `git describe --dirty`, which only marks tracked-file modifications. So an emergency build with `FORCE_DIRTY=1` over an **untracked-only** dirty state produced a binary whose `/healthz` returned the same version string as a genuinely clean build — defeating the rollback gate's ability to spot a forced build after the fact.

## Change

Both `phase4-coordinator/scripts/build-linux.sh` and `phase5-gateway/scripts/build-linux.sh`: after computing `VERSION`, if `FORCE_DIRTY` was needed (porcelain non-empty) AND `git describe` did not already attach `-dirty` (modified-tracked path), append `-dirty-forced`.

```bash
if [ -n "${FORCE_DIRTY:-}" ] && [ -n "$DIRTY_STATE" ]; then
  case "$VERSION" in
    *-dirty) ;;  # git describe already marked the modified-tracked path
    *) VERSION="${VERSION}-dirty-forced" ;;
  esac
fi
```

## Cases

| State | Override | Resulting version |
|---|---|---|
| Clean | — | `<describe>` |
| Modified-tracked | `FORCE_DIRTY=1` | `<describe>-dirty` (`git describe`) |
| Untracked-only | `FORCE_DIRTY=1` | `<describe>-dirty-forced` (**new**) |
| Both | `FORCE_DIRTY=1` | `<describe>-dirty` (modified-tracked path wins) |
| Any dirty | unset | refuses (unchanged from #18) |

## Test plan

Smoke-run all three resolvable paths against fresh `main` at `HEAD=0545774`:

```
Case 1 (clean):              v1.3.0-11-g0545774
Case 2 (modified + force):   v1.3.0-11-g0545774-dirty
Case 3 (untracked + force):  v1.3.0-11-g0545774-dirty-forced
```

The deploy script's step 8/9 provenance assertion already treats ANY suffix mismatch as a `WARN` line — both `-dirty` and `-dirty-forced` flag the binary as non-canonical, so `deploy-pearl-vps.sh` needs no parallel change.

## Follow-up actions for human

None. No production behavior change; the new suffix is only visible when an operator runs the override path.

Generated with Claude Code.
