### PR TITLE
docs(OPS.md): path-filter the M3-2 cutover-watch query to /internal/*

### DIFF
--- a/OPS.md
+++ b/OPS.md
@@ -199,13 +199,32 @@ gateway side fails closed on the same pattern as of the same fix.
 4. `sudo systemctl reload macprovider-coordinator` so the coordinator
    re-reads `gateway_service_token`.
 5. Restart each gateway so it sends the new service token upstream.
-6. Watch the audit log:
-   `journalctl -u macprovider-coordinator -f | grep internal_bearer_accepted`
-   Look for `key=service_token` on every gateway-origin internal hit.
-7. After **24h of zero** `key=operator_key` on gateway-origin hits,
-   rotate the legacy `operator_key` (steps below). Admin tooling
-   needs the new operator key; gateways do not, since they are now on
-   service token.
+6. Watch the audit log on the BRIDGE paths only — `/internal/*`:
+   ```
+   journalctl -u macprovider-coordinator -f | \
+     grep -E 'internal_bearer_accepted.*"path":"/internal/'
+   ```
+   Look for `"key":"service_token"` on every gateway-origin
+   `/internal/*` hit. (The bridge paths are `/internal/routing` and
+   `/internal/sticky`; they fire on buyer disclosure + sticky-route
+   maintenance.)
+7. After **24h of zero** `"key":"operator_key"` on gateway-origin
+   `/internal/*` hits, rotate the legacy `operator_key` (steps below).
+   Cutover-countdown one-liner:
+   ```
+   journalctl -u macprovider-coordinator --since "24h ago" | \
+     grep -E 'internal_bearer_accepted.*"key":"operator_key".*"path":"/internal/' | \
+     wc -l    # must be 0 before rotating
+   ```
+   Admin tooling needs the new operator key; gateways do not, since
+   they are now on service token.
+
+   **Note on `/poolz`:** the gateway polls `/poolz` every 10s for
+   pool-state caching. `/poolz` is an admin-scoped endpoint (per
+   codex PR #73 HIGH-1 fix) so its bearer is `operator_key` —
+   forever. That is by design: `/poolz` audit-log lines with
+   `"key":"operator_key","path":"/poolz"` are NOT cutover-blocking
+   and must be excluded from the countdown grep above.
 
 ### Rotating `operator_key` (human admin)
 


### PR DESCRIPTION
Surfaced during the live M3-2 deploy to Pearl this session.

The cutover-countdown query I wrote in `OPS.md §6` step 7 was:

```
journalctl -u macprovider-coordinator -f | grep internal_bearer_accepted
# "after 24h of zero key=operator_key, rotate"
```

That signal will **never reach zero**. The gateway polls `/poolz` every 10s (per `gateway.yaml: coordinator.poolz_poll_interval_s`), and `/poolz` is an **admin-scoped endpoint per codex PR #73 HIGH-1 fix** — its bearer is `operator_key`, by design, forever.

The actual cutover signal is gateway-origin **`/internal/*`** calls (`/internal/routing` for buyer disclosure, `/internal/sticky` for sticky-route maintenance). Those are the dual-credential paths that converge to `key=service_token` once the gateway is plumbed.

Verified live on Pearl post-deploy:

```
GET /internal/routing  Bearer=operator_key    → 200 (audit: key=operator_key path=/internal/routing)
GET /internal/routing  Bearer=service_token   → 200 (audit: key=service_token path=/internal/routing)
GET /poolz             Bearer=operator_key    → 200 (audit: key=operator_key path=/poolz)  ← admin-scoped, forever
GET /poolz             Bearer=service_token   → 401 (admin-scoped rejects service_token)
```

## Fix

- §6 step 6: grep adds `"path":"/internal/`.
- §6 step 7: countdown one-liner `journalctl ... | grep ... | wc -l` (must read 0 before rotation).
- New paragraph explaining `/poolz` is intentionally admin-scoped and its `key=operator_key` log lines are NOT cutover-blocking.

Single-file, docs-only, 26 insertions / 7 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
