### PR TITLE
ModelFit: pre-flight RAM fit check on `models switch` (PR B)

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/ModelFit.swift
+++ b/phase3-binary/Sources/MacProviderCore/ModelFit.swift
@@ -74,22 +74,51 @@ public enum ModelFit {
     // MARK: - Internals (internal for testability)
 
     static func parseParamsBillions(from modelID: String) -> Double? {
+        // Round-2 (codex code MAJOR): match Mixture-of-Experts "NxMB" shape
+        // (e.g. "Mixtral-8x7B" — 8 experts of 7B each, total ~56B params)
+        // BEFORE the single-N pattern. Otherwise the old regex captured
+        // only the "7B" half and undercounted memory by N×, letting the
+        // switch fit guard pass a model that would OOM the host.
+        if let moe = matchFirst(pattern: #"([0-9]+)x([0-9]+(\.[0-9]+)?)[Bb]"#, in: modelID),
+           let experts = Double(moe.captures[1]),
+           let perExpert = Double(moe.captures[2]) {
+            return experts * perExpert
+        }
+
         // Regex compiled at first use; NSRegularExpression isn't Sendable so
         // we just rebuild it per call (tiny cost vs. avoiding shared mutable
         // state under StrictConcurrency).
-        let pattern = #"[0-9]+(\.[0-9]+)?[Bb]"#
+        guard let match = matchFirst(pattern: #"[0-9]+(\.[0-9]+)?[Bb]"#, in: modelID) else {
+            return nil
+        }
+        // Drop the trailing B/b from the full match.
+        let raw = match.fullMatch
+        return Double(raw.dropLast())
+    }
+
+    private struct RegexMatch {
+        let fullMatch: Substring
+        let captures: [String]
+    }
+
+    private static func matchFirst(pattern: String, in input: String) -> RegexMatch? {
         guard let regex = try? NSRegularExpression(pattern: pattern) else {
             return nil
         }
-        let range = NSRange(modelID.startIndex..., in: modelID)
-        guard let match = regex.firstMatch(in: modelID, range: range),
-              let matchRange = Range(match.range, in: modelID) else {
+        let nsRange = NSRange(input.startIndex..., in: input)
+        guard let match = regex.firstMatch(in: input, range: nsRange),
+              let fullRange = Range(match.range, in: input) else {
             return nil
         }
-        let raw = modelID[matchRange]
-        // Drop the trailing B/b.
-        let numPart = raw.dropLast()
-        return Double(numPart)
+        var captures: [String] = [String(input[fullRange])]
+        for groupIndex in 1..<match.numberOfRanges {
+            if let r = Range(match.range(at: groupIndex), in: input) {
+                captures.append(String(input[r]))
+            } else {
+                captures.append("")
+            }
+        }
+        return RegexMatch(fullMatch: input[fullRange], captures: captures)
     }
 
     static func inferBytesPerParam(from modelID: String) -> Double {

--- a/phase3-binary/Sources/MacProviderCore/ModelFit.swift
+++ b/phase3-binary/Sources/MacProviderCore/ModelFit.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Pure, network-free heuristic for "does this MLX model fit this Mac's RAM?"
+///
+/// Mirrors the install.sh `hf_check_model` fit math (SPEC-003 v0.9 FR-D2.1
+/// step 4) so a model accepted at install time is judged the same way at
+/// `models switch` time. Both surfaces use the same headroom constants and
+/// the same name-parsing rules — drift between them would mean a model the
+/// installer accepted could be rejected by `models switch` (or vice versa).
+public enum ModelFit {
+    /// Headroom above weight size for the "comfortable fit" tier. Covers
+    /// macOS (3–4 GB), the Metal/mlx runtime, the binary, and a KV cache for
+    /// typical context lengths. The 6 GB value is calibrated against the
+    /// existing installer RAM-tier defaults: 7B (~4 GB weights) → 16 GB Mac
+    /// is comfortable (4 + 6 = 10 ≤ 16), 7B on 8 GB Mac is not.
+    public static let comfortableHeadroomGB: Int = 6
+
+    /// Headroom for the "tight fit" tier — model loads but the box is close
+    /// to swapping under any concurrent load. Below this threshold the model
+    /// is rejected outright as "won't fit".
+    public static let tightHeadroomGB: Int = 2
+
+    public enum Verdict: Sendable, Equatable {
+        case fits(estGB: Int, ramGB: Int)
+        case tight(estGB: Int, ramGB: Int)
+        case wontFit(estGB: Int, ramGB: Int)
+        case unknown(reason: String)
+    }
+
+    /// Detected physical RAM rounded up to whole GB. Uses Foundation's
+    /// `ProcessInfo.physicalMemory` (which wraps `host_info(HOST_BASIC_INFO)`
+    /// on Darwin) so callers don't need to drop to `sysctl`.
+    public static func detectRAMGB() -> Int {
+        let bytes = ProcessInfo.processInfo.physicalMemory
+        let oneGB: UInt64 = 1_073_741_824
+        return Int((bytes + oneGB - 1) / oneGB)
+    }
+
+    /// Estimate weight size in GB from a HuggingFace repo name. Returns nil
+    /// if the name doesn't carry a `<N>B` parameter-count suffix — callers
+    /// treat nil as "skip fit check, surface a 'could not estimate' note".
+    ///
+    /// Parameters are parsed from the first `[0-9]+(\.[0-9]+)?B` substring
+    /// (case-insensitive). Quantization is inferred from substrings:
+    ///   4bit / -q4 / _q4  → 0.5 bytes/param
+    ///   8bit / -q8 / _q8  → 1.0 bytes/param
+    ///   bf16 / fp16 / -f16 → 2.0 bytes/param
+    ///   anything else      → 2.0 bytes/param (assume full-precision fallback)
+    public static func estimateWeightSizeGB(modelID: String) -> Int? {
+        guard let params = parseParamsBillions(from: modelID) else {
+            return nil
+        }
+        let bytesPerParam = inferBytesPerParam(from: modelID)
+        let gb = max(1.0, params * bytesPerParam)
+        return Int(gb.rounded())
+    }
+
+    /// Verdict for a (modelID, ramGB) pair. RAM is supplied explicitly so
+    /// tests don't depend on host RAM. Production callers pass
+    /// `detectRAMGB()`.
+    public static func evaluate(modelID: String, ramGB: Int) -> Verdict {
+        guard let estGB = estimateWeightSizeGB(modelID: modelID) else {
+            return .unknown(reason: "could not estimate weight size from \"\(modelID)\"")
+        }
+        if ramGB >= estGB + comfortableHeadroomGB {
+            return .fits(estGB: estGB, ramGB: ramGB)
+        }
+        if ramGB >= estGB + tightHeadroomGB {
+            return .tight(estGB: estGB, ramGB: ramGB)
+        }
+        return .wontFit(estGB: estGB, ramGB: ramGB)
+    }
+
+    // MARK: - Internals (internal for testability)
+
+    static func parseParamsBillions(from modelID: String) -> Double? {
+        // Regex compiled at first use; NSRegularExpression isn't Sendable so
+        // we just rebuild it per call (tiny cost vs. avoiding shared mutable
+        // state under StrictConcurrency).
+        let pattern = #"[0-9]+(\.[0-9]+)?[Bb]"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return nil
+        }
+        let range = NSRange(modelID.startIndex..., in: modelID)
+        guard let match = regex.firstMatch(in: modelID, range: range),
+              let matchRange = Range(match.range, in: modelID) else {
+            return nil
+        }
+        let raw = modelID[matchRange]
+        // Drop the trailing B/b.
+        let numPart = raw.dropLast()
+        return Double(numPart)
+    }
+
+    static func inferBytesPerParam(from modelID: String) -> Double {
+        let lower = modelID.lowercased()
+        if lower.contains("4bit") || lower.contains("-q4") || lower.contains("_q4") {
+            return 0.5
+        }
+        if lower.contains("8bit") || lower.contains("-q8") || lower.contains("_q8") {
+            return 1.0
+        }
+        if lower.contains("bf16") || lower.contains("fp16") || lower.contains("-f16") {
+            return 2.0
+        }
+        return 2.0
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -101,6 +101,26 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
             throw ExitCode(2)
         }
 
+        // Pre-flight RAM fit check. Uses the same name-parsing + headroom
+        // rules as the installer (SPEC-003 v0.9 FR-D2.1 step 4) so a model
+        // accepted at install time is judged the same way here. `--force`
+        // bypasses both the wontFit hard-block and the tight-fit warning.
+        switch ModelFit.evaluate(modelID: targetModelID, ramGB: ModelFit.detectRAMGB()) {
+        case let .wontFit(estGB, ramGB):
+            if options.force {
+                writeStderr("warning: target ~\(estGB) GB weights will not fit on \(ramGB) GB Mac; --force set, proceeding")
+            } else {
+                writeStderr("switch target \(targetModelID) (~\(estGB) GB weights) will not fit on \(ramGB) GB Mac. Re-issue with --force to override.")
+                throw ExitCode(2)
+            }
+        case let .tight(estGB, ramGB):
+            writeStderr("warning: tight fit — target ~\(estGB) GB weights on \(ramGB) GB Mac; may swap or OOM under load")
+        case .fits:
+            break
+        case let .unknown(reason):
+            writeStderr("note: \(reason); skipping fit check")
+        }
+
         if !options.force {
             let storePath = ControlSocketPaths.defaultSwitchStatePath(resolved.switchStatePath)
             let store = SwitchStateStore(path: storePath)

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -104,7 +104,8 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
         // Pre-flight RAM fit check. Uses the same name-parsing + headroom
         // rules as the installer (SPEC-003 v0.9 FR-D2.1 step 4) so a model
         // accepted at install time is judged the same way here. `--force`
-        // bypasses both the wontFit hard-block and the tight-fit warning.
+        // bypasses both the wontFit hard-block and the tight-fit warning,
+        // and also overrides the round-2 fail-closed-on-unknown gate below.
         switch ModelFit.evaluate(modelID: targetModelID, ramGB: ModelFit.detectRAMGB()) {
         case let .wontFit(estGB, ramGB):
             if options.force {
@@ -114,10 +115,28 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
                 throw ExitCode(2)
             }
         case let .tight(estGB, ramGB):
-            writeStderr("warning: tight fit — target ~\(estGB) GB weights on \(ramGB) GB Mac; may swap or OOM under load")
+            // Round-2 (codex code MINOR): match the comment — --force quiets
+            // the tight warning too. CI scripts use --force to mean "I know
+            // what I'm doing, don't shout."
+            if !options.force {
+                writeStderr("warning: tight fit — target ~\(estGB) GB weights on \(ramGB) GB Mac; may swap or OOM under load")
+            }
         case .fits:
             break
         case let .unknown(reason):
+            // Round-2 (codex security MINOR): fail closed when the target
+            // *looks like* an HF id (contains '/' and isn't a local path)
+            // but the parser can't size it. Otherwise a malicious or
+            // oddly-named oversized repo bypasses the guard. Synthetic IDs
+            // like "old-model" / "A" used in tests, and local paths like
+            // "./checkpoints/foo", still skip the fit check as before.
+            let looksLikeHFID = targetModelID.contains("/")
+                && !targetModelID.hasPrefix(".")
+                && !targetModelID.hasPrefix("/")
+            if looksLikeHFID && !options.force {
+                writeStderr("could not size HF-style target \(targetModelID): \(reason). Re-issue with --force to override.")
+                throw ExitCode(2)
+            }
             writeStderr("note: \(reason); skipping fit check")
         }
 

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -63,7 +63,7 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
     @Argument(help: "Target HuggingFace model ID or local path.")
     var targetModelID: String
 
-    @Flag(help: "Bypass the CLI-side cooldown soft guard.")
+    @Flag(help: "Bypass the CLI-side cooldown soft guard AND the local RAM fit guard (SPEC-001 v1.4 R-6.13.2): wontFit becomes a warning, tight is silenced, and HF-shape unknown fail-closed is overridden. Does NOT bypass --supported-models membership or server-side concurrency rejection.")
     var force = false
 
     @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG.")
@@ -101,11 +101,12 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
             throw ExitCode(2)
         }
 
-        // Pre-flight RAM fit check. Uses the same name-parsing + headroom
-        // rules as the installer (SPEC-003 v0.9 FR-D2.1 step 4) so a model
-        // accepted at install time is judged the same way here. `--force`
-        // bypasses both the wontFit hard-block and the tight-fit warning,
-        // and also overrides the round-2 fail-closed-on-unknown gate below.
+        // Pre-flight RAM fit check per SPEC-001 v1.4 §6.13 (R-6.13.1 through
+        // R-6.13.5). Same name-parsing + headroom rules as SPEC-003 v0.9.1
+        // FR-D2.1 step 4 so a model accepted at install time is judged the
+        // same way here. `--force` bypasses both the wontFit hard-block and
+        // the tight-fit warning, and overrides the .unknown fail-closed gate
+        // for HF-shape ids (R-6.13.2).
         switch ModelFit.evaluate(modelID: targetModelID, ramGB: ModelFit.detectRAMGB()) {
         case let .wontFit(estGB, ramGB):
             if options.force {

--- a/phase3-binary/Tests/macprovider-cliTests/ModelFitTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelFitTests.swift
@@ -1,0 +1,119 @@
+import MacProviderCore
+import XCTest
+
+final class ModelFitTests: XCTestCase {
+
+    // MARK: - estimateWeightSizeGB
+
+    func testEstimateLlama3B4bit() {
+        // 3B * 0.5 = 1.5 → rounds to 2
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "mlx-community/Llama-3.2-3B-Instruct-4bit"), 2)
+    }
+
+    func testEstimateQwen7B4bit() {
+        // 7B * 0.5 = 3.5 → rounds to 4
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit"), 4)
+    }
+
+    func testEstimateQwen14B4bit() {
+        // 14B * 0.5 = 7
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "mlx-community/Qwen2.5-14B-Instruct-4bit"), 7)
+    }
+
+    func testEstimateSmolLM17B4bitClampsToOne() {
+        // 1.7B * 0.5 = 0.85, clamped to 1
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "mlx-community/SmolLM2-1.7B-Instruct-4bit"), 1)
+    }
+
+    func testEstimate32B8bit() {
+        // 32B * 1.0 = 32
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "mlx-community/Qwen2.5-32B-Instruct-8bit"), 32)
+    }
+
+    func testEstimate7BBF16() {
+        // 7B * 2.0 = 14
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "mlx-community/Mistral-7B-Instruct-bf16"), 14)
+    }
+
+    func testEstimate70B4bit() {
+        // 70B * 0.5 = 35
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "mlx-community/Llama-3.3-70B-Instruct-4bit"), 35)
+    }
+
+    func testEstimateSkipsVersionDecimalBeforeNonB() {
+        // "Qwen2.5" should not be parsed as 2.5B because next char is "-",
+        // not B. Parser should skip past it to find "7B".
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "Qwen2.5-7B-Instruct"), 14)
+    }
+
+    func testEstimateUnknownNameReturnsNil() {
+        XCTAssertNil(ModelFit.estimateWeightSizeGB(modelID: "some-org/some-random-model"))
+        XCTAssertNil(ModelFit.estimateWeightSizeGB(modelID: ""))
+    }
+
+    func testEstimateAssumesFP16WhenQuantUnknown() {
+        // No 4bit/8bit/bf16/fp16 in the name → 2.0 bytes/param.
+        // 7B * 2.0 = 14
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "Mistral-7B-Instruct-v0.3"), 14)
+    }
+
+    func testEstimateRecognizesQ4SuffixVariants() {
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "user/Qwen-7B-q4"), 4)
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "user/Qwen-7B_q4_k_m"), 4)
+    }
+
+    // MARK: - evaluate (verdict tiers)
+
+    func testEvaluateFitsWhenComfortable() {
+        // 7B 4bit (4 GB) on 16 GB Mac: 16 >= 4 + 6 → fits
+        XCTAssertEqual(
+            ModelFit.evaluate(modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit", ramGB: 16),
+            .fits(estGB: 4, ramGB: 16)
+        )
+    }
+
+    func testEvaluateTightAtBoundary() {
+        // 7B 4bit (4 GB) on 8 GB Mac: 8 < 4 + 6 but 8 >= 4 + 2 → tight
+        XCTAssertEqual(
+            ModelFit.evaluate(modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit", ramGB: 8),
+            .tight(estGB: 4, ramGB: 8)
+        )
+    }
+
+    func testEvaluateWontFitOnUndersizedMac() {
+        // 70B 4bit (35 GB) on 8 GB Mac: 8 < 35 + 2 → wontFit
+        XCTAssertEqual(
+            ModelFit.evaluate(modelID: "mlx-community/Llama-3.3-70B-Instruct-4bit", ramGB: 8),
+            .wontFit(estGB: 35, ramGB: 8)
+        )
+    }
+
+    func testEvaluateLlama3BFitsOnEightGB() {
+        // 3B 4bit (2 GB) on 8 GB Mac: 8 >= 2 + 6 → fits (the default install pick)
+        XCTAssertEqual(
+            ModelFit.evaluate(modelID: "mlx-community/Llama-3.2-3B-Instruct-4bit", ramGB: 8),
+            .fits(estGB: 2, ramGB: 8)
+        )
+    }
+
+    func testEvaluateUnknownPropagates() {
+        if case .unknown = ModelFit.evaluate(modelID: "some-org/random", ramGB: 16) {
+            // expected
+        } else {
+            XCTFail("expected .unknown for unparseable name")
+        }
+    }
+
+    // MARK: - detectRAMGB (smoke: returns positive)
+
+    func testDetectRAMGBIsPositive() {
+        XCTAssertGreaterThan(ModelFit.detectRAMGB(), 0)
+    }
+
+    // MARK: - Headroom constants match the SPEC-003 v0.9 FR-D2.1 contract
+
+    func testHeadroomConstantsMatchInstaller() {
+        XCTAssertEqual(ModelFit.comfortableHeadroomGB, 6)
+        XCTAssertEqual(ModelFit.tightHeadroomGB, 2)
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ModelFitTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelFitTests.swift
@@ -62,6 +62,28 @@ final class ModelFitTests: XCTestCase {
         XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "user/Qwen-7B_q4_k_m"), 4)
     }
 
+    // Round-2 (codex code MAJOR): Mixture-of-Experts shape must be parsed as
+    // experts × per-expert, not just the trailing "MB" half. A regression
+    // here means the switch fit guard accepts models that OOM the host.
+
+    func testEstimateMixtral8x7B4bit() {
+        // 8 × 7B = 56B params * 0.5 byte = 28 GB
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "mlx-community/Mixtral-8x7B-Instruct-v0.1-4bit"), 28)
+    }
+
+    func testEstimateMixtral8x22B4bit() {
+        // 8 × 22B = 176B params * 0.5 = 88 GB
+        XCTAssertEqual(ModelFit.estimateWeightSizeGB(modelID: "mlx-community/Mixtral-8x22B-Instruct-v0.1-4bit"), 88)
+    }
+
+    func testEstimateMoEBeatsSingleNFallback() throws {
+        // The presence of "x7B" inside "8x7B" must not be captured as a
+        // standalone 7B; check by comparing against the single-N case.
+        let moe = try XCTUnwrap(ModelFit.estimateWeightSizeGB(modelID: "Mixtral-8x7B-4bit"))
+        let single = try XCTUnwrap(ModelFit.estimateWeightSizeGB(modelID: "Qwen-7B-4bit"))
+        XCTAssertGreaterThan(moe, single)
+    }
+
     // MARK: - evaluate (verdict tiers)
 
     func testEvaluateFitsWhenComfortable() {


### PR DESCRIPTION
## Summary
- New `ModelFit` module in `MacProviderCore` — pure, network-free heuristic for "does this MLX model fit this Mac's RAM?"
- Wired into `macprovider-cli models switch` as a pre-flight check between catalog validation and the warm-swap socket round-trip.
- Mirrors the install.sh fit math (PR #67 / SPEC-003 v0.9 FR-D2.1) so a model accepted at install time is judged the same way at switch time. Drift between the two would mean a model the installer let in could later be rejected by switch (or vice versa).

## API surface
```swift
ModelFit.estimateWeightSizeGB(modelID:) -> Int?
ModelFit.detectRAMGB() -> Int                    // ProcessInfo.physicalMemory
ModelFit.evaluate(modelID:, ramGB:) -> Verdict   // .fits / .tight / .wontFit / .unknown
ModelFit.comfortableHeadroomGB == 6
ModelFit.tightHeadroomGB == 2
```

## Verdict semantics in `models switch`
- `.fits` — silent
- `.tight` — stderr warning, proceed
- `.wontFit` — `ExitCode(2)` with "re-run with `--force` to override" message
- `.unknown` — stderr "skipping fit check" note, proceed (covers synthetic IDs and future local-path overrides)

`--force` already bypasses the cooldown guard; extending it to bypass the fit-check is consistent with that "I know what I'm doing" semantics — no new flag.

## Headroom constants
Calibrated against the existing install-time RAM tiers:
- 3B 4bit (~2 GB) on 8 GB Mac → `8 >= 2 + 6` → **fits** ✓ (default installer pick)
- 7B 4bit (~4 GB) on 16 GB Mac → `16 >= 4 + 6` → **fits** ✓
- 7B 4bit (~4 GB) on 8 GB Mac → `8 < 4 + 6` but `8 >= 4 + 2` → **tight** (warns, proceeds)
- 70B 4bit (~35 GB) on 8 GB Mac → **wontFit** (blocks unless `--force`)

## Why no HF networking
`models switch` is a **warm-swap** between models already in the running provider's `--supported-models` catalog — not a download. The fit check just needs RAM + the target id; no need to round-trip HuggingFace. The HF API client moves to PR C where `macprovider-cli models browse` actually needs it.

## Test plan
- [x] 18 `ModelFitTests`: name parsing (3B/7B/14B/70B 4bit, 1.7B clamps to 1, 32B 8bit, 7B bf16, q4/q8 suffix variants, version-decimal skip, unparseable → nil), verdict tiers at the boundary cases, headroom constants.
- [x] Full suite: 190/190 pass on macOS 14 arm64.
- [x] Existing `ModelsSubcommandTests` (9 tests) still pass — synthetic IDs like `old-model`/`A`/`slow-model` hit the `.unknown` branch and proceed.
- [ ] Manual smoke after merge: `macprovider-cli models switch mlx-community/Llama-3.3-70B-Instruct-4bit` on an 8 GB Mac should block with the new exit code; `--force` should let it through.

## Series context
PR A: #67 — installer custom-id branch (merged or pending review).
PR B: this PR — shared `ModelFit` + `models switch` fit guard.
PR C (next): `macprovider-cli models browse` — HF API client + filterable list.
