### PR TITLE
m3-10: hoist logRowWithBilling into typed billing recorder (ARCH-6 close-out)

### DIFF
--- a/audits/2026-06-10/REMAINING_WORK.md
+++ b/audits/2026-06-10/REMAINING_WORK.md
@@ -95,11 +95,6 @@ _Forward-looking punch list from the 2026-06-10 audit verification pass. Items i
 - **Status:** `CODE_SHIPPED_OPERATOR_PENDING`
 - **Detail:** **Evidence** - PR #73 / commit 11f7c0c `m3-2: operator-key split + coordinator env-file + de-root monitor (SECU-4 + DEVE-7)`, plus codex fixups c99f1ca and 55bb5c0. - `phase4-coordinator/dist/monitor/macprovider-monitor.service`: `User=macprovider`, `Group=macprovider`, `NoNewPrivileges=true`, `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`, `PrivateDevices=true`, `ReadOnlyPaths=/opt/macprovider`, `StateDirectory=macprovider-monitor`, `EnvironmentFile=-/etc/macprovider/coordinator.env` (the env file the coordinator unit also reads — symmetric with gateway). - `macprovider-monitor.py:54-61, 107`: `operator_key()` returns `os.environ.get("OPERATOR_KEY", "")` — no more regex-against-yaml-as-root. - `deploy-pearl-vps.sh:194-208`: enforces `coordinator.env` perms `root:macprovi...
 
-### [Low] ARCH-6 — Billing/request-log persistence orchestration lives inline in handler closures
-
-- **Status:** `DEFERRED`
-- **Detail:** **Evidence** Handoff lists M3-10 as DEFERRED, pairing with M2-1c. No commit references ARCH-6 or `logRowWithBilling` extraction. `buyer/server.go:869-974` still defines `logRowWithBilling` as an inline closure inside `handleChatCompletions` (lines 880-974). The gateway pattern the audit pointed at as the goal remains the contrast. **Original citation** Audit cited `buyer/server.go:851-945`; the closure now spans 880-974 (drifted but same shape). **Fix delta** Explicit deferral, paired with the M2-1 ARCH-1 work-stream so the extraction lands once the failover loops collapse to one. Justified sequencing. **Notes** No regression risk while deferred (money math in `formula.go` is the high-stakes part and stays isolated).
-
 ## §5 tasks not in RESOLVED state
 
 Tasks that did not reach `RESOLVED` (each maps to one or more findings above; this view is by task ID).
