### PR TITLE
[codex] Recognize Qwen coding tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Latest release and signed binaries: [github.com/augustas11/macprovider/releases]
 
 :white_check_mark: **Signed inference receipts — Shipped in v1.0.0.** The SPEC-015 v0.2 verifier is available as the open-source [macprovider-verify](phase7-verify/README.md) CLI.
 
-:white_check_mark: **OpenAI-compatible tool calling — Shipped for Qwen2.5-7B.** Requests with `tools` are rendered through the MLX chat template and responses emit `choices[0].message.tool_calls[]` with `function.arguments` as a JSON string. See [examples/tool_calling_demo.py](examples/tool_calling_demo.py).
+:white_check_mark: **OpenAI-compatible tool calling — Shipped for recognized MLX tool-call templates.** Requests with `tools` are rendered through the MLX chat template, and Qwen-style `<tool_call>...</tool_call>` or Llama 3.3-style `<|python_tag|>...<|eom_id|>` outputs emit `choices[0].message.tool_calls[]` with `function.arguments` as a JSON string. Other models safely fall back to normal assistant text unless their template emits one of those recognized formats. See [examples/tool_calling_demo.py](examples/tool_calling_demo.py).
 
 Every request through MacProvider carries a signed receipt that lets the caller later prove which provider signed the canonical prompt/output binding. The receipt is issued on the response path and signed with the provider's receipt key:
 

