### PR TITLE
fix(deploy): early connected-provider check + FORCE_RESTART tombstone

### DIFF
--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -81,6 +81,19 @@ log "step 1/9: confirm SSH + DNS"
 $SSH 'hostname && uptime' >/dev/null
 dig +short "$DOMAIN" | grep -q "$VPS_HOST" || { echo "DNS for $DOMAIN does not resolve to $VPS_HOST yet" >&2; exit 1; }
 
+# Previous-deploy bypass tombstone — if the last deploy used
+# FORCE_RESTART=1 (or got manually bypassed past the connected-provider
+# guard), step 1c or step 6c writes /var/lib/macprovider/last-deploy-bypass.json
+# below. Surface it here so the operator can audit before scping a new
+# binary. Does NOT exit — informational only. Remove the file once
+# audited by the operator.
+PREV_BYPASS=$($SSH 'cat /var/lib/macprovider/last-deploy-bypass.json 2>/dev/null || true')
+if [ -n "$PREV_BYPASS" ]; then
+  log "  NOTE: previous deploy left a bypass tombstone:"
+  printf '%s\n' "$PREV_BYPASS" | sed 's/^/    /'
+  log "  If audited, clear with: ssh <pearl> rm /var/lib/macprovider/last-deploy-bypass.json"
+fi
+
 log "step 1b/9: drift check vs live /opt/macprovider/coordinator.yaml"
 # Catches the silent-config-change hazard. The 2026-06-11 deploy caused
 # a brief outage because the local config dropped auth.require_provider_tokens
