### PR TITLE
fix(ws): re-arm write deadline on reactive control replies

### DIFF
--- a/phase4-coordinator/internal/ws/relay_writedeadline_test.go
+++ b/phase4-coordinator/internal/ws/relay_writedeadline_test.go
@@ -1,0 +1,122 @@
+package ws
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	gobwas "github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+	"github.com/rs/zerolog"
+)
+
+// TestProviderControlPongSurvivesStaleWriteDeadline is a regression test for the
+// idle-provider disconnect bug.
+//
+// runWriter (relay.go) sets an absolute write deadline only at the top of each
+// writeCh send, and socket write deadlines are never cleared after a successful
+// write. Once a provider goes idle (no server-initiated writes), that deadline
+// silently lapses. The next keepalive PING the provider sends drives gobwas's
+// HandlePing to write a PONG reply synchronously from the read goroutine
+// (readClientData) directly to the conn — inheriting the stale, already-expired
+// deadline. Pre-fix, that PONG write fails instantly with `i/o timeout`, which
+// readProviderLoop surfaces as a read failure and tears the session down,
+// disconnecting an otherwise healthy provider.
+//
+// The fix routes reactive control replies through deadlineRefreshingWriter so
+// every PONG/Close write re-arms the deadline first. This test lets the writer's
+// deadline lapse with no server-initiated write, then sends a client PING and
+// asserts the session survives (PONG returns, no read-loop teardown).
+func TestProviderControlPongSurvivesStaleWriteDeadline(t *testing.T) {
+	serverConn, providerConn := net.Pipe()
+	defer serverConn.Close()
+	defer providerConn.Close()
+
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	}
+	registry.Register(provider, serverConn)
+	s := NewServer(config.Default(), registry, zerolog.Nop())
+
+	// Short writer deadline so a single real server send leaves behind a deadline
+	// that lapses within the test rather than after the 10s default WriteTimeoutS.
+	// The fix's refresh still uses config WriteTimeoutS (10s), so re-armed writes
+	// have ample headroom.
+	const writeLimit = 50 * time.Millisecond
+	session := newProviderSession("p1", "s1", serverConn, 8, writeLimit)
+	s.sessions.Store(sessionKey("p1", "s1"), session)
+	go session.runWriter()
+
+	done := make(chan struct{})
+	go func() {
+		s.readProviderLoop(serverConn, "p1", "s1")
+		close(done)
+	}()
+
+	// 1) Drive a real server-initiated write through runWriter. This is the only
+	//    place the provider conn's write deadline is set, exactly as in prod.
+	if err := session.send([]byte("warmup")); err != nil {
+		t.Fatalf("seed server write: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read seeded server frame: %v", err)
+	}
+
+	// 2) Let the write deadline lapse with no further server-initiated write —
+	//    the idle gap an unused provider sits in between keepalives.
+	time.Sleep(4 * writeLimit)
+
+	// 3) A keepalive PING now would, pre-fix, make the reactive PONG inherit the
+	//    expired deadline and fail. Post-fix the deadline is re-armed, the client
+	//    receives the PONG, and the read loop keeps running.
+	assertKeepalivePingPong(t, providerConn, "after-deadline-lapse")
+
+	// 4) Re-arm the stale deadline directly and confirm repeated idle keepalives
+	//    keep surviving — i.e. no read-loop teardown across successive cycles.
+	for i := 0; i < 2; i++ {
+		if err := serverConn.SetWriteDeadline(time.Now().Add(-time.Hour)); err != nil {
+			t.Fatalf("re-arm stale write deadline: %v", err)
+		}
+		assertKeepalivePingPong(t, providerConn, "re-armed-stale-deadline")
+	}
+
+	// Clean shutdown: closing the client end ends the server read loop.
+	_ = providerConn.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readProviderLoop did not exit after client close")
+	}
+}
+
+// assertKeepalivePingPong sends a client keepalive PING and asserts a PONG comes
+// back within a short deadline, proving the reactive control write succeeded and
+// the provider read loop did not tear the session down.
+func assertKeepalivePingPong(t *testing.T, clientConn net.Conn, label string) {
+	t.Helper()
+	if err := wsutil.WriteClientMessage(clientConn, gobwas.OpPing, []byte("keepalive")); err != nil {
+		t.Fatalf("%s: write client ping: %v", label, err)
+	}
+	if err := clientConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("%s: set client read deadline: %v", label, err)
+	}
+	frame, err := gobwas.ReadFrame(clientConn)
+	if err != nil {
+		t.Fatalf("%s: expected PONG, got read error (session torn down by stale write deadline?): %v", label, err)
+	}
+	if frame.Header.OpCode != gobwas.OpPong {
+		t.Fatalf("%s: frame opcode = %v, want PONG", label, frame.Header.OpCode)
+	}
+	_ = clientConn.SetReadDeadline(time.Time{})
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -1286,8 +1286,31 @@ func (s *Server) writeServerMessage(conn net.Conn, op gobwas.OpCode, payload []b
 	return wsutil.WriteServerMessage(conn, op, payload)
 }
 
