### PR TITLE
test(phase7-verify): AST-walk reasonXxx constants for enum bijection (#127)

### DIFF
--- a/phase7-verify/internal/verify/enum_drift_test.go
+++ b/phase7-verify/internal/verify/enum_drift_test.go
@@ -2,44 +2,147 @@ package verify
 
 import (
 	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
+	"unicode"
 )
 
-func TestReasonEnumBijection(t *testing.T) {
-	expectedReasons := []string{
-		"signature_and_canonicalization_match",
-		"signature_verify_failed",
-		"prompt_hash_mismatch",
-		"output_hash_mismatch",
-		"pubkey_not_endorsed",
-		"previous_key_outside_grace_window",
-		"bundle_pubkey_provider_mismatch",
-		"pubkey_unresolvable",
-		"provider_id_not_in_pool",
-		"cache_stale_and_live_unreachable",
-		// SPEC-015 v0.3 §M.3.2.1 — new reason enum.
-		"model_hash_mismatch",
-		"model_hash_required",
-		"model_id_not_in_catalog",
-		"catalog_signature_invalid",
-		"catalog_unreachable",
-		"catalog_expired",
-		"catalog_format_invalid",
-		"unknown_receipt_version",
-		"extra_field",
-		"missing_field",
-	}
-	expected := make(map[string]bool, len(expectedReasons))
-	for _, reason := range expectedReasons {
-		expected[reason] = true
-	}
+// reservedMarkerRE matches FORWARD-COMPAT or RESERVED only at the start of
+// a comment line (optionally after a list-marker prefix like "* " or "- ").
+// This rejects leading prose negations such as "NOT RESERVED" or "DEFINITELY
+// NOT-RESERVED" while still accepting natural forms like
+// "FORWARD-COMPAT v0.3+:", "RESERVED (do not delete)", and "* RESERVED *".
+// go/ast.CommentGroup.Text strips comment markers, so each line we match
+// against begins with the comment's content.
+var reservedMarkerRE = regexp.MustCompile(`(?m)^\s*(?:[*-]\s+)?(FORWARD-COMPAT|RESERVED)(\W|$)`)
 
-	data, err := os.ReadFile(filepath.Join("..", "..", "schemas", "output.schema.json"))
+// TestReasonEnumBijection enforces a bijection between
+//   - reasonXxx string constants declared in this package's non-test source, and
+//   - reason values declared in schemas/output.schema.json.
+//
+// Source of truth: the reasonXxx Go constants, extracted via AST walk of the
+// verify package. The schema is checked against this set; SPEC §10.4.2 is
+// the spec-side authority and is kept in lock-step with the schema by the
+// schema's own commits.
+//
+// Closes the original #127 gap: a contributor who adds a reasonXxx constant
+// but never references it in non-test code now fails the test, UNLESS the
+// constant carries a "FORWARD-COMPAT" or "RESERVED" marker in its doc
+// comment (e.g. reasonBundlePubkeyProviderMismatch is intentionally reserved
+// for a future SPEC revision).
+func TestReasonEnumBijection(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse verify package: %v", err)
+	}
+	pkg, ok := pkgs["verify"]
+	if !ok {
+		t.Fatalf("verify package not found in current directory")
+	}
+	schemaBytes, err := os.ReadFile(filepath.Join("..", "..", "schemas", "output.schema.json"))
 	if err != nil {
 		t.Fatalf("read output schema: %v", err)
 	}
+	if err := checkReasonEnumBijection(pkg, schemaBytes); err != nil {
+		t.Fatalf("bijection check failed: %v", err)
+	}
+}
+
+// checkReasonEnumBijection is the testable core. It walks pkg's AST for
+// reasonXxx string constants, checks each non-reserved constant is referenced
+// in non-test source, and enforces a 1:1 mapping with the schema's reason
+// enum. Returns the first violation encountered, or nil on success.
+func checkReasonEnumBijection(pkg *ast.Package, schemaBytes []byte) error {
+	type reasonDecl struct {
+		value    string
+		reserved bool
+		declPos  token.Pos
+	}
+	declared := map[string]*reasonDecl{}
+	for _, file := range pkg.Files {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range vs.Names {
+					if !isReasonConstName(name.Name) {
+						continue
+					}
+					if i >= len(vs.Values) {
+						return fmt.Errorf("reason constant %s has no explicit value (iota/carry-forward not supported for reasonXxx constants)", name.Name)
+					}
+					lit, ok := vs.Values[i].(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						return fmt.Errorf("reason constant %s must be a string literal, got %T", name.Name, vs.Values[i])
+					}
+					val, err := strconv.Unquote(lit.Value)
+					if err != nil {
+						return fmt.Errorf("unquote %s value: %w", name.Name, err)
+					}
+					declared[name.Name] = &reasonDecl{
+						value:    val,
+						reserved: hasReservedMarker(vs.Doc),
+						declPos:  name.Pos(),
+					}
+				}
+			}
+		}
+	}
+	if len(declared) == 0 {
+		return fmt.Errorf("no reasonXxx constants found in verify package")
+	}
+
+	refCount := map[string]int{}
+	for _, file := range pkg.Files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			ident, ok := n.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			decl, exists := declared[ident.Name]
+			if !exists {
+				return true
+			}
+			if ident.Pos() == decl.declPos {
+				return true
+			}
+			refCount[ident.Name]++
+			return true
+		})
+	}
+
+	for name, decl := range declared {
+		if refCount[name] == 0 && !decl.reserved {
+			return fmt.Errorf("reason constant %s (=%q) declared but never referenced in non-test source; either reference it, mark its doc comment with FORWARD-COMPAT/RESERVED, or remove it", name, decl.value)
+		}
+	}
+
+	expected := make(map[string]string, len(declared))
+	for name, decl := range declared {
+		if prior, dup := expected[decl.value]; dup {
+			return fmt.Errorf("reason constants %s and %s both declare wire value %q; values must be unique", prior, name, decl.value)
+		}
+		expected[decl.value] = name
+	}
+
 	var schema struct {
 		OneOf []struct {
 			Properties map[string]struct {
@@ -48,69 +151,328 @@ func TestReasonEnumBijection(t *testing.T) {
 			} `json:"properties"`
 		} `json:"oneOf"`
 	}
-	if err := json.Unmarshal(data, &schema); err != nil {
-		t.Fatalf("decode output schema: %v", err)
+	if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+		return fmt.Errorf("decode output schema: %w", err)
 	}
 	if len(schema.OneOf) != 3 {
-		t.Fatalf("schema oneOf branch count = %d, want 3", len(schema.OneOf))
+		return fmt.Errorf("schema oneOf branch count = %d, want 3", len(schema.OneOf))
 	}
 
 	branchByReason := map[string][]int{}
 	for branchIndex, branch := range schema.OneOf {
-		reasonProperty, ok := branch.Properties["reason"]
+		prop, ok := branch.Properties["reason"]
 		if !ok {
-			t.Fatalf("schema branch %d missing reason property", branchIndex)
+			return fmt.Errorf("schema branch %d missing reason property", branchIndex)
 		}
-		reasons := reasonProperty.Enum
-		if reasonProperty.Const != "" {
-			reasons = append(reasons, reasonProperty.Const)
+		reasons := prop.Enum
+		if prop.Const != "" {
+			reasons = append(reasons, prop.Const)
 		}
 		if len(reasons) == 0 {
-			t.Fatalf("schema branch %d has no reason const/enum", branchIndex)
+			return fmt.Errorf("schema branch %d has no reason const/enum", branchIndex)
 		}
 		for _, reason := range reasons {
-			if !expected[reason] {
-				t.Fatalf("schema reason %q is not in expectedReasons", reason)
+			if _, ok := expected[reason]; !ok {
+				return fmt.Errorf("schema reason %q has no matching reasonXxx Go constant", reason)
 			}
 			branchByReason[reason] = append(branchByReason[reason], branchIndex)
 		}
 	}
 
-	for _, reason := range expectedReasons {
-		branches := branchByReason[reason]
+	for value, constName := range expected {
+		branches := branchByReason[value]
 		if len(branches) != 1 {
-			t.Fatalf("expected reason %q appears in schema branches %v, want exactly one branch", reason, branches)
+			return fmt.Errorf("Go constant %s (=%q) appears in schema branches %v, want exactly one branch", constName, value, branches)
 		}
+	}
+	return nil
+}
+
+func isReasonConstName(name string) bool {
+	const prefix = "reason"
+	if !strings.HasPrefix(name, prefix) || len(name) == len(prefix) {
+		return false
+	}
+	return unicode.IsUpper(rune(name[len(prefix)]))
+}
+
+func hasReservedMarker(doc *ast.CommentGroup) bool {
+	if doc == nil {
+		return false
+	}
+	return reservedMarkerRE.MatchString(doc.Text())
+}
+
+// TestReasonEnumBijection_DetectsDrift exercises checkReasonEnumBijection
+// against synthetic fixtures to verify each drift scenario it must catch.
+func TestReasonEnumBijection_DetectsDrift(t *testing.T) {
+	// schemaABC builds a three-branch schema with one reason value per branch.
+	schemaABC := func(a, b, c string) []byte {
+		return []byte(fmt.Sprintf(`{
+  "oneOf": [
+    {"properties": {"result": {"const": "valid"}, "reason": {"const": "%s"}}},
+    {"properties": {"result": {"const": "invalid"}, "reason": {"enum": ["%s"]}}},
+    {"properties": {"result": {"const": "inconclusive"}, "reason": {"enum": ["%s"]}}}
+  ]
+}`, a, b, c))
 	}
 
-	verifyReasonConstants := []string{
-		reasonValid,
-		reasonSignatureFailed,
-		reasonPromptHashMismatch,
-		reasonOutputHashMismatch,
-		reasonPubkeyNotEndorsed,
-		reasonPreviousKeyOutsideGraceWindow,
-		reasonBundlePubkeyProviderMismatch,
-		reasonPubkeyUnresolvable,
-		reasonProviderIDNotInPool,
-		reasonCacheStaleAndLiveUnreachable,
-		reasonModelHashMismatch,
-		reasonModelHashRequired,
-		reasonModelIDNotInCatalog,
-		reasonCatalogSignatureInvalid,
-		reasonCatalogUnreachable,
-		reasonCatalogExpired,
-		reasonCatalogFormatInvalid,
-		reasonUnknownReceiptVersion,
-		reasonExtraField,
-		reasonMissingField,
+	cases := []struct {
+		name        string
+		source      string
+		schema      []byte
+		wantErrFrag string
+	}{
+		{
+			// Four Go constants, schema covers only three; one Go constant is missing
+			// from any schema branch. Tests the "Go const has no schema branch" check.
+			name: "go constant missing from schema",
+			source: `package verify
+const (
+	reasonA = "av"
+	reasonB = "bv"
+	reasonC = "cv"
+	reasonD = "dv"
+)
+var _ = []string{reasonA, reasonB, reasonC, reasonD}
+`,
+			schema:      schemaABC("av", "bv", "cv"),
+			wantErrFrag: `Go constant reasonD`,
+		},
+		{
+			// Schema references a reason value with no matching Go constant.
+			name: "schema reason missing from Go constants",
+			source: `package verify
+const (
+	reasonA = "av"
+	reasonB = "bv"
+	reasonC = "cv"
+)
+var _ = []string{reasonA, reasonB, reasonC}
+`,
+			schema:      schemaABC("av", "bv", "ghost_value"),
+			wantErrFrag: `schema reason "ghost_value" has no matching`,
+		},
+		{
+			// Go constant declared but never referenced in non-test source AND not marked reserved.
+			name: "unused non-reserved constant fails",
+			source: `package verify
+const (
+	reasonA      = "av"
+	reasonB      = "bv"
+	reasonC      = "cv"
+	reasonUnused = "dangling"
+)
+var _ = []string{reasonA, reasonB, reasonC}
+`,
+			schema: func() []byte {
+				return []byte(`{
+  "oneOf": [
+    {"properties": {"result": {"const": "valid"}, "reason": {"const": "av"}}},
+    {"properties": {"result": {"const": "invalid"}, "reason": {"enum": ["bv", "dangling"]}}},
+    {"properties": {"result": {"const": "inconclusive"}, "reason": {"enum": ["cv"]}}}
+  ]
+}`)
+			}(),
+			wantErrFrag: `reasonUnused`,
+		},
+		{
+			// Same shape as previous case, but constant carries the FORWARD-COMPAT marker → must pass.
+			name: "unused reserved constant passes (no error)",
+			source: `package verify
+const (
+	reasonA = "av"
+	reasonB = "bv"
+	reasonC = "cv"
+	// FORWARD-COMPAT: reserved for a future spec revision.
+	reasonReserved = "dangling"
+)
+var _ = []string{reasonA, reasonB, reasonC}
+`,
+			schema: func() []byte {
+				return []byte(`{
+  "oneOf": [
+    {"properties": {"result": {"const": "valid"}, "reason": {"const": "av"}}},
+    {"properties": {"result": {"const": "invalid"}, "reason": {"enum": ["bv", "dangling"]}}},
+    {"properties": {"result": {"const": "inconclusive"}, "reason": {"enum": ["cv"]}}}
+  ]
+}`)
+			}(),
+			wantErrFrag: "",
+		},
+		{
+			// Two Go constants declare the same wire value → silent-collapse violation.
+			name: "two go constants with the same wire value",
+			source: `package verify
+const (
+	reasonA      = "av"
+	reasonB      = "bv"
+	reasonC      = "cv"
+	reasonAlias  = "av"
+)
+var _ = []string{reasonA, reasonB, reasonC, reasonAlias}
+`,
+			schema:      schemaABC("av", "bv", "cv"),
+			wantErrFrag: `both declare wire value`,
+		},
+		{
+			// reasonXxx constant declared without an explicit string-literal value.
+			name: "reason constant without explicit value",
+			source: `package verify
+const (
+	reasonA = "av"
+	reasonB = "bv"
+	reasonC = "cv"
+	reasonNoLit
+)
+var _ = []string{reasonA, reasonB, reasonC, reasonNoLit}
+`,
+			schema:      schemaABC("av", "bv", "cv"),
+			wantErrFrag: `reasonNoLit has no explicit value`,
+		},
+		{
+			// reasonXxx constant whose value is a non-string literal.
+			name: "reason constant with non-string-literal value",
+			source: `package verify
+const (
+	reasonA       = "av"
+	reasonB       = "bv"
+	reasonC       = "cv"
+	reasonNonStr  = 42
+)
+var _ = []string{reasonA, reasonB, reasonC, reasonNonStr}
+`,
+			schema:      schemaABC("av", "bv", "cv"),
+			wantErrFrag: `must be a string literal`,
+		},
+		{
+			// Reserved-marker check requires the marker at line start —
+			// "NOT RESERVED" / "DEFINITELY NOT-RESERVED" / "NOT FORWARD-COMPATIBLE"
+			// must not silence the unused-constant check.
+			name: "negated reserved-marker prose still flags unused constant",
+			source: `package verify
+const (
+	reasonA = "av"
+	reasonB = "bv"
+	reasonC = "cv"
+	// This constant is DEFINITELY NOT-RESERVED and not FORWARD-COMPATIBLE.
+	// NOT RESERVED in any spec revision.
+	reasonNegated = "dangling"
+)
+var _ = []string{reasonA, reasonB, reasonC}
+`,
+			schema: func() []byte {
+				return []byte(`{
+  "oneOf": [
+    {"properties": {"result": {"const": "valid"}, "reason": {"const": "av"}}},
+    {"properties": {"result": {"const": "invalid"}, "reason": {"enum": ["bv", "dangling"]}}},
+    {"properties": {"result": {"const": "inconclusive"}, "reason": {"enum": ["cv"]}}}
+  ]
+}`)
+			}(),
+			wantErrFrag: `reasonNegated`,
+		},
+		{
+			// Same constant value appears in two schema branches → bijection violation.
+			name: "go constant appears in multiple schema branches",
+			source: `package verify
+const (
+	reasonA = "av"
+	reasonB = "bv"
+	reasonC = "cv"
+)
+var _ = []string{reasonA, reasonB, reasonC}
+`,
+			schema: func() []byte {
+				return []byte(`{
+  "oneOf": [
+    {"properties": {"result": {"const": "valid"}, "reason": {"const": "av"}}},
+    {"properties": {"result": {"const": "invalid"}, "reason": {"enum": ["bv", "av"]}}},
+    {"properties": {"result": {"const": "inconclusive"}, "reason": {"enum": ["cv"]}}}
+  ]
+}`)
+			}(),
+			wantErrFrag: `want exactly one branch`,
+		},
 	}
-	for _, reason := range verifyReasonConstants {
-		if !expected[reason] {
-			t.Fatalf("verify reason constant %q is not in expectedReasons", reason)
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "fake.go", tc.source, parser.ParseComments)
+			if err != nil {
+				t.Fatalf("parse synthetic source: %v", err)
+			}
+			pkg := &ast.Package{Name: "verify", Files: map[string]*ast.File{"fake.go": file}}
+			err = checkReasonEnumBijection(pkg, tc.schema)
+			if tc.wantErrFrag == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErrFrag)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrFrag) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErrFrag, err.Error())
+			}
+		})
+	}
+}
+
+// TestReservedMarkerRE pins the marker-recognition contract: which doc-comment
+// forms count as a "reserved" annotation and which do not. Future contributors
+// adjusting reservedMarkerRE must keep these cases passing.
+func TestReservedMarkerRE(t *testing.T) {
+	mustReserve := []string{
+		// The live verify.go form.
+		"FORWARD-COMPAT v0.3+: reserved enum value.\nNext line.",
+		"RESERVED (do not delete)",
+		"* RESERVED *",
+		"- RESERVED for SPEC-016",
+		"FORWARD-COMPAT: pending v0.4",
+		"context line\nRESERVED for future revision",
+	}
+	mustNotReserve := []string{
+		"NOT RESERVED",
+		"DEFINITELY NOT-RESERVED and not FORWARD-COMPATIBLE.",
+		"NOT FORWARD-COMPAT yet",
+		"may someday be RESERVED",       // marker not at line start
+		"intentionally UNRESERVED",      // not the marker token
+		"this RESERVED-LIKE thing",      // marker not at line start
+		"",
+	}
+	for _, in := range mustReserve {
+		if !reservedMarkerRE.MatchString(in) {
+			t.Errorf("expected reserved match for %q", in)
 		}
 	}
-	if len(verifyReasonConstants) != len(expectedReasons) {
-		t.Fatalf("verify reason constant count = %d, want %d", len(verifyReasonConstants), len(expectedReasons))
+	for _, in := range mustNotReserve {
+		if reservedMarkerRE.MatchString(in) {
+			t.Errorf("expected NO reserved match for %q", in)
+		}
+	}
+}
+
+func TestIsReasonConstName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"reasonValid", true},
+		{"reasonModelHashMismatch", true},
+		{"reason", false},        // bare prefix
+		{"reasonable", false},    // not exported camelCase under prefix
+		{"warningFoo", false},    // wrong prefix
+		{"resultValid", false},   // wrong prefix
+		{"Reason", false},        // wrong case start
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isReasonConstName(tc.name); got != tc.want {
+			t.Errorf("isReasonConstName(%q) = %v, want %v", tc.name, got, tc.want)
+		}
 	}
 }

