### PR TITLE
fix(provider): drain WS receive loop so constrained providers hold ready

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -366,16 +366,75 @@ actor CoordinatorClient {
         try await receiveLoop(socket)
     }
 
+    // Receive/handle decoupling (provider WS drain fix). Previously this loop
+    // ran `await socket.receive()` then `await handle(message)` serially on the
+    // CoordinatorClient actor. While handle() suspended — drain's
+    // waitUntilDrained (up to drainTimeoutSeconds), warm_up's two state_update
+    // writes, acceptCoordinatorSession's token-persist + state_update, or an
+    // InferenceRelay actor hop — the actor could not re-enter the loop to call
+    // the next receive(). The OS WS read buffer backed up, TCP backpressure made
+    // the coordinator's heartbeat/control writes block and time out (~30-48s),
+    // and the coordinator dropped the session. A constrained provider thus never
+    // held a steady `ready` heartbeat.
+    //
+    // The fix splits receiving from handling across two structured child tasks:
+    //   - the receive task does only `socket.receive()` -> `continuation.yield`
+    //     and loops straight back, so the socket is always drained promptly;
+    //   - one drainer task consumes the stream and calls handle() serially,
+    //     preserving inbound frame ordering (control/heartbeat frames are no
+    //     longer blocked by inference handling, which spawns its own child Task
+    //     in InferenceRelay and returns quickly).
+    // The inbox is .unbounded: AsyncStream.yield never suspends, so it never
+    // re-introduces producer backpressure, and unbounded never drops a control
+    // frame (a bounded buffering policy would silently drop cancel/drain/
+    // inference frames). On any handle() throw (e.g. CoordinatorDrainComplete or
+    // a send failure) the drainer rethrows; the first child to finish ends the
+    // connection and the group cancels its sibling, so the error unwinds to
+    // runReconnectLoop exactly as before.
     private func receiveLoop(_ socket: ProviderWebSocketTask) async throws {
-        while !Task.isCancelled {
-            let message: URLSessionWebSocketTask.Message
+        let (inbox, continuation) = AsyncStream.makeStream(
+            of: URLSessionWebSocketTask.Message.self,
+            bufferingPolicy: .unbounded
+        )
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            // Receive task: keep the socket drained. Captures `socket` and
+            // `continuation` (both Sendable), never `self`, so nothing here
+            // hops onto the actor and stalls the next receive().
+            group.addTask {
+                defer { continuation.finish() }
+                while !Task.isCancelled {
+                    let message: URLSessionWebSocketTask.Message
+                    do {
+                        message = try await socket.receive()
+                    } catch {
+                        Self.keepaliveDebug("ws_receive_error error=\(error)")
+                        throw error
+                    }
+                    continuation.yield(message)
+                }
+            }
+
+            // Drainer task: serial handle() preserves frame ordering. The actor
+            // hop on self.handle is the serialization point and is race-free.
+            group.addTask { [self] in
+                for await message in inbox {
+                    try Task.checkCancellation()
+                    try await handle(message)
+                }
+            }
+
+            // The first child to finish (normal end or throw) ends the
+            // connection; cancel the sibling and unwind. Rethrowing here
+            // carries CoordinatorDrainComplete / receive errors to
+            // runReconnectLoop unchanged.
             do {
-                message = try await socket.receive()
+                try await group.next()
             } catch {
-                Self.keepaliveDebug("ws_receive_error error=\(error)")
+                group.cancelAll()
                 throw error
             }
-            try await handle(message)
+            group.cancelAll()
         }
     }
 
@@ -657,18 +716,58 @@ actor CoordinatorClient {
         try await sendStateUpdate(state: nil, reason: reason)
     }
 
