### PR TITLE
spec(cli): SPEC-013 v0.3 — macprovider-cli autotune subcommand

### DIFF
--- a/specs/AUDIT_SPEC_013_PROMPT.md
+++ b/specs/AUDIT_SPEC_013_PROMPT.md
@@ -1,0 +1,872 @@
+# Audit prompt — SPEC-013 v0.1 (`macprovider-cli autotune` subcommand)
+
+Operator-paste prompt to audit SPEC-013 v0.1
+(`specs/SPEC-013-cli-autotune.md`).
+
+**Cross-model pattern:** SPEC-013 v0.1 was drafted by Claude (Opus)
+on 2026-06-18. For independence, the audit runs in **Codex CLI
+first**. After Codex round 1 lands, an optional round 2 in Claude
+may be appended; both audit reports go into `specs/SPEC-013-audit.md`
+as separate sections, matching the SPEC-010 / SPEC-011 audit history
+pattern.
+
+**Expected duration:** ~30–45 min for Codex. SPEC-013 is operator-
+facing CLI surface only — no wire protocol changes, no coordinator
+behavior changes, no money-path. The audit's highest-leverage
+checks are (i) the two-stage pipeline correctness (FR-A → FR-B), (ii)
+the knob-axis claims against the actual PR #105 mlx-swift wiring,
+(iii) the back-compat-with-prototype migration note. The locked
+product framing in §1 is out of scope — see Critical constraint 1.
+
+**Trigger context:** PR #103 (Python prototype, branch
+`spike/provider-model-autotune`) hill-climbed over a cartesian
+`(model × ctx × kv-bits × max-batch)` max-tps objective, which
+under the v1 product framing is the wrong objective — it would push
+every capable Mac to serve the smallest model in the candidate list,
+destroying the network value SPEC-013 §1 names. PR #105 (merged) is
+the foundation: it exposes `--kv-bits`, `--max-context`,
+`--max-batch` on `macprovider-cli serve`. SPEC-013 v1 wraps those
+flags with the two-stage **largest-first-feasibility → in-model
+knob hill-climb** pipeline that encodes the network's "use this
+Mac's capacity to maximum useful capability" strategy.
+
+Paste everything between `=== BEGIN PROMPT ===` and `=== END PROMPT ===`
+into a fresh Codex CLI session rooted at `/Users/augstar/macprovider-poc`.
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are auditing SPEC-013 v0.1, the `macprovider-cli autotune`
+subcommand spec at /Users/augstar/macprovider-poc/specs/SPEC-013-cli-autotune.md.
+
+You are NOT here to validate, rewrite, or extend the spec. Find
+problems, report them with specific severity and location, and let
+the operator decide fixes. The operator has read the spec; they want
+an independent second opinion on what is missing, wrong, or under-
+specified before any implementation work starts.
+
+Output:
+  /Users/augstar/macprovider-poc/specs/SPEC-013-audit.md
+
+Format: structured audit report. Findings grouped by category below,
+each finding tagged with severity (CRITICAL / MAJOR / MINOR / QUESTION)
+and location (section number + line range when possible). Match the
+rigor and tone of prior audit reports in this repo
+(specs/SPEC-010-audit.md, specs/SPEC-011-audit.md,
+specs/SPEC-004-smart-router.md audit pattern).
+
+## Severity definitions
+
+- **CRITICAL** — would cause production failure on rollout, silent
+  regression of locked spec behavior, scope creep into a locked
+  upstream spec (SPEC-001 v1.4, SPEC-002 v1.3.5, SPEC-003 v0.9.2,
+  SPEC-010 v1.5, SPEC-011 v0.5), security regression (operator
+  config corrupted by `--apply`, candidate provider leaks into the
+  coordinator pool, recipe replay vulnerability), or violation of
+  the product framing in §1 (the "biggest-fit, not max-tps"
+  objective is LOCKED per the originating prompt).
+
+- **MAJOR** — would cause significant implementer confusion,
+  predictable v0.2 patch within first month of v1 rollout,
+  unjustified numeric thresholds (other than the four OQ-flagged
+  ones), ambiguous failure semantics, knob-axis claims that don't
+  match the actual PR #105 mlx-swift wiring, JSON schema gaps that
+  break `console.streamvc.live` ingestion, or contract precision
+  gaps that an implementer would hit on day one.
+
+- **MINOR** — quality issues that don't block v0.1 but should be
+  cleaned in v0.2. Naming inconsistencies, missing cross-references,
+  edge cases that won't fire frequently, prose drift inside an
+  otherwise-precise FR.
+
+- **QUESTION** — genuinely unresolved design choices the spec
+  couldn't decide alone. Distinguish from the §9 OQs the spec
+  already names — those are not findings unless they hide a
+  CRITICAL / MAJOR underneath (e.g. the OQ is actually a
+  load-bearing decision the v1 cannot defer).
+
+## Critical constraints to honor while auditing
+
+**1. The "biggest-fit, not max-tps" product framing in §1 is
+LOCKED.** This is the operator's product decision (see the
+originating prompt at `.omc/prompts/spec-cli-autotune-v1.md`,
+which states "Don't relitigate the 'max-tps vs biggest-fit'
+debate; it's settled"). Findings that recommend reverting to a
+cross-model throughput-maximization objective are REJECTED.
+What IS in scope: findings that the two-stage pipeline (§3) does
+not faithfully implement the biggest-fit objective, or that it
+admits an interpretation under which max-tps wins. Either of those
+is CRITICAL.
+
+**2. SPEC-001 v1.4, SPEC-002 v1.3.5, SPEC-003 v0.9.2, SPEC-010
+v1.5, SPEC-011 v0.5 are LOCKED.** Any SPEC-013 clause that
+requires a normative edit to one of these locked specs is a
+CRITICAL finding ("scope creep across spec boundary"). v0.1
+explicitly does NOT propose any normative edit to a locked spec;
+the implementing PR may add a sibling subcommand (`models pull
+<id>`, FR-D.1) and a `--no-join` flag (FR-E.2), but these are
+implementation preconditions, not normative edits to existing
+specs.
+
+**3. SPEC-only, no code.** SPEC-013 v0.1 must NOT contain
+implementation code, test code, or coordinator/binary diffs. If
+audit finds embedded code that goes beyond illustrative wire shapes
+or schema definitions (FR-F.2 JSON, FR-G SQL), flag as MAJOR
+(scope drift). The CLI surface in §7 is reference, not normative
+— §5 FRs are the binding semantics.
+
+**4. Additive only / Tier-1 backward compat.** With autotune
+unused, every provider's behavior is byte-identical to pre-SPEC-013.
+The PR #105 serving knobs were already merged; SPEC-013 wraps them.
+If any clause silently changes `macprovider-cli serve` default
+behavior (e.g. mutating the binary's HF-offline default, changing
+the default kv-bits, modifying the coordinator-join path outside
+the `--no-join` opt-in) = CRITICAL.
+
+**5. The product strategy says "candidate list is ordered,
+largest-first by weight footprint" — that ordering is the
+CONTRACT, not a heuristic.** If §5.1 FR-A.1 / FR-A.2 leave room
+for the implementation to internally re-rank by predicted
+feasibility (e.g. "we know 32B won't fit on this Mac, let's
+skip it"), the biggest-fit guarantee is broken because the
+implementation is now making a feasibility prediction the
+operator didn't authorize. Re-ranking would also make the
+recommendation non-deterministic across hardware tiers. If FR-A
+leaves this open = CRITICAL.
+
+**6. The default candidate list in §5.3 FR-C.1 is curated by the
+network**, intentionally — listing 32B at position 1 even though
+most operators' Macs will reject it. The feasibility gate's job is
+to reject 32B cleanly so the iteration reaches the largest model
+that fits. If the audit recommends trimming the default list to
+fit a "median operator" (e.g. starting at 14B), that's a
+MISINTERPRETATION of the product framing — flag as QUESTION not
+finding, and the operator decides.
+
+**7. Knob-axis claims must match PR #105 reality.** PR #105
+landed three serve flags: `--kv-bits {4,8}` (mapping to
+`MLXLMCommon.GenerateParameters.kvBits`), `--max-context <N>`
+(mapping to `GenerateParameters.maxKVSize` + 413 prompt-too-long
+gate), `--max-batch <N>` (mapping to `AsyncSemaphore(value: maxBatch)`,
+default 1). If SPEC-013 §5.2 FR-B.1 claims an axis value PR #105
+doesn't actually accept (e.g. `--kv-bits 6`), or claims a default
+PR #105 doesn't have, or claims a wiring site that doesn't exist
+= MAJOR per discrepancy.
+
+**8. Clean-room boundary.** Do NOT inspect d-inference
+(layr-labs) source. NOASSERTION license. Any SPEC-013 clause that
+appears to require d-inference inspection is a CRITICAL finding.
+(SPEC-013 v0.1 is not expected to reference d-inference at all;
+flag any such reference as CRITICAL.)
+
+**9. Telemetry / privacy invariant.** NFR-4 states "Nothing leaves
+the machine" in v1, no opt-in/opt-out. If any clause elsewhere
+(JSON ingestion via `console.streamvc.live`, recipe_hash sharing,
+coordinator-side comparison in v2 references, telemetry-adjacent
+log fields) silently violates this = CRITICAL. The recipe_hash
+emission to a local file is fine; auto-upload of any kind is not.
+
+## Required reading (in order, fully)
+
+1. `/Users/augstar/macprovider-poc/specs/SPEC-013-cli-autotune.md`
+   v0.1 — the spec under audit. Read all 13 sections and all 16 ACs
+   fully. Bias toward reading §3 (architecture), §5 (FRs), and §8
+   (ACs) most carefully — these are the binding surface. §10
+   (implementation note) and §12 (migration from prototype) are
+   informational; audit them as "do these correctly describe what
+   the v1 implementer will face?" not as binding contracts.
+
+2. `/Users/augstar/macprovider-poc/.omc/prompts/spec-cli-autotune-v1.md`
+   — the ORIGINATING prompt that commissioned SPEC-013 v0.1. This
+   is the source-of-truth for what the operator asked for. The
+   biggest-fit objective, the FR-A through FR-H breakdown, the
+   four OQs, and the "what the spec must NOT do" list all come
+   from this prompt. If SPEC-013 v0.1 contradicts the originating
+   prompt or omits a required FR, that is a CRITICAL coverage gap
+   (the spec was commissioned with a specific FR list and a
+   missing FR is a contract violation).
+
+3. `/Users/augstar/macprovider-poc/CLAUDE.md` and
+   `/Users/augstar/macprovider-poc/AGENTS.md` — project conventions,
+   especially the PR workflow rule, the Augustas11 git identity
+   rule, and the spec naming pattern.
+
+4. `/Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md`
+   v1.4 — focus on:
+   - The `ServeCommand` CLI flag set (PR #105 additions:
+     `--kv-bits`, `--max-context`, `--max-batch`). SPEC-013 §5.2
+     FR-B.1 must align with what PR #105 actually accepts.
+   - The `--no-join` flag — does it exist in SPEC-001 v1.4? If not,
+     SPEC-013 §5.5 FR-E.2 names it as an implementation
+     precondition, and the audit should confirm whether v1.4
+     ships it or whether SPEC-013 is implicitly proposing a
+     SPEC-001 v1.5 candidate.
+   - `/v1/models` response shape — SPEC-013's "wait for ready"
+     polls this endpoint (FR-A.2 step 4).
+   - HF offline-mode default — SPEC-013 §5.4 FR-D.1 picks
+     `models pull <id>` over a "temporary online mode" because
+     of this default. If v1.4 doesn't actually run HF offline by
+     default, the rationale in FR-D.1 is wrong = MAJOR.
+
+5. `/Users/augstar/macprovider-poc/specs/SPEC-002-coordinator.md`
+   v1.3.5 — focus on:
+   - The provider WS auth path. SPEC-013 v0.1 claims "no
+     coordinator-side change required." Verify by walking the auth
+     flow: if `--no-join` semantics actually need a coordinator-
+     side opt-out (vs. just provider-side abstention from WS
+     connect), the claim is wrong = MAJOR.
+   - Pool registration timing — when does a provider appear in
+     `seenModels` / the routable pool? If a candidate provider
+     could leak into the pool during the `wait-for-ready` window
+     even with `--no-join`, that's a buyer-traffic exposure =
+     CRITICAL.
+
+6. `/Users/augstar/macprovider-poc/specs/SPEC-003-open-onboarding.md`
+   v0.9.2 — focus on:
+   - `~/.config/macprovider/config.yaml` shape. SPEC-013 §5.6
+     FR-F.3 `--apply` modifies this file; the audit must verify
+     the YAML key names SPEC-013 names (`model`, `kv_bits`,
+     `max_context_tokens`, `max_batch`) actually match the
+     SPEC-003 config schema. If any key name is wrong = MAJOR.
+   - Install / launchd interaction. SPEC-013 §5.6 FR-F.3 says
+     `--apply` does NOT restart launchd — does this match the
+     SPEC-003 install pattern? If SPEC-003 expects autotune to
+     restart launchd and SPEC-013 punts to the operator, flag as
+     QUESTION (operator decides).
+
+7. `/Users/augstar/macprovider-poc/specs/SPEC-010-model-catalog.md`
+   v1.5 — focus on:
+   - Model id semantics (NFC + ASCII case-fold for equality).
+     SPEC-013 §5.1 FR-A.2 inherits this — verify the inheritance
+     is correctly cited and would not be broken by autotune's
+     pick (e.g. if autotune prints the operator's input string
+     instead of the canonical form, that's an interop drift) =
+     MAJOR.
+   - `supported_models[]` shape — SPEC-013 doesn't directly emit
+     this, but the FR-F.2 JSON recommendation eventually feeds
+     into the operator's config, which feeds into SPEC-010's
+     auth-request frame. If there's a path under which autotune's
+     recommendation silently violates SPEC-010 id rules = MAJOR.
+
+8. `/Users/augstar/macprovider-poc/specs/SPEC-011-operator-pushed-warm-swap.md`
+   v0.5 — focus on:
+   - Warm-swap opt-in semantics. SPEC-013 v1 explicitly stays out
+     of warm-swap (§11 deferral). Verify §3 architecture and §5.5
+     FR-E.1 `--drain` correctly stay on the non-warm-swap
+     "process-restart" model. If `--drain` accidentally invokes
+     warm-swap when `--enable-warm-swap=true` is set on the live
+     provider = QUESTION (operator decides interaction).
+   - `--enable-warm-swap` default (false). Confirm SPEC-013 v1
+     does not require this to be true.
+   - Successor SPEC numbering: SPEC-011 §8 informally reserved
+     "SPEC-013 (future)" for a recommended-catalog feature.
+     SPEC-013 v0.1 picks SPEC-013 for autotune and defers the
+     recommended-catalog to "provisionally SPEC-014" (§11). Is
+     the renumber clean, or does any locked spec reference
+     SPEC-013 with a meaning that contradicts this audit's
+     subject? Grep specs/ for "SPEC-013" mentions outside the
+     SPEC-013 file itself.
+
+9. PR #105 (`feat(provider): expose --kv-bits / --max-context /
+   --max-batch serve knobs for autoresearch`, merged commit
+   46d2f1e) — read via `gh pr view 105` or by reading the merged
+   diff. Focus on:
+   - The wiring table in the PR description (mapping flag →
+     mlx-swift call site). Verify SPEC-013 §5.2 FR-B.1 axis
+     specifications are consistent.
+   - The `ServingKnobsConfigTests.swift` test list — these are
+     the actual contract surface. SPEC-013 ACs should not
+     contradict what these tests already prove.
+
+10. PR #103 (`spike: provider-side model-selection autotune loop
+    (autoresearch)`, branch `spike/provider-model-autotune`,
+    DRAFT) — read `beta/autotune.py` from that branch. Focus on:
+    - The cartesian max-tps objective (the thing SPEC-013 §12
+      rejects). Verify §12's account of "what survives / what
+      changes" is accurate.
+    - The `_is_new_best` function and its `TPS_TIE_EPSILON`
+      constant. SPEC-013 §5.2 FR-B.2 reuses these semantics
+      verbatim — verify the reuse is faithful and didn't
+      accidentally re-spec different semantics.
+    - The `tune_trials` SQL schema. SPEC-013 §5.7 FR-G.1 carries
+      this over with one additive `stage` column — verify the
+      schema match is exact (column types, indexes, additive
+      columns from the prototype's `_ADDITIVE_TUNE_COLUMNS`).
+    - The provider-lifecycle pattern (pkill + port-poll +
+      `start_new_session=True`). SPEC-013 §3 inherits this; verify
+      no detail is silently dropped.
+
+11. Code spot-checks (for cross-checking §5 FRs against reality):
+    - `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+      — the `ServeCommand` flag set (PR #105 additions). Confirm
+      `--kv-bits`, `--max-context`, `--max-batch` are present
+      with the documented defaults.
+    - `phase3-binary/Sources/MacProviderCore/Config.swift` — the
+      config YAML key names (`kv_bits`, `max_context_tokens`,
+      `max_batch`, `model`). SPEC-013 §5.6 FR-F.3 lists these as
+      the four owned keys; spot-check the spelling.
+    - `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+      — the `kvBits`, `maxKVSize`, semaphore-based batch gate.
+      Verify SPEC-013 §5.2 FR-B.1's axis claims align.
+    - `phase4-coordinator/internal/ws/server.go` — the
+      `handleConn` / `handleV2Conn` auth flow for the
+      `--no-join` claim in FR-E.2 (does a provider that simply
+      does NOT open the WS connect leave the coordinator side
+      truly inert, or is there some side effect?).
+
+12. `/Users/augstar/macprovider-poc/specs/SPEC-010-audit.md` and
+    `/Users/augstar/macprovider-poc/specs/SPEC-011-audit.md` —
+    for tone, severity-bar continuity, and "what does a
+    code-grounding pass actually look like."
+
+## Audit categories — work through each
+
+### Category A: Product framing preservation (HIGHEST PRIORITY)
+
+A.1  Walk §1 (Mission) and §3 (Architecture). Confirm the two-stage
+     pipeline FAITHFULLY implements "biggest-fit, not max-tps."
+     Critical question: is there ANY path through FR-A + FR-B
+     under which a smaller model could be recommended over a
+     larger feasible model? If yes = CRITICAL.
+
+A.2  FR-A.1 says the candidate list ORDERING is the contract.
+     Confirm FR-A.2 step 7 ("If feasible: this is the chosen
+     model. STOP iterating models.") is unambiguous. If FR-A.2
+     leaves room for the implementation to internally re-rank
+     by feasibility prediction (per Critical constraint 5) =
+     CRITICAL.
+
+A.3  FR-B is in-model knob hill-climb. Confirm Stage 2 cannot
+     produce a recommendation for a DIFFERENT model than Stage 1
+     chose. If FR-B.1's optional max-context axis could trigger
+     a re-evaluation that swaps the chosen model (e.g. because
+     a wider max-context cell fits 3B at higher tps than 7B at
+     target) = CRITICAL.
+
+A.4  FR-F.1 RECOMMENDATION block: confirm the operator-visible
+     output unambiguously names the biggest-fit model. Fallbacks
+     are smaller models; verify §5.6 doesn't accidentally invert
+     the framing by sorting fallbacks tps-descending instead of
+     size-descending = MAJOR.
+
+A.5  Defaults bias check. The four OQ-flagged defaults
+     (TPS_TIE_EPSILON, stage1/2_replicates, kv-bits axis) are
+     OK to flag. But other defaults (gate_ttft_ms = 60000,
+     candidate list ordering, --no-join always-on, --apply
+     opt-in) MUST be load-bearing for the biggest-fit framing.
+     If any default silently weakens the framing = MAJOR.
+
+### Category B: Two-stage pipeline correctness
+
+B.1  FR-A.2 step 3: Stage 1 probes at DEFAULT knobs (kv-bits
+     unset, max-batch=1). Verify this is the cheapest probe
+     that meaningfully predicts Stage 2 feasibility. If Stage 1's
+     defaults could declare a model feasible that Stage 2 then
+     proves infeasible at every cell, the loop ends with no
+     recommendation despite Stage 1 saying yes = MAJOR (the
+     biggest-fit guarantee is now conditional on Stage 2's knobs,
+     which violates "Stage 1 = fit decision, Stage 2 =
+     optimization within fit").
+
+B.2  FR-A.3 feasibility criteria: confirm the four conditions
+     (HTTP 2xx, TTFT ≤ gate, no stop-token leak, no process
+     exit) are individually testable and collectively exhaustive.
+     If any failure mode the prototype handles (e.g. "model
+     loads but returns garbage tokens") isn't covered by these
+     four = MAJOR.
+
+B.3  FR-B.1 axis sizing: kv-bits cells = `{4, 8, unset}` = 3,
+     max-batch cells = `{1, 2}` = 2, optional max-context axis
+     defaulting to 1 cell. Cartesian = 6 cells minimum. At
+     stage2_replicates=3 + ~1-5min model load per cell, the NFR-1
+     wall-clock estimates need to actually fit. Walk the
+     arithmetic. If the NFR-1 table overstates feasibility (the
+     32GB tier claims ~30 min for Stage 2 but 6 cells × 3
+     replicates × 14B-loaded-time exceeds it) = MAJOR (operator
+     will be surprised).
+
+B.4  FR-B.2 _is_new_best semantics: verify the prose matches the
+     prototype's `_is_new_best` in `beta/autotune.py`. Note: the
+     prototype's tie band is symmetric (`abs(rel_gap) <=
+     TPS_TIE_EPSILON`); SPEC-013's prose says "throughput
+     primary, TTFT tiebreak WITHIN TPS_TIE_EPSILON." If the
+     spec's prose admits an interpretation where tps > best *
+     (1 + ε) but TTFT-better-than-best still wins, the rule is
+     ambiguous = MAJOR.
+
+B.5  Stage 2 "max-context axis is OPTIONAL in v1; the recommended
+     max_context equals --target-context unless the operator
+     opted into the axis." Confirm the operator's path to opt in
+     is documented. If §7 lists `--max-context-axis` but FR-B
+     doesn't say what cells the operator should pass, the
+     default-cell case is the only practical path = MINOR (most
+     operators will accept the default; the axis is escape-hatch
+     only).
+
+### Category C: Knob-axis correctness vs PR #105
+
+C.1  FR-B.1 kv-bits axis: PR #105 accepts `{4, 8}` per the
+     description, with unset meaning "no KV-cache quantization"
+     (mlx-swift's default unquantized). Verify SPEC-013 §5.2
+     FR-B.1's "plus the unset-default as an explicit third cell"
+     is implementable: can the autotune subcommand express
+     "no flag passed" to `serve` as a discrete cell, or does the
+     binary's flag parser collapse no-flag to a sentinel?
+     Read PR #105's `Config.swift` / `MacProviderCLI.swift`
+     diffs and confirm. If unset-as-cell is not expressible =
+     MAJOR (recommendation can't include the unquantized
+     baseline).
+
+C.2  FR-B.1 max-batch axis: PR #105 default is 1 with a runtime
+     bug fix folded in (`maxConcurrencyOverride: 1` was hardcoded;
+     now reflects the resolved config). Verify SPEC-013's
+     `--max-batch-axis 1,2` actually exercises the fix. If the
+     prior bug means `max-batch=2` silently behaves as 1 = MAJOR
+     (Stage 2 would never discriminate).
+
+C.3  FR-B.1 max-context: SPEC-013 says the axis defaults to a
+     single value (target context itself) and the operator MAY
+     opt in. Verify PR #105's max-context semantics:
+     `--max-context N` sets `maxKVSize=N` AND triggers the 413
+     prompt-too-long gate at N. If the autotune is firing at
+     target context = N and the gate fires at the boundary,
+     measurement results may be artificially degraded by the
+     gate's behavior. If FR-B.1 doesn't account for this = MAJOR.
+
+C.4  Knob-axis defaults that SPEC-013 picks. v0.1 picks 6-cell
+     Stage 2 (3 × 2 × 1) as the default. Is this the right
+     default given the air5 empirical findings cited in §1 of
+     the originating prompt? The originating prompt notes
+     "max-batch > 1 never helped" and "kv-bits=8 outperformed
+     kv-bits=4 on every model." If the default is too aggressive
+     (operators on 8GB Macs running 6 cells × 3 replicates on
+     1B/3B are sitting through unnecessary cells), QUESTION
+     (operator decides defaults). If the default is too
+     conservative (e.g. should be 4 cells skipping the kv-bits=4
+     case that consistently loses), flag as such.
+
+### Category D: Pre-download integration (FR-D)
+
+D.1  FR-D.1 picks `macprovider-cli models pull <id>` (option a).
+     Verify the rationale is sound:
+       (i) "macprovider-cli runs HF Hub in OFFLINE mode
+           internally" — confirm by spot-checking
+           ModelRuntime.swift HF resolution. If the binary
+           actually runs HF in online mode (or operator-
+           configurable), the FR-D.1 rationale is wrong =
+           MAJOR (the spec is solving a non-problem).
+      (ii) The `models pull` subcommand is named as an
+           implementation precondition. If it doesn't exist in
+           SPEC-001 v1.4, SPEC-013 v1 implicitly depends on
+           shipping it. Is the "ships alongside" plan in §5.4
+           FR-D.1 realistic (one-screen subcommand) or
+           understated = MINOR / MAJOR depending on size.
+
+D.2  FR-D.2 pre-download failure advances. Verify the failure
+     classification is correct: network failures (transient)
+     should advance to the next candidate; signature-mismatch
+     failures (security-relevant) should arguably abort the
+     entire run, not advance. If FR-D.2 collapses both =
+     QUESTION (operator decides).
+
+D.3  Bandwidth / disk caps. Pre-downloading a 32B-4bit (~17 GB)
+     candidate that will then be rejected by Stage 1 wastes a
+     lot of bandwidth on operators with limited connections.
+     Is there a `--no-prefetch-largest-N` escape? §5.3 FR-C.2
+     gives `--max-model-size`, which is sufficient — but the
+     spec doesn't connect the dots. If operators are likely to
+     get burned by a full 32B download just to discover
+     infeasibility = MINOR (callout in §6 NFR or §5.3 prose).
+
+### Category E: Provider-conflict safety (FR-E)
+
+E.1  FR-E.1 pre-flight refusal: verify the PID detection method
+     is realistic. `pkill -f "macprovider-cli serve"` (prototype's
+     method) MAY match the autotune-spawned candidate itself if
+     the autotune process is also invoked via `macprovider-cli
+     autotune` (the parent name). If the autotune process's
+     command line could ALSO match the grep, the check is
+     wrong = MAJOR.
+
+E.2  FR-E.1 `--drain`: the drain semantics defer to SPEC-011
+     when warm-swap is enabled, otherwise a clean process stop.
+     Verify the SPEC-011 reference is correct (§3.4 drain
+     semantics) and that the drain on the launchd-managed
+     install path actually works (launchd may auto-restart the
+     binary if its KeepAlive is set). If `--drain` could trigger
+     a launchd respawn race that brings the serve back up
+     mid-tune = CRITICAL.
+
+E.3  FR-E.2 `--no-join` semantics: confirm the three sub-bullets
+     (no WS session, local /v1/* surfaces reachable, no
+     state_update on exit) are individually testable. Critical
+     question: does the binary's normal startup ALWAYS open a WS
+     session, or is `--no-join` already supported? Spot-check
+     `phase3-binary/Sources/macprovider-cli` for an existing flag.
+     If a `--no-join` flag exists with different semantics from
+     what SPEC-013 names = MAJOR (rename).
+
+E.4  Pool leakage window. Even with `--no-join`, is there any
+     coordinator-side side-channel by which a candidate provider
+     could be discovered (e.g. operator-token usage, audit-log
+     emissions, M-DNS-style discovery)? If yes = CRITICAL.
+
+### Category F: Recommendation surface (FR-F) + JSON schema + recipe_hash
+
+F.1  FR-F.1 terminal output: verify the seven required elements
+     (model id, knobs, target context, replicated median tps + p95
+     TTFT + replicate count, fallbacks, serve command line) are
+     individually testable. If the "exact serve command line" is
+     ambiguous (e.g. `--max-context` may or may not appear if it
+     defaults to target context), specify in §5.6.
+
+F.2  FR-F.2 JSON schema completeness:
+     - Does the schema include every field needed for v1
+       `console.streamvc.live` ingestion? If a field name is
+       wrong (e.g. `tps_median` vs `median_tps`), or a unit is
+       wrong (`ttft_p95_ms` is milliseconds; recipe_hash format
+       is "sha256:<32-byte-hex>" — but SHA-256 is 32 BYTES =
+       64 hex chars; spec says "32-byte-hex" which is ambiguous)
+       = MAJOR.
+     - Is the schema versioned (`spec_version: "SPEC-013 v0.1"`)?
+       Confirm v0.2+ additive fields would not break v1 readers.
+     - Is `recommendation: null` valid (no feasible) and is the
+       ingestion contract clear about it? AC-13 says yes for
+       budget-exhausted; FR-F.2 doesn't say explicitly = MINOR.
+
+F.3  recipe_hash determinism: AC-12 says same machine + same
+     recommendation → same hash; different machine → different
+     hash. Confirm the canonical-JSON form (used as the hash
+     input) is precisely defined. If two implementations could
+     emit different canonical JSON for the same recommendation
+     (key ordering, whitespace, number serialization) = MAJOR
+     (the hash is not reproducible across implementations).
+
+F.4  `--apply` safety (FR-F.3):
+     - Atomic write: temp-file + rename is named. Confirm the
+       lock semantics on the rename (POSIX rename is atomic;
+       on macOS the target may exist). If the prior config is
+       open by `serve` at the moment of rename, is the swap
+       safe = QUESTION.
+     - Backup naming: `.bak-<unix-ts>` could collide on the
+       same second if `--apply` runs twice fast. If collision
+       silently overwrites the prior backup = MINOR.
+     - Owned keys: verify the four listed keys (`model`,
+       `kv_bits`, `max_context_tokens`, `max_batch`) match
+       SPEC-003's config schema names exactly. Cross-check
+       `phase3-binary/Sources/MacProviderCore/Config.swift`. If
+       the YAML key is actually `max_context` not
+       `max_context_tokens`, the spec is wrong = MAJOR.
+
+### Category G: State / DB (FR-G)
+
+G.1  FR-G.1 `tune_trials` schema: verify exact match with
+     prototype's schema in `beta/autotune.py`. The additive
+     `stage` column claim says "ALTER TABLE ADD COLUMN stage"
+     for upgrades; confirm SQLite syntax (`ALTER TABLE ADD
+     COLUMN` only adds; doesn't allow NOT NULL without DEFAULT
+     on existing rows). If the spec says NOT NULL but the
+     ALTER would fail = MAJOR.
+
+G.2  FR-G.1 retention semantics: deleting rows where `run_id`
+     is not in the most recent N is OK but should be transactional
+     (otherwise an interrupted retention sweep could leave the DB
+     in a partial state). If §5.7 doesn't say "in a single
+     transaction" = MINOR.
+
+G.3  FR-G.2 `tune_runs` schema: verify completeness. Is there a
+     field for whether `--apply` was used? Yes, `applied INTEGER`.
+     Is there a field for the `--target-context`? Yes. Is there a
+     field for the `--candidate-models` list? Yes, JSON-encoded.
+     If any input that affects determinism is missing = MAJOR
+     (replay won't be reproducible).
+
+G.4  DB location: `~/.config/macprovider/autotune.sqlite`. Confirm
+     this matches SPEC-003 v0.9.2's config-dir convention. If
+     SPEC-003 puts state under a different path (e.g. `~/Library/
+     Application Support/macprovider/`), the spec is wrong =
+     MAJOR.
+
+### Category H: Failure modes (FR-H)
+
+H.1  FR-H.1 Ctrl-C: verify the post-condition list (no orphan
+     provider, port released, DB consistent) is enforceable in
+     both Option A (Swift task cancellation) and Option B (Python
+     signal.SIGINT). If the contract is met by the prototype but
+     not by an Option-A Swift implementation that uses async
+     tasks = QUESTION (operator picks but should know).
+
+H.2  FR-H.2 midway crash + `--resume`: v0.1 says "v0.1 default
+     behavior is full rerun" and defers `--resume` to v2. Is
+     "full rerun is safe and produces equivalent results"
+     actually true given the DB retention? If a crash leaves the
+     DB at retain-50 + 1 partial row, the next run pushes a fresh
+     `tune_runs` row and deletes the oldest — does the partial
+     row from the crash get carried into the next run's reports?
+     If yes = MINOR (operator could be confused).
+
+H.3  FR-H.3 network down during pre-download: see D.2 above.
+
+H.4  FR-H.4 all-infeasible exit: verify the "smallest-first
+     reason" claim is actually informative. On a hardware tier
+     where the smallest candidate (1B) is infeasible at
+     `--target-context 200000`, the reason might be "TTFT 95s >
+     gate 60s" — not maximally diagnostic for the operator. If
+     the spec doesn't say "the suggested remediation must include
+     a recommended lower --target-context" = MINOR.
+
+### Category I: Non-functional requirements
+
+I.1  NFR-1 wall-clock budget per RAM tier: see B.3 above. Walk
+     the arithmetic for each tier and confirm the totals fit the
+     `--max-duration 7200s` default. If the 32GB tier's actual
+     time exceeds 2 hours under realistic conditions (32B model
+     load is ~5 min, but loading WITH KV-cache-quantized variants
+     is more) = MAJOR.
+
+I.2  NFR-2 single-slot guarantee: verify FR-E.2's `--no-join` is
+     sufficient to ensure no buyer traffic during tuning. See
+     E.4.
+
+I.3  NFR-3 reversibility: verify the `.bak-<unix-ts>` claim
+     against F.4 backup-naming collision concern.
+
+I.4  NFR-4 telemetry / privacy: confirm "nothing leaves the
+     machine" actually holds. The `models pull <id>` step
+     ARGUABLY violates this — it makes outbound HTTPS to HF.
+     Spec acknowledges this exception ("except `models pull
+     <id>` to HuggingFace"). Confirm the carve-out is
+     well-understood and there isn't a hidden second egress
+     (e.g. mlx-swift logging, telemetry-adjacent HTTP that the
+     binary makes during load). If yes = CRITICAL.
+
+### Category J: ACs are deterministically verifiable
+
+J.1  Walk each of AC-1 through AC-16. For each, write down (in
+     the audit) the exact test setup and assertion that would
+     verify it. If you cannot do this in 3-5 lines, the AC is
+     ambiguous = MAJOR per ambiguous AC.
+
+J.2  Coverage gap check: walk every FR-A through FR-H sub-rule
+     and confirm at least one AC exercises it. Specifically check:
+     - FR-A.1 ordering-is-contract: AC-14 covers default list; is
+       any AC covering "operator's --candidate-models order is
+       honored verbatim, no internal re-rank"? If not = MAJOR.
+     - FR-B.1 max-context axis: is any AC covering the optional
+       axis path?
+     - FR-C.2 size-flag warning: AC-15 covers conflict; what
+       about `--max-model-size 16B` alone (no --candidate-models)?
+       If unchecked = MINOR.
+     - FR-D.2 advance on pre-download failure: AC-8 covers; OK.
+     - FR-E.1 launchd interaction: is any AC covering the
+       launchd-managed install path? If not = MAJOR (the most
+       common operator install per SPEC-003).
+     - FR-G.2 `tune_runs.exit_reason` values: AC-3, AC-10, AC-13
+       cover three values; AC-8 implies a fourth. Is the full
+       value enum spelled out? = MINOR.
+
+J.3  AC-9 atomic config write: the test asserts "either fully
+     old or fully new at every observation moment, never
+     half-written." Is this realistically testable on macOS
+     without an `flock` equivalent? If the AC is unverifiable in
+     practice = MAJOR.
+
+J.4  AC-12 recipe hash determinism: verify the test setup is
+     specified precisely enough. If the AC says "same machine"
+     but the machine fingerprint includes `binary_version`, a
+     binary upgrade between two runs would (correctly) produce
+     different hashes — but the AC's wording could be
+     misinterpreted as "any two runs on the same Mac." Clarify
+     = MINOR.
+
+### Category K: Open questions
+
+K.1  The four OQs in §9 (OQ-A through OQ-D) are flagged as
+     "pending the in-flight n=3 air5 replication run." Verify
+     each OQ:
+     - Names a specific placeholder value (yes for all 4)
+     - Has a measurable decision threshold (OQ-A names
+       "σ(tps)/μ(tps) > 0.02 vs < 0.005"; OQ-B is qualitative;
+       OQ-C names "wins on every model on every RAM tier within
+       TPS_TIE_EPSILON"; OQ-D is qualitative). If OQ-B and OQ-D
+       need quantitative thresholds = MINOR.
+     - The placeholder, if wrong, doesn't catastrophically
+       break v1. If a wrong OQ-A (TPS_TIE_EPSILON) value would
+       silently invert the FR-B.2 keep-best decision in 20% of
+       cases = MAJOR (the OQ is load-bearing and should not be
+       deferred).
+
+K.2  Are there OPEN QUESTIONS that SPEC-013 v0.1 should have
+     flagged but didn't? Examples to check:
+     - Behavior on partial RAM disclosure (some Macs return
+       wrong `ram_gb` to system APIs)
+     - Behavior under thermal throttling (Stage 2 cell N's tps
+       affected by Stage 2 cell N-1's heat soak)
+     - Behavior when `--target-context` exceeds the largest
+       candidate's `max_context_tokens` cap
+     If any of these is a load-bearing missing OQ = MAJOR.
+
+### Category L: Migration note correctness vs prototype
+
+L.1  §12 "What survives" list: walk each item against
+     `beta/autotune.py` on the `spike/provider-model-autotune`
+     branch. Verify each survives-item is in fact reusable as
+     described. If `_is_new_best` is described as "reused
+     unchanged" but the SPEC-013 v0.1 prose for FR-B.2 actually
+     contains a subtle re-spec = MAJOR (caught by category B.4).
+
+L.2  §12 "What changes" list: confirm the rejected items are
+     accurately described. The objective, the candidate list,
+     the coordinator-join, the DB location, the recommendation
+     surface — all named as changes. If any "change" is described
+     but the prototype actually already had that behavior =
+     MINOR (the prototype gives more for free than the spec
+     claims).
+
+L.3  §12 "What is provisional" tied to OQ-A through OQ-D —
+     confirm the cross-reference is complete.
+
+L.4  Branch posture: §12 says "the prototype branch MUST NOT be
+     merged as-is." Verify the implementing PR for SPEC-013 v1
+     would replace or rebase that branch. If the spec is silent
+     on which option (A) Swift-native or (B) wrap Python takes
+     this disposition, §10 says the implementing PR makes the
+     call — OK. Note the open implementation choice in the audit
+     summary.
+
+### Category M: Anything else (operator UX, docs drift, etc.)
+
+M.1  Documentation drift. If SPEC-013 v1 ships, what else needs
+     to be updated? Examples:
+     - SPEC-003 install flow may want to mention autotune as
+       "what to run after install"
+     - `beta/DECISION_CRITERIA.md` should get a SPEC-013-lock
+       entry
+     - `specs/README.md` index gets the SPEC-013 row (verify it
+       was added)
+     - PR #103 (the prototype) should be closed or repurposed
+       once SPEC-013 lands
+     If the spec doesn't mention these = MINOR.
+
+M.2  Spec numbering: SPEC-011 §8 informally reserved SPEC-013 for
+     a "Recommended catalog (`GET /v1/recommended-catalog`)
+     future" feature. SPEC-013 v0.1 takes SPEC-013 for autotune
+     and defers the recommended-catalog to "provisionally
+     SPEC-014" (§11). Is this renumber clean? Verify by:
+       - `grep -rn "SPEC-013" specs/` — every reference should
+         resolve to autotune semantics under v0.1
+       - Confirm SPEC-014 is not already in use
+     If a locked spec references SPEC-013 with the
+     recommended-catalog meaning, the renumber needs a
+     companion-spec annotation = MINOR.
+
+M.3  Operator-facing examples in §4 (User stories): verify the
+     example serve commands match the actual binary's flag names.
+     If the example uses `--max-context 4000` but the binary
+     uses `--max-context-tokens 4000` = MAJOR.
+
+M.4  Anything else the operator should know about that doesn't
+     fit A-L.
+
+## Output structure
+
+Write to `/Users/augstar/macprovider-poc/specs/SPEC-013-audit.md`.
+Top-of-file frontmatter:
+
+```
+# SPEC-013 v0.1 — Audit Report
+
+**Audited:** SPEC-013 v0.1 (specs/SPEC-013-cli-autotune.md)
+**Auditor model:** [Codex / GPT-5 / etc.]
+**Audit round:** 1 of N
+**Date:** 2026-06-18
+**Total findings:** [N CRITICAL / N MAJOR / N MINOR / N QUESTION]
+
+---
+
+## Executive summary
+
+[2-4 paragraphs. State whether SPEC-013 v0.1 is ready to lock as
+drafted, ready with the CRITICAL findings addressed, or needs
+structural revision. Be specific about what the operator should
+do next.]
+```
+
+Then for each category A-M, write a section. For each finding:
+
+```
+### A.2  [SHORT TITLE]   [CRITICAL | MAJOR | MINOR | QUESTION]
+Location: §5.1 FR-A.2, line ~XXX-YYY
+
+[What the spec says or fails to say. 1-3 sentences.]
+
+[Why it matters. 1-3 sentences. Reference a concrete failure
+scenario or a specific reader confusion.]
+
+[Recommendation. 1-2 sentences. What v0.2 should do — but don't
+rewrite the spec for the operator.]
+```
+
+If a category has zero findings, write `(no findings)` under the
+category header — don't omit the section.
+
+## Out of scope for this audit
+
+- Inspecting d-inference source (NOASSERTION license)
+- Rewriting the spec
+- Implementing the spec
+- Auditing SPEC-001 v1.4, SPEC-002 v1.3.5, SPEC-003 v0.9.2,
+  SPEC-010 v1.5, SPEC-011 v0.5 themselves (they are locked;
+  SPEC-013 layers on top)
+- Re-litigating the "biggest-fit vs max-tps" framing (Critical
+  constraint 1)
+- Auditing PR #103's Python prototype as production code (it's
+  a draft and SPEC-013 §12 already addresses what survives /
+  changes / provisional)
+- Designing the v0.2 audit-response (separate session after v0.1
+  audit closes)
+- Picking Option A (Swift-native) vs Option B (Python wrapper)
+  — §10 explicitly defers to the implementing PR
+
+## Done criteria
+
+You are done when:
+
+- /Users/augstar/macprovider-poc/specs/SPEC-013-audit.md exists
+- Every category A-M has a section (even if "(no findings)")
+- Every finding has severity, location, what/why/recommendation
+- Executive summary states a clear "lock as-is" / "lock with
+  these CRITICAL/MAJOR findings closed" / "needs structural
+  revision" verdict
+- Total CRITICAL count is honest (do not under-report to avoid a
+  revision round; do not over-report to seem rigorous)
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (NOT part of the prompt)
+
+- Run with `codex` CLI on the host that has the repo checked out.
+- Expected wall-clock: 30-45 min Codex round 1.
+- After Codex finishes, the operator decides whether to run a Claude
+  round 2 (append, not overwrite). If only one round is needed,
+  delete the "Audit round: 1 of N" line in the audit file and bump
+  to "Audit round: 1 of 1" so future readers don't expect a round 2.
+- If Codex finds zero CRITICAL findings and ≤3 MAJOR findings, the
+  operator can choose to lock SPEC-013 v0.1 as-is OR roll a narrow
+  v0.2 closing them; matches the SPEC-010 v1.1 / SPEC-011 v0.3
+  pattern.
+- If Codex finds ≥1 CRITICAL or >3 MAJOR findings, draft SPEC-013
+  v0.2 incorporating the fixes, re-audit in Codex round 2.
+- After lock, append decision-log entry to `beta/DECISION_CRITERIA.md`
+  (next free entry number) summarizing: trigger, the biggest-fit
+  decision, what shipped, what was deferred to v2 (recommended
+  catalog, recipe attestation, sticky-affinity-from-recipes, etc.).
+- After lock, the implementing PR picks Option A (Swift-native) or
+  Option B (Python wrapper) per SPEC-013 §10. The PR #103 prototype
+  branch (`spike/provider-model-autotune`) is closed or rebased
+  onto the chosen option.

--- a/specs/AUDIT_SPEC_013_V0_2_PROMPT.md
+++ b/specs/AUDIT_SPEC_013_V0_2_PROMPT.md
@@ -1,0 +1,403 @@
+# Audit prompt — SPEC-013 v0.2 (round 2 — audit-response check)
+
+Operator-paste prompt to audit SPEC-013 v0.2
+(`specs/SPEC-013-cli-autotune.md`).
+
+**Round 2 of N (audit-response check).** Round 1 (Codex on v0.1,
+`specs/SPEC-013-audit.md`) returned `0 CRITICAL / 7 MAJOR / 11
+MINOR / 2 QUESTION`. v0.2 claims to close all 7 MAJORs, 10 of 11
+MINORs, and both QUESTIONs (M.2 documentation-checklist MINOR was
+intentionally deferred to a post-lock checklist). v0.2's change log
+block at the top of the spec enumerates each closure with explicit
+audit-finding references (A.1, D.1, E.1, F.1, F.2, G.1, J.1 for
+the MAJORs).
+
+Round 2 is NARROWER than round 1. The brief: "Did v0.2 actually
+close the round-1 findings, and did the closures introduce new
+contract precision gaps?" Round 2 is NOT a fresh full-spec audit —
+findings unrelated to the round-1 list are accepted but should be
+rare, and any v0.2-introduced regression in unchanged FRs is a
+CRITICAL anti-regression finding.
+
+Output to the same file: `specs/SPEC-013-audit.md`. APPEND a new
+"## Round 2 audit (Codex on v0.2)" section AFTER the existing
+round-1 sections; do NOT overwrite round 1. The single-file pattern
+matches `specs/SPEC-010-audit.md` and `specs/SPEC-011-audit.md`.
+
+Paste everything between `=== BEGIN PROMPT ===` and `=== END PROMPT ===`
+into a fresh Codex CLI session rooted at `/Users/augstar/macprovider-poc`.
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are running round 2 of the audit on SPEC-013 v0.2 at
+/Users/augstar/macprovider-poc/specs/SPEC-013-cli-autotune.md.
+Round 1 was you (Codex) on v0.1; the report is in
+/Users/augstar/macprovider-poc/specs/SPEC-013-audit.md. v0.2 is
+the audit-response draft on the same feature branch.
+
+You are NOT here to validate, rewrite, or extend the spec. You are
+here to answer two questions:
+
+1. Did v0.2 actually close each round-1 MAJOR, MINOR, and QUESTION
+   it claims to close? Closure means "the new wording does not
+   admit the failure mode round-1 named." Cosmetic closures that
+   restate the problem without fixing it are NOT closed.
+2. Did the round-1 closures introduce new contract precision
+   gaps elsewhere in the spec? v0.2 edited large sections (FR-D
+   rewritten, FR-E.1 rewritten, FR-F.1/F.2/F.3 retitled, FR-G.1
+   expanded, §7 CLI summary changed, 3 new ACs added, JSON schema
+   expanded, §11 expanded with renumber note + post-lock
+   checklist). Each edit is a potential precision-loss site.
+
+Output: APPEND a new section to
+  /Users/augstar/macprovider-poc/specs/SPEC-013-audit.md
+titled `## Round 2 audit (Codex on v0.2)`. Do NOT overwrite or
+edit the round-1 sections; the round-1 report is the historical
+record.
+
+Match the rigor and tone of round 1 and of prior audit reports in
+this repo (specs/SPEC-010-audit.md, specs/SPEC-011-audit.md).
+
+## Severity definitions (unchanged from round 1)
+
+- **CRITICAL** — would cause production failure on rollout; silent
+  regression of locked spec behavior; v0.2 INTRODUCED a contract
+  violation in a previously-correct FR; v0.2's claimed closure
+  of a round-1 finding is COSMETIC and the original failure mode
+  still applies.
+- **MAJOR** — round-1 MAJOR closure is incomplete (closed in some
+  cases but admits the failure mode in others); v0.2 introduced
+  a new precision gap; the round-1 closure language is
+  unambiguous but conflicts with a different existing FR.
+- **MINOR** — quality issues that don't block lock; closure works
+  but the new wording is awkward or has a sentence-level error.
+- **QUESTION** — genuinely unresolved design choice surfaced by
+  the v0.2 changes.
+
+## Critical constraints (unchanged from round 1)
+
+All round-1 critical constraints remain in force:
+
+1. The "biggest-fit, not max-tps" framing in §1 is LOCKED.
+2. SPEC-001 v1.4, SPEC-002 v1.3.5, SPEC-003 v0.9.2, SPEC-010
+   v1.5, SPEC-011 v0.5 are LOCKED.
+3. SPEC-only, no code.
+4. Additive only / Tier-1 backward compat.
+5. Operator-supplied candidate-list order is the contract.
+6. Default candidate list is curated by the network.
+7. Knob-axis claims must match PR #105 reality.
+8. Clean-room boundary on d-inference.
+9. Telemetry / privacy invariant: nothing leaves the machine.
+
+Additionally for round 2:
+
+10. **Anti-regression discipline.** v0.2 must NOT have weakened or
+    broken any v0.1 FR that round 1 did NOT flag. Spot-check the
+    untouched sections (§1 mission, §2 scope, §3 architecture,
+    §5.1 FR-A, §5.2 FR-B, §5.3 FR-C, §5.5 FR-E.2 `--no-join`,
+    §6 NFR-1/2/3/4, AC-1-5 and AC-7-8, AC-10-15, AC-16). Any
+    regression introduced into these = CRITICAL anti-regression
+    finding.
+
+## Required reading (in order)
+
+1. `/Users/augstar/macprovider-poc/specs/SPEC-013-cli-autotune.md`
+   v0.2 — the spec under audit. Pay particular attention to the
+   v0.2 change-log block at the top, which enumerates each
+   closure claim with explicit audit-finding references.
+
+2. `/Users/augstar/macprovider-poc/specs/SPEC-013-audit.md`
+   round-1 report — the input to this round. Round 2's job is to
+   verify each round-1 finding is closed (or honestly flag the
+   ones that aren't).
+
+3. `/Users/augstar/macprovider-poc/specs/AUDIT_SPEC_013_PROMPT.md`
+   — the round-1 prompt, for severity definitions and critical
+   constraints.
+
+4. Code spot-checks for the new factual claims v0.2 introduces:
+   - `phase3-binary/Sources/MacProviderCore/Config.swift`
+     lines 239-241 — verify v0.2 FR-F.3's owned-key list
+     (`model`, `kv_bits`, `max_context_override`,
+     `max_concurrency_override`) matches what the parser
+     actually reads. v0.1 had this wrong; v0.2 claims it's
+     fixed.
+   - `phase3-binary/dist/install.sh` lines ~749 and ~923 +
+     `phase3-binary/dist/launchd-plist-template.plist` — verify
+     v0.2 FR-E.1's launchd label `live.streamvc.macprovider`
+     and the bootout/bootstrap drain sequence match
+     SPEC-003 v0.9.2 + the install scripts.
+   - `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+     lines 559-566 and 622-641 — verify v0.2 FR-D.1's Shape B
+     "rely on online-fallback during load" claim matches the
+     actual runtime behavior.
+
+5. The PR #103 prototype branch `spike/provider-model-autotune`
+   `beta/autotune.py` — verify v0.2 §12 L.1 closure correctly
+   characterizes what the prototype actually does (no explicit
+   pre-download).
+
+You do NOT need to re-read SPEC-001 / SPEC-002 / SPEC-003 /
+SPEC-010 / SPEC-011 in full — round 1 covered them. Spot-check
+only where v0.2's edits make a new factual claim about a locked
+spec.
+
+## Round 2 audit categories — work through each in order
+
+### Category Z-CLOSURE: did v0.2 actually close round 1?
+
+For each round-1 finding listed below, write a closure verdict:
+**CLOSED**, **PARTIAL** (some failure modes closed, some not),
+**NOT CLOSED** (cosmetic / failure mode still applies), or **OVER-CLOSED**
+(closure introduced a new gap). For PARTIAL / NOT CLOSED /
+OVER-CLOSED, file a finding with severity.
+
+Round-1 MAJORs:
+- **A.1** fallback contradiction → v0.2 replaces `fallbacks` with
+  NAME-ONLY `alternates`; AC-1/AC-2 updated. Verify.
+- **D.1** `models pull` precondition understated → v0.2 reframes
+  FR-D as "weights cache-warm before probe; measurement-isolation
+  guarantee" with Shape A / Shape B implementation choice.
+  Verify the contract is now sufficient without depending on a
+  not-yet-existing `models pull` subcommand.
+- **E.1** launchd label wrong → v0.2 binds to
+  `live.streamvc.macprovider` and the SPEC-003 bootout/bootstrap
+  sequence. Verify against `phase3-binary/dist/`.
+- **F.1** `--apply` wrote wrong YAML keys → v0.2 updates to
+  `max_context_override` / `max_concurrency_override`. Verify
+  against `Config.swift:239-241`.
+- **F.2** recipe_hash not deterministic → v0.2 pins
+  `sha256:<64-lowercase-hex>` + RFC 8785 JCS + explicit hash
+  input domain. Verify the canonicalization profile is
+  implementable from the spec text alone.
+- **G.1** SQLite migration invalid → v0.2 spells the SQL as
+  `ALTER TABLE tune_trials ADD COLUMN stage INTEGER NOT NULL
+  DEFAULT 1`. Verify this is now valid SQLite.
+- **J.1** no AC for operator-supplied order → v0.2 adds AC-17.
+  Verify AC-17 actually catches the failure mode (an
+  implementation that pre-sorts `--candidate-models` by
+  parameter-count-descending must fail AC-17).
+
+Round-1 MINORs (10 claimed closed):
+- B.1 (max-context-axis semantics); C.1 (CLI summary kv-bits);
+  F.3 (backup naming); G.2 (transactional retention); H.1
+  (--resume removed from §7); J.2 (AC-18 new); J.3 (AC-19 new +
+  exit_reason enum); K.1 (OQ-B/D thresholds); L.1 (prototype
+  migration note); M.1 (cross-spec renumber note).
+
+Round-1 QUESTIONs (2 resolved):
+- D.2 (signature mismatch vs network failure) → v0.2 splits
+  pre-warm failures into transient (advance) vs integrity
+  (abort whole run). Verify the classification is operationally
+  unambiguous.
+- K.2 (thermal/order) → v0.2 adds OQ-E with a quantitative
+  decision threshold. Verify the threshold is measurable from
+  the planned air5 data.
+
+### Category R-REGRESSION: anti-regression in unchanged FRs
+
+Walk these v0.2-UNCHANGED FRs and confirm they still work as
+v0.1 originally specified:
+
+- §5.1 FR-A.1, FR-A.2, FR-A.3, FR-A.4 (Stage 1 iteration logic)
+- §5.2 FR-B.1, FR-B.2, FR-B.3 (Stage 2 hill-climb)
+- §5.3 FR-C.1, FR-C.2, FR-C.3 (default candidate list)
+- §5.5 FR-E.2 `--no-join` (still an implementation precondition;
+  the binary doesn't yet have this flag)
+- §6 NFR-1, NFR-2, NFR-3, NFR-4
+- §8 AC-1 through AC-5, AC-7, AC-8, AC-10, AC-11, AC-13, AC-14,
+  AC-15
+
+If v0.2 incidentally edited any of these and weakened them =
+CRITICAL anti-regression. If v0.2 left them as-is and round 1
+already covered them = no finding.
+
+Specifically check:
+- AC-1 + AC-2 wording: v0.2 changed the `fallbacks` →
+  `alternates` outputs. Verify the ACs were updated correctly,
+  not just renamed.
+- FR-A.2 step 7: v0.2 must still STOP iterating models on first
+  feasible. v0.2's new `alternates` list MUST be populated from
+  the operator's input list, NOT from a fallback-probing pass
+  that re-iterates.
+- FR-B.2 `_is_new_best` semantics: v0.2 must not have changed
+  the throughput-primary + TTFT-tiebreak-within-epsilon rule.
+
+### Category N-NEWGAPS: precision gaps introduced by v0.2 edits
+
+For each v0.2 edited section, check whether the new wording
+introduces:
+- A claim that contradicts another part of the spec
+- An ambiguity that didn't exist before
+- A reference to a locked spec section that doesn't exist
+- A code citation (file path, line number, function name) that
+  doesn't match reality
+
+Specific check sites (high-leverage):
+
+- §5.4 FR-D.1: the "measurement-isolation" contract requires
+  load-fetch latency to be excluded from gate-ttft-ms. Is the
+  exclusion mechanism specified precisely enough to implement?
+  How does the implementation distinguish "load-fetch latency"
+  from "first-request prefill latency"?
+- §5.4 FR-D.2: the integrity-class enumeration includes
+  "repository contents inconsistent with expected shape (e.g.
+  missing tokenizer.json)." Is this enforceable by autotune,
+  or does it require coordination with the HF cache layer? If
+  the failure mode can only be detected at serve-start (not at
+  pre-warm), the abort-whole-run rule may be wrong.
+- §5.5 FR-E.1 launchd drain: step 2's "do NOT escalate to
+  SIGKILL on a launchd-managed install" — what if the
+  bootout-then-poll never frees the port? The spec says
+  "abort with a clear error" — is the operator state recoverable
+  from there?
+- §5.6 FR-F.2 recipe_hash input domain: the spec enumerates
+  fields IN the hash but uses ad-hoc field names. Cross-check
+  against the JSON schema — any field named in the hash input
+  that doesn't actually appear in the JSON schema = MAJOR
+  (impossible to compute).
+- §5.6 FR-F.3 launchd hint: the hint command uses `$UID` (shell
+  variable). Will the printed hint work as a copy-paste in the
+  operator's shell, or does autotune need to resolve `$UID` at
+  print-time?
+- §5.7 FR-G.1 transactional retention: SQLite transaction
+  semantics — must the retention sweep be in the SAME
+  transaction as the new `tune_runs` INSERT, or a SEPARATE
+  transaction after the insert commits? v0.2 says "after the
+  new `tune_runs` row is created" which is ambiguous on this
+  point.
+- §5.7 FR-G.2 exit_reason enum: the enum lists 9 values; do any
+  of them collide with the `applied INTEGER` semantics? E.g.
+  `applied = 1, exit_reason = 'interrupted'` — is the
+  interrupted state allowed to have applied changes already?
+- §7 `--kv-bits-axis` representation table: the `serve_command`
+  row says "`--kv-bits` flag omitted entirely" when value is
+  null. Is the FR-F.2 JSON `knobs.kv_bits: null` consistent
+  with this? The `serve_command` string and the JSON must
+  produce identical runtime behavior.
+- §8 AC-17: is the test setup precise enough? "Hardware where
+  both 1B and 32B are feasible" — does this exist on any
+  realistic test rig, or is the test always hardware-specific?
+  May need a mock-provider-based test.
+- §8 AC-18: `--max-context-axis 2000,4000` with `--target-context
+  4000` — the test says the 2000 cell makes it invalid. Is the
+  rejection rule clearly enough specified that an implementer
+  knows to fail at flag-parse time vs Stage-2 setup?
+- §9 OQ-E thermal threshold: "would produce a DIFFERENT
+  keep-best winner more than 5% of the time" — measurable how?
+  Run the same cell set forward + reverse N times and compare?
+  How many repeats? Is this defensible?
+- §11 cross-spec renumber note: verify SPEC-014 is not already
+  claimed by any other in-flight spec work.
+- §12 L.1 closure: verify against `beta/autotune.py` on the
+  prototype branch.
+
+### Category O-OTHER: anything else round 2 surfaces
+
+This is the catch-all. Round 2 should NOT generate broad new
+findings outside the round-1 scope; if you find one, ask
+yourself whether round 1 should have caught it (and if so, file
+it as MAJOR-class because that's a hole in round 1's coverage
+that v0.2's edits may have exposed).
+
+Examples that DO belong here:
+- AC numbering off-by-one after v0.2 added 3 ACs
+- Cross-reference drift (a section number that v0.2 edits
+  invalidated)
+- Change-log block at top has a typo or references a wrong
+  audit-finding ID
+
+## Output structure
+
+APPEND to `/Users/augstar/macprovider-poc/specs/SPEC-013-audit.md`:
+
+```
+---
+
+## Round 2 audit (Codex on v0.2)
+
+**Audited:** SPEC-013 v0.2 (specs/SPEC-013-cli-autotune.md)
+**Auditor model:** Codex / GPT-5
+**Audit round:** 2 of N
+**Date:** 2026-06-18
+**Closure summary:** [N CLOSED / N PARTIAL / N NOT CLOSED / N
+                     OVER-CLOSED] across 7 MAJOR + 10 MINOR + 2
+                     QUESTION round-1 findings
+**Round-2 findings:** [N CRITICAL anti-regression / N MAJOR new /
+                      N MINOR new]
+
+### Executive summary
+
+[2-3 paragraphs. State whether v0.2 is ready to lock, ready with
+narrow v0.3 fixes, or needs another response round. Be specific.]
+
+### Round-1 finding closures
+
+For each of the 19 round-1 findings (7 MAJOR + 10 MINOR + 2
+QUESTION), one paragraph: closure verdict and rationale. Reference
+the round-1 finding's category code (e.g. "A.1 → CLOSED").
+
+### Round-2 new findings
+
+Group by category Z / R / N / O. Same finding format as round 1:
+SHORT TITLE, severity, location, what / why / recommendation.
+
+### Lock readiness
+
+State your verdict in one of:
+- LOCK READY (no CRITICAL, ≤3 MAJOR — operator may lock or roll
+  narrow v0.3)
+- NARROW V0.3 REQUIRED (any CRITICAL anti-regression, or >3
+  MAJORs)
+- STRUCTURAL REVISION REQUIRED (multiple CRITICAL or v0.2
+  failed to close >2 round-1 MAJORs)
+```
+
+## Out of scope for round 2
+
+- Re-litigating round-1 findings that v0.2 closed
+- Rewriting the spec
+- Implementing the spec
+- Auditing locked specs themselves
+- Re-litigating biggest-fit framing
+- Picking Option A vs Option B
+
+## Done criteria
+
+You are done when:
+
+- The new "## Round 2 audit (Codex on v0.2)" section is appended
+  to `/Users/augstar/macprovider-poc/specs/SPEC-013-audit.md`.
+- Round-1 sections are unchanged.
+- Each of 19 round-1 findings has an explicit closure verdict.
+- Each round-2 new finding has severity, location, what / why /
+  recommendation.
+- Lock-readiness verdict is stated.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (NOT part of the prompt)
+
+- Run with `codex` CLI on the host that has the repo checked out.
+- Expected wall-clock: ~20-30 min Codex round 2 (narrower than
+  round 1, primarily closure verification + new-gap spot-checks).
+- Round-2 expected outcome (estimated): LOCK READY with 0-2
+  remaining MINORs to clean in v0.3 OR at lock-time. The MAJORs
+  in round 1 were code-grounded and v0.2's responses are
+  code-grounded; the closure rate should be high.
+- If round 2 returns LOCK READY: operator decides whether to lock
+  v0.2 as-is or roll a narrow v0.3 closing the remaining MINORs.
+  Either is acceptable per the SPEC-010 v1.5 / SPEC-011 v0.5
+  patterns.
+- If round 2 returns NARROW V0.3 REQUIRED: Claude drafts v0.3
+  closing the remaining issues and authors
+  `AUDIT_SPEC_013_V0_3_PROMPT.md` for round 3.
+- After lock, the implementing PR picks Option A (Swift-native) or
+  Option B (Python wrapper) per SPEC-013 §10. PR #103 disposition
+  per the §11 post-lock checklist.

--- a/specs/AUDIT_SPEC_013_V0_3_PROMPT.md
+++ b/specs/AUDIT_SPEC_013_V0_3_PROMPT.md
@@ -1,0 +1,283 @@
+# Audit prompt — SPEC-013 v0.3 (round 3 — closure-confirmation, LOCK candidate)
+
+Operator-paste prompt to audit SPEC-013 v0.3
+(`specs/SPEC-013-cli-autotune.md`).
+
+**Round 3 of N (LOCK-CONFIRMATION audit).** Round 1 (Codex on
+v0.1) returned `0 CRITICAL / 7 MAJOR / 11 MINOR / 2 QUESTION` →
+v0.2 closed 17 of 19. Round 2 (Codex on v0.2) returned LOCK READY
+with `0 CRITICAL anti-regression / 1 MAJOR new / 3 MINOR new`.
+v0.3 closes the 4 new round-2 findings (N-D.1 MAJOR, Z-B.1
+PARTIAL→CLOSED, N-OQ-E.1 MINOR, O.1 MINOR). v0.3's change log block
+at the top of the spec enumerates each closure.
+
+Round 3 is the NARROWEST round. The brief: "Did v0.3 close the
+four round-2 findings, and did it introduce any new contract
+precision gap?" Round 3 is NOT a fresh audit — it is a
+LOCK-CONFIRMATION pass. The expected outcome is `0 CRITICAL / 0
+MAJOR / ≤2 MINOR new`, at which point SPEC-013 v0.3 LOCKs and the
+implementing PR can begin.
+
+Output: APPEND a new `## Round 3 audit (Codex on v0.3 — LOCK
+confirmation)` section to `specs/SPEC-013-audit.md`. Do NOT
+overwrite or edit the round-1 or round-2 sections.
+
+Paste everything between `=== BEGIN PROMPT ===` and `=== END PROMPT ===`
+into a fresh Codex CLI session rooted at `/Users/augstar/macprovider-poc`.
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are running round 3 of the audit on SPEC-013 v0.3 at
+/Users/augstar/macprovider-poc/specs/SPEC-013-cli-autotune.md.
+Round 2 found v0.2 LOCK READY pending 4 narrow cleanups
+(N-D.1 MAJOR, Z-B.1 PARTIAL, N-OQ-E.1 MINOR, O.1 MINOR);
+v0.3 claims to close all 4. The audit history is in
+specs/SPEC-013-audit.md.
+
+Round 3 is a LOCK-CONFIRMATION audit. Output: APPEND a new
+section to /Users/augstar/macprovider-poc/specs/SPEC-013-audit.md
+titled `## Round 3 audit (Codex on v0.3 — LOCK confirmation)`.
+Do NOT edit or overwrite the round-1 or round-2 sections.
+
+The audit's two questions:
+
+1. Did v0.3 actually close each of the 4 round-2 findings?
+   "Closed" = the new wording does not admit the failure mode.
+2. Did the round-2 closures introduce any NEW contract precision
+   gap? Round 3 spot-checks the SPECIFIC sections v0.3 edited:
+   §5.2 FR-B.1 (Z-B.1 parse-rule lift), §5.4 FR-D.1 + §6 NFR-4
+   + §8 AC-8 (N-D.1 shape-neutrality), §9 OQ-E (sampling
+   protocol), and the four O.1 drift sites (FR-G.2 SQL comment,
+   FR-H.2 prose, NFR-3 backup pattern, §7 disclaimer).
+
+Round 3 is NOT a fresh full-spec audit. Findings unrelated to
+the four round-2 closures are accepted but should be rare.
+
+## Severity definitions (unchanged from rounds 1+2)
+
+- **CRITICAL** — would cause production failure on rollout;
+  silent regression of locked spec behavior; v0.3 INTRODUCED
+  a contract violation in a previously-correct FR; v0.3's
+  claimed closure of a round-2 finding is COSMETIC and the
+  original failure mode still applies.
+- **MAJOR** — round-2 closure is incomplete or v0.3 introduced
+  a new precision gap.
+- **MINOR** — quality issues that don't block LOCK.
+- **QUESTION** — unresolved design choice.
+
+## Critical constraints (unchanged from rounds 1+2)
+
+All round-1 + round-2 critical constraints remain in force:
+
+1. The "biggest-fit, not max-tps" framing in §1 is LOCKED.
+2. SPEC-001 v1.4, SPEC-002 v1.3.5, SPEC-003 v0.9.2, SPEC-010
+   v1.5, SPEC-011 v0.5 are LOCKED.
+3. SPEC-only, no code.
+4. Additive only / Tier-1 backward compat.
+5. Operator-supplied candidate-list order is the contract.
+6. Default candidate list curated by the network.
+7. Knob-axis claims must match PR #105 reality.
+8. Clean-room boundary on d-inference.
+9. Telemetry / privacy invariant: nothing leaves the machine
+   except per FR-D.1 pre-warm.
+10. Anti-regression: v0.3 must NOT have weakened any v0.2
+    behavior that round 2 did NOT flag.
+
+## Required reading (very narrow this round)
+
+1. `/Users/augstar/macprovider-poc/specs/SPEC-013-cli-autotune.md`
+   v0.3 — focus on the v0.3 change-log block at the top + the
+   five edit sites named below. You do NOT need to re-read the
+   unchanged surface; rounds 1+2 covered it.
+
+2. `/Users/augstar/macprovider-poc/specs/SPEC-013-audit.md`
+   § Round 2 — the input to this round. Round 3's job is to
+   verify the four round-2 findings (N-D.1, Z-B.1, N-OQ-E.1,
+   O.1) are now closed.
+
+3. Code spot-checks ONLY for round-2-related claims:
+   - `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+     lines 559-566 and 622-641 — verify v0.3 NFR-4's Shape A /
+     Shape B carve-out still accurately describes the runtime
+     online-fallback path.
+   - No other code re-checks required (round 2 covered Config.swift
+     and the launchd artifacts).
+
+## Round 3 audit categories — narrow
+
+### Category Z-CLOSURE: did v0.3 close the round-2 four?
+
+For each of the 4 round-2 findings, write CLOSED / PARTIAL /
+NOT CLOSED / OVER-CLOSED verdict with a one-paragraph rationale:
+
+- **N-D.1 (MAJOR)** Shape B pre-warm vs `models pull`-only
+  wording inconsistency → v0.3 rewords NFR-4 to admit both
+  Shape A and Shape B, and AC-8 is now shape-neutral with
+  explicit Shape A and Shape B variants. Verify the rewording
+  actually permits a Shape B implementation without violating
+  the egress invariant, and that the AC variants are
+  testable.
+- **Z-B.1 (PARTIAL → CLOSED)** `--max-context-axis` parse
+  rules in §7 reference only → v0.3 lifts the parse rules
+  into FR-B.1 as a normative paragraph (absolute caps, sorted
+  ascending, ≥ `--target-context`, flag-parse-time
+  rejection, duplicate rejection, empty axis → single cell).
+  Verify the lifted rules are complete and unambiguous and
+  that the §7 / §5 conflict-resolution rule is stated.
+- **N-OQ-E.1 (MINOR)** OQ-E thermal threshold lacked repeat
+  protocol → v0.3 adds: minimum 10 paired forward/reverse
+  runs on air5, 60s idle between paired runs, mismatch_pairs
+  / 10 > 0.05 threshold. Verify the protocol is measurable
+  and the math is honest (10 trials at 5% threshold is
+  marginal statistical power; is this defensible for v1?).
+- **O.1 (MINOR)** Residual v0.1 wording drift → v0.3 updates
+  the four sites:
+  - `tune_runs.spec_version` SQL comment ('SPEC-013 v0.1' →
+    "e.g. 'SPEC-013 v0.3'; writer emits its own producing
+    version")
+  - FR-H.2 ("v0.1 default behavior" → "v1 default behavior";
+    "out of scope for v0.1's normative contract" → "deferred
+    from v1's normative contract")
+  - NFR-3 (`.bak-<unix-ts>` → `.bak-<unix-ts>-<counter>` with
+    collision explanation)
+  - §7 ("MAY change in v0.2" → §5-vs-§7 conflict rule + flag
+    shape may be refined while §5 semantics are preserved)
+  Verify all four sites are actually updated and no NEW
+  drift was introduced.
+
+### Category N-NEWGAPS-V03: precision gaps introduced by v0.3 edits
+
+Spot-check the v0.3 edit sites for new gaps. Examples to look
+for:
+
+- FR-B.1 lifted parse rules: does "reject duplicates after sort"
+  conflict with operator UX (e.g. `--max-context-axis 4000,4000`
+  is a deduped 1-element list, not an error)? Audit's choice.
+- NFR-4 rewording: the new "the HuggingFace pre-warm fetch
+  path selected by FR-D.1, whether explicit `models pull` or
+  runtime online fallback" — does this exempt all weight
+  fetches or only the autotune-driven ones? An implementation
+  could argue the runtime's fetch during a normal `serve`
+  also qualifies, but autotune isn't running. Make sure
+  NFR-4's carve-out is scoped to "during an `autotune` run."
+- AC-8 Shape B variant: "block egress to HuggingFace at the
+  network-mock layer" — is the test fixture for this defined
+  precisely enough? Network-mocking is non-trivial.
+- OQ-E sampling protocol: 10 pairs at 5% threshold is marginal
+  power; would the operator be satisfied with "≥ 1 mismatch in
+  10" as the trigger threshold given there's a chance of
+  observing 1 mismatch in 10 by pure chance even when the true
+  rate is < 5%? Audit's call.
+
+### Category R-REGRESSION-V03: anti-regression on v0.2 surface
+
+The v0.3 edits were prose-narrow. Spot-check that none
+incidentally weakened or invalidated:
+
+- FR-D.1 Shape A and Shape B definitions (untouched in v0.3)
+- FR-D.2 transient/integrity split (untouched in v0.3)
+- FR-F.3 four-owned-keys list (untouched in v0.3)
+- FR-G.1 ALTER TABLE migration SQL (untouched in v0.3)
+- AC-17 operator-order test (untouched in v0.3)
+- The round-1 + round-2 closure language in the change-log
+  blocks at the top of the spec
+
+If any of these was incidentally edited and weakened =
+CRITICAL anti-regression.
+
+### Category O-OTHER-V03: catch-all
+
+Use sparingly. Round 3 is narrow; broad findings are not
+expected. Any finding here SHOULD reference why rounds 1+2
+didn't catch it.
+
+## Output structure
+
+APPEND to `/Users/augstar/macprovider-poc/specs/SPEC-013-audit.md`:
+
+```
+---
+
+## Round 3 audit (Codex on v0.3 — LOCK confirmation)
+
+**Audited:** SPEC-013 v0.3 (specs/SPEC-013-cli-autotune.md)
+**Auditor model:** Codex / GPT-5
+**Audit round:** 3 of N (LOCK confirmation)
+**Date:** 2026-06-18
+**Closure summary:** [N CLOSED / N PARTIAL / N NOT CLOSED /
+                     N OVER-CLOSED] across the 4 round-2 findings
+**Round-3 findings:** [N CRITICAL anti-regression / N MAJOR new /
+                      N MINOR new]
+**Lock verdict:** [LOCK / NARROW V0.4 REQUIRED / OTHER]
+
+### Executive summary
+
+[1-2 paragraphs.]
+
+### Round-2 finding closures
+
+For each of the 4 round-2 findings (N-D.1, Z-B.1, N-OQ-E.1,
+O.1): closure verdict + one-paragraph rationale.
+
+### Round-3 new findings
+
+Group by category Z / N / R / O. Empty categories: `(no findings)`.
+
+### Lock readiness
+
+State your verdict: LOCK (v0.3 may be locked as-is) or NARROW
+V0.4 REQUIRED (state the blocker).
+```
+
+## Out of scope for round 3
+
+- Re-litigating round-1 or round-2 findings already closed
+- Rewriting the spec
+- Implementing the spec
+- Auditing locked specs themselves
+- Re-litigating biggest-fit framing
+- Picking Option A vs Option B
+- Fresh broad-scope audit of unchanged sections
+
+## Done criteria
+
+You are done when:
+
+- The new `## Round 3 audit (Codex on v0.3 — LOCK confirmation)`
+  section is appended to
+  /Users/augstar/macprovider-poc/specs/SPEC-013-audit.md.
+- Round-1 and round-2 sections are unchanged.
+- Each of 4 round-2 findings has an explicit closure verdict.
+- Each round-3 new finding (if any) has severity, location,
+  what / why / recommendation.
+- The "Lock verdict" line at the top says LOCK or NARROW V0.4
+  REQUIRED.
+
+=== END PROMPT ===
+```
+
+---
+
+## Operator notes (NOT part of the prompt)
+
+- Run with `codex` CLI on the host that has the repo checked out.
+- Expected wall-clock: ~10-15 min Codex round 3 (this is the
+  NARROWEST round — closure verification of 4 findings on
+  ~5 edit sites).
+- Round-3 expected outcome (estimated): LOCK with 0 new findings
+  or ≤1 MINOR. The v0.3 closures are localized prose edits and
+  the round-2 findings were already cleanups, not architectural.
+- If round 3 returns LOCK: push the branch and open the DRAFT PR
+  per the originating prompt at
+  `.omc/prompts/spec-cli-autotune-v1.md`. The PR title is
+  `spec(cli): SPEC-013 v0.3 — macprovider-cli autotune subcommand`
+  and the PR body leads with the biggest-fit-not-max-tps decision.
+- If round 3 returns NARROW V0.4 REQUIRED: Claude drafts v0.4 +
+  AUDIT_SPEC_013_V0_4_PROMPT.md for round 4 (very unlikely given
+  v0.3's scope).
+- After lock + merge, the implementing PR picks Option A or B
+  per SPEC-013 §10 and the §11 post-lock checklist runs
+  (decision-log entry, SPEC-003 install note, PR #103 disposition).

--- a/specs/BUILD_SPEC_013_PROMPT.md
+++ b/specs/BUILD_SPEC_013_PROMPT.md
@@ -1,0 +1,653 @@
+# Build prompt — SPEC-013 v0.3 (`macprovider-cli autotune` subcommand)
+
+Operator-paste prompt to start the SPEC-013 v0.3 build. This wraps
+SPEC-013 v0.3 § 0's operator-paste invocation block with the
+self-contained context a fresh Codex CLI session needs.
+
+Paste everything between the markers into a fresh **Codex CLI session**
+rooted at `/Users/augstar/macprovider-poc`. The agent will read the
+spec, add a new `autotune` subcommand to the existing
+`phase3-binary/` Swift package, and build incrementally per the
+step sequence below. Expected wall-clock: 1–2 weeks of session work
+(the spec is one new subcommand inside an existing binary, not a
+whole new binary), with operator checkpoints at T+15 min and T+1 h
+on day 1.
+
+---
+
+```
+=== BEGIN PROMPT ===
+
+You are implementing SPEC-013 v0.3 — the `macprovider-cli
+autotune` subcommand. SPEC-013 is at
+/Users/augstar/macprovider-poc/specs/SPEC-013-cli-autotune.md and
+has been through 3 codex audit rounds (full audit history at
+/Users/augstar/macprovider-poc/specs/SPEC-013-audit.md;
+round-3 LOCK verdict). It is build-ready. Your output is working
+code, NOT spec revisions.
+
+## Wrapper directive (from SPEC-013 § 0, verbatim)
+
+"Implement SPEC-013. As you work, maintain a running
+phase3-binary/implementation-notes.html that captures anything I
+should know about how the implementation diverges from or interprets
+the spec:
+
+- Design decisions: choices made where the spec was ambiguous
+- Deviations: places where you intentionally departed from the spec, and why
+- Tradeoffs: alternatives considered and why you picked what you did
+- Open questions: anything you'd want me to confirm or revise"
+
+This directive is operative throughout the build. Update
+implementation-notes.html as you go, not just at the end. The
+operator reads it asynchronously to catch divergence early. The
+file already exists (created during the SPEC-001 build); append
+new sections per-spec like "SPEC-013 design decisions",
+"SPEC-013 deviations", etc.
+
+## Implementation choice (PICKED here — SPEC-013 § 10 left this open)
+
+The BUILD prompt picks **Option A: Swift-native subcommand inside
+`macprovider-cli`**, not Option B (Python wrapper). Rationale:
+
+- The rest of the binary is Swift; adding a Python runtime to the
+  operator install pipeline contradicts SPEC-003 v0.9.2's
+  single-binary install promise.
+- Drain semantics, atomic config writes, and SIGINT/SIGTERM
+  handling all match the patterns already shipped in
+  `UninstallCommand.swift` / `SelfUpdate.swift`.
+- Future SPEC-011 warm-swap integration (§11 v2 deferral) needs
+  Swift-native; Option B paints us into a corner.
+- The PR #103 prototype (`beta/autotune.py`) on the
+  `spike/provider-model-autotune` branch is the reference for the
+  algorithm shape and the schemas — Option A re-implements the
+  loop in Swift but reuses the `tune_trials` schema verbatim and
+  the `_is_new_best` decision rule verbatim.
+
+If during build you find Option A genuinely blocks something, STOP
+and write an Open Question. Do NOT silently pivot to Option B
+without operator approval.
+
+## Required reading (in order, fully — do not skim)
+
+1. /Users/augstar/macprovider-poc/specs/SPEC-013-cli-autotune.md
+   v0.3 — your specification. The whole document is in scope.
+   Particular attention:
+   - § 3 architecture (two-stage pipeline + provider-lifecycle
+     invariant)
+   - § 5.1 FR-A (Stage 1 — STOP-on-first-feasible)
+   - § 5.2 FR-B (Stage 2 — knob hill-climb + `_is_new_best`)
+   - § 5.4 FR-D (pre-warm contract — pick Shape A or Shape B per
+     the implementer's discretion; both are permitted)
+   - § 5.5 FR-E (provider-conflict pre-flight + `--no-join`)
+   - § 5.6 FR-F (recommendation surface + JSON schema +
+     recipe_hash JCS + `--apply`)
+   - § 5.7 FR-G (`tune_trials` + `tune_runs` SQLite schema +
+     migration)
+   - § 8 acceptance criteria (AC-1 through AC-19 — these drive
+     your test suite)
+
+2. /Users/augstar/macprovider-poc/specs/SPEC-013-audit.md —
+   the audit history (3 rounds). NOT required line-by-line; skim
+   for shape. Useful for understanding why certain wordings
+   exist (e.g. round-2 N-D.1 closure explains why NFR-4 names
+   both Shape A and Shape B).
+
+3. /Users/augstar/macprovider-poc/specs/SPEC-001-phase3-binary.md
+   — the binary's normative surface. Pay attention to:
+   - The existing `serve` flag set (PR #105 added `--kv-bits`,
+     `--max-context`, `--max-batch` which autotune wraps)
+   - The launchd label `live.streamvc.macprovider` (FR-E.1)
+   - The config YAML key names (FR-F.3 owns
+     `model`, `kv_bits`, `max_context_override`,
+     `max_concurrency_override`)
+
+4. /Users/augstar/macprovider-poc/specs/SPEC-003-open-onboarding.md
+   v0.9.2 § FR-C5 — launchd interaction details for the
+   `--drain` path.
+
+5. The PR #103 prototype on the `spike/provider-model-autotune`
+   branch — `beta/autotune.py`. READ-ONLY reference for the
+   algorithm, signal handling pattern, `_is_new_best` semantics,
+   and `tune_trials` schema. Do NOT port the Python verbatim;
+   the Swift implementation re-implements with native types.
+   To read without checking out the branch:
+   `git show origin/spike/provider-model-autotune:beta/autotune.py | less`
+
+6. Existing Swift files you will touch or reference:
+   - `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+     — the top-level CLI structure; you ADD an `AutotuneCommand`
+     subcommand.
+   - `phase3-binary/Sources/MacProviderCore/Config.swift` —
+     YAML config parser; `--apply` calls into here.
+   - `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+     — HF cache + online-fallback path (relevant for FR-D Shape
+     B implementation).
+   - `phase3-binary/Sources/macprovider-cli/SelfUpdate.swift`
+     and `UninstallCommand.swift` — patterns for launchd
+     `bootout/bootstrap` calls; reuse the
+     `runProcess("/bin/launchctl", ...)` helper shape.
+
+## Build environment
+
+You are running on macOS Apple Silicon. The operator has the
+Swift toolchain available (Xcode 15+; `xcrun swift --version`
+returns 5.9+). The `phase3-binary/` Swift Package Manager project
+already exists; you ADD a new `Sources/macprovider-cli/AutotuneCommand.swift`
+(and supporting files) plus tests under
+`phase3-binary/Tests/macprovider-cliTests/`.
+
+Dependencies pinned in SPEC-001 are unchanged; autotune adds NO
+new top-level deps. SQLite access uses the same approach as the
+rest of the codebase (check for existing SQLite usage in
+`phase3-binary/Sources/`; if none, the simplest path is the
+system `libsqlite3` via Swift's C-interop wrapper. Document the
+choice in implementation-notes.html "SPEC-013 design decisions").
+
+## Branch strategy
+
+This BUILD work lives on a NEW branch
+`feat/cli-autotune-impl` branched OFF
+`spec/cli-autotune-v1` (the SPEC branch, which has PR #108 open
+as DRAFT against `main`). When you start:
+
+```bash
+cd /Users/augstar/macprovider-poc
+git fetch origin
+git checkout -b feat/cli-autotune-impl origin/spec/cli-autotune-v1
+```
+
+This way your build PR is STACKED on the SPEC PR. When the SPEC
+PR merges to main, this PR rebases onto main cleanly. Do NOT
+modify the SPEC file (`specs/SPEC-013-cli-autotune.md`) or any
+file under `specs/` from this branch — see Hard Rule 1.
+
+Commit checkpoints (Hard Rule 4) on this branch:
+`feat(autotune) Step N: <deliverable>`.
+
+## Reference hygiene (strict clean-room — non-negotiable)
+
+SPEC-001 § 7.2 establishes strict clean-room for d-inference (the
+DARKBLOOM LICENSE AGREEMENT prohibits use in competing products).
+You MUST NOT:
+- Fetch, clone, or read https://github.com/Layr-Labs/d-inference
+- Read any d-inference source files, README, or config files
+- Consult third-party blog posts that reproduce d-inference source
+
+You MAY consult:
+- mlx-swift-lm source (Apple/mlx-swift-examples, MIT)
+- Apple MLX documentation
+- HuggingFace tokenizer_config.json schema
+- This repository's PR #103 prototype on the
+  `spike/provider-model-autotune` branch
+- This repository's Phase 1+2 materials
+
+SPEC-013 doesn't touch attestation or privacy paths, so the
+clean-room concern is small. But the rule is the rule.
+
+## Build sequence
+
+Follow this order. Each step has a clear deliverable; complete
+it before moving on. Commit at each step boundary.
+
+**Step 1. Subcommand scaffolding.**
+Add `AutotuneCommand: ParsableCommand` to
+`phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift`.
+Register it under the top-level `MacProviderCLI` parser. Wire
+the §7 flag set (CLI surface summary): `--target-context`,
+`--candidate-models`, `--max-model-size`, `--min-model-size`,
+`--kv-bits-axis`, `--max-batch-axis`, `--max-context-axis`,
+`--stage1-replicates`, `--stage2-replicates`, `--gate-ttft-ms`,
+`--tps-tie-epsilon`, `--max-duration`, `--drain-grace`, `--port`,
+`--db-path`, `--retain-runs`, `--json`, `--apply`, `--drain`,
+`--restart-foreground`, `--dry-run`, `--report-only`,
+`--verbose`. Each flag with the defaults from §7. Implement
+`--dry-run` first (prints candidate plan and exits) as the
+cheapest way to prove the parser is wired.
+Deliverable: `macprovider-cli autotune --help` prints the full
+flag set; `macprovider-cli autotune --dry-run` prints the
+default candidate list and exits 0.
+
+**Step 2. `--no-join` flag on `serve` (implementation precondition).**
+SPEC-013 FR-E.2 requires `--no-join` semantics on
+`macprovider-cli serve`. The flag does NOT exist today; add it
+as a tiny additive change to `ServeCommand` in
+`MacProviderCLI.swift`. When `--no-join` is set:
+- The binary does NOT establish a WS session with the coordinator
+- The binary's local `/v1/models`, `/v1/chat/completions` etc.
+  surfaces remain reachable on `127.0.0.1:<port>`
+- On exit, no `state_update reason: "shutdown"` flows
+Audit-grade test in `ServeCommand` tests asserts the WS coordinator
+client is never instantiated when `--no-join` is set.
+Deliverable: `macprovider-cli serve --no-join --model X --port Y`
+serves locally without coordinator handshake; coordinator pool
+membership unchanged.
+
+**Step 3. SQLite schema + DB layer.**
+Implement `AutotuneDB`:
+- Open `~/.config/macprovider/autotune.sqlite` (operator-overridable
+  via `--db-path`).
+- Create the `tune_trials` table per FR-G.1 if absent, including
+  the `stage INTEGER NOT NULL DEFAULT 1` column.
+- Run the migration `ALTER TABLE tune_trials ADD COLUMN stage
+  INTEGER NOT NULL DEFAULT 1` against an existing prototype DB
+  (wrap in a duplicate-column ignore per the prototype's pattern).
+- Create the `tune_runs` table per FR-G.2 with the normative
+  `exit_reason` enum constraint enforced at the application
+  layer (SQLite doesn't have native enums; document this in
+  implementation-notes).
+- Implement transactional retention sweep per FR-G.1 (single
+  SQLite transaction covering both `tune_trials` and `tune_runs`
+  deletes; runs after the new `tune_runs` row is created;
+  default N=50, operator-overridable via `--retain-runs`,
+  enforced N>=1).
+Deliverable: a fresh autotune.sqlite is created on first run;
+prototype-DB migration works on a fixture; retention sweep is
+tested.
+
+**Step 4. Provider lifecycle (start/stop/wait-ready).**
+Implement `CandidateProviderRunner`:
+- `start(model:, port:, kvBits:, maxContext:, maxBatch:)` —
+  spawns `macprovider-cli serve --no-join --model <id>
+  --port <N>` with optional knob flags. Use the same
+  `Process()` pattern as `SelfUpdate.swift`. Stream stdout/stderr
+  to a per-trial log file under
+  `~/.cache/macprovider/autotune-logs/`.
+- `waitForReady(timeout:)` — poll
+  `GET http://127.0.0.1:<port>/v1/models` until 200, the
+  process exits (record `notes = "provider exited rc=<n> during
+  load"` and tail of stderr), or timeout. The wait time is NOT
+  counted against gate-ttft-ms per FR-D.1 measurement-isolation.
+- `stop(graceSeconds:)` — SIGTERM the subprocess, poll for port
+  free up to the grace window, escalate to SIGKILL only on the
+  manually-started foreground path (NEVER on the launchd-managed
+  install — FR-E.1).
+Invariant: AT MOST ONE provider alive at any moment.
+Deliverable: a unit test starts a real `serve`, waits for ready
+against a small model, runs one HTTP request, stops cleanly.
+Port `:18080` is free post-stop within the grace.
+
+**Step 5. Provider-conflict pre-flight (FR-E.1).**
+Implement the pre-flight check:
+- Detect launchd-managed install via
+  `launchctl list | grep live.streamvc.macprovider`.
+- Detect foreground install via PID + argv match on
+  `macprovider-cli serve` excluding the autotune's own argv
+  (whole-word match on `serve`).
+- Default (no `--drain`): refuse with stderr error naming the
+  install path; write `tune_runs.exit_reason = 'provider_conflict'`;
+  exit non-zero.
+- With `--drain`: implement the launchd `bootout/bootstrap` and
+  foreground SIGTERM paths per FR-E.1's "Drain sequence" prose.
+- With `--drain --apply`: install the new recipe before
+  bootstrap so the restart picks it up.
+- With `--drain` alone: restore the original config on exit.
+Deliverable: with no serve running, autotune proceeds; with a
+launchd-managed serve and no `--drain`, autotune refuses cleanly;
+with `--drain`, autotune drains and resumes after.
+
+**Step 6. Pre-warm (FR-D — Shape A or Shape B).**
+Pick ONE shape and document in implementation-notes:
+- **Shape A**: invoke `macprovider-cli models pull <id>` before
+  each candidate's probe. This requires shipping a new `models
+  pull` subcommand. The subcommand's normative contract is OUT
+  of SPEC-013's v1 scope, so spec it narrowly here: synchronous
+  online HF fetch into the same cache `ModelRuntime` reads from;
+  exit 0 on success, non-zero with a discriminated reason on
+  failure (network / HTTP error / signature mismatch).
+- **Shape B**: rely on the runtime's online fallback during
+  `serve` load. Detect cold-cache by checking the local HF
+  snapshot path BEFORE spawning the provider; if missing, spawn
+  the provider, time the load phase separately, and ONLY start
+  the measurement window after `/v1/models` returns 200 (the
+  cold load is excluded from gate-ttft-ms per FR-D.1).
+Whichever you pick, classify failures per FR-D.2 (transient =
+advance; integrity = abort whole run with
+`exit_reason = 'pre_warm_integrity_failure'`).
+Deliverable: a unit test that simulates a transient pre-warm
+failure for candidate 1 and a successful pre-warm for candidate 2;
+autotune records the failure with a transient classification and
+proceeds.
+
+**Step 7. Stage 1 — feasibility iteration (FR-A.1-4).**
+Implement `Stage1Iterator`:
+- Iterate the operator-supplied or default candidate list in
+  the GIVEN order. NO internal re-rank by parameter count or
+  predicted fit (FR-A.1; AC-17 will catch this).
+- For each candidate, pre-warm + start + wait-for-ready + fire
+  `stage1_replicates` requests at the target context + stop.
+- Apply the FR-A.3 four-condition feasibility gate (HTTP 2xx,
+  TTFT ≤ gate, no stop-token leak, no process exit).
+- STOP on the first feasible candidate. Return the chosen
+  model id. Record per-candidate trial rows with `stage=1`.
+- If no candidate is feasible: emit the all-infeasible error
+  per FR-A.4 with the SMALLEST candidate's reason surfaced
+  first (FR-H.4); write `tune_runs.exit_reason = 'no_feasible'`.
+Deliverable: AC-1, AC-2, AC-3, AC-17 pass.
+
+**Step 8. Stage 2 — knob hill-climb (FR-B.1-3).**
+Implement `Stage2HillClimb`:
+- For the chosen model, evaluate the cartesian product of
+  `kv_bits ∈ {unset, 4, 8}`, `max_batch ∈ {1, 2}`,
+  `max_context` (default `[--target-context]` single cell; opt-in
+  axis per FR-B.1's parse rules).
+- Each cell: `stage2_replicates` replicates, median tps, p95
+  TTFT, strict-all-feasible-or-cell-fails.
+- Apply `_is_new_best` semantics per FR-B.2 — port verbatim
+  from the prototype `_is_new_best()` function. The prototype is
+  at `beta/autotune.py` on the prototype branch.
+- Return the winning `(model, kv_bits, max_batch, max_context)`
+  tuple + recorded median tps + p95 TTFT.
+- Record per-cell trial rows with `stage=2`.
+Deliverable: AC-4, AC-5, AC-16, AC-18 pass.
+
+**Step 9. Recommendation surface (FR-F.1-3).**
+Implement `RecommendationEmitter`:
+- Terminal output per FR-F.1 — the RECOMMENDATION block with
+  model id, knobs, target context, replicated median tps + p95
+  TTFT, alternates (smaller candidates from input list by NAME
+  ONLY — never probed), exact serve command line.
+- `--json` output per FR-F.2 — the full JSON schema with
+  `spec_version`, `run_id`, `started_at/ended_at`, machine
+  fingerprint, inputs, recommendation, alternates, infeasible,
+  recipe_hash, db_path. Use RFC 8785 JCS for the hash input
+  canonicalization (the only published Swift JCS implementation
+  I'm aware of is small; if you can't find one, vendor a JCS
+  encoder following https://datatracker.ietf.org/doc/html/rfc8785).
+  Hash: SHA-256 of the JCS form of the §5.6 hash input table;
+  format `sha256:<64-lowercase-hex>`. AC-12 tests the
+  cross-implementation determinism (the test harness can
+  compute the same hash in Python or via shell `jq + sha256sum`
+  to verify).
+- `--apply` per FR-F.3 — atomic temp-file + rename to
+  `~/.config/macprovider/config.yaml`; backup as
+  `config.yaml.bak-<unix-ts>-<counter>` (lowest non-negative
+  free counter, no overwrite); modify ONLY the 4 owned keys
+  (`model`, `kv_bits`, `max_context_override`,
+  `max_concurrency_override`); carry all other keys verbatim
+  with comments preserved (use Yams' round-trip-preserving
+  YAML if available; otherwise document the comment-preservation
+  limitation in implementation-notes).
+- Print the launchd restart hint per FR-F.3 when `--apply` is
+  used without `--drain`.
+Deliverable: AC-9, AC-11, AC-12 pass.
+
+**Step 10. Failure modes + signal handling (FR-H.1-4).**
+Implement SIGINT / SIGTERM handler: stop the current candidate
+provider within `--drain-grace` (default 30s); write the
+partial `tune_runs` row with `exit_reason = 'interrupted'`;
+write the last in-flight `tune_trials` row; close the DB;
+exit code 130. Use Swift `DispatchSource.makeSignalSource(signal:)`
+on the main queue or equivalent.
+Wall-clock budget enforcement per NFR-1: `--max-duration` is a
+hard cap; mid-Stage-1 exhaustion → `exit_reason =
+'budget_exhausted_no_model_selected'`; mid-Stage-2 →
+`exit_reason = 'budget_exhausted_with_partial_recommendation'`
+with the best-so-far recommendation emitted.
+Deliverable: AC-10, AC-13 pass.
+
+**Step 11. Acceptance test suite.**
+Implement test fixtures and scripts in
+`phase3-binary/Tests/macprovider-cliTests/AutotuneTests/`
+covering AC-1 through AC-19. Some ACs need real binary
+execution (AC-6, AC-7); mark these as integration tests gated
+behind a `--enable-integration` swift test flag so unit tests
+remain fast.
+Deliverable: the full AC suite passes locally with both
+unit-only and integration runs.
+
+## Operator checkpoint timing
+
+The operator will check on the build at:
+- **T+15 minutes** — Are you reading required files? Do you
+  understand the SPEC-013 scope and the picked Option A? Any
+  immediate clarifying questions you'd want answered before
+  writing code?
+- **T+1 hour** — Step 1 should be complete (`autotune --help`
+  works, `autotune --dry-run` works). Any spec ambiguity
+  surfaced should be in implementation-notes.html Open Questions.
+- **End of day 1** — Steps 1-4 done is on track. The DB layer
+  and provider lifecycle are the technical risk.
+- **Daily during active work** — Operator reads
+  implementation-notes.html Open Questions and resolves them.
+
+If you have a question that blocks progress, STOP and write it
+to implementation-notes.html Open Questions. The operator will
+address it asynchronously. Do not invent answers to substantive
+spec ambiguity.
+
+## When to stop and ask vs proceed
+
+**Proceed without asking when:**
+- The spec answers your question exactly.
+- A trivial design choice has an obvious cheap default (pick it,
+  note in implementation-notes "SPEC-013 design decisions").
+- You can satisfy a requirement two equivalent ways; pick the
+  simpler.
+
+**Stop and ask (via Open Questions) when:**
+- A requirement conflicts with another requirement.
+- The spec assumes a Swift API that doesn't match the pinned
+  version's actual surface.
+- An AC is testable only with infrastructure that doesn't exist
+  yet (acceptable to defer; flag it).
+- You discover the runtime's online-fallback path is not what
+  SPEC-013 §5.4 Shape B claims.
+- The §10 implementation choice (Option A vs Option B) appears
+  to be genuinely blocked on something the BUILD prompt picks
+  wrong.
+
+## Acceptance gate
+
+When you believe Step 11 is complete:
+
+1. Run the full Swift test suite (`swift test --package-path
+   phase3-binary`). Every AC must pass. Capture pass/fail.
+2. Run a smoke test on a real Mac: a fresh
+   `macprovider-cli autotune --target-context 2000
+   --max-duration 600` end-to-end against the operator's
+   actual hardware (or a small candidate list to keep it short).
+   The recommendation block must print, the JSON schema must
+   validate against the FR-F.2 schema in §5.6, and the
+   `tune_runs.exit_reason` must be `'ok'`.
+3. Verify a fresh recipe_hash is reproducible: run the same
+   `autotune` invocation twice on the same Mac with the same
+   flags; both `tune_runs.recipe_hash` values MUST be identical
+   even though observed tps/ttft differ. This is AC-12 property 1.
+4. Write a final summary in implementation-notes.html:
+   "SPEC-013 Acceptance complete" section with per-AC pass/fail
+   and any deviations.
+
+Total expected effort: 1-2 weeks of active session work.
+
+## Hard rules
+
+1. **Do not modify SPEC-013 or any file under `specs/`.** This
+   build branch is downstream of the SPEC PR. If you find a real
+   spec bug, write it to implementation-notes.html Open Questions;
+   the operator amends the SPEC on the SPEC branch.
+
+2. **Do not modify code outside `phase3-binary/`.** Specifically:
+   do not touch `beta/`, `specs/`, `phase4-coordinator/`,
+   `phase5-gateway/`. The autotune subcommand is fully
+   self-contained in the binary.
+
+3. **Strict clean-room.** Reference hygiene above is enforceable.
+   If you find d-inference content via search, close the tab and
+   add an Open Question.
+
+4. **Commit checkpoints.** Commit working code at the end of each
+   completed Step (1 through 11). Operator can roll back to a
+   step boundary if needed. Commit messages: `feat(autotune)
+   Step N: <deliverable>`.
+
+5. **Never silently bump dependency versions.** Pinned versions
+   are contract. If a pin breaks, Open Question. Autotune adds
+   NO new top-level deps; the SQLite path uses the system
+   `libsqlite3` via Swift's C-interop or an existing repo helper
+   if one is already present.
+
+6. **Honor the FR contract.** Every FR-X has a binding rule.
+   `tune_trials.stage` defaults from migration are for backfill
+   ONLY; new inserts MUST set 1 or 2 explicitly. `recipe_hash`
+   format is `sha256:<64-lowercase-hex>` — verify in tests.
+   The `alternates` list is NAME-ONLY (no metrics) — AC-1 and
+   AC-2 verify.
+
+7. **No silent --apply restart.** `--apply` writes the config
+   and exits. It NEVER restarts launchd on its own (unless
+   `--drain` was also passed). FR-F.3 mandates a stderr hint
+   in the no-drain case.
+
+8. **Preserve the biggest-fit objective.** If you find yourself
+   considering "score candidates by tps and pick the highest" —
+   STOP. That is the prototype's anti-pattern objective that
+   SPEC-013 §1 explicitly rejects. The selection rule is
+   STOP-on-first-feasible per operator-supplied order. AC-17
+   catches this; reading it once before writing Stage 1 is
+   cheap insurance.
+
+## Anti-rules
+
+- Do not write build prompts for other SPECs.
+- Do not pre-optimize. Get correctness first, profile later.
+- Do not skip writing tests. Every FR should have a unit test
+  where feasible; every AC has a script or test case.
+- Do not implement coordinator-side recipe ingestion (§11 v2
+  deferral; SPEC-014 territory).
+- Do not implement warm-swap-driven tuning (§11 v2 deferral;
+  SPEC-011 coupling).
+- Do not implement the v2 `--resume` flag (§11 deferral).
+- Do not refactor unrelated files. The autotune subcommand is
+  additive. The only non-autotune edit you make is the
+  `--no-join` flag on `ServeCommand` (Step 2).
+
+## Open question template
+
+When you write an Open Question to implementation-notes.html,
+use this shape:
+
+```
+<section><h3>OQ-IMPL-N: <SHORT TITLE></h3>
+<p class=meta>Step N · status: <open|resolved> · added: <date></p>
+<p><strong>What:</strong> <one sentence>.</p>
+<p><strong>Why blocked:</strong> <one sentence on what you'd do
+if you had the answer>.</p>
+<p><strong>Spec reference:</strong> SPEC-013 § X.Y FR-Z (line ranges).</p>
+<p><strong>Proposed default if no operator response:</strong>
+<one sentence>.</p>
+</section>
+```
+
+The proposed-default sentence is critical: if the operator
+doesn't respond, you can proceed by adopting your own
+proposal and noting that in the resolution. Open Questions
+should not be a build blocker by themselves; they're a
+forcing function for the operator to check in.
+
+## Final pre-flight before you start
+
+Print to stdout:
+- Your understanding of the mission (1 sentence — must include
+  "biggest-fit, not max-tps").
+- Your understanding of the picked implementation choice (Option A
+  Swift-native).
+- The first 3 things you'll do in the first 15 minutes.
+- Any immediate questions for the operator (none is acceptable).
+
+Then begin Step 1 of the build sequence.
+
+Good luck. The spec is locked at v0.3; the operator is available
+asynchronously for substantive questions. Build well.
+
+=== END PROMPT ===
+```
+
+---
+
+## How to use
+
+```bash
+cd /Users/augstar/macprovider-poc
+git fetch origin
+git checkout -b feat/cli-autotune-impl origin/spec/cli-autotune-v1
+
+# Fire codex via omc ask:
+omc ask codex "$(cat specs/BUILD_SPEC_013_PROMPT.md | sed -n '/=== BEGIN PROMPT ===/,/=== END PROMPT ===/p' | sed '1d;$d')"
+```
+
+Or paste the content between `=== BEGIN PROMPT ===` and `=== END
+PROMPT ===` into a fresh interactive Codex CLI session.
+
+## What you should see in the first 15 minutes
+
+- Agent reads SPEC-013 (~3-5 min)
+- Agent skims SPEC-001, SPEC-003 §FR-C5, the audit report (~5
+  min)
+- Agent peeks at the prototype on the spike branch (~2 min)
+- Agent prints its mission understanding (must include
+  "biggest-fit, not max-tps") + first-15-min plan
+- Agent begins Step 1: `AutotuneCommand.swift` scaffolding
+
+Red flags to watch for in the first 15 min:
+
+- Agent jumps to coding before reading
+- Agent asks for clarification on the picked Option A (it
+  should accept the BUILD prompt's pick; if it pushes back,
+  that's a legitimate Open Question)
+- Agent attempts to read d-inference (clean-room violation)
+- Agent attempts to modify SPEC-013 (Hard Rule 1)
+- Agent silently pivots to Option B without an Open Question
+
+## Operator checkpoints — concrete actions
+
+**T+15 min:**
+```bash
+git -C /Users/augstar/macprovider-poc log --oneline -3
+cat /Users/augstar/macprovider-poc/phase3-binary/implementation-notes.html | grep -A3 'SPEC-013'
+```
+Look for any "Open questions" entries tagged OQ-IMPL-N. If
+blocking, answer asynchronously.
+
+**T+1 hour:**
+```bash
+ls /Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+git -C /Users/augstar/macprovider-poc log --oneline -5
+```
+Expect `AutotuneCommand.swift` scaffolded, Step 1 commit, and
+`macprovider-cli autotune --help` printing the flag set.
+
+**Daily:**
+Open implementation-notes.html in a browser, scan the SPEC-013
+sections. Resolve any open OQ-IMPL-N entries.
+
+## When build is done
+
+You'll know because:
+1. All 19 ACs (AC-1 through AC-19) pass
+2. Smoke test on a real Mac produces a valid recommendation +
+   recipe_hash
+3. `tune_runs.exit_reason = 'ok'` on the smoke test
+4. implementation-notes.html has "SPEC-013 Acceptance complete"
+   section
+
+At that point: open a PR for `feat/cli-autotune-impl` against
+`main` (the SPEC PR will have merged by then, or will merge
+just before). The build PR's body should lead with "implements
+SPEC-013 v0.3 Option A Swift-native; AC-1 through AC-19
+passing; deferred items per §11 unchanged."
+
+## Post-merge documentation hooks (per SPEC-013 §11 checklist)
+
+Once the build PR merges:
+
+1. Append a decision-log entry to `beta/DECISION_CRITERIA.md`
+   summarizing the biggest-fit lock, Option A choice, deferred
+   v2 items.
+2. Add a one-liner to SPEC-003 v0.x's onboarding flow:
+   "after install, consider `macprovider-cli autotune`."
+3. Patch SPEC-010 §11 and SPEC-011 §8/§11 cross-references
+   (SPEC-013 = autotune; recommended catalog is SPEC-014).
+4. Close PR #103 (the Python prototype) — either by closing as
+   superseded or by repurposing the branch for the air5 n=3
+   replication study that backs OQ-A through OQ-E.

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,7 +14,7 @@
 | SPEC-010 | Provider model catalog | v1.5 | [SPEC-010-model-catalog.md](SPEC-010-model-catalog.md) |
 | SPEC-011 | Operator-pushed warm swap | v0.5 | [SPEC-011-operator-pushed-warm-swap.md](SPEC-011-operator-pushed-warm-swap.md) |
 | SPEC-012 | Source spec history | v0.3 | [SPEC-012-source.md](SPEC-012-source.md) |
-| SPEC-013 | `macprovider-cli autotune` subcommand | v0.1 | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |
+| SPEC-013 | `macprovider-cli autotune` subcommand | v0.3 | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |
 
 **Version of record is line 3 of each spec; do not trust this index for compatibility decisions — read the spec header.** This index drifts; the spec headers do not. When in doubt, `grep -m1 '^\*\*Version' specs/SPEC-*.md`.
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,6 +14,7 @@
 | SPEC-010 | Provider model catalog | v1.5 | [SPEC-010-model-catalog.md](SPEC-010-model-catalog.md) |
 | SPEC-011 | Operator-pushed warm swap | v0.5 | [SPEC-011-operator-pushed-warm-swap.md](SPEC-011-operator-pushed-warm-swap.md) |
 | SPEC-012 | Source spec history | v0.3 | [SPEC-012-source.md](SPEC-012-source.md) |
+| SPEC-013 | `macprovider-cli autotune` subcommand | v0.1 | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |
 
 **Version of record is line 3 of each spec; do not trust this index for compatibility decisions — read the spec header.** This index drifts; the spec headers do not. When in doubt, `grep -m1 '^\*\*Version' specs/SPEC-*.md`.
 

--- a/specs/SPEC-013-audit.md
+++ b/specs/SPEC-013-audit.md
@@ -367,3 +367,63 @@ Recommendation: Update the stale comments/prose to v0.2/v1 wording and make NFR-
 - All 19 round-1 findings have explicit closure verdicts.
 - Required code spot-checks were performed: `Config.swift`, install artifacts, `ModelRuntime.swift`, and PR #103 `beta/autotune.py`.
 - No d-inference source was inspected.
+
+---
+
+## Round 3 audit (Codex on v0.3 — LOCK confirmation)
+
+**Audited:** SPEC-013 v0.3 (specs/SPEC-013-cli-autotune.md)
+**Auditor model:** Codex / GPT-5
+**Audit round:** 3 of N (LOCK confirmation)
+**Date:** 2026-06-18
+**Closure summary:** 4 CLOSED / 0 PARTIAL / 0 NOT CLOSED / 0 OVER-CLOSED across the 4 round-2 findings
+**Round-3 findings:** 0 CRITICAL anti-regression / 0 MAJOR new / 1 MINOR new
+**Lock verdict:** LOCK
+
+### Executive summary
+
+Verdict: **LOCK.** v0.3 closes the four round-2 cleanup findings without weakening the locked biggest-fit, ordered-candidate, local-only, or backward-compatible surfaces. The Shape A / Shape B pre-warm wording is now shape-neutral across FR-D.1, NFR-4, and AC-8, and the required code spot-check still supports the runtime-online-fallback description: `ModelRuntime.configuration(for:)` first checks a local HF snapshot and then falls back to `LLMModelFactory.shared.configuration(id:)`.
+
+I found one new MINOR version-drift issue in the FR-F.2 JSON/spec-version text: the v0.3 document still shows `"SPEC-013 v0.2"` as the producing spec example in one live recommendation surface. This does not block LOCK because the adjacent v0.3 SQL comment already states that writers emit their own producing version, but it should be corrected in the implementation PR or the next editorial spec touch.
+
+### Round-2 finding closures
+
+**N-D.1 — CLOSED.** v0.3 rewords NFR-4 to allow only the HuggingFace pre-warm fetch path selected by FR-D.1, explicitly covering both Shape A (`models pull` or equivalent) and Shape B (runtime online fallback during model load). The carve-out is scoped to an `autotune` run and to weight fetches only, so it does not reopen telemetry or recipe-upload egress. AC-8 is now shape-neutral and testable: Shape A mocks the pull/equivalent fetch, Shape B blocks HuggingFace egress at the network-mock layer, and both variants must classify the failure as pre-warm rather than measurement or generic load failure.
+
+**Z-B.1 — CLOSED.** FR-B.1 now contains the `--max-context-axis` parse contract directly: positive integer absolute token caps, sorted ascending before evaluation, each cell at least `--target-context`, invalid/duplicate cells rejected at flag-parse time with `config_error`, and the empty default treated as `[--target-context]`. The §7 / §5 conflict rule is explicit: §7 is reference-only and FR-B.1 wins, so the prior non-normative-placement gap is closed.
+
+**N-OQ-E.1 — CLOSED.** OQ-E now defines a measurable repeat protocol: at least 10 paired forward/reverse Stage 2 runs on air5, 60s idle between paired runs, compare keep-best winners per pair, and trigger v0.4 mitigation if `mismatch_pairs / 10 > 0.05` (one or more mismatches in the minimum 10-pair run). Ten pairs has marginal statistical power, but the spec is honest that this is a minimum and permits more pairs to tighten the confidence interval; for a v1 open-question gate, the protocol is sufficiently measurable.
+
+**O.1 — CLOSED.** All four named drift sites were updated: the `tune_runs.spec_version` SQL comment now uses a v0.3 example plus "writer emits its own producing version"; FR-H.2 now says the future `--resume` optimization is deferred from v1 and that v1 defaults to full rerun; NFR-3 now references `.bak-<unix-ts>-<counter>` with the collision-safe counter rationale; and §7 replaces "MAY change in v0.2" with a future-v0.x refinement rule preserving §5 semantics.
+
+### Round-3 new findings
+
+#### Category Z-CLOSURE
+
+(no findings)
+
+#### Category N-NEWGAPS-V03
+
+(no findings)
+
+#### Category R-REGRESSION-V03
+
+(no findings)
+
+Anti-regression spot-checks passed for the prompt's named surfaces. FR-D.1 still defines Shape A and Shape B as implementation choices under one measurement-isolation contract; FR-D.2 still splits transient pre-warm failures from integrity aborts; FR-F.3 still owns exactly `model`, `kv_bits`, `max_context_override`, and `max_concurrency_override`; FR-G.1 still uses the valid SQLite `stage INTEGER NOT NULL DEFAULT 1` migration; and AC-17 still proves operator-supplied order is honored verbatim with no internal rerank.
+
+#### Category O-OTHER-V03
+
+##### O-V03.1 FR-F.2 spec-version example still says v0.2 inside v0.3 [MINOR]
+
+Location: `specs/SPEC-013-cli-autotune.md` §5.6 FR-F.2, JSON example and `spec_version` bullet.
+
+What: The v0.3 document still shows `"spec_version": "SPEC-013 v0.2"` in the recommendation JSON example and says the canonical producing spec is `"SPEC-013 v0.2"`.
+
+Why it matters: v0.3 fixed the SQL comment to say the writer emits its own producing version, but an implementer copying the FR-F.2 JSON block literally could emit stale v0.2 identity from a v0.3 implementation. This is narrow documentation drift, not a behavior or architecture blocker.
+
+Recommendation: Change both FR-F.2 occurrences to either `"SPEC-013 v0.3"` or a placeholder such as `"SPEC-013 v<producing-version>"` with the existing rule that writers emit their own producing version.
+
+### Lock readiness
+
+**LOCK.** SPEC-013 v0.3 may be locked as-is. The four round-2 findings are closed, there are no CRITICAL anti-regressions and no MAJOR new precision gaps, and the single new MINOR is editorial version drift that does not block the implementing PR.

--- a/specs/SPEC-013-audit.md
+++ b/specs/SPEC-013-audit.md
@@ -1,0 +1,249 @@
+# SPEC-013 v0.1 — Audit Report
+
+**Audited:** SPEC-013 v0.1 (specs/SPEC-013-cli-autotune.md)  
+**Auditor model:** Codex / GPT-5  
+**Audit round:** 1 of N  
+**Date:** 2026-06-18  
+**Total findings:** 0 CRITICAL / 7 MAJOR / 11 MINOR / 2 QUESTION
+
+---
+
+## Executive summary
+
+Verdict: **not ready to lock as drafted; v0.2 should close the MAJOR findings and get a narrow round-2 audit.**
+
+SPEC-013 v0.1 preserves the locked product framing. I found no path where the main recommendation intentionally picks a smaller model over a larger feasible model, no cross-model max-tps objective, and no coordinator/billing/buyer-wire scope creep. FR-A.1/FR-A.2 are explicit that candidate-list order is the contract and that the first feasible model wins.
+
+The blockers are contract precision and implementation fit. The largest issues are that fallback reporting contradicts the STOP-on-first-feasible pipeline, `--apply` writes config keys the current binary does not read, the `tune_trials.stage` migration is not SQLite-valid as written, and the recipe hash is not reproducible across implementations. The pre-download and launchd/drain surfaces also need tightening because they are day-one operator workflows, not edge cases.
+
+Recommended next step: keep the two-stage architecture and biggest-fit objective intact, but draft SPEC-013 v0.2 with narrow fixes for the seven MAJOR findings below. The implementation-choice question in §10 can remain deferred to the implementing PR.
+
+## Category A: Product framing preservation
+
+### A.1  Fallback reporting contradicts STOP-on-first-feasible   [MAJOR]
+Location: §3 lines 157-168; §5.6 FR-F.1 lines 541-559; AC-1/AC-2 lines 912-924
+
+The main model-selection path correctly stops at the first feasible candidate, but the architecture and FR-F.1 say the recommendation includes every smaller candidate that also passed Stage 1 feasibility. Those smaller candidates are not probed after the chosen model, and AC-1/AC-2 correctly expect empty fallback lists when the loop stops before Z.
+
+Why it matters: an implementer cannot satisfy both "STOP iterating models" and "list every smaller candidate that also passed Stage 1" without adding a second fallback-probing phase. That would change wall-clock, DB rows, and possibly the operator's interpretation of the recommendation.
+
+Recommendation: v0.2 should either define fallbacks as "smaller candidates already evaluated before stop" (usually empty) or add an explicit optional fallback-probing phase that is outside the biggest-fit selection decision.
+
+## Category B: Two-stage pipeline correctness
+
+### B.1  Optional max-context axis lacks cell semantics   [MINOR]
+Location: §5.2 FR-B.1 lines 353-358; §7 lines 878-880
+
+FR-B.1 says the operator may pass `--max-context-axis` to opt into a small neighborhood, but it does not define whether values are absolute token caps, relative deltas around `--target-context`, sorted order, or whether cells below the target context are invalid.
+
+Why it matters: the default single-cell path is clear, so this does not block v0.1. The escape hatch is still underspecified enough that two implementations could test different neighborhoods and produce different recipes for the same flags.
+
+Recommendation: define `--max-context-axis` as an ordered comma-separated list of absolute token caps, require each cell to be `>= --target-context`, and state how invalid cells are rejected.
+
+## Category C: Knob-axis correctness vs PR #105
+
+### C.1  CLI summary drops the required unset kv-bits cell   [MINOR]
+Location: §5.2 FR-B.1 lines 342-358; §7 lines 872-880; PR #105 body; `MacProviderCLI.swift` lines 67-74
+
+The binding FR says the default kv-bits search is `{4, 8, unset}`, and PR #105 confirms unset maps to no `GenerateParameters.kvBits`. The CLI summary says `--kv-bits-axis <csv>` defaults to `'4,8'`, which omits the unquantized baseline.
+
+Why it matters: §7 is non-normative, but implementers commonly start from the flag summary. If they follow it literally, Stage 2 never tests the PR #105 default path and cannot recommend the baseline.
+
+Recommendation: make the summary match FR-B.1, e.g. default `unset,4,8`, and define how `unset` is represented in flags, JSON, SQL, and terminal output.
+
+## Category D: Pre-download integration (FR-D)
+
+### D.1  `models pull` is a larger missing precondition than the spec admits   [MAJOR]
+Location: §5.4 FR-D.1 lines 444-479; §12 lines 1166-1169; `ModelsSubcommand.swift` lines 5-14; `ModelRuntime.swift` lines 559-566 and 622-641
+
+SPEC-013 depends on `macprovider-cli models pull <id>`, but the current `models` subcommand only exposes list/switch/status/browse. The current runtime first checks the local HuggingFace snapshot path, then falls back to `LLMModelFactory.shared.configuration(id:)`; the code does not contain a locked "serve is HF-offline" contract or an existing download subcommand.
+
+Why it matters: FR-D is on the critical path before every candidate. A "one-screen pull subcommand" understates the needed contract: cache target, online/offline behavior, gated repos, progress, cancellation, partial downloads, and exact failure classes all affect autotune correctness and privacy expectations.
+
+Recommendation: either specify `models pull` enough for SPEC-013's needs, or split it into a prerequisite SPEC/FR with its own ACs. Also correct the offline-mode rationale to match the current binary behavior or make the offline requirement explicit.
+
+### D.2  Signature mismatch is treated like a candidate-level miss   [QUESTION]
+Location: §5.4 FR-D.2 lines 481-486
+
+FR-D.2 groups network down, missing weights, signature mismatch, and disk full under the same "record candidate infeasible and advance" rule.
+
+Why it matters: transient network and disk failures are plausibly candidate-local; a signature mismatch is security-relevant and may indicate cache corruption or supply-chain trouble. Continuing to smaller candidates could hide the stronger operator action needed.
+
+Recommendation: operator should decide whether signature/hash/integrity failures abort the whole run while ordinary pull failures advance.
+
+## Category E: Provider-conflict safety (FR-E)
+
+### E.1  launchd service identity and restore semantics do not match SPEC-003   [MAJOR]
+Location: §5.5 FR-E.1 lines 492-513; SPEC-003 §FR-C5 lines 415-478
+
+SPEC-013 names the launchd-managed install as `com.macprovider.cli` and requires drain to restore plist state on exit. SPEC-003's launchd label/path are `live.streamvc.macprovider` and `~/Library/LaunchAgents/live.streamvc.macprovider.plist`, with `KeepAlive.SuccessfulExit = false`.
+
+Why it matters: the common operator install path is launchd-managed. If the implementation looks for the wrong service label or does not define whether it uses `bootout/bootstrap`, clean SIGTERM, or a direct process handle, `--drain` can fail to stop the live provider or fail to restore it after tuning.
+
+Recommendation: bind FR-E.1 to the SPEC-003 label/path and define the exact launchd drain/restore sequence. Add an AC that exercises the launchd-managed install path.
+
+## Category F: Recommendation surface (FR-F) + JSON schema + recipe_hash
+
+### F.1  `--apply` writes config keys the current binary does not read   [MAJOR]
+Location: §5.6 FR-F.3 lines 644-670; SPEC-001 §FR-19 lines 693-705; `Config.swift` lines 229-252; `ServingKnobsConfigTests.swift` lines 61-100
+
+FR-F.3 says SPEC-013 owns `model`, `kv_bits`, `max_context_tokens`, and `max_batch`. The current config loader reads `model` and `kv_bits`, but the PR #105 config keys are `max_context_override` and `max_concurrency_override`; tests confirm YAML uses those names.
+
+Why it matters: `autotune --apply` would appear to succeed while leaving the recommended context and batch knobs unapplied. The next `serve` would read old/default values and run a different recipe than the recommendation block and JSON claim.
+
+Recommendation: change the owned-key list and examples to `model`, `kv_bits`, `max_context_override`, and `max_concurrency_override`, or explicitly add a config-schema migration in the implementing PR.
+
+### F.2  recipe_hash format and canonical JSON are not deterministic enough   [MAJOR]
+Location: §5.6 FR-F.2 lines 632-642; AC-12 lines 1001-1007
+
+The schema shows `"recipe_hash": "sha256:<32-byte-hex>"`, which is ambiguous because SHA-256 is 32 bytes but 64 hex characters. It also says the hash covers a "canonical-JSON form" without defining key ordering, whitespace, Unicode normalization, float/integer serialization, timestamp exclusion, or whether omitted/null fields are included.
+
+Why it matters: the hash is explicitly the v2 sticky identifier. Two implementations can produce different hashes for the same machine and recommendation, breaking replay, console ingestion, and future sticky-affinity semantics.
+
+Recommendation: specify the hash as `sha256:<64-lowercase-hex>` and define a canonicalization profile, preferably RFC 8785 JCS or an equivalent local rule set.
+
+### F.3  Backup naming can collide within one second   [MINOR]
+Location: §5.6 FR-F.3 lines 648-655; NFR-3 lines 838-848
+
+Backups are named `config.yaml.bak-<unix-ts>`. Two rapid `--apply` runs in the same second can target the same backup path.
+
+Why it matters: the second apply can overwrite the first backup unless the implementation adds a suffix or fails closed. This is rare but directly touches the reversibility invariant.
+
+Recommendation: require collision-safe backup names, e.g. nanosecond timestamp or `bak-<unix-ts>-<counter>` with no overwrite.
+
+## Category G: State / DB (FR-G)
+
+### G.1  `stage` upgrade is not valid SQLite as written   [MAJOR]
+Location: §5.7 FR-G.1 lines 684-712; PR #103 `beta/autotune.py` lines 115-151 and 158-166
+
+The new CREATE TABLE includes `stage INTEGER NOT NULL`, then the upgrade text says implementations must `ALTER TABLE ADD COLUMN stage` and default existing rows to `1`. SQLite cannot add a `NOT NULL` column to an existing populated table unless the column has a non-null DEFAULT, and the spec does not give the actual migration SQL.
+
+Why it matters: the first implementation running against a prototype DB can fail migration before any tuning starts, or silently create nullable `stage` values that violate AC-16 and reporting assumptions.
+
+Recommendation: spell the migration as `ALTER TABLE tune_trials ADD COLUMN stage INTEGER NOT NULL DEFAULT 1`, and say new inserts must set `1` or `2` explicitly.
+
+### G.2  Retention deletes are not required to be transactional   [MINOR]
+Location: §5.7 FR-G.1 lines 714-723
+
+Retention deletes both `tune_trials` and `tune_runs` rows outside the most recent N run IDs, but the spec does not require the sweep to run in one transaction.
+
+Why it matters: an interrupted retention sweep could delete summary rows without trial rows, or trial rows without their run summary, leaving reports inconsistent.
+
+Recommendation: require retention to run inside a single SQLite transaction after the new `tune_runs` row is created.
+
+## Category H: Failure modes (FR-H)
+
+### H.1  `--resume` appears in the v0.1 CLI despite being out of scope   [MINOR]
+Location: §5.8 FR-H.2 lines 771-778; §7 lines 891-895; §11 lines 1134-1135
+
+FR-H.2 and §11 defer `--resume` out of v0.1's normative contract, but the CLI summary lists `--resume` as a flag.
+
+Why it matters: even though §7 is reference-only, a listed flag creates user and implementer expectations. A partial or no-op `--resume` path can make crash recovery appear stronger than the v0.1 contract.
+
+Recommendation: remove `--resume` from the v0.1 flag summary or label it as "reserved; MUST exit unsupported in v0.1."
+
+## Category I: Non-functional requirements
+
+(no findings)
+
+Notes: The NFR-1 estimates are optimistic but still below the 7200s cap as expectations, not contracts. The NFR-4 hidden-egress risk is captured in D.1 because it depends on the unresolved `models pull` / runtime online-mode contract.
+
+## Category J: ACs are deterministically verifiable
+
+AC setup map checked: AC-1/2 use ordered fake candidates and trial-row assertions; AC-3 uses all-infeasible fixtures plus `tune_runs`; AC-4/5 use deterministic Stage-2 metric fixtures; AC-6 uses an existing serve listener; AC-7 watches spawn argv and coordinator non-registration; AC-8 stubs `models pull`; AC-9 observes temp-file/rename and backup content; AC-10 sends SIGINT; AC-11 schema-validates JSON; AC-12 replays same/different machine inputs; AC-13 uses a tiny max-duration; AC-14 checks default first probe; AC-15 checks override precedence; AC-16 checks stage row counts.
+
+### J.1  No AC proves operator-supplied order is honored without rerank   [MAJOR]
+Location: §5.1 FR-A.1 lines 263-275; AC-14/AC-15 lines 1019-1029
+
+FR-A.1 makes supplied order the contract and forbids internal feasibility re-ranking. AC-14 covers the default list's first entry, and AC-15 covers explicit-list precedence over size flags, but no AC gives an intentionally "wrong" operator order and proves the implementation honors it verbatim.
+
+Why it matters: this is the load-bearing biggest-fit guard. A well-meaning implementation could sort by estimated fit or size after parsing `--candidate-models` and still pass the current ACs.
+
+Recommendation: add an AC with `--candidate-models 1B,32B` where both fit; the recommendation must be 1B because the operator-supplied order wins.
+
+### J.2  Optional max-context axis has no acceptance coverage   [MINOR]
+Location: §5.2 FR-B.1 lines 353-358; AC-16 lines 1031-1036
+
+The ACs count the max-context axis size when present, but none exercises a non-default `--max-context-axis` path or proves the winning cell can change `recommendation.knobs.max_context`.
+
+Why it matters: this is an escape hatch, so the gap is minor. Without one test, the implementation may silently ignore the axis while still passing default-path tests.
+
+Recommendation: add a small fixture where two max-context cells are evaluated and the non-target-context cell wins.
+
+### J.3  Size-flag-only trimming and exit_reason enum need direct coverage   [MINOR]
+Location: §5.3 FR-C.2 lines 416-430; §5.7 FR-G.2 lines 730-750; AC-8/AC-13/AC-15 lines 965-1029
+
+AC-15 covers `--candidate-models` winning over `--max-model-size`, but no AC covers `--max-model-size 16B` alone trimming the default list. The `exit_reason` column examples also expand beyond the table's listed values in AC-13 (`budget_exhausted_*`) without a full enum in FR-G.2.
+
+Why it matters: both are low-effort contract locks that wrappers and reports will rely on.
+
+Recommendation: add one size-trim AC and replace the `exit_reason` comment with a normative enum covering `ok`, `interrupted`, `no_feasible`, `budget_exhausted_with_partial_recommendation`, `budget_exhausted_no_model_selected`, and implementation error strings if allowed.
+
+## Category K: Open questions
+
+### K.1  OQ-B and OQ-D thresholds are still qualitative   [MINOR]
+Location: §9 OQ-B/OQ-D lines 1055-1080
+
+OQ-A and OQ-C name measurable thresholds. OQ-B says data will show whether n=3 is sufficient, and OQ-D says data will show whether single-trial fit decisions are unstable, but neither states a quantitative decision rule.
+
+Why it matters: v0.2 can end up relitigating the same defaults because "sufficient" and "unstable" are not tied to a threshold.
+
+Recommendation: define concrete thresholds, e.g. allowed false-fit/false-reject rate for Stage 1 and minimum discriminable tps gap at n=3 for Stage 2.
+
+### K.2  Thermal/order effects are not flagged as an open question   [QUESTION]
+Location: §6 NFR-2 lines 825-836; §9 lines 1040-1080
+
+NFR-2 says v1 has no explicit thermal pacing, but §9 does not ask whether sequential Stage-2 cell order creates heat-soak bias. The default axis order is deterministic, so later cells may be measured on a hotter machine than earlier cells.
+
+Why it matters: this may or may not be load-bearing depending on the air5 replication data. If heat soak is material, the keep-best decision can favor earlier cells for reasons unrelated to recipe quality.
+
+Recommendation: operator should decide whether v0.2 needs a thermal/order OQ, randomized cell order, cooldown policy, or merely a note that deterministic order is accepted for v1.
+
+## Category L: Migration note correctness vs prototype
+
+### L.1  Prototype "pre-download" wording overstates what beta/autotune.py does   [MINOR]
+Location: §12 lines 1166-1169; PR #103 `beta/autotune.py` lines 224-257 and 452-470
+
+§12 says the prototype's pre-download via external install/cache pre-warm is replaced by `models pull`. The prototype code does not implement a pre-download step; it starts `serve`, waits for `/v1/models`, and treats load/offline/cache errors as trial failure notes.
+
+Why it matters: the migration note is informational, but it is meant to tell the implementer what can be reused. This wording makes the prototype look closer to FR-D than it is.
+
+Recommendation: rewrite the item to say the prototype's "weights must already be available or the candidate fails during load" behavior is replaced by explicit `models pull`.
+
+## Category M: Anything else (operator UX, docs drift, etc.)
+
+### M.1  Locked specs still use SPEC-013 for recommended catalog   [MINOR]
+Location: SPEC-010 §11 lines ~1328; SPEC-011 §8/§11 lines 242-251, 1162, 1737; SPEC-013 §11 lines 1137-1139
+
+SPEC-013 v0.1 takes the number for autotune and defers recommended catalog to provisionally SPEC-014, but locked SPEC-010 and SPEC-011 still contain references where "SPEC-013" means the future recommended-catalog surface.
+
+Why it matters: this is not a semantic conflict inside autotune, but it creates navigation drift for future BUILD prompts and readers following cross-spec breadcrumbs.
+
+Recommendation: add a companion annotation or follow-up documentation patch stating that the old recommended-catalog placeholder is now SPEC-014 provisional, while SPEC-013 is autotune.
+
+### M.2  SPEC-013 lock/implementation docs need explicit follow-up hooks   [MINOR]
+Location: §13 lines 1218-1239; specs/README.md line 17; originating prompt lines 142-147
+
+`specs/README.md` already has a SPEC-013 row. The draft does not mention the remaining lifecycle updates: SPEC-003 install/onboarding docs may need an "run autotune after install" note, `beta/DECISION_CRITERIA.md` needs a lock entry, and PR #103 should be closed or rebased after the implementation option is chosen.
+
+Why it matters: these are not v0.1 lock blockers, but they are exactly the project-memory steps that prevent prototype and spec drift.
+
+Recommendation: add a short "post-lock documentation/update checklist" or capture these in the decision-log entry when the operator locks SPEC-013.
+
+## Out of scope for this audit
+
+- Inspecting d-inference source (NOASSERTION license)
+- Rewriting the spec
+- Implementing the spec
+- Auditing SPEC-001 v1.4, SPEC-002 v1.3.5, SPEC-003 v0.9.2, SPEC-010 v1.5, SPEC-011 v0.5 themselves
+- Re-litigating the "biggest-fit vs max-tps" framing
+- Auditing PR #103's Python prototype as production code
+- Designing the v0.2 audit-response
+- Picking Option A (Swift-native) vs Option B (Python wrapper)
+
+## Self-verification
+
+- Required inputs were read, including SPEC-013 v0.1, the originating prompt, CLAUDE.md, AGENTS.md, SPEC-001/002/003/010/011, PR #105, PR #103 `beta/autotune.py`, and the requested code spot-checks.
+- Every category A-M has a section.
+- Every finding includes severity, location, what, why, and recommendation.
+- No d-inference source was inspected.

--- a/specs/SPEC-013-audit.md
+++ b/specs/SPEC-013-audit.md
@@ -247,3 +247,123 @@ Recommendation: add a short "post-lock documentation/update checklist" or captur
 - Every category A-M has a section.
 - Every finding includes severity, location, what, why, and recommendation.
 - No d-inference source was inspected.
+
+---
+
+## Round 2 audit (Codex on v0.2)
+
+**Audited:** SPEC-013 v0.2 (specs/SPEC-013-cli-autotune.md)
+**Auditor model:** Codex / GPT-5
+**Audit round:** 2 of N
+**Date:** 2026-06-18
+**Closure summary:** 17 CLOSED / 1 PARTIAL / 0 NOT CLOSED / 1 OVER-CLOSED across 7 MAJOR + 10 MINOR + 2 QUESTION round-1 findings
+**Round-2 findings:** 0 CRITICAL anti-regression / 1 MAJOR new / 3 MINOR new
+
+### Executive summary
+
+Verdict: **LOCK READY under the round-2 threshold, with one narrow v0.3 cleanup strongly recommended before implementation.**
+
+v0.2 closes the substance of the round-1 audit. The biggest-fit framing, STOP-on-first-feasible model iteration, in-model Stage 2 hill-climb, operator-supplied order contract, config-key mapping, launchd label, SQLite `stage` migration, and deterministic recipe hash are now implementable. The code spot-checks support the key factual repairs: `Config.swift` reads `max_context_override`, `max_concurrency_override`, and `kv_bits`; the install artifacts use `live.streamvc.macprovider`; `ModelRuntime.configuration(for:)` checks the local HF snapshot before falling back to `LLMModelFactory.shared.configuration(id:)`; and the PR #103 prototype starts `serve` / waits for `/v1/models` rather than pre-downloading weights.
+
+The remaining round-2 issue is a new precision gap introduced by the D.1 closure. FR-D now permits Shape B, where autotune relies on the runtime's online fallback during model load, but NFR-4 and AC-8 still speak as if the only allowed pre-warm network path is `macprovider-cli models pull`. That is not a product or architecture failure, but it is a day-one contract conflict for the implementing PR. The other findings are minor editorial/testability cleanups.
+
+### Round-1 finding closures
+
+A.1 -> CLOSED. v0.2 replaces metrics-bearing `fallbacks` with name-only `alternates` in §3 and FR-F.1/FR-F.2 (lines 292-296, 766-785, 870-874). AC-1 now expects `[Z]` as an unprobed smaller alternate and explicitly forbids a Z trial row (lines 1284-1290), so the STOP-on-first-feasible failure mode is closed.
+
+D.1 -> OVER-CLOSED. The original missing `models pull` precondition is no longer load-bearing: FR-D.1 makes the operative contract "weights are present before measurement" and permits Shape A or Shape B (lines 575-626), matching the current runtime fallback behavior in `ModelRuntime.swift` lines 559-566 and 622-641. However, that Shape B closure introduces the new N-D.1 precision gap below because NFR-4 and AC-8 still assume the only pre-warm network/failure surface is `models pull`.
+
+E.1 -> CLOSED. FR-E.1 now binds to `live.streamvc.macprovider`, `~/Library/LaunchAgents/live.streamvc.macprovider.plist`, `launchctl bootout`, and `launchctl bootstrap` (lines 663-712). The code spot-check matches: `install.sh` renders the same label at lines 748-749, loads the plist via launchctl at lines 728-729, detects it at line 923, and the plist template has `KeepAlive.SuccessfulExit = false` at lines 25-28.
+
+F.1 -> CLOSED. FR-F.2 and FR-F.3 now use YAML key names `kv_bits`, `max_context_override`, and `max_concurrency_override` (lines 857-866, 935-947). `Config.swift` confirms those are parsed at lines 239-241. The JSON surface and CLI `serve_command` keep CLI flag names separate, which closes the "apply writes unread keys" failure mode.
+
+F.2 -> CLOSED. `recipe_hash` is now `sha256:<64-lowercase-hex>`, with RFC 8785 JCS and an explicit input domain that excludes run IDs, timestamps, observations, alternates, infeasible rows, DB path, and serve command (lines 875-905). The hash input fields all exist in the FR-F.2 schema, and AC-12 requires same-machine, cross-implementation, machine-sensitive, and binary-sensitive test vectors (lines 1396-1421).
+
+G.1 -> CLOSED. The migration is now spelled as valid SQLite: `ALTER TABLE tune_trials ADD COLUMN stage INTEGER NOT NULL DEFAULT 1` (lines 1009-1022). New inserts must set `stage` explicitly to 1 or 2 (lines 1024-1029), and AC-16 verifies both row counts and migration against a populated prototype DB (lines 1445-1453).
+
+J.1 -> CLOSED. AC-17 now tests an intentionally wrong operator order, `1B,32B`, on hardware where both are feasible and requires the 1B recommendation with exactly one Stage 1 row (lines 1455-1475). An implementation that internally re-sorts by parameter count would fail this AC.
+
+B.1 -> PARTIAL. v0.2 adds useful semantics for `--max-context-axis`: §7 says values are absolute token caps, sorted ascending, and each must be `>= --target-context` (lines 1231-1233), and AC-18 checks an invalid below-target cell at flag-parse time (lines 1477-1487). The binding FR-B.1 text still only says "small neighborhood" and points to operator opt-in (lines 484-489), while §7 declares itself non-normative (lines 1218-1221). See Z-B.1.
+
+C.1 -> CLOSED. The CLI summary now defaults `--kv-bits-axis` to `unset,4,8` and defines `unset` across flag, JSON, SQL, YAML, terminal, and `serve_command` surfaces (lines 1229, 1257-1268). FR-B.1 also includes the unset-default cell (lines 477-479).
+
+F.3 -> CLOSED. FR-F.3 now requires `config.yaml.bak-<unix-ts>-<counter>`, picks the lowest free counter, forbids overwrite, and aborts after counter exhaustion (lines 922-931). AC-9 directly tests two applies in the same wall-clock second and requires distinct counters (lines 1365-1370).
+
+G.2 -> CLOSED. Retention now keeps at least N runs, enforces `N >= 1`, and requires a single SQLite transaction covering both `tune_trials` and `tune_runs` deletes (lines 1031-1041). This closes the orphan-summary/orphan-trials crash window named in round 1.
+
+H.1 -> CLOSED. `--resume` is removed from the §7 flag summary (lines 1223-1251), and §11 keeps resume deferred as v2 optimization (line 1622). FR-H.2 still mentions the future flag as best-effort/out-of-scope, but the v0.1 issue was the advertised v1 CLI surface.
+
+J.2 -> CLOSED. AC-18 now exercises a non-default `--max-context-axis 4000,8000` path, requires an 8000 winning cell to appear in `recommendation.knobs.max_context_override`, verifies extra Stage 2 rows, and rejects a below-target axis at flag-parse time (lines 1477-1487).
+
+J.3 -> CLOSED. AC-19 covers `--max-model-size` alone trimming the default list (lines 1489-1497), and `tune_runs.exit_reason` is now a closed enum with no free-form strings (lines 1079-1097). The enum covers the budget-exhausted cases used by AC-13.
+
+K.1 -> CLOSED. OQ-B now defines a 90% confidence minimum-discriminable-gap threshold tied to `TPS_TIE_EPSILON` (lines 1516-1525), and OQ-D defines false-fit / false-reject thresholds with concrete default-change outcomes (lines 1538-1548). The thresholds are measurable from the planned air5 replication data.
+
+L.1 -> CLOSED. §12 now correctly says the prototype has no explicit pre-download step; `evaluate_candidate` starts `serve`, waits for `/v1/models`, and records load failures as trial notes (lines 1704-1717). The PR #103 branch confirms this behavior in `beta/autotune.py` lines 294-344 and 880-948.
+
+M.1 -> CLOSED. §11 now explicitly renumbers SPEC-013 as autotune and provisional SPEC-014 as the coordinator-served recommended catalog (lines 1624-1647). A repo search found no existing `SPEC-014-*.md`; the remaining SPEC-010/SPEC-011 references are listed as follow-up documentation patches.
+
+D.2 -> CLOSED. FR-D.2 splits transient failures from integrity failures, advances only on transient pre-warm failures, and aborts the whole run for signature/hash/tampering/shape failures with `exit_reason = 'pre_warm_integrity_failure'` (lines 628-650). FR-H.3 repeats the same split for operational recovery (lines 1122-1137).
+
+K.2 -> CLOSED. v0.2 adds OQ-E for thermal/cell-order bias and preserves deterministic v1 order pending data (lines 1550-1567). The round-1 question was whether the spec should surface the design choice; it now does. See N-OQ-E.1 for a minor measurement-procedure gap inside the new OQ.
+
+### Round-2 new findings
+
+#### Category Z-CLOSURE
+
+##### Z-B.1 `--max-context-axis` semantics are still partly outside the binding FR [MINOR]
+Location: §5.2 FR-B.1 lines 484-489; §7 lines 1218-1233; AC-18 lines 1477-1487.
+
+What: v0.2 defines the useful `--max-context-axis` parse rules in §7, but §7 says it is reference-only and "the normative surface is the FRs above." FR-B.1 itself does not say values are absolute caps, sorted ascending, or rejected when below `--target-context`; only AC-18 locks the below-target rejection case.
+
+Why it matters: the main escape hatch now works in tests, but an implementer reading only the binding FR can still choose a different parse/order rule for valid values. This is not a lock blocker because AC-18 catches the highest-risk invalid-cell case, but it leaves the B.1 closure less clean than the change log claims.
+
+Recommendation: Move the §7 parse sentence into FR-B.1: "`--max-context-axis` is a comma-separated list of absolute token caps, sorted ascending after parse, each value MUST be >= `--target-context`; invalid cells fail at flag-parse time with `config_error`."
+
+#### Category R-REGRESSION
+
+(no findings)
+
+Anti-regression spot-checks passed for the unchanged surfaces named in the prompt: FR-A still stops on first feasible and uses input order (lines 394-430); FR-B.2 still uses throughput primary plus TTFT tie-break within `TPS_TIE_EPSILON` (lines 495-511); FR-C still keeps the curated local default list and operator overrides (lines 523-569); FR-E.2 remains an implementation precondition for `--no-join` (lines 725-745); NFR-1/2/3 retain the local, single-provider, reversible tuning posture (lines 1150-1199); NFR-4 still preserves the no-telemetry/no-upload invariant (lines 1201-1214), with the Shape B egress wording gap filed separately as N-D.1; and AC-1 through AC-5, AC-7, AC-8, AC-10, AC-11, AC-13, AC-14, and AC-15 still test the intended v0.1 behavior after the `fallbacks` -> `alternates` edit.
+
+#### Category N-NEWGAPS
+
+##### N-D.1 Shape B pre-warm conflicts with the remaining `models pull`-only wording [MAJOR]
+Location: §5.4 FR-D.1 lines 588-626; §5.8 FR-H.3 lines 1122-1125; §6 NFR-4 lines 1201-1209; §8 AC-8 lines 1352-1357.
+
+What: FR-D.1 now permits Shape B: rely on `ModelRuntime`'s online fallback during load, measure load time separately, and start the first measured request only after weights are warm. FR-H.3 also names "Shape B's online-fallback HTTP failure." But NFR-4 still says autotune performs no network egress except `models pull <id>` to HuggingFace, and AC-8 tests only a mocked `macprovider-cli models pull <id>` failure.
+
+Why it matters: D.1's original failure mode is closed, but the closure leaves two inconsistent implementation contracts. A Shape B implementation would satisfy FR-D.1 yet violate the literal NFR-4 egress exception and would not have a matching pre-warm-failure AC. A Shape A implementation is fine, but v0.2 explicitly says Shape B is permitted, so the spec needs to make the egress and test contract shape-neutral.
+
+Recommendation: Reword NFR-4 to allow "the HuggingFace pre-warm fetch path selected by FR-D.1, whether explicit `models pull` or runtime online fallback" and update AC-8 to run against the implementation's selected pre-warm mechanism. If both shapes remain allowed, AC-8 should have Shape A and Shape B variants or a fixture abstraction that fails the pre-warm step before measurement regardless of mechanism.
+
+##### N-OQ-E.1 Thermal/order threshold lacks a repeat protocol [MINOR]
+Location: §9 OQ-E lines 1550-1567.
+
+What: OQ-E defines a quantitative threshold: reverse-order evaluation producing a different keep-best winner more than 5% of the time. It does not specify the sampling protocol: how many forward/reverse repeats, whether the same cell set is interleaved or blocked, and how the planned air5 n=3 data can estimate a "more than 5%" event rate.
+
+Why it matters: This does not block v1 because OQ-E is explicitly pending data and deterministic order is preserved. It does affect whether the operator can close the OQ without relitigating methodology.
+
+Recommendation: Add one sentence: "Measure by running the same Stage 2 cell set in forward and reverse order for at least N paired runs on air5; compare keep-best winners per pair; if mismatches / pairs > 0.05, v0.3 must add randomization or cooldown."
+
+#### Category O-OTHER
+
+##### O.1 Residual v0.1 / pre-v0.2 wording drift remains in live normative text [MINOR]
+Location: §5.7 FR-G.2 line 1057; §5.8 FR-H.2 lines 1117-1120; §6 NFR-3 line 1191; §7 line 1270.
+
+What: Several live v0.2 sections still carry stale wording: the `tune_runs.spec_version` SQL comment says `'SPEC-013 v0.1'` while FR-F.2 emits `"SPEC-013 v0.2"`; FR-H.2 says `--resume` is "out of scope for v0.1's normative contract" and "v0.1 default behavior"; NFR-3 still names `.bak-<unix-ts>` instead of the new collision-safe `.bak-<unix-ts>-<counter>`; and §7 says "The flag shape MAY change in v0.2" inside the v0.2 draft.
+
+Why it matters: These are not behavioral blockers because the surrounding sections are clear. They do create avoidable audit noise and can mislead implementers copying schema comments or lifecycle prose into tests.
+
+Recommendation: Update the stale comments/prose to v0.2/v1 wording and make NFR-3 reference the exact FR-F.3 backup pattern.
+
+### Lock readiness
+
+**LOCK READY.** Round 2 found no CRITICAL anti-regressions and only one MAJOR new precision gap. Under the prompt's lock-readiness rule, the operator may lock v0.2 or roll a narrow v0.3. I recommend a narrow v0.3 that fixes N-D.1 plus the three MINORs before implementation, because all fixes are localized prose/test-contract edits and do not change the architecture.
+
+### Self-verification
+
+- The new section was appended after the round-1 report; round-1 sections were not edited.
+- All 19 round-1 findings have explicit closure verdicts.
+- Required code spot-checks were performed: `Config.swift`, install artifacts, `ModelRuntime.swift`, and PR #103 `beta/autotune.py`.
+- No d-inference source was inspected.

--- a/specs/SPEC-013-cli-autotune.md
+++ b/specs/SPEC-013-cli-autotune.md
@@ -1,7 +1,7 @@
 # SPEC-013 — `macprovider-cli autotune` subcommand
 
-**Version:** 0.2 (round-1 audit response)
-**Status:** Draft (pre round-2 audit)
+**Version:** 0.3 (round-2 audit response — LOCK candidate)
+**Status:** Draft (pre round-3 closure-confirmation audit)
 **Date drafted:** 2026-06-18
 **Depends on:** SPEC-001 v1.4 (`macprovider-cli serve` flags `--kv-bits`, `--max-context`, `--max-batch` per PR #105), SPEC-010 v1.5 (provider-advertised `supported_models[]` shape, model id semantics)
 **Companion to (LOCKED):** SPEC-002 v1.3.5 (no coordinator-side change required), SPEC-003 v0.9.2 (autotune is invoked before / between `macprovider-cli serve` lifetimes; not part of install flow; SPEC-013 v0.2 binds the launchd label and drain sequence to SPEC-003 §FR-C5)
@@ -16,6 +16,41 @@ pre-SPEC-013.
 ---
 
 ## Change log
+
+### v0.3 (2026-06-18) — round-2 audit response (LOCK candidate)
+
+Codex round 2 (`specs/SPEC-013-audit.md` § Round 2) returned
+`17 CLOSED / 1 PARTIAL / 0 NOT CLOSED / 1 OVER-CLOSED` on the
+round-1 findings and `0 CRITICAL anti-regression / 1 MAJOR new /
+3 MINOR new`. Verdict: LOCK READY; codex recommended a narrow
+v0.3 closing the 4 new findings before implementation. v0.3
+closes all 4. No architecture change.
+
+- **N-D.1 fix (MAJOR — Shape B vs `models pull`-only wording
+  inconsistency):** v0.2 permitted FR-D Shape B (rely on the
+  runtime's online fallback during load + measurement
+  isolation), but NFR-4's egress carve-out and AC-8 still
+  spoke only of `macprovider-cli models pull <id>` failures.
+  v0.3 reworords NFR-4's egress exception to "the
+  HuggingFace pre-warm fetch path selected by FR-D.1, whether
+  explicit `models pull` or runtime online fallback" and
+  updates AC-8 to test the implementation's selected pre-warm
+  mechanism (with explicit Shape A / Shape B variants).
+- **Z-B.1 fix (PARTIAL → CLOSED — `--max-context-axis` parse
+  rules were in non-normative §7 but not in binding FR-B.1):**
+  v0.3 lifts the parse rules (absolute token caps, sorted
+  ascending, each cell ≥ `--target-context`, flag-parse-time
+  rejection of invalid cells) into FR-B.1 as a normative
+  paragraph.
+- **N-OQ-E.1 fix (MINOR — OQ-E thermal threshold lacked a
+  repeat protocol):** v0.3 adds a sampling protocol (minimum
+  10 paired forward/reverse runs on air5; mismatch rate over
+  pairs is the metric).
+- **O.1 fix (MINOR — residual v0.1-era wording drift in live
+  text):** v0.3 closes four discrete drift sites — the
+  `tune_runs.spec_version` SQL comment, FR-H.2's "v0.1
+  normative contract" prose, NFR-3's stale `.bak-<unix-ts>`
+  pattern, and §7's "MAY change in v0.2" disclaimer.
 
 ### v0.2 (2026-06-18) — round-1 audit response
 
@@ -487,6 +522,30 @@ of:
   This axis is OPTIONAL in v1; the recommended `max_context` in the
   output equals `--target-context` unless the operator opted into
   the axis and a different cell won.
+
+  **`--max-context-axis` parse rules (NORMATIVE — round-2 Z-B.1
+  closure).** When the operator passes `--max-context-axis <csv>`,
+  the implementation MUST:
+
+  - Parse the value as a comma-separated list of positive integers
+    interpreted as ABSOLUTE token caps (not deltas relative to
+    `--target-context`).
+  - Sort the parsed cells in ascending order before evaluation.
+  - Reject any cell whose value is strictly less than
+    `--target-context` at FLAG-PARSE TIME (before any DB write,
+    before any provider spawn), exiting non-zero with
+    `tune_runs.exit_reason = 'config_error'` and a stderr message
+    naming the offending cell and the `--target-context` floor.
+  - Reject duplicate cells (after sort) at flag-parse time with
+    the same `config_error` exit.
+  - Treat an EMPTY axis (the default) as the single-cell case
+    `[--target-context]`; the recommended `max_context_override`
+    equals `--target-context` and FR-F.3's `--apply` writes that
+    value.
+
+  These parse rules are part of the binding FR-B.1 contract; the
+  §7 CLI summary is reference-only and any §7-vs-FR-B.1 conflict
+  is resolved in FR-B.1's favor.
 
 Each cell MUST be evaluated with `stage2_replicates` replicates
 (default 3 — **OPEN QUESTION OQ-B** pending air5 n=3 data) at the
@@ -1054,7 +1113,7 @@ CREATE TABLE IF NOT EXISTS tune_runs (
     run_id TEXT PRIMARY KEY,
     started_at_utc TEXT NOT NULL,
     ended_at_utc TEXT,                       -- NULL if interrupted
-    spec_version TEXT NOT NULL,              -- 'SPEC-013 v0.1'
+    spec_version TEXT NOT NULL,              -- e.g. 'SPEC-013 v0.3'; writer emits its own producing version
     binary_version TEXT NOT NULL,
     machine_ram_gb INTEGER NOT NULL,
     machine_chip TEXT NOT NULL,
@@ -1114,10 +1173,10 @@ provider, port released, DB in a consistent state.
 A crashed run leaves its `tune_runs.ended_at_utc` as NULL and any
 written `tune_trials` rows as-is. Rerun is safe: a fresh `run_id`
 opens a fresh `tune_runs` row; the old run's data is preserved and
-reusable by reporting. The operator MAY pass `--resume` to skip
-Stage 1 candidates that the prior crashed run already proved
-infeasible (best-effort optimization; out of scope for v0.1's
-normative contract — see §11). v0.1 default behavior is full rerun.
+reusable by reporting. A future `--resume` flag could skip Stage 1
+candidates that the prior crashed run already proved infeasible
+(best-effort optimization; deferred from v1's normative contract
+— see §11). v1 default behavior is full rerun.
 
 **FR-H.3. Network down during pre-warm.**
 A failed pre-warm fetch (Shape A `models pull` exit non-zero, or
@@ -1188,8 +1247,10 @@ thermal pacing.
 
 **NFR-3. Reversibility.**
 Pre-tune `~/.config/macprovider/config.yaml` is ALWAYS recoverable
-via the `.bak-<unix-ts>` file written by `--apply` (FR-F.3). If
-`--apply` was not used, the config was not touched. There is no
+via the `.bak-<unix-ts>-<counter>` file written by `--apply` per
+FR-F.3 (collision-safe; the counter ensures two `--apply` runs in
+the same wall-clock second never overwrite each other's backup).
+If `--apply` was not used, the config was not touched. There is no
 case in which an autotune run renders the prior config
 unrecoverable.
 
@@ -1205,13 +1266,28 @@ fingerprint (`ram_gb`, `chip`, `os_version`, `binary_version`)
 appears in `tune_runs.machine_*` columns and in the FR-F.2 JSON
 output for local consumption by `console.streamvc.live` (when the
 operator chooses to share that JSON), but `autotune` itself
-performs no network egress except `models pull <id>` to
-HuggingFace.
+performs no network egress except the **HuggingFace pre-warm
+fetch path selected by FR-D.1** — i.e. either:
+
+- **Shape A:** explicit `macprovider-cli models pull <id>` (or
+  equivalent operator-invoked fetch) per FR-D.1.
+- **Shape B:** the runtime's online fallback during model load
+  (`LLMModelFactory.shared.configuration(id:)` reaches HuggingFace
+  when the local snapshot is not cached) per FR-D.1's
+  measurement-isolation contract.
+
+Both shapes egress only to HuggingFace and only for weight
+fetches — no telemetry, no observability beacons, no recipe
+upload. An implementation that performs ANY other network egress
+during a `autotune` run is a contract violation. (Round-2 N-D.1
+closure.)
 
 The coordinator-side recipe registry is v2 territory — see §11.
 Even when it ships, it MUST be opt-in. The v1 design intentionally
 keeps the recipe wholly local so operators can run autotune on
-private/air-gapped Macs.
+private/air-gapped Macs (which by definition will use Shape A
+with pre-staged weights, since Shape B's online fallback would
+fail with a transient-class pre-warm error per FR-D.2).
 
 ---
 
@@ -1267,8 +1343,12 @@ KV-cache baseline). Representation across surfaces:
 | terminal display | the literal string `unset` |
 | `serve_command` line | `--kv-bits` flag omitted entirely |
 
-The flag shape MAY change in v0.2 based on audit feedback. The
-SEMANTICS in §5 are the normative surface.
+§7 is REFERENCE-ONLY; the SEMANTICS in §5 (especially the FR-B.1
+`--max-context-axis` parse rules and the §5.6 / §5.7 owned-key
+sets) are the normative surface. Any conflict between §7 and §5
+is resolved in §5's favor at implementation time. The flag shape
+above MAY be refined in a future v0.x as long as the §5 semantics
+are preserved.
 
 ---
 
@@ -1349,12 +1429,34 @@ observe any provider connection during the autotune run (verified
 via an integration test that watches the coordinator's
 `/admin/pool/check` or equivalent).
 
-**AC-8. Pre-download failure advances to next candidate.**
-With `macprovider-cli models pull <id>` mocked to fail for candidate
-1, the run MUST emit an infeasibility row for candidate 1 with notes
-containing the pull error message and proceed to candidate 2. The
-`tune_runs.exit_reason` MUST be `'ok'` IFF some candidate
-succeeded, otherwise `'no_feasible'`.
+**AC-8. Pre-warm failure advances to next candidate (shape-neutral).**
+The test MUST exercise the implementation's selected pre-warm
+mechanism per FR-D.1 — NOT a specific subcommand name (round-2
+N-D.1 closure). Both Shape A and Shape B implementations MUST
+satisfy this AC; the test harness MUST provide a fixture that
+forces a transient-class pre-warm failure for candidate 1
+without specifying HOW:
+
+- **Shape A variant** (the implementation invokes
+  `macprovider-cli models pull <id>` or equivalent): mock the
+  pull subcommand to exit non-zero (e.g. simulated HTTP 503).
+- **Shape B variant** (the implementation relies on the runtime
+  online-fallback): block egress to HuggingFace at the
+  network-mock layer so the runtime's online fetch fails during
+  load; the autotune MUST classify this as a Shape-B pre-warm
+  failure (not as a load-runtime-error) by inspecting the
+  failure mode against FR-D.1's measurement-isolation contract.
+
+In either variant, the run MUST emit an infeasibility row for
+candidate 1 with `notes` containing the pre-warm error message
+and the transient/integrity classification (per FR-D.2), proceed
+to candidate 2, and end with `tune_runs.exit_reason = 'ok'` IFF
+some candidate succeeded, otherwise `'no_feasible'`. A separate
+test variant MUST force a Shape A INTEGRITY-class failure
+(simulated signature mismatch); per FR-D.2, the whole run MUST
+abort with `exit_reason = 'pre_warm_integrity_failure'` —
+this asymmetric handling distinguishes AC-8 from the simpler
+"advance on any pull failure" pattern.
 
 **AC-9. `--apply` is atomic + backs up + idempotent.**
 With `--apply`, a successful run MUST:
@@ -1563,8 +1665,24 @@ drives the recommendation), v0.3 will need ONE of:
 Decision threshold: if the same Stage 2 cell set, evaluated in
 reverse order, would produce a DIFFERENT keep-best winner more
 than 5% of the time on air5 n=3 data, the bias is load-bearing
-and v0.3 must address it. v0.2 ships the deterministic order
-unchanged pending the data; operators are warned in §6 NFR-2.
+and v0.4 must address it.
+
+**Sampling protocol** (round-2 N-OQ-E.1 closure). Measure by
+running the same Stage 2 cell set in FORWARD and REVERSE order
+for at least **10 paired runs** on air5 (one forward run + one
+reverse run = one pair). Between paired runs, idle the machine
+for at least 60s to dissipate heat soak from the prior run.
+Compare keep-best winners per pair; if `mismatch_pairs / 10 >
+0.05` (i.e. ≥ 1 mismatch in 10 pairs), the bias is load-bearing
+and v0.4 must add ONE of randomized cell order (with the seed
+recorded in `tune_runs` for replay), a fixed inter-cell cooldown
+delay, or a thermal-state probe + pause-until-quiet gate. 10
+pairs is the minimum; the operator MAY run more pairs to tighten
+the confidence interval but the 5% threshold and pair-mismatch
+metric are normative.
+
+v1 ships the deterministic order unchanged pending the data;
+operators are warned in §6 NFR-2.
 
 ---
 

--- a/specs/SPEC-013-cli-autotune.md
+++ b/specs/SPEC-013-cli-autotune.md
@@ -1,10 +1,10 @@
 # SPEC-013 — `macprovider-cli autotune` subcommand
 
-**Version:** 0.1 (initial draft)
-**Status:** Draft (pre round-1 audit)
+**Version:** 0.2 (round-1 audit response)
+**Status:** Draft (pre round-2 audit)
 **Date drafted:** 2026-06-18
 **Depends on:** SPEC-001 v1.4 (`macprovider-cli serve` flags `--kv-bits`, `--max-context`, `--max-batch` per PR #105), SPEC-010 v1.5 (provider-advertised `supported_models[]` shape, model id semantics)
-**Companion to (LOCKED):** SPEC-002 v1.3.5 (no coordinator-side change required), SPEC-003 v0.9.2 (autotune is invoked before / between `macprovider-cli serve` lifetimes; not part of install flow)
+**Companion to (LOCKED):** SPEC-002 v1.3.5 (no coordinator-side change required), SPEC-003 v0.9.2 (autotune is invoked before / between `macprovider-cli serve` lifetimes; not part of install flow; SPEC-013 v0.2 binds the launchd label and drain sequence to SPEC-003 §FR-C5)
 **Related (future):** SPEC-011 v0.5 (warm-swap; opt-in coupling deferred to v2 — see §11)
 
 SPEC-013 is operator-facing CLI surface only. It MUST NOT modify any
@@ -16,6 +16,131 @@ pre-SPEC-013.
 ---
 
 ## Change log
+
+### v0.2 (2026-06-18) — round-1 audit response
+
+Codex round 1 (`specs/SPEC-013-audit.md`) returned `0 CRITICAL / 7
+MAJOR / 11 MINOR / 2 QUESTION`. v0.2 closes all 7 MAJORs, 10 of
+11 MINORs, and both QUESTIONs. The product framing (§1) and the
+two-stage architecture (§3) are unchanged; the round-1 verdict
+explicitly preserved both.
+
+**MAJORs closed:**
+
+- **A.1 fix** (fallbacks contradicted STOP-on-first-feasible):
+  FR-F.1 and FR-F.2 no longer emit "fallbacks" as
+  metrics-bearing entries (which would have required a
+  separate fallback-probing pass that contradicted the
+  largest-first STOP rule). The recommendation now emits an
+  `alternates` list of NAME-ONLY smaller candidate IDs from
+  the input list — operators who want to manually downsize
+  invoke a follow-up `autotune --candidate-models <id>`. AC-1
+  and AC-2 are updated.
+- **D.1 fix** (`models pull` was a bigger missing precondition
+  than v0.1 admitted; the current binary has no `pull`
+  subcommand and no locked HF-offline contract): FR-D
+  rewritten to make the OPERATIVE requirement "candidate
+  weights MUST be cache-warm before the feasibility probe
+  begins" and to make load-fetch latency normative-excluded
+  from the gate-ttft-ms metric. The HOW is implementation
+  choice, deferred to the implementing PR. The `models pull`
+  subcommand shape is no longer a SPEC-013 v1 normative
+  dependency; it remains a recommended mechanism and a
+  follow-on SPEC may formalize it.
+- **E.1 fix** (launchd label `com.macprovider.cli` was
+  wrong): FR-E.1 now binds to SPEC-003 v0.9.2's actual label
+  `live.streamvc.macprovider` and plist path
+  `~/Library/LaunchAgents/live.streamvc.macprovider.plist`.
+  The drain sequence is `launchctl bootout
+  gui/$UID/live.streamvc.macprovider` to stop and
+  `launchctl bootstrap gui/$UID <plist>` to restore. AC-6 is
+  extended to cover the launchd-managed install path.
+- **F.1 fix** (`--apply` wrote keys the binary doesn't read):
+  FR-F.3 owned-key list updated to match the actual
+  `Config.swift` parser
+  (`max_context_override` instead of `max_context_tokens`,
+  `max_concurrency_override` instead of `max_batch`). The
+  FR-F.2 JSON `knobs` object now uses these YAML key names
+  so a `--json` output is round-trippable into config.yaml.
+  The terminal output's `serve_command` retains the CLI flag
+  names per PR #105.
+- **F.2 fix** (recipe_hash format ambiguous + canonicalization
+  undefined): hash format pinned to
+  `sha256:<64-lowercase-hex>` (32 bytes = 64 hex chars). The
+  canonicalization profile is pinned to RFC 8785 JSON
+  Canonicalization Scheme (JCS). The hash input domain is
+  explicitly enumerated (machine, inputs.target_context,
+  inputs.candidate_models, recommendation.model,
+  recommendation.knobs); timestamps, run_id, and observed
+  metrics are explicitly excluded.
+- **G.1 fix** (`tune_trials.stage` migration was not valid
+  SQLite): migration SQL now spelled out as
+  `ALTER TABLE tune_trials ADD COLUMN stage INTEGER NOT NULL
+  DEFAULT 1`. New inserts MUST set `stage = 1` (Stage 1
+  probe) or `stage = 2` (Stage 2 cell) explicitly. AC-16 is
+  unchanged in shape; the migration step is now stated as a
+  prerequisite, not an in-test step.
+- **J.1 fix** (no AC proved operator-supplied order is
+  honored without internal rerank — the load-bearing
+  biggest-fit guard had no test): new AC-17 explicitly tests
+  `--candidate-models 1B,32B` on a Mac where both fit;
+  recommendation MUST be 1B (operator-supplied order wins).
+
+**MINORs closed (10 of 11):**
+
+- B.1: `--max-context-axis` semantics defined (absolute caps,
+  each ≥ `--target-context`, sorted ascending, invalid cells
+  fail at flag-parse time).
+- C.1: §7 CLI summary kv-bits default fixed to `unset,4,8`
+  (matching FR-B.1); representation of `unset` defined for
+  flags, JSON, SQL, and terminal output.
+- F.3: backup naming changed to `bak-<unix-ts>-<counter>` with
+  no overwrite (implementation MUST find the lowest available
+  counter starting at 0).
+- G.2: retention sweep MUST run inside a single SQLite
+  transaction after the new `tune_runs` row is created.
+- H.1: `--resume` removed from the §7 flag summary (still
+  deferred to v2 per §11).
+- J.2: new AC-18 covers non-default `--max-context-axis`.
+- J.3: new AC-19 covers `--max-model-size` alone trimming the
+  default list; `tune_runs.exit_reason` value set is now an
+  explicit normative enum.
+- K.1: OQ-B and OQ-D get quantitative thresholds (minimum
+  discriminable tps gap at n=3; Stage-1 false-fit /
+  false-reject rates).
+- L.1: §12 prototype migration note rewritten — the prototype
+  has no explicit pre-download step; the prototype's "weights
+  must already be present or candidate fails during load"
+  behavior is what FR-D replaces.
+- M.1: companion-spec note added — SPEC-010 §11 and SPEC-011
+  §8/§11 still cite "SPEC-013" with the recommended-catalog
+  meaning; v0.2 documents the renumber (SPEC-013 = autotune,
+  recommended catalog is now provisionally SPEC-014) and
+  flags a follow-up docs patch.
+
+**MINOR deferred to v0.3 (post-lock):**
+
+- M.2 documentation checklist (`beta/DECISION_CRITERIA.md`
+  entry, SPEC-003 install note, PR #103 disposition): v0.2
+  adds a short post-lock checklist to §13, but the
+  decision-log entry and SPEC-003 patch are out-of-PR work
+  the operator performs at lock time.
+
+**QUESTIONs resolved:**
+
+- D.2 (signature vs network failure handling): v0.2 picks
+  asymmetric — transient failures (network down, disk full)
+  advance to the next candidate per FR-D.2; integrity
+  failures (signature mismatch, hash mismatch) ABORT the
+  whole run with a security-relevant exit code. The two
+  failure classes are distinguished in the `notes` column
+  and in the FR-F.2 JSON.
+- K.2 (thermal/order effects): v0.2 adds OQ-E flagging this
+  as a v0.2 open question pending the air5 n=3 data. v1's
+  current behavior (deterministic axis order, no thermal
+  pacing) is preserved; if the data shows heat-soak bias on
+  later cells, v0.3 may randomize cell order or add a
+  cooldown policy.
 
 ### v0.1 (2026-06-18) — initial draft
 
@@ -164,7 +289,11 @@ for each (kv_bits, max_batch, [optional small ctx neighborhood]):
 best knob cell  ──>  RECOMMENDATION
                      model = chosen
                      knobs = best knob cell
-                     fallbacks = smaller candidates that ALSO fit
+                     alternates = NAME-ONLY list of smaller
+                                  candidates from the input list
+                                  (not probed; operator may
+                                  manually pin via a follow-up
+                                  autotune --candidate-models)
 ```
 
 Stage 1 spends the budget on a **fit decision**, not on
@@ -217,8 +346,10 @@ RECOMMENDATION
   --max-batch:     1
   median tok/s:    4.9  (n=3 replicates)
   p95 TTFT:        4.2s
-  fallbacks (if you'd rather serve a smaller model):
-    2. mlx-community/Llama-3.2-1B-Instruct-4bit  (9.7 tok/s)
+  alternates (smaller candidates from your input list, not probed):
+    - mlx-community/Llama-3.2-1B-Instruct-4bit
+  To try a smaller alternate instead:
+    macprovider-cli autotune --candidate-models mlx-community/Llama-3.2-1B-Instruct-4bit
 
 To apply this to your config and restart serve:
   macprovider-cli autotune --apply
@@ -439,78 +570,157 @@ dependency on a workflow that is otherwise fully local.
 
 ---
 
-### 5.4 Pre-download integration
+### 5.4 Pre-warm (replaces v0.1's "pre-download" framing)
 
-**FR-D.1. Pre-download via `models pull <id>`.**
+**FR-D.1. Cache-warm prerequisite + measurement isolation.**
 `autotune` MUST ensure each candidate's weights are present in the
-HuggingFace cache before invoking `macprovider-cli serve` for that
-candidate. v1 picks **option (a)** from the prompt: `autotune`
-invokes `macprovider-cli models pull <id>` as an explicit
-operator-visible step before each candidate's feasibility probe.
+local HuggingFace cache BEFORE the feasibility probe begins
+measuring tps / TTFT. This is the operative requirement: a
+candidate evaluated against a cold cache is unmeasurable because
+mlx-swift's load path is on the critical path of the first
+request, and a slow network fetch would inflate TTFT and falsely
+reject feasible models.
 
-The rationale for this over option (b) ("flip the binary into
-temporary online mode during tune"):
+There are two implementation shapes; v1 leaves the choice to the
+implementing PR and binds only the measurement-isolation
+contract:
 
-- **Explicit and observable.** A failed download is a discrete
-  failure with a discrete subcommand at the top of the trace, not a
-  silent stretch of online-mode behavior buried inside a serve
-  process.
-- **No new global state on the binary.** Option (b) requires
-  `macprovider-cli serve` to grow a "temporarily-online" runtime
-  mode and a transition contract for it. That is more surface area
-  to test and ship than a sibling subcommand.
-- **Composable.** Operators can pre-pull the candidate list manually
-  (`macprovider-cli models pull <id>` for each) and then run
-  `autotune` in a network-isolated environment. Option (b) makes
-  this awkward.
-- **Matches existing ergonomics.** `pull` / `download` is the
-  conventional CLI shape; SPEC-003 v0.9.2 already exposes a model
-  selection prompt at install time and operators expect a
-  per-model fetch surface.
+- **Shape A (preferred): explicit `models pull <id>`.**
+  `autotune` invokes a sibling subcommand (e.g.
+  `macprovider-cli models pull <id>` if one is added or already
+  exists at implementation time) that fetches weights into the
+  same HF cache the runtime reads from. The pull subcommand's
+  contract — cache target, gated-repo handling, partial-download
+  recovery, progress, cancellation, exit codes — is OUT OF SCOPE
+  for SPEC-013 v1; the autotune SPEC's only normative requirement
+  is "weights are present when the probe begins." Defining
+  `models pull` rigorously is a follow-on (potentially SPEC-013
+  v0.3 or a sibling SPEC).
+- **Shape B: rely on the runtime's online-fallback during load.**
+  The current `ModelRuntime` (per
+  `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`) first
+  checks the local HF snapshot path and falls back to
+  `LLMModelFactory.shared.configuration(id:)`, which can fetch
+  online. An implementation MAY rely on this fallback **iff** it
+  separately tracks the load wall-clock and excludes it from the
+  feasibility metrics computed by FR-A.3. Concretely: the autotune
+  MUST measure cold-cache load time as a separate metric, MUST
+  warm the cache (by running one disposable request to completion,
+  or by waiting for the load to finish before starting the
+  measurement window), and MUST NOT count load-fetch wall-clock
+  inside the gate-ttft-ms decision. The first-measured request
+  MUST land on warm weights.
 
-**Normative dependency.** SPEC-013 v1 implicitly requires the
-`macprovider-cli models pull <id>` subcommand to exist. If it does
-not exist at implementation time, the implementing PR MUST add it;
-the SPEC for that subcommand is short enough to fit alongside the
-autotune work (a one-screen `pull` subcommand that flips HF online
-mode for the duration of one fetch and writes weights to the same
-HF cache the runtime reads from). The autotune SPEC does NOT
-normatively specify the `pull` subcommand's flags beyond the call
-shape `macprovider-cli models pull <id>`.
+**Normative contract** (regardless of shape):
 
-**FR-D.2. Pre-download failure is candidate-level fatal.**
-If `models pull <id>` fails for a candidate (network down, weights
-missing from HF, signature mismatch, disk full), that candidate is
-recorded as infeasible-with-reason and `autotune` advances to the
-next candidate. The autotune run does NOT fail unless EVERY
-candidate fails pre-download (in which case FR-H.4 applies).
+1. Cold-cache weight fetch latency MUST NOT contribute to the
+   gate-ttft-ms feasibility decision (FR-A.3).
+2. A weight fetch failure MUST be recorded with a discrete reason
+   distinguishable from a load-time runtime error and from a
+   gate-miss (operator-visible).
+3. The autotune MUST NOT silently switch HF cache locations
+   between runs (would invalidate per-machine recipe replay).
+
+`autotune` does NOT, in v1, normatively require any new
+subcommand on the binary. Shape A is the recommended ergonomics;
+Shape B is permitted with the measurement-isolation guard.
+
+**FR-D.2. Failure classification: transient vs integrity.**
+Pre-warm failures split into two classes with asymmetric handling
+(round-1 audit QUESTION D.2 resolved here):
+
+- **Transient failures.** Network down, HTTP 5xx from HF, disk
+  full, partial download interrupted, gated-repo access denied
+  for the current credentials. Record the candidate as infeasible
+  with `notes = "pre-warm transient: <reason>"`, advance to the
+  next candidate. The autotune run fails only if EVERY candidate
+  hits a transient failure (FR-H.4 applies).
+- **Integrity failures.** Signature mismatch, weight hash
+  mismatch, repository contents inconsistent with the expected
+  shape (e.g. missing tokenizer.json), or any tampering signal.
+  These are security-relevant and MUST NOT be silently advanced
+  past. The autotune MUST ABORT the whole run with a distinct
+  non-zero exit code (`exit_reason =
+  'pre_warm_integrity_failure'`), write a `tune_runs` row, and
+  emit the offending candidate's reason on stderr. Operator must
+  investigate before re-running.
+
+The two classes MUST be distinguishable in `tune_trials.notes` and
+in the FR-F.2 JSON. An implementation that classifies all
+pre-warm failures as transient (the v0.1 wording) is a contract
+violation in v0.2.
 
 ---
 
 ### 5.5 Provider-conflict safety
 
 **FR-E.1. Pre-flight: refuse if `serve` already running.**
-Before starting any candidate provider, `autotune` MUST check for an
-existing `macprovider-cli serve` process and an existing listener on
-the configured `--port` (default 18080). If either is present:
+Before starting any candidate provider, `autotune` MUST check for
+an existing `macprovider-cli serve` process and an existing
+listener on the configured `--port` (default 18080). The check MUST
+cover BOTH install paths:
 
-- Default: refuse with a clear error, naming the conflicting PID
-  and the suggested remediation (`--drain` opt-in, or a manual
-  `launchctl unload` for launchd-managed installs, or simply
-  killing the process).
-- With `--drain`: `autotune` gracefully stops the live serve
-  (matching SPEC-011 v0.5 §3.4 drain semantics if warm-swap is
-  enabled, otherwise a clean process stop), runs the tune, then
-  either (a) restores the original serve config at the end (default
-  behavior) or (b) applies the new recommendation if `--apply` was
-  also passed.
+- **launchd-managed install** (per SPEC-003 v0.9.2 §FR-C5,
+  the dominant operator install path):
+  - launchd label: `live.streamvc.macprovider`
+  - plist path:
+    `~/Library/LaunchAgents/live.streamvc.macprovider.plist`
+  - check method: `launchctl list | awk '/live.streamvc.macprovider/'`
+    (matches the existing pattern in
+    `phase3-binary/dist/install.sh` line ~923)
+- **foreground / manually-run process**: PID match on
+  `macprovider-cli serve` argv plus port-listener check on
+  `127.0.0.1:<--port>`. The argv-match grep MUST exclude the
+  autotune process itself (an `autotune` invocation has
+  `macprovider-cli autotune ...` in its argv, not
+  `macprovider-cli serve ...`; the match SHOULD use
+  whole-word `serve` to avoid false positives).
+
+On conflict, the behavior is:
+
+- **Default (no `--drain`):** refuse with a clear error naming
+  the conflicting install path (`launchd-managed` or
+  `foreground-PID-<n>`) and the suggested remediation: pass
+  `--drain` to stop-then-tune (and optionally `--apply` to
+  install the new recipe), or manually stop the process
+  yourself.
+- **With `--drain`:** stop the live serve gracefully, run the
+  tune, then either (a) restore the original serve config and
+  restart at the end (default behavior — autotune is a
+  diagnostic that does not change the operator's serving
+  posture) or (b) apply the new recommendation if `--apply`
+  was also passed (the recipe-replacement path).
+
+**Drain sequence on the launchd-managed install path** (binding
+to SPEC-003 v0.9.2 §FR-C5):
+
+1. `launchctl bootout gui/$UID/live.streamvc.macprovider` to stop
+   the live service. SPEC-003's plist has
+   `KeepAlive.SuccessfulExit = false`, so bootout reliably stops
+   without auto-restart.
+2. Poll for `port_is_free(--port)` with a `--drain-grace` timeout
+   (default 30s). If the port is not free in time, abort with
+   a clear error — do NOT escalate to SIGKILL on a
+   launchd-managed install (the operator's launchd state would
+   become inconsistent with the SPEC-003 install).
+3. Run the full autotune.
+4. On exit, restore by either:
+   - Default (no `--apply`): `launchctl bootstrap gui/$UID
+     ~/Library/LaunchAgents/live.streamvc.macprovider.plist`,
+     leaving the operator's pre-tune config in place.
+   - `--apply`: write the new config (per FR-F.3), then
+     `launchctl bootstrap` to bring the new config live.
+
+**Drain sequence on the foreground process path:**
+SIGTERM the foreground PID, poll for port-free (same grace
+period), restart the foreground process at exit only if the
+operator explicitly opted in via a separate `--restart-foreground`
+flag (default: do nothing — the operator ran the foreground
+process manually and can restart it manually).
 
 `--drain` is an explicit opt-in. v1 MUST NOT auto-drain — buyer
 traffic is on the line and an unconfirmed drain is the wrong
-default. The check MUST cover both the launchd-managed install
-(`com.macprovider.cli` plist) and a manually-run foreground
-process; the launchd-managed install's drain MUST restore the plist
-state on exit (unless `--apply` says otherwise).
+default.
 
 **FR-E.2. `--no-join` is the default tuning mode.**
 While autotune is running, candidate providers MUST start with
@@ -548,15 +758,31 @@ able to `tee` it). The block MUST include:
 - The recommended knob settings as concrete `--kv-bits`,
   `--max-batch`, `--max-context` values (with `--max-context` set to
   the operator's `--target-context` unless FR-B.1's max-context
-  axis was opted into and a different cell won).
+  axis was opted into and a different cell won). The `--kv-bits`
+  value is printed as `unset` when the unquantized-baseline cell
+  wins (no `--kv-bits` flag emitted in the serve command line).
 - The target context the recommendation was tuned for.
 - The replicated median tps and p95 TTFT, with the replicate count.
-- Fallbacks: every smaller candidate from the candidate list that
-  ALSO passed Stage 1 feasibility, with its Stage-1 single-replicate
-  tps. Operators who want to manually choose a smaller / faster
-  model see what's available without re-running.
+- An `alternates` list: NAME-ONLY model IDs from the input
+  candidate list that are SMALLER than the chosen model (and were
+  not probed, per the FR-A.2 STOP-on-first-feasible rule). No
+  metrics. The list provides operators a copy-paste path to
+  manually downsize via `autotune --candidate-models <id>`. If the
+  chosen model is the smallest in the input list, the alternates
+  list is empty.
 - The exact `macprovider-cli serve` command line that the
-  recommendation reduces to, copy-pasteable.
+  recommendation reduces to, copy-pasteable. CLI flag names are
+  used here (`--kv-bits`, `--max-context`, `--max-batch`) so the
+  line is a literal shell command. The YAML config keys
+  (`kv_bits`, `max_context_override`, `max_concurrency_override`,
+  per FR-F.3) are SEPARATE from these CLI flag names; the
+  `serve_command` line is for shell paste, the `knobs` JSON
+  object is for `--apply` round-trip.
+
+Round-1 audit A.1 closure: the `alternates` list replaces v0.1's
+`fallbacks` (which was contradictory — STOP-on-first-feasible
+means no smaller candidate was ever probed, so fallback metrics
+were structurally impossible to emit).
 
 **FR-F.2. JSON output (`--json`).**
 With `--json`, the recommendation surface MUST also be emitted as
@@ -565,7 +791,7 @@ additive fields):
 
 ```json
 {
-  "spec_version": "SPEC-013 v0.1",
+  "spec_version": "SPEC-013 v0.2",
   "run_id": "<uuid>",
   "started_at": "2026-06-18T12:34:56Z",
   "ended_at": "2026-06-18T13:01:22Z",
@@ -594,8 +820,8 @@ additive fields):
     "target_context": 4000,
     "knobs": {
       "kv_bits": 4,
-      "max_batch": 1,
-      "max_context": 4000
+      "max_concurrency_override": 1,
+      "max_context_override": 4000
     },
     "tps_median": 2.1,
     "ttft_p95_ms": 19500,
@@ -603,17 +829,9 @@ additive fields):
     "serve_command":
       "macprovider-cli serve --model mlx-community/Qwen2.5-Coder-7B-Instruct-4bit --kv-bits 4 --max-batch 1 --max-context 4000"
   },
-  "fallbacks": [
-    {
-      "model": "mlx-community/Llama-3.2-3B-Instruct-4bit",
-      "tps_stage1": 4.9,
-      "rank": 4
-    },
-    {
-      "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
-      "tps_stage1": 9.7,
-      "rank": 5
-    }
+  "alternates": [
+    "mlx-community/Llama-3.2-3B-Instruct-4bit",
+    "mlx-community/Llama-3.2-1B-Instruct-4bit"
   ],
   "infeasible": [
     {
@@ -626,20 +844,73 @@ additive fields):
       "model": "mlx-community/Qwen2.5-14B-Instruct-4bit",
       "rank": 2,
       "reason":
-        "ttft p95 23500ms > gate 60000ms passed but n_err=1 streaming abort"
+        "ttft p95 95234ms > gate 60000ms"
     }
   ],
-  "recipe_hash": "sha256:<32-byte-hex>",
+  "recipe_hash": "sha256:<64-lowercase-hex>",
   "db_path": "/Users/op/.config/macprovider/autotune.sqlite"
 }
 ```
 
-The JSON schema is the canonical format for `console.streamvc.live`
-ingestion. The `recipe_hash` is a SHA-256 over the canonical-JSON
-form of `{machine, inputs, recommendation.knobs, recommendation.model}`
-and is the v2 sticky identifier for "this Mac + this recipe."
-v1-side it has no semantic use beyond display; it MUST still be
-emitted so v2 ingestion is back-compatible.
+Schema notes (round-1 audit F.1 + F.2 closures):
+
+- `recommendation.knobs` uses YAML KEY NAMES
+  (`kv_bits`, `max_concurrency_override`, `max_context_override`),
+  not CLI flag names. This makes the `--json` output
+  round-trippable into `~/.config/macprovider/config.yaml` per
+  FR-F.3. Two-token name mapping:
+  | YAML key                    | CLI flag (in `serve_command`) | mlx-swift wire site            |
+  |-----------------------------|-------------------------------|--------------------------------|
+  | `kv_bits` (4 \| 8 \| null)  | `--kv-bits {4,8}` (omitted if null) | `GenerateParameters.kvBits` |
+  | `max_context_override`      | `--max-context <N>`           | `GenerateParameters.maxKVSize` + 413 gate |
+  | `max_concurrency_override`  | `--max-batch <N>`             | `AsyncSemaphore(value: maxBatch)` |
+- `kv_bits` is `null` (JSON) / `NULL` (SQL) / omitted (YAML) /
+  the literal string `unset` (terminal display) when the
+  unquantized-baseline cell wins.
+- `alternates` is a flat array of NAME-ONLY HF model IDs, in
+  the same order as the input `candidate_models` list, filtered
+  to entries SMALLER than the chosen model and not probed (per
+  the STOP-on-first-feasible rule in FR-A.2). Empty if the
+  chosen model is the smallest in the input list.
+- `recipe_hash` is `sha256:<64-lowercase-hex>` — 32 bytes,
+  hex-encoded, 64 ASCII chars in `[0-9a-f]`, with the literal
+  prefix `sha256:`. The hash input is the **RFC 8785 JSON
+  Canonicalization Scheme (JCS)** serialization of:
+
+  ```json
+  {
+    "binary_version": "<machine.binary_version>",
+    "candidate_models": ["<inputs.candidate_models, in input order>"],
+    "chip": "<machine.chip>",
+    "model": "<recommendation.model>",
+    "knobs": {
+      "kv_bits": <value or null>,
+      "max_concurrency_override": <value>,
+      "max_context_override": <value>
+    },
+    "ram_gb": <machine.ram_gb>,
+    "target_context": <inputs.target_context>
+  }
+  ```
+
+  Keys sorted lexicographically per JCS, no whitespace, integers
+  without trailing zeros, `null` for omitted `kv_bits`. Fields
+  EXCLUDED from the hash: `run_id`, `started_at`, `ended_at`,
+  `os_version`, `stage1_replicates`, `stage2_replicates`,
+  `gate_ttft_ms`, `tps_tie_epsilon`, `tps_median`, `ttft_p95_ms`,
+  `replicates`, `alternates`, `infeasible`, `db_path`,
+  `serve_command`. The hash identifies a "machine + recipe"
+  tuple, NOT an observation; two runs that produce the same
+  recommendation on the same machine MUST hash identically even
+  if their measured tps differs.
+- `spec_version` is the canonical identity of the producing
+  spec ("SPEC-013 v0.2"); v0.3+ MAY add fields additively but
+  MUST NOT remove or retype existing fields.
+- `recommendation` is `null` (not `{}`) when no model was
+  selected (all-infeasible, budget-exhausted-pre-Stage-2, or
+  pre-warm integrity-aborted). Ingestion contract:
+  `recommendation === null` MUST be handled before reading
+  inner fields.
 
 **FR-F.3. `--apply`: write to config.**
 `--apply` is the only mode in which `autotune` writes to
@@ -648,26 +919,55 @@ emitted so v2 ingestion is back-compatible.
 1. Be opt-in. v1's default is "show the recommendation, do nothing."
 2. Atomically write the new config (temp-file + rename). Concurrent
    reads MUST never see a half-written YAML.
-3. Save the prior config as `~/.config/macprovider/config.yaml.bak-<unix-ts>`.
-   The backup path MUST appear in stdout so the operator can revert.
+3. Save the prior config as
+   `~/.config/macprovider/config.yaml.bak-<unix-ts>-<counter>`
+   where `<counter>` is the lowest non-negative integer such that
+   the resulting path does not exist (start at 0; increment until
+   free). The backup write MUST NOT overwrite an existing file —
+   if a collision occurs at every counter from 0 to 65535, abort
+   with an error. The backup path MUST appear in stdout so the
+   operator can revert. (Round-1 audit F.3 closure: nanosecond
+   timestamps are race-prone on macOS HFS+; the counter approach
+   is collision-safe and deterministic.)
 4. Be idempotent: applying the same recommendation twice produces
    the same config and the same (empty) diff against the saved
    backup.
 5. Modify ONLY the keys SPEC-013 owns:
-   `model`, `kv_bits`, `max_context_tokens`, `max_batch`. All other
-   YAML keys (coordinator_endpoint, provider_token, log paths, etc.)
-   MUST be carried through verbatim. `autotune` is not a config
-   rewrite tool.
+   `model`, `kv_bits`, `max_context_override`,
+   `max_concurrency_override`. All other YAML keys
+   (`coordinator_endpoint`, `provider_token`, log paths, etc.) MUST
+   be carried through verbatim with comments + ordering preserved
+   where the YAML library allows. `autotune` is not a config
+   rewrite tool. (Round-1 audit F.1 closure: the prior v0.1 key
+   names `max_context_tokens` and `max_batch` were the CLI FLAG
+   names; the actual YAML keys per
+   `phase3-binary/Sources/MacProviderCore/Config.swift` lines
+   239-241 are `max_context_override` and
+   `max_concurrency_override`. An implementation that wrote the
+   flag names would leave the recipe unapplied because the
+   binary's config parser would not read them.)
 6. Print a single line summarizing what changed, e.g.
-   `applied: model=Qwen-7B kv_bits=4 max_batch=1 max_context=4000
-   (backup at ...)`.
+   `applied: model=Qwen-7B kv_bits=4 max_concurrency_override=1
+   max_context_override=4000 (backup at ...)`.
 
-`--apply` does NOT restart the launchd service. If the operator's
-`macprovider-cli serve` was running under launchd, they MUST
-manually run `launchctl unload ... && launchctl load ...` (or the
-equivalent SPEC-003 v0.9.2 install-script helper if one exists) to
-pick up the new config. SPEC-013 v1 does NOT depend on or trigger
-SPEC-011 warm-swap for this.
+`--apply` does NOT restart the launchd service by itself. If the
+operator passed `--drain` alongside `--apply` per FR-E.1, the
+drain sequence handles the restart at exit (launchctl bootstrap
+brings up the new config). If `--apply` was used WITHOUT
+`--drain`, the operator MUST manually restart for the new config
+to take effect — `--apply` prints a follow-up hint to stderr in
+this case:
+
+```
+applied: ... (backup at ~/.config/macprovider/config.yaml.bak-1718712345-0)
+hint: to apply the new recipe live, restart the serve process:
+  launchctl bootout gui/$UID/live.streamvc.macprovider && \
+    launchctl bootstrap gui/$UID ~/Library/LaunchAgents/live.streamvc.macprovider.plist
+```
+
+SPEC-013 v1 does NOT depend on or trigger SPEC-011 warm-swap for
+this — `--enable-warm-swap` is off by default per SPEC-011 §3.1
+and SPEC-013 stays out of that opt-in.
 
 ---
 
@@ -706,17 +1006,39 @@ CREATE INDEX IF NOT EXISTS idx_tune_trials_run_id ON tune_trials(run_id);
 CREATE INDEX IF NOT EXISTS idx_tune_trials_ts ON tune_trials(ts_utc);
 ```
 
-The `stage` column is a SPEC-013 v0.1 addition; v1 implementations
-MUST `ALTER TABLE ADD COLUMN stage` if upgrading from a prototype
-DB. Default value is `1` for existing rows so historical reports
-don't crash.
+The `stage` column is a SPEC-013 v0.2 addition. v1 implementations
+upgrading from a prototype DB MUST run the migration:
+
+```sql
+ALTER TABLE tune_trials ADD COLUMN stage INTEGER NOT NULL DEFAULT 1;
+```
+
+(Round-1 audit G.1 closure: the v0.1 wording said "ALTER TABLE ADD
+COLUMN stage" without the `DEFAULT 1` clause; SQLite rejects
+adding a NOT NULL column to a populated table unless a non-NULL
+default is supplied, so the v0.1 migration would have failed on
+any prototype DB. The migration must be idempotent — implementers
+SHOULD wrap in a `try ... ignore "duplicate column"` pattern
+matching the prototype's `_ADDITIVE_TUNE_COLUMNS` ALTER loop.)
+
+After migration, ALL new inserts into `tune_trials` MUST set
+`stage` explicitly: `stage = 1` for Stage 1 feasibility probes,
+`stage = 2` for Stage 2 hill-climb cells. The DEFAULT 1 is for
+backfill of existing prototype rows only; relying on the default
+in new code is a contract violation (would silently misattribute
+Stage 2 cells as Stage 1 probes).
 
 **Retention.** The DB MUST keep AT LEAST the most recent N runs by
 default (default `N = 50`; operator-overridable via
-`--retain-runs N`). Older runs are dropped on each new run start
-(scope: delete `tune_trials` and `tune_runs` rows whose `run_id` is
-not in the most recent N). `N >= 1` MUST be enforced; setting to 0
-or negative is an error at flag-parse time.
+`--retain-runs N`). Older runs are dropped at the START of each
+new autotune run, AFTER the new `tune_runs` row has been written.
+The retention sweep MUST execute as a SINGLE SQLite transaction
+covering both `tune_trials` and `tune_runs` deletes (round-1
+audit G.2 closure: a non-transactional sweep that crashes between
+the `tune_trials` delete and the `tune_runs` delete leaves orphan
+trials or orphan runs, breaking report consistency). `N >= 1` MUST
+be enforced; setting to 0 or negative is an error at flag-parse
+time.
 
 The DB path defaults to `~/.config/macprovider/autotune.sqlite`
 (NOT the prototype's `beta/runs.sqlite` location, which is a
@@ -746,13 +1068,33 @@ CREATE TABLE IF NOT EXISTS tune_runs (
     recommendation_json TEXT,                -- NULL if no feasible recommendation
     recipe_hash TEXT,                        -- NULL if no recommendation
     applied INTEGER NOT NULL DEFAULT 0,      -- 1 iff --apply was used
-    exit_reason TEXT                         -- 'ok' | 'interrupted' | 'no_feasible' | error msg
+    exit_reason TEXT NOT NULL                -- normative enum, see below
 );
 ```
 
 The `recipe_hash` is the FR-F.2 hash. Two `tune_runs` rows with the
 same `recipe_hash` represent the same machine + recipe; this is the
 v2 sticky comparison key.
+
+**`exit_reason` is a normative enum** (round-1 audit J.3 closure
+— v0.1's "or error msg" tail was too loose). Valid values:
+
+| value | meaning | recommendation_json |
+|---|---|---|
+| `ok` | Stage 1 chose a model; Stage 2 produced a recommendation | non-NULL |
+| `interrupted` | SIGINT or SIGTERM stopped the run | NULL if pre-Stage-2; non-NULL with `partial=true` if mid-Stage-2 |
+| `no_feasible` | every candidate failed Stage 1 feasibility | NULL |
+| `budget_exhausted_no_model_selected` | `--max-duration` hit during Stage 1 | NULL |
+| `budget_exhausted_with_partial_recommendation` | `--max-duration` hit during Stage 2; best-so-far emitted | non-NULL with `partial=true` |
+| `pre_warm_integrity_failure` | FR-D.2 integrity-failure abort | NULL |
+| `provider_conflict` | FR-E.1 refused (no `--drain`) | NULL |
+| `config_error` | flag-parse error, DB-open error, or other pre-run setup failure | NULL |
+| `internal_error` | unexpected exception with stack trace in `notes` of a partial row | NULL |
+
+Free-form error strings are NOT permitted in `exit_reason`. The
+operator-visible error message goes to stderr + the last
+`tune_trials.notes` row; `exit_reason` is the machine-readable
+classification. Wrappers and reports SHOULD switch on this enum.
 
 ---
 
@@ -777,13 +1119,22 @@ Stage 1 candidates that the prior crashed run already proved
 infeasible (best-effort optimization; out of scope for v0.1's
 normative contract — see §11). v0.1 default behavior is full rerun.
 
-**FR-H.3. Network down during pre-download.**
-A failed `models pull` for candidate K marks K infeasible with
-reason "pre-download failed: <error>" and advances to candidate K+1.
-The run only fails if EVERY candidate fails pre-download (then
-FR-H.4 applies). This way, an operator running autotune with the
-2 largest models pre-cached and a flaky network still gets a
-working recommendation from the smaller cached candidates.
+**FR-H.3. Network down during pre-warm.**
+A failed pre-warm fetch (Shape A `models pull` exit non-zero, or
+Shape B's online-fallback HTTP failure) for candidate K is
+classified per FR-D.2:
+- **Transient class** (network down, HTTP 5xx, disk full): mark K
+  infeasible with reason `"pre-warm transient: <error>"`,
+  advance to candidate K+1. The run only fails-with-no-feasible
+  if EVERY candidate hits a transient pre-warm failure (then
+  FR-H.4 applies). This way, an operator running autotune with
+  the 2 largest models pre-cached and a flaky network still gets
+  a working recommendation from the smaller cached candidates.
+- **Integrity class** (signature mismatch, hash mismatch): ABORT
+  the whole run with `exit_reason =
+  'pre_warm_integrity_failure'` per FR-D.2; do not advance to
+  smaller candidates because the security-relevant failure mode
+  warrants operator investigation.
 
 **FR-H.4. All-infeasible: surface most-informative reason.**
 Per FR-A.4. The error message MUST lead with the SMALLEST candidate
@@ -872,28 +1223,49 @@ above. The actual flag set is:
 ```
 macprovider-cli autotune
   --target-context <N>           target context in tokens (default 2000)
-  --candidate-models <csv>       override default ordered list
+  --candidate-models <csv>       override default ordered list (operator order is contract)
   --max-model-size <Nb>          trim default list above this size
   --min-model-size <Nb>          trim default list below this size
-  --kv-bits-axis <csv>           Stage 2 kv-bits cells (default '4,8')
+  --kv-bits-axis <csv>           Stage 2 kv-bits cells (default 'unset,4,8'; 'unset' = no flag)
   --max-batch-axis <csv>         Stage 2 max-batch cells (default '1,2')
-  --max-context-axis <csv>       Stage 2 max-context cells (default '' = target only)
+  --max-context-axis <csv>       Stage 2 max-context cells; absolute token caps,
+                                 sorted ascending, each >= --target-context
+                                 (default empty = use target only)
   --stage1-replicates <N>        default 1
   --stage2-replicates <N>        default 3
   --gate-ttft-ms <N>             default 60000
   --tps-tie-epsilon <F>          default 0.02
   --max-duration <seconds>       default 7200
+  --drain-grace <seconds>        FR-E.1 drain grace (default 30)
   --port <N>                     local provider port (default 18080)
   --db-path <path>               default ~/.config/macprovider/autotune.sqlite
   --retain-runs <N>              default 50
   --json                         emit recommendation as JSON
   --apply                        write recommendation to config.yaml
   --drain                        if `serve` is running, drain it before tuning
-  --resume                       skip candidates known infeasible from a prior crashed run (v2)
+  --restart-foreground           after `--drain` of a foreground process, restart it at exit
+                                 (no effect on launchd-managed installs)
   --dry-run                      print the candidate plan and exit
   --report-only                  re-render the latest run's report and exit
   -v / --verbose                 stream per-trial details to stderr
 ```
+
+Round-1 audit closures: C.1 (kv-bits default now `unset,4,8`
+matching FR-B.1), H.1 (`--resume` removed; still deferred to v2
+per §11), B.1 (`--max-context-axis` semantics inlined).
+
+The `unset` token in `--kv-bits-axis` means "evaluate a cell with
+no `--kv-bits` flag passed to `serve`" (the mlx-swift unquantized
+KV-cache baseline). Representation across surfaces:
+
+| surface | `unset` representation |
+|---|---|
+| `--kv-bits-axis` CSV | the literal string `unset` |
+| FR-F.2 JSON `knobs.kv_bits` | `null` |
+| `tune_trials.kv_bits` SQL | `NULL` |
+| YAML config `kv_bits` (via `--apply`) | key omitted entirely |
+| terminal display | the literal string `unset` |
+| `serve_command` line | `--kv-bits` flag omitted entirely |
 
 The flag shape MAY change in v0.2 based on audit feedback. The
 SEMANTICS in §5 are the normative surface.
@@ -913,15 +1285,16 @@ maintain).
 Configure candidate list `[X, Y, Z]` where X is infeasible (oversized
 candidate id pointing at a too-large model) and Y is feasible. The
 run MUST select Y, NOT iterate to Z, NOT emit a Z trial row, and the
-RECOMMENDATION block MUST name Y. The fallbacks list MUST be empty
-in this case (only Z would be a fallback, and the iteration didn't
-reach it).
+RECOMMENDATION block MUST name Y. The `alternates` list MUST
+contain exactly `[Z]` (the smaller candidate not probed; name only,
+no metrics).
 
 **AC-2. Largest-first iteration ITERATES past infeasible.**
 Configure candidate list `[X, Y, Z]` where X is infeasible at the
 target context, Y is infeasible, Z is feasible. The run MUST emit
 infeasibility rows for X and Y (with `notes` populated) and select
-Z. RECOMMENDATION names Z; fallbacks list is empty.
+Z. RECOMMENDATION names Z; `alternates` is empty (Z is the
+smallest in the list).
 
 **AC-3. All-infeasible exits non-zero with smallest-first reason.**
 Configure a candidate list where every candidate is infeasible at the
@@ -949,10 +1322,24 @@ prototype's `_is_new_best` semantics verbatim.
 **AC-6. Provider-conflict pre-flight refuses by default.**
 With a `macprovider-cli serve` already running on the configured
 port, `autotune` (no `--drain`) MUST refuse with a clear error
-naming the existing PID and the `--drain` opt-in. The DB MUST NOT
-have a `tune_runs` row written. Exit code MUST be non-zero and
-distinct from the all-infeasible exit code (so wrappers can
-distinguish).
+naming the existing install path (`launchd-managed` or
+`foreground-PID-<n>`) and the `--drain` opt-in. The
+`tune_runs.exit_reason` MUST be `'provider_conflict'`. This AC
+MUST cover BOTH install paths:
+
+- **launchd-managed case:** with `live.streamvc.macprovider`
+  loaded via `launchctl bootstrap`, autotune detects it via
+  `launchctl list` and refuses; with `--drain`, autotune runs
+  `launchctl bootout gui/$UID/live.streamvc.macprovider`,
+  completes the tune, and either restarts the original config
+  (no `--apply`) or applies + restarts (with `--apply`).
+- **foreground case:** with `macprovider-cli serve ...`
+  running in a separate shell as the operator's PID, autotune
+  detects via argv-match-on-`serve` (not `autotune` — the
+  argv-match grep MUST NOT match the autotune process itself);
+  with `--drain` and `--restart-foreground`, autotune SIGTERMs,
+  tunes, and restarts the foreground process via the original
+  argv.
 
 **AC-7. `--no-join` is set on every candidate.**
 The implementation MUST always pass `--no-join` (or its equivalent
@@ -971,15 +1358,23 @@ succeeded, otherwise `'no_feasible'`.
 
 **AC-9. `--apply` is atomic + backs up + idempotent.**
 With `--apply`, a successful run MUST:
-- Write the new `config.yaml` atomically (test asserts the file is
-  either fully old or fully new at every observation moment, never
-  half-written, via an `flock`-equivalent or a temp-file-rename
-  trace).
-- Save the prior config as `config.yaml.bak-<unix-ts>` with file
-  contents byte-identical to the pre-apply config.
-- Modify ONLY keys SPEC-013 owns. A test asserts every non-owned key
-  (e.g. `coordinator_endpoint`, `provider_token`) is byte-identical
-  pre/post.
+- Write the new `config.yaml` atomically via a temp-file-rename
+  trace (the test asserts the rename target either matches the
+  pre-apply contents or the post-apply contents at every
+  observable moment, never a partial write).
+- Save the prior config as
+  `config.yaml.bak-<unix-ts>-<counter>` with file contents
+  byte-identical to the pre-apply config. With two `--apply`
+  runs in the same wall-clock second, the second backup MUST
+  have `<counter>` greater than the first; neither backup is
+  overwritten.
+- Modify ONLY the four keys SPEC-013 owns (`model`, `kv_bits`,
+  `max_context_override`, `max_concurrency_override`). A test
+  asserts every non-owned key (e.g. `coordinator_endpoint`,
+  `provider_token`) is byte-identical pre/post and that the
+  binary's `Config.swift` parser actually reads the four owned
+  keys from the post-apply file (catches the v0.1 bug where
+  the spec named flag-names instead of YAML-key-names).
 - Re-running with the same recommendation produces zero diff
   against the saved backup (idempotence).
 
@@ -999,12 +1394,31 @@ present with the documented type. Additive fields are allowed in
 v0.2+; field removal or type change is a SPEC bump.
 
 **AC-12. Recipe hash determinism.**
-Two `autotune` runs on the same machine with the same flags
-producing the same recommendation MUST emit the same `recipe_hash`.
-A run on a different RAM tier (e.g. 8 GB vs 16 GB) producing
-even-coincidentally-the-same recommendation MUST emit a different
-`recipe_hash` (because `machine.ram_gb` is part of the canonical
-JSON the hash covers).
+The `recipe_hash` MUST satisfy three properties simultaneously:
+
+1. **Reproducible same-machine.** Two `autotune` runs on the same
+   machine + same `binary_version` + same flags producing the
+   same recommendation emit IDENTICAL `recipe_hash`, even though
+   observed tps/ttft and run_id/timestamps differ between the
+   two runs (the hash input domain excludes observations).
+2. **Reproducible cross-implementation.** A reference vector
+   (fixed machine + inputs + recommendation, JSON pre-computed)
+   is hashed by both an Option-A (Swift) and an Option-B
+   (Python) implementation; both produce IDENTICAL hash. This
+   tests the RFC 8785 JCS canonicalization.
+3. **Sensitive to machine.** Two runs on different RAM tiers
+   (e.g. 8 GB vs 16 GB) producing coincidentally-the-same
+   recommendation `model + knobs + target_context` emit
+   DIFFERENT `recipe_hash` (because `machine.ram_gb` is in the
+   hash input).
+4. **Sensitive to binary.** Same machine, same recommendation,
+   different `machine.binary_version` → DIFFERENT hash. This
+   is the v2 sticky's "did this Mac's recipe drift after a
+   binary update?" signal.
+
+The format MUST be `sha256:<64-lowercase-hex>`; a test asserts
+the prefix is exactly `sha256:`, the suffix matches `^[0-9a-f]{64}$`,
+and no upper-case characters appear.
 
 **AC-13. Wall-clock budget enforcement.**
 With `--max-duration 60` (very small), the run MUST exit
@@ -1033,7 +1447,54 @@ Stage 1 probes MUST be recorded with `stage = 1`; Stage 2 cells MUST
 be recorded with `stage = 2`. A test asserts the row count per
 stage matches the expected: stage 1 count = (candidates iterated
 until chosen model); stage 2 count = (kv_bits axis size × max_batch
-axis size × max_context axis size).
+axis size × max_context axis size). A separate test verifies the
+v0.2 migration SQL (`ALTER TABLE tune_trials ADD COLUMN stage
+INTEGER NOT NULL DEFAULT 1`) runs successfully against a populated
+prototype DB and that existing rows acquire `stage = 1`.
+
+**AC-17. Operator-supplied order is honored verbatim (no internal
+rerank).** [round-1 J.1 closure — load-bearing biggest-fit guard]
+Configure
+`--candidate-models mlx-community/Llama-3.2-1B-Instruct-4bit,mlx-community/Qwen2.5-32B-Instruct-4bit`
+on hardware where BOTH models are feasible at the target context.
+The recommendation MUST be the 1B model — because the operator's
+supplied order put 1B first, even though 32B is the larger model
+and would have won under the default-list largest-first ordering.
+A test asserts:
+- `tune_trials` has exactly ONE stage-1 row (for 1B) — the 32B
+  was never probed, because Stage 1 STOPped on first feasible
+  per FR-A.2.
+- The recommendation's `model` field is the 1B model id.
+- `alternates` is empty (no candidates SMALLER than the chosen
+  1B in the input list).
+- A failure mode this catches: an implementation that
+  pre-sorts `--candidate-models` by parameter-count-descending
+  before Stage 1 iteration would (wrongly) pick 32B and pass
+  AC-14/AC-15 — only AC-17 detects this. The biggest-fit
+  guarantee depends entirely on operator-supplied order being
+  the contract per FR-A.1.
+
+**AC-18. Optional `--max-context-axis` evaluates extra cells and
+can win.** [round-1 J.2 closure]
+With `--target-context 4000 --max-context-axis 4000,8000`,
+configure a mock provider whose 8000-cell produces higher median
+tps than the 4000-cell (within feasibility). The recommendation's
+`knobs.max_context_override` MUST be 8000 (the winning cell). A
+test asserts: `tune_trials` has 2 Stage-2 cell rows per
+(kv_bits, max_batch) combination, and the recommendation reflects
+the winning cell. Invalid `--max-context-axis 2000,4000` (the
+2000 cell is below `--target-context 4000`) MUST fail at
+flag-parse time with a clear error and `exit_reason = 'config_error'`.
+
+**AC-19. `--max-model-size` alone trims the default list.** [round-1
+J.3 closure]
+With `--max-model-size 8B` and no `--candidate-models`, the
+iteration MUST start at the 7B candidate (the 32B and 14B
+defaults are trimmed). A test asserts the first probed candidate
+is `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit` and no probe
+of the 14B or 32B occurs (no `tune_trials` row with those model
+IDs). Combined with `--min-model-size 3B`, the iteration MUST
+also skip the 1B entry.
 
 ---
 
@@ -1053,11 +1514,15 @@ too aggressive (real differences will be flattened to "tie"); if
 real difference). v0.2 picks whichever bound the data supports.
 
 **OQ-B. `stage2_replicates` recommended default.**
-v0.1 uses `3`, balancing wall-clock against noise. Air5 n=3 data
-will tell us whether 3 is sufficient to discriminate cells whose
-true tps gap is within `TPS_TIE_EPSILON`. If discrimination is
-poor at n=3, v0.2 raises the default to 5 (Stage 2 wall-clock grows
-linearly; the NFR-1 budget table absorbs the change).
+v0.1 uses `3`, balancing wall-clock against noise. Quantitative
+decision rule (round-1 K.1 closure): at the chosen replicate
+count, the **minimum discriminable tps gap** (the smallest delta
+that the median-of-N comparison can reliably distinguish from
+noise, at 90% confidence) MUST be ≤ `TPS_TIE_EPSILON × measured
+median tps`. If air5 n=3 data shows minimum-discriminable-gap >
+TPS_TIE_EPSILON × median across the typical Stage 2 cell set,
+v0.3 raises the default to 5 (Stage 2 wall-clock grows linearly;
+the NFR-1 budget table absorbs the change).
 
 **OQ-C. Should `kv_bits` remain a search axis or become a fixed
 default?**
@@ -1071,13 +1536,35 @@ fixation (a future MLX-swift version changing the kv-bits trade-off)
 is higher than the cost of one extra cell.
 
 **OQ-D. Does Stage 1 fit-determination need N > 1 replicates?**
-v0.1 uses `stage1_replicates = 1` (cheap probe). If air5 n=3 data
-shows that single-trial fit decisions are unstable (one probe rules
-a model feasible while the next probe rules the same model
-infeasible at the same context), v0.2 raises the default to N=2 or
-N=3. The wall-clock cost is meaningful in Stage 1 (the iteration
-runs across the whole candidate list), so the change requires real
-evidence.
+v0.1 uses `stage1_replicates = 1` (cheap probe). Quantitative
+decision rule (round-1 K.1 closure): single-trial Stage 1 fit
+determination is "stable enough" iff measured **false-fit rate**
+(rules a model feasible at N=1 but infeasible at N=3) ≤ 5% AND
+**false-reject rate** (rules infeasible at N=1 but feasible at
+N=3) ≤ 5% across the air5 candidate set. If air5 n=3 data shows
+either rate > 5%, v0.3 raises the default to N=2 (or to N=3 if
+the rate exceeds 15%). The wall-clock cost is meaningful in
+Stage 1 (the iteration runs across the whole candidate list), so
+the change requires real evidence.
+
+**OQ-E. Thermal / cell-order bias in Stage 2.** [round-1 K.2
+closure — new in v0.2]
+NFR-2 v1 has no explicit thermal pacing, and Stage 2's deterministic
+axis order means later cells run on a hotter machine than earlier
+cells. If air5 n=3 data shows the keep-best decision is biased
+toward earlier-tested cells (i.e. cell-order rather than cell-quality
+drives the recommendation), v0.3 will need ONE of:
+- randomized cell order (with the seed recorded in `tune_runs` for
+  replay)
+- a fixed inter-cell cooldown delay (e.g. 30s idle between cells)
+- a thermal-state probe before each cell that pauses until the
+  Mac is thermally-quiet
+
+Decision threshold: if the same Stage 2 cell set, evaluated in
+reverse order, would produce a DIFFERENT keep-best winner more
+than 5% of the time on air5 n=3 data, the bias is load-bearing
+and v0.3 must address it. v0.2 ships the deterministic order
+unchanged pending the data; operators are warned in §6 NFR-2.
 
 ---
 
@@ -1138,6 +1625,57 @@ The successor SPEC for items 1, 4, 5 is provisionally SPEC-014 (the
 recommended-catalog surface anticipated by SPEC-011 §8). SPEC-013 v2
 and SPEC-014 v1 ship together if they ship at all.
 
+**Cross-spec renumber note** (round-1 audit M.1 closure):
+SPEC-010 §11 and SPEC-011 §8/§11 still cite "SPEC-013" with the
+recommended-catalog meaning, written before SPEC-013 was claimed
+for autotune. The renumber assignment is now:
+
+- **SPEC-013** (this spec) = autotune.
+- **SPEC-014** (provisional, not yet drafted) = coordinator-served
+  recommended catalog (the "future" referenced by SPEC-011 §8).
+
+A follow-up documentation-only patch SHOULD update the
+SPEC-010 and SPEC-011 cross-references when convenient (not a
+v1 blocker because the locked specs' references are
+forward-looking-aspirational, not normative). The patch
+candidates are:
+
+- SPEC-010 §11 (line ~1328): rewrite "SPEC-013 (future)" → "SPEC-014 (provisional)"
+- SPEC-011 §8 table row "Recommended catalog ... SPEC-013 (future)": same
+- SPEC-011 §11 references the same — same.
+
+This SPEC-013 v0.2 takes the number for autotune unambiguously.
+
+### Post-lock documentation checklist
+
+When SPEC-013 v0.2 (or a successor v0.x) reaches LOCK status, the
+operator SHOULD complete the following lifecycle updates as
+out-of-PR documentation work (round-1 audit M.2 — listed but
+deferred from the binding contract):
+
+1. Append a decision-log entry to `beta/DECISION_CRITERIA.md`
+   summarizing: the locked biggest-fit decision, the chosen
+   implementation shape (Option A Swift-native vs Option B
+   Python wrapper), what shipped in v1, what was deferred to v2
+   (recommended catalog, recipe attestation,
+   sticky-affinity-from-recipes, warm-swap-driven tuning).
+2. Add a one-line note to SPEC-003 v0.9.2's onboarding flow:
+   "after install, consider running `macprovider-cli autotune`
+   to find the best model for your Mac." (SPEC-003 is locked,
+   so this is a v0.10 candidate or a CLAUDE.md addition.)
+3. Patch the cross-spec renumber per the note above (SPEC-010,
+   SPEC-011).
+4. Close PR #103 (the Python prototype on
+   `spike/provider-model-autotune`) — either by rebasing onto
+   the SPEC-013 v1 implementing PR (Option B) or by closing as
+   superseded (Option A).
+5. Update `specs/README.md` SPEC-013 row to "LOCKED" when
+   appropriate.
+
+These steps are not v1 implementation work; they are spec /
+project-memory hygiene that the operator performs when the spec
+locks.
+
 ---
 
 ## 12. Migration note from the PR #103 prototype
@@ -1163,10 +1701,20 @@ survives, what changes, and what is rejected.
   Stage 2 (FR-B.2). This is the part of the prototype that earns
   its keep — it's a small, well-validated piece of decision logic
   the v0.1 SPEC inherits.
-- **HF offline-mode handling.** The prototype's pre-download via
-  external `pip install` / cache pre-warm is replaced by FR-D.1's
-  `macprovider-cli models pull <id>`, but the principle (model
-  weights must be on disk before `serve` starts) is the same.
+- **Cold-cache load classification.** The prototype does NOT have
+  an explicit pre-download step — `evaluate_candidate` starts
+  `serve`, waits for `/v1/models`, and records load failures
+  (offline-mode error, cache miss, OOM) as infeasible trial
+  rows via `_tail_log`. SPEC-013 v0.2 FR-D replaces this
+  implicit-cold-cache behavior with an explicit pre-warm
+  prerequisite + measurement-isolation contract. What survives
+  is the failure-classification PATTERN — both spec and
+  prototype record load failures with a discriminated reason in
+  `notes`; what changes is that the spec REQUIRES weights to be
+  cache-warm BEFORE measurement, where the prototype lets the
+  load happen during the measurement window.
+  (Round-1 audit L.1 closure: v0.1's wording overstated the
+  prototype's pre-download surface — the prototype has none.)
 - **`--replicates N` aggregation.** Median tps + p95 TTFT,
   strict-all-feasible. SPEC-013 v1 names the two stage-specific
   flags (`--stage1-replicates`, `--stage2-replicates`) but the

--- a/specs/SPEC-013-cli-autotune.md
+++ b/specs/SPEC-013-cli-autotune.md
@@ -850,7 +850,7 @@ additive fields):
 
 ```json
 {
-  "spec_version": "SPEC-013 v0.2",
+  "spec_version": "SPEC-013 v<producing-version>",
   "run_id": "<uuid>",
   "started_at": "2026-06-18T12:34:56Z",
   "ended_at": "2026-06-18T13:01:22Z",
@@ -963,8 +963,10 @@ Schema notes (round-1 audit F.1 + F.2 closures):
   recommendation on the same machine MUST hash identically even
   if their measured tps differs.
 - `spec_version` is the canonical identity of the producing
-  spec ("SPEC-013 v0.2"); v0.3+ MAY add fields additively but
-  MUST NOT remove or retype existing fields.
+  spec; writers emit their own producing version (e.g. an
+  implementation built against SPEC-013 v0.3 emits
+  `"SPEC-013 v0.3"`). Future v0.x revisions MAY add fields
+  additively but MUST NOT remove or retype existing fields.
 - `recommendation` is `null` (not `{}`) when no model was
   selected (all-infeasible, budget-exhausted-pre-Stage-2, or
   pre-warm integrity-aborted). Ingestion contract:

--- a/specs/SPEC-013-cli-autotune.md
+++ b/specs/SPEC-013-cli-autotune.md
@@ -1,0 +1,1239 @@
+# SPEC-013 — `macprovider-cli autotune` subcommand
+
+**Version:** 0.1 (initial draft)
+**Status:** Draft (pre round-1 audit)
+**Date drafted:** 2026-06-18
+**Depends on:** SPEC-001 v1.4 (`macprovider-cli serve` flags `--kv-bits`, `--max-context`, `--max-batch` per PR #105), SPEC-010 v1.5 (provider-advertised `supported_models[]` shape, model id semantics)
+**Companion to (LOCKED):** SPEC-002 v1.3.5 (no coordinator-side change required), SPEC-003 v0.9.2 (autotune is invoked before / between `macprovider-cli serve` lifetimes; not part of install flow)
+**Related (future):** SPEC-011 v0.5 (warm-swap; opt-in coupling deferred to v2 — see §11)
+
+SPEC-013 is operator-facing CLI surface only. It MUST NOT modify any
+SPEC-001 wire protocol, SPEC-002 coordinator behavior, SPEC-005
+billing/settlement, or SPEC-006 buyer API surface. With autotune
+unused, every provider's serving behavior is byte-identical to
+pre-SPEC-013.
+
+---
+
+## Change log
+
+### v0.1 (2026-06-18) — initial draft
+
+- First normative draft. Encodes the "biggest-fit model" product
+  strategy as a binary `autotune` subcommand that wraps the PR #105
+  serving knobs.
+- The candidate-list iteration is **largest-first** with a feasibility
+  gate (FR-A.1 / FR-A.2 / FR-A.3); the chosen model is the FIRST one
+  that passes. This is the load-bearing departure from the PR #103
+  Python prototype, whose cartesian max-tps loop would push every Mac
+  to the smallest model in the list.
+- Knob hill-climb (FR-B) operates within the chosen model only; the
+  prototype's `_is_new_best` semantics with `TPS_TIE_EPSILON = 0.02`
+  carry over here unchanged.
+- Four numerical defaults (`stage1_replicates`, `TPS_TIE_EPSILON`,
+  `stage2_replicates`, kv-bits axis-vs-default) are flagged as Open
+  Questions pending the in-flight air5 n=3 replication run; v0.2 may
+  revise them based on measured trial-to-trial variance.
+- v1 picks Swift-native (vs. wrapping the Python prototype) is
+  deferred to the implementing PR — §10 lays out the trade-off but
+  does not pick.
+
+---
+
+## 0. Operator-paste invocation block
+
+```
+Implement SPEC-013. As you work, maintain a running
+phase3-binary/implementation-notes.html that captures anything I
+should know about how the implementation diverges from or interprets
+the spec:
+
+- Design decisions: choices made where the spec was ambiguous
+- Deviations: places where you intentionally departed from the spec, and why
+- Tradeoffs: alternatives considered and why you picked what you did
+- Open questions: anything you'd want me to confirm or revise
+```
+
+---
+
+## 1. Mission
+
+MacProvider pools heterogeneous Apple Silicon Macs to serve LLM
+inference. The pool's value to buyers is **access to bigger models
+than they can run locally** (7B, 14B, 32B+), routed through whichever
+Mac in the pool can host them. A 16 GB Mac contributing capacity to
+serve a 7B is creating real network value; the same 16 GB Mac serving
+a 1B is wasting capacity (the buyer could call any cloud API).
+
+`autotune` encodes this product strategy as a deterministic per-Mac
+recommendation. Its job is:
+
+> **Find the BIGGEST model from a ranked candidate list that fits
+> this Mac at the operator's target context, and recommend the best
+> knob configuration for serving it.**
+
+It is NOT "find the highest-throughput model on this Mac" — that
+would push every capable Mac to serve the smallest model. It IS "use
+this Mac's capacity to its maximum useful capability." Throughput is
+the tiebreaker among knob settings for a chosen model, not the
+cross-model objective.
+
+Smaller models still appear in the candidate list as fallbacks: if
+32B doesn't fit, try 14B; if that doesn't fit, try 7B; eventually 1B
+always fits. The recommendation is the **largest one that survives
+the feasibility gate**.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- New `macprovider-cli autotune` subcommand.
+- Two-stage pipeline (§3): (1) largest-first feasibility iteration
+  across a curated candidate model list; (2) knob hill-climb within
+  the chosen model over the PR #105 axes (`--kv-bits`,
+  `--max-batch`, optionally a small `--max-context` neighborhood).
+- Per-trial SQLite persistence in the additive `tune_trials` table
+  (the prototype's schema, slightly extended; FR-G) and a per-run
+  `tune_runs` summary row (FR-G.2) capturing inputs and the final
+  recommendation for replay/comparison.
+- Operator-visible recommendation surface (terminal text + JSON +
+  optional `--apply`).
+- Pre-download integration via a sibling subcommand (FR-D);
+  provider-conflict pre-flight (FR-E); Ctrl-C / crash safety (FR-H).
+- A default curated candidate list shipped as a code constant (FR-C).
+
+### Out of scope (v1)
+
+- Cross-model throughput optimization. The product framing in §1
+  rules this out; the prototype's max-tps cartesian objective is
+  explicitly rejected — see §12 migration note.
+- Coordinator-side scheduling, dispatch, or any RPC that triggers
+  tuning from the coordinator. Tuning is always operator-initiated
+  and always local.
+- Automatic model downloads from sources other than HuggingFace
+  (signed via the HF transport already used by SPEC-003 v0.9.2 §
+  FR-D2.1). Untrusted-source pre-download is out of scope.
+- Remote tuning (tuning a different Mac than the one running the
+  CLI). Always local.
+- Auto-apply without explicit operator confirmation. `--apply` is
+  opt-in (FR-F.3).
+- Pareto-frontier UX (`"7B is 3× slower but 5× more capable"` style
+  charts). v1's recommendation is opinionated and singular.
+- Coordinator-side recipe registry (v2 territory; see §11).
+- Per-provider recipe attestation, sticky-affinity from recipes,
+  automatic re-tune on hardware/binary changes (v2).
+- Multi-model serving on one Mac (architectural; not a v1 autotune
+  concern).
+- Warm-swap-driven tuning (`autotune` could in principle re-use one
+  loaded provider process via SPEC-011 warm swap to skip
+  load-per-candidate cost; v1 explicitly does NOT do this — see §10).
+
+---
+
+## 3. Architecture
+
+`autotune` runs a two-stage pipeline. Both stages share the same
+provider-lifecycle invariants (one provider serving at a time,
+`--no-join` to keep the coordinator pool out of tuning candidates,
+feasibility gate identical across stages).
+
+```
+Stage 1: Model selection (largest-first iteration)
+─────────────────────────────────────────────────
+candidate_list[0]  (largest)  ──>  feasibility probe
+                                   ├─ feasible? ──> chosen = candidate[0]
+                                   │                STOP iterating models
+                                   │                proceed to Stage 2
+                                   └─ infeasible ─> candidate_list[1]
+                                                    (next largest)
+                                                    ... repeat ...
+
+(if all candidates infeasible) ──> exit with the most-informative
+                                   error (smallest candidate's
+                                   failure reason, per FR-H.4)
+
+Stage 2: Knob hill-climb within the chosen model
+────────────────────────────────────────────────
+for each (kv_bits, max_batch, [optional small ctx neighborhood]):
+    fire N replicates at the target context  ──>  median tps + p95 ttft
+    apply _is_new_best (throughput primary,
+                        TTFT tiebreak within TPS_TIE_EPSILON)
+
+best knob cell  ──>  RECOMMENDATION
+                     model = chosen
+                     knobs = best knob cell
+                     fallbacks = smaller candidates that ALSO fit
+```
+
+Stage 1 spends the budget on a **fit decision**, not on
+optimization. Stage 2 spends the budget on **optimization within the
+chosen model**, not on a fit decision. This separation is what makes
+the wall-clock budget bounded per RAM tier (§ NFR-1) and what makes
+the recommendation deterministic given a candidate list + target
+context.
+
+### Provider lifecycle invariant
+
+At every moment during an `autotune` run, AT MOST ONE
+`macprovider-cli serve` process is alive holding the local port
+(default 18080). Before evaluating the next candidate, `autotune`
+MUST stop the prior provider and wait for the port to free. The
+prototype enforces this with `pkill -f "macprovider-cli serve"` +
+poll; a Swift-native implementation MAY hold the subprocess handle
+directly. Either is acceptable. What is NOT acceptable is overlapping
+provider lifetimes.
+
+### Coordinator-pool invariant
+
+During tuning, candidate providers MUST NOT register with the
+coordinator pool. Buyer traffic during tuning would (a) pollute
+measurements and (b) expose buyers to providers that are about to be
+killed. FR-E.2 specifies the `--no-join` semantic; v1 makes this the
+DEFAULT and provides no flag to opt out.
+
+---
+
+## 4. User stories
+
+**(a) New provider onboarding: "I just installed macprovider-cli.
+What should I serve?"**
+
+```
+$ macprovider-cli autotune
+autotune: target_context=2000 (use --target-context to change)
+autotune: candidates (largest-first):
+  1. mlx-community/Qwen2.5-32B-Instruct-4bit
+  2. mlx-community/Qwen2.5-14B-Instruct-4bit
+  3. mlx-community/Qwen2.5-Coder-7B-Instruct-4bit
+  4. mlx-community/Llama-3.2-3B-Instruct-4bit
+  5. mlx-community/Llama-3.2-1B-Instruct-4bit
+...
+RECOMMENDATION
+  model:           mlx-community/Llama-3.2-3B-Instruct-4bit
+  target_context:  2000
+  --kv-bits:       8
+  --max-batch:     1
+  median tok/s:    4.9  (n=3 replicates)
+  p95 TTFT:        4.2s
+  fallbacks (if you'd rather serve a smaller model):
+    2. mlx-community/Llama-3.2-1B-Instruct-4bit  (9.7 tok/s)
+
+To apply this to your config and restart serve:
+  macprovider-cli autotune --apply
+```
+
+**(b) Existing provider: "macOS / mlx-swift / binary changed. Is my
+config still optimal?"**
+
+```
+$ macprovider-cli autotune --compare
+... runs same pipeline, then prints:
+RECOMMENDATION (current run)
+  model:           mlx-community/Qwen2.5-Coder-7B-Instruct-4bit
+  --kv-bits:       8                            (was 4 in last recipe)
+  median tok/s:    2.6                          (was 2.1)
+... summary of delta vs. last persisted run, if any.
+```
+
+**(c) Operator with a specific use case: "I want to commit to
+ctx=16000 — what's the biggest model I can serve?"**
+
+```
+$ macprovider-cli autotune --target-context 16000
+...
+RECOMMENDATION
+  model:           mlx-community/Llama-3.2-1B-Instruct-4bit
+  target_context:  16000
+  --kv-bits:       4
+  --max-batch:     1
+  median tok/s:    2.5
+  note: 3B / 7B / 14B / 32B candidates failed feasibility at
+        ctx=16000 (TTFT > 60s gate). Lower --target-context to
+        unlock larger models.
+```
+
+---
+
+## 5. Functional requirements
+
+### 5.1 Stage 1 — model selection (largest-first iteration)
+
+**FR-A.1. Candidate list is ordered, largest-first.**
+The candidate-models input is an ORDERED list sorted by approximate
+on-device weight footprint (parameter count × bytes-per-param, with
+the operator's chosen quantization), LARGEST first. The operator MAY
+override the order entirely (`--candidate-models <ordered,csv>`) or
+constrain it (`--max-model-size 16B`). v1 ships a default curated
+list described in §6.
+
+The order is the contract. `autotune` MUST iterate the list in the
+supplied order with no internal re-ranking and MUST NOT re-sort by
+predicted feasibility. If the operator passes a manifestly-wrong
+order ("1B first, then 32B"), `autotune` honors it — the candidate
+that fits first wins, even if it's the operator's worst choice.
+
+**FR-A.2. Per-candidate feasibility probe; STOP on first pass.**
+For each model in the list, in order, `autotune` MUST:
+
+1. Stop any prior candidate provider (provider lifecycle invariant).
+2. Pre-download the candidate's weights per FR-D.
+3. Start `macprovider-cli serve --model <id> --no-join --port 18080`
+   at the **default** knobs for this stage (kv-bits unset,
+   max-batch=1, max-context unset — the binary defaults). The intent
+   is to probe FIT cheaply; knob hill-climb is Stage 2's job.
+4. Wait for the provider to become ready (`/v1/models` returns 200).
+5. Fire `stage1_replicates` requests at the operator's
+   `--target-context` (default 2000).
+6. Stop the provider.
+7. Evaluate feasibility per FR-A.3. If feasible: this is the chosen
+   model. STOP iterating models. Proceed to Stage 2 with this model
+   id.
+8. If infeasible: record the failure reason and advance to the next
+   candidate.
+
+When the loop selects a model, the model id MUST be the one
+`autotune` actually started — not the operator's input string, not
+a normalized form. SPEC-010 v1.5 model-id semantics (NFC + ASCII
+case-fold for equality) apply.
+
+**FR-A.3. Feasibility is binary, gate-driven.**
+A candidate is feasible at the target context IFF all of the
+following hold across all `stage1_replicates` replicates:
+
+- Every request returned HTTP 2xx within the request timeout.
+- Every request's TTFT p95 ≤ `--gate-ttft-ms` (default 60_000 ms).
+  The gate is generous on purpose — TTFT > 60s is "the model
+  technically loaded but is unservable on this Mac at this context."
+- No stop-token leak in any response (the SPEC-001-defined stop
+  token, e.g. `<|im_end|>`, MUST NOT appear in the generated text).
+  This is the SPEC-001 §6.6 gate as currently enforced by
+  `harness.fire_stream` in the prototype.
+- The provider did not exit during the probe (a process exit during
+  load is the dominant OOM signal on small-RAM Macs and is recorded
+  as infeasible with the binary's stderr tail in `notes`).
+
+Default `stage1_replicates = 1` (cheap probe). The operator MAY raise
+it (`--stage1-replicates N`). **OPEN QUESTION OQ-D**: pending air5
+n=3 replication data, this default may be revised to N>1 if
+single-trial fit determination proves unstable. The spec flags this
+as a tunable; the implementation MUST surface the flag so v0.2 can
+re-default without a binary change.
+
+**FR-A.4. All-infeasible exit.**
+If NO model in the candidate list is feasible at the target context,
+`autotune` MUST exit non-zero with an error block that:
+
+- Names the target context.
+- Lists each candidate and its failure reason in order
+  (most-informative reason taken from the binary's stderr tail or
+  the gate-miss summary).
+- Suggests both remediations: a smaller `--target-context Y` and a
+  longer / different `--candidate-models ...`. The smallest
+  candidate's reason MUST be surfaced first (it carries the highest
+  information density for "even 1B can't fit my requirements" cases,
+  per FR-H.4).
+
+---
+
+### 5.2 Stage 2 — knob hill-climb within the chosen model
+
+**FR-B.1. Knob search space.**
+For the chosen model, `autotune` MUST search the cartesian product
+of:
+
+- `kv_bits`: `{4, 8}` (the two values PR #105 accepts), plus the
+  unset-default as an explicit third cell so the comparison includes
+  the unquantized KV-cache baseline.
+- `max_batch`: `{1, 2}` by default. The prototype found `max_batch
+  > 1` never helps at single-slot throughput; v1 still tests it so
+  the loop re-discovers per machine. The operator MAY widen to
+  `{1, 2, 4}` via `--max-batch-axis 1,2,4`.
+- `max_context`: a SMALL neighborhood around `--target-context`. v1
+  defaults to a single value (the target context itself) and the
+  operator MAY pass `--max-context-axis` to opt into a neighborhood.
+  This axis is OPTIONAL in v1; the recommended `max_context` in the
+  output equals `--target-context` unless the operator opted into
+  the axis and a different cell won.
+
+Each cell MUST be evaluated with `stage2_replicates` replicates
+(default 3 — **OPEN QUESTION OQ-B** pending air5 n=3 data) at the
+target context, with median tps and p95 TTFT recorded.
+
+**FR-B.2. Keep-best decision.**
+Throughput is the primary criterion; TTFT is the tiebreaker within
+`TPS_TIE_EPSILON` (default `0.02`, i.e. 2% relative — **OPEN
+QUESTION OQ-A** pending air5 n=3 data). This is the
+`_is_new_best()` semantic from the prototype (`beta/autotune.py`),
+reused unchanged in v1:
+
+```
+new_tps > best_tps * (1 + TPS_TIE_EPSILON)              -> new wins
+abs(new_tps - best_tps) / best_tps <= TPS_TIE_EPSILON   -> tie band
+    new_ttft < best_ttft                                -> new wins on TTFT
+otherwise                                               -> best held
+None tps (unmeasurable)                                 -> never wins
+```
+
+A cell that fails the feasibility gate (FR-A.3 applied per-cell)
+MUST NOT replace `best`, regardless of throughput.
+
+**FR-B.3. Stage-2 output.**
+The output of Stage 2 is one tuple `(model, kv_bits, max_batch,
+max_context)` plus the recorded median tps + p95 TTFT + the
+replicate count actually used. This tuple feeds the recommendation
+surface (FR-F).
+
+---
+
+### 5.3 Default candidate list (curated by the network)
+
+**FR-C.1. Default ordered list.**
+v1 ships a default ordered list, largest-first by weight footprint
+(parameter count × 4 bits/param for 4-bit quants). The list MUST
+cover the parameter counts the network wants represented:
+
+```
+1. mlx-community/Qwen2.5-32B-Instruct-4bit        (~17 GB)
+2. mlx-community/Qwen2.5-14B-Instruct-4bit        (~8 GB)
+3. mlx-community/Qwen2.5-Coder-7B-Instruct-4bit   (~4 GB)
+4. mlx-community/Llama-3.2-3B-Instruct-4bit       (~1.8 GB)
+5. mlx-community/Llama-3.2-1B-Instruct-4bit       (~0.7 GB)
+```
+
+These are MLX-community models with proven prior empirical evidence
+(see §1's empirical findings). The list is curated, not enumerated
+from HuggingFace; v1 does NOT pull the list from the coordinator
+(see §11 v2 deferral).
+
+The largest entry (32B) is intentionally over the median operator's
+RAM ceiling — the feasibility gate's job is to reject it cleanly so
+the iteration reaches a model that fits. A 16 GB Mac will reject
+items 1 and 2 quickly (load failure or OOM during probe) and accept
+item 3 or 4 depending on target context.
+
+**FR-C.2. Operator override.**
+The operator MAY override the entire list:
+
+- `--candidate-models <id1>,<id2>,<id3>...` — explicit ordered list;
+  largest-first ordering is the operator's responsibility.
+- `--max-model-size <Nb>` — trim the default list to items whose
+  parameter count is at most N billion (e.g. `--max-model-size 16B`
+  drops the 32B entry).
+- `--min-model-size <Nb>` — drop items below N billion (e.g.
+  `--min-model-size 7B` skips the 1B/3B fallbacks; useful when an
+  operator wants "fail loudly if my Mac can't serve at least 7B").
+
+When both `--candidate-models` and `--max/min-model-size` are
+supplied, the explicit list wins and the size flags are ignored
+(emit a warning).
+
+**FR-C.3. List source.**
+The default list is a code constant in the v1 binary. Pulling the
+list from the coordinator (so the network can ship new entrants
+without a binary release) is v2 — see §11. v1's choice keeps the
+recipe-replay surface deterministic and offline-friendly; the
+coordinator-served list introduces a coordinator-availability
+dependency on a workflow that is otherwise fully local.
+
+---
+
+### 5.4 Pre-download integration
+
+**FR-D.1. Pre-download via `models pull <id>`.**
+`autotune` MUST ensure each candidate's weights are present in the
+HuggingFace cache before invoking `macprovider-cli serve` for that
+candidate. v1 picks **option (a)** from the prompt: `autotune`
+invokes `macprovider-cli models pull <id>` as an explicit
+operator-visible step before each candidate's feasibility probe.
+
+The rationale for this over option (b) ("flip the binary into
+temporary online mode during tune"):
+
+- **Explicit and observable.** A failed download is a discrete
+  failure with a discrete subcommand at the top of the trace, not a
+  silent stretch of online-mode behavior buried inside a serve
+  process.
+- **No new global state on the binary.** Option (b) requires
+  `macprovider-cli serve` to grow a "temporarily-online" runtime
+  mode and a transition contract for it. That is more surface area
+  to test and ship than a sibling subcommand.
+- **Composable.** Operators can pre-pull the candidate list manually
+  (`macprovider-cli models pull <id>` for each) and then run
+  `autotune` in a network-isolated environment. Option (b) makes
+  this awkward.
+- **Matches existing ergonomics.** `pull` / `download` is the
+  conventional CLI shape; SPEC-003 v0.9.2 already exposes a model
+  selection prompt at install time and operators expect a
+  per-model fetch surface.
+
+**Normative dependency.** SPEC-013 v1 implicitly requires the
+`macprovider-cli models pull <id>` subcommand to exist. If it does
+not exist at implementation time, the implementing PR MUST add it;
+the SPEC for that subcommand is short enough to fit alongside the
+autotune work (a one-screen `pull` subcommand that flips HF online
+mode for the duration of one fetch and writes weights to the same
+HF cache the runtime reads from). The autotune SPEC does NOT
+normatively specify the `pull` subcommand's flags beyond the call
+shape `macprovider-cli models pull <id>`.
+
+**FR-D.2. Pre-download failure is candidate-level fatal.**
+If `models pull <id>` fails for a candidate (network down, weights
+missing from HF, signature mismatch, disk full), that candidate is
+recorded as infeasible-with-reason and `autotune` advances to the
+next candidate. The autotune run does NOT fail unless EVERY
+candidate fails pre-download (in which case FR-H.4 applies).
+
+---
+
+### 5.5 Provider-conflict safety
+
+**FR-E.1. Pre-flight: refuse if `serve` already running.**
+Before starting any candidate provider, `autotune` MUST check for an
+existing `macprovider-cli serve` process and an existing listener on
+the configured `--port` (default 18080). If either is present:
+
+- Default: refuse with a clear error, naming the conflicting PID
+  and the suggested remediation (`--drain` opt-in, or a manual
+  `launchctl unload` for launchd-managed installs, or simply
+  killing the process).
+- With `--drain`: `autotune` gracefully stops the live serve
+  (matching SPEC-011 v0.5 §3.4 drain semantics if warm-swap is
+  enabled, otherwise a clean process stop), runs the tune, then
+  either (a) restores the original serve config at the end (default
+  behavior) or (b) applies the new recommendation if `--apply` was
+  also passed.
+
+`--drain` is an explicit opt-in. v1 MUST NOT auto-drain — buyer
+traffic is on the line and an unconfirmed drain is the wrong
+default. The check MUST cover both the launchd-managed install
+(`com.macprovider.cli` plist) and a manually-run foreground
+process; the launchd-managed install's drain MUST restore the plist
+state on exit (unless `--apply` says otherwise).
+
+**FR-E.2. `--no-join` is the default tuning mode.**
+While autotune is running, candidate providers MUST start with
+`--no-join` (or equivalent: a flag that prevents the candidate
+binary from registering with the coordinator pool). The pool MUST
+NOT see partial-tuning candidates — they would receive buyer
+traffic that the autotune is about to interrupt by killing the
+process.
+
+`--no-join` semantics:
+- The candidate binary does NOT establish a WS session with the
+  coordinator.
+- The candidate binary's local `/v1/models`, `/v1/chat/completions`
+  etc. surfaces remain reachable on `127.0.0.1:<port>` for
+  `autotune`'s own probes.
+- On exit, no `state_update reason: "shutdown"` flows to the
+  coordinator (because no WS session existed).
+
+The `--no-join` flag is an implementation precondition of SPEC-013
+v1; if the `macprovider-cli serve` flag does not exist, the
+implementing PR MUST add it. v1 of `autotune` ALWAYS passes it; no
+operator override.
+
+---
+
+### 5.6 Recommendation surface
+
+**FR-F.1. Terminal output.**
+On successful completion, `autotune` MUST print a clearly delimited
+RECOMMENDATION block to stdout (NOT stderr — operators should be
+able to `tee` it). The block MUST include:
+
+- The recommended model id (full HF path, e.g.
+  `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit`).
+- The recommended knob settings as concrete `--kv-bits`,
+  `--max-batch`, `--max-context` values (with `--max-context` set to
+  the operator's `--target-context` unless FR-B.1's max-context
+  axis was opted into and a different cell won).
+- The target context the recommendation was tuned for.
+- The replicated median tps and p95 TTFT, with the replicate count.
+- Fallbacks: every smaller candidate from the candidate list that
+  ALSO passed Stage 1 feasibility, with its Stage-1 single-replicate
+  tps. Operators who want to manually choose a smaller / faster
+  model see what's available without re-running.
+- The exact `macprovider-cli serve` command line that the
+  recommendation reduces to, copy-pasteable.
+
+**FR-F.2. JSON output (`--json`).**
+With `--json`, the recommendation surface MUST also be emitted as
+JSON to stdout, with the following schema (frozen for v1; v2 may add
+additive fields):
+
+```json
+{
+  "spec_version": "SPEC-013 v0.1",
+  "run_id": "<uuid>",
+  "started_at": "2026-06-18T12:34:56Z",
+  "ended_at": "2026-06-18T13:01:22Z",
+  "machine": {
+    "ram_gb": 16,
+    "chip": "Apple M2",
+    "os_version": "macOS 26.3.1",
+    "binary_version": "1.4.0"
+  },
+  "inputs": {
+    "target_context": 4000,
+    "candidate_models": [
+      "mlx-community/Qwen2.5-32B-Instruct-4bit",
+      "mlx-community/Qwen2.5-14B-Instruct-4bit",
+      "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
+      "mlx-community/Llama-3.2-3B-Instruct-4bit",
+      "mlx-community/Llama-3.2-1B-Instruct-4bit"
+    ],
+    "stage1_replicates": 1,
+    "stage2_replicates": 3,
+    "gate_ttft_ms": 60000,
+    "tps_tie_epsilon": 0.02
+  },
+  "recommendation": {
+    "model": "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
+    "target_context": 4000,
+    "knobs": {
+      "kv_bits": 4,
+      "max_batch": 1,
+      "max_context": 4000
+    },
+    "tps_median": 2.1,
+    "ttft_p95_ms": 19500,
+    "replicates": 3,
+    "serve_command":
+      "macprovider-cli serve --model mlx-community/Qwen2.5-Coder-7B-Instruct-4bit --kv-bits 4 --max-batch 1 --max-context 4000"
+  },
+  "fallbacks": [
+    {
+      "model": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+      "tps_stage1": 4.9,
+      "rank": 4
+    },
+    {
+      "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+      "tps_stage1": 9.7,
+      "rank": 5
+    }
+  ],
+  "infeasible": [
+    {
+      "model": "mlx-community/Qwen2.5-32B-Instruct-4bit",
+      "rank": 1,
+      "reason":
+        "provider exited rc=137 during load (likely OOM); log tail: Metal allocation failed"
+    },
+    {
+      "model": "mlx-community/Qwen2.5-14B-Instruct-4bit",
+      "rank": 2,
+      "reason":
+        "ttft p95 23500ms > gate 60000ms passed but n_err=1 streaming abort"
+    }
+  ],
+  "recipe_hash": "sha256:<32-byte-hex>",
+  "db_path": "/Users/op/.config/macprovider/autotune.sqlite"
+}
+```
+
+The JSON schema is the canonical format for `console.streamvc.live`
+ingestion. The `recipe_hash` is a SHA-256 over the canonical-JSON
+form of `{machine, inputs, recommendation.knobs, recommendation.model}`
+and is the v2 sticky identifier for "this Mac + this recipe."
+v1-side it has no semantic use beyond display; it MUST still be
+emitted so v2 ingestion is back-compatible.
+
+**FR-F.3. `--apply`: write to config.**
+`--apply` is the only mode in which `autotune` writes to
+`~/.config/macprovider/config.yaml`. It MUST:
+
+1. Be opt-in. v1's default is "show the recommendation, do nothing."
+2. Atomically write the new config (temp-file + rename). Concurrent
+   reads MUST never see a half-written YAML.
+3. Save the prior config as `~/.config/macprovider/config.yaml.bak-<unix-ts>`.
+   The backup path MUST appear in stdout so the operator can revert.
+4. Be idempotent: applying the same recommendation twice produces
+   the same config and the same (empty) diff against the saved
+   backup.
+5. Modify ONLY the keys SPEC-013 owns:
+   `model`, `kv_bits`, `max_context_tokens`, `max_batch`. All other
+   YAML keys (coordinator_endpoint, provider_token, log paths, etc.)
+   MUST be carried through verbatim. `autotune` is not a config
+   rewrite tool.
+6. Print a single line summarizing what changed, e.g.
+   `applied: model=Qwen-7B kv_bits=4 max_batch=1 max_context=4000
+   (backup at ...)`.
+
+`--apply` does NOT restart the launchd service. If the operator's
+`macprovider-cli serve` was running under launchd, they MUST
+manually run `launchctl unload ... && launchctl load ...` (or the
+equivalent SPEC-003 v0.9.2 install-script helper if one exists) to
+pick up the new config. SPEC-013 v1 does NOT depend on or trigger
+SPEC-011 warm-swap for this.
+
+---
+
+### 5.7 State / DB
+
+**FR-G.1. `tune_trials` table.**
+Every per-cell evaluation (Stage 1 probes AND Stage 2 cells) MUST
+be persisted as one row in the additive `tune_trials` table. The
+schema is the prototype's schema (carried over verbatim from
+`beta/autotune.py` so the prototype's existing reporting code keeps
+working) plus a `stage` column distinguishing Stage 1 probes from
+Stage 2 hill-climb cells:
+
+```sql
+CREATE TABLE IF NOT EXISTS tune_trials (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_utc TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    stage INTEGER NOT NULL,                      -- 1 or 2 (v1 addition)
+    model TEXT NOT NULL,
+    target_context INTEGER NOT NULL,
+    measured_prompt_tokens INTEGER,
+    max_tokens INTEGER NOT NULL,
+    agg_throughput_tps REAL,                     -- median across replicates
+    ttft_p95_ms REAL,                            -- median across replicates
+    fits INTEGER NOT NULL DEFAULT 0,
+    n_err INTEGER NOT NULL DEFAULT 0,
+    kept INTEGER NOT NULL DEFAULT 0,             -- Stage 2 only; 0 in Stage 1
+    notes TEXT,
+    kv_bits INTEGER,
+    max_context_cap INTEGER,
+    max_batch INTEGER,
+    replicates_n INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_tune_trials_run_id ON tune_trials(run_id);
+CREATE INDEX IF NOT EXISTS idx_tune_trials_ts ON tune_trials(ts_utc);
+```
+
+The `stage` column is a SPEC-013 v0.1 addition; v1 implementations
+MUST `ALTER TABLE ADD COLUMN stage` if upgrading from a prototype
+DB. Default value is `1` for existing rows so historical reports
+don't crash.
+
+**Retention.** The DB MUST keep AT LEAST the most recent N runs by
+default (default `N = 50`; operator-overridable via
+`--retain-runs N`). Older runs are dropped on each new run start
+(scope: delete `tune_trials` and `tune_runs` rows whose `run_id` is
+not in the most recent N). `N >= 1` MUST be enforced; setting to 0
+or negative is an error at flag-parse time.
+
+The DB path defaults to `~/.config/macprovider/autotune.sqlite`
+(NOT the prototype's `beta/runs.sqlite` location, which is a
+repo-development path). Operator-overridable via `--db-path`.
+
+**FR-G.2. `tune_runs` table.**
+One row per autotune invocation. Captures inputs and the final
+recommendation, providing a single-row replay surface that doesn't
+require scanning `tune_trials` to reconstruct what happened:
+
+```sql
+CREATE TABLE IF NOT EXISTS tune_runs (
+    run_id TEXT PRIMARY KEY,
+    started_at_utc TEXT NOT NULL,
+    ended_at_utc TEXT,                       -- NULL if interrupted
+    spec_version TEXT NOT NULL,              -- 'SPEC-013 v0.1'
+    binary_version TEXT NOT NULL,
+    machine_ram_gb INTEGER NOT NULL,
+    machine_chip TEXT NOT NULL,
+    machine_os_version TEXT NOT NULL,
+    target_context INTEGER NOT NULL,
+    candidate_models_json TEXT NOT NULL,     -- the input list
+    stage1_replicates INTEGER NOT NULL,
+    stage2_replicates INTEGER NOT NULL,
+    gate_ttft_ms INTEGER NOT NULL,
+    tps_tie_epsilon REAL NOT NULL,
+    recommendation_json TEXT,                -- NULL if no feasible recommendation
+    recipe_hash TEXT,                        -- NULL if no recommendation
+    applied INTEGER NOT NULL DEFAULT 0,      -- 1 iff --apply was used
+    exit_reason TEXT                         -- 'ok' | 'interrupted' | 'no_feasible' | error msg
+);
+```
+
+The `recipe_hash` is the FR-F.2 hash. Two `tune_runs` rows with the
+same `recipe_hash` represent the same machine + recipe; this is the
+v2 sticky comparison key.
+
+---
+
+### 5.8 Failure modes + recovery
+
+**FR-H.1. Ctrl-C is safe.**
+SIGINT (Ctrl-C) MUST stop the currently-running candidate provider
+within `--drain-grace` seconds (default 10s), write a partial row
+to `tune_runs` with `exit_reason = 'interrupted'`, write any
+in-flight `tune_trials` row, close the DB, and exit cleanly with a
+non-zero status. The prototype's signal handler establishes the
+pattern; the Swift-native implementation MAY use Swift's task
+cancellation primitives. Either way, post-condition: no orphan
+provider, port released, DB in a consistent state.
+
+**FR-H.2. Midway crash: rerun is safe.**
+A crashed run leaves its `tune_runs.ended_at_utc` as NULL and any
+written `tune_trials` rows as-is. Rerun is safe: a fresh `run_id`
+opens a fresh `tune_runs` row; the old run's data is preserved and
+reusable by reporting. The operator MAY pass `--resume` to skip
+Stage 1 candidates that the prior crashed run already proved
+infeasible (best-effort optimization; out of scope for v0.1's
+normative contract — see §11). v0.1 default behavior is full rerun.
+
+**FR-H.3. Network down during pre-download.**
+A failed `models pull` for candidate K marks K infeasible with
+reason "pre-download failed: <error>" and advances to candidate K+1.
+The run only fails if EVERY candidate fails pre-download (then
+FR-H.4 applies). This way, an operator running autotune with the
+2 largest models pre-cached and a flaky network still gets a
+working recommendation from the smaller cached candidates.
+
+**FR-H.4. All-infeasible: surface most-informative reason.**
+Per FR-A.4. The error message MUST lead with the SMALLEST candidate
+that failed (the most informative case: "even 1B can't fit your
+requirements" tells the operator immediately that their
+`--target-context` is too aggressive for the hardware) followed by
+each larger candidate's failure reason in size order. This is the
+opposite of "first failure wins": the smallest is the most
+diagnostic.
+
+---
+
+## 6. Non-functional requirements
+
+**NFR-1. Wall-clock budget per RAM tier.**
+
+Approximate expected wall-clock times (target context = 4000,
+defaults, single-replicate Stage 1 + 3-replicate Stage 2):
+
+| RAM tier | Stage 1 (largest-first iteration) | Stage 2 (knob hill-climb) | Total |
+|---|---|---|---|
+|  8 GB | ~10 min (rejects 32B/14B/7B quickly via OOM-during-load; settles at 3B or 1B) | ~10 min (1B/3B knob space is small and loads are fast) | ~20 min |
+| 16 GB | ~30 min (32B rejects, 14B may TTFT-gate; settles at 7B or 3B) | ~20 min (7B loads are ~1 min; 6 cells × 3 replicates) | ~50 min |
+| 32 GB | ~45 min (32B may TTFT-gate; settles at 14B) | ~30 min (14B loads are ~2 min; 6 cells × 3 replicates) | ~75 min |
+| 64 GB+ | ~60 min (32B fits; one big probe is the dominant cost) | ~35 min (32B loads are ~5 min; 6 cells × 3 replicates) | ~95 min |
+
+These are **expectations**, not contracts. The binding contract is:
+
+- `autotune` MUST accept `--max-duration <seconds>` (default 7200s
+  = 2 hours total cap covering Stage 1 + Stage 2).
+- On budget exhaustion mid-Stage-2, `autotune` MUST emit the
+  best-so-far recommendation and exit non-zero (treating it as a
+  "partial recommendation" with a warning).
+- On budget exhaustion mid-Stage-1, `autotune` MUST exit non-zero
+  with a "tuning incomplete: no model selected" error and a
+  suggestion to raise `--max-duration` or trim
+  `--candidate-models` / `--max-model-size`.
+
+**NFR-2. Resource impact during tuning.**
+`autotune` is single-slot: at any moment, exactly one provider
+process is alive at single-batch concurrency. CPU/RAM/thermal
+impact MUST be at most one `macprovider-cli serve` process's worth.
+No concurrent buyers (enforced by FR-E.2 `--no-join`), no
+background workers, no spawn of parallel probes.
+
+The wall-clock budget in NFR-1 already accounts for thermal
+throttling on small-RAM Macs (the 8 GB tier's larger candidates
+fail to load quickly enough that thermal headroom is preserved for
+the small candidates that DO load). v1 does NOT include explicit
+thermal pacing.
+
+**NFR-3. Reversibility.**
+Pre-tune `~/.config/macprovider/config.yaml` is ALWAYS recoverable
+via the `.bak-<unix-ts>` file written by `--apply` (FR-F.3). If
+`--apply` was not used, the config was not touched. There is no
+case in which an autotune run renders the prior config
+unrecoverable.
+
+The recipe DB (`autotune.sqlite`) is additive; an autotune run does
+not delete the prior run's `tune_runs` or `tune_trials` rows except
+through the retention limit (FR-G.1), which defaults to 50 runs
+retained.
+
+**NFR-4. Telemetry / privacy.**
+**Nothing leaves the machine.** v1 has NO opt-in or opt-out
+telemetry — no upload, no analytics, no remote logging. The machine
+fingerprint (`ram_gb`, `chip`, `os_version`, `binary_version`)
+appears in `tune_runs.machine_*` columns and in the FR-F.2 JSON
+output for local consumption by `console.streamvc.live` (when the
+operator chooses to share that JSON), but `autotune` itself
+performs no network egress except `models pull <id>` to
+HuggingFace.
+
+The coordinator-side recipe registry is v2 territory — see §11.
+Even when it ships, it MUST be opt-in. The v1 design intentionally
+keeps the recipe wholly local so operators can run autotune on
+private/air-gapped Macs.
+
+---
+
+## 7. CLI surface (summary)
+
+This is reference, not normative — the normative surface is the FRs
+above. The actual flag set is:
+
+```
+macprovider-cli autotune
+  --target-context <N>           target context in tokens (default 2000)
+  --candidate-models <csv>       override default ordered list
+  --max-model-size <Nb>          trim default list above this size
+  --min-model-size <Nb>          trim default list below this size
+  --kv-bits-axis <csv>           Stage 2 kv-bits cells (default '4,8')
+  --max-batch-axis <csv>         Stage 2 max-batch cells (default '1,2')
+  --max-context-axis <csv>       Stage 2 max-context cells (default '' = target only)
+  --stage1-replicates <N>        default 1
+  --stage2-replicates <N>        default 3
+  --gate-ttft-ms <N>             default 60000
+  --tps-tie-epsilon <F>          default 0.02
+  --max-duration <seconds>       default 7200
+  --port <N>                     local provider port (default 18080)
+  --db-path <path>               default ~/.config/macprovider/autotune.sqlite
+  --retain-runs <N>              default 50
+  --json                         emit recommendation as JSON
+  --apply                        write recommendation to config.yaml
+  --drain                        if `serve` is running, drain it before tuning
+  --resume                       skip candidates known infeasible from a prior crashed run (v2)
+  --dry-run                      print the candidate plan and exit
+  --report-only                  re-render the latest run's report and exit
+  -v / --verbose                 stream per-trial details to stderr
+```
+
+The flag shape MAY change in v0.2 based on audit feedback. The
+SEMANTICS in §5 are the normative surface.
+
+---
+
+## 8. Acceptance criteria
+
+Each AC names the specific behavior the test verifies. Tests MUST
+NOT use mock providers exclusively — the autotune subcommand's
+contract is "drives a real `macprovider-cli serve` process," so the
+critical-path ACs require an integration harness that exercises the
+real binary on at least one RAM tier (8 GB is the cheapest to
+maintain).
+
+**AC-1. Largest-first iteration STOPS on first feasible.**
+Configure candidate list `[X, Y, Z]` where X is infeasible (oversized
+candidate id pointing at a too-large model) and Y is feasible. The
+run MUST select Y, NOT iterate to Z, NOT emit a Z trial row, and the
+RECOMMENDATION block MUST name Y. The fallbacks list MUST be empty
+in this case (only Z would be a fallback, and the iteration didn't
+reach it).
+
+**AC-2. Largest-first iteration ITERATES past infeasible.**
+Configure candidate list `[X, Y, Z]` where X is infeasible at the
+target context, Y is infeasible, Z is feasible. The run MUST emit
+infeasibility rows for X and Y (with `notes` populated) and select
+Z. RECOMMENDATION names Z; fallbacks list is empty.
+
+**AC-3. All-infeasible exits non-zero with smallest-first reason.**
+Configure a candidate list where every candidate is infeasible at the
+target context. The run MUST exit non-zero. The error message MUST
+lead with the SMALLEST candidate's failure reason (per FR-H.4) and
+list each larger candidate's failure in size order. The `tune_runs`
+row MUST have `exit_reason = 'no_feasible'` and
+`recommendation_json IS NULL`.
+
+**AC-4. Stage 2 hill-climb uses median-of-N + strict-all-feasible.**
+For the chosen model with `--stage2-replicates 3`, configure a mock
+provider whose 3 replicates produce tps `[2.0, 2.1, 2.05]`. The
+recorded `agg_throughput_tps` MUST equal `2.05` (median). With one
+replicate erroring (`n_err = 1`), the cell MUST be marked `fits = 0`
+regardless of the other replicates' median, per FR-B.2's
+strict-all-feasible application of FR-A.3.
+
+**AC-5. TPS tiebreak by TTFT.**
+For two Stage 2 cells where cell A has tps=10.0 / ttft=4000ms and
+cell B has tps=10.05 / ttft=3000ms (within `TPS_TIE_EPSILON = 0.02`),
+the run MUST select cell B (lower TTFT). With cell B's ttft=4500ms
+(higher), the run MUST select cell A. This reproduces the
+prototype's `_is_new_best` semantics verbatim.
+
+**AC-6. Provider-conflict pre-flight refuses by default.**
+With a `macprovider-cli serve` already running on the configured
+port, `autotune` (no `--drain`) MUST refuse with a clear error
+naming the existing PID and the `--drain` opt-in. The DB MUST NOT
+have a `tune_runs` row written. Exit code MUST be non-zero and
+distinct from the all-infeasible exit code (so wrappers can
+distinguish).
+
+**AC-7. `--no-join` is set on every candidate.**
+The implementation MUST always pass `--no-join` (or its equivalent
+flag) to every candidate `serve` invocation. A test asserts the
+spawn argv contains `--no-join` and the coordinator pool MUST NOT
+observe any provider connection during the autotune run (verified
+via an integration test that watches the coordinator's
+`/admin/pool/check` or equivalent).
+
+**AC-8. Pre-download failure advances to next candidate.**
+With `macprovider-cli models pull <id>` mocked to fail for candidate
+1, the run MUST emit an infeasibility row for candidate 1 with notes
+containing the pull error message and proceed to candidate 2. The
+`tune_runs.exit_reason` MUST be `'ok'` IFF some candidate
+succeeded, otherwise `'no_feasible'`.
+
+**AC-9. `--apply` is atomic + backs up + idempotent.**
+With `--apply`, a successful run MUST:
+- Write the new `config.yaml` atomically (test asserts the file is
+  either fully old or fully new at every observation moment, never
+  half-written, via an `flock`-equivalent or a temp-file-rename
+  trace).
+- Save the prior config as `config.yaml.bak-<unix-ts>` with file
+  contents byte-identical to the pre-apply config.
+- Modify ONLY keys SPEC-013 owns. A test asserts every non-owned key
+  (e.g. `coordinator_endpoint`, `provider_token`) is byte-identical
+  pre/post.
+- Re-running with the same recommendation produces zero diff
+  against the saved backup (idempotence).
+
+**AC-10. Ctrl-C cleanup.**
+SIGINT during a candidate probe MUST: stop the provider within
+`--drain-grace` seconds, leave the port free, write the partial
+`tune_runs.exit_reason = 'interrupted'`, and exit. A subsequent
+autotune run MUST be able to open the DB and start a fresh run
+without errors. A test asserts the port is free post-SIGINT (with a
+small settle window) and that no orphan `macprovider-cli` process
+remains.
+
+**AC-11. JSON output schema stability.**
+With `--json`, the emitted JSON MUST validate against the FR-F.2
+schema. A schema regression test asserts every documented field is
+present with the documented type. Additive fields are allowed in
+v0.2+; field removal or type change is a SPEC bump.
+
+**AC-12. Recipe hash determinism.**
+Two `autotune` runs on the same machine with the same flags
+producing the same recommendation MUST emit the same `recipe_hash`.
+A run on a different RAM tier (e.g. 8 GB vs 16 GB) producing
+even-coincidentally-the-same recommendation MUST emit a different
+`recipe_hash` (because `machine.ram_gb` is part of the canonical
+JSON the hash covers).
+
+**AC-13. Wall-clock budget enforcement.**
+With `--max-duration 60` (very small), the run MUST exit
+non-zero within the budget plus a small grace. If the budget exhausts
+mid-Stage-2 with a best-so-far recommendation, the run MUST emit
+that recommendation with a "partial" warning, write `exit_reason =
+'budget_exhausted_with_partial_recommendation'`, and exit non-zero.
+If exhausted mid-Stage-1 with no chosen model, `exit_reason =
+'budget_exhausted_no_model_selected'` and the JSON output's
+`recommendation` MUST be `null`.
+
+**AC-14. Default candidate list is honored.**
+With no `--candidate-models` flag, the run MUST iterate the v1
+default list (FR-C.1) in the specified order. A test asserts the
+first candidate the run probes is `mlx-community/Qwen2.5-32B-Instruct-4bit`
+even on hardware that will reject it.
+
+**AC-15. Operator override beats size flags.**
+With both `--candidate-models a,b,c` and `--max-model-size 7B`,
+the explicit list MUST win and the size flag MUST be ignored with a
+stderr warning. A test asserts the warning is emitted and the
+iterated candidates are exactly `[a, b, c]`.
+
+**AC-16. `tune_trials.stage` populates correctly.**
+Stage 1 probes MUST be recorded with `stage = 1`; Stage 2 cells MUST
+be recorded with `stage = 2`. A test asserts the row count per
+stage matches the expected: stage 1 count = (candidates iterated
+until chosen model); stage 2 count = (kv_bits axis size × max_batch
+axis size × max_context axis size).
+
+---
+
+## 9. Open questions
+
+All four open questions below are flagged as **pending the in-flight
+air5 n=3 replication run**. Each names the placeholder default and
+the decision threshold; v0.2 either confirms the placeholder or
+adjusts it via a narrow PR with the air5 data attached.
+
+**OQ-A. `TPS_TIE_EPSILON` default given measured variance.**
+v0.1 uses `0.02` (2% relative), inherited from the prototype. The
+correct value depends on the measured trial-to-trial tps variance on
+air5 at n=3 replicates. If σ(tps)/μ(tps) > 0.02, the placeholder is
+too aggressive (real differences will be flattened to "tie"); if
+< 0.005, the placeholder is too loose (noise will register as a
+real difference). v0.2 picks whichever bound the data supports.
+
+**OQ-B. `stage2_replicates` recommended default.**
+v0.1 uses `3`, balancing wall-clock against noise. Air5 n=3 data
+will tell us whether 3 is sufficient to discriminate cells whose
+true tps gap is within `TPS_TIE_EPSILON`. If discrimination is
+poor at n=3, v0.2 raises the default to 5 (Stage 2 wall-clock grows
+linearly; the NFR-1 budget table absorbs the change).
+
+**OQ-C. Should `kv_bits` remain a search axis or become a fixed
+default?**
+Prior runs showed kv-bits=8 outperformed kv-bits=4 on every air5
+model (1B +12%, 3B +58%). If the air5 n=3 replication confirms this
+generalizes (i.e. kv-bits=8 wins on every model on every RAM tier
+within `TPS_TIE_EPSILON`), v0.2 may drop kv-bits from Stage 2 search
+and bake it in as the default. Until then, v0.1 keeps it as an axis
+so the loop re-discovers per machine — the risk of premature
+fixation (a future MLX-swift version changing the kv-bits trade-off)
+is higher than the cost of one extra cell.
+
+**OQ-D. Does Stage 1 fit-determination need N > 1 replicates?**
+v0.1 uses `stage1_replicates = 1` (cheap probe). If air5 n=3 data
+shows that single-trial fit decisions are unstable (one probe rules
+a model feasible while the next probe rules the same model
+infeasible at the same context), v0.2 raises the default to N=2 or
+N=3. The wall-clock cost is meaningful in Stage 1 (the iteration
+runs across the whole candidate list), so the change requires real
+evidence.
+
+---
+
+## 10. Implementation note (Swift-native vs Python-prototype wrapper)
+
+v1 of SPEC-013 does NOT pick between two viable implementation
+shapes. The implementing PR makes the call. The trade-off:
+
+**Option A: Swift-native subcommand inside `macprovider-cli`.**
+- Pro: consistent with the rest of the CLI; one binary; one
+  release pipeline; can directly hold the candidate provider's
+  subprocess handle without `pkill`; can opt into SPEC-011
+  warm-swap in a future v2 without an FFI boundary; clean install
+  story (no Python runtime required).
+- Pro: signal handling, drain semantics, and atomic config writes
+  match the rest of the Swift binary's patterns.
+- Con: Swift-native re-implements the prototype's harness +
+  measurement layer (~2 weeks of work to match the prototype's
+  parity).
+- Con: Loses the prototype's HTML report (or re-implements it in
+  Swift, which is more work than its value).
+
+**Option B: Ship the Python prototype as the v1
+implementation, invoked as `macprovider-cli autotune` via a Swift
+shim that exec's `python3 beta/autotune.py`.**
+- Pro: lands faster (prototype is ~1000 lines and works today);
+  reuses harness.py + sweep.py + sweep_report.py unchanged.
+- Pro: HTML report ships for free.
+- Con: requires a working Python 3 environment on every operator
+  Mac. macOS ships system Python but `requests` is not in the
+  stdlib; either bundle a wheel or `pip install` at install time.
+- Con: Two languages in the operator install story.
+- Con: SPEC-011 warm-swap integration (v2) is harder across the
+  subprocess boundary.
+- Con: The `models pull <id>` FR-D.1 dependency still needs a
+  Swift-side subcommand; option B requires both surfaces.
+
+v1 SPEC is neutral. The implementing PR justifies the choice in its
+description and the audit pass on the implementation calls out any
+divergence from the spec's FRs that the choice introduces.
+
+---
+
+## 11. Out of scope for v1 (queued for v2)
+
+| Feature | Why deferred |
+|---|---|
+| Coordinator-served candidate list (so the network can ship new entrants without a binary release) | FR-C.3 explicitly defers. Requires SPEC-014 (or a SPEC-010 extension) defining the wire surface for the coordinator-served list, plus a freshness / signature contract. Not blocking the v1 product strategy. |
+| Per-provider recipe attestation (the coordinator verifies "this provider really ran the recipe it claims") | Coupled to SPEC-008 v0.3 Pillar A. Useful for trust tiers; not load-bearing for "biggest-fit recommendation." |
+| Sticky-affinity from recipes (route buyer requests preferentially to providers whose recipe matches a buyer's pin) | Coupled to SPEC-004 routing. Useful for "stable buyer experience across reconnects"; SPEC-013 v1 stays out of routing. |
+| Automatic re-tune on hardware/binary changes (cron-style "autotune ran last on binary v1.4.0; you're now on v1.5.0; run again?") | SPEC-013 v2 can add a status check (`macprovider-cli autotune --check-stale`) that recommends a re-tune; v1 leaves this to the operator. |
+| Pareto-frontier UX ("here are 3 candidates: biggest, fastest, balanced") | v1 is opinionated and singular per the product framing in §1. v2 can add `--show-pareto` if operators ask for it. |
+| Multi-model serving on one Mac (warm-pool of multiple loaded models) | Architectural; out of scope for an autotune subcommand. |
+| SPEC-011 warm-swap-driven tuning (load one provider once, swap models via the warm-swap path to avoid load-per-candidate cost) | SPEC-011 v0.5 is opt-in via `--enable-warm-swap`. v1 of autotune stays on the prototype's process-restart model. v2 can opt-in. |
+| `--resume` for crashed runs (FR-H.2 mentions; v1 default is full rerun) | Useful, but v1's correct contract is "rerun is safe and produces equivalent results"; the optimization is additive. |
+
+The successor SPEC for items 1, 4, 5 is provisionally SPEC-014 (the
+recommended-catalog surface anticipated by SPEC-011 §8). SPEC-013 v2
+and SPEC-014 v1 ship together if they ship at all.
+
+---
+
+## 12. Migration note from the PR #103 prototype
+
+The PR #103 Python prototype (`beta/autotune.py`,
+`spike/provider-model-autotune` branch) is the implementation
+reference for everything SPEC-013 reuses. This note enumerates what
+survives, what changes, and what is rejected.
+
+### What survives (reuse verbatim)
+
+- **Provider lifecycle.** `start_provider` /
+  `wait_for_ready` / `stop_provider` semantics. Including the
+  `pkill -f "macprovider-cli serve"` settle pattern (Option B
+  implementation) or the equivalent Swift subprocess handle (Option
+  A). The invariant "one provider at a time, port released before
+  the next candidate" is unchanged.
+- **`tune_trials` schema.** The prototype's schema is carried over
+  verbatim (FR-G.1) with one additive `stage` column. Existing rows
+  upgrade with `stage = 1` default (no data loss).
+- **`_is_new_best()` semantics.** The keep-best decision with
+  `TPS_TIE_EPSILON = 0.02` TTFT tiebreak is reused unchanged for
+  Stage 2 (FR-B.2). This is the part of the prototype that earns
+  its keep — it's a small, well-validated piece of decision logic
+  the v0.1 SPEC inherits.
+- **HF offline-mode handling.** The prototype's pre-download via
+  external `pip install` / cache pre-warm is replaced by FR-D.1's
+  `macprovider-cli models pull <id>`, but the principle (model
+  weights must be on disk before `serve` starts) is the same.
+- **`--replicates N` aggregation.** Median tps + p95 TTFT,
+  strict-all-feasible. SPEC-013 v1 names the two stage-specific
+  flags (`--stage1-replicates`, `--stage2-replicates`) but the
+  per-cell aggregation logic is the prototype's.
+- **Signal handler / Ctrl-C safety.** FR-H.1 inherits the
+  prototype's `signal.SIGINT` / `signal.SIGTERM` cleanup pattern.
+
+### What changes (rejected from the prototype)
+
+- **The objective.** The prototype hill-climbs over a cartesian
+  `(model × ctx × kv-bits × max-batch)` space and keeps the cell
+  with the highest median tps. This produces "find the
+  highest-throughput model" — the very anti-pattern SPEC-013 §1
+  rejects. SPEC-013 v1 replaces the prototype's single-stage
+  cartesian max-tps loop with the two-stage "largest-first
+  feasibility iteration → in-model knob hill-climb" pipeline (§3,
+  FR-A, FR-B).
+- **The candidate list.** The prototype's default
+  `DEFAULT_MODELS = [1B, 3B, Phi-3.5-mini]` is rejected. SPEC-013
+  v1 defaults to the 5-entry largest-first list (FR-C.1) covering
+  32B / 14B / 7B / 3B / 1B. The 32B entry is intentionally over the
+  median operator's RAM ceiling — the feasibility gate rejects it
+  cleanly.
+- **The coordinator-join behavior.** The prototype's docstring
+  notes "Joining is a harmless side effect" and lets each candidate
+  briefly register. SPEC-013 v1 FR-E.2 REQUIRES `--no-join` for
+  candidates so the pool never sees partial-tuning providers.
+- **The DB location.** The prototype uses `beta/runs.sqlite` (a
+  repo-development path). SPEC-013 v1 uses
+  `~/.config/macprovider/autotune.sqlite` (operator-home).
+- **The recommendation surface.** The prototype emits a winner line
+  and an HTML report. SPEC-013 v1 adds the FR-F.1 terminal
+  RECOMMENDATION block, the FR-F.2 JSON schema, and the FR-F.3
+  `--apply` flag. The HTML report MAY ship in Option B but is not
+  normative.
+
+### What is provisional (depends on the air5 n=3 replication run)
+
+- All four numerical defaults flagged in §9 (`TPS_TIE_EPSILON`,
+  `stage1_replicates`, `stage2_replicates`, kv-bits axis).
+
+The prototype branch (`spike/provider-model-autotune`) MUST NOT be
+merged as-is. The implementing PR for SPEC-013 v1 either supersedes
+it (Option A) or rebases it onto the SPEC-013 design (Option B with
+the objective rewrite).
+
+---
+
+## 13. References
+
+- [SPEC-001 v1.4](SPEC-001-phase3-binary.md) — Phase 3 binary
+  (PR #105 added `--kv-bits`, `--max-context`, `--max-batch` serve
+  flags; SPEC-013 wraps them)
+- [SPEC-003 v0.9.2](SPEC-003-open-onboarding.md) — install /
+  onboarding (SPEC-013's `autotune` answers the "what should I
+  serve?" question the install flow currently leaves open)
+- [SPEC-010 v1.5](SPEC-010-model-catalog.md) — provider model
+  catalog (SPEC-013 produces a single chosen model; SPEC-010
+  defines how that model is advertised to the network)
+- [SPEC-011 v0.5](SPEC-011-operator-pushed-warm-swap.md) —
+  operator-pushed warm swap (SPEC-013 v1 stays out of warm-swap;
+  §11 notes the v2 opt-in)
+- [PR #105](https://github.com/Augustas11/macprovider/pull/105) —
+  `--kv-bits` / `--max-context` / `--max-batch` serve knobs
+- [PR #103](https://github.com/Augustas11/macprovider/pull/103) —
+  Python prototype on `spike/provider-model-autotune` branch
+  (`beta/autotune.py`)
+- `beta/autotune.py` on the `spike/provider-model-autotune` branch
+  — the implementation reference for the parts SPEC-013 reuses
+  (lifecycle, schema, `_is_new_best`, signal handling)


### PR DESCRIPTION
## Summary

SPEC-013 v0.3 specifies a new `macprovider-cli autotune` subcommand that encodes the network's "use this Mac's capacity to its maximum useful capability" product strategy.

**The load-bearing decision: biggest-fit, not max-tps.** Autotune wraps the PR #105 serving knobs (`--kv-bits`, `--max-context`, `--max-batch`) in a two-stage pipeline. **Stage 1** iterates a curated largest-first candidate model list and STOPS on the first model that passes the feasibility gate; **Stage 2** hill-climbs the knobs WITHIN that chosen model. This is the explicit rejection of the PR #103 Python prototype's objective — its cartesian max-tps cell-search would push every capable Mac to serve the smallest model (the buyer could call any cloud API for that), destroying the network value. Throughput is the tiebreaker among knob settings, NOT the cross-model objective.

A 16 GB Mac that can host a 7B SHOULD serve a 7B even though the 1B is faster on the same hardware. SPEC-013 is what encodes that.

### What this is NOT

- **Not implementation.** SPEC-only. No Swift code, no Python code, no tests, no deploy. Implementation choice between Option A (Swift-native subcommand) vs Option B (Python-wrapper around the prototype) is explicitly deferred to the implementing PR per §10.
- **Not merge-ready.** This PR opens as DRAFT for spec review. The audit cycle has converged (3 codex rounds, see below), but reviewers should still pass on the locked v0.3 before any implementation PR begins.
- **Not a coordinator change.** SPEC-002 v1.3.5 / SPEC-006 v0.8.3 are untouched; no wire protocol changes; no buyer-facing behavior changes; no billing implications. With autotune unused, provider behavior is byte-identical to pre-SPEC-013.

### Audit cycle (codex, 3 rounds)

Per the project's house pattern, the SPEC went through a codex audit loop before opening this PR. Full report at [specs/SPEC-013-audit.md](specs/SPEC-013-audit.md).

| Round | Verdict | Closure |
|---|---|---|
| 1 (on v0.1) | 0 CRITICAL / 7 MAJOR / 11 MINOR / 2 QUESTION | v0.2 closes 17 of 19 (1 MINOR deferred to post-lock checklist) |
| 2 (on v0.2) | LOCK READY + 1 MAJOR new + 3 MINOR new | v0.3 closes all 4 |
| 3 (on v0.3) | **LOCK** + 0 MAJOR / 1 trivial MINOR | folded into v0.3 |

Key round-1 closures were code-grounded fixes that would have broken on day one of implementation: the `--apply` config keys (`max_context_override` / `max_concurrency_override` per [Config.swift:239](phase3-binary/Sources/MacProviderCore/Config.swift)), the launchd label (`live.streamvc.macprovider` per SPEC-003 v0.9.2 §FR-C5), and the `tune_trials.stage` SQLite migration (`ALTER TABLE ... ADD COLUMN ... INTEGER NOT NULL DEFAULT 1`).

### What's in the SPEC

- **§3 architecture:** two-stage pipeline with provider-lifecycle invariants (one provider at a time, `--no-join` so candidates never enter the coordinator pool)
- **§5 functional requirements:** FR-A.1–4 (Stage 1), FR-B.1–3 (Stage 2), FR-C.1–3 (default curated candidate list), FR-D.1–2 (pre-warm contract with Shape A vs Shape B implementation choice + integrity-vs-transient failure split), FR-E.1–2 (provider-conflict safety, launchd drain), FR-F.1–3 (recommendation surface + JSON schema + opt-in `--apply`), FR-G.1–2 (`tune_trials` + `tune_runs` SQLite schema), FR-H.1–4 (failure modes)
- **§6 NFRs:** wall-clock budget per RAM tier (~20 min on 8 GB → ~95 min on 64 GB+), single-slot resource posture, reversibility via collision-safe backups, **nothing leaves the machine** except FR-D.1 HuggingFace pre-warm fetches
- **§8 acceptance criteria:** 19 ACs including AC-17 — the load-bearing "operator-supplied order is honored verbatim, no internal rerank" guard
- **§9 open questions:** 5 OQs flagged for the in-flight air5 n=3 replication run (`TPS_TIE_EPSILON` default, `stage2_replicates`, kv-bits axis vs default, `stage1_replicates` stability, OQ-E thermal/cell-order bias). Each names a measurable decision threshold.
- **§11 out of scope for v1 / queued for v2:** coordinator-served candidate list, recipe attestation, sticky-affinity from recipes, warm-swap-driven tuning. SPEC-014 provisionally reserved for the coordinator-served recommended catalog (cross-spec renumber per SPEC-011 §8).
- **§12 prototype migration note:** what survives from PR #103 (provider lifecycle, `_is_new_best` knob tiebreak, `tune_trials` schema, signal handling), what changes (the objective itself).

### Open questions (pending air5 n=3 replication run)

Each has a quantitative decision threshold; v0.4 either confirms placeholders or adjusts via a narrow PR with the air5 data attached:

- **OQ-A** `TPS_TIE_EPSILON` default given measured σ(tps)/μ(tps)
- **OQ-B** `stage2_replicates` minimum discriminable tps gap ≤ TPS_TIE_EPSILON × median
- **OQ-C** whether kv-bits stays a search axis or becomes a fixed default
- **OQ-D** Stage 1 fit-determination needs N>1 replicates (false-fit/false-reject rate > 5% → escalate)
- **OQ-E** thermal/cell-order bias (10 paired forward/reverse runs; mismatch_pairs/10 > 0.05 → randomize/cooldown)

## Test plan

- [x] Audit cycle converged (3 codex rounds, LOCK verdict)
- [x] All FR/AC cross-references resolve within the document
- [x] Spec text grounded against actual code: `Config.swift` YAML keys, `live.streamvc.macprovider` launchd label, `ModelRuntime.configuration(for:)` HF cache + online-fallback path, `beta/autotune.py` provider lifecycle + `_is_new_best`
- [ ] **Spec review:** human reviewer reads v0.3 end-to-end and approves LOCK (or files round-4 findings)
- [ ] **DO NOT MERGE** until spec review is complete
- [ ] **No implementation work begins** until this PR merges and §11 post-lock checklist runs (decision-log entry, SPEC-003 install-flow note, PR #103 disposition)

## Related

- [PR #105](https://github.com/Augustas11/macprovider/pull/105) — the serving knobs (`--kv-bits`, `--max-context`, `--max-batch`) that autotune wraps
- [PR #103](https://github.com/Augustas11/macprovider/pull/103) — the Python prototype; SPEC-013 §12 documents what survives and what's rejected. Disposition (close vs rebase) follows the implementation choice (Option A vs Option B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
