### PR TITLE
fix(coordinator,gateway): propagate buyer X-Request-ID end-to-end (closes #188)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -129,6 +129,20 @@ func main() {
 		os.Exit(1)
 	}
 	defer reqLogStore.Close()
+	// SPEC-002 v1.4.2 R-2 / ISS-188: request_log.external_request_id
+	// is added by OpenStore as an additive column. The matching partial-
+	// NULL index is built asynchronously here: SQLite holds the writer
+	// lock through CREATE INDEX, so doing this inline would stall the
+	// hot path during deploy. A failure here only loses the
+	// reconciliation-side index — INSERTs and the new column still work
+	// — so we log and continue. Repeated calls are idempotent.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		if err := reqLogStore.MigrateIndexes(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "requestlog MigrateIndexes (non-fatal): %v\n", err)
+		}
+	}()
 	canaryStore, err := setupCanarySanctionStore(context.Background(), cfg, reqLogStore.DB(), registry)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "canary sanction storage: %v\n", err)

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -76,6 +76,8 @@ func main() {
 			os.Exit(runPartnerKeys(os.Args[2:]))
 		case "visibility":
 			os.Exit(runVisibility(os.Args[2:]))
+		case "migrate-indexes":
+			os.Exit(runMigrateIndexes(os.Args[2:]))
 		}
 		// Round-1 CODE H1 fix: a non-flag first positional that
 		// is NEITHER a known daemon flag NOR a known CLI verb is
@@ -91,6 +93,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "  coordinator --version           (print build version)")
 			fmt.Fprintln(os.Stderr, "  coordinator partner-keys <issue|revoke|list> [flags]")
 			fmt.Fprintln(os.Stderr, "  coordinator visibility revert --id <pid> --reason TEXT")
+			fmt.Fprintln(os.Stderr, "  coordinator migrate-indexes --config <path>  (one-shot operator migration)")
 			os.Exit(2)
 		}
 	}
@@ -131,18 +134,14 @@ func main() {
 	defer reqLogStore.Close()
 	// SPEC-002 v1.4.2 R-2 / ISS-188: request_log.external_request_id
 	// is added by OpenStore as an additive column. The matching partial-
-	// NULL index is built asynchronously here: SQLite holds the writer
-	// lock through CREATE INDEX, so doing this inline would stall the
-	// hot path during deploy. A failure here only loses the
-	// reconciliation-side index — INSERTs and the new column still work
-	// — so we log and continue. Repeated calls are idempotent.
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
-		if err := reqLogStore.MigrateIndexes(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "requestlog MigrateIndexes (non-fatal): %v\n", err)
-		}
-	}()
+	// NULL reconciliation index is NOT auto-built here — the request-log
+	// store caps the pool at one writer connection (see
+	// requestlog.OpenStore SetMaxOpenConns(1)), so running CREATE INDEX
+	// from the daemon would contend with the 6s-timeout INSERT hot
+	// path. The index ships via the `coordinator migrate-indexes`
+	// subcommand, intended to be invoked once per deploy by the
+	// operator runbook before binding traffic (or during a maintenance
+	// window).
 	canaryStore, err := setupCanarySanctionStore(context.Background(), cfg, reqLogStore.DB(), registry)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "canary sanction storage: %v\n", err)

--- a/phase4-coordinator/cmd/coordinator/migrate_indexes.go
+++ b/phase4-coordinator/cmd/coordinator/migrate_indexes.go
@@ -1,0 +1,60 @@
+package main
+
+// SPEC-002 v1.4.2 R-2 / ISS-188 operator-runbook subcommand:
+//
+//	coordinator migrate-indexes --config <path>
+//
+// One-shot CREATE INDEX for request_log.external_request_id (and any
+// future ensureIndex DDL). Intentionally NOT invoked from the daemon
+// path: the request-log store caps the pool at one writer connection,
+// so running CREATE INDEX inside the daemon would contend with the 6s
+// INSERT timeout on the hot path. Operator runs this once per deploy
+// before re-binding traffic, or during a maintenance window.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/requestlog"
+)
+
+func runMigrateIndexes(args []string) int {
+	return runMigrateIndexesIO(args, os.Stdout, os.Stderr)
+}
+
+func runMigrateIndexesIO(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("migrate-indexes", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configPath := fs.String("config", "coordinator.yaml", "path to coordinator YAML config")
+	timeout := fs.Duration("timeout", 30*time.Minute, "max time the index build may run")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "config: %v\n", err)
+		return 1
+	}
+	store, err := requestlog.OpenStore(cfg.Storage.DBPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "open request_log store: %v\n", err)
+		return 1
+	}
+	defer store.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	started := time.Now()
+	if err := store.MigrateIndexes(ctx); err != nil {
+		fmt.Fprintf(stderr, "MigrateIndexes: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "migrate-indexes ok (%s)\n", time.Since(started).Round(time.Millisecond))
+	return 0
+}

--- a/phase4-coordinator/internal/buyer/billing_recorder.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder.go
@@ -58,6 +58,12 @@ type billingRecorder struct {
 	model     string
 	stream    bool
 	requestID string
+	// externalRequestID is the inbound X-Request-ID per SPEC-002 §11 /
+	// v1.4.2 R-2 — preserved into request_log.external_request_id so
+	// out-of-process auditors can join gateway usage_events with
+	// coordinator request_log by a stable shared id. Empty when the
+	// inbound request carried no X-Request-ID.
+	externalRequestID string
 
 	// attemptN is the running per-provider-attempt counter. Pre-refactor
 	// this was billingAttemptN, incremented via deferred closure on
@@ -70,13 +76,14 @@ type billingRecorder struct {
 // forwardState pointer the sequence helpers will mutate; the recorder
 // reads state.routingDone at write time to compute RoutingMs (matching
 // the pre-refactor closure's live-capture semantics).
-func (s *Server) newBillingRecorder(r *http.Request, state *forwardState, startedAt time.Time, requestID string) *billingRecorder {
+func (s *Server) newBillingRecorder(r *http.Request, state *forwardState, startedAt time.Time, requestID, externalRequestID string) *billingRecorder {
 	return &billingRecorder{
-		server:    s,
-		state:     state,
-		req:       r,
-		startedAt: startedAt,
-		requestID: requestID,
+		server:            s,
+		state:             state,
+		req:               r,
+		startedAt:         startedAt,
+		requestID:         requestID,
+		externalRequestID: externalRequestID,
 	}
 }
 
@@ -137,6 +144,7 @@ func (b *billingRecorder) recordRow(
 	row := requestlog.Row{
 		TSUtc:               b.startedAt,
 		RequestID:           b.requestID,
+		ExternalRequestID:   b.externalRequestID,
 		Model:               b.model,
 		ProviderAssignedID:  providerAssignedID,
 		PromptTokens:        promptTok,

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1246,7 +1246,7 @@ type chatMessage struct {
 }
 
 func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
-	externalRequestID := strings.TrimSpace(r.Header.Get("X-Request-ID"))
+	externalRequestID := sanitizeExternalRequestID(r.Header.Get("X-Request-ID"))
 	requestID := requestIDForBuyerRequest()
 	routingRequestID := uuid.NewString()
 	originalRequestID := requestID
@@ -1266,7 +1266,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// setRequestID land before the first provider-bound recordRow call,
 	// preserving the pre-refactor closure's "latest value at fire time"
 	// semantics for what used to be captured outer-scope variables.
-	rec := s.newBillingRecorder(r, state, startedAt, originalRequestID)
+	rec := s.newBillingRecorder(r, state, startedAt, originalRequestID, externalRequestID)
 	maxBodyBytes := s.maxChatBodyBytes
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes+1))
 	if err != nil {
@@ -4057,6 +4057,37 @@ func normalizeIdempotencyKey(value string) string {
 	}
 	for _, r := range value {
 		if r < 0x21 || r > 0x7e {
+			return ""
+		}
+	}
+	return value
+}
+
+// sanitizeExternalRequestID normalizes the inbound X-Request-ID header
+// for persistent storage in request_log.external_request_id. SPEC-002
+// §11 requires the coordinator to "honor any inbound X-Request-ID";
+// this honoring is bounded by defense-in-depth:
+//
+//   - Trim surrounding whitespace.
+//   - Cap at 128 bytes (UUID v4 is 36; allowing for vendor-prefixed
+//     ids like "req_<48hex>" gives reasonable headroom without
+//     unbounded growth).
+//   - Reject control characters (< 0x20, 0x7f, and the C1 range
+//     0x80-0x9f) to keep the value safe for structured logs and DB
+//     storage.
+//
+// On failure, returns "" — the coordinator treats the value as if no
+// header was present, which is allowed by §11 ("If absent, coordinator
+// MAY generate its own UUID v4"). The malformed header is not
+// surfaced to the buyer; logging it as-is would replay any
+// log-injection payload.
+func sanitizeExternalRequestID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 128 {
+		return ""
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
 			return ""
 		}
 	}

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -1147,6 +1147,25 @@ func TestRequestLogBuyerPinnedClientRequestIDDoesNotReuseBillingID(t *testing.T)
 			t.Fatalf("request_log rows for %s = %d, want 1: %#v", id, len(rows), rows)
 		}
 	}
+	// SPEC-002 v1.4.2 R-2: external_request_id MUST equal the inbound
+	// X-Request-ID on EVERY row of one logical request, **regardless of
+	// pinning** (i.e., even when per-row request_id differs). This test
+	// covers the pinned-retry-shape branch: each row carries a distinct
+	// coordinator-generated request_id (asserted above via
+	// providerRequestIDs[0] != providerRequestIDs[1]) yet both rows must
+	// carry the same external_request_id.
+	allRows := queryAllRequestLogRows(t, dbPath)
+	if len(allRows) != 2 {
+		t.Fatalf("queryAllRequestLogRows = %d rows, want 2", len(allRows))
+	}
+	for i, row := range allRows {
+		if !row.ExternalRequestID.Valid || row.ExternalRequestID.String != clientRequestID {
+			t.Fatalf("row[%d] external_request_id = %#v, want %q", i, row.ExternalRequestID, clientRequestID)
+		}
+	}
+	if allRows[0].RequestID == allRows[1].RequestID {
+		t.Fatalf("guarded invariant broken: expected distinct request_id per row, got %q twice", allRows[0].RequestID)
+	}
 }
 
 // SPEC-002 v1.4.2 R-2 / §11 + issue #188: when an inbound buyer

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -1149,6 +1149,146 @@ func TestRequestLogBuyerPinnedClientRequestIDDoesNotReuseBillingID(t *testing.T)
 	}
 }
 
