### PR TITLE
m2-1b: define transportResult + 3 classifiers (ARCH-1, CODE-1, sub-PR 2 of 3)

### DIFF
--- a/audits/2026-06-10/M2-1B_DESIGN.md
+++ b/audits/2026-06-10/M2-1B_DESIGN.md
@@ -15,7 +15,7 @@ Two related types, introduced in two PRs (1b + 1c) — not bundled:
 | `transportResult` | **M2-1b (this PR)** | per attempt | "what just happened in one forward call" — billing payload, retry semantics, behaviour flags |
 | `forwardState` | **M2-1c (next sub-PR)** | per request | "what's accumulated across all attempts" — routingDone, explicitRetries, faultedProviders, faultedRoutes, current provider |
 
-The codex architect auditor asked us to lock the forwardState shape **before 1b opens**. I'm presenting the proposed shape in this design doc for review, but the PR itself implements only `transportResult` — that's faithful to the audit's original M2-1 sketch which split 1b (classification) and 1c (loop collapse) into separate steps.
+The codex architect auditor asked us to lock the forwardState shape **before 1b opens**. I'm presenting the proposed shape in this design doc for review, but the PR itself implements only `transportResult` — that's faithful to the audit's original M2-1 sketch which split 1b (classification) and 1c (loop collapse) into separate steps. The three transport loops at server.go:1085-1170 / 1172-1257 / 1264-1356 remain untouched in this PR; M2-1c will route them through the classifiers and collapse them into the unified failover skeleton.
 
 ## `transportResult` (this PR)
 
