### PR TITLE
Expose verified public catalog for provider install

### DIFF
--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -269,11 +269,33 @@ model_default_for_ram() {
   ram_gb="$1"
   if [ "$ram_gb" -lt 12 ]; then
     printf "mlx-community/Llama-3.2-3B-Instruct-4bit"
+  elif [ "$ram_gb" -lt 16 ]; then
+    printf "mlx-community/Qwen3-4B-Instruct-2507-4bit"
   elif [ "$ram_gb" -lt 24 ]; then
     printf "mlx-community/Qwen2.5-7B-Instruct-4bit"
-  else
+  elif [ "$ram_gb" -lt 32 ]; then
     printf "mlx-community/Qwen2.5-14B-Instruct-4bit"
+  elif [ "$ram_gb" -lt 48 ]; then
+    printf "mlx-community/Qwen3-32B-4bit"
+  elif [ "$ram_gb" -lt 64 ]; then
+    printf "mlx-community/Llama-3.3-70B-Instruct-4bit"
+  else
+    printf "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit"
   fi
+}
+
+known_min_ram_gb_for_model() {
+  case "$1" in
+    mlx-community/Llama-3.2-3B-Instruct-4bit) printf "8" ;;
+    mlx-community/Qwen3-4B-Instruct-2507-4bit) printf "12" ;;
+    mlx-community/Qwen2.5-7B-Instruct-4bit) printf "16" ;;
+    mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit) printf "16" ;;
+    mlx-community/Qwen2.5-14B-Instruct-4bit) printf "24" ;;
+    mlx-community/Qwen3-32B-4bit) printf "32" ;;
+    mlx-community/Qwen2.5-Coder-32B-Instruct-4bit) printf "32" ;;
+    mlx-community/Llama-3.3-70B-Instruct-4bit) printf "48" ;;
+    mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit) printf "64" ;;
+  esac
 }
 
 # SPEC-003 v0.9 FR-D2: enforce safe HuggingFace repo id format.
@@ -342,6 +364,44 @@ estimate_weights_gb_from_name() {
     'BEGIN { gb = p * b; if (gb < 1) gb = 1; printf "%d", gb + 0.5 }'
 }
 
