### PR TITLE
fix(explorer): expose auth_state in provider list + detail (#82 item 4)

### DIFF
--- a/phase4-coordinator/internal/explorer/handlers_test.go
+++ b/phase4-coordinator/internal/explorer/handlers_test.go
@@ -140,6 +140,71 @@ func TestSessionDetailGatewayOnlyReturnsEmptyLocalArrays(t *testing.T) {
 	}
 }
 
+// Test82Item4_ProviderMapExposesAuthState verifies that the explorer
+// admin surface includes the SPEC-003 FR-C9.4 auth_state value for every
+// provider in the list + detail views, so operators can see WHY a
+// session is non-routable (e.g. bearerless_duplicate) without needing to
+// cross-reference /poolz.
+func Test82Item4_ProviderMapExposesAuthState(t *testing.T) {
+	cases := []struct {
+		name      string
+		authState pool.AuthState
+		// What the rendered JSON's "auth_state" field MUST contain.
+		wantJSONFrag string
+	}{
+		{"bearer_validated", pool.AuthBearerValidated, `"auth_state":"bearer_validated"`},
+		{"self_minted", pool.AuthSelfMinted, `"auth_state":"self_minted"`},
+		{"bearerless_duplicate", pool.AuthBearerlessDuplicate, `"auth_state":"bearerless_duplicate"`},
+		{"mint_failed", pool.AuthMintFailed, `"auth_state":"mint_failed"`},
+		{"empty_legacy", pool.AuthState(""), `"auth_state":""`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			h, db := newTestExplorer(t, nil)
+			left, right := net.Pipe()
+			t.Cleanup(func() { _ = left.Close(); _ = right.Close() })
+			providerID := "provider_" + tc.name
+			registry := pool.NewRegistry(nil)
+			registry.Register(&pool.Provider{
+				ProviderID: providerID,
+				AssignedID: "assigned_" + tc.name,
+				ModelID:    "llama",
+				State:      pool.StateReady,
+				SlotsFree:  1,
+				SlotsTotal: 1,
+				AuthState:  tc.authState,
+			}, left)
+			h.pool = registry
+			if _, err := db.ExecContext(context.Background(), `
+insert into provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at)
+values (?, ?, ?, ?, ?)`,
+				"hash-"+tc.name, "tok_"+tc.name, providerID, tc.name, fixedExplorerTime().Format(time.RFC3339Nano)); err != nil {
+				t.Fatalf("seed provider token: %v", err)
+			}
+
+			// List view.
+			respList := requestExplorer(t, h, http.MethodGet, "/admin/explorer/providers", "operator-key")
+			if respList.Code != http.StatusOK {
+				t.Fatalf("list status=%d body=%s", respList.Code, respList.Body.String())
+			}
+			if !strings.Contains(respList.Body.String(), tc.wantJSONFrag) {
+				t.Fatalf("list missing %q: %s", tc.wantJSONFrag, respList.Body.String())
+			}
+
+			// Detail view.
+			respDetail := requestExplorer(t, h, http.MethodGet, "/admin/explorer/providers/"+providerID, "operator-key")
+			if respDetail.Code != http.StatusOK {
+				t.Fatalf("detail status=%d body=%s", respDetail.Code, respDetail.Body.String())
+			}
+			if !strings.Contains(respDetail.Body.String(), tc.wantJSONFrag) {
+				t.Fatalf("detail missing %q: %s", tc.wantJSONFrag, respDetail.Body.String())
+			}
+		})
+	}
+}
+
 func TestAC08_ProviderDirectoryCombinesPoolAndTokenStatus(t *testing.T) {
 	h, db := newTestExplorer(t, nil)
 	left, right := net.Pipe()

--- a/phase4-coordinator/internal/explorer/store.go
+++ b/phase4-coordinator/internal/explorer/store.go
@@ -518,6 +518,12 @@ func providerMap(p pool.Provider, token map[string]any) map[string]any {
 		"encrypted_leg":           p.EncryptedLeg,
 		"token_status":            token["status"],
 		"token_prefix":            token["token_prefix"],
+		// auth_state surfaces WHY a session is (non-)routable per
+		// SPEC-003 FR-C9.4 (#82 item 4). Empty string is the legacy
+		// pre-FR-C9 admit; operators see the same distinct values
+		// /poolz exposes (bearer_validated / self_minted /
+		// bearerless_duplicate / mint_failed).
+		"auth_state": p.AuthState,
 	}
 }
 

