### PR TITLE
m2-4 (Parts A+B): gateway read-only handle + reservation cleanup (PERF-1, PERF-4)

### DIFF
--- a/phase5-gateway/cmd/gateway/main.go
+++ b/phase5-gateway/cmd/gateway/main.go
@@ -52,6 +52,23 @@ func main() {
 		}
 	}()
 
+	// M2-4 / PERF-4: open a SECOND handle in read-only mode for the
+	// explorer + /v1/usage GET-only handlers. The primary handle is
+	// SetMaxOpenConns(1) so BEGIN IMMEDIATE writes serialize cleanly,
+	// but that also means a slow explorer query stalls ReserveQuota
+	// on the money path. The read handle is conn cap 4 and runs against
+	// the same WAL file, so reads compose with writes without contention.
+	readStore, err := sqlite.OpenReadOnly(ctx, cfg.Storage.DBPath)
+	if err != nil {
+		slog.Error("open read-only storage failed", "path", cfg.Storage.DBPath, "error", err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err := readStore.Close(); err != nil {
+			slog.Warn("close read-only storage failed", "error", err)
+		}
+	}()
+
 	slog.Info("gateway initialized", "address", cfg.Address(), "db_path", cfg.Storage.DBPath)
 	if *checkOnly {
 		return
@@ -72,7 +89,11 @@ func main() {
 	}
 	oauthClient := &http.Client{Timeout: 30 * time.Second}
 	oauth := auth.NewGitHubProvider(cfg.Auth.OAuth.GitHub, oauthClient)
-	httpServer := newHTTPServer(cfg.Address(), router.New(cfg, store, oauth, router.WithHTTPClient(coordinatorClient), router.WithVersion(version)).Handler())
+	httpServer := newHTTPServer(cfg.Address(), router.New(cfg, store, oauth,
+		router.WithHTTPClient(coordinatorClient),
+		router.WithVersion(version),
+		router.WithReadStore(readStore),
+	).Handler())
 	go func() {
 		slog.Info("gateway listening", "address", cfg.Address())
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -100,8 +121,14 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 	}
 }
 
+// terminalReservationRetention is the threshold below which terminal-state
+// quota_reservations rows carry no audit value (the usage_events row is
+// the durable record) — M2-4 / PERF-1 Part B.
+const terminalReservationRetention = 7 * 24 * time.Hour
+
 type reservationReaper interface {
 	ReapExpiredReservations(context.Context, time.Time) (int64, error)
+	DeleteTerminalQuotaReservations(context.Context, time.Time) (int64, error)
 }
 
 func runReservationReaper(ctx context.Context, store reservationReaper, interval time.Duration) {
@@ -109,13 +136,21 @@ func runReservationReaper(ctx context.Context, store reservationReaper, interval
 		interval = time.Hour
 	}
 	reap := func() {
-		n, err := store.ReapExpiredReservations(ctx, time.Now().UTC())
+		now := time.Now().UTC()
+		n, err := store.ReapExpiredReservations(ctx, now)
 		if err != nil {
 			slog.Warn("quota reservation reaper failed", "error", err)
-			return
-		}
-		if n > 0 {
+		} else if n > 0 {
 			slog.Info("expired quota reservations reaped", "count", n)
+		}
+		// M2-4 / PERF-1 Part B: after marking expired, prune terminal-state
+		// rows past the retention window. concurrency_reservations has an
+		// append-only trigger; only quota_reservations is touched here.
+		deleted, err := store.DeleteTerminalQuotaReservations(ctx, now.Add(-terminalReservationRetention))
+		if err != nil {
+			slog.Warn("quota reservation terminal-prune failed", "error", err)
+		} else if deleted > 0 {
+			slog.Info("terminal quota reservations pruned", "count", deleted, "retention_hours", int(terminalReservationRetention.Hours()))
 		}
 	}
 	reap()

--- a/phase5-gateway/internal/router/explorer.go
+++ b/phase5-gateway/internal/router/explorer.go
@@ -34,7 +34,7 @@ func (s *Server) handleExplorerBuyers(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(explorerQueryTimeoutMs)*time.Millisecond)
 	defer cancel()
-	out, err := s.store.ExplorerListBuyers(ctx, q)
+	out, err := s.readStore().ExplorerListBuyers(ctx, q)
 	if err != nil {
 		writeExplorerStorageError(w, err)
 		return
@@ -58,7 +58,7 @@ func (s *Server) handleExplorerBuyerDetail(w http.ResponseWriter, r *http.Reques
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(explorerQueryTimeoutMs)*time.Millisecond)
 	defer cancel()
-	out, err := s.store.ExplorerBuyerDetail(ctx, accountID, storage.ExplorerDetailQuery{
+	out, err := s.readStore().ExplorerBuyerDetail(ctx, accountID, storage.ExplorerDetailQuery{
 		From: window.from, To: window.to, Limit: parseExplorerLimit(r),
 	})
 	if err != nil {
@@ -79,7 +79,7 @@ func (s *Server) handleExplorerSessions(w http.ResponseWriter, r *http.Request) 
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(explorerQueryTimeoutMs)*time.Millisecond)
 	defer cancel()
-	out, err := s.store.ExplorerListSessions(ctx, storage.ExplorerSessionQuery{
+	out, err := s.readStore().ExplorerListSessions(ctx, storage.ExplorerSessionQuery{
 		From: window.from, To: window.to, AccountID: r.URL.Query().Get("account_id"),
 		Limit: parseExplorerLimit(r), Cursor: r.URL.Query().Get("cursor"),
 	})
@@ -101,7 +101,7 @@ func (s *Server) handleExplorerSessionDetail(w http.ResponseWriter, r *http.Requ
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(explorerQueryTimeoutMs)*time.Millisecond)
 	defer cancel()
-	out, err := s.store.ExplorerSessionDetail(ctx, requestID)
+	out, err := s.readStore().ExplorerSessionDetail(ctx, requestID)
 	if err != nil {
 		writeExplorerStorageError(w, err)
 		return
@@ -120,7 +120,7 @@ func (s *Server) handleExplorerActivity(w http.ResponseWriter, r *http.Request) 
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(explorerQueryTimeoutMs)*time.Millisecond)
 	defer cancel()
-	out, err := s.store.ExplorerActivity(ctx, storage.ExplorerActivityQuery{
+	out, err := s.readStore().ExplorerActivity(ctx, storage.ExplorerActivityQuery{
 		From: window.from, To: window.to, Type: r.URL.Query().Get("type"),
 		AccountID: r.URL.Query().Get("account_id"), RequestID: r.URL.Query().Get("request_id"),
 		Limit: parseExplorerLimit(r), Cursor: r.URL.Query().Get("cursor"),
@@ -149,7 +149,7 @@ func (s *Server) handleExplorerHealth(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(explorerQueryTimeoutMs)*time.Millisecond)
 	defer cancel()
-	out, err := s.store.ExplorerHealth(ctx, s.now().Add(-time.Duration(windowHours)*time.Hour))
+	out, err := s.readStore().ExplorerHealth(ctx, s.now().Add(-time.Duration(windowHours)*time.Hour))
 	if err != nil {
 		writeExplorerStorageError(w, err)
 		return

--- a/phase5-gateway/internal/router/readstore_test.go
+++ b/phase5-gateway/internal/router/readstore_test.go
@@ -1,0 +1,62 @@
+package router
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/augstar/macprovider-gateway/internal/storage"
+	"github.com/augstar/macprovider-gateway/internal/storage/sqlite"
+)
+
+// Compile-time assertion: *sqlite.Store satisfies router.ReadStore.
+// M2-4 / PERF-4: this is the boundary that makes WithReadStore typed
+// safely. If a future change to ReadStore adds a method *sqlite.Store
+// doesn't implement, this line stops the build.
+var _ ReadStore = (*sqlite.Store)(nil)
+
+// Compile-time assertion: the wider Store also satisfies ReadStore,
+// so readStore()'s fallback to s.store is sound.
+var _ ReadStore = (Store)(nil)
+
+// TestReadStoreBoundaryRejectsWritesAtCompileTime documents — for any
+// future reader — what `readStore() ReadStore` actually buys us.
+// Uncommenting the lines marked `// WANT: compile error` MUST refuse
+// to build. We don't actually execute write methods through readStore
+// here (that would be a runtime test); the value is the type-level
+// guard. Removing the ReadStore interface would silently let a write
+// compile.
+func TestReadStoreBoundaryRejectsWritesAtCompileTime(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gateway.db")
+	primary, err := sqlite.Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer primary.Close()
+
+	ro, err := sqlite.OpenReadOnly(ctx, path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer ro.Close()
+
+	// This is the type guard in action — assigning a *sqlite.Store to
+	// a ReadStore variable is fine; the narrow interface only exposes
+	// reads.
+	var rs ReadStore = ro
+	if _, _, err := rs.DailyUsage(ctx, "no-such-account", "2026-05-29"); err != nil {
+		t.Fatalf("DailyUsage via ReadStore: %v", err)
+	}
+
+	// WANT: compile error. Uncommenting these MUST break the build —
+	// they prove ReadStore is a genuine narrow surface, not a wider
+	// interface in disguise.
+	//
+	//   rs.CreateAccount(ctx, storage.Account{AccountID: "x"})
+	//   rs.SetCapacityTier(ctx, storage.CapacityTier{Tier: "tier_1"})
+	//   rs.ReserveQuota(ctx, storage.ReservationRequest{})
+	//   rs.SettleReservation(ctx, storage.ReservationSettlement{})
+	//   rs.InsertUsageEvent(ctx, storage.UsageEvent{})
+	_ = storage.Account{}
+}

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -33,9 +33,18 @@ import (
 const maxUpstreamResponseBodyBytes = int64(16 << 20)
 
 type Server struct {
-	cfg              config.Config
-	cfgPath          string
-	store            Store
+	cfg     config.Config
+	cfgPath string
+	store   Store
+	// readOnlyStore, when non-nil, backs GET-only handlers (explorer +
+	// /v1/usage). M2-4 / PERF-4: the primary `store` is capped at
+	// MaxOpenConns=1 to serialize BEGIN IMMEDIATE writes; a slow explorer
+	// query on the same handle blocks ReserveQuota on the money path.
+	// Routing reads through a second handle (opened by main.go via
+	// sqlite.OpenReadOnly with conn cap 4) lets SQLite WAL's concurrent-
+	// reader semantics absorb explorer load without touching the write
+	// path. When nil, handlers fall back to `store`.
+	readOnlyStore    Store
 	keyMgr           auth.KeyManager
 	demoMgr          auth.DemoManager
 	oauth            auth.OAuthProvider
@@ -51,6 +60,17 @@ type Server struct {
 	// 5s TTL — coordinator config only changes on reload, so staleness is
 	// harmless; cap on bursts.
 	routingMeta routingMetaCache
+}
+
+// readStore returns the read-only handle if registered, else the
+// primary store. M2-4: keep callers oblivious to whether the deployment
+// has the separate handle wired. Tests and the `-check` path use the
+// primary unconditionally; production wires both.
+func (s *Server) readStore() Store {
+	if s.readOnlyStore != nil {
+		return s.readOnlyStore
+	}
+	return s.store
 }
 
 type routingMetaCache struct {
@@ -101,6 +121,17 @@ func WithVersion(v string) Option {
 	return func(s *Server) {
 		if v != "" {
 			s.version = v
+		}
+	}
+}
+
+// WithReadStore registers a separate read-only Store handle for
+// GET-only handlers. See Server.readOnlyStore doc for the why
+// (M2-4 / PERF-4).
+func WithReadStore(store Store) Option {
+	return func(s *Server) {
+		if store != nil {
+			s.readOnlyStore = store
 		}
 	}
 }
@@ -527,12 +558,15 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	window := s.now().UTC().Format("2006-01-02")
-	used, reserved, err := s.store.DailyUsage(r.Context(), validation.AccountID, window)
+	// M2-4 / PERF-4: /v1/usage is a GET-only handler — read through
+	// the separate read-only handle so a hot explorer query can't
+	// stall a buyer-facing usage lookup.
+	used, reserved, err := s.readStore().DailyUsage(r.Context(), validation.AccountID, window)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "usage_load_failed", "Could not load usage")
 		return
 	}
-	keys, err := s.store.ListAPIKeys(r.Context(), validation.AccountID)
+	keys, err := s.readStore().ListAPIKeys(r.Context(), validation.AccountID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "keys_load_failed", "Could not load API keys")
 		return
@@ -543,7 +577,7 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 		remaining = 0
 	}
 	setRateLimitHeaders(w, limit, remaining, resetUnix(window))
-	tier, _ := s.store.GetCapacityTier(r.Context())
+	tier, _ := s.readStore().GetCapacityTier(r.Context())
 	writeJSON(w, http.StatusOK, map[string]any{
 		"account_id": validation.AccountID,
 		"quota": map[string]any{

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -44,7 +44,12 @@ type Server struct {
 	// sqlite.OpenReadOnly with conn cap 4) lets SQLite WAL's concurrent-
 	// reader semantics absorb explorer load without touching the write
 	// path. When nil, handlers fall back to `store`.
-	readOnlyStore    Store
+	//
+	// Typed as ReadStore (the narrow read-only view), so a write method
+	// invoked via readStore() is a COMPILE error, not a runtime mode=ro
+	// driver error. The DSN-level mode=ro+query_only(1) guard in
+	// internal/storage/sqlite stays as defense in depth.
+	readOnlyStore    ReadStore
 	keyMgr           auth.KeyManager
 	demoMgr          auth.DemoManager
 	oauth            auth.OAuthProvider
@@ -62,11 +67,14 @@ type Server struct {
 	routingMeta routingMetaCache
 }
 
-// readStore returns the read-only handle if registered, else the
-// primary store. M2-4: keep callers oblivious to whether the deployment
-// has the separate handle wired. Tests and the `-check` path use the
-// primary unconditionally; production wires both.
-func (s *Server) readStore() Store {
+// readStore returns the read-only view of the database. M2-4: this
+// is the canonical invariant location for "GET-only handlers MUST NOT
+// write" — it returns a ReadStore, so any attempt to call a write
+// method through it is a compile error. When no separate handle is
+// registered (tests, -check) we fall back to the primary Store, which
+// trivially implements ReadStore because Store embeds every sub-
+// interface ReadStore lists.
+func (s *Server) readStore() ReadStore {
 	if s.readOnlyStore != nil {
 		return s.readOnlyStore
 	}
@@ -88,6 +96,19 @@ type Store interface {
 	storage.CapacityStore
 	storage.HealthStore
 	storage.ExplorerStore
+}
+
+// ReadStore is the narrow, write-free view of the gateway database used
+// by GET-only handlers (explorer + /v1/usage). M2-4 / PERF-4: the
+// router routes reads through ReadStore so a future handler can't
+// accidentally call ReserveQuota / SettleReservation / SetCapacityTier
+// through readStore() — that's a compile error. Bound by what
+// router/explorer.go and the /v1/usage path actually call.
+type ReadStore interface {
+	storage.ExplorerStore
+	DailyUsage(ctx context.Context, accountID, windowDate string) (int64, int64, error)
+	ListAPIKeys(ctx context.Context, accountID string) ([]storage.APIKeySummary, error)
+	GetCapacityTier(ctx context.Context) (storage.CapacityTier, error)
 }
 
 type Option func(*Server)
@@ -125,10 +146,12 @@ func WithVersion(v string) Option {
 	}
 }
 
-// WithReadStore registers a separate read-only Store handle for
-// GET-only handlers. See Server.readOnlyStore doc for the why
-// (M2-4 / PERF-4).
-func WithReadStore(store Store) Option {
+// WithReadStore registers a separate read-only handle for GET-only
+// handlers. The argument is typed as ReadStore (the narrow,
+// write-free interface) so callers can pass any read-only
+// implementation; a *sqlite.Store opened via OpenReadOnly satisfies
+// it. See Server.readOnlyStore doc for the why (M2-4 / PERF-4).
+func WithReadStore(store ReadStore) Option {
 	return func(s *Server) {
 		if store != nil {
 			s.readOnlyStore = store

--- a/phase5-gateway/internal/storage/interfaces.go
+++ b/phase5-gateway/internal/storage/interfaces.go
@@ -60,6 +60,12 @@ type UsageStore interface {
 	InsertUsageEvent(ctx context.Context, event UsageEvent) error
 	DailyUsage(ctx context.Context, accountID, windowDate string) (usedTokens, activeReservedTokens int64, err error)
 	ReapExpiredReservations(ctx context.Context, now time.Time) (int64, error)
+	// DeleteTerminalQuotaReservations drops quota_reservations rows in a
+	// terminal status (expired / settled / refunded) whose settled_at is
+	// strictly before `before`. M2-4 / PERF-1 Part B. Implementations
+	// MUST leave concurrency_reservations alone — that table is protected
+	// by an append-only trigger (Q4 territory).
+	DeleteTerminalQuotaReservations(ctx context.Context, before time.Time) (int64, error)
 	AcquireConcurrency(ctx context.Context, req ConcurrencyRequest) (ConcurrencyDecision, error)
 	ReleaseConcurrency(ctx context.Context, accountID, requestID string, releasedAt time.Time) error
 }

--- a/phase5-gateway/internal/storage/sqlite/dsn.go
+++ b/phase5-gateway/internal/storage/sqlite/dsn.go
@@ -21,3 +21,34 @@ func sqliteDSN(path string) string {
 	}
 	return path + separator + values.Encode()
 }
+
+// sqliteReadOnlyDSN returns a read-only DSN for the same file in WAL mode.
+// Used by Open's `OpenReadOnly` counterpart (M2-4 / PERF-4) so the gateway
+// can route GET-only handlers (explorer, usage) through a separate handle
+// with a larger conn cap, while the primary handle stays capped at 1 to
+// serialize `BEGIN IMMEDIATE` writes.
+//
+// modernc.org/sqlite parses the standard `mode=ro` URI parameter for
+// open-time read-only intent. We also assert `query_only=1` as a
+// per-connection pragma so every connection in the pool is locked into
+// read mode at the SQLite engine level (defense in depth against an
+// accidental write routed through readStore()).
+func sqliteReadOnlyDSN(path string) string {
+	values := url.Values{}
+	values.Add("mode", "ro")
+	for _, pragma := range []string{
+		"busy_timeout=5000",
+		"foreign_keys=1",
+		// journal_mode is set by the primary writer; the read handle
+		// follows. synchronous pinned to NORMAL for parity.
+		"synchronous(NORMAL)",
+		"query_only(1)",
+	} {
+		values.Add("_pragma", pragma)
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + values.Encode()
+}

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -49,6 +49,34 @@ func Open(ctx context.Context, path string) (*Store, error) {
 	return store, nil
 }
 
+// OpenReadOnly opens a SECOND handle to the same database file in
+// read-only mode. M2-4 / PERF-4: the primary handle is capped at
+// MaxOpenConns=1 to serialize BEGIN IMMEDIATE writes, which means a
+// slow explorer query (e.g. `EXPLAIN`-unfriendly aggregate over
+// usage_events) blocks ReserveQuota on the money path. A separate
+// read-only handle with conn cap 4 leverages SQLite WAL's concurrent
+// reader semantics so explorer/status/usage GETs no longer share a
+// connection with writes.
+//
+// The caller is responsible for opening the writable Store first and
+// running Migrate(): the read-only DSN cannot create or evolve schema.
+func OpenReadOnly(ctx context.Context, path string) (*Store, error) {
+	if path == "" {
+		return nil, fmt.Errorf("sqlite db path must be set")
+	}
+	db, err := sql.Open("sqlite", sqliteReadOnlyDSN(path))
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(2)
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return &Store{db: db}, nil
+}
+
 func (s *Store) Close() error {
 	return s.db.Close()
 }
@@ -673,6 +701,42 @@ func (s *Store) ReapExpiredReservations(ctx context.Context, now time.Time) (int
 	}
 	defer tx.Rollback()
 	n, err := reapExpiredReservationsTx(ctx, tx, now)
+	if err != nil {
+		return 0, err
+	}
+	return n, tx.Commit()
+}
+
+// DeleteTerminalQuotaReservations removes quota_reservations rows in a
+// terminal status (expired / settled / refunded) whose settled_at is
+// strictly before `before`. M2-4 / PERF-1 Part B: terminal reservations
+// carry no audit value — the usage_events row is the durable record —
+// so they're safe to delete past a retention threshold. The caller picks
+// `before` (the reaper uses now - 7d).
+//
+// Only quota_reservations is touched here. concurrency_reservations has
+// a `concurrency_reservations_no_delete` BEFORE DELETE trigger that
+// forbids deletion; treating that as a Q4-gated decision per the audit's
+// PERF-1 / Open Q4 ("append-only-forever: requirement or default?").
+func (s *Store) DeleteTerminalQuotaReservations(ctx context.Context, before time.Time) (int64, error) {
+	if before.IsZero() {
+		return 0, fmt.Errorf("before time must be non-zero")
+	}
+	tx, err := s.beginImmediate(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+	res, err := tx.ExecContext(ctx, `
+		DELETE FROM quota_reservations
+		WHERE status IN ('expired', 'settled', 'refunded')
+		  AND settled_at IS NOT NULL
+		  AND settled_at < ?`,
+		encodeTime(before))
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
 	if err != nil {
 		return 0, err
 	}

--- a/phase5-gateway/internal/storage/sqlite/store_test.go
+++ b/phase5-gateway/internal/storage/sqlite/store_test.go
@@ -409,6 +409,104 @@ func TestExpiredReservationsReclaimedAfter24h(t *testing.T) {
 	}
 }
 
+// TestDeleteTerminalQuotaReservationsKeepsActiveAndDropsOld pins the
+// M2-4 / PERF-1 Part B contract: terminal-state rows past the retention
+// window are deletable; active rows (and recent terminal rows) survive.
+func TestDeleteTerminalQuotaReservationsKeepsActiveAndDropsOld(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	createAccount(t, store, "acct_delete_terminal")
+
+	// 100 reservations created 8 days ago and settled then — terminal,
+	// past the 7-day retention window.
+	oldAt := fixedTime().Add(-8 * 24 * time.Hour)
+	for i := 0; i < 100; i++ {
+		reqID := fmt.Sprintf("req_old_%03d", i)
+		if _, err := store.ReserveQuota(ctx, storage.ReservationRequest{
+			AccountID: "acct_delete_terminal", RequestID: reqID, WindowDate: "2026-05-21",
+			RequestedTokens: 1, DailyQuota: 1000000, CreatedAt: oldAt, ExpiresAt: oldAt.Add(24 * time.Hour),
+		}); err != nil {
+			t.Fatalf("ReserveQuota old #%d: %v", i, err)
+		}
+		if err := store.SettleReservation(ctx, storage.ReservationSettlement{
+			AccountID: "acct_delete_terminal", RequestID: reqID,
+			PromptTokens: 1, CompletionTokens: 0, TotalTokens: 1, MaxTotalTokens: 1000,
+			TokenSource: "provider_reported", Outcome: "ok", SettledAt: oldAt,
+		}); err != nil {
+			t.Fatalf("SettleReservation old #%d: %v", i, err)
+		}
+	}
+
+	// 10 active reservations created now — not yet terminal, must survive.
+	for i := 0; i < 10; i++ {
+		if _, err := store.ReserveQuota(ctx, storage.ReservationRequest{
+			AccountID: "acct_delete_terminal", RequestID: fmt.Sprintf("req_active_%02d", i),
+			WindowDate: "2026-05-29", RequestedTokens: 1, DailyQuota: 1000000,
+			CreatedAt: fixedTime(), ExpiresAt: fixedTime().Add(24 * time.Hour),
+		}); err != nil {
+			t.Fatalf("ReserveQuota active #%d: %v", i, err)
+		}
+	}
+
+	deleted, err := store.DeleteTerminalQuotaReservations(ctx, fixedTime().Add(-7*24*time.Hour))
+	if err != nil {
+		t.Fatalf("DeleteTerminalQuotaReservations: %v", err)
+	}
+	if deleted != 100 {
+		t.Fatalf("deleted = %d, want 100 (terminal rows >7d old)", deleted)
+	}
+
+	// Active rows untouched.
+	used, reserved, err := store.DailyUsage(ctx, "acct_delete_terminal", "2026-05-29")
+	if err != nil {
+		t.Fatalf("DailyUsage post-prune: %v", err)
+	}
+	if used != 0 || reserved != 10 {
+		t.Fatalf("post-prune used=%d reserved=%d, want 0/10", used, reserved)
+	}
+}
+
+// TestOpenReadOnlyServesReadsButNotWrites pins the M2-4 / PERF-4 design:
+// the read handle uses mode=ro so writes through it fail loudly. This
+// catches a regression where a future handler accidentally routes a
+// write through readStore().
+func TestOpenReadOnlyServesReadsButNotWrites(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gateway.db")
+	primary, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer primary.Close()
+	if err := primary.CreateAccount(ctx, storage.Account{
+		AccountID: "acct_ro_test", Status: "active", QuotaClass: "default", ConcurrencyClass: "default", CreatedAt: fixedTime(),
+	}); err != nil {
+		t.Fatalf("CreateAccount via primary: %v", err)
+	}
+
+	readStore, err := OpenReadOnly(ctx, path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer readStore.Close()
+
+	// Reads work.
+	used, reserved, err := readStore.DailyUsage(ctx, "acct_ro_test", "2026-05-29")
+	if err != nil {
+		t.Fatalf("DailyUsage via readStore: %v", err)
+	}
+	if used != 0 || reserved != 0 {
+		t.Fatalf("readStore DailyUsage = (%d,%d), want (0,0)", used, reserved)
+	}
+
+	// Writes fail (mode=ro at the SQLite driver level).
+	if err := readStore.CreateAccount(ctx, storage.Account{
+		AccountID: "acct_should_fail", Status: "active", QuotaClass: "default", ConcurrencyClass: "default", CreatedAt: fixedTime(),
+	}); err == nil {
+		t.Fatal("CreateAccount via read-only store unexpectedly succeeded; mode=ro guard is missing")
+	}
+}
+
 func TestConcurrentQuotaReservationsNoOverspend(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)


### PR DESCRIPTION
Closes **PERF-1** (Parts A + B) and **PERF-4** from `audits/2026-06-10/REPO_AUDIT.md` §3.6.

Audit WHY (one-sentence quote):
> "The gateway DB can never shrink: `RAISE(ABORT)` BEFORE-DELETE triggers… ≥3 permanent rows per request, forever, on a disk/RAM-constrained VPS."

## Part A — Read-only DB handle (PERF-4)

The gateway's primary `*sql.DB` is capped at `SetMaxOpenConns(1)` to serialize `BEGIN IMMEDIATE` writes. A slow explorer query on that single connection stalls every concurrent `ReserveQuota` — the money path.

- New `phase5-gateway/internal/storage/sqlite.OpenReadOnly(ctx, path)` opens a SECOND handle to the same WAL file with `mode=ro` + `query_only=1` pragma + `SetMaxOpenConns(4)`. SQLite WAL allows concurrent readers; the new handle never competes with writes.
- New `router.WithReadStore` option threads it through to a `readOnlyStore` field on the router `Server`; `s.readStore()` returns it when set, falls back to the primary otherwise. Tests are untouched — they call `router.New` without `WithReadStore`.
- Routed reads through `readStore()`: all six explorer handlers (`router/explorer.go`) plus `/v1/usage` (3 calls).
- `cmd/gateway/main.go` opens both handles, defers `Close`, passes the read handle via `WithReadStore`.

## Part B — Terminal-reservation cleanup (PERF-1 Part B)

- New `phase5-gateway/internal/storage/sqlite.DeleteTerminalQuotaReservations(ctx, before)` DELETEs `quota_reservations` rows in `{expired, settled, refunded}` whose `settled_at < before`. `quota_reservations` has no BEFORE DELETE trigger so this is safe.
- `concurrency_reservations` is **NOT** touched — it has the `concurrency_reservations_no_delete` BEFORE DELETE trigger, which is **Open Q4 territory** (still unanswered). The audit prompt called this table "deletable" but the schema disagrees; deferring to Q4 is the conservative call.
- `storage.UsageStore` interface gains `DeleteTerminalQuotaReservations`.
- `cmd/gateway/main.go runReservationReaper` now runs both passes per tick: UPDATE active-expired (existing) THEN DELETE terminal-state rows older than 7 days (new). Each step logs only on non-zero count.

## Part C — DEFERRED, gated on Open Q4

The eight event tables (`usage_events`, `feedback_events`, `audit_events`, `api_key_events`, `demo_usage_events`, `capacity_signal_events`, `signup_events`, `demo_session_events`) all `RAISE(ABORT)` on DELETE per `migrate.go:184-251`. The audit's **Open Q4** asks: *"Gateway append-only-forever: compliance requirement or default? — archive-rotate to cold storage vs amend triggers to permit aged-out DELETE."* Until Q4 is answered, `migrate.go` is untouched. The MILESTONE_2_HANDOFF.md will surface this for operator decision.

## Tests

- `TestDeleteTerminalQuotaReservationsKeepsActiveAndDropsOld` — 100 settled reservations from 8 days ago + 10 active today; DeleteTerminal drops the 100, post-prune `DailyUsage` confirms the 10 active rows still reserved.
- `TestOpenReadOnlyServesReadsButNotWrites` — `DailyUsage` succeeds via the read-only handle; `CreateAccount` fails loudly, pinning the `query_only=1` guard (defense in depth against an accidental write routed through `readStore()`).

## Test plan
- [ ] `go test -race ./...` green in `phase5-gateway` (verified locally)
- [ ] Manually inspect `runReservationReaper` ordering: UPDATE-then-DELETE per tick
- [ ] Inspect `readStore()` callsites — all 6 explorer + 3 usage reads route through it; writes still go to primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
