### PR TITLE
gateway: bound streaming fallback settlement

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -370,9 +370,18 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	var emitted int64
 	var reported *tokenUsage
 	invalidReportedUsage := false
+	settleReported := func(outcome string) {
+		usage := *reported
+		observedCompletion := estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens)
+		if observedCompletion > usage.CompletionTokens {
+			s.settleAfterCommit(r, subject, promptEstimate, observedCompletion, maxUsageTokens, "gateway_estimated", outcome)
+			return
+		}
+		s.settleAfterCommit(r, subject, usage.PromptTokens, usage.CompletionTokens, maxUsageTokens, "provider_reported", outcome)
+	}
 	settleTruncated := func() {
 		if reported != nil {
-			s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "stream_truncated")
+			settleReported("stream_truncated")
 			return
 		}
 		s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "stream_truncated")
@@ -381,7 +390,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		select {
 		case <-r.Context().Done():
 			if reported != nil {
-				s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "client_disconnect")
+				settleReported("client_disconnect")
 				return false
 			}
 			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
@@ -391,7 +400,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		text := strings.TrimRight(string(line), "\r\n")
 		if data, ok := sseDataValue(text); ok {
 			if data != "[DONE]" {
-				deltaBytes, parseOK := streamingCompletionDeltaBytes(data)
+				deltaBytes, hasChoices, parseOK := streamingCompletionDeltaBytes(data)
 				if !parseOK {
 					slog.Warn("streaming gateway estimate saw malformed chunk; truncating stream", "request_id", requestID(r))
 					writeSSEError(w, "Upstream stream returned malformed data", "stream_malformed")
@@ -426,13 +435,23 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 					} else if !invalidReportedUsage {
 						reported = &usage
 					}
+				} else if !hasChoices {
+					slog.Warn("streaming gateway estimate saw data chunk without choices or usage; truncating stream", "request_id", requestID(r))
+					writeSSEError(w, "Upstream stream returned malformed data", "stream_malformed")
+					if flusher != nil {
+						flusher.Flush()
+					}
+					cancelCoordinator()
+					completion := estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens)
+					s.settleAfterCommit(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "stream_malformed")
+					return false
 				}
 			}
 		}
 		if _, err := w.Write(line); err != nil {
 			slog.Warn("streaming buyer write failed", "request_id", requestID(r), "error", err)
 			if reported != nil {
-				s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "client_disconnect")
+				settleReported("client_disconnect")
 				return false
 			}
 			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
@@ -467,7 +486,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		}
 		if errors.Is(r.Context().Err(), context.Canceled) {
 			if reported != nil {
-				s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "client_disconnect")
+				settleReported("client_disconnect")
 				return
 			}
 			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
@@ -483,14 +502,14 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	}
 	if errors.Is(r.Context().Err(), context.Canceled) {
 		if reported != nil {
-			s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "client_disconnect")
+			settleReported("client_disconnect")
 			return
 		}
 		s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
 		return
 	}
 	if reported != nil && !invalidReportedUsage {
-		s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "ok")
+		settleReported("ok")
 		return
 	}
 	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "ok")
@@ -630,14 +649,14 @@ func estimateTokensFromBytes(n int64) int64 {
 	return int64(math.Ceil(float64(n) / 4.0))
 }
 