+hf_safetensors_gb_from_api_body() {
+  body="$1"
+  printf "%s" "$body" | tr '\n\r' '  ' | awk '
+    {
+      data = $0
+      while (match(data, /"rfilename"[[:space:]]*:[[:space:]]*"[^"]*\.safetensors"/)) {
+        data = substr(data, RSTART + RLENGTH)
+        window = substr(data, 1, 700)
+        if (match(window, /"size"[[:space:]]*:[[:space:]]*[0-9]+/)) {
+          value = substr(window, RSTART, RLENGTH)
+          gsub(/[^0-9]/, "", value)
+          total += value + 0
+        }
+      }
+    }
+    END {
+      if (total > 0) {
+        printf "%d", int((total + 1073741824 - 1) / 1073741824)
+      }
+    }
+  '
+}
+
+ram_floor_for_weight_gb() {
+  weight_gb="$1"
+  awk -v w="$weight_gb" '
+    BEGIN {
+      if (w <= 2) print 8;
+      else if (w <= 3) print 12;
+      else if (w <= 5) print 16;
+      else if (w <= 9) print 24;
+      else if (w <= 20) print 32;
+      else if (w <= 38) print 48;
+      else print 64;
+    }
+  '
+}
+
 confirm_model_fit_override() {
   reason="$1"
   if [ "$NO_PROMPT" = "1" ]; then
@@ -351,9 +411,40 @@ confirm_model_fit_override() {
   prompt_yes_no "Proceed anyway? [y/N]" "N" || die 7 "aborted by user"
 }
 
+enforce_model_min_ram_floor() {
+  id="$1"
+  ram_gb="$2"
+  min_ram_gb="$3"
+  source="$4"
+  if [ "$ram_gb" -lt "$min_ram_gb" ]; then
+    confirm_model_fit_override "$source requires ${min_ram_gb} GB RAM for $id, but this Mac has ${ram_gb} GB"
+  else
+    log "Model fits: $id requires ${min_ram_gb} GB RAM by $source; this Mac has ${ram_gb} GB."
+  fi
+}
+
+enforce_model_ram_fit_from_weight_gb() {
+  id="$1"
+  ram_gb="$2"
+  weight_gb="$3"
+  source="$4"
+  min_ram_gb="$(ram_floor_for_weight_gb "$weight_gb")"
+  if [ "$ram_gb" -lt "$min_ram_gb" ]; then
+    confirm_model_fit_override "$source reports ~${weight_gb} GB safetensors; recommended RAM floor is ${min_ram_gb} GB for $id, but this Mac has ${ram_gb} GB"
+  else
+    log "Model fits: $source reports ~${weight_gb} GB safetensors; recommended RAM floor is ${min_ram_gb} GB and this Mac has ${ram_gb} GB."
+  fi
+}
+
 enforce_model_ram_fit() {
   id="$1"
   ram_gb="$2"
+  min_ram_gb="$(known_min_ram_gb_for_model "$id")"
+  if [ -n "$min_ram_gb" ]; then
+    enforce_model_min_ram_floor "$id" "$ram_gb" "$min_ram_gb" "model table"
+    return 0
+  fi
+
   est_gb="$(estimate_weights_gb_from_name "$id")"
   if [ -z "$est_gb" ]; then
     log "WARNING: could not estimate weight size from model name; skipping fit check."
@@ -380,7 +471,7 @@ catalog_min_ram_from_body() {
   printf "%s" "$catalog_body" | tr '\n\r' '  ' | awk -v id="$model_id" '
     BEGIN { RS = "}"; }
     index($0, "\"model_id\"") && index($0, "\"" id "\"") {
-      if (match($0, /"min_ram_gb"[[:space:]]*:[[:space:]]*[0-9]+/)) {
+      if (match($0, /"min_ram_gb"[[:space:]]*:[[:space:]]*[1-9][0-9]*/)) {
         value = substr($0, RSTART, RLENGTH)
         gsub(/[^0-9]/, "", value)
         print value
@@ -402,25 +493,18 @@ check_catalog_ram_metadata() {
     return 1
   fi
 
-  poolz_url="$coordinator_base/poolz"
-  body_and_code="$(curl -sSL -m 5 -o - -w '\n__HTTP_STATUS__%{http_code}' "$poolz_url" 2>/dev/null || printf '\n__HTTP_STATUS__network_error')"
+  catalog_url="$coordinator_base/catalog/current"
+  body_and_code="$(curl -sSL -m 5 -o - -w '\n__HTTP_STATUS__%{http_code}' "$catalog_url" 2>/dev/null || printf '\n__HTTP_STATUS__network_error')"
   http_code="${body_and_code##*__HTTP_STATUS__}"
-  poolz_body="${body_and_code%__HTTP_STATUS__*}"
+  catalog_body="${body_and_code%__HTTP_STATUS__*}"
   if [ "$http_code" != "200" ]; then
-    log "WARNING: could not read catalog metadata from $poolz_url (status $http_code); using built-in model RAM estimates."
+    log "WARNING: could not read signed catalog $catalog_url (status $http_code); using built-in model RAM estimates."
     return 1
   fi
 
-  catalog_id="$(printf "%s" "$poolz_body" | sed -n 's/.*"catalog_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  catalog_id="$(printf "%s" "$catalog_body" | sed -n 's/.*"catalog_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
   if [ -z "$catalog_id" ]; then
-    log "WARNING: /poolz did not include catalog_id; using built-in model RAM estimates."
-    return 1
-  fi
-
-  catalog_url="$coordinator_base/catalog/$catalog_id"
-  catalog_body="$(curl -fsSL -m 5 "$catalog_url" 2>/dev/null || true)"
-  if [ -z "$catalog_body" ]; then
-    log "WARNING: could not read signed catalog $catalog_url; using built-in model RAM estimates."
+    log "WARNING: signed catalog did not include catalog_id; using built-in model RAM estimates."
     return 1
   fi
 
@@ -463,7 +547,7 @@ hf_check_model() {
     return 0
   fi
   log "Checking model $id on HuggingFace…"
-  api_url="https://huggingface.co/api/models/$id"
+  api_url="https://huggingface.co/api/models/$id?blobs=true"
   # -f omitted so 4xx bodies still reach us; status is routed explicitly below.
   body_and_code="$(curl -sSL -m 10 -o - -w '\n__HTTP_STATUS__%{http_code}' "$api_url" 2>/dev/null || printf '\n__HTTP_STATUS__network_error')"
   http_code="${body_and_code##*__HTTP_STATUS__}"
@@ -505,7 +589,12 @@ hf_check_model() {
     die 7 "model $id is not an MLX repo. macprovider runs MLX-format models only. Pick an mlx-community/* variant or convert with mlx_lm.convert."
   fi
 
-  enforce_model_ram_fit "$id" "$ram_gb"
+  hf_weight_gb="$(hf_safetensors_gb_from_api_body "$body")"
+  if [ -n "$hf_weight_gb" ]; then
+    enforce_model_ram_fit_from_weight_gb "$id" "$ram_gb" "$hf_weight_gb" "HuggingFace"
+  else
+    enforce_model_ram_fit "$id" "$ram_gb"
+  fi
 }
 
 choose_model() {
@@ -530,16 +619,28 @@ choose_model() {
   printf "[macprovider-install] Detected approximately %s GB RAM.\n" "$ram_gb" >&2
   printf "Choose a model:\n" >&2
   printf "  1) mlx-community/Llama-3.2-3B-Instruct-4bit      ~2 GB, 8 GB Macs\n" >&2
-  printf "  2) mlx-community/Qwen2.5-7B-Instruct-4bit        ~4 GB, 16 GB Macs\n" >&2
-  printf "  3) mlx-community/Qwen2.5-14B-Instruct-4bit       ~8 GB, 24 GB+ Macs\n" >&2
+  printf "  2) mlx-community/Qwen3-4B-Instruct-2507-4bit     ~2 GB, 12 GB+ Macs\n" >&2
+  printf "  3) mlx-community/Qwen2.5-7B-Instruct-4bit        ~4 GB, 16 GB Macs\n" >&2
+  printf "  4) mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit  ~4 GB, 16 GB+ Macs\n" >&2
+  printf "  5) mlx-community/Qwen2.5-14B-Instruct-4bit       ~8 GB, 24 GB+ Macs\n" >&2
+  printf "  6) mlx-community/Qwen3-32B-4bit                  ~18 GB, 32 GB+ Macs\n" >&2
+  printf "  7) mlx-community/Qwen2.5-Coder-32B-Instruct-4bit ~17 GB, 32 GB+ Macs\n" >&2
+  printf "  8) mlx-community/Llama-3.3-70B-Instruct-4bit     ~35 GB, 48 GB+ Macs\n" >&2
+  printf "  9) mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit ~40 GB, 64 GB+ Macs\n" >&2
   printf "  c) custom HuggingFace MLX model id\n" >&2
   printf "Selection [default: %s]: " "$default_model" >&2
   read_line
   selection="$REPLY"
   case "$selection" in
     1) printf "mlx-community/Llama-3.2-3B-Instruct-4bit" ;;
-    2) printf "mlx-community/Qwen2.5-7B-Instruct-4bit" ;;
-    3) printf "mlx-community/Qwen2.5-14B-Instruct-4bit" ;;
+    2) printf "mlx-community/Qwen3-4B-Instruct-2507-4bit" ;;
+    3) printf "mlx-community/Qwen2.5-7B-Instruct-4bit" ;;
+    4) printf "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit" ;;
+    5) printf "mlx-community/Qwen2.5-14B-Instruct-4bit" ;;
+    6) printf "mlx-community/Qwen3-32B-4bit" ;;
+    7) printf "mlx-community/Qwen2.5-Coder-32B-Instruct-4bit" ;;
+    8) printf "mlx-community/Llama-3.3-70B-Instruct-4bit" ;;
+    9) printf "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit" ;;
     c|C)
       printf "HuggingFace model id (org/name): " >&2
       read_line

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -155,7 +155,8 @@ server {
     }
 
     # ---------------------------------------------------------------------
