### PR TITLE
chore: ship coordinator-cli to Pearl alongside the daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ default.profraw
 
 # Phase 4 dist artifacts that are rebuilt locally
 phase4-coordinator/dist/coordinator-linux-amd64
+phase4-coordinator/dist/coordinator-cli-linux-amd64
 phase4-coordinator/dist/*.bak
 
 # Phase 5 gateway build artifacts

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -30,11 +30,18 @@ EMAIL="${EMAIL:-augstar@gmail.com}"
 
 DIST_DIR="$(cd "$(dirname "$0")" && pwd)"
 BINARY="$DIST_DIR/coordinator-linux-amd64"
+CLI_BINARY="$DIST_DIR/coordinator-cli-linux-amd64"
 CONFIG="$DIST_DIR/coordinator.yaml"
 SERVICE="$DIST_DIR/macprovider-coordinator.service"
 NGINX_SITE="$DIST_DIR/nginx-coordinator.streamvc.live.conf"
 
-for f in "$BINARY" "$CONFIG" "$SERVICE" "$NGINX_SITE"; do
+# coordinator-cli is required ALONGSIDE the daemon (SPEC-003 v0.8.3
+# FR-C9.4 strict-reject path still requires `coordinator-cli
+# revoke-token` for the used-token-persist-failure case; routine
+# prune-tokens / list-tokens also belong on Pearl). If absent, the
+# operator forgot to run build-linux.sh after the M2 update that
+# extended it. Fail closed — do NOT silently deploy with a stale CLI.
+for f in "$BINARY" "$CLI_BINARY" "$CONFIG" "$SERVICE" "$NGINX_SITE"; do
   [ -f "$f" ] || { echo "missing required file: $f" >&2; exit 1; }
 done
 
@@ -148,6 +155,7 @@ $SSH 'if [ -x /opt/macprovider/coordinator ]; then
       fi'
 
 $SCP "$BINARY" "$VPS_USER@$VPS_HOST:/tmp/coordinator-linux-amd64"
+$SCP "$CLI_BINARY" "$VPS_USER@$VPS_HOST:/tmp/coordinator-cli-linux-amd64"
 $SCP "$CONFIG" "$VPS_USER@$VPS_HOST:/tmp/coordinator.yaml"
 $SCP "$SERVICE" "$VPS_USER@$VPS_HOST:/tmp/macprovider-coordinator.service"
 $SCP "$NGINX_SITE" "$VPS_USER@$VPS_HOST:/tmp/nginx-coordinator-full.conf"
@@ -168,9 +176,16 @@ $SSH "if [ -f /opt/macprovider/coordinator.yaml ]; then
 
 $SSH "set -e
   install -o macprovider -g macprovider -m 0755 /tmp/coordinator-linux-amd64 /opt/macprovider/coordinator
+  # coordinator-cli is the operator-facing token-management tool. It's
+  # invoked manually (not under systemd) so it does NOT get a .prev
+  # snapshot — re-deploy is the rollback. Owned macprovider:macprovider
+  # so the operator runs it via 'sudo -u macprovider' for the same DB
+  # file-ownership posture as the daemon (the auth Store opens
+  # coordinator.db with the daemon's uid).
+  install -o macprovider -g macprovider -m 0755 /tmp/coordinator-cli-linux-amd64 /opt/macprovider/coordinator-cli
   install -o macprovider -g macprovider -m 0600 /tmp/coordinator.yaml /opt/macprovider/coordinator.yaml
   install -o root -g root -m 0644 /tmp/macprovider-coordinator.service /etc/systemd/system/macprovider-coordinator.service
-  rm -f /tmp/coordinator-linux-amd64 /tmp/coordinator.yaml /tmp/macprovider-coordinator.service
+  rm -f /tmp/coordinator-linux-amd64 /tmp/coordinator-cli-linux-amd64 /tmp/coordinator.yaml /tmp/macprovider-coordinator.service
 "
 
 # nginx + Let's Encrypt strategy:

--- a/phase4-coordinator/scripts/build-linux.sh
+++ b/phase4-coordinator/scripts/build-linux.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# build-linux.sh — produce a version-stamped linux/amd64 coordinator binary.
+# build-linux.sh — produce version-stamped linux/amd64 coordinator binaries:
+#   dist/coordinator-linux-amd64       — the long-running daemon (version-stamped)
+#   dist/coordinator-cli-linux-amd64   — operator token-management CLI
+#                                        (revoke-token / list-tokens /
+#                                         prune-tokens / revoke-and-kick)
 #
 # Refuses to build with uncommitted changes by default; set FORCE_DIRTY=1
 # to override (the resulting binary's version string will end in "-dirty"
@@ -40,3 +44,15 @@ OUT="dist/coordinator-linux-amd64"
 mkdir -p dist
 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o "$OUT" ./cmd/coordinator
 echo "built $OUT @ ${VERSION}"
+
+# coordinator-cli ships alongside the daemon so the operator has token
+# management (revoke-token, list-tokens, prune-tokens, revoke-and-kick)
+# available on Pearl without sqlite3 surgery. SPEC-003 v0.8.3 narrowed
+# the FR-C9.4 lockout class but did NOT eliminate it (used-token
+# persist-failure still requires manual revoke); the CLI also covers
+# routine prune-tokens / list-tokens. No version stamp — the CLI has
+# no main.version symbol; the deploy script logs which build it just
+# installed.
+CLI_OUT="dist/coordinator-cli-linux-amd64"
+GOOS=linux GOARCH=amd64 go build -o "$CLI_OUT" ./cmd/coordinator-cli
+echo "built $CLI_OUT @ ${VERSION}"


### PR DESCRIPTION
## Summary

`coordinator-cli` (the operator-facing token-management tool: `revoke-token`, `list-tokens`, `prune-tokens`, `revoke-and-kick`) was never produced by `build-linux.sh` and never shipped by `deploy-pearl-vps.sh`. The only path to revoke a token on Pearl today is direct `sqlite3` surgery on `/var/lib/macprovider/coordinator.db`. That's the friction that drove the air5 unblock on 2026-06-12 (sqlite3 UPDATE rather than `coordinator-cli revoke-token`).

PR #78 (SPEC-003 v0.8.3 unused-token self-heal) narrowed the FR-C9.4 lockout class but did NOT eliminate it. The used-token-persist-failure case still requires manual `revoke-token`; routine `prune-tokens` / `list-tokens` are also part of standing operations. Both need the CLI on Pearl.

## Changes

- `phase4-coordinator/scripts/build-linux.sh` — extended to also build `dist/coordinator-cli-linux-amd64` from `./cmd/coordinator-cli`. No version stamp (the CLI's `main` package has no `version` symbol; the deploy script announces which build it just installed).
- `phase4-coordinator/dist/deploy-pearl-vps.sh` — adds `CLI_BINARY=`, includes it in the pre-flight existence check (fail closed if absent), adds the `scp` step + the `install -o macprovider -g macprovider -m 0755 … /opt/macprovider/coordinator-cli` step, includes it in the `rm -f /tmp/…` cleanup. No `.prev` snapshot for the CLI — re-deploy is the rollback.
- `.gitignore` — covers `phase4-coordinator/dist/coordinator-cli-linux-amd64` alongside the existing daemon artifact.

## Test plan

- [x] `bash -n` syntax check passes on both scripts
- [x] `FORCE_DIRTY=1 bash scripts/build-linux.sh` produces both binaries; `file` confirms ELF 64-bit linux/amd64
- [ ] Operator next coordinator deploy: confirm `/opt/macprovider/coordinator-cli` is in place and the daemon owner can execute it via `sudo -u macprovider /opt/macprovider/coordinator-cli list-tokens --db /var/lib/macprovider/coordinator.db`

## Out of scope

- The same shipping pattern for the gateway side (no `gateway-cli` exists today; if/when token administration moves to the gateway, mirror this pattern).
- Documenting the on-Pearl CLI command syntax in `OPS.md` — separate docs PR (Task #12 in the post-deploy task slate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