+// SPEC-002 v1.4.2 R-2 / §11 + issue #188: when an inbound buyer
+// request carries an X-Request-ID header, the coordinator MUST store
+// that value in request_log.external_request_id on every row that
+// covers the logical request (success row + any retry rows). This is
+// the reconciliation join-key shared with gateway usage_events.
+// request_log.request_id continues to be the coordinator's per-attempt
+// internal id (unchanged behavior); SPEC-002 v1.4.2 names the inbound
+// header value as external_request_id specifically to avoid disturbing
+// the per-attempt-unique invariant the existing test suite verifies.
+func TestRequestLogPreservesInboundXRequestIDAcrossAttempts(t *testing.T) {
+	const externalID = "55555555-5555-4555-8555-555555555555"
+	failUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer failUpstream.Close()
+	okUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`))
+	}))
+	defer okUpstream.Close()
+
+	reqLog, dbPath := openBuyerRequestLog(t)
+	defer reqLog.Close()
+	registry := pool.NewRegistry([]config.ProviderConfig{
+		{ProviderID: "fail", EndpointURL: failUpstream.URL},
+		{ProviderID: "ok", EndpointURL: okUpstream.URL},
+	})
+	registerWithEndpoint(registry, "fail", "s1", "model-a", pool.StateReady, 20000, 1, failUpstream.URL, 30)
+	registerWithEndpoint(registry, "ok", "s2", "model-a", pool.StateReady, 20000, 1, okUpstream.URL, 20)
+	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0),
+		buyer.WithRequestLog(reqLog),
+		buyer.WithRoutingConfig(config.RoutingConfig{
+			MaxRetries:              1,
+			RetryPerAttemptTimeoutS: 1,
+			StickyTTLS:              1800,
+			StickyMaxEntries:        10000,
+		}),
+	)
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}]}`), http.Header{
+		"X-MacProvider-Retry": []string{"1"},
+		"X-Request-ID":        []string{externalID},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	rows := queryAllRequestLogRows(t, dbPath)
+	if len(rows) != 2 {
+		t.Fatalf("request_log rows = %d, want 2 (fail + ok attempt): %#v", len(rows), rows)
+	}
+	for i, row := range rows {
+		if !row.ExternalRequestID.Valid || row.ExternalRequestID.String != externalID {
+			t.Fatalf("row[%d] external_request_id = %#v, want %q", i, row.ExternalRequestID, externalID)
+		}
+		// Existing invariant preserved: per-attempt request_id is coord-generated
+		// and MUST NOT equal the buyer's X-Request-ID.
+		if row.RequestID == externalID {
+			t.Fatalf("row[%d] request_id == buyer X-Request-ID; should be coord-generated", i)
+		}
+	}
+	// In the non-pinned retry path (this test), both attempt rows share
+	// the SAME coord-generated request_id (see existing
+	// TestRequestLogBuyerMultiAttemptRows at line ~1093). The shared
+	// external_request_id above is the property new to v1.4.2.
+	if rows[0].RequestID != rows[1].RequestID {
+		t.Fatalf("non-pinned retry rows should share request_id; got %q vs %q", rows[0].RequestID, rows[1].RequestID)
+	}
+}
+
+// When the inbound request carries NO X-Request-ID, the coordinator
+// MUST still log a row but external_request_id is NULL (empty
+// sql.NullString). Existing buyer flows that omit the header remain
+// observable.
+// Malformed inbound X-Request-ID headers (control characters,
+// over-128 bytes) MUST be rejected at the handler boundary and stored
+// as NULL, not passed through to the persistent log column.
+// Defense-in-depth per the codex security-lane audit (ISS-188 R1).
+// The inbound header is buyer-controllable; an empty / NULL
+// external_request_id loses the reconciliation join for this row but
+// keeps malformed payloads out of structured logs and DB rows.
+func TestRequestLogExternalRequestIDRejectsMalformedHeader(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`))
+	}))
+	defer upstream.Close()
+
+	for name, badHeader := range map[string]string{
+		"control_null": "req-\x00abc",
+		"control_lf":   "req-\nabc",
+		"del_char":     "req-\x7fabc",
+		"over_128":     strings.Repeat("a", 129),
+	} {
+		t.Run(name, func(t *testing.T) {
+			reqLog, dbPath := openBuyerRequestLog(t)
+			defer reqLog.Close()
+			registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: upstream.URL}})
+			registerWithEndpoint(registry, "p1", "s1", "model-a", pool.StateReady, 20000, 1, upstream.URL, 20)
+			server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0), buyer.WithRequestLog(reqLog))
+
+			rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}]}`),
+				http.Header{"X-Request-ID": []string{badHeader}})
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+			}
+			rows := queryAllRequestLogRows(t, dbPath)
+			if len(rows) != 1 {
+				t.Fatalf("rows=%d want 1: %#v", len(rows), rows)
+			}
+			if rows[0].ExternalRequestID.Valid {
+				t.Fatalf("malformed inbound header persisted as %#v; want NULL",
+					rows[0].ExternalRequestID)
+			}
+		})
+	}
+}
+
+func TestRequestLogExternalRequestIDNullWhenHeaderAbsent(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`))
+	}))
+	defer upstream.Close()
+	reqLog, dbPath := openBuyerRequestLog(t)
+	defer reqLog.Close()
+	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: upstream.URL}})
+	registerWithEndpoint(registry, "p1", "s1", "model-a", pool.StateReady, 20000, 1, upstream.URL, 20)
+	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0), buyer.WithRequestLog(reqLog))
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}]}`), nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	rows := queryAllRequestLogRows(t, dbPath)
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d want 1: %#v", len(rows), rows)
+	}
+	if rows[0].ExternalRequestID.Valid {
+		t.Fatalf("external_request_id = %#v, want NULL", rows[0].ExternalRequestID)
+	}
+}
+
 func TestSuccessfulNonStreamingBillingClampsInflatedProviderCompletion(t *testing.T) {
 	responseBody := []byte(`{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":4,"completion_tokens":10000000,"total_tokens":10000004}}`)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4221,6 +4361,7 @@ func deadMidInferenceRelay(ctx context.Context, provider pool.Provider, requestI
 type requestLogTestRow struct {
 	ID                 int64
 	RequestID          string
+	ExternalRequestID  sql.NullString
 	Model              string
 	ProviderAssignedID sql.NullString
 	PromptTokens       sql.NullInt64
@@ -4248,8 +4389,8 @@ func queryRequestLogRows(t *testing.T, dbPath, requestID string) []requestLogTes
 	}
 	defer db.Close()
 	rows, err := db.Query(`
-SELECT id, request_id, model, provider_assigned_id, prompt_tokens,
-       completion_tokens, status, error_code, retried
+SELECT id, request_id, external_request_id, model, provider_assigned_id,
+       prompt_tokens, completion_tokens, status, error_code, retried
 FROM request_log
 WHERE request_id = ?
 ORDER BY id ASC`, requestID)
@@ -4263,6 +4404,7 @@ ORDER BY id ASC`, requestID)
 		if err := rows.Scan(
 			&row.ID,
 			&row.RequestID,
+			&row.ExternalRequestID,
 			&row.Model,
 			&row.ProviderAssignedID,
 			&row.PromptTokens,
@@ -4289,8 +4431,8 @@ func queryAllRequestLogRows(t *testing.T, dbPath string) []requestLogTestRow {
 	}
 	defer db.Close()
 	rows, err := db.Query(`
-SELECT id, request_id, model, provider_assigned_id, prompt_tokens,
-       completion_tokens, status, error_code, retried
+SELECT id, request_id, external_request_id, model, provider_assigned_id,
+       prompt_tokens, completion_tokens, status, error_code, retried
 FROM request_log
 ORDER BY id ASC`)
 	if err != nil {
@@ -4303,6 +4445,7 @@ ORDER BY id ASC`)
 		if err := rows.Scan(
 			&row.ID,
 			&row.RequestID,
+			&row.ExternalRequestID,
 			&row.Model,
 			&row.ProviderAssignedID,
 			&row.PromptTokens,

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -403,18 +403,39 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 
 // ensureIndexes creates request_log indexes that depend on
 // ensureColumns having already added their underlying columns.
-// CREATE INDEX IF NOT EXISTS is idempotent; we don't gate by an
-// existence check because index existence isn't tracked alongside
-// columns (PRAGMA table_info doesn't list indexes).
+//
+// We probe sqlite_master first so the write lock + table scan that
+// `CREATE INDEX` triggers is paid exactly once per coordinator deploy
+// lifetime, not on every process restart. `CREATE INDEX IF NOT EXISTS`
+// is idempotent but still acquires a write lock and inspects the table
+// to confirm the existing index matches — on a large request_log that
+// would stall every restart for the duration of the scan. The gating
+// query is a cheap point read against sqlite_master.
 func (s *Store) ensureIndexes(ctx context.Context) error {
-	for _, ddl := range []string{
-		// SPEC-002 v1.4.2 R-2: reconciliation scans join gateway
-		// usage_events to request_log on external_request_id; the
-		// partial-NULL index keeps the index small (legacy rows have
-		// NULL and are not indexed).
-		`CREATE INDEX IF NOT EXISTS idx_request_log_external_request_id ON request_log(external_request_id) WHERE external_request_id IS NOT NULL`,
-	} {
-		if _, err := s.db.ExecContext(ctx, ddl); err != nil {
+	// SPEC-002 v1.4.2 R-2: reconciliation scans join gateway
+	// usage_events to request_log on external_request_id; the
+	// partial-NULL index keeps the index small (legacy rows have
+	// NULL and are not indexed).
+	indexes := []struct {
+		name string
+		ddl  string
+	}{
+		{
+			name: "idx_request_log_external_request_id",
+			ddl:  `CREATE INDEX idx_request_log_external_request_id ON request_log(external_request_id) WHERE external_request_id IS NOT NULL`,
+		},
+	}
+	for _, ix := range indexes {
+		var existing string
+		switch err := s.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='index' AND name=?`, ix.name).Scan(&existing); err {
+		case nil:
+			continue
+		case sql.ErrNoRows:
+			// fall through and create
+		default:
+			return err
+		}
+		if _, err := s.db.ExecContext(ctx, ix.ddl); err != nil {
 			return err
 		}
 	}

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -406,13 +406,18 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 // MigrateIndexes builds the request_log indexes whose underlying
 // columns ensureColumns has already added.
 //
-// Intentionally NOT called from OpenStore. SQLite has no concurrent
-// index build; CREATE INDEX takes the writer lock and table-scans the
-// underlying table. Running it inside OpenStore would block the hot
-// path during process startup. Callers SHOULD invoke MigrateIndexes
-// asynchronously after startup completes (e.g., a goroutine in main)
-// so the deploy is not gated on the scan. Repeated calls are cheap:
-// a sqlite_master point lookup decides whether the DDL runs at all.
+// Intentionally NOT called from OpenStore, nor from a goroutine in
+// the coordinator daemon. SQLite has no concurrent index build;
+// CREATE INDEX takes the writer lock and table-scans the underlying
+// table, and the request-log store caps the SQL pool at one writer
+// connection (see SetMaxOpenConns(1) in OpenStore), so any in-daemon
+// invocation would starve the 6s-timeout INSERT hot path. The
+// supported invocation path is the operator subcommand `coordinator
+// migrate-indexes`, run once per deploy before binding traffic or
+// during a maintenance window — see
+// phase4-coordinator/cmd/coordinator/migrate_indexes.go. Repeated
+// calls are cheap: a sqlite_master point lookup decides whether the
+// DDL runs at all.
 func (s *Store) MigrateIndexes(ctx context.Context) error {
 	// SPEC-002 v1.4.2 R-2: reconciliation scans join gateway
 	// usage_events to request_log on external_request_id; the

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -25,10 +25,19 @@ type execer interface {
 }
 
 type Row struct {
-	TSUtc               time.Time
-	RequestID           string
-	Model               string
-	ProviderAssignedID  string
+	TSUtc time.Time
+	// RequestID is the coordinator's per-attempt identifier (one row per
+	// provider attempt). Generated internally; not equal to whatever the
+	// inbound X-Request-ID was.
+	RequestID string
+	// ExternalRequestID is the inbound X-Request-ID header value (per
+	// SPEC-002 §11). Shared across all rows for one logical request and
+	// across the gateway's usage_events.request_id for the same logical
+	// request, enabling end-to-end billing reconciliation. Empty when
+	// the inbound request carried no X-Request-ID.
+	ExternalRequestID string
+	Model             string
+	ProviderAssignedID string
 	PromptTokens        *int64
 	CompletionTokens    *int64
 	EstimatedCompTokens *int64
@@ -107,6 +116,7 @@ CREATE TABLE IF NOT EXISTS request_log (
     id                   INTEGER PRIMARY KEY AUTOINCREMENT,
     ts_utc               TEXT    NOT NULL,
     request_id           TEXT    NOT NULL,
+    external_request_id  TEXT    NULL,
     model                TEXT    NOT NULL,
     provider_assigned_id TEXT    NULL,
     prompt_tokens        INTEGER NULL,
@@ -128,6 +138,13 @@ CREATE INDEX IF NOT EXISTS idx_request_log_ts_utc
     ON request_log(ts_utc);
 CREATE INDEX IF NOT EXISTS idx_request_log_request_id_id
     ON request_log(request_id, id);
+-- Index for SPEC-002 v1.4.2 R-2 reconciliation scans (column added
+-- in ensureColumns; index also created from there) is NOT issued in
+-- the inline schema block — on a pre-existing DB the table won't have
+-- the column yet at this point in execution, so CREATE INDEX would
+-- reference a non-existent column. ensureColumns runs ALTER TABLE
+-- ADD COLUMN and CREATE INDEX in order, which works for both fresh
+-- DBs and legacy upgrades.
 
 CREATE TABLE IF NOT EXISTS request_idempotency_keys (
     idempotency_key TEXT PRIMARY KEY,
@@ -300,6 +317,7 @@ func insert(ctx context.Context, db execer, row Row) error {
 INSERT INTO request_log (
     ts_utc,
     request_id,
+    external_request_id,
     model,
     provider_assigned_id,
     prompt_tokens,
@@ -316,9 +334,10 @@ INSERT INTO request_log (
     pref_header,
     provider_header,
     retried
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		row.TSUtc.UTC().Format(time.RFC3339Nano),
 		row.RequestID,
+		nullString(row.ExternalRequestID),
 		row.Model,
 		nullString(row.ProviderAssignedID),
 		nullInt64(row.PromptTokens),
@@ -363,6 +382,11 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 		{name: "pref_header", sql: `ALTER TABLE request_log ADD COLUMN pref_header TEXT NULL`},
 		{name: "provider_header", sql: `ALTER TABLE request_log ADD COLUMN provider_header TEXT NULL`},
 		{name: "retried", sql: `ALTER TABLE request_log ADD COLUMN retried INTEGER NOT NULL DEFAULT 0`},
+		// SPEC-002 v1.4.2 R-2 / §11: inbound X-Request-ID, the
+		// reconciliation join-key shared with gateway usage_events.
+		// Pre-existing rows scan as NULL; new INSERTs carry the
+		// gateway-forwarded id when present.
+		{name: "external_request_id", sql: `ALTER TABLE request_log ADD COLUMN external_request_id TEXT NULL`},
 	} {
 		if cols[migration.name] {
 			continue
@@ -371,7 +395,30 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 			return err
 		}
 	}
-	return s.requireColumns(ctx, []string{"id", "ts_utc", "request_id", "model"})
+	if err := s.requireColumns(ctx, []string{"id", "ts_utc", "request_id", "model"}); err != nil {
+		return err
+	}
+	return s.ensureIndexes(ctx)
+}
+
+// ensureIndexes creates request_log indexes that depend on
+// ensureColumns having already added their underlying columns.
+// CREATE INDEX IF NOT EXISTS is idempotent; we don't gate by an
+// existence check because index existence isn't tracked alongside
+// columns (PRAGMA table_info doesn't list indexes).
+func (s *Store) ensureIndexes(ctx context.Context) error {
+	for _, ddl := range []string{
+		// SPEC-002 v1.4.2 R-2: reconciliation scans join gateway
+		// usage_events to request_log on external_request_id; the
+		// partial-NULL index keeps the index small (legacy rows have
+		// NULL and are not indexed).
+		`CREATE INDEX IF NOT EXISTS idx_request_log_external_request_id ON request_log(external_request_id) WHERE external_request_id IS NOT NULL`,
+	} {
+		if _, err := s.db.ExecContext(ctx, ddl); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Store) columns(ctx context.Context) (map[string]bool, error) {

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -26,9 +26,14 @@ type execer interface {
 
 type Row struct {
 	TSUtc time.Time
-	// RequestID is the coordinator's per-attempt identifier (one row per
-	// provider attempt). Generated internally; not equal to whatever the
-	// inbound X-Request-ID was.
+	// RequestID is the coordinator-generated request/billing id. Always
+	// internally generated; NEVER equal to the inbound X-Request-ID. On the
+	// non-pinned retry path multiple request_log rows for one logical
+	// buyer request share this value (verified by
+	// TestRequestLogBuyerMultiAttemptRows). On the pinned-client retry
+	// path successive rows carry distinct request_ids (verified by
+	// TestRequestLogBuyerPinnedClientRequestIDDoesNotReuseBillingID).
+	// Attempt identity is `id` (auto-increment PK) plus `retried`.
 	RequestID string
 	// ExternalRequestID is the inbound X-Request-ID header value (per
 	// SPEC-002 §11). Shared across all rows for one logical request and
@@ -395,23 +400,20 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := s.requireColumns(ctx, []string{"id", "ts_utc", "request_id", "model"}); err != nil {
-		return err
-	}
-	return s.ensureIndexes(ctx)
+	return s.requireColumns(ctx, []string{"id", "ts_utc", "request_id", "model"})
 }
 
-// ensureIndexes creates request_log indexes that depend on
-// ensureColumns having already added their underlying columns.
+// MigrateIndexes builds the request_log indexes whose underlying
+// columns ensureColumns has already added.
 //
-// We probe sqlite_master first so the write lock + table scan that
-// `CREATE INDEX` triggers is paid exactly once per coordinator deploy
-// lifetime, not on every process restart. `CREATE INDEX IF NOT EXISTS`
-// is idempotent but still acquires a write lock and inspects the table
-// to confirm the existing index matches — on a large request_log that
-// would stall every restart for the duration of the scan. The gating
-// query is a cheap point read against sqlite_master.
-func (s *Store) ensureIndexes(ctx context.Context) error {
+// Intentionally NOT called from OpenStore. SQLite has no concurrent
+// index build; CREATE INDEX takes the writer lock and table-scans the
+// underlying table. Running it inside OpenStore would block the hot
+// path during process startup. Callers SHOULD invoke MigrateIndexes
+// asynchronously after startup completes (e.g., a goroutine in main)
+// so the deploy is not gated on the scan. Repeated calls are cheap:
+// a sqlite_master point lookup decides whether the DDL runs at all.
+func (s *Store) MigrateIndexes(ctx context.Context) error {
 	// SPEC-002 v1.4.2 R-2: reconciliation scans join gateway
 	// usage_events to request_log on external_request_id; the
 	// partial-NULL index keeps the index small (legacy rows have

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -143,13 +143,13 @@ CREATE INDEX IF NOT EXISTS idx_request_log_ts_utc
     ON request_log(ts_utc);
 CREATE INDEX IF NOT EXISTS idx_request_log_request_id_id
     ON request_log(request_id, id);
--- Index for SPEC-002 v1.4.2 R-2 reconciliation scans (column added
--- in ensureColumns; index also created from there) is NOT issued in
--- the inline schema block — on a pre-existing DB the table won't have
--- the column yet at this point in execution, so CREATE INDEX would
--- reference a non-existent column. ensureColumns runs ALTER TABLE
--- ADD COLUMN and CREATE INDEX in order, which works for both fresh
--- DBs and legacy upgrades.
+-- SPEC-002 v1.4.2 R-2 reconciliation scans want an index on
+-- request_log.external_request_id. The column is added by
+-- ensureColumns (additive ALTER TABLE, cheap). The matching partial-
+-- NULL index is built by MigrateIndexes, invoked via the operator-
+-- runbook subcommand "coordinator migrate-indexes" — NOT from the
+-- daemon startup path, because SQLite has no concurrent index build
+-- and the request-log store caps the pool at one writer connection.
 
 CREATE TABLE IF NOT EXISTS request_idempotency_keys (
     idempotency_key TEXT PRIMARY KEY,

--- a/phase4-coordinator/internal/requestlog/store_test.go
+++ b/phase4-coordinator/internal/requestlog/store_test.go
@@ -382,6 +382,26 @@ CREATE TABLE request_log (
 	if err != nil {
 		t.Fatalf("seed old schema: %v", err)
 	}
+	// Seed a row INTO the old schema (no external_request_id column),
+	// directly via raw SQL — this is the actual pre-migration row the
+	// assertion below verifies. Insert via store.Insert (after OpenStore)
+	// would be post-migration and wouldn't test the legacy path.
+	if _, err := db.Exec(`
+INSERT INTO request_log (
+    ts_utc, request_id, model, provider_assigned_id,
+    prompt_tokens, completion_tokens, total_tokens,
+    latency_ms, routing_ms, status, stream,
+    buyer_ip, error, pref_header, provider_header, retried
+) VALUES (?, ?, ?, ?, NULL, NULL, NULL, 0, 0, ?, 0, ?, NULL, NULL, NULL, 0)`,
+		time.Now().UTC().Format(time.RFC3339Nano),
+		"req-pre-migration",
+		"model-a",
+		"session-pre",
+		200,
+		"127.0.0.1",
+	); err != nil {
+		t.Fatalf("seed pre-migration row: %v", err)
+	}
 	_ = db.Close()
 
 	store, err := OpenStore(dbPath)
@@ -407,11 +427,41 @@ CREATE TABLE request_log (
 	if !errorCode.Valid || errorCode.String != "error_internal" {
 		t.Fatalf("error_code = %#v, want error_internal", errorCode)
 	}
-	for _, name := range []string{"idx_request_log_ts_utc", "idx_request_log_request_id_id"} {
+	for _, name := range []string{"idx_request_log_ts_utc", "idx_request_log_request_id_id", "idx_request_log_external_request_id"} {
 		var got string
 		if err := store.db.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?`, name).Scan(&got); err != nil {
 			t.Fatalf("index %s missing: %v", name, err)
 		}
+	}
+	// SPEC-002 v1.4.2 R-2: the row inserted INTO the old schema above
+	// predates external_request_id; a SELECT after migration MUST
+	// return NULL (not an error and not a garbage default) so the
+	// reconciliation join (gateway.usage_events.request_id =
+	// coord.request_log.external_request_id) cleanly skips legacy
+	// rows instead of false-matching them.
+	var migrated sql.NullString
+	if err := store.db.QueryRow(`SELECT external_request_id FROM request_log WHERE request_id = ?`, "req-pre-migration").Scan(&migrated); err != nil {
+		t.Fatalf("query external_request_id on pre-migration row: %v", err)
+	}
+	if migrated.Valid {
+		t.Fatalf("pre-migration row external_request_id = %#v, want NULL", migrated)
+	}
+	// A fresh insert with ExternalRequestID set MUST persist the value.
+	if err := store.Insert(context.Background(), Row{
+		TSUtc:             time.Now().UTC(),
+		RequestID:         "req-fresh",
+		ExternalRequestID: "55555555-5555-4555-8555-555555555555",
+		Model:             "model-a",
+		Status:            200,
+	}); err != nil {
+		t.Fatalf("insert fresh row with external_request_id: %v", err)
+	}
+	var fresh sql.NullString
+	if err := store.db.QueryRow(`SELECT external_request_id FROM request_log WHERE request_id = ?`, "req-fresh").Scan(&fresh); err != nil {
+		t.Fatalf("query external_request_id on fresh row: %v", err)
+	}
+	if !fresh.Valid || fresh.String != "55555555-5555-4555-8555-555555555555" {
+		t.Fatalf("fresh external_request_id = %#v, want UUID", fresh)
 	}
 }
 

--- a/phase4-coordinator/internal/requestlog/store_test.go
+++ b/phase4-coordinator/internal/requestlog/store_test.go
@@ -405,6 +405,14 @@ INSERT INTO request_log (
 	_ = db.Close()
 
 	store, err := OpenStore(dbPath)
+	// SPEC-002 v1.4.2 R-2 / ISS-188 R4 audit: OpenStore is column-only;
+	// the partial-NULL index ships via MigrateIndexes invoked from main.
+	// Tests asserting index presence call it synchronously here.
+	if err == nil {
+		if mErr := store.MigrateIndexes(context.Background()); mErr != nil {
+			t.Fatalf("MigrateIndexes: %v", mErr)
+		}
+	}
 	if err != nil {
 		t.Fatalf("open migrated store: %v", err)
 	}

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -199,7 +199,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 	copyForwardHeaders(upReq.Header, r.Header)
 	upReq.Header.Set("Content-Type", "application/json")
-	upReq.Header.Set("X-Request-ID", newUUID())
+	// SPEC-002 §11 + v1.4.2 R-2: forward the gateway-visible request id
+	// (which itself was honored from the buyer's inbound X-Request-ID
+	// when present, else minted by the gateway middleware) so the
+	// coordinator can store it in request_log.external_request_id and
+	// out-of-process auditors can join gateway usage_events with
+	// coordinator request_log on this shared id. Earlier code minted a
+	// fresh UUID here, breaking that join.
+	upReq.Header.Set("X-Request-ID", requestID(r))
 	if s.cfg.Routing.StickyEnabled && !authn.Demo {
 		if tag := strings.TrimSpace(r.Header.Get("X-MacProvider-Conversation")); tag != "" {
 			if !validConversationTag(tag) {

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -252,7 +252,11 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "coordinator_unavailable", "Coordinator unavailable")
 		return
 	}
-	upReq.Header.Set("X-Request-ID", newUUID())
+	// SPEC-006 v0.X R-G2 / SPEC-002 v1.4.2 R-2: gateway forwards the
+	// buyer-visible request id verbatim so the coordinator's
+	// request_log.external_request_id matches the gateway's
+	// usage_events.request_id on a per-request basis.
+	upReq.Header.Set("X-Request-ID", requestID(r))
 	resp, err := s.client.Do(upReq)
 	if err != nil {
 		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "coordinator_unavailable", "Coordinator unavailable")
@@ -354,7 +358,10 @@ func (s *Server) handleStickyDelete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "coordinator_unavailable", "Coordinator unavailable")
 		return
 	}
-	upReq.Header.Set("X-Request-ID", newUUID())
+	// SPEC-006 v0.X R-G2: gateway forwards the buyer-visible request id
+	// on every forwarded buyer-facing request so the coordinator
+	// audit log joins to gateway usage on a single key.
+	upReq.Header.Set("X-Request-ID", requestID(r))
 	// M3-2 / SECU-4: prefer ServiceToken when set; falls back to
 	// OperatorKey so a not-yet-upgraded coordinator keeps accepting us.
 	upReq.Header.Set("Authorization", "Bearer "+s.cfg.Coordinator.UpstreamCoordinatorBearer())

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -359,8 +359,11 @@ func (s *Server) handleStickyDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// SPEC-006 v0.X R-G3: gateway forwards the buyer-visible request id
-	// on every forwarded buyer-facing request so the coordinator
-	// audit log joins to gateway usage on a single key.
+	// on every forwarded buyer-facing coordinator call. /v1/sticky is
+	// request-scoped audit-diagnostic surface, not a usage-event path,
+	// so the join target here is gateway audit_events.request_id ↔
+	// coordinator audit_events / request_log diagnostics — NOT the
+	// gateway usage_events join used by /v1/chat/completions.
 	upReq.Header.Set("X-Request-ID", requestID(r))
 	// M3-2 / SECU-4: prefer ServiceToken when set; falls back to
 	// OperatorKey so a not-yet-upgraded coordinator keeps accepting us.

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -252,7 +252,7 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "coordinator_unavailable", "Coordinator unavailable")
 		return
 	}
-	// SPEC-006 v0.X R-G2 / SPEC-002 v1.4.2 R-2: gateway forwards the
+	// SPEC-006 v0.X R-G3 / SPEC-002 v1.4.2 R-2: gateway forwards the
 	// buyer-visible request id verbatim so the coordinator's
 	// request_log.external_request_id matches the gateway's
 	// usage_events.request_id on a per-request basis.
@@ -358,7 +358,7 @@ func (s *Server) handleStickyDelete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "coordinator_unavailable", "Coordinator unavailable")
 		return
 	}
-	// SPEC-006 v0.X R-G2: gateway forwards the buyer-visible request id
+	// SPEC-006 v0.X R-G3: gateway forwards the buyer-visible request id
 	// on every forwarded buyer-facing request so the coordinator
 	// audit log joins to gateway usage on a single key.
 	upReq.Header.Set("X-Request-ID", requestID(r))

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1589,6 +1589,38 @@ func TestProviderPinningHeadersStripped(t *testing.T) {
 	}
 }
 
+// SPEC-006 v0.X R-G2: gateway forwards buyer X-Request-ID on every
+// buyer-facing coordinator proxy path, not only /v1/chat/completions.
+// /v1/models is the other buyer-facing surface; this test pins that
+// behavior so a refactor doesn't silently revert it to newUUID().
+func TestModelsForwardsBuyerRequestID(t *testing.T) {
+	var capturedModelsXRequestID string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/v1/models" {
+			capturedModelsXRequestID = r.Header.Get("X-Request-ID")
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{"object":"list","data":[]}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, "acct_models_xrequestid")
+
+	const buyerID = "66666666-6666-4666-8666-666666666666"
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer "+fullKey)
+	req.Header.Set("X-Real-IP", "1.2.3.4")
+	req.Header.Set("X-Request-ID", buyerID)
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("models status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if capturedModelsXRequestID != buyerID {
+		t.Fatalf("forwarded X-Request-ID on /v1/models = %q, want buyer-supplied %q", capturedModelsXRequestID, buyerID)
+	}
+}
+
 func TestStickyConversationDerivesInternalHeaderAndStripsInjection(t *testing.T) {
 	var captured http.Header
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1535,8 +1535,14 @@ func TestProviderPinningHeadersStripped(t *testing.T) {
 	if got := resp.Header().Get("X-MacProvider-Route"); got != "" {
 		t.Fatalf("buyer response exposed route=%q", got)
 	}
-	if got := captured.Get("X-Request-ID"); got == "" || got == "55555555-5555-4555-8555-555555555555" {
-		t.Fatalf("forwarded X-Request-ID = %q, want gateway-generated coordinator ID", got)
+	// SPEC-002 §11 + v1.4.2 R-2 + issue #188: the gateway MUST forward
+	// the buyer-supplied X-Request-ID verbatim so the coordinator can
+	// store it in request_log.external_request_id, giving out-of-process
+	// auditors a stable shared id between gateway usage_events and
+	// coordinator request_log. Earlier behavior minted a fresh UUID
+	// here, breaking that join.
+	if got := captured.Get("X-Request-ID"); got != "55555555-5555-4555-8555-555555555555" {
+		t.Fatalf("forwarded X-Request-ID = %q, want buyer-supplied value preserved", got)
 	}
 	if got := captured.Get("X-MacProvider-Retry"); got != "1" {
 		t.Fatalf("forwarded retry = %q, want 1", got)

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1589,7 +1589,7 @@ func TestProviderPinningHeadersStripped(t *testing.T) {
 	}
 }
 
-// SPEC-006 v0.X R-G2: gateway forwards buyer X-Request-ID on every
+// SPEC-006 v0.X R-G3: gateway forwards buyer X-Request-ID on every
 // buyer-facing coordinator proxy path, not only /v1/chat/completions.
 // /v1/models is the other buyer-facing surface; this test pins that
 // behavior so a refactor doesn't silently revert it to newUUID().
@@ -1618,6 +1618,46 @@ func TestModelsForwardsBuyerRequestID(t *testing.T) {
 	}
 	if capturedModelsXRequestID != buyerID {
 		t.Fatalf("forwarded X-Request-ID on /v1/models = %q, want buyer-supplied %q", capturedModelsXRequestID, buyerID)
+	}
+}
+
+// SPEC-006 v0.X R-G3 / SPEC-002 v1.4.2 R-2: when the buyer omits
+// X-Request-ID, gateway middleware mints a UUID, sets it as the
+// response header, AND forwards that SAME id upstream. The two MUST
+// agree so the buyer can correlate their request id with what reaches
+// the coordinator's request_log.external_request_id. R5 architect
+// audit MINOR: previous tests only covered buyer-supplied; this pins
+// the middleware-minted branch.
+func TestChatForwardsMiddlewareMintedRequestIDWhenBuyerOmits(t *testing.T) {
+	var capturedChatXRequestID string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/v1/chat/completions" {
+			capturedChatXRequestID = r.Header.Get("X-Request-ID")
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}},
+			`{"id":"chatcmpl_1","object":"chat.completion","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, "acct_minted_rid")
+
+	body := `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+fullKey)
+	req.Header.Set("Content-Type", "application/json")
+	// No X-Request-ID header: gateway middleware MUST mint one.
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	respID := resp.Header().Get("X-Request-ID")
+	if !isUUIDLike(respID) {
+		t.Fatalf("response X-Request-ID = %q, want middleware-minted UUID", respID)
+	}
+	if capturedChatXRequestID != respID {
+		t.Fatalf("forwarded X-Request-ID = %q, want response/middleware-minted %q", capturedChatXRequestID, respID)
 	}
 }
 

--- a/specs/AUDIT_FIX_ISS_188_R1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_188_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,109 @@
+# ISS-188 R1 — architect-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-188-xrequestid-propagation`
+(PR https://github.com/Augustas11/macprovider/pull/195) against
+`origin/main`. The change adds a coordinator-side
+`request_log.external_request_id` column to carry the inbound
+`X-Request-ID`, and the gateway forwards the buyer's id verbatim
+to the coordinator. The PR is paired with SPEC-002 v1.4.2 addendum
+(PR #192, R-2).
+
+## Scope of this lane
+
+You are the **architect lane**. Focus on:
+
+- **Spec consistency.** SPEC-002 v1.4.1 §11 line 1291 says
+  `request_id TEXT UUID v4 from inbound X-Request-ID when present,
+  otherwise UUID assigned by coordinator`. A literal reading says
+  request_id IS the inbound id. This PR sidesteps that by ADDING a
+  new column `external_request_id` instead of flipping request_id's
+  semantics. Is the additive approach defensible? Does it leave a
+  spec gap that v1.4.2 R-2 (PR #192) should explicitly address?
+- **Naming alignment.** The column name `external_request_id`
+  matches a local variable in coord code but is unprecedented in
+  the spec corpus. Is this name aligned with how SPEC-005 / SPEC-006
+  describe cross-service correlation? Should it be `correlation_id`
+  or `client_request_id` or `inbound_request_id`?
+- **Cross-service ownership.** The PR touches coordinator and
+  gateway. Gateway-side: did the change correctly identify
+  `requestID(r)` as the SPEC-002 §11-honored id? Or is there a
+  layer-1 gateway-middleware issue where requestID(r) itself
+  doesn't faithfully reflect the inbound header (case mismatch,
+  trim issues)?
+- **Schema migration discipline.** Adding nullable columns to a
+  live SQLite DB is the canonical safe pattern. Are there
+  conventions in the project (e.g., gated by a feature flag,
+  documented in BUILD_SPEC, requiring a separate DROP-old fallback)
+  the PR should follow but skips?
+- **Reconciliation contract surface.** The PR's reconciliation
+  promise is `gateway.usage_events.request_id ==
+  coord.request_log.external_request_id`. Is that the ONLY join
+  key needed, or do other tables need similar plumbing (audit
+  events, billing snapshots, payout ledger)?
+- **Phase-C harness implications.** The internal e2e harness's
+  reconciler will need to switch from fuzzy matching to the new
+  column. Is there enough versioning / migration runway in the
+  PR for the harness to know whether to use the old or new path?
+- **Test coverage shape vs spec.** Do the new tests verify the
+  spec-derivable invariant ("external_request_id == inbound
+  X-Request-ID across all attempts of a logical request"), or do
+  they test implementation details that could drift?
+
+Out of scope for this lane (other lanes own):
+
+- **Code lane:** SQL correctness, Go idiom, test runnability.
+- **Security lane:** header trust, log injection, PII.
+
+Do NOT duplicate their work.
+
+## Files in the diff
+
+```
+phase4-coordinator/internal/buyer/billing_recorder.go
+phase4-coordinator/internal/buyer/server.go
+phase4-coordinator/internal/buyer/server_test.go
+phase4-coordinator/internal/requestlog/store.go
+phase5-gateway/internal/router/chat_proxy.go
+phase5-gateway/internal/router/server_test.go
+```
+
+Reference docs:
+
+- `specs/SPEC-002-coordinator.md` v1.4.1 — especially §11 lines
+  2239-2243 (the X-Request-ID contract) and line 1291 (the schema
+  description for request_log.request_id).
+- The companion `specs/SPEC-002-v1.4.2-routing-contract-addendum.md`
+  (PR #192) — especially R-2 which this PR implements against.
+- `specs/SPEC-006-buyer-api.md` for the gateway-side contract.
+- `specs/SPEC-005-*.md` (whatever the billing settlement spec is)
+  for the provider-credit mirror, since this affects reconciliation.
+
+PR body at https://github.com/Augustas11/macprovider/pull/195
+explains the trade-off the PR makes (additive vs flip-the-semantics)
+— address whether that trade-off is the right call.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **Aspect:** spec / naming / cross-service / migration / contract / harness / test-shape
+- **Issue:** one-sentence statement
+- **Evidence:** quote from the diff or referenced spec
+- **Recommendation:** specific change. If a clause needs new wording
+  in the v1.4.2 addendum, propose it.
+
+Severity definitions:
+
+- **CRITICAL:** clause-or-implementation will mislead future authors
+  or break the contract. Must fix before this lands.
+- **MAJOR:** materially weakens the spec or introduces ambiguity.
+- **MINOR:** clarity improvement.
+- **NOTE:** future-revision consideration.
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Keep response under 800 words.

--- a/specs/AUDIT_FIX_ISS_188_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_188_R1_CODE_PROMPT.md
@@ -1,0 +1,103 @@
+# ISS-188 R1 — code-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-188-xrequestid-propagation`
+(PR https://github.com/Augustas11/macprovider/pull/195) against
+`origin/main`. The change adds an `external_request_id` column to
+`request_log`, plumbs the inbound `X-Request-ID` through the
+coordinator's billing recorder, and changes the gateway to forward
+the buyer-visible request id to the coordinator verbatim. It also
+adds 2 new tests on the coordinator side and flips 1 test assertion
+on the gateway side.
+
+## Scope of this lane
+
+You are the **code lane**. Focus on:
+
+- Correctness of the SQL / migration / scan changes.
+- Go-idiom hygiene (nil safety, error handling, struct field
+  placement, exported vs unexported, naming consistency).
+- Test coverage — are the two new tests sufficient? Any obvious
+  failure modes uncovered? Do they assert the right thing?
+- Backwards compatibility — does the additive `ALTER TABLE` work on
+  a live SQLite WAL DB without disturbing live writers? Does a
+  pre-fix row (no external_request_id column) survive query through
+  the new helper that scans it?
+- Concurrency — is `externalRequestID` propagated correctly through
+  the per-request `billingRecorder` actor-ish boundary? Is the field
+  set once at construction and never mutated?
+- Dead code / unused symbols / commented-out lines.
+
+Out of scope for this lane (other lanes own):
+
+- **Security lane:** header trust, replay/spoofing, log-injection,
+  PII via X-Request-ID, TOCTOU on sanitization.
+- **Architect lane:** spec consistency vs SPEC-002 §11, contract
+  shape, cross-service ownership, naming alignment with SPEC-006,
+  observability, downstream impact on phase-C harness.
+
+Do NOT duplicate their work — flag if a finding overlaps and let
+the other lane own it.
+
+## Files in the diff
+
+```
+phase4-coordinator/internal/buyer/billing_recorder.go
+phase4-coordinator/internal/buyer/server.go
+phase4-coordinator/internal/buyer/server_test.go
+phase4-coordinator/internal/requestlog/store.go
+phase5-gateway/internal/router/chat_proxy.go
+phase5-gateway/internal/router/server_test.go
+```
+
+Useful command to view the diff locally:
+```
+git diff origin/main -- phase4-coordinator/ phase5-gateway/
+```
+
+The PR body is at
+https://github.com/Augustas11/macprovider/pull/195 — read it for the
+approach + rationale.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **File:line(s):** exact reference
+- **Issue:** one-sentence statement
+- **Evidence:** quote the offending code
+- **Recommendation:** specific change. Propose new code when relevant.
+
+Severity definitions:
+
+- **CRITICAL:** the change will mislead implementors or cause a
+  real bug. Must fix before this lands.
+- **MAJOR:** materially weakens correctness or introduces ambiguity
+  that WILL be exploited / misread. Should fix.
+- **MINOR:** style / structure improvement; correct as-is but
+  cleaner wording exists.
+- **NOTE:** observation that may inform a future revision; no
+  change required.
+
+End with a single summary line:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Be honest about what you DON'T have evidence to judge. Better to
+flag "uncertain — need [X]" than to invent confidence.
+
+## Files to read
+
+- The diff above.
+- `phase4-coordinator/internal/requestlog/store.go` in full for
+  migration ordering / column index correctness.
+- `phase4-coordinator/internal/buyer/server_test.go` lines 1045-1200
+  for the existing test pattern the new tests sit alongside.
+- `phase5-gateway/internal/router/chat_proxy.go` lines 180-230 for
+  the gateway forward path context (header copying, sticky
+  conditional Authorization header, error refund path).
+- Optionally, `phase4-coordinator/internal/buyer/billing_recorder.go`
+  in full to see all sites that read `b.externalRequestID`.
+
+Keep total response under 800 words. Quality over quantity.

--- a/specs/AUDIT_FIX_ISS_188_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_188_R1_SECURITY_PROMPT.md
@@ -1,0 +1,137 @@
+# ISS-188 R1 — security-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-188-xrequestid-propagation`
+(PR https://github.com/Augustas11/macprovider/pull/195) against
+`origin/main`. The change persists the buyer-supplied `X-Request-ID`
+header into the coordinator's `request_log.external_request_id`
+column and makes the gateway forward the buyer-visible request id to
+the coordinator verbatim instead of minting a fresh UUID.
+
+## Scope of this lane
+
+You are the **security lane**. Focus on:
+
+- **Header trust boundary.** The buyer-controlled `X-Request-ID` now
+  reaches a column in the coordinator's persistent SQLite DB. Are
+  there sanitization gaps? Length bounds? Format validation?
+- **Log injection / SQL injection.** The value is bound via parameter
+  in the INSERT (`nullString(row.ExternalRequestID)`) but is it ever
+  string-interpolated into a query elsewhere? Is it written to
+  structured logs that might suffer JSON-escape issues?
+- **Replay / collision attacks.** A buyer can submit an arbitrary
+  `X-Request-ID` and have it persisted alongside another buyer's
+  legitimate id. Does this break any uniqueness or audit-integrity
+  invariant? The schema doesn't put a unique constraint on
+  external_request_id; is that the right call?
+- **Buyer-visible information leak.** Does the gateway ever echo back
+  the coordinator's per-attempt internal `request_id` to the buyer
+  via response headers or body, leaking internal state? The flipped
+  test asserts the buyer-supplied id is forwarded — does any earlier
+  middleware redact it on the response side?
+- **PII / regulatory.** OpenAI SDK clients sometimes include
+  user-correlated identifiers in `X-Request-ID`. Persisting that
+  string in a coordinator log — is it PII per the project's existing
+  policy? Search the repo for "redact" / "PII" / "GDPR" hits to see
+  what posture the project takes.
+- **Sticky-routing path.** chat_proxy.go between lines 195-220 has a
+  conditional Authorization header for sticky routing. Does that
+  conditional interact with the X-Request-ID change in any
+  unexpected way (e.g., is the bearer or conversation key
+  X-Request-ID-derived)?
+- **Database write authority.** Is there any path where the
+  coordinator's billing recorder runs at a privilege the
+  external_request_id wouldn't be cleared through (e.g., shared
+  store with relaxed RLS)?
+- **Idempotency.** A separate idempotency-key code path exists
+  (`request_idempotency_keys` table per store.go). Does the new
+  column interact with idempotency replay — could a malicious buyer
+  resubmit with a colliding external_request_id and confuse the
+  idempotency cache?
+
+Out of scope for this lane (other lanes own):
+
+- **Code lane:** Go idiom, SQL correctness, test coverage,
+  backwards compat at the schema level.
+- **Architect lane:** spec consistency vs SPEC-002 §11, naming,
+  cross-service ownership, observability shape.
+
+Do NOT duplicate their work.
+
+## Scope: PR-INTRODUCED findings only
+
+Per the locked three-lane convergence convention: this audit gates
+this PR on findings INTRODUCED by the diff against origin/main.
+Pre-existing vulnerabilities visible to your audit but NOT modified
+by this PR are out of scope for blocking convergence — they may be
+worth filing as separate issues but they do NOT block PR #195 from
+landing.
+
+Example of in-scope: the new `sanitizeExternalRequestID` accepts
+128-byte non-UUIDv4 values when stricter validation would be safer.
+This is introduced by the PR.
+
+Example of out-of-scope: gateway `usage_events.request_id` was
+already the primary key before this PR. If you find a vulnerability
+in that PK shape, file it as a separate issue (see existing
+[#196](https://github.com/Augustas11/macprovider/issues/196) which
+already tracks this) — do NOT report it as a CRITICAL against this
+PR.
+
+If you re-find a CRITICAL/MAJOR that was already filed as a separate
+issue, drop it from your findings list and add a one-line NOTE
+referencing the issue number.
+
+## Files in the diff
+
+```
+phase4-coordinator/internal/buyer/billing_recorder.go
+phase4-coordinator/internal/buyer/server.go
+phase4-coordinator/internal/buyer/server_test.go
+phase4-coordinator/internal/requestlog/store.go
+phase5-gateway/internal/router/chat_proxy.go
+phase5-gateway/internal/router/server_test.go
+```
+
+Useful command:
+```
+git diff origin/main -- phase4-coordinator/ phase5-gateway/
+```
+
+PR body at https://github.com/Augustas11/macprovider/pull/195.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **File:line(s):** exact reference
+- **Threat model / attack surface:** one-sentence statement
+- **Evidence:** quote relevant code
+- **Recommendation:** specific change (validation, sanitization,
+  bounds, schema constraint, etc.).
+
+Severity definitions:
+
+- **CRITICAL:** exploitable now or under realistic adversary
+  assumptions. Must fix before this lands.
+- **MAJOR:** weakens defense in depth; likely to be problematic at
+  scale or in beta.
+- **MINOR:** hardening opportunity.
+- **NOTE:** future-proofing observation.
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Be honest about what you DON'T have evidence to judge.
+
+## Reference reading
+
+Search for prior security audits:
+- `specs/125_TRUSTED_PROXIES_SECURITY_audit.md`
+- `specs/127_ENUM_AST_SECURITY_audit.md`
+- `phase5-gateway/internal/auth/`
+- `phase4-coordinator/internal/audit/` (if it exists)
+
+Keep response under 800 words.


### PR DESCRIPTION
## Summary

Closes #188 (P0).

SPEC-002 v1.4.1 §11 (lines 2239-2243) mandates that the buyer-visible `X-Request-ID` flows through gateway → coordinator and serves as the join key between gateway `usage_events` and coordinator `request_log`. Earlier code violated this on two fronts:

- **Gateway** ([phase5-gateway/internal/router/chat_proxy.go:202](phase5-gateway/internal/router/chat_proxy.go#L202)) minted a fresh UUID for the coordinator-bound request, discarding the buyer's id.
- **Coordinator** ([phase4-coordinator/internal/buyer/server.go:1244-1247](phase4-coordinator/internal/buyer/server.go#L1244-L1247)) read the inbound `X-Request-ID` into `externalRequestID` but never persisted it — `request_log.request_id` was always a per-attempt coord-generated UUID.

Result: gateway `usage_events.request_id` and coord `request_log.request_id` lived in entirely separate id spaces with zero overlap. Out-of-process auditors (the internal e2e harness, any SRE audit, any billing-dispute resolver) could only reconcile by fuzzy `(ts ± 60s, model, completion_tokens)` matching, which collapses under concurrent live traffic.

## Approach: additive `external_request_id` column, not flip-the-semantics

The existing test suite deliberately codifies "per-attempt unique request_id" semantics in coordinator's request_log (test_RequestLogBuyer*** at server_test.go:1045 and :1114). Flipping that contract would have wide blast radius.

Instead this PR adds an **additive** column `request_log.external_request_id` (TEXT NULL, migrated) and stores the buyer-visible `X-Request-ID` there. `request_log.request_id` keeps its existing per-attempt-coord-generated semantics. The reconciliation join is now:

```
gateway.usage_events.request_id  ==  coord.request_log.external_request_id
```

## Changes

- **phase4-coordinator/internal/requestlog/store.go** — additive schema migration for `external_request_id TEXT NULL`; `Row` struct field; INSERT extended.
- **phase4-coordinator/internal/buyer/billing_recorder.go** — recorder carries `externalRequestID`, writes it into every row (success + retry attempts share the same value).
- **phase4-coordinator/internal/buyer/server.go** — passes `externalRequestID` into the recorder constructor.
- **phase5-gateway/internal/router/chat_proxy.go** — forwards `requestID(r)` (the gateway-middleware id, already honored from inbound `X-Request-ID` per §11) to coordinator verbatim instead of minting a fresh UUID. Three-line comment block explains the contract.
- **phase4-coordinator/internal/buyer/server_test.go** — added 2 new tests:
  - `TestRequestLogPreservesInboundXRequestIDAcrossAttempts` — positive: external_request_id populated, persists across retry attempts, request_id stays per-attempt coord-generated, retry rows share request_id (existing non-pinned invariant preserved).
  - `TestRequestLogExternalRequestIDNullWhenHeaderAbsent` — negative: NULL when no inbound header.
- **phase4-coordinator/internal/buyer/server_test.go** — extended query helpers (`requestLogTestRow`, `queryRequestLogRows`, `queryAllRequestLogRows`) to scan the new column.
- **phase5-gateway/internal/router/server_test.go** — flipped `TestProviderPinningHeadersStripped`'s X-Request-ID assertion (it previously codified the broken behavior). Now asserts the buyer's value is preserved through to the coordinator-bound request.

Refs SPEC-002 v1.4.2 R-2 from PR #192.

## Test plan

- [x] `go build ./...` clean on both modules.
- [x] `go test ./internal/buyer/ ./internal/requestlog/ -count=1` PASS on coordinator.
- [x] `go test ./internal/router/ -count=1` PASS on gateway.
- [x] New regression tests cover positive + negative paths.
- [ ] (After deploy) Re-run internal e2e network-harness scenarios 02 + 03 and confirm `ledger_reconcile.json` reports `unmatched_successes: []` and `gateway_minus_coordinator_tokens: 0` (the apparent +17 / +32 token "drift" from phase-A was almost certainly concurrent live traffic confounded by this id-space gap; the join now disambiguates).

## Out of scope (filed separately)

- Provider-forward `X-Request-ID` preservation per §11 line 2241 — touches a different code path with its own test invariants; will land as a follow-up against a new issue if/when it's a beta requirement.
- Schema migration safety on live Pearl — additive `ALTER TABLE ADD COLUMN` is the safe path SQLite supports without downtime; pre-existing rows have NULL in the new column (acceptable for reconciliation since they'll all fail the join cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**PR ordering note (architect R4 audit):** This PR depends on **PR #192** (SPEC-002 v1.4.2 R-2). #192 explicitly supersedes the locked v1.4.1 `request_id` schema-row description so this implementation does not contradict the spec. **#192 MUST merge before this PR**, or both merge in the same merge train. Reviewers should treat them as a paired set.

---

## Deployment runbook (operator action required)

PR #195 changes the SQLite migration shape on the request-log path. After deploy, BEFORE re-binding traffic, the operator MUST run:

```bash
./coordinator migrate-indexes --config /etc/macprovider/coordinator.yaml
```

The daemon writes the new `request_log.external_request_id` column on first start (additive ALTER TABLE — cheap, runs inline). The matching partial-NULL index is intentionally NOT built by the daemon: the request-log SQLite handle caps the writer pool at one connection, so CREATE INDEX inline would starve the 6s-timeout INSERT hot path. The subcommand exists for the operator to run this CREATE INDEX once per deploy.

**Until the index is built, exact reconciliation queries still work** — they just run a full table scan instead of a partial-index lookup. The new column is populated correctly from the moment the daemon ships. Internal harness Phase-C SHOULD introspect both the column AND the index, and report "exact reconciliation available but unindexed / rollout incomplete" when the column exists without the index.

PR-introduced check pattern:

```bash
sqlite3 /var/lib/macprovider/coordinator.db <<SQL
.schema request_log | grep -q external_request_id && echo "column: ok"
SELECT name FROM sqlite_master WHERE type='index' AND name='idx_request_log_external_request_id';
SQL
```