### PR TITLE
Enforce CI and review gates for money-path changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Sensitive money/auth paths require repository-owner review.
+phase4-coordinator/internal/billing/** @Augustas11
+phase4-coordinator/internal/buyer/** @Augustas11
+phase4-coordinator/internal/auth/** @Augustas11
+phase4-coordinator/internal/requestlog/** @Augustas11
+phase5-gateway/internal/router/** @Augustas11
+phase5-gateway/internal/auth/** @Augustas11
+
+# CI gate controls for the sensitive paths.
+.github/CODEOWNERS @Augustas11
+.github/workflows/ci.yml @Augustas11
+Makefile @Augustas11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,3 +177,47 @@ jobs:
       - name: Run Swift tests
         working-directory: phase3-binary
         run: swift test --parallel
+
+  ci-required:
+    name: ci-required
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - coordinator
+      - gateway
+      - integration
+      - spec-014-v0-2-gate
+      - dist-tooling
+      - swift-tests
+    if: always()
+    steps:
+      - name: Require all CI jobs
+        shell: bash
+        env:
+          COORDINATOR_RESULT: ${{ needs.coordinator.result }}
+          GATEWAY_RESULT: ${{ needs.gateway.result }}
+          INTEGRATION_RESULT: ${{ needs.integration.result }}
+          SPEC_014_RESULT: ${{ needs.spec-014-v0-2-gate.result }}
+          DIST_TOOLING_RESULT: ${{ needs.dist-tooling.result }}
+          SWIFT_TESTS_RESULT: ${{ needs.swift-tests.result }}
+        run: |
+          set -euo pipefail
+
+          failed=0
+          for check in \
+            "phase4-coordinator (go vet + test):${COORDINATOR_RESULT}" \
+            "phase5-gateway (go vet + test):${GATEWAY_RESULT}" \
+            "integration (cross-service):${INTEGRATION_RESULT}" \
+            "spec-014-v0-2-gate:${SPEC_014_RESULT}" \
+            "deploy tooling (check-deploy-config gate):${DIST_TOOLING_RESULT}" \
+            "phase3-binary (swift test):${SWIFT_TESTS_RESULT}"
+          do
+            name="${check%%:*}"
+            result="${check#*:}"
+            if [ "$result" != "success" ]; then
+              printf '%s result=%s\n' "$name" "$result" >&2
+              failed=1
+            fi
+          done
+
+          exit "$failed"


### PR DESCRIPTION
## Summary
- Add .github/CODEOWNERS entries for money/auth paths and CI gate controls.
- Add a stable ci-required aggregate job that fails unless coordinator Go, gateway Go, integration, deploy-tooling, SPEC-014, and Swift test jobs all pass.
- Created GitHub ruleset 17964007 on main requiring PRs, code-owner review, resolved threads, stale-review dismissal, strict up-to-date checks, and ci-required.

## Validation
- ruby YAML parse for .github/workflows/ci.yml
- git diff --check
- GitHub ruleset readback confirms pull_request and required_status_checks requiring ci-required

## Notes
- Existing untracked specs/ files in the worktree were left untouched.
- The branch CI run is expected to produce the new ci-required context for the ruleset.