+// deadlineRefreshingWriter refreshes conn's write deadline before every write.
+// It is handed to wsutil.ControlFrameHandler as the reply destination so that
+// reactive PONG/Close frames — which gobwas writes synchronously from the read
+// goroutine (wsutil ControlHandler.HandlePing / HandleClose) — always get a
+// fresh deadline. Socket write deadlines are absolute and are never cleared
+// after a successful write, so without this an idle provider's PONG inherits
+// the stale deadline left by the last runWriter send (~WriteTimeoutS old) and
+// fails instantly with `i/o timeout`, tearing down an otherwise healthy
+// session in readProviderLoop. See readClientData.
+type deadlineRefreshingWriter struct {
+	s    *Server
+	conn net.Conn
+}
+
+func (w deadlineRefreshingWriter) Write(p []byte) (int, error) {
+	w.s.setWriteDeadline(w.conn)
+	return w.conn.Write(p)
+}
+
 func (s *Server) readClientData(conn net.Conn) ([]byte, gobwas.OpCode, error) {
-	controlHandler := wsutil.ControlFrameHandler(conn, gobwas.StateServerSide)
+	// Route control-frame replies through deadlineRefreshingWriter so a PONG
+	// (or echoed Close) written from this read goroutine never inherits the
+	// stale write deadline left by the last runWriter send. The Reader still
+	// reads from the raw conn; only reply writes are wrapped.
+	controlHandler := wsutil.ControlFrameHandler(deadlineRefreshingWriter{s: s, conn: conn}, gobwas.StateServerSide)
 	rd := wsutil.Reader{
 		Source:          conn,
 		State:           gobwas.StateServerSide,


### PR DESCRIPTION
## Summary
- `runWriter` sets an absolute write deadline only at the top of each `writeCh` send, and socket write deadlines are never cleared after a successful write. Once a provider goes idle, that deadline lapses. The next keepalive PING the provider sends drives gobwas's `HandlePing` to write a PONG synchronously from the read goroutine (`readClientData`) directly to the conn, inheriting the stale, already-expired deadline. The PONG write fails with `i/o timeout`, which `readProviderLoop` surfaces as a read failure and tears the session down — disconnecting an idle-but-healthy provider on its keepalive cadence. `HandleClose` has the same direct-write pattern, so coordinator-initiated Close frames during an idle gap fail identically.
- Fix: route the control handler's reply destination through a small `deadlineRefreshingWriter` so every reactive PONG/Close write re-arms the write deadline first. The `Reader` still reads from the raw conn; only reply writes are wrapped, so this covers both the explicit control-frame branch and the `OnIntermediate` path, and works uniformly for the handshake-phase `readClientData` callers that have no `writeCh`.
- New regression test `TestProviderControlPongSurvivesStaleWriteDeadline` opens a provider session with a 50ms write limit, drives a real `runWriter` send to set the deadline exactly as production does, lets it lapse, sends a client PING, and asserts the session survives (PONG returns, no read-loop teardown), then re-arms the stale deadline twice to confirm sustained idle-keepalive survival.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/ws/` clean
- [x] `go test ./internal/ws/ -race -count=1` green (full suite, 11.3s under race)
- [x] New regression test verified red→green: passes with fix, fails with `read pipe: i/o timeout` ("session torn down by stale write deadline?") when the wrapped `Dst` is temporarily reverted
- [x] Stress run: regression test x10 under `-race` — non-flaky

## Scope notes
- No public API, wire-protocol, or config-key change (`ws.write_timeout_s` semantics unchanged).
- Closes a divergence between implementation and the documented FR-P11 / FR-P19 contracts in `specs/SPEC-002-coordinator.md`; no spec edits needed.
- Same pattern as previous sibling WS bug-fix commits (591a0e2 receive-loop drain, fbae02b sendPing continuation) — code-only.
- Latent follow-up flagged separately: serialize all provider WS writes through `runWriter` (current fix re-arms the deadline; it does not eliminate the concurrent-writer hazard between `runWriter` and reactive control replies — the race detector cannot see WS-frame-level interleaving because `net.Conn.Write` is internally locked).