--- a/phase7-verify/internal/verify/implementation-notes.md
+++ b/phase7-verify/internal/verify/implementation-notes.md
@@ -46,6 +46,24 @@ future spec revision may define a narrower bundle-layer detection that
 distinguishes intra-bundle identity drift; the schema/enum is
 forward-compatible.
 
+### Reserved-reason convention
+
+`TestReasonEnumBijection` (`enum_drift_test.go`) AST-walks this package's
+`reasonXxx` string constants and fails if any are declared but never
+referenced in non-test source. To declare a constant that is intentionally
+reserved for a future SPEC revision (like `reasonBundlePubkeyProviderMismatch`
+above), open the constant's doc comment with the literal token
+`FORWARD-COMPAT` or `RESERVED` at the start of a line (optionally after a
+list-marker prefix like `*` or `-`). Natural forms accepted:
+
+- `// FORWARD-COMPAT v0.3+: reserved for ...`
+- `// RESERVED (do not delete)`
+- `// * RESERVED *`
+
+Prose negations like `// NOT RESERVED`, `// DEFINITELY NOT-RESERVED`, or
+`// may someday be RESERVED` do NOT silence the check — the marker must
+lead its line. The pinned contract lives in `TestReservedMarkerRE`.
+
 ## Warning Merge Strategy
 
 The resolver owns trust-root warnings:

