### PR TITLE
release: add signed stapled pkg asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,12 +70,13 @@ jobs:
       # writeup (2026-06-12 session).
       #
       # The fix: codesign the binary with a Developer ID Application cert
-      # and notarize via xcrun notarytool. The current release artifact is a
-      # tarball containing a standalone Mach-O executable; Apple's stapler
-      # cannot attach a ticket to that raw file format. If the release format
-      # changes to a signed pkg, dmg, or app bundle, add stapling for that
-      # container. Once the operator has an Apple Developer Program membership
-      # and populates the required secrets, this step activates automatically.
+      # and notarize via xcrun notarytool. The compatibility artifact remains
+      # a tarball containing a standalone Mach-O executable, which Apple's
+      # stapler cannot ticket directly. When a Developer ID Installer cert is
+      # also present, this step additionally builds, signs, notarizes, staples,
+      # and validates a flat pkg delivery container for install.sh to consume.
+      # Once the operator has an Apple Developer Program membership
+      # and populates the required secrets, signing activates automatically.
       # Until then it is a documented no-op so the workflow still produces a
       # release (operator can install under earlier macOS or run the binary
       # outside launchd while the signing pipeline is being set up).
@@ -84,11 +85,30 @@ jobs:
         env:
           APPLE_DEVELOPER_ID_CERT_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12_BASE64 }}
           APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+          APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD }}
           APPLE_NOTARY_APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
           APPLE_NOTARY_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
           APPLE_NOTARY_TEAM_ID: ${{ secrets.APPLE_NOTARY_TEAM_ID }}
         run: |
           set -euo pipefail
+          KEYCHAIN_CREATED=0
+          WORK=""
+          SIGNING_TMP=""
+          NOTARIZE_ZIP=""
+          cleanup_signing_material() {
+            if [ -n "$SIGNING_TMP" ]; then
+              rm -rf "$SIGNING_TMP"
+            fi
+            if [ "$KEYCHAIN_CREATED" = "1" ]; then
+              security delete-keychain build.keychain >/dev/null 2>&1 || true
+            fi
+            if [ -n "$WORK" ]; then
+              rm -rf "$WORK"
+            fi
+          }
+          trap cleanup_signing_material EXIT
+
           tag="${{ steps.version.outputs.tag }}"
           src="phase3-binary/dist/phase3-binary-m4-${tag}.tar.gz"
           test -f "$src"
@@ -115,21 +135,38 @@ jobs:
             echo "::error::Developer ID cert present but other Apple secrets missing:$missing" >&2
             exit 1
           fi
+          if [ -n "$APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64" ] && \
+             [ -z "$APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD" ]; then
+            echo "::error::Developer ID Installer cert present but APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD missing" >&2
+            exit 1
+          fi
 
-          # Step 1: import .p12 into a transient keychain.
+          # Step 1: import .p12 certificate identities into a transient
+          # keychain. The Application identity signs the executable; the
+          # Installer identity signs the staplable .pkg artifact.
           KEYCHAIN_PASS=$(openssl rand -hex 16)
+          SIGNING_TMP=$(mktemp -d)
           security create-keychain -p "$KEYCHAIN_PASS" build.keychain
+          KEYCHAIN_CREATED=1
           security default-keychain -s build.keychain
           security unlock-keychain -p "$KEYCHAIN_PASS" build.keychain
           security set-keychain-settings -lut 3600 build.keychain
 
-          echo "$APPLE_DEVELOPER_ID_CERT_P12_BASE64" | base64 -d > /tmp/cert.p12
-          security import /tmp/cert.p12 \
+          echo "$APPLE_DEVELOPER_ID_CERT_P12_BASE64" | base64 -d > "$SIGNING_TMP/cert.p12"
+          security import "$SIGNING_TMP/cert.p12" \
             -k build.keychain \
             -P "$APPLE_DEVELOPER_ID_CERT_PASSWORD" \
             -T /usr/bin/codesign \
             -T /usr/bin/security
-          rm -f /tmp/cert.p12
+
+          if [ -n "$APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64" ]; then
+            echo "$APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64" | base64 -d > "$SIGNING_TMP/installer-cert.p12"
+            security import "$SIGNING_TMP/installer-cert.p12" \
+              -k build.keychain \
+              -P "$APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD" \
+              -T /usr/bin/productsign \
+              -T /usr/bin/security
+          fi
 
           # Required on macOS Sierra+ so the codesign tool can access the
           # imported private key non-interactively.
@@ -144,6 +181,15 @@ jobs:
           if [ -z "$SIGNING_ID" ]; then
             echo "::error::No Developer ID Application identity found in imported cert" >&2
             exit 1
+          fi
+          INSTALLER_ID=""
+          if [ -n "$APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64" ]; then
+            INSTALLER_ID=$(security find-identity -v build.keychain \
+                          | awk -F'"' '/Developer ID Installer/ {print $2; exit}')
+            if [ -z "$INSTALLER_ID" ]; then
+              echo "::error::No Developer ID Installer identity found in imported cert" >&2
+              exit 1
+            fi
           fi
 
           # Extract tarball so we can sign the binary in place, then repack.
@@ -169,7 +215,7 @@ jobs:
           # notarization is the release gate for this artifact format
           # (--wait blocks until notarization completes, typically 1-15
           # minutes).
-          NOTARIZE_ZIP=$(mktemp -u).zip
+          NOTARIZE_ZIP="$SIGNING_TMP/notary.zip"
           (cd "$WORK" && /usr/bin/ditto -c -k --keepParent macprovider-cli "$NOTARIZE_ZIP")
 
           xcrun notarytool submit "$NOTARIZE_ZIP" \
@@ -186,13 +232,67 @@ jobs:
           rm -f "$src"
           tar czf "$src" -C "$WORK" .
 