@@ -117,7 +112,6 @@ Tasks that did not reach `RESOLVED` (each maps to one or more findings above; th
 | M3-2 | `CODE_SHIPPED_OPERATOR_PENDING` | Operator key split + de-root monitor |
 | M3-4 | `CODE_SHIPPED_OPERATOR_PENDING` | swift-nio bump + drop swift-log + Swift CI |
 | M2-9 | `DEFERRED` | Cross-service integration test |
-| M3-10 | `DEFERRED` | Hoist logRowWithBilling into billing-recorder type |
 
 ## Operator-pending items (require human action, not code)
 
@@ -140,9 +134,7 @@ Code is merged; resolution depends on operator action on Pearl, in GitHub branch
 Confirmed-as-deferred findings, tasks, and Open Questions.
 
 - **TEST-6** (Medium) — No cross-service integration test between gateway and coordinator.
-- **ARCH-6** (Low) — Billing/request-log persistence orchestration lives inline in handler closures.
 - **M2-9** — Cross-service integration test.
-- **M3-10** — Hoist logRowWithBilling into billing-recorder type.
 - **Q3** — Target tier-2 posture for this beta.
 
 ## New issues surfaced (severity-ordered)

--- a/phase4-coordinator/internal/buyer/billing_recorder.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder.go
@@ -1,0 +1,252 @@
+package buyer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/billing"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/requestlog"
+)
+
+// billingRecorder is the typed extraction of the previously-inline
+// logRowWithBilling closure from handleChatCompletions. M3-10
+// (audits/2026-06-10/REPO_AUDIT.md ARCH-6) hoisted the closure into
+// this struct so the per-request orchestration of request_log +
+// billing-ledger writes is no longer hidden inside a handler closure.
+//
+// Lifecycle: exactly one billingRecorder per handleChatCompletions
+// invocation, constructed up front and passed by pointer through the
+// three transport sequence helpers (forwardStreamSequence,
+// forwardWSNonStreamSequence, forwardHTTPSequence). Single-goroutine
+// per request — the recorder is NOT shared across requests, so its
+// mutable fields (attemptN, model, stream, requestID) are unguarded
+// by design, matching the pre-refactor closure's capture semantics.
+//
+// Byte-identical preservation: every field written, every operation
+// order, every NULL-vs-zero treatment matches the pre-refactor
+// closure. The only structural change is that captured outer-scope
+// variables become struct fields, and the closure body becomes the
+// recordRow method. The hot-path-then-fallback flow inside
+// WriteHotPath / WriteRequestLogWithIdentity is unchanged.
+//
+// Mutation contract:
+//   - attemptN auto-increments on each successful recordRow call that
+//     names a provider (providerAssignedID != ""), matching the
+//     pre-refactor `defer billingAttemptN++` semantics.
+//   - model / stream / requestID are setters called from
+//     handleChatCompletions as the request parses (the closure read
+//     these by-reference from outer scope; the recorder updates the
+//     field on Set). All sets land BEFORE the first provider-bound
+//     recordRow call, preserving the pre-refactor value-at-fire-time
+//     contract.
+type billingRecorder struct {
+	server    *Server
+	state     *forwardState
+	req       *http.Request
+	startedAt time.Time
+
+	// Late-bound per-request fields. Set as the request parses, before
+	// any provider-bound recordRow call. Pre-refactor these were
+	// captured outer-scope variables (requestLogModel, requestLogStream,
+	// originalRequestID).
+	model     string
+	stream    bool
+	requestID string
+
+	// attemptN is the running per-provider-attempt counter. Pre-refactor
+	// this was billingAttemptN, incremented via deferred closure on
+	// every successful provider-bound record.
+	attemptN int
+}
+
+// newBillingRecorder constructs the per-request recorder. Called once
+// from handleChatCompletions before any logging fires. state is the
+// forwardState pointer the sequence helpers will mutate; the recorder
+// reads state.routingDone at write time to compute RoutingMs (matching
+// the pre-refactor closure's live-capture semantics).
+func (s *Server) newBillingRecorder(r *http.Request, state *forwardState, startedAt time.Time, requestID string) *billingRecorder {
+	return &billingRecorder{
+		server:    s,
+		state:     state,
+		req:       r,
+		startedAt: startedAt,
+		requestID: requestID,
+	}
+}
+
+// setModel updates the model field. Called from handleChatCompletions
+// after body parse, before any provider-bound recordRow fires. The
+// pre-refactor closure read this from a captured outer-scope variable;
+// the setter preserves the same "latest value at fire time" contract.
+func (b *billingRecorder) setModel(model string) {
+	b.model = model
+}
+
+// setStream updates the stream field. See setModel for contract.
+func (b *billingRecorder) setStream(stream bool) {
+	b.stream = stream
+}
+
+// setRequestID updates the requestID field after idempotency-key
+// reservation may have rewritten it. Pre-refactor the closure read
+// `originalRequestID` from outer scope; the setter preserves the same
+// post-idempotency-rewrite semantics.
+func (b *billingRecorder) setRequestID(requestID string) {
+	b.requestID = requestID
+}
+
+// recordRow is the typed equivalent of the pre-refactor
+// logRowWithBilling closure. Behaviour preserved byte-identical:
+//   - reqLog nil → no-op nil return (early exit).
+//   - attemptN snapshot before deferred increment matches the
+//     pre-refactor `attemptN := billingAttemptN` + `defer ...++`
+//     pattern; increment fires only when providerAssignedID != "".
+//   - row construction reads state.routingDone live, so RoutingMs
+//     reflects the latest routing decision (M2-1c invariant).
+//   - billing hot-path branch: providerAssignedID set AND status !=
+//     503 AND both stores present → resolve stableProviderID, call
+//     WriteHotPath, fall back to WriteRequestLogWithIdentity on
+//     hot-path error.
+//   - non-hot-path branch: fall through to reqLog.Insert.
+func (b *billingRecorder) recordRow(
+	providerAssignedID string,
+	providerID string,
+	status int,
+	promptTok, completionTok *int64,
+	errMsg, errCode string,
+	retried int,
+	estimatedCompTokens *int64,
+	faultFlag string,
+) error {
+	s := b.server
+	if s.reqLog == nil {
+		return nil
+	}
+	attemptN := b.attemptN
+	if providerAssignedID != "" {
+		defer func() {
+			b.attemptN++
+		}()
+	}
+	row := requestlog.Row{
+		TSUtc:               b.startedAt,
+		RequestID:           b.requestID,
+		Model:               b.model,
+		ProviderAssignedID:  providerAssignedID,
+		PromptTokens:        promptTok,
+		CompletionTokens:    completionTok,
+		EstimatedCompTokens: estimatedCompTokens,
+		LatencyMs:           float64(time.Since(b.startedAt).Milliseconds()),
+		RoutingMs:           float64(b.state.routingDone.Sub(b.startedAt).Milliseconds()),
+		Status:              status,
+		Stream:              b.stream,
+		BuyerIP:             buyerIP(b.req.RemoteAddr),
+		Error:               sanitizeRequestLogText(errMsg),
+		ErrorCode:           errCode,
+		PrefHeader:          sanitizeRequestLogText(b.req.Header.Get("X-MacProvider-Pref")),
+		ProviderHeader:      sanitizeRequestLogText(b.req.Header.Get("X-MacProvider-Provider")),
+		Retried:             retried,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), requestLogWriteTimeout)
+	defer cancel()
+	billingStore, billingCfg, billingSnapshotID := s.billingState()
+	if billingStore != nil && s.reqLogStore != nil && providerAssignedID != "" && status != http.StatusServiceUnavailable {
+		stableProviderID := providerID
+		if stableProviderID == "" {
+			for _, p := range s.pool.Snapshot() {
+				if p.AssignedID == providerAssignedID {
+					stableProviderID = p.ProviderID
+					break
+				}
+			}
+		}
+		if stableProviderID == "" {
+			s.log.Warn().Str("request_id", b.requestID).Str("provider_assigned_id", providerAssignedID).Msg("billing hot-path skipped without stable provider identity")
+			return fmt.Errorf("billing hot-path missing stable provider identity")
+		}
+		if faultFlag == "" {
+			faultFlag = billing.FaultNone
+		}
+		billingInput := billing.HotPathInput{
+			RequestID:           row.RequestID,
+			AttemptN:            attemptN,
+			ProviderAssignedID:  providerAssignedID,
+			ProviderID:          stableProviderID,
+			Model:               row.Model,
+			Status:              status,
+			Stream:              row.Stream,
+			TSUtc:               row.TSUtc,
+			PromptTokens:        promptTok,
+			CompletionTokens:    completionTok,
+			EstimatedCompTokens: estimatedCompTokens,
+			ErrorCode:           errCode,
+			FaultFlag:           faultFlag,
+			ConfigSnapshotID:    billingSnapshotID,
+			RateEntry:           billing.RateFor(billingCfg.RateCard, row.Model),
+			MultiplierPPM:       billing.ParseMultiplierPPM(billingCfg.GlobalMultiplier),
+			ProviderShareBps:    billing.ParseShareBps(billingCfg.ProviderShare),
+		}
+		err := billingStore.WriteHotPath(ctx, s.reqLogStore, row, billingInput)
+		if err != nil {
+			s.log.Warn().Err(err).Str("request_id", b.requestID).Msg("billing hot-path insert failed")
+			fallbackCtx, fallbackCancel := context.WithTimeout(context.Background(), requestLogWriteTimeout)
+			defer fallbackCancel()
+			if fallbackErr := billingStore.WriteRequestLogWithIdentity(fallbackCtx, s.reqLogStore, row, billingInput); fallbackErr != nil {
+				s.log.Warn().Err(fallbackErr).Str("request_id", b.requestID).Msg("request_log identity fallback insert failed")
+				return fmt.Errorf("billing hot-path insert failed: %w; fallback failed: %v", err, fallbackErr)
+			}
+		}
+		return nil
+	}
+	if err := s.reqLog.Insert(ctx, row); err != nil {
+		s.log.Warn().Err(err).Str("request_id", b.requestID).Msg("request_log insert failed")
+		return err
+	}
+	return nil
+}
+
+// logRow is the convenience wrapper matching the pre-refactor `logRow`
+// closure shape. Used at no-provider sites (route errors, buyer
+// failures) where providerID is unknown and faultFlag is implicitly
+// FaultNone.
+func (b *billingRecorder) logRow(
+	providerAssignedID string,
+	status int,
+	promptTok, completionTok *int64,
+	errMsg, errCode string,
+	retried int,
+) {
+	_ = b.recordRow(providerAssignedID, "", status, promptTok, completionTok, errMsg, errCode, retried, nil, billing.FaultNone)
+}
+
+// logBuyerFailure mirrors the pre-refactor `logBuyerFailure` closure.
+func (b *billingRecorder) logBuyerFailure(status int, msg string) {
+	b.logRow("", status, nil, nil, msg, "", 0)
+}
+
+// logProviderRow mirrors the pre-refactor `logProviderRow` closure.
+func (b *billingRecorder) logProviderRow(
+	provider pool.Provider,
+	status int,
+	promptTok, completionTok *int64,
+	errMsg, errCode string,
+	retried int,
+) error {
+	return b.recordRow(provider.AssignedID, provider.ProviderID, status, promptTok, completionTok, errMsg, errCode, retried, nil, billing.FaultNone)
+}
+
+// logProviderRowWithEstimate mirrors the pre-refactor
+// `logProviderRowWithEstimate` closure.
+func (b *billingRecorder) logProviderRowWithEstimate(
+	provider pool.Provider,
+	status int,
+	promptTok, completionTok *int64,
+	errMsg, errCode string,
+	retried int,
+	estimatedCompTokens *int64,
+) error {
+	return b.recordRow(provider.AssignedID, provider.ProviderID, status, promptTok, completionTok, errMsg, errCode, retried, estimatedCompTokens, billing.FaultNone)
+}

