### PR TITLE
m0: check-deploy-config.sh — fail-loud when auth.require_provider_tokens absent

### DIFF
--- a/phase4-coordinator/dist/check-deploy-config.sh
+++ b/phase4-coordinator/dist/check-deploy-config.sh
@@ -45,6 +45,25 @@ elif not re.fullmatch(r"[0-9a-fA-F]{64}", key):
 else:
     ok("operator_key present (64-hex, non-placeholder)")
 
+# --- require_provider_tokens ---
+# Security-sensitive: the binary default is `true` (fail-closed), but a
+# pre-existing fleet without issued provider tokens needs `false` to keep
+# connecting. Silent-defaulting on this field caused the 2026-06-11 outage
+# (deployed a config without the field; new binary defaulted true; air5/air8gb
+# rejected with close_code:4005 reason:invalid_token). Force an explicit choice.
+rpt = g(coord, "require_provider_tokens")
+if rpt is None:
+    hard("auth.require_provider_tokens is ABSENT — binary default (true) "
+         "will reject any provider not presenting a token. "
+         "Set explicitly to true (production / tokens issued) or false (legacy fleet).")
+elif rpt.lower() == "false":
+    warn("auth.require_provider_tokens=false — provider WS is unauthenticated; "
+         "intended only for legacy providers without issued tokens. Plan token migration.")
+elif rpt.lower() == "true":
+    ok("auth.require_provider_tokens=true (fail-closed)")
+else:
+    hard(f"auth.require_provider_tokens must be true or false, got: {rpt!r}")
+
 # --- threshold sanity ---
 hi = g(coord, "heartbeat_interval_s")
 hm = g(coord, "heartbeat_miss_threshold_s")


### PR DESCRIPTION
## Summary

Follow-up to the 2026-06-11 coordinator deploy outage.

The deployed `coordinator.yaml` had no `auth.require_provider_tokens` field. The previous binary (`v0.1.0`, Jun 7) tolerated this silently. The new binary (`v1.3.0-24-g87b3a6b`) defaults the field to `true` (fail-closed) — air5 and air8gb were rejected with `close_code:4005 reason:invalid_token` and the pool emptied. Recovered by adding `require_provider_tokens: false` on Pearl and restarting.

This is exactly the silent-default hazard `check-deploy-config.sh` was built to prevent — but the field wasn't on its checklist. Add it.

## Change

`phase4-coordinator/dist/check-deploy-config.sh` now requires `auth.require_provider_tokens` to be explicitly set (true or false). Absent = HARD FAIL, deploy aborts at step 0/9.

| State | Result |
|---|---|
| `require_provider_tokens: true` | `ok: fail-closed` |
| `require_provider_tokens: false` | `WARN: legacy fleet, plan token migration` |
| absent | `FAIL` (exit 1) |
| junk value | `FAIL` |

## Verification

Present + false: WARN, exits 0.
Absent: FAIL line, deploy aborts at step 0/9 with exit 1.
Present + true: ok line, exits 0.

## Follow-up actions for human

1. Pearl is currently on `require_provider_tokens: false` as the legacy-fleet workaround. Real fix is provider token issuance + distribution — separate workstream. Until then this PR ensures no future deploy can omit the field and silently re-break the pool.
2. Local `dist/coordinator.yaml` working copies are gitignored; operators should sync them to include this field (mine has been updated locally).

Generated with Claude Code.
