### PR TITLE
m1-8: cap demo concurrency (PERF-6)

### DIFF
--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -45,6 +45,7 @@ quotas:
   demo_daily_tokens_per_ip: 1000
   demo_sessions_per_ip_per_hour: 10
   account_concurrency: 2
+  demo_concurrency: 2
   signup_accounts_per_ip_per_day: 3
   reaper_interval_hours: 1
   reservation_max_age_hours: 24

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -86,6 +86,7 @@ type QuotasConfig struct {
 	DemoDailyTokensPerIP      int64 `yaml:"demo_daily_tokens_per_ip"`
 	DemoSessionsPerIPPerHour  int   `yaml:"demo_sessions_per_ip_per_hour"`
 	AccountConcurrency        int   `yaml:"account_concurrency"`
+	DemoConcurrency           int   `yaml:"demo_concurrency"`
 	SignupAccountsPerIPPerDay int   `yaml:"signup_accounts_per_ip_per_day"`
 	ReaperIntervalHours       uint  `yaml:"reaper_interval_hours"`
 	ReservationMaxAgeHours    uint  `yaml:"reservation_max_age_hours"`
@@ -156,6 +157,7 @@ func Default() Config {
 			DemoDailyTokensPerIP:      1000,
 			DemoSessionsPerIPPerHour:  10,
 			AccountConcurrency:        2,
+			DemoConcurrency:           2,
 			SignupAccountsPerIPPerDay: 3,
 			ReaperIntervalHours:       1,
 			ReservationMaxAgeHours:    24,
@@ -294,6 +296,9 @@ func (c Config) Validate() error {
 	}
 	if c.Quotas.DemoSessionsPerIPPerHour <= 0 || c.Quotas.AccountConcurrency <= 0 || c.Quotas.SignupAccountsPerIPPerDay <= 0 {
 		return fmt.Errorf("quota counters must be positive")
+	}
+	if c.Quotas.DemoConcurrency <= 0 {
+		return fmt.Errorf("quotas.demo_concurrency must be positive")
 	}
 	if c.Quotas.ReaperIntervalHours < 1 {
 		return fmt.Errorf("quotas.reaper_interval_hours must be >= 1")

--- a/phase5-gateway/internal/router/integration_test.go
+++ b/phase5-gateway/internal/router/integration_test.go
@@ -248,6 +248,62 @@ func TestAccountConcurrencyCap(t *testing.T) {
 	}
 }
 
+// Regression: M1-8 / PERF-6. Demo requests must respect a concurrency cap.
+// Pre-fix the router skipped AcquireConcurrency for demo subjects, so 3+
+// parallel demo requests from a single IP could saturate the MLX-serialized
+// pool for up to CoordinatorTimeout — an accidental DoS against paying
+// buyers. The cap is keyed on subject.AccountID = "demo:<ip>" with IPv6
+// normalized to /64.
+func TestDemoConcurrencyCap(t *testing.T) {
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		entered <- struct{}{}
+		<-release
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_demo_concurrency",
+			"object":"chat.completion",
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2},
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, _, _, _ := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Quotas.DemoConcurrency = 2
+		// Keep daily-token budget high enough that 3 requests don't hit
+		// quota_exhausted (which is checked before concurrency).
+		cfg.Quotas.DemoDailyTokensPerIP = 1_000_000
+		cfg.Limits.DemoMaxTokensPerRequest = 1_000
+	}, WithHTTPClient(client))
+	demo := issueDemoToken(t, h, "1.2.3.4")
+	body := `{"model":"llama","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}`
+	headers := map[string]string{"X-Demo-Token": demo, "X-Real-IP": "1.2.3.4"}
+
+	done := make(chan *httptest.ResponseRecorder, 2)
+	for i := 0; i < 2; i++ {
+		go func() { done <- postChat(t, h, "", body, headers) }()
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case <-entered:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for upstream demo request to enter")
+		}
+	}
+	third := postChat(t, h, "", body, headers)
+	if third.Code != http.StatusTooManyRequests {
+		t.Fatalf("third demo request status=%d body=%s, want 429", third.Code, third.Body.String())
+	}
+	assertErrorCode(t, third.Body.String(), "demo_concurrency_exceeded")
+	close(release)
+	for i := 0; i < 2; i++ {
+		resp := <-done
+		if resp.Code != http.StatusOK {
+			t.Fatalf("in-flight demo response status=%d body=%s", resp.Code, resp.Body.String())
+		}
+	}
+}
+
 func TestProviderUnavailableReturns503AndRefunds(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		return responseWithBody(http.StatusServiceUnavailable, nil, ""), nil

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -1369,26 +1369,40 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	setRateLimitHeaders(w, decision.LimitTokens, decision.RemainingTokens, decision.ResetUnix)
-	if !authn.Demo {
-		if _, err := s.store.AcquireConcurrency(r.Context(), storage.ConcurrencyRequest{
-			AccountID: subject.AccountID, RequestID: requestID(r), Limit: s.cfg.Quotas.AccountConcurrency,
-			CreatedAt: s.now(), ExpiresAt: s.now().Add(s.cfg.CoordinatorTimeout() + time.Minute),
-		}); errors.Is(err, storage.ErrQuotaExceeded) {
-			_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
-			writeError(w, http.StatusTooManyRequests, "rate_limit_exceeded", "account_concurrency_exceeded", "Account concurrency limit exceeded")
-			return
-		} else if err != nil {
-			_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return
-			}
-			writeError(w, http.StatusInternalServerError, "server_error", "concurrency_reservation_failed", "Could not reserve concurrency")
+	// M1-8 / PERF-6: demo subjects must also acquire concurrency. Pre-fix,
+	// only paying accounts went through AcquireConcurrency. 3+ parallel demo
+	// requests from a single demo identity (keyed on IP/64 via the demo
+	// AccountID) saturated the MLX-serialized provider pool for up to
+	// CoordinatorTimeout, an accidental DoS against paying buyers.
+	// subject.AccountID is already "demo:<ip>" with IPv6 normalized to /64
+	// (see auth.normalizeDemoIP), so the existing per-AccountID reservation
+	// machinery keys correctly without further per-IP tracking.
+	concurrencyLimit := s.cfg.Quotas.AccountConcurrency
+	concurrencyErrCode := "account_concurrency_exceeded"
+	concurrencyErrMsg := "Account concurrency limit exceeded"
+	if authn.Demo {
+		concurrencyLimit = s.cfg.Quotas.DemoConcurrency
+		concurrencyErrCode = "demo_concurrency_exceeded"
+		concurrencyErrMsg = "Demo concurrency limit exceeded"
+	}
+	if _, err := s.store.AcquireConcurrency(r.Context(), storage.ConcurrencyRequest{
+		AccountID: subject.AccountID, RequestID: requestID(r), Limit: concurrencyLimit,
+		CreatedAt: s.now(), ExpiresAt: s.now().Add(s.cfg.CoordinatorTimeout() + time.Minute),
+	}); errors.Is(err, storage.ErrQuotaExceeded) {
+		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+		writeError(w, http.StatusTooManyRequests, "rate_limit_exceeded", concurrencyErrCode, concurrencyErrMsg)
+		return
+	} else if err != nil {
+		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return
 		}
-		defer func() {
-			_ = s.store.ReleaseConcurrency(context.Background(), subject.AccountID, requestID(r), s.now())
-		}()
+		writeError(w, http.StatusInternalServerError, "server_error", "concurrency_reservation_failed", "Could not reserve concurrency")
+		return
 	}
+	defer func() {
+		_ = s.store.ReleaseConcurrency(context.Background(), subject.AccountID, requestID(r), s.now())
+	}()
 
 	upCtx, cancelUpstream := context.WithTimeout(r.Context(), s.cfg.CoordinatorTimeout())
 	defer cancelUpstream()


### PR DESCRIPTION
Closes PERF-6 from `audits/2026-06-10/REPO_AUDIT.md` (M1-8).

> "Paying accounts cap at 2 concurrent; demo has no cap; 3 parallel demo requests saturate the N=3 MLX-serialized pool for up to CoordinatorTimeout — an accidental DoS path against paying buyers."
> — REPO_AUDIT.md §3.6

## Changes

Pre-fix `router/server.go:1372` `if !authn.Demo { AcquireConcurrency... }` skipped concurrency reservation entirely for demo subjects. Post-fix the demo path goes through the same machinery, keyed on `subject.AccountID = "demo:<ip>"` (already /64-normalized for IPv6 by `auth.normalizeDemoIP` — see `auth/demo_test.go`).

- New config knob `quotas.demo_concurrency` (default `2`, validated `> 0`)
- Distinct error code `demo_concurrency_exceeded` (vs paying `account_concurrency_exceeded`) so client envelopes stay unambiguous
- `gateway.yaml.example` updated

## Tests

New `TestDemoConcurrencyCap` mirrors the existing `TestAccountConcurrencyCap`: two parked upstreams hold the demo's 2 concurrency slots, third demo request from the same IP returns 429 with `demo_concurrency_exceeded`. Pre-fix the third request would have proceeded to the coordinator and queued behind the MLX serialization.

Full gateway suite green: `go test ./...` clean.

## Audit refs

- PERF-6: `audits/2026-06-10/REPO_AUDIT.md` §3.6 (verifier-upgraded from Low → Medium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
