### PR TITLE
release: bump CLI version to v1.6.1

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -153,7 +153,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.6.0"
+    static let binaryVersion = "1.6.1"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1209,10 +1209,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.6.0")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.6.0")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.6.0")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.6.0")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.6.1")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.6.1")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.6.1")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.6.1")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {


### PR DESCRIPTION
## Summary
- bump macprovider-cli binaryVersion to 1.6.1
- update handshake/version assertions to match the release tag

## Context
The v1.6.1 release run reached and passed the Apple signing/notarization step, then failed pre-publish because the built binary still reported 1.6.0. No v1.6.1 release assets were published.

## Validation
- swift test --package-path phase3-binary --filter testBinaryVersion_AdvertisesSPEC001V16AcrossHandshakeFrames
- git diff --check