### PR TITLE
fix(deploy): proxy /v1/receipt-keys/ on coordinator nginx (caught in PR #124 prod deploy)

### DIFF
--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -138,9 +138,29 @@ server {
     }
 
     # ---------------------------------------------------------------------
+    # /v1/receipt-keys/<provider_id> — public buyer endpoint per SPEC-002
+    # v1.5 candidate annotation + SPEC-015 §10.7. UNAUTHENTICATED. Lives on
+    # buyer_port (8443), NOT operator port. Rate-limited inside the
+    # coordinator (10 req/s per remote IP, 4 KiB max response, redacted to
+    # exactly {provider_id, receipt_pubkey, receipt_pubkey_prev, fetched_at}).
+    # MUST be declared BEFORE the catch-all `location /v1/` 404 block so the
+    # location-prefix longest-match rule routes receipt-keys requests here.
+    # ---------------------------------------------------------------------
+    location /v1/receipt-keys/ {
+        proxy_pass http://127.0.0.1:8443;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 10s;
+    }
+
+    # ---------------------------------------------------------------------
     # /v1/* is intentionally not exposed on the coordinator hostname.
     # Buyer API traffic must enter through the gateway so account auth,
     # quota enforcement, demo restrictions, and header allowlisting apply.
+    # The /v1/receipt-keys/ exception above is per SPEC-015 v0.2 — the
+    # verifier MUST be able to fetch trust-root pubkeys without operator
+    # credentials.
     # ---------------------------------------------------------------------
     location /v1/ {
         return 404;


### PR DESCRIPTION
## Summary

Adds the nginx route block for `/v1/receipt-keys/<provider_id>` that was missing from PR #124's Step 0 work. The handler exists in coordinator code (lives on buyer port 8443), but the nginx site config had a catch-all `location /v1/ { return 404; }` block that intentionally blocked all `/v1/*` paths on the coordinator hostname.

Surfaced live during the verify-v1.0.0 production deploy on Pearl: smoke check returned nginx's text/html 404 instead of the coordinator's `application/json` envelope.

## Fix

Explicit `location /v1/receipt-keys/` block proxying to `127.0.0.1:8443`, placed **before** the catch-all `location /v1/` 404 block so nginx's prefix-longest-match rule routes receipt-keys requests through while every other `/v1/*` path stays 404.

```nginx
location /v1/receipt-keys/ {
    proxy_pass http://127.0.0.1:8443;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_read_timeout 10s;
}
```

## Test plan

- [x] Verified live at `https://coordinator.streamvc.live/v1/receipt-keys/unknown-id` — returns `application/json` 404 with the coordinator's error envelope
- [x] `nginx -t` passes on Pearl
- [x] Provenance check: deployed coordinator at `verify-v1.0.0`
- [ ] Will return real keys once a v1.6+ provider connects (pool currently empty)

## Why this wasn't caught earlier

The IMPL audit chain (22 codex rounds + Claude 3-lens) covered the handler implementation + tests, but the nginx site config was treated as deploy-tooling — not exercised by unit/integration tests. The Step 9 mock used httptest.NewTLSServer rather than testing through the real nginx config.

Follow-up: PR #124 surfaced an existing finding (issue #125) that the rate-limit keying is broken behind nginx. Both that and this nginx-routing gap suggest CI should grow a "nginx-config-vs-handler-routes" lint that asserts every public buyer-port handler has a corresponding nginx `location` block.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
