### PR TITLE
feat(provider): expose --kv-bits / --max-context / --max-batch serve knobs for autoresearch

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -30,6 +30,12 @@ public struct AppConfig: Equatable, Sendable {
     public var logFile: String?
     public var maxContextOverride: Int?
     public var maxConcurrencyOverride: Int?
+    // SPEC-013 (autoresearch serving knobs): KV-cache quantization bits
+    // forwarded to mlx-swift `GenerateParameters.kvBits`. nil ⇒ no
+    // quantization (mlx-swift default). Triple-exposed: yaml key
+    // `kv_bits`, env `MACPROVIDER_KV_BITS`, CLI `--kv-bits`. Validated
+    // to be 4 or 8 (the values mlx-swift accepts) at serve preflight.
+    public var kvBitsOverride: Int?
     public var drainTimeoutSeconds: Int
     public var warmupEnabled: Bool
     public var maxRequestBodyBytes: Int
@@ -68,6 +74,7 @@ public struct AppConfig: Equatable, Sendable {
             logFile: nil,
             maxContextOverride: nil,
             maxConcurrencyOverride: nil,
+            kvBitsOverride: nil,
             drainTimeoutSeconds: 30,
             warmupEnabled: true,
             maxRequestBodyBytes: 10 * 1024 * 1024,
@@ -98,6 +105,11 @@ public struct CLIOverrides: Equatable, Sendable {
     public var ctlSocketPath: String?
     public var switchStatePath: String?
     public var providerToken: String?
+    // SPEC-013 autoresearch serving knobs. nil ⇒ defer to env / YAML /
+    // built-in default (the latter mirrors prior single-slot behavior).
+    public var kvBits: Int?
+    public var maxContext: Int?
+    public var maxBatch: Int?
 
     public init(
         port: Int? = nil,
@@ -113,7 +125,10 @@ public struct CLIOverrides: Equatable, Sendable {
         swapDrainTimeoutSeconds: Int? = nil,
         ctlSocketPath: String? = nil,
         switchStatePath: String? = nil,
-        providerToken: String? = nil
+        providerToken: String? = nil,
+        kvBits: Int? = nil,
+        maxContext: Int? = nil,
+        maxBatch: Int? = nil
     ) {
         self.port = port
         self.model = model
@@ -129,6 +144,9 @@ public struct CLIOverrides: Equatable, Sendable {
         self.ctlSocketPath = ctlSocketPath
         self.switchStatePath = switchStatePath
         self.providerToken = providerToken
+        self.kvBits = kvBits
+        self.maxContext = maxContext
+        self.maxBatch = maxBatch
     }
 }
 
@@ -220,6 +238,7 @@ public enum ConfigLoader {
         try assign(&config.logFile, from: dict, key: "log_file", expected: "string")
         try assign(&config.maxContextOverride, from: dict, key: "max_context_override", expected: "integer")
         try assign(&config.maxConcurrencyOverride, from: dict, key: "max_concurrency_override", expected: "integer")
+        try assign(&config.kvBitsOverride, from: dict, key: "kv_bits", expected: "integer (4 or 8)")
         try assign(&config.drainTimeoutSeconds, from: dict, key: "drain_timeout_s", expected: "integer")
         try assign(&config.warmupEnabled, from: dict, key: "warmup_enabled", expected: "boolean")
         try assign(&config.maxRequestBodyBytes, from: dict, key: "max_request_body_bytes", expected: "integer")
@@ -251,6 +270,7 @@ public enum ConfigLoader {
         try assign(&config.logFile, from: environment, env: "MACPROVIDER_LOG_FILE", expected: "string")
         try assign(&config.maxContextOverride, from: environment, env: "MACPROVIDER_MAX_CONTEXT_OVERRIDE", expected: "integer")
         try assign(&config.maxConcurrencyOverride, from: environment, env: "MACPROVIDER_MAX_CONCURRENCY_OVERRIDE", expected: "integer")
+        try assign(&config.kvBitsOverride, from: environment, env: "MACPROVIDER_KV_BITS", expected: "integer (4 or 8)")
         try assign(&config.drainTimeoutSeconds, from: environment, env: "MACPROVIDER_DRAIN_TIMEOUT_S", expected: "integer")
         try assign(&config.warmupEnabled, from: environment, env: "MACPROVIDER_WARMUP_ENABLED", expected: "boolean")
         try assign(&config.maxRequestBodyBytes, from: environment, env: "MACPROVIDER_MAX_REQUEST_BODY_BYTES", expected: "integer")
@@ -308,6 +328,15 @@ public enum ConfigLoader {
         }
         if let providerToken = cli.providerToken {
             config.providerToken = providerToken
+        }
+        if let kvBits = cli.kvBits {
+            config.kvBitsOverride = kvBits
+        }
+        if let maxContext = cli.maxContext {
+            config.maxContextOverride = maxContext
+        }
+        if let maxBatch = cli.maxBatch {
+            config.maxConcurrencyOverride = maxBatch
         }
         return config
     }

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -64,6 +64,15 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "Provider authentication token (SPEC-001 / XSEC-1). When set, the binary sends 'Authorization: Bearer <token>' on the coordinator WS connect. Required when the coordinator runs with auth.require_provider_tokens=true. Overrides MACPROVIDER_PROVIDER_TOKEN and config key provider_token. Treat as a secret — the binary never logs it; chmod 0600 the config file containing it.")
     var providerToken: String?
 
+    @Option(help: "KV-cache quantization precision in bits (4 or 8). When set, forwarded to mlx-swift GenerateParameters.kvBits — quantizes the KV cache to reduce per-token memory footprint at a small accuracy cost. Unset (default) keeps the mlx-swift default of no KV quantization. Overrides MACPROVIDER_KV_BITS and config key kv_bits.")
+    var kvBits: Int?
+
+    @Option(help: "Maximum prompt context length (tokens) this provider will accept. Prompts whose tokenized length exceeds this cap are rejected with HTTP 413 context_length_exceeded. Also wired to mlx-swift GenerateParameters.maxKVSize, capping KV-cache allocation. Unset defers to the per-tier default (8GB:20000, 16GB:50000, 32GB:120000, 64GB+:200000). Overrides MACPROVIDER_MAX_CONTEXT_OVERRIDE and config key max_context_override.")
+    var maxContext: Int?
+
+    @Option(help: "Maximum concurrent in-flight inferences. Defaults to 1 (single-slot, the only safe value while mlx-swift parallel generation remains unproven). Lifting this above 1 is an autotune knob — the binary itself does not enforce safety beyond the AsyncSemaphore. Overrides MACPROVIDER_MAX_CONCURRENCY_OVERRIDE and config key max_concurrency_override.")
+    var maxBatch: Int?
+
     static func runSupportedModelsPreflight(_ resolved: inout AppConfig) throws {
         if resolved.supportedModels != nil {
             do {
@@ -88,6 +97,30 @@ struct ServeCommand: AsyncParsableCommand {
         }
     }
 
+    // SPEC-013 autoresearch serving knobs: fail loud at serve start
+    // instead of mid-inference when an operator passes a value mlx-swift
+    // does not accept.
+    static func runServingKnobsPreflight(_ resolved: AppConfig) throws {
+        if let kvBits = resolved.kvBitsOverride, kvBits != 4 && kvBits != 8 {
+            FileHandle.standardError.write(Data((
+                "--kv-bits \(kvBits) invalid; must be 4 or 8\n"
+            ).utf8))
+            throw ExitCode(2)
+        }
+        if let maxContext = resolved.maxContextOverride, maxContext < 1 {
+            FileHandle.standardError.write(Data((
+                "--max-context \(maxContext) must be >= 1\n"
+            ).utf8))
+            throw ExitCode(2)
+        }
+        if let maxBatch = resolved.maxConcurrencyOverride, maxBatch < 1 {
+            FileHandle.standardError.write(Data((
+                "--max-batch \(maxBatch) must be >= 1\n"
+            ).utf8))
+            throw ExitCode(2)
+        }
+    }
+
     func run() async throws {
         var resolved = try ConfigLoader.load(
             cli: CLIOverrides(
@@ -104,27 +137,34 @@ struct ServeCommand: AsyncParsableCommand {
                 swapDrainTimeoutSeconds: swapDrainTimeoutSeconds,
                 ctlSocketPath: ctlSocketPath,
                 switchStatePath: switchStatePath,
-                providerToken: providerToken
+                providerToken: providerToken,
+                kvBits: kvBits,
+                maxContext: maxContext,
+                maxBatch: maxBatch
             )
         )
 
         try Self.runSupportedModelsPreflight(&resolved)
         try Self.runDrainTimeoutPreflight(resolved)
+        try Self.runServingKnobsPreflight(resolved)
 
         printResolvedConfiguration(resolved)
 
         let modelRuntime = try await ModelRuntime(
             modelID: resolved.model,
             maxContextTokensOverride: resolved.maxContextOverride,
+            kvBitsOverride: resolved.kvBitsOverride,
+            maxBatch: resolved.maxConcurrencyOverride ?? 1,
             warmSwapEnabled: resolved.enableWarmSwap,
             swapDrainTimeoutSeconds: resolved.swapDrainTimeoutSeconds
         )
-        // MLX generation is currently guarded by a process-local semaphore of 1.
-        // Advertise the real runtime concurrency until the runtime is proven safe
-        // for parallel generation.
+        // The serve runtime defaults `--max-batch` to 1 (the prior
+        // single-slot behavior). Operators opting in via --max-batch >1
+        // own the safety check; we surface the configured value in
+        // capacity so the coordinator's view stays consistent.
         let capacityDefaults = ProviderCapacity(
             maxContextOverride: resolved.maxContextOverride,
-            maxConcurrencyOverride: 1
+            maxConcurrencyOverride: resolved.maxConcurrencyOverride ?? 1
         )
         let throughputEstimate = await modelRuntime.measureStartupThroughput()
         let providerStatus = ProviderStatus(
@@ -290,4 +330,7 @@ private func printResolvedConfiguration(_ config: AppConfig) {
     print("  log_level: \(config.logLevel.rawValue)")
     print("  log_format: \(config.logFormat.rawValue)")
     print("  tier2_mda_artifact_path: \(config.tier2MDAArtifactPath ?? "<unset>")")
+    print("  kv_bits: \(config.kvBitsOverride.map(String.init) ?? "<unset, mlx default>")")
+    print("  max_context: \(config.maxContextOverride.map(String.init) ?? "<unset, per-tier default>")")
+    print("  max_batch: \(config.maxConcurrencyOverride.map(String.init) ?? "1")")
 }

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -53,7 +53,12 @@ actor ModelRuntime: ModelRuntimeServing {
     private let stopTokenFilter: StopTokenFilter
     private var currentModelHash: String?
     private let maxContextTokens: Int
-    private let inferenceGate = AsyncSemaphore(value: 1)
+    // SPEC-013 autoresearch serving knobs. nil kvBits ⇒ no KV
+    // quantization (mlx-swift default). maxBatch defaults to 1, the
+    // pre-knob behavior; lifting above 1 widens the autotune search.
+    private let kvBitsOverride: Int?
+    private let inferenceGate: AsyncSemaphore
+    private let maxBatch: Int
     private let warmSwapEnabled: Bool
     private let swapDrainTimeoutSeconds: Int
     private var providerStatus: ProviderStatus?
@@ -79,11 +84,16 @@ actor ModelRuntime: ModelRuntimeServing {
     init(
         modelID: String?,
         maxContextTokensOverride: Int? = nil,
+        kvBitsOverride: Int? = nil,
+        maxBatch: Int = 1,
         warmSwapEnabled: Bool = false,
         swapDrainTimeoutSeconds: Int = 30
     ) async throws {
         self.currentModelID = modelID
         self.maxContextTokens = maxContextTokensOverride ?? Self.defaultMaxContextTokens()
+        self.kvBitsOverride = kvBitsOverride
+        self.maxBatch = max(1, maxBatch)
+        self.inferenceGate = AsyncSemaphore(value: max(1, maxBatch))
         self.warmSwapEnabled = warmSwapEnabled
         self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
         self.loader = { targetModelID in
@@ -121,6 +131,8 @@ actor ModelRuntime: ModelRuntimeServing {
         modelID: String?,
         modelHash: String? = nil,
         maxContextTokensOverride: Int? = nil,
+        kvBitsOverride: Int? = nil,
+        maxBatch: Int = 1,
         warmSwapEnabled: Bool,
         swapDrainTimeoutSeconds: Int = 30,
         providerStatus: ProviderStatus? = nil,
@@ -133,6 +145,9 @@ actor ModelRuntime: ModelRuntimeServing {
         self.currentModelHash = modelHash
         self.stopTokenFilter = StopTokenFilter(tokens: [])
         self.maxContextTokens = maxContextTokensOverride ?? Self.defaultMaxContextTokens()
+        self.kvBitsOverride = kvBitsOverride
+        self.maxBatch = max(1, maxBatch)
+        self.inferenceGate = AsyncSemaphore(value: max(1, maxBatch))
         self.warmSwapEnabled = warmSwapEnabled
         self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
         self.providerStatus = providerStatus
@@ -202,6 +217,20 @@ actor ModelRuntime: ModelRuntimeServing {
 
     nonisolated func swapDrainTimeoutForTest() -> Int {
         swapDrainTimeoutSeconds
+    }
+
+    // SPEC-013 autoresearch serving knobs: test-only accessors so test
+    // suites can confirm CLI flag values reached the runtime.
+    func kvBitsOverrideForTest() -> Int? {
+        kvBitsOverride
+    }
+
+    func maxBatchForTest() -> Int {
+        maxBatch
+    }
+
+    func maxContextTokensForTest() -> Int {
+        maxContextTokens
     }
 
     private func transitionToLoading(target: String) throws {
@@ -346,6 +375,7 @@ actor ModelRuntime: ModelRuntimeServing {
         }
 
         let maxContextTokens = maxContextTokens
+        let kvBitsOverride = kvBitsOverride
         let inferenceGate = inferenceGate
         let stopTokenFilter = stopTokenFilter
         return try await Self.withDrainCancellation(drainCancelled) {
@@ -360,6 +390,8 @@ actor ModelRuntime: ModelRuntimeServing {
                     try Self.validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
                     let parameters = GenerateParameters(
                         maxTokens: request.maxTokens,
+                        maxKVSize: maxContextTokens,
+                        kvBits: kvBitsOverride,
                         temperature: Float(request.temperature),
                         topP: Float(request.topP)
                     )
@@ -418,6 +450,7 @@ actor ModelRuntime: ModelRuntimeServing {
         }
 
         let maxContextTokens = maxContextTokens
+        let kvBitsOverride = kvBitsOverride
         let inferenceGate = inferenceGate
         let stopTokenFilter = stopTokenFilter
         return try await Self.withDrainCancellation(drainCancelled) {
@@ -432,6 +465,8 @@ actor ModelRuntime: ModelRuntimeServing {
                     try Self.validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
                     let parameters = GenerateParameters(
                         maxTokens: request.maxTokens,
+                        maxKVSize: maxContextTokens,
+                        kvBits: kvBitsOverride,
                         temperature: Float(request.temperature),
                         topP: Float(request.topP)
                     )
@@ -531,7 +566,7 @@ actor ModelRuntime: ModelRuntimeServing {
         return LLMModelFactory.shared.configuration(id: modelID)
     }
 
-    private static func validatePromptTokenCount(_ promptTokens: Int, maxContextTokens: Int) throws {
+    static func validatePromptTokenCount(_ promptTokens: Int, maxContextTokens: Int) throws {
         guard promptTokens <= maxContextTokens else {
             throw APIError(
                 status: 413,

--- a/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+// SPEC-013 autoresearch serving knobs: covers --kv-bits / --max-context
+// / --max-batch end-to-end — config resolution (CLI > env > YAML),
+// defaults preserved when omitted, preflight rejects invalid values,
+// runtime threading reaches the actor, and the existing
+// context_length_exceeded gate honors the new override.
+
+final class ServingKnobsConfigTests: XCTestCase {
+    // MARK: - Defaults preserved
+
+    func testDefaultsUnchangedWhenAllKnobsOmitted() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [:],
+            fileExists: { _ in false },
+            readFile: { _ in "" }
+        )
+        XCTAssertNil(config.kvBitsOverride)
+        XCTAssertNil(config.maxContextOverride)
+        XCTAssertNil(config.maxConcurrencyOverride)
+    }
+
+    // MARK: - --kv-bits
+
+    func testKvBitsCLIOverridesEnvironmentOverridesYAML() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(kvBits: 8),
+            environment: ["MACPROVIDER_KV_BITS": "4"],
+            fileExists: { _ in true },
+            readFile: { _ in "kv_bits: 4\n" }
+        )
+        XCTAssertEqual(config.kvBitsOverride, 8)
+    }
+
+    func testKvBitsEnvironmentOverridesYAML() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: ["MACPROVIDER_KV_BITS": "4"],
+            fileExists: { _ in true },
+            readFile: { _ in "kv_bits: 8\n" }
+        )
+        XCTAssertEqual(config.kvBitsOverride, 4)
+    }
+
+    func testKvBitsYAMLApplied() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in "kv_bits: 4\n" }
+        )
+        XCTAssertEqual(config.kvBitsOverride, 4)
+    }
+
+    // MARK: - --max-context
+
+    func testMaxContextCLIOverridesEnvironmentOverridesYAML() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(maxContext: 8192),
+            environment: ["MACPROVIDER_MAX_CONTEXT_OVERRIDE": "16384"],
+            fileExists: { _ in true },
+            readFile: { _ in "max_context_override: 4096\n" }
+        )
+        XCTAssertEqual(config.maxContextOverride, 8192)
+    }
+
+    func testMaxContextYAMLApplied() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in "max_context_override: 4096\n" }
+        )
+        XCTAssertEqual(config.maxContextOverride, 4096)
+    }
+
+    // MARK: - --max-batch
+
+    func testMaxBatchCLIOverridesEnvironmentOverridesYAML() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(maxBatch: 4),
+            environment: ["MACPROVIDER_MAX_CONCURRENCY_OVERRIDE": "2"],
+            fileExists: { _ in true },
+            readFile: { _ in "max_concurrency_override: 1\n" }
+        )
+        XCTAssertEqual(config.maxConcurrencyOverride, 4)
+    }
+
+    func testMaxBatchYAMLApplied() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in "max_concurrency_override: 2\n" }
+        )
+        XCTAssertEqual(config.maxConcurrencyOverride, 2)
+    }
+
+    // MARK: - Preflight validation
+
+    func testKvBitsPreflightRejectsInvalidValue() throws {
+        var config = AppConfig.defaults()
+        config.kvBitsOverride = 5
+        XCTAssertThrowsError(try ServeCommand.runServingKnobsPreflight(config))
+    }
+
+    func testKvBitsPreflightAcceptsFour() throws {
+        var config = AppConfig.defaults()
+        config.kvBitsOverride = 4
+        XCTAssertNoThrow(try ServeCommand.runServingKnobsPreflight(config))
+    }
+
+    func testKvBitsPreflightAcceptsEight() throws {
+        var config = AppConfig.defaults()
+        config.kvBitsOverride = 8
+        XCTAssertNoThrow(try ServeCommand.runServingKnobsPreflight(config))
+    }
+
+    func testKvBitsPreflightAcceptsNil() throws {
+        let config = AppConfig.defaults()
+        XCTAssertNoThrow(try ServeCommand.runServingKnobsPreflight(config))
+    }
+
+    func testMaxContextPreflightRejectsZero() throws {
+        var config = AppConfig.defaults()
+        config.maxContextOverride = 0
+        XCTAssertThrowsError(try ServeCommand.runServingKnobsPreflight(config))
+    }
+
+    func testMaxBatchPreflightRejectsZero() throws {
+        var config = AppConfig.defaults()
+        config.maxConcurrencyOverride = 0
+        XCTAssertThrowsError(try ServeCommand.runServingKnobsPreflight(config))
+    }
+
+    // MARK: - Runtime threading
+
+    func testRuntimeReceivesKvBitsOverride() async throws {
+        let runtime = ModelRuntime(
+            modelID: "test-model",
+            kvBitsOverride: 4,
+            warmSwapEnabled: false,
+            loader: { _ in throw TestRuntimeError.notExpected }
+        )
+        let observed = await runtime.kvBitsOverrideForTest()
+        XCTAssertEqual(observed, 4)
+    }
+
+    func testRuntimeDefaultKvBitsIsNil() async throws {
+        let runtime = ModelRuntime(
+            modelID: "test-model",
+            warmSwapEnabled: false,
+            loader: { _ in throw TestRuntimeError.notExpected }
+        )
+        let observed = await runtime.kvBitsOverrideForTest()
+        XCTAssertNil(observed)
+    }
+
+    func testRuntimeReceivesMaxBatch() async throws {
+        let runtime = ModelRuntime(
+            modelID: "test-model",
+            maxBatch: 3,
+            warmSwapEnabled: false,
+            loader: { _ in throw TestRuntimeError.notExpected }
+        )
+        let observed = await runtime.maxBatchForTest()
+        XCTAssertEqual(observed, 3)
+    }
+
+    func testRuntimeDefaultMaxBatchIsOne() async throws {
+        let runtime = ModelRuntime(
+            modelID: "test-model",
+            warmSwapEnabled: false,
+            loader: { _ in throw TestRuntimeError.notExpected }
+        )
+        let observed = await runtime.maxBatchForTest()
+        XCTAssertEqual(observed, 1)
+    }
+
+    func testRuntimeReceivesMaxContext() async throws {
+        let runtime = ModelRuntime(
+            modelID: "test-model",
+            maxContextTokensOverride: 4096,
+            warmSwapEnabled: false,
+            loader: { _ in throw TestRuntimeError.notExpected }
+        )
+        let observed = await runtime.maxContextTokensForTest()
+        XCTAssertEqual(observed, 4096)
+    }
+
+    // MARK: - --max-context gates prompts at the documented boundary
+
+    func testValidatePromptTokenCountRejectsOversize() throws {
+        XCTAssertThrowsError(try ModelRuntime.validatePromptTokenCount(4097, maxContextTokens: 4096)) { error in
+            guard let apiError = error as? APIError else {
+                XCTFail("expected APIError, got \(error)")
+                return
+            }
+            XCTAssertEqual(apiError.status, 413)
+            XCTAssertEqual(apiError.code, "context_length_exceeded")
+            XCTAssertEqual(apiError.type, "context_length_exceeded")
+        }
+    }
+
+    func testValidatePromptTokenCountAcceptsAtBoundary() throws {
+        XCTAssertNoThrow(try ModelRuntime.validatePromptTokenCount(4096, maxContextTokens: 4096))
+    }
+}
+
+private enum TestRuntimeError: Error {
+    case notExpected
+}


### PR DESCRIPTION
## Summary

Adds three new `serve` flags so `beta/autotune.py` (PR #103) can
hill-climb a real per-machine recipe space, not just `--model`:

| Flag | Default | mlx-swift wire site |
|------|---------|---------------------|
| `--kv-bits {4,8}` | unset (no quantization) | `GenerateParameters.kvBits` — both `complete()` and `stream()` |
| `--max-context <N>` | per-tier (8GB:20000, 16GB:50000, 32GB:120000, 64GB+:200000) | `GenerateParameters.maxKVSize` + existing `validatePromptTokenCount` 413 gate |
| `--max-batch <N>` | 1 (preserves prior single-slot behavior) | `AsyncSemaphore(value: maxBatch)` in `ModelRuntime` |

All three are triple-exposed (CLI > env > YAML > default), matching
the house convention used by every other flag in `ServeCommand`. A
new `runServingKnobsPreflight` fails loud at serve start on invalid
values (`--kv-bits 7`, `--max-context 0`, etc.) instead of leaking to
mid-inference.

### Why
The reference autoresearch repo's "different recipe per machine"
insight depends on tuning *config* per machine, not just the model.
Today's autotune loop can only flip `--model`; this PR widens its
search to KV-cache precision, served context window, and concurrency.

### Bug fix folded in
`ServeCommand.run()` was hardcoding `maxConcurrencyOverride: 1` when
building `ProviderCapacity`, silently ignoring the resolved config.
Capacity now reflects the actual `--max-batch` value.

## Flags shipped vs dropped

All three target knobs shipped — verified against the checked-out
mlx-swift-examples 2.29.1 in `.build/checkouts/mlx-swift-examples/Libraries/MLXLMCommon/Evaluate.swift:54-105`,
which exposes `GenerateParameters.kvBits`, `maxKVSize`, and accepts
the existing semaphore-gated batch model. Nothing was dropped.

## mlx-swift wiring approach

- `--kv-bits`: passed as `GenerateParameters.kvBits` at both the
  non-streaming (`ModelRuntime.complete()`) and streaming
  (`ModelRuntime.stream()`) generation sites. nil keeps the mlx-swift
  default of unquantized KV cache. Group size and quantizedKVStart
  use mlx-swift defaults (64 / 0) — exposed as knobs would widen the
  search prematurely without operator evidence.
- `--max-context`: continues to enforce the existing 413
  `context_length_exceeded` gate (`ModelRuntime.validatePromptTokenCount`).
  Additionally passes `maxKVSize=maxContextTokens` to
  `GenerateParameters` so the RotatingKVCache bounds the allocation —
  this is what gives KV-cache memory pressure relief on small-RAM
  nodes.
- `--max-batch`: changes `inferenceGate = AsyncSemaphore(value: 1)` to
  `AsyncSemaphore(value: max(1, maxBatch))`. The existing
  `acquire/withPermit` pattern is unchanged; the actor already handles
  multi-permit safely.

## Test additions

`Tests/macprovider-cliTests/ServingKnobsConfigTests.swift` adds 21
test cases:

- Defaults preserved when all knobs omitted (regression).
- CLI > env > YAML precedence for each of the 3 flags.
- YAML-only resolution for each (the most common ops path).
- Preflight rejects `--kv-bits 5`, accepts 4 and 8 and nil.
- Preflight rejects `--max-context 0` and `--max-batch 0`.
- Runtime threading: each knob reaches `ModelRuntime` via test
  accessors (`kvBitsOverrideForTest`, `maxBatchForTest`,
  `maxContextTokensForTest`).
- `--max-context` boundary: oversize prompts still throw the
  documented 413 `context_length_exceeded` `APIError`; at-boundary
  prompts pass.

Full suite: 219 → 240 tests, all green.

## Out of scope

Per-request `--kv-group-size` / `--quantized-kv-start` knobs are
intentionally **not** exposed; they sit below the autotune's noise
floor today and would widen the search without operator evidence.
Adding them later is mechanical (same call site, same plumbing
pattern).

## Test plan

- [x] `swift build -c release --product macprovider-cli` clean
- [x] `swift test` — 240 / 240 passing
- [x] `macprovider-cli help serve` lists `--kv-bits`, `--max-context`, `--max-batch`
- [x] `MACPROVIDER_KV_BITS=7 macprovider-cli serve ...` rejects with documented error
- [x] No coordinator/gateway/Pearl-side changes
- [x] No live deploy — build + tests only on the 8GB Air

## Related

- Widens the autoresearch search space landed by #103
  (`beta/autotune.py` — provider-side keep/revert hill-climb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
