### PR TITLE
m1-1: provider_token plumbing + Bearer on WS connect (XSEC-1, pinned tier)

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -40,6 +40,16 @@ public struct AppConfig: Equatable, Sendable {
     public var swapDrainTimeoutSeconds: Int
     public var ctlSocketPath: String?
     public var switchStatePath: String?
+    // SPEC-001: provider authentication token (closes XSEC-1 from
+    // audits/2026-06-10/REPO_AUDIT.md). When set, the binary sends
+    // "Authorization: Bearer <token>" on the WS connect and the
+    // coordinator validates against its store when
+    // auth.require_provider_tokens=true. Triple-exposed per house
+    // convention: yaml key `provider_token`, env
+    // MACPROVIDER_PROVIDER_TOKEN, CLI --provider-token. Operator should
+    // chmod 0600 the config file containing this value; the binary
+    // never logs the token (URL is redacted, headers are not logged).
+    public var providerToken: String?
 
     public static let defaultConfigPath = "~/.config/macprovider/config.yaml"
 
@@ -67,7 +77,8 @@ public struct AppConfig: Equatable, Sendable {
             enableWarmSwap: false,
             swapDrainTimeoutSeconds: 30,
             ctlSocketPath: nil,
-            switchStatePath: nil
+            switchStatePath: nil,
+            providerToken: nil
         )
     }
 }
@@ -86,6 +97,7 @@ public struct CLIOverrides: Equatable, Sendable {
     public var swapDrainTimeoutSeconds: Int?
     public var ctlSocketPath: String?
     public var switchStatePath: String?
+    public var providerToken: String?
 
     public init(
         port: Int? = nil,
@@ -100,7 +112,8 @@ public struct CLIOverrides: Equatable, Sendable {
         enableWarmSwap: Bool? = nil,
         swapDrainTimeoutSeconds: Int? = nil,
         ctlSocketPath: String? = nil,
-        switchStatePath: String? = nil
+        switchStatePath: String? = nil,
+        providerToken: String? = nil
     ) {
         self.port = port
         self.model = model
@@ -115,6 +128,7 @@ public struct CLIOverrides: Equatable, Sendable {
         self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
         self.ctlSocketPath = ctlSocketPath
         self.switchStatePath = switchStatePath
+        self.providerToken = providerToken
     }
 }
 
@@ -216,6 +230,7 @@ public enum ConfigLoader {
         try assign(&config.swapDrainTimeoutSeconds, from: dict, key: "swap_drain_timeout_s", expected: "integer")
         try assign(&config.ctlSocketPath, from: dict, key: "ctl_socket_path", expected: "string")
         try assign(&config.switchStatePath, from: dict, key: "switch_state_path", expected: "string")
+        try assign(&config.providerToken, from: dict, key: "provider_token", expected: "string")
         return config
     }
 
@@ -246,6 +261,7 @@ public enum ConfigLoader {
         try assign(&config.swapDrainTimeoutSeconds, from: environment, env: "MACPROVIDER_SWAP_DRAIN_TIMEOUT_S", expected: "integer")
         try assign(&config.ctlSocketPath, from: environment, env: "MACPROVIDER_CTL_SOCKET_PATH", expected: "string")
         try assign(&config.switchStatePath, from: environment, env: "MACPROVIDER_SWITCH_STATE_PATH", expected: "string")
+        try assign(&config.providerToken, from: environment, env: "MACPROVIDER_PROVIDER_TOKEN", expected: "string")
         return config
     }
 
@@ -289,6 +305,9 @@ public enum ConfigLoader {
         }
         if let switchStatePath = cli.switchStatePath {
             config.switchStatePath = switchStatePath
+        }
+        if let providerToken = cli.providerToken {
+            config.providerToken = providerToken
         }
         return config
     }

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -10,6 +10,39 @@ protocol ProviderWebSocketTask: AnyObject, Sendable {
     func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?)
 }
 
