### PR TITLE
chore: bump binaryVersion 1.3.0 -> 1.3.1 for release tag

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -100,7 +100,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.3.0"
+    static let binaryVersion = "1.3.1"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL


### PR DESCRIPTION
## Summary

PR #41 (M1-1) bumped SPEC-001 to v1.3.1 but missed the `binaryVersion` constant in `CoordinatorClient.swift:103`. PR #44 (FR-C9) inherited the drift. This closes the gap before tagging `v1.3.1`.

Per CLAUDE.md, the binaryVersion constant is one of two canonical versions-of-record (the other being the SPEC headers). Tests and runtime envelopes consume it dynamically, so the bump propagates with no test changes.

## Why now

Next operator action after PR #44 merge is cutting `v1.3.1` so `install.sh` resolves to a binary carrying the FR-C9 flow. The release workflow requires the tag match the version field; with the constant pinned to 1.3.0, the released binary would advertise itself as 1.3.0.

## Test plan

- 172 Swift tests pass with the bumped constant
- Tests use CoordinatorClient.binaryVersion dynamically; no hardcoded "1.3.0" pinning the version

## After merge

Tag v1.3.1 + push tag triggers release.yml — publishes the first release containing M1-1 Bearer plumbing + FR-C9 self-serve persist + TOCTOU-safe TOFU + await-persist.

Generated with Claude Code
