### PR TITLE
fix(gateway): exclude bearerless-duplicate sessions from /v1/status capacity (#82 item 1)

### DIFF
--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -503,6 +503,14 @@ type statusModel struct {
 	SupportedModels []string `json:"supported_models,omitempty"`
 }
 
+// authStateBearerlessDuplicate is the wire value the coordinator emits for
+// SPEC-003 v0.8.3 FR-C9.4 bearer-less duplicate sessions on /poolz. The
+// authoritative const lives at phase4-coordinator/internal/pool/provider.go
+// `AuthBearerlessDuplicate`; the gateway cannot import that package, so the
+// value is mirrored here as a string literal. SPEC-002 v1.4.1 is the
+// normative contract — if these ever drift, fix SPEC-002 first.
+const authStateBearerlessDuplicate = "bearerless_duplicate"
+
 type poolzResponse struct {
 	Pool []struct {
 		ProviderID               string   `json:"provider_id"`
@@ -519,6 +527,14 @@ type poolzResponse struct {
 		OperatorIdentity         string   `json:"operator_identity"`
 		SupportedModels          []string `json:"supported_models,omitempty"`
 		PublishesSupportedModels bool     `json:"publishes_supported_models,omitempty"`
+		// SPEC-003 v0.8.3 FR-C9.4 auth_state — empty / bearer_validated /
+		// self_minted are routable; bearerless_duplicate is non-routable
+		// (admitted for /poolz visibility, excluded from buyer traffic +
+		// billing). The gateway mirrors pool.Provider.RoutingEligible() by
+		// dropping bearerless_duplicate entries from /v1/status capacity
+		// aggregation so the buyer-visible status doesn't promise capacity
+		// the coordinator will refuse to route.
+		AuthState string `json:"auth_state,omitempty"`
 	} `json:"pool"`
 	Summary struct {
 		TotalProviders int `json:"total_providers"`
@@ -587,6 +603,16 @@ func aggregateStatus(poolz poolzResponse, readyThreshold int, now time.Time) sta
 		Coordinator: coordinatorStatus{Status: "up", CheckedAt: now.Format(time.RFC3339)},
 	}
 	for _, p := range poolz.Pool {
+		// SPEC-003 v0.8.3 FR-C9.4 — bearerless duplicates are admitted to
+		// /poolz for operator visibility but are non-routable (excluded by
+		// pool.Provider.RoutingEligible). They MUST NOT contribute to the
+		// gateway's buyer-facing capacity counts: counting them would
+		// over-promise capacity that the coordinator will refuse to route,
+		// and would taint per-model availability (a model whose only
+		// "ready" entry is a bearerless duplicate would appear available).
+		if p.AuthState == authStateBearerlessDuplicate {
+			continue
+		}
 		out.Pool.TotalProviders++
 		switch p.State {
 		case "ready":
@@ -633,7 +659,16 @@ func aggregateStatus(poolz poolzResponse, readyThreshold int, now time.Time) sta
 		}
 		stats[p.ModelID] = st
 	}
-	if out.Pool.TotalProviders == 0 && poolz.Summary.TotalProviders > 0 {
+	// SPEC-002 v1.4.1 — the summary fallback only fires when the coordinator
+	// omitted the detailed `pool` array entirely (e.g. a redacted/summary-only
+	// response). It MUST NOT fire when `pool` rows ARE present but all have
+	// been excluded by the bearerless-duplicate gate above; otherwise the
+	// coordinator's summary (which includes bearerless rows in
+	// `total_providers`) would reintroduce excluded capacity on the buyer-
+	// facing surface. The condition is on `len(poolz.Pool)`, not on
+	// `out.Pool.TotalProviders`, so an all-bearerless pool collapses to no-
+	// capacity instead of falling through to the summary.
+	if len(poolz.Pool) == 0 && poolz.Summary.TotalProviders > 0 {
 		out.Pool.TotalProviders = poolz.Summary.TotalProviders
 		out.Pool.Ready = poolz.Summary.Ready
 	}

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -991,6 +991,164 @@ func TestAggregateStatusExcludesNonPublishingProviderFromUnion(t *testing.T) {
 	}
 }
 
+// SPEC-003 v0.8.3 FR-C9.4 — bearerless-duplicate sessions are admitted to
+// /poolz for operator visibility but are non-routable. The gateway's buyer-
+// facing /v1/status aggregation MUST exclude them so the headline "Ready"
+// count and per-model availability don't promise capacity the coordinator
+// will refuse to route. Tracking issue #82 item 1.
+func TestAggregateStatusExcludesBearerlessDuplicatesFromCapacity(t *testing.T) {
+	out := aggregateStatus(decodePoolz(t, `{
+		"pool":[
+			{"model_id":"llama","state":"ready","slots_free":2,"slots_total":2,"max_context_tokens":4096,"auth_state":"bearer_validated"},
+			{"model_id":"llama","state":"ready","slots_free":1,"slots_total":1,"max_context_tokens":4096,"auth_state":"bearerless_duplicate"},
+			{"model_id":"llama","state":"ready","slots_free":1,"slots_total":1,"max_context_tokens":4096,"auth_state":"self_minted"},
+			{"model_id":"llama","state":"ready","slots_free":1,"slots_total":1,"max_context_tokens":4096}
+		],
+		"summary":{"total_providers":4,"ready":3,"total_slots":5,"free_slots":5}
+	}`), 1, fixedNow())
+
+	if out.Pool.TotalProviders != 3 {
+		t.Fatalf("TotalProviders=%d, want 3 (bearerless duplicate excluded)", out.Pool.TotalProviders)
+	}
+	if out.Pool.Ready != 3 {
+		t.Fatalf("Pool.Ready=%d, want 3 (bearerless duplicate excluded)", out.Pool.Ready)
+	}
+	if len(out.Models) != 1 {
+		t.Fatalf("models=%+v, want one model entry", out.Models)
+	}
+	m := out.Models[0]
+	if m.ProviderCount != 3 {
+		t.Fatalf("model.ProviderCount=%d, want 3 (bearerless duplicate excluded)", m.ProviderCount)
+	}
+	if m.ReadyProviderCount != 3 {
+		t.Fatalf("model.ReadyProviderCount=%d, want 3 (bearerless duplicate excluded)", m.ReadyProviderCount)
+	}
+	if m.TotalSlots != 4 {
+		t.Fatalf("model.TotalSlots=%d, want 4 (1 from bearerless duplicate excluded)", m.TotalSlots)
+	}
+	if m.SlotsFree != 4 {
+		t.Fatalf("model.SlotsFree=%d, want 4 (1 from bearerless duplicate excluded)", m.SlotsFree)
+	}
+	if !m.Available || m.Availability != "available" {
+		t.Fatalf("model availability=%+v, want available", m)
+	}
+}
+
+// All-bearerless pool MUST collapse to no-ready capacity even when the
+// coordinator's summary echoes a non-zero total. The Ready=0 promise is the
+// load-bearing invariant — buyers MUST NOT see Available=true for a model
+// whose only sessions are non-routable bearerless duplicates.
+func TestAggregateStatusAllBearerlessPoolReportsNoCapacity(t *testing.T) {
+	out := aggregateStatus(decodePoolz(t, `{
+		"pool":[
+			{"model_id":"llama","state":"ready","slots_free":1,"slots_total":1,"max_context_tokens":4096,"auth_state":"bearerless_duplicate"}
+		],
+		"summary":{"total_providers":1,"ready":0,"total_slots":1,"free_slots":0}
+	}`), 1, fixedNow())
+
+	if out.Pool.Ready != 0 {
+		t.Fatalf("Pool.Ready=%d, want 0", out.Pool.Ready)
+	}
+	if out.Status != "idle" {
+		t.Fatalf("status=%q, want idle", out.Status)
+	}
+	if len(out.Models) != 0 {
+		t.Fatalf("models=%+v, want no model entries (bearerless skipped before model registration)", out.Models)
+	}
+}
+
+// Regression for the IMPL r1 MEDIUM finding: when /poolz returns pool rows
+// that are ALL bearerless_duplicate AND the coordinator's summary reports a
+// non-zero Ready, the old fallback (`out.Pool.TotalProviders == 0`)
+// reintroduced the excluded Ready capacity into the buyer-visible status.
+// The fix gates the fallback on `len(poolz.Pool) == 0` instead, so an
+// all-bearerless pool collapses to no capacity even if the coordinator's
+// summary is non-zero. (A non-zero coordinator summary.ready alongside an
+// all-bearerless pool is a misconfigured-coordinator shape, but the gateway
+// MUST NOT amplify it into a buyer-visible promise.)
+func TestAggregateStatusAllBearerlessPoolIgnoresSummaryFallback(t *testing.T) {
+	out := aggregateStatus(decodePoolz(t, `{
+		"pool":[
+			{"model_id":"llama","state":"ready","slots_free":2,"slots_total":2,"max_context_tokens":4096,"auth_state":"bearerless_duplicate"}
+		],
+		"summary":{"total_providers":3,"ready":2,"total_slots":4,"free_slots":2}
+	}`), 1, fixedNow())
+
+	if out.Pool.TotalProviders != 0 {
+		t.Fatalf("Pool.TotalProviders=%d, want 0 (summary fallback MUST NOT fire when pool rows are present)", out.Pool.TotalProviders)
+	}
+	if out.Pool.Ready != 0 {
+		t.Fatalf("Pool.Ready=%d, want 0 (summary fallback MUST NOT reintroduce excluded Ready)", out.Pool.Ready)
+	}
+	if out.Status != "idle" {
+		t.Fatalf("status=%q, want idle", out.Status)
+	}
+}
+
+// Summary-fallback positive case: a coordinator that returns ONLY a summary
+// (no pool rows) is still honored by the gateway — this preserves the
+// pre-existing behavior the fallback was added for. The condition is "no
+// detailed pool rows," not "no aggregated capacity after filtering."
+func TestAggregateStatusSummaryFallbackFiresOnlyWhenPoolIsEmpty(t *testing.T) {
+	out := aggregateStatus(decodePoolz(t, `{
+		"pool":[],
+		"summary":{"total_providers":2,"ready":2,"total_slots":4,"free_slots":3}
+	}`), 1, fixedNow())
+
+	if out.Pool.TotalProviders != 2 {
+		t.Fatalf("Pool.TotalProviders=%d, want 2 (summary fallback)", out.Pool.TotalProviders)
+	}
+	if out.Pool.Ready != 2 {
+		t.Fatalf("Pool.Ready=%d, want 2 (summary fallback)", out.Pool.Ready)
+	}
+}
+
+// SPEC-003 v0.8.3 enum coverage — pins per-value routability so future
+// changes (issue #82 item 2 will flip `mint_failed` semantics) MUST update
+// this test and SPEC-002 v1.4.1's aggregation rule together. Only
+// `bearerless_duplicate` is excluded today; everything else — including
+// empty (pre-v0.8.3 coordinator), `bearer_validated`, `self_minted`,
+// `mint_failed`, and unknown future values — aggregates normally.
+func TestAggregateStatusAuthStateRoutabilityCoverage(t *testing.T) {
+	cases := []struct {
+		name      string
+		authState string
+		wantReady int
+	}{
+		{name: "empty (pre-v0.8.3 coordinator)", authState: "", wantReady: 1},
+		{name: "bearer_validated", authState: "bearer_validated", wantReady: 1},
+		{name: "self_minted", authState: "self_minted", wantReady: 1},
+		{name: "mint_failed (currently routable; flips in #82 item 2)", authState: "mint_failed", wantReady: 1},
+		{name: "unknown future value (defensive default = aggregate)", authState: "future_value_xyz", wantReady: 1},
+		{name: "bearerless_duplicate (the only excluded value)", authState: "bearerless_duplicate", wantReady: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := fmt.Sprintf(`{
+				"pool":[
+					{"model_id":"llama","state":"ready","slots_free":1,"slots_total":1,"max_context_tokens":4096,"auth_state":%q}
+				],
+				"summary":{"total_providers":1,"ready":%d,"total_slots":1,"free_slots":1}
+			}`, tc.authState, tc.wantReady)
+			out := aggregateStatus(decodePoolz(t, payload), 1, fixedNow())
+			if out.Pool.Ready != tc.wantReady {
+				t.Fatalf("auth_state=%q: Pool.Ready=%d, want %d", tc.authState, out.Pool.Ready, tc.wantReady)
+			}
+		})
+	}
+}
+
+// Drift-prevention: the string literal in server.go MUST track SPEC-002
+// v1.4.1's normative enum value. If the SPEC ever renames
+// `bearerless_duplicate`, this test pins the gateway-side const so the
+// rename surfaces as a test failure before silent capacity over-promising.
+func TestAuthStateBearerlessDuplicateConstantMatchesSpec(t *testing.T) {
+	const want = "bearerless_duplicate"
+	if authStateBearerlessDuplicate != want {
+		t.Fatalf("authStateBearerlessDuplicate = %q, want %q (SPEC-002 v1.4.1 FR-O2 aggregation rule)", authStateBearerlessDuplicate, want)
+	}
+}
+
 func TestStatusCoordinatorUnreachableRemainsDown(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		return nil, errors.New("coordinator unavailable")

--- a/specs/AUDIT_PHASE5_GATEWAY_AUTH_STATE_IMPL_PROMPT.md
+++ b/specs/AUDIT_PHASE5_GATEWAY_AUTH_STATE_IMPL_PROMPT.md
@@ -1,0 +1,143 @@
+# Phase 5 Gateway `auth_state` IMPL Audit Prompt
+
+You are an IMPL auditor. Scope is the gateway-side `/poolz` decode +
+capacity aggregation change for issue #82 item 1 — NOT the SPEC-002 v1.4.1
+delta, NOT the rest of phase5-gateway.
+
+## Branch / commit
+- Branch: `fix/gateway-poolz-auth-state`
+- Worktree: `../macprovider-gateway-poolz-auth-state` (origin/main base: e816dff)
+- Files in scope (`git diff origin/main -- phase5-gateway/`):
+  - `phase5-gateway/internal/router/server.go`
+  - `phase5-gateway/internal/router/server_test.go`
+
+## What the change does (operator summary — not the audit answer)
+
+1. Adds `AuthState string \`json:"auth_state,omitempty"\`` to the inner
+   anonymous struct in `poolzResponse.Pool` (~line 506).
+2. In `aggregateStatus` (~line 581), the first thing the loop body does
+   is `if p.AuthState == "bearerless_duplicate" { continue }` — BEFORE
+   any counter is touched.
+3. Adds two new tests in `server_test.go`:
+   `TestAggregateStatusExcludesBearerlessDuplicatesFromCapacity` and
+   `TestAggregateStatusAllBearerlessPoolReportsNoCapacity`.
+
+## Authoritative source the IMPL must mirror
+
+- `phase4-coordinator/internal/pool/provider.go`
+  - `AuthState` const block defining the enum (~lines 64-91)
+  - `RoutingEligible()` (~line 214) — currently excludes ONLY
+    `AuthBearerlessDuplicate`; `AuthMintFailed` is intentionally NOT
+    excluded per SPEC-003 v0.8.4 rationale.
+- `phase4-coordinator/internal/ws/server.go` `providerPublishedReady`
+  (~line 2784) — coordinator's own `/poolz` summary computation; same
+  exclusion shape.
+- `specs/SPEC-002-coordinator.md` v1.4.1 (this branch) — the normative
+  contract the IMPL must honor.
+
+## Audit lenses (apply each independently — do not collapse)
+
+### Lens 1 — correctness vs SPEC
+- Does the IMPL exclusion match the new SPEC-002 v1.4.1 normative rule
+  (excludes `bearerless_duplicate`, includes everything else)?
+- Does the IMPL agree with the authoritative coordinator-side predicate
+  `pool.Provider.RoutingEligible()`?
+- The exclusion uses the string literal `"bearerless_duplicate"`. The
+  authoritative const is `pool.AuthBearerlessDuplicate` in
+  `phase4-coordinator/internal/pool/provider.go`. The gateway cannot
+  import `phase4-coordinator` internals. Is the string-literal duplication
+  acceptable? Is there a risk the value drifts from the const? If a
+  drift-prevention test is warranted, where would it live?
+- The decode field uses `json:"auth_state,omitempty"` matching the
+  coordinator's emission tag. Confirm pre-v0.8.3 coordinators (which omit
+  the field) decode to `""` and aggregate normally.
+
+### Lens 2 — placement of the early-`continue`
+- The `continue` is placed BEFORE `out.Pool.TotalProviders++` and BEFORE
+  the `switch p.State` block. This means a bearerless duplicate is
+  excluded from EVERY counter, including `TotalProviders`. Compare
+  against SPEC-002 v1.4.1 which only explicitly requires exclusion from
+  `Ready / ReadyProviderCount / slots / availability` — TotalProviders
+  isn't explicitly covered. Is the IMPL over-excluding? Could it be
+  argued that operators want bearerless rows visible in TotalProviders
+  as a "non-routable but present" count?
+- Does the same `continue` correctly skip per-model registration
+  (`models[p.ModelID]`, `supportedSets[p.ModelID]`, `stats[p.ModelID]`)?
+  Could a bearerless duplicate's `supported_models` array still leak
+  into the buyer-visible per-model union? Trace through the loop body
+  and confirm.
+
+### Lens 3 — summary-fallback edge case
+- The function has an existing fallback at
+  `if out.Pool.TotalProviders == 0 && poolz.Summary.TotalProviders > 0`
+  which copies `poolz.Summary.TotalProviders` and `poolz.Summary.Ready`
+  into the output. After this change, an all-bearerless pool yields
+  `out.Pool.TotalProviders == 0` and triggers the fallback. Trace what
+  the buyer sees in that case:
+  - `out.Pool.TotalProviders` becomes coordinator's `Summary.TotalProviders`
+    (which INCLUDES bearerless rows — see `phase4-coordinator/internal/ws/server.go` ~line 2682 `TotalProviders: len(providers)`).
+  - `out.Pool.Ready` becomes coordinator's `Summary.Ready` (which
+    EXCLUDES bearerless rows via `providerPublishedReady`).
+  Is this acceptable? Does the test `TestAggregateStatusAllBearerlessPoolReportsNoCapacity` cover it adequately?
+- Could an attacker / misconfigured coordinator construct a `/poolz`
+  response that exploits the fallback to inflate buyer-visible Ready?
+
+### Lens 4 — test adequacy
+- Are the two new tests sufficient? Specifically:
+  - Mixed-pool test asserts TotalProviders=3, Ready=3, slot totals,
+    per-model availability. Is there an off-by-one risk it would miss?
+  - All-bearerless test asserts no model entries appear. Verify the
+    summary-fallback in that test doesn't accidentally populate Ready.
+- Missing-coverage check:
+  - Empty `auth_state` (pre-v0.8.3 coordinator) — does any test prove
+    it still counts as routable?
+  - `auth_state == "mint_failed"` — does any test pin its current
+    routable treatment so item 2 can flip it explicitly?
+  - `auth_state` with an unknown future value — does the IMPL silently
+    aggregate it (defensive default) or skip it?
+
+### Lens 5 — broader gateway surface
+- Are there OTHER places in `phase5-gateway/` that decode `/poolz` or
+  consume per-provider entries from the coordinator? `grep` for `poolz`,
+  `auth_state`, `bearerless`, and any place that constructs capacity
+  counts. If a sibling code path exists, has it been updated too?
+
+### Lens 6 — money-path side effects
+- This is buyer-facing capacity. Could the change reduce capacity below
+  what a billing/usage path expects? Check `coordinatorBuyerURL` callers
+  and any health-gated routing that consults `/v1/status`. If a
+  bearerless duplicate currently "counts" in some money-path predicate,
+  removing it from `/v1/status` aggregation could shift behavior
+  elsewhere. Trace the consumers.
+
+## Output format
+
+Return findings in this exact structure:
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+
+HIGH (N):
+  H1. ...
+
+MEDIUM (N):
+  M1. ...
+
+LOW (N):
+  L1. ...
+
+QUESTIONS (N):
+  Q1. ...
+```
+
+Use the CRITICAL/HIGH/MEDIUM/LOW severity scale (not MAJOR/MINOR).
+
+Write the audit report to `specs/PHASE5_GATEWAY_AUTH_STATE_IMPL_audit.md`
+with a round suffix on follow-ups (e.g.
+`specs/PHASE5_GATEWAY_AUTH_STATE_IMPL_r2_audit.md`).
+
+If 0 CRITICAL and 0 HIGH and 0 MEDIUM, end the report with the line:
+`VERDICT: READY TO MERGE phase5-gateway auth_state IMPL`

--- a/specs/AUDIT_PHASE5_GATEWAY_AUTH_STATE_IMPL_R2_PROMPT.md
+++ b/specs/AUDIT_PHASE5_GATEWAY_AUTH_STATE_IMPL_R2_PROMPT.md
@@ -1,0 +1,78 @@
+# Phase 5 Gateway `auth_state` IMPL Audit Prompt — Round 2 (closure verification)
+
+You are an IMPL auditor running ROUND 2 on the gateway-side `/poolz`
+decode + capacity aggregation change. Round 1 produced
+`specs/PHASE5_GATEWAY_AUTH_STATE_IMPL_audit.md` with 0 CRITICAL, 0 HIGH,
+1 MEDIUM, 2 LOW, 1 QUESTION. The author has fixed the findings. Your job
+is **closure verification**, not a fresh audit:
+
+1. For each round-1 finding (M1, L1, L2, Q1), state PASS / PARTIAL /
+   FAIL based on the current branch state.
+2. Re-audit fresh — surface any NEW issue the fix introduces.
+
+## Branch / commit
+- Branch: `fix/gateway-poolz-auth-state`
+- Worktree: `../macprovider-gateway-poolz-auth-state`
+- Read: `git diff origin/main -- phase5-gateway/`
+
+## Round-1 findings to verify closure on
+
+- **M1.** Summary fallback can reintroduce excluded ready capacity
+  after all detailed rows are skipped.
+  - Fix expected: gate the fallback on `len(poolz.Pool) == 0` (no
+    detailed rows present) instead of
+    `out.Pool.TotalProviders == 0` (no rows after filtering). Add a
+    regression test with all-bearerless pool + non-zero
+    `summary.ready`.
+- **L1.** `mint_failed` and unknown future auth states not pinned by
+  tests.
+  - Fix expected: table test covering empty / `bearer_validated` /
+    `self_minted` / `mint_failed` / unknown / `bearerless_duplicate`.
+- **L2.** Gateway mirrors coordinator enum with an unguarded string
+  literal.
+  - Fix expected: extract a named const + a drift-prevention test
+    pinning the const value to the SPEC-002 v1.4.1 normative literal.
+- **Q1.** Should `Pool.TotalProviders` be a routable count or a
+  present-provider count?
+  - Resolution expected: documented in SPEC-002 v1.4.1 round-2
+    rewrite (this is a SPEC question; IMPL audit verifies IMPL
+    matches whatever the SPEC says).
+
+## Audit lenses for fresh issues (apply briefly)
+
+- Does the new fallback gate (`len(poolz.Pool) == 0`) handle ALL the
+  pre-existing scenarios the old gate handled? (Coordinator returns
+  only summary block; coordinator returns empty pool array.)
+- Does the new table test actually exercise the IMPL — e.g. is it
+  asserting Ready correctly per case?
+- Is the drift-prevention test on the const useful, or is it tautology
+  (asserting the const equals the same literal)?
+
+## Output format
+
+```
+CLOSURE on round-1 findings:
+  M1: PASS|PARTIAL|FAIL — <one line>
+  L1: ...
+  L2: ...
+  Q1: ...
+
+NEW FINDINGS (round 2):
+CRITICAL (N):
+  ...
+HIGH (N):
+  ...
+MEDIUM (N):
+  ...
+LOW (N):
+  ...
+QUESTIONS (N):
+  ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW severity. Write the round-2 report to
+`specs/PHASE5_GATEWAY_AUTH_STATE_IMPL_r2_audit.md`.
+
+If all round-1 findings closed AND zero NEW CRITICAL/HIGH/MEDIUM, end
+the report with:
+`VERDICT: READY TO MERGE phase5-gateway auth_state IMPL`

--- a/specs/AUDIT_SPEC_002_v1_4_1_PROMPT.md
+++ b/specs/AUDIT_SPEC_002_v1_4_1_PROMPT.md
@@ -1,0 +1,124 @@
+# SPEC-002 v1.4.1 Audit Prompt — additive `/poolz` `auth_state` delta
+
+You are a SPEC auditor. Scope is the SPEC-002 v1.4.1 additive delta only —
+NOT the rest of SPEC-002.
+
+## Branch / commit
+- Branch: `fix/gateway-poolz-auth-state`
+- Worktree: `../macprovider-gateway-poolz-auth-state` (origin/main base: e816dff)
+- File in scope (read the diff `git diff origin/main -- specs/SPEC-002-coordinator.md`):
+  - `specs/SPEC-002-coordinator.md`
+
+## What this delta does (operator summary — not the audit answer)
+
+Tracking issue #82 item 1. The coordinator's `pool.Provider.AuthState`
+has been emitted on `/poolz` since SPEC-003 v0.8.3 (enum
+`bearer_validated`, `self_minted`, `bearerless_duplicate`, `mint_failed`),
+but SPEC-002 never documented it as part of the `/poolz` contract surface.
+
+The v1.4.1 delta:
+1. Adds `auth_state` to the FR-O2 `/poolz` provider-row example + a
+   new descriptive paragraph.
+2. Adds a normative aggregation rule: downstream `/poolz` consumers (the
+   SPEC-006 gateway `/v1/status`) MUST exclude
+   `auth_state == "bearerless_duplicate"` rows from capacity counts
+   (Ready, per-model ReadyProviderCount, slot totals, model availability).
+3. Bumps version 1.4.0 → 1.4.1 (additive; pre-v1.4.1 consumers that
+   ignore unknown fields keep working).
+
+## Sources of truth to cross-check
+
+- `phase4-coordinator/internal/pool/provider.go` — `AuthState` const block
+  (~lines 64-91) and `RoutingEligible()` (~line 214).
+- `phase4-coordinator/internal/ws/server.go` — `/poolz` handler
+  (~line 2705 onward), `providerPublishedReady` (~line 2784).
+- `specs/SPEC-003-*.md` — FR-C9.1 / FR-C9.4 normative source for the
+  enum semantics.
+- `phase5-gateway/internal/router/server.go` — the downstream consumer
+  whose `aggregateStatus` the new normative rule binds.
+
+## Audit lenses (apply each independently — do not collapse)
+
+### Lens 1 — contract correctness
+- Does the v1.4.1 enum match what the coordinator actually emits today?
+- Is the `omitempty` semantics ("absent/empty preserves pre-v0.8.3
+  behavior") consistent with `pool.Provider.AuthState` zero-value
+  being treated as routable by `RoutingEligible()`?
+- Is the cross-reference to SPEC-003 (v0.8.3 for the enum, v0.8.4
+  for `mint_failed`) accurate against the current spec text?
+
+### Lens 2 — aggregation-rule precision
+- The new rule excludes only `bearerless_duplicate`. SPEC-003 v0.8.4
+  added `mint_failed` with the rationale that admitting it as fully
+  routable would amplify a DB-error storm into a routing DoS. But
+  `pool.Provider.RoutingEligible()` excludes only
+  `AuthBearerlessDuplicate`. Is the SPEC self-consistent in deferring
+  `mint_failed` aggregation policy to issue #82 item 2 rather than
+  bundling it here?
+- Does the rule cover the right counters? (Ready, ReadyProviderCount,
+  slot totals, availability — vs. TotalProviders, which the IMPL also
+  excludes.) Is the SPEC silent on TotalProviders intentional or a gap?
+- The gateway's existing summary-fallback path triggers when the per-
+  provider loop produces zero entries
+  (`out.Pool.TotalProviders == 0 && poolz.Summary.TotalProviders > 0`).
+  After v1.4.1, an all-bearerless pool would land in this fallback
+  using coordinator-supplied `Summary.TotalProviders` (which includes
+  bearerless) and `Summary.Ready` (which already excludes bearerless
+  per coordinator-side `providerPublishedReady`). Does the SPEC need
+  to address this edge case explicitly?
+
+### Lens 3 — version policy
+- Is v1.4.1 (patch bump) the right semver step for an additive `/poolz`
+  field PLUS a new normative aggregation rule? Or should this be v1.5
+  given the second change has behavioural consequences for the gateway?
+- Are pre-v1.4.1 consumers actually safe? The gateway already decodes
+  `/poolz` without `auth_state` today — they get the over-promise bug
+  but no parse error. Is "additive" the right characterization?
+
+### Lens 4 — completeness and cross-spec consistency
+- Anything in the FR-O2 prose or the `/poolz` example block that
+  contradicts the new paragraph?
+- Are downstream specs that reference `/poolz` (SPEC-006 gateway,
+  SPEC-015 receipt-pubkey absorption) affected and missing a
+  cross-reference? Should v1.4.1 add a pointer in SPEC-006?
+- Is the change-log entry style consistent with v1.4.0 and v1.4
+  preceding entries?
+
+### Lens 5 — operator visibility
+- Does the SPEC distinguish clearly enough between "auth_state is
+  emitted for operator visibility (all values)" and "auth_state ==
+  bearerless_duplicate triggers buyer-facing capacity exclusion"?
+  Could an operator reading only v1.4.1 misunderstand bearerless
+  rows being hidden from operators?
+
+## Output format
+
+Return findings in this exact structure:
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+
+HIGH (N):
+  H1. ...
+
+MEDIUM (N):
+  M1. ...
+
+LOW (N):
+  L1. ...
+
+QUESTIONS (N):
+  Q1. ...
+```
+
+Use the CRITICAL/HIGH/MEDIUM/LOW severity scale (not MAJOR/MINOR).
+
+Write the audit report to `specs/SPEC-002-v1-4-1-audit.md` with the round
+number in the filename if this is a follow-up round (e.g.
+`specs/SPEC-002-v1-4-1-r2-audit.md`).
+
+If 0 CRITICAL and 0 HIGH and 0 MEDIUM, end the report with the line:
+`VERDICT: READY TO LOCK v1.4.1`

--- a/specs/AUDIT_SPEC_002_v1_4_1_R2_PROMPT.md
+++ b/specs/AUDIT_SPEC_002_v1_4_1_R2_PROMPT.md
@@ -1,0 +1,89 @@
+# SPEC-002 v1.4.1 Audit Prompt — Round 2 (closure verification)
+
+You are a SPEC auditor running ROUND 2 on the SPEC-002 v1.4.1 additive
+delta. Round 1 produced `specs/SPEC-002-v1-4-1-audit.md` with 0 CRITICAL,
+0 HIGH, 3 MEDIUM, 2 LOW, 2 QUESTIONS. The author has fixed the findings.
+Your job is **closure verification**, not a fresh audit:
+
+1. For each round-1 finding (M1, M2, M3, L1, L2, Q1, Q2), state PASS /
+   PARTIAL / FAIL based on the current `specs/SPEC-002-coordinator.md`
+   text on the branch.
+2. Re-audit fresh — surface any NEW issue the v1.4.1 delta introduces
+   that round 1 did not flag (especially: regressions caused by the
+   fixes, ambiguities introduced by the new wording).
+
+## Branch / commit
+- Branch: `fix/gateway-poolz-auth-state`
+- Worktree: `../macprovider-gateway-poolz-auth-state`
+- Read: `git diff origin/main -- specs/SPEC-002-coordinator.md`
+
+## Round-1 findings to verify closure on
+
+- **M1.** `mint_failed` documented as `/poolz` row enum even though
+  current WS flow never publishes such a row.
+  - Fix expected: state that `mint_failed` is a defined/reserved
+    AuthState not currently emitted on registered `/poolz` rows, OR
+    change the coordinator to publish an observable row.
+- **M2.** Aggregation rule omitted provider-count counters that the
+  gateway already excludes.
+  - Fix expected: extend exclusion rule to top-level
+    `Pool.TotalProviders` and per-model `ProviderCount`, or define
+    them as raw operator-visible counts and align the IMPL.
+- **M3.** Summary-fallback ambiguity — coordinator `summary` could
+  reintroduce excluded rows.
+  - Fix expected: explicit rule that auth-state-aware consumers MUST
+    NOT use coordinator `summary` to repopulate excluded counters
+    when `/poolz.pool` rows are present.
+- **L1.** SPEC-003 dependency line misattributed full enum to v0.8.3.
+  - Fix expected: split provenance — base enum from v0.8.3,
+    `mint_failed` from v0.8.4.
+- **L2.** SPEC-006 stale for new `/v1/status` aggregation invariant.
+  - Fix expected: a pointer / deferred follow-up.
+- **Q1.** What does `Pool.TotalProviders` on `/v1/status` mean?
+  - Resolution expected: explicit decision (buyer = routable-eligible;
+    operator = raw).
+- **Q2.** Is `mint_failed` operator-visible on `/poolz`?
+  - Resolution expected: explicit answer about current behavior.
+
+## Audit lenses for fresh issues (apply briefly)
+
+- Consistency: does the new aggregation rule and the summary-fallback
+  prohibition agree with the FR-O2 example and the `auth_state`
+  paragraph below it?
+- Wording: is "buyer-facing" / "operator-facing" usage tight enough
+  that an implementer reading only v1.4.1 knows which surface a given
+  counter belongs to?
+- Cross-version: did the change-log entry style still match v1.4.0
+  and v1.4 conventions?
+
+## Output format
+
+```
+CLOSURE on round-1 findings:
+  M1: PASS|PARTIAL|FAIL — <one line>
+  M2: ...
+  M3: ...
+  L1: ...
+  L2: ...
+  Q1: ...
+  Q2: ...
+
+NEW FINDINGS (round 2):
+CRITICAL (N):
+  ...
+HIGH (N):
+  ...
+MEDIUM (N):
+  ...
+LOW (N):
+  ...
+QUESTIONS (N):
+  ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW severity. Write the round-2 report to
+`specs/SPEC-002-v1-4-1-r2-audit.md`.
+
+If all round-1 findings closed (PASS or PARTIAL with explicit
+justification) AND zero NEW CRITICAL/HIGH/MEDIUM, end the report with:
+`VERDICT: READY TO LOCK v1.4.1`

--- a/specs/PHASE5_GATEWAY_AUTH_STATE_IMPL_audit.md
+++ b/specs/PHASE5_GATEWAY_AUTH_STATE_IMPL_audit.md
@@ -1,0 +1,28 @@
+CRITICAL (0):
+  (none)
+
+HIGH (0):
+  (none)
+
+MEDIUM (1):
+  M1. Summary fallback can reintroduce excluded ready capacity after all detailed rows are skipped
+      Evidence: phase5-gateway/internal/router/server.go:597
+      Evidence: phase5-gateway/internal/router/server.go:605
+      Evidence: phase5-gateway/internal/router/server.go:654
+      Evidence: phase5-gateway/internal/router/server.go:656
+      Evidence: phase5-gateway/internal/router/server_test.go:1046
+      Fix:     Apply the summary fallback only when the coordinator omitted detailed pool rows, e.g. `len(poolz.Pool) == 0`, and add a regression case with only `auth_state:"bearerless_duplicate"` rows plus `summary.ready > 0`.
+
+LOW (2):
+  L1. `mint_failed` and unknown future auth states are not pinned by tests
+      Evidence: phase5-gateway/internal/router/server.go:605
+      Evidence: phase5-gateway/internal/router/server_test.go:1002
+      Fix:     Add a table test proving empty, `bearer_validated`, `self_minted`, `mint_failed`, and an unknown string aggregate normally while only `bearerless_duplicate` is skipped.
+
+  L2. Gateway mirrors the coordinator enum with an unguarded string literal
+      Evidence: phase5-gateway/internal/router/server.go:605
+      Evidence: phase4-coordinator/internal/pool/provider.go:80
+      Fix:     Keep the local literal or local gateway const because `phase4-coordinator/internal` cannot be imported, but add a repo-level contract test or static check comparing it to `pool.AuthBearerlessDuplicate` / SPEC-002 text.
+
+QUESTIONS (1):
+  Q1. Should buyer-facing `pool.total_providers` be a routable-capacity count or a present-provider count? The loop excludes bearerless duplicates before `TotalProviders++`, but the fallback restores coordinator `summary.total_providers` for an all-bearerless pool; SPEC-002 v1.4.1 explicitly names Ready / slots / availability but not `TotalProviders`.

--- a/specs/PHASE5_GATEWAY_AUTH_STATE_IMPL_r2_audit.md
+++ b/specs/PHASE5_GATEWAY_AUTH_STATE_IMPL_r2_audit.md
@@ -1,0 +1,30 @@
+CLOSURE on round-1 findings:
+  M1: PASS — `aggregateStatus` now gates summary fallback on `len(poolz.Pool) == 0`, and `TestAggregateStatusAllBearerlessPoolIgnoresSummaryFallback` covers an all-`bearerless_duplicate` pool with non-zero `summary.ready`.
+  L1: PASS — `TestAggregateStatusAuthStateRoutabilityCoverage` exercises the implementation for empty, `bearer_validated`, `self_minted`, `mint_failed`, unknown future value, and `bearerless_duplicate`, asserting `Pool.Ready` per case.
+  L2: PASS — the gateway now uses named const `authStateBearerlessDuplicate`, and `TestAuthStateBearerlessDuplicateConstantMatchesSpec` pins it to the SPEC-002 v1.4.1 normative literal.
+  Q1: PASS — SPEC-002 v1.4.1 now resolves buyer-facing `total_providers` as a routable-eligible count, and the implementation matches by skipping `bearerless_duplicate` before incrementing `Pool.TotalProviders`.
+
+NEW FINDINGS (round 2):
+CRITICAL (0):
+  (none)
+
+HIGH (0):
+  (none)
+
+MEDIUM (0):
+  (none)
+
+LOW (0):
+  (none)
+
+QUESTIONS (0):
+  (none)
+
+Verification:
+  - Reviewed `git diff origin/main -- phase5-gateway/`.
+  - Reviewed SPEC-002 v1.4.1 auth_state aggregation language.
+  - Ran `go test ./internal/router` in `phase5-gateway`: PASS.
+  - Ran `go test ./...` in `phase5-gateway`: PASS.
+  - Ran `git diff --check -- phase5-gateway/internal/router/server.go phase5-gateway/internal/router/server_test.go specs/SPEC-002-coordinator.md`: PASS.
+
+VERDICT: READY TO MERGE phase5-gateway auth_state IMPL

--- a/specs/SPEC-002-coordinator.md
+++ b/specs/SPEC-002-coordinator.md
@@ -1,7 +1,78 @@
 # SPEC-002 — Phase 4 Coordinator: Mac Provider Request Router
 
-**Version:** 1.4.0 (2026-06-26, issue #92 streaming-commit predicate documented in FR-P11a; SPEC-015 v0.1.3 /poolz receipt pubkey absorption from 2026-06-22)
-**Depends on:** SPEC-001 v1.4 (Phase 3 binary wire protocol, locked; v1.4 adds installer custom-model selection + `models browse` + fit guard on top of the v1.3 absorbed in §7.8/§7.9)
+**Version:** 1.4.1 (2026-06-26, SPEC-003 v0.8.3 FR-C9.4 `/poolz` `auth_state` field absorbed; gateway aggregation rule for non-routable sessions added — issue #82 item 1)
+**Depends on:** SPEC-001 v1.4 (Phase 3 binary wire protocol, locked; v1.4 adds installer custom-model selection + `models browse` + fit guard on top of the v1.3 absorbed in §7.8/§7.9); SPEC-003 FR-C9.4 composed contract — base AuthState enum (`bearer_validated`, `self_minted`, `bearerless_duplicate`) introduced in v0.8.3; `mint_failed` reserved value added in v0.8.4.
+
+**Change log v1.4.1 (2026-06-26, additive — issue #82 item 1):**
+- FR-O2 `/poolz` provider row gains the optional `auth_state` string
+  field (`omitempty`). Enum: `bearer_validated`, `self_minted`,
+  `bearerless_duplicate` (SPEC-003 v0.8.3 FR-C9.4), plus the
+  `mint_failed` value reserved by SPEC-003 v0.8.4. Absent / empty
+  preserves pre-v0.8.3 behavior (routable). The field is
+  documentational on the coordinator side (`pool.Provider.AuthState`
+  has been emitted via the embedded `pool.Provider` struct since
+  SPEC-003 v0.8.3) and is now normatively part of the SPEC-002
+  `/poolz` contract surface. **Observability scope:** today only
+  `bearer_validated`, `self_minted`, `bearerless_duplicate`, and the
+  empty pre-v0.8.3 value actually appear on registered `/poolz` rows.
+  `mint_failed` is a reserved enum value — the coordinator returns it
+  internally from `resolveProvisionalToken` on transient DB-write
+  failure but immediately closes the WebSocket with `CloseInvalidToken`
+  before the session is registered (`phase4-coordinator/internal/ws/server.go`
+  `handleHello` / `handleAuthRequest` close paths), so it does NOT
+  currently surface as a `/poolz` row. Issue #82 item 2 may publish
+  an observable non-routable `mint_failed` row in the future — when
+  it does, the aggregation rule below MUST be re-evaluated.
+- Adds normative aggregation rule for downstream `/poolz` consumers
+  (SPEC-006 gateway `/v1/status`): provider rows with
+  `auth_state == "bearerless_duplicate"` MUST be excluded from ALL
+  buyer-facing capacity counters derived from the detailed pool
+  array, including top-level `Pool.TotalProviders`, top-level
+  `Pool.Ready`, per-model `ProviderCount`, per-model
+  `ReadyProviderCount`, slot totals, model availability, and
+  per-model `supported_models` unions. This mirrors
+  `pool.Provider.RoutingEligible()` on the coordinator side — a
+  bearerless duplicate is admitted to `/poolz` for operator
+  visibility but is non-routable; counting it would over-promise
+  capacity the coordinator will refuse to route. Other `auth_state`
+  values (empty, `bearer_validated`, `self_minted`, and currently
+  `mint_failed` — which never appears on registered rows today) are
+  aggregated normally; the eventual `mint_failed`-becomes-observable
+  decision is intentionally deferred to issue #82 item 2 and is NOT
+  in scope for v1.4.1.
+- **Buyer-vs-operator counter separation (Q1 resolution).** On
+  buyer-facing surfaces derived from `/poolz` (the SPEC-006 gateway
+  `/v1/status`), `total_providers` is a routable-eligible count, not
+  a raw session count — it excludes `bearerless_duplicate` rows by
+  the aggregation rule above. The operator-facing `/poolz` body
+  itself still surfaces ALL admitted sessions in its `pool` array
+  (including bearerless duplicates) and in its top-level `summary`;
+  operator visibility is preserved precisely because operators must
+  be able to see WHY a session is non-routable. Consumers that need
+  raw operator-visible session counts MUST read the `/poolz`
+  `summary` block (which is coordinator-emitted and includes
+  bearerless rows in `total_providers`); consumers that surface
+  buyer-facing counts MUST apply the aggregation rule.
+- **Summary-fallback prohibition (covers the all-bearerless edge
+  case).** Auth-state-aware consumers that derive buyer-facing
+  counts from `/poolz` MUST NOT use the coordinator-supplied
+  `summary` block as a fallback to repopulate counts that have been
+  excluded by the aggregation rule when the detailed `pool` array
+  was present. The coordinator's `summary.total_providers` is
+  `len(providers)` on the coordinator side (includes bearerless);
+  using it as a fallback after filtering would reintroduce excluded
+  capacity. The gateway IMPL gates its summary fallback on
+  `len(poolz.Pool) == 0` (no detailed rows at all), not on
+  `out.Pool.TotalProviders == 0` after filtering.
+- Wire-additive change. Pre-v1.4.1 consumers that ignore unknown
+  fields continue to work unchanged; the only behaviour change is
+  the gateway aggregation exclusion. No SPEC-001 wire change.
+- **Cross-spec follow-up (deferred).** SPEC-006 (buyer-facing gateway)
+  currently describes `/v1/status` without the `auth_state`
+  exclusion. A SPEC-006 amendment carrying a pointer to this rule is
+  the right place to surface the invariant for implementers reading
+  the gateway spec alone; that amendment is out of scope for
+  v1.4.1 and lands as part of issue #82 closure.
 
 **Change log v1.4.0 (2026-06-26):**
 - **v1.4.0 (2026-06-26, issue #92):** FR-P11a streaming-failover paragraph
@@ -1368,6 +1439,7 @@ Response:
       "connected_at": "2026-05-27T12:00:00Z",
       "binary_version": "0.1.0",
       "endpoint_url": "https://m4.streamvc.live",
+      "auth_state": "bearer_validated",
       "receipt_pubkey": "<base64-32-byte-ed25519>" | null,
       "receipt_pubkey_prev": null | {
         "pubkey": "<base64-32-byte-ed25519>",
@@ -1396,7 +1468,54 @@ Response:
 }
 ```
 
-The `summary` block is the SPEC-006 v0.3 gateway input for `/v1/status`; the detailed `pool` array is operator-only and MUST NOT be exposed to buyers by the gateway.
+The `summary` block is the raw coordinator/operator summary; per the SPEC-002 v1.4.1 aggregation rule below, the SPEC-006 gateway derives buyer-facing `/v1/status` counters from the detailed `pool` array (applying the `auth_state == "bearerless_duplicate"` exclusion) when those rows are present, and MAY fall back to `summary` only when the coordinator omitted the detailed `pool` array entirely. The detailed `pool` array is operator-only and MUST NOT be exposed to buyers by the gateway.
+
+SPEC-002 v1.4.1 documents the optional `auth_state` field shown above
+(SPEC-003 FR-C9.4 absorption — base enum from v0.8.3, `mint_failed`
+reserved by v0.8.4, emitted by the coordinator via embedded
+`pool.Provider.AuthState`). Enum values are `bearer_validated`
+(connect carried a matching Bearer header), `self_minted` (FR-C9.1
+fresh provisional mint, cleartext returned in the ack frame),
+`bearerless_duplicate` (tokenless connect for a provider_id that
+already has an unrevoked token row — admitted for operator visibility
+but non-routable per FR-C9.4), and the reserved `mint_failed` value
+(FR-C9.1 mint attempted but the DB write failed with a non-constraint
+error; today the connect is closed with `CloseInvalidToken` before
+session registration so this value does NOT currently surface on
+registered `/poolz` rows — issue #82 item 2 may change that). The
+field is `omitempty`; absent / empty preserves pre-v0.8.3 behavior
+(routable, billable).
+
+**Aggregation rule for buyer-facing consumers (normative).**
+Downstream `/poolz` consumers that derive buyer-facing capacity
+(SPEC-006 gateway `/v1/status`) MUST exclude rows with `auth_state ==
+"bearerless_duplicate"` from EVERY counter they expose:
+- top-level `Pool.TotalProviders` and top-level `Pool.Ready`,
+- per-model `ProviderCount`, per-model `ReadyProviderCount`,
+- per-model slot totals (`TotalSlots`, `SlotsFree`),
+- per-model availability flags,
+- per-model `supported_models` unions.
+Counting bearerless rows on the buyer surface would over-promise
+capacity the coordinator will refuse to route.
+
+Operator-facing `/poolz` output is not subject to this rule: the raw
+`pool` array still surfaces ALL admitted sessions (including
+bearerless duplicates), and the coordinator-emitted `summary` block
+still counts them in `total_providers` — operator visibility into
+WHY a session is non-routable depends on it. Buyer-facing aggregators
+applying the rule above MUST NOT fall back to the coordinator
+`summary` block to repopulate counters that have been excluded; the
+summary includes bearerless rows in `total_providers` (it is
+`len(providers)` on the coordinator side), so using it as a fallback
+after filtering would silently reintroduce the excluded capacity.
+The gateway implementation lives at
+`phase5-gateway/internal/router/server.go` `aggregateStatus`; its
+summary fallback gates on `len(poolz.Pool) == 0`, not on
+`out.Pool.TotalProviders == 0` after filtering.
+
+SPEC-006 (buyer-facing gateway) currently describes `/v1/status`
+without this exclusion — a SPEC-006 amendment carrying the pointer
+to this rule is deferred to issue #82 closure.
 
 SPEC-015 v0.1.3 adds the two receipt fields shown above as the SPEC-002
 v1.4 absorption. `receipt_pubkey` is `null` when the provider did not

--- a/specs/SPEC-002-v1-4-1-audit.md
+++ b/specs/SPEC-002-v1-4-1-audit.md
@@ -1,0 +1,29 @@
+CRITICAL (0):
+
+HIGH (0):
+
+MEDIUM (3):
+  M1. `mint_failed` is documented as a `/poolz` row enum even though current WS flow never publishes such a row
+      Evidence: specs/SPEC-002-coordinator.md:1434; phase4-coordinator/internal/ws/server.go:667; phase4-coordinator/internal/ws/server.go:713; phase4-coordinator/internal/ws/server.go:968
+      Fix:     Either state that `mint_failed` is a defined/reserved AuthState not currently emitted on registered `/poolz` rows, or change the coordinator to publish an observable non-routable row and define its aggregation policy.
+
+  M2. The aggregation rule omits provider-count counters that the gateway already excludes
+      Evidence: specs/SPEC-002-coordinator.md:1438; phase5-gateway/internal/router/server.go:605; phase5-gateway/internal/router/server.go:608; phase5-gateway/internal/router/server.go:624; specs/SPEC-006-buyer-api.md:1763
+      Fix:     Add top-level `Pool.TotalProviders` and per-model `ProviderCount` to the `bearerless_duplicate` exclusion rule if they are buyer-facing eligible-provider counts, or explicitly define them as raw pool counts and align the gateway implementation.
+
+  M3. The all-bearerless summary fallback remains ambiguous and can reintroduce excluded rows into buyer-visible totals
+      Evidence: specs/SPEC-002-coordinator.md:1440; phase5-gateway/internal/router/server.go:654; phase5-gateway/internal/router/server.go:655; phase5-gateway/internal/router/server_test.go:1037
+      Fix:     Specify that auth-state-aware consumers MUST NOT use coordinator `summary` fallback to repopulate excluded provider counters when `/poolz.pool` rows are present, or explicitly define top-level totals as raw operator-visible counts.
+
+LOW (2):
+  L1. The SPEC-003 dependency line misattributes the full enum provenance to v0.8.3
+      Evidence: specs/SPEC-002-coordinator.md:4; specs/SPEC-003-open-onboarding.md:8; specs/SPEC-003-open-onboarding.md:20; specs/SPEC-003-open-onboarding.md:597
+      Fix:     Reference the current SPEC-003 FR-C9.4 composed contract and say the base AuthState values came from the v0.8.3 line while `mint_failed` was added by v0.8.4.
+
+  L2. SPEC-006 remains stale for the new `/v1/status` aggregation invariant
+      Evidence: specs/SPEC-002-coordinator.md:1438; specs/SPEC-006-buyer-api.md:1284; specs/SPEC-006-buyer-api.md:1288; specs/SPEC-006-buyer-api.md:1763
+      Fix:     Add a SPEC-006 pointer or follow-up amendment so implementers reading the gateway spec alone see the `auth_state == "bearerless_duplicate"` exclusion rule.
+
+QUESTIONS (2):
+  Q1. Should `Pool.TotalProviders` on `/v1/status` intentionally mean buyer-routable eligible providers, matching the current gateway implementation, or raw coordinator-visible sessions?
+  Q2. Is `mint_failed` intended to become operator-visible in `/poolz`, or is it only a fail-closed internal AuthState marker returned before the session is registered?

--- a/specs/SPEC-002-v1-4-1-r2-audit.md
+++ b/specs/SPEC-002-v1-4-1-r2-audit.md
@@ -1,0 +1,29 @@
+CLOSURE on round-1 findings:
+  M1: PASS — `mint_failed` is now explicitly reserved/currently non-observable on registered `/poolz` rows, with close-before-registration behavior documented.
+  M2: PASS — The exclusion rule now covers top-level `Pool.TotalProviders`, top-level `Pool.Ready`, per-model `ProviderCount`, `ReadyProviderCount`, slot totals, availability, and supported-model unions.
+  M3: PASS — Auth-state-aware buyer-facing consumers are now explicitly forbidden from using coordinator `summary` fallback to repopulate excluded counters when detailed `pool` rows were present.
+  L1: PASS — SPEC-003 provenance is split between the v0.8.3 base enum and the v0.8.4 reserved `mint_failed` value.
+  L2: PASS — The spec now carries an explicit deferred SPEC-006 amendment pointer for the `/v1/status` aggregation invariant.
+  Q1: PASS — The spec now decides buyer-facing `/v1/status` `total_providers` is routable-eligible, while operator-facing `/poolz` `summary.total_providers` remains raw coordinator-visible session count.
+  Q2: PASS — The spec now answers that `mint_failed` is not currently operator-visible on registered `/poolz` rows.
+
+NEW FINDINGS (round 2):
+CRITICAL (0):
+  None.
+
+HIGH (0):
+  None.
+
+MEDIUM (0):
+  None.
+
+LOW (1):
+  L-R2-1. Stale adjacent wording can still imply `summary` is the primary SPEC-006 gateway input.
+      Evidence: `specs/SPEC-002-coordinator.md` still says "The `summary` block is the SPEC-006 v0.3 gateway input for `/v1/status`" immediately before the v1.4.1 rule, while the new rule requires buyer-facing aggregators to derive eligible counters from detailed `pool` rows when present and forbids summary fallback from repopulating excluded counters.
+      Impact: Low. The new normative text below resolves the behavior, so implementers reading the full v1.4.1 section get the right rule. Tightening the older sentence would reduce scan-time confusion.
+      Suggested fix: Change the older sentence to say `summary` remains the raw coordinator/operator summary and may only serve gateway fallback behavior when detailed `pool` rows are absent.
+
+QUESTIONS (0):
+  None.
+
+VERDICT: READY TO LOCK v1.4.1


### PR DESCRIPTION
## Summary

Gateway `/poolz` aggregation has been silently including SPEC-003 v0.8.3 FR-C9.4 bearer-less duplicate sessions in buyer-facing capacity counts. Those sessions are admitted to `/poolz` for operator visibility but are non-routable per `pool.Provider.RoutingEligible()`, so the gateway was over-promising capacity the coordinator will refuse to route.

Closes issue #82 item 1. (Items 2/3/4 remain open in #82.)

## Changes

**Gateway IMPL** — `phase5-gateway/internal/router/`
- Decode `auth_state` on each `/poolz` row.
- Skip rows where `AuthState == "bearerless_duplicate"` before any counter is touched.
- Fix the summary-fallback condition: gates on `len(poolz.Pool) == 0` (no detailed rows present) instead of `out.Pool.TotalProviders == 0` after filtering. Without this, an all-bearerless pool would smuggle excluded Ready back through the coordinator-supplied summary block (whose `total_providers` includes bearerless rows).
- Extract `authStateBearerlessDuplicate` const with drift-prevention test.

**Tests added** — `server_test.go`
- Mixed-pool exclusion (`TestAggregateStatusExcludesBearerlessDuplicatesFromCapacity`)
- All-bearerless collapse (`TestAggregateStatusAllBearerlessPoolReportsNoCapacity`)
- All-bearerless + non-zero `summary.ready` regression (`TestAggregateStatusAllBearerlessPoolIgnoresSummaryFallback`)
- Summary-fallback positive case (`TestAggregateStatusSummaryFallbackFiresOnlyWhenPoolIsEmpty`)
- Per-enum routability table covering empty / `bearer_validated` / `self_minted` / `mint_failed` / unknown / `bearerless_duplicate` (`TestAggregateStatusAuthStateRoutabilityCoverage`)
- Const-vs-SPEC drift (`TestAuthStateBearerlessDuplicateConstantMatchesSpec`)

**SPEC** — `specs/SPEC-002-coordinator.md`
- Bump v1.4.0 → v1.4.1 (additive).
- FR-O2 `/poolz` row gains optional `auth_state` field (`omitempty`).
- Normative aggregation rule: `bearerless_duplicate` excluded from EVERY buyer-facing counter (TotalProviders, Ready, per-model ProviderCount/ReadyProviderCount, slots, availability, supported_models unions).
- Summary-fallback prohibition spelled out for auth-state-aware consumers.
- Q1 resolved: buyer-facing `total_providers` is routable-eligible; operator-facing `/poolz` summary remains raw.
- Q2 resolved: `mint_failed` is a reserved enum value but is NOT currently emitted on registered `/poolz` rows (coordinator closes connection before registration).
- SPEC-006 amendment deferred to #82 closure.

## Codex audit loop (per repo discipline)

SPEC v1.4.1 audits ([prompt r1](specs/AUDIT_SPEC_002_v1_4_1_PROMPT.md), [prompt r2](specs/AUDIT_SPEC_002_v1_4_1_R2_PROMPT.md)):
- r1: 0 CRITICAL / 0 HIGH / 3 MEDIUM / 2 LOW / 2 QUESTIONS — [report](specs/SPEC-002-v1-4-1-audit.md)
- r2: 7/7 round-1 findings PASS, 0 C/H/M — **VERDICT: READY TO LOCK v1.4.1** — [report](specs/SPEC-002-v1-4-1-r2-audit.md)

IMPL audits ([prompt r1](specs/AUDIT_PHASE5_GATEWAY_AUTH_STATE_IMPL_PROMPT.md), [prompt r2](specs/AUDIT_PHASE5_GATEWAY_AUTH_STATE_IMPL_R2_PROMPT.md)):
- r1: 0 CRITICAL / 0 HIGH / 1 MEDIUM / 2 LOW / 1 QUESTION — [report](specs/PHASE5_GATEWAY_AUTH_STATE_IMPL_audit.md)
- r2: 4/4 round-1 findings PASS, 0 C/H/M — **VERDICT: READY TO MERGE** — [report](specs/PHASE5_GATEWAY_AUTH_STATE_IMPL_r2_audit.md)

## Test plan

- [x] `cd phase5-gateway && go build ./...`
- [x] `cd phase5-gateway && go test ./...` — all green
- [ ] Pearl smoke: `/v1/status` against a coordinator with a bearerless duplicate session shows Ready count excluding that session

## Out of scope (tracked in #82)
- Item 2: `AuthMintFailed` enum publishing + aggregation policy
- Item 3: `coordinator-cli pre-flip-audit` subcommand
- Item 4: Explorer `auth_state` exposure

🤖 Generated with [Claude Code](https://claude.com/claude-code)