-func streamingCompletionDeltaBytes(data string) (int64, bool) {
+func streamingCompletionDeltaBytes(data string) (int64, bool, bool) {
 	var envelope struct {
 		Choices []struct {
 			Delta json.RawMessage `json:"delta"`
 		} `json:"choices"`
 	}
 	if err := json.Unmarshal([]byte(data), &envelope); err != nil {
-		return 0, false
+		return 0, false, false
 	}
 	var n int64
 	for _, choice := range envelope.Choices {
@@ -646,11 +665,11 @@ func streamingCompletionDeltaBytes(data string) (int64, bool) {
 		}
 		deltaBytes, ok := generatedDeltaStringBytes(choice.Delta)
 		if !ok {
-			return 0, false
+			return 0, false, false
 		}
 		n += deltaBytes
 	}
-	return n, true
+	return n, len(envelope.Choices) > 0, true
 }
 
 func generatedDeltaStringBytes(raw json.RawMessage) (int64, bool) {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -353,8 +353,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 	flusher, _ := w.(http.Flusher)
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	reader := bufio.NewReaderSize(resp.Body, maxStreamingLineBytes)
 	var cancelOnce sync.Once
 	cancelCoordinator := func() {
 		cancelOnce.Do(cancelUpstream)
@@ -371,20 +370,26 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	var emitted int64
 	var reported *tokenUsage
 	invalidReportedUsage := false
-	for scanner.Scan() {
+	settleTruncated := func() {
+		if reported != nil {
+			s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "stream_truncated")
+			return
+		}
+		s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "stream_truncated")
+	}
+	forwardLine := func(line []byte) bool {
 		select {
 		case <-r.Context().Done():
 			if reported != nil {
 				s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "client_disconnect")
-				return
+				return false
 			}
 			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
-			return
+			return false
 		default:
 		}
-		line := scanner.Text()
-		if strings.HasPrefix(line, "data: ") {
-			data := strings.TrimPrefix(line, "data: ")
+		text := strings.TrimRight(string(line), "\r\n")
+		if data, ok := sseDataValue(text); ok {
 			if data != "[DONE]" {
 				deltaBytes, parseOK := streamingCompletionDeltaBytes(data)
 				if !parseOK {
@@ -396,7 +401,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 					cancelCoordinator()
 					completion := estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens)
 					s.settleAfterCommit(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "stream_malformed")
-					return
+					return false
 				}
 				if deltaBytes > 0 {
 					projectedCompletion := estimateTokensFromBytes(emitted + deltaBytes)
@@ -409,7 +414,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 						}
 						cancelCoordinator()
 						s.settleAfterCommit(r, subject, promptEstimate, maxCompletion, maxUsageTokens, "gateway_estimated", "stream_output_exceeded")
-						return
+						return false
 					}
 					emitted += deltaBytes
 				}
@@ -424,10 +429,57 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 				}
 			}
 		}
-		_, _ = w.Write([]byte(line + "\n"))
+		if _, err := w.Write(line); err != nil {
+			slog.Warn("streaming buyer write failed", "request_id", requestID(r), "error", err)
+			if reported != nil {
+				s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "client_disconnect")
+				return false
+			}
+			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
+			return false
+		}
 		if flusher != nil {
 			flusher.Flush()
 		}