--- a/specs/127_ENUM_AST_ARCHITECT_R2_audit.md
+++ b/specs/127_ENUM_AST_ARCHITECT_R2_audit.md
@@ -1,0 +1,23 @@
+CRITICAL (0):
+  None.
+
+HIGH (0):
+  None.
+
+MEDIUM (0):
+  None.
+
+LOW (0):
+  None.
+
+QUESTIONS (0):
+  None.
+
+Architect notes:
+- The new "Reserved-reason convention" subsection is in the right place: it follows the existing `bundle_pubkey_provider_mismatch` reserved reason explanation inside the "Reasons" material and appears before the separate "Warning Merge Strategy" section. Evidence: phase7-verify/internal/verify/implementation-notes.md:43, phase7-verify/internal/verify/implementation-notes.md:49, phase7-verify/internal/verify/implementation-notes.md:59
+- The doc does not overpromise scope. It names `TestReasonEnumBijection`, `reasonXxx` string constants, future SPEC reason reservations, and `reasonBundlePubkeyProviderMismatch`; it does not extend the marker convention to warnings or result constants. Evidence: phase7-verify/internal/verify/implementation-notes.md:51, phase7-verify/internal/verify/implementation-notes.md:52, phase7-verify/internal/verify/implementation-notes.md:54
+- The test boundary remains unchanged from r1: the AST walker is still scoped to `reasonXxx` constants and schema reason values, with SPEC §10.4.2 described as the spec-side authority rather than a parsed/generated source. Evidence: phase7-verify/internal/verify/enum_drift_test.go:24, phase7-verify/internal/verify/enum_drift_test.go:28, phase7-verify/internal/verify/enum_drift_test.go:29
+- The marker semantics are documented consistently with the r2 code: the note lists the exact `FORWARD-COMPAT` / `RESERVED` tokens and states standalone-token matching, while the regex and synthetic negated-prose case enforce that "NOT RESERVED" does not silence the unused-constant check. Evidence: phase7-verify/internal/verify/implementation-notes.md:55, phase7-verify/internal/verify/implementation-notes.md:56, phase7-verify/internal/verify/enum_drift_test.go:19, phase7-verify/internal/verify/enum_drift_test.go:345
+- Calling out #127 as the final v1.0.1-followup-labeled issue remains useful PR-body/release-management context, but it does not require a SPEC or architecture change. Evidence: specs/127_ENUM_AST_ARCHITECT_audit.md:24
+
+VERDICT: architect lane r2 READY TO MERGE

--- a/specs/127_ENUM_AST_ARCHITECT_R3_audit.md
+++ b/specs/127_ENUM_AST_ARCHITECT_R3_audit.md
@@ -1,0 +1,23 @@
+CRITICAL (0):
+  None.
+
+HIGH (0):
+  None.
+
+MEDIUM (0):
+  None.
+
+LOW (0):
+  None.
+
+QUESTIONS (0):
+  None.
+
+Architect notes:
+- The r3 delta does not affect the architectural single-source-of-truth boundary blessed in r2. The test still names `reasonXxx` Go constants as the extracted source, checks the schema against that set, and treats the SPEC text as the human-reviewed authority rather than a parsed/generated input. Evidence: phase7-verify/internal/verify/enum_drift_test.go:28, phase7-verify/internal/verify/enum_drift_test.go:32, phase7-verify/internal/verify/enum_drift_test.go:33
+- The tightened marker remains a doc-comment opt-out signal only. `reservedMarkerRE` is consumed through `hasReservedMarker`, which only sets the reserved bit for the unused-constant exemption inside the reason-enum bijection check. Evidence: phase7-verify/internal/verify/enum_drift_test.go:26, phase7-verify/internal/verify/enum_drift_test.go:199, phase7-verify/internal/verify/enum_drift_test.go:203
+- The line-leading grammar is the right convention to formalize for future contributors. It matches Go-style annotation comments by requiring `FORWARD-COMPAT` or `RESERVED` at the start of a comment-content line, optionally after a list marker, while rejecting negated or incidental prose. Evidence: phase7-verify/internal/verify/enum_drift_test.go:19, phase7-verify/internal/verify/enum_drift_test.go:26, phase7-verify/internal/verify/enum_drift_test.go:425, phase7-verify/internal/verify/enum_drift_test.go:438
+- The doc change does not overpromise or under-specify the convention. It scopes the rule to `TestReasonEnumBijection`, this package's `reasonXxx` string constants, and intentionally reserved future SPEC reasons; it names the exact accepted tokens, states the line-leading/list-marker grammar, gives examples, and points to `TestReservedMarkerRE` as the pinned contract. Evidence: phase7-verify/internal/verify/implementation-notes.md:51, phase7-verify/internal/verify/implementation-notes.md:54, phase7-verify/internal/verify/implementation-notes.md:55, phase7-verify/internal/verify/implementation-notes.md:63, phase7-verify/internal/verify/implementation-notes.md:65
+- The live reserved reason already follows the formalized convention, so r3 documents existing intended usage rather than introducing a new architecture surface. Evidence: phase7-verify/internal/verify/verify.go:33, phase7-verify/internal/verify/implementation-notes.md:43
+
+VERDICT: architect lane r3 READY TO MERGE

--- a/specs/127_ENUM_AST_ARCHITECT_audit.md
+++ b/specs/127_ENUM_AST_ARCHITECT_audit.md
@@ -1,0 +1,26 @@
+CRITICAL (0):
+  None.
+
+HIGH (0):
+  None.
+
+MEDIUM (0):
+  None.
+
+LOW (1):
+  L1. Reserved-marker convention should be documented outside the test before reuse.
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:186
+      Fix:     Add a short note to phase7-verify/internal/verify/implementation-notes.md saying unused reserved reason constants must carry a FORWARD-COMPAT or RESERVED doc marker; defer any extension to warnings/result constants to a separate PR.
+
+QUESTIONS (0):
+  None.
+
+Architect notes:
+- Early landing is architecturally acceptable despite deviating from the original "next reason enum extension" trigger: the change is test-only, the live schema already carries 20 reason values across the valid/invalid/inconclusive branches, and the latest SPEC-015 v0.3.4 change added only a warning enum (`non_default_tls_trust`), not a reason enum. Evidence: phase7-verify/internal/verify/enum_drift_test.go:18, phase7-verify/schemas/output.schema.json:23, phase7-verify/schemas/output.schema.json:241, phase7-verify/schemas/output.schema.json:548, specs/SPEC-015-receipts.md:3, specs/SPEC-015-receipts.md:2245
+- The single-source boundary is appropriate for this PR: Go reason constants are the implementation source, the JSON schema is the machine-consumable contract checked by the test, and SPEC §10.4.2 / §M.3.2.1 remain human-reviewed normative text. Codegen from schema or Markdown would add build/spec-parser machinery out of proportion to a test-only drift guard. Evidence: phase7-verify/internal/verify/enum_drift_test.go:22, phase7-verify/internal/verify/enum_drift_test.go:133, specs/SPEC-015-receipts.md:2217, specs/SPEC-015-receipts.md:3151
+- Not parsing the SPEC Markdown is the right architectural boundary here: the schema is already the structured contract, while §10.4.2 and §M.3.2.1 are prose/table authorities reviewed alongside schema edits. Evidence: specs/SPEC-015-receipts.md:2200, specs/SPEC-015-receipts.md:2217, specs/SPEC-015-receipts.md:3132, phase7-verify/internal/verify/enum_drift_test.go:23
+- The larger test surface is justified because the synthetic fixtures verify the verifier: they prove missing-Go, missing-schema, unused-unreserved, reserved-unused, and duplicate-branch drift cases. Dropping this table would leave the trunk pass as a black-box assertion with weak future-regression evidence. Evidence: phase7-verify/internal/verify/enum_drift_test.go:194, phase7-verify/internal/verify/enum_drift_test.go:214, phase7-verify/internal/verify/enum_drift_test.go:230, phase7-verify/internal/verify/enum_drift_test.go:244, phase7-verify/internal/verify/enum_drift_test.go:267, phase7-verify/internal/verify/enum_drift_test.go:291
+- The existing live-tree reserved reason already uses the exact FORWARD-COMPAT marker and has behavior-level documentation in implementation notes. Evidence: phase7-verify/internal/verify/verify.go:33, phase7-verify/internal/verify/verify.go:39, phase7-verify/internal/verify/implementation-notes.md:43
+- Closing #127 as the final v1.0.1-followup item is a clean release-management signal worth mentioning in the PR body/changelog text, but it does not require a SPEC change. Evidence: specs/SPEC-015-receipts.md:6, specs/SPEC-015-receipts.md:7
+
+VERDICT: architect lane READY TO MERGE

