### PR TITLE
m0: build-linux.sh — fix OUT path to match deploy script (fix #18 latent bug)

### DIFF
--- a/phase4-coordinator/scripts/build-linux.sh
+++ b/phase4-coordinator/scripts/build-linux.sh
@@ -36,7 +36,7 @@ if [ -n "${FORCE_DIRTY:-}" ] && [ -n "$DIRTY_STATE" ]; then
   esac
 fi
 
-OUT="dist/$(basename "$PWD")-linux-amd64"
+OUT="dist/coordinator-linux-amd64"
 mkdir -p dist
 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o "$OUT" ./cmd/coordinator
 echo "built $OUT @ ${VERSION}"

--- a/phase5-gateway/scripts/build-linux.sh
+++ b/phase5-gateway/scripts/build-linux.sh
@@ -36,7 +36,7 @@ if [ -n "${FORCE_DIRTY:-}" ] && [ -n "$DIRTY_STATE" ]; then
   esac
 fi
 
-OUT="dist/$(basename "$PWD")-linux-amd64"
+OUT="dist/gateway-linux-amd64"
 mkdir -p dist
 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o "$OUT" ./cmd/gateway
 echo "built $OUT @ ${VERSION}"


### PR DESCRIPTION
## Summary

Follow-up to [PR #18](https://github.com/Augustas11/macprovider/pull/18) and [PR #22](https://github.com/Augustas11/macprovider/pull/22) (M0-5 Phase 1 build-script work).

Latent bug surfaced during the 2026-06-11 coordinator deploy: `build-linux.sh` was writing the binary to `dist/$(basename "$PWD")-linux-amd64`, producing `dist/phase4-coordinator-linux-amd64` and `dist/phase5-gateway-linux-amd64`. But `phase4-coordinator/dist/deploy-pearl-vps.sh` (and the phase5 gateway runbook) read from `dist/coordinator-linux-amd64` and `dist/gateway-linux-amd64`. The two have never matched.

In practice operators had been manually renaming the binary after each build — invisible until someone ran build-and-deploy as a single workflow.

## Change

Hardcode the OUT path in both scripts:

- `phase4-coordinator/scripts/build-linux.sh`: `OUT="dist/coordinator-linux-amd64"`
- `phase5-gateway/scripts/build-linux.sh`: `OUT="dist/gateway-linux-amd64"`

One fewer manual step per deploy.

## Verification

Local build now produces the expected filenames directly:

```
$ bash phase4-coordinator/scripts/build-linux.sh
built dist/coordinator-linux-amd64 @ v1.3.0-25-gXXXXXXX

$ bash phase5-gateway/scripts/build-linux.sh
built dist/gateway-linux-amd64 @ v1.3.0-25-gXXXXXXX
```

## Reference event

This was hit during the 2026-06-11 coordinator deploy of `v1.3.0-24-g87b3a6b`. The build produced `phase4-coordinator-linux-amd64`; the deploy script expected `coordinator-linux-amd64`. Worked around by manual rename; this PR removes the manual step.

## Follow-up actions for human

None for the merge itself.

Generated with Claude Code.