### PR TITLE
Absorb SPEC-015 receipt wire authority

### DIFF
--- a/specs/AUDIT_SPEC_015_IMPL_STEP_0_PROMPT.md
+++ b/specs/AUDIT_SPEC_015_IMPL_STEP_0_PROMPT.md
@@ -1,0 +1,68 @@
+# AUDIT_SPEC_015_IMPL_STEP_0 — Locked-spec candidate absorption audit
+
+You are auditing Step 0 of `specs/BUILD_SPEC_015_IMPL_PROMPT.md` on branch
+`impl/spec-015-step-00`.
+
+## Scope
+
+Step 0 is spec-only. The only intended modified files are:
+
+- `specs/SPEC-001-phase3-binary.md`
+- `specs/SPEC-002-coordinator.md`
+- `specs/SPEC-006-buyer-api.md`
+
+No runtime code, tests, README text, deployment config, or other locked specs
+should be modified in this step.
+
+## Intended changes
+
+1. SPEC-001 line-3 version bumps from v1.5 to v1.6.
+   - Top change-log block records SPEC-015 v0.1.3 absorption.
+   - §6.7.1 initial-stage `auth_request` table gains exactly one optional
+     `provider_receipt_public_key` row.
+   - New §6.7.5 cross-references SPEC-015 and states the field is
+     initial-stage only, parser-optional, standard padded base64 of exactly
+     32-byte ed25519 public key material.
+   - Proof-stage frame text/table is not modified to include the field.
+
+2. SPEC-002 line-3 version bumps from v1.3.5 to v1.4.
+   - Top change-log block records SPEC-015 v0.1.3 absorption.
+   - `/poolz` provider row gains additive `receipt_pubkey` and
+     `receipt_pubkey_prev` fields.
+   - `receipt_pubkey` is nullable standard padded base64 32-byte ed25519
+     public key.
+   - `receipt_pubkey_prev` is nullable and, when populated, has exactly
+     `pubkey`, `rotated_at`, and `expires_at`.
+   - Cross-reference text points back to SPEC-015 and keeps durable storage
+     out of scope.
+
+3. SPEC-006 line-3 version bumps from v0.8.3 to v0.9.
+   - Top change-log block records SPEC-015 v0.1.3 absorption.
+   - Response-pass-through allowlist gains exactly `X-MacProvider-Receipt`.
+   - Inbound buyer request header stripping rules remain unchanged.
+   - No `X-MacProvider-Receipt-Pending` or any second buyer-visible
+     receipt-related `X-MacProvider-*` header is introduced.
+
+## Audit tasks
+
+Review the diff against `origin/spec/015-receipts-v0-1` and report findings
+by severity:
+
+- CRITICAL: any code/runtime change; edits to locked specs outside the three
+  intended files; proof-stage `provider_receipt_public_key`; second
+  receipt-related buyer-visible header; non-additive wire/schema change.
+- MAJOR: wrong field/header name; wrong base64/public-key semantics; parser
+  requiredness not optional; `/poolz` null/object shape mismatches SPEC-015;
+  change-log misstates the absorption; response allowlist incomplete or
+  internally inconsistent.
+- MINOR: wording, line-placement, or clarity issues that do not change the
+  contract.
+
+The lock gate for this step is 0 CRITICAL and 0 MAJOR.
+
+Return a concise report with:
+
+- Verdict: READY or NEEDS FIX PASS.
+- Counts: CRITICAL / MAJOR / MINOR.
+- Findings with file/line references.
+- Any residual non-blocking notes.

--- a/specs/SPEC-001-phase3-binary.md
+++ b/specs/SPEC-001-phase3-binary.md
@@ -1,6 +1,6 @@
 # SPEC-001 — Phase 3 Binary: Mac Provider Inference CLI
 
-**Version:** 1.5 (2026-06-21, additive pair_ot + claim_url ack fields + ownership_event frame + needs_claim signal for SPEC-014 v0.2 downstream consumer)
+**Version:** 1.6 (2026-06-22, SPEC-015 v0.1.3 receipt pubkey auth_request absorption)
 **Revision:** v1.3.1 adds the `provider_token` (yaml, top-level) /
 `MACPROVIDER_PROVIDER_TOKEN` (env) / `--provider-token` (CLI) config key
 and mandates the binary attach `Authorization: Bearer <token>` on the
@@ -14,6 +14,15 @@ handshake starts. Backwards-compatible: a v1.3.1 binary with no
 behavior, so a coordinator running with `auth.require_provider_tokens=false`
 continues to accept tokenless legacy fleets. Flag flip on the
 coordinator is the compatibility cutoff for old binaries.