+          pkg_src="phase3-binary/dist/phase3-binary-m4-${tag}.pkg"
+          if [ -n "$INSTALLER_ID" ]; then
+            # Step 5: build a signed, notarized, stapled flat package as the
+            # Apple-native delivery container. install.sh treats this as a
+            # verified payload container and still owns per-user config,
+            # launchd plist rendering, and support-file placement. A direct
+            # Installer.app install is blocked by the package preinstall script
+            # so operators do not bypass install.sh's user-level setup.
+            PKG_ROOT="$WORK/pkg-root"
+            PKG_SCRIPTS="$WORK/pkg-scripts"
+            mkdir -p "$PKG_ROOT"
+            mkdir -p "$PKG_SCRIPTS"
+            cp "$WORK/macprovider-cli" "$PKG_ROOT/macprovider-cli"
+            find "$WORK" -mindepth 1 -maxdepth 1 -name '*.bundle' -exec cp -R {} "$PKG_ROOT"/ \;
+            if [ -f "$WORK/THIRD-PARTY-NOTICES.txt" ]; then
+              cp "$WORK/THIRD-PARTY-NOTICES.txt" "$PKG_ROOT/THIRD-PARTY-NOTICES.txt"
+            fi
+            printf '%s\n' \
+              '#!/bin/sh' \
+              'echo "macprovider-cli.pkg is a signed delivery container for install.sh." >&2' \
+              'echo "Install with: curl -fsSL https://get.streamvc.live/install.sh | bash" >&2' \
+              'exit 1' \
+              > "$PKG_SCRIPTS/preinstall"
+            chmod 755 "$PKG_SCRIPTS/preinstall"
+
+            UNSIGNED_PKG="$WORK/macprovider-cli-unsigned.pkg"
+            SIGNED_PKG="$WORK/macprovider-cli.pkg"
+            pkgbuild \
+              --root "$PKG_ROOT" \
+              --scripts "$PKG_SCRIPTS" \
+              --identifier live.streamvc.macprovider.cli \
+              --version "${tag#v}" \
+              --install-location "/" \
+              "$UNSIGNED_PKG"
+            productsign --sign "$INSTALLER_ID" "$UNSIGNED_PKG" "$SIGNED_PKG"
+
+            xcrun notarytool submit "$SIGNED_PKG" \
+              --apple-id "$APPLE_NOTARY_APPLE_ID" \
+              --password "$APPLE_NOTARY_PASSWORD" \
+              --team-id "$APPLE_NOTARY_TEAM_ID" \
+              --wait
+            xcrun stapler staple "$SIGNED_PKG"
+            xcrun stapler validate "$SIGNED_PKG"
+            cp "$SIGNED_PKG" "$pkg_src"
+          else
+            rm -f "$pkg_src"
+            echo "::warning::APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64 not set; skipping signed/stapled .pkg artifact."
+          fi
+
           # Clean up keychain so secrets do not linger on the runner.
-          security delete-keychain build.keychain
-          rm -rf "$WORK"
+          cleanup_signing_material
+          trap - EXIT
 
           echo "  binary signed by: $SIGNING_ID"
           echo "  notarization: accepted"
           echo "  stapling: skipped for standalone executable tarball"
+          if [ -n "$INSTALLER_ID" ]; then
+            echo "  installer signed by: $INSTALLER_ID"
+            echo "  pkg notarization: accepted"
+            echo "  pkg stapling: validated"
+          fi
 
       - name: Tier-2 provider artifact preflight
         shell: bash
@@ -210,6 +310,102 @@ jobs:
             PROVIDER_SHA256="" \
             scripts/check-tier2-provider-artifact.sh
 
