### PR TITLE
m1-2: fix two confirmed failover divergences (ARCH-1/CODE-1)

### DIFF
--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1087,6 +1087,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				}
 				excluded[routeKey(provider)] = struct{}{}
 				faultedRoutes[routeKey(provider)] = struct{}{}
+				if result == wsForwardQueueFull {
+					s.pool.MarkState(provider.ProviderID, provider.AssignedID, pool.StateBusy)
+				}
 				if result == wsForwardCancelled {
 					if shouldLogAttempt(attempt) {
 						logAttempt(provider, http.StatusOK, attempt)
@@ -1248,6 +1251,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			routingDone = s.now()
+			explicitRetries++
+			faultedProviders++
 			if !provider.IsWSTunneled() {
 				break
 			}

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -2897,6 +2897,110 @@ func TestChatCompletionsWSTunneledQueueFullFallsBackToNextProvider(t *testing.T)
 	}
 }
 
+// Regression: M1-2 ARCH-1/CODE-1 divergence 1. Streaming-WS forwardWS returning
+// wsForwardQueueFull must mark the provider StateBusy, matching the non-streaming
+// loop's behavior. Pre-fix: streaming branch never called pool.MarkState; provider
+// stayed StateReady and could be re-selected immediately.
+func TestChatCompletionsStreamingWSTunneledQueueFullMarksProviderBusy(t *testing.T) {
+	registry := pool.NewRegistry(nil)
+	registerWithPath(registry, "p1", "s1", "model-a", pool.StateReady, 20000, 1, "", 10, pool.TierProvisional, pool.InferencePathWSTunneled)
+	registerWithPath(registry, "p2", "s2", "model-a", pool.StateReady, 20000, 2, "", 20, pool.TierProvisional, pool.InferencePathWSTunneled)
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithRoutingConfig(config.RoutingConfig{
+			MaxRetries:              1,
+			RetryPerAttemptTimeoutS: 1,
+			StickyTTLS:              1800,
+			StickyMaxEntries:        10000,
+		}),
+		buyer.WithRelay(func(ctx context.Context, provider pool.Provider, requestID string, body []byte, stream bool) (*providerws.RelayStream, error) {
+			chunks := make(chan providerws.InferenceResponseChunk, 1)
+			done := make(chan providerws.InferenceResponseEnd, 1)
+			errs := make(chan error, 1)
+			if provider.ProviderID == "p1" {
+				done <- providerws.InferenceResponseEnd{Type: "inference_response_end", RequestID: requestID, Status: "error_queue_full"}
+				return &providerws.RelayStream{RequestID: requestID, Chunks: chunks, Done: done, Errors: errs}, nil
+			}
+			chunks <- providerws.InferenceResponseChunk{Type: "inference_response_chunk", RequestID: requestID, Seq: 0, Data: "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n"}
+			done <- providerws.InferenceResponseEnd{Type: "inference_response_end", RequestID: requestID, Status: "complete", ChunksSent: 1}
+			return &providerws.RelayStream{RequestID: requestID, Chunks: chunks, Done: done, Errors: errs}, nil
+		}, 10*time.Second),
+	)
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}],"stream":true}`), http.Header{"X-MacProvider-Retry": []string{"1"}})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if rr.Header().Get("X-MacProvider-Provider") != "p2" {
+		t.Fatalf("provider = %q, want p2", rr.Header().Get("X-MacProvider-Provider"))
+	}
+	if p1, ok := registry.Resolve("p1", ""); !ok || p1.State != pool.StateBusy {
+		t.Fatalf("p1 = %#v ok=%v, want busy", p1, ok)
+	}
+}
+
+// Regression: M1-2 ARCH-1/CODE-1 divergence 2. Non-streaming QueueFull path must
+// increment explicitRetries (and faultedProviders) after the successful routing
+// transition, matching the timeout-retry pattern. Pre-fix: the retry hop after
+// QueueFull logged retried=0 on the next attempt's request_log row.
+func TestChatCompletionsWSTunneledQueueFullIncrementsExplicitRetries(t *testing.T) {
+	const requestID = "22222222-2222-4222-8222-222222222222"
+	reqLog, dbPath := openBuyerRequestLog(t)
+	defer reqLog.Close()
+	registry := pool.NewRegistry(nil)
+	registerWithPath(registry, "p1", "s1", "model-a", pool.StateReady, 20000, 1, "", 10, pool.TierProvisional, pool.InferencePathWSTunneled)
+	registerWithPath(registry, "p2", "s2", "model-a", pool.StateReady, 20000, 2, "", 20, pool.TierProvisional, pool.InferencePathWSTunneled)
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithRequestLog(reqLog),
+		buyer.WithRoutingConfig(config.RoutingConfig{
+			MaxRetries:              1,
+			RetryPerAttemptTimeoutS: 1,
+			StickyTTLS:              1800,
+			StickyMaxEntries:        10000,
+		}),
+		buyer.WithRelay(func(ctx context.Context, provider pool.Provider, requestID string, body []byte, stream bool) (*providerws.RelayStream, error) {
+			chunks := make(chan providerws.InferenceResponseChunk, 1)
+			done := make(chan providerws.InferenceResponseEnd, 1)
+			errs := make(chan error, 1)
+			if provider.ProviderID == "p1" {
+				done <- providerws.InferenceResponseEnd{Type: "inference_response_end", RequestID: requestID, Status: "error_queue_full"}
+				return &providerws.RelayStream{RequestID: requestID, Chunks: chunks, Done: done, Errors: errs}, nil
+			}
+			chunks <- providerws.InferenceResponseChunk{Type: "inference_response_chunk", RequestID: requestID, Seq: 0, Data: `{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`}
+			done <- providerws.InferenceResponseEnd{Type: "inference_response_end", RequestID: requestID, Status: "complete", ChunksSent: 1}
+			return &providerws.RelayStream{RequestID: requestID, Chunks: chunks, Done: done, Errors: errs}, nil
+		}, time.Second),
+	)
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}]}`), http.Header{
+		"X-MacProvider-Retry": []string{"1"},
+		"X-Request-ID":        []string{requestID},
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	rows := queryAllRequestLogRows(t, dbPath)
+	if len(rows) != 2 {
+		t.Fatalf("request_log rows = %d, want 2: %#v", len(rows), rows)
+	}
+	if rows[0].ProviderAssignedID.String != "s1" || rows[1].ProviderAssignedID.String != "s2" {
+		t.Fatalf("provider assignments = %#v, want s1 then s2", rows)
+	}
+	if rows[0].Retried != 0 {
+		t.Fatalf("rows[0].Retried = %d, want 0", rows[0].Retried)
+	}
+	if rows[1].Retried != 1 {
+		t.Fatalf("rows[1].Retried = %d, want 1 (QueueFull retry hop must bump explicitRetries)", rows[1].Retried)
+	}
+}
+
 func TestChatCompletionsWSTunneledDeadProviderFastFails(t *testing.T) {
 	registry := pool.NewRegistry(nil)
 	registerWithPath(registry, "p1", "s1", "model-a", pool.StateReady, 20000, 1, "", 20, pool.TierProvisional, pool.InferencePathWSTunneled)


### PR DESCRIPTION
Closes ARCH-1/CODE-1 from `audits/2026-06-10/REPO_AUDIT.md` (M1-2).

> "the drift is already real, not theoretical: a streaming-WS provider returning queue-full is never marked StateBusy (the non-streaming loop does this at :1229), and the QueueFull path at :1233 omits the explicitRetries++ the other paths perform."
> — REPO_AUDIT.md §3.1 item 3

## Changes

**Divergence 1** (`buyer/server.go` ~1086): streaming-WS `forwardWS` returning `wsForwardQueueFull` now calls `s.pool.MarkState(StateBusy)`, matching the non-streaming branch at line 1239.

**Divergence 2** (`buyer/server.go` ~1238): the non-streaming QueueFull retry hop now increments `explicitRetries` and `faultedProviders` after the successful routing transition, matching the timeout-retry pattern at lines 1198-1199. Without this, the next attempt's `request_log` row was written with `retried=0` instead of `1`.

## Tests

Two new regression tests in `buyer/server_test.go`. Both were verified to **fail on pre-fix code** and pass on post-fix:

1. `TestChatCompletionsStreamingWSTunneledQueueFullMarksProviderBusy` — drives streaming WS-tunneled QueueFull, asserts `p1.State == pool.StateBusy` (pre-fix: still `StateReady`).
2. `TestChatCompletionsWSTunneledQueueFullIncrementsExplicitRetries` — drives non-streaming WS-tunneled QueueFull through `WithRequestLog`, asserts `rows[1].Retried == 1` (pre-fix: `0`).

Full coordinator suite green: `go test ./...` clean across all packages.

## Scope discipline

This intentionally does **not** extract `forwardWithFailover` from `handleChatCompletions`. That refactor is M2-1, and per the audit's Theme 4 sequencing it depends on these two regression tests landing first to pin the correct behavior.

## Audit refs

- ARCH-1: `audits/2026-06-10/REPO_AUDIT.md` §3.1 item 3 / §3.2
- CODE-1: §3.3 (merged into ARCH-1 per the verifier)
- Theme 4 sequencing rationale: §4 Improvement Strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)