### PR TITLE
fix(beta): capture HTTP status + error into sweep_runs.notes

### DIFF
--- a/beta/sweep.py
+++ b/beta/sweep.py
@@ -201,11 +201,14 @@ def aggregate_cell(
     total_completion_tokens = 0
     prompt_tokens_list: list[int] = []
     any_leak = False
+    error_pairs: dict[tuple[Any, str], str] = {}
 
     for r in results:
         is_err = bool(r.get("error")) or (r.get("http_status") is not None and r["http_status"] != 200)
         if is_err:
             n_err += 1
+            err_str = r.get("error") or f"HTTP {r.get('http_status')}"
+            error_pairs.setdefault((r.get("http_status"), err_str[:80]), err_str)
         else:
             n_ok += 1
             if r.get("ttft_ms") is not None:
@@ -233,6 +236,12 @@ def aggregate_cell(
         int(statistics.median(prompt_tokens_list)) if prompt_tokens_list else None
     )
 
+    notes: str | None = None
+    if error_pairs:
+        notes = " | ".join(list(error_pairs.values())[:3])
+        if len(notes) > 200:
+            notes = notes[:197] + "..."
+
     feasible = (
         n_err == 0
         and (ttft_p95_ms is not None and ttft_p95_ms <= gate_ttft_ms)
@@ -246,6 +255,7 @@ def aggregate_cell(
         "ttft_p95_ms": ttft_p95_ms,
         "measured_prompt_tokens": measured_prompt_tokens,
         "feasible": int(feasible),
+        "notes": notes,
     }
 
 
@@ -436,7 +446,7 @@ def main() -> int:
                 "n_ok": agg["n_ok"],
                 "n_err": agg["n_err"],
                 "feasible": agg["feasible"],
-                "notes": None,
+                "notes": agg["notes"],
             }
             write_cell_row(conn, row)
 


### PR DESCRIPTION
## Problem

When a sweep cell fails, `sweep_runs` records `n_err > 0` but the `notes` column is NULL — the per-request HTTP status and error string already captured by `harness.fire_stream` are dropped on the floor in `aggregate_cell`. This caused a real misdiagnosis last week: a ctx=2000 failure through the production gateway was misread as a "gateway streaming read-idle timeout bug" when gateway-path timeouts are all 280–360s. The actual cause was almost certainly a transient `503 provider_unavailable` on a marginal single-slot provider, but the harness gave no way to confirm without re-running.

Base is `spike/provider-model-autotune` because that is where `beta/sweep.py` lives today; it is not yet on `main`.

## Fix

- In `aggregate_cell`, collect up to 3 distinct `(http_status, error[:80])` pairs while iterating per-request results, join them into a ~200-char summary, and expose it as `notes` (NULL when every request succeeds). The cell-row builder uses `agg["notes"]` instead of the hardcoded `None`. ≤20-line change; no schema migration needed (`notes` column already exists).

## Verification

Local smoke against `beta/mock_llm_server.py`.

100% error mock (per the verification plan in the task prompt) — `notes` populated:

```
context_target  n_err  notes
--------------  -----  ---------------------------------------------
1000            1      HTTP 500: {"error": "simulated server error"}
```

Green mock (0% errors) — `notes` stays NULL:

```
context_target  n_ok  n_err  notes
--------------  ----  -----  -----
1000            1     0
```

- `python3 -m py_compile beta/sweep.py beta/harness.py` — OK
- Sweep against erroring mock exits 1; sweep against green mock exits 0.
- No changes outside `beta/sweep.py`. `harness.py`, schema, and other phases untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)