### PR TITLE
fix: M2 low follow-ups — emitter doc + rejection-policy + test boundary (codex audit Low #46, #47, #49)

### DIFF
--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -495,14 +495,24 @@ type SwapEvent struct {
 //
 // CONCURRENCY CONTRACT (M2-2 / ARCH-2): the emitter is invoked AFTER
 // ApplyHeartbeat releases Registry.mu. Implementations MAY:
-//   - call back into Registry methods (no longer deadlocks)
-//   - block freely (will not stall heartbeat throughput); cmd/coordinator
-//     dispatches onto a buffered channel drained by a single goroutine,
-//     so a slow audit writer cannot back-pressure the heartbeat handler
-//   - per SPEC-002 v1.3.5 §7.10 R-7.10.8, audit-write failures are
-//     best-effort and MUST NOT block heartbeat processing or drop the
-//     provider; a panic still propagates and crashes the heartbeat
-//     handler, matching the v1.3.4 default failure mode.
+//   - call back into Registry methods (no longer deadlocks the global
+//     lock the way the pre-M2-2 design did).
+//
+// Implementations that block in the emitter callback DO pay that
+// latency on the calling goroutine — usually the WS heartbeat handler.
+// The pool contract makes that safe in the sense that no other
+// heartbeat is stalled, but it is NOT the same as a non-blocking
+// emitter: the calling goroutine itself waits. For true non-blocking
+// semantics the implementation MUST dispatch off the call path, e.g.
+// via a buffered channel + dedicated drain goroutine like the
+// cmd/coordinator wiring does (the production path). A naive
+// synchronous SQLite write here will still delay this provider's next
+// heartbeat ack by up to busy_timeout seconds.
+//
+// Per SPEC-002 v1.3.5 §7.10 R-7.10.8, audit-write failures are
+// best-effort and MUST NOT block heartbeat processing or drop the
+// provider; a panic still propagates and crashes the heartbeat
+// handler, matching the v1.3.4 default failure mode.
 type SwapEventEmitter func(event SwapEvent)
 
 type HeartbeatUpdate struct {

--- a/phase4-coordinator/internal/ws/admission.go
+++ b/phase4-coordinator/internal/ws/admission.go
@@ -180,6 +180,18 @@ func (a *AdmissionManager) Promote(providerID string) (string, bool) {
 	return string(pool.TierProvisional), true
 }
 
+// Reject marks a provisional provider as banned by the operator.
+//
+// REJECTION POLICY (M2-5 follow-up to codex security-audit Low #47):
+// rejections have TTL semantics keyed to the provisional record's
+// lifetime — Prune drops a rejection whose underlying record is past
+// ProvisionalRetentionDays (default 30d). The operator's effective
+// intent is "ban this activity," not "ban this provider_id forever":
+// if the provider does not reappear inside the retention window, the
+// rejection lapses; if they reappear within it, the rejection still
+// blocks them. A durable, identity-forever blocklist is intentionally
+// NOT this code path — that belongs in a separate operator-managed
+// blocklist (M3 follow-up, not yet built).
 func (a *AdmissionManager) Reject(providerID, reason string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/phase5-gateway/internal/storage/sqlite/store_test.go
+++ b/phase5-gateway/internal/storage/sqlite/store_test.go
@@ -437,6 +437,47 @@ func TestDeleteTerminalQuotaReservationsKeepsActiveAndDropsOld(t *testing.T) {
 		}
 	}
 
+	// 5 recently-settled reservations (3 days ago) — terminal but INSIDE
+	// the retention window. Must survive. Added per codex code-audit
+	// 2026-06-11 Low #49: the original fixture only had old-terminal +
+	// active, so the test could not distinguish "deletes terminal rows
+	// past cutoff" from "deletes all terminal rows".
+	recentAt := fixedTime().Add(-3 * 24 * time.Hour)
+	for i := 0; i < 5; i++ {
+		reqID := fmt.Sprintf("req_recent_%03d", i)
+		if _, err := store.ReserveQuota(ctx, storage.ReservationRequest{
+			AccountID: "acct_delete_terminal", RequestID: reqID, WindowDate: "2026-05-26",
+			RequestedTokens: 1, DailyQuota: 1000000, CreatedAt: recentAt, ExpiresAt: recentAt.Add(24 * time.Hour),
+		}); err != nil {
+			t.Fatalf("ReserveQuota recent #%d: %v", i, err)
+		}
+		if err := store.SettleReservation(ctx, storage.ReservationSettlement{
+			AccountID: "acct_delete_terminal", RequestID: reqID,
+			PromptTokens: 1, CompletionTokens: 0, TotalTokens: 1, MaxTotalTokens: 1000,
+			TokenSource: "provider_reported", Outcome: "ok", SettledAt: recentAt,
+		}); err != nil {
+			t.Fatalf("SettleReservation recent #%d: %v", i, err)
+		}
+	}
+
+	// 1 reservation settled EXACTLY at the cutoff (7 days ago). Must
+	// survive because the predicate is strict less-than (settled_at <
+	// before), not less-or-equal. Pins the boundary semantic.
+	boundaryAt := fixedTime().Add(-7 * 24 * time.Hour)
+	if _, err := store.ReserveQuota(ctx, storage.ReservationRequest{
+		AccountID: "acct_delete_terminal", RequestID: "req_boundary", WindowDate: "2026-05-22",
+		RequestedTokens: 1, DailyQuota: 1000000, CreatedAt: boundaryAt, ExpiresAt: boundaryAt.Add(24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("ReserveQuota boundary: %v", err)
+	}
+	if err := store.SettleReservation(ctx, storage.ReservationSettlement{
+		AccountID: "acct_delete_terminal", RequestID: "req_boundary",
+		PromptTokens: 1, CompletionTokens: 0, TotalTokens: 1, MaxTotalTokens: 1000,
+		TokenSource: "provider_reported", Outcome: "ok", SettledAt: boundaryAt,
+	}); err != nil {
+		t.Fatalf("SettleReservation boundary: %v", err)
+	}
+
 	// 10 active reservations created now — not yet terminal, must survive.
 	for i := 0; i < 10; i++ {
 		if _, err := store.ReserveQuota(ctx, storage.ReservationRequest{
@@ -453,16 +494,36 @@ func TestDeleteTerminalQuotaReservationsKeepsActiveAndDropsOld(t *testing.T) {
 		t.Fatalf("DeleteTerminalQuotaReservations: %v", err)
 	}
 	if deleted != 100 {
-		t.Fatalf("deleted = %d, want 100 (terminal rows >7d old)", deleted)
+		t.Fatalf("deleted = %d, want 100 (old-terminal only; recent-terminal + boundary + active must survive)", deleted)
 	}
 
-	// Active rows untouched.
+	// Active rows untouched on today's window.
 	used, reserved, err := store.DailyUsage(ctx, "acct_delete_terminal", "2026-05-29")
 	if err != nil {
-		t.Fatalf("DailyUsage post-prune: %v", err)
+		t.Fatalf("DailyUsage post-prune (active window): %v", err)
 	}
 	if used != 0 || reserved != 10 {
-		t.Fatalf("post-prune used=%d reserved=%d, want 0/10", used, reserved)
+		t.Fatalf("post-prune (active) used=%d reserved=%d, want 0/10", used, reserved)
+	}
+
+	// Recent-terminal rows are settled, not active — they have used=5 on
+	// the 2026-05-26 window. Survives the prune; not in DailyUsage's
+	// active-reservation count.
+	used, reserved, err = store.DailyUsage(ctx, "acct_delete_terminal", "2026-05-26")
+	if err != nil {
+		t.Fatalf("DailyUsage post-prune (recent window): %v", err)
+	}
+	if used != 5 || reserved != 0 {
+		t.Fatalf("post-prune (recent) used=%d reserved=%d, want 5/0 (recent-terminal rows must survive)", used, reserved)
+	}
+
+	// Boundary row is settled on the 2026-05-22 window. Survives.
+	used, reserved, err = store.DailyUsage(ctx, "acct_delete_terminal", "2026-05-22")
+	if err != nil {
+		t.Fatalf("DailyUsage post-prune (boundary window): %v", err)
+	}
+	if used != 1 || reserved != 0 {
+		t.Fatalf("post-prune (boundary) used=%d reserved=%d, want 1/0 (cutoff-boundary row must survive on strict-less-than)", used, reserved)
 	}
 }
 


### PR DESCRIPTION
**Follow-up PR** — three Low findings from the 2026-06-11 codex audit panel, folded into one PR so the M2 series can land cleanly.

> **Merge ordering note.** This PR's base merges in PRs #46, #47, and #49 (the three M2 PRs that originated the Low findings). It is **logically sequenced AFTER those three**. Merge order:
> 1. #46, #47, #49 land first (any order — they touch independent paths)
> 2. Rebase this branch onto post-merge `main` (the M2-merge commits will drop out and the diff shrinks to just the three Low-fix commits)
> 3. Merge this PR

GitHub will show a large diff against current `main` until step 1 happens.

## Findings addressed

### Low #46 — `SwapEventEmitter` doc overclaims (from PR #46)
**File:** `phase4-coordinator/internal/pool/provider.go:496`

The M2-2 comment said implementations "MAY block freely (will not stall heartbeat throughput)". The codex code-auditor flagged that this is true only for the cmd/coordinator wiring, which dispatches onto a buffered channel + drain goroutine. A naive implementation doing a synchronous SQLite write IN the callback WILL stall the calling heartbeat handler by `busy_timeout`. The pool contract guarantees no DEADLOCK (Registry.mu is released before the call) but **does not** guarantee non-blocking semantics.

Tightened the comment to make the distinction explicit: "blocks pay latency on the calling goroutine — usually the WS heartbeat handler … for true non-blocking semantics the implementation MUST dispatch off the call path, e.g. via a buffered channel + dedicated drain goroutine like the cmd/coordinator wiring does."

### Low #47 — Rejection policy now documented (from PR #47)
**File:** `phase4-coordinator/internal/ws/admission.go:183` (`Reject`)

Codex security-auditor flagged that operator rejections now expire when `Prune` drops their underlying provisional record. That's **by design** — rejections have TTL semantics keyed to `ProvisionalRetentionDays` — but the doc didn't say so.

Added a `REJECTION POLICY` comment block to `Reject()` naming the "ban this activity, not this identity forever" intent and pointing the durable-blocklist case at M3.

### Low #49 — Test fixture extended (from PR #49)
**File:** `phase5-gateway/internal/storage/sqlite/store_test.go:412`

The original `TestDeleteTerminalQuotaReservationsKeepsActiveAndDropsOld` had only old-terminal + active rows; it could not distinguish "deletes terminal rows past cutoff" from "deletes all terminal rows". Codex code-auditor flagged this.

Extended with two new groups:
- **5 recently-settled rows (3 days ago, inside the 7-day retention).** Asserts they survive the prune.
- **1 cutoff-boundary row (settled exactly 7 days ago).** Asserts it survives. Pins the strict-less-than predicate (`settled_at < before`) vs less-or-equal.

Both additions check `DailyUsage` on the appropriate window post-prune to confirm the rows are still there.

## Deferred to M3 (NOT in this PR)

**Cross-PR Low — pruner-loop duplication.** Four near-identical "run now, then every 24h" loops across `phase4-coordinator/cmd/coordinator/main.go` (request_log, audit_log, admission) and `phase5-gateway/cmd/gateway/main.go` (reservation reaper). The codex code-auditor flagged the shape drift. This is a refactor that needs its own design review (where does the shared helper live? does it cover the gateway reaper's 2-step UPDATE-then-DELETE shape?), not a low-finding fix. Captured in the M3 backlog.

## Test plan
- [x] `go test -race ./... -count=1` green in both modules (verified locally)
- [ ] Confirm rebase onto post-#46/#47/#49 `main` drops the merge commits cleanly (no conflicts expected — the Low fixes touch lines added by those PRs but don't conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