--- a/specs/127_ENUM_AST_CODE_R2_audit.md
+++ b/specs/127_ENUM_AST_CODE_R2_audit.md
@@ -1,0 +1,22 @@
+CRITICAL (0):
+HIGH (0):
+MEDIUM (0):
+LOW (1):
+  L1. Space-separated negated RESERVED prose still silences unused-constant checks
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:22
+      Fix:     Tighten the marker grammar to an explicit marker form such as `FORWARD-COMPAT:` / `RESERVED:` on the comment line, or otherwise ensure `NOT RESERVED` cannot match.
+QUESTIONS (0):
+
+R1 RESOLUTION CHECKS:
+  M1. Resolved: the const walker now errors on missing explicit values and non-string literals at phase7-verify/internal/verify/enum_drift_test.go:85 and phase7-verify/internal/verify/enum_drift_test.go:88; the new fixtures at phase7-verify/internal/verify/enum_drift_test.go:316 and phase7-verify/internal/verify/enum_drift_test.go:331 would have failed before the fix because those constants were silently skipped.
+  M2. Resolved: duplicate Go wire values are detected before schema comparison at phase7-verify/internal/verify/enum_drift_test.go:134; the fixture at phase7-verify/internal/verify/enum_drift_test.go:301 would have failed before the fix because `reasonA` and `reasonAlias` collapsed into one expected map entry.
+  L1. Partially resolved: the new fixture at phase7-verify/internal/verify/enum_drift_test.go:346 covers `NOT-RESERVED` and `FORWARD-COMPATIBLE`, but the regex still matches the original space-separated `NOT RESERVED` example because spaces satisfy both non-alphanumeric boundaries.
+
+R2 NOTES:
+  - Intended reserved markers such as `FORWARD-COMPAT:` and `RESERVED:` still match the new regex.
+  - Returning early for unsupported reason constant declarations is the desired semantic for this test: silently skipping malformed `reasonXxx` constants was the M1 failure mode.
+  - The duplicate-value error can name the pair in either order because map iteration is nondeterministic, but the current table test asserts only the stable `both declare wire value` fragment, so the test is not flaky.
+
+VERIFICATION:
+  - `go test ./internal/verify -run 'TestReasonEnumBijection|TestIsReasonConstName' -count=1`
+  - `go test ./internal/verify -run 'TestReasonEnumBijection_DetectsDrift' -count=1 -v`

--- a/specs/127_ENUM_AST_CODE_R3_audit.md
+++ b/specs/127_ENUM_AST_CODE_R3_audit.md
@@ -1,0 +1,20 @@
+CRITICAL (0):
+HIGH (0):
+MEDIUM (0):
+LOW (1):
+  L1. Line-start hyphen-suffixed marker words still count as reserved markers
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:26
+      Fix:     Tighten the post-marker boundary to reject alphanumeric, underscore, and hyphen suffixes, e.g. `(?:[^[:alnum:]_-]|$)`, and add line-start `RESERVED-LIKE` / `FORWARD-COMPAT-LIKE` negative cases if those forms are meant to remain prose.
+QUESTIONS (0):
+
+r2 L1 closure: CLOSED. `reservedMarkerRE` is anchored to comment-line start, and `TestReservedMarkerRE` rejects `NOT RESERVED`, `DEFINITELY NOT-RESERVED and not FORWARD-COMPATIBLE.`, `NOT FORWARD-COMPAT yet`, `may someday be RESERVED`, `intentionally UNRESERVED`, `this RESERVED-LIKE thing`, and the empty string. Evidence: phase7-verify/internal/verify/enum_drift_test.go:26, phase7-verify/internal/verify/enum_drift_test.go:438.
+
+Live marker check: the live `// FORWARD-COMPAT v0.3+: reserved enum value.` comment on `reasonBundlePubkeyProviderMismatch` is accepted after `go/ast.CommentGroup.Text()` strips the `//` marker, matching the pinned live-form fixture. Evidence: phase7-verify/internal/verify/verify.go:33, phase7-verify/internal/verify/enum_drift_test.go:431.
+
+Bypass notes: a preceding one-line block doc comment `/* RESERVED */` would be accepted because AST text strips block markers and leaves `RESERVED` at line start; a same-line trailing block comment is not checked by `hasReservedMarker` because it only reads `ValueSpec.Doc`. ASCII tab indentation is accepted by `\s`; Unicode-only indentation is not accepted by Go regexp `\s` and would fail closed rather than silence the unused-constant check. Evidence: phase7-verify/internal/verify/enum_drift_test.go:19, phase7-verify/internal/verify/enum_drift_test.go:199.
+
+Doc accuracy: the `reservedMarkerRE` doc comment accurately describes the start-of-line anchor, optional list prefix, accepted live forms, and the r2 negation rejection. The only caveat is LOW L1's unpinned hyphen-suffix behavior from the `\W` boundary. Evidence: phase7-verify/internal/verify/enum_drift_test.go:19, phase7-verify/internal/verify/implementation-notes.md:51.
+
+Verification: `go test ./internal/verify -run 'Test(ReasonEnumBijection|ReservedMarkerRE)'` and `go test ./internal/verify` both passed from `phase7-verify`.
+
+VERDICT: code lane r3 READY TO MERGE

--- a/specs/127_ENUM_AST_CODE_audit.md
+++ b/specs/127_ENUM_AST_CODE_audit.md
@@ -1,0 +1,14 @@
+CRITICAL (0):
+HIGH (0):
+MEDIUM (2):
+  M1. AST extraction silently ignores valid reason constants without direct literal values
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:79
+      Fix:     Return an error for any reasonXxx const that lacks an explicit string literal value, or implement Go const expression carry-forward/alias evaluation instead of continuing silently.
+  M2. Duplicate Go reason values collapse before the schema bijection check
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:128
+      Fix:     Track value-to-const collisions while building expected and fail when two reasonXxx constants resolve to the same schema reason value.
+LOW (1):
+  L1. Reserved marker substring match accepts negated prose such as "NOT RESERVED"
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:190
+      Fix:     Match explicit marker forms such as FORWARD-COMPAT: or RESERVED: on comment lines instead of arbitrary substrings.
+QUESTIONS (0):

--- a/specs/127_ENUM_AST_SECURITY_R2_audit.md
+++ b/specs/127_ENUM_AST_SECURITY_R2_audit.md
@@ -1,0 +1,17 @@
+CRITICAL (0):
+
+HIGH (0):
+
+MEDIUM (0):
+
+LOW (1):
+  L1. Reserved-marker regex is still broader than the claimed standalone-token convention.
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:20
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:22
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:352
+      Evidence: phase7-verify/internal/verify/implementation-notes.md:56
+      Fix:     Either remove the "NOT RESERVED" claim from code/docs or tighten marker recognition with explicit negative coverage for `NOT RESERVED` and full alphanumeric boundaries such as `[^[:alnum:]_-]`; the natural marker forms `FORWARD-COMPAT v0.3+:`, `RESERVED (do not delete)`, and `* RESERVED *` remain acceptable.
+
+QUESTIONS (0):
+
+VERDICT: security lane r2 NOT READY TO MERGE

--- a/specs/127_ENUM_AST_SECURITY_R3_audit.md
+++ b/specs/127_ENUM_AST_SECURITY_R3_audit.md
@@ -1,0 +1,35 @@
+CRITICAL (0):
+  (none)
+
+HIGH (0):
+  (none)
+
+MEDIUM (0):
+  (none)
+
+LOW (0):
+  (none)
+
+QUESTIONS (0):
+  (none)
+
+Security verification notes:
+- r2 L1 is closed. `reservedMarkerRE` is anchored with `(?m)^`, allows only leading whitespace plus optional `* ` / `- ` list markers before `FORWARD-COMPAT` or `RESERVED`, and therefore rejects leading prose negations such as `NOT RESERVED`, `DEFINITELY NOT-RESERVED and not FORWARD-COMPATIBLE.`, and `NOT FORWARD-COMPAT yet`.
+  Evidence: phase7-verify/internal/verify/enum_drift_test.go:19
+  Evidence: phase7-verify/internal/verify/enum_drift_test.go:26
+  Evidence: phase7-verify/internal/verify/enum_drift_test.go:438
+- Required accept cases are covered: the live `FORWARD-COMPAT v0.3+` form, plain `RESERVED (do not delete)`, list marker `* RESERVED *`, and indented/list-marker semantics through the optional leading whitespace and bullet prefix.
+  Evidence: phase7-verify/internal/verify/verify.go:33
+  Evidence: phase7-verify/internal/verify/enum_drift_test.go:429
+- Mixed-case `Reserved` fails because the regex alternatives are exact uppercase literals. A marker on a continuation line after leading prose is accepted by `(?m)` and is consistent with the documented "start of a line" convention.
+  Evidence: phase7-verify/internal/verify/enum_drift_test.go:26
+  Evidence: phase7-verify/internal/verify/enum_drift_test.go:436
+  Evidence: phase7-verify/internal/verify/implementation-notes.md:55
+- The documentation accurately describes the semantics: literal uppercase marker at line start, optional list-marker prefix, and prose negations not accepted.
+  Evidence: phase7-verify/internal/verify/implementation-notes.md:49
+  Evidence: phase7-verify/internal/verify/implementation-notes.md:63
+
+Validation:
+- `go test ./internal/verify -run 'TestReservedMarkerRE|TestReasonEnumBijection'` from `phase7-verify`: PASS.
+
+VERDICT: security lane r3 READY TO MERGE

