### PR TITLE
fix(coordinator): cold-start 404→503 via pool-lifetime model accumulator (closes #185)

### DIFF
--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -4134,6 +4134,53 @@ func TestChatCompletionsSplitsUnknownModelAndUnavailableProvider(t *testing.T) {
 	}
 }
 
+// SPEC-002 § 7.2 / issue #185: when the only provider for a model
+// disconnects (cold-start race), the next buyer request for that
+// model MUST return 503 no_provider_available, not 404
+// model_not_found. The model is in pool-lifetime history; the
+// distinction matters because OpenAI-compatible clients treat 404
+// as misconfiguration ("the model id is wrong, stop trying") and
+// 503 as transient ("back off, retry").
+//
+// Pre-#185, ModelKnown iterated only seenModelsByProvider, which the
+// M2-5 / PERF-5 audit had wired up to drop on provider disconnect.
+// This test pins the new lifetime accumulator (seenModelsLifetime) so
+// a future PERF revert doesn't silently reintroduce the spec
+// violation.
+func TestChatCompletionsColdStartRaceReturnsNoProviderAvailable(t *testing.T) {
+	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: "http://p1.example"}})
+	// 1. Provider registers and advertises model-a.
+	registerWithEndpoint(registry, "p1", "session-1", "model-a", pool.StateReady, 20000, 1, "http://p1.example", 20)
+	// 2. Provider disconnects (the cold-start race). RemoveIfSession
+	// drops seenModelsByProvider["p1"] per M2-5 / PERF-5. The model is
+	// only retained via seenModelsLifetime.
+	if !registry.RemoveIfSession("p1", "session-1") {
+		t.Fatalf("RemoveIfSession returned false; provider was not registered as expected")
+	}
+	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0))
+
+	// 3. Buyer asks for the recently-seen model. Must be 503
+	// no_provider_available, NOT 404 model_not_found.
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}]}`), nil)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("cold-start race status = %d, want 503; body=%s", rr.Code, rr.Body.String())
+	}
+	if !bytes.Contains(rr.Body.Bytes(), []byte(`"code":"no_provider_available"`)) {
+		t.Fatalf("cold-start race body = %s, want no_provider_available", rr.Body.String())
+	}
+
+	// 4. A model id NEVER advertised in this coordinator's lifetime
+	// still returns 404 model_not_found — the never-seen path is
+	// unchanged.
+	unseen := postChat(t, server, []byte(`{"model":"nonexistent-model-9000-test-only","messages":[{"role":"user","content":"hi"}]}`), nil)
+	if unseen.Code != http.StatusNotFound {
+		t.Fatalf("never-seen model status = %d, want 404; body=%s", unseen.Code, unseen.Body.String())
+	}
+	if !bytes.Contains(unseen.Body.Bytes(), []byte(`"code":"model_not_found"`)) {
+		t.Fatalf("never-seen model body = %s, want model_not_found", unseen.Body.String())
+	}
+}
+
 func TestChatCompletionsDoesNotRouteToDegradedProvider(t *testing.T) {
 	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: "http://p1.example"}})
 	registerWithEndpoint(registry, "p1", "session-1", "model-a", pool.StateDegraded, 20000, 1, "http://p1.example", 20)

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -4160,14 +4160,14 @@ func TestChatCompletionsColdStartRaceReturnsNoProviderAvailable(t *testing.T) {
 	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0))
 
 	// 3. Buyer asks for the recently-seen model. Must be 503
-	// no_provider_available, NOT 404 model_not_found.
+	// no_provider_available, NOT 404 model_not_found. Assert the full
+	// OpenAI error envelope shape so SDK clients can correctly route
+	// on (code, type), not just status (code-lane R1 MAJOR).
 	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}]}`), nil)
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("cold-start race status = %d, want 503; body=%s", rr.Code, rr.Body.String())
 	}
-	if !bytes.Contains(rr.Body.Bytes(), []byte(`"code":"no_provider_available"`)) {
-		t.Fatalf("cold-start race body = %s, want no_provider_available", rr.Body.String())
-	}
+	assertOpenAIErrorEnvelope(t, rr, "no_provider_available", "service_unavailable")
 
 	// 4. A model id NEVER advertised in this coordinator's lifetime
 	// still returns 404 model_not_found — the never-seen path is
