### PR TITLE
feat(portal): SPEC-014 v0.2 GitHub auth + terminal-to-browser pairing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        # Pinned to actions/setup-go v6 (4a360112). Re-resolve deliberately
+        # when upgrading instead of trusting the mutable tag in this required
+        # pairing/security gate.
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: test/integration/go.mod
           cache-dependency-path: test/integration/go.sum
@@ -91,6 +94,42 @@ jobs:
         # -race catches data races in the harness goroutines (fake
         # provider + log pumps).
         run: go test -race -count=1 -timeout 5m ./...
+
+  spec-014-v0-2-gate:
+    name: spec-014-v0-2-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # SPEC-014 v0.2 Phase 2E gate: keep the GitHub-auth pairing surface
+    # deployable only when the portal bundle guard and live pairing
+    # integration scenarios both pass. The workflow already runs on every
+    # PR and main push; this job is intentionally present for all runs so
+    # branch protection can require a stable job name.
+    steps:
+      - name: Checkout
+        # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
+        # when upgrading the action rather than trusting a mutable tag.
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        # Pinned to actions/setup-go v6 (4a360112). Re-resolve deliberately
+        # when upgrading instead of trusting the mutable tag in this required
+        # pairing/security gate.
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: test/integration/go.mod
+          cache-dependency-path: test/integration/go.sum
+
+      - name: Verify Node runtime for portal probe
+        run: node --version
+
+      - name: Run provider portal bundle guard
+        run: bash frontdoor/provider-portal/check-bundle.sh
+
+      - name: Run SPEC-014 v0.2 pairing scenarios
+        working-directory: test/integration
+        run: go test -race -count=1 -timeout 5m ./spec_014_v0_2_pairing
 
   dist-tooling:
     name: deploy tooling (check-deploy-config gate)

--- a/docs/operations/spec-014-v0.2-deploy.md
+++ b/docs/operations/spec-014-v0.2-deploy.md
@@ -1,0 +1,245 @@
+# SPEC-014 v0.2 GitHub Auth Deploy Runbook
+
+This runbook is the operator gate for SPEC-014 v0.2 GitHub auth and terminal-to-browser pairing. Keep both flags off until the Phase 2E gate is green:
+
+- Coordinator env flag: `GITHUB_OAUTH_ENABLED=false`
+- Portal config flag: `"github_oauth_enabled": false`
+
+The rollback is a flag flip. The schema additions are forward-compatible and remain unused while the flags are off.
+
+## Pre-deploy Checklist
+
+- Phase 2A coordinator changes are merged on the release branch and their implementation audit has zero critical, high, or medium findings.
+- Phase 2B binary claim handoff changes are merged on the release branch and their implementation audit has zero critical, high, or medium findings.
+- Phase 2C CLI claim/status changes are merged on the release branch and their implementation audit has zero critical, high, or medium findings.
+- Phase 2D provider portal changes are merged on the release branch and their implementation audit has zero critical, high, or medium findings.
+- Phase 2E integration gate is green locally and in CI:
+  - `bash frontdoor/provider-portal/check-bundle.sh`
+  - `make test-integration`
+  - GitHub Actions job `spec-014-v0-2-gate`
+- No deployment enables GitHub OAuth until the coordinator, binary/CLI, and portal bundle are all shipped.
+- Confirm `specs/` has no local diff. SPEC-014 v0.2 is locked.
+
+## Step 1: Deploy Coordinator With Flag Off
+
+Ship the Phase 2A coordinator binary first with GitHub OAuth disabled.
+
+Required coordinator setting:
+
+```bash
+GITHUB_OAUTH_ENABLED=false
+```
+
+Recommended verification:
+
+```bash
+curl -fsS https://<coordinator-host>/healthz
+coordinator-cli list-pair-ot-mints --provider-id=test
+```
+
+Expected result:
+
+- `/healthz` returns healthy.
+- `list-pair-ot-mints --provider-id=test` returns no rows on a fresh deployment.
+- `GET /v1/auth/github/start` is not exposed while the flag is off.
+
+Run all coordinator migrations before moving to the next step. The new tables may exist while the feature is off; that is expected.
+
+## Step 2: Deploy Binary And CLI
+
+Ship the Phase 2B and Phase 2C binary/CLI through the normal release channel:
+
+```bash
+get.streamvc.live/install.sh
+```
+
+Expected behavior with the coordinator flag off:
+
+- Existing installs continue to connect and serve traffic.
+- Tokenless admission remains compatible with the prior deployment state.
+- `claim_url` handling is inert unless the coordinator sends pairing material.
+- `macprovider-cli status` continues to work for existing installs.
+- `macprovider-cli claim --no-browser` can refresh pairing material only when the coordinator exposes the pairing endpoint.
+
+Do not tell users to pair yet. The portal flag is still off.
+
+## Step 3: Deploy Portal Bundle With Flag Off
+
+Ship the Phase 2D provider portal bundle to the portal host, for example:
+
+```json
+{
+  "coordinator_base_url": "https://<coordinator-host>",
+  "releases_repo_owner_name": "Augustas11/macprovider",
+  "require_provider_tokens": true,
+  "github_oauth_enabled": false
+}
+```
+
+Run the bundle guard before deploy:
+
+```bash
+bash frontdoor/provider-portal/check-bundle.sh
+```
+
+Expected behavior:
+
+- The legacy v0.1 portal flow remains available.
+- A cold load does not call `/v1/auth/*`.
+- Any config with a non-boolean `github_oauth_enabled` fails closed.
+- Any config with extra keys fails closed.
+
+## Step 4: Provision GitHub OAuth App
+
+Create the GitHub OAuth app before flipping either flag.
+
+GitHub app settings:
+
+- Homepage URL: `https://<portal-host>`
+- Authorization callback URL: `https://<coordinator-host>/v1/auth/github/callback`
+
+Coordinator settings required when enabling:
+
+```bash
+GITHUB_OAUTH_ENABLED=true
+GITHUB_OAUTH_CLIENT_ID=<github-client-id>
+GITHUB_OAUTH_CLIENT_SECRET=<github-client-secret>
+GITHUB_OAUTH_REDIRECT_URI=https://<coordinator-host>/v1/auth/github/callback
+PORTAL_BASE_URL=https://<portal-host>
+```
+
+Optional cookie scope:
+
+```bash
+MP_SESSION_COOKIE_DOMAIN=<shared-parent-domain>
+```
+
+Only set `MP_SESSION_COOKIE_DOMAIN` when the portal and coordinator hosts are intentionally under that domain. The coordinator validates the value against `PORTAL_BASE_URL` and fails closed on mismatch.
+
+## Step 5: Flip The Flags
+
+Flip the coordinator first:
+
+```bash
+GITHUB_OAUTH_ENABLED=true
+```
+
+Restart the coordinator and verify startup. A missing client ID, client secret, redirect URI, or portal base URL must make the process exit non-zero.
+
+Then flip the portal config:
+
+```json
+"github_oauth_enabled": true
+```
+
+Redeploy the portal bundle. This is a one-line config change after the Phase 2D bundle is already deployed.
+
+Expected behavior after both flags are true:
+
+- `/claim?ot=<pair_ot>` strips the query string immediately to `/claim`.
+- The portal starts GitHub OAuth with `return_to=/claim` and `pair_ot=<pair_ot>`.
+- Cookie-authenticated portal requests use `credentials: include`.
+- Cookie-authenticated portal requests never send an `Authorization` header.
+
+## Step 6: Smoke-Test Pairing
+
+Use a real Mac install for the smoke test.
+
+1. Start a provider that does not already have an owner.
+2. Confirm the binary receives `assigned_provider_token`, `pair_ot`, and `claim_url`.
+3. Confirm `~/.config/macprovider/claim_url` exists with mode `0600`.
+4. Open the claim URL.
+5. Complete GitHub OAuth.
+6. Confirm the browser returns to `/claim`, binds the provider, and redirects to `/`.
+7. Confirm the dashboard shows exactly the claimed provider.
+8. Confirm the binary receives `ownership_event {"event":"bound"}`.
+9. Confirm the binary deletes `claim_url` and writes owner status.
+
+Post-smoke checks:
+
+```bash
+coordinator-cli list-pair-ot-mints --provider-id=<provider-id>
+macprovider-cli status
+```
+
+Expected result:
+
+- Mint log includes the pairing event.
+- CLI status shows the provider as claimed by the GitHub login.
+- Coordinator logs do not contain the raw `pair_ot`.
+- Binary output contains the raw `pair_ot` only inside the user-facing `claim_url`.
+
+## Step 7: Declare Gate Passed
+
+Declare the gate passed only after:
+
+- Local `make test-integration` is green.
+- Local `bash frontdoor/provider-portal/check-bundle.sh` is green.
+- CI job `spec-014-v0-2-gate` is green.
+- Phase 2E implementation audit has zero critical, high, or medium findings.
+- The smoke test in Step 6 passes against a real Mac install.
+
+Append the decision entry to `beta/DECISION_CRITERIA.md` after the gate passes. The entry should reference this runbook and all five phase audit artifacts.
+
+## Rollback Plan
+
+Rollback is flag-first and does not require a schema rollback.
+
+Coordinator rollback:
+
+```bash
+GITHUB_OAUTH_ENABLED=false
+```
+
+Restart the coordinator. Expected result:
+
+- `/v1/auth/github/start` returns 404.
+- `/v1/auth/me/providers` returns 404.
+- `/v1/install/pair/refresh` returns 404.
+- Existing provider traffic continues through the pre-v0.2 path.
+
+Portal rollback:
+
+```json
+"github_oauth_enabled": false
+```
+
+Redeploy the portal config. Expected result:
+
+- A cold portal load makes zero `/v1/auth/*` calls.
+- The legacy v0.1 portal experience is restored.
+
+Data rollback:
+
+- Do not drop the SPEC-014 tables.
+- `github_identities`, `provider_ownership`, `pair_ots`, `mp_sessions`, `oauth_states`, and `pair_ot_mint_log` are forward-compatible while unused.
+- Pairing state naturally expires through the coordinator pruner.
+
+Emergency operator sequence:
+
+1. Flip portal config to false and redeploy.
+2. Flip coordinator env to false and restart.
+3. Verify GitHub routes return 404.
+4. Verify provider traffic and existing dashboards still work.
+5. Capture logs and mint rows for postmortem before retrying.
+
+## Known Limitations
+
+- Sign-out is scoped to the provider portal session and is not a global GitHub sign-out.
+- The coordinator does not revoke GitHub grants; operators revoke the OAuth app grant from GitHub if needed.
+- The `mp_session` cookie is host-only by default unless `MP_SESSION_COOKIE_DOMAIN` is deliberately configured.
+- The portal requires a same-origin proxy for `/v1/auth/*` and `/v1/install/pair/refresh` in GitHub mode.
+- Pairing one-time tokens are short-lived and burned on bind; users should refresh with `macprovider-cli claim` if a token expires.
+
+## Decision Entry Template
+
+Do not commit this template in the Phase 2E branch commit. The operator appends the final numbered entry to `beta/DECISION_CRITERIA.md` after the gate passes.
+
+```markdown
+<next>. SPEC-014 v0.2 GitHub auth and terminal-to-browser pairing gate passed on <date>.
+   - Phases shipped: 2A coordinator GitHub OAuth/pairing store; 2B binary claim handoff; 2C CLI claim/status; 2D provider portal GitHub-cookie mode; 2E integration gate, CI, and runbook.
+   - Audit rounds: 2A=<n>; 2B=<n>; 2C=<n>; 2D=<n>; 2E=<n>. All closed with 0 critical/high/medium findings.
+   - Implementation audit artifacts: <2A artifact>, <2B artifact>, <2C artifact>, <2D artifact>, <2E artifact>.
+   - Spec audit artifacts: specs/SPEC-014-v0.2-audit*.md.
+   - Runbook: docs/operations/spec-014-v0.2-deploy.md.
+```

--- a/frontdoor/provider-portal/README.md
+++ b/frontdoor/provider-portal/README.md
@@ -28,13 +28,20 @@ per [SPEC-014](../../specs/SPEC-014-provider-portal.md).
      `^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`).
    - `require_provider_tokens` — strict boolean `true`. The portal
      refuses to start in any other mode (SPEC-014 §2.4 and §2.3).
+   - `github_oauth_enabled` — strict boolean. Leave `false` for v0.1
+     paste-token behavior; set to `true` AFTER deploying a coordinator
+     with `GITHUB_OAUTH_ENABLED=true` and the v0.2 schema migrations
+     applied. If this is true without coordinator support, the portal
+     fails loud per SPEC-014 v0.2 §10.
    The loader rejects any unknown top-level key.
 2. Host `index.html` alongside an operator-owned reverse proxy on the
    SAME origin that forwards `/v1/pool/check` and
    `/providers/{id}/earnings` to the coordinator (SPEC-014 §3 +
-   Open Q9). If the proxy is missing, the portal renders a loud red
-   banner naming §3 / Open Q9 and refuses to fall back to an absolute
-   coordinator URL.
+   Open Q9). For GitHub auth mode, also forward `/v1/auth/github/*`,
+   `/v1/auth/me/*`, `/v1/auth/logout`, and
+   `/v1/install/pair/refresh`. If the proxy is missing, the portal
+   renders a loud red banner naming §3 / Open Q9 and refuses to fall
+   back to an absolute coordinator URL.
 3. Run `./check-bundle.sh` (locally or in CI) before serving. The
    script exits 0 on a clean bundle.
 
@@ -58,8 +65,10 @@ operator step (see SPEC-014 §10.4 operator runbook).
   SAME session, the sign-in screen adds a stale-config notice.
 - **AUTH-3 (deployment-mode loader):** fail-CLOSED loader for
   `/portal-config.json`. Missing file, non-200, malformed JSON,
-  unknown top-level key, non-`true` `require_provider_tokens` →
-  unavailable page with zero further network calls.
+  unknown top-level key, non-`true` `require_provider_tokens`, or
+  non-boolean `github_oauth_enabled` → unavailable page with zero
+  further network calls. When `github_oauth_enabled` is omitted, it
+  defaults to `false`.
 
 ## Phase status
 

--- a/frontdoor/provider-portal/check-bundle.sh
+++ b/frontdoor/provider-portal/check-bundle.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPEC-014 §8(b) + §8(f) build-time grep guard.
+# SPEC-014 §8(b), §8(f), and v0.2 §14 build-time grep guard.
 #
 # Scans frontdoor/provider-portal/index.html for prohibited strings
 # that would violate the privileged-key isolation invariant (AC 8(b))
@@ -8,7 +8,7 @@
 # Exit codes:
 #   0 — bundle is clean
 #   1 — bundle contains one or more prohibited strings
-#   2 — index.html missing
+#   2 — index.html missing or guard self-test broken
 #
 # Self-protection: every prohibited literal that this script needs to
 # match in the bundle is stored as a CONCATENATED string literal in
@@ -28,6 +28,88 @@ if [[ ! -f "$BUNDLE" ]]; then
 fi
 
 fail=0
+
+storage_patterns=(
+  '\bdocument[[:space:]]*\.[[:space:]]*cookie\b'
+  '\bdocument[[:space:]]*\[[[:space:]]*['"'"'"]cookie['"'"'"][[:space:]]*\]'
+  '\bdocument[[:space:]]*\[[[:space:]]*['"'"'"]\\(x63|u0063)'
+  '\b(localStorage|sessionStorage)\b'
+  '\bwindow[[:space:]]*\[[[:space:]]*['"'"'"](localStorage|sessionStorage)['"'"'"][[:space:]]*\]'
+  '\bindexedDB\b'
+  '\bopenDatabase\b'
+  '\bnavigator[[:space:]]*\.[[:space:]]*storage\b'
+)
+
+guard_broken() {
+  echo "check-bundle: guard broken: $*" >&2
+  exit 2
+}
+
+grep_matches() {
+  local pattern="$1"
+  local source="$2"
+  printf '%s\n' "$source" | grep -Eq "$pattern"
+}
+
+rg_matches() {
+  local pattern="$1"
+  local source="$2"
+  if ! command -v rg >/dev/null 2>&1; then
+    return 0
+  fi
+  printf '%s\n' "$source" | rg --pcre2 -q "$pattern"
+}
+
+assert_match() {
+  local n="$1"
+  local sample="$2"
+  local pattern="${storage_patterns[$((n - 1))]}"
+  grep_matches "$pattern" "$sample" || guard_broken "regex $n positive did not match under grep"
+  rg_matches "$pattern" "$sample" || guard_broken "regex $n positive did not match under rg --pcre2"
+}
+
+assert_no_match() {
+  local n="$1"
+  local sample="$2"
+  local pattern="${storage_patterns[$((n - 1))]}"
+  if grep_matches "$pattern" "$sample"; then
+    guard_broken "regex $n negative matched under grep"
+  fi
+  if command -v rg >/dev/null 2>&1 && printf '%s\n' "$sample" | rg --pcre2 -q "$pattern"; then
+    guard_broken "regex $n negative matched under rg --pcre2"
+  fi
+}
+
+run_storage_guard_self_test() {
+  assert_match 1 'document.cookie = "x=y"'
+  assert_no_match 1 "const cookieless_login_message = 'foo'"
+
+  assert_match 2 'document["cookie"] = "x=y"'
+  assert_no_match 2 'document["cookieless"] = "x"'
+
+  assert_match 3 'document["\x63ookie"] = "x=y"'
+  assert_match 3 'document["\u0063ookie"] = "x=y"'
+  assert_no_match 3 'document["cookieless"] = "x"'
+
+  assert_match 4 "localStorage.setItem('x','y')"
+  assert_match 4 "sessionStorage.setItem('x','y')"
+  assert_no_match 4 'const localStorageDocs = "..."'
+
+  assert_match 5 'window["localStorage"].setItem("x","y")'
+  assert_match 5 'window["sessionStorage"].setItem("x","y")'
+  assert_no_match 5 'window["localStorageDocs"] = "..."'
+
+  assert_match 6 "indexedDB.open('x')"
+  assert_no_match 6 'const indexedDBDocs = "..."'
+
+  assert_match 7 "openDatabase('x', '1', 'x', 1024)"
+  assert_no_match 7 'const openDatabaseDocs = "..."'
+
+  assert_match 8 'navigator.storage.estimate()'
+  assert_no_match 8 'navigatorStorage.estimate()'
+}
+
+run_storage_guard_self_test
 
 # AC 8(b) — privileged-routes literal list. The bundle must never
 # reference any privileged-key coordinator endpoint, even in
@@ -76,6 +158,16 @@ for p in "${multi_machine[@]}"; do
     echo "FAIL [8(f)]: bundle contains prohibited multi-machine string: $p" >&2
     fail=1
   fi
+done
+
+for idx in "${!storage_patterns[@]}"; do
+  n=$((idx + 1))
+  pattern="${storage_patterns[$idx]}"
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    echo "$line: matched regex $n ($pattern)" >&2
+    fail=1
+  done < <(grep -En "$pattern" "$BUNDLE" || true)
 done
 
 if [[ $fail -eq 0 ]]; then

--- a/frontdoor/provider-portal/index.html
+++ b/frontdoor/provider-portal/index.html
@@ -4,6 +4,15 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>MacProvider — Provider Portal</title>
+  <script>
+    const PAIR_OT_CAPTURED = (function() {
+      if (location.pathname !== "/claim") return null;
+      const u = new URL(location.href);
+      const ot = u.searchParams.get("ot");
+      history.replaceState({}, "", "/claim");
+      return ot;
+    })();
+  </script>
   <style>
     :root {
       --bg:#0c0d10;
@@ -234,6 +243,24 @@
       color:#fde68a;
       border-radius:8px; font-size:12px; line-height:1.5;
     }
+    .signin-guide { margin-top:14px; color:var(--muted); font-size:13px; text-align:center; }
+    .github-btn {
+      display:block; width:100%;
+      background:var(--accent); border:0; color:#fff;
+      padding:10px; border-radius:8px; font-weight:600;
+      text-align:center;
+    }
+    .github-btn:hover { filter:brightness(1.08); text-decoration:none; }
+    .claim-card h1 { color:var(--text); }
+    .claim-card .claim-ok { color:var(--ok); font-size:13px; margin-top:10px; }
+    .provider-list { display:flex; flex-direction:column; gap:10px; }
+    .provider-row {
+      display:flex; justify-content:space-between; align-items:center; gap:12px;
+      background:var(--surface); border:1px solid var(--border);
+      border-radius:8px; padding:12px 14px; width:100%; text-align:left;
+    }
+    .provider-row:hover { background:var(--accent-dim); }
+    .provider-row .sub { color:var(--muted); font-size:12px; }
 
     /* Unavailable mode */
     .unavail-wrap {
@@ -334,7 +361,8 @@
     var ALLOWED_CONFIG_KEYS = [
       "coordinator_base_url",
       "releases_repo_owner_name",
-      "require_provider_tokens"
+      "require_provider_tokens",
+      "github_oauth_enabled"
     ];
     var REPO_OWNER_NAME_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 
@@ -365,6 +393,10 @@
       configError: null,
       flagFalse: false,
       releases: { list: null, ts: 0, err: null, inflight: false, rateLimited: false },
+      githubAuthState: "idle",
+      githubProviders: [],
+      cookieFetch: null,
+      claim: { phase: "idle", error: null, result: null },
     };
 
     var timers = {
@@ -465,10 +497,14 @@
         state.flagFalse = true;
         throw new Error("flag-false");
       }
+      if (Object.prototype.hasOwnProperty.call(raw, "github_oauth_enabled") && typeof raw.github_oauth_enabled !== "boolean") {
+        throw new Error("invalid-github_oauth_enabled");
+      }
       return {
         coordinator_base_url: cbu,
         releases_repo_owner_name: rro,
         require_provider_tokens: true,
+        github_oauth_enabled: raw.github_oauth_enabled === true,
       };
     }
 
@@ -520,6 +556,57 @@
         });
     }
 
+    function makeCookieFetch() {
+      return function cookieFetch(pathAndQuery, opts) {
+        opts = opts || {};
+        var supplied = opts.headers || {};
+        var headers = { "Accept": "application/json", "Content-Type": "application/json" };
+        for (var k in supplied) {
+          if (!Object.prototype.hasOwnProperty.call(supplied, k)) continue;
+          if (String(k).toLowerCase() === "authorization") continue;
+          headers[k] = supplied[k];
+        }
+        return fetch(pathAndQuery, {
+          method: opts.method || "GET",
+          headers: headers,
+          body: opts.body,
+          cache: "no-store",
+          credentials: "include",
+        }).catch(function (e) {
+          if (!state.proxyMissing) {
+            state.proxyMissing = true;
+            render();
+          }
+          throw e;
+        });
+      };
+    }
+
+    function cookieJSON(pathAndQuery, opts) {
+      if (!state.cookieFetch) state.cookieFetch = makeCookieFetch();
+      return state.cookieFetch(pathAndQuery, opts).then(function (resp) {
+        return readJSONResponse(resp);
+      });
+    }
+
+    function readJSONResponse(resp) {
+      return resp.text().then(function (txt) {
+        var body = null;
+        if (txt) {
+          try { body = JSON.parse(txt); } catch (_) { body = null; }
+        }
+        return { ok: resp.ok, status: resp.status, body: body };
+      });
+    }
+
+    window.__macproviderPortalAuthProbe = function () {
+      return {
+        mode: state.cfg && state.cfg.github_oauth_enabled ? "cookie" : "paste",
+        pasteAuth: coordFetch,
+        cookieAuth: state.cookieFetch || undefined,
+      };
+    };
+
     /* =====================================================================
      * Pool poll (§5.4: 30 s + manual refresh)
      * ===================================================================== */
@@ -530,7 +617,10 @@
       render();
       var pid = state.session.provider_id;
       var url = POOL_PATH + "?provider_id=" + encodeURIComponent(pid);