--- a/specs/82_ITEM4_ARCHITECT_audit.md
+++ b/specs/82_ITEM4_ARCHITECT_audit.md
@@ -1,0 +1,41 @@
+CRITICAL (0): None.
+
+HIGH (0): None.
+
+MEDIUM (0): None.
+
+LOW (1): SPEC-007 schema hygiene follow-up, non-blocking. The prompt's
+SPEC-002/SPEC-003 conclusion is correct: item 4 does not change the buyer
+wire, provider handshake, `/poolz` contract, or SPEC-003 FR-C9.4 auth-state
+semantics. The explorer exposure is an internal operator/admin projection, so
+duplicating this field into SPEC-002 or SPEC-003 would blur spec ownership.
+However, the repo does have a normative `specs/SPEC-007-explorer.md` for the
+explorer itself, and its provider list schema/privacy-tag table predates
+`auth_state`. Because the implementation is additive, operator-only, and
+directly sourced from live `pool.Provider.AuthState`, this does not block item
+4; a future SPEC-007 hygiene patch can list `auth_state` beside
+`token_status`/`token_prefix` if the explorer contract is refreshed.
+
+QUESTIONS (0): None.
+
+Architect checks:
+- ARCH-1 boundary cleanliness: PASS. `Store.Providers` and
+  `Store.ProviderDetail` both render providers through the shared
+  `providerMap`, so adding `"auth_state": p.AuthState` there is the right
+  architectural boundary. Duplicating the field in list/detail handlers would
+  create drift risk with no compensating isolation.
+- ARCH-2 no SPEC-002/SPEC-003 change: PASS. SPEC-002 v1.4.1 already owns the
+  normative `/poolz auth_state` surface and gateway aggregation rule; SPEC-003
+  FR-C9.4 already owns the auth-state semantics. Item 4 only mirrors that
+  state into the operator explorer projection.
+- ARCH-3 #82 closure criterion: PASS for item-4 merge readiness. Current
+  local evidence shows item 1 shipped via PR #174 and SPEC-002 is v1.4.1 with
+  the `/poolz auth_state` absorption. This branch intentionally carries no
+  sibling SPEC-003 diff; assuming item 3 ships the stated SPEC-003 v0.10.1
+  cross-spec restatement, item 4 adds no remaining architecture dependency.
+- ARCH-4 test depth: PASS. The table covers the four defined `pool.AuthState`
+  constants plus legacy empty string across both list and detail surfaces. That
+  is adequate for a MEDIUM observability fix and pins the shared renderer
+  contract without excessive architectural surface area.
+
+VERDICT: architect lane READY TO MERGE

--- a/specs/82_ITEM4_CODE_audit.md
+++ b/specs/82_ITEM4_CODE_audit.md
@@ -1,0 +1,25 @@
+CRITICAL (0): None.
+
+HIGH (0): None.
+
+MEDIUM (0): None.
+
+LOW (0): None.
+
+QUESTIONS (0): None.
+
+CODE-1: PASS. `Store.Providers` renders each pool snapshot row through `providerMap`, and `Store.ProviderDetail` renders its `"provider"` object through the same `providerMap`, so the one-line addition covers both `/admin/explorer/providers` and `/admin/explorer/providers/{id}`. The value is emitted as `p.AuthState`; `pool.AuthState` is a `string` alias, so Go JSON encoding serializes it as the underlying string literal.
+
+CODE-2: PASS. Always emitting `"auth_state": ""` for legacy zero-value sessions is consistent with this explorer renderer. `providerMap` already unconditionally emits empty-capable fields such as `binary_version`, `hash_status`, `attestation_status`, timestamp strings, token status fields, and other scalar values; it is not using `pool.Provider` struct tags as the explorer JSON contract. For an authenticated operator admin view, explicit empty legacy state is clearer than omission.
+
+CODE-3: PASS. `Test82Item4_ProviderMapExposesAuthState` covers the four named AuthState constants plus the legacy empty string, and checks both list and detail responses. Seeding by calling `pool.Registry.Register(&pool.Provider{AuthState: tc.authState}, conn)` is the right level for this renderer test: `providerMap` consumes the already-registered in-memory `pool.Provider`, while the raw `provider_tokens` row satisfies the existing explorer token-status join. No full admission-flow test is needed for this one-line rendering surface.
+
+CODE-4: PASS. The field was added at the end of the Go map literal, but `encoding/json` sorts map keys deterministically, so wire ordering remains stable and not insertion-order dependent.
+
+CODE-5: PASS. This is an internal operator explorer surface protected by the operator token path. The underlying `auth_state` contract is already specified for `/poolz`/operator observability, and exposing the same in-memory field in the explorer does not create a new external API or require a SPEC update.
+
+Verification:
+- `go test ./internal/explorer -run Test82Item4_ProviderMapExposesAuthState -count=1`
+- `go test ./internal/explorer -count=1`
+
+VERDICT: code lane READY TO MERGE