--- a/specs/127_ENUM_AST_SECURITY_audit.md
+++ b/specs/127_ENUM_AST_SECURITY_audit.md
@@ -1,0 +1,26 @@
+CRITICAL (0):
+
+HIGH (0):
+
+MEDIUM (0):
+
+LOW (4):
+  L1. Duplicate Go reason string values can collapse before the schema comparison.
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:128
+      Fix:     Track `map[string][]string` for reason values and fail if more than one `reasonXxx` constant declares the same wire value before building the schema lookup.
+
+  L2. Implicit or non-string `reasonXxx` constants are ignored instead of rejected.
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:79
+      Fix:     When a name matches `isReasonConstName`, return an error unless that constant has an explicit string literal value.
+
+  L3. Reserved-marker matching is a loose substring check.
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:186
+      Fix:     Require `FORWARD-COMPAT` or `RESERVED` as standalone tokens, e.g. `(^|\\W)(FORWARD-COMPAT|RESERVED)(\\W|$)`.
+
+  L4. The schema reader is intentionally tied to the current three-branch `oneOf` layout.
+      Evidence: phase7-verify/internal/verify/enum_drift_test.go:133
+      Fix:     Keep the three-branch failure for SPEC-015 v0.3, and require an explicit test update if future schema revisions move reason values into `anyOf`, `if/then/else`, `$ref`, or another combinator.
+
+QUESTIONS (0):
+
+VERDICT: security lane READY TO MERGE

--- a/specs/AUDIT_127_ENUM_AST_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_127_ENUM_AST_ARCHITECT_PROMPT.md
@@ -1,0 +1,120 @@
+# Issue #127 phase7-verify TestReasonEnumBijection AST walk — ARCHITECT-lane audit
+
+You are the **architect** lane of a three-lane audit (code / security /
+architect) of the issue #127 AST-walking enum-bijection test. Stay
+narrowly in your lane.
+
+## Branch / commit
+
+- Branch: `fix/phase7-verify-enum-ast-walk`
+- Worktree: `../macprovider-127-enum-ast` (origin/main base: 8585586)
+- File in scope (`git diff origin/main`):
+  - `phase7-verify/internal/verify/enum_drift_test.go` (test-only)
+
+## What this change does (operator summary — NOT the audit answer)
+
+Issue #127 was deferred earlier today (see comment on the issue):
+"Tracking confirms the deferral until first SPEC-015 v0.3 reason-
+enum extension — when that lands, ship the AST walk in the same PR."
+
+That forcing function did NOT fire — PR #178 added a `warnings[]`
+enum value (`non_default_tls_trust`), not a `reason` enum value.
+However, the hand-maintained slice has grown to 20 entries (from
+10 in the original report; the issue body's comment quotes "22"
+which counts pre-rename overcount), so the drift surface is now
+larger than at the original defer. The user pulled this in early
+to finish the `v1.0.1-followup` queue cleanly before deploying to
+Pearl.
+
+## Architect-lane scope (apply each; stay in lane)
+
+### ARCH-1. Is this the right time to land #127?
+- The original deferral was "ship in same PR as the next reason-
+  enum extension." That forcing function has NOT fired. Pulling
+  #127 in standalone now is a deviation from the documented plan.
+- Is this premature, or does the grown drift surface (20 hand-
+  maintained entries) justify it? Recall the issue body says:
+  "Defer until first SPEC-015 v0.3 reason-enum extension lands."
+- Counterpoint: shipping the AST walk now means the NEXT reason-
+  enum extension lands without ANY test-fixture overhead. Net
+  win on future-cost; immediate cost is one test-only diff.
+- The user explicitly chose this to finalize the v1.0.1-followup
+  label (PRs #178 already closed #126/#128, the only other label
+  members). After this, the label has 0 open items.
+
+### ARCH-2. Single-source-of-truth shape
+- The new architecture: Go reason constants are the source of
+  truth. Schema is checked against them. SPEC §10.4.2 is
+  human-maintained, in lock-step via PR review.
+- Alternative shapes to consider:
+  - **A (current)**: Go constants → AST walk → schema check. SPEC
+    is a parallel human-maintained doc.
+  - **B**: Schema is canonical, codegen Go constants from it.
+    Cost: Build-system step. Benefit: SPEC-aligned single source.
+  - **C**: SPEC table is canonical, codegen both Go and schema from
+    it. Cost: Spec-format parser. Benefit: spec is truly the source.
+- The author chose A (minimum-friction, no codegen). Is this the
+  right boundary?
+
+### ARCH-3. Reserved-marker convention
+- `FORWARD-COMPAT`/`RESERVED` is now a convention for marking
+  constants that are declared but intentionally unused. This is
+  a new convention; should it be documented in
+  `phase7-verify/internal/verify/implementation-notes.md` or
+  similar? Currently the only documentation is the comment IN
+  enum_drift_test.go.
+- The existing `reasonBundlePubkeyProviderMismatch` comment uses
+  the exact word "FORWARD-COMPAT" — that's already in the live
+  tree. Confirm.
+- Long-term, could this marker convention be extended to other
+  unused declarations (e.g. warning kinds, result types)? Out
+  of scope for this PR but worth flagging.
+
+### ARCH-4. Test surface budget
+- The new test file is ~340 lines (up from 116). Most of the
+  growth is the table-driven `_DetectsDrift` test with 5
+  synthetic fixtures. Is the test growth justified?
+- Counterpoint: without the drift-detection table, the live test
+  is a black box — passing-on-trunk gives no confidence it would
+  catch a regression on a future PR. The synthetic fixtures are
+  the verification-of-the-verification.
+- Alternative: drop the `_DetectsDrift` table, rely on the
+  bijection check working "by construction." Acceptable trade?
+
+### ARCH-5. Spec doc reference
+- SPEC §10.4.2 lists the reason enum table in Markdown. The new
+  test does NOT parse the spec; it only cross-checks Go ↔ schema.
+  The original issue body's "Suggested fix" mentioned parsing
+  spec markdown. The author chose NOT to.
+- Rationale: spec markdown parsing is fragile (depends on table
+  format), and the spec is human-maintained / reviewed alongside
+  schema changes anyway. The schema is the machine-consumable
+  contract.
+- Confirm this is the right architectural boundary.
+
+### ARCH-6. Closing the v1.0.1-followup label
+- After this PR merges, the `v1.0.1-followup` label has zero open
+  issues (assuming #126/#128 closed by PR #178 and #127 closed
+  by this PR). That's a clean signal that the v1.0.1 verifier
+  release is fully hardened. Worth noting in the PR body /
+  change-log? (No SPEC change in this PR; nothing to add.)
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/127_ENUM_AST_ARCHITECT_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM AND the early-land timing is acceptable
+architecturally, end with:
+`VERDICT: architect lane READY TO MERGE`