+
+**Change log v1.6:**
+- **v1.6 (2026-06-22, SPEC-015 v0.1.3 absorption):** Adds one
+  parser-optional field to the v2 `auth_request` initial-stage frame:
+  `provider_receipt_public_key`. The field carries the provider's
+  standard padded base64-encoded 32-byte ed25519 receipt public key for
+  SPEC-015 v0.1.3 non-streaming inference receipts. This is additive
+  only: the field is NOT required by parsers, absent values preserve
+  pre-v1.6 behavior, and the v2 proof-stage frame is unchanged.
 
 **Change log v1.5:**
 - **v1.5 (2026-06-21, pair_ot / claim_url wire additions):** Adds
@@ -1782,6 +1791,7 @@ The initial-stage frame field table is the SPEC-010 v1.5 §3.1.A table:
 | Binary version | `binary_version` | string | REQUIRED by `parseAuthInitial` | |
 | Endpoint URL | `endpoint_url` | string pointer (nullable) | optional | |
 | Provider ECDH public key | `provider_ecdh_public_key` | string base64 | REQUIRED by `parseAuthInitial` | SPEC-008 Tier-2 |
+| Provider receipt public key | `provider_receipt_public_key` | string standard padded base64 of 32-byte ed25519 public key | optional, ADDED by SPEC-015 v0.1.3 / SPEC-001 v1.6 | parser-optional; initial-stage only; absent means the provider is not receipt-issuing |
 | Tier-2 capabilities | `tier2_capabilities` | object `{encrypted_leg: bool, attestation: bool, aead_suites: []string}` | REQUIRED by `parseAuthInitial` | SPEC-008 Tier-2 |
 | Supported models | `supported_models` | array of strings | optional, ADDED by SPEC-010 v1.5 | rules per SPEC-010 v1.5 R-3.1.1 through R-3.1.9 and R-3.6.1 through R-3.6.3 |
 | Publishes supported models | `publishes_supported_models` | bool | optional, ADDED by SPEC-010 v1.5 | rules per SPEC-010 v1.5 R-3.1.6 and R-3.6.4 |
@@ -1937,6 +1947,22 @@ reconnect after a warm-swap-in-flight.
 R-6.7.10 A pre-v1.3 (v1.2.x) binary uses legacy `hello` on first
 connect; the coordinator accepts both paths per SPEC-010 v1.5 §3.1 and
 SPEC-011 v0.5 R-3.8.3 compatibility notes.
+
+#### 6.7.5. SPEC-015 receipt pubkey initial-stage field (NEW in v1.6)
+
+SPEC-015 v0.1.3 §7.2 adds the optional initial-stage field
+`provider_receipt_public_key` to publish the provider's receipt
+verification key for non-streaming inference receipts. When present,
+the field value MUST be standard padded base64 of exactly 32 bytes of
+ed25519 public key material. The coordinator parser MUST accept an
+absent field so pre-v1.6 binaries continue to admit; an absent field
+means the provider is not receipt-issuing for SPEC-015 v0.1.x.
+
+The field is valid on the v2 `auth_request` initial-stage frame only.
+The proof-stage field table in §6.7.2 is unchanged; the binary MUST NOT
+echo `provider_receipt_public_key` on proof-stage frames. SPEC-015
+v0.1.3 deliberately restricts this absorption to one additive field and
+does not introduce any receipt-specific WebSocket control frame.
 
 ### 6.8. Warm-swap opt-in gate + runtime state machine (NEW in v1.3)
 

--- a/specs/SPEC-002-coordinator.md
+++ b/specs/SPEC-002-coordinator.md
@@ -1,7 +1,19 @@
 # SPEC-002 — Phase 4 Coordinator: Mac Provider Request Router
 
-**Version:** 1.3.5 (2026-06-06, SPEC-010 v1.5 + SPEC-011 v0.5 + SPEC-001 v1.3 absorption)
+**Version:** 1.4 (2026-06-22, SPEC-015 v0.1.3 /poolz receipt pubkey absorption)
 **Depends on:** SPEC-001 v1.4 (Phase 3 binary wire protocol, locked; v1.4 adds installer custom-model selection + `models browse` + fit guard on top of the v1.3 absorbed in §7.8/§7.9)
