### PR TITLE
m2-1d: close WS queue-full bypass (Q3 close-out; Q1 stays open for M2-1e)

### DIFF
--- a/phase4-coordinator/internal/buyer/forward_loop_test.go
+++ b/phase4-coordinator/internal/buyer/forward_loop_test.go
@@ -310,3 +310,110 @@ func TestM2_1C_RowSequence_WSNonStreamingFailoverDoesNotBumpRetried(t *testing.T
 		t.Fatalf("rows[1].Retried = %d, want 0 (failover ≠ retry — must not bump explicitRetries)", rows[1].Retried)
 	}
 }
+
+// Scenario 5 (M2-1d): WS-non-streaming queue-full → advance → success.
+//
+// Pins the Q3 close-out from the post-merge architect verification of
+// PR #91. Pre-M2-1d the queue-full branch at server.go:1357-1367
+// inline-mutated state.explicitRetries / state.faultedProviders and
+// called selectProviderExcluding directly — bypassing the shared
+// advanceToNextProvider helper that M2-1a (PR #48) hoisted exactly to
+// centralize this mutation. M2-1d routes queue-full through
+// advanceToNextProvider; this test pins the resulting row sequence.
+//
+// CRITICAL pins (byte-identical to PR #91 baseline):
+//   - 2 logAttempt rows: (503 queue-full row, retried=0) then
+//     (200 success row, retried=1). Status 503 comes from
+//     wsEndHTTPStatus("error_queue_full") → ServiceUnavailable
+//     populated into attempt.Status at server.go:1669; logAttempt's
+//     "use attempt.Status when non-zero, else fallback" rule means
+//     the 502 fallback passed by the helper is overridden. This is
+//     identical to PR #91 baseline behaviour.
+//   - Queue-full IS treated as an explicit retry — explicitRetries
+//     bumps from 0 to 1 across the advance. This matches the pre-M2-1d
+//     behaviour at the removed server.go:1364-1365 inline
+//     state.explicitRetries++ / state.faultedProviders++ pair. Q3 is
+//     a structural/routing fix, NOT a semantic change — the billing
+//     ledger row sequence stays identical.
+//   - p1 must be marked StateBusy (queue-full classifier sets
+//     markBusy=true; the helper calls pool.MarkState before advancing).
+func TestM2_1D_RowSequence_WSNonStreamingQueueFullThroughAdvance(t *testing.T) {
+	const requestID = "eeeeeeee-5555-4555-8555-555555555555"
+	reqLog, dbPath := openBuyerRequestLog(t)
+	defer reqLog.Close()
+
+	registry := pool.NewRegistry(nil)
+	registerWithPath(registry, "p1", "s1", "model-a", pool.StateReady, 20000, 1, "", 30, pool.TierProvisional, pool.InferencePathWSTunneled)
+	registerWithPath(registry, "p2", "s2", "model-a", pool.StateReady, 20000, 2, "", 20, pool.TierProvisional, pool.InferencePathWSTunneled)
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithRequestLog(reqLog),
+		buyer.WithRoutingConfig(config.RoutingConfig{
+			MaxRetries:       1,
+			StickyTTLS:       1800,
+			StickyMaxEntries: 10000,
+		}),
+		buyer.WithRelay(func(ctx context.Context, provider pool.Provider, reqID string, body []byte, stream bool) (*providerws.RelayStream, error) {
+			chunks := make(chan providerws.InferenceResponseChunk, 1)
+			done := make(chan providerws.InferenceResponseEnd, 1)
+			errs := make(chan error, 1)
+			if provider.ProviderID == "p1" {
+				// Drive into wsForwardQueueFull via end.Status="error_queue_full".
+				done <- providerws.InferenceResponseEnd{Type: "inference_response_end", RequestID: reqID, Status: "error_queue_full"}
+				return &providerws.RelayStream{RequestID: reqID, Chunks: chunks, Done: done, Errors: errs}, nil
+			}
+			chunks <- providerws.InferenceResponseChunk{Type: "inference_response_chunk", RequestID: reqID, Seq: 0, Data: `{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`}
+			done <- providerws.InferenceResponseEnd{Type: "inference_response_end", RequestID: reqID, Status: "complete", ChunksSent: 1}
+			return &providerws.RelayStream{RequestID: reqID, Chunks: chunks, Done: done, Errors: errs}, nil
+		}, time.Second),
+	)
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}]}`), http.Header{
+		"X-Request-ID": []string{requestID},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if rr.Header().Get("X-MacProvider-Provider") != "p2" {
+		t.Fatalf("provider = %q, want p2 (after queue-full advance)", rr.Header().Get("X-MacProvider-Provider"))
+	}
+	// p1 must have been MarkState(Busy) before the advance — markBusy=true
+	// classifier flag drives pool.MarkState in the queue-full helper branch.
+	if p1, ok := registry.Resolve("p1", ""); !ok || p1.State != pool.StateBusy {
+		t.Fatalf("p1 state = %v ok=%v, want StateBusy after queue-full", p1.State, ok)
+	}
+	rows := queryAllRequestLogRows(t, dbPath)
+	if len(rows) != 2 {
+		t.Fatalf("request_log rows = %d, want 2 (queue-full then success): %#v", len(rows), rows)
+	}
+	// Pin: row 0 = p1 queue-full with 502 and retried=0
+	// (queue-full row is logged BEFORE advanceToNextProvider bumps
+	// explicitRetries — matches pre-M2-1d row order at server.go:1354).
+	if rows[0].ProviderAssignedID.String != "s1" {
+		t.Fatalf("rows[0].ProviderAssignedID = %q, want s1", rows[0].ProviderAssignedID.String)
+	}
+	if rows[0].Status != http.StatusServiceUnavailable {
+		t.Fatalf("rows[0].Status = %d, want 503 (wsEndHTTPStatus(error_queue_full))", rows[0].Status)
+	}
+	if rows[0].Retried != 0 {
+		t.Fatalf("rows[0].Retried = %d, want 0 (pre-advance)", rows[0].Retried)
+	}
+	// CRITICAL: row 1 = p2 success with 200 and retried=1.
+	// Queue-full IS an explicit retry — advanceToNextProvider bumps
+	// state.explicitRetries from 0 to 1, and the success row carries
+	// the bumped value. This is byte-identical to the pre-M2-1d
+	// inline state.explicitRetries++ at the removed server.go:1364.
+	// If this row has retried=0, the Q3 fix has accidentally treated
+	// queue-full as failover (no retry-bump) — billing ledger drift.
+	if rows[1].ProviderAssignedID.String != "s2" {
+		t.Fatalf("rows[1].ProviderAssignedID = %q, want s2", rows[1].ProviderAssignedID.String)
+	}
+	if rows[1].Status != http.StatusOK {
+		t.Fatalf("rows[1].Status = %d, want 200", rows[1].Status)
+	}
+	if rows[1].Retried != 1 {
+		t.Fatalf("rows[1].Retried = %d, want 1 (queue-full = explicit retry; must bump explicitRetries)", rows[1].Retried)
+	}
+}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1344,27 +1344,31 @@ func (s *Server) forwardWSNonStreamSequence(
 			}
 			return true
 		}
-		// Queue full: markBusy + retryable=true. Inline-advance path
-		// (NOT via advanceToNextProvider — preserves pre-refactor
-		// server.go:1244-1253 behaviour where queue-full uses
-		// selectProviderExcluding directly without logRow on success).
-		if tr.markBusy {
-			s.pool.MarkState(state.provider.ProviderID, state.provider.AssignedID, pool.StateBusy)
-			excluded[routeKey(state.provider)] = struct{}{}
-			logAttempt(state.provider, http.StatusBadGateway, tr.attempt, state.explicitRetries)
-		}
-		var routeErr *routeError
-		nextProvider, routeErr := s.selectProviderExcluding(uuid.NewString(), req, r.Header, excluded)
-		if routeErr != nil {
-			state.routingDone = s.now()
-			logRow("", routeErr.status, nil, nil, routeErr.message, "", state.explicitRetries)
-			writeRouteError(w, routeErr)
+		// Queue full: markBusy + retryable=true. The audit (post-merge
+		// verification of PR #91 — Q3 BLOCKING) called out the prior
+		// inline state mutation here as the concrete shared-state
+		// bypass that kept ARCH-1 / CODE-1 at PARTIAL_RESOLVED_DIFFERENTLY.
+		// M2-1d routes this path through advanceToNextProvider so the
+		// "pick next provider + bump explicitRetries/faultedProviders"
+		// tail lives in exactly one place — same as the timeout branch
+		// above and the two siblings (forwardStreamSequence,
+		// forwardHTTPSequence).
+		//
+		// Byte-identical to PR #91 baseline: classifier sets markBusy=true
+		// only on wsForwardQueueFull (the only case that falls through to
+		// this point), so the unconditional MarkState + excluded-add +
+		// logAttempt block here matches the pre-1d guarded behaviour.
+		// advanceToNextProvider performs the identical mutation order
+		// (selectProviderExcluding → routingDone → explicitRetries++ →
+		// faultedProviders++ → state.provider = next) as the prior inline
+		// block, preserving the request_log row sequence the billing
+		// ledger keys off (verified by forward_loop_test.go scenario 5).
+		s.pool.MarkState(state.provider.ProviderID, state.provider.AssignedID, pool.StateBusy)
+		excluded[routeKey(state.provider)] = struct{}{}
+		logAttempt(state.provider, http.StatusBadGateway, tr.attempt, state.explicitRetries)
+		if _, ok := s.advanceToNextProvider(w, r, req, state, excluded, logRow); !ok {
 			return false
 		}
-		state.provider = nextProvider
-		state.routingDone = s.now()
-		state.explicitRetries++
-		state.faultedProviders++
 		if !state.provider.IsWSTunneled() {
 			return true
 		}


### PR DESCRIPTION
## Summary

Closes the architect's Q3 BLOCKING finding from the post-merge verification of PR #91 (M2-1c). PR #91 collapsed the three failover loops into three transport-typed sequence helpers sharing `*forwardState` + `transportResult` flags, but a fresh post-merge architect pass identified one concrete shared-state bypass that kept ARCH-1 / CODE-1 at `PARTIAL_RESOLVED_DIFFERENTLY`: the WS-non-streaming queue-full branch at `server.go:1357-1367` incremented `state.explicitRetries` / `state.faultedProviders` inline and called `selectProviderExcluding` directly, bypassing the shared `advanceToNextProvider` helper that PR #48 (M2-1a) hoisted exactly to centralize this mutation.

## What it changes

- `phase4-coordinator/internal/buyer/server.go`: queue-full branch in `forwardWSNonStreamSequence` now routes through `advanceToNextProvider`. The audit-cited inline mutation (`state.explicitRetries++`, `state.faultedProviders++`, `state.routingDone = s.now()`, direct `selectProviderExcluding` + `writeRouteError` block) is fully eliminated. The `if tr.markBusy` guard is removed (only `wsForwardQueueFull` falls through to this point per the classifier and the helper's earlier early-return branches; the guard was defensive-only).
- `phase4-coordinator/internal/buyer/forward_loop_test.go`: scenario 5 added pinning the queue-full advance success row sequence — 2 rows, `(503 queue-full, retried=0)` then `(200 success, retried=1)`, plus `p1` marked StateBusy.

## What it preserves

Byte-identical to PR #91 baseline:

- The four pinned scenarios in `forward_loop_test.go` (HTTP success, HTTP 502 advance 200, streaming committed, WS-non-streaming failoverCandidate) all continue to pass byte-identical.
- The new scenario 5 pins queue-full as an explicit retry (`explicitRetries++`) matching the removed pre-fix inline `state.explicitRetries++`. Queue-full status 503 comes from `wsEndHTTPStatus("error_queue_full")` populated into `attempt.Status`; logAttempt's "use attempt.Status when non-zero" rule overrides the 502 fallback the helper passes.
- All three audit-flagged INTENTIONAL per-transport differences (HTTP per-attempt timeout, WS-non-streaming `failoverEligible` semantics, streaming `committed`) remain flagged not flattened.

## Q1 status

Option A (sweep). With Q3 fixed, every `explicitRetries` / `faultedProviders` mutation in all three sequence helpers flows through `advanceToNextProvider`. The remaining direct `state.provider = next` assigns are failover branches (intentionally `retried=0` — failover is same-attempt re-route).

**Architect verdict on Q1: NOT RESOLVED.** The architect ruled the 3-helper shape still has the failover state machine split across helper-local decision trees. The named next step: "Scope M2-1e as extraction of a shared `forwardWithFailover` core, or equivalent shared transition core, with transport callbacks for dispatch, success/error rendering, committed handling, and WS-to-HTTP fallthrough."

## Audit loop

1 iteration. Three codex auditors run in parallel post-commit:

- **Code auditor (codex high effort):** APPROVE on all 5 questions. No substantive findings. Confirmed byte-identical to PR #91 for scenarios 1-4; scenario 5 correctly pinned at `retried=1`; inline mutation fully eliminated; no new races; unconditional `MarkState`+excluded-add+logAttempt block correct per classifier+control-flow walk.
- **Security auditor (codex high effort):** APPROVE on all 5 questions. No blocking findings. Confirmed no auth/money-path/token changes; billing-visible order preserved; queue-full status 503 skipped by billing hot path so no double-bill; no new attacker-influenced state; no new TOCTOU.
- **Architect auditor (codex high effort) — PROMOTION GATE:** Q3 PASS, Q1 FAIL, DO NOT PROMOTE. Q3 fully eliminates the inline mutation and correctly routes through `advanceToNextProvider`. Q1 still has the failover state machine split. Named M2-1e as the explicit next step.

## Tests

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./internal/buyer -race -count=5 -timeout 180s` GREEN (11.3s)
- `go test ./... -timeout 300s` GREEN

## REMAINING_WORK.md

ARCH-1 / CODE-1 stays at `PARTIAL_RESOLVED_DIFFERENTLY`. Not promoted in this PR per architect verdict. M2-1e to be filed as follow-up issue for the `forwardWithFailover` core extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
