### PR TITLE
fix(console): restore 5 missing security headers via snippet pattern (silent prod regression)

### DIFF
--- a/frontdoor/console/dist/nginx-console.streamvc.live.conf
+++ b/frontdoor/console/dist/nginx-console.streamvc.live.conf
@@ -12,6 +12,14 @@ server {
     }
 }
 
+# Console security headers live in a snippet because nginx `add_header` is
+# all-or-nothing per level: any location-level `add_header` (e.g. the
+# Cache-Control directives below) shadows ALL inherited add_headers from
+# the server level — silent security-header regression if you forget.
+# Snippet path: /etc/nginx/snippets/console-security-headers.conf
+# (deployed from frontdoor/console/dist/nginx-snippets/console-security-headers.conf).
+# Same pattern as portal.streamvc.live (decision-log Entry 86).
+
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
@@ -20,21 +28,17 @@ server {
     ssl_certificate /etc/letsencrypt/live/console.streamvc.live/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/console.streamvc.live/privkey.pem;
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer" always;
-    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=()" always;
-    add_header Content-Security-Policy "default-src 'none'; base-uri 'none'; connect-src https://api.streamvc.live; img-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; font-src 'none'; form-action https://api.streamvc.live; frame-ancestors 'none'; upgrade-insecure-requests" always;
-
     root /var/www/console;
     index index.html;
 
     location = /index.html {
+        include /etc/nginx/snippets/console-security-headers.conf;
         add_header Cache-Control "public, max-age=300" always;
-        try_files /index.html =404;
+        try_files $uri /index.html =404;
     }
 
     location / {
+        include /etc/nginx/snippets/console-security-headers.conf;
         add_header Cache-Control "public, max-age=300" always;
         try_files $uri /index.html =404;
     }

--- a/frontdoor/console/dist/nginx-snippets/console-security-headers.conf
+++ b/frontdoor/console/dist/nginx-snippets/console-security-headers.conf
@@ -1,0 +1,5 @@
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "no-referrer" always;
+add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=()" always;
+add_header Content-Security-Policy "default-src 'none'; base-uri 'none'; connect-src https://api.streamvc.live; img-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; font-src 'none'; form-action https://api.streamvc.live; frame-ancestors 'none'; upgrade-insecure-requests" always;


### PR DESCRIPTION
## Summary

**This is a security-header regression fix masquerading as a refactor.** While moving the console nginx config to the same snippet pattern as the new `portal.streamvc.live` site (decision-log Entry 86 follow-up), I discovered console.streamvc.live had been serving ZERO of its 5 declared security headers (HSTS, CSP, X-Content-Type-Options, Referrer-Policy, Permissions-Policy) in production. Pre-deploy `curl -sI` returned only `cache-control`.

Root cause: nginx `add_header` is all-or-nothing per level. The location-level `add_header Cache-Control` directives were silently shadowing all 5 server-level security `add_header` directives even with `always` set.

## Fix

Extract security headers into `frontdoor/console/dist/nginx-snippets/console-security-headers.conf` (deployed to `/etc/nginx/snippets/console-security-headers.conf`) and `include` it in every `location` block. Same pattern shipped for portal in PR #135.

## Test plan

- [x] Pre-deploy `curl -sI https://console.streamvc.live/` → only `cache-control` header (regression confirmed)
- [x] Post-deploy `curl -sI https://console.streamvc.live/` → all 5 security headers + cache-control (regression fixed, byte-identical CSP text vs old server-level declaration)
- [x] `nginx -t` passes on Pearl, reload clean
- [x] Page content unchanged (same files, same routing, same caching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
