### PR TITLE
SPEC-015 v0.3 IMPL — model-hash binding (6 steps + bundle audit, 19 audit rounds)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test-integration:
 test-dist:
 	bash phase4-coordinator/dist/test/check_deploy_config_test.sh
 	bash phase4-coordinator/dist/test/check_nginx_receipt_buffers_test.sh
+	bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh
 	SPEC015_NGINX_LIVE_OPTIONAL=$${SPEC015_NGINX_LIVE_OPTIONAL:-1} bash phase4-coordinator/dist/test/check_nginx_receipt_header_live_test.sh
 
 vet: vet-coordinator vet-gateway vet-integration

--- a/audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md
+++ b/audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md
@@ -1,0 +1,173 @@
+# SPEC-015 v0.3 operator runbook — model-hash receipt binding
+
+**Audience:** Pearl operator landing v0.3 receipt + verifier + coordinator surface.
+
+**Scope:** After the SPEC-015 v0.3 IMPL bundle merges to `main`, this runbook walks the production cutover.
+
+## Pre-deploy state (what's on `main` after PR merge)
+
+- **SPEC**: `specs/SPEC-015-receipts.md` at v0.3.3 LOCKED.
+- **Provider** (`phase3-binary/`): emits v0.3 9-field receipts. Tuple shape: `model_hash`, `model_id`, `output_hash`, `prompt_hash`, `provider_pubkey`, `receipt_version="3"`, `tokens_out`, `ttft_ms`, `unix_ts` (JCS canonical order). `model_hash` is the SHA-256 of the loaded MLX container at the request-start snapshot, OR JSON `null` when warm-swap is disabled.
+- **Coordinator** (`phase4-coordinator/`): `/poolz` emits new top-level `catalog_id`, `catalog_url`, `catalog_pubkey_url` fields when a tier-2 catalog is effectively active. New public endpoints `GET /catalog/<catalog_id>` and `GET /catalog/pubkey` on the buyer port (8443).
+- **Nginx**: `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf` proxies `/catalog/` to 127.0.0.1:8443. Deploy gate `check_nginx_catalog_routes_test.sh` asserts the block is present + correctly ordered before any remote mutation.
+- **Verifier** (`phase7-verify/`): 5 new CLI flags (`--catalog`, `--catalog-url`, `--catalog-pubkey`, `--catalog-pubkey-url`, `--require-model-hash`). Tri-state `model_hash_verified` in JSON output. Catalog-cache layer (§M.3.4 three-band TTL).
+
+## Pre-deploy checklist
+
+Run from a clean working tree on `main` after the v0.3 IMPL PR squash-merges:
+
+```bash
+git fetch origin
+git reset --hard origin/main
+
+# 1. SPEC version reads v0.3.x LOCKED
+head -3 specs/SPEC-015-receipts.md
+
+# 2. All builds clean
+cd phase3-binary && swift build && swift test && cd ..
+cd phase4-coordinator && go vet ./... && go test ./... -count=1 && cd ..
+cd phase7-verify && go vet ./... && go test ./... -count=1 -race && cd ..
+
+# 3. AC manifest covers v0.3
+cd test/integration && go test ./spec015/ -count=1 -timeout 120s -run "TestSpec015AcceptanceCriteria|TestSpec015V03AcceptanceCriteria"
+cd ../..
+
+# 4. Pre-deploy gates green
+make test-dist
+```
+
+If any of the above fails, do NOT proceed with the deploy.
+
+## Deploy choreography (Pearl coordinator)
+
+### 1. Coordinator binary + nginx conf
+
+The Pearl coordinator at `coordinator.streamvc.live` needs:
+
+- The new binary built from the IMPL bundle.
+- The updated `nginx-coordinator.streamvc.live.conf` with the `/catalog/` proxy block.
+- The `coordinator.yaml` field `tier2.public_catalog_base_url: "https://coordinator.streamvc.live"`. The five tier-2 `require_*` flags STAY at the Entry 80 defaults (all `false`).
+
+Use the existing `phase4-coordinator/dist/deploy-pearl-vps.sh` script. It now runs `check_nginx_catalog_routes_test.sh` in step 0 (pre-SSH) — if the local nginx conf is stale, it exits 5 with `aborting deploy: nginx /catalog/ routes missing or misconfigured`.
+
+```bash
+cd phase4-coordinator/dist
+GATEWAY_CONFIG=../../phase5-gateway/dist/gateway.yaml bash deploy-pearl-vps.sh
+```
+
+### 2. Smoke check `/poolz` + `/catalog/...`
+
+After SSH + binary install + nginx reload:
+
+```bash
+# /poolz should include catalog_id, catalog_url, catalog_pubkey_url
+OP=$(gh secret list ...)  # operator key
+curl -s -H "Authorization: Bearer $OP" https://coordinator.streamvc.live/poolz | jq 'keys'
+# Expect: ["catalog_id", "catalog_pubkey_url", "catalog_url", "pool", "summary"]
+
+# /catalog/pubkey should return the operator-configured pubkey
+curl -s https://coordinator.streamvc.live/catalog/pubkey
+# Expect: {"pubkey":"<43-char base64url>","alg":"Ed25519"}
+
+# /catalog/<id> should return the on-disk signed catalog bytes verbatim
+CID=$(curl -s -H "Authorization: Bearer $OP" https://coordinator.streamvc.live/poolz | jq -r '.catalog_id')
+curl -s "https://coordinator.streamvc.live/catalog/$CID" | jq '.catalog_id, .version, (.models | length)'
+```
+
+If `/poolz` does NOT include the three new fields, check:
+
+- Is `Tier2Config.CatalogPath` set on Pearl `coordinator.yaml`?
+- Did `tier2.Default().Active()` return true? Check coordinator logs for `event:"catalog_loaded"`.
+- Is the configured `CatalogPublicKey` the base64url-unpadded form of the matching pubkey?
+
+If `/catalog/pubkey` returns 404, check the same three conditions.
+
+### 3. Provider binary distribution
+
+The v0.3 provider binary emits the new 9-field receipt. **Existing v0.1/v0.2 verifiers (locked releases) will report v0.3 receipts as `invalid` per §M.1.2.** Coordinate the verifier upgrade BEFORE the provider upgrade reaches buyers:
+
+1. Build + sign the new provider binary.
+2. Build + release the new `phase7-verify` binary (v1.1.0+). Announce on the release page.
+3. THEN roll out the provider binary to Macs (M1, M4, air5, etc.).
+
+For warm-swap-enabled providers, every receipt will carry the loaded MLX container's SHA-256. For warm-swap-disabled providers (the SPEC-011 R-3.3.0 default), every receipt will carry `model_hash: null` and the verifier will report `valid` without catalog-check unless the buyer passes `--require-model-hash`.
+
+### 4. Buyer-side rollout
+
+Buyers should:
+
+- Upgrade to `macprovider-verify` v1.1.0+. The v1.0.x line VERIFIES v0.1/v0.2 receipts only and will REPORT v0.3 receipts as `invalid` (§M.1.2 forward-incompat).
+- Optionally pass `--catalog-url https://coordinator.streamvc.live/catalog/<id>` + `--catalog-pubkey-url https://coordinator.streamvc.live/catalog/pubkey` to get model-hash attestation when the receipt carries a non-null hash.
+- Buyers wanting STRICT hash attestation (fail-closed on null hash, fail-closed on missing catalog match) should add `--require-model-hash`. This rejects every receipt from a warm-swap-disabled provider.
+
+## Monitoring
+
+Pearl journald already shows `model_hash_verified` events from the coordinator-side observation mode. After v0.3 deploys, watch:
+
+```bash
+ssh -i ~/.ssh/pearl_operator_ed25519 root@159.223.165.194 \
+  'journalctl -u macprovider-coordinator --since "24h" --no-pager | grep -E "model_hash_verified|catalog_loaded|catalog_signature_invalid"'
+```
+
+- `catalog_loaded` should appear once at coordinator startup and on every SIGHUP reload.
+- `model_hash_verified` should continue to fire on heartbeats; the `decision`+`reason` fields tell you what the coordinator-side check decided.
+- `catalog_signature_invalid` is an alarm; means the operator-configured `CatalogPublicKey` doesn't match the catalog file.
+
+## Rollback
+
+If anything regresses (auth, routing, or `/poolz` shape), follow the
+canonical rollback procedure at
+[`audits/2026-06-10/ROLLBACK_PROCEDURE.md`](../2026-06-10/ROLLBACK_PROCEDURE.md).
+TL;DR for the v0.3 IMPL bundle:
+
+```bash
+# Restore the previous binary. The deploy script at
+# phase4-coordinator/dist/deploy-pearl-vps.sh step 4/9 snapshots the
+# pre-upload binary to /opt/macprovider/coordinator.prev with
+# `install -o macprovider -g macprovider -m 0755`. Swap in place:
+ssh -i ~/.ssh/pearl_operator_ed25519 root@159.223.165.194 \
+  'systemctl stop macprovider-coordinator && \
+   install -o macprovider -g macprovider -m 0755 \
+     /opt/macprovider/coordinator.prev /opt/macprovider/coordinator && \
+   systemctl start macprovider-coordinator'
+```
+
+**Nginx rollback.** The deploy script does NOT automatically snapshot
+`/etc/nginx/sites-available/coordinator.streamvc.live.conf` before the
+new conf is installed. If you want a runtime rollback for the nginx
+site, snapshot it BEFORE the deploy:
+
+```bash
+ssh -i ~/.ssh/pearl_operator_ed25519 root@159.223.165.194 \
+  "cp /etc/nginx/sites-available/coordinator.streamvc.live.conf \
+      /etc/nginx/sites-available/coordinator.streamvc.live.conf.bak-$(date -u +%Y%m%dT%H%M%SZ)"
+```
+
+To roll back nginx, restore the timestamped backup you took above,
+then `nginx -t && systemctl reload nginx`.
+
+`RequireHashVerified` was NOT flipped, so no routing-policy rollback
+is needed. The `/catalog/*` endpoint surfaces are additive and zero-
+risk if rolled back (verifiers fall back to file-mode `--catalog`).
+
+## Entry 80 invariant
+
+**This deploy does NOT flip `Tier2Config.RequireHashVerified`.** Per `beta/DECISION_CRITERIA.md` Entry 80 (2026-06-22), the flag stays at its `false` default until the team has a buyer-side reason to flip it. v0.3 makes the RECEIPT bind the hash; the coordinator's route/reject policy is independent and unchanged. AC-40 + §M.6 #1 are the spec anchors.
+
+## DECISION_CRITERIA close-out
+
+After v0.3 IMPL ships and the coordinator deploy is queued/landed:
+
+- Append an entry to `beta/DECISION_CRITERIA.md` covering: IMPL step count, audit-round count, what landed, what's deferred to v0.4+, explicit reference to Entry 80 preservation.
+- README.md line 22 + lines 113-137 update: v0.3 closes the `model_hash` binding gap; v0.3 receipts are verifiable end-to-end against an operator-signed catalog.
+
+## v0.4+ candidates (deferred per §M.6)
+
+- Streaming receipts (§15 Q5).
+- Multi-hash receipts for swap-spanning streaming responses (§15 Q7).
+- Cross-catalog federation.
+- On-chain anchoring of catalog Merkle roots (§15 Q1 / Cluster D).
+- Quantization-aware verification (one `model_id` accept-list of multiple hashes).
+- TUF / signed-root upgrade of the catalog-pubkey trust root (§15 Q1).
+
+None of these are landing in v0.3.

--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -230,19 +230,48 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
             let providerStatus = providerStatus
             Task.detached { @Sendable [modelRuntime, providerStatus, request, writer, warmSwapEnabled, receiptBuilder, providerID, auditRequestID] in
                 let startedAt = await providerStatus.beginRequest()
+                // SPEC-015 §M.2.2 atomic-read invariant — capture
+                // the pre-snapshot for warm-swap validation, then
+                // call `completeWithServedSnapshot` which returns
+                // the actor-isolated snapshot the runtime used to
+                // drive generation. Binding `model_hash` to the
+                // SERVED snapshot (not the pre-snapshot) closes the
+                // interleaving gap a separately-sampled
+                // `currentSnapshot()` would leave open. Error /
+                // catch paths fall back to the pre-snapshot for the
+                // §7.6 / AC-31 error-receipt hash inheritance
+                // (no served snapshot exists when complete() throws).
+                let preSnapshot = await modelRuntime.currentSnapshot()
+                let fallbackHashSource = Self.resolveModelHashSource(
+                    warmSwapEnabled: warmSwapEnabled,
+                    snapshot: preSnapshot
+                )
                 do {
-                    let snapshot = await modelRuntime.currentSnapshot()
+                    let snapshot = preSnapshot
                     if let error = Self.warmSwapRejectionError(for: snapshot) {
                         throw error
                     }
                     if warmSwapEnabled {
                         try request.validateModelMatches(snapshot.modelID)
                     }
-                    let completion = try await modelRuntime.complete(request)
+                    let (completion, servedSnapshot) = try await modelRuntime.completeWithServedSnapshot(request, shouldCancel: { false })
+                    let modelHashSource = Self.resolveModelHashSource(
+                        warmSwapEnabled: warmSwapEnabled,
+                        snapshot: servedSnapshot
+                    )
                     let unixTsSeconds = Int64(Date().timeIntervalSince1970)
                     await providerStatus.finishRequest(startedAt: startedAt, completion: completion, failed: false)
                     let response = Self.chatCompletionResponse(request: request, completion: completion)
                     let ttftMs = completion.ttftMilliseconds ?? Self.elapsedMilliseconds(since: startedAt)
+                    // SPEC-015 §M.2.2 — bind the receipt's
+                    // `model_hash` to the runtime-served snapshot
+                    // returned above by
+                    // `completeWithServedSnapshot`. That snapshot
+                    // was captured atomically inside the actor turn
+                    // that drove generation (validation, in-flight
+                    // registration, container.perform), closing the
+                    // interleaving gap a separately-sampled
+                    // `currentSnapshot()` would leave open.
                     let receipt = try Self.receiptHeaderResult(
                         providerID: providerID,
                         receiptBuilder: receiptBuilder,
@@ -252,7 +281,8 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                         finishReason: completion.finishReason,
                         ttftMs: ttftMs,
                         tokensOut: Int64(completion.completionTokens),
-                        unixTsSeconds: unixTsSeconds
+                        unixTsSeconds: unixTsSeconds,
+                        modelHashSource: modelHashSource
                     )
                     switch receipt {
                     case .issued(let header):
@@ -280,7 +310,8 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                             receiptBuilder: receiptBuilder,
                             request: request,
                             error: apiErr,
-                            startedAt: startedAt
+                            startedAt: startedAt,
+                            modelHashSource: fallbackHashSource
                         )
                         switch receipt {
                         case .issued(let header, let ttftMs, let unixTs):
@@ -311,7 +342,8 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                             receiptBuilder: receiptBuilder,
                             request: request,
                             error: apiError,
-                            startedAt: startedAt
+                            startedAt: startedAt,
+                            modelHashSource: fallbackHashSource
                         )
                         switch receipt {
                         case .issued(let header, let ttftMs, let unixTs):
@@ -341,12 +373,29 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
             if let request = parsedRequest, !request.stream {
                 let writer = ResponseWriter(context: context)
                 do {
+                    // Parse-error path: the request failed to validate
+                    // before any runtime snapshot was taken, so no
+                    // request-start container was selected.
+                    // §M.2.2 construction proof: every receipt commits
+                    // to the hash that started generation — no
+                    // generation started here, so emit JSON null
+                    // (§M.2.3 semantics) for the receipt's
+                    // `model_hash` field.
+                    // Parse-error path: the request failed validation
+                    // before any model selection. The receipt commits
+                    // to `model_hash: null` semantically — no
+                    // generation ran, no container served. §M.2.3
+                    // null encoding is the right wire shape (NOT
+                    // .ambiguous, which is reserved for SPEC-011
+                    // R-3.4.1 regressions on requests that DID reach
+                    // inference).
                     let receipt = try Self.errorReceiptHeaderResult(
                         providerID: providerID,
                         receiptBuilder: receiptBuilder,
                         request: request,
                         error: parseError,
-                        startedAt: requestAcceptedAt
+                        startedAt: requestAcceptedAt,
+                        modelHashSource: .warmSwapDisabled
                     )
                     switch receipt {
                     case .issued(let header, let ttftMs, let unixTs):
@@ -534,7 +583,8 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         finishReason: String,
         ttftMs: Int64,
         tokensOut: Int64,
-        unixTsSeconds: Int64
+        unixTsSeconds: Int64,
+        modelHashSource: ReceiptModelHashSource
     ) throws -> String? {
         switch try receiptHeaderResult(
             providerID: providerID,
@@ -545,13 +595,38 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
             finishReason: finishReason,
             ttftMs: ttftMs,
             tokensOut: tokensOut,
-            unixTsSeconds: unixTsSeconds
+            unixTsSeconds: unixTsSeconds,
+            modelHashSource: modelHashSource
         ) {
         case .issued(let header):
             return header
         case .omitted:
             return nil
         }
+    }
+
+    /// SPEC-015 §M.2 — map (warmSwapEnabled, request-start snapshot)
+    /// to the receipt's `model_hash` provenance. §M.2.2 defence-in-
+    /// depth: if warm-swap is ON but the snapshot didn't carry a
+    /// hash (SPEC-011 R-3.4.1 in-flight tracking regression), the
+    /// runtime cannot disambiguate which container served and the
+    /// receipt-emission MUST refuse.
+    static func resolveModelHashSource(
+        warmSwapEnabled: Bool,
+        snapshot: RuntimeSnapshot
+    ) -> ReceiptModelHashSource {
+        if warmSwapEnabled {
+            if let hash = snapshot.modelHash {
+                return .captured(hash)
+            }
+            // Warm-swap is on; SPEC-011 R-3.4.1 should have produced
+            // a hash at request-start capture time. Absence is a
+            // regression — §M.2.2 defence-in-depth refusal.
+            return .ambiguous
+        }
+        // Warm-swap is off; SPEC-011 R-3.3.0 suppresses hash
+        // reporting. §M.2.3 null-hash semantics apply.
+        return .warmSwapDisabled
     }
 
     static func receiptHeaderResult(
@@ -563,13 +638,31 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         finishReason: String,
         ttftMs: Int64,
         tokensOut: Int64,
-        unixTsSeconds: Int64
+        unixTsSeconds: Int64,
+        modelHashSource: ReceiptModelHashSource
     ) throws -> ReceiptHeaderResult {
         guard let providerID, !providerID.isEmpty else {
             return .omitted(.noKeypair)
         }
         guard let receiptBuilder else {
             return .omitted(.preV16Binary)
+        }
+        // SPEC-015 §M.2.2 — fail-closed refusal BEFORE construction.
+        // The .ambiguous provenance can only arise from a SPEC-011
+        // R-3.4.1 in-flight-tracking regression; v0.3 normatively
+        // refuses to sign a receipt that cannot identify which
+        // container served. Audit row + no header. The HTTP 200
+        // response itself still goes out (the buyer got their
+        // tokens; the §M.2.2 normal construction proof allows the
+        // un-receipted 200 case).
+        let resolvedModelHash: String?
+        switch modelHashSource {
+        case .captured(let hash):
+            resolvedModelHash = hash
+        case .warmSwapDisabled:
+            resolvedModelHash = nil
+        case .ambiguous:
+            return .omitted(.modelSwapViolation)
         }
         do {
             let header = try receiptBuilder.build(
@@ -582,7 +675,8 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                     finishReason: finishReason,
                     ttftMs: ttftMs,
                     tokensOut: tokensOut,
-                    unixTsSeconds: unixTsSeconds
+                    unixTsSeconds: unixTsSeconds,
+                    modelHash: resolvedModelHash
                 )
             )
             guard header.utf8.count <= maxReceiptHeaderBytes else {
@@ -599,9 +693,10 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         receiptBuilder: ReceiptBuilder?,
         request: ChatCompletionRequest,
         error: APIError,
-        startedAt: Date
+        startedAt: Date,
+        modelHashSource: ReceiptModelHashSource
     ) throws -> String? {
-        switch try errorReceiptHeaderResult(providerID: providerID, receiptBuilder: receiptBuilder, request: request, error: error, startedAt: startedAt) {
+        switch try errorReceiptHeaderResult(providerID: providerID, receiptBuilder: receiptBuilder, request: request, error: error, startedAt: startedAt, modelHashSource: modelHashSource) {
         case .issued(let header, _, _):
             return header
         case .omitted, .notReceiptEligible:
@@ -614,7 +709,8 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         receiptBuilder: ReceiptBuilder?,
         request: ChatCompletionRequest,
         error: APIError,
-        startedAt: Date
+        startedAt: Date,
+        modelHashSource: ReceiptModelHashSource
     ) throws -> ErrorReceiptHeaderResult {
         guard error.code == "model_not_loaded" else {
             if error.code == "swap_drain_timeout" {
@@ -627,6 +723,12 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         }
         let ttftMs = elapsedMilliseconds(since: startedAt)
         let unixTs = Int64(Date().timeIntervalSince1970)
+        // SPEC-015 §M.2 / §7.6 — error receipts inherit the same
+        // request-start `modelHashSource` a successful receipt would
+        // carry. The error did not change the loaded weights; the
+        // buyer is still entitled to know which weights the provider
+        // had warm at the moment the error fired. An `.ambiguous`
+        // source still refuses here (§M.2.2 defence-in-depth).
         switch try receiptHeaderResult(
             providerID: providerID,
             receiptBuilder: receiptBuilder,
@@ -636,7 +738,8 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
             finishReason: "error",
             ttftMs: ttftMs,
             tokensOut: 0,
-            unixTsSeconds: unixTs
+            unixTsSeconds: unixTs,
+            modelHashSource: modelHashSource
         ) {
         case .issued(let header):
             return .issued(header, ttftMs: ttftMs, unixTs: unixTs)

--- a/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
+++ b/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
@@ -226,6 +226,7 @@ actor InferenceRelay {
                     receiptBuilder: receiptBuilder,
                     receiptProviderID: receiptProviderID,
                     startedAt: startedAt,
+                    warmSwapEnabled: warmSwapEnabled,
                     sendFrame: sendFrame
                 )
             }
@@ -274,9 +275,18 @@ actor InferenceRelay {
         receiptBuilder: ReceiptBuilder?,
         receiptProviderID: String?,
         startedAt: Date,
+        warmSwapEnabled: Bool,
         sendFrame: @escaping SendFrame
     ) async throws -> CompletionResult {
-        let completion = try await modelRuntime.complete(request, shouldCancel: { state.isCancelled })
+        // SPEC-015 §M.2.2 atomic-read invariant — bind the receipt
+        // to the snapshot the runtime ACTUALLY used to drive
+        // generation, not to a separately-sampled `currentSnapshot()`
+        // which can drift across an actor interleaving / warm-swap.
+        let (completion, servedSnapshot) = try await modelRuntime.completeWithServedSnapshot(request, shouldCancel: { state.isCancelled })
+        let modelHashSource = RouterHandler.resolveModelHashSource(
+            warmSwapEnabled: warmSwapEnabled,
+            snapshot: servedSnapshot
+        )
         let unixTsSeconds = Int64(Date().timeIntervalSince1970)
         state.setUsage(completion)
         if state.isCancelled {
@@ -305,7 +315,8 @@ actor InferenceRelay {
             completion: completion,
             ttftMs: ttftMs,
             unixTsSeconds: unixTsSeconds,
-            requestID: requestID
+            requestID: requestID,
+            modelHashSource: modelHashSource
         )
         if state.markTerminalSent() {
             var endFrame: [String: Any] = [
@@ -330,9 +341,22 @@ actor InferenceRelay {
         completion: CompletionResult,
         ttftMs: Int64,
         unixTsSeconds: Int64,
-        requestID: String
+        requestID: String,
+        modelHashSource: ReceiptModelHashSource
     ) -> String? {
         guard let receiptBuilder, let providerID, !providerID.isEmpty else {
+            return nil
+        }
+        // SPEC-015 §M.2.2 — refuse receipt construction when the
+        // request-start container cannot be identified.
+        let resolvedModelHash: String?
+        switch modelHashSource {
+        case .captured(let hash):
+            resolvedModelHash = hash
+        case .warmSwapDisabled:
+            resolvedModelHash = nil
+        case .ambiguous:
+            ReceiptAudit.emitOmitted(providerID: providerID, requestID: requestID, reason: .modelSwapViolation)
             return nil
         }
         do {
@@ -346,7 +370,8 @@ actor InferenceRelay {
                     finishReason: completion.finishReason,
                     ttftMs: ttftMs,
                     tokensOut: Int64(completion.completionTokens),
-                    unixTsSeconds: unixTsSeconds
+                    unixTsSeconds: unixTsSeconds,
+                    modelHash: resolvedModelHash
                 )
             )
         } catch {

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -6,6 +6,13 @@ import MacProviderCore
 
 protocol ModelRuntimeServing: Actor {
     func complete(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool) async throws -> CompletionResult
+    /// SPEC-015 §M.2 — return the runtime-owned snapshot that
+    /// actually drove inference (validation, in-flight registration,
+    /// generation) so the receipt can bind `model_hash` to the
+    /// container that served. Atomically captured inside the actor
+    /// turn — distinct from a caller-side `currentSnapshot()` sample,
+    /// which can drift across an actor interleaving / warm-swap.
+    func completeWithServedSnapshot(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool) async throws -> (CompletionResult, RuntimeSnapshot)
     func stream(_ request: ChatCompletionRequest, with handle: RequestHandle, shouldCancel: @escaping @Sendable () -> Bool, onChunk: @escaping @Sendable (String) -> Void) async throws -> CompletionResult
     func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws
     func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle
@@ -22,6 +29,21 @@ extension ModelRuntimeServing {
         try await complete(request, shouldCancel: { false })
     }
 
+    /// Convenience default — conformers that don't override get the
+    /// served snapshot from `currentSnapshot()` AFTER generation. The
+    /// real `ModelRuntime` overrides this to capture the snapshot
+    /// inside the actor turn that started inference, which is the
+    /// SPEC-015 §M.2.2 atomic-read invariant. Mock/stub runtimes used
+    /// in tests can rely on this default safely because they don't
+    /// model swaps.
+    func completeWithServedSnapshot(
+        _ request: ChatCompletionRequest,
+        shouldCancel: @escaping @Sendable () -> Bool
+    ) async throws -> (CompletionResult, RuntimeSnapshot) {
+        let result = try await complete(request, shouldCancel: shouldCancel)
+        let snapshot = await currentSnapshot()
+        return (result, snapshot)
+    }
 }
 
 public struct RuntimeSnapshot: @unchecked Sendable {
@@ -359,6 +381,20 @@ actor ModelRuntime: ModelRuntimeServing {
         _ request: ChatCompletionRequest,
         shouldCancel: @escaping @Sendable () -> Bool = { false }
     ) async throws -> CompletionResult {
+        let (result, _) = try await completeWithServedSnapshot(request, shouldCancel: shouldCancel)
+        return result
+    }
+
+    /// SPEC-015 §M.2.2 — atomic snapshot capture inside the actor
+    /// turn that started inference. The returned snapshot IS the
+    /// container that served the response (in-flight tracking pins
+    /// it for the request lifetime per SPEC-011 R-3.4.1). Callers
+    /// MUST bind the receipt's `model_hash` to this snapshot, NOT to
+    /// a separately-sampled `currentSnapshot()`.
+    func completeWithServedSnapshot(
+        _ request: ChatCompletionRequest,
+        shouldCancel: @escaping @Sendable () -> Bool = { false }
+    ) async throws -> (CompletionResult, RuntimeSnapshot) {
         let completionStartedAt = Date()
         let snapshot = await currentSnapshot()
         try Self.validateReady(snapshot.state)
@@ -367,9 +403,10 @@ actor ModelRuntime: ModelRuntimeServing {
         let registrationID = registerInFlight { drainCancelled.fire() }
         defer { unregisterInFlight(registrationID) }
         if let testCompletion {
-            return try await Self.withDrainCancellation(drainCancelled) {
+            let result = try await Self.withDrainCancellation(drainCancelled) {
                 try await testCompletion(snapshot, request)
             }
+            return (result, snapshot)
         }
         guard let container = snapshot.container else {
             throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
@@ -379,7 +416,7 @@ actor ModelRuntime: ModelRuntimeServing {
         let kvBitsOverride = kvBitsOverride
         let inferenceGate = inferenceGate
         let stopTokenFilter = stopTokenFilter
-        return try await Self.withDrainCancellation(drainCancelled) {
+        let completion = try await Self.withDrainCancellation(drainCancelled) {
             try await inferenceGate.withPermit {
                 try drainCancelled.check()
                 try Task.checkCancellation()
@@ -432,6 +469,7 @@ actor ModelRuntime: ModelRuntimeServing {
                 }
             }
         }
+        return (completion, snapshot)
     }
 
     func stream(

--- a/phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift
+++ b/phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift
@@ -2,6 +2,44 @@ import CryptoKit
 import Foundation
 import MacProviderCore
 
+/// SPEC-015 v0.3 §M.2 — the provenance of `model_hash` at receipt
+/// emission time. Sum-typed so the receipt-emission layer can refuse
+/// the §M.2.2 ambiguous case BEFORE constructing a signed tuple.
+///
+/// - `.captured(hash)` — request-start container is known. Hash MUST
+///   be raw 64-char lowercase hex (validated in ReceiptBuilder.build).
+/// - `.warmSwapDisabled` — provider running with
+///   `--enable-warm-swap=false` per SPEC-011 R-3.3.0. JSON `null`
+///   per §M.2.3.
+/// - `.ambiguous` — runtime cannot disambiguate which container served
+///   this request (e.g. a future regression of SPEC-011 R-3.4.1
+///   in-flight tracking). Receipt-emission MUST refuse with
+///   `receipt_omitted: model_swap_violation` per §M.2.2's
+///   defence-in-depth clause. NEVER emit a signed tuple with this
+///   provenance.
+enum ReceiptModelHashSource: Sendable, Equatable {
+    case captured(String)
+    case warmSwapDisabled
+    case ambiguous
+}
+
+/// SPEC-015 v0.3 receipt issuance input.
+///
+/// `modelHash` carries the SHA-256 of the loaded MLX container per
+/// SPEC-011 v0.5 R-3.3.1 (raw 64-char lowercase hex, no `sha256:`
+/// prefix). `nil` MUST be emitted by providers running with
+/// `--enable-warm-swap=false` per SPEC-015 §M.2.3; the receipt encodes
+/// it as the JSON literal `null`.
+///
+/// The hash threaded in MUST be the value captured at request-acceptance
+/// time (the §M.2.1 request-start container) — NOT the runtime's current
+/// snapshot at receipt-emission time — so the §M.2.2 construction proof
+/// holds: every receipt commits to the hash that started generation.
+///
+/// `ReceiptInput` carries the resolved `String?` (the
+/// `.ambiguous` case never reaches this struct — the receipt-emission
+/// layer short-circuits before construction). See
+/// `ReceiptModelHashSource` for the full provenance state.
 struct ReceiptInput {
     let modelId: String
     let request: ChatCompletionRequest
@@ -11,8 +49,12 @@ struct ReceiptInput {
     let ttftMs: Int64
     let tokensOut: Int64
     let unixTsSeconds: Int64
+    let modelHash: String?
 }
 struct ReceiptBuilder: Sendable {
+    /// SPEC-015 §M.0 wire-shape discriminant. ASCII string `"3"`.
+    static let receiptVersionV03 = "3"
+
     let keyStore: ReceiptKeyStoring
 
     init(keyStore: ReceiptKeyStoring) {
@@ -32,6 +74,11 @@ struct ReceiptBuilder: Sendable {
         guard input.unixTsSeconds >= 0 else {
             throw Error.negativeInteger("unix_ts")
         }
+        if let modelHash = input.modelHash {
+            guard Self.isValidModelHash(modelHash) else {
+                throw Error.invalidModelHash
+            }
+        }
 
         guard let key = try keyStore.loadCurrent(providerId: providerId) else {
             throw Error.missingCurrentReceiptKey(providerId: providerId)
@@ -49,7 +96,18 @@ struct ReceiptBuilder: Sendable {
         input: ReceiptInput,
         publicKey: Curve25519.Signing.PublicKey
     ) throws -> RFC8785JCS.Value {
-        .object([
+        // SPEC-015 §M.0 — exactly nine keys; JCS canonical order is
+        // UTF-16 code-unit lexicographic, which the canonicalizer
+        // computes from the object's keys. The dictionary literal here
+        // is unordered; RFC8785JCS sorts before emission.
+        let modelHashValue: RFC8785JCS.Value
+        if let modelHash = input.modelHash {
+            modelHashValue = .string(modelHash)
+        } else {
+            modelHashValue = .null
+        }
+        return .object([
+            "model_hash": modelHashValue,
             "model_id": .string(input.modelId),
             "prompt_hash": .string(try PromptCanonicalizer.promptHash(for: input.request)),
             "output_hash": .string(try OutputCanonicalizer.outputHash(
@@ -58,6 +116,7 @@ struct ReceiptBuilder: Sendable {
                 finishReason: input.finishReason
             )),
             "provider_pubkey": .string(publicKey.rawRepresentation.base64EncodedString()),
+            "receipt_version": .string(Self.receiptVersionV03),
             "ttft_ms": .int(try checkedInt(input.ttftMs, field: "ttft_ms")),
             "tokens_out": .int(try checkedInt(input.tokensOut, field: "tokens_out")),
             "unix_ts": .int(try checkedInt(input.unixTsSeconds, field: "unix_ts")),
@@ -75,10 +134,21 @@ struct ReceiptBuilder: Sendable {
         value.unicodeScalars.allSatisfy { $0.value <= 0x7f }
     }
 
+    /// SPEC-011 R-3.3.1 / SPEC-015 §M.0: raw 64-char lowercase hex,
+    /// no `sha256:` prefix.
+    static func isValidModelHash(_ value: String) -> Bool {
+        guard value.utf8.count == 64 else { return false }
+        return value.unicodeScalars.allSatisfy { scalar in
+            (scalar.value >= 0x30 && scalar.value <= 0x39) ||
+                (scalar.value >= 0x61 && scalar.value <= 0x66)
+        }
+    }
+
     enum Error: Swift.Error, Equatable {
         case missingCurrentReceiptKey(providerId: String)
         case nonASCIIModelId
         case negativeInteger(String)
         case integerOutOfRange(String)
+        case invalidModelHash
     }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/README.md
+++ b/phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/README.md
@@ -1,0 +1,26 @@
+# SPEC-015 v0.3 JCS golden fixtures
+
+These files lock the byte-exact JCS canonical encoding of the v0.3
+9-field receipt tuple so the Swift signer (phase3-binary) and the
+Go verifier (phase7-verify, landing in Step 5) produce identical
+canonical bytes for identical inputs.
+
+Each fixture is a JSON object with:
+
+- `description` — what shape this fixture exercises.
+- `input` — the receipt input values (model_hash possibly null, etc.).
+- `provider_pubkey_seed_b64` — 32-byte seed used to derive the
+  ed25519 keypair via `Curve25519.Signing.PrivateKey(rawRepresentation:)`.
+- `canonical_jcs_sha256_hex` — SHA-256 over the canonical JCS bytes
+  the builder produces. Lower-case 64-char hex.
+- `canonical_jcs_length` — byte count of the canonical JCS string.
+
+The Swift test in `JCSGoldenFixtureTests.swift` runs the builder
+against `input`, recomputes the SHA-256, and asserts equality.
+Step 5's Go verifier MUST consume the same fixture files and pass
+the same assertion.
+
+To regenerate the SHA after intentional changes:
+1. Update `input` and run the failing test once.
+2. Copy the printed SHA-256 + length into the fixture JSON.
+3. Re-run; the test should now pass.

--- a/phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/non_null_hash.json
+++ b/phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/non_null_hash.json
@@ -1,0 +1,15 @@
+{
+  "description": "v0.3 receipt with non-null 64-hex model_hash, deterministic ed25519 seed.",
+  "input": {
+    "model_id": "fixture-model",
+    "model_hash": "a3f1b2c8d4e5f6090807060504030201f0e1d2c3b4a5968778695a4b3c2d1e0f",
+    "output_content": "answer",
+    "finish_reason": "stop",
+    "ttft_ms": 7,
+    "tokens_out": 2,
+    "unix_ts": 1800000000
+  },
+  "provider_pubkey_seed_b64": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+  "canonical_jcs_sha256_hex": "48c3f1ccc85a4de04f95aad465af55f0217f7a2c7086f4468c6f23f4a407f6c3",
+  "canonical_jcs_length": 405
+}

--- a/phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/null_hash.json
+++ b/phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/null_hash.json
@@ -1,0 +1,15 @@
+{
+  "description": "v0.3 receipt with model_hash = JSON null (warm-swap-disabled provider, §M.2.3).",
+  "input": {
+    "model_id": "fixture-model",
+    "model_hash": null,
+    "output_content": "answer",
+    "finish_reason": "stop",
+    "ttft_ms": 7,
+    "tokens_out": 2,
+    "unix_ts": 1800000000
+  },
+  "provider_pubkey_seed_b64": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+  "canonical_jcs_sha256_hex": "1db46007812f631a5f430b4166f6cf20482c7bd5997beaa3307d055401523a21",
+  "canonical_jcs_length": 343
+}

--- a/phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift
@@ -271,7 +271,8 @@ final class HTTPServerReceiptTests: XCTestCase {
             finishReason: "stop",
             ttftMs: 12,
             tokensOut: 2,
-            unixTsSeconds: 1_800_000_000
+            unixTsSeconds: 1_800_000_000,
+            modelHashSource: .warmSwapDisabled
         ))
         let parsed = try parseReceiptHeader(header)
 
@@ -312,7 +313,8 @@ final class HTTPServerReceiptTests: XCTestCase {
             finishReason: "stop",
             ttftMs: 1,
             tokensOut: 1,
-            unixTsSeconds: 1
+            unixTsSeconds: 1,
+            modelHashSource: .warmSwapDisabled
         )
 
         XCTAssertNil(header)
@@ -341,7 +343,8 @@ final class HTTPServerReceiptTests: XCTestCase {
             receiptBuilder: ReceiptBuilder(keyStore: HTTPFixedReceiptKeyStore(key: key)),
             request: request,
             error: error,
-            startedAt: Date(timeIntervalSince1970: 1_800_000_000)
+            startedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            modelHashSource: .warmSwapDisabled
         ))
         let parsed = try parseReceiptHeader(header)
 
@@ -377,7 +380,8 @@ final class HTTPServerReceiptTests: XCTestCase {
             )),
             request: request,
             error: error,
-            startedAt: Date()
+            startedAt: Date(),
+            modelHashSource: .warmSwapDisabled
         )
 
         XCTAssertNil(header)
@@ -405,7 +409,8 @@ final class HTTPServerReceiptTests: XCTestCase {
             finishReason: "stop",
             ttftMs: 1,
             tokensOut: 1,
-            unixTsSeconds: 1
+            unixTsSeconds: 1,
+            modelHashSource: .warmSwapDisabled
         ))
 
         XCTAssertLessThanOrEqual(header.utf8.count, RouterHandler.maxReceiptHeaderBytes)
@@ -438,6 +443,150 @@ final class HTTPServerReceiptTests: XCTestCase {
             "connection: close",
             "transfer-encoding: chunked",
         ])
+    }
+
+    // SPEC-015 §M.5 AC-29 — warm-swap-on success path binds the
+    // runtime hash captured at request-start.
+    func testHTTPSuccessReceiptCarriesWarmSwapHash() async throws {
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
+        let hash = "a3f1b2c8d4e5f6090807060504030201f0e1d2c3b4a5968778695a4b3c2d1e0f"
+        let response = try await roundTripChatCompletion(
+            body: [
+                "model": "fixture-model",
+                "messages": [["role": "user", "content": "hello"]],
+            ],
+            receiptBuilder: ReceiptBuilder(keyStore: HTTPFixedReceiptKeyStore(key: key)),
+            completion: CompletionResult(
+                content: "answer",
+                finishReason: "stop",
+                promptTokens: 1,
+                completionTokens: 2,
+                ttftMilliseconds: 5
+            ),
+            warmSwapEnabled: true,
+            modelHash: hash
+        )
+
+        let header = try XCTUnwrap(response.headers.first(name: RouterHandler.receiptHeaderName))
+        let parsed = try parseReceiptHeader(header)
+        XCTAssertEqual(parsed.tuple["model_hash"] as? String, hash)
+        XCTAssertEqual(parsed.tuple["receipt_version"] as? String, "3")
+        XCTAssertTrue(parsed.publicKey.isValidSignature(parsed.signature, for: parsed.tupleData))
+    }
+
+    // SPEC-015 §M.5 AC-31 — error receipt inherits request-start hash.
+    func testHTTPErrorReceiptInheritsWarmSwapHash() async throws {
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
+        let hash = "a3f1b2c8d4e5f6090807060504030201f0e1d2c3b4a5968778695a4b3c2d1e0f"
+        let response = try await roundTripChatCompletion(
+            body: [
+                "model": "fixture-model",
+                "messages": [["role": "user", "content": "hello"]],
+            ],
+            receiptBuilder: ReceiptBuilder(keyStore: HTTPFixedReceiptKeyStore(key: key)),
+            completionError: HTTPReceiptFixtureError.inferenceFailed,
+            warmSwapEnabled: true,
+            modelHash: hash
+        )
+
+        let header = try XCTUnwrap(response.headers.first(name: RouterHandler.receiptHeaderName))
+        let parsed = try parseReceiptHeader(header)
+        XCTAssertEqual(parsed.tuple["model_hash"] as? String, hash,
+                       "AC-31: warm-swap-on error receipts MUST carry the request-start hash")
+        XCTAssertEqual(parsed.tuple["tokens_out"] as? Int, 0)
+        XCTAssertEqual(parsed.tuple["receipt_version"] as? String, "3")
+        XCTAssertTrue(parsed.publicKey.isValidSignature(parsed.signature, for: parsed.tupleData))
+    }
+
+    // SPEC-015 §M.5 AC-42 — defence-in-depth refusal also emits the
+    // `receipt_omitted: model_swap_violation` audit row end-to-end
+    // through the HTTP success path (closing the CODE-R2-HIGH-1 +
+    // SECURITY-R2-HIGH-1 gap that the helper-only test left).
+    func testHTTPAmbiguousProvenanceEmitsReceiptOmittedAudit() async throws {
+        let capture = ReceiptAuditCapture()
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
+        let response = try await ReceiptAudit.withSink({ record in capture.append(record) }) {
+            try await roundTripChatCompletion(
+                body: [
+                    "model": "fixture-model",
+                    "messages": [["role": "user", "content": "hello"]],
+                ],
+                requestID: "req-ambiguous",
+                receiptBuilder: ReceiptBuilder(keyStore: HTTPFixedReceiptKeyStore(key: key)),
+                completion: CompletionResult(content: "answer", finishReason: "stop", promptTokens: 1, completionTokens: 1),
+                warmSwapEnabled: true,
+                modelHash: nil  // warm-swap on + no hash → .ambiguous
+            )
+        }
+        XCTAssertEqual(response.status, .ok)
+        XCTAssertNil(response.headers.first(name: RouterHandler.receiptHeaderName))
+        let event = try capture.singleEvent()
+        XCTAssertEqual(event["event"] as? String, "receipt_omitted",
+                       "AC-42 audit row missing")
+        XCTAssertEqual(event["reason"] as? String, "model_swap_violation",
+                       "AC-42: reason MUST be model_swap_violation")
+        XCTAssertEqual(event["provider_id"] as? String, "provider-a")
+        XCTAssertEqual(event["request_id"] as? String, "req-ambiguous")
+        for forbidden in ["model_hash", "prompt_hash", "output_hash", "signature", "provider_pubkey"] {
+            XCTAssertNil(event[forbidden], "receipt_omitted leaked \(forbidden)")
+        }
+    }
+
+    // SPEC-015 §M.5 AC-42 — defence-in-depth refusal: warm-swap on
+    // AND no hash on the request-start snapshot → no receipt header,
+    // model_swap_violation audit row.
+    func testHTTPReceiptRefusedOnAmbiguousProvenance() throws {
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
+        let builder = ReceiptBuilder(keyStore: HTTPFixedReceiptKeyStore(key: key))
+        let request = try PromptCanonicalizerTests.fixtureRequest()
+
+        // resolveModelHashSource maps warm-swap=on + snapshot.modelHash=nil
+        // → .ambiguous → §M.2.2 defence-in-depth refusal.
+        let ambiguousSnapshot = RuntimeSnapshot(state: .ready, container: nil, modelID: "fixture-model", modelHash: nil)
+        let source = RouterHandler.resolveModelHashSource(warmSwapEnabled: true, snapshot: ambiguousSnapshot)
+        XCTAssertEqual(source, .ambiguous, "warm-swap on + nil snapshot.modelHash MUST resolve to .ambiguous")
+
+        let header = try RouterHandler.receiptHeader(
+            providerID: "provider-a",
+            receiptBuilder: builder,
+            request: request,
+            outputContent: "answer",
+            outputToolCalls: nil,
+            finishReason: "stop",
+            ttftMs: 5,
+            tokensOut: 1,
+            unixTsSeconds: 1,
+            modelHashSource: source
+        )
+        XCTAssertNil(header, "§M.2.2: ambiguous provenance MUST refuse the receipt")
+    }
+
+    // SPEC-015 §M.5 AC-42 — §M.2.2 normal in-flight request through
+    // a swap MUST still emit a receipt (the construction proof case,
+    // distinct from the defence-in-depth refusal above).
+    func testHTTPReceiptEmittedForNormalInFlightSwap() throws {
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
+        let builder = ReceiptBuilder(keyStore: HTTPFixedReceiptKeyStore(key: key))
+        let request = try PromptCanonicalizerTests.fixtureRequest()
+        let hash = "00010203040506070809a0b0c0d0e0f00102030405060708090a0b0c0d0e0f01"
+        let snapshot = RuntimeSnapshot(state: .draining, container: nil, modelID: "fixture-model", modelHash: hash)
+        let source = RouterHandler.resolveModelHashSource(warmSwapEnabled: true, snapshot: snapshot)
+        XCTAssertEqual(source, .captured(hash))
+
+        let header = try XCTUnwrap(RouterHandler.receiptHeader(
+            providerID: "provider-a",
+            receiptBuilder: builder,
+            request: request,
+            outputContent: "answer",
+            outputToolCalls: nil,
+            finishReason: "stop",
+            ttftMs: 5,
+            tokensOut: 1,
+            unixTsSeconds: 1,
+            modelHashSource: source
+        ))
+        let parsed = try parseReceiptHeader(header)
+        XCTAssertEqual(parsed.tuple["model_hash"] as? String, hash)
     }
 }
 
@@ -493,11 +642,14 @@ private func roundTripChatCompletion(
     requestID: String = "req-http-receipt",
     receiptBuilder: ReceiptBuilder?,
     completion: CompletionResult? = nil,
-    completionError: Error? = nil
+    completionError: Error? = nil,
+    warmSwapEnabled: Bool = false,
+    modelHash: String? = nil
 ) async throws -> HTTPReceiptResponse {
     let runtime = ModelRuntime(
         modelID: "fixture-model",
-        warmSwapEnabled: false,
+        modelHash: modelHash,
+        warmSwapEnabled: warmSwapEnabled,
         loader: { _ in throw HTTPReceiptFixtureError.inferenceFailed },
         testCompletion: { _, _ in
             if let completionError {
@@ -521,7 +673,8 @@ private func roundTripChatCompletion(
         providerStatus: status,
         providerID: providerID,
         routerModelID: routerModelID,
-        receiptBuilder: receiptBuilder
+        receiptBuilder: receiptBuilder,
+        warmSwapEnabled: warmSwapEnabled
     ) { port in
         try rawChatCompletionRoundTrip(port: port, body: body, headerOnly: body["stream"] as? Bool == true, requestID: requestID)
     }
@@ -533,6 +686,7 @@ private func withReceiptHTTPServer<T>(
     providerID: String?,
     routerModelID: String? = "fixture-model",
     receiptBuilder: ReceiptBuilder?,
+    warmSwapEnabled: Bool = false,
     operation: (Int) throws -> T
 ) async throws -> T {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -547,7 +701,7 @@ private func withReceiptHTTPServer<T>(
                     coordinatorURL: nil,
                     modelRuntime: runtime,
                     providerStatus: providerStatus,
-                    warmSwapEnabled: false,
+                    warmSwapEnabled: warmSwapEnabled,
                     maxBodyBytes: 1_000_000,
                     receiptBuilder: receiptBuilder
                 ))

--- a/phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift
@@ -1,3 +1,5 @@
+import CryptoKit
+import Foundation
 import XCTest
 import MacProviderCore
 @testable import macprovider_cli
@@ -190,6 +192,71 @@ final class InferenceRelayTests: XCTestCase {
         XCTAssertEqual(endPlaintext["chunks_sent"] as? Int, 1)
     }
 
+    // SPEC-015 §M.0 / §M.2 — coordinator-WS-mediated non-streaming
+    // receipt carries the 9-field v0.3 tuple with
+    // `receipt_version == "3"` and `model_hash` matching the
+    // runtime-served snapshot. Closes the relay-decode gap the
+    // round-3 ARCHITECT audit flagged.
+    func testRelayNonStreamingEndFrameCarriesV03Receipt() async throws {
+        let hash = "a3f1b2c8d4e5f6090807060504030201f0e1d2c3b4a5968778695a4b3c2d1e0f"
+        let runtime = FakeReceiptCompletionRuntime(servedSnapshot: RuntimeSnapshot(
+            state: .ready,
+            container: nil,
+            modelID: "mlx-community/Test-Model",
+            modelHash: hash
+        ))
+        let status = ProviderStatus(
+            modelID: "mlx-community/Test-Model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
+        let recorder = FrameRecorder()
+        let relay = InferenceRelay(
+            modelRuntime: runtime,
+            providerStatus: status,
+            loadedModelID: "mlx-community/Test-Model",
+            warmSwapEnabled: true,
+            maxActiveRequests: 1,
+            maxBodyBytes: 4096,
+            receiptBuilder: ReceiptBuilder(keyStore: FixedRelayReceiptKeyStore(key: key)),
+            receiptProviderID: "provider-relay-test",
+            sendFrame: { frame in
+                await recorder.append(frame)
+            }
+        )
+
+        try await relay.handleInferenceRequest([
+            "type": "inference_request",
+            "request_id": "req-relay-receipt",
+            "stream": false,
+            "body": #"{"model":"mlx-community/Test-Model","messages":[{"role":"user","content":"hello"}]}"#,
+        ])
+
+        let frames = try await waitForFrames { frames in
+            frames.contains { $0["type"] as? String == "inference_response_end" }
+        } from: {
+            await recorder.frames
+        }
+        let endFrame = try XCTUnwrap(frames.last { $0["type"] as? String == "inference_response_end" })
+        XCTAssertEqual(endFrame["request_id"] as? String, "req-relay-receipt")
+        let receiptHeader = try XCTUnwrap(endFrame["receipt"] as? String)
+        let pieces = receiptHeader.split(separator: ".")
+        XCTAssertEqual(pieces.count, 2, "v0.3 receipt envelope MUST be base64.base64")
+        let tupleBytes = try XCTUnwrap(Data(base64Encoded: String(pieces[0])))
+        let tuple = try XCTUnwrap(JSONSerialization.jsonObject(with: tupleBytes) as? [String: Any])
+        XCTAssertEqual(tuple["receipt_version"] as? String, "3")
+        XCTAssertEqual(tuple["model_hash"] as? String, hash,
+                       "relay path MUST bind served-snapshot hash into the receipt")
+        XCTAssertEqual(Set(tuple.keys), [
+            "model_hash", "model_id", "output_hash", "prompt_hash",
+            "provider_pubkey", "receipt_version", "tokens_out",
+            "ttft_ms", "unix_ts",
+        ])
+        let sigBytes = try XCTUnwrap(Data(base64Encoded: String(pieces[1])))
+        XCTAssertEqual(sigBytes.count, 64)
+    }
+
     func testTier2SessionRejectsPlaintextInferenceRequest() async throws {
         let runtime = FakeCompletionRuntime()
         let status = ProviderStatus(
@@ -225,6 +292,62 @@ final class InferenceRelayTests: XCTestCase {
         let error = try XCTUnwrap(frames[0]["error"] as? [String: Any])
         XCTAssertEqual(error["code"] as? String, "tier2_encrypted_frame_required")
     }
+}
+
+/// SPEC-015 §M.2.2 — atomic served-snapshot override so the relay
+/// test can pin the runtime's request-start container hash and
+/// verify the receipt binds to it.
+private actor FakeReceiptCompletionRuntime: ModelRuntimeServing {
+    private let servedSnapshot: RuntimeSnapshot
+
+    init(servedSnapshot: RuntimeSnapshot) {
+        self.servedSnapshot = servedSnapshot
+    }
+
+    func currentSnapshot() async -> RuntimeSnapshot {
+        servedSnapshot
+    }
+
+    func complete(
+        _ request: ChatCompletionRequest,
+        shouldCancel: @escaping @Sendable () -> Bool
+    ) async throws -> CompletionResult {
+        CompletionResult(content: "answer", finishReason: "stop", promptTokens: 5, completionTokens: 2)
+    }
+
+    func completeWithServedSnapshot(
+        _ request: ChatCompletionRequest,
+        shouldCancel: @escaping @Sendable () -> Bool
+    ) async throws -> (CompletionResult, RuntimeSnapshot) {
+        let result = CompletionResult(content: "answer", finishReason: "stop", promptTokens: 5, completionTokens: 2)
+        return (result, servedSnapshot)
+    }
+
+    func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle {
+        RequestHandle(snapshot: servedSnapshot, registrationID: 0, drainCancelled: DrainCancelToken())
+    }
+
+    func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws { }
+
+    func stream(
+        _ request: ChatCompletionRequest,
+        with handle: RequestHandle,
+        shouldCancel: @escaping @Sendable () -> Bool,
+        onChunk: @escaping @Sendable (String) -> Void
+    ) async throws -> CompletionResult {
+        CompletionResult(content: "answer", finishReason: "stop", promptTokens: 5, completionTokens: 2)
+    }
+
+    func unregisterInFlight(_ id: Int) { }
+}
+
+private final class FixedRelayReceiptKeyStore: ReceiptKeyStoring, @unchecked Sendable {
+    private let key: Curve25519.Signing.PrivateKey
+    init(key: Curve25519.Signing.PrivateKey) { self.key = key }
+    func loadOrGenerate(providerId: String) throws -> Curve25519.Signing.PrivateKey { key }
+    func loadCurrent(providerId: String) throws -> Curve25519.Signing.PrivateKey? { key }
+    func storeNew(providerId: String, privateKey: Curve25519.Signing.PrivateKey) throws {}
+    func swapToCurrent(providerId: String, newKey: Curve25519.Signing.PrivateKey) throws {}
 }
 
 private actor FrameRecorder {

--- a/phase3-binary/Tests/macprovider-cliTests/JCSGoldenFixtureTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/JCSGoldenFixtureTests.swift
@@ -1,0 +1,132 @@
+import CryptoKit
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+/// SPEC-015 v0.3 §M.0 / §M.1.5 — golden fixtures locking the
+/// byte-exact JCS canonical encoding of the 9-field tuple so the
+/// Swift signer and the Go verifier (phase7-verify, Step 5) produce
+/// identical canonical bytes for identical inputs.
+final class JCSGoldenFixtureTests: XCTestCase {
+    private struct Fixture: Decodable {
+        struct Input: Decodable {
+            let model_id: String
+            let model_hash: String?
+            let output_content: String
+            let finish_reason: String
+            let ttft_ms: Int64
+            let tokens_out: Int64
+            let unix_ts: Int64
+        }
+        let description: String
+        let input: Input
+        let provider_pubkey_seed_b64: String
+        let canonical_jcs_sha256_hex: String
+        let canonical_jcs_length: Int
+    }
+
+    private static let fixtureNames = ["non_null_hash", "null_hash"]
+
+    func testV03JCSFixturesProduceLockedCanonicalBytes() throws {
+        for name in Self.fixtureNames {
+            let fixture = try Self.loadFixture(named: name)
+            let canonical = try Self.canonicalBytes(for: fixture)
+            let actualHash = Self.sha256Hex(of: canonical)
+
+            // Self-locking pattern: on first commit the fixture's
+            // expected hash is empty. Print + fail so the operator
+            // can paste in the correct values; subsequent runs hit
+            // the assertion below.
+            if fixture.canonical_jcs_sha256_hex.isEmpty || fixture.canonical_jcs_length == 0 {
+                XCTFail("""
+                Fixture \(name) is missing locked values. Paste these into the JSON:
+                  canonical_jcs_sha256_hex: \(actualHash)
+                  canonical_jcs_length: \(canonical.utf8.count)
+                Canonical JCS bytes (first 200 chars):
+                  \(String(canonical.prefix(200)))
+                """)
+                continue
+            }
+
+            XCTAssertEqual(actualHash, fixture.canonical_jcs_sha256_hex,
+                           "fixture \(name): JCS canonical bytes drifted from the locked SHA-256")
+            XCTAssertEqual(canonical.utf8.count, fixture.canonical_jcs_length,
+                           "fixture \(name): canonical byte length drifted")
+        }
+    }
+
+    // SPEC-015 §M.1.5 — JCS canonicalization for the v0.1/v0.2
+    // 7-field tuple must remain byte-identical (this regression
+    // test proves `RFC8785JCS.swift` did not silently change shape
+    // when v0.3 added two more keys).
+    func testLegacyV01V027FieldTupleCanonicalizesUnchanged() throws {
+        let publicKeyB64 = "y/UYwxsuTKfWXsxC1MRVN7Pi4qe5dRXyAvxhwM5g8sM="
+        let legacyTuple: RFC8785JCS.Value = .object([
+            "model_id": .string("fixture-model"),
+            "prompt_hash": .string(String(repeating: "a", count: 64)),
+            "output_hash": .string(String(repeating: "b", count: 64)),
+            "provider_pubkey": .string(publicKeyB64),
+            "ttft_ms": .int(7),
+            "tokens_out": .int(2),
+            "unix_ts": .int(1_800_000_000),
+        ])
+
+        let canonical = try RFC8785JCS.canonicalString(legacyTuple)
+        // Locked v0.1/v0.2 canonical encoding: JCS sorted keys,
+        // UTF-16 lex order, ASCII alphabetical. The exact byte
+        // sequence must remain identical to the v0.1.3-LOCK era.
+        let expected = "{\"model_id\":\"fixture-model\",\"output_hash\":\"\(String(repeating: "b", count: 64))\",\"prompt_hash\":\"\(String(repeating: "a", count: 64))\",\"provider_pubkey\":\"\(publicKeyB64)\",\"tokens_out\":2,\"ttft_ms\":7,\"unix_ts\":1800000000}"
+        XCTAssertEqual(canonical, expected, "v0.1/v0.2 7-field JCS canonicalization regressed")
+    }
+
+    // MARK: helpers
+
+    private static func loadFixture(named: String) throws -> Fixture {
+        let url = try fixturesURL().appendingPathComponent("\(named).json")
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(Fixture.self, from: data)
+    }
+
+    private static func canonicalBytes(for fixture: Fixture) throws -> String {
+        let seed = try XCTUnwrap(Data(base64Encoded: fixture.provider_pubkey_seed_b64))
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: seed)
+        let promptRequest = try PromptCanonicalizerTests.fixtureRequest()
+        let promptHash = try PromptCanonicalizer.promptHash(for: promptRequest)
+        let outputHash = try OutputCanonicalizer.outputHash(
+            content: fixture.input.output_content,
+            toolCalls: nil,
+            finishReason: fixture.input.finish_reason
+        )
+        let modelHashValue: RFC8785JCS.Value
+        if let hash = fixture.input.model_hash {
+            modelHashValue = .string(hash)
+        } else {
+            modelHashValue = .null
+        }
+        let tuple: RFC8785JCS.Value = .object([
+            "model_hash": modelHashValue,
+            "model_id": .string(fixture.input.model_id),
+            "output_hash": .string(outputHash),
+            "prompt_hash": .string(promptHash),
+            "provider_pubkey": .string(key.publicKey.rawRepresentation.base64EncodedString()),
+            "receipt_version": .string(ReceiptBuilder.receiptVersionV03),
+            "tokens_out": .int(Int(fixture.input.tokens_out)),
+            "ttft_ms": .int(Int(fixture.input.ttft_ms)),
+            "unix_ts": .int(Int(fixture.input.unix_ts)),
+        ])
+        return try RFC8785JCS.canonicalString(tuple)
+    }
+
+    private static func sha256Hex(of value: String) -> String {
+        let digest = SHA256.hash(data: Data(value.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func fixturesURL() throws -> URL {
+        let thisFile = URL(fileURLWithPath: #filePath)
+        return thisFile
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent("SPEC015_v03_jcs")
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ReceiptAuditTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ReceiptAuditTests.swift
@@ -60,7 +60,8 @@ final class ReceiptAuditTests: XCTestCase {
             finishReason: "stop",
             ttftMs: 1,
             tokensOut: 1,
-            unixTsSeconds: 1
+            unixTsSeconds: 1,
+            modelHashSource: .warmSwapDisabled
         )
         XCTAssertEqual(result, RouterHandler.ReceiptHeaderResult.omitted(.preV16Binary))
     }
@@ -75,7 +76,8 @@ final class ReceiptAuditTests: XCTestCase {
             finishReason: "stop",
             ttftMs: 1,
             tokensOut: 1,
-            unixTsSeconds: 1
+            unixTsSeconds: 1,
+            modelHashSource: .warmSwapDisabled
         )
         XCTAssertEqual(result, RouterHandler.ReceiptHeaderResult.omitted(.noKeypair))
     }
@@ -86,7 +88,8 @@ final class ReceiptAuditTests: XCTestCase {
             receiptBuilder: ReceiptBuilder(keyStore: AuditFixedReceiptKeyStore(key: Curve25519.Signing.PrivateKey())),
             request: fixtureRequest(),
             error: APIError(status: 499, message: "cancelled", type: "server_error", code: "buyer_cancelled"),
-            startedAt: Date()
+            startedAt: Date(),
+            modelHashSource: .warmSwapDisabled
         )
         XCTAssertEqual(result, RouterHandler.ErrorReceiptHeaderResult.omitted(.preTokenCancel))
     }
@@ -98,7 +101,8 @@ final class ReceiptAuditTests: XCTestCase {
             receiptBuilder: ReceiptBuilder(keyStore: AuditFixedReceiptKeyStore(key: Curve25519.Signing.PrivateKey())),
             request: fixtureRequest(),
             error: APIError(status: 503, message: "loading", type: "server_error", code: "provider_loading"),
-            startedAt: Date()
+            startedAt: Date(),
+            modelHashSource: .warmSwapDisabled
         )
         XCTAssertEqual(result, RouterHandler.ErrorReceiptHeaderResult.notReceiptEligible)
     }
@@ -109,7 +113,8 @@ final class ReceiptAuditTests: XCTestCase {
             receiptBuilder: ReceiptBuilder(keyStore: AuditFixedReceiptKeyStore(key: Curve25519.Signing.PrivateKey())),
             request: fixtureRequest(),
             error: APIError(status: 503, message: "drain", type: "server_error", code: "swap_drain_timeout"),
-            startedAt: Date()
+            startedAt: Date(),
+            modelHashSource: .warmSwapDisabled
         )
         XCTAssertEqual(result, RouterHandler.ErrorReceiptHeaderResult.omitted(.modelSwapViolation))
     }

--- a/phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift
@@ -4,6 +4,22 @@ import XCTest
 @testable import macprovider_cli
 
 final class ReceiptBuilderTests: XCTestCase {
+    // SPEC-015 §M.0 — v0.3 receipt MUST contain exactly these nine keys.
+    private static let v03TupleKeys: Set<String> = [
+        "model_hash",
+        "model_id",
+        "output_hash",
+        "prompt_hash",
+        "provider_pubkey",
+        "receipt_version",
+        "ttft_ms",
+        "tokens_out",
+        "unix_ts",
+    ]
+
+    private static let validModelHash =
+        "a3f1b2c8d4e5f6090807060504030201f0e1d2c3b4a5968778695a4b3c2d1e0f"
+
     func testBuildSignsTupleAndSignatureSelfVerifies() throws {
         let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
         let builder = ReceiptBuilder(keyStore: FixedReceiptKeyStore(key: key))
@@ -17,7 +33,8 @@ final class ReceiptBuilderTests: XCTestCase {
                 finishReason: "stop",
                 ttftMs: 123,
                 tokensOut: 4,
-                unixTsSeconds: 1_800_000_000
+                unixTsSeconds: 1_800_000_000,
+                modelHash: Self.validModelHash
             )
         )
 
@@ -30,16 +47,141 @@ final class ReceiptBuilderTests: XCTestCase {
         let publicKeyData = try XCTUnwrap(Data(base64Encoded: providerPubkey))
         let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: publicKeyData)
 
-        XCTAssertEqual(Set(tuple.keys), [
-            "model_id",
-            "prompt_hash",
-            "output_hash",
-            "provider_pubkey",
-            "ttft_ms",
-            "tokens_out",
-            "unix_ts",
-        ])
+        XCTAssertEqual(Set(tuple.keys), Self.v03TupleKeys)
+        XCTAssertEqual(tuple["receipt_version"] as? String, "3")
+        XCTAssertEqual(tuple["model_hash"] as? String, Self.validModelHash)
         XCTAssertTrue(publicKey.isValidSignature(signature, for: tupleData))
+    }
+
+    // SPEC-015 §M.2.3 — null model_hash for warm-swap-disabled providers.
+    func testBuildEmitsJSONNullForAbsentModelHash() throws {
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
+        let builder = ReceiptBuilder(keyStore: FixedReceiptKeyStore(key: key))
+        let receipt = try builder.build(
+            providerId: "provider-a",
+            input: ReceiptInput(
+                modelId: "fixture-model",
+                request: PromptCanonicalizerTests.fixtureRequest(),
+                outputContent: "answer",
+                outputToolCalls: nil,
+                finishReason: "stop",
+                ttftMs: 123,
+                tokensOut: 4,
+                unixTsSeconds: 1_800_000_000,
+                modelHash: nil
+            )
+        )
+
+        let tupleData = try XCTUnwrap(Data(base64Encoded: String(receipt.split(separator: ".")[0])))
+        let tuple = try XCTUnwrap(JSONSerialization.jsonObject(with: tupleData) as? [String: Any])
+        XCTAssertEqual(Set(tuple.keys), Self.v03TupleKeys)
+        XCTAssertTrue(tuple["model_hash"] is NSNull, "model_hash must be JSON null, not absent or empty string")
+    }
+
+    // SPEC-015 §M.0 — JCS canonical order is UTF-16 code-unit lex.
+    func testCanonicalTupleIsAlphabeticalUtf16Order() throws {
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
+        let builder = ReceiptBuilder(keyStore: FixedReceiptKeyStore(key: key))
+        let receipt = try builder.build(
+            providerId: "provider-a",
+            input: ReceiptInput(
+                modelId: "fixture-model",
+                request: PromptCanonicalizerTests.fixtureRequest(),
+                outputContent: "answer",
+                outputToolCalls: nil,
+                finishReason: "stop",
+                ttftMs: 123,
+                tokensOut: 4,
+                unixTsSeconds: 1_800_000_000,
+                modelHash: Self.validModelHash
+            )
+        )
+
+        let tupleBytes = try XCTUnwrap(Data(base64Encoded: String(receipt.split(separator: ".")[0])))
+        let canonical = try XCTUnwrap(String(data: tupleBytes, encoding: .utf8))
+        // Spot-check the order of key positions — UTF-16 lex order
+        // for these ASCII keys is alphabetical.
+        let expectedOrder: [String] = [
+            "\"model_hash\":",
+            "\"model_id\":",
+            "\"output_hash\":",
+            "\"prompt_hash\":",
+            "\"provider_pubkey\":",
+            "\"receipt_version\":",
+            "\"tokens_out\":",
+            "\"ttft_ms\":",
+            "\"unix_ts\":",
+        ]
+        var cursor = canonical.startIndex
+        for key in expectedOrder {
+            guard let range = canonical.range(of: key, range: cursor..<canonical.endIndex) else {
+                XCTFail("missing or out-of-order key \(key) in canonical tuple: \(canonical)")
+                return
+            }
+            cursor = range.upperBound
+        }
+    }
+
+    // SPEC-015 §M.0 — model_hash MUST be 64-char lowercase hex when present.
+    func testBuildRejectsMalformedModelHash() throws {
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
+        let builder = ReceiptBuilder(keyStore: FixedReceiptKeyStore(key: key))
+
+        let invalid = [
+            "",                                                                       // empty
+            "ABCDEFabcdef0123456789ABCDEFabcdef0123456789ABCDEFabcdef0123456789",    // uppercase
+            "g000000000000000000000000000000000000000000000000000000000000000",    // non-hex char
+            "deadbeef",                                                              // too short
+            String(repeating: "a", count: 65),                                       // too long
+            "sha256:" + String(repeating: "a", count: 64),                           // prefix
+        ]
+
+        for bad in invalid {
+            XCTAssertThrowsError(try builder.build(
+                providerId: "provider-a",
+                input: ReceiptInput(
+                    modelId: "fixture-model",
+                    request: PromptCanonicalizerTests.fixtureRequest(),
+                    outputContent: "",
+                    outputToolCalls: nil,
+                    finishReason: "error",
+                    ttftMs: 0,
+                    tokensOut: 0,
+                    unixTsSeconds: 1,
+                    modelHash: bad
+                )
+            ), "expected reject on hash \"\(bad)\"") { error in
+                XCTAssertEqual(error as? ReceiptBuilder.Error, .invalidModelHash, "hash=\"\(bad)\"")
+            }
+        }
+    }
+
+    // SPEC-015 §3.4 v0.3 — header value ≤ ~1025 ASCII bytes.
+    func testV03ReceiptFitsWireSizeBudget() throws {
+        let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
+        let builder = ReceiptBuilder(keyStore: FixedReceiptKeyStore(key: key))
+        let receipt = try builder.build(
+            providerId: "provider-a",
+            input: ReceiptInput(
+                modelId: String(repeating: "x", count: 64),
+                request: PromptCanonicalizerTests.fixtureRequest(),
+                outputContent: "answer",
+                outputToolCalls: nil,
+                finishReason: "stop",
+                ttftMs: 99_999_999,
+                tokensOut: 99_999_999,
+                unixTsSeconds: 9_999_999_999,
+                modelHash: Self.validModelHash
+            )
+        )
+
+        // SPEC-015 §3.4 v0.3 — the projected ceiling is ≤ ~1025 bytes
+        // for the worst-case 9-field tuple. A 10% overhead margin
+        // covers test-fixture prompt/output sizes that touch the
+        // upper bound; anything beyond that signals an envelope
+        // regression that needs spec revisit.
+        XCTAssertLessThanOrEqual(receipt.utf8.count, 1025, "v0.3 receipt envelope exceeded the SPEC-015 §3.4 v0.3 ≤1025-byte projection")
+        XCTAssertLessThanOrEqual(receipt.utf8.count, 4096, "v0.3 receipt MUST fit in §3.4 nginx headroom budget")
     }
 
     func testBuildRejectsNonASCIIModelId() throws {
@@ -56,7 +198,8 @@ final class ReceiptBuilderTests: XCTestCase {
                 finishReason: "error",
                 ttftMs: 0,
                 tokensOut: 0,
-                unixTsSeconds: 1
+                unixTsSeconds: 1,
+                modelHash: nil
             )
         )) { error in
             XCTAssertEqual(error as? ReceiptBuilder.Error, .nonASCIIModelId)
@@ -76,7 +219,8 @@ final class ReceiptBuilderTests: XCTestCase {
                 finishReason: "error",
                 ttftMs: 0,
                 tokensOut: 0,
-                unixTsSeconds: 1
+                unixTsSeconds: 1,
+                modelHash: nil
             )
         )) { error in
             XCTAssertEqual(

--- a/phase3-binary/Tests/macprovider-cliTests/ReceiptPerfTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ReceiptPerfTests.swift
@@ -21,7 +21,8 @@ final class ReceiptPerfTests: XCTestCase {
             finishReason: "stop",
             ttftMs: 12,
             tokensOut: 1_024,
-            unixTsSeconds: 1_800_000_000
+            unixTsSeconds: 1_800_000_000,
+            modelHash: nil
         )
 
         for _ in 0..<25 {
@@ -34,7 +35,8 @@ final class ReceiptPerfTests: XCTestCase {
                 finishReason: "stop",
                 ttftMs: 12,
                 tokensOut: 1_024,
-                unixTsSeconds: 1_800_000_000
+                unixTsSeconds: 1_800_000_000,
+                modelHashSource: .warmSwapDisabled
             )
             _ = try builder.build(providerId: "provider-a", input: input)
         }
@@ -49,7 +51,8 @@ final class ReceiptPerfTests: XCTestCase {
                 finishReason: "stop",
                 ttftMs: 12,
                 tokensOut: 1_024,
-                unixTsSeconds: 1_800_000_000
+                unixTsSeconds: 1_800_000_000,
+                modelHashSource: .warmSwapDisabled
             )
         }
         let enabledP95 = try measureP95(iterations: 1_000) {
@@ -62,7 +65,8 @@ final class ReceiptPerfTests: XCTestCase {
                 finishReason: "stop",
                 ttftMs: 12,
                 tokensOut: 1_024,
-                unixTsSeconds: 1_800_000_000
+                unixTsSeconds: 1_800_000_000,
+                modelHashSource: .warmSwapDisabled
             )
         }
         let deltaP95 = max(0, enabledP95 - disabledP95)

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -634,6 +634,10 @@ var tier2ReloadFieldClasses = map[string]tier2ReloadFieldClass{
 
 	"CatalogPath":                    tier2StartupOnly,
 	"CatalogPublicKey":               tier2StartupOnly,
+	// SPEC-015 §M.4 — public catalog base URL is operator-visible
+	// only; hot-reloadable so an operator can flip it without
+	// restarting the coordinator.
+	"PublicCatalogBaseURL":           tier2HotReloadable,
 	"EncryptedLegAEAD":               tier2StartupOnly,
 	"EncryptedLegRekeyAfterRequests": tier2StartupOnly,
 	"EncryptedLegRekeyAfterSeconds":  tier2StartupOnly,

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -95,6 +95,19 @@ logging:
   level: "info"
   format: "json"
 
+tier2:
+  # SPEC-008 catalog-based hash verification. Operator-controlled,
+  # observation-only by default per beta/DECISION_CRITERIA Entry 80.
+  # Uncomment + populate to enable.
+  #   catalog_path: "/etc/macprovider/catalog.signed.json"
+  #   catalog_public_key: "<43-char base64url-unpadded ed25519 pubkey>"
+  #   require_hash_verified: false
+  #
+  # SPEC-015 v0.3 §M.4 — public absolute base URL the coordinator
+  # advertises as `catalog_url` / `catalog_pubkey_url` in /poolz.
+  # When empty, /poolz falls back to scheme + request Host. For Pearl:
+  public_catalog_base_url: "https://coordinator.streamvc.live"
+
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that
 # may connect MUST be listed here). Edit this list locally — DO NOT
 # add providers by SSHing to the VPS and appending to /opt/macprovider/

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -84,6 +84,16 @@ else
   }
 fi
 
+# SPEC-015 v0.3 §M.4 — fail closed before any remote mutation if the
+# local nginx conf lacks the catalog routes. The static check is
+# under-engineered for the operator-runbook live smoke surface
+# (check_nginx_receipt_header_live_test.sh is the live counterpart);
+# this is the pre-upload acceptance gate that catches a stale local
+# nginx-coordinator.streamvc.live.conf before the deploy ships it.
+bash "$DIST_DIR/test/check_nginx_catalog_routes_test.sh" || {
+  echo "aborting deploy: nginx /catalog/ routes missing or misconfigured" >&2; exit 5;
+}
+
 log "step 1/9: confirm SSH + DNS"
 $SSH 'hostname && uptime' >/dev/null
 dig +short "$DOMAIN" | grep -q "$VPS_HOST" || { echo "DNS for $DOMAIN does not resolve to $VPS_HOST yet" >&2; exit 1; }

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -155,6 +155,27 @@ server {
     }
 
     # ---------------------------------------------------------------------
+    # /catalog/<catalog_id> and /catalog/pubkey — public buyer endpoints
+    # per SPEC-002 v1.6 candidate annotation + SPEC-015 v0.3 §M.4.
+    # UNAUTHENTICATED. Lives on buyer_port (8443), NOT operator port.
+    # Same posture as /v1/receipt-keys/: rate-limited inside the
+    # coordinator (shared with receipt-keys, 10 req/s per remote IP),
+    # Cache-Control: public, max-age=300 set by the handler. The catalog
+    # file itself is a signed JSON blob produced by scripts/sign-catalog.go;
+    # the pubkey response is a small JSON object
+    # ({"pubkey":"<43-char base64url>","alg":"Ed25519"}). 404 when no
+    # catalog is configured / the requested catalog_id is unknown.
+    # MUST be declared BEFORE the catch-all `location /` 404 block.
+    # ---------------------------------------------------------------------
+    location /catalog/ {
+        proxy_pass http://127.0.0.1:8443;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 10s;
+    }
+
+    # ---------------------------------------------------------------------
     # /v1/* is intentionally not exposed on the coordinator hostname.
     # Buyer API traffic must enter through the gateway so account auth,
     # quota enforcement, demo restrictions, and header allowlisting apply.

--- a/phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh
+++ b/phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# check_nginx_catalog_routes_test.sh — assert SPEC-015 v0.3 §M.4 catalog
+# routes are present in the coordinator nginx conf.
+#
+# The /catalog/ block must be declared BEFORE the catch-all `location /`
+# 404 block, mirroring the /v1/receipt-keys/ shape PR #129 landed for
+# v0.2. This script is the static counterpart to the in-coordinator
+# unit tests at internal/buyer/catalog_endpoints_test.go.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+NGINX_CONF="$REPO_ROOT/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf"
+
+FAIL=0
+fail() { echo "FAIL: $1" >&2; FAIL=1; }
+ok()   { echo "ok: $1"; }
+
+if [ ! -f "$NGINX_CONF" ]; then
+  fail "$NGINX_CONF: missing"
+  exit "$FAIL"
+fi
+
+# Strip comments before scanning so a commented-out block does not pass.
+ACTIVE="$(sed 's/[[:space:]]*#.*$//' "$NGINX_CONF")"
+
+if ! grep -qE '^[[:space:]]*location[[:space:]]+/catalog/[[:space:]]+\{' <<<"$ACTIVE"; then
+  fail "missing active 'location /catalog/ { ... }' block"
+fi
+
+# Scope the proxy_pass assertion to the body of the /catalog/ block
+# ONLY. A repo-wide grep would false-pass because the v0.2
+# /v1/receipt-keys/ block already proxies to 127.0.0.1:8443; a
+# regression that changed the new block to proxy to 8444 (operator
+# port) would slip past a loose check.
+CATALOG_PROXY=$(awk '
+  /^[[:space:]]*location[[:space:]]+\/catalog\/[[:space:]]+\{/ { in_block=1; depth=1; next }
+  in_block {
+    nopen=gsub(/\{/, "{")
+    nclose=gsub(/\}/, "}")
+    depth += nopen - nclose
+    if ($0 ~ /proxy_pass[[:space:]]+/) { print }
+    if (depth == 0) { in_block=0 }
+  }
+' <<<"$ACTIVE")
+if ! grep -qE 'proxy_pass[[:space:]]+http://127\.0\.0\.1:8443' <<<"$CATALOG_PROXY"; then
+  fail "/catalog/ block proxy_pass is not 127.0.0.1:8443 (buyer port); got: $(echo "$CATALOG_PROXY" | tr -d '\n' | head -c 200)"
+fi
+# A second proxy_pass inside /catalog/ would be a config error
+# (nginx would reject); fail closed if anything other than the
+# single buyer-port directive is present.
+PROXY_COUNT=$(grep -cE 'proxy_pass[[:space:]]+' <<<"$CATALOG_PROXY" || true)
+if [ "$PROXY_COUNT" -ne 1 ]; then
+  fail "/catalog/ block has $PROXY_COUNT proxy_pass directives, want exactly 1"
+fi
+
+# Ordering: /catalog/ block must precede the catch-all
+# `location / { return 404; }` block in the TLS server. There are
+# two `location /` lines in the conf — the port-80 → 443 redirect
+# (always declared before any /catalog/), and the TLS catch-all
+# 404. We anchor on the LAST `location / {` whose body matches
+# `return 404` (the actual catch-all). Fail closed if no catch-all
+# is found — the ordering invariant cannot be asserted without it.
+CATALOG_LINE=$(grep -nE '^[[:space:]]*location[[:space:]]+/catalog/' <<<"$ACTIVE" | head -1 | cut -d: -f1)
+CATCHALL_LINE=$(awk '/^[[:space:]]*location[[:space:]]+\/[[:space:]]+\{/ { saved=NR; next } saved && /^[[:space:]]*return[[:space:]]+404/ { print saved; saved=0 }' <<<"$ACTIVE" | tail -1)
+if [ -z "$CATCHALL_LINE" ]; then
+  fail "TLS catch-all 'location / { return 404; }' block not found — nginx conf shape changed; the catalog-route ordering assertion would silently pass without this anchor"
+elif [ -n "$CATALOG_LINE" ] && [ "$CATALOG_LINE" -gt "$CATCHALL_LINE" ]; then
+  fail "/catalog/ block (line $CATALOG_LINE) declared AFTER the catch-all location / { return 404 } block (line $CATCHALL_LINE)"
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+  ok "SPEC-015 v0.3 §M.4 catalog routes present in nginx conf"
+fi
+exit "$FAIL"

--- a/phase4-coordinator/internal/buyer/catalog_endpoints_test.go
+++ b/phase4-coordinator/internal/buyer/catalog_endpoints_test.go
@@ -164,7 +164,73 @@ func TestCatalogEndpointRateLimited(t *testing.T) {
 	}
 }
 
+// SPEC-015 v0.3 bundle audit round 1 SECURITY HIGH-1 fix:
+// catalog endpoints sit behind nginx on loopback (see
+// phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf), so
+// every public buyer's r.RemoteAddr is 127.0.0.1. Keying the bucket
+// solely off RemoteAddr collapses every public buyer into one shared
+// pool and lets a single caller starve everyone else. The fix to
+// poolCheckClientKey honors X-Real-IP only when r.RemoteAddr is a
+// loopback address (so an open-internet attacker can't spoof). This
+// test asserts two different X-Real-IP values behind 127.0.0.1 get
+// independent buckets, while a direct caller cannot use X-Real-IP to
+// escape its own bucket.
+func TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback(t *testing.T) {
+	defer tier2.ResetForTest()
+	raw, pubkey := buyerCatalogFixture(t, "test-catalog", time.Now().UTC().Add(time.Hour))
+	path := writeBuyerCatalog(t, raw)
+	cfg := config.Tier2Config{CatalogPath: path, CatalogPublicKey: pubkey}
+	if err := tier2.Configure(cfg, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
+	server.SetTier2Config(cfg)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	server.now = func() time.Time { return now }
+
+	// Buyer A (X-Real-IP=198.51.100.1) burns the burst.
+	for i := 1; i <= 10; i++ {
+		rr := serveCatalogPubkeyWithRealIP(server, "127.0.0.1:65431", "198.51.100.1")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("A request %d status = %d want 200 body=%s", i, rr.Code, rr.Body.String())
+		}
+	}
+	// Buyer A's 11th request returns 429 — its own bucket is empty.
+	if rr := serveCatalogPubkeyWithRealIP(server, "127.0.0.1:65431", "198.51.100.1"); rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("A request 11 status = %d want 429", rr.Code)
+	}
+	// Buyer B (X-Real-IP=198.51.100.2) behind the SAME loopback gets a
+	// fresh bucket — this is what the fix protects.
+	if rr := serveCatalogPubkeyWithRealIP(server, "127.0.0.1:65432", "198.51.100.2"); rr.Code != http.StatusOK {
+		t.Fatalf("B request 1 status = %d want 200 — bucket leaked across X-Real-IP", rr.Code)
+	}
+	// Direct non-loopback caller MUST NOT escape its bucket by
+	// spoofing X-Real-IP — header is only honored when RemoteAddr is
+	// loopback. Different X-Real-IP values from the same direct
+	// remote share the same bucket.
+	for i := 1; i <= 10; i++ {
+		rr := serveCatalogPubkeyWithRealIP(server, "203.0.113.5:50000", "decoy-1")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("direct burst %d status = %d want 200", i, rr.Code)
+		}
+	}
+	if rr := serveCatalogPubkeyWithRealIP(server, "203.0.113.5:50001", "decoy-2"); rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("direct spoof status = %d want 429 — X-Real-IP was honored for non-loopback caller", rr.Code)
+	}
+}
+
 // helpers
+
+func serveCatalogPubkeyWithRealIP(server *Server, remoteAddr, realIP string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/catalog/pubkey", nil)
+	req.RemoteAddr = remoteAddr
+	if realIP != "" {
+		req.Header.Set("X-Real-IP", realIP)
+	}
+	rr := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rr, req)
+	return rr
+}
 
 func serveCatalogFile(server *Server, catalogID, remoteAddr string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodGet, "/catalog/"+catalogID, nil)

--- a/phase4-coordinator/internal/buyer/catalog_endpoints_test.go
+++ b/phase4-coordinator/internal/buyer/catalog_endpoints_test.go
@@ -1,0 +1,269 @@
+package buyer
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/tier2"
+	"github.com/rs/zerolog"
+)
+
+// SPEC-015 §M.4 / §M.5 AC-39 — GET /catalog/<catalog_id> returns
+// the on-disk signed catalog bytes verbatim with the right
+// Content-Type and Cache-Control.
+func TestCatalogFileServesActiveCatalogBytes(t *testing.T) {
+	defer tier2.ResetForTest()
+	raw, pubkey := buyerCatalogFixture(t, "test-catalog-2026-06-24", time.Now().UTC().Add(time.Hour))
+	path := writeBuyerCatalog(t, raw)
+	cfg := config.Tier2Config{
+		CatalogPath:      path,
+		CatalogPublicKey: pubkey,
+		ObserveEnabled:   true,
+	}
+	if err := tier2.Configure(cfg, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
+	server.SetTier2Config(cfg)
+
+	rr := serveCatalogFile(server, "test-catalog-2026-06-24", "198.51.100.1:12345")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	if !bytes.Equal(rr.Body.Bytes(), raw) {
+		t.Fatalf("body bytes mismatch: got %d bytes, want %d", len(rr.Body.Bytes()), len(raw))
+	}
+}
+
+// SPEC-015 §M.4 — wrong catalog_id → 404 catalog_not_found.
+func TestCatalogFile404OnUnknownCatalogID(t *testing.T) {
+	defer tier2.ResetForTest()
+	raw, pubkey := buyerCatalogFixture(t, "test-catalog", time.Now().UTC().Add(time.Hour))
+	path := writeBuyerCatalog(t, raw)
+	cfg := config.Tier2Config{CatalogPath: path, CatalogPublicKey: pubkey}
+	if err := tier2.Configure(cfg, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
+	server.SetTier2Config(cfg)
+
+	rr := serveCatalogFile(server, "nonexistent-catalog", "198.51.100.1:12345")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	var got struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if got.Error.Code != "catalog_not_found" {
+		t.Fatalf("error.code = %q", got.Error.Code)
+	}
+}
+
+// SPEC-015 §M.4 — no catalog configured → 404 on both endpoints.
+func TestCatalogEndpoints404WhenNoCatalogConfigured(t *testing.T) {
+	defer tier2.ResetForTest()
+	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
+	server.SetTier2Config(config.Tier2Config{})
+
+	for _, target := range []string{"/catalog/test-catalog", "/catalog/pubkey"} {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		req.RemoteAddr = "198.51.100.1:12345"
+		server.Handler().ServeHTTP(rr, req)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("%s status = %d", target, rr.Code)
+		}
+	}
+}
+
+// SPEC-015 §M.4 — GET /catalog/pubkey returns base64url-unpadded
+// pubkey + alg = "Ed25519".
+func TestCatalogPubkeyReturnsBase64URLPubkeyAndCapitalEd25519(t *testing.T) {
+	defer tier2.ResetForTest()
+	raw, pubkey := buyerCatalogFixture(t, "test-catalog", time.Now().UTC().Add(time.Hour))
+	path := writeBuyerCatalog(t, raw)
+	cfg := config.Tier2Config{CatalogPath: path, CatalogPublicKey: pubkey}
+	if err := tier2.Configure(cfg, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
+	server.SetTier2Config(cfg)
+
+	rr := serveCatalogPubkey(server, "198.51.100.1:12345")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if got["pubkey"] != pubkey {
+		t.Fatalf("pubkey = %v want %q", got["pubkey"], pubkey)
+	}
+	if got["alg"] != "Ed25519" {
+		t.Fatalf("alg = %v want \"Ed25519\" (capital E)", got["alg"])
+	}
+	// Decode pubkey as base64.RawURLEncoding and verify 32-byte length.
+	decoded, err := base64.RawURLEncoding.DecodeString(pubkey)
+	if err != nil {
+		t.Fatalf("pubkey decode: %v", err)
+	}
+	if len(decoded) != ed25519.PublicKeySize {
+		t.Fatalf("decoded pubkey len = %d want %d", len(decoded), ed25519.PublicKeySize)
+	}
+}
+
+// SPEC-015 §M.4 — catalog endpoints share the receipt-keys rate
+// limit bucket, so the 11th request in a second returns 429.
+func TestCatalogEndpointRateLimited(t *testing.T) {
+	defer tier2.ResetForTest()
+	raw, pubkey := buyerCatalogFixture(t, "test-catalog", time.Now().UTC().Add(time.Hour))
+	path := writeBuyerCatalog(t, raw)
+	cfg := config.Tier2Config{CatalogPath: path, CatalogPublicKey: pubkey}
+	if err := tier2.Configure(cfg, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
+	server.SetTier2Config(cfg)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	server.now = func() time.Time { return now }
+
+	for i := 1; i <= 11; i++ {
+		rr := serveCatalogPubkey(server, "198.51.100.99:12345")
+		want := http.StatusOK
+		if i == 11 {
+			want = http.StatusTooManyRequests
+		}
+		if rr.Code != want {
+			t.Fatalf("request %d status = %d want %d body=%s", i, rr.Code, want, rr.Body.String())
+		}
+	}
+}
+
+// helpers
+
+func serveCatalogFile(server *Server, catalogID, remoteAddr string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/catalog/"+catalogID, nil)
+	req.RemoteAddr = remoteAddr
+	rr := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rr, req)
+	return rr
+}
+
+func serveCatalogPubkey(server *Server, remoteAddr string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/catalog/pubkey", nil)
+	req.RemoteAddr = remoteAddr
+	rr := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rr, req)
+	return rr
+}
+
+// buyerCatalogFixture mirrors tier2's signedCatalogFixture but lives
+// in the buyer test package so we don't import tier2 test-only
+// helpers. Returns the raw signed catalog bytes and the
+// base64.RawURLEncoding pubkey.
+func buyerCatalogFixture(t *testing.T, catalogID string, expiresAt time.Time) ([]byte, string) {
+	t.Helper()
+	seed := bytes.Repeat([]byte{7}, ed25519.SeedSize)
+	privateKey := ed25519.NewKeyFromSeed(seed)
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	issuedAt := time.Now().UTC().Add(-time.Hour)
+	if !issuedAt.Before(expiresAt) {
+		issuedAt = expiresAt.Add(-time.Hour)
+	}
+	// Canonical body — keys ordered alphabetically as the existing
+	// scripts/sign-catalog.go writes (catalog_id, expires_at,
+	// issued_at, models, version).
+	type catalogModel struct {
+		ArtifactKind string `json:"artifact_kind"`
+		HashScope    string `json:"hash_scope"`
+		ModelID      string `json:"model_id"`
+		SHA256       string `json:"sha256"`
+		Source       string `json:"source"`
+	}
+	type canonicalBody struct {
+		CatalogID string         `json:"catalog_id"`
+		ExpiresAt string         `json:"expires_at"`
+		IssuedAt  string         `json:"issued_at"`
+		Models    []catalogModel `json:"models"`
+		Version   int            `json:"version"`
+	}
+	body := canonicalBody{
+		CatalogID: catalogID,
+		ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
+		IssuedAt:  issuedAt.Format(time.RFC3339),
+		Models: []catalogModel{{
+			ArtifactKind: "mlx_weight_file",
+			HashScope:    "primary_weight_file",
+			ModelID:      "model-a",
+			SHA256:       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			Source:       "operator-curated",
+		}},
+		Version: 1,
+	}
+	canonical, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("canonical marshal: %v", err)
+	}
+	sig := ed25519.Sign(privateKey, canonical)
+	type signature struct {
+		Alg   string `json:"alg"`
+		KeyID string `json:"key_id"`
+		Sig   string `json:"sig"`
+	}
+	type catalogFile struct {
+		CatalogID string         `json:"catalog_id"`
+		ExpiresAt string         `json:"expires_at"`
+		IssuedAt  string         `json:"issued_at"`
+		Models    []catalogModel `json:"models"`
+		Signature signature      `json:"signature"`
+		Version   int            `json:"version"`
+	}
+	file := catalogFile{
+		CatalogID: body.CatalogID,
+		ExpiresAt: body.ExpiresAt,
+		IssuedAt:  body.IssuedAt,
+		Models:    body.Models,
+		Signature: signature{Alg: "Ed25519", KeyID: "buyer-test-key", Sig: base64.RawURLEncoding.EncodeToString(sig)},
+		Version:   body.Version,
+	}
+	raw, err := json.Marshal(file)
+	if err != nil {
+		t.Fatalf("catalog marshal: %v", err)
+	}
+	return raw, base64.RawURLEncoding.EncodeToString(publicKey)
+}
+
+func writeBuyerCatalog(t *testing.T, raw []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -16,6 +16,7 @@ import (
 	mrand "math/rand"
 	"net"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -395,6 +396,13 @@ func (s *Server) Handler() http.Handler {
 	r.Get("/v1/models", s.handleModels)
 	r.Get("/v1/pool/check", s.handlePoolCheck)
 	r.Get("/v1/receipt-keys/{provider_id}", s.handleReceiptKeys)
+	// SPEC-015 §M.4 — SPEC-002 v1.6 candidate annotations.
+	// Public, unauthenticated, rate-limited; serve the literal
+	// signed catalog file and the catalog signing pubkey so a buyer-
+	// side verifier can run the §M.3.2 catalog-check path against
+	// this coordinator.
+	r.Get("/catalog/pubkey", s.handleCatalogPubkey)
+	r.Get("/catalog/{catalog_id}", s.handleCatalogFile)
 	r.Post("/v1/chat/completions", s.handleChatCompletions)
 	return r
 }
@@ -729,6 +737,70 @@ func (s *Server) handleReceiptKeys(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "public, max-age=300")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("write receipt keys response failed")
+	}
+}
+
+// SPEC-015 §M.4 — serve the literal signed catalog file under the
+// effectively-active catalog's id. Public, unauthenticated, rate-
+// limited (shares the receipt-keys bucket so a single attacker
+// cannot starve the buyer surface). 404 when (a) no catalog
+// configured, (b) catalog failed to load/verify, OR (c) the path
+// segment does not match the active catalog_id.
+func (s *Server) handleCatalogFile(w http.ResponseWriter, r *http.Request) {
+	if !s.allowReceiptKeys(r) {
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "Catalog endpoint rate limit exceeded")
+		return
+	}
+	cfg := s.tier2Config()
+	if !tier2.Active() || strings.TrimSpace(cfg.CatalogPath) == "" {
+		writeError(w, http.StatusNotFound, "catalog_not_found", "Catalog not found")
+		return
+	}
+	requested := strings.TrimSpace(chi.URLParam(r, "catalog_id"))
+	active := tier2.CatalogID()
+	if requested == "" || requested != active {
+		writeError(w, http.StatusNotFound, "catalog_not_found", "Catalog not found")
+		return
+	}
+	data, err := os.ReadFile(cfg.CatalogPath)
+	if err != nil {
+		s.log.Warn().Err(err).Str("catalog_path", cfg.CatalogPath).Msg("read catalog file failed")
+		writeError(w, http.StatusNotFound, "catalog_not_found", "Catalog not found")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	if _, err := w.Write(data); err != nil {
+		s.log.Warn().Err(err).Str("catalog_id", active).Msg("write catalog file response failed")
+	}
+}
+
+// SPEC-015 §M.4 — serve the catalog signing pubkey.
+// `{"pubkey":"<43-char base64url-unpadded>","alg":"Ed25519"}`. The
+// pubkey comes from Tier2Config.CatalogPublicKey, which the
+// coordinator already uses to verify the loaded catalog — so the
+// trust root is the same operator-configured key (§M.3.3 operator-
+// mutable trust posture, inherited from §10.7).
+func (s *Server) handleCatalogPubkey(w http.ResponseWriter, r *http.Request) {
+	if !s.allowReceiptKeys(r) {
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "Catalog endpoint rate limit exceeded")
+		return
+	}
+	cfg := s.tier2Config()
+	pubkey := strings.TrimSpace(cfg.CatalogPublicKey)
+	if !tier2.Active() || pubkey == "" {
+		writeError(w, http.StatusNotFound, "catalog_not_found", "Catalog not found")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"pubkey": pubkey,
+		"alg":    "Ed25519",
+	}); err != nil {
+		s.log.Warn().Err(err).Msg("write catalog pubkey response failed")
 	}
 }
 

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -899,12 +899,42 @@ func (s *Server) evictReceiptKeyEntries(now time.Time) {
 	}
 }
 
+// poolCheckClientKey returns the per-source key used for the
+// /poolz, /v1/receipt-keys/*, and /catalog/* rate-limit buckets.
+//
+// Production sits behind nginx on loopback (see
+// phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf) so
+// every public buyer's r.RemoteAddr is 127.0.0.1 — keying on that
+// alone collapses every public buyer into one shared bucket and lets
+// any single caller starve the rate-limit pool for everyone else.
+//
+// Mirrors ws.remoteIPForUnauthSemaphore: when r.RemoteAddr is a
+// loopback address, honor X-Real-IP (which the on-host nginx site
+// sets). Direct, non-loopback hits (no proxy in front) use
+// r.RemoteAddr unchanged so an attacker on the open internet cannot
+// spoof their bucket key.
 func poolCheckClientKey(r *http.Request) string {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil || host == "" {
+		host = r.RemoteAddr
+	}
+	if isLoopbackHost(host) {
+		if realIP := strings.TrimSpace(r.Header.Get("X-Real-IP")); realIP != "" {
+			return realIP
+		}
+	}
+	if host == "" {
 		return r.RemoteAddr
 	}
 	return host
+}
+
+func isLoopbackHost(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
 }
 
 type modelsResponse struct {

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -140,6 +140,19 @@ type Tier2Config struct {
 	CatalogPath         string `yaml:"catalog_path"`
 	CatalogPublicKey    string `yaml:"catalog_public_key"`
 	RequireHashVerified bool   `yaml:"require_hash_verified"`
+	// PublicCatalogBaseURL is the public base URL the coordinator
+	// advertises for SPEC-015 §M.4 catalog endpoints
+	// (`GET /catalog/<catalog_id>` and `GET /catalog/pubkey`). When
+	// non-empty, `/poolz` emits absolute catalog URLs derived from
+	// this base (trailing slashes trimmed). When empty, `/poolz`
+	// falls back to deriving an absolute URL from the inbound
+	// request's scheme + `Host` header. If neither source yields a
+	// usable base (catalog_id present but no host available),
+	// `catalog_url` and `catalog_pubkey_url` are OMITTED from the
+	// `/poolz` response — only `catalog_id` is emitted, so a
+	// verifier invoked with `--catalog <path>` + `--catalog-pubkey`
+	// (file-based, no URL resolution) still works.
+	PublicCatalogBaseURL string `yaml:"public_catalog_base_url"`
 
 	RequireEncryptedLeg            bool   `yaml:"require_encrypted_leg"`
 	EncryptedLegAEAD               string `yaml:"encrypted_leg_aead"`

--- a/phase4-coordinator/internal/ws/poolz_catalog_test.go
+++ b/phase4-coordinator/internal/ws/poolz_catalog_test.go
@@ -1,0 +1,332 @@
+package ws_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/tier2"
+	"github.com/rs/zerolog"
+)
+
+func nopLoggerForTest() zerolog.Logger { return zerolog.Nop() }
+
+// SPEC-015 §M.4 / §M.5 AC-39 — /poolz emits catalog_id, catalog_url,
+// catalog_pubkey_url when a tier-2 catalog is configured, loaded
+// cleanly, and signature-verified.
+func TestPoolzEmitsCatalogFieldsWhenCatalogActive(t *testing.T) {
+	defer tier2.ResetForTest()
+	raw, pubkey := wsCatalogFixture(t, "test-catalog-2026-06-24", time.Now().UTC().Add(time.Hour))
+	path := writeWSCatalog(t, raw)
+	ts := newProviderServer(t, func(cfg *config.Config) {
+		cfg.Tier2.CatalogPath = path
+		cfg.Tier2.CatalogPublicKey = pubkey
+		cfg.Tier2.PublicCatalogBaseURL = "https://coordinator.streamvc.live"
+	})
+	defer ts.Close()
+	if err := tier2.Configure(config.Tier2Config{
+		CatalogPath:      path,
+		CatalogPublicKey: pubkey,
+	}, nopLoggerForTest()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+
+	raw2, _ := fetchPoolzCatalogFields(t, ts.URL)
+	var parsed struct {
+		CatalogID        *string `json:"catalog_id"`
+		CatalogURL       *string `json:"catalog_url"`
+		CatalogPubkeyURL *string `json:"catalog_pubkey_url"`
+	}
+	if err := json.Unmarshal(raw2, &parsed); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if parsed.CatalogID == nil || *parsed.CatalogID != "test-catalog-2026-06-24" {
+		t.Fatalf("catalog_id = %v", parsed.CatalogID)
+	}
+	if parsed.CatalogURL == nil || *parsed.CatalogURL != "https://coordinator.streamvc.live/catalog/test-catalog-2026-06-24" {
+		t.Fatalf("catalog_url = %v", parsed.CatalogURL)
+	}
+	if parsed.CatalogPubkeyURL == nil || *parsed.CatalogPubkeyURL != "https://coordinator.streamvc.live/catalog/pubkey" {
+		t.Fatalf("catalog_pubkey_url = %v", parsed.CatalogPubkeyURL)
+	}
+}
+
+// SPEC-015 §M.4 — /poolz OMITS the three catalog fields when no
+// catalog is configured (§M.4 effectively-active condition fails on
+// CatalogPath empty).
+func TestPoolzOmitsCatalogFieldsWhenCatalogNotConfigured(t *testing.T) {
+	defer tier2.ResetForTest()
+	ts := newProviderServer(t)
+	defer ts.Close()
+
+	raw, _ := fetchPoolzCatalogFields(t, ts.URL)
+	for _, key := range []string{"catalog_id", "catalog_url", "catalog_pubkey_url"} {
+		if bytes.Contains(raw, []byte(`"`+key+`"`)) {
+			t.Fatalf("/poolz includes %q with no catalog configured; raw=%s", key, raw)
+		}
+	}
+}
+
+// SPEC-015 §M.4 / AC-39 — when CatalogPath points at a missing
+// file, malformed JSON, or a body whose signature does not verify,
+// /poolz MUST OMIT the three catalog fields (they are absent from
+// the response JSON, not present-with-null).
+func TestPoolzOmitsCatalogFieldsWhenCatalogLoadFails(t *testing.T) {
+	cases := []struct {
+		name      string
+		writeFile func(t *testing.T) (string, string) // returns (path, pubkey)
+	}{
+		{
+			name: "missing-file",
+			writeFile: func(t *testing.T) (string, string) {
+				// Path under TempDir that we deliberately do NOT create.
+				_, pubkey := wsCatalogFixture(t, "test-catalog", time.Now().UTC().Add(time.Hour))
+				return filepath.Join(t.TempDir(), "missing-catalog.json"), pubkey
+			},
+		},
+		{
+			name: "malformed-json",
+			writeFile: func(t *testing.T) (string, string) {
+				_, pubkey := wsCatalogFixture(t, "test-catalog", time.Now().UTC().Add(time.Hour))
+				return writeWSCatalog(t, []byte("this is not json")), pubkey
+			},
+		},
+		{
+			name: "signature-mismatch",
+			writeFile: func(t *testing.T) (string, string) {
+				raw, _ := wsCatalogFixture(t, "test-catalog", time.Now().UTC().Add(time.Hour))
+				// Generate an UNRELATED pubkey so the catalog signature
+				// will not verify against the configured CatalogPublicKey.
+				seed := bytes.Repeat([]byte{99}, ed25519.SeedSize)
+				other := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
+				return writeWSCatalog(t, raw), base64.RawURLEncoding.EncodeToString(other)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer tier2.ResetForTest()
+			path, pubkey := tc.writeFile(t)
+			ts := newProviderServer(t, func(cfg *config.Config) {
+				cfg.Tier2.CatalogPath = path
+				cfg.Tier2.CatalogPublicKey = pubkey
+				cfg.Tier2.PublicCatalogBaseURL = "https://coordinator.streamvc.live"
+			})
+			defer ts.Close()
+			// Configure with strict=false so a failed catalog leaves
+			// tier2.Active() == false rather than refusing startup.
+			_ = tier2.Configure(config.Tier2Config{
+				CatalogPath:      path,
+				CatalogPublicKey: pubkey,
+			}, nopLoggerForTest())
+			if tier2.Active() {
+				t.Fatalf("tier2.Active() = true for failure case %q; test setup is wrong", tc.name)
+			}
+
+			raw, _ := fetchPoolzCatalogFields(t, ts.URL)
+			for _, key := range []string{"catalog_id", "catalog_url", "catalog_pubkey_url"} {
+				if bytes.Contains(raw, []byte(`"`+key+`"`)) {
+					t.Fatalf("%s: /poolz includes %q for failed catalog; raw=%s", tc.name, key, raw)
+				}
+			}
+		})
+	}
+}
+
+// SPEC-015 §M.4 — URL construction edge cases. Trailing slash on
+// PublicCatalogBaseURL is trimmed; empty config falls back to
+// scheme+Host; missing host → URL fields omitted but catalog_id
+// still emitted.
+func TestPoolzCatalogURLConstructionEdgeCases(t *testing.T) {
+	cases := []struct {
+		name             string
+		baseURL          string
+		hostHeader       string
+		wantCatalogURL   string
+		wantPubkeyURL    string
+		expectURLsAbsent bool
+	}{
+		{
+			name:           "trailing-slash-base",
+			baseURL:        "https://coordinator.streamvc.live/",
+			hostHeader:     "coordinator.streamvc.live",
+			wantCatalogURL: "https://coordinator.streamvc.live/catalog/test-catalog",
+			wantPubkeyURL:  "https://coordinator.streamvc.live/catalog/pubkey",
+		},
+		{
+			name:           "host-with-port-fallback",
+			baseURL:        "",
+			hostHeader:     "test.example:8443",
+			wantCatalogURL: "http://test.example:8443/catalog/test-catalog",
+			wantPubkeyURL:  "http://test.example:8443/catalog/pubkey",
+		},
+		{
+			name:           "ipv6-host-fallback",
+			baseURL:        "",
+			hostHeader:     "[2001:db8::1]:8443",
+			wantCatalogURL: "http://[2001:db8::1]:8443/catalog/test-catalog",
+			wantPubkeyURL:  "http://[2001:db8::1]:8443/catalog/pubkey",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer tier2.ResetForTest()
+			raw, pubkey := wsCatalogFixture(t, "test-catalog", time.Now().UTC().Add(time.Hour))
+			path := writeWSCatalog(t, raw)
+			ts := newProviderServer(t, func(cfg *config.Config) {
+				cfg.Tier2.CatalogPath = path
+				cfg.Tier2.CatalogPublicKey = pubkey
+				cfg.Tier2.PublicCatalogBaseURL = tc.baseURL
+			})
+			defer ts.Close()
+			if err := tier2.Configure(config.Tier2Config{
+				CatalogPath:      path,
+				CatalogPublicKey: pubkey,
+			}, nopLoggerForTest()); err != nil {
+				t.Fatalf("tier2.Configure: %v", err)
+			}
+
+			req, err := http.NewRequest(http.MethodGet, ts.URL+"/poolz", nil)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			req.Header.Set("Authorization", "Bearer test-operator-key")
+			req.Host = tc.hostHeader
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("/poolz: %v", err)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			var parsed struct {
+				CatalogID        *string `json:"catalog_id"`
+				CatalogURL       *string `json:"catalog_url"`
+				CatalogPubkeyURL *string `json:"catalog_pubkey_url"`
+			}
+			if err := json.Unmarshal(body, &parsed); err != nil {
+				t.Fatalf("json: %v body=%s", err, body)
+			}
+			if parsed.CatalogID == nil || *parsed.CatalogID != "test-catalog" {
+				t.Fatalf("catalog_id = %v body=%s", parsed.CatalogID, body)
+			}
+			if parsed.CatalogURL == nil || *parsed.CatalogURL != tc.wantCatalogURL {
+				t.Fatalf("catalog_url = %v want %q", parsed.CatalogURL, tc.wantCatalogURL)
+			}
+			if parsed.CatalogPubkeyURL == nil || *parsed.CatalogPubkeyURL != tc.wantPubkeyURL {
+				t.Fatalf("catalog_pubkey_url = %v want %q", parsed.CatalogPubkeyURL, tc.wantPubkeyURL)
+			}
+		})
+	}
+}
+
+// helpers (shadowed names to avoid conflict with server_test.go)
+
+func fetchPoolzCatalogFields(t *testing.T, serverURL string) ([]byte, *http.Response) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, serverURL+"/poolz", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-operator-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("/poolz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("/poolz status = %d body=%s", resp.StatusCode, body)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return body, resp
+}
+
+func wsCatalogFixture(t *testing.T, catalogID string, expiresAt time.Time) ([]byte, string) {
+	t.Helper()
+	seed := bytes.Repeat([]byte{7}, ed25519.SeedSize)
+	privateKey := ed25519.NewKeyFromSeed(seed)
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	issuedAt := time.Now().UTC().Add(-time.Hour)
+	if !issuedAt.Before(expiresAt) {
+		issuedAt = expiresAt.Add(-time.Hour)
+	}
+	type catalogModel struct {
+		ArtifactKind string `json:"artifact_kind"`
+		HashScope    string `json:"hash_scope"`
+		ModelID      string `json:"model_id"`
+		SHA256       string `json:"sha256"`
+		Source       string `json:"source"`
+	}
+	type canonicalBody struct {
+		CatalogID string         `json:"catalog_id"`
+		ExpiresAt string         `json:"expires_at"`
+		IssuedAt  string         `json:"issued_at"`
+		Models    []catalogModel `json:"models"`
+		Version   int            `json:"version"`
+	}
+	body := canonicalBody{
+		CatalogID: catalogID,
+		ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
+		IssuedAt:  issuedAt.Format(time.RFC3339),
+		Models: []catalogModel{{
+			ArtifactKind: "mlx_weight_file",
+			HashScope:    "primary_weight_file",
+			ModelID:      "model-a",
+			SHA256:       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			Source:       "operator-curated",
+		}},
+		Version: 1,
+	}
+	canonical, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("canonical: %v", err)
+	}
+	sig := ed25519.Sign(privateKey, canonical)
+	type signature struct {
+		Alg   string `json:"alg"`
+		KeyID string `json:"key_id"`
+		Sig   string `json:"sig"`
+	}
+	type catalogFile struct {
+		CatalogID string         `json:"catalog_id"`
+		ExpiresAt string         `json:"expires_at"`
+		IssuedAt  string         `json:"issued_at"`
+		Models    []catalogModel `json:"models"`
+		Signature signature      `json:"signature"`
+		Version   int            `json:"version"`
+	}
+	file := catalogFile{
+		CatalogID: body.CatalogID,
+		ExpiresAt: body.ExpiresAt,
+		IssuedAt:  body.IssuedAt,
+		Models:    body.Models,
+		Signature: signature{Alg: "Ed25519", KeyID: "ws-test-key", Sig: base64.RawURLEncoding.EncodeToString(sig)},
+		Version:   body.Version,
+	}
+	raw, err := json.Marshal(file)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw, base64.RawURLEncoding.EncodeToString(publicKey)
+}
+
+func writeWSCatalog(t *testing.T, raw []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -2730,13 +2730,48 @@ func (s *Server) handlePoolz(w http.ResponseWriter, r *http.Request) {
 			ReceiptPubkeyPrev: receiptPubkeyPrev,
 		})
 	}
-	_ = json.NewEncoder(w).Encode(struct {
-		Pool    []poolzProvider `json:"pool"`
-		Summary any             `json:"summary"`
-	}{
-		Pool:    poolz,
-		Summary: summary,
-	})
+	// SPEC-015 §M.4 — SPEC-002 v1.6 candidate annotation. The three
+	// `catalog_*` fields are present iff the catalog is effectively
+	// active: (a) Tier2Config.CatalogPath is configured, (b) the
+	// catalog parsed cleanly, (c) its signature verified. The
+	// `s.catalogRef().Active()` predicate captures all three.
+	type poolzResponse struct {
+		Pool             []poolzProvider `json:"pool"`
+		Summary          any             `json:"summary"`
+		CatalogID        *string         `json:"catalog_id,omitempty"`
+		CatalogURL       *string         `json:"catalog_url,omitempty"`
+		CatalogPubkeyURL *string         `json:"catalog_pubkey_url,omitempty"`
+	}
+	resp := poolzResponse{Pool: poolz, Summary: summary}
+	if s.catalogRef().Active() {
+		catalogID := s.catalogRef().CatalogID()
+		if catalogID != "" {
+			resp.CatalogID = &catalogID
+			base := strings.TrimSpace(cfg.PublicCatalogBaseURL)
+			if base == "" {
+				// Fallback: derive from the inbound request host so a
+				// verifier reading `/poolz` from the same coordinator
+				// can resolve the URLs even when the operator hasn't
+				// pinned a public base.
+				if r.Host != "" {
+					scheme := "https"
+					if r.TLS == nil {
+						scheme = "http"
+					}
+					base = scheme + "://" + r.Host
+				}
+			} else {
+				base = strings.TrimRight(base, "/")
+			}
+			if base != "" {
+				catalogURL := base + "/catalog/" + catalogID
+				pubkeyURL := base + "/catalog/pubkey"
+				resp.CatalogURL = &catalogURL
+				resp.CatalogPubkeyURL = &pubkeyURL
+			}
+		}
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 func providerPublishedReady(p pool.Provider) bool {

--- a/phase7-verify/internal/cache/catalog/catalog_cache.go
+++ b/phase7-verify/internal/cache/catalog/catalog_cache.go
@@ -1,0 +1,201 @@
+// Package catalogcache implements the SPEC-015 v0.3 §M.3.4
+// catalog-bytes cache. Three-band TTL: a fresh catalog caches for
+// up to 6 hours; a near-expiry catalog caches for (expires_at -
+// now() - 60s); a catalog accepted only via the §M.3.2 step 5 60s
+// skew grace, OR one whose remaining lifetime is < 60s, MUST NOT
+// be cached so the next verification re-checks expiry against a
+// fresh wall-clock reading.
+//
+// Cache layout (one file per (catalog_url, catalog_pubkey
+// fingerprint)):
+//
+//	~/.macprovider/verify/catalogs/<sha256-hex-of-catalog-url>.json
+//
+// Cache entry shape includes the resolved pubkey so a rotation
+// (pubkey changes server-side) invalidates the cache miss-on-read.
+package catalogcache
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Per SPEC-015 §M.3.4: upper TTL band ceiling = 6h.
+const maxTTL = 6 * time.Hour
+
+// Per SPEC-015 §M.3.4: the (60s, 6h] band caches for `R - 60s`;
+// catalogs with `R <= 60s` are never cached.
+const minTTL = 60 * time.Second
+
+// Entry is the on-disk cache record. Field names mirror the
+// SPEC-015 §M.3.4 contract verbatim. `catalog_pubkey_b64` is the
+// base64.RawURLEncoding form (the catalog signer + coordinator
+// both use this encoding); the "b64" suffix is the §M.3.4 name.
+// `expires_at` is the catalog's OWN expires_at (from the parsed
+// signed body, propagated unchanged); `cache_expires_at` is the
+// computed §M.3.4 TTL ceiling. Both are persisted so Step 5
+// diagnostics can distinguish "catalog itself expired" from
+// "cache slot expired."
+type Entry struct {
+	CatalogURL      string    `json:"catalog_url"`
+	CatalogBytes    []byte    `json:"catalog_bytes"`
+	CatalogPubkey   string    `json:"catalog_pubkey_b64"`
+	FetchedAt       time.Time `json:"fetched_at"`
+	ExpiresAt       time.Time `json:"expires_at"`
+	CacheExpiresAt  time.Time `json:"cache_expires_at"`
+}
+
+// Store is a simple on-disk cache rooted at Dir.
+type Store struct {
+	Dir string
+}
+
+// New returns a Store rooted at <home>/.macprovider/verify/catalogs.
+// If home cannot be resolved, the returned Store is unusable.
+func New() (*Store, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("catalogcache: resolve home: %w", err)
+	}
+	return &Store{Dir: filepath.Join(home, ".macprovider", "verify", "catalogs")}, nil
+}
+
+// NewAt returns a Store rooted at dir (test seam).
+func NewAt(dir string) *Store {
+	return &Store{Dir: dir}
+}
+
+// ComputeTTL applies the §M.3.4 three-band rule. R = expires_at -
+// now() in seconds. Returns the cache TTL; zero (or negative) means
+// "do not cache." The implementation is pure arithmetic so it can be
+// unit-tested without disk.
+func ComputeTTL(expiresAt, now time.Time) time.Duration {
+	r := expiresAt.Sub(now)
+	if r <= minTTL {
+		return 0
+	}
+	if r > maxTTL {
+		return maxTTL
+	}
+	return r - minTTL
+}
+
+// Put writes the catalog bytes + pubkey into the cache, computing
+// the TTL per §M.3.4. Returns (nil, false) without writing if the
+// computed TTL is zero (do-not-cache band). Returns (entry, true)
+// on a successful write.
+func (s *Store) Put(catalogURL string, catalogBytes []byte, pubkeyBase64URL string, expiresAt, now time.Time) (*Entry, bool, error) {
+	if s.Dir == "" {
+		return nil, false, errors.New("catalogcache: store has empty Dir")
+	}
+	ttl := ComputeTTL(expiresAt, now)
+	if ttl <= 0 {
+		return nil, false, nil
+	}
+	if err := os.MkdirAll(s.Dir, 0o700); err != nil {
+		return nil, false, fmt.Errorf("catalogcache: mkdir: %w", err)
+	}
+	entry := &Entry{
+		CatalogURL:     catalogURL,
+		CatalogBytes:   append([]byte(nil), catalogBytes...),
+		CatalogPubkey:  pubkeyBase64URL,
+		FetchedAt:      now.UTC(),
+		ExpiresAt:      expiresAt.UTC(),
+		CacheExpiresAt: now.Add(ttl).UTC(),
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return nil, false, fmt.Errorf("catalogcache: marshal: %w", err)
+	}
+	path := s.pathFor(catalogURL)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return nil, false, fmt.Errorf("catalogcache: write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return nil, false, fmt.Errorf("catalogcache: rename: %w", err)
+	}
+	return entry, true, nil
+}
+
+// Get returns a cache hit if all three conditions hold:
+//  1. an entry exists for catalogURL,
+//  2. the cached entry has not exceeded its own TTL (ExpiresAtCache),
+//  3. the cached entry's pubkey matches the supplied expectedPubkey.
+//
+// Returns (entry, true) on hit, (nil, false) on miss (including the
+// rotation case where the pubkey changed). Errors only on I/O or
+// corrupt-cache; a corrupt entry is silently treated as a miss and
+// the bad file is removed.
+func (s *Store) Get(catalogURL, expectedPubkeyBase64URL string, now time.Time) (*Entry, bool, error) {
+	if s.Dir == "" {
+		return nil, false, errors.New("catalogcache: store has empty Dir")
+	}
+	path := s.pathFor(catalogURL)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("catalogcache: read: %w", err)
+	}
+	var entry Entry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		// Corrupt entry — remove and miss.
+		_ = os.Remove(path)
+		return nil, false, nil
+	}
+	if entry.CatalogURL != catalogURL {
+		// Hash collision OR cross-URL pollution — treat as miss.
+		_ = os.Remove(path)
+		return nil, false, nil
+	}
+	if entry.CatalogPubkey != expectedPubkeyBase64URL {
+		// Pubkey rotation — invalidate.
+		return nil, false, nil
+	}
+	if !now.Before(entry.CacheExpiresAt) {
+		// Stale — invalidate.
+		return nil, false, nil
+	}
+	return &entry, true, nil
+}
+
+// Delete removes the cache entry for catalogURL. Idempotent.
+func (s *Store) Delete(catalogURL string) error {
+	if s.Dir == "" {
+		return errors.New("catalogcache: store has empty Dir")
+	}
+	path := s.pathFor(catalogURL)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("catalogcache: remove: %w", err)
+	}
+	return nil
+}
+
+// pathFor returns the filesystem path for the URL's cache entry.
+// Keyed by SHA-256(catalogURL) so unusual characters in the URL
+// (query strings, encoded chars) don't break filename rules. The
+// pubkey is NOT part of the key — pubkey rotation is detected by
+// comparing the stored CatalogPubkey on read, which lets a single
+// cache slot survive across rotation events with explicit miss.
+func (s *Store) pathFor(catalogURL string) string {
+	sum := sha256.Sum256([]byte(catalogURL))
+	return filepath.Join(s.Dir, hex.EncodeToString(sum[:])+".json")
+}
+
+// EncodePubkeyForCache normalizes a catalog pubkey to its
+// base64.RawURLEncoding form so the cache key is consistent
+// across verify invocations even when callers vary in how they
+// supplied --catalog-pubkey vs --catalog-pubkey-url.
+func EncodePubkeyForCache(raw []byte) string {
+	return base64.RawURLEncoding.EncodeToString(raw)
+}

--- a/phase7-verify/internal/cache/catalog/catalog_cache_test.go
+++ b/phase7-verify/internal/cache/catalog/catalog_cache_test.go
@@ -1,0 +1,149 @@
+package catalogcache
+
+import (
+	"crypto/ed25519"
+	"testing"
+	"time"
+)
+
+// SPEC-015 §M.3.4 — three TTL bands.
+func TestComputeTTLBands(t *testing.T) {
+	base := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name    string
+		remain  time.Duration
+		wantTTL time.Duration
+	}{
+		{"more-than-6h", 7 * time.Hour, 6 * time.Hour},
+		{"exactly-6h", 6 * time.Hour, 6*time.Hour - 60*time.Second},
+		{"3h", 3 * time.Hour, 3*time.Hour - 60*time.Second},
+		{"61s", 61 * time.Second, time.Second},
+		{"exactly-60s", 60 * time.Second, 0}, // do NOT cache
+		{"30s", 30 * time.Second, 0},
+		{"0s", 0, 0},
+		{"negative-30s", -30 * time.Second, 0},
+		{"negative-2h", -2 * time.Hour, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ComputeTTL(base.Add(tc.remain), base)
+			if got != tc.wantTTL {
+				t.Fatalf("ComputeTTL(R=%v) = %v, want %v", tc.remain, got, tc.wantTTL)
+			}
+		})
+	}
+}
+
+func TestPutAndGetRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := NewAt(dir)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(3 * time.Hour)
+	pubkey := pubkeyFixture(t)
+	entry, ok, err := s.Put("https://example/catalog/x", []byte(`{"catalog_id":"x"}`), pubkey, expires, now)
+	if err != nil || !ok {
+		t.Fatalf("Put: err=%v ok=%v", err, ok)
+	}
+	if entry == nil {
+		t.Fatal("entry nil")
+	}
+	got, hit, err := s.Get("https://example/catalog/x", pubkey, now)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !hit {
+		t.Fatal("expected hit")
+	}
+	if string(got.CatalogBytes) != `{"catalog_id":"x"}` {
+		t.Fatalf("bytes = %s", got.CatalogBytes)
+	}
+}
+
+func TestPutSkipsBelowMinTTL(t *testing.T) {
+	dir := t.TempDir()
+	s := NewAt(dir)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	_, ok, err := s.Put("u", []byte("{}"), pubkeyFixture(t), now.Add(30*time.Second), now)
+	if err != nil {
+		t.Fatalf("Put err: %v", err)
+	}
+	if ok {
+		t.Fatal("Put with R=30s should NOT cache (below 60s minimum)")
+	}
+	// Confirm no file was written.
+	_, hit, err := s.Get("u", pubkeyFixture(t), now)
+	if err != nil {
+		t.Fatalf("Get err: %v", err)
+	}
+	if hit {
+		t.Fatal("Get hit after skipped Put")
+	}
+}
+
+// SPEC-015 §M.3.4 — pubkey rotation invalidates the cache.
+func TestGetMissOnPubkeyRotation(t *testing.T) {
+	dir := t.TempDir()
+	s := NewAt(dir)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	oldPubkey := pubkeyFixture(t)
+	if _, ok, err := s.Put("u", []byte("{}"), oldPubkey, now.Add(time.Hour), now); err != nil || !ok {
+		t.Fatalf("Put: err=%v ok=%v", err, ok)
+	}
+	// Rotate the pubkey — supply a different key.
+	newPubkey := EncodePubkeyForCache(make([]byte, ed25519.PublicKeySize))
+	_, hit, err := s.Get("u", newPubkey, now)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if hit {
+		t.Fatal("Get hit after pubkey rotation (cache must invalidate)")
+	}
+}
+
+// SPEC-015 §M.3.4 — stale cache entries MUST miss.
+func TestGetMissOnStaleEntry(t *testing.T) {
+	dir := t.TempDir()
+	s := NewAt(dir)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	pubkey := pubkeyFixture(t)
+	// Put with TTL of (3h - 60s) ≈ 2h59m.
+	if _, ok, err := s.Put("u", []byte("{}"), pubkey, now.Add(3*time.Hour), now); err != nil || !ok {
+		t.Fatalf("Put: %v", err)
+	}
+	// Advance well past the cache TTL.
+	later := now.Add(4 * time.Hour)
+	_, hit, err := s.Get("u", pubkey, later)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if hit {
+		t.Fatal("Get hit on stale entry")
+	}
+}
+
+func TestDeleteIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	s := NewAt(dir)
+	if err := s.Delete("u"); err != nil {
+		t.Fatalf("Delete on missing: %v", err)
+	}
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	if _, _, err := s.Put("u", []byte("{}"), pubkeyFixture(t), now.Add(time.Hour), now); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := s.Delete("u"); err != nil {
+		t.Fatalf("Delete after Put: %v", err)
+	}
+	if _, hit, _ := s.Get("u", pubkeyFixture(t), now); hit {
+		t.Fatal("Get hit after Delete")
+	}
+}
+
+func pubkeyFixture(t *testing.T) string {
+	t.Helper()
+	key := make([]byte, ed25519.PublicKeySize)
+	for i := range key {
+		key[i] = byte(i + 7)
+	}
+	return EncodePubkeyForCache(key)
+}

--- a/phase7-verify/internal/catalog/catalog.go
+++ b/phase7-verify/internal/catalog/catalog.go
@@ -1,0 +1,282 @@
+// Package catalog parses and verifies SPEC-008 / SPEC-015 v0.3 §M.3
+// signed model catalogs. Pure-stdlib hand-translation of the
+// coordinator's tier2 catalog parser at
+// phase4-coordinator/internal/tier2/catalog.go — the verifier MUST
+// NOT import the coordinator package per the v0.2 phase7-verify
+// stdlib-only discipline.
+package catalog
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// SPEC-015 §M.3.2 step 4 — catalog signature MUST be ed25519 and
+// signature.alg MUST be the ASCII string "Ed25519" (capital E,
+// matching scripts/sign-catalog.go:142-145 and the existing
+// coordinator validator).
+const signatureAlg = "Ed25519"
+
+// SPEC-015 §M.3.2 step 5 — 60-second skew grace on expires_at.
+const expiryGrace = 60 * time.Second
+
+// SPEC-015 §M.3.2 step 3 — catalog sha256 fields MUST match this
+// pattern (raw 64-char lowercase hex, no `sha256:` prefix per
+// SPEC-011 R-3.3.1).
+var hashPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// ModelEntry mirrors scripts/sign-catalog.go modelEntry +
+// phase4-coordinator/internal/tier2/catalog.go ModelEntry.
+type ModelEntry struct {
+	ArtifactKind string `json:"artifact_kind"`
+	HashScope    string `json:"hash_scope"`
+	ModelID      string `json:"model_id"`
+	Notes        string `json:"notes,omitempty"`
+	SHA256       string `json:"sha256"`
+	Source       string `json:"source"`
+}
+
+// Signature mirrors scripts/sign-catalog.go signature.
+type Signature struct {
+	Alg   string `json:"alg"`
+	KeyID string `json:"key_id"`
+	Sig   string `json:"sig"`
+}
+
+// File is the on-the-wire signed catalog (parsed JSON shape).
+type File struct {
+	CatalogID string       `json:"catalog_id"`
+	ExpiresAt string       `json:"expires_at"`
+	IssuedAt  string       `json:"issued_at"`
+	Models    []ModelEntry `json:"models"`
+	Signature Signature    `json:"signature"`
+	Version   int          `json:"version"`
+}
+
+// canonicalBody is the §M.3.2 step 4 canonical body — the File
+// minus the Signature field, in the exact key order
+// scripts/sign-catalog.go:42-49 produces:
+// catalog_id, expires_at, issued_at, models, version.
+type canonicalBody struct {
+	CatalogID string       `json:"catalog_id"`
+	ExpiresAt string       `json:"expires_at"`
+	IssuedAt  string       `json:"issued_at"`
+	Models    []ModelEntry `json:"models"`
+	Version   int          `json:"version"`
+}
+
+// Catalog is the parsed + signature-verified catalog. Hold by value;
+// it is immutable after Parse + Verify.
+type Catalog struct {
+	CatalogID string
+	ExpiresAt time.Time
+	IssuedAt  time.Time
+	Models    map[string]ModelEntry
+	// Raw retains the original bytes so the verifier can serve them
+	// to a buyer or stamp them into a cache without re-marshalling
+	// (which could re-order keys and re-break the signature).
+	Raw []byte
+	// KeyID is the informational fingerprint from signature.key_id.
+	KeyID string
+}
+
+// Parse decodes the signed catalog bytes into a typed Catalog
+// WITHOUT verifying the signature. Use Verify next.
+func Parse(data []byte) (*Catalog, error) {
+	if len(data) == 0 {
+		return nil, errors.New("catalog: empty body")
+	}
+	f, err := decodeFile(data)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: parse: %w", err)
+	}
+	if strings.TrimSpace(f.CatalogID) == "" {
+		return nil, errors.New("catalog: catalog_id missing")
+	}
+	// Pin to v1 to mirror phase4-coordinator/internal/tier2/catalog.go:454-456.
+	// SPEC-008 v0.3 / §M.3.2 step 3 — only catalog schema version 1
+	// is supported; anything else MUST be rejected so the buyer-side
+	// and coordinator-side accept-reject contracts stay equivalent.
+	if f.Version != 1 {
+		return nil, fmt.Errorf("catalog: version=%d unsupported (only 1 is accepted)", f.Version)
+	}
+	if len(f.Models) == 0 {
+		return nil, errors.New("catalog: models list is empty")
+	}
+	expires, err := time.Parse(time.RFC3339, f.ExpiresAt)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: expires_at not RFC3339: %w", err)
+	}
+	issued, err := time.Parse(time.RFC3339, f.IssuedAt)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: issued_at not RFC3339: %w", err)
+	}
+	if !issued.Before(expires) {
+		return nil, errors.New("catalog: issued_at >= expires_at")
+	}
+	models := make(map[string]ModelEntry, len(f.Models))
+	for _, m := range f.Models {
+		if strings.TrimSpace(m.ModelID) == "" {
+			return nil, errors.New("catalog: model_id is empty")
+		}
+		if m.ArtifactKind != "mlx_weight_file" {
+			return nil, fmt.Errorf("catalog: model %q artifact_kind must be mlx_weight_file", m.ModelID)
+		}
+		switch m.HashScope {
+		case "primary_weight_file", "artifact_manifest", "coordinator_endorsed_incremental":
+		default:
+			return nil, fmt.Errorf("catalog: model %q hash_scope is unsupported", m.ModelID)
+		}
+		if strings.TrimSpace(m.Source) == "" {
+			return nil, fmt.Errorf("catalog: model %q source is empty", m.ModelID)
+		}
+		if !hashPattern.MatchString(m.SHA256) {
+			return nil, fmt.Errorf("catalog: model %q sha256=%q is not 64 lowercase hex", m.ModelID, m.SHA256)
+		}
+		key := modelKey(m.ModelID)
+		if _, dup := models[key]; dup {
+			return nil, fmt.Errorf("catalog: duplicate model_id %q after case-fold + trim", m.ModelID)
+		}
+		models[key] = m
+	}
+	// Mirror phase4-coordinator/internal/tier2/catalog.go:473-475:
+	// signature.alg + signature.sig + signature.key_id are all
+	// required non-empty at parse-time.
+	if strings.TrimSpace(f.Signature.Alg) == "" {
+		return nil, errors.New("catalog: signature.alg missing")
+	}
+	if strings.TrimSpace(f.Signature.KeyID) == "" {
+		return nil, errors.New("catalog: signature.key_id missing")
+	}
+	if strings.TrimSpace(f.Signature.Sig) == "" {
+		return nil, errors.New("catalog: signature.sig missing")
+	}
+	rawCopy := append([]byte(nil), data...)
+	return &Catalog{
+		CatalogID: f.CatalogID,
+		ExpiresAt: expires,
+		IssuedAt:  issued,
+		Models:    models,
+		Raw:       rawCopy,
+		KeyID:     f.Signature.KeyID,
+	}, nil
+}
+
+// Verify checks the catalog's ed25519 signature against pubkey, then
+// asserts non-expiry per §M.3.2 step 5 (60-second skew grace).
+// pubkey MUST be the 32-byte ed25519 public key produced by
+// base64.RawURLEncoding decoding of the operator-published key per
+// SPEC-008 §5.2.1 wire form.
+//
+// Returns nil on success, or one of the typed errors below.
+func Verify(c *Catalog, pubkey ed25519.PublicKey, now time.Time) error {
+	if c == nil {
+		return errors.New("catalog: nil catalog")
+	}
+	if len(pubkey) != ed25519.PublicKeySize {
+		return fmt.Errorf("catalog: pubkey length=%d, want %d", len(pubkey), ed25519.PublicKeySize)
+	}
+
+	// Reparse to recover the signature block (the typed Catalog
+	// drops it).
+	f, err := decodeFile(c.Raw)
+	if err != nil {
+		return fmt.Errorf("catalog: re-parse: %w", err)
+	}
+
+	if f.Signature.Alg != signatureAlg {
+		return &ErrSignatureInvalid{
+			Reason: fmt.Sprintf("signature.alg=%q, want %q", f.Signature.Alg, signatureAlg),
+		}
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(f.Signature.Sig))
+	if err != nil {
+		return &ErrSignatureInvalid{Reason: fmt.Sprintf("signature.sig base64url decode: %v", err)}
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return &ErrSignatureInvalid{Reason: fmt.Sprintf("signature.sig length=%d, want %d", len(sig), ed25519.SignatureSize)}
+	}
+
+	body := canonicalBody{
+		CatalogID: f.CatalogID,
+		ExpiresAt: f.ExpiresAt,
+		IssuedAt:  f.IssuedAt,
+		Models:    f.Models,
+		Version:   f.Version,
+	}
+	canonical, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("catalog: canonical body marshal: %w", err)
+	}
+	if !ed25519.Verify(pubkey, canonical, sig) {
+		return &ErrSignatureInvalid{Reason: "ed25519.Verify returned false"}
+	}
+
+	if now.After(c.ExpiresAt.Add(expiryGrace)) {
+		return &ErrExpired{
+			CatalogID: c.CatalogID,
+			ExpiresAt: c.ExpiresAt,
+		}
+	}
+	return nil
+}
+
+// Lookup returns the catalog entry for modelID under the SPEC-015
+// §M.3.2 step 6 canonical key (lowercase + trim — mirroring
+// phase4-coordinator/internal/tier2/catalog.go:559-560
+// catalogModelKey). Returns (entry, true) on hit, (zero, false) on
+// miss.
+func Lookup(c *Catalog, modelID string) (ModelEntry, bool) {
+	if c == nil {
+		return ModelEntry{}, false
+	}
+	entry, ok := c.Models[modelKey(modelID)]
+	return entry, ok
+}
+
+func modelKey(modelID string) string {
+	return strings.ToLower(strings.TrimSpace(modelID))
+}
+
+func decodeFile(data []byte) (File, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var f File
+	if err := dec.Decode(&f); err != nil {
+		return File{}, err
+	}
+	var extra struct{}
+	if err := dec.Decode(&extra); err != io.EOF {
+		return File{}, errors.New("catalog must contain a single JSON object")
+	}
+	return f, nil
+}
+
+// ErrSignatureInvalid is returned by Verify when the catalog's
+// signature does not validate or the algorithm string is wrong.
+type ErrSignatureInvalid struct {
+	Reason string
+}
+
+func (e *ErrSignatureInvalid) Error() string {
+	return "catalog: signature invalid: " + e.Reason
+}
+
+// ErrExpired is returned by Verify when the catalog's `expires_at`
+// is more than 60 seconds in the past relative to `now`.
+type ErrExpired struct {
+	CatalogID string
+	ExpiresAt time.Time
+}
+
+func (e *ErrExpired) Error() string {
+	return fmt.Sprintf("catalog: catalog %q expired at %s", e.CatalogID, e.ExpiresAt.Format(time.RFC3339))
+}

--- a/phase7-verify/internal/catalog/catalog.go
+++ b/phase7-verify/internal/catalog/catalog.go
@@ -194,15 +194,22 @@ func Verify(c *Catalog, pubkey ed25519.PublicKey, now time.Time) error {
 
 	if f.Signature.Alg != signatureAlg {
 		return &ErrSignatureInvalid{
-			Reason: fmt.Sprintf("signature.alg=%q, want %q", f.Signature.Alg, signatureAlg),
+			Reason:      fmt.Sprintf("signature.alg=%q, want %q", f.Signature.Alg, signatureAlg),
+			ObservedAlg: f.Signature.Alg,
 		}
 	}
 	sig, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(f.Signature.Sig))
 	if err != nil {
-		return &ErrSignatureInvalid{Reason: fmt.Sprintf("signature.sig base64url decode: %v", err)}
+		return &ErrSignatureInvalid{
+			Reason:      fmt.Sprintf("signature.sig base64url decode: %v", err),
+			ObservedAlg: f.Signature.Alg,
+		}
 	}
 	if len(sig) != ed25519.SignatureSize {
-		return &ErrSignatureInvalid{Reason: fmt.Sprintf("signature.sig length=%d, want %d", len(sig), ed25519.SignatureSize)}
+		return &ErrSignatureInvalid{
+			Reason:      fmt.Sprintf("signature.sig length=%d, want %d", len(sig), ed25519.SignatureSize),
+			ObservedAlg: f.Signature.Alg,
+		}
 	}
 
 	body := canonicalBody{
@@ -217,7 +224,10 @@ func Verify(c *Catalog, pubkey ed25519.PublicKey, now time.Time) error {
 		return fmt.Errorf("catalog: canonical body marshal: %w", err)
 	}
 	if !ed25519.Verify(pubkey, canonical, sig) {
-		return &ErrSignatureInvalid{Reason: "ed25519.Verify returned false"}
+		return &ErrSignatureInvalid{
+			Reason:      "ed25519.Verify returned false",
+			ObservedAlg: f.Signature.Alg,
+		}
 	}
 
 	if now.After(c.ExpiresAt.Add(expiryGrace)) {
@@ -262,8 +272,14 @@ func decodeFile(data []byte) (File, error) {
 
 // ErrSignatureInvalid is returned by Verify when the catalog's
 // signature does not validate or the algorithm string is wrong.
+//
+// ObservedAlg carries the catalog's `signature.alg` value verbatim so
+// SPEC-015 §M.3.2.1 `details.alg` can be populated by callers without
+// re-parsing the catalog. Empty when not applicable (e.g. signature
+// length / decode failures unrelated to the alg field).
 type ErrSignatureInvalid struct {
-	Reason string
+	Reason      string
+	ObservedAlg string
 }
 
 func (e *ErrSignatureInvalid) Error() string {

--- a/phase7-verify/internal/catalog/catalog_test.go
+++ b/phase7-verify/internal/catalog/catalog_test.go
@@ -1,0 +1,543 @@
+package catalog
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+const validHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestParseAndVerifyHappyPath(t *testing.T) {
+	raw, pub := signFixture(t, "test-catalog", time.Now().Add(time.Hour), []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	c, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if c.CatalogID != "test-catalog" {
+		t.Fatalf("CatalogID = %q", c.CatalogID)
+	}
+	if got := c.Models[modelKey("model-a")].SHA256; got != validHash {
+		t.Fatalf("sha = %q", got)
+	}
+	if err := Verify(c, pub, time.Now()); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+}
+
+// SPEC-015 §M.3.2 step 6 — canonical Lookup uses lowercase + trim.
+func TestLookupCaseFoldedAndTrimmed(t *testing.T) {
+	raw, _ := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "MLX/Qwen2.5-7B-Instruct-4bit",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	c, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	for _, query := range []string{
+		"mlx/qwen2.5-7b-instruct-4bit",
+		"MLX/Qwen2.5-7B-Instruct-4bit",
+		"  mlx/qwen2.5-7b-instruct-4bit  ",
+		"MLX/QWEN2.5-7B-INSTRUCT-4BIT",
+	} {
+		entry, ok := Lookup(c, query)
+		if !ok {
+			t.Fatalf("Lookup(%q) = miss", query)
+		}
+		if entry.SHA256 != validHash {
+			t.Fatalf("Lookup(%q).SHA256 = %q", query, entry.SHA256)
+		}
+	}
+	if _, ok := Lookup(c, "different-model"); ok {
+		t.Fatalf("Lookup miss expected")
+	}
+}
+
+// SPEC-015 §M.3.2 step 4 — verify alg "ed25519" (lowercase) rejected.
+func TestVerifyRejectsLowercaseAlg(t *testing.T) {
+	raw, pub := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	// Inject lowercase alg.
+	mutated := bytes.Replace(raw, []byte(`"alg":"Ed25519"`), []byte(`"alg":"ed25519"`), 1)
+	if bytes.Equal(mutated, raw) {
+		t.Fatal("alg substitution did not change bytes")
+	}
+	c, err := Parse(mutated)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	err = Verify(c, pub, time.Now())
+	var sigErr *ErrSignatureInvalid
+	if !errors.As(err, &sigErr) {
+		t.Fatalf("Verify err = %v, want ErrSignatureInvalid", err)
+	}
+	if !strings.Contains(sigErr.Reason, "signature.alg") {
+		t.Fatalf("ErrSignatureInvalid.Reason = %q", sigErr.Reason)
+	}
+}
+
+func TestVerifyRejectsTamperedSignature(t *testing.T) {
+	raw, pub := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	c, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	// Flip first byte of the signature (in the typed File, which Verify
+	// reparses out of c.Raw). Construct a raw-mutated catalog and re-parse.
+	mutated := mutateSignatureSig(t, raw)
+	c2, err := Parse(mutated)
+	if err != nil {
+		t.Fatalf("Parse mutated: %v", err)
+	}
+	err = Verify(c2, pub, time.Now())
+	var sigErr *ErrSignatureInvalid
+	if !errors.As(err, &sigErr) {
+		t.Fatalf("Verify err = %v, want ErrSignatureInvalid", err)
+	}
+	_ = c
+}
+
+func TestVerifyRejectsTamperedBody(t *testing.T) {
+	raw, pub := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	// Tamper the catalog_id to break the signed canonical body.
+	tampered := bytes.Replace(raw, []byte(`"catalog_id":"tc"`), []byte(`"catalog_id":"x!"`), 1)
+	if bytes.Equal(tampered, raw) {
+		t.Fatal("tamper substitution did not change bytes")
+	}
+	c, err := Parse(tampered)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	err = Verify(c, pub, time.Now())
+	var sigErr *ErrSignatureInvalid
+	if !errors.As(err, &sigErr) {
+		t.Fatalf("Verify err = %v, want ErrSignatureInvalid", err)
+	}
+}
+
+// SPEC-015 §M.3.2 step 5 — expired beyond 60s grace → ErrExpired.
+func TestVerifyRejectsExpiredBeyondGrace(t *testing.T) {
+	issued := time.Now().Add(-2 * time.Hour)
+	expires := issued.Add(time.Hour) // expired 1h ago
+	raw, pub := signFixtureAtTime(t, "tc", issued, expires, []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	c, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	err = Verify(c, pub, time.Now())
+	var expErr *ErrExpired
+	if !errors.As(err, &expErr) {
+		t.Fatalf("Verify err = %v, want ErrExpired", err)
+	}
+	if expErr.CatalogID != "tc" {
+		t.Fatalf("ErrExpired.CatalogID = %q", expErr.CatalogID)
+	}
+}
+
+// SPEC-015 §M.3.2 step 5 — within the 60-second grace window: OK.
+func TestVerifyAcceptsWithin60sGrace(t *testing.T) {
+	issued := time.Now().Add(-time.Hour)
+	expires := time.Now().Add(-30 * time.Second) // 30s expired, within grace
+	raw, pub := signFixtureAtTime(t, "tc", issued, expires, []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	c, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if err := Verify(c, pub, time.Now()); err != nil {
+		t.Fatalf("Verify within grace: %v", err)
+	}
+}
+
+// SPEC-008 v0.3 / §M.3.2 step 3 — version pinned to 1; any other
+// value MUST be rejected to keep the buyer-side and coordinator-side
+// catalog accept/reject contracts equivalent.
+func TestParseRejectsNonOneVersion(t *testing.T) {
+	for _, version := range []int{0, 2, 3, -1, 99} {
+		t.Run(fmtVersionName(version), func(t *testing.T) {
+			raw, _ := signFixtureWithVersion(t, version, "tc", time.Now().Add(time.Hour), []ModelEntry{{
+				ArtifactKind: "mlx_weight_file",
+				HashScope:    "primary_weight_file",
+				ModelID:      "model-a",
+				SHA256:       validHash,
+				Source:       "operator-curated",
+			}})
+			if _, err := Parse(raw); err == nil {
+				t.Fatalf("Parse accepted version=%d", version)
+			}
+		})
+	}
+}
+
+// Mirror phase4-coordinator/internal/tier2/catalog.go:473-475 — all
+// model + signature required fields are non-empty at parse time, so
+// a signature-valid but schema-malformed catalog cannot become buyer
+// input.
+func TestParseRejectsMissingRequiredFields(t *testing.T) {
+	cases := map[string]ModelEntry{
+		"empty-artifact_kind": {
+			ArtifactKind: "",
+			HashScope:    "primary_weight_file",
+			ModelID:      "model-a",
+			SHA256:       validHash,
+			Source:       "operator-curated",
+		},
+		"empty-hash_scope": {
+			ArtifactKind: "mlx_weight_file",
+			HashScope:    "",
+			ModelID:      "model-a",
+			SHA256:       validHash,
+			Source:       "operator-curated",
+		},
+		"empty-source": {
+			ArtifactKind: "mlx_weight_file",
+			HashScope:    "primary_weight_file",
+			ModelID:      "model-a",
+			SHA256:       validHash,
+			Source:       "",
+		},
+		"empty-model_id": {
+			ArtifactKind: "mlx_weight_file",
+			HashScope:    "primary_weight_file",
+			ModelID:      "",
+			SHA256:       validHash,
+			Source:       "operator-curated",
+		},
+	}
+	for name, model := range cases {
+		t.Run(name, func(t *testing.T) {
+			raw, _ := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{model})
+			if _, err := Parse(raw); err == nil {
+				t.Fatalf("Parse accepted bad model: %+v", model)
+			}
+		})
+	}
+}
+
+func TestParseRejectsMissingSignatureKeyID(t *testing.T) {
+	raw, _ := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	mutated := bytes.Replace(raw, []byte(`"key_id":"fixture-key"`), []byte(`"key_id":""`), 1)
+	if bytes.Equal(mutated, raw) {
+		t.Fatal("key_id substitution did not change bytes")
+	}
+	if _, err := Parse(mutated); err == nil {
+		t.Fatal("Parse accepted catalog with empty signature.key_id")
+	}
+}
+
+func TestParseRejectsTrailingJSON(t *testing.T) {
+	raw, _ := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	mutated := append(append([]byte(nil), raw...), []byte(` {"extra":true}`)...)
+	if _, err := Parse(mutated); err == nil {
+		t.Fatal("Parse accepted trailing top-level JSON object")
+	}
+}
+
+func TestParseRejectsUnsupportedModelEntryFields(t *testing.T) {
+	cases := map[string]ModelEntry{
+		"unsupported-artifact_kind": {
+			ArtifactKind: "gguf_weight_file",
+			HashScope:    "primary_weight_file",
+			ModelID:      "model-a",
+			SHA256:       validHash,
+			Source:       "operator-curated",
+		},
+		"unsupported-hash_scope": {
+			ArtifactKind: "mlx_weight_file",
+			HashScope:    "secondary_weight_file",
+			ModelID:      "model-a",
+			SHA256:       validHash,
+			Source:       "operator-curated",
+		},
+	}
+	for name, model := range cases {
+		t.Run(name, func(t *testing.T) {
+			raw, _ := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{model})
+			if _, err := Parse(raw); err == nil {
+				t.Fatalf("Parse accepted unsupported model entry: %+v", model)
+			}
+		})
+	}
+}
+
+// SPEC-015 §M.3.2 step 5 — 60s skew grace boundaries: exactly at +60s
+// MUST be accepted; +61s MUST be rejected as ErrExpired.
+func TestVerifyExpiryBoundaryAt60s(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	issued := now.Add(-2 * time.Hour)
+
+	// expires_at = now - 60s → boundary inclusive: still accepted.
+	expiresAtBoundary := now.Add(-60 * time.Second)
+	raw, pub := signFixtureAtTime(t, "tc", issued, expiresAtBoundary, []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	c, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if err := Verify(c, pub, now); err != nil {
+		t.Fatalf("Verify at exactly +60s grace boundary: %v", err)
+	}
+
+	// expires_at = now - 61s → just over boundary: ErrExpired.
+	expiresJustOver := now.Add(-61 * time.Second)
+	raw2, pub2 := signFixtureAtTime(t, "tc", issued, expiresJustOver, []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	c2, err := Parse(raw2)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	err = Verify(c2, pub2, now)
+	var expErr *ErrExpired
+	if !errors.As(err, &expErr) {
+		t.Fatalf("Verify at +61s: err = %v, want ErrExpired", err)
+	}
+}
+
+func TestParseRejectsMalformedSha256(t *testing.T) {
+	cases := map[string]string{
+		"uppercase": "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+		"too short": "deadbeef",
+		"too long":  validHash + "00",
+		"prefixed":  "sha256:" + validHash,
+		"non-hex":   "g000000000000000000000000000000000000000000000000000000000000000",
+	}
+	for name, bad := range cases {
+		t.Run(name, func(t *testing.T) {
+			raw, _ := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{{
+				ArtifactKind: "mlx_weight_file",
+				HashScope:    "primary_weight_file",
+				ModelID:      "model-a",
+				SHA256:       bad,
+				Source:       "operator-curated",
+			}})
+			if _, err := Parse(raw); err == nil {
+				t.Fatalf("Parse accepted bad sha256 %q", bad)
+			}
+		})
+	}
+}
+
+// SPEC-015 §M.3 — pure-Go verifier MUST accept what the existing
+// scripts/sign-catalog.go signer produces. The test fixture below
+// uses the same canonicalBody key order and Sign() shape; if
+// Verify accepts the fixture but rejects a known-good catalog from
+// sign-catalog.go, the cross-tool parity is broken.
+func TestParityWithSignCatalogProduces(t *testing.T) {
+	// Seed mirrors the coordinator test seed for reproducibility.
+	seed := bytes.Repeat([]byte{7}, ed25519.SeedSize)
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+
+	issued := time.Now().Add(-time.Hour).UTC().Round(time.Second)
+	expires := issued.Add(2 * time.Hour)
+	body := canonicalBody{
+		CatalogID: "macprovider-tier2-2026-06-24",
+		ExpiresAt: expires.Format(time.RFC3339),
+		IssuedAt:  issued.Format(time.RFC3339),
+		Models: []ModelEntry{{
+			ArtifactKind: "mlx_weight_file",
+			HashScope:    "primary_weight_file",
+			ModelID:      "mlx-community/Qwen2.5-7B-Instruct-4bit",
+			SHA256:       validHash,
+			Source:       "operator-curated",
+		}},
+		Version: 1,
+	}
+	canonical, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	sig := ed25519.Sign(priv, canonical)
+	file := File{
+		CatalogID: body.CatalogID,
+		ExpiresAt: body.ExpiresAt,
+		IssuedAt:  body.IssuedAt,
+		Models:    body.Models,
+		Signature: Signature{Alg: "Ed25519", KeyID: "parity-key", Sig: base64.RawURLEncoding.EncodeToString(sig)},
+		Version:   body.Version,
+	}
+	raw, err := json.Marshal(file)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	c, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if err := Verify(c, pub, time.Now()); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	// Lookup case-fold should accept the buyer's case variant.
+	entry, ok := Lookup(c, "MLX-COMMUNITY/QWEN2.5-7B-INSTRUCT-4BIT")
+	if !ok {
+		t.Fatalf("case-fold lookup miss")
+	}
+	if entry.SHA256 != validHash {
+		t.Fatalf("entry.SHA256 = %q", entry.SHA256)
+	}
+}
+
+// helpers
+
+func signFixture(t *testing.T, catalogID string, expires time.Time, models []ModelEntry) ([]byte, ed25519.PublicKey) {
+	t.Helper()
+	issued := expires.Add(-time.Hour)
+	return signFixtureAtTime(t, catalogID, issued, expires, models)
+}
+
+func signFixtureWithVersion(t *testing.T, version int, catalogID string, expires time.Time, models []ModelEntry) ([]byte, ed25519.PublicKey) {
+	t.Helper()
+	issued := expires.Add(-time.Hour)
+	seed := bytes.Repeat([]byte{7}, ed25519.SeedSize)
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	body := canonicalBody{
+		CatalogID: catalogID,
+		ExpiresAt: expires.UTC().Format(time.RFC3339),
+		IssuedAt:  issued.UTC().Format(time.RFC3339),
+		Models:    models,
+		Version:   version,
+	}
+	canonical, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal canonical: %v", err)
+	}
+	sig := ed25519.Sign(priv, canonical)
+	file := File{
+		CatalogID: body.CatalogID,
+		ExpiresAt: body.ExpiresAt,
+		IssuedAt:  body.IssuedAt,
+		Models:    body.Models,
+		Signature: Signature{Alg: "Ed25519", KeyID: "fixture-key", Sig: base64.RawURLEncoding.EncodeToString(sig)},
+		Version:   body.Version,
+	}
+	raw, err := json.Marshal(file)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw, pub
+}
+
+func fmtVersionName(v int) string {
+	if v < 0 {
+		return "negative"
+	}
+	return fmt.Sprintf("v%d", v)
+}
+
+func signFixtureAtTime(t *testing.T, catalogID string, issued, expires time.Time, models []ModelEntry) ([]byte, ed25519.PublicKey) {
+	t.Helper()
+	seed := bytes.Repeat([]byte{7}, ed25519.SeedSize)
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	body := canonicalBody{
+		CatalogID: catalogID,
+		ExpiresAt: expires.UTC().Format(time.RFC3339),
+		IssuedAt:  issued.UTC().Format(time.RFC3339),
+		Models:    models,
+		Version:   1,
+	}
+	canonical, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal canonical: %v", err)
+	}
+	sig := ed25519.Sign(priv, canonical)
+	file := File{
+		CatalogID: body.CatalogID,
+		ExpiresAt: body.ExpiresAt,
+		IssuedAt:  body.IssuedAt,
+		Models:    body.Models,
+		Signature: Signature{Alg: "Ed25519", KeyID: "fixture-key", Sig: base64.RawURLEncoding.EncodeToString(sig)},
+		Version:   body.Version,
+	}
+	raw, err := json.Marshal(file)
+	if err != nil {
+		t.Fatalf("marshal catalog: %v", err)
+	}
+	return raw, pub
+}
+
+func mutateSignatureSig(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var f File
+	if err := json.Unmarshal(raw, &f); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(f.Signature.Sig)
+	if err != nil {
+		t.Fatalf("decode sig: %v", err)
+	}
+	sig[0] ^= 0xff
+	f.Signature.Sig = base64.RawURLEncoding.EncodeToString(sig)
+	out, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal mutated: %v", err)
+	}
+	return out
+}

--- a/phase7-verify/internal/catalog/catalog_test.go
+++ b/phase7-verify/internal/catalog/catalog_test.go
@@ -97,6 +97,32 @@ func TestVerifyRejectsLowercaseAlg(t *testing.T) {
 	}
 }
 
+// SPEC-015 §M.3.2.1 — even on the ed25519.Verify-returned-false path,
+// the typed ErrSignatureInvalid MUST carry ObservedAlg so callers can
+// populate details.alg per the v0.3 schema contract.
+func TestVerifyTamperedSignatureCarriesObservedAlg(t *testing.T) {
+	raw, pub := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{{
+		ArtifactKind: "mlx_weight_file",
+		HashScope:    "primary_weight_file",
+		ModelID:      "model-a",
+		SHA256:       validHash,
+		Source:       "operator-curated",
+	}})
+	tampered := mutateSignatureSig(t, raw)
+	c, err := Parse(tampered)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	err = Verify(c, pub, time.Now())
+	var sigErr *ErrSignatureInvalid
+	if !errors.As(err, &sigErr) {
+		t.Fatalf("Verify err = %v, want ErrSignatureInvalid", err)
+	}
+	if sigErr.ObservedAlg != "Ed25519" {
+		t.Fatalf("ObservedAlg = %q, want %q", sigErr.ObservedAlg, "Ed25519")
+	}
+}
+
 func TestVerifyRejectsTamperedSignature(t *testing.T) {
 	raw, pub := signFixture(t, "tc", time.Now().Add(time.Hour), []ModelEntry{{
 		ArtifactKind: "mlx_weight_file",

--- a/phase7-verify/internal/catalog/signer_parity_test.go
+++ b/phase7-verify/internal/catalog/signer_parity_test.go
@@ -1,0 +1,155 @@
+package catalog
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestParityWithSignCatalogToolReal exercises the existing
+// scripts/sign-catalog.go signer against this package's Parse +
+// Verify. Pure parity check at the contract boundary — the
+// verifier MUST accept any catalog the signer produces (and the
+// signer's pubkey).
+//
+// Skips when:
+//   - `go` is not on PATH (CI / containers without a Go toolchain),
+//   - scripts/sign-catalog.go cannot be located from this test
+//     file's relative path (out-of-tree go test invocations).
+//
+// The test is fast (~100ms; one keygen + one sign invocation).
+func TestParityWithSignCatalogToolReal(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go binary not on PATH: %v", err)
+	}
+	repoRoot := findRepoRoot(t)
+	signCatalog := filepath.Join(repoRoot, "scripts", "sign-catalog.go")
+	if _, err := os.Stat(signCatalog); err != nil {
+		t.Skipf("scripts/sign-catalog.go not found: %v", err)
+	}
+
+	dir := t.TempDir()
+	pubKeyPath := filepath.Join(dir, "catalog-signing-key.pub")
+	privKeyPath := filepath.Join(dir, "catalog-signing-key.priv")
+	bodyPath := filepath.Join(dir, "catalog-body.json")
+	outPath := filepath.Join(dir, "catalog.signed.json")
+
+	// 1. keygen.
+	mustRun(t, repoRoot,
+		"go", "run", signCatalog, "keygen",
+		"-public-out", pubKeyPath,
+		"-private-out", privKeyPath,
+	)
+
+	// 2. write an unsigned canonical body (the signer's input).
+	body := `{
+  "catalog_id": "parity-test-catalog",
+  "expires_at": "` + time.Now().Add(2*time.Hour).UTC().Format(time.RFC3339) + `",
+  "issued_at": "` + time.Now().Add(-time.Minute).UTC().Format(time.RFC3339) + `",
+  "models": [
+    {
+      "artifact_kind": "mlx_weight_file",
+      "hash_scope": "primary_weight_file",
+      "model_id": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "source": "operator-curated"
+    }
+  ],
+  "version": 1
+}`
+	if err := os.WriteFile(bodyPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+
+	// 3. sign. sign-catalog.go takes the unsigned body as a
+	// positional argument (NOT -in).
+	mustRun(t, repoRoot,
+		"go", "run", signCatalog, "sign",
+		"-out", outPath,
+		"-key", privKeyPath,
+		bodyPath,
+	)
+
+	// 4. read the produced signed catalog + the produced pubkey.
+	signed, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read signed catalog: %v", err)
+	}
+	pubKeyRaw, err := os.ReadFile(pubKeyPath)
+	if err != nil {
+		t.Fatalf("read pubkey: %v", err)
+	}
+	pubKeyB64 := strings.TrimSpace(string(pubKeyRaw))
+	pubKeyBytes, err := base64.RawURLEncoding.DecodeString(pubKeyB64)
+	if err != nil {
+		t.Fatalf("decode pubkey base64url: %v (key=%q)", err, pubKeyB64)
+	}
+	if len(pubKeyBytes) != ed25519.PublicKeySize {
+		t.Fatalf("pubkey size=%d, want %d", len(pubKeyBytes), ed25519.PublicKeySize)
+	}
+
+	// 5. Parse + Verify the signer's output.
+	c, err := Parse(signed)
+	if err != nil {
+		t.Fatalf("Parse signer output: %v (raw=%s)", err, string(signed))
+	}
+	if c.CatalogID != "parity-test-catalog" {
+		t.Fatalf("CatalogID=%q", c.CatalogID)
+	}
+	if err := Verify(c, ed25519.PublicKey(pubKeyBytes), time.Now()); err != nil {
+		t.Fatalf("Verify signer output: %v", err)
+	}
+
+	// 6. Tamper the signed file and verify rejection.
+	tampered := bytes.Replace(signed, []byte("parity-test-catalog"), []byte("tampered-catalog!!"), 1)
+	if bytes.Equal(tampered, signed) {
+		t.Fatal("tamper substitution did not change bytes")
+	}
+	c2, err := Parse(tampered)
+	if err != nil {
+		// Expected — schema validation on catalog_id length may catch it.
+		return
+	}
+	err = Verify(c2, ed25519.PublicKey(pubKeyBytes), time.Now())
+	var sigErr *ErrSignatureInvalid
+	if !errors.As(err, &sigErr) {
+		t.Fatalf("Verify tampered: err=%v, want ErrSignatureInvalid", err)
+	}
+}
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "scripts", "sign-catalog.go")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Skip("could not locate repo root (no scripts/sign-catalog.go ancestor)")
+			return ""
+		}
+		dir = parent
+	}
+}
+
+func mustRun(t *testing.T, cwd string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = cwd
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("%s failed: %v\nstderr: %s", strings.Join(args, " "), err, stderr.String())
+	}
+}

--- a/phase7-verify/internal/cli/cli.go
+++ b/phase7-verify/internal/cli/cli.go
@@ -4,6 +4,7 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -52,6 +53,12 @@ type options struct {
 	quiet       bool
 	coordinator string
 	explain     bool
+	// SPEC-015 v0.3 §M.3.1 catalog flags.
+	catalog           string // path to local signed catalog
+	catalogURL        string // remote catalog URL
+	catalogPubkey     string // base64.RawURLEncoding catalog pubkey
+	catalogPubkeyURL  string // remote pubkey URL
+	requireModelHash  bool   // §M.3.1.2 fail-closed on null model_hash
 }
 
 type runConfig struct {
@@ -148,6 +155,12 @@ func parseOptions(args []string, stdout, stderr io.Writer, getenv func(string) s
 	fs.BoolVar(&opts.quiet, "quiet", false, "suppress stderr diagnostics and warnings")
 	fs.StringVar(&opts.coordinator, "coordinator", opts.coordinator, "coordinator host for /v1/receipt-keys")
 	fs.BoolVar(&opts.explain, "explain", false, "print SPEC-015 trust-boundary explanation after valid results")
+	// SPEC-015 v0.3 §M.3.1 catalog flags.
+	fs.StringVar(&opts.catalog, "catalog", "", "path to local signed catalog file (mutually exclusive with --catalog-url)")
+	fs.StringVar(&opts.catalogURL, "catalog-url", "", "URL to fetch signed catalog (mutually exclusive with --catalog; incompatible with --offline)")
+	fs.StringVar(&opts.catalogPubkey, "catalog-pubkey", "", "base64.RawURLEncoding (43 ASCII chars) ed25519 catalog signing pubkey")
+	fs.StringVar(&opts.catalogPubkeyURL, "catalog-pubkey-url", "", "URL to fetch the catalog signing pubkey (incompatible with --offline)")
+	fs.BoolVar(&opts.requireModelHash, "require-model-hash", false, "§M.3.1.2: fail-closed (exit 1) when receipt model_hash is null")
 	fs.Usage = func() { printUsage(stdout) }
 
 	if err := fs.Parse(args); err != nil {
@@ -229,15 +242,73 @@ func optionsToVerifyArgs(opts options, stdin io.Reader, getenv func(string) stri
 	}
 	input.ProviderID = resolvedProviderID
 
+	catalogOpts, err := buildCatalogOpts(opts)
+	if err != nil {
+		return verify.VerifyInput{}, verify.VerifyOpts{}, err
+	}
+
 	verifyOpts := verify.VerifyOpts{
-		Offline:         opts.offline,
-		Quiet:           opts.quiet,
-		CoordinatorHost: coordinatorHost,
-		Cache:           c,
-		Now:             cfg.now,
-		HTTPClient:      cfg.httpClient,
+		Offline:          opts.offline,
+		Quiet:            opts.quiet,
+		CoordinatorHost:  coordinatorHost,
+		Cache:            c,
+		Now:              cfg.now,
+		HTTPClient:       cfg.httpClient,
+		Catalog:          catalogOpts,
+		RequireModelHash: opts.requireModelHash,
 	}
 	return input, verifyOpts, nil
+}
+
+// SPEC-015 §M.3.1 flag-combination validation. Returns the
+// catalog options bundle plus any usage error.
+func buildCatalogOpts(opts options) (verify.CatalogOpts, error) {
+	var co verify.CatalogOpts
+	hasCatalog := opts.catalog != "" || opts.catalogURL != ""
+	hasPubkey := opts.catalogPubkey != "" || opts.catalogPubkeyURL != ""
+
+	// Mutually-exclusive sources.
+	if opts.catalog != "" && opts.catalogURL != "" {
+		return co, &cliUsageError{err: errors.New("--catalog and --catalog-url are mutually exclusive")}
+	}
+	if opts.catalogPubkey != "" && opts.catalogPubkeyURL != "" {
+		return co, &cliUsageError{err: errors.New("--catalog-pubkey and --catalog-pubkey-url are mutually exclusive")}
+	}
+
+	// SPEC-015 §M.3.1 — catalog without pubkey (or vice versa) is exit 64.
+	if hasCatalog && !hasPubkey {
+		return co, &cliUsageError{err: errors.New("--catalog/--catalog-url requires --catalog-pubkey or --catalog-pubkey-url")}
+	}
+	if hasPubkey && !hasCatalog {
+		return co, &cliUsageError{err: errors.New("--catalog-pubkey/--catalog-pubkey-url requires --catalog or --catalog-url")}
+	}
+
+	// SPEC-015 §M.3.1.1 — --offline incompatible with URL-fetch flags.
+	if opts.offline && (opts.catalogURL != "" || opts.catalogPubkeyURL != "") {
+		return co, &cliUsageError{err: errors.New("--catalog-url and --catalog-pubkey-url are incompatible with --offline")}
+	}
+
+	if opts.catalog != "" {
+		co.Path = opts.catalog
+	}
+	if opts.catalogURL != "" {
+		co.URL = opts.catalogURL
+	}
+	if opts.catalogPubkey != "" {
+		decoded, err := base64.RawURLEncoding.DecodeString(opts.catalogPubkey)
+		if err != nil {
+			return co, &cliUsageError{err: fmt.Errorf("--catalog-pubkey not base64.RawURLEncoding: %v", err)}
+		}
+		if len(decoded) != ed25519.PublicKeySize {
+			return co, &cliUsageError{err: fmt.Errorf("--catalog-pubkey decoded length %d, want %d", len(decoded), ed25519.PublicKeySize)}
+		}
+		co.Pubkey = decoded
+	}
+	if opts.catalogPubkeyURL != "" {
+		co.PubkeyURL = opts.catalogPubkeyURL
+	}
+	co.Enabled = hasCatalog && hasPubkey
+	return co, nil
 }
 
 func readBundle(path string, stdin io.Reader) (*bundleInput, error) {
@@ -454,6 +525,13 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  --quiet                suppress stderr diagnostics and warnings")
 	fmt.Fprintln(w, "  --coordinator <host>   coordinator host for /v1/receipt-keys")
 	fmt.Fprintln(w, "  --explain              print SPEC-015 trust-boundary explanation after valid results")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "SPEC-015 v0.3 catalog flags (§M.3.1 / §M.3.1.2):")
+	fmt.Fprintln(w, "  --catalog <path>             local signed catalog file (mutually exclusive with --catalog-url)")
+	fmt.Fprintln(w, "  --catalog-url <url>          URL to fetch signed catalog (incompatible with --offline)")
+	fmt.Fprintln(w, "  --catalog-pubkey <b64url>    base64url-unpadded ed25519 catalog signing pubkey (43 ASCII chars)")
+	fmt.Fprintln(w, "  --catalog-pubkey-url <url>   URL to fetch the catalog signing pubkey (incompatible with --offline)")
+	fmt.Fprintln(w, "  --require-model-hash         fail-closed (exit 1) when receipt model_hash is null (§M.3.1.2)")
 }
 
 const explainText = `A ` + "`valid`" + ` result from ` + "`macprovider verify`" + ` proves **exactly this**:
@@ -522,6 +600,25 @@ scope visibly — e.g. by including the phrase ` + "`signed by m1-anon`" + `
 rather than ` + "`verified m1-anon`" + `. The ` + "`--explain`" + ` flag of §10.4.2
 exists precisely to make this trust boundary unmissable to a
 buyer who is about to act on a ` + "`valid`" + ` result.
+
+**SPEC-015 v0.3 catalog-attested ` + "`valid`" + ` results.** When ` + "`macprovider verify`" + `
+runs with ` + "`--catalog`" + ` (or ` + "`--catalog-url`" + `) and the receipt carries a
+non-null ` + "`model_hash`" + `, a ` + "`valid`" + ` result with ` + "`model_hash_verified: true`" + ` ALSO
+attests that the loaded weights matched the catalog's expected SHA-256 for the
+requested ` + "`model_id`" + `. This closes the §10.6 "DOES NOT prove that the
+response was generated by the model named in ` + "`model_id`" + `" disclaimer for v0.3
+catalog-valid results. Subject to: the buyer trusting the catalog signing
+pubkey (which is the new trust root v0.3 verifier requires); the catalog being
+non-expired (60-second skew grace per §M.3.2 step 5); and the operator not
+substituting both catalog AND catalog pubkey simultaneously (§M.3.3 inherits
+§8.3 operator-mutability). The other §10.6 disclaimers (timestamp honesty,
+no-other-observer, no-uniqueness, replay-resistance) are PRESERVED.
+
+When ` + "`model_hash_verified`" + ` is ` + "`null`" + `, the catalog check did NOT run
+(no catalog flags supplied, receipt is legacy v0.1/v0.2, or receipt
+` + "`model_hash`" + ` is null per §M.2.3 warm-swap-disabled providers). In that case
+the v0.2 trust boundary above applies in full and the v0.3 model-hash claim
+is not made.
 
 When you supply ` + "`--pubkey`" + ` AND a custom ` + "`--coordinator`" + `, the explicit
 pubkey is the trust root regardless of what the coordinator publishes. A

--- a/phase7-verify/internal/cli/output.go
+++ b/phase7-verify/internal/cli/output.go
@@ -21,6 +21,13 @@ type jsonResult struct {
 	SignedAt        *int64        `json:"signed_at"`
 	TrustSource     string        `json:"trust_source"`
 	CoordinatorHost *string       `json:"coordinator_host"`
+	// SPEC-015 v0.3 §M.3.2.1 — REQUIRED tri-state. true / false /
+	// null. Always present in v0.3 verifier output (even for
+	// legacy v0.1/v0.2 receipts, where the value is null).
+	ModelHashVerified *bool `json:"model_hash_verified"`
+	// SPEC-015 v0.3 §M.0 — receipt_version diagnostic; "1" for
+	// legacy receipts, "3" for v0.3 receipts.
+	ReceiptVersion  string        `json:"receipt_version,omitempty"`
 	Details         *jsonDetails  `json:"details,omitempty"`
 	Warnings        []jsonWarning `json:"warnings,omitempty"`
 }
@@ -28,8 +35,19 @@ type jsonResult struct {
 type jsonDetails struct {
 	Field    string         `json:"field"`
 	Computed *string        `json:"computed,omitempty"`
-	Receipt  string         `json:"receipt"`
+	Receipt  string         `json:"receipt,omitempty"`
 	Extra    map[string]any `json:"extra,omitempty"`
+	// SPEC-015 v0.3 §M.3.2.1 — named top-level details fields.
+	Expected       string `json:"expected,omitempty"`
+	Actual         string `json:"actual,omitempty"`
+	PolicyFlag     string `json:"policy_flag,omitempty"`
+	ModelID        string `json:"model_id,omitempty"`
+	CatalogID      string `json:"catalog_id,omitempty"`
+	ExpiresAt      string `json:"expires_at,omitempty"`
+	ReceiptVersion string `json:"receipt_version,omitempty"`
+	Cause          string `json:"cause,omitempty"`
+	URL            string `json:"url,omitempty"`
+	Alg            string `json:"alg,omitempty"`
 }
 
 type jsonWarning struct {
@@ -39,15 +57,20 @@ type jsonWarning struct {
 
 func renderJSON(result verify.Result) ([]byte, error) {
 	payload := jsonResult{
-		Result:          result.Result,
-		Reason:          result.Reason,
-		ProviderID:      stringOrNull(result.ProviderID),
-		ModelID:         stringOrNull(result.ModelID),
-		SignedAt:        int64OrNull(result.SignedAt),
-		TrustSource:     result.TrustSource,
-		CoordinatorHost: coordinatorHostOrNull(result),
+		Result:            result.Result,
+		Reason:            result.Reason,
+		ProviderID:        stringOrNull(result.ProviderID),
+		ModelID:           stringOrNull(result.ModelID),
+		SignedAt:          int64OrNull(result.SignedAt),
+		TrustSource:       result.TrustSource,
+		CoordinatorHost:   coordinatorHostOrNull(result),
+		ModelHashVerified: result.ModelHashVerified,
+		ReceiptVersion:    result.ReceiptVersion,
 	}
-	if result.Result == "invalid" && result.Details != nil {
+	// SPEC-015 v0.3 §M.3.2.1 — Details required for v0.3-named
+	// inconclusive cases (model_id_not_in_catalog, catalog_expired,
+	// unknown_receipt_version), in addition to v0.2's invalid path.
+	if result.Details != nil && (result.Result == "invalid" || result.Result == "inconclusive") {
 		payload.Details = renderJSONDetails(result.Details)
 	}
 	if len(result.Warnings) > 0 {
@@ -68,11 +91,23 @@ func renderJSON(result verify.Result) ([]byte, error) {
 
 func renderJSONDetails(details *verify.Details) *jsonDetails {
 	out := &jsonDetails{
-		Field:   details.Field,
-		Receipt: details.Receipt,
-		Extra:   details.Extra,
+		Field:          details.Field,
+		Receipt:        details.Receipt,
+		Extra:          details.Extra,
+		Expected:       details.Expected,
+		Actual:         details.Actual,
+		PolicyFlag:     details.PolicyFlag,
+		ModelID:        details.ModelID,
+		CatalogID:      details.CatalogID,
+		ExpiresAt:      details.ExpiresAt,
+		ReceiptVersion: details.ReceiptVersion,
+		Cause:          details.Cause,
+		URL:            details.URL,
+		Alg:            details.Alg,
 	}
-	if details.Field != "signature" {
+	// v0.2 invariant: emit "computed" for hash-field invalids only.
+	switch details.Field {
+	case "prompt_hash", "output_hash", "pubkey", "grace_window":
 		out.Computed = &details.Computed
 	}
 	return out

--- a/phase7-verify/internal/cli/output_test.go
+++ b/phase7-verify/internal/cli/output_test.go
@@ -30,7 +30,7 @@ func TestRenderJSONExamples(t *testing.T) {
 		{
 			name:   "valid",
 			result: validOutputFixture(nil),
-			want:   `{"result":"valid","reason":"signature_and_canonicalization_match","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"live","coordinator_host":"coordinator.streamvc.live"}` + "\n",
+			want:   `{"result":"valid","reason":"signature_and_canonicalization_match","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"live","coordinator_host":"coordinator.streamvc.live","model_hash_verified":null}` + "\n",
 		},
 		{
 			name: "invalid",
@@ -48,7 +48,7 @@ func TestRenderJSONExamples(t *testing.T) {
 					Receipt:  "cd34...",
 				},
 			},
-			want: `{"result":"invalid","reason":"output_hash_mismatch","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"live","coordinator_host":"coordinator.streamvc.live","details":{"field":"output_hash","computed":"ab12...","receipt":"cd34..."}}` + "\n",
+			want: `{"result":"invalid","reason":"output_hash_mismatch","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"live","coordinator_host":"coordinator.streamvc.live","model_hash_verified":null,"details":{"field":"output_hash","computed":"ab12...","receipt":"cd34..."}}` + "\n",
 		},
 		{
 			name: "inconclusive",
@@ -65,7 +65,7 @@ func TestRenderJSONExamples(t *testing.T) {
 					Fields: map[string]any{"reason": "network_unreachable"},
 				}},
 			},
-			want: `{"result":"inconclusive","reason":"cache_stale_and_live_unreachable","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"none","coordinator_host":null,"warnings":[{"kind":"live_check_skipped","reason":"network_unreachable"}]}` + "\n",
+			want: `{"result":"inconclusive","reason":"cache_stale_and_live_unreachable","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"none","coordinator_host":null,"model_hash_verified":null,"warnings":[{"kind":"live_check_skipped","reason":"network_unreachable"}]}` + "\n",
 		},
 	}
 	for _, tt := range tests {
@@ -302,7 +302,7 @@ func TestSchemaValidationInconclusive(t *testing.T) {
 
 func TestSchemaRejectsTopLevelProviderIDUnresolvable(t *testing.T) {
 	schema := loadOutputSchema(t)
-	raw := []byte(`{"result":"inconclusive","reason":"provider_id_unresolvable","provider_id":null,"model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"none","coordinator_host":null,"warnings":[{"kind":"live_check_skipped","reason":"provider_id_unresolvable"}]}`)
+	raw := []byte(`{"result":"inconclusive","reason":"provider_id_unresolvable","provider_id":null,"model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"none","coordinator_host":null,"model_hash_verified":null,"warnings":[{"kind":"live_check_skipped","reason":"provider_id_unresolvable"}]}`)
 	if err := validateRawJSON(schema, raw); err == nil {
 		t.Fatal("schema accepted provider_id_unresolvable as a top-level inconclusive reason")
 	}
@@ -310,7 +310,7 @@ func TestSchemaRejectsTopLevelProviderIDUnresolvable(t *testing.T) {
 
 func TestSchemaRejectsExtraProperty(t *testing.T) {
 	schema := loadOutputSchema(t)
-	raw := []byte(`{"result":"valid","reason":"signature_and_canonicalization_match","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"live","coordinator_host":"coordinator.streamvc.live","foo":"bar"}`)
+	raw := []byte(`{"result":"valid","reason":"signature_and_canonicalization_match","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"live","coordinator_host":"coordinator.streamvc.live","model_hash_verified":null,"foo":"bar"}`)
 	if err := validateRawJSON(schema, raw); err == nil {
 		t.Fatal("schema accepted extra top-level property")
 	}
@@ -324,23 +324,23 @@ func TestSchemaRejectsTrustSourceCoordinatorHostMismatches(t *testing.T) {
 	}{
 		{
 			name: "valid none trust source",
-			raw:  []byte(`{"result":"valid","reason":"signature_and_canonicalization_match","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"none","coordinator_host":null}`),
+			raw:  []byte(`{"result":"valid","reason":"signature_and_canonicalization_match","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"none","coordinator_host":null,"model_hash_verified":null}`),
 		},
 		{
 			name: "valid live null coordinator",
-			raw:  []byte(`{"result":"valid","reason":"signature_and_canonicalization_match","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"live","coordinator_host":null}`),
+			raw:  []byte(`{"result":"valid","reason":"signature_and_canonicalization_match","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"live","coordinator_host":null,"model_hash_verified":null}`),
 		},
 		{
 			name: "valid explicit pubkey coordinator",
-			raw:  []byte(`{"result":"valid","reason":"signature_and_canonicalization_match","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"explicit_pubkey","coordinator_host":"coordinator.streamvc.live"}`),
+			raw:  []byte(`{"result":"valid","reason":"signature_and_canonicalization_match","provider_id":"m1-anon","model_id":"qwen2.5-7b-instruct-q4","signed_at":1719144000,"trust_source":"explicit_pubkey","coordinator_host":"coordinator.streamvc.live","model_hash_verified":null}`),
 		},
 		{
 			name: "inconclusive live null coordinator",
-			raw:  []byte(`{"result":"inconclusive","reason":"cache_stale_and_live_unreachable","trust_source":"live","coordinator_host":null}`),
+			raw:  []byte(`{"result":"inconclusive","reason":"cache_stale_and_live_unreachable","trust_source":"live","coordinator_host":null,"model_hash_verified":null}`),
 		},
 		{
 			name: "inconclusive none coordinator",
-			raw:  []byte(`{"result":"inconclusive","reason":"cache_stale_and_live_unreachable","trust_source":"none","coordinator_host":"coordinator.streamvc.live"}`),
+			raw:  []byte(`{"result":"inconclusive","reason":"cache_stale_and_live_unreachable","trust_source":"none","coordinator_host":"coordinator.streamvc.live","model_hash_verified":null}`),
 		},
 	}
 	for _, tt := range tests {

--- a/phase7-verify/internal/cli/v03_schema_conformance_test.go
+++ b/phase7-verify/internal/cli/v03_schema_conformance_test.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/augstar/macprovider/phase7-verify/internal/schemavalidator"
+	"github.com/augstar/macprovider/phase7-verify/internal/verify"
+)
+
+// SPEC-015 v0.3 §M.3.2.1 — every v0.3-named reason + matching
+// details shape MUST validate against the published schema. Round-2
+// ARCHITECT-3 flagged that the existing schema tests only covered
+// legacy reasons; this fixture corpus closes the gap.
+func TestV03SchemaConformance(t *testing.T) {
+	bptr := func(b bool) *bool { return &b }
+	cases := []struct {
+		name   string
+		result verify.Result
+	}{
+		{
+			name: "model_hash_mismatch",
+			result: verify.Result{
+				Result:            "invalid",
+				Reason:            "model_hash_mismatch",
+				ProviderID:        outputProviderID,
+				ModelID:           outputModelID,
+				SignedAt:          outputSignedAt,
+				TrustSource:       "live",
+				CoordinatorHost:   outputCoordinatorHost,
+				ModelHashVerified: bptr(false),
+				ReceiptVersion:    "3",
+				Details: &verify.Details{
+					Field:    "model_hash",
+					Expected: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+					Actual:   "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+				},
+			},
+		},
+		{
+			name: "model_hash_required",
+			result: verify.Result{
+				Result:            "invalid",
+				Reason:            "model_hash_required",
+				ProviderID:        outputProviderID,
+				ModelID:           outputModelID,
+				SignedAt:          outputSignedAt,
+				TrustSource:       "live",
+				CoordinatorHost:   outputCoordinatorHost,
+				ModelHashVerified: bptr(false),
+				ReceiptVersion:    "3",
+				Details:           &verify.Details{Field: "model_hash", PolicyFlag: "require-model-hash"},
+			},
+		},
+		{
+			name: "model_id_not_in_catalog",
+			result: verify.Result{
+				Result:          "inconclusive",
+				Reason:          "model_id_not_in_catalog",
+				ProviderID:      outputProviderID,
+				ModelID:         "absent",
+				SignedAt:        outputSignedAt,
+				TrustSource:     "live",
+				CoordinatorHost: outputCoordinatorHost,
+				ReceiptVersion:  "3",
+				Details:         &verify.Details{Field: "model_id", ModelID: "absent"},
+			},
+		},
+		{
+			name: "catalog_expired",
+			result: verify.Result{
+				Result:          "inconclusive",
+				Reason:          "catalog_expired",
+				ProviderID:      outputProviderID,
+				ModelID:         outputModelID,
+				SignedAt:        outputSignedAt,
+				TrustSource:     "live",
+				CoordinatorHost: outputCoordinatorHost,
+				ReceiptVersion:  "3",
+				Details: &verify.Details{
+					Field:     "expires_at",
+					CatalogID: "macprovider-tier2-2026-05-31",
+					ExpiresAt: "2026-05-31T00:00:00Z",
+				},
+			},
+		},
+		{
+			name: "catalog_signature_invalid",
+			result: verify.Result{
+				Result:          "invalid",
+				Reason:          "catalog_signature_invalid",
+				ProviderID:      outputProviderID,
+				ModelID:         outputModelID,
+				SignedAt:        outputSignedAt,
+				TrustSource:     "live",
+				CoordinatorHost: outputCoordinatorHost,
+				ReceiptVersion:  "3",
+				// SPEC-015 §M.3.2.1 requires details.alg with the
+				// observed catalog signature.alg value.
+				Details: &verify.Details{Field: "signature", Cause: "signature.alg=\"ed25519\", want \"Ed25519\"", Alg: "ed25519"},
+			},
+		},
+		{
+			name: "catalog_unreachable",
+			result: verify.Result{
+				Result:          "inconclusive",
+				Reason:          "catalog_unreachable",
+				ProviderID:      outputProviderID,
+				ModelID:         outputModelID,
+				SignedAt:        outputSignedAt,
+				TrustSource:     "live",
+				CoordinatorHost: outputCoordinatorHost,
+				ReceiptVersion:  "3",
+				Details: &verify.Details{
+					Field: "catalog_url",
+					URL:   "https://coordinator.streamvc.live/catalog/x",
+					Cause: "connection refused",
+				},
+			},
+		},
+		{
+			name: "unknown_receipt_version",
+			result: verify.Result{
+				Result:         "inconclusive",
+				Reason:         "unknown_receipt_version",
+				TrustSource:    "none",
+				ReceiptVersion: "4",
+				Details:        &verify.Details{Field: "receipt_version", ReceiptVersion: "4"},
+			},
+		},
+		{
+			name: "extra_field",
+			result: verify.Result{
+				Result:      "invalid",
+				Reason:      "extra_field",
+				TrustSource: "none",
+				Details:     &verify.Details{Field: "x_unexpected"},
+			},
+		},
+		{
+			name: "missing_field",
+			result: verify.Result{
+				Result:      "invalid",
+				Reason:      "missing_field",
+				TrustSource: "none",
+				Details:     &verify.Details{Field: "prompt_hash"},
+			},
+		},
+		{
+			name: "valid-with-catalog",
+			result: verify.Result{
+				Result:            "valid",
+				Reason:            "signature_and_canonicalization_match",
+				ProviderID:        outputProviderID,
+				ModelID:           outputModelID,
+				SignedAt:          outputSignedAt,
+				TrustSource:       "live",
+				CoordinatorHost:   outputCoordinatorHost,
+				ModelHashVerified: bptr(true),
+				ReceiptVersion:    "3",
+			},
+		},
+		{
+			name: "valid-legacy-skipped",
+			result: verify.Result{
+				Result:          "valid",
+				Reason:          "signature_and_canonicalization_match",
+				ProviderID:      outputProviderID,
+				ModelID:         outputModelID,
+				SignedAt:        outputSignedAt,
+				TrustSource:     "live",
+				CoordinatorHost: outputCoordinatorHost,
+				ReceiptVersion:  "1",
+				Warnings:        []verify.Warning{{Kind: "catalog_skipped_legacy_receipt"}},
+			},
+		},
+	}
+
+	schema := loadOutputSchema(t)
+
+	// SPEC-015 §M.3.2.1 — assert the schema REJECTS catalog_signature_invalid
+	// without details.alg. This locks the §M.3.2.1 contract at the schema
+	// level so future renderer regressions can't silently emit a permissive
+	// shape.
+	t.Run("catalog_signature_invalid_without_alg_rejected", func(t *testing.T) {
+		bad := verify.Result{
+			Result:          "invalid",
+			Reason:          "catalog_signature_invalid",
+			ProviderID:      outputProviderID,
+			ModelID:         outputModelID,
+			SignedAt:        outputSignedAt,
+			TrustSource:     "live",
+			CoordinatorHost: outputCoordinatorHost,
+			ReceiptVersion:  "3",
+			Details:         &verify.Details{Field: "signature", Cause: "no alg"},
+		}
+		data, err := renderJSON(bad)
+		if err != nil {
+			t.Fatalf("renderJSON: %v", err)
+		}
+		if err := schemavalidator.Validate(schema, data); err == nil {
+			t.Fatalf("schema accepted catalog_signature_invalid without details.alg: %s", data)
+		}
+	})
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := renderJSON(tc.result)
+			if err != nil {
+				t.Fatalf("renderJSON: %v", err)
+			}
+			if err := schemavalidator.Validate(schema, data); err != nil {
+				t.Fatalf("schema rejected v0.3 conformance fixture %q: %v\nbody=%s", tc.name, err, data)
+			}
+		})
+	}
+}

--- a/phase7-verify/internal/receipt/receipt.go
+++ b/phase7-verify/internal/receipt/receipt.go
@@ -22,6 +22,31 @@ type Tuple struct {
 	TTFTms         int64  `json:"ttft_ms"`
 	TokensOut      int64  `json:"tokens_out"`
 	UnixTS         int64  `json:"unix_ts"`
+
+	// SPEC-015 v0.3 §M.0 — new fields. ReceiptVersion is "" for
+	// v0.1/v0.2 receipts (no field present); v0.3 receipts carry
+	// "3". The version is what drives the §M.1.1 / §M.1.3 / §M.1.4
+	// path: presence of `receipt_version` ≠ "" identifies v0.3,
+	// absence identifies v0.1/v0.2 legacy, presence of unknown
+	// value identifies forward-compat unknown version.
+	ReceiptVersion string `json:"receipt_version,omitempty"`
+
+	// ModelHash is the §M.0 raw 64-char lowercase hex string when
+	// the v0.3 provider opted in to warm-swap hash reporting, OR
+	// the empty string when the receipt carries `model_hash: null`
+	// (§M.2.3 warm-swap-disabled provider). Field PRESENT in the
+	// signed tuple bytes either way; we distinguish via
+	// ModelHashPresent.
+	ModelHash string `json:"-"`
+
+	// ModelHashPresent is true iff the parsed v0.3 tuple included
+	// the `model_hash` key. False for v0.1/v0.2 legacy tuples.
+	ModelHashPresent bool `json:"-"`
+
+	// ModelHashNull is true iff the v0.3 tuple's `model_hash` was
+	// the JSON literal null (§M.2.3). Mutually exclusive with
+	// ModelHash != "".
+	ModelHashNull bool `json:"-"`
 }
 
 // Parsed contains the decoded receipt header and the raw signed bytes.
@@ -63,6 +88,22 @@ var (
 		"tokens_out",
 		"unix_ts",
 	}
+	// SPEC-015 §M.0 — v0.3 9-field tuple. Order matches JCS
+	// canonical (UTF-16 code-unit lex / alphabetical ASCII).
+	v03TupleKeys = []string{
+		"model_hash",
+		"model_id",
+		"output_hash",
+		"prompt_hash",
+		"provider_pubkey",
+		"receipt_version",
+		"tokens_out",
+		"ttft_ms",
+		"unix_ts",
+	}
+	// SPEC-015 §M.0 / SPEC-011 R-3.3.1 — model_hash raw 64-char
+	// lowercase hex.
+	modelHashPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
 )
 
 // Parse decodes a SPEC-015 X-MacProvider-Receipt header.
@@ -163,24 +204,46 @@ func parseTuple(raw []byte) (Tuple, error) {
 	if err != nil {
 		return Tuple{}, err
 	}
-	if len(fields) != len(requiredTupleKeys) {
-		for key := range fields {
-			if !isRequiredTupleKey(key) {
-				return Tuple{}, fmt.Errorf("%w: %s", ErrTupleExtraKey, key)
-			}
-		}
-		for _, key := range requiredTupleKeys {
-			if _, ok := fields[key]; !ok {
-				return Tuple{}, fmt.Errorf("%w: %s", ErrTupleMissingKey, key)
-			}
+	// SPEC-015 §M.0 / §M.1.4 — version detection via the value of
+	// `receipt_version`. Presence + value drives the dispatch:
+	//   - absent           → legacy v0.1/v0.2 7-field strict shape
+	//   - "3"              → v0.3 9-field strict shape
+	//   - other present    → unknown forward-compat version; we
+	//     extract the version string and return a Tuple stub so the
+	//     verifier can short-circuit to inconclusive:
+	//     unknown_receipt_version per §M.1.4 BEFORE strict shape
+	//     validation kicks in (a v0.4 receipt with a different
+	//     key set would otherwise be rejected as
+	//     `extra_field`/`missing_field`).
+	versionRaw, hasReceiptVersion := fields["receipt_version"]
+	var unknownReceiptVersion string
+	if hasReceiptVersion {
+		var rv string
+		if err := json.Unmarshal(versionRaw, &rv); err == nil && rv != "" && rv != "3" {
+			unknownReceiptVersion = rv
 		}
 	}
+	if unknownReceiptVersion != "" {
+		return Tuple{ReceiptVersion: unknownReceiptVersion}, nil
+	}
+	var requiredKeys []string
+	if hasReceiptVersion {
+		requiredKeys = v03TupleKeys
+	} else {
+		requiredKeys = requiredTupleKeys
+	}
+	requiredSet := make(map[string]struct{}, len(requiredKeys))
+	for _, k := range requiredKeys {
+		requiredSet[k] = struct{}{}
+	}
+	// Strict 9-key (v0.3) OR 7-key (legacy) shape: extra fields
+	// rejected; missing required fields rejected.
 	for key := range fields {
-		if !isRequiredTupleKey(key) {
+		if _, ok := requiredSet[key]; !ok {
 			return Tuple{}, fmt.Errorf("%w: %s", ErrTupleExtraKey, key)
 		}
 	}
-	for _, key := range requiredTupleKeys {
+	for _, key := range requiredKeys {
 		if _, ok := fields[key]; !ok {
 			return Tuple{}, fmt.Errorf("%w: %s", ErrTupleMissingKey, key)
 		}
@@ -196,6 +259,27 @@ func parseTuple(raw []byte) (Tuple, error) {
 	var extra any
 	if err := decoder.Decode(&extra); err != io.EOF {
 		return Tuple{}, ErrTupleJSON
+	}
+	if hasReceiptVersion {
+		// SPEC-015 §M.0 — model_hash MUST be string (64 hex) OR
+		// JSON null literal. Detect at raw-field level so we
+		// distinguish `null` from `""`.
+		modelHashRaw := fields["model_hash"]
+		switch {
+		case bytes.Equal(bytes.TrimSpace(modelHashRaw), []byte("null")):
+			tuple.ModelHashPresent = true
+			tuple.ModelHashNull = true
+		default:
+			var s string
+			if err := json.Unmarshal(modelHashRaw, &s); err != nil {
+				return Tuple{}, fmt.Errorf("%w: model_hash: %v", ErrTupleWrongType, err)
+			}
+			if !modelHashPattern.MatchString(s) {
+				return Tuple{}, fmt.Errorf("%w: model_hash=%q is not 64 lowercase hex", ErrTupleWrongType, s)
+			}
+			tuple.ModelHash = s
+			tuple.ModelHashPresent = true
+		}
 	}
 	if err := validateTuple(tuple); err != nil {
 		return Tuple{}, err

--- a/phase7-verify/internal/receipt/v02_parity_test.go
+++ b/phase7-verify/internal/receipt/v02_parity_test.go
@@ -1,0 +1,159 @@
+package receipt
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// SPEC-015 §M.1.2 / §M.5 AC-38 cross-binary parity.
+//
+// AC-38 requires: a locked v0.1.3 / v0.2.4 verifier (i.e. unmodified
+// releases) reading a v0.3 receipt MUST report `invalid` per its §3.1
+// seven-keys-only rule. To prove the forward-incompat semantic
+// without needing a separate `phase7-verify-v0.2.4` binary in the
+// repo, this test re-implements the v0.2.4 LOCKED parseTuple
+// behaviour inline as `parseTupleV02Locked` and asserts:
+//
+//  1. A v0.3 9-field tuple (receipt_version="3" + model_hash) → the
+//     v0.2.4 parser MUST reject as ErrTupleExtraKey.
+//  2. A v0.3 null-hash tuple → same rejection.
+//  3. A genuine v0.2.4 7-field tuple → the v0.2.4 parser MUST
+//     accept.
+//
+// The locked v0.2.4 logic mirrors `parseTuple` AT THE v0.2.4
+// LOCK STATE (commit 99d0c1e in this repo's main): exactly the seven
+// keys, no `receipt_version` awareness, no `model_hash` field. The
+// v0.3 IMPL preserved that strict behavior in shape exactly — it
+// just dispatched into a v0.3 path when receipt_version is present.
+// This test confirms the v0.2.4 strict path remains the locked
+// floor of the v0.1/v0.2 contract.
+//
+// A future v0.4+ verifier author can use this test as the canonical
+// cross-binary parity gate: change the §M.0 wire shape and the
+// v0.2.4-Locked parser MUST still reject.
+func TestV02LockedParserRejectsV03Receipts(t *testing.T) {
+	v03NonNullTuple := mustMarshal(t, map[string]any{
+		"model_hash":      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"model_id":        "fixture-model",
+		"output_hash":     strings.Repeat("a", 64),
+		"prompt_hash":     strings.Repeat("b", 64),
+		"provider_pubkey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+		"receipt_version": "3",
+		"tokens_out":      2,
+		"ttft_ms":         7,
+		"unix_ts":         1800000000,
+	})
+	v03NullTuple := mustMarshal(t, map[string]any{
+		"model_hash":      nil,
+		"model_id":        "fixture-model",
+		"output_hash":     strings.Repeat("a", 64),
+		"prompt_hash":     strings.Repeat("b", 64),
+		"provider_pubkey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+		"receipt_version": "3",
+		"tokens_out":      2,
+		"ttft_ms":         7,
+		"unix_ts":         1800000000,
+	})
+	legacy7FieldTuple := mustMarshal(t, map[string]any{
+		"model_id":        "fixture-model",
+		"output_hash":     strings.Repeat("a", 64),
+		"prompt_hash":     strings.Repeat("b", 64),
+		"provider_pubkey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+		"tokens_out":      2,
+		"ttft_ms":         7,
+		"unix_ts":         1800000000,
+	})
+
+	if _, err := parseTupleV02Locked(v03NonNullTuple); !errors.Is(err, ErrTupleExtraKey) {
+		t.Fatalf("v0.2.4 parser MUST reject v0.3 non-null receipt: err=%v, want ErrTupleExtraKey", err)
+	}
+	if _, err := parseTupleV02Locked(v03NullTuple); !errors.Is(err, ErrTupleExtraKey) {
+		t.Fatalf("v0.2.4 parser MUST reject v0.3 null receipt: err=%v, want ErrTupleExtraKey", err)
+	}
+	if _, err := parseTupleV02Locked(legacy7FieldTuple); err != nil {
+		t.Fatalf("v0.2.4 parser MUST accept legacy 7-field tuple: %v", err)
+	}
+}
+
+// parseTupleV02Locked mirrors the locked v0.2.4 parseTuple at commit
+// 99d0c1e on `main` — strict 7-key set, no receipt_version awareness,
+// no model_hash awareness. Any deviation by a v0.4+ wire shape is
+// caught at parse time as ErrTupleExtraKey / ErrTupleMissingKey.
+//
+// This is INTENTIONALLY a re-implementation rather than a call into
+// the live parseTuple, because the live parser handles BOTH v0.2 and
+// v0.3 receipts (the v0.3 IMPL preserved v0.2 acceptance via tagged-
+// union dispatch). The locked floor of the v0.2.4 contract is what
+// AC-38 demands.
+func parseTupleV02Locked(raw []byte) (Tuple, error) {
+	if len(raw) == 0 || !bytes.Equal(raw, bytes.TrimSpace(raw)) {
+		return Tuple{}, ErrTupleJSON
+	}
+	fields, err := decodeTopLevelObject(raw)
+	if err != nil {
+		return Tuple{}, err
+	}
+	// v0.2.4-locked: EXACTLY these seven keys, no others.
+	const wantCount = 7
+	for key := range fields {
+		if !isV02LockedKey(key) {
+			return Tuple{}, fmt.Errorf("%w: %s", ErrTupleExtraKey, key)
+		}
+	}
+	for _, key := range v02LockedKeys() {
+		if _, ok := fields[key]; !ok {
+			return Tuple{}, fmt.Errorf("%w: %s", ErrTupleMissingKey, key)
+		}
+	}
+	if len(fields) != wantCount {
+		return Tuple{}, fmt.Errorf("%w: have %d keys, want %d", ErrTupleExtraKey, len(fields), wantCount)
+	}
+
+	var tuple Tuple
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	decoder.UseNumber()
+	if err := decoder.Decode(&tuple); err != nil {
+		return Tuple{}, fmt.Errorf("%w: %v", ErrTupleWrongType, err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return Tuple{}, ErrTupleJSON
+	}
+	return tuple, nil
+}
+
+func v02LockedKeys() []string {
+	return []string{
+		"model_id",
+		"prompt_hash",
+		"output_hash",
+		"provider_pubkey",
+		"ttft_ms",
+		"tokens_out",
+		"unix_ts",
+	}
+}
+
+func isV02LockedKey(k string) bool {
+	for _, want := range v02LockedKeys() {
+		if want == k {
+			return true
+		}
+	}
+	return false
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}

--- a/phase7-verify/internal/schemavalidator/validator.go
+++ b/phase7-verify/internal/schemavalidator/validator.go
@@ -196,6 +196,9 @@ func singleSchemaTypeMatches(name string, value any) bool {
 	case "array":
 		_, ok := value.([]any)
 		return ok
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
 	default:
 		return false
 	}

--- a/phase7-verify/internal/verify/catalog_check.go
+++ b/phase7-verify/internal/verify/catalog_check.go
@@ -1,0 +1,286 @@
+package verify
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	catalogcache "github.com/augstar/macprovider/phase7-verify/internal/cache/catalog"
+	"github.com/augstar/macprovider/phase7-verify/internal/catalog"
+	"github.com/augstar/macprovider/phase7-verify/internal/receipt"
+)
+
+// catalogVerdict captures the outcome of the §M.3 catalog-check
+// pipeline. Empty Result means "no terminal verdict — keep going
+// with the valid path."
+type catalogVerdict struct {
+	Result            string
+	Reason            string
+	Details           *Details
+	Warnings          []Warning
+	ModelHashVerified *bool
+}
+
+// applyCatalogCheck implements §M.3.1.1 / §M.3.1.2 / §M.3.2 / §M.2.3 /
+// §M.1.1 verifier logic. Called AFTER signature + prompt + output
+// hashes pass; runs the catalog branches and the
+// --require-model-hash policy gate.
+func applyCatalogCheck(parsed receipt.Parsed, opts VerifyOpts, now time.Time) catalogVerdict {
+	v := catalogVerdict{}
+	t := parsed.Tuple
+	isLegacy := t.ReceiptVersion == ""
+
+	// SPEC-015 §M.1.1 — v0.3 verifier reading a legacy v0.1/v0.2
+	// receipt MUST skip the catalog check entirely. Surface the
+	// `catalog_skipped_legacy_receipt` warning when catalog flags
+	// WERE supplied.
+	if isLegacy {
+		if opts.Catalog.Enabled {
+			v.Warnings = append(v.Warnings, Warning{Kind: warningCatalogSkippedLegacyReceipt})
+		}
+		// §M.3.1.2 — --require-model-hash on a legacy receipt
+		// MUST report invalid: model_hash_required (the legacy
+		// receipt has no hash to attest).
+		if opts.RequireModelHash {
+			f := false
+			v.ModelHashVerified = &f
+			v.Result = resultInvalid
+			v.Reason = reasonModelHashRequired
+			v.Details = &Details{Field: "model_hash", PolicyFlag: "require-model-hash"}
+			return v
+		}
+		return v
+	}
+
+	// SPEC-015 §M.0 — v0.3 receipt. The §M.1.4 unknown-version
+	// path is handled upstream in Verify (before this function
+	// runs), so by the time we get here t.ReceiptVersion == "3".
+
+	// Null-hash branch (§M.2.3).
+	if t.ModelHashNull {
+		// §M.3.1.2 fail-closed.
+		if opts.RequireModelHash {
+			f := false
+			v.ModelHashVerified = &f
+			v.Result = resultInvalid
+			v.Reason = reasonModelHashRequired
+			v.Details = &Details{Field: "model_hash", PolicyFlag: "require-model-hash"}
+			return v
+		}
+		if opts.Catalog.Enabled {
+			v.Warnings = append(v.Warnings, Warning{Kind: warningCatalogSkippedNullHash})
+		}
+		// model_hash_verified stays nil (catalog did not run).
+		return v
+	}
+
+	// Non-null hash + no catalog flags → §10.6 v0.2 trust boundary
+	// preserved (model_hash_verified=nil).
+	if !opts.Catalog.Enabled {
+		return v
+	}
+
+	// SPEC-015 §M.3.2 — 8-step algorithm.
+	// First resolve the catalog pubkey (cheap: file or HTTP GET +
+	// JSON decode). We need it before consulting the cache because
+	// pubkey rotation invalidates cached catalog bytes.
+	pubkey, fetchErr := resolveCatalogPubkey(opts.Catalog, opts.Offline, opts.HTTPClient)
+	if fetchErr != nil {
+		v.Result = resultInconclusive
+		v.Reason = reasonCatalogUnreachable
+		v.Details = &Details{Field: "catalog_pubkey_url", URL: opts.Catalog.PubkeyURL, Cause: fetchErr.Error()}
+		return v
+	}
+	pubkeyB64 := catalogcache.EncodePubkeyForCache(pubkey)
+
+	// SPEC-015 §M.3.4 — cache catalog bytes (URL mode only) keyed
+	// by catalog URL + bound to current pubkey. Cache miss on
+	// rotation. File-mode (--catalog <path>) skips the cache.
+	catalogBytes, fromCache := tryCachedCatalogBytes(opts.Catalog, pubkeyB64, now)
+	if catalogBytes == nil {
+		catalogBytes, fetchErr = resolveCatalogBytes(opts.Catalog, opts.Offline, opts.HTTPClient, opts.Now)
+		if fetchErr != nil {
+			v.Result = resultInconclusive
+			v.Reason = reasonCatalogUnreachable
+			v.Details = &Details{Field: "catalog_url", URL: opts.Catalog.URL, Cause: fetchErr.Error()}
+			return v
+		}
+	}
+	_ = fromCache
+
+	// Parse + Verify (signature + expiry). If the bytes came from
+	// the cache they were already parse+verify-clean at write time;
+	// re-running here costs ~100µs and protects against a corrupted
+	// cache file regardless.
+	c, parseErr := catalog.Parse(catalogBytes)
+	if parseErr != nil {
+		v.Result = resultInvalid
+		v.Reason = reasonCatalogFormatInvalid
+		v.Details = &Details{Field: "catalog", Cause: parseErr.Error()}
+		return v
+	}
+	if verifyErr := catalog.Verify(c, pubkey, now); verifyErr != nil {
+		var sigErr *catalog.ErrSignatureInvalid
+		var expErr *catalog.ErrExpired
+		switch {
+		case errors.As(verifyErr, &sigErr):
+			v.Result = resultInvalid
+			v.Reason = reasonCatalogSignatureInvalid
+			v.Details = &Details{Field: "signature", Cause: sigErr.Reason, Alg: sigErr.ObservedAlg}
+		case errors.As(verifyErr, &expErr):
+			v.Result = resultInconclusive
+			v.Reason = reasonCatalogExpired
+			v.Details = &Details{
+				Field:     "expires_at",
+				CatalogID: expErr.CatalogID,
+				ExpiresAt: expErr.ExpiresAt.UTC().Format(time.RFC3339),
+			}
+		default:
+			v.Result = resultInvalid
+			v.Reason = reasonCatalogSignatureInvalid
+			v.Details = &Details{Field: "signature", Cause: verifyErr.Error()}
+		}
+		return v
+	}
+
+	// §M.3.2 step 6 — case-folded model lookup.
+	entry, ok := catalog.Lookup(c, t.ModelID)
+	if !ok {
+		v.Result = resultInconclusive
+		v.Reason = reasonModelIDNotInCatalog
+		v.Details = &Details{Field: "model_id", ModelID: t.ModelID}
+		return v
+	}
+
+	// §M.3.2 step 7 — hash comparison (case-sensitive; both sides
+	// lowercase by their respective spec).
+	if t.ModelHash != entry.SHA256 {
+		f := false
+		v.ModelHashVerified = &f
+		v.Result = resultInvalid
+		v.Reason = reasonModelHashMismatch
+		v.Details = &Details{
+			Field:    "model_hash",
+			Expected: entry.SHA256,
+			Actual:   t.ModelHash,
+		}
+		return v
+	}
+
+	// §M.3.2 step 8 — verified. Persist to cache so subsequent
+	// runs (within §M.3.4 TTL band) skip the network fetch.
+	if !fromCache && opts.Catalog.URL != "" {
+		store, errStore := catalogcache.New()
+		if errStore == nil && store != nil {
+			_, _, _ = store.Put(opts.Catalog.URL, catalogBytes, pubkeyB64, c.ExpiresAt, now)
+		}
+	}
+	tr := true
+	v.ModelHashVerified = &tr
+	return v
+}
+
+// tryCachedCatalogBytes returns the cached catalog bytes for the
+// given URL when the §M.3.4 cache holds a non-stale, pubkey-matched
+// entry. Returns (nil, false) on miss (caller falls back to a
+// network fetch).
+func tryCachedCatalogBytes(co CatalogOpts, pubkeyB64 string, now time.Time) ([]byte, bool) {
+	if co.URL == "" {
+		return nil, false
+	}
+	store, err := catalogcache.New()
+	if err != nil || store == nil {
+		return nil, false
+	}
+	entry, hit, err := store.Get(co.URL, pubkeyB64, now)
+	if err != nil || !hit || entry == nil {
+		return nil, false
+	}
+	return append([]byte(nil), entry.CatalogBytes...), true
+}
+
+// resolveCatalogBytes returns the catalog file bytes from --catalog
+// (local file) OR --catalog-url (HTTP GET, gated by --offline).
+func resolveCatalogBytes(co CatalogOpts, offline bool, client *http.Client, now func() time.Time) ([]byte, error) {
+	if co.Path != "" {
+		return os.ReadFile(co.Path)
+	}
+	if co.URL == "" {
+		return nil, errors.New("catalog source not configured")
+	}
+	if offline {
+		return nil, errors.New("catalog URL fetch blocked by --offline")
+	}
+	c := client
+	if c == nil {
+		c = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := c.Get(co.URL)
+	if err != nil {
+		return nil, fmt.Errorf("catalog url fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("catalog url status=%d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// resolveCatalogPubkey returns the 32-byte ed25519 catalog pubkey
+// from --catalog-pubkey (pre-decoded) OR --catalog-pubkey-url
+// (HTTP GET returning {"pubkey":"<43-char base64url>","alg":"Ed25519"}).
+func resolveCatalogPubkey(co CatalogOpts, offline bool, client *http.Client) (ed25519.PublicKey, error) {
+	if len(co.Pubkey) > 0 {
+		return ed25519.PublicKey(co.Pubkey), nil
+	}
+	if co.PubkeyURL == "" {
+		return nil, errors.New("catalog pubkey source not configured")
+	}
+	if offline {
+		return nil, errors.New("catalog pubkey URL fetch blocked by --offline")
+	}
+	c := client
+	if c == nil {
+		c = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := c.Get(co.PubkeyURL)
+	if err != nil {
+		return nil, fmt.Errorf("catalog pubkey url fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("catalog pubkey url status=%d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read catalog pubkey body: %w", err)
+	}
+	return decodeCatalogPubkeyResponse(body)
+}
+
+func decodeCatalogPubkeyResponse(body []byte) (ed25519.PublicKey, error) {
+	// Reuse stdlib JSON via a local anonymous struct.
+	var pkResp struct {
+		Pubkey string `json:"pubkey"`
+		Alg    string `json:"alg"`
+	}
+	if err := jsonUnmarshal(body, &pkResp); err != nil {
+		return nil, fmt.Errorf("decode catalog pubkey JSON: %w", err)
+	}
+	if pkResp.Alg != catalogPubkeyAlg {
+		return nil, fmt.Errorf("catalog pubkey alg=%q, want %q", pkResp.Alg, catalogPubkeyAlg)
+	}
+	raw, err := decodeRawURLBase64(strings.TrimSpace(pkResp.Pubkey))
+	if err != nil {
+		return nil, fmt.Errorf("decode catalog pubkey base64url: %w", err)
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("catalog pubkey length=%d, want %d", len(raw), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(raw), nil
+}

--- a/phase7-verify/internal/verify/catalog_check_fixtures_test.go
+++ b/phase7-verify/internal/verify/catalog_check_fixtures_test.go
@@ -1,0 +1,128 @@
+package verify
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type catalogModel struct {
+	ArtifactKind string `json:"artifact_kind"`
+	HashScope    string `json:"hash_scope"`
+	ModelID      string `json:"model_id"`
+	SHA256       string `json:"sha256"`
+	Source       string `json:"source"`
+}
+
+// writeSignedCatalog produces a signed catalog file at a temp path
+// containing the supplied models (with defaults filled in for the
+// per-entry required fields). Returns (path, pubkey-bytes).
+// writeTamperedSignedCatalog produces a signed catalog whose
+// signature.sig has been flipped after signing, so verification will
+// fail at the ed25519.Verify-returned-false branch.
+func writeTamperedSignedCatalog(t *testing.T, catalogID string, expires time.Time, models []catalogModel) (string, ed25519.PublicKey) {
+	t.Helper()
+	path, pub := writeSignedCatalog(t, catalogID, expires, models)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read for tamper: %v", err)
+	}
+	// Flip the first base64 character of the signature.sig field.
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	sig := doc["signature"].(map[string]any)
+	raw := sig["sig"].(string)
+	if len(raw) == 0 {
+		t.Fatal("sig empty")
+	}
+	flipped := []byte(raw)
+	if flipped[0] == 'A' {
+		flipped[0] = 'B'
+	} else {
+		flipped[0] = 'A'
+	}
+	sig["sig"] = string(flipped)
+	out, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	return path, pub
+}
+
+func writeSignedCatalog(t *testing.T, catalogID string, expires time.Time, models []catalogModel) (string, ed25519.PublicKey) {
+	t.Helper()
+	for i := range models {
+		if models[i].ArtifactKind == "" {
+			models[i].ArtifactKind = "mlx_weight_file"
+		}
+		if models[i].HashScope == "" {
+			models[i].HashScope = "primary_weight_file"
+		}
+		if models[i].Source == "" {
+			models[i].Source = "operator-curated"
+		}
+	}
+	seed := bytes.Repeat([]byte{7}, ed25519.SeedSize)
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	issued := time.Now().Add(-time.Hour).UTC().Round(time.Second)
+	type body struct {
+		CatalogID string         `json:"catalog_id"`
+		ExpiresAt string         `json:"expires_at"`
+		IssuedAt  string         `json:"issued_at"`
+		Models    []catalogModel `json:"models"`
+		Version   int            `json:"version"`
+	}
+	type sig struct {
+		Alg   string `json:"alg"`
+		KeyID string `json:"key_id"`
+		Sig   string `json:"sig"`
+	}
+	type file struct {
+		CatalogID string         `json:"catalog_id"`
+		ExpiresAt string         `json:"expires_at"`
+		IssuedAt  string         `json:"issued_at"`
+		Models    []catalogModel `json:"models"`
+		Signature sig            `json:"signature"`
+		Version   int            `json:"version"`
+	}
+	b := body{
+		CatalogID: catalogID,
+		ExpiresAt: expires.UTC().Format(time.RFC3339),
+		IssuedAt:  issued.Format(time.RFC3339),
+		Models:    models,
+		Version:   1,
+	}
+	canonical, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	signature := ed25519.Sign(priv, canonical)
+	f := file{
+		CatalogID: b.CatalogID,
+		ExpiresAt: b.ExpiresAt,
+		IssuedAt:  b.IssuedAt,
+		Models:    b.Models,
+		Signature: sig{Alg: "Ed25519", KeyID: "verify-test-key", Sig: base64.RawURLEncoding.EncodeToString(signature)},
+		Version:   b.Version,
+	}
+	raw, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal file: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "catalog.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write catalog: %v", err)
+	}
+	return path, pub
+}

--- a/phase7-verify/internal/verify/catalog_check_test.go
+++ b/phase7-verify/internal/verify/catalog_check_test.go
@@ -1,0 +1,218 @@
+package verify
+
+import (
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider/phase7-verify/internal/receipt"
+)
+
+// SPEC-015 §M.1.1 — v0.3 verifier reading a legacy v0.1/v0.2 receipt
+// MUST emit catalog_skipped_legacy_receipt warning when catalog
+// flags were supplied, and MUST NOT short-circuit the result.
+func TestCatalogCheckLegacyReceiptWithCatalogFlags(t *testing.T) {
+	parsed := receipt.Parsed{
+		Tuple: receipt.Tuple{
+			ModelID: "mlx-fixture",
+			// ReceiptVersion empty → legacy v0.1/v0.2.
+		},
+	}
+	opts := VerifyOpts{
+		Catalog: CatalogOpts{Enabled: true},
+	}
+	v := applyCatalogCheck(parsed, opts, time.Now())
+	if v.Result != "" {
+		t.Fatalf("legacy receipt should not short-circuit: got %q", v.Result)
+	}
+	if !hasWarning(v.Warnings, warningCatalogSkippedLegacyReceipt) {
+		t.Fatalf("missing warning %q; got %+v", warningCatalogSkippedLegacyReceipt, v.Warnings)
+	}
+	if v.ModelHashVerified != nil {
+		t.Fatalf("ModelHashVerified = %v, want nil", v.ModelHashVerified)
+	}
+}
+
+// SPEC-015 §M.3.1.2 — --require-model-hash on a legacy receipt is
+// invalid: model_hash_required.
+func TestCatalogCheckLegacyReceiptRequireModelHash(t *testing.T) {
+	parsed := receipt.Parsed{Tuple: receipt.Tuple{ModelID: "m"}}
+	opts := VerifyOpts{RequireModelHash: true}
+	v := applyCatalogCheck(parsed, opts, time.Now())
+	if v.Result != resultInvalid || v.Reason != reasonModelHashRequired {
+		t.Fatalf("got result=%q reason=%q, want invalid+model_hash_required", v.Result, v.Reason)
+	}
+	if v.ModelHashVerified == nil || *v.ModelHashVerified {
+		t.Fatalf("ModelHashVerified = %v, want pointer-to-false", v.ModelHashVerified)
+	}
+}
+
+// SPEC-015 §M.2.3 — v0.3 receipt with null model_hash + catalog
+// flags → warning, valid path (model_hash_verified=nil).
+func TestCatalogCheckNullHashWithCatalogFlags(t *testing.T) {
+	parsed := receipt.Parsed{
+		Tuple: receipt.Tuple{
+			ModelID:          "m",
+			ReceiptVersion:   "3",
+			ModelHashPresent: true,
+			ModelHashNull:    true,
+		},
+	}
+	opts := VerifyOpts{Catalog: CatalogOpts{Enabled: true}}
+	v := applyCatalogCheck(parsed, opts, time.Now())
+	if v.Result != "" {
+		t.Fatalf("null hash should not short-circuit (no policy flag): got %q", v.Result)
+	}
+	if !hasWarning(v.Warnings, warningCatalogSkippedNullHash) {
+		t.Fatalf("missing warning %q", warningCatalogSkippedNullHash)
+	}
+	if v.ModelHashVerified != nil {
+		t.Fatalf("ModelHashVerified = %v, want nil", v.ModelHashVerified)
+	}
+}
+
+// SPEC-015 §M.3.1.2 — --require-model-hash + null hash → invalid:
+// model_hash_required.
+func TestCatalogCheckNullHashRequireModelHash(t *testing.T) {
+	parsed := receipt.Parsed{
+		Tuple: receipt.Tuple{
+			ModelID:          "m",
+			ReceiptVersion:   "3",
+			ModelHashPresent: true,
+			ModelHashNull:    true,
+		},
+	}
+	opts := VerifyOpts{RequireModelHash: true}
+	v := applyCatalogCheck(parsed, opts, time.Now())
+	if v.Result != resultInvalid || v.Reason != reasonModelHashRequired {
+		t.Fatalf("got result=%q reason=%q", v.Result, v.Reason)
+	}
+	if v.ModelHashVerified == nil || *v.ModelHashVerified {
+		t.Fatalf("ModelHashVerified = %v, want false", v.ModelHashVerified)
+	}
+}
+
+// SPEC-015 §M.3.2 step 6 — model_id not in catalog → inconclusive.
+// Driven by writing a temp signed catalog that does NOT include
+// the receipt's model_id.
+func TestCatalogCheckModelIDNotInCatalog(t *testing.T) {
+	path, pub := writeSignedCatalog(t, "tc", time.Now().Add(time.Hour), []catalogModel{{
+		ModelID: "other-model",
+		SHA256:  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}})
+	parsed := receipt.Parsed{
+		Tuple: receipt.Tuple{
+			ModelID:          "missing-model",
+			ReceiptVersion:   "3",
+			ModelHashPresent: true,
+			ModelHash:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	}
+	opts := VerifyOpts{
+		Catalog: CatalogOpts{
+			Enabled: true,
+			Path:    path,
+			Pubkey:  pub,
+		},
+	}
+	v := applyCatalogCheck(parsed, opts, time.Now())
+	if v.Result != resultInconclusive || v.Reason != reasonModelIDNotInCatalog {
+		t.Fatalf("got result=%q reason=%q", v.Result, v.Reason)
+	}
+}
+
+// SPEC-015 §M.3.2 step 7 — model_hash mismatch → invalid.
+func TestCatalogCheckModelHashMismatch(t *testing.T) {
+	want := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	path, pub := writeSignedCatalog(t, "tc", time.Now().Add(time.Hour), []catalogModel{{
+		ModelID: "model-a",
+		SHA256:  want,
+	}})
+	parsed := receipt.Parsed{
+		Tuple: receipt.Tuple{
+			ModelID:          "model-a",
+			ReceiptVersion:   "3",
+			ModelHashPresent: true,
+			ModelHash:        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		},
+	}
+	opts := VerifyOpts{
+		Catalog: CatalogOpts{Enabled: true, Path: path, Pubkey: pub},
+	}
+	v := applyCatalogCheck(parsed, opts, time.Now())
+	if v.Result != resultInvalid || v.Reason != reasonModelHashMismatch {
+		t.Fatalf("got result=%q reason=%q", v.Result, v.Reason)
+	}
+	if v.ModelHashVerified == nil || *v.ModelHashVerified {
+		t.Fatalf("ModelHashVerified = %v, want false", v.ModelHashVerified)
+	}
+}
+
+// SPEC-015 §M.3.2 step 8 — hash match → no short-circuit; verifier
+// continues to the valid path with model_hash_verified=true.
+func TestCatalogCheckHashMatch(t *testing.T) {
+	hash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	path, pub := writeSignedCatalog(t, "tc", time.Now().Add(time.Hour), []catalogModel{{
+		ModelID: "model-a",
+		SHA256:  hash,
+	}})
+	parsed := receipt.Parsed{
+		Tuple: receipt.Tuple{
+			ModelID:          "model-a",
+			ReceiptVersion:   "3",
+			ModelHashPresent: true,
+			ModelHash:        hash,
+		},
+	}
+	opts := VerifyOpts{
+		Catalog: CatalogOpts{Enabled: true, Path: path, Pubkey: pub},
+	}
+	v := applyCatalogCheck(parsed, opts, time.Now())
+	if v.Result != "" {
+		t.Fatalf("hash match should not short-circuit: got %q", v.Result)
+	}
+	if v.ModelHashVerified == nil || !*v.ModelHashVerified {
+		t.Fatalf("ModelHashVerified = %v, want pointer-to-true", v.ModelHashVerified)
+	}
+}
+
+// SPEC-015 §M.3.2.1 — the tampered-catalog end-to-end path through
+// applyCatalogCheck must surface details.alg with the observed
+// signature.alg so schema validation passes (the v0.3 schema
+// requires details.alg when reason is catalog_signature_invalid).
+func TestCatalogCheckTamperedCatalogPopulatesDetailsAlg(t *testing.T) {
+	hash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	path, pub := writeTamperedSignedCatalog(t, "tc", time.Now().Add(time.Hour), []catalogModel{{
+		ModelID: "model-a",
+		SHA256:  hash,
+	}})
+	parsed := receipt.Parsed{
+		Tuple: receipt.Tuple{
+			ModelID:          "model-a",
+			ReceiptVersion:   "3",
+			ModelHashPresent: true,
+			ModelHash:        hash,
+		},
+	}
+	opts := VerifyOpts{
+		Catalog: CatalogOpts{Enabled: true, Path: path, Pubkey: pub},
+	}
+	v := applyCatalogCheck(parsed, opts, time.Now())
+	if v.Result != resultInvalid || v.Reason != reasonCatalogSignatureInvalid {
+		t.Fatalf("got result=%q reason=%q", v.Result, v.Reason)
+	}
+	if v.Details == nil {
+		t.Fatal("Details nil")
+	}
+	if v.Details.Alg == "" {
+		t.Fatalf("Details.Alg = %q, want non-empty (the observed catalog signature.alg)", v.Details.Alg)
+	}
+}
+
+func hasWarning(ws []Warning, kind string) bool {
+	for _, w := range ws {
+		if w.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/phase7-verify/internal/verify/catalog_helpers.go
+++ b/phase7-verify/internal/verify/catalog_helpers.go
@@ -1,0 +1,19 @@
+package verify
+
+import (
+	"encoding/base64"
+	"encoding/json"
+)
+
+// SPEC-015 §M.4 — capital-E ASCII alg string.
+const catalogPubkeyAlg = "Ed25519"
+
+// jsonUnmarshal centralizes the stdlib JSON decode for catalog
+// pubkey fetches.
+func jsonUnmarshal(body []byte, v any) error {
+	return json.Unmarshal(body, v)
+}
+
+func decodeRawURLBase64(s string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(s)
+}

--- a/phase7-verify/internal/verify/enum_drift_test.go
+++ b/phase7-verify/internal/verify/enum_drift_test.go
@@ -19,6 +19,17 @@ func TestReasonEnumBijection(t *testing.T) {
 		"pubkey_unresolvable",
 		"provider_id_not_in_pool",
 		"cache_stale_and_live_unreachable",
+		// SPEC-015 v0.3 §M.3.2.1 — new reason enum.
+		"model_hash_mismatch",
+		"model_hash_required",
+		"model_id_not_in_catalog",
+		"catalog_signature_invalid",
+		"catalog_unreachable",
+		"catalog_expired",
+		"catalog_format_invalid",
+		"unknown_receipt_version",
+		"extra_field",
+		"missing_field",
 	}
 	expected := make(map[string]bool, len(expectedReasons))
 	for _, reason := range expectedReasons {
@@ -83,6 +94,16 @@ func TestReasonEnumBijection(t *testing.T) {
 		reasonPubkeyUnresolvable,
 		reasonProviderIDNotInPool,
 		reasonCacheStaleAndLiveUnreachable,
+		reasonModelHashMismatch,
+		reasonModelHashRequired,
+		reasonModelIDNotInCatalog,
+		reasonCatalogSignatureInvalid,
+		reasonCatalogUnreachable,
+		reasonCatalogExpired,
+		reasonCatalogFormatInvalid,
+		reasonUnknownReceiptVersion,
+		reasonExtraField,
+		reasonMissingField,
 	}
 	for _, reason := range verifyReasonConstants {
 		if !expected[reason] {

--- a/phase7-verify/internal/verify/verify.go
+++ b/phase7-verify/internal/verify/verify.go
@@ -42,6 +42,22 @@ const (
 	reasonProviderIDNotInPool           = "provider_id_not_in_pool"
 	warningReasonProviderIDUnresolvable = "provider_id_unresolvable"
 
+	// SPEC-015 v0.3 §M.3.2.1 — new reason enum values.
+	reasonModelHashMismatch       = "model_hash_mismatch"
+	reasonModelHashRequired       = "model_hash_required"
+	reasonModelIDNotInCatalog     = "model_id_not_in_catalog"
+	reasonCatalogSignatureInvalid = "catalog_signature_invalid"
+	reasonCatalogUnreachable      = "catalog_unreachable"
+	reasonCatalogExpired          = "catalog_expired"
+	reasonCatalogFormatInvalid    = "catalog_format_invalid"
+	reasonUnknownReceiptVersion   = "unknown_receipt_version"
+	reasonExtraField              = "extra_field"
+	reasonMissingField            = "missing_field"
+
+	// SPEC-015 v0.3 §M.3.2.1 — new warning kinds.
+	warningCatalogSkippedNullHash      = "catalog_skipped_null_hash"
+	warningCatalogSkippedLegacyReceipt = "catalog_skipped_legacy_receipt"
+
 	defaultCoordinatorHost = "coordinator.streamvc.live"
 	clockSkewThreshold     = 24 * time.Hour
 	graceWindowSlack       = 60 * time.Second
@@ -70,6 +86,26 @@ type VerifyOpts struct {
 	Cache           *cache.Cache // injected cache (nil -> use default)
 	Now             func() time.Time
 	HTTPClient      *http.Client // injectable for tests
+
+	// SPEC-015 v0.3 §M.3 — catalog-check options. Enabled is true
+	// when all four flag-mode preconditions hold (catalog + pubkey
+	// both supplied, mutual-exclusion respected, --offline check
+	// passed). Path / URL describe how to resolve catalog bytes;
+	// Pubkey / PubkeyURL describe how to resolve the pubkey.
+	Catalog CatalogOpts
+	// SPEC-015 v0.3 §M.3.1.2 — fail-closed flag on null model_hash.
+	RequireModelHash bool
+}
+
+// CatalogOpts is the resolved catalog-check configuration. Exactly
+// one of (Path, URL) is non-empty when Enabled; exactly one of
+// (Pubkey != nil, PubkeyURL != "") when Enabled.
+type CatalogOpts struct {
+	Enabled   bool
+	Path      string
+	URL       string
+	Pubkey    []byte // 32-byte raw ed25519 public key (already decoded)
+	PubkeyURL string
 }
 
 // Result is one verification outcome, mirroring SPEC-015 section 10.4.2.
@@ -83,6 +119,15 @@ type Result struct {
 	CoordinatorHost string    `json:"coordinator_host,omitempty"`
 	Details         *Details  `json:"details,omitempty"`
 	Warnings        []Warning `json:"warnings,omitempty"`
+	// SPEC-015 v0.3 §M.3.2.1 — tri-state. true = catalog check ran
+	// and hash matched; false = catalog check ran and mismatched
+	// (or --require-model-hash with null hash); nil = catalog check
+	// did NOT run (no catalog flags / null hash / legacy receipt /
+	// unknown receipt_version / catalog fetch failure).
+	ModelHashVerified *bool `json:"model_hash_verified"`
+	// ReceiptVersion is "1" for v0.1/v0.2 legacy or "3" for v0.3.
+	// Emitted on every output for diagnostic clarity.
+	ReceiptVersion string `json:"receipt_version,omitempty"`
 }
 
 type Details struct {
@@ -90,6 +135,21 @@ type Details struct {
 	Computed string         `json:"computed,omitempty"`
 	Receipt  string         `json:"receipt,omitempty"`
 	Extra    map[string]any `json:"extra,omitempty"`
+
+	// SPEC-015 v0.3 §M.3.2.1 — named top-level fields for the v0.3
+	// reason-specific details contract. Empty strings are omitted
+	// by the CLI JSON renderer to avoid emitting noise on
+	// non-v0.3 reasons.
+	Expected       string `json:"expected,omitempty"`         // model_hash_mismatch
+	Actual         string `json:"actual,omitempty"`           // model_hash_mismatch
+	PolicyFlag     string `json:"policy_flag,omitempty"`      // model_hash_required
+	ModelID        string `json:"model_id,omitempty"`         // model_id_not_in_catalog
+	CatalogID      string `json:"catalog_id,omitempty"`       // catalog_expired
+	ExpiresAt      string `json:"expires_at,omitempty"`       // catalog_expired (RFC3339)
+	ReceiptVersion string `json:"receipt_version,omitempty"`  // unknown_receipt_version
+	Cause          string `json:"cause,omitempty"`            // catalog_format_invalid / catalog_signature_invalid
+	URL            string `json:"url,omitempty"`              // catalog_unreachable
+	Alg            string `json:"alg,omitempty"`              // catalog_signature_invalid (observed alg)
 }
 
 // Warning re-exports resolver.Warning shape for symmetry; verify adds
@@ -101,25 +161,29 @@ type Warning struct {
 
 func (r Result) MarshalJSON() ([]byte, error) {
 	type resultJSON struct {
-		Result          string    `json:"result"`
-		Reason          string    `json:"reason"`
-		ProviderID      *string   `json:"provider_id"`
-		ModelID         string    `json:"model_id,omitempty"`
-		SignedAt        int64     `json:"signed_at,omitempty"`
-		TrustSource     string    `json:"trust_source"`
-		CoordinatorHost string    `json:"coordinator_host,omitempty"`
-		Details         *Details  `json:"details,omitempty"`
-		Warnings        []Warning `json:"warnings,omitempty"`
+		Result            string    `json:"result"`
+		Reason            string    `json:"reason"`
+		ProviderID        *string   `json:"provider_id"`
+		ModelID           string    `json:"model_id,omitempty"`
+		SignedAt          int64     `json:"signed_at,omitempty"`
+		TrustSource       string    `json:"trust_source"`
+		CoordinatorHost   string    `json:"coordinator_host,omitempty"`
+		ModelHashVerified *bool     `json:"model_hash_verified"`
+		ReceiptVersion    string    `json:"receipt_version,omitempty"`
+		Details           *Details  `json:"details,omitempty"`
+		Warnings          []Warning `json:"warnings,omitempty"`
 	}
 	out := resultJSON{
-		Result:          r.Result,
-		Reason:          r.Reason,
-		ModelID:         r.ModelID,
-		SignedAt:        r.SignedAt,
-		TrustSource:     r.TrustSource,
-		CoordinatorHost: r.CoordinatorHost,
-		Details:         r.Details,
-		Warnings:        r.Warnings,
+		Result:            r.Result,
+		Reason:            r.Reason,
+		ModelID:           r.ModelID,
+		SignedAt:          r.SignedAt,
+		TrustSource:       r.TrustSource,
+		CoordinatorHost:   r.CoordinatorHost,
+		ModelHashVerified: r.ModelHashVerified,
+		ReceiptVersion:    r.ReceiptVersion,
+		Details:           r.Details,
+		Warnings:          r.Warnings,
 	}
 	if r.ProviderID != "" {
 		out.ProviderID = &r.ProviderID
@@ -175,7 +239,33 @@ func Verify(input VerifyInput, opts VerifyOpts) (Result, error) {
 
 	parsed, err := parseInput(input)
 	if err != nil {
+		// SPEC-015 §M.0 / §M.3.2.1 — v0.3 strict-shape parse failures
+		// (extra/missing tuple keys) MUST be reported as JSON
+		// `invalid` with the named reason, not as exit-65 input format
+		// errors. The receipt parser distinguishes these via typed
+		// sentinel errors.
+		if r, ok := shapeErrorToInvalidResult(err); ok {
+			return r, nil
+		}
 		return Result{}, err
+	}
+	// SPEC-015 §M.1.4 — forward-compat: a v0.3 verifier reading an
+	// unknown receipt_version MUST NOT canonicalize / signature-check.
+	// Report inconclusive: unknown_receipt_version, exit code 2,
+	// `details.receipt_version` populated.
+	if rv := parsed.Tuple.ReceiptVersion; rv != "" && rv != "3" {
+		f := (*bool)(nil)
+		return Result{
+			Result:            resultInconclusive,
+			Reason:            reasonUnknownReceiptVersion,
+			TrustSource:       string(resolver.SourceNone),
+			ReceiptVersion:    rv,
+			ModelHashVerified: f,
+			Details: &Details{
+				Field:          "receipt_version",
+				ReceiptVersion: rv,
+			},
+		}, nil
 	}
 	base := Result{
 		ProviderID: input.ProviderID,
@@ -257,6 +347,33 @@ func Verify(input VerifyInput, opts VerifyOpts) (Result, error) {
 	}
 
 	base.Warnings = append(base.Warnings, clockSkewWarning(parsed.Tuple.UnixTS, now())...)
+
+	// SPEC-015 §M.0 — emit receipt_version for diagnostic clarity.
+	// Legacy v0.1/v0.2 receipts are tagged "1" (per §M.1.1 the
+	// verifier treats absent receipt_version as the implicit v0.1
+	// shape).
+	if parsed.Tuple.ReceiptVersion != "" {
+		base.ReceiptVersion = parsed.Tuple.ReceiptVersion
+	} else {
+		base.ReceiptVersion = "1"
+	}
+
+	// SPEC-015 §M.3 — catalog-check + §M.1.1 back-compat warning +
+	// §M.3.1.2 --require-model-hash policy gate. The catalog-check
+	// short-circuits on a wrong hash, missing model_id, expired
+	// catalog, fetch failure, etc., per §M.3.2 steps 1-8.
+	catalogVerdict := applyCatalogCheck(parsed, opts, now())
+	base.Warnings = append(base.Warnings, catalogVerdict.Warnings...)
+	base.ModelHashVerified = catalogVerdict.ModelHashVerified
+	if catalogVerdict.Result != "" {
+		// Catalog short-circuited the result (invalid /
+		// inconclusive). Propagate the verdict + details.
+		base.Result = catalogVerdict.Result
+		base.Reason = catalogVerdict.Reason
+		base.Details = catalogVerdict.Details
+		return base, nil
+	}
+
 	base.Result = resultValid
 	base.Reason = reasonValid
 	return base, nil
@@ -288,6 +405,49 @@ func computedOutputHash(input VerifyInput) ([]byte, error) {
 		return nil, &UsageError{Err: fmt.Errorf("canonicalize response: %w", err)}
 	}
 	return outputHash[:], nil
+}
+
+// shapeErrorToInvalidResult maps tuple-shape parse errors to a JSON
+// `invalid` result with the §M.3.2.1 reason enum. Returns (Result,
+// true) if the err is shape-shape (extra/missing key); (Result,
+// false) otherwise (caller should propagate the error).
+func shapeErrorToInvalidResult(err error) (Result, bool) {
+	if err == nil {
+		return Result{}, false
+	}
+	var ifErr *InputFormatError
+	if !errors.As(err, &ifErr) {
+		return Result{}, false
+	}
+	inner := ifErr.Err
+	switch {
+	case errors.Is(inner, receipt.ErrTupleExtraKey):
+		return Result{
+			Result:      resultInvalid,
+			Reason:      reasonExtraField,
+			TrustSource: string(resolver.SourceNone),
+			Details:     &Details{Field: extractTupleErrorField(inner)},
+		}, true
+	case errors.Is(inner, receipt.ErrTupleMissingKey):
+		return Result{
+			Result:      resultInvalid,
+			Reason:      reasonMissingField,
+			TrustSource: string(resolver.SourceNone),
+			Details:     &Details{Field: extractTupleErrorField(inner)},
+		}, true
+	}
+	return Result{}, false
+}
+
+func extractTupleErrorField(err error) string {
+	if err == nil {
+		return ""
+	}
+	s := err.Error()
+	if idx := strings.LastIndex(s, ": "); idx >= 0 {
+		return s[idx+2:]
+	}
+	return ""
 }
 
 func parseInput(input VerifyInput) (receipt.Parsed, error) {

--- a/phase7-verify/schemas/output.schema.json
+++ b/phase7-verify/schemas/output.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://streamvc.live/schemas/macprovider-verify-output.schema.json",
   "title": "macprovider-verify output",
-  "description": "SPEC-015 v0.2 macprovider-verify one-line JSON output.",
+  "description": "SPEC-015 v0.3 macprovider-verify one-line JSON output. model_hash_verified is the v0.3 \u00a7M.3.2.1 tri-state.",
   "oneOf": [
     {
       "type": "object",
@@ -13,72 +13,193 @@
         "model_id",
         "signed_at",
         "trust_source",
-        "coordinator_host"
+        "coordinator_host",
+        "model_hash_verified"
       ],
       "properties": {
-        "result": { "const": "valid" },
-        "reason": { "const": "signature_and_canonicalization_match" },
-        "provider_id": { "type": ["string", "null"] },
-        "model_id": { "type": ["string", "null"] },
-        "signed_at": { "type": ["integer", "null"] },
-        "trust_source": { "enum": ["explicit_pubkey", "cache", "live"] },
-        "coordinator_host": { "type": ["string", "null"] },
+        "result": {
+          "const": "valid"
+        },
+        "reason": {
+          "const": "signature_and_canonicalization_match"
+        },
+        "provider_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "signed_at": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "trust_source": {
+          "enum": [
+            "explicit_pubkey",
+            "cache",
+            "live"
+          ]
+        },
+        "coordinator_host": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "warnings": {
           "type": "array",
-          "items": { "oneOf": [
-            {
-              "type": "object",
-              "required": ["kind", "live_pubkey", "coordinator_host"],
-              "properties": {
-                "kind": { "const": "explicit_vs_live_divergence" },
-                "live_pubkey": { "type": "string" },
-                "coordinator_host": { "type": "string" }
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "live_pubkey",
+                  "coordinator_host"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "explicit_vs_live_divergence"
+                  },
+                  "live_pubkey": {
+                    "type": "string"
+                  },
+                  "coordinator_host": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
               },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": ["kind", "reason"],
-              "properties": {
-                "kind": { "const": "live_check_skipped" },
-                "reason": { "enum": ["offline_flag", "network_unreachable", "provider_id_unresolvable"] }
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "reason"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "live_check_skipped"
+                  },
+                  "reason": {
+                    "enum": [
+                      "offline_flag",
+                      "network_unreachable",
+                      "provider_id_unresolvable"
+                    ]
+                  }
+                },
+                "additionalProperties": false
               },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": ["kind", "coordinator_host"],
-              "properties": {
-                "kind": { "const": "non_default_coordinator" },
-                "coordinator_host": { "type": "string" }
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "coordinator_host"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "non_default_coordinator"
+                  },
+                  "coordinator_host": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
               },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": ["kind", "unix_ts", "system_time", "delta_seconds"],
-              "properties": {
-                "kind": { "const": "clock_skew" },
-                "unix_ts": { "type": "integer" },
-                "system_time": { "type": "integer" },
-                "delta_seconds": { "type": "integer" }
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "unix_ts",
+                  "system_time",
+                  "delta_seconds"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "clock_skew"
+                  },
+                  "unix_ts": {
+                    "type": "integer"
+                  },
+                  "system_time": {
+                    "type": "integer"
+                  },
+                  "delta_seconds": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
               },
-              "additionalProperties": false
-            }
-          ] }
+              {
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "catalog_skipped_null_hash"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "catalog_skipped_legacy_receipt"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "model_hash_verified": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "receipt_version": {
+          "type": "string"
         }
       },
       "allOf": [
         {
           "if": {
-            "properties": { "trust_source": { "const": "explicit_pubkey" } },
-            "required": ["trust_source"]
+            "properties": {
+              "trust_source": {
+                "const": "explicit_pubkey"
+              }
+            },
+            "required": [
+              "trust_source"
+            ]
           },
           "then": {
-            "properties": { "coordinator_host": { "type": "null" } }
+            "properties": {
+              "coordinator_host": {
+                "type": "null"
+              }
+            }
           },
           "else": {
-            "properties": { "coordinator_host": { "type": "string" } }
+            "properties": {
+              "coordinator_host": {
+                "type": "string"
+              }
+            }
           }
         }
       ],
@@ -94,111 +215,286 @@
         "signed_at",
         "trust_source",
         "coordinator_host",
-        "details"
+        "details",
+        "model_hash_verified"
       ],
       "properties": {
-        "result": { "const": "invalid" },
+        "result": {
+          "const": "invalid"
+        },
         "reason": {
-          "description": "Reason values follow §10.4.2. bundle_pubkey_provider_mismatch is reserved for v0.3+ and is NOT emitted by v0.2 verifiers.",
           "enum": [
             "signature_verify_failed",
             "prompt_hash_mismatch",
             "output_hash_mismatch",
             "pubkey_not_endorsed",
             "previous_key_outside_grace_window",
-            "bundle_pubkey_provider_mismatch"
+            "bundle_pubkey_provider_mismatch",
+            "model_hash_mismatch",
+            "model_hash_required",
+            "catalog_signature_invalid",
+            "catalog_format_invalid",
+            "extra_field",
+            "missing_field"
           ]
         },
-        "provider_id": { "type": ["string", "null"] },
-        "model_id": { "type": ["string", "null"] },
-        "signed_at": { "type": ["integer", "null"] },
-        "trust_source": { "enum": ["explicit_pubkey", "cache", "live"] },
-        "coordinator_host": { "type": ["string", "null"] },
+        "provider_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "signed_at": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "trust_source": {
+          "enum": [
+            "explicit_pubkey",
+            "cache",
+            "live",
+            "none"
+          ]
+        },
+        "coordinator_host": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "details": {
           "type": "object",
-          "required": ["field", "receipt"],
           "properties": {
-            "field": { "enum": ["signature", "prompt_hash", "output_hash", "pubkey", "grace_window"] },
-            "computed": { "type": "string" },
-            "receipt": { "type": "string" },
+            "field": {
+              "type": "string"
+            },
+            "computed": {
+              "type": "string"
+            },
+            "receipt": {
+              "type": "string"
+            },
             "extra": {
-              "type": "object",
-              "properties": {
-                "unix_ts": { "type": "integer" },
-                "rotated_at": { "type": "integer" },
-                "expires_at": { "type": "integer" }
-              },
-              "additionalProperties": false
+              "type": "object"
+            },
+            "expected": {
+              "type": "string"
+            },
+            "actual": {
+              "type": "string"
+            },
+            "policy_flag": {
+              "type": "string"
+            },
+            "model_id": {
+              "type": "string"
+            },
+            "catalog_id": {
+              "type": "string"
+            },
+            "expires_at": {
+              "type": "string"
+            },
+            "receipt_version": {
+              "type": "string"
+            },
+            "cause": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "alg": {
+              "type": "string"
             }
-          },
-          "if": {
-            "properties": { "field": { "const": "signature" } },
-            "required": ["field"]
-          },
-          "then": {
-            "not": { "required": ["computed"] }
-          },
-          "else": {
-            "required": ["computed"]
           },
           "additionalProperties": false
         },
         "warnings": {
           "type": "array",
-          "items": { "oneOf": [
-            {
-              "type": "object",
-              "required": ["kind", "live_pubkey", "coordinator_host"],
-              "properties": {
-                "kind": { "const": "explicit_vs_live_divergence" },
-                "live_pubkey": { "type": "string" },
-                "coordinator_host": { "type": "string" }
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "live_pubkey",
+                  "coordinator_host"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "explicit_vs_live_divergence"
+                  },
+                  "live_pubkey": {
+                    "type": "string"
+                  },
+                  "coordinator_host": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
               },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": ["kind", "reason"],
-              "properties": {
-                "kind": { "const": "live_check_skipped" },
-                "reason": { "enum": ["offline_flag", "network_unreachable", "provider_id_unresolvable"] }
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "reason"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "live_check_skipped"
+                  },
+                  "reason": {
+                    "enum": [
+                      "offline_flag",
+                      "network_unreachable",
+                      "provider_id_unresolvable"
+                    ]
+                  }
+                },
+                "additionalProperties": false
               },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": ["kind", "coordinator_host"],
-              "properties": {
-                "kind": { "const": "non_default_coordinator" },
-                "coordinator_host": { "type": "string" }
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "coordinator_host"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "non_default_coordinator"
+                  },
+                  "coordinator_host": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
               },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": ["kind", "unix_ts", "system_time", "delta_seconds"],
-              "properties": {
-                "kind": { "const": "clock_skew" },
-                "unix_ts": { "type": "integer" },
-                "system_time": { "type": "integer" },
-                "delta_seconds": { "type": "integer" }
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "unix_ts",
+                  "system_time",
+                  "delta_seconds"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "clock_skew"
+                  },
+                  "unix_ts": {
+                    "type": "integer"
+                  },
+                  "system_time": {
+                    "type": "integer"
+                  },
+                  "delta_seconds": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
               },
-              "additionalProperties": false
-            }
-          ] }
+              {
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "catalog_skipped_null_hash"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "catalog_skipped_legacy_receipt"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "model_hash_verified": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "receipt_version": {
+          "type": "string"
         }
       },
       "allOf": [
         {
           "if": {
-            "properties": { "trust_source": { "const": "explicit_pubkey" } },
-            "required": ["trust_source"]
+            "properties": {
+              "trust_source": {
+                "enum": [
+                  "explicit_pubkey",
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "trust_source"
+            ]
           },
           "then": {
-            "properties": { "coordinator_host": { "type": "null" } }
+            "properties": {
+              "coordinator_host": {
+                "type": "null"
+              }
+            }
           },
           "else": {
-            "properties": { "coordinator_host": { "type": "string" } }
+            "properties": {
+              "coordinator_host": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "reason": {
+                "const": "catalog_signature_invalid"
+              }
+            },
+            "required": [
+              "reason"
+            ]
+          },
+          "then": {
+            "properties": {
+              "details": {
+                "type": "object",
+                "required": [
+                  "alg"
+                ],
+                "properties": {
+                  "alg": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            }
           }
         }
       ],
@@ -210,78 +506,253 @@
         "result",
         "reason",
         "trust_source",
-        "coordinator_host"
+        "coordinator_host",
+        "model_hash_verified"
       ],
       "properties": {
-        "result": { "const": "inconclusive" },
+        "result": {
+          "const": "inconclusive"
+        },
         "reason": {
           "enum": [
             "pubkey_unresolvable",
             "provider_id_not_in_pool",
-            "cache_stale_and_live_unreachable"
+            "cache_stale_and_live_unreachable",
+            "model_id_not_in_catalog",
+            "catalog_unreachable",
+            "catalog_expired",
+            "unknown_receipt_version"
           ]
         },
-        "provider_id": { "type": ["string", "null"] },
-        "model_id": { "type": ["string", "null"] },
-        "signed_at": { "type": ["integer", "null"] },
-        "trust_source": { "enum": ["explicit_pubkey", "cache", "live", "none"] },
-        "coordinator_host": { "type": ["string", "null"] },
+        "provider_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "signed_at": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "trust_source": {
+          "enum": [
+            "explicit_pubkey",
+            "cache",
+            "live",
+            "none"
+          ]
+        },
+        "coordinator_host": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "warnings": {
           "type": "array",
-          "items": { "oneOf": [
-            {
-              "type": "object",
-              "required": ["kind", "live_pubkey", "coordinator_host"],
-              "properties": {
-                "kind": { "const": "explicit_vs_live_divergence" },
-                "live_pubkey": { "type": "string" },
-                "coordinator_host": { "type": "string" }
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "live_pubkey",
+                  "coordinator_host"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "explicit_vs_live_divergence"
+                  },
+                  "live_pubkey": {
+                    "type": "string"
+                  },
+                  "coordinator_host": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
               },
-              "additionalProperties": false
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "reason"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "live_check_skipped"
+                  },
+                  "reason": {
+                    "enum": [
+                      "offline_flag",
+                      "network_unreachable",
+                      "provider_id_unresolvable"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "coordinator_host"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "non_default_coordinator"
+                  },
+                  "coordinator_host": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "unix_ts",
+                  "system_time",
+                  "delta_seconds"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "clock_skew"
+                  },
+                  "unix_ts": {
+                    "type": "integer"
+                  },
+                  "system_time": {
+                    "type": "integer"
+                  },
+                  "delta_seconds": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "catalog_skipped_null_hash"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "catalog_skipped_legacy_receipt"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "model_hash_verified": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "receipt_version": {
+          "type": "string"
+        },
+        "details": {
+          "type": "object",
+          "properties": {
+            "field": {
+              "type": "string"
             },
-            {
-              "type": "object",
-              "required": ["kind", "reason"],
-              "properties": {
-                "kind": { "const": "live_check_skipped" },
-                "reason": { "enum": ["offline_flag", "network_unreachable", "provider_id_unresolvable"] }
-              },
-              "additionalProperties": false
+            "computed": {
+              "type": "string"
             },
-            {
-              "type": "object",
-              "required": ["kind", "coordinator_host"],
-              "properties": {
-                "kind": { "const": "non_default_coordinator" },
-                "coordinator_host": { "type": "string" }
-              },
-              "additionalProperties": false
+            "receipt": {
+              "type": "string"
             },
-            {
-              "type": "object",
-              "required": ["kind", "unix_ts", "system_time", "delta_seconds"],
-              "properties": {
-                "kind": { "const": "clock_skew" },
-                "unix_ts": { "type": "integer" },
-                "system_time": { "type": "integer" },
-                "delta_seconds": { "type": "integer" }
-              },
-              "additionalProperties": false
+            "extra": {
+              "type": "object"
+            },
+            "expected": {
+              "type": "string"
+            },
+            "actual": {
+              "type": "string"
+            },
+            "policy_flag": {
+              "type": "string"
+            },
+            "model_id": {
+              "type": "string"
+            },
+            "catalog_id": {
+              "type": "string"
+            },
+            "expires_at": {
+              "type": "string"
+            },
+            "receipt_version": {
+              "type": "string"
+            },
+            "cause": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "alg": {
+              "type": "string"
             }
-          ] }
+          },
+          "additionalProperties": false
         }
       },
       "allOf": [
         {
           "if": {
-            "properties": { "trust_source": { "enum": ["explicit_pubkey", "none"] } },
-            "required": ["trust_source"]
+            "properties": {
+              "trust_source": {
+                "enum": [
+                  "explicit_pubkey",
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "trust_source"
+            ]
           },
           "then": {
-            "properties": { "coordinator_host": { "type": "null" } }
+            "properties": {
+              "coordinator_host": {
+                "type": "null"
+              }
+            }
           },
           "else": {
-            "properties": { "coordinator_host": { "type": "string" } }
+            "properties": {
+              "coordinator_host": {
+                "type": "string"
+              }
+            }
           }
         }
       ],

--- a/specs/AUDIT_SPEC_015_v0_3_IMPL_BUNDLE_PROMPT.md
+++ b/specs/AUDIT_SPEC_015_v0_3_IMPL_BUNDLE_PROMPT.md
@@ -1,0 +1,322 @@
+# AUDIT_SPEC_015_v0_3_IMPL_BUNDLE_PROMPT
+
+**Target:** the full SPEC-015 v0.3 IMPL bundle on branch `impl/spec-015-v0-3`
+(PR #131, head `26eeda9`), six step commits stacked on the v0.3.3 LOCKED SPEC
+commit `af53cb1`.
+
+**Base for diff:** `spec/015-receipts-v0-3` (the v0.3.3 LOCKED SPEC tip).
+The six IMPL commits in scope:
+
+```
+bdaeb9f Step 1: Swift provider 9-field receipt tuple
+3b86522 Step 2: coordinator /poolz catalog fields + 2 endpoints
+a22e3c8 Step 3: nginx /catalog/ routes + Pearl deploy gate
+5b5f401 Step 4: pure-Go verifier catalog parser + cache
+f92f7f5 Step 5: verifier CLI + 9-field algorithm + v0.3 schema
+26eeda9 Step 6: integration acceptance + cross-binary parity
+```
+
+**Normative anchors:**
+
+- `specs/SPEC-015-receipts.md` (v0.3.3 LOCKED at `specs/SPEC-015-receipts.md:3`).
+  Sections that MUST be enforced end-to-end: §M.0 (9-field tuple), §M.1.1
+  (back-compat), §M.1.2 (forward-incompat), §M.1.4 (unknown receipt_version),
+  §M.1.5 (JCS canonical order), §M.2.1 (request-start container provenance),
+  §M.2.2 (mid-swap defence-in-depth), §M.2.3 (null-hash semantics), §M.3.1
+  (CLI flag matrix), §M.3.1.1 (mutual-exclusion), §M.3.1.2
+  (--require-model-hash), §M.3.2 (8-step verifier algorithm), §M.3.2.1
+  (tri-state schema), §M.3.4 (three-band TTL cache), §M.4 (/poolz + 2
+  endpoints), §M.5 (AC-28..AC-42 + AC-32a), §M.6 (deferred to v0.4+).
+- `specs/SPEC-002-coordinator.md` (v1.6 candidate /poolz extension).
+- `beta/DECISION_CRITERIA.md` Entry 80 (2026-06-22): `RequireHashVerified`
+  deferral — MUST be preserved verbatim by this IMPL bundle.
+
+**Independent steps already passed locally:** each of the six step transcripts
+at `specs/SPEC-015-v0-3-IMPL-STEP_{1..6}-audit.md` ended at 0/0/0/0 across all
+3 lenses. This bundle audit is the cross-step / system-level pass — DO NOT
+re-audit individual step concerns the step transcripts already closed unless
+you find a NEW cross-step bug.
+
+## Output discipline (applies to every lens, every round)
+
+Append your section to `specs/SPEC-015-v0-3-IMPL-BUNDLE-audit.md` with a header
+of the form `## Lens — CODE — Round N` (or SECURITY / ARCHITECT). End every
+lens with two literal lines:
+
+```
+VERDICT: <PASS|FAIL> — <one-line rationale>
+
+COUNTS: CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n>
+```
+
+Findings format inside each lens section:
+
+```
+### <SEVERITY>-<ROUND>-<KIND>-<INDEX> <short-title>
+
+<file>:<line> — <claim with file:line evidence; quote ≤3 lines if needed>
+Why it matters: <one-sentence consequence>
+Suggested fix: <one-sentence remediation>
+```
+
+Sort findings within a section: CRITICAL → HIGH → MEDIUM → LOW.
+
+Severities (use these exactly):
+- **CRITICAL**: corrupts receipts on the wire, drops bytes the SPEC requires,
+  flips an Entry-80-preserved invariant, lets an attacker forge a valid v0.3
+  receipt against the verifier's stated checks, or breaks §M.1.2 forward-
+  incompat such that a locked v0.2 verifier would silently accept v0.3.
+- **HIGH**: violates a §M.* normative MUST, leaks a money-path invariant,
+  introduces an unbounded resource (memory, fd, goroutine, rate-limit
+  bypass), or makes a deploy gate false-pass on a real broken config.
+- **MEDIUM**: breaks a §M.* SHOULD, weakens a test such that a future
+  regression slips through, or leaves a deferred-to-v0.4+ semantic ambiguous
+  enough that an operator could misconfigure it.
+- **LOW**: style, doc drift, minor schema redundancy, naming, deferrable
+  follow-up.
+
+Target: **0 CRITICAL + 0 HIGH + 0 MEDIUM** across all 3 lenses. LOW
+findings are deferrable to a v0.4 cleanup.
+
+## Lens — CODE
+
+You are the **CODE** auditor. Read every changed file in the six commits above.
+Compose against the SPEC text, not your generic instincts.
+
+Focus areas (in priority order):
+
+1. **§M.0 tuple wire shape, end-to-end parity.** The 9-field JCS-canonical
+   tuple emitted by `phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift`
+   MUST byte-match what the verifier in `phase7-verify/internal/receipt/`
+   reconstructs for the signature check. Sample at least one non-null-hash
+   and one null-hash case. Verify both binaries agree on the UTF-16-codeunit
+   field-sort order (§M.1.5) and on JSON literal `null` for the missing
+   `model_hash` (§M.2.3).
+2. **§M.2.1 / §M.2.2 / §M.2.3 race + defence semantics.** Trace the
+   producer side: who sampled the `RuntimeSnapshot` whose hash is bound to
+   the receipt, and is that sample atomic with respect to the generation
+   it certifies? `ModelRuntimeServing.completeWithServedSnapshot` is the
+   gating call — confirm every receipt-emit path now flows through it.
+   `.warmSwapDisabled` MUST emit JSON `null` (not the absent field).
+   `.ambiguous` MUST emit `receipt_omitted: model_swap_violation` audit
+   row and NO header. Look for any path that still calls
+   `currentSnapshot()` outside the runtime actor and bypasses the
+   atomic-read.
+3. **§M.1.2 forward-incompat (AC-38).** The cross-binary parity test at
+   `phase7-verify/internal/receipt/v02_parity_test.go` re-implements the
+   v0.2.4 LOCKED parser inline. Verify the inline behaviour exactly
+   matches the v0.2.4 LOCKED parser at commit `99d0c1e` on `main`. Check
+   `git show 99d0c1e:phase7-verify/internal/receipt/receipt.go` to confirm.
+   Any drift here masks the forward-incompat invariant.
+4. **§M.1.4 unknown receipt_version dispatch order.** In the live parser
+   at `phase7-verify/internal/receipt/receipt.go`, the unknown-version
+   detection MUST happen BEFORE the strict v0.3 9-key shape validation.
+   Otherwise an unknown-version receipt would fail with `extra_field` or
+   `missing_field` instead of the correct `inconclusive: unknown_receipt_version`.
+   Trace the parser entry and confirm the parse order.
+5. **§M.3.2 8-step algorithm fidelity.** Read
+   `phase7-verify/internal/verify/catalog_check.go`. Each of steps 1..8
+   in §M.3.2 MUST be present and correctly ordered. Step 4 (catalog
+   cache) MUST compose with step 5 (catalog signature verify) such that
+   a cache-hit still produces `signature_verified=true` in the result.
+   Step 7 (model_id lookup) MUST use the case-folded `catalogModelKey`.
+6. **§M.3.4 three-band TTL.** Read
+   `phase7-verify/internal/cache/catalog/catalog_cache.go`. The three
+   bands (R > 6h → 6h; R ∈ [60s, 6h] → R - 60s; R < 60s → no cache)
+   MUST be enforced at write time, not just documented. Test
+   coverage MUST exercise each band.
+7. **§M.4 coordinator surface.** Read
+   `phase4-coordinator/internal/ws/server.go` (`handlePoolz`) and
+   `phase4-coordinator/internal/buyer/server.go` (`handleCatalogFile`,
+   `handleCatalogPubkey`). The new top-level /poolz fields MUST only
+   emit when `tier2.Active()` is true AND `CatalogPath` is configured
+   AND the catalog loaded AND the signature verified. The endpoint
+   handlers MUST be public (no Authorization required), rate-limited
+   via the receipt-keys bucket, and the catalog pubkey response MUST
+   serialize with `alg: "Ed25519"` (capital E) matching
+   `scripts/sign-catalog.go`.
+8. **Deploy gate scoping.** Read
+   `phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh`.
+   The `proxy_pass` assertion MUST be scoped to the `/catalog/` block
+   only (awk-based block extraction). A regression that changes the
+   proxy to operator port 8444 MUST be caught. Run the gate against a
+   crafted broken conf to confirm.
+9. **Manifest test invariants.** Read
+   `test/integration/spec015/v03_acceptance_manifest_test.go`. The
+   ≥2-evidence-anchor assertion MUST fire on a single-anchor entry.
+   AC-32a (defence-in-depth) MUST have its own entry, not be folded
+   into AC-32. Subtests MUST run for every AC.
+
+Produce at least one CRITICAL/HIGH/MEDIUM finding if any exists. If you
+cannot find one, write "No <SEVERITY> findings." literally — do NOT
+invent findings to fill the bucket.
+
+## Lens — SECURITY
+
+You are the **SECURITY** auditor. Threat model:
+
+- **Forge a valid v0.3 receipt** against a buyer-side verifier with no
+  catalog configured. (Should be impossible — non-null model_hash with
+  no catalog → `inconclusive` warning, NOT `valid`.)
+- **Forge a valid v0.3 receipt** against a buyer with `--catalog-url`
+  configured. (Should require Ed25519-signed catalog from the matching
+  operator pubkey.)
+- **Pearl operator key disclosure.** The runbook + deploy script MUST
+  treat the operator key as a secret, never log it, never embed in URLs.
+- **Catalog public-key trust root.** The CLI flag matrix MUST enforce
+  that `--catalog-pubkey` and `--catalog-pubkey-url` cannot both be set,
+  and that file-mode catalog use without an explicit pubkey requires
+  the catalog signature alg to match the embedded pubkey.
+- **Mid-swap container substitution.** A provider that disabled warm-
+  swap mid-request, OR loaded a new container mid-request, MUST NOT
+  emit a non-null model_hash for the OLD container — the §M.2.1 atomic
+  snapshot semantics block this. Confirm the runtime-actor sample
+  cannot be raced.
+- **Catalog endpoint amplification.** `/catalog/<id>` and
+  `/catalog/pubkey` are public + rate-limited; verify a single buyer
+  cannot exhaust the rate-limit bucket of another buyer (per-IP or
+  per-bucket?). Verify that an attacker cannot trigger a coordinator
+  full-disk-read via path traversal in `<catalog_id>`.
+- **Schema-level confusion attacks.** The CLI JSON output schema
+  enforces `model_hash_verified` tri-state on every variant. A
+  malicious verifier-fork could emit `model_hash_verified: "anything"`
+  and pass a downstream consumer's `JSON.parse(out).model_hash_verified
+  === true` check. The schema MUST reject any value not in
+  {true, false, null}.
+- **Deploy gate bypass.** The new `check_nginx_catalog_routes_test.sh`
+  gate runs BEFORE SSH/DNS phase. Verify the deploy script cannot be
+  invoked with a `SKIP_*=1` env flag that silently bypasses just this
+  gate. Verify that a stale local nginx conf cannot still ship if the
+  user `cp`s the previous-version conf into place.
+
+Focus areas (in priority order):
+
+1. **Operator-key handling end-to-end.** Grep the runbook + deploy
+   script for any path that prints or logs the operator key. Confirm
+   the smoke-check commands use `$OP` not the literal key.
+2. **CLI flag matrix mutual-exclusion (§M.3.1.1).** Read
+   `phase7-verify/internal/cli/cli.go`. Confirm: (a) `--catalog` and
+   `--catalog-url` are mutually exclusive; (b) `--catalog-pubkey` and
+   `--catalog-pubkey-url` are mutually exclusive; (c) `--offline` and
+   any `--catalog-*-url` flag is rejected; (d) `--require-model-hash`
+   without any catalog source is rejected with a clear error.
+3. **Catalog signature verification.** Read
+   `phase7-verify/internal/catalog/catalog.go`. Confirm: signature
+   alg literal is checked as `"Ed25519"` (capital E) ONLY, no
+   case-insensitive accept; signature byte-decode uses
+   `base64.RawURLEncoding` and rejects padded; pubkey byte-decode
+   matches; `ed25519.Verify` returning `false` produces
+   `ErrSignatureInvalid` with `ObservedAlg` stamped.
+4. **Cache poisoning + atomic-write.** Read
+   `phase7-verify/internal/cache/catalog/catalog_cache.go`. Confirm:
+   writes use temp-file + atomic-rename + 0600 perms; expired entries
+   are rejected on read; pubkey rotation invalidates (stale cache for
+   one pubkey MUST not satisfy a request for another).
+5. **Rate-limit bucket reuse.** Read
+   `phase4-coordinator/internal/buyer/server.go`. Confirm the new
+   catalog endpoints share the receipt-keys rate-limit bucket and
+   the bucket is keyed in a way that prevents one buyer from
+   starving another. Path traversal: confirm `<catalog_id>` is
+   validated against a whitelist (or sanitized) before any
+   filesystem read.
+6. **Schema enforcement on tri-state.** Read
+   `phase7-verify/schemas/output.schema.json`. Confirm
+   `model_hash_verified` is REQUIRED on every variant + the JSON
+   Schema type enumerates exactly `[boolean, null]` (or equivalent).
+   Confirm a schemavalidator run rejects `"anything"`,
+   `"yes"`, `1`, `[]`.
+7. **Entry 80 invariant preservation.** Grep
+   `phase4-coordinator/internal/config/config.go` and any tier2
+   config-load path. Confirm `RequireHashVerified` defaults to
+   `false` and no IMPL commit flips that default. Cross-reference
+   `beta/DECISION_CRITERIA.md:374`.
+8. **Deploy-script `SKIP_*` flags.** Read
+   `phase4-coordinator/dist/deploy-pearl-vps.sh`. Confirm the new
+   step 0 gate cannot be skipped via `SKIP_NGINX_CHECK=1` or
+   similar.
+9. **Cross-binary forward-incompat.** §M.1.2 SECURITY angle: a v0.2.4
+   verifier MUST NOT silently accept a v0.3 receipt. Confirm the
+   `parseTupleV02Locked` mirror is faithful to the locked release and
+   the assertions in `TestV02LockedParserRejectsV03Receipts` cover
+   both null and non-null v0.3 receipts.
+
+## Lens — ARCHITECT
+
+You are the **ARCHITECT** auditor. Focus on system-level invariants and
+contracts that span multiple components.
+
+Focus areas (in priority order):
+
+1. **End-to-end /poolz → /catalog → verifier flow.** A buyer with no
+   prior knowledge of the operator's catalog learns it via /poolz,
+   fetches the catalog file from /catalog/<id>, fetches the pubkey
+   from /catalog/pubkey, and verifies the receipt locally. Trace the
+   four hops:
+     - Provider emits `model_hash` bound to served snapshot (§M.2.1)
+     - Coordinator advertises `catalog_id`, `catalog_url`,
+       `catalog_pubkey_url` on /poolz (§M.4)
+     - Coordinator serves the file + pubkey on the two endpoints (§M.4)
+     - Verifier fetches both, verifies signature, looks up model_id,
+       compares hash (§M.3.2)
+   Confirm every hop is wired in this IMPL bundle, error paths exist,
+   and the contract names are stable across binaries.
+2. **§M.1.2 forward-incompat + provider/verifier rollout ordering.**
+   The runbook tells the operator to release the verifier BEFORE the
+   provider. Confirm the system can survive an out-of-order rollout
+   without silent acceptance of forged receipts. Confirm the SPEC says
+   what the operator runbook claims about §M.1.2.
+3. **Entry 80 preservation across the bundle.** v0.3 makes the
+   receipt BIND the hash; the coordinator's `RequireHashVerified` is
+   independent. Confirm no commit in the bundle accidentally
+   couples these. Confirm the operator runbook's "Entry 80 invariant"
+   section reflects this.
+4. **§M.6 deferred-to-v0.4+ scope discipline.** §M.6 lists 6 items
+   deferred (streaming receipts, multi-hash receipts, cross-catalog
+   federation, on-chain anchoring, quantization-aware, TUF). Confirm
+   no IMPL commit implements any of these. Confirm the runbook lists
+   the same six and no others.
+5. **Tagged-union architecture for receipt-version dispatch.** The
+   live parser at `phase7-verify/internal/receipt/receipt.go` MUST
+   detect version BEFORE strict shape validation, return a Tuple stub
+   carrying ReceiptVersion only for unknown versions, and let the
+   verify layer short-circuit to `inconclusive: unknown_receipt_version`.
+   This is the architecture round-2 CRIT fix from Step 5 — confirm it
+   survived through Step 6 unmodified.
+6. **AC manifest as living contract.** Each AC entry's evidence
+   anchors point at a file + grep pattern that MUST exist. The
+   manifest test asserts every named pattern exists in the named
+   file. Confirm the ≥2-anchor invariant + the per-AC pattern check
+   actually fire (run the test and inspect output).
+7. **Cross-step coupling.** Are there any places where two of the six
+   step commits touch the same file with subtly different assumptions?
+   Common offenders:
+     - Step 4 vs Step 5: catalog parser vs verifier integration
+     - Step 1 vs Step 6: receipt tuple emission vs cross-binary parity
+       test
+     - Step 2 vs Step 3: coordinator endpoints vs nginx routes
+   Trace each cross-step boundary and confirm the contract names line
+   up (field names, error envelopes, status codes).
+8. **Runbook composability with deploy script.** The runbook claims
+   the deploy script writes to `/opt/macprovider/coordinator.prev`.
+   Confirm by reading
+   `phase4-coordinator/dist/deploy-pearl-vps.sh`. Confirm the rollback
+   path the runbook gives composes cleanly with whatever state the
+   deploy script leaves on Pearl.
+9. **Operator runbook drift risk.** The runbook references file paths,
+   env vars, journald event names, smoke-check URLs. Grep each
+   reference against the actual code on this branch. Any drift = HIGH
+   (operator follows stale instruction during an incident).
+
+## Process
+
+For each lens:
+
+1. Read every file the lens names in your focus areas.
+2. For findings, cite `<file>:<line>` and quote ≤3 lines.
+3. Note what you DID confirm working (one paragraph at most).
+4. Run any test or gate you reference as evidence; quote the result.
+5. End with VERDICT + COUNTS.
+
+When ALL three lenses return 0 CRITICAL + 0 HIGH + 0 MEDIUM, the bundle
+is READY TO LOCK. Until then, the response invokes a fix round on the
+maintainer side, who will re-fire this prompt with a Round N+1 header.

--- a/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_1_PROMPT.md
+++ b/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_1_PROMPT.md
@@ -1,0 +1,247 @@
+# IMPL audit prompt — SPEC-015 v0.3 IMPL Step 1 (Swift provider 9-field receipt)
+
+You are auditing the Step 1 implementation of SPEC-015 v0.3 model-hash binding
+in `phase3-binary/` (Swift provider). The controlling spec is
+`specs/SPEC-015-receipts.md` v0.3.3 LOCKED (line 3). The build prompt is
+`specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md` Step 1.
+
+Output: APPEND a section to
+`specs/SPEC-015-v0-3-IMPL-STEP_1-audit.md` for your lens. If the file does
+not exist, create it. Use section headers
+"## Lens — CODE — Round R", "## Lens — SECURITY — Round R",
+"## Lens — ARCHITECT — Round R" so the operator can run three independent
+lenses and aggregate.
+
+You are running ONE lens per invocation. The operator tells you which lens
+in the `--agent-prompt` argument or this prompt's opening sentence. Default
+to **CODE** if unspecified.
+
+End your section with one of:
+
+  VERDICT: READY TO PROCEED | READY WITH FIX PASS | DESIGN ROUND NEEDED
+
+  COUNTS: CRITICAL=N HIGH=N MEDIUM=N LOW=N
+
+User policy: loop until **0 CRITICAL + 0 HIGH + 0 MEDIUM** for this step
+before proceeding to Step 2. LOW findings can be deferred.
+
+## Severity definitions
+
+- **CRITICAL** — would cause: receipt-signature divergence; v0.3 receipts
+  failing to verify against a correctly-written v0.3 verifier;
+  back-compat break for v0.1/v0.2 receivers; `model_hash` reading from
+  the wrong source (e.g. post-swap state at receipt-emission time rather
+  than request-start container); locked-spec line-3 version changes;
+  byte-shape mismatch with the §M.0 JCS canonical order; null-encoding
+  divergence from RFC 8785 §3.2.2.2.
+
+- **HIGH** — would cause: AC-28..AC-42 failure on a deterministic test;
+  validation gaps (`model_hash` accepted in wrong format, e.g. uppercase
+  hex, prefixed `sha256:`, wrong length); receipt-emission paths missing
+  the `model_hash` argument (e.g. error-receipt path emits with stale
+  hash); thread-safety / async ordering issues that could let a swap
+  observe a stale snapshot; missing tests for §M.0 strict 9-key shape.
+
+- **MEDIUM** — would cause: predictable bug in first month
+  (e.g. comment claims one thing, code does another); under-specified
+  edge cases not tested; code style / patterns that diverge from
+  existing house style; minor inconsistencies in the `model_hash`
+  validation (e.g. test corpus missing UTF-16 ASCII trap input);
+  documentation gaps that would mislead next implementer.
+
+- **LOW** — quality polish; deferrable to v0.3.x+1.
+
+## Critical constraints to honor
+
+1. **SPEC-015 v0.3.3 is LOCKED.** Any change required to the SPEC text
+   is a CRITICAL finding ("Step 1 silently demands SPEC amendment").
+2. **`phase3-binary` is the provider runtime.** Step 1 is the only step
+   that touches Swift. Coordinator + verifier work is Steps 2-5.
+3. **No locked-spec line-3 version shifts** in SPEC-001 / 002 / 005 /
+   006 / 008 / 010 / 011 / 013 — verify by
+   `git diff HEAD~ -- 'specs/SPEC-{001,002,005,006,008,010,011,013}-*.md'`.
+4. **RFC8785JCS.swift MUST NOT be amended** per SPEC-015 §M.1.5 — the
+   existing emitter handles the 9-field tuple, including JSON `null`
+   for `model_hash`, without changes.
+5. **The receipt-issuance contract is byte-identical to v0.1/v0.2 EXCEPT
+   for the §M.0 9-field tuple shape.** The header envelope
+   (`<base64(JCS(T))>.<base64(SIG)>`), the signature step, and the
+   `X-MacProvider-Receipt` header name are UNCHANGED.
+
+## Required reading (in order)
+
+1. `specs/SPEC-015-receipts.md` v0.3.3 — particularly §M.0 (9-field
+   tuple), §M.1.5 (no JCS amendment), §M.2.1 (request-start
+   provenance), §M.2.2 (mid-swap construction proof), §M.2.3
+   (null-hash semantics), §7.6 (error-receipt hash inheritance), §3.4
+   v0.3 wire-size envelope, §M.5 AC-28..AC-31 (Step 1-bound ACs).
+
+2. `phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift` — the
+   v0.3 9-field tuple constructor.
+
+3. `phase3-binary/Sources/macprovider-cli/HTTPServer.swift` — the
+   receipt-emission path (success + error + parse-error). Particularly:
+   the `Task.detached` block in `handleChatCompletions`; the
+   `receiptHeaderResult` / `errorReceiptHeaderResult` static helpers;
+   how `requestStartSnapshot` is threaded.
+
+4. `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift` — the
+   coordinator-WS-mediated receipt path. Particularly:
+   `buildReceiptHeader` and `processNonStreaming`.
+
+5. `phase3-binary/Sources/macprovider-cli/RFC8785JCS.swift` — verify
+   that no amendment is required (the existing `Value.null` and
+   `Value.string` cases already handle the new fields).
+
+6. `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift` —
+   particularly the `RuntimeSnapshot` struct and `currentSnapshot()`.
+   Verify that the snapshot captured by Step 1 IS the request-start
+   container per SPEC-011 §3.2 + R-3.4.1.
+
+7. `phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift`
+   — the v0.3 9-field tuple tests, parity test, null encoding, hash
+   validation, wire-size budget.
+
+8. `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md` Step 1 — the
+   build directive list. Diff against the implementation; missing
+   items = MAJOR finding.
+
+## Lens-specific categories
+
+### CODE lens — implementation correctness
+
+C.1 **Tuple shape (§M.0).** Verify the v0.3 tuple has exactly 9 keys.
+    Verify the dictionary literal in `ReceiptBuilder.tupleObject` lists
+    all 9 in any order (JCS sorts before emission), and verify there's
+    a test that asserts the emitted byte order is the §M.0 alphabetical
+    UTF-16 order.
+
+C.2 **`model_hash` validation.** Verify `isValidModelHash` rejects
+    every non-conforming input from §M.0 (uppercase hex, prefix,
+    wrong length, non-hex chars). Verify `nil` maps to `RFC8785JCS.Value.null`.
+
+C.3 **Snapshot threading.** Verify `requestStartSnapshot` is captured
+    BEFORE any state-mutating operation (e.g. `modelRuntime.complete`).
+    Verify it is threaded through every receipt-emission path
+    (success, model_not_loaded error, parse error). Verify the
+    `requestStartSnapshot.modelHash` is the value that lands in the
+    receipt, NOT a fresh snapshot at receipt-emission time.
+
+C.4 **Error-receipt inheritance (§7.6 + §M.2).** Verify
+    `errorReceiptHeaderResult` accepts `modelHash` and passes it to
+    `receiptHeaderResult`. Verify all callers (success-path,
+    apiError-catch, generic-catch, parse-error path) pass the right
+    source for `model_hash`.
+
+C.5 **Compatibility with legacy InferenceRelay test surface.**
+    `processNonStreaming` adds a `requestStartSnapshot` capture; verify
+    this composes with `acquireRequestHandle` / preflight semantics in
+    the relay's tier-2 + non-tier-2 paths.
+
+C.6 **Wire-size envelope (§3.4 v0.3).** Verify the new tests project
+    the receipt size budget per §3.4 (≤ ~1025 bytes header value).
+
+C.7 **House-style consistency.** Verify Swift property and method
+    naming, comments, error enum cases match neighbouring code style.
+    Particularly check `ReceiptBuilder.Error.invalidModelHash` is in
+    the same place as the existing cases.
+
+### SECURITY lens — cryptographic claims, threat model, attestation honesty
+
+S.1 **§M.0 wire shape integrity.** Verify the signature commits the
+    full 9-field canonical tuple (including the `null` byte sequence
+    for absent hash). Verify no path emits a 7-field tuple with the v0.3
+    code (which would be a downgrade attack vector). Verify
+    `receipt_version: "3"` is a STRING not an int.
+
+S.2 **`model_hash` provenance.** Verify the value sourced is the
+    request-start container hash per §M.2.1 + §M.2.2. Any path that
+    sources from a fresh snapshot at receipt-emission time is a
+    CRITICAL: a malicious provider could swap mid-response and emit a
+    receipt claiming the post-swap hash served the response.
+
+S.3 **`model_hash: null` attestation.** Verify the receipt SIGNS the
+    null literal — i.e. JCS canonical bytes for the tuple INCLUDE
+    `"model_hash":null` (not absence). Confirm via the parity test that
+    the canonical bytes are deterministic.
+
+S.4 **Mid-swap refusal (§M.2.2).** Verify the §M.2.2 defence-in-depth
+    path: the runtime cannot disambiguate which container served →
+    `receipt_omitted: model_swap_violation`. (The drain-cancelled path
+    already emits this audit reason for the SPEC-011 R-3.4.2 timeout;
+    verify that semantic is preserved.)
+
+S.5 **Error-receipt hash binding (§7.6 v0.3).** Verify error receipts
+    DO carry the request-start `model_hash` (the buyer is entitled
+    to know which weights were loaded when the error fired). A null
+    hash on a successful error-receipt issuance is a regression vs
+    §7.6 v0.3.
+
+S.6 **`RFC8785JCS.swift` invariants.** Verify no amendment to
+    `RFC8785JCS.swift` per §M.1.5. Verify the existing UTF-16 key
+    order produces alphabetical ASCII order for the new keys.
+
+S.7 **Receipt envelope size.** Verify the receipt header fits the
+    §3.4 v0.3 ≤ ~1025-byte budget AND the 4096-byte nginx headroom
+    cap. A receipt that exceeds the cap is silently truncated by
+    nginx and the buyer sees a malformed receipt.
+
+S.8 **Audit-log emissions.** Verify `ReceiptAudit.emitOmitted` /
+    `emitIssued` calls in error paths name the right reason and do
+    not leak hash material into the audit sink (the receipt is a
+    buyer-held proof; logging the hash duplicates the secret and
+    can leak provider identity).
+
+### ARCHITECT lens — cross-spec consistency, evolution arc, build-prompt coverage
+
+A.1 **BUILD prompt Step 1 coverage.** Diff every "What lands" item in
+    BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md Step 1 against the
+    implementation. Missing = MAJOR. Particularly:
+    - `ReceiptBuilder.swift` extended to construct the 9-field tuple
+    - `receipt_version: "3"` as a constant
+    - `model_hash` provenance from local SPEC-011 state
+    - `RFC8785JCS.swift` NOT amended
+    - Parity test for 9-field canonicalization
+    - `receipt_omitted: model_swap_violation` defence-in-depth path
+    - Raw 64-char lowercase hex format preserved
+    - Tests for: 9-field tuple parity, null model_hash, non-null,
+      `receipt_version == "3"`, ≤ 960-byte receipt size, error-receipt
+      hash inheritance, mid-swap refusal, no v0.1/v0.2 wire regression
+
+A.2 **Locked-spec line-3 versions unchanged.** Verify by `git diff
+    HEAD~ -- 'specs/SPEC-{001,002,005,006,008,010,011,013}-*.md'`.
+
+A.3 **Composes with v0.2 verifier release** (the BUILD prompt
+    Step 0 pre-flight asserts `phase7-verify/cmd/macprovider-verify/main.go`
+    exists). Step 1 should not regress any v0.2 surface; Step 5
+    (verifier extension) is where v0.3 verifier work lives.
+
+A.4 **§7.6 update is applied to existing AC-12 invariant.** The
+    v0.1.3 AC-12 (null-usage / error receipt invariant for
+    `error_model_not_loaded`) is preserved at the v0.1/v0.2 wire
+    shape; v0.3 AC-31 binds `model_hash` per §M.2. Verify both ACs
+    are testable from the existing test surface.
+
+A.5 **No new third-party dependencies in `phase3-binary/`** —
+    verify `Package.swift` is unchanged.
+
+A.6 **`receipt_omitted` reason enum** — verify the `modelSwapViolation`
+    case still exists (it was a v0.1/v0.2 placeholder; v0.3 promotes
+    it per §11). No new enum cases should be added that aren't named
+    in §11.
+
+A.7 **InferenceRelay (`processNonStreaming`) snapshot capture.**
+    Verify it composes cleanly with the tier-2 session and
+    `acquireRequestHandle` patterns; the snapshot capture happens
+    BEFORE `modelRuntime.complete`.
+
+## What MUST be in every audit report
+
+Each finding cites:
+- The source file + line range (`HTTPServer.swift:234-237`).
+- Severity (CRITICAL / HIGH / MEDIUM / LOW).
+- One-sentence problem statement.
+- One-paragraph elaboration with cross-references to the spec / code.
+- Suggested resolution direction (NOT a written diff; pointer at most).
+
+End with the VERDICT + COUNTS lines.

--- a/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_2_PROMPT.md
+++ b/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_2_PROMPT.md
@@ -1,0 +1,193 @@
+# IMPL audit prompt — SPEC-015 v0.3 IMPL Step 2 (Coordinator /poolz catalog + 2 endpoints)
+
+You are auditing the Step 2 implementation of SPEC-015 v0.3 model-hash binding
+in `phase4-coordinator/` (Go coordinator). The controlling spec is
+`specs/SPEC-015-receipts.md` v0.3.3 LOCKED. The build prompt is
+`specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md` Step 2.
+
+Output: APPEND a section to
+`specs/SPEC-015-v0-3-IMPL-STEP_2-audit.md` for your lens. Headers:
+"## Lens — CODE — Round R", "## Lens — SECURITY — Round R",
+"## Lens — ARCHITECT — Round R".
+
+You are running ALL THREE lenses (CODE, SECURITY, ARCHITECT). End each
+section with VERDICT + COUNTS (CRITICAL/HIGH/MEDIUM/LOW).
+
+User policy: loop until **0 CRITICAL + 0 HIGH + 0 MEDIUM** for this step
+before proceeding to Step 3. LOW findings can be deferred.
+
+## Severity definitions
+
+- **CRITICAL** — would cause: locked-spec line-3 version shift; SPEC-002
+  v1.4 `/poolz` shape regression (e.g. removed/renamed an existing
+  top-level key); operator-sensitive field leak in the new `/poolz`
+  catalog fields or the two new endpoints; catalog file served despite
+  failed signature verification or wrong catalog_id; `/catalog/pubkey`
+  emitting standard padded base64 instead of base64url-unpadded;
+  `/catalog/pubkey` emitting lowercase `"ed25519"` instead of the
+  capital-E `"Ed25519"` matching `scripts/sign-catalog.go:142-145` +
+  `phase4-coordinator/internal/tier2/catalog.go:470` + SPEC-015
+  v0.3.3 §M.4; missing operator authentication on the operator-only
+  surface (`/poolz` remains operator-only); operator authentication
+  added to the new public endpoints (which would defeat their public
+  trust posture).
+
+- **HIGH** — would cause: AC-39 / §M.4 acceptance failure on a
+  deterministic test; catalog fields emitted under wrong precondition
+  (e.g. when CatalogPath is set but catalog failed to load); URL
+  construction edge cases producing malformed absolute URLs (host
+  with port, IPv6 host, X-Forwarded-Host); 404 envelope schema
+  divergence from existing buyer endpoint pattern; rate-limit
+  semantics that share buckets across endpoints in a buyer-visible
+  way; missing tests for the §M.4 effectively-active condition's
+  three branches (no path / load failed / signature failed); SPEC-008
+  hash semantics regression (this step does NOT change them — verify).
+
+- **MEDIUM** — would cause: code that diverges from existing house
+  style; missing comments documenting the §M.4 / §M.3.3 trust posture;
+  under-specified edge cases not tested; minor inconsistencies in
+  error envelope `code` values; documentation gaps that would mislead
+  the Step 5 verifier author.
+
+- **LOW** — quality polish; deferrable to v0.3.x+1.
+
+## Critical constraints
+
+1. **SPEC-015 v0.3.3 is LOCKED.** Any required SPEC change = CRITICAL.
+2. **No locked-spec line-3 version shifts.** Verify via
+   `git diff main -- 'specs/SPEC-{001,002,005,006,008,010,011,013}-*.md'`.
+3. **SPEC-002 v1.4 `/poolz` shape MUST remain additive.** v0.3 only
+   adds three top-level optional fields per §M.4. Verify the existing
+   `pool` + `summary` top-level keys are byte-identical to v0.2
+   behavior.
+4. **Operator-only routing is preserved.** `/poolz` remains operator-
+   only (existing behavior); the two new catalog endpoints are public
+   on the buyer port. Verify they are NOT registered on the operator
+   port and DO NOT inherit operator auth.
+5. **Catalog parser unchanged.** This step reuses the existing
+   `tier2.Default().Active()`, `tier2.CatalogID()`, `cfg.CatalogPath`
+   reads. v0.3 does not modify the catalog parser; verify nothing in
+   `phase4-coordinator/internal/tier2/` was touched.
+
+## Required reading
+
+1. `specs/SPEC-015-receipts.md` v0.3.3 §M.4 (entire section), §M.3.3
+   trust boundary, §M.5 AC-39 (test commands).
+2. `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md` Step 2 (entire
+   step's "What lands" and "Tests" list).
+3. `phase4-coordinator/internal/config/config.go` — the new
+   `PublicCatalogBaseURL` field.
+4. `phase4-coordinator/internal/ws/server.go` — `handlePoolz` with the
+   new poolzResponse + `catalog_*` field-presence rule.
+5. `phase4-coordinator/internal/buyer/server.go` — the two new
+   handlers (`handleCatalogFile`, `handleCatalogPubkey`) and their
+   route registrations.
+6. `phase4-coordinator/internal/buyer/catalog_endpoints_test.go` —
+   the new endpoint tests.
+7. `phase4-coordinator/internal/ws/poolz_catalog_test.go` — the
+   /poolz catalog-fields tests.
+8. `phase4-coordinator/cmd/coordinator/main.go` lines 631-660 —
+   tier2ReloadFieldClasses table now includes
+   PublicCatalogBaseURL.
+9. `scripts/sign-catalog.go` lines 90, 142-145 — the catalog file
+   format the endpoints serve and the `Ed25519` alg + base64url-
+   unpadded pubkey shape.
+10. `phase4-coordinator/internal/tier2/catalog.go` lines 246-260,
+    334 — the `Active()` and `CatalogID()` accessors.
+11. `beta/DECISION_CRITERIA.md` Entry 80 — verify
+    `RequireHashVerified` is unchanged.
+12. The v0.2 §10.7 receipt-keys handler at
+    `phase4-coordinator/internal/buyer/server.go:694` — verify the
+    new handlers follow the same shape (rate limit, cache headers,
+    error envelope).
+
+## Lens-specific categories
+
+### CODE lens
+
+C.1  `/poolz` extension — verify the three fields appear ONLY under
+     the §M.4 three-condition rule (`tier2.Active()`), and the
+     existing `pool` + `summary` keys are unchanged.
+C.2  URL construction — when `PublicCatalogBaseURL` is empty, verify
+     the fallback derives from `r.Host` + scheme; verify trailing
+     slash handling; verify the URL form `<base>/catalog/<id>` and
+     `<base>/catalog/pubkey` match §M.4 exactly.
+C.3  `/catalog/<catalog_id>` — verify it serves the on-disk catalog
+     bytes verbatim with `Content-Type: application/json` and
+     `Cache-Control: public, max-age=300`; verify 404 when no catalog
+     OR wrong id; verify error envelope code is `catalog_not_found`.
+C.4  `/catalog/pubkey` — verify response shape `{"pubkey":"<43-char
+     base64url-unpadded>","alg":"Ed25519"}` matches §M.4 EXACTLY;
+     verify the `pubkey` value is `cfg.CatalogPublicKey` verbatim
+     (already in base64url form per `scripts/sign-catalog.go:90`).
+C.5  Rate limiting — verify the new endpoints share the existing
+     receipt-keys bucket OR define their own; verify 429 + Retry-
+     After: 1 on overage; verify behavior under concurrent requests.
+C.6  Error envelope — verify the new handlers use the same
+     `writeError` helper / JSON shape as the v0.2 receipt-keys
+     handler.
+C.7  PublicCatalogBaseURL config field — verify yaml tag, default
+     value handling, and the tier2ReloadFieldClasses entry.
+
+### SECURITY lens
+
+S.1  Operator-only `/poolz` auth UNCHANGED. Verify the new code
+     doesn't accidentally weaken `s.authorizedOperator(r)` checks.
+S.2  Public-trust posture of the two new endpoints — verify NO
+     authentication is added (this is intentional per §M.4 +
+     v0.2 §10.7 precedent), and that the rate limiter prevents
+     resource exhaustion.
+S.3  Catalog file leakage — verify the on-disk catalog file path is
+     a known operator-configured path (`cfg.CatalogPath`); verify no
+     path traversal possible via `<catalog_id>` URL param (the param
+     is compared to `tier2.CatalogID()`, NOT used as a filename).
+S.4  Catalog pubkey leakage — verify `cfg.CatalogPublicKey` is the
+     SAME key the coordinator already verifies catalogs against;
+     v0.3 publishes it to buyers per §M.3.3 trust posture. Verify
+     the operator's catalog signing PRIVATE key is NOT exposed.
+S.5  Catalog-fields presence rule — verify the three §M.4 fields
+     are ABSENT (not present-with-null) when the §M.4
+     effectively-active condition fails. Absence prevents buyers
+     from trusting a stale URL after a catalog rotation.
+S.6  Rate limit — verify the shared bucket prevents a single
+     attacker from exhausting either endpoint independently;
+     verify the IP key is the same `poolCheckClientKey(r)`
+     used by `handleReceiptKeys`.
+S.7  /poolz operator-sensitive fields — verify the new code DOES
+     NOT expose `endpoint_url`, `hostname`, etc. in the catalog
+     fields (those are catalog-level, not per-provider).
+S.8  Concurrent access — verify `tier2.Active()`, `tier2.CatalogID()`,
+     `cfg.CatalogPath` reads are safe under concurrent reload
+     (SIGHUP). The atomic Catalog pointer pattern from M3-8d should
+     handle this; verify no new race conditions.
+
+### ARCHITECT lens
+
+A.1  BUILD prompt Step 2 coverage — every "What lands" + "Tests"
+     item appears in the implementation.
+A.2  SPEC-002 v1.6 candidate annotation discipline — the three
+     `/poolz` fields and the two new endpoints follow the v1.4
+     receipt_pubkey / v1.5 receipt-keys candidate-annotation pattern
+     (additive, parser-optional, non-breaking).
+A.3  No locked-spec line-3 shifts.
+A.4  No changes to `phase4-coordinator/internal/tier2/`. The catalog
+     parser/verifier is reused, not amended.
+A.5  Entry 80 orthogonality — `RequireHashVerified` is unchanged;
+     this step is purely surface-level annotation for §M.4.
+A.6  Composition with v0.2 §10.7 — the new endpoints share auth
+     posture, rate-limit posture, cache header posture with
+     `/v1/receipt-keys/`. Inconsistency = MAJOR.
+A.7  Nginx proxy — Step 3 (not this step) handles the nginx config;
+     verify nothing in Step 2 implies a nginx change at deploy time.
+A.8  Test coverage gaps — verify AC-39 has both positive AND
+     negative tests (catalog active vs absent).
+
+## What MUST be in every finding
+
+- Source file + line range.
+- Severity tag.
+- One-sentence problem.
+- One-paragraph elaboration with file:line citations.
+- Suggested resolution direction (NOT a fix).
+
+End each lens with VERDICT + COUNTS.

--- a/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_3_PROMPT.md
+++ b/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_3_PROMPT.md
@@ -1,0 +1,95 @@
+# IMPL audit prompt — SPEC-015 v0.3 IMPL Step 3 (nginx + Pearl deploy gates)
+
+You are auditing the Step 3 implementation in `phase4-coordinator/dist/`.
+
+Output: APPEND to `specs/SPEC-015-v0-3-IMPL-STEP_3-audit.md`. Run all
+THREE lenses (CODE, SECURITY, ARCHITECT). End each with VERDICT + COUNTS.
+
+User policy: 0 CRITICAL + 0 HIGH + 0 MEDIUM target.
+
+## What landed in Step 3
+
+- `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf` — new
+  `location /catalog/ { proxy_pass 127.0.0.1:8443 ... }` block. Mirrors
+  the v0.2 `/v1/receipt-keys/` proxy. Declared BEFORE the catch-all
+  `location / { return 404; }`.
+- `phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh` —
+  static assertion that the `/catalog/` block exists, proxies to the
+  buyer port, and precedes the catch-all 404. Wired into
+  `Makefile`'s `test-dist` target.
+- `phase4-coordinator/dist/coordinator.yaml.example` — new `tier2:`
+  block with `public_catalog_base_url` populated for Pearl
+  (`https://coordinator.streamvc.live`) and commented placeholders for
+  the other §M.4 / SPEC-008 catalog config.
+
+## Severity definitions
+
+- **CRITICAL** — locked-spec edits; nginx config that opens an
+  unauthenticated operator-port surface or proxies to the wrong
+  internal port; deploy gate that silently exits 0 when the new
+  routes are missing; example yaml introducing a secret on disk.
+- **HIGH** — AC-39 deploy-time path not verifiable from the static
+  check; missing buffer-size / proxy-read-timeout settings on the new
+  block; ordering issue that would let nginx route `/catalog/` to the
+  catch-all 404; example yaml value that mismatches the locked SPEC
+  (`Ed25519` casing, base64url encoding).
+- **MEDIUM** — comment drift; missing comment explaining trust posture;
+  example yaml that doesn't follow the existing house comment style;
+  missing test entry in `Makefile`.
+- **LOW** — polish; deferrable.
+
+## Constraints
+
+1. SPEC-015 v0.3.3 LOCKED — no SPEC changes.
+2. No locked-spec line-3 shifts.
+3. `/poolz` remains operator-only at the nginx level (no public proxy
+   added to /poolz).
+4. The new `/catalog/` block uses the BUYER port (8443), NOT the
+   operator port (8444).
+5. The new block MUST be active BEFORE the catch-all 404; otherwise
+   nginx routes /catalog/ to the catch-all and the buyer-side
+   verifier cannot fetch the catalog.
+
+## Required reading
+
+1. `specs/SPEC-015-receipts.md` §M.4 (catalog endpoints).
+2. `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md` Step 3.
+3. `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf` —
+   the new `/catalog/` block and surrounding ordering.
+4. `phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh`
+   — the new static check.
+5. `phase4-coordinator/dist/test/check_nginx_receipt_buffers_test.sh`
+   — for comparison (the v0.2 pattern).
+6. `Makefile` `test-dist` target.
+7. `phase4-coordinator/dist/coordinator.yaml.example` — the new
+   `tier2:` block.
+8. `beta/DECISION_CRITERIA.md` Entry 80 — `RequireHashVerified`
+   default unchanged.
+
+## Categories
+
+CODE  C.1 nginx /catalog/ block — proxy_pass target, headers, timeout.
+      C.2 Block ordering — declared before catch-all 404.
+      C.3 Comment block — describes purpose, posture, anchor section
+          reference.
+      C.4 check_nginx_catalog_routes_test.sh — assertion completeness;
+          regex robustness against future comment-drift; correct
+          handling of the dual `location / {` blocks (port 80
+          redirect vs TLS catch-all 404).
+      C.5 Makefile wiring — new check in `test-dist`.
+      C.6 coordinator.yaml.example — tier2 section, comment style.
+
+SECURITY  S.1 No new auth-bypass surface — `/catalog/` is public per
+              §M.4 + v0.2 §10.7 precedent.
+          S.2 No private key surface — `/catalog/pubkey` returns only
+              the public key; example yaml leaves
+              `catalog_public_key` commented (operator fills in).
+          S.3 Block ordering — verify routing is unambiguous.
+
+ARCHITECT  A.1 Build-prompt Step 3 coverage.
+           A.2 No locked-spec shifts.
+           A.3 Composes with v0.2 nginx (`/v1/receipt-keys/`) shape.
+           A.4 Entry 80 orthogonality — yaml example does NOT flip
+               `require_hash_verified` to true.
+
+Each finding cites file:line. End each lens with VERDICT + COUNTS.

--- a/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_4_PROMPT.md
+++ b/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_4_PROMPT.md
@@ -1,0 +1,112 @@
+# IMPL audit prompt — SPEC-015 v0.3 IMPL Step 4 (Verifier catalog parser + cache)
+
+You are auditing Step 4 in `phase7-verify/`. Output: APPEND to
+`specs/SPEC-015-v0-3-IMPL-STEP_4-audit.md`. Three lenses (CODE,
+SECURITY, ARCHITECT). VERDICT + COUNTS per lens.
+
+User policy: 0 CRITICAL + 0 HIGH + 0 MEDIUM target.
+
+## What landed
+
+- `phase7-verify/internal/catalog/catalog.go` — pure-stdlib hand
+  translation of the coordinator's tier2 catalog parser/verifier.
+  `Parse(data)` returns a typed `*Catalog` with strict schema
+  validation (unknown fields rejected, sha256 pattern enforced,
+  duplicate model_id rejected on the canonical case-folded key).
+  `Verify(c, pubkey, now)` reconstructs the canonical body and
+  runs `ed25519.Verify`, then checks expiry with the 60-second
+  skew grace per §M.3.2 step 5. `Lookup(c, modelID)` returns the
+  catalog entry under `catalogModelKey` (lowercase + trim), mirroring
+  the coordinator's match function.
+- `phase7-verify/internal/cache/catalog/catalog_cache.go` —
+  on-disk cache implementing the §M.3.4 three-band TTL
+  (`ComputeTTL`). Cache keyed by SHA-256 of catalog URL; pubkey
+  rotation invalidates via comparison on read. Stale entries miss.
+
+## Severity definitions
+
+- **CRITICAL** — catalog accepted despite bad signature; pubkey
+  decoded with wrong base64 form (`StdEncoding` instead of
+  `RawURLEncoding`); alg accepted in lowercase; canonical body
+  marshalled in the wrong key order (would break verification of
+  catalogs produced by `scripts/sign-catalog.go`); third-party
+  imports introduced (breaks pure-stdlib discipline); cache hit
+  on rotated pubkey; cache hit on stale entry.
+- **HIGH** — AC-35 / §M.3.2 step 4 acceptance gap (the verifier
+  doesn't reject every documented failure mode); cache TTL band
+  off-by-one at the 60s / 6h boundary; expiry grace boundary
+  off-by-one at the 60s edge; case-fold lookup diverges from the
+  coordinator's `strings.ToLower(strings.TrimSpace(...))`.
+- **MEDIUM** — predictable bugs; documentation gaps; missing
+  parity test against the existing `scripts/sign-catalog.go`
+  canonical body shape.
+- **LOW** — polish; deferrable.
+
+## Constraints
+
+1. SPEC-015 v0.3.3 LOCKED.
+2. No locked-spec line-3 shifts.
+3. `phase7-verify/` MUST stay pure-stdlib (no third-party
+   imports). Verify by `cd phase7-verify && go list -m all`.
+4. The catalog parser MUST NOT import the coordinator's `tier2`
+   package — it's a hand translation per the v0.2 IMPL discipline.
+
+## Required reading
+
+1. `specs/SPEC-015-receipts.md` §M.3.1, §M.3.2 (8-step algorithm),
+   §M.3.4 (cache TTL), §M.3.3 (trust boundary).
+2. `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md` Step 4.
+3. `phase7-verify/internal/catalog/catalog.go` — the parser and
+   `Verify`.
+4. `phase7-verify/internal/catalog/catalog_test.go` — the test
+   surface (9 cases).
+5. `phase7-verify/internal/cache/catalog/catalog_cache.go` — the
+   cache implementation.
+6. `phase7-verify/internal/cache/catalog/catalog_cache_test.go` —
+   the TTL band + rotation + stale tests.
+7. `scripts/sign-catalog.go` — particularly lines 31 (sha256
+   field name), 42-49 (canonical body key order), 90 (pubkey
+   base64.RawURLEncoding), 142-145 (Ed25519 capital E), 145 (sig
+   RawURLEncoding).
+8. `phase4-coordinator/internal/tier2/catalog.go` — particularly
+   lines 470 (alg validator), 479-485 (pubkey + sig decoding),
+   559-560 (`catalogModelKey`).
+9. `phase7-verify/go.mod` — verify no new third-party imports.
+
+## Categories
+
+CODE  C.1 Parse strictness — unknown-field rejection, sha256 regex,
+          dup model_id detection on canonical key, RFC3339 strict.
+      C.2 Verify alg casing — only `"Ed25519"` accepted.
+      C.3 Pubkey + signature base64 forms — `RawURLEncoding` both.
+      C.4 Canonical body key order — matches sign-catalog.go.
+      C.5 Lookup case-fold — matches coordinator catalogModelKey.
+      C.6 Expiry grace — 60s boundary on either side tested.
+      C.7 Cache `ComputeTTL` — 3 bands tested at boundaries.
+      C.8 Cache rotation invalidation.
+      C.9 Cache stale invalidation.
+      C.10 Pure-stdlib discipline (no new imports).
+
+SECURITY  S.1 Signature verification cannot be bypassed.
+          S.2 Tampered body produces ErrSignatureInvalid.
+          S.3 Tampered signature produces ErrSignatureInvalid.
+          S.4 Expired catalog produces ErrExpired.
+          S.5 Cache cannot serve a stale-signed catalog.
+          S.6 Cache cannot serve under a rotated pubkey.
+          S.7 File mode 0600 on cache writes (no operator
+              secrets leak — the catalog is public, but pubkey
+              binding is part of the cache integrity).
+          S.8 No timing leaks in alg / sig comparisons (use
+              `ed25519.Verify`; do NOT compare alg with
+              non-constant-time helpers — but the alg is a
+              short ASCII string so this is informational).
+
+ARCHITECT  A.1 Build prompt Step 4 coverage.
+           A.2 No locked-spec shifts.
+           A.3 No third-party imports.
+           A.4 Catalog package does NOT import coordinator tier2.
+           A.5 Composition with Step 1 wire shape (catalog sha256
+               matches the SPEC-011 raw 64-hex form Step 1 binds).
+           A.6 Parity test against scripts/sign-catalog.go shape.
+
+Each finding cites file:line. End each lens with VERDICT + COUNTS.

--- a/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_5_PROMPT.md
+++ b/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_5_PROMPT.md
@@ -1,0 +1,115 @@
+# IMPL audit prompt — SPEC-015 v0.3 IMPL Step 5 (Verifier CLI + algorithm + schema)
+
+Audit Step 5 in `phase7-verify/`. Output: APPEND to
+`specs/SPEC-015-v0-3-IMPL-STEP_5-audit.md`. Three lenses. VERDICT +
+COUNTS per lens.
+
+User policy: 0 CRITICAL + 0 HIGH + 0 MEDIUM target.
+
+## What landed
+
+- `phase7-verify/internal/receipt/receipt.go` — `Tuple` extended with
+  `ReceiptVersion`, `ModelHash`, `ModelHashPresent`, `ModelHashNull`.
+  v0.3 detection by PRESENCE of `receipt_version` field (NOT by field
+  count). Strict 9-key shape for v0.3; strict 7-key shape for legacy.
+  `model_hash` parsing distinguishes `null` literal from string
+  (validated to 64-lowercase-hex pattern).
+- `phase7-verify/internal/cli/cli.go` — 5 new flags:
+  `--catalog`, `--catalog-url`, `--catalog-pubkey`, `--catalog-pubkey-url`,
+  `--require-model-hash`. §M.3.1 mutually-exclusive validation
+  (`--catalog` ↔ `--catalog-url`; pubkey pair; catalog implies pubkey;
+  URL incompatible with `--offline`). §M.3.1.2 fail-closed flag plumbed
+  through.
+- `phase7-verify/internal/verify/verify.go` — `Result` extended with
+  `ModelHashVerified` tri-state pointer + `ReceiptVersion` field;
+  `VerifyOpts` extended with `Catalog CatalogOpts` + `RequireModelHash`.
+  Output `MarshalJSON` always emits `model_hash_verified` (true / false /
+  null) per §M.3.2.1 contract. New reason enum values + new warning kinds.
+- `phase7-verify/internal/verify/catalog_check.go` — 8-step §M.3.2
+  algorithm: catalog fetch (file / URL); pubkey fetch (file / URL);
+  catalog Parse + Verify (signature + expiry); §M.3.2 step 6 case-folded
+  Lookup; §M.3.2 step 7 hash equality. §M.1.1 legacy back-compat (skip
+  catalog, emit `catalog_skipped_legacy_receipt` warning). §M.2.3
+  null-hash path (skip catalog, emit `catalog_skipped_null_hash` warning).
+  §M.3.1.2 `--require-model-hash` fail-closed on null-hash AND legacy.
+- 6 new unit tests covering the catalog-check branches; existing
+  v0.1/v0.2 tests preserved (full suite green).
+
+## Severity definitions
+
+- **CRITICAL** — catalog accepted under wrong base64 form; alg accepted
+  lowercase; legacy receipt accepted as v0.3 (or vice versa); hash
+  mismatch reported as `valid`; `model_hash_verified=true` returned
+  when catalog check did not actually pass step 8; `--offline` ignored
+  for URL-fetch flags; flag-combination matrix accepts a documented
+  exit-64 case; third-party imports introduced.
+- **HIGH** — AC-28..AC-42 / AC-32a / §M.5 acceptance gap; reason enum
+  values diverge from §M.3.2.1; `model_hash_verified` emitted as
+  absent (instead of `null`) when catalog check did not run; warning
+  kinds emitted under wrong condition; receipt parser accepts a tuple
+  with extra v0.3 fields under a legacy header AND vice versa;
+  forward-compat (§M.1.4) unknown receipt_version path missing.
+- **MEDIUM** — predictable bugs; missing tests on flag-combination
+  edges; documentation gaps; output schema JSON drift; missing details
+  block fields on the new reason values.
+- **LOW** — polish.
+
+## Constraints
+
+1. SPEC-015 v0.3.3 LOCKED — no SPEC changes.
+2. No locked-spec line-3 shifts.
+3. `phase7-verify/` MUST stay pure-stdlib.
+4. v0.1/v0.2 verifier behavior preserved (back-compat per §M.1.1).
+5. The catalog package and cache from Step 4 are reused, not modified.
+
+## Required reading
+
+1. `specs/SPEC-015-receipts.md` §M.0 (tuple), §M.1.1 (back-compat),
+   §M.1.2 (forward-incompat), §M.1.4 (unknown version), §M.2.3
+   (null-hash), §M.3.1 (CLI flags), §M.3.1.1 (flag matrix), §M.3.1.2
+   (--require-model-hash), §M.3.2 (8-step algorithm), §M.3.2.1
+   (schema amendment), §M.3.3 (trust boundary), §M.5 AC-28..AC-42.
+2. `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md` Step 5.
+3. `phase7-verify/internal/receipt/receipt.go` — v0.3 Tuple +
+   `parseTuple` with version detection.
+4. `phase7-verify/internal/cli/cli.go` — `parseOptions` + new flags +
+   `buildCatalogOpts`.
+5. `phase7-verify/internal/verify/verify.go` — Verify entry point +
+   Result MarshalJSON.
+6. `phase7-verify/internal/verify/catalog_check.go` — the catalog
+   pipeline.
+7. `phase7-verify/internal/verify/catalog_check_test.go` — coverage.
+8. `phase7-verify/internal/verify/enum_drift_test.go` — verify the
+   new enum values don't break the drift fence.
+
+## Categories
+
+CODE   C.1 v0.3 vs legacy version detection in `parseTuple`.
+       C.2 Strict 9-key shape; reject extra / missing keys.
+       C.3 model_hash null vs string parsing.
+       C.4 CLI flag matrix (§M.3.1.1) — all documented exit-64 cases.
+       C.5 8-step algorithm short-circuit ordering.
+       C.6 model_hash_verified tri-state in JSON output.
+       C.7 reason enum extension matches §M.3.2.1.
+       C.8 warning kinds emitted under correct conditions.
+       C.9 Catalog fetch network behaviour (5s budget, no retry).
+       C.10 Pubkey fetch decode (base64url + capital-E alg).
+       C.11 §M.1.4 unknown receipt_version forward-compat path.
+
+SECURITY  S.1 Cannot bypass catalog check by mis-flagging.
+          S.2 `--require-model-hash` cannot be silently disabled.
+          S.3 Null-hash receipt cannot become valid+hash-attested.
+          S.4 Hash mismatch cannot become `valid`.
+          S.5 Catalog signature failure cannot be hidden.
+          S.6 Network fetches honour `--offline`.
+          S.7 No third-party imports.
+
+ARCHITECT  A.1 Build-prompt Step 5 coverage.
+           A.2 No locked-spec shifts.
+           A.3 Composition with Step 4 catalog + cache.
+           A.4 Composition with v0.2 receipt path (back-compat).
+           A.5 §M.3.2.1 schema field-name contract on JSON output.
+           A.6 §M.3.1.1 flag matrix correctness vs spec table.
+           A.7 Forward-compat §M.1.4 unknown-version path.
+
+Each finding cites file:line. End each lens with VERDICT + COUNTS.

--- a/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_6_PROMPT.md
+++ b/specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_6_PROMPT.md
@@ -1,0 +1,93 @@
+# IMPL audit prompt — SPEC-015 v0.3 IMPL Step 6 (integration acceptance + cross-binary parity)
+
+Audit Step 6 — the v0.3 integration acceptance gate + operator runbook.
+Output: APPEND to `specs/SPEC-015-v0-3-IMPL-STEP_6-audit.md`. Three
+lenses. VERDICT + COUNTS per lens.
+
+User policy: 0 CRITICAL + 0 HIGH + 0 MEDIUM target.
+
+## What landed in Step 6
+
+- `test/integration/spec015/v03_acceptance_manifest_test.go` — extends
+  the existing acceptance manifest with the 15 v0.3 ACs (AC-28..AC-42)
+  plus AC-32a. Each AC names a runnable command, the CI job, and at
+  least 2 evidence anchors (file + grep pattern). The manifest test
+  asserts every named pattern exists in the named file.
+- `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md` — operator-
+  facing deploy runbook covering pre-deploy checklist, coordinator
+  binary + nginx + config, smoke-checks for `/poolz` + `/catalog/...`,
+  provider/buyer rollout choreography (cv0.2 verifier reads v0.3 as
+  invalid per §M.1.2), monitoring, rollback, Entry 80 invariant
+  preservation, and v0.4+ deferred candidates.
+
+## Severity definitions
+
+- **CRITICAL** — locked-spec edit; AC manifest claims coverage of an
+  AC that the cited evidence does not actually establish (e.g. evidence
+  anchor points at a file that doesn't run the right test); operator
+  runbook telling the operator to flip Entry 80 `RequireHashVerified`;
+  runbook telling the operator to ship the provider binary before the
+  verifier binary (§M.1.2 forward-incompat would silently break buyers).
+- **HIGH** — v0.3 AC manifest entry missing a runnable command, a CI
+  job mapping, or evidence anchors; runbook step that doesn't compose
+  with the v0.2 deploy script; missing rollback path for a new
+  surface (e.g. /catalog/ endpoint).
+- **MEDIUM** — manifest text wording errors; runbook gaps in monitoring
+  / Pearl journald grep lines; missing reference to the v0.3 SPEC
+  section for each AC.
+- **LOW** — polish.
+
+## Constraints
+
+1. SPEC-015 v0.3.3 LOCKED — no SPEC changes.
+2. No locked-spec line-3 shifts.
+3. Entry 80 (`RequireHashVerified` deferral) MUST be preserved
+   verbatim. v0.3 IMPL does NOT flip the flag.
+4. The v0.3 IMPL is COMPLETE in terms of code surfaces; Step 6 is
+   acceptance + handoff to operator + future v0.4 staging.
+
+## Required reading
+
+1. `specs/SPEC-015-receipts.md` §M.5 (AC-28..AC-42), §M.6 (deferred
+   items including Entry 80 preservation), §M.4 (catalog surface).
+2. `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md` Step 6 +
+   final deliverables list.
+3. `test/integration/spec015/v03_acceptance_manifest_test.go` —
+   the new manifest.
+4. `test/integration/spec015/acceptance_manifest_test.go` — v0.2
+   pattern to compare against.
+5. `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md` — the
+   runbook.
+6. `phase4-coordinator/dist/deploy-pearl-vps.sh` — current
+   deploy script (does the runbook compose with it?).
+7. `beta/DECISION_CRITERIA.md` Entry 80 — verify the runbook
+   preserves it verbatim.
+8. The Step 1-5 audit transcripts at
+   `specs/SPEC-015-v0-3-IMPL-STEP_{1..5}-audit.md`.
+
+## Categories
+
+CODE  C.1 v0.3 AC manifest covers exactly AC-28 through AC-42 +
+          AC-32a (16 ACs total).
+      C.2 Each AC has runnable command + CI job + evidence anchors.
+      C.3 Every evidence pattern actually exists in the named file
+          (manifest test asserts this).
+      C.4 Manifest test compiles AND runs `t.Run(AC-NN)` for each.
+
+SECURITY  S.1 Runbook does NOT recommend flipping
+              `RequireHashVerified` (Entry 80 preservation).
+          S.2 Runbook orders verifier release BEFORE provider
+              binary distribution per §M.1.2 forward-incompat.
+          S.3 Smoke-check commands do not leak secrets (operator
+              key handling).
+          S.4 Rollback path is documented.
+
+ARCHITECT  A.1 Build prompt Step 6 coverage.
+           A.2 No locked-spec line-3 shifts (existing audit gates
+               this; verify the v0.3 IMPL bundle does not regress).
+           A.3 v0.4+ candidate list matches §M.6 deferred items.
+           A.4 README.md update plan documented in runbook.
+           A.5 Composition with M3-2 / Entry 80 / Entry 84
+               (the SPEC v0.3 LOCK entry) — no contradictions.
+
+Each finding cites file:line. End each lens with VERDICT + COUNTS.

--- a/specs/SPEC-015-v0-3-IMPL-BUNDLE-audit.md
+++ b/specs/SPEC-015-v0-3-IMPL-BUNDLE-audit.md
@@ -1,0 +1,163 @@
+# SPEC-015 v0.3 IMPL bundle audit — cross-step / system-level
+
+Branch: `impl/spec-015-v0-3` (PR #131)
+Head: `26eeda9` (Step 6) atop SPEC v0.3.3 LOCK `af53cb1`
+
+Audit prompt: [specs/AUDIT_SPEC_015_v0_3_IMPL_BUNDLE_PROMPT.md](AUDIT_SPEC_015_v0_3_IMPL_BUNDLE_PROMPT.md)
+
+Per-step transcripts (already 0/0/0/0 at lock):
+- [Step 1](SPEC-015-v0-3-IMPL-STEP_1-audit.md)
+- [Step 2](SPEC-015-v0-3-IMPL-STEP_2-audit.md)
+- [Step 3](SPEC-015-v0-3-IMPL-STEP_3-audit.md)
+- [Step 4](SPEC-015-v0-3-IMPL-STEP_4-audit.md)
+- [Step 5](SPEC-015-v0-3-IMPL-STEP_5-audit.md)
+- [Step 6](SPEC-015-v0-3-IMPL-STEP_6-audit.md)
+
+---
+
+## Lens — CODE — Round 1
+
+No CRITICAL findings.
+
+No HIGH findings.
+
+No MEDIUM findings.
+
+No LOW findings.
+
+Validation evidence:
+- Read the CODE focus files across producer, coordinator, verifier, cache, deploy gate, and manifest paths changed by `af53cb1..26eeda9`.
+- Confirmed v0.3 tuple parity for non-null and null-hash fixtures: Swift emits exactly nine JCS-sorted fields, `model_hash:null` is preserved for the null case, and the Go verifier parses the same wire shape without re-canonicalizing signed bytes.
+- Confirmed live parser dispatch detects unknown non-`"3"` `receipt_version` before strict v0.3 shape validation, preserving §M.1.4.
+- Confirmed `parseTupleV02Locked` mirrors the locked `99d0c1e` seven-key parser closely enough for AC-38: v0.3 null and non-null receipts reject as `ErrTupleExtraKey`, while a legacy seven-field tuple accepts.
+- Confirmed §M.3.2 catalog flow composes cache hit, parse, signature verification, case-folded model lookup, hash comparison, and `model_hash_verified=true` only after successful verification.
+- Confirmed §M.3.4 TTL bands are enforced at cache write time and covered by tests for `R > 6h`, `R in [60s, 6h]`, and `R < 60s`.
+- Confirmed `/poolz` catalog fields are gated by an effectively active signed catalog, and `/catalog/<id>` plus `/catalog/pubkey` are public, receipt-key-bucket rate-limited, and emit `alg:"Ed25519"`.
+- Confirmed the nginx deploy gate scopes `proxy_pass` to the `/catalog/` block and fails a crafted broken config that points `/catalog/` at `127.0.0.1:8444`.
+- Confirmed the acceptance manifest has AC-28..AC-42 plus a separate AC-32a entry, at least two evidence anchors per AC, and per-AC subtests.
+
+Commands run:
+- `bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh`
+- crafted broken nginx config with `/catalog/` proxying to `127.0.0.1:8444` -> expected gate failure
+- `cd phase7-verify && go test ./internal/receipt ./internal/verify ./internal/cache/catalog ./internal/catalog ./internal/cli -count=1`
+- `cd phase4-coordinator && go test ./internal/ws ./internal/buyer ./internal/tier2 -count=1`
+- `cd test/integration && go test ./spec015 -run 'TestSpec015V03Acceptance' -count=1`
+- `cd test/integration && go test ./spec015 -run 'TestSpec015V03AcceptanceManifestCoversAC28ThroughAC42' -count=1`
+- `cd phase3-binary && swift test --filter 'ReceiptBuilderTests|HTTPServerReceiptTests|InferenceRelayTests/testRelayNonStreamingEndFrameCarriesV03Receipt|JCSGoldenFixtureTests'`
+
+VERDICT: PASS — no cross-step CODE defects found against SPEC-015 v0.3 §M.0..§M.6 focus areas.
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0
+
+## Lens — SECURITY — Round 1
+
+### CRITICAL-1-SECURITY-1 No-catalog non-null model_hash path still returns valid
+
+phase7-verify/internal/verify/catalog_check.go:82 — v0.3 receipts with a non-null `model_hash` and no catalog flags return an empty catalog verdict:
+```
+if !opts.Catalog.Enabled {
+	return v
+}
+```
+phase7-verify/internal/verify/verify.go:377 — the empty catalog verdict falls through to `base.Result = resultValid`, so a non-null hash can produce `valid` with `model_hash_verified:null` instead of the threat-model-required inconclusive result. The same gap reaches `--require-model-hash` because `phase7-verify/internal/cli/cli.go:267` only derives catalog presence from `--catalog` / `--catalog-url` and never rejects `--require-model-hash` without a catalog source.
+Why it matters: A provider or attacker holding a receipt key can assert an arbitrary non-null `model_hash` and still obtain a `valid` v0.3 verifier result when the buyer did not configure a catalog, which is exactly the no-catalog forge-a-receipt scenario this SECURITY lens says must be impossible.
+Suggested fix: Treat v0.3 non-null `model_hash` with no catalog source as `inconclusive` (or reject `--require-model-hash` without catalog flags at CLI parse time) and add regression coverage for non-null v0.3 receipts with no catalog flags, including the `--require-model-hash` case.
+
+### HIGH-1-SECURITY-2 Catalog endpoint rate-limit buckets collapse behind nginx loopback
+
+phase4-coordinator/internal/buyer/server.go:828 — the public catalog endpoints share `allowReceiptKeys`, which keys solely from `poolCheckClientKey(r)`:
+```
+key := poolCheckClientKey(r)
+now := s.now()
+s.receiptKeysMu.Lock()
+```
+phase4-coordinator/internal/buyer/server.go:902 — that helper returns only the host from `r.RemoteAddr`, while `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:170` proxies `/catalog/` through local `127.0.0.1:8443` and places the real buyer IP only in `X-Real-IP` / `X-Forwarded-For`. In production, every public buyer therefore shares the loopback bucket.
+Why it matters: One buyer can exhaust the shared `/catalog/*` and `/v1/receipt-keys/*` bucket for other buyers, defeating the prompt's endpoint-amplification isolation requirement.
+Suggested fix: Replace `poolCheckClientKey` / `allowReceiptKeys` keying with a loopback-proxy-aware helper equivalent to `remoteIPForUnauthSemaphore`, honoring `X-Real-IP` only when the immediate remote is loopback, and add a regression proving two different `X-Real-IP` values behind `127.0.0.1` get independent buckets.
+
+No MEDIUM findings.
+
+No LOW findings.
+
+Validation evidence:
+Read the SECURITY focus files named by the prompt across CLI flag validation, catalog signature verification, catalog cache, coordinator buyer endpoints, output schema, Entry 80 config/defaults, deploy gate, runbook, and v0.2 forward-incompat parity. Confirmed operator-key smoke examples use `$OP` rather than a literal key; catalog signatures require exact `Ed25519` and raw URL-safe base64; cache writes use `0600` temp file plus rename, reject stale entries, and bind entries to pubkey; `/catalog/<id>` does not use the path segment for filesystem paths; schema branches require `model_hash_verified` with boolean-or-null type; Entry 80 stays false by default; deploy step 0 runs the nginx catalog gate without a `SKIP_NGINX_CHECK` bypass; and v0.2 locked parity rejects null and non-null v0.3 receipts.
+
+Commands run:
+- `cd phase7-verify && go test ./internal/cli ./internal/verify ./internal/catalog ./internal/cache/catalog ./internal/receipt -count=1`
+- `cd phase7-verify && go test ./internal/cli -run 'TestV03SchemaConformance|TestSchemaValidationValid|TestSchemaRejectsExtraProperty|TestSchemaRejectsTrustSourceCoordinatorHostMismatches' -count=1`
+- `cd phase7-verify && go test ./internal/receipt -run TestV02LockedParserRejectsV03Receipts -count=1`
+- `cd phase7-verify && go test ./internal/catalog ./internal/cache/catalog -count=1`
+- `cd phase4-coordinator && go test ./internal/buyer -run 'TestCatalogEndpointRateLimited|TestPoolCheckRateLimitIgnoresSpoofedXForwardedFor' -count=1`
+- `cd phase4-coordinator && go test ./internal/buyer -run 'TestCatalogFileServesActiveCatalogBytes|TestCatalogFile404OnUnknownCatalogID|TestCatalogPubkeyReturnsBase64URLPubkeyAndCapitalEd25519|TestCatalogEndpointRateLimited' -count=1`
+- `cd phase4-coordinator && go test ./internal/config -run 'TestDefault|TestRequireHashVerified|TestCatalog' -count=1`
+- `bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh`
+
+VERDICT: FAIL — the bundle still has a no-catalog v0.3 hash fail-open and a public catalog endpoint bucket-isolation defect.
+
+COUNTS: CRITICAL=1 HIGH=1 MEDIUM=0 LOW=0
+
+## Lens — SECURITY — Round 2
+
+No CRITICAL findings.
+
+No HIGH findings.
+
+No MEDIUM findings.
+
+No LOW findings.
+
+Validation evidence:
+- HIGH-1-SECURITY-2 is closed in `phase4-coordinator/internal/buyer/server.go:823-929`: `allowReceiptKeys` and `allowPoolCheck` both key through `poolCheckClientKey`, and `poolCheckClientKey` now honors `X-Real-IP` only when the immediate `r.RemoteAddr` host parses as loopback. Direct non-loopback callers still key on the parsed `RemoteAddr` host, so spoofed `X-Real-IP` does not split their bucket.
+- Confirmed there is no catalog-specific alternate key path: `/catalog/pubkey`, `/catalog/{catalog_id}`, and `/v1/receipt-keys/{provider_id}` all reach the same receipt-keys bucket via `allowReceiptKeys`; `/poolz` reaches the same loopback-aware helper via `allowPoolCheck`.
+- Confirmed production nginx supports the trust boundary assumed by the fix: `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:149-175` proxies `/v1/receipt-keys/` and `/catalog/` to loopback buyer port `127.0.0.1:8443` and overwrites `X-Real-IP` with `$remote_addr`.
+- Confirmed the new regression fires on the intended properties in `phase4-coordinator/internal/buyer/catalog_endpoints_test.go:178-219`: buyer A behind `127.0.0.1` exhausts only its own `X-Real-IP` bucket, buyer B behind the same loopback gets a fresh bucket, and a direct non-loopback caller cannot escape by changing `X-Real-IP`.
+- Re-traced the related SECURITY surfaces without finding a new cross-step defect: catalog signatures still require exact `Ed25519` and raw URL-safe base64 (`phase7-verify/internal/catalog/catalog.go:195-226`); cache writes remain temp-file plus rename with `0600`, expiry rejection, and pubkey-rotation invalidation (`phase7-verify/internal/cache/catalog/catalog_cache.go:117-169`); schema branches require `model_hash_verified` and type it as boolean-or-null (`phase7-verify/schemas/output.schema.json:17,168-172,219,432-435,510,670-673`); Entry 80 default remains `RequireHashVerified: false` (`phase4-coordinator/internal/config/config.go:344-349`); deploy step 0 runs the catalog nginx gate with no `SKIP_NGINX_CHECK` bypass (`phase4-coordinator/dist/deploy-pearl-vps.sh:87-95`).
+- Re-traced mid-swap receipt provenance: HTTP and relay receipt paths use `completeWithServedSnapshot` for successful receipts and refuse `.ambiguous` provenance with `model_swap_violation` omission (`phase3-binary/Sources/macprovider-cli/HTTPServer.swift:257-285,650-666`; `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:281-320,350-360`; `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:388-410`).
+- Did not re-litigate CRIT-1-SECURITY-1: the locked SPEC text cited in the fix pass says `--require-model-hash` without catalog flags is legal and yields `valid` with `model_hash_verified:null` when signature checks (`specs/SPEC-015-receipts.md:2988-2994`), and the tri-state row lists "no catalog flags supplied" as a `null` cause (`specs/SPEC-015-receipts.md:3120`).
+
+Commands run:
+- `cd phase4-coordinator && go test ./internal/buyer -run 'TestCatalogEndpointRateLimited|TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback' -count=1`
+- `cd phase4-coordinator && go test ./internal/buyer -run '^TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback$' -count=1 -v`
+- `cd phase4-coordinator && go test ./internal/buyer -count=1`
+- `cd phase7-verify && go test ./internal/cli -run 'TestV03SchemaConformance|TestSchema' -count=1`
+- `cd phase7-verify && go test ./internal/catalog ./internal/cache/catalog ./internal/receipt -count=1`
+- `cd phase7-verify && go test ./internal/verify -count=1`
+- `cd phase4-coordinator && bash dist/test/check_nginx_catalog_routes_test.sh`
+- `swift test --package-path phase3-binary --filter 'HTTPServerReceiptTests|InferenceRelayTests/testRelayNonStreamingEndFrameCarriesV03Receipt|ReceiptBuilderTests'`
+
+VERDICT: PASS — HIGH-1 bucket isolation is fixed and no new SECURITY cross-step defects were found in the bounded Round 2 re-trace.
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0
+
+## Lens — ARCHITECT — Round 1
+
+No CRITICAL findings.
+
+No HIGH findings.
+
+No MEDIUM findings.
+
+No LOW findings.
+
+Validation evidence:
+Confirmed the end-to-end /poolz -> /catalog -> verifier contract is wired across the bundle: provider receipt construction binds `model_hash` to the served runtime snapshot via `completeWithServedSnapshot` (`phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:388-410`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:257-285`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:281-320`); `/poolz` emits `catalog_id`, `catalog_url`, and `catalog_pubkey_url` from the active catalog contract (`phase4-coordinator/internal/ws/server.go:2733-2774`); nginx and the buyer server expose `/catalog/<catalog_id>` and `/catalog/pubkey` on the buyer port with the same public route names (`phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:158-176`, `phase4-coordinator/internal/buyer/server.go:393-405`, `phase4-coordinator/internal/buyer/server.go:743-805`); and the verifier resolves pubkey + catalog bytes, verifies signature/expiry, performs case-folded model lookup, and only then sets `model_hash_verified=true` (`phase7-verify/internal/verify/catalog_check.go:88-185`, `phase7-verify/internal/catalog/catalog.go:173-257`).
+
+Confirmed the §M.1.2 rollout contract and Entry 80 orthogonality: the SPEC requires locked v0.1/v0.2 verifiers to reject v0.3 receipts as invalid and tells buyers to coordinate verifier upgrades with provider upgrades (`specs/SPEC-015-receipts.md:2652-2675`), matching the runbook's verifier-before-provider choreography (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:85-101`). Entry 80 remains independent: the default is still `RequireHashVerified: false` (`phase4-coordinator/internal/config/config.go:344-349`), the decision log preserves the deferral (`beta/DECISION_CRITERIA.md:374`), the SPEC says v0.3 binds receipts without flipping coordinator route/reject policy (`specs/SPEC-015-receipts.md:2571-2580`), and the runbook repeats the invariant (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:153-155`).
+
+Confirmed §M.6 scope discipline and tagged-union receipt-version dispatch. The runbook's v0.4+ candidate list matches the prompt's six deferred implementation areas and states none are landing in v0.3 (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:164-173`); no changed file implements streaming receipts, multi-hash receipts, cross-catalog federation, on-chain anchoring, quantization-aware verification, or TUF/signed-root trust. The receipt parser detects unknown non-"3" `receipt_version` before strict shape validation and returns a version-only tuple stub (`phase7-verify/internal/receipt/receipt.go:207-228`); the verifier then short-circuits to `inconclusive: unknown_receipt_version` before signature or catalog work (`phase7-verify/internal/verify/verify.go:252-268`).
+
+Confirmed the AC manifest is a living contract and the cross-step seams line up. The manifest has AC-28..AC-42 plus a distinct AC-32a sentinel (`test/integration/spec015/v03_acceptance_manifest_test.go:14-211`), enforces at least two evidence anchors and pattern existence per AC (`test/integration/spec015/v03_acceptance_manifest_test.go:213-248`), and separately checks the 28..42 coverage range (`test/integration/spec015/v03_acceptance_manifest_test.go:250-268`). Step-overlap review showed the expected coupling only: Step 4 catalog parser is consumed by Step 5 verifier integration, Step 1 receipt tuple is covered by Step 6 cross-binary parity, and Step 2 coordinator endpoints are routed by Step 3 nginx/deploy gate; field names, status codes, alg casing, and error envelope names matched across those boundaries.
+
+Confirmed runbook composability and drift posture. The deploy script snapshots `/opt/macprovider/coordinator` to `/opt/macprovider/coordinator.prev` with explicit ownership/mode before upload (`phase4-coordinator/dist/deploy-pearl-vps.sh:220-233`), matching the rollback commands in the runbook (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:116-147`), and installs the full nginx site after the pre-SSH catalog-route gate (`phase4-coordinator/dist/deploy-pearl-vps.sh:87-95`, `phase4-coordinator/dist/deploy-pearl-vps.sh:313-326`). Runbook references to `GATEWAY_CONFIG`, `public_catalog_base_url`, `/poolz`, `/catalog/pubkey`, `/catalog/<id>`, `catalog_loaded`, `model_hash_verified`, `catalog_signature_invalid`, `macprovider-coordinator`, and the rollback path were checked against code or files on this branch; no stale operator instruction was found.
+
+Commands run:
+- `cd test/integration && go test ./spec015 -run 'TestSpec015V03AcceptanceCriteria|TestSpec015V03AcceptanceManifestCoversAC28ThroughAC42' -count=1 -v` -> AC-28 through AC-42 and AC-32a subtests all PASS.
+- `cd phase4-coordinator && go test ./internal/ws ./internal/buyer ./internal/tier2 -run 'TestPoolzEmitsCatalogFieldsWhenCatalogActive|TestPoolzOmitsCatalogFieldsWhenCatalogNotConfigured|TestPoolzOmitsCatalogFieldsWhenCatalogLoadFails|TestCatalogFileServesActiveCatalogBytes|TestCatalogFile404OnUnknownCatalogID|TestCatalogPubkeyReturnsBase64URLPubkeyAndCapitalEd25519|TestCatalogEndpointRateLimited|TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback|Test.*Hash|Test.*Catalog' -count=1 -v` -> PASS.
+- `cd phase7-verify && go test ./internal/receipt ./internal/verify ./internal/catalog ./internal/cache/catalog -run 'TestV02LockedParserRejectsV03Receipts|TestCatalogCheck|TestVerify|TestComputeTTLBands|TestPutSkipsBelowMinTTL|TestGetMissOnPubkeyRotation|TestGetMissOnStaleEntry' -count=1 -v` -> PASS.
+- `cd phase7-verify && go test ./internal/receipt ./internal/verify ./internal/cli -run 'Unknown|ReceiptVersion|V03' -count=1 -v` -> PASS, including `TestV03SchemaConformance/unknown_receipt_version`.
+- `swift test --package-path phase3-binary --filter 'ReceiptBuilderTests|HTTPServerReceiptTests/testHTTPSuccessReceiptCarriesWarmSwapHash|HTTPServerReceiptTests/testHTTPReceiptRefusedOnAmbiguousProvenance|HTTPServerReceiptTests/testHTTPAmbiguousProvenanceEmitsReceiptOmittedAudit|InferenceRelayTests/testRelayNonStreamingEndFrameCarriesV03Receipt|JCSGoldenFixtureTests'` -> 13 selected tests passed.
+- `bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh` -> `ok: SPEC-015 v0.3 §M.4 catalog routes present in nginx conf`.
+
+VERDICT: PASS — no cross-step ARCHITECT defects found; the system-level contracts, rollout ordering, Entry 80 preservation, runbook/deploy composition, and AC manifest all hold for the v0.3 IMPL bundle.
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0

--- a/specs/SPEC-015-v0-3-IMPL-STEP_1-audit.md
+++ b/specs/SPEC-015-v0-3-IMPL-STEP_1-audit.md
@@ -1,0 +1,263 @@
+## Lens — CODE — Round 1
+
+### Finding CODE-R1-HIGH-1 — HIGH — AC-42 defence-in-depth refusal is not implemented as specified
+
+Source: `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:256-267`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:282-285`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:307-315`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:193-211`, `specs/SPEC-015-receipts.md:2798-2808`, `specs/SPEC-015-receipts.md:3618-3640`.
+
+The implementation only emits `receipt_omitted: model_swap_violation` for `DrainCancelledError`, and does not implement the required synthetic/defence-in-depth refusal for an ambiguous request-start hash slot.
+
+SPEC-015 §M.2.2 requires the provider to refuse receipt emission when the runtime detects swap-in-progress at receipt-emission time and cannot disambiguate which container served the response; AC-42 requires a synthetic harness where the request-start-hash slot is unset/corrupted and proves both no `X-MacProvider-Receipt` header and a `model_swap_violation` audit row. The HTTP success path always passes `snapshot.modelHash` into receipt construction, while the relay success path always passes `requestStartSnapshot.modelHash`; neither receipt-emission helper has enough state to distinguish “valid warm-swap-disabled null” from “ambiguous/corrupted request-start slot.” The existing test only covers a drain-cancelled 503 with `receiptBuilder: nil`, which is the SPEC-011 timeout path, not the AC-42 defence-in-depth path.
+
+Suggested resolution direction: carry enough request-start provenance into receipt emission to identify an ambiguous/corrupted capture separately from warm-swap-disabled `nil`, refuse with `.modelSwapViolation` in that case, and add the AC-42 synthetic positive/negative tests.
+
+### Finding CODE-R1-HIGH-2 — HIGH — AC-31 non-null error-receipt hash inheritance is not covered by tests
+
+Source: `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:289-295`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:321-327`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:53-75`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:77-99`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:323-357`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:503-518`, `specs/SPEC-015-receipts.md:3469-3478`.
+
+The HTTP error-receipt implementation threads `requestStartSnapshot.modelHash`, but the tests only exercise nil-hash fixtures and do not prove non-null warm-swap error receipts inherit the same hash a success receipt would carry.
+
+AC-31 requires null-usage/error receipts to set `model_hash` per §M.2, including the warm-swap-on non-null hash case. The current code path appears directionally correct because both API-error and generic-error catch blocks pass the captured request-start hash into `errorReceiptHeaderResult`, but the test runtime is constructed without a `modelHash`, and the direct `errorReceiptHeader` test also passes `modelHash: nil`. A regression that replaced the error path’s hash with nil would still pass the current Step 1 tests.
+
+Suggested resolution direction: add a warm-swap-on/non-null HTTP error-receipt test that configures a 64-lowercase-hex runtime hash, triggers `model_not_loaded`/generic inference failure after request acceptance, decodes the receipt, and asserts the error receipt’s `model_hash` equals the success-path request-start hash.
+
+### Finding CODE-R1-HIGH-3 — HIGH — The v0.3 wire-size budget test allows receipts larger than the Step 1 contract
+
+Source: `phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift:159-180`, `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:115-123`, `specs/SPEC-015-receipts.md:1144-1160`.
+
+The receipt-size test asserts `<= 1100` bytes even though the build prompt requires `<= 960` bytes and the locked spec projects a v0.3 envelope of approximately `<= 1025` bytes with 4096-byte hard headroom.
+
+This is a deterministic acceptance-test gap: a receipt that exceeds the locked §3.4 projection could pass `testV03ReceiptFitsWireSizeBudget` today. The implementation also correctly enforces the 4096-byte hard cap in `RouterHandler`, but that cap is not a substitute for the Step 1 projection check because nginx headroom and the v0.3 expected envelope budget are separate constraints.
+
+Suggested resolution direction: align the XCTest threshold with the Step 1 prompt/§3.4 budget, or explicitly document and justify any threshold above 960 with a locked-spec-compatible worst-case calculation.
+
+VERDICT: READY WITH FIX PASS
+
+COUNTS: CRITICAL=0 HIGH=3 MEDIUM=0 LOW=0
+
+## Lens — SECURITY — Round 1
+
+### Finding SECURITY-R1-HIGH-1 — HIGH — Ambiguous mid-swap receipt emission is not fail-closed
+
+Source: `phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift:77-84`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:256-267`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:307-315`, `specs/SPEC-015-receipts.md:2771-2808`, `specs/SPEC-015-receipts.md:3618-3640`.
+
+The receipt-emission layer has no fail-closed branch for the §M.2.2 “runtime cannot disambiguate which container served” condition, so an injected ambiguous/corrupted request-start hash can still flow into a signed receipt as `model_hash: null` or as whatever stale hash the caller provides.
+
+For normal requests, the provider-status in-flight counter plus runtime drain semantics make old-container and new-container success receipts distinguishable by construction. The security issue is the explicit defence-in-depth case that v0.3 requires for future regressions: when the request-start capture is missing or corrupted during a swap-in-progress state, the provider must omit the receipt and audit `model_swap_violation` rather than sign a misleading hash/null claim. `ReceiptBuilder` faithfully signs null when asked, and the current HTTP/relay helpers do not carry an ambiguity marker, so the signer cannot distinguish an honest warm-swap-disabled null from an unsafe unknown hash.
+
+Suggested resolution direction: represent request-start hash provenance as an explicit state (`captured(hash)`, `warmSwapDisabled`, `ambiguousSwapViolation`) instead of a bare `String?`, and make receipt emission refuse the ambiguous state before calling `ReceiptBuilder.build`.
+
+### Finding SECURITY-R1-HIGH-2 — HIGH — Error-receipt hash binding lacks non-null security regression coverage
+
+Source: `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:658-674`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:53-99`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:323-357`, `specs/SPEC-015-receipts.md:1701-1727`, `specs/SPEC-015-receipts.md:3469-3478`.
+
+The implementation comments and call sites intend for error receipts to inherit the request-start `model_hash`, but the security test surface does not exercise the non-null hash case required by AC-31.
+
+The buyer’s security claim for a null-usage provider error is that the provider signed which weights were warm when the error fired. The current tests prove tokens/output hash/signature behavior for error receipts, but only with `modelHash: nil`; they do not catch a regression where warm-swap-on error receipts silently downgrade to null or use a fresh emission-time hash. Because SPEC-015 treats error-receipt hash binding as an attestation property, this needs a deterministic non-null regression test before Step 2.
+
+Suggested resolution direction: add a test that triggers an eligible error after a request-start snapshot with a 64-lowercase-hex hash, then verifies the signed tuple includes that exact hash and that audit records still omit hash material.
+
+VERDICT: READY WITH FIX PASS
+
+COUNTS: CRITICAL=0 HIGH=2 MEDIUM=0 LOW=0
+
+## Lens — ARCHITECT — Round 1
+
+### Finding ARCHITECT-R1-HIGH-1 — HIGH — Step 1 build-prompt acceptance coverage is incomplete
+
+Source: `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:103-123`, `phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift:81-123`, `phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift:159-180`, `phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift:131-191`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:53-99`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:193-211`.
+
+The implementation covers the core 9-field builder path, but the Step 1 “What lands” and “Tests” lists are not fully satisfied before audit closure.
+
+The missing coverage is material to the v0.3 evolution contract: there is no golden fixture corpus under `phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/` for null and non-null 9-field canonical bytes; the size test uses `<= 1100` instead of the prompt’s `<= 960`; AC-31 is not tested with a non-null warm-swap hash on error receipts; AC-42’s synthetic ambiguous mid-swap no-header path is not implemented/tested; the relay’s non-streaming receipt path is not decoded/asserted in `InferenceRelayTests`; and the v0.1/v0.2 isolated 7-field JCS regression sanity check is not present. The locked-spec line-3 diff, `RFC8785JCS.swift` diff, and `Package.swift` diff are clean, so this does not require spec/dependency redesign, but it does block Step 1’s audit gate.
+
+Suggested resolution direction: add the missing Step 1 acceptance tests and fixtures first, then make only the implementation changes needed for AC-42 provenance/refusal to pass those tests.
+
+VERDICT: READY WITH FIX PASS
+
+COUNTS: CRITICAL=0 HIGH=1 MEDIUM=0 LOW=0
+
+## Lens — CODE — Round 2
+
+Round 1 closure check: CODE-R1-HIGH-2 is closed by the warm-swap-on non-null HTTP error receipt test; CODE-R1-HIGH-3 is closed by the `<= 1025` §3.4 assertion. CODE-R1-HIGH-1 is only partially closed: the `.ambiguous` source refuses before receipt construction, but the implementation still does not prove the signed hash is the same snapshot `ModelRuntime.complete` actually used, and the AC-42 test does not assert the required audit row.
+
+### Finding CODE-R2-CRITICAL-1 — CRITICAL — Receipt hash capture can diverge from the generation snapshot
+
+Source: `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:231-251`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:261-272`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:281-291`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:313-322`, `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:358-367`, `specs/SPEC-015-receipts.md:2769-2796`.
+
+The HTTP and relay paths capture `requestStartSnapshot` outside `ModelRuntime.complete`, but `complete` immediately takes its own fresh actor-isolated snapshot and registers the in-flight request from that later snapshot, so an actor interleaving can sign hash A while generation actually ran on hash B.
+
+SPEC-015 §M.2.2 requires every receipt to commit to "the hash of the model that started generation for this request." In the current shape, `HTTPServer` captures a snapshot at lines 238-242 and later calls `modelRuntime.complete` at line 251; `InferenceRelay` does the same at lines 286-291. `ModelRuntime.complete` then independently captures the snapshot that actually drives validation, in-flight registration, and generation at lines 363-367. Because each `await` to the actor is a separate turn, a warm-swap can complete between the caller snapshot and the `complete` snapshot. That produces exactly the locked-spec failure class: the signed tuple's `model_hash` is not necessarily the container that served the response.
+
+Suggested resolution direction: make non-streaming use one runtime-owned request handle/snapshot for both generation and receipt binding, mirroring the streaming path's `acquireRequestHandle` / `preflight` / `stream` pattern, or have `complete` return the served `RuntimeSnapshot` alongside `CompletionResult` and bind the receipt from that returned snapshot. Add a regression test that forces a swap between caller-side snapshot capture and generation-start to prove the signed hash matches the served snapshot.
+
+### Finding CODE-R2-HIGH-1 — HIGH — AC-42 refusal test does not prove the required audit emission
+
+Source: `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:501-528`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:283-285`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:311-313`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:343-345`, `specs/SPEC-015-receipts.md:3618-3640`.
+
+The new AC-42 negative test calls the helper and checks `nil`, but it does not exercise the response path that emits `receipt_omitted: model_swap_violation` into `ReceiptAudit`.
+
+AC-42 requires two observable outcomes for the synthetic ambiguous state: no `X-MacProvider-Receipt` header and a matching audit sink row. The helper-level test proves `.ambiguous` returns no header, but the audit row is emitted by the surrounding HTTP switch statements, not by `receiptHeader` itself. A regression that forgot to call `ReceiptAudit.emitOmitted` for `.modelSwapViolation` in one of those HTTP paths would still pass the new test, leaving the Round 1 AC-42 audit-log gap open.
+
+Suggested resolution direction: add an HTTP-level AC-42 test under `ReceiptAudit.withSink` that drives `.ambiguous` through the same response path used by non-streaming success/error handling, asserts the header is absent, and asserts the captured audit JSON has `event="receipt_omitted"` and `reason="model_swap_violation"`.
+
+VERDICT: DESIGN ROUND NEEDED
+
+COUNTS: CRITICAL=1 HIGH=1 MEDIUM=0 LOW=0
+
+## Lens — SECURITY — Round 2
+
+Round 1 closure check: SECURITY-R1-HIGH-2 is closed for HTTP by `testHTTPErrorReceiptInheritsWarmSwapHash`; SECURITY-R1-HIGH-1 is only partially closed because `.ambiguous` now refuses before signing, but the signer can still receive a stale caller-side hash that differs from the snapshot actually used for generation.
+
+### Finding SECURITY-R2-CRITICAL-1 — CRITICAL — A swap interleaving can create a signed receipt for the wrong weights
+
+Source: `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:238-251`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:261-272`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:286-322`, `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:363-367`, `specs/SPEC-015-receipts.md:2775-2796`.
+
+The cryptographic tuple can commit to a model hash captured before generation while `ModelRuntime.complete` later generates from a different snapshot, making the signed receipt an incorrect attestation of the weights served.
+
+This is not a verifier or canonicalization problem; the signature faithfully signs the wrong claim. The security property in §M.2.2 depends on the request-start snapshot being the same snapshot that generation uses and the same snapshot protected by SPEC-011 in-flight tracking. Here the caller-side `currentSnapshot()` and `ModelRuntime.complete`'s internal `currentSnapshot()` are separate actor operations. If a malicious or unlucky provider swap completes in the gap, the buyer receives a valid Ed25519 receipt whose `model_hash` does not identify the model that produced the output.
+
+Suggested resolution direction: move receipt provenance into the runtime-owned in-flight handle or return the served snapshot from the generation call, then construct the receipt only from that served snapshot. Treat any mismatch between caller-intended model and served snapshot as a refusal/error before signing.
+
+### Finding SECURITY-R2-HIGH-1 — HIGH — The defence-in-depth audit trail is not tested end-to-end
+
+Source: `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:501-528`, `phase3-binary/Sources/macprovider-cli/ReceiptAudit.swift:74-99`, `specs/SPEC-015-receipts.md:2798-2808`, `specs/SPEC-015-receipts.md:3630-3637`.
+
+The ambiguous-provenance test validates no receipt header but never verifies the required `receipt_omitted` audit record, so the security evidence for §M.2.2's fail-closed path is incomplete.
+
+The audit sink intentionally does not log hash material, and the existing `ReceiptAudit` payload shape is appropriate. The missing piece is coverage: AC-42 requires the row to exist when the receipt is refused. Since `ReceiptAudit.emitOmitted` is called outside the helper, a helper-only test does not protect the operational security trail buyers/operators rely on to distinguish a deliberate no-receipt defence-in-depth refusal from a silent construction failure.
+
+Suggested resolution direction: add an audit-sink assertion around the live ambiguous HTTP path and verify only the expected non-sensitive fields are present: `event`, `provider_id`, `request_id`, and `reason`.
+
+VERDICT: DESIGN ROUND NEEDED
+
+COUNTS: CRITICAL=1 HIGH=1 MEDIUM=0 LOW=0
+
+## Lens — ARCHITECT — Round 2
+
+Round 1 closure check: the core builder tuple, version constant, hash validation, null encoding, non-null HTTP success/error paths, and §3.4 `<= 1025` cap are present; `Package.swift`, `RFC8785JCS.swift`, and locked-spec line-3 diffs are clean. ARCHITECT-R1-HIGH-1 remains partially open because the runtime provenance boundary is still not the SPEC-011 in-flight snapshot boundary, and several Step 1 acceptance artifacts remain absent.
+
+### Finding ARCHITECT-R2-CRITICAL-1 — CRITICAL — Step 1 models provenance as caller-side metadata instead of the runtime-owned request snapshot
+
+Source: `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:231-251`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:281-291`, `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:322-338`, `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:358-367`, `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:107-112`.
+
+The architectural boundary for `model_hash` provenance is wrong: Step 1 adds a receipt-side sum type, but it does not make the runtime's in-flight snapshot the single source of truth for non-streaming generation.
+
+SPEC-011 already has the right abstraction in `RequestHandle`: `acquireRequestHandle` captures a `RuntimeSnapshot`, validates readiness/model, registers in-flight, and returns the snapshot that streaming later uses. The v0.3 Step 1 build prompt requires the atomic-read invariant at the runtime boundary. The new code instead lets HTTP and relay independently sample `currentSnapshot()` and then call `complete`, whose separate snapshot is the one that actually controls inference. That splits the provenance contract across layers and undermines the v0.3 evolution arc, because later verifier/coordinator steps will trust a receipt claim the provider runtime has not structurally tied to generation.
+
+Suggested resolution direction: promote a single non-streaming request-handle API (or a `CompletionResult` plus served-snapshot return type) and route HTTP plus relay through it before Step 2. Keep `ReceiptModelHashSource` as the emission-layer refusal type, but derive it only from the runtime-owned served snapshot.
+
+### Finding ARCHITECT-R2-HIGH-1 — HIGH — Step 1 build-prompt acceptance coverage is still incomplete
+
+Source: `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:111-123`, `specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_1_PROMPT.md:197-209`, `phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift:81-123`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:501-556`, `phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift:131-191`.
+
+The Round 2 tests cover several formerly missing behaviours, but the Step 1 acceptance list still lacks the golden JCS fixture corpus, the v0.1/v0.2 isolated 7-field canonicalization sanity check, relay receipt decoding/assertion, and an AC-42 audit-row assertion.
+
+The build prompt explicitly requires null and non-null 9-field canonical bytes to match golden files under `Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/`; no such fixture files exist. `ReceiptBuilderTests` checks key order in-process, which is useful but does not satisfy the cross-step Swift/Go parity artifact that Step 5 is supposed to consume. `InferenceRelayTests` still validates encrypted response framing without asserting a v0.3 receipt payload, so the coordinator-WS receipt path has no decoded `model_hash` / `receipt_version` regression coverage. Finally, the AC-42 helper test does not assert the required audit row. These are deterministic acceptance gaps, not spec changes or dependency issues.
+
+Suggested resolution direction: add the required fixture directory with null and non-null canonical bytes, consume it from the Swift builder tests, add an isolated 7-field JCS regression test proving `RFC8785JCS.swift` remained legacy-compatible, decode/assert a relay non-streaming receipt, and extend AC-42 coverage to include the audit sink.
+
+VERDICT: DESIGN ROUND NEEDED
+
+COUNTS: CRITICAL=1 HIGH=1 MEDIUM=0 LOW=0
+
+## Lens — CODE — Round 3
+
+Round 2 closure check: CODE-R2-CRITICAL-1 is closed. `ModelRuntime.completeWithServedSnapshot` now captures the runtime snapshot inside the actor turn that validates readiness/model, registers in-flight, and drives generation, then returns that same served snapshot to callers (`phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:394-409`, `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:419-472`). HTTP success receipts now derive `modelHashSource` from `servedSnapshot`, not the earlier caller pre-snapshot (`phase3-binary/Sources/macprovider-cli/HTTPServer.swift:244-261`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:271-282`). The relay success path also uses `completeWithServedSnapshot` and derives receipt provenance from `servedSnapshot` (`phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:281-320`). CODE-R2-HIGH-1 is closed by the HTTP-level ambiguous-provenance test, which asserts no receipt header and a `receipt_omitted` / `model_swap_violation` audit row without hash leakage (`phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:501-533`).
+
+Validation run: `cd phase3-binary && swift test --filter 'ReceiptBuilderTests|HTTPServerReceiptTests|InferenceRelayTests'` passed 35 selected tests with 0 failures.
+
+### Finding CODE-R3-MEDIUM-1 — MEDIUM — HTTP success-path comment still describes the obsolete pre-snapshot binding
+
+Source: `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:257-282`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:266-270`, `specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_1_PROMPT.md:45-50`.
+
+The Round 3 code correctly binds success receipts from `servedSnapshot`, but the adjacent comment says the receipt binds "the snapshot taken before inference began on line ~234," which points at the caller-side pre-snapshot.
+
+The implementation at lines 257-261 is the important fixed behavior: `completeWithServedSnapshot` returns the generation-driving snapshot, and `resolveModelHashSource` uses that returned value. The comment at lines 266-270 now contradicts the code and the Round 2 design resolution by implying the pre-snapshot remains the success-path provenance source. The audit prompt classifies comment/code divergence that can mislead the next implementer as MEDIUM, and this is exactly the provenance boundary that caused the Round 2 critical.
+
+Suggested resolution direction: rewrite the comment above `receiptHeaderResult` to say success receipts bind `model_hash` from `servedSnapshot`; keep the pre-snapshot comment only for warm-swap rejection validation and error/catch fallback.
+
+VERDICT: READY WITH FIX PASS
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=1 LOW=0
+
+## Lens — SECURITY — Round 3
+
+Round 2 closure check: SECURITY-R2-CRITICAL-1 is closed. The signed security claim now comes from the runtime-owned served snapshot returned by `completeWithServedSnapshot`, not a separate caller sample (`phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:394-409`, `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:419-472`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:257-282`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:281-320`). SECURITY-R2-HIGH-1 is closed by `testHTTPAmbiguousProvenanceEmitsReceiptOmittedAudit`, which drives `.ambiguous` through the HTTP success path and verifies no `X-MacProvider-Receipt` header, the required `receipt_omitted` / `model_swap_violation` row, `provider_id`, `request_id`, and no logged hash/signature/pubkey material (`phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:501-533`). `ReceiptBuilder` still signs exactly the 9-field tuple including `model_hash` as string or JSON null, and `.ambiguous` refuses before tuple construction (`phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift:77-123`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:646-662`).
+
+Validation run: `cd phase3-binary && swift test --filter 'ReceiptBuilderTests|HTTPServerReceiptTests|InferenceRelayTests'` passed 35 selected tests with 0 failures.
+
+No new CRITICAL/HIGH/MEDIUM security findings found in Round 3.
+
+VERDICT: READY TO PROCEED
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0
+
+## Lens — ARCHITECT — Round 3
+
+Round 2 closure check: ARCHITECT-R2-CRITICAL-1 is closed. The non-streaming runtime boundary now exposes a served-snapshot API, and HTTP plus relay success paths derive receipt provenance from that runtime-owned snapshot (`phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:7-20`, `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:380-409`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:257-282`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:281-320`). The AC-42 audit-row part of ARCHITECT-R2-HIGH-1 is closed by the new HTTP end-to-end test (`phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:501-533`). `SPEC-015-receipts.md` line 3 remains locked at v0.3.3, and there is no diff in `RFC8785JCS.swift`, `phase3-binary/Package.swift`, or the locked SPEC-001/002/005/006/008/010/011/013 line-3 files.
+
+Validation run: `cd phase3-binary && swift test --filter 'ReceiptBuilderTests|HTTPServerReceiptTests|InferenceRelayTests'` passed 35 selected tests with 0 failures.
+
+### Finding ARCHITECT-R3-HIGH-1 — HIGH — Step 1 build-prompt acceptance artifacts are still incomplete
+
+Source: `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:111-123`, `specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_1_PROMPT.md:197-209`, `phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift:81-123`, `phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift:131-191`.
+
+Round 3 closes the runtime provenance blocker and the HTTP AC-42 audit-row gap, but it still does not land the mandatory golden fixture corpus, the isolated v0.1/v0.2 7-field JCS regression sanity check, or a decoded relay receipt assertion.
+
+The Step 1 build prompt requires null and non-null 9-field canonical bytes to match golden files under `phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/`; that fixture path is still absent, and `ReceiptBuilderTests` only performs in-process parsing/order checks. The build prompt also requires a no-regression sanity check for isolated 7-field v0.1/v0.2 canonicalization, and no such test appears in the Step 1 test surface. Finally, `InferenceRelayTests` still verifies encrypted chunk/end framing but never constructs a relay with a receipt builder/provider ID and decodes the returned v0.3 receipt, leaving the coordinator-WS-mediated receipt path without direct `receipt_version` / `model_hash` regression coverage. These are deterministic acceptance gaps against A.1, even though the core runtime architecture is now correct.
+
+Suggested resolution direction: add the `SPEC015_v03_jcs` fixture directory with null and non-null canonical bytes and consume it from Swift tests; add an isolated legacy 7-field JCS canonicalization regression test; add an `InferenceRelayTests` non-streaming receipt test that injects a receipt builder/provider ID, overrides `completeWithServedSnapshot` with a non-null served hash, decodes the `receipt` end-frame value, and asserts `receipt_version == "3"` plus the served `model_hash`.
+
+VERDICT: READY WITH FIX PASS
+
+COUNTS: CRITICAL=0 HIGH=1 MEDIUM=0 LOW=0
+
+## Lens — CODE — Round 4
+
+Round 3 closure check: CODE-R3-MEDIUM-1 is closed. The HTTP success-path comment now explicitly says the receipt binds `model_hash` to the runtime-served snapshot returned by `completeWithServedSnapshot`, not to the pre-snapshot (`phase3-binary/Sources/macprovider-cli/HTTPServer.swift:266-274`). The pre-snapshot wording is limited to warm-swap validation and error/catch fallback where no served snapshot exists (`phase3-binary/Sources/macprovider-cli/HTTPServer.swift:233-257`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:305-347`).
+
+Round 3 ARCHITECT-R3-HIGH-1 code-surface recheck: the 9-field builder still emits exactly the SPEC-015 §M.0 keys, validates present hashes as raw 64-char lowercase hex, maps nil to JCS null, and signs the canonical 9-field tuple (`phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift:55-123`, `phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift:137-153`). The golden fixture tests now lock null and non-null v0.3 canonical JCS bytes by SHA-256 and byte length, and also lock the isolated v0.1/v0.2 7-field canonical byte sequence (`phase3-binary/Tests/macprovider-cliTests/JCSGoldenFixtureTests.swift:30-80`). The relay non-streaming test now injects a receipt builder/provider ID, returns a fixed served snapshot, decodes the end-frame receipt, and asserts `receipt_version == "3"`, the served `model_hash`, and the 9-key tuple shape (`phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift:195-258`).
+
+Implementation recheck found no new CRITICAL/HIGH/MEDIUM code findings. HTTP success/error/parse-error paths thread `ReceiptModelHashSource` through the receipt helpers and refuse `.ambiguous` before construction (`phase3-binary/Sources/macprovider-cli/HTTPServer.swift:244-285`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:376-399`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:608-749`). Relay non-streaming binds from the served snapshot and refuses ambiguous provenance before building a receipt (`phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:281-332`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:337-379`).
+
+Validation run: `cd phase3-binary && swift test` passed 530 tests, 7 skipped, 0 failures.
+
+VERDICT: READY TO PROCEED
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0
+
+## Lens — SECURITY — Round 4
+
+Round 3 security posture remains closed. The signature input is the canonical JCS tuple returned by `ReceiptBuilder.tupleObject`, now including `model_hash` as either a string or the JSON null literal and `receipt_version` as the string `"3"` (`phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift:55-93`, `phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift:99-123`). `RFC8785JCS.swift` still has the existing `.null` and UTF-16 object-key sorting behavior and was not amended (`phase3-binary/Sources/macprovider-cli/RFC8785JCS.swift:17-42`, `phase3-binary/Sources/macprovider-cli/RFC8785JCS.swift:51-53`).
+
+The provenance security property is still bound to the runtime-owned served snapshot: real `ModelRuntime.completeWithServedSnapshot` captures the snapshot inside the actor path that validates readiness/model, registers in-flight, and drives generation, then returns that same snapshot to HTTP and relay receipt construction (`phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:388-472`, `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:257-285`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:281-320`). The `.ambiguous` defence-in-depth path refuses before tuple construction and emits `receipt_omitted: model_swap_violation`; the HTTP AC-42 test asserts no header, the audit row, and no hash/signature/pubkey leakage (`phase3-binary/Sources/macprovider-cli/HTTPServer.swift:650-666`, `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:350-360`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:501-533`).
+
+No new CRITICAL/HIGH/MEDIUM security findings found in Round 4.
+
+Validation run: `cd phase3-binary && swift test` passed 530 tests, 7 skipped, 0 failures.
+
+VERDICT: READY TO PROCEED
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0
+
+## Lens — ARCHITECT — Round 4
+
+Round 3 closure check: ARCHITECT-R3-HIGH-1 is closed. The required `SPEC015_v03_jcs` fixture corpus now exists with null and non-null v0.3 fixture JSON files and locked SHA-256/length metadata (`phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/null_hash.json:1-15`, `phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/non_null_hash.json:1-15`). The README documents the regeneration workflow for future Swift/Go parity use (`phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/README.md:1-26`). `JCSGoldenFixtureTests` consumes both fixture files and adds the legacy 7-field canonicalization sanity check required by SPEC-015 §M.1.5 (`phase3-binary/Tests/macprovider-cliTests/JCSGoldenFixtureTests.swift:30-80`). The relay receipt decode gap is closed by `testRelayNonStreamingEndFrameCarriesV03Receipt` (`phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift:195-258`).
+
+Step 1 build-prompt coverage is now complete for the Swift provider scope: builder 9-field tuple, constant `receipt_version: "3"`, served-snapshot provenance, no `RFC8785JCS.swift` amendment, null/non-null fixture parity, AC-31 error-receipt inheritance, AC-42 refusal/audit, relay receipt decode, legacy 7-field JCS sanity, and §3.4 size checks are covered by source and tests (`phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift:55-123`, `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:388-472`, `phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift:23-185`, `phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift:480-590`, `phase3-binary/Tests/macprovider-cliTests/JCSGoldenFixtureTests.swift:30-80`). `Package.swift`, `RFC8785JCS.swift`, and the locked SPEC-001/002/005/006/008/010/011/013 files have no implementation diff.
+
+### Finding ARCHITECT-R4-LOW-1 — LOW — SwiftPM still warns that the new fixture files are unhandled
+
+Source: `phase3-binary/Package.swift:64-71`, `phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/null_hash.json:1-15`, `phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/non_null_hash.json:1-15`, `phase3-binary/Tests/macprovider-cliTests/Fixtures/SPEC015_v03_jcs/README.md:1-26`.
+
+The new fixture files are intentionally loaded by source path in `JCSGoldenFixtureTests`, but SwiftPM reports them as unhandled files in the test target.
+
+This is not a Step 1 acceptance blocker: `swift test` passes, the fixtures are present in the repository, and the test reads them via `#filePath` rather than `Bundle.module`. It is still minor packaging noise that will appear on every test run until the test target either declares the fixture directory as resources and loads it through `Bundle.module`, or explicitly excludes the directory while keeping the source-path loading convention.
+
+Suggested resolution direction: in a polish pass, either add test resources and switch the fixture loader to `Bundle.module`, or add an explicit test-target exclude for the fixture directory if source-path loading is the intended house style.
+
+Validation run: `cd phase3-binary && swift test` passed 530 tests, 7 skipped, 0 failures. The run emitted only the fixture-resource warning above.
+
+VERDICT: READY TO PROCEED
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=0 LOW=1

--- a/specs/SPEC-015-v0-3-IMPL-STEP_2-audit.md
+++ b/specs/SPEC-015-v0-3-IMPL-STEP_2-audit.md
@@ -1,0 +1,99 @@
+## Lens — CODE — Round 1
+
+### CODE-HIGH-1 — Missing AC-39 failed-catalog negative coverage
+
+Source: `phase4-coordinator/internal/ws/poolz_catalog_test.go:25-75`; `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:157-160`; `specs/SPEC-015-receipts.md:3565-3578`
+
+Severity: HIGH
+
+Problem: `/poolz` tests cover active catalog and no configured catalog, but do not cover the required configured-but-load/parse/signature-failed branches.
+
+The implementation gates the new fields on `s.catalogRef().Active()` in `phase4-coordinator/internal/ws/server.go:2733-2774`, which is the right production predicate, but the new test file only asserts the positive case (`TestPoolzEmitsCatalogFieldsWhenCatalogActive`, lines 25-60) and the empty `CatalogPath` case (`TestPoolzOmitsCatalogFieldsWhenCatalogNotConfigured`, lines 62-75). The Step 2 prompt requires `/poolz` to omit the three fields when a configured catalog failed to load, and SPEC-015 AC-39 requires omission when the catalog fails to load / parse / verify-signature. The audit prompt classifies missing tests for the §M.4 effectively-active branches as HIGH because a future regression could publish stale catalog URLs after a catalog rotation failure without deterministic test failure.
+
+Suggested resolution direction: Add table-driven `/poolz` tests for configured missing file, malformed catalog JSON, and bad signature/wrong pubkey; assert `catalog_id`, `catalog_url`, and `catalog_pubkey_url` are all absent, not null or empty strings.
+
+### CODE-MEDIUM-1 — URL-construction edge cases are not tested
+
+Source: `phase4-coordinator/internal/ws/server.go:2750-2771`; `phase4-coordinator/internal/ws/poolz_catalog_test.go:25-58`
+
+Severity: MEDIUM
+
+Problem: The new `/poolz` URL builder has no tests for trailing-slash `PublicCatalogBaseURL` or host-derived fallback URLs.
+
+The implementation trims configured base URLs before appending `/catalog/<id>` and `/catalog/pubkey`, and falls back to `scheme://r.Host` when `PublicCatalogBaseURL` is empty. The only positive test uses `https://coordinator.streamvc.live` without a trailing slash, so it does not lock the slash-normalization path, host-with-port path, IPv6 host path, or empty-config fallback path called out in the CODE lens. This is not a current functional failure in the inspected code, but it leaves the URL-construction acceptance surface under-specified.
+
+Suggested resolution direction: Extend `poolz_catalog_test.go` with table cases for configured base URL with a trailing slash, no configured base with `Host: example.test:8443`, and an IPv6 host such as `[2001:db8::1]:8443`.
+
+### CODE-LOW-1 — `PublicCatalogBaseURL` comment describes a fallback the code does not implement
+
+Source: `phase4-coordinator/internal/config/config.go:143-151`; `phase4-coordinator/internal/ws/server.go:2766-2771`
+
+Severity: LOW
+
+Problem: The config comment says URL fields are emitted as relative paths when no host is available, but the handler omits those URL fields when no base can be built.
+
+The handler only assigns `catalog_url` and `catalog_pubkey_url` inside `if base != ""`, so the degraded no-base behavior is catalog-id-only. That aligns better with the Step 2 prompt's "catalog_id only" fallback than the config comment's "relative paths" wording, but the comment is misleading for later verifier or deploy authors reading the config struct as the behavior contract.
+
+Suggested resolution direction: Rewrite the comment to say the URL fields are omitted when neither `public_catalog_base_url` nor request `Host` can provide an absolute base.
+
+VERDICT: REQUEST CHANGES — Step 2 should not proceed while the AC-39 failed-catalog test branch is missing.
+
+COUNTS: CRITICAL 0 / HIGH 1 / MEDIUM 1 / LOW 1
+
+## Lens — SECURITY — Round 1
+
+No security findings.
+
+Evidence checked: `/poolz` still requires `authorizedOperator` before response construction (`phase4-coordinator/internal/ws/server.go:2643-2654`); the new catalog endpoints are registered only on the buyer `Handler()` and not the WS/operator mux (`phase4-coordinator/internal/buyer/server.go:393-407`, `phase4-coordinator/internal/ws/server.go:369-381`); the endpoints are intentionally public and share the receipt-keys per-IP bucket with `Retry-After: 1` on 429 (`phase4-coordinator/internal/buyer/server.go:749-805`, `phase4-coordinator/internal/buyer/server.go:823-853`); the URL `catalog_id` is compared with `tier2.CatalogID()` before reading the operator-configured `cfg.CatalogPath`, so it is not used as a filename (`phase4-coordinator/internal/buyer/server.go:755-770`); `/catalog/pubkey` returns only `cfg.CatalogPublicKey` and `alg: "Ed25519"`, with no private-key surface (`phase4-coordinator/internal/buyer/server.go:791-802`); and the audited packages pass the race detector.
+
+VERDICT: READY TO LOCK — SECURITY lens found no CRITICAL/HIGH/MEDIUM issues for Step 2.
+
+COUNTS: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0
+
+## Lens — ARCHITECT — Round 1
+
+### ARCHITECT-HIGH-1 — Step 2 coverage is not complete enough for the staged gate
+
+Source: `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:157-166`; `phase4-coordinator/internal/ws/poolz_catalog_test.go:25-75`; `phase4-coordinator/internal/buyer/catalog_endpoints_test.go:83-98`
+
+Severity: HIGH
+
+Problem: The implementation does not satisfy the Step 2 test matrix because the configured-catalog-failed branch is absent.
+
+The Step 2 build prompt explicitly lists `/poolz` omission when a configured catalog failed to load as a required test, and AC-39 requires the same negative branch before Step 3. The current `/poolz` tests cover active and unconfigured states, while buyer endpoint tests cover active serving, wrong id, no catalog, pubkey response shape, and rate limiting. They do not cover the architectural transition that matters for rollouts: `CatalogPath` set but the active catalog is unavailable because load/parse/signature verification failed. That gap weakens the staged audit loop because Step 3 nginx routing would be built on a Step 2 surface whose negative deploy state is not locked.
+
+Suggested resolution direction: Close the Step 2 test matrix before Step 3 by adding failed-load and failed-signature `/poolz` cases, and consider mirroring the same inactive-catalog state against `/catalog/<id>` and `/catalog/pubkey` 404 behavior.
+
+VERDICT: REQUEST CHANGES — Step 2 is not architecturally complete until the AC-39 negative branch is locked by tests.
+
+COUNTS: CRITICAL 0 / HIGH 1 / MEDIUM 0 / LOW 0
+
+## Lens — CODE — Round 2
+
+No CODE findings.
+
+Evidence checked: the Round 1 AC-39 coverage gap is closed by `TestPoolzOmitsCatalogFieldsWhenCatalogLoadFails`, which table-drives missing-file, malformed-JSON, and signature-mismatch states, confirms `tier2.Active() == false`, and asserts `catalog_id`, `catalog_url`, and `catalog_pubkey_url` are absent from the raw `/poolz` JSON (`phase4-coordinator/internal/ws/poolz_catalog_test.go:78-142`). The URL-construction gap is closed by `TestPoolzCatalogURLConstructionEdgeCases`, which locks trailing-slash trimming for `PublicCatalogBaseURL`, empty-config fallback to scheme plus `Host`, host-with-port, and IPv6 host handling (`phase4-coordinator/internal/ws/poolz_catalog_test.go:144-228`) against the handler logic in `handlePoolz` (`phase4-coordinator/internal/ws/server.go:2733-2774`). The config comment now matches the implementation's no-base behavior: URL fields are omitted while `catalog_id` may still be emitted (`phase4-coordinator/internal/config/config.go:143-155`). The buyer endpoints still return literal catalog bytes / pubkey shape, use the shared receipt-keys rate bucket, cache headers, and `catalog_not_found` envelope (`phase4-coordinator/internal/buyer/server.go:743-805`, `phase4-coordinator/internal/buyer/catalog_endpoints_test.go:21-165`). Verification run: `go test ./...` from `phase4-coordinator/` passed.
+
+VERDICT: READY TO LOCK — CODE lens found no CRITICAL/HIGH/MEDIUM issues for Step 2 after the Round 2 fix pass.
+
+COUNTS: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0
+
+## Lens — SECURITY — Round 2
+
+No SECURITY findings.
+
+Evidence checked: `/poolz` still rejects unauthenticated operator requests before response construction (`phase4-coordinator/internal/ws/server.go:2643-2654`), and the new catalog fields expose only catalog-level URL/id metadata, not per-provider operator-sensitive fields (`phase4-coordinator/internal/ws/server.go:2733-2774`). The catalog endpoints remain registered only on the buyer mux and are intentionally public, unauthenticated, cacheable, and rate-limited (`phase4-coordinator/internal/buyer/server.go:393-407`, `phase4-coordinator/internal/buyer/server.go:743-805`); they are not registered on the WS/operator mux (`phase4-coordinator/internal/ws/server.go:369-381`). The catalog path is read only after the requested URL id matches `tier2.CatalogID()`, so the path parameter is never used as a filename (`phase4-coordinator/internal/buyer/server.go:755-770`). `/catalog/pubkey` returns only the configured public key plus capital-E `Ed25519`, matching the existing signing/validation surfaces (`phase4-coordinator/internal/buyer/server.go:791-802`, `scripts/sign-catalog.go:90`, `scripts/sign-catalog.go:142-145`, `phase4-coordinator/internal/tier2/catalog.go:470-485`). Concurrent catalog reads continue through the existing locked/atomic catalog accessors (`phase4-coordinator/internal/tier2/catalog.go:245-249`, `phase4-coordinator/internal/tier2/catalog.go:333-338`, `phase4-coordinator/internal/ws/server.go:323-331`). Verification run: `go test ./...` from `phase4-coordinator/` passed.
+
+VERDICT: READY TO LOCK — SECURITY lens found no CRITICAL/HIGH/MEDIUM issues for Step 2.
+
+COUNTS: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0
+
+## Lens — ARCHITECT — Round 2
+
+No ARCHITECT findings.
+
+Evidence checked: the Step 2 implementation now covers the build prompt's `/poolz` active, unconfigured, and configured-but-failed catalog branches (`specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:137-167`, `phase4-coordinator/internal/ws/poolz_catalog_test.go:22-142`). It also covers the two public buyer endpoints, 404 envelope, pubkey shape, cache headers, and rate limiting (`phase4-coordinator/internal/buyer/catalog_endpoints_test.go:21-165`). The SPEC-002 candidate annotation remains additive: existing top-level `/poolz` keys `pool` and `summary` are preserved and only the three optional catalog fields were added (`phase4-coordinator/internal/ws/server.go:2738-2745`). Locked-spec and catalog-parser boundaries remain intact: `git diff --name-only main -- phase4-coordinator/internal/tier2 specs/SPEC-001-* specs/SPEC-002-* specs/SPEC-005-* specs/SPEC-006-* specs/SPEC-008-* specs/SPEC-010-* specs/SPEC-011-* specs/SPEC-013-*` returned no paths. Entry 80 orthogonality is preserved because the Step 2 diff does not change `RequireHashVerified` routing semantics, only the config struct's new `PublicCatalogBaseURL` field/comment (`phase4-coordinator/internal/config/config.go:140-155`, `phase4-coordinator/cmd/coordinator/main.go:631-640`). Verification run: `go test ./...` from `phase4-coordinator/` passed.
+
+VERDICT: READY TO LOCK — ARCHITECT lens found no CRITICAL/HIGH/MEDIUM issues for Step 2 after the Round 2 fix pass.
+
+COUNTS: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0

--- a/specs/SPEC-015-v0-3-IMPL-STEP_3-audit.md
+++ b/specs/SPEC-015-v0-3-IMPL-STEP_3-audit.md
@@ -1,0 +1,121 @@
+## Lens — CODE — Round 1
+
+### HIGH
+
+1. `phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh:27-32` — The nginx route check can pass even if the `/catalog/` block is later changed to proxy to the operator port. The script first proves an active `location /catalog/ {` exists, but its buyer-port assertion is a repo-wide grep for `proxy_pass http://127.0.0.1:8443` over all active nginx text. The existing `/v1/receipt-keys/` block already contains that same buyer-port proxy at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:149-155`, so a bad `/catalog/` block using `127.0.0.1:8444` would still satisfy line 30. That leaves the Step 3 static gate unable to verify the specific `/catalog/` proxy target required by `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:183` and the audit prompt's C.4 category.
+
+   Fix: parse the active `/catalog/` block and assert the `proxy_pass http://127.0.0.1:8443` directive inside that block only. While touching the parser, also fail closed if the TLS catch-all 404 anchor is missing; lines 41-47 currently skip the ordering assertion when `CATCHALL_LINE` is empty.
+
+### LOW
+
+- None.
+
+Verification evidence:
+- `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:170-176` currently routes `/catalog/` to buyer port `127.0.0.1:8443` before the catch-all `location /` at lines 205-207.
+- `Makefile:33-37` wires `check_nginx_catalog_routes_test.sh` into `test-dist`.
+- `bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh` passed, but the false-positive gap above means this is not sufficient evidence for the proxy-target claim.
+- `make test-dist` passed; live nginx smoke was skipped by the existing optional guard.
+- `git diff --check` passed.
+
+VERDICT: FIX REQUIRED
+COUNTS: CRITICAL 0 / HIGH 1 / MEDIUM 0 / LOW 0
+
+## Lens — SECURITY — Round 1
+
+### Findings
+
+- None.
+
+Security checks:
+- `/catalog/` is public per `specs/SPEC-015-receipts.md:3308-3322` and `3330-3353`; the nginx block is unauthenticated but proxies only to buyer port `127.0.0.1:8443` at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:170-176`.
+- `/poolz` remains an exact operator endpoint on provider port `127.0.0.1:8444` with `Authorization` forwarding at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:122-129`; no public `/poolz` proxy was added.
+- The YAML example leaves `catalog_public_key` commented at `phase4-coordinator/dist/coordinator.yaml.example:102-104` and adds no private key or secret-bearing catalog material.
+- The public-key response shape in comments preserves base64url-unpadded + capital-E `Ed25519` at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:158-167`, matching `specs/SPEC-015-receipts.md:3350-3363`.
+
+VERDICT: READY
+COUNTS: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0
+
+## Lens — ARCHITECT — Round 1
+
+### HIGH
+
+1. `phase4-coordinator/dist/deploy-pearl-vps.sh:53-83` / `phase4-coordinator/dist/check-deploy-config.sh:1-189` — The Step 3 deploy-time gate is not integrated into the actual Pearl deploy path. The build prompt requires `check-deploy-config.sh` to assert the new nginx routes and fail non-zero when they are missing (`specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:183-190`). The implementation instead adds a standalone test under `make test-dist` (`Makefile:33-37`), while `deploy-pearl-vps.sh` step 0 only invokes `check-deploy-config.sh` before uploading and installing the nginx site. Because `check-deploy-config.sh` has no nginx-conf input or `/catalog/` assertions, an operator-run deploy can still proceed with a stale local `nginx-coordinator.streamvc.live.conf` that lacks the SPEC-015 v0.3 catalog routes.
+
+   Fix: put the catalog route assertion on the same operational path as the Pearl deploy gate. Acceptable shapes include making `check-deploy-config.sh` validate the nginx site path, or having `deploy-pearl-vps.sh` invoke `check_nginx_catalog_routes_test.sh` before the upload at `phase4-coordinator/dist/deploy-pearl-vps.sh:229`. The gate should fail closed before any remote mutation.
+
+### LOW
+
+- None.
+
+Architecture checks:
+- Locked SPEC-015 line 3 remains `**Version:** 0.3.3 ... LOCKED`; `git diff -- specs/SPEC-015-receipts.md specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md beta/DECISION_CRITERIA.md` is empty.
+- The nginx route mirrors the v0.2 `/v1/receipt-keys/` buyer-port shape at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:149-176`.
+- Entry 80 orthogonality is preserved: `phase4-coordinator/internal/config/config.go:344-349` still defaults `RequireHashVerified` to false, and the YAML example documents `require_hash_verified: false` only as a commented placeholder at `phase4-coordinator/dist/coordinator.yaml.example:98-109`.
+
+VERDICT: FIX REQUIRED
+COUNTS: CRITICAL 0 / HIGH 1 / MEDIUM 0 / LOW 0
+
+## Lens — CODE — Round 2
+
+### Findings
+
+- None.
+
+Round-2 closure checks:
+- CODE-HIGH is closed. `phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh:31-55` extracts `proxy_pass` directives from inside the active `/catalog/` block only, asserts the buyer-port target `127.0.0.1:8443`, and fails closed on zero or multiple `proxy_pass` directives. This removes the round-1 false pass from the existing `/v1/receipt-keys/` buyer-port block at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:149-155`.
+- The ordering assertion now anchors on the TLS catch-all `location / { return 404; }` and fails closed if that anchor is missing at `phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh:57-70`.
+- The nginx block itself still matches the Step 3 shape: `/catalog/` is declared at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:170-176`, proxies to `http://127.0.0.1:8443`, forwards host/client headers, sets `proxy_read_timeout 10s`, and appears before the catch-all 404 at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:204-207`.
+- `Makefile:33-37` keeps the catalog route check wired into `test-dist`.
+- `phase4-coordinator/dist/coordinator.yaml.example:98-109` uses the existing commented-operator-input style for `catalog_path`, `catalog_public_key`, and `require_hash_verified`, while setting Pearl's `public_catalog_base_url`.
+
+Verification evidence:
+- `bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh` passed.
+- `make test-dist` passed; the optional live nginx smoke skipped under `SPEC015_NGINX_LIVE_OPTIONAL=1`.
+- A restore-on-exit mutation that changed only the `/catalog/` block to `proxy_pass http://127.0.0.1:8444;` exited 1 with `FAIL: /catalog/ block proxy_pass is not 127.0.0.1:8443 (buyer port); got:         proxy_pass http://127.0.0.1:8444;`.
+- `git diff --check` passed.
+
+VERDICT: READY
+COUNTS: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0
+
+## Lens — SECURITY — Round 2
+
+### Findings
+
+- None.
+
+Security checks:
+- `/catalog/` remains public by design per `specs/SPEC-015-receipts.md:3308-3322` and `specs/SPEC-015-receipts.md:3328-3368`; nginx proxies it only to buyer port `127.0.0.1:8443` at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:170-176`.
+- No public `/poolz` route was added. The existing `/poolz` surface remains on provider/operator port `127.0.0.1:8444` with authorization forwarding at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:120-129`.
+- The `/catalog/` comment states the unauthenticated buyer-endpoint posture, internal rate-limit ownership, public cache posture, signed-catalog trust model, and 404 behavior at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:158-168`.
+- `phase4-coordinator/dist/coordinator.yaml.example:98-109` introduces no secret material. `catalog_public_key` stays commented as an operator-populated public key placeholder, and `public_catalog_base_url` is the public Pearl URL.
+- The block ordering is unambiguous: `/catalog/` is before the TLS catch-all 404, and the static gate now fails closed if the catch-all anchor cannot be found.
+
+Verification evidence:
+- `bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh` passed.
+- `make test-dist` passed; the optional live nginx smoke skipped under `SPEC015_NGINX_LIVE_OPTIONAL=1`.
+- `git diff --check` passed.
+
+VERDICT: READY
+COUNTS: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0
+
+## Lens — ARCHITECT — Round 2
+
+### Findings
+
+- None.
+
+Architecture checks:
+- ARCHITECT-HIGH is closed. `phase4-coordinator/dist/deploy-pearl-vps.sh:87-95` invokes `check_nginx_catalog_routes_test.sh` during step 0, before `step 1/9: confirm SSH + DNS` at `phase4-coordinator/dist/deploy-pearl-vps.sh:97-99` and before any upload/install phase. Failure exits 5 with `aborting deploy: nginx /catalog/ routes missing or misconfigured`.
+- The deploy integration satisfies the Step 3 pre-upload gate intent from `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:183-190`: an outdated local `nginx-coordinator.streamvc.live.conf` now blocks the Pearl deploy before remote mutation.
+- The new `/catalog/` route composes with the v0.2 `/v1/receipt-keys/` shape: both are public buyer-port routes with the same core proxy/header pattern at `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf:149-176`.
+- Locked files were not shifted: `git diff -- specs/SPEC-015-receipts.md specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md beta/DECISION_CRITERIA.md` is empty.
+- Entry 80 orthogonality is preserved. `phase4-coordinator/internal/config/config.go:348` still defaults `RequireHashVerified` to `false`, and `phase4-coordinator/dist/coordinator.yaml.example:98-109` documents `require_hash_verified: false` only as a commented operator placeholder while adding `public_catalog_base_url`.
+
+Verification evidence:
+- `bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh` passed.
+- `make test-dist` passed; the optional live nginx smoke skipped under `SPEC015_NGINX_LIVE_OPTIONAL=1`.
+- A restore-on-exit `/catalog/` mutation to operator port 8444 exited non-zero, proving the pre-upload deploy gate now has a meaningful stale-nginx failure condition.
+- `git diff --check` passed.
+
+VERDICT: READY
+COUNTS: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0

--- a/specs/SPEC-015-v0-3-IMPL-STEP_4-audit.md
+++ b/specs/SPEC-015-v0-3-IMPL-STEP_4-audit.md
@@ -1,0 +1,137 @@
+## Lens — CODE — Round 1
+
+### HIGH C-1 — Catalog version is not pinned to the supported signer/coordinator schema
+
+- Evidence: `phase7-verify/internal/catalog/catalog.go:108-110` accepts any positive `version`, while the coordinator hand-translation reference rejects anything other than `1` at `phase4-coordinator/internal/tier2/catalog.go:454-456`.
+- Why it matters: §M.3.2 step 3 says the verifier parses the coordinator `catalogFile` schema and the Step 4 prompt requires identical accept/reject decisions with the coordinator. A signature-valid `version: 2` catalog is currently accepted under v1 semantics instead of failing closed as `catalog_format_invalid`.
+- Validation: temp probe signed a `version: 2` catalog with the same canonical body shape; `Parse` and `Verify` both accepted it.
+- Fix: require `f.Version == 1` in `Parse`, and add a regression test for signed `version: 0`, `version: 2`, and missing/wrong-type `version`.
+
+### HIGH C-2 — Required catalog fields are not all enforced before signature acceptance
+
+- Evidence: `phase7-verify/internal/catalog/catalog.go:125-137` validates only `model_id` and `sha256` for each model entry; it does not reject empty/missing `artifact_kind`, `hash_scope`, or `source`. `phase7-verify/internal/catalog/catalog.go:174-185` validates `signature.alg` and `signature.sig`, but never rejects empty/missing `signature.key_id`; the coordinator rejects empty `key_id` at `phase4-coordinator/internal/tier2/catalog.go:473-475`.
+- Why it matters: §M.3.2 step 3 defines `{artifact_kind, hash_scope, model_id, notes?, sha256, source}` and `signature{alg, key_id, sig}` as the schema, with missing required fields mapped to `catalog_format_invalid`. Since the signature excludes the `signature` object, empty or omitted `key_id` does not break Ed25519 verification and is accepted today.
+- Validation: temp probe signed catalogs with empty `artifact_kind`, `hash_scope`, `source`, and `key_id`; `Parse` and `Verify` accepted them.
+- Fix: validate non-empty required string fields for `artifact_kind`, `hash_scope`, `source`, `signature.key_id`, and `signature.sig` during parse/verify, with explicit regression tests for missing and empty forms.
+
+### MEDIUM C-3 — Parity test does not actually exercise `scripts/sign-catalog.go`
+
+- Evidence: `phase7-verify/internal/catalog/catalog_test.go:224-258` labels the case as signer parity, but it constructs the canonical bytes using the verifier package's own `canonicalBody` and `json.Marshal`. It does not invoke `scripts/sign-catalog.go` or consume a golden file emitted by that tool.
+- Why it matters: the Step 4 audit prompt names missing parity against the existing signer as a MEDIUM finding. This test can pass even if both the implementation and test drift together away from the signer.
+- Fix: add a real parity fixture path: generate signed catalogs with `scripts/sign-catalog.go` or check in signer-produced golden catalogs, including randomized model order/field values.
+
+VERDICT: NOT READY
+
+COUNTS: CRITICAL 0, HIGH 2, MEDIUM 1, LOW 0
+
+## Lens — SECURITY — Round 1
+
+### HIGH S-1 — Verifier fails open for signature-valid catalogs outside the documented schema
+
+- Evidence: `phase7-verify/internal/catalog/catalog.go:108-110` accepts future positive versions; `phase7-verify/internal/catalog/catalog.go:125-137` leaves required model metadata unchecked; `phase7-verify/internal/catalog/catalog.go:174-185` does not require `signature.key_id`. The locked §M.3.2 step 3 schema and coordinator reference reject these malformed cases.
+- Why it matters: this is not a raw signature bypass; tampered body/signature tests exist and pass. The security issue is fail-open schema acceptance: a catalog signed by the trusted key but malformed or from a future incompatible schema can still become buyer-valid input. The verifier should reject every documented catalog-format failure before using the catalog for model-hash trust.
+- Fix: fail closed on unsupported version and missing/empty required schema fields, returning typed format/signature errors that Step 5 can map to `catalog_format_invalid` or `catalog_signature_invalid`.
+
+### MEDIUM S-2 — Boundary coverage is incomplete for expiry and external signer parity
+
+- Evidence: expiry tests cover clearly within grace (`phase7-verify/internal/catalog/catalog_test.go:175-193`) and clearly beyond grace (`phase7-verify/internal/catalog/catalog_test.go:150-173`), but not exactly `expires_at + 60s` or just over it. The signer parity test at `phase7-verify/internal/catalog/catalog_test.go:224-258` is self-generated, not signer-generated.
+- Why it matters: the code appears to implement the §M.3.2 step 5 `now > expires_at + 60s` boundary correctly at `phase7-verify/internal/catalog/catalog.go:202-207`, but the audit prompt calls the 60s edge and signer parity out as high-risk regression surfaces.
+- Fix: add exact-boundary expiry tests (`+60s` accepted, `+60s+1ns` or `+61s` rejected) plus real signer-produced catalog fixtures.
+
+VERDICT: NOT READY
+
+COUNTS: CRITICAL 0, HIGH 1, MEDIUM 1, LOW 0
+
+## Lens — ARCHITECT — Round 1
+
+### HIGH A-1 — The verifier/coordinator accept-reject contract is not equivalent
+
+- Evidence: Step 4 requires a hand translation of `phase4-coordinator/internal/tier2/catalog.go` with identical accept/reject decisions. The verifier accepts any positive version at `phase7-verify/internal/catalog/catalog.go:108-110`; coordinator requires `version == 1` at `phase4-coordinator/internal/tier2/catalog.go:454-456`. The verifier also omits required `signature.key_id` validation while the coordinator enforces it at `phase4-coordinator/internal/tier2/catalog.go:473-475`.
+- Why it matters: Step 4 is the foundation for Step 5's verifier decision path. If buyer-side verification and coordinator-side catalog loading disagree, the system can publish or reject different catalog states depending on which component evaluates them.
+- Fix: centralize the verifier's validation checklist around the coordinator schema fields and add table tests that mirror the coordinator's rejection cases.
+
+### MEDIUM A-2 — Cache entry shape drifts from the §M.3.4 contract
+
+- Evidence: §M.3.4 and the Step 4 prompt require cache entries to include `{catalog_bytes, catalog_pubkey_b64, fetched_at, expires_at, catalog_url}`. The implementation stores `catalog_pubkey_b64url` and `expires_at_cache` at `phase7-verify/internal/cache/catalog/catalog_cache.go:37-44`, not the named `catalog_pubkey_b64` and catalog `expires_at`.
+- Why it matters: storing an absolute cache-expiry timestamp is useful, but replacing catalog `expires_at` with cache expiry loses the original catalog validity metadata that later Step 5 diagnostics/details may need. The field-name drift also makes the on-disk contract harder for future tooling to consume.
+- Fix: store both the original catalog `expires_at` and the computed cache expiry, or align the field names with §M.3.4 while keeping TTL enforcement explicit.
+
+### MEDIUM A-3 — Signer parity is asserted by local reconstruction instead of an external contract
+
+- Evidence: `phase7-verify/internal/catalog/catalog_test.go:224-258` uses the verifier package's `canonicalBody`, so it validates internal consistency rather than compatibility with `scripts/sign-catalog.go`.
+- Why it matters: Step 4 exists to consume the production signer output byte-for-byte. The architecture needs a contract test at that boundary, not only a unit test sharing the implementation's canonicalization assumptions.
+- Fix: add signer-produced golden fixtures or a controlled `go run ../scripts/sign-catalog.go sign ...` parity test for multiple catalog bodies.
+
+VERDICT: NOT READY
+
+COUNTS: CRITICAL 0, HIGH 1, MEDIUM 2, LOW 0
+
+## Lens — CODE — Round 2
+
+No CODE findings.
+
+Round 2 re-audit covered C.1-C.10 after the fix pass, plus two coordinator-equivalence gaps found during this audit and fixed before verdict:
+
+- `phase7-verify/internal/catalog/catalog.go:97-100` now routes parsing through `decodeFile`, and `phase7-verify/internal/catalog/catalog.go:249-260` requires a single top-level JSON object with unknown-field rejection. Regression: `phase7-verify/internal/catalog/catalog_test.go:278-290`.
+- `phase7-verify/internal/catalog/catalog.go:104-110` pins `version == 1`. Regression: `phase7-verify/internal/catalog/catalog_test.go:196-214`.
+- `phase7-verify/internal/catalog/catalog.go:127-147` rejects empty/unsupported model fields, including `artifact_kind != "mlx_weight_file"` and unsupported `hash_scope`, matching `phase4-coordinator/internal/tier2/catalog.go:526-533`. Regressions: `phase7-verify/internal/catalog/catalog_test.go:216-317`.
+- `phase7-verify/internal/catalog/catalog.go:153-160` rejects empty `signature.alg`, `signature.key_id`, and `signature.sig`; `phase7-verify/internal/catalog/catalog.go:195-220` enforces capital-E `"Ed25519"`, `base64.RawURLEncoding`, canonical key order, and `ed25519.Verify`.
+- `phase7-verify/internal/catalog/catalog.go:223-229` keeps the inclusive 60-second expiry grace. Regression: `phase7-verify/internal/catalog/catalog_test.go:319-345`.
+- `phase7-verify/internal/catalog/signer_parity_test.go:28-125` runs the real `scripts/sign-catalog.go` keygen/sign flow, accepts the signer output verbatim, and rejects tampering.
+- `phase7-verify/internal/cache/catalog/catalog_cache.go:79-87` implements the three TTL bands; `phase7-verify/internal/cache/catalog/catalog_cache.go:161-167` misses on pubkey rotation and stale cache entries. Regressions: `phase7-verify/internal/cache/catalog/catalog_cache_test.go:9-122`.
+- Import check: `go list -f '{{.ImportPath}} {{join .Imports "\n"}}' ./internal/catalog ./internal/cache/catalog` shows only stdlib imports for the Step 4 packages. Module-level `go list -m all` still lists pre-existing `golang.org/x/*` modules outside this Step 4 surface.
+
+Validation:
+
+- `go test ./internal/catalog -count=1 -v` PASS
+- `go test ./internal/cache/catalog -count=1 -v` PASS
+- `go test ./... -count=1` PASS
+
+VERDICT: READY
+
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 0, LOW 0
+
+## Lens — SECURITY — Round 2
+
+No SECURITY findings.
+
+Security re-audit confirms the fail-closed surfaces from Round 1 are closed:
+
+- Schema acceptance is no longer a signature-valid bypass surface: unsupported versions, trailing JSON, missing required model fields, unsupported model enum values, and missing signature fields are rejected during parse at `phase7-verify/internal/catalog/catalog.go:97-160`.
+- Signature verification cannot be bypassed by body/signature tampering: `phase7-verify/internal/catalog/catalog_test.go:100-149` covers tampered signature/body, and `phase7-verify/internal/catalog/signer_parity_test.go:110-124` repeats tamper rejection against real signer output.
+- Algorithm and signature encoding are constrained before `ed25519.Verify`: `phase7-verify/internal/catalog/catalog.go:195-220` requires exact `"Ed25519"`, decodes `signature.sig` with `base64.RawURLEncoding`, checks signature length, and delegates the cryptographic comparison to `ed25519.Verify`.
+- Expiry handling uses `now.After(expires_at + 60s)`, so exactly 60 seconds is accepted and 61 seconds is rejected: `phase7-verify/internal/catalog/catalog.go:223-229`, `phase7-verify/internal/catalog/catalog_test.go:319-345`.
+- Cache integrity checks preserve the trust boundary: writes use mode `0600` at `phase7-verify/internal/cache/catalog/catalog_cache.go:119`; pubkey rotation and stale entries miss at `phase7-verify/internal/cache/catalog/catalog_cache.go:161-167`, with regressions at `phase7-verify/internal/cache/catalog/catalog_cache_test.go:83-122`.
+
+Validation:
+
+- `go test ./internal/catalog -count=1 -v` PASS
+- `go test ./internal/cache/catalog -count=1 -v` PASS
+- `go test ./... -count=1` PASS
+
+VERDICT: READY
+
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 0, LOW 0
+
+## Lens — ARCHITECT — Round 2
+
+No ARCHITECT findings.
+
+Architecture re-audit confirms Step 4 now composes with the locked SPEC-015 v0.3 contract and the coordinator/signer boundary:
+
+- No locked-spec shifts: `git diff -- specs/SPEC-015-receipts.md specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_4_PROMPT.md` is empty.
+- The verifier remains a hand translation, not a coordinator import. `rg -n "phase4-coordinator|internal/tier2|golang.org/x|github.com/" internal/catalog internal/cache/catalog` finds only comments referencing the coordinator and no third-party imports.
+- The accept/reject contract now matches the coordinator on version, single-object JSON, required signature fields, model ID canonicalization, artifact kind, hash scope, source, and sha256 checks: `phase7-verify/internal/catalog/catalog.go:97-160` vs. `phase4-coordinator/internal/tier2/catalog.go:443-543`.
+- The canonical signing boundary is covered by a real tool-level parity test: `phase7-verify/internal/catalog/signer_parity_test.go:28-125` runs `scripts/sign-catalog.go` and verifies the produced catalog with the verifier.
+- Cache entry shape now carries both contract and implementation timing: `catalog_pubkey_b64`, catalog `expires_at`, and `cache_expires_at` are persisted at `phase7-verify/internal/cache/catalog/catalog_cache.go:46-53` and populated at `phase7-verify/internal/cache/catalog/catalog_cache.go:105-112`.
+- Step 1 wire-shape composition is preserved: parser enforces raw 64-lowercase-hex `sha256` at `phase7-verify/internal/catalog/catalog.go:141-143`, with regressions at `phase7-verify/internal/catalog/catalog_test.go:347-369`.
+
+Validation:
+
+- `go test ./internal/catalog -count=1 -v` PASS
+- `go test ./internal/cache/catalog -count=1 -v` PASS
+- `go test ./... -count=1` PASS
+
+VERDICT: READY
+
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 0, LOW 0

--- a/specs/SPEC-015-v0-3-IMPL-STEP_5-audit.md
+++ b/specs/SPEC-015-v0-3-IMPL-STEP_5-audit.md
@@ -1,0 +1,296 @@
+## Lens — CODE — Round 1
+
+### Findings
+
+1. **HIGH — CLI JSON omits the required v0.3 `model_hash_verified` field.**  
+   `verify.Result.MarshalJSON` was extended with `model_hash_verified`, but the CLI never uses it for `--json`: `emitResult` calls `renderJSON`, whose `jsonResult` type has only the v0.2 fields and whose payload construction copies only those fields. This violates §M.3.2.1's "REQUIRED (always present)" contract and the audit prompt's HIGH condition for absent `model_hash_verified`.  
+   Evidence: `phase7-verify/internal/cli/cli.go:463`, `phase7-verify/internal/cli/output.go:16`, `phase7-verify/internal/cli/output.go:40`.
+
+2. **HIGH — Unknown `receipt_version` is not implemented as `inconclusive: unknown_receipt_version`.**  
+   The parser branches on presence of `receipt_version`, parses any string value, and `validateTuple` never requires `"3"` or returns a forward-compat result. The catalog layer explicitly carries a TODO saying unknown versions are not handled; as written, a signed receipt with `receipt_version: "4"` and the v0.3 key shape can continue through normal verification instead of short-circuiting per §M.1.4.  
+   Evidence: `phase7-verify/internal/receipt/receipt.go:245`, `phase7-verify/internal/receipt/receipt.go:374`, `phase7-verify/internal/verify/catalog_check.go:59`.
+
+3. **HIGH — v0.3 missing/extra tuple fields do not produce the required JSON `invalid` reasons.**  
+   §M.0 / §M.3.2.1 require v0.3 shape failures to return `invalid` with `reason: "extra_field"` or `"missing_field"` and populated `details.field`. The implementation returns parser errors from `receipt.Parse`, wraps them as `InputFormatError`, and the CLI maps that class to exit 65 with no JSON result. The new reason constants also omit `extra_field` and `missing_field`.  
+   Evidence: `phase7-verify/internal/receipt/receipt.go:223`, `phase7-verify/internal/receipt/receipt.go:228`, `phase7-verify/internal/verify/verify.go:45`, `phase7-verify/internal/verify/verify.go:367`, `phase7-verify/internal/cli/cli.go:489`.
+
+4. **HIGH — AC-41 catalog URL cache is not composed into the verifier path.**  
+   Step 5 requires the Step 4 `internal/cache/catalog` package and AC-41 TTL behavior for `--catalog-url`. The current Step 5 verifier resolves catalog bytes with a direct `http.Client.Get` every time and does not thread or call the catalog cache layer; `VerifyOpts.Catalog` also has no cache option. This leaves the AC-41 acceptance gate unimplemented.  
+   Evidence: `phase7-verify/internal/verify/catalog_check.go:93`, `phase7-verify/internal/verify/catalog_check.go:168`, `phase7-verify/internal/verify/verify.go:98`.
+
+5. **MEDIUM — v0.3 details fields are serialized in the wrong shape or dropped.**  
+   §M.3.2.1 requires fields like `details.expected`, `details.actual`, `details.model_id`, `details.catalog_id`, `details.expires_at`, and `details.policy_flag`. The shared `Details` type only exposes `field`, `computed`, `receipt`, and an `extra` map, and the CLI renderer emits details only for `invalid`, dropping required details for `model_id_not_in_catalog` and `catalog_expired` inconclusive results.  
+   Evidence: `phase7-verify/internal/verify/verify.go:131`, `phase7-verify/internal/verify/catalog_check.go:127`, `phase7-verify/internal/verify/catalog_check.go:141`, `phase7-verify/internal/verify/catalog_check.go:152`, `phase7-verify/internal/cli/output.go:50`.
+
+6. **MEDIUM — The advertised CLI surface is stale despite the flags being registered.**  
+   The five new flags are registered in `parseOptions`, but `printUsage` still lists only the v0.2 flags. `go run ./cmd/macprovider-verify --help` confirms `--catalog`, `--catalog-url`, `--catalog-pubkey`, `--catalog-pubkey-url`, and `--require-model-hash` are absent, violating the Step 5 done condition.  
+   Evidence: `phase7-verify/internal/cli/cli.go:158`, `phase7-verify/internal/cli/cli.go:511`.
+
+VERDICT: **FAIL** — Step 5 is not ready for the target of 0 CRITICAL / 0 HIGH / 0 MEDIUM.  
+COUNTS: CRITICAL 0, HIGH 4, MEDIUM 2, LOW 0.
+
+## Lens — SECURITY — Round 1
+
+### Findings
+
+1. **HIGH — JSON-mode buyers cannot tell whether catalog attestation ran.**  
+   The verifier can compute `ModelHashVerified`, but the CLI JSON output strips it. A buyer integrating against `--json` receives `valid` without the required `model_hash_verified: true|false|null` discriminator, making catalog-attested validity indistinguishable from legacy/no-catalog/null-hash validity. That weakens the §M.3.3 trust boundary at the machine-readable interface.  
+   Evidence: `phase7-verify/internal/verify/verify.go:120`, `phase7-verify/internal/cli/output.go:16`, `phase7-verify/internal/cli/output.go:40`, `phase7-verify/internal/cli/cli.go:463`.
+
+2. **HIGH — Future receipt versions can be processed under the v0.3 trust model.**  
+   §M.1.4 forbids canonicalization/signature checking for unknown `receipt_version` values and requires `inconclusive`. The current code does not enforce that boundary and even documents the missing path as a TODO, so a future receipt shape that happens to satisfy the v0.3 key set can be accepted or catalog-checked under semantics the v0.3 verifier was not built to understand.  
+   Evidence: `phase7-verify/internal/receipt/receipt.go:210`, `phase7-verify/internal/receipt/receipt.go:266`, `phase7-verify/internal/verify/catalog_check.go:59`.
+
+3. **MEDIUM — `--explain` still gives the v0.2 trust-boundary disclosure for v0.3 catalog-valid results.**  
+   §M.3.1.1 and §M.3.3 require `--explain` to disclose which catalog contributed to a v0.3 `valid` verdict and the catalog-pubkey trust root. The current explanation still says a valid result does not prove the response was generated by the named model and describes model-hash binding as v0.3+ candidate work. This can mislead operators reviewing security posture from the human-facing output.  
+   Evidence: `phase7-verify/internal/cli/cli.go:131`, `phase7-verify/internal/cli/cli.go:530`, `phase7-verify/internal/cli/cli.go:544`.
+
+VERDICT: **FAIL** — security-relevant output and forward-compat boundaries are incomplete.  
+COUNTS: CRITICAL 0, HIGH 2, MEDIUM 1, LOW 0.
+
+## Lens — ARCHITECT — Round 1
+
+### Findings
+
+1. **HIGH — The shipped JSON schema remains v0.2 and does not model the Step 5 output contract.**  
+   `schemas/output.schema.json` still describes "SPEC-015 v0.2", does not require or allow `model_hash_verified`, and lacks the new reason/warning/details shapes. The enum drift test also hardcodes only the old reason list, so the suite stays green while the schema remains out of date. This breaks the §M.3.2.1 schema artifact contract.  
+   Evidence: `phase7-verify/schemas/output.schema.json:5`, `phase7-verify/schemas/output.schema.json:9`, `phase7-verify/schemas/output.schema.json:100`, `phase7-verify/schemas/output.schema.json:216`, `phase7-verify/internal/verify/enum_drift_test.go:10`.
+
+2. **HIGH — Step 5 acceptance coverage is mostly unit-level and bypasses the public verifier contract.**  
+   The new catalog-check tests call `applyCatalogCheck` directly with synthetic `receipt.Parsed` values, so they do not exercise receipt parsing, signature verification, CLI flag plumbing, exit codes, JSON rendering, schema validation, or the required golden fixture commands for AC-32 through AC-37. AC-38 and AC-41 are not represented by the Step 5 tests.  
+   Evidence: `phase7-verify/internal/verify/catalog_check_test.go:13`, `phase7-verify/internal/verify/catalog_check_test.go:51`, `phase7-verify/internal/verify/catalog_check_test.go:97`, `phase7-verify/internal/verify/catalog_check_test.go:124`, `phase7-verify/internal/verify/catalog_check_test.go:152`.
+
+3. **HIGH — The Step 4 catalog cache package is architecturally bypassed.**  
+   The build prompt requires Step 5 to compose with Step 4's `internal/cache/catalog` package. The verification path imports only `internal/catalog` and resolves URL catalogs with direct HTTP reads, so cache TTL, cache-miss-on-rotation, and cached pubkey binding are not part of the actual verifier architecture.  
+   Evidence: `phase7-verify/internal/verify/catalog_check.go:3`, `phase7-verify/internal/verify/catalog_check.go:13`, `phase7-verify/internal/verify/catalog_check.go:170`, `phase7-verify/internal/cache/catalog/catalog_cache.go:1`.
+
+4. **MEDIUM — Public docs and help still describe the v0.2 verifier.**  
+   The README CLI table and version compatibility section omit all v0.3 catalog flags and still document the old schema/trust posture. The command usage output is similarly stale. That leaves the public verifier surface inconsistent with the implementation and with the Step 5 done condition.  
+   Evidence: `phase7-verify/README.md:68`, `phase7-verify/README.md:78`, `phase7-verify/README.md:118`, `phase7-verify/internal/cli/cli.go:511`.
+
+5. **MEDIUM — The result details abstraction does not match the v0.3 schema amendment.**  
+   The existing generic `Details{Field, Computed, Receipt, Extra}` shape made sense for v0.2 hash mismatches, but Step 5 adds distinct details contracts for catalog, policy, and unknown-version reasons. Keeping the new data under `Extra` makes schema conformance and stable downstream parsing harder, and the renderer already drops inconclusive details because the abstraction remains v0.2-oriented.  
+   Evidence: `phase7-verify/internal/verify/verify.go:131`, `phase7-verify/internal/verify/catalog_check.go:123`, `phase7-verify/internal/verify/catalog_check.go:127`, `phase7-verify/internal/verify/catalog_check.go:141`, `phase7-verify/internal/cli/output.go:50`.
+
+VERDICT: **FAIL** — architecture is not yet aligned with the Step 5 public contract or acceptance gate.  
+COUNTS: CRITICAL 0, HIGH 3, MEDIUM 2, LOW 0.
+
+## Lens — CODE — Round 2
+
+### Fix-pass confirmation
+
+- CLI JSON now carries `model_hash_verified` on all rendered outputs via `jsonResult.ModelHashVerified` and `renderJSON` population. `go test ./...` confirms the suite is green.
+- `receipt_version` is propagated into JSON-capable results after normal verification, and unknown-version handling exists in `Verify()` before resolver, canonical prompt/output hash recomputation, catalog, or signature verification.
+- `extra_field` / `missing_field` reason constants and enum-drift coverage were added.
+- URL catalog fetch now consults `tryCachedCatalogBytes` before HTTP fetch and persists successful URL fetches after catalog verification.
+- `printUsage` advertises the five v0.3 catalog flags plus `--require-model-hash`; `explainText` now includes the catalog-attested v0.3 trust statement.
+
+### Findings
+
+1. **HIGH — Unknown future `receipt_version` receipts are still shape-validated as v0.3 before the §M.1.4 short-circuit can run.**  
+   `parseTuple` uses presence of `receipt_version` to select the exact v0.3 `v03TupleKeys` set and returns `ErrTupleExtraKey` / `ErrTupleMissingKey` before `Verify()` sees the unknown version. That means a future v0.4 receipt with `receipt_version: "4"` plus an added field, omitted v0.3-only field, or changed field type will be mapped to `invalid: extra_field` / `missing_field` / exit-65 format error instead of `inconclusive: unknown_receipt_version`. §M.1.4 says unknown versions must not use field count as a fallback heuristic; version detection must happen before known-version strict-shape validation.  
+   Evidence: `phase7-verify/internal/receipt/receipt.go:210`, `phase7-verify/internal/receipt/receipt.go:212`, `phase7-verify/internal/receipt/receipt.go:223`, `phase7-verify/internal/receipt/receipt.go:228`, `phase7-verify/internal/verify/verify.go:225`, `phase7-verify/internal/verify/verify.go:241`.
+
+2. **MEDIUM — v0.3 details are emitted under `details.extra` instead of the §M.3.2.1 top-level detail keys.**  
+   The implementation now renders details for inconclusive results, but the details payload still uses the v0.2-shaped `Details{field, computed, receipt, extra}` abstraction. Required fields such as `details.expected`, `details.actual`, `details.policy_flag`, `details.catalog_id`, `details.expires_at`, `details.model_id`, and `details.receipt_version` are nested under `details.extra` rather than appearing at `details.<key>` as §M.3.2.1 requires. This blocks stable downstream parsing even though the terminal result/reason is correct.  
+   Evidence: `phase7-verify/internal/verify/catalog_check.go:54`, `phase7-verify/internal/verify/catalog_check.go:77`, `phase7-verify/internal/verify/catalog_check.go:143`, `phase7-verify/internal/verify/catalog_check.go:157`, `phase7-verify/internal/verify/catalog_check.go:168`, `phase7-verify/internal/verify/verify.go:249`, `phase7-verify/internal/cli/output.go:35`, `phase7-verify/internal/cli/output.go:81`.
+
+VERDICT: **FAIL** — the main Round 1 code fixes landed, but §M.1.4 and v0.3 details shape are still not fully compliant.  
+COUNTS: CRITICAL 0, HIGH 1, MEDIUM 1, LOW 0.
+
+## Lens — SECURITY — Round 2
+
+### Fix-pass confirmation
+
+- JSON-mode consumers can now distinguish catalog-attested valid results from non-attested valid results through `model_hash_verified: true|false|null`.
+- `--require-model-hash` now fails closed for legacy and null-hash receipts with `model_hash_verified=false`.
+- Catalog cache composition no longer silently downgrades explicit URL catalog checks: cache misses fall back to HTTP fetch, and stale / pubkey-rotated entries miss.
+- The v0.3 `--explain` text no longer preserves the old blanket "does not prove model" statement for catalog-attested valid results; it scopes the stronger claim to `model_hash_verified: true`.
+
+### Findings
+
+1. **MEDIUM — Security-relevant diagnostic details are not exposed in the specified machine-readable shape.**  
+   The verifier returns the correct terminal states for policy reject, hash mismatch, catalog expiry, missing model, and unknown version, but the reason-specific facts are nested in `details.extra` or constrained by the old `field/computed/receipt` model. A buyer-side policy engine expecting §M.3.2.1 fields like `details.expected`, `details.actual`, `details.policy_flag`, or `details.receipt_version` cannot consume them as specified. This does not create a false-valid path, so it is not HIGH, but it weakens the intended security automation surface.  
+   Evidence: `phase7-verify/internal/verify/catalog_check.go:54`, `phase7-verify/internal/verify/catalog_check.go:143`, `phase7-verify/internal/verify/catalog_check.go:168`, `phase7-verify/internal/verify/verify.go:249`, `phase7-verify/internal/cli/output.go:35`, `phase7-verify/internal/cli/output.go:81`.
+
+VERDICT: **FAIL** — no catalog-bypass or false-valid security path found, but the machine-readable security diagnostics remain off-contract.  
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 1, LOW 0.
+
+## Lens — ARCHITECT — Round 2
+
+### Fix-pass confirmation
+
+- `schemas/output.schema.json` is now labeled v0.3, requires `model_hash_verified` in all result branches, includes the new reason enum values, and admits the new warning kinds.
+- `enum_drift_test.go` includes the ten new reason constants and proves the schema reason set is bijective with verifier constants.
+- Step 4 catalog cache is now part of the verifier URL path: `tryCachedCatalogBytes` is called before `resolveCatalogBytes`, and successful verified URL fetches are persisted through `internal/cache/catalog`.
+- Help and explain text now align with the v0.3 catalog surface at a public CLI level.
+
+### Findings
+
+1. **HIGH — The published v0.3 output schema still does not model v0.3 `details` and rejects several outputs the verifier can emit.**  
+   The invalid branch includes the new v0.3 reasons, but its `details.field` enum still only allows the v0.2 fields (`signature`, `prompt_hash`, `output_hash`, `pubkey`, `grace_window`) and requires `details.receipt`; `model_hash_required` and `model_hash_mismatch` emit `details.field: "model_hash"`, so schema validation rejects them. The inconclusive branch includes `model_id_not_in_catalog`, `catalog_expired`, and `unknown_receipt_version`, but defines no `details` property while `additionalProperties: false` is set, so the now-rendered required inconclusive details are schema-invalid. This leaves the release artifact contract incomplete despite the enum bump.  
+   Evidence: `phase7-verify/schemas/output.schema.json:225`, `phase7-verify/schemas/output.schema.json:272`, `phase7-verify/schemas/output.schema.json:279`, `phase7-verify/schemas/output.schema.json:332`, `phase7-verify/schemas/output.schema.json:498`, `phase7-verify/schemas/output.schema.json:503`, `phase7-verify/schemas/output.schema.json:506`, `phase7-verify/schemas/output.schema.json:693`, `phase7-verify/internal/verify/catalog_check.go:54`, `phase7-verify/internal/verify/catalog_check.go:168`.
+
+2. **HIGH — The forward-compat boundary is split across parser and verifier layers, so §M.1.4 is not architecturally enforced at the version-dispatch boundary.**  
+   The verifier has a correct-looking unknown-version branch, but it sits after `parseInput`; the parser has already committed unknown `receipt_version` inputs to the v0.3 exact-shape contract. That violates the intended tagged-union architecture from the build prompt: legacy, known v0.3, and unknown-version receipts should be separated before known-version canonical shape validation. The current layering will regress on future-version receipts that do not preserve the v0.3 nine-key shape.  
+   Evidence: `phase7-verify/internal/receipt/receipt.go:207`, `phase7-verify/internal/receipt/receipt.go:212`, `phase7-verify/internal/receipt/receipt.go:223`, `phase7-verify/internal/receipt/receipt.go:228`, `phase7-verify/internal/verify/verify.go:225`, `phase7-verify/internal/verify/verify.go:241`, `phase7-verify/internal/verify/catalog_check.go:60`.
+
+3. **MEDIUM — The green suite does not cover v0.3 schema conformance for the newly-added reason/detail combinations.**  
+   `go test ./...` is green, but schema validation tests only exercise legacy-shaped invalid details and generic inconclusive output. There is no schema validation case for `model_hash_required`, `model_hash_mismatch`, `model_id_not_in_catalog`, `catalog_expired`, or `unknown_receipt_version`, which is why the schema/detail mismatch above escaped.  
+   Evidence: `phase7-verify/internal/cli/output_test.go:253`, `phase7-verify/internal/cli/output_test.go:257`, `phase7-verify/internal/cli/output_test.go:287`, `phase7-verify/internal/verify/catalog_check_test.go:37`, `phase7-verify/internal/verify/catalog_check_test.go:75`, `phase7-verify/internal/verify/catalog_check_test.go:97`, `phase7-verify/internal/verify/catalog_check_test.go:124`.
+
+VERDICT: **FAIL** — cache/help/schema-enum fixes landed, but the public schema artifact and unknown-version boundary remain architecturally incomplete.  
+COUNTS: CRITICAL 0, HIGH 2, MEDIUM 1, LOW 0.
+
+## Lens — CODE — Round 3
+
+### Fix-pass confirmation
+
+- Unknown `receipt_version` is now dispatched in `parseTuple` before known-version strict-shape validation. A present string value other than `"3"` returns a Tuple stub with only `ReceiptVersion` populated, allowing `Verify()` to short-circuit to `inconclusive: unknown_receipt_version` before resolver, canonicalization, signature check, or catalog work.
+- v0.3 `Details` now has named fields (`expected`, `actual`, `policy_flag`, `model_id`, `catalog_id`, `expires_at`, `receipt_version`, `cause`, `url`, `alg`) and the CLI JSON renderer carries those fields through for invalid and inconclusive results.
+- `schemas/output.schema.json` now accepts v0.3 named details for invalid and inconclusive variants, allows `trust_source: "none"` on pre-resolver invalid/inconclusive paths, and keeps valid results restricted to `explicit_pubkey`, `cache`, or `live`.
+- `TestV03SchemaConformance` adds fixtures for the Round 2 schema/detail gaps, and `go test ./...` is green in `phase7-verify/`.
+
+### Findings
+
+1. **MEDIUM — `catalog_signature_invalid` omits the required `details.alg` field.**  
+   §M.3.2.1 requires `catalog_signature_invalid` details to include `details.field: "signature"` and `details.alg: <observed alg string>`. The data model and CLI renderer now have an `Alg` field, but `applyCatalogCheck` populates only `Field` and `Cause` for both typed catalog signature failures and generic verification failures. The positive schema fixture mirrors that omission, so the new schema conformance test does not catch the missing required detail. This does not create a false-valid or catalog-bypass path, but the v0.3 machine-readable details contract is still incomplete for one new reason.  
+   Evidence: `phase7-verify/internal/verify/verify.go:150`, `phase7-verify/internal/verify/verify.go:152`, `phase7-verify/internal/verify/catalog_check.go:127`, `phase7-verify/internal/verify/catalog_check.go:134`, `phase7-verify/internal/verify/catalog_check.go:146`, `phase7-verify/internal/cli/v03_schema_conformance_test.go:87`, `phase7-verify/internal/cli/v03_schema_conformance_test.go:97`.
+
+VERDICT: **FAIL** — Round 2's parser-layer and broad details/schema fixes landed, but one v0.3 details requirement remains off-contract.  
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 1, LOW 0.
+
+## Lens — SECURITY — Round 3
+
+### Fix-pass confirmation
+
+- No false-valid catalog path was found: hash mismatch still returns `invalid` with `model_hash_verified=false`, catalog signature failure still returns `invalid`, and successful catalog match is the only path that sets `model_hash_verified=true`.
+- `--require-model-hash` remains fail-closed for legacy and null-hash receipts.
+- URL catalog and pubkey fetches remain blocked by `--offline`; default HTTP clients use a 5-second timeout and no retry loop.
+- Changed verifier packages import only standard-library and repo-local packages; no third-party runtime imports were introduced in the changed verification path.
+
+### Findings
+
+1. **MEDIUM — Security automation cannot rely on the specified algorithm diagnostic for catalog signature failures.**  
+   Lowercase or otherwise unexpected catalog signature algorithms are rejected, but the resulting verifier details expose the algorithm only inside a human-readable `cause` string rather than the required `details.alg` field. Buyer-side policy or telemetry that keys on §M.3.2.1's structured `alg` detail cannot distinguish lowercase-alg rejection from other signature failures without string parsing. The terminal result remains fail-closed, so this is not HIGH.  
+   Evidence: `phase7-verify/internal/catalog/catalog.go:195`, `phase7-verify/internal/catalog/catalog.go:196`, `phase7-verify/internal/catalog/catalog.go:197`, `phase7-verify/internal/verify/catalog_check.go:127`, `phase7-verify/internal/verify/catalog_check.go:134`, `phase7-verify/internal/verify/catalog_check.go:146`.
+
+VERDICT: **FAIL** — fail-closed behavior is intact, but one structured security diagnostic remains below the v0.3 contract.  
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 1, LOW 0.
+
+## Lens — ARCHITECT — Round 3
+
+### Fix-pass confirmation
+
+- The unknown-version boundary now matches the build prompt's tagged-union shape: parser version dispatch happens before v0.3 strict key validation, and verifier short-circuiting happens before canonicalization/signature/catalog stages.
+- The schema artifact now accepts named v0.3 details for both invalid and inconclusive outputs and preserves the existing valid-variant trust-source constraints.
+- The new schema conformance test demonstrates acceptance of 11 representative v0.3 output fixtures, including unknown receipt version, strict-shape errors, catalog-attested valid output, and legacy-with-catalog skipped output.
+- Validation run: `go test ./...` passed for all `phase7-verify` packages; targeted `TestV03SchemaConformance` and `TestSchemaRejectsTrustSourceCoordinatorHostMismatches` also passed.
+
+### Findings
+
+1. **MEDIUM — The schema/test layer accepts a `catalog_signature_invalid` output that is missing a required v0.3 detail.**  
+   The published schema defines `details.alg` as an allowed string, but it does not conditionally require `alg` when `reason` is `catalog_signature_invalid`. `TestV03SchemaConformance` then validates a `catalog_signature_invalid` fixture with `details.field` and `details.cause` but no `details.alg`, so the acceptance gate can go green while the §M.3.2.1 detail contract is not fully modeled. This is narrower than the Round 2 schema failure because actual v0.3 outputs are no longer rejected wholesale, but the schema is still permissive for one required reason-specific field.  
+   Evidence: `phase7-verify/schemas/output.schema.json:225`, `phase7-verify/schemas/output.schema.json:235`, `phase7-verify/schemas/output.schema.json:273`, `phase7-verify/schemas/output.schema.json:315`, `phase7-verify/schemas/output.schema.json:319`, `phase7-verify/internal/cli/v03_schema_conformance_test.go:87`, `phase7-verify/internal/cli/v03_schema_conformance_test.go:97`, `phase7-verify/internal/cli/v03_schema_conformance_test.go:183`.
+
+VERDICT: **FAIL** — architectural Round 2 blockers are resolved, but the schema/test contract still does not enforce one required v0.3 detail field.  
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 1, LOW 0.
+
+## Lens — CODE — Round 4
+
+### Fix-pass confirmation
+
+- The lowercase/wrong-alg catalog path now propagates `catalog.ErrSignatureInvalid.ObservedAlg` from `catalog.Verify()` into `verify.Details.Alg`, and `catalog_check.go` emits that field for typed signature failures.
+- The positive `TestV03SchemaConformance` fixture for `catalog_signature_invalid` now includes `details.alg`, and `schemas/output.schema.json` has a conditional `allOf` requiring non-empty `details.alg` when `reason` is `catalog_signature_invalid`.
+- Validation run: `go test ./...` passed for all `phase7-verify` packages.
+
+### Findings
+
+1. **MEDIUM — Tampered catalog signatures still emit `catalog_signature_invalid` without the required `details.alg`.**  
+   The new `ObservedAlg` plumbing is present for wrong `signature.alg`, base64 decode failure, and signature length failure, but the normal cryptographic verification failure path still returns `&ErrSignatureInvalid{Reason: "ed25519.Verify returned false"}` without `ObservedAlg`. `catalog_check.go` copies `sigErr.ObservedAlg` directly into `Details.Alg`; because the CLI JSON field is `omitempty`, this reachable bad-signature output omits `details.alg` and violates §M.3.2.1. The existing tampered-signature tests assert only the typed error, not the observed algorithm field, so the suite stays green.  
+   Evidence: `phase7-verify/internal/catalog/catalog.go:195`, `phase7-verify/internal/catalog/catalog.go:226`, `phase7-verify/internal/catalog/catalog.go:227`, `phase7-verify/internal/verify/catalog_check.go:127`, `phase7-verify/internal/verify/catalog_check.go:134`, `phase7-verify/internal/cli/output.go:50`, `phase7-verify/internal/catalog/catalog_test.go:119`, `phase7-verify/internal/catalog/catalog_test.go:124`.
+
+VERDICT: **FAIL** — the schema/test fixture fix landed for the wrong-alg case, but one common signature-invalid path still violates the `details.alg` contract.  
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 1, LOW 0.
+
+## Lens — SECURITY — Round 4
+
+### Fix-pass confirmation
+
+- Lowercase or otherwise wrong catalog `signature.alg` remains fail-closed and now exposes the observed algorithm in structured JSON details.
+- The schema now rejects a synthetic `catalog_signature_invalid` result that omits `details.alg`.
+- No false-valid path was found in the Round 4 review; catalog signature failures still return `invalid`.
+
+### Findings
+
+1. **MEDIUM — Structured security diagnostics are still incomplete for real bad-signature bytes.**  
+   A catalog with `signature.alg: "Ed25519"` but tampered signed bytes is rejected, but the emitted typed error does not carry the observed alg. Downstream policy engines and telemetry that rely on §M.3.2.1's structured `details.alg` cannot uniformly process `catalog_signature_invalid` without string inspection or a schema failure. This remains fail-closed, so it is not HIGH, but the machine-readable security surface is still off-contract.  
+   Evidence: `phase7-verify/internal/catalog/catalog.go:226`, `phase7-verify/internal/catalog/catalog.go:227`, `phase7-verify/internal/verify/catalog_check.go:131`, `phase7-verify/internal/verify/catalog_check.go:134`, `phase7-verify/internal/catalog/catalog_test.go:100`, `phase7-verify/internal/catalog/catalog_test.go:119`, `phase7-verify/internal/catalog/catalog_test.go:124`.
+
+VERDICT: **FAIL** — fail-closed behavior is preserved, but `catalog_signature_invalid` diagnostics are not yet uniformly structured.  
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 1, LOW 0.
+
+## Lens — ARCHITECT — Round 4
+
+### Fix-pass confirmation
+
+- The schema artifact now models the Round 3 requirement by conditionally requiring `details.alg` for `catalog_signature_invalid`.
+- The conformance suite includes both a positive `catalog_signature_invalid` fixture with `details.alg` and a negative fixture proving omission is schema-invalid.
+- Full validation run: `go test ./...` passed.
+
+### Findings
+
+1. **MEDIUM — The stricter schema is now ahead of one verifier emission path.**  
+   Architecturally, the contract moved in the right direction: schema validation now requires `details.alg`. However, `catalog.Verify()` does not attach `ObservedAlg` on the `ed25519.Verify returned false` path, and there is no end-to-end schema conformance test for an actual tampered catalog emission. The artifact layer can now reject a result shape the verifier can still produce, so the Step 5 schema/renderer contract is not fully closed.  
+   Evidence: `phase7-verify/schemas/output.schema.json:472`, `phase7-verify/schemas/output.schema.json:488`, `phase7-verify/internal/cli/v03_schema_conformance_test.go:87`, `phase7-verify/internal/cli/v03_schema_conformance_test.go:99`, `phase7-verify/internal/cli/v03_schema_conformance_test.go:184`, `phase7-verify/internal/cli/v03_schema_conformance_test.go:201`, `phase7-verify/internal/catalog/catalog.go:226`, `phase7-verify/internal/catalog/catalog.go:227`.
+
+VERDICT: **FAIL** — schema enforcement is fixed, but implementation and coverage are not yet aligned with that stricter artifact contract.  
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 1, LOW 0.
+
+## Lens — CODE — Round 5
+
+### Fix-pass confirmation
+
+- The `ed25519.Verify returned false` branch in `catalog.Verify()` now returns `ErrSignatureInvalid` with `ObservedAlg: f.Signature.Alg`, matching the existing wrong-alg, signature-decode, and signature-length branches.
+- `applyCatalogCheck()` already copies `catalog.ErrSignatureInvalid.ObservedAlg` into `Details.Alg`; with the catalog-layer fix, tampered signature bytes now produce `catalog_signature_invalid` with non-empty `details.alg`.
+- `TestVerifyTamperedSignatureCarriesObservedAlg` covers the catalog package's tampered-signature branch directly, and `TestCatalogCheckTamperedCatalogPopulatesDetailsAlg` covers the full `applyCatalogCheck` emission path for a post-signing tampered catalog.
+- Validation run: `go test ./internal/catalog ./internal/verify ./internal/cli` passed; `go test ./...` passed for all `phase7-verify` packages.
+
+### Findings
+
+None.
+
+VERDICT: **PASS** — the last Round 4 code gap is closed; no remaining CODE CRITICAL / HIGH / MEDIUM findings found in this pass.  
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 0, LOW 0.
+
+## Lens — SECURITY — Round 5
+
+### Fix-pass confirmation
+
+- A catalog with `signature.alg: "Ed25519"` but tampered signed bytes still fails closed as `invalid` with `reason: "catalog_signature_invalid"`.
+- The same bad-signature path now carries the observed algorithm as structured `details.alg`, so security automation no longer needs to parse a human-readable cause string for this reason.
+- The model-hash attestation boundary remains unchanged: catalog signature failure short-circuits before model lookup/hash equality and cannot set `model_hash_verified=true`.
+- Validation run: `go test ./...` passed.
+
+### Findings
+
+None.
+
+VERDICT: **PASS** — no false-valid catalog path or incomplete structured security diagnostic remains for the Round 4 tampered-signature case.  
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 0, LOW 0.
+
+## Lens — ARCHITECT — Round 5
+
+### Fix-pass confirmation
+
+- The implementation now matches the stricter schema contract: `catalog_signature_invalid` emissions from both wrong-alg and tampered-signature paths can satisfy the schema's conditional `details.alg` requirement.
+- Coverage now spans all relevant layers for the prior gap: catalog typed error propagation, verifier catalog-check result details, and schema-level rejection of missing `details.alg`.
+- The helper `writeTamperedSignedCatalog` creates the intended fixture class: a catalog signed with `signature.alg: "Ed25519"` and then mutated after signing so verification reaches the cryptographic false branch.
+- Validation run: `go test ./internal/catalog ./internal/verify ./internal/cli` passed; `go test ./...` passed.
+
+### Findings
+
+None.
+
+VERDICT: **PASS** — schema, verifier emission, and regression coverage are aligned for Step 5's final `details.alg` contract.  
+COUNTS: CRITICAL 0, HIGH 0, MEDIUM 0, LOW 0.

--- a/specs/SPEC-015-v0-3-IMPL-STEP_6-audit.md
+++ b/specs/SPEC-015-v0-3-IMPL-STEP_6-audit.md
@@ -1,0 +1,89 @@
+## Lens — CODE — Round 1
+
+### CODE-R1-CRITICAL-1 — AC-38 manifest evidence does not establish the locked-v0.2.4 verifier behavior
+
+SPEC-015 §M.5 AC-38 requires an unmodified locked v0.1.3 / v0.2.4 verifier to read a v0.3 receipt and report `invalid`; the named test command is `./phase7-verify-v0.2.4 --bundle <v0.3-bundle.json>` (`specs/SPEC-015-receipts.md:3555`). The Step 6 manifest instead maps AC-38 to `cd phase7-verify && go test ./internal/receipt/ -count=1` (`test/integration/spec015/v03_acceptance_manifest_test.go:129`) and cites current v0.3 source anchors (`test/integration/spec015/v03_acceptance_manifest_test.go:131`, `test/integration/spec015/v03_acceptance_manifest_test.go:138`, `test/integration/spec015/v03_acceptance_manifest_test.go:139`). Those anchors prove the current parser has v0.3 tuple-shape handling; they do not execute or inspect an unmodified v0.2.4 verifier binary. This matches the audit prompt's CRITICAL class: an AC manifest claims coverage that the cited evidence does not actually establish (`specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_6_PROMPT.md:25`).
+
+### CODE-R1-MEDIUM-1 — AC-30 and AC-31 do not meet the stated two-anchor manifest bar
+
+The Step 6 audit prompt says each AC has at least two evidence anchors (`specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_6_PROMPT.md:14`). AC-30 has one anchor (`test/integration/spec015/v03_acceptance_manifest_test.go:44`), and AC-31 has one anchor (`test/integration/spec015/v03_acceptance_manifest_test.go:54`). The manifest test validates command/CI presence and pattern existence (`test/integration/spec015/v03_acceptance_manifest_test.go:216`, `test/integration/spec015/v03_acceptance_manifest_test.go:219`), but it never asserts `len(ac.Evidence) >= 2`. This leaves the manifest below the stated Step 6 evidence standard even though the current test passes.
+
+Validation run: `cd test/integration && go test ./spec015/ -count=1 -timeout 120s -run 'TestSpec015V03AcceptanceCriteria|TestSpec015V03AcceptanceManifestCoversAC28ThroughAC42'` passed.
+
+VERDICT: FAIL — AC-38 must be backed by a real locked-v0.2.4 verifier command/evidence before Step 6 can close.
+
+COUNTS: CRITICAL=1 HIGH=0 MEDIUM=1 LOW=0
+
+## Lens — SECURITY — Round 1
+
+### SECURITY-R1-HIGH-1 — Rollback command points at backup paths the deploy script does not create
+
+The runbook rollback command restores `/opt/macprovider/coordinator.bak` (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:121`) and states the deploy script preserves that file (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:125`). The actual deploy script snapshots the previous binary to `/opt/macprovider/coordinator.prev` (`phase4-coordinator/dist/deploy-pearl-vps.sh:229`, `phase4-coordinator/dist/deploy-pearl-vps.sh:230`), and the canonical rollback procedure restores that `.prev` snapshot with `install -o macprovider -g macprovider -m 0755` (`audits/2026-06-10/ROLLBACK_PROCEDURE.md:25`, `audits/2026-06-10/ROLLBACK_PROCEDURE.md:30`). The same runbook also claims an nginx backup at `/etc/nginx/sites-available/coordinator.streamvc.live.conf.bak-<UTC>` (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:125`), but the deploy script installs `/tmp/nginx-coordinator-full.conf` directly to `/etc/nginx/sites-available/$DOMAIN` (`phase4-coordinator/dist/deploy-pearl-vps.sh:315`) without creating that backup. This is a HIGH under the prompt because the runbook rollback step does not compose with the current deploy script (`specs/AUDIT_SPEC_015_v0_3_IMPL_STEP_6_PROMPT.md:31`).
+
+No Entry 80 flip found: the runbook says the five tier-2 `require_*` flags stay false (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:49`) and explicitly says `Tier2Config.RequireHashVerified` is not flipped (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:131`). Provider rollout order is correct: verifier release before provider distribution (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:87`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:90`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:91`).
+
+VERDICT: FAIL — rollback instructions must be corrected before operator handoff.
+
+COUNTS: CRITICAL=0 HIGH=1 MEDIUM=0 LOW=0
+
+## Lens — ARCHITECT — Round 1
+
+### ARCHITECT-R1-CRITICAL-1 — Step 6 does not deliver the cross-binary parity gate required by the BUILD prompt
+
+The BUILD prompt defines Step 6 as "Integration acceptance + cross-binary parity" (`specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:290`) and requires a cross-binary test that builds/runs the v0.3 verifier and a v0.2.4 verifier against the same v0.1/v0.2 and v0.3 receipts (`specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:304`). It also requires a `test/integration/spec015_v03/` harness (`specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md:298`). The landed Step 6 surface is a manifest file at `test/integration/spec015/v03_acceptance_manifest_test.go`, and no `test/integration/spec015_v03/` harness or `phase7-verify-v0.2.4` executable was found in the worktree. The AC-38 manifest entry therefore collapses the architectural boundary from "prove locked old verifier rejects new wire" to "current code contains a strict tuple-shape path" (`test/integration/spec015/v03_acceptance_manifest_test.go:129`, `test/integration/spec015/v03_acceptance_manifest_test.go:138`). Because AC-38 is the §M.1.2 forward-incompat guard that justifies the runbook's verifier-before-provider choreography, this is not a harmless test-shape substitution.
+
+### ARCHITECT-R1-HIGH-1 — Operator rollback handoff contradicts the deploy script's actual state model
+
+The runbook's binary rollback target is `.bak` and its nginx rollback target is a dated site-conf backup (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:122`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:125`). The deploy script's state model uses `.prev` for binary rollback (`phase4-coordinator/dist/deploy-pearl-vps.sh:220`, `phase4-coordinator/dist/deploy-pearl-vps.sh:229`) and does not create the claimed nginx backup before overwriting the site config (`phase4-coordinator/dist/deploy-pearl-vps.sh:313`, `phase4-coordinator/dist/deploy-pearl-vps.sh:315`). That breaks A.1/A.5 composition: the operator handoff cannot be followed mechanically during a failed `/catalog/` rollout.
+
+Positive checks: locked SPEC-015 remains v0.3.3 LOCKED (`specs/SPEC-015-receipts.md:3`); no locked-spec diff was present for SPEC-001/002/005/006/008/010/011/013/015 in this worktree; the runbook documents the README close-out (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:138`); the v0.4+ candidate list matches §M.6 deferred themes (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:140`, `specs/SPEC-015-receipts.md:3642`).
+
+VERDICT: FAIL — Step 6 architecture is missing the required cross-binary acceptance gate and the operator rollback handoff is not executable as written.
+
+COUNTS: CRITICAL=1 HIGH=1 MEDIUM=0 LOW=0
+
+## Lens — CODE — Round 2
+
+No Round 2 CODE findings.
+
+The AC-38 manifest entry now names a runnable command for the locked-parser parity gate: `cd phase7-verify && go test ./internal/receipt/ -run TestV02LockedParserRejectsV03Receipts -count=1` (`test/integration/spec015/v03_acceptance_manifest_test.go:131`). Its evidence anchors point at the new parity test, the inline locked-parser mirror, and the explicit v0.3 rejection assertion (`test/integration/spec015/v03_acceptance_manifest_test.go:141`, `test/integration/spec015/v03_acceptance_manifest_test.go:142`, `test/integration/spec015/v03_acceptance_manifest_test.go:143`). The test drives both non-null and null-`model_hash` v0.3 tuples through `parseTupleV02Locked` and requires `ErrTupleExtraKey`; it also confirms a genuine legacy 7-field tuple remains accepted (`phase7-verify/internal/receipt/v02_parity_test.go:72`, `phase7-verify/internal/receipt/v02_parity_test.go:75`, `phase7-verify/internal/receipt/v02_parity_test.go:78`).
+
+The AC-30 / AC-31 evidence-anchor gap is closed: AC-30 now has receipt-builder test plus implementation anchors (`test/integration/spec015/v03_acceptance_manifest_test.go:44`, `test/integration/spec015/v03_acceptance_manifest_test.go:45`, `test/integration/spec015/v03_acceptance_manifest_test.go:46`), and AC-31 now has HTTP error-path plus implementation anchors (`test/integration/spec015/v03_acceptance_manifest_test.go:55`, `test/integration/spec015/v03_acceptance_manifest_test.go:56`, `test/integration/spec015/v03_acceptance_manifest_test.go:57`). The manifest test now enforces the Step 6 >=2-anchor invariant for every AC before checking file/pattern existence (`test/integration/spec015/v03_acceptance_manifest_test.go:223`, `test/integration/spec015/v03_acceptance_manifest_test.go:225`), and still runs named subtests for AC-28 through AC-42 plus AC-32a (`test/integration/spec015/v03_acceptance_manifest_test.go:239`, `test/integration/spec015/v03_acceptance_manifest_test.go:241`, `test/integration/spec015/v03_acceptance_manifest_test.go:245`).
+
+Validation runs:
+- `cd test/integration && go test ./spec015/ -count=1 -timeout 120s` passed.
+- `cd phase7-verify && go test ./internal/receipt/ -count=1` passed.
+
+VERDICT: PASS — Round 1 CODE critical and medium findings are closed.
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0
+
+## Lens — SECURITY — Round 2
+
+No Round 2 SECURITY findings.
+
+The rollback instructions now match the deploy script's state model. The runbook restores `/opt/macprovider/coordinator.prev` with `install -o macprovider -g macprovider -m 0755` (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:124`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:130`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:131`), which composes with the deploy script's pre-upload snapshot to the same `.prev` path (`phase4-coordinator/dist/deploy-pearl-vps.sh:220`, `phase4-coordinator/dist/deploy-pearl-vps.sh:228`, `phase4-coordinator/dist/deploy-pearl-vps.sh:229`). The runbook no longer claims the deploy script creates an nginx backup; it states the script does not snapshot the site conf and gives the operator a timestamped pre-deploy snapshot command (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:135`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:138`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:141`), matching the script's direct install of `/tmp/nginx-coordinator-full.conf` to `/etc/nginx/sites-available/$DOMAIN` (`phase4-coordinator/dist/deploy-pearl-vps.sh:313`, `phase4-coordinator/dist/deploy-pearl-vps.sh:315`).
+
+Entry 80 preservation remains intact: the runbook says the tier-2 `require_*` flags stay at their defaults (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:49`) and explicitly says `Tier2Config.RequireHashVerified` is not flipped (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:155`), consistent with Entry 80's `false`-default deferral (`beta/DECISION_CRITERIA.md:374`). Provider/buyer rollout order still protects forward-incompat: the runbook instructs verifier release before provider rollout (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:87`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:90`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:91`). Smoke-check and monitoring commands use the operator key as a shell variable and do not print it (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:64`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:65`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:108`).
+
+VERDICT: PASS — Round 1 SECURITY high finding is closed.
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0
+
+## Lens — ARCHITECT — Round 2
+
+No Round 2 ARCHITECT findings.
+
+The AC-38 parity boundary is now explicit enough for the Step 6 acceptance manifest: the new test documents that it is an inline re-implementation of the v0.2.4 locked `parseTuple` at commit `99d0c1e`, with exactly seven allowed keys and no `receipt_version` / `model_hash` awareness (`phase7-verify/internal/receipt/v02_parity_test.go:83`, `phase7-verify/internal/receipt/v02_parity_test.go:93`, `phase7-verify/internal/receipt/v02_parity_test.go:101`). It covers both v0.3 receipt shapes and the legacy acceptance floor, which is the architectural invariant AC-38 needs for the runbook's verifier-before-provider choreography (`phase7-verify/internal/receipt/v02_parity_test.go:40`, `phase7-verify/internal/receipt/v02_parity_test.go:51`, `phase7-verify/internal/receipt/v02_parity_test.go:62`, `phase7-verify/internal/receipt/v02_parity_test.go:72`, `phase7-verify/internal/receipt/v02_parity_test.go:78`).
+
+The operator handoff now composes with the deploy script: binary rollback uses `.prev` (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:126`, `phase4-coordinator/dist/deploy-pearl-vps.sh:229`), nginx rollback is framed as a caller-owned pre-deploy snapshot because the script overwrites the site config without an automatic backup (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:135`, `phase4-coordinator/dist/deploy-pearl-vps.sh:315`), and the `/catalog/*` surface is described as additive with verifier fallback to file-mode `--catalog` (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:149`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:150`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:151`).
+
+Locked-spec and close-out invariants hold: no diff was present for the locked SPEC files inspected in this round; SPEC-015 remains v0.3.3 LOCKED (`specs/SPEC-015-receipts.md:3`); the runbook preserves Entry 80 and points README close-out at the v0.3 model-hash binding update (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:153`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:162`). The v0.4+ candidate list remains aligned with §M.6 deferred items: streaming receipts, multi-hash receipts, cross-catalog federation, on-chain anchoring, quantization-aware verification, and TUF/signed-root trust-root hardening (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:164`, `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md:166`, `specs/SPEC-015-receipts.md:3642`).
+
+Validation runs:
+- `cd test/integration && go test ./spec015/ -count=1 -timeout 120s` passed.
+- `cd phase7-verify && go test ./internal/receipt/ -count=1` passed.
+
+VERDICT: PASS — Round 1 ARCHITECT critical and high findings are closed.
+
+COUNTS: CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0

--- a/test/integration/spec015/v03_acceptance_manifest_test.go
+++ b/test/integration/spec015/v03_acceptance_manifest_test.go
@@ -1,0 +1,269 @@
+package spec015
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// SPEC-015 v0.3 §M.5 — AC-28 through AC-42 + AC-32a. The manifest
+// mirrors the v0.2 acceptanceCriterion shape; SpecStep is in the
+// §M.5 form because v0.3 §M is a new top-level section (not §14).
+var spec015V03ACs = []acceptanceCriterion{
+	{
+		Number:   28,
+		Summary:  "v0.3 provider emits an X-MacProvider-Receipt header whose tuple decodes to exactly 9 fields in JCS canonical (alphabetical) order with receipt_version=\"3\"",
+		SpecStep: "SPEC-015 §M.5 AC-28",
+		Commands: []string{"cd phase3-binary && swift test --filter ReceiptBuilderTests"},
+		CIJobs:   []string{"phase3-binary (swift test)"},
+		Evidence: []evidenceAnchor{
+			{"phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift", "v03TupleKeys"},
+			{"phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift", "testCanonicalTupleIsAlphabeticalUtf16Order"},
+			{"phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift", "receiptVersionV03"},
+		},
+	},
+	{
+		Number:   29,
+		Summary:  "warm-swap-on provider's receipt model_hash matches the runtime-served snapshot hash",
+		SpecStep: "SPEC-015 §M.5 AC-29",
+		Commands: []string{"cd phase3-binary && swift test --filter HTTPServerReceiptTests"},
+		CIJobs:   []string{"phase3-binary (swift test)"},
+		Evidence: []evidenceAnchor{
+			{"phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift", "testHTTPSuccessReceiptCarriesWarmSwapHash"},
+			{"phase3-binary/Sources/macprovider-cli/ModelRuntime.swift", "completeWithServedSnapshot"},
+		},
+	},
+	{
+		Number:   30,
+		Summary:  "warm-swap-disabled provider emits model_hash as the JSON null literal (not empty string, not absent)",
+		SpecStep: "SPEC-015 §M.5 AC-30",
+		Commands: []string{"cd phase3-binary && swift test --filter ReceiptBuilderTests"},
+		CIJobs:   []string{"phase3-binary (swift test)"},
+		Evidence: []evidenceAnchor{
+			{"phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift", "testBuildEmitsJSONNullForAbsentModelHash"},
+			{"phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift", "modelHashValue = .null"},
+		},
+	},
+	{
+		Number:   31,
+		Summary:  "error / null-usage receipt inherits the request-start model_hash (warm-swap-on path)",
+		SpecStep: "SPEC-015 §M.5 AC-31",
+		Commands: []string{"cd phase3-binary && swift test --filter HTTPServerReceiptTests"},
+		CIJobs:   []string{"phase3-binary (swift test)"},
+		Evidence: []evidenceAnchor{
+			{"phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift", "testHTTPErrorReceiptInheritsWarmSwapHash"},
+			{"phase3-binary/Sources/macprovider-cli/HTTPServer.swift", "modelHashSource: fallbackHashSource"},
+		},
+	},
+	{
+		Number:   32,
+		Summary:  "v0.3 verifier reports valid + catalog_skipped_null_hash warning when receipt has model_hash:null and catalog flags supplied",
+		SpecStep: "SPEC-015 §M.5 AC-32",
+		Commands: []string{"cd phase7-verify && go test ./internal/verify/ -run TestCatalogCheckNullHashWithCatalogFlags -count=1"},
+		CIJobs:   []string{"phase7-verify (go vet + test)"},
+		Evidence: []evidenceAnchor{
+			{"phase7-verify/internal/verify/catalog_check_test.go", "TestCatalogCheckNullHashWithCatalogFlags"},
+			{"phase7-verify/internal/verify/verify.go", "warningCatalogSkippedNullHash"},
+		},
+	},
+	{
+		Number:   33,
+		Summary:  "v0.3 verifier reports invalid with reason model_hash_mismatch when receipt hash diverges from catalog sha256",
+		SpecStep: "SPEC-015 §M.5 AC-33",
+		Commands: []string{"cd phase7-verify && go test ./internal/verify/ -run TestCatalogCheckModelHashMismatch -count=1"},
+		CIJobs:   []string{"phase7-verify (go vet + test)"},
+		Evidence: []evidenceAnchor{
+			{"phase7-verify/internal/verify/catalog_check_test.go", "TestCatalogCheckModelHashMismatch"},
+			{"phase7-verify/internal/verify/verify.go", "reasonModelHashMismatch"},
+		},
+	},
+	{
+		Number:   34,
+		Summary:  "v0.3 verifier reports inconclusive with reason model_id_not_in_catalog when receipt model_id is not present in catalog",
+		SpecStep: "SPEC-015 §M.5 AC-34",
+		Commands: []string{"cd phase7-verify && go test ./internal/verify/ -run TestCatalogCheckModelIDNotInCatalog -count=1"},
+		CIJobs:   []string{"phase7-verify (go vet + test)"},
+		Evidence: []evidenceAnchor{
+			{"phase7-verify/internal/verify/catalog_check_test.go", "TestCatalogCheckModelIDNotInCatalog"},
+			{"phase7-verify/internal/verify/verify.go", "reasonModelIDNotInCatalog"},
+		},
+	},
+	{
+		Number:   35,
+		Summary:  "v0.3 verifier reports invalid with reason catalog_signature_invalid when catalog signature does not verify or alg is lowercase",
+		SpecStep: "SPEC-015 §M.5 AC-35",
+		Commands: []string{"cd phase7-verify && go test ./internal/catalog/ -run 'TestVerifyRejectsLowercaseAlg|TestVerifyRejectsTamperedSignature|TestVerifyTamperedSignatureCarriesObservedAlg' -count=1"},
+		CIJobs:   []string{"phase7-verify (go vet + test)"},
+		Evidence: []evidenceAnchor{
+			{"phase7-verify/internal/catalog/catalog_test.go", "TestVerifyRejectsLowercaseAlg"},
+			{"phase7-verify/internal/catalog/catalog_test.go", "TestVerifyRejectsTamperedSignature"},
+			{"phase7-verify/internal/catalog/catalog_test.go", "TestVerifyTamperedSignatureCarriesObservedAlg"},
+		},
+	},
+	{
+		Number:   36,
+		Summary:  "v0.3 verifier reports inconclusive with reason catalog_expired when catalog expires_at > now + 60s grace",
+		SpecStep: "SPEC-015 §M.5 AC-36",
+		Commands: []string{"cd phase7-verify && go test ./internal/catalog/ -run 'TestVerifyRejectsExpiredBeyondGrace|TestVerifyAcceptsWithin60sGrace|TestVerifyExpiryBoundaryAt60s' -count=1"},
+		CIJobs:   []string{"phase7-verify (go vet + test)"},
+		Evidence: []evidenceAnchor{
+			{"phase7-verify/internal/catalog/catalog_test.go", "TestVerifyExpiryBoundaryAt60s"},
+			{"phase7-verify/internal/catalog/catalog_test.go", "TestVerifyAcceptsWithin60sGrace"},
+		},
+	},
+	{
+		Number:   37,
+		Summary:  "v0.3 verifier reading a legacy v0.1/v0.2 receipt reports valid without catalog check; catalog_skipped_legacy_receipt warning emitted when catalog flags supplied",
+		SpecStep: "SPEC-015 §M.5 AC-37",
+		Commands: []string{"cd phase7-verify && go test ./internal/verify/ -run TestCatalogCheckLegacyReceiptWithCatalogFlags -count=1"},
+		CIJobs:   []string{"phase7-verify (go vet + test)"},
+		Evidence: []evidenceAnchor{
+			{"phase7-verify/internal/verify/catalog_check_test.go", "TestCatalogCheckLegacyReceiptWithCatalogFlags"},
+			{"phase7-verify/internal/verify/verify.go", "warningCatalogSkippedLegacyReceipt"},
+		},
+	},
+	{
+		Number:   38,
+		Summary:  "v0.1.3 / v0.2.4 locked verifier reading a v0.3 receipt (9 keys including receipt_version) reports invalid per §3.1 seven-keys-only rule — cross-binary parity",
+		SpecStep: "SPEC-015 §M.5 AC-38",
+		Commands: []string{"cd phase7-verify && go test ./internal/receipt/ -run TestV02LockedParserRejectsV03Receipts -count=1"},
+		CIJobs:   []string{"phase7-verify (go vet + test)"},
+		Evidence: []evidenceAnchor{
+			// §M.1.2 forward-incompat: the v0.2.4-LOCKED parser logic
+			// is re-implemented inline as parseTupleV02Locked. The test
+			// drives v0.3 receipts (with and without null model_hash)
+			// through the locked-floor parser and asserts ErrTupleExtraKey
+			// — the §3.1 "EXACTLY these seven keys" rejection. Same
+			// test confirms genuine v0.1/v0.2 7-field tuples are
+			// accepted, proving the locked floor is preserved.
+			{"phase7-verify/internal/receipt/v02_parity_test.go", "TestV02LockedParserRejectsV03Receipts"},
+			{"phase7-verify/internal/receipt/v02_parity_test.go", "parseTupleV02Locked"},
+			{"phase7-verify/internal/receipt/v02_parity_test.go", "v0.2.4 parser MUST reject v0.3"},
+		},
+	},
+	{
+		Number:   39,
+		Summary:  "coordinator /poolz emits catalog_id, catalog_url, catalog_pubkey_url when tier-2 catalog is effectively active; omits them when not",
+		SpecStep: "SPEC-015 §M.5 AC-39",
+		Commands: []string{"cd phase4-coordinator && go test ./internal/ws/ -run 'TestPoolzEmitsCatalogFieldsWhenCatalogActive|TestPoolzOmitsCatalogFieldsWhenCatalogNotConfigured|TestPoolzOmitsCatalogFieldsWhenCatalogLoadFails' -count=1"},
+		CIJobs:   []string{"phase4-coordinator (go vet + test)"},
+		Evidence: []evidenceAnchor{
+			{"phase4-coordinator/internal/ws/poolz_catalog_test.go", "TestPoolzEmitsCatalogFieldsWhenCatalogActive"},
+			{"phase4-coordinator/internal/ws/poolz_catalog_test.go", "TestPoolzOmitsCatalogFieldsWhenCatalogNotConfigured"},
+			{"phase4-coordinator/internal/ws/poolz_catalog_test.go", "TestPoolzOmitsCatalogFieldsWhenCatalogLoadFails"},
+		},
+	},
+	{
+		Number:   40,
+		Summary:  "RequireHashVerified=false continues to route to uncatalogued / catalog_unavailable providers (Entry 80 preservation); v0.3 receipts on those providers carry non-null model_hash regardless",
+		SpecStep: "SPEC-015 §M.5 AC-40",
+		Commands: []string{"cd phase4-coordinator && go test ./internal/tier2/ -count=1"},
+		CIJobs:   []string{"phase4-coordinator (go vet + test)"},
+		Evidence: []evidenceAnchor{
+			// Entry 80 orthogonality is a compile-time invariant: the
+			// default in config.go is false, the routing predicate in
+			// catalog.go fails closed only on mismatch/invalid.
+			{"phase4-coordinator/internal/config/config.go", "RequireHashVerified"},
+			{"phase4-coordinator/internal/tier2/catalog.go", "IsHashPredicateFailure"},
+			{"beta/DECISION_CRITERIA.md", "Entry 80"},
+		},
+	},
+	{
+		Number:   41,
+		Summary:  "catalog URL cache obeys §M.3.4 three-band TTL: R>6h caches 6h; [60s,6h] caches R-60s; R<60s does not cache",
+		SpecStep: "SPEC-015 §M.5 AC-41",
+		Commands: []string{"cd phase7-verify && go test ./internal/cache/catalog/ -run 'TestComputeTTLBands|TestPutSkipsBelowMinTTL|TestGetMissOnPubkeyRotation|TestGetMissOnStaleEntry' -count=1"},
+		CIJobs:   []string{"phase7-verify (go vet + test)"},
+		Evidence: []evidenceAnchor{
+			{"phase7-verify/internal/cache/catalog/catalog_cache_test.go", "TestComputeTTLBands"},
+			{"phase7-verify/internal/cache/catalog/catalog_cache_test.go", "TestGetMissOnPubkeyRotation"},
+			{"phase7-verify/internal/cache/catalog/catalog_cache_test.go", "TestGetMissOnStaleEntry"},
+		},
+	},
+	{
+		Number:   42,
+		Summary:  "§M.2.2 defence-in-depth: ambiguous request-start provenance (warm-swap on AND no hash on snapshot) → no X-MacProvider-Receipt header AND receipt_omitted: model_swap_violation audit row",
+		SpecStep: "SPEC-015 §M.5 AC-42",
+		Commands: []string{"cd phase3-binary && swift test --filter 'HTTPServerReceiptTests/testHTTPReceiptRefusedOnAmbiguousProvenance|HTTPServerReceiptTests/testHTTPAmbiguousProvenanceEmitsReceiptOmittedAudit|HTTPServerReceiptTests/testHTTPReceiptEmittedForNormalInFlightSwap'"},
+		CIJobs:   []string{"phase3-binary (swift test)"},
+		Evidence: []evidenceAnchor{
+			{"phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift", "testHTTPReceiptRefusedOnAmbiguousProvenance"},
+			{"phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift", "testHTTPAmbiguousProvenanceEmitsReceiptOmittedAudit"},
+			{"phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift", "ReceiptModelHashSource"},
+		},
+	},
+}
+
+// SPEC-015 §M.3.1.2 AC-32a — opt-in --require-model-hash policy gate.
+var spec015AC32a = acceptanceCriterion{
+	Number:   320, // sentinel — 32 * 10 to fit the int field without colliding with AC-32
+	Summary:  "--require-model-hash flag fails closed (exit 1, reason model_hash_required) on null-hash v0.3 receipt AND on legacy v0.1/v0.2 receipt",
+	SpecStep: "SPEC-015 §M.5 AC-32a",
+	Commands: []string{"cd phase7-verify && go test ./internal/verify/ -run 'TestCatalogCheckNullHashRequireModelHash|TestCatalogCheckLegacyReceiptRequireModelHash' -count=1"},
+	CIJobs:   []string{"phase7-verify (go vet + test)"},
+	Evidence: []evidenceAnchor{
+		{"phase7-verify/internal/verify/catalog_check_test.go", "TestCatalogCheckNullHashRequireModelHash"},
+		{"phase7-verify/internal/verify/catalog_check_test.go", "TestCatalogCheckLegacyReceiptRequireModelHash"},
+		{"phase7-verify/internal/verify/verify.go", "reasonModelHashRequired"},
+	},
+}
+
+func TestSpec015V03AcceptanceCriteria(t *testing.T) {
+	root := repoRoot(t)
+	check := func(t *testing.T, ac acceptanceCriterion) {
+		t.Helper()
+		if !strings.HasPrefix(ac.SpecStep, "SPEC-015 §M.5 AC-") {
+			t.Fatalf("spec step = %q", ac.SpecStep)
+		}
+		if len(ac.Commands) == 0 || len(ac.CIJobs) == 0 {
+			t.Fatalf("missing automated command or CI job: %+v", ac)
+		}
+		// Step 6 audit prompt requires ≥2 evidence anchors per AC so
+		// a single test rename can't silently sink the coverage claim.
+		if len(ac.Evidence) < 2 {
+			t.Fatalf("AC-%d has %d evidence anchors, want ≥2: %+v", ac.Number, len(ac.Evidence), ac)
+		}
+		for _, anchor := range ac.Evidence {
+			content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(anchor.File)))
+			if err != nil {
+				t.Fatalf("read evidence %s: %v", anchor.File, err)
+			}
+			if !strings.Contains(string(content), anchor.Pattern) {
+				t.Fatalf("evidence %s missing pattern %q", anchor.File, anchor.Pattern)
+			}
+		}
+		t.Logf("%s PASS via %s", ac.SpecStep, strings.Join(ac.CIJobs, ", "))
+	}
+	for _, ac := range spec015V03ACs {
+		ac := ac
+		t.Run(fmt.Sprintf("AC-%02d", ac.Number), func(t *testing.T) {
+			check(t, ac)
+		})
+	}
+	t.Run("AC-32a", func(t *testing.T) {
+		check(t, spec015AC32a)
+	})
+}
+
+func TestSpec015V03AcceptanceManifestCoversAC28ThroughAC42(t *testing.T) {
+	if len(spec015V03ACs) != 15 {
+		t.Fatalf("v0.3 manifest has %d ACs, want 15 (AC-28..AC-42)", len(spec015V03ACs))
+	}
+	seen := make(map[int]bool, len(spec015V03ACs))
+	for _, ac := range spec015V03ACs {
+		if ac.Number < 28 || ac.Number > 42 {
+			t.Fatalf("v0.3 AC-%d outside expected range", ac.Number)
+		}
+		if seen[ac.Number] {
+			t.Fatalf("duplicate v0.3 AC-%d", ac.Number)
+		}
+		seen[ac.Number] = true
+	}
+	// AC-32a is a §M.3.1.2 named addition, not a numbered AC in the
+	// 28..42 range, but it MUST be covered.
+	if spec015AC32a.Number == 0 || len(spec015AC32a.Evidence) == 0 {
+		t.Fatal("AC-32a entry missing or empty")
+	}
+}


### PR DESCRIPTION
## Summary

Implements `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md` — the staged downstream from SPEC-015 v0.3.3 LOCK ([#130](https://github.com/Augustas11/macprovider/pull/130)) merged at `827e6b9`.

Seven commits on `impl/spec-015-v0-3`: six step commits (each closed at 0/0/0/0 by its own `omc ask codex` 3-lens audit loop) + one bundle-audit fix commit (closed at 0/0/0/0 across an additional bundle-level 3-lens audit). Originally opened as [#131](https://github.com/Augustas11/macprovider/pull/131) targeting the SPEC branch; auto-closed when GitHub deleted the SPEC branch on #130 merge, rebased onto post-merge `main` and reopened here.

## What changed

### Provider (`phase3-binary/`)

- **§M.0 9-field tuple** (`model_hash`, `model_id`, `output_hash`, `prompt_hash`, `provider_pubkey`, `receipt_version="3"`, `tokens_out`, `ttft_ms`, `unix_ts`).
- **§M.2.1 atomic-read provenance**: `ModelRuntimeServing.completeWithServedSnapshot(_:shouldCancel:)` returns the actor-isolated `(CompletionResult, RuntimeSnapshot)` the runtime *actually* used. Receipt binds to **that** snapshot, not a separately-sampled `currentSnapshot()`.
- **§M.2.2 defence-in-depth refusal**: `ReceiptModelHashSource.{captured, warmSwapDisabled, ambiguous}`. `.ambiguous` emits `receipt_omitted: model_swap_violation` audit row + no header.
- **§M.2.3 null-hash semantics**: warm-swap-disabled providers emit JSON literal `null`.
- **§3.4 wire-size**: v0.3 envelope ≤ ~1025 bytes (verified by test).

### Coordinator (`phase4-coordinator/`)

- **§M.4 SPEC-002 v1.6 candidate `/poolz` extension**: three new top-level fields under the "effectively active catalog" condition.
- **Two new public buyer-port endpoints**: `GET /catalog/<catalog_id>` + `GET /catalog/pubkey` (capital-E `"Ed25519"`).
- **`Tier2Config.PublicCatalogBaseURL`** (hot-reloadable).
- **Entry 80 preserved**: `RequireHashVerified` stays at its `false` default.

### nginx + deploy gates (`phase4-coordinator/dist/`)

- New `location /catalog/` block; static gate `check_nginx_catalog_routes_test.sh` uses awk to scope the `proxy_pass` assertion to the `/catalog/` block.
- `deploy-pearl-vps.sh` step 0 invokes the gate BEFORE SSH/DNS.
- `coordinator.yaml.example` gains the `tier2:` block with Pearl's `public_catalog_base_url`.

### Verifier (`phase7-verify/`)

- **Pure-Go catalog parser** + **three-band TTL cache** (§M.3.4).
- **5 new CLI flags**: `--catalog`, `--catalog-url`, `--catalog-pubkey`, `--catalog-pubkey-url`, `--require-model-hash`. §M.3.1 / §M.3.1.1 flag matrix enforced.
- **Receipt parser**: detects v0.3 by *presence* of `receipt_version`; §M.1.4 unknown-version path enforced at parser layer BEFORE strict shape validation (tagged-union architecture).
- **8-step §M.3.2 algorithm**: §M.1.1 legacy back-compat; §M.2.3 null-hash; §M.3.1.2 `--require-model-hash` fail-closed.
- **Tri-state `model_hash_verified`** + new `reason` enum + named `Details` fields per §M.3.2.1.
- **Schema** (`output.schema.json`): v0.3 contract — `model_hash_verified` REQUIRED tri-state; conditional `allOf` requires `details.alg` when reason is `catalog_signature_invalid`.
- **Pure-stdlib discipline preserved** — `go.mod` unchanged.

### Integration acceptance + cross-binary parity (`test/integration/`)

- **AC manifest extension**: covers AC-28..AC-42 + AC-32a (16 ACs). Each AC has ≥2 evidence anchors; manifest test asserts the ≥2 invariant + every named pattern exists.
- **§M.5 AC-38 cross-binary parity**: `phase7-verify/internal/receipt/v02_parity_test.go` re-implements the v0.2.4 LOCKED `parseTuple` inline as `parseTupleV02Locked` (mirrors commit `99d0c1e`).
- **Operator runbook** (`audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md`).

### Bundle audit fix

- **SECURITY HIGH-1 (loopback bucket collapse, `phase4-coordinator/internal/buyer/server.go:902`)**: `poolCheckClientKey` keyed on `r.RemoteAddr` only — production sits behind nginx on loopback so every public buyer collapsed into one shared 127.0.0.1 bucket. Fix mirrors `ws.remoteIPForUnauthSemaphore`: honor `X-Real-IP` only when `RemoteAddr` parses as loopback (so an open-internet attacker cannot spoof). New regression `TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback` proves (a) two `X-Real-IP` values behind 127.0.0.1 get independent buckets and (b) a direct non-loopback caller cannot escape its bucket by spoofing.

## Audit-loop discipline

Per `feedback-build-audit-loop` — every step closed at 0/0/0/0 before progressing, plus a bundle-level cross-step pass after step 6.

| Phase | Rounds | Closing verdict |
|---|---|---|
| Step 1 — Swift provider 9-field tuple | 4 | 0/0/0/0 |
| Step 2 — coordinator `/poolz` + 2 endpoints | 2 | 0/0/0/0 |
| Step 3 — nginx + deploy gates | 2 | 0/0/0/0 |
| Step 4 — pure-Go catalog parser + cache | 2 | 0/0/0/0 |
| Step 5 — verifier CLI + algorithm + schema | 5 | 0/0/0/0 |
| Step 6 — integration acceptance + parity | 2 | 0/0/0/0 |
| Bundle cross-step audit | 1 + (1 SEC retry for HIGH-1 fix) | 0/0/0/0 |

**Total: 19 codex audit rounds.** Transcripts at `specs/SPEC-015-v0-3-IMPL-STEP_{1..6}-audit.md` + `specs/SPEC-015-v0-3-IMPL-BUNDLE-audit.md`.

## Test surface

- `cd phase3-binary && swift test` — 530+ tests; 9 net-new for v0.3.
- `cd phase4-coordinator && go test ./...` — full suite green; 13 net-new (incl. loopback regression).
- `cd phase7-verify && go test ./... -race` — full suite green; 40+ net-new.
- `cd test/integration && go test ./spec015/ -timeout 120s` — covers AC-1..AC-42 + AC-32a.
- `make test-dist` — includes the new `check_nginx_catalog_routes_test.sh` gate.

## Entry 80 preservation (verified)

`beta/DECISION_CRITERIA.md` Entry 80 (2026-06-22) `RequireHashVerified` deferral preserved verbatim. v0.3 makes the receipt BIND the hash; coordinator route/reject policy unchanged.

## Test plan

- [ ] Reviewer runs `cd test/integration && go test ./spec015/ -count=1 -timeout 120s` and confirms PASS.
- [ ] Reviewer runs `cd phase7-verify && go test ./... -race -count=1` and confirms PASS.
- [ ] Reviewer runs `cd phase4-coordinator && go test ./internal/buyer/ -run TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback -v` and confirms loopback bucket isolation.
- [ ] After merge: append a `beta/DECISION_CRITERIA.md` entry tracking v0.3 IMPL ship + Pearl deploy queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
