### PR TITLE
fix: nginx-config drift surfaced by first M0-5/M1-6 deploy

### DIFF
--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -15,8 +15,16 @@
 # no per-IP dimension; one host could starve all provider readmissions
 # (full inference outage at N=3). 10 req/min/IP with burst=5; 5 concurrent
 # unauthenticated WS conns/IP, matching api vhost.
-limit_req_zone $binary_remote_addr zone=ws_provider_rate:10m rate=10r/m;
-limit_conn_zone $binary_remote_addr zone=ws_provider_conn:10m;
+#
+# The `ws_provider_rate` and `ws_provider_conn` zones are declared in the
+# api.streamvc.live vhost (nginx-api.streamvc.live.conf:10-11) and live
+# in the http context — nginx makes them visible across every vhost on
+# the same instance. Re-declaring them here breaks `nginx -t` with
+# "limit_conn_zone is already bound" (Pearl, 2026-06-11 deploy). The
+# directives below REFERENCE the shared zones; they are not redeclared.
+# If this coordinator vhost is ever deployed to a host where the api
+# vhost is NOT present, add the two `*_zone` declarations back at the
+# top of this file.
 
 # Port 80: only used for ACME http-01 challenge and to redirect to https.
 server {

--- a/phase5-gateway/dist/deploy-pearl-vps.sh
+++ b/phase5-gateway/dist/deploy-pearl-vps.sh
@@ -134,6 +134,15 @@ $SSH "set -e
   install -o root -g root -m 0644 /tmp/nginx-api.streamvc.live.conf /etc/nginx/sites-available/$DOMAIN
   rm -f /tmp/gateway-linux-amd64 /tmp/macprovider-gateway.service /tmp/nginx-api.streamvc.live.conf
   ln -sf /etc/nginx/sites-available/$DOMAIN /etc/nginx/sites-enabled/$DOMAIN
+  # Mirror the coordinator script's step 6b: nginx-api.streamvc.live.conf ships
+  # with the ssl_certificate / ssl_certificate_key lines commented (so a
+  # first-deploy clean run before certbot doesn't fail nginx -t with a missing
+  # cert). The cert exists by the time we get here on every subsequent deploy;
+  # uncomment idempotently. Without this, step 4 fails nginx -t with
+  # 'no ssl_certificate is defined for the listen ... ssl' (Pearl, 2026-06-11
+  # deploy — mitigated by switching to a binary-only swap at the time).
+  sed -i 's|# ssl_certificate /etc/letsencrypt|ssl_certificate /etc/letsencrypt|g' /etc/nginx/sites-available/$DOMAIN
+  sed -i 's|# ssl_certificate_key /etc/letsencrypt|ssl_certificate_key /etc/letsencrypt|g' /etc/nginx/sites-available/$DOMAIN
   nginx -t
   systemctl reload nginx
 "


### PR DESCRIPTION
## Summary

Two drift items the 2026-06-11 Pearl deploy patched live but left unfixed in the repo. Both would re-bite the next deploy. Companion to PR #75, which surfaced them in its description but explicitly didn't carry the fixes.

**1. Coordinator nginx config redeclares zones the api vhost already owns**

`phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf` declared `limit_req_zone ws_provider_rate` and `limit_conn_zone ws_provider_conn` at lines 18-19. The `api.streamvc.live` vhost (`phase5-gateway/dist/nginx-api.streamvc.live.conf:10-11`) already declares them. nginx http-context zones are visible across all vhosts on the same instance — re-declaring fails `nginx -t` with `"limit_conn_zone is already bound"`. The Pearl coordinator vhost had been dedup'd in place earlier on 2026-06-11 (`.bak-pre-dedup-20260611T135903Z` artifact survives); the deploy script overwrote that with the still-duped local file and tripped step 6b's `nginx -t`. Fixed in-place by sed-deleting the two lines on Pearl.

This commit removes the dup declarations from the local file and leaves a comment block explaining the cross-vhost sharing — so a future operator deploying the coordinator vhost standalone (no api vhost on the same nginx) knows to add them back.

**2. Gateway deploy script missing the `ssl_certificate` sed-uncomment that the coordinator script has**

`phase5-gateway/dist/nginx-api.streamvc.live.conf:34-35` ships those lines commented (first-deploy ACME ordering — `nginx -t` must pass before certbot has a cert). The coordinator script handles this at its step 6b with an idempotent `sed`; the gateway script `phase5-gateway/dist/deploy-pearl-vps.sh` at step 4 just `install`s the file as-shipped. End-to-end, that would fail `nginx -t` with `"no ssl_certificate is defined for the listen ... ssl"`. The 2026-06-11 deploy avoided this by switching to a binary-only swap (skipping the nginx step entirely).

This commit adds the same `sed` pair the coordinator script uses, with a comment cross-referencing the coordinator script's step 6b.

## Test plan

- [ ] `bash -n phase5-gateway/dist/deploy-pearl-vps.sh` — no syntax errors
- [ ] On the next coordinator deploy: step 6b passes `nginx -t` cleanly (no `already bound` error)
- [ ] On the next gateway deploy with the full nginx step: step 4 passes `nginx -t` cleanly (no missing `ssl_certificate` error)

## Out of scope

- **FR-C9.4 TOFU regression on air5** (PR #75 item 3) — addressed operationally via `UPDATE provider_tokens SET revoked_at = ...` on Pearl's coordinator.db; no code change needed for the immediate unblock. Any persistent operator-facing CLI work (`coordinator-cli` shipped to Pearl) is a separate follow-up.
- **The connected-provider guard bypass** (PR #75 process note) — folds into a separate OPS.md tightening PR, not this drift fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
