### PR TITLE
Fix gateway header timeout and late encrypted relay cleanup

### DIFF
--- a/phase4-coordinator/internal/ws/relay.go
+++ b/phase4-coordinator/internal/ws/relay.go
@@ -23,6 +23,8 @@ var (
 	ErrRelayAEADFailed   = errors.New("tier2 aead decrypt failed")
 )
 
+const retiredRelayRequestTTL = 5 * time.Minute
+
 type RelayStream struct {
 	RequestID string
 	Chunks    <-chan InferenceResponseChunk
@@ -45,6 +47,11 @@ type relayActive struct {
 	errs      chan error
 }
 
+type retiredRelayRequest struct {
+	stream    bool
+	retiredAt time.Time
+}
+
 type providerSession struct {
 	providerID string
 	assignedID string
@@ -56,6 +63,7 @@ type providerSession struct {
 	closed     bool
 	activeMu   sync.Mutex
 	active     map[string]*relayActive
+	retired    map[string]retiredRelayRequest
 	httpOnly   bool
 	tier2Mu    sync.Mutex
 	tier2      *pool.Tier2Session
@@ -116,6 +124,7 @@ func newProviderSession(providerID, assignedID string, conn net.Conn, bufferSize
 		writeCh:    make(chan providerFrame, bufferSize),
 		writeLimit: writeLimit,
 		active:     map[string]*relayActive{},
+		retired:    map[string]retiredRelayRequest{},
 	}
 }
 
@@ -205,8 +214,39 @@ func (ps *providerSession) removeActive(requestID string) (*relayActive, bool) {
 	active, ok := ps.active[requestID]
 	if ok {
 		delete(ps.active, requestID)
+		ps.markRetiredLocked(active, time.Now())
 	}
 	return active, ok
+}
+
+func (ps *providerSession) markRetiredLocked(active *relayActive, now time.Time) {
+	if active == nil || strings.TrimSpace(active.requestID) == "" {
+		return
+	}
+	cutoff := now.Add(-retiredRelayRequestTTL)
+	for id, retired := range ps.retired {
+		if retired.retiredAt.Before(cutoff) {
+			delete(ps.retired, id)
+		}
+	}
+	ps.retired[active.requestID] = retiredRelayRequest{
+		stream:    active.stream,
+		retiredAt: now,
+	}
+}
+
+func (ps *providerSession) recentlyRetired(requestID string) (retiredRelayRequest, bool) {
+	ps.activeMu.Lock()
+	defer ps.activeMu.Unlock()
+	retired, ok := ps.retired[requestID]
+	if !ok {
+		return retiredRelayRequest{}, false
+	}
+	if time.Since(retired.retiredAt) > retiredRelayRequestTTL {
+		delete(ps.retired, requestID)
+		return retiredRelayRequest{}, false
+	}
+	return retired, true
 }
 
 func (ps *providerSession) failActive(requestID string, err error) {
@@ -400,6 +440,44 @@ func (ps *providerSession) openInferenceEnd(providerID, assignedID string, activ
 	return end, nil
 }
 
+func (ps *providerSession) consumeRetiredEncryptedFrame(providerID, assignedID string, retired retiredRelayRequest, expectedType, expectedRequestID string, aad tier2.AEADFrameAAD, envelope tier2.AEADEnvelope) error {
+	ps.tier2Mu.Lock()
+	defer ps.tier2Mu.Unlock()
+	if ps.tier2 == nil {
+		return errors.New("encrypted frame for provider without tier2 session")
+	}
+	if ps.tier2.P2CCounter == ^uint64(0) {
+		return errors.New("tier2 p2c frame counter exhausted")
+	}
+	if aad.Type != expectedType {
+		return errors.New("tier2 retired frame type mismatch")
+	}
+	if aad.Direction != "p2c" {
+		return errors.New("tier2 retired frame direction mismatch")
+	}
+	if aad.RequestID != expectedRequestID {
+		return errors.New("tier2 retired frame request_id mismatch")
+	}
+	if aad.Stream != retired.stream {
+		return errors.New("tier2 retired frame stream mismatch")
+	}
+	seq := ps.tier2.P2CCounter
+	expectedAAD := tier2.AEADFrameAAD{
+		Type:       expectedType,
+		Direction:  "p2c",
+		RequestID:  expectedRequestID,
+		Stream:     retired.stream,
+		ProviderID: providerID,
+		AssignedID: assignedID,
+		Seq:        seq,
+	}
+	if _, err := tier2.OpenPillarBFrame(ps.tier2.P2CKey, ps.tier2.P2CNonceBase, ps.tier2.KeyID, seq, expectedAAD, envelope); err != nil {
+		return err
+	}
+	ps.tier2.P2CCounter++
+	return nil
+}
+
 func (ps *providerSession) markTier2RequestDispatched() {
 	ps.tier2Mu.Lock()
 	defer ps.tier2Mu.Unlock()
@@ -526,6 +604,14 @@ func (s *Server) handleInferenceChunk(providerID, assignedID string, payload []b
 		}
 		active, ok := session.activeFor(requestID)
 		if !ok {
+			if retired, ok := session.recentlyRetired(requestID); ok {
+				if err := session.consumeRetiredEncryptedFrame(providerID, assignedID, retired, "inference_response_chunk", requestID, aad, tier2.AEADEnvelope{Encrypted: true, Enc: envelope.Enc}); err != nil {
+					s.closeProviderForTier2AEADFailure(session, providerID, assignedID, requestID, err.Error())
+					return
+				}
+				s.log.Warn().Str("provider_id", providerID).Str("request_id", requestID).Msg("late encrypted inference_response_chunk for retired request dropped")
+				return
+			}
 			s.log.Warn().Str("provider_id", providerID).Str("request_id", requestID).Msg("unknown encrypted inference_response_chunk request_id")
 			s.closeProviderForTier2AEADFailure(session, providerID, assignedID, requestID, "unknown encrypted inference_response_chunk request_id")
 			return
@@ -594,6 +680,14 @@ func (s *Server) handleInferenceEnd(providerID, assignedID string, payload []byt
 		}
 		active, ok := session.activeFor(requestID)
 		if !ok {
+			if retired, ok := session.recentlyRetired(requestID); ok {
+				if err := session.consumeRetiredEncryptedFrame(providerID, assignedID, retired, "inference_response_end", requestID, aad, tier2.AEADEnvelope{Encrypted: true, Enc: envelope.Enc}); err != nil {
+					s.closeProviderForTier2AEADFailure(session, providerID, assignedID, requestID, err.Error())
+					return
+				}
+				s.log.Warn().Str("provider_id", providerID).Str("request_id", requestID).Msg("late encrypted inference_response_end for retired request dropped")
+				return
+			}
 			s.log.Warn().Str("provider_id", providerID).Str("request_id", requestID).Msg("unknown encrypted inference_response_end request_id")
 			s.closeProviderForTier2AEADFailure(session, providerID, assignedID, requestID, "unknown encrypted inference_response_end request_id")
 			return

--- a/phase4-coordinator/internal/ws/relay_test.go
+++ b/phase4-coordinator/internal/ws/relay_test.go
@@ -175,6 +175,118 @@ func TestEncryptedRelayDecryptsResponseEnd(t *testing.T) {
 	}
 }
 
+func TestEncryptedRelayDropsLateEndForRetiredRequest(t *testing.T) {
+	var logs bytes.Buffer
+	s, provider, providerConn := newEncryptedRelayHarnessWithConfig(t, config.Default(), zerolog.New(&logs), time.Now())
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-late-end", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+	relay.Cancel("buyer_disconnected")
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read cancel_request: %v", err)
+	}
+
+	s.handleInferenceEnd("p1", "s1", encryptedResponseEnd(t, provider, "req-late-end", false, 0, InferenceResponseEnd{
+		Type:       "inference_response_end",
+		RequestID:  "req-late-end",
+		Status:     "complete",
+		ChunksSent: 0,
+	}))
+
+	if _, ok := s.storedSessionFor("p1", "s1"); !ok {
+		t.Fatal("session closed after valid late encrypted end for retired request")
+	}
+	got, ok := s.pool.Resolve("p1", "s1")
+	if !ok {
+		t.Fatal("provider missing from pool")
+	}
+	if got.State != pool.StateReady {
+		t.Fatalf("provider state = %s, want ready", got.State)
+	}
+	if provider.Tier2Session.P2CCounter != 1 {
+		t.Fatalf("p2c counter = %d, want 1", provider.Tier2Session.P2CCounter)
+	}
+	if bytes.Contains(logs.Bytes(), []byte(`"event":"aead_decrypt_failed"`)) {
+		t.Fatalf("late retired end logged AEAD failure: %s", logs.String())
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("late encrypted inference_response_end for retired request dropped")) {
+		t.Fatalf("missing late-drop log: %s", logs.String())
+	}
+}
+
+func TestEncryptedRelayDropsLateChunkForRetiredRequest(t *testing.T) {
+	var logs bytes.Buffer
+	s, provider, providerConn := newEncryptedRelayHarnessWithConfig(t, config.Default(), zerolog.New(&logs), time.Now())
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-late-chunk", []byte(`{"model":"model-a"}`), true)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+	relay.Cancel("buyer_disconnected")
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read cancel_request: %v", err)
+	}
+
+	s.handleInferenceChunk("p1", "s1", encryptedResponseChunk(t, provider, "req-late-chunk", true, 0, []byte(`{"ok":true}`)))
+
+	if _, ok := s.storedSessionFor("p1", "s1"); !ok {
+		t.Fatal("session closed after valid late encrypted chunk for retired request")
+	}
+	got, ok := s.pool.Resolve("p1", "s1")
+	if !ok {
+		t.Fatal("provider missing from pool")
+	}
+	if got.State != pool.StateReady {
+		t.Fatalf("provider state = %s, want ready", got.State)
+	}
+	if provider.Tier2Session.P2CCounter != 1 {
+		t.Fatalf("p2c counter = %d, want 1", provider.Tier2Session.P2CCounter)
+	}
+	if bytes.Contains(logs.Bytes(), []byte(`"event":"aead_decrypt_failed"`)) {
+		t.Fatalf("late retired chunk logged AEAD failure: %s", logs.String())
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("late encrypted inference_response_chunk for retired request dropped")) {
+		t.Fatalf("missing late-drop log: %s", logs.String())
+	}
+}
+
+func TestEncryptedRelayRejectsLateRetiredFrameTypeMismatch(t *testing.T) {
+	s, provider, providerConn := newEncryptedRelayHarness(t)
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-late-mismatch", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+	relay.Cancel("buyer_disconnected")
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read cancel_request: %v", err)
+	}
+
+	s.handleInferenceEnd("p1", "s1", encryptedResponseChunk(t, provider, "req-late-mismatch", false, 0, []byte(`{"ok":true}`)))
+
+	if _, ok := s.storedSessionFor("p1", "s1"); ok {
+		t.Fatal("session still stored after late retired frame type mismatch")
+	}
+	got, ok := s.pool.Resolve("p1", "s1")
+	if !ok {
+		t.Fatal("provider missing from pool")
+	}
+	if got.State != pool.StateUnavailable {
+		t.Fatalf("provider state = %s, want unavailable", got.State)
+	}
+	if provider.Tier2Session.P2CCounter != 0 {
+		t.Fatalf("p2c counter = %d, want 0", provider.Tier2Session.P2CCounter)
+	}
+}
+
 func TestEncryptedRelayRekeysAfterRequestThreshold(t *testing.T) {
 	var logs bytes.Buffer
 	cfg := config.Default()

--- a/phase5-gateway/cmd/gateway/main.go
+++ b/phase5-gateway/cmd/gateway/main.go
@@ -18,7 +18,9 @@ import (
 )
 
 // version is overridden at build time via
-//   go build -ldflags "-X main.version=$(git describe --always --dirty --tags)"
+//
+//	go build -ldflags "-X main.version=$(git describe --always --dirty --tags)"
+//
 // (see scripts/build-linux.sh). Defaults to "dev" for local `go run`.
 var version = "dev"
 
@@ -77,10 +79,11 @@ func main() {
 	go runReservationReaper(ctx, store, time.Duration(cfg.Quotas.ReaperIntervalHours)*time.Hour)
 
 	// coordinatorTransport clones the default transport and adds
-	// ResponseHeaderTimeout so buyers get a fast 503 if the coordinator
-	// holds the connection without sending headers (e.g. during a restart
-	// while the provider pool is empty). This does not affect inference
-	// streams — ResponseHeaderTimeout only covers the header phase.
+	// ResponseHeaderTimeout so buyers get a bounded failure if the coordinator
+	// holds the connection without sending headers. This timeout must still be
+	// long enough for non-streaming large-model inference, because the
+	// coordinator cannot send headers until a complete non-streaming response
+	// is available. Streaming response bodies continue unaffected after headers.
 	coordinatorTransport := http.DefaultTransport.(*http.Transport).Clone()
 	coordinatorTransport.ResponseHeaderTimeout = cfg.CoordinatorHeaderTimeout()
 	coordinatorClient := &http.Client{

--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -79,6 +79,10 @@ capacity:
 
 timeouts:
   coordinator_request_seconds: 300
+  # Non-streaming inference does not commit coordinator response headers until
+  # the provider returns a full response. Keep this above expected first
+  # response latency for large local models.
+  coordinator_header_timeout_seconds: 60
   streaming_cancel_ms: 500
 
 routing:

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -180,7 +180,7 @@ func Default() Config {
 		Capacity: CapacityConfig{
 			MonthlyBudgetUSD: 500, ReadyProviderDegradedThreshold: 1, ProjectedCostTier1Percent: 80, TierCooldownSeconds: 3600,
 		},
-		Timeouts: TimeoutsConfig{CoordinatorRequestSeconds: 300, CoordinatorHeaderTimeoutSeconds: 10, StreamingCancelMS: 500},
+		Timeouts: TimeoutsConfig{CoordinatorRequestSeconds: 300, CoordinatorHeaderTimeoutSeconds: 60, StreamingCancelMS: 500},
 		CORS:     CORSConfig{AllowedOrigins: []string{"https://console.streamvc.live", "https://streamvc.live"}},
 		Routing:  RoutingConfig{StickyEnabled: false, StickyTTLS: 1800},
 		Explorer: ExplorerConfig{Enabled: false},
@@ -449,10 +449,11 @@ func (c Config) CoordinatorTimeout() time.Duration {
 }
 
 // CoordinatorHeaderTimeout is the max time to wait for the coordinator to
-// start sending response headers after the request is fully written. This
-// bounds buyer-visible hangs during coordinator restarts or empty-pool windows
-// without capping long-running inference streams (ResponseHeaderTimeout only
-// covers the header phase; body streaming continues unaffected).
+// start sending response headers after the request is fully written. It must
+// cover non-streaming first-response latency for large local models, because
+// the coordinator cannot send headers until the provider returns a complete
+// non-streaming response. Body streaming continues unaffected after headers
+// are committed.
 func (c Config) CoordinatorHeaderTimeout() time.Duration {
 	return time.Duration(c.Timeouts.CoordinatorHeaderTimeoutSeconds) * time.Second
 }

--- a/phase5-gateway/internal/config/config_test.go
+++ b/phase5-gateway/internal/config/config_test.go
@@ -15,6 +15,13 @@ func TestQuotaReaperDefaults(t *testing.T) {
 	}
 }
 
+func TestGatewayHeaderTimeoutDefaultCoversLargeModelFirstResponse(t *testing.T) {
+	cfg := Default()
+	if cfg.Timeouts.CoordinatorHeaderTimeoutSeconds < 60 {
+		t.Fatalf("CoordinatorHeaderTimeoutSeconds=%d want >=60", cfg.Timeouts.CoordinatorHeaderTimeoutSeconds)
+	}
+}
+
 func TestQuotaReaperConfigValidation(t *testing.T) {
 	for name, tc := range map[string]struct {
 		mutate func(*Config)

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -3098,6 +3098,7 @@ capacity:
   tier_cooldown_seconds: 3600
 timeouts:
   coordinator_request_seconds: 300
+  coordinator_header_timeout_seconds: 60
   streaming_cancel_ms: 500
 `, allPublicAPI)
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {


### PR DESCRIPTION
## Summary
- raise the gateway coordinator header timeout default/example from 10s to 60s so non-streaming large-model inference has time to produce first headers
- document why `ResponseHeaderTimeout` must cover non-streaming first-response latency
- keep valid late encrypted response frames for retired relay requests from closing the provider session as AEAD failures

## Why
PR #143 gateway e2e reached the coordinator and provider, but Pearl gateway returned `503 provider_unavailable` after about 10s. The failure path was the live gateway header timeout expiring before non-streaming Qwen3 returned response headers. The coordinator then retired the active relay, and a later valid encrypted provider terminal frame was misclassified as an unknown request / AEAD failure.

## Validation
- `git diff --check`
- `cd phase4-coordinator && go test ./internal/ws`
- `cd phase5-gateway && go test ./internal/config ./cmd/gateway ./internal/router`

## Operator follow-up still required
- update live Pearl `/opt/macprovider/gateway.yaml` to set `timeouts.coordinator_header_timeout_seconds: 60` or higher
- restart the gateway
- rerun the PR #143 gateway e2e through the public gateway after deploy

Draft because this is the follow-up implementation PR for the findings; the operator/deploy work above remains outside this branch.