### PR TITLE
refactor(buyer): extract shared forwardWithFailover core (M2-1e / #94 / ARCH-1+CODE-1 RESOLVED)

### DIFF
--- a/audits/2026-06-10/REMAINING_WORK.md
+++ b/audits/2026-06-10/REMAINING_WORK.md
@@ -4,18 +4,9 @@ _Forward-looking punch list from the 2026-06-10 audit verification pass. Items i
 
 **Sweep update 2026-06-22:** five items graduated to `RESOLVED` based on live evidence (`audits/2026-06-22/CLUSTER_HANDOFF.md` §1 production probe + Pearl journald/systemd verification + branch-protection API write): **ARCH-1** + **CODE-1** (PR [#91](https://github.com/Augustas11/macprovider/pull/91) M2-1c + PR [#93](https://github.com/Augustas11/macprovider/pull/93) M2-1d close-out merged); **XSEC-1** (live tokenless WS rejection at `coordinator.streamvc.live`); **DEVE-7** (Pearl `macprovider-monitor.service` runs as `User=macprovider`, no root-yaml regex); operator-pending checklist items **M1-4** (`nginx -T` confirms `limit_req_zone` live) and **M3-4** (`phase3-binary (swift test)` added to required status checks on `main`). **M3-2 / SECU-4**: env-file architecture deployed and verified, but runtime cutover proof (gateway → coordinator `/internal/*` calls using `service_token`) is gated on real buyer traffic returning — currently blocked by the air5 production incident triaged in §"New issues surfaced (2026-06-22)" below.
 
+**Sweep update 2026-06-26:** **ARCH-1** + **CODE-1** promoted from `RESOLVED_DIFFERENTLY` to `RESOLVED` and their per-finding entries removed per the doc contract (RESOLVED items do not appear). M2-1e (issue #94, PR — fix/m2-1e-forward-with-failover-core) extracts the shared `forwardWithFailover` core that the architect's named close-out called for, on top of M2-1c (PR #91) + M2-1d (PR #93). The three sequence helpers (`forwardStreamSequence`, `forwardWSNonStreamSequence`, `forwardHTTPSequence`) are now thin wrappers that build per-transport callbacks; the failover state machine — dispatch → committed early-exit → success → failoverCandidate → shouldRetry → advanceToNextProvider — lives in exactly one place. The FOUR audit-flagged INTENTIONAL per-transport differences (HTTP per-attempt timeout, WS-non-streaming failoverEligible+retryable=false fast-fail, streaming committed early-exit, and the M2-1e-discovered WS-non-streaming queue-full retry-budget bypass) remain flagged in the callbacks, not flattened. `forward_loop_test.go` 11 row-sequence scenarios byte-identical to PR #91 baseline; `go test ./internal/buyer -race -count=5` green in 10.5s.
+
 ## Severity-ordered punch list
-
-### [High] ARCH-1 — handleChatCompletions god-function with three diverging copies of failover state machine
-
-- **Status:** `RESOLVED_DIFFERENTLY` (flipped 2026-06-22)
-- **Recalibrated severity:** Medium → closed
-- **Detail:** **Evidence** PR #36 (27559ae) fixed the two confirmed divergences (queue-full→StateBusy in the streaming path; explicitRetries++ unified inside `advanceToNextProvider`). PR #48 (8f18f5a, M2-1a) extracted `advanceToNextProvider` helper. PR #61 (a2a1063, M2-1b) introduced `transportResult` + 3 classifiers at `buyer/transport_result.go`. PR [#91](https://github.com/Augustas11/macprovider/pull/91) (3d5f209, M2-1c) collapsed the three transport loops into three sequence helpers (`forwardStreamSequence`, `forwardWSNonStreamSequence`, `forwardHTTPSequence`) on `*Server`, each driven by `transportResult` flags + `*forwardState`. PR [#93](https://github.com/Augustas11/macprovider/pull/93) (966f6df, M2-1d) closed the shared-state bypass at the WS queue-full path — commit message tagged "ARCH-1 / CODE-1 close-out". Post-merge architect verification documented in memory [post-merge-verification-caught-overclaim](../../.claude/projects/-Users-augstar-macprovider-poc/memory/post-merge-verification-caught-overclaim.md). **Shape change vs original audit sketch** Audit asked for one `forwardWithFailover`; M2-1c landed three transport-typed helpers because success/error/SSE rendering paths are genuinely different. The audit's underlying intent — "every retry-semantics edit touches exactly one place per transport, not three near-duplicate inline loop bodies" — is met. **Original citation** Audit cited `buyer/server.go:840-1350` and three loops at 1056-1153, 1154-1245, 1246-1349.
-
-### [High] CODE-1 — Drift across three copies of failover state machine (merged with ARCH-1)
-
-- **Status:** `RESOLVED_DIFFERENTLY` (flipped 2026-06-22, merged with ARCH-1)
-- **Detail:** See ARCH-1 above. PR [#91](https://github.com/Augustas11/macprovider/pull/91) + PR [#93](https://github.com/Augustas11/macprovider/pull/93) jointly closed the structural deduplication; the drift correctness fixes had shipped earlier in PR #36.
 
 ### [High] DEVE-2 — The 3am story — single Gmail channel co-hosted on VPS, no external check
 
@@ -95,7 +86,7 @@ Tasks that did not reach `RESOLVED` (each maps to one or more findings above; th
 | M2-3 | `PARTIAL` | SetMaxOpenConns(1) on coordinator stores |
 | QW-5 | `PARTIAL` | SetMaxOpenConns(1) on coordinator stores |
 | M1-6 | `PARTIAL` | Deploy-gate hardening |
-| M2-1 | `RESOLVED_DIFFERENTLY` (2026-06-22) | M2-1c (PR #91) + M2-1d (PR #93) landed; ARCH-1 / CODE-1 close-out commit message + post-merge architect verification. |
+| M2-1 | `RESOLVED` (2026-06-26) | M2-1c (PR #91) + M2-1d (PR #93) + M2-1e (issue #94) landed; shared `forwardWithFailover` core extracted; ARCH-1 / CODE-1 RESOLVED. |
 | M3-9 | `PARTIAL` | Gateway server.go file split (Phase 1) |
 | M1-1 | `RESOLVED` (2026-06-22) | Live in production — tokenless WS rejected with `invalid_token` at `coordinator.streamvc.live`. |
 | M1-7 | `CODE_SHIPPED_OPERATOR_PENDING` | Bump modernc.org/sqlite |

--- a/phase4-coordinator/internal/buyer/forward_with_failover.go
+++ b/phase4-coordinator/internal/buyer/forward_with_failover.go
@@ -1,0 +1,364 @@
+package buyer
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/google/uuid"
+)
+
+// forwardWithFailover is the shared failover state machine for the three
+// transport sequences (HTTP / SSE streaming / WS-tunneled non-streaming).
+// M2-1e (issue #94) extraction — the architect's named close-out for
+// ARCH-1 / CODE-1 on top of the M2-1c three-helper landing.
+//
+// The core owns the decision tree: dispatch → classify → branch on
+// transportResult flags (committed / success / failoverEligible / retryable
+// / terminal) → failoverCandidate → advanceToNextProvider → loop.
+//
+// The FOUR INTENTIONAL per-transport divergences flagged by the
+// 2026-06-10 audit (3 named on PR #93, +1 caught by the M2-1e cap=1
+// test sweep) live in the `tx` callbacks, NOT flattened into the
+// core:
+//
+//  1. HTTP per-attempt context.WithTimeout(...) — lives inside the HTTP
+//     dispatch callback; never visible at this level for other transports.
+//  2. WS-non-streaming `failoverEligible` carries `retryable=false` in the
+//     classifier; the WS-non-streaming `onFailoverMiss` returns
+//     handled=true (fast-fail + 502 rendered). Streaming carries
+//     `retryable=true`; its `onFailoverMiss` returns handled=false (fall
+//     through to shouldRetry).
+//  3. Streaming committed early-exit (pre-first-chunk vs post-first-chunk
+//     semantics) — `renderCommitted` callback fires only on the streaming
+//     path; the other two leave it nil.
+//  4. WS-non-streaming queue-full bypasses the shouldRetry budget gate
+//     (always advances when a candidate exists) — `skipRetryBudgetCheck`
+//     callback returns true for wsForwardQueueFull. Streaming and HTTP
+//     never set the callback so the gate fires normally. Preserves the
+//     M2-1d-baseline behaviour pinned by forward_loop_test scenario
+//     TestM2_1D_RowSequence_WSNonStreamingQueueFullThroughAdvance.
+//
+// Money-path invariant: attempt_n numbering + logAttempt row sequence MUST
+// stay byte-identical to the PR #91 baseline pinned by
+// forward_loop_test.go (11 row-sequence scenarios). The core implements
+// the same mutation order as the prior inline branches:
+// `excluded[routeKey]++ → faultedRoutes[routeKey]++ → MarkState (if
+// markBusy) → failoverCandidate → state.provider = next (on hit)` or
+// `shouldRetry → logAttempt → advanceToNextProvider →
+// excluded[routeKey]++`. The advance helper continues to be the single
+// owner of explicitRetries++ / faultedProviders++.
+//
+// The returned `shouldFallThroughToHTTP` is the WS-non-streaming-only
+// signal that the loop's "advance picked a non-WS provider" path fired;
+// the caller (handleChatCompletions) drives the HTTP fallback loop on
+// `state.provider` when this returns true. For streaming and HTTP
+// callers the return is always false (their callback bundles' afterHop
+// callbacks return false).
+func (s *Server) forwardWithFailover(
+	w http.ResponseWriter,
+	r *http.Request,
+	req chatRequest,
+	requestID, originalRequestID string,
+	startedAt time.Time,
+	state *forwardState,
+	excluded map[string]struct{},
+	rec *billingRecorder,
+	tx transportCallbacks,
+) (shouldFallThroughToHTTP bool) {
+	failoverAttempted := false
+	for {
+		// Dispatch — per-transport. The callback runs one attempt and
+		// returns the classified result. HTTP's callback also owns its
+		// per-attempt context.WithTimeout setup and the cancelAttempt
+		// cleanup on EVERY exit path (success, terminal, retry-advance).
+		dispatched, ok := tx.dispatch(w, r, req, requestID, originalRequestID, startedAt, state, rec)
+		if !ok {
+			// Dispatch reported a terminal pre-classification error
+			// (dispatchBodyForProvider failure, request construction
+			// failure, etc.). The callback already rendered the error
+			// response and the request_log row; we just return.
+			return false
+		}
+		tr := dispatched.tr
+
+		// Committed early-exit (streaming only — see invariant 3 above).
+		// Streaming's callback handles both wsForwardProviderDisconnected
+		// Committed and wsForwardCancelled (with the shouldLogAttempt
+		// gating on cancelled). HTTP / WS-non-streaming leave this nil.
+		if tr.committed && tx.renderCommitted != nil {
+			if tx.renderCommitted(w, r, dispatched, state) {
+				return false
+			}
+		}
+
+		// Terminal short-circuits before the failover/retry tree —
+		// WS-non-streaming's classify returns Cancelled / Failed /
+		// Unavailable here without going through the rest of the tree.
+		// HTTP doesn't classify those into transportResult kinds; its
+		// terminal path is the shouldRetry-exhausted branch below.
+		// Streaming covers cancelled via tr.committed above.
+		if tx.handleNonRetryableTerminal != nil {
+			if handled := tx.handleNonRetryableTerminal(w, dispatched, state); handled {
+				return false
+			}
+		}
+
+		// Success — per-transport rendering. HTTP writes body + headers;
+		// streaming does logAttempt + stickyStore-if-WS; WS-non-streaming
+		// does logAttempt + stickyStore. Each callback returns whether
+		// the loop is done (always true for success today, but the
+		// signature lets future success-with-continue cases plug in
+		// without revisiting the core).
+		if dispatched.success {
+			tx.renderSuccess(w, r, req, dispatched, state)
+			return false
+		}
+
+		// Mark fault state — shared across all transports. The mutation
+		// order matches the pre-refactor inline blocks exactly:
+		// excluded → faultedRoutes → (markBusy MarkState if set).
+		excluded[routeKey(state.provider)] = struct{}{}
+		state.faultedRoutes[routeKey(state.provider)] = struct{}{}
+		if tr.markBusy {
+			s.pool.MarkState(state.provider.ProviderID, state.provider.AssignedID, pool.StateBusy)
+		}
+
+		// Failover branch — the unified failover state machine. The
+		// failoverCandidate call + state.provider mutation that used to
+		// be inlined in each helper now lives here exactly once. The
+		// "what to do on miss" divergence (fast-fail vs fall-through-to-
+		// retry) is the onFailoverMiss callback's call: WS-non-streaming
+		// returns handled=true (the callback rendered the 502 + logged
+		// fast_fail), streaming returns handled=false (fall through to
+		// shouldRetry below). HTTP never sets failoverEligible so this
+		// branch is dead code for it; its callback may leave the
+		// failover callbacks nil.
+		if tr.failoverEligible && tx.onFailoverHit != nil && tx.onFailoverMiss != nil {
+			if !failoverAttempted && !hasPinnedRoute(r.Header) {
+				next, hit := s.failoverCandidate(uuid.NewString(), req, r.Header, state.provider, excluded)
+				if hit {
+					tx.onFailoverHit(originalRequestID, requestID, dispatched, state, next)
+					failoverAttempted = true
+					state.provider = next
+					if tx.afterFailoverHit != nil {
+						if fallThrough := tx.afterFailoverHit(state); fallThrough {
+							return true
+						}
+					}
+					continue
+				}
+			}
+			if handled := tx.onFailoverMiss(w, r, dispatched, state); handled {
+				return false
+			}
+		}
+
+		// Retry budget — shared shouldRetry gate. On exhaustion the
+		// per-transport renderRetryExhausted callback writes the final
+		// error response and logs the attempt row with the
+		// transport-specific message.
+		//
+		// One transport opts OUT of this gate: WS-non-streaming's
+		// queue-full branch goes straight to advance without consulting
+		// shouldRetry — that bypass is the M2-1d-preserved behaviour the
+		// byte-identical contract pins via forward_loop_test scenario
+		// TestM2_1D_RowSequence_WSNonStreamingQueueFullThroughAdvance.
+		// The callback returns true to skip the gate for that branch
+		// only; other transports + other branches leave the callback
+		// nil so the gate fires as usual.
+		if tx.skipRetryBudgetCheck == nil || !tx.skipRetryBudgetCheck(dispatched) {
+			if !s.shouldRetry(r, startedAt, state.explicitRetries, state.faultedProviders, tr.status, tr.err) {
+				tx.renderRetryExhausted(w, dispatched, state)
+				return false
+			}
+		}
+
+		// Per-retry log + advance — the streaming/WS paths call
+		// logAttempt before advancing; HTTP calls logProviderRow with a
+		// transport-specific message. The advance call is shared and
+		// owns explicitRetries++ + faultedProviders++ + state.provider
+		// = next (NOT the failover same-attempt re-route mutation
+		// above).
+		tx.logRetryAttempt(dispatched, state)
+		nextRouteID, ok := s.advanceToNextProvider(w, r, req, state, excluded, rec)
+		if !ok {
+			return false
+		}
+		excluded[routeKey(state.provider)] = struct{}{}
+
+		// afterAdvance — WS-non-streaming returns true (caller falls
+		// through to the HTTP loop on state.provider) when the new
+		// provider is not WS-tunneled. Streaming + HTTP return false
+		// here; streaming's callback additionally emits the
+		// logRoutingDecision row that the HTTP path ALSO emits but the
+		// WS-non-streaming path does NOT. That asymmetry is preserved
+		// by leaving the routing-log call in the callback.
+		if tx.afterAdvance != nil {
+			if fallThrough := tx.afterAdvance(state, nextRouteID); fallThrough {
+				return true
+			}
+		}
+	}
+}
+
+// transportCallbacks bundles the per-transport divergence points the
+// forwardWithFailover core defers to. Each helper (HTTP, streaming, WS-
+// non-streaming) constructs one of these and passes it to the core. The
+// shape isolates the FOUR audit-flagged INTENTIONAL differences (the
+// three named on PR #93 plus the M2-1e-discovered queue-full retry-
+// budget bypass; see the `forwardWithFailover` doc block above) so they
+// remain visibly per-transport in the callback bundles rather than
+// flattened into the shared decision tree.
+type transportCallbacks struct {
+	// dispatch runs one provider attempt. Returns the dispatched payload
+	// (carries the classified transportResult plus per-transport extras
+	// like nativeResult for streaming) and ok=true on classification
+	// success. Returns ok=false ONLY when the callback rendered a
+	// terminal pre-classification error itself (e.g. dispatchBodyFor-
+	// Provider failure, HTTP request-construction failure); the core
+	// just returns in that case.
+	//
+	// HTTP-specific: the callback sets up context.WithTimeout against
+	// r.Context() and calls cancelAttempt on every exit path. Streaming
+	// / WS use r.Context() directly.
+	dispatch func(
+		w http.ResponseWriter,
+		r *http.Request,
+		req chatRequest,
+		requestID, originalRequestID string,
+		startedAt time.Time,
+		state *forwardState,
+		rec *billingRecorder,
+	) (dispatched dispatchedAttempt, ok bool)
+
+	// renderCommitted handles the streaming-only committed-path early
+	// return (post-first-chunk disconnect, cancelled). Nil for HTTP /
+	// WS-non-streaming. Returns true when handled (the core returns).
+	renderCommitted func(
+		w http.ResponseWriter,
+		r *http.Request,
+		dispatched dispatchedAttempt,
+		state *forwardState,
+	) (handled bool)
+
+	// handleNonRetryableTerminal handles the WS-non-streaming-only
+	// short-circuit on Cancelled / Failed / Unavailable. Nil for HTTP /
+	// streaming. Returns true when handled.
+	handleNonRetryableTerminal func(
+		w http.ResponseWriter,
+		dispatched dispatchedAttempt,
+		state *forwardState,
+	) (handled bool)
+
+	// renderSuccess runs the 200-success render. HTTP writes the body
+	// and copies receipt headers; streaming + WS log the attempt and
+	// stickyStore. The core's `dispatched.success` field is set by the
+	// per-transport dispatch callback to gate this.
+	renderSuccess func(
+		w http.ResponseWriter,
+		r *http.Request,
+		req chatRequest,
+		dispatched dispatchedAttempt,
+		state *forwardState,
+	)
+
+	// onFailoverHit runs after the core picks a failover candidate and
+	// is about to mutate state.provider. WS paths log the
+	// logWSDeadMidRequest "failover" event; HTTP leaves this nil. The
+	// state.provider mutation is performed by the CORE, not the
+	// callback — keeps the same-attempt-re-route policy in one place.
+	onFailoverHit func(
+		originalRequestID, requestID string,
+		dispatched dispatchedAttempt,
+		state *forwardState,
+		next pool.Provider,
+	)
+
+	// afterFailoverHit runs immediately after the core's state.provider
+	// = next on a hit. WS-non-streaming returns true when the new
+	// provider is not WS (signals fallthrough to HTTP). Streaming
+	// returns false. Nil for HTTP.
+	afterFailoverHit func(state *forwardState) (fallThrough bool)
+
+	// onFailoverMiss runs when failoverEligible fires but no candidate
+	// is available. WS-non-streaming returns handled=true (renders 502
+	// + logs fast_fail). Streaming returns handled=false (falls through
+	// to shouldRetry in the core). HTTP leaves this nil (never reached
+	// — HTTP doesn't set failoverEligible).
+	onFailoverMiss func(
+		w http.ResponseWriter,
+		r *http.Request,
+		dispatched dispatchedAttempt,
+		state *forwardState,
+	) (handled bool)
+
+	// skipRetryBudgetCheck returns true when the core should bypass the
+	// shouldRetry gate for this dispatched attempt and proceed directly
+	// to advanceToNextProvider. WS-non-streaming sets this for
+	// wsForwardQueueFull to preserve the M2-1d-baseline bypass; other
+	// transports leave it nil. Optional.
+	skipRetryBudgetCheck func(dispatched dispatchedAttempt) bool
+
+	// renderRetryExhausted is the shouldRetry-returns-false render.
+	// Each transport has its own error envelope: HTTP disambiguates
+	// timeout vs error, streaming uses writeStreamForwardError, WS-non-
+	// streaming uses writeError with the WS-specific message.
+	renderRetryExhausted func(
+		w http.ResponseWriter,
+		dispatched dispatchedAttempt,
+		state *forwardState,
+	)
+
+	// logRetryAttempt logs the per-retry row before advanceToNextProvider.
+	// HTTP uses logProviderRow with a custom message; streaming + WS use
+	// logAttempt with the classifier-populated attempt fields.
+	logRetryAttempt func(
+		dispatched dispatchedAttempt,
+		state *forwardState,
+	)
+
+	// afterAdvance runs after a successful advanceToNextProvider call.
+	// HTTP + streaming emit logRoutingDecision and return false.
+	// WS-non-streaming inspects state.provider.IsWSTunneled() and
+	// returns true when the new provider is NOT WS (signals
+	// fallthrough). Optional — the core skips it when nil (all current
+	// transports supply one, but the design preserves the option).
+	afterAdvance func(state *forwardState, nextRouteID string) (fallThrough bool)
+}
+
+// dispatchedAttempt is the per-transport dispatch result the callbacks
+// pass to the core's decision branches. Carrying the native
+// wsForwardResult preserves the streaming committed-path's need to
+// dispatch logWSDeadMidRequest on the precise sub-kind
+// (wsForwardProviderDisconnectedCommitted vs wsForwardCancelled), which
+// transportResult flags alone don't disambiguate.
+type dispatchedAttempt struct {
+	// tr is the classifier output (status, attempt, retryable,
+	// failoverEligible, markBusy, committed, cancelled, err). The core
+	// branches on these.
+	tr transportResult
+
+	// nativeResult is the wsForwardResult kind for streaming + WS
+	// dispatches; unset for HTTP. Callbacks that need to dispatch on
+	// the precise kind (logWSDeadMidRequest "stream_terminal" vs
+	// "failover" vs "fast_fail"; writeStreamForwardError's
+	// status-keyed table) read this directly.
+	nativeResult wsForwardResult
+
+	// success is the per-transport "this attempt was a 200" verdict —
+	// set by the dispatch callback because the HTTP path detects it
+	// via resp.StatusCode == 200 (and runs token extraction + body
+	// read inside dispatch), while streaming / WS detect it via
+	// nativeResult == wsForwardComplete. Centralising the flag at
+	// dispatch keeps the core's success-branch shape trivial.
+	success bool
+
+	// extra carries per-transport scratch state the dispatch callback
+	// captured for downstream render callbacks (HTTP response body,
+	// HTTP response headers, prompt/completion token pointers, the
+	// HTTP attempt's cancelAttempt closure for callbacks that run on
+	// terminal exits). Type-asserted by the renderSuccess / render-
+	// RetryExhausted callbacks that need it.
+	extra any
+}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1279,90 +1279,118 @@ func (s *Server) forwardStreamSequence(
 	logAttempt func(pool.Provider, int, requestLogAttempt, int),
 	shouldLogAttempt func(requestLogAttempt) bool,
 ) {
-	failoverAttempted := false
-	for {
-		dispatchBody, err := dispatchBodyForProvider(req, state.provider)
-		if err != nil {
-			rec.logRow(state.provider.AssignedID, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
-			writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
-			return
-		}
-		wsTunneled := state.provider.IsWSTunneled()
-		var tr transportResult
-		var nativeResult wsForwardResult
-		if wsTunneled {
-			result, attempt := s.forwardWS(w, r, requestID, dispatchBody, state.provider, true, s.attemptTimeout(r))
-			// Per pre-refactor server.go:1130/1131 — WS-streaming status
-			// for shouldRetry + logAttempt is statusForForwardResult(result).
-			tr = classifyStreamResult(result, statusForForwardResult(result), attempt)
-			nativeResult = result
-		} else {
-			result, status, attempt := s.forwardStreaming(w, r, requestID, dispatchBody, state.provider, req.Model, s.attemptTimeout(r))
-			tr = classifyStreamResult(result, status, attempt)
-			nativeResult = result
-		}
-		// Committed-early-exit: the streaming first-chunk-received path
-		// (wsForwardProviderDisconnectedCommitted, wsForwardCancelled).
-		// Encoded as committed=true by classifyStreamResult.
-		if tr.committed {
+	// M2-1e (issue #94): thin wrapper that builds streaming callbacks
+	// and delegates the decision tree to forwardWithFailover. Audit-
+	// flagged INTENTIONAL invariants preserved inside the callbacks:
+	//   - Streaming `failoverEligible` carries `retryable=true` (per
+	//     classifyStreamResult); onFailoverMiss returns handled=false
+	//     so the core falls through to shouldRetry — the audit-cited
+	//     intentional divergence vs WS-non-streaming's fast-fail.
+	//   - committed early-exit (renderCommitted): post-first-chunk
+	//     disconnect / cancelled get final-OK semantics with
+	//     stream_terminal logging (WS-tunneled disconnect only).
+	//   - logRoutingDecision fires after every successful advance (HTTP
+	//     non-streaming also emits this; WS-non-streaming does NOT).
+	cbs := transportCallbacks{
+		dispatch: func(w http.ResponseWriter, r *http.Request, req chatRequest, requestID, _ string, _ time.Time, state *forwardState, rec *billingRecorder) (dispatchedAttempt, bool) {
+			dispatchBody, err := dispatchBodyForProvider(req, state.provider)
+			if err != nil {
+				rec.logRow(state.provider.AssignedID, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
+				writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
+				return dispatchedAttempt{}, false
+			}
+			wsTunneled := state.provider.IsWSTunneled()
+			var tr transportResult
+			var nativeResult wsForwardResult
+			if wsTunneled {
+				result, attempt := s.forwardWS(w, r, requestID, dispatchBody, state.provider, true, s.attemptTimeout(r))
+				tr = classifyStreamResult(result, statusForForwardResult(result), attempt)
+				nativeResult = result
+			} else {
+				result, status, attempt := s.forwardStreaming(w, r, requestID, dispatchBody, state.provider, req.Model, s.attemptTimeout(r))
+				tr = classifyStreamResult(result, status, attempt)
+				nativeResult = result
+			}
+			// Pre-refactor streaming gated the failoverCandidate
+			// same-attempt re-route on `tr.failoverEligible && wsTunneled`
+			// (server.go:1337). The classifier sets failoverEligible for
+			// every pre-first-chunk disconnect regardless of transport,
+			// but only the WS-tunneled streaming case actually invokes
+			// failoverCandidate — HTTP-streaming pre-chunk disconnect
+			// goes through normal shouldRetry+advance (which bumps
+			// retried; pinned by forward_loop_test TestM92_RowSequence_*).
+			// Clear the flag here so the core's failover branch fires
+			// only for the WS-tunneled streaming case, matching pre-1e.
+			if !wsTunneled {
+				tr.failoverEligible = false
+			}
+			return dispatchedAttempt{
+				tr:           tr,
+				nativeResult: nativeResult,
+				success:      nativeResult == wsForwardComplete,
+			}, true
+		},
+		renderCommitted: func(_ http.ResponseWriter, _ *http.Request, dispatched dispatchedAttempt, state *forwardState) bool {
+			tr := dispatched.tr
 			if tr.cancelled {
 				if shouldLogAttempt(tr.attempt) {
 					logAttempt(state.provider, http.StatusOK, tr.attempt, state.explicitRetries)
 				}
 			} else {
 				logAttempt(state.provider, http.StatusOK, tr.attempt, state.explicitRetries)
-				if wsTunneled && nativeResult == wsForwardProviderDisconnectedCommitted {
+				if state.provider.IsWSTunneled() && dispatched.nativeResult == wsForwardProviderDisconnectedCommitted {
 					s.logWSDeadMidRequest(originalRequestID, requestID, externalRequestID, state.provider, "stream_terminal", "")
 				}
 			}
-			return
-		}
-		// Success: classifyStreamResult sets status=200, no behaviour flags.
-		if nativeResult == wsForwardComplete {
-			logAttempt(state.provider, http.StatusOK, tr.attempt, state.explicitRetries)
-			if wsTunneled {
+			return true
+		},
+		renderSuccess: func(_ http.ResponseWriter, r *http.Request, req chatRequest, dispatched dispatchedAttempt, state *forwardState) {
+			logAttempt(state.provider, http.StatusOK, dispatched.tr.attempt, state.explicitRetries)
+			if state.provider.IsWSTunneled() {
 				s.stickyStore(r.Header, state.provider, req.Model)
 			}
-			return
-		}
-		excluded[routeKey(state.provider)] = struct{}{}
-		state.faultedRoutes[routeKey(state.provider)] = struct{}{}
-		if tr.markBusy {
-			s.pool.MarkState(state.provider.ProviderID, state.provider.AssignedID, pool.StateBusy)
-		}
-		// failoverEligible: WS-streaming pre-first-chunk disconnect path.
-		// Only set by classifyStreamResult on wsForwardProviderDisconnected
-		// in the WS-tunneled branch. Streaming-pre-chunk falls through to
-		// shouldRetry if failover misses (retryable=true).
-		if tr.failoverEligible && wsTunneled {
-			if !failoverAttempted && !hasPinnedRoute(r.Header) {
-				next, ok := s.failoverCandidate(uuid.NewString(), req, r.Header, state.provider, excluded)
-				if ok {
-					s.logWSDeadMidRequest(originalRequestID, requestID, externalRequestID, state.provider, "failover", next.ProviderID)
-					failoverAttempted = true
-					state.provider = next
-					continue
-				}
-			}
+		},
+		onFailoverHit: func(_, _ string, _ dispatchedAttempt, state *forwardState, next pool.Provider) {
+			// Streaming gates failoverEligible on wsTunneled at the
+			// dispatch callback (see the `if !wsTunneled {
+			// tr.failoverEligible = false }` clear in this file's
+			// streaming dispatch). The classifier itself sets
+			// failoverEligible=true for every pre-first-chunk
+			// disconnect regardless of transport (classifyStreamResult
+			// at transport_result.go:154); the streaming dispatch
+			// callback clears it for non-WS so the core's failover
+			// branch — and therefore this hit hook — only fires for
+			// WS-tunneled streaming, matching pre-refactor
+			// `if tr.failoverEligible && wsTunneled` at server.go:1337.
+			s.logWSDeadMidRequest(originalRequestID, requestID, externalRequestID, state.provider, "failover", next.ProviderID)
+		},
+		onFailoverMiss: func(_ http.ResponseWriter, _ *http.Request, _ dispatchedAttempt, state *forwardState) bool {
+			// Streaming intentional divergence: failoverEligible carries
+			// retryable=true. A miss must fall THROUGH to shouldRetry —
+			// return handled=false to let the core's retry-budget gate
+			// evaluate. The fast_fail event is still logged here so the
+			// downstream observability tracks the same shape as
+			// pre-refactor server.go:1347.
 			s.logWSDeadMidRequest(originalRequestID, requestID, externalRequestID, state.provider, "fast_fail", "")
-		}
-		// Curated attempt.Error: classify*Result already populated
-		// tr.attempt with the curated error string. logAttempt reads
-		// from tr.attempt — never from a raw tr.err mirror. Carry-forward
-		// from PR #61 security audit.
-		if !s.shouldRetry(r, startedAt, state.explicitRetries, state.faultedProviders, tr.status, nil) {
-			logAttempt(state.provider, tr.status, tr.attempt, state.explicitRetries)
-			writeStreamForwardError(w, nativeResult)
-			return
-		}
-		logAttempt(state.provider, tr.status, tr.attempt, state.explicitRetries)
-		nextRouteID, ok := s.advanceToNextProvider(w, r, req, state, excluded, rec)
-		if !ok {
-			return
-		}
-		excluded[routeKey(state.provider)] = struct{}{}
-		s.logRoutingDecision(nextRouteID, []pool.Provider{state.provider}, "retry", 0, 0, "retry_"+itoa(state.explicitRetries), state.provider.ProviderID)
+			return false
+		},
+		renderRetryExhausted: func(w http.ResponseWriter, dispatched dispatchedAttempt, state *forwardState) {
+			// Curated attempt.Error: classifyStreamResult populated
+			// dispatched.tr.attempt with the curated error string;
+			// logAttempt reads from tr.attempt — never from a raw err
+			// mirror. Carry-forward from PR #61 security audit.
+			logAttempt(state.provider, dispatched.tr.status, dispatched.tr.attempt, state.explicitRetries)
+			writeStreamForwardError(w, dispatched.nativeResult)
+		},
+		logRetryAttempt: func(dispatched dispatchedAttempt, state *forwardState) {
+			logAttempt(state.provider, dispatched.tr.status, dispatched.tr.attempt, state.explicitRetries)
+		},
+		afterAdvance: func(state *forwardState, nextRouteID string) bool {
+			s.logRoutingDecision(nextRouteID, []pool.Provider{state.provider}, "retry", 0, 0, "retry_"+itoa(state.explicitRetries), state.provider.ProviderID)
+			return false
+		},
 	}
+	s.forwardWithFailover(w, r, req, requestID, originalRequestID, startedAt, state, excluded, rec, cbs)
 }
 
 // forwardWSNonStreamSequence is the unified loop body for non-streaming
@@ -1390,108 +1418,105 @@ func (s *Server) forwardWSNonStreamSequence(
 	logAttempt func(pool.Provider, int, requestLogAttempt, int),
 	shouldLogAttempt func(requestLogAttempt) bool,
 ) (shouldFallThroughToHTTP bool) {
-	failoverAttempted := false
-	for {
-		dispatchBody, err := dispatchBodyForProvider(req, state.provider)
-		if err != nil {
-			rec.logRow(state.provider.AssignedID, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
-			writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
+	// M2-1e (issue #94): now a thin wrapper that builds per-transport
+	// callbacks and delegates the decision tree to forwardWithFailover.
+	// Audit-flagged INTENTIONAL invariants preserved inside the
+	// callbacks:
+	//   - failoverEligible carries retryable=false (per classifyWSResult);
+	//     onFailoverMiss returns handled=true to fast-fail with 502 rather
+	//     than fall through to shouldRetry — the audit-cited intentional
+	//     divergence vs streaming.
+	//   - Cancelled / Failed / Unavailable short-circuit via
+	//     handleNonRetryableTerminal — no advance, no failover.
+	//   - Queue-full (wsForwardQueueFull): markBusy fires in the shared
+	//     core; the retry-budget gate is bypassed via skipRetryBudgetCheck
+	//     to preserve the M2-1d "always advance on queue-full" behaviour
+	//     pinned by forward_loop_test scenario
+	//     TestM2_1D_RowSequence_WSNonStreamingQueueFullThroughAdvance.
+	//   - afterAdvance / afterFailoverHit return true when the new
+	//     provider is not WS so the caller falls through to the HTTP loop
+	//     on state.provider.
+	cbs := transportCallbacks{
+		dispatch: func(w http.ResponseWriter, r *http.Request, req chatRequest, requestID, _ string, _ time.Time, state *forwardState, rec *billingRecorder) (dispatchedAttempt, bool) {
+			dispatchBody, err := dispatchBodyForProvider(req, state.provider)
+			if err != nil {
+				rec.logRow(state.provider.AssignedID, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
+				writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
+				return dispatchedAttempt{}, false
+			}
+			result, attempt := s.forwardWS(w, r, requestID, dispatchBody, state.provider, false, s.attemptTimeout(r))
+			tr := classifyWSResult(result, attempt)
+			return dispatchedAttempt{
+				tr:           tr,
+				nativeResult: result,
+				success:      result == wsForwardComplete,
+			}, true
+		},
+		handleNonRetryableTerminal: func(_ http.ResponseWriter, dispatched dispatchedAttempt, state *forwardState) bool {
+			result := dispatched.nativeResult
+			if result == wsForwardFailed || result == wsForwardUnavailable || result == wsForwardCancelled {
+				if result != wsForwardCancelled || shouldLogAttempt(dispatched.tr.attempt) {
+					logAttempt(state.provider, statusForForwardResult(result), dispatched.tr.attempt, state.explicitRetries)
+				}
+				return true
+			}
 			return false
-		}
-		result, attempt := s.forwardWS(w, r, requestID, dispatchBody, state.provider, false, s.attemptTimeout(r))
-		tr := classifyWSResult(result, attempt)
-		if result == wsForwardComplete {
-			logAttempt(state.provider, http.StatusOK, tr.attempt, state.explicitRetries)
+		},
+		renderSuccess: func(_ http.ResponseWriter, r *http.Request, req chatRequest, dispatched dispatchedAttempt, state *forwardState) {
+			logAttempt(state.provider, http.StatusOK, dispatched.tr.attempt, state.explicitRetries)
 			s.stickyStore(r.Header, state.provider, req.Model)
-			return false
-		}
-		// Cancelled / Failed / Unavailable: short-circuit return.
-		if result == wsForwardFailed || result == wsForwardUnavailable || result == wsForwardCancelled {
-			if result != wsForwardCancelled || shouldLogAttempt(tr.attempt) {
-				logAttempt(state.provider, statusForForwardResult(result), tr.attempt, state.explicitRetries)
-			}
-			return false
-		}
-		// Timeout: classifier marks retryable=true, no failoverEligible.
-		// Runs through shouldRetry + advanceToNextProvider; on advance
-		// the loop continues if the next provider is WS, or breaks to
-		// HTTP fallback otherwise.
-		if result == wsForwardTimedOut {
-			excluded[routeKey(state.provider)] = struct{}{}
-			state.faultedRoutes[routeKey(state.provider)] = struct{}{}
-			if !s.shouldRetry(r, startedAt, state.explicitRetries, state.faultedProviders, http.StatusGatewayTimeout, nil) {
-				logAttempt(state.provider, http.StatusGatewayTimeout, tr.attempt, state.explicitRetries)
-				writeError(w, http.StatusGatewayTimeout, "provider_timeout", "Selected provider timed out; buyer should retry")
-				return false
-			}
-			logAttempt(state.provider, http.StatusGatewayTimeout, tr.attempt, state.explicitRetries)
-			_, ok := s.advanceToNextProvider(w, r, req, state, excluded, rec)
-			if !ok {
-				return false
-			}
-			excluded[routeKey(state.provider)] = struct{}{}
-			if state.provider.IsWSTunneled() {
-				continue
-			}
-			return true
-		}
-		// Provider disconnected (pre-commit): failoverEligible + retryable=false.
-		// The non-streaming WS loop fast-fails with 502 when failover misses
-		// (audit-flagged intentional divergence vs streaming).
-		if tr.failoverEligible {
-			excluded[routeKey(state.provider)] = struct{}{}
-			state.faultedRoutes[routeKey(state.provider)] = struct{}{}
-			if failoverAttempted || hasPinnedRoute(r.Header) {
-				s.logWSDeadMidRequest(originalRequestID, requestID, externalRequestID, state.provider, "fast_fail", "")
-				logAttempt(state.provider, http.StatusBadGateway, tr.attempt, state.explicitRetries)
-				writeError(w, http.StatusBadGateway, "provider_disconnected", "Selected provider disconnected; buyer should retry")
-				return false
-			}
-			next, ok := s.failoverCandidate(uuid.NewString(), req, r.Header, state.provider, excluded)
-			if !ok {
-				s.logWSDeadMidRequest(originalRequestID, requestID, externalRequestID, state.provider, "fast_fail", "")
-				logAttempt(state.provider, http.StatusBadGateway, tr.attempt, state.explicitRetries)
-				writeError(w, http.StatusBadGateway, "provider_disconnected", "Selected provider disconnected; buyer should retry")
-				return false
-			}
+		},
+		onFailoverHit: func(_, _ string, dispatched dispatchedAttempt, state *forwardState, next pool.Provider) {
 			s.logWSDeadMidRequest(originalRequestID, requestID, externalRequestID, state.provider, "failover", next.ProviderID)
-			logAttempt(state.provider, http.StatusBadGateway, tr.attempt, state.explicitRetries)
-			failoverAttempted = true
-			state.provider = next
-			if state.provider.IsWSTunneled() {
-				continue
+			logAttempt(state.provider, http.StatusBadGateway, dispatched.tr.attempt, state.explicitRetries)
+		},
+		afterFailoverHit: func(state *forwardState) bool {
+			return !state.provider.IsWSTunneled()
+		},
+		onFailoverMiss: func(w http.ResponseWriter, _ *http.Request, dispatched dispatchedAttempt, state *forwardState) bool {
+			// Intentional divergence vs streaming: WS-non-streaming
+			// failoverEligible carries retryable=false, so a miss MUST
+			// fast-fail with 502 — NOT fall through to shouldRetry.
+			s.logWSDeadMidRequest(originalRequestID, requestID, externalRequestID, state.provider, "fast_fail", "")
+			logAttempt(state.provider, http.StatusBadGateway, dispatched.tr.attempt, state.explicitRetries)
+			writeError(w, http.StatusBadGateway, "provider_disconnected", "Selected provider disconnected; buyer should retry")
+			return true
+		},
+		skipRetryBudgetCheck: func(dispatched dispatchedAttempt) bool {
+			// Queue-full bypasses the retry-budget gate (always advances
+			// when a candidate exists). M2-1d-preserved behaviour pinned
+			// by forward_loop_test scenario
+			// TestM2_1D_RowSequence_WSNonStreamingQueueFullThroughAdvance.
+			return dispatched.nativeResult == wsForwardQueueFull
+		},
+		renderRetryExhausted: func(w http.ResponseWriter, dispatched dispatchedAttempt, state *forwardState) {
+			// Only the timeout branch reaches this in WS-non-streaming
+			// today: failoverEligible's miss path renders + returns
+			// inside onFailoverMiss; queue-full skips the gate above;
+			// cancelled/failed/unavailable short-circuit before fault
+			// mutation. The 504/provider_timeout envelope mirrors the
+			// pre-refactor inline branch at server.go:1423-1424.
+			logAttempt(state.provider, http.StatusGatewayTimeout, dispatched.tr.attempt, state.explicitRetries)
+			writeError(w, http.StatusGatewayTimeout, "provider_timeout", "Selected provider timed out; buyer should retry")
+		},
+		logRetryAttempt: func(dispatched dispatchedAttempt, state *forwardState) {
+			// Timeout: classifier-mapped status (504). Queue-full: 502.
+			// Matches pre-refactor pattern (timeout at server.go:1427,
+			// queue-full at :1487).
+			status := http.StatusGatewayTimeout
+			if dispatched.nativeResult == wsForwardQueueFull {
+				status = http.StatusBadGateway
 			}
-			return true
-		}
-		// Queue full: markBusy + retryable=true. The audit (post-merge
-		// verification of PR #91 — Q3 BLOCKING) called out the prior
-		// inline state mutation here as the concrete shared-state
-		// bypass that kept ARCH-1 / CODE-1 at PARTIAL_RESOLVED_DIFFERENTLY.
-		// M2-1d routes this path through advanceToNextProvider so the
-		// "pick next provider + bump explicitRetries/faultedProviders"
-		// tail lives in exactly one place — same as the timeout branch
-		// above and the two siblings (forwardStreamSequence,
-		// forwardHTTPSequence).
-		//
-		// Byte-identical to PR #91 baseline: classifier sets markBusy=true
-		// only on wsForwardQueueFull (the only case that falls through to
-		// this point), so the unconditional MarkState + excluded-add +
-		// logAttempt block here matches the pre-1d guarded behaviour.
-		// advanceToNextProvider performs the identical mutation order
-		// (selectProviderExcluding → routingDone → explicitRetries++ →
-		// faultedProviders++ → state.provider = next) as the prior inline
-		// block, preserving the request_log row sequence the billing
-		// ledger keys off (verified by forward_loop_test.go scenario 5).
-		s.pool.MarkState(state.provider.ProviderID, state.provider.AssignedID, pool.StateBusy)
-		excluded[routeKey(state.provider)] = struct{}{}
-		logAttempt(state.provider, http.StatusBadGateway, tr.attempt, state.explicitRetries)
-		if _, ok := s.advanceToNextProvider(w, r, req, state, excluded, rec); !ok {
-			return false
-		}
-		if !state.provider.IsWSTunneled() {
-			return true
-		}
+			logAttempt(state.provider, status, dispatched.tr.attempt, state.explicitRetries)
+		},
+		afterAdvance: func(state *forwardState, _ string) bool {
+			// WS-non-streaming-only signal: if advance landed on a non-WS
+			// provider, the caller (handleChatCompletions) drives the
+			// HTTP loop on state.provider. WS targets continue the loop.
+			return !state.provider.IsWSTunneled()
+		},
 	}
+	return s.forwardWithFailover(w, r, req, requestID, originalRequestID, startedAt, state, excluded, rec, cbs)
 }
 
 // forwardHTTPSequence is the unified loop body for HTTP non-streaming
@@ -1505,6 +1530,21 @@ func (s *Server) forwardWSNonStreamSequence(
 //   - handleProviderFailure called on non-200 status (HTTP-only fault
 //     tracking — WS path has its own MarkState semantics via classifier
 //     markBusy flag).
+// httpDispatchExtra carries the HTTP dispatch's post-classification
+// scratch state forward to the renderRetryExhausted / logRetryAttempt
+// callbacks (status code, raw err, ErrorCode, retryRequested flag).
+// The dispatch callback itself owns ALL the lifecycle plumbing
+// (per-attempt context.WithTimeout setup, cancelAttempt cleanup on
+// every exit path, 200-success render, receipt-bearing null-usage
+// early-return); this struct only carries the post-dispatch
+// observables the failure-render callbacks need.
+type httpDispatchExtra struct {
+	status         int
+	err            error
+	errorCode      string
+	retryRequested bool
+}
+
 func (s *Server) forwardHTTPSequence(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -1515,138 +1555,179 @@ func (s *Server) forwardHTTPSequence(
 	excluded map[string]struct{},
 	rec *billingRecorder,
 ) {
-	for {
-		dispatchBody, err := dispatchBodyForProvider(req, state.provider)
-		if err != nil {
-			rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
-			writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
-			return
-		}
-		upstreamURL := state.provider.EndpointURL + "/v1/chat/completions"
-		attemptCtx := r.Context()
-		cancelAttempt := func() {}
-		retryRequested := s.maxRetries > 0 && retryHeaderLimit(r.Header.Get("X-MacProvider-Retry")) > 0
-		if retryRequested && s.retryPerAttemptTimeout > 0 {
-			attemptCtx, cancelAttempt = context.WithTimeout(r.Context(), s.retryPerAttemptTimeout)
-		}
-		upReq, err := http.NewRequestWithContext(attemptCtx, http.MethodPost, upstreamURL, bytes.NewReader(dispatchBody))
-		if err != nil {
-			cancelAttempt()
-			rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
-			writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
-			return
-		}
-		upReq.Header.Set("Content-Type", "application/json")
-		upReq.Header.Set("X-Request-ID", originalRequestID)
-		resp, err := providerhttp.Client.Do(upReq)
-		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
-			respBody, readErr := readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
-			_ = resp.Body.Close()
-			if readErr != nil {
+	// M2-1e (issue #94): thin wrapper that builds HTTP-transport
+	// callbacks and delegates the decision tree to forwardWithFailover.
+	// Audit-flagged INTENTIONAL invariants preserved inside the
+	// callbacks:
+	//   - HTTP per-attempt context.WithTimeout(...) — set up inside
+	//     the dispatch callback when retryRequested && retryPerAttempt-
+	//     Timeout > 0; cancelAttempt fires on EVERY exit path
+	//     (200-success render, receipt-bearing early-return,
+	//     fall-through-to-failure-classify). Never visible at the core
+	//     level for other transports.
+	//   - handleProviderFailure called on non-200 status — HTTP-only
+	//     fault tracking, mirrored from pre-refactor server.go:1620;
+	//     WS markBusy semantics live in their own classifier flag.
+	//   - Receipt-bearing null-usage early-return (Round-1 audit H1):
+	//     when shouldRetry would say stop AND the response has a
+	//     null-usage error code AND the provider is receipt-eligible,
+	//     render the response body + receipt headers verbatim before
+	//     returning. Otherwise fall through to the normal failure
+	//     path. Lives inside the dispatch callback so cancelAttempt
+	//     lifetime stays correct.
+	//   - Custom terminal disambiguation: shouldRetry-miss renders
+	//     "provider_timeout" (504) vs "provider_error" (502) based on
+	//     status+retryRequested. The renderRetryExhausted callback
+	//     reads status/retryRequested from httpDispatchExtra.
+	cbs := transportCallbacks{
+		dispatch: func(w http.ResponseWriter, r *http.Request, req chatRequest, _, originalRequestID string, startedAt time.Time, state *forwardState, rec *billingRecorder) (dispatchedAttempt, bool) {
+			dispatchBody, err := dispatchBodyForProvider(req, state.provider)
+			if err != nil {
+				rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
+				writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
+				return dispatchedAttempt{}, false
+			}
+			upstreamURL := state.provider.EndpointURL + "/v1/chat/completions"
+			attemptCtx := r.Context()
+			cancelAttempt := func() {}
+			retryRequested := s.maxRetries > 0 && retryHeaderLimit(r.Header.Get("X-MacProvider-Retry")) > 0
+			if retryRequested && s.retryPerAttemptTimeout > 0 {
+				attemptCtx, cancelAttempt = context.WithTimeout(r.Context(), s.retryPerAttemptTimeout)
+			}
+			upReq, err := http.NewRequestWithContext(attemptCtx, http.MethodPost, upstreamURL, bytes.NewReader(dispatchBody))
+			if err != nil {
 				cancelAttempt()
 				rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
 				writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
-				return
+				return dispatchedAttempt{}, false
 			}
-			promptTok, completionTok := tokenPointersFromChatResponse(respBody)
-			estimatedCompletion := s.observedCompletionTokensFromBytes(len(respBody))
-			if err := rec.logProviderRowWithEstimate(state.provider, http.StatusOK, promptTok, completionTok, "", "", state.explicitRetries, estimatedCompletion); err != nil {
-				cancelAttempt()
-				writeError(w, http.StatusInternalServerError, "request_log_failed", "Could not durably log request")
-				return
-			}
-			copyReceiptHeaderForProvider(w.Header(), resp.Header, state.provider)
-			w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
-			if w.Header().Get("Content-Type") == "" {
-				w.Header().Set("Content-Type", "application/json")
-			}
-			w.Header().Set("X-MacProvider-Provider", state.provider.ProviderID)
-			w.Header().Set("X-MacProvider-Route", state.provider.AssignedID)
-			w.WriteHeader(http.StatusOK)
-			s.stickyStore(r.Header, state.provider, req.Model)
-			_, _ = w.Write(respBody)
-			cancelAttempt()
-			return
-		}
-		status := 0
-		attempt := requestLogAttempt{}
-		if resp != nil {
-			status = resp.StatusCode
-			respBody, _ := readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
-			_ = resp.Body.Close()
-			attempt.ErrorCode = nullUsageProviderErrorCode(respBody)
-			if attempt.ErrorCode != "" && providerReceiptEligible(state.provider) {
-				// Round-1 audit H1: receipt-bearing null-usage errors used to
-				// return immediately to the buyer, bypassing the
-				// `X-MacProvider-Retries: N` budget. Only short-circuit when
-				// the retry budget is genuinely exhausted; otherwise fall
-				// through to the failover path so the buyer's explicit retry
-				// budget is honored. The receipt is preserved on the final
-				// attempt.
-				if !s.shouldRetry(r, startedAt, state.explicitRetries, state.faultedProviders, status, nil) {
-					if err := rec.logProviderRow(state.provider, status, nil, nil, http.StatusText(status), attempt.ErrorCode, state.explicitRetries); err != nil {
-						cancelAttempt()
-						writeError(w, http.StatusInternalServerError, "request_log_failed", "Could not durably log request")
-						return
-					}
-					copyReceiptHeaderForProvider(w.Header(), resp.Header, state.provider)
-					w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
-					if w.Header().Get("Content-Type") == "" {
-						w.Header().Set("Content-Type", "application/json")
-					}
-					w.Header().Set("X-MacProvider-Provider", state.provider.ProviderID)
-					w.Header().Set("X-MacProvider-Route", state.provider.AssignedID)
-					w.WriteHeader(status)
-					_, _ = w.Write(respBody)
+			upReq.Header.Set("Content-Type", "application/json")
+			upReq.Header.Set("X-Request-ID", originalRequestID)
+			resp, doErr := providerhttp.Client.Do(upReq)
+			// 200 success path: render body + receipt headers, log row,
+			// cancelAttempt on every exit.
+			if doErr == nil && resp != nil && resp.StatusCode == http.StatusOK {
+				respBody, readErr := readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
+				_ = resp.Body.Close()
+				if readErr != nil {
 					cancelAttempt()
-					return
+					rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
+					writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
+					return dispatchedAttempt{}, false
+				}
+				promptTok, completionTok := tokenPointersFromChatResponse(respBody)
+				estimatedCompletion := s.observedCompletionTokensFromBytes(len(respBody))
+				if err := rec.logProviderRowWithEstimate(state.provider, http.StatusOK, promptTok, completionTok, "", "", state.explicitRetries, estimatedCompletion); err != nil {
+					cancelAttempt()
+					writeError(w, http.StatusInternalServerError, "request_log_failed", "Could not durably log request")
+					return dispatchedAttempt{}, false
+				}
+				copyReceiptHeaderForProvider(w.Header(), resp.Header, state.provider)
+				w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+				if w.Header().Get("Content-Type") == "" {
+					w.Header().Set("Content-Type", "application/json")
+				}
+				w.Header().Set("X-MacProvider-Provider", state.provider.ProviderID)
+				w.Header().Set("X-MacProvider-Route", state.provider.AssignedID)
+				w.WriteHeader(http.StatusOK)
+				s.stickyStore(r.Header, state.provider, req.Model)
+				_, _ = w.Write(respBody)
+				cancelAttempt()
+				// Signal to the core: this attempt was handled in
+				// dispatch (we rendered the 200 + logged). Return
+				// ok=false so the core just returns.
+				return dispatchedAttempt{}, false
+			}
+			// Non-200 path.
+			status := 0
+			attempt := requestLogAttempt{}
+			var respBody []byte
+			if resp != nil {
+				status = resp.StatusCode
+				respBody, _ = readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
+				_ = resp.Body.Close()
+				attempt.ErrorCode = nullUsageProviderErrorCode(respBody)
+				// Receipt-bearing null-usage early-return (Round-1
+				// audit H1). Only short-circuit when the retry budget
+				// is genuinely exhausted; otherwise fall through so
+				// the buyer's explicit retry budget is honored.
+				if attempt.ErrorCode != "" && providerReceiptEligible(state.provider) {
+					if !s.shouldRetry(r, startedAt, state.explicitRetries, state.faultedProviders, status, nil) {
+						if err := rec.logProviderRow(state.provider, status, nil, nil, http.StatusText(status), attempt.ErrorCode, state.explicitRetries); err != nil {
+							cancelAttempt()
+							writeError(w, http.StatusInternalServerError, "request_log_failed", "Could not durably log request")
+							return dispatchedAttempt{}, false
+						}
+						copyReceiptHeaderForProvider(w.Header(), resp.Header, state.provider)
+						w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+						if w.Header().Get("Content-Type") == "" {
+							w.Header().Set("Content-Type", "application/json")
+						}
+						w.Header().Set("X-MacProvider-Provider", state.provider.ProviderID)
+						w.Header().Set("X-MacProvider-Route", state.provider.AssignedID)
+						w.WriteHeader(status)
+						_, _ = w.Write(respBody)
+						cancelAttempt()
+						return dispatchedAttempt{}, false
+					}
 				}
 			}
-		}
-		cancelAttempt()
-		// classifyHTTPResult is the canonical translation of the
-		// (resp, err) pair into transportResult.status (with the
-		// nil-response → 502 normalisation) and tr.retryable. The HTTP
-		// failure path keeps its inline shouldRetry + logProviderRow
-		// shape because logProviderRow vs logAttempt differ in
-		// caller-supplied message wording (the HTTP-specific
-		// "provider_timeout" / "provider_error" disambiguation lives
-		// here, not in the classifier). Using tr.status downstream
-		// pulls the status-derivation contract into one place across
-		// HTTP/streaming/WS.
-		tr := classifyHTTPResult(resp, err, attempt)
-		s.log.Warn().Err(err).Int("status", status).Str("request_id", requestID).Str("provider_id", state.provider.ProviderID).Msg("provider request failed")
-		if status != 0 {
-			s.handleProviderFailure(state.provider, status)
-		}
-		if !s.shouldRetry(r, startedAt, state.explicitRetries, state.faultedProviders, status, err) {
-			if retryRequested && status == http.StatusGatewayTimeout {
-				rec.logProviderRow(state.provider, http.StatusGatewayTimeout, nil, nil, "Selected provider timed out; buyer should retry", attempt.ErrorCode, state.explicitRetries)
+			cancelAttempt()
+			tr := classifyHTTPResult(resp, doErr, attempt)
+			s.log.Warn().Err(doErr).Int("status", status).Str("request_id", requestID).Str("provider_id", state.provider.ProviderID).Msg("provider request failed")
+			if status != 0 {
+				s.handleProviderFailure(state.provider, status)
+			}
+			return dispatchedAttempt{
+				tr:           tr,
+				nativeResult: "",
+				success:      false,
+				extra: httpDispatchExtra{
+					status:         status,
+					err:            doErr,
+					errorCode:      attempt.ErrorCode,
+					retryRequested: retryRequested,
+				},
+			}, true
+		},
+		// HTTP never reaches the success branch via the core — the
+		// dispatch callback handles 200 inline (writes body + returns
+		// ok=false). The core's success branch is unused for HTTP, but
+		// the callback is required by the struct shape, so we provide
+		// a no-op (never invoked because dispatch returns success=false
+		// for the non-200 path it falls through with).
+		renderSuccess: func(http.ResponseWriter, *http.Request, chatRequest, dispatchedAttempt, *forwardState) {},
+		renderRetryExhausted: func(w http.ResponseWriter, dispatched dispatchedAttempt, state *forwardState) {
+			extra := dispatched.extra.(httpDispatchExtra)
+			// HTTP-specific terminal disambiguation: provider_timeout
+			// (504) when retryRequested and the upstream actually
+			// returned 504, otherwise provider_error (502). Mirrors
+			// pre-refactor server.go:1645-1652.
+			if extra.retryRequested && extra.status == http.StatusGatewayTimeout {
+				rec.logProviderRow(state.provider, http.StatusGatewayTimeout, nil, nil, "Selected provider timed out; buyer should retry", extra.errorCode, state.explicitRetries)
 				writeError(w, http.StatusGatewayTimeout, "provider_timeout", "Selected provider timed out; buyer should retry")
 				return
 			}
-			rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", attempt.ErrorCode, state.explicitRetries)
+			rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", extra.errorCode, state.explicitRetries)
 			writeError(w, http.StatusBadGateway, "provider_error", "Selected provider failed; buyer should retry")
-			return
-		}
-		// tr.status already encodes the nil-response → 502 normalisation
-		// the pre-refactor code did inline (failStatus := status; if
-		// failStatus == 0 { failStatus = http.StatusBadGateway }). Read
-		// it from the classifier so HTTP and streaming/WS paths share
-		// the same status-derivation contract.
-		failStatus := tr.status
-		errMsg := "Selected provider failed; buyer should retry"
-		if err != nil {
-			errMsg = err.Error()
-		}
-		rec.logProviderRow(state.provider, failStatus, nil, nil, errMsg, attempt.ErrorCode, state.explicitRetries)
-		nextRouteID, ok := s.advanceToNextProvider(w, r, req, state, excluded, rec)
-		if !ok {
-			return
-		}
-		excluded[routeKey(state.provider)] = struct{}{}
-		s.logRoutingDecision(nextRouteID, []pool.Provider{state.provider}, "retry", 0, 0, "retry_"+itoa(state.explicitRetries), state.provider.ProviderID)
+		},
+		logRetryAttempt: func(dispatched dispatchedAttempt, state *forwardState) {
+			extra := dispatched.extra.(httpDispatchExtra)
+			// failStatus = tr.status (already encodes the nil-response
+			// → 502 normalisation per classifyHTTPResult). Mirrors
+			// pre-refactor server.go:1659.
+			errMsg := "Selected provider failed; buyer should retry"
+			if extra.err != nil {
+				errMsg = extra.err.Error()
+			}
+			rec.logProviderRow(state.provider, dispatched.tr.status, nil, nil, errMsg, extra.errorCode, state.explicitRetries)
+		},
+		afterAdvance: func(state *forwardState, nextRouteID string) bool {
+			s.logRoutingDecision(nextRouteID, []pool.Provider{state.provider}, "retry", 0, 0, "retry_"+itoa(state.explicitRetries), state.provider.ProviderID)
+			return false
+		},
 	}
+	s.forwardWithFailover(w, r, req, requestID, originalRequestID, startedAt, state, excluded, rec, cbs)
 }
 
 // advanceToNextProvider performs the per-retry "pick a fresh provider,

--- a/specs/AUDIT_M2_1E_FORWARD_CORE_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_M2_1E_FORWARD_CORE_ARCHITECT_PROMPT.md
@@ -1,0 +1,190 @@
+# M2-1e forwardWithFailover core — ARCHITECT-lane audit
+
+You are the **architect** lane of a three-lane audit (code / security /
+architect) of the M2-1e forwardWithFailover core extraction for
+issue #94. Stay narrowly in your lane.
+
+**This lane has authority to approve / withhold the ARCH-1 / CODE-1
+RESOLVED gate** named in the issue's acceptance criteria:
+
+> Architect post-merge verification approves promotion of ARCH-1 /
+> CODE-1 to RESOLVED.
+
+## Branch / commit
+- Branch: `fix/m2-1e-forward-with-failover-core`
+- Worktree: `../macprovider-m2-1e-forward-core` (origin/main base: 4f73f5d)
+- Files in scope (`git diff origin/main`):
+  - `phase4-coordinator/internal/buyer/forward_with_failover.go` (new — shared core + transportCallbacks struct + dispatchedAttempt)
+  - `phase4-coordinator/internal/buyer/server.go` (three sequence helpers refactored)
+  - `audits/2026-06-10/REMAINING_WORK.md` (ARCH-1 / CODE-1 entries removed, M2-1 row → RESOLVED)
+
+## Architect history: what ARCH-1 / CODE-1 named
+
+Original audit (2026-06-10 REPO_AUDIT.md §3.1 item 3):
+> handleChatCompletions god-function with three diverging copies of
+> failover state machine.
+
+PR #91 (M2-1c) landed three transport-typed sequence helpers but
+the failover state machine was still split across helper-local
+decision trees. PR #93 (M2-1d) closed the Q3 BLOCKING shared-state-
+bypass at WS queue-full but left Q1 open.
+
+Architect verdict on PR #93 named the M2-1e shape:
+> Scope M2-1e as extraction of a shared `forwardWithFailover` core,
+> or equivalent shared transition core, with transport callbacks for
+> dispatch, success/error rendering, committed handling, and WS-to-
+> HTTP fallthrough.
+
+## What this branch ships
+
+- `forward_with_failover.go` — new file containing
+  `s.forwardWithFailover(...)` (the shared decision-tree core) +
+  `transportCallbacks` struct (12 callback fields) +
+  `dispatchedAttempt` carrier struct (`tr` + `nativeResult` +
+  `success` + `extra any`).
+- The three sequence helpers in `server.go` are now thin wrappers
+  (~80-120 lines each) that build per-transport callback bundles
+  and delegate to the core.
+- The audit-flagged INTENTIONAL per-transport differences remain
+  flagged in callbacks, not flattened:
+  1. HTTP per-attempt `context.WithTimeout` — inside HTTP dispatch
+     callback.
+  2. WS-non-streaming `failoverEligible+retryable=false` fast-fail —
+     `onFailoverMiss` returns handled=true; streaming returns
+     handled=false (falls through to shouldRetry).
+  3. Streaming committed early-exit — `renderCommitted` callback;
+     other transports leave it nil.
+  Plus the 4th divergence the test sweep caught (WS-non-streaming
+  queue-full skips shouldRetry) is now expressed via
+  `skipRetryBudgetCheck` callback.
+
+## Architect-lane scope (apply each; stay in lane)
+
+### ARCH-1. Does this satisfy the architect's named close-out shape?
+- The verdict named "one failover state machine" with "transport
+  callbacks for dispatch, success/error rendering, committed
+  handling, and WS-to-HTTP fallthrough". Map the named callbacks to
+  what shipped:
+  - dispatch → `tx.dispatch` ✅
+  - success rendering → `tx.renderSuccess` ✅
+  - error rendering → `tx.renderRetryExhausted` ✅
+  - committed handling → `tx.renderCommitted` ✅
+  - WS-to-HTTP fallthrough → `tx.afterAdvance` + `tx.afterFailoverHit`
+    (both return `fallThrough bool`) ✅
+- The 4 named callbacks plus the 8 additional ones (`handleNon-
+  RetryableTerminal`, `onFailoverHit`, `onFailoverMiss`, `skipRetry-
+  BudgetCheck`, `logRetryAttempt`, `afterAdvance` overlap). Are any
+  of the additional callbacks evidence of leftover decision-tree
+  code that should have moved INTO the core?
+- Is `skipRetryBudgetCheck` a clean abstraction or a code smell?
+  WS-non-streaming queue-full intentionally bypasses shouldRetry per
+  the M2-1d-baseline byte-identical contract. The cleanest move
+  would be to surface this as a 4th INTENTIONAL per-transport
+  difference, properly named, OR to refactor shouldRetry itself so
+  the bypass isn't needed. Recommend the right resolution.
+
+### ARCH-2. Is "one failover state machine" actually met?
+- Search the new server.go for any remaining `failoverCandidate`
+  call. The pre-refactor had 2 such calls (one each in stream +
+  WS-NS). Post-refactor, the core has exactly 1; the helpers have 0.
+  Confirm.
+- Search for any remaining inline `state.provider = next` assignment
+  outside the core's failover branch. Pre-refactor had 2 (one each
+  in stream + WS-NS failover blocks). Post-refactor: the core has
+  exactly 1; the helpers have 0. Confirm.
+- The architect's intent: "every retry-semantics edit touches
+  exactly one place per transport, not three near-duplicate inline
+  loop bodies". Post-1e, where does a retry-semantics edit live?
+  - "Change shouldRetry's budget semantics" → buyer/retry.go (out
+    of scope, single file already).
+  - "Change failover candidate selection" → failoverCandidate
+    helper (single function, all callers go through it).
+  - "Change advance-to-next-provider mutation order" →
+    advanceToNextProvider (single function).
+  - "Add a new transport result branch" → classifier + core
+    branch + callback addition.
+  - "Tighten the HTTP per-attempt context handling" → HTTP
+    dispatch callback only.
+  - "Change committed-stream semantics" → streaming's
+    renderCommitted callback only.
+  Does this map satisfy ARCH-1 / CODE-1? IS this RESOLVED, or
+  RESOLVED_DIFFERENTLY again?
+
+### ARCH-3. New surface area: cost / benefit
+- The new file is ~260 lines (core + types). Each helper shed
+  ~80-150 lines of inline decision tree but gained ~80-120 lines
+  of callback construction. Net code volume is roughly similar.
+  Is the abstraction worth the visual cost?
+- The `transportCallbacks` struct has 12 fields. Several are
+  optional (nil for some transports). Is the struct shape right
+  (large flat callback bag) or should it be split into mandatory
+  + optional groups?
+- `dispatchedAttempt.extra any` — type-asserted in HTTP callbacks.
+  Is this the right escape hatch, or should it be a typed
+  interface? Cost: type assertion runtime cost (negligible) +
+  miswiring risk (a future contributor wiring HTTP callbacks
+  for WS would panic on the type assertion). Recommend a fix
+  if the risk is real.
+
+### ARCH-4. Cross-cutting refactors enabled by this shape
+- With the core in place, what NEW work is now easier?
+  - Adding a new transport (e.g. gRPC streaming): build a new
+    callback bundle, no inline-loop duplication.
+  - Adding cross-transport instrumentation (e.g. per-attempt
+    timing histogram): single place to add.
+  - Adding a new failover-eligibility criterion (e.g. "skip failover
+    when buyer set X-No-Failover header"): single place to add.
+- What's still hard / unchanged?
+  - The classifier per-transport (classifyStreamResult,
+    classifyWSResult, classifyHTTPResult) remains separate; their
+    transportResult flag matrix is the actual decision encoding.
+  - The handler-level wiring (handleChatCompletions dispatches to
+    one of three sequence helpers based on stream + WS-tunneled)
+    remains. Should that dispatch ALSO move into the core?
+
+### ARCH-5. Doc trail
+- `audits/2026-06-10/REMAINING_WORK.md` strip-out of ARCH-1 / CODE-1
+  per the doc contract — correct per the issue's acceptance criteria
+  ("RESOLVED items do not appear")?
+- The 2026-06-26 sweep update note at line 5 added by this branch
+  documents the M2-1e flip. Is the wording precise enough that a
+  future reader unfamiliar with the M2-1 arc understands what
+  shipped and what it closed?
+- M2-1 task table row updated to `RESOLVED`. Correct?
+- Is there ANYTHING in the M2-1e shape that should be tracked as
+  follow-up (i.e. a NEW finding to add to REMAINING_WORK.md)? E.g.
+  the architect's question on handleChatCompletions dispatch moving
+  INTO the core (ARCH-4 above) — should that become an M2-1f issue?
+
+### ARCH-6. Architect verdict
+- Based on ARCH-1 through ARCH-5, does this branch warrant
+  promotion of ARCH-1 / CODE-1 from `RESOLVED_DIFFERENTLY` to
+  `RESOLVED`?
+- If yes, state so in the verdict line.
+- If no, name the specific gap and the smallest delta needed to
+  close it.
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/M2_1E_FORWARD_CORE_ARCHITECT_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM AND ARCH-1/CODE-1 can promote to RESOLVED,
+end with:
+`VERDICT: architect lane READY TO MERGE — ARCH-1 / CODE-1 → RESOLVED`
+
+If 0 C/H/M but RESOLVED gate withheld for a substantive architect
+reason, end with:
+`VERDICT: architect lane READY TO MERGE — ARCH-1 / CODE-1 stay
+RESOLVED_DIFFERENTLY pending <one-line gap>`

--- a/specs/AUDIT_M2_1E_FORWARD_CORE_ARCHITECT_R2_PROMPT.md
+++ b/specs/AUDIT_M2_1E_FORWARD_CORE_ARCHITECT_R2_PROMPT.md
@@ -1,0 +1,64 @@
+# M2-1e forwardWithFailover core — ARCHITECT-lane audit, Round 2 (closure verification)
+
+Round 1 produced `specs/M2_1E_FORWARD_CORE_ARCHITECT_audit.md`:
+**0 CRITICAL / 0 HIGH / 0 MEDIUM / 3 LOW / 0 QUESTIONS**.
+VERDICT: architect lane READY TO MERGE — **ARCH-1 / CODE-1 → RESOLVED**.
+
+The author addressed architect L1 (naming the fourth INTENTIONAL
+divergence). L2 (split callback bag) and L3 (replace `extra any`)
+are explicitly deferred per the round-1 audit's own framing ("before
+adding a fourth transport / before contributors compose pieces").
+
+## Branch / commit
+- Branch: `fix/m2-1e-forward-with-failover-core`
+- Worktree: `../macprovider-m2-1e-forward-core`
+- Read: `git diff origin/main`
+
+## Round-1 findings to verify closure on
+
+- **L1.** Name the retry-budget bypass as the fourth INTENTIONAL
+  transport divergence.
+  - Fix expected: `forward_with_failover.go` doc block now enumerates
+    4 (was 3) INTENTIONAL divergences, with `skipRetryBudgetCheck`
+    explicitly named as #4 with its M2-1d-baseline justification.
+- **L2.** Split callback bag before adding a fourth transport.
+  - Deferred (advisory; this PR doesn't add a fourth transport).
+- **L3.** Replace `extra any` before HTTP callback reuse becomes
+  likely.
+  - Deferred (advisory; current scope is single-transport extra).
+
+## ARCH-1 / CODE-1 gate confirmation
+
+Re-confirm the round-1 ARCHITECT GATE verdict still holds after the
+comment-only fix-pass:
+
+- Single `failoverCandidate` call site (in core)?
+- Single `state.provider = next` same-attempt mutation (in core)?
+- Single-owner-per-category retry-semantics map?
+- Doc trail (REMAINING_WORK.md) still correct (ARCH-1 / CODE-1
+  entries removed; M2-1 row `RESOLVED`; 2026-06-26 sweep note
+  precise)?
+
+## Output format
+
+```
+CLOSURE on round-1 findings:
+  L1: PASS|PARTIAL|FAIL — <one line>
+  L2: <note deferred>
+  L3: <note deferred>
+
+ARCH-1 / CODE-1 GATE: HOLDS | WITHDRAWN — <one-line reason if withdrawn>
+
+NEW FINDINGS (round 2):
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/M2_1E_FORWARD_CORE_ARCHITECT_r2_audit.md`.
+
+If L1 closed AND gate holds AND zero NEW C/H/M, end with:
+`VERDICT: architect lane READY TO MERGE — ARCH-1 / CODE-1 → RESOLVED`

--- a/specs/AUDIT_M2_1E_FORWARD_CORE_ARCHITECT_R3_PROMPT.md
+++ b/specs/AUDIT_M2_1E_FORWARD_CORE_ARCHITECT_R3_PROMPT.md
@@ -1,0 +1,53 @@
+# M2-1e forwardWithFailover core — ARCHITECT-lane R3 (L4 closure + gate re-confirm)
+
+You are the **architect** lane, round 3. r1 + r2 both verdict-line'd
+`READY TO MERGE — ARCH-1 / CODE-1 → RESOLVED`. r2 flagged exactly
+one LOW:
+
+> L4. Secondary documentation still says "three" intentional
+> divergences after L1 made four canonical.
+
+The fix-pass updated two doc comments:
+- `forward_with_failover.go` `transportCallbacks` doc comment (was
+  "three audit-flagged INTENTIONAL differences", now "FOUR ...").
+- `audits/2026-06-10/REMAINING_WORK.md` 2026-06-26 sweep note (was
+  "three audit-flagged INTENTIONAL per-transport differences", now
+  "FOUR ...").
+
+The primary `forwardWithFailover` doc block was already at "FOUR"
+in r2.
+
+## Branch / commit
+- Branch: `fix/m2-1e-forward-with-failover-core`
+- Worktree: `../macprovider-m2-1e-forward-core`
+- Read: `git log -1 --stat` and `git diff origin/main`
+
+## Closure + gate re-confirm
+
+- L4 PASS / FAIL: do the two secondary comments now match the
+  primary doc block's "FOUR"?
+- ARCH-1 / CODE-1 RESOLVED gate: still HOLDS on the committed state?
+- ARCH-1 / CODE-1 entries removed from REMAINING_WORK.md severity
+  punch list: still correct?
+- M2-1 task table row at `RESOLVED`: still correct?
+
+## Output format
+
+```
+L4 CLOSURE: PASS|FAIL — <one line>
+
+ARCH-1 / CODE-1 GATE: HOLDS | WITHDRAWN — <one line if withdrawn>
+
+NEW FINDINGS (r3):
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/M2_1E_FORWARD_CORE_ARCHITECT_r3_audit.md`.
+
+If L4 closes AND gate HOLDS AND zero NEW C/H/M, end with:
+`VERDICT: architect lane READY TO MERGE — ARCH-1 / CODE-1 → RESOLVED`

--- a/specs/AUDIT_M2_1E_FORWARD_CORE_CODE_PROMPT.md
+++ b/specs/AUDIT_M2_1E_FORWARD_CORE_CODE_PROMPT.md
@@ -1,0 +1,174 @@
+# M2-1e forwardWithFailover core — CODE-lane audit
+
+You are the **code** lane of a three-lane audit (code / security /
+architect) of the M2-1e forwardWithFailover core extraction for
+issue #94. Stay narrowly in your lane.
+
+## Branch / commit
+- Branch: `fix/m2-1e-forward-with-failover-core`
+- Worktree: `../macprovider-m2-1e-forward-core` (origin/main base: 4f73f5d)
+- Files in scope (`git diff origin/main`):
+  - `phase4-coordinator/internal/buyer/forward_with_failover.go` (new — shared core + transportCallbacks)
+  - `phase4-coordinator/internal/buyer/server.go` (three sequence helpers now thin wrappers)
+  - `audits/2026-06-10/REMAINING_WORK.md` (ARCH-1 / CODE-1 entries removed; M2-1 row → RESOLVED)
+
+## What the change does (operator summary — NOT the audit answer)
+
+Issue #94 (M2-1e) is the architect's named close-out for ARCH-1 /
+CODE-1 on top of M2-1c (PR #91, three-sequence-helper landing) + M2-1d
+(PR #93, Q3 shared-state-bypass close-out). The architect verdict on
+PR #93 named the shape:
+
+> Scope M2-1e as extraction of a shared `forwardWithFailover` core, or
+> equivalent shared transition core, with transport callbacks for
+> dispatch, success/error rendering, committed handling, and WS-to-HTTP
+> fallthrough.
+
+This branch ships:
+- `forward_with_failover.go` — new file containing `forwardWithFailover`
+  (the shared decision-tree core) + `transportCallbacks` struct + the
+  `dispatchedAttempt` carrier type.
+- `forwardStreamSequence`, `forwardWSNonStreamSequence`,
+  `forwardHTTPSequence` — now thin wrappers that build per-transport
+  callbacks and delegate to the core.
+
+Acceptance criteria (from the issue):
+- `forward_loop_test.go` 12 row-sequence scenarios byte-identical to
+  PR #91 baseline ✅
+- `go test ./internal/buyer -race -count=5` green ✅ (10.5s)
+- Three audit-flagged INTENTIONAL per-transport differences remain
+  flagged in callbacks, not flattened.
+
+## Code-lane scope (apply each; stay in lane)
+
+### CODE-1. Decision-tree semantics preservation
+For each of the three migrated sequences, trace one execution path
+end-to-end against the pre-refactor inline behavior.
+- WS-non-streaming queue-full path: pre-refactor at server.go:1466-
+  1493 (before this branch). After refactor: classifier sets markBusy
+  + retryable=true; core marks fault state + MarkState; the new
+  `skipRetryBudgetCheck` callback returns true for wsForwardQueueFull
+  so shouldRetry is bypassed; logRetryAttempt logs at 502; advance
+  fires; afterAdvance returns true if next provider is non-WS. Confirm
+  this path matches forward_loop_test scenario
+  TestM2_1D_RowSequence_WSNonStreamingQueueFullThroughAdvance
+  byte-for-byte (logAttempt row sequence, retried bumps, status codes).
+- WS-non-streaming failoverEligible miss: pre-refactor at server.go:
+  1444-1455 (fast-fail with 502, NO shouldRetry consultation). After
+  refactor: core fires failover branch; on miss, onFailoverMiss
+  returns handled=true after rendering 502 + logging fast_fail. Trace
+  through the core's failover branch — `tx.onFailoverMiss(...) → if
+  handled return false` correctly bypasses shouldRetry?
+- Streaming HTTP (non-WS) pre-chunk disconnect: pre-refactor at
+  server.go:1337 was `if tr.failoverEligible && wsTunneled` —
+  HTTP-streaming SKIPS the failover branch and falls through to
+  shouldRetry+advance. After refactor: the streaming dispatch
+  callback explicitly clears `tr.failoverEligible` when
+  `!wsTunneled`. Confirm this preserves the byte-identical row
+  sequence in TestM92_RowSequence_HTTPStreaming* (4 scenarios: zero-
+  body, one-byte-partial, comment-only, [DONE]-only). The test
+  expectation is "row 0 status=502 retried=0 for bad provider, row 1
+  status=200 retried=1 for ok provider" — driven by advance, NOT
+  failover.
+- HTTP success path: lives ENTIRELY inside the HTTP dispatch
+  callback (writes body + headers + logs row + returns ok=false).
+  The core's success branch is unused for HTTP. Confirm there's no
+  path that could double-render or skip the cancelAttempt cleanup.
+- HTTP receipt-bearing null-usage early-return: lives inside the
+  HTTP dispatch callback, before the fall-through path. Confirm
+  shouldRetry is called only once (not duplicated between dispatch
+  and the core's shouldRetry gate) for this path. If the early-return
+  fires, dispatch returns ok=false → core returns immediately. If it
+  doesn't fire, dispatch falls through to classify+return ok=true
+  with extra populated; the core then calls shouldRetry again with
+  the classified status — that's a second call but with the same
+  buyer-budget state.
+
+### CODE-2. Core function correctness
+- `forwardWithFailover` (forward_with_failover.go) — branch order:
+  dispatch → committed (streaming-only) → non-retryable terminal
+  short-circuit (WS-NS-only) → success → fault state mutations →
+  failover branch (failoverEligible) → retry budget gate (with
+  skipRetryBudgetCheck opt-out) → logRetryAttempt → advance →
+  afterAdvance. Is this the correct decision-tree order? Is there
+  any path where two callbacks fire when one should?
+- `state.provider = next` mutation in the failover branch lives in
+  the CORE (line ~115 of forward_with_failover.go), not in
+  onFailoverHit callback. Confirm callbacks don't ALSO mutate
+  state.provider (would be a double-mutation bug).
+- `failoverAttempted` flag in the core — never set to false again;
+  scoped to a single forwardWithFailover invocation. Correct?
+- The shared `excluded[routeKey(state.provider)] = struct{}{}` after
+  the success branch — happens BEFORE the failover/retry branches.
+  Pre-refactor inlined this in each helper. Confirm no ordering
+  changes (e.g. the excluded-add must precede failoverCandidate so
+  the candidate isn't the failed provider).
+
+### CODE-3. Callback bundle completeness
+- Each migrated helper provides a transportCallbacks struct. Are
+  there any fields the helper FORGOT to set that the core might
+  invoke? E.g.:
+  - HTTP doesn't set onFailoverHit / onFailoverMiss / afterFailover-
+    Hit — because HTTP's classifyHTTPResult never sets
+    failoverEligible. Confirm the classifier truly never sets it,
+    so the core's `if tr.failoverEligible && tx.onFailoverHit !=
+    nil && tx.onFailoverMiss != nil` guard correctly short-circuits.
+  - Streaming doesn't set handleNonRetryableTerminal — because
+    classifyStreamResult covers Cancelled via committed=true (not
+    via the WS-NS-style short-circuit). Confirm.
+  - WS-NS doesn't set renderCommitted — because classifyWSResult
+    never sets committed=true for non-streaming. Confirm.
+- The streaming dispatch's `if !wsTunneled { tr.failoverEligible =
+  false }` line: is this the cleanest place for that gate, or should
+  it live in the classifier? Architect-overlap — flag as QUESTION,
+  not MEDIUM.
+
+### CODE-4. Byte-identical contract
+- The 12 forward_loop_test scenarios pass post-refactor. List the
+  scenarios and the path each exercises:
+  1. HTTP success first-attempt (forwardHTTPSequence success branch)
+  2. HTTP retry-to-success (HTTP shouldRetry + advance)
+  3. Streaming committed single-row (streaming renderCommitted)
+  4. WS-non-streaming failover doesn't bump retried (WS-NS failover-
+     Hit + afterFailoverHit fallthrough)
+  5-9. HTTP streaming failover scenarios (5 sub-cases: zero-body,
+     one-byte-partial, slow-first-event-commits, comment-only,
+     [DONE]-only, usage-only-first-chunk-commits)
+  10. WS-non-streaming queue-full through advance (M2-1d skip-
+      RetryBudgetCheck path)
+  Are there OTHER row-sequence-sensitive paths not covered by these
+  12 scenarios that the refactor could have broken? Specifically:
+  - HTTP receipt-bearing null-usage early-return (no test).
+  - HTTP non-200 + retry-budget-exhausted (no specific test? exists
+    in TestForwardLoop_HTTP_RetryExhausted?).
+  - WS-non-streaming cancelled + shouldLogAttempt true vs false.
+
+### CODE-5. Comment quality + maintainability
+- Each callback closure carries a 3-5 line comment justifying its
+  per-transport divergence. Comments justifying NON-OBVIOUS code
+  (the retryable/failoverEligible matrix, the cancelAttempt lifetime,
+  the skipRetryBudgetCheck rationale) are good; comments restating
+  what the code does are noise.
+- The new file forward_with_failover.go opens with a doc block
+  enumerating the three INTENTIONAL divergences. Is the wording
+  precise enough that an editor unfamiliar with the audit history
+  would understand WHY each callback exists?
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/M2_1E_FORWARD_CORE_CODE_audit.md` (round suffix on follow-ups).
+
+If 0 CRITICAL/HIGH/MEDIUM, end with:
+`VERDICT: code lane READY TO MERGE`

--- a/specs/AUDIT_M2_1E_FORWARD_CORE_CODE_R2_PROMPT.md
+++ b/specs/AUDIT_M2_1E_FORWARD_CORE_CODE_R2_PROMPT.md
@@ -1,0 +1,61 @@
+# M2-1e forwardWithFailover core — CODE-lane audit, Round 2 (closure verification)
+
+Round 1 produced `specs/M2_1E_FORWARD_CORE_CODE_audit.md`:
+**0 CRITICAL / 0 HIGH / 0 MEDIUM / 2 LOW / 2 QUESTIONS**. The author
+applied targeted fixes for two of the four. Verify closure + flag any
+NEW issue introduced.
+
+## Branch / commit
+- Branch: `fix/m2-1e-forward-with-failover-core`
+- Worktree: `../macprovider-m2-1e-forward-core`
+- Read: `git diff origin/main`
+
+## Round-1 findings to verify closure on
+
+- **L1.** Streaming `onFailoverHit` callback comment misattributed the
+  WS-only gate to the classifier.
+  - Fix expected: comment now clearly states the gate lives in the
+    streaming dispatch callback (`if !wsTunneled { tr.failoverEligible
+    = false }`), with the classifier behavior referenced as background.
+- **L2.** Some row-sequence-sensitive branches lack explicit
+  forward_loop assertions (receipt-bearing null-usage, HTTP retry-budget
+  exhaustion, WS-NS cancelled).
+  - Deferred to follow-up (advisory finding).
+- **Q1.** Should the HTTP-streaming failoverEligible-clearing live in
+  the classifier instead of the dispatch callback?
+  - Architect-overlap; current placement preserves behavior, architect
+    lane chose to leave it as-is.
+- **Q2.** Prompt said 12 scenarios; actual is 11.
+  - Fix expected: count corrected to 11 in
+    `forward_with_failover.go` doc block AND
+    `audits/2026-06-10/REMAINING_WORK.md` 2026-06-26 sweep note.
+
+## Audit lenses for fresh issues (apply briefly)
+
+- The streaming dispatch's `if !wsTunneled { tr.failoverEligible =
+  false }` line — is the new comment self-contained enough?
+- Any other surface where the 11 vs 12 count drifts?
+- Side-effects of comment-only edits — should be none, but verify.
+
+## Output format
+
+```
+CLOSURE on round-1 findings:
+  L1: PASS|PARTIAL|FAIL — <one line>
+  L2: <note deferred>
+  Q1: <note deferred>
+  Q2: PASS|PARTIAL|FAIL — <one line>
+
+NEW FINDINGS (round 2):
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/M2_1E_FORWARD_CORE_CODE_r2_audit.md`.
+
+If all addressed findings closed AND zero NEW CRITICAL/HIGH/MEDIUM,
+end with: `VERDICT: code lane READY TO MERGE`

--- a/specs/AUDIT_M2_1E_FORWARD_CORE_CODE_R3_PROMPT.md
+++ b/specs/AUDIT_M2_1E_FORWARD_CORE_CODE_R3_PROMPT.md
@@ -1,0 +1,50 @@
+# M2-1e forwardWithFailover core — CODE-lane R3 (H1 closure)
+
+You are the **code** lane, round 3. r2 flagged exactly one HIGH:
+
+> H1. The branch diff is not buildable because the extracted core
+> file is untracked.
+> Fix: Add `phase4-coordinator/internal/buyer/forward_with_failover.go`
+> to the branch before merge, then rerun the buyer package tests
+> from a clean checkout/branch diff.
+
+The branch has since been committed with the file staged. Verify
+closure.
+
+## Branch / commit
+- Branch: `fix/m2-1e-forward-with-failover-core`
+- Worktree: `../macprovider-m2-1e-forward-core`
+- Read: `git log -1 --stat` and `git diff origin/main --name-only`
+
+## Closure check
+
+- `git diff origin/main --name-only` MUST include
+  `phase4-coordinator/internal/buyer/forward_with_failover.go`.
+- A fresh clone + `git checkout fix/m2-1e-forward-with-failover-core`
+  + `cd phase4-coordinator && go build ./... && go test ./internal/
+  buyer/... -run 'TestM2_1C_RowSequence|TestM92_RowSequence|TestM2_1D_
+  RowSequence' -count=1` MUST succeed.
+
+## Fresh re-audit lenses (apply briefly)
+
+- Has the committed state introduced any NEW code-lane issue not
+  present in r1 / r2?
+
+## Output format
+
+```
+H1 CLOSURE: PASS|FAIL — <one line>
+
+NEW FINDINGS (r3):
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/M2_1E_FORWARD_CORE_CODE_r3_audit.md`.
+
+If H1 closes AND zero NEW C/H/M, end with:
+`VERDICT: code lane READY TO MERGE`

--- a/specs/AUDIT_M2_1E_FORWARD_CORE_SECURITY_PROMPT.md
+++ b/specs/AUDIT_M2_1E_FORWARD_CORE_SECURITY_PROMPT.md
@@ -1,0 +1,153 @@
+# M2-1e forwardWithFailover core — SECURITY-lane audit
+
+You are the **security** lane of a three-lane audit (code / security /
+architect) of the M2-1e forwardWithFailover core extraction for
+issue #94. Stay narrowly in your lane.
+
+## Branch / commit
+- Branch: `fix/m2-1e-forward-with-failover-core`
+- Worktree: `../macprovider-m2-1e-forward-core` (origin/main base: 4f73f5d)
+- Files in scope (`git diff origin/main`):
+  - `phase4-coordinator/internal/buyer/forward_with_failover.go` (new)
+  - `phase4-coordinator/internal/buyer/server.go` (three sequence helpers refactored)
+  - `audits/2026-06-10/REMAINING_WORK.md` (ledger update)
+
+## Why security cares about this diff
+
+This is buyer-facing money-path code:
+- The three sequence helpers are the chat-completions request hot path.
+- The failover state machine determines which provider gets attributed
+  for a buyer's request — i.e. which provider gets billed credit, which
+  the SPEC-005 ledger keys off `request_log.provider_assigned_id`.
+- attempt_n numbering + logAttempt row sequence MUST be byte-identical
+  to PR #91 baseline (the issue's load-bearing acceptance criterion).
+- The receipt-bearing null-usage early-return path is a money-path
+  primitive (preserves the provider's receipt header when the buyer's
+  retry budget is exhausted).
+
+## Security-lane scope (apply each; stay in lane)
+
+### SEC-1. Money-path semantics preservation under the refactor
+- The 12 row-sequence forward_loop_test scenarios cover the happy-
+  paths + 4 failover-from-HTTP-streaming + 1 WS-NS-queue-full +
+  WS-NS-failover. Are there OTHER money-path invariants the test
+  suite doesn't pin that this refactor could have broken?
+  Specifically:
+  - WS-non-streaming failoverEligible HIT → no logAttempt at the
+    failed provider for the failover row? Pre-refactor at
+    server.go:1458 emitted `logAttempt(state.provider, 502, ...)`
+    INSIDE the failover-hit branch (BEFORE state.provider = next).
+    Confirm the new onFailoverHit callback also emits that row at
+    state.provider (the OLD provider) before the core mutates
+    state.provider = next.
+  - HTTP receipt-bearing null-usage early-return: the receipt header
+    + status code propagate to the buyer verbatim. Confirm the new
+    callback (inside HTTP dispatch) preserves the header-copy +
+    status-code-write order.
+  - Cancelled (buyer disconnected mid-stream after first chunk):
+    streaming renderCommitted gates the logAttempt on shouldLog-
+    Attempt(tr.attempt). Confirm the new callback honors that
+    gating (mis-gating would either over-bill or under-bill the
+    cancelled-but-committed attempt).
+
+### SEC-2. cancelAttempt lifecycle (HTTP-only)
+- HTTP's dispatch callback owns a `cancelAttempt` closure tied to
+  the per-attempt context.WithTimeout. Pre-refactor, cancelAttempt
+  fired on EVERY exit path (success, terminal, retry-advance,
+  read-error, etc.). After refactor, cancelAttempt is local to the
+  dispatch closure. Trace all exit paths inside HTTP dispatch and
+  confirm cancelAttempt fires on each. Specifically:
+  - 200 success with body read error → cancelAttempt fires?
+  - 200 success with logProviderRow error → cancelAttempt fires?
+  - 200 success normal path → cancelAttempt fires?
+  - Receipt-bearing early-return with logProviderRow error → cancel?
+  - Receipt-bearing early-return normal → cancelAttempt fires before
+    return?
+  - Non-200 fall-through path → cancelAttempt fires before classify?
+- A missed cancelAttempt is a goroutine + context leak (the timer
+  fires harmlessly but the context isn't released). Low-blast but
+  diagnose pattern.
+
+### SEC-3. provider_id attribution + billing correctness
+- The failover branch in the core: `tx.onFailoverHit(...) →
+  failoverAttempted = true → state.provider = next →
+  tx.afterFailoverHit(state)`. Confirm `state.provider` at the time
+  of `onFailoverHit` is still the FAILED provider (so the WS dead-
+  mid-request log + logAttempt-at-502 row carry the failed provider,
+  NOT the new one). Pre-refactor at server.go:1457: `next, ok :=
+  s.failoverCandidate(...)` → `s.logWSDeadMidRequest(... state.
+  provider, "failover", next.ProviderID)` → `logAttempt(state.
+  provider, 502, ...)` — both calls use state.provider BEFORE the
+  `state.provider = next` mutation at server.go:1460. The new core
+  preserves this order? Trace the core's failover branch.
+- Could a concurrent call to forwardWithFailover (different buyer
+  request, different goroutine) observe an inconsistent state?
+  Each call gets its own *forwardState; the core doesn't share
+  mutable state with itself across goroutines. Confirm no callback
+  closes over a shared mutable variable that two goroutines could
+  race on (the closures capture `s *Server`, `r *http.Request`,
+  `excluded`, `rec` — all per-request).
+
+### SEC-4. shouldRetry double-call surface in HTTP receipt-bearing path
+- HTTP dispatch's receipt-bearing null-usage branch calls
+  `s.shouldRetry(r, startedAt, state.explicitRetries, state.
+  faultedProviders, status, nil)` to decide whether to early-return.
+  If the early-return DOESN'T fire (budget is fresh), dispatch falls
+  through; the core's retry-budget gate then calls shouldRetry
+  AGAIN with the same arguments. Two consecutive calls with no
+  state mutation between them should return the same value. Confirm
+  shouldRetry is idempotent (no rate-limit-like side effects that
+  count consecutive calls as separate retries).
+- The classifier's `tr.err` for HTTP non-200 is `doErr` (the Go
+  network error). The core's shouldRetry call uses `tr.err`. In the
+  receipt-bearing case, doErr is nil (resp arrived with status code).
+  So the core passes nil err; the receipt-bearing inline call passed
+  nil err. Both match.
+
+### SEC-5. Logged attribution-row taint
+- Each logAttempt / logProviderRow call writes a request_log row.
+  After the refactor, the call sites moved from inline branches into
+  callbacks (closures). Confirm none of the callbacks accidentally
+  log against the WRONG provider (e.g. using state.provider AFTER
+  the core mutated it for failover, or using a captured `next`
+  variable from an outer scope).
+- The new file's onFailoverHit signature passes `next pool.Provider`
+  but the WS-NS callback still uses `state.provider` (the OLD
+  provider) for logWSDeadMidRequest and logAttempt — confirming the
+  core didn't yet mutate state.provider when calling onFailoverHit.
+
+### SEC-6. New surface area in forward_with_failover.go
+- The new file adds ~250 lines of Go in a money-path package. Lint
+  the file for:
+  - any new unchecked error path
+  - any new place that could log via fmt.Fprintf to ResponseWriter
+    (none expected — writes go through writeError / writeStream-
+    ForwardError / explicit w.Write)
+  - any panic-on-nil callback (the core has nil-guards before each
+    optional callback invocation; verify each guard)
+- The `dispatchedAttempt.extra any` field is type-asserted via
+  `dispatched.extra.(httpDispatchExtra)` in the HTTP callbacks.
+  If a future contributor wires the wrong callback for HTTP (or
+  another transport reuses the HTTP callbacks accidentally), this
+  type assertion would panic. Is the cost of `any` worth the
+  flexibility, or should it be a typed interface? Architect-overlap;
+  flag as QUESTION.
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/M2_1E_FORWARD_CORE_SECURITY_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM, end with:
+`VERDICT: security lane READY TO MERGE`

--- a/specs/AUDIT_M2_1E_FORWARD_CORE_SECURITY_R2_PROMPT.md
+++ b/specs/AUDIT_M2_1E_FORWARD_CORE_SECURITY_R2_PROMPT.md
@@ -1,0 +1,56 @@
+# M2-1e forwardWithFailover core — SECURITY-lane audit, Round 2 (closure verification)
+
+Round 1 produced `specs/M2_1E_FORWARD_CORE_SECURITY_audit.md`:
+**0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW / 2 QUESTIONS**.
+VERDICT: security lane READY TO MERGE. The author applied
+comment-only fixes from the code + architect lanes. Re-verify
+nothing security-relevant regressed.
+
+## Branch / commit
+- Branch: `fix/m2-1e-forward-with-failover-core`
+- Worktree: `../macprovider-m2-1e-forward-core`
+- Read: `git diff origin/main`
+
+## Round-1 questions (informational)
+
+- **Q1.** shouldRetry not strictly time-idempotent — receipt-bearing
+  path calls shouldRetry twice across dispatch + core; a deadline /
+  cancel boundary could cause the second call to return false and
+  use the generic terminal renderer instead of the receipt-preserving
+  path. Acknowledged as preserved-from-pre-refactor behavior.
+- **Q2.** `dispatchedAttempt.extra any` future-proofing — addressed
+  in architect lane L3.
+
+## Audit lenses for fresh issues (comment-only fix-pass)
+
+The only edits since r1 are comment-only:
+- `forward_with_failover.go` doc block: enumerated 4 INTENTIONAL
+  divergences (was 3); count corrected to 11.
+- `server.go` streaming `onFailoverHit` callback comment rewritten.
+- `audits/2026-06-10/REMAINING_WORK.md` count corrected to 11.
+
+Confirm:
+- No money-path semantic change.
+- No new cancelAttempt / shouldRetry / logAttempt call site.
+- No provider attribution surface change.
+
+## Output format
+
+```
+CLOSURE on round-1 findings:
+  Q1: noted (pre-refactor preserved)
+  Q2: noted (cross-lane to architect)
+
+NEW FINDINGS (round 2):
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/M2_1E_FORWARD_CORE_SECURITY_r2_audit.md`.
+
+If zero NEW CRITICAL/HIGH/MEDIUM, end with:
+`VERDICT: security lane READY TO MERGE`

--- a/specs/AUDIT_M2_1E_FORWARD_CORE_SECURITY_R3_PROMPT.md
+++ b/specs/AUDIT_M2_1E_FORWARD_CORE_SECURITY_R3_PROMPT.md
@@ -1,0 +1,37 @@
+# M2-1e forwardWithFailover core — SECURITY-lane R3 (post-commit re-verify)
+
+You are the **security** lane, round 3. r1 + r2 both verdict-line'd
+`READY TO MERGE` with 0 C/H/M. Since r2, the fix-pass:
+1. Staged the previously-untracked `forward_with_failover.go`.
+2. Updated 2 doc comments to say "FOUR" intentional divergences.
+
+Re-verify nothing security-relevant regressed on the committed state.
+
+## Branch / commit
+- Branch: `fix/m2-1e-forward-with-failover-core`
+- Worktree: `../macprovider-m2-1e-forward-core`
+- Read: `git log -1 --stat` and `git diff origin/main`
+
+## Closure check
+
+- No new money-path semantic change vs r2.
+- No new cancelAttempt / shouldRetry / logAttempt / logProviderRow /
+  failoverCandidate call site.
+- No provider attribution surface change.
+
+## Output format
+
+```
+NEW FINDINGS (r3):
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/M2_1E_FORWARD_CORE_SECURITY_r3_audit.md`.
+
+If zero NEW C/H/M, end with:
+`VERDICT: security lane READY TO MERGE`

--- a/specs/M2_1E_FORWARD_CORE_ARCHITECT_audit.md
+++ b/specs/M2_1E_FORWARD_CORE_ARCHITECT_audit.md
@@ -1,0 +1,63 @@
+CRITICAL (0):
+  (none)
+
+HIGH (0):
+  (none)
+
+MEDIUM (0):
+  (none)
+
+LOW (3):
+  L1. Name the retry-budget bypass as the fourth intentional transport divergence
+      Evidence: phase4-coordinator/internal/buyer/forward_with_failover.go:155
+      Fix:     Keep the behavior non-blocking, but prefer a classifier-owned flag such as `advanceWithoutRetryBudget` or a prominently named "INTENTIONAL difference #4" note so queue-full bypass semantics are data, not callback policy.
+
+  L2. Split the callback bag if this core grows another transport or result branch
+      Evidence: phase4-coordinator/internal/buyer/forward_with_failover.go:204
+      Fix:     Leave the current flat `transportCallbacks` struct for M2-1e, but split mandatory callbacks from optional divergence hooks before adding a fourth transport or more terminal branches.
+
+  L3. Replace `extra any` before HTTP callback reuse becomes likely
+      Evidence: phase4-coordinator/internal/buyer/forward_with_failover.go:348
+      Fix:     Keep the current escape hatch for this branch, but replace it with a typed per-attempt payload interface or transport-specific wrapper before contributors start composing HTTP and WS callback pieces.
+
+QUESTIONS (0):
+  (none)
+
+ARCHITECT GATE:
+  The branch satisfies the named M2-1e close-out shape. The shared core owns the loop and transition order: dispatch, committed early-exit, terminal short-circuit, success, fault marking, failoverCandidate, retry-budget check, advanceToNextProvider, and WS-to-HTTP fallthrough all flow through `forwardWithFailover`.
+
+  Callback mapping is complete:
+  - dispatch: `tx.dispatch` at phase4-coordinator/internal/buyer/forward_with_failover.go:68
+  - success rendering: `tx.renderSuccess` at phase4-coordinator/internal/buyer/forward_with_failover.go:107
+  - error rendering: `tx.renderRetryExhausted` at phase4-coordinator/internal/buyer/forward_with_failover.go:165
+  - committed handling: `tx.renderCommitted` at phase4-coordinator/internal/buyer/forward_with_failover.go:82
+  - WS-to-HTTP fallthrough: `tx.afterFailoverHit` and `tx.afterAdvance` at phase4-coordinator/internal/buyer/forward_with_failover.go:137 and phase4-coordinator/internal/buyer/forward_with_failover.go:190
+
+  The additional callbacks are not evidence of three leftover inline state machines. They carry transport-specific rendering, logging, terminal envelopes, and fallthrough behavior while the core owns shared mutation order. The only design smell is `skipRetryBudgetCheck`: it is a real preserved transport divergence, not a blocker, but it should be documented as the fourth intentional difference or moved into a classifier-owned flag.
+
+ONE STATE MACHINE CHECK:
+  Confirmed by search: the only executable `failoverCandidate` call is in the shared core at phase4-coordinator/internal/buyer/forward_with_failover.go:132. The helper mentions are comments around callback construction, not calls.
+
+  Confirmed by search: the failover same-attempt provider mutation is centralized at phase4-coordinator/internal/buyer/forward_with_failover.go:136. The other executable provider assignments are initial route selection at phase4-coordinator/internal/buyer/server.go:1220 and normal retry advance at phase4-coordinator/internal/buyer/server.go:1767.
+
+  Retry-semantics edits now have a single owner by category: budget semantics in `shouldRetry` at phase4-coordinator/internal/buyer/server.go:3323, candidate selection in `failoverCandidate` at phase4-coordinator/internal/buyer/server.go:2886, advance mutation in `advanceToNextProvider` at phase4-coordinator/internal/buyer/server.go:1748, and cross-transport loop order in `forwardWithFailover` at phase4-coordinator/internal/buyer/forward_with_failover.go:51.
+
+COST / BENEFIT:
+  The abstraction is worth the visual cost. Net code volume is similar, but the previous drift risk was not line count; it was three places owning retry/failover transition order. This branch moves that order into one function while preserving the audit-flagged transport differences in explicit callback bundles.
+
+  The `transportCallbacks` shape is acceptable for this close-out because all optional hooks map to known divergences. It should not be treated as an open-ended extension point: adding a new transport should trigger a small interface cleanup first.
+
+  The `dispatchedAttempt.extra any` risk is real but low. The current type assertions are limited to HTTP callbacks at phase4-coordinator/internal/buyer/server.go:1698 and phase4-coordinator/internal/buyer/server.go:1712, so miswiring would be caught quickly in tests or panic visibly. This does not block the gate.
+
+CROSS-CUTTING FOLLOW-UP:
+  New work made easier: adding another transport can be done by adding a classifier/callback bundle instead of cloning the loop; cross-transport per-attempt instrumentation can be inserted in the core; failover eligibility policy changes have one core branch plus classifier inputs to update.
+
+  Still hard/unchanged: classifier semantics remain the true transport decision matrix at phase4-coordinator/internal/buyer/transport_result.go:85, phase4-coordinator/internal/buyer/transport_result.go:125, and phase4-coordinator/internal/buyer/transport_result.go:184. Handler-level stream / WS / HTTP dispatch remains in `handleChatCompletions` at phase4-coordinator/internal/buyer/server.go:1231. That dispatch should not move into the core now; it chooses transport family before the failover loop starts and does not duplicate retry/failover state transitions.
+
+DOC TRAIL:
+  The `REMAINING_WORK.md` strip-out is correct under the stated doc contract: RESOLVED and RESOLVED_DIFFERENTLY items do not appear in the severity punch list. The 2026-06-26 sweep note is precise enough for a future reader: it names M2-1e, the shared core, the three thin wrappers, the transition chain, and the preserved intentional differences at audits/2026-06-10/REMAINING_WORK.md:7. The M2-1 task row is correctly marked `RESOLVED` at audits/2026-06-10/REMAINING_WORK.md:89.
+
+VALIDATION:
+  Ran `go test ./internal/buyer -run 'TestM2_1C|TestM92|TestM2_1D' -count=1` from `phase4-coordinator`; result: pass.
+
+VERDICT: architect lane READY TO MERGE — ARCH-1 / CODE-1 → RESOLVED

--- a/specs/M2_1E_FORWARD_CORE_ARCHITECT_r2_audit.md
+++ b/specs/M2_1E_FORWARD_CORE_ARCHITECT_r2_audit.md
@@ -1,0 +1,29 @@
+CLOSURE on round-1 findings:
+  L1: PASS — `forwardWithFailover` now names FOUR intentional divergences and explicitly lists `skipRetryBudgetCheck` / WS-non-streaming queue-full budget bypass as #4 with the M2-1d baseline test justification (`phase4-coordinator/internal/buyer/forward_with_failover.go:20`, `:35`).
+  L2: Deferred — advisory before adding a fourth transport or more terminal branches; this pass does not add a fourth transport.
+  L3: Deferred — advisory before HTTP callback reuse becomes likely; current `extra any` use remains single-transport HTTP scratch state.
+
+ARCH-1 / CODE-1 GATE: HOLDS — executable state-machine ownership still centralizes `failoverCandidate`, same-attempt `state.provider = next`, retry-budget policy, and normal retry advance in the shared core/helper set.
+
+NEW FINDINGS (round 2):
+CRITICAL (0): none
+HIGH (0): none
+MEDIUM (0): none
+LOW (1):
+  L4. Secondary documentation still says "three" intentional divergences after L1 made four canonical.
+      Evidence: `transportCallbacks`'s comment still says the shape isolates "the three audit-flagged INTENTIONAL differences" at `phase4-coordinator/internal/buyer/forward_with_failover.go:205`; `REMAINING_WORK.md`'s 2026-06-26 sweep note also names only three preserved INTENTIONAL differences at `audits/2026-06-10/REMAINING_WORK.md:7`.
+      Impact: Non-blocking documentation drift only. The primary `forwardWithFailover` block, the WS callback comment, and the skip hook itself correctly name the fourth queue-full retry-budget bypass.
+      Fix: Update the secondary comments to say four divergences, or explicitly distinguish the original three PR #93 divergences from the fourth M2-1e/M2-1d queue-full budget bypass.
+QUESTIONS (0): none
+
+GATE EVIDENCE:
+  - Single executable `failoverCandidate` call site: `phase4-coordinator/internal/buyer/forward_with_failover.go:139`.
+  - Single same-attempt failover mutation: `phase4-coordinator/internal/buyer/forward_with_failover.go:143`. Other provider assignments are initial selection (`server.go:1220`) and normal retry advance (`server.go:1770`).
+  - Single-owner-per-category retry semantics map still holds: budget gate in `forwardWithFailover` / `shouldRetry`; same-attempt failover selection in `failoverCandidate`; retry mutation in `advanceToNextProvider`; per-transport rendering/log envelopes in callback bundles.
+  - Doc trail remains gate-sufficient: ARCH-1 / CODE-1 entries are removed from the severity punch list and the M2-1 row is `RESOLVED` at `audits/2026-06-10/REMAINING_WORK.md:89`. The only doc-trail issue is LOW L4's stale "three" count in the sweep note.
+
+VALIDATION:
+  - Ran from `phase4-coordinator`: `go test ./internal/buyer -run 'TestM2_1C|TestM92|TestM2_1D' -count=1`
+  - Result: pass (`ok github.com/augstar/macprovider-coordinator/internal/buyer 0.361s`).
+
+VERDICT: architect lane READY TO MERGE — ARCH-1 / CODE-1 → RESOLVED

--- a/specs/M2_1E_FORWARD_CORE_ARCHITECT_r3_audit.md
+++ b/specs/M2_1E_FORWARD_CORE_ARCHITECT_r3_audit.md
@@ -1,0 +1,20 @@
+L4 CLOSURE: PASS — the primary `forwardWithFailover` block, `transportCallbacks` comment, and 2026-06-26 `REMAINING_WORK.md` sweep note all now name the FOUR intentional per-transport divergences.
+
+ARCH-1 / CODE-1 GATE: HOLDS — committed state still centralizes `failoverCandidate`, same-attempt `state.provider = next`, retry-budget policy, and normal retry advance in the shared core/helper set.
+
+NEW FINDINGS (r3):
+CRITICAL (0): none
+HIGH (0): none
+MEDIUM (0): none
+LOW (0): none
+QUESTIONS (0): none
+
+GATE EVIDENCE:
+  - `phase4-coordinator/internal/buyer/forward_with_failover.go` is tracked in `git diff --name-status origin/main`, closing the r2 CODE-lane tracked-file blocker.
+  - L4 text check: `phase4-coordinator/internal/buyer/forward_with_failover.go:20` says `The FOUR INTENTIONAL`; `phase4-coordinator/internal/buyer/forward_with_failover.go:208` says `shape isolates the FOUR audit-flagged INTENTIONAL differences`; `audits/2026-06-10/REMAINING_WORK.md:7` says `The FOUR audit-flagged INTENTIONAL per-transport differences`.
+  - Single executable `failoverCandidate` call site remains `phase4-coordinator/internal/buyer/forward_with_failover.go:139`.
+  - Single same-attempt failover mutation remains `phase4-coordinator/internal/buyer/forward_with_failover.go:143`; the other provider assignments are initial selection in `server.go:1220` and normal retry advance in `server.go:1770`.
+  - ARCH-1 / CODE-1 per-finding entries remain absent from the severity punch list; the M2-1 task row remains `RESOLVED` at `audits/2026-06-10/REMAINING_WORK.md:89`.
+  - Validation: from `phase4-coordinator`, `go test ./internal/buyer -run 'TestM2_1C_RowSequence|TestM92_RowSequence|TestM2_1D_RowSequence' -count=1` passed (`ok github.com/augstar/macprovider-coordinator/internal/buyer 0.336s`).
+
+VERDICT: architect lane READY TO MERGE — ARCH-1 / CODE-1 → RESOLVED

--- a/specs/M2_1E_FORWARD_CORE_CODE_audit.md
+++ b/specs/M2_1E_FORWARD_CORE_CODE_audit.md
@@ -1,0 +1,56 @@
+CRITICAL (0):
+  (none)
+
+HIGH (0):
+  (none)
+
+MEDIUM (0):
+  (none)
+
+LOW (2):
+  L1. Streaming failover-hit comment now misattributes the WS-only gate to the classifier.
+      Evidence: phase4-coordinator/internal/buyer/server.go:1314, phase4-coordinator/internal/buyer/server.go:1324, phase4-coordinator/internal/buyer/server.go:1354
+      Fix:     Update the callback comment to say the dispatch callback clears failoverEligible for non-WS streaming attempts, or move that gate into the classifier if the architecture lane chooses that shape.
+
+  L2. Some row-sequence-sensitive branches remain covered functionally, but not by forward_loop row-sequence assertions.
+      Evidence: phase4-coordinator/internal/buyer/server.go:1647, phase4-coordinator/internal/buyer/server_test.go:990, phase4-coordinator/internal/buyer/server.go:1452, phase4-coordinator/internal/buyer/server_test.go:2873
+      Fix:     Add focused row-sequence tests before the next core edit for receipt-bearing null-usage early-return, HTTP retry-budget exhaustion, and WS-non-streaming cancelled logging/no-logging.
+
+QUESTIONS (2):
+  Q1. Should the HTTP-streaming pre-chunk failover gate live in classifyStreamResult instead of the streaming dispatch callback?
+      Evidence: phase4-coordinator/internal/buyer/server.go:1314, phase4-coordinator/internal/buyer/server.go:1324, phase4-coordinator/internal/buyer/transport_result.go:154
+      Fix:     Architect-overlap only: current placement preserves behavior, but classifier ownership would make the transportResult contract more self-contained.
+
+  Q2. The prompt says 12 forward_loop row-sequence scenarios, but the file currently has 11 named RowSequence tests.
+      Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:54, phase4-coordinator/internal/buyer/forward_loop_test.go:755
+      Fix:     Confirm whether the "12" count includes a non-RowSequence test or whether one expected scenario is missing from forward_loop_test.go.
+
+CODE-LANE TRACE NOTES:
+  - Core order reviewed as dispatch -> committed -> non-retryable terminal -> success -> fault mutations -> failover -> retry gate -> log -> advance -> afterAdvance. Evidence: phase4-coordinator/internal/buyer/forward_with_failover.go:68, phase4-coordinator/internal/buyer/forward_with_failover.go:82, phase4-coordinator/internal/buyer/forward_with_failover.go:94, phase4-coordinator/internal/buyer/forward_with_failover.go:106, phase4-coordinator/internal/buyer/forward_with_failover.go:114, phase4-coordinator/internal/buyer/forward_with_failover.go:130, phase4-coordinator/internal/buyer/forward_with_failover.go:163, phase4-coordinator/internal/buyer/forward_with_failover.go:176, phase4-coordinator/internal/buyer/forward_with_failover.go:177, phase4-coordinator/internal/buyer/forward_with_failover.go:190.
+  - WS-non-streaming queue-full path preserves markBusy, retry-budget bypass, 502/503 logAttempt behavior, advance, and HTTP fallthrough guard. Evidence: phase4-coordinator/internal/buyer/transport_result.go:97, phase4-coordinator/internal/buyer/forward_with_failover.go:116, phase4-coordinator/internal/buyer/server.go:1482, phase4-coordinator/internal/buyer/server.go:1499, phase4-coordinator/internal/buyer/forward_with_failover.go:177, phase4-coordinator/internal/buyer/server.go:1509, phase4-coordinator/internal/buyer/forward_loop_test.go:755.
+  - WS-non-streaming failover miss bypasses shouldRetry because onFailoverMiss returns handled=true and the core returns immediately. Evidence: phase4-coordinator/internal/buyer/forward_with_failover.go:145, phase4-coordinator/internal/buyer/server.go:1473.
+  - HTTP-streaming pre-chunk disconnect on non-WS preserves advance-driven retry rather than same-attempt failover by clearing failoverEligible before the core sees it. Evidence: phase4-coordinator/internal/buyer/server.go:1314, phase4-coordinator/internal/buyer/server.go:1324, phase4-coordinator/internal/buyer/forward_loop_test.go:330, phase4-coordinator/internal/buyer/forward_loop_test.go:418, phase4-coordinator/internal/buyer/forward_loop_test.go:549, phase4-coordinator/internal/buyer/forward_loop_test.go:616.
+  - HTTP 200 success is rendered entirely inside dispatch and returns ok=false, so the core success branch cannot double-render; cancelAttempt is called before return. Evidence: phase4-coordinator/internal/buyer/server.go:1606, phase4-coordinator/internal/buyer/server.go:1632, phase4-coordinator/internal/buyer/server.go:1636, phase4-coordinator/internal/buyer/forward_with_failover.go:68.
+  - HTTP receipt-bearing null-usage early-return calls shouldRetry only in dispatch and returns ok=false on terminal handling; if retry continues, the core later consults shouldRetry once for the classified attempt. Evidence: phase4-coordinator/internal/buyer/server.go:1651, phase4-coordinator/internal/buyer/server.go:1668, phase4-coordinator/internal/buyer/server.go:1673, phase4-coordinator/internal/buyer/forward_with_failover.go:163.
+  - The core is the only failover-hit state.provider mutator; callbacks log but do not also assign state.provider. Evidence: phase4-coordinator/internal/buyer/forward_with_failover.go:134, phase4-coordinator/internal/buyer/forward_with_failover.go:136, phase4-coordinator/internal/buyer/server.go:1353, phase4-coordinator/internal/buyer/server.go:1466.
+  - failoverAttempted is per forwardWithFailover invocation and only flips false -> true after a hit. Evidence: phase4-coordinator/internal/buyer/forward_with_failover.go:62, phase4-coordinator/internal/buyer/forward_with_failover.go:135.
+  - The failed route is added to excluded before failoverCandidate/advance, matching the preserved streaming/WS ordering and the HTTP entry excluded seeding. Evidence: phase4-coordinator/internal/buyer/forward_with_failover.go:114, phase4-coordinator/internal/buyer/forward_with_failover.go:132, phase4-coordinator/internal/buyer/server.go:1243, phase4-coordinator/internal/buyer/server.go:1247.
+
+FORWARD_LOOP SCENARIOS:
+  1. TestM2_1C_RowSequence_HTTPSuccessFirstAttempt: HTTP dispatch handles 200 success inline. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:54, phase4-coordinator/internal/buyer/server.go:1606.
+  2. TestM2_1C_RowSequence_HTTPRetryToSuccess: HTTP shouldRetry + logProviderRow + advance. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:100, phase4-coordinator/internal/buyer/server.go:1711.
+  3. TestM2_1C_RowSequence_StreamingCommittedSingleRow: streaming renderCommitted early return. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:169, phase4-coordinator/internal/buyer/server.go:1333.
+  4. TestM2_1C_RowSequence_WSNonStreamingFailoverDoesNotBumpRetried: WS-non-streaming failover hit and afterFailoverHit fallthrough. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:240, phase4-coordinator/internal/buyer/server.go:1466.
+  5. TestM92_RowSequence_HTTPStreamingZeroBodyTriggersFailover: non-WS streaming pre-chunk disconnect advances to success. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:330, phase4-coordinator/internal/buyer/server.go:1324.
+  6. TestM92_RowSequence_HTTPStreamingOneBytePartialTriggersFailover: non-WS streaming invalid pre-commit byte advances to success. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:418, phase4-coordinator/internal/buyer/server.go:1324.
+  7. TestM92_RowSequence_HTTPStreamingSlowFirstEventCommits: valid first event commits with one 200 row. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:495, phase4-coordinator/internal/buyer/server.go:1333.
+  8. TestM92_RowSequence_HTTPStreamingCommentOnlyTriggersFailover: comment-only pre-commit advances to success. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:549, phase4-coordinator/internal/buyer/server.go:1324.
+  9. TestM92_RowSequence_HTTPStreamingDoneOnlyTriggersFailover: DONE-only pre-commit advances to success. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:616, phase4-coordinator/internal/buyer/server.go:1324.
+  10. TestM92_RowSequence_HTTPStreamingUsageOnlyFirstChunkCommits: usage-only first chunk commits with one 200 row. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:685, phase4-coordinator/internal/buyer/server.go:1333.
+  11. TestM2_1D_RowSequence_WSNonStreamingQueueFullThroughAdvance: WS-non-streaming queue-full skips shouldRetry and advances. Evidence: phase4-coordinator/internal/buyer/forward_loop_test.go:755, phase4-coordinator/internal/buyer/server.go:1482.
+
+VALIDATION:
+  - go test ./internal/buyer -run 'TestM2_1C_RowSequence|TestM92_RowSequence|TestM2_1D_RowSequence' -count=1: PASS
+  - go test ./internal/buyer -race -count=5: PASS
+
+VERDICT: code lane READY TO MERGE

--- a/specs/M2_1E_FORWARD_CORE_CODE_r2_audit.md
+++ b/specs/M2_1E_FORWARD_CORE_CODE_r2_audit.md
@@ -1,0 +1,29 @@
+CLOSURE on round-1 findings:
+  L1: PASS — `onFailoverHit` now says the WS-only gate is enforced by the streaming dispatch callback's `if !wsTunneled { tr.failoverEligible = false }`, while the classifier behavior is referenced only as background.
+  L2: Deferred advisory — no closure expected in this round; row-sequence-sensitive follow-up assertions remain advisory.
+  Q1: Deferred architect-overlap — current placement in the streaming dispatch callback is unchanged and matches the architect lane's leave-as-is decision.
+  Q2: PASS — active code/doc count is corrected to 11 in `forward_with_failover.go` and the 2026-06-26 sweep note in `audits/2026-06-10/REMAINING_WORK.md`.
+
+NEW FINDINGS (round 2):
+CRITICAL (0):
+  (none)
+
+HIGH (1):
+  H1. The branch diff is not buildable because the extracted core file is untracked.
+      Evidence: `git diff --name-only origin/main` lists only `audits/2026-06-10/REMAINING_WORK.md` and `phase4-coordinator/internal/buyer/server.go`, while `git status -sb` shows `?? phase4-coordinator/internal/buyer/forward_with_failover.go`. Applying only `git diff origin/main` to a clean `origin/main` worktree and running `go test ./internal/buyer -run 'TestM2_1C_RowSequence' -count=1` fails with undefined symbols from `server.go` (`transportCallbacks`, `dispatchedAttempt`, etc.).
+      Risk: A PR/merge built from the tracked branch diff will fail to compile; local tests pass only because the untracked file exists in this worktree.
+      Fix: Add `phase4-coordinator/internal/buyer/forward_with_failover.go` to the branch before merge, then rerun the buyer package tests from a clean checkout/branch diff.
+
+MEDIUM (0):
+  (none)
+
+LOW (0):
+  (none)
+
+QUESTIONS (0):
+  (none)
+
+VALIDATION:
+  - `rg '^func Test.*RowSequence' phase4-coordinator/internal/buyer/forward_loop_test.go`: 11 named RowSequence tests.
+  - Local worktree `go test ./internal/buyer -run 'TestM2_1C_RowSequence|TestM92_RowSequence|TestM2_1D_RowSequence' -count=1`: PASS, confirming the present worktree builds when the untracked core file is available.
+  - Clean `origin/main` worktree + only `git diff origin/main` applied + targeted buyer test: FAIL with undefined `transportCallbacks` / `dispatchedAttempt`, confirming H1.

--- a/specs/M2_1E_FORWARD_CORE_CODE_r3_audit.md
+++ b/specs/M2_1E_FORWARD_CORE_CODE_r3_audit.md
@@ -1,0 +1,10 @@
+H1 CLOSURE: PASS — `git diff origin/main --name-only` includes `phase4-coordinator/internal/buyer/forward_with_failover.go`; fresh clone checkout of `fix/m2-1e-forward-with-failover-core` passed `go build ./...` and the requested buyer row-sequence test filter.
+
+NEW FINDINGS (r3):
+CRITICAL (0): (none)
+HIGH (0): (none)
+MEDIUM (0): (none)
+LOW (0): (none)
+QUESTIONS (0): (none)
+
+VERDICT: code lane READY TO MERGE

--- a/specs/M2_1E_FORWARD_CORE_SECURITY_audit.md
+++ b/specs/M2_1E_FORWARD_CORE_SECURITY_audit.md
@@ -1,0 +1,22 @@
+CRITICAL (0):
+
+HIGH (0):
+
+MEDIUM (0):
+
+LOW (0):
+
+QUESTIONS (2):
+  Q1. shouldRetry has no retry-counter/rate-limit side effects, but it is not strictly time-idempotent.
+      Evidence: phase4-coordinator/internal/buyer/server.go:1652
+      Evidence: phase4-coordinator/internal/buyer/forward_with_failover.go:164
+      Evidence: phase4-coordinator/internal/buyer/server.go:3323
+      Question: The receipt-bearing null-usage branch still calls shouldRetry once inline and, if retry remains allowed, lets the core call shouldRetry again; this matches the pre-refactor shape, and shouldRetry mutates no retry counters, but it reads r.Context() and s.now(), so a deadline/cancel boundary could make the second check return false and use the generic HTTP terminal renderer instead of the receipt-preserving path.
+
+  Q2. HTTP callbacks depend on an untyped dispatchedAttempt.extra assertion.
+      Evidence: phase4-coordinator/internal/buyer/forward_with_failover.go:348
+      Evidence: phase4-coordinator/internal/buyer/server.go:1698
+      Evidence: phase4-coordinator/internal/buyer/server.go:1712
+      Question: Current wiring only sets httpDispatchExtra from the HTTP dispatch callback, so this is not a present attribution bug; should a future hardening pass replace extra any with a typed interface or per-transport typed wrapper to prevent accidental callback reuse from becoming a panic?
+
+VERDICT: security lane READY TO MERGE

--- a/specs/M2_1E_FORWARD_CORE_SECURITY_r2_audit.md
+++ b/specs/M2_1E_FORWARD_CORE_SECURITY_r2_audit.md
@@ -1,0 +1,20 @@
+CLOSURE on round-1 findings:
+  Q1: noted (pre-refactor preserved)
+  Q2: noted (cross-lane to architect)
+
+NEW FINDINGS (round 2):
+CRITICAL (0): none
+HIGH (0): none
+MEDIUM (0): none
+LOW (0): none
+QUESTIONS (0): none
+
+Evidence:
+- Reviewed `git diff origin/main` for `phase4-coordinator/internal/buyer/server.go` and `audits/2026-06-10/REMAINING_WORK.md`.
+- Also reviewed `phase4-coordinator/internal/buyer/forward_with_failover.go` directly because it is currently untracked in this worktree while `server.go` depends on it.
+- Money-path semantics: no new security-relevant regression found. The shared core preserves the established order: mark failed route/busy state, failover candidate branch, retry-budget gate, per-attempt log, and `advanceToNextProvider`.
+- Call sites: no new independent `cancelAttempt`, `shouldRetry`, `logAttempt`/`logProviderRow`, `failoverCandidate`, or provider-failure attribution path was introduced beyond the extracted core/callback split already covered by round 1. Q1's receipt-bearing double `shouldRetry` shape remains preserved-from-pre-refactor behavior.
+- Provider attribution: success and receipt-bearing terminal paths still copy receipt headers and set `X-MacProvider-Provider` / `X-MacProvider-Route` from `state.provider` before writing the response.
+- Validation: `go test ./internal/buyer -race -count=1` passed.
+
+VERDICT: security lane READY TO MERGE

--- a/specs/M2_1E_FORWARD_CORE_SECURITY_r3_audit.md
+++ b/specs/M2_1E_FORWARD_CORE_SECURITY_r3_audit.md
@@ -1,0 +1,15 @@
+NEW FINDINGS (r3):
+CRITICAL (0): none
+HIGH (0): none
+MEDIUM (0): none
+LOW (0): none
+QUESTIONS (0): none
+
+Evidence:
+- Read `git log -1 --stat`: committed state includes `phase4-coordinator/internal/buyer/forward_with_failover.go`; the commit message documents the doc-comment correction to FOUR intentional divergences.
+- Read `git diff origin/main`: no security-relevant semantic change beyond the r1/r2-reviewed extraction shape was found.
+- Closure surfaces checked: no new independent `cancelAttempt`, `shouldRetry`, `logAttempt`, `logProviderRow`, or `failoverCandidate` call site beyond the extracted core/callback split already reviewed in r2.
+- Provider attribution checked: HTTP success and receipt-bearing terminal paths still set `X-MacProvider-Provider` / `X-MacProvider-Route` from `state.provider`; no provider attribution surface change found.
+- Validation: `git diff --check origin/main` passed; `go test ./internal/buyer -run 'Test(M92|M2_1|M2_1D).*RowSequence|TestM2_1D_RowSequence_WSNonStreamingQueueFullThroughAdvance' -count=1` passed.
+
+VERDICT: security lane READY TO MERGE


### PR DESCRIPTION
## Summary

Closes issue #94 — the architect-named M2-1e close-out for ARCH-1 / CODE-1, on top of M2-1c (PR #91, three-sequence-helper landing) + M2-1d (PR #93, Q3 shared-state-bypass close-out).

The architect verdict on PR #93 named the shape:

> Scope M2-1e as extraction of a shared `forwardWithFailover` core, or equivalent shared transition core, with transport callbacks for dispatch, success/error rendering, committed handling, and WS-to-HTTP fallthrough.

This branch ships that core.

## Changes

**`phase4-coordinator/internal/buyer/forward_with_failover.go` (NEW)**
- `s.forwardWithFailover()` shared decision-tree core
- `transportCallbacks` struct (12 fields)
- `dispatchedAttempt` carrier

The core owns: dispatch → committed early-exit → non-retryable terminal short-circuit → success → fault state mutations → `failoverCandidate` same-attempt re-route (with `state.provider = next` mutation) → `shouldRetry` budget gate (with `skipRetryBudgetCheck` opt-out) → `logRetryAttempt` → `advanceToNextProvider` → `afterAdvance` (WS-to-HTTP fallthrough signal).

**`phase4-coordinator/internal/buyer/server.go`** — three sequence helpers now thin wrappers (80-120 lines each of callback construction).

**FOUR INTENTIONAL per-transport divergences preserved in callbacks (NOT flattened):**

1. HTTP per-attempt `context.WithTimeout(...)` — inside HTTP dispatch.
2. WS-non-streaming `failoverEligible+retryable=false` → fast-fail via `onFailoverMiss` returning handled=true; streaming returns handled=false (falls through to shouldRetry).
3. Streaming committed early-exit — `renderCommitted` callback.
4. WS-non-streaming queue-full bypasses shouldRetry — `skipRetryBudgetCheck` callback. Caught by the M2-1e cap=1 test sweep; preserves M2-1d baseline pinned by `TestM2_1D_RowSequence_WSNonStreamingQueueFullThroughAdvance`.

**`audits/2026-06-10/REMAINING_WORK.md`** — ARCH-1 + CODE-1 entries removed per the doc contract (RESOLVED items do not appear). 2026-06-26 sweep note added. M2-1 task table row promoted to `RESOLVED`.

## Money-path invariant

11 `forward_loop_test.go` row-sequence scenarios byte-identical to PR #91 baseline. `attempt_n` numbering, `logAttempt` row sequence, `retried` bumps, and provider attribution all preserved exactly.

## Codex audit loop — three independent lanes (code / security / architect)

Per the repo's lock convention (SPEC-001 v1.3, SPEC-010 v1.5, SPEC-015 v0.3) — three separate codex invocations, NOT one combined-lens prompt.

| Round | code | security | architect |
|---|---|---|---|
| r1 | 0 C / 0 H / 0 M / 2 L / 2 Q | 0 / 0 / 0 / 0 / 2 | 0 / 0 / 0 / 3 / 0 — **ARCH-1/CODE-1 → RESOLVED** |
| r2 (post-fix) | 0 / **1H** / 0 / 0 / 0 (untracked file) | 0 / 0 / 0 / 0 / 0 — READY TO MERGE | 0 / 0 / 0 / 1L / 0 — gate HOLDS |
| r3 (post-fix) | **0 / 0 / 0 / 0 / 0 — READY TO MERGE** | **0 / 0 / 0 / 0 / 0 — READY TO MERGE** | **0 / 0 / 0 / 0 / 0 — ARCH-1/CODE-1 → RESOLVED** |

All three lanes converged at 0 C/H/M on r3. Architect lane verdict-line'd RESOLVED gate on every round.

Audit prompts + reports:
- code: [r1 prompt](specs/AUDIT_M2_1E_FORWARD_CORE_CODE_PROMPT.md) / [r1 report](specs/M2_1E_FORWARD_CORE_CODE_audit.md) → [r2](specs/M2_1E_FORWARD_CORE_CODE_r2_audit.md) → [r3](specs/M2_1E_FORWARD_CORE_CODE_r3_audit.md)
- security: [r1 prompt](specs/AUDIT_M2_1E_FORWARD_CORE_SECURITY_PROMPT.md) / [r1 report](specs/M2_1E_FORWARD_CORE_SECURITY_audit.md) → [r2](specs/M2_1E_FORWARD_CORE_SECURITY_r2_audit.md) → [r3](specs/M2_1E_FORWARD_CORE_SECURITY_r3_audit.md)
- architect: [r1 prompt](specs/AUDIT_M2_1E_FORWARD_CORE_ARCHITECT_PROMPT.md) / [r1 report](specs/M2_1E_FORWARD_CORE_ARCHITECT_audit.md) → [r2](specs/M2_1E_FORWARD_CORE_ARCHITECT_r2_audit.md) → [r3](specs/M2_1E_FORWARD_CORE_ARCHITECT_r3_audit.md)

## Acceptance criteria from issue #94

- [x] `forward_loop_test.go` scenarios byte-identical (11 scenarios — issue said "5" / "12"; actual is 11, caught + corrected by code r2 Q2)
- [x] `go test ./internal/buyer -race -count=5` GREEN (10.5s)
- [x] Architect post-merge verification approves ARCH-1 / CODE-1 RESOLVED (architect lane verdict-line'd on every round)
- [x] `audits/2026-06-10/REMAINING_WORK.md` ARCH-1 / CODE-1 entries removed per the doc contract

## Test plan

- [x] `cd phase4-coordinator && go build ./...`
- [x] `cd phase4-coordinator && go test ./... -timeout 120s` — green in 15.4s
- [x] `cd phase4-coordinator && go test ./internal/buyer -race -count=5 -timeout 600s` — green in 10.5s
- [x] 11 forward_loop_test row-sequence scenarios byte-identical to PR #91 baseline
- [ ] Pearl smoke: a few production buyer requests across all three transports observed to log byte-identical request_log rows

## Deferred / out of scope (advisory findings from the 3-lane audit)

- Split `transportCallbacks` into mandatory + optional groups before adding a fourth transport (architect L2). No fourth transport in this PR.
- Replace `dispatchedAttempt.extra any` with a typed interface before HTTP callback reuse becomes likely (architect L3). Current single-transport use is contained.
- Add focused row-sequence tests for receipt-bearing null-usage early-return, HTTP retry-budget exhaustion, and WS-non-streaming cancelled logging/no-logging paths (code L2). Current scenarios cover the load-bearing byte-identical contract; advisory hardening.
- HTTP-streaming `failoverEligible`-clearing could live in `classifyStreamResult` instead of the streaming dispatch callback (code Q1 / architect ARCH-2). Current placement preserves behavior, architect lane chose leave-as-is.

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
