### PR TITLE
fix(phase7-verify): surface TLS trust widening + exit 64 on private coordinator (#128 + #126)

### DIFF
--- a/phase7-verify/integration_test.go
+++ b/phase7-verify/integration_test.go
@@ -124,16 +124,22 @@ func TestReceiptBundleFixturesEndToEnd(t *testing.T) {
 		expectJSON    bool
 		expectNetwork bool
 	}{
-		{name: "valid_fresh", file: "valid_fresh.bundle.json", exitCode: 0, result: "valid", reason: "signature_and_canonicalization_match", warnings: []string{"non_default_coordinator"}, expectJSON: true, expectNetwork: true},
-		{name: "valid_prev_key_in_grace", file: "valid_prev_key_in_grace.bundle.json", exitCode: 0, result: "valid", reason: "signature_and_canonicalization_match", warnings: []string{"non_default_coordinator"}, expectJSON: true, expectNetwork: true},
-		{name: "invalid_tampered_output", file: "invalid_tampered_output.bundle.json", exitCode: 1, result: "invalid", reason: "output_hash_mismatch", warnings: []string{"non_default_coordinator"}, expectJSON: true, expectNetwork: true},
-		{name: "invalid_tampered_prompt", file: "invalid_tampered_prompt.bundle.json", exitCode: 1, result: "invalid", reason: "prompt_hash_mismatch", warnings: []string{"non_default_coordinator"}, expectJSON: true, expectNetwork: true},
-		{name: "invalid_tampered_unix_ts", file: "invalid_tampered_unix_ts.bundle.json", exitCode: 1, result: "invalid", reason: "signature_verify_failed", warnings: []string{"non_default_coordinator"}, expectJSON: true, expectNetwork: true},
-		{name: "invalid_pubkey_not_endorsed", file: "invalid_pubkey_not_endorsed.bundle.json", exitCode: 1, result: "invalid", reason: "pubkey_not_endorsed", warnings: []string{"non_default_coordinator"}, expectJSON: true, expectNetwork: true},
-		{name: "invalid_prev_key_outside_grace", file: "invalid_prev_key_outside_grace.bundle.json", exitCode: 1, result: "invalid", reason: "previous_key_outside_grace_window", warnings: []string{"non_default_coordinator"}, expectJSON: true, expectNetwork: true},
-		{name: "inconclusive_pubkey_unresolvable", file: "valid_fresh.bundle.json", exitCode: 2, result: "inconclusive", reason: "pubkey_unresolvable", warnings: []string{"live_check_skipped", "non_default_coordinator"}, fail5xx: true, expectJSON: true, expectNetwork: true},
-		{name: "inconclusive_resolver_404", file: "inconclusive_resolver_404.bundle.json", exitCode: 2, result: "inconclusive", reason: "provider_id_not_in_pool", warnings: []string{"non_default_coordinator"}, fail404: true, expectJSON: true, expectNetwork: true},
-		{name: "inconclusive_stale_cache_live_fail", file: "inconclusive_stale_cache_live_fail.bundle.json", exitCode: 2, result: "inconclusive", reason: "cache_stale_and_live_unreachable", warnings: []string{"live_check_skipped", "non_default_coordinator"}, fail5xx: true, seedStale: true, expectJSON: true, expectNetwork: true},
+		// Issue #128 / SPEC-015 v0.3.4: every scenario below runs with
+		// MACPROVIDER_VERIFY_TLS_CA_FILE pointing at the integration's
+		// mock CA (line 357 below), so the verifier MUST also emit a
+		// `non_default_tls_trust` warning per the new normative rule.
+		// The mock-CA setup is unchanged; only the expected warnings[]
+		// slice grows.
+		{name: "valid_fresh", file: "valid_fresh.bundle.json", exitCode: 0, result: "valid", reason: "signature_and_canonicalization_match", warnings: []string{"non_default_coordinator", "non_default_tls_trust"}, expectJSON: true, expectNetwork: true},
+		{name: "valid_prev_key_in_grace", file: "valid_prev_key_in_grace.bundle.json", exitCode: 0, result: "valid", reason: "signature_and_canonicalization_match", warnings: []string{"non_default_coordinator", "non_default_tls_trust"}, expectJSON: true, expectNetwork: true},
+		{name: "invalid_tampered_output", file: "invalid_tampered_output.bundle.json", exitCode: 1, result: "invalid", reason: "output_hash_mismatch", warnings: []string{"non_default_coordinator", "non_default_tls_trust"}, expectJSON: true, expectNetwork: true},
+		{name: "invalid_tampered_prompt", file: "invalid_tampered_prompt.bundle.json", exitCode: 1, result: "invalid", reason: "prompt_hash_mismatch", warnings: []string{"non_default_coordinator", "non_default_tls_trust"}, expectJSON: true, expectNetwork: true},
+		{name: "invalid_tampered_unix_ts", file: "invalid_tampered_unix_ts.bundle.json", exitCode: 1, result: "invalid", reason: "signature_verify_failed", warnings: []string{"non_default_coordinator", "non_default_tls_trust"}, expectJSON: true, expectNetwork: true},
+		{name: "invalid_pubkey_not_endorsed", file: "invalid_pubkey_not_endorsed.bundle.json", exitCode: 1, result: "invalid", reason: "pubkey_not_endorsed", warnings: []string{"non_default_coordinator", "non_default_tls_trust"}, expectJSON: true, expectNetwork: true},
+		{name: "invalid_prev_key_outside_grace", file: "invalid_prev_key_outside_grace.bundle.json", exitCode: 1, result: "invalid", reason: "previous_key_outside_grace_window", warnings: []string{"non_default_coordinator", "non_default_tls_trust"}, expectJSON: true, expectNetwork: true},
+		{name: "inconclusive_pubkey_unresolvable", file: "valid_fresh.bundle.json", exitCode: 2, result: "inconclusive", reason: "pubkey_unresolvable", warnings: []string{"live_check_skipped", "non_default_coordinator", "non_default_tls_trust"}, fail5xx: true, expectJSON: true, expectNetwork: true},
+		{name: "inconclusive_resolver_404", file: "inconclusive_resolver_404.bundle.json", exitCode: 2, result: "inconclusive", reason: "provider_id_not_in_pool", warnings: []string{"non_default_coordinator", "non_default_tls_trust"}, fail404: true, expectJSON: true, expectNetwork: true},
+		{name: "inconclusive_stale_cache_live_fail", file: "inconclusive_stale_cache_live_fail.bundle.json", exitCode: 2, result: "inconclusive", reason: "cache_stale_and_live_unreachable", warnings: []string{"live_check_skipped", "non_default_coordinator", "non_default_tls_trust"}, fail5xx: true, seedStale: true, expectJSON: true, expectNetwork: true},
 		{name: "malformed_bundle", file: "malformed_bundle.bundle.json", exitCode: 65},
 		{name: "malformed_receipt", file: "malformed_receipt.bundle.json", exitCode: 65},
 	}

--- a/phase7-verify/internal/cli/cli.go
+++ b/phase7-verify/internal/cli/cli.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/augstar/macprovider/phase7-verify/internal/cache"
 	"github.com/augstar/macprovider/phase7-verify/internal/receipt"
+	"github.com/augstar/macprovider/phase7-verify/internal/resolver"
 	"github.com/augstar/macprovider/phase7-verify/internal/verify"
 	"github.com/augstar/macprovider/phase7-verify/internal/version"
 )