--- a/phase4-coordinator/internal/buyer/billing_recorder.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder.go
@@ -33,9 +33,12 @@ import (
 // WriteHotPath / WriteRequestLogWithIdentity is unchanged.
 //
 // Mutation contract:
-//   - attemptN auto-increments on each successful recordRow call that
-//     names a provider (providerAssignedID != ""), matching the
-//     pre-refactor `defer billingAttemptN++` semantics.
+//   - attemptN auto-increments on every provider-bound recordRow call
+//     (providerAssignedID != ""), regardless of write outcome — the
+//     deferred increment fires even when the hot-path or fallback
+//     write errors. Matches the pre-refactor `defer billingAttemptN++`
+//     semantics: the counter tracks provider-bound record attempts,
+//     not successful row writes.
 //   - model / stream / requestID are setters called from
 //     handleChatCompletions as the request parses (the closure read
 //     these by-reference from outer scope; the recorder updates the

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -872,169 +872,46 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	routingRequestID := uuid.NewString()
 	originalRequestID := requestID
 	startedAt := s.now()
-	// state is allocated up-front so the logRowWithBilling closure
-	// captures the pointer — pre-1c the closure read mutable locals
-	// (routingDone, explicitRetries); post-1c those locals migrated
-	// into forwardState, but the closure still needs the live values
-	// at log-write time. Capturing *state preserves that contract
-	// without restructuring the closure-vs-helper boundary.
+	// state is allocated up-front so the billingRecorder captures the
+	// pointer — pre-1c the inline logRowWithBilling closure read
+	// mutable locals (routingDone, explicitRetries); post-1c those
+	// locals migrated into forwardState; M3-10 hoists the closure
+	// itself into *billingRecorder. The recorder still needs the live
+	// state values at log-write time, so it holds *forwardState.
 	state := &forwardState{
 		routingDone:   startedAt,
 		faultedRoutes: map[string]struct{}{},
 	}
-	requestLogModel := ""
-	requestLogStream := false
-	billingAttemptN := 0
-	logRowWithBilling := func(
-		providerAssignedID string,
-		providerID string,
-		status int,
-		promptTok, completionTok *int64,
-		errMsg, errCode string,
-		retried int,
-		estimatedCompTokens *int64,
-		faultFlag string,
-	) error {
-		if s.reqLog == nil {
-			return nil
-		}
-		attemptN := billingAttemptN
-		if providerAssignedID != "" {
-			defer func() {
-				billingAttemptN++
-			}()
-		}
-		row := requestlog.Row{
-			TSUtc:               startedAt,
-			RequestID:           originalRequestID,
-			Model:               requestLogModel,
-			ProviderAssignedID:  providerAssignedID,
-			PromptTokens:        promptTok,
-			CompletionTokens:    completionTok,
-			EstimatedCompTokens: estimatedCompTokens,
-			LatencyMs:           float64(time.Since(startedAt).Milliseconds()),
-			RoutingMs:           float64(state.routingDone.Sub(startedAt).Milliseconds()),
-			Status:              status,
-			Stream:              requestLogStream,
-			BuyerIP:             buyerIP(r.RemoteAddr),
-			Error:               sanitizeRequestLogText(errMsg),
-			ErrorCode:           errCode,
-			PrefHeader:          sanitizeRequestLogText(r.Header.Get("X-MacProvider-Pref")),
-			ProviderHeader:      sanitizeRequestLogText(r.Header.Get("X-MacProvider-Provider")),
-			Retried:             retried,
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), requestLogWriteTimeout)
-		defer cancel()
-		billingStore, billingCfg, billingSnapshotID := s.billingState()
-		if billingStore != nil && s.reqLogStore != nil && providerAssignedID != "" && status != http.StatusServiceUnavailable {
-			stableProviderID := providerID
-			if stableProviderID == "" {
-				for _, p := range s.pool.Snapshot() {
-					if p.AssignedID == providerAssignedID {
-						stableProviderID = p.ProviderID
-						break
-					}
-				}
-			}
-			if stableProviderID == "" {
-				s.log.Warn().Str("request_id", originalRequestID).Str("provider_assigned_id", providerAssignedID).Msg("billing hot-path skipped without stable provider identity")
-				return fmt.Errorf("billing hot-path missing stable provider identity")
-			}
-			if faultFlag == "" {
-				faultFlag = billing.FaultNone
-			}
-			billingInput := billing.HotPathInput{
-				RequestID:           row.RequestID,
-				AttemptN:            attemptN,
-				ProviderAssignedID:  providerAssignedID,
-				ProviderID:          stableProviderID,
-				Model:               row.Model,
-				Status:              status,
-				Stream:              row.Stream,
-				TSUtc:               row.TSUtc,
-				PromptTokens:        promptTok,
-				CompletionTokens:    completionTok,
-				EstimatedCompTokens: estimatedCompTokens,
-				ErrorCode:           errCode,
-				FaultFlag:           faultFlag,
-				ConfigSnapshotID:    billingSnapshotID,
-				RateEntry:           billing.RateFor(billingCfg.RateCard, row.Model),
-				MultiplierPPM:       billing.ParseMultiplierPPM(billingCfg.GlobalMultiplier),
-				ProviderShareBps:    billing.ParseShareBps(billingCfg.ProviderShare),
-			}
-			err := billingStore.WriteHotPath(ctx, s.reqLogStore, row, billingInput)
-			if err != nil {
-				s.log.Warn().Err(err).Str("request_id", originalRequestID).Msg("billing hot-path insert failed")
-				fallbackCtx, fallbackCancel := context.WithTimeout(context.Background(), requestLogWriteTimeout)
-				defer fallbackCancel()
-				if fallbackErr := billingStore.WriteRequestLogWithIdentity(fallbackCtx, s.reqLogStore, row, billingInput); fallbackErr != nil {
-					s.log.Warn().Err(fallbackErr).Str("request_id", originalRequestID).Msg("request_log identity fallback insert failed")
-					return fmt.Errorf("billing hot-path insert failed: %w; fallback failed: %v", err, fallbackErr)
-				}
-			}
-			return nil
-		}
-		if err := s.reqLog.Insert(ctx, row); err != nil {
-			s.log.Warn().Err(err).Str("request_id", originalRequestID).Msg("request_log insert failed")
-			return err
-		}
-		return nil
-	}
-	logRow := func(
-		providerAssignedID string,
-		status int,
-		promptTok, completionTok *int64,
-		errMsg, errCode string,
-		retried int,
-	) {
-		_ = logRowWithBilling(providerAssignedID, "", status, promptTok, completionTok, errMsg, errCode, retried, nil, billing.FaultNone)
-	}
-	logBuyerFailure := func(status int, msg string) {
-		logRow("", status, nil, nil, msg, "", 0)
-	}
-	logProviderRow := func(
-		provider pool.Provider,
-		status int,
-		promptTok, completionTok *int64,
-		errMsg, errCode string,
-		retried int,
-	) error {
-		return logRowWithBilling(provider.AssignedID, provider.ProviderID, status, promptTok, completionTok, errMsg, errCode, retried, nil, billing.FaultNone)
-	}
-	logProviderRowWithEstimate := func(
-		provider pool.Provider,
-		status int,
-		promptTok, completionTok *int64,
-		errMsg, errCode string,
-		retried int,
-		estimatedCompTokens *int64,
-	) error {
-		return logRowWithBilling(provider.AssignedID, provider.ProviderID, status, promptTok, completionTok, errMsg, errCode, retried, estimatedCompTokens, billing.FaultNone)
-	}
+	// M3-10 (ARCH-6 close-out): the previously-inline logRowWithBilling
+	// closure now lives as *billingRecorder. setModel / setStream /
+	// setRequestID land before the first provider-bound recordRow call,
+	// preserving the pre-refactor closure's "latest value at fire time"
+	// semantics for what used to be captured outer-scope variables.
+	rec := s.newBillingRecorder(r, state, startedAt, originalRequestID)
 	maxBodyBytes := s.maxChatBodyBytes
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes+1))
 	if err != nil {
-		logBuyerFailure(http.StatusBadRequest, "Could not read request body")
+		rec.logBuyerFailure(http.StatusBadRequest, "Could not read request body")
 		writeError(w, http.StatusBadRequest, "invalid_request", "Could not read request body")
 		return
 	}