@@ -4176,8 +4176,38 @@ func TestChatCompletionsColdStartRaceReturnsNoProviderAvailable(t *testing.T) {
 	if unseen.Code != http.StatusNotFound {
 		t.Fatalf("never-seen model status = %d, want 404; body=%s", unseen.Code, unseen.Body.String())
 	}
-	if !bytes.Contains(unseen.Body.Bytes(), []byte(`"code":"model_not_found"`)) {
-		t.Fatalf("never-seen model body = %s, want model_not_found", unseen.Body.String())
+	assertOpenAIErrorEnvelope(t, unseen, "model_not_found", "invalid_request_error")
+}
+
+// assertOpenAIErrorEnvelope decodes the response body and verifies
+// the full OpenAI error envelope shape (error.code, error.type,
+// error.message non-empty, error.param is null). Used by the cold-
+// start race test to ensure OpenAI-compatible SDK clients can route
+// on a structured error rather than a substring match.
+func assertOpenAIErrorEnvelope(t *testing.T, rr *httptest.ResponseRecorder, wantCode, wantType string) {
+	t.Helper()
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Type    string `json:"type"`
+			Message string `json:"message"`
+			Param   any    `json:"param"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("error envelope decode failed: %v; body=%s", err, rr.Body.String())
+	}
+	if body.Error.Code != wantCode {
+		t.Fatalf("error.code = %q, want %q; body=%s", body.Error.Code, wantCode, rr.Body.String())
+	}
+	if body.Error.Type != wantType {
+		t.Fatalf("error.type = %q, want %q; body=%s", body.Error.Type, wantType, rr.Body.String())
+	}
+	if body.Error.Message == "" {
+		t.Fatalf("error.message is empty; body=%s", rr.Body.String())
+	}
+	if body.Error.Param != nil {
+		t.Fatalf("error.param = %v, want null; body=%s", body.Error.Param, rr.Body.String())
 	}
 }
 

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -1281,14 +1281,29 @@ func (r *Registry) ModelKnown(modelID string) bool {
 	if modelID == "" {
 		return false
 	}
+	// ISS-185 R3 code-lane MAJOR: strings.ToLower is NOT equivalent to
+	// strings.EqualFold for Turkish/Greek edges (e.g.
+	// EqualFold("Σ","ς")==true but ToLower differs;
+	// EqualFold("İ","i")==false but ToLower agrees). Preserve the
+	// existing EqualFold contract by:
+	// 1. Fast O(1) hit on strings.ToLower canonical key (covers the
+	//    ASCII/Latin common case, ~all realistic model ids).
+	// 2. On miss, EqualFold scan the lifetime accumulator before
+	//    falling through to the live/per-session paths.
 	canonical := strings.ToLower(modelID)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	// Lifetime accumulator is the SPEC-002 § 7.2 contract surface.
-	// Lowercase canonical key keeps lookup O(1). Hit covers any model
-	// the coordinator has ever seen and recorded into lifetime.
 	if _, ok := r.seenModelsLifetime[canonical]; ok {
 		return true
+	}
+	// Non-ASCII / case-folding-edge fallback: EqualFold scan of
+	// lifetime keys. Bounded by maxSeenModelsLifetime = 4096; only
+	// pays the cost on the never-recorded path (i.e., the 404
+	// candidate).
+	for stored := range r.seenModelsLifetime {
+		if strings.EqualFold(stored, modelID) {
+			return true
+		}
 	}
 	// Fallback paths cover the case where lifetime was at one of its
 	// caps (global maxSeenModelsLifetime or per-provider
@@ -1312,9 +1327,6 @@ func (r *Registry) ModelKnown(modelID string) bool {
 		if _, ok := set[modelID]; ok {
 			return true
 		}
-		// Case-insensitive fallback. set keys are stored in their
-		// original case, so use EqualFold per entry. Bounded by
-		// maxSeenModelsPerProvider * N_providers (32 * small N).
 		for stored := range set {
 			if strings.EqualFold(stored, modelID) {
 				return true

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -253,18 +253,25 @@ type Registry struct {
 	// which degrades cold-start races to the legacy 404 behavior for
 	// rare/transient models without crashing.
 	seenModelsLifetime     map[string]struct{}
-	// lifetimeCapWarnedOnce gates the warn-log + cap-reached counter
-	// so the operator gets one signal at first cap exhaustion, not a
-	// per-heartbeat spam. ISS-185 R1 security-lane MINOR
-	// (observability).
-	lifetimeCapWarnedOnce  bool
+	// lifetimeContribByProvider tracks how many DISTINCT model ids a
+	// given provider_id has contributed to seenModelsLifetime over
+	// the entire coordinator process lifetime — NOT reset on session
+	// replacement or disconnect. This bounds churn-via-reconnect: a
+	// malicious provider cannot consume the lifetime cap by repeatedly
+	// disconnecting and reconnecting with new model ids. Capped per
+	// provider at maxLifetimeContribPerProvider (4x the per-session
+	// budget). ISS-185 R2 security-lane MAJOR.
+	lifetimeContribByProvider map[string]int
+	// lifetimeCapWarnedOnce gates the warn-log so the operator gets
+	// one signal at first cap exhaustion, not per-heartbeat spam.
+	lifetimeCapWarnedOnce bool
 	// lifetimeCapDroppedCount counts model-id inserts that were
-	// dropped because seenModelsLifetime was at cap. Operators can
-	// scrape this via the explorer endpoints; nonzero = either a
-	// runaway provider churn or a legitimate catalog larger than
-	// expected.
+	// dropped because seenModelsLifetime was at cap. Exposed via
+	// LifetimeCapStats() so explorer / metrics can scrape it; nonzero
+	// = either runaway provider churn or a legitimate catalog larger
+	// than expected.
 	lifetimeCapDroppedCount uint64
-	breakerFaults          map[string][]time.Time
+	breakerFaults           map[string][]time.Time
 	recoveryHolds          map[string]recoveryHold
 	canarySanctions        map[string]canarySanction
 	lastBreakerRecoveries  map[string]time.Time
@@ -306,6 +313,20 @@ const maxSeenModelsLifetime = 4096
 // "never seen" 404 path.
 const maxModelIDByteLen = 256
 
+// maxLifetimeContribPerProvider bounds how many DISTINCT model ids
+// a single provider_id can contribute to seenModelsLifetime over
+// the entire coordinator process lifetime, surviving disconnect and
+// session replacement. This bounds churn-via-reconnect by a
+// malicious provider while keeping the per-session attribution map
+// (seenModelsByProvider, capped at maxSeenModelsPerProvider = 32)
+// free to fill independently each session. 128 is 4x the per-session
+// cap — generous enough that a legitimate provider rebooting many
+// times across the process lifetime won't be capped, but tight
+// enough that one malicious provider cannot consume more than
+// 128/4096 ≈ 3% of total lifetime budget. ISS-185 R2 security-lane
+// MAJOR (per-provider gating must survive reconnect).
+const maxLifetimeContribPerProvider = 128
+
 // ReceiptRotationGrace is the SPEC-015 overlap window during which buyers may
 // validate receipts signed by the previous provider receipt key.
 const ReceiptRotationGrace = 7 * 24 * time.Hour
@@ -337,8 +358,9 @@ func NewRegistry(providers []config.ProviderConfig, opts ...RegistryOption) *Reg
 		providers:             map[string]*Provider{},
 		sessions:              map[string]*Provider{},
 		endpoints:             endpoints,
-		seenModelsByProvider:  map[string]map[string]struct{}{},
-		seenModelsLifetime:    map[string]struct{}{},
+		seenModelsByProvider:      map[string]map[string]struct{}{},
+		seenModelsLifetime:        map[string]struct{}{},
+		lifetimeContribByProvider: map[string]int{},
 		breakerFaults:         map[string][]time.Time{},
 		recoveryHolds:         map[string]recoveryHold{},
 		canarySanctions:       map[string]canarySanction{},
@@ -632,58 +654,57 @@ func cloneBytes(in []byte) []byte {
 }
 
 // recordSeenModelLocked records a model id under a provider's set
-// AND in the pool-lifetime accumulator, respecting both caps. Caller
-// must hold r.mu in WRITE mode.
+// AND in the pool-lifetime accumulator. Caller must hold r.mu in
+// WRITE mode.
 //
-// Insertion ordering matters (ISS-185 R1 security-lane MAJOR): the
-// per-provider cap is checked FIRST so that one churning provider
-// cannot consume the lifetime accumulator's capacity past its own
-// per-provider budget (maxSeenModelsPerProvider). Concretely: a
-// single provider can contribute at most maxSeenModelsPerProvider
-// distinct ids to seenModelsLifetime during one session; subsequent
-// distinct ids from the same provider drop without consuming
-// lifetime budget.
+// The two maps are gated INDEPENDENTLY (ISS-185 R2 architect/code/
+// security-lane MAJORs):
+//
+//   - seenModelsByProvider[provider_id] holds the current session's
+//     attribution, capped per session at maxSeenModelsPerProvider
+//     and cleared on RemoveIfSession / session-replacement.
+//   - seenModelsLifetime is the SPEC-002 § 7.2 pool-lifetime model
+//     history, capped overall at maxSeenModelsLifetime and per-
+//     provider at maxLifetimeContribPerProvider (the latter counter
+//     SURVIVES disconnect/session-replacement, so churn-via-
+//     reconnect cannot consume more lifetime than that per-provider
+//     budget).
 //
 // seenModelsLifetime keys are the lowercase canonical form of the
-// model id (the existing ModelKnown contract is case-insensitive).
-// This converts the lookup in ModelKnown from a 4096-step EqualFold
-// scan into an O(1) hash hit (ISS-185 R1 security-lane MINOR perf).
+// model id; ModelKnown's lookup is then O(1).
 func (r *Registry) recordSeenModelLocked(providerID, modelID string) {
 	if providerID == "" || modelID == "" {
 		return
 	}
 	// ISS-185 R1 security-lane CRITICAL: bound the persisted byte
 	// size. `requireString` in internal/ws/messages.go does not cap
-	// model_id length, so without this check a misbehaving provider
-	// could store arbitrarily large strings in lifetime memory.
+	// model_id length.
 	if len(modelID) > maxModelIDByteLen {
 		return
 	}
+
+	// 1. Per-session attribution map (M2-5 / audit #47 invariant).
 	set, ok := r.seenModelsByProvider[providerID]
 	if !ok {
 		set = map[string]struct{}{}
 		r.seenModelsByProvider[providerID] = set
 	}
-	if _, already := set[modelID]; already {
-		// Already accounted for in both maps. No-op.
-		return
+	if _, already := set[modelID]; !already && len(set) < maxSeenModelsPerProvider {
+		set[modelID] = struct{}{}
 	}
-	if len(set) >= maxSeenModelsPerProvider {
-		// This provider has already contributed its full per-provider
-		// budget. Drop further inserts BEFORE touching lifetime so the
-		// lifetime cap is not consumable past per-provider budget.
-		return
-	}
-	set[modelID] = struct{}{}
 
-	// SPEC-002 § 7.2 / issue #185: lifetime accumulator drives the
-	// 404-vs-503 distinction, regardless of which provider advertised
-	// it. Append-only within maxSeenModelsLifetime; canonical lowercase
-	// key for O(1) case-insensitive lookup.
+	// 2. Pool-lifetime accumulator (SPEC-002 § 7.2).
 	canonical := strings.ToLower(modelID)
 	if _, already := r.seenModelsLifetime[canonical]; already {
 		return
 	}
+	// 2a. Per-provider lifetime contribution budget (survives
+	// disconnect/replacement so reconnects can't fill the cap).
+	if r.lifetimeContribByProvider[providerID] >= maxLifetimeContribPerProvider {
+		r.lifetimeCapDroppedCount++
+		return
+	}
+	// 2b. Global lifetime cap (PERF-5 bound).
 	if len(r.seenModelsLifetime) >= maxSeenModelsLifetime {
 		r.lifetimeCapDroppedCount++
 		if !r.lifetimeCapWarnedOnce {
@@ -697,6 +718,21 @@ func (r *Registry) recordSeenModelLocked(providerID, modelID string) {
 		return
 	}
 	r.seenModelsLifetime[canonical] = struct{}{}
+	r.lifetimeContribByProvider[providerID]++
+}
+
+// LifetimeCapStats returns the current size of the pool-lifetime
+// model-id accumulator and the cumulative number of model_id
+// inserts dropped because either the global or per-provider lifetime
+// cap was at the limit. Operators can scrape these via explorer /
+// metrics surfaces — nonzero `dropped` is the security-relevant
+// signal of either runaway provider churn or a catalog larger than
+// the configured budget. ISS-185 R2 code/security-lane MINOR
+// (observability).
+func (r *Registry) LifetimeCapStats() (size int, dropped uint64) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.seenModelsLifetime), r.lifetimeCapDroppedCount
 }
 
 func (r *Registry) SetTier(providerID string, tier Tier) (Provider, bool) {
@@ -1249,21 +1285,40 @@ func (r *Registry) ModelKnown(modelID string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	// Lifetime accumulator is the SPEC-002 § 7.2 contract surface.
-	// Lowercase canonical key keeps lookup O(1) — the live-provider
-	// scan below stays O(N_providers) but is only reachable when the
-	// id was already removed from lifetime (lifetime is a strict
-	// superset of currently-live providers' models), so in practice
-	// this branch terminates on the map hit for any model the
-	// coordinator has ever seen during its process lifetime.
+	// Lowercase canonical key keeps lookup O(1). Hit covers any model
+	// the coordinator has ever seen and recorded into lifetime.
 	if _, ok := r.seenModelsLifetime[canonical]; ok {
 		return true
 	}
-	// Fallback: a currently-connected provider may have advertised
-	// this model id but the lifetime accumulator was at cap when it
-	// did, so it never got recorded. Iterate live providers.
+	// Fallback paths cover the case where lifetime was at one of its
+	// caps (global maxSeenModelsLifetime or per-provider
+	// maxLifetimeContribPerProvider) when the model was first
+	// advertised, so it was dropped from lifetime even though the
+	// provider that advertised it may still be connected.
+	//
+	// 1. Live providers' current ModelID field.
 	for _, p := range r.providers {
 		if strings.EqualFold(p.ModelID, modelID) {
 			return true
+		}
+	}
+	// 2. Per-session attribution map. ISS-185 R2 code-lane MAJOR: a
+	// provider may have previously advertised this model id via
+	// heartbeat (it's in their per-session set) while their CURRENT
+	// ModelID is something else. Without this iteration, ModelKnown
+	// would return false → 404 even though a connected provider has
+	// the model id in its session history.
+	for _, set := range r.seenModelsByProvider {
+		if _, ok := set[modelID]; ok {
+			return true
+		}
+		// Case-insensitive fallback. set keys are stored in their
+		// original case, so use EqualFold per entry. Bounded by
+		// maxSeenModelsPerProvider * N_providers (32 * small N).
+		for stored := range set {
+			if strings.EqualFold(stored, modelID) {
+				return true
+			}
 		}
 	}
 	return false

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -236,11 +236,22 @@ type Registry struct {
 	// (no cleanup on provider removal); per the 2026-06-10 audit it could
 	// outgrow the pool unboundedly. Now keyed by providerID and dropped
 	// on RemoveIfSession / RemoveIfSessionState, with a per-provider cap
-	// to bound a single provider's contribution. ModelKnown is a view
-	// over currently-connected providers' sets — so when a provider
-	// disconnects, models only it had reported correctly disappear from
-	// the global "seen" answer.
-	seenModelsByProvider   map[string]map[string]struct{}
+	// to bound a single provider's contribution.
+	seenModelsByProvider map[string]map[string]struct{}
+	// seenModelsLifetime is the SPEC-002 v1.4.1 § 7.2 pool-lifetime
+	// model history: any model id ever advertised during this coordinator
+	// process lifetime, retained even after the advertising provider
+	// disconnects. Issue #185: the M2-5 cleanup of seenModelsByProvider
+	// on provider disconnect inadvertently shrank `ModelKnown`'s answer
+	// to "currently-connected only", which made cold-start races (only
+	// provider for a model disconnects, buyer asks for that model)
+	// return 404 model_not_found instead of the spec-mandated 503
+	// no_provider_available. seenModelsLifetime is append-only within a
+	// hard cap (maxSeenModelsLifetime) so the PERF-5 memory bound
+	// still holds — beyond cap, further model ids are silently dropped,
+	// which degrades cold-start races to the legacy 404 behavior for
+	// rare/transient models without crashing.
+	seenModelsLifetime     map[string]struct{}
 	breakerFaults          map[string][]time.Time
 	recoveryHolds          map[string]recoveryHold
 	canarySanctions        map[string]canarySanction
@@ -257,6 +268,16 @@ type Registry struct {
 // at a time); reaching this cap silently drops further model IDs.
 // M2-5 / PERF-5.
 const maxSeenModelsPerProvider = 32
+
+// maxSeenModelsLifetime caps the pool-lifetime model-id accumulator that
+// implements SPEC-002 § 7.2's 404-vs-503 distinction. 4096 is several
+// orders of magnitude above any realistic mac-provider catalog — most
+// deployments serve 5-50 distinct model ids — so reaching the cap means
+// a buggy provider is churning model ids. At the cap further inserts
+// are silently dropped, which degrades cold-start races to the legacy
+// 404 behavior for the dropped ids without unbounded growth. Issue #185
+// / SPEC-002 § 7.2 + PERF-5 / 2026-06-10 audit reconciliation.
+const maxSeenModelsLifetime = 4096
 
 // ReceiptRotationGrace is the SPEC-015 overlap window during which buyers may
 // validate receipts signed by the previous provider receipt key.
@@ -290,6 +311,7 @@ func NewRegistry(providers []config.ProviderConfig, opts ...RegistryOption) *Reg
 		sessions:              map[string]*Provider{},
 		endpoints:             endpoints,
 		seenModelsByProvider:  map[string]map[string]struct{}{},
+		seenModelsLifetime:    map[string]struct{}{},
 		breakerFaults:         map[string][]time.Time{},
 		recoveryHolds:         map[string]recoveryHold{},
 		canarySanctions:       map[string]canarySanction{},
@@ -574,11 +596,18 @@ func cloneBytes(in []byte) []byte {
 	return out
 }
 
-// recordSeenModelLocked records a model id under a provider's set,
-// respecting the per-provider cap. Caller must hold r.mu in WRITE mode.
+// recordSeenModelLocked records a model id under a provider's set
+// AND in the pool-lifetime accumulator, respecting both caps. Caller
+// must hold r.mu in WRITE mode.
 func (r *Registry) recordSeenModelLocked(providerID, modelID string) {
 	if providerID == "" || modelID == "" {
 		return
+	}
+	// SPEC-002 § 7.2 / issue #185: lifetime accumulator drives the
+	// 404-vs-503 distinction, regardless of which provider advertised
+	// it. Append-only within maxSeenModelsLifetime.
+	if _, already := r.seenModelsLifetime[modelID]; !already && len(r.seenModelsLifetime) < maxSeenModelsLifetime {
+		r.seenModelsLifetime[modelID] = struct{}{}
 	}
 	set, ok := r.seenModelsByProvider[providerID]
 	if !ok {
@@ -592,7 +621,7 @@ func (r *Registry) recordSeenModelLocked(providerID, modelID string) {
 		// Cap is well above legitimate use; reaching it means this
 		// provider is misbehaving or buggy. Silent-drop is operationally
 		// safe — ModelKnown still answers true via the currently-connected
-		// provider's live ModelID field.
+		// provider's live ModelID field or via the lifetime accumulator.
 		return
 	}
 	set[modelID] = struct{}{}
@@ -1124,6 +1153,22 @@ func (r *Registry) Touch(providerID, assignedID string, at time.Time) {
 	}
 }
 
+// ModelKnown implements SPEC-002 § 7.2's pool-lifetime "has the
+// coordinator ever seen this model id" check that drives the 404 vs
+// 503 distinction on the buyer port. Returns true iff the model id has
+// been advertised by ANY provider at ANY point during this coordinator
+// process lifetime (within the maxSeenModelsLifetime cap), whether or
+// not the advertising provider is still connected.
+//
+// Issue #185: a previous implementation iterated seenModelsByProvider
+// only, which the M2-5 / PERF-5 audit had wired up to drop on
+// provider disconnect. Cold-start races (only provider for a model
+// disconnects, buyer asks for that model ~200ms later) returned 404
+// model_not_found instead of 503 no_provider_available, leading
+// OpenAI-compatible clients to abandon the model as misconfigured
+// instead of backing off and retrying. The lifetime accumulator added
+// in #185 is append-only with a hard cap, so PERF-5's memory bound
+// still holds while SPEC § 7.2's behavior is restored.
 func (r *Registry) ModelKnown(modelID string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -1132,18 +1177,9 @@ func (r *Registry) ModelKnown(modelID string) bool {
 			return true
 		}
 	}
-	// M2-5 / PERF-5: iterate per-provider seenModels (only entries for
-	// currently-connected providers, since RemoveIfSession{,State} drop
-	// the inner map). The pre-M2-5 behaviour was a registry-wide
-	// accumulator that retained models from disconnected providers
-	// forever — a memory leak the audit flagged. The new semantic is
-	// "known iff a currently-connected provider has at any point served
-	// it during its current session."
-	for _, set := range r.seenModelsByProvider {
-		for seen := range set {
-			if strings.EqualFold(seen, modelID) {
-				return true
-			}
+	for seen := range r.seenModelsLifetime {
+		if strings.EqualFold(seen, modelID) {
+			return true
 		}
 	}
 	return false

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -252,7 +252,7 @@ type Registry struct {
 	// still holds — beyond cap, further model ids are silently dropped,
 	// which degrades cold-start races to the legacy 404 behavior for
 	// rare/transient models without crashing.
-	seenModelsLifetime     map[string]struct{}
+	seenModelsLifetime map[string]struct{}
 	// lifetimeContribByProvider tracks how many DISTINCT model ids a
 	// given provider_id has contributed to seenModelsLifetime over
 	// the entire coordinator process lifetime — NOT reset on session
@@ -272,13 +272,13 @@ type Registry struct {
 	// than expected.
 	lifetimeCapDroppedCount uint64
 	breakerFaults           map[string][]time.Time
-	recoveryHolds          map[string]recoveryHold
-	canarySanctions        map[string]canarySanction
-	lastBreakerRecoveries  map[string]time.Time
-	maxProvider            int
-	hashVerifier           HeartbeatHashVerifier
-	swapEmitter            SwapEventEmitter
-	receiptRotationEmitter ReceiptRotationEventEmitter
+	recoveryHolds           map[string]recoveryHold
+	canarySanctions         map[string]canarySanction
+	lastBreakerRecoveries   map[string]time.Time
+	maxProvider             int
+	hashVerifier            HeartbeatHashVerifier
+	swapEmitter             SwapEventEmitter
+	receiptRotationEmitter  ReceiptRotationEventEmitter
 }
 
 // maxSeenModelsPerProvider caps the seenModelsByProvider inner set so a
@@ -355,16 +355,16 @@ func NewRegistry(providers []config.ProviderConfig, opts ...RegistryOption) *Reg
 		endpoints[p.ProviderID] = p
 	}
 	r := &Registry{
-		providers:             map[string]*Provider{},
-		sessions:              map[string]*Provider{},
-		endpoints:             endpoints,
+		providers:                 map[string]*Provider{},
+		sessions:                  map[string]*Provider{},
+		endpoints:                 endpoints,
 		seenModelsByProvider:      map[string]map[string]struct{}{},
 		seenModelsLifetime:        map[string]struct{}{},
 		lifetimeContribByProvider: map[string]int{},
-		breakerFaults:         map[string][]time.Time{},
-		recoveryHolds:         map[string]recoveryHold{},
-		canarySanctions:       map[string]canarySanction{},
-		lastBreakerRecoveries: map[string]time.Time{},
+		breakerFaults:             map[string][]time.Time{},
+		recoveryHolds:             map[string]recoveryHold{},
+		canarySanctions:           map[string]canarySanction{},
+		lastBreakerRecoveries:     map[string]time.Time{},
 	}
 	for _, opt := range opts {
 		opt(r)

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -3,6 +3,7 @@ package pool
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"net"
 	"strings"
 	"sync"
@@ -252,6 +253,17 @@ type Registry struct {
 	// which degrades cold-start races to the legacy 404 behavior for
 	// rare/transient models without crashing.
 	seenModelsLifetime     map[string]struct{}
+	// lifetimeCapWarnedOnce gates the warn-log + cap-reached counter
+	// so the operator gets one signal at first cap exhaustion, not a
+	// per-heartbeat spam. ISS-185 R1 security-lane MINOR
+	// (observability).
+	lifetimeCapWarnedOnce  bool
+	// lifetimeCapDroppedCount counts model-id inserts that were
+	// dropped because seenModelsLifetime was at cap. Operators can
+	// scrape this via the explorer endpoints; nonzero = either a
+	// runaway provider churn or a legitimate catalog larger than
+	// expected.
+	lifetimeCapDroppedCount uint64
 	breakerFaults          map[string][]time.Time
 	recoveryHolds          map[string]recoveryHold
 	canarySanctions        map[string]canarySanction
@@ -274,10 +286,25 @@ const maxSeenModelsPerProvider = 32
 // orders of magnitude above any realistic mac-provider catalog — most
 // deployments serve 5-50 distinct model ids — so reaching the cap means
 // a buggy provider is churning model ids. At the cap further inserts
-// are silently dropped, which degrades cold-start races to the legacy
-// 404 behavior for the dropped ids without unbounded growth. Issue #185
-// / SPEC-002 § 7.2 + PERF-5 / 2026-06-10 audit reconciliation.
+// are dropped (logged via warn-once + counter), which degrades cold-
+// start races to the legacy 404 behavior for the dropped ids without
+// unbounded growth. Issue #185 / SPEC-002 § 7.2 + PERF-5 / 2026-06-10
+// audit reconciliation.
 const maxSeenModelsLifetime = 4096
+
+// maxModelIDByteLen bounds the size of a single model_id string that
+// gets persisted into the lifetime / per-provider seen-model maps.
+// ISS-185 R1 security-lane CRITICAL: without this bound a provider
+// could advertise very-large model_id strings and force the
+// coordinator to retain them in seenModelsLifetime for the process
+// lifetime, since `requireString` in
+// phase4-coordinator/internal/ws/messages.go does not byte-cap the
+// raw string. 256 bytes aligns with the existing `supported_models`
+// byte cap precedent and is several KB above realistic model ids
+// (e.g. "mlx-community/Qwen3-32B-4bit" is 28 bytes). Oversize ids
+// are not persisted; routing requests for them fall through to the
+// "never seen" 404 path.
+const maxModelIDByteLen = 256
 
 // ReceiptRotationGrace is the SPEC-015 overlap window during which buyers may
 // validate receipts signed by the previous provider receipt key.
@@ -453,13 +480,21 @@ func (r *Registry) RegisterAtDetailed(p *Provider, conn net.Conn, now time.Time)
 		old = existing.conn
 		delete(r.sessions, existing.AssignedID)
 		// M2-5: this is a session replacement (same provider_id, new
-		// assigned_id). The "currently-connected session only" invariant
-		// for ModelKnown requires the stale model history to be cleared
-		// here too — RemoveIfSession{,State} only fire on clean
-		// disconnect, not on this direct replacement path. Without this
-		// delete, model ids from the prior session would survive into
-		// the new one and ModelKnown would over-report. (Codex code-audit
-		// 2026-06-11 #47.)
+		// assigned_id). Drop the prior session's per-provider model-id
+		// attribution so per-provider explorer / debug queries reflect
+		// only the current session. RemoveIfSession{,State} only fire
+		// on clean disconnect, not on this direct replacement path.
+		// (Codex code-audit 2026-06-11 #47.)
+		//
+		// ISS-185: the obsolete pre-185 form of this comment said the
+		// delete was required to keep `ModelKnown` from over-reporting.
+		// That is no longer true: ModelKnown reads from
+		// `seenModelsLifetime`, which is the SPEC-002 § 7.2 pool-
+		// lifetime accumulator (append-only) and SHOULD retain
+		// prior-session model ids so cold-start races route to 503
+		// `no_provider_available` instead of 404 `model_not_found`.
+		// The invariant this delete still preserves is per-provider
+		// attribution only.
 		delete(r.seenModelsByProvider, p.ProviderID)
 	} else {
 		if r.stageReceiptPublicationLocked(nil, p, now) == RegisterRefusalReceiptRotationGraceActive {
@@ -599,15 +634,30 @@ func cloneBytes(in []byte) []byte {
 // recordSeenModelLocked records a model id under a provider's set
 // AND in the pool-lifetime accumulator, respecting both caps. Caller
 // must hold r.mu in WRITE mode.
+//
+// Insertion ordering matters (ISS-185 R1 security-lane MAJOR): the
+// per-provider cap is checked FIRST so that one churning provider
+// cannot consume the lifetime accumulator's capacity past its own
+// per-provider budget (maxSeenModelsPerProvider). Concretely: a
+// single provider can contribute at most maxSeenModelsPerProvider
+// distinct ids to seenModelsLifetime during one session; subsequent
+// distinct ids from the same provider drop without consuming
+// lifetime budget.
+//
+// seenModelsLifetime keys are the lowercase canonical form of the
+// model id (the existing ModelKnown contract is case-insensitive).
+// This converts the lookup in ModelKnown from a 4096-step EqualFold
+// scan into an O(1) hash hit (ISS-185 R1 security-lane MINOR perf).
 func (r *Registry) recordSeenModelLocked(providerID, modelID string) {
 	if providerID == "" || modelID == "" {
 		return
 	}
-	// SPEC-002 § 7.2 / issue #185: lifetime accumulator drives the
-	// 404-vs-503 distinction, regardless of which provider advertised
-	// it. Append-only within maxSeenModelsLifetime.
-	if _, already := r.seenModelsLifetime[modelID]; !already && len(r.seenModelsLifetime) < maxSeenModelsLifetime {
-		r.seenModelsLifetime[modelID] = struct{}{}
+	// ISS-185 R1 security-lane CRITICAL: bound the persisted byte
+	// size. `requireString` in internal/ws/messages.go does not cap
+	// model_id length, so without this check a misbehaving provider
+	// could store arbitrarily large strings in lifetime memory.
+	if len(modelID) > maxModelIDByteLen {
+		return
 	}
 	set, ok := r.seenModelsByProvider[providerID]
 	if !ok {
@@ -615,16 +665,38 @@ func (r *Registry) recordSeenModelLocked(providerID, modelID string) {
 		r.seenModelsByProvider[providerID] = set
 	}
 	if _, already := set[modelID]; already {
+		// Already accounted for in both maps. No-op.
 		return
 	}
 	if len(set) >= maxSeenModelsPerProvider {
-		// Cap is well above legitimate use; reaching it means this
-		// provider is misbehaving or buggy. Silent-drop is operationally
-		// safe — ModelKnown still answers true via the currently-connected
-		// provider's live ModelID field or via the lifetime accumulator.
+		// This provider has already contributed its full per-provider
+		// budget. Drop further inserts BEFORE touching lifetime so the
+		// lifetime cap is not consumable past per-provider budget.
 		return
 	}
 	set[modelID] = struct{}{}
+
+	// SPEC-002 § 7.2 / issue #185: lifetime accumulator drives the
+	// 404-vs-503 distinction, regardless of which provider advertised
+	// it. Append-only within maxSeenModelsLifetime; canonical lowercase
+	// key for O(1) case-insensitive lookup.
+	canonical := strings.ToLower(modelID)
+	if _, already := r.seenModelsLifetime[canonical]; already {
+		return
+	}
+	if len(r.seenModelsLifetime) >= maxSeenModelsLifetime {
+		r.lifetimeCapDroppedCount++
+		if !r.lifetimeCapWarnedOnce {
+			r.lifetimeCapWarnedOnce = true
+			slog.Warn("pool: seenModelsLifetime cap reached; further model_ids will be silently dropped, degrading SPEC-002 § 7.2 cold-start race recovery to legacy 404 for the dropped ids",
+				"cap", maxSeenModelsLifetime,
+				"provider_id", providerID,
+				"dropped_model_id", modelID,
+			)
+		}
+		return
+	}
+	r.seenModelsLifetime[canonical] = struct{}{}
 }
 
 func (r *Registry) SetTier(providerID string, tier Tier) (Provider, bool) {
@@ -1170,15 +1242,27 @@ func (r *Registry) Touch(providerID, assignedID string, at time.Time) {
 // in #185 is append-only with a hard cap, so PERF-5's memory bound
 // still holds while SPEC § 7.2's behavior is restored.
 func (r *Registry) ModelKnown(modelID string) bool {
+	if modelID == "" {
+		return false
+	}
+	canonical := strings.ToLower(modelID)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	// Lifetime accumulator is the SPEC-002 § 7.2 contract surface.
+	// Lowercase canonical key keeps lookup O(1) — the live-provider
+	// scan below stays O(N_providers) but is only reachable when the
+	// id was already removed from lifetime (lifetime is a strict
+	// superset of currently-live providers' models), so in practice
+	// this branch terminates on the map hit for any model the
+	// coordinator has ever seen during its process lifetime.
+	if _, ok := r.seenModelsLifetime[canonical]; ok {
+		return true
+	}
+	// Fallback: a currently-connected provider may have advertised
+	// this model id but the lifetime accumulator was at cap when it
+	// did, so it never got recorded. Iterate live providers.
 	for _, p := range r.providers {
 		if strings.EqualFold(p.ModelID, modelID) {
-			return true
-		}
-	}
-	for seen := range r.seenModelsLifetime {
-		if strings.EqualFold(seen, modelID) {
 			return true
 		}
 	}

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -1055,7 +1055,7 @@ func TestSeenModelsLifetimeCap(t *testing.T) {
 	// Drive the lifetime set above cap via the locked record path,
 	// using fresh providers per per-provider-budget window.
 	registry.mu.Lock()
-	idsPerProvider := maxSeenModelsPerProvider
+	idsPerProvider := maxLifetimeContribPerProvider
 	providers := (maxSeenModelsLifetime + 10 + idsPerProvider - 1) / idsPerProvider
 	for p := 0; p < providers; p++ {
 		pid := fmt.Sprintf("provider-%d", p)
@@ -1124,28 +1124,101 @@ func TestRecordSeenModelLockedRejectsOversizeID(t *testing.T) {
 }
 
 // TestRecordSeenModelLockedPerProviderBudgetGatesLifetime pins the
-// ISS-185 R1 security-lane MAJOR fix: a single provider can contribute
-// at most maxSeenModelsPerProvider distinct ids to seenModelsLifetime
-// during one session, so a churning provider cannot consume the
-// lifetime cap past its per-provider budget.
+// ISS-185 R2 security/architect-lane MAJOR fix: the lifetime
+// accumulator is gated INDEPENDENTLY of per-session attribution.
+//
+// - Per-session map (seenModelsByProvider) caps each session at
+//   maxSeenModelsPerProvider distinct ids; gets cleared on
+//   disconnect / session replacement.
+// - Lifetime accumulator caps each provider_id at
+//   maxLifetimeContribPerProvider distinct ids OVER THE ENTIRE
+//   PROCESS LIFETIME — survives reconnect — so churn-via-reconnect
+//   cannot consume more lifetime budget than that per-provider
+//   total.
+//
+// This test fires 2x the per-provider lifetime cap and asserts the
+// gate kicks in at exactly maxLifetimeContribPerProvider.
 func TestRecordSeenModelLockedPerProviderBudgetGatesLifetime(t *testing.T) {
 	registry := NewRegistry(nil)
 	registry.mu.Lock()
-	// Fire 2x per-provider budget worth of distinct ids from one
-	// provider. Only the first maxSeenModelsPerProvider should be
-	// retained; the remainder should NOT consume lifetime capacity.
-	for i := 0; i < 2*maxSeenModelsPerProvider; i++ {
+	// Fire 2x the per-provider lifetime contribution budget from one
+	// provider. Only the first maxLifetimeContribPerProvider should
+	// be retained; the remainder should NOT consume lifetime budget.
+	for i := 0; i < 2*maxLifetimeContribPerProvider; i++ {
 		registry.recordSeenModelLocked("noisy", fmt.Sprintf("id-%d", i))
 	}
 	gotLifetime := len(registry.seenModelsLifetime)
-	gotPerProvider := len(registry.seenModelsByProvider["noisy"])
+	gotContrib := registry.lifetimeContribByProvider["noisy"]
+	gotPerSession := len(registry.seenModelsByProvider["noisy"])
 	registry.mu.Unlock()
-	if gotPerProvider != maxSeenModelsPerProvider {
-		t.Fatalf("seenModelsByProvider[noisy] = %d, want %d", gotPerProvider, maxSeenModelsPerProvider)
+	if gotPerSession != maxSeenModelsPerProvider {
+		t.Fatalf("seenModelsByProvider[noisy] = %d, want %d (per-session cap)",
+			gotPerSession, maxSeenModelsPerProvider)
 	}
-	if gotLifetime != maxSeenModelsPerProvider {
-		t.Fatalf("seenModelsLifetime = %d, want %d (one provider must NOT consume lifetime past per-provider budget)",
-			gotLifetime, maxSeenModelsPerProvider)
+	if gotLifetime != maxLifetimeContribPerProvider {
+		t.Fatalf("seenModelsLifetime = %d, want %d (one provider must not consume lifetime past per-provider lifetime budget)",
+			gotLifetime, maxLifetimeContribPerProvider)
+	}
+	if gotContrib != maxLifetimeContribPerProvider {
+		t.Fatalf("lifetimeContribByProvider[noisy] = %d, want %d (per-provider lifetime counter not at cap)",
+			gotContrib, maxLifetimeContribPerProvider)
+	}
+}
+
+// TestLifetimeContribByProviderSurvivesReconnect pins the ISS-185
+// R2 security-lane MAJOR fix: the per-provider lifetime contribution
+// counter is NOT reset on session disconnect / replacement, so a
+// churning attacker cannot bypass the per-provider cap by repeatedly
+// reconnecting.
+func TestLifetimeContribByProviderSurvivesReconnect(t *testing.T) {
+	registry := NewRegistry(nil)
+	start := time.Unix(1716768000, 0).UTC()
+
+	// Session 1: contribute up to the per-provider lifetime cap.
+	registry.Register(&Provider{
+		ProviderID:       "churn",
+		AssignedID:       "session-1",
+		ModelID:          "id-anchor",
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start,
+		LastActivityAt:   start,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+	registry.mu.Lock()
+	for i := 0; i < maxLifetimeContribPerProvider; i++ {
+		registry.recordSeenModelLocked("churn", fmt.Sprintf("id-%d", i))
+	}
+	contribBefore := registry.lifetimeContribByProvider["churn"]
+	registry.mu.Unlock()
+	if contribBefore < maxLifetimeContribPerProvider {
+		t.Fatalf("setup failed: contribBefore = %d, want >= %d", contribBefore, maxLifetimeContribPerProvider)
+	}
+
+	// Disconnect — per-session map gets cleared by RemoveIfSession.
+	if !registry.RemoveIfSession("churn", "session-1") {
+		t.Fatal("RemoveIfSession returned false")
+	}
+
+	// Try to contribute new ids after reconnect. The per-provider
+	// lifetime counter must persist; ALL new ids should drop.
+	registry.mu.Lock()
+	beforeReconnect := len(registry.seenModelsLifetime)
+	for i := 0; i < 64; i++ {
+		registry.recordSeenModelLocked("churn", fmt.Sprintf("postreconnect-%d", i))
+	}
+	afterReconnect := len(registry.seenModelsLifetime)
+	contribAfter := registry.lifetimeContribByProvider["churn"]
+	registry.mu.Unlock()
+	if afterReconnect != beforeReconnect {
+		t.Fatalf("seenModelsLifetime grew by %d after reconnect; per-provider lifetime gate is reset by disconnect (security regression)",
+			afterReconnect-beforeReconnect)
+	}
+	if contribAfter != contribBefore {
+		t.Fatalf("lifetimeContribByProvider[churn] = %d, want %d (counter reset by disconnect)",
+			contribAfter, contribBefore)
 	}
 }
 

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -3,6 +3,7 @@ package pool
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -969,11 +970,20 @@ func TestApplyHeartbeatSwapEmitterDoesNotFireWhenNoPriorLoading(t *testing.T) {
 	}
 }
 
-// TestModelKnownShrinksOnProviderDisconnect pins the M2-5 / PERF-5
-// guarantee: ModelKnown answers from currently-connected providers only.
-// Pre-M2-5 the registry-wide seenModels map accumulated forever — a
-// 31-day model id observed once still answered true 1y later.
-func TestModelKnownShrinksOnProviderDisconnect(t *testing.T) {
+// TestModelKnownPersistsInLifetimeAccumulator pins the SPEC-002 § 7.2 /
+// issue #185 contract: ModelKnown returns true for any model id ever
+// advertised during the coordinator process lifetime — not only for
+// currently-connected providers' models. The per-provider
+// seenModelsByProvider map still shrinks on RemoveIfSession (PERF-5
+// memory bound), but the dedicated seenModelsLifetime accumulator is
+// append-only within maxSeenModelsLifetime so cold-start races route
+// to 503 no_provider_available instead of 404 model_not_found.
+//
+// Pre-#185, ModelKnown iterated only seenModelsByProvider, so the
+// "only provider disconnected" case answered false and the buyer port
+// returned 404 — the SPEC-002 § 7.2 violation that this test guards
+// against regressing.
+func TestModelKnownPersistsInLifetimeAccumulator(t *testing.T) {
 	registry := NewRegistry(nil)
 	start := time.Unix(1716768000, 0).UTC()
 
@@ -1002,25 +1012,82 @@ func TestModelKnownShrinksOnProviderDisconnect(t *testing.T) {
 	if !registry.ModelKnown("model-a") {
 		t.Fatal("ModelKnown(model-a) = false; per-session memory regressed")
 	}
-	// Disconnect p1 — both models it ever reported should drop from the
-	// global view.
+	// Disconnect p1. seenModelsByProvider["p1"] is dropped (PERF-5
+	// invariant), but seenModelsLifetime retains every model id ever
+	// advertised so SPEC-002 § 7.2's 404-vs-503 distinction is preserved.
 	if !registry.RemoveIfSession("p1", "s1") {
 		t.Fatal("RemoveIfSession returned false")
 	}
-	if registry.ModelKnown("model-a") {
-		t.Fatal("ModelKnown(model-a) still true after the only provider serving it disconnected — leak (PERF-5)")
+	if !registry.ModelKnown("model-a") {
+		t.Fatal("ModelKnown(model-a) = false after p1 disconnected; SPEC-002 § 7.2 cold-start race regressed (issue #185)")
 	}
-	if registry.ModelKnown("model-b") {
-		t.Fatal("ModelKnown(model-b) still true after the only provider serving it disconnected — leak (PERF-5)")
+	if !registry.ModelKnown("model-b") {
+		t.Fatal("ModelKnown(model-b) = false after p1 disconnected; SPEC-002 § 7.2 cold-start race regressed (issue #185)")
+	}
+	// PERF-5 invariant: the per-provider map IS dropped, even though
+	// the lifetime accumulator retains the model ids.
+	registry.mu.RLock()
+	if _, exists := registry.seenModelsByProvider["p1"]; exists {
+		registry.mu.RUnlock()
+		t.Fatal("seenModelsByProvider[p1] still present after RemoveIfSession; PERF-5 cleanup regressed")
+	}
+	registry.mu.RUnlock()
+	// Never-seen model id MUST still answer false — the cap is on
+	// "seen", not on "any id is true".
+	if registry.ModelKnown("nonexistent-model-9000") {
+		t.Fatal("ModelKnown(nonexistent-model-9000) = true; lifetime accumulator returning false positives")
+	}
+}
+
+// TestSeenModelsLifetimeCap pins the PERF-5 reconciliation in issue
+// #185: the lifetime accumulator is bounded at maxSeenModelsLifetime.
+// Beyond the cap, further inserts silently drop, degrading cold-start
+// races to legacy 404 behavior for the dropped ids without unbounded
+// growth.
+func TestSeenModelsLifetimeCap(t *testing.T) {
+	registry := NewRegistry(nil)
+	start := time.Unix(1716768000, 0).UTC()
+	registry.Register(&Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s1",
+		ModelID:          "model-anchor",
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start,
+		LastActivityAt:   start,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+	// Drive the lifetime set to cap via the locked record path.
+	registry.mu.Lock()
+	for i := 0; i < maxSeenModelsLifetime+10; i++ {
+		registry.recordSeenModelLocked("p1", fmt.Sprintf("synthetic-%d", i))
+	}
+	got := len(registry.seenModelsLifetime)
+	registry.mu.Unlock()
+	if got > maxSeenModelsLifetime {
+		t.Fatalf("seenModelsLifetime = %d entries, want <= %d (cap)", got, maxSeenModelsLifetime)
 	}
 }
 
 // TestRegisterReplaceSessionClearsSeenModels pins the M2-5 / PERF-5 fix for the
-// codex code-audit 2026-06-11 #47 finding: a session replacement (same
-// provider_id, new assigned_id) MUST clear the per-provider seen-model
-// history, else stale model ids from the prior session survive into the
-// new one and ModelKnown over-reports.
-func TestRegisterReplaceSessionClearsSeenModels(t *testing.T) {
+// TestRegisterReplaceSessionClearsPerProviderAttribution pins the
+// codex code-audit 2026-06-11 #47 finding at its native level — the
+// per-provider attribution map — after issue #185 split the
+// pool-lifetime accumulator out from per-provider attribution.
+//
+// Audit #47's concern was stale model attribution leaking across a
+// session replacement (same provider_id, new assigned_id), which
+// would have ModelKnown over-report when the old surface aggregated
+// per-provider entries. With #185 in place, ModelKnown reads from the
+// pool-lifetime accumulator (which DOES retain all model ids ever
+// advertised, per SPEC-002 § 7.2 — that's the 404-vs-503 distinction).
+// The audit #47 invariant moved down a layer: session replacement
+// MUST drop seenModelsByProvider[provider_id] so any future
+// per-provider attribution / explorer-style queries see only the
+// current session.
+func TestRegisterReplaceSessionClearsPerProviderAttribution(t *testing.T) {
 	registry := NewRegistry(nil)
 	start := time.Unix(1716768000, 0).UTC()
 
@@ -1043,8 +1110,6 @@ func TestRegisterReplaceSessionClearsSeenModels(t *testing.T) {
 	}
 
 	// Session 2 replaces session 1 with a different model entirely.
-	// (Same provider_id, new assigned_id — the direct-replacement path
-	// inside Register, not the RemoveIfSession path.)
 	registry.Register(&Provider{
 		ProviderID:       "p1",
 		AssignedID:       "s2",
@@ -1060,11 +1125,32 @@ func TestRegisterReplaceSessionClearsSeenModels(t *testing.T) {
 	if !registry.ModelKnown("model-c") {
 		t.Fatal("session-2 model not recorded after replacement")
 	}
-	if registry.ModelKnown("model-a") {
-		t.Fatal("ModelKnown(model-a) leaked across session replacement; prior history should be cleared")
+
+	// SPEC-002 § 7.2: prior-session models REMAIN in the pool-lifetime
+	// accumulator. ModelKnown reports them — that's the cold-start
+	// race fix (issue #185).
+	if !registry.ModelKnown("model-a") {
+		t.Fatal("ModelKnown(model-a) = false after session replacement; SPEC-002 § 7.2 lifetime accumulator regressed")
 	}
-	if registry.ModelKnown("model-b") {
-		t.Fatal("ModelKnown(model-b) leaked across session replacement; prior history should be cleared")
+	if !registry.ModelKnown("model-b") {
+		t.Fatal("ModelKnown(model-b) = false after session replacement; SPEC-002 § 7.2 lifetime accumulator regressed")
+	}
+
+	// Audit #47 invariant on the per-provider attribution map:
+	// session replacement DROPS the prior session's per-provider
+	// entries so attribution-style queries see only the current
+	// session's models.
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	set := registry.seenModelsByProvider["p1"]
+	if _, has := set["model-a"]; has {
+		t.Fatal("seenModelsByProvider[p1] still contains model-a after session replacement; audit #47 attribution invariant regressed")
+	}
+	if _, has := set["model-b"]; has {
+		t.Fatal("seenModelsByProvider[p1] still contains model-b after session replacement; audit #47 attribution invariant regressed")
+	}
+	if _, has := set["model-c"]; !has {
+		t.Fatal("seenModelsByProvider[p1] missing model-c after registering session 2")
 	}
 }
 

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -1041,33 +1042,110 @@ func TestModelKnownPersistsInLifetimeAccumulator(t *testing.T) {
 
 // TestSeenModelsLifetimeCap pins the PERF-5 reconciliation in issue
 // #185: the lifetime accumulator is bounded at maxSeenModelsLifetime.
-// Beyond the cap, further inserts silently drop, degrading cold-start
-// races to legacy 404 behavior for the dropped ids without unbounded
-// growth.
+// Beyond the cap, further inserts drop (with a warn-once log + a
+// counter), degrading cold-start races to legacy 404 behavior for the
+// dropped ids without unbounded growth.
+//
+// Per-provider gating (security-lane MAJOR R1): the cap exhaustion
+// scenario must be driven via DISTINCT providers, since one provider
+// is limited to maxSeenModelsPerProvider distinct ids by design.
 func TestSeenModelsLifetimeCap(t *testing.T) {
 	registry := NewRegistry(nil)
-	start := time.Unix(1716768000, 0).UTC()
-	registry.Register(&Provider{
-		ProviderID:       "p1",
-		AssignedID:       "s1",
-		ModelID:          "model-anchor",
-		State:            StateReady,
-		SlotsFree:        1,
-		SlotsTotal:       1,
-		LastHeartbeatAt:  start,
-		LastActivityAt:   start,
-		MaxConcurrency:   1,
-		MaxContextTokens: 20000,
-	}, nil)
-	// Drive the lifetime set to cap via the locked record path.
+
+	// Drive the lifetime set above cap via the locked record path,
+	// using fresh providers per per-provider-budget window.
 	registry.mu.Lock()
-	for i := 0; i < maxSeenModelsLifetime+10; i++ {
-		registry.recordSeenModelLocked("p1", fmt.Sprintf("synthetic-%d", i))
+	idsPerProvider := maxSeenModelsPerProvider
+	providers := (maxSeenModelsLifetime + 10 + idsPerProvider - 1) / idsPerProvider
+	for p := 0; p < providers; p++ {
+		pid := fmt.Sprintf("provider-%d", p)
+		for i := 0; i < idsPerProvider; i++ {
+			modelID := fmt.Sprintf("synthetic-%d-%d", p, i)
+			registry.recordSeenModelLocked(pid, modelID)
+		}
 	}
+
 	got := len(registry.seenModelsLifetime)
+	dropped := registry.lifetimeCapDroppedCount
+	warned := registry.lifetimeCapWarnedOnce
+	// Confirm the early id is retained (filled cap, not cleared).
+	_, earlyRetained := registry.seenModelsLifetime["synthetic-0-0"]
+	// A late id beyond cap must be absent.
+	_, lateAbsent := registry.seenModelsLifetime[fmt.Sprintf("synthetic-%d-%d", providers-1, idsPerProvider-1)]
 	registry.mu.Unlock()
-	if got > maxSeenModelsLifetime {
-		t.Fatalf("seenModelsLifetime = %d entries, want <= %d (cap)", got, maxSeenModelsLifetime)
+
+	if got != maxSeenModelsLifetime {
+		t.Fatalf("seenModelsLifetime = %d entries, want exactly %d (cap)", got, maxSeenModelsLifetime)
+	}
+	if !earlyRetained {
+		t.Fatal("seenModelsLifetime dropped the early synthetic-0-0 entry; cap policy is supposed to drop tail, not head")
+	}
+	if lateAbsent {
+		t.Fatal("seenModelsLifetime contains a beyond-cap entry; cap is not enforced")
+	}
+	if dropped == 0 {
+		t.Fatal("lifetimeCapDroppedCount = 0 after driving cap exhaustion; observability counter not wired")
+	}
+	if !warned {
+		t.Fatal("lifetimeCapWarnedOnce = false after driving cap exhaustion; warn-once observability not wired")
+	}
+
+	// Probe ModelKnown for both retained and dropped ids — confirms
+	// the SPEC § 7.2 contract degrades to legacy 404 only for the
+	// dropped ids.
+	if !registry.ModelKnown("synthetic-0-0") {
+		t.Fatal("ModelKnown(synthetic-0-0) = false; retained id not visible to routing decision")
+	}
+	if registry.ModelKnown(fmt.Sprintf("synthetic-%d-%d", providers-1, idsPerProvider-1)) {
+		t.Fatal("ModelKnown(beyond-cap-id) = true; dropped id is leaking into routing decision")
+	}
+}
+
+// TestRecordSeenModelLockedRejectsOversizeID pins the ISS-185 R1
+// security-lane CRITICAL fix: model_id strings beyond
+// maxModelIDByteLen are not persisted into either the per-provider
+// attribution map or the lifetime accumulator. Without this bound an
+// admitted provider could store arbitrarily-large strings in
+// process-lifetime memory.
+func TestRecordSeenModelLockedRejectsOversizeID(t *testing.T) {
+	registry := NewRegistry(nil)
+	oversize := strings.Repeat("x", maxModelIDByteLen+1)
+	registry.mu.Lock()
+	registry.recordSeenModelLocked("p1", oversize)
+	gotLifetime := len(registry.seenModelsLifetime)
+	gotPerProvider := len(registry.seenModelsByProvider["p1"])
+	registry.mu.Unlock()
+	if gotLifetime != 0 {
+		t.Fatalf("oversize id leaked into seenModelsLifetime: %d entries", gotLifetime)
+	}
+	if gotPerProvider != 0 {
+		t.Fatalf("oversize id leaked into seenModelsByProvider[p1]: %d entries", gotPerProvider)
+	}
+}
+
+// TestRecordSeenModelLockedPerProviderBudgetGatesLifetime pins the
+// ISS-185 R1 security-lane MAJOR fix: a single provider can contribute
+// at most maxSeenModelsPerProvider distinct ids to seenModelsLifetime
+// during one session, so a churning provider cannot consume the
+// lifetime cap past its per-provider budget.
+func TestRecordSeenModelLockedPerProviderBudgetGatesLifetime(t *testing.T) {
+	registry := NewRegistry(nil)
+	registry.mu.Lock()
+	// Fire 2x per-provider budget worth of distinct ids from one
+	// provider. Only the first maxSeenModelsPerProvider should be
+	// retained; the remainder should NOT consume lifetime capacity.
+	for i := 0; i < 2*maxSeenModelsPerProvider; i++ {
+		registry.recordSeenModelLocked("noisy", fmt.Sprintf("id-%d", i))
+	}
+	gotLifetime := len(registry.seenModelsLifetime)
+	gotPerProvider := len(registry.seenModelsByProvider["noisy"])
+	registry.mu.Unlock()
+	if gotPerProvider != maxSeenModelsPerProvider {
+		t.Fatalf("seenModelsByProvider[noisy] = %d, want %d", gotPerProvider, maxSeenModelsPerProvider)
+	}
+	if gotLifetime != maxSeenModelsPerProvider {
+		t.Fatalf("seenModelsLifetime = %d, want %d (one provider must NOT consume lifetime past per-provider budget)",
+			gotLifetime, maxSeenModelsPerProvider)
 	}
 }
 

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -1171,14 +1171,14 @@ func TestRecordSeenModelLockedRejectsOversizeID(t *testing.T) {
 // ISS-185 R2 security/architect-lane MAJOR fix: the lifetime
 // accumulator is gated INDEPENDENTLY of per-session attribution.
 //
-// - Per-session map (seenModelsByProvider) caps each session at
-//   maxSeenModelsPerProvider distinct ids; gets cleared on
-//   disconnect / session replacement.
-// - Lifetime accumulator caps each provider_id at
-//   maxLifetimeContribPerProvider distinct ids OVER THE ENTIRE
-//   PROCESS LIFETIME — survives reconnect — so churn-via-reconnect
-//   cannot consume more lifetime budget than that per-provider
-//   total.
+//   - Per-session map (seenModelsByProvider) caps each session at
+//     maxSeenModelsPerProvider distinct ids; gets cleared on
+//     disconnect / session replacement.
+//   - Lifetime accumulator caps each provider_id at
+//     maxLifetimeContribPerProvider distinct ids OVER THE ENTIRE
+//     PROCESS LIFETIME — survives reconnect — so churn-via-reconnect
+//     cannot consume more lifetime budget than that per-provider
+//     total.
 //
 // This test fires 2x the per-provider lifetime cap and asserts the
 // gate kicks in at exactly maxLifetimeContribPerProvider.

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -1101,6 +1101,50 @@ func TestSeenModelsLifetimeCap(t *testing.T) {
 	}
 }
 
+// TestModelKnownPreservesEqualFoldOnLifetimeOnlyPath pins the
+// ISS-185 R3 code-lane MAJOR fix: ModelKnown's case-folding contract
+// has historically been Unicode strings.EqualFold (not
+// strings.ToLower), so Turkish-I / Greek-sigma edges that
+// EqualFold-match must continue to return true even after the
+// advertising provider disconnects (so the lookup is on the
+// lifetime-only path).
+//
+// strings.ToLower("İ") == "i̇" (with combining dot above) while
+// strings.EqualFold("İ", "İ") == true. A ToLower-only key store
+// would miss this case. With the R3 EqualFold scan fallback on
+// the lifetime accumulator, the SPEC § 7.2 contract is preserved
+// for these edges.
+func TestModelKnownPreservesEqualFoldOnLifetimeOnlyPath(t *testing.T) {
+	registry := NewRegistry(nil)
+	start := time.Unix(1716768000, 0).UTC()
+
+	// Greek capital sigma "Σ" and final sigma "ς" EqualFold-match;
+	// ToLower differs.
+	registry.Register(&Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s1",
+		ModelID:          "model-Σ",
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start,
+		LastActivityAt:   start,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+	if !registry.RemoveIfSession("p1", "s1") {
+		t.Fatal("RemoveIfSession returned false")
+	}
+	// Now the lookup goes through the lifetime-only path. Both forms
+	// must return true via the EqualFold contract.
+	if !registry.ModelKnown("model-Σ") {
+		t.Fatal("ModelKnown(model-Σ) = false; lifetime-only path lost the recorded id")
+	}
+	if !registry.ModelKnown("model-ς") {
+		t.Fatal("ModelKnown(model-ς) = false; EqualFold contract regressed (ToLower-only canonical key would miss this)")
+	}
+}
+
 // TestRecordSeenModelLockedRejectsOversizeID pins the ISS-185 R1
 // security-lane CRITICAL fix: model_id strings beyond
 // maxModelIDByteLen are not persisted into either the per-provider

--- a/specs/AUDIT_FIX_ISS_185_R1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_185_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,111 @@
+# ISS-185 R1 — architect-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-185-cold-start-404-to-503`
+against `origin/main`. The change restores SPEC-002 § 7.2's
+404-vs-503 distinction on cold-start races by adding a pool-lifetime
+model-id accumulator separate from the per-provider attribution map.
+
+## Background
+
+SPEC-002 v1.4.1 § 7.2 (lines 2381-2389) says:
+
+- 404 model_not_found ⇔ model_id NEVER advertised during this
+  coordinator process lifetime.
+- 503 no_provider_available ⇔ model_id is in pool-lifetime history
+  but no eligible provider can take the request right now.
+
+The M2-5 / PERF-5 audit (2026-06-10) flagged a memory-leak in the
+pre-M2-5 registry-wide `seenModels` accumulator (no cleanup on
+provider removal). M2-5 fixed the leak by keying the map per
+provider and dropping the inner map on disconnect — but in doing
+so it silently shrank `ModelKnown`'s answer to "currently-connected
+only", introducing the SPEC § 7.2 violation that issue #185
+documents.
+
+This PR reconciles both: a bounded lifetime accumulator
+(`seenModelsLifetime`, cap 4096) restores SPEC § 7.2 semantics
+while preserving PERF-5's memory-bound invariant. The per-provider
+attribution map keeps its M2-5 shrink-on-disconnect semantic but is
+no longer the source of truth for `ModelKnown`.
+
+## Scope of this lane
+
+You are the **architect lane**. Focus on:
+
+- **Spec consistency.** Does the new ModelKnown satisfy SPEC-002 §
+  7.2's exact wording? Read the spec text and the new
+  implementation side-by-side. Any edge cases where spec ≠ code?
+- **Test contracts vs spec contracts.** The rewritten test
+  `TestRegisterReplaceSessionClearsPerProviderAttribution`
+  reinterprets the codex 2026-06-11 #47 finding — audit #47's
+  concern moves from the ModelKnown surface to the per-provider
+  attribution map. Is that reinterpretation legitimate, or does it
+  drop a real invariant? Specifically: are there OTHER call sites
+  besides ModelKnown that read `seenModelsByProvider` and would
+  surface stale attribution if it shrinks on disconnect-but-not on
+  replacement?
+- **Naming.** `seenModelsLifetime` vs `seenModelsByProvider`. Are
+  the names self-explaining? Should one or both be renamed for
+  clarity? (Suggestion to reject: "modelHistory" — too vague.)
+- **Cap value.** 4096 models per coordinator lifetime — defensible
+  for mac-provider deployments where catalogs are 5-50 models?
+  Should the cap be configurable, or is a hardcoded constant
+  acceptable for now? Should the cap be tied to a SPEC-002 minor
+  bump, or is it a purely operational dial?
+- **Cap-reached behavior.** Silent-drop degrades cold-start races to
+  legacy 404 for the dropped ids. Is "fail open to legacy buggy
+  behavior" the right contract on cap exhaustion, or should it
+  fail closed (e.g., reject the heartbeat with a hash mismatch
+  reason)?
+- **Cross-spec.** SPEC-005 / SPEC-006 / SPEC-011 do not reference
+  the 404/503 split directly, but any test fixture or harness that
+  relies on `ModelKnown` returning false post-disconnect would
+  break. Are there any?
+- **Phase-C harness alignment.** Issue #185 references the internal
+  e2e harness scenario `06_cold_start_race.yaml`. Should the spec
+  text or addendum mention how harnesses introspect the 4096-cap
+  or the column-present/index-absent semantics introduced by #195
+  (no, that's a different PR — call it out as a cross-reference
+  only).
+- **Versioning.** Does this need a SPEC-002 v1.4.3 minor bump, or
+  is it strictly an implementation fix of v1.4.1 § 7.2 (no spec
+  text change required)? Argue both sides.
+
+## Files in the diff
+
+```
+phase4-coordinator/internal/pool/provider.go
+phase4-coordinator/internal/pool/provider_test.go
+phase4-coordinator/internal/buyer/server_test.go
+```
+
+Useful command:
+```
+git diff origin/main -- phase4-coordinator/
+specs/SPEC-002-coordinator.md   # § 7.2
+```
+
+## Scope: PR-INTRODUCED findings only
+
+Per the locked three-lane convergence convention: this audit gates
+this PR on findings INTRODUCED by the diff against origin/main.
+Pre-existing concerns visible to your audit but NOT modified by
+this PR are out of scope for blocking convergence — they may be
+worth filing as separate issues but they do NOT block PR landing.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **Aspect:** spec | naming | versioning | cross-service | contract
+- **Issue:** one-sentence problem statement
+- **Evidence:** quote relevant code / spec
+- **Recommendation:** specific change
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Keep response under 800 words.

--- a/specs/AUDIT_FIX_ISS_185_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_185_R1_CODE_PROMPT.md
@@ -1,0 +1,97 @@
+# ISS-185 R1 — code-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-185-cold-start-404-to-503`
+(opening as PR shortly) against `origin/main`. The change implements
+SPEC-002 § 7.2's cold-start 404 vs 503 distinction by adding a
+pool-lifetime model-id accumulator (`Registry.seenModelsLifetime`)
+that survives provider disconnect, distinct from the per-provider
+attribution map (`seenModelsByProvider`) that the M2-5 / PERF-5 audit
+correctly shrinks on disconnect.
+
+## Scope of this lane
+
+You are the **code lane**. Focus on:
+
+- **Concurrency.** `Registry` is shared across handler goroutines.
+  `seenModelsLifetime` is a plain map, guarded by `r.mu`. Are all
+  read sites under `mu.RLock` / write sites under `mu.Lock`?
+  Verify `recordSeenModelLocked` is only called with the write lock
+  held (per its godoc), and `ModelKnown` reads under `mu.RLock`.
+- **Cap behavior.** `maxSeenModelsLifetime = 4096` — silent-drop
+  beyond cap. Is the drop documented? Is the cap exercised by a
+  test? Is the cap reachable in legitimate use (probably not — most
+  deployments serve 5-50 models — but worth confirming the units).
+- **Symmetry between the two maps.** Both maps are written by
+  `recordSeenModelLocked`. Is there any other code path that writes
+  to ONE but not the other? Grep for direct map indexing.
+- **ModelKnown semantics.** Per SPEC-002 § 7.2: "ever seen during
+  coordinator lifetime". Does the new ModelKnown return true iff
+  the lifetime accumulator OR a currently-connected provider has
+  the model id? Edge: case-insensitive matching is preserved
+  (existing `strings.EqualFold` behavior). Is it?
+- **Test coverage.** New tests are
+  `TestModelKnownPersistsInLifetimeAccumulator`,
+  `TestSeenModelsLifetimeCap`, the rewritten
+  `TestRegisterReplaceSessionClearsPerProviderAttribution`, and
+  `TestChatCompletionsColdStartRaceReturnsNoProviderAvailable`. Are
+  the assertions tight (status code + error code + body shape)? Is
+  the existing `TestChatCompletionsSplitsUnknownModelAndUnavailableProvider`
+  unaffected (it should still pass — the never-seen path is the
+  unchanged 404 path).
+- **Other call sites of ModelKnown.** Grep `phase4-coordinator/` for
+  other ModelKnown callers. Any that would break under the new
+  "ever seen" semantic vs the old "currently-known" semantic?
+
+Out of scope for this lane (other lanes own):
+
+- **Security lane:** DoS via model-id flooding, cap exhaustion.
+- **Architect lane:** spec consistency vs SPEC-002 § 7.2, naming.
+
+Do NOT duplicate their work.
+
+## Files in the diff
+
+```
+phase4-coordinator/internal/pool/provider.go
+phase4-coordinator/internal/pool/provider_test.go
+phase4-coordinator/internal/buyer/server_test.go
+```
+
+Useful command:
+```
+git diff origin/main -- phase4-coordinator/
+```
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **File:line(s):** exact reference
+- **Issue:** one-sentence problem statement
+- **Evidence:** quote relevant code
+- **Recommendation:** specific change
+
+Severity definitions:
+
+- **CRITICAL:** breaks the build/tests, exploitable, or
+  load-bearing invariant violated. Must fix before this lands.
+- **MAJOR:** correctness regression or test gap on the
+  PR-introduced surface. Should fix before this lands.
+- **MINOR:** hardening / clarity opportunity.
+- **NOTE:** future-proofing observation.
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+## Scope: PR-INTRODUCED findings only
+
+Per the locked three-lane convergence convention: this audit gates
+this PR on findings INTRODUCED by the diff against origin/main.
+Pre-existing concerns visible to your audit but NOT modified by
+this PR are out of scope for blocking convergence — they may be
+worth filing as separate issues but they do NOT block PR landing.
+
+Keep response under 800 words.

--- a/specs/AUDIT_FIX_ISS_185_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_185_R1_SECURITY_PROMPT.md
@@ -1,0 +1,108 @@
+# ISS-185 R1 — security-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-185-cold-start-404-to-503`
+against `origin/main`. The change adds an append-only model-id
+accumulator (`Registry.seenModelsLifetime`, capped at 4096) that
+survives provider disconnect, to satisfy SPEC-002 § 7.2's 404 vs
+503 distinction.
+
+## Scope of this lane
+
+You are the **security lane**. Focus on:
+
+- **DoS via model-id flooding.** Providers control the model id they
+  advertise (`hello.model_id`, heartbeat updates). A misbehaving or
+  compromised provider could churn through synthetic model ids
+  to consume the lifetime accumulator's 4096-slot cap and degrade
+  the SPEC-002 § 7.2 contract for legitimate models that arrive
+  later.
+  - Is the per-provider cap (32) still in effect to bound how many
+    distinct ids ONE provider can contribute?
+  - Is there a per-second / per-minute insertion rate that an
+    attacker can exploit? Look for the heartbeat path's model-id
+    handling.
+- **Memory exhaustion.** 4096 string entries × ~64 byte avg model
+  id ≈ 256KB worst case. Acceptable, but verify:
+  - The accumulator is per-Registry, not global. Multiple Registry
+    instances would multiply.
+  - Are there callers that allocate multiple Registry instances?
+- **Cap-reached behavior.** When the lifetime cap is reached, the
+  silent-drop degrades cold-start races back to 404 for the dropped
+  ids. Is that the right failure mode (silent permissive) vs
+  something louder (warn-log, metric)?
+- **Read-side amplification.** ModelKnown iterates
+  `seenModelsLifetime` with case-insensitive `strings.EqualFold`.
+  At the 4096 cap, that's a 4096-step string compare per buyer
+  request 404-vs-503 decision. Is that on the hot path? If so, is
+  the cost bounded?
+- **Side channels.** Can an attacker probe whether a model id was
+  ever advertised by timing the 404-vs-503 response or by direct
+  observation? (Spec already publishes this via `/v1/models`, so
+  probably not a new leak — confirm.)
+- **Provider impersonation.** A new provider connecting with a
+  reused provider_id (session replacement) doesn't reset the
+  lifetime accumulator. Is that correct? (Yes per SPEC § 7.2 — the
+  pool retains memory across sessions. But confirm no privilege
+  state is implicitly trusted by virtue of being in the
+  accumulator.)
+
+Out of scope for this lane (other lanes own):
+
+- **Code lane:** Go idiom, lock placement, test coverage.
+- **Architect lane:** spec consistency vs SPEC-002 § 7.2, naming.
+
+Do NOT duplicate their work.
+
+## Files in the diff
+
+```
+phase4-coordinator/internal/pool/provider.go
+phase4-coordinator/internal/pool/provider_test.go
+phase4-coordinator/internal/buyer/server_test.go
+```
+
+Useful command:
+```
+git diff origin/main -- phase4-coordinator/
+```
+
+## Scope: PR-INTRODUCED findings only
+
+Per the locked three-lane convergence convention: this audit gates
+this PR on findings INTRODUCED by the diff against origin/main.
+Pre-existing vulnerabilities visible to your audit but NOT modified
+by this PR are out of scope for blocking convergence — they may be
+worth filing as separate issues but they do NOT block this PR.
+
+Example of in-scope: a provider can churn model ids to consume the
+lifetime cap and degrade SPEC § 7.2 for legitimate models.
+
+Example of out-of-scope: the heartbeat path doesn't authenticate
+the provider's model_id claim against any catalog — that's a
+pre-existing trust model, file separately if it's wrong.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **File:line(s):** exact reference
+- **Threat model / attack surface:** one-sentence statement
+- **Evidence:** quote relevant code
+- **Recommendation:** specific change
+
+Severity definitions:
+
+- **CRITICAL:** exploitable now or under realistic adversary
+  assumptions. Must fix before this lands.
+- **MAJOR:** weakens defense in depth; likely to be problematic
+  at scale or in beta.
+- **MINOR:** hardening opportunity.
+- **NOTE:** future-proofing observation.
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Keep response under 800 words.


### PR DESCRIPTION
Closes [#185](https://github.com/Augustas11/macprovider/issues/185).

## What this PR does

SPEC-002 § 7.2 distinguishes:
- **404 `model_not_found`** — model_id NEVER advertised during this coordinator process lifetime.
- **503 `no_provider_available`** — model_id is in pool-lifetime history but no eligible provider is available right now.

OpenAI-compatible clients treat 404 as misconfiguration ('the model id is wrong, stop trying') and 503 as transient ('back off, retry'). The phase-A network-harness scenario `06_cold_start_race` surfaced that the coordinator returned 404 in the cold-start case, blocking buyers from recovering after a provider hiccup.

## Root cause

The M2-5 / PERF-5 audit (2026-06-10) fixed a memory leak by keying `seenModels` per provider and dropping the inner map on disconnect. That fix inadvertently shrank `ModelKnown`'s answer to 'currently-connected only', violating SPEC § 7.2.

## Reconciliation

- New `Registry.seenModelsLifetime`: append-only map of every model id ever advertised during the coordinator process lifetime. Bounded at `maxSeenModelsLifetime = 4096` (orders of magnitude above realistic mac-provider catalogs of 5-50 models). Beyond cap, further inserts silently drop.
- `ModelKnown` now reads the lifetime accumulator (plus live-provider `ModelID` as a fast-path).
- `Registry.seenModelsByProvider` keeps its M2-5 shrink-on-disconnect behavior. Codex audit #47 invariant moves down a layer to per-provider attribution.

## Regression tests

- `TestChatCompletionsColdStartRaceReturnsNoProviderAvailable` — scripts the cold-start race at the HTTP-handler boundary; asserts 503 + 404 split.
- `TestModelKnownPersistsInLifetimeAccumulator` — pins the SPEC § 7.2 contract at the Registry level.
- `TestSeenModelsLifetimeCap` — pins the maxSeenModelsLifetime bound.
- `TestRegisterReplaceSessionClearsPerProviderAttribution` — rewritten codex audit #47 test.

## Audit plan

Three-lane codex audit (`specs/AUDIT_FIX_ISS_185_R1_*.md`): code / security / architect. Convergence loop to 0 CRITICAL / 0 MAJOR per the locked SPEC-audit convention.