--- a/specs/82_ITEM4_SECURITY_audit.md
+++ b/specs/82_ITEM4_SECURITY_audit.md
@@ -1,0 +1,21 @@
+CRITICAL (0): None.
+
+HIGH (0): None.
+
+MEDIUM (0): None.
+
+LOW (0): None.
+
+QUESTIONS (0): None.
+
+Security review notes:
+
+- SEC-1 disclosure surface: `auth_state` is a `pool.AuthState` enum/string read from `pool.Provider.AuthState`. The defined values are `bearer_validated`, `self_minted`, `bearerless_duplicate`, `mint_failed`, plus legacy empty string. This does not expose bearer tokens, token hashes, source IPs, or other credential material. The same provider projection already exposes more operationally sensitive identifiers/statuses such as `provider_id`, `assigned_id`, `hostname`, `model_id`, `token_status`, and `token_prefix`, so adding admission-state classification is not a new credential disclosure boundary.
+
+- SEC-2 authorization boundary: `/admin/explorer/providers` and `/admin/explorer/providers/{id}` are dispatched only after `Handler.ServeHTTP` calls `h.authorized(r)`. That helper uses `auth.OperatorOnlyBearerMatches(r.Header, h.cfg.Auth.OperatorKey)`, whose contract is human-admin/operator-only and explicitly denies empty operator keys and gateway service tokens. Item 4 changes only the provider JSON map and tests; no handler routing or auth predicate changed.
+
+- SEC-3 cross-surface consistency: `/poolz` is also operator-only via `Server.handlePoolz` -> `s.authorizedOperator(r)` -> `auth.OperatorOnlyBearerMatches`. Its response embeds `pool.Provider`, whose `AuthState` JSON tag is `auth_state`; therefore `/poolz` already exposes the same field at the same auth tier. Explorer alignment is appropriate because it prevents operators from needing to cross-reference `/poolz` to identify SPEC-003 FR-C9.4 non-routable duplicate sessions.
+
+- SEC-4 no write path: the change is a read-only projection in `providerMap`: `"auth_state": p.AuthState`. `Store.Providers` and `Store.ProviderDetail` receive a pool snapshot/provider, enrich it with token status reads, and serialize JSON. No new mutation, database write, registry update, token minting, or auth-state transition is introduced.
+
+VERDICT: security lane READY TO MERGE

