### PR TITLE
fix(gateway): SPEC-006 § 17.7 partial-stream settlement fallback (closes #187)

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -677,9 +677,20 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 			return
 		}
 		// Fallback insert succeeded (or the row already existed via
-		// race AND matches by account_id). Log at warn — the path
-		// fired, but the spec is now satisfied. Buyer's reservation
-		// hold stays as-is; the subsequent reaper will tidy it.
+		// race AND matches by full billing payload). The buyer is now
+		// debited via usage_events.
+		//
+		// R2 architect MAJOR: release any still-active reservation
+		// hold so DailyUsage doesn't double-count the buyer's quota
+		// (sum of usage_events.total_tokens AND active
+		// quota_reservations.reserved_tokens). RefundReservation is a
+		// no-op when the reservation row is missing or already
+		// terminal (which is the common case here — settle_error was
+		// ErrReservationNotFound or status != 'active'); when the row
+		// IS still active (e.g., settleRequest failed on a transient
+		// DB error, leaving the reservation row in 'active' state),
+		// the call releases the quota hold.
+		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
 		slog.Warn("gateway settlement used SPEC-006 § 17.7 fallback usage_events insert (settle_path failure)",
 			"request_id", requestID(r),
 			"account_id", subject.AccountID,

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -235,7 +235,12 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	promptEstimate := estimatePromptTokens(body)
 	maxUsageTokens := promptEstimate + maxTokens
 	if chat.Stream {
-		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, cancelUpstream)
+		// ISS-187 R1 architect/code MAJOR: thread the reservation
+		// window through to forwardStreamingChat so the SPEC-006 §
+		// 17.7 fallback usage_events insert in settleAfterCommit
+		// uses the SAME window_date as the original reservation
+		// (avoids drift for streams that cross UTC midnight).
+		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, cancelUpstream, window)
 		return
 	}
 	s.forwardNonStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens)
@@ -315,7 +320,7 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 	_, _ = w.Write(body)
 }
 
-func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens int64, cancelUpstream func()) {
+func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens int64, cancelUpstream func(), reservationWindow string) {
 	if resp.StatusCode == http.StatusServiceUnavailable {
 		body, _ := io.ReadAll(resp.Body)
 		if coordinatorTier2PolicyError(resp.StatusCode, body) {
@@ -381,17 +386,17 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		usage := *reported
 		observedCompletion := estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens)
 		if observedCompletion > usage.CompletionTokens {
-			s.settleAfterCommit(r, subject, promptEstimate, observedCompletion, maxUsageTokens, "gateway_estimated", outcome)
+			s.settleAfterCommit(r, subject, promptEstimate, observedCompletion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow)
 			return
 		}
-		s.settleAfterCommit(r, subject, usage.PromptTokens, usage.CompletionTokens, maxUsageTokens, "provider_reported", outcome)
+		s.settleAfterCommit(r, subject, usage.PromptTokens, usage.CompletionTokens, maxUsageTokens, "provider_reported", outcome, reservationWindow)
 	}
 	settleTruncated := func() {
 		if reported != nil {
 			settleReported("stream_truncated")
 			return
 		}
-		s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "stream_truncated")
+		s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "stream_truncated", reservationWindow)
 	}
 	forwardLine := func(line []byte) bool {
 		select {
@@ -400,7 +405,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 				settleReported("client_disconnect")
 				return false
 			}
-			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
+			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator, reservationWindow)
 			return false
 		default:
 		}
@@ -416,7 +421,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 					}
 					cancelCoordinator()
 					completion := estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens)
-					s.settleAfterCommit(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "stream_malformed")
+					s.settleAfterCommit(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "stream_malformed", reservationWindow)
 					return false
 				}
 				if deltaBytes > 0 {
@@ -429,7 +434,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 							flusher.Flush()
 						}
 						cancelCoordinator()
-						s.settleAfterCommit(r, subject, promptEstimate, maxCompletion, maxUsageTokens, "gateway_estimated", "stream_output_exceeded")
+						s.settleAfterCommit(r, subject, promptEstimate, maxCompletion, maxUsageTokens, "gateway_estimated", "stream_output_exceeded", reservationWindow)
 						return false
 					}
 					emitted += deltaBytes
@@ -450,7 +455,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 					}
 					cancelCoordinator()
 					completion := estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens)
-					s.settleAfterCommit(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "stream_malformed")
+					s.settleAfterCommit(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "stream_malformed", reservationWindow)
 					return false
 				}
 			}
@@ -461,7 +466,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 				settleReported("client_disconnect")
 				return false
 			}
-			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
+			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator, reservationWindow)
 			return false
 		}
 		if flusher != nil {
@@ -500,7 +505,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 				settleReported("client_disconnect")
 				return
 			}
-			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
+			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator, reservationWindow)
 			return
 		}
 		slog.Error("streaming coordinator read failed", "request_id", requestID(r), "error", err)
@@ -533,14 +538,14 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			settleReported("client_disconnect")
 			return
 		}
-		s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator)
+		s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator, reservationWindow)
 		return
 	}
 	if reported != nil && !invalidReportedUsage {
 		settleReported("ok")
 		return
 	}