@@ -118,6 +131,43 @@ if ! DRIFT_DIFF=$(diff <(printf '%s\n' "$LOCAL_NORM") <(printf '%s\n' "$LIVE_NOR
 else
   echo "  ok: local config matches live (modulo secrets)"
 fi
+
+log "step 1c/9: early connected-provider check"
+# Mirror of step 6c, run BEFORE binary swap so a refusal does not leave
+# the operator with new code on disk and old code running. The full
+# script does the connected-provider check twice on purpose:
+#   - step 1c here: protects the longest part of the window (between
+#     step 4 binary install and step 7 restart, which spans certbot +
+#     nginx work and can take minutes); refusing here saves the scp.
+#   - step 6c just before restart: protects against providers that
+#     connected DURING the deploy itself (between step 1c and step 7).
+# Both honor FORCE_RESTART=1, which writes a sticky tombstone at
+# /var/lib/macprovider/last-deploy-bypass.json so the NEXT deploy
+# notices the operator override (see step 1's PREV_BYPASS surface).
+CONNECTED_COUNT_EARLY=$(curl -fsS --max-time 5 --max-filesize 65536 "https://$DOMAIN/healthz" 2>/dev/null \
+  | python3 -c "import sys,json; print(json.load(sys.stdin).get('pool_size', 0))" 2>/dev/null \
+  || echo 0)
+if [ "${CONNECTED_COUNT_EARLY:-0}" -gt 0 ] && [ "${FORCE_RESTART:-0}" != "1" ]; then
+  log "  REFUSING TO DEPLOY — $CONNECTED_COUNT_EARLY provider(s) currently connected."
+  log "  Restart at step 7 would trigger SPEC-001 § 6.5 drain on these providers."
+  log "  Refusing EARLY (pre-scp) so you don't leave a new binary on disk."
+  log "  To proceed anyway:  FORCE_RESTART=1 bash $0"
+  exit 4
+fi
+if [ "${FORCE_RESTART:-0}" = "1" ] && [ "${CONNECTED_COUNT_EARLY:-0}" -gt 0 ]; then
+  TS_NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  OP_HOST="${HOSTNAME:-unknown}"
+  $SSH "set -e
+        install -d -o macprovider -g macprovider -m 0750 /var/lib/macprovider 2>/dev/null || true
+        cat > /tmp/last-deploy-bypass.json <<EOF
+{\"ts\":\"$TS_NOW\",\"service\":\"coordinator\",\"reason\":\"FORCE_RESTART=1\",\"step\":\"1c\",\"metric\":\"connected_providers\",\"value\":$CONNECTED_COUNT_EARLY,\"operator_host\":\"$OP_HOST\"}
+EOF
+        install -o macprovider -g macprovider -m 0640 /tmp/last-deploy-bypass.json /var/lib/macprovider/last-deploy-bypass.json
+        rm -f /tmp/last-deploy-bypass.json
+        logger -t macprovider-deploy \"FORCE_RESTART=1 used at step 1c; connected=$CONNECTED_COUNT_EARLY\""
+  log "  AUDIT TRAIL: FORCE_RESTART=1 override written to /var/lib/macprovider/last-deploy-bypass.json"
+fi
+log "  ok: $CONNECTED_COUNT_EARLY connected providers (or FORCE_RESTART=1 set)"
 
 log "step 2/9: install certbot + nginx-snippets (apt)"
 $SSH 'DEBIAN_FRONTEND=noninteractive apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y certbot python3-certbot-nginx >/dev/null' || {
@@ -232,14 +282,25 @@ $SSH "set -e
   systemctl reload nginx
 "
 
-log "step 6c/9: pre-restart safeguard (check for connected providers)"
+log "step 6c/9: pre-restart safeguard (late connected-provider check)"
 # Coordinator restart triggers SPEC-001 § 6.5 drain on all connected
 # providers. v1.1.3+ phase3-binary handles this gracefully (drops WS,
 # keeps serving direct traffic, reconnects after grace period). Older
 # phase3-binary (v1.1.2 and earlier) exits the process on drain — which
 # kills tunnel-direct buyer traffic. Until you can guarantee every
 # connected provider is on v1.1.3+, refuse to auto-restart with
-# connected providers unless the operator passes --force-restart.
+# connected providers unless the operator passes FORCE_RESTART=1.
+#
+# This is the LATE check — step 1c was the early one. Both exist on
+# purpose: a provider that wasn't connected at step 1c can have
+# connected during certbot/nginx work (step 2-6b is the longest part
+# of the script). The 2026-06-12 deploy had air5 connect mid-script
+# under exactly this shape; the operator manually jumped past this
+# step. The tombstone wired below + the early check + the PREV_BYPASS
+# surface at step 1 are the audit-trail trio that makes future
+# bypasses visible to the NEXT deploy. Manual jumps past this step
+# leave no trail beyond the absence of a completion marker — write
+# the bypass file by hand if jumping past, see message below.
 CONNECTED_COUNT=$(curl -fsS --max-time 5 --max-filesize 65536 "https://$DOMAIN/healthz" 2>/dev/null \
   | python3 -c "import sys,json; print(json.load(sys.stdin).get('pool_size', 0))" 2>/dev/null \
   || echo 0)
@@ -248,7 +309,23 @@ if [ "${CONNECTED_COUNT:-0}" -gt 0 ] && [ "${FORCE_RESTART:-0}" != "1" ]; then
   log "  Restart triggers drain; phase3-binary <= v1.1.2 exits the process"
   log "  on drain and breaks tunnel-direct buyer traffic."
   log "  To proceed anyway:  FORCE_RESTART=1 bash $0"
+  log "  If you must JUMP past this step manually, please first write:"
+  log "    ssh <pearl> 'echo {\"ts\":\"\$(date -u +%FT%TZ)\",\"service\":\"coordinator\",\"reason\":\"manual_jump\",\"step\":\"6c\",\"metric\":\"connected_providers\",\"value\":$CONNECTED_COUNT,\"operator_host\":\"\$HOSTNAME\"} > /var/lib/macprovider/last-deploy-bypass.json'"
+  log "  so the next deploy surfaces the bypass at step 1."
   exit 4
+fi
+if [ "${FORCE_RESTART:-0}" = "1" ] && [ "${CONNECTED_COUNT:-0}" -gt 0 ]; then
+  TS_NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  OP_HOST="${HOSTNAME:-unknown}"
+  $SSH "set -e
+        install -d -o macprovider -g macprovider -m 0750 /var/lib/macprovider 2>/dev/null || true
+        cat > /tmp/last-deploy-bypass.json <<EOF
+{\"ts\":\"$TS_NOW\",\"service\":\"coordinator\",\"reason\":\"FORCE_RESTART=1\",\"step\":\"6c\",\"metric\":\"connected_providers\",\"value\":$CONNECTED_COUNT,\"operator_host\":\"$OP_HOST\"}
+EOF
+        install -o macprovider -g macprovider -m 0640 /tmp/last-deploy-bypass.json /var/lib/macprovider/last-deploy-bypass.json
+        rm -f /tmp/last-deploy-bypass.json
+        logger -t macprovider-deploy \"FORCE_RESTART=1 used at step 6c; connected=$CONNECTED_COUNT\""
+  log "  AUDIT TRAIL: FORCE_RESTART=1 override written to /var/lib/macprovider/last-deploy-bypass.json"
 fi
 log "  ok: $CONNECTED_COUNT connected providers (or FORCE_RESTART=1 set)"
 

--- a/phase5-gateway/dist/deploy-pearl-vps.sh
+++ b/phase5-gateway/dist/deploy-pearl-vps.sh
@@ -110,6 +110,17 @@ log "step 1/8: confirm SSH + DNS"
 $SSH 'hostname && uptime' >/dev/null
 dig +short "$DOMAIN" | grep -q "$VPS_HOST" || { echo "DNS for $DOMAIN does not resolve to $VPS_HOST yet" >&2; exit 1; }
 
+# Previous-deploy bypass tombstone — the coordinator script and this
+# script share /var/lib/macprovider/last-deploy-bypass.json. Surface
+# it here so the operator can audit before scping a new binary.
+# Does NOT exit — informational only.
+PREV_BYPASS=$($SSH 'cat /var/lib/macprovider/last-deploy-bypass.json 2>/dev/null || true')
+if [ -n "$PREV_BYPASS" ]; then
+  log "  NOTE: previous deploy left a bypass tombstone:"
+  printf '%s\n' "$PREV_BYPASS" | sed 's/^/    /'
+  log "  If audited, clear with: ssh <pearl> rm /var/lib/macprovider/last-deploy-bypass.json"
+fi
+
 log "step 2/8: confirm /etc/macprovider/gateway.env exists on Pearl"
 $SSH "test -f /etc/macprovider/gateway.env || { echo 'missing /etc/macprovider/gateway.env on Pearl' >&2; exit 1; }"
 
@@ -144,13 +155,36 @@ log "step 5/8: pre-restart safeguard (check for in-flight buyer requests)"
 # overrideable.
 # We use the gateway's own /healthz which includes a coarse in-flight metric
 # when available; if absent, fall back to nginx access-log activity.
+#
+# Both this script and the coordinator's deploy-pearl-vps.sh write the
+# bypass tombstone to the same path (/var/lib/macprovider/last-deploy-bypass.json)
+# so a subsequent deploy of either service surfaces the override at its
+# step 1. Manual jumps past this step are tracked the same way as
+# manual jumps past the coordinator's step 6c — write the file by hand
+# (the refusal message below has the command).
 INFLIGHT=$(curl -fsS --max-time 5 --max-filesize 65536 "https://$DOMAIN/healthz" 2>/dev/null \
   | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('in_flight_requests', d.get('inflight', 0)))" 2>/dev/null \
   || echo 0)
 if [ "${INFLIGHT:-0}" -gt 0 ] && [ "${FORCE_RESTART:-0}" != "1" ]; then
   log "  REFUSING TO RESTART — $INFLIGHT request(s) in flight."
   log "  To proceed anyway:  FORCE_RESTART=1 bash $0"
+  log "  If you must JUMP past this step manually, please first write:"
+  log "    ssh <pearl> 'echo {\"ts\":\"\$(date -u +%FT%TZ)\",\"service\":\"gateway\",\"reason\":\"manual_jump\",\"step\":\"5\",\"metric\":\"in_flight_requests\",\"value\":$INFLIGHT,\"operator_host\":\"\$HOSTNAME\"} > /var/lib/macprovider/last-deploy-bypass.json'"
+  log "  so the next deploy surfaces the bypass at step 1."
   exit 4
+fi
+if [ "${FORCE_RESTART:-0}" = "1" ] && [ "${INFLIGHT:-0}" -gt 0 ]; then
+  TS_NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  OP_HOST="${HOSTNAME:-unknown}"
+  $SSH "set -e
+        install -d -o macprovider -g macprovider -m 0750 /var/lib/macprovider 2>/dev/null || true
+        cat > /tmp/last-deploy-bypass.json <<EOF
+{\"ts\":\"$TS_NOW\",\"service\":\"gateway\",\"reason\":\"FORCE_RESTART=1\",\"step\":\"5\",\"metric\":\"in_flight_requests\",\"value\":$INFLIGHT,\"operator_host\":\"$OP_HOST\"}
+EOF
+        install -o macprovider -g macprovider -m 0640 /tmp/last-deploy-bypass.json /var/lib/macprovider/last-deploy-bypass.json
+        rm -f /tmp/last-deploy-bypass.json
+        logger -t macprovider-deploy \"FORCE_RESTART=1 used at gateway step 5; in_flight=$INFLIGHT\""
+  log "  AUDIT TRAIL: FORCE_RESTART=1 override written to /var/lib/macprovider/last-deploy-bypass.json"
 fi
 log "  ok: $INFLIGHT in-flight requests (or FORCE_RESTART=1 set)"
 


### PR DESCRIPTION
## Summary

Closes two operational gaps that the 2026-06-12 first end-to-end M0-5/M1-6 production deploy on Pearl exposed.

### Gap 1 — connected-provider check fires too late

Coordinator `deploy-pearl-vps.sh` only runs the connected-provider check at step 6c (just before `systemctl restart`). The binary is already on disk from step 4 at that point, and the script spends minutes running certbot + nginx work in between. The window in which a provider can connect under the OLD process and get TOFU-locked-out on reconnect under the new binary spans steps 4→7, not just step 6c→7.

This PR adds an **early check at step 1c** (right after the drift check, before anything mutates Pearl state). A refusal at step 1c saves the scp and lets the operator make the call before any state mutation. The late check at step 6c stays — it catches providers that connect DURING the deploy itself.

### Gap 2 — bypasses leave no audit trail

`FORCE_RESTART=1` today silently overrides the connected-provider refusal. Manual jumps past the step (today's incident: after the nginx-dedup fix, the operator manually jumped from step 5b to step 7 to keep the deploy moving) also leave no trail. The next deploy has no signal that the previous one bypassed the safeguard.

This PR wires a three-piece audit:

1. **Step 1** reads `/var/lib/macprovider/last-deploy-bypass.json` from the previous deploy if present and surfaces it before scping anything. Informational — does not exit.
2. **Step 1c (new) and step 6c (existing)** both write the tombstone when `FORCE_RESTART=1` actually overrides a non-zero connected count. JSON includes `ts`, `service`, `reason`, `step`, `metric`, `value`, `operator_host`. Also logs to journald via `logger(1)`.
3. **Refusal messages** on both steps now include the exact one-liner to write the tombstone manually IF the operator must jump past — so the deploy session's "I bypassed it by jumping to step 7 manually" case from today would now leave a tombstone visible to the next deploy.

### Symmetric edit to phase5-gateway/dist/deploy-pearl-vps.sh

Gateway has a single in-flight-requests guard (no early/late split since it has no certbot middle). Same shape: previous-tombstone surface at step 1, `FORCE_RESTART=1` writes the tombstone, refusal message includes the manual-jump one-liner. **Same tombstone path** so a coordinator deploy following a gateway bypass still surfaces it.

## Test plan

- [x] `bash -n` on both scripts passes
- [ ] Operator next coordinator deploy: verify step 1 surfaces no tombstone (clean slate), step 1c passes (0 connected providers), step 6c passes
- [ ] Operator next coordinator deploy with deliberate `FORCE_RESTART=1` while a provider is connected: verify step 1c writes the tombstone, the next deploy's step 1 surfaces it

## Not in this PR

- **Spec change** — none. This is operational hardening. SPEC-003 v0.8.3 (PR #78) is the related auth fix that makes the deploy-gap case in-band recoverable; this PR makes the operator-level bypass case auditable.
- **Proactive drain** (actually disconnect providers gracefully before restart, rather than refusing if any are connected). Larger surface area — separate design decision.
- **Completion marker** (write `/opt/macprovider/.deploy-complete-<TS>` at script end so the next deploy can detect a previous incomplete run). Nice-to-have, separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
