### PR TITLE
m0: deploy script — fail-loud on /healthz missing version field

### DIFF
--- a/audits/2026-06-10/ROLLBACK_PROCEDURE.md
+++ b/audits/2026-06-10/ROLLBACK_PROCEDURE.md
@@ -95,6 +95,22 @@ the `.prev` binary back. Reasoning:
 
 The full version-pin / blue-green path is a future M-tier item.
 
+### `STRICT_PROVENANCE=1` for the binary-predates-instrumentation case
+
+There is one provenance state where the deploy script will exit
+non-zero if the operator opts in: when `/healthz` returns no `version`
+field at all. That case (printed as `CRITICAL provenance MISSING` in
+step 8/9) almost certainly means the deployed binary predates PR #18
+and the entire rollback gate is bypassed — which is qualitatively
+different from a normal "deployed != expected" drift, because the
+operator can't reason about the running code from scrollback alone.
+
+Default is still non-fatal (operator decision). Set
+`STRICT_PROVENANCE=1 bash deploy-pearl-vps.sh` to abort with exit
+code 7 on the missing-version state. Recommended for any deploy
+where downstream automation expects the M0-5 instrumentation to be
+present.
+
 ## Rebuilding the `.prev` snapshot from scratch
 
 If `/opt/macprovider/coordinator.prev` is missing (manual deploys,

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -195,12 +195,30 @@ HEALTHZ_BODY=$(curl -fsS --max-time 10 --max-filesize 65536 "https://$DOMAIN/hea
 printf '%s\n' "$HEALTHZ_BODY" | python3 -m json.tool
 
 # Provenance check: compare the deployed version (from /healthz) against
-# what the local working tree would have built. Non-fatal — a warning is
-# enough to surface a mismatched binary without blocking the deploy.
+# what the local working tree would have built. Three outcomes:
+#   - "?"        the binary predates PR #18 and has no `version` field on
+#                /healthz at all → CRITICAL line (and abort if
+#                STRICT_PROVENANCE=1) because the entire M0-5 instrumentation
+#                got bypassed. By design still non-fatal by default so the
+#                operator can decide.
+#   - matched    OK line.
+#   - mismatched WARN line (the deployed binary was built from a different
+#                commit than the local tree — usually means an unstaged or
+#                unfetched change locally; investigate before trusting).
 # See audits/2026-06-10/ROLLBACK_PROCEDURE.md for the rollback path.
 DEPLOYED_VERSION=$(printf '%s' "$HEALTHZ_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version', '?'))" 2>/dev/null || echo "?")
 EXPECTED_VERSION=$(git describe --always --dirty --tags 2>/dev/null || git rev-parse --short HEAD)
-if [ "$DEPLOYED_VERSION" = "$EXPECTED_VERSION" ]; then
+if [ "$DEPLOYED_VERSION" = "?" ]; then
+  echo "  CRITICAL provenance MISSING: /healthz returned no \"version\" field" >&2
+  echo "           This almost certainly means the deployed binary predates the" >&2
+  echo "           M0-5 instrumentation (PR #18) and the rollback gate is bypassed." >&2
+  echo "           Expected was: $EXPECTED_VERSION" >&2
+  echo "           See audits/2026-06-10/ROLLBACK_PROCEDURE.md to replace the live binary." >&2
+  if [ "${STRICT_PROVENANCE:-0}" = "1" ]; then
+    echo "  STRICT_PROVENANCE=1 set — aborting." >&2
+    exit 7
+  fi
+elif [ "$DEPLOYED_VERSION" = "$EXPECTED_VERSION" ]; then
   echo "  provenance OK: deployed=$DEPLOYED_VERSION | expected=$EXPECTED_VERSION"
 else
   echo "  WARN provenance mismatch: deployed=$DEPLOYED_VERSION | expected=$EXPECTED_VERSION" >&2


### PR DESCRIPTION
## Summary

Follow-up on [PR #19](https://github.com/Augustas11/macprovider/pull/19) (M0-5 Phase 2) code-review finding. The existing step 8/9 provenance assertion treats two qualitatively different states identically:

- **(a)** the deployed binary IS instrumented but reports a different `git describe` than the local tree — usually a benign unstaged change or unfetched commit (`WARN provenance mismatch`); and
- **(b)** `/healthz` returned NO `version` field at all, which almost certainly means the deployed binary predates PR #18 and the entire M0-5 rollback gate is bypassed.

Case (b) is the dangerous one: the operator can't reason about the running code from scrollback alone. Folding it into the same WARN as (a) lets it slip past.

## Change

- Step 8/9 now branches three ways: `provenance OK` / `WARN provenance mismatch` / `CRITICAL provenance MISSING`. The MISSING branch is non-fatal **by default** (matches the doc's "auto-rollback is not wired up" stance) but is visually distinct in scrollback and references `ROLLBACK_PROCEDURE.md` explicitly.
- New env-gated `STRICT_PROVENANCE=1` opts the operator into a true fail-loud: exit code 7 on the MISSING case. Recommended for any deploy where downstream automation expects the M0-5 instrumentation to be present.
- `audits/2026-06-10/ROLLBACK_PROCEDURE.md` "Auto-rollback is not wired up" section documents the new strict-mode knob with a worked example.

## Verification (smoke against synthetic /healthz bodies)

| /healthz body | `STRICT_PROVENANCE` | Output | Exit |
|---|---|---|---|
| has matching `version` | unset | `provenance OK` | 0 |
| has mismatched `version` | unset | `WARN ... mismatch` | 0 |
| no `version` field | unset | `CRITICAL MISSING` | 0 |
| no `version` field | `1` | `CRITICAL MISSING` + `aborting` | 7 |

## Follow-up actions for human

None for the merge itself. Worth flagging in the next deploy window whether to set `STRICT_PROVENANCE=1` as the default for production runs (probably yes once the M0-5 binary is confirmed live), but that's a runbook choice, not a code change.

Generated with Claude Code.
