### PR TITLE
release: skip raw CLI stapling after notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,13 +69,16 @@ jobs:
       # macprovider-launchd-amfi-blocker-macos-26 for the full discovery
       # writeup (2026-06-12 session).
       #
-      # The fix: codesign the binary with a Developer ID Application cert,
-      # notarize via xcrun notarytool, and staple. Once the operator has an
-      # Apple Developer Program membership and populates the required secrets,
-      # this step activates automatically. Until then it is a documented
-      # no-op so the workflow still produces a release (operator can install
-      # under earlier macOS or run the binary outside launchd while the
-      # signing pipeline is being set up).
+      # The fix: codesign the binary with a Developer ID Application cert
+      # and notarize via xcrun notarytool. The current release artifact is a
+      # tarball containing a standalone Mach-O executable; Apple's stapler
+      # cannot attach a ticket to that raw file format. If the release format
+      # changes to a signed pkg, dmg, or app bundle, add stapling for that
+      # container. Once the operator has an Apple Developer Program membership
+      # and populates the required secrets, this step activates automatically.
+      # Until then it is a documented no-op so the workflow still produces a
+      # release (operator can install under earlier macOS or run the binary
+      # outside launchd while the signing pipeline is being set up).
       - name: Sign + notarize binary (conditional on operator secrets)
         shell: bash
         env:
@@ -160,10 +163,12 @@ jobs:
           codesign --verify --strict --verbose=2 "$WORK/macprovider-cli"
 
           # Step 3: notarize. notarytool needs a zip or dmg, not a raw
-          # binary — wrap the binary in a transient zip for submission
-          # only. The tarball is what we ship; we staple the binary
-          # itself before re-tarring (--wait blocks until notarization
-          # completes, typically 1-15 minutes).
+          # binary, so wrap the binary in a transient zip for submission
+          # only. The tarball is what we ship. Apple's stapler cannot
+          # attach a ticket to a standalone executable, so Accepted
+          # notarization is the release gate for this artifact format
+          # (--wait blocks until notarization completes, typically 1-15
+          # minutes).
           NOTARIZE_ZIP=$(mktemp -u).zip
           (cd "$WORK" && /usr/bin/ditto -c -k --keepParent macprovider-cli "$NOTARIZE_ZIP")
 
@@ -174,15 +179,7 @@ jobs:
             --wait
           rm -f "$NOTARIZE_ZIP"
 
-          # Step 4: staple. Without stapling, first launch needs a
-          # network round-trip to Apple's notary servers — bad UX for
-          # curl|bash install flows on machines that have just come
-          # online. With stapling, the notarization ticket is embedded
-          # in the binary and verified offline.
-          xcrun stapler staple "$WORK/macprovider-cli"
-          xcrun stapler validate "$WORK/macprovider-cli"
-
-          # Step 5: re-tar with the signed + notarized + stapled binary.
+          # Step 4: re-tar with the signed + notarized binary.
           # Preserve the same internal layout package.sh produced; the
           # only difference vs the input tarball is that
           # ./macprovider-cli now carries a real signature chain.
@@ -194,7 +191,8 @@ jobs:
           rm -rf "$WORK"
 
           echo "  binary signed by: $SIGNING_ID"
-          echo "  notarization: stapled"
+          echo "  notarization: accepted"
+          echo "  stapling: skipped for standalone executable tarball"
 
       - name: Tier-2 provider artifact preflight
         shell: bash

--- a/phase3-binary/dist/release-signing-runbook.md
+++ b/phase3-binary/dist/release-signing-runbook.md
@@ -5,6 +5,14 @@ The release workflow (`.github/workflows/release.yml`) signs the
 notarizes via `xcrun notarytool` so freshly-installed binaries pass
 macOS 26.3.1+ launchd's tightened AMFI policy.
 
+The current release artifact is a `.tar.gz` containing a standalone
+Mach-O executable. Apple notarization accepts the executable when it is
+submitted inside a transient zip, but `xcrun stapler` cannot attach a
+notarization ticket directly to that raw executable format. For this
+artifact shape, the release gate is `notarytool submit --wait` returning
+`Accepted`. If releases move to a `.pkg`, `.dmg`, or `.app` bundle, add
+stapling for that container.
+
 The signing step is **conditional on operator-supplied secrets**. If
 `APPLE_DEVELOPER_ID_CERT_P12_BASE64` is empty, the step emits a
 GitHub Actions warning and ships an adhoc-signed binary (current
@@ -99,9 +107,8 @@ on top of the existing ~5-10 minute build. The step:
 1. Imports the `.p12` into a transient keychain
 2. Codesigns the binary with `--options runtime --timestamp`
 3. Notarizes via `xcrun notarytool submit --wait`
-4. Staples the notarization ticket to the binary
-5. Re-tars with the signed binary
-6. Deletes the transient keychain
+4. Re-tars with the signed, notarization-accepted binary
+5. Deletes the transient keychain
 
 Verify on a macOS 26.3.1+ Mac:
 
@@ -120,16 +127,17 @@ log show --last 1m | grep -iE "macprovider|AMFI"
 
 Common follow-up issues:
 
-- **"the certificate could not be validated"** — notarization succeeded
-  but staple failed. The binary is online-verifiable but launchd's
-  offline-only check rejects it. Re-run `xcrun stapler staple` locally
-  and republish the tarball.
+- **`xcrun stapler` exits with Error 73** — expected if someone tries
+  to staple `macprovider-cli` directly. Raw standalone executables are
+  not a supported stapler target. Use a signed `.pkg`, `.dmg`, or
+  executable bundle if offline stapling becomes required.
 - **"Notarization request was not found"** — `notarytool submit` was
-  invoked without `--wait` (or it timed out), so the ticket never
-  attached. Re-trigger the workflow.
+  invoked without `--wait` (or it timed out), so notarization was not
+  accepted before packaging. Re-trigger the workflow.
 - **"developer cannot be verified"** — Gatekeeper, not AMFI. Clears
   with `xattr -d com.apple.quarantine <binary>` or accepting the
-  Gatekeeper prompt once. Should not happen for stapled binaries.
+  Gatekeeper prompt once. Should not happen for signed and accepted
+  notarized binaries under normal online verification.
 
 ## Cost summary
 


### PR DESCRIPTION
## Summary
- remove direct `xcrun stapler` calls for the standalone CLI executable
- keep Developer ID signing and `notarytool submit --wait` as the release gate
- update the operator runbook with the raw executable stapling limitation

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml yaml ok"'`

## Reason
The v1.6.0 release run now signs successfully and Apple notarization returns Accepted, but fails afterward because `xcrun stapler` cannot attach a ticket to a raw standalone Mach-O executable inside the current tarball format.