### PR TITLE
fix(phase7-verify): pin verifier "now" in fixture tests via testclock build tag

### DIFF
--- a/phase7-verify/integration_test.go
+++ b/phase7-verify/integration_test.go
@@ -74,7 +74,11 @@ func TestMain(m *testing.M) {
 	defer os.RemoveAll(tmp)
 
 	verifyBin = filepath.Join(tmp, "macprovider-verify")
-	cmd := exec.Command("go", "build", "-o", verifyBin, "./cmd/macprovider-verify")
+	// `-tags=testclock` enables the MACPROVIDER_VERIFY_NOW_UNIX hook in
+	// internal/cli (clock_testclock.go), letting tests pin "now" against
+	// the frozen receipt fixtures so clock_skew doesn't fire as fixtures
+	// age past 24h. Production builds (no tag) ignore the env var.
+	cmd := exec.Command("go", "build", "-tags=testclock", "-o", verifyBin, "./cmd/macprovider-verify")
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "go build ./cmd/macprovider-verify: %v\n%s", err, out)
@@ -153,7 +157,13 @@ func TestReceiptBundleFixturesEndToEnd(t *testing.T) {
 			cacheDir := t.TempDir()
 			coordinatorHost := serverHost(t, server.URL)
 			if tt.seedStale {
-				writeCacheLine(t, cacheDir, coordinatorHost, fixtureProvider, current, time.Now().UTC().Add(-8*24*time.Hour), nil)
+				// FetchedAt must be stale RELATIVE to the verifier's
+				// pinned "now" (validFreshUnixTS+60), not real time.Now.
+				// hasStaleCacheEntry compares against opts.Now, so a
+				// real-clock offset that looks 8d old to wall time can
+				// look <7d old (within TTL) to the pinned verifier.
+				pinnedNow := time.Unix(validFreshUnixTS+60, 0).UTC()
+				writeCacheLine(t, cacheDir, coordinatorHost, fixtureProvider, current, pinnedNow.Add(-8*24*time.Hour), nil)
 			}
 
 			stdout, stderr, code := runVerify(t, filepath.Join("testdata", tt.file), server.URL, cacheDir, certFile)
@@ -334,6 +344,12 @@ func runVerifyArgs(t *testing.T, args []string, cacheDir, certFile string) ([]by
 	cmd.Env = append(os.Environ(),
 		"MACPROVIDER_CACHE_DIR="+cacheDir,
 		"MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR=1",
+		// Pin "now" to just after the fixture's unix_ts (see
+		// TestMain's `-tags=testclock` build) so receipts aging
+		// past clockSkewThreshold (24h) don't add a clock_skew
+		// warning the test wasn't expecting. Honored only because
+		// the binary was built with the testclock tag.
+		fmt.Sprintf("MACPROVIDER_VERIFY_NOW_UNIX=%d", validFreshUnixTS+60),
 	)
 	if certFile != "" {
 		cmd.Env = append(cmd.Env,

--- a/phase7-verify/internal/cli/cli.go
+++ b/phase7-verify/internal/cli/cli.go
@@ -95,6 +95,12 @@ func run(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, get
 		}
 	}()
 
+	if cfg.now == nil {
+		if override := envClockOverride(getenv); override != nil {
+			cfg.now = override
+		}
+	}
+
 	opts, err := parseOptions(args, stdout, stderr, getenv)
 	if err != nil {
 		writeErr(stderr, false, err)

--- a/phase7-verify/internal/cli/clock_default.go
+++ b/phase7-verify/internal/cli/clock_default.go
@@ -1,0 +1,16 @@
+//go:build !testclock
+
+package cli
+
+import "time"
+
+// envClockOverride returns nil in production builds. The test-only
+// `testclock` build tag swaps in an implementation that honors
+// MACPROVIDER_VERIFY_NOW_UNIX, used by integration tests to pin the
+// verifier's "now" against frozen receipt fixtures. Keeping this off
+// production builds prevents an attacker who can set env vars from
+// silencing clock_skew or expanding the grace-window check.
+func envClockOverride(getenv func(string) string) func() time.Time {
+	_ = getenv
+	return nil
+}

--- a/phase7-verify/internal/cli/clock_testclock.go
+++ b/phase7-verify/internal/cli/clock_testclock.go
@@ -1,0 +1,24 @@
+//go:build testclock
+
+package cli
+
+import (
+	"strconv"
+	"time"
+)
+
+// envClockOverride is enabled only when the binary is built with
+// `-tags=testclock`. Integration tests use this to freeze "now" against
+// committed receipt fixtures (which carry a fixed unix_ts) so that
+// clock_skew warnings don't fire as the fixtures age past 24h.
+func envClockOverride(getenv func(string) string) func() time.Time {
+	v := getenv("MACPROVIDER_VERIFY_NOW_UNIX")
+	if v == "" {
+		return nil
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return nil
+	}
+	return func() time.Time { return time.Unix(n, 0).UTC() }
+}


### PR DESCRIPTION
## Summary

- The `phase7-verify integration (fixtures)` CI job has been failing on `main` since ~26h after fixture generation. `valid_fresh` and `valid_prev_key_in_grace` both signed-receipts with `unix_ts = 2026-06-23T12:00:00Z`, and `verify.go` emits a `clock_skew` warning when `|system_time - unix_ts| > clockSkewThreshold` (24h). The tests asserted `warnings == [non_default_coordinator]`, so the extra `clock_skew` warning broke them. This recurs every 24h until structurally fixed.
- Fix: add a build-tag-gated clock override. The production binary is unchanged — `clock_default.go` (`//go:build !testclock`) returns `nil`. Only when built with `-tags=testclock` does `clock_testclock.go` honor `MACPROVIDER_VERIFY_NOW_UNIX` and feed it into `cfg.now` → `verify.VerifyOpts.Now`.
- `TestMain` adds `-tags=testclock` to `go build`, and `runVerifyArgs` sets the env var to `validFreshUnixTS + 60`. Verifier sees receipts as exactly 1 minute old. Fixtures stay stable forever.
- The `seedStale: true` cache write also rebased to the pinned clock: `hasStaleCacheEntry` compares cache `FetchedAt` against the pinned "now", and a real-clock offset that looks stale to wall time can look fresh to the verifier once the clocks disagree by ~26h. Cache-write epoch is now `pinnedNow - 8d`, which is stale to both pinned and real clocks.

## Why not the alternatives

- **Bump `validFreshUnixTS`** — only buys 24h before the same break.
- **Regenerate fixtures in `TestMain` against `time.Now()`** — would require extracting `testdata/generator` helpers into a reusable package; larger refactor, and `TestFixtureGeneratorIdempotentAndCommitted` would have to be rethought.
- **Production env-var clock override (no build tag)** — adds an env-var-controlled clock to a production verifier that decides cryptographic freshness. The build tag keeps the surface area zero in shipped binaries.

## Test plan

- [x] `go test -tags=integration ./...` in `phase7-verify` — all green (was: `valid_fresh` + `valid_prev_key_in_grace` red).
- [x] `go test ./...` (default build, no tag) — all green; production code path unaffected.
- [x] `go build -tags=testclock ./cmd/macprovider-verify` — clean build.
- [x] `go vet -tags=integration ./...` — clean.
- [ ] CI green on this PR.

## Notes

- Once CI is green here, [#144](https://github.com/Augustas11/macprovider/pull/144) (installer-latest filter, blocked by this same failure) can also go green and merge.
