### PR TITLE
Stabilize cancellation usage relay test

### DIFF
--- a/phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift
@@ -54,7 +54,13 @@ final class InferenceRelayTests: XCTestCase {
         let end = try XCTUnwrap(frames.last { $0["type"] as? String == "inference_response_end" })
         XCTAssertEqual(end["request_id"] as? String, "req-cancel-usage")
         XCTAssertEqual(end["status"] as? String, "cancelled")
-        XCTAssertEqual(end["chunks_sent"] as? Int, 2)
+        let chunksSent = try XCTUnwrap(end["chunks_sent"] as? Int)
+        let responseChunks = frames.filter { $0["type"] as? String == "inference_response_chunk" }
+        XCTAssertEqual(chunksSent, responseChunks.count)
+        XCTAssertTrue(
+            [2, 3].contains(chunksSent),
+            "cancel may race with the fake runtime's already-queued second content chunk"
+        )
         let usage = try XCTUnwrap(end["usage"] as? [String: Any])
         XCTAssertEqual(usage["prompt_tokens"] as? Int, 7)
         XCTAssertEqual(usage["completion_tokens"] as? Int, 2)


### PR DESCRIPTION
## Summary
- Stabilizes `testCancelActiveStreamingRequestReportsUsage` against the CI-only cancellation scheduling race.
- Keeps cancelled usage assertions exact.
- Preserves the protocol delivery-count contract by asserting `chunks_sent` equals the number of recorded response chunk frames, then allows the two valid cancel-race outcomes `{2, 3}`.

## Root Cause
The relay reports `chunks_sent` as delivered `inference_response_chunk` frames. On macOS CI, cancellation can arrive after the fake runtime has queued the second content chunk but before the recorder drain has fully settled, so the terminal frame can legitimately report either 2 or 3 delivered chunks while usage remains exact.

## Audit
- Code auditor: APPROVE, 0 critical/high/medium/low.
- Security auditor: APPROVE, 0 critical/high/medium/low.
- Architect auditor: CLEAR, 0 critical/high/medium/low.

## Validation
- 30-run focused flake loop passed.
- `swift test --filter 'macprovider_cliTests.InferenceRelayTests'` passed: 6 tests.
- Full `phase3-binary` `swift test` passed: 554 tests, 7 skipped, 0 failures.