+// M1-1 follow-up (codex security audit 2026-06-11): refuse HTTP redirects
+// on the provider WS connect so the Authorization: Bearer <token> header
+// cannot leak to an attacker-controlled redirect target. The default
+// URLSession.shared follows redirects with the credential headers attached.
+// We install this delegate on a dedicated session via providerWebSocketSession
+// so the same isolation holds across reconnects.
+final class NoRedirectURLSessionDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        CoordinatorClient.keepaliveDebug("ws_redirect_refused status=\(response.statusCode)")
+        completionHandler(nil)
+    }
+}
+
+// providerWebSocketSession is the dedicated URLSession used by the default
+// webSocketFactory. URLSession retains its delegate until invalidated, so we
+// keep a process-wide singleton rather than leaking one session per connect.
+private let providerWebSocketSession: URLSession = {
+    let config = URLSessionConfiguration.default
+    config.httpShouldUsePipelining = false
+    config.httpAdditionalHeaders = nil
+    return URLSession(
+        configuration: config,
+        delegate: NoRedirectURLSessionDelegate(),
+        delegateQueue: nil
+    )
+}()
+
 extension URLSessionWebSocketTask: ProviderWebSocketTask {}
 
 extension URLSessionWebSocketTask {
@@ -111,7 +144,7 @@ actor CoordinatorClient {
         sendOverride: SendOverride? = nil,
         reconnectGraceNanoseconds: UInt64 = 10 * 1_000_000_000,
         attestationGenerator: Tier2AttestationTokenGenerating = ManagedDeviceAttestationGenerator(),
-        webSocketFactory: @escaping @Sendable (URLRequest) -> ProviderWebSocketTask = { URLSession.shared.webSocketTask(with: $0) },
+        webSocketFactory: @escaping @Sendable (URLRequest) -> ProviderWebSocketTask = { providerWebSocketSession.webSocketTask(with: $0) },
         sleepAssertionFactory: @escaping @Sendable () -> ProviderSleepAssertion? = { CaffeinateSleepAssertion.start() },
         connectAndRunOverride: (@Sendable () async throws -> Void)? = nil
     ) {

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -86,7 +86,14 @@ actor CoordinatorClient {
     private let reconnectGraceNanoseconds: UInt64
     private let connectAndRunOverride: (@Sendable () async throws -> Void)?
     private let attestationGenerator: Tier2AttestationTokenGenerating
-    private let webSocketFactory: @Sendable (URL) -> ProviderWebSocketTask
+    // M1-1 / XSEC-1: the factory now takes a URLRequest so the binary can
+    // attach an Authorization: Bearer header when a provider token is
+    // configured. The header is required when the coordinator runs with
+    // auth.require_provider_tokens=true (the production posture per
+    // SPEC-001). The factory signature change is intentional — keeping
+    // it URL-only would require a parallel header-injection seam.
+    private let webSocketFactory: @Sendable (URLRequest) -> ProviderWebSocketTask
+    private let providerToken: String?
     private let sleepAssertionFactory: @Sendable () -> ProviderSleepAssertion?
     private var inferenceRelay: InferenceRelay?
     private var tier2Session: Tier2ProviderSession?
@@ -104,7 +111,7 @@ actor CoordinatorClient {
         sendOverride: SendOverride? = nil,
         reconnectGraceNanoseconds: UInt64 = 10 * 1_000_000_000,
         attestationGenerator: Tier2AttestationTokenGenerating = ManagedDeviceAttestationGenerator(),
-        webSocketFactory: @escaping @Sendable (URL) -> ProviderWebSocketTask = { URLSession.shared.webSocketTask(with: $0) },
+        webSocketFactory: @escaping @Sendable (URLRequest) -> ProviderWebSocketTask = { URLSession.shared.webSocketTask(with: $0) },
         sleepAssertionFactory: @escaping @Sendable () -> ProviderSleepAssertion? = { CaffeinateSleepAssertion.start() },
         connectAndRunOverride: (@Sendable () async throws -> Void)? = nil
     ) {
@@ -131,6 +138,10 @@ actor CoordinatorClient {
         self.reconnectGraceNanoseconds = reconnectGraceNanoseconds
         self.attestationGenerator = attestationGenerator
         self.webSocketFactory = webSocketFactory
+        self.providerToken = config.providerToken.flatMap { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
         self.sleepAssertionFactory = sleepAssertionFactory
         self.connectAndRunOverride = connectAndRunOverride
         self.sendOverride = sendOverride
@@ -241,10 +252,20 @@ actor CoordinatorClient {
     }
 
     private func openWebSocket() -> ProviderWebSocketTask {
-        let socket = webSocketFactory(coordinatorURL)
+        var request = URLRequest(url: coordinatorURL)
+        // M1-1 / XSEC-1: attach Authorization: Bearer when the operator has
+        // issued this provider a token. Coordinator validates the header in
+        // its WS upgrade path (server.go:236-262) and rejects with
+        // CloseInvalidToken when auth.require_provider_tokens=true.
+        // The token never appears in log lines — redactedURL only logs the
+        // URL, not headers, and we don't dump headers anywhere.
+        if let token = providerToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        let socket = webSocketFactory(request)
         webSocket = socket
         socket.resume()
-        Self.keepaliveDebug("ws_resume url=\(Self.redactedURL(coordinatorURL))")
+        Self.keepaliveDebug("ws_resume url=\(Self.redactedURL(coordinatorURL)) token=\(providerToken == nil ? "absent" : "present")")
         return socket
     }
 

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -61,6 +61,9 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "CLI-side cooldown state file. Overrides MACPROVIDER_SWITCH_STATE_PATH and config switch_state_path. Default $HOME/Library/Application Support/macprovider-cli/last-switch.ts. Cooldown soft guard lands in Phase 1E.")
     var switchStatePath: String?
 
+    @Option(help: "Provider authentication token (SPEC-001 / XSEC-1). When set, the binary sends 'Authorization: Bearer <token>' on the coordinator WS connect. Required when the coordinator runs with auth.require_provider_tokens=true. Overrides MACPROVIDER_PROVIDER_TOKEN and config key provider_token. Treat as a secret — the binary never logs it; chmod 0600 the config file containing it.")
+    var providerToken: String?
+
     static func runSupportedModelsPreflight(_ resolved: inout AppConfig) throws {
         if resolved.supportedModels != nil {
             do {
@@ -100,7 +103,8 @@ struct ServeCommand: AsyncParsableCommand {
                 enableWarmSwap: enableWarmSwap,
                 swapDrainTimeoutSeconds: swapDrainTimeoutSeconds,
                 ctlSocketPath: ctlSocketPath,
-                switchStatePath: switchStatePath
+                switchStatePath: switchStatePath,
+                providerToken: providerToken
             )
         )
 

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -206,6 +206,40 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
     }
 
+    // Regression: M1-1 follow-up (codex security audit 2026-06-11). The
+    // NoRedirectURLSessionDelegate refuses HTTP redirects on the provider
+    // WS task so the Authorization: Bearer <token> header cannot leak to an
+    // attacker-controlled redirect target. Pre-fix URLSession.shared
+    // followed redirects with credential headers attached.
+    func testNoRedirectURLSessionDelegateRefusesRedirect() {
+        let delegate = NoRedirectURLSessionDelegate()
+        let session = URLSession.shared
+        let dummyURL = URL(string: "https://example.test/ws/provider")!
+        let task = session.dataTask(with: dummyURL)
+        let response = HTTPURLResponse(
+            url: dummyURL,
+            statusCode: 302,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Location": "https://attacker.test/ws/provider"]
+        )!
+        let newRequest = URLRequest(url: URL(string: "https://attacker.test/ws/provider")!)
+
+        var capturedRequest: URLRequest? = URLRequest(url: dummyURL) // non-nil sentinel
+        let expectation = self.expectation(description: "completion called")
+        delegate.urlSession(
+            session,
+            task: task,
+            willPerformHTTPRedirection: response,
+            newRequest: newRequest
+        ) { request in
+            capturedRequest = request
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        task.cancel()
+        XCTAssertNil(capturedRequest, "delegate must call completion with nil to refuse the redirect")
+    }
+
     func testCoordinatorSessionSendsWebSocketPingBeforeHeartbeat() async throws {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
         config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -100,6 +100,112 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertEqual(attemptCount, 2)
     }
 
+    // Regression: M1-1 / XSEC-1. When config.providerToken is set, the WS
+    // connect attaches "Authorization: Bearer <token>". When unset, no
+    // Authorization header is sent (preserves the legacy fleet's ability
+    // to connect against a coordinator with require_provider_tokens=false).
+    // Covers both v1 plaintext (wsTunneledMode=false) and v2 ECDH
+    // (wsTunneledMode=true) connect paths via openWebSocket.
+    func testWebSocketConnectAttachesBearerAuthorizationWhenTokenConfigured_v1Plaintext() async throws {
+        let token = "test-token-deadbeef-deadbeef-deadbeef"
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = "model-a"
+        config.wsTunneledMode = false
+        config.providerToken = token
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let socket = FakeProviderWebSocketTask(receiveResults: [.failure(CancellationError())])
+        let factory = FakeProviderWebSocketFactory(sockets: [socket])
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            webSocketFactory: { factory.makeSocket(for: $0) }
+        ))
+
+        do {
+            try await client.connectAndRunOnceForTest()
+        } catch is CancellationError {
+        } catch {
+            // Other failures fine — we only care about the request handed to the factory.
+        }
+
+        let request = try XCTUnwrap(factory.lastRequest, "factory never received a URLRequest")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(token)")
+    }
+
+    func testWebSocketConnectAttachesBearerAuthorizationWhenTokenConfigured_v2Tier2() async throws {
+        let token = "tier2-token-cafebabe-cafebabe-cafebabe"
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = "model-a"
+        config.wsTunneledMode = true
+        config.providerToken = token
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let socket = FakeProviderWebSocketTask(receiveResults: [
+            .failure(CoordinatorAuthError.invalidMessage("unrecognized auth message")),
+        ])
+        let factory = FakeProviderWebSocketFactory(sockets: [socket])
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            attestationGenerator: StaticAttestationGenerator(token: nil),
+            webSocketFactory: { factory.makeSocket(for: $0) }
+        ))
+
+        do {
+            try await client.connectAndRunOnceForTest()
+        } catch {
+        }
+
+        let request = try XCTUnwrap(factory.lastRequest, "factory never received a URLRequest")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(token)")
+    }
+
+    func testWebSocketConnectOmitsAuthorizationWhenTokenUnset() async throws {
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = "model-a"
+        config.wsTunneledMode = false
+        // providerToken intentionally not set
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let socket = FakeProviderWebSocketTask(receiveResults: [.failure(CancellationError())])
+        let factory = FakeProviderWebSocketFactory(sockets: [socket])
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            webSocketFactory: { factory.makeSocket(for: $0) }
+        ))
+
+        do {
+            try await client.connectAndRunOnceForTest()
+        } catch {
+        }
+
+        let request = try XCTUnwrap(factory.lastRequest, "factory never received a URLRequest")
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+    }
+
     func testCoordinatorSessionSendsWebSocketPingBeforeHeartbeat() async throws {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
         config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
@@ -976,8 +1082,11 @@ private final class FakeProviderWebSocketFactory: @unchecked Sendable {
         self.sockets = sockets
     }
 
-    func makeSocket(for _: URL) -> ProviderWebSocketTask {
+    private(set) var lastRequest: URLRequest?
+
+    func makeSocket(for request: URLRequest) -> ProviderWebSocketTask {
         queue.sync {
+            lastRequest = request
             precondition(!sockets.isEmpty, "fake web socket factory exhausted")
             return sockets.removeFirst()
         }

--- a/specs/SPEC-001-phase3-binary.md
+++ b/specs/SPEC-001-phase3-binary.md
@@ -1,7 +1,39 @@
 # SPEC-001 — Phase 3 Binary: Mac Provider Inference CLI
 
-**Version:** 1.3 (2026-06-06, SPEC-010 v1.5 + SPEC-011 v0.5 absorption)
-**Revision:** v1.3 absorbs the binary-side surface of LOCKED SPEC-010 v1.5 (Provider Model Catalog) and LOCKED SPEC-011 v0.5 (Operator-Pushed Warm Swap), and adds the first normative documentation of the v2 `auth_request` two-stage handshake. L-1 baseline preserved: with neither `--supported-models` nor `--enable-warm-swap` set, a v1.3 binary introduces no NEW SPEC-010 or SPEC-011 fields, sockets, or runtime state beyond the SPEC-010 R-3.6.2 single-entry `supported_models: [model_id]` default emission, which SPEC-010 v1.5 §4.1 establishes as observably indistinguishable from a pre-SPEC-010 binary on routing, `/v1/status`, and `/v1/models`. The v2 `auth_request` first-connect frame type is unchanged from existing v1.2.x binaries (already in code per SPEC-010 v1.5 §3.1.A; v1.3 normatively documents the contract for the first time).
+**Version:** 1.3.1 (2026-06-11, M1-1 / XSEC-1 provider-token plumbing)
+**Revision:** v1.3.1 adds the `auth.provider_token` (yaml) /
+`MACPROVIDER_PROVIDER_TOKEN` (env) / `--provider-token` (CLI) config key
+and mandates the binary attach `Authorization: Bearer <token>` on the
+coordinator WS connect when the token is non-empty. Closes
+[XSEC-1](../audits/2026-06-10/REPO_AUDIT.md) — "Provider identity
+unauthenticated end-to-end" — for pinned providers. No change to the
+v2 ECDH handshake itself; the Bearer header is an HTTP-level credential
+checked at the WS upgrade (SPEC-002 v1.3.5 § auth) before the v2
+handshake starts. Backwards-compatible: a v1.3.1 binary with no
+provider_token configured sends no Authorization header, matching v1.3
+behavior, so a coordinator running with `auth.require_provider_tokens=false`
+continues to accept tokenless legacy fleets. Flag flip on the
+coordinator is the compatibility cutoff for old binaries.
+
+**Change log v1.3.1:**
+- **v1.3.1 (2026-06-11, M1-1 / XSEC-1):** Adds `auth.provider_token`
+  config key, triple-exposed per house convention
+  (yaml `auth.provider_token`, env `MACPROVIDER_PROVIDER_TOKEN`, CLI
+  `--provider-token`). When set, the binary attaches
+  `Authorization: Bearer <token>` to the coordinator WS connect
+  (`CoordinatorClient.swift` `openWebSocket`). When unset, no
+  Authorization header is sent. Token is redacted from logs (URL
+  redaction already in place; headers were never logged). The operator
+  is expected to chmod 0600 the config file containing this value.
+  Pinned-tier migration uses `coordinator-cli issue-token` to mint
+  per-provider tokens, write them into each provider's `macprovider.yaml`,
+  then flip `auth.require_provider_tokens=true` in the coordinator
+  config. v1.2.x and earlier binaries cannot send tokens; the flag flip
+  is the compatibility cutoff. Stranger / curl|bash onboarding token
+  flow is pending Open Question 2 (operator-issued vs self-serve
+  provisional). SPEC-002's normative surface is unchanged — the
+  validator already exists at `internal/ws/server.go:236-262`; the
+  binary now sends Bearer (was: nothing).
 
 **Change log v1.3:**
 - **v1.3 (2026-06-06, SPEC-010 v1.5 + SPEC-011 v0.5 absorption):** Adds binary-side surface for two now-LOCKED companion specs. SPEC-010 v1.5 adds `--supported-models` / `--publish-supported-models` flags, gains the two optional v2 `auth_request` initial-stage fields, gains local pre-flight validation per R-3.6.3. SPEC-011 v0.5 adds `--enable-warm-swap` opt-in gate, `--swap-drain-timeout-seconds`, `--ctl-socket-path`, `--switch-state-path` flags on `serve`; adds the `models` subcommand with `list / switch / status` actions; mandates a `ModelRuntime` refactor from immutable `let container` to actor-isolated mutable `current_container` with an atomic-swap state machine; adds an opt-in heartbeat extension carrying `model_hash` (raw lowercase hex) and `loading: bool`; adds a newline-delimited JSON control socket protocol on a macOS-native `$TMPDIR`-based path. ALSO adds a new normative §6.7 v2 `auth_request` handshake section — the v2 contract has been in code since v1.2.x but was never normatively documented in SPEC-001; v1.3 closes that gap. L-1 baseline preserved: with neither flag set, a v1.3 binary introduces no NEW SPEC-010/SPEC-011 fields, sockets, or runtime state beyond the SPEC-010 R-3.6.2 single-entry `supported_models: [model_id]` default (which SPEC-010 v1.5 §4.1 establishes as observably indistinguishable from a pre-SPEC-010 binary on routing, `/v1/status`, and `/v1/models`).

--- a/specs/SPEC-001-phase3-binary.md
+++ b/specs/SPEC-001-phase3-binary.md
@@ -1,7 +1,7 @@
 # SPEC-001 — Phase 3 Binary: Mac Provider Inference CLI
 
 **Version:** 1.3.1 (2026-06-11, M1-1 / XSEC-1 provider-token plumbing)
-**Revision:** v1.3.1 adds the `auth.provider_token` (yaml) /
+**Revision:** v1.3.1 adds the `provider_token` (yaml, top-level) /
 `MACPROVIDER_PROVIDER_TOKEN` (env) / `--provider-token` (CLI) config key
 and mandates the binary attach `Authorization: Bearer <token>` on the
 coordinator WS connect when the token is non-empty. Closes
@@ -10,25 +10,34 @@ unauthenticated end-to-end" — for pinned providers. No change to the
 v2 ECDH handshake itself; the Bearer header is an HTTP-level credential
 checked at the WS upgrade (SPEC-002 v1.3.5 § auth) before the v2
 handshake starts. Backwards-compatible: a v1.3.1 binary with no
-provider_token configured sends no Authorization header, matching v1.3
+`provider_token` configured sends no Authorization header, matching v1.3
 behavior, so a coordinator running with `auth.require_provider_tokens=false`
 continues to accept tokenless legacy fleets. Flag flip on the
 coordinator is the compatibility cutoff for old binaries.
 
 **Change log v1.3.1:**
-- **v1.3.1 (2026-06-11, M1-1 / XSEC-1):** Adds `auth.provider_token`
-  config key, triple-exposed per house convention
-  (yaml `auth.provider_token`, env `MACPROVIDER_PROVIDER_TOKEN`, CLI
-  `--provider-token`). When set, the binary attaches
+- **v1.3.1 (2026-06-11, M1-1 / XSEC-1):** Adds top-level
+  `provider_token` config key, triple-exposed per house convention
+  (yaml `provider_token`, env `MACPROVIDER_PROVIDER_TOKEN`, CLI
+  `--provider-token`). Note: this is **flat**, not nested under
+  `auth:`, matching the rest of the binary's flat
+  `~/.config/macprovider/config.yaml` schema (the `auth.<flag>`
+  spelling refers to the COORDINATOR-side `coordinator.yaml` and is
+  not the binary's config layout). When set, the binary attaches
   `Authorization: Bearer <token>` to the coordinator WS connect
   (`CoordinatorClient.swift` `openWebSocket`). When unset, no
   Authorization header is sent. Token is redacted from logs (URL
-  redaction already in place; headers were never logged). The operator
-  is expected to chmod 0600 the config file containing this value.
-  Pinned-tier migration uses `coordinator-cli issue-token` to mint
-  per-provider tokens, write them into each provider's `macprovider.yaml`,
-  then flip `auth.require_provider_tokens=true` in the coordinator
-  config. v1.2.x and earlier binaries cannot send tokens; the flag flip
+  redaction already in place; headers were never logged; the default
+  `webSocketFactory` now uses a dedicated `URLSession` with a
+  `NoRedirectURLSessionDelegate` that refuses HTTP redirects so the
+  Bearer header cannot leak to an attacker-controlled redirect
+  target — M1-1 follow-up after the 2026-06-11 codex security audit).
+  The operator is expected to chmod 0600 the config file containing
+  this value. Pinned-tier migration uses `coordinator-cli issue-token`
+  to mint per-provider tokens, write them into each provider's
+  `macprovider.yaml` as `provider_token: <token>`, then flip
+  `auth.require_provider_tokens=true` in the COORDINATOR config.
+  v1.2.x and earlier binaries cannot send tokens; the flag flip
   is the compatibility cutoff. Stranger / curl|bash onboarding token
   flow is pending Open Question 2 (operator-issued vs self-serve
   provisional). SPEC-002's normative surface is unchanged — the


### PR DESCRIPTION
Closes XSEC-1 from `audits/2026-06-10/REPO_AUDIT.md` (M1-1, pinned tier only).

> "Provider identity is effectively unauthenticated end-to-end on the live network ... a remote attacker can be admitted as a pinned provider, receive buyer inference attributed to a trusted Mac, serve arbitrary responses under its identity, and poison its billing/fault stats. The entire `internal/auth/tokens.go` token system is dead code for real providers."
> — REPO_AUDIT.md §3.1 item 1

## What this PR does

Wires the provider-side half of the existing coordinator token machinery. The coordinator already validates `Authorization: Bearer <token>` when `auth.require_provider_tokens=true` (`internal/ws/server.go:236-262`), the `coordinator-cli issue-token` CLI mints tokens, and the auth store hashes them. The binary previously never sent the header, so production had to run with `require_provider_tokens=false` — which also disabled the pinned-impersonation guard at `ws/server.go:602-619`.

## Changes

- **`MacProviderCore/Config.swift`** — `AppConfig` and `CLIOverrides` gain `providerToken: String?`. Triple-exposed per house convention:
  - yaml: `provider_token`
  - env: `MACPROVIDER_PROVIDER_TOKEN`
  - CLI: `--provider-token`
- **`macprovider-cli/MacProviderCLI.swift`** — new `--provider-token` flag. Help text explains it's a secret and advises `chmod 0600` on the config file.
- **`macprovider-cli/CoordinatorClient.swift`** — `webSocketFactory` signature changed from `(URL) -> ProviderWebSocketTask` to `(URLRequest) -> ...`. `openWebSocket` attaches `Authorization: Bearer <token>` when `providerToken` is non-empty. The token is trimmed and blank-guarded at construction; the binary never logs it (only the redacted URL appears in keepalive logs).
- **`SPEC-001-phase3-binary.md`** — changelog v1.3.1 documents the `auth.provider_token` key and the Bearer-on-connect contract.

## Tests

- 3 new tests in `CoordinatorClientTests.swift` covering both connect paths:
  - `testWebSocketConnectAttachesBearerAuthorizationWhenTokenConfigured_v1Plaintext`
  - `testWebSocketConnectAttachesBearerAuthorizationWhenTokenConfigured_v2Tier2`
  - `testWebSocketConnectOmitsAuthorizationWhenTokenUnset`
- All 162 Swift tests pass.
- Existing `TestProviderTokensRequiredFailsClosedWithoutValidator` already covers the coordinator side (tokenless connect → `CloseInvalidToken` when `require_provider_tokens=true`), so no new Go test added.

## Stranger-tier installer flow — DEFERRED

`phase3-binary/dist/install.sh:464-469` is **not modified** in this PR. The stranger / curl|bash onboarding flow is gated on **Open Question 2** (operator-issued tokens vs self-serve provisional tokens minted at first admission). The PR description for the follow-up will land based on that answer.

## Production migration (operator-only)

1. Use `coordinator-cli issue-token --provider-id M1/M4/air8gb` against Pearl to mint pinned-tier tokens; copy each show-once value securely to that Mac.
2. Update each provider's `macprovider.yaml` with `auth.provider_token: <token>` (`chmod 0600`); `systemctl restart` the provider service.
3. Verify all 3 providers heartbeat with a validated token in coordinator logs (grep `provider_token_validated`).
4. Flip `require_provider_tokens=true` in Pearl's `coordinator.yaml`; SIGHUP the coordinator. Verify all 3 providers re-auth cleanly; verify a fresh tokenless connect attempt is now rejected (curl wss test or equivalent).
5. Old v1.2.x binaries cannot send tokens — the flag flip IS the compatibility cutoff. Document this in `DECISION_CRITERIA.md`.

## Audit refs

- XSEC-1: `audits/2026-06-10/REPO_AUDIT.md` §3.1 item 1 (completeness-critic finding, High)
- SECU-6: §3.4 (provider-reported token counts trusted within a cap) — partially mitigated by authenticating provider identity here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