+
+**Change log v1.4:**
+- **v1.4 (2026-06-22, SPEC-015 v0.1.3 absorption):** Adds two
+  parser/consumer-optional fields to each `/poolz` provider row:
+  `receipt_pubkey` and `receipt_pubkey_prev`. `receipt_pubkey` is a
+  nullable standard padded base64 ed25519 public key string; null means
+  the provider did not publish a SPEC-001 v1.6 receipt pubkey.
+  `receipt_pubkey_prev` is null outside key-rotation grace windows or
+  an object carrying `pubkey`, `rotated_at`, and `expires_at` during
+  the SPEC-015 v0.1.3 reconnect-based rotation grace window. This is a
+  `/poolz` JSON shape absorption only; durable receipt-key storage is
+  deferred to future specs.
 
 **Change log v1.3.5:**
 - **v1.3.5 (2026-06-06, SPEC-010 v1.5 + SPEC-011 v0.5 + SPEC-001 v1.3 absorption):** Adds coordinator-side surface for three now-LOCKED companion specs. SPEC-010 v1.5 adds the `Provider` data-model extension (`SupportedModels[]`, `PublishesSupportedModels`); opt-in `/v1/status.supported_models` echo per R-3.3.3 / AC-21. SPEC-011 v0.5 adds heartbeat parsing for optional `model_hash` + `loading: bool` per R-3.3.0 / R-3.3.1; REPLACES the locked `ApplyHeartbeat` hash-clearing semantics with a two-path (legacy clear / SPEC-011 re-verify) contract at `phase4-coordinator/internal/pool/provider.go:411-432`; adds NEW §7.10 audit-log infrastructure + normative `operator_model_swap` event schema. ALSO adds a new normative §7.8 v2 `auth_request` provider handshake section — the v2 contract has been in code since SPEC-002 v1.2.x but was never normatively documented in SPEC-002; v1.3.5 closes that gap on the coordinator side (matching SPEC-001 v1.3 §6.7 binary-side closure). ALSO adds a new normative §7.9 auth-attempt lifecycle section (10-minute timeout per `s.now().Add(10 * time.Minute)` at server.go:355; per-attempt state release on success/reject/expiry/disconnect); takes over as the source of truth from SPEC-010 v1.5 R-3.1.10 clauses 1 and 5 per SPEC-010 §6.2 transition note. L-1 baseline preserved literally: a v1.3 binary in the unset/unset cell continues to be accepted and processed exactly as a pre-SPEC-010/SPEC-011 binary per SPEC-001 v1.3 §6.7.3 cell 1 and SPEC-010 §4.1 back-compat analysis. NO new buyer HTTP surface; NO routing-behavior change; NO Tier-2 (SPEC-008) expansion; NO change to existing FR-P* numbering or AC numbering.
@@ -1326,7 +1338,13 @@ Response:
       "last_heartbeat_at": "2026-05-27T14:30:00Z",
       "connected_at": "2026-05-27T12:00:00Z",
       "binary_version": "0.1.0",
