### PR TITLE
release(verify): macprovider-verify v1.1.0 — SPEC-015 v0.3.3 model-hash binding

### DIFF
--- a/phase7-verify/README.md
+++ b/phase7-verify/README.md
@@ -6,12 +6,12 @@ Buyer-side verification for SPEC-015 signed inference receipts.
 
 ## Install
 
-Release artifacts are published on tags named `verify-v<version>`, for example `verify-v1.0.0`.
+Release artifacts are published on tags named `verify-v<version>`, for example `verify-v1.1.0`.
 
 ### macOS Apple Silicon
 
 ```sh
-VERSION=1.0.0
+VERSION=1.1.0
 gh release download "verify-v${VERSION}" --repo Augustas11/macprovider \
   --pattern "macprovider-verify-${VERSION}-darwin-arm64" \
   --pattern "macprovider-verify-${VERSION}-darwin-arm64.sha256"
@@ -23,7 +23,7 @@ sudo install -m 0755 "macprovider-verify-${VERSION}-darwin-arm64" /usr/local/bin
 ### macOS Intel
 
 ```sh
-VERSION=1.0.0
+VERSION=1.1.0
 gh release download "verify-v${VERSION}" --repo Augustas11/macprovider \
   --pattern "macprovider-verify-${VERSION}-darwin-amd64" \
   --pattern "macprovider-verify-${VERSION}-darwin-amd64.sha256"