-    # /catalog/<catalog_id> and /catalog/pubkey — public buyer endpoints
+    # /catalog/current, /catalog/<catalog_id>, and /catalog/pubkey —
+    # public buyer endpoints
     # per SPEC-002 v1.6 candidate annotation + SPEC-015 v0.3 §M.4.
     # UNAUTHENTICATED. Lives on buyer_port (8443), NOT operator port.
     # Same posture as /v1/receipt-keys/: rate-limited inside the

--- a/phase4-coordinator/internal/buyer/catalog_endpoints_test.go
+++ b/phase4-coordinator/internal/buyer/catalog_endpoints_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 // SPEC-015 §M.4 / §M.5 AC-39 — GET /catalog/<catalog_id> returns
-// the on-disk signed catalog bytes verbatim with the right
-// Content-Type and Cache-Control.
+// the verified signed catalog bytes verbatim with the right Content-Type
+// and Cache-Control.
 func TestCatalogFileServesActiveCatalogBytes(t *testing.T) {
 	defer tier2.ResetForTest()
 	raw, pubkey := buyerCatalogFixture(t, "test-catalog-2026-06-24", time.Now().UTC().Add(time.Hour))
@@ -37,6 +37,73 @@ func TestCatalogFileServesActiveCatalogBytes(t *testing.T) {
 	server.SetTier2Config(cfg)
 
 	rr := serveCatalogFile(server, "test-catalog-2026-06-24", "198.51.100.1:12345")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	if !bytes.Equal(rr.Body.Bytes(), raw) {
+		t.Fatalf("body bytes mismatch: got %d bytes, want %d", len(rr.Body.Bytes()), len(raw))
+	}
+}
+
+func TestCatalogEndpointServesVerifiedBytesAfterFileReplacement(t *testing.T) {
+	defer tier2.ResetForTest()
+	raw, pubkey := buyerCatalogFixture(t, "test-catalog-2026-06-24", time.Now().UTC().Add(time.Hour))
+	path := writeBuyerCatalog(t, raw)
+	cfg := config.Tier2Config{
+		CatalogPath:      path,
+		CatalogPublicKey: pubkey,
+		ObserveEnabled:   true,
+	}
+	if err := tier2.Configure(cfg, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+	tampered := bytes.Replace(raw, []byte(`"catalog_id":"test-catalog-2026-06-24"`), []byte(`"catalog_id":"tampered-catalog-2026-06"`), 1)
+	if bytes.Equal(tampered, raw) {
+		t.Fatal("tamper replacement did not change catalog bytes")
+	}
+	if err := os.WriteFile(path, tampered, 0o600); err != nil {
+		t.Fatalf("replace catalog file: %v", err)
+	}
+	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
+	server.SetTier2Config(cfg)
+
+	for name, rr := range map[string]*httptest.ResponseRecorder{
+		"current": serveCatalogCurrent(server, "198.51.100.1:12345"),
+		"id":      serveCatalogFile(server, "test-catalog-2026-06-24", "198.51.100.1:12346"),
+	} {
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s status = %d body=%s", name, rr.Code, rr.Body.String())
+		}
+		if !bytes.Equal(rr.Body.Bytes(), raw) {
+			t.Fatalf("%s served bytes from replaced file; got %s want verified raw catalog", name, rr.Body.String())
+		}
+	}
+}
+
+// GET /catalog/current serves the same signed catalog bytes without requiring
+// installers to discover catalog_id from operator-only /poolz.
+func TestCatalogCurrentServesActiveCatalogBytes(t *testing.T) {
+	defer tier2.ResetForTest()
+	raw, pubkey := buyerCatalogFixture(t, "test-catalog-2026-06-24", time.Now().UTC().Add(time.Hour))
+	path := writeBuyerCatalog(t, raw)
+	cfg := config.Tier2Config{
+		CatalogPath:      path,
+		CatalogPublicKey: pubkey,
+		ObserveEnabled:   true,
+	}
+	if err := tier2.Configure(cfg, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
+	server.SetTier2Config(cfg)
+
+	rr := serveCatalogCurrent(server, "198.51.100.1:12345")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
 	}
@@ -86,7 +153,7 @@ func TestCatalogEndpoints404WhenNoCatalogConfigured(t *testing.T) {
 	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
 	server.SetTier2Config(config.Tier2Config{})
 
-	for _, target := range []string{"/catalog/test-catalog", "/catalog/pubkey"} {
+	for _, target := range []string{"/catalog/current", "/catalog/test-catalog", "/catalog/pubkey"} {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, target, nil)
 		req.RemoteAddr = "198.51.100.1:12345"
@@ -234,6 +301,14 @@ func serveCatalogPubkeyWithRealIP(server *Server, remoteAddr, realIP string) *ht
 
 func serveCatalogFile(server *Server, catalogID, remoteAddr string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodGet, "/catalog/"+catalogID, nil)
+	req.RemoteAddr = remoteAddr
+	rr := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rr, req)
+	return rr
+}
+
+func serveCatalogCurrent(server *Server, remoteAddr string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/catalog/current", nil)
 	req.RemoteAddr = remoteAddr
 	rr := httptest.NewRecorder()
 	server.Handler().ServeHTTP(rr, req)

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -16,7 +16,6 @@ import (
 	mrand "math/rand"
 	"net"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -399,8 +398,9 @@ func (s *Server) Handler() http.Handler {
 	// SPEC-015 §M.4 — SPEC-002 v1.6 candidate annotations.
 	// Public, unauthenticated, rate-limited; serve the literal
 	// signed catalog file and the catalog signing pubkey so a buyer-
-	// side verifier can run the §M.3.2 catalog-check path against
-	// this coordinator.
+	// side verifier or public installer can run the §M.3.2 catalog-
+	// check path against this coordinator without reading /poolz.
+	r.Get("/catalog/current", s.handleCatalogCurrent)
 	r.Get("/catalog/pubkey", s.handleCatalogPubkey)
 	r.Get("/catalog/{catalog_id}", s.handleCatalogFile)
 	r.Post("/v1/chat/completions", s.handleChatCompletions)
@@ -740,32 +740,34 @@ func (s *Server) handleReceiptKeys(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// SPEC-015 §M.4 — serve the literal signed catalog file under the
+// SPEC-015 §M.4 — serve the verified signed catalog bytes under the
 // effectively-active catalog's id. Public, unauthenticated, rate-
 // limited (shares the receipt-keys bucket so a single attacker
 // cannot starve the buyer surface). 404 when (a) no catalog
 // configured, (b) catalog failed to load/verify, OR (c) the path
 // segment does not match the active catalog_id.
 func (s *Server) handleCatalogFile(w http.ResponseWriter, r *http.Request) {
+	s.serveCatalogFile(w, r, strings.TrimSpace(chi.URLParam(r, "catalog_id")))
+}
+
+// handleCatalogCurrent serves the effectively-active catalog without requiring
+// clients to discover catalog_id through operator-only /poolz.
+func (s *Server) handleCatalogCurrent(w http.ResponseWriter, r *http.Request) {
+	s.serveCatalogFile(w, r, "")
+}
+
+func (s *Server) serveCatalogFile(w http.ResponseWriter, r *http.Request, requested string) {
 	if !s.allowReceiptKeys(r) {
 		w.Header().Set("Retry-After", "1")
 		writeError(w, http.StatusTooManyRequests, "rate_limited", "Catalog endpoint rate limit exceeded")
 		return
 	}
-	cfg := s.tier2Config()
-	if !tier2.Active() || strings.TrimSpace(cfg.CatalogPath) == "" {
+	active, data, ok := tier2.CatalogSnapshot()
+	if !ok {
 		writeError(w, http.StatusNotFound, "catalog_not_found", "Catalog not found")
 		return
 	}
-	requested := strings.TrimSpace(chi.URLParam(r, "catalog_id"))
-	active := tier2.CatalogID()
-	if requested == "" || requested != active {
-		writeError(w, http.StatusNotFound, "catalog_not_found", "Catalog not found")
-		return
-	}
-	data, err := os.ReadFile(cfg.CatalogPath)
-	if err != nil {
-		s.log.Warn().Err(err).Str("catalog_path", cfg.CatalogPath).Msg("read catalog file failed")
+	if requested != "" && requested != active {
 		writeError(w, http.StatusNotFound, "catalog_not_found", "Catalog not found")
 		return
 	}

--- a/phase4-coordinator/internal/tier2/catalog.go
+++ b/phase4-coordinator/internal/tier2/catalog.go
@@ -31,6 +31,7 @@ type ModelEntry struct {
 	ArtifactKind string `json:"artifact_kind"`
 	HashScope    string `json:"hash_scope"`
 	ModelID      string `json:"model_id"`
+	MinRAMGB     *int   `json:"min_ram_gb,omitempty"`
 	Notes        string `json:"notes,omitempty"`
 	SHA256       string `json:"sha256"`
 	Source       string `json:"source"`
@@ -45,6 +46,7 @@ type ParsedCatalog struct {
 	CatalogID string
 	ExpiresAt time.Time
 	Models    map[string]ModelEntry
+	Raw       []byte
 }
 
 type HashCounts struct {
@@ -341,6 +343,28 @@ func (c *Catalog) CatalogID() string {
 	return parsed.CatalogID
 }
 
+// CatalogSnapshot returns the active catalog ID and the exact signed catalog
+// bytes accepted by signature verification, read under one catalog lock.
+func (c *Catalog) CatalogSnapshot() (string, []byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	parsed := activeParsedLocked(c.st)
+	if parsed == nil || len(parsed.Raw) == 0 {
+		return "", nil, false
+	}
+	return parsed.CatalogID, append([]byte(nil), parsed.Raw...), true
+}
+
+// CatalogBytes returns the exact signed catalog bytes accepted by signature
+// verification, or nil if no active catalog exists.
+func (c *Catalog) CatalogBytes() []byte {
+	_, raw, ok := c.CatalogSnapshot()
+	if !ok {
+		return nil
+	}
+	return raw
+}
+
 // --- Package-level shims (legacy API; route to Default()) -------------------
 //
 // Pre-M3-8d code, including buyer.Server, cmd/coordinator/main.go, and tests
@@ -356,16 +380,18 @@ func ConfigureStrict(cfg config.Tier2Config, logger zerolog.Logger) error {
 	return Default().ConfigureStrict(cfg, logger)
 }
 
-func Active() bool                                                  { return Default().Active() }
-func Configured() bool                                              { return Default().Configured() }
-func LoadFailed() bool                                              { return Default().LoadFailed() }
-func CatalogUnavailable() bool                                      { return Default().CatalogUnavailable() }
-func Catalogued(modelID string) bool                                { return Default().Catalogued(modelID) }
+func Active() bool                   { return Default().Active() }
+func Configured() bool               { return Default().Configured() }
+func LoadFailed() bool               { return Default().LoadFailed() }
+func CatalogUnavailable() bool       { return Default().CatalogUnavailable() }
+func Catalogued(modelID string) bool { return Default().Catalogued(modelID) }
 func VerifyProviderHash(modelID, reportedHash string) pool.HashStatus {
 	return Default().VerifyProviderHash(modelID, reportedHash)
 }
 func ExpectedHashPrefix(modelID string) string { return Default().ExpectedHashPrefix(modelID) }
 func CatalogID() string                        { return Default().CatalogID() }
+func CatalogBytes() []byte                     { return Default().CatalogBytes() }
+func CatalogSnapshot() (string, []byte, bool)  { return Default().CatalogSnapshot() }
 
 // ResetForTest swaps in a fresh package-singleton Catalog and restores nowUTC.
 //
@@ -534,13 +560,21 @@ func ParseCatalog(raw []byte, publicKey string) (*ParsedCatalog, error) {
 		if strings.TrimSpace(model.Source) == "" {
 			return nil, fmt.Errorf("catalog source for %q must not be empty", model.ModelID)
 		}
+		if model.MinRAMGB != nil && *model.MinRAMGB < 1 {
+			return nil, fmt.Errorf("catalog min_ram_gb for %q must be positive", model.ModelID)
+		}
 		if !hashPattern.MatchString(model.SHA256) {
 			return nil, fmt.Errorf("catalog sha256 for %q must be 64 lowercase hex chars", model.ModelID)
 		}
 		model.SHA256 = strings.ToLower(model.SHA256)
 		models[modelID] = model
 	}
-	return &ParsedCatalog{CatalogID: file.CatalogID, ExpiresAt: expiresAt, Models: models}, nil
+	return &ParsedCatalog{
+		CatalogID: file.CatalogID,
+		ExpiresAt: expiresAt,
+		Models:    models,
+		Raw:       append([]byte(nil), raw...),
+	}, nil
 }
 
 func activeParsedLocked(st state) *ParsedCatalog {

--- a/phase4-coordinator/internal/tier2/catalog_test.go
+++ b/phase4-coordinator/internal/tier2/catalog_test.go
@@ -33,6 +33,9 @@ func TestLoadCatalogVerifiesKnownGoodFixture(t *testing.T) {
 	if got := catalog.Models["model-a"].SHA256; got != testHash {
 		t.Fatalf("sha=%q", got)
 	}
+	if got := catalog.Models["model-a"].MinRAMGB; got == nil || *got != 16 {
+		t.Fatalf("min_ram_gb=%v, want 16", got)
+	}
 }
 
 func TestLoadCatalogLogsSuccessfulActivation(t *testing.T) {
@@ -242,6 +245,16 @@ func TestParseCatalogRejectsUnknownFieldsDuplicateModelsAndBadSemantics(t *testi
 			t.Fatalf("ParseCatalog err=%v, want hash_scope rejection", err)
 		}
 	})
+
+	t.Run("non-positive min ram", func(t *testing.T) {
+		zero := 0
+		model := validModelEntry("model-a", testHash)
+		model.MinRAMGB = &zero
+		raw, publicKey := signedCatalogFixtureWithModels(t, time.Now().UTC().Add(time.Hour), []ModelEntry{model})
+		if _, err := ParseCatalog(raw, publicKey); err == nil || !strings.Contains(err.Error(), "min_ram_gb") {
+			t.Fatalf("ParseCatalog err=%v, want min_ram_gb rejection", err)
+		}
+	})
 }
 
 func TestTier2AuditEventsIncludeCommonFields(t *testing.T) {
@@ -296,10 +309,12 @@ func signedCatalogFixture(t *testing.T, expiresAt time.Time, sha string) ([]byte
 }
 
 func validModelEntry(modelID, sha string) ModelEntry {
+	minRAMGB := 16
 	return ModelEntry{
 		ArtifactKind: "mlx_weight_file",
 		HashScope:    "primary_weight_file",
 		ModelID:      modelID,
+		MinRAMGB:     &minRAMGB,
 		SHA256:       sha,
 		Source:       "operator-curated",
 	}

--- a/phase7-verify/internal/catalog/catalog.go
+++ b/phase7-verify/internal/catalog/catalog.go
@@ -39,6 +39,7 @@ type ModelEntry struct {
 	ArtifactKind string `json:"artifact_kind"`
 	HashScope    string `json:"hash_scope"`
 	ModelID      string `json:"model_id"`
+	MinRAMGB     *int   `json:"min_ram_gb,omitempty"`
 	Notes        string `json:"notes,omitempty"`
 	SHA256       string `json:"sha256"`
 	Source       string `json:"source"`
@@ -137,6 +138,9 @@ func Parse(data []byte) (*Catalog, error) {
 		}
 		if strings.TrimSpace(m.Source) == "" {
 			return nil, fmt.Errorf("catalog: model %q source is empty", m.ModelID)
+		}
+		if m.MinRAMGB != nil && *m.MinRAMGB < 1 {
+			return nil, fmt.Errorf("catalog: model %q min_ram_gb must be positive", m.ModelID)
 		}
 		if !hashPattern.MatchString(m.SHA256) {
 			return nil, fmt.Errorf("catalog: model %q sha256=%q is not 64 lowercase hex", m.ModelID, m.SHA256)

--- a/phase7-verify/internal/catalog/catalog_test.go
+++ b/phase7-verify/internal/catalog/catalog_test.go
@@ -19,6 +19,7 @@ func TestParseAndVerifyHappyPath(t *testing.T) {
 		ArtifactKind: "mlx_weight_file",
 		HashScope:    "primary_weight_file",
 		ModelID:      "model-a",
+		MinRAMGB:     intPtr(16),
 		SHA256:       validHash,
 		Source:       "operator-curated",
 	}})
@@ -31,6 +32,9 @@ func TestParseAndVerifyHappyPath(t *testing.T) {
 	}
 	if got := c.Models[modelKey("model-a")].SHA256; got != validHash {
 		t.Fatalf("sha = %q", got)
+	}
+	if got := c.Models[modelKey("model-a")].MinRAMGB; got == nil || *got != 16 {
+		t.Fatalf("min_ram_gb = %v, want 16", got)
 	}
 	if err := Verify(c, pub, time.Now()); err != nil {
 		t.Fatalf("Verify: %v", err)
@@ -331,6 +335,14 @@ func TestParseRejectsUnsupportedModelEntryFields(t *testing.T) {
 			SHA256:       validHash,
 			Source:       "operator-curated",
 		},
+		"non-positive-min_ram_gb": {
+			ArtifactKind: "mlx_weight_file",
+			HashScope:    "primary_weight_file",
+			ModelID:      "model-a",
+			MinRAMGB:     intPtr(0),
+			SHA256:       validHash,
+			Source:       "operator-curated",
+		},
 	}
 	for name, model := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -430,6 +442,7 @@ func TestParityWithSignCatalogProduces(t *testing.T) {
 			ArtifactKind: "mlx_weight_file",
 			HashScope:    "primary_weight_file",
 			ModelID:      "mlx-community/Qwen2.5-7B-Instruct-4bit",
+			MinRAMGB:     intPtr(16),
 			SHA256:       validHash,
 			Source:       "operator-curated",
 		}},
@@ -467,9 +480,16 @@ func TestParityWithSignCatalogProduces(t *testing.T) {
 	if entry.SHA256 != validHash {
 		t.Fatalf("entry.SHA256 = %q", entry.SHA256)
 	}
+	if entry.MinRAMGB == nil || *entry.MinRAMGB != 16 {
+		t.Fatalf("entry.MinRAMGB = %v, want 16", entry.MinRAMGB)
+	}
 }
 
 // helpers
+
+func intPtr(v int) *int {
+	return &v
+}
 
 func signFixture(t *testing.T, catalogID string, expires time.Time, models []ModelEntry) ([]byte, ed25519.PublicKey) {
 	t.Helper()

--- a/phase7-verify/internal/catalog/signer_parity_test.go
+++ b/phase7-verify/internal/catalog/signer_parity_test.go
@@ -58,6 +58,7 @@ func TestParityWithSignCatalogToolReal(t *testing.T) {
       "artifact_kind": "mlx_weight_file",
       "hash_scope": "primary_weight_file",
       "model_id": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+      "min_ram_gb": 16,
       "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
       "source": "operator-curated"
     }
@@ -102,6 +103,13 @@ func TestParityWithSignCatalogToolReal(t *testing.T) {
 	}
 	if c.CatalogID != "parity-test-catalog" {
 		t.Fatalf("CatalogID=%q", c.CatalogID)
+	}
+	entry, ok := Lookup(c, "mlx-community/Qwen2.5-7B-Instruct-4bit")
+	if !ok {
+		t.Fatal("Lookup signer output = miss")
+	}
+	if entry.MinRAMGB == nil || *entry.MinRAMGB != 16 {
+		t.Fatalf("MinRAMGB=%v, want 16", entry.MinRAMGB)
 	}
 	if err := Verify(c, ed25519.PublicKey(pubKeyBytes), time.Now()); err != nil {
 		t.Fatalf("Verify signer output: %v", err)

--- a/scripts/hash-model-weights.go
+++ b/scripts/hash-model-weights.go
@@ -26,6 +26,7 @@ type artifactManifest struct {
 type catalogEntry struct {
 	ArtifactKind string `json:"artifact_kind"`
 	HashScope    string `json:"hash_scope"`
+	MinRAMGB     int    `json:"min_ram_gb,omitempty"`
 	ModelID      string `json:"model_id"`
 	SHA256       string `json:"sha256"`
 	Source       string `json:"source"`
@@ -33,8 +34,9 @@ type catalogEntry struct {
 
 func main() {
 	modelID := flag.String("model-id", "", "model id for the catalog entry, e.g. mlx-community/Qwen2.5-7B-Instruct-4bit")
+	minRAMGB := flag.Int("min-ram-gb", 0, "override minimum RAM GB for the catalog entry; default derives from safetensors bytes")
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "usage: go run scripts/hash-model-weights.go [-model-id MODEL] SNAPSHOT_DIR\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "usage: go run scripts/hash-model-weights.go [-model-id MODEL] [-min-ram-gb N] SNAPSHOT_DIR\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -51,15 +53,23 @@ func main() {
 	if resolvedModelID == "" {
 		exitf("model id not provided and could not be derived from %q", snapshotDir)
 	}
+	if *minRAMGB < 0 {
+		exitf("-min-ram-gb must be non-negative")
+	}
 
-	hash, err := artifactManifestHash(snapshotDir)
+	hash, totalBytes, err := artifactManifestHash(snapshotDir)
 	if err != nil {
 		exitf("%v", err)
+	}
+	resolvedMinRAMGB := *minRAMGB
+	if resolvedMinRAMGB == 0 {
+		resolvedMinRAMGB = ramFloorForArtifactBytes(totalBytes)
 	}
 
 	entry := catalogEntry{
 		ArtifactKind: "mlx_weight_file",
 		HashScope:    "artifact_manifest",
+		MinRAMGB:     resolvedMinRAMGB,
 		ModelID:      resolvedModelID,
 		SHA256:       hash,
 		Source:       "operator-curated",
@@ -71,13 +81,14 @@ func main() {
 	}
 }
 
-func artifactManifestHash(snapshotDir string) (string, error) {
+func artifactManifestHash(snapshotDir string) (string, int64, error) {
 	entries, err := os.ReadDir(snapshotDir)
 	if err != nil {
-		return "", fmt.Errorf("read snapshot directory: %w", err)
+		return "", 0, fmt.Errorf("read snapshot directory: %w", err)
 	}
 
 	files := make([]manifestFile, 0)
+	var totalBytes int64
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".safetensors" {
 			continue
@@ -85,31 +96,53 @@ func artifactManifestHash(snapshotDir string) (string, error) {
 		path := filepath.Join(snapshotDir, entry.Name())
 		info, err := os.Stat(path)
 		if err != nil {
-			return "", fmt.Errorf("stat %s: %w", path, err)
+			return "", 0, fmt.Errorf("stat %s: %w", path, err)
 		}
 		hash, err := fileSHA256(path)
 		if err != nil {
-			return "", err
+			return "", 0, err
 		}
 		files = append(files, manifestFile{
 			Name:   entry.Name(),
 			SHA256: hash,
 			Size:   info.Size(),
 		})
+		totalBytes += info.Size()
 	}
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].Name < files[j].Name
 	})
 	if len(files) == 0 {
-		return "", fmt.Errorf("no .safetensors files found in %s", snapshotDir)
+		return "", 0, fmt.Errorf("no .safetensors files found in %s", snapshotDir)
 	}
 
 	canonical, err := json.Marshal(artifactManifest{Files: files})
 	if err != nil {
-		return "", fmt.Errorf("encode artifact manifest: %w", err)
+		return "", 0, fmt.Errorf("encode artifact manifest: %w", err)
 	}
 	sum := sha256.Sum256(canonical)
-	return hex.EncodeToString(sum[:]), nil
+	return hex.EncodeToString(sum[:]), totalBytes, nil
+}
+
+func ramFloorForArtifactBytes(totalBytes int64) int {
+	const gib = int64(1024 * 1024 * 1024)
+	weightGB := int((totalBytes + gib - 1) / gib)
+	switch {
+	case weightGB <= 2:
+		return 8
+	case weightGB <= 3:
+		return 12
+	case weightGB <= 5:
+		return 16
+	case weightGB <= 9:
+		return 24
+	case weightGB <= 20:
+		return 32
+	case weightGB <= 38:
+		return 48
+	default:
+		return 64
+	}
 }
 
 func fileSHA256(path string) (string, error) {

--- a/scripts/sign-catalog.go
+++ b/scripts/sign-catalog.go
@@ -27,6 +27,7 @@ type modelEntry struct {
 	ArtifactKind string `json:"artifact_kind"`
 	HashScope    string `json:"hash_scope"`
 	ModelID      string `json:"model_id"`
+	MinRAMGB     *int   `json:"min_ram_gb,omitempty"`
 	Notes        string `json:"notes,omitempty"`
 	SHA256       string `json:"sha256"`
 	Source       string `json:"source"`
@@ -270,6 +271,9 @@ func validateCatalogBody(catalog signedCatalog) error {
 		}
 		if strings.TrimSpace(model.Source) == "" {
 			return fmt.Errorf("catalog source for %q must not be empty", model.ModelID)
+		}
+		if model.MinRAMGB != nil && *model.MinRAMGB < 1 {
+			return fmt.Errorf("catalog min_ram_gb for %q must be positive", model.ModelID)
 		}
 		if !hashPattern.MatchString(model.SHA256) {
 			return fmt.Errorf("catalog sha256 for %q must be 64 lowercase hex chars", model.ModelID)

--- a/specs/SPEC-008-tier2.md
+++ b/specs/SPEC-008-tier2.md
@@ -630,6 +630,7 @@ The catalog MUST include:
       "artifact_kind": "mlx_weight_file",
       "sha256": "64 lowercase hex chars",
       "hash_scope": "primary_weight_file",
+      "min_ram_gb": 16,
       "source": "operator-curated",
       "notes": "optional operator note"
     }
@@ -655,6 +656,12 @@ The coordinator MUST verify the signature using `tier2.catalog_public_key`
 before accepting any entry. If verification fails, the coordinator MUST reject
 the catalog at startup or reload time and MUST leave the previous accepted
 catalog active, if one exists.
+
+Catalog model entries MAY include `min_ram_gb`, a positive integer RAM floor
+for provider-install UX and model-fit guidance. Because it is inside
+`models[]`, `min_ram_gb` is covered by the catalog signature when present. It
+MUST NOT affect hash equality; `sha256` remains the only model artifact hash
+field used for Pillar A verification.
 
 If no previous accepted catalog exists and `tier2.require_hash_verified: true`,
 the coordinator MUST fail startup. If `tier2.require_hash_verified: false`, the

--- a/specs/SPEC-015-receipts.md
+++ b/specs/SPEC-015-receipts.md
@@ -3019,8 +3019,11 @@ order. Any failed step short-circuits with the named result:
    `catalogFile` schema: top-level fields `catalog_id` (string),
    `expires_at` (RFC3339 UTC string), `issued_at` (RFC3339 UTC
    string), `models[]` (array of `{artifact_kind, hash_scope,
-   model_id, notes?, sha256, source}`), `signature{alg, key_id,
-   sig}`, `version` (int). Reject as `invalid` with `reason:
+   model_id, min_ram_gb?, notes?, sha256, source}`), `signature{alg,
+   key_id, sig}`, `version` (int). If present, `min_ram_gb` is a
+   positive integer RAM floor for installer/provider UX and is covered
+   by the catalog signature; it is NOT used for model-hash equality.
+   Reject as `invalid` with `reason:
    "catalog_format_invalid"` on any schema mismatch (missing
    required field, wrong type, malformed RFC3339, `sha256`
    field not matching `[0-9a-f]{64}` per
@@ -3333,9 +3336,11 @@ covered by the "effectively active catalog" condition above.
   `/v1/receipt-keys` posture.
 - **Cache-Control:** `public, max-age=300` (5 minutes; same as
   §10.7).
-- **Response:** the literal signed catalog file bytes, as
-  produced by `scripts/sign-catalog.go`. `Content-Type:
-  application/json`.
+- **Response:** the literal signed catalog bytes accepted by the
+  coordinator's catalog signature verification, as produced by
+  `scripts/sign-catalog.go`. Implementations MUST NOT reread and
+  serve mutable on-disk catalog bytes that have not passed the active
+  catalog verification state. `Content-Type: application/json`.
 - **404:** the `<catalog_id>` path segment does NOT match the
   effectively-active catalog's `catalog_id`, OR the
   coordinator has no effectively-active catalog per the §M.4
@@ -3346,6 +3351,16 @@ covered by the "effectively active catalog" condition above.
 - **5xx / 429:** verifier treats as fetch-failure → `inconclusive:
   catalog_unreachable`; no retry within the same verification
   invocation.
+
+**`GET /catalog/current` endpoint (SPEC-002 v1.6 candidate).**
+
+- Same authentication / rate-limit / cache posture as
+  `GET /catalog/<catalog_id>`.
+- **Response:** the same verified signed catalog bytes as
+  `GET /catalog/<active catalog_id>`, without requiring clients to
+  discover the active ID from operator-only `/poolz`.
+- **404:** no effectively-active catalog per the §M.4 three-condition
+  rule. Verifier treats as `inconclusive: catalog_unreachable`.
 
 **`GET /catalog/pubkey` endpoint (SPEC-002 v1.6 candidate).**
 


### PR DESCRIPTION
## Summary
- add public `/catalog/current` routing so installers can fetch signed catalog metadata without `/poolz`
- carry optional signed `min_ram_gb` metadata through catalog signing, coordinator parsing, verifier parsing, and installer menus
- serve catalog endpoint responses from verified in-memory signed bytes, with catalog id and body read from one snapshot

## Validation
- `go test -count=1 ./internal/tier2 ./internal/buyer` in `phase4-coordinator`
- `go test ./...` in `phase4-coordinator`
- `go test -count=1 ./internal/catalog ./internal/verify` in `phase7-verify`
- `go test ./...` in `phase7-verify`
- `bash -n phase3-binary/dist/install.sh && go test scripts/hash-model-weights.go && go test scripts/sign-catalog.go && git diff --check`
- `make test-dist`
- code/security/architecture audit lanes returned `CLEAR` for critical/high/medium findings
