### PR TITLE
fix(deploy): resolve env:NAME secrets in C2 pre-deploy gate (stop false-fail)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,27 @@ jobs:
         # provider + log pumps).
         run: go test -race -count=1 -timeout 5m ./...
 
+  dist-tooling:
+    name: deploy tooling (check-deploy-config gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Guards the fail-closed C2 pre-deploy gate
+    # (phase4-coordinator/dist/check-deploy-config.sh), also invoked by
+    # phase5-gateway/dist/deploy-pearl-vps.sh. Bash + python3 only — no Go
+    # build — so it stays a fast, isolated job. Closes the 2026-06-17
+    # regression where an env:NAME-indirected operator_key false-failed the
+    # gate and pushed operators into SKIP_C2_CHECK=1.
+    steps:
+      - name: Checkout
+        # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
+        # when upgrading the action rather than trusting a mutable tag.
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: make test-dist
+        run: make test-dist
+
   swift-tests:
     name: phase3-binary (swift test)
     runs-on: macos-15

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@
 # keep CI and local on the same targets. CI jobs use the per-service
 # targets below to preserve parallel jobs and failure isolation.
 
-.PHONY: test test-coordinator test-gateway test-integration \
+.PHONY: test test-coordinator test-gateway test-integration test-dist \
         vet vet-coordinator vet-gateway \
         build-linux check fmt
 
-test: test-coordinator test-gateway test-integration
+test: test-coordinator test-gateway test-integration test-dist
 
 test-coordinator:
 	cd phase4-coordinator && go test ./...
@@ -25,6 +25,13 @@ test-gateway:
 # the M3-2 internalBearerAuthorized dual-credential gate.
 test-integration:
 	cd test/integration && go test -race -count=1 -timeout 5m ./...
+
+# Deploy-tooling tests (bash + python3, no Go build). Guards the fail-closed
+# pre-deploy gate in phase4-coordinator/dist/check-deploy-config.sh — notably
+# that an env:NAME-indirected secret is deferred to runtime rather than
+# false-failing the gate (the 2026-06-17 regression that forced SKIP_C2_CHECK=1).
+test-dist:
+	bash phase4-coordinator/dist/test/check_deploy_config_test.sh
 
 vet: vet-coordinator vet-gateway vet-integration
 

--- a/phase4-coordinator/dist/check-deploy-config.sh
+++ b/phase4-coordinator/dist/check-deploy-config.sh
@@ -47,7 +47,7 @@ case "$GW" in
 esac
 
 python3 - "$COORD" "$GW" <<'PY'
-import re, sys
+import os, re, sys
 
 coord = open(sys.argv[1]).read()
 gw = open(sys.argv[2]).read() if len(sys.argv) > 2 and sys.argv[2] else ""
@@ -62,16 +62,59 @@ def hard(m):
 def warn(m): print(f"  WARN: {m}")
 def ok(m):   print(f"  ok:   {m}")
 
-# --- operator_key ---
-key = g(coord, "operator_key")
-if not key:
-    hard("coordinator operator_key missing")
-elif re.search(r"REPLACE|change-me|<required>|placeholder|xxx", key, re.I):
-    hard(f"coordinator operator_key is a PLACEHOLDER -> would break /poolz + /admin auth")
-elif not re.fullmatch(r"[0-9a-fA-F]{64}", key):
-    hard(f"operator_key is not 64-hex (len {len(key)}); expected `openssl rand -hex 32`")
-else:
-    ok("operator_key present (64-hex, non-placeholder)")
+# Secrets may be inlined as a literal value OR indirected to a runtime
+# environment variable as `env:NAME` (M3-2 / DEVE-7). The systemd units inject
+# NAME from /etc/macprovider/{coordinator,gateway}.env at start. This gate runs
+# LOCALLY before the config is shipped to Pearl, where those env files do not
+# exist and secrets are deliberately never pulled to local disk (see
+# normalize_yaml masking in deploy-pearl-vps.sh). So an `env:NAME` value is
+# "deferred to runtime": validate the reference is well-formed, and only if
+# NAME happens to be present in THIS process's environment (e.g. the gate is
+# run on Pearl with the env file sourced) do we also validate the resolved
+# secret. A bare unresolved `env:NAME` is NOT a failure — hex-validating the
+# literal string "env:NAME" was a false fail-closed gate that pressured
+# operators into SKIP_C2_CHECK=1, which also skipped the genuinely load-bearing
+# C2 timer check (observed 2026-06-17 on a gateway deploy to Pearl).
+ENV_REF = re.compile(r"^env:([A-Za-z_][A-Za-z0-9_]*)$")
+PLACEHOLDER = re.compile(r"REPLACE|change-me|<required>|placeholder|xxx", re.I)
+
+def check_hex_secret(label, raw):
+    """Validate a 64-hex secret that may be inline or `env:NAME`-indirected.
+
+    Reusable across every secret-shaped field this gate hex/placeholder-checks
+    (currently operator_key; add a field by calling this). Behavior:
+      - missing                 -> HARD fail
+      - "env:NAME", NAME unset   -> ok (deferred to runtime; cannot resolve here)
+      - "env:NAME", NAME set     -> validate the resolved value (placeholder/hex)
+      - "env:" / "env:1bad"      -> HARD fail (malformed reference)
+      - inline literal           -> validate as before (placeholder/hex)
+    """
+    if not raw:
+        hard(f"{label} missing")
+        return
+    src = ""
+    if raw.startswith("env:"):
+        m = ENV_REF.match(raw)
+        if not m:
+            hard(f"{label} malformed env indirection {raw!r}; expected env:NAME")
+            return
+        name = m.group(1)
+        resolved = os.environ.get(name)
+        if not resolved:
+            ok(f"{label} deferred to runtime via env:{name} "
+               f"(injected from /etc/macprovider/*.env at start; not resolvable in this gate)")
+            return
+        raw = resolved
+        src = f" (resolved from env:{name})"
+    if PLACEHOLDER.search(raw):
+        hard(f"{label} is a PLACEHOLDER{src} -> would break /poolz + /admin auth")
+    elif not re.fullmatch(r"[0-9a-fA-F]{64}", raw):
+        hard(f"{label} is not 64-hex (len {len(raw)}){src}; expected `openssl rand -hex 32`")
+    else:
+        ok(f"{label} present (64-hex, non-placeholder){src}")
+
+# --- operator_key (inline literal or env:NAME deferred to runtime) ---
+check_hex_secret("coordinator operator_key", g(coord, "operator_key"))
 
 # --- require_provider_tokens ---
 # Security-sensitive: the binary default is `true` (fail-closed), but a

--- a/phase4-coordinator/dist/test/check_deploy_config_test.sh
+++ b/phase4-coordinator/dist/test/check_deploy_config_test.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# check_deploy_config_test.sh — tests for check-deploy-config.sh, the
+# fail-closed C2 pre-deploy gate. Plain-bash assertions (no bats dependency),
+# matching the house style of ../../../phase5-gateway/dist/test/archive_rotate_test.sh.
+#
+# Regression focus (observed 2026-06-17 on a gateway deploy to Pearl): the gate
+# read operator_key literally and hex-validated the string "env:OPERATOR_KEY"
+# (len 16) of an env-indirected config, FAILed, and pressured the operator into
+# SKIP_C2_CHECK=1 — which silently skipped the genuinely load-bearing C2 timer
+# check too. An `env:NAME` secret is "deferred to runtime" and must NOT fail the
+# gate just for being indirected.
+#
+# Scenarios:
+#   T1 — inline literal 64-hex operator_key            -> pass (exit 0)
+#   T2 — env:NAME, var UNSET (the false-fail)          -> pass, "deferred to runtime"
+#   T3 — env:NAME, var SET to valid 64-hex             -> pass, "resolved from env"
+#   T4 — env:NAME, var SET to a too-short value        -> FAIL (resolution still validates)
+#   T5 — env:NAME, var SET to a placeholder            -> FAIL (resolution still validates)
+#   T6 — inline placeholder (REPLACE_ME...)            -> FAIL (original guard preserved)
+#   T7 — malformed env ref ("env:" / "env:1bad")       -> FAIL (clear message)
+#   T8 — operator_key absent                           -> FAIL
+#   T9 — env-indirected key does NOT mask a real C2 timer inversion -> FAIL on C2
+#
+# Run from repo root or any cwd: SCRIPT_DIR is derived from $0.
+# Skips with a noisy message if python3 is unavailable (the gate needs it).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SH="$DIST_DIR/check-deploy-config.sh"
+
+[ -f "$CHECK_SH" ] || { echo "missing $CHECK_SH" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 not installed" >&2; exit 0; }
+
+HEX64=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+OUT=""   # last gate stdout+stderr
+RC=0     # last gate exit code
+
+# ---- helpers ---------------------------------------------------------------
+
+mk_workdir() { mktemp -d -t check-deploy-config-test.XXXXXX; }
+
+# Write a coordinator.yaml whose operator_key is $1 (verbatim, already
+# quoted/unquoted by the caller) plus the fields the gate needs to otherwise
+# pass: an explicit require_provider_tokens and a C2-clean request_timeout_s.
+write_coord() {
+  local wd="$1" opkey="$2" rt="${3:-280}"
+  cat > "$wd/coordinator.yaml" <<EOF
+auth:
+  operator_key: $opkey
+  require_provider_tokens: true
+routing:
+  request_timeout_s: $rt
+EOF
+}
+
+# Write a minimal gateway.yaml carrying the one key the C2 cross-check reads.
+write_gw() {
+  local wd="$1" gwt="${2:-300}"
+  cat > "$wd/gateway.yaml" <<EOF
+timeouts:
+  coordinator_request_seconds: $gwt
+EOF
+}
+
+# Run the gate; capture combined output in OUT and exit code in RC. Any extra
+# args (e.g. NAME=value) are passed through as environment for the gate, so a
+# test can exercise the env:NAME resolution path.
+run_check() {
+  local wd="$1"; shift
+  OUT="$(env "$@" bash "$CHECK_SH" "$wd/coordinator.yaml" "$wd/gateway.yaml" 2>&1)"
+  RC=$?
+}
+
+assert_exit() { # $1 expected rc, $2 test name
+  if [ "$RC" -eq "$1" ]; then
+    PASS=$((PASS+1)); echo "  ok: $2 (exit $RC)"
+  else
+    FAIL=$((FAIL+1)); FAIL_NAMES+=("$2"); echo "  FAIL: $2 — expected exit $1, got $RC"
+    printf '%s\n' "$OUT" | sed 's/^/      | /'
+  fi
+}
+
+assert_contains() { # $1 substring, $2 test name
+  if printf '%s' "$OUT" | grep -qF "$1"; then
+    PASS=$((PASS+1)); echo "  ok: $2 (found: $1)"
+  else
+    FAIL=$((FAIL+1)); FAIL_NAMES+=("$2"); echo "  FAIL: $2 — output missing: $1"
+    printf '%s\n' "$OUT" | sed 's/^/      | /'
+  fi
+}
+
+# ---- scenarios -------------------------------------------------------------
+
+test_inline_hex_passes() {
+  local wd; wd="$(mk_workdir)"
+  write_gw "$wd"; write_coord "$wd" "\"$HEX64\""
+  run_check "$wd"
+  assert_exit 0 "T1 inline 64-hex passes"
+  assert_contains "operator_key present (64-hex" "T1 inline 64-hex message"
+  rm -rf "$wd"
+}
+
+test_env_ref_unset_is_deferred() {
+  # The exact false-fail from 2026-06-17. Must NOT abort the deploy.
+  local wd; wd="$(mk_workdir)"
+  write_gw "$wd"; write_coord "$wd" "env:OPERATOR_KEY"
+  # Explicitly clear the var so the host's environment can't mask the case.
+  run_check "$wd" OPERATOR_KEY=
+  assert_exit 0 "T2 env:NAME (unset) does not false-fail"
+  assert_contains "deferred to runtime via env:OPERATOR_KEY" "T2 deferred message"
+  rm -rf "$wd"
+}
+
+test_env_ref_set_valid_resolves() {
+  local wd; wd="$(mk_workdir)"
+  write_gw "$wd"; write_coord "$wd" "env:OPERATOR_KEY"
+  run_check "$wd" "OPERATOR_KEY=$HEX64"
+  assert_exit 0 "T3 env:NAME resolves to valid hex"
+  assert_contains "resolved from env:OPERATOR_KEY" "T3 resolved message"
+  rm -rf "$wd"
+}
+
+test_env_ref_set_short_fails() {
+  local wd; wd="$(mk_workdir)"
+  write_gw "$wd"; write_coord "$wd" "env:OPERATOR_KEY"
+  run_check "$wd" "OPERATOR_KEY=deadbeef"
+  assert_exit 1 "T4 env:NAME resolves to short value -> FAIL"
+  assert_contains "is not 64-hex" "T4 short-value message"
+  rm -rf "$wd"
+}
+
+test_env_ref_set_placeholder_fails() {
+  local wd; wd="$(mk_workdir)"
+  write_gw "$wd"; write_coord "$wd" "env:OPERATOR_KEY"
+  run_check "$wd" "OPERATOR_KEY=REPLACE_ME_WITH_RANDOM_HEX_64"
+  assert_exit 1 "T5 env:NAME resolves to placeholder -> FAIL"
+  assert_contains "PLACEHOLDER" "T5 placeholder message"
+  rm -rf "$wd"
+}
+
+test_inline_placeholder_fails() {
+  local wd; wd="$(mk_workdir)"
+  write_gw "$wd"; write_coord "$wd" "\"REPLACE_ME_WITH_RANDOM_HEX_64\""
+  run_check "$wd"
+  assert_exit 1 "T6 inline placeholder still rejected"
+  assert_contains "PLACEHOLDER" "T6 placeholder message"
+  rm -rf "$wd"
+}
+
+test_malformed_env_ref_fails() {
+  local wd; wd="$(mk_workdir)"
+  write_gw "$wd"
+  # Empty NAME.
+  write_coord "$wd" "env:"
+  run_check "$wd"
+  assert_exit 1 "T7a env: (empty NAME) -> FAIL"
+  assert_contains "malformed env indirection" "T7a malformed message"
+  # Leading digit is not a valid env var identifier.
+  write_coord "$wd" "env:1bad"
+  run_check "$wd"
+  assert_exit 1 "T7b env:1bad -> FAIL"
+  assert_contains "malformed env indirection" "T7b malformed message"
+  rm -rf "$wd"
+}
+
+test_missing_key_fails() {
+  local wd; wd="$(mk_workdir)"
+  write_gw "$wd"
+  cat > "$wd/coordinator.yaml" <<EOF
+auth:
+  require_provider_tokens: true
+routing:
+  request_timeout_s: 280
+EOF
+  run_check "$wd"
+  assert_exit 1 "T8 absent operator_key -> FAIL"
+  assert_contains "operator_key missing" "T8 missing message"
+  rm -rf "$wd"
+}
+
+test_env_ref_does_not_mask_c2_inversion() {
+  # An env-indirected (deferred) operator_key must not turn the gate into a
+  # no-op: a real C2 timer inversion still has to be caught.
+  local wd; wd="$(mk_workdir)"
+  write_gw "$wd" 200                       # gateway 200s
+  write_coord "$wd" "env:OPERATOR_KEY" 280  # coordinator 280s >= gateway -> inversion
+  run_check "$wd" OPERATOR_KEY=
+  assert_contains "C2: coordinator request_timeout_s" "T9 C2 inversion still surfaced"
+  rm -rf "$wd"
+}
+
+# ---- run -------------------------------------------------------------------
+
+echo "== check-deploy-config.sh tests =="
+echo "gate: $CHECK_SH"
+echo
+
+test_inline_hex_passes
+test_env_ref_unset_is_deferred
+test_env_ref_set_valid_resolves
+test_env_ref_set_short_fails
+test_env_ref_set_placeholder_fails
+test_inline_placeholder_fails
+test_malformed_env_ref_fails
+test_missing_key_fails
+test_env_ref_does_not_mask_c2_inversion
+
+echo
+echo "== summary =="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "failed tests:"
+  for n in "${FAIL_NAMES[@]}"; do echo "  - $n"; done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem

`phase4-coordinator/dist/check-deploy-config.sh` — the fail-closed C2 pre-deploy gate, also invoked by `phase5-gateway/dist/deploy-pearl-vps.sh` — hex-validates `operator_key` read **literally** from the YAML. The live configs store the secret as an env reference, not a literal:

- `coordinator.yaml`: `operator_key: env:OPERATOR_KEY`
- `gateway.yaml`: `operator_key: env:COORDINATOR_OPERATOR_KEY`

…injected at runtime from `/etc/macprovider/*.env` by the systemd units. The gate saw the 16-char string `env:OPERATOR_KEY`, reported `FAIL: operator_key is not 64-hex (len 16)`, and aborted the deploy even though the runtime key is a valid 64-hex value.

**Observed 2026-06-17** on a gateway deploy to Pearl: the gate failed *only* on this (plus a pre-existing `require_provider_tokens=false` WARN); the genuinely deploy-relevant invariant (`C2 timer ordering: coordinator 280s < gateway 300s`) passed. The deploy had to use `SKIP_C2_CHECK=1` — which **also skips the load-bearing C2 timer-ordering check**, the one invariant that caught a real past production incident. A false failure on a mandatory safety gate that pressures operators into disabling the whole gate.

## Fix

The gate runs **locally** before the config ships to Pearl, where the env files do not exist and secrets are deliberately never pulled to local disk (see the `normalize_yaml` masking in `deploy-pearl-vps.sh`). So an `env:NAME` value is treated as **deferred to runtime**:

| Value | Behavior |
|---|---|
| `env:NAME`, var unset | ok — "deferred to runtime" (was the false-fail) |
| `env:NAME`, var present | resolve and validate (best-effort hardening) |
| `env:` / `env:1bad` (malformed) | HARD fail, clear message |
| inline placeholder / short / inline literal | unchanged — original protection preserved |

Logic is factored into a reusable `check_hex_secret(label, raw)` helper so any future secret-shaped field the gate checks gets the same `env:NAME` handling.

## Tests / CI

- `phase4-coordinator/dist/test/check_deploy_config_test.sh` — 19 assertions across 9 scenarios (plain-bash house style, matching `phase5-gateway/dist/test/archive_rotate_test.sh`). Covers both a literal 64-hex value and `env:NAME` references (unset / set-valid / set-bad), placeholder / missing / malformed cases, and that a deferred key does **not** turn the gate into a no-op (a real C2 timer inversion is still surfaced).
- `make test-dist` target, wired into `make test`.
- New fast `dist-tooling` CI job (bash + python3, no Go build) so the regression is guarded on every PR.

All 19 assertions pass; the original repro fixture now prints `config-drift check passed` (exit 0) with the C2 ordering check still running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