@@ -499,6 +500,14 @@ func exitForError(err error) int {
 	var cliFormat *cliInputFormatError
 	switch {
 	case errors.As(err, &usageErr), errors.As(err, &cliUsage):
+		return exitUsage
+	// Issue #126: --coordinator pointing at a loopback / RFC1918 /
+	// link-local host without MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR=1
+	// is a CLI invocation policy violation, not an internal software
+	// error. Map to exit 64 (EX_USAGE) per SPEC-015 §10.4.3 so scripts
+	// and CI pipelines can distinguish "operator pointed at a bad host"
+	// from "verifier crashed".
+	case errors.Is(err, resolver.ErrPrivateCoordinatorDenied):
 		return exitUsage
 	case errors.As(err, &formatErr), errors.As(err, &cliFormat):
 		return exitDataErr

--- a/phase7-verify/internal/cli/cli_test.go
+++ b/phase7-verify/internal/cli/cli_test.go
@@ -461,6 +461,31 @@ func TestUsageBoundaries(t *testing.T) {
 	}
 }
 
+// Issue #126: --coordinator pointing at loopback / RFC1918 / link-local
+// without MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR=1 MUST exit 64
+// (EX_USAGE), not the default 70 (software). Pinned via the
+// resolver.ErrPrivateCoordinatorDenied sentinel in cli.exitForError so
+// scripts and CI pipelines can distinguish "operator pointed at a bad
+// host" from "verifier crashed".
+//
+// This test temporarily clears the escape-hatch env var that TestMain
+// sets to 1 for other CLI tests; t.Setenv restores it at teardown.
+func TestCLIPrivateCoordinatorExitsUsage(t *testing.T) {
+	t.Setenv("MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR", "")
+	fixture := newCLIFixture(t, makeKey(80), cliNow.Unix())
+	pubkey := base64.StdEncoding.EncodeToString(fixture.pub)
+	args := append(headerArgs("https://127.0.0.1:8080", fixture, "--provider-id", testProviderID), "--pubkey", pubkey)
+
+	stdout, stderr, c := buffersAndCache(t)
+	code := run(args, strings.NewReader(""), stdout, stderr, getenvNone, runConfig{cache: c, now: func() time.Time { return cliNow }})
+	if code != exitUsage {
+		t.Fatalf("exit=%d want=64 (exitUsage) stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR") {
+		t.Fatalf("stderr=%q want mention of MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR env var", stderr.String())
+	}
+}
+
 func TestSingleMatchCacheScannerOverflowRequiresProviderID(t *testing.T) {
 	fixture := newCLIFixture(t, makeKey(50), cliNow.Unix())
 	stdout, stderr, c := buffersAndCache(t)

--- a/phase7-verify/internal/resolver/resolver.go
+++ b/phase7-verify/internal/resolver/resolver.go
@@ -79,6 +79,15 @@ var (
 	// followed by net/http after the first response.
 	ErrRedirectOffPath = errors.New("redirect target path differs from the original receipt-keys request")
 	ErrFetchFailed     = errors.New("receipt key fetch failed")
+	// ErrPrivateCoordinatorDenied fires when --coordinator points to a
+	// loopback / RFC1918 / link-local host and the
+	// MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR=1 escape hatch is
+	// not set. This is a CLI invocation policy violation (the operator
+	// pointed the verifier at a private-network coordinator without
+	// opting in), so cli.exitForError maps it to exit 64 (EX_USAGE)
+	// per SPEC-015 §10.4.3 rather than the default exit 70 (software
+	// error). Issue #126.
+	ErrPrivateCoordinatorDenied = errors.New("--coordinator host is loopback/private")
 )
 
 var providerIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
@@ -112,6 +121,16 @@ func Resolve(providerID string, explicitPubkey []byte, opts ResolveOpts) (Resolv
 		now = opts.Now
 	}
 	warnings := coordinatorWarnings(target.host)
+	// Issue #128: surface silent TLS trust widening so a buyer running
+	// under a wrapper script where MACPROVIDER_VERIFY_TLS_CA_FILE has
+	// been set sees a visible indicator in the warnings[] array (and
+	// on stderr unless --quiet). The actual cert-pool augmentation
+	// happens deeper inside configuredClient; this helper just checks
+	// the same env-var + readable-PEM precondition so the warning
+	// fires only on real widening, not on env-var-set-but-file-broken.
+	if w, ok := nonDefaultTLSTrustWarning(); ok {
+		warnings = append(warnings, w)
+	}
 
 	if len(explicitPubkey) > 0 && len(explicitPubkey) != 32 {
 		return ResolvedRoot{}, fmt.Errorf("%w: got %d bytes", receipt.ErrPubkeyLength, len(explicitPubkey))
@@ -404,6 +423,44 @@ func extraTLSRootsFromEnv() *x509.CertPool {
 	return pool
 }
 
+// nonDefaultTLSTrustWarning returns the SPEC-015 v0.3.4
+// `non_default_tls_trust` warning IFF the same env-var honoring
+// extraTLSRootsFromEnv performs returns a non-nil augmented pool,
+// AND ok=true. Mirroring the same successful-augmentation predicate
+// (file readable + PEM parseable) keeps the warning precise — it
+// fires only when the operator's `MACPROVIDER_VERIFY_TLS_CA_FILE`
+// actually widened the trust pool, not when the env var was set
+// but the file was unreadable / unparseable (no actual widening,
+// no need to warn). Issue #128. The env var is re-read here because
+// the warning is built at the Resolve()-layer (where the warnings[]
+// slice is owned) but the augmentation happens deeper inside
+// configuredClient — duplicating the env-var + file read is a
+// micro-cost only paid when the env var is actually set, which is
+// rare and operator-deliberate.
+func nonDefaultTLSTrustWarning() (Warning, bool) {
+	path := os.Getenv("MACPROVIDER_VERIFY_TLS_CA_FILE")
+	if path == "" {
+		return Warning{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Warning{}, false
+	}
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM(data) {
+		return Warning{}, false
+	}
+	return Warning{
+		Kind: "non_default_tls_trust",
+		Fields: map[string]any{
+			"ca_file_path": path,
+		},
+	}, true
+}
+
 func transportWithRootCAs(base http.RoundTripper, roots *x509.CertPool) http.RoundTripper {
 	var transport *http.Transport
 	if base == nil {
@@ -441,7 +498,11 @@ func normalizeCoordinator(raw string) (coordinatorTarget, error) {
 	}
 	host := parsed.Hostname()
 	if isPrivateOrLoopback(host) && os.Getenv(allowPrivateCoordinatorEnv) != "1" {
-		return coordinatorTarget{}, fmt.Errorf("--coordinator host %q is loopback/private; set %s=1 to allow", host, allowPrivateCoordinatorEnv)
+		// Wrap ErrPrivateCoordinatorDenied so cli.exitForError can map
+		// to exit 64 (EX_USAGE) per SPEC-015 §10.4.3. The error message
+		// itself preserves the human-friendly hostname + escape-hatch
+		// env var name. Issue #126.
+		return coordinatorTarget{}, fmt.Errorf("%w: host %q; set %s=1 to allow", ErrPrivateCoordinatorDenied, host, allowPrivateCoordinatorEnv)
 	}
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
 	if parsed.Path != "" {

--- a/phase7-verify/internal/resolver/resolver_test.go
+++ b/phase7-verify/internal/resolver/resolver_test.go
@@ -1,9 +1,16 @@
 package resolver
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -629,4 +636,167 @@ func assertNoWarning(t *testing.T, root ResolvedRoot, kind string) {
 			t.Fatalf("unexpected warning %s in %#v", kind, root.Warnings)
 		}
 	}
+}
+
+// Issue #128 coverage — silent TLS trust widening MUST surface as a
+// warnings[] entry of kind non_default_tls_trust with the CA file
+// path. Pre-fix: env var was honored silently, valid result emitted
+// with no visible indicator that the verifier was trusting a
+// non-default CA chain.
+
+func TestResolveEmitsNonDefaultTLSTrustWarningWhenEnvVarHonored(t *testing.T) {
+	// Write a small PEM file that AppendCertsFromPEM will accept.
+	// Use a known-valid self-signed cert PEM for the predicate; the
+	// content doesn't need to chain anywhere because the warning fires
+	// purely on successful pool augmentation, before any TLS handshake.
+	caPath := writeFakeCAPEM(t)
+	t.Setenv("MACPROVIDER_VERIFY_TLS_CA_FILE", caPath)
+
+	var calls int32
+	server := receiptKeyServer(t, testKey(1), http.StatusOK, &calls)
+	defer server.Close()
+
+	root, err := Resolve(providerID, testKey(1), ResolveOpts{
+		Offline:         true, // offline keeps the test hermetic; the warning fires from Resolve's top, NOT from network state.
+		CoordinatorHost: server.URL,
+		HTTPClient:      server.Client(),
+		Now:             func() time.Time { return fixedNow },
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	assertWarning(t, root, "non_default_tls_trust", "ca_file_path", caPath)
+}
+
+func TestResolveDoesNotEmitNonDefaultTLSTrustWarningWhenEnvVarUnset(t *testing.T) {
+	// The TestMain sets MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR
+	// but never MACPROVIDER_VERIFY_TLS_CA_FILE. Defensively clear it
+	// in case a stray runtime ever sets it.
+	t.Setenv("MACPROVIDER_VERIFY_TLS_CA_FILE", "")
+
+	var calls int32
+	server := receiptKeyServer(t, testKey(1), http.StatusOK, &calls)
+	defer server.Close()
+
+	root, err := Resolve(providerID, testKey(1), ResolveOpts{
+		Offline:         true,
+		CoordinatorHost: server.URL,
+		HTTPClient:      server.Client(),
+		Now:             func() time.Time { return fixedNow },
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	assertNoWarning(t, root, "non_default_tls_trust")
+}
+
+func TestResolveDoesNotEmitNonDefaultTLSTrustWarningWhenCAFileUnreadable(t *testing.T) {
+	// Env var set but path doesn't exist → augmentation cannot
+	// happen, so the warning MUST NOT fire (false-positive would
+	// alarm operators about a non-event).
+	t.Setenv("MACPROVIDER_VERIFY_TLS_CA_FILE", "/nonexistent-ca-file-xyzzy")
+
+	var calls int32
+	server := receiptKeyServer(t, testKey(1), http.StatusOK, &calls)
+	defer server.Close()
+
+	root, err := Resolve(providerID, testKey(1), ResolveOpts{
+		Offline:         true,
+		CoordinatorHost: server.URL,
+		HTTPClient:      server.Client(),
+		Now:             func() time.Time { return fixedNow },
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	assertNoWarning(t, root, "non_default_tls_trust")
+}
+
+func TestResolveDoesNotEmitNonDefaultTLSTrustWarningWhenCAFileNotPEM(t *testing.T) {
+	// File exists and is readable but isn't a PEM cert →
+	// AppendCertsFromPEM returns false → augmentation didn't
+	// happen → no warning.
+	dir := t.TempDir()
+	junkPath := filepath.Join(dir, "not-a-cert.pem")
+	if err := os.WriteFile(junkPath, []byte("this is not a PEM cert\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MACPROVIDER_VERIFY_TLS_CA_FILE", junkPath)
+
+	var calls int32
+	server := receiptKeyServer(t, testKey(1), http.StatusOK, &calls)
+	defer server.Close()
+
+	root, err := Resolve(providerID, testKey(1), ResolveOpts{
+		Offline:         true,
+		CoordinatorHost: server.URL,
+		HTTPClient:      server.Client(),
+		Now:             func() time.Time { return fixedNow },
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	assertNoWarning(t, root, "non_default_tls_trust")
+}
+
+// Issue #126 coverage — private/loopback --coordinator without
+// MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR=1 returns an error
+// that wraps ErrPrivateCoordinatorDenied. cli.exitForError uses
+// errors.Is on this sentinel to map to exit 64 (EX_USAGE).
+
+func TestNormalizeCoordinatorRejectsPrivateHostsWithSentinel(t *testing.T) {
+	t.Setenv("MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR", "")
+	_, err := normalizeCoordinator("https://127.0.0.1:8080")
+	if err == nil {
+		t.Fatal("normalizeCoordinator(127.0.0.1) want error, got nil")
+	}
+	if !errors.Is(err, ErrPrivateCoordinatorDenied) {
+		t.Fatalf("err = %v; want errors.Is ErrPrivateCoordinatorDenied", err)
+	}
+	// Restore the default for the rest of the test run since
+	// TestMain set it to 1.
+	t.Setenv("MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR", "1")
+}
+
+func TestNormalizeCoordinatorAllowsPrivateHostsWithEscapeHatch(t *testing.T) {
+	// TestMain sets the env var to 1.
+	_, err := normalizeCoordinator("https://127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("normalizeCoordinator with escape hatch err=%v want nil", err)
+	}
+}
+
+// writeFakeCAPEM generates a real self-signed P-256 cert at runtime
+// and writes its PEM encoding to a temp file. The cert is never
+// actually used in a TLS handshake — we only need its DER to be
+// valid so AppendCertsFromPEM accepts it and the
+// nonDefaultTLSTrustWarning predicate fires. A hand-crafted PEM
+// fixture is rejected because x509.AppendCertsFromPEM requires the
+// inner DER to be well-formed even if the cert is never trust-
+// validated downstream.
+func writeFakeCAPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test.macprovider.local"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	path := filepath.Join(t.TempDir(), "test-ca.pem")
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/phase7-verify/schemas/output.schema.json
+++ b/phase7-verify/schemas/output.schema.json
@@ -118,6 +118,22 @@
                 "type": "object",
                 "required": [
                   "kind",
+                  "ca_file_path"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "non_default_tls_trust"
+                  },
+                  "ca_file_path": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": [
+                  "kind",
                   "unix_ts",
                   "system_time",
                   "delta_seconds"
@@ -382,6 +398,22 @@
                 "type": "object",
                 "required": [
                   "kind",
+                  "ca_file_path"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "non_default_tls_trust"
+                  },
+                  "ca_file_path": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": [
+                  "kind",
                   "unix_ts",
                   "system_time",
                   "delta_seconds"
@@ -611,6 +643,22 @@
                     "const": "non_default_coordinator"
                   },
                   "coordinator_host": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "ca_file_path"
+                ],
+                "properties": {
+                  "kind": {
+                    "const": "non_default_tls_trust"
+                  },
+                  "ca_file_path": {
                     "type": "string"
                   }
                 },

--- a/specs/126_128_PHASE7_VERIFY_ARCHITECT_audit.md
+++ b/specs/126_128_PHASE7_VERIFY_ARCHITECT_audit.md
@@ -1,0 +1,74 @@
+# Issue #126 + #128 phase7-verify hardening architect-lane audit
+
+Audited branch: `fix/phase7-verify-tls-warn-and-exit64`
+
+Scope: `git diff origin/main` for SPEC-015 v0.3.4, verifier output schema, resolver/CLI layering, and integration-test contract updates.
+
+CRITICAL (0):
+  None.
+
+HIGH (0):
+  None.
+
+MEDIUM (0):
+  None.
+
+LOW (0):
+  None.
+
+QUESTIONS (0):
+  None.
+
+ARCHITECT NOTES:
+  ARCH-1. SPEC-015 v0.3.4 is a legitimate additive patch on the locked v0.3.3 baseline, not a v0.4 wire-shape change.
+      Evidence: specs/SPEC-015-receipts.md:3
+      Evidence: specs/SPEC-015-receipts.md:6
+      Evidence: specs/SPEC-015-receipts.md:14
+      Evidence: specs/SPEC-015-receipts.md:17
+      Evidence: specs/SPEC-015-receipts.md:2245
+      Evidence: phase7-verify/schemas/output.schema.json:117
+      Evidence: phase7-verify/schemas/output.schema.json:397
+      Evidence: phase7-verify/schemas/output.schema.json:651
+      Rationale: v0.3.4 adds only the `non_default_tls_trust` warning variant with `ca_file_path`; the receipt tuple remains the locked v0.3 9-field tuple. Strict validators pinned to the v0.3.3 schema would reject the new warning kind, but the schema is repo-internal and ships with the verifier binary. This matches the repo's additive-patch convention for SPEC-002 v1.4.1's optional `auth_state` field.
+
+  ARCH-2. The current `nonDefaultTLSTrustWarning` boundary is acceptable; choose shape C.
+      Evidence: phase7-verify/internal/resolver/resolver.go:123
+      Evidence: phase7-verify/internal/resolver/resolver.go:401
+      Evidence: phase7-verify/internal/resolver/resolver.go:407
+      Evidence: phase7-verify/internal/resolver/resolver.go:430
+      Evidence: phase7-verify/internal/resolver/resolver.go:440
+      Rationale: `Resolve()` owns `warnings[]`; `configuredClient()` owns HTTP transport construction. Duplicating the env-var/readable-PEM/successful-AppendCerts predicate is a small, deliberate cost on a rare operator-controlled path and avoids pushing warning construction into transport setup or client construction into `Resolve()`.
+
+  ARCH-3. `ErrPrivateCoordinatorDenied` is placed at the right altitude.
+      Evidence: phase7-verify/internal/resolver/resolver.go:69
+      Evidence: phase7-verify/internal/resolver/resolver.go:82
+      Evidence: phase7-verify/internal/resolver/resolver.go:500
+      Evidence: phase7-verify/internal/cli/cli.go:24
+      Evidence: phase7-verify/internal/cli/cli.go:500
+      Rationale: private-coordinator denial is resolver policy surfaced through the resolver package's public error contract, alongside existing resolver sentinels. Keeping the sentinel in `cli/` would invert the dependency direction.
+
+  ARCH-4. The integration warning expansion is a feature, not a smell.
+      Evidence: phase7-verify/integration_test.go:127
+      Evidence: phase7-verify/integration_test.go:133
+      Evidence: phase7-verify/integration_test.go:188
+      Evidence: phase7-verify/integration_test.go:200
+      Evidence: phase7-verify/integration_test.go:360
+      Rationale: the harness intentionally sets `MACPROVIDER_VERIFY_TLS_CA_FILE` to trust the mock coordinator CA. The expanded expectations prove the verifier now surfaces that non-default trust posture in every scenario that depends on the widened TLS root.
+
+  ARCH-5. The doc trail is correctly scoped.
+      Evidence: specs/SPEC-015-receipts.md:6
+      Evidence: specs/SPEC-015-receipts.md:2245
+      Evidence: specs/SPEC-015-receipts.md:2282
+      Evidence: specs/SPEC-015-receipts.md:2289
+      Evidence: specs/SPEC-015-receipts.md:2297
+      Rationale: v0.3.4 should reference issue #128 because the TLS warning is the only SPEC change. Issue #126 is an implementation conformance fix: §10.4.3 already classifies invocation problems as exit 64, so adding private-coordinator denial text normatively is optional clarification, not required for this additive patch.
+
+  ARCH-6. The lock criterion for v0.3.4 is appropriate.
+      Evidence: specs/SPEC-015-v0-3-audit.md:285
+      Evidence: specs/SPEC-015-v0-3-audit.md:299
+      Evidence: specs/SPEC-015-v0-3-audit.md:325
+      Evidence: specs/SPEC-015-receipts.md:21
+      Evidence: specs/SPEC-015-receipts.md:37
+      Rationale: v0.3.3 was the locked baseline after the three-lane audit. Because v0.3.4 is additive on that baseline, convergence from the code, security, and architect lanes at 0 CRITICAL / 0 HIGH / 0 MEDIUM is sufficient lock-equivalent evidence; a full major-version re-lock round is not architecturally required.
+
+VERDICT: architect lane READY TO MERGE — SPEC-015 v0.3.4 additive bump approved

--- a/specs/126_128_PHASE7_VERIFY_CODE_audit.md
+++ b/specs/126_128_PHASE7_VERIFY_CODE_audit.md
@@ -1,0 +1,14 @@
+CRITICAL (0):
+
+HIGH (0):
+
+MEDIUM (0):
+
+LOW (1):
+  L1. Duplicated TLS trust augmentation predicate can drift from installer behavior
+      Evidence: phase7-verify/internal/resolver/resolver.go:407 and phase7-verify/internal/resolver/resolver.go:440
+      Fix:     Prefer a single-source helper/return shape where the TLS-root installer returns the augmented pool plus a non-empty ca_file_path iff augmentation succeeded; keep the current duplicated minimal-change shape only with tests guarding future predicate changes.
+
+QUESTIONS (0):
+
+VERDICT: code lane READY TO MERGE

--- a/specs/126_128_PHASE7_VERIFY_SECURITY_audit.md
+++ b/specs/126_128_PHASE7_VERIFY_SECURITY_audit.md
@@ -1,0 +1,14 @@
+CRITICAL (0):
+
+HIGH (0):
+
+MEDIUM (0):
+
+LOW (1):
+  L1. Stderr renders the new TLS warning only by kind, without the `ca_file_path` context.
+      Evidence: `nonDefaultTLSTrustWarning` emits `kind=non_default_tls_trust` with `ca_file_path` when the env var is readable and `AppendCertsFromPEM` succeeds (`phase7-verify/internal/resolver/resolver.go:440`, `phase7-verify/internal/resolver/resolver.go:453`, `phase7-verify/internal/resolver/resolver.go:457`); JSON flattens warning fields with `json.Marshal`, so `ca_file_path` is present and control characters are escaped there (`phase7-verify/internal/cli/output.go:116`, `phase7-verify/internal/cli/output.go:132`); stderr has no specific case for `non_default_tls_trust` and falls through to `warning: <kind>` (`phase7-verify/internal/cli/output.go:186`, `phase7-verify/internal/cli/output.go:204`).
+      Fix:     Add a dedicated `non_default_tls_trust` stderr renderer that prints a sanitized/quoted `ca_file_path` value, with a test covering control characters.
+
+QUESTIONS (0):
+
+VERDICT: security lane READY TO MERGE — #128 silent-trust gap closed

--- a/specs/AUDIT_126_128_PHASE7_VERIFY_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_126_128_PHASE7_VERIFY_ARCHITECT_PROMPT.md
@@ -1,0 +1,137 @@
+# Issue #126 + #128 phase7-verify hardening — ARCHITECT-lane audit
+
+You are the **architect** lane of a three-lane audit (code / security /
+architect) of the bundled #126 + #128 phase7-verify hardening. Stay
+narrowly in your lane.
+
+**This lane has authority to approve the SPEC-015 v0.3.4 bump on the
+locked v0.3.3 baseline.** The lock memo says v0.3.3 was "READY TO LOCK"
+on 2026-06-24 — your verdict on whether v0.3.4 is a legitimate
+additive patch (vs. a wire-shape change requiring a v0.4 major bump)
+is the gating decision.
+
+## Branch / commit
+- Branch: `fix/phase7-verify-tls-warn-and-exit64`
+- Worktree: `../macprovider-126-128-phase7-verify-hardening`
+- Files in scope (`git diff origin/main`).
+
+## What this change does (operator summary — NOT the audit answer)
+
+Bundled fix for two v1.0.1-followup issues:
+- **#128** (MEDIUM security): silent TLS trust widening when
+  `MACPROVIDER_VERIFY_TLS_CA_FILE` is honored.
+- **#126** (LOW cosmetic): private-coordinator rejection exits 70
+  instead of 64.
+
+Both are post-PR-#124 follow-ups (merge commit 99d0c1e). The bundle
+ships SPEC-015 v0.3.4 (additive patch on v0.3.3 LOCKED) + IMPL +
+schema + tests + integration-test updates.
+
+## Architect-lane scope (apply each; stay in lane)
+
+### ARCH-1. Is v0.3.4 a legitimate additive patch on the locked v0.3.3?
+- SPEC-015 v0.3.3 was locked on 2026-06-24 via 3-lane codex audit
+  (`specs/SPEC-015-v0-3-audit.md`). The lock memo characterizes
+  v0.3 as "changes the wire shape (7-field tuple → 9-field tuple,
+  adding `model_hash` and `receipt_version`)" — a MAJOR bump.
+- v0.3.4 changes:
+  - §10.4.2 `warnings[]` enum gains `non_default_tls_trust`.
+  - Field `ca_file_path` (string) on the new variant.
+  - Schema enum at `phase7-verify/schemas/output.schema.json` adds
+    a new branch in each of the 3 result contexts.
+- Wire shape: receipt tuple unchanged. Verifier output JSON gains
+  a new enum value; pre-v0.3.4 consumers that ignore unknown
+  `kind` values are unaffected.
+- Is this an ADDITIVE patch (v0.3.4) or a wire-shape change
+  requiring v0.4? Recall the project's convention: SPEC-002 v1.4.1
+  shipped an additive `auth_state` field as patch; SPEC-015 v0.3.4
+  shipping a new enum value should follow the same convention.
+- Verify: any consumer downstream that VALIDATES strictly against
+  the v0.3.3 schema would reject the new kind. The schema lives
+  IN this repo and ships WITH the verifier binary, so it's
+  versioned together. Cross-repo consumers? (Likely none — the
+  schema is internal.)
+
+### ARCH-2. The `nonDefaultTLSTrustWarning` helper — module boundary?
+- The helper duplicates `extraTLSRootsFromEnv`'s augmentation
+  predicate (file read + PEM parse + AppendCertsFromPEM). Two
+  identical predicates is a single-source-of-truth violation. Is
+  the architectural correct shape:
+  - **A** — `extraTLSRootsFromEnv` returns `(pool, caPath string)`;
+    `configuredClient` consumes the pool, ignores caPath; Resolve()
+    consults caPath via a different code path (still duplicated,
+    just refactored).
+  - **B** — Resolve() reads the env var itself, builds the warning,
+    AND constructs the augmented http.Client itself. configured-
+    Client becomes a helper consuming a pre-built pool.
+  - **C** — Keep current shape (two predicates, comment explains
+    why). Acceptable for a low-frequency hot path; the cost of
+    duplicated env-var read is negligible.
+- Recommend the right shape. The author chose (C) explicitly in
+  the comment.
+
+### ARCH-3. Sentinel error placement
+- `ErrPrivateCoordinatorDenied` is exported from `resolver/` and
+  consumed by `cli/`. The other sentinels in the resolver package
+  (`ErrFetchFailed`, `ErrRedirectOffHost`, etc.) are also exported
+  and form the resolver's public error contract. Is the new
+  sentinel at the right altitude?
+- Alternative: put the sentinel in `cli/` (since it's only the CLI
+  that maps the error to an exit code). That would be a layering
+  inversion — the resolver shouldn't import CLI's error type. The
+  current placement (resolver owns the sentinel) is right.
+
+### ARCH-4. Integration test surface change
+- Every integration scenario's expected `warnings[]` grew by one
+  entry. The test fixture sets `MACPROVIDER_VERIFY_TLS_CA_FILE` to
+  the mock CA path (line ~357) — necessary for the integration's
+  TLS handshake to work. Is this an architectural smell (every
+  test now warns about its own setup) or a feature (the verifier
+  honestly surfaces the test harness's non-default trust posture)?
+- Note: this WAS the bug. Pre-fix, the integration tests would
+  have ALSO produced false `valid` results without surfacing the
+  trust widening. The new warnings prove the fix works in the
+  integration harness, not just unit tests.
+
+### ARCH-5. Doc-trail
+- SPEC-015 v0.3.4 change-log entry references issue #128. Should
+  it also reference issue #126 (the exit-code fix in the same PR)?
+  Looking at v0.3.4 carefully: the exit-code fix is NOT a SPEC
+  change (SPEC-015 §10.4.3 already says private-coordinator should
+  be 64; the implementation was wrong, not the spec). So the
+  change-log entry correctly references only #128. Confirm.
+- Should the v0.3.4 bump warrant adding the cli.go ErrPrivate-
+  CoordinatorDenied mapping to SPEC-015 §10.4.3 normatively (e.g.
+  "exit 64 (EX_USAGE) — includes private-coordinator rejection")?
+  Or is the spec already implicitly clear and the implementation
+  fix doesn't need spec text?
+
+### ARCH-6. Lock criteria for SPEC-015 v0.3.4
+- Recall v0.3.3 locked via 3-lane codex audit returning
+  `READY TO LOCK` 0/0/0/0 across all three lenses.
+- v0.3.4 is additive on the locked baseline. The 3-lane audit
+  approach here is: code + security + architect EACH verdict
+  READY TO MERGE on the v0.3.4 PR. If all three converge to 0
+  CRITICAL / 0 HIGH / 0 MEDIUM, v0.3.4 is locked-equivalent.
+- Confirm this is the right lock criterion for an additive patch
+  (vs. a full re-lock round).
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/126_128_PHASE7_VERIFY_ARCHITECT_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM AND v0.3.4 is a legitimate additive patch
+on v0.3.3, end with:
+`VERDICT: architect lane READY TO MERGE — SPEC-015 v0.3.4 additive bump approved`

--- a/specs/AUDIT_126_128_PHASE7_VERIFY_CODE_PROMPT.md
+++ b/specs/AUDIT_126_128_PHASE7_VERIFY_CODE_PROMPT.md
@@ -1,0 +1,122 @@
+# Issue #126 + #128 phase7-verify hardening — CODE-lane audit
+
+You are the **code** lane of a three-lane audit (code / security /
+architect) of the bundled #126 + #128 phase7-verify hardening on
+top of the SPEC-015 v0.3.3 LOCKED baseline. Stay narrowly in your
+lane.
+
+## Branch / commit
+- Branch: `fix/phase7-verify-tls-warn-and-exit64`
+- Worktree: `../macprovider-126-128-phase7-verify-hardening` (origin/main base: 9ff708d)
+- Files in scope (`git diff origin/main`):
+  - `phase7-verify/internal/resolver/resolver.go` — new `ErrPrivateCoordinatorDenied` sentinel + `nonDefaultTLSTrustWarning` helper; `normalizeCoordinator` wraps the sentinel.
+  - `phase7-verify/internal/cli/cli.go` — `exitForError` recognizes `resolver.ErrPrivateCoordinatorDenied` → `exitUsage` (64).
+  - `phase7-verify/internal/resolver/resolver_test.go` — 4 new TLS-trust-warning tests + 2 new normalizeCoordinator tests + `writeFakeCAPEM` helper (real generated cert).
+  - `phase7-verify/internal/cli/cli_test.go` — new `TestCLIPrivateCoordinatorExitsUsage` (locally clears the escape-hatch env var).
+  - `phase7-verify/integration_test.go` — every scenario's expected `warnings[]` now includes `non_default_tls_trust` because the integration harness sets `MACPROVIDER_VERIFY_TLS_CA_FILE`.
+  - `phase7-verify/schemas/output.schema.json` — `non_default_tls_trust` enum branch added in all 3 result contexts.
+  - `specs/SPEC-015-receipts.md` — v0.3.4 additive bump; §10.4.2 `warnings[]` taxonomy gains `non_default_tls_trust`.
+
+## What this change does (operator summary — NOT the audit answer)
+
+Two v1.0.1-followup bugs bundled:
+- **#128 (MEDIUM security)**: `MACPROVIDER_VERIFY_TLS_CA_FILE` silently widens TLS trust when honored. No warning, no log, no `--explain` notice. Combined with a public-DNS attacker-controlled coordinator host (private-coordinator deny from PR #124 only blocks the localhost / RFC1918 variant), the verifier silently trusts the attacker's pubkey response.
+- **#126 (LOW cosmetic)**: `--coordinator` private/loopback rejection exits 70 (software) instead of 64 (usage) per SPEC-015 §10.4.3.
+
+The fix introduces `nonDefaultTLSTrustWarning()` mirroring
+`extraTLSRootsFromEnv()`'s successful-augmentation predicate (file
+readable + `AppendCertsFromPEM` returns true). Resolve() prepends
+this warning when the predicate fires. The exit-code fix adds an
+exported `ErrPrivateCoordinatorDenied` sentinel; `normalizeCoordinator`
+wraps it with `fmt.Errorf("%w: …")`; cli.exitForError recognizes via
+`errors.Is`.
+
+## Code-lane scope (apply each; stay in lane)
+
+### CODE-1. Warning-emission correctness
+- `nonDefaultTLSTrustWarning()` re-reads the env var AND re-reads
+  the file AND re-calls `x509.SystemCertPool` AND re-calls
+  `AppendCertsFromPEM`. This is intentional duplication of
+  `extraTLSRootsFromEnv` (the comment names it). Is the duplication
+  load-bearing or fragile?
+  - Risk: if `extraTLSRootsFromEnv` ever changes its predicate
+    (e.g. adds a new way to augment the pool) the warning will go
+    stale.
+  - Alternative: have `extraTLSRootsFromEnv` return `(pool, caPath)`
+    where caPath is non-empty IFF augmentation succeeded; both the
+    pool installer and the warning emitter consult the same return.
+  - Recommend one or the other. (The current duplication is the
+    minimal-change shape; the unified return is the
+    single-source-of-truth shape.)
+- The warning is added to `warnings` in Resolve() at the top, BEFORE
+  the explicit-pubkey / cache / live branches diverge. So every
+  branch carries it forward. Confirm no branch resets or replaces
+  the slice.
+
+### CODE-2. Error sentinel + exit mapping
+- `ErrPrivateCoordinatorDenied` is exported from `resolver/`. The
+  CLI imports `resolver` only for this sentinel. Confirm the import
+  is alphabetical and consistent with the other resolver imports
+  in the codebase.
+- `exitForError` uses `errors.Is(err, resolver.ErrPrivateCoordinator-
+  Denied)`. The wrap site in `normalizeCoordinator` is
+  `fmt.Errorf("%w: …", ErrPrivateCoordinatorDenied, …)` so `errors.Is`
+  matches. Confirm the wrap depth doesn't get lost as the error
+  propagates through `Resolve → verify.Verify → run → exitForError`
+  call chain. (Each layer either returns the err verbatim or wraps
+  it with %w; trace through verify.Verify.)
+- The new case in `exitForError` is placed BEFORE the `formatErr`
+  case. Order matters only if the same error could match multiple
+  branches; here ErrPrivateCoordinatorDenied is structurally
+  distinct from `UsageError` / `InputFormatError`. Confirm.
+
+### CODE-3. Test fidelity
+- The new resolver tests use `t.Setenv("MACPROVIDER_VERIFY_TLS_CA_FILE", …)`.
+  TestMain sets `MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR=1`
+  globally — does the t.Setenv unset behavior interact safely
+  (t.Setenv restores at teardown). Confirm.
+- `writeFakeCAPEM` generates a real P-256 self-signed cert at
+  runtime. The cert is never trust-validated — only its DER must be
+  well-formed so `AppendCertsFromPEM` accepts it. Worth a comment
+  pinning this expectation.
+- `TestCLIPrivateCoordinatorExitsUsage` calls `t.Setenv` to clear
+  the escape-hatch BEFORE running. Confirm t.Setenv restores it at
+  teardown so adjacent tests aren't affected.
+- Integration test changes: every scenario's `warnings[]` grew by
+  one entry. Is there any scenario the env var ISN'T set for that
+  should NOT have grown? Trace: `MACPROVIDER_VERIFY_TLS_CA_FILE=` is
+  set at line ~357 in the env-prepend block, which runs for every
+  case. So all 10 cases correctly grow. Confirm.
+
+### CODE-4. Schema enum sites
+- `output.schema.json` has 3 contexts (valid / invalid / inconclusive
+  result schemas). Each context's `warnings[]` allOf branch needs
+  the new enum value. `grep` confirms 3 additions. Confirm no other
+  schema site needs updating.
+
+### CODE-5. SPEC v0.3.4 wording
+- SPEC-015 v0.3.4 is an ADDITIVE patch bump on the LOCKED v0.3.3.
+  The change-log entry says "preserves wire shape" — confirm by
+  reading the new §10.4.2 table row: only adds a new enum value and
+  its associated fields; no existing row touched.
+- The new row uses `ca_file_path` (snake_case) consistent with
+  other `warnings[]` field names. Confirm.
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/126_128_PHASE7_VERIFY_CODE_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM, end with:
+`VERDICT: code lane READY TO MERGE`

--- a/specs/AUDIT_126_128_PHASE7_VERIFY_SECURITY_PROMPT.md
+++ b/specs/AUDIT_126_128_PHASE7_VERIFY_SECURITY_PROMPT.md
@@ -1,0 +1,135 @@
+# Issue #126 + #128 phase7-verify hardening — SECURITY-lane audit
+
+You are the **security** lane of a three-lane audit (code / security /
+architect) of the bundled #126 + #128 phase7-verify hardening. Stay
+narrowly in your lane.
+
+**This lane is the primary stakeholder for #128 (the MEDIUM security
+finding the PR closes).** Your verdict on whether the new warning
+adequately closes the silent-TLS-trust-widening surface IS the
+load-bearing security check.
+
+## Branch / commit
+- Branch: `fix/phase7-verify-tls-warn-and-exit64`
+- Worktree: `../macprovider-126-128-phase7-verify-hardening`
+- Files in scope (`git diff origin/main`).
+
+## Why security cares about this diff
+
+#128 was reported as a MEDIUM by Claude security-reviewer on PR
+#124 (commit 99d0c1e):
+- `MACPROVIDER_VERIFY_TLS_CA_FILE` silently widens TLS trust when
+  honored.
+- Attack scenario: buyer running under wrapper script (CI helper,
+  devcontainer setup, ~/.profile modification by malware) where
+  env var is set to attacker-controlled CA chain.
+- Combined with a public-DNS attacker-controlled coordinator host,
+  verifier silently trusts attacker's pubkey response → false
+  `valid` verdict.
+- PR #124's private-coordinator deny (issue #126's other half)
+  blocks the localhost / RFC1918 variant but NOT public-DNS
+  attacker-controlled hosts.
+
+The fix surfaces the trust widening as a `non_default_tls_trust`
+warning that the buyer sees on stderr (unless `--quiet`) and ALWAYS
+in the JSON `warnings[]` output (per the existing v0.2.4 §10.4.2
+quiet-doesn't-suppress-JSON contract).
+
+## Security-lane scope (apply each; stay in lane)
+
+### SEC-1. Does the warning adequately close the silent-trust gap?
+- The warning fires IFF `MACPROVIDER_VERIFY_TLS_CA_FILE` is set AND
+  the file is readable AND `AppendCertsFromPEM` succeeds. This is
+  the SAME predicate `extraTLSRootsFromEnv` uses to actually
+  augment the pool, so the warning is precise:
+  - false-positive (warning without augmentation) impossible —
+    augmentation predicate identical.
+  - false-negative (augmentation without warning) impossible —
+    same reason.
+- The warning fires at Resolve()-time (before the live fetch), not
+  fetchLive-time. Does that matter? Trace: the augmentation
+  happens at fetchLive's configuredClient. If Resolve() bails
+  before calling fetchLive (e.g. offline + cache hit), the warning
+  STILL fires — even though the TLS pool wasn't actually used.
+  - Pro: defensive ("env var is set, you've configured a non-
+    default trust posture, you should know").
+  - Con: warns even when no live request happens, which could be
+    seen as noise.
+  - The current shape is "warn-on-config", not "warn-on-use". Is
+    that the right boundary?
+- The buyer's stderr displays `warning: …`. Confirm the stderr-
+  formatting code path actually renders `non_default_tls_trust` —
+  trace through `renderWarningsToStderr` / similar.
+
+### SEC-2. Spoof / poisoning surfaces around the env var
+- The env var value lands directly in the warning's `ca_file_path`
+  field. If an attacker controls the env var, they also control
+  this string. Could the path contain ANSI escape codes, terminal
+  control chars, or anything that poisons the stderr display? The
+  `warning: non_default_tls_trust …` line includes the path
+  verbatim. Cross-reference [[c1-control-chars-terminal-sanitizer-bypass]]
+  memory rule — does the verifier's stderr path go through a
+  terminal sanitizer?
+  - If NOT, this is a new injection surface (low blast — only
+    visible to a buyer who already trusts the env var).
+- The path is also embedded in the JSON `warnings[]` output.
+  json.Marshal escapes control chars in strings, so JSON consumers
+  are safe. Stderr line MIGHT not.
+
+### SEC-3. The exit-code change (#126) and its security implications
+- The exit-code change is purely cosmetic — same error message,
+  same failure mode, just exit 64 vs 70. No new attack surface;
+  no behavior change for an attacker.
+- But: the error message string now wraps the sentinel via
+  `fmt.Errorf("%w: host %q; …")`. Confirm `%q` for the host name
+  safely escapes any control chars or quotes. (Go's %q is
+  injection-safe.)
+
+### SEC-4. SPEC v0.3.4 lock criteria
+- The v0.3.4 bump is additive on the LOCKED v0.3.3. The 2026-06-24
+  v0.3 lock memo says "v0.3 changes the wire shape (7-field tuple
+  → 9-field tuple)" — v0.3.4 does NOT touch the wire tuple shape,
+  only the `warnings[]` enum. Confirm.
+- The warning's `ca_file_path` is a STRING field. Schema enforces
+  type. Confirm.
+
+### SEC-5. Integration test coverage
+- The integration test now expects `non_default_tls_trust` in every
+  scenario's warnings (because every scenario runs with the env
+  var set to the mock CA path). Does ANY scenario disprove the
+  warning ever surfaces a real issue (e.g. a scenario where the env
+  var is set but augmentation fails)?
+- Coverage gap: there's no integration scenario where the env var
+  is set to a malformed CA file (e.g. junk PEM). The unit test
+  covers it (`TestResolveDoesNotEmitNonDefaultTLSTrustWarningWhen-
+  CAFileNotPEM`). Worth promoting to integration, or unit is
+  sufficient?
+
+### SEC-6. Adjacent surface — does the warning interact with the
+###       private-coordinator deny (#126's other half)?
+- A buyer who sets `MACPROVIDER_VERIFY_TLS_CA_FILE` AND points
+  `--coordinator` at a private host AND sets
+  `MACPROVIDER_VERIFY_ALLOW_PRIVATE_COORDINATOR=1` is opting into
+  TWO non-default trust postures. Does the verifier emit BOTH the
+  `non_default_tls_trust` warning AND a `non_default_coordinator`
+  warning? The integration tests show both fire together. Confirm.
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/126_128_PHASE7_VERIFY_SECURITY_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM AND the warning adequately closes the #128
+silent-trust-widening gap, end with:
+`VERDICT: security lane READY TO MERGE — #128 silent-trust gap closed`

--- a/specs/SPEC-015-receipts.md
+++ b/specs/SPEC-015-receipts.md
@@ -1,7 +1,18 @@
 # SPEC-015 — Verifiable inference receipts
 
-**Version:** 0.3.3 (2026-06-24, model-hash binding — LOCKED)
+**Version:** 0.3.4 (2026-06-26, additive — `non_default_tls_trust` warning kind added to §10.4.2 `warnings[]` enum; preserves wire shape, callers that ignore unknown kinds are unaffected; issue #128)
 **Depends on:** SPEC-001 v1.6, SPEC-002 v1.4 (v1.5 candidate `GET /v1/receipt-keys/<provider_id>` buyer-safe pubkey resolver; v1.6 candidate `/poolz` catalog fields + `/catalog/<catalog_id>` + `/catalog/pubkey` per §M.4), SPEC-005 v0.3, SPEC-006 v0.9, SPEC-008 v0.3 (hard — §5.3-5.6 model-hash semantics; §5.5 hash_status enum), SPEC-010 v1.5, SPEC-011 v0.5 (hard — §3.3.1 heartbeat `model_hash`; §3.2 warm-swap state machine; §3.3.0 opt-in gating), SPEC-013 v0.3
+
+**Change log v0.3.4 (2026-06-26, additive — issue #128):**
+- §10.4.2 `warnings[]` enum gains `non_default_tls_trust` kind with
+  `ca_file_path` (string) field. Verifiers MUST emit this warning
+  when the `MACPROVIDER_VERIFY_TLS_CA_FILE` env var is honored and
+  successfully augments the TLS trust pool — surfaces silent trust
+  widening that previously produced a `valid` result with no
+  visible indicator. Schema enum updated at
+  `phase7-verify/schemas/output.schema.json` (all three result
+  contexts). Preserves wire shape: pre-v0.3.4 consumers that ignore
+  unknown `kind` values are unaffected; this is strictly additive.
 
 **Lock state v0.3:** Round-3 codex audit returned `READY TO LOCK` across all three lenses (code, security, architect) on 2026-06-24 — see `specs/SPEC-015-v0-3-audit.md`. Three-round audit history captured 3 CRITICAL + 11 MAJOR + 4 MINOR + 1 QUESTION findings; all CRITICAL / MAJOR resolved across v0.3.1 (round-1 fix pass) and v0.3.2 (round-2 fix pass). One round-3 MINOR (stale "four new flags" wording in staged IMPL prompt) fixed in v0.3.3. v0.3 changes the wire shape (7-field tuple → 9-field tuple, adding `model_hash` and `receipt_version`) and per [[feedback-bundle-spec-impl-one-pr]] EXCEPTION rule ships SPEC-only (no bundled IMPL) because it is a major version bump with a downstream implementer; the BUILD prompt for IMPL is staged at `specs/BUILD_SPEC_015_v0_3_MODELHASH_IMPL_PROMPT.md` for the next session.
 
@@ -2231,6 +2242,7 @@ v0.2-known values for v0.2-mapped cases.
 | `explicit_vs_live_divergence` | `live_pubkey` (string), `coordinator_host` (string) | Explicit `--pubkey` was used AND a live `/v1/receipt-keys` fetch succeeded AND returned a different pubkey for the same `provider_id`. |
 | `live_check_skipped` | `reason` (one of `offline_flag`, `network_unreachable`, `provider_id_unresolvable`) | The live divergence check did not run. `offline_flag`: `--offline` was passed. `network_unreachable`: live fetch failed (network down, 5xx, timeout, 429). `provider_id_unresolvable`: explicit `--pubkey` was supplied AND no `provider_id` was recoverable from CLI, bundle, or cache (the verifier had nothing to address the resolver with). |
 | `non_default_coordinator` | `coordinator_host` (string) | A non-default coordinator (i.e. not `coordinator.streamvc.live`) was used as the trust-root source. |
+| `non_default_tls_trust` | `ca_file_path` (string) | The `MACPROVIDER_VERIFY_TLS_CA_FILE` env var was honored and successfully augmented the TLS trust pool used to reach the coordinator. Surfaces silent trust widening so a buyer running under a wrapper script (CI helper, devcontainer setup, ~/.profile modification by malware) where the env var has been set to point at an attacker-controlled CA chain sees a visible indicator. Added in SPEC-015 v0.3.4 (issue #128). |
 | `clock_skew` | `unix_ts` (int), `system_time` (int), `delta_seconds` (int) | Receipt `unix_ts` differs from the verifier's system clock by more than 24 hours. Informational only — does NOT downgrade `result` per §10.6. |
 
 A verifier MUST emit `warnings[]` entries regardless of `--quiet`


### PR DESCRIPTION
## Summary

Bundled v1.0.1 follow-up — closes #128 (MEDIUM security) and #126 (LOW cosmetic).

- **#128**: `MACPROVIDER_VERIFY_TLS_CA_FILE` silently widened TLS trust when honored. Now Resolve() emits a `non_default_tls_trust` warning whenever the env var is set AND the file is readable AND `AppendCertsFromPEM` succeeds (same predicate `extraTLSRootsFromEnv` uses to actually augment the pool). Warning surfaces on stderr (unless `--quiet`) and ALWAYS in JSON `warnings[]` (per v0.2.4 §10.4.2 quiet-doesn't-suppress-JSON contract).
- **#126**: `--coordinator` loopback/private rejection now exits 64 (EX_USAGE), not 70 (software). New exported `ErrPrivateCoordinatorDenied` sentinel in `resolver/`; `normalizeCoordinator` wraps via `fmt.Errorf("%w: …")`; `cli.exitForError` recognizes via `errors.Is`.

SPEC-015 bumped **0.3.3 → 0.3.4** (additive patch on locked v0.3.3): new `warnings[]` enum kind `non_default_tls_trust` with `ca_file_path` field. Receipt wire shape (9-field tuple) unchanged.

Schema enum updated in 3 result contexts (valid / invalid / inconclusive).

## Tests

- 4 new resolver unit tests (warning fires/doesn't on unset / missing-file / malformed-PEM / successful-PEM)
- 2 new `normalizeCoordinator` tests (sentinel wrap matches `errors.Is`)
- `writeFakeCAPEM` helper generates a real P-256 self-signed cert at runtime (so `AppendCertsFromPEM` accepts it)
- `TestCLIPrivateCoordinatorExitsUsage` standalone CLI test (clears escape-hatch env locally; expects exit 64)
- Integration test scenarios' expected `warnings[]` expanded to include `non_default_tls_trust` (every scenario sets the env var for mock TLS handshake)

## Audit gate

Three-lane codex audit (code / security / architect):

| Lane | C | H | M | L | Verdict |
|---|---|---|---|---|---|
| code | 0 | 0 | 0 | 1 | READY TO MERGE |
| security | 0 | 0 | 0 | 1 | READY TO MERGE — #128 closed |
| architect | 0 | 0 | 0 | 0 | READY TO MERGE — v0.3.4 approved |

LOWs deferred (predicate dedup; stderr renderer for `ca_file_path` — JSON already carries it safely via `json.Marshal`).

Audit reports: `specs/126_128_PHASE7_VERIFY_{CODE,SECURITY,ARCHITECT}_audit.md`.

## Test plan

- [x] `go test ./...` in phase7-verify — green (7.7s)
- [x] `go test -tags integration ./...` — green
- [x] 3-lane codex audit — 0 C / 0 H / 0 M across all lanes

Closes #128
Closes #126