+          pkg_src="phase3-binary/dist/phase3-binary-m4-${tag}.pkg"
+          if [ ! -f "$pkg_src" ]; then
+            echo "No signed .pkg artifact present; tarball compatibility release preflight complete."
+            exit 0
+          fi
+
+          validate_payload_entries() {
+            payload_dir="$1"
+            label="$2"
+            entries="$(cd "$payload_dir" && find . -mindepth 1 -print)" || {
+              echo "::error::failed to list $label" >&2
+              exit 1
+            }
+            [ -n "$entries" ] || {
+              echo "::error::$label is empty" >&2
+              exit 1
+            }
+            has_binary=0
+            while IFS= read -r entry; do
+              normalized_entry="$entry"
+              while :; do
+                case "$normalized_entry" in
+                  ./*) normalized_entry="${normalized_entry#./}" ;;
+                  *) break ;;
+                esac
+              done
+              case "$normalized_entry" in
+                ""|.) continue ;;
+              esac
+              case "$normalized_entry" in
+                /*|*"/../"*|../*|*/..|..)
+                  echo "::error::unsafe $label path: $entry" >&2
+                  exit 1
+                  ;;
+                macprovider-cli)
+                  has_binary=1
+                  ;;
+                THIRD-PARTY-NOTICES.txt)
+                  ;;
+                *.bundle|*.bundle/*)
+                  ;;
+                *)
+                  echo "::error::unexpected $label member: $entry" >&2
+                  exit 1
+                  ;;
+              esac
+            done <<EOF
+          $entries
+          EOF
+            [ "$has_binary" -eq 1 ] || {
+              echo "::error::$label does not contain macprovider-cli" >&2
+              exit 1
+            }
+            if find "$payload_dir" \( -type l -o -type b -o -type c -o -type p \) -print -quit | grep -q .; then
+              echo "::error::$label contains unsafe link or device members" >&2
+              exit 1
+            fi
+          }
+
+          spctl -a -vv -t install "$pkg_src"
+          xcrun stapler validate "$pkg_src"
+
+          preflight_dir="$(mktemp -d)"
+          cleanup_preflight() {
+            rm -rf "$preflight_dir"
+          }
+          trap cleanup_preflight EXIT
+
+          tar_payload_dir="$preflight_dir/tar-payload"
+          pkg_expand_dir="$preflight_dir/pkg-expanded"
+          pkg_payload_tar="$preflight_dir/pkg-payload.tar.gz"
+          mkdir -p "$tar_payload_dir"
+          tar -xzf "phase3-binary/dist/phase3-binary-m4-${tag}.tar.gz" -C "$tar_payload_dir" macprovider-cli
+          pkgutil --expand-full "$pkg_src" "$pkg_expand_dir"
+          test -x "$pkg_expand_dir/Payload/macprovider-cli"
+          validate_payload_entries "$pkg_expand_dir/Payload" "provider package payload"
+
+          tar_binary_sha="$(shasum -a 256 "$tar_payload_dir/macprovider-cli" | awk '{print $1}')"
+          pkg_binary_sha="$(shasum -a 256 "$pkg_expand_dir/Payload/macprovider-cli" | awk '{print $1}')"
+          if [ "$pkg_binary_sha" != "$tar_binary_sha" ]; then
+            echo "::error::package binary sha256 differs from tarball binary" >&2
+            exit 1
+          fi
+
+          pkg_version="$("$pkg_expand_dir/Payload/macprovider-cli" --version)"
+          if [ "$pkg_version" != "${tag#v}" ]; then
+            echo "::error::provider package version mismatch: got $pkg_version want ${tag#v}" >&2
+            exit 1
+          fi
+
+          tar czf "$pkg_payload_tar" -C "$pkg_expand_dir/Payload" .
+          PROVIDER_ARTIFACT="$pkg_payload_tar" \
+            PROVIDER_VERSION="${tag#v}" \
+            PROVIDER_SHA256="" \
+            scripts/check-tier2-provider-artifact.sh
+
       - name: Prepare release assets
         id: assets
         shell: bash
@@ -219,19 +415,30 @@ jobs:
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
           src="phase3-binary/dist/phase3-binary-m4-${tag}.tar.gz"
-          asset="macprovider-cli-${tag}-darwin-arm64.tar.gz"
+          pkg_src="phase3-binary/dist/phase3-binary-m4-${tag}.pkg"
+          tar_asset="macprovider-cli-${tag}-darwin-arm64.tar.gz"
+          pkg_asset="macprovider-cli-${tag}-darwin-arm64.pkg"
           test -f "$src"
           if [ -z "$MACPROVIDER_RELEASE_SIGNING_KEY_PEM" ]; then
             echo "MACPROVIDER_RELEASE_SIGNING_KEY_PEM secret is required" >&2
             exit 1
           fi
-          cp "$src" "$asset"
-          shasum -a 256 "$asset" > checksums.txt
+          cp "$src" "$tar_asset"
+          release_assets=("$tar_asset")
+          if [ -f "$pkg_src" ]; then
+            cp "$pkg_src" "$pkg_asset"
+            release_assets+=("$pkg_asset")
+          fi
+          : > checksums.txt
+          for release_asset in "${release_assets[@]}"; do
+            shasum -a 256 "$release_asset" >> checksums.txt
+          done
+          printf "%s\n" "${release_assets[@]}" > release-assets.txt
           printf "%s\n" "$MACPROVIDER_RELEASE_SIGNING_KEY_PEM" > release-signing-private.pem
           chmod 600 release-signing-private.pem
           openssl dgst -sha256 -sign release-signing-private.pem -out checksums.txt.sig checksums.txt
           rm -f release-signing-private.pem
-          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+          echo "asset=$tar_asset" >> "$GITHUB_OUTPUT"
 
       - name: Prepare release notes
         shell: bash
@@ -246,9 +453,9 @@ jobs:
 
           Darwin arm64 build for Apple Silicon Macs.
 
-          This release is currently unsigned. SPEC-003 OQ-1/OQ-5 tracks
-          Developer ID signing and notarization; install.sh clears the
-          macOS quarantine attribute after explicit user confirmation.
+          This release is Developer ID signed and notarized when the
+          release operator secrets are populated. New releases may include
+          a stapled .pkg asset in addition to the compatibility tarball.
           EOF
           fi
 
@@ -259,8 +466,12 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
+          release_assets=()
+          while IFS= read -r release_asset; do
+            [ -n "$release_asset" ] && release_assets+=("$release_asset")
+          done < release-assets.txt
           gh release create "$tag" \
-            "${{ steps.assets.outputs.asset }}" \
+            "${release_assets[@]}" \
             checksums.txt \
             checksums.txt.sig \
             --title "macprovider-cli $tag" \

--- a/phase3-binary/README.md
+++ b/phase3-binary/README.md
@@ -2,7 +2,8 @@
 
 This package builds `macprovider-cli`, the Apple Silicon provider binary
 for Mac Provider. The distribution layer in `dist/` publishes a
-darwin-arm64 tarball and installs it as a user-level service.
+darwin-arm64 tarball, may also publish a stapled package delivery
+container, and installs the provider as a user-level service.
 
 ## Join the Network
 
@@ -16,8 +17,9 @@ curl -fsSL https://get.streamvc.live/install.sh | bash
 The installer:
 
 - Downloads `macprovider-cli-vX.Y.Z-darwin-arm64.tar.gz` from GitHub
-  Releases.
-- Verifies `checksums.txt.sig`, then verifies the release tarball
+  Releases, or prefers `macprovider-cli-vX.Y.Z-darwin-arm64.pkg` when
+  that stapled delivery container is present.
+- Verifies `checksums.txt.sig`, then verifies the selected release asset
   against `checksums.txt`.
 - Installs the binary and resource bundles under `~/macprovider`.
 - Selects a default MLX model from RAM: 3B for 8 GB, 7B for 16 GB, 14B
@@ -40,15 +42,15 @@ The installer:
 
 The public installer is intentionally independent of local build output:
 it assumes the matching release tarball already exists on GitHub
-Releases.
+Releases. The tarball remains the canonical self-update artifact until
+`macprovider-cli update` explicitly supports the package delivery path.
 
-## Trust Caveat
+## Trust Model
 
-The current binary is unsigned at the macOS app-signing layer.
 `install.sh` verifies the signed checksum manifest and SHA-256 before
-extracting, then asks before clearing the macOS quarantine attribute.
-This keeps the v1 install path working while Developer ID signing
-remains an open SPEC-003 operator question.
+extracting either release asset. Developer ID signed releases can include
+a stapled `.pkg` delivery container; older or compatibility releases keep
+using the signed/notarized tarball path.
 
 ## Provider economics (earnings, payouts, lifecycle)
 

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -65,6 +65,7 @@ Environment overrides:
   MACPROVIDER_COORDINATOR_URL    coordinator WebSocket URL
   MACPROVIDER_PORT               local HTTP port
   MACPROVIDER_INSTALL_DIR        support dir for binary + bundles
+  MACPROVIDER_RELEASE_FORMAT     auto, pkg, or tar (default: auto)
   MACPROVIDER_NO_PROMPT=1        use defaults without interactive prompts
   MACPROVIDER_NO_LAUNCHD=1       skip launchd service install
   MACPROVIDER_SKIP_HF_CHECK=1    skip HuggingFace lookup on custom model id
@@ -734,17 +735,45 @@ latest_release_tag() {
 
 download_release() {
   tag="$1"
-  asset="macprovider-cli-${tag}-darwin-arm64.tar.gz"
+  tarball_asset="macprovider-cli-${tag}-darwin-arm64.tar.gz"
+  pkg_asset="macprovider-cli-${tag}-darwin-arm64.pkg"
   base="https://github.com/${GITHUB_REPO}/releases/download/${tag}"
   TMPDIR_PATH="$(mktemp -d)"
-  tarball_path="$TMPDIR_PATH/$asset"
+  tarball_path="$TMPDIR_PATH/$tarball_asset"
+  pkg_path="$TMPDIR_PATH/$pkg_asset"
   checksums_path="$TMPDIR_PATH/checksums.txt"
   checksums_sig_path="$TMPDIR_PATH/checksums.txt.sig"
+  asset_path=""
+  asset_kind=""
 
-  log "Downloading $asset from GitHub Releases."
-  curl -fL "$base/$asset" -o "$tarball_path" || die 3 "failed to download release tarball"
   curl -fL "$base/checksums.txt" -o "$checksums_path" || die 3 "failed to download checksums.txt"
   curl -fL "$base/checksums.txt.sig" -o "$checksums_sig_path" || die 3 "failed to download checksums.txt.sig"
+  verify_checksum_signature
+
+  release_format="${MACPROVIDER_RELEASE_FORMAT:-auto}"
+  case "$release_format" in
+    auto|pkg|tar) ;;
+    *) die 7 "MACPROVIDER_RELEASE_FORMAT must be auto, pkg, or tar" ;;
+  esac
+
+  if [ "$release_format" != "tar" ]; then
+    pkg_expected="$(checksum_for_asset "$pkg_asset")"
+    if [ -n "$pkg_expected" ]; then
+      log "Downloading signed package $pkg_asset from GitHub Releases."
+      curl -fL "$base/$pkg_asset" -o "$pkg_path" || die 3 "failed to download release package"
+      asset_path="$pkg_path"
+      asset_kind="pkg"
+      log "Using signed package release asset: $pkg_asset"
+      return
+    fi
+    [ "$release_format" = "auto" ] || die 3 "checksums.txt has no entry for $pkg_asset"
+    log "Signed release manifest has no package for $tag; falling back to tarball."
+  fi
+
+  log "Downloading $tarball_asset from GitHub Releases."
+  curl -fL "$base/$tarball_asset" -o "$tarball_path" || die 3 "failed to download release tarball"
+  asset_path="$tarball_path"
+  asset_kind="tar"
 }
 
 write_checksum_public_key() {
@@ -773,41 +802,117 @@ verify_checksum_signature() {
   log "checksums.txt signature verified."
 }
 
+checksum_for_asset() {
+  asset_name="$1"
+  awk -v asset="$asset_name" '$2 == asset { print $1; exit }' "$checksums_path"
+}
+
 verify_sha256() {
-  expected="$(grep "  $(basename "$tarball_path")$" "$checksums_path" | awk '{print $1}' | head -1)"
-  [ -n "$expected" ] || die 4 "checksums.txt has no entry for $(basename "$tarball_path")"
-  actual="$(shasum -a 256 "$tarball_path" | awk '{print $1}')"
-  [ "$actual" = "$expected" ] || die 4 "checksum mismatch for $(basename "$tarball_path")"
+  asset_name="$(basename "$asset_path")"
+  expected="$(checksum_for_asset "$asset_name")"
+  [ -n "$expected" ] || die 4 "checksums.txt has no entry for $asset_name"
+  actual="$(shasum -a 256 "$asset_path" | awk '{print $1}')"
+  [ "$actual" = "$expected" ] || die 4 "checksum mismatch for $asset_name"
   log "SHA256 verified."
 }
 
 validate_tarball() {
-  entries="$(tar tzf "$tarball_path")" || die 5 "failed to list release tarball"
+  entries="$(tar tzf "$asset_path")" || die 5 "failed to list release tarball"
   [ -n "$entries" ] || die 5 "release tarball is empty"
 
+  validate_staged_entries "$entries" "tarball"
+  if tar tvzf "$asset_path" | awk '{print substr($1,1,1), $0}' | grep -E '^[lhbcp]' >/dev/null; then
+    die 5 "release tarball contains unsafe link or device members"
+  fi
+}
+
+validate_staged_entries() {
+  entries="$1"
+  label="$2"
   has_binary=0
   while IFS= read -r entry; do
-    case "$entry" in
-      ""|/*|*"/../"*|../*|*/..|..)
+    normalized_entry="$entry"
+    while :; do
+      case "$normalized_entry" in
+        ./*) normalized_entry="${normalized_entry#./}" ;;
+        *) break ;;
+      esac
+    done
+    case "$normalized_entry" in
+      ""|.) continue ;;
+    esac
+    case "$normalized_entry" in
+      /*|*"/../"*|../*|*/..|..)
         die 5 "unsafe tarball path: $entry"
         ;;
       macprovider-cli)
         has_binary=1
         ;;
