### PR TITLE
spike: provider-side model-selection autotune loop (autoresearch)

### DIFF
--- a/beta/autotune.py
+++ b/beta/autotune.py
@@ -63,6 +63,7 @@ import argparse
 import html
 import signal
 import sqlite3
+import statistics
 import subprocess
 import sys
 import time
@@ -143,6 +144,10 @@ _ADDITIVE_TUNE_COLUMNS = (
     ("kv_bits", "INTEGER"),
     ("max_context_cap", "INTEGER"),
     ("max_batch", "INTEGER"),
+    # Number of replicate requests fired per trial (default 1 = original
+    # single-shot behavior). Median tps/ttft are recorded in
+    # agg_throughput_tps / ttft_p95_ms so existing reports keep working.
+    ("replicates_n", "INTEGER"),
 )
 
 
@@ -167,11 +172,11 @@ def write_trial_row(conn: sqlite3.Connection, row: dict) -> None:
         """INSERT INTO tune_trials
                (ts_utc, run_id, model, target_context, measured_prompt_tokens,
                 max_tokens, agg_throughput_tps, ttft_p95_ms, fits, n_err, kept, notes,
-                kv_bits, max_context_cap, max_batch)
+                kv_bits, max_context_cap, max_batch, replicates_n)
            VALUES
                (:ts_utc, :run_id, :model, :target_context, :measured_prompt_tokens,
                 :max_tokens, :agg_throughput_tps, :ttft_p95_ms, :fits, :n_err, :kept, :notes,
-                :kv_bits, :max_context_cap, :max_batch)""",
+                :kv_bits, :max_context_cap, :max_batch, :replicates_n)""",
         row,
     )
     conn.commit()
@@ -300,6 +305,7 @@ def evaluate_candidate(
     kv_bits: int | None = None,
     max_context_cap: int | None = None,
     max_batch: int | None = None,
+    replicates: int = 1,
 ) -> dict[str, Any]:
     """Start provider for `model` (with the optional serving knobs applied),
     fire a workload at `context`, stop provider.
@@ -337,36 +343,96 @@ def evaluate_candidate(
                 "notes": full_note[:480],
             }
 
-        # Provider is up. Fire one streamed request at the target context.
+        # Provider is up. Fire `replicates` streamed requests against the same
+        # loaded provider; aggregate by MEDIAN (robust to single-trial flakes
+        # like a momentary swap pressure spike). When --replicates=1 this is
+        # identical to the original single-shot behavior; when >1 the cell is
+        # treated as feasible only if EVERY replicate is feasible — strict, as
+        # befits a recipe meant to be applied as a recommendation.
         body = build_padded_prompt(context, max_tokens)
-        wall_t0 = time.monotonic()
-        result = fire_stream(chat_url, model, body, request_timeout)
-        wall_seconds = time.monotonic() - wall_t0
+        per_replicate: list[tuple[dict, dict]] = []  # (agg, result)
+        for _ in range(max(1, replicates)):
+            wall_t0 = time.monotonic()
+            result = fire_stream(chat_url, model, body, request_timeout)
+            wall_seconds = time.monotonic() - wall_t0
+            cell = {"wall_seconds": wall_seconds, "results": [result]}
+            agg = aggregate_cell(cell, gate_ttft_ms)
+            per_replicate.append((agg, result))
 
-        # Reuse sweep.aggregate_cell with a single-result "cell". It computes
-        # agg_throughput_tps (completion tokens / wall), ttft_p95, n_err, and a
-        # feasibility flag (n_err==0 AND ttft within gate AND no stop-token leak).
-        cell = {"wall_seconds": wall_seconds, "results": [result]}
-        agg = aggregate_cell(cell, gate_ttft_ms)
+        tps_values = [a["agg_throughput_tps"] for a, _ in per_replicate
+                      if a["agg_throughput_tps"] is not None]
+        ttft_values = [a["ttft_p95_ms"] for a, _ in per_replicate
+                       if a["ttft_p95_ms"] is not None]
+        all_feasible = all(a["feasible"] for a, _ in per_replicate)
+        total_n_err = sum(a["n_err"] for a, _ in per_replicate)
 
-        notes = None
-        if agg["n_err"]:
-            err = result.get("error") or f"HTTP {result.get('http_status')}"
-            notes = f"request error: {str(err)[:200]}"
-        elif not agg["feasible"]:
-            notes = f"missed gate: ttft_p95={agg['ttft_p95_ms']}ms > {gate_ttft_ms}ms"
+        median_tps = statistics.median(tps_values) if tps_values else None
+        median_ttft = statistics.median(ttft_values) if ttft_values else None
+        # measured_prompt_tokens is a property of the prompt + tokenizer, not
+        # of the load; take the first non-null value across replicates.
+        measured_prompt_tokens = next(
+            (a["measured_prompt_tokens"] for a, _ in per_replicate
+             if a["measured_prompt_tokens"] is not None),
+            None,
+        )
+
+        # Build notes from any errors / gate-misses across the replicates.
+        # Dedupe up to 3 distinct messages, then cap total length.
+        notes: str | None = None
+        err_msgs: list[str] = []
+        for a, r in per_replicate:
+            if a["n_err"]:
+                err = r.get("error") or f"HTTP {r.get('http_status')}"
+                err_msgs.append(f"err: {str(err)[:120]}")
+            elif not a["feasible"]:
+                err_msgs.append(f"missed gate ttft={a['ttft_p95_ms']:.0f}ms")
+        if err_msgs:
+            uniq = list(dict.fromkeys(err_msgs))[:3]
+            notes = (" | ".join(uniq))[:240]
 
         return {
-            "fits": int(agg["feasible"]),
-            "n_err": agg["n_err"],
-            "agg_throughput_tps": agg["agg_throughput_tps"],
-            "ttft_p95_ms": agg["ttft_p95_ms"],
-            "measured_prompt_tokens": agg["measured_prompt_tokens"],
+            "fits": int(all_feasible),
+            "n_err": total_n_err,
+            "agg_throughput_tps": median_tps,
+            "ttft_p95_ms": median_ttft,
+            "measured_prompt_tokens": measured_prompt_tokens,
             "notes": notes,
         }
     finally:
         # INVARIANT: stop the provider before returning, always.
         stop_provider(port)
+
+
+# Throughput tie band for the keep-best decision. Two trials whose tps differ
+# by no more than this fraction of the current best are treated as a tie and
+# decided by TTFT (lower is better). 2% absorbs the per-trial measurement
+# noise we observed in the air5 24-trial run without falsely declaring
+# materially-different configs equivalent.
+TPS_TIE_EPSILON = 0.02
+
+
+def _is_new_best(tps: float | None, ttft: float | None, best: dict | None) -> bool:
+    """Decide whether the current trial should replace `best`.
+
+    Throughput is the primary criterion; TTFT is the tiebreaker inside the
+    TPS_TIE_EPSILON band. None tps means "not measurable" -> never a new best.
+    """
+    if tps is None:
+        return False
+    if best is None:
+        return True
+    best_tps = best.get("tps") or 0.0
+    if best_tps <= 0:
+        return tps > 0
+    rel_gap = (tps - best_tps) / best_tps
+    if rel_gap > TPS_TIE_EPSILON:
+        return True
+    if abs(rel_gap) <= TPS_TIE_EPSILON:
+        # Effectively tied throughput; decide by TTFT (lower is better).
+        best_ttft = best.get("ttft")
+        if ttft is not None and (best_ttft is None or ttft < best_ttft):
+            return True
+    return False
 
 
 def _knob_tag(kv_bits: int | None, max_context_cap: int | None, max_batch: int | None) -> str:
@@ -684,6 +750,15 @@ def main() -> int:
         help="Comma-separated max-batch values (e.g. '1,2') to hill-climb over. "
              "Forwarded to `macprovider-cli serve --max-batch N`. Default is 1.",
     )
+    ap.add_argument(
+        "--replicates", type=int, default=1,
+        help="Number of requests to fire against EACH loaded candidate (default 1). "
+             "When >1 the cell's recorded tps/ttft are the MEDIAN across replicates and "
+             "the cell is feasible only if EVERY replicate is feasible. Use 3+ when "
+             "publishing a recipe — single-trial measurements can drift 10–15%% just "
+             "from background CPU/GPU contention. Provider is loaded once per cell and "
+             "reused across its replicates (no extra model-load cost).",
+    )
     ap.add_argument("--verbose", "-v", action="store_true")
     args = ap.parse_args()
 
@@ -737,7 +812,8 @@ def main() -> int:
     print("autotune: provider-side model hill-climb (keep/revert)")
     print(f"autotune: provider_bin={args.provider_bin}")
     print(f"autotune: port={args.port}  max_tokens={args.max_tokens}  "
-          f"ready_timeout={args.ready_timeout:.0f}s  gate_ttft={args.gate_ttft_ms:.0f}ms")
+          f"ready_timeout={args.ready_timeout:.0f}s  gate_ttft={args.gate_ttft_ms:.0f}ms  "
+          f"replicates={args.replicates}")
     print(f"autotune: models = {models}")
     print(f"autotune: contexts = {contexts}")
     if knobs_active:
@@ -815,16 +891,23 @@ def main() -> int:
                 kv_bits=kv_bits,
                 max_context_cap=max_context_cap,
                 max_batch=max_batch,
+                replicates=args.replicates,
             )
 
             fits = metrics["fits"]
             tps = metrics["agg_throughput_tps"]
 
             # --- keep / revert decision ---
+            # Tiebreak on TTFT when throughputs are within TPS_TIE_EPSILON
+            # (default 2% relative). Without this, two trials posting the same
+            # tok/s but different TTFT would let the EARLIER trial win even if
+            # the later one is operationally-better. Air5 showed this exactly:
+            # 1B kv=8 mb=1 (10.9 tps, 3.8s ttft) was kept over 1B kv=8 mb=2
+            # (10.9 tps, 3.0s ttft) — the kept config had the worse TTFT.
             kept = 0
             verdict = ""
             if fits and tps is not None:
-                if best is None or tps > best["tps"]:
+                if _is_new_best(tps, metrics["ttft_p95_ms"], best):
                     kept = 1
                     best = {
                         "model": model, "context": context, "tps": tps,
@@ -860,6 +943,7 @@ def main() -> int:
                 "kv_bits": kv_bits,
                 "max_context_cap": max_context_cap,
                 "max_batch": max_batch,
+                "replicates_n": args.replicates,
             }
             write_trial_row(conn, row)
 

