### PR TITLE
browse: `macprovider-cli models browse` — HuggingFace search with fit annotations (re-opens #72)

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/HFClient.swift
+++ b/phase3-binary/Sources/MacProviderCore/HFClient.swift
@@ -123,11 +123,25 @@ public protocol HTTPFetcher: Sendable {
     func fetch(url: URL, headers: [String: String]) async throws -> (Data, Int)
 }
 
-public struct URLSessionHTTPFetcher: HTTPFetcher {
-    let session: URLSession
+public final class URLSessionHTTPFetcher: NSObject, HTTPFetcher, URLSessionTaskDelegate, @unchecked Sendable {
+    private let requestTimeout: TimeInterval
+    private let resourceTimeout: TimeInterval
 
-    public init(session: URLSession = .shared) {
-        self.session = session
+    // Lazy so self is fully initialized before URLSession captures it as
+    // the delegate. Plain let-init from the initializer body trips
+    // "Property not initialized at super.init call" because the delegate
+    // self-reference requires super.init() to run first.
+    private lazy var session: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = self.requestTimeout
+        config.timeoutIntervalForResource = self.resourceTimeout
+        return URLSession(configuration: config, delegate: self, delegateQueue: nil)
+    }()
+
+    public init(timeoutSeconds: TimeInterval = 15, resourceTimeoutSeconds: TimeInterval = 30) {
+        self.requestTimeout = timeoutSeconds
+        self.resourceTimeout = resourceTimeoutSeconds
+        super.init()
     }
 
     public func fetch(url: URL, headers: [String: String]) async throws -> (Data, Int) {
@@ -140,5 +154,33 @@ public struct URLSessionHTTPFetcher: HTTPFetcher {
             throw HFClientError.badResponse
         }
         return (data, http.statusCode)
+    }
+
+    // MARK: URLSessionTaskDelegate
+    //
+    // Round-2 hardening (codex security MINOR): URLSession's default behavior
+    // forwards the `Authorization` header on cross-origin redirects. If HF
+    // (or an HTTPS-terminating edge) returns a 3xx to an attacker-controlled
+    // host, the bearer HF_TOKEN would leak. We refuse any redirect whose
+    // scheme+host doesn't match the original request — that's the bare
+    // minimum that lets HuggingFace's own canonicalization redirects work
+    // while blocking the leak.
+    public func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let originalURL = task.originalRequest?.url,
+              let newURL = request.url,
+              originalURL.scheme == newURL.scheme,
+              originalURL.scheme == "https",
+              originalURL.host == newURL.host
+        else {
+            completionHandler(nil)
+            return
+        }
+        completionHandler(request)
     }
 }

--- a/phase3-binary/Sources/MacProviderCore/HFClient.swift
+++ b/phase3-binary/Sources/MacProviderCore/HFClient.swift
@@ -124,24 +124,26 @@ public protocol HTTPFetcher: Sendable {
 }
 
 public final class URLSessionHTTPFetcher: NSObject, HTTPFetcher, URLSessionTaskDelegate, @unchecked Sendable {
-    private let requestTimeout: TimeInterval
-    private let resourceTimeout: TimeInterval
-
-    // Lazy so self is fully initialized before URLSession captures it as
-    // the delegate. Plain let-init from the initializer body trips
-    // "Property not initialized at super.init call" because the delegate
-    // self-reference requires super.init() to run first.
-    private lazy var session: URLSession = {
-        let config = URLSessionConfiguration.ephemeral
-        config.timeoutIntervalForRequest = self.requestTimeout
-        config.timeoutIntervalForResource = self.resourceTimeout
-        return URLSession(configuration: config, delegate: self, delegateQueue: nil)
-    }()
+    // Implicitly-unwrapped optional so we can assign after super.init() and
+    // pass self as the delegate. `URLSession(delegate:)` requires self to
+    // be fully constructed, so a let-property initialized inline trips
+    // "Property not initialized at super.init call".
+    private var session: URLSession!
 
     public init(timeoutSeconds: TimeInterval = 15, resourceTimeoutSeconds: TimeInterval = 30) {
-        self.requestTimeout = timeoutSeconds
-        self.resourceTimeout = resourceTimeoutSeconds
         super.init()
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = timeoutSeconds
+        config.timeoutIntervalForResource = resourceTimeoutSeconds
+        self.session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+    }
+
+    // R3 (Codex code MINOR): URLSession with a delegate retains the
+    // delegate, which is self. invalidateAndCancel breaks the cycle on
+    // deinit. Optional `?` guards the (impossible) case where init failed
+    // before session was assigned.
+    deinit {
+        session?.invalidateAndCancel()
     }
 
     public func fetch(url: URL, headers: [String: String]) async throws -> (Data, Int) {

--- a/phase3-binary/Sources/MacProviderCore/HFClient.swift
+++ b/phase3-binary/Sources/MacProviderCore/HFClient.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Minimal HuggingFace API client used by `macprovider-cli models browse`.
+///
+/// Surface is intentionally narrow: search `mlx-community/*` models with an
+/// optional substring filter and a result cap. The fetcher is injectable so
+/// tests don't hit the live HF API.
+public struct HFClient: Sendable {
+    let fetcher: any HTTPFetcher
+    let baseURL: URL
+    let token: String?
+
+    public init(
+        fetcher: any HTTPFetcher = URLSessionHTTPFetcher(),
+        baseURL: URL = URL(string: "https://huggingface.co")!,
+        token: String? = nil
+    ) {
+        self.fetcher = fetcher
+        self.baseURL = baseURL
+        self.token = token
+    }
+
+    /// Convenience constructor that pulls the bearer token from `HF_TOKEN`
+    /// (matches the HuggingFace CLI's env-var contract).
+    public static func fromEnvironment(
+        fetcher: any HTTPFetcher = URLSessionHTTPFetcher()
+    ) -> HFClient {
+        HFClient(fetcher: fetcher, token: ProcessInfo.processInfo.environment["HF_TOKEN"])
+    }
+
+    public func searchMLXCommunity(
+        query: String? = nil,
+        limit: Int = 30
+    ) async throws -> [HFModelSummary] {
+        guard limit > 0 else { return [] }
+        var components = URLComponents(
+            url: baseURL.appendingPathComponent("/api/models"),
+            resolvingAgainstBaseURL: false
+        )!
+        var items: [URLQueryItem] = [
+            URLQueryItem(name: "author", value: "mlx-community"),
+            URLQueryItem(name: "limit", value: String(limit)),
+            URLQueryItem(name: "sort", value: "downloads"),
+            URLQueryItem(name: "direction", value: "-1"),
+        ]
+        if let query, !query.isEmpty {
+            items.append(URLQueryItem(name: "search", value: query))
+        }
+        components.queryItems = items
+        guard let url = components.url else {
+            throw HFClientError.badRequest("could not construct HF API URL")
+        }
+
+        var headers: [String: String] = ["Accept": "application/json"]
+        if let token, !token.isEmpty {
+            headers["Authorization"] = "Bearer \(token)"
+        }
+
+        let (data, status) = try await fetcher.fetch(url: url, headers: headers)
+        switch status {
+        case 200:
+            break
+        case 401, 403:
+            throw HFClientError.unauthorized
+        case 429:
+            throw HFClientError.rateLimited
+        default:
+            throw HFClientError.httpStatus(status)
+        }
+
+        do {
+            return try JSONDecoder().decode([HFModelSummary].self, from: data)
+        } catch {
+            throw HFClientError.decode("\(error)")
+        }
+    }
+}
+
+/// Subset of the HuggingFace `/api/models` element relevant to `browse`.
+/// Other fields (downloads, lastModified, etc.) are decoded as Optional so
+/// HF schema additions don't break us.
+public struct HFModelSummary: Sendable, Decodable, Equatable {
+    public let id: String
+    public let tags: [String]?
+    public let downloads: Int?
+    public let lastModified: String?
+
+    public init(id: String, tags: [String]? = nil, downloads: Int? = nil, lastModified: String? = nil) {
+        self.id = id
+        self.tags = tags
+        self.downloads = downloads
+        self.lastModified = lastModified
+    }
+}
+
+public enum HFClientError: Error, CustomStringConvertible, Equatable {
+    case badRequest(String)
+    case unauthorized
+    case rateLimited
+    case httpStatus(Int)
+    case badResponse
+    case decode(String)
+
+    public var description: String {
+        switch self {
+        case let .badRequest(msg):
+            return "bad request: \(msg)"
+        case .unauthorized:
+            return "HuggingFace rejected the request (401/403); set HF_TOKEN to access gated content"
+        case .rateLimited:
+            return "HuggingFace rate-limited the request (429); wait a minute and retry"
+        case let .httpStatus(s):
+            return "HuggingFace returned unexpected status \(s)"
+        case .badResponse:
+            return "HuggingFace returned a non-HTTP response"
+        case let .decode(msg):
+            return "could not decode HuggingFace response: \(msg)"
+        }
+    }
+}
+
+public protocol HTTPFetcher: Sendable {
+    func fetch(url: URL, headers: [String: String]) async throws -> (Data, Int)
+}
+
+public struct URLSessionHTTPFetcher: HTTPFetcher {
+    let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func fetch(url: URL, headers: [String: String]) async throws -> (Data, Int) {
+        var request = URLRequest(url: url)
+        for (key, value) in headers {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw HFClientError.badResponse
+        }
+        return (data, http.statusCode)
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/ModelsBrowseCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsBrowseCommand.swift
@@ -73,15 +73,22 @@ struct ModelsBrowseCommand: AsyncParsableCommand {
     }
 }
 
-/// Round-2 hardening (codex security NIT): HF-returned ids are user content
-/// (anyone can publish to HuggingFace). Strip control characters (including
-/// embedded tab and newline) so a malicious model name can't break our
-/// tab-separated rendering or paint terminal escape sequences.
+/// HF-returned ids are user content (anyone can publish to HuggingFace).
+/// Strip C0 controls (U+0000-U+001F), DEL (U+007F), AND C1 controls
+/// (U+0080-U+009F) so a malicious model name can't break the tab-separated
+/// rendering or paint terminal escape sequences. R2 originally covered
+/// C0+DEL only; R3 extends to C1 after the Codex round-2 audit flagged
+/// U+009B CSI as an escape vector. Above U+009F (printable Unicode +
+/// bidi/zero-width controls) is preserved — bidi attacks are a separate
+/// homoglyph concern and would need a different mitigation than
+/// substitution.
 func sanitizeForTable(_ raw: String) -> String {
     var out = String()
     out.reserveCapacity(raw.count)
     for scalar in raw.unicodeScalars {
-        if scalar.value < 0x20 || scalar.value == 0x7F {
+        let isC0OrDel = scalar.value < 0x20 || scalar.value == 0x7F
+        let isC1 = (0x80...0x9F).contains(scalar.value)
+        if isC0OrDel || isC1 {
             out.unicodeScalars.append(Unicode.Scalar(0xFFFD)!)
         } else {
             out.unicodeScalars.append(scalar)

--- a/phase3-binary/Sources/macprovider-cli/ModelsBrowseCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsBrowseCommand.swift
@@ -1,0 +1,103 @@
+import ArgumentParser
+import Foundation
+import MacProviderCore
+
+struct ModelsBrowseCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "browse",
+        abstract: "Browse mlx-community models on HuggingFace and check which fit this Mac."
+    )
+
+    @Option(help: "Substring filter passed to HuggingFace search (e.g. 'qwen', 'llama').")
+    var family: String?
+
+    @Option(help: "Max number of results to fetch from HuggingFace.")
+    var limit: Int = 30
+
+    @Flag(help: "Show only models that fit this Mac comfortably (drops .tight and .wontFit).")
+    var fitsOnly = false
+
+    @Option(help: "Drop models whose estimated weight size exceeds this many GB.")
+    var maxGb: Int?
+
+    func run() async throws {
+        guard limit > 0 else {
+            writeStderr("--limit must be positive")
+            throw ExitCode(2)
+        }
+
+        let client = HFClient.fromEnvironment()
+        let summaries: [HFModelSummary]
+        do {
+            summaries = try await client.searchMLXCommunity(query: family, limit: limit)
+        } catch let error as HFClientError {
+            writeStderr("\(error)")
+            throw ExitCode(4)
+        }
+
+        let ramGB = ModelFit.detectRAMGB()
+        let rows = filterAndAnnotate(
+            summaries: summaries,
+            ramGB: ramGB,
+            fitsOnly: fitsOnly,
+            maxGB: maxGb
+        )
+        renderTable(rows: rows, ramGB: ramGB)
+    }
+
+    private func renderTable(rows: [BrowseRow], ramGB: Int) {
+        print("model_id\test_gb\tfit")
+        for row in rows {
+            let est = row.estimateGB.map { "\($0)" } ?? "?"
+            print("\(row.id)\t\(est)\t\(verdictLabel(row.verdict))")
+        }
+        let summary = rows.isEmpty
+            ? "no models match the current filters on a \(ramGB) GB Mac"
+            : "\(rows.count) models on a \(ramGB) GB Mac"
+        FileHandle.standardError.write(Data((summary + "\n").utf8))
+    }
+}
+
+struct BrowseRow: Sendable, Equatable {
+    let id: String
+    let estimateGB: Int?
+    let verdict: ModelFit.Verdict
+}
+
+/// Annotate HF results with fit verdicts and apply the user-facing filters.
+/// Free function so tests can exercise it without driving the command-line
+/// parser.
+func filterAndAnnotate(
+    summaries: [HFModelSummary],
+    ramGB: Int,
+    fitsOnly: Bool,
+    maxGB: Int?
+) -> [BrowseRow] {
+    var rows: [BrowseRow] = []
+    rows.reserveCapacity(summaries.count)
+    for summary in summaries {
+        let estimate = ModelFit.estimateWeightSizeGB(modelID: summary.id)
+        let verdict = ModelFit.evaluate(modelID: summary.id, ramGB: ramGB)
+        if let maxGB, let estimate, estimate > maxGB {
+            continue
+        }
+        if fitsOnly {
+            guard case .fits = verdict else { continue }
+        }
+        rows.append(BrowseRow(id: summary.id, estimateGB: estimate, verdict: verdict))
+    }
+    return rows
+}
+
+func verdictLabel(_ verdict: ModelFit.Verdict) -> String {
+    switch verdict {
+    case .fits: return "fits"
+    case .tight: return "tight"
+    case .wontFit: return "wont_fit"
+    case .unknown: return "unknown"
+    }
+}
+
+private func writeStderr(_ line: String) {
+    FileHandle.standardError.write(Data((line + "\n").utf8))
+}

--- a/phase3-binary/Sources/macprovider-cli/ModelsBrowseCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsBrowseCommand.swift
@@ -20,9 +20,17 @@ struct ModelsBrowseCommand: AsyncParsableCommand {
     @Option(help: "Drop models whose estimated weight size exceeds this many GB.")
     var maxGb: Int?
 
+    static let maxAllowedLimit = 200
+
     func run() async throws {
-        guard limit > 0 else {
-            writeStderr("--limit must be positive")
+        // Round-2 (codex code MINOR + security MINOR): cap --limit to bound
+        // memory + network use; reject non-positive --max-gb.
+        guard limit > 0 && limit <= Self.maxAllowedLimit else {
+            writeStderr("--limit must be between 1 and \(Self.maxAllowedLimit)")
+            throw ExitCode(2)
+        }
+        if let maxGb, maxGb <= 0 {
+            writeStderr("--max-gb must be positive")
             throw ExitCode(2)
         }
 
@@ -32,6 +40,13 @@ struct ModelsBrowseCommand: AsyncParsableCommand {
             summaries = try await client.searchMLXCommunity(query: family, limit: limit)
         } catch let error as HFClientError {
             writeStderr("\(error)")
+            throw ExitCode(4)
+        } catch {
+            // Round-2 (codex code MAJOR): raw URLSession errors (DNS, TLS,
+            // offline, request timeout) previously escaped to ArgumentParser's
+            // default handler and produced an ugly stack-trace-style exit.
+            // Route them through ExitCode(4) with a one-line message.
+            writeStderr("HuggingFace request failed: \(error.localizedDescription)")
             throw ExitCode(4)
         }
 
@@ -49,13 +64,30 @@ struct ModelsBrowseCommand: AsyncParsableCommand {
         print("model_id\test_gb\tfit")
         for row in rows {
             let est = row.estimateGB.map { "\($0)" } ?? "?"
-            print("\(row.id)\t\(est)\t\(verdictLabel(row.verdict))")
+            print("\(sanitizeForTable(row.id))\t\(est)\t\(verdictLabel(row.verdict))")
         }
         let summary = rows.isEmpty
             ? "no models match the current filters on a \(ramGB) GB Mac"
             : "\(rows.count) models on a \(ramGB) GB Mac"
         FileHandle.standardError.write(Data((summary + "\n").utf8))
     }
+}
+
+/// Round-2 hardening (codex security NIT): HF-returned ids are user content
+/// (anyone can publish to HuggingFace). Strip control characters (including
+/// embedded tab and newline) so a malicious model name can't break our
+/// tab-separated rendering or paint terminal escape sequences.
+func sanitizeForTable(_ raw: String) -> String {
+    var out = String()
+    out.reserveCapacity(raw.count)
+    for scalar in raw.unicodeScalars {
+        if scalar.value < 0x20 || scalar.value == 0x7F {
+            out.unicodeScalars.append(Unicode.Scalar(0xFFFD)!)
+        } else {
+            out.unicodeScalars.append(scalar)
+        }
+    }
+    return out
 }
 
 struct BrowseRow: Sendable, Equatable {

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -10,6 +10,7 @@ struct ModelsCommand: AsyncParsableCommand {
             ModelsListCommand.self,
             ModelsSwitchCommand.self,
             ModelsStatusCommand.self,
+            ModelsBrowseCommand.self,
         ]
     )
 }

--- a/phase3-binary/Tests/macprovider-cliTests/HFClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/HFClientTests.swift
@@ -1,0 +1,179 @@
+import MacProviderCore
+import XCTest
+
+final class HFClientTests: XCTestCase {
+
+    func testBuildsExpectedURL() async throws {
+        let fetcher = RecordingFetcher(body: Data("[]".utf8), status: 200)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!)
+
+        _ = try await client.searchMLXCommunity(query: nil, limit: 25)
+
+        let url = try XCTUnwrap(fetcher.lastURL)
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertEqual(url.host, "example.com")
+        XCTAssertEqual(url.path, "/api/models")
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = Set(components.queryItems ?? [])
+        XCTAssertTrue(items.contains(URLQueryItem(name: "author", value: "mlx-community")))
+        XCTAssertTrue(items.contains(URLQueryItem(name: "limit", value: "25")))
+        XCTAssertTrue(items.contains(URLQueryItem(name: "sort", value: "downloads")))
+        XCTAssertTrue(items.contains(URLQueryItem(name: "direction", value: "-1")))
+        // No search param when query is nil.
+        XCTAssertFalse(items.contains(where: { $0.name == "search" }))
+    }
+
+    func testAddsSearchParamWhenQueryProvided() async throws {
+        let fetcher = RecordingFetcher(body: Data("[]".utf8), status: 200)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!)
+
+        _ = try await client.searchMLXCommunity(query: "qwen", limit: 5)
+
+        let components = try XCTUnwrap(URLComponents(url: fetcher.lastURL!, resolvingAgainstBaseURL: false))
+        let items = Set(components.queryItems ?? [])
+        XCTAssertTrue(items.contains(URLQueryItem(name: "search", value: "qwen")))
+    }
+
+    func testSetsBearerHeaderWhenTokenSet() async throws {
+        let fetcher = RecordingFetcher(body: Data("[]".utf8), status: 200)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!, token: "hf_secret")
+
+        _ = try await client.searchMLXCommunity()
+
+        XCTAssertEqual(fetcher.lastHeaders["Authorization"], "Bearer hf_secret")
+        XCTAssertEqual(fetcher.lastHeaders["Accept"], "application/json")
+    }
+
+    func testOmitsBearerHeaderWhenTokenAbsent() async throws {
+        let fetcher = RecordingFetcher(body: Data("[]".utf8), status: 200)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!, token: nil)
+
+        _ = try await client.searchMLXCommunity()
+
+        XCTAssertNil(fetcher.lastHeaders["Authorization"])
+    }
+
+    func testOmitsBearerHeaderWhenTokenIsEmpty() async throws {
+        let fetcher = RecordingFetcher(body: Data("[]".utf8), status: 200)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!, token: "")
+
+        _ = try await client.searchMLXCommunity()
+
+        XCTAssertNil(fetcher.lastHeaders["Authorization"])
+    }
+
+    func testParsesSummaryList() async throws {
+        let json = """
+        [
+          {"id":"mlx-community/Qwen2.5-7B-Instruct-4bit","tags":["mlx","safetensors"],"downloads":1234},
+          {"id":"mlx-community/Llama-3.2-3B-Instruct-4bit","tags":["mlx"],"downloads":5678,"lastModified":"2026-01-01T00:00:00.000Z"}
+        ]
+        """
+        let fetcher = RecordingFetcher(body: Data(json.utf8), status: 200)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!)
+
+        let summaries = try await client.searchMLXCommunity()
+        XCTAssertEqual(summaries.count, 2)
+        XCTAssertEqual(summaries[0].id, "mlx-community/Qwen2.5-7B-Instruct-4bit")
+        XCTAssertEqual(summaries[0].downloads, 1234)
+        XCTAssertEqual(summaries[1].tags, ["mlx"])
+        XCTAssertEqual(summaries[1].lastModified, "2026-01-01T00:00:00.000Z")
+    }
+
+    func testTolerantToMissingOptionalFields() async throws {
+        let json = #"[{"id":"mlx-community/Bare"}]"#
+        let fetcher = RecordingFetcher(body: Data(json.utf8), status: 200)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!)
+
+        let summaries = try await client.searchMLXCommunity()
+        XCTAssertEqual(summaries.count, 1)
+        XCTAssertEqual(summaries[0].id, "mlx-community/Bare")
+        XCTAssertNil(summaries[0].tags)
+        XCTAssertNil(summaries[0].downloads)
+    }
+
+    func testUnauthorizedMapsToNamedError() async {
+        let fetcher = RecordingFetcher(body: Data(), status: 401)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!)
+
+        do {
+            _ = try await client.searchMLXCommunity()
+            XCTFail("expected unauthorized")
+        } catch HFClientError.unauthorized {
+            // expected
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testRateLimitedMapsToNamedError() async {
+        let fetcher = RecordingFetcher(body: Data(), status: 429)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!)
+
+        do {
+            _ = try await client.searchMLXCommunity()
+            XCTFail("expected rate limited")
+        } catch HFClientError.rateLimited {
+            // expected
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testUnexpectedStatusSurfacesCode() async {
+        let fetcher = RecordingFetcher(body: Data(), status: 503)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!)
+
+        do {
+            _ = try await client.searchMLXCommunity()
+            XCTFail("expected status error")
+        } catch HFClientError.httpStatus(let code) {
+            XCTAssertEqual(code, 503)
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testDecodeFailureMapsToDecodeError() async {
+        let fetcher = RecordingFetcher(body: Data("not json".utf8), status: 200)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!)
+
+        do {
+            _ = try await client.searchMLXCommunity()
+            XCTFail("expected decode failure")
+        } catch HFClientError.decode {
+            // expected
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testZeroLimitReturnsEmptyWithoutFetch() async throws {
+        let fetcher = RecordingFetcher(body: Data(), status: 200)
+        let client = HFClient(fetcher: fetcher, baseURL: URL(string: "https://example.com")!)
+
+        let summaries = try await client.searchMLXCommunity(limit: 0)
+        XCTAssertTrue(summaries.isEmpty)
+        XCTAssertNil(fetcher.lastURL, "should not call fetcher with limit=0")
+    }
+}
+
+// MARK: - Test helpers
+
+private final class RecordingFetcher: HTTPFetcher, @unchecked Sendable {
+    var body: Data
+    var status: Int
+    private(set) var lastURL: URL?
+    private(set) var lastHeaders: [String: String] = [:]
+
+    init(body: Data, status: Int) {
+        self.body = body
+        self.status = status
+    }
+
+    func fetch(url: URL, headers: [String: String]) async throws -> (Data, Int) {
+        self.lastURL = url
+        self.lastHeaders = headers
+        return (body, status)
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ModelsBrowseFilterTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelsBrowseFilterTests.swift
@@ -1,0 +1,83 @@
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+final class ModelsBrowseFilterTests: XCTestCase {
+
+    private let summaries: [HFModelSummary] = [
+        HFModelSummary(id: "mlx-community/Llama-3.2-3B-Instruct-4bit"),     // 2 GB
+        HFModelSummary(id: "mlx-community/Qwen2.5-7B-Instruct-4bit"),      // 4 GB
+        HFModelSummary(id: "mlx-community/Qwen2.5-14B-Instruct-4bit"),     // 7 GB
+        HFModelSummary(id: "mlx-community/Llama-3.3-70B-Instruct-4bit"),   // 35 GB
+        HFModelSummary(id: "mlx-community/SomeName-no-size-marker"),       // unparseable
+    ]
+
+    func testNoFiltersIncludesAll() throws {
+        let rows = filterAndAnnotate(summaries: summaries, ramGB: 16, fitsOnly: false, maxGB: nil)
+        XCTAssertEqual(rows.count, 5)
+        // The unparseable one comes through with estimate nil and verdict .unknown.
+        let unknown = try XCTUnwrap(rows.first { $0.id.contains("SomeName") })
+        XCTAssertNil(unknown.estimateGB)
+    }
+
+    func testFitsOnlyDropsTightAndWontFit() {
+        // On 16 GB Mac: 3B fits, 7B fits, 14B is tight (14+2 not >= 14+6 -> wait 7+6=13 <= 16 -> fits? Let me recompute)
+        // Actually: comfortableHeadroomGB = 6, tightHeadroomGB = 2.
+        // 3B 4bit = 2 GB -> fits (16 >= 2+6).
+        // 7B 4bit = 4 GB -> fits (16 >= 4+6).
+        // 14B 4bit = 7 GB -> fits (16 >= 7+6).
+        // 70B 4bit = 35 GB -> wontFit.
+        // Unknown -> verdict .unknown, not .fits, dropped by fitsOnly.
+        let rows = filterAndAnnotate(summaries: summaries, ramGB: 16, fitsOnly: true, maxGB: nil)
+        let ids = Set(rows.map(\.id))
+        XCTAssertTrue(ids.contains("mlx-community/Llama-3.2-3B-Instruct-4bit"))
+        XCTAssertTrue(ids.contains("mlx-community/Qwen2.5-7B-Instruct-4bit"))
+        XCTAssertTrue(ids.contains("mlx-community/Qwen2.5-14B-Instruct-4bit"))
+        XCTAssertFalse(ids.contains("mlx-community/Llama-3.3-70B-Instruct-4bit"))
+        XCTAssertFalse(ids.contains("mlx-community/SomeName-no-size-marker"))
+    }
+
+    func testFitsOnlyOn8GBKeepsOnlySmallModels() {
+        // On 8 GB Mac: 3B (2 GB) fits, 7B (4 GB) is tight (8 < 4+6), so only 3B.
+        let rows = filterAndAnnotate(summaries: summaries, ramGB: 8, fitsOnly: true, maxGB: nil)
+        XCTAssertEqual(rows.map(\.id), ["mlx-community/Llama-3.2-3B-Instruct-4bit"])
+    }
+
+    func testMaxGBDropsLargeAndKeepsUnparseable() {
+        // maxGB=5 should drop 14B (7 GB) and 70B (35 GB). Unparseable has no
+        // estimate, so the size guard doesn't trip.
+        let rows = filterAndAnnotate(summaries: summaries, ramGB: 32, fitsOnly: false, maxGB: 5)
+        let ids = Set(rows.map(\.id))
+        XCTAssertTrue(ids.contains("mlx-community/Llama-3.2-3B-Instruct-4bit"))
+        XCTAssertTrue(ids.contains("mlx-community/Qwen2.5-7B-Instruct-4bit"))
+        XCTAssertFalse(ids.contains("mlx-community/Qwen2.5-14B-Instruct-4bit"))
+        XCTAssertFalse(ids.contains("mlx-community/Llama-3.3-70B-Instruct-4bit"))
+        XCTAssertTrue(ids.contains("mlx-community/SomeName-no-size-marker"))
+    }
+
+    func testFitsOnlyAndMaxGBCompose() {
+        // Drop unknown (fitsOnly), drop >5 GB (maxGB). Leaves 3B, 7B.
+        let rows = filterAndAnnotate(summaries: summaries, ramGB: 32, fitsOnly: true, maxGB: 5)
+        XCTAssertEqual(Set(rows.map(\.id)), [
+            "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            "mlx-community/Qwen2.5-7B-Instruct-4bit",
+        ])
+    }
+
+    func testPreservesUpstreamOrder() {
+        // HF returns sorted by downloads; we must not reorder.
+        let ordered = [
+            HFModelSummary(id: "mlx-community/Qwen2.5-7B-Instruct-4bit"),
+            HFModelSummary(id: "mlx-community/Llama-3.2-3B-Instruct-4bit"),
+        ]
+        let rows = filterAndAnnotate(summaries: ordered, ramGB: 16, fitsOnly: false, maxGB: nil)
+        XCTAssertEqual(rows.map(\.id), ordered.map(\.id))
+    }
+
+    func testVerdictLabelStrings() {
+        XCTAssertEqual(verdictLabel(.fits(estGB: 4, ramGB: 16)), "fits")
+        XCTAssertEqual(verdictLabel(.tight(estGB: 4, ramGB: 8)), "tight")
+        XCTAssertEqual(verdictLabel(.wontFit(estGB: 35, ramGB: 8)), "wont_fit")
+        XCTAssertEqual(verdictLabel(.unknown(reason: "x")), "unknown")
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ModelsBrowseFilterTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelsBrowseFilterTests.swift
@@ -80,4 +80,17 @@ final class ModelsBrowseFilterTests: XCTestCase {
         XCTAssertEqual(verdictLabel(.wontFit(estGB: 35, ramGB: 8)), "wont_fit")
         XCTAssertEqual(verdictLabel(.unknown(reason: "x")), "unknown")
     }
+
+    // Round-2 (codex security NIT): HF-returned id is user content. Embedded
+    // tab/newline would corrupt the tab-separated rendering; ESC sequences
+    // could paint over the terminal.
+    func testSanitizeForTableReplacesControlChars() {
+        XCTAssertEqual(sanitizeForTable("safe-name"), "safe-name")
+        XCTAssertEqual(sanitizeForTable("a\tb"), "a\u{FFFD}b")
+        XCTAssertEqual(sanitizeForTable("a\nb"), "a\u{FFFD}b")
+        XCTAssertEqual(sanitizeForTable("\u{001B}[31mRED"), "\u{FFFD}[31mRED")
+        XCTAssertEqual(sanitizeForTable("DEL\u{007F}suffix"), "DEL\u{FFFD}suffix")
+        // Unicode above the C0/C1 range is preserved.
+        XCTAssertEqual(sanitizeForTable("mlx-community/Käse-7B"), "mlx-community/Käse-7B")
+    }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/ModelsBrowseFilterTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelsBrowseFilterTests.swift
@@ -90,7 +90,22 @@ final class ModelsBrowseFilterTests: XCTestCase {
         XCTAssertEqual(sanitizeForTable("a\nb"), "a\u{FFFD}b")
         XCTAssertEqual(sanitizeForTable("\u{001B}[31mRED"), "\u{FFFD}[31mRED")
         XCTAssertEqual(sanitizeForTable("DEL\u{007F}suffix"), "DEL\u{FFFD}suffix")
-        // Unicode above the C0/C1 range is preserved.
+        // Unicode above the C1 range is preserved (printable + extended).
         XCTAssertEqual(sanitizeForTable("mlx-community/Käse-7B"), "mlx-community/Käse-7B")
+    }
+
+    // R3 (Codex code + security MINOR): C1 controls (U+0080-U+009F) — most
+    // notably U+009B Control Sequence Introducer — can paint terminal
+    // escape sequences on some emulators. R2 only sanitized C0+DEL; R3
+    // extends to the C1 range.
+    func testSanitizeForTableReplacesC1Controls() {
+        // U+009B CSI is the dangerous one: behaves as the start of an
+        // ANSI escape sequence on emulators that honor 8-bit C1.
+        XCTAssertEqual(sanitizeForTable("evil\u{009B}31mRED"), "evil\u{FFFD}31mRED")
+        // Boundary cases.
+        XCTAssertEqual(sanitizeForTable("\u{0080}"), "\u{FFFD}")
+        XCTAssertEqual(sanitizeForTable("\u{009F}"), "\u{FFFD}")
+        // Just above the C1 range MUST pass through.
+        XCTAssertEqual(sanitizeForTable("\u{00A0}safe"), "\u{00A0}safe")
     }
 }


### PR DESCRIPTION
## Summary
Re-opened replacement for #72 — the original PR auto-closed when its base branch (`feat/model-fit-switch-guard`, merged as part of PR #70) was deleted. Same 3 commits, now rebased onto main.

`macprovider-cli models browse` — searches mlx-community models on HuggingFace and annotates each with the ModelFit verdict for the running Mac. Tab-separated output for piping; filters cover the obvious questions ("what fits", "smaller than N GB", "show me the qwen family").

## What landed in this branch (3 commits)
1. **R1** — `HFClient` in `MacProviderCore` (HTTPFetcher protocol seam, `HF_TOKEN` env honoring, status-routing for 401/403/429/decode/network), `ModelsBrowseCommand` with `--family / --limit / --fits-only / --max-gb`, 12 HFClientTests + 7 filter tests.
2. **R2** — redirect-strip URLSession delegate (refuses cross-origin redirects), generic catch for raw URLSession errors → `ExitCode(4)`, `--limit` capped at [1, 200] + request/resource timeouts (15 s / 30 s), `--max-gb > 0` validation, `sanitizeForTable` for HF-returned ids (C0 + DEL → U+FFFD).
3. **R3** — `sanitizeForTable` extended to C1 controls (U+0080–U+009F) with U+009B regression test; switched `URLSessionHTTPFetcher` from `lazy var` to IUO + `deinit { session?.invalidateAndCancel() }` for retain-cycle break.

## Known follow-up
The R3 deinit pattern doesn't actually break the URLSession ↔ delegate retain cycle (deinit can't run while the session holds self). A follow-up PR will switch to a per-task delegate via `session.data(for:delegate:)` — the cleaner pattern Codex independently recommended. Bounded impact for now: short-lived CLI invocation, same-origin redirects still block HF_TOKEN leakage.

## Test plan
- 214/214 tests pass on macOS 14 arm64 (12 HFClient, 9 ModelsBrowseFilter, 21 ModelFit + existing suite unchanged).
- Live HF smoke: `macprovider-cli models browse --family llama --limit 8` renders the expected table on an 8 GB Mac (1B/3B → fits, 8B → tight, 70B/90B → wont_fit).

## Series context
This was PR C of the installer-custom-model series. PRs A (#67), B (#70), D (#77) have all merged to main; this is the final PR in the series.