--- a/specs/AUDIT_127_ENUM_AST_ARCHITECT_R2_PROMPT.md
+++ b/specs/AUDIT_127_ENUM_AST_ARCHITECT_R2_PROMPT.md
@@ -1,0 +1,62 @@
+# Issue #127 r2 — ARCHITECT-lane closure audit
+
+You are the **architect** lane of the r2 closure audit for issue
+#127. r1 returned 0 CRITICAL/HIGH/MEDIUM and 1 LOW (document the
+FORWARD-COMPAT/RESERVED convention outside the test). Stay narrowly
+in your lane.
+
+## r1 architect finding → r2 fix
+
+- **r1 L1** (Reserved-marker convention should be documented outside
+  the test): added a new "Reserved-reason convention" subsection at
+  the end of the existing "Reasons" section in
+  `phase7-verify/internal/verify/implementation-notes.md`. The
+  section describes:
+  - WHO uses the marker (`TestReasonEnumBijection` AST walker)
+  - WHAT triggers it (declared but never referenced in non-test
+    source)
+  - WHICH tokens it recognizes (FORWARD-COMPAT, RESERVED)
+  - HOW it matches (standalone tokens, not substring match)
+
+## Files in scope (`git diff origin/main` for r2)
+
+- `phase7-verify/internal/verify/enum_drift_test.go` — see r1
+  code/security delta described in
+  `specs/AUDIT_127_ENUM_AST_CODE_R2_PROMPT.md`.
+- `phase7-verify/internal/verify/implementation-notes.md` — new
+  "Reserved-reason convention" subsection.
+
+## Architect verification ask
+
+1. Is the implementation-notes addition at the right location
+   (under "Reasons" rather than "Warning Merge Strategy" or
+   elsewhere)?
+2. Does it overpromise — for instance by suggesting the marker
+   convention extends to warnings or result types? The r1 audit
+   explicitly said "defer any extension to warnings/result
+   constants to a separate PR." Confirm the doc respects that
+   scope.
+3. The PR is still test-only + one doc paragraph. Is the
+   single-source-of-truth boundary unchanged from r1 (Go consts ↔
+   schema; SPEC remains human-maintained authority)?
+4. Closing #127 as the last v1.0.1-followup-labeled issue — worth
+   calling out in the PR body? (Same r1 question.)
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Write to `specs/127_ENUM_AST_ARCHITECT_R2_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM AND the implementation-notes addition is
+architecturally sound, end with: `VERDICT: architect lane r2 READY
+TO MERGE`

--- a/specs/AUDIT_127_ENUM_AST_ARCHITECT_R3_PROMPT.md
+++ b/specs/AUDIT_127_ENUM_AST_ARCHITECT_R3_PROMPT.md
@@ -1,0 +1,45 @@
+# Issue #127 r3 — ARCHITECT-lane closure audit
+
+You are the **architect** lane of the r3 closure audit for issue
+#127. r2 verdict was READY TO MERGE (0/0/0/0). r3's only delta is
+tightening the reserved-marker regex and updating the doc comment —
+no architectural surface changes. Stay narrowly in your lane.
+
+## r3 deltas vs r2
+
+- Regex grammar tightened: substring/word-boundary → start-of-line
+  with optional list-marker prefix.
+- New `TestReservedMarkerRE` pins the must-reserve vs must-NOT-
+  reserve cases.
+- "Reserved-reason convention" doc updated to match the tightened
+  semantics.
+
+## Architect verification ask
+
+1. Does the r3 delta affect the architectural single-source-of-truth
+   boundary you blessed in r2? (Probably no — the marker is still a
+   doc-comment opt-out signal, just with a stricter grammar.)
+2. Is the doc-comment grammar choice (line-leading marker) the right
+   convention to formalize for future contributors? It matches how
+   Go conventionally writes annotation tags (`// TODO:`, `// FIXME:`,
+   `// Deprecated:`) — all line-leading.
+3. Anything in the r3 doc change that overpromises or under-specifies
+   the convention?
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Write to `specs/127_ENUM_AST_ARCHITECT_R3_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM, end with: `VERDICT: architect lane r3
+READY TO MERGE`

--- a/specs/AUDIT_127_ENUM_AST_CODE_PROMPT.md
+++ b/specs/AUDIT_127_ENUM_AST_CODE_PROMPT.md
@@ -1,0 +1,143 @@
+# Issue #127 phase7-verify TestReasonEnumBijection AST walk — CODE-lane audit
+
+You are the **code** lane of a three-lane audit (code / security /
+architect) of the issue #127 AST-walking enum-bijection test. Stay
+narrowly in your lane.
+
+## Branch / commit
+
+- Branch: `fix/phase7-verify-enum-ast-walk`
+- Worktree: `../macprovider-127-enum-ast` (origin/main base: 8585586)
+- Files in scope (`git diff origin/main`):
+  - `phase7-verify/internal/verify/enum_drift_test.go` — entire file
+    rewritten. Hand-maintained 20-entry `expectedReasons` slice
+    replaced by an AST walk of the verify package's `reasonXxx`
+    constants. Adds unused-constant detection (with
+    `FORWARD-COMPAT`/`RESERVED` doc-comment escape hatch) and a
+    `TestReasonEnumBijection_DetectsDrift` table-driven test that
+    exercises 5 distinct drift scenarios via synthetic in-memory
+    packages. Helper `isReasonConstName` + tiny `TestIsReasonConstName`.
+
+## What this change does (operator summary — NOT the audit answer)
+
+Closes the issue #127 gap: a contributor adding a new `reasonXxx`
+constant but never referencing it now fails the bijection test
+silently. Original test relied on a hand-maintained slice as the
+source of truth; new test uses `go/parser` + `go/ast` to extract the
+constant set from `verify.go` itself, then enforces the bijection
+against `schemas/output.schema.json`. The `reasonBundlePubkey-
+ProviderMismatch` constant (intentionally reserved for future SPEC
+revision per the in-source `FORWARD-COMPAT` block comment) passes
+the unused check because the test recognizes its doc-comment marker.
+
+## Code-lane scope (apply each; stay in lane)
+
+### CODE-1. AST extraction correctness
+- The walker only collects identifiers whose name matches
+  `isReasonConstName` (literal prefix `reason` + first-character-of-
+  suffix is uppercase). Confirm this REJECTS:
+  - `reason` (bare prefix)
+  - `reasonable` (lowercase suffix start)
+  - `Reason` (wrong case start)
+  - `warningReasonProviderIDUnresolvable` (wrong prefix despite
+    embedded "reason"; this IS declared in verify.go const block but
+    must NOT be picked up by the reason walker).
+- The walker only collects from `*ast.GenDecl` with `Tok ==
+  token.CONST`. Confirm it does NOT pick up:
+  - `var reasonFoo = "..."` declarations (var, not const)
+  - `reasonFoo := "..."` short-var assignments (not GenDecl)
+- The walker requires `vs.Values[i]` to exist for each name in
+  `vs.Names`. For iota-style declarations like `const ( a = iota;
+  b; c )`, only `a` has a value; `b` and `c` reuse the previous
+  expression. Confirm this case can never apply to `reasonXxx`
+  string constants (which never use iota).
+- `strconv.Unquote` parses the value. Confirm it correctly handles
+  raw-string literals `\`foo\`` if a contributor ever uses them.
+  (Strict double-quoted is the convention.)
+
+### CODE-2. Reference counting / unused-constant detection
+- The walker uses `ast.Inspect` to count `*ast.Ident` nodes whose
+  name matches a declared reason constant, EXCLUDING the
+  declaration's own `name.Pos()`. Trace whether this correctly
+  separates the declaration site from subsequent uses. The
+  declaration site's `ident.Pos()` is the position of the name
+  inside the `ValueSpec`; subsequent references to the same name
+  have different positions. Confirm.
+- Edge case: if a reason constant is declared in one file and
+  referenced in another file in the same package, does the walker
+  count the reference? It walks `pkg.Files` (all non-test files in
+  the package), so yes. Trace: `reasonProviderIDNotInPool` is
+  referenced in `catalog_check.go`? Or only in `verify.go`?
+- Edge case: a reason constant could be referenced ONLY in a test
+  file. With test files excluded from the parser, it would appear
+  unused. Is this the correct semantic? (Yes — the architectural
+  claim is that any reason constant must be USED in production
+  code; tests-only is the same as unused for this purpose.)
+
+### CODE-3. Reserved-marker escape hatch
+- `hasReservedMarker` checks `vs.Doc` for the substring
+  `FORWARD-COMPAT` or `RESERVED`. It does NOT check `gen.Doc` (the
+  GenDecl-level doc). Is that the right boundary?
+- The current FORWARD-COMPAT comment on
+  `reasonBundlePubkeyProviderMismatch` is placed BETWEEN
+  `reasonPreviousKeyOutsideGraceWindow` and itself, inside the
+  const block. `go/parser` with `parser.ParseComments` attaches it
+  as `vs.Doc` on the `reasonBundlePubkeyProviderMismatch` ValueSpec.
+  Confirm with `go test` actually runs.
+- Substring match (vs. word-boundary or all-caps requirement) — is
+  this overly permissive? A contributor could write "DEFINITELY
+  NOT RESERVED" and the test would consider it reserved. Acceptable?
+
+### CODE-4. Schema-bijection check
+- The schema struct only decodes `oneOf[].properties.reason.{const,
+  enum}`. Confirm this matches the actual schema layout (3
+  branches, each with a `reason` property at that path).
+- The `expected` map uses `value → constName` (not just a set).
+  When a schema reason has no matching Go constant, the error
+  message says `"schema reason %q has no matching reasonXxx Go
+  constant"` — informative.
+- The duplication check (`want exactly one branch`) catches the
+  case where the same reason value appears in multiple `oneOf`
+  branches. Confirm the message names the Go constant + value +
+  the branches.
+
+### CODE-5. Drift-detection table tests
+- `TestReasonEnumBijection_DetectsDrift` covers 5 scenarios:
+  1. Go constant missing from schema
+  2. Schema reason missing from Go constants
+  3. Unused non-reserved constant fails
+  4. Unused reserved constant passes
+  5. Go constant appears in multiple schema branches
+- Each fixture is self-contained: a synthetic Go source string + a
+  synthetic JSON schema. The walker is invoked via
+  `parser.ParseFile` → constructed `*ast.Package` wrapper. Confirm
+  this faithfully exercises the same code path as the live test.
+- `wantErrFrag` does substring containment; if the error message
+  text changes, only the matching fragment matters. Acceptable.
+
+### CODE-6. Test packaging
+- `enum_drift_test.go` is in `package verify` (not `package
+  verify_test`), so it has access to unexported `checkReasonEnum-
+  Bijection` and the helpers. Confirm no other file in this
+  package defines a symbol that collides with the new helpers
+  (`isReasonConstName`, `hasReservedMarker`,
+  `checkReasonEnumBijection`).
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/127_ENUM_AST_CODE_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM, end with:
+`VERDICT: code lane READY TO MERGE`

