### PR TITLE
m1-5: fail-closed auth predicates (SECU-5/TEST-5)

### DIFF
--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -34,10 +34,6 @@ type TokenRecord struct {
 	LastUsedAt   sql.NullString
 }
 
-func AuthorizedBearer(r *http.Request, expected string) bool {
-	return expected == "" || BearerTokenMatchesHeader(r.Header, expected)
-}
-
 func BearerTokenMatchesHeader(headers http.Header, expected string) bool {
 	expected = strings.TrimSpace(expected)
 	if expected == "" {

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -60,7 +60,10 @@ func (h *handler) admin(w http.ResponseWriter, r *http.Request, fn func(http.Res
 		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
-	if h.operatorKey != "" && !auth.BearerTokenMatchesHeader(r.Header, h.operatorKey) {
+	// Fail closed when the operator key is unset (M1-5 / SECU-5). Previously
+	// an empty configured key allowed every caller, relying on config.Validate
+	// in main.go to refuse to start.
+	if h.operatorKey == "" || !auth.BearerTokenMatchesHeader(r.Header, h.operatorKey) {
 		writeError(w, http.StatusForbidden, "forbidden", "operator key required")
 		return
 	}

--- a/phase4-coordinator/internal/billing/endpoints_test.go
+++ b/phase4-coordinator/internal/billing/endpoints_test.go
@@ -39,6 +39,40 @@ func TestSummaryEndpoint(t *testing.T) {
 	}
 }
 
+// Regression: M1-5 / SECU-5. The admin gate must fail closed when the
+// configured operator key is empty. Pre-fix the `if operatorKey != ""`
+// short-circuit allowed every caller; we relied on config.Validate to
+// refuse to start. This test constructs Handlers with operatorKey="" and
+// asserts /admin/ledger/* denies — locking the local invariant so future
+// entry points cannot bypass Validate and silently fail open.
+func TestAdminLedgerDeniesWhenOperatorKeyEmpty(t *testing.T) {
+	_, store := newRequestAndBillingStores(t)
+	handler := store.Handlers("", fakeTokens{}, true, 60)
+
+	paths := []string{
+		"/admin/ledger/summary",
+		"/admin/ledger/providers",
+		"/admin/ledger/reconcile?from=2026-06-01&to=2026-06-08",
+	}
+	for _, p := range paths {
+		// No Authorization header.
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("%s without bearer: status=%d body=%s, want 403 (empty operator key must deny)", p, w.Code, w.Body.String())
+		}
+		// Bearer-with-anything must also deny when configured key is empty.
+		req2 := httptest.NewRequest(http.MethodGet, p, nil)
+		req2.Header.Set("Authorization", "Bearer anything")
+		w2 := httptest.NewRecorder()
+		handler.ServeHTTP(w2, req2)
+		if w2.Code != http.StatusForbidden {
+			t.Fatalf("%s with arbitrary bearer: status=%d body=%s, want 403", p, w2.Code, w2.Body.String())
+		}
+	}
+}
+
 func TestProvidersEndpoint(t *testing.T) {
 	_, store := newRequestAndBillingStores(t)
 	now := time.Now().UTC()

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -1727,8 +1727,14 @@ func (s *Server) handleBlacklist(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// authorizedOperator returns true only when the configured operator key is
+// non-empty and matches the request's Bearer token. Empty configured key →
+// DENY (M1-5 / SECU-5). Previously this short-circuited to allow on empty
+// expected key, relying on config.Validate() to refuse to start with an empty
+// key. That defense-in-depth coupling meant any future entry point bypassing
+// Validate (live SIGHUP, ad-hoc Server construction) would silently fail open.
 func (s *Server) authorizedOperator(r *http.Request) bool {
-	return s.cfg.Auth.OperatorKey == "" || auth.BearerTokenMatchesHeader(r.Header, s.cfg.Auth.OperatorKey)
+	return s.cfg.Auth.OperatorKey != "" && auth.BearerTokenMatchesHeader(r.Header, s.cfg.Auth.OperatorKey)
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/phase4-coordinator/internal/ws/server_test.go
+++ b/phase4-coordinator/internal/ws/server_test.go
@@ -1786,6 +1786,43 @@ func TestPoolzRequiresOperatorKey(t *testing.T) {
 	}
 }
 
+// Regression: M1-5 / SECU-5. authorizedOperator must DENY when the configured
+// operator key is empty (fail closed). Previously the predicate short-circuited
+// to allow on empty expected key, relying on config.Validate() in main.go to
+// refuse to start. That defense-in-depth coupling meant any future entry point
+// that bypassed Validate would silently fail open. This test constructs a
+// server with an empty OperatorKey directly (bypassing Validate) and asserts
+// /poolz returns 401 even without a Bearer token in the request.
+func TestPoolzDeniesWhenOperatorKeyEmpty(t *testing.T) {
+	ts := newProviderServer(t, func(cfg *config.Config) {
+		cfg.Auth.OperatorKey = ""
+	})
+	defer ts.Close()
+
+	// No Authorization header — pre-fix this returned 200 because the
+	// short-circuit treated empty expected key as "no auth required."
+	resp, err := http.Get(ts.URL + "/poolz")
+	if err != nil {
+		t.Fatalf("poolz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (empty operator key must deny)", resp.StatusCode)
+	}
+
+	// Even a Bearer token that happens to be the empty string must deny.
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/poolz", nil)
+	req.Header.Set("Authorization", "Bearer ")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("poolz: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 with empty-bearer header", resp2.StatusCode)
+	}
+}
+
 func TestProviderHealthzReportsInjectedVersion(t *testing.T) {
 	harness := newProviderHarnessWithServerOptions(t, nil, []providerws.Option{
 		providerws.WithVersion("v1.3.0-7-gabcdef0"),


### PR DESCRIPTION
Closes SECU-5/TEST-5 from `audits/2026-06-10/REPO_AUDIT.md` (M1-5).

> "Auth predicates fail open on empty keys ... masked solely by `config.Validate()` in a different file; no test locks the behavior."
> — REPO_AUDIT.md §3.4

## Changes

Three predicate sites inverted so empty configured key → DENY instead of allowing every caller. Production safety becomes a **local** invariant: `config.Validate()` in main.go is now belt-and-suspenders, not the sole line of defense.

| Site | Before | After |
|---|---|---|
| `ws/server.go` `authorizedOperator` | `key == "" or matches` | `key != "" and matches` |
| `billing/endpoints.go` admin gate | `if key != "" and not matches { 403 }` | `if key == "" or not matches { 403 }` |
| `auth/tokens.go` `AuthorizedBearer` | dead code that fails open | **deleted** |

`AuthorizedBearer` deletion is safe — confirmed zero callers across both modules. The verifier's note in the audit independently flagged it as dead.

## Tests

Two regression tests verified to **fail on pre-fix code** and pass on post-fix:

1. `TestPoolzDeniesWhenOperatorKeyEmpty` — constructs a server with empty `OperatorKey` (bypassing `config.Validate`) and asserts `/poolz` returns 401 both without and with empty `Bearer ` header.
2. `TestAdminLedgerDeniesWhenOperatorKeyEmpty` — `Handlers("", ...)` and asserts `/admin/ledger/{summary,providers,reconcile}` return 403 both with no bearer and with arbitrary bearer.

Full coordinator suite green: `go test ./...` clean across all packages.

## Why this matters now

The audit's verifier note: "SIGHUP reload cannot zero the key — risk is future entry points bypassing Validate." This PR removes that latent landmine. Any future admin endpoint that doesn't think to consult `config.Validate` will still fail closed.

## Audit refs

- SECU-5: `audits/2026-06-10/REPO_AUDIT.md` §3.4
- TEST-5: §3.5 (merged into SECU-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
