### PR TITLE
docs: close stale deploy observation gaps in OPS

### DIFF
--- a/OPS.md
+++ b/OPS.md
@@ -70,8 +70,16 @@ Post-restart: the script polls `/healthz` and asserts the deployed `version`
 field matches the freshly built binary (M0-5 phase 2 provenance check). A
 mismatch implies the systemd unit started a stale binary; the script exits
 non-zero and the operator's responsibility is to investigate **before**
-declaring success. **TBD after first M0-5/M1-6 deploy**: the exact timing of
-this poll loop, and any retry/sleep tweaks discovered in practice.
+declaring success.
+
+Observed timing from the first M0-5/M1-6 production deploy (2026-06-11,
+v1.3.0-24-g87b3a6b -> v1.3.1-5-gba04cd4): there is no retry loop. Step 7
+does `systemctl restart` -> `sleep 3` -> `systemctl is-active` (active on
+first check). Step 8 does `sleep 2` -> a single `curl --max-time 10` GET
+on `https://coordinator.streamvc.live/healthz`. Total window between
+restart command and the provenance assert is about 5 seconds; `/healthz`
+responded immediately at `uptime_s=12` with the version field set. No
+tweaks were needed.
 
 ## 3. Safe gateway restart
 
@@ -100,10 +108,18 @@ sudo systemctl restart macprovider-gateway
 curl -s http://127.0.0.1:9443/healthz   # confirm OK + version reflects .prev
 ```
 
-**TBD after first M0-5/M1-6 deploy**: confirm the `.prev` filename layout
-matches the script (the path was inferred from `deploy-pearl-vps.sh`
-comments; the first real deploy should leave a `gateway.prev` artifact that
-either confirms or amends this section).
+Confirmed by the first M0-5/M1-6 production deploy (2026-06-11): both
+services maintain a single `.prev` artifact that is overwritten on each
+deploy, owned `macprovider:macprovider`, mode `0755`:
+
+- `/opt/macprovider/coordinator.prev`
+- `/opt/macprovider/gateway.prev`
+
+For the coordinator, the deploy script additionally writes a timestamped
+config backup at `/opt/macprovider/coordinator.yaml.bak-<UTC>` (UTC stamp
+in `YYYYMMDDTHHMMSSZ` form) before overwriting the live config. These
+accumulate across deploys; operators who want to free disk should reap the
+older ones after confirming a successful run.
 
 ### 3.1 Gateway DB archive-rotate (M2-4 Part C / PERF-1)
 


### PR DESCRIPTION
## Summary

- replace the two first M0-5/M1-6 deploy TBDs in OPS.md with the captured 2026-06-11 Pearl observations
- document coordinator restart health-check timing as a single post-sleep /healthz probe, not a retry loop
- document the observed `.prev` rollback artifact layout and coordinator config backup naming

## Supersedes

Supersedes PR #75. This replacement keeps only the still-useful OPS.md edits and intentionally drops #75's stale companion-findings section because those follow-ups have since been resolved or documented on main.

## Validation

- `git diff --check`
- local deploy-script check: `phase4-coordinator/dist/deploy-pearl-vps.sh` currently does `systemctl restart` -> `sleep 3` -> `systemctl is-active`, then `sleep 2` -> one `curl --max-time 10 ... /healthz`; gateway script mirrors the same restart/provenance shape
- Pearl filesystem check at 2026-06-25T08:26:22Z: `/opt/macprovider/coordinator.prev` and `/opt/macprovider/gateway.prev` exist, owned `macprovider:macprovider`, mode `0755`
- Pearl backup check: latest `/opt/macprovider/coordinator.yaml.bak-20260625T073758Z` exists, and older timestamped backups accumulate
- Pearl FR-C9.4 check: `journalctl -u macprovider-coordinator --since "14 days ago"` had `0` `fr_c9_4_tofu_reject` entries; no FR-C9.4 self-heal/reject events after 2026-06-20 09:00 UTC
- Health checks: `https://coordinator.streamvc.live/healthz` returned `status: ok`, `pool_ready: 2`, `version: v1.6.1-4-g4f6284b`; `https://api.streamvc.live/healthz` returned `status: ok`, `version: v1.3.1-37-g4f727e5`
