### PR TITLE
m2-6: coordinator README + root Makefile (DEVE-6, DOCS-8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,11 @@ jobs:
           go-version-file: phase4-coordinator/go.mod
           cache-dependency-path: phase4-coordinator/go.sum
 
-      - name: go vet
-        working-directory: phase4-coordinator
-        run: go vet ./...
+      - name: make vet-coordinator
+        run: make vet-coordinator
 
-      - name: go test
-        working-directory: phase4-coordinator
-        run: go test ./...
+      - name: make test-coordinator
+        run: make test-coordinator
 
   gateway:
     name: phase5-gateway (go vet + test)
@@ -54,10 +52,8 @@ jobs:
           go-version-file: phase5-gateway/go.mod
           cache-dependency-path: phase5-gateway/go.sum
 
-      - name: go vet
-        working-directory: phase5-gateway
-        run: go vet ./...
+      - name: make vet-gateway
+        run: make vet-gateway
 
-      - name: go test
-        working-directory: phase5-gateway
-        run: go test ./...
+      - name: make test-gateway
+        run: make test-gateway

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# Root Makefile — one entry point for both Go services.
+#
+# Contributors: `make test` runs every Go test in the repo. `make vet` is
+# the same for static checks. Per the 2026-06-10 audit (DEVE-6 / DOCS-8):
+# keep CI and local on the same targets. CI jobs use the per-service
+# targets below to preserve parallel jobs and failure isolation.
+
+.PHONY: test test-coordinator test-gateway \
+        vet vet-coordinator vet-gateway \
+        build-linux check fmt
+
+test: test-coordinator test-gateway
+
+test-coordinator:
+	cd phase4-coordinator && go test ./...
+
+test-gateway:
+	cd phase5-gateway && go test ./...
+
+vet: vet-coordinator vet-gateway
+
+vet-coordinator:
+	cd phase4-coordinator && go vet ./...
+
+vet-gateway:
+	cd phase5-gateway && go vet ./...
+
+build-linux:
+	phase4-coordinator/scripts/build-linux.sh
+	phase5-gateway/scripts/build-linux.sh
+
+check:
+	phase4-coordinator/dist/check-deploy-config.sh \
+		phase4-coordinator/dist/coordinator.yaml \
+		phase5-gateway/dist/gateway.yaml
+
+fmt:
+	cd phase4-coordinator && gofmt -w .
+	cd phase5-gateway && gofmt -w .

--- a/phase4-coordinator/README.md
+++ b/phase4-coordinator/README.md
@@ -1,0 +1,70 @@
+# Mac Provider Coordinator
+
+Phase 4 coordinator — the hub of the MacProvider network. Provider Macs connect over WebSocket; buyer requests arrive over HTTP (proxied through `phase5-gateway`). The coordinator owns the provider pool, routing and failover, the request log, the billing ledger, and the explorer UI. Money math lives in `internal/billing/`; see `phase5-gateway/README.md` for buyer identity, quotas, and the public API gateway.
+
+## Local Development
+
+```sh
+cd phase4-coordinator
+cp coordinator.yaml.example coordinator.yaml
+export COORDINATOR_OPERATOR_KEY=dev-operator-key
+go test ./...
+go run ./cmd/coordinator -config=coordinator.yaml
+```
+
+By default the coordinator binds two ports on `127.0.0.1`:
+
+- `provider_port: 8444` — WebSocket `/ws/provider` for provider Macs, plus operator endpoints (`/poolz`, `/admin/*`, `/ledger/*`) guarded by the operator key.
+- `buyer_port: 8443` — buyer-facing HTTP (`/v1/chat/completions`, `/v1/models`). In production this is reached only through the gateway over loopback.
+
+## Using `mockprovider`
+
+`tools/mockprovider/main.go` is a standalone in-process mock of a Phase 3 provider binary. It connects to the coordinator over WS, behaves like a Tier-1 provider, and serves a local OpenAI-compatible HTTP endpoint the coordinator proxies to. Used by `scripts/run-local-pool.sh` and the AC-2/3/6 shell tests:
+
+```sh
+go run ./tools/mockprovider -coordinator ws://127.0.0.1:8444/ws/provider -provider-id mock-1
+```
+
+`scripts/run-local-pool.sh` brings up the coordinator plus one or more mockproviders against a temp SQLite DB and is the fastest path to a working local routing setup.
+
+## Critical Test Sets
+
+```sh
+go test ./internal/billing/...       # ledger math, settle/refund, idempotency
+go test ./internal/requestlog/...    # WriteHotPath atomic tx + quarantine
+go test ./internal/ws/...            # admission, hello/auth, frame handling
+go test ./internal/pool/...          # registry, routing/failover, breakers
+go test ./internal/buyer/...         # the public buyer API + handleChatCompletions
+go test ./... -race                  # race-clean is required before deploy
+```
+
+The full suite (`go test ./...`) is the only required gate; the named subsets are the ones most often run during money-path edits.
+
+## Cross-Compile For Linux
+
+Production builds run on Apple Silicon and ship to a linux/amd64 VPS. CGO-free `modernc.org/sqlite` makes this a one-liner:
+
+```sh
+scripts/build-linux.sh           # version-stamped via git describe; refuses dirty trees
+```
+
+Output: `dist/coordinator-linux-amd64`. Override the dirty guard with `FORCE_DIRTY=1` (the version string then ends in `-dirty` or `-dirty-forced` so `/healthz` can self-identify the override at deploy time — see `dist/check-deploy-config.sh` and the M0-5 deploy-rollback story).
+
+## Deployment
+
+Deployment is operator-driven. See `dist/deploy-pearl-vps.sh` for the scripted path (drift check, snapshot, restart, post-restart provenance assertion) and root [`OPS.md`](../OPS.md) for production topology, safe-restart procedure, settlement, and incident response.
+
+## Layout
+
+| Path | What |
+|---|---|
+| `cmd/coordinator/` | Composition root, config loading, signal handling |
+| `internal/billing/` | Credit ledger math (integer credits, overflow-checked) and persistence |
+| `internal/buyer/` | Buyer HTTP API including `handleChatCompletions` and failover |
+| `internal/pool/` | Provider registry, routing, breakers, swap audit |
+| `internal/ws/` | Provider WS lifecycle, admission, hello/auth, frame routing |
+| `internal/requestlog/` | Append-only request log with quarantine fallback |
+| `internal/auth/` | Provider-token store, operator-key validation |
+| `internal/tier2/` | Tier-2 trust disclosure (encrypted leg, attestation, behavioral safety) |
+| `internal/explorer/` | Read-only explorer UI handlers |
+| `tools/mockprovider/` | Standalone WS-speaking provider mock for local + CI |


### PR DESCRIPTION
Closes **DEVE-6** + **DOCS-8** from `audits/2026-06-10/REPO_AUDIT.md` §3.8 / §3.9.

Audit WHY (one-sentence quote):
> "a fresh contributor can clone, `make test`, and get a green run without reading any other doc; CI uses make targets."

## Summary

- New `phase4-coordinator/README.md` (no README existed) modeled on `phase5-gateway/README.md` (the audit's identified house template). Covers Overview, Local development, mockprovider, the two-port layout, named critical test sets, Linux cross-compile via `scripts/build-linux.sh`, and a layout map. Deployment pointer references the OPS.md that lands in M2-8.
- New root `Makefile` with aggregate `test`/`vet` plus per-service `test-coordinator`/`test-gateway`/`vet-coordinator`/`vet-gateway` helpers, and `build-linux`/`check`/`fmt`. The audit asked for aggregate-only targets; per-service variants are added so CI keeps parallel jobs and failure isolation while contributors still get the one-command local entry point (`make test`).
- `.github/workflows/ci.yml` now invokes `make vet-coordinator` / `make test-coordinator` and the gateway equivalents — CI and local share one entry point.

## Test plan
- [ ] CI green on this branch (both jobs use the new make targets)
- [ ] `make test` runs the full corpus locally
- [ ] `make vet` clean
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