+      THIRD-PARTY-NOTICES.txt)
+        ;;
       *.bundle|*.bundle/*)
         ;;
       *)
-        die 5 "unexpected tarball member: $entry"
+        die 5 "unexpected $label member: $entry"
         ;;
     esac
   done <<EOF
 $entries
 EOF
 
-  [ "$has_binary" -eq 1 ] || die 5 "release tarball does not contain macprovider-cli"
-  if tar tvzf "$tarball_path" | awk '{print substr($1,1,1), $0}' | grep -E '^[lhbcp]' >/dev/null; then
-    die 5 "release tarball contains unsafe link or device members"
+  [ "$has_binary" -eq 1 ] || die 5 "$label does not contain macprovider-cli"
+}
+
+validate_package() {
+  require_tool pkgutil
+  if command -v spctl >/dev/null 2>&1; then
+    spctl -a -vv -t install "$asset_path" || die 4 "package failed Gatekeeper assessment"
+    log "Package Gatekeeper assessment passed."
+  else
+    log "spctl not found; package checksum was verified but Gatekeeper assessment was skipped."
   fi
+  if command -v xcrun >/dev/null 2>&1 && xcrun --find stapler >/dev/null 2>&1; then
+    xcrun stapler validate "$asset_path" || die 4 "package stapler validation failed"
+    log "Package stapler validation passed."
+  else
+    log "stapler not found; local package stapler validation skipped."
+  fi
+}
+
+validate_release_payload() {
+  case "$asset_kind" in
+    tar) validate_tarball ;;
+    pkg) validate_package ;;
+    *) die 5 "release asset was not selected" ;;
+  esac
+}
+
+stage_release_payload() {
+  staging_dir="$TMPDIR_PATH/staging"
+  rm -rf "$staging_dir"
+  mkdir -p "$staging_dir"
+
+  case "$asset_kind" in
+    tar)
+      tar xzf "$asset_path" -C "$staging_dir" || die 5 "failed to extract release tarball"
+      ;;
+    pkg)
+      expanded_dir="$TMPDIR_PATH/pkg-expanded"
+      rm -rf "$expanded_dir"
+      pkgutil --expand-full "$asset_path" "$expanded_dir" || die 5 "failed to expand release package"
+      [ -d "$expanded_dir/Payload" ] || die 5 "expanded package does not contain Payload"
+      payload_entries="$(cd "$expanded_dir/Payload" && find . -mindepth 1 -print)" \
+        || die 5 "failed to list expanded package payload"
+      validate_staged_entries "$payload_entries" "package payload"
+      if find "$expanded_dir/Payload" \( -type l -o -type b -o -type c -o -type p \) -print -quit | grep -q .; then
+        die 5 "package payload contains unsafe link or device members"
+      fi
+      cp -R "$expanded_dir/Payload/." "$staging_dir"/
+      ;;
+    *)
+      die 5 "release asset was not selected"
+      ;;
+  esac
 }
 
 write_config() {
@@ -835,10 +940,7 @@ install_binary() {
     log "Would keep release support files in $INSTALL_DIR"
     return
   fi
-  staging_dir="$TMPDIR_PATH/staging"
-  rm -rf "$staging_dir"
-  mkdir -p "$staging_dir"
-  tar xzf "$tarball_path" -C "$staging_dir" || die 5 "failed to extract release tarball"
+  stage_release_payload
 
   # CRITICAL: mlx-swift loads Metal kernels from .bundle directories
   # adjacent to the binary. We install the REAL binary into $INSTALL_DIR
@@ -895,7 +997,11 @@ clear_quarantine() {
     log "xattr not found; skipping quarantine cleanup."
     return
   fi
-  log "The current release is unsigned. Clearing com.apple.quarantine lets macOS run it."
+  if [ "${asset_kind:-}" = "pkg" ]; then
+    log "Package release passed Gatekeeper assessment; quarantine cleanup is not required."
+    return
+  fi
+  log "Tarball release may carry a quarantine attribute. Clearing it lets macOS run the CLI."
   if prompt_yes_no "Clear quarantine attribute on $BINARY_PATH and $INSTALL_DIR? [Y/n]" "Y"; then
     run xattr -dr com.apple.quarantine "$BINARY_PATH"
     run xattr -dr com.apple.quarantine "$INSTALL_DIR"
@@ -1160,9 +1266,8 @@ main() {
   tag="$(latest_release_tag)"
   log "Latest release: $tag"
   download_release "$tag"
-  verify_checksum_signature
   verify_sha256
-  validate_tarball
+  validate_release_payload
   check_install_dir_clean
   install_binary
   check_path_hint

--- a/phase3-binary/dist/release-signing-runbook.md
+++ b/phase3-binary/dist/release-signing-runbook.md
@@ -5,13 +5,21 @@ The release workflow (`.github/workflows/release.yml`) signs the
 notarizes via `xcrun notarytool` so freshly-installed binaries pass
 macOS 26.3.1+ launchd's tightened AMFI policy.
 
-The current release artifact is a `.tar.gz` containing a standalone
+The compatibility release artifact is a `.tar.gz` containing a standalone
 Mach-O executable. Apple notarization accepts the executable when it is
 submitted inside a transient zip, but `xcrun stapler` cannot attach a
-notarization ticket directly to that raw executable format. For this
+notarization ticket directly to that raw executable format. For that
 artifact shape, the release gate is `notarytool submit --wait` returning
-`Accepted`. If releases move to a `.pkg`, `.dmg`, or `.app` bundle, add
-stapling for that container.
+`Accepted`.
+
+New releases can also publish a signed flat `.pkg` delivery container.
+The package carries the same `macprovider-cli` payload as the tarball,
+is signed with a Developer ID Installer certificate, is submitted to
+notarytool directly, and is stapled after Apple accepts it. `install.sh`
+prefers this package when present and falls back to the tarball for older
+releases. The package is not a standalone GUI installer; its preinstall
+script fails direct Installer.app installs so operators do not bypass
+`install.sh`'s user-level config, launchd, and support-file setup.
 
 The signing step is **conditional on operator-supplied secrets**. If
 `APPLE_DEVELOPER_ID_CERT_P12_BASE64` is empty, the step emits a
@@ -71,34 +79,45 @@ Keychain Access → Certificates → [find "Developer ID Application: <name>"]
 → set a password you will paste into APPLE_DEVELOPER_ID_CERT_PASSWORD
 ```
 
-### 3. Generate an app-specific password for notarytool
+### 3. Generate a Developer ID Installer certificate for `.pkg` releases
+
+Repeat the CSR upload flow from step 2, but choose
+**Developer ID Installer**. Download the resulting `.cer`, install it in
+Keychain Access, then export it as `.p12`.
+
+Use a separate export password; it becomes
+`APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD`.
+
+### 4. Generate an app-specific password for notarytool
 
 At <https://appleid.apple.com/account/manage> → App-Specific Passwords →
 Generate. This is **separate** from your Apple ID password — `notarytool`
 will not accept the main password. Label it "macprovider notarytool".
 
-### 4. Find your Team ID
+### 5. Find your Team ID
 
 <https://developer.apple.com/account> → Membership → Team ID. Looks
 like a 10-character alphanumeric string.
 
-### 5. Populate GitHub Secrets
+### 6. Populate GitHub Secrets
 
 At <https://github.com/Augustas11/macprovider/settings/secrets/actions>,
 add these repository secrets:
 
 | Secret name | Value |
 |---|---|
-| `APPLE_DEVELOPER_ID_CERT_P12_BASE64` | `base64 -i path/to/cert.p12 \| pbcopy` |
-| `APPLE_DEVELOPER_ID_CERT_PASSWORD` | The .p12 export password from step 2 |
+| `APPLE_DEVELOPER_ID_CERT_P12_BASE64` | `base64 -i path/to/application-cert.p12 \| pbcopy` |
+| `APPLE_DEVELOPER_ID_CERT_PASSWORD` | The Application .p12 export password from step 2 |
+| `APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64` | `base64 -i path/to/installer-cert.p12 \| pbcopy` |
+| `APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD` | The Installer .p12 export password from step 3 |
 | `APPLE_NOTARY_APPLE_ID` | The enrolled Apple ID email |
-| `APPLE_NOTARY_PASSWORD` | The app-specific password from step 3 |
-| `APPLE_NOTARY_TEAM_ID` | The Team ID from step 4 |
+| `APPLE_NOTARY_PASSWORD` | The app-specific password from step 4 |
+| `APPLE_NOTARY_TEAM_ID` | The Team ID from step 5 |
 
 The existing `MACPROVIDER_RELEASE_SIGNING_KEY_PEM` secret
 (checksums.txt signing) is unrelated and stays as-is.
 
-### 6. Cut a release and verify
+### 7. Cut a release and verify
 
 Push a new tag (e.g. `v1.3.2`). The workflow's "Sign + notarize binary"
 step now activates. Expected duration: 1-15 minutes for notarization,
@@ -108,7 +127,20 @@ on top of the existing ~5-10 minute build. The step:
 2. Codesigns the binary with `--options runtime --timestamp`
 3. Notarizes via `xcrun notarytool submit --wait`
 4. Re-tars with the signed, notarization-accepted binary
-5. Deletes the transient keychain
+5. Builds a signed flat `.pkg` when the Installer certificate secrets exist
+6. Notarizes and staples the `.pkg`
+7. Deletes the transient keychain
+
+Expected release assets:
+
+- `macprovider-cli-vX.Y.Z-darwin-arm64.tar.gz` — compatibility artifact
+- `macprovider-cli-vX.Y.Z-darwin-arm64.pkg` — preferred stapled delivery
+  container for `install.sh`
+- `checksums.txt`
+- `checksums.txt.sig`
+
+The tarball remains the canonical `macprovider-cli update` artifact until
+the self-update implementation explicitly learns the package path.
 
 Verify on a macOS 26.3.1+ Mac:
 
@@ -129,8 +161,11 @@ Common follow-up issues:
 
 - **`xcrun stapler` exits with Error 73** — expected if someone tries
   to staple `macprovider-cli` directly. Raw standalone executables are
-  not a supported stapler target. Use a signed `.pkg`, `.dmg`, or
-  executable bundle if offline stapling becomes required.
+  not a supported stapler target. Use the signed `.pkg` artifact for a
+  stapled release container.
+- **`.pkg` asset is missing** — the release workflow did not find
+  `APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64` and skipped package
+  creation. The tarball remains published for compatibility.
 - **"Notarization request was not found"** — `notarytool submit` was
   invoked without `--wait` (or it timed out), so notarization was not
   accepted before packaging. Re-trigger the workflow.

--- a/scripts/test-tier2-provider-release.sh
+++ b/scripts/test-tier2-provider-release.sh
@@ -75,12 +75,33 @@ make_release_fixture() {
   local fixture_dir="$1"
   local version="$2"
   local include_surfaces="$3"
+  local package_mode="${4:-none}"
   mkdir -p "$fixture_dir"
   local binary_dir="$fixture_dir/bin"
   local asset="$fixture_dir/macprovider-cli-v$version-darwin-arm64.tar.gz"
+  local pkg_asset="$fixture_dir/macprovider-cli-v$version-darwin-arm64.pkg"
   make_fake_binary "$binary_dir" "$version" "$include_surfaces"
   tar -czf "$asset" -C "$binary_dir" macprovider-cli
   sha256_file "$asset" | awk -v asset="$(basename "$asset")" '{ print $1 "  " asset }' >"$fixture_dir/checksums.txt"
+  case "$package_mode" in
+    none)
+      ;;
+    good|bad-extra)
+      local pkg_root="$fixture_dir/pkg-root"
+      mkdir -p "$pkg_root/Payload/example.bundle"
+      cp "$binary_dir/macprovider-cli" "$pkg_root/Payload/macprovider-cli"
+      printf '%s\n' 'fixture notice' >"$pkg_root/Payload/THIRD-PARTY-NOTICES.txt"
+      printf '%s\n' 'fixture bundle' >"$pkg_root/Payload/example.bundle/info.txt"
+      if [ "$package_mode" = "bad-extra" ]; then
+        printf '%s\n' 'unexpected' >"$pkg_root/Payload/unexpected.txt"
+      fi
+      tar -czf "$pkg_asset" -C "$pkg_root" Payload
+      sha256_file "$pkg_asset" | awk -v asset="$(basename "$pkg_asset")" '{ print $1 "  " asset }' >>"$fixture_dir/checksums.txt"
+      ;;
+    *)
+      die "unknown package fixture mode: $package_mode"
+      ;;
+  esac
   openssl dgst -sha256 -sign "$WORKDIR/private.pem" -out "$fixture_dir/checksums.txt.sig" "$fixture_dir/checksums.txt"
 }
 
@@ -108,7 +129,7 @@ done
 [ -n "$url" ] || exit 2
 name="${url##*/}"
 case "$name" in
