### PR TITLE
fix(install): filter /releases/latest to macprovider-cli tags (^v[0-9])

### DIFF
--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -615,10 +615,19 @@ validate_inputs() {
 }
 
 latest_release_tag() {
-  api_url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
+  # Scan the recent release list and pick the newest tag that names a
+  # macprovider-cli release (tag matches ^v[0-9], e.g. v1.3.1). The
+  # /releases/latest endpoint can't be trusted on its own: it returns
+  # whichever release is flagged "Latest" repo-wide, so any unrelated
+  # release published under the same repo (e.g. macprovider-verify
+  # under tag verify-vX.Y.Z) silently hijacks the installer.
+  api_url="https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=30"
   json="$(curl -fsSL "$api_url")" || die 3 "failed to query GitHub Releases API: $api_url"
-  tag="$(printf "%s" "$json" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
-  [ -n "$tag" ] || die 3 "GitHub Releases API response did not include tag_name"
+  tag="$(printf "%s" "$json" \
+    | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | grep -E '^v[0-9]' \
+    | head -1)"
+  [ -n "$tag" ] || die 3 "no macprovider-cli release (tag ^v[0-9]) found in recent GitHub Releases"
   printf "%s" "$tag"
 }
 


### PR DESCRIPTION
## Summary

- `install.sh` was calling GitHub's `/releases/latest`, which returns whichever release is flagged "Latest" **repo-wide**. After we shipped `macprovider-verify` v1.0.0 / v1.1.0 yesterday and today, that endpoint returned tag `verify-v1.1.0`. The installer then built `macprovider-cli-verify-v1.1.0-darwin-arm64.tar.gz`, which doesn't exist → `curl: (56) ... 404`. Anyone running `curl -fsSL https://get.streamvc.live/install.sh | bash` between ~10:08 UTC and the prod restore hit this.
- Prod was already restored out-of-band by re-flagging `v1.3.1` as Latest (`gh release edit v1.3.1 --latest`).
- This PR is the permanent guard. `latest_release_tag()` now scans `/releases?per_page=30` and picks the newest tag matching `^v[0-9]`. `verify-*` (and any other future co-published binary that doesn't use the `vX.Y.Z` scheme) cannot hijack the installer again.

## Test plan

- [x] Live API check: `curl .../releases?per_page=30 | sed ... | grep -E '^v[0-9]' | head -1` returns `v1.3.1` (correct cli release, ignoring `verify-v1.1.0` / `verify-v1.0.0` at the top).
- [x] `bash -n install.sh` passes.
- [ ] After merge, re-run `curl -fsSL https://get.streamvc.live/install.sh | bash` on a fresh Mac and confirm the installer reaches the binary-download step regardless of what's currently marked Latest on GitHub.

## Notes

- Keep `v1.3.1` flagged Latest on GitHub for now anyway — defense-in-depth.
- If we later publish a `macprovider-cli` prerelease like `v1.4.0-rc1`, this filter still picks it up (tag matches `^v[0-9]`). Skipping prereleases would need an extra exclusion — out of scope.