+		return true
+	}
+	for {
+		line, err := reader.ReadSlice('\n')
+		if errors.Is(err, bufio.ErrBufferFull) {
+			slog.Error("streaming coordinator line exceeded limit", "request_id", requestID(r), "max_line_bytes", maxStreamingLineBytes)
+			writeSSEError(w, "Upstream stream failed", "stream_truncated")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			settleTruncated()
+			return
+		}
+		if len(line) > 0 {
+			if !forwardLine(line) {
+				return
+			}
+		}
+		if err == nil {
+			continue
+		}
+		if err == io.EOF {
+			break
+		}
+		if errors.Is(r.Context().Err(), context.Canceled) {
+			if reported != nil {
+				s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "client_disconnect")
+				return
+			}
+			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
+			return
+		}
+		slog.Error("streaming coordinator read failed", "request_id", requestID(r), "error", err)
+		writeSSEError(w, "Upstream stream failed", "stream_truncated")
+		if flusher != nil {
+			flusher.Flush()
+		}
+		settleTruncated()
+		return
 	}
 	if errors.Is(r.Context().Err(), context.Canceled) {
 		if reported != nil {
@@ -435,19 +487,6 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			return
 		}
 		s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
-		return
-	}
-	if err := scanner.Err(); err != nil {
-		slog.Error("streaming coordinator read failed", "request_id", requestID(r), "error", err)
-		writeSSEError(w, "Upstream stream failed", "stream_truncated")
-		if flusher != nil {
-			flusher.Flush()
-		}
-		if reported != nil {
-			s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "stream_truncated")
-			return
-		}
-		s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "stream_truncated")
 		return
 	}
 	if reported != nil && !invalidReportedUsage {
@@ -594,14 +633,7 @@ func estimateTokensFromBytes(n int64) int64 {
 func streamingCompletionDeltaBytes(data string) (int64, bool) {
 	var envelope struct {
 		Choices []struct {
-			Delta struct {
-				Content   string `json:"content"`
-				ToolCalls []struct {
-					Function struct {
-						Arguments string `json:"arguments"`
-					} `json:"function"`
-				} `json:"tool_calls"`
-			} `json:"delta"`
+			Delta json.RawMessage `json:"delta"`
 		} `json:"choices"`
 	}
 	if err := json.Unmarshal([]byte(data), &envelope); err != nil {
@@ -609,12 +641,71 @@ func streamingCompletionDeltaBytes(data string) (int64, bool) {
 	}
 	var n int64
 	for _, choice := range envelope.Choices {
-		n += int64(len(choice.Delta.Content))
-		for _, toolCall := range choice.Delta.ToolCalls {
-			n += int64(len(toolCall.Function.Arguments))
+		if len(choice.Delta) == 0 || bytes.Equal(choice.Delta, []byte("null")) {
+			continue
 		}
+		deltaBytes, ok := generatedDeltaStringBytes(choice.Delta)
+		if !ok {
+			return 0, false
+		}
+		n += deltaBytes
 	}
 	return n, true
+}
+
+func generatedDeltaStringBytes(raw json.RawMessage) (int64, bool) {
+	var delta any
+	if err := json.Unmarshal(raw, &delta); err != nil {
+		return 0, false
+	}
+	if _, ok := delta.(map[string]any); !ok {
+		return 0, false
+	}
+	return countGeneratedDeltaStrings("", delta), true
+}
+
+func countGeneratedDeltaStrings(key string, value any) int64 {
+	switch v := value.(type) {
+	case map[string]any:
+		var n int64
+		for childKey, childValue := range v {
+			n += countGeneratedDeltaStrings(childKey, childValue)
+		}
+		return n
+	case []any:
+		var n int64
+		for _, childValue := range v {
+			n += countGeneratedDeltaStrings(key, childValue)
+		}
+		return n
+	case string:
+		if !countDeltaStringKey(key) {
+			return 0
+		}
+		return int64(len(v))
+	default:
+		return 0
+	}
+}
+
+func countDeltaStringKey(key string) bool {
+	switch strings.ToLower(key) {
+	case "", "role", "id", "type", "name":
+		return false
+	default:
+		return true
+	}
+}
+
+func sseDataValue(line string) (string, bool) {
+	if !strings.HasPrefix(line, "data:") {
+		return "", false
+	}
+	value := strings.TrimPrefix(line, "data:")
+	if strings.HasPrefix(value, " ") {
+		value = strings.TrimPrefix(value, " ")
+	}
+	return value, true
 }
 
 func demoTokenHash(token string) string {
@@ -627,6 +718,7 @@ func demoTokenHash(token string) string {
 // ============================================================
 
 const maxUpstreamResponseBodyBytes = int64(16 << 20)
+const maxStreamingLineBytes = 1024 * 1024
 
 func readLimitedBody(r io.Reader, maxBytes int64) ([]byte, error) {
 	if maxBytes < 0 {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -386,7 +386,33 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		if strings.HasPrefix(line, "data: ") {
 			data := strings.TrimPrefix(line, "data: ")
 			if data != "[DONE]" {
-				emitted += int64(len(data))
+				deltaBytes, parseOK := streamingCompletionDeltaBytes(data)
+				if !parseOK {
+					slog.Warn("streaming gateway estimate saw malformed chunk; truncating stream", "request_id", requestID(r))
+					writeSSEError(w, "Upstream stream returned malformed data", "stream_malformed")
+					if flusher != nil {
+						flusher.Flush()
+					}
+					cancelCoordinator()
+					completion := estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens)
+					s.settleAfterCommit(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "stream_malformed")
+					return
+				}
+				if deltaBytes > 0 {
+					projectedCompletion := estimateTokensFromBytes(emitted + deltaBytes)
+					maxCompletion := maxStreamingCompletionTokens(promptEstimate, maxUsageTokens)
+					if projectedCompletion > maxCompletion {
+						slog.Warn("streaming gateway estimate exceeded request maximum; truncating stream", "request_id", requestID(r), "estimated_completion_tokens", projectedCompletion, "max_completion_tokens", maxCompletion)
+						writeSSEError(w, "Upstream stream exceeded requested max_tokens", "stream_output_exceeded")
+						if flusher != nil {
+							flusher.Flush()
+						}
+						cancelCoordinator()
+						s.settleAfterCommit(r, subject, promptEstimate, maxCompletion, maxUsageTokens, "gateway_estimated", "stream_output_exceeded")
+						return
+					}
+					emitted += deltaBytes
+				}
 				if usage, ok, err := usageFromJSON([]byte(data), maxUsageTokens); ok {
 					if err != nil {
 						invalidReportedUsage = true
@@ -421,14 +447,14 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "stream_truncated")
 			return
 		}
-		s.settleAfterCommit(r, subject, promptEstimate, int64(math.Ceil(float64(emitted)/4.0)), maxUsageTokens, "gateway_estimated", "stream_truncated")
+		s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "stream_truncated")
 		return
 	}
 	if reported != nil && !invalidReportedUsage {
 		s.settleAfterCommit(r, subject, reported.PromptTokens, reported.CompletionTokens, maxUsageTokens, "provider_reported", "ok")
 		return
 	}
-	s.settleAfterCommit(r, subject, promptEstimate, int64(math.Ceil(float64(emitted)/4.0)), maxUsageTokens, "gateway_estimated", "ok")
+	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "ok")
 }
 
 func (s *Server) passThroughNoProviderCoordinatorError(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, body []byte) {
@@ -482,7 +508,7 @@ func openAIErrorCode(body []byte) string {
 
 func (s *Server) settleCancelledStream(r *http.Request, subject usageSubject, promptEstimate, emitted, maxUsageTokens int64, cancelCoordinator func()) {
 	cancelCoordinator()
-	s.settleAfterCommit(r, subject, promptEstimate, int64(math.Ceil(float64(emitted)/4.0)), maxUsageTokens, "gateway_estimated", "client_disconnect")
+	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "client_disconnect")
 }
 
 func (s *Server) settleBeforeResponse(w http.ResponseWriter, r *http.Request, subject usageSubject, prompt, completion, maxTotal int64, source, outcome string) bool {
@@ -542,6 +568,53 @@ func (s *Server) settleRequest(r *http.Request, subject usageSubject, prompt, co
 		})
 	}
 	return s.store.SettleReservation(context.Background(), settlement)
+}
+
+func estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens int64) int64 {
+	completion := estimateTokensFromBytes(emitted)
+	maxCompletion := maxStreamingCompletionTokens(promptEstimate, maxUsageTokens)
+	if completion > maxCompletion {
+		return maxCompletion
+	}
+	return completion
+}
+
+func maxStreamingCompletionTokens(promptEstimate, maxUsageTokens int64) int64 {
+	maxCompletion := maxUsageTokens - promptEstimate
+	if maxCompletion < 0 {
+		return 0
+	}
+	return maxCompletion
+}
+
+func estimateTokensFromBytes(n int64) int64 {
+	return int64(math.Ceil(float64(n) / 4.0))
+}
+
+func streamingCompletionDeltaBytes(data string) (int64, bool) {
+	var envelope struct {
+		Choices []struct {
+			Delta struct {
+				Content   string `json:"content"`
+				ToolCalls []struct {
+					Function struct {
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal([]byte(data), &envelope); err != nil {
+		return 0, false
+	}
+	var n int64
+	for _, choice := range envelope.Choices {
+		n += int64(len(choice.Delta.Content))
+		for _, toolCall := range choice.Delta.ToolCalls {
+			n += int64(len(toolCall.Function.Arguments))
+		}
+	}
+	return n, true
 }
 
 func demoTokenHash(token string) string {
@@ -607,7 +680,7 @@ func writeSSEError(w http.ResponseWriter, message, code string) {
 	payload, _ := json.Marshal(map[string]any{"error": map[string]any{"message": message, "type": "api_error", "code": code}})
 	_, _ = w.Write([]byte("data: "))
 	_, _ = w.Write(payload)
-	_, _ = w.Write([]byte("\n\n"))
+	_, _ = w.Write([]byte("\n\ndata: [DONE]\n\n"))
 }
 
 func parseChatRequest(body []byte) (chatRequest, error) {
@@ -661,7 +734,7 @@ func usageFromJSON(body []byte, maxUsageTokens int64) (tokenUsage, bool, error) 
 	if sum > maxUsageTokens {
 		return tokenUsage{}, true, fmt.Errorf("usage token total exceeds request maximum")
 	}
-	if rawUsage.TotalTokens != nil && usage.TotalTokens != 0 && usage.TotalTokens != sum {
+	if rawUsage.TotalTokens != nil && usage.TotalTokens != sum {
 		return tokenUsage{}, true, fmt.Errorf("usage total_tokens does not match prompt_tokens plus completion_tokens")
 	}
 	usage.TotalTokens = sum

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1694,6 +1694,7 @@ func TestUsageFromJSONValidatesProviderReportedUsage(t *testing.T) {
 		{name: "malformed_field", body: `{"usage":{"prompt_tokens":"1","completion_tokens":2}}`},
 		{name: "overflow", body: `{"usage":{"prompt_tokens":9223372036854775807,"completion_tokens":1}}`},
 		{name: "inconsistent_total", body: `{"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":4}}`},
+		{name: "explicit_zero_total_mismatch", body: `{"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":0}}`},
 		{name: "exceeds_request_bound", body: `{"usage":{"prompt_tokens":1,"completion_tokens":10,"total_tokens":11}}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1941,7 +1942,7 @@ func TestStreamingQuotaReservationAndSettlementUsesDisconnectEstimation(t *testi
 		reservedAtFirstByte = reserved
 		pr, pw := io.Pipe()
 		go func() {
-			_, _ = fmt.Fprintf(pw, "data: %s\n\n", strings.Repeat("x", 120))
+			_, _ = fmt.Fprintf(pw, "data: {\"id\":\"chatcmpl\",\"choices\":[{\"delta\":{\"content\":\"%s\"}}]}\n\n", strings.Repeat("x", 120))
 			close(firstByte)
 			<-r.Context().Done()
 			close(cancelSeen)
@@ -2060,6 +2061,218 @@ func TestStreamingCleanEOFSettlesOK(t *testing.T) {
 	outcome, source := usageEventOutcome(t, dbPath, accountID)
 	if outcome != "ok" || source != "provider_reported" {
 		t.Fatalf("usage outcome/source = %s/%s, want ok/provider_reported", outcome, source)
+	}
+}
+
+func TestStreamingGatewayEstimateStopsOverMaxOutput(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":1,"messages":[{"role":"user","content":"ok"}]}`
+	accountID := "acct_stream_clamped"
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data: {"id":"chatcmpl","choices":[{"delta":{"content":"` + strings.Repeat("x", 400) + `"}}]}`,
+			`data: {"id":"chatcmpl","choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "stream_output_exceeded") {
+		t.Fatalf("stream body missing stream_output_exceeded: %s", resp.Body.String())
+	}
+	if !strings.HasSuffix(resp.Body.String(), "data: [DONE]\n\n") {
+		t.Fatalf("stream body missing DONE terminator: %s", resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "stream_output_exceeded" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want stream_output_exceeded/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
+func TestStreamingGatewayEstimateCountsDeltaContentNotMetadata(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":1,"messages":[{"role":"user","content":"ok"}]}`
+	accountID := "acct_stream_metadata"
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data: {"id":"` + strings.Repeat("m", 400) + `","object":"chat.completion.chunk","choices":[{"delta":{"content":"ok"},"finish_reason":null}]}`,
+			`data: {"id":"` + strings.Repeat("m", 400) + `","object":"chat.completion.chunk","choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), "stream_output_exceeded") {
+		t.Fatalf("stream body unexpectedly exceeded output cap: %s", resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "ok" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want ok/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
+func TestStreamingGatewayEstimateCountsToolCallArguments(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":1,"messages":[{"role":"user","content":"tool"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}]}`
+	accountID := "acct_stream_tool_call"
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data: {"id":"chatcmpl","choices":[{"delta":{"tool_calls":[{"index":0,"id":"` + strings.Repeat("m", 400) + `","type":"function","function":{"name":"` + strings.Repeat("n", 400) + `","arguments":"abcd"}}]},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl","choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), "stream_output_exceeded") {
+		t.Fatalf("stream body unexpectedly exceeded output cap: %s", resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "ok" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want ok/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
+func TestStreamingGatewayEstimateStopsOverMaxToolCallArguments(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":1,"messages":[{"role":"user","content":"tool"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}]}`
+	accountID := "acct_stream_tool_call_clamped"
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data: {"id":"chatcmpl","choices":[{"delta":{"tool_calls":[{"index":0,"id":"c","type":"function","function":{"name":"lookup","arguments":"` + strings.Repeat("x", 400) + `"}}]},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl","choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "stream_output_exceeded") {
+		t.Fatalf("stream body missing stream_output_exceeded: %s", resp.Body.String())
+	}
+	if !strings.HasSuffix(resp.Body.String(), "data: [DONE]\n\n") {
+		t.Fatalf("stream body missing DONE terminator: %s", resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "stream_output_exceeded" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want stream_output_exceeded/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
+func TestStreamingGatewayEstimateStopsMalformedChunkWithoutRawCounting(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":100,"messages":[{"role":"user","content":"malformed"}]}`
+	accountID := "acct_stream_malformed"
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data: {"id":"chatcmpl","choices":[{"delta":{"content":"ok"},"finish_reason":null}]}`,
+			`data: not-json-` + strings.Repeat("m", 400),
+			`data: [DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "stream_malformed") {
+		t.Fatalf("stream body missing stream_malformed: %s", resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), strings.Repeat("m", 200)) {
+		t.Fatalf("malformed raw payload was forwarded: %s", resp.Body.String())
+	}
+	if !strings.HasSuffix(resp.Body.String(), "data: [DONE]\n\n") {
+		t.Fatalf("stream body missing DONE terminator: %s", resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "stream_malformed" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want stream_malformed/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
 	}
 }
 

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2037,6 +2038,47 @@ func TestStreamingScannerErrorSettlesStreamTruncated(t *testing.T) {
 	}
 }
 
+func TestStreamingProviderReportedUsageCannotUnderstateTruncatedOutput(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"large line"}]}`
+	accountID := "acct_stream_underreported_truncated"
+	output := strings.Repeat("x", 40)
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		pr, pw := io.Pipe()
+		go func() {
+			_, _ = pw.Write([]byte(`data: {"id":"chatcmpl","choices":[{"delta":{"content":"` + output + `"}}]}` + "\n\n"))
+			_, _ = pw.Write([]byte(`data: {"id":"chatcmpl","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2},"choices":[{"delta":{},"finish_reason":"stop"}]}` + "\n\n"))
+			_ = pw.CloseWithError(errors.New("forced upstream stream failure"))
+		}()
+		header := http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}
+		return &http.Response{StatusCode: http.StatusOK, Header: header, Body: pr}, nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "stream_truncated" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want stream_truncated/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	promptEstimate := estimatePromptTokens([]byte(body))
+	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), promptEstimate, promptEstimate+500)
+	wantUsed := float64(promptEstimate + wantCompletion)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
 func TestStreamingReadErrorAfterBuyerCancelSettlesClientDisconnect(t *testing.T) {
 	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"cancel"}]}`
 	accountID := "acct_stream_read_cancel"
@@ -2534,6 +2576,52 @@ func TestStreamingGatewayEstimateStopsNonObjectDelta(t *testing.T) {
 	}
 }
 
+func TestStreamingGatewayEstimateStopsDataWithoutChoicesOrUsage(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":100,"messages":[{"role":"user","content":"malformed"}]}`
+	accountID := "acct_stream_no_choices"
+	rawPayload := strings.Repeat("m", 400)
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data:{"object":"not-a-chat-chunk","text":"` + rawPayload + `"}`,
+			`data:[DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "stream_malformed") {
+		t.Fatalf("stream body missing stream_malformed: %s", resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), strings.Repeat("m", 200)) {
+		t.Fatalf("data without choices/usage was forwarded: %s", resp.Body.String())
+	}
+	if !strings.HasSuffix(resp.Body.String(), "data: [DONE]\n\n") {
+		t.Fatalf("stream body missing DONE terminator: %s", resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "stream_malformed" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want stream_malformed/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	wantUsed := float64(estimatePromptTokens([]byte(body)))
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
 func TestStreamingInvalidUsageAfterValidFallsBackToGatewayEstimate(t *testing.T) {
 	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"ok"}]}`
 	accountID := "acct_stream_invalid_usage"
@@ -2564,6 +2652,87 @@ func TestStreamingInvalidUsageAfterValidFallsBackToGatewayEstimate(t *testing.T)
 	outcome, source := usageEventOutcome(t, dbPath, accountID)
 	if outcome != "ok" || source != "gateway_estimated" {
 		t.Fatalf("usage outcome/source = %s/%s, want ok/gateway_estimated", outcome, source)
+	}
+}
+
+func TestStreamingProviderReportedUsageCannotUnderstateObservedOutput(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"ok"}]}`
+	accountID := "acct_stream_underreported_usage"
+	output := strings.Repeat("x", 40)
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data: {"id":"chatcmpl","choices":[{"delta":{"content":"` + output + `"}}]}`,
+			`data: {"id":"chatcmpl","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2},"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "ok" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want ok/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	promptEstimate := estimatePromptTokens([]byte(body))
+	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), promptEstimate, promptEstimate+500)
+	wantUsed := float64(promptEstimate + wantCompletion)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
+func TestStreamingUnderreportedUsageWithHighProviderPromptFallsBackToGatewayEstimate(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"ok"}]}`
+	accountID := "acct_stream_underreported_high_prompt"
+	output := strings.Repeat("x", 40)
+	promptEstimate := estimatePromptTokens([]byte(body))
+	providerPrompt := promptEstimate + 19
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data: {"id":"chatcmpl","choices":[{"delta":{"content":"` + output + `"}}]}`,
+			`data: {"id":"chatcmpl","usage":{"prompt_tokens":` + strconv.FormatInt(providerPrompt, 10) + `,"completion_tokens":1,"total_tokens":` + strconv.FormatInt(providerPrompt+1, 10) + `},"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "ok" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want ok/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), promptEstimate, promptEstimate+20)
+	wantUsed := float64(promptEstimate + wantCompletion)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
 	}
 }
 

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2037,6 +2037,38 @@ func TestStreamingScannerErrorSettlesStreamTruncated(t *testing.T) {
 	}
 }
 
+func TestStreamingReadErrorAfterBuyerCancelSettlesClientDisconnect(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"cancel"}]}`
+	accountID := "acct_stream_read_cancel"
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		header := http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     header,
+			Body:       cancelingReadCloser{cancel: cancel, err: context.Canceled},
+		}, nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+fullKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "client_disconnect" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want client_disconnect/gateway_estimated", outcome, source)
+	}
+}
+
 func TestStreamingCleanEOFSettlesOK(t *testing.T) {
 	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"ok"}]}`
 	accountID := "acct_stream_ok"
@@ -2061,6 +2093,32 @@ func TestStreamingCleanEOFSettlesOK(t *testing.T) {
 	outcome, source := usageEventOutcome(t, dbPath, accountID)
 	if outcome != "ok" || source != "provider_reported" {
 		t.Fatalf("usage outcome/source = %s/%s, want ok/provider_reported", outcome, source)
+	}
+}
+
+func TestStreamingPreservesSSELineBytes(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"ok"}]}`
+	accountID := "acct_stream_bytes"
+	streamBody := "data: {\"id\":\"chatcmpl\",\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\r\n\r\ndata: [DONE]\r\n\r\n"
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, streamBody), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if got := resp.Body.String(); got != streamBody {
+		t.Fatalf("stream body bytes changed:\ngot  %q\nwant %q", got, streamBody)
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "ok" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want ok/gateway_estimated", outcome, source)
 	}
 }
 
@@ -2104,6 +2162,114 @@ func TestStreamingGatewayEstimateStopsOverMaxOutput(t *testing.T) {
 	}
 	if quota["daily_tokens_reserved"].(float64) != 0 {
 		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
+func TestStreamingGatewayEstimateCountsDataWithoutSpace(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":1,"messages":[{"role":"user","content":"ok"}]}`
+	accountID := "acct_stream_no_space"
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data:{"id":"chatcmpl","choices":[{"delta":{"content":"` + strings.Repeat("x", 400) + `"}}]}`,
+			`data:[DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "stream_output_exceeded") {
+		t.Fatalf("stream body missing stream_output_exceeded: %s", resp.Body.String())
+	}
+	if !strings.HasSuffix(resp.Body.String(), "data: [DONE]\n\n") {
+		t.Fatalf("stream body missing DONE terminator: %s", resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "stream_output_exceeded" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want stream_output_exceeded/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
+func TestStreamingGatewayEstimateCountsGeneratedDeltaStrings(t *testing.T) {
+	cases := []struct {
+		name    string
+		account string
+		delta   string
+	}{
+		{
+			name:    "reasoning_content",
+			account: "acct_stream_reasoning",
+			delta:   `"reasoning_content":"` + strings.Repeat("r", 400) + `"`,
+		},
+		{
+			name:    "refusal",
+			account: "acct_stream_refusal",
+			delta:   `"refusal":"` + strings.Repeat("f", 400) + `"`,
+		},
+		{
+			name:    "legacy_function_call_arguments",
+			account: "acct_stream_function_call",
+			delta:   `"function_call":{"name":"lookup","arguments":"` + strings.Repeat("a", 400) + `"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"model":"llama","stream":true,"max_tokens":1,"messages":[{"role":"user","content":"ok"}]}`
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				payload := strings.Join([]string{
+					`data:{"id":"chatcmpl","choices":[{"delta":{` + tc.delta + `},"finish_reason":null}]}`,
+					`data:[DONE]`,
+					``,
+				}, "\n\n")
+				return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+			})}
+			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+				cfg.Coordinator.BuyerURL = "http://coordinator.test"
+			}, WithHTTPClient(client))
+			fullKey := createAccountAndKey(t, store, cfg, tc.account)
+
+			resp := postChat(t, h, fullKey, body, nil)
+
+			if resp.Code != http.StatusOK {
+				t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+			}
+			if !strings.Contains(resp.Body.String(), "stream_output_exceeded") {
+				t.Fatalf("stream body missing stream_output_exceeded: %s", resp.Body.String())
+			}
+			if !strings.HasSuffix(resp.Body.String(), "data: [DONE]\n\n") {
+				t.Fatalf("stream body missing DONE terminator: %s", resp.Body.String())
+			}
+			outcome, source := usageEventOutcome(t, dbPath, tc.account)
+			if outcome != "stream_output_exceeded" || source != "gateway_estimated" {
+				t.Fatalf("usage outcome/source = %s/%s, want stream_output_exceeded/gateway_estimated", outcome, source)
+			}
+			usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+			quota := readQuota(t, usageResp)
+			wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+			if quota["daily_tokens_used"].(float64) != wantUsed {
+				t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+			}
+			if quota["daily_tokens_reserved"].(float64) != 0 {
+				t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+			}
+		})
 	}
 }
 
@@ -2268,6 +2434,98 @@ func TestStreamingGatewayEstimateStopsMalformedChunkWithoutRawCounting(t *testin
 	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
 	quota := readQuota(t, usageResp)
 	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
+func TestStreamingGatewayEstimateStopsMalformedDataWithoutSpace(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":100,"messages":[{"role":"user","content":"malformed"}]}`
+	accountID := "acct_stream_malformed_no_space"
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data:{"id":"chatcmpl","choices":[{"delta":{"content":"ok"},"finish_reason":null}]}`,
+			`data:not-json-` + strings.Repeat("m", 400),
+			`data:[DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "stream_malformed") {
+		t.Fatalf("stream body missing stream_malformed: %s", resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), strings.Repeat("m", 200)) {
+		t.Fatalf("malformed raw payload was forwarded: %s", resp.Body.String())
+	}
+	if !strings.HasSuffix(resp.Body.String(), "data: [DONE]\n\n") {
+		t.Fatalf("stream body missing DONE terminator: %s", resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "stream_malformed" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want stream_malformed/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	if quota["daily_tokens_used"].(float64) != wantUsed {
+		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
+	}
+	if quota["daily_tokens_reserved"].(float64) != 0 {
+		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
+	}
+}
+
+func TestStreamingGatewayEstimateStopsNonObjectDelta(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":100,"messages":[{"role":"user","content":"malformed"}]}`
+	accountID := "acct_stream_non_object_delta"
+	rawDelta := strings.Repeat("m", 400)
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data:{"id":"chatcmpl","choices":[{"delta":"` + rawDelta + `","finish_reason":null}]}`,
+			`data:[DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "stream_malformed") {
+		t.Fatalf("stream body missing stream_malformed: %s", resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), strings.Repeat("m", 200)) {
+		t.Fatalf("non-object delta raw payload was forwarded: %s", resp.Body.String())
+	}
+	if !strings.HasSuffix(resp.Body.String(), "data: [DONE]\n\n") {
+		t.Fatalf("stream body missing DONE terminator: %s", resp.Body.String())
+	}
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "stream_malformed" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source = %s/%s, want stream_malformed/gateway_estimated", outcome, source)
+	}
+	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, usageResp)
+	wantUsed := float64(estimatePromptTokens([]byte(body)))
 	if quota["daily_tokens_used"].(float64) != wantUsed {
 		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
 	}
@@ -2785,6 +3043,20 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+type cancelingReadCloser struct {
+	cancel func()
+	err    error
+}
+
+func (r cancelingReadCloser) Read(_ []byte) (int, error) {
+	r.cancel()
+	return 0, r.err
+}
+
+func (r cancelingReadCloser) Close() error {
+	return nil
 }
 
 func responseWithBody(status int, header http.Header, body string) *http.Response {

--- a/test/integration/spec015/sdk_compat/js/smoke_openai_node.mjs
+++ b/test/integration/spec015/sdk_compat/js/smoke_openai_node.mjs
@@ -15,6 +15,7 @@ const model = process.env.MACPROVIDER_SPEC015_MODEL || "llama-3.2-3b-instruct";
 const client = new OpenAI({
   apiKey: process.env.MACPROVIDER_SPEC015_API_KEY || "test-key",
   baseURL: baseURL(endpoint),
+  fetch: globalThis.fetch,
   timeout: 30000,
 });
 


### PR DESCRIPTION
## Summary
- bound gateway-estimated streaming fallback settlement to generated output, not SSE metadata
- stop malformed or over-max streamed chunks with SSE errors that terminate with [DONE]
- keep provider-reported usage validation strict, including explicit total_tokens mismatch checks

## Validation
- go test ./internal/router -run 'TestStreamingGatewayEstimateStopsOverMaxOutput|TestStreamingGatewayEstimateCountsDeltaContentNotMetadata|TestStreamingGatewayEstimateCountsToolCallArguments|TestStreamingGatewayEstimateStopsOverMaxToolCallArguments|TestStreamingGatewayEstimateStopsMalformedChunkWithoutRawCounting|TestStreamingCleanEOFSettlesOK|TestStreamingInvalidUsageAfterValidFallsBackToGatewayEstimate|TestStreamingScannerErrorSettlesStreamTruncated|TestStreamingQuotaReservationAndSettlementUsesDisconnectEstimation|TestUsageFromJSONValidatesProviderReportedUsage' -count=1\n- SPEC015_SDK_COMPAT_GATEWAY=1 go test -race -count=1 -timeout 10m . -run TestSpec015SDKCompatAgainstGateway\n- go test ./... -count=1 (phase5-gateway)\n- git diff --check\n- code/security/architecture auditors: 0 critical/high/medium findings\n\n## Notes\nThis is split out from the v1.6.1 release bump because it touches gateway quota/settlement behavior.