@@ -35,7 +35,7 @@ sudo install -m 0755 "macprovider-verify-${VERSION}-darwin-amd64" /usr/local/bin
 ### Linux amd64
 
 ```sh
-VERSION=1.0.0
+VERSION=1.1.0
 gh release download "verify-v${VERSION}" --repo Augustas11/macprovider \
   --pattern "macprovider-verify-${VERSION}-linux-amd64" \
   --pattern "macprovider-verify-${VERSION}-linux-amd64.sha256"
@@ -118,6 +118,9 @@ JSON mode emits one line conforming to the shipped Draft-07 schema:
 | macprovider-verify | SPEC-015 receipt versions verified |
 |---|---|
 | 1.0.x | 0.2.0 through 0.2.4 |
+| 1.1.x | 0.2.0 through 0.3.3 (catalog-based model-hash binding per §M) |
+
+**§M.1.2 forward-incompat note.** Locked v1.0.x verifiers report v0.3 receipts as `invalid` per SPEC-015 §M.1.2. Operators rolling out v0.3-emitting providers MUST release v1.1.x to buyers BEFORE that provider rollout reaches them. See `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md`.
 
 ## Trust Boundary
 

--- a/phase7-verify/RELEASE_NOTES_v1.1.0.md
+++ b/phase7-verify/RELEASE_NOTES_v1.1.0.md
@@ -1,0 +1,106 @@
+# macprovider-verify v1.1.0
+
+**SPEC-015 v0.3.3 model-hash binding** — catalog-based verification of the loaded MLX container against an operator-signed catalog.
+
+## What's new
+
+### Receipt format
+
+- **v0.3 9-field receipt tuple** verification (`model_hash`, `model_id`, `output_hash`, `prompt_hash`, `provider_pubkey`, `receipt_version="3"`, `tokens_out`, `ttft_ms`, `unix_ts`).
+- **Back-compat preserved (§M.1.1):** v0.1 / v0.2.0–v0.2.4 receipts still verify exactly as v1.0.x did. A `catalog_skipped_legacy_receipt` warning is emitted when `--catalog*` flags are supplied against a legacy receipt.
+- **Forward-incompat enforced (§M.1.2):** the v0.2.4 LOCKED parser at the v1.0.x floor is preserved; locked v1.0.x verifiers report v0.3 receipts as `invalid` per spec. v1.1.x dispatches via tagged-union on `receipt_version` presence.
+- **Unknown receipt_version → `inconclusive: unknown_receipt_version`** (§M.1.4). Future v0.4+ wire shapes degrade gracefully.
+
+### New CLI flags
+
+| Flag | Purpose |
+|---|---|
+| `--catalog <path>` | Local signed catalog file. |
+| `--catalog-url <url>` | Remote signed catalog (e.g. `https://coordinator.streamvc.live/catalog/<id>`). |
+| `--catalog-pubkey <43-char base64url-unpadded>` | Catalog Ed25519 pubkey, explicit. |
+| `--catalog-pubkey-url <url>` | Catalog Ed25519 pubkey, fetched (e.g. `https://coordinator.streamvc.live/catalog/pubkey`). |
+| `--require-model-hash` | Buyer fail-closed policy on null hash. With no `--catalog*` flags, asserts "I demand the provider participates in hash attestation, but I'll trust the provider's self-reported hash without catalog cross-check." |
+
+§M.3.1.1 mutual-exclusion enforced: `--catalog` / `--catalog-url` mutually exclusive; `--catalog-pubkey` / `--catalog-pubkey-url` mutually exclusive; `--offline` incompatible with any `--catalog*-url` flag. `--catalog` / `--catalog-url` requires a paired pubkey source (exit 64).
+
+### §M.3.2 8-step catalog algorithm
+
+For v0.3 receipts with non-null `model_hash` AND catalog arguments supplied:
+
+1. Resolve catalog pubkey from `--catalog-pubkey` or `--catalog-pubkey-url` (HTTP GET → `{"pubkey":"<43-char base64url>","alg":"Ed25519"}`).
+2. Fetch catalog bytes from `--catalog` or `--catalog-url` (the §M.3.4 three-band TTL cache short-circuits when fresh).
+3. Parse catalog (version pinned to 1; required fields enforced).
+4. Verify Ed25519 signature (`alg` literal-checked as capital-E `"Ed25519"`; signature + pubkey via `base64.RawURLEncoding`).
+5. Check `expires_at` (60-second skew grace).
+6. Look up `model_id` (case-folded `catalogModelKey`).
+7. Compare receipt `model_hash` to catalog `sha256` (case-sensitive lowercase hex).
+8. Emit `model_hash_verified: true` on equality; `false` on mismatch; `null` if the algorithm short-circuited before step 7.
+
+### Tri-state `model_hash_verified` (§M.3.2.1)
+
+JSON output (`--json`) now always emits the `model_hash_verified` field:
+
+- `true` — catalog ran AND hash matched.
+- `false` — catalog ran AND hash mismatched (`reason: "model_hash_mismatch"`) OR `--require-model-hash` set with null hash (`reason: "model_hash_required"`).
+- `null` — catalog did NOT run for any reason (no catalog flags supplied; null `model_hash` without `--require-model-hash`; legacy v0.1/v0.2 receipt; unknown `receipt_version`; catalog fetch / signature / expiry failure that short-circuits before step 7).
+
+### New reasons + warnings
+
+- Reasons: `model_hash_mismatch`, `model_hash_required`, `model_id_not_in_catalog`, `catalog_signature_invalid`, `catalog_unreachable`, `catalog_expired`, `catalog_format_invalid`, `unknown_receipt_version`, `extra_field`, `missing_field`.
+- Warnings: `catalog_skipped_legacy_receipt`, `catalog_skipped_null_hash`.
+- Schema (`schemas/output.schema.json`) v0.3 bump: `model_hash_verified` REQUIRED tri-state on every variant; conditional `allOf` requires `details.alg` when reason is `catalog_signature_invalid`.
+
+### Catalog cache (§M.3.4)
+
+URL-mode catalog fetches go through a three-band TTL cache at `~/.cache/macprovider-verify/catalog/`:
+
+| Remaining receipt validity (R) | TTL band |
+|---|---|
+| R > 6h | 6h |
+| 60s ≤ R ≤ 6h | R - 60s |
+| R < 60s | no cache |
+
+Cache writes are atomic (temp + rename, 0600). Pubkey rotation invalidates (stale entry for one pubkey will not satisfy a request for another). File-mode (`--catalog <path>`) bypasses the cache.
+
+## What's unchanged
+
+- **Pure-stdlib discipline.** `go.mod` unchanged.
+- **Trust boundary (§10.6).** The v1.0.x trust statement still applies; v0.3 ADDS a catalog-attested model-honesty claim atop it.
+- **Exit codes.** Unchanged: 0 valid, 1 invalid, 2 inconclusive, 64 usage, 65 input.
+- **Legacy v0.1/v0.2 verification.** Same code path as v1.0.x; AC-38 cross-binary parity gate (`internal/receipt/v02_parity_test.go`) re-implements the v1.0.x LOCKED parser inline and asserts v0.3 receipts STILL reject as `ErrTupleExtraKey` under that parser — protects the §M.1.2 floor against future drift.
+
+## Audit-loop trajectory
+
+This release ships behind 19 codex audit rounds:
+
+| Phase | Rounds | Closing verdict |
+|---|---|---|
+| SPEC v0.3.3 LOCK ([PR #130](https://github.com/Augustas11/macprovider/pull/130)) | 3 | 0 CRIT / 0 MAJ across 3 lenses |
+| IMPL Step 1 — Swift provider 9-field tuple | 4 | 0/0/0/0 across 3 lenses |
+| IMPL Step 2 — coordinator `/poolz` + 2 endpoints | 2 | 0/0/0/0 |
+| IMPL Step 3 — nginx + deploy gates | 2 | 0/0/0/0 |
+| IMPL Step 4 — pure-Go catalog parser + cache | 2 | 0/0/0/0 |
+| IMPL Step 5 — verifier CLI + algorithm + schema | 5 | 0/0/0/0 |
+| IMPL Step 6 — integration acceptance + parity | 2 | 0/0/0/0 |
+| Bundle cross-step audit (CODE + SECURITY + ARCHITECT) | 1 + 1 SEC retry | 0/0/0/0 |
+
+Per-step transcripts at `specs/SPEC-015-v0-3-IMPL-STEP_{1..6}-audit.md`; bundle transcript at `specs/SPEC-015-v0-3-IMPL-BUNDLE-audit.md`.
+
+## Compatibility table
+
+| macprovider-verify | SPEC-015 receipt versions verified |
+|---|---|
+| 1.0.x | 0.2.0 through 0.2.4 |
+| 1.1.x | 0.2.0 through 0.3.3 (catalog-based model-hash binding per §M) |
+
+## Operator rollout ordering
+
+Per §M.1.2 forward-incompat: **release v1.1.0 to buyers BEFORE rolling out v0.3-emitting providers.** Existing v1.0.x verifiers report v0.3 receipts as `invalid`. Operator runbook at `audits/2026-06-24/SPEC_015_V03_OPERATOR_RUNBOOK.md`.
+
+## Install
+
+See `phase7-verify/README.md` install section. SHA-256 sums for each platform binary are published as release assets next to the binary.
+
+## Reporting bugs and security issues
+
+Same as v1.0.x. Use GitHub Issues for non-sensitive verifier bugs; GitHub's private vulnerability reporting for security-sensitive reports. Do not attach private prompts, responses, API keys, or receipt bundles to public issues.

--- a/phase7-verify/internal/version/version.go
+++ b/phase7-verify/internal/version/version.go
@@ -1,9 +1,13 @@
 // Package version centralizes the verifier binary and SPEC compatibility versions.
 //
-// Updated to BinaryVersion 1.0.0 per IMPL Step 10 final acceptance.
+// Updated to BinaryVersion 1.1.0 per SPEC-015 v0.3 IMPL bundle ship
+// (see beta/DECISION_CRITERIA.md Entry 85). v1.1.x ADDS v0.3.3 receipt
+// verification on top of the v1.0.x v0.1/v0.2 compatibility floor —
+// the §M.1.2 forward-incompat guarantee still holds (locked v0.2.4
+// verifiers report v0.3 receipts as `invalid`).
 package version
 
 const (
-	BinaryVersion  = "1.0.0"
-	MaxSPECVersion = "0.2.4"
+	BinaryVersion  = "1.1.0"
+	MaxSPECVersion = "0.3.3"
 )

--- a/phase7-verify/internal/version/version_test.go
+++ b/phase7-verify/internal/version/version_test.go
@@ -35,14 +35,17 @@ func TestConstants(t *testing.T) {
 	}
 }
 
-// TestStep10FinalConstants pins the exact Step 10 final-acceptance values per
-// the IMPL prompt. BinaryVersion is the verifier release version; MaxSPECVersion
-// stays pinned to the locked SPEC-015 v0.2.4 compatibility ceiling.
-func TestStep10FinalConstants(t *testing.T) {
-	if BinaryVersion != "1.0.0" {
-		t.Fatalf("BinaryVersion = %q, want %q (Step 10 final acceptance pin per BUILD prompt)", BinaryVersion, "1.0.0")
+// TestReleaseConstants pins the verifier release values. Bump this
+// AND the constants in version.go together when cutting a new release;
+// the pin guards against accidental version drift during a release PR.
+//
+// Current pin: v1.1.0 / SPEC-015 v0.3.3 (Entry 85 ship). v1.0.0 was
+// the previous floor (Step 10 final acceptance, SPEC v0.2.4).
+func TestReleaseConstants(t *testing.T) {
+	if BinaryVersion != "1.1.0" {
+		t.Fatalf("BinaryVersion = %q, want %q (v0.3 IMPL ship pin)", BinaryVersion, "1.1.0")
 	}
-	if MaxSPECVersion != "0.2.4" {
-		t.Fatalf("MaxSPECVersion = %q, want %q (matches LOCKED SPEC-015 v0.2.4)", MaxSPECVersion, "0.2.4")
+	if MaxSPECVersion != "0.3.3" {
+		t.Fatalf("MaxSPECVersion = %q, want %q (matches LOCKED SPEC-015 v0.3.3)", MaxSPECVersion, "0.3.3")
 	}
 }


### PR DESCRIPTION
## Summary

Bumps `macprovider-verify` to v1.1.0 for the SPEC-015 v0.3.3 model-hash binding shipped in [#132](https://github.com/Augustas11/macprovider/pull/132) and deployed to Pearl coordinator at 2026-06-24T09:25:52Z (see `beta/DECISION_CRITERIA.md` Entry 85, [#133](https://github.com/Augustas11/macprovider/pull/133)).

Per §M.1.2 forward-incompat, this verifier release MUST land on buyers BEFORE v0.3-emitting providers reach them — existing locked v1.0.x verifiers report v0.3 receipts as `invalid`.

## What's in this PR

- **`phase7-verify/internal/version/version.go`**: `BinaryVersion 1.0.0 → 1.1.0`, `MaxSPECVersion 0.2.4 → 0.3.3`.
- **`phase7-verify/internal/version/version_test.go`**: `TestStep10FinalConstants` → `TestReleaseConstants` (pin guards against version drift mid-release; semantics unchanged).
- **`phase7-verify/README.md`**: install snippets bumped (3 platforms), compat table gains the `1.1.x` row covering `0.2.0 through 0.3.3`, forward-incompat note + runbook pointer added.
- **`phase7-verify/RELEASE_NOTES_v1.1.0.md`** (new): full notes covering wire shape, 5 new CLI flags, §M.3.2 algorithm, tri-state `model_hash_verified`, §M.3.4 cache mechanics, AC-38 parity gate, 19-round audit trajectory.

Pure-stdlib discipline preserved; `go.mod` unchanged. Full verifier suite green.

## Post-merge

1. Tag `verify-v1.1.0` on the merge commit.
2. Push the tag — `.github/workflows/release-verify.yml` triggers and builds darwin-arm64 + darwin-amd64 + linux-amd64 binaries + sha256 sums and creates the GitHub Release.
3. Operator updates the GitHub Release description with the contents of `phase7-verify/RELEASE_NOTES_v1.1.0.md` (the workflow's auto-generated notes are a one-line placeholder).
4. Buyers can pull the new binary via `gh release download verify-v1.1.0 ...` per README.

## Test plan

- [ ] Reviewer runs `cd phase7-verify && go test ./... -race -count=1` and confirms PASS (incl. the renamed `TestReleaseConstants` pin).
- [ ] Reviewer confirms `phase7-verify/README.md` compat table includes the new `1.1.x` row and the §M.1.2 forward-incompat note.
- [ ] Reviewer reads `phase7-verify/RELEASE_NOTES_v1.1.0.md` end-to-end and confirms it matches what's actually in this release line.
- [ ] After tag push: confirm `release-verify.yml` ran on the merge commit, three platform binaries and three `.sha256` sums attached to the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
