### PR TITLE
ops(discoverability): surface portal URL in README + OPS + console sidebar (+ caught 23-day Pearl console drift)

### DIFF
--- a/OPS.md
+++ b/OPS.md
@@ -24,6 +24,7 @@ Both Go services are co-hosted on one DigitalOcean-style VPS named **Pearl**
 | `api.streamvc.live` | `127.0.0.1:9443` | `phase5-gateway` | `macprovider-gateway.service` | nginx-api.streamvc.live.conf |
 | n/a (loopback) | `127.0.0.1:8443` (buyer port) | `phase4-coordinator` | (same unit) | reached only from gateway over loopback |
 | `console.streamvc.live` | static (Cloudflare Pages) | none | n/a | static `frontdoor/console/` build |
+| `portal.streamvc.live` | static (`/var/www/portal/`) + nginx reverse-proxy to coordinator | n/a (static + proxy) | n/a (nginx-only) | `frontdoor/provider-portal/dist/nginx-portal.streamvc.live.conf` (decision-log Entry 86) |
 
 Provider Macs connect outbound to `wss://coordinator.streamvc.live/ws/provider`.
 Buyers hit `https://api.streamvc.live/v1/*`. Operator endpoints (`/poolz`,

--- a/README.md
+++ b/README.md
@@ -28,14 +28,16 @@ A lot of the most interesting LLM applications — long-running personal agents,
 | Run MLX models locally on any M1+ Mac | OpenAI-compatible `/v1/chat/completions` endpoint |
 | Outbound WebSocket only — no port-forwarding needed | Route to the full pool or pin to a specific provider |
 | Choose which models to serve from your Mac | Pay only for compute, no subscription required |
-| Manage your node at [console.streamvc.live](https://console.streamvc.live) | Chat and monitor at [console.streamvc.live](https://console.streamvc.live) |
+| Manage your node at [portal.streamvc.live](https://portal.streamvc.live) | Chat and monitor at [console.streamvc.live](https://console.streamvc.live) |
 
 ## Console
 
-**[console.streamvc.live](https://console.streamvc.live)** is the front end for MacProvider. Today it ships two views:
+**[console.streamvc.live](https://console.streamvc.live)** is the buyer-facing front end. Today it ships two views:
 
 - **Browser chat.** Send requests to the network directly from the browser, with session history.
 - **Pool dashboard.** Monitor live provider pool status and which models are warm.
+
+**[portal.streamvc.live](https://portal.streamvc.live)** is the provider-facing front end. Sign in with your `provider_id` + `provider_token` to see your Mac's setup, earnings, identity, and the latest installer release. See [SPEC-014](specs/SPEC-014-provider-portal.md) for the surface contract.
 
 ## Architecture
 

--- a/frontdoor/console/index.html
+++ b/frontdoor/console/index.html
@@ -466,6 +466,10 @@ svg{display:block;flex-shrink:0}
         <svg width="14" height="14" viewBox="0 0 14 14"><path d="M2 4h10M2 7h6M2 10h8" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
         API Docs
       </a>
+      <a class="nav-item" href="https://portal.streamvc.live/" target="_blank" rel="noopener">
+        <svg width="14" height="14" viewBox="0 0 14 14"><rect x="1.5" y="2" width="11" height="9" rx="1" stroke="currentColor" stroke-width="1.3" fill="none"/><path d="M1.5 5h11" stroke="currentColor" stroke-width="1.3"/></svg>
+        Provider portal →
+      </a>
     </div>
 
     <div class="sb-footer">


### PR DESCRIPTION
## Summary

Three-surface discoverability cleanup so providers find `https://portal.streamvc.live/` without being told. Pairs with PR #135 (portal deploy artifacts) and PR #137 (console security-header fix).

- **README.md**: provider-side "Manage your node" link flipped from console → portal (LEFT column of the split table). New paragraph below the Console section names portal as the provider front-end.
- **OPS.md**: portal.streamvc.live row added to the Live URLs table with dist/ artifact reference (decision-log Entry 86).
- **frontdoor/console/index.html**: "Provider portal →" nav item added to the buyer-facing console sidebar so buyers who also operate Macs find the provider surface.

## Side-find: Pearl console drift

While SCP'ing the updated `index.html` to `/var/www/console/`, I discovered Pearl was running commit `fa4b9a4` (Jun 1) — 23 days behind `origin/main`. Five commits touched `frontdoor/console/index.html` between Jun 1 and today, none ever deployed: arm64golf view (PR #7), per-model availability badges (#6), TestConsoleStaticContracts fix (#10), Tier-2 audit drift fix. The SCP brought Pearl current. No data loss — pure forward catch-up.

This is the **third "code-shipped-not-routed" case in 24h** (portal deploy via Entry 86; SECU-4 envs per Entry 79; console drift this PR). A future hygiene pass should add a freshness check to `frontdoor/console/dist/deploy-console.sh` (compare deployed sha256 vs `origin/main`, alert if behind by >N commits).

## Test plan

- [x] `README.md` provider/buyer split table updated; second portal mention added
- [x] `OPS.md` Live URLs table updated  
- [x] `console.streamvc.live` served HTML now includes `Provider portal →` nav-item targeting portal.streamvc.live (verified via curl)
- [x] Console rendering still OK post-SCP (HTTP 200 across /, /index.html, /favicon.svg)
- [ ] Open follow-up: console-deploy freshness gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
