### PR TITLE
fix(provider): resume sendPing continuation exactly once

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -45,10 +45,33 @@ private let providerWebSocketSession: URLSession = {
 
 extension URLSessionWebSocketTask: ProviderWebSocketTask {}
 
+// Guards a CheckedContinuation so it resumes exactly once. URLSession's
+// pongReceiveHandler can fire more than once on a connection abort (observed
+// in the field: NSPOSIXErrorDomain Code=53 "Software caused connection
+// abort"), which previously double-resumed the continuation and tripped a
+// SWIFT TASK CONTINUATION MISUSE fatalError — crashing the whole provider on
+// a single transient WS blip. NSLock-guarded flag matches the @unchecked
+// Sendable idiom used elsewhere in this file (CaffeinateSleepAssertion).
+private final class ResumeOnceGuard: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resumed = false
+    /// Returns true exactly once — for the first caller. All later calls
+    /// return false so the continuation is never resumed twice.
+    func claim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if resumed { return false }
+        resumed = true
+        return true
+    }
+}
+
 extension URLSessionWebSocketTask {
     func sendPing() async throws {
+        let once = ResumeOnceGuard()
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             sendPing { error in
+                guard once.claim() else { return }
                 if let error {
                     continuation.resume(throwing: error)
                 } else {


### PR DESCRIPTION
## Problem
A single transient WebSocket blip to the coordinator crashed the **entire provider** (exit 133 / SIGTRAP):
```
_Concurrency/CheckedContinuation.swift:196: Fatal error: SWIFT TASK CONTINUATION MISUSE:
sendPing() tried to resume its continuation more than once, throwing ...
Code=53 "Software caused connection abort"
```
`URLSessionWebSocketTask.sendPing(pongReceiveHandler:)` can invoke its handler more than once on a connection abort. The async wrapper in `CoordinatorClient.swift` resumed its `CheckedContinuation` directly in that handler, so the second invocation double-resumed → `fatalError`.

## Fix
Guard the resume with an `NSLock`-backed `ResumeOnceGuard` (matches the `@unchecked Sendable` idiom already used by `CaffeinateSleepAssertion` in the same file) so the continuation resumes exactly once; later handler calls are ignored.

## Validation
- `swift build -c release` clean.
- Empirically: rebuilt provider stays up through the coordinator keepalive ping cycle that previously crashed it (used to run a buyer-harness sweep). Before fix: crash within seconds of the first ping abort.
- **Recommended before merge:** add a unit test (make `ResumeOnceGuard` internal + `@testable`) asserting `claim()` returns true once then false.

Do NOT merge until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)