--- a/examples/tool_calling_demo.py
+++ b/examples/tool_calling_demo.py
@@ -21,17 +21,25 @@ client = OpenAI(
 
 resp = client.chat.completions.create(
     model=MODEL,
-    messages=[{"role": "user", "content": "What is the weather in Vilnius?"}],
+    messages=[
+        {
+            "role": "user",
+            "content": (
+                "Use the find_definition tool to answer. Call find_definition "
+                "with symbol ToolCallParser and do not answer directly."
+            ),
+        }
+    ],
     tools=[
         {
             "type": "function",
             "function": {
-                "name": "get_weather",
-                "description": "Get the current weather for a city",
+                "name": "find_definition",
+                "description": "Find where a code symbol is defined",
                 "parameters": {
                     "type": "object",
-                    "properties": {"city": {"type": "string"}},
-                    "required": ["city"],
+                    "properties": {"symbol": {"type": "string"}},
+                    "required": ["symbol"],
                 },
             },
         }
@@ -43,9 +51,9 @@ tool_calls = message.tool_calls or []
 assert tool_calls, "expected at least one tool call"
 
 call = tool_calls[0]
-assert call.function.name == "get_weather", call.function.name
+assert call.function.name == "find_definition", call.function.name
 
 arguments = json.loads(call.function.arguments)
-assert arguments.get("city", "").lower() == "vilnius", arguments
+assert arguments.get("symbol") == "ToolCallParser", arguments
 
 print(json.dumps([call.model_dump() for call in tool_calls], indent=2))

--- a/phase3-binary/Sources/macprovider-cli/ToolCallParser.swift
+++ b/phase3-binary/Sources/macprovider-cli/ToolCallParser.swift
@@ -49,10 +49,18 @@ enum ToolCallParser {
         return (nilIfBlank(cleaned), calls)
     }
 
-    private static func parseCall(_ rawJSON: String, argumentKey: String) throws -> ToolCall {
+    private static func parseCall(_ rawCall: String, argumentKey: String) throws -> ToolCall {
+        if rawCall.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("{") {
+            return try parseJSONCall(rawCall, argumentKey: argumentKey)
+        }
+        return try parsePythonStyleCall(rawCall)
+    }
+
+    private static func parseJSONCall(_ rawJSON: String, argumentKey: String) throws -> ToolCall {
         guard let data = rawJSON.data(using: .utf8) else {
             throw ParseError.invalidUTF8
         }
+        try validateNoDuplicateJSONKeys(rawJSON)
         let parsed = try JSONSerialization.jsonObject(with: data)
         guard let object = parsed as? [String: Any],
               let name = object["name"] as? String,
@@ -66,6 +74,167 @@ enum ToolCallParser {
         return ToolCall(id: "call_\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())", functionName: name, arguments: arguments)
     }
 
+    private static func parsePythonStyleCall(_ rawCall: String) throws -> ToolCall {
+        let trimmed = rawCall.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let open = trimmed.firstIndex(of: "("),
+              trimmed.last == ")"
+        else {
+            throw ParseError.invalidShape
+        }
+        let name = String(trimmed[..<open]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isPythonIdentifier(name) else {
+            throw ParseError.invalidShape
+        }
+
+        let argumentsStart = trimmed.index(after: open)
+        let argumentsEnd = trimmed.index(before: trimmed.endIndex)
+        let rawArguments = String(trimmed[argumentsStart..<argumentsEnd])
+        let arguments = try pythonKeywordArguments(rawArguments)
+        return ToolCall(id: "call_\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())", functionName: name, arguments: arguments)
+    }
+
+    private static func pythonKeywordArguments(_ rawArguments: String) throws -> String {
+        let trimmed = rawArguments.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return "{}"
+        }
+
+        var object: [String: Any] = [:]
+        for item in try splitPythonArguments(trimmed) {
+            guard let equals = item.firstIndex(of: "=") else {
+                throw ParseError.invalidArguments
+            }
+            let key = String(item[..<equals]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard isPythonIdentifier(key) else {
+                throw ParseError.invalidArguments
+            }
+            guard object[key] == nil else {
+                throw ParseError.invalidArguments
+            }
+            let valueStart = item.index(after: equals)
+            let value = String(item[valueStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            object[key] = try parsePythonLiteral(value)
+        }
+        guard JSONSerialization.isValidJSONObject(object) else {
+            throw ParseError.invalidArguments
+        }
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func splitPythonArguments(_ rawArguments: String) throws -> [String] {
+        var parts: [String] = []
+        var current = ""
+        var quote: Character?
+        var escaped = false
+
+        for ch in rawArguments {
+            if let activeQuote = quote {
+                current.append(ch)
+                if escaped {
+                    escaped = false
+                } else if ch == "\\" {
+                    escaped = true
+                } else if ch == activeQuote {
+                    quote = nil
+                }
+                continue
+            }
+            switch ch {
+            case "'", "\"":
+                quote = ch
+                current.append(ch)
+            case ",":
+                let item = current.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !item.isEmpty else {
+                    throw ParseError.invalidArguments
+                }
+                parts.append(item)
+                current = ""
+            default:
+                current.append(ch)
+            }
+        }
+        guard quote == nil else {
+            throw ParseError.invalidArguments
+        }
+        let item = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !item.isEmpty else {
+            throw ParseError.invalidArguments
+        }
+        parts.append(item)
+        return parts
+    }
+
+    private static func parsePythonLiteral(_ rawValue: String) throws -> Any {
+        if rawValue.hasPrefix("\"") || rawValue.hasPrefix("'") {
+            return try parsePythonString(rawValue)
+        }
+        switch rawValue {
+        case "True", "true":
+            return true
+        case "False", "false":
+            return false
+        case "None", "null":
+            return NSNull()
+        default:
+            if let intValue = Int(rawValue) {
+                return intValue
+            }
+            if let doubleValue = Double(rawValue), rawValue.contains(".") {
+                return doubleValue
+            }
+            throw ParseError.invalidArguments
+        }
+    }
+
+    private static func parsePythonString(_ rawValue: String) throws -> String {
+        guard rawValue.count >= 2,
+              let first = rawValue.first,
+              let last = rawValue.last,
+              (first == "\"" || first == "'"),
+              first == last
+        else {
+            throw ParseError.invalidArguments
+        }
+        var out = ""
+        var escaped = false
+        for ch in rawValue.dropFirst().dropLast() {
+            if escaped {
+                switch ch {
+                case "n":
+                    out.append("\n")
+                case "r":
+                    out.append("\r")
+                case "t":
+                    out.append("\t")
+                case "\\", "'", "\"":
+                    out.append(ch)
+                default:
+                    throw ParseError.invalidArguments
+                }
+                escaped = false
+            } else if ch == "\\" {
+                escaped = true
+            } else {
+                out.append(ch)
+            }
+        }
+        guard !escaped else {
+            throw ParseError.invalidArguments
+        }
+        return out
+    }
+
+    private static func isPythonIdentifier(_ value: String) -> Bool {
+        guard let first = value.first,
+              first == "_" || first.isLetter
+        else {
+            return false
+        }
+        return value.dropFirst().allSatisfy { $0 == "_" || $0.isLetter || $0.isNumber }
+    }
+
     private static func argumentsString(_ rawArguments: Any?) throws -> String {
         guard let rawArguments else {
             return "{}"
@@ -77,6 +246,7 @@ enum ToolCallParser {
             guard string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
                 return "{}"
             }
+            try validateNoDuplicateJSONKeys(string)
             guard let data = string.data(using: .utf8),
                   try JSONSerialization.jsonObject(with: data) is [String: Any]
             else {
@@ -93,6 +263,11 @@ enum ToolCallParser {
         return String(decoding: data, as: UTF8.self)
     }
 
+    private static func validateNoDuplicateJSONKeys(_ rawJSON: String) throws {
+        var validator = JSONDuplicateKeyValidator(rawJSON)
+        try validator.validate()
+    }
+
     private static func nilIfBlank(_ value: String) -> String? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
@@ -103,6 +278,173 @@ enum ToolCallParser {
         case invalidUTF8
         case invalidShape
         case invalidArguments
+    }
+
+    private struct JSONDuplicateKeyValidator {
+        let rawJSON: String
+        var index: String.Index
+
+        init(_ rawJSON: String) {
+            self.rawJSON = rawJSON
+            self.index = rawJSON.startIndex
+        }
+
+        mutating func validate() throws {
+            skipWhitespace()
+            try parseValue()
+            skipWhitespace()
+            guard index == rawJSON.endIndex else {
+                throw ParseError.invalidArguments
+            }
+        }
+
+        private mutating func parseValue() throws {
+            skipWhitespace()
+            guard index < rawJSON.endIndex else {
+                throw ParseError.invalidArguments
+            }
+
+            switch rawJSON[index] {
+            case "{":
+                try parseObject()
+            case "[":
+                try parseArray()
+            case "\"":
+                _ = try parseString()
+            case "t":
+                try consumeLiteral("true")
+            case "f":
+                try consumeLiteral("false")
+            case "n":
+                try consumeLiteral("null")
+            case "-", "0"..."9":
+                parseNumber()
+            default:
+                throw ParseError.invalidArguments
+            }
+        }
+
+        private mutating func parseObject() throws {
+            advance()
+            skipWhitespace()
+            var keys = Set<String>()
+
+            if consume("}") {
+                return
+            }
+
+            while true {
+                skipWhitespace()
+                guard index < rawJSON.endIndex, rawJSON[index] == "\"" else {
+                    throw ParseError.invalidArguments
+                }
+                let key = try parseString()
+                guard keys.insert(key).inserted else {
+                    throw ParseError.invalidArguments
+                }
+                skipWhitespace()
+                guard consume(":") else {
+                    throw ParseError.invalidArguments
+                }
+                try parseValue()
+                skipWhitespace()
+                if consume("}") {
+                    return
+                }
+                guard consume(",") else {
+                    throw ParseError.invalidArguments
+                }
+            }
+        }
+
+        private mutating func parseArray() throws {
+            advance()
+            skipWhitespace()
+
+            if consume("]") {
+                return
+            }
+
+            while true {
+                try parseValue()
+                skipWhitespace()
+                if consume("]") {
+                    return
+                }
+                guard consume(",") else {
+                    throw ParseError.invalidArguments
+                }
+            }
+        }
+
+        private mutating func parseString() throws -> String {
+            guard index < rawJSON.endIndex, rawJSON[index] == "\"" else {
+                throw ParseError.invalidArguments
+            }
+
+            var rawString = "\""
+            advance()
+            var escaped = false
+
+            while index < rawJSON.endIndex {
+                let ch = rawJSON[index]
+                rawString.append(ch)
+                advance()
+
+                if escaped {
+                    escaped = false
+                } else if ch == "\\" {
+                    escaped = true
+                } else if ch == "\"" {
+                    guard let data = rawString.data(using: .utf8),
+                          let decoded = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) as? String
+                    else {
+                        throw ParseError.invalidArguments
+                    }
+                    return decoded
+                }
+            }
+
+            throw ParseError.invalidArguments
+        }
+
+        private mutating func consumeLiteral(_ literal: String) throws {
+            guard rawJSON[index...].hasPrefix(literal) else {
+                throw ParseError.invalidArguments
+            }
+            for _ in literal {
+                advance()
+            }
+        }
+
+        private mutating func parseNumber() {
+            while index < rawJSON.endIndex {
+                switch rawJSON[index] {
+                case "-", "+", ".", "e", "E", "0"..."9":
+                    advance()
+                default:
+                    return
+                }
+            }
+        }
+
+        private mutating func skipWhitespace() {
+            while index < rawJSON.endIndex, rawJSON[index].isWhitespace {
+                advance()
+            }
+        }
+
+        private mutating func consume(_ expected: Character) -> Bool {
+            guard index < rawJSON.endIndex, rawJSON[index] == expected else {
+                return false
+            }
+            advance()
+            return true
+        }
+
+        private mutating func advance() {
+            index = rawJSON.index(after: index)
+        }
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift
@@ -6,7 +6,7 @@ import MacProviderCore
 final class ToolCallParserTests: XCTestCase {
     func testSingleQwenToolCall() throws {
         let parsed = ToolCallParser.parseToolCalls(
-            rawOutput: #"<tool_call>{"name":"get_weather","arguments":{"city":"Vilnius"}}</tool_call>"#,
+            rawOutput: #"<tool_call>{"name":"find_definition","arguments":{"symbol":"ToolCallParser"}}</tool_call>"#,
             modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit"
         )
 
@@ -14,24 +14,73 @@ final class ToolCallParserTests: XCTestCase {
         let call = try XCTUnwrap(parsed.toolCalls.first)
         XCTAssertEqual(parsed.toolCalls.count, 1)
         XCTAssertTrue(call.id.hasPrefix("call_"))
-        XCTAssertEqual(call.functionName, "get_weather")
-        XCTAssertEqual(try argumentValue(call.arguments, key: "city") as? String, "Vilnius")
+        XCTAssertEqual(call.functionName, "find_definition")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "symbol") as? String, "ToolCallParser")
     }
 
     func testMultipleQwenToolCalls() throws {
         let parsed = ToolCallParser.parseToolCalls(
-            rawOutput: #"<tool_call>{"name":"get_weather","arguments":{"city":"Vilnius"}}</tool_call><tool_call>{"name":"get_time","arguments":{"city":"Kaunas"}}</tool_call>"#,
+            rawOutput: #"<tool_call>{"name":"find_definition","arguments":{"symbol":"ToolCallParser"}}</tool_call><tool_call>{"name":"list_references","arguments":{"symbol":"ToolCallParser"}}</tool_call>"#,
             modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit"
         )
 
         XCTAssertNil(parsed.cleanedContent)
-        XCTAssertEqual(parsed.toolCalls.map(\.functionName), ["get_weather", "get_time"])
-        XCTAssertEqual(try argumentValue(parsed.toolCalls[1].arguments, key: "city") as? String, "Kaunas")
+        XCTAssertEqual(parsed.toolCalls.map(\.functionName), ["find_definition", "list_references"])
+        XCTAssertEqual(try argumentValue(parsed.toolCalls[1].arguments, key: "symbol") as? String, "ToolCallParser")
+    }
+
+    func testQwenPythonStyleToolCall() throws {
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: #"<tool_call>find_definition(symbol="ToolCallParser")</tool_call>"#,
+            modelID: "mlx-community/Qwen3-32B-4bit",
+            allowedFunctionNames: ["find_definition"]
+        )
+
+        XCTAssertNil(parsed.cleanedContent)
+        let call = try XCTUnwrap(parsed.toolCalls.first)
+        XCTAssertEqual(parsed.toolCalls.count, 1)
+        XCTAssertEqual(call.functionName, "find_definition")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "symbol") as? String, "ToolCallParser")
+    }
+
+    func testQwenDelimiterParsesIndependentOfModelID() throws {
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: #"<tool_call>find_definition(symbol="ToolCallParser")</tool_call>"#,
+            modelID: "mlx-community/Other-Instruct-7B-4bit",
+            allowedFunctionNames: ["find_definition"]
+        )
+
+        let call = try XCTUnwrap(parsed.toolCalls.first)
+        XCTAssertEqual(parsed.toolCalls.count, 1)
+        XCTAssertEqual(call.functionName, "find_definition")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "symbol") as? String, "ToolCallParser")
+    }
+
+    func testQwenPythonStyleToolCallKeepsThinkingOutOfToolArguments() throws {
+        let raw = """
+        <think>
+        I should use the provided tool.
+        </think>
+
+        <tool_call>
+        find_definition(symbol='ToolCallParser')
+        </tool_call>
+        """
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: raw,
+            modelID: "mlx-community/Qwen3-32B-4bit",
+            allowedFunctionNames: ["find_definition"]
+        )
+
+        let call = try XCTUnwrap(parsed.toolCalls.first)
+        XCTAssertEqual(call.functionName, "find_definition")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "symbol") as? String, "ToolCallParser")
+        XCTAssertEqual(parsed.cleanedContent?.trimmingCharacters(in: .whitespacesAndNewlines), "<think>\nI should use the provided tool.\n</think>")
     }
 
     func testToolCallWithNoArgumentsUsesEmptyObjectString() throws {
         let parsed = ToolCallParser.parseToolCalls(
-            rawOutput: #"<tool_call>{"name":"get_weather"}</tool_call>"#,
+            rawOutput: #"<tool_call>{"name":"explain_current_file"}</tool_call>"#,
             modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit"
         )
 
@@ -40,7 +89,7 @@ final class ToolCallParserTests: XCTestCase {
     }
 
     func testExplicitNullArgumentsFallBackToPlainText() {
-        let raw = #"<tool_call>{"name":"get_weather","arguments":null}</tool_call>"#
+        let raw = #"<tool_call>{"name":"find_definition","arguments":null}</tool_call>"#
         let parsed = ToolCallParser.parseToolCalls(
             rawOutput: raw,
             modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit"
@@ -51,7 +100,7 @@ final class ToolCallParserTests: XCTestCase {
     }
 
     func testMalformedToolCallJSONFallsBackToPlainText() {
-        let raw = #"<tool_call>{"name":"get_weather","arguments":</tool_call>"#
+        let raw = #"<tool_call>{"name":"find_definition","arguments":</tool_call>"#
         let parsed = ToolCallParser.parseToolCalls(
             rawOutput: raw,
             modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit"
@@ -61,8 +110,68 @@ final class ToolCallParserTests: XCTestCase {
         XCTAssertTrue(parsed.toolCalls.isEmpty)
     }
 
+    func testMalformedPythonStyleToolCallFallsBackToPlainText() {
+        let raw = #"<tool_call>find_definition("ToolCallParser")</tool_call>"#
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: raw,
+            modelID: "mlx-community/Qwen3-32B-4bit",
+            allowedFunctionNames: ["find_definition"]
+        )
+
+        XCTAssertEqual(parsed.cleanedContent, raw)
+        XCTAssertTrue(parsed.toolCalls.isEmpty)
+    }
+
+    func testDuplicatePythonStyleArgumentsFallBackToPlainText() {
+        let raw = #"<tool_call>find_definition(symbol="ToolCallParser", symbol="Other")</tool_call>"#
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: raw,
+            modelID: "mlx-community/Qwen3-32B-4bit",
+            allowedFunctionNames: ["find_definition"]
+        )
+
+        XCTAssertEqual(parsed.cleanedContent, raw)
+        XCTAssertTrue(parsed.toolCalls.isEmpty)
+    }
+
+    func testDuplicateJSONObjectArgumentsFallBackToPlainText() {
+        let raw = #"<tool_call>{"name":"find_definition","arguments":{"symbol":"ToolCallParser","symbol":"Other"}}</tool_call>"#
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: raw,
+            modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit",
+            allowedFunctionNames: ["find_definition"]
+        )
+
+        XCTAssertEqual(parsed.cleanedContent, raw)
+        XCTAssertTrue(parsed.toolCalls.isEmpty)
+    }
+
+    func testDuplicateJSONStringArgumentsFallBackToPlainText() {
+        let raw = #"<tool_call>{"name":"find_definition","arguments":"{\"symbol\":\"ToolCallParser\",\"symbol\":\"Other\"}"}</tool_call>"#
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: raw,
+            modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit",
+            allowedFunctionNames: ["find_definition"]
+        )
+
+        XCTAssertEqual(parsed.cleanedContent, raw)
+        XCTAssertTrue(parsed.toolCalls.isEmpty)
+    }
+
+    func testUnknownModelWithoutToolDelimiterDoesNotParsePythonStyleText() {
+        let raw = #"find_definition(symbol="ToolCallParser")"#
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: raw,
+            modelID: "mlx-community/Other-Instruct-7B-4bit",
+            allowedFunctionNames: ["find_definition"]
+        )
+
+        XCTAssertEqual(parsed.cleanedContent, raw)
+        XCTAssertTrue(parsed.toolCalls.isEmpty)
+    }
+
     func testNonObjectArgumentsFallBackToPlainText() {
-        let raw = #"<tool_call>{"name":"get_weather","arguments":["Vilnius"]}</tool_call>"#
+        let raw = #"<tool_call>{"name":"find_definition","arguments":["ToolCallParser"]}</tool_call>"#
         let parsed = ToolCallParser.parseToolCalls(
             rawOutput: raw,
             modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit"
@@ -74,7 +183,7 @@ final class ToolCallParserTests: XCTestCase {
 
     func testMixedProseAndToolCallKeepsCleanedContent() throws {
         let parsed = ToolCallParser.parseToolCalls(
-            rawOutput: #"I'll check that.<tool_call>{"name":"get_weather","arguments":{"city":"Vilnius"}}</tool_call>"#,
+            rawOutput: #"I'll check that.<tool_call>{"name":"find_definition","arguments":{"symbol":"ToolCallParser"}}</tool_call>"#,
             modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit"
         )
 
@@ -84,21 +193,33 @@ final class ToolCallParserTests: XCTestCase {
 
     func testLlamaParametersNormalizeToArgumentsString() throws {
         let parsed = ToolCallParser.parseToolCalls(
-            rawOutput: #"<|python_tag|>{"name":"get_weather","parameters":{"city":"Vilnius"}}<|eom_id|>"#,
+            rawOutput: #"<|python_tag|>{"name":"find_definition","parameters":{"symbol":"ToolCallParser"}}<|eom_id|>"#,
             modelID: "mlx-community/Llama-3.3-70B-Instruct-4bit"
         )
 
         let call = try XCTUnwrap(parsed.toolCalls.first)
-        XCTAssertEqual(call.functionName, "get_weather")
-        XCTAssertEqual(try argumentValue(call.arguments, key: "city") as? String, "Vilnius")
+        XCTAssertEqual(call.functionName, "find_definition")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "symbol") as? String, "ToolCallParser")
+    }
+
+    func testLlamaPythonStyleToolCall() throws {
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: #"<|python_tag|>find_definition(symbol="ToolCallParser")<|eom_id|>"#,
+            modelID: "mlx-community/Llama-3.3-70B-Instruct-4bit",
+            allowedFunctionNames: ["find_definition"]
+        )
+
+        let call = try XCTUnwrap(parsed.toolCalls.first)
+        XCTAssertEqual(call.functionName, "find_definition")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "symbol") as? String, "ToolCallParser")
     }
 
     func testUndeclaredFunctionFallsBackToPlainText() {
-        let raw = #"<tool_call>{"name":"delete_city","arguments":{"city":"Vilnius"}}</tool_call>"#
+        let raw = #"<tool_call>{"name":"delete_symbol","arguments":{"symbol":"ToolCallParser"}}</tool_call>"#
         let parsed = ToolCallParser.parseToolCalls(
             rawOutput: raw,
             modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit",
-            allowedFunctionNames: ["get_weather"]
+            allowedFunctionNames: ["find_definition"]
         )
 
         XCTAssertEqual(parsed.cleanedContent, raw)
@@ -111,12 +232,12 @@ final class ToolCallParserTests: XCTestCase {
                 "type": .string("function"),
                 "x_tool_extra": .string("must-not-reach-template"),
                 "function": .object([
-                    "name": .string("get_weather"),
-                    "description": .string("Get weather"),
+                    "name": .string("find_definition"),
+                    "description": .string("Find where a code symbol is defined"),
                     "parameters": .object([
                         "type": .string("object"),
                         "properties": .object([
-                            "city": .object(["type": .string("string")]),
+                            "symbol": .object(["type": .string("string")]),
                         ]),
                     ]),
                     "x_function_extra": .string("must-not-reach-template"),
@@ -129,8 +250,8 @@ final class ToolCallParserTests: XCTestCase {
         XCTAssertEqual(tool["type"] as? String, "function")
         XCTAssertNil(tool["x_tool_extra"])
         let function = try! XCTUnwrap(tool["function"] as? [String: Any])
-        XCTAssertEqual(function["name"] as? String, "get_weather")
-        XCTAssertEqual(function["description"] as? String, "Get weather")
+        XCTAssertEqual(function["name"] as? String, "find_definition")
+        XCTAssertEqual(function["description"] as? String, "Find where a code symbol is defined")
         XCTAssertNotNil(function["parameters"])
         XCTAssertNil(function["x_function_extra"])
     }

--- a/test/integration/tool_calling/README.md
+++ b/test/integration/tool_calling/README.md
@@ -27,10 +27,27 @@ the SPEC-015 SDK compatibility smoke. It asserts:
 
 - OpenAI Python SDK parses non-streaming `message.tool_calls[]`.
 - `finish_reason` is `tool_calls`.
-- `get_weather` arguments parse as JSON and contain `city: Vilnius`.
+- `find_definition` arguments parse as JSON and contain `symbol: ToolCallParser`.
 - Streaming emits `delta.tool_calls[]` and does not leak raw delimiters.
 - Unsupported v1 inputs return expected 400 codes for non-`auto`
   `tool_choice`, assistant `tool_calls`, and `tool` role messages.
 
 By default the JSON artifact is written to
 `artifacts/tool-calling-e2e-<timestamp>.json`. Secrets are not printed.
+
+## Model Compatibility
+
+Tool schemas are passed into the MLX chat template for any served model, but
+MacProvider only emits OpenAI `tool_calls[]` when the model output uses a
+recognized tool-call delimiter format:
+
+- Qwen-style `<tool_call>...</tool_call>` output, with either JSON tool-call
+  bodies or scalar Python-style keyword calls such as
+  `find_definition(symbol="ToolCallParser")`.
+- Llama 3.3-style `<|python_tag|>...<|eom_id|>` output, with either JSON
+  bodies or the same scalar Python-style keyword calls.
+
+Other HuggingFace MLX models may work if their chat template produces one of
+those raw formats. Models that answer in prose, or use a different tool-call
+syntax, safely fall back to normal assistant text instead of structured
+`tool_calls[]`.

--- a/test/integration/tool_calling/openai_tool_call_e2e.py
+++ b/test/integration/tool_calling/openai_tool_call_e2e.py
@@ -22,12 +22,12 @@ RAW_DELIMITERS = ("<tool_call>", "</tool_call>", "<|python_tag|>", "<|eom_id|>")
 TOOL = {
     "type": "function",
     "function": {
-        "name": "get_weather",
-        "description": "Get the current weather for a city",
+        "name": "find_definition",
+        "description": "Find where a code symbol is defined",
         "parameters": {
             "type": "object",
-            "properties": {"city": {"type": "string"}},
-            "required": ["city"],
+            "properties": {"symbol": {"type": "string"}},
+            "required": ["symbol"],
         },
     },
 }
@@ -36,8 +36,8 @@ MESSAGES = [
     {
         "role": "user",
         "content": (
-            "Use the get_weather tool to answer. Call get_weather with city "
-            "Vilnius and do not answer directly."
+            "Use the find_definition tool to answer. Call find_definition with "
+            "symbol ToolCallParser and do not answer directly."
         ),
     }
 ]
@@ -76,12 +76,12 @@ def model_dump(value: Any) -> dict[str, Any]:
 
 
 def assert_tool_call(call: Any) -> dict[str, Any]:
-    if call.function.name != "get_weather":
+    if call.function.name != "find_definition":
         raise AssertionError(f"unexpected function name: {call.function.name!r}")
     arguments = json.loads(call.function.arguments)
-    city = str(arguments.get("city", "")).lower()
-    if city != "vilnius":
-        raise AssertionError(f"expected city Vilnius, got arguments {arguments!r}")
+    symbol = str(arguments.get("symbol", ""))
+    if symbol != "ToolCallParser":
+        raise AssertionError(f"expected symbol ToolCallParser, got arguments {arguments!r}")
     return arguments
 
 
@@ -217,8 +217,8 @@ def run() -> dict[str, Any]:
                                 "id": "call_test",
                                 "type": "function",
                                 "function": {
-                                    "name": "get_weather",
-                                    "arguments": "{\"city\":\"Vilnius\"}",
+                                    "name": "find_definition",
+                                    "arguments": "{\"symbol\":\"ToolCallParser\"}",
                                 },
                             }
                         ],


### PR DESCRIPTION
## Summary

- Normalize Qwen Python-style tool calls such as `find_definition(symbol="ToolCallParser")` when they appear inside `<tool_call>...</tool_call>` delimiters.
- Keep malformed, positional, undeclared, or unsupported expressions on the existing plain-text fallback path.
- Switch the tool-calling e2e and demo from the weather fixture to a coding-domain `find_definition` tool.

## Root Cause

The public Qwen3 gateway e2e reached the provider successfully after PR #159, but the model emitted a Python-style call inside `<tool_call>` tags as assistant content. The provider parser only accepted JSON bodies inside those delimiters, so the response returned `finish_reason=stop` instead of OpenAI `tool_calls[]`.

## Validation

- `cd phase3-binary && swift test --filter ToolCallParserTests`
- `cd phase3-binary && swift test`
- `python3 -m py_compile test/integration/tool_calling/openai_tool_call_e2e.py examples/tool_calling_demo.py`
- `git diff --check`

## Not Tested

- Live public gateway e2e after this provider-side change. That requires deploying an updated provider binary.
