### PR TITLE
feat(coordinator): trusted-proxy + X-Forwarded-For rate-limit keying (#125)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"os"
 	"os/signal"
 	"reflect"
@@ -283,6 +284,7 @@ func main() {
 		buyer.WithRoutingConfig(cfg.Routing),
 		buyer.WithTier2Config(cfg.Tier2),
 		buyer.WithLimitsConfig(cfg.Limits),
+		buyer.WithTrustedProxies(mustParseTrustedProxies(cfg, logger)),
 		buyer.WithInternalAuthKey(cfg.Auth.OperatorKey),
 		buyer.WithGatewayServiceToken(cfg.Auth.GatewayServiceToken),
 		buyer.WithRelay(wsServer.DispatchInference, time.Duration(cfg.Routing.RequestTimeoutS)*time.Second),
@@ -393,6 +395,24 @@ func main() {
 
 type requestLogPruner interface {
 	PruneBefore(context.Context, time.Time) (int64, error)
+}
+
+// mustParseTrustedProxies parses cfg.Proxy.TrustedProxies into the
+// netip.Prefix slice the buyer Server's rate-limit keying expects.
+// Validate() at config.Load already rejected malformed CIDRs and
+// default-route prefixes, so this helper should never fail in
+// practice. If it DOES fail post-Validate (drift between Validate
+// and TrustedProxyPrefixes, e.g. a future contributor splits the
+// validation), the architect-lane r1 audit (issue #125 L3) called
+// out the prior silent-nil fallback as a weakening of the
+// validation contract — a proxied-clients-collapse bug masquerading
+// as a non-event. Fail-fast at startup instead. Issue #125.
+func mustParseTrustedProxies(cfg config.Config, logger zerolog.Logger) []netip.Prefix {
+	prefixes, err := cfg.TrustedProxyPrefixes()
+	if err != nil {
+		logger.Fatal().Err(err).Msg("trusted_proxies parse failed at startup")
+	}
+	return prefixes
 }
 
 func setupCanarySanctionStore(ctx context.Context, cfg config.Config, db *sql.DB, registry *pool.Registry) (providerws.CanarySanctionStore, error) {

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -3,6 +3,19 @@ listen:
   provider_port: 8444
   bind_address: "127.0.0.1"
 
+proxy:
+  # CIDR ranges whose X-Forwarded-For / X-Real-IP headers the
+  # coordinator honors when deriving the per-source rate-limit key for
+  # /v1/pool/check, /v1/receipt-keys/*, and /catalog/*. Default is
+  # loopback-only — production sits behind nginx on localhost. Add the
+  # proxy's CIDR(s) here ONLY if you front the coordinator with a
+  # non-loopback reverse proxy; expanding to non-actual-proxy CIDRs
+  # lets attackers in those CIDRs spoof their bucket key via
+  # X-Forwarded-For. Issue #125.
+  trusted_proxies:
+    - "127.0.0.0/8"
+    - "::1/128"
+
 pool:
   heartbeat_interval_s: 30
   disconnect_grace_period_s: 30

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -9,6 +9,19 @@ listen:
   provider_port: 8444
   bind_address: "127.0.0.1"
 
+proxy:
+  # Production sits behind nginx on localhost — the default
+  # ["127.0.0.0/8", "::1/128"] is correct. The coordinator parses
+  # X-Forwarded-For / X-Real-IP only when r.RemoteAddr falls in one
+  # of these CIDRs; for any other peer the forwarded headers are
+  # IGNORED so an attacker on the open internet cannot spoof their
+  # bucket key. If you move the coordinator behind a remote LB,
+  # ADD the LB's CIDR here — do NOT widen to non-actual-proxy
+  # ranges. Issue #125.
+  trusted_proxies:
+    - "127.0.0.0/8"
+    - "::1/128"
+
 pool:
   heartbeat_interval_s: 30
   disconnect_grace_period_s: 30

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -16,6 +16,7 @@ import (
 	mrand "math/rand"
 	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"sort"
 	"strings"
@@ -82,6 +83,12 @@ type Server struct {
 	receiptKeysLimiters    map[string]receiptKeysBucket
 	receiptKeysMaxEntries  int
 	receiptKeysTTL         time.Duration
+	// trustedProxies is the parsed CIDR set whose X-Forwarded-For /
+	// X-Real-IP headers the rate-limit keying honors. Pre-parsed at
+	// construction (config.go TrustedProxyPrefixes) so the hot path
+	// never re-parses. Default loopback-only — see WithTrustedProxies.
+	// Issue #125.
+	trustedProxies         []netip.Prefix
 	billingMu              sync.RWMutex
 	billing                *billing.Store
 	billingCfg             config.RewardsConfig
@@ -243,6 +250,25 @@ func WithLimitsConfig(cfg config.LimitsConfig) Option {
 	}
 }
 
+// WithTrustedProxies sets the parsed trusted-proxy CIDR set the
+// rate-limit keying honors. When r.RemoteAddr falls inside one of
+// these prefixes, the coordinator parses X-Forwarded-For (rightmost
+// untrusted hop) / X-Real-IP to derive the per-source key for
+// /v1/pool/check, /v1/receipt-keys/*, and /catalog/* buckets;
+// otherwise r.RemoteAddr is used unmodified so an attacker on the
+// open internet cannot spoof their bucket key by sending those
+// headers themselves. Issue #125.
+//
+// Pass the result of config.Config.TrustedProxyPrefixes(); Validate
+// already rejected malformed CIDRs at Load time. A nil/empty list
+// trusts NO proxy — only direct connections, matching the strictest
+// possible production posture.
+func WithTrustedProxies(prefixes []netip.Prefix) Option {
+	return func(s *Server) {
+		s.trustedProxies = append(s.trustedProxies[:0], prefixes...)
+	}
+}
+
 func (s *Server) SetTier2Config(cfg config.Tier2Config) {
 	s.tier2Mu.Lock()
 	defer s.tier2Mu.Unlock()
@@ -383,6 +409,13 @@ func NewServer(registry *pool.Registry, logger zerolog.Logger, startedAt time.Ti
 		receiptKeysLimiters:    map[string]receiptKeysBucket{},
 		receiptKeysMaxEntries:  4096,
 		receiptKeysTTL:         5 * time.Minute,
+		// Default trusted-proxy set mirrors config.Default()'s
+		// loopback-only posture so callers that construct via NewServer
+		// without WithTrustedProxies keep the production nginx-on-
+		// loopback behavior (X-Real-IP / X-Forwarded-For honored only
+		// when r.RemoteAddr is 127.0.0.0/8 or ::1). WithTrustedProxies
+		// replaces this set. Issue #125.
+		trustedProxies:         []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8"), netip.MustParsePrefix("::1/128")},
 		now:                    func() time.Time { return time.Now().UTC() },
 		version:                "dev",
 	}
@@ -810,7 +843,7 @@ func (s *Server) handleCatalogPubkey(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) allowPoolCheck(r *http.Request) bool {
-	key := poolCheckClientKey(r)
+	key := s.poolCheckClientKey(r)
 	now := s.now()
 	s.poolCheckMu.Lock()
 	defer s.poolCheckMu.Unlock()
@@ -830,7 +863,7 @@ func (s *Server) allowReceiptKeys(r *http.Request) bool {
 		receiptKeysRatePerSecond = 10.0
 		receiptKeysBurst         = 10.0
 	)
-	key := poolCheckClientKey(r)
+	key := s.poolCheckClientKey(r)
 	now := s.now()
 	s.receiptKeysMu.Lock()
 	defer s.receiptKeysMu.Unlock()
@@ -907,39 +940,147 @@ func (s *Server) evictReceiptKeyEntries(now time.Time) {
 // poolCheckClientKey returns the per-source key used for the
 // /poolz, /v1/receipt-keys/*, and /catalog/* rate-limit buckets.
 //
-// Production sits behind nginx on loopback (see
-// phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf) so
-// every public buyer's r.RemoteAddr is 127.0.0.1 — keying on that
-// alone collapses every public buyer into one shared bucket and lets
-// any single caller starve the rate-limit pool for everyone else.
+// When r.RemoteAddr falls inside the configured trusted-proxy CIDR
+// set (`proxy.trusted_proxies`; default `["127.0.0.0/8", "::1/128"]`
+// covers the production nginx-on-localhost topology) the helper
+// honors the forwarded-for chain:
 //
-// Mirrors ws.remoteIPForUnauthSemaphore: when r.RemoteAddr is a
-// loopback address, honor X-Real-IP (which the on-host nginx site
-// sets). Direct, non-loopback hits (no proxy in front) use
-// r.RemoteAddr unchanged so an attacker on the open internet cannot
-// spoof their bucket key.
-func poolCheckClientKey(r *http.Request) string {
+//  1. `X-Forwarded-For`: rightmost-untrusted hop — the closest IP in
+//     the chain that is NOT itself in the trusted-proxy set. This is
+//     the standard "rightmost untrusted" pattern (`MDN
+//     X-Forwarded-For`); it survives chained trusted proxies (LB →
+//     nginx → coordinator) without admitting a buyer-supplied
+//     leftmost IP into the bucket key.
+//  2. `X-Real-IP`: nginx's single-hop alias if the operator's nginx
+//     site sets it (`proxy_set_header X-Real-IP $remote_addr`) but
+//     does NOT set `X-Forwarded-For`.
+//  3. Fallback to r.RemoteAddr (the trusted-proxy's IP) if neither
+//     header is usable.
+//
+// When r.RemoteAddr is OUTSIDE the trusted set, the helper IGNORES
+// both forwarded headers entirely and returns r.RemoteAddr's IP. An
+// attacker on the open internet cannot spoof their bucket key by
+// sending `X-Forwarded-For` / `X-Real-IP` themselves; only operators
+// who explicitly trust a proxy CIDR opt their setup into header-
+// based keying.
+//
+// Issue #125. Mirrors ws.remoteIPForUnauthSemaphore in shape (which
+// still implements the narrower loopback-only X-Real-IP path; that
+// path is deliberately not unified into this helper because the WS
+// admission semaphore lives in a different package and its surface
+// is intentionally minimal — a future PR may converge both onto a
+// shared `httpip` helper).
+func (s *Server) poolCheckClientKey(r *http.Request) string {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil || host == "" {
 		host = r.RemoteAddr
 	}
-	if isLoopbackHost(host) {
-		if realIP := strings.TrimSpace(r.Header.Get("X-Real-IP")); realIP != "" {
-			return realIP
+	hostAddr, parseErr := netip.ParseAddr(host)
+	if parseErr != nil {
+		// Unparseable r.RemoteAddr — never trust the forwarded headers
+		// in this case; return whatever we have so the bucket key is
+		// at least deterministic per malformed peer.
+		if host == "" {
+			return r.RemoteAddr
+		}
+		return host
+	}
+	if !isTrustedProxy(hostAddr, s.trustedProxies) {
+		// Direct (untrusted) connection — IGNORE X-Forwarded-For /
+		// X-Real-IP, key on the actual peer.
+		return host
+	}
+	// Trusted proxy. Walk X-Forwarded-For right-to-left for the first
+	// non-trusted hop; that is the buyer-visible IP we want to key on.
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if client := rightmostUntrustedXFF(xff, s.trustedProxies); client != "" {
+			return client
 		}
 	}
-	if host == "" {
-		return r.RemoteAddr
+	// X-Real-IP: parse via netip.ParseAddr to canonicalize and reject
+	// junk (issue #125 security-lane L1). nginx's standard
+	// `proxy_set_header X-Real-IP $remote_addr` produces a bare IP
+	// without port, so a port-bearing value is treated as malformed
+	// and falls through. An attacker who sneaks a non-IP value past a
+	// trusted proxy cannot poison the bucket key — we use the canonical
+	// addr.String() form instead.
+	if realIP := strings.TrimSpace(r.Header.Get("X-Real-IP")); realIP != "" {
+		if addr, err := netip.ParseAddr(realIP); err == nil {
+			return addr.String()
+		}
 	}
 	return host
 }
 
+// isLoopbackHost is retained for legacy callers that may still consult
+// it directly. Issue #125 routes the rate-limit key derivation through
+// the configured trusted-proxy CIDR set instead, but the helper stays
+// for any non-rate-limit callsite that wants a quick loopback check.
 func isLoopbackHost(host string) bool {
 	ip := net.ParseIP(host)
 	if ip == nil {
 		return false
 	}
 	return ip.IsLoopback()
+}
+
+// isTrustedProxy reports whether addr falls inside any of the
+// configured trusted-proxy prefixes. Pure function — both
+// poolCheckClientKey and rightmostUntrustedXFF call it so the
+// prefix-membership check is in exactly one place (architect-lane
+// follow-up to issue #125). A nil/empty trusted slice returns false
+// — strictest possible posture (no proxy is trusted; always key on
+// r.RemoteAddr).
+func isTrustedProxy(addr netip.Addr, trusted []netip.Prefix) bool {
+	for _, p := range trusted {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// rightmostUntrustedXFF walks X-Forwarded-For from RIGHT to LEFT
+// (last hop nearest the coordinator → first hop nearest the buyer)
+// and returns the first entry whose IP is NOT in the trusted-proxy
+// set. That entry is the buyer-visible IP — survives chained trusted
+// proxies (LB → nginx → coordinator) without admitting a buyer-
+// supplied leftmost IP.
+//
+// Behavior:
+//   - Returns "" on empty header / unparseable hops / all-hops-trusted
+//     (the caller's fallback path then runs).
+//   - Each hop is trimmed; brackets stripped if present
+//     ([2001:db8::1]:443 → 2001:db8::1).
+//   - Hops with attached :port are split via net.SplitHostPort before
+//     the prefix check; bare IPs (no port) keep their literal value;
+//     either way the final IP is parsed via netip.ParseAddr.
+//
+// MDN: "Take care when leftmost values are user-controlled. Use the
+// rightmost-untrusted entry instead." We do exactly that.
+func rightmostUntrustedXFF(header string, trusted []netip.Prefix) string {
+	hops := strings.Split(header, ",")
+	for i := len(hops) - 1; i >= 0; i-- {
+		raw := strings.TrimSpace(hops[i])
+		if raw == "" {
+			continue
+		}
+		// Strip optional [v6]:port or v4:port suffix.
+		host := raw
+		if h, _, err := net.SplitHostPort(raw); err == nil {
+			host = h
+		}
+		// Strip lone IPv6 brackets if no port was present.
+		host = strings.Trim(host, "[]")
+		addr, err := netip.ParseAddr(host)
+		if err != nil {
+			continue
+		}
+		if !isTrustedProxy(addr, trusted) {
+			return addr.String()
+		}
+	}
+	return ""
 }
 
 type modelsResponse struct {

--- a/phase4-coordinator/internal/buyer/trusted_proxies_test.go
+++ b/phase4-coordinator/internal/buyer/trusted_proxies_test.go
@@ -1,0 +1,239 @@
+package buyer
+
+// Issue #125 — trusted-proxy + X-Forwarded-For coverage.
+//
+// PR #124's partial fix taught poolCheckClientKey to honor X-Real-IP
+// when r.RemoteAddr is a loopback address (production nginx-on-
+// localhost topology). The remaining gap was non-loopback proxy
+// topologies (remote LB, sidecar reverse proxies) plus chained-
+// trusted-proxy hops via X-Forwarded-For. This file covers:
+//
+//   - Loopback default still honors X-Real-IP (back-compat with
+//     the PR #124 fix; also covered by
+//     TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback in
+//     catalog_endpoints_test.go).
+//   - Trusted non-loopback proxy CIDR: X-Forwarded-For rightmost-
+//     untrusted hop becomes the bucket key.
+//   - Untrusted proxy attempting spoof: X-Forwarded-For / X-Real-IP
+//     IGNORED; r.RemoteAddr is the bucket key.
+//   - Multi-hop X-Forwarded-For with chained trusted proxies: the
+//     rightmost-untrusted entry is the buyer.
+//   - X-Forwarded-For takes priority over X-Real-IP when both are
+//     present on a trusted-proxy request.
+//   - Empty trusted-proxies set: NO proxy is trusted, even loopback.
+//   - Malformed X-Forwarded-For hops: parse error skips that hop,
+//     falls through to next-rightmost or fallback.
+
+import (
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+)
+
+func TestPoolCheckClientKey_LoopbackDefaultHonorsXRealIP(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Real-IP", "198.51.100.7")
+	if got := s.poolCheckClientKey(req); got != "198.51.100.7" {
+		t.Fatalf("loopback X-Real-IP key = %q, want 198.51.100.7", got)
+	}
+}
+
+func TestPoolCheckClientKey_NonLoopbackTrustedProxyHonorsXFF(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.5.0.42:43210"
+	req.Header.Set("X-Forwarded-For", "203.0.113.99")
+	if got := s.poolCheckClientKey(req); got != "203.0.113.99" {
+		t.Fatalf("trusted-proxy XFF key = %q, want 203.0.113.99", got)
+	}
+}
+
+func TestPoolCheckClientKey_UntrustedProxyIgnoresXFFAndXRealIP(t *testing.T) {
+	// Loopback-only trusted set. A spoofing client from the open
+	// internet MUST NOT escape its bucket by sending XFF / X-Real-IP.
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "203.0.113.5:50000"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	req.Header.Set("X-Real-IP", "5.6.7.8")
+	if got := s.poolCheckClientKey(req); got != "203.0.113.5" {
+		t.Fatalf("untrusted spoof key = %q, want 203.0.113.5 (XFF/X-Real-IP MUST be ignored)", got)
+	}
+}
+
+func TestPoolCheckClientKey_MultiHopXFFReturnsRightmostUntrusted(t *testing.T) {
+	// Trusted: loopback + 10.0.0.0/8 (e.g. a remote LB at 10.5.0.42
+	// forwards to nginx on 127.0.0.1 which forwards to the
+	// coordinator on 127.0.0.1).
+	// XFF chain: buyer (203.0.113.99) → LB (10.5.0.42) → nginx
+	// (127.0.0.1). Rightmost-untrusted is the buyer.
+	s := &Server{trustedProxies: []netip.Prefix{
+		netip.MustParsePrefix("127.0.0.0/8"),
+		netip.MustParsePrefix("10.0.0.0/8"),
+	}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "203.0.113.99, 10.5.0.42, 127.0.0.1")
+	if got := s.poolCheckClientKey(req); got != "203.0.113.99" {
+		t.Fatalf("multi-hop XFF key = %q, want 203.0.113.99", got)
+	}
+}
+
+func TestPoolCheckClientKey_XFFTakesPriorityOverXRealIP(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "198.51.100.99")
+	req.Header.Set("X-Real-IP", "198.51.100.7")
+	if got := s.poolCheckClientKey(req); got != "198.51.100.99" {
+		t.Fatalf("XFF vs X-Real-IP priority: got %q, want 198.51.100.99 (XFF wins)", got)
+	}
+}
+
+func TestPoolCheckClientKey_EmptyTrustedSetIgnoresForwardedHeaders(t *testing.T) {
+	// Empty trusted set = strictest posture. Even loopback callers
+	// cannot use X-Real-IP / X-Forwarded-For.
+	s := &Server{trustedProxies: nil}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	req.Header.Set("X-Real-IP", "5.6.7.8")
+	if got := s.poolCheckClientKey(req); got != "127.0.0.1" {
+		t.Fatalf("empty-trusted key = %q, want 127.0.0.1 (no proxy is trusted)", got)
+	}
+}
+
+func TestPoolCheckClientKey_AllHopsTrustedFallsBackToXRealIP(t *testing.T) {
+	// XFF chain is entirely inside the trusted set → rightmostUntrustedXFF
+	// returns "". The helper then falls through to X-Real-IP.
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "127.0.0.1, 127.0.0.2")
+	req.Header.Set("X-Real-IP", "198.51.100.7")
+	if got := s.poolCheckClientKey(req); got != "198.51.100.7" {
+		t.Fatalf("all-trusted-hops + X-Real-IP fallback key = %q, want 198.51.100.7", got)
+	}
+}
+
+func TestPoolCheckClientKey_AllHopsTrustedNoHeadersFallsBackToRemoteAddr(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "127.0.0.1, 127.0.0.2")
+	// No X-Real-IP either.
+	if got := s.poolCheckClientKey(req); got != "127.0.0.1" {
+		t.Fatalf("all-trusted no-X-Real-IP key = %q, want 127.0.0.1", got)
+	}
+}
+
+func TestPoolCheckClientKey_IPv6LoopbackHonored(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("::1/128")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "[::1]:54321"
+	req.Header.Set("X-Real-IP", "2001:db8::1")
+	if got := s.poolCheckClientKey(req); got != "2001:db8::1" {
+		t.Fatalf("IPv6 loopback X-Real-IP key = %q, want 2001:db8::1", got)
+	}
+}
+
+func TestPoolCheckClientKey_MalformedXFFHopSkipped(t *testing.T) {
+	// XFF has a junk middle entry. The rightmost-untrusted walk should
+	// skip "not-an-ip" and return the next valid untrusted entry.
+	s := &Server{trustedProxies: []netip.Prefix{
+		netip.MustParsePrefix("127.0.0.0/8"),
+		netip.MustParsePrefix("10.0.0.0/8"),
+	}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "203.0.113.99, not-an-ip, 10.5.0.42, 127.0.0.1")
+	if got := s.poolCheckClientKey(req); got != "203.0.113.99" {
+		t.Fatalf("malformed-XFF-hop key = %q, want 203.0.113.99 (skip junk, find rightmost-untrusted)", got)
+	}
+}
+
+func TestPoolCheckClientKey_UnparseableRemoteAddrFallsBack(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "garbage" // no host:port shape
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	// Unparseable peer never trusts forwarded headers; returns the
+	// raw RemoteAddr string so the bucket is at least deterministic.
+	if got := s.poolCheckClientKey(req); got != "garbage" {
+		t.Fatalf("unparseable peer key = %q, want \"garbage\"", got)
+	}
+}
+
+// Issue #125 r1 code-lane L3 + security-lane L1 follow-ups: explicit
+// edge-case pins for XFF separator handling + X-Real-IP canonicalization.
+
+func TestPoolCheckClientKey_XFFWhitespaceTrimmed(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "   198.51.100.99  ,   127.0.0.1  ")
+	if got := s.poolCheckClientKey(req); got != "198.51.100.99" {
+		t.Fatalf("whitespace-padded XFF key = %q, want 198.51.100.99", got)
+	}
+}
+
+func TestPoolCheckClientKey_XFFEmptyHopsSkipped(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "198.51.100.99,,,127.0.0.1")
+	if got := s.poolCheckClientKey(req); got != "198.51.100.99" {
+		t.Fatalf("empty-XFF-hops key = %q, want 198.51.100.99 (empty hops MUST be skipped)", got)
+	}
+}
+
+func TestPoolCheckClientKey_XFFOnlyCommasFallsThrough(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", ",,, ,,")
+	req.Header.Set("X-Real-IP", "198.51.100.7")
+	if got := s.poolCheckClientKey(req); got != "198.51.100.7" {
+		t.Fatalf("only-commas XFF key = %q, want 198.51.100.7 (XFF returns \"\"; X-Real-IP fallback fires)", got)
+	}
+}
+
+func TestPoolCheckClientKey_XRealIPMalformedFallsThrough(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Real-IP", "not-an-ip-at-all")
+	// Malformed X-Real-IP MUST NOT poison the bucket key; helper
+	// falls through to r.RemoteAddr's host. Issue #125 security-lane L1.
+	if got := s.poolCheckClientKey(req); got != "127.0.0.1" {
+		t.Fatalf("malformed X-Real-IP key = %q, want 127.0.0.1 (parse failure → fallback)", got)
+	}
+}
+
+func TestPoolCheckClientKey_XRealIPWithPortRejected(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	// nginx's `proxy_set_header X-Real-IP $remote_addr` produces a
+	// bare IP without port. A port-bearing value (manual misconfig
+	// or a non-nginx proxy) is rejected by netip.ParseAddr and
+	// falls through. Issue #125 code-lane L4 + security-lane L1.
+	req.Header.Set("X-Real-IP", "198.51.100.7:8080")
+	if got := s.poolCheckClientKey(req); got != "127.0.0.1" {
+		t.Fatalf("port-bearing X-Real-IP key = %q, want 127.0.0.1 (port-bearing values are NOT accepted; fallback to peer)", got)
+	}
+}
+
+func TestPoolCheckClientKey_XRealIPIPv6Canonicalized(t *testing.T) {
+	s := &Server{trustedProxies: []netip.Prefix{netip.MustParsePrefix("::1/128")}}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "[::1]:54321"
+	// IPv6 with full notation should canonicalize to the short form
+	// via addr.String().
+	req.Header.Set("X-Real-IP", "2001:0db8:0000:0000:0000:0000:0000:0001")
+	if got := s.poolCheckClientKey(req); got != "2001:db8::1" {
+		t.Fatalf("IPv6 X-Real-IP canonical form = %q, want 2001:db8::1", got)
+	}
+}

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/netip"
 	"net/url"
 	"os"
 	"regexp"
@@ -34,7 +35,31 @@ type Config struct {
 	Settlement                   SettlementConfig             `yaml:"settlement"`
 	Endpoints                    EndpointsConfig              `yaml:"endpoints"`
 	Explorer                     ExplorerConfig               `yaml:"explorer"`
+	Proxy                        ProxyConfig                  `yaml:"proxy"`
 	Providers                    []ProviderConfig             `yaml:"providers"`
+}
+
+// ProxyConfig configures how the coordinator interprets `X-Forwarded-For` /
+// `X-Real-IP` headers when deriving per-buyer rate-limit keys. Issue #125
+// (post-PR-#124 follow-up): production sits behind nginx on loopback, so
+// the default trusted-proxies list `["127.0.0.0/8", "::1/128"]` covers
+// that topology. Operators deploying behind a remote LB or non-loopback
+// reverse proxy MUST add the proxy's CIDR(s) here; otherwise the
+// coordinator will treat the proxy as untrusted and key the rate-limit
+// bucket on the proxy's IP — collapsing all upstream buyers into one
+// shared bucket. Conversely, expanding this list to non-actual-proxy
+// CIDRs lets attackers in those CIDRs spoof their bucket key via
+// `X-Forwarded-For`; treat the list as security-sensitive.
+type ProxyConfig struct {
+	// TrustedProxies is a list of CIDR ranges whose `X-Forwarded-For` /
+	// `X-Real-IP` headers the coordinator will honor when deriving the
+	// per-source rate-limit key for `/v1/pool/check`, `/v1/receipt-keys/*`,
+	// and `/catalog/*`. Default `["127.0.0.0/8", "::1/128"]` matches the
+	// production nginx-on-localhost topology (see
+	// `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`).
+	// Invalid CIDRs and default-route prefixes (`0.0.0.0/0`, `::/0`)
+	// fail `config.Load` at startup via `TrustedProxyPrefixes`.
+	TrustedProxies []string `yaml:"trusted_proxies"`
 }
 
 type ListenConfig struct {
@@ -424,6 +449,14 @@ func Default() Config {
 		Auth: AuthConfig{
 			RequireProviderTokens: true,
 		},
+		Proxy: ProxyConfig{
+			// Default trusts loopback only. Production sits behind nginx on
+			// localhost, so the default keys rate-limit buckets on the
+			// X-Real-IP / X-Forwarded-For headers nginx sets. Operators with
+			// a remote LB MUST add the proxy CIDR(s) explicitly; spoofing
+			// risk if anything else is added. Issue #125.
+			TrustedProxies: []string{"127.0.0.0/8", "::1/128"},
+		},
 	}
 }
 
@@ -575,6 +608,43 @@ func (c Config) ProviderWSMaxUnauthenticatedConnPerIP() int {
 	return count
 }
 
+// TrustedProxyPrefixes parses c.Proxy.TrustedProxies into a slice of
+// netip.Prefix values for the buyer Server's rate-limit-key derivation.
+// Returns an error if any CIDR is malformed OR if the operator has
+// listed a default-route prefix (0.0.0.0/0, ::/0); those would let
+// every public caller spoof their bucket key via X-Forwarded-For —
+// almost certainly a config bug, never a deliberate posture, so
+// reject at Validate time. Issue #125 security-lane finding.
+//
+// Callers should invoke this at startup (config.Load already calls
+// it via Validate) so the hot path never re-parses. An empty
+// TrustedProxies list returns a nil slice (callers treat as "no
+// proxy is trusted; always use r.RemoteAddr").
+func (c Config) TrustedProxyPrefixes() ([]netip.Prefix, error) {
+	if len(c.Proxy.TrustedProxies) == 0 {
+		return nil, nil
+	}
+	out := make([]netip.Prefix, 0, len(c.Proxy.TrustedProxies))
+	for _, raw := range c.Proxy.TrustedProxies {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		p, err := netip.ParsePrefix(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("proxy.trusted_proxies[%q]: %w", raw, err)
+		}
+		// Reject default-route prefixes — trusting every IP means
+		// every caller can spoof their bucket key. Issue #125
+		// security-lane L2.
+		if p.Bits() == 0 {
+			return nil, fmt.Errorf("proxy.trusted_proxies[%q]: default-route prefix is not a valid trusted proxy (every caller would be header-trusted)", raw)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
 func (c Config) ProviderByID() map[string]ProviderConfig {
 	out := make(map[string]ProviderConfig, len(c.Providers))
 	for _, p := range c.Providers {
@@ -586,6 +656,9 @@ func (c Config) ProviderByID() map[string]ProviderConfig {
 func (c Config) Validate() error {
 	if c.Auth.OperatorKey == "" {
 		return fmt.Errorf("auth.operator_key must be set")
+	}
+	if _, err := c.TrustedProxyPrefixes(); err != nil {
+		return err
 	}
 	if err := c.validateGitHubOAuth(); err != nil {
 		return err

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -229,3 +229,61 @@ func TestTier2ValidationPreservesDefaultsAndRejectsUnsafeConfig(t *testing.T) {
 		t.Fatalf("response anomaly factor err=%v", err)
 	}
 }
+
+// Issue #125: trusted-proxy CIDR validation pins for ProxyConfig.
+
+func TestDefaultProxyConfigTrustsLoopbackOnly(t *testing.T) {
+	cfg := Default()
+	if got, want := len(cfg.Proxy.TrustedProxies), 2; got != want {
+		t.Fatalf("default trusted_proxies len=%d want %d", got, want)
+	}
+	prefixes, err := cfg.TrustedProxyPrefixes()
+	if err != nil {
+		t.Fatalf("TrustedProxyPrefixes default parse: %v", err)
+	}
+	if len(prefixes) != 2 {
+		t.Fatalf("default prefixes len=%d want 2", len(prefixes))
+	}
+	if !prefixes[0].Contains(prefixes[0].Addr()) || prefixes[0].String() != "127.0.0.0/8" {
+		t.Fatalf("default[0] = %q want 127.0.0.0/8", prefixes[0].String())
+	}
+	if prefixes[1].String() != "::1/128" {
+		t.Fatalf("default[1] = %q want ::1/128", prefixes[1].String())
+	}
+}
+
+func TestTrustedProxyPrefixesRejectsDefaultRouteIPv4(t *testing.T) {
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Proxy.TrustedProxies = []string{"0.0.0.0/0"}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "default-route prefix") {
+		t.Fatalf("Validate(0.0.0.0/0) err=%v, want default-route rejection (every caller would be header-trusted)", err)
+	}
+}
+
+func TestTrustedProxyPrefixesRejectsDefaultRouteIPv6(t *testing.T) {
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Proxy.TrustedProxies = []string{"::/0"}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "default-route prefix") {
+		t.Fatalf("Validate(::/0) err=%v, want default-route rejection", err)
+	}
+}
+
+func TestTrustedProxyPrefixesRejectsMalformedCIDR(t *testing.T) {
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Proxy.TrustedProxies = []string{"not-a-cidr"}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "proxy.trusted_proxies") {
+		t.Fatalf("Validate(not-a-cidr) err=%v, want parse-error rejection", err)
+	}
+}
+
+func TestTrustedProxyPrefixesEmptyAllowed(t *testing.T) {
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Proxy.TrustedProxies = nil // strictest posture
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("empty trusted_proxies Validate err=%v, want nil (empty list is strictest posture, valid)", err)
+	}
+}

--- a/specs/125_TRUSTED_PROXIES_ARCHITECT_audit.md
+++ b/specs/125_TRUSTED_PROXIES_ARCHITECT_audit.md
@@ -1,0 +1,26 @@
+CRITICAL (0):
+  (none)
+
+HIGH (0):
+  (none)
+
+MEDIUM (1):
+  M1. Trusted-proxy policy is not discoverable from shipped operator docs/templates
+      Evidence: phase4-coordinator/internal/config/config.go:42 adds the security-sensitive `proxy.trusted_proxies` surface, phase4-coordinator/internal/config/config.go:451 sets the loopback default, and phase4-coordinator/cmd/coordinator/main.go:284 wires it into buyer rate-limit keying; however phase4-coordinator/coordinator.yaml.example:1 and phase4-coordinator/dist/coordinator.yaml.example:7 still go directly from `listen` to `pool` with no `proxy` block, while specs/SPEC-002-coordinator.md:2519 documents `/v1/pool/check` rate limiting without naming the source-IP derivation and specs/SPEC-015-receipts.md:2476 plus specs/SPEC-015-receipts.md:3333 only say "per source IP".
+      Fix:     Add a commented `proxy.trusted_proxies: ["127.0.0.0/8", "::1/128"]` block with the spoof/collapse warning to both coordinator YAML templates, and add SPEC-002 / SPEC-015 notes that public coordinator endpoint rate-limit source IP is derived through `proxy.trusted_proxies` (default loopback only).
+
+LOW (3):
+  L1. Buyer/WS IP-helper asymmetry is deliberate but should remain tracked boundary debt
+      Evidence: phase4-coordinator/internal/buyer/server.go:967 explicitly defers unification to a future shared `httpip` helper, while phase4-coordinator/internal/ws/server.go:1366 still implements only loopback `X-Real-IP` and specs/SPEC-002-coordinator.md:2775 keeps WS pre-upgrade controls at the proxy layer.
+      Fix:     Leave the asymmetry for this PR; if WS later needs non-loopback proxy tiers, extract an `internal/httpip` package (Option A), not a miscellaneous mid-level utility package.
+
+  L2. Trusted-proxy membership is not quite a single predicate inside buyer
+      Evidence: phase4-coordinator/internal/buyer/server.go:1022 implements `(s *Server).isTrustedProxy`, while phase4-coordinator/internal/buyer/server.go:1066 repeats the same prefix loop inside `rightmostUntrustedXFF`.
+      Fix:     Prefer a package-level pure `isTrustedProxy(addr, trusted)` helper and have both `poolCheckClientKey` and `rightmostUntrustedXFF` call it; keep `poolCheckClientKey` as the Server method because it derives keys for Server-owned buckets.
+
+  L3. Startup parse fallback weakens the config validation contract
+      Evidence: phase4-coordinator/internal/config/config.go:648 rejects invalid `proxy.trusted_proxies` during `Validate`, but phase4-coordinator/cmd/coordinator/main.go:408 reparses and silently substitutes nil on error, changing an invalid trusted-proxy config into "trust no proxy".
+      Fix:     Treat a post-Validate parse error as fatal or return it from startup wiring; an operator config that fails trusted-proxy parsing should not silently collapse proxied clients into the proxy's bucket.
+
+QUESTIONS (0):
+  (none)

--- a/specs/125_TRUSTED_PROXIES_ARCHITECT_r2_audit.md
+++ b/specs/125_TRUSTED_PROXIES_ARCHITECT_r2_audit.md
@@ -1,0 +1,20 @@
+CLOSURE on round-1 findings:
+  M1 (MEDIUM): PASS — Operator-facing discoverability is now covered in both YAML examples and the normative specs: both `coordinator.yaml.example` templates include `proxy.trusted_proxies: ["127.0.0.0/8", "::1/128"]`, SPEC-002 documents the `/v1/pool/check` source-IP derivation under the 429 block, and SPEC-015 points both rate-limited public receipt/catalog surfaces back to `proxy.trusted_proxies`.
+  L1: noted (deferred)
+  L2: PASS — Trusted-proxy membership is now a package-level pure `isTrustedProxy(addr, trusted)` helper, with both `poolCheckClientKey` and `rightmostUntrustedXFF` calling it; no missed callsites found in `phase4-coordinator`.
+  L3: PASS — `mustParseTrustedProxies` now calls `logger.Fatal()` on post-Validate parse drift instead of silently falling back to nil, while `Config.Validate()` already rejects malformed/default-route CIDRs through `TrustedProxyPrefixes()`.
+
+NEW FINDINGS (round 2):
+CRITICAL (0): None.
+HIGH (0): None.
+MEDIUM (0): None.
+LOW (0): None.
+QUESTIONS (0): None.
+
+Evidence:
+- Template consistency: `phase4-coordinator/coordinator.yaml.example` and `phase4-coordinator/dist/coordinator.yaml.example` both define the same `proxy.trusted_proxies` values (`127.0.0.0/8`, `::1/128`). Their comments differ by deployment audience but state the same trust boundary and spoofing constraint.
+- Spec placement/precision: SPEC-002 places source-IP derivation immediately after the `/v1/pool/check` 429 response; SPEC-015 adds the same derivation pointer under §10.7 `/v1/receipt-keys` and the `GET /catalog/<catalog_id>` rate-limit block.
+- Callsite scan: `rg` found `isTrustedProxy` only at the extracted helper and the two expected consumers.
+- Validation run: `go test ./internal/buyer ./internal/config` and `go test ./cmd/coordinator` both pass from `phase4-coordinator`.
+
+VERDICT: architect lane READY TO MERGE

--- a/specs/125_TRUSTED_PROXIES_CODE_audit.md
+++ b/specs/125_TRUSTED_PROXIES_CODE_audit.md
@@ -1,0 +1,30 @@
+CRITICAL (0):
+  (none)
+
+HIGH (0):
+  (none)
+
+MEDIUM (0):
+  (none)
+
+LOW (4):
+  L1. ProxyConfig comment references a nonexistent config test.
+      Evidence: phase4-coordinator/internal/config/config.go:57
+      Fix:     Either add the named TestDefaultProxyConfigTrustsLoopbackOnly config test, or remove the test-name claim from the comment.
+
+  L2. rightmostUntrustedXFF comment says ports are split with netip.ParseAddrPort, but the code uses net.SplitHostPort.
+      Evidence: phase4-coordinator/internal/buyer/server.go:1043
+      Fix:     Update the comment to name net.SplitHostPort, or switch the implementation to netip.ParseAddrPort if that API is preferred.
+
+  L3. XFF separator edge cases are implemented but not pinned by tests.
+      Evidence: phase4-coordinator/internal/buyer/server.go:1049
+      Fix:     Add table cases for whitespace around hops, empty hops, and only-comma headers so the skip/fallback behavior stays explicit.
+
+  L4. X-Real-IP fallback accepts a raw string, including a value with an attached port.
+      Evidence: phase4-coordinator/internal/buyer/server.go:1000
+      Fix:     Add a test or comment pinning the nginx-without-port assumption, or normalize X-Real-IP through the same host parsing path if port-bearing values should be accepted.
+
+QUESTIONS (0):
+  (none)
+
+VERDICT: code lane READY TO MERGE

--- a/specs/125_TRUSTED_PROXIES_CODE_r2_audit.md
+++ b/specs/125_TRUSTED_PROXIES_CODE_r2_audit.md
@@ -1,0 +1,22 @@
+CLOSURE on round-1 findings:
+  L1: PASS — `TestDefaultProxyConfigTrustsLoopbackOnly` now exists and the `ProxyConfig` comment no longer references a nonexistent test name.
+  L2: PASS — `rightmostUntrustedXFF` now documents `net.SplitHostPort`, matching the implementation.
+  L3: PASS — XFF whitespace, empty-hop, and only-comma cases are pinned in `trusted_proxies_test.go`.
+  L4: PASS — X-Real-IP is parsed with `netip.ParseAddr`, canonicalized via `addr.String()`, and malformed/port-bearing values fall through to `r.RemoteAddr`.
+
+NEW FINDINGS (round 2):
+CRITICAL (0): none.
+HIGH (0): none.
+MEDIUM (0): none.
+LOW (0): none.
+QUESTIONS (0): none.
+
+Validation evidence:
+- `rg -n "s\\.isTrustedProxy|func \\(s \\*Server\\) isTrustedProxy|isTrustedProxy\\(" phase4-coordinator/internal/buyer phase4-coordinator/cmd/coordinator` found only the package-level helper and its two intended call sites.
+- `go test ./internal/config -run 'TestDefaultProxyConfigTrustsLoopbackOnly|TestTrustedProxyPrefixes' -count=1 -v` PASS.
+- `go test ./internal/buyer -run 'TestPoolCheckClientKey|TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback' -count=1 -v` PASS.
+- `go test ./internal/buyer -run '^TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback$' -count=1 -v` PASS.
+- `go test ./internal/config ./internal/buyer -count=1` PASS.
+- `go test ./cmd/coordinator -count=1` PASS.
+
+VERDICT: code lane READY TO MERGE

--- a/specs/125_TRUSTED_PROXIES_SECURITY_audit.md
+++ b/specs/125_TRUSTED_PROXIES_SECURITY_audit.md
@@ -1,0 +1,21 @@
+CRITICAL (0):
+
+HIGH (0):
+
+MEDIUM (0):
+
+LOW (2):
+  L1. X-Real-IP fallback stores a trusted header value without IP parsing/canonicalization
+      Evidence: phase4-coordinator/internal/buyer/server.go:1000
+      Fix:     Parse X-Real-IP with netip.ParseAddr or netip.ParseAddrPort and return the canonical address only when parsing succeeds; otherwise fall back to r.RemoteAddr.
+
+  L2. Validate accepts universal trusted-proxy CIDRs such as 0.0.0.0/0 and ::/0
+      Evidence: phase4-coordinator/internal/config/config.go:617
+      Fix:     Reject at least IPv4/IPv6 default-route prefixes in TrustedProxyPrefixes or Validate so an obviously unsafe setting cannot make every public caller header-trusted.
+
+QUESTIONS (1):
+  Q1. Should the WS unauth semaphore get a follow-up trusted-proxy/XFF parity issue for remote-LB deployments?
+      Evidence: phase4-coordinator/internal/ws/server.go:1366
+      Fix:     If remote load balancers are in scope for provider WebSocket handshakes, track a follow-up to move remoteIPForUnauthSemaphore to the same trusted-proxy chain logic or a shared helper.
+
+VERDICT: security lane READY TO MERGE

--- a/specs/125_TRUSTED_PROXIES_SECURITY_r2_audit.md
+++ b/specs/125_TRUSTED_PROXIES_SECURITY_r2_audit.md
@@ -1,0 +1,21 @@
+CLOSURE on round-1 findings:
+  L1: PASS — `X-Real-IP` is now accepted only after `netip.ParseAddr` succeeds and returns `addr.String()`; malformed and port-bearing values fall through to `r.RemoteAddr` (`server.go:1000-1012`, tests at `trusted_proxies_test.go:203-238`).
+  L2: PASS — `TrustedProxyPrefixes` rejects `Bits() == 0`, `Validate` calls it at startup, and IPv4/IPv6 default-route regression tests cover `0.0.0.0/0` and `::/0` (`config.go:623-641`, `config.go:656-662`, `config_test.go:255-270`).
+  Q1: noted (deferred to follow-up) — `poolCheckClientKey` explicitly documents that WS unauth semaphore parity remains intentionally separate pending a future shared `httpip` helper (`server.go:967-972`).
+
+NEW FINDINGS (round 2):
+CRITICAL (0): None.
+HIGH (0): None.
+MEDIUM (0): None.
+LOW (0): None.
+QUESTIONS (0): None.
+
+Notes:
+- The X-Real-IP canonical-form change hardens bucket keying: valid alternate spellings of the same IP collapse to one canonical `netip.Addr.String()` value, while invalid spellings cannot become attacker-chosen keys.
+- Default-route rejection closes the obvious universal-trust footgun. Wider-but-nondefault prefixes such as `0.0.0.0/1` remain operator policy rather than a startup validation failure; the config comments and YAML templates now warn that only actual proxy CIDRs belong in `proxy.trusted_proxies`.
+- `mustParseTrustedProxies` now fail-fasts via `logger.Fatal()` if post-Validate parsing ever drifts, avoiding the prior silent "trust no proxy" downgrade (`main.go:410-415`).
+
+Validation:
+- `go test ./internal/config ./internal/buyer` passed from `phase4-coordinator`.
+
+VERDICT: security lane READY TO MERGE

--- a/specs/AUDIT_125_TRUSTED_PROXIES_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_125_TRUSTED_PROXIES_ARCHITECT_PROMPT.md
@@ -1,0 +1,120 @@
+# Issue #125 trusted-proxy + X-Forwarded-For — ARCHITECT-lane audit
+
+You are the **architect** lane of a three-lane audit (code / security /
+architect) of the trusted-proxy + XFF refactor for issue #125. Stay
+narrowly in your lane.
+
+The architect lens cares about: module boundaries, single source of
+truth, abstraction altitude, coupling, future-evolution constraints,
+cross-spec consistency, anti-pattern entrenchment.
+
+## Branch / commit
+- Branch: `fix/coordinator-trusted-proxies-xff`
+- Worktree: `../macprovider-125-trusted-proxies` (origin/main base: d27aac5)
+- Files in scope (`git diff origin/main`).
+
+## What this change does (operator summary — NOT the audit answer)
+
+Issue #125 generalizes PR #124's loopback-only X-Real-IP fix to:
+1. Configurable trusted-proxy CIDR set via `proxy.trusted_proxies`.
+2. X-Forwarded-For rightmost-untrusted-hop parsing for chained
+   trusted proxies.
+3. Spoof rejection for untrusted callers (forwarded headers ignored).
+
+## Architect-lane scope (apply each; stay in lane)
+
+### ARCH-1. Module boundaries — config / buyer / WS
+- The new `ProxyConfig` lives in `config.Config` (top-level).
+  `TrustedProxyPrefixes()` parses to `[]netip.Prefix`. The buyer
+  Server consumes it via `WithTrustedProxies(prefixes)`.
+- The PARALLEL `ws.remoteIPForUnauthSemaphore` (admission semaphore
+  for unauth WS handshakes; M1-4 SECU-1) still implements the narrow
+  loopback-only X-Real-IP path. The diff preserves this asymmetry.
+  Is that intentional, or is the WS-side helper now stale?
+- If both sides should share a helper, where should it live?
+  - Option A: `internal/httpip` new package — both buyer + ws import.
+  - Option B: move ws helper into a shared utility under
+    `internal/sqliteutil`-style mid-level package.
+  - Option C: leave both narrow; document the asymmetry with a
+    pointer.
+- Recommend the right resolution. (Author's note: the comment in
+  the new poolCheckClientKey doc block explicitly defers a future
+  unify-PR; verify the comment is adequate.)
+
+### ARCH-2. Abstraction altitude of the new helpers
+- `rightmostUntrustedXFF(header, trusted)`: package-level function;
+  takes a string + a slice. Pure function — easy to test in
+  isolation.
+- `isTrustedProxy(addr)`: `(s *Server)` method, but takes only
+  `s.trustedProxies`. Could be a pure function too. Is the method
+  receiver right, or should it be a package-level
+  `isTrustedProxy(addr, trusted)`?
+- `poolCheckClientKey(r)`: `(s *Server)` method, consumes `r` and
+  `s.trustedProxies`. Method-on-Server is appropriate because the
+  derived key feeds Server-owned state (the rate-limit buckets).
+
+### ARCH-3. Config shape
+- New top-level `proxy` block in `config.Config`. Could have lived
+  under `listen` (ListenConfig) since it's listener-policy. Could
+  have lived under a new `security` block grouping spoof-related
+  settings. Recommend if a different home would be more discoverable.
+- Default value `["127.0.0.0/8", "::1/128"]` — sane default. Does
+  the SPEC documentation (SPEC-002 or SPEC-005) call out this
+  policy anywhere? Should it?
+
+### ARCH-4. Future-evolution constraints
+- The current shape assumes a single trusted-proxy CIDR set per
+  coordinator. If a future deployment has multiple proxy tiers
+  (e.g. CDN → LB → nginx → coordinator), the rightmost-untrusted
+  walk handles it as long as ALL hops are in the trusted set.
+  Does that scale, or is per-hop trust required (i.e. "trust the LB
+  but NOT the CDN")?
+- The current shape returns a single bucket key (string) per
+  request. If a future feature wants per-CIDR aggregate buckets
+  (issue #125 option (c)), the helper would need to return a
+  prefix-aware key. Is the current return-string-only shape a
+  premature commitment?
+
+### ARCH-5. New surface area cost
+- ~233 lines added across config + buyer + main. Roughly:
+  - config.go: 60 lines (ProxyConfig + TrustedProxyPrefixes + Validate call)
+  - server.go: 110 lines (rightmostUntrustedXFF + isTrustedProxy + ProxyOption + constructor wiring + poolCheckClientKey rewrite)
+  - trusted_proxies_test.go: 175 lines (11 new tests)
+  - main.go: 19 lines (mustParseTrustedProxies + WithTrustedProxies wiring)
+- Is the surface area worth it for an issue rated LOW (production case
+  was already covered by PR #124's partial fix)? Or should this PR
+  scope shrink — e.g. ship the trusted-proxy CIDR config + the
+  loopback-only XFF preservation, defer the multi-hop XFF + spoof
+  test matrix to a follow-up?
+
+### ARCH-6. Cross-spec consistency
+- Does SPEC-002 (coordinator) or SPEC-005 (billing) document the
+  rate-limit policy on these endpoints? Is the new trusted-proxy
+  surface worth a normative note? The endpoints in question
+  (`/v1/pool/check`, `/v1/receipt-keys/*`, `/catalog/*`) are
+  documented in SPEC-002 v1.4 + SPEC-015 v0.3 — does either spec
+  call out the per-source rate-limit primitive, and if so, should
+  it be updated to reference `proxy.trusted_proxies`?
+
+### ARCH-7. Doc-trail / audit ledger
+- Should `audits/2026-06-10/REMAINING_WORK.md` (or any other
+  ledger) be updated to reflect this fix?
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/125_TRUSTED_PROXIES_ARCHITECT_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM, end with:
+`VERDICT: architect lane READY TO MERGE`

--- a/specs/AUDIT_125_TRUSTED_PROXIES_ARCHITECT_R2_PROMPT.md
+++ b/specs/AUDIT_125_TRUSTED_PROXIES_ARCHITECT_R2_PROMPT.md
@@ -1,0 +1,82 @@
+# Issue #125 trusted-proxy + XFF — ARCHITECT-lane R2 (closure verification)
+
+Round 1 (`specs/125_TRUSTED_PROXIES_ARCHITECT_audit.md`) returned
+**0 C/H / 1 MEDIUM (M1) / 3 LOW / 0 Q — NOT READY** (the MEDIUM
+held the merge gate). The author applied targeted fixes for M1 + L2
++ L3; L1 was deferred per its own framing.
+
+## Branch / commit
+- Branch: `fix/coordinator-trusted-proxies-xff`
+- Worktree: `../macprovider-125-trusted-proxies`
+- Read: `git diff origin/main`
+
+## Round-1 findings to verify closure on
+
+- **M1 (MEDIUM, gate-holding).** Trusted-proxy policy was not
+  discoverable from shipped operator docs/templates.
+  - Fix expected:
+    - Added `proxy:` block with `trusted_proxies: ["127.0.0.0/8",
+      "::1/128"]` to BOTH `phase4-coordinator/coordinator.yaml.example`
+      AND `phase4-coordinator/dist/coordinator.yaml.example` (the
+      production template).
+    - Added a normative source-IP-derivation paragraph to
+      `specs/SPEC-002-coordinator.md` under the `/v1/pool/check` 429
+      response block.
+    - Added a `proxy.trusted_proxies` pointer to `specs/SPEC-015-receipts.md`
+      under BOTH rate-limit mentions (§10.7 `/v1/receipt-keys` and the
+      `/catalog/<catalog_id>` endpoint block).
+- **L1.** Buyer/WS IP-helper asymmetry is deliberate but tracked as
+  boundary debt.
+  - Deferred per L1's own framing ("Leave the asymmetry for this
+    PR"). The new `poolCheckClientKey` doc block explicitly defers
+    unification to a future shared `httpip` helper (Option A from
+    L1's recommendation).
+- **L2.** Trusted-proxy membership repeated inside
+  `rightmostUntrustedXFF` and `(s *Server).isTrustedProxy`.
+  - Fix expected: extracted to package-level pure
+    `isTrustedProxy(addr, trusted)`; both callers updated.
+- **L3.** Startup parse fallback weakened the config validation
+  contract (silent nil-fallback on parse error).
+  - Fix expected: `mustParseTrustedProxies` now `logger.Fatal()`s on
+    parse error instead of returning nil. Validate already rejects
+    malformed CIDRs at config.Load, so this is a fail-fast on drift.
+
+## Audit lenses for fresh issues (apply briefly)
+
+- The SPEC additions (SPEC-002 + SPEC-015) — are they in the right
+  sections? Is the wording precise enough for an implementer
+  reading the spec alone to derive the same behavior?
+- The YAML examples both now have a `proxy:` block. Confirm the
+  block is identical / consistent between the two templates (no
+  drift between dev and prod).
+- The `isTrustedProxy` extraction — package-level pure function,
+  single owner. Right altitude? (Not a Server method; takes the
+  prefix slice explicitly.) Any callsite missed?
+- The Fatal-on-parse-error change in main.go — operationally,
+  a malformed `proxy.trusted_proxies` now refuses to boot. Is that
+  the right contract? (vs. the prior silent-nil-fallback.) Recall
+  Validate already catches malformed CIDRs at Load; this fail-fast
+  is a drift defense.
+
+## Output format
+
+```
+CLOSURE on round-1 findings:
+  M1 (MEDIUM): PASS|PARTIAL|FAIL — <one line>
+  L1: noted (deferred)
+  L2: PASS|PARTIAL|FAIL — <one line>
+  L3: PASS|PARTIAL|FAIL — <one line>
+
+NEW FINDINGS (round 2):
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/125_TRUSTED_PROXIES_ARCHITECT_r2_audit.md`.
+
+If M1 closes AND L2/L3 close AND zero NEW C/H/M, end with:
+`VERDICT: architect lane READY TO MERGE`

--- a/specs/AUDIT_125_TRUSTED_PROXIES_CODE_PROMPT.md
+++ b/specs/AUDIT_125_TRUSTED_PROXIES_CODE_PROMPT.md
@@ -1,0 +1,82 @@
+# Issue #125 trusted-proxy + X-Forwarded-For — CODE-lane audit
+
+You are the **code** lane of a three-lane audit (code / security /
+architect) of the trusted-proxy + XFF refactor for issue #125. Stay
+narrowly in your lane.
+
+## Branch / commit
+- Branch: `fix/coordinator-trusted-proxies-xff`
+- Worktree: `../macprovider-125-trusted-proxies` (origin/main base: d27aac5)
+- Files in scope (`git diff origin/main`):
+  - `phase4-coordinator/internal/config/config.go` — new `ProxyConfig{TrustedProxies}` block + `TrustedProxyPrefixes()` helper + `Validate()` call.
+  - `phase4-coordinator/internal/buyer/server.go` — refactored `poolCheckClientKey` to a Server method consulting `s.trustedProxies`; new `rightmostUntrustedXFF` helper + `isTrustedProxy` predicate; `WithTrustedProxies` option; constructor seeds default loopback prefixes.
+  - `phase4-coordinator/internal/buyer/trusted_proxies_test.go` (NEW) — 11 tests covering the surface.
+  - `phase4-coordinator/cmd/coordinator/main.go` — wires `cfg.TrustedProxyPrefixes()` into the buyer Server via a `mustParseTrustedProxies` helper.
+
+## What this change does (operator summary — NOT the audit answer)
+
+Issue #125. PR #124 landed a partial fix that honored X-Real-IP only when r.RemoteAddr is loopback. The remaining surface:
+- Non-loopback proxy topologies (remote LB, sidecar)
+- Trusted-proxy CIDR allowlist
+- Chained-trusted-proxy hops via X-Forwarded-For (rightmost-untrusted)
+
+This branch:
+1. Adds `proxy.trusted_proxies` config (default `["127.0.0.0/8", "::1/128"]` preserves production behavior).
+2. `poolCheckClientKey` now (a) parses r.RemoteAddr to netip.Addr; (b) consults `s.trustedProxies`; (c) if trusted, walks XFF right-to-left for the first non-trusted hop, falls back to X-Real-IP, then r.RemoteAddr; (d) if untrusted, IGNORES forwarded headers and returns r.RemoteAddr — spoof rejection.
+3. Constructor seeds default loopback prefixes so existing tests + callers keep working without explicit `WithTrustedProxies`.
+
+## Code-lane scope (apply each; stay in lane)
+
+### CODE-1. Helper correctness
+- `rightmostUntrustedXFF(header, trusted)`: walks comma-split hops right-to-left; for each hop trims whitespace, strips optional :port via net.SplitHostPort, strips lone brackets for IPv6, parses via netip.ParseAddr, returns first non-trusted hop's `addr.String()`. Trace:
+  - Empty header → "" (caller falls through).
+  - All hops trusted → "" (falls through to X-Real-IP).
+  - Junk middle hop (e.g. "not-an-ip") → continue past it; return next-rightmost untrusted.
+  - IPv6 with brackets `[2001:db8::1]:443` → SplitHostPort strips port; Trim drops residual brackets; ParseAddr succeeds.
+  - Bare IPv6 `2001:db8::1` → SplitHostPort fails (no port); Trim no-op; ParseAddr succeeds.
+- `isTrustedProxy(addr)`: nil-safe (returns false on empty s.trustedProxies). Confirm.
+- `(s *Server).poolCheckClientKey(r)`: branch order: SplitHostPort → ParseAddr → if !trusted return host → XFF rightmost-untrusted → X-Real-IP → host. Trace each branch.
+
+### CODE-2. Constructor / default seeding
+- `NewServer` seeds `trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8"), netip.MustParsePrefix("::1/128")}`. `WithTrustedProxies` REPLACES this set (uses `s.trustedProxies[:0]` to discard the default; confirm the slice mutation is safe — no aliased reference held elsewhere).
+- `mustParseTrustedProxies(cfg, logger)` in main.go: returns nil on parse error after logging a warning (strictest possible posture). Trace: is "nil → no proxy trusted" the right failure mode, or should the boot fail fast?
+- `Validate()` calls `TrustedProxyPrefixes()` so malformed CIDRs reject at config.Load. The same parse happens AGAIN in `mustParseTrustedProxies` — verify the duplication is intentional (defensive vs single-source-of-truth).
+
+### CODE-3. Existing test compatibility
+- `TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback` (catalog_endpoints_test.go:245) constructs `NewServer` without `WithTrustedProxies`. After the refactor it depends on the constructor's default loopback seeding. Confirm the test still pins the PR #124 invariant (loopback honors X-Real-IP; direct caller cannot spoof). Run the test mentally against the new code.
+
+### CODE-4. New test adequacy
+The 11 new `TestPoolCheckClientKey_*` tests in trusted_proxies_test.go cover:
+- LoopbackDefaultHonorsXRealIP, NonLoopbackTrustedProxyHonorsXFF, UntrustedProxyIgnoresXFFAndXRealIP, MultiHopXFFReturnsRightmostUntrusted, XFFTakesPriorityOverXRealIP, EmptyTrustedSetIgnoresForwardedHeaders, AllHopsTrustedFallsBackToXRealIP, AllHopsTrustedNoHeadersFallsBackToRemoteAddr, IPv6LoopbackHonored, MalformedXFFHopSkipped, UnparseableRemoteAddrFallsBack.
+- Missing coverage to flag? Specifically:
+  - XFF with leading/trailing whitespace + commas (`" 1.2.3.4 , 5.6.7.8 "`)?
+  - Empty hop in XFF (`"1.2.3.4,,5.6.7.8"`) — does the empty-string TrimSpace + ParseAddr-fail path do the right thing?
+  - XFF with only commas (`",,,"`) → "" return → fallback path?
+  - X-Real-IP with attached port (`"1.2.3.4:443"`) — current code does NOT strip the port for X-Real-IP, but production nginx sets it without port. Worth a test pin or comment?
+
+### CODE-5. Backward compatibility + isLoopbackHost retention
+- `isLoopbackHost` is now unused in the rate-limit path (replaced by `isTrustedProxy`). The function is retained per the new doc comment. Grep for any remaining caller — is it actually used anywhere, or is the retention purely defensive?
+- The pre-refactor `poolCheckClientKey` was a package-level function; it's now a `(s *Server)` method. Callers update: confirm both `allowPoolCheck` and `allowReceiptKeys` callsites switched to `s.poolCheckClientKey(r)`. Any other callsite (greppable)?
+
+### CODE-6. Comment quality
+- The new `poolCheckClientKey` doc block enumerates the 3-tier priority (XFF → X-Real-IP → r.RemoteAddr) and the spoof-rejection rationale. Is the wording precise enough?
+- The `ProxyConfig` config-side doc block mentions the security-sensitive nature of expanding TrustedProxies. Sufficient?
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/125_TRUSTED_PROXIES_CODE_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM, end with:
+`VERDICT: code lane READY TO MERGE`

--- a/specs/AUDIT_125_TRUSTED_PROXIES_CODE_R2_PROMPT.md
+++ b/specs/AUDIT_125_TRUSTED_PROXIES_CODE_R2_PROMPT.md
@@ -1,0 +1,65 @@
+# Issue #125 trusted-proxy + XFF — CODE-lane R2 (closure verification)
+
+Round 1 (`specs/125_TRUSTED_PROXIES_CODE_audit.md`) returned
+**0 C/H/M / 4 LOW / 0 Q — READY TO MERGE**. The author applied
+targeted fixes for 3 of the 4 LOWs + most of the cross-lane LOWs.
+Verify closure + flag any NEW issue introduced.
+
+## Branch / commit
+- Branch: `fix/coordinator-trusted-proxies-xff`
+- Worktree: `../macprovider-125-trusted-proxies`
+- Read: `git diff origin/main`
+
+## Round-1 findings to verify closure on
+
+- **L1.** `ProxyConfig` comment referenced a nonexistent config test
+  (`TestDefaultProxyConfigTrustsLoopbackOnly`).
+  - Fix expected: either remove the test-name claim or actually add the
+    test. The author DID add the test (config_test.go) and updated the
+    comment to drop the dangling reference.
+- **L2.** `rightmostUntrustedXFF` comment said
+  `netip.ParseAddrPort` but the code uses `net.SplitHostPort`.
+  - Fix expected: comment updated.
+- **L3.** XFF edge cases (whitespace, empty hops, only commas) not
+  pinned by tests.
+  - Fix expected: new tests added in trusted_proxies_test.go.
+- **L4.** X-Real-IP accepts raw string including value-with-port.
+  - Fix expected: X-Real-IP now parsed via `netip.ParseAddr` →
+    canonical `addr.String()`; port-bearing or junk values fall
+    through to r.RemoteAddr. (This also closes the security-lane L1.)
+
+## Audit lenses for fresh issues (apply briefly)
+
+- The new X-Real-IP `netip.ParseAddr` canonicalization changes the
+  bucket key for any pre-existing test or production case that
+  passed an X-Real-IP value that ParseAddr-doesn't-accept. The
+  TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback existing
+  test uses bare IP literals — confirm it still passes.
+- The package-level `isTrustedProxy(addr, trusted)` refactor (was a
+  `(s *Server)` method) — both callers updated? grep for any stale
+  `s.isTrustedProxy`.
+- New config-side tests in config_test.go — do they exercise the
+  Validate path AND the TrustedProxyPrefixes path?
+
+## Output format
+
+```
+CLOSURE on round-1 findings:
+  L1: PASS|PARTIAL|FAIL — <one line>
+  L2: ...
+  L3: ...
+  L4: ...
+
+NEW FINDINGS (round 2):
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/125_TRUSTED_PROXIES_CODE_r2_audit.md`.
+
+If all findings closed AND zero NEW C/H/M, end with:
+`VERDICT: code lane READY TO MERGE`

--- a/specs/AUDIT_125_TRUSTED_PROXIES_SECURITY_PROMPT.md
+++ b/specs/AUDIT_125_TRUSTED_PROXIES_SECURITY_PROMPT.md
@@ -1,0 +1,137 @@
+# Issue #125 trusted-proxy + X-Forwarded-For — SECURITY-lane audit
+
+You are the **security** lane of a three-lane audit (code / security /
+architect) of the trusted-proxy + XFF refactor for issue #125. Stay
+narrowly in your lane.
+
+## Why security cares about this diff
+
+`poolCheckClientKey` is the rate-limit key for three buyer-facing
+endpoints: `/v1/pool/check`, `/v1/receipt-keys/*`, and
+`/catalog/*`. The rate-limit bucket gates anti-abuse, not direct
+money flow — but it IS the surface that prevents one noisy caller
+from starving every other buyer's access to these endpoints.
+
+Pre-PR-#124: bucket keyed off `r.RemoteAddr` only, which collapsed
+to 127.0.0.1 for every public buyer behind nginx. PR #124 fixed the
+loopback case via X-Real-IP. This branch generalizes the fix and
+introduces a new threat surface — *if the trusted-proxy CIDR set is
+mis-configured, attackers in those CIDRs can spoof their bucket key
+by sending X-Forwarded-For / X-Real-IP themselves.*
+
+## Branch / commit
+- Branch: `fix/coordinator-trusted-proxies-xff`
+- Worktree: `../macprovider-125-trusted-proxies` (origin/main base: d27aac5)
+- Files in scope (`git diff origin/main`).
+
+## Security-lane scope (apply each; stay in lane)
+
+### SEC-1. Spoof rejection — the load-bearing security invariant
+- Untrusted peer with XFF + X-Real-IP MUST be keyed on r.RemoteAddr,
+  NOT the spoofed headers. Trace:
+  `TestPoolCheckClientKey_UntrustedProxyIgnoresXFFAndXRealIP`
+  pins this with `203.0.113.5:50000` + spoofed XFF=1.2.3.4 +
+  X-Real-IP=5.6.7.8 → expected key 203.0.113.5. Confirm the helper
+  honors this.
+- Direct internet caller from 0.0.0.0/0 (default trusted set is
+  loopback-only) MUST never have its bucket key controllable via
+  headers. Confirm.
+- Empty trusted-proxies set means EVERY caller is untrusted (only
+  r.RemoteAddr keys). Confirm
+  `TestPoolCheckClientKey_EmptyTrustedSetIgnoresForwardedHeaders`.
+
+### SEC-2. Trust-chain integrity
+- `rightmostUntrustedXFF` walks RIGHT TO LEFT. The rightmost hop is
+  the one closest to the coordinator (added by the immediate-upstream
+  proxy); the leftmost is the buyer's claimed IP. Walking right-to-
+  left and returning the first non-trusted entry IS the standard MDN
+  "rightmost-untrusted" pattern that prevents a buyer-supplied
+  leftmost IP from leaking into the bucket key. Confirm:
+  - If buyer sends `X-Forwarded-For: 1.2.3.4` (leftmost claimed),
+    and immediate-upstream nginx prepends `, 203.0.113.99` (the real
+    buyer), and final hop appends `, 127.0.0.1` (LB→coordinator),
+    the trusted set is `{127.0.0.0/8, 10.0.0.0/8}`, and the chain is
+    `1.2.3.4, 203.0.113.99, 127.0.0.1` — the helper returns
+    203.0.113.99 (correct: the buyer-presented "1.2.3.4" is not
+    admitted because 203.0.113.99 is the rightmost-untrusted).
+- What if an attacker controls the LEFTMOST entry only — e.g. sends
+  `X-Forwarded-For: 1.2.3.4`, nginx receives it from
+  `198.51.100.42`, nginx appends 198.51.100.42 to make the chain
+  `1.2.3.4, 198.51.100.42`, then forwards to coordinator at
+  127.0.0.1. The trusted set is loopback-only. The rightmost-
+  untrusted walk: hop[1] = 198.51.100.42 → not trusted → returned.
+  CORRECT — buyer's spoofed 1.2.3.4 ignored. Confirm.
+
+### SEC-3. Mis-configuration risk
+- Operators expanding TrustedProxies to a non-actual-proxy CIDR
+  (e.g. `0.0.0.0/0`) would let any caller in that CIDR spoof. The
+  config comment names this as "security-sensitive". Is the warning
+  prominent enough? Is there a Validate-time guard against
+  obviously-wrong values (e.g. reject `0.0.0.0/0` outright)?
+- Default is loopback-only. Confirm `config.Default()` returns
+  `["127.0.0.0/8", "::1/128"]` and `Load` preserves it through YAML
+  round-trip when `proxy.trusted_proxies` is absent.
+
+### SEC-4. Resource-exhaustion (DoS via the rate-limit bucket map)
+- The bucket maps (`poolCheckLast`, `receiptKeysLimiters`) are
+  keyed on the derived client key. Pre-refactor: max ~2^32 keys
+  (one per IP). Post-refactor with trusted-proxy mis-config: an
+  attacker who can choose their own bucket key (via spoofed XFF in
+  a trusted CIDR) could either:
+  - Pin one specific key to consume all bursts for that key (no
+    new bucket inflation), OR
+  - Cycle through 2^32 keys to inflate the map past
+    `maxEntries=4096` — but the existing eviction loop bounds the
+    map size. Confirm the eviction is still bounded.
+- Is the TTL-based eviction (`evictPoolCheckEntries`,
+  `evictReceiptKeyEntries`) still adequate at the new keying surface?
+
+### SEC-5. Boot-time / fail-closed behavior
+- `mustParseTrustedProxies` returns nil on parse failure after a
+  warning log. Nil means strictest posture (no proxy trusted) — but
+  this means a mis-configured `proxy.trusted_proxies` would silently
+  degrade to "X-Real-IP / X-Forwarded-For never honored", breaking
+  the production loopback case. Is that the right failure mode?
+  - Alternative: fail-fast at boot (panic / exit non-zero) so the
+    operator notices.
+  - Current `config.Validate` already rejects malformed CIDRs, so
+    the helper's nil-fallback is dead-code-on-the-happy-path —
+    only fires on Validate/parse drift. Acceptable?
+
+### SEC-6. WS-side parity
+- `ws.remoteIPForUnauthSemaphore` still uses the narrower
+  loopback-only X-Real-IP path (NOT the new trusted-proxy CIDR
+  logic). The PR comment says this is "intentionally not unified".
+  Is the WS-side surface (unauth WS-handshake semaphore for M1-4
+  SECU-1) at risk of the same per-buyer-bucket-collapse if an
+  operator moves to a remote LB? Worth a follow-up issue?
+
+### SEC-7. Header injection / parsing safety
+- The XFF header value comes from r.Header.Get("X-Forwarded-For")
+  — Go's http.Header normalizes via canonical form, so injection
+  via raw header bytes shouldn't apply. Parsing via comma-split +
+  TrimSpace + ParseAddr is strict. Confirm no path could panic on
+  pathological input (e.g. extremely long header, deeply nested
+  brackets, etc.).
+- `net.SplitHostPort` on a non-host:port string returns err and the
+  helper falls through. Confirm there's no path where the helper
+  uses an unsanitized value as the bucket key.
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/125_TRUSTED_PROXIES_SECURITY_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM, end with:
+`VERDICT: security lane READY TO MERGE`

--- a/specs/AUDIT_125_TRUSTED_PROXIES_SECURITY_R2_PROMPT.md
+++ b/specs/AUDIT_125_TRUSTED_PROXIES_SECURITY_R2_PROMPT.md
@@ -1,0 +1,67 @@
+# Issue #125 trusted-proxy + XFF — SECURITY-lane R2 (closure verification)
+
+Round 1 (`specs/125_TRUSTED_PROXIES_SECURITY_audit.md`) returned
+**0 C/H/M / 2 LOW / 1 Q — READY TO MERGE**. The author applied
+targeted fixes.
+
+## Branch / commit
+- Branch: `fix/coordinator-trusted-proxies-xff`
+- Worktree: `../macprovider-125-trusted-proxies`
+- Read: `git diff origin/main`
+
+## Round-1 findings to verify closure on
+
+- **L1.** X-Real-IP fallback stored a trusted header value WITHOUT
+  IP parsing / canonicalization.
+  - Fix expected: X-Real-IP is now parsed via `netip.ParseAddr`;
+    success returns `addr.String()` (canonical form), failure falls
+    through to r.RemoteAddr. Port-bearing values (`1.2.3.4:8080`)
+    fail to parse and fall through.
+- **L2.** `Validate` accepted universal trusted-proxy CIDRs
+  (`0.0.0.0/0`, `::/0`).
+  - Fix expected: `TrustedProxyPrefixes` now rejects prefixes with
+    `Bits() == 0` at parse time; `Validate` rejects them at startup.
+    Config-side tests added.
+- **Q1.** WS unauth semaphore parity — flagged as a follow-up
+  question. The new poolCheckClientKey doc comment explicitly defers
+  unification to a future shared `httpip` helper. No fix in this
+  PR; verify the deferral is documented.
+
+## Audit lenses for fresh issues (apply briefly)
+
+- Does the X-Real-IP canonical-form change introduce any spoof
+  surface? E.g. an attacker who sends a different non-canonical form
+  of an IP they want to share a bucket with — but addr.String() is
+  injective on valid IPs (only one canonical form per IP), so all
+  representations of the SAME IP collapse to the same key (good —
+  this is actually a hardening).
+- Default-route rejection: `0.0.0.0/0` and `::/0` (both Bits() == 0)
+  rejected. Any OTHER class of "obviously unsafe" prefix? E.g.
+  `0.0.0.0/1` covers half the IPv4 space. Should the rejection
+  threshold tighten further (e.g. require >=/8), or is the
+  default-route guard sufficient?
+- Validate failure modes: `mustParseTrustedProxies` in main.go now
+  Fatals on parse error. Defensive against drift between Validate
+  and TrustedProxyPrefixes. Confirm.
+
+## Output format
+
+```
+CLOSURE on round-1 findings:
+  L1: PASS|PARTIAL|FAIL — <one line>
+  L2: PASS|PARTIAL|FAIL — <one line>
+  Q1: noted (deferred to follow-up)
+
+NEW FINDINGS (round 2):
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/125_TRUSTED_PROXIES_SECURITY_r2_audit.md`.
+
+If all addressed findings closed AND zero NEW C/H/M, end with:
+`VERDICT: security lane READY TO MERGE`

--- a/specs/SPEC-002-coordinator.md
+++ b/specs/SPEC-002-coordinator.md
@@ -2550,6 +2550,18 @@ Unknown providers return the same 200 shape with `"state": "unknown"`.
 {"error":{"code":"rate_limited","message":"Pool check rate limit exceeded"}}
 ```
 
+**Rate-limit source-IP derivation (issue #125).** The per-source rate-
+limit bucket key is derived as follows: if `r.RemoteAddr` falls inside
+one of the operator-configured `proxy.trusted_proxies` CIDR ranges
+(default `["127.0.0.0/8", "::1/128"]` covers the production nginx-on-
+localhost topology), the coordinator parses the `X-Forwarded-For`
+header rightmost-untrusted-hop first, falling back to `X-Real-IP`,
+then to `r.RemoteAddr`. For peers outside the trusted-proxy CIDR set
+the `X-Forwarded-For` / `X-Real-IP` headers are IGNORED — direct
+internet callers cannot spoof their bucket key. Operators MUST keep
+`proxy.trusted_proxies` narrow; expanding it to non-actual-proxy CIDRs
+admits spoofing.
+
 Purpose: SPEC-003 v0.6 `install.sh` self-test calls this endpoint after
 first WebSocket connect to confirm that a freshly installed provider has
 registered with the coordinator. It is also a generic provider-registered

--- a/specs/SPEC-015-receipts.md
+++ b/specs/SPEC-015-receipts.md
@@ -2477,6 +2477,14 @@ provided the coordinator returns the exact shape.
   `10 req/sec` per source IP, with a `429` response on overage.
   This protects the coordinator against amplification attacks
   while leaving headroom for batch buyer-side verification.
+  **Source-IP derivation (issue #125).** Per-source bucket keying
+  goes through the operator-configured `proxy.trusted_proxies`
+  CIDR set (see SPEC-002 v1.4.x `proxy.trusted_proxies` block):
+  when the immediate peer is in the trusted set the coordinator
+  parses `X-Forwarded-For` rightmost-untrusted-hop first, falling
+  back to `X-Real-IP`; for untrusted peers the forwarded headers
+  are ignored and the peer's own IP is the bucket key (spoof
+  rejection).
 - **Caching headers:** Response MUST include `Cache-Control: public,
   max-age=300` (5 minutes). Verifiers SHOULD NOT bypass this cache
   via `Cache-Control: no-cache` request headers — staleness up to
@@ -3333,7 +3341,8 @@ covered by the "effectively active catalog" condition above.
 - **Authentication:** None (public).
 - **Rate limiting:** Operator-configurable; recommended floor
   10 req/sec per source IP, mirroring §10.7's
-  `/v1/receipt-keys` posture.
+  `/v1/receipt-keys` posture. Source-IP derivation goes through
+  `proxy.trusted_proxies` (issue #125; see §10.7 and SPEC-002 v1.4.x).
 - **Cache-Control:** `public, max-age=300` (5 minutes; same as
   §10.7).
 - **Response:** the literal signed catalog bytes accepted by the


### PR DESCRIPTION
## Summary

Closes issue #125 — generalizes PR #124's loopback-only X-Real-IP fix to support non-loopback proxy topologies, a configurable trusted-proxy CIDR allowlist, and chained-trusted-proxy hops via X-Forwarded-For (rightmost-untrusted).

Pre-PR-#124: rate-limit bucket keyed off `r.RemoteAddr` only → collapsed to `127.0.0.1` for every public buyer behind nginx-on-localhost. PR #124 fixed the loopback case via X-Real-IP. This PR closes the rest.

## Changes

**Config — `phase4-coordinator/internal/config/config.go`**
- New `ProxyConfig{TrustedProxies []string}` block, top-level `proxy:` key.
- Default `["127.0.0.0/8", "::1/128"]` preserves the production nginx-on-localhost topology.
- `TrustedProxyPrefixes()` helper parses to `[]netip.Prefix`; `Validate` rejects malformed CIDRs AND default-route prefixes (`0.0.0.0/0`, `::/0`) at config.Load.

**Rate-limit keying — `phase4-coordinator/internal/buyer/server.go`**
- `poolCheckClientKey` is now a Server method consulting `s.trustedProxies`.
- **Trusted peer**: walks `X-Forwarded-For` right-to-left for the first non-trusted hop (rightmost-untrusted; survives chained trusted proxies). Falls back to `X-Real-IP` parsed via `netip.ParseAddr` → canonical form. Port-bearing/junk `X-Real-IP` values are rejected and fall through to `r.RemoteAddr`.
- **Untrusted peer**: forwarded headers IGNORED entirely. Direct internet callers cannot spoof their bucket key.
- Package-level pure `isTrustedProxy(addr, trusted)` shared by both `poolCheckClientKey` and `rightmostUntrustedXFF`.
- New `WithTrustedProxies(prefixes)` option; constructor seeds default loopback set so existing callers + tests keep working.

**Plumbing — `phase4-coordinator/cmd/coordinator/main.go`**
- `mustParseTrustedProxies` wires `cfg.TrustedProxyPrefixes()` into `buyer.NewServer`. `logger.Fatal()`s at startup on any post-Validate parse drift instead of silently degrading to no-proxy-trusted.

**Operator docs**
- Both `coordinator.yaml.example` templates now ship the `proxy.trusted_proxies` block with the spoof/collapse warning.
- SPEC-002 `/v1/pool/check` 429 response block gains a normative source-IP-derivation paragraph.
- SPEC-015 gains pointers to `proxy.trusted_proxies` under both rate-limit mentions (§10.7 `/v1/receipt-keys` and `GET /catalog/<catalog_id>`).

**Tests**
- `phase4-coordinator/internal/buyer/trusted_proxies_test.go` (NEW): 17 tests covering loopback default, trusted CIDR, multi-hop XFF, untrusted-proxy spoof rejection, XFF priority, empty trusted-set, all-hops-trusted fallback, IPv6 loopback, malformed XFF skipping, unparseable RemoteAddr, plus XFF whitespace/empty/only-commas edge cases, X-Real-IP malformed/port-bearing rejection, and IPv6 X-Real-IP canonical form pinning.
- `phase4-coordinator/internal/config/config_test.go`: 5 new tests for default-route rejection (`0.0.0.0/0`, `::/0`), malformed CIDR rejection, and empty-trusted-proxies validity.

## Codex audit loop (3 lanes, per repo discipline)

| Round | code | security | architect |
|---|---|---|---|
| r1 | 0 / 0 / 0 / 4L / 0 — READY TO MERGE | 0 / 0 / 0 / 2L / 1Q — READY TO MERGE | 0 / 0 / **1M** / 3L / 0 — gate held (operator-docs gap) |
| r2 (post-fix) | 4/4 PASS — **READY TO MERGE** | 2/2 PASS — **READY TO MERGE** | 3 PASS + 1 deferred — **READY TO MERGE** |

Audit prompts + reports:
- code: [r1](specs/AUDIT_125_TRUSTED_PROXIES_CODE_PROMPT.md) → [r1 report](specs/125_TRUSTED_PROXIES_CODE_audit.md) → [r2](specs/125_TRUSTED_PROXIES_CODE_r2_audit.md)
- security: [r1](specs/AUDIT_125_TRUSTED_PROXIES_SECURITY_PROMPT.md) → [r1 report](specs/125_TRUSTED_PROXIES_SECURITY_audit.md) → [r2](specs/125_TRUSTED_PROXIES_SECURITY_r2_audit.md)
- architect: [r1](specs/AUDIT_125_TRUSTED_PROXIES_ARCHITECT_PROMPT.md) → [r1 report](specs/125_TRUSTED_PROXIES_ARCHITECT_audit.md) → [r2](specs/125_TRUSTED_PROXIES_ARCHITECT_r2_audit.md)

## Verification

- [x] `cd phase4-coordinator && go build ./...`
- [x] `cd phase4-coordinator && go test ./... -timeout 180s` — green in 15.3s
- [x] `cd phase4-coordinator && go test ./internal/buyer -race -count=5 -timeout 600s` — green in 10.6s
- [x] Existing `TestCatalogEndpointRateLimitedPerXRealIPBehindLoopback` still pins PR #124 invariant
- [ ] Pearl smoke: verify the existing loopback rate-limit behavior unchanged on production

## Deferred (advisory cross-lane findings)

- WS-side `ws.remoteIPForUnauthSemaphore` still implements the narrow loopback-only X-Real-IP path. The new `poolCheckClientKey` doc block explicitly defers unification to a future shared `internal/httpip` helper (architect L1 + security Q1). Out of scope.
- Wider-but-nondefault prefixes (e.g. `0.0.0.0/1`) remain operator policy rather than a Validate-time rejection. The default-route guard catches the obvious universal-trust footgun; tighter thresholds are advisory.

Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