+    // Provider WS keepalive fix. The coordinator advertises heartbeat_interval_s
+    // (typically 30) and we previously slept the FULL interval before the first
+    // keepalive, then on each tick sent a WebSocket control PING followed by a
+    // heartbeat. That kept a constrained provider out of the `ready` pool via a
+    // connect -> i/o-timeout -> disconnect -> reconnect loop, for two reasons
+    // confirmed against the coordinator code:
+    //
+    //   1. A provider->coordinator WS control PING is actively harmful here. The
+    //      coordinator's gobwas reader auto-writes a PONG to the raw conn
+    //      (server.go readClientData / ControlFrameHandler), but the coordinator
+    //      only ever sets the connection write deadline inside its runWriter
+    //      text-frame path (relay.go:106, write_timeout_s=10) and never clears
+    //      it. Once the connection has been idle past that absolute 10s deadline,
+    //      the PONG write fails immediately with "write tcp ... i/o timeout" and
+    //      the coordinator drops the session. So the PING we sent to keep the
+    //      link alive was the very thing triggering the disconnect — which is
+    //      why the drop cadence tracked our ping period.
+    //   2. The coordinator does not count provider control frames as liveness:
+    //      readProviderLoop ignores any non-text frame (server.go:1127) and only
+    //      text frames refresh activity. A PING would not have kept us alive even
+    //      without bug (1).
+    //
+    // The fix: send a heartbeat TEXT frame on a short sub-interval tick and send
+    // no control pings. A text frame routes through the coordinator's runWriter,
+    // which sets a FRESH write deadline before writing, and reaches handleMessage
+    // which refreshes liveness. The tick is capped well under the coordinator's
+    // 10s write deadline (and any proxy idle timeout) so the connection never
+    // sits idle long enough for the stale-deadline write to fire. The since-last
+    // metrics window is still rolled only on the full coordinator interval
+    // (resetWindow), so heartbeat metrics are unchanged from before.
+    private static let keepaliveTickCeilingSeconds = 5
     private func startHeartbeat(intervalSeconds: Int) {
         heartbeatTask?.cancel()
-        Self.keepaliveDebug("heartbeat_start interval_s=\(intervalSeconds)")
+        let tickSeconds = max(1, min(intervalSeconds, Self.keepaliveTickCeilingSeconds))
+        Self.keepaliveDebug("heartbeat_start interval_s=\(intervalSeconds) tick_s=\(tickSeconds)")
         heartbeatTask = Task { [weak self] in
+            var secondsSinceWindowReset = 0
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: UInt64(tickSeconds) * 1_000_000_000)
                 if Task.isCancelled {
                     return
                 }
+                secondsSinceWindowReset += tickSeconds
+                // Roll the metrics window only on the full coordinator interval;
+                // intermediate ticks are keepalive heartbeats that report the
+                // same accumulating window without resetting it.
+                let rollWindow = secondsSinceWindowReset >= intervalSeconds
+                if rollWindow {
+                    secondsSinceWindowReset = 0
+                }
                 do {
-                    try await self?.sendWebSocketPing()
-                    try await self?.sendHeartbeat()
+                    try await self?.sendHeartbeat(resetWindow: rollWindow)
                 } catch {
                     Self.keepaliveDebug("keepalive_send_error error=\(error)")
                     await self?.closeWebSocketAfterKeepaliveFailure()
@@ -676,12 +775,6 @@ actor CoordinatorClient {
                 }
             }
         }
