### PR TITLE
Extend JCS before receipt hashing

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/RFC8785JCS.swift
+++ b/phase3-binary/Sources/macprovider-cli/RFC8785JCS.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import JavaScriptCore
 
 enum RFC8785JCS {
     enum Value: Equatable {
@@ -7,6 +8,7 @@ enum RFC8785JCS {
         case array([Value])
         case string(String)
         case int(Int)
+        case double(Double)
         case bool(Bool)
         case null
     }
@@ -19,15 +21,17 @@ enum RFC8785JCS {
                 guard let member = object[key] else {
                     throw Error.missingObjectMember(key)
                 }
-                return "\(escapeString(key)):\(try canonicalString(member))"
+                return "\(escapeString(key, normalizeNFC: false)):\(try canonicalString(member))"
             }
             return "{\(members.joined(separator: ","))}"
         case .array(let array):
             return try "[\(array.map { try canonicalString($0) }.joined(separator: ","))]"
         case .string(let string):
-            return escapeString(string)
+            return escapeString(string, normalizeNFC: true)
         case .int(let int):
             return String(int)
+        case .double(let double):
+            return try canonicalDouble(double)
         case .bool(let bool):
             return bool ? "true" : "false"
         case .null:
@@ -45,9 +49,25 @@ enum RFC8785JCS {
         lhs.utf16.lexicographicallyPrecedes(rhs.utf16)
     }
 
-    private static func escapeString(_ string: String) -> String {
+    private static func canonicalDouble(_ double: Double) throws -> String {
+        guard double.isFinite else {
+            throw Error.nonFiniteDouble
+        }
+        guard let context = JSContext() else {
+            throw Error.numberFormatterUnavailable
+        }
+        context.setObject(double, forKeyedSubscript: "n" as NSString)
+        guard let formatted = context.evaluateScript("JSON.stringify(n)")?.toString(),
+              formatted != "null" else {
+            throw Error.numberFormatterUnavailable
+        }
+        return formatted
+    }
+
+    private static func escapeString(_ string: String, normalizeNFC: Bool) -> String {
+        let source = normalizeNFC ? string.precomposedStringWithCanonicalMapping : string
         var escaped = "\""
-        for scalar in string.unicodeScalars {
+        for scalar in source.unicodeScalars {
             switch scalar.value {
             case 0x22:
                 escaped += "\\\""
@@ -77,5 +97,7 @@ enum RFC8785JCS {
 
     enum Error: Swift.Error, Equatable {
         case missingObjectMember(String)
+        case nonFiniteDouble
+        case numberFormatterUnavailable
     }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/RFC8785JCSTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/RFC8785JCSTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class RFC8785JCSTests: XCTestCase {
+    func testStringValuesAreNormalizedToNFCBeforeEscaping() throws {
+        let decomposed = "Cafe\u{0301}"
+        let precomposed = "Caf\u{00e9}"
+
+        XCTAssertEqual(try RFC8785JCS.canonicalString(.string(decomposed)), "\"\(precomposed)\"")
+        XCTAssertEqual(
+            try RFC8785JCS.canonicalString(.string(decomposed)),
+            try RFC8785JCS.canonicalString(.string(precomposed))
+        )
+    }
+
+    func testASCIIStringNormalizationIsNoOp() throws {
+        XCTAssertEqual(
+            try RFC8785JCS.canonicalString(.string("plain ASCII")),
+            "\"plain ASCII\""
+        )
+    }
+
+    func testDoubleFormattingMatchesRFC8785ECMAScriptRules() throws {
+        let cases: [(Double, String)] = [
+            (0.0, "0"),
+            (-0.0, "0"),
+            (1.0, "1"),
+            (1.1, "1.1"),
+            (1e-7, "1e-7"),
+            (1e-6, "0.000001"),
+            (1e20, "100000000000000000000"),
+            (1e21, "1e+21"),
+            (333333333.33333329, "333333333.3333333"),
+            (4.5, "4.5"),
+            (2e-3, "0.002"),
+            (1e-27, "1e-27"),
+            (1.2345678901234568e30, "1.2345678901234568e+30"),
+        ]
+
+        for (input, expected) in cases {
+            XCTAssertEqual(
+                try RFC8785JCS.canonicalString(.double(input)),
+                expected,
+                "Unexpected canonical form for \(input)"
+            )
+        }
+    }
+
+    func testNonFiniteDoublesAreRejected() {
+        XCTAssertThrowsError(try RFC8785JCS.canonicalString(.double(.nan))) { error in
+            XCTAssertEqual(error as? RFC8785JCS.Error, .nonFiniteDouble)
+        }
+        XCTAssertThrowsError(try RFC8785JCS.canonicalString(.double(.infinity))) { error in
+            XCTAssertEqual(error as? RFC8785JCS.Error, .nonFiniteDouble)
+        }
+        XCTAssertThrowsError(try RFC8785JCS.canonicalString(.double(-.infinity))) { error in
+            XCTAssertEqual(error as? RFC8785JCS.Error, .nonFiniteDouble)
+        }
+    }
+
+    func testExistingIntegerBooleanNullArrayAndObjectBehaviorIsUnchanged() throws {
+        let value = RFC8785JCS.Value.object([
+            "z": .array([.int(1), .bool(false), .null]),
+            "a": .string("line\nquote\"slash\\"),
+            "m": .object([
+                "b": .int(2),
+                "a": .bool(true),
+            ]),
+        ])
+
+        XCTAssertEqual(
+            try RFC8785JCS.canonicalString(value),
+            #"{"a":"line\nquote\"slash\\","m":{"a":true,"b":2},"z":[1,false,null]}"#
+        )
+    }
+
+    func testTupleTierASCIIFieldsHashUnchangedByNFCStep() throws {
+        let value = RFC8785JCS.Value.object([
+            "model_id": .string("mlx-community/Qwen2.5-Coder-7B-Instruct-4bit"),
+            "output_hash": .string("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+            "prompt_hash": .string("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            "provider_pubkey": .string("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="),
+            "tokens_out": .int(42),
+            "ttft_ms": .int(1234),
+            "unix_ts": .int(1_771_234_567),
+        ])
+
+        XCTAssertEqual(
+            try RFC8785JCS.canonicalString(value),
+            #"{"model_id":"mlx-community/Qwen2.5-Coder-7B-Instruct-4bit","output_hash":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","prompt_hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","provider_pubkey":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","tokens_out":42,"ttft_ms":1234,"unix_ts":1771234567}"#
+        )
+    }
+}

--- a/phase3-binary/implementation-notes.html
+++ b/phase3-binary/implementation-notes.html
@@ -17,6 +17,35 @@ code { background: #f4f4f4; padding: 0.1em 0.3em; border-radius: 3px; }
 <p class=meta>Status: <strong>3h local soak PASS · M4 parity validation pending</strong> · Spec:
 <a href="../specs/SPEC-001-phase3-binary.md">SPEC-001 v1.1.1</a></p>
 
+<section id="spec015-receipts-step1">
+  <h2>SPEC-015 design decisions — Step 1 JCS canonicalizer extensions (2026-06-22)</h2>
+  <div class="entry">
+    <time>2026-06-22</time>
+    <p><strong>Scope:</strong> extended <code>RFC8785JCS</code> for
+    SPEC-015 v0.1.3 receipt hashing prerequisites only: NFC normalization for
+    JSON string values and RFC 8785 / ECMAScript JSON-number rendering for
+    finite <code>Double</code> values.</p>
+    <p><strong>Number-format decision:</strong> Swift's native
+    <code>String(Double)</code> and <code>JSONSerialization</code> do not match
+    RFC 8785 for required cases such as <code>-0.0</code>,
+    <code>1.0</code>, <code>1e20</code>, and <code>1.1</code>. The
+    implementation delegates only the numeric string rendering to the
+    platform JavaScriptCore ECMAScript engine via <code>JSON.stringify(n)</code>
+    after rejecting NaN and infinities. This keeps the existing in-house JCS
+    object/array/string/int path intact while using the same ECMAScript number
+    semantics RFC 8785 normatively references.</p>
+    <p><strong>NFC decision:</strong> normalization is applied to JSON string
+    values immediately before escaping. Object keys are not normalized; the
+    receipt and prompt/output canonical object keys are fixed ASCII names, and
+    preserving key bytes avoids changing existing key-order semantics.</p>
+    <p><strong>Deviations:</strong> none for Step 1. No receipt signing,
+    Keychain, coordinator, or gateway behavior is implemented in this step.</p>
+    <p><strong>Open questions:</strong> if a future Linux provider binary is
+    introduced, the JavaScriptCore dependency will need a replacement
+    ECMAScript-compatible dtoa implementation or a platform abstraction.</p>
+  </div>
+</section>
+
 <section id="spec013-autotune-step1">
   <h2>SPEC-013 design decisions — Step 1 autotune scaffold (2026-06-18)</h2>
   <div class="entry">

--- a/specs/AUDIT_SPEC_015_IMPL_STEP_1_PROMPT.md
+++ b/specs/AUDIT_SPEC_015_IMPL_STEP_1_PROMPT.md
@@ -1,0 +1,99 @@
+# AUDIT_SPEC_015_IMPL_STEP_1 — JCS canonicalizer extensions
+
+You are auditing the implementation branch for BUILD_SPEC_015 Step 1 in
+`/Users/augstar/macprovider-poc-spec015-step01`.
+
+## Normative sources
+
+- `specs/BUILD_SPEC_015_IMPL_PROMPT.md` Step 1.
+- `specs/SPEC-015-receipts.md` v0.1.3, especially §3.2 and AC-5/AC-6.
+- `phase3-binary/Sources/macprovider-cli/RFC8785JCS.swift`.
+- `phase3-binary/Tests/macprovider-cliTests/RFC8785JCSTests.swift`.
+- `phase3-binary/implementation-notes.html`.
+
+## Scope under audit
+
+Step 1 is limited to the Swift JCS canonicalizer prerequisite for receipts:
+
+1. Add NFC normalization on JSON string values before escaping.
+2. Add RFC 8785 §3.2.2.3 / ECMAScript-compatible finite `Double`
+   serialization via `RFC8785JCS.Value.double(Double)`.
+3. Reject NaN and infinities.
+4. Keep existing int, bool, null, string, array, object behavior
+   backward-compatible.
+5. Add focused Swift tests and phase3 implementation notes.
+
+No receipt signing, Keychain, coordinator, gateway, locked-spec text, or
+wire-protocol work should land in this step.
+
+## Required local commands
+
+Run or inspect equivalent fresh evidence:
+
+```bash
+git diff --check
+env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --package-path phase3-binary --filter RFC8785JCSTests
+env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --package-path phase3-binary
+```
+
+## Audit lenses
+
+### Code auditor
+
+- Verify `.double(Double)` is integrated into `RFC8785JCS.Value` and
+  `canonicalString(_:)` without changing existing object/array/int/bool/null
+  semantics.
+- Verify NFC normalization is applied before escaping string values.
+- Verify object key sorting remains UTF-16 lexicographic and existing ASCII
+  tuple-tier fields remain byte-stable.
+- Verify the tests cover the minimum cases from the BUILD prompt: decomposed
+  vs precomposed NFC equality, ASCII no-op, `0.0`, `-0.0`, `1.0`, `1.1`,
+  `1e-7`, `1e20`, NaN rejection, infinity rejection, and old-type behavior.
+
+### Security auditor
+
+- Verify NaN and infinities cannot serialize as `null`, `"nan"`, `"inf"`, or
+  any other accepted canonical number.
+- Verify the implementation does not add receipt persistence, secret logging,
+  key material, network calls, or external package dependencies.
+- Verify the JavaScriptCore use cannot execute attacker-controlled script; it
+  should only format a numeric value with a fixed script.
+- Verify no receipt tuple hashes, signatures, or pubkeys are logged.
+
+### Architect auditor
+
+- Verify the implementation remains one shared canonicalizer and does not
+  introduce a parallel receipt-specific JCS path.
+- Verify the JavaScriptCore number-formatting decision is documented with the
+  platform constraint and future Linux caveat.
+- Verify Step 1 does not leak into later BUILD_SPEC_015 steps.
+- Verify the design is compatible with later prompt hashing, where only
+  prompt canonical-object floats exercise `.double`.
+
+## Severity contract
+
+Report findings with severities:
+
+- `CRITICAL`: violates a locked spec, emits wrong canonical bytes for required
+  RFC 8785/JCS cases, accepts non-finite numbers, or implements out-of-scope
+  receipt/key/coordinator/gateway behavior.
+- `HIGH`: likely receipt verification divergence, unsafe script execution,
+  missing required tests for a mandatory Step 1 behavior, or architecture that
+  creates a parallel canonicalizer.
+- `MEDIUM`: incomplete edge-case coverage, undocumented tradeoff that future
+  implementers need, or fragile implementation likely to break AC-5/AC-6.
+- `LOW`: style, clarity, or optional additional coverage.
+
+The gate to proceed is **0 CRITICAL / 0 HIGH / 0 MEDIUM**. LOW findings may
+remain if explicitly justified.
+
+## Expected output
+
+Return:
+
+1. Verdict: `READY` or `FIX REQUIRED`.
+2. Counts: `CRITICAL n / HIGH n / MEDIUM n / LOW n`.
+3. Findings grouped by code/security/architecture lens, with concrete file and
+   line references.
+4. Verification commands actually run and their results.
+5. Any residual risk.

--- a/specs/SPEC-015-IMPL-STEP_1-audit.md
+++ b/specs/SPEC-015-IMPL-STEP_1-audit.md
@@ -1,0 +1,40 @@
+# SPEC-015 implementation Step 1 audit
+
+Step: JCS canonicalizer extensions.
+
+Branch/worktree:
+
+- Branch: `impl/spec-015-step-01`
+- Worktree: `/Users/augstar/macprovider-poc-spec015-step01`
+- Base: `origin/spec/015-receipts-v0-1` after Step 0 landed
+
+## Audit prompt
+
+Checked-in prompt:
+
+- `specs/AUDIT_SPEC_015_IMPL_STEP_1_PROMPT.md`
+
+## Round 1
+
+Tool:
+
+- `omc ask codex`
+
+Artifact:
+
+- `.omc/artifacts/ask/codex-audit-spec-015-impl-step-1-jcs-canonicalizer-extensions-you--2026-06-22T12-24-21-772Z.md`
+
+Result:
+
+- Verdict: `READY`
+- Counts: `CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0`
+
+Auditor verification evidence:
+
+- `git diff --check`: passed, no output.
+- `env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --package-path phase3-binary --filter RFC8785JCSTests`: passed, 6 tests, 0 failures.
+- `env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --package-path phase3-binary`: passed, 430 tests, 7 skipped, 0 failures.
+
+Gate:
+
+- Step 1 gate satisfied: 0 critical / 0 high / 0 medium findings.


### PR DESCRIPTION
## Summary
- extend the shared Swift RFC8785JCS canonicalizer with NFC string-value normalization
- add finite Double canonicalization using ECMAScript JSON.stringify semantics via JavaScriptCore
- reject NaN and infinities before number rendering
- add focused RFC8785JCSTests plus phase3 implementation notes
- add Step 1 audit prompt and audit summary

## Verification
- git diff --check
- env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --package-path phase3-binary --filter RFC8785JCSTests: 6 tests, 0 failures
- env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --package-path phase3-binary: 430 tests, 7 skipped, 0 failures
- omc ask codex Step 1 audit: READY, 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW

## Notes
- Depends on Step 0 already merged into spec/015-receipts-v0-1.
- This PR intentionally does not implement receipt signing, Keychain storage, coordinator parsing, or gateway forwarding.