### PR TITLE
m0: deploy-pearl-vps.sh — pre-deploy drift check vs live config

### DIFF
--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -55,6 +55,44 @@ log "step 1/9: confirm SSH + DNS"
 $SSH 'hostname && uptime' >/dev/null
 dig +short "$DOMAIN" | grep -q "$VPS_HOST" || { echo "DNS for $DOMAIN does not resolve to $VPS_HOST yet" >&2; exit 1; }
 
+log "step 1b/9: drift check vs live /opt/macprovider/coordinator.yaml"
+# Catches the silent-config-change hazard. The 2026-06-11 deploy caused
+# a brief outage because the local config dropped auth.require_provider_tokens
+# entirely; the prior binary defaulted false, the new binary defaulted true,
+# and providers were rejected. A field-level diff vs live is the tripwire
+# that would have surfaced that drift before the restart.
+#
+# Secrets are masked in the SSH pipe so unmasked Pearl content never lands
+# on local disk. Operator opts into pushing local-over-live with
+# ALLOW_CONFIG_DRIFT=1.
+normalize_yaml() {
+  # Mask any field whose name ends in _key / _secret / _token, then strip
+  # pure-comment lines and blanks so the drift check focuses on semantic
+  # differences (values + structure) rather than comment-placement noise.
+  sed -E 's/^([[:space:]]*[a-zA-Z0-9_]*(_key|_secret|_token)):[[:space:]]*.*$/\1: <MASKED>/' \
+    | sed -E 's/[[:space:]]+#.*$//' \
+    | grep -vE '^[[:space:]]*(#|$)'
+}
+LIVE_NORM=$($SSH 'cat /opt/macprovider/coordinator.yaml' 2>/dev/null | normalize_yaml) || {
+  echo "could not pull live coordinator.yaml from Pearl for drift check" >&2; exit 6;
+}
+LOCAL_NORM=$(normalize_yaml < "$CONFIG")
+if ! DRIFT_DIFF=$(diff <(printf '%s\n' "$LOCAL_NORM") <(printf '%s\n' "$LIVE_NORM")); then
+  echo "" >&2
+  echo "  CONFIG DRIFT detected (secrets masked; '<' = local, '>' = live):" >&2
+  printf '%s\n' "$DRIFT_DIFF" | sed 's/^/    /' >&2
+  echo "" >&2
+  if [ "${ALLOW_CONFIG_DRIFT:-0}" != "1" ]; then
+    echo "  Aborting. The local config will overwrite the live one on deploy." >&2
+    echo "  Review the diff above. To proceed (pushing local over live):" >&2
+    echo "    ALLOW_CONFIG_DRIFT=1 $0" >&2
+    exit 8
+  fi
+  echo "  ALLOW_CONFIG_DRIFT=1 set — proceeding despite drift." >&2
+else
+  echo "  ok: local config matches live (modulo secrets)"
+fi
+
 log "step 2/9: install certbot + nginx-snippets (apt)"
 $SSH 'DEBIAN_FRONTEND=noninteractive apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y certbot python3-certbot-nginx >/dev/null' || {
   echo "certbot install failed" >&2; exit 1;


### PR DESCRIPTION
## Summary

Follow-up to the 2026-06-11 coordinator deploy outage. Adds step 1b/9 to `deploy-pearl-vps.sh` that fetches the live `/opt/macprovider/coordinator.yaml` from Pearl, masks secret-shaped fields and strips comments in both files, then diffs. Hard-aborts (exit 8) on drift unless the operator passes `ALLOW_CONFIG_DRIFT=1`.

## Why

On 2026-06-11 the coordinator deploy from `v0.1.0` → `v1.3.0-24-g87b3a6b` caused a brief outage. Root cause: the deployed local config dropped `auth.require_provider_tokens`, the new binary defaulted `true` (fail-closed) while the prior binary tolerated absent-as-false, and air5 + air8gb were rejected with `close_code:4005 reason:invalid_token`. Pool emptied for ~3 minutes until recovery (added the field to Pearl + restart).

Sister PR #34 adds an assertion to `check-deploy-config.sh` that fails-loud when this specific field is absent. This PR addresses the broader class of failure: ANY local-vs-live config drift, not just this one field.

## Design

- Masking happens **in the SSH pipe** (`$SSH 'cat ...' | normalize_yaml`); unmasked Pearl content never touches local disk.
- The `normalize_yaml` function masks `*_key`, `*_secret`, `*_token` fields, then strips pure-comment and blank lines so the diff focuses on semantic + structural drift, not comment placement.
- Field reordering still trips the check (line-diff is structural by design). That is intentional: any in-place sed edit on Pearl (like the 2026-06-11 emergency recovery) should be reflected back into local before the next deploy.
- The operator decides on `ALLOW_CONFIG_DRIFT=1` after reviewing the printed diff. Same pattern as `FORCE_RESTART=1` and `STRICT_PROVENANCE=1`.

## Verification

| State | Behavior |
|---|---|
| local + live identical (modulo masked secrets) | `ok: local config matches live (modulo secrets)`, proceed |
| local + live differ, no override | diff printed, exit 8, deploy aborts |
| local + live differ, `ALLOW_CONFIG_DRIFT=1` | diff printed + "proceeding despite drift", deploy continues |
| live config unreachable | exit 6, deploy aborts |

## Limitations

- Line-order matters in the diff (since we use `diff(1)`, not a YAML AST diff). Operator must keep field ordering consistent between local and live, or use the override flag. Acceptable for this codebase.
- The mask pattern (`_key|_secret|_token`) is heuristic. Any other secret-shaped fields added in future need their suffix included.

## Follow-up actions for human

None for the merge itself. After this lands, the next deploy will fail loud if local and Pearl differ — including the field-reorder drift left from the 2026-06-11 recovery. Operator should sync local field-order to match Pearl, or accept the drift with `ALLOW_CONFIG_DRIFT=1`.

Generated with Claude Code.