-  macprovider-cli-*-darwin-arm64.tar.gz|checksums.txt|checksums.txt.sig)
+  macprovider-cli-*-darwin-arm64.tar.gz|macprovider-cli-*-darwin-arm64.pkg|checksums.txt|checksums.txt.sig)
     cp "$RELEASE_FIXTURE_DIR/$name" "$out"
     ;;
   *)
@@ -117,6 +138,33 @@ case "$name" in
 esac
 SH
 chmod +x "$WORKDIR/curl"
+
+cat >"$WORKDIR/pkgutil" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = "--expand-full" ] || exit 2
+pkg_path="$2"
+expanded_dir="$3"
+mkdir -p "$expanded_dir"
+tar -xzf "$pkg_path" -C "$expanded_dir"
+SH
+chmod +x "$WORKDIR/pkgutil"
+
+cat >"$WORKDIR/spctl" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$WORKDIR/spctl"
+
+cat >"$WORKDIR/xcrun" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "stapler" ] && [ "${2:-}" = "validate" ]; then
+  exit 0
+fi
+exit 2
+SH
+chmod +x "$WORKDIR/xcrun"
 
 openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out "$WORKDIR/private.pem" >/dev/null 2>&1
 openssl pkey -in "$WORKDIR/private.pem" -pubout -out "$WORKDIR/public.pem" >/dev/null 2>&1
