### PR TITLE
fix(ws): give runWriter exclusive ownership of provider conn writes

### DIFF
--- a/phase4-coordinator/internal/ws/admin_endpoints.go
+++ b/phase4-coordinator/internal/ws/admin_endpoints.go
@@ -104,8 +104,7 @@ func (s *Server) handleAdminReject(w http.ResponseWriter, r *http.Request) {
 			_ = session.send([]byte(`{"type":"drain"}`))
 			s.pool.MarkState(provider.ProviderID, provider.AssignedID, pool.StateDraining)
 			time.AfterFunc(200*time.Millisecond, func() {
-				s.close(session.conn, CloseBanned, "banned: provider "+providerID+" has been rejected by operator")
-				_ = session.conn.Close()
+				s.closeSession(session, CloseBanned, "banned: provider "+providerID+" has been rejected by operator")
 			})
 		}
 	}

--- a/phase4-coordinator/internal/ws/relay.go
+++ b/phase4-coordinator/internal/ws/relay.go
@@ -49,7 +49,7 @@ type providerSession struct {
 	providerID string
 	assignedID string
 	conn       net.Conn
-	writeCh    chan []byte
+	writeCh    chan providerFrame
 	writeLimit time.Duration
 	closeOnce  sync.Once
 	writeMu    sync.Mutex
@@ -59,6 +59,24 @@ type providerSession struct {
 	httpOnly   bool
 	tier2Mu    sync.Mutex
 	tier2      *pool.Tier2Session
+}
+
+// providerFrame is the unit of work consumed by runWriter. Two kinds exist:
+//
+//   - text payloads (raw == false): JSON-ish coordinator → provider control
+//     messages (hello_ack, auth_response, inference_request, cancel_request,
+//     drain, etc.); written via wsutil.WriteServerText.
+//
+//   - pre-baked raw WS frames (raw == true): reactive PONG / Close-echo replies
+//     and server-initiated Close frames. Captured upstream as the exact bytes
+//     gobwas would have emitted (header + body) and written via a single
+//     conn.Write so they cannot interleave with a text frame.
+//
+// The single runWriter goroutine has exclusive ownership of all post-handshake
+// conn writes; every other caller MUST go through send / enqueueRaw.
+type providerFrame struct {
+	raw     bool
+	payload []byte
 }
 
 type encryptedInferenceRequest struct {
@@ -95,16 +113,25 @@ func newProviderSession(providerID, assignedID string, conn net.Conn, bufferSize
 		providerID: providerID,
 		assignedID: assignedID,
 		conn:       conn,
-		writeCh:    make(chan []byte, bufferSize),
+		writeCh:    make(chan providerFrame, bufferSize),
 		writeLimit: writeLimit,
 		active:     map[string]*relayActive{},
 	}
 }
 
 func (ps *providerSession) runWriter() {
-	for payload := range ps.writeCh {
+	for f := range ps.writeCh {
 		_ = ps.conn.SetWriteDeadline(time.Now().Add(ps.writeLimit))
-		if err := wsutil.WriteServerText(ps.conn, payload); err != nil {
+		var err error
+		if f.raw {
+			// Single Write of an already-framed control reply. The header and
+			// body were assembled into f.payload upstream so they cannot be
+			// split across goroutines mid-frame.
+			_, err = ps.conn.Write(f.payload)
+		} else {
+			err = wsutil.WriteServerText(ps.conn, f.payload)
+		}
+		if err != nil {
 			ps.failAll(ErrRelayClosed)
 			_ = ps.conn.Close()
 			return
@@ -123,13 +150,26 @@ func (ps *providerSession) close() {
 }
 
 func (ps *providerSession) send(payload []byte) error {
+	return ps.enqueueFrame(providerFrame{payload: payload})
+}
+
+// enqueueRaw queues a pre-baked WS frame (header + body, already assembled by
+// the caller) for runWriter to emit with a single conn.Write. Used by the
+// post-handshake control-frame handler and by server-initiated Close paths so
+// reactive PONG / Close / shutdown frames cannot interleave with an in-flight
+// text frame from the writer.
+func (ps *providerSession) enqueueRaw(rawFrame []byte) error {
+	return ps.enqueueFrame(providerFrame{raw: true, payload: rawFrame})
+}
+
+func (ps *providerSession) enqueueFrame(f providerFrame) error {
 	ps.writeMu.Lock()
 	defer ps.writeMu.Unlock()
 	if ps.closed {
 		return ErrRelayClosed
 	}
 	select {
-	case ps.writeCh <- payload:
+	case ps.writeCh <- f:
 		return nil
 	default:
 		return ErrRelayBackpressure

--- a/phase4-coordinator/internal/ws/relay_writer_serialize_test.go
+++ b/phase4-coordinator/internal/ws/relay_writer_serialize_test.go
@@ -1,0 +1,205 @@
+package ws
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	gobwas "github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+	"github.com/rs/zerolog"
+)
+
+// TestProviderWriterSerializesUnderConcurrentControlAndDataFrames is a
+// concurrency regression test for the framing-corruption hazard described in
+// the Option-2 writer-ownership fix.
+//
+// Pre-fix: runWriter (the intended sole coordinator→provider writer) and the
+// readProviderLoop goroutine (via gobwas's ControlHandler.HandlePing/HandleClose)
+// both wrote WS frames directly to the same provider conn. Each wsutil-level
+// frame write issues TWO underlying conn.Write calls (header, then payload). A
+// PONG reply from the read goroutine arriving between the header and payload of
+// an in-flight inference_request from runWriter would land its OWN header+
+// payload on the wire mid-frame, corrupting the WS framing for both. The Go race
+// detector cannot see this because net.TCPConn.Write is internally locked; the
+// hazard lives one layer up at the WS framing boundary.
+//
+// Post-fix: every coordinator→provider write (text payloads, reactive control
+// replies, server-initiated Close frames) is enqueued on session.writeCh and
+// emitted by the single runWriter goroutine via one conn.Write per frame.
+//
+// This test drives a large number of concurrent text frames from the
+// "coordinator" side AND a large number of inbound client PING frames whose
+// reactive PONG replies must traverse the read-loop control-handler path. Every
+// frame that lands on the wire is parsed with gobwas.ReadFrame. ANY framing
+// corruption (header parsed from payload bytes, wrong declared length, garbage
+// opcode) surfaces as a ReadFrame error and fails the test.
+//
+// Additional invariants asserted:
+//   - All expected text frames arrive in their original send order (runWriter
+//     preserves writeCh order).
+//   - Every PING payload is echoed back exactly once in a PONG (no losses, no
+//     duplicates).
+//   - Total frame count on the wire matches expected text + ping counts.
+//
+// Must pass under `go test -race`.
+func TestProviderWriterSerializesUnderConcurrentControlAndDataFrames(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = serverConn.Close()
+		_ = clientConn.Close()
+	})
+
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	}
+	registry.Register(provider, serverConn)
+	s := NewServer(config.Default(), registry, zerolog.Nop())
+
+	// Large buffer + generous write limit so backpressure on writeCh stays
+	// improbable under the load below; under net.Pipe's synchronous handoff,
+	// runWriter drains as fast as the test's reader pulls.
+	session := newProviderSession("p1", "s1", serverConn, 1024, 5*time.Second)
+	s.sessions.Store(sessionKey("p1", "s1"), session)
+	go session.runWriter()
+
+	readLoopDone := make(chan struct{})
+	go func() {
+		s.readProviderLoop(serverConn, "p1", "s1")
+		close(readLoopDone)
+	}()
+
+	const (
+		textFrames = 200
+		pingFrames = 200
+	)
+
+	// Distinct payloads so we can match received PONGs back to PINGs and
+	// received TEXTs back to their send order without ambiguity. Padding the
+	// text payload makes each WS frame multi-byte so the framing-interleave
+	// window from the pre-fix bug is wide enough that ReadFrame would fail
+	// fast if it ever returned.
+	expectedText := make([]string, textFrames)
+	for i := range expectedText {
+		expectedText[i] = fmt.Sprintf(`{"type":"inference_request","seq":%d,"body":"%s"}`, i, strings.Repeat("x", 64))
+	}
+	expectedPing := make([][]byte, pingFrames)
+	for i := range expectedPing {
+		expectedPing[i] = []byte(fmt.Sprintf("ping-%04d", i))
+	}
+
+	var sendersWG sync.WaitGroup
+	sendersWG.Add(2)
+
+	// Text producer: pushes coordinator→provider text frames through
+	// session.send (the runWriter-owned path). Retries on backpressure rather
+	// than failing so the throughput is bounded only by net.Pipe.
+	go func() {
+		defer sendersWG.Done()
+		for _, payload := range expectedText {
+			for {
+				err := session.send([]byte(payload))
+				if err == nil {
+					break
+				}
+				if errors.Is(err, ErrRelayClosed) {
+					return
+				}
+				// ErrRelayBackpressure: writeCh full; spin briefly and retry.
+				time.Sleep(50 * time.Microsecond)
+			}
+		}
+	}()
+
+	// Client PING producer: drives inbound control frames whose reactive PONG
+	// replies must, post-fix, traverse session.enqueueRaw (NOT a direct
+	// conn.Write from the read goroutine). Pre-fix, this is precisely the
+	// goroutine whose direct PONG writes raced runWriter mid-text-frame.
+	go func() {
+		defer sendersWG.Done()
+		for _, p := range expectedPing {
+			if err := wsutil.WriteClientMessage(clientConn, gobwas.OpPing, p); err != nil {
+				return
+			}
+		}
+	}()
+
+	receivedText := make([]string, 0, textFrames)
+	pongCounts := make(map[string]int, pingFrames)
+	totalDeadline := time.Now().Add(30 * time.Second)
+
+	for len(receivedText)+sumValues(pongCounts) < textFrames+pingFrames {
+		if err := clientConn.SetReadDeadline(totalDeadline); err != nil {
+			t.Fatalf("set read deadline: %v", err)
+		}
+		frame, err := gobwas.ReadFrame(clientConn)
+		if err != nil {
+			t.Fatalf("ReadFrame failed at sawText=%d sawPong=%d (out of want text=%d ping=%d): %v "+
+				"— this is the framing-corruption signal the writer-ownership fix is meant to prevent",
+				len(receivedText), sumValues(pongCounts), textFrames, pingFrames, err)
+		}
+		switch frame.Header.OpCode {
+		case gobwas.OpText:
+			receivedText = append(receivedText, string(frame.Payload))
+		case gobwas.OpPong:
+			pongCounts[string(frame.Payload)]++
+		default:
+			t.Fatalf("unexpected opcode %v at sawText=%d sawPong=%d", frame.Header.OpCode, len(receivedText), sumValues(pongCounts))
+		}
+	}
+
+	sendersWG.Wait()
+
+	if got := len(receivedText); got != textFrames {
+		t.Fatalf("text frame count: got %d, want %d", got, textFrames)
+	}
+	if got := sumValues(pongCounts); got != pingFrames {
+		t.Fatalf("pong frame count: got %d, want %d", got, pingFrames)
+	}
+	// Order invariant: runWriter is the single writer, so writeCh order is
+	// preserved on the wire. A regression that introduced multiple writers
+	// would generally also break ordering.
+	for i, want := range expectedText {
+		if got := receivedText[i]; got != want {
+			t.Fatalf("text frame %d out of order: got %q, want %q", i, got, want)
+		}
+	}
+	// Echo invariant: each PING payload echoed exactly once as a PONG. Lost or
+	// duplicated PONG payloads indicate frame-boundary slop.
+	for _, p := range expectedPing {
+		if n := pongCounts[string(p)]; n != 1 {
+			t.Fatalf("PONG echo for %q: got %d times, want 1", string(p), n)
+		}
+	}
+
+	// Clean shutdown: closing the client end ends the server read loop.
+	_ = clientConn.Close()
+	select {
+	case <-readLoopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readProviderLoop did not exit after client close")
+	}
+}
+
+func sumValues(m map[string]int) int {
+	total := 0
+	for _, v := range m {
+		total += v
+	}
+	return total
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -450,7 +450,7 @@ func (s *Server) handleConn(conn net.Conn, auth providerAuth, releaseUnauthentic
 		}
 	}()
 
-	payload, op, err := s.readClientData(conn)
+	payload, op, err := s.readClientData(conn, s.directControlReply(conn))
 	if err != nil {
 		s.close(conn, CloseInvalidHello, "invalid_hello: read")
 		return
@@ -665,7 +665,10 @@ func (s *Server) handleV1Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	}
 	b, err := json.Marshal(ack)
 	if err != nil {
-		s.close(conn, CloseInvalidHello, "invalid_hello: ack")
+		// runWriter is already running for `session`; route the Close through
+		// it instead of writing directly to conn so we don't race an in-flight
+		// frame on the wire.
+		s.closeSession(session, CloseInvalidHello, "invalid_hello: ack")
 		return "", ""
 	}
 	if err := session.send(b); err != nil {
@@ -789,7 +792,7 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	}
 
 	s.setReadDeadline(conn, s.cfg.ProviderWSHandshakeTimeout())
-	proofPayload, op, err := s.readClientData(conn)
+	proofPayload, op, err := s.readClientData(conn, s.directControlReply(conn))
 	if err != nil {
 		s.close(conn, CloseInvalidHello, "invalid_auth_request: read")
 		return "", ""
@@ -918,7 +921,10 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	}
 	rawResponse, err := json.Marshal(response)
 	if err != nil {
-		s.close(conn, CloseInvalidHello, "invalid_auth_response")
+		// runWriter is already running for `session`; route the Close through
+		// it instead of writing directly to conn so we don't race an in-flight
+		// frame on the wire.
+		s.closeSession(session, CloseInvalidHello, "invalid_auth_response")
 		return "", ""
 	}
 	if err := session.send(rawResponse); err != nil {
@@ -1117,9 +1123,26 @@ func (s *Server) registerProviderSession(conn net.Conn, entry *pool.Provider) *p
 }
 
 func (s *Server) readProviderLoop(conn net.Conn, providerID, assignedID string) {
+	// Resolve the session once so reactive PONG / Close-echo writes funnel
+	// through session.enqueueRaw — i.e. through the single runWriter goroutine.
+	// Without this, gobwas's ControlHandler would emit reply frames directly to
+	// conn from THIS read goroutine, racing runWriter mid-text-frame and
+	// corrupting WS framing on the wire. The race is invisible to -race because
+	// net.TCPConn.Write itself is internally locked; the corruption lives one
+	// layer up at the WS framing boundary.
+	//
+	// Fallback to directControlReply when no session is registered (only
+	// reachable from tests that drive readProviderLoop without a sessions-map
+	// entry) — keeps the historical behaviour for those callers.
+	var controlReply func([]byte) error
+	if session, ok := s.storedSessionFor(providerID, assignedID); ok {
+		controlReply = session.enqueueRaw
+	} else {
+		controlReply = s.directControlReply(conn)
+	}
 	for {
 		s.setReadDeadline(conn, s.cfg.HeartbeatMissThreshold())
-		payload, op, err := s.readClientData(conn)
+		payload, op, err := s.readClientData(conn, controlReply)
 		if err != nil {
 			s.log.Warn().Err(err).Str("provider_id", providerID).Msg("provider websocket read failed")
 			return
@@ -1174,6 +1197,29 @@ func (s *Server) close(conn net.Conn, code gobwas.StatusCode, reason string) {
 	// deploy's invalid_token rejection of M4/M1) are visible in the journal.
 	s.log.Warn().Int("close_code", int(code)).Str("reason", reason).Msg("provider websocket closing")
 	_ = s.writeServerMessage(conn, gobwas.OpClose, gobwas.NewCloseFrameBody(code, reason))
+}
+
+// closeSession is the post-handshake equivalent of close: it enqueues a Close
+// frame through the providerSession's writer (so it serializes with any
+// in-flight text frame from runWriter instead of racing it on the wire) and
+// schedules conn.Close after a short grace period so runWriter can actually
+// flush the frame before the TCP conn dies. Callers MUST use this instead of
+// close(session.conn, ...) once runWriter is running — i.e. after
+// registerProviderSession has returned.
+func (s *Server) closeSession(session *providerSession, code gobwas.StatusCode, reason string) {
+	s.log.Warn().Int("close_code", int(code)).Str("reason", reason).Msg("provider websocket closing")
+	body := gobwas.NewCloseFrameBody(code, reason)
+	var buf bytes.Buffer
+	if err := gobwas.WriteFrame(&buf, gobwas.NewCloseFrame(body)); err != nil {
+		// Writing to bytes.Buffer cannot realistically fail; fall back to a
+		// hard conn.Close so the session still tears down.
+		_ = session.conn.Close()
+		return
+	}
+	_ = session.enqueueRaw(buf.Bytes())
+	time.AfterFunc(100*time.Millisecond, func() {
+		_ = session.conn.Close()
+	})
 }
 
 func (s *Server) reserveUnauthenticatedConn() bool {
@@ -1286,31 +1332,56 @@ func (s *Server) writeServerMessage(conn net.Conn, op gobwas.OpCode, payload []b
 	return wsutil.WriteServerMessage(conn, op, payload)
 }
 
-// deadlineRefreshingWriter refreshes conn's write deadline before every write.
-// It is handed to wsutil.ControlFrameHandler as the reply destination so that
-// reactive PONG/Close frames — which gobwas writes synchronously from the read
-// goroutine (wsutil ControlHandler.HandlePing / HandleClose) — always get a
-// fresh deadline. Socket write deadlines are absolute and are never cleared
-// after a successful write, so without this an idle provider's PONG inherits
-// the stale deadline left by the last runWriter send (~WriteTimeoutS old) and
-// fails instantly with `i/o timeout`, tearing down an otherwise healthy
-// session in readProviderLoop. See readClientData.
-type deadlineRefreshingWriter struct {
-	s    *Server
-	conn net.Conn
-}
-
-func (w deadlineRefreshingWriter) Write(p []byte) (int, error) {
-	w.s.setWriteDeadline(w.conn)
-	return w.conn.Write(p)
-}
-
-func (s *Server) readClientData(conn net.Conn) ([]byte, gobwas.OpCode, error) {
-	// Route control-frame replies through deadlineRefreshingWriter so a PONG
-	// (or echoed Close) written from this read goroutine never inherits the
-	// stale write deadline left by the last runWriter send. The Reader still
-	// reads from the raw conn; only reply writes are wrapped.
-	controlHandler := wsutil.ControlFrameHandler(deadlineRefreshingWriter{s: s, conn: conn}, gobwas.StateServerSide)
+// readClientData reads the next data frame from conn, handling any inbound
+// control frames inline. Control-frame replies (PONG, Close echo, protocol-
+// error Close) are assembled into a single contiguous frame and delivered via
+// controlReply.
+//
+// Two reply paths exist:
+//
+//   - Pre-handshake (handleConn / handleV2Conn before a providerSession has
+//     been registered): callers pass directControlReply, which writes the
+//     assembled frame straight to conn after re-arming the write deadline.
+//     No runWriter exists yet, so there is no goroutine to race against.
+//
+//   - Post-handshake (readProviderLoop): callers pass session.enqueueRaw, so
+//     the assembled frame is serialized through writeCh and emitted by the
+//     single runWriter goroutine. This closes the framing-corruption hazard
+//     where gobwas's ControlHandler would otherwise write header+payload in
+//     two separate conn.Write calls that could interleave with an in-flight
+//     coordinator→provider text frame (inference_request, cancel_request, …).
+//
+// We capture into a bytes.Buffer rather than writing through ControlHandler's
+// destination directly because HandlePing/HandleClose emit the frame as
+// TWO underlying Writes (one for the header, one for the body). Buffering
+// folds them into a single payload runWriter (or directControlReply) can ship
+// with one conn.Write — the unit of atomicity at the WS framing layer.
+func (s *Server) readClientData(conn net.Conn, controlReply func([]byte) error) ([]byte, gobwas.OpCode, error) {
+	controlHandler := func(hdr gobwas.Header, src io.Reader) error {
+		var buf bytes.Buffer
+		h := wsutil.ControlHandler{
+			Src: src,
+			Dst: &buf,
+			// src is the enclosing wsutil.Reader which already unmasks the
+			// frame payload as it Reads. ControlHandler's own cipher reader
+			// would XOR a second time and corrupt the bytes — match the
+			// invariant wsutil.ControlFrameHandler relies on.
+			DisableSrcCiphering: true,
+			State:               gobwas.StateServerSide,
+		}
+		handleErr := h.Handle(hdr)
+		// Always attempt delivery if any reply bytes were assembled. HandleClose
+		// returns a wsutil.ClosedError after the echo write succeeds, and the
+		// internal protocol-error path returns its error after writing a Close
+		// frame — in both cases the bytes still belong on the wire.
+		if buf.Len() > 0 {
+			reply := append([]byte(nil), buf.Bytes()...)
+			if err := controlReply(reply); err != nil && handleErr == nil {
+				handleErr = err
+			}
+		}
+		return handleErr
+	}
 	rd := wsutil.Reader{
 		Source:          conn,
 		State:           gobwas.StateServerSide,
@@ -1338,6 +1409,21 @@ func (s *Server) readClientData(conn net.Conn) ([]byte, gobwas.OpCode, error) {
 		}
 		payload, err := io.ReadAll(&rd)
 		return payload, hdr.OpCode, err
+	}
+}
+
+// directControlReply is the pre-handshake reply path. Writes the fully-assembled
+// control frame straight to conn after re-arming the write deadline. Socket
+// write deadlines are absolute and are never cleared after a successful write,
+// so an idle handshake conn's reactive PONG would otherwise inherit a stale,
+// expired deadline and fail instantly with i/o timeout. Used only before a
+// providerSession (and its runWriter) exists; once registerProviderSession has
+// started runWriter the post-handshake reply path is session.enqueueRaw.
+func (s *Server) directControlReply(conn net.Conn) func([]byte) error {
+	return func(frame []byte) error {
+		s.setWriteDeadline(conn)
+		_, err := conn.Write(frame)
+		return err
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the concurrent-writer hazard on provider WS conns that PR #104's deadline-refresh fix surfaced but didn't fully resolve. `runWriter` is now the **sole goroutine** writing WS frames to a provider conn after handshake; reactive PONG/Close replies and server-initiated Close frames funnel through `writeCh` as pre-baked raw frames instead of racing it on the wire.

- **Hazard.** `wsutil.WriteServerText` / `gobwas.WriteFrame` each issue **two** underlying `conn.Write` calls (header, then payload). Before this PR, runWriter and the read goroutine (via gobwas's `ControlHandler.HandlePing`/`HandleClose`) both wrote directly to the same conn. A PONG arriving between runWriter's header and payload writes interleaves at the WS framing boundary — invisible to `-race` (because `net.TCPConn.Write` is internally locked) and surfaces as parser failures on the receiving side. Additional racing paths: admin-reject Close (`admin_endpoints.go`), and the two `json.Marshal` failure paths in `handleV1Conn`/`handleV2Conn` after `registerProviderSession`.
- **Fix (Option 2 — single-writer ownership).** `writeCh` now carries `providerFrame{raw, payload}`; runWriter dispatches text → `wsutil.WriteServerText`, raw → one `conn.Write` of pre-baked bytes. `readClientData` takes a `controlReply func([]byte) error`; the post-handshake path passes `session.enqueueRaw`, pre-handshake passes `directControlReply(conn)` (replaces `deadlineRefreshingWriter` and preserves its deadline-refresh semantics — `TestProviderControlPongSurvivesStaleWriteDeadline` still passes). The control handler captures gobwas's PONG/Close-echo bytes into a `bytes.Buffer` (with `DisableSrcCiphering: true`, matching the contract `wsutil.ControlFrameHandler` relies on with `wsutil.Reader`) and hands the assembled frame to `controlReply`. New `s.closeSession(session, code, reason)` enqueues a Close frame + schedules `conn.Close` after a 100ms drain; replaces the three post-runWriter direct-Close sites (admin reject; v1/v2 ack-marshal failure).
- **Regression test (`relay_writer_serialize_test.go`).** 200 concurrent text sends + 200 inbound client PINGs over `net.Pipe`. Parses every wire frame with `gobwas.ReadFrame`; asserts no parse errors, expected counts, send-order preservation for text, exactly-once PONG echo per PING. Has teeth: a temporary regression shim that forced the old direct-write path failed the test 5/5 with `unexpected opcode 8 (OpClose)` parsed out of garbage bytes (the framing-corruption signature).

## Test plan

- [x] `go test ./internal/ws/ -race -count=1 -timeout 300s` → ok 11.0s (entire ws suite, including PR #104's `TestProviderControlPongSurvivesStaleWriteDeadline`)
- [x] New regression test under `-race -count=30` → ok
- [x] `go vet ./...` / `go build ./...` clean module-wide
- [x] Teeth-check: regression shim forcing the old direct-write path → 5/5 failures with `unexpected opcode 8` (framing corruption)
- [ ] Stage soak / live-fire — gated on operator heads-up per the live-fire convention