--- a/specs/AUDIT_82_ITEM4_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_82_ITEM4_ARCHITECT_PROMPT.md
@@ -1,0 +1,57 @@
+# Issue #82 item 4 — explorer auth_state exposure — ARCHITECT-lane audit
+
+You are the **architect** lane of a three-lane audit of #82 item 4.
+Stay narrowly in your lane.
+
+## Files in scope (`git diff origin/main`)
+
+- `phase4-coordinator/internal/explorer/store.go` — adds
+  `"auth_state": p.AuthState` to `providerMap`.
+- `phase4-coordinator/internal/explorer/handlers_test.go` — table-
+  driven test.
+
+## Architect-lane scope
+
+### ARCH-1. Boundary cleanliness
+- `providerMap` is the shared rendering function for both list and
+  detail views. The fix is a single-field addition to that map. Is
+  this the right architectural boundary, vs. duplicating in two
+  handlers?
+
+### ARCH-2. No SPEC change
+- The issue body marks item 4 as MEDIUM observability. The
+  explorer surface is not on the SPEC-002/SPEC-003 normative wire;
+  it's an internal admin convenience. The PR ships no SPEC change.
+  Is that the right call?
+- Counter: should SPEC-002 or SPEC-003 normatively document the
+  explorer's `auth_state` field for forward-compatibility? My
+  read: no — the explorer is treated as a debug/admin surface and
+  has no SPEC tier of its own. Confirm.
+
+### ARCH-3. Closing criterion for #82
+- Items 1 (PR #174), 2 (shipped pre-#82-close), 3 (this PR's
+  sibling, item 3), and 4 (this PR) all shipped → #82 closes. The
+  closing criterion in the issue body is "all 4 items shipped +
+  verified. SPEC-002 + SPEC-003 cross-spec consistency restated."
+  Item 1 brought SPEC-002 to v1.4.1; item 3 brings SPEC-003 to
+  v0.10.1. Cross-spec consistency: confirm.
+
+### ARCH-4. Test depth vs item severity
+- Item 4 is MEDIUM. The new test is table-driven across 5
+  AuthState values + 2 surfaces (list + detail) = 10 assertions.
+  Is that adequate, or overkill for a MEDIUM-rated single-line
+  fix? (Probably adequate — the AuthState enum is exhaustive and
+  the test pins the contract.)
+
+## Output format
+
+```
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Write to `specs/82_ITEM4_ARCHITECT_audit.md`. If 0 C/H/M, end with:
+`VERDICT: architect lane READY TO MERGE`

--- a/specs/AUDIT_82_ITEM4_CODE_PROMPT.md
+++ b/specs/AUDIT_82_ITEM4_CODE_PROMPT.md
@@ -1,0 +1,82 @@
+# Issue #82 item 4 — explorer auth_state exposure — CODE-lane audit
+
+You are the **code** lane of a three-lane audit of #82 item 4 — a
+small admin-surface addition exposing `auth_state` in the explorer's
+provider list + detail views. Stay narrowly in your lane.
+
+## Branch / commit
+
+- Branch: `fix/explorer-auth-state-exposure`
+- Worktree: `../macprovider-82-item4-explorer` (origin/main base: 5a233bc)
+- Files in scope (`git diff origin/main`):
+  - `phase4-coordinator/internal/explorer/store.go` — added
+    `"auth_state": p.AuthState` to `providerMap` (line ~520).
+  - `phase4-coordinator/internal/explorer/handlers_test.go` — new
+    `Test82Item4_ProviderMapExposesAuthState` (5 sub-cases:
+    bearer_validated, self_minted, bearerless_duplicate, mint_failed,
+    empty_legacy).
+
+## What this change does (operator summary — NOT the audit answer)
+
+Closes issue #82 item 4 (MEDIUM). The explorer admin surface listed
+providers but omitted `auth_state` from the JSON — operators could
+see a provider in `/poolz` but couldn't see WHY a session was
+non-routable from the explorer. The fix adds `auth_state` to the
+shared `providerMap` so both list (`/admin/explorer/providers`) and
+detail (`/admin/explorer/providers/{id}`) responses include it.
+
+## Code-lane scope
+
+### CODE-1. Single-source-of-truth boundary
+- The change is one line in `providerMap`. `providerMap` is the
+  shared rendering function for both list and detail views, so a
+  single edit covers both surfaces. Confirm.
+- The serialized value is `p.AuthState` directly (a `pool.AuthState`
+  typed string). It JSON-marshals as its underlying string value
+  (bearer_validated / self_minted / bearerless_duplicate /
+  mint_failed / empty).
+
+### CODE-2. Empty-state semantics
+- For pre-FR-C9 sessions the AuthState field is the zero value
+  (empty string). `providerMap` emits `"auth_state": ""` rather
+  than omitting the field. Is that the right choice (always-emit
+  for explorer admin views), or should the rendering use
+  `omitempty`-style suppression to match `pool.Provider`'s JSON
+  tag?
+- The other fields in `providerMap` (e.g. `binary_version`,
+  `hash_status`) are emitted unconditionally even when empty.
+  Confirm consistency.
+
+### CODE-3. Test coverage
+- The new test exercises all 5 distinct AuthState values, asserting
+  both list and detail views surface the field correctly. Is
+  there any scenario the test does not cover?
+- The test seeds a registered provider via `pool.Registry.Register`
+  and a corresponding `provider_tokens` row via raw SQL. The
+  registry call uses `&pool.Provider{... AuthState: tc.authState}`.
+  Confirm this is the right way to set AuthState on a registered
+  Provider (vs. needing to go through the full admission flow).
+
+### CODE-4. JSON ordering / shape stability
+- The added field is at the end of the map. Map key ordering in Go
+  JSON marshal is deterministic (alphabetical), so the on-wire
+  position is unaffected. Confirm.
+
+### CODE-5. No SPEC change
+- The explorer is internal admin surface (operator-only,
+  authenticated by operator token). The issue body explicitly
+  treats item 4 as MEDIUM observability. No SPEC change is
+  required. Confirm.
+
+## Output format
+
+```
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Write to `specs/82_ITEM4_CODE_audit.md`. If 0 C/H/M, end with:
+`VERDICT: code lane READY TO MERGE`

