### PR TITLE
docs: tighten OPS.md sections 2/3 against first M0-5/M1-6 deploy

### DIFF
--- a/OPS.md
+++ b/OPS.md
@@ -69,8 +69,16 @@ Post-restart: the script polls `/healthz` and asserts the deployed `version`
 field matches the freshly built binary (M0-5 phase 2 provenance check). A
 mismatch implies the systemd unit started a stale binary; the script exits
 non-zero and the operator's responsibility is to investigate **before**
-declaring success. **TBD after first M0-5/M1-6 deploy**: the exact timing of
-this poll loop, and any retry/sleep tweaks discovered in practice.
+declaring success.
+
+Observed timing from the first M0-5/M1-6 production deploy (2026-06-11,
+v1.3.0-24-g87b3a6b → v1.3.1-5-gba04cd4): there is no retry loop. Step 7
+does `systemctl restart` → `sleep 3` → `systemctl is-active` (active on
+first check). Step 8 does `sleep 2` → a single `curl --max-time 10` GET
+on `https://coordinator.streamvc.live/healthz`. Total window between
+restart command and the provenance assert is ~5 seconds; `/healthz`
+responded immediately at `uptime_s=12` with the version field set. No
+tweaks were needed.
 
 ## 3. Safe gateway restart
 
@@ -99,10 +107,19 @@ sudo systemctl restart macprovider-gateway
 curl -s http://127.0.0.1:9443/healthz   # confirm OK + version reflects .prev
 ```
 
-**TBD after first M0-5/M1-6 deploy**: confirm the `.prev` filename layout
-matches the script (the path was inferred from `deploy-pearl-vps.sh`
-comments; the first real deploy should leave a `gateway.prev` artifact that
-either confirms or amends this section).
+Confirmed by the first M0-5/M1-6 production deploy (2026-06-11): both
+services maintain a **single** `.prev` artifact that is overwritten on
+each deploy, owned `macprovider:macprovider`, mode `0755`:
+
+- `/opt/macprovider/coordinator.prev`
+- `/opt/macprovider/gateway.prev`
+
+For the coordinator, the deploy script additionally writes a timestamped
+config backup at `/opt/macprovider/coordinator.yaml.bak-<UTC>` (UTC stamp
+in `YYYYMMDDTHHMMSSZ` form) before overwriting the live config. These
+accumulate across deploys (the script does not prune them); operators
+who want to free disk should reap the older ones after confirming a
+successful run.
 
 ## 4. Settlement
 


### PR DESCRIPTION
## Summary
- Resolves the two `**TBD after first M0-5/M1-6 deploy**` callouts in OPS.md §2 and §3 against observations from the first end-to-end M0-5/M1-6 production deploy (2026-06-11, v1.3.0-24-g87b3a6b → v1.3.1-5-gba04cd4 on Pearl).
- §2: documents the observed restart→/healthz timing (single GET after 2s sleep, ~5s end-to-end, no retry loop, immediate response).
- §3: confirms the single-file `.prev` layout at `/opt/macprovider/{coordinator,gateway}.prev` (owned `macprovider:macprovider`, mode `0755`), plus the coordinator-side timestamped `coordinator.yaml.bak-<UTC>` accumulating backups.

## Companion findings worth a follow-up (not in this PR)
During the deploy, two on-disk surprises caused the coordinator deploy script to fail at step 6b and would have caused the gateway deploy script to fail at step 4 (mitigated by switching to a binary-only swap for the gateway). These are not OPS.md content but should be tracked separately:

1. **Local repo's `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf` still declares `limit_req_zone ws_provider_rate` and `limit_conn_zone ws_provider_conn`** — both already declared by the `api.streamvc.live` site on Pearl. Pearl's live coordinator site had been dedup'd earlier on 2026-06-11 (`.bak-pre-dedup-20260611T135903Z` artifact survives) but the local file was never updated. Step 6b overwrote the dedup'd live with the un-dedup'd local; nginx -t failed with "limit_conn_zone is already bound." Fixed in-place on Pearl; the local file still drifts.
2. **Gateway deploy script (`phase5-gateway/dist/deploy-pearl-vps.sh`) lacks the `sed`-uncomment step the coordinator script has for `ssl_certificate` lines.** The local `nginx-api.streamvc.live.conf` ships those lines commented; if the gateway script's step 4 ran end-to-end, it would install the commented config and `nginx -t` would fail with "no ssl_certificate defined for SSL listener." Avoided here by skipping the script's nginx step. Either the gateway script needs the same `sed` step, or the local config needs to ship uncommented.
3. **FR-C9.4 TOFU policy regression**: a provider (`air5`) that connected during the deploy gap under the old binary cannot reconnect under v1.3.1-5 with `auth.require_provider_tokens=false`. Coordinator log: `tokenless connect refused; an active token already exists for this provider_id`. Operator will revoke the stored token or run a TOFU bypass; flagged for the decision log.

## Test plan
- [ ] Operator skims §2 + §3 wording and confirms it matches their recollection of the deploy
- [ ] On the next deploy, verify the timing characterization still holds (single GET, ~5s window)
- [ ] On the next deploy, verify a fresh `coordinator.yaml.bak-<UTC>` accumulates as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)