-    }
-
-    private func sendWebSocketPing() async throws {
-        guard let webSocket else { throw CancellationError() }
-        try await webSocket.sendPing()
-        Self.keepaliveDebug("ws_ping")
     }
 
     private func closeWebSocketAfterKeepaliveFailure() {
@@ -779,8 +872,13 @@ actor CoordinatorClient {
         await providerStatus.setState(.ready)
     }
 
-    private func sendHeartbeat() async throws {
-        let snapshot = await providerStatus.snapshot(resetWindow: true)
+    // resetWindow=true rolls the since-last metrics window (the coordinator-
+    // interval heartbeat). Intermediate keepalive heartbeats (sent on the short
+    // sub-interval tick to keep the connection alive) pass resetWindow=false so
+    // the since-last window stays aligned to the full coordinator interval and
+    // metrics are unchanged from the prior single-heartbeat-per-interval cadence.
+    private func sendHeartbeat(resetWindow: Bool = true) async throws {
+        let snapshot = await providerStatus.snapshot(resetWindow: resetWindow)
         var payload: [String: Any] = [
             "type": "heartbeat",
             "status": snapshot.status.rawValue,

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -240,7 +240,13 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertNil(capturedRequest, "delegate must call completion with nil to refuse the redirect")
     }
 
-    func testCoordinatorSessionSendsWebSocketPingBeforeHeartbeat() async throws {
+    // Keepalive sends a heartbeat TEXT frame on the sub-interval tick and sends
+    // NO WebSocket control ping. A provider->coordinator control PING triggers
+    // the coordinator's auto-PONG write onto a stale (never-cleared) write
+    // deadline, which fails with i/o timeout and drops the session; control
+    // frames also do not count as liveness on the coordinator. So keepalive must
+    // be a text heartbeat, never a ping. See startHeartbeat doc-comment.
+    func testCoordinatorSessionKeepaliveSendsHeartbeatTextFrameAndNoPing() async throws {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
         config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
@@ -274,8 +280,11 @@ final class CoordinatorClientTests: XCTestCase {
         } catch is CancellationError {
         }
 
-        XCTAssertGreaterThanOrEqual(socket.pingCountSnapshot(), 1)
+        // A heartbeat text frame is emitted on the keepalive tick (interval 1s,
+        // tick capped at <= interval, fires inside the 1.2s receive window)...
         XCTAssertTrue(socket.sentFrames().contains { $0["type"] as? String == "heartbeat" })
+        // ...and no WebSocket control ping is ever sent.
+        XCTAssertEqual(socket.pingCountSnapshot(), 0)
     }
 
     func testHelloIncludesModelHashWhenAvailable() async throws {


### PR DESCRIPTION
## Root cause

A constrained provider (`augustass-macbook-air`, `mlx-community/Llama-3.2-3B-Instruct-4bit`) could not hold **ready** in the coordinator pool. It cycled:

```
connect -> coordinator "write tcp ... i/o timeout" / "provider websocket read failed"
        -> "provider websocket disconnected (grace 30000)" -> reconnect -> ...
```

on a cadence that **tracked the provider's own keepalive period** (ping at 30s -> drop ~30s; ping at 15s -> drop ~15s), so the provider never delivered a steady heartbeat. The gateway then computed `no_awake_provider` (`phase5-gateway/internal/router/server.go:687`) and buyers got 503.

Bilateral keepalive tracing (provider + coordinator journal) revealed **two** provider-side problems, both confirmed against the coordinator source:

1. **The keepalive WebSocket control PING was *causing* the disconnect.** The coordinator's gobwas reader auto-writes a PONG to the raw `conn` when it receives a provider PING (`phase4-coordinator/internal/ws/server.go:1289` `readClientData` / `ControlFrameHandler`). But the coordinator only ever sets the connection write deadline inside its `runWriter` text-frame path (`phase4-coordinator/internal/ws/relay.go:106`, `write_timeout_s=10`) and **never clears it** — it is an absolute deadline of `last_text_write + 10s`. Once the link has been idle past that deadline, the auto-PONG write fails immediately with `write tcp ... i/o timeout`, and `readProviderLoop` drops the session. The warmup-probe response (a text write via `runWriter`) refreshes the deadline, which is exactly why each connection survived ~the keepalive period and then died on the next ping.
2. **Provider control frames do not count as coordinator liveness.** `readProviderLoop` ignores any non-text frame (`server.go:1127`, `if op != OpText { continue }`, skipping `handleMessage` / `LastActivityAt`), so a PING would not have kept the session alive even without problem (1).

This is also why bumping the coordinator's `ws.write_timeout_s` 10->30 (tried earlier, reverted) did not help — wrong knob; the kill is the stale-deadline auto-PONG write, not a slow legitimate write.

> Note: the coordinator's stale-write-deadline behavior is a real coordinator bug, but it is **out of scope** for this provider-side change and is **not** touched here.

## The fix (provider-side only; 1 source file + its test)

`phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`:

1. **Decouple the WS receive loop from message handling.** `receiveLoop` ran on the `CoordinatorClient` actor and did `socket.receive()` then `handle(message)` serially; while `handle()` suspended (drain's `waitUntilDrained` up to `drainTimeoutSeconds`, `warm_up`'s two `state_update` writes, token persist, or an `InferenceRelay` actor hop) the actor could not re-enter to call the next `receive()`, the OS WS read buffer backed up, and TCP backpressure stalled the coordinator's writes. Now a **receive child task** does only `socket.receive()` then `continuation.yield` (unbounded `AsyncStream` — `yield` never suspends and never drops control frames) and loops straight back, while **one drainer child task** calls `handle()` serially (inbound frame ordering preserved; control/heartbeat no longer blocked by inference handling, which spawns its own child `Task` and returns quickly). A `handle()` throw (`CoordinatorDrainComplete`, send failure) still unwinds to `runReconnectLoop` unchanged, via `withThrowingTaskGroup`.

2. **Replace the keepalive control PING with a short-interval heartbeat TEXT frame.** `startHeartbeat` no longer sends a WS control ping; it sends a heartbeat **text** frame on a tick capped at **5s** (`keepaliveTickCeilingSeconds`, well under the coordinator's 10s write deadline and any proxy idle timeout). A text frame routes through the coordinator's `runWriter` (which sets a **fresh** write deadline before writing) and reaches `handleMessage` (refreshing `LastActivityAt`). `sendHeartbeat` gains a `resetWindow` flag so the since-last metrics window is rolled only on the full coordinator interval — intermediate keepalive heartbeats report the same accumulating window — keeping heartbeat metrics unchanged from the prior one-per-interval cadence.

The now-unused `sendWebSocketPing()` is removed; the `ProviderWebSocketTask.sendPing()` protocol requirement and the `URLSessionWebSocketTask` extension (PR #101's resume-once guard) are left intact.

### Diff: receive loop (before -> after)

Before:

    private func receiveLoop(_ socket: ProviderWebSocketTask) async throws {
        while !Task.isCancelled {
            let message: URLSessionWebSocketTask.Message
            do {
                message = try await socket.receive()
            } catch {
                Self.keepaliveDebug("ws_receive_error error=...")
                throw error
            }
            try await handle(message)        // blocks the actor; next receive() cannot run
        }
    }

After:

    private func receiveLoop(_ socket: ProviderWebSocketTask) async throws {
        let (inbox, continuation) = AsyncStream.makeStream(
            of: URLSessionWebSocketTask.Message.self,
            bufferingPolicy: .unbounded
        )
        try await withThrowingTaskGroup(of: Void.self) { group in
            group.addTask {                              // receive: always drain the socket
                defer { continuation.finish() }
                while !Task.isCancelled {
                    let message: URLSessionWebSocketTask.Message
                    do { message = try await socket.receive() }
                    catch { Self.keepaliveDebug("ws_receive_error ..."); throw error }
                    continuation.yield(message)
                }
            }
            group.addTask { [self] in                    // drainer: serial handle(), ordering preserved
                for await message in inbox {
                    try Task.checkCancellation()
                    try await handle(message)
                }
            }
            do { try await group.next() } catch { group.cancelAll(); throw error }
            group.cancelAll()
        }
    }

And in `startHeartbeat`: the per-tick `sendWebSocketPing()` + `sendHeartbeat()` (which slept the full interval first) becomes a `tickSeconds = max(1, min(interval, 5))` loop that sends only `sendHeartbeat(resetWindow:)`, rolling the window on the full interval.

## Tests

- `swift build -c release --product macprovider-cli` -> clean (Swift 6.3 strict concurrency, zero errors).
- `swift test` -> **219 tests, 0 failures.** The former `testCoordinatorSessionSendsWebSocketPingBeforeHeartbeat` is replaced by `testCoordinatorSessionKeepaliveSendsHeartbeatTextFrameAndNoPing`, asserting the keepalive emits a heartbeat text frame on the tick and **no** control ping (`pingCount == 0`).

## Live validation (acceptance bar)

Patched binary deployed to `~/macprovider/macprovider-cli` (backup `macprovider-cli.pre-drainfix.bak`); provider run with the real config (`~/.config/macprovider/config.yaml`).

**1. 90s coordinator journal (3+ heartbeat cycles) -- NO write-timeout, holds ready:**

    04:48:45 ... {"provider_id":"augustass-macbook-air","state":"ready","slots_free":1,"slots_total":1,"message":"provider heartbeat"}
    04:48:51 ... state:"ready" slots_free:1 ... heartbeat
    04:48:56 ... state:"ready" ... heartbeat
       (steady every ~5-6s, all state:"ready", through ...)
    04:50:14 ... {"provider_id":"augustass-macbook-air","state":"ready","slots_free":1,"slots_total":1,"message":"provider heartbeat"}

Zero `write tcp ... i/o timeout`, zero `provider websocket disconnected` for the whole window. (Pre-fix, those two lines appeared every ~30s.)

Provider-side keepalive trace over the same connection: one connect, heartbeat text frames every ~5s, **0** `ws_ping`, **0** `keepalive_send_error` for 100s+.

**2. Gateway pool -- ready and stable (not flapping):**

    GET https://api.streamvc.live/v1/status
      pool: { total_providers: 1, ready: 1, degraded: 0, draining: 0, unavailable: 0 }
      models[Llama-3.2-3B-Instruct-4bit]: ready_provider_count: 1, slots_free: 1, available: true, availability: "available"

Re-checked 53s later -- still `availability: "available"`, `ready_provider_count: 1`.

**3. Buyer transaction through the gateway -> HTTP 200 (not 503):**

    POST https://api.streamvc.live/v1/chat/completions  (3B model, "say ok")
    -> 200
    {"id":"chatcmpl-...","model":"mlx-community/Llama-3.2-3B-Instruct-4bit","object":"chat.completion",
     "usage":{"total_tokens":40,"prompt_tokens":39,"completion_tokens":1},
     "choices":[{"finish_reason":"stop","index":0,"message":{"content":"Ok","role":"assistant"}}]}

Provider was stopped after validation (`pkill -f "macprovider-cli serve"`, confirmed no process remains). Coordinator and Pearl were used read-only (journalctl only); no coordinator / gateway / nginx / config changes (`git diff --name-only origin/main` = the two provider files only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
