### PR TITLE
m1-4: rate-limit /ws/provider + per-IP semaphore (SECU-1)

### DIFF
--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -8,6 +8,16 @@
 # default_server on port 80 for `_`. This site matches by server_name
 # only, so it does NOT interfere with Pearl traffic.
 
+# M1-4 / SECU-1: rate- and conn-limit /ws/provider identically to the api
+# vhost's buyer routes (see nginx-api.streamvc.live.conf:10-11). Pre-fix,
+# coordinator's /ws/provider was unrate-limited at nginx and the only
+# backstop was a global 64-slot unauthenticated-conn semaphore in Go with
+# no per-IP dimension; one host could starve all provider readmissions
+# (full inference outage at N=3). 10 req/min/IP with burst=5; 5 concurrent
+# unauthenticated WS conns/IP, matching api vhost.
+limit_req_zone $binary_remote_addr zone=ws_provider_rate:10m rate=10r/m;
+limit_conn_zone $binary_remote_addr zone=ws_provider_conn:10m;
+
 # Port 80: only used for ACME http-01 challenge and to redirect to https.
 server {
     listen 80;
@@ -63,6 +73,12 @@ server {
     # headers; nginx must NOT buffer.
     # ---------------------------------------------------------------------
     location = /ws/provider {
+        # M1-4 / SECU-1: per-IP rate + concurrency caps. Matches the api
+        # vhost block (nginx-api.streamvc.live.conf:124-134).
+        limit_req zone=ws_provider_rate burst=5 nodelay;
+        limit_conn ws_provider_conn 5;
+        limit_req_status 429;
+        limit_conn_status 429;
         proxy_pass http://127.0.0.1:8444/ws/provider;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -103,6 +103,11 @@ type WSConfig struct {
 	WriteTimeoutS          int   `yaml:"write_timeout_s"`
 	MaxFrameBytes          int64 `yaml:"max_frame_bytes"`
 	MaxUnauthenticatedConn int   `yaml:"max_unauthenticated_conn"`
+	// MaxUnauthenticatedConnPerIP caps concurrent unauthenticated WS
+	// handshakes from a single remote IP. Defense-in-depth against a single
+	// host starving all provider readmissions even if it slips past nginx's
+	// limit_conn (M1-4 / SECU-1). Default 4. Must be > 0.
+	MaxUnauthenticatedConnPerIP int `yaml:"max_unauthenticated_conn_per_ip"`
 }
 
 type AdmissionConfig struct {
@@ -273,7 +278,8 @@ func Default() Config {
 			HandshakeTimeoutS:      10,
 			WriteTimeoutS:          10,
 			MaxFrameBytes:          4 << 20,
-			MaxUnauthenticatedConn: 64,
+			MaxUnauthenticatedConn:      64,
+			MaxUnauthenticatedConnPerIP: 4,
 		},
 		Admission: AdmissionConfig{
 			PinnedOnly:                      false,
@@ -436,6 +442,14 @@ func (c Config) ProviderWSMaxUnauthenticatedConn() int {
 	return count
 }
 
+func (c Config) ProviderWSMaxUnauthenticatedConnPerIP() int {
+	count := c.WS.MaxUnauthenticatedConnPerIP
+	if count <= 0 {
+		count = Default().WS.MaxUnauthenticatedConnPerIP
+	}
+	return count
+}
+
 func (c Config) ProviderByID() map[string]ProviderConfig {
 	out := make(map[string]ProviderConfig, len(c.Providers))
 	for _, p := range c.Providers {
@@ -453,6 +467,9 @@ func (c Config) Validate() error {
 	}
 	if c.WS.HandshakeTimeoutS <= 0 || c.WS.WriteTimeoutS <= 0 || c.WS.MaxFrameBytes <= 0 || c.WS.MaxUnauthenticatedConn <= 0 {
 		return fmt.Errorf("ws handshake, write, frame, and unauthenticated connection limits must be > 0")
+	}
+	if c.WS.MaxUnauthenticatedConnPerIP <= 0 {
+		return fmt.Errorf("ws.max_unauthenticated_conn_per_ip must be > 0")
 	}
 	if c.WS.MaxFrameBytes > 64<<20 {
 		return fmt.Errorf("ws.max_frame_bytes must be <= 67108864")

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -29,7 +29,8 @@ func TestProviderWebSocketBoundsDefaultAndValidate(t *testing.T) {
 	cfg := Default()
 	cfg.Auth.OperatorKey = "operator-key"
 	if cfg.WS.HandshakeTimeoutS != 10 || cfg.WS.WriteTimeoutS != 10 ||
-		cfg.WS.MaxFrameBytes != 4<<20 || cfg.WS.MaxUnauthenticatedConn != 64 {
+		cfg.WS.MaxFrameBytes != 4<<20 || cfg.WS.MaxUnauthenticatedConn != 64 ||
+		cfg.WS.MaxUnauthenticatedConnPerIP != 4 {
 		t.Fatalf("unexpected ws bounds defaults: %+v", cfg.WS)
 	}
 	if err := cfg.Validate(); err != nil {

--- a/phase4-coordinator/internal/ws/export_test.go
+++ b/phase4-coordinator/internal/ws/export_test.go
@@ -1,0 +1,9 @@
+package ws
+
+import "net/http"
+
+// RemoteIPForUnauthSemaphoreExport exposes remoteIPForUnauthSemaphore for
+// external _test packages. M1-4 follow-up regression coverage.
+func RemoteIPForUnauthSemaphoreExport(remoteAddr string, header http.Header) string {
+	return remoteIPForUnauthSemaphore(remoteAddr, header)
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -247,8 +247,11 @@ func (s *Server) handleProvider(w http.ResponseWriter, r *http.Request) {
 	}
 	s.enableProviderTCPKeepAlive(conn)
 	// M1-4 / SECU-1: per-IP gate runs first so one source cannot starve all
-	// admissions even within the global unauth budget.
-	remoteIP := remoteIPForUnauthSemaphore(r.RemoteAddr)
+	// admissions even within the global unauth budget. Proxy-aware (M1-4
+	// follow-up): when nginx fronts the coordinator on loopback, X-Real-IP
+	// carries the real client IP — otherwise the per-IP bucket collapses
+	// to a single shared 127.0.0.1 slot.
+	remoteIP := remoteIPForUnauthSemaphore(r.RemoteAddr, r.Header)
 	perIPOK, releasePerIP := s.reserveUnauthenticatedConnForIP(remoteIP)
 	if !perIPOK {
 		s.close(conn, ClosePoolFull, "too_many_unauthenticated_connections_per_ip")
@@ -907,18 +910,40 @@ func (s *Server) reserveUnauthenticatedConnForIP(ip string) (bool, func()) {
 	}
 }
 
-// remoteIPForUnauthSemaphore extracts the IP portion of r.RemoteAddr for
-// per-IP unauth tracking. Returns "" if parsing fails so the caller skips
-// the per-IP gate (the global semaphore still applies).
-func remoteIPForUnauthSemaphore(remoteAddr string) string {
+// remoteIPForUnauthSemaphore extracts the per-source IP for unauth tracking.
+// Pre-fix (M1-4 v1) used r.RemoteAddr only, but production sits behind nginx
+// on loopback so every public client appeared as 127.0.0.1 and the per-IP
+// cap collapsed to one shared bucket (codex security audit, 2026-06-11).
+// Fix: when r.RemoteAddr is a loopback address, honor X-Real-IP (which the
+// on-host nginx site sets — see nginx-coordinator.streamvc.live.conf).
+// Direct, non-loopback hits (no proxy in front) use r.RemoteAddr unchanged.
+// Returns "" if parsing fails so the caller skips the per-IP gate (the
+// global semaphore still applies).
+func remoteIPForUnauthSemaphore(remoteAddr string, header http.Header) string {
 	if remoteAddr == "" {
 		return ""
 	}
 	host, _, err := net.SplitHostPort(remoteAddr)
 	if err != nil {
-		return remoteAddr
+		host = remoteAddr
+	}
+	if isLoopbackHost(host) {
+		if realIP := strings.TrimSpace(header.Get("X-Real-IP")); realIP != "" {
+			return realIP
+		}
 	}
 	return host
+}
+
+// isLoopbackHost reports whether host is an IPv4 or IPv6 loopback address.
+// Anything not parseable as an IP is treated as non-loopback so the
+// fallback path through r.RemoteAddr stays in play.
+func isLoopbackHost(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
 }
 
 func (s *Server) setReadDeadline(conn net.Conn, timeout time.Duration) {

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -58,7 +58,12 @@ type Server struct {
 	started   time.Time
 	explorer  http.Handler
 	unauth    chan struct{}
-	version   string
+	// unauthPerIP counts concurrent unauthenticated WS handshakes by remote IP.
+	// Defense-in-depth against nginx limit_conn evasion: one host can still
+	// burn the global 64-slot semaphore without per-IP shaping (M1-4 / SECU-1).
+	unauthPerIPMu sync.Mutex
+	unauthPerIP   map[string]int
+	version       string
 	// SPEC-002 v1.3.5 §7.9 — auth-attempt retention store, 1024 bound
 	authAttempts *authAttemptStore
 }
@@ -139,6 +144,19 @@ func (s *Server) AuthAttemptCount() int {
 	return s.authAttempts.count()
 }
 
+// UnauthenticatedPerIPSnapshot returns the current sum of per-IP unauthenticated
+// WS handshake counters. Test-only; lets regression tests wait for handler
+// goroutines to actually reserve their slots after gobwas.Dial returns.
+func (s *Server) UnauthenticatedPerIPSnapshot() int {
+	s.unauthPerIPMu.Lock()
+	defer s.unauthPerIPMu.Unlock()
+	total := 0
+	for _, n := range s.unauthPerIP {
+		total += n
+	}
+	return total
+}
+
 type pendingPreflight struct {
 	providerID string
 	assignedID string
@@ -154,8 +172,9 @@ func NewServer(cfg config.Config, registry *pool.Registry, logger zerolog.Logger
 		now:     func() time.Time { return time.Now().UTC() },
 		newUUID: func() string { return uuid.NewString() },
 		started: time.Now().UTC(),
-		unauth:  make(chan struct{}, cfg.ProviderWSMaxUnauthenticatedConn()),
-		version: "dev",
+		unauth:      make(chan struct{}, cfg.ProviderWSMaxUnauthenticatedConn()),
+		unauthPerIP: map[string]int{},
+		version:     "dev",
 	}
 	s.authAttempts = newAuthAttemptStore(1024)
 	s.admission = NewAdmissionManager(cfg.Admission, s.now)
@@ -227,8 +246,18 @@ func (s *Server) handleProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.enableProviderTCPKeepAlive(conn)
+	// M1-4 / SECU-1: per-IP gate runs first so one source cannot starve all
+	// admissions even within the global unauth budget.
+	remoteIP := remoteIPForUnauthSemaphore(r.RemoteAddr)
+	perIPOK, releasePerIP := s.reserveUnauthenticatedConnForIP(remoteIP)
+	if !perIPOK {
+		s.close(conn, ClosePoolFull, "too_many_unauthenticated_connections_per_ip")
+		time.AfterFunc(100*time.Millisecond, func() { _ = conn.Close() })
+		return
+	}
 	if !s.reserveUnauthenticatedConn() {
 		s.close(conn, ClosePoolFull, "too_many_unauthenticated_connections")
+		releasePerIP()
 		time.AfterFunc(100*time.Millisecond, func() { _ = conn.Close() })
 		return
 	}
@@ -237,10 +266,14 @@ func (s *Server) handleProvider(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		s.close(conn, CloseInvalidToken, "invalid_token")
 		s.releaseUnauthenticatedConn()
+		releasePerIP()
 		time.AfterFunc(100*time.Millisecond, func() { _ = conn.Close() })
 		return
 	}
-	go s.handleConn(conn, auth, s.releaseUnauthenticatedConn)
+	go s.handleConn(conn, auth, func() {
+		s.releaseUnauthenticatedConn()
+		releasePerIP()
+	})
 }
 
 func (s *Server) validateProviderToken(r *http.Request) (providerAuth, bool) {
@@ -845,6 +878,47 @@ func (s *Server) releaseUnauthenticatedConn() {
 	case <-s.unauth:
 	default:
 	}
+}
+
+// reserveUnauthenticatedConnForIP returns true if the per-IP cap for
+// unauthenticated handshakes has room for one more. The release closure
+// MUST be called exactly once per successful reservation (defer it at the
+// caller). Empty ip is not tracked — pass r.RemoteAddr's host portion.
+func (s *Server) reserveUnauthenticatedConnForIP(ip string) (bool, func()) {
+	if ip == "" {
+		return true, func() {}
+	}
+	cap := s.cfg.ProviderWSMaxUnauthenticatedConnPerIP()
+	s.unauthPerIPMu.Lock()
+	if s.unauthPerIP[ip] >= cap {
+		s.unauthPerIPMu.Unlock()
+		return false, func() {}
+	}
+	s.unauthPerIP[ip]++
+	s.unauthPerIPMu.Unlock()
+	return true, func() {
+		s.unauthPerIPMu.Lock()
+		defer s.unauthPerIPMu.Unlock()
+		if s.unauthPerIP[ip] <= 1 {
+			delete(s.unauthPerIP, ip)
+			return
+		}
+		s.unauthPerIP[ip]--
+	}
+}
+
+// remoteIPForUnauthSemaphore extracts the IP portion of r.RemoteAddr for
+// per-IP unauth tracking. Returns "" if parsing fails so the caller skips
+// the per-IP gate (the global semaphore still applies).
+func remoteIPForUnauthSemaphore(remoteAddr string) string {
+	if remoteAddr == "" {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return host
 }
 
 func (s *Server) setReadDeadline(conn net.Conn, timeout time.Duration) {

--- a/phase4-coordinator/internal/ws/server_test.go
+++ b/phase4-coordinator/internal/ws/server_test.go
@@ -1772,6 +1772,40 @@ func TestProviderClosedAfterActivityStops(t *testing.T) {
 	})
 }
 
+// Regression: M1-4 follow-up. When nginx fronts the coordinator on
+// loopback, r.RemoteAddr is 127.0.0.1 for every public client and the
+// pre-fix per-IP bucket collapsed to a single shared 127.0.0.1 slot
+// (codex security audit 2026-06-11). Fix: honor X-Real-IP when the
+// immediate remote is loopback. This pins the bucket per real-client
+// IP behind a loopback proxy.
+func TestRemoteIPForUnauthSemaphoreHonorsXRealIPBehindLoopback(t *testing.T) {
+	cases := []struct {
+		name       string
+		remoteAddr string
+		xRealIP    string
+		want       string
+	}{
+		{name: "loopback_ipv4_with_real_ip", remoteAddr: "127.0.0.1:54321", xRealIP: "203.0.113.5", want: "203.0.113.5"},
+		{name: "loopback_ipv6_with_real_ip", remoteAddr: "[::1]:54321", xRealIP: "2001:db8::1", want: "2001:db8::1"},
+		{name: "loopback_no_real_ip_falls_back", remoteAddr: "127.0.0.1:54321", xRealIP: "", want: "127.0.0.1"},
+		{name: "non_loopback_ignores_real_ip", remoteAddr: "198.51.100.7:443", xRealIP: "203.0.113.5", want: "198.51.100.7"},
+		{name: "non_loopback_no_real_ip", remoteAddr: "198.51.100.7:443", xRealIP: "", want: "198.51.100.7"},
+		{name: "x_real_ip_whitespace_trimmed", remoteAddr: "127.0.0.1:54321", xRealIP: "  203.0.113.5  ", want: "203.0.113.5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			header := http.Header{}
+			if tc.xRealIP != "" {
+				header.Set("X-Real-IP", tc.xRealIP)
+			}
+			got := providerws.RemoteIPForUnauthSemaphoreExport(tc.remoteAddr, header)
+			if got != tc.want {
+				t.Fatalf("remoteIPForUnauthSemaphore(%q, X-Real-IP=%q) = %q, want %q", tc.remoteAddr, tc.xRealIP, got, tc.want)
+			}
+		})
+	}
+}
+
 // Regression: M1-4 / SECU-1. Per-IP cap on concurrent unauthenticated WS
 // handshakes refuses the (cap+1)-th attempt from a single source even
 // when the global semaphore still has room. Pre-fix the only backstop

--- a/phase4-coordinator/internal/ws/server_test.go
+++ b/phase4-coordinator/internal/ws/server_test.go
@@ -1772,6 +1772,67 @@ func TestProviderClosedAfterActivityStops(t *testing.T) {
 	})
 }
 
+// Regression: M1-4 / SECU-1. Per-IP cap on concurrent unauthenticated WS
+// handshakes refuses the (cap+1)-th attempt from a single source even
+// when the global semaphore still has room. Pre-fix the only backstop
+// was a single global 64-slot semaphore with no per-IP dimension — one
+// host could starve all provider readmissions (full inference outage at
+// N=3). Test sets the cap to 4, opens 4 dialed-but-silent connections,
+// asserts the 5th gets ClosePoolFull with the per-IP reason.
+func TestProviderUnauthenticatedConnPerIPCapDeniesFifth(t *testing.T) {
+	h := newProviderHarness(t, func(cfg *config.Config) {
+		cfg.WS.MaxUnauthenticatedConnPerIP = 4
+		cfg.WS.MaxUnauthenticatedConn = 64 // global cap leaves room — per-IP must fire
+	})
+	defer h.HTTP.Close()
+
+	conns := make([]net.Conn, 0, 4)
+	defer func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}()
+	for i := 0; i < 4; i++ {
+		c, _, _, err := gobwas.Dial(context.Background(), wsURL(h.HTTP.URL))
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		conns = append(conns, c)
+	}
+	// Dial returning means the HTTP upgrade completed; the server's
+	// reserveUnauthenticatedConnForIP call runs in the handler goroutine
+	// after gobwas.UpgradeHTTP returns. Wait for the counter to reach 4
+	// before opening the 5th conn, otherwise the 5th can win the race and
+	// reserve a slot before earlier conns get accounted (test flakiness).
+	eventually(t, func() bool {
+		return h.Provider.UnauthenticatedPerIPSnapshot() >= 4
+	})
+
+	fifth, fifthBR, _, err := gobwas.Dial(context.Background(), wsURL(h.HTTP.URL))
+	if err != nil {
+		t.Fatalf("dial fifth: %v", err)
+	}
+	defer fifth.Close()
+	// The server writes the close frame immediately after HTTP upgrade.
+	// gobwas.Dial's bufio.Reader may have already buffered those bytes off
+	// the socket as part of the same TCP read that delivered the upgrade
+	// response. Read from the bufio.Reader, not from the raw conn (which
+	// would EOF if the close frame was already pulled into the buffer).
+	_ = fifth.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var reader io.Reader = fifth
+	if fifthBR != nil && fifthBR.Buffered() > 0 {
+		reader = fifthBR
+	}
+	frame, err := gobwas.ReadFrame(reader)
+	if err != nil {
+		t.Fatalf("read fifth close: %v", err)
+	}
+	code, reason := gobwas.ParseCloseFrameData(frame.Payload)
+	if code != providerws.ClosePoolFull || reason != "too_many_unauthenticated_connections_per_ip" {
+		t.Fatalf("fifth close = (%d, %q), want (%d, %q)", code, reason, providerws.ClosePoolFull, "too_many_unauthenticated_connections_per_ip")
+	}
+}
+
 func TestPoolzRequiresOperatorKey(t *testing.T) {
 	ts := newProviderServer(t)
 	defer ts.Close()


### PR DESCRIPTION
Closes SECU-1 from `audits/2026-06-10/REPO_AUDIT.md` (M1-4).

> "Unrate-limited public /ws/provider on the coordinator hostname bypasses the rate limits the api hostname applies ... The only backstop is a single *global* 64-slot unauthenticated-conn semaphore with no per-IP dimension — one host can starve all provider (re)admissions; at N=3 that is a full inference outage."
> — REPO_AUDIT.md §3.1 item 6 (verifier-upgraded Medium → High)

## Part A — nginx

`phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf` gains `limit_req_zone` + `limit_conn_zone` declarations and applies them to `/ws/provider` with `burst=5` / `cap=5`, **matching `nginx-api.streamvc.live.conf:10-11,124-134` byte-for-byte**.

**Operator action**: this PR does not deploy. Once merged, the operator copies the updated conf to Pearl and reloads nginx (`nginx -t && systemctl reload nginx`). The change is additive — no existing legitimate provider reconnect pattern hits 10 req/min on a single IP.

## Part B — per-IP semaphore in Go

`WSConfig` gains `MaxUnauthenticatedConnPerIP` (default 4, validated > 0). `Server` gains `unauthPerIP` map (guarded by `unauthPerIPMu`). `handleProvider` now consults the per-IP gate **before** the global 64-slot semaphore so one host cannot burn the global budget even if it slips past nginx.

Configurable in `coordinator.yaml` via `ws.max_unauthenticated_conn_per_ip`. Default 4 chosen because legitimate providers reconnect via outbound WS only — a single Mac never holds more than 1 connection in steady state; 4 leaves headroom for handshake races and roaming networks.

## Tests

`TestProviderUnauthenticatedConnPerIPCapDeniesFifth` opens 4 silent connections, waits for the per-IP counter to settle at 4 via the new `UnauthenticatedPerIPSnapshot` test seam, then asserts the 5th receives `ClosePoolFull` with reason `"too_many_unauthenticated_connections_per_ip"`. Test reads from `gobwas.Dial`'s `bufio.Reader` because the close frame arrives in the same TCP read as the HTTP upgrade response and is already buffered when Dial returns.

Stress: `-count=10` all green on the per-IP test. Full coordinator suite green under `go test ./...`.

## Audit refs

- SECU-1: `audits/2026-06-10/REPO_AUDIT.md` §3.1 item 6 / §3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