--- a/specs/AUDIT_127_ENUM_AST_CODE_R2_PROMPT.md
+++ b/specs/AUDIT_127_ENUM_AST_CODE_R2_PROMPT.md
@@ -1,0 +1,67 @@
+# Issue #127 r2 — CODE-lane closure audit
+
+You are the **code** lane of the r2 closure audit for issue #127. r1
+returned 2 MEDIUM findings + 1 LOW. Each has been addressed; this r2
+audit verifies the fixes only. Stay narrowly in your lane.
+
+## r1 findings → r2 fixes
+
+- **r1 M1** (AST silently ignores reason consts without explicit literal
+  values): now returns an error if `i >= len(vs.Values)` OR
+  `vs.Values[i]` is not a `*ast.BasicLit` of `token.STRING`. New table
+  cases `reason constant without explicit value` and `reason constant
+  with non-string-literal value` exercise both branches.
+- **r1 M2** (Duplicate Go reason values collapse before bijection
+  check): the `expected` map build now checks for prior entry and
+  returns `"reason constants X and Y both declare wire value %q;
+  values must be unique"`. New table case `two go constants with the
+  same wire value` exercises it.
+- **r1 L1** (Reserved-marker substring match accepts negated prose
+  like "NOT RESERVED"): replaced `strings.Contains` with a compiled
+  regex `reservedMarkerRE` that matches FORWARD-COMPAT/RESERVED only
+  as standalone tokens (non-alphanumeric boundary on each side). New
+  table case `negated reserved-marker prose still flags unused
+  constant` confirms `// DEFINITELY NOT-RESERVED and not
+  FORWARD-COMPATIBLE.` does NOT count as reserved.
+
+## Files in scope (`git diff origin/main` for r2)
+
+- `phase7-verify/internal/verify/enum_drift_test.go` — added M1 error
+  returns, M2 dup check, L1 regex helper, 4 new table cases.
+
+## Verification ask
+
+Read the r1 audit findings at `specs/127_ENUM_AST_CODE_audit.md` and
+the current `enum_drift_test.go`. For each r1 finding, confirm the
+fix is correct and the new table case actually exercises the failure
+mode (would have failed before the fix).
+
+Are there NEW issues introduced by the r2 deltas? Specifically:
+- The regex `(^|[^A-Z0-9_-])(FORWARD-COMPAT|RESERVED)([^A-Z0-9_-]|$)` —
+  any corner case where intended reserved markers fail to match?
+- Returning early from the const-walk loop (rather than skipping)
+  changes a previously-soft skip into a hard error. Confirm this is
+  the desired semantic.
+- The dup-value error names the prior constant — Go map iteration
+  order is non-deterministic, so the "prior" name will be whichever
+  the iteration saw first. Is this a flaky error message? (It does
+  fail the test the same way either order, but the message text
+  differs.)
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Write to `specs/127_ENUM_AST_CODE_R2_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM AND all three r1 findings are resolved, end
+with: `VERDICT: code lane r2 READY TO MERGE`

--- a/specs/AUDIT_127_ENUM_AST_CODE_R3_PROMPT.md
+++ b/specs/AUDIT_127_ENUM_AST_CODE_R3_PROMPT.md
@@ -1,0 +1,69 @@
+# Issue #127 r3 — CODE-lane closure audit
+
+You are the **code** lane of the r3 closure audit for issue #127. r2
+returned 0 CRITICAL/HIGH/MEDIUM + 1 LOW: the reserved-marker regex
+matched `NOT RESERVED` because space satisfied both word boundaries.
+Fixed in r3 by anchoring the marker to start-of-line. Stay narrowly
+in your lane.
+
+## r2 finding → r3 fix
+
+- **r2 L1** (NOT RESERVED still matches): the regex changed from
+  `(^|[^A-Z0-9_-])(FORWARD-COMPAT|RESERVED)([^A-Z0-9_-]|$)` (word-
+  boundary anywhere) to
+  `(?m)^\s*(?:[*-]\s+)?(FORWARD-COMPAT|RESERVED)(\W|$)` (start-of-
+  line, optional list-marker prefix). New `TestReservedMarkerRE`
+  pins the contract: must-reserve set (FORWARD-COMPAT v0.3+:, RESERVED
+  (do not delete), * RESERVED *, - RESERVED for SPEC-016, FORWARD-COMPAT:
+  pending v0.4, two-line "context\nRESERVED ...") and must-NOT-reserve
+  set (NOT RESERVED, DEFINITELY NOT-RESERVED ..., NOT FORWARD-COMPAT
+  yet, "may someday be RESERVED", "intentionally UNRESERVED", "this
+  RESERVED-LIKE thing", empty string).
+
+## Files in scope (`git diff origin/main` for r3 delta only)
+
+- `phase7-verify/internal/verify/enum_drift_test.go`:
+  - `reservedMarkerRE` constant rewritten with multi-line anchor.
+  - Doc comment on the constant explains accepted/rejected forms.
+  - New `TestReservedMarkerRE` test (6+7 cases).
+  - Existing drift table case `negated reserved-marker prose still
+    flags unused constant` now also covers a leading-prose `NOT
+    RESERVED` line.
+- `phase7-verify/internal/verify/implementation-notes.md`:
+  - "Reserved-reason convention" section updated to match the
+    tightened semantics; calls out `TestReservedMarkerRE` as the
+    pinned-contract test.
+
+## Verification ask
+
+1. Confirm the new regex correctly accepts the live verify.go form
+   `// FORWARD-COMPAT v0.3+: reserved enum value.` (the doc comment
+   on `reasonBundlePubkeyProviderMismatch`). Note `go/ast`'s
+   `CommentGroup.Text()` strips the `//` markers.
+2. Confirm the new regex rejects all the `mustNotReserve` cases in
+   `TestReservedMarkerRE`.
+3. Are there any remaining marker grammar bypasses? E.g.
+   - Trailing-line markers like a one-line block `/* RESERVED */`?
+   - Tab-only leading whitespace? (`\s` includes tabs.)
+   - Unicode whitespace? (`\s` in Go RE2 is ASCII whitespace by
+     default.)
+4. Does the doc comment on `reservedMarkerRE` accurately describe
+   the regex semantics?
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Write to `specs/127_ENUM_AST_CODE_R3_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM AND the r2 L1 is closed, end with:
+`VERDICT: code lane r3 READY TO MERGE`

--- a/specs/AUDIT_127_ENUM_AST_SECURITY_PROMPT.md
+++ b/specs/AUDIT_127_ENUM_AST_SECURITY_PROMPT.md
@@ -1,0 +1,117 @@
+# Issue #127 phase7-verify TestReasonEnumBijection AST walk — SECURITY-lane audit
+
+You are the **security** lane of a three-lane audit (code / security /
+architect) of the issue #127 AST-walking enum-bijection test. Stay
+narrowly in your lane.
+
+**Scope note.** This is a TEST-FILE-ONLY change (`enum_drift_test.go`).
+No production code is modified. No new dependency surface. No new
+runtime path. The security stake is small but worth confirming:
+test hygiene affects ability to detect future drift on a money-path-
+adjacent schema (verifier output is what buyers consume; receipt
+fields downstream of this schema are part of SPEC-015's signed-receipt
+trust boundary).
+
+## Branch / commit
+
+- Branch: `fix/phase7-verify-enum-ast-walk`
+- Worktree: `../macprovider-127-enum-ast` (origin/main base: 8585586)
+- File in scope (`git diff origin/main`):
+  - `phase7-verify/internal/verify/enum_drift_test.go` (test-only)
+
+## Why security cares about this diff
+
+The verifier surfaces a `reason` field to the buyer. The mapping
+between (Go reason constants) and (schema enum) is part of the
+contract a buyer's tooling relies on. Drift in either direction
+silently weakens trust:
+- Schema lists a reason Go code never emits → buyer tooling treats
+  unreachable case as live; possible false-positive defense logic.
+- Go code emits a reason missing from schema → buyer JSON-schema
+  validator rejects the verifier's own output; the verifier looks
+  broken even when correct.
+
+The original test had a third silent failure mode (the #127 gap):
+a Go constant added but never used. The new test closes that gap.
+
+## Security-lane scope (apply each; stay in lane)
+
+### SEC-1. Drift detection completeness
+- The new test enforces FIVE invariants:
+  1. Every Go `reasonXxx` constant appears in exactly one schema
+     branch (no missing, no duplicated).
+  2. Every schema reason value maps back to a Go constant.
+  3. Every non-reserved Go constant is referenced ≥ once in
+     non-test source.
+  4. Schema has exactly 3 `oneOf` branches (valid/invalid/
+     inconclusive).
+  5. Each branch has at least one reason const/enum.
+- Are these the right invariants for the trust boundary? Specifically:
+  is there any drift mode the test does NOT catch that the original
+  hand-maintained slice DID catch? Trace.
+
+### SEC-2. Escape-hatch abuse
+- `hasReservedMarker` recognizes substrings `FORWARD-COMPAT` or
+  `RESERVED` anywhere in the constant's doc comment. A contributor
+  who wants to silence the unused-detection check can simply paste
+  one of those words into a comment.
+- Is this an actual attack surface? In practice the doc comment is
+  visible in code review, and an unreviewed comment change won't
+  silently land in production. But the marker matching is loose
+  (substring, case-sensitive) — a strict word-boundary check would
+  be more defensible. Recommend.
+- Word-boundary alternative: require the marker as a standalone
+  token (e.g. `(^|\W)(FORWARD-COMPAT|RESERVED)(\W|$)`). Cost: tiny.
+
+### SEC-3. AST walker correctness under malicious input
+- The walker parses real Go source. If a contributor injects code
+  designed to fool the walker — for instance, an iota-based const
+  block with no explicit string value, or a const declared in a
+  build-tagged file that's not part of the default build — does
+  the walker degrade safely (declared map missing the entry,
+  test fails loudly) or silently?
+- The walker DOES NOT respect build tags — it parses every `.go`
+  file regardless of `//go:build` constraints. If a future
+  contributor puts reason constants in a build-tagged file, the
+  walker will count them. Is this the right semantic? (Probably
+  yes — drift should be caught even for build-conditional code.)
+
+### SEC-4. Schema parser surface
+- The schema struct decodes only `oneOf[].properties.reason.{const,
+  enum}`. If a contributor adds an `anyOf` or `if/then/else`
+  construct at the same level, the schema walk silently misses
+  reasons declared there. The current schema layout is fixed at 3
+  `oneOf` branches; would a future SPEC-015 v0.4 wire-shape change
+  break this assumption? Recommend.
+
+### SEC-5. Synthetic-fixture test does not weaken the live test
+- `TestReasonEnumBijection_DetectsDrift` builds synthetic packages
+  via `parser.ParseFile` and constructs a wrapper `*ast.Package`.
+  Confirm this does NOT mock around any of the live test's
+  invariants. The synthetic case calls the SAME
+  `checkReasonEnumBijection` function with synthetic inputs;
+  it does NOT bypass any check.
+
+### SEC-6. No new dependency
+- Imports added: `go/ast`, `go/parser`, `go/token`, `io/fs`,
+  `strconv`, `strings`, `unicode`, `fmt`. All stdlib. No third-
+  party modules. Confirm `go.mod` is unchanged.
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Use CRITICAL/HIGH/MEDIUM/LOW. Write to
+`specs/127_ENUM_AST_SECURITY_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM, end with:
+`VERDICT: security lane READY TO MERGE`

--- a/specs/AUDIT_127_ENUM_AST_SECURITY_R2_PROMPT.md
+++ b/specs/AUDIT_127_ENUM_AST_SECURITY_R2_PROMPT.md
@@ -1,0 +1,62 @@
+# Issue #127 r2 — SECURITY-lane closure audit
+
+You are the **security** lane of the r2 closure audit for issue #127.
+r1 returned 0 CRITICAL/HIGH/MEDIUM and 4 LOWs; LOWs L1–L3 (which the
+code lane graded MEDIUM) are addressed in r2. Stay narrowly in your
+lane.
+
+## r1 security findings → r2 fixes
+
+- **r1 L1** (Duplicate Go reason string values can collapse): fixed
+  via dup detection on the `expected` map build (also graded
+  code-lane M2).
+- **r1 L2** (Non-literal `reasonXxx` constants silently ignored):
+  fixed via explicit `*ast.BasicLit`/string-kind check (also graded
+  code-lane M1).
+- **r1 L3** (Reserved-marker substring match): replaced with a
+  compiled regex that requires non-alphanumeric boundaries on both
+  sides of FORWARD-COMPAT/RESERVED.
+- **r1 L4** (Schema reader tied to 3-branch `oneOf` layout):
+  accepted — the test fails loudly if a future schema revision moves
+  reason values to a different combinator, prompting explicit test
+  update.
+
+## Files in scope (`git diff origin/main` for r2)
+
+- `phase7-verify/internal/verify/enum_drift_test.go` — see r1
+  delta description in `specs/AUDIT_127_ENUM_AST_CODE_R2_PROMPT.md`.
+- `phase7-verify/internal/verify/implementation-notes.md` — new
+  "Reserved-reason convention" subsection documenting the
+  FORWARD-COMPAT/RESERVED marker convention for future contributors.
+
+## Security verification ask
+
+1. Confirm each r1 fix actually closes the drift surface it claimed
+   to close. The original concern was the test design's gap, NOT a
+   live security incident.
+2. Word-boundary regex: does it match what a future contributor
+   would naturally write? E.g. `// FORWARD-COMPAT v0.3+: ...`,
+   `// RESERVED (do not delete)`, `* RESERVED *` at column 0. Any
+   intended marker form that the regex would reject?
+3. The implementation-notes.md doc: does it accurately describe
+   what the test enforces, or could the prose drift from the code?
+4. Are there any drift modes still uncaught? Trace.
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Write to `specs/127_ENUM_AST_SECURITY_R2_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM AND each r1 LOW is either closed or
+explicitly accepted, end with: `VERDICT: security lane r2 READY TO
+MERGE`

--- a/specs/AUDIT_127_ENUM_AST_SECURITY_R3_PROMPT.md
+++ b/specs/AUDIT_127_ENUM_AST_SECURITY_R3_PROMPT.md
@@ -1,0 +1,63 @@
+# Issue #127 r3 — SECURITY-lane closure audit
+
+You are the **security** lane of the r3 closure audit for issue #127.
+r2 graded the reserved-marker regex still permissive (NOT READY TO
+MERGE) — it would silence the unused-constant check on a doc comment
+containing "NOT RESERVED" because space satisfied both word
+boundaries. r3 tightens the marker to require start-of-line anchoring.
+Stay narrowly in your lane.
+
+## r2 finding → r3 fix
+
+- **r2 L1** (Reserved-marker regex still broader than the standalone-
+  token convention): regex changed to
+  `(?m)^\s*(?:[*-]\s+)?(FORWARD-COMPAT|RESERVED)(\W|$)`. New
+  `TestReservedMarkerRE` pins must-reserve vs must-NOT-reserve sets.
+  Doc updated in implementation-notes.md.
+
+## Files in scope (`git diff origin/main` for r3 delta only)
+
+- `phase7-verify/internal/verify/enum_drift_test.go` — regex
+  constant + doc comment + new pinned-contract test.
+- `phase7-verify/internal/verify/implementation-notes.md` — updated
+  "Reserved-reason convention" section.
+
+## Security verification ask
+
+1. Does the new regex close the r2 L1 gap? Test each of these by
+   eye:
+   - `NOT RESERVED` (line-start "NOT" before marker) — must reject.
+   - `DEFINITELY NOT-RESERVED and not FORWARD-COMPATIBLE.` —
+     must reject.
+   - `// NOT FORWARD-COMPAT yet` — must reject.
+   - `FORWARD-COMPAT v0.3+: ...` (live verify.go form) — must accept.
+   - `RESERVED (do not delete)` — must accept.
+   - `* RESERVED *` (list-marker bullet) — must accept.
+   - `\n  - RESERVED for SPEC-016` (indented bullet on second line)
+     — must accept (multi-line mode).
+2. Are there ways an attacker (or accidental contributor) could
+   smuggle the marker past the regex? Consider:
+   - Mixed-case `Reserved` (lowercase fragment) — should fail.
+   - Marker on a CONTINUATION line of a single comment, after
+     leading prose — `// Note: this is\nFORWARD-COMPAT: ...`. The
+     `(?m)` flag should accept this. Is that intended?
+3. Does the doc in implementation-notes.md accurately describe the
+   semantics?
+
+## Output format
+
+```
+CRITICAL (N):
+  C1. <one-line title>
+      Evidence: <file:line>
+      Fix:     <one-sentence fix>
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Write to `specs/127_ENUM_AST_SECURITY_R3_audit.md`.
+
+If 0 CRITICAL/HIGH/MEDIUM AND r2 L1 is closed, end with:
+`VERDICT: security lane r3 READY TO MERGE`


### PR DESCRIPTION
## Summary

Closes #127 — the last `v1.0.1-followup`-labeled issue. (PRs [#174](https://github.com/Augustas11/macprovider/pull/174) / [#178](https://github.com/Augustas11/macprovider/pull/178) closed the others.)

Replaces the hand-maintained 20-entry `expectedReasons` slice in `TestReasonEnumBijection` with an AST walk of the verify package's non-test source. The Go `reasonXxx` string constants are now the single source of truth; the schema is checked against them. SPEC §10.4.2 remains the human-reviewed authority, lock-stepped to the schema via PR review.

Closes the original #127 gap: a contributor adding a `reasonXxx` constant but never referencing it in non-test source now fails the test, unless the constant carries a `FORWARD-COMPAT` or `RESERVED` marker at the start of a line in its doc comment.

## Reserved-reason convention

`TestReservedMarkerRE` pins the marker-recognition contract:

**Accepted forms (line-leading):**
- `// FORWARD-COMPAT v0.3+: reserved for ...` (live form on `reasonBundlePubkeyProviderMismatch`)
- `// RESERVED (do not delete)`
- `// * RESERVED *`
- `// - RESERVED for SPEC-016`