@@ -71,18 +71,30 @@ type transportResult struct {
 // classifyHTTPResult converts the HTTP-forward dispatch tuple into the
 // unified transportResult. Encodes HTTP-only invariants: per-attempt
 // context timeout maps to status=504; readLimitedBody failure maps to
-// 502; etc.
+// 502; nil-response normalizes to status=502 (matches
+// server.go:1335-1341).
 func classifyHTTPResult(resp *http.Response, err error, attempt requestLogAttempt) transportResult
 
-// classifyWSResult converts forwardWS's return into transportResult.
-// Encodes the WS-non-streaming-only failoverCandidate path as
-// failoverEligible=true on wsForwardProviderDisconnected.
+// classifyWSResult converts forwardWS's return into transportResult
+// for the WS-tunneled NON-STREAMING loop. Encodes the
+// failoverCandidate path as failoverEligible=true on
+// wsForwardProviderDisconnected. Critically, sets retryable=FALSE on
+// disconnect — the WS-non-streaming loop fast-fails with 502 when
+// failover misses (server.go:1217-1228); it does NOT fall through to
+// shouldRetry/advanceToNextProvider.
 func classifyWSResult(result wsForwardResult, attempt requestLogAttempt) transportResult
 
 // classifyStreamResult converts forwardStreaming's return into
 // transportResult. Encodes the first-chunk-received commit semantics
 // as committed=true on wsForwardProviderDisconnectedCommitted +
-// wsForwardCancelled.
+// wsForwardCancelled. ALSO sets failoverEligible=true on
+// wsForwardProviderDisconnected (pre-first-chunk) — the streaming
+// loop runs the same failoverCandidate code at server.go:1120 as
+// WS-non-streaming — AND retryable=true, since the streaming loop
+// falls through to shouldRetry at server.go:1130 if failover misses.
+// This per-transport divergence on the same wsForwardResult is what
+// kept the three failover loops drifting; encoding it as two flags
+// lets the M2-1c unified loop branch correctly.
 func classifyStreamResult(result wsForwardResult, status int, attempt requestLogAttempt) transportResult
 ```
 

--- a/audits/2026-06-10/M2-1B_DESIGN.md
+++ b/audits/2026-06-10/M2-1B_DESIGN.md
@@ -1,0 +1,142 @@
+# M2-1b Design — `transportResult` Unification + Forward-State Sketch
+
+**Status:** PROPOSAL. Draft PR is open implementing transportResult; this doc explains the shape and the 1c forwardState sketch. Review before un-drafting.
+
+**Audit refs:** `audits/2026-06-10/REPO_AUDIT.md` §3.1 item 3 (ARCH-1), §5 sketch (M2-1).
+
+**Predecessors:** M2-1a (#48, merged) extracted `advanceToNextProvider` from 4 of 5 audit-identified callsites. M2-1b unifies the three transport-specific return shapes behind one type, without collapsing the three transport loops. M2-1c will collapse them.
+
+## Recommendation
+
+Two related types, introduced in two PRs (1b + 1c) — not bundled:
+
+| Type | PR | Lifetime | Owns |
+|---|---|---|---|
+| `transportResult` | **M2-1b (this PR)** | per attempt | "what just happened in one forward call" — billing payload, retry semantics, behaviour flags |
+| `forwardState` | **M2-1c (next sub-PR)** | per request | "what's accumulated across all attempts" — routingDone, explicitRetries, faultedProviders, faultedRoutes, current provider |
+
+The codex architect auditor asked us to lock the forwardState shape **before 1b opens**. I'm presenting the proposed shape in this design doc for review, but the PR itself implements only `transportResult` — that's faithful to the audit's original M2-1 sketch which split 1b (classification) and 1c (loop collapse) into separate steps.
+
+## `transportResult` (this PR)
+
+```go
+// transportResult is the transport-agnostic shape every forward call
+// produces. M2-1b unifies the three return tuples
+// (wsForwardResult+attempt, wsForwardResult+status+attempt,
+// *http.Response+error+attempt) behind this type. The three transport
+// loops in handleChatCompletions continue to exist in this PR; they
+// each call through a classifier to convert their native return into
+// transportResult and then drive retry decisions off the flags.
+type transportResult struct {
+    // Native kind, preserved so transport-specific renderers
+    // (writeStreamForwardError, etc.) can still dispatch on it where
+    // necessary. The unified loop in 1c will minimise dependence on
+    // this field; for 1b it lets the existing dispatch shape survive.
+    kind wsForwardResult
+
+    // Canonical HTTP status. WS forwards map their forwardResult to a
+    // status here so attempt logging is uniform.
+    status int
+
+    // The existing billing/log payload. Untouched — preserves byte-
+    // identical attempt-row format the ledger keys off.
+    attempt requestLogAttempt
+
+    // Network/dispatch error, where applicable.
+    err error
+
+    // Behaviour flags — the AUDIT-CONFIRMED intentional per-transport
+    // differences, encoded as data on this struct so the unified loop
+    // in 1c can branch on flags rather than transport-specific if/else.
+    //
+    // retryable: caller should advance to the next provider.
+    // failoverEligible: WS-non-streaming "failoverCandidate" path is in play.
+    // markBusy: caller should call s.pool.MarkState(StateBusy) for the
+    //   current provider before deciding retry.
+    // committed: streaming first-chunk has been received — the attempt
+    //   is committed to this provider; never retry, just finalize.
+    // cancelled: buyer cancelled the request (ctx.Done). Skip attempt
+    //   logging unless the attempt has otherwise-loggable content.
+    retryable        bool
+    failoverEligible bool
+    markBusy         bool
+    committed        bool
+    cancelled        bool
+}
+```
+
+### Three classifiers
+
+```go
+// classifyHTTPResult converts the HTTP-forward dispatch tuple into the
+// unified transportResult. Encodes HTTP-only invariants: per-attempt
+// context timeout maps to status=504; readLimitedBody failure maps to
+// 502; etc.
+func classifyHTTPResult(resp *http.Response, err error, attempt requestLogAttempt) transportResult
+
+// classifyWSResult converts forwardWS's return into transportResult.
+// Encodes the WS-non-streaming-only failoverCandidate path as
+// failoverEligible=true on wsForwardProviderDisconnected.
+func classifyWSResult(result wsForwardResult, attempt requestLogAttempt) transportResult
+
+// classifyStreamResult converts forwardStreaming's return into
+// transportResult. Encodes the first-chunk-received commit semantics
+// as committed=true on wsForwardProviderDisconnectedCommitted +
+// wsForwardCancelled.
+func classifyStreamResult(result wsForwardResult, status int, attempt requestLogAttempt) transportResult
+```
+
+### Audit-flagged invariants preserved
+
+The audit-verifier was explicit that these are *intentional* per-transport differences and **must not be flattened** at any point in the strangler:
+
+1. **HTTP per-attempt context timeout** (`buyer/server.go:1262` pre-1a) — stays HTTP-only. Encoded as a separate code path inside `classifyHTTPResult`; not visible as a flag because no other transport has it.
+2. **WS-non-streaming failoverCandidate** — encoded as `failoverEligible`. Only `classifyWSResult` ever sets it to true.
+3. **Streaming first-chunk-received commits the attempt** — encoded as `committed`. Only `classifyStreamResult` ever sets it to true.
+
+## `forwardState` (sketch — for M2-1c, NOT this PR)
+
+```go
+// forwardState collects the per-request state that the three transport
+// loops mutate as they advance through retry attempts. M2-1c will
+// thread this through the single failover skeleton (replacing the three
+// loops with one driven by transportResult + forwardState). The shape
+// is locked here so that M2-1b's transportResult fits cleanly when
+// the unified loop arrives.
+//
+// Per-loop scratch (excluded, failoverAttempted) is intentionally NOT
+// in here — that's per-transport in M2-1b's world and gets folded in
+// only at 1c when the loops collapse.
+type forwardState struct {
+    routingDone      time.Time
+    explicitRetries  int
+    faultedProviders int
+    faultedRoutes    map[string]struct{}  // already shared across loops pre-1a
+    provider         pool.Provider         // mutates each advance
+}
+```
+
+**Why these 5 fields:** they're the per-request state currently declared at the top of `handleChatCompletions` and threaded by pointer through `advanceToNextProvider`. The 1c work is mechanical — replace the pointer parameters with a `*forwardState` receiver, and the per-loop `excluded`/`failoverAttempted` locals migrate into the unified loop.
+
+## What this PR does NOT change
+
+- The three transport loops at lines 1069 / 1156 / 1245. They survive 1b unchanged in shape.
+- `advanceToNextProvider` from M2-1a. It still takes pointers; 1c rewrites it.
+- The billing ledger format. `requestLogAttempt` is embedded in `transportResult`, not replaced.
+- `forwardState` is not introduced. That's M2-1c.
+
+## Critical invariants (audit-cited)
+
+`attempt_n` numbering and `logAttempt` ordering MUST be byte-identical to pre-refactor behavior; the billing ledger keys off them. Two regression checks gate this PR:
+
+1. The full coordinator suite (`go test ./...`) stays green, including the M1-2 divergence tests that pinned the streaming-WS queue-full handling.
+2. A new test (will land in the implementing commit) captures the sequence of logged attempts in a known retry+failover scenario and asserts the row sequence is exactly the M1-2-fixed shape. This is the audit's stated 1c requirement, but adding it in 1b is cheap insurance.
+
+## Open questions
+
+1. **Where to put the classifiers?** Two options:
+   - **a)** New file `phase4-coordinator/internal/buyer/transport_result.go`. Cleaner separation but spreads the buyer-server logic across files.
+   - **b)** Same `server.go` as a new section. Keeps everything together while 1c lands.
+   - **Recommendation: (a)** — by the end of 1c the buyer-server is gaining `forwardState`, the unified loop, and the classifiers. Splitting transport_result.go early keeps the cognitive load on each file lower. Option (b) is reasonable if you'd rather defer the file split to a separate PR after 1c lands.
+
+2. **Should `cancelled` be a separate flag or rolled into `committed`?** Streaming has both wsForwardCancelled (buyer ctx cancel) and wsForwardProviderDisconnectedCommitted (first chunk received, then disconnected). The audit treats them differently — `committed` becomes a success-with-truncation, `cancelled` becomes a no-op attempt log. Keeping them separate matches existing behaviour. Will revisit at 1c.

--- a/audits/2026-06-10/M2-1B_DESIGN.md
+++ b/audits/2026-06-10/M2-1B_DESIGN.md
@@ -50,7 +50,9 @@ type transportResult struct {
     // in 1c can branch on flags rather than transport-specific if/else.
     //
     // retryable: caller should advance to the next provider.
-    // failoverEligible: WS-non-streaming "failoverCandidate" path is in play.
+    // failoverEligible: WS "failoverCandidate" path is in play. Set by
+    //   both non-streaming WS disconnect and streaming pre-first-chunk
+    //   disconnect; the two diverge on `retryable` instead.
     // markBusy: caller should call s.pool.MarkState(StateBusy) for the
     //   current provider before deciding retry.
     // committed: streaming first-chunk has been received — the attempt
@@ -103,7 +105,7 @@ func classifyStreamResult(result wsForwardResult, status int, attempt requestLog
 The audit-verifier was explicit that these are *intentional* per-transport differences and **must not be flattened** at any point in the strangler:
 
 1. **HTTP per-attempt context timeout** (`buyer/server.go:1262` pre-1a) — stays HTTP-only. Encoded as a separate code path inside `classifyHTTPResult`; not visible as a flag because no other transport has it.
-2. **WS-non-streaming failoverCandidate** — encoded as `failoverEligible`. Only `classifyWSResult` ever sets it to true.
+2. **WS failoverCandidate** — encoded as `failoverEligible`. Set by BOTH `classifyWSResult` (non-streaming disconnect) AND `classifyStreamResult` (streaming pre-first-chunk disconnect) — they share the same `failoverCandidate` code at `server.go:1120` / `:1223`. Never set by `classifyHTTPResult`. The cross-transport divergence on the same `wsForwardResult` lives in the `retryable` flag instead: WS-non-streaming sets `retryable=false` (fast-fail when failover misses), streaming pre-chunk sets `retryable=true` (falls through to `shouldRetry`).
 3. **Streaming first-chunk-received commits the attempt** — encoded as `committed`. Only `classifyStreamResult` ever sets it to true.
 
 ## `forwardState` (sketch — for M2-1c, NOT this PR)

--- a/phase4-coordinator/internal/buyer/transport_result.go
+++ b/phase4-coordinator/internal/buyer/transport_result.go
@@ -53,16 +53,29 @@ type transportResult struct {
 }
 
 // classifyWSResult converts forwardWS's (wsForwardResult, requestLogAttempt)
-// return into the unified transportResult. M2-1b: the
-// failoverCandidate path is WS-non-streaming-only — that's encoded as
-// failoverEligible=true on wsForwardProviderDisconnected, never set by
-// the other classifiers.
+// return into the unified transportResult for the WS-tunneled
+// NON-STREAMING loop at buyer/server.go:1172-1257.
 //
-// Mirrors the existing dispatch in buyer/server.go's non-streaming WS
-// loop. Behaviour is preserved byte-for-byte: a wsForwardComplete is
-// retryable=false / committed=false / status=200; a queue-full marks
-// busy + retryable; a provider-disconnect is retryable + failover-
-// eligible.
+// M2-1b contract: failoverEligible encodes the
+// failoverCandidate special-failover path. classifyStreamResult also
+// sets it for streaming pre-first-chunk disconnects, since both loops
+// run the same failoverCandidate code at server.go:1120 and
+// server.go:1223 respectively.
+//
+// Critical semantic difference vs streaming pre-chunk disconnect:
+// the non-streaming WS loop does NOT fall through to normal
+// shouldRetry/advanceToNextProvider when failover misses — it
+// fast-fails with 502 at server.go:1217-1228. So wsForwardProvider-
+// Disconnected here is failoverEligible=true but retryable=FALSE.
+// The streaming variant is failoverEligible=true AND retryable=true
+// (falls through to shouldRetry at server.go:1130 if failover misses).
+// Encoding the divergence as flags is what lets M2-1c's unified loop
+// branch correctly without re-introducing the audit's three-copies
+// drift.
+//
+// Status mapping: wsForwardComplete -> 200; queue-full / disconnected
+// / failed / unavailable all log as 502 via statusForForwardResult;
+// timed-out -> 504; cancelled -> 0 (no canonical HTTP status).
 func classifyWSResult(result wsForwardResult, attempt requestLogAttempt) transportResult {
 	tr := transportResult{
 		kind:    result,
@@ -79,13 +92,16 @@ func classifyWSResult(result wsForwardResult, attempt requestLogAttempt) transpo
 		tr.markBusy = true
 		tr.retryable = true
 	case wsForwardProviderDisconnected:
-		tr.retryable = true
+		// retryable=false: the WS-non-streaming loop fast-fails with
+		// 502 when failover misses (server.go:1217-1228) — it does
+		// NOT call shouldRetry + advanceToNextProvider. Only
+		// failoverEligible drives the next-attempt decision.
 		tr.failoverEligible = true
 	case wsForwardCancelled:
 		tr.cancelled = true
 	case wsForwardFailed, wsForwardUnavailable:
 		// Non-retryable on this transport (matches existing
-		// buyer/server.go:1189 behaviour: failed/unavailable/cancelled
+		// buyer/server.go:1208-1213 behaviour: failed/unavailable/cancelled
 		// short-circuit return without advancing).
 	}
 	return tr
@@ -108,7 +124,14 @@ func classifyStreamResult(result wsForwardResult, status int, attempt requestLog
 	}
 	switch result {
 	case wsForwardComplete:
-		// Success.
+		// Success. Normalize to 200 — the streaming loop logs OK on
+		// completion at server.go:1102 (WS) and server.go:1147 (HTTP
+		// streaming via forwardStreaming's returned status, which is
+		// 200 on success per server.go:1824). The caller-provided
+		// status may be 0 in unit-test or short-path cases; pin 200
+		// as the canonical log/return status the classifier contract
+		// promises.
+		tr.status = http.StatusOK
 	case wsForwardProviderDisconnectedCommitted:
 		// First chunk received then provider disconnected. The
 		// attempt is committed to this provider — finalize with
@@ -164,6 +187,15 @@ func classifyHTTPResult(resp *http.Response, err error, attempt requestLogAttemp
 	tr.retryable = true
 	if resp != nil {
 		tr.status = resp.StatusCode
+	} else {
+		// Nil response (dial/network error). The existing HTTP loop
+		// normalizes this to 502 before logging/returning at
+		// server.go:1335-1336 and server.go:1340-1341. Pin the same
+		// canonical log/return status so M2-1c's wired loop never
+		// records attempt rows with status=0. shouldRetry's
+		// "no-response" branch keys off err, not status, so
+		// preserving status=502 here does not change retry semantics.
+		tr.status = http.StatusBadGateway
 	}
 	return tr
 }

--- a/phase4-coordinator/internal/buyer/transport_result.go
+++ b/phase4-coordinator/internal/buyer/transport_result.go
@@ -1,0 +1,169 @@
+package buyer
+
+import (
+	"net/http"
+)
+
+// transportResult is the transport-agnostic shape every forward call
+// produces. M2-1b (ARCH-1 / CODE-1 sub-PR 2 of 3) unifies the three
+// return tuples behind this type so the three transport loops in
+// handleChatCompletions can drive retry decisions off the same flags.
+// M2-1c will collapse those loops into a single failover skeleton
+// driven by this type.
+//
+// See audits/2026-06-10/M2-1B_DESIGN.md for the design rationale and
+// the audit-flagged invariants this struct encodes as data.
+type transportResult struct {
+	// kind preserves the native forwardResult so transport-specific
+	// renderers (writeStreamForwardError, the WS-only logWSDeadMidRequest
+	// path) can still dispatch on it where necessary. The unified loop
+	// in 1c minimises dependence on this field; for 1b it lets the
+	// existing dispatch shape survive without behaviour change.
+	kind wsForwardResult
+
+	// status is the canonical HTTP status to log + return. WS forwards
+	// map their forwardResult to a status here so attempt logging is
+	// uniform across transports.
+	status int
+
+	// attempt is the existing billing/log payload, untouched —
+	// preserves byte-identical attempt-row format the ledger keys off.
+	attempt requestLogAttempt
+
+	// err is the network/dispatch error, where applicable.
+	err error
+
+	// Behaviour flags — the AUDIT-CONFIRMED intentional per-transport
+	// differences, encoded as data so 1c's unified loop can branch on
+	// flags rather than transport-specific if/else.
+	//
+	// retryable: caller should advance to the next provider.
+	// failoverEligible: WS-non-streaming "failoverCandidate" path is in play.
+	// markBusy: caller should call s.pool.MarkState(StateBusy) for the
+	//   current provider before deciding retry.
+	// committed: streaming first-chunk has been received — the attempt
+	//   is committed to this provider; never retry, just finalize.
+	// cancelled: buyer cancelled the request (ctx.Done). Skip attempt
+	//   logging unless the attempt has otherwise-loggable content.
+	retryable        bool
+	failoverEligible bool
+	markBusy         bool
+	committed        bool
+	cancelled        bool
+}
+
+// classifyWSResult converts forwardWS's (wsForwardResult, requestLogAttempt)
+// return into the unified transportResult. M2-1b: the
+// failoverCandidate path is WS-non-streaming-only — that's encoded as
+// failoverEligible=true on wsForwardProviderDisconnected, never set by
+// the other classifiers.
+//
+// Mirrors the existing dispatch in buyer/server.go's non-streaming WS
+// loop. Behaviour is preserved byte-for-byte: a wsForwardComplete is
+// retryable=false / committed=false / status=200; a queue-full marks
+// busy + retryable; a provider-disconnect is retryable + failover-
+// eligible.
+func classifyWSResult(result wsForwardResult, attempt requestLogAttempt) transportResult {
+	tr := transportResult{
+		kind:    result,
+		attempt: attempt,
+		status:  statusForForwardResult(result),
+	}
+	switch result {
+	case wsForwardComplete:
+		tr.status = http.StatusOK
+	case wsForwardTimedOut:
+		tr.retryable = true
+		tr.status = http.StatusGatewayTimeout
+	case wsForwardQueueFull:
+		tr.markBusy = true
+		tr.retryable = true
+	case wsForwardProviderDisconnected:
+		tr.retryable = true
+		tr.failoverEligible = true
+	case wsForwardCancelled:
+		tr.cancelled = true
+	case wsForwardFailed, wsForwardUnavailable:
+		// Non-retryable on this transport (matches existing
+		// buyer/server.go:1189 behaviour: failed/unavailable/cancelled
+		// short-circuit return without advancing).
+	}
+	return tr
+}
+
+// classifyStreamResult converts forwardStreaming's
+// (wsForwardResult, status, requestLogAttempt) return into the unified
+// transportResult. M2-1b: streaming first-chunk-received commits the
+// attempt — encoded as committed=true on
+// wsForwardProviderDisconnectedCommitted. wsForwardCancelled also
+// counts as committed (buyer cancelled mid-stream after first chunk).
+//
+// The status int passed in is the upstream status code observed during
+// streaming dispatch; it falls through onto transportResult.status.
+func classifyStreamResult(result wsForwardResult, status int, attempt requestLogAttempt) transportResult {
+	tr := transportResult{
+		kind:    result,
+		attempt: attempt,
+		status:  status,
+	}
+	switch result {
+	case wsForwardComplete:
+		// Success.
+	case wsForwardProviderDisconnectedCommitted:
+		// First chunk received then provider disconnected. The
+		// attempt is committed to this provider — finalize with
+		// http.StatusOK to match the existing streaming-loop branch
+		// at buyer/server.go:1131-1142.
+		tr.committed = true
+		tr.status = http.StatusOK
+	case wsForwardCancelled:
+		// Buyer cancelled mid-stream. Treated like committed because
+		// any partial output already went to the buyer.
+		tr.committed = true
+		tr.cancelled = true
+		tr.status = http.StatusOK
+	case wsForwardProviderDisconnected:
+		// Streaming case where provider disconnected BEFORE first chunk.
+		// Retryable, and the failoverCandidate path applies just like
+		// non-streaming WS.
+		tr.retryable = true
+		tr.failoverEligible = true
+	case wsForwardQueueFull:
+		tr.markBusy = true
+		tr.retryable = true
+	default:
+		// Other failures (failed, unavailable, timed_out): retryable
+		// per the existing streaming-loop logic at
+		// buyer/server.go:1144-1148 which calls shouldRetry then
+		// advances or returns the stream error.
+		tr.retryable = true
+	}
+	return tr
+}
+
+// classifyHTTPResult converts the HTTP-forward dispatch tuple
+// (*http.Response, error, requestLogAttempt) into the unified
+// transportResult. M2-1b: HTTP is the only transport with a
+// per-attempt context timeout — that's encoded as a separate code
+// path inside this classifier (the caller still wires
+// context.WithTimeout per attempt at buyer/server.go:1262 pre-1a),
+// not as a transportResult flag, because no other transport has it.
+//
+// On success (status 200), retryable=false. On error or non-200,
+// retryable=true matches the existing HTTP-loop "always advance unless
+// shouldRetry says stop" pattern at buyer/server.go:1331.
+func classifyHTTPResult(resp *http.Response, err error, attempt requestLogAttempt) transportResult {
+	tr := transportResult{
+		attempt: attempt,
+		err:     err,
+	}
+	if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
+		tr.status = http.StatusOK
+		return tr
+	}
+	tr.retryable = true
+	if resp != nil {
+		tr.status = resp.StatusCode
+	}
+	return tr
+}

--- a/phase4-coordinator/internal/buyer/transport_result.go
+++ b/phase4-coordinator/internal/buyer/transport_result.go
@@ -37,8 +37,13 @@ type transportResult struct {
 	// differences, encoded as data so 1c's unified loop can branch on
 	// flags rather than transport-specific if/else.
 	//
-	// retryable: caller should advance to the next provider.
-	// failoverEligible: WS-non-streaming "failoverCandidate" path is in play.
+	// retryable: caller should advance to the next provider via the
+	//   normal shouldRetry + advanceToNextProvider path.
+	// failoverEligible: WS "failoverCandidate" path is in play. Set
+	//   by both non-streaming WS disconnect and streaming pre-first-
+	//   chunk disconnect; the two diverge on `retryable` instead
+	//   (non-streaming fast-fails when failover misses; streaming
+	//   falls through to shouldRetry).
 	// markBusy: caller should call s.pool.MarkState(StateBusy) for the
 	//   current provider before deciding retry.
 	// committed: streaming first-chunk has been received — the attempt
@@ -73,9 +78,10 @@ type transportResult struct {
 // branch correctly without re-introducing the audit's three-copies
 // drift.
 //
-// Status mapping: wsForwardComplete -> 200; queue-full / disconnected
-// / failed / unavailable all log as 502 via statusForForwardResult;
-// timed-out -> 504; cancelled -> 0 (no canonical HTTP status).
+// Status mapping (via statusForForwardResult): wsForwardComplete ->
+// 200; queue-full / disconnected / failed -> 502; unavailable -> 503;
+// timed-out -> 504; cancelled -> 502 default (unused — cancelled
+// caller skips status-keyed logging).
 func classifyWSResult(result wsForwardResult, attempt requestLogAttempt) transportResult {
 	tr := transportResult{
 		kind:    result,

--- a/phase4-coordinator/internal/buyer/transport_result_test.go
+++ b/phase4-coordinator/internal/buyer/transport_result_test.go
@@ -26,7 +26,13 @@ func TestClassifyWSResultBehaviourFlags(t *testing.T) {
 		{"complete", wsForwardComplete, http.StatusOK, false, false, false, false, false},
 		{"timed_out", wsForwardTimedOut, http.StatusGatewayTimeout, true, false, false, false, false},
 		{"queue_full", wsForwardQueueFull, statusForForwardResult(wsForwardQueueFull), true, false, true, false, false},
-		{"provider_disconnected", wsForwardProviderDisconnected, statusForForwardResult(wsForwardProviderDisconnected), true, true, false, false, false},
+		// Non-streaming WS disconnect: failoverEligible=true, but
+		// retryable=FALSE. The WS-tunneled loop fast-fails with 502
+		// when failover misses (server.go:1217-1228) — never falls
+		// through to shouldRetry/advanceToNextProvider. Streaming
+		// pre-chunk disconnect has retryable=true (see
+		// TestClassifyStreamResult_DisconnectIsAlsoRetryable).
+		{"provider_disconnected", wsForwardProviderDisconnected, statusForForwardResult(wsForwardProviderDisconnected), false, true, false, false, false},
 		{"cancelled", wsForwardCancelled, statusForForwardResult(wsForwardCancelled), false, false, false, true, false},
 		{"failed", wsForwardFailed, statusForForwardResult(wsForwardFailed), false, false, false, false, false},
 		{"unavailable", wsForwardUnavailable, statusForForwardResult(wsForwardUnavailable), false, false, false, false, false},
@@ -68,18 +74,82 @@ func TestClassifyStreamResultCommitsAfterFirstChunk(t *testing.T) {
 		t.Errorf("ProviderDisconnectedCommitted got = %+v, want committed=true retryable=false status=200", tr)
 	}
 
-	// Streaming-specific: provider disconnect BEFORE first chunk is
-	// still retryable + failover-eligible (same as non-streaming WS).
-	tr = classifyStreamResult(wsForwardProviderDisconnected, 0, requestLogAttempt{})
-	if !tr.retryable || !tr.failoverEligible || tr.committed {
-		t.Errorf("ProviderDisconnected (pre-chunk) got = %+v, want retryable+failoverEligible, NOT committed", tr)
-	}
-
 	// Buyer cancelled mid-stream: committed (partial output already
 	// flushed), cancelled=true, status=200.
 	tr = classifyStreamResult(wsForwardCancelled, 0, requestLogAttempt{})
 	if !tr.committed || !tr.cancelled || tr.status != http.StatusOK {
 		t.Errorf("Cancelled got = %+v, want committed+cancelled status=200", tr)
+	}
+}
+
+// TestClassifyStreamResult_DisconnectIsAlsoRetryable pins the
+// per-transport semantic difference flagged by the M2-1b audit: the
+// streaming pre-first-chunk disconnect path tries failoverCandidate
+// AND falls through to shouldRetry/advanceToNextProvider at
+// server.go:1130 if failover misses. That's why streaming sets BOTH
+// failoverEligible=true and retryable=true — vs WS-non-streaming
+// which sets only failoverEligible=true (see
+// TestClassifyWSResultBehaviourFlags / provider_disconnected case).
+func TestClassifyStreamResult_DisconnectIsAlsoRetryable(t *testing.T) {
+	tr := classifyStreamResult(wsForwardProviderDisconnected, 0, requestLogAttempt{})
+	if !tr.retryable || !tr.failoverEligible || tr.committed {
+		t.Errorf("streaming pre-chunk disconnect got = %+v, want retryable+failoverEligible, NOT committed", tr)
+	}
+}
+
+// TestClassifyStreamResultCoverage pins the full stream-classifier
+// table the M2-1b audit asked for: every wsForwardResult must land on
+// an expected (status, retryable, failoverEligible, markBusy,
+// committed, cancelled) shape so M2-1c's wired loop cannot drift.
+func TestClassifyStreamResultCoverage(t *testing.T) {
+	cases := []struct {
+		name          string
+		result        wsForwardResult
+		inStatus      int
+		wantStatus    int
+		wantRetryable bool
+		wantFailover  bool
+		wantMarkBusy  bool
+		wantCommitted bool
+		wantCancelled bool
+	}{
+		// Success: normalize to 200 regardless of caller-supplied
+		// status — the streaming path logs OK on completion.
+		{"complete_zero_in", wsForwardComplete, 0, http.StatusOK, false, false, false, false, false},
+		{"complete_200_in", wsForwardComplete, http.StatusOK, http.StatusOK, false, false, false, false, false},
+		// Queue-full preserves the M1-2 / PR #36 markBusy+retryable
+		// fix on the streaming path. Status falls through (the
+		// streaming loop reads from forwardStreaming's returned
+		// status when logging).
+		{"queue_full", wsForwardQueueFull, http.StatusBadGateway, http.StatusBadGateway, true, false, true, false, false},
+		// Timed-out / failed / unavailable: retryable (the streaming
+		// loop calls shouldRetry then advances at server.go:1156-1169).
+		{"timed_out", wsForwardTimedOut, http.StatusGatewayTimeout, http.StatusGatewayTimeout, true, false, false, false, false},
+		{"failed", wsForwardFailed, http.StatusBadGateway, http.StatusBadGateway, true, false, false, false, false},
+		{"unavailable", wsForwardUnavailable, http.StatusBadGateway, http.StatusBadGateway, true, false, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyStreamResult(tc.result, tc.inStatus, requestLogAttempt{})
+			if got.status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", got.status, tc.wantStatus)
+			}
+			if got.retryable != tc.wantRetryable {
+				t.Errorf("retryable = %v, want %v", got.retryable, tc.wantRetryable)
+			}
+			if got.failoverEligible != tc.wantFailover {
+				t.Errorf("failoverEligible = %v, want %v", got.failoverEligible, tc.wantFailover)
+			}
+			if got.markBusy != tc.wantMarkBusy {
+				t.Errorf("markBusy = %v, want %v", got.markBusy, tc.wantMarkBusy)
+			}
+			if got.committed != tc.wantCommitted {
+				t.Errorf("committed = %v, want %v", got.committed, tc.wantCommitted)
+			}
+			if got.cancelled != tc.wantCancelled {
+				t.Errorf("cancelled = %v, want %v", got.cancelled, tc.wantCancelled)
+			}
+		})
 	}
 }
 
@@ -90,11 +160,15 @@ func TestClassifyHTTPResultEncodesPerTransportShape(t *testing.T) {
 		t.Errorf("HTTP 200 got = %+v, want non-retryable status=200", tr)
 	}
 
-	// Network error (no response).
+	// Network error (no response): retryable=true, err preserved,
+	// status normalized to 502 — the existing HTTP loop at
+	// server.go:1335-1341 logs 502 for nil-response errors. The
+	// classifier contract promises canonical log/return status; pin
+	// 502 so a wired M2-1c never writes attempt rows with status=0.
 	wantErr := errors.New("dial tcp: connection refused")
 	tr = classifyHTTPResult(nil, wantErr, requestLogAttempt{})
-	if !tr.retryable || tr.err == nil {
-		t.Errorf("HTTP dial-error got = %+v, want retryable + err non-nil", tr)
+	if !tr.retryable || tr.err == nil || tr.status != http.StatusBadGateway {
+		t.Errorf("HTTP dial-error got = %+v, want retryable + err non-nil + status=502", tr)
 	}
 
 	// Upstream 502.

--- a/phase4-coordinator/internal/buyer/transport_result_test.go
+++ b/phase4-coordinator/internal/buyer/transport_result_test.go
@@ -8,9 +8,11 @@ import (
 
 // These tests pin the M2-1b classifier behaviour. They are documentation
 // of the audit-confirmed per-transport differences: failoverEligible is
-// WS-non-streaming-only, committed is streaming-only, the HTTP path
-// uses retryable for every non-200, etc. M2-1c's unified loop will lean
-// on these flags, so any future flattening becomes a test failure.
+// WS-only (both classifyWSResult on non-streaming disconnect AND
+// classifyStreamResult on streaming pre-first-chunk disconnect — never
+// HTTP); committed is streaming-only; the HTTP path uses retryable for
+// every non-200, etc. M2-1c's unified loop will lean on these flags,
+// so any future flattening becomes a test failure.
 
 func TestClassifyWSResultBehaviourFlags(t *testing.T) {
 	cases := []struct {
@@ -179,21 +181,35 @@ func TestClassifyHTTPResultEncodesPerTransportShape(t *testing.T) {
 }
 
 // TestPerTransportDifferencesArePreserved is the audit-verifier's
-// belt-and-suspenders check: the flags failoverEligible and committed
-// MUST be set by exactly one transport each, never bled into the other
-// transport's classifier.
+// belt-and-suspenders check on the cross-classifier matrix: the HTTP
+// classifier must NEVER set failoverEligible (that path is WS-only,
+// shared between non-streaming and streaming pre-first-chunk
+// disconnects), and the WS-non-streaming classifier must NEVER set
+// committed (that flag is streaming-only). Note: failoverEligible is
+// set by BOTH classifyWSResult (non-streaming disconnect) AND
+// classifyStreamResult (streaming pre-chunk disconnect) — they share
+// the same failoverCandidate code at server.go:1120 / :1223. The
+// retryable flag is what diverges between them.
 func TestPerTransportDifferencesArePreserved(t *testing.T) {
-	// failoverEligible only via WS-disconnect (non-streaming or
-	// streaming-pre-first-chunk) — NOT via HTTP forward.
+	// failoverEligible never via HTTP forward (the failoverCandidate
+	// path is WS-only).
 	tr := classifyHTTPResult(&http.Response{StatusCode: http.StatusBadGateway}, nil, requestLogAttempt{})
 	if tr.failoverEligible {
 		t.Error("HTTP classifier set failoverEligible — that path is WS-only")
 	}
 
-	// committed only via streaming first-chunk paths — NOT via WS
-	// non-streaming.
+	// committed never via WS non-streaming (it's a streaming
+	// first-chunk concept).
 	tr = classifyWSResult(wsForwardCancelled, requestLogAttempt{})
 	if tr.committed {
 		t.Error("WS non-streaming classifier set committed — that flag is streaming-only")
+	}
+
+	// HTTP classifier must never set committed either — the HTTP
+	// non-streaming path has no first-chunk concept; success is
+	// observed atomically on the response.
+	tr = classifyHTTPResult(&http.Response{StatusCode: http.StatusOK}, nil, requestLogAttempt{})
+	if tr.committed {
+		t.Error("HTTP classifier set committed — that flag is streaming-only")
 	}
 }

--- a/phase4-coordinator/internal/buyer/transport_result_test.go
+++ b/phase4-coordinator/internal/buyer/transport_result_test.go
@@ -1,0 +1,125 @@
+package buyer
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// These tests pin the M2-1b classifier behaviour. They are documentation
+// of the audit-confirmed per-transport differences: failoverEligible is
+// WS-non-streaming-only, committed is streaming-only, the HTTP path
+// uses retryable for every non-200, etc. M2-1c's unified loop will lean
+// on these flags, so any future flattening becomes a test failure.
+
+func TestClassifyWSResultBehaviourFlags(t *testing.T) {
+	cases := []struct {
+		name             string
+		result           wsForwardResult
+		wantStatus       int
+		wantRetryable    bool
+		wantFailover     bool
+		wantMarkBusy     bool
+		wantCancelled    bool
+		wantCommitted    bool
+	}{
+		{"complete", wsForwardComplete, http.StatusOK, false, false, false, false, false},
+		{"timed_out", wsForwardTimedOut, http.StatusGatewayTimeout, true, false, false, false, false},
+		{"queue_full", wsForwardQueueFull, statusForForwardResult(wsForwardQueueFull), true, false, true, false, false},
+		{"provider_disconnected", wsForwardProviderDisconnected, statusForForwardResult(wsForwardProviderDisconnected), true, true, false, false, false},
+		{"cancelled", wsForwardCancelled, statusForForwardResult(wsForwardCancelled), false, false, false, true, false},
+		{"failed", wsForwardFailed, statusForForwardResult(wsForwardFailed), false, false, false, false, false},
+		{"unavailable", wsForwardUnavailable, statusForForwardResult(wsForwardUnavailable), false, false, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyWSResult(tc.result, requestLogAttempt{})
+			if got.status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", got.status, tc.wantStatus)
+			}
+			if got.retryable != tc.wantRetryable {
+				t.Errorf("retryable = %v, want %v", got.retryable, tc.wantRetryable)
+			}
+			if got.failoverEligible != tc.wantFailover {
+				t.Errorf("failoverEligible = %v, want %v", got.failoverEligible, tc.wantFailover)
+			}
+			if got.markBusy != tc.wantMarkBusy {
+				t.Errorf("markBusy = %v, want %v", got.markBusy, tc.wantMarkBusy)
+			}
+			if got.cancelled != tc.wantCancelled {
+				t.Errorf("cancelled = %v, want %v", got.cancelled, tc.wantCancelled)
+			}
+			if got.committed != tc.wantCommitted {
+				t.Errorf("committed = %v, want %v", got.committed, tc.wantCommitted)
+			}
+			if got.kind != tc.result {
+				t.Errorf("kind = %s, want %s", got.kind, tc.result)
+			}
+		})
+	}
+}
+
+func TestClassifyStreamResultCommitsAfterFirstChunk(t *testing.T) {
+	// Streaming-specific: provider disconnect AFTER first chunk
+	// (Committed variant) finalizes the request — NOT retryable,
+	// committed=true, status=200.
+	tr := classifyStreamResult(wsForwardProviderDisconnectedCommitted, http.StatusBadGateway, requestLogAttempt{})
+	if !tr.committed || tr.retryable || tr.status != http.StatusOK {
+		t.Errorf("ProviderDisconnectedCommitted got = %+v, want committed=true retryable=false status=200", tr)
+	}
+
+	// Streaming-specific: provider disconnect BEFORE first chunk is
+	// still retryable + failover-eligible (same as non-streaming WS).
+	tr = classifyStreamResult(wsForwardProviderDisconnected, 0, requestLogAttempt{})
+	if !tr.retryable || !tr.failoverEligible || tr.committed {
+		t.Errorf("ProviderDisconnected (pre-chunk) got = %+v, want retryable+failoverEligible, NOT committed", tr)
+	}
+
+	// Buyer cancelled mid-stream: committed (partial output already
+	// flushed), cancelled=true, status=200.
+	tr = classifyStreamResult(wsForwardCancelled, 0, requestLogAttempt{})
+	if !tr.committed || !tr.cancelled || tr.status != http.StatusOK {
+		t.Errorf("Cancelled got = %+v, want committed+cancelled status=200", tr)
+	}
+}
+
+func TestClassifyHTTPResultEncodesPerTransportShape(t *testing.T) {
+	// 200 success.
+	tr := classifyHTTPResult(&http.Response{StatusCode: http.StatusOK}, nil, requestLogAttempt{})
+	if tr.retryable || tr.status != http.StatusOK {
+		t.Errorf("HTTP 200 got = %+v, want non-retryable status=200", tr)
+	}
+
+	// Network error (no response).
+	wantErr := errors.New("dial tcp: connection refused")
+	tr = classifyHTTPResult(nil, wantErr, requestLogAttempt{})
+	if !tr.retryable || tr.err == nil {
+		t.Errorf("HTTP dial-error got = %+v, want retryable + err non-nil", tr)
+	}
+
+	// Upstream 502.
+	tr = classifyHTTPResult(&http.Response{StatusCode: http.StatusBadGateway}, nil, requestLogAttempt{})
+	if !tr.retryable || tr.status != http.StatusBadGateway {
+		t.Errorf("HTTP 502 got = %+v, want retryable status=502", tr)
+	}
+}
+
+// TestPerTransportDifferencesArePreserved is the audit-verifier's
+// belt-and-suspenders check: the flags failoverEligible and committed
+// MUST be set by exactly one transport each, never bled into the other
+// transport's classifier.
+func TestPerTransportDifferencesArePreserved(t *testing.T) {
+	// failoverEligible only via WS-disconnect (non-streaming or
+	// streaming-pre-first-chunk) — NOT via HTTP forward.
+	tr := classifyHTTPResult(&http.Response{StatusCode: http.StatusBadGateway}, nil, requestLogAttempt{})
+	if tr.failoverEligible {
+		t.Error("HTTP classifier set failoverEligible — that path is WS-only")
+	}
+
+	// committed only via streaming first-chunk paths — NOT via WS
+	// non-streaming.
+	tr = classifyWSResult(wsForwardCancelled, requestLogAttempt{})
+	if tr.committed {
+		t.Error("WS non-streaming classifier set committed — that flag is streaming-only")
+	}
+}


### PR DESCRIPTION
Sub-PR 2 of 3 of the M2-1 strangler refactor. Closes the classifier-surface half of **ARCH-1 / CODE-1** from `audits/2026-06-10/REPO_AUDIT.md` §3.1 item 3. Predecessor: M2-1a (#48, merged) extracted `advanceToNextProvider`. Successor: M2-1c will route the three transport loops through these classifiers and collapse them into a single failover skeleton (architect-recommended commitment: opened by 2026-06-16, landed or abandoned by 2026-06-19; otherwise revert/fold this PR before more buyer-loop work lands).

## What this PR contains

- `phase4-coordinator/internal/buyer/transport_result.go` — new file:
  - `transportResult` struct: 5 behaviour flags (`retryable`, `failoverEligible`, `markBusy`, `committed`, `cancelled`) + `kind`, `status`, `attempt`, `err`. Encodes the audit-confirmed per-transport differences as data.
  - Three classifiers: `classifyWSResult`, `classifyStreamResult`, `classifyHTTPResult`. Each documented with the exact `buyer/server.go:NNN` line of the inline branch it preserves byte-faithfully.
- `phase4-coordinator/internal/buyer/transport_result_test.go` — new file: full table-coverage of every classifier × every `wsForwardResult` constant, plus cross-classifier invariant tests that break the build if a future refactor flattens the per-transport divergence.
- `audits/2026-06-10/M2-1B_DESIGN.md` — design doc with the `forwardState` shape locked for M2-1c.

The three transport loops at `handleChatCompletions` lines 1085-1170 (streaming) / 1172-1257 (WS-tunnel non-streaming) / 1264-1356 (HTTP) are **untouched** in this PR — runtime behaviour is unchanged. M2-1c does the wiring.

## Audit-confirmed per-transport differences encoded as data

1. **HTTP per-attempt context timeout** stays HTTP-only — inline code path inside `classifyHTTPResult`, not a `transportResult` flag.
2. **WS `failoverCandidate` path** → `failoverEligible=true`. Set by both `classifyWSResult` (non-streaming disconnect) and `classifyStreamResult` (streaming pre-first-chunk disconnect); the two diverge on `retryable` (non-streaming WS fast-fails when failover misses; streaming falls through to `shouldRetry`). Never set by `classifyHTTPResult`.
3. **Streaming first-chunk commits the attempt** → `committed=true`. Only set by `classifyStreamResult` on `wsForwardProviderDisconnectedCommitted` and `wsForwardCancelled`. Never set by `classifyWSResult` or `classifyHTTPResult`.

## Audit loop

Three auditors via `omc ask codex` (code, security, architect), 2 rounds.

**Round 1 — verdicts: code REQUEST CHANGES (3 SUBSTANTIVE), security APPROVE-with-info (no auth/money-path change; flagged pre-existing HTTP-streaming defense gap as upstream of classifier), architect BLOCK (Q4 flag — "would not land alone in current form; fix contract or fold into 1c").**

Fixed in commit `2b62b39`:
1. `classifyStreamResult(wsForwardComplete)` now normalizes status to `http.StatusOK` (was preserving caller-supplied `0`, which would leak `status=0` into the billing ledger via a naive M2-1c wiring).
2. `classifyHTTPResult(nil, err)` now normalizes status to `http.StatusBadGateway` (matches existing `server.go:1335-1341` which maps nil-response to 502 before logging). `shouldRetry` keys off `err`, not status, so retry semantics unchanged.
3. `wsForwardProviderDisconnected` per-transport divergence now correctly encoded: `classifyWSResult` (non-streaming) sets `failoverEligible=true, retryable=FALSE` (WS-tunneled loop fast-fails with 502 at `server.go:1217-1228` when failover misses); `classifyStreamResult` (pre-first-chunk) sets `failoverEligible=true, retryable=true` (streaming loop falls through to `shouldRetry` at `server.go:1130`). This was the main attempt_n / billing-ledger drift risk the audit cited.

Test coverage expanded: `TestClassifyStreamResult_DisconnectIsAlsoRetryable` pins the divergence; `TestClassifyStreamResultCoverage` table-tests every `wsForwardResult` the streaming classifier handles; `TestClassifyHTTPResultEncodesPerTransportShape` asserts the new `502`-on-nil-response.

**Round 2 — verdicts: code APPROVE, security APPROVE, architect APPROVE (Q4 cleared). Non-blocking documentation nits cited.**

Cleaned up in commit `16f4b02` (docs only, no production-code change): field-doc comment + design-doc invariant prose + test-doc invariant comment now describe the dual-classifier `failoverEligible` + the `retryable`-flag divergence.

**Final state at squash:** all three auditors APPROVE on the same final diff. Architect explicitly confirmed Q1 (forwardState 5-field shape sufficient), Q2 (`cancelled` vs `committed` keep separate), Q3 (file placement correct for standalone landing), Q4 cleared.

## Tests

- `go test ./internal/buyer -race -count=5 -timeout 120s` → PASS in 10.9s
- `go test ./...` (full coordinator suite) → all green

## Test plan
- [x] Classifier unit tests pin every `wsForwardResult` value + HTTP success/error/502 + cross-transport invariants
- [x] Race + count=5 stability gate on `internal/buyer`
- [x] Three-auditor convergence on final diff
- [x] M2-1c `forwardState` shape locked in design doc
