### PR TITLE
install: recover disabled launchd service state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ test-dist:
 	bash phase4-coordinator/dist/test/check_nginx_receipt_buffers_test.sh
 	bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh
 	SPEC015_NGINX_LIVE_OPTIONAL=$${SPEC015_NGINX_LIVE_OPTIONAL:-1} bash phase4-coordinator/dist/test/check_nginx_receipt_header_live_test.sh
+	bash scripts/test-install-launchd-enable.sh
 
 vet: vet-coordinator vet-gateway vet-integration
 

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -1023,6 +1023,7 @@ install_plist() {
   run mkdir -p "$(dirname "$PLIST_PATH")" "$LOG_DIR"
   if [ "$DRY_RUN" -eq 1 ]; then
     log "Would render launchd plist to $PLIST_PATH"
+    log "Would enable launchd service: launchctl enable gui/$UID/live.streamvc.macprovider"
     log "Would bootstrap with: launchctl bootstrap gui/$UID $PLIST_PATH"
     return
   fi
@@ -1031,6 +1032,7 @@ install_plist() {
 
   plutil -lint "$PLIST_PATH" >/dev/null || die 5 "rendered launchd plist is invalid"
   launchctl bootout "gui/$UID" "$PLIST_PATH" >/dev/null 2>&1 || true
+  launchctl enable "gui/$UID/live.streamvc.macprovider" || die 5 "failed to enable launchd service"
   launchctl bootstrap "gui/$UID" "$PLIST_PATH" || die 5 "failed to load launchd service"
   LAUNCHD_INSTALLED=1
 }

--- a/scripts/test-install-launchd-enable.sh
+++ b/scripts/test-install-launchd-enable.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Hermetic guard for install.sh launchd recovery sequencing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+
+die() {
+  printf '[install-launchd-test] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_line() {
+  local pattern="$1"
+  local description="$2"
+  if ! grep -Fq "$pattern" "$INSTALL_SH"; then
+    die "missing $description: $pattern"
+  fi
+}
+
+line_number() {
+  local pattern="$1"
+  awk -v pattern="$pattern" 'index($0, pattern) { print NR; exit }' "$INSTALL_SH"
+}
+
+require_line 'launchctl bootout "gui/$UID" "$PLIST_PATH"' "launchd bootout before replacement"
+require_line 'launchctl enable "gui/$UID/live.streamvc.macprovider"' "launchd enable before bootstrap"
+require_line 'launchctl bootstrap "gui/$UID" "$PLIST_PATH"' "launchd bootstrap"
+require_line 'Would enable launchd service: launchctl enable gui/$UID/live.streamvc.macprovider' "dry-run enable hint"
+
+bootout_line="$(line_number 'launchctl bootout "gui/$UID" "$PLIST_PATH"')"
+enable_line="$(line_number 'launchctl enable "gui/$UID/live.streamvc.macprovider"')"
+bootstrap_line="$(line_number 'launchctl bootstrap "gui/$UID" "$PLIST_PATH"')"
+
+[ -n "$bootout_line" ] || die "could not locate bootout line"
+[ -n "$enable_line" ] || die "could not locate enable line"
+[ -n "$bootstrap_line" ] || die "could not locate bootstrap line"
+
+if [ "$bootout_line" -ge "$enable_line" ] || [ "$enable_line" -ge "$bootstrap_line" ]; then
+  die "launchd sequence must be bootout -> enable -> bootstrap; got $bootout_line -> $enable_line -> $bootstrap_line"
+fi
+
+printf '[install-launchd-test] install.sh launchd enable sequencing ok\n'


### PR DESCRIPTION
## Summary
- enable the macprovider LaunchAgent label before bootstrap so installs recover a persisted disabled state
- document the enable step in install.sh dry-run output
- add a hermetic test guarding bootout -> enable -> bootstrap sequencing

## Evidence
- Clean-install smoke on macOS 26.5 proved package checksum, Gatekeeper, and stapler validation passed, then bootstrap failed with launchd 119 Service is disabled.
- Manual `launchctl enable gui/501/live.streamvc.macprovider` followed by bootstrap made the service run.

## Tests
- `bash scripts/test-install-launchd-enable.sh`
- `make test-dist`
- `bash -n phase3-binary/dist/install.sh`
- `bash -n scripts/test-install-launchd-enable.sh`
