### PR TITLE
m2-5: ProvisionalRetentionDays pruner + bound seenModels (XPERF-2, PERF-5)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -173,6 +173,7 @@ func main() {
 	billingStore.StartWeeklySettlement(shutdownCtx, cfg.Settlement)
 	startRequestLogRetentionPruner(shutdownCtx, reqLogStore, cfg.Storage.RequestLogRetentionDays, logger)
 	startAuditLogRetentionPruner(shutdownCtx, auditStore, cfg.Storage.AuditLogRetentionDays, logger)
+	startAdmissionRetentionPruner(shutdownCtx, wsServer.Admission(), cfg.Admission.ProvisionalRetentionDays, logger)
 
 	go func() {
 		logger.Info().Str("addr", providerAddr).Msg("provider websocket server listening")
@@ -240,6 +241,49 @@ func startRequestLogRetentionPruner(ctx context.Context, store requestLogPruner,
 		}
 	}
 	prune()
+	go func() {
+		ticker := time.NewTicker(24 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				prune()
+			}
+		}
+	}()
+}
+
+// admissionPruner is the interface satisfied by *ws.AdmissionManager.Prune.
+// Kept narrow so tests can substitute a stub.
+type admissionPruner interface {
+	Prune(cutoff time.Time) (deletedRecords, deletedRejected, deletedTimePoints int)
+}
+
+// startAdmissionRetentionPruner wires ProvisionalRetentionDays
+// (coordinator.yaml admission.provisional_retention_days, default 30)
+// into the daily retention loop. M2-5 / XPERF-2: the config knob existed
+// since SPEC-003 but no code path consumed it.
+func startAdmissionRetentionPruner(ctx context.Context, mgr admissionPruner, retentionDays int, logger zerolog.Logger) {
+	if mgr == nil || retentionDays <= 0 {
+		return
+	}
+	prune := func() {
+		cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
+		records, rejected, timePoints := mgr.Prune(cutoff)
+		if records > 0 || rejected > 0 || timePoints > 0 {
+			logger.Info().
+				Int("deleted_records", records).
+				Int("deleted_rejected", rejected).
+				Int("deleted_time_points", timePoints).
+				Time("cutoff", cutoff).
+				Msg("admission state retention pruned")
+		}
+	}
+	prune()
+	nextRun := time.Now().UTC().Add(24 * time.Hour)
+	logger.Info().Time("next_prune_at", nextRun).Int("retention_days", retentionDays).Msg("admission state retention pruner armed")
 	go func() {
 		ticker := time.NewTicker(24 * time.Hour)
 		defer ticker.Stop()

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -126,11 +126,21 @@ func (p Provider) IsWSTunneled() bool {
 }
 
 type Registry struct {
-	mu                    sync.RWMutex
-	providers             map[string]*Provider
-	sessions              map[string]*Provider
-	endpoints             map[string]config.ProviderConfig
-	seenModels            map[string]struct{}
+	mu        sync.RWMutex
+	providers map[string]*Provider
+	sessions  map[string]*Provider
+	endpoints map[string]config.ProviderConfig
+	// seenModelsByProvider tracks the model IDs ever reported by each
+	// currently-connected provider. M2-5 / PERF-5: previously a single
+	// registry-wide `seenModels map[string]struct{}` accumulated forever
+	// (no cleanup on provider removal); per the 2026-06-10 audit it could
+	// outgrow the pool unboundedly. Now keyed by providerID and dropped
+	// on RemoveIfSession / RemoveIfSessionState, with a per-provider cap
+	// to bound a single provider's contribution. ModelKnown is a view
+	// over currently-connected providers' sets — so when a provider
+	// disconnects, models only it had reported correctly disappear from
+	// the global "seen" answer.
+	seenModelsByProvider  map[string]map[string]struct{}
 	breakerFaults         map[string][]time.Time
 	recoveryHolds         map[string]recoveryHold
 	lastBreakerRecoveries map[string]time.Time
@@ -138,6 +148,13 @@ type Registry struct {
 	hashVerifier          HeartbeatHashVerifier
 	swapEmitter           SwapEventEmitter
 }
+
+// maxSeenModelsPerProvider caps the seenModelsByProvider inner set so a
+// single misbehaving provider can't blow up memory. 32 is several orders
+// of magnitude above legitimate use (a real provider serves 1-2 models
+// at a time); reaching this cap silently drops further model IDs.
+// M2-5 / PERF-5.
+const maxSeenModelsPerProvider = 32
 
 type recoveryHold struct {
 	assignedID string
@@ -153,7 +170,7 @@ func NewRegistry(providers []config.ProviderConfig, opts ...RegistryOption) *Reg
 		providers:             map[string]*Provider{},
 		sessions:              map[string]*Provider{},
 		endpoints:             endpoints,
-		seenModels:            map[string]struct{}{},
+		seenModelsByProvider:  map[string]map[string]struct{}{},
 		breakerFaults:         map[string][]time.Time{},
 		recoveryHolds:         map[string]recoveryHold{},
 		lastBreakerRecoveries: map[string]time.Time{},
@@ -191,11 +208,35 @@ func (r *Registry) Register(p *Provider, conn net.Conn) (old net.Conn) {
 	}
 	r.providers[p.ProviderID] = p
 	r.sessions[p.AssignedID] = p
-	r.seenModels[p.ModelID] = struct{}{}
+	r.recordSeenModelLocked(p.ProviderID, p.ModelID)
 	delete(r.breakerFaults, p.ProviderID)
 	delete(r.recoveryHolds, p.ProviderID)
 	delete(r.lastBreakerRecoveries, p.ProviderID)
 	return old
+}
+
+// recordSeenModelLocked records a model id under a provider's set,
+// respecting the per-provider cap. Caller must hold r.mu in WRITE mode.
+func (r *Registry) recordSeenModelLocked(providerID, modelID string) {
+	if providerID == "" || modelID == "" {
+		return
+	}
+	set, ok := r.seenModelsByProvider[providerID]
+	if !ok {
+		set = map[string]struct{}{}
+		r.seenModelsByProvider[providerID] = set
+	}
+	if _, already := set[modelID]; already {
+		return
+	}
+	if len(set) >= maxSeenModelsPerProvider {
+		// Cap is well above legitimate use; reaching it means this
+		// provider is misbehaving or buggy. Silent-drop is operationally
+		// safe — ModelKnown still answers true via the currently-connected
+		// provider's live ModelID field.
+		return
+	}
+	set[modelID] = struct{}{}
 }
 
 func (r *Registry) SetTier(providerID string, tier Tier) (Provider, bool) {
@@ -516,7 +557,7 @@ func (r *Registry) ApplyHeartbeat(providerID, assignedID string, hb HeartbeatUpd
 	p.SlotsFree = hb.SlotsFree
 	p.SlotsTotal = hb.SlotsTotal
 	p.ThroughputTPSEstimate = hb.ThroughputTPSEstimate
-	r.seenModels[hb.ModelID] = struct{}{}
+	r.recordSeenModelLocked(p.ProviderID, hb.ModelID)
 	if hb.Status != "" && hb.Status != p.State {
 		if r.canApplyProviderStateLocked(p, hb.Status) {
 			r.setStateLocked(p, hb.Status)
@@ -586,9 +627,18 @@ func (r *Registry) ModelKnown(modelID string) bool {
 			return true
 		}
 	}
-	for seen := range r.seenModels {
-		if strings.EqualFold(seen, modelID) {
-			return true
+	// M2-5 / PERF-5: iterate per-provider seenModels (only entries for
+	// currently-connected providers, since RemoveIfSession{,State} drop
+	// the inner map). The pre-M2-5 behaviour was a registry-wide
+	// accumulator that retained models from disconnected providers
+	// forever — a memory leak the audit flagged. The new semantic is
+	// "known iff a currently-connected provider has at any point served
+	// it during its current session."
+	for _, set := range r.seenModelsByProvider {
+		for seen := range set {
+			if strings.EqualFold(seen, modelID) {
+				return true
+			}
 		}
 	}
 	return false
@@ -629,6 +679,7 @@ func (r *Registry) RemoveIfSession(providerID, assignedID string) bool {
 	}
 	delete(r.providers, providerID)
 	delete(r.sessions, assignedID)
+	delete(r.seenModelsByProvider, providerID)
 	r.clearBreakerStateLocked(providerID)
 	return true
 }
@@ -642,6 +693,7 @@ func (r *Registry) RemoveIfSessionState(providerID, assignedID string, state Sta
 	}
 	delete(r.providers, providerID)
 	delete(r.sessions, assignedID)
+	delete(r.seenModelsByProvider, providerID)
 	r.clearBreakerStateLocked(providerID)
 	return true
 }

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -194,6 +194,15 @@ func (r *Registry) Register(p *Provider, conn net.Conn) (old net.Conn) {
 	if existing := r.providers[p.ProviderID]; existing != nil {
 		old = existing.conn
 		delete(r.sessions, existing.AssignedID)
+		// M2-5: this is a session replacement (same provider_id, new
+		// assigned_id). The "currently-connected session only" invariant
+		// for ModelKnown requires the stale model history to be cleared
+		// here too — RemoveIfSession{,State} only fire on clean
+		// disconnect, not on this direct replacement path. Without this
+		// delete, model ids from the prior session would survive into
+		// the new one and ModelKnown would over-report. (Codex code-audit
+		// 2026-06-11 #47.)
+		delete(r.seenModelsByProvider, p.ProviderID)
 	}
 	p.conn = conn
 	if p.Tier == "" {

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -600,6 +600,59 @@ func TestModelKnownShrinksOnProviderDisconnect(t *testing.T) {
 	}
 }
 
+// TestRegisterReplaceSessionClearsSeenModels pins the M2-5 / PERF-5 fix for the
+// codex code-audit 2026-06-11 #47 finding: a session replacement (same
+// provider_id, new assigned_id) MUST clear the per-provider seen-model
+// history, else stale model ids from the prior session survive into the
+// new one and ModelKnown over-reports.
+func TestRegisterReplaceSessionClearsSeenModels(t *testing.T) {
+	registry := NewRegistry(nil)
+	start := time.Unix(1716768000, 0).UTC()
+
+	// Session 1: register p1@s1 reporting model-a, heartbeat in model-b.
+	registry.Register(&Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s1",
+		ModelID:          "model-a",
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start,
+		LastActivityAt:   start,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+	registry.ApplyHeartbeat("p1", "s1", heartbeatUpdateAt("model-b", start.Add(time.Minute)))
+	if !registry.ModelKnown("model-a") || !registry.ModelKnown("model-b") {
+		t.Fatal("session-1 seen models not recorded")
+	}
+
+	// Session 2 replaces session 1 with a different model entirely.
+	// (Same provider_id, new assigned_id — the direct-replacement path
+	// inside Register, not the RemoveIfSession path.)
+	registry.Register(&Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s2",
+		ModelID:          "model-c",
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start.Add(2 * time.Minute),
+		LastActivityAt:   start.Add(2 * time.Minute),
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+	if !registry.ModelKnown("model-c") {
+		t.Fatal("session-2 model not recorded after replacement")
+	}
+	if registry.ModelKnown("model-a") {
+		t.Fatal("ModelKnown(model-a) leaked across session replacement; prior history should be cleared")
+	}
+	if registry.ModelKnown("model-b") {
+		t.Fatal("ModelKnown(model-b) leaked across session replacement; prior history should be cleared")
+	}
+}
+
 // TestSeenModelsCappedPerProvider pins the M2-5 / PERF-5 per-provider cap.
 // A single misbehaving provider cannot grow its inner set without bound.
 func TestSeenModelsCappedPerProvider(t *testing.T) {

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -554,6 +554,82 @@ func TestApplyHeartbeatSwapEmitterDoesNotFireWhenNoPriorLoading(t *testing.T) {
 	}
 }
 
+// TestModelKnownShrinksOnProviderDisconnect pins the M2-5 / PERF-5
+// guarantee: ModelKnown answers from currently-connected providers only.
+// Pre-M2-5 the registry-wide seenModels map accumulated forever — a
+// 31-day model id observed once still answered true 1y later.
+func TestModelKnownShrinksOnProviderDisconnect(t *testing.T) {
+	registry := NewRegistry(nil)
+	start := time.Unix(1716768000, 0).UTC()
+
+	registry.Register(&Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s1",
+		ModelID:          "model-a",
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start,
+		LastActivityAt:   start,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+
+	if !registry.ModelKnown("model-a") {
+		t.Fatal("ModelKnown(model-a) = false while p1 is connected reporting it")
+	}
+	// Heartbeat with a different model id — that model is also seen.
+	registry.ApplyHeartbeat("p1", "s1", heartbeatUpdateAt("model-b", start.Add(time.Minute)))
+	if !registry.ModelKnown("model-b") {
+		t.Fatal("ModelKnown(model-b) = false after p1 reported it via heartbeat")
+	}
+	// model-a should still be remembered (p1 reported it earlier this session).
+	if !registry.ModelKnown("model-a") {
+		t.Fatal("ModelKnown(model-a) = false; per-session memory regressed")
+	}
+	// Disconnect p1 — both models it ever reported should drop from the
+	// global view.
+	if !registry.RemoveIfSession("p1", "s1") {
+		t.Fatal("RemoveIfSession returned false")
+	}
+	if registry.ModelKnown("model-a") {
+		t.Fatal("ModelKnown(model-a) still true after the only provider serving it disconnected — leak (PERF-5)")
+	}
+	if registry.ModelKnown("model-b") {
+		t.Fatal("ModelKnown(model-b) still true after the only provider serving it disconnected — leak (PERF-5)")
+	}
+}
+
+// TestSeenModelsCappedPerProvider pins the M2-5 / PERF-5 per-provider cap.
+// A single misbehaving provider cannot grow its inner set without bound.
+func TestSeenModelsCappedPerProvider(t *testing.T) {
+	registry := NewRegistry(nil)
+	start := time.Unix(1716768000, 0).UTC()
+	registry.Register(&Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s1",
+		ModelID:          "model-0",
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start,
+		LastActivityAt:   start,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+	// Drive the per-provider set well past the cap with 200 distinct model ids.
+	for i := 0; i < 200; i++ {
+		modelID := "model-" + itoaForTest(i)
+		registry.ApplyHeartbeat("p1", "s1", heartbeatUpdateAt(modelID, start.Add(time.Duration(i+1)*time.Second)))
+	}
+	registry.mu.RLock()
+	got := len(registry.seenModelsByProvider["p1"])
+	registry.mu.RUnlock()
+	if got > maxSeenModelsPerProvider {
+		t.Fatalf("seenModelsByProvider[p1] = %d entries, want <= %d (cap)", got, maxSeenModelsPerProvider)
+	}
+}
+
 func TestApplyHeartbeatSwapEmitterNilDoesNotCrash(t *testing.T) {
 	registry := NewRegistry(nil)
 	start := time.Unix(1716768000, 0).UTC()
@@ -574,6 +650,23 @@ func assertProviderReady(t *testing.T, registry *Registry, lastActivityAt time.T
 	if provider.State != StateReady || provider.SlotsFree != 1 || !provider.LastActivityAt.Equal(lastActivityAt) {
 		t.Fatalf("provider = %#v, want ready unchanged with last_activity_at %s", provider, lastActivityAt)
 	}
+}
+
+// itoaForTest is a tiny stdlib-free integer-to-string for test loops
+// that need distinct model ids. The pool package already avoids strconv;
+// keep that style here.
+func itoaForTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
 }
 
 func registerHeartbeatProvider(t *testing.T, registry *Registry, modelID, modelHash string, hashStatus HashStatus, at time.Time) {

--- a/phase4-coordinator/internal/ws/admission.go
+++ b/phase4-coordinator/internal/ws/admission.go
@@ -206,6 +206,58 @@ func (a *AdmissionManager) Records(connected map[string]bool) []ProvisionalRecor
 	return out
 }
 
+// Prune drops provisional state older than cutoff:
+//   - records with LastSeenAt strictly before cutoff (the provider hasn't
+//     re-admitted within the retention window)
+//   - per-provider request-window timestamps strictly before cutoff
+//   - operator-rejected entries whose record was pruned (rejections
+//     expire alongside the provisional record they were aimed at —
+//     if the provider re-appears later it goes through the rate-limiter
+//     fresh, which is the operator's effective intent: the rejection
+//     was about the activity, not the identity-forever)
+//   - admission timestamps strictly before cutoff
+//
+// On every removal the SQLite persistence blob is rewritten so a restart
+// reads the pruned state directly. Returns the number of records,
+// rejected entries, and total time-points removed (admissions +
+// requestWindow entries). M2-5 / XPERF-2: wired into the daily retention
+// loop in cmd/coordinator/main.go alongside the request_log + audit_log
+// pruners.
+func (a *AdmissionManager) Prune(cutoff time.Time) (deletedRecords, deletedRejected, deletedTimePoints int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for id, rec := range a.records {
+		if rec == nil || rec.LastSeenAt.Before(cutoff) {
+			delete(a.records, id)
+			delete(a.requestWindows, id)
+			deletedRecords++
+		}
+	}
+	for id := range a.rejected {
+		if _, hasRecord := a.records[id]; !hasRecord {
+			delete(a.rejected, id)
+			deletedRejected++
+		}
+	}
+	for id, window := range a.requestWindows {
+		before := len(window)
+		pruned := keepAfter(window, cutoff)
+		if len(pruned) == 0 {
+			delete(a.requestWindows, id)
+		} else {
+			a.requestWindows[id] = pruned
+		}
+		deletedTimePoints += before - len(pruned)
+	}
+	beforeAdmissions := len(a.admissions)
+	a.admissions = keepAfter(a.admissions, cutoff)
+	deletedTimePoints += beforeAdmissions - len(a.admissions)
+	if deletedRecords > 0 || deletedRejected > 0 || deletedTimePoints > 0 {
+		a.persistLocked()
+	}
+	return deletedRecords, deletedRejected, deletedTimePoints
+}
+
 func (a *AdmissionManager) persistLocked() {
 	if a.store == nil {
 		return

--- a/phase4-coordinator/internal/ws/admission_test.go
+++ b/phase4-coordinator/internal/ws/admission_test.go
@@ -110,3 +110,58 @@ func TestAdmissionManagerPersistenceSurvivesRestart(t *testing.T) {
 		t.Fatalf("reload state: %v", err)
 	}
 }
+
+// TestAdmissionManagerPruneShrinksStateBeyondCutoff pins the M2-5 / XPERF-2
+// guarantee: ProvisionalRetentionDays actually takes effect. Without the
+// pruner the existing admission state grew without bound — the audit
+// flagged the config knob was set to 30 days but referenced nowhere in
+// the ws package.
+func TestAdmissionManagerPruneShrinksStateBeyondCutoff(t *testing.T) {
+	base := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	cur := base
+	cfg := config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 1000,
+		ProvisionalPoolMax:              1000,
+		ProvisionalQuotaPerHour:         1000,
+		ProvisionalTierWeight:           0.3,
+		ProvisionalRetentionDays:        30,
+	}
+	adm := NewAdmissionManager(cfg, func() time.Time { return cur })
+
+	// Three old providers (>30d ago) and one fresh provider (today).
+	for _, id := range []string{"old-1", "old-2", "old-3"} {
+		if _, _, _ = adm.Admit(Hello{ProviderID: id, ModelID: "m"}, false, 0); false {
+		}
+	}
+	cur = base.AddDate(0, 0, 31)
+	if _, _, _ = adm.Admit(Hello{ProviderID: "fresh-1", ModelID: "m"}, false, 0); false {
+	}
+	adm.Reject("old-1", "operator dropped")
+	adm.Reject("fresh-1", "operator")
+
+	// Populate fresh-1's request window so the time-points counter is
+	// observable on the survivor. Do NOT reserve on the old records —
+	// TryReserveRequest bumps LastSeenAt to the current time, which would
+	// keep them alive past the cutoff.
+	adm.TryReserveRequest(pool.Provider{ProviderID: "fresh-1", Tier: pool.TierProvisional})
+
+	cutoff := cur.AddDate(0, 0, -cfg.ProvisionalRetentionDays)
+	deletedRecords, deletedRejected, _ := adm.Prune(cutoff)
+	if deletedRecords != 3 {
+		t.Fatalf("deleted records = %d, want 3 (old-1/old-2/old-3)", deletedRecords)
+	}
+	// old-1 rejection drops because its record dropped; fresh-1 rejection survives.
+	if deletedRejected != 1 {
+		t.Fatalf("deleted rejected = %d, want 1 (only old-1's; fresh-1 must stay)", deletedRejected)
+	}
+	records := adm.Records(map[string]bool{"fresh-1": true})
+	if len(records) != 1 || records[0].ProviderID != "fresh-1" {
+		t.Fatalf("records after prune = %+v, want only fresh-1", records)
+	}
+	if !adm.Rejected("fresh-1") {
+		t.Fatal("fresh rejection lost across prune (operator action must survive while record survives)")
+	}
+	if adm.Rejected("old-1") {
+		t.Fatal("old rejection survived prune (record was dropped, rejection should follow)")
+	}
+}


### PR DESCRIPTION
Closes **XPERF-2** (critic finding) + **PERF-5** from `audits/2026-06-10/REPO_AUDIT.md` §3.6.

Audit WHY (one-sentence quote):
> "The config knob `admission.provisional_retention_days` is set to 30 days but referenced NOWHERE in the ws package… `seenModels` declared as `map[string]struct{}`; writes without bounds; iterates it."

## Summary

**Part A — `ProvisionalRetentionDays` actually takes effect (XPERF-2)**
- New `AdmissionManager.Prune(cutoff time.Time)` in `internal/ws/admission.go`: drops `records` with `LastSeenAt < cutoff`, drops operator-rejected entries whose record was pruned (rejections expire alongside the provisional record they were aimed at), prunes per-provider `requestWindows` entries, and the global `admissions` timestamps. Rewrites the SQLite persistence blob when state changed.
- `cmd/coordinator/main.go` daily retention loop now calls `startAdmissionRetentionPruner` alongside `startRequestLogRetentionPruner` and `startAuditLogRetentionPruner`. Startup logs `next_prune_at` + `retention_days`.

**Part B — `seenModels` bounded per-provider (PERF-5)**
- `pool.Registry`'s registry-wide `seenModels` accumulator was never cleared — a model id observed once stayed "known" forever, even after the provider serving it left.
- Replaced with `seenModelsByProvider map[string]map[string]struct{}` keyed by `providerID`, dropped on `RemoveIfSession` / `RemoveIfSessionState`. Per-provider cap of `maxSeenModelsPerProvider = 32` (silent drop above the cap; legitimate providers serve 1–2 models).
- `ModelKnown` is now a view over currently-connected providers' inner sets.

## Tests

- `TestAdmissionManagerPruneShrinksStateBeyondCutoff` — 3 stale + 1 fresh provider; cutoff drops the 3, fresh-1 survives with its operator rejection; the rejection on a pruned record drops alongside it.
- `TestModelKnownShrinksOnProviderDisconnect` — `ModelKnown` returns true for two distinct models a provider reports during its session, then `false` for both after `RemoveIfSession` — directly pins the leak fix.
- `TestSeenModelsCappedPerProvider` — 200 distinct model ids through a single provider; final inner-set size ≤ 32.

## Test plan
- [ ] `go test ./... -race` green in `phase4-coordinator` (verified locally)
- [ ] Inspect new startup log: `admission state retention pruner armed next_prune_at=… retention_days=30`
- [ ] Confirm `ProvisionalRetentionDays = 0` disables the pruner (mirrors existing knobs)

Two follow-ups out of scope, noted in the audit prompt:
- `persistLocked()` is still called on every provisional request (rewrites the whole blob); restructuring to per-record INSERT/UPDATE is a deeper change → defer to M3 backlog.
- Logging dropped seen-model-ids requires either a callback option or a logger dep in `pool` — silent drop chosen; cap is operationally generous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
