### PR TITLE
phase3-binary: mark RouterHandler @unchecked Sendable (fix swift-nio 2.101 warnings)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -39,7 +39,7 @@ struct HTTPServer {
     }
 }
 
-final class RouterHandler: ChannelInboundHandler {
+final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
 


### PR DESCRIPTION
## Summary

Follow-up to [PR #25](https://github.com/Augustas11/macprovider/pull/25) (swift-nio 2.65.0 -> 2.101.0).

After the bump, `swift build` surfaced two warnings on `Sources/macprovider-cli/HTTPServer.swift:23` flagging that `RouterHandler` does not conform to `Sendable` — `Channel.addHandler` in 2.101.0 requires Sendable handlers.

## Change

`RouterHandler` is declared `@unchecked Sendable`. Same pattern is already used a few lines below for `ResponseWriter`.

Why `@unchecked` is correct: `RouterHandler` has mutable state (`requestHead`, `bodyBuffer`, `bodyTooLarge`) that is touched only inside `channelRead` and `handleRequest`. NIO guarantees these are called on the channel's event loop, so the state is single-threaded by construction. The Swift compiler can't prove that without an actor or value type, hence `@unchecked`.

## Verification

- `swift build` -> warning-free (previously 2 warnings)
- `swift test` -> 159/159 pass

## Follow-up actions for human

None. Pure annotation change, no runtime behavior delta.

Generated with Claude Code.