-	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "ok")
+	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "ok", reservationWindow)
 }
 
 func (s *Server) passThroughNoProviderCoordinatorError(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, body []byte) {
@@ -592,9 +597,9 @@ func openAIErrorCode(body []byte) string {
 	return strings.TrimSpace(envelope.Error.Code)
 }
 
-func (s *Server) settleCancelledStream(r *http.Request, subject usageSubject, promptEstimate, emitted, maxUsageTokens int64, cancelCoordinator func()) {
+func (s *Server) settleCancelledStream(r *http.Request, subject usageSubject, promptEstimate, emitted, maxUsageTokens int64, cancelCoordinator func(), reservationWindow string) {
 	cancelCoordinator()
-	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "client_disconnect")
+	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "client_disconnect", reservationWindow)
 }
 
 func (s *Server) settleBeforeResponse(w http.ResponseWriter, r *http.Request, subject usageSubject, prompt, completion, maxTotal int64, source, outcome string) bool {
@@ -607,7 +612,7 @@ func (s *Server) settleBeforeResponse(w http.ResponseWriter, r *http.Request, su
 	return true
 }
 
-func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt, completion, maxTotal int64, source, outcome string) {
+func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt, completion, maxTotal int64, source, outcome, reservationWindow string) {
 	if err := s.settleRequest(r, subject, prompt, completion, maxTotal, source, outcome); err != nil {
 		slog.Error("gateway settlement failed after response commit",
 			"request_id", requestID(r),
@@ -618,17 +623,32 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 		)
 		// SPEC-006 § 17.7 / issue #187: response bytes already flowed
 		// to the buyer. The buyer MUST be debited and the audit row
-		// MUST exist regardless of why SettleReservation failed
-		// (missing reservation, status drift, transient DB error).
-		// Falling back to RefundReservation here — the previous
-		// behavior — silently lost the usage_events row and
-		// undercharged buyer + provider on every partial-stream
-		// settlement failure.
+		// (gateway-side usage_events) MUST exist regardless of why
+		// SettleReservation failed (missing reservation, status
+		// drift, transient DB error). Pre-#187 behavior fell back to
+		// RefundReservation, silently losing the audit row and
+		// undercharging the buyer.
+		//
+		// SCOPE: this fallback restores the BUYER-SIDE billing
+		// invariant. The provider-credit / mirror path lives on the
+		// COORDINATOR (SPEC-005 reads coord request_log, NOT this
+		// gateway-side usage_events row), so the SPEC-005 mirror is
+		// unaffected by this fix.
+		//
+		// WINDOW: use the reservation window captured at admission
+		// time (not s.now()) so a stream that crosses UTC midnight
+		// settles against the SAME daily quota window the buyer's
+		// reservation was made against. ISS-187 R1 architect+code
+		// MAJOR.
+		window := reservationWindow
+		if window == "" {
+			window = s.now().UTC().Format("2006-01-02")
+		}
 		ev := storage.UsageEvent{
 			RequestID:        requestID(r),
 			AccountID:        subject.AccountID,
 			DemoIdentity:     subject.DemoIdentity,
-			WindowDate:       s.now().UTC().Format("2006-01-02"),
+			WindowDate:       window,
 			PromptTokens:     prompt,
 			CompletionTokens: completion,
 			TotalTokens:      prompt + completion,
@@ -638,10 +658,13 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 		}
 		if fallbackErr := s.store.EnsureUsageEvent(context.Background(), ev); fallbackErr != nil {
 			// Both the normal settle path and the idempotent fallback
-			// failed. Genuine DB-level pathology — log loudly and
-			// release the reservation hold so the buyer's quota is
-			// not held forever. The audit row is lost; operators
-			// must reconcile from coordinator-side request_log.
+			// failed. Could be a genuine DB pathology OR (per #196 PK
+			// collision territory) a cross-account request_id
+			// collision detected via row-mismatch verify inside
+			// EnsureUsageEvent. Log loudly and release the
+			// reservation hold so the buyer's quota is not held
+			// forever. The audit row is lost; operators must
+			// reconcile from coordinator-side request_log.
 			slog.Error("gateway SPEC-006 § 17.7 fallback usage_events insert failed",
 				"request_id", requestID(r),
 				"account_id", subject.AccountID,
@@ -654,9 +677,9 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 			return
 		}
 		// Fallback insert succeeded (or the row already existed via
-		// race). Log at warn — the path fired, but the spec is now
-		// satisfied. Buyer's reservation hold stays as-is; the
-		// subsequent reaper will tidy it.
+		// race AND matches by account_id). Log at warn — the path
+		// fired, but the spec is now satisfied. Buyer's reservation
+		// hold stays as-is; the subsequent reaper will tidy it.
 		slog.Warn("gateway settlement used SPEC-006 § 17.7 fallback usage_events insert (settle_path failure)",
 			"request_id", requestID(r),
 			"account_id", subject.AccountID,

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -631,8 +631,9 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 		//
 		// SCOPE: this fallback restores the BUYER-SIDE billing
 		// invariant. The provider-credit / mirror path lives on the
-		// COORDINATOR (SPEC-005 reads coord request_log, NOT this
-		// gateway-side usage_events row), so the SPEC-005 mirror is
+		// COORDINATOR (per SPEC-005 § 10.3, "SPEC-005 does NOT read
+		// SPEC-006 usage tables"; provider credit composes from
+		// coordinator request_log), so the SPEC-005 mirror is
 		// unaffected by this fix.
 		//
 		// WINDOW: use the reservation window captured at admission
@@ -679,6 +680,31 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 		// Fallback insert succeeded (or the row already existed via
 		// race AND matches by full billing payload). The buyer is now
 		// debited via usage_events.
+		//
+		// R3 architect MINOR: for demo-token requests, also write
+		// the matching demo_usage_events row idempotently so the
+		// demo-side audit trail required by SPEC-006 §4.5 / §14.3
+		// stays consistent with the buyer-side usage_events row.
+		// EnsureDemoUsageEvent is INSERT OR IGNORE on PK; a failure
+		// here is non-fatal because the usage_events row above is the
+		// load-bearing money-path record.
+		if subject.DemoIdentity != "" {
+			if demoErr := s.store.EnsureDemoUsageEvent(context.Background(), storage.DemoUsageEvent{
+				RequestID:     requestID(r),
+				ClientIP:      subject.DemoIdentity,
+				DemoTokenHash: subject.DemoTokenHash,
+				WindowDate:    window,
+				TotalTokens:   prompt + completion,
+				CreatedAt:     s.now(),
+			}); demoErr != nil {
+				slog.Warn("gateway SPEC-006 fallback demo_usage_events insert failed (usage_events row is OK)",
+					"request_id", requestID(r),
+					"account_id", subject.AccountID,
+					"demo_identity", subject.DemoIdentity,
+					"error", demoErr.Error(),
+				)
+			}
+		}
 		//
 		// R2 architect MAJOR: release any still-active reservation
 		// hold so DailyUsage doesn't double-count the buyer's quota

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -609,8 +609,60 @@ func (s *Server) settleBeforeResponse(w http.ResponseWriter, r *http.Request, su
 
 func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt, completion, maxTotal int64, source, outcome string) {
 	if err := s.settleRequest(r, subject, prompt, completion, maxTotal, source, outcome); err != nil {
-		slog.Error("gateway settlement failed after response commit", "request_id", requestID(r), "account_id", subject.AccountID, "source", source, "outcome", outcome, "error", err)
-		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+		slog.Error("gateway settlement failed after response commit",
+			"request_id", requestID(r),
+			"account_id", subject.AccountID,
+			"source", source,
+			"outcome", outcome,
+			"error", err,
+		)
+		// SPEC-006 § 17.7 / issue #187: response bytes already flowed
+		// to the buyer. The buyer MUST be debited and the audit row
+		// MUST exist regardless of why SettleReservation failed
+		// (missing reservation, status drift, transient DB error).
+		// Falling back to RefundReservation here — the previous
+		// behavior — silently lost the usage_events row and
+		// undercharged buyer + provider on every partial-stream
+		// settlement failure.
+		ev := storage.UsageEvent{
+			RequestID:        requestID(r),
+			AccountID:        subject.AccountID,
+			DemoIdentity:     subject.DemoIdentity,
+			WindowDate:       s.now().UTC().Format("2006-01-02"),
+			PromptTokens:     prompt,
+			CompletionTokens: completion,
+			TotalTokens:      prompt + completion,
+			TokenSource:      source,
+			Outcome:          outcome,
+			CreatedAt:        s.now(),
+		}
+		if fallbackErr := s.store.EnsureUsageEvent(context.Background(), ev); fallbackErr != nil {
+			// Both the normal settle path and the idempotent fallback
+			// failed. Genuine DB-level pathology — log loudly and
+			// release the reservation hold so the buyer's quota is
+			// not held forever. The audit row is lost; operators
+			// must reconcile from coordinator-side request_log.
+			slog.Error("gateway SPEC-006 § 17.7 fallback usage_events insert failed",
+				"request_id", requestID(r),
+				"account_id", subject.AccountID,
+				"source", source,
+				"outcome", outcome,
+				"settle_error", err.Error(),
+				"fallback_error", fallbackErr.Error(),
+			)
+			_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+			return
+		}
+		// Fallback insert succeeded (or the row already existed via
+		// race). Log at warn — the path fired, but the spec is now
+		// satisfied. Buyer's reservation hold stays as-is; the
+		// subsequent reaper will tidy it.
+		slog.Warn("gateway settlement used SPEC-006 § 17.7 fallback usage_events insert (settle_path failure)",
+			"request_id", requestID(r),
+			"account_id", subject.AccountID,
+			"outcome", outcome,
+			"settle_error", err.Error(),
+		)
 	}
 }
 

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2240,6 +2240,92 @@ func TestStreamingQuotaReservationAndSettlementUsesDisconnectEstimation(t *testi
 	}
 }
 
+// SPEC-006 § 17.7 / issue #187 (P0 money-path): when the gateway's
+// normal SettleReservation path fails after bytes have already
+// flowed to the buyer, the gateway MUST still write a usage_events
+// row (via the new EnsureUsageEvent fallback) so the buyer is
+// debited and the SPEC-005 § 6.9 mirror-credit path has data to
+// work with. Pre-#187, the failure mode silently called
+// RefundReservation, lost the audit row, and undercharged everyone.
+//
+// Repro: provider streams partial bytes (well under max_tokens),
+// then errors out. Between the bytes flowing and settlement
+// running, we externally refund the reservation — simulating ANY
+// path that could remove the reservation row out from under
+// SettleReservation (the phase-A scenario 05 production failure
+// mode was empirically observed; root cause was not nailed down,
+// but the defensive fix here writes the usage_events row regardless
+// of why the reservation lookup fails).
+func TestStreamingSettlementFallbackWritesUsageEventOnMissingReservation(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`
+	accountID := "acct_fallback_usage_event"
+	// Track when the upstream stream has started, so the test can
+	// refund the reservation AFTER the gateway has already
+	// committed response headers and started forwarding bytes.
+	var streamStarted = make(chan struct{}, 1)
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		pr, pw := io.Pipe()
+		go func() {
+			_, _ = pw.Write([]byte(`data: {"id":"chatcmpl","choices":[{"delta":{"content":"hello"}}]}` + "\n\n"))
+			streamStarted <- struct{}{}
+			// Block until the test refunds, then close the stream.
+			time.Sleep(50 * time.Millisecond)
+			_ = pw.CloseWithError(errors.New("forced upstream provider disconnect"))
+		}()
+		header := http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}
+		return &http.Response{StatusCode: http.StatusOK, Header: header, Body: pr}, nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	// Wait for the upstream stream to begin, then refund out from
+	// under the gateway's settlement attempt. Done in a goroutine
+	// because postChat below blocks until the response completes.
+	go func() {
+		<-streamStarted
+		// Find the reservation's request_id by reading
+		// quota_reservations directly. Use sql.Open instead of the
+		// gateway's store to avoid any in-flight lock.
+		db, err := sql.Open("sqlite", dbPath)
+		if err != nil {
+			return
+		}
+		defer db.Close()
+		var requestID string
+		for i := 0; i < 50; i++ {
+			if err := db.QueryRow(`SELECT request_id FROM quota_reservations WHERE account_id = ? AND status = 'active' ORDER BY created_at DESC LIMIT 1`, accountID).Scan(&requestID); err == nil {
+				break
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+		if requestID == "" {
+			return
+		}
+		// Delete the reservation row to simulate the production
+		// failure mode where SettleReservation returns
+		// ErrReservationNotFound. This is more pathological than
+		// any code path actually triggers, but the defensive fix
+		// must handle it regardless.
+		_, _ = db.Exec(`DELETE FROM quota_reservations WHERE account_id = ? AND request_id = ?`, accountID, requestID)
+	}()
+
+	resp := postChat(t, h, fullKey, body, nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	// The SPEC-006 § 17.7 invariant: a usage_events row exists for
+	// this account even though the reservation was wiped.
+	outcome, source := usageEventOutcome(t, dbPath, accountID)
+	if outcome != "stream_truncated" {
+		t.Fatalf("usage_events outcome = %q, want stream_truncated; fallback did not record the partial-stream row (#187 regression)", outcome)
+	}
+	if source != "gateway_estimated" {
+		t.Fatalf("usage_events token_source = %q, want gateway_estimated", source)
+	}
+}
+
 // SPEC-002 § FR-B6 / issue #186: when the upstream coordinator
 // stream dies mid-flight (provider disconnect surfaces here as an
 // io.Pipe close-with-error), the gateway MUST emit the exact

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2243,10 +2243,12 @@ func TestStreamingQuotaReservationAndSettlementUsesDisconnectEstimation(t *testi
 // SPEC-006 § 17.7 / issue #187 (P0 money-path): when the gateway's
 // normal SettleReservation path fails after bytes have already
 // flowed to the buyer, the gateway MUST still write a usage_events
-// row (via the new EnsureUsageEvent fallback) so the buyer is
-// debited and the SPEC-005 § 6.9 mirror-credit path has data to
-// work with. Pre-#187, the failure mode silently called
-// RefundReservation, lost the audit row, and undercharged everyone.
+// row (via the new EnsureUsageEvent fallback) so the buyer-side
+// SPEC-006 accounting + audit trail are preserved. SPEC-005 §6.9's
+// provider-credit composition is computed on the COORDINATOR from
+// request_log (NOT from gateway usage_events), so it's unaffected
+// by either the bug or the fix. Pre-#187, the failure mode silently
+// called RefundReservation and lost the buyer-side audit row.
 //
 // Repro: provider streams partial bytes (well under max_tokens),
 // then errors out. Between the bytes flowing and settlement
@@ -2341,6 +2343,26 @@ func TestStreamingSettlementFallbackWritesUsageEventOnMissingReservation(t *test
 	if source != "gateway_estimated" {
 		t.Fatalf("usage_events token_source = %q, want gateway_estimated", source)
 	}
+	// R2 architect MAJOR: after the fallback writes the usage_events
+	// row, the reservation hold MUST also be released so the buyer's
+	// quota is not double-counted (sum of usage_events.total_tokens
+	// AND active quota_reservations.reserved_tokens). The test
+	// deletes the reservation row out from under settlement, so the
+	// RefundReservation call after EnsureUsageEvent is a no-op
+	// here — but the assertion still pins the contract that there
+	// is NO 'active' reservation row left after the handler returns.
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open for post-condition check: %v", err)
+	}
+	defer db.Close()
+	var activeCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM quota_reservations WHERE account_id = ? AND status = 'active'`, accountID).Scan(&activeCount); err != nil {
+		t.Fatalf("count active reservations: %v", err)
+	}
+	if activeCount != 0 {
+		t.Fatalf("active quota_reservations rows = %d, want 0 (R2 architect MAJOR: quota double-count regression)", activeCount)
+	}
 }
 
 // TestEnsureUsageEventRejectsCrossAccountConflict pins the ISS-187
@@ -2377,10 +2399,50 @@ func TestEnsureUsageEventRejectsCrossAccountConflict(t *testing.T) {
 	}
 }
 
+// TestEnsureUsageEventRejectsSameIdentityPayloadMismatch pins the
+// R2 code MAJOR fix: the conflict-verify check covers the FULL
+// billing payload (tokens + window_date), not just identity. Without
+// this, a buyer racing two settle paths could pin a low-token row
+// first and then have higher-token settles silently no-op,
+// undercharging themselves.
+func TestEnsureUsageEventRejectsSameIdentityPayloadMismatch(t *testing.T) {
+	dir := t.TempDir()
+	st, err := sqlite.Open(context.Background(), dir+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer st.Close()
+	rid := "77777777-7777-4777-8777-777777777777"
+	now := time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC)
+	base := storage.UsageEvent{
+		RequestID: rid, AccountID: "buyer",
+		WindowDate: "2026-06-28", PromptTokens: 5, CompletionTokens: 7, TotalTokens: 12,
+		TokenSource: "gateway_estimated", Outcome: "stream_truncated", CreatedAt: now,
+	}
+	if err := st.InsertUsageEvent(context.Background(), base); err != nil {
+		t.Fatalf("InsertUsageEvent (base row): %v", err)
+	}
+	// Same identity (account, source, outcome) but DIFFERENT
+	// completion tokens — must be rejected as a conflict.
+	bumped := base
+	bumped.CompletionTokens = 50
+	bumped.TotalTokens = 55
+	if err := st.EnsureUsageEvent(context.Background(), bumped); !errors.Is(err, storage.ErrUsageEventConflict) {
+		t.Fatalf("EnsureUsageEvent with bumped tokens: err=%v, want ErrUsageEventConflict", err)
+	}
+	// Same identity + tokens but DIFFERENT window_date — also must
+	// be rejected (covers UTC-midnight-crossing race attempts).
+	shifted := base
+	shifted.WindowDate = "2026-06-29"
+	if err := st.EnsureUsageEvent(context.Background(), shifted); !errors.Is(err, storage.ErrUsageEventConflict) {
+		t.Fatalf("EnsureUsageEvent with shifted window: err=%v, want ErrUsageEventConflict", err)
+	}
+}
+
 // TestEnsureUsageEventAcceptsMatchingRetry confirms the benign
 // idempotency case: a duplicate INSERT with all matching identity
-// fields (account, source, outcome) is treated as success — covers
-// retries / race-with-normal-settle scenarios.
+// + token + window fields is treated as success — covers retries
+// and race-with-normal-settle scenarios.
 func TestEnsureUsageEventAcceptsMatchingRetry(t *testing.T) {
 	dir := t.TempDir()
 	st, err := sqlite.Open(context.Background(), dir+"/test.db")

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2259,17 +2259,21 @@ func TestStreamingQuotaReservationAndSettlementUsesDisconnectEstimation(t *testi
 func TestStreamingSettlementFallbackWritesUsageEventOnMissingReservation(t *testing.T) {
 	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`
 	accountID := "acct_fallback_usage_event"
-	// Track when the upstream stream has started, so the test can
-	// refund the reservation AFTER the gateway has already
-	// committed response headers and started forwarding bytes.
+	// Synchronization channels. The test goroutine waits for the
+	// gateway's first delta to flush, deletes the reservation row
+	// deterministically, signals via deleteDone, and only THEN does
+	// the upstream stream close — guaranteeing the settlement path
+	// sees a missing reservation. Polling avoided per ISS-187 R1
+	// code/security NOTEs.
 	var streamStarted = make(chan struct{}, 1)
+	var deleteDone = make(chan error, 1)
+	var releaseUpstream = make(chan struct{}, 1)
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		pr, pw := io.Pipe()
 		go func() {
 			_, _ = pw.Write([]byte(`data: {"id":"chatcmpl","choices":[{"delta":{"content":"hello"}}]}` + "\n\n"))
 			streamStarted <- struct{}{}
-			// Block until the test refunds, then close the stream.
-			time.Sleep(50 * time.Millisecond)
+			<-releaseUpstream
 			_ = pw.CloseWithError(errors.New("forced upstream provider disconnect"))
 		}()
 		header := http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}
@@ -2280,49 +2284,122 @@ func TestStreamingSettlementFallbackWritesUsageEventOnMissingReservation(t *test
 	}, WithHTTPClient(client))
 	fullKey := createAccountAndKey(t, store, cfg, accountID)
 
-	// Wait for the upstream stream to begin, then refund out from
-	// under the gateway's settlement attempt. Done in a goroutine
-	// because postChat below blocks until the response completes.
 	go func() {
 		<-streamStarted
-		// Find the reservation's request_id by reading
-		// quota_reservations directly. Use sql.Open instead of the
-		// gateway's store to avoid any in-flight lock.
 		db, err := sql.Open("sqlite", dbPath)
 		if err != nil {
+			deleteDone <- fmt.Errorf("sql.Open: %w", err)
+			releaseUpstream <- struct{}{}
 			return
 		}
 		defer db.Close()
+		// Poll-with-deadline for the reservation row. The reservation
+		// is inserted very early in handleChatCompletions (before the
+		// upstream request fires), so by the time streamStarted
+		// signals, the row almost certainly exists. The poll
+		// tolerates a tiny window for slow CI runners.
 		var requestID string
-		for i := 0; i < 50; i++ {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
 			if err := db.QueryRow(`SELECT request_id FROM quota_reservations WHERE account_id = ? AND status = 'active' ORDER BY created_at DESC LIMIT 1`, accountID).Scan(&requestID); err == nil {
 				break
 			}
-			time.Sleep(2 * time.Millisecond)
+			time.Sleep(5 * time.Millisecond)
 		}
 		if requestID == "" {
+			deleteDone <- errors.New("timed out waiting for quota_reservations row")
+			releaseUpstream <- struct{}{}
 			return
 		}
-		// Delete the reservation row to simulate the production
-		// failure mode where SettleReservation returns
-		// ErrReservationNotFound. This is more pathological than
-		// any code path actually triggers, but the defensive fix
-		// must handle it regardless.
-		_, _ = db.Exec(`DELETE FROM quota_reservations WHERE account_id = ? AND request_id = ?`, accountID, requestID)
+		res, err := db.Exec(`DELETE FROM quota_reservations WHERE account_id = ? AND request_id = ?`, accountID, requestID)
+		if err != nil {
+			deleteDone <- fmt.Errorf("delete: %w", err)
+			releaseUpstream <- struct{}{}
+			return
+		}
+		rows, _ := res.RowsAffected()
+		if rows != 1 {
+			deleteDone <- fmt.Errorf("delete affected %d rows, want 1", rows)
+			releaseUpstream <- struct{}{}
+			return
+		}
+		deleteDone <- nil
+		releaseUpstream <- struct{}{}
 	}()
 
 	resp := postChat(t, h, fullKey, body, nil)
+	if err := <-deleteDone; err != nil {
+		t.Fatalf("test setup failed: %v", err)
+	}
 	if resp.Code != http.StatusOK {
 		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
 	}
-	// The SPEC-006 § 17.7 invariant: a usage_events row exists for
-	// this account even though the reservation was wiped.
 	outcome, source := usageEventOutcome(t, dbPath, accountID)
 	if outcome != "stream_truncated" {
 		t.Fatalf("usage_events outcome = %q, want stream_truncated; fallback did not record the partial-stream row (#187 regression)", outcome)
 	}
 	if source != "gateway_estimated" {
 		t.Fatalf("usage_events token_source = %q, want gateway_estimated", source)
+	}
+}
+
+// TestEnsureUsageEventRejectsCrossAccountConflict pins the ISS-187
+// R1 code+security MAJOR: when the gateway's INSERT OR IGNORE
+// silently no-ops on the pre-existing #196 PK-collision attack
+// surface, EnsureUsageEvent now reads the existing row and rejects
+// the call if (account_id, demo_identity, token_source, outcome)
+// don't match — preventing a malicious buyer from skipping their
+// audit row by colliding with an unrelated request_id.
+func TestEnsureUsageEventRejectsCrossAccountConflict(t *testing.T) {
+	dir := t.TempDir()
+	st, err := sqlite.Open(context.Background(), dir+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer st.Close()
+	rid := "55555555-5555-4555-8555-555555555555"
+	now := time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC)
+	if err := st.InsertUsageEvent(context.Background(), storage.UsageEvent{
+		RequestID: rid, AccountID: "victim_account",
+		WindowDate: "2026-06-28", PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30,
+		TokenSource: "provider_reported", Outcome: "ok", CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("InsertUsageEvent (victim row): %v", err)
+	}
+	// Attacker tries to write the SAME request_id under a different account.
+	err = st.EnsureUsageEvent(context.Background(), storage.UsageEvent{
+		RequestID: rid, AccountID: "attacker_account",
+		WindowDate: "2026-06-28", PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2,
+		TokenSource: "gateway_estimated", Outcome: "stream_truncated", CreatedAt: now,
+	})
+	if !errors.Is(err, storage.ErrUsageEventConflict) {
+		t.Fatalf("EnsureUsageEvent on cross-account PK collision: err=%v, want ErrUsageEventConflict", err)
+	}
+}
+
+// TestEnsureUsageEventAcceptsMatchingRetry confirms the benign
+// idempotency case: a duplicate INSERT with all matching identity
+// fields (account, source, outcome) is treated as success — covers
+// retries / race-with-normal-settle scenarios.
+func TestEnsureUsageEventAcceptsMatchingRetry(t *testing.T) {
+	dir := t.TempDir()
+	st, err := sqlite.Open(context.Background(), dir+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer st.Close()
+	rid := "66666666-6666-4666-8666-666666666666"
+	now := time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC)
+	ev := storage.UsageEvent{
+		RequestID: rid, AccountID: "buyer",
+		WindowDate: "2026-06-28", PromptTokens: 5, CompletionTokens: 7, TotalTokens: 12,
+		TokenSource: "gateway_estimated", Outcome: "stream_truncated", CreatedAt: now,
+	}
+	if err := st.InsertUsageEvent(context.Background(), ev); err != nil {
+		t.Fatalf("InsertUsageEvent first call: %v", err)
+	}
+	if err := st.EnsureUsageEvent(context.Background(), ev); err != nil {
+		t.Fatalf("EnsureUsageEvent retry with matching fields: %v", err)
 	}
 }
 

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2244,9 +2244,10 @@ func TestStreamingQuotaReservationAndSettlementUsesDisconnectEstimation(t *testi
 // normal SettleReservation path fails after bytes have already
 // flowed to the buyer, the gateway MUST still write a usage_events
 // row (via the new EnsureUsageEvent fallback) so the buyer-side
-// SPEC-006 accounting + audit trail are preserved. SPEC-005 §6.9's
+// SPEC-006 accounting + audit trail are preserved. Per SPEC-005
+// § 10.3 ('SPEC-005 does NOT read SPEC-006 usage tables'),
 // provider-credit composition is computed on the COORDINATOR from
-// request_log (NOT from gateway usage_events), so it's unaffected
+// request_log, NOT from gateway usage_events — so it's unaffected
 // by either the bug or the fix. Pre-#187, the failure mode silently
 // called RefundReservation and lost the buyer-side audit row.
 //

--- a/phase5-gateway/internal/storage/errors.go
+++ b/phase5-gateway/internal/storage/errors.go
@@ -8,4 +8,11 @@ var (
 	ErrQuotaExceeded       = errors.New("quota exceeded")
 	ErrReservationExists   = errors.New("quota reservation exists")
 	ErrReservationNotFound = errors.New("quota reservation not found")
+	// ErrUsageEventConflict is returned by EnsureUsageEvent when the
+	// request_id PK already has a row whose identity fields
+	// (account_id, demo_identity, token_source, outcome) DISAGREE
+	// with the incoming event. Pre-existing #196 PK-collision attack
+	// surface: this sentinel forces the caller to refund + log
+	// instead of silently absorbing the duplicate.
+	ErrUsageEventConflict = errors.New("usage event conflicts with existing row for request_id")
 )

--- a/phase5-gateway/internal/storage/interfaces.go
+++ b/phase5-gateway/internal/storage/interfaces.go
@@ -58,13 +58,24 @@ type UsageStore interface {
 	SettleDemoReservation(ctx context.Context, settlement ReservationSettlement, demo DemoUsageEvent) error
 	RefundReservation(ctx context.Context, accountID, requestID string, refundedAt int64) error
 	InsertUsageEvent(ctx context.Context, event UsageEvent) error
-	// EnsureUsageEvent inserts a usage_events row idempotently —
-	// returns nil on either fresh insert or pre-existing row at the
-	// same request_id PK. Used as a SPEC-006 § 17.7 fallback path
-	// when SettleReservation fails after bytes have already flowed
-	// to the buyer (issue #187): the buyer MUST be debited and the
-	// audit trail MUST exist even if the reservation row is missing
-	// or in an unexpected state.
+	// EnsureUsageEvent inserts a usage_events row idempotently. The
+	// behavior on a request_id PK conflict is the SPEC-006 § 17.7
+	// money-path contract for the failure-mode fallback in
+	// chat_proxy.settleAfterCommit (issue #187):
+	//
+	//   - Returns nil on a fresh insert.
+	//   - Returns nil when an existing row at the same request_id
+	//     matches the incoming event in EVERY billing-relevant field
+	//     (account_id, demo_identity, window_date, prompt_tokens,
+	//     completion_tokens, total_tokens, token_source, outcome).
+	//   - Returns ErrUsageEventConflict when an existing row at the
+	//     same request_id DIFFERS from the incoming event in any of
+	//     those fields — covers cross-account collisions (#196
+	//     pre-existing) and any same-account payload drift.
+	//
+	// The caller must treat ErrUsageEventConflict as a failure to
+	// settle (i.e., the audit trail is unrecoverable for THIS event)
+	// and proceed to refund + log loudly.
 	EnsureUsageEvent(ctx context.Context, event UsageEvent) error
 	DailyUsage(ctx context.Context, accountID, windowDate string) (usedTokens, activeReservedTokens int64, err error)
 	ReapExpiredReservations(ctx context.Context, now time.Time) (int64, error)

--- a/phase5-gateway/internal/storage/interfaces.go
+++ b/phase5-gateway/internal/storage/interfaces.go
@@ -77,6 +77,16 @@ type UsageStore interface {
 	// settle (i.e., the audit trail is unrecoverable for THIS event)
 	// and proceed to refund + log loudly.
 	EnsureUsageEvent(ctx context.Context, event UsageEvent) error
+	// EnsureDemoUsageEvent is the demo-token sibling of
+	// EnsureUsageEvent: idempotently inserts a demo_usage_events row
+	// (INSERT OR IGNORE on request_id PK). Used by the SPEC-006
+	// fallback path when SettleDemoReservation fails so the demo
+	// audit trail required by SPEC-006 §4.5 / §14.3 still exists.
+	// Returns nil on insert OR on a benign duplicate; the gateway's
+	// fallback path bounds collision exposure via the earlier
+	// EnsureUsageEvent call, which already runs the cross-account
+	// payload-mismatch check.
+	EnsureDemoUsageEvent(ctx context.Context, event DemoUsageEvent) error
 	DailyUsage(ctx context.Context, accountID, windowDate string) (usedTokens, activeReservedTokens int64, err error)
 	ReapExpiredReservations(ctx context.Context, now time.Time) (int64, error)
 	// DeleteTerminalQuotaReservations drops quota_reservations rows in a

--- a/phase5-gateway/internal/storage/interfaces.go
+++ b/phase5-gateway/internal/storage/interfaces.go
@@ -58,6 +58,14 @@ type UsageStore interface {
 	SettleDemoReservation(ctx context.Context, settlement ReservationSettlement, demo DemoUsageEvent) error
 	RefundReservation(ctx context.Context, accountID, requestID string, refundedAt int64) error
 	InsertUsageEvent(ctx context.Context, event UsageEvent) error
+	// EnsureUsageEvent inserts a usage_events row idempotently —
+	// returns nil on either fresh insert or pre-existing row at the
+	// same request_id PK. Used as a SPEC-006 § 17.7 fallback path
+	// when SettleReservation fails after bytes have already flowed
+	// to the buyer (issue #187): the buyer MUST be debited and the
+	// audit trail MUST exist even if the reservation row is missing
+	// or in an unexpected state.
+	EnsureUsageEvent(ctx context.Context, event UsageEvent) error
 	DailyUsage(ctx context.Context, accountID, windowDate string) (usedTokens, activeReservedTokens int64, err error)
 	ReapExpiredReservations(ctx context.Context, now time.Time) (int64, error)
 	// DeleteTerminalQuotaReservations drops quota_reservations rows in a

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -722,6 +722,24 @@ func (s *Store) EnsureUsageEvent(ctx context.Context, event storage.UsageEvent) 
 	return nil
 }
 
+// EnsureDemoUsageEvent inserts a demo_usage_events row idempotently
+// — duplicates on the request_id PK silently no-op. The
+// EnsureUsageEvent caller already runs the cross-account payload
+// verify on usage_events, so a benign duplicate here on the
+// demo-side table is not a security regression: an attacker who
+// could pass the usage_events conflict check could already write
+// the demo row legitimately.
+func (s *Store) EnsureDemoUsageEvent(ctx context.Context, event storage.DemoUsageEvent) error {
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO demo_usage_events(request_id, client_ip, demo_token_hash, window_date, total_tokens, created_at)
+		VALUES(?, ?, ?, ?, ?, ?)`,
+		event.RequestID, event.ClientIP, event.DemoTokenHash, event.WindowDate, event.TotalTokens, encodeTime(event.CreatedAt))
+	return err
+}
+
 func (s *Store) insertUsageEventExec(ctx context.Context, event storage.UsageEvent, idempotent bool) (sql.Result, error) {
 	if event.CreatedAt.IsZero() {
 		event.CreatedAt = time.Now().UTC()

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -681,23 +681,40 @@ func (s *Store) EnsureUsageEvent(ctx context.Context, event storage.UsageEvent) 
 		return nil
 	}
 	// PK collision. Read the existing row and verify it matches the
-	// incoming event's identity fields. Mismatch => cross-account
-	// collision (or a corrupted prior write), NOT a benign duplicate.
+	// incoming event's billing-relevant fields. Mismatch => cross-
+	// account collision, a corrupted prior write, OR a payload
+	// drift (e.g., same account/request_id retrying with a different
+	// token count) — none of which should silently succeed.
+	// R2 code MAJOR: verify the FULL billing payload (tokens + window
+	// + identity), not just identity. Without this, a buyer who can
+	// race two settle paths with different token counts could pin a
+	// low-token row first and then have higher-token settles
+	// silently no-op.
 	var existing struct {
-		AccountID    string
-		DemoIdentity string
-		TokenSource  string
-		Outcome      string
+		AccountID        string
+		DemoIdentity     string
+		WindowDate       string
+		PromptTokens     int64
+		CompletionTokens int64
+		TotalTokens      int64
+		TokenSource      string
+		Outcome          string
 	}
 	if err := s.db.QueryRowContext(ctx, `
-		SELECT account_id, demo_identity, token_source, outcome
+		SELECT account_id, demo_identity, window_date, prompt_tokens, completion_tokens, total_tokens, token_source, outcome
 		FROM usage_events WHERE request_id = ?`, event.RequestID).Scan(
-		&existing.AccountID, &existing.DemoIdentity, &existing.TokenSource, &existing.Outcome,
+		&existing.AccountID, &existing.DemoIdentity, &existing.WindowDate,
+		&existing.PromptTokens, &existing.CompletionTokens, &existing.TotalTokens,
+		&existing.TokenSource, &existing.Outcome,
 	); err != nil {
 		return err
 	}
 	if existing.AccountID != event.AccountID ||
 		existing.DemoIdentity != event.DemoIdentity ||
+		existing.WindowDate != event.WindowDate ||
+		existing.PromptTokens != event.PromptTokens ||
+		existing.CompletionTokens != event.CompletionTokens ||
+		existing.TotalTokens != event.TotalTokens ||
 		existing.TokenSource != event.TokenSource ||
 		existing.Outcome != event.Outcome {
 		return storage.ErrUsageEventConflict

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -648,7 +648,8 @@ func (s *Store) ReleaseConcurrency(ctx context.Context, accountID, requestID str
 }
 
 func (s *Store) InsertUsageEvent(ctx context.Context, event storage.UsageEvent) error {
-	return s.insertUsageEvent(ctx, event, false)
+	_, err := s.insertUsageEventExec(ctx, event, false)
+	return err
 }
 
 // EnsureUsageEvent inserts a usage_events row idempotently — duplicate
@@ -657,25 +658,68 @@ func (s *Store) InsertUsageEvent(ctx context.Context, event storage.UsageEvent) 
 // the normal SettleReservation path fails: even if the reservation
 // is missing or in an unexpected state, the buyer-facing usage record
 // MUST exist after bytes have flowed (issue #187).
+//
+// PK-collision verify (ISS-187 R1 code+security MAJOR): the gateway
+// `usage_events.request_id` is a GLOBAL primary key (issue #196,
+// pre-existing). If INSERT OR IGNORE silently no-ops on conflict,
+// an attacker with two accounts could collide a request_id and skip
+// the audit row. EnsureUsageEvent now checks RowsAffected; on 0, it
+// reads the existing row and confirms (account_id, demo_identity,
+// token_source, outcome) MATCH the incoming event. If they
+// disagree, returns ErrUsageEventConflict so the caller knows the
+// fallback failed and must refund.
 func (s *Store) EnsureUsageEvent(ctx context.Context, event storage.UsageEvent) error {
-	return s.insertUsageEvent(ctx, event, true)
+	result, err := s.insertUsageEventExec(ctx, event, true)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected > 0 {
+		return nil
+	}
+	// PK collision. Read the existing row and verify it matches the
+	// incoming event's identity fields. Mismatch => cross-account
+	// collision (or a corrupted prior write), NOT a benign duplicate.
+	var existing struct {
+		AccountID    string
+		DemoIdentity string
+		TokenSource  string
+		Outcome      string
+	}
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT account_id, demo_identity, token_source, outcome
+		FROM usage_events WHERE request_id = ?`, event.RequestID).Scan(
+		&existing.AccountID, &existing.DemoIdentity, &existing.TokenSource, &existing.Outcome,
+	); err != nil {
+		return err
+	}
+	if existing.AccountID != event.AccountID ||
+		existing.DemoIdentity != event.DemoIdentity ||
+		existing.TokenSource != event.TokenSource ||
+		existing.Outcome != event.Outcome {
+		return storage.ErrUsageEventConflict
+	}
+	return nil
 }
 
-func (s *Store) insertUsageEvent(ctx context.Context, event storage.UsageEvent, idempotent bool) error {
+func (s *Store) insertUsageEventExec(ctx context.Context, event storage.UsageEvent, idempotent bool) (sql.Result, error) {
 	if event.CreatedAt.IsZero() {
 		event.CreatedAt = time.Now().UTC()
 	}
 	if event.PromptTokens < 0 || event.CompletionTokens < 0 || event.TotalTokens < 0 {
-		return fmt.Errorf("usage tokens must be non-negative")
+		return nil, fmt.Errorf("usage tokens must be non-negative")
 	}
 	if event.PromptTokens > math.MaxInt64-event.CompletionTokens {
-		return fmt.Errorf("usage token total overflows int64")
+		return nil, fmt.Errorf("usage token total overflows int64")
 	}
 	sum := event.PromptTokens + event.CompletionTokens
 	if event.TotalTokens == 0 {
 		event.TotalTokens = sum
 	} else if event.TotalTokens != sum {
-		return fmt.Errorf("usage total_tokens does not match prompt_tokens plus completion_tokens")
+		return nil, fmt.Errorf("usage total_tokens does not match prompt_tokens plus completion_tokens")
 	}
 	stmt := `
 		INSERT INTO usage_events(request_id, account_id, demo_identity, window_date, prompt_tokens, completion_tokens, total_tokens, token_source, outcome, created_at)
@@ -685,10 +729,9 @@ func (s *Store) insertUsageEvent(ctx context.Context, event storage.UsageEvent, 
 		INSERT OR IGNORE INTO usage_events(request_id, account_id, demo_identity, window_date, prompt_tokens, completion_tokens, total_tokens, token_source, outcome, created_at)
 		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	}
-	_, err := s.db.ExecContext(ctx, stmt,
+	return s.db.ExecContext(ctx, stmt,
 		event.RequestID, event.AccountID, event.DemoIdentity, event.WindowDate, event.PromptTokens, event.CompletionTokens,
 		event.TotalTokens, event.TokenSource, event.Outcome, encodeTime(event.CreatedAt))
-	return err
 }
 
 func normalizeSettlementTokens(settlement *storage.ReservationSettlement) error {

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -648,6 +648,20 @@ func (s *Store) ReleaseConcurrency(ctx context.Context, accountID, requestID str
 }
 
 func (s *Store) InsertUsageEvent(ctx context.Context, event storage.UsageEvent) error {
+	return s.insertUsageEvent(ctx, event, false)
+}
+
+// EnsureUsageEvent inserts a usage_events row idempotently — duplicate
+// request_id PKs are absorbed via INSERT OR IGNORE. Used as the
+// SPEC-006 § 17.7 fallback path in chat_proxy.settleAfterCommit when
+// the normal SettleReservation path fails: even if the reservation
+// is missing or in an unexpected state, the buyer-facing usage record
+// MUST exist after bytes have flowed (issue #187).
+func (s *Store) EnsureUsageEvent(ctx context.Context, event storage.UsageEvent) error {
+	return s.insertUsageEvent(ctx, event, true)
+}
+
+func (s *Store) insertUsageEvent(ctx context.Context, event storage.UsageEvent, idempotent bool) error {
 	if event.CreatedAt.IsZero() {
 		event.CreatedAt = time.Now().UTC()
 	}
@@ -663,9 +677,15 @@ func (s *Store) InsertUsageEvent(ctx context.Context, event storage.UsageEvent) 
 	} else if event.TotalTokens != sum {
 		return fmt.Errorf("usage total_tokens does not match prompt_tokens plus completion_tokens")
 	}
-	_, err := s.db.ExecContext(ctx, `
+	stmt := `
 		INSERT INTO usage_events(request_id, account_id, demo_identity, window_date, prompt_tokens, completion_tokens, total_tokens, token_source, outcome, created_at)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	if idempotent {
+		stmt = `
+		INSERT OR IGNORE INTO usage_events(request_id, account_id, demo_identity, window_date, prompt_tokens, completion_tokens, total_tokens, token_source, outcome, created_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	}
+	_, err := s.db.ExecContext(ctx, stmt,
 		event.RequestID, event.AccountID, event.DemoIdentity, event.WindowDate, event.PromptTokens, event.CompletionTokens,
 		event.TotalTokens, event.TokenSource, event.Outcome, encodeTime(event.CreatedAt))
 	return err

--- a/specs/AUDIT_FIX_ISS_187_R1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_187_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,106 @@
+# ISS-187 R1 — architect-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-187-mid-stream-settlement`
+against `origin/main`. The change closes a SPEC-006 § 17.7 P0
+money-path gap: when the gateway's normal settlement path fails
+after streaming bytes have flowed to the buyer, the gateway now
+writes a usage_events row via a new idempotent fallback
+(`EnsureUsageEvent`) instead of silently dropping the audit row +
+refunding the reservation.
+
+## Background
+
+SPEC-006 v0.6 § 17.7 (Quota refund and settlement matrix). Streaming
+partial-stream row:
+
+| Status | Completion tokens | Quota debited |
+|---|---|---|
+| 502, >0 partial stream | provider-reported actuals, else ceil(bytes_emitted/4) | prompt + actual_completion |
+
+Phase-A scenario 05 caught the gateway emitting HTTP 200 + 13kB +
+[DONE] with NO usage_events row. Buyer paid $0, provider got $0.
+Root cause was not pinpointed empirically; the diff is a defensive
+fix that handles the failure mode regardless of upstream cause.
+
+SPEC-002 v1.4.2 R-3 (in the recently-merged #192) re-affirms FR-B6's
+SSE envelope but doesn't go into the settlement contract — that's
+SPEC-006's domain.
+
+## Scope of this lane
+
+You are the **architect lane**. Focus on:
+
+- **Spec consistency vs SPEC-006 § 17.7.** Does the new fallback
+  satisfy the spec's "prompt + actual_completion" debit rule for
+  partial streams? Look at the fallback's TokenSource and
+  CompletionTokens derivation in `settleAfterCommit`.
+- **SPEC-005 § 6.9 mirror credit composition.** SPEC-005 says the
+  provider gets credited via mirror reads from `usage_events`. With
+  the fix, usage_events now reliably has a row → SPEC-005 mirror
+  runs as expected. Without the fix, no row → no credit → provider
+  underpaid. Does the fix correctly compose with the SPEC-005 mirror
+  job's read path?
+- **Settlement outcome vocabulary.** The fallback preserves the
+  caller-supplied outcome string ("stream_truncated",
+  "client_disconnect", "stream_malformed", etc.). Is the outcome
+  vocabulary used consistently with SPEC-006 § 17.7's row labels?
+  Any outcome strings that don't appear in the spec matrix and might
+  surprise harnesses?
+- **Window-date drift.** Normal-path SettleReservation uses the
+  reservation row's window_date. Fallback uses
+  `s.now().UTC().Format("2006-01-02")`. For a request that spans
+  UTC midnight (rare but possible for long streams), the window_date
+  could differ by one day. SPEC-006 says quotas are per-window-date;
+  could that drift double-count or miscount toward a buyer's daily
+  quota?
+- **SPEC-002 v1.4.3 follow-up.** Issue #197 already collects
+  v1.4.3 clauses (UUID-tolerance + cap-exhaustion + cold-start
+  fallback semantics). Does this PR introduce new SPEC-006
+  clarification candidates worth bundling into a similar #197-style
+  follow-up?
+- **Versioning.** Does this PR need a SPEC-006 minor bump (e.g.,
+  v0.X.Y) to document the fallback path? Or is "the gateway MUST
+  write a usage_events row for partial-stream outcomes regardless
+  of reservation state" an implementation detail rather than a
+  spec clause?
+- **Naming.** `EnsureUsageEvent` vs `InsertUsageEvent`. Are the
+  two names self-explanatory? Should the spec / addendum mention
+  the fallback explicitly so a future reader understands when each
+  is called?
+
+## Files in the diff
+
+```
+phase5-gateway/internal/router/chat_proxy.go
+phase5-gateway/internal/router/server_test.go
+phase5-gateway/internal/storage/interfaces.go
+phase5-gateway/internal/storage/sqlite/store.go
+```
+
+Useful command:
+```
+git diff origin/main -- phase5-gateway/
+specs/SPEC-006-buyer-api.md   # § 17.7 settlement matrix
+specs/SPEC-005-billing.md      # § 6.9 mirror credit
+```
+
+## Scope: PR-INTRODUCED findings only
+
+Per the locked three-lane convergence convention.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **Aspect:** spec | naming | versioning | cross-service | contract
+- **Issue:** one-sentence statement
+- **Evidence:** quote relevant code or spec
+- **Recommendation:** specific change
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Keep response under 700 words.

--- a/specs/AUDIT_FIX_ISS_187_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_187_R1_CODE_PROMPT.md
@@ -1,0 +1,104 @@
+# ISS-187 R1 — code-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-187-mid-stream-settlement`
+against `origin/main`. The change implements SPEC-006 § 17.7 by
+adding an idempotent fallback path to `settleAfterCommit` — when
+`SettleReservation` fails after bytes have flowed, the gateway now
+INSERTs a usage_events row directly via the new `EnsureUsageEvent`
+storage method (INSERT OR IGNORE on the PK).
+
+## Scope of this lane
+
+You are the **code lane**. Focus on:
+
+- **Idempotency.** `EnsureUsageEvent` uses `INSERT OR IGNORE` on
+  the request_id PK. If a usage_events row already exists (e.g.,
+  via the normal settle path that succeeded), the fallback's
+  INSERT OR IGNORE silently no-ops. Is that the right behavior?
+  Could there be a path where the normal-settle's row has
+  different/incorrect data than the fallback's intended data, and
+  the silent no-op masks a real discrepancy?
+- **Error handling.** When `SettleReservation` fails AND
+  `EnsureUsageEvent` fails, the code refunds and returns. Is the
+  refund still correct here? The reservation might not exist at
+  all (settle_error="quota reservation not found") — refund is a
+  no-op. But for `status != 'active'`, refund could now mutate a
+  settled row to refunded. Is that ever wrong?
+- **Storage interface contract.** `UsageStore.EnsureUsageEvent` is
+  newly added. Any test fixtures or mock implementations of
+  `UsageStore` outside the diff also need this method or they
+  won't compile. Search for `UsageStore` and `InsertUsageEvent` —
+  do any non-real-storage implementations exist that need
+  updating?
+- **`Server.settleAfterCommit` signature.** It still takes
+  prompt/completion individually; `EnsureUsageEvent` derives
+  TotalTokens via `prompt + completion`. Is that derivation
+  correct in all callers? Compare to `SettleReservation`'s
+  internal `normalizeSettlementTokens` logic.
+- **window_date derivation.** The fallback uses
+  `s.now().UTC().Format("2006-01-02")`. The original SettleReservation
+  used the reservation row's window_date. Could these diverge for
+  edge cases (request crosses UTC midnight)? Look for any
+  reconciliation-side join that would break if the window_date
+  differs by a day.
+- **Test coverage.**
+  - `TestStreamingSettlementFallbackWritesUsageEventOn
+    MissingReservation` — new test that DELETEs the reservation
+    mid-stream and asserts the fallback wrote the row. Is the
+    timing race solid (50ms sleep + 50-attempt poll for the
+    reservation)? Could the test be flaky on slow CI runners?
+  - Existing tests using `settleAfterCommit` paths
+    (TestStreamingMidStreamProviderDisconnect, etc) — do they
+    still pass and still cover their original invariants?
+  - Demo-token path: `subject.DemoIdentity != ""` triggers
+    `SettleDemoReservation` in the normal path. The fallback uses
+    `EnsureUsageEvent` which inserts a `demo_identity` field. Is
+    the fallback symmetric with the demo flow? Should there be a
+    separate `EnsureDemoUsageEvent` (no — demo_usage_events is a
+    secondary table; the primary usage_events insert is enough
+    for SPEC-006 §17.7 audit). Confirm.
+- **Logging shape.** The diff emits one `slog.Error` for the
+  normal-settle failure, then either a `slog.Warn` (fallback
+  succeeded) or a second `slog.Error` (fallback also failed).
+  Is the log shape useful for an oncall reading logs?
+
+Out of scope for this lane:
+
+- **Security lane:** retriability, double-billing, attack surface.
+- **Architect lane:** SPEC-006 § 17.7 wording match, SPEC-005
+  mirror credit, settlement matrix consistency.
+
+## Files in the diff
+
+```
+phase5-gateway/internal/router/chat_proxy.go
+phase5-gateway/internal/router/server_test.go
+phase5-gateway/internal/storage/interfaces.go
+phase5-gateway/internal/storage/sqlite/store.go
+```
+
+Useful command:
+```
+git diff origin/main -- phase5-gateway/
+```
+
+## Scope: PR-INTRODUCED findings only
+
+Per the locked three-lane convergence convention.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **File:line(s):** exact reference
+- **Issue:** one-sentence problem statement
+- **Evidence:** quote relevant code
+- **Recommendation:** specific change
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Keep response under 700 words.

--- a/specs/AUDIT_FIX_ISS_187_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_187_R1_SECURITY_PROMPT.md
@@ -1,0 +1,93 @@
+# ISS-187 R1 — security-lane audit prompt
+
+Audit target: the diff on branch `fix/iss-187-mid-stream-settlement`
+against `origin/main`. The change adds an `EnsureUsageEvent`
+fallback path in `settleAfterCommit` so the gateway writes a
+usage_events row even when `SettleReservation` fails. Before this
+change, a SPEC-006 § 17.7 settlement failure refunded the
+reservation and silently dropped the audit row — buyer paid
+nothing, provider got nothing.
+
+## Scope of this lane
+
+You are the **security lane**. Focus on:
+
+- **Forged usage_events.** The fallback `EnsureUsageEvent` does
+  NOT consult the reservation row. Can an attacker make the
+  gateway write a usage_events row WITHOUT having gone through
+  ReserveQuota first? If yes — does the rest of the code path
+  ensure `subject.AccountID` is authenticated before reaching
+  `settleAfterCommit`? Trace from `handleChatCompletions` down to
+  the new fallback.
+- **Buyer over-charging.** The fallback uses
+  `gateway_estimated` for `token_source` and `ceil(emitted / 4)`
+  for completion tokens (per estimateStreamingCompletionTokens).
+  Could an attacker (a malicious provider, or compromised
+  coordinator) make the gateway over-estimate token counts and
+  over-charge a buyer? Look at the `emitted` counter — what
+  bounds it? Does it cap at `max_tokens` per the buyer's
+  original request?
+- **Buyer under-charging via collision.** The pre-existing PK
+  collision (issue #196 — gateway `usage_events.request_id` is a
+  global PK, not account-scoped) interacts with the new
+  `INSERT OR IGNORE`. A cross-account collision now produces a
+  SILENT NO-OP (where before it might have been an explicit
+  error). Does the new behavior make #196 worse?
+- **Audit-log injection.** The fallback `slog.Warn`/`slog.Error`
+  paths include `subject.AccountID`, `requestID(r)`, and
+  err.Error() strings. Could a malicious upstream-coordinator
+  error string contain newlines or control characters that would
+  break log parsing? (slog handles escaping, but worth
+  confirming.)
+- **Race in the test.** `TestStreamingSettlementFallback...` runs
+  a goroutine that polls quota_reservations every 2ms, then
+  DELETEs the row mid-stream. Could this test's structure expose
+  a real race in the gateway (e.g., between settlement-tx-begin
+  and settlement-tx-commit, a row delete could leave the
+  transaction in a weird state)? Not a code-blocker for the PR
+  but worth flagging.
+- **window_date derivation.** Fallback computes
+  `s.now().UTC().Format("2006-01-02")`. If `s.now` is
+  attacker-influenced (it isn't in production, but in tests it
+  uses fixedNow), could window_date be manipulated to escape
+  rate-limit windows?
+
+Out of scope for this lane:
+
+- **Code lane:** idempotency semantics, signature consistency.
+- **Architect lane:** SPEC alignment.
+
+## Files in the diff
+
+```
+phase5-gateway/internal/router/chat_proxy.go
+phase5-gateway/internal/router/server_test.go
+phase5-gateway/internal/storage/interfaces.go
+phase5-gateway/internal/storage/sqlite/store.go
+```
+
+## Scope: PR-INTRODUCED findings only
+
+Per the locked three-lane convergence convention. The pre-existing
+gateway PK collision is tracked in [#196](https://github.com/Augustas11/macprovider/issues/196).
+The pre-existing gateway-side Idempotency-Key dedupe gap is tracked
+in [#200](https://github.com/Augustas11/macprovider/issues/200). Drop any
+re-finding of those from your output and add a one-line NOTE
+referencing the issue.
+
+## Output format
+
+For each finding:
+
+- **Severity:** CRITICAL | MAJOR | MINOR | NOTE
+- **File:line(s):** exact reference
+- **Threat model / attack surface:** one-sentence statement
+- **Evidence:** quote relevant code
+- **Recommendation:** specific change
+
+End with:
+```
+Found: <N> CRITICAL, <N> MAJOR, <N> MINOR, <N> NOTE.
+```
+
+Keep response under 700 words.


### PR DESCRIPTION
Closes [#187](https://github.com/Augustas11/macprovider/issues/187) — P0 money-path.

## What this PR does

Phase-A scenario `05_mid_stream_drop` showed that when a provider disconnects mid-stream, the buyer receives HTTP 200 + partial bytes + `[DONE]` but no `usage_events` row is written. **Buyer paid $0. Provider got $0. SPEC-006 § 17.7 violated.**

Root cause: `settleAfterCommit` silently swallowed `SettleReservation` errors and fell back to `RefundReservation`. ANY settle failure (missing reservation, status drift, transient DB error) lost the audit row and undercharged everyone.

## Defensive fix

1. New `Store.EnsureUsageEvent` storage method — `INSERT OR IGNORE` on the `usage_events` PK. Allows direct usage_events write without requiring a reservation row.
2. `settleAfterCommit` failure path now retries via `EnsureUsageEvent` with the same (prompt, completion, source, outcome) data. On success → `slog.Warn` naming the fallback fire. On both failing → `slog.Error` with both error strings + `RefundReservation` as last-resort cleanup.
3. Regression test `TestStreamingSettlementFallbackWritesUsageEventOnMissingReservation` simulates the production failure mode (reservation row deleted mid-stream) and asserts the fallback wrote the usage_events row.

## Audit plan

Three-lane codex audit (`specs/AUDIT_FIX_ISS_187_R1_*.md`): code / security / architect. Convergence loop to 0 CRITICAL / 0 MAJOR per the locked SPEC-audit convention.

Test status (local): full gateway test suite green.

## Related

- Pre-existing gateway PK collision (#196) interacts with the new `INSERT OR IGNORE` — see security prompt scope.
- Pre-existing gateway Idempotency-Key dedupe gap (#200) is orthogonal — neither blocks the other.