-	requestLogModel = modelForRequestLog(body)
+	rec.setModel(modelForRequestLog(body))
 	if int64(len(body)) > maxBodyBytes {
-		logBuyerFailure(http.StatusRequestEntityTooLarge, "Request body too large")
+		rec.logBuyerFailure(http.StatusRequestEntityTooLarge, "Request body too large")
 		writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Request body too large")
 		return
 	}
 	req, status, code, msg := validateChatRequest(body)
 	if status != 0 {
-		logBuyerFailure(status, msg)
+		rec.logBuyerFailure(status, msg)
 		writeError(w, status, code, msg)
 		return
 	}
-	requestLogModel = req.Model
-	requestLogStream = req.Stream
+	rec.setModel(req.Model)
+	rec.setStream(req.Stream)
 	if idempotencyKey := normalizeIdempotencyKey(r.Header.Get("Idempotency-Key")); idempotencyKey != "" {
 		if s.reqLogStore == nil {
-			logBuyerFailure(http.StatusServiceUnavailable, "Idempotency-Key requires durable request logging")
+			rec.logBuyerFailure(http.StatusServiceUnavailable, "Idempotency-Key requires durable request logging")
 			writeError(w, http.StatusServiceUnavailable, "idempotency_unavailable", "Idempotency-Key requires durable request logging")
 			return
 		}
@@ -1042,27 +919,28 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		reservedRequestID, replay, err := s.reqLogStore.ReserveIdempotencyKey(r.Context(), idempotencyKey, hex.EncodeToString(bodyHash[:]), originalRequestID, startedAt)
 		if err != nil {
 			if errors.Is(err, requestlog.ErrIdempotencyConflict) {
-				logBuyerFailure(http.StatusConflict, "Idempotency-Key was already used with a different request body")
+				rec.logBuyerFailure(http.StatusConflict, "Idempotency-Key was already used with a different request body")
 				writeError(w, http.StatusConflict, "idempotency_key_body_mismatch", "Idempotency-Key was already used with a different request body")
 				return
 			}
 			s.log.Warn().Err(err).Msg("idempotency reservation failed")
-			logBuyerFailure(http.StatusInternalServerError, "Could not reserve idempotency key")
+			rec.logBuyerFailure(http.StatusInternalServerError, "Could not reserve idempotency key")
 			writeError(w, http.StatusInternalServerError, "idempotency_reservation_failed", "Could not reserve idempotency key")
 			return
 		}
 		originalRequestID = reservedRequestID
 		requestID = reservedRequestID
 		routingRequestID = reservedRequestID
+		rec.setRequestID(reservedRequestID)
 		if replay {
 			w.Header().Set("X-Request-ID", reservedRequestID)
-			logBuyerFailure(http.StatusConflict, "Idempotency-Key request is already recorded")
+			rec.logBuyerFailure(http.StatusConflict, "Idempotency-Key request is already recorded")
 			writeError(w, http.StatusConflict, "idempotency_key_replayed", "Idempotency-Key request is already recorded")
 			return
 		}
 	}
 	if !s.pool.ModelKnown(req.Model) && s.resolveModelClass(req.Model) == nil {
-		logBuyerFailure(http.StatusNotFound, "No provider has advertised model "+req.Model)
+		rec.logBuyerFailure(http.StatusNotFound, "No provider has advertised model "+req.Model)
 		writeError(w, http.StatusNotFound, "model_not_found", "No provider has advertised model "+req.Model)
 		return
 	}