-      "endpoint_url": "https://m4.streamvc.live"
+      "endpoint_url": "https://m4.streamvc.live",
+      "receipt_pubkey": "<base64-32-byte-ed25519>" | null,
+      "receipt_pubkey_prev": null | {
+        "pubkey": "<base64-32-byte-ed25519>",
+        "rotated_at": "2026-06-22T12:00:00Z",
+        "expires_at": "2026-06-29T12:00:00Z"
+      }
     }
   ],
   "summary": {
@@ -1350,6 +1368,16 @@ Response:
 ```
 
 The `summary` block is the SPEC-006 v0.3 gateway input for `/v1/status`; the detailed `pool` array is operator-only and MUST NOT be exposed to buyers by the gateway.
+
+SPEC-015 v0.1.3 adds the two receipt fields shown above as the SPEC-002
+v1.4 absorption. `receipt_pubkey` is `null` when the provider did not
+publish SPEC-001 v1.6 `auth_request.provider_receipt_public_key`;
+otherwise it is the provider's current standard padded base64 32-byte
+ed25519 receipt public key. `receipt_pubkey_prev` is `null` outside the
+SPEC-015 rotation grace window; during that window it carries the prior
+pubkey plus coordinator UTC timestamps `rotated_at` and `expires_at`.
+Both fields are additive to the provider row and consumers MUST tolerate
+their absence when reading pre-v1.4 coordinator responses.
 
 Returns HTTP 401 if the operator key is missing or invalid.
 
@@ -2334,7 +2362,9 @@ No authentication. Returns coordinator health (FR-O1).
 #### GET /poolz
 
 Requires `Authorization: Bearer <operator-key>`. Returns full pool
-state (FR-O2). See FR-O2 for response schema.
+state (FR-O2). See FR-O2 for response schema, including the optional
+SPEC-015 v0.1.3 `receipt_pubkey` and `receipt_pubkey_prev` provider
+row fields.
 
 **401 Unauthorized** if operator key missing or invalid.
 

--- a/specs/SPEC-006-buyer-api.md
+++ b/specs/SPEC-006-buyer-api.md
@@ -1,7 +1,14 @@
 # SPEC-006 - Buyer API Gateway: Mac Provider's first public buyer surface
 
-**Version:** 0.8.3 (2026-05-31, context-cancel reservation refund invariant)
+**Version:** 0.9 (2026-06-22, SPEC-015 v0.1.3 receipt response-header allowlist absorption)
 **Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.3.4, SPEC-003 v0.7, SPEC-004 v0.2
+
+**Change log v0.9:**
+- SPEC-015 v0.1.3 absorption: adds `X-MacProvider-Receipt` to the
+  documented response-pass-through allowlist so the gateway forwards
+  provider-issued non-streaming inference receipt headers unchanged.
+  The inbound buyer request header strip rules are unchanged, and no
+  second receipt-related `X-MacProvider-*` response header is added.
 
 **Change log v0.8.3:**
 - Enumerates the § 17.7 context-cancel refund invariant already enforced by gateway code: cancelled or timed-out buyer connections at quota or concurrency reservation gates MUST refund reservations before return and MUST NOT write a 500 to the dead connection.
@@ -1082,6 +1089,11 @@ The gateway MUST strip these upstream coordinator response headers before return
 - `X-MacProvider-Route`
 - any response header starting with `X-MacProvider-` that is not on a documented response-pass-through allowlist
 
+The documented response-pass-through allowlist is:
+
+- `X-MacProvider-Receipt`, emitted by SPEC-015 v0.1.3 non-streaming
+  receipt-capable providers and forwarded unchanged by the gateway.
+
 The gateway MUST reject immediately with 503 when no provider slot is immediately available.
 
 The gateway MUST NOT queue buyer requests waiting for future capacity.
@@ -1734,6 +1746,11 @@ The explicit outbound strip list is:
 - `X-MacProvider-Provider`
 - `X-MacProvider-Route`
 - any other `X-MacProvider-*` response header not on a documented response-pass-through allowlist
+
+The documented response-pass-through allowlist is:
+
+- `X-MacProvider-Receipt`, emitted by SPEC-015 v0.1.3 non-streaming
+  receipt-capable providers and forwarded unchanged by the gateway.
 
 The gateway MAY expose a public request ID.
 

--- a/specs/SPEC-015-IMPL-STEP_0-audit.md
+++ b/specs/SPEC-015-IMPL-STEP_0-audit.md
@@ -1,0 +1,24 @@
+# SPEC-015 IMPL Step 0 audit
+
+**Step:** 0 — locked-spec candidate absorption  
+**Branch:** `impl/spec-015-step-00`  
+**Prompt:** `specs/AUDIT_SPEC_015_IMPL_STEP_0_PROMPT.md`  
+**Tool:** `omc ask codex`  
+**Artifact:** `.omc/artifacts/ask/codex-audit-spec-015-impl-step-0-locked-spec-candidate-absorption--2026-06-22T09-48-17-871Z.md`
+
+## Round 1
+
+**Verdict:** READY  
+**Counts:** CRITICAL 0 / MAJOR 0 / MINOR 1
+
+### Findings
+
+- MINOR: `specs/SPEC-002-coordinator.md` still has `Depends on:
+  SPEC-001 v1.4` while the new `/poolz` receipt text references
+  SPEC-001 v1.6. The auditor classified this as dependency-line clarity
+  only; the added receipt contract points to the correct SPEC-001 v1.6
+  field.
+
+### Gate
+
+Step 0 lock gate is satisfied: 0 CRITICAL and 0 MAJOR findings.


### PR DESCRIPTION
## Summary
- bump SPEC-001 to v1.6 and add parser-optional initial-stage provider_receipt_public_key
- bump SPEC-002 to v1.4 and add /poolz receipt_pubkey + receipt_pubkey_prev shape
- bump SPEC-006 to v0.9 and allowlist X-MacProvider-Receipt response pass-through
- add Step 0 audit prompt and audit summary

## Verification
- git diff --check
- omc ask codex Step 0 audit: READY, 0 CRITICAL / 0 MAJOR / 1 MINOR

## Notes
- Base is spec/015-receipts-v0-1 because origin/main does not yet contain SPEC-015 or BUILD_SPEC_015_IMPL_PROMPT.md; this keeps the PR scoped to Step 0.