--- a/beta/autotune.py
+++ b/beta/autotune.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+"""
+Provider-side model autotune — a REAL keep/revert hill-climb that discovers the
+optimal servable model for THIS Mac.
+
+This is NOT a static benchmark. It is a genuine optimization loop:
+
+    propose config  ->  measure metric  ->  keep-if-better  ->  log trial
+                                              |
+                                              +-> track best-so-far
+
+The only PROVIDER-SIDE serving knob the binary exposes today is MODEL CHOICE
+(size x quant). There are no KV-cache / batch / max-context flags yet (those are
+a separate future Swift change). So this loop hill-climbs over the MODEL
+dimension. The candidate space is the cross product of --models x --contexts;
+each (model, context) pair is one candidate config the loop proposes, evaluates,
+and keeps-or-reverts.
+
+How the keep/revert loop works
+------------------------------
+1. Enumerate candidates (model x context). Optionally shuffle is NOT used — the
+   order is deterministic so reruns are comparable.
+2. For each candidate:
+     a. Start the provider binary serving that model (one process, port 18080).
+     b. Wait for readiness (GET /v1/models succeeds), up to --ready-timeout.
+     c. Fire a fixed workload at the target context (concurrency=1,
+        max_tokens small) and measure agg throughput_tps + ttft_p95.
+     d. Feasibility gate: any request error / non-200 / load failure / OOM
+        => fits=0 (INFEASIBLE). A model that OOMs at a context is a VALID
+        recorded trial, not a tool failure.
+     e. STOP the provider (pkill) and wait for :18080 to free BEFORE the next
+        candidate. Never two providers at once.
+3. Maintain `best` = the FEASIBLE candidate with the highest throughput_tps.
+   - If this trial is feasible AND beats best  -> kept=1 (NEW BEST), best updated.
+   - Otherwise                                 -> kept=0 (reverted; best held).
+4. Persist one row per trial to the tune_trials table.
+5. At the end, declare the WINNER (best feasible model+context) and render a
+   self-contained HTML report mirroring sweep_report.py.
+
+Reuse (does NOT modify these):
+  - harness.fire_stream            : per-request SSE metrics (ttft, throughput).
+  - sweep.build_padded_prompt      : padded prompt at a target context.
+  - sweep.aggregate_cell           : same aggregation + feasibility shape.
+
+Usage
+-----
+    # Dry-run: print the candidate plan, serve nothing
+    python beta/autotune.py --dry-run
+
+    # First hill-climb on this Mac (default 3 models x 2 contexts)
+    python beta/autotune.py --contexts 2000,8000
+
+    # Custom model list
+    python beta/autotune.py --models mlx-community/Llama-3.2-1B-Instruct-4bit
+
+    # Render the report for the latest run
+    python beta/autotune.py --report-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+
+# Resolve beta/ on sys.path so we can import sibling modules.
+BETA_DIR = Path(__file__).resolve().parent
+if str(BETA_DIR) not in sys.path:
+    sys.path.insert(0, str(BETA_DIR))
+
+# Reuse the SSE parser (all Phase 1 quirk handling) and the padded-prompt builder
+# + the cell aggregator. We do NOT modify harness.py or sweep.py.
+from harness import fire_stream  # noqa: E402
+from sweep import build_padded_prompt, aggregate_cell  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Defaults — machine-agnostic. The only baked-in assumption is the default
+# candidate set; everything is overridable via flags.
+# ---------------------------------------------------------------------------
+
+# Provider binary that serves an MLX model + joins the coordinator pool. Joining
+# is a harmless side effect (it holds `ready`); we do not modify its config.
+DEFAULT_PROVIDER_BIN = str(Path.home() / "macprovider" / "macprovider-cli")
+DEFAULT_PORT = 18080
+
+# Default candidate models: all small 4-bit instruct models. 3B + Phi-3.5-mini
+# are already in the HF cache on most dev Macs; 1B downloads on first serve
+# (~0.7GB). Keep downloads minimal — only what the candidate set requires.
+DEFAULT_MODELS = [
+    "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "mlx-community/Llama-3.2-3B-Instruct-4bit",
+    "mlx-community/Phi-3.5-mini-instruct-4bit",
+]
+DEFAULT_CONTEXTS = [2000, 8000]
+DEFAULT_MAX_TOKENS = 48  # short decode: we measure SERVING (prefill), not generation
+DEFAULT_READY_TIMEOUT = 150  # seconds to wait for model load on a constrained Mac
+
+# Feasibility TTFT gate. Unlike the context sweep we are NOT trying to find a
+# latency ceiling here — we want fits to reflect "does this model serve at all at
+# this context", so the gate is generous. A request error / non-200 / OOM is the
+# real INFEASIBLE signal. Override with --gate-ttft-ms if you want a stricter SLA.
+DEFAULT_GATE_TTFT_MS = 60000.0
+
+TUNE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS tune_trials (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_utc TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    target_context INTEGER NOT NULL,
+    measured_prompt_tokens INTEGER,
+    max_tokens INTEGER NOT NULL,
+    agg_throughput_tps REAL,
+    ttft_p95_ms REAL,
+    fits INTEGER NOT NULL DEFAULT 0,
+    n_err INTEGER NOT NULL DEFAULT 0,
+    kept INTEGER NOT NULL DEFAULT 0,
+    notes TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_tune_trials_run_id ON tune_trials(run_id);
+CREATE INDEX IF NOT EXISTS idx_tune_trials_ts ON tune_trials(ts_utc);
+"""
+
+
+# ---------------------------------------------------------------------------
+# DB helpers — additive only. Never touches runs / adversarial_runs / sweep_runs.
+# ---------------------------------------------------------------------------
+
+def open_db(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(TUNE_SCHEMA)
+    conn.commit()
+    return conn
+
+
+def write_trial_row(conn: sqlite3.Connection, row: dict) -> None:
+    conn.execute(
+        """INSERT INTO tune_trials
+               (ts_utc, run_id, model, target_context, measured_prompt_tokens,
+                max_tokens, agg_throughput_tps, ttft_p95_ms, fits, n_err, kept, notes)
+           VALUES
+               (:ts_utc, :run_id, :model, :target_context, :measured_prompt_tokens,
+                :max_tokens, :agg_throughput_tps, :ttft_p95_ms, :fits, :n_err, :kept, :notes)""",
+        row,
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Provider lifecycle — start serving one model, wait until ready, stop cleanly.
+# Invariant: NEVER two providers at once. Always stop before the next candidate.
+# ---------------------------------------------------------------------------
+
+def port_is_listening(port: int) -> bool:
+    """True if something is accepting TCP on 127.0.0.1:<port>."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        return s.connect_ex(("127.0.0.1", port)) == 0
+
+
+def stop_provider(port: int, settle_s: float = 30.0) -> None:
+    """Kill any running provider and wait for the port to free.
+
+    Uses pkill on the serve command so we catch the binary even if our own
+    Popen handle is stale. Idempotent — safe to call when nothing is running.
+    """
+    subprocess.run(
+        ["pkill", "-f", "macprovider-cli serve"],
+        capture_output=True,
+        check=False,
+    )
+    deadline = time.monotonic() + settle_s
+    while time.monotonic() < deadline:
+        if not port_is_listening(port):
+            return
+        time.sleep(0.5)
+    # Escalate to SIGKILL if a process is wedged holding the port.
+    subprocess.run(
+        ["pkill", "-9", "-f", "macprovider-cli serve"],
+        capture_output=True,
+        check=False,
+    )
+    time.sleep(2.0)
+
+
+def start_provider(
+    provider_bin: str,
+    model: str,
+    port: int,
+    log_path: Path,
+) -> subprocess.Popen:
+    """Launch `macprovider-cli serve --model <model> --port <port>` in background.
+
+    stdout/stderr are teed to log_path so a load failure / OOM leaves evidence.
+    The process is started in its own session so we can signal the whole group.
+    """
+    log_fh = log_path.open("wb")
+    proc = subprocess.Popen(
+        [provider_bin, "serve", "--model", model, "--port", str(port)],
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    return proc
+
+
+def wait_for_ready(
+    base_url: str,
+    proc: subprocess.Popen,
+    timeout_s: float,
+) -> tuple[bool, str]:
+    """Poll GET /v1/models until 200, the process dies, or timeout.
+
+    Returns (ready, note). note carries the failure reason when not ready
+    (process exited / load error / timeout) so it can land in the trial row.
+    """
+    models_url = base_url.rstrip("/") + "/v1/models"
+    deadline = time.monotonic() + timeout_s
+    last_err = ""
+    while time.monotonic() < deadline:
+        # If the provider process already exited, the model failed to load
+        # (OOM, missing weights, bad id). That's an INFEASIBLE trial.
+        rc = proc.poll()
+        if rc is not None:
+            return False, f"provider exited rc={rc} during load (see log for cause)"
+        try:
+            r = requests.get(models_url, timeout=5)
+            if r.status_code == 200:
+                return True, "ready"
+            last_err = f"/v1/models -> HTTP {r.status_code}"
+        except requests.RequestException as e:
+            last_err = f"{type(e).__name__}"
+        time.sleep(2.0)
+    return False, f"ready timeout after {timeout_s:.0f}s (last: {last_err or 'no response'})"
+
+
+# ---------------------------------------------------------------------------
+# Evaluate one candidate config (model, context). Returns a metrics dict.
+# ---------------------------------------------------------------------------
+
+def evaluate_candidate(
+    provider_bin: str,
+    model: str,
+    context: int,
+    port: int,
+    max_tokens: int,
+    ready_timeout: float,
+    request_timeout: float,
+    gate_ttft_ms: float,
+    log_dir: Path,
+    verbose: bool,
+) -> dict[str, Any]:
+    """Start provider for `model`, fire a workload at `context`, stop provider.
+
+    Always stops the provider before returning (success or failure path), so the
+    caller can move straight to the next candidate. Returns:
+        fits, n_err, agg_throughput_tps, ttft_p95_ms, measured_prompt_tokens, notes
+    """
+    base_url = f"http://127.0.0.1:{port}"
+    chat_url = base_url + "/v1/chat/completions"
+    safe_model = model.replace("/", "_")
+    log_path = log_dir / f"provider-{safe_model}-ctx{context}.log"
+
+    # Defensive: ensure nothing is already bound before we start.
+    if port_is_listening(port):
+        stop_provider(port)
+
+    proc = start_provider(provider_bin, model, port, log_path)
+    try:
+        ready, note = wait_for_ready(base_url, proc, ready_timeout)
+        if not ready:
+            # Load failure / OOM / timeout => infeasible trial (valid record).
+            tail = _tail_log(log_path)
+            full_note = note + (f" | log: {tail}" if tail else "")
+            return {
+                "fits": 0,
+                "n_err": 1,
+                "agg_throughput_tps": None,
+                "ttft_p95_ms": None,
+                "measured_prompt_tokens": None,
+                "notes": full_note[:480],
+            }
+
+        # Provider is up. Fire one streamed request at the target context.
+        body = build_padded_prompt(context, max_tokens)
+        wall_t0 = time.monotonic()
+        result = fire_stream(chat_url, model, body, request_timeout)
+        wall_seconds = time.monotonic() - wall_t0
+
+        # Reuse sweep.aggregate_cell with a single-result "cell". It computes
+        # agg_throughput_tps (completion tokens / wall), ttft_p95, n_err, and a
+        # feasibility flag (n_err==0 AND ttft within gate AND no stop-token leak).
+        cell = {"wall_seconds": wall_seconds, "results": [result]}
+        agg = aggregate_cell(cell, gate_ttft_ms)
+
+        notes = None
+        if agg["n_err"]:
+            err = result.get("error") or f"HTTP {result.get('http_status')}"
+            notes = f"request error: {str(err)[:200]}"
+        elif not agg["feasible"]:
+            notes = f"missed gate: ttft_p95={agg['ttft_p95_ms']}ms > {gate_ttft_ms}ms"
+
+        return {
+            "fits": int(agg["feasible"]),
+            "n_err": agg["n_err"],
+            "agg_throughput_tps": agg["agg_throughput_tps"],
+            "ttft_p95_ms": agg["ttft_p95_ms"],
+            "measured_prompt_tokens": agg["measured_prompt_tokens"],
+            "notes": notes,
+        }
+    finally:
+        # INVARIANT: stop the provider before returning, always.
+        stop_provider(port)
+
+
+def _tail_log(log_path: Path, n_chars: int = 240) -> str:
+    """Pull the most informative line out of a provider launch log.
+
+    The binary prints its fatal reason on an `Error:` / `error` line (e.g.
+    "Offline mode error: Repository not available locally" for an
+    un-downloaded model, or an MLX OOM message) and then echoes its config
+    block. A naive last-N-chars tail would capture the config echo, not the
+    cause — so prefer the first error-ish line, falling back to the tail.
+    """
+    try:
+        text = log_path.read_text(errors="replace").strip()
+    except OSError:
+        return ""
+    for line in text.splitlines():
+        low = line.lower()
+        if "error" in low or "oom" in low or "out of memory" in low or "traceback" in low:
+            return " ".join(line.split())[:n_chars]
+    # No explicit error line — fall back to the tail.
+    return " ".join(text[-n_chars:].split())
+
+
+# ---------------------------------------------------------------------------
+# HTML report — mirrors sweep_report.py style (self-contained, Apple-system font).
+# ---------------------------------------------------------------------------
+
+CSS = """
+body {
+  font: 14px/1.45 -apple-system, system-ui, sans-serif;
+  margin: 2em;
+  max-width: 1100px;
+  color: #222;
+}
+h1 { font-size: 1.4em; margin-bottom: 0; }
+h2 { font-size: 1.1em; margin-top: 2em; border-bottom: 1px solid #ccc; padding-bottom: 0.2em; }
+.meta { color: #666; font-size: 0.9em; margin-top: 0.2em; }
+table { border-collapse: collapse; margin-top: 1em; width: 100%; }
+th, td {
+  border: 1px solid #ddd;
+  padding: 8px 12px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+th { background: #f6f6f6; font-weight: 600; }
+td.left, th.left { text-align: left; }
+.cell-ok { background: #d4edda; color: #155724; }
+.cell-fail { background: #f8d7da; color: #721c24; }
+.winner { background: #fff3cd; }
+.winner td { font-weight: 700; }
+.tps { font-weight: 700; }
+.summary { display: flex; gap: 2em; margin: 1em 0; flex-wrap: wrap; }
+.summary div { background: #f6f6f6; padding: 0.6em 1em; border-radius: 6px; }
+.summary .label { font-size: 0.8em; color: #666; text-transform: uppercase; letter-spacing: 0.05em; }
+.summary .value { font-size: 1.4em; font-weight: 600; }
+.muted { color: #888; }
+.legend { display: flex; gap: 1.5em; margin-top: 0.8em; font-size: 0.9em; align-items: center; }
+.swatch { width: 18px; height: 18px; display: inline-block; border-radius: 3px; vertical-align: middle; margin-right: 4px; }
+.swatch-ok { background: #d4edda; border: 1px solid #c3e6cb; }
+.swatch-fail { background: #f8d7da; border: 1px solid #f5c6cb; }
+.swatch-win { background: #fff3cd; border: 1px solid #ffeeba; }
+.kept-yes { color: #155724; font-weight: 700; }
+.kept-no { color: #888; }
+code { background: #f0f0f0; padding: 0 3px; border-radius: 3px; }
+"""
+
+
+def fmt_val(v: Any, digits: int = 1, suffix: str = "") -> str:
+    if v is None:
+        return "—"
+    if isinstance(v, float):
+        return f"{v:.{digits}f}{suffix}"
+    return f"{v}{suffix}"
+
+
+def render_report(rows: list[sqlite3.Row], run_id: str) -> str:
+    if not rows:
+        return f"<html><body><p>No trials for run_id={html.escape(run_id)}</p></body></html>"
+
+    ts_first = rows[0]["ts_utc"]
+    n_trials = len(rows)
+    feasible_rows = [r for r in rows if r["fits"]]
+    n_feasible = len(feasible_rows)
+    n_infeasible = n_trials - n_feasible
+
+    # Winner = feasible trial with highest tps (the final `best`).
+    winner = None
+    for r in feasible_rows:
+        if r["agg_throughput_tps"] is None:
+            continue
+        if winner is None or r["agg_throughput_tps"] > winner["agg_throughput_tps"]:
+            winner = r
+
+    p: list[str] = []
+    p.append(
+        f'<!doctype html><html><head><meta charset=utf-8>'
+        f'<title>Autotune — {html.escape(run_id[:8])}</title>'
+        f'<style>{CSS}</style></head><body>'
+    )
+    p.append('<h1>Provider Model Autotune &mdash; keep/revert hill-climb</h1>')
+    p.append(
+        f'<div class=meta>run_id: <code>{html.escape(run_id)}</code> &nbsp;|&nbsp; '
+        f'started: <code>{html.escape(ts_first)}</code> &nbsp;|&nbsp; '
+        f'metric: <strong>agg throughput (tok/s)</strong>, higher is better</div>'
+    )
+
+    # Summary bar
+    p.append('<div class=summary>')
+    p.append(f'<div><div class=label>Trials</div><div class=value>{n_trials}</div></div>')
+    p.append(f'<div><div class=label>Feasible</div><div class=value style="color:#155724">{n_feasible}</div></div>')
+    inf_color = '#721c24' if n_infeasible else '#155724'
+    p.append(f'<div><div class=label>Infeasible</div><div class=value style="color:{inf_color}">{n_infeasible}</div></div>')
+    if winner is not None:
+        p.append(
+            f'<div><div class=label>Winner</div>'
+            f'<div class=value style="color:#856404">'
+            f'{html.escape(winner["model"].split("/")[-1])} @ {winner["target_context"]:,}'
+            f'</div></div>'
+        )
+    p.append('</div>')
+
+    if winner is not None:
+        p.append(
+            f'<p>&#127942; <strong>WINNER:</strong> <code>{html.escape(winner["model"])}</code> '
+            f'at target context <strong>{winner["target_context"]:,}</strong> tokens &mdash; '
+            f'<strong>{fmt_val(winner["agg_throughput_tps"], 1, " tok/s")}</strong> '
+            f'(ttft {fmt_val(winner["ttft_p95_ms"], 0, " ms")}, '
+            f'measured prompt {winner["measured_prompt_tokens"] or "—"} tokens).</p>'
+        )
+    else:
+        p.append('<p><strong>No feasible config found.</strong> Every candidate '
+                 'errored / OOM&rsquo;d / missed the gate at the tested contexts.</p>')
+
+    p.append(
+        '<div class=legend>'
+        '<span><span class="swatch swatch-win"></span>Winner (best feasible tps)</span>'
+        '<span><span class="swatch swatch-ok"></span>Feasible (served, no error)</span>'
+        '<span><span class="swatch swatch-fail"></span>Infeasible (error / OOM / gate miss)</span>'
+        '</div>'
+    )
+
+    # Trial log with best-so-far progression. Recompute best-so-far in row order
+    # to show how the optimum evolved across the climb.
+    p.append('<h2>Trial log (best-so-far progression)</h2>')
+    p.append('<table><thead><tr>'
+             '<th class=left>#</th><th class=left>model</th><th>target ctx</th>'
+             '<th>prompt tok</th><th>tok/s</th><th>ttft (ms)</th>'
+             '<th>fits</th><th>n_err</th><th>kept</th><th>best-so-far tok/s</th>'
+             '</tr></thead><tbody>')
+    best_tps_so_far: float | None = None
+    best_label_so_far = "—"
+    for i, r in enumerate(rows, 1):
+        is_winner = winner is not None and r["id"] == winner["id"]
+        if r["fits"] and r["agg_throughput_tps"] is not None:
+            if best_tps_so_far is None or r["agg_throughput_tps"] > best_tps_so_far:
+                best_tps_so_far = r["agg_throughput_tps"]
+                best_label_so_far = f'{r["model"].split("/")[-1]} @ {r["target_context"]:,}'
+        row_cls = "winner" if is_winner else ("cell-ok" if r["fits"] else "cell-fail")
+        kept_cls = "kept-yes" if r["kept"] else "kept-no"
+        kept_txt = "NEW BEST" if r["kept"] else "reverted"
+        bsf = (
+            f'{fmt_val(best_tps_so_far, 1)} <span class=muted>({html.escape(best_label_so_far)})</span>'
+            if best_tps_so_far is not None else '—'
+        )
+        p.append(
+            f'<tr class={row_cls}>'
+            f'<td class=left>{i}</td>'
+            f'<td class=left><code>{html.escape(r["model"])}</code></td>'
+            f'<td>{r["target_context"]:,}</td>'
+            f'<td>{r["measured_prompt_tokens"] or "—"}</td>'
+            f'<td class=tps>{fmt_val(r["agg_throughput_tps"], 1)}</td>'
+            f'<td>{fmt_val(r["ttft_p95_ms"], 0)}</td>'
+            f'<td>{"yes" if r["fits"] else "no"}</td>'
+            f'<td>{r["n_err"]}</td>'
+            f'<td class={kept_cls}>{kept_txt}</td>'
+            f'<td>{bsf}</td>'
+            f'</tr>'
+        )
+    p.append('</tbody></table>')
+
+    # Notes column (failure reasons) for infeasible trials.
+    infeasible_with_notes = [r for r in rows if not r["fits"] and r["notes"]]
+    if infeasible_with_notes:
+        p.append('<h2>Infeasible trial notes</h2>')
+        p.append('<table><thead><tr><th class=left>model</th><th>ctx</th>'
+                 '<th class=left>reason</th></tr></thead><tbody>')
+        for r in infeasible_with_notes:
+            p.append(
+                f'<tr><td class=left><code>{html.escape(r["model"])}</code></td>'
+                f'<td>{r["target_context"]:,}</td>'
+                f'<td class=left>{html.escape(r["notes"] or "")}</td></tr>'
+            )
+        p.append('</tbody></table>')
+
+    p.append(
+        f'<p class=muted>Generated {datetime.now(timezone.utc).isoformat(timespec="seconds")} '
+        f'&middot; one provider served at a time &middot; concurrency 1 &middot; '
+        f'metric = completion tokens / wall seconds.</p>'
+    )
+    p.append('</body></html>')
+    return "".join(p)
+
+
+def fetch_trial_rows(conn: sqlite3.Connection, run_id: str) -> list[sqlite3.Row]:
+    cur = conn.cursor()
+    cur.row_factory = sqlite3.Row
+    cur.execute(
+        "SELECT * FROM tune_trials WHERE run_id = ? ORDER BY id",
+        (run_id,),
+    )
+    return cur.fetchall()
+
+
+def latest_run_id(conn: sqlite3.Connection) -> str | None:
+    cur = conn.execute("SELECT run_id FROM tune_trials ORDER BY ts_utc DESC, id DESC LIMIT 1")
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def write_report(conn: sqlite3.Connection, run_id: str, reports_dir: Path) -> Path:
+    rows = fetch_trial_rows(conn, run_id)
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    out_path = reports_dir / f"autotune-{run_id}.html"
+    out_path.write_text(render_report(rows, run_id))
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Main — the hill-climb driver.
+# ---------------------------------------------------------------------------
+
+def parse_str_list(s: str) -> list[str]:
+    return [x.strip() for x in s.split(",") if x.strip()]
+
+
+def parse_int_list(s: str) -> list[int]:
+    return [int(x.strip()) for x in s.split(",") if x.strip()]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Provider-side model autotune: keep/revert hill-climb over the model dimension.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    ap.add_argument(
+        "--models", default=None,
+        help="Comma-separated HF model IDs to consider as candidates. "
+             f"Default: the three small 4-bit instruct models "
+             f"({', '.join(m.split('/')[-1] for m in DEFAULT_MODELS)}).",
+    )
+    ap.add_argument(
+        "--contexts", default=None,
+        help="Comma-separated target context token sizes. Each (model, context) "
+             f"pair is one candidate. Default: {','.join(map(str, DEFAULT_CONTEXTS))}.",
+    )
+    ap.add_argument("--db-path", default=str(BETA_DIR / "runs.sqlite"),
+                    help="SQLite DB path (default: beta/runs.sqlite).")
+    ap.add_argument("--reports-dir", default=str(BETA_DIR / "reports"),
+                    help="Directory for the HTML report (default: beta/reports).")
+    ap.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS,
+                    help=f"Decode length per request (default: {DEFAULT_MAX_TOKENS}). "
+                         "Short on purpose — we measure serving (prefill), not generation.")
+    ap.add_argument("--ready-timeout", type=float, default=DEFAULT_READY_TIMEOUT,
+                    help=f"Seconds to wait for model load before declaring infeasible "
+                         f"(default: {DEFAULT_READY_TIMEOUT}).")
+    ap.add_argument("--gate-ttft-ms", type=float, default=DEFAULT_GATE_TTFT_MS,
+                    help=f"Max p95 TTFT (ms) for the feasibility gate (default: "
+                         f"{DEFAULT_GATE_TTFT_MS:.0f}). Generous by design — request "
+                         "errors / OOM are the real infeasible signal.")
+    ap.add_argument("--request-timeout", type=float, default=180.0,
+                    help="Per-request HTTP timeout in seconds (default: 180).")
+    ap.add_argument("--provider-bin", default=DEFAULT_PROVIDER_BIN,
+                    help=f"Path to macprovider-cli (default: {DEFAULT_PROVIDER_BIN}).")
+    ap.add_argument("--port", type=int, default=DEFAULT_PORT,
+                    help=f"Local port the provider binds (default: {DEFAULT_PORT}).")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Print the candidate plan and exit. Serves nothing.")
+    ap.add_argument("--report-only", action="store_true",
+                    help="Render the HTML report for the latest run_id and exit.")
+    ap.add_argument("--verbose", "-v", action="store_true")
+    args = ap.parse_args()
+
+    db_path = Path(args.db_path)
+    reports_dir = Path(args.reports_dir)
+
+    # --report-only short-circuit (no serving).
+    if args.report_only:
+        if not db_path.exists():
+            sys.exit(f"no db at {db_path}; run a tune first")
+        conn = open_db(db_path)
+        try:
+            run_id = latest_run_id(conn)
+            if not run_id:
+                sys.exit("no tune_trials in DB yet")
+            out_path = write_report(conn, run_id, reports_dir)
+            print(f"Report written: {out_path}")
+            return 0
+        finally:
+            conn.close()
+
+    models = parse_str_list(args.models) if args.models else list(DEFAULT_MODELS)
+    contexts = parse_int_list(args.contexts) if args.contexts else list(DEFAULT_CONTEXTS)
+
+    # Candidate config space = model x context, deterministic order.
+    candidates = [(m, c) for m in models for c in contexts]
+    n = len(candidates)
+
+    print("autotune: provider-side model hill-climb (keep/revert)")
+    print(f"autotune: provider_bin={args.provider_bin}")
+    print(f"autotune: port={args.port}  max_tokens={args.max_tokens}  "
+          f"ready_timeout={args.ready_timeout:.0f}s  gate_ttft={args.gate_ttft_ms:.0f}ms")
+    print(f"autotune: models = {models}")
+    print(f"autotune: contexts = {contexts}")
+    print(f"autotune: candidate space = {len(models)} models x {len(contexts)} contexts = {n} configs")
+    print()
+    print(f"{'#':>3}  {'model':<48}  {'target_ctx':>10}")
+    print("-" * 68)
+    for i, (m, c) in enumerate(candidates, 1):
+        print(f"{i:>3}  {m:<48}  {c:>10}")
+
+    if args.dry_run:
+        print()
+        print(f"[dry-run] would evaluate {n} candidate configs, one provider at a time. "
+              "Nothing served.")
+        return 0
+
+    if not Path(args.provider_bin).exists():
+        sys.exit(f"provider binary not found at {args.provider_bin} (pass --provider-bin)")
+
+    # Logs for each provider launch (load failures / OOM land here).
+    log_dir = BETA_DIR / ".cache" / "autotune-logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    run_id = str(uuid.uuid4())
+    print()
+    print(f"autotune: run_id={run_id}")
+    print(f"autotune: db={db_path}")
+    print()
+
+    conn = open_db(db_path)
+
+    # best = the feasible candidate with the highest throughput_tps so far.
+    best: dict[str, Any] | None = None
+
+    # Ensure no provider is running before we begin (clean slate).
+    stop_provider(args.port)
+
+    def _cleanup_and_exit(signum, frame):  # pragma: no cover - signal path
+        print("\nautotune: interrupted — stopping provider before exit.")
+        stop_provider(args.port)
+        conn.close()
+        sys.exit(130)
+
+    signal.signal(signal.SIGINT, _cleanup_and_exit)
+    signal.signal(signal.SIGTERM, _cleanup_and_exit)
+
+    try:
+        for i, (model, context) in enumerate(candidates, 1):
+            ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            print(f"[{i}/{n}] model={model.split('/')[-1]} ctx={context} ... ",
+                  end="", flush=True)
+
+            metrics = evaluate_candidate(
+                provider_bin=args.provider_bin,
+                model=model,
+                context=context,
+                port=args.port,
+                max_tokens=args.max_tokens,
+                ready_timeout=args.ready_timeout,
+                request_timeout=args.request_timeout,
+                gate_ttft_ms=args.gate_ttft_ms,
+                log_dir=log_dir,
+                verbose=args.verbose,
+            )
+
+            fits = metrics["fits"]
+            tps = metrics["agg_throughput_tps"]
+
+            # --- keep / revert decision ---
+            kept = 0
+            verdict = ""
+            if fits and tps is not None:
+                if best is None or tps > best["tps"]:
+                    kept = 1
+                    best = {"model": model, "context": context, "tps": tps,
+                            "ttft": metrics["ttft_p95_ms"]}
+                    verdict = "NEW BEST"
+                else:
+                    verdict = (f"kept best={best['model'].split('/')[-1]}@{best['context']} "
+                               f"({best['tps']:.1f} t/s)")
+            else:
+                # Infeasible (or feasible-but-no-tokens) => revert, best unchanged.
+                if best is not None:
+                    verdict = (f"INFEASIBLE -> kept best={best['model'].split('/')[-1]}"
+                               f"@{best['context']} ({best['tps']:.1f} t/s)")
+                else:
+                    verdict = "INFEASIBLE -> no best yet"
+
+            row = {
+                "ts_utc": ts,
+                "run_id": run_id,
+                "model": model,
+                "target_context": context,
+                "measured_prompt_tokens": metrics["measured_prompt_tokens"],
+                "max_tokens": args.max_tokens,
+                "agg_throughput_tps": tps,
+                "ttft_p95_ms": metrics["ttft_p95_ms"],
+                "fits": fits,
+                "n_err": metrics["n_err"],
+                "kept": kept,
+                "notes": metrics["notes"],
+            }
+            write_trial_row(conn, row)
+
+            tps_str = f"{tps:.1f}" if tps is not None else "—"
+            ttft_str = f"{metrics['ttft_p95_ms']:.0f}ms" if metrics["ttft_p95_ms"] is not None else "—"
+            tag = "{NEW BEST}" if kept else f"{{{verdict}}}"
+            print(f"-> tps={tps_str} ttft={ttft_str} fits={fits} {tag}")
+            if metrics["notes"] and not fits:
+                print(f"        note: {metrics['notes'][:160]}")
+
+        print()
+        # --- Declare the winner ---
+        if best is not None:
+            print("=" * 68)
+            print(f"WINNER: {best['model']} @ ctx={best['context']} "
+                  f"-> {best['tps']:.1f} tok/s (ttft {fmt_val(best['ttft'], 0)} ms)")
+            print("=" * 68)
+        else:
+            print("NO FEASIBLE CONFIG: every candidate errored / OOM'd / missed the gate.")
+
+        # --- Summary table of all trials with best-so-far progression ---
+        rows = fetch_trial_rows(conn, run_id)
+        print()
+        print("Trial log (best-so-far progression):")
+        print(f"{'#':>2}  {'model':<34}  {'ctx':>5}  {'tps':>7}  {'ttft_ms':>8}  "
+              f"{'fits':>4}  {'kept':>4}  {'best-so-far':>22}")
+        print("-" * 100)
+        bsf_tps: float | None = None
+        bsf_label = "—"
+        for i, r in enumerate(rows, 1):
+            if r["fits"] and r["agg_throughput_tps"] is not None:
+                if bsf_tps is None or r["agg_throughput_tps"] > bsf_tps:
+                    bsf_tps = r["agg_throughput_tps"]
+                    bsf_label = f"{r['model'].split('/')[-1][:14]}@{r['target_context']}"
+            tps_s = f"{r['agg_throughput_tps']:.1f}" if r["agg_throughput_tps"] is not None else "—"
+            ttft_s = f"{r['ttft_p95_ms']:.0f}" if r["ttft_p95_ms"] is not None else "—"
+            bsf_s = f"{bsf_tps:.1f} ({bsf_label})" if bsf_tps is not None else "—"
+            print(f"{i:>2}  {r['model'].split('/')[-1][:34]:<34}  {r['target_context']:>5}  "
+                  f"{tps_s:>7}  {ttft_s:>8}  {r['fits']:>4}  {r['kept']:>4}  {bsf_s:>22}")
+
+        # --- HTML report ---
+        out_path = write_report(conn, run_id, reports_dir)
+        print()
+        print(f"autotune: report written -> {out_path}")
+        print(f"autotune: run_id={run_id}")
+        return 0 if best is not None else 1
+
+    finally:
+        # INVARIANT: never leave a provider alive at the very end.
+        stop_provider(args.port)
+        conn.close()
+        # Final confirmation line.
+        still = port_is_listening(args.port)
+        print(f"autotune: provider stopped; :{args.port} listening={still}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/beta/autotune.py
+++ b/beta/autotune.py
@@ -125,11 +125,25 @@ CREATE TABLE IF NOT EXISTS tune_trials (
     fits INTEGER NOT NULL DEFAULT 0,
     n_err INTEGER NOT NULL DEFAULT 0,
     kept INTEGER NOT NULL DEFAULT 0,
-    notes TEXT
+    notes TEXT,
+    kv_bits INTEGER,
+    max_context_cap INTEGER,
+    max_batch INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_tune_trials_run_id ON tune_trials(run_id);
 CREATE INDEX IF NOT EXISTS idx_tune_trials_ts ON tune_trials(ts_utc);
 """
+
+# Columns added after the initial spike for the richer per-hardware-recipe
+# search (PR #105 exposed --kv-bits / --max-context / --max-batch as serve
+# flags). On an existing DB the CREATE TABLE IF NOT EXISTS above is a no-op,
+# so we additively ALTER each new column in; the try/except handles "duplicate
+# column" without needing SQLite 3.35+'s IF NOT EXISTS clause.
+_ADDITIVE_TUNE_COLUMNS = (
+    ("kv_bits", "INTEGER"),
+    ("max_context_cap", "INTEGER"),
+    ("max_batch", "INTEGER"),
+)
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +153,11 @@ CREATE INDEX IF NOT EXISTS idx_tune_trials_ts ON tune_trials(ts_utc);
 def open_db(db_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path)
     conn.executescript(TUNE_SCHEMA)
+    for col, sql_type in _ADDITIVE_TUNE_COLUMNS:
+        try:
+            conn.execute(f"ALTER TABLE tune_trials ADD COLUMN {col} {sql_type}")
+        except sqlite3.OperationalError:
+            pass  # already added on a prior run
     conn.commit()
     return conn
 
@@ -147,10 +166,12 @@ def write_trial_row(conn: sqlite3.Connection, row: dict) -> None:
     conn.execute(
         """INSERT INTO tune_trials
                (ts_utc, run_id, model, target_context, measured_prompt_tokens,
-                max_tokens, agg_throughput_tps, ttft_p95_ms, fits, n_err, kept, notes)
+                max_tokens, agg_throughput_tps, ttft_p95_ms, fits, n_err, kept, notes,
+                kv_bits, max_context_cap, max_batch)
            VALUES
                (:ts_utc, :run_id, :model, :target_context, :measured_prompt_tokens,
-                :max_tokens, :agg_throughput_tps, :ttft_p95_ms, :fits, :n_err, :kept, :notes)""",
+                :max_tokens, :agg_throughput_tps, :ttft_p95_ms, :fits, :n_err, :kept, :notes,
+                :kv_bits, :max_context_cap, :max_batch)""",
         row,
     )
     conn.commit()
@@ -200,15 +221,30 @@ def start_provider(
     model: str,
     port: int,
     log_path: Path,
+    kv_bits: int | None = None,
+    max_context_cap: int | None = None,
+    max_batch: int | None = None,
 ) -> subprocess.Popen:
     """Launch `macprovider-cli serve --model <model> --port <port>` in background.
 
     stdout/stderr are teed to log_path so a load failure / OOM leaves evidence.
     The process is started in its own session so we can signal the whole group.
+    Optional serving knobs (kv_bits, max_context_cap, max_batch) are passed to
+    the binary only when set, so older binaries without those flags still work
+    for the default search path.
     """
     log_fh = log_path.open("wb")
+    cmd = [provider_bin, "serve", "--model", model, "--port", str(port)]
+    # Optional serving knobs (PR #105). Each is appended only when set so an
+    # older binary still works for the default-flag path.
+    if kv_bits is not None:
+        cmd += ["--kv-bits", str(kv_bits)]
+    if max_context_cap is not None:
+        cmd += ["--max-context", str(max_context_cap)]
+    if max_batch is not None:
+        cmd += ["--max-batch", str(max_batch)]
     proc = subprocess.Popen(
-        [provider_bin, "serve", "--model", model, "--port", str(port)],
+        cmd,
         stdout=log_fh,
         stderr=subprocess.STDOUT,
         start_new_session=True,
@@ -261,8 +297,12 @@ def evaluate_candidate(
     gate_ttft_ms: float,
     log_dir: Path,
     verbose: bool,
+    kv_bits: int | None = None,
+    max_context_cap: int | None = None,
+    max_batch: int | None = None,
 ) -> dict[str, Any]:
-    """Start provider for `model`, fire a workload at `context`, stop provider.
+    """Start provider for `model` (with the optional serving knobs applied),
+    fire a workload at `context`, stop provider.
 
     Always stops the provider before returning (success or failure path), so the
     caller can move straight to the next candidate. Returns:
@@ -271,13 +311,17 @@ def evaluate_candidate(
     base_url = f"http://127.0.0.1:{port}"
     chat_url = base_url + "/v1/chat/completions"
     safe_model = model.replace("/", "_")
-    log_path = log_dir / f"provider-{safe_model}-ctx{context}.log"
+    knob_tag = _knob_tag(kv_bits, max_context_cap, max_batch)
+    log_path = log_dir / f"provider-{safe_model}-ctx{context}{knob_tag}.log"
 
     # Defensive: ensure nothing is already bound before we start.
     if port_is_listening(port):
         stop_provider(port)
 
-    proc = start_provider(provider_bin, model, port, log_path)
+    proc = start_provider(
+        provider_bin, model, port, log_path,
+        kv_bits=kv_bits, max_context_cap=max_context_cap, max_batch=max_batch,
+    )
     try:
         ready, note = wait_for_ready(base_url, proc, ready_timeout)
         if not ready:
@@ -323,6 +367,20 @@ def evaluate_candidate(
     finally:
         # INVARIANT: stop the provider before returning, always.
         stop_provider(port)
+
+
+def _knob_tag(kv_bits: int | None, max_context_cap: int | None, max_batch: int | None) -> str:
+    """Compact tag suffix for log filenames and printed trial lines when any
+    optional serving knob is set. Returns "" if all are None (preserves the
+    pre-PR-105 log filenames + line shape exactly)."""
+    parts = []
+    if kv_bits is not None:
+        parts.append(f"kv{kv_bits}")
+    if max_context_cap is not None:
+        parts.append(f"mx{max_context_cap}")
+    if max_batch is not None:
+        parts.append(f"mb{max_batch}")
+    return ("-" + "-".join(parts)) if parts else ""
 
 
 def _tail_log(log_path: Path, n_chars: int = 240) -> str:
@@ -603,6 +661,29 @@ def main() -> int:
                     help="Print the candidate plan and exit. Serves nothing.")
     ap.add_argument("--report-only", action="store_true",
                     help="Render the HTML report for the latest run_id and exit.")
+    # Optional serving-knob axes (require a macprovider-cli binary built from
+    # main with PR #105 — older binaries will fail load and the trial will be
+    # recorded as INFEASIBLE, which is correct behavior). Each axis defaults
+    # to a single null value so omitting all three preserves the original
+    # model x context candidate space exactly.
+    ap.add_argument(
+        "--kv-bits-options", default=None,
+        help="Comma-separated kv-bits values (e.g. '4,8') to hill-climb over. "
+             "Forwarded to `macprovider-cli serve --kv-bits N`. Omit to leave "
+             "KV-cache precision at the model default (single trial per axis).",
+    )
+    ap.add_argument(
+        "--max-context-options", default=None,
+        help="Comma-separated provider max-context caps (e.g. '4000,8000') to "
+             "hill-climb over. Forwarded to `macprovider-cli serve --max-context N`. "
+             "This is the SERVER-SIDE cap (bounds KV-cache size); distinct from "
+             "--contexts which is the per-request prompt size axis.",
+    )
+    ap.add_argument(
+        "--max-batch-options", default=None,
+        help="Comma-separated max-batch values (e.g. '1,2') to hill-climb over. "
+             "Forwarded to `macprovider-cli serve --max-batch N`. Default is 1.",
+    )
     ap.add_argument("--verbose", "-v", action="store_true")
     args = ap.parse_args()
 
@@ -626,10 +707,32 @@ def main() -> int:
 
     models = parse_str_list(args.models) if args.models else list(DEFAULT_MODELS)
     contexts = parse_int_list(args.contexts) if args.contexts else list(DEFAULT_CONTEXTS)
+    # Optional serving-knob axes — each defaults to [None] (single "unset"
+    # value, no flag passed), so omitting all three preserves the original
+    # model x context candidate space exactly.
+    kv_bits_axis: list[int | None] = (
+        parse_int_list(args.kv_bits_options) if args.kv_bits_options else [None]
+    )
+    max_context_axis: list[int | None] = (
+        parse_int_list(args.max_context_options) if args.max_context_options else [None]
+    )
+    max_batch_axis: list[int | None] = (
+        parse_int_list(args.max_batch_options) if args.max_batch_options else [None]
+    )
 
-    # Candidate config space = model x context, deterministic order.
-    candidates = [(m, c) for m in models for c in contexts]
+    # Candidate config space = model x context x kv_bits x max_context_cap x
+    # max_batch, deterministic order. When all optional axes are unset this
+    # collapses back to the original model x context shape (one row per pair).
+    candidates = [
+        (m, c, kv, mx, mb)
+        for m in models
+        for c in contexts
+        for kv in kv_bits_axis
+        for mx in max_context_axis
+        for mb in max_batch_axis
+    ]
     n = len(candidates)
+    knobs_active = any(a != [None] for a in (kv_bits_axis, max_context_axis, max_batch_axis))
 
     print("autotune: provider-side model hill-climb (keep/revert)")
     print(f"autotune: provider_bin={args.provider_bin}")
@@ -637,12 +740,23 @@ def main() -> int:
           f"ready_timeout={args.ready_timeout:.0f}s  gate_ttft={args.gate_ttft_ms:.0f}ms")
     print(f"autotune: models = {models}")
     print(f"autotune: contexts = {contexts}")
-    print(f"autotune: candidate space = {len(models)} models x {len(contexts)} contexts = {n} configs")
+    if knobs_active:
+        print(f"autotune: kv_bits axis = {kv_bits_axis}")
+        print(f"autotune: max_context axis = {max_context_axis}")
+        print(f"autotune: max_batch axis = {max_batch_axis}")
+    print(f"autotune: candidate space = {n} configs")
     print()
-    print(f"{'#':>3}  {'model':<48}  {'target_ctx':>10}")
-    print("-" * 68)
-    for i, (m, c) in enumerate(candidates, 1):
-        print(f"{i:>3}  {m:<48}  {c:>10}")
+    if knobs_active:
+        print(f"{'#':>3}  {'model':<48}  {'ctx':>5}  {'kv':>3}  {'maxctx':>6}  {'mb':>3}")
+        print("-" * 78)
+        for i, (m, c, kv, mx, mb) in enumerate(candidates, 1):
+            print(f"{i:>3}  {m:<48}  {c:>5}  {str(kv if kv is not None else '-'):>3}  "
+                  f"{str(mx if mx is not None else '-'):>6}  {str(mb if mb is not None else '-'):>3}")
+    else:
+        print(f"{'#':>3}  {'model':<48}  {'target_ctx':>10}")
+        print("-" * 68)
+        for i, (m, c, _kv, _mx, _mb) in enumerate(candidates, 1):
+            print(f"{i:>3}  {m:<48}  {c:>10}")
 
     if args.dry_run:
         print()
@@ -681,9 +795,10 @@ def main() -> int:
     signal.signal(signal.SIGTERM, _cleanup_and_exit)
 
     try:
-        for i, (model, context) in enumerate(candidates, 1):
+        for i, (model, context, kv_bits, max_context_cap, max_batch) in enumerate(candidates, 1):
             ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
-            print(f"[{i}/{n}] model={model.split('/')[-1]} ctx={context} ... ",
+            knob_str = _knob_tag(kv_bits, max_context_cap, max_batch)
+            print(f"[{i}/{n}] model={model.split('/')[-1]} ctx={context}{knob_str} ... ",
                   end="", flush=True)
 
             metrics = evaluate_candidate(
@@ -697,6 +812,9 @@ def main() -> int:
                 gate_ttft_ms=args.gate_ttft_ms,
                 log_dir=log_dir,
                 verbose=args.verbose,
+                kv_bits=kv_bits,
+                max_context_cap=max_context_cap,
+                max_batch=max_batch,
             )
 
             fits = metrics["fits"]
@@ -708,8 +826,12 @@ def main() -> int:
             if fits and tps is not None:
                 if best is None or tps > best["tps"]:
                     kept = 1
-                    best = {"model": model, "context": context, "tps": tps,
-                            "ttft": metrics["ttft_p95_ms"]}
+                    best = {
+                        "model": model, "context": context, "tps": tps,
+                        "ttft": metrics["ttft_p95_ms"],
+                        "kv_bits": kv_bits, "max_context_cap": max_context_cap,
+                        "max_batch": max_batch,
+                    }
                     verdict = "NEW BEST"
                 else:
                     verdict = (f"kept best={best['model'].split('/')[-1]}@{best['context']} "
@@ -735,6 +857,9 @@ def main() -> int:
                 "n_err": metrics["n_err"],
                 "kept": kept,
                 "notes": metrics["notes"],
+                "kv_bits": kv_bits,
+                "max_context_cap": max_context_cap,
+                "max_batch": max_batch,
             }
             write_trial_row(conn, row)
 
@@ -748,8 +873,11 @@ def main() -> int:
         print()
         # --- Declare the winner ---
         if best is not None:
+            knob_suffix = _knob_tag(
+                best.get("kv_bits"), best.get("max_context_cap"), best.get("max_batch")
+            )
             print("=" * 68)
-            print(f"WINNER: {best['model']} @ ctx={best['context']} "
+            print(f"WINNER: {best['model']} @ ctx={best['context']}{knob_suffix} "
                   f"-> {best['tps']:.1f} tok/s (ttft {fmt_val(best['ttft'], 0)} ms)")
             print("=" * 68)
         else:

--- a/beta/harness.py
+++ b/beta/harness.py
@@ -194,12 +194,12 @@ def strip_leaks_model(text: str, model_id: str) -> str:
     return regex.sub("", text or "")
 
 
-def fire_nonstream(url: str, model: str, body: dict, timeout: float) -> dict:
+def fire_nonstream(url: str, model: str, body: dict, timeout: float, headers: dict | None = None) -> dict:
     """POST a non-streaming request. Returns a metrics dict."""
     payload = {"model": model, "stream": False, **body}
     t0 = time.monotonic()
     try:
-        r = requests.post(url, json=payload, timeout=timeout)
+        r = requests.post(url, json=payload, timeout=timeout, headers=headers)
     except requests.RequestException as e:
         return {"error": f"{type(e).__name__}: {e}", "total_ms": (time.monotonic() - t0) * 1000}
     total_ms = (time.monotonic() - t0) * 1000
@@ -233,7 +233,7 @@ def fire_nonstream(url: str, model: str, body: dict, timeout: float) -> dict:
     return out
 
 
-def fire_stream(url: str, model: str, body: dict, timeout: float) -> dict:
+def fire_stream(url: str, model: str, body: dict, timeout: float, headers: dict | None = None) -> dict:
     """POST a streaming request, parse SSE. Returns a metrics dict with TTFT."""
     payload = {"model": model, **body, "stream": True}
     t0 = time.monotonic()
@@ -244,7 +244,7 @@ def fire_stream(url: str, model: str, body: dict, timeout: float) -> dict:
     error: str | None = None
 
     try:
-        with requests.post(url, json=payload, timeout=timeout, stream=True) as r:
+        with requests.post(url, json=payload, timeout=timeout, stream=True, headers=headers) as r:
             http_status = r.status_code
             if r.status_code != 200:
                 return {

--- a/beta/mock_llm_server.py
+++ b/beta/mock_llm_server.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Local mock LLM server for smoke-testing sweep.py.
+
+Serves /v1/chat/completions with fake SSE streaming. Does NOT forward to any
+remote host — safe to hammer repeatedly without network impact.
+
+Usage:
+    python beta/mock_llm_server.py [--port 18080] [--error-rate 0.0]
+
+--error-rate 0.25 causes 25% of requests to return HTTP 500, which exercises
+the sweep gate's "red path" (n_err > 0 -> feasible=0).
+
+The server echoes a short canned response and includes usage counts derived
+from the prompt length so TTFT/throughput metrics are populated realistically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import random
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+# Approximate tokens: 4 chars per token heuristic (good enough for smoke-tests)
+def _approx_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
+
+
+CANNED_REPLY = (
+    "The colony scouts returned with reports. The seasonal rhythm continues "
+    "as documented. Humidity levels are nominal in the fungus gardens."
+)
+
+
+class Handler(BaseHTTPRequestHandler):
+    error_rate: float = 0.0
+
+    def log_message(self, fmt, *args):
+        sys.stderr.write("[mock-llm] " + fmt % args + "\n")
+
+    def do_GET(self):
+        if self.path == "/v1/models":
+            body = json.dumps({
+                "object": "list",
+                "data": [{"id": "mlx-community/Llama-3.2-3B-Instruct-4bit", "object": "model"}],
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        if self.path != "/v1/chat/completions":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        try:
+            req = json.loads(self.rfile.read(length) or b"{}")
+        except json.JSONDecodeError:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        # Simulate errors at configured rate
+        if random.random() < self.error_rate:
+            body = b'{"error": "simulated server error"}'
+            self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        messages = req.get("messages", [])
+        prompt_text = " ".join(
+            m.get("content", "") for m in messages if isinstance(m.get("content"), str)
+        )
+        prompt_tokens = _approx_tokens(prompt_text)
+        max_tokens = req.get("max_tokens", 64)
+        # Reply tokens: min(max_tokens, len(canned reply) / 4)
+        completion_tokens = min(max_tokens, _approx_tokens(CANNED_REPLY))
+        model = req.get("model", "mlx-community/Llama-3.2-3B-Instruct-4bit")
+
+        is_stream = req.get("stream", False)
+
+        if is_stream:
+            self._respond_stream(model, prompt_tokens, completion_tokens, max_tokens)
+        else:
+            self._respond_nonstream(model, prompt_tokens, completion_tokens)
+
+    def _respond_stream(self, model: str, prompt_tokens: int, completion_tokens: int, max_tokens: int) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        # Do NOT set Transfer-Encoding: chunked — BaseHTTPRequestHandler is not a
+        # true chunked encoder; setting the header but not encoding the body causes
+        # InvalidChunkLength on the client side. SSE works fine without it.
+        self.end_headers()
+
+        # Emit a small TTFT delay to simulate real prefill
+        time.sleep(0.05)
+
+        words = CANNED_REPLY.split()
+        words_to_emit = words[:completion_tokens]
+
+        for i, word in enumerate(words_to_emit):
+            piece = word + (" " if i < len(words_to_emit) - 1 else "")
+            chunk = {
+                "id": "mock-1",
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [{"index": 0, "delta": {"content": piece}, "finish_reason": None}],
+            }
+            line = "data: " + json.dumps(chunk) + "\n\n"
+            try:
+                self.wfile.write(line.encode())
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                return
+
+        # Usage chunk (mlx_lm.server sends usage in the final chunk)
+        usage_chunk = {
+            "id": "mock-1",
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+        }
+        try:
+            self.wfile.write(("data: " + json.dumps(usage_chunk) + "\n\n").encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def _respond_nonstream(self, model: str, prompt_tokens: int, completion_tokens: int) -> None:
+        body = json.dumps({
+            "id": "mock-1",
+            "object": "chat.completion",
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": CANNED_REPLY},
+                "finish_reason": "stop",
+            }],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Local mock LLM server for sweep smoke-tests")
+    ap.add_argument("--port", type=int, default=18080)
+    ap.add_argument(
+        "--error-rate", type=float, default=0.0,
+        help="Fraction of requests that return HTTP 500 (0.0–1.0). Use >0 to exercise the red path.",
+    )
+    args = ap.parse_args()
+
+    Handler.error_rate = args.error_rate
+
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    print(f"[mock-llm] listening on http://127.0.0.1:{args.port}")
+    print(f"[mock-llm] error_rate={args.error_rate:.0%}")
+    print("[mock-llm] Ctrl+C to stop")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/beta/sweep.py
+++ b/beta/sweep.py
@@ -164,6 +164,7 @@ def run_cell(
     body: dict,
     concurrency: int,
     timeout_s: float,
+    headers: dict | None = None,
 ) -> dict[str, Any]:
     """Fire `concurrency` parallel streamed requests for one grid cell.
 
@@ -174,7 +175,7 @@ def run_cell(
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
         futures = [
-            pool.submit(fire_stream, url, model, body, timeout_s)
+            pool.submit(fire_stream, url, model, body, timeout_s, headers)
             for _ in range(concurrency)
         ]
         results = [f.result() for f in concurrent.futures.as_completed(futures)]
@@ -292,6 +293,12 @@ def main() -> int:
         help="If set, run an additional pass with this max_tokens value (e.g. 1024)",
     )
     ap.add_argument(
+        "--max-tokens", type=int, default=None,
+        help=f"Decode length (max_tokens) per request. Default {DEFAULT_MAX_TOKENS}. "
+             "Lower it (e.g. 48) for fast runs on slow/constrained nodes — the context "
+             "ceiling is driven by prefill, not decode length.",
+    )
+    ap.add_argument(
         "--contexts", default=None,
         help="Comma-separated context targets in tokens to override the default grid "
              "(e.g. '1000,2000,4000')",
@@ -313,23 +320,51 @@ def main() -> int:
              "that merely misses the TTFT gate (slow but no errors) does NOT stop the "
              "sweep — only real request failures do.",
     )
+    ap.add_argument(
+        "--model", default=None,
+        help="Override the model id sent in each request (default: the `model:` "
+             "from --config). On the coordinator/gateway path this also pins the "
+             "provider: only the provider serving this model can fulfill the request.",
+    )
+    ap.add_argument(
+        "--api-key", default=None,
+        help="Bearer key for the gateway path (e.g. mp_...). If omitted, falls back "
+             "to --api-key-file when that file exists. Leave unset for a direct local "
+             "provider endpoint (no auth).",
+    )
+    ap.add_argument(
+        "--api-key-file", default=str(Path.home() / ".config/macprovider/buyer-api-key"),
+        help="File to read the bearer key from when --api-key is not given. "
+             "Default: ~/.config/macprovider/buyer-api-key. Ignored if absent "
+             "(direct/local runs send no auth).",
+    )
     ap.add_argument("--verbose", "-v", action="store_true")
     args = ap.parse_args()
 
     cfg = load_config_relaxed(Path(args.config))
-    model = cfg.get("model", "mlx-community/Llama-3.2-3B-Instruct-4bit")
+    model = args.model or cfg.get("model", "mlx-community/Llama-3.2-3B-Instruct-4bit")
     timeout_s = float(cfg.get("timeout_s", 180))
     db_path = BETA_DIR / cfg.get("db_path", "runs.sqlite")
     reports_dir = BETA_DIR / cfg.get("reports_dir", "reports")
 
     url = args.base_url.rstrip("/") + "/v1/chat/completions"
 
+    # Resolve bearer auth: explicit --api-key wins, else read --api-key-file if it
+    # exists. No key -> headers=None -> direct/local provider path (Leg 1, no auth).
+    api_key = args.api_key
+    if not api_key:
+        key_path = Path(args.api_key_file)
+        if key_path.is_file():
+            api_key = key_path.read_text().strip()
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
+
     context_targets = parse_int_list(args.contexts) if args.contexts else DEFAULT_CONTEXT_TARGETS
     concurrencies = parse_int_list(args.concurrency) if args.concurrency else DEFAULT_CONCURRENCIES
 
     # Determine max_tokens passes
-    max_tokens_list = [DEFAULT_MAX_TOKENS]
-    if args.decode_control and args.decode_control != DEFAULT_MAX_TOKENS:
+    base_max_tokens = args.max_tokens or DEFAULT_MAX_TOKENS
+    max_tokens_list = [base_max_tokens]
+    if args.decode_control and args.decode_control != base_max_tokens:
         max_tokens_list.append(args.decode_control)
 
     # Build the full grid
@@ -344,6 +379,7 @@ def main() -> int:
 
     print(f"sweep: model={model}")
     print(f"sweep: endpoint={url}")
+    print(f"sweep: auth={'bearer ' + api_key[:6] + '…' if api_key else 'none (direct/local)'}")
     print(f"sweep: gate_ttft_ms={args.gate_ttft_ms}")
     print(f"sweep: grid = {len(context_targets)} contexts × {len(concurrencies)} concurrencies"
           f" × {len(max_tokens_list)} decode pass(es) = {n_cells} cells")
@@ -384,7 +420,7 @@ def main() -> int:
 
             print(f"[{i:>3}/{n_cells}] ctx={ctx:>6} conc={conc} max_tokens={mt} ... ", end="", flush=True)
 
-            cell_result = run_cell(url, model, body, conc, timeout_s)
+            cell_result = run_cell(url, model, body, conc, timeout_s, headers)
             agg = aggregate_cell(cell_result, args.gate_ttft_ms)
 
             row: dict[str, Any] = {

--- a/beta/sweep.py
+++ b/beta/sweep.py
@@ -305,6 +305,14 @@ def main() -> int:
         "--dry-run", action="store_true",
         help="Print the grid plan (cells, prompt sizes) without sending any requests",
     )
+    ap.add_argument(
+        "--stop-on-fail", action="store_true",
+        help="Abort the sweep as soon as a cell returns request errors (n_err > 0), "
+             "which on a memory-constrained node almost always means OOM. Protects a "
+             "collaborator's box from being re-slammed by every heavier cell. A cell "
+             "that merely misses the TTFT gate (slow but no errors) does NOT stop the "
+             "sweep — only real request failures do.",
+    )
     ap.add_argument("--verbose", "-v", action="store_true")
     args = ap.parse_args()
 
@@ -367,8 +375,10 @@ def main() -> int:
     conn = open_db(db_path)
 
     failures = 0
+    attempted = 0
     try:
         for i, (ctx, conc, mt) in enumerate(cells, 1):
+            attempted = i
             body = build_padded_prompt(ctx, mt)
             ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
@@ -406,11 +416,26 @@ def main() -> int:
             if not agg["feasible"]:
                 failures += 1
 
+            if args.stop_on_fail and agg["n_err"] > 0:
+                print()
+                print(
+                    f"sweep: --stop-on-fail tripped at cell {i}/{n_cells} "
+                    f"(ctx={ctx} conc={conc} max_tokens={mt}, n_err={agg['n_err']}). "
+                    f"Aborting before heavier cells re-slam the node."
+                )
+                print(
+                    f"sweep: {n_cells - i} cells skipped. Resume the remainder with "
+                    f"narrowed --contexts/--concurrency once the node has recovered."
+                )
+                break
+
     finally:
         conn.close()
 
     print()
-    print(f"sweep: done. {n_cells - failures}/{n_cells} cells feasible.")
+    skipped = n_cells - attempted
+    skip_note = f" ({skipped} skipped via --stop-on-fail)" if skipped > 0 else ""
+    print(f"sweep: done. {attempted - failures}/{attempted} attempted cells feasible{skip_note}.")
     print(f"sweep: sweep_id={sweep_id}")
     print(f"sweep: run `python beta/sweep_report.py --sweep-id {sweep_id}` to render the heatmap")
     return 0 if failures == 0 else 1

--- a/beta/sweep.py
+++ b/beta/sweep.py
@@ -201,11 +201,14 @@ def aggregate_cell(
     total_completion_tokens = 0
     prompt_tokens_list: list[int] = []
     any_leak = False
+    error_pairs: dict[tuple[Any, str], str] = {}
 
     for r in results:
         is_err = bool(r.get("error")) or (r.get("http_status") is not None and r["http_status"] != 200)
         if is_err:
             n_err += 1
+            err_str = r.get("error") or f"HTTP {r.get('http_status')}"
+            error_pairs.setdefault((r.get("http_status"), err_str[:80]), err_str)
         else:
             n_ok += 1
             if r.get("ttft_ms") is not None:
@@ -233,6 +236,12 @@ def aggregate_cell(
         int(statistics.median(prompt_tokens_list)) if prompt_tokens_list else None
     )
 
+    notes: str | None = None
+    if error_pairs:
+        notes = " | ".join(list(error_pairs.values())[:3])
+        if len(notes) > 200:
+            notes = notes[:197] + "..."
+
     feasible = (
         n_err == 0
         and (ttft_p95_ms is not None and ttft_p95_ms <= gate_ttft_ms)
@@ -246,6 +255,7 @@ def aggregate_cell(
         "ttft_p95_ms": ttft_p95_ms,
         "measured_prompt_tokens": measured_prompt_tokens,
         "feasible": int(feasible),
+        "notes": notes,
     }
 
 
@@ -436,7 +446,7 @@ def main() -> int:
                 "n_ok": agg["n_ok"],
                 "n_err": agg["n_err"],
                 "feasible": agg["feasible"],
-                "notes": None,
+                "notes": agg["notes"],
             }
             write_cell_row(conn, row)
 

--- a/beta/sweep.py
+++ b/beta/sweep.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""
+Context × concurrency throughput sweep for the MacProvider Phase 2 buyer harness.
+
+Runs a deterministic grid of (context_length, concurrency) cells against a local
+or remote LLM endpoint. Model is held FIXED (no weight reload between cells).
+
+DO NOT default to a remote host. Pass --base-url explicitly. The live M1 node
+(m1.streamvc.live) must NOT be targeted without human go-ahead.
+
+Usage:
+    # Dry-run: print grid plan without sending any requests
+    python beta/sweep.py --dry-run --base-url http://127.0.0.1:18080
+
+    # Small smoke sweep against local mock
+    python beta/sweep.py --base-url http://127.0.0.1:18080 --contexts 1000,2000 --concurrency 1,2
+
+    # Full sweep (28 cells) against local mock
+    python beta/sweep.py --base-url http://127.0.0.1:18080
+
+    # Full sweep with extended decode
+    python beta/sweep.py --base-url http://127.0.0.1:18080 --decode-control 1024
+
+    # Ready-for-live-fire (human must run after greenlighting with collaborator):
+    # python beta/sweep.py --base-url https://m1.streamvc.live --config beta/config-m1.yaml
+
+Results go to sweep_runs table in the configured db_path. Use sweep_report.py to render.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import statistics
+import sys
+import sqlite3
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Resolve beta/ on sys.path so we can import sibling modules
+BETA_DIR = Path(__file__).resolve().parent
+if str(BETA_DIR) not in sys.path:
+    sys.path.insert(0, str(BETA_DIR))
+
+# Import fire_stream directly from harness — reuses its SSE parser with all
+# Phase 1 quirk handling (keepalive comments, stop-token leak detection, etc.)
+from harness import fire_stream
+
+# _PROSE_BLOCK from workloads.py: ~2K tokens of realistic filler prose.
+from workloads import _PROSE_BLOCK
+
+DEFAULT_CONFIG = BETA_DIR / "config-m1.yaml"
+
+# Default grid knobs
+DEFAULT_CONTEXT_TARGETS = [1000, 2000, 4000, 8000, 16000, 24000, 32000]
+DEFAULT_CONCURRENCIES = [1, 2, 4, 8]
+DEFAULT_MAX_TOKENS = 256
+
+SWEEP_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sweep_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_utc TEXT NOT NULL,
+    sweep_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    context_target INTEGER NOT NULL,
+    measured_prompt_tokens INTEGER,
+    concurrency INTEGER NOT NULL,
+    max_tokens INTEGER NOT NULL,
+    agg_throughput_tps REAL,
+    ttft_p95_ms REAL,
+    n_ok INTEGER NOT NULL,
+    n_err INTEGER NOT NULL,
+    feasible INTEGER NOT NULL DEFAULT 0,
+    notes TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_sweep_runs_sweep_id ON sweep_runs(sweep_id);
+CREATE INDEX IF NOT EXISTS idx_sweep_runs_ts ON sweep_runs(ts_utc);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Prompt building
+# ---------------------------------------------------------------------------
+
+# Approximate chars per token for padding estimation (rough heuristic; real
+# prompt_tokens is recorded from usage in the response).
+_CHARS_PER_TOKEN = 4
+# Overhead for system/user message structure + question suffix (~50 tokens)
+_TEMPLATE_OVERHEAD_TOKENS = 50
+
+# Fixed question at end of every padded prompt
+_QUESTION_SUFFIX = "\n\nIn one sentence, what is the main theme of the passage above?"
+
+
+def build_padded_prompt(context_target_tokens: int, max_tokens: int) -> dict:
+    """Build a chat body with messages padded to approximately context_target_tokens.
+
+    The prompt is a user message containing repeated _PROSE_BLOCK text padded
+    to fill the target token budget, followed by a fixed question. stream=True
+    so we get TTFT via the SSE parser in harness.fire_stream.
+    """
+    # Tokens available for padding (subtract template overhead + decode budget)
+    pad_tokens = max(0, context_target_tokens - _TEMPLATE_OVERHEAD_TOKENS)
+    prose_len_tokens = len(_PROSE_BLOCK) // _CHARS_PER_TOKEN
+
+    if prose_len_tokens == 0:
+        context_text = "Hello."
+    else:
+        repeats = max(1, (pad_tokens + prose_len_tokens - 1) // prose_len_tokens)
+        context_text = (_PROSE_BLOCK.strip() + "\n\n") * repeats
+
+    content = context_text + _QUESTION_SUFFIX
+
+    return {
+        "messages": [
+            {"role": "user", "content": content},
+        ],
+        "max_tokens": max_tokens,
+        "stream": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def open_db(db_path: Path) -> sqlite3.Connection:
+    """Open (or create) the SQLite DB and ensure sweep_runs table exists.
+    Does NOT alter existing runs/adversarial_runs tables.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SWEEP_SCHEMA)
+    conn.commit()
+    return conn
+
+
+def write_cell_row(conn: sqlite3.Connection, row: dict) -> None:
+    conn.execute(
+        """INSERT INTO sweep_runs
+               (ts_utc, sweep_id, model, context_target, measured_prompt_tokens,
+                concurrency, max_tokens, agg_throughput_tps, ttft_p95_ms,
+                n_ok, n_err, feasible, notes)
+           VALUES
+               (:ts_utc, :sweep_id, :model, :context_target, :measured_prompt_tokens,
+                :concurrency, :max_tokens, :agg_throughput_tps, :ttft_p95_ms,
+                :n_ok, :n_err, :feasible, :notes)""",
+        row,
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Cell execution
+# ---------------------------------------------------------------------------
+
+def run_cell(
+    url: str,
+    model: str,
+    body: dict,
+    concurrency: int,
+    timeout_s: float,
+) -> dict[str, Any]:
+    """Fire `concurrency` parallel streamed requests for one grid cell.
+
+    Returns aggregated metrics:
+        wall_seconds, results (list of per-request dicts)
+    """
+    wall_t0 = time.monotonic()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [
+            pool.submit(fire_stream, url, model, body, timeout_s)
+            for _ in range(concurrency)
+        ]
+        results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+    wall_seconds = time.monotonic() - wall_t0
+    return {"wall_seconds": wall_seconds, "results": results}
+
+
+def aggregate_cell(
+    cell_result: dict[str, Any],
+    gate_ttft_ms: float,
+) -> dict[str, Any]:
+    """Compute cell-level aggregates and apply the feasibility gate.
+
+    feasible = (n_err == 0) AND (ttft_p95_ms <= gate_ttft_ms) AND (no stop_token_leak)
+    """
+    results = cell_result["results"]
+    wall_seconds = cell_result["wall_seconds"]
+
+    n_ok = 0
+    n_err = 0
+    ttft_values: list[float] = []
+    total_completion_tokens = 0
+    prompt_tokens_list: list[int] = []
+    any_leak = False
+
+    for r in results:
+        is_err = bool(r.get("error")) or (r.get("http_status") is not None and r["http_status"] != 200)
+        if is_err:
+            n_err += 1
+        else:
+            n_ok += 1
+            if r.get("ttft_ms") is not None:
+                ttft_values.append(r["ttft_ms"])
+            if r.get("completion_tokens"):
+                total_completion_tokens += r["completion_tokens"]
+            if r.get("prompt_tokens"):
+                prompt_tokens_list.append(r["prompt_tokens"])
+            if r.get("stop_token_leak"):
+                any_leak = True
+
+    # Aggregate throughput: total completion tokens / wall clock (not sum of per-request)
+    agg_throughput_tps = (
+        total_completion_tokens / wall_seconds if wall_seconds > 0 and total_completion_tokens > 0 else None
+    )
+
+    ttft_p95_ms: float | None = None
+    if ttft_values:
+        ttft_values_sorted = sorted(ttft_values)
+        p95_idx = max(0, int(len(ttft_values_sorted) * 0.95) - 1)
+        # For small N: p95 = max (conservative)
+        ttft_p95_ms = ttft_values_sorted[-1] if len(ttft_values_sorted) < 20 else ttft_values_sorted[p95_idx]
+
+    measured_prompt_tokens: int | None = (
+        int(statistics.median(prompt_tokens_list)) if prompt_tokens_list else None
+    )
+
+    feasible = (
+        n_err == 0
+        and (ttft_p95_ms is not None and ttft_p95_ms <= gate_ttft_ms)
+        and not any_leak
+    )
+
+    return {
+        "n_ok": n_ok,
+        "n_err": n_err,
+        "agg_throughput_tps": agg_throughput_tps,
+        "ttft_p95_ms": ttft_p95_ms,
+        "measured_prompt_tokens": measured_prompt_tokens,
+        "feasible": int(feasible),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Config loading (relaxed — does not call harness.load_config because that
+# sys.exit()s on localhost non-HTTPS URLs and CHANGE-ME values)
+# ---------------------------------------------------------------------------
+
+def load_config_relaxed(path: Path) -> dict:
+    with path.open() as f:
+        cfg = yaml.safe_load(f)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_int_list(s: str) -> list[int]:
+    return [int(x.strip()) for x in s.split(",") if x.strip()]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Context × concurrency throughput sweep (local/remote LLM endpoint)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    ap.add_argument(
+        "--base-url", required=True,
+        help="Base URL of the LLM endpoint (e.g. http://127.0.0.1:18080). "
+             "NEVER default to a remote host.",
+    )
+    ap.add_argument(
+        "--config", default=str(DEFAULT_CONFIG),
+        help="Config YAML (model, db_path, reports_dir, timeout_s). "
+             "Default: beta/config-m1.yaml",
+    )
+    ap.add_argument(
+        "--gate-ttft-ms", type=float, default=8000.0,
+        help="Max acceptable p95 TTFT in ms for feasibility gate (default: 8000)",
+    )
+    ap.add_argument(
+        "--decode-control", type=int, default=None,
+        help="If set, run an additional pass with this max_tokens value (e.g. 1024)",
+    )
+    ap.add_argument(
+        "--contexts", default=None,
+        help="Comma-separated context targets in tokens to override the default grid "
+             "(e.g. '1000,2000,4000')",
+    )
+    ap.add_argument(
+        "--concurrency", default=None,
+        help="Comma-separated concurrency levels to override the default grid "
+             "(e.g. '1,2')",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the grid plan (cells, prompt sizes) without sending any requests",
+    )
+    ap.add_argument("--verbose", "-v", action="store_true")
+    args = ap.parse_args()
+
+    cfg = load_config_relaxed(Path(args.config))
+    model = cfg.get("model", "mlx-community/Llama-3.2-3B-Instruct-4bit")
+    timeout_s = float(cfg.get("timeout_s", 180))
+    db_path = BETA_DIR / cfg.get("db_path", "runs.sqlite")
+    reports_dir = BETA_DIR / cfg.get("reports_dir", "reports")
+
+    url = args.base_url.rstrip("/") + "/v1/chat/completions"
+
+    context_targets = parse_int_list(args.contexts) if args.contexts else DEFAULT_CONTEXT_TARGETS
+    concurrencies = parse_int_list(args.concurrency) if args.concurrency else DEFAULT_CONCURRENCIES
+
+    # Determine max_tokens passes
+    max_tokens_list = [DEFAULT_MAX_TOKENS]
+    if args.decode_control and args.decode_control != DEFAULT_MAX_TOKENS:
+        max_tokens_list.append(args.decode_control)
+
+    # Build the full grid
+    cells = [
+        (ctx, conc, mt)
+        for mt in max_tokens_list
+        for ctx in context_targets
+        for conc in concurrencies
+    ]
+
+    n_cells = len(cells)
+
+    print(f"sweep: model={model}")
+    print(f"sweep: endpoint={url}")
+    print(f"sweep: gate_ttft_ms={args.gate_ttft_ms}")
+    print(f"sweep: grid = {len(context_targets)} contexts × {len(concurrencies)} concurrencies"
+          f" × {len(max_tokens_list)} decode pass(es) = {n_cells} cells")
+    print(f"sweep: contexts={context_targets}")
+    print(f"sweep: concurrencies={concurrencies}")
+    print(f"sweep: max_tokens={max_tokens_list}")
+    print()
+    print(f"{'#':>3}  {'context':>8}  {'conc':>4}  {'max_tok':>7}  {'est_chars':>10}")
+    print("-" * 42)
+    for i, (ctx, conc, mt) in enumerate(cells, 1):
+        # Estimate padded content length (for planning only)
+        pad_tokens = max(0, ctx - _TEMPLATE_OVERHEAD_TOKENS)
+        prose_token_len = len(_PROSE_BLOCK) // _CHARS_PER_TOKEN
+        repeats = max(1, (pad_tokens + prose_token_len - 1) // prose_token_len) if prose_token_len else 1
+        est_chars = repeats * len(_PROSE_BLOCK) + len(_QUESTION_SUFFIX)
+        print(f"{i:>3}  {ctx:>8}  {conc:>4}  {mt:>7}  {est_chars:>10}")
+
+    if args.dry_run:
+        print()
+        print(f"[dry-run] would send {n_cells} cells × concurrency requests each. No HTTP sent.")
+        return 0
+
+    sweep_id = str(uuid.uuid4())
+    print()
+    print(f"sweep: sweep_id={sweep_id}")
+    print(f"sweep: db={db_path}")
+    print()
+
+    conn = open_db(db_path)
+
+    failures = 0
+    try:
+        for i, (ctx, conc, mt) in enumerate(cells, 1):
+            body = build_padded_prompt(ctx, mt)
+            ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+            print(f"[{i:>3}/{n_cells}] ctx={ctx:>6} conc={conc} max_tokens={mt} ... ", end="", flush=True)
+
+            cell_result = run_cell(url, model, body, conc, timeout_s)
+            agg = aggregate_cell(cell_result, args.gate_ttft_ms)
+
+            row: dict[str, Any] = {
+                "ts_utc": ts,
+                "sweep_id": sweep_id,
+                "model": model,
+                "context_target": ctx,
+                "measured_prompt_tokens": agg["measured_prompt_tokens"],
+                "concurrency": conc,
+                "max_tokens": mt,
+                "agg_throughput_tps": agg["agg_throughput_tps"],
+                "ttft_p95_ms": agg["ttft_p95_ms"],
+                "n_ok": agg["n_ok"],
+                "n_err": agg["n_err"],
+                "feasible": agg["feasible"],
+                "notes": None,
+            }
+            write_cell_row(conn, row)
+
+            feasible_str = "OK" if agg["feasible"] else "FAIL"
+            tps_str = f"{agg['agg_throughput_tps']:.1f}" if agg["agg_throughput_tps"] is not None else "—"
+            ttft_str = f"{agg['ttft_p95_ms']:.0f}ms" if agg["ttft_p95_ms"] is not None else "—"
+            print(
+                f"{feasible_str}  ok={agg['n_ok']} err={agg['n_err']} "
+                f"tps={tps_str} ttft_p95={ttft_str} "
+                f"prompt_tok={agg['measured_prompt_tokens'] or '—'}"
+            )
+
+            if not agg["feasible"]:
+                failures += 1
+
+    finally:
+        conn.close()
+
+    print()
+    print(f"sweep: done. {n_cells - failures}/{n_cells} cells feasible.")
+    print(f"sweep: sweep_id={sweep_id}")
+    print(f"sweep: run `python beta/sweep_report.py --sweep-id {sweep_id}` to render the heatmap")
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/beta/sweep_report.py
+++ b/beta/sweep_report.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Context × concurrency sweep heatmap report.
+
+Reads sweep_runs for a given sweep_id (or the latest sweep) and renders a
+single-file self-contained HTML heatmap. Matches report.py style.
+
+Rows: concurrency level
+Cols: context target (tokens)
+Each cell: green (feasible) / red (failed), showing agg_throughput_tps and ttft_p95_ms.
+
+Usage:
+    python beta/sweep_report.py                        # latest sweep_id
+    python beta/sweep_report.py --sweep-id <uuid>      # specific sweep
+    python beta/sweep_report.py --config beta/config-m1.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+BETA_DIR = Path(__file__).resolve().parent
+DEFAULT_CONFIG = BETA_DIR / "config-m1.yaml"
+
+
+def load_config(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+def fetch_sweep_rows(conn: sqlite3.Connection, sweep_id: str) -> list[sqlite3.Row]:
+    cur = conn.cursor()
+    cur.row_factory = sqlite3.Row
+    cur.execute(
+        "SELECT * FROM sweep_runs WHERE sweep_id = ? ORDER BY context_target, concurrency",
+        (sweep_id,),
+    )
+    return cur.fetchall()
+
+
+def latest_sweep_id(conn: sqlite3.Connection) -> str | None:
+    cur = conn.execute(
+        "SELECT sweep_id FROM sweep_runs ORDER BY ts_utc DESC LIMIT 1"
+    )
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def fmt_val(v: Any, digits: int = 1, suffix: str = "") -> str:
+    if v is None:
+        return "—"
+    if isinstance(v, float):
+        return f"{v:.{digits}f}{suffix}"
+    return f"{v}{suffix}"
+
+
+CSS = """
+body {
+  font: 14px/1.45 -apple-system, system-ui, sans-serif;
+  margin: 2em;
+  max-width: 1100px;
+  color: #222;
+}
+h1 { font-size: 1.4em; margin-bottom: 0; }
+h2 { font-size: 1.1em; margin-top: 2em; border-bottom: 1px solid #ccc; padding-bottom: 0.2em; }
+.meta { color: #666; font-size: 0.9em; margin-top: 0.2em; }
+table { border-collapse: collapse; margin-top: 1em; }
+th, td {
+  border: 1px solid #ddd;
+  padding: 8px 12px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  min-width: 90px;
+}
+th { background: #f6f6f6; font-weight: 600; }
+th.row-header { text-align: left; min-width: 110px; }
+td.row-header { text-align: left; font-weight: 600; background: #f6f6f6; }
+.cell-ok {
+  background: #d4edda;
+  color: #155724;
+}
+.cell-fail {
+  background: #f8d7da;
+  color: #721c24;
+}
+.cell-empty {
+  background: #f9f9f9;
+  color: #aaa;
+}
+.tps { font-size: 1.1em; font-weight: 700; }
+.ttft { font-size: 0.85em; color: inherit; opacity: 0.85; }
+.summary { display: flex; gap: 2em; margin: 1em 0; }
+.summary div { background: #f6f6f6; padding: 0.6em 1em; border-radius: 6px; }
+.summary .label { font-size: 0.8em; color: #666; text-transform: uppercase; letter-spacing: 0.05em; }
+.summary .value { font-size: 1.4em; font-weight: 600; }
+.muted { color: #888; }
+.legend { display: flex; gap: 1.5em; margin-top: 0.8em; font-size: 0.9em; align-items: center; }
+.swatch { width: 18px; height: 18px; display: inline-block; border-radius: 3px; vertical-align: middle; margin-right: 4px; }
+.swatch-ok { background: #d4edda; border: 1px solid #c3e6cb; }
+.swatch-fail { background: #f8d7da; border: 1px solid #f5c6cb; }
+.raw-table table { font-size: 12px; }
+.raw-table th, .raw-table td { padding: 4px 8px; min-width: 60px; }
+"""
+
+
+def render(rows: list[sqlite3.Row], sweep_id: str) -> str:
+    if not rows:
+        return f"<html><body><p>No data for sweep_id={html.escape(sweep_id)}</p></body></html>"
+
+    model = rows[0]["model"]
+    ts_first = rows[0]["ts_utc"]
+    n_cells = len(rows)
+    n_feasible = sum(1 for r in rows if r["feasible"])
+    n_fail = n_cells - n_feasible
+
+    context_targets = sorted(set(r["context_target"] for r in rows))
+    concurrencies = sorted(set(r["concurrency"] for r in rows))
+    max_tokens_vals = sorted(set(r["max_tokens"] for r in rows))
+
+    # Index rows: (context_target, concurrency, max_tokens) -> row
+    cell_map: dict[tuple, sqlite3.Row] = {}
+    for r in rows:
+        cell_map[(r["context_target"], r["concurrency"], r["max_tokens"])] = r
+
+    parts: list[str] = []
+    parts.append(
+        f'<!doctype html><html><head><meta charset=utf-8>'
+        f'<title>Sweep — {html.escape(sweep_id[:8])}</title>'
+        f'<style>{CSS}</style></head><body>'
+    )
+    parts.append(f'<h1>Context &times; Concurrency Throughput Sweep</h1>')
+    parts.append(
+        f'<div class=meta>sweep_id: <code>{html.escape(sweep_id)}</code> &nbsp;|&nbsp; '
+        f'model: <code>{html.escape(model)}</code> &nbsp;|&nbsp; '
+        f'started: <code>{html.escape(ts_first)}</code></div>'
+    )
+
+    # Summary bar
+    parts.append('<div class=summary>')
+    parts.append(f'<div><div class=label>Total cells</div><div class=value>{n_cells}</div></div>')
+    parts.append(f'<div><div class=label>Feasible</div><div class=value style="color:#155724">{n_feasible}</div></div>')
+    fail_color = '#721c24' if n_fail else '#155724'
+    parts.append(f'<div><div class=label>Failed</div><div class=value style="color:{fail_color}">{n_fail}</div></div>')
+    parts.append('</div>')
+
+    # Legend
+    parts.append(
+        '<div class=legend>'
+        '<span><span class="swatch swatch-ok"></span>Feasible: n_err=0, ttft_p95 within gate, no stop-token leak</span>'
+        '<span><span class="swatch swatch-fail"></span>Failed: at least one gate condition missed</span>'
+        '</div>'
+    )
+
+    # One heatmap per max_tokens pass
+    for mt in max_tokens_vals:
+        parts.append(f'<h2>Heatmap &mdash; max_tokens={mt}</h2>')
+        parts.append('<p class=meta>Rows: concurrency &nbsp;|&nbsp; Cols: context target (tokens) '
+                     '&nbsp;|&nbsp; Cell: <strong>tok/s (aggregate)</strong> / ttft_p95</p>')
+        parts.append('<table>')
+
+        # Header row
+        parts.append('<thead><tr>')
+        parts.append('<th class=row-header>Concurrency \\ Context</th>')
+        for ctx in context_targets:
+            parts.append(f'<th>{ctx:,}</th>')
+        parts.append('</tr></thead>')
+
+        parts.append('<tbody>')
+        for conc in concurrencies:
+            parts.append('<tr>')
+            parts.append(f'<td class=row-header>conc={conc}</td>')
+            for ctx in context_targets:
+                cell = cell_map.get((ctx, conc, mt))
+                if cell is None:
+                    parts.append('<td class=cell-empty>—</td>')
+                    continue
+                feasible = bool(cell["feasible"])
+                cls = "cell-ok" if feasible else "cell-fail"
+                tps_str = fmt_val(cell["agg_throughput_tps"], 1, " t/s")
+                ttft_str = fmt_val(cell["ttft_p95_ms"], 0, " ms")
+                ok_err = f'<div class=ttft>ok={cell["n_ok"]} err={cell["n_err"]}</div>'
+                parts.append(
+                    f'<td class={cls}>'
+                    f'<div class=tps>{html.escape(tps_str)}</div>'
+                    f'<div class=ttft>ttft_p95: {html.escape(ttft_str)}</div>'
+                    f'{ok_err}'
+                    f'</td>'
+                )
+            parts.append('</tr>')
+        parts.append('</tbody></table>')
+
+    # Raw data table
+    parts.append('<h2>Raw sweep_runs rows</h2>')
+    parts.append('<div class=raw-table>')
+    parts.append(
+        '<table><thead><tr>'
+        '<th>context_target</th><th>concurrency</th><th>max_tokens</th>'
+        '<th>prompt_tok</th><th>agg_tps</th><th>ttft_p95_ms</th>'
+        '<th>n_ok</th><th>n_err</th><th>feasible</th><th>ts_utc</th>'
+        '</tr></thead><tbody>'
+    )
+    for r in rows:
+        feasible_str = '<span style="color:#155724">yes</span>' if r["feasible"] else '<span style="color:#721c24">no</span>'
+        parts.append(
+            f'<tr>'
+            f'<td>{r["context_target"]:,}</td>'
+            f'<td>{r["concurrency"]}</td>'
+            f'<td>{r["max_tokens"]}</td>'
+            f'<td>{r["measured_prompt_tokens"] or "—"}</td>'
+            f'<td>{fmt_val(r["agg_throughput_tps"], 1)}</td>'
+            f'<td>{fmt_val(r["ttft_p95_ms"], 0)}</td>'
+            f'<td>{r["n_ok"]}</td>'
+            f'<td>{r["n_err"]}</td>'
+            f'<td>{feasible_str}</td>'
+            f'<td style="font-size:11px">{html.escape(r["ts_utc"])}</td>'
+            f'</tr>'
+        )
+    parts.append('</tbody></table></div>')
+
+    parts.append(
+        f'<p class=muted>Generated {datetime.now(timezone.utc).isoformat(timespec="seconds")}</p>'
+    )
+    parts.append('</body></html>')
+    return "".join(parts)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Render HTML heatmap from sweep_runs table")
+    ap.add_argument("--config", default=str(DEFAULT_CONFIG))
+    ap.add_argument("--sweep-id", default=None, help="Sweep ID to report on (default: latest)")
+    ap.add_argument("--list", action="store_true", help="List all sweep_ids in the DB and exit")
+    args = ap.parse_args()
+
+    cfg = load_config(Path(args.config))
+    db_path = BETA_DIR / cfg.get("db_path", "runs.sqlite")
+
+    if not db_path.exists():
+        sys.exit(f"no db at {db_path}; run sweep.py first")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        # Ensure sweep_runs table exists (idempotent)
+        conn.executescript(
+            "CREATE TABLE IF NOT EXISTS sweep_runs ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, ts_utc TEXT NOT NULL, sweep_id TEXT NOT NULL,"
+            "model TEXT NOT NULL, context_target INTEGER NOT NULL, measured_prompt_tokens INTEGER,"
+            "concurrency INTEGER NOT NULL, max_tokens INTEGER NOT NULL,"
+            "agg_throughput_tps REAL, ttft_p95_ms REAL, n_ok INTEGER NOT NULL,"
+            "n_err INTEGER NOT NULL, feasible INTEGER NOT NULL DEFAULT 0, notes TEXT);"
+        )
+
+        if args.list:
+            cur = conn.execute(
+                "SELECT sweep_id, COUNT(*) as n, MIN(ts_utc) as started "
+                "FROM sweep_runs GROUP BY sweep_id ORDER BY started DESC"
+            )
+            rows = cur.fetchall()
+            if not rows:
+                print("No sweep runs in DB.")
+                return 0
+            for r in rows:
+                print(f"{r[0]}  n={r[1]}  started={r[2]}")
+            return 0
+
+        sweep_id = args.sweep_id or latest_sweep_id(conn)
+        if not sweep_id:
+            sys.exit("No sweep_runs in DB. Run sweep.py first.")
+
+        rows = fetch_sweep_rows(conn, sweep_id)
+        if not rows:
+            sys.exit(f"No rows for sweep_id={sweep_id}")
+
+        out_dir = BETA_DIR / cfg.get("reports_dir", "reports")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"sweep-{sweep_id[:8]}.html"
+        out_path.write_text(render(rows, sweep_id))
+        print(f"Report written: {out_path}")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What
First real **autoresearch** loop for MacProvider: a keep/revert hill-climb over the model dimension (size × quant) that discovers the optimal servable model for a given Mac.

Not a benchmark — a genuine optimization loop: propose config → load via `macprovider-cli serve --model X` → measure tok/s + TTFT at a target context → fit gate (errors / OOM / TTFT > 60s ⇒ infeasible) → keep best feasible → log every trial → declare winner.

## First hill-climb (8GB M1 Air)
| # | model | ctx | tps | ttft_ms | fits | kept |
|---|-------|-----|-----|---------|------|------|
| 1 | Llama-3.2-1B-4bit | 2000 | 9.7 | 2380 | ✅ | **NEW BEST** |
| 2 | Llama-3.2-1B-4bit | 8000 | 2.4 | 11268 | ✅ | — |
| 3 | Llama-3.2-3B-4bit | 2000 | 3.1 | 9960 | ✅ | — |
| 4 | Llama-3.2-3B-4bit | 8000 | 0.4 | 94604 | ❌ infeasible | — |
| 5 | Phi-3.5-mini-4bit | 2000 | 0.5 | 83662 | ❌ infeasible | — |
| 6 | Phi-3.5-mini-4bit | 8000 | — | — | ❌ infeasible | — |

**Winner on 8GB:** `Llama-3.2-1B-Instruct-4bit @ ctx=2000 → 9.7 tok/s`. Fit gate rejected 3/6 candidates as expected.

## Files
- `beta/autotune.py` — the loop CLI. Reuses `harness.fire_stream` + `sweep.build_padded_prompt`/`aggregate_cell` unchanged.
- New additive `tune_trials` SQLite table (existing tables untouched).
- HTML report at `beta/reports/autotune-<run_id>.html`.

## Status
Spike / draft — designed to be machine-agnostic so the next run can target a roomier Mac (air5: Qwen-Coder-7B @ 50k context) where the real per-hardware recipe surfaces. Knob exposure (KV-bits / batch / max-context as `serve` flags in the Swift binary) is the natural follow-up to widen the search space beyond model choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)