--- a/specs/AUDIT_82_ITEM4_SECURITY_PROMPT.md
+++ b/specs/AUDIT_82_ITEM4_SECURITY_PROMPT.md
@@ -1,0 +1,60 @@
+# Issue #82 item 4 — explorer auth_state exposure — SECURITY-lane audit
+
+You are the **security** lane of a three-lane audit of #82 item 4.
+Stay narrowly in your lane.
+
+## Files in scope (`git diff origin/main`)
+
+- `phase4-coordinator/internal/explorer/store.go` — adds
+  `"auth_state": p.AuthState` to `providerMap`.
+- `phase4-coordinator/internal/explorer/handlers_test.go` — adds
+  test asserting the field appears for every AuthState value.
+
+## Why security cares
+
+The explorer admin surface is operator-only (bearer auth checked at
+the handler layer). Exposing `auth_state` lets operators distinguish
+bearer-validated / self-minted / bearerless-duplicate / mint-failed
+sessions — which is exactly the WHY-non-routable signal SPEC-003
+FR-C9.4 introduced. Without it, an operator might admit a session
+to a deploy pipeline that should have been quarantined.
+
+## Security-lane scope
+
+### SEC-1. Disclosure surface
+- `auth_state` is an enum value (strings: bearer_validated /
+  self_minted / bearerless_duplicate / mint_failed / empty). It
+  carries NO credential material (no token, no hash, no IP). Is
+  this disclosure boundary safe?
+- The explorer surface already discloses `provider_id`,
+  `assigned_id`, `hostname`, `model_id`, `token_prefix`, etc.
+  Adding `auth_state` is strictly less sensitive than the existing
+  surface.
+
+### SEC-2. Authorization boundary
+- The handlers gating this view (`/admin/explorer/providers`) already
+  require operator-level bearer. Confirm no change in
+  authorization is required by the addition.
+
+### SEC-3. Cross-surface consistency
+- The same `auth_state` field is exposed by `/poolz` (operator-only,
+  same auth tier). Item 4 brings the explorer surface in line with
+  `/poolz`. Confirm this is the right cross-surface alignment.
+
+### SEC-4. No write path
+- The explorer surface is read-only. The added field is read from
+  in-memory `pool.Provider.AuthState`; no new write path is
+  introduced. Confirm.
+
+## Output format
+
+```
+CRITICAL (N): ...
+HIGH (N): ...
+MEDIUM (N): ...
+LOW (N): ...
+QUESTIONS (N): ...
+```
+
+Write to `specs/82_ITEM4_SECURITY_audit.md`. If 0 C/H/M, end with:
+`VERDICT: security lane READY TO MERGE`


### PR DESCRIPTION
## Summary

Closes #82 item 4 (MEDIUM observability). Single-line addition to the explorer's `providerMap` so the admin surface includes `auth_state` alongside `token_status` / `token_prefix`.

Before: operators see a provider in `/poolz` with `auth_state=bearerless_duplicate` (non-routable per SPEC-003 FR-C9.4), but the explorer view of the same provider doesn't surface that. They have to cross-reference two endpoints to understand WHY a session is non-routable.

After: explorer list (`/admin/explorer/providers`) AND detail (`/admin/explorer/providers/{id}`) JSON both include `auth_state` per provider. One edit to the shared `providerMap` covers both surfaces.

## Test plan

- [x] New `Test82Item4_ProviderMapExposesAuthState` table-drives all 5 AuthState values (`bearer_validated`, `self_minted`, `bearerless_duplicate`, `mint_failed`, legacy empty string) across both list + detail views — 10 assertions total
- [x] `go test ./...` in phase4-coordinator — green

## No SPEC change

Explorer is internal admin surface. SPEC-002 v1.4.1 already owns the normative `/poolz auth_state` field; SPEC-003 FR-C9.4 owns the auth-state semantics. The explorer mirrors operator-only state.

Architect lane noted a non-blocking SPEC-007 hygiene follow-up (could list `auth_state` alongside `token_status`/`token_prefix` in the explorer SPEC); deferred.

## Audit gate

Three-lane codex audit:

| Lane | C | H | M | L | Verdict |
|---|---|---|---|---|---|
| code | 0 | 0 | 0 | 0 | READY TO MERGE |
| security | 0 | 0 | 0 | 0 | READY TO MERGE |
| architect | 0 | 0 | 0 | 1 | READY TO MERGE (SPEC-007 hygiene non-blocking) |

Audit reports: `specs/82_ITEM4_{CODE,SECURITY,ARCHITECT}_audit.md`.

Closes #82 item 4