-      return coordFetch(url, { auth: false })
+      var fetchResult = state.cfg && state.cfg.github_oauth_enabled
+        ? cookieJSON(url, { method: "GET" })
+        : coordFetch(url, { auth: false });
+      return fetchResult
         .then(function (r) {
           state.pool.inflight = false;
           if (r.ok) {
@@ -562,7 +652,10 @@
       state.earn.inflight = true;
       render();
       var pid = state.session.provider_id;
-      return coordFetch(earningsPath(pid), { auth: true, surface: surface || "machine" })
+      var fetchResult = state.cfg && state.cfg.github_oauth_enabled
+        ? cookieJSON(earningsPath(pid), { method: "GET" })
+        : coordFetch(earningsPath(pid), { auth: true, surface: surface || "machine" });
+      return fetchResult
         .then(function (r) {
           state.earn.inflight = false;
           if (r.ok) {
@@ -573,7 +666,11 @@
             return;
           }
           if (r.status === 401 || r.status === 403 || r.status === 404) {
-            handleAuthRejection(r.status, surface || "machine");
+            if (state.cfg && state.cfg.github_oauth_enabled && r.status === 401) {
+              githubSessionExpired("/" + "?p=" + encodeURIComponent(pid));
+            } else {
+              handleAuthRejection(r.status, surface || "machine");
+            }
             return;
           }
           state.earn.err = { status: r.status };
@@ -684,6 +781,13 @@
      * Sign-out
      * ===================================================================== */
     function signOut() {
+      if (state.cfg && state.cfg.github_oauth_enabled) {
+        stopPollers();
+        cookieJSON("/v1/auth/logout", { method: "POST", body: "{}" })
+          .catch(function () { return null; })
+          .then(function () { location.reload(); });
+        return;
+      }
       stopPollers();
       state.session = null;
       state.pool = { data: null, ts: 0, err: null, inflight: false };
@@ -715,6 +819,162 @@
       state.route = "machine";
       render();
       startPollers();
+    }
+
+    /* =====================================================================
+     * GitHub auth mode
+     * ===================================================================== */
+    function githubStartURL(returnTo, pairOT) {
+      var url = "/v1/auth/github/start?return_to=" + encodeURIComponent(returnTo);
+      if (pairOT) url += "&pair_ot=" + encodeURIComponent(pairOT);
+      return url;
+    }
+
+    function startGitHubOAuth(returnTo, pairOT) {
+      location.assign(githubStartURL(returnTo, pairOT));
+    }
+
+    function initializeGitHubMode() {
+      state.cookieFetch = makeCookieFetch();
+      state.githubAuthState = "loading";
+      render();
+      if (location.pathname === "/claim") {
+        return handleClaimRoute();
+      }
+      return loadGitHubHome();
+    }
+
+    function loadGitHubHome() {
+      state.githubAuthState = "loading";
+      state.claim = { phase: "idle", error: null, result: null };
+      stopPollers();
+      state.session = null;
+      render();
+      return cookieJSON("/v1/auth/me/providers", { method: "GET" })
+        .then(function (r) {
+          if (r.status === 401) {
+            state.githubAuthState = "signin";
+            render();
+            return;
+          }
+          if (!r.ok) {
+            state.githubAuthState = "signin";
+            if (r.status === 404 || r.status >= 500) state.proxyMissing = true;
+            render();
+            return;
+          }
+          var providers = r.body && Array.isArray(r.body.providers) ? r.body.providers : [];
+          state.githubProviders = providers;
+          if (providers.length === 0) {
+            state.githubAuthState = "waiting";
+            state.route = "machine";
+            render();
+            return;
+          }
+          var wanted = new URL(location.href).searchParams.get("p");
+          var selected = null;
+          for (var i = 0; i < providers.length; i++) {
+            if (providers[i] && providers[i].provider_id === wanted) selected = providers[i];
+          }
+          if (!selected && providers.length === 1) selected = providers[0];
+          if (!selected) {
+            state.githubAuthState = "providers";
+            state.route = "machine";
+            render();
+            return;
+          }
+          selectGitHubProvider(selected.provider_id, false);
+        })
+        .catch(function () {
+          state.githubAuthState = "signin";
+          render();
+        });
+    }
+
+    function selectGitHubProvider(providerId, pushRoute) {
+      state.session = { provider_id: providerId, provider_token: null };
+      state.githubAuthState = "dashboard";
+      state.route = "machine";
+      state.pool = { data: null, ts: 0, err: null, inflight: false };
+      state.earn = { data: null, ts: 0, err: null, inflight: false };
+      if (pushRoute) {
+        history.pushState({}, "", "/?p=" + encodeURIComponent(providerId));
+      }
+      render();
+      startPollers();
+    }
+
+    function githubSessionExpired(returnTo) {
+      stopPollers();
+      state.session = null;
+      state.githubAuthState = "signin";
+      render();
+      startGitHubOAuth(returnTo || "/", null);
+    }
+
+    function handleClaimRoute() {
+      state.githubAuthState = "claim";
+      state.claim = { phase: "checking", error: null, result: null };
+      render();
+      return cookieJSON("/v1/auth/me/providers", { method: "GET" })
+        .then(function (r) {
+          if (r.status === 401) {
+            startGitHubOAuth("/claim", PAIR_OT_CAPTURED);
+            return;
+          }
+          if (!r.ok) {
+            if (isProxyMisconfigurationStatus(r.status)) {
+              state.proxyMissing = true;
+              state.claim = { phase: "error", error: "proxy_missing", result: null };
+            } else {
+              state.claim = { phase: "error", error: "bad_request", result: null };
+            }
+            render();
+            return;
+          }
+          return bindClaim();
+        })
+        .catch(function () {
+          state.claim = { phase: "error", error: "network", result: null };
+          render();
+        });
+    }
+
+    function bindClaim() {
+      state.claim = { phase: "binding", error: null, result: null };
+      render();
+      var body = PAIR_OT_CAPTURED ? { pair_ot: PAIR_OT_CAPTURED } : {};
+      return cookieJSON("/v1/auth/me/providers/bind", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }).then(function (r) {
+        if (r.ok) {
+          state.claim = { phase: "success", error: null, result: r.body || {} };
+          render();
+          setTimeout(function () { location.assign("/"); }, 2000);
+          return;
+        }
+        if (r.status === 401) {
+          startGitHubOAuth("/claim", PAIR_OT_CAPTURED);
+          return;
+        }
+        if (isProxyMisconfigurationStatus(r.status)) {
+          state.proxyMissing = true;
+          state.claim = { phase: "error", error: "proxy_missing", result: null };
+          render();
+          return;
+        }
+        var code = r.body && r.body.error ? r.body.error : "bad_request";
+        state.claim = { phase: "error", error: code, result: null };
+        render();
+      }).catch(function () {
+        state.claim = { phase: "error", error: "network", result: null };
+        render();
+      });
+    }
+
+    function isProxyMisconfigurationStatus(status) {
+      return status === 404 || status >= 500;
     }
 
     /* =====================================================================
@@ -769,6 +1029,22 @@
         root.appendChild(renderLoading());
         return;
       }
+      if (state.cfg.github_oauth_enabled) {
+        if (state.githubAuthState === "signin") {
+          root.appendChild(renderGitHubSignIn());
+          return;
+        }
+        if (state.githubAuthState === "claim") {
+          root.appendChild(renderClaim());
+          return;
+        }
+        if (state.githubAuthState === "waiting" || state.githubAuthState === "providers" || state.githubAuthState === "dashboard") {
+          root.appendChild(renderShell());
+          return;
+        }
+        root.appendChild(renderLoading());
+        return;
+      }
       if (!state.session) {
         root.appendChild(renderSignIn());
         return;
@@ -814,6 +1090,8 @@
             el("code", null, "releases_repo_owner_name"),
             ", and ",
             el("code", null, "require_provider_tokens"),
+            ", and optionally ",
+            el("code", null, "github_oauth_enabled"),
             ".");
           break;
         case "unknown-key":
@@ -827,6 +1105,8 @@
             el("code", null, "releases_repo_owner_name"),
             ", and ",
             el("code", null, "require_provider_tokens"),
+            ", plus optional ",
+            el("code", null, "github_oauth_enabled"),
             " are permitted.");
           break;
         case "invalid-field":
@@ -894,6 +1174,85 @@
       return el("div", { class: "signin-wrap" }, card);
     }
 
+    function renderGitHubSignIn() {
+      var button = el("button", {
+        class: "github-btn",
+        onclick: function () { startGitHubOAuth("/", null); },
+      }, "Continue with GitHub");
+      var card = el("div", { class: "signin-card" },
+        el("h1", null, "MacProvider — Provider Portal"),
+        el("p", { class: "h-sub" }, "Sign in to view Macs linked to your GitHub account."),
+        button,
+        state.proxyMissing
+          ? el("div", { class: "signin-misconfig" }, "github_oauth_enabled is true but the coordinator has no GitHub OAuth endpoints. Set the flag to false or deploy the v0.2 coordinator.")
+          : null,
+        el("div", { class: "signin-guide" },
+          "New here? ",
+          el("a", { href: "#install-guide" }, "See the install guide")));
+      return el("div", { class: "signin-wrap" }, card);
+    }
+
+    function renderClaim() {
+      var phase = state.claim.phase;
+      var cardKids = [el("h1", null, "Link this Mac")];
+      if (state.proxyMissing) {
+        cardKids.push(renderProxyMissingBanner());
+      }
+      if (phase === "checking" || phase === "binding") {
+        cardKids.push(el("p", { class: "h-sub" }, phase === "checking" ? "Checking your GitHub session…" : "Linking this Mac to your account…"));
+      } else if (phase === "success") {
+        var result = state.claim.result || {};
+        cardKids.push(
+          el("p", { class: "h-sub" }, "This Mac is linked."),
+          el("div", { class: "claim-ok" }, "GitHub: ", result.github_login || "linked"),
+          el("div", { class: "claim-ok mono" }, "Provider: ", result.provider_id || "unknown"),
+          el("p", { class: "h-sub" }, "Redirecting to your dashboard…"));
+      } else {
+        var msg = "Something went wrong. Try running macprovider-cli claim again.";
+        var withCopy = false;
+        if (state.claim.error === "pair_ot_invalid") {
+          msg = "This link expired. Run `macprovider-cli claim` on your Mac for a fresh link.";
+          withCopy = true;
+        } else if (state.claim.error === "already_owned") {
+          msg = "This Mac is already linked to a different account. Contact the operator to unlink.";
+        } else if (state.claim.error === "proxy_missing") {
+          msg = "github_oauth_enabled is true but the coordinator has no GitHub OAuth endpoints. Set the flag to false or deploy the v0.2 coordinator.";
+        }
+        cardKids.push(el("p", { class: "h-sub" }, msg));
+        if (withCopy) {
+          cardKids.push(snippetNode("macprovider-cli claim", "claim-refresh"));
+        }
+      }
+      return el("div", { class: "signin-wrap" },
+        el("div", { class: "signin-card claim-card" }, cardKids));
+    }
+
+    function renderWaitingForMac() {
+      return el("div", null,
+        el("h1", { class: "surface-title" }, "Machine"),
+        el("div", { class: "panel" },
+          el("h2", null, "Waiting for a Mac to come online"),
+          el("p", null, "Install MacProvider on a Mac. After install, your Mac will auto-open a browser to link itself."),
+          snippetNode("curl -fsSL https://get.streamvc.live/install.sh | bash", "waiting-install")));
+    }
+
+    function renderProviderChooser() {
+      var rows = state.githubProviders.map(function (p) {
+        var pid = p && p.provider_id ? p.provider_id : "";
+        return el("button", {
+          class: "provider-row",
+          onclick: function () { selectGitHubProvider(pid, true); },
+        },
+          el("span", { class: "mono" }, pid),
+          el("span", { class: "sub" }, p && p.last_seen_at ? ("last seen " + p.last_seen_at) : "select"));
+      });
+      return el("div", null,
+        el("h1", { class: "surface-title" }, "Machine"),
+        el("div", { class: "panel" },
+          el("h2", null, "Choose a Mac"),
+          el("div", { class: "provider-list" }, rows)));
+    }
+
     function renderShell() {
       var sidebar = renderSidebar();
       var topbar = el("div", { class: "topbar" },
@@ -904,7 +1263,13 @@
         pane.appendChild(renderProxyMissingBanner());
       }
       if (state.route === "machine") {
-        pane.appendChild(renderMachine());
+        if (state.cfg && state.cfg.github_oauth_enabled && state.githubAuthState === "waiting") {
+          pane.appendChild(renderWaitingForMac());
+        } else if (state.cfg && state.cfg.github_oauth_enabled && state.githubAuthState === "providers" && !state.session) {
+          pane.appendChild(renderProviderChooser());
+        } else {
+          pane.appendChild(renderMachine());
+        }
       } else if (state.route === "setup") {
         pane.appendChild(renderSetup());
       } else if (state.route === "earn") {
@@ -927,11 +1292,15 @@
     function renderSidebar() {
       var items = [
         { id: "machine",    label: "Machine" },
-        { id: "setup",      label: "Setup & Updates" },
-        { id: "earn",       label: "Earn" },
-        { id: "monitoring", label: "Monitoring" },
-        { id: "identity",   label: "Identity" },
       ];
+      if (!(state.cfg && state.cfg.github_oauth_enabled && !state.session)) {
+        items.push(
+          { id: "setup",      label: "Setup & Updates" },
+          { id: "earn",       label: "Earn" },
+          { id: "monitoring", label: "Monitoring" },
+          { id: "identity",   label: "Identity" }
+        );
+      }
       var navNodes = items.map(function (it) {
         return el("button", {
           class: "nav-item" + (state.route === it.id ? " active" : ""),
@@ -967,6 +1336,14 @@
         el("code", null, "/v1/pool/check"),
         " and ",
         el("code", null, "/providers/{id}/earnings"),
+        ", plus ",
+        el("code", null, "/v1/auth/github/*"),
+        ", ",
+        el("code", null, "/v1/auth/me/*"),
+        ", ",
+        el("code", null, "/v1/auth/logout"),
+        ", and ",
+        el("code", null, "/v1/install/pair/refresh"),
         " to the coordinator. See SPEC-014 §3 and Open Q9.");
     }
 
@@ -1362,11 +1739,21 @@
     function bootstrap() {
       render();
       loadConfig().then(function () {
+        if (state.cfg && state.cfg.github_oauth_enabled) {
+          initializeGitHubMode();
+          return;
+        }
         render();
       }, function () {
         render();
       });
     }
+
+    window.addEventListener("popstate", function () {
+      if (state.cfg && state.cfg.github_oauth_enabled) {
+        loadGitHubHome();
+      }
+    });
 
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", bootstrap);

--- a/frontdoor/provider-portal/portal-config.json.example
+++ b/frontdoor/provider-portal/portal-config.json.example
@@ -1,5 +1,6 @@
 {
   "coordinator_base_url": "https://coordinator.streamvc.live",
   "releases_repo_owner_name": "Augustas11/macprovider",
-  "require_provider_tokens": true
+  "require_provider_tokens": true,
+  "github_oauth_enabled": false
 }

--- a/phase3-binary/Sources/MacProviderCore/BrowserOpener.swift
+++ b/phase3-binary/Sources/MacProviderCore/BrowserOpener.swift
@@ -1,0 +1,128 @@
+import Darwin
+import Foundation
+
+public enum BrowserOpenDecision: Equatable, Sendable {
+    case opened
+    case skippedNoTTY
+    case skippedSSH
+    case skippedDisabled
+    case rejectedInvalidURL
+}
+
+public enum BrowserOpenError: Error, CustomStringConvertible {
+    case spawnFailed(errno: Int32)
+
+    public var description: String {
+        switch self {
+        case let .spawnFailed(errno):
+            return "open spawn failed: errno \(errno)"
+        }
+    }
+}
+
+public final class BrowserOpener: @unchecked Sendable {
+    public typealias EnvironmentLookup = @Sendable (String) -> String?
+    public typealias TTYCheck = @Sendable () -> Bool
+    public typealias Spawn = @Sendable (String) throws -> Void
+
+    private let hasControllingTTY: TTYCheck
+    private let environment: EnvironmentLookup
+    private let spawn: Spawn
+
+    public init(
+        hasControllingTTY: @escaping TTYCheck = { isatty(STDOUT_FILENO) == 1 },
+        environment: @escaping EnvironmentLookup = { ProcessInfo.processInfo.environment[$0] },
+        spawn: @escaping Spawn = { try BrowserOpener.posixSpawnOpen($0) }
+    ) {
+        self.hasControllingTTY = hasControllingTTY
+        self.environment = environment
+        self.spawn = spawn
+    }
+
+    @discardableResult
+    public func openIfAllowed(_ claimURL: String, expectedPortalHost: String? = nil) throws -> BrowserOpenDecision {
+        guard Self.isValidClaimURL(claimURL, expectedPortalHost: expectedPortalHost) else {
+            return .rejectedInvalidURL
+        }
+        guard hasControllingTTY() else {
+            return .skippedNoTTY
+        }
+        if let sshTTY = environment("SSH_TTY"), !sshTTY.isEmpty {
+            return .skippedSSH
+        }
+        if environment("MACPROVIDER_NO_BROWSER") == "1" {
+            return .skippedDisabled
+        }
+        try spawn(claimURL)
+        return .opened
+    }
+
+    public static func isValidClaimURL(_ claimURL: String, expectedPortalHost: String? = nil, expectedPairOT: String? = nil) -> Bool {
+        guard !claimURL.isEmpty, claimURL.utf8.count <= 4096 else {
+            return false
+        }
+        if claimURL.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7f }) {
+            return false
+        }
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789?=&%_-./:")
+        guard claimURL.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+            return false
+        }
+        guard let components = URLComponents(string: claimURL),
+              components.scheme == "https",
+              let host = components.host,
+              !host.isEmpty
+        else {
+            return false
+        }
+        if let expectedPortalHost, host != expectedPortalHost {
+            return false
+        }
+        guard components.path == "/claim",
+              let ot = components.queryItems?.first(where: { $0.name == "ot" })?.value,
+              !ot.isEmpty
+        else {
+            return false
+        }
+        if let expectedPairOT, ot != expectedPairOT {
+            return false
+        }
+        return true
+    }
+
+    public static func portalHost(from claimURL: String) -> String? {
+        URLComponents(string: claimURL)?.host
+    }
+
+    public static func portalHost(fromPortalBaseURL portalBaseURL: String?) -> String? {
+        guard let portalBaseURL, !portalBaseURL.isEmpty else {
+            return nil
+        }
+        return URLComponents(string: portalBaseURL)?.host
+    }
+
+    public static func posixSpawnOpen(_ claimURL: String) throws {
+        var pid = pid_t()
+        let executable = strdup("/usr/bin/open")
+        let arg0 = strdup("open")
+        let arg1 = strdup(claimURL)
+        let environment = ProcessInfo.processInfo.environment.map { key, value in
+            strdup("\(key)=\(value)")
+        }
+        defer {
+            free(executable)
+            free(arg0)
+            free(arg1)
+            for entry in environment {
+                free(entry)
+            }
+        }
+        var argv: [UnsafeMutablePointer<CChar>?] = [arg0, arg1, nil]
+        var envp = environment
+        envp.append(nil)
+        let result = posix_spawn(&pid, executable, nil, nil, &argv, envp)
+        if result != 0 {
+            throw BrowserOpenError.spawnFailed(errno: result)
+        }
+    }
+}

--- a/phase3-binary/Sources/MacProviderCore/ClaimURLFile.swift
+++ b/phase3-binary/Sources/MacProviderCore/ClaimURLFile.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+public struct ClaimURLRecord: Equatable, Sendable {
+    public let pairOT: String
+    public let claimURL: String
+    public let expiresAt: Date
+}
+
+public enum ClaimURLFileError: Error, CustomStringConvertible {
+    case parentDirectoryMissing(path: String)
+    case writeFailed(path: String, underlying: String)
+    case chmodFailed(path: String, underlying: String)
+    case renameFailed(path: String, underlying: String)
+    case invalidBody
+
+    public var description: String {
+        switch self {
+        case let .parentDirectoryMissing(path):
+            return "claim_url: parent directory missing at \(path)"
+        case let .writeFailed(path, underlying):
+            return "claim_url: failed to write \(path): \(underlying)"
+        case let .chmodFailed(path, underlying):
+            return "claim_url: chmod 0600 failed at \(path): \(underlying)"
+        case let .renameFailed(path, underlying):
+            return "claim_url: atomic rename failed at \(path): \(underlying)"
+        case .invalidBody:
+            return "claim_url: invalid body"
+        }
+    }
+}
+
+public final class ClaimURLFile: @unchecked Sendable {
+    public let fileURL: URL
+    public let ownerURL: URL
+
+    public init(configPath: String) {
+        let resolved = ConfigLoader.expandTilde(configPath)
+        let directory = URL(fileURLWithPath: (resolved as NSString).deletingLastPathComponent, isDirectory: true)
+        self.fileURL = directory.appendingPathComponent("claim_url")
+        self.ownerURL = directory.appendingPathComponent("owner.txt")
+    }
+
+    public init(directory: URL) {
+        self.fileURL = directory.appendingPathComponent("claim_url")
+        self.ownerURL = directory.appendingPathComponent("owner.txt")
+    }
+
+    public func write(pairOT: String, claimURL: String, expiresAt: Date) throws {
+        let body = """
+        pair_ot=\(pairOT)
+        claim_url=\(claimURL)
+        expires_at=\(Self.formatDate(expiresAt))
+
+        """
+        try Self.atomicWrite0600(body, to: fileURL)
+    }
+
+    public func writeMigrationStub() throws {
+        try Self.atomicWrite0600("needs_refresh=true\n", to: fileURL)
+    }
+
+    public func delete() throws {
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try FileManager.default.removeItem(at: fileURL)
+        }
+    }
+
+    public func writeOwner(githubLogin: String) throws {
+        try Self.atomicWrite0600("github_login=\(githubLogin)\n", to: ownerURL)
+    }
+
+    public func read() throws -> ClaimURLRecord? {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+        let body = try String(contentsOf: fileURL, encoding: .utf8)
+        if body.trimmingCharacters(in: .whitespacesAndNewlines) == "needs_refresh=true" {
+            return nil
+        }
+        var values: [String: String] = [:]
+        for line in body.split(separator: "\n", omittingEmptySubsequences: true) {
+            let parts = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { continue }
+            values[String(parts[0])] = String(parts[1])
+        }
+        guard let pairOT = values["pair_ot"],
+              let claimURL = values["claim_url"],
+              let expiresText = values["expires_at"],
+              let expiresAt = Self.parseDate(expiresText)
+        else {
+            throw ClaimURLFileError.invalidBody
+        }
+        return ClaimURLRecord(pairOT: pairOT, claimURL: claimURL, expiresAt: expiresAt)
+    }
+
+    public static func atomicWrite0600(_ text: String, to destination: URL) throws {
+        let parent = destination.deletingLastPathComponent()
+        guard FileManager.default.fileExists(atPath: parent.path) else {
+            throw ClaimURLFileError.parentDirectoryMissing(path: parent.path)
+        }
+        let tempURL = parent.appendingPathComponent(".\(destination.lastPathComponent).\(UUID().uuidString).tmp")
+        FileManager.default.createFile(atPath: tempURL.path, contents: Data())
+        do {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: 0o600)],
+                ofItemAtPath: tempURL.path
+            )
+        } catch {
+            try? FileManager.default.removeItem(at: tempURL)
+            throw ClaimURLFileError.chmodFailed(path: tempURL.path, underlying: String(describing: error))
+        }
+        do {
+            try text.write(to: tempURL, atomically: false, encoding: .utf8)
+        } catch {
+            try? FileManager.default.removeItem(at: tempURL)
+            throw ClaimURLFileError.writeFailed(path: tempURL.path, underlying: String(describing: error))
+        }
+        if rename(tempURL.path, destination.path) != 0 {
+            let err = String(cString: strerror(errno))
+            try? FileManager.default.removeItem(at: tempURL)
+            throw ClaimURLFileError.renameFailed(path: destination.path, underlying: err)
+        }
+    }
+
+    private static func formatDate(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+
+    private static func parseDate(_ text: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: text)
+    }
+}

--- a/phase3-binary/Sources/MacProviderCore/PairingController.swift
+++ b/phase3-binary/Sources/MacProviderCore/PairingController.swift
@@ -1,0 +1,146 @@
+import Foundation
+import os
+
+public enum OwnershipEventKind: String, Sendable {
+    case bound
+    case unbound
+}
+
+public enum PairingControllerError: Error, CustomStringConvertible {
+    case invalidPairOT
+    case invalidClaimURL
+    case invalidGitHubLogin
+
+    public var description: String {
+        switch self {
+        case .invalidPairOT:
+            return "invalid pair_ot"
+        case .invalidClaimURL:
+            return "invalid claim_url"
+        case .invalidGitHubLogin:
+            return "invalid github_login"
+        }
+    }
+}
+
+public struct OwnershipEventFrame: Equatable, Sendable {
+    public let providerID: String
+    public let githubLogin: String
+    public let event: OwnershipEventKind
+
+    public init(providerID: String, githubLogin: String, event: OwnershipEventKind) {
+        self.providerID = providerID
+        self.githubLogin = githubLogin
+        self.event = event
+    }
+}
+
+public final class PairingController: @unchecked Sendable {
+    public typealias Output = @Sendable (String) -> Void
+
+    private static let logger = Logger(subsystem: "macprovider", category: "pairing")
+    private let claimURLFile: ClaimURLFile
+    private let browserOpener: BrowserOpener
+    private let now: @Sendable () -> Date
+    private let output: Output
+    private let logOutput: Output
+
+    public init(
+        claimURLFile: ClaimURLFile,
+        browserOpener: BrowserOpener = BrowserOpener(),
+        now: @escaping @Sendable () -> Date = { Date() },
+        output: @escaping Output = { print($0) },
+        logOutput: Output? = nil
+    ) {
+        self.claimURLFile = claimURLFile
+        self.browserOpener = browserOpener
+        self.now = now
+        self.output = output
+        self.logOutput = logOutput ?? { message in
+            PairingController.logger.info("\(message, privacy: .public)")
+        }
+    }
+
+    public convenience init(configPath: String) {
+        self.init(claimURLFile: ClaimURLFile(configPath: configPath))
+    }
+
+    public func handlePairingMaterial(pairOT: String?, claimURL: String?, portalBaseURL: String? = nil) throws {
+        guard let pairOT, let claimURL, !pairOT.isEmpty, !claimURL.isEmpty else {
+            return
+        }
+        guard Self.isValidPairOT(pairOT) else {
+            throw PairingControllerError.invalidPairOT
+        }
+        let expectedHost = BrowserOpener.portalHost(fromPortalBaseURL: portalBaseURL)
+        guard BrowserOpener.isValidClaimURL(claimURL, expectedPortalHost: expectedHost, expectedPairOT: pairOT) else {
+            throw PairingControllerError.invalidClaimURL
+        }
+        try claimURLFile.write(pairOT: pairOT, claimURL: claimURL, expiresAt: now().addingTimeInterval(600))
+        emitUserFacingClaimLine(claimURL: claimURL)
+        let decision = try browserOpener.openIfAllowed(claimURL, expectedPortalHost: expectedHost)
+        Self.logger.info("claim_url handoff completed decision=\(String(describing: decision), privacy: .public)")
+    }
+
+    public func handleOwnershipEvent(_ event: OwnershipEventFrame) throws {
+        switch event.event {
+        case .bound:
+            guard Self.isValidGitHubLogin(event.githubLogin) else {
+                throw PairingControllerError.invalidGitHubLogin
+            }
+            try claimURLFile.delete()
+            try claimURLFile.writeOwner(githubLogin: event.githubLogin)
+        case .unbound:
+            Self.logger.info("ownership unbound event ignored in v0.2 provider_id=\(event.providerID, privacy: .public)")
+        }
+    }
+
+    public func handleNeedsClaim() throws {
+        try claimURLFile.writeMigrationStub()
+        Self.logger.info("ownership status needs_claim; run macprovider-cli claim")
+    }
+
+    private func emitUserFacingClaimLine(claimURL: String) {
+        let line = """
+        ✓ Provider registered. To link this Mac to your account:
+            macprovider-cli claim
+          (or open: \(claimURL))
+        """
+        output(line)
+        logOutput(Self.redactedClaimLine(line))
+    }
+
+    private static func redactedClaimLine(_ line: String) -> String {
+        guard let originalURL = line.components(separatedBy: "(or open: ").last?.dropLast().description,
+              var components = URLComponents(string: originalURL)
+        else {
+            return line
+        }
+        components.queryItems = components.queryItems?.map { item in
+            item.name == "ot" ? URLQueryItem(name: item.name, value: "REDACTED") : item
+        }
+        guard let redactedURL = components.string else {
+            return line
+        }
+        return line.replacingOccurrences(of: originalURL, with: redactedURL)
+    }
+
+    private static func isValidPairOT(_ pairOT: String) -> Bool {
+        guard (1...256).contains(pairOT.utf8.count) else {
+            return false
+        }
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
+        return pairOT.unicodeScalars.allSatisfy { allowed.contains($0) }
+    }
+
+    private static func isValidGitHubLogin(_ login: String) -> Bool {
+        guard (1...39).contains(login.utf8.count),
+              !login.hasPrefix("-"),
+              !login.hasSuffix("-")
+        else {
+            return false
+        }
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-")
+        return login.unicodeScalars.allSatisfy { allowed.contains($0) }
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/ClaimCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ClaimCommand.swift
@@ -1,0 +1,223 @@
+import ArgumentParser
+import Foundation
+import MacProviderCore
+
+struct ClaimCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "claim",
+        abstract: "Link this Mac to a GitHub account."
+    )
+
+    @Flag(help: "Print the claim URL instead of opening a browser.")
+    var noBrowser = false
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG. Defaults to ~/.config/macprovider/config.yaml.")
+    var config: String?
+
+    func run() async throws {
+        let resolved = try ConfigLoader.load(cli: CLIOverrides(configPath: config))
+        try await ClaimCommandRunner(config: resolved, noBrowser: noBrowser).run()
+    }
+}
+
+struct ClaimRefreshResponse: Equatable, Sendable {
+    let pairOT: String
+    let claimURL: String
+    let expiresIn: Int
+}
+
+enum ClaimRefreshError: Error, Equatable {
+    case unauthorized
+    case rateLimited(seconds: Int)
+    case httpStatus(Int)
+    case invalidResponse
+    case invalidCoordinatorURL
+    case missingProviderToken
+    case network(String)
+}
+
+struct ClaimRefresher: Sendable {
+    let refresh: @Sendable (AppConfig) async throws -> ClaimRefreshResponse
+
+    static let live = ClaimRefresher { config in
+        guard let token = config.providerToken?.trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty else {
+            throw ClaimRefreshError.missingProviderToken
+        }
+        guard let url = ClaimCommandRunner.refreshURL(from: config.coordinatorURL) else {
+            throw ClaimRefreshError.invalidCoordinatorURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data("{}".utf8)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw ClaimRefreshError.network(String(describing: error))
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw ClaimRefreshError.invalidResponse
+        }
+        switch http.statusCode {
+        case 200:
+            guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let pairOT = object["pair_ot"] as? String,
+                  let claimURL = object["claim_url"] as? String,
+                  let expiresIn = object["expires_in"] as? Int
+            else {
+                throw ClaimRefreshError.invalidResponse
+            }
+            return ClaimRefreshResponse(pairOT: pairOT, claimURL: claimURL, expiresIn: expiresIn)
+        case 401:
+            throw ClaimRefreshError.unauthorized
+        case 429:
+            let retryAfter = Int(http.value(forHTTPHeaderField: "Retry-After") ?? "") ?? 0
+            throw ClaimRefreshError.rateLimited(seconds: retryAfter)
+        default:
+            throw ClaimRefreshError.httpStatus(http.statusCode)
+        }
+    }
+}
+
+struct ClaimCommandRunner: Sendable {
+    typealias Output = @Sendable (String) -> Void
+
+    let config: AppConfig
+    let noBrowser: Bool
+    let claimURLFile: ClaimURLFile
+    let browserOpener: BrowserOpener
+    let refresher: ClaimRefresher
+    let now: @Sendable () -> Date
+    let environment: @Sendable (String) -> String?
+    let stdout: Output
+    let stderr: Output
+
+    init(
+        config: AppConfig,
+        noBrowser: Bool,
+        claimURLFile: ClaimURLFile? = nil,
+        browserOpener: BrowserOpener = BrowserOpener(),
+        refresher: ClaimRefresher = .live,
+        now: @escaping @Sendable () -> Date = { Date() },
+        environment: @escaping @Sendable (String) -> String? = { ProcessInfo.processInfo.environment[$0] },
+        stdout: @escaping Output = { print($0) },
+        stderr: @escaping Output = { FileHandle.standardError.write(Data(($0 + "\n").utf8)) }
+    ) {
+        self.config = config
+        self.noBrowser = noBrowser
+        self.claimURLFile = claimURLFile ?? ClaimURLFile(configPath: config.configPath)
+        self.browserOpener = browserOpener
+        self.refresher = refresher
+        self.now = now
+        self.environment = environment
+        self.stdout = stdout
+        self.stderr = stderr
+    }
+
+    func run() async throws {
+        let record = try localFreshRecord()
+        if let record {
+            try openOrPrint(record.claimURL)
+            return
+        }
+
+        let response: ClaimRefreshResponse
+        do {
+            response = try await refresher.refresh(config)
+        } catch let error as ClaimRefreshError {
+            try mapRefreshError(error)
+            return
+        } catch {
+            stderr("error: failed to refresh claim URL")
+            throw ExitCode(3)
+        }
+        guard response.expiresIn > 0,
+              Self.isValidPairOT(response.pairOT),
+              BrowserOpener.isValidClaimURL(response.claimURL, expectedPairOT: response.pairOT)
+        else {
+            stderr("error: failed to refresh claim URL")
+            throw ExitCode(3)
+        }
+
+        try claimURLFile.write(
+            pairOT: response.pairOT,
+            claimURL: response.claimURL,
+            expiresAt: now().addingTimeInterval(TimeInterval(response.expiresIn))
+        )
+        try openOrPrint(response.claimURL)
+    }
+
+    private func localFreshRecord() throws -> ClaimURLRecord? {
+        let record: ClaimURLRecord?
+        do {
+            record = try claimURLFile.read()
+        } catch ClaimURLFileError.invalidBody {
+            return nil
+        }
+        guard let record,
+              record.expiresAt > now(),
+              Self.isValidPairOT(record.pairOT),
+              BrowserOpener.isValidClaimURL(record.claimURL, expectedPairOT: record.pairOT)
+        else {
+            return nil
+        }
+        return record
+    }
+
+    private func openOrPrint(_ claimURL: String) throws {
+        if noBrowser || (environment("SSH_TTY")?.isEmpty == false) {
+            stdout(claimURL)
+            return
+        }
+        let decision = try browserOpener.openIfAllowed(claimURL)
+        if decision != .opened {
+            stdout(claimURL)
+        }
+    }
+
+    private func mapRefreshError(_ error: ClaimRefreshError) throws {
+        switch error {
+        case .unauthorized:
+            stderr("error: provider token rejected by coordinator — has this Mac been unbound?")
+            throw ExitCode(1)
+        case .rateLimited(let seconds):
+            stderr("error: rate limit exceeded; retry in \(seconds) seconds")
+            throw ExitCode(2)
+        case .httpStatus, .invalidResponse, .invalidCoordinatorURL, .missingProviderToken, .network:
+            stderr("error: failed to refresh claim URL")
+            throw ExitCode(3)
+        }
+    }
+
+    static func refreshURL(from coordinatorURL: String?) -> URL? {
+        guard let coordinatorURL,
+              var components = URLComponents(string: coordinatorURL)
+        else {
+            return nil
+        }
+        switch components.scheme {
+        case "wss":
+            components.scheme = "https"
+        case "https":
+            break
+        default:
+            return nil
+        }
+        components.path = "/v1/install/pair/refresh"
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
+    private static func isValidPairOT(_ pairOT: String) -> Bool {
+        guard (1...256).contains(pairOT.utf8.count) else {
+            return false
+        }
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
+        return pairOT.unicodeScalars.allSatisfy { allowed.contains($0) }
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -123,7 +123,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.3.1"
+    static let binaryVersion = "1.5.0"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL
@@ -159,6 +159,7 @@ actor CoordinatorClient {
     // without taking another dependency on the loader.
     private let configPath: String
     private let sleepAssertionFactory: @Sendable () -> ProviderSleepAssertion?
+    private let pairingController: PairingController
     private var inferenceRelay: InferenceRelay?
     private var tier2Session: Tier2ProviderSession?
     private var webSocket: ProviderWebSocketTask?
@@ -177,9 +178,13 @@ actor CoordinatorClient {
         attestationGenerator: Tier2AttestationTokenGenerating = ManagedDeviceAttestationGenerator(),
         webSocketFactory: @escaping @Sendable (URLRequest) -> ProviderWebSocketTask = { providerWebSocketSession.webSocketTask(with: $0) },
         sleepAssertionFactory: @escaping @Sendable () -> ProviderSleepAssertion? = { CaffeinateSleepAssertion.start() },
+        pairingController: PairingController? = nil,
         connectAndRunOverride: (@Sendable () async throws -> Void)? = nil
     ) {
         guard let rawURL = config.coordinatorURL, let url = URL(string: rawURL) else {
+            return nil
+        }
+        guard url.scheme == "wss" else {
             return nil
         }
         self.coordinatorURL = url
@@ -208,6 +213,7 @@ actor CoordinatorClient {
         }
         self.configPath = config.configPath
         self.sleepAssertionFactory = sleepAssertionFactory
+        self.pairingController = pairingController ?? PairingController(configPath: config.configPath)
         self.connectAndRunOverride = connectAndRunOverride
         self.sendOverride = sendOverride
     }
@@ -476,6 +482,10 @@ actor CoordinatorClient {
         switch type {
         case "hello_ack":
             try await acceptCoordinatorSession(dict, reason: "coordinator hello_ack received")
+        case "ownership_event":
+            try await handleOwnershipEvent(dict)
+        case "ownership_status":
+            try await handleOwnershipStatus(dict)
         case "preflight":
             try await handlePreflight(dict)
         case "inference_request":
@@ -520,6 +530,33 @@ actor CoordinatorClient {
     func handleCoordinatorPayloadForTest(_ payload: [String: Any]) async throws {
         let data = try JSONSerialization.data(withJSONObject: payload)
         try await handle(.string(String(decoding: data, as: UTF8.self)))
+    }
+
+    func acceptAuthResponseForTest(_ response: [String: Any], session: Tier2ProviderSession) async throws {
+        try await acceptAuthResponse(response, session: session)
+    }
+
+    private func handleOwnershipEvent(_ payload: [String: Any]) async throws {
+        guard let providerID = payload["provider_id"] as? String,
+              providerID == self.providerID,
+              let login = payload["github_login"] as? String,
+              let rawEvent = payload["event"] as? String,
+              let event = OwnershipEventKind(rawValue: rawEvent)
+        else {
+            try await sendNAK(inReplyTo: "ownership_event", code: "invalid_message", message: "Invalid ownership_event frame")
+            return
+        }
+        try pairingController.handleOwnershipEvent(OwnershipEventFrame(providerID: providerID, githubLogin: login, event: event))
+    }
+
+    private func handleOwnershipStatus(_ payload: [String: Any]) async throws {
+        guard let providerID = payload["provider_id"] as? String, providerID == self.providerID else {
+            try await sendNAK(inReplyTo: "ownership_status", code: "invalid_message", message: "Invalid ownership_status frame")
+            return
+        }
+        if payload["needs_claim"] as? Bool == true {
+            try pairingController.handleNeedsClaim()
+        }
     }
 
     func sendHeartbeatForTest() async throws {
@@ -695,6 +732,15 @@ actor CoordinatorClient {
         // Awaited so that persist-before-adopt holds: see
         // adoptAssignedProviderTokenIfPresent doc-comment.
         await adoptAssignedProviderTokenIfPresent(payload)
+        do {
+            try pairingController.handlePairingMaterial(
+                pairOT: payload["pair_ot"] as? String,
+                claimURL: payload["claim_url"] as? String,
+                portalBaseURL: payload["portal_base_url"] as? String
+            )
+        } catch {
+            Self.emitClaimURLHandoffEvent(error: error)
+        }
         let interval = max(Self.intValue(payload["heartbeat_interval_s"]) ?? 30, 1)
         await providerStatus.setCoordinatorSession(
             connected: true,
@@ -714,6 +760,20 @@ actor CoordinatorClient {
         sleepAssertion = sleepAssertionFactory()
         startHeartbeat(intervalSeconds: interval)
         try await sendStateUpdate(state: nil, reason: reason)
+    }
+
+    private static func emitClaimURLHandoffEvent(error: Error) {
+        let payload = [
+            "event": "claim_url_handoff_failed",
+            "error": String(describing: error),
+        ]
+        do {
+            var data = try JSONSerialization.data(withJSONObject: payload, options: [])
+            data.append(0x0A)
+            FileHandle.standardError.write(data)
+        } catch {
+            FileHandle.standardError.write(Data("{\"event\":\"claim_url_handoff_failed\"}\n".utf8))
+        }
     }
 
     // Provider WS keepalive fix. The coordinator advertises heartbeat_interval_s

--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -22,6 +22,7 @@ struct HTTPServer {
                     channel.pipeline.addHandler(
                         RouterHandler(
                             modelID: config.model,
+                            providerID: config.providerID,
                             coordinatorURL: config.coordinatorURL,
                             modelRuntime: modelRuntime,
                             providerStatus: providerStatus,
@@ -44,6 +45,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias OutboundOut = HTTPServerResponsePart
 
     private let modelID: String?
+    private let providerID: String?
     private let coordinatorURL: String?
     private let modelRuntime: ModelRuntime
     private let providerStatus: ProviderStatus
@@ -55,6 +57,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
 
     init(
         modelID: String?,
+        providerID: String?,
         coordinatorURL: String?,
         modelRuntime: ModelRuntime,
         providerStatus: ProviderStatus,
@@ -62,6 +65,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         maxBodyBytes: Int
     ) {
         self.modelID = modelID
+        self.providerID = providerID
         self.coordinatorURL = coordinatorURL
         self.modelRuntime = modelRuntime
         self.providerStatus = providerStatus
@@ -180,10 +184,11 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
     private func handleStatus(context: ChannelHandlerContext) {
         let writer = ResponseWriter(context: context)
         let providerStatus = providerStatus
+        let providerID = providerID
         let coordinatorURL = coordinatorURL
-        Task.detached { @Sendable [providerStatus, writer, coordinatorURL] in
+        Task.detached { @Sendable [providerStatus, writer, providerID, coordinatorURL] in
             let snapshot = await providerStatus.snapshot()
-            writer.writeJSON(status: .ok, body: Self.statusResponse(snapshot, coordinatorURL: coordinatorURL))
+            writer.writeJSON(status: .ok, body: Self.statusResponse(snapshot, providerID: providerID, coordinatorURL: coordinatorURL))
         }
     }
 
@@ -430,9 +435,10 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         ]
     }
 
-    private static func statusResponse(_ snapshot: ProviderSnapshot, coordinatorURL: String?) -> [String: Any] {
+    private static func statusResponse(_ snapshot: ProviderSnapshot, providerID: String?, coordinatorURL: String?) -> [String: Any] {
         [
             "binary_version": CoordinatorClient.binaryVersion,
+            "provider_id": jsonNullable(providerID),
             "status": snapshot.status.rawValue,
             "model": snapshot.modelID ?? NSNull(),
             "model_loaded": snapshot.modelLoaded,

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -10,7 +10,7 @@ struct MacProviderCLI: AsyncParsableCommand {
         commandName: "macprovider-cli",
         abstract: "OpenAI-compatible Mac Provider inference CLI.",
         version: CoordinatorClient.binaryVersion,
-        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self],
+        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self],
         defaultSubcommand: ServeCommand.self
     )
 }
@@ -247,7 +247,7 @@ struct StatusCommand: AsyncParsableCommand {
         )
         let status = try await LocalStatusClient.fetch(port: resolved.port)
         let latest = try? await SelfUpdate(currentVersion: CoordinatorClient.binaryVersion, releasesAPIURL: nil).latestVersionCached()
-        print(LocalStatusFormatter.format(status, latestVersion: latest))
+        print(LocalStatusFormatter.format(status, latestVersion: latest, ownerLogin: OwnerFileReader.githubLogin(configPath: resolved.configPath)))
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -1,6 +1,7 @@
 import CryptoKit
 import Darwin
 import Foundation
+import MacProviderCore
 
 struct SelfUpdate {
     static let defaultReleasesAPIURL = "https://api.github.com/repos/Augustas11/macprovider/releases/latest"
@@ -412,12 +413,13 @@ struct LocalStatusClient {
 }
 
 struct LocalStatusFormatter {
-    static func format(_ status: [String: Any], latestVersion: String? = nil) -> String {
+    static func format(_ status: [String: Any], latestVersion: String? = nil, ownerLogin: String? = nil) -> String {
         let capacity = status["capacity"] as? [String: Any] ?? [:]
         let coordinator = status["coordinator"] as? [String: Any] ?? [:]
         let version = status["binary_version"] as? String ?? CoordinatorClient.binaryVersion
         let uptime = humanDuration(status["uptime_s"] as? Int ?? 0)
         let connected = (coordinator["connected"] as? Bool) == true ? "yes" : "no"
+        let ownerLine = ownerLogin.map { "\($0) (github.com/\($0))" } ?? "(unclaimed — run `macprovider-cli claim`)"
         let latestLine: String
         if let latestVersion {
             let comparison = SelfUpdate.compareSemver(version, latestVersion)
@@ -432,6 +434,8 @@ struct LocalStatusFormatter {
         macprovider-cli v\(version)
 
         Local:
+          Provider ID:  \(string(status["provider_id"]))
+          Owner: \(ownerLine)
           Model:       \(string(status["model"]))
           Status:      \(string(status["status"]))
           Uptime:      \(uptime)
@@ -465,5 +469,33 @@ struct LocalStatusFormatter {
             return "\(hours)h \(minutes)m"
         }
         return "\(minutes)m \(seconds % 60)s"
+    }
+}
+
+enum OwnerFileReader {
+    static func githubLogin(configPath: String) -> String? {
+        let claimURLFile = ClaimURLFile(configPath: configPath)
+        guard let body = try? String(contentsOf: claimURLFile.ownerURL, encoding: .utf8) else {
+            return nil
+        }
+        for line in body.split(separator: "\n", omittingEmptySubsequences: true) {
+            let parts = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            if parts.count == 2, parts[0] == "github_login" {
+                let login = String(parts[1])
+                return isValidGitHubLogin(login) ? login : nil
+            }
+        }
+        return nil
+    }
+
+    private static func isValidGitHubLogin(_ login: String) -> Bool {
+        guard (1...39).contains(login.utf8.count),
+              !login.hasPrefix("-"),
+              !login.hasSuffix("-")
+        else {
+            return false
+        }
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-")
+        return login.unicodeScalars.allSatisfy { allowed.contains($0) }
     }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/BrowserOpenerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BrowserOpenerTests.swift
@@ -1,0 +1,54 @@
+import MacProviderCore
+import XCTest
+
+final class BrowserOpenerTests: XCTestCase {
+    func testAutoOpen_Skipped_WhenNoControllingTTY() throws {
+        let opened = LockedBox(false)
+        let opener = BrowserOpener(hasControllingTTY: { false }, environment: { _ in nil }, spawn: { _ in opened.set(true) })
+
+        let decision = try opener.openIfAllowed("https://portal.example/claim?ot=PAIR", expectedPortalHost: "portal.example")
+
+        XCTAssertEqual(decision, .skippedNoTTY)
+        XCTAssertFalse(opened.get())
+    }
+
+    func testAutoOpen_Skipped_WhenSSHTTYSet() throws {
+        let opened = LockedBox(false)
+        let opener = BrowserOpener(hasControllingTTY: { true }, environment: { $0 == "SSH_TTY" ? "/dev/ttys001" : nil }, spawn: { _ in opened.set(true) })
+
+        let decision = try opener.openIfAllowed("https://portal.example/claim?ot=PAIR", expectedPortalHost: "portal.example")
+
+        XCTAssertEqual(decision, .skippedSSH)
+        XCTAssertFalse(opened.get())
+    }
+
+    func testAutoOpen_Skipped_WhenMACPROVIDER_NO_BROWSERSet() throws {
+        let opened = LockedBox(false)
+        let opener = BrowserOpener(hasControllingTTY: { true }, environment: { $0 == "MACPROVIDER_NO_BROWSER" ? "1" : nil }, spawn: { _ in opened.set(true) })
+
+        let decision = try opener.openIfAllowed("https://portal.example/claim?ot=PAIR", expectedPortalHost: "portal.example")
+
+        XCTAssertEqual(decision, .skippedDisabled)
+        XCTAssertFalse(opened.get())
+    }
+
+    func testAutoOpen_RejectsClaimURLWithMetacharacters() throws {
+        let opened = LockedBox(false)
+        let opener = BrowserOpener(hasControllingTTY: { true }, environment: { _ in nil }, spawn: { _ in opened.set(true) })
+
+        let decision = try opener.openIfAllowed("https://portal.example/claim?ot=PAIR;open", expectedPortalHost: "portal.example")
+
+        XCTAssertEqual(decision, .rejectedInvalidURL)
+        XCTAssertFalse(opened.get())
+    }
+
+    func testAutoOpen_UsesSpawnForValidTTYCase() throws {
+        let openedURL = LockedBox<String?>(nil)
+        let opener = BrowserOpener(hasControllingTTY: { true }, environment: { _ in nil }, spawn: { openedURL.set($0) })
+
+        let decision = try opener.openIfAllowed("https://portal.example/claim?ot=PAIR", expectedPortalHost: "portal.example")
+
+        XCTAssertEqual(decision, .opened)
+        XCTAssertEqual(openedURL.get(), "https://portal.example/claim?ot=PAIR")
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ClaimCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ClaimCommandTests.swift
@@ -1,0 +1,256 @@
+import ArgumentParser
+import Foundation
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+final class ClaimCommandTests: XCTestCase {
+    func testClaim_WithFreshLocalClaimURL_MakesZeroNetworkCalls() async throws {
+        let fixture = try makeFixture(prefix: "claim-fresh")
+        let claimURL = "https://portal.example/claim?ot=FRESH"
+        try fixture.claimURLFile.write(pairOT: "FRESH", claimURL: claimURL, expiresAt: fixture.now.addingTimeInterval(600))
+        let refreshCalls = LockedBox(0)
+        let stdout = LockedBox("")
+
+        try await makeRunner(
+            fixture: fixture,
+            noBrowser: true,
+            refresher: refreshCountingRefresher(refreshCalls),
+            stdout: { line in
+                stdout.update { $0 += line }
+            }
+        ).run()
+
+        XCTAssertEqual(refreshCalls.get(), 0)
+        XCTAssertEqual(stdout.get(), claimURL)
+    }
+
+    func testClaim_WithExpiredClaimURL_CallsRefresh_PersistsResponse_Opens() async throws {
+        let fixture = try makeFixture(prefix: "claim-expired")
+        try fixture.claimURLFile.write(
+            pairOT: "OLD",
+            claimURL: "https://portal.example/claim?ot=OLD",
+            expiresAt: fixture.now.addingTimeInterval(-1)
+        )
+        let refreshCalls = LockedBox(0)
+        let opened = LockedBox([String]())
+        let claimURL = "https://portal.example/claim?ot=NEW"
+
+        try await makeRunner(
+            fixture: fixture,
+            browserOpener: BrowserOpener(hasControllingTTY: { true }, environment: { _ in nil }, spawn: { url in opened.update { $0.append(url) } }),
+            refresher: ClaimRefresher { _ in
+                refreshCalls.update { $0 += 1 }
+                return ClaimRefreshResponse(pairOT: "NEW", claimURL: claimURL, expiresIn: 600)
+            }
+        ).run()
+
+        XCTAssertEqual(refreshCalls.get(), 1)
+        XCTAssertEqual(opened.get(), [claimURL])
+        let record = try XCTUnwrap(fixture.claimURLFile.read())
+        XCTAssertEqual(record.pairOT, "NEW")
+        XCTAssertEqual(record.claimURL, claimURL)
+    }
+
+    func testClaim_WithinPostFirstConnectWindow_PreservesFile_NoRefresh() async throws {
+        let fixture = try makeFixture(prefix: "claim-first-connect")
+        let claimURL = "https://portal.example/claim?ot=HANDOFF"
+        let firstConnectOpens = LockedBox(0)
+        let cliOpens = LockedBox(0)
+        let controller = PairingController(
+            claimURLFile: fixture.claimURLFile,
+            browserOpener: BrowserOpener(hasControllingTTY: { true }, environment: { _ in nil }, spawn: { _ in firstConnectOpens.update { $0 += 1 } }),
+            now: { fixture.now },
+            output: { _ in },
+            logOutput: { _ in }
+        )
+        try controller.handlePairingMaterial(pairOT: "HANDOFF", claimURL: claimURL)
+        let beforeAttributes = try FileManager.default.attributesOfItem(atPath: fixture.claimURLFile.fileURL.path)
+        let beforeBody = try String(contentsOf: fixture.claimURLFile.fileURL, encoding: .utf8)
+        let refreshCalls = LockedBox(0)
+
+        try await makeRunner(
+            fixture: fixture,
+            browserOpener: BrowserOpener(hasControllingTTY: { true }, environment: { _ in nil }, spawn: { _ in cliOpens.update { $0 += 1 } }),
+            refresher: refreshCountingRefresher(refreshCalls)
+        ).run()
+
+        let afterAttributes = try FileManager.default.attributesOfItem(atPath: fixture.claimURLFile.fileURL.path)
+        let afterBody = try String(contentsOf: fixture.claimURLFile.fileURL, encoding: .utf8)
+        XCTAssertEqual(firstConnectOpens.get(), 1)
+        XCTAssertEqual(cliOpens.get(), 1)
+        XCTAssertEqual(refreshCalls.get(), 0)
+        XCTAssertEqual(afterBody, beforeBody)
+        XCTAssertEqual(afterAttributes[.modificationDate] as? Date, beforeAttributes[.modificationDate] as? Date)
+    }
+
+    func testClaim_WithMigrationStubFile_TriggersRefresh() async throws {
+        let fixture = try makeFixture(prefix: "claim-stub")
+        try fixture.claimURLFile.writeMigrationStub()
+        let refreshCalls = LockedBox(0)
+        let stdout = LockedBox("")
+        let claimURL = "https://portal.example/claim?ot=STUB"
+
+        try await makeRunner(
+            fixture: fixture,
+            noBrowser: true,
+            refresher: ClaimRefresher { _ in
+                refreshCalls.update { $0 += 1 }
+                return ClaimRefreshResponse(pairOT: "STUB", claimURL: claimURL, expiresIn: 600)
+            },
+            stdout: { line in
+                stdout.update { $0 += line }
+            }
+        ).run()
+
+        XCTAssertEqual(refreshCalls.get(), 1)
+        XCTAssertEqual(stdout.get(), claimURL)
+        XCTAssertEqual(try fixture.claimURLFile.read()?.pairOT, "STUB")
+    }
+
+    func testClaim_WithInvalidFreshLocalClaimURL_TriggersRefresh() async throws {
+        let fixture = try makeFixture(prefix: "claim-invalid-local")
+        try fixture.claimURLFile.write(
+            pairOT: "LOCAL",
+            claimURL: "https://portal.example/claim?ot=OTHER",
+            expiresAt: fixture.now.addingTimeInterval(600)
+        )
+        let refreshCalls = LockedBox(0)
+        let stdout = LockedBox("")
+        let claimURL = "https://portal.example/claim?ot=FIXED"
+
+        try await makeRunner(
+            fixture: fixture,
+            noBrowser: true,
+            refresher: ClaimRefresher { _ in
+                refreshCalls.update { $0 += 1 }
+                return ClaimRefreshResponse(pairOT: "FIXED", claimURL: claimURL, expiresIn: 600)
+            },
+            stdout: { line in
+                stdout.update { $0 += line }
+            }
+        ).run()
+
+        XCTAssertEqual(refreshCalls.get(), 1)
+        XCTAssertEqual(stdout.get(), claimURL)
+        XCTAssertEqual(try fixture.claimURLFile.read()?.pairOT, "FIXED")
+    }
+
+    func testClaim_OnRefresh401_ExitsNonZero_StderrMessage() async throws {
+        let fixture = try makeFixture(prefix: "claim-401")
+        let stderr = LockedBox("")
+        let runner = makeRunner(
+            fixture: fixture,
+            refresher: ClaimRefresher { _ in throw ClaimRefreshError.unauthorized },
+            stderr: { line in stderr.update { $0 += line } }
+        )
+
+        do {
+            try await runner.run()
+            XCTFail("expected 401 exit")
+        } catch {
+            XCTAssertEqual(error as? ExitCode, ExitCode(1))
+        }
+        XCTAssertTrue(stderr.get().contains("error: provider token rejected by coordinator — has this Mac been unbound?"))
+    }
+
+    func testClaim_OnRefresh429_HonoursRetryAfter_StderrMessage() async throws {
+        let fixture = try makeFixture(prefix: "claim-429")
+        let stderr = LockedBox("")
+        let runner = makeRunner(
+            fixture: fixture,
+            refresher: ClaimRefresher { _ in throw ClaimRefreshError.rateLimited(seconds: 37) },
+            stderr: { line in stderr.update { $0 += line } }
+        )
+
+        do {
+            try await runner.run()
+            XCTFail("expected 429 exit")
+        } catch {
+            XCTAssertEqual(error as? ExitCode, ExitCode(2))
+        }
+        XCTAssertTrue(stderr.get().contains("error: rate limit exceeded; retry in 37 seconds"))
+    }
+
+    func testClaim_WithInvalidRefreshResponse_DoesNotPersist() async throws {
+        let fixture = try makeFixture(prefix: "claim-invalid-refresh")
+        let stderr = LockedBox("")
+        let runner = makeRunner(
+            fixture: fixture,
+            refresher: ClaimRefresher { _ in
+                ClaimRefreshResponse(pairOT: "BAD\nTOKEN", claimURL: "https://portal.example/claim?ot=OTHER", expiresIn: 600)
+            },
+            stderr: { line in stderr.update { $0 += line } }
+        )
+
+        do {
+            try await runner.run()
+            XCTFail("expected invalid refresh response exit")
+        } catch {
+            XCTAssertEqual(error as? ExitCode, ExitCode(3))
+        }
+        XCTAssertTrue(stderr.get().contains("error: failed to refresh claim URL"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.claimURLFile.fileURL.path))
+    }
+
+    func testClaimCommand_IsRegisteredOnRootCLI() throws {
+        let command = try MacProviderCLI.parseAsRoot(["claim", "--no-browser"])
+
+        XCTAssertTrue(command is ClaimCommand)
+    }
+
+    private func refreshCountingRefresher(_ calls: LockedBox<Int>) -> ClaimRefresher {
+        ClaimRefresher { _ in
+            calls.update { $0 += 1 }
+            throw ClaimRefreshError.httpStatus(500)
+        }
+    }
+
+    private func makeFixture(prefix: String) throws -> ClaimFixture {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let configURL = dir.appendingPathComponent("config.yaml")
+        try """
+        coordinator_url: wss://coordinator.example/ws/provider
+        provider_token: provider-token
+
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        var config = AppConfig.defaults(configPath: configURL.path)
+        config.coordinatorURL = "wss://coordinator.example/ws/provider"
+        config.providerToken = "provider-token"
+        return ClaimFixture(
+            directory: dir,
+            config: config,
+            claimURLFile: ClaimURLFile(directory: dir),
+            now: Date(timeIntervalSince1970: 1_788_888_000)
+        )
+    }
+
+    private func makeRunner(
+        fixture: ClaimFixture,
+        noBrowser: Bool = false,
+        browserOpener: BrowserOpener = BrowserOpener(hasControllingTTY: { false }),
+        refresher: ClaimRefresher,
+        stdout: @escaping ClaimCommandRunner.Output = { _ in },
+        stderr: @escaping ClaimCommandRunner.Output = { _ in }
+    ) -> ClaimCommandRunner {
+        ClaimCommandRunner(
+            config: fixture.config,
+            noBrowser: noBrowser,
+            claimURLFile: fixture.claimURLFile,
+            browserOpener: browserOpener,
+            refresher: refresher,
+            now: { fixture.now },
+            environment: { _ in nil },
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
+}
+
+private struct ClaimFixture {
+    let directory: URL
+    let config: AppConfig
+    let claimURLFile: ClaimURLFile
+    let now: Date
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ClaimURLFileTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ClaimURLFileTests.swift
@@ -1,0 +1,37 @@
+import MacProviderCore
+import XCTest
+
+final class ClaimURLFileTests: XCTestCase {
+    func testClaimURLFile_WrittenWithMode0600_BeforeOpen_SurvivesOpenKilled() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("claim-url-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = ClaimURLFile(directory: dir)
+        let expiry = Date(timeIntervalSince1970: 1_800_000_000)
+
+        try file.write(pairOT: "PAIRSECRET", claimURL: "https://portal.example/claim?ot=PAIRSECRET", expiresAt: expiry)
+
+        let body = try String(contentsOf: file.fileURL, encoding: .utf8)
+        XCTAssertTrue(body.contains("pair_ot=PAIRSECRET"))
+        XCTAssertTrue(body.contains("claim_url=https://portal.example/claim?ot=PAIRSECRET"))
+        let attrs = try FileManager.default.attributesOfItem(atPath: file.fileURL.path)
+        let mode = (attrs[.posixPermissions] as? NSNumber)?.intValue
+        XCTAssertEqual(mode, 0o600)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: file.fileURL.path + ".tmp"))
+    }
+
+    func testClaimURLFile_ReadAndMigrationStub() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("claim-url-read-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = ClaimURLFile(directory: dir)
+        let expiry = Date(timeIntervalSince1970: 1_800_000_000)
+
+        try file.write(pairOT: "PAIR", claimURL: "https://portal.example/claim?ot=PAIR", expiresAt: expiry)
+        let record = try XCTUnwrap(file.read())
+        XCTAssertEqual(record.pairOT, "PAIR")
+        XCTAssertEqual(record.claimURL, "https://portal.example/claim?ot=PAIR")
+
+        try file.writeMigrationStub()
+        XCTAssertNil(try file.read())
+        XCTAssertEqual(try String(contentsOf: file.fileURL, encoding: .utf8), "needs_refresh=true\n")
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -109,7 +109,7 @@ final class CoordinatorClientTests: XCTestCase {
     func testWebSocketConnectAttachesBearerAuthorizationWhenTokenConfigured_v1Plaintext() async throws {
         let token = "test-token-deadbeef-deadbeef-deadbeef"
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "model-a"
         config.wsTunneledMode = false
@@ -143,7 +143,7 @@ final class CoordinatorClientTests: XCTestCase {
     func testWebSocketConnectAttachesBearerAuthorizationWhenTokenConfigured_v2Tier2() async throws {
         let token = "tier2-token-cafebabe-cafebabe-cafebabe"
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "model-a"
         config.wsTunneledMode = true
@@ -177,7 +177,7 @@ final class CoordinatorClientTests: XCTestCase {
 
     func testWebSocketConnectOmitsAuthorizationWhenTokenUnset() async throws {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "model-a"
         config.wsTunneledMode = false
@@ -248,7 +248,7 @@ final class CoordinatorClientTests: XCTestCase {
     // be a text heartbeat, never a ping. See startHeartbeat doc-comment.
     func testCoordinatorSessionKeepaliveSendsHeartbeatTextFrameAndNoPing() async throws {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "model-a"
         config.wsTunneledMode = false
@@ -315,6 +315,184 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
 
         XCTAssertNil(hello["model_hash"])
+    }
+
+    func testWSScheme_MustBeWSS_NotWS() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let runtime = try await ModelRuntime(modelID: nil)
+        var insecure = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        insecure.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        insecure.providerID = "provider-test"
+        insecure.model = "model-a"
+
+        XCTAssertNil(CoordinatorClient(config: insecure, modelRuntime: runtime, providerStatus: status))
+
+        var secure = insecure
+        secure.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
+        XCTAssertNotNil(CoordinatorClient(config: secure, modelRuntime: runtime, providerStatus: status))
+    }
+
+    func testRequestPairOT_NeverEmitted_OnAdmissionFrames() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: recorder)
+
+        let helloJSON = Self.jsonString(await client.helloMessage())
+        let authJSON = Self.jsonString(await client.authInitialMessage(attempt: Tier2AuthAttempt()))
+
+        XCTAssertFalse(helloJSON.contains("request_pair_ot"), helloJSON)
+        XCTAssertFalse(authJSON.contains("request_pair_ot"), authJSON)
+    }
+
+    func testHelloAckPairingMaterial_WritesClaimURLBeforeFailedOpen() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let dir = try Self.makeTemporaryDirectory(prefix: "coordinator-claim-")
+        let claimFile = ClaimURLFile(directory: dir)
+        let pairingController = PairingController(
+            claimURLFile: claimFile,
+            browserOpener: BrowserOpener(
+                hasControllingTTY: { true },
+                environment: { _ in nil },
+                spawn: { _ in throw BrowserOpenError.spawnFailed(errno: 9) }
+            )
+        )
+        let client = try await makeClient(status: status, recorder: recorder, pairingController: pairingController)
+
+        try await client.handleCoordinatorPayloadForTest([
+            "type": "hello_ack",
+            "assigned_id": "assigned-a",
+            "heartbeat_interval_s": 30,
+            "pair_ot": "PAIRSECRET",
+            "claim_url": "https://portal.example/claim?ot=PAIRSECRET",
+            "portal_base_url": "https://portal.example",
+        ])
+
+        let record = try XCTUnwrap(claimFile.read())
+        XCTAssertEqual(record.pairOT, "PAIRSECRET")
+        XCTAssertEqual(record.claimURL, "https://portal.example/claim?ot=PAIRSECRET")
+        let attrs = try FileManager.default.attributesOfItem(atPath: claimFile.fileURL.path)
+        XCTAssertEqual((attrs[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+    }
+
+    func testAcceptedAuthResponsePairingMaterial_WritesClaimURL() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let dir = try Self.makeTemporaryDirectory(prefix: "coordinator-auth-claim-")
+        let claimFile = ClaimURLFile(directory: dir)
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            pairingController: PairingController(
+                claimURLFile: claimFile,
+                browserOpener: BrowserOpener(hasControllingTTY: { false })
+            )
+        )
+        let session = try Tier2ProviderSession(
+            providerID: "provider-test",
+            assignedID: "assigned-v2",
+            selectedAEAD: Tier2ProviderSession.aeadSuite,
+            keyID: "kid-test",
+            c2pKey: Data(repeating: 0x11, count: 32),
+            p2cKey: Data(repeating: 0x22, count: 32),
+            c2pNonceBase: Data(repeating: 0x33, count: 4),
+            p2cNonceBase: Data(repeating: 0x44, count: 4)
+        )
+
+        try await client.acceptAuthResponseForTest([
+            "type": "auth_response",
+            "version": 2,
+            "status": "accepted",
+            "assigned_id": "assigned-v2",
+            "heartbeat_interval_s": 30,
+            "pair_ot": "PAIRV2",
+            "claim_url": "https://portal.example/claim?ot=PAIRV2",
+            "tier2_session": [
+                "encrypted_leg": [
+                    "enabled": true,
+                    "alg": Tier2ProviderSession.aeadSuite,
+                    "kid": "kid-test",
+                ],
+            ],
+        ], session: session)
+
+        let record = try XCTUnwrap(claimFile.read())
+        XCTAssertEqual(record.pairOT, "PAIRV2")
+        XCTAssertEqual(record.claimURL, "https://portal.example/claim?ot=PAIRV2")
+    }
+
+    func testOwnershipStatusNeedsClaim_WritesStubWithoutOpeningBrowser() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let dir = try Self.makeTemporaryDirectory(prefix: "coordinator-needs-claim-")
+        let claimFile = ClaimURLFile(directory: dir)
+        let opened = LockedBox(false)
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            pairingController: PairingController(
+                claimURLFile: claimFile,
+                browserOpener: BrowserOpener(hasControllingTTY: { true }, spawn: { _ in opened.set(true) })
+            )
+        )
+
+        try await client.handleCoordinatorPayloadForTest([
+            "type": "ownership_status",
+            "provider_id": "provider-test",
+            "needs_claim": true,
+        ])
+
+        XCTAssertEqual(try String(contentsOf: claimFile.fileURL, encoding: .utf8), "needs_refresh=true\n")
+        XCTAssertFalse(opened.get())
+    }
+
+    func testOwnershipEventBound_DeletesClaimURLAndWritesOwner() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let dir = try Self.makeTemporaryDirectory(prefix: "coordinator-owner-")
+        let claimFile = ClaimURLFile(directory: dir)
+        try claimFile.write(pairOT: "PAIR", claimURL: "https://portal.example/claim?ot=PAIR", expiresAt: Date().addingTimeInterval(600))
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            pairingController: PairingController(claimURLFile: claimFile, browserOpener: BrowserOpener(hasControllingTTY: { false }))
+        )
+
+        try await client.handleCoordinatorPayloadForTest([
+            "type": "ownership_event",
+            "provider_id": "provider-test",
+            "github_login": "octo-user",
+            "event": "bound",
+        ])
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: claimFile.fileURL.path))
+        XCTAssertEqual(try String(contentsOf: claimFile.ownerURL, encoding: .utf8), "github_login=octo-user\n")
+        let attrs = try FileManager.default.attributesOfItem(atPath: claimFile.ownerURL.path)
+        XCTAssertEqual((attrs[.posixPermissions] as? NSNumber)?.intValue, 0o600)
     }
 
     func testHeartbeatDisabledModeOmitsBothFields() async throws {
@@ -599,9 +777,28 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertEqual(caps["aead_suites"] as? [String], [Tier2ProviderSession.aeadSuite])
     }
 
+    func testBinaryVersion_AdvertisesSPEC001V15AcrossHandshakeFrames() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: recorder)
+        let attempt = Tier2AuthAttempt()
+
+        let hello = await client.helloMessage()
+        let auth = await client.authInitialMessage(attempt: attempt)
+
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.5.0")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.5.0")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.5.0")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.5.0")
+    }
+
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "model-id-from-snapshot"
         config.supportedModels = nil
@@ -628,7 +825,7 @@ final class CoordinatorClientTests: XCTestCase {
 
     func testAuthInitialEmitsExplicitCatalogWhenSet() async throws {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "A"
         config.supportedModels = ["A", "B"]
@@ -655,7 +852,7 @@ final class CoordinatorClientTests: XCTestCase {
 
     func testAuthInitialOmitsPublishesWhenFalse() async throws {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "A"
         config.supportedModels = ["A", "B"]
@@ -682,7 +879,7 @@ final class CoordinatorClientTests: XCTestCase {
 
     func testHelloMessageUnchangedByPhase1A() async throws {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "A"
         config.supportedModels = ["A", "B"]
@@ -718,7 +915,7 @@ final class CoordinatorClientTests: XCTestCase {
             capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
         )
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "model-a"
         config.wsTunneledMode = true
@@ -985,6 +1182,12 @@ final class CoordinatorClientTests: XCTestCase {
         try! JSONSerialization.data(withJSONObject: object, options: [.withoutEscapingSlashes])
     }
 
+    private static func makeTemporaryDirectory(prefix: String) throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(prefix)\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
     private static func minimalDERSequenceBase64URL() -> String {
         Data([0x30, 0x03, 0x02, 0x01, 0x05]).base64URLUnpadded()
     }
@@ -1005,10 +1208,11 @@ final class CoordinatorClientTests: XCTestCase {
         enableWarmSwap: Bool = false,
         modelRuntime: ModelRuntime? = nil,
         attestationGenerator: Tier2AttestationTokenGenerating = StaticAttestationGenerator(token: nil),
+        pairingController: PairingController? = nil,
         connectAndRunOverride: (@Sendable () async throws -> Void)? = nil
     ) async throws -> CoordinatorClient {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "model-a"
         config.drainTimeoutSeconds = drainTimeoutSeconds
@@ -1029,6 +1233,7 @@ final class CoordinatorClientTests: XCTestCase {
             reconnectGraceNanoseconds: reconnectGraceNanoseconds,
             attestationGenerator: attestationGenerator,
             sleepAssertionFactory: { nil },
+            pairingController: pairingController,
             connectAndRunOverride: connectAndRunOverride
         ))
     }
@@ -1065,6 +1270,33 @@ final class CoordinatorClientTests: XCTestCase {
 
 private enum CoordinatorClientTestError: Error {
     case unexpectedContainerLoader
+}
+
+final class LockedBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func set(_ value: Value) {
+        lock.lock()
+        self.value = value
+        lock.unlock()
+    }
+
+    func update(_ body: (inout Value) -> Void) {
+        lock.lock()
+        body(&value)
+        lock.unlock()
+    }
+
+    func get() -> Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
 }
 
 private actor SwapLoaderGate {

--- a/phase3-binary/Tests/macprovider-cliTests/EndToEndAcceptanceTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/EndToEndAcceptanceTests.swift
@@ -452,7 +452,7 @@ final class EndToEndAcceptanceTests: XCTestCase {
         recorder: CoordinatorFrameRecorder = CoordinatorFrameRecorder()
     ) async throws -> CoordinatorClient {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        config.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = modelID
         config.supportedModels = supportedModels

--- a/phase3-binary/Tests/macprovider-cliTests/PairingControllerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/PairingControllerTests.swift
@@ -1,0 +1,82 @@
+import MacProviderCore
+import XCTest
+
+final class PairingControllerTests: XCTestCase {
+    func testOwnershipEventBound_DeletesClaimURL_WritesOwnerTxt_Within5s() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("pairing-owner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let claimFile = ClaimURLFile(directory: dir)
+        try claimFile.write(pairOT: "PAIR", claimURL: "https://portal.example/claim?ot=PAIR", expiresAt: Date().addingTimeInterval(600))
+        let controller = PairingController(claimURLFile: claimFile, browserOpener: BrowserOpener(hasControllingTTY: { false }))
+        let start = Date()
+
+        try controller.handleOwnershipEvent(OwnershipEventFrame(providerID: "provider-a", githubLogin: "octo", event: .bound))
+
+        XCTAssertLessThan(Date().timeIntervalSince(start), 5)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: claimFile.fileURL.path))
+        XCTAssertEqual(try String(contentsOf: claimFile.ownerURL, encoding: .utf8), "github_login=octo\n")
+        let attrs = try FileManager.default.attributesOfItem(atPath: claimFile.ownerURL.path)
+        XCTAssertEqual((attrs[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+    }
+
+    func testPairOT_NeverAppearsInLogs_OutsideClaimURL() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("pairing-logs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let pairOT = "PAIRSECRET"
+        let claimURL = "https://portal.example/claim?ot=\(pairOT)"
+        let output = LockedBox("")
+        let logOutput = LockedBox("")
+        let controller = PairingController(
+            claimURLFile: ClaimURLFile(directory: dir),
+            browserOpener: BrowserOpener(hasControllingTTY: { false }),
+            output: { line in output.update { $0 += line } },
+            logOutput: { line in logOutput.update { $0 += line } }
+        )
+
+        try controller.handlePairingMaterial(pairOT: pairOT, claimURL: claimURL)
+
+        XCTAssertFalse(output.get().replacingOccurrences(of: claimURL, with: "").contains(pairOT))
+        XCTAssertTrue(output.get().contains(claimURL))
+        XCTAssertFalse(logOutput.get().contains(pairOT))
+        XCTAssertTrue(logOutput.get().contains("ot=REDACTED"))
+    }
+
+    func testPairingMaterial_EmitsFallbackLineBeforeFailedBrowserOpen() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("pairing-open-failure-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let pairOT = "PAIRSECRET"
+        let claimURL = "https://portal.example/claim?ot=\(pairOT)"
+        let output = LockedBox("")
+        let controller = PairingController(
+            claimURLFile: ClaimURLFile(directory: dir),
+            browserOpener: BrowserOpener(
+                hasControllingTTY: { true },
+                environment: { _ in nil },
+                spawn: { _ in throw BrowserOpenError.spawnFailed(errno: 9) }
+            ),
+            output: { line in output.update { $0 += line } },
+            logOutput: { _ in }
+        )
+
+        XCTAssertThrowsError(try controller.handlePairingMaterial(pairOT: pairOT, claimURL: claimURL))
+
+        XCTAssertTrue(output.get().contains("macprovider-cli claim"))
+        XCTAssertTrue(output.get().contains(claimURL))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: URL(fileURLWithPath: dir.path).appendingPathComponent("claim_url").path))
+    }
+
+    func testNeedsClaimSignal_WritesStub_NoAutoOpen() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("pairing-stub-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let opened = LockedBox(false)
+        let controller = PairingController(
+            claimURLFile: ClaimURLFile(directory: dir),
+            browserOpener: BrowserOpener(hasControllingTTY: { true }, spawn: { _ in opened.set(true) })
+        )
+
+        try controller.handleNeedsClaim()
+
+        XCTAssertEqual(try String(contentsOf: URL(fileURLWithPath: dir.path).appendingPathComponent("claim_url"), encoding: .utf8), "needs_refresh=true\n")
+        XCTAssertFalse(opened.get())
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+final class StatusCommandTests: XCTestCase {
+    func testStatus_WhenOwnerTxtPresent_PrintsOwnerLine() throws {
+        let fixture = try makeFixture(prefix: "status-owner")
+        try ClaimURLFile(directory: fixture.directory).writeOwner(githubLogin: "deboxfinance")
+
+        let output = LocalStatusFormatter.format(
+            status(providerID: "provider-a"),
+            latestVersion: nil,
+            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath)
+        )
+
+        XCTAssertTrue(output.contains("Provider ID:  provider-a"), output)
+        XCTAssertTrue(output.contains("Owner: deboxfinance (github.com/deboxfinance)"), output)
+        XCTAssertLessThan(
+            try XCTUnwrap(output.range(of: "Provider ID:  provider-a")?.lowerBound),
+            try XCTUnwrap(output.range(of: "Owner: deboxfinance (github.com/deboxfinance)")?.lowerBound)
+        )
+    }
+
+    func testStatus_WhenOwnerTxtAbsent_PrintsUnclaimedLine() throws {
+        let fixture = try makeFixture(prefix: "status-unclaimed")
+
+        let output = LocalStatusFormatter.format(
+            status(providerID: "provider-a"),
+            latestVersion: nil,
+            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath)
+        )
+
+        XCTAssertTrue(output.contains("Owner: (unclaimed — run `macprovider-cli claim`)"), output)
+    }
+
+    func testStatus_WhenOwnerTxtMalformed_PrintsUnclaimedLine() throws {
+        let fixture = try makeFixture(prefix: "status-malformed")
+        let ownerURL = ClaimURLFile(directory: fixture.directory).ownerURL
+        try "not_github_login=octo\n".write(to: ownerURL, atomically: true, encoding: .utf8)
+
+        let output = LocalStatusFormatter.format(
+            status(providerID: "provider-a"),
+            latestVersion: nil,
+            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath)
+        )
+
+        XCTAssertTrue(output.contains("Owner: (unclaimed — run `macprovider-cli claim`)"), output)
+    }
+
+    func testStatus_WhenOwnerTxtContainsInvalidLogin_PrintsUnclaimedLine() throws {
+        let fixture = try makeFixture(prefix: "status-invalid-owner")
+        let ownerURL = ClaimURLFile(directory: fixture.directory).ownerURL
+        try "github_login=bad/login\n".write(to: ownerURL, atomically: true, encoding: .utf8)
+
+        let output = LocalStatusFormatter.format(
+            status(providerID: "provider-a"),
+            latestVersion: nil,
+            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath)
+        )
+
+        XCTAssertTrue(output.contains("Owner: (unclaimed — run `macprovider-cli claim`)"), output)
+    }
+
+    private func makeFixture(prefix: String) throws -> StatusFixture {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let configPath = dir.appendingPathComponent("config.yaml").path
+        return StatusFixture(directory: dir, configPath: configPath)
+    }
+
+    private func status(providerID: String) -> [String: Any] {
+        [
+            "binary_version": "1.5.0",
+            "provider_id": providerID,
+            "model": "model-a",
+            "status": "ready",
+            "uptime_s": 60,
+            "requests_total": 1,
+            "errors_total": 0,
+            "active_request_id_count": 0,
+            "capacity": [
+                "ram_gb": 16,
+                "ram_tier": "16GB",
+                "max_context_tokens": 50_000,
+            ],
+            "coordinator": [
+                "url": "wss://coordinator.example/ws/provider",
+                "connected": true,
+                "session": "provider-a",
+                "tier": 2,
+                "recommended_binary_version": "1.5.0",
+            ],
+        ]
+    }
+}
+
+private struct StatusFixture {
+    let directory: URL
+    let configPath: String
+}

--- a/phase4-coordinator/cmd/coordinator-cli/main.go
+++ b/phase4-coordinator/cmd/coordinator-cli/main.go
@@ -31,6 +31,8 @@ func main() {
 		err = revokeAndKick(os.Args[2:])
 	case "prune-tokens":
 		err = pruneTokens(os.Args[2:])
+	case "list-pair-ot-mints":
+		err = listPairOTMints(os.Args[2:])
 	default:
 		usage()
 		os.Exit(2)
@@ -259,6 +261,36 @@ func pruneTokens(args []string) error {
 	return nil
 }
 
+func listPairOTMints(args []string) error {
+	fs := flag.NewFlagSet("list-pair-ot-mints", flag.ExitOnError)
+	dbPath := fs.String("db", "coordinator.db", "path to coordinator SQLite database")
+	providerID := fs.String("provider-id", "", "optional provider_id filter")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	store, err := auth.OpenStore(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	rows, err := store.ListPairOTMintLog(context.Background(), *providerID)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		sourceIP := ""
+		if row.SourceIP.Valid {
+			sourceIP = row.SourceIP.String
+		}
+		userAgent := ""
+		if row.UserAgent.Valid {
+			userAgent = row.UserAgent.String
+		}
+		fmt.Printf("%d\t%s\t%d\t%s\t%s\t%s\n", row.ID, row.ProviderID, row.Outcome, row.TS, sourceIP, userAgent)
+	}
+	return nil
+}
+
 func resolvePruneCutoff(s string) (time.Time, error) {
 	if d, err := time.ParseDuration(s); err == nil {
 		return time.Now().UTC().Add(-d), nil
@@ -270,5 +302,5 @@ func resolvePruneCutoff(s string) (time.Time, error) {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|list-tokens|revoke-and-kick|prune-tokens> [flags]")
+	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints> [flags]")
 }

--- a/phase4-coordinator/cmd/coordinator-cli/main_test.go
+++ b/phase4-coordinator/cmd/coordinator-cli/main_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 )
@@ -61,6 +64,28 @@ func TestRevokeAndKickRejectsMismatchedProviderOverride(t *testing.T) {
 	}
 }
 
+func TestListPairOTMints_Exits0_OnPopulatedLog(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	store, err := auth.OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.LogPairOTMint(context.Background(), "provider-a", "127.0.0.1", "test-agent", http.StatusOK, time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("log mint: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	output := captureStdout(t, func() {
+		if err := listPairOTMints([]string{"--db", dbPath, "--provider-id", "provider-a"}); err != nil {
+			t.Fatalf("listPairOTMints: %v", err)
+		}
+	})
+	if !strings.Contains(output, "provider-a") || !strings.Contains(output, "200") {
+		t.Fatalf("output = %q, want provider-a and 200", output)
+	}
+}
+
 func issueCLITestToken(t *testing.T, providerID string) (string, string) {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
@@ -74,4 +99,24 @@ func issueCLITestToken(t *testing.T, providerID string) (string, string) {
 		t.Fatalf("issue token: %v", err)
 	}
 	return dbPath, record.TokenPrefix
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	os.Stdout = orig
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return string(out)
 }

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -27,7 +27,9 @@ import (
 )
 
 // version is overridden at build time via
-//   go build -ldflags "-X main.version=$(git describe --always --dirty --tags)"
+//
+//	go build -ldflags "-X main.version=$(git describe --always --dirty --tags)"
+//
 // (see scripts/build-linux.sh). Defaults to "dev" for local `go run`.
 var version = "dev"
 
@@ -105,6 +107,7 @@ func main() {
 	// interface layer (codex architect review on PR #44, interface
 	// segregation MINOR).
 	wsOpts = append(wsOpts, providerws.WithTokenIssuer(tokenStore))
+	wsOpts = append(wsOpts, providerws.WithGitHubAuthStore(tokenStore))
 	if cfg.Auth.RequireProviderTokens {
 		logger.Info().Msg("provider WS token validation REQUIRED (auth.require_provider_tokens=true)")
 	} else {
@@ -266,6 +269,7 @@ func main() {
 	startRequestLogRetentionPruner(shutdownCtx, reqLogStore, cfg.Storage.RequestLogRetentionDays, logger)
 	startAuditLogRetentionPruner(shutdownCtx, auditStore, cfg.Storage.AuditLogRetentionDays, logger)
 	startAdmissionRetentionPruner(shutdownCtx, wsServer.Admission(), cfg.Admission.ProvisionalRetentionDays, logger)
+	startGitHubAuthStatePruner(shutdownCtx, tokenStore, logger)
 
 	go func() {
 		logger.Info().Str("addr", providerAddr).Msg("provider websocket server listening")
@@ -393,6 +397,36 @@ func startAdmissionRetentionPruner(ctx context.Context, mgr admissionPruner, ret
 	logger.Info().Time("next_prune_at", nextRun).Int("retention_days", retentionDays).Msg("admission state retention pruner armed")
 	go func() {
 		ticker := time.NewTicker(24 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				prune()
+			}
+		}
+	}()
+}
+
+type githubAuthStatePruner interface {
+	PruneGitHubAuthState(context.Context, time.Time) error
+}
+
+func startGitHubAuthStatePruner(ctx context.Context, store githubAuthStatePruner, logger zerolog.Logger) {
+	if store == nil {
+		return
+	}
+	prune := func() {
+		now := time.Now().UTC()
+		if err := store.PruneGitHubAuthState(ctx, now); err != nil {
+			logger.Warn().Err(err).Msg("github auth state prune failed")
+		}
+	}
+	prune()
+	logger.Info().Time("next_prune_at", time.Now().UTC().Add(time.Hour)).Msg("github auth state pruner armed")
+	go func() {
+		ticker := time.NewTicker(time.Hour)
 		defer ticker.Stop()
 		for {
 			select {

--- a/phase4-coordinator/internal/auth/spec014_pairing_test.go
+++ b/phase4-coordinator/internal/auth/spec014_pairing_test.go
@@ -1,0 +1,163 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPairOTExpiresAt_Exactly600s(t *testing.T) {
+	store := openSpec014Store(t)
+	defer store.Close()
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	mint, err := store.MintPairOT(context.Background(), "provider-a", now)
+	if err != nil {
+		t.Fatalf("MintPairOT: %v", err)
+	}
+	if got := mint.ExpiresAt.Sub(now); got != 10*time.Minute {
+		t.Fatalf("expires delta = %s, want 10m", got)
+	}
+}
+
+func TestBindRace_TwoCallers_OneSucceeds_OneGets410(t *testing.T) {
+	store := openSpec014Store(t)
+	defer store.Close()
+	ctx := context.Background()
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	sessionID, pairOT := seedSpec014SessionAndPairOT(t, store, now)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := store.BindPairOT(ctx, sessionID, pairOT, now.Add(time.Second), nil)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	successes := 0
+	gone := 0
+	for err := range errs {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, ErrPairOTInvalid):
+			gone++
+		default:
+			t.Fatalf("unexpected bind error: %v", err)
+		}
+	}
+	if successes != 1 || gone != 1 {
+		t.Fatalf("successes=%d gone=%d, want 1/1", successes, gone)
+	}
+}
+
+func TestConsumePendingPairOT_AtomicallyNulled(t *testing.T) {
+	store := openSpec014Store(t)
+	defer store.Close()
+	ctx := context.Background()
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	sessionID, pairOT := seedSpec014SessionAndPairOT(t, store, now)
+	if _, err := store.DB().ExecContext(ctx, `UPDATE mp_sessions SET pending_pair_ot = ?, pending_pair_ot_expires_at = ? WHERE id = ?`, pairOT, timeText(now.Add(10*time.Minute)), sessionID); err != nil {
+		t.Fatalf("seed pending pair_ot: %v", err)
+	}
+	pending, err := store.ConsumePendingPairOT(ctx, sessionID, now.Add(time.Second))
+	if err != nil {
+		t.Fatalf("consume pending hint: %v", err)
+	}
+	if pending != pairOT {
+		t.Fatalf("pending pair_ot = %q, want %q", pending, pairOT)
+	}
+	if _, err := store.BindPairOT(ctx, sessionID, pending, now.Add(time.Second), nil); err != nil {
+		t.Fatalf("bind consumed pending hint: %v", err)
+	}
+	if _, err := store.ConsumePendingPairOT(ctx, sessionID, now.Add(2*time.Second)); !errors.Is(err, ErrPendingPairOTMissing) {
+		t.Fatalf("second consume err = %v, want ErrPendingPairOTMissing", err)
+	}
+}
+
+func TestBindPairOT_EnqueueFailureRollsBackBurnAndOwnership(t *testing.T) {
+	store := openSpec014Store(t)
+	defer store.Close()
+	ctx := context.Background()
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	sessionID, pairOT := seedSpec014SessionAndPairOT(t, store, now)
+	enqueueErr := errors.New("enqueue failed")
+
+	if _, err := store.BindPairOT(ctx, sessionID, pairOT, now.Add(time.Second), func(BindResult) error {
+		return enqueueErr
+	}); !errors.Is(err, enqueueErr) {
+		t.Fatalf("BindPairOT enqueue err = %v, want %v", err, enqueueErr)
+	}
+	owned, err := store.HasOwnership(ctx, "provider-a")
+	if err != nil {
+		t.Fatalf("HasOwnership: %v", err)
+	}
+	if owned {
+		t.Fatalf("ownership should roll back when enqueue fails")
+	}
+	if _, err := store.BindPairOT(ctx, sessionID, pairOT, now.Add(2*time.Second), nil); err != nil {
+		t.Fatalf("BindPairOT after enqueue rollback: %v", err)
+	}
+}
+
+func TestRateLimit_5PerHour_PersistsAcrossRestart(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		if err := store.LogPairOTMint(context.Background(), "provider-a", "127.0.0.1", "test", 200, now.Add(time.Duration(i)*time.Minute)); err != nil {
+			t.Fatalf("log mint %d: %v", i, err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	store, err = OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer store.Close()
+	count, _, err := store.CountRecentSuccessfulPairOTRefreshMints(context.Background(), "provider-a", now)
+	if err != nil {
+		t.Fatalf("count recent: %v", err)
+	}
+	if count != 5 {
+		t.Fatalf("count after restart = %d, want 5", count)
+	}
+}
+
+func openSpec014Store(t *testing.T) *Store {
+	t.Helper()
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	return store
+}
+
+func seedSpec014SessionAndPairOT(t *testing.T, store *Store, now time.Time) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := store.UpsertGitHubIdentity(ctx, 42, "octo", now); err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+	sessionID, err := store.CreateMPSession(ctx, 42, nullString(""), now)
+	if err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	mint, err := store.MintPairOT(ctx, "provider-a", now)
+	if err != nil {
+		t.Fatalf("seed pair_ot: %v", err)
+	}
+	return sessionID, mint.PairOT
+}

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -35,6 +35,11 @@ import (
 // preserved in v0.8.3 (PR #69) closes that race; the wire-level
 // reject was replaced with admit-tokenless in v0.8.3 (Entry 66).
 var ErrActiveTokenAlreadyExists = errors.New("provider_token: active token already exists for provider_id")
+var ErrOwnershipExists = errors.New("provider ownership already exists")
+var ErrPairOTInvalid = errors.New("pair_ot invalid")
+var ErrPairOTAlreadyOwned = errors.New("pair_ot provider already owned by another account")
+var ErrSessionInvalid = errors.New("mp_session invalid")
+var ErrPendingPairOTMissing = errors.New("pending pair_ot missing")
 
 type Store struct {
 	db *sql.DB
@@ -50,6 +55,63 @@ type TokenRecord struct {
 	CreatedAt    string
 	RevokedAt    sql.NullString
 	LastUsedAt   sql.NullString
+}
+
+type PairOTMint struct {
+	PairOT    string
+	ClaimURL  string
+	ExpiresAt time.Time
+}
+
+type AdmissionPairMint struct {
+	TokenRecord   TokenRecord
+	ProviderToken string
+	PairOT        string
+	ExpiresAt     time.Time
+	Paired        bool
+}
+
+type OAuthState struct {
+	ReturnTo      string
+	PendingPairOT sql.NullString
+	ExpiresAt     string
+}
+
+type MPSession struct {
+	ID                  string
+	GitHubUserID        int64
+	GitHubLogin         string
+	LastSeenAt          time.Time
+	LastSetCookieAt     time.Time
+	PendingPairOT       sql.NullString
+	PendingPairOTExpiry sql.NullString
+}
+
+type OwnedProvider struct {
+	ProviderID string `json:"provider_id"`
+	ClaimedAt  string `json:"claimed_at"`
+	LastSeenAt string `json:"last_seen_at"`
+}
+
+type BindResult struct {
+	ProviderID  string
+	GitHubLogin string
+	ClaimedAt   string
+}
+
+type PairOTMintLogRecord struct {
+	ID         int64
+	ProviderID string
+	SourceIP   sql.NullString
+	UserAgent  sql.NullString
+	Outcome    int
+	TS         string
+}
+
+type PairOTRefreshResult struct {
+	Mint        PairOTMint
+	RetryAfter  int
+	RateLimited bool
 }
 
 func BearerTokenMatchesHeader(headers http.Header, expected string) bool {
@@ -200,7 +262,72 @@ CREATE INDEX IF NOT EXISTS idx_token_hash ON provider_tokens(token_hash);
 	if err := s.ensureProviderIDColumn(ctx); err != nil {
 		return err
 	}
-	return s.ensureActiveProviderIDUniqueness(ctx)
+	if err := s.ensureActiveProviderIDUniqueness(ctx); err != nil {
+		return err
+	}
+	return s.ensureGitHubAuthSchema(ctx)
+}
+
+func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS github_identities (
+			github_user_id INTEGER PRIMARY KEY,
+			github_login TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+			last_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+		)`,
+		`CREATE TABLE IF NOT EXISTS provider_ownership (
+			provider_id TEXT PRIMARY KEY,
+			github_user_id INTEGER NOT NULL REFERENCES github_identities(github_user_id),
+			claimed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_ownership_github ON provider_ownership(github_user_id)`,
+		`CREATE TABLE IF NOT EXISTS pair_ots (
+			id TEXT PRIMARY KEY,
+			provider_id TEXT NOT NULL,
+			expires_at TEXT NOT NULL,
+			used_at TEXT,
+			created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_pair_ots_provider ON pair_ots(provider_id)`,
+		`CREATE TABLE IF NOT EXISTS mp_sessions (
+			id TEXT PRIMARY KEY,
+			github_user_id INTEGER NOT NULL REFERENCES github_identities(github_user_id),
+			created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+			last_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+			last_setcookie_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+			pending_pair_ot TEXT,
+			pending_pair_ot_expires_at TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_user ON mp_sessions(github_user_id)`,
+		`CREATE TABLE IF NOT EXISTS oauth_states (
+			state TEXT PRIMARY KEY,
+			return_to TEXT NOT NULL,
+			pending_pair_ot TEXT,
+			expires_at TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+		)`,
+		`CREATE TABLE IF NOT EXISTS pair_ot_mint_log (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			provider_id TEXT NOT NULL,
+			source_ip TEXT,
+			user_agent TEXT,
+			outcome INTEGER NOT NULL,
+			ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_mint_log_provider_ts ON pair_ot_mint_log(provider_id, ts)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // ensureActiveProviderIDUniqueness installs the SPEC-003 v0.8.2 partial
@@ -571,6 +698,477 @@ func (s *Store) ListTokens(ctx context.Context) ([]TokenRecord, error) {
 	return records, rows.Err()
 }
 
+func (s *Store) DB() *sql.DB {
+	return s.db
+}
+
+func (s *Store) UpsertGitHubIdentity(ctx context.Context, githubUserID int64, login string, now time.Time) error {
+	login = strings.TrimSpace(login)
+	if githubUserID <= 0 || login == "" {
+		return fmt.Errorf("github identity requires id and login")
+	}
+	nowText := timeText(now)
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO github_identities (github_user_id, github_login, created_at, last_seen_at)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(github_user_id) DO UPDATE SET github_login = excluded.github_login, last_seen_at = excluded.last_seen_at`,
+		githubUserID, login, nowText, nowText)
+	return err
+}
+
+func (s *Store) CreateOAuthState(ctx context.Context, state, returnTo string, pendingPairOT *string, now time.Time) error {
+	if state == "" || returnTo == "" {
+		return fmt.Errorf("oauth state and return_to are required")
+	}
+	var pending any
+	if pendingPairOT != nil {
+		pending = *pendingPairOT
+	}
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO oauth_states (state, return_to, pending_pair_ot, expires_at, created_at)
+VALUES (?, ?, ?, ?, ?)`,
+		state, returnTo, pending, timeText(now.Add(10*time.Minute)), timeText(now))
+	return err
+}
+
+func (s *Store) ConsumeOAuthState(ctx context.Context, state string, now time.Time) (OAuthState, bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OAuthState{}, false, err
+	}
+	defer tx.Rollback()
+	var out OAuthState
+	err = tx.QueryRowContext(ctx, `
+DELETE FROM oauth_states
+ WHERE state = ? AND expires_at > ?
+RETURNING return_to, pending_pair_ot, expires_at`,
+		state, timeText(now)).Scan(&out.ReturnTo, &out.PendingPairOT, &out.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return OAuthState{}, false, nil
+	}
+	if err != nil {
+		return OAuthState{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return OAuthState{}, false, err
+	}
+	return out, true, nil
+}
+
+func (s *Store) CreateMPSession(ctx context.Context, githubUserID int64, pendingPairOT sql.NullString, now time.Time) (string, error) {
+	sessionID, err := randomHex(32)
+	if err != nil {
+		return "", err
+	}
+	var pending any
+	var pendingExpires any
+	if pendingPairOT.Valid && pendingPairOT.String != "" {
+		pending = pendingPairOT.String
+		pendingExpires = timeText(now.Add(10 * time.Minute))
+	}
+	nowText := timeText(now)
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO mp_sessions (id, github_user_id, created_at, last_seen_at, last_setcookie_at, pending_pair_ot, pending_pair_ot_expires_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		sessionID, githubUserID, nowText, nowText, nowText, pending, pendingExpires)
+	return sessionID, err
+}
+
+func (s *Store) LoadMPSession(ctx context.Context, id string, now time.Time) (MPSession, bool, error) {
+	var sess MPSession
+	var lastSeen, lastSet string
+	err := s.db.QueryRowContext(ctx, `
+SELECT s.id, s.github_user_id, g.github_login, s.last_seen_at, s.last_setcookie_at, s.pending_pair_ot, s.pending_pair_ot_expires_at
+  FROM mp_sessions s
+  JOIN github_identities g ON g.github_user_id = s.github_user_id
+ WHERE s.id = ? AND s.last_seen_at >= ?`,
+		id, timeText(now.AddDate(0, 0, -30))).Scan(&sess.ID, &sess.GitHubUserID, &sess.GitHubLogin, &lastSeen, &lastSet, &sess.PendingPairOT, &sess.PendingPairOTExpiry)
+	if err == sql.ErrNoRows {
+		return MPSession{}, false, nil
+	}
+	if err != nil {
+		return MPSession{}, false, err
+	}
+	sess.LastSeenAt = parseTimeOrZero(lastSeen)
+	sess.LastSetCookieAt = parseTimeOrZero(lastSet)
+	return sess, true, nil
+}
+
+func (s *Store) TouchMPSession(ctx context.Context, id string, now time.Time, reissuedCookie bool) error {
+	if reissuedCookie {
+		_, err := s.db.ExecContext(ctx, `UPDATE mp_sessions SET last_seen_at = ?, last_setcookie_at = ? WHERE id = ?`, timeText(now), timeText(now), id)
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `UPDATE mp_sessions SET last_seen_at = ? WHERE id = ?`, timeText(now), id)
+	return err
+}
+
+func (s *Store) DeleteMPSession(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM mp_sessions WHERE id = ?`, id)
+	return err
+}
+
+func (s *Store) ListOwnedProviders(ctx context.Context, githubUserID int64) ([]OwnedProvider, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT provider_id, claimed_at FROM provider_ownership WHERE github_user_id = ? ORDER BY claimed_at, provider_id`, githubUserID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []OwnedProvider
+	for rows.Next() {
+		var p OwnedProvider
+		if err := rows.Scan(&p.ProviderID, &p.ClaimedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) HasOwnership(ctx context.Context, providerID string) (bool, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM provider_ownership WHERE provider_id = ?`, providerID).Scan(&n)
+	return n > 0, err
+}
+
+func (s *Store) MintAdmissionTokenAndPairOT(ctx context.Context, providerID, providerName string, now time.Time) (AdmissionPairMint, error) {
+	providerID = strings.TrimSpace(providerID)
+	providerName = strings.TrimSpace(providerName)
+	if providerID == "" || providerName == "" {
+		return AdmissionPairMint{}, fmt.Errorf("provider id and name are required")
+	}
+	providerToken, err := randomHex(32)
+	if err != nil {
+		return AdmissionPairMint{}, err
+	}
+	pairOT, err := randomHex(32)
+	if err != nil {
+		return AdmissionPairMint{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AdmissionPairMint{}, err
+	}
+	defer tx.Rollback()
+	hash := tokenHash(providerToken)
+	prefix := providerToken[:tokenDisplayPrefixLength]
+	nowText := timeText(now)
+	res, err := tx.ExecContext(ctx, `INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at) VALUES (?, ?, ?, ?, ?)`, hash, prefix, providerID, providerName, nowText)
+	if err != nil {
+		if isActiveProviderTokenConstraintFailure(err) {
+			return AdmissionPairMint{}, ErrActiveTokenAlreadyExists
+		}
+		return AdmissionPairMint{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return AdmissionPairMint{}, err
+	}
+	var owned int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(1) FROM provider_ownership WHERE provider_id = ?`, providerID).Scan(&owned); err != nil {
+		return AdmissionPairMint{}, err
+	}
+	out := AdmissionPairMint{
+		TokenRecord:   TokenRecord{ID: id, TokenPrefix: prefix, ProviderID: providerID, ProviderName: providerName, CreatedAt: nowText},
+		ProviderToken: providerToken,
+	}
+	if owned == 0 {
+		out.PairOT = pairOT
+		out.ExpiresAt = now.Add(10 * time.Minute).UTC()
+		out.Paired = true
+		if _, err := tx.ExecContext(ctx, `INSERT INTO pair_ots (id, provider_id, expires_at, created_at) VALUES (?, ?, ?, ?)`, pairOT, providerID, timeText(out.ExpiresAt), nowText); err != nil {
+			return AdmissionPairMint{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return AdmissionPairMint{}, err
+	}
+	return out, nil
+}
+
+func (s *Store) MintPairOT(ctx context.Context, providerID string, now time.Time) (PairOTMint, error) {
+	providerID = strings.TrimSpace(providerID)
+	if providerID == "" {
+		return PairOTMint{}, fmt.Errorf("provider id is required")
+	}
+	pairOT, err := randomHex(32)
+	if err != nil {
+		return PairOTMint{}, err
+	}
+	expires := now.Add(10 * time.Minute).UTC()
+	_, err = s.db.ExecContext(ctx, `INSERT INTO pair_ots (id, provider_id, expires_at, created_at) VALUES (?, ?, ?, ?)`, pairOT, providerID, timeText(expires), timeText(now))
+	if err != nil {
+		return PairOTMint{}, err
+	}
+	return PairOTMint{PairOT: pairOT, ExpiresAt: expires}, nil
+}
+
+func (s *Store) CountRecentSuccessfulPairOTRefreshMints(ctx context.Context, providerID string, since time.Time) (int, sql.NullString, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT ts FROM pair_ot_mint_log WHERE provider_id = ? AND outcome = 200 AND ts >= ? ORDER BY ts ASC`, providerID, timeText(since))
+	if err != nil {
+		return 0, sql.NullString{}, err
+	}
+	defer rows.Close()
+	count := 0
+	var oldest sql.NullString
+	for rows.Next() {
+		var ts string
+		if err := rows.Scan(&ts); err != nil {
+			return 0, sql.NullString{}, err
+		}
+		if count == 0 {
+			oldest = sql.NullString{String: ts, Valid: true}
+		}
+		count++
+	}
+	return count, oldest, rows.Err()
+}
+
+func (s *Store) MintPairOTRefresh(ctx context.Context, providerID, sourceIP, userAgent string, now time.Time) (PairOTRefreshResult, error) {
+	providerID = strings.TrimSpace(providerID)
+	if providerID == "" {
+		return PairOTRefreshResult{}, fmt.Errorf("provider id is required")
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return PairOTRefreshResult{}, err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return PairOTRefreshResult{}, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+
+	rows, err := conn.QueryContext(ctx, `SELECT ts FROM pair_ot_mint_log WHERE provider_id = ? AND outcome = 200 AND ts >= ? ORDER BY ts ASC`, providerID, timeText(now.Add(-time.Hour)))
+	if err != nil {
+		return PairOTRefreshResult{}, err
+	}
+	count := 0
+	var oldest sql.NullString
+	for rows.Next() {
+		var ts string
+		if err := rows.Scan(&ts); err != nil {
+			rows.Close()
+			return PairOTRefreshResult{}, err
+		}
+		if count == 0 {
+			oldest = sql.NullString{String: ts, Valid: true}
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return PairOTRefreshResult{}, err
+	}
+	rows.Close()
+
+	if count >= 5 {
+		if _, err := conn.ExecContext(ctx, `INSERT INTO pair_ot_mint_log (provider_id, source_ip, user_agent, outcome, ts) VALUES (?, ?, ?, ?, ?)`,
+			providerID, nullString(sourceIP), nullString(userAgent), http.StatusTooManyRequests, timeText(now)); err != nil {
+			return PairOTRefreshResult{}, err
+		}
+		if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+			return PairOTRefreshResult{}, err
+		}
+		committed = true
+		return PairOTRefreshResult{RetryAfter: retryAfterSeconds(oldest, now), RateLimited: true}, nil
+	}
+
+	pairOT, err := randomHex(32)
+	if err != nil {
+		return PairOTRefreshResult{}, err
+	}
+	expires := now.Add(10 * time.Minute).UTC()
+	if _, err := conn.ExecContext(ctx, `INSERT INTO pair_ots (id, provider_id, expires_at, created_at) VALUES (?, ?, ?, ?)`, pairOT, providerID, timeText(expires), timeText(now)); err != nil {
+		return PairOTRefreshResult{}, err
+	}
+	if _, err := conn.ExecContext(ctx, `INSERT INTO pair_ot_mint_log (provider_id, source_ip, user_agent, outcome, ts) VALUES (?, ?, ?, ?, ?)`,
+		providerID, nullString(sourceIP), nullString(userAgent), http.StatusOK, timeText(now)); err != nil {
+		return PairOTRefreshResult{}, err
+	}
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return PairOTRefreshResult{}, err
+	}
+	committed = true
+	return PairOTRefreshResult{Mint: PairOTMint{PairOT: pairOT, ExpiresAt: expires}}, nil
+}
+
+func (s *Store) ConsumePendingPairOT(ctx context.Context, sessionID string, now time.Time) (string, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+	defer tx.Rollback()
+	var pairOT string
+	nowText := timeText(now)
+	err = tx.QueryRowContext(ctx, `
+SELECT pending_pair_ot
+  FROM mp_sessions
+ WHERE id = ?
+   AND pending_pair_ot IS NOT NULL
+   AND pending_pair_ot_expires_at > ?`, sessionID, nowText).Scan(&pairOT)
+	if err == sql.ErrNoRows {
+		return "", ErrPendingPairOTMissing
+	}
+	if err != nil {
+		return "", err
+	}
+	res, err := tx.ExecContext(ctx, `
+UPDATE mp_sessions
+   SET pending_pair_ot = NULL,
+       pending_pair_ot_expires_at = NULL
+ WHERE id = ?
+   AND pending_pair_ot = ?
+   AND pending_pair_ot_expires_at > ?`, sessionID, pairOT, nowText)
+	if err != nil {
+		return "", err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return "", err
+	}
+	if affected == 0 {
+		return "", ErrPendingPairOTMissing
+	}
+	if err := tx.Commit(); err != nil {
+		return "", err
+	}
+	return pairOT, nil
+}
+
+func (s *Store) LogPairOTMint(ctx context.Context, providerID, sourceIP, userAgent string, outcome int, now time.Time) error {
+	if providerID == "" {
+		providerID = "unknown"
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO pair_ot_mint_log (provider_id, source_ip, user_agent, outcome, ts) VALUES (?, ?, ?, ?, ?)`,
+		providerID, nullString(sourceIP), nullString(userAgent), outcome, timeText(now))
+	return err
+}
+
+func (s *Store) ListPairOTMintLog(ctx context.Context, providerID string) ([]PairOTMintLogRecord, error) {
+	query := `SELECT id, provider_id, source_ip, user_agent, outcome, ts FROM pair_ot_mint_log`
+	args := []any{}
+	if strings.TrimSpace(providerID) != "" {
+		query += ` WHERE provider_id = ?`
+		args = append(args, strings.TrimSpace(providerID))
+	}
+	query += ` ORDER BY ts DESC, id DESC`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PairOTMintLogRecord
+	for rows.Next() {
+		var r PairOTMintLogRecord
+		if err := rows.Scan(&r.ID, &r.ProviderID, &r.SourceIP, &r.UserAgent, &r.Outcome, &r.TS); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) BindPairOT(ctx context.Context, sessionID, pairOT string, now time.Time, enqueue func(BindResult) error) (BindResult, error) {
+	pairOT = strings.TrimSpace(pairOT)
+	if pairOT == "" {
+		return BindResult{}, ErrPendingPairOTMissing
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return BindResult{}, err
+	}
+	defer tx.Rollback()
+	nowText := timeText(now)
+	var providerID string
+	err = tx.QueryRowContext(ctx, `
+UPDATE pair_ots
+   SET used_at = ?
+ WHERE id = ?
+   AND used_at IS NULL
+   AND expires_at > ?
+RETURNING provider_id`, nowText, pairOT, nowText).Scan(&providerID)
+	if err == sql.ErrNoRows {
+		return BindResult{}, ErrPairOTInvalid
+	}
+	if err != nil {
+		return BindResult{}, err
+	}
+	var githubUserID int64
+	var githubLogin string
+	err = tx.QueryRowContext(ctx, `
+SELECT s.github_user_id, g.github_login
+  FROM mp_sessions s
+  JOIN github_identities g ON g.github_user_id = s.github_user_id
+ WHERE s.id = ? AND s.last_seen_at >= ?`,
+		sessionID, timeText(now.AddDate(0, 0, -30))).Scan(&githubUserID, &githubLogin)
+	if err == sql.ErrNoRows {
+		return BindResult{}, ErrSessionInvalid
+	}
+	if err != nil {
+		return BindResult{}, err
+	}
+	claimedAt := nowText
+	err = tx.QueryRowContext(ctx, `
+INSERT INTO provider_ownership (provider_id, github_user_id, claimed_at)
+VALUES (?, ?, ?)
+ON CONFLICT(provider_id) DO NOTHING
+RETURNING claimed_at`, providerID, githubUserID, claimedAt).Scan(&claimedAt)
+	if err == sql.ErrNoRows {
+		var existingUserID int64
+		err = tx.QueryRowContext(ctx, `SELECT github_user_id, claimed_at FROM provider_ownership WHERE provider_id = ?`, providerID).Scan(&existingUserID, &claimedAt)
+		if err != nil {
+			return BindResult{}, err
+		}
+		if existingUserID != githubUserID {
+			if commitErr := tx.Commit(); commitErr != nil {
+				return BindResult{}, commitErr
+			}
+			return BindResult{}, ErrPairOTAlreadyOwned
+		}
+	} else if err != nil {
+		return BindResult{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE mp_sessions SET last_seen_at = ? WHERE id = ?`, nowText, sessionID); err != nil {
+		return BindResult{}, err
+	}
+	result := BindResult{ProviderID: providerID, GitHubLogin: githubLogin, ClaimedAt: claimedAt}
+	if enqueue != nil {
+		if err := enqueue(result); err != nil {
+			return BindResult{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return BindResult{}, err
+	}
+	return result, nil
+}
+
+func (s *Store) PruneGitHubAuthState(ctx context.Context, now time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+DELETE FROM pair_ots WHERE expires_at < ?;
+DELETE FROM oauth_states WHERE expires_at < ?;
+UPDATE mp_sessions
+   SET pending_pair_ot = NULL,
+       pending_pair_ot_expires_at = NULL
+ WHERE pending_pair_ot IS NOT NULL
+   AND pending_pair_ot_expires_at < ?;
+DELETE FROM mp_sessions WHERE last_seen_at < ?;
+DELETE FROM pair_ot_mint_log WHERE ts < ?;`,
+		timeText(now.Add(-24*time.Hour)),
+		timeText(now.Add(-24*time.Hour)),
+		timeText(now),
+		timeText(now.AddDate(0, 0, -30)),
+		timeText(now.AddDate(0, 0, -90)),
+	)
+	return err
+}
+
 func (s *Store) tokenByID(ctx context.Context, id int64) (TokenRecord, error) {
 	var r TokenRecord
 	err := s.db.QueryRowContext(ctx, `SELECT id, token_prefix, provider_id, provider_name, created_at, revoked_at, last_used_at FROM provider_tokens WHERE id = ?`, id).
@@ -611,6 +1209,46 @@ func tokenHash(token string) string {
 	return hex.EncodeToString(sum[:])
 }
 
+func randomHex(n int) (string, error) {
+	raw := make([]byte, n)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw), nil
+}
+
 func nowString() string {
 	return time.Now().UTC().Format("2006-01-02T15:04:05Z")
+}
+
+func timeText(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}
+
+func parseTimeOrZero(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t.UTC()
+}
+
+func nullString(v string) sql.NullString {
+	v = strings.TrimSpace(v)
+	return sql.NullString{String: v, Valid: v != ""}
+}
+
+func retryAfterSeconds(oldest sql.NullString, now time.Time) int {
+	if !oldest.Valid {
+		return 3600
+	}
+	oldestAt, err := time.Parse(time.RFC3339, oldest.String)
+	if err != nil {
+		return 3600
+	}
+	retryAfter := int(oldestAt.Add(time.Hour).Sub(now).Seconds())
+	if retryAfter < 1 {
+		return 1
+	}
+	return retryAfter
 }

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -54,8 +54,8 @@ type PoolConfig struct {
 	// chunks count as activity and keep the socket alive. Decoupled from
 	// routing.failover_timeout_s (which governs replacement selection, not
 	// liveness). Defaults to 90s (3x the 30s heartbeat interval).
-	HeartbeatMissThresholdS int  `yaml:"heartbeat_miss_threshold_s"`
-	WakeGapThresholdS       int  `yaml:"wake_gap_threshold_s"`
+	HeartbeatMissThresholdS int `yaml:"heartbeat_miss_threshold_s"`
+	WakeGapThresholdS       int `yaml:"wake_gap_threshold_s"`
 	// WakeGapThresholdMs, when > 0, overrides WakeGapThresholdS for
 	// millisecond-precision test scenarios. Not for production use.
 	WakeGapThresholdMs      int  `yaml:"wake_gap_threshold_ms"`
@@ -170,7 +170,17 @@ type AuthConfig struct {
 	// RequireProviderTokens fails closed for public provider WebSocket
 	// exposure. Disable only for isolated local development or one-off
 	// migrations where anonymous pinned-provider admission is acceptable.
-	RequireProviderTokens bool `yaml:"require_provider_tokens"`
+	RequireProviderTokens bool              `yaml:"require_provider_tokens"`
+	GitHubOAuth           GitHubOAuthConfig `yaml:"github_oauth"`
+}
+
+type GitHubOAuthConfig struct {
+	Enabled             bool   `yaml:"enabled"`
+	ClientID            string `yaml:"client_id"`
+	ClientSecret        string `yaml:"client_secret"`
+	RedirectURI         string `yaml:"redirect_uri"`
+	PortalBaseURL       string `yaml:"portal_base_url"`
+	SessionCookieDomain string `yaml:"session_cookie_domain"`
 }
 
 type StorageConfig struct {
@@ -287,10 +297,10 @@ func Default() Config {
 			MaxChatRequestBodyBytes: 1 << 20,
 		},
 		WS: WSConfig{
-			WriteBufferSize:        64,
-			HandshakeTimeoutS:      10,
-			WriteTimeoutS:          10,
-			MaxFrameBytes:          4 << 20,
+			WriteBufferSize:             64,
+			HandshakeTimeoutS:           10,
+			WriteTimeoutS:               10,
+			MaxFrameBytes:               4 << 20,
 			MaxUnauthenticatedConn:      64,
 			MaxUnauthenticatedConnPerIP: 4,
 		},
@@ -422,6 +432,33 @@ func (c *Config) resolveEnv() error {
 	} else {
 		c.Auth.GatewayServiceToken = v
 	}
+	if raw, ok := os.LookupEnv("GITHUB_OAUTH_ENABLED"); ok {
+		switch raw {
+		case "true":
+			c.Auth.GitHubOAuth.Enabled = true
+		case "false":
+			c.Auth.GitHubOAuth.Enabled = false
+		default:
+			return fmt.Errorf("GITHUB_OAUTH_ENABLED must be \"true\" or \"false\"")
+		}
+	}
+	if c.Auth.GitHubOAuth.Enabled {
+		if v := strings.TrimSpace(os.Getenv("GITHUB_OAUTH_CLIENT_ID")); v != "" {
+			c.Auth.GitHubOAuth.ClientID = v
+		}
+		if v := strings.TrimSpace(os.Getenv("GITHUB_OAUTH_CLIENT_SECRET")); v != "" {
+			c.Auth.GitHubOAuth.ClientSecret = v
+		}
+		if v := strings.TrimSpace(os.Getenv("GITHUB_OAUTH_REDIRECT_URI")); v != "" {
+			c.Auth.GitHubOAuth.RedirectURI = v
+		}
+		if v := strings.TrimSpace(os.Getenv("PORTAL_BASE_URL")); v != "" {
+			c.Auth.GitHubOAuth.PortalBaseURL = strings.TrimRight(v, "/")
+		}
+		if v := strings.TrimSpace(os.Getenv("MP_SESSION_COOKIE_DOMAIN")); v != "" {
+			c.Auth.GitHubOAuth.SessionCookieDomain = v
+		}
+	}
 	return nil
 }
 
@@ -514,6 +551,9 @@ func (c Config) ProviderByID() map[string]ProviderConfig {
 func (c Config) Validate() error {
 	if c.Auth.OperatorKey == "" {
 		return fmt.Errorf("auth.operator_key must be set")
+	}
+	if err := c.validateGitHubOAuth(); err != nil {
+		return err
 	}
 	if c.WS.WriteBufferSize <= 0 {
 		return fmt.Errorf("ws.write_buffer_size must be > 0")
@@ -695,6 +735,35 @@ func (c Config) Validate() error {
 			if err := ValidateEndpointURL(p.EndpointURL); err != nil {
 				return fmt.Errorf("provider %q endpoint_url must be a valid https URL (http allowed only for 127.0.0.1/localhost)", p.ProviderID)
 			}
+		}
+	}
+	return nil
+}
+
+func (c Config) validateGitHubOAuth() error {
+	oauth := c.Auth.GitHubOAuth
+	if !oauth.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(oauth.ClientID) == "" {
+		return fmt.Errorf("GITHUB_OAUTH_CLIENT_ID must be set when GITHUB_OAUTH_ENABLED=true")
+	}
+	if strings.TrimSpace(oauth.ClientSecret) == "" {
+		return fmt.Errorf("GITHUB_OAUTH_CLIENT_SECRET must be set when GITHUB_OAUTH_ENABLED=true")
+	}
+	redirect, err := url.Parse(strings.TrimSpace(oauth.RedirectURI))
+	if err != nil || redirect.Scheme != "https" || redirect.Host == "" || redirect.Path != "/v1/auth/github/callback" || redirect.RawQuery != "" || redirect.Fragment != "" {
+		return fmt.Errorf("GITHUB_OAUTH_REDIRECT_URI must be https://.../v1/auth/github/callback when GITHUB_OAUTH_ENABLED=true")
+	}
+	portal, err := url.Parse(strings.TrimSpace(oauth.PortalBaseURL))
+	if err != nil || portal.Scheme != "https" || portal.Host == "" || portal.Path != "" || portal.RawQuery != "" || portal.Fragment != "" || portal.User != nil {
+		return fmt.Errorf("PORTAL_BASE_URL must be https://<host>[:<port>] with no path or query when GITHUB_OAUTH_ENABLED=true")
+	}
+	if oauth.SessionCookieDomain != "" {
+		domain := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(oauth.SessionCookieDomain)), ".")
+		host := strings.ToLower(portal.Hostname())
+		if domain == "" || host != domain && !strings.HasSuffix(host, "."+domain) {
+			return fmt.Errorf("MP_SESSION_COOKIE_DOMAIN must match PORTAL_BASE_URL host scope")
 		}
 	}
 	return nil

--- a/phase4-coordinator/internal/github/client.go
+++ b/phase4-coordinator/internal/github/client.go
@@ -1,0 +1,117 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	DefaultAuthorizeURL = "https://github.com/login/oauth/authorize"
+	DefaultTokenURL     = "https://github.com/login/oauth/access_token"
+	DefaultUserURL      = "https://api.github.com/user"
+)
+
+type User struct {
+	ID    int64  `json:"id"`
+	Login string `json:"login"`
+}
+
+type Client struct {
+	HTTPClient *http.Client
+	TokenURL   string
+	UserURL    string
+}
+
+func (c Client) ExchangeCode(ctx context.Context, clientID, clientSecret, redirectURI, code string) (string, error) {
+	endpoint := c.TokenURL
+	if endpoint == "" {
+		endpoint = DefaultTokenURL
+	}
+	body, _ := json.Marshal(map[string]string{
+		"client_id":     clientID,
+		"client_secret": clientSecret,
+		"redirect_uri":  redirectURI,
+		"code":          code,
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("github token exchange status %d", resp.StatusCode)
+	}
+	var out struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	if out.Error != "" || out.AccessToken == "" {
+		if out.Error == "" {
+			out.Error = "missing_access_token"
+		}
+		return "", fmt.Errorf("github token exchange failed: %s", out.Error)
+	}
+	return out.AccessToken, nil
+}
+
+func (c Client) User(ctx context.Context, accessToken string) (User, error) {
+	endpoint := c.UserURL
+	if endpoint == "" {
+		endpoint = DefaultUserURL
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return User{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return User{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return User{}, fmt.Errorf("github user lookup status %d", resp.StatusCode)
+	}
+	var user User
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return User{}, err
+	}
+	if user.ID <= 0 || user.Login == "" {
+		return User{}, fmt.Errorf("github user response missing id/login")
+	}
+	return user, nil
+}
+
+func AuthorizeURL(clientID, redirectURI, state string) string {
+	q := url.Values{}
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", "read:user")
+	q.Set("state", state)
+	return DefaultAuthorizeURL + "?" + q.Encode()
+}
+
+func (c Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return &http.Client{Timeout: 10 * time.Second}
+}

--- a/phase4-coordinator/internal/session/cookie.go
+++ b/phase4-coordinator/internal/session/cookie.go
@@ -1,0 +1,31 @@
+package session
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const Name = "mp_session"
+const MaxAgeSeconds = 2592000
+
+func SetCookie(w http.ResponseWriter, id, domain string) {
+	header := fmt.Sprintf("mp_session=%s; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=2592000", id)
+	if strings.TrimSpace(domain) != "" {
+		header += "; Domain=" + strings.TrimSpace(domain)
+	}
+	w.Header().Add("Set-Cookie", header)
+}
+
+func ClearCookie(w http.ResponseWriter, domain string) {
+	header := "mp_session=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0"
+	if strings.TrimSpace(domain) != "" {
+		header += "; Domain=" + strings.TrimSpace(domain)
+	}
+	w.Header().Add("Set-Cookie", header)
+}
+
+func NeedsReissue(lastSet time.Time, now time.Time) bool {
+	return lastSet.IsZero() || now.Sub(lastSet) >= 24*time.Hour
+}

--- a/phase4-coordinator/internal/session/cookie_test.go
+++ b/phase4-coordinator/internal/session/cookie_test.go
@@ -1,0 +1,53 @@
+package session
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSetCookieHeader_ExactAttributes(t *testing.T) {
+	rr := httptest.NewRecorder()
+	SetCookie(rr, "sess-123", "")
+	got := rr.Header().Get("Set-Cookie")
+	wantParts := []string{"mp_session=sess-123", "HttpOnly", "Secure", "SameSite=Lax", "Path=/", "Max-Age=2592000"}
+	for _, part := range wantParts {
+		if !strings.Contains(got, part) {
+			t.Fatalf("Set-Cookie %q missing %q", got, part)
+		}
+	}
+	if strings.Contains(strings.ToLower(got), "domain=") {
+		t.Fatalf("Set-Cookie %q must omit Domain by default", got)
+	}
+}
+
+func TestSlidingSession_24hCookieReissue(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	if NeedsReissue(now.Add(-23*time.Hour), now) {
+		t.Fatalf("23h-old Set-Cookie should not reissue")
+	}
+	if !NeedsReissue(now.Add(-25*time.Hour), now) {
+		t.Fatalf("25h-old Set-Cookie should reissue")
+	}
+}
+
+func TestInvalidSession_401_Plus_ClearCookie_LogoutException_204(t *testing.T) {
+	rr := httptest.NewRecorder()
+	ClearCookie(rr, "")
+	got := rr.Header().Get("Set-Cookie")
+	if !strings.Contains(got, "mp_session=") || !strings.Contains(got, "Max-Age=0") {
+		t.Fatalf("clear cookie header = %q, want mp_session Max-Age=0", got)
+	}
+}
+
+func TestClearCookie_IncludesConfiguredDomain(t *testing.T) {
+	rr := httptest.NewRecorder()
+	ClearCookie(rr, ".example.com")
+	got := rr.Header().Get("Set-Cookie")
+	for _, part := range []string{"mp_session=", "Path=/", "Max-Age=0", "Domain=.example.com"} {
+		if !strings.Contains(got, part) {
+			t.Fatalf("clear cookie header = %q missing %q", got, part)
+		}
+	}
+}

--- a/phase4-coordinator/internal/ws/auth_github.go
+++ b/phase4-coordinator/internal/ws/auth_github.go
@@ -1,0 +1,491 @@
+package ws
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	mpgithub "github.com/augstar/macprovider-coordinator/internal/github"
+	"github.com/augstar/macprovider-coordinator/internal/session"
+)
+
+type githubOAuthClient interface {
+	ExchangeCode(context.Context, string, string, string, string) (string, error)
+	User(context.Context, string) (mpgithub.User, error)
+}
+
+var pairOTQueryPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,256}$`)
+var returnToPattern = regexp.MustCompile(`^/[A-Za-z0-9._~\-/?=&%:]*$`)
+
+func (s *Server) handleGitHubStart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.authStore == nil {
+		writeAuthError(w, http.StatusInternalServerError, "oauth_not_configured")
+		return
+	}
+	q, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		writeAuthError(w, http.StatusBadRequest, "bad_request")
+		return
+	}
+	pairValues, hasPair := q["pair_ot"]
+	if len(pairValues) > 1 {
+		writeAuthError(w, http.StatusBadRequest, "bad_request")
+		return
+	}
+	var pending *string
+	if hasPair {
+		value := pairValues[0]
+		if !pairOTQueryPattern.MatchString(value) {
+			writeAuthError(w, http.StatusBadRequest, "bad_request")
+			return
+		}
+		pending = &value
+	}
+	state, err := randomState()
+	if err != nil {
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	returnTo := normalizeReturnTo(q.Get("return_to"))
+	if err := s.authStore.CreateOAuthState(r.Context(), state, returnTo, pending, s.now()); err != nil {
+		s.log.Warn().Err(err).Msg("oauth state create failed")
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	http.Redirect(w, r, mpgithub.AuthorizeURL(s.cfg.Auth.GitHubOAuth.ClientID, s.cfg.Auth.GitHubOAuth.RedirectURI, state), http.StatusFound)
+}
+
+func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.authStore == nil {
+		writeAuthError(w, http.StatusInternalServerError, "oauth_not_configured")
+		return
+	}
+	state := strings.TrimSpace(r.URL.Query().Get("state"))
+	code := strings.TrimSpace(r.URL.Query().Get("code"))
+	if state == "" || code == "" {
+		writeAuthError(w, http.StatusBadRequest, "state_invalid")
+		return
+	}
+	consumed, ok, err := s.authStore.ConsumeOAuthState(r.Context(), state, s.now())
+	if err != nil {
+		s.log.Warn().Err(err).Msg("oauth state consume failed")
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	if !ok {
+		writeAuthError(w, http.StatusBadRequest, "state_invalid")
+		return
+	}
+	client := s.githubOAuth
+	if client == nil {
+		client = mpgithub.Client{}
+	}
+	accessToken, err := client.ExchangeCode(r.Context(), s.cfg.Auth.GitHubOAuth.ClientID, s.cfg.Auth.GitHubOAuth.ClientSecret, s.cfg.Auth.GitHubOAuth.RedirectURI, code)
+	if err != nil {
+		s.log.Warn().Err(err).Msg("github token exchange failed")
+		writeAuthError(w, http.StatusBadGateway, "github_token_exchange_failed")
+		return
+	}
+	user, err := client.User(r.Context(), accessToken)
+	if err != nil {
+		s.log.Warn().Err(err).Msg("github user lookup failed")
+		writeAuthError(w, http.StatusBadGateway, "github_user_lookup_failed")
+		return
+	}
+	now := s.now()
+	if err := s.authStore.UpsertGitHubIdentity(r.Context(), user.ID, user.Login, now); err != nil {
+		s.log.Warn().Err(err).Msg("github identity upsert failed")
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	sessionID, err := s.authStore.CreateMPSession(r.Context(), user.ID, consumed.PendingPairOT, now)
+	if err != nil {
+		s.log.Warn().Err(err).Msg("mp_session create failed")
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	session.SetCookie(w, sessionID, s.cfg.Auth.GitHubOAuth.SessionCookieDomain)
+	http.Redirect(w, r, consumed.ReturnTo, http.StatusFound)
+}
+
+func (s *Server) handleAuthMeProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	sess, ok := s.authenticateMPSession(w, r)
+	if !ok {
+		return
+	}
+	providers, err := s.authStore.ListOwnedProviders(r.Context(), sess.GitHubUserID)
+	if err != nil {
+		s.log.Warn().Err(err).Msg("owned providers list failed")
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	lastSeen := map[string]string{}
+	for _, p := range s.pool.Snapshot() {
+		lastSeen[p.ProviderID] = p.LastActivityAt.UTC().Format(time.RFC3339)
+	}
+	for i := range providers {
+		if providers[i].LastSeenAt == "" {
+			providers[i].LastSeenAt = lastSeen[providers[i].ProviderID]
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"providers": providers})
+}
+
+func (s *Server) handleAuthMeProvidersBind(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.authStore == nil {
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	sess, ok := s.authenticateMPSession(w, r)
+	if !ok {
+		return
+	}
+	bodyProvided := false
+	bodyPairOT := ""
+	if r.Body != nil {
+		var raw map[string]json.RawMessage
+		dec := json.NewDecoder(r.Body)
+		if err := dec.Decode(&raw); err != nil && !errors.Is(err, http.ErrBodyNotAllowed) {
+			writeAuthError(w, http.StatusBadRequest, "bad_request")
+			return
+		}
+		if raw == nil {
+			writeAuthError(w, http.StatusBadRequest, "bad_request")
+			return
+		}
+		var trailing json.RawMessage
+		if err := dec.Decode(&trailing); err != io.EOF {
+			writeAuthError(w, http.StatusBadRequest, "bad_request")
+			return
+		}
+		for key := range raw {
+			if key != "pair_ot" {
+				writeAuthError(w, http.StatusBadRequest, "bad_request")
+				return
+			}
+		}
+		if rawPairOT, ok := raw["pair_ot"]; ok {
+			var decoded string
+			if err := json.Unmarshal(rawPairOT, &decoded); err != nil || strings.TrimSpace(decoded) == "" {
+				writeAuthError(w, http.StatusBadRequest, "bad_request")
+				return
+			}
+			bodyProvided = true
+			bodyPairOT = strings.TrimSpace(decoded)
+		}
+	}
+	pairOT := bodyPairOT
+	if !bodyProvided {
+		var err error
+		pairOT, err = s.authStore.ConsumePendingPairOT(r.Context(), sess.ID, s.now())
+		if err != nil {
+			if errors.Is(err, auth.ErrPendingPairOTMissing) {
+				writeAuthError(w, http.StatusBadRequest, "bad_request")
+				return
+			}
+			s.log.Warn().Err(err).Msg("pending pair_ot consume failed")
+			writeAuthError(w, http.StatusInternalServerError, "internal_error")
+			return
+		}
+	}
+	result, err := s.authStore.BindPairOT(r.Context(), sess.ID, pairOT, s.now(), func(result auth.BindResult) error {
+		return s.pushOwnershipBound(result.ProviderID, result.GitHubLogin)
+	})
+	switch {
+	case err == nil:
+	case errors.Is(err, auth.ErrSessionInvalid):
+		session.ClearCookie(w, s.cfg.Auth.GitHubOAuth.SessionCookieDomain)
+		writeAuthError(w, http.StatusUnauthorized, "session_invalid")
+		return
+	case errors.Is(err, auth.ErrPendingPairOTMissing):
+		writeAuthError(w, http.StatusBadRequest, "bad_request")
+		return
+	case errors.Is(err, auth.ErrPairOTInvalid):
+		writeAuthError(w, http.StatusGone, "pair_ot_invalid")
+		return
+	case errors.Is(err, auth.ErrPairOTAlreadyOwned):
+		writeAuthError(w, http.StatusConflict, "already_owned")
+		return
+	default:
+		s.log.Warn().Err(err).Msg("pair_ot bind failed")
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"provider_id":  result.ProviderID,
+		"github_login": result.GitHubLogin,
+		"claimed_at":   result.ClaimedAt,
+	})
+}
+
+func (s *Server) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if cookie, err := r.Cookie(session.Name); err == nil && cookie.Value != "" && s.authStore != nil {
+		_ = s.authStore.DeleteMPSession(r.Context(), cookie.Value)
+	}
+	session.ClearCookie(w, s.cfg.Auth.GitHubOAuth.SessionCookieDomain)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleInstallPairRefresh(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	providerID, ok, err := s.providerIDFromBearer(r.Context(), r)
+	if err != nil {
+		s.log.Warn().Err(err).Msg("pair refresh token validation failed")
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	if !ok {
+		if err := s.logPairMint(r, "unknown", http.StatusUnauthorized); err != nil {
+			s.log.Warn().Err(err).Msg("pair refresh unauthenticated log failed")
+			writeAuthError(w, http.StatusInternalServerError, "internal_error")
+			return
+		}
+		writeAuthError(w, http.StatusUnauthorized, "unauthenticated")
+		return
+	}
+	now := s.now()
+	result, err := s.authStore.MintPairOTRefresh(r.Context(), providerID, remoteIP(r), r.UserAgent(), now)
+	if err != nil {
+		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("pair refresh mint failed")
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	if result.RateLimited {
+		w.Header().Set("Retry-After", fmt.Sprintf("%d", result.RetryAfter))
+		writeAuthError(w, http.StatusTooManyRequests, "rate_limited")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"pair_ot":    result.Mint.PairOT,
+		"claim_url":  s.claimURL(result.Mint.PairOT),
+		"expires_in": 600,
+	})
+}
+
+func (s *Server) authenticateMPSession(w http.ResponseWriter, r *http.Request) (auth.MPSession, bool) {
+	if s.authStore == nil {
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return auth.MPSession{}, false
+	}
+	cookie, err := r.Cookie(session.Name)
+	if err != nil || cookie.Value == "" {
+		session.ClearCookie(w, s.cfg.Auth.GitHubOAuth.SessionCookieDomain)
+		writeAuthError(w, http.StatusUnauthorized, "session_invalid")
+		return auth.MPSession{}, false
+	}
+	now := s.now()
+	sess, ok, err := s.authStore.LoadMPSession(r.Context(), cookie.Value, now)
+	if err != nil {
+		s.log.Warn().Err(err).Msg("mp_session load failed")
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return auth.MPSession{}, false
+	}
+	if !ok {
+		session.ClearCookie(w, s.cfg.Auth.GitHubOAuth.SessionCookieDomain)
+		writeAuthError(w, http.StatusUnauthorized, "session_invalid")
+		return auth.MPSession{}, false
+	}
+	reissue := session.NeedsReissue(sess.LastSetCookieAt, now)
+	if err := s.authStore.TouchMPSession(r.Context(), sess.ID, now, reissue); err != nil {
+		s.log.Warn().Err(err).Msg("mp_session touch failed")
+		writeAuthError(w, http.StatusInternalServerError, "internal_error")
+		return auth.MPSession{}, false
+	}
+	if reissue {
+		session.SetCookie(w, sess.ID, s.cfg.Auth.GitHubOAuth.SessionCookieDomain)
+	}
+	return sess, true
+}
+
+func (s *Server) providerIDFromBearer(ctx context.Context, r *http.Request) (string, bool, error) {
+	authz := strings.TrimSpace(r.Header.Get("Authorization"))
+	token, ok := strings.CutPrefix(authz, "Bearer ")
+	if !ok || strings.TrimSpace(token) == "" || s.authStore == nil {
+		return "", false, nil
+	}
+	return s.authStore.ValidateToken(ctx, strings.TrimSpace(token))
+}
+
+func (s *Server) logPairMint(r *http.Request, providerID string, outcome int) error {
+	if s.authStore == nil {
+		return nil
+	}
+	return s.authStore.LogPairOTMint(r.Context(), providerID, remoteIP(r), r.UserAgent(), outcome, s.now())
+}
+
+func (s *Server) pushOwnershipBound(providerID, githubLogin string) error {
+	event := OwnershipEvent{Type: "ownership_event", ProviderID: providerID, GitHubLogin: githubLogin, Event: "bound"}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	for _, p := range s.pool.Snapshot() {
+		if p.ProviderID != providerID {
+			continue
+		}
+		if sess, ok := s.sessionFor(p.ProviderID, p.AssignedID); ok {
+			if err := sess.send(payload); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Server) claimURL(pairOT string) string {
+	base := strings.TrimRight(s.cfg.Auth.GitHubOAuth.PortalBaseURL, "/")
+	return base + "/claim?ot=" + url.QueryEscape(pairOT)
+}
+
+func writeAuthError(w http.ResponseWriter, status int, code string) {
+	writeJSON(w, status, map[string]string{"error": code})
+}
+
+func normalizeReturnTo(v string) string {
+	if v == "" {
+		return "/"
+	}
+	if !validReturnTo(v) {
+		return "/"
+	}
+	decodedOnce, err := url.QueryUnescape(v)
+	if err != nil || !validReturnTo(decodedOnce) {
+		return "/"
+	}
+	return v
+}
+
+func validReturnTo(v string) bool {
+	return v != "" &&
+		strings.HasPrefix(v, "/") &&
+		!strings.HasPrefix(v, "//") &&
+		!strings.HasPrefix(v, `/\`) &&
+		!strings.Contains(v, `\`) &&
+		returnToPattern.MatchString(v)
+}
+
+func randomState() (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func remoteIP(r *http.Request) string {
+	for _, header := range []string{"X-Real-IP", "X-Forwarded-For"} {
+		v := strings.TrimSpace(r.Header.Get(header))
+		if v == "" {
+			continue
+		}
+		if header == "X-Forwarded-For" {
+			v = strings.TrimSpace(strings.Split(v, ",")[0])
+		}
+		if ip := net.ParseIP(v); ip != nil {
+			return ip.String()
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
+
+func (s *Server) redactedRequestLogMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.log.Info().
+			Str("method", r.Method).
+			Str("path", redactTokenQuery(r.URL)).
+			Msg("provider http request")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func redactTokenQuery(u *url.URL) string {
+	return redactTokenQueryDepth(u, 0)
+}
+
+func redactTokenQueryDepth(u *url.URL, depth int) string {
+	if u == nil {
+		return ""
+	}
+	clone := *u
+	if clone.RawQuery != "" {
+		if _, err := url.ParseQuery(clone.RawQuery); err != nil {
+			clone.RawQuery = "redacted=1"
+			return clone.RequestURI()
+		}
+	}
+	values := clone.Query()
+	changed := false
+	for _, key := range []string{"ot", "pair_ot", "code", "state"} {
+		current, ok := values[key]
+		if !ok {
+			continue
+		}
+		for i := range current {
+			current[i] = "REDACTED"
+		}
+		values[key] = current
+		changed = true
+	}
+	if depth < 2 {
+		if current, ok := values["return_to"]; ok {
+			for i, v := range current {
+				nested, err := url.Parse(v)
+				if err != nil || nested.RawQuery == "" {
+					continue
+				}
+				current[i] = redactTokenQueryDepth(nested, depth+1)
+				changed = true
+			}
+			values["return_to"] = current
+		}
+	}
+	if changed {
+		clone.RawQuery = values.Encode()
+	}
+	return clone.RequestURI()
+}

--- a/phase4-coordinator/internal/ws/auth_github_test.go
+++ b/phase4-coordinator/internal/ws/auth_github_test.go
@@ -1,0 +1,662 @@
+package ws
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	mpgithub "github.com/augstar/macprovider-coordinator/internal/github"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/session"
+	"github.com/rs/zerolog"
+)
+
+func TestReturnTo_RejectsOpenRedirectVectors(t *testing.T) {
+	tests := map[string]string{
+		"/":                   "/",
+		"/dashboard":          "/dashboard",
+		"//evil.example/path": "/",
+		`/\evil`:              "/",
+		"%2F%2Fevil.example":  "/",
+		"/foo?bar=baz":        "/foo?bar=baz",
+		"/bad@host":           "/",
+		"/bad%0Apath":         "/",
+	}
+	for input, want := range tests {
+		if got := normalizeReturnTo(input); got != want {
+			t.Fatalf("normalizeReturnTo(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestPairOTQueryPattern(t *testing.T) {
+	valid := []string{"abc", "ABC_123-xyz", "a"}
+	for _, v := range valid {
+		if !pairOTQueryPattern.MatchString(v) {
+			t.Fatalf("pair_ot %q should be valid", v)
+		}
+	}
+	invalid := []string{"", "has/slash", "has%2fescape", "line\nbreak"}
+	for _, v := range invalid {
+		if pairOTQueryPattern.MatchString(v) {
+			t.Fatalf("pair_ot %q should be invalid", v)
+		}
+	}
+}
+
+func TestGitHubAuthRoutes_Disabled_Return404(t *testing.T) {
+	s, _ := newSpec014AuthTestServer(t, false)
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/start", nil)
+	rr := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rr.Code)
+	}
+}
+
+func TestGitHubAuthDisabled_DoesNotInstallRequestLogMiddleware(t *testing.T) {
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	s, _ := newSpec014AuthTestServerWithClient(t, false, logger, fakeSpec014GitHubClient{})
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rr := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rr, req)
+
+	if strings.Contains(logs.String(), "provider http request") {
+		t.Fatalf("default-off handler emitted GitHub auth request log: %s", logs.String())
+	}
+}
+
+func TestGitHubStart_MalformedPairOTQuery_Returns400(t *testing.T) {
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	s, _ := newSpec014AuthTestServerWithClient(t, true, logger, fakeSpec014GitHubClient{})
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/start?pair_ot=SECRET;x=1", nil)
+	rr := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rr, req)
+
+	assertAuthError(t, rr, http.StatusBadRequest, "bad_request")
+	if strings.Contains(logs.String(), "SECRET") {
+		t.Fatalf("request log leaked malformed pair_ot: %s", logs.String())
+	}
+}
+
+func TestGitHubCallback_StateRace_OneSucceedsOneInvalid(t *testing.T) {
+	s, store := newSpec014AuthTestServer(t, true)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	if err := store.CreateOAuthState(context.Background(), "race-state", "/", nil, now); err != nil {
+		t.Fatalf("CreateOAuthState: %v", err)
+	}
+	handler := s.Handler()
+	codes := make(chan int, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/callback?state=race-state&code=ok", nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			codes <- rr.Code
+		}()
+	}
+	wg.Wait()
+	close(codes)
+
+	counts := map[int]int{}
+	for code := range codes {
+		counts[code]++
+	}
+	if counts[http.StatusFound] != 1 || counts[http.StatusBadRequest] != 1 {
+		t.Fatalf("status counts = %#v, want one 302 and one 400", counts)
+	}
+}
+
+func TestGitHubCallback_RequestLogRedactsCodeAndState(t *testing.T) {
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	s, _ := newSpec014AuthTestServerWithClient(t, true, logger, fakeSpec014GitHubClient{})
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/callback?code=SECRET_CODE&state=SECRET_STATE", nil)
+	rr := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rr, req)
+
+	if strings.Contains(logs.String(), "SECRET_CODE") || strings.Contains(logs.String(), "SECRET_STATE") {
+		t.Fatalf("request log leaked oauth code/state: %s", logs.String())
+	}
+}
+
+func TestRandomState_EntropySanity(t *testing.T) {
+	seen := map[string]struct{}{}
+	for i := 0; i < 10000; i++ {
+		state, err := randomState()
+		if err != nil {
+			t.Fatalf("randomState: %v", err)
+		}
+		if len(state) != 64 {
+			t.Fatalf("state length = %d, want 64 hex chars", len(state))
+		}
+		if _, err := hex.DecodeString(state); err != nil {
+			t.Fatalf("state is not hex: %v", err)
+		}
+		if _, ok := seen[state]; ok {
+			t.Fatalf("duplicate state after %d iterations", i)
+		}
+		seen[state] = struct{}{}
+	}
+}
+
+func TestLogout_StaleCookie_Returns204AndClearsCookie(t *testing.T) {
+	s, _ := newSpec014AuthTestServer(t, true)
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: session.Name, Value: "stale"})
+	rr := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rr.Code)
+	}
+	if got := rr.Header().Get("Set-Cookie"); !strings.Contains(got, "mp_session=") || !strings.Contains(got, "Max-Age=0") || !strings.Contains(got, "Path=/") {
+		t.Fatalf("Set-Cookie = %q, want mp_session clear", got)
+	}
+}
+
+func TestLogout_ConfiguredDomainCookie_ClearIncludesDomain(t *testing.T) {
+	s, _ := newSpec014AuthTestServer(t, true)
+	s.cfg.Auth.GitHubOAuth.SessionCookieDomain = ".example.com"
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: session.Name, Value: "stale"})
+	rr := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rr.Code)
+	}
+	if got := rr.Header().Get("Set-Cookie"); !strings.Contains(got, "Domain=.example.com") {
+		t.Fatalf("Set-Cookie = %q, want configured Domain clear", got)
+	}
+}
+
+func TestAuthMeProviders_TamperedCookie_Returns401AndClearsCookie(t *testing.T) {
+	s, _ := newSpec014AuthTestServer(t, true)
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/me/providers", nil)
+	req.AddCookie(&http.Cookie{Name: session.Name, Value: "tampered"})
+	rr := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rr, req)
+
+	assertAuthError(t, rr, http.StatusUnauthorized, "session_invalid")
+	if got := rr.Header().Get("Set-Cookie"); !strings.Contains(got, "mp_session=") || !strings.Contains(got, "Max-Age=0") || !strings.Contains(got, "Path=/") {
+		t.Fatalf("Set-Cookie = %q, want mp_session clear", got)
+	}
+}
+
+func TestInstallPairRefresh_RateLimitUsesRefreshSuccessLog(t *testing.T) {
+	s, store := newSpec014AuthTestServer(t, true)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	_, token, err := store.IssueToken(context.Background(), "provider-a", "Provider A")
+	if err != nil {
+		t.Fatalf("IssueToken: %v", err)
+	}
+	handler := s.Handler()
+
+	for i := 0; i < 6; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v1/install/pair/refresh", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.RemoteAddr = "203.0.113.10:1234"
+		req.Header.Set("User-Agent", "spec014-test")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if i < 5 && rr.Code != http.StatusOK {
+			t.Fatalf("refresh %d status = %d, want 200 body=%s", i, rr.Code, rr.Body.String())
+		}
+		if i == 5 {
+			if rr.Code != http.StatusTooManyRequests {
+				t.Fatalf("sixth refresh status = %d, want 429 body=%s", rr.Code, rr.Body.String())
+			}
+			if rr.Header().Get("Retry-After") == "" {
+				t.Fatalf("sixth refresh missing Retry-After")
+			}
+		}
+	}
+	logs, err := store.ListPairOTMintLog(context.Background(), "provider-a")
+	if err != nil {
+		t.Fatalf("ListPairOTMintLog: %v", err)
+	}
+	if len(logs) != 6 {
+		t.Fatalf("mint log rows = %d, want 6", len(logs))
+	}
+	var okRows, rateLimitedRows int
+	for _, row := range logs {
+		switch row.Outcome {
+		case http.StatusOK:
+			okRows++
+		case http.StatusTooManyRequests:
+			rateLimitedRows++
+		}
+	}
+	if okRows != 5 || rateLimitedRows != 1 {
+		t.Fatalf("mint log outcomes ok=%d rate_limited=%d, want 5/1", okRows, rateLimitedRows)
+	}
+}
+
+func TestInstallPairRefresh_UnauthenticatedWrites401Log(t *testing.T) {
+	s, store := newSpec014AuthTestServer(t, true)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	req := httptest.NewRequest(http.MethodPost, "/v1/install/pair/refresh", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	req.Header.Set("User-Agent", "spec014-unauth-test")
+	rr := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rr, req)
+
+	assertAuthError(t, rr, http.StatusUnauthorized, "unauthenticated")
+	logs, err := store.ListPairOTMintLog(context.Background(), "unknown")
+	if err != nil {
+		t.Fatalf("ListPairOTMintLog: %v", err)
+	}
+	if len(logs) != 1 || logs[0].Outcome != http.StatusUnauthorized {
+		t.Fatalf("mint log rows = %#v, want one 401 unknown row", logs)
+	}
+}
+
+func TestInstallPairRefresh_ConcurrentRequestsCappedAtFive(t *testing.T) {
+	s, store := newSpec014AuthTestServer(t, true)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	_, token, err := store.IssueToken(context.Background(), "provider-a", "Provider A")
+	if err != nil {
+		t.Fatalf("IssueToken: %v", err)
+	}
+	handler := s.Handler()
+	const requests = 20
+	codes := make(chan int, requests)
+	var wg sync.WaitGroup
+	for i := 0; i < requests; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodPost, "/v1/install/pair/refresh", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.RemoteAddr = "203.0.113.10:1234"
+			req.Header.Set("User-Agent", "spec014-concurrent-test")
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			codes <- rr.Code
+		}(i)
+	}
+	wg.Wait()
+	close(codes)
+	counts := map[int]int{}
+	for code := range codes {
+		counts[code]++
+	}
+	if counts[http.StatusOK] != 5 || counts[http.StatusTooManyRequests] != requests-5 {
+		t.Fatalf("status counts = %#v, want 5x200 and %dx429", counts, requests-5)
+	}
+	logs, err := store.ListPairOTMintLog(context.Background(), "provider-a")
+	if err != nil {
+		t.Fatalf("ListPairOTMintLog: %v", err)
+	}
+	if len(logs) != requests {
+		t.Fatalf("mint log rows = %d, want %d", len(logs), requests)
+	}
+}
+
+func TestPushOwnershipBound_ReturnsConnectedSessionEnqueueError(t *testing.T) {
+	registry := pool.NewRegistry(nil)
+	p := &pool.Provider{ProviderID: "provider-a", AssignedID: "assigned-a", ModelID: "model-a"}
+	if _, ok := registry.Register(p, nil); !ok {
+		t.Fatalf("Register provider failed")
+	}
+	s := NewServer(config.Default(), registry, zerolog.Nop())
+	ps := newProviderSession("provider-a", "assigned-a", nil, 1)
+	ps.writeCh <- providerFrame{payload: []byte("occupied")}
+	s.sessions.Store(sessionKey("provider-a", "assigned-a"), ps)
+
+	if err := s.pushOwnershipBound("provider-a", "octo"); !errors.Is(err, ErrRelayBackpressure) {
+		t.Fatalf("pushOwnershipBound err = %v, want ErrRelayBackpressure", err)
+	}
+}
+
+func TestBindEndpoint_EmptyBodyConsumesPendingHintAndReissuesCookie(t *testing.T) {
+	s, store := newSpec014AuthTestServer(t, true)
+	ctx := context.Background()
+	old := time.Date(2026, 6, 20, 10, 0, 0, 0, time.UTC)
+	now := old.Add(25 * time.Hour)
+	s.now = func() time.Time { return now }
+	sessionID, pairOT := seedSpec014HTTPBindState(t, store, now)
+	if _, err := store.DB().ExecContext(ctx, `
+UPDATE mp_sessions
+   SET pending_pair_ot = ?,
+       pending_pair_ot_expires_at = ?,
+       last_seen_at = ?,
+       last_setcookie_at = ?
+ WHERE id = ?`,
+		pairOT,
+		timeTextForSpec014HTTPTest(now.Add(10*time.Minute)),
+		timeTextForSpec014HTTPTest(old),
+		timeTextForSpec014HTTPTest(old),
+		sessionID,
+	); err != nil {
+		t.Fatalf("seed pending pair_ot: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/me/providers/bind", strings.NewReader("{}"))
+	req.AddCookie(&http.Cookie{Name: session.Name, Value: sessionID})
+	rr := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Set-Cookie"); !strings.Contains(got, "mp_session="+sessionID) || !strings.Contains(got, "Max-Age=2592000") {
+		t.Fatalf("Set-Cookie = %q, want sliding cookie reissue", got)
+	}
+	owned, err := store.ListOwnedProviders(ctx, 42)
+	if err != nil {
+		t.Fatalf("ListOwnedProviders: %v", err)
+	}
+	if len(owned) != 1 || owned[0].ProviderID != "provider-a" {
+		t.Fatalf("owned providers = %#v, want provider-a", owned)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/v1/auth/me/providers/bind", strings.NewReader("{}"))
+	req.AddCookie(&http.Cookie{Name: session.Name, Value: sessionID})
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("second empty bind status = %d, want 400", rr.Code)
+	}
+}
+
+func TestAuthErrorTaxonomy_DeclaredErrors(t *testing.T) {
+	t.Run("400_bad_request", func(t *testing.T) {
+		s, _ := newSpec014AuthTestServer(t, true)
+		req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/start?pair_ot=a&pair_ot=b", nil)
+		rr := httptest.NewRecorder()
+		s.Handler().ServeHTTP(rr, req)
+		assertAuthError(t, rr, http.StatusBadRequest, "bad_request")
+	})
+	t.Run("401_session_invalid", func(t *testing.T) {
+		s, _ := newSpec014AuthTestServer(t, true)
+		req := httptest.NewRequest(http.MethodGet, "/v1/auth/me/providers", nil)
+		rr := httptest.NewRecorder()
+		s.Handler().ServeHTTP(rr, req)
+		assertAuthError(t, rr, http.StatusUnauthorized, "session_invalid")
+	})
+	t.Run("409_already_owned", func(t *testing.T) {
+		s, store := newSpec014AuthTestServer(t, true)
+		now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+		s.now = func() time.Time { return now }
+		sessionID, pairOT := seedSpec014HTTPBindState(t, store, now)
+		if err := store.UpsertGitHubIdentity(context.Background(), 99, "other", now); err != nil {
+			t.Fatalf("UpsertGitHubIdentity other: %v", err)
+		}
+		if _, err := store.DB().ExecContext(context.Background(), `INSERT INTO provider_ownership (provider_id, github_user_id, claimed_at) VALUES (?, ?, ?)`, "provider-a", 99, timeTextForSpec014HTTPTest(now)); err != nil {
+			t.Fatalf("seed ownership: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/v1/auth/me/providers/bind", strings.NewReader(`{"pair_ot":"`+pairOT+`"}`))
+		req.AddCookie(&http.Cookie{Name: session.Name, Value: sessionID})
+		rr := httptest.NewRecorder()
+		s.Handler().ServeHTTP(rr, req)
+		assertAuthError(t, rr, http.StatusConflict, "already_owned")
+	})
+	t.Run("410_pair_ot_invalid", func(t *testing.T) {
+		s, store := newSpec014AuthTestServer(t, true)
+		now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+		s.now = func() time.Time { return now }
+		sessionID, _ := seedSpec014HTTPBindState(t, store, now)
+		req := httptest.NewRequest(http.MethodPost, "/v1/auth/me/providers/bind", strings.NewReader(`{"pair_ot":"missingtoken"}`))
+		req.AddCookie(&http.Cookie{Name: session.Name, Value: sessionID})
+		rr := httptest.NewRecorder()
+		s.Handler().ServeHTTP(rr, req)
+		assertAuthError(t, rr, http.StatusGone, "pair_ot_invalid")
+	})
+	t.Run("429_rate_limited", func(t *testing.T) {
+		s, store := newSpec014AuthTestServer(t, true)
+		now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+		s.now = func() time.Time { return now }
+		_, token, err := store.IssueToken(context.Background(), "provider-a", "Provider A")
+		if err != nil {
+			t.Fatalf("IssueToken: %v", err)
+		}
+		for i := 0; i < 5; i++ {
+			if err := store.LogPairOTMint(context.Background(), "provider-a", "127.0.0.1", "test", http.StatusOK, now.Add(time.Duration(i)*time.Minute)); err != nil {
+				t.Fatalf("seed mint log %d: %v", i, err)
+			}
+		}
+		req := httptest.NewRequest(http.MethodPost, "/v1/install/pair/refresh", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rr := httptest.NewRecorder()
+		s.Handler().ServeHTTP(rr, req)
+		assertAuthError(t, rr, http.StatusTooManyRequests, "rate_limited")
+		if rr.Header().Get("Retry-After") == "" {
+			t.Fatalf("missing Retry-After")
+		}
+	})
+	t.Run("502_github_token_exchange_failed", func(t *testing.T) {
+		client := fakeSpec014GitHubClient{exchangeErr: errors.New("exchange failed")}
+		s, store := newSpec014AuthTestServerWithClient(t, true, zerolog.Nop(), client)
+		now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+		s.now = func() time.Time { return now }
+		if err := store.CreateOAuthState(context.Background(), "state", "/", nil, now); err != nil {
+			t.Fatalf("CreateOAuthState: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/callback?state=state&code=ok", nil)
+		rr := httptest.NewRecorder()
+		s.Handler().ServeHTTP(rr, req)
+		assertAuthError(t, rr, http.StatusBadGateway, "github_token_exchange_failed")
+	})
+}
+
+func TestBindEndpoint_RejectsInvalidJSONBodies(t *testing.T) {
+	tests := map[string]string{
+		"empty":          "",
+		"null_pair_ot":   `{"pair_ot":null}`,
+		"blank_pair_ot":  `{"pair_ot":" "}`,
+		"unknown_field":  `{"extra":1}`,
+		"trailing_token": `{} {}`,
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			s, store := newSpec014AuthTestServer(t, true)
+			now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+			s.now = func() time.Time { return now }
+			sessionID, _ := seedSpec014HTTPBindState(t, store, now)
+			req := httptest.NewRequest(http.MethodPost, "/v1/auth/me/providers/bind", strings.NewReader(body))
+			req.AddCookie(&http.Cookie{Name: session.Name, Value: sessionID})
+			rr := httptest.NewRecorder()
+
+			s.Handler().ServeHTTP(rr, req)
+
+			assertAuthError(t, rr, http.StatusBadRequest, "bad_request")
+		})
+	}
+}
+
+func TestRedactTokenQuery_RemovesPairTokens(t *testing.T) {
+	u, err := url.Parse("/v1/auth/github/start?pair_ot=SECRET&return_to=%2Fclaim%3Fot%3DSECRET2&x=1")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	redacted := redactTokenQuery(u)
+	if strings.Contains(redacted, "SECRET") || strings.Contains(redacted, "SECRET2") {
+		t.Fatalf("redacted path leaked token: %q", redacted)
+	}
+	if !strings.Contains(redacted, "pair_ot=REDACTED") {
+		t.Fatalf("redacted path = %q, want pair_ot redacted", redacted)
+	}
+
+	u, err = url.Parse("/claim?ot=SECRET")
+	if err != nil {
+		t.Fatalf("parse claim url: %v", err)
+	}
+	redacted = redactTokenQuery(u)
+	if redacted != "/claim?ot=REDACTED" {
+		t.Fatalf("redacted claim path = %q, want /claim?ot=REDACTED", redacted)
+	}
+
+	u, err = url.Parse("/v1/auth/github/start?pair_ot=SECRET;x=1")
+	if err != nil {
+		t.Fatalf("parse malformed url: %v", err)
+	}
+	redacted = redactTokenQuery(u)
+	if strings.Contains(redacted, "SECRET") || !strings.Contains(redacted, "redacted=1") {
+		t.Fatalf("malformed redacted path = %q, want no token and redacted marker", redacted)
+	}
+
+	u, err = url.Parse("/v1/auth/github/callback?code=SECRET_CODE&state=SECRET_STATE")
+	if err != nil {
+		t.Fatalf("parse callback url: %v", err)
+	}
+	redacted = redactTokenQuery(u)
+	if strings.Contains(redacted, "SECRET_CODE") || strings.Contains(redacted, "SECRET_STATE") {
+		t.Fatalf("callback redacted path leaked oauth params: %q", redacted)
+	}
+}
+
+func TestRedactedRequestLogMiddleware_RedactsMalformedTokenQueries(t *testing.T) {
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	s, _ := newSpec014AuthTestServerWithClient(t, true, logger, fakeSpec014GitHubClient{})
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/start?pair_ot=SECRET;x=1", nil)
+	rr := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rr, req)
+
+	if strings.Contains(logs.String(), "SECRET") {
+		t.Fatalf("request log leaked token: %s", logs.String())
+	}
+	if !strings.Contains(logs.String(), "redacted=1") {
+		t.Fatalf("request log missing redacted marker: %s", logs.String())
+	}
+}
+
+func TestGitHubAuthHandlers_DoNotUseOperatorKeyOrAdminRoutes(t *testing.T) {
+	src, err := os.ReadFile("auth_github.go")
+	if err != nil {
+		t.Fatalf("read auth_github.go: %v", err)
+	}
+	for _, forbidden := range []string{
+		"operator_key",
+		"/poolz",
+		"/admin/blacklist",
+		"/admin/provisional",
+		"/admin/promote/",
+		"/admin/reject/",
+		"/admin/ledger/",
+	} {
+		if bytes.Contains(src, []byte(forbidden)) {
+			t.Fatalf("auth_github.go contains forbidden operator surface %q", forbidden)
+		}
+	}
+}
+
+type fakeSpec014GitHubClient struct {
+	exchangeErr error
+	userErr     error
+}
+
+func (f fakeSpec014GitHubClient) ExchangeCode(context.Context, string, string, string, string) (string, error) {
+	if f.exchangeErr != nil {
+		return "", f.exchangeErr
+	}
+	return "github-access-token", nil
+}
+
+func (f fakeSpec014GitHubClient) User(context.Context, string) (mpgithub.User, error) {
+	if f.userErr != nil {
+		return mpgithub.User{}, f.userErr
+	}
+	return mpgithub.User{ID: 42, Login: "octo"}, nil
+}
+
+func newSpec014AuthTestServer(t *testing.T, enabled bool) (*Server, *auth.Store) {
+	return newSpec014AuthTestServerWithClient(t, enabled, zerolog.Nop(), fakeSpec014GitHubClient{})
+}
+
+func newSpec014AuthTestServerWithClient(t *testing.T, enabled bool, logger zerolog.Logger, client githubOAuthClient) (*Server, *auth.Store) {
+	t.Helper()
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	cfg := config.Default()
+	cfg.Auth.GitHubOAuth = config.GitHubOAuthConfig{
+		Enabled:       enabled,
+		ClientID:      "client-id",
+		ClientSecret:  "client-secret",
+		RedirectURI:   "https://coordinator.example/v1/auth/github/callback",
+		PortalBaseURL: "https://portal.example",
+	}
+	s := NewServer(
+		cfg,
+		pool.NewRegistry(nil),
+		logger,
+		WithTokenValidator(store),
+		WithTokenIssuer(store),
+		WithGitHubAuthStore(store),
+		WithGitHubOAuthClient(client),
+	)
+	return s, store
+}
+
+func seedSpec014HTTPBindState(t *testing.T, store *auth.Store, now time.Time) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := store.UpsertGitHubIdentity(ctx, 42, "octo", now); err != nil {
+		t.Fatalf("UpsertGitHubIdentity: %v", err)
+	}
+	sessionID, err := store.CreateMPSession(ctx, 42, sql.NullString{}, now)
+	if err != nil {
+		t.Fatalf("CreateMPSession: %v", err)
+	}
+	mint, err := store.MintPairOT(ctx, "provider-a", now)
+	if err != nil {
+		t.Fatalf("MintPairOT: %v", err)
+	}
+	return sessionID, mint.PairOT
+}
+
+func timeTextForSpec014HTTPTest(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}
+
+func assertAuthError(t *testing.T, rr *httptest.ResponseRecorder, status int, code string) {
+	t.Helper()
+	if rr.Code != status {
+		t.Fatalf("status = %d, want %d body=%s", rr.Code, status, rr.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error body: %v body=%q", err, rr.Body.String())
+	}
+	if len(body) != 1 || body["error"] != code {
+		t.Fatalf("body = %#v, want {error:%q}", body, code)
+	}
+}

--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -38,6 +38,8 @@ type HelloAck struct {
 	// reconnect carries Bearer. Note: top-level, NOT nested under
 	// `auth:` — codex audit on PR #44 caught the prior spec/code drift.
 	AssignedProviderToken string `json:"assigned_provider_token,omitempty"`
+	PairOT                string `json:"pair_ot,omitempty"`
+	ClaimURL              string `json:"claim_url,omitempty"`
 }
 
 type AuthRequest struct {
@@ -104,6 +106,15 @@ type AuthResponse struct {
 	// when a tokenless provisional provider was just self-minted on this
 	// connect. Never present on rejection-shaped responses.
 	AssignedProviderToken string `json:"assigned_provider_token,omitempty"`
+	PairOT                string `json:"pair_ot,omitempty"`
+	ClaimURL              string `json:"claim_url,omitempty"`
+}
+
+type OwnershipEvent struct {
+	Type        string `json:"type"`
+	ProviderID  string `json:"provider_id"`
+	GitHubLogin string `json:"github_login"`
+	Event       string `json:"event"`
 }
 
 type AuthResponseError struct {

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -60,12 +60,14 @@ type Server struct {
 	// mint behavior (e.g. mintFailingStore) without touching the
 	// validator. Codex architect review on PR #44 flagged the
 	// interface-segregation regression of mixing both on TokenValidator.
-	issuer    TokenIssuer
-	admission *AdmissionManager
-	sessions  sync.Map
-	started   time.Time
-	explorer  http.Handler
-	unauth    chan struct{}
+	issuer      TokenIssuer
+	authStore   *auth.Store
+	githubOAuth githubOAuthClient
+	admission   *AdmissionManager
+	sessions    sync.Map
+	started     time.Time
+	explorer    http.Handler
+	unauth      chan struct{}
 	// unauthPerIP counts concurrent unauthenticated WS handshakes by remote IP.
 	// Defense-in-depth against nginx limit_conn evasion: one host can still
 	// burn the global 64-slot semaphore without per-IP shaping (M1-4 / SECU-1).
@@ -173,6 +175,18 @@ func WithTokenValidator(tokens TokenValidator) Option {
 func WithTokenIssuer(issuer TokenIssuer) Option {
 	return func(s *Server) {
 		s.issuer = issuer
+	}
+}
+
+func WithGitHubAuthStore(store *auth.Store) Option {
+	return func(s *Server) {
+		s.authStore = store
+	}
+}
+
+func WithGitHubOAuthClient(client githubOAuthClient) Option {
+	return func(s *Server) {
+		s.githubOAuth = client
 	}
 }
 
@@ -342,6 +356,15 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/admin/provisional", s.handleAdminProvisional)
 	mux.HandleFunc("/admin/promote/", s.handleAdminPromote)
 	mux.HandleFunc("/admin/reject/", s.handleAdminReject)
+	if s.cfg.Auth.GitHubOAuth.Enabled {
+		mux.HandleFunc("/v1/auth/github/start", s.handleGitHubStart)
+		mux.HandleFunc("/v1/auth/github/callback", s.handleGitHubCallback)
+		mux.HandleFunc("/v1/auth/me/providers", s.handleAuthMeProviders)
+		mux.HandleFunc("/v1/auth/me/providers/bind", s.handleAuthMeProvidersBind)
+		mux.HandleFunc("/v1/auth/logout", s.handleAuthLogout)
+		mux.HandleFunc("/v1/install/pair/refresh", s.handleInstallPairRefresh)
+		return s.redactedRequestLogMiddleware(mux)
+	}
 	return mux
 }
 
@@ -480,12 +503,12 @@ func (s *Server) handleConn(conn net.Conn, auth providerAuth, releaseUnauthentic
 // FR-C9.4 contract:
 //
 //   - Skip:        admit without minting, optionally with an AuthState
-//                  marker (BearerValidated / BearerlessDuplicate / empty).
+//     marker (BearerValidated / BearerlessDuplicate / empty).
 //   - Minted:      admit with a freshly-minted token in the ack frame.
 //   - RejectTOFU:  close the connection with CloseInvalidToken. Fires
-//                  when the existing row has last_used_at IS NOT NULL
-//                  (credential-capture closure) or a DB error blocked
-//                  the gate evaluation (fail closed).
+//     when the existing row has last_used_at IS NOT NULL
+//     (credential-capture closure) or a DB error blocked
+//     the gate evaluation (fail closed).
 //
 // The auth state is carried separately via pool.AuthState so registry +
 // routing + billing can distinguish bearer-less-duplicate from other
@@ -522,8 +545,8 @@ const (
 //   - outcome:        provisionalTokenSkip | provisionalTokenMinted | provisionalTokenRejectTOFU
 //   - cleartextToken: populated only when outcome == provisionalTokenMinted
 //   - authState:      pool.AuthState assigned to the provider entry —
-//                     drives registry eviction defense, buyer routing
-//                     exclusion, and billing exclusion.
+//     drives registry eviction defense, buyer routing
+//     exclusion, and billing exclusion.
 //
 // Algorithm (v0.8.4 composed):
 //  1. If the issuer is not wired: return Skip + empty authState (legacy
@@ -533,19 +556,19 @@ const (
 //  3. Call RevokeUnusedTokenForProvider:
 //     - (true, nil): self-heal fired — proceed to mint.
 //     - (false, nil): call HasActiveTokenForProvider; if true a USED
-//       row exists → return RejectTOFU (preserves v0.8.1 closure of
-//       codex MAJOR-1 credential-capture vector).
+//     row exists → return RejectTOFU (preserves v0.8.1 closure of
+//     codex MAJOR-1 credential-capture vector).
 //     - (_, err): fail closed, return RejectTOFU.
 //  4. Mint via IssueToken:
 //     - success: return Minted + cleartext + authState=SelfMinted.
 //     - ErrActiveTokenAlreadyExists: a concurrent connect won the race
-//       between our revoke and our INSERT. Return Skip + authState=
-//       BearerlessDuplicate. The connection is admitted bearer-less,
-//       but pool.Registry.Register refuses to evict an existing
-//       routable session, and buyer routing + billing exclude this
-//       entry (PR #69 fix-pass-3 + fix-pass-4).
+//     between our revoke and our INSERT. Return Skip + authState=
+//     BearerlessDuplicate. The connection is admitted bearer-less,
+//     but pool.Registry.Register refuses to evict an existing
+//     routable session, and buyer routing + billing exclude this
+//     entry (PR #69 fix-pass-3 + fix-pass-4).
 //     - other DB error: return Skip + empty authState (transient infra
-//       failure; binary retries next reconnect).
+//     failure; binary retries next reconnect).
 //
 // Settling-window posture (FR-C9.4):
 // validateProviderToken rejects all tokenless connects at the WS
@@ -556,18 +579,18 @@ const (
 // bearer; race-losers are quarantined as AuthBearerlessDuplicate.
 //
 // authParam is renamed to disambiguate from the auth package import.
-func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, providerName string) (provisionalTokenOutcome, string, pool.AuthState) {
+func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, providerName string) (provisionalTokenOutcome, string, string, string, pool.AuthState) {
 	if s.issuer == nil {
-		return provisionalTokenSkip, "", ""
+		return provisionalTokenSkip, "", "", "", ""
 	}
 	if authParam.validated {
-		return provisionalTokenSkip, "", pool.AuthBearerValidated
+		return provisionalTokenSkip, "", "", "", pool.AuthBearerValidated
 	}
 	ctx := context.Background()
 	selfHealed, err := s.issuer.RevokeUnusedTokenForProvider(ctx, providerID)
 	if err != nil {
 		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("FR-C9.4 unused-token self-heal evaluation failed; closing tokenless connect (fail closed)")
-		return provisionalTokenRejectTOFU, "", ""
+		return provisionalTokenRejectTOFU, "", "", "", ""
 	}
 	if selfHealed {
 		s.log.Info().Str("provider_id", providerID).Str("event", "fr_c9_4_self_heal").Msg("FR-C9.4 self-heal: revoked existing unused token for this provider_id; proceeding to mint a fresh one (SPEC-003 v0.8.4 deploy-gap recovery path)")
@@ -575,12 +598,29 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 		hasActive, err := s.issuer.HasActiveTokenForProvider(ctx, providerID)
 		if err != nil {
 			s.log.Warn().Err(err).Str("provider_id", providerID).Msg("FR-C9.4 TOFU gate evaluation failed; closing tokenless connect (fail closed)")
-			return provisionalTokenRejectTOFU, "", ""
+			return provisionalTokenRejectTOFU, "", "", "", ""
 		}
 		if hasActive {
 			s.log.Info().Str("provider_id", providerID).Str("event", "fr_c9_4_tofu_reject").Msg("FR-C9.4 TOFU: tokenless connect refused; an active USED token already exists for this provider_id (operator can revoke + retry if this is the legitimate provider after a used-token persist failure)")
-			return provisionalTokenRejectTOFU, "", ""
+			return provisionalTokenRejectTOFU, "", "", "", ""
 		}
+	}
+	if s.cfg.Auth.GitHubOAuth.Enabled && s.authStore != nil {
+		mint, err := s.authStore.MintAdmissionTokenAndPairOT(ctx, providerID, providerName, s.now())
+		if err == nil {
+			claimURL := ""
+			if mint.Paired {
+				claimURL = s.claimURL(mint.PairOT)
+			}
+			s.log.Info().Str("provider_id", providerID).Msg("FR-C9.1 self-serve provisional token minted on first tokenless admission")
+			return provisionalTokenMinted, mint.ProviderToken, mint.PairOT, claimURL, pool.AuthSelfMinted
+		}
+		if errors.Is(err, auth.ErrActiveTokenAlreadyExists) {
+			s.log.Info().Str("provider_id", providerID).Str("event", "fr_c9_4_race_loss_admit_quarantined").Msg("FR-C9.4 race-loss: concurrent connect won IssueToken; admitting bearer-less-duplicate (non-routable; operator MUST revoke before legitimate provider can reconnect cleanly)")
+			return provisionalTokenSkip, "", "", "", pool.AuthBearerlessDuplicate
+		}
+		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("FR-C10 pair_ot compound mint failed; closing tokenless connect (fail closed)")
+		return provisionalTokenRejectTOFU, "", "", "", pool.AuthMintFailed
 	}
 	_, token, err := s.issuer.IssueToken(ctx, providerID, providerName)
 	if err != nil {
@@ -591,7 +631,7 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 			// the registry eviction defense + routing/billing
 			// exclusion neutralize impact.
 			s.log.Info().Str("provider_id", providerID).Str("event", "fr_c9_4_race_loss_admit_quarantined").Msg("FR-C9.4 race-loss: concurrent connect won IssueToken; admitting bearer-less-duplicate (non-routable; operator MUST revoke before legitimate provider can reconnect cleanly)")
-			return provisionalTokenSkip, "", pool.AuthBearerlessDuplicate
+			return provisionalTokenSkip, "", "", "", pool.AuthBearerlessDuplicate
 		}
 		// SPEC-003 v0.8.4 (fix-pass-5) — fail-closed on transient DB
 		// error. Previously this path returned (Skip, "", "") and the
@@ -603,10 +643,10 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 		// and close the connection so the binary retries cleanly on
 		// next reconnect.
 		s.log.Warn().Err(err).Str("provider_id", providerID).Str("event", "fr_c9_1_mint_failed").Msg("FR-C9.1 self-serve mint failed (transient DB error); closing tokenless connect (fail closed)")
-		return provisionalTokenRejectTOFU, "", pool.AuthMintFailed
+		return provisionalTokenRejectTOFU, "", "", "", pool.AuthMintFailed
 	}
 	s.log.Info().Str("provider_id", providerID).Msg("FR-C9.1 self-serve provisional token minted on first tokenless admission")
-	return provisionalTokenMinted, token, pool.AuthSelfMinted
+	return provisionalTokenMinted, token, "", "", pool.AuthSelfMinted
 }
 
 func (s *Server) handleV1Conn(conn net.Conn, auth providerAuth, payload []byte, releaseUnauth func()) (string, string) {
@@ -638,7 +678,7 @@ func (s *Server) handleV1Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	// the provided AuthState (BearerValidated / BearerlessDuplicate /
 	// empty) and let the registry eviction defense + RoutingEligible
 	// gates take over.
-	outcome, assignedProviderToken, authState := s.resolveProvisionalToken(auth, entry.ProviderID, hello.Hostname)
+	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(auth, entry.ProviderID, hello.Hostname)
 	if outcome == provisionalTokenRejectTOFU {
 		s.close(conn, CloseInvalidToken, "invalid_token")
 		return "", ""
@@ -662,6 +702,8 @@ func (s *Server) handleV1Conn(conn net.Conn, auth providerAuth, payload []byte, 
 		RecommendedBinaryVersion: s.cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion,
 		RequiredBinaryVersion:    s.cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion,
 		AssignedProviderToken:    assignedProviderToken,
+		PairOT:                   pairOT,
+		ClaimURL:                 claimURL,
 	}
 	b, err := json.Marshal(ack)
 	if err != nil {
@@ -882,7 +924,7 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	// flow: RejectTOFU closes; Minted embeds; Skip admits with the
 	// provided AuthState; eviction defense protects existing routable
 	// sessions from bearer-less duplicates.
-	outcome, assignedProviderToken, authState := s.resolveProvisionalToken(auth, entry.ProviderID, initial.Hostname)
+	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(auth, entry.ProviderID, initial.Hostname)
 	if outcome == provisionalTokenRejectTOFU {
 		s.close(conn, CloseInvalidToken, "invalid_token")
 		return "", ""
@@ -904,6 +946,8 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 		RecommendedBinaryVersion: s.cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion,
 		RequiredBinaryVersion:    s.cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion,
 		AssignedProviderToken:    assignedProviderToken,
+		PairOT:                   pairOT,
+		ClaimURL:                 claimURL,
 		Tier2Session: &AuthTier2Session{
 			EncryptedLeg: AuthEncryptedLegSession{
 				Enabled:            true,

--- a/test/integration/spec_014_v0_2_pairing/config_validation_test.go
+++ b/test/integration/spec_014_v0_2_pairing/config_validation_test.go
@@ -1,0 +1,29 @@
+package spec014pairing
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSpec014V02CoordinatorConfigValidationMissingGitHubEnv(t *testing.T) {
+	required := map[string]string{
+		"GITHUB_OAUTH_CLIENT_ID":     "client-id",
+		"GITHUB_OAUTH_CLIENT_SECRET": "client-secret",
+		"GITHUB_OAUTH_REDIRECT_URI":  "https://coordinator.example/v1/auth/github/callback",
+		"PORTAL_BASE_URL":            "https://portal.example",
+	}
+	for missing := range required {
+		t.Run(missing, func(t *testing.T) {
+			env := map[string]string{"GITHUB_OAUTH_ENABLED": "true"}
+			for k, v := range required {
+				if k != missing {
+					env[k] = v
+				}
+			}
+			out := runCoordinatorExpectFailure(t, env)
+			if !strings.Contains(out, missing) {
+				t.Fatalf("coordinator failure output %q does not name %s", out, missing)
+			}
+		})
+	}
+}

--- a/test/integration/spec_014_v0_2_pairing/flag_off_regression_test.go
+++ b/test/integration/spec_014_v0_2_pairing/flag_off_regression_test.go
@@ -1,0 +1,37 @@
+package spec014pairing
+
+import (
+	"encoding/json"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestSpec014V02CoordinatorGitHubRoutes404WhenFlagOff(t *testing.T) {
+	coord := startCoordinator(t, false, nil)
+	resp, err := http.Get(coord.providerURL + "/v1/auth/github/start")
+	if err != nil {
+		t.Fatalf("github start flag-off request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("flag-off /v1/auth/github/start status=%d want 404", resp.StatusCode)
+	}
+}
+
+func TestSpec014V02ProviderPortalBundleProbe(t *testing.T) {
+	cmd := exec.Command("node", "portal_bundle_probe.js", filepath.Join(repoRoot, "frontdoor/provider-portal/index.html"))
+	cmd.Dir = filepath.Join(repoRoot, "test/integration/spec_014_v0_2_pairing")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("portal bundle probe failed: %v\n%s", err, string(out))
+	}
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("decode portal probe output: %v\n%s", err, string(out))
+	}
+	if result["ok"] != true {
+		t.Fatalf("portal probe returned non-ok: %#v", result)
+	}
+}

--- a/test/integration/spec_014_v0_2_pairing/full_handoff_test.go
+++ b/test/integration/spec_014_v0_2_pairing/full_handoff_test.go
@@ -1,0 +1,187 @@
+package spec014pairing
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSpec014V02FullPairingHandoff(t *testing.T) {
+	coord := startCoordinator(t, true, nil)
+	db := openDB(t, coord.dbPath)
+	providerID := "spec014-provider-" + randHex(t, 4)
+	conn, ack := dialProvider(t, coord.providerURL, providerID)
+	defer conn.Close()
+
+	assignedToken, _ := ack["assigned_provider_token"].(string)
+	pairOT, _ := ack["pair_ot"].(string)
+	claimURL, _ := ack["claim_url"].(string)
+	if assignedToken == "" || pairOT == "" || claimURL == "" {
+		t.Fatalf("hello_ack missing pairing fields: %#v", ack)
+	}
+	if !strings.Contains(claimURL, "/claim?ot="+pairOT) {
+		t.Fatalf("claim_url %q does not carry pair_ot %q", claimURL, pairOT)
+	}
+
+	binaryHome := t.TempDir()
+	binaryTranscript := writeClaimURLBeforeOpen(t, binaryHome, pairOT, claimURL)
+
+	startClient := &http.Client{
+		Timeout: 5 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	startURL := coord.providerURL + "/v1/auth/github/start?return_to=%2Fclaim&pair_ot=" + pairOT
+	resp, err := startClient.Get(startURL)
+	if err != nil {
+		t.Fatalf("github start: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("github start status=%d want 302", resp.StatusCode)
+	}
+	var pending string
+	if err := db.QueryRow(`SELECT pending_pair_ot FROM oauth_states WHERE pending_pair_ot = ?`, pairOT).Scan(&pending); err != nil {
+		t.Fatalf("oauth_states.pending_pair_ot not persisted: %v", err)
+	}
+
+	sessionID := seedSession(t, db, pairOT)
+	status, body := postBind(t, authClient(t, sessionID), coord.providerURL, `{}`)
+	if status != http.StatusOK {
+		t.Fatalf("pending pair bind status=%d body=%s", status, string(body))
+	}
+	var bindResp map[string]any
+	if err := json.Unmarshal(body, &bindResp); err != nil {
+		t.Fatalf("decode bind response: %v body=%s", err, string(body))
+	}
+	if bindResp["provider_id"] != providerID || bindResp["github_login"] != "octo" {
+		t.Fatalf("bind response=%#v, want provider_id=%s login=octo", bindResp, providerID)
+	}
+
+	event := readOwnershipEvent(t, conn, providerID)
+	if event["github_login"] != "octo" {
+		t.Fatalf("ownership_event=%#v, want github_login=octo", event)
+	}
+	completeBinaryClaim(t, binaryHome, providerID, event)
+
+	status, body = getProviders(t, authClient(t, sessionID), coord.providerURL)
+	if status != http.StatusOK {
+		t.Fatalf("providers status=%d body=%s", status, string(body))
+	}
+	if !strings.Contains(string(body), providerID) {
+		t.Fatalf("providers body %s does not include %s", string(body), providerID)
+	}
+
+	assertBurnFirstAgainstLiveCoordinator(t, coord.providerURL, db)
+	assertPairOTNotLeaked(t, pairOT, coord.logs.String(), binaryTranscript)
+}
+
+func writeClaimURLBeforeOpen(t *testing.T, home, pairOT, claimURL string) string {
+	t.Helper()
+	configDir := filepath.Join(home, ".config", "macprovider")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	claimPath := filepath.Join(configDir, "claim_url")
+	body := "pair_ot=" + pairOT + "\nclaim_url=" + claimURL + "\n"
+	if err := os.WriteFile(claimPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write claim_url: %v", err)
+	}
+	info, err := os.Stat(claimPath)
+	if err != nil {
+		t.Fatalf("stat claim_url: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("claim_url mode=%#o want 0600", info.Mode().Perm())
+	}
+	openMarker := filepath.Join(configDir, "open.attempted")
+	if _, err := os.Stat(openMarker); !os.IsNotExist(err) {
+		t.Fatalf("open marker exists before claim_url write barrier")
+	}
+	if err := os.WriteFile(openMarker, []byte(time.Now().UTC().Format(time.RFC3339Nano)), 0o600); err != nil {
+		t.Fatalf("write open marker: %v", err)
+	}
+	return "claim_url=" + claimURL + "\n"
+}
+
+func completeBinaryClaim(t *testing.T, home, providerID string, event map[string]any) {
+	t.Helper()
+	configDir := filepath.Join(home, ".config", "macprovider")
+	if event["event"] != "bound" {
+		t.Fatalf("unexpected ownership event: %#v", event)
+	}
+	if err := os.Remove(filepath.Join(configDir, "claim_url")); err != nil {
+		t.Fatalf("delete claim_url: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "owner.txt"), []byte("provider_id="+providerID+"\ngithub_login=octo\n"), 0o600); err != nil {
+		t.Fatalf("write owner.txt: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "claim_url")); !os.IsNotExist(err) {
+		t.Fatalf("claim_url still exists after ownership event")
+	}
+	owner, err := os.ReadFile(filepath.Join(configDir, "owner.txt"))
+	if err != nil {
+		t.Fatalf("read owner.txt: %v", err)
+	}
+	if !strings.Contains(string(owner), providerID) {
+		t.Fatalf("owner.txt=%q missing provider_id %s", string(owner), providerID)
+	}
+}
+
+func getProviders(t *testing.T, c *http.Client, baseURL string) (int, []byte) {
+	t.Helper()
+	resp, err := c.Get(baseURL + "/v1/auth/me/providers")
+	if err != nil {
+		t.Fatalf("get providers: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, body
+}
+
+func assertBurnFirstAgainstLiveCoordinator(t *testing.T, baseURL string, db *sql.DB) {
+	t.Helper()
+	pairOT := seedPairOT(t, db, "burn-first-"+randHex(t, 4))
+	sessionA := seedSession(t, db, "")
+	sessionB := seedSession(t, db, "")
+	body := fmt.Sprintf(`{"pair_ot":%q}`, pairOT)
+	statuses := make(chan int, 2)
+	var wg sync.WaitGroup
+	for _, sessionID := range []string{sessionA, sessionB} {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			status, _ := postBind(t, authClient(t, id), baseURL, body)
+			statuses <- status
+		}(sessionID)
+	}
+	wg.Wait()
+	close(statuses)
+	seen := map[int]int{}
+	for status := range statuses {
+		seen[status]++
+	}
+	if seen[http.StatusOK] != 1 || seen[http.StatusGone] != 1 {
+		t.Fatalf("burn-first concurrent bind statuses=%v, want one 200 and one 410", seen)
+	}
+}
+
+func assertPairOTNotLeaked(t *testing.T, pairOT, coordinatorLogs, binaryTranscript string) {
+	t.Helper()
+	if strings.Contains(coordinatorLogs, pairOT) {
+		t.Fatalf("pair_ot leaked in coordinator logs")
+	}
+	allowed := "claim_url=https://portal.example/claim?ot=" + pairOT + "\n"
+	if strings.ReplaceAll(binaryTranscript, allowed, "") != "" {
+		t.Fatalf("binary transcript contains pair_ot outside claim_url line: %q", binaryTranscript)
+	}
+}

--- a/test/integration/spec_014_v0_2_pairing/harness_test.go
+++ b/test/integration/spec_014_v0_2_pairing/harness_test.go
@@ -1,0 +1,525 @@
+package spec014pairing
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gobwas "github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+	"gopkg.in/yaml.v3"
+	_ "modernc.org/sqlite"
+)
+
+var (
+	repoRoot       string
+	coordinatorBin string
+	buildErr       error
+)
+
+func TestMain(m *testing.M) {
+	var err error
+	repoRoot, err = findRepoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "find repo root: %v\n", err)
+		os.Exit(1)
+	}
+	tmpRoot, err := os.MkdirTemp("", "spec-014-v0-2-bins-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tempdir: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmpRoot)
+	coordinatorBin = filepath.Join(tmpRoot, "coordinator")
+	buildErr = buildCoordinator(coordinatorBin)
+	os.Exit(m.Run())
+}
+
+func requireCoordinator(t *testing.T) {
+	t.Helper()
+	if buildErr != nil {
+		t.Fatalf("build coordinator: %v", buildErr)
+	}
+}
+
+func buildCoordinator(outPath string) error {
+	cmd := exec.Command("go", "build", "-o", outPath, "./cmd/coordinator")
+	cmd.Dir = filepath.Join(repoRoot, "phase4-coordinator")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v\n%s", err, string(out))
+	}
+	return nil
+}
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "Makefile")); err == nil {
+			if _, err := os.Stat(filepath.Join(dir, "phase4-coordinator")); err == nil {
+				return dir, nil
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not locate repo root from %s", dir)
+		}
+		dir = parent
+	}
+}
+
+type coordinatorProcess struct {
+	providerURL string
+	dbPath      string
+	logs        *safeBuffer
+}
+
+func startCoordinator(t *testing.T, githubEnabled bool, extraEnv map[string]string) *coordinatorProcess {
+	t.Helper()
+	requireCoordinator(t)
+	dir := t.TempDir()
+	providerPort := allocatePort(t)
+	buyerPort := allocatePort(t)
+	dbPath := filepath.Join(dir, "coordinator.db")
+	cfgPath := filepath.Join(dir, "coordinator.yaml")
+	writeCoordinatorConfig(t, cfgPath, dbPath, providerPort, buyerPort, githubEnabled)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, coordinatorBin, "-config", cfgPath)
+	cmd.Env = withoutGitHubOAuthEnv(os.Environ())
+	for k, v := range extraEnv {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	logs := &safeBuffer{}
+	cmd.Stdout = logs
+	cmd.Stderr = logs
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("start coordinator: %v", err)
+	}
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-waitDone:
+		case <-time.After(5 * time.Second):
+			_ = cmd.Process.Kill()
+			<-waitDone
+		}
+	})
+
+	proc := &coordinatorProcess{
+		providerURL: fmt.Sprintf("http://127.0.0.1:%d", providerPort),
+		dbPath:      dbPath,
+		logs:        logs,
+	}
+	waitForHTTP(t, proc.providerURL+"/healthz")
+	return proc
+}
+
+func runCoordinatorExpectFailure(t *testing.T, env map[string]string) string {
+	t.Helper()
+	requireCoordinator(t)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "coordinator.yaml")
+	writeCoordinatorConfigWithoutGitHubValues(t, cfgPath, filepath.Join(dir, "coordinator.db"), allocatePort(t), allocatePort(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, coordinatorBin, "-config", cfgPath)
+	cmd.Env = withoutGitHubOAuthEnv(os.Environ())
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("coordinator did not fail closed within 5s; output=%s", string(out))
+	}
+	if err == nil {
+		t.Fatalf("coordinator exited 0, want non-zero; output=%s", string(out))
+	}
+	return string(out)
+}
+
+func withoutGitHubOAuthEnv(env []string) []string {
+	blocked := map[string]struct{}{
+		"GITHUB_OAUTH_ENABLED":       {},
+		"GITHUB_OAUTH_CLIENT_ID":     {},
+		"GITHUB_OAUTH_CLIENT_SECRET": {},
+		"GITHUB_OAUTH_REDIRECT_URI":  {},
+		"PORTAL_BASE_URL":            {},
+		"MP_SESSION_COOKIE_DOMAIN":   {},
+	}
+	out := env[:0]
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			out = append(out, entry)
+			continue
+		}
+		if _, drop := blocked[key]; drop {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func writeCoordinatorConfig(t *testing.T, path, dbPath string, providerPort, buyerPort int, githubEnabled bool) {
+	t.Helper()
+	writeCoordinatorConfigWithOAuth(t, path, dbPath, providerPort, buyerPort, map[string]any{
+		"enabled":         githubEnabled,
+		"client_id":       "spec014-client",
+		"client_secret":   "spec014-secret",
+		"redirect_uri":    "https://coordinator.example/v1/auth/github/callback",
+		"portal_base_url": "https://portal.example",
+	})
+}
+
+func writeCoordinatorConfigWithoutGitHubValues(t *testing.T, path, dbPath string, providerPort, buyerPort int) {
+	t.Helper()
+	writeCoordinatorConfigWithOAuth(t, path, dbPath, providerPort, buyerPort, map[string]any{"enabled": false})
+}
+
+func writeCoordinatorConfigWithOAuth(t *testing.T, path, dbPath string, providerPort, buyerPort int, githubOAuth map[string]any) {
+	t.Helper()
+	cfg := map[string]any{
+		"listen": map[string]any{
+			"bind_address":  "127.0.0.1",
+			"provider_port": providerPort,
+			"buyer_port":    buyerPort,
+		},
+		"pool": map[string]any{
+			"heartbeat_interval_s":       30,
+			"disconnect_grace_period_s":  5,
+			"heartbeat_miss_threshold_s": 90,
+			"wake_gap_threshold_s":       300,
+			"warmup_fallback_s":          2,
+			"warmup_gate_enabled":        false,
+			"warmup_gate_timeout_s":      1,
+			"warmup_gate_max_tokens":     8,
+			"degraded_backoff_s":         1,
+			"degraded_max_retries":       1,
+			"degraded_probe_after_502":   false,
+			"breaker_failure_threshold":  3,
+			"breaker_window_s":           60,
+		},
+		"routing": map[string]any{
+			"preflight_threshold_tokens":        0,
+			"preflight_timeout_s":               1,
+			"request_timeout_s":                 5,
+			"failover_enabled":                  true,
+			"failover_timeout_s":                1,
+			"tiebreak_randomize":                false,
+			"tiebreak_epsilon":                  0.01,
+			"max_retries":                       1,
+			"retry_per_attempt_timeout_s":       5,
+			"max_providers_faulted_per_request": 1,
+			"sticky_enabled":                    false,
+			"sticky_ttl_s":                      60,
+			"sticky_max_entries":                100,
+			"model_classes":                     map[string]any{},
+		},
+		"provider_http": map[string]any{"timeout_s": 5},
+		"limits":        map[string]any{"max_chat_request_body_bytes": 1048576},
+		"ws": map[string]any{
+			"write_buffer_size":               64,
+			"handshake_timeout_s":             10,
+			"write_timeout_s":                 10,
+			"max_frame_bytes":                 4 << 20,
+			"max_unauthenticated_conn":        64,
+			"max_unauthenticated_conn_per_ip": 16,
+		},
+		"admission": map[string]any{
+			"pinned_only":                         false,
+			"provisional_admission_rate_per_hour": 1000,
+			"provisional_pool_max":                100,
+			"provisional_quota_per_hour":          1000,
+			"provisional_tier_weight":             0.3,
+			"provisional_retention_days":          30,
+		},
+		"tier2": map[string]any{
+			"observe_enabled":                    false,
+			"require_hash_verified":              false,
+			"require_encrypted_leg":              false,
+			"encrypted_leg_aead":                 "A256GCM",
+			"encrypted_leg_rekey_after_requests": 10000,
+			"encrypted_leg_rekey_after_seconds":  3600,
+			"require_attestation":                false,
+			"attestation_max_age_s":              600,
+			"behavioral_safety_enabled":          false,
+			"output_size_cap_bytes":              0,
+			"output_bytes_per_token_ceiling":     16,
+			"default_output_size_cap_bytes":      1048576,
+			"encoding_validation_enabled":        false,
+			"response_time_anomaly_enabled":      false,
+			"response_time_anomaly_factor":       5.0,
+			"response_time_anomaly_min_ms":       10000,
+		},
+		"auth": map[string]any{
+			"operator_key":            randHex(t, 32),
+			"gateway_service_token":   randHex(t, 32),
+			"require_provider_tokens": false,
+			"github_oauth":            githubOAuth,
+		},
+		"storage": map[string]any{
+			"db_path":                    dbPath,
+			"snapshot_interval_s":        300,
+			"request_log_retention_days": 90,
+			"audit_log_retention_days":   90,
+		},
+		"logging": map[string]any{"level": "info", "format": "json"},
+		"rewards": map[string]any{
+			"global_multiplier": 1.0,
+			"provider_share":    0.9,
+			"rate_card": map[string]any{"default": map[string]any{
+				"prompt_credits_per_mtok":     500000,
+				"completion_credits_per_mtok": 1000000,
+			}},
+		},
+		"settlement": map[string]any{
+			"cadence_days":                   7,
+			"min_payout_credits":             0,
+			"startup_reconcile_window_hours": 24,
+			"nightly_reconcile_window_days":  7,
+			"recovery_grace_seconds":         30,
+			"job_enabled":                    false,
+		},
+		"endpoints": map[string]any{
+			"provider_earnings": map[string]any{"rate_limit_per_minute": 60},
+		},
+		"explorer":  map[string]any{"enabled": false},
+		"providers": []any{},
+	}
+	b, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal coordinator config: %v", err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write coordinator config: %v", err)
+	}
+}
+
+func providerHello(providerID string) map[string]any {
+	return map[string]any{
+		"type":                    "hello",
+		"version":                 1,
+		"tier":                    1,
+		"provider_id":             providerID,
+		"hostname":                "spec014-binary-stub",
+		"model_id":                "llama-3.2-3b-instruct",
+		"model_params_b":          3.0,
+		"ram_gb":                  16,
+		"max_context_tokens":      8192,
+		"max_concurrency":         1,
+		"throughput_tps_estimate": 10.0,
+		"binary_version":          "spec014-v0.2-stub",
+		"attestation":             nil,
+	}
+}
+
+func dialProvider(t *testing.T, providerURL, providerID string) (net.Conn, map[string]any) {
+	t.Helper()
+	conn, _, _, err := gobwas.Dial(context.Background(), strings.Replace(providerURL, "http://", "ws://", 1)+"/ws/provider")
+	if err != nil {
+		t.Fatalf("dial provider ws: %v", err)
+	}
+	b, err := json.Marshal(providerHello(providerID))
+	if err != nil {
+		conn.Close()
+		t.Fatalf("marshal hello: %v", err)
+	}
+	if err := wsutil.WriteClientText(conn, b); err != nil {
+		conn.Close()
+		t.Fatalf("write hello: %v", err)
+	}
+	payload, _, err := wsutil.ReadServerData(conn)
+	if err != nil {
+		conn.Close()
+		t.Fatalf("read hello_ack: %v", err)
+	}
+	var ack map[string]any
+	if err := json.Unmarshal(payload, &ack); err != nil {
+		conn.Close()
+		t.Fatalf("decode hello_ack: %v payload=%s", err, string(payload))
+	}
+	return conn, ack
+}
+
+func readOwnershipEvent(t *testing.T, conn net.Conn, providerID string) map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	for time.Now().Before(deadline) {
+		payload, _, err := wsutil.ReadServerData(conn)
+		if err != nil {
+			t.Fatalf("read ownership event: %v", err)
+		}
+		var event map[string]any
+		if err := json.Unmarshal(payload, &event); err != nil {
+			continue
+		}
+		if event["type"] == "ownership_event" && event["event"] == "bound" && event["provider_id"] == providerID {
+			return event
+		}
+	}
+	t.Fatalf("ownership_event bound for %s did not arrive within 5s", providerID)
+	return nil
+}
+
+func openDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func seedSession(t *testing.T, db *sql.DB, pendingPairOT string) string {
+	t.Helper()
+	now := time.Now().UTC()
+	sessionID := randHex(t, 32)
+	if _, err := db.Exec(`INSERT INTO github_identities (github_user_id, github_login, created_at, last_seen_at) VALUES (?, ?, ?, ?) ON CONFLICT(github_user_id) DO UPDATE SET github_login = excluded.github_login, last_seen_at = excluded.last_seen_at`,
+		42, "octo", timeText(now), timeText(now)); err != nil {
+		t.Fatalf("seed github identity: %v", err)
+	}
+	var pending any
+	var pendingExpires any
+	if pendingPairOT != "" {
+		pending = pendingPairOT
+		pendingExpires = timeText(now.Add(10 * time.Minute))
+	}
+	if _, err := db.Exec(`INSERT INTO mp_sessions (id, github_user_id, created_at, last_seen_at, last_setcookie_at, pending_pair_ot, pending_pair_ot_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		sessionID, 42, timeText(now), timeText(now), timeText(now), pending, pendingExpires); err != nil {
+		t.Fatalf("seed mp_session: %v", err)
+	}
+	return sessionID
+}
+
+func seedPairOT(t *testing.T, db *sql.DB, providerID string) string {
+	t.Helper()
+	pairOT := randHex(t, 16)
+	now := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO pair_ots (id, provider_id, expires_at, created_at) VALUES (?, ?, ?, ?)`,
+		pairOT, providerID, timeText(now.Add(10*time.Minute)), timeText(now)); err != nil {
+		t.Fatalf("seed pair_ot: %v", err)
+	}
+	return pairOT
+}
+
+func authClient(t *testing.T, sessionID string) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	c := &http.Client{Jar: jar, Timeout: 5 * time.Second}
+	u := mustURL(t, "http://127.0.0.1/")
+	jar.SetCookies(u, []*http.Cookie{{Name: "mp_session", Value: sessionID, Path: "/"}})
+	return c
+}
+
+func postBind(t *testing.T, c *http.Client, baseURL, body string) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/auth/me/providers/bind", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new bind req: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("post bind: %v", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, b
+}
+
+func waitForHTTP(t *testing.T, rawURL string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(rawURL)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("%s did not become ready", rawURL)
+}
+
+func allocatePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("allocate port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func randHex(t *testing.T, n int) string {
+	t.Helper()
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return hex.EncodeToString(b)
+}
+
+func timeText(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	return u
+}
+
+type safeBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}

--- a/test/integration/spec_014_v0_2_pairing/portal_bundle_probe.js
+++ b/test/integration/spec_014_v0_2_pairing/portal_bundle_probe.js
@@ -1,0 +1,219 @@
+const fs = require("fs");
+const vm = require("vm");
+
+const htmlPath = process.argv[2];
+if (!htmlPath) {
+  throw new Error("usage: node portal_bundle_probe.js <frontdoor/provider-portal/index.html>");
+}
+const html = fs.readFileSync(htmlPath, "utf8");
+const scripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]).join("\n");
+
+function makeContext(url, fetchImpl) {
+  const nodes = [];
+  function FakeNode() {}
+  function makeNode(tag) {
+    const node = new FakeNode();
+    node.tag = tag;
+    node.children = [];
+    node.attrs = {};
+    node.style = {};
+    node.className = "";
+    node.value = "";
+    node.appendChild = (child) => {
+      node.children.push(child);
+      return child;
+    };
+    node.removeChild = (child) => {
+      node.children = node.children.filter((item) => item !== child);
+    };
+    node.setAttribute = (key, value) => {
+      node.attrs[key] = String(value);
+    };
+    node.addEventListener = () => {};
+    node.select = () => {};
+    Object.defineProperty(node, "firstChild", {
+      get() {
+        return node.children[0] || null;
+      },
+    });
+    nodes.push(node);
+    return node;
+  }
+
+  const app = makeNode("div");
+  app.id = "app";
+  const parsed = new URL(url);
+  const assigned = [];
+  const context = {
+    URL,
+    Node: FakeNode,
+    setTimeout(fn) {
+      context.timeout = fn;
+      return 1;
+    },
+    setInterval() {
+      return 1;
+    },
+    clearInterval() {},
+    location: {
+      href: parsed.href,
+      pathname: parsed.pathname,
+      search: parsed.search,
+      assign(target) {
+        assigned.push(target);
+      },
+    },
+    history: {
+      replaceState(_state, _title, target) {
+        const next = new URL(target, parsed.origin);
+        context.location.href = next.href;
+        context.location.pathname = next.pathname;
+        context.location.search = next.search;
+      },
+      pushState(_state, _title, target) {
+        const next = new URL(target, parsed.origin);
+        context.location.href = next.href;
+        context.location.pathname = next.pathname;
+        context.location.search = next.search;
+      },
+    },
+    document: {
+      readyState: "loading",
+      addEventListener() {},
+      createElement: makeNode,
+      createTextNode(text) {
+        return { text: String(text) };
+      },
+      getElementById(id) {
+        return id === "app" ? app : null;
+      },
+      body: makeNode("body"),
+      execCommand() {
+        return true;
+      },
+    },
+    navigator: { clipboard: { writeText: async () => {} } },
+    addEventListener() {},
+    fetch: fetchImpl,
+    window: {},
+    console,
+  };
+  context.window = context;
+  context.app = app;
+  context.assigned = assigned;
+  context.createdNodes = nodes;
+  return context;
+}
+
+function assert(cond, msg) {
+  if (!cond) {
+    throw new Error(msg);
+  }
+}
+
+(async () => {
+  const claimContext = makeContext("http://portal.test/claim?ot=PAIR123", async () => ({
+    ok: true,
+    status: 200,
+    text: async () => "{\"providers\":[]}",
+  }));
+  vm.runInNewContext(scripts, claimContext);
+  assert(claimContext.location.search === "", "claim route must strip ?ot before app work");
+  assert(claimContext.location.pathname === "/claim", "claim route must remain on /claim after stripping token");
+
+  const configContext = makeContext("http://portal.test/", async () => ({
+    ok: true,
+    status: 200,
+    text: async () => "{}",
+  }));
+  vm.runInNewContext(scripts, configContext);
+  assert(configContext.validateConfig({
+    coordinator_base_url: "https://c.example",
+    releases_repo_owner_name: "Augustas11/macprovider",
+    require_provider_tokens: true,
+    github_oauth_enabled: true,
+  }).github_oauth_enabled === true, "four-key config should accept boolean github_oauth_enabled");
+  assert(configContext.validateConfig({
+    coordinator_base_url: "https://c.example",
+    releases_repo_owner_name: "Augustas11/macprovider",
+    require_provider_tokens: true,
+  }).github_oauth_enabled === false, "omitted github_oauth_enabled should default false");
+  let rejected = false;
+  try {
+    configContext.validateConfig({
+      coordinator_base_url: "https://c.example",
+      releases_repo_owner_name: "Augustas11/macprovider",
+      require_provider_tokens: true,
+      github_oauth_enabled: "true",
+    });
+  } catch (_err) {
+    rejected = true;
+  }
+  assert(rejected, "string github_oauth_enabled must fail closed");
+
+  rejected = false;
+  try {
+    configContext.validateConfig({
+      coordinator_base_url: "https://c.example",
+      releases_repo_owner_name: "Augustas11/macprovider",
+      require_provider_tokens: true,
+      github_oauth_enabled: false,
+      extra: true,
+    });
+  } catch (_err) {
+    rejected = true;
+  }
+  assert(rejected, "fifth portal-config key must fail closed");
+
+  const falseBranchFetches = [];
+  const falseContext = makeContext("http://portal.test/", async (path, opts) => {
+    falseBranchFetches.push({ path, opts });
+    if (String(path).endsWith("portal-config.json")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          coordinator_base_url: "https://c.example",
+          releases_repo_owner_name: "Augustas11/macprovider",
+          require_provider_tokens: true,
+          github_oauth_enabled: false,
+        }),
+        text: async () => "{}",
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => "{}",
+    };
+  });
+  vm.runInNewContext(scripts, falseContext);
+  await falseContext.loadConfig();
+  falseContext.render();
+  assert(falseContext.state.configError == null, "flag-off bootstrap must load portal config successfully");
+  assert(falseContext.state.cfg.github_oauth_enabled === false, "flag-off bootstrap must use loaded false config");
+  assert(falseContext.state.cookieFetch == null, "flag-off bootstrap must not initialize cookie auth helper");
+  assert(falseBranchFetches.filter((call) => String(call.path).includes("/v1/auth/")).length === 0,
+    "flag-off cold load must not fetch /v1/auth/*");
+
+  const fetchCalls = [];
+  configContext.fetch = async (path, opts) => {
+    fetchCalls.push({ path, opts });
+    return { ok: true, status: 200, text: async () => "{}" };
+  };
+  configContext.state.cfg = { github_oauth_enabled: true };
+  configContext.state.cookieFetch = configContext.makeCookieFetch();
+  await configContext.cookieJSON("/v1/auth/me/providers", {
+    headers: { Authorization: "Bearer should-not-pass", "X-Test": "ok" },
+  });
+  const call = fetchCalls[0];
+  assert(call.opts.credentials === "include", "GitHub branch fetch must include credentials");
+  assert(!("Authorization" in call.opts.headers) && !("authorization" in call.opts.headers),
+    "GitHub branch fetch must strip Authorization");
+
+  console.log(JSON.stringify({ ok: true }));
+})().catch((err) => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Implements SPEC-014 v0.2 Phases 2A-2E as one PR.
- Adds coordinator GitHub OAuth/session/pairing endpoints behind flag.
- Adds binary claim URL handoff and ownership event handling.
- Adds CLI claim refresh/status owner visibility.
- Gates provider portal GitHub-cookie mode behind `github_oauth_enabled`.
- Adds Phase 2E integration gate, CI job, and deploy/rollback runbook.

## Validation
- `bash frontdoor/provider-portal/check-bundle.sh`
- `node --check test/integration/spec_014_v0_2_pairing/portal_bundle_probe.js`
- `go test -race -count=1 -timeout 5m ./spec_014_v0_2_pairing`
- `make test-integration`
- `git diff --check`
- `git diff -- specs` empty
- Code/security/architecture auditors: 0 critical/high/medium findings

## Notes
- The SPEC-014 v0.2 flags should remain off until CI and the operator smoke test in `docs/operations/spec-014-v0.2-deploy.md` pass.
- Decision log entry remains operator-owned after the gate passes.
