### PR TITLE
installer: add custom HF model id branch with MLX/fit validation (SPEC-003 v0.9 FR-D2.1)

### DIFF
--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -294,6 +294,19 @@ validate_hf_id() {
   case "$id" in
     /*|*/) die 7 "model id must be in the form org/name (got: $id)" ;;
   esac
+  # Round-2 hardening (codex code/security MAJOR): reject "." / ".." path
+  # components even though the charset filter allows them. Otherwise an id
+  # like "org/.." or "../name" passes the format check and could be
+  # path-normalized into the HF URL or later treated as a relative local
+  # model path by the binary.
+  hf_org="${id%/*}"
+  hf_name="${id##*/}"
+  case "$hf_org" in
+    .|..) die 7 "model id org segment cannot be \".\" or \"..\"" ;;
+  esac
+  case "$hf_name" in
+    .|..) die 7 "model id name segment cannot be \".\" or \"..\"" ;;
+  esac
 }
 
 # SPEC-003 v0.9 FR-D2: estimate weight size in GB from HF repo name.
@@ -303,7 +316,20 @@ validate_hf_id() {
 # "skip fit check, warn user".
 estimate_weights_gb_from_name() {
   id="$1"
-  params_b="$(printf "%s" "$id" | grep -oE '[0-9]+(\.[0-9]+)?[Bb]' | head -n1 | tr -d 'Bb')"
+  # Round-2 (codex code MAJOR): match "NxMB" Mixture-of-Experts shape FIRST
+  # (e.g. "Mixtral-8x7B" — 8 experts of 7B each, total ~56B params). The
+  # single-N pattern below would otherwise capture only the "7B" half and
+  # under-count memory by ~N×, letting the fit check pass a model that
+  # would OOM the host.
+  moe_match="$(printf "%s" "$id" | grep -oE '[0-9]+x[0-9]+(\.[0-9]+)?[Bb]' | head -n1)"
+  if [ -n "$moe_match" ]; then
+    experts="${moe_match%%x*}"
+    per_rest="${moe_match#*x}"
+    per_b="${per_rest%[Bb]}"
+    params_b="$(awk -v e="$experts" -v p="$per_b" 'BEGIN { printf "%g", e * p }')"
+  else
+    params_b="$(printf "%s" "$id" | grep -oE '[0-9]+(\.[0-9]+)?[Bb]' | head -n1 | tr -d 'Bb')"
+  fi
   [ -n "$params_b" ] || return 0
   quant_lc="$(printf "%s" "$id" | tr '[:upper:]' '[:lower:]')"
   case "$quant_lc" in
@@ -360,9 +386,15 @@ hf_check_model() {
   case "$id" in
     mlx-community/*) is_mlx=1 ;;
   esac
-  if [ "$is_mlx" -eq 0 ] && \
-     printf "%s" "$body" | grep -qE '"library_name"[[:space:]]*:[[:space:]]*"mlx"|"tags"[[:space:]]*:[[:space:]]*\[[^]]*"mlx"'; then
-    is_mlx=1
+  if [ "$is_mlx" -eq 0 ]; then
+    # Round-2 (codex code MINOR): flatten the body to one line before the
+    # tags regex. HF currently returns minified JSON, but a future format
+    # change to pretty-printed bodies would defeat the bracketed-class
+    # match because grep -E reads line-by-line.
+    flat_body="$(printf "%s" "$body" | tr -d '\n\r')"
+    if printf "%s" "$flat_body" | grep -qE '"library_name"[[:space:]]*:[[:space:]]*"mlx"|"tags"[[:space:]]*:[[:space:]]*\[[^]]*"mlx"'; then
+      is_mlx=1
+    fi
   fi
   if [ "$is_mlx" -eq 0 ]; then
     die 7 "model $id is not an MLX repo. macprovider runs MLX-format models only. Pick an mlx-community/* variant or convert with mlx_lm.convert."

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -67,6 +67,7 @@ Environment overrides:
   MACPROVIDER_INSTALL_DIR        support dir for binary + bundles
   MACPROVIDER_NO_PROMPT=1        use defaults without interactive prompts
   MACPROVIDER_NO_LAUNCHD=1       skip launchd service install
+  MACPROVIDER_SKIP_HF_CHECK=1    skip HuggingFace lookup on custom model id
 USAGE
 }
 
@@ -275,9 +276,126 @@ model_default_for_ram() {
   fi
 }
 
+# SPEC-003 v0.9 FR-D2: enforce safe HuggingFace repo id format.
+# Path-component charset (A-Za-z0-9._-) plus a single "/" separator. Any
+# deviation from "org/name" is rejected — this id is interpolated into a URL
+# and a YAML field, so traversal/newlines/whitespace must not slip through.
+validate_hf_id() {
+  id="$1"
+  reject_newlines "model id" "$id"
+  case "$id" in
+    */*/*|*/) die 7 "model id must be in the form org/name (got: $id)" ;;
+    */*) ;;
+    *) die 7 "model id must be in the form org/name (got: $id)" ;;
+  esac
+  case "$id" in
+    *[!A-Za-z0-9._/-]*) die 7 "model id contains invalid characters; allowed: A-Z a-z 0-9 . _ - /" ;;
+  esac
+  case "$id" in
+    /*|*/) die 7 "model id must be in the form org/name (got: $id)" ;;
+  esac
+}
+
+# SPEC-003 v0.9 FR-D2: estimate weight size in GB from HF repo name.
+# Parses N params from "...3B...", "...7B...", "...1.7B..." patterns and a
+# quantization hint (4bit/8bit/bf16/fp16/q4/q8). Returns an integer GB to
+# stdout or empty if the name can't be parsed — callers treat empty as
+# "skip fit check, warn user".
+estimate_weights_gb_from_name() {
+  id="$1"
+  params_b="$(printf "%s" "$id" | grep -oE '[0-9]+(\.[0-9]+)?[Bb]' | head -n1 | tr -d 'Bb')"
+  [ -n "$params_b" ] || return 0
+  quant_lc="$(printf "%s" "$id" | tr '[:upper:]' '[:lower:]')"
+  case "$quant_lc" in
+    *4bit*|*-q4*|*_q4*) bytes_per_param=0.5 ;;
+    *8bit*|*-q8*|*_q8*) bytes_per_param=1.0 ;;
+    *bf16*|*fp16*|*-f16*) bytes_per_param=2.0 ;;
+    *) bytes_per_param=2.0 ;;
+  esac
+  awk -v p="$params_b" -v b="$bytes_per_param" \
+    'BEGIN { gb = p * b; if (gb < 1) gb = 1; printf "%d", gb + 0.5 }'
+}
+
+# SPEC-003 v0.9 FR-D2: pre-install validation of a user-supplied HuggingFace
+# model id. Hard-blocks on inaccessible (401/403/404 — HF returns 401 for both
+# gated and nonexistent repos) and on non-MLX repos. Warns and prompts on
+# tight/over-RAM fit; user may override. Network errors downgrade to a
+# "skipped" warning so a flaky HF doesn't brick installs. All output goes to
+# stderr — caller's stdout is reserved for the chosen id.
+hf_check_model() {
+  id="$1"
+  ram_gb="$2"
+  if [ "${MACPROVIDER_SKIP_HF_CHECK:-0}" = "1" ]; then
+    log "Skipping HuggingFace check (MACPROVIDER_SKIP_HF_CHECK=1)."
+    return 0
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    log "curl not found; skipping HuggingFace check."
+    return 0
+  fi
+  log "Checking model $id on HuggingFace…"
+  api_url="https://huggingface.co/api/models/$id"
+  # -f omitted so 4xx bodies still reach us; status is routed explicitly below.
+  body_and_code="$(curl -sSL -m 10 -o - -w '\n__HTTP_STATUS__%{http_code}' "$api_url" 2>/dev/null || printf '\n__HTTP_STATUS__network_error')"
+  http_code="${body_and_code##*__HTTP_STATUS__}"
+  body="${body_and_code%__HTTP_STATUS__*}"
+  case "$http_code" in
+    200) ;;
+    401|403|404)
+      die 7 "model $id is not accessible on HuggingFace (private, gated, or doesn't exist). For a gated repo, use 'macprovider-cli models switch' post-install with HF_TOKEN set."
+      ;;
+    network_error)
+      log "WARNING: could not reach HuggingFace API; skipping fit check."
+      return 0
+      ;;
+    *)
+      log "WARNING: unexpected HuggingFace API status $http_code; skipping fit check."
+      return 0
+      ;;
+  esac
+
+  # MLX detection: mlx-community/* repos are mlx by convention, plus any repo
+  # that declares mlx as library_name or carries an "mlx" tag.
+  is_mlx=0
+  case "$id" in
+    mlx-community/*) is_mlx=1 ;;
+  esac
+  if [ "$is_mlx" -eq 0 ] && \
+     printf "%s" "$body" | grep -qE '"library_name"[[:space:]]*:[[:space:]]*"mlx"|"tags"[[:space:]]*:[[:space:]]*\[[^]]*"mlx"'; then
+    is_mlx=1
+  fi
+  if [ "$is_mlx" -eq 0 ]; then
+    die 7 "model $id is not an MLX repo. macprovider runs MLX-format models only. Pick an mlx-community/* variant or convert with mlx_lm.convert."
+  fi
+
+  est_gb="$(estimate_weights_gb_from_name "$id")"
+  if [ -z "$est_gb" ]; then
+    log "WARNING: could not estimate weight size from model name; skipping fit check."
+    return 0
+  fi
+  # Headroom: ~6 GB for macOS (3-4 GB) + Metal + mlx runtime + binary +
+  # KV cache. This matches the existing RAM-tier policy where the 7B (~4 GB)
+  # default targets 16 GB Macs, not 8 GB Macs.
+  comfortable_gb=$((est_gb + 6))
+  if [ "$ram_gb" -ge "$comfortable_gb" ]; then
+    log "Model fits: ~${est_gb} GB weights on ${ram_gb} GB Mac (working set ~${comfortable_gb} GB)."
+    return 0
+  fi
+  if [ "$ram_gb" -ge "$((est_gb + 2))" ]; then
+    log "WARNING: tight fit — ~${est_gb} GB weights on ${ram_gb} GB Mac; may swap or OOM under load."
+    prompt_yes_no "Proceed anyway? [y/N]" "N" || die 7 "aborted by user"
+    return 0
+  fi
+  log "WARNING: ~${est_gb} GB weights will not fit on ${ram_gb} GB Mac."
+  prompt_yes_no "Proceed anyway? [y/N]" "N" || die 7 "aborted by user"
+}
+
 choose_model() {
   ram_gb="$1"
   if [ -n "${MACPROVIDER_MODEL:-}" ]; then
+    # Env-var override is an explicit power-user path; validate format only,
+    # skip interactive HF prompts so CI / NO_PROMPT flows don't deadlock.
+    validate_hf_id "$MACPROVIDER_MODEL"
     printf "%s" "$MACPROVIDER_MODEL"
     return
   fi
@@ -293,6 +411,7 @@ choose_model() {
   printf "  1) mlx-community/Llama-3.2-3B-Instruct-4bit      ~2 GB, 8 GB Macs\n" >&2
   printf "  2) mlx-community/Qwen2.5-7B-Instruct-4bit        ~4 GB, 16 GB Macs\n" >&2
   printf "  3) mlx-community/Qwen2.5-14B-Instruct-4bit       ~8 GB, 24 GB+ Macs\n" >&2
+  printf "  c) custom HuggingFace MLX model id\n" >&2
   printf "Selection [default: %s]: " "$default_model" >&2
   read_line
   selection="$REPLY"
@@ -300,6 +419,15 @@ choose_model() {
     1) printf "mlx-community/Llama-3.2-3B-Instruct-4bit" ;;
     2) printf "mlx-community/Qwen2.5-7B-Instruct-4bit" ;;
     3) printf "mlx-community/Qwen2.5-14B-Instruct-4bit" ;;
+    c|C)
+      printf "HuggingFace model id (org/name): " >&2
+      read_line
+      custom_id="$REPLY"
+      [ -n "$custom_id" ] || die 7 "custom model id cannot be empty"
+      validate_hf_id "$custom_id"
+      hf_check_model "$custom_id" "$ram_gb" >&2
+      printf "%s" "$custom_id"
+      ;;
     "") printf "%s" "$default_model" ;;
     *) die 7 "invalid model selection" ;;
   esac

--- a/specs/SPEC-003-open-onboarding.md
+++ b/specs/SPEC-003-open-onboarding.md
@@ -1,7 +1,9 @@
 # SPEC-003 — Open Onboarding: Distribution, Lifecycle & Onboarding UX
 
-**Version:** 0.9 (2026-06-12, installer custom-model branch under FR-D2)
+**Version:** 0.9.1 (2026-06-12, FR-D2.1 step 4 picks up MoE NxMB parser + installer traversal hardening)
 **Depends on:** SPEC-001 v1.3.1, SPEC-002 v1.3.5
+
+**Change log v0.9.1:** Two installer-side R2/R3 hardenings surfaced by the parallel codex audits on PR #67. **(a) FR-D2.1 step 1 (format validation)** now MUST reject path components equal to `.` or `..` (split on `/`, reject either segment) in addition to the existing charset and shape checks. Prior wording said "no traversal/whitespace" in prose but the implementation relied on the charset filter alone, which permitted `org/..` and `../name`. **(b) FR-D2.1 step 4 (weight estimation)** now MUST match a Mixture-of-Experts `[0-9]+x[0-9]+(\.[0-9]+)?B` shape BEFORE the single `[0-9]+(\.[0-9]+)?B` shape. Otherwise an id like `Mixtral-8x7B-Instruct-4bit` is read as 7B and the fit check accepts a 56B model that would OOM the host. Headroom constants, quant table, and tier thresholds are unchanged.
 
 **Change log v0.9:** Extends FR-D2 with a fourth interactive option `c) custom HuggingFace MLX model id` so providers are no longer locked to the three RAM-tier defaults. The `c)` branch reads a free-form `org/name`, validates format (path-component charset, single slash, no traversal/whitespace/newlines), then queries `https://huggingface.co/api/models/<id>` to enforce two hard blocks and one soft check: (i) HTTP 401/403/404 → die with a single "not accessible" message (HF does not disclose existence to unauth'd callers, so these are indistinguishable from outside); (ii) repos that neither sit under `mlx-community/*` nor declare `library_name:"mlx"` / `"mlx"` in `tags` → die with "not an MLX repo"; (iii) RAM fit — weights estimated from the `[0-9]+(\.[0-9]+)?B` suffix and a `(4bit|8bit|bf16|fp16|q4|q8)` quant hint, then compared to detected RAM with a 6 GB headroom for the "comfortable" tier and a 2 GB headroom for the "tight" tier (matches the existing RAM-tier defaults where 7B targets 16 GB, not 8 GB). Tight/over-RAM cases warn-and-prompt; user may override. New env var `MACPROVIDER_SKIP_HF_CHECK=1` bypasses (i)/(ii)/(iii) for offline or self-mirrored installs. `MACPROVIDER_MODEL=` env override continues to skip the interactive prompts entirely (CI/`NO_PROMPT` path) but now also runs the format validator so a malformed env value fails fast. Coordinator/gateway are unaffected — no protocol change.
 
@@ -654,8 +656,12 @@ in order:
 
 1. **Format**: id MUST match `org/name` with each component drawn
    from `[A-Za-z0-9._-]+`, exactly one `/`, and no leading or
-   trailing `/`, whitespace, or newline. Violations die with exit
-   code 7 before any network call.
+   trailing `/`, whitespace, or newline. Additionally (v0.9.1, after
+   the charset and shape checks) neither segment may equal `.` or
+   `..` — the charset filter permits these by themselves, so the
+   installer MUST split on `/` and reject the literal `.` / `..`
+   values explicitly. Violations die with exit code 7 before any
+   network call.
 2. **HuggingFace existence**: installer issues
    `GET https://huggingface.co/api/models/<id>` with a 10 s timeout.
    - `200` → proceed to step 3.
@@ -673,10 +679,16 @@ in order:
    contains the literal element `"mlx"`. Failure dies with "not an
    MLX repo" and references `mlx_lm.convert` / `mlx-community/*`.
 4. **RAM fit**: weights are estimated as `params_b ×
-   bytes_per_param`, where `params_b` is parsed from the first
-   `[0-9]+(\.[0-9]+)?B` substring in the repo name and
-   `bytes_per_param` is `0.5` (`4bit`/`q4`), `1.0`
-   (`8bit`/`q8`), or `2.0` (`bf16`/`fp16`/`-f16` or unknown).
+   bytes_per_param`. `params_b` is parsed from the repo name with
+   two patterns tried in order (v0.9.1):
+   - First, the Mixture-of-Experts shape
+     `[0-9]+x[0-9]+(\.[0-9]+)?B` (e.g. `Mixtral-8x7B`); when
+     matched, `params_b = experts × per_expert` (8 × 7 = 56 in the
+     example).
+   - Otherwise, the single-N shape `[0-9]+(\.[0-9]+)?B` from the
+     first match.
+   `bytes_per_param` is `0.5` (`4bit`/`q4`), `1.0` (`8bit`/`q8`),
+   or `2.0` (`bf16`/`fp16`/`-f16` or unknown).
    - Comfortable: `ram_gb >= est_gb + 6` → log "fits", proceed.
    - Tight: `ram_gb >= est_gb + 2` → log warning, prompt
      `Proceed anyway? [y/N]`, default N.

--- a/specs/SPEC-003-open-onboarding.md
+++ b/specs/SPEC-003-open-onboarding.md
@@ -1,7 +1,9 @@
 # SPEC-003 — Open Onboarding: Distribution, Lifecycle & Onboarding UX
 
-**Version:** 0.8.3 (2026-06-12, post-deploy FR-C9.4 unused-token self-heal: deploy-gap lockout class closed)
+**Version:** 0.9 (2026-06-12, installer custom-model branch under FR-D2)
 **Depends on:** SPEC-001 v1.3.1, SPEC-002 v1.3.5
+
+**Change log v0.9:** Extends FR-D2 with a fourth interactive option `c) custom HuggingFace MLX model id` so providers are no longer locked to the three RAM-tier defaults. The `c)` branch reads a free-form `org/name`, validates format (path-component charset, single slash, no traversal/whitespace/newlines), then queries `https://huggingface.co/api/models/<id>` to enforce two hard blocks and one soft check: (i) HTTP 401/403/404 → die with a single "not accessible" message (HF does not disclose existence to unauth'd callers, so these are indistinguishable from outside); (ii) repos that neither sit under `mlx-community/*` nor declare `library_name:"mlx"` / `"mlx"` in `tags` → die with "not an MLX repo"; (iii) RAM fit — weights estimated from the `[0-9]+(\.[0-9]+)?B` suffix and a `(4bit|8bit|bf16|fp16|q4|q8)` quant hint, then compared to detected RAM with a 6 GB headroom for the "comfortable" tier and a 2 GB headroom for the "tight" tier (matches the existing RAM-tier defaults where 7B targets 16 GB, not 8 GB). Tight/over-RAM cases warn-and-prompt; user may override. New env var `MACPROVIDER_SKIP_HF_CHECK=1` bypasses (i)/(ii)/(iii) for offline or self-mirrored installs. `MACPROVIDER_MODEL=` env override continues to skip the interactive prompts entirely (CI/`NO_PROMPT` path) but now also runs the format validator so a malformed env value fails fast. Coordinator/gateway are unaffected — no protocol change.
 
 **Change log v0.6:** Resolves cross-spec findings F-603-1 and F-603-2 from `specs/SPEC-CROSS-006-audit.md`: the installer visibility self-test now references SPEC-002 v1.1.4's coordinator-owned `GET /v1/pool/check`, and dependencies align to SPEC-001 v1.2.2 + SPEC-002 v1.1.4.
 
@@ -637,11 +639,72 @@ options:
 | 24 GB+ | Llama 3.2 3B, Qwen 2.5 7B, `mlx-community/Qwen2.5-14B-Instruct-4bit` (~8 GB) | Qwen 2.5 14B |
 
 The installer prints the model name, approximate download size, and
-estimated context window. The user selects by number. If the model is
-not already downloaded, the installer runs
+estimated context window. The user selects by number, or chooses
+`c)` to enter a custom HuggingFace model id (see FR-D2.1). If the
+model is not already downloaded, the installer runs
 `huggingface-cli download {model}` (or prints instructions if
 `huggingface-cli` is not installed). Model download is the longest
 step and is NOT included in the "2 minutes to pool" target.
+
+**FR-D2.1. install.sh custom-id branch (v0.9).**
+The interactive menu MUST offer a fourth option `c) custom
+HuggingFace MLX model id`. When selected, the installer reads a
+single line of input (the HF repo id) and applies the following gates
+in order:
+
+1. **Format**: id MUST match `org/name` with each component drawn
+   from `[A-Za-z0-9._-]+`, exactly one `/`, and no leading or
+   trailing `/`, whitespace, or newline. Violations die with exit
+   code 7 before any network call.
+2. **HuggingFace existence**: installer issues
+   `GET https://huggingface.co/api/models/<id>` with a 10 s timeout.
+   - `200` → proceed to step 3.
+   - `401`, `403`, `404` → die with a single "not accessible
+     (private, gated, or doesn't exist)" message; the installer MUST
+     NOT distinguish these because HuggingFace does not disclose
+     existence to unauthenticated callers. The error MUST direct the
+     user to `macprovider-cli models switch` post-install with
+     `HF_TOKEN` set for the gated-repo path.
+   - Network error or unexpected status → log warning, skip
+     remaining checks, proceed.
+3. **MLX detection**: the repo qualifies if any of the following
+   holds — the id starts with `mlx-community/`, OR the API body
+   contains `"library_name":"mlx"`, OR the API body's `tags` array
+   contains the literal element `"mlx"`. Failure dies with "not an
+   MLX repo" and references `mlx_lm.convert` / `mlx-community/*`.
+4. **RAM fit**: weights are estimated as `params_b ×
+   bytes_per_param`, where `params_b` is parsed from the first
+   `[0-9]+(\.[0-9]+)?B` substring in the repo name and
+   `bytes_per_param` is `0.5` (`4bit`/`q4`), `1.0`
+   (`8bit`/`q8`), or `2.0` (`bf16`/`fp16`/`-f16` or unknown).
+   - Comfortable: `ram_gb >= est_gb + 6` → log "fits", proceed.
+   - Tight: `ram_gb >= est_gb + 2` → log warning, prompt
+     `Proceed anyway? [y/N]`, default N.
+   - Won't fit: otherwise → log warning, prompt as above.
+   - If the name does not match the `B`-suffix pattern, log
+     "could not estimate weight size; skipping fit check" and
+     proceed.
+
+The headroom constants match the existing RAM-tier defaults: 7B
+(~4 GB weights) targets 16 GB Macs (`4 + 6 = 10 ≤ 16`), not 8 GB
+Macs (`4 + 6 = 10 > 8`, falls to tight tier).
+
+The env var `MACPROVIDER_SKIP_HF_CHECK=1` bypasses steps 2–4
+entirely for offline or self-mirrored installs. The format check
+(step 1) is always enforced. `MACPROVIDER_MODEL=<id>` continues to
+skip the interactive prompt and proceed straight to install, but
+SHOULD now also run the format check so malformed env values fail
+fast; the HF/MLX/fit checks are skipped on the env-override path so
+CI and `MACPROVIDER_NO_PROMPT=1` flows do not deadlock on an
+interactive yes/no prompt.
+
+All FR-D2.1 prompts and warnings MUST be written to stderr so the
+installer's stdout-captured model id remains clean.
+
+Coordinator and gateway behavior is unchanged: the coordinator
+already accepts arbitrary `supported_models` advertised in the
+provider's initial WS frame, so no protocol or schema change is
+required for this branch.
 
 **FR-D3. First-run self-test.**
 On first run (or when invoked via `macprovider-cli self-test`), the


### PR DESCRIPTION
## Summary
- Adds a fourth interactive option `c) custom HuggingFace MLX model id` to `install.sh`, so providers are no longer locked to the three hardcoded RAM-tier defaults.
- The custom branch validates the id format, queries the HF API, hard-blocks gated/non-existent/non-MLX repos, and warn-and-prompts on tight or over-RAM fit.
- SPEC-003 v0.9 documents the contract under new FR-D2.1.

## What changed
**`phase3-binary/dist/install.sh`**
- New helpers `validate_hf_id`, `estimate_weights_gb_from_name`, `hf_check_model`.
- `choose_model` gains a `c)` branch that runs format validation + HF check before returning the id.
- `MACPROVIDER_MODEL=` env override now also runs format validation (HF/MLX/fit checks still skipped on that path, since it's the CI / `NO_PROMPT` lane).
- New env var `MACPROVIDER_SKIP_HF_CHECK=1` to bypass network checks for offline / self-mirrored installs.

**`specs/SPEC-003-open-onboarding.md`**
- Version 0.8.2 → 0.9.
- New FR-D2.1 documenting the four gates (format, existence, MLX, fit), the headroom constants (6 GB comfortable / 2 GB tight) and why they match the existing RAM-tier defaults.

## Why this scope
- Coordinator already accepts arbitrary `supported_models` in the provider's initial WS frame, so this is purely an installer UX change — no protocol / coordinator / gateway change required.
- This is PR A of a planned three-PR sequence (B: shared Swift `ModelFit` + `models switch` fit guard; C: `macprovider-cli models browse`). PR A ships standalone value.

## Design decisions
- **Gated models hard-block at install time**: 401/403/404 all collapse to "not accessible" because HF doesn't disclose existence to unauth'd callers. Users with `HF_TOKEN` get routed to `macprovider-cli models switch` post-install.
- **MLX-only**: detection by `mlx-community/*` prefix OR `library_name:"mlx"` OR `"mlx"` in `tags`. Other libraries (GGUF, raw safetensors) are blocked outright.
- **Warn-and-prompt, not block, on RAM**: some users genuinely know better (e.g. headless Macs with no UI overhead). Hard-blocking would be paternalistic.
- **Network down = skip, not fail**: a flaky HF API shouldn't brick installs. Logs a warning and proceeds.

## Test plan
- [x] Unit-test helpers against name parsing (3B/4bit → 2 GB, 7B/4bit → 4 GB, 14B/4bit → 7 GB, 1.7B/4bit → 1 GB, 32B/8bit → 32 GB, unparseable → empty).
- [x] `validate_hf_id` positive/negative cases: rejects `../etc/passwd`, `noslash`, `a/b/c`, `/leading`, `trailing/`, `with space/x`, empty.
- [x] Live HF API smoke test:
  - mlx-community/Qwen2.5-7B on 16 GB → fits
  - mlx-community/Qwen2.5-7B on 8 GB → tight, warn-and-prompt
  - mlx-community/Llama-3.2-3B on 8 GB → fits
  - mlx-community/Llama-3.3-70B on 8 GB → won't fit, warn-and-prompt
  - meta-llama/Llama-3.2-3B → blocked as not-MLX (returns 200 metadata even when gated for downloads)
  - this-org-does-not-exist-xyz/nope → "not accessible"
  - openai/whisper-large-v3 → blocked as not-MLX
- [x] `MACPROVIDER_SKIP_HF_CHECK=1` short-circuits.
- [x] Simulated network-down (`*.invalid` hostname) → logs warning + proceeds.
- [ ] End-to-end install on a real Mac with `c)` branch — recommend running once after merge before publishing to `get.streamvc.live`.

## Not in this PR
- `macprovider-cli models browse` (PR C) — the post-install picker that uses the HF search API.
- Shared Swift `ModelFit` module + `models switch` fit guard (PR B).
- Live download size check via HF safetensors file list — current implementation estimates from the repo name; PR B will do the real thing using the binary's HF client.

## Note re v1.3.1+ install blocker
Per the AMFI signing memory: v1.3.1+ installs currently fail on macOS 26.3.1 under launchd bootstrap (adhoc-signed binaries rejected). That's an orthogonal release-pipeline issue and does not affect this PR's installer-UX change, which becomes visible once signed releases resume.