**Rejected forms:**
- `// NOT RESERVED`
- `// DEFINITELY NOT-RESERVED and not FORWARD-COMPATIBLE.`
- `// may someday be RESERVED` (marker not at line start)
- `// intentionally UNRESERVED` (not the marker token)

The convention is documented in `phase7-verify/internal/verify/implementation-notes.md`.

## Drift-detection coverage

`TestReasonEnumBijection_DetectsDrift` exercises 9 scenarios via synthetic in-memory packages:

1. Go constant missing from schema
2. Schema reason missing from Go constants
3. Unused non-reserved constant
4. Unused reserved constant (must pass)
5. Two Go constants with the same wire value
6. Reason constant without explicit value
7. Reason constant with non-string-literal value
8. Negated reserved-marker prose (must NOT silence the check)
9. Go constant in multiple schema branches

## Audit gate

Three rounds of three-lane codex audit (code / security / architect):

| Round | code | security | architect |
|---|---|---|---|
| r1 | 0/0/**2**/1 | 0/0/0/4 | 0/0/0/1 |
| r2 | 0/0/0/1 | 0/0/0/**1 NOT READY** | 0/0/0/0 |
| r3 | 0/0/0/1 | 0/0/0/0 | 0/0/0/0 |

All three lanes returned **READY TO MERGE** at r3. The r3 code-lane LOW (line-leading `RESERVED-LIKE` would still match because `\W` accepts hyphen) is a theoretical edge case below the 0 C/H/M merge bar.

Audit reports: `specs/127_ENUM_AST_{CODE,SECURITY,ARCHITECT}{,_R2,_R3}_audit.md`.

## Test plan

- [x] `go test ./...` in phase7-verify — green
- [x] `go test ./internal/verify -run 'TestReasonEnumBijection|TestReservedMarkerRE|TestIsReasonConstName' -count=1 -v` — 12 subtests + 13 marker forms + 8 name shapes — all PASS
- [x] 3-lane codex audit converged at r3 with all 3 lanes READY TO MERGE

Closes #127