@@ -171,6 +219,30 @@ if PATH="$WORKDIR:$PATH" \
   die "missing Tier-2 surface unexpectedly passed"
 fi
 assert_contains "$WORKDIR/missing-surface.err" "provider binary lacks Tier-2 surface string"
+
+package_fixture="$WORKDIR/package-release"
+make_release_fixture "$package_fixture" "1.2.6" "1" "good"
+PATH="$WORKDIR:$PATH" \
+  CURL_BIN="$WORKDIR/curl" \
+  RELEASE_FIXTURE_DIR="$package_fixture" \
+  MACPROVIDER_CHECKSUM_PUBLIC_KEY_PEM="$PUBLIC_KEY_PEM" \
+  RELEASE_TAG=v1.2.6 \
+  "$VERIFIER" >"$WORKDIR/package.out" 2>"$WORKDIR/package.err"
+assert_contains "$WORKDIR/package.err" "provider package sha256 verified"
+assert_contains "$WORKDIR/package.err" "provider package binary matches tarball binary"
+assert_contains "$WORKDIR/package.err" "provider package version ok"
+
+bad_package_fixture="$WORKDIR/bad-package-release"
+make_release_fixture "$bad_package_fixture" "1.2.6" "1" "bad-extra"
+if PATH="$WORKDIR:$PATH" \
+  CURL_BIN="$WORKDIR/curl" \
+  RELEASE_FIXTURE_DIR="$bad_package_fixture" \
+  MACPROVIDER_CHECKSUM_PUBLIC_KEY_PEM="$PUBLIC_KEY_PEM" \
+  RELEASE_TAG=v1.2.6 \
+  "$VERIFIER" >"$WORKDIR/bad-package.out" 2>"$WORKDIR/bad-package.err"; then
+  die "unexpected package payload member unexpectedly passed"
+fi
+assert_contains "$WORKDIR/bad-package.err" "unexpected provider package payload member"
 
 if PATH="$WORKDIR:$PATH" \
   CURL_BIN="$WORKDIR/curl" \

