### PR TITLE
Document provider token config placement

### DIFF
--- a/OPS.md
+++ b/OPS.md
@@ -420,15 +420,17 @@ sudo -u macprovider /opt/macprovider/coordinator-cli issue-token \
 ```
 
 Send the token to the provider operator over a secure channel; they place
-it as `auth.provider_token: <token>` in their `macprovider.yaml` (and
-`chmod 0600 macprovider.yaml`), then restart the provider.
+it as top-level `provider_token: <token>` in their macprovider config
+(normally `~/.config/macprovider/config.yaml`, mode 0600), then restart
+the provider.
 
 Stranger-tier (curl|bash open-onboarding) — **self-serve provisional**
 is the production path per SPEC-003 v0.8.x. The coordinator mints a
 fresh `provider_token` on every tokenless provisional admission and
 returns it in the v1 `hello_ack` and v2 `auth_response` frames; the
-binary persists it atomically to `~/.config/macprovider/macprovider.yaml`
-(mode 0600). Next reconnect carries it as `Authorization: Bearer`.
+binary persists it atomically to top-level `provider_token:` in
+`~/.config/macprovider/config.yaml` (mode 0600). Next reconnect carries
+it as `Authorization: Bearer`.
 No operator action is required for the open-onboarding tier under
 `auth.require_provider_tokens=false`. After the flag flip (FR-C9.5
 compatibility cutoff), tokenless connects are rejected at the auth


### PR DESCRIPTION
## Summary
- document that provider tokens live at top-level `provider_token:`, not under `auth`
- document the actual default config path used by the Swift provider binary

## Production verification
- Pearl coordinator deployed at `v1.3.1-52-g6bb8600`
- `auth.require_provider_tokens=true` on Pearl
- `/poolz` showed `air5` and `augustass-macbook-air` as `bearer_validated`

## Tests
- `SKIP_C2_CHECK=1 bash phase4-coordinator/dist/check-deploy-config.sh phase4-coordinator/dist/coordinator.yaml`
- `go test ./internal/config ./internal/auth ./internal/ws`

## Not tested
- full deploy C2 timer check; this checkout does not have a real `phase5-gateway/dist/gateway.yaml`