@@ -1076,6 +954,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// transport's view of "what retry am I on" without relying on
 	// closure-by-reference semantics that wouldn't survive the helper
 	// boundary.
+	//
+	// M3-10: logAttempt stays as a local closure because the
+	// estimated-prompt-token computation reads req.raw (the chat
+	// request body), which is local to handleChatCompletions. The
+	// closure delegates the actual row write to rec.recordRow, so the
+	// billing/request-log orchestration that ARCH-6 flagged still
+	// lives in *billingRecorder — only the per-attempt token-estimate
+	// adapter remains here.
 	logAttempt := func(provider pool.Provider, fallbackStatus int, attempt requestLogAttempt, retried int) {
 		status := attempt.Status
 		if status == 0 {
@@ -1085,7 +971,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			estimatedPrompt := int64(estimateTokens(req.raw))
 			attempt.PromptTokens = &estimatedPrompt
 		}
-		logRowWithBilling(provider.AssignedID, provider.ProviderID, status, attempt.PromptTokens, attempt.CompletionTokens, attempt.Error, attempt.ErrorCode, retried, attempt.EstimatedCompTokens, attempt.FaultFlag)
+		rec.recordRow(provider.AssignedID, provider.ProviderID, status, attempt.PromptTokens, attempt.CompletionTokens, attempt.Error, attempt.ErrorCode, retried, attempt.EstimatedCompTokens, attempt.FaultFlag)
 	}
 	shouldLogAttempt := func(attempt requestLogAttempt) bool {
 		return attempt.Status != 0 || attempt.PromptTokens != nil || attempt.CompletionTokens != nil || attempt.EstimatedCompTokens != nil || attempt.Error != "" || attempt.ErrorCode != ""
@@ -1093,7 +979,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	provider, routeErr := s.selectProvider(routingRequestID, req, r.Header)
 	if routeErr != nil {
 		state.routingDone = s.now()
-		logRow("", routeErr.status, nil, nil, routeErr.message, "", 0)
+		rec.logRow("", routeErr.status, nil, nil, routeErr.message, "", 0)
 		writeRouteError(w, routeErr)
 		return
 	}
@@ -1111,12 +997,12 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// does not survive transport boundaries.
 	if req.Stream {
 		excluded := map[string]struct{}{}
-		s.forwardStreamSequence(w, r, req, requestID, originalRequestID, externalRequestID, startedAt, state, excluded, logAttempt, shouldLogAttempt, logRow)
+		s.forwardStreamSequence(w, r, req, requestID, originalRequestID, externalRequestID, startedAt, state, excluded, rec, logAttempt, shouldLogAttempt)
 		return
 	}
 	if state.provider.IsWSTunneled() {
 		excluded := map[string]struct{}{}
-		shouldFallThroughToHTTP := s.forwardWSNonStreamSequence(w, r, req, requestID, originalRequestID, externalRequestID, startedAt, state, excluded, logAttempt, shouldLogAttempt, logRow)
+		shouldFallThroughToHTTP := s.forwardWSNonStreamSequence(w, r, req, requestID, originalRequestID, externalRequestID, startedAt, state, excluded, rec, logAttempt, shouldLogAttempt)
 		if !shouldFallThroughToHTTP {
 			return
 		}
@@ -1126,7 +1012,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		excluded[key] = struct{}{}
 	}
 	excluded[routeKey(state.provider)] = struct{}{}
-	s.forwardHTTPSequence(w, r, req, requestID, originalRequestID, startedAt, state, excluded, logProviderRow, logProviderRowWithEstimate, logRow)
+	s.forwardHTTPSequence(w, r, req, requestID, originalRequestID, startedAt, state, excluded, rec)
 }
 
 // forwardStreamSequence is the unified loop body for streaming requests