--- a/scripts/verify-tier2-provider-release.sh
+++ b/scripts/verify-tier2-provider-release.sh
@@ -112,6 +112,50 @@ checksum_for_asset() {
   awk -v asset="$asset" '$2 == asset { print $1 }' "$checksums" | head -1
 }
 
+validate_payload_entries() {
+  local payload_dir="$1"
+  local label="$2"
+  local entries
+  local entry normalized_entry has_binary=0
+
+  entries="$(cd "$payload_dir" && find . -mindepth 1 -print)" || die "failed to list $label"
+  [ -n "$entries" ] || die "$label is empty"
+  while IFS= read -r entry; do
+    normalized_entry="$entry"
+    while :; do
+      case "$normalized_entry" in
+        ./*) normalized_entry="${normalized_entry#./}" ;;
+        *) break ;;
+      esac
+    done
+    case "$normalized_entry" in
+      ""|.) continue ;;
+    esac
+    case "$normalized_entry" in
+      /*|*"/../"*|../*|*/..|..)
+        die "unsafe $label path: $entry"
+        ;;
+      macprovider-cli)
+        has_binary=1
+        ;;
+      THIRD-PARTY-NOTICES.txt)
+        ;;
+      *.bundle|*.bundle/*)
+        ;;
+      *)
+        die "unexpected $label member: $entry"
+        ;;
+    esac
+  done <<EOF
+$entries
+EOF
+
+  [ "$has_binary" -eq 1 ] || die "$label does not contain macprovider-cli"
+  if find "$payload_dir" \( -type l -o -type b -o -type c -o -type p \) -print -quit | grep -q .; then
+    die "$label contains unsafe link or device members"
+  fi
+}
+
 tmpdir=""
 temp_parent=""
 cleanup() {
@@ -127,6 +171,8 @@ trap cleanup EXIT
 require_command "$CURL_BIN"
 require_command "$OPENSSL_BIN"
 require_command awk
+require_command find
+require_command tar
 require_file "$INSTALL_SH"
 require_file "$CHECKER"
 
@@ -157,6 +203,7 @@ download_file() {
 }
 
 asset="macprovider-cli-${RELEASE_TAG}-darwin-arm64.tar.gz"
+pkg_asset="macprovider-cli-${RELEASE_TAG}-darwin-arm64.pkg"
 base="https://github.com/${GITHUB_REPO}/releases/download/${RELEASE_TAG}"
 
 temp_parent="${TMPDIR:-/tmp}"
@@ -165,6 +212,7 @@ temp_parent="$(cd "$temp_parent" && pwd -P)"
 tmpdir="$(mktemp -d "$temp_parent/tier2-provider-release.XXXXXX")"
 
 tarball_path="$tmpdir/$asset"
+pkg_path="$tmpdir/$pkg_asset"
 checksums_path="$tmpdir/checksums.txt"
 checksums_sig_path="$tmpdir/checksums.txt.sig"
 public_key_path="$tmpdir/release-signing-public.pem"
@@ -193,6 +241,49 @@ expected_sha="$(checksum_for_asset "$checksums_path" "$asset")"
 actual_sha="$(sha256_file "$tarball_path")"
 [ "$actual_sha" = "$expected_sha" ] || die "provider artifact sha256 mismatch: got $actual_sha want $expected_sha"
 log "provider artifact sha256 verified: $actual_sha"
+
+pkg_expected_sha="$(checksum_for_asset "$checksums_path" "$pkg_asset")"
+if [ -n "$pkg_expected_sha" ]; then
+  download_file "$base/$pkg_asset" "$pkg_path" "$pkg_asset"
+  pkg_actual_sha="$(sha256_file "$pkg_path")"
+  [ "$pkg_actual_sha" = "$pkg_expected_sha" ] || die "provider package sha256 mismatch: got $pkg_actual_sha want $pkg_expected_sha"
+  log "provider package sha256 verified: $pkg_actual_sha"
+  if command -v spctl >/dev/null 2>&1; then
+    spctl -a -vv -t install "$pkg_path" || die "provider package failed Gatekeeper assessment"
+    log "provider package Gatekeeper assessment passed"
+  fi
+  if command -v xcrun >/dev/null 2>&1; then
+    xcrun stapler validate "$pkg_path" || die "provider package stapler validation failed"
+    log "provider package stapler validation passed"
+  fi
+
+  require_command pkgutil
+  tar_payload_dir="$tmpdir/tar-payload"
+  pkg_expand_dir="$tmpdir/pkg-expanded"
+  pkg_payload_tar="$tmpdir/pkg-payload.tar.gz"
+  mkdir -p "$tar_payload_dir"
+  tar -xzf "$tarball_path" -C "$tar_payload_dir" macprovider-cli
+  pkgutil --expand-full "$pkg_path" "$pkg_expand_dir" || die "failed to expand provider package"
+  [ -x "$pkg_expand_dir/Payload/macprovider-cli" ] || die "provider package payload lacks executable macprovider-cli"
+  validate_payload_entries "$pkg_expand_dir/Payload" "provider package payload"
+
+  tar_binary_sha="$(sha256_file "$tar_payload_dir/macprovider-cli")"
+  pkg_binary_sha="$(sha256_file "$pkg_expand_dir/Payload/macprovider-cli")"
+  [ "$pkg_binary_sha" = "$tar_binary_sha" ] || die "package binary sha256 differs from tarball binary"
+  log "provider package binary matches tarball binary: $pkg_binary_sha"
+
+  pkg_version="$("$pkg_expand_dir/Payload/macprovider-cli" --version)"
+  [ "$pkg_version" = "$PROVIDER_VERSION" ] || die "provider package version mismatch: got $pkg_version want $PROVIDER_VERSION"
+  log "provider package version ok: $pkg_version"
+
+  tar czf "$pkg_payload_tar" -C "$pkg_expand_dir/Payload" .
+  PROVIDER_ARTIFACT="$pkg_payload_tar" \
+    PROVIDER_VERSION="$PROVIDER_VERSION" \
+    PROVIDER_SHA256="" \
+    "$CHECKER"
+else
+  log "no package entry in checksums.txt; tarball-only compatibility release"
+fi
 
 PROVIDER_ARTIFACT="$tarball_path" \
   PROVIDER_VERSION="$PROVIDER_VERSION" \


### PR DESCRIPTION
## Summary
- publish an optional signed/notarized/stapled `.pkg` asset alongside the compatibility tarball
- keep `macprovider-cli-<tag>-darwin-arm64.tar.gz` as the canonical compatibility artifact for existing consumers
- update `install.sh` to prefer `.pkg` when present, Gatekeeper-assess it, extract its payload, and fall back to the tarball for older releases
- extend the release verifier and operator runbook for the new Developer ID Installer certificate secrets

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml yaml ok"'`
- `bash -n phase3-binary/dist/install.sh`
- `bash -n scripts/verify-tier2-provider-release.sh`
- `MACPROVIDER_NO_PROMPT=1 MACPROVIDER_NO_LAUNCHD=1 bash phase3-binary/dist/install.sh --dry-run` on macOS 26.5
- local `pkgbuild` + `pkgutil --expand-full` payload extraction smoke test

## Operational notes
This PR requires two new GitHub secrets before a release emits the `.pkg` asset:
- `APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64`
- `APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD`

Without those secrets, releases continue to publish the tarball only.
