### PR TITLE
fix(gateway): SPEC-002 FR-B6 mid-stream provider_disconnected SSE envelope (closes #186)

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -410,7 +410,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 				deltaBytes, hasChoices, parseOK := streamingCompletionDeltaBytes(data)
 				if !parseOK {
 					slog.Warn("streaming gateway estimate saw malformed chunk; truncating stream", "request_id", requestID(r))
-					writeSSEError(w, "Upstream stream returned malformed data", "stream_malformed")
+					writeSSEError(w, "Upstream stream returned malformed data", "api_error", "stream_malformed")
 					if flusher != nil {
 						flusher.Flush()
 					}
@@ -424,7 +424,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 					maxCompletion := maxStreamingCompletionTokens(promptEstimate, maxUsageTokens)
 					if projectedCompletion > maxCompletion {
 						slog.Warn("streaming gateway estimate exceeded request maximum; truncating stream", "request_id", requestID(r), "estimated_completion_tokens", projectedCompletion, "max_completion_tokens", maxCompletion)
-						writeSSEError(w, "Upstream stream exceeded requested max_tokens", "stream_output_exceeded")
+						writeSSEError(w, "Upstream stream exceeded requested max_tokens", "api_error", "stream_output_exceeded")
 						if flusher != nil {
 							flusher.Flush()
 						}
@@ -444,7 +444,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 					}
 				} else if !hasChoices {
 					slog.Warn("streaming gateway estimate saw data chunk without choices or usage; truncating stream", "request_id", requestID(r))
-					writeSSEError(w, "Upstream stream returned malformed data", "stream_malformed")
+					writeSSEError(w, "Upstream stream returned malformed data", "api_error", "stream_malformed")
 					if flusher != nil {
 						flusher.Flush()
 					}
@@ -473,7 +473,11 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		line, err := reader.ReadSlice('\n')
 		if errors.Is(err, bufio.ErrBufferFull) {
 			slog.Error("streaming coordinator line exceeded limit", "request_id", requestID(r), "max_line_bytes", maxStreamingLineBytes)
-			writeSSEError(w, "Upstream stream failed", "stream_truncated")
+			// Gateway-side truncation due to oversized line — NOT a
+			// provider disconnect. Keep the legacy stream_truncated /
+			// api_error envelope; this is gateway protection, not
+			// upstream failure.
+			writeSSEError(w, "Upstream stream failed", "api_error", "stream_truncated")
 			if flusher != nil {
 				flusher.Flush()
 			}
@@ -500,7 +504,16 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			return
 		}
 		slog.Error("streaming coordinator read failed", "request_id", requestID(r), "error", err)
-		writeSSEError(w, "Upstream stream failed", "stream_truncated")
+		// SPEC-002 § FR-B6 / issue #186: an unexpected read error on
+		// the coordinator-side stream (not EOF, not buyer cancel) is
+		// the mid-stream provider-disconnect surface. The buyer MUST
+		// see the exact FR-B6 envelope so OpenAI-compatible SDKs
+		// distinguish a truncated successful response from a provider
+		// drop and react (retry / surface to caller). The internal
+		// settlement outcome remains `stream_truncated` per SPEC-006
+		// § 17.7 — that maps to usage_events.outcome, a separate
+		// field from the buyer-visible SSE error.code.
+		writeSSEError(w, "Provider disconnected during streaming", "server_error", "provider_disconnected")
 		if flusher != nil {
 			flusher.Flush()
 		}
@@ -794,8 +807,15 @@ func (sw *statusWriter) Flush() {
 	}
 }
 
-func writeSSEError(w http.ResponseWriter, message, code string) {
-	payload, _ := json.Marshal(map[string]any{"error": map[string]any{"message": message, "type": "api_error", "code": code}})
+// writeSSEError emits the FR-B6 mid-stream OpenAI-compatible error
+// envelope followed by `data: [DONE]`. errType is the OpenAI error
+// `type` field; the canonical SPEC-002 FR-B6 example for a mid-stream
+// provider disconnect uses `server_error`. Other call sites
+// (malformed upstream, gateway-side truncation, max-tokens overflow)
+// continue to use `api_error` — the spec only fixes the
+// provider-disconnect shape.
+func writeSSEError(w http.ResponseWriter, message, errType, code string) {
+	payload, _ := json.Marshal(map[string]any{"error": map[string]any{"message": message, "type": errType, "code": code}})
 	_, _ = w.Write([]byte("data: "))
 	_, _ = w.Write(payload)
 	_, _ = w.Write([]byte("\n\ndata: [DONE]\n\n"))

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -510,10 +510,18 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		// see the exact FR-B6 envelope so OpenAI-compatible SDKs
 		// distinguish a truncated successful response from a provider
 		// drop and react (retry / surface to caller). The internal
-		// settlement outcome remains `stream_truncated` per SPEC-006
-		// § 17.7 — that maps to usage_events.outcome, a separate
-		// field from the buyer-visible SSE error.code.
-		writeSSEError(w, "Provider disconnected during streaming", "server_error", "provider_disconnected")
+		// settlement outcome remains `stream_truncated` per the gateway
+		// settlement convention + SPEC-006 § 17.7 quota-debit policy —
+		// that maps to usage_events.outcome, a separate field from the
+		// buyer-visible SSE error.code.
+		//
+		// NOTE: error.type=server_error signals OpenAI-compatible SDKs
+		// that the request is retriable. Gateway-side Idempotency-Key
+		// dedupe is the open follow-up tracked in issue #200 — until
+		// that lands, a buyer retrying after this envelope MAY incur
+		// a fresh reservation if the coordinator's idempotency-cache
+		// response isn't refund-honored on the gateway side.
+		writeProviderDisconnectedSSE(w)
 		if flusher != nil {
 			flusher.Flush()
 		}
@@ -819,6 +827,16 @@ func writeSSEError(w http.ResponseWriter, message, errType, code string) {
 	_, _ = w.Write([]byte("data: "))
 	_, _ = w.Write(payload)
 	_, _ = w.Write([]byte("\n\ndata: [DONE]\n\n"))
+}
+
+// writeProviderDisconnectedSSE emits the SPEC-002 § FR-B6 mid-stream
+// provider-disconnect envelope verbatim. The strings are
+// load-bearing: SDK clients route on (error.code, error.type) and
+// any drift breaks compatibility. Centralizing the call here lets
+// future refactors lean on a single named contract surface instead
+// of free-form writeSSEError args. Issue #186; architect R1 NOTE.
+func writeProviderDisconnectedSSE(w http.ResponseWriter) {
+	writeSSEError(w, "Provider disconnected during streaming", "server_error", "provider_disconnected")
 }
 
 func parseChatRequest(body []byte) (chatRequest, error) {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -815,13 +815,16 @@ func (sw *statusWriter) Flush() {
 	}
 }
 
-// writeSSEError emits the FR-B6 mid-stream OpenAI-compatible error
-// envelope followed by `data: [DONE]`. errType is the OpenAI error
-// `type` field; the canonical SPEC-002 FR-B6 example for a mid-stream
-// provider disconnect uses `server_error`. Other call sites
-// (malformed upstream, gateway-side truncation, max-tokens overflow)
-// continue to use `api_error` — the spec only fixes the
-// provider-disconnect shape.
+// writeSSEError emits an SSE error event followed by `data: [DONE]`.
+// errType is the OpenAI error `type` field. Call sites use this
+// helper for several mid-stream error shapes: malformed upstream
+// chunks (api_error / stream_malformed), max-tokens overflow
+// (api_error / stream_output_exceeded), gateway-side line
+// truncation (api_error / stream_truncated), and the SPEC-002
+// FR-B6 provider-disconnect envelope (server_error /
+// provider_disconnected). The FR-B6 envelope is built via the
+// dedicated writeProviderDisconnectedSSE wrapper so its strings
+// are centralized and resistant to drift.
 func writeSSEError(w http.ResponseWriter, message, errType, code string) {
 	payload, _ := json.Marshal(map[string]any{"error": map[string]any{"message": message, "type": errType, "code": code}})
 	_, _ = w.Write([]byte("data: "))

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2240,6 +2240,67 @@ func TestStreamingQuotaReservationAndSettlementUsesDisconnectEstimation(t *testi
 	}
 }
 
+// SPEC-002 § FR-B6 / issue #186: when the upstream coordinator
+// stream dies mid-flight (provider disconnect surfaces here as an
+// io.Pipe close-with-error), the gateway MUST emit the exact
+// provider_disconnected SSE error envelope BEFORE `data: [DONE]`.
+// OpenAI-compatible SDK clients route on (error.code, error.type)
+// to distinguish a normal short response from a provider drop.
+//
+// The internal settlement outcome stays `stream_truncated` (per
+// SPEC-006 § 17.7 — a separate usage_events.outcome field, not the
+// buyer-visible SSE error.code). Earlier the buyer-visible code
+// was also `stream_truncated`, conflating settlement and signaling
+// (and silently truncating responses for SDK consumers).
+func TestStreamingMidStreamProviderDisconnectEmitsFRB6Envelope(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`
+	accountID := "acct_provider_disconnected"
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		pr, pw := io.Pipe()
+		go func() {
+			// One valid delta, then force an unexpected upstream close.
+			_, _ = pw.Write([]byte(`data: {"id":"chatcmpl","choices":[{"delta":{"content":"hello"}}]}` + "\n\n"))
+			_ = pw.CloseWithError(errors.New("forced upstream provider disconnect"))
+		}()
+		header := http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}
+		return &http.Response{StatusCode: http.StatusOK, Header: header, Body: pr}, nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	// Locate the FR-B6 error event in the SSE stream BEFORE [DONE].
+	bodyStr := resp.Body.String()
+	doneIdx := strings.Index(bodyStr, "data: [DONE]")
+	if doneIdx < 0 {
+		t.Fatalf("response missing data: [DONE]; body=%s", bodyStr)
+	}
+	preDone := bodyStr[:doneIdx]
+	if !strings.Contains(preDone, `"code":"provider_disconnected"`) {
+		t.Fatalf("FR-B6 envelope missing provider_disconnected before [DONE]; preDone=%s", preDone)
+	}
+	if !strings.Contains(preDone, `"type":"server_error"`) {
+		t.Fatalf("FR-B6 envelope missing type=server_error before [DONE]; preDone=%s", preDone)
+	}
+	if !strings.Contains(preDone, `"message":"Provider disconnected during streaming"`) {
+		t.Fatalf("FR-B6 envelope missing canonical message before [DONE]; preDone=%s", preDone)
+	}
+
+	// Internal settlement outcome stays stream_truncated (SPEC-006
+	// § 17.7); the buyer-visible code is a SEPARATE field. This
+	// assertion guards against any accidental coupling.
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "stream_truncated" || source != "gateway_estimated" {
+		t.Fatalf("settlement outcome/source = %s/%s, want stream_truncated/gateway_estimated", outcome, source)
+	}
+}
+
 func TestStreamingScannerErrorSettlesStreamTruncated(t *testing.T) {
 	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"large line"}]}`
 	accountID := "acct_stream_truncated"

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2247,10 +2247,12 @@ func TestStreamingQuotaReservationAndSettlementUsesDisconnectEstimation(t *testi
 // OpenAI-compatible SDK clients route on (error.code, error.type)
 // to distinguish a normal short response from a provider drop.
 //
-// The internal settlement outcome stays `stream_truncated` (per
-// SPEC-006 § 17.7 — a separate usage_events.outcome field, not the
-// buyer-visible SSE error.code). Earlier the buyer-visible code
-// was also `stream_truncated`, conflating settlement and signaling
+// The internal settlement outcome stays `stream_truncated` per the
+// gateway settlement convention and SPEC-006 § 17.7 quota-debit
+// policy (partial stream → prompt + actual completion tokens
+// charged) — a separate usage_events.outcome field, not the
+// buyer-visible SSE error.code. Earlier the buyer-visible code was
+// also `stream_truncated`, conflating settlement and signaling
 // (and silently truncating responses for SDK consumers).
 func TestStreamingMidStreamProviderDisconnectEmitsFRB6Envelope(t *testing.T) {
 	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`
@@ -2328,6 +2330,28 @@ func TestStreamingScannerErrorSettlesStreamTruncated(t *testing.T) {
 
 	if resp.Code != http.StatusOK {
 		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	// Issue #186 / code R1 NOTE: pin the BUYER-VISIBLE envelope on
+	// the buffer-full gateway-truncation path. This is intentionally
+	// stream_truncated / api_error (NOT FR-B6's
+	// provider_disconnected / server_error) because the line-too-
+	// long failure is gateway protection, not a provider drop. If
+	// the codepath drifts, OpenAI SDK consumers would misclassify
+	// gateway truncation as a retriable provider failure.
+	bodyStr := resp.Body.String()
+	doneIdx := strings.Index(bodyStr, "data: [DONE]")
+	if doneIdx < 0 {
+		t.Fatalf("response missing data: [DONE]; body=%s", bodyStr)
+	}
+	preDone := bodyStr[:doneIdx]
+	if !strings.Contains(preDone, `"code":"stream_truncated"`) {
+		t.Fatalf("buffer-full envelope missing code=stream_truncated; preDone=%s", preDone)
+	}
+	if !strings.Contains(preDone, `"type":"api_error"`) {
+		t.Fatalf("buffer-full envelope missing type=api_error; preDone=%s", preDone)
+	}
+	if strings.Contains(preDone, `"provider_disconnected"`) {
+		t.Fatalf("buffer-full envelope leaked provider_disconnected; gateway-truncation must NOT use the FR-B6 envelope; preDone=%s", preDone)
 	}
 	outcome, source := usageEventOutcome(t, dbPath, accountID)
 	if outcome != "stream_truncated" || source != "gateway_estimated" {

--- a/specs/AUDIT_FIX_ISS_186_R1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_186_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,92 @@
+# ISS-186 R1 — architect-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-186-mid-stream-sse-envelope`
+against `origin/main`. Restores SPEC-002 § FR-B6's exact
+mid-stream-disconnect SSE envelope (`provider_disconnected` /
+`server_error` / "Provider disconnected during streaming") on the
+gateway-side relay path. Internal settlement outcome stays
+`stream_truncated` per SPEC-006 § 17.7.
+
+## Background
+
+SPEC-002 v1.4.1 FR-B6 (lines 1248-1254) mandates the exact envelope.
+The phase-A network harness scenario `05_mid_stream_drop.yaml`
+caught the gateway emitting `code: "stream_truncated"` instead. The
+SPEC-002 v1.4.2 R-3 re-affirms FR-B6.
+
+## Scope of this lane
+
+You are the **architect lane**. Focus on:
+
+- **Spec wording vs implementation.** Does the new envelope EXACTLY
+  match FR-B6's specified strings?
+  - `message: "Provider disconnected during streaming"`
+  - `type: "server_error"`
+  - `code: "provider_disconnected"`
+  Any drift breaks SDK compatibility.
+- **FR-B7 alignment.** FR-B7 (lines 1257-1268) describes the broader
+  "clean error on provider failure" contract: streaming requests
+  emit the FR-B6 envelope then `data: [DONE]`. Does the diff
+  satisfy this composition?
+- **Settlement matrix (SPEC-006 § 17.7).** The buyer-visible
+  envelope (FR-B6) and settlement outcome (§ 17.7) are now
+  explicitly two different fields:
+  - Buyer-visible: SSE error.code = `provider_disconnected`
+  - Settlement: usage_events.outcome = `stream_truncated`
+  Is that mapping spec-consistent? § 17.7 lists `stream_truncated`
+  as the gateway's "provider died mid-stream" row — keep
+  in mind the spec wording.
+- **Gateway-truncation vs provider-disconnect distinction.** The
+  bufio.ErrBufferFull path (gateway truncating an overlong line)
+  keeps `stream_truncated`. Is the SPEC clear about this case, or
+  does FR-B6 implicitly cover ALL mid-stream failures? Read FR-B6
+  carefully — "if the provider disconnects mid-stream" is
+  specifically about provider disconnect, not gateway-internal
+  protection. The distinction seems correct, but worth confirming.
+- **Cross-spec.** SPEC-002 v1.4.2 R-3 re-affirms FR-B6. Does this
+  PR fully satisfy R-3, or is there a coordinator-side companion
+  change (the spec text says "the coordinator emits" — gateway
+  in the architecture acts as relay)?
+- **Naming / future-proofing.** Should writeSSEError continue to
+  be a free function in chat_proxy.go, or should the FR-B6 envelope
+  be its own typed builder so future codes can't drift? (Minor
+  recommendation territory.)
+- **Versioning.** Does this code fix need a SPEC-002 minor bump?
+  Probably not — it restores existing FR-B6 behavior. The v1.4.2
+  R-3 addendum is already the re-affirmation.
+
+## Files in the diff
+
+```
+phase5-gateway/internal/router/chat_proxy.go
+phase5-gateway/internal/router/server_test.go
+```
+
+Useful command:
+```
+git diff origin/main -- phase5-gateway/
+specs/SPEC-002-coordinator.md  # FR-B6 lines 1241-1255, FR-B7 lines 1257-1268
+specs/SPEC-006-buyer-api.md    # § 17.7 settlement matrix
+specs/SPEC-002-v1.4.2-routing-contract-addendum.md  # R-3
+```
+
+## Scope: PR-INTRODUCED findings only
+
+Per the locked three-lane convergence convention.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **Aspect:** spec | naming | versioning | cross-service | contract
+- **Issue:** one-sentence statement
+- **Evidence:** quote relevant code or spec
+- **Recommendation:** specific change
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Keep response under 700 words.

--- a/specs/AUDIT_FIX_ISS_186_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_186_R1_CODE_PROMPT.md
@@ -1,0 +1,95 @@
+# ISS-186 R1 — code-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-186-mid-stream-sse-envelope`
+against `origin/main`. The change implements SPEC-002 FR-B6's
+mid-stream-disconnect error envelope by changing one writeSSEError
+call site to emit `code: "provider_disconnected"` / `type:
+"server_error"` instead of the legacy `stream_truncated` / `api_error`,
+and extends writeSSEError's signature to take an explicit type so
+the other (non-FR-B6) call sites stay on `api_error`.
+
+## Scope of this lane
+
+You are the **code lane**. Focus on:
+
+- **Signature change of writeSSEError.** It now takes 4 args
+  (writer, message, type, code) — were ALL existing call sites
+  updated? Grep `writeSSEError(` across phase5-gateway/. Any stragglers
+  will fail compilation but verify the four-arg form is consistently
+  applied.
+- **Distinction between gateway-truncation and provider-disconnect.**
+  The buffer-full path (bufio.ErrBufferFull) keeps stream_truncated /
+  api_error because it's gateway-side protection, NOT a provider
+  drop. The "unexpected read error" path becomes
+  provider_disconnected / server_error per FR-B6. Is the distinction
+  clearly motivated in code comments?
+- **Settlement vs signaling separation.** SPEC-006 § 17.7 outcome
+  `stream_truncated` remains on usage_events.outcome via
+  `settleTruncated()`. Only the buyer-visible SSE error.code changes.
+  Are these two surfaces unambiguously separate, or could a future
+  refactor recouple them?
+- **Test coverage.**
+  - `TestStreamingMidStreamProviderDisconnectEmitsFRB6Envelope` —
+    new test asserting (code, type, message) all match FR-B6 verbatim.
+    Does it also confirm settlement outcome stays stream_truncated?
+  - `TestStreamingScannerErrorSettlesStreamTruncated` — existing
+    test on the buffer-full path. Was the assertion updated to
+    expect the now-narrower stream_truncated/api_error envelope, or
+    did it not assert envelope shape before (only settlement)?
+  - `TestStreamingProviderReportedUsageCannotUnderstateTruncated
+    Output` — also exercises the new path (CloseWithError on
+    upstream). Should this test ALSO assert the new envelope, or is
+    that adequately covered by the new dedicated test?
+- **Buyer write failure paths.** Look for other places where
+  buyer-side stream writes could fail (e.g., line 459's `streaming
+  buyer write failed`). Does that path need the same envelope, or
+  does it not reach writeSSEError because the buyer is already
+  gone?
+- **Concurrency.** writeSSEError + flusher.Flush happen on the
+  gateway's response writer goroutine; settleTruncated may dispatch
+  background. No new shared state is introduced — confirm.
+
+Out of scope for this lane (other lanes own):
+
+- **Security lane:** error envelope leakage, log injection, denial
+  of service.
+- **Architect lane:** SPEC-002 FR-B6 wording, FR-B7 vs FR-B6
+  alignment, SPEC-006 § 17.7 settlement matrix.
+
+Do NOT duplicate their work.
+
+## Files in the diff
+
+```
+phase5-gateway/internal/router/chat_proxy.go
+phase5-gateway/internal/router/server_test.go
+```
+
+Useful command:
+```
+git diff origin/main -- phase5-gateway/
+```
+
+## Scope: PR-INTRODUCED findings only
+
+Per the locked three-lane convergence convention: this audit gates
+this PR on findings INTRODUCED by the diff against origin/main.
+Pre-existing concerns visible to your audit but NOT modified by
+this PR are out of scope for blocking convergence.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **File:line(s):** exact reference
+- **Issue:** one-sentence problem statement
+- **Evidence:** quote relevant code
+- **Recommendation:** specific change
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Keep response under 800 words.

--- a/specs/AUDIT_FIX_ISS_186_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_186_R1_SECURITY_PROMPT.md
@@ -57,7 +57,38 @@ phase5-gateway/internal/router/server_test.go
 
 ## Scope: PR-INTRODUCED findings only
 
-Per the locked three-lane convergence convention.
+Per the locked three-lane convergence convention: this audit gates
+this PR on findings INTRODUCED by the diff against origin/main.
+Pre-existing vulnerabilities visible to your audit but NOT modified
+by this PR — even if THIS PR makes them more salient or more
+exploitable in practice — are out of scope for blocking
+convergence. They may be worth filing as separate issues but they
+do NOT block this PR.
+
+Specifically out of scope for THIS PR:
+
+- **Gateway-side Idempotency-Key dedupe.** The diff changes only
+  the SSE error envelope strings (`code`, `type`, `message`). It
+  does NOT introduce or modify the gateway's reservation/
+  settlement flow, nor its Idempotency-Key handling. The pre-
+  existing gateway-side dedupe gap is filed as
+  [#200](https://github.com/Augustas11/macprovider/issues/200)
+  with full repro + fix options + acceptance. PR #199 (this PR)
+  is correct per SPEC-002 FR-B6 — the spec explicitly mandates
+  `type: server_error` for the mid-stream-disconnect envelope,
+  and a buyer's retry policy is on the buyer's SDK, not the
+  gateway's choice of envelope type.
+
+  Re-finding this as a CRITICAL or MAJOR is a duplicate of #200's
+  intent; drop it from your findings and add a one-line NOTE
+  referencing the issue.
+
+If you find a NEW security issue that this PR genuinely introduces
+— e.g., the new envelope leaks internal state, the new helper has
+a path-traversal-style flaw, the new comment is wrong about
+something load-bearing — surface it as MAJOR/CRITICAL. But the
+specific "server_error is retriable → no gateway dedupe → double-
+billing risk" path is out of scope here.
 
 ## Output format
 

--- a/specs/AUDIT_FIX_ISS_186_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_186_R1_SECURITY_PROMPT.md
@@ -1,0 +1,77 @@
+# ISS-186 R1 — security-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-186-mid-stream-sse-envelope`
+against `origin/main`. The change emits a mid-stream SSE error
+envelope with code `provider_disconnected` / type `server_error` /
+message `Provider disconnected during streaming` when the upstream
+coordinator stream dies unexpectedly.
+
+## Scope of this lane
+
+You are the **security lane**. Focus on:
+
+- **Information leak via error envelope.** Does the new envelope
+  carry any internal-state values (provider_id, internal request_id,
+  stack trace, IP)? Look at writeSSEError's payload construction.
+  The buyer-visible error message is now a fixed string
+  ("Provider disconnected during streaming") with no interpolation
+  — confirm.
+- **DoS amplification via SSE.** Is there a path where an attacker
+  buyer can force repeated mid-stream disconnects (e.g., by
+  exploiting provider-side fragility) and exhaust gateway buffer
+  space? Look at flusher.Flush + writeSSEError sequence — does the
+  envelope itself cost more than the legacy stream_truncated one?
+  Bounded by a small constant, but verify.
+- **Settlement integrity.** Buyer-visible signaling changes from
+  stream_truncated to provider_disconnected — does the settlement
+  / billing path still settle correctly? Specifically:
+  - Does the gateway-estimated-tokens path still fire
+    settleTruncated() before returning?
+  - Does any code path (e.g., audit_events) use the SSE error.code
+    as a billing key? If so, the new code value could break that.
+- **Error type "server_error" — clients may retry.** OpenAI SDKs
+  treat type=server_error as retriable. If a buyer's idempotency
+  is not honored or the gateway issues fresh charges on retry, this
+  could be exploitable. Check idempotency handling in the
+  chat-completions handler.
+- **Buffer-full path stays stream_truncated.** A buyer COULD attempt
+  to attack by sending pathologically long lines to the gateway,
+  forcing the bufio.ErrBufferFull branch. That still emits
+  stream_truncated/api_error. Confirm that's not the right path
+  for the FR-B6 envelope — the spec wording is specifically about
+  PROVIDER disconnects, not gateway truncation.
+
+Out of scope for this lane:
+
+- **Code lane:** Go idiom, signature change consistency.
+- **Architect lane:** SPEC consistency.
+
+Do NOT duplicate their work.
+
+## Files in the diff
+
+```
+phase5-gateway/internal/router/chat_proxy.go
+phase5-gateway/internal/router/server_test.go
+```
+
+## Scope: PR-INTRODUCED findings only
+
+Per the locked three-lane convergence convention.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **File:line(s):** exact reference
+- **Threat model / attack surface:** one-sentence statement
+- **Evidence:** quote relevant code
+- **Recommendation:** specific change
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Keep response under 700 words.


### PR DESCRIPTION
Closes [#186](https://github.com/Augustas11/macprovider/issues/186).

## What this PR does

SPEC-002 § FR-B6 mandates the exact SSE envelope on mid-stream provider disconnect:

```
data: {"error":{"message":"Provider disconnected during streaming","type":"server_error","code":"provider_disconnected"}}

data: [DONE]
```

Phase-A network harness scenario `05_mid_stream_drop` caught the gateway emitting `code: stream_truncated` / `type: api_error` — OpenAI-compatible SDK consumers couldn't tell a provider drop apart from a normal short response.

## Changes

- `writeSSEError` signature extended to take an explicit `type` arg.
- The coordinator-side unexpected-read-error path emits the FR-B6 envelope verbatim (code, type, message).
- The buffer-full path (gateway-side line truncation) keeps `stream_truncated` / `api_error` — that's gateway protection, not a provider drop.
- Internal settlement outcome stays `stream_truncated` per SPEC-006 § 17.7 — a SEPARATE `usage_events.outcome` field from the buyer-visible SSE error.code. The two were previously conflated.

## Regression test

`TestStreamingMidStreamProviderDisconnectEmitsFRB6Envelope` forces an upstream `CloseWithError` mid-stream and asserts the FR-B6 envelope (all three fields verbatim) BEFORE `data: [DONE]`, plus the decoupled settlement outcome.

## Audit plan

Three-lane codex audit (`specs/AUDIT_FIX_ISS_186_R1_*.md`): code / security / architect. Convergence loop to 0 CRITICAL / 0 MAJOR per the locked SPEC-audit convention.

Test status (local): full gateway test suite green.

---

## Known limitation surfaced by codex security R1

The new envelope correctly uses `type: server_error` per FR-B6, which OpenAI-compatible SDKs treat as **retriable**. The gateway forwards `Idempotency-Key` to the coordinator but does NOT dedupe locally on the gateway's own reservation/settlement flow. A buyer retry after this envelope MAY incur a fresh gateway reservation if the coordinator's idempotency-cache response isn't refund-honored on the gateway side.

This is a pre-existing architectural gap, not introduced by this PR — but the FR-B6 envelope's retriable type makes it more salient. Filed as separate tracking issue [#200](https://github.com/Augustas11/macprovider/issues/200) with full repro + fix options + acceptance criteria. Not blocking this PR per the locked three-lane convergence convention (PR-introduced surface only).