### PR TITLE
fix(coordinator,gateway): align 503 code on 'no_provider_available' (closes #184)

### DIFF
--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1973,7 +1973,7 @@ func (s *Server) attemptTimeout(r *http.Request) time.Duration {
 
 func (s *Server) forwardWS(w http.ResponseWriter, r *http.Request, requestID string, body []byte, provider pool.Provider, stream bool, timeout time.Duration) (wsForwardResult, requestLogAttempt) {
 	if s.relay == nil {
-		writeError(w, http.StatusServiceUnavailable, "provider_unavailable", "Selected provider is not reachable")
+		writeError(w, http.StatusServiceUnavailable, "no_provider_available", "Selected provider is not reachable")
 		return wsForwardUnavailable, requestLogAttempt{Status: http.StatusServiceUnavailable, Error: "Selected provider is not reachable"}
 	}
 	reserved := false
@@ -2001,7 +2001,7 @@ func (s *Server) forwardWS(w http.ResponseWriter, r *http.Request, requestID str
 			if stream {
 				return wsForwardUnavailable, requestLogAttempt{Status: http.StatusServiceUnavailable, Error: "Selected provider is not reachable"}
 			}
-			writeError(w, http.StatusServiceUnavailable, "provider_unavailable", "Selected provider is not reachable")
+			writeError(w, http.StatusServiceUnavailable, "no_provider_available", "Selected provider is not reachable")
 			return wsForwardUnavailable, requestLogAttempt{Status: http.StatusServiceUnavailable, Error: "Selected provider is not reachable"}
 		}
 		if errors.Is(err, providerws.ErrRelayAEADFailed) {
@@ -2136,7 +2136,7 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 				writeError(w, http.StatusBadGateway, "tier2_aead_decrypt_failed", "Provider encrypted response failed authentication")
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider encrypted response failed authentication"}
 			} else if errors.Is(err, providerws.ErrRelayNAKFallback) {
-				writeError(w, http.StatusServiceUnavailable, "provider_unavailable", "Selected provider is not reachable")
+				writeError(w, http.StatusServiceUnavailable, "no_provider_available", "Selected provider is not reachable")
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusServiceUnavailable, Error: "Selected provider is not reachable"}
 			} else {
 				writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
@@ -3402,7 +3402,7 @@ func writeStreamForwardError(w http.ResponseWriter, result wsForwardResult) {
 	case wsForwardTimedOut:
 		writeError(w, http.StatusGatewayTimeout, "provider_timeout", "Selected provider timed out; buyer should retry")
 	case wsForwardUnavailable:
-		writeError(w, http.StatusServiceUnavailable, "provider_unavailable", "Selected provider is not reachable")
+		writeError(w, http.StatusServiceUnavailable, "no_provider_available", "Selected provider is not reachable")
 	case wsForwardProviderDisconnected:
 		writeError(w, http.StatusBadGateway, "provider_disconnected", "Selected provider disconnected; buyer should retry")
 	case wsForwardCancelled, wsForwardProviderDisconnectedCommitted:
@@ -4815,7 +4815,7 @@ func writeWSEndError(w http.ResponseWriter, end providerws.InferenceResponseEnd)
 	case "error_context_exceeded":
 		writeError(w, wsEndHTTPStatus(end.Status), "context_exceeds_capacity", "Request exceeds provider context capacity")
 	case "error_model_not_loaded", "error_queue_full":
-		writeError(w, wsEndHTTPStatus(end.Status), "provider_unavailable", "Selected provider is not reachable")
+		writeError(w, wsEndHTTPStatus(end.Status), "no_provider_available", "Selected provider is not reachable")
 	case "cancelled":
 		return
 	default:

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -291,7 +291,7 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 			return
 		}
 		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
-		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "provider_unavailable", "No provider available")
+		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "no_provider_available", "No provider available")
 		return
 	}
 	if resp.StatusCode == http.StatusGatewayTimeout {
@@ -356,7 +356,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			return
 		}
 		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
-		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "provider_unavailable", "No provider available")
+		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "no_provider_available", "No provider available")
 		return
 	}
 	if resp.StatusCode != http.StatusOK {

--- a/phase5-gateway/internal/router/integration_test.go
+++ b/phase5-gateway/internal/router/integration_test.go
@@ -383,7 +383,7 @@ func TestProviderUnavailableReturns503AndRefunds(t *testing.T) {
 	if resp.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
 	}
-	assertErrorCode(t, resp.Body.String(), "provider_unavailable")
+	assertErrorCode(t, resp.Body.String(), "no_provider_available")
 	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
 	quota := readQuota(t, usageResp)
 	if quota["daily_tokens_used"].(float64) != 0 || quota["daily_tokens_reserved"].(float64) != 0 {


### PR DESCRIPTION
## Summary

Closes #184.

SPEC-002 v1.4.1 FR-B4 (line 1232) and § 7.2 (line 2388) specify `no_provider_available` as the canonical code for 503 zero-provider responses. The codebase had drifted to also emit `provider_unavailable` on the WS-forward / preflight rejection paths — two different strings for the same conceptual case. External buyer clients matching on `error.code` saw inconsistent enums depending on which rejection path fired.

This PR aligns all paths on the canonical `no_provider_available` per FR-B4 and § 7.2. Refs SPEC-002 v1.4.2 R-5 from PR #192.

## Changes

7 string replacements + 1 test assertion update:

- `phase4-coordinator/internal/buyer/server.go`: lines 1924, 1952, 2087, 2726, 3989 — 5 WS-forward / preflight paths.
- `phase5-gateway/internal/router/chat_proxy.go`: lines 254, 319 — 2 gateway propagation paths.
- `phase5-gateway/internal/router/integration_test.go:319` — test now asserts on the canonical string.

The other coordinator paths (server.go: 3122, 3183, 3661, 3704) were already emitting `no_provider_available` per spec, so they're untouched. `phase5-gateway/internal/router/server_test.go:3538` already negates on `"provider_unavailable"` (testing that coord Tier-2 policy errors are NOT remapped); that assertion stays valid since the gateway no longer emits the wrong string at all.

## Test plan

- [x] `go build ./...` clean on both `phase4-coordinator/` and `phase5-gateway/`.
- [x] `go test ./internal/router/ -run "Provider|Unavailable|NoProvider" -count=1` PASS on gateway.
- [x] `go test ./internal/buyer/ -run "Unavailable|NoProvider|Selected" -count=1` PASS on coordinator.
- [x] `grep -rn '"provider_unavailable"' phase4-coordinator/ phase5-gateway/ --include="*.go" | grep -v _test.go` returns zero matches.
- [ ] (After deploy) Live curl probe against a forced WS-forward 503 scenario returns `error.code: "no_provider_available"`.
- [ ] (Follow-up) Phase-C network-harness scenario `02_capacity_contention.yaml` asserts `error_taxonomy` contains only `no_provider_available` (no `provider_unavailable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