@@ -1156,15 +1042,15 @@ func (s *Server) forwardStreamSequence(
 	startedAt time.Time,
 	state *forwardState,
 	excluded map[string]struct{},
+	rec *billingRecorder,
 	logAttempt func(pool.Provider, int, requestLogAttempt, int),
 	shouldLogAttempt func(requestLogAttempt) bool,
-	logRow forwardLogRowFunc,
 ) {
 	failoverAttempted := false
 	for {
 		dispatchBody, err := dispatchBodyForProvider(req, state.provider)
 		if err != nil {
-			logRow(state.provider.AssignedID, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
+			rec.logRow(state.provider.AssignedID, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
 			writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
 			return
 		}
@@ -1237,7 +1123,7 @@ func (s *Server) forwardStreamSequence(
 			return
 		}
 		logAttempt(state.provider, tr.status, tr.attempt, state.explicitRetries)
-		nextRouteID, ok := s.advanceToNextProvider(w, r, req, state, excluded, logRow)
+		nextRouteID, ok := s.advanceToNextProvider(w, r, req, state, excluded, rec)
 		if !ok {
 			return
 		}
@@ -1267,15 +1153,15 @@ func (s *Server) forwardWSNonStreamSequence(
 	startedAt time.Time,
 	state *forwardState,
 	excluded map[string]struct{},
+	rec *billingRecorder,
 	logAttempt func(pool.Provider, int, requestLogAttempt, int),
 	shouldLogAttempt func(requestLogAttempt) bool,
-	logRow forwardLogRowFunc,
 ) (shouldFallThroughToHTTP bool) {
 	failoverAttempted := false
 	for {
 		dispatchBody, err := dispatchBodyForProvider(req, state.provider)
 		if err != nil {
-			logRow(state.provider.AssignedID, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
+			rec.logRow(state.provider.AssignedID, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
 			writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
 			return false
 		}
@@ -1306,7 +1192,7 @@ func (s *Server) forwardWSNonStreamSequence(
 				return false
 			}
 			logAttempt(state.provider, http.StatusGatewayTimeout, tr.attempt, state.explicitRetries)
-			_, ok := s.advanceToNextProvider(w, r, req, state, excluded, logRow)
+			_, ok := s.advanceToNextProvider(w, r, req, state, excluded, rec)
 			if !ok {
 				return false
 			}
@@ -1366,7 +1252,7 @@ func (s *Server) forwardWSNonStreamSequence(
 		s.pool.MarkState(state.provider.ProviderID, state.provider.AssignedID, pool.StateBusy)
 		excluded[routeKey(state.provider)] = struct{}{}
 		logAttempt(state.provider, http.StatusBadGateway, tr.attempt, state.explicitRetries)
-		if _, ok := s.advanceToNextProvider(w, r, req, state, excluded, logRow); !ok {
+		if _, ok := s.advanceToNextProvider(w, r, req, state, excluded, rec); !ok {
 			return false
 		}
 		if !state.provider.IsWSTunneled() {
@@ -1394,14 +1280,12 @@ func (s *Server) forwardHTTPSequence(
 	startedAt time.Time,
 	state *forwardState,
 	excluded map[string]struct{},
-	logProviderRow func(pool.Provider, int, *int64, *int64, string, string, int) error,
-	logProviderRowWithEstimate func(pool.Provider, int, *int64, *int64, string, string, int, *int64) error,
-	logRow forwardLogRowFunc,
+	rec *billingRecorder,
 ) {
 	for {
 		dispatchBody, err := dispatchBodyForProvider(req, state.provider)
 		if err != nil {
-			logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
+			rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
 			writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
 			return
 		}
@@ -1415,7 +1299,7 @@ func (s *Server) forwardHTTPSequence(
 		upReq, err := http.NewRequestWithContext(attemptCtx, http.MethodPost, upstreamURL, bytes.NewReader(dispatchBody))
 		if err != nil {
 			cancelAttempt()
-			logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
+			rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
 			writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
 			return
 		}
@@ -1427,13 +1311,13 @@ func (s *Server) forwardHTTPSequence(
 			_ = resp.Body.Close()
 			if readErr != nil {
 				cancelAttempt()
-				logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
+				rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
 				writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
 				return
 			}
 			promptTok, completionTok := tokenPointersFromChatResponse(respBody)
 			estimatedCompletion := s.observedCompletionTokensFromBytes(len(respBody))
-			if err := logProviderRowWithEstimate(state.provider, http.StatusOK, promptTok, completionTok, "", "", state.explicitRetries, estimatedCompletion); err != nil {
+			if err := rec.logProviderRowWithEstimate(state.provider, http.StatusOK, promptTok, completionTok, "", "", state.explicitRetries, estimatedCompletion); err != nil {
 				cancelAttempt()
 				writeError(w, http.StatusInternalServerError, "request_log_failed", "Could not durably log request")
 				return
@@ -1476,11 +1360,11 @@ func (s *Server) forwardHTTPSequence(
 		}
 		if !s.shouldRetry(r, startedAt, state.explicitRetries, state.faultedProviders, status, err) {
 			if retryRequested && status == http.StatusGatewayTimeout {
-				logProviderRow(state.provider, http.StatusGatewayTimeout, nil, nil, "Selected provider timed out; buyer should retry", attempt.ErrorCode, state.explicitRetries)
+				rec.logProviderRow(state.provider, http.StatusGatewayTimeout, nil, nil, "Selected provider timed out; buyer should retry", attempt.ErrorCode, state.explicitRetries)
 				writeError(w, http.StatusGatewayTimeout, "provider_timeout", "Selected provider timed out; buyer should retry")
 				return
 			}
-			logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", attempt.ErrorCode, state.explicitRetries)
+			rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", attempt.ErrorCode, state.explicitRetries)
 			writeError(w, http.StatusBadGateway, "provider_error", "Selected provider failed; buyer should retry")
 			return
 		}
@@ -1494,8 +1378,8 @@ func (s *Server) forwardHTTPSequence(
 		if err != nil {
 			errMsg = err.Error()
 		}
-		logProviderRow(state.provider, failStatus, nil, nil, errMsg, attempt.ErrorCode, state.explicitRetries)
-		nextRouteID, ok := s.advanceToNextProvider(w, r, req, state, excluded, logRow)
+		rec.logProviderRow(state.provider, failStatus, nil, nil, errMsg, attempt.ErrorCode, state.explicitRetries)
+		nextRouteID, ok := s.advanceToNextProvider(w, r, req, state, excluded, rec)
 		if !ok {
 			return
 		}
@@ -1503,12 +1387,6 @@ func (s *Server) forwardHTTPSequence(
 		s.logRoutingDecision(nextRouteID, []pool.Provider{state.provider}, "retry", 0, 0, "retry_"+itoa(state.explicitRetries), state.provider.ProviderID)
 	}
 }
-
-// forwardLogRowFunc is the signature of the `logRow` closure inside
-// handleChatCompletions. Hoisted into a named type so advanceToNextProvider
-// can accept the closure as a parameter without re-spelling the
-// 7-parameter signature.
-type forwardLogRowFunc func(providerAssignedID string, status int, promptTok, completionTok *int64, errMsg, errCode string, retried int)
 
 // advanceToNextProvider performs the per-retry "pick a fresh provider,
 // dispatch the route-error response on no-candidate, bump explicitRetries
@@ -1520,6 +1398,11 @@ type forwardLogRowFunc func(providerAssignedID string, status int, promptTok, co
 // continue/break) because those vary across callsites. Sub-PRs 1b and 1c
 // unify the three transport loops into a single failover skeleton.
 //
+// M3-10 (ARCH-6 close-out): the route-error logRow that this helper
+// emits on no-candidate now routes through *billingRecorder, matching
+// the rest of the request-log/billing orchestration that the audit
+// hoisted out of inline closures.
+//
 // Returns (next provider, nextRouteID used for routing-decision logging,
 // ok). ok=false means a route error has already been written to w and
 // the caller MUST return from handleChatCompletions immediately.
@@ -1529,13 +1412,13 @@ func (s *Server) advanceToNextProvider(
 	req chatRequest,
 	state *forwardState,
 	excluded map[string]struct{},
-	logRow forwardLogRowFunc,
+	rec *billingRecorder,
 ) (nextRouteID string, ok bool) {
 	nextRouteID = uuid.NewString()
 	picked, routeErr := s.selectProviderExcluding(nextRouteID, req, r.Header, excluded)
 	if routeErr != nil {
 		state.routingDone = s.now()
-		logRow("", routeErr.status, nil, nil, routeErr.message, "", state.explicitRetries)
+		rec.logRow("", routeErr.status, nil, nil, routeErr.message, "", state.explicitRetries)
 		writeRouteError(w, routeErr)
 		return "", false
 	}


### PR DESCRIPTION
## Summary

Closes ARCH-6 from `audits/2026-06-10/REPO_AUDIT.md` ("Billing/request-log persistence orchestration lives inline in handler closures"). The previously-inline `logRowWithBilling` closure at `phase4-coordinator/internal/buyer/server.go` is now a typed `*billingRecorder` mirroring the gateway's interface-clean store pattern (typed boundary around per-request persistence orchestration).

## What it changes

- **New** `phase4-coordinator/internal/buyer/billing_recorder.go` (~250 lines). Defines `billingRecorder` with `server / state / req / startedAt / model / stream / requestID / attemptN` fields and methods `recordRow / logRow / logBuyerFailure / logProviderRow / logProviderRowWithEstimate`.
- `handleChatCompletions` constructs the recorder once via `s.newBillingRecorder(...)` and threads it through `forwardStreamSequence`, `forwardWSNonStreamSequence`, `forwardHTTPSequence`, and `advanceToNextProvider`. The three sequence helpers and `advanceToNextProvider` now take `*billingRecorder` instead of closure parameters (`logRow / logProviderRow / logProviderRowWithEstimate / forwardLogRowFunc`).
- Deleted: the five inline closures (`logRowWithBilling`, `logRow`, `logBuyerFailure`, `logProviderRow`, `logProviderRowWithEstimate`) inside `handleChatCompletions`, plus the `forwardLogRowFunc` type that only existed to type those closures across the helper boundary.
- `logAttempt` and `shouldLogAttempt` stay as local closures (they read `req.raw` for prompt-token estimation, which is local to the handler). `logAttempt` delegates the actual row write to `rec.recordRow`, so the ARCH-6 orchestration still lives in `*billingRecorder`.

## What it preserves (byte-identical)

- Every field written to `requestlog.Row` and `billing.HotPathInput`: same values, same types, same NULL-vs-zero treatment.
- Defer ordering inside `recordRow`: `cancel` -> `fallbackCancel` (when hot-path falls back) -> `attemptN++` increment. Matches the pre-refactor closure exactly.
- Hot-path-then-fallback flow: `WriteHotPath` -> on error, `WriteRequestLogWithIdentity`; on both errors, return wrapped error.
- `RoutingMs` driven by live `state.routingDone` (the M2-1c invariant).
- Setter pattern (`setModel / setStream / setRequestID`) preserves the pre-refactor "latest value at fire time" semantics for outer-scope-captured variables.
- All five `forward_loop_test.go` scenarios (1-5) pass under `-race -count=5`.

## Audit loop

Three Codex auditors at effort=high, single iteration, all converged:

- **Code auditor:** "no behavior divergence" — one style nit on `attemptN` docstring (fixed in commit `f2f2115`). Recommends approve.
- **Security auditor:** no cross-request bleed, no new state-sharing surface, locking discipline preserved, TOCTOU on `setRequestID` correct, `context.WithTimeout(context.Background(), ...)` intentional. Single residual semantic caveat (attemptN increments on failed-write paths) is pre-existing pre-refactor behaviour, not introduced by M3-10.
- **Architect auditor (promotion gate):** **PROMOTE TO RESOLVED**, no named gap. Typed billingRecorder matches the spirit of the gateway's interface-clean store pattern; file placement consistent with `forward_state.go` / `transport_result.go`; no residual closures inside `handleChatCompletions` touch billing/request_log writes.

## Tests

```
go build ./... -> clean
go vet ./... -> clean
go test ./internal/buyer -race -count=5 -timeout 180s -> ok
go test ./... -timeout 300s -> ok across the coordinator module
```

## REMAINING_WORK.md

ARCH-6 promoted from `DEFERRED` to `RESOLVED`. Per the doc contract (matching PR #90's pattern for ARCH-5/DOCS-7/DOCS-4):

- ARCH-6 entry removed from the severity-ordered punch list.
- M3-10 row removed from the §5 task table.
- ARCH-6 and M3-10 removed from the "Deferred items" section.
- `grep "ARCH-6\|M3-10" REMAINING_WORK.md` returns no matches.

## Test plan

- [x] `go build ./...` in `phase4-coordinator` — clean
- [x] `go vet ./...` in `phase4-coordinator` — clean
- [x] `go test ./internal/buyer -race -count=5 -timeout 180s` — pass
- [x] `go test ./... -timeout 300s` in `phase4-coordinator` — all green
- [ ] CI green on this PR before merge
