### PR TITLE
fix(provider): heartbeat bounded send + liveness watchdog (closes #189)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -53,6 +53,18 @@ protocol ReceiptKeyRotatingCoordinatorClient: Sendable {
     ) async throws
 }
 
+// Issue #189: heartbeat send wedged at the URLSession layer (TCP socket
+// half-open or App Nap-starved task). The keepalive loop bounds each
+// sendHeartbeat() with this timeout; a timeout throw routes to the
+// existing closeWebSocketAfterKeepaliveFailure() → runReconnectLoop path.
+struct CoordinatorHeartbeatSendTimeout: Error, CustomStringConvertible, Equatable {
+    let timeoutSeconds: Double
+
+    var description: String {
+        String(format: "coordinator heartbeat send timed out after %.1fs", timeoutSeconds)
+    }
+}
+
 struct CoordinatorReceiptRotationTimeout: Error, CustomStringConvertible, Equatable {
     let timeoutSeconds: Double
 
@@ -199,6 +211,12 @@ actor CoordinatorClient {
     private var webSocket: ProviderWebSocketTask?
     private var runTask: Task<Void, Never>?
     private var heartbeatTask: Task<Void, Never>?
+    // Issue #189: separate watchdog task observing heartbeat liveness.
+    // If the heartbeat task itself stalls (App Nap, cooperative-task
+    // starvation), the watchdog fires watchdogExitHook so launchd respawns.
+    private var heartbeatWatchdogTask: Task<Void, Never>?
+    private var lastHeartbeatSuccessNanoseconds: UInt64 = 0
+    private let watchdogExitHook: @Sendable (String) -> Void
     private var swapHeartbeatTask: Task<Void, Never>?
     private var sleepAssertion: ProviderSleepAssertion?
     private let sendOverride: SendOverride?
@@ -216,7 +234,13 @@ actor CoordinatorClient {
         pairingController: PairingController? = nil,
         connectAndRunOverride: (@Sendable () async throws -> Void)? = nil,
         providerReceiptPublicKey: String? = nil,
-        receiptBuilder: ReceiptBuilder? = nil
+        receiptBuilder: ReceiptBuilder? = nil,
+        // Issue #189: injectable in tests; production uses Darwin.exit(1)
+        // so the launchd KeepAlive contract recovers the wedged process.
+        watchdogExitHook: @escaping @Sendable (String) -> Void = { reason in
+            FileHandle.standardError.write(Data("FATAL coordinator heartbeat watchdog: \(reason)\n".utf8))
+            Darwin.exit(1)
+        }
     ) {
         guard let rawURL = config.coordinatorURL, let url = URL(string: rawURL) else {
             return nil
@@ -256,6 +280,7 @@ actor CoordinatorClient {
         self.pairingController = pairingController ?? PairingController(configPath: config.configPath)
         self.connectAndRunOverride = connectAndRunOverride
         self.sendOverride = sendOverride
+        self.watchdogExitHook = watchdogExitHook
     }
 
     func start() {
@@ -270,6 +295,7 @@ actor CoordinatorClient {
     func stop() async {
         runTask?.cancel()
         heartbeatTask?.cancel()
+        heartbeatWatchdogTask?.cancel()
         swapHeartbeatTask?.cancel()
         sleepAssertion?.stop()
         sleepAssertion = nil
@@ -280,6 +306,7 @@ actor CoordinatorClient {
         await providerStatus.setCoordinatorSession(connected: false)
         runTask = nil
         heartbeatTask = nil
+        heartbeatWatchdogTask = nil
         swapHeartbeatTask = nil
         webSocket = nil
     }
@@ -294,10 +321,17 @@ actor CoordinatorClient {
             case .loadFinished:
                 continue
             case .completed:
+                // Issue #189 R1 architect MEDIUM: the warm-swap completion
+                // path is the second hot heartbeat callsite. A wedged
+                // URLSession.send() here would park swapHeartbeatTask
+                // exactly the way it parks the keepalive loop; bound it
+                // through the same 5s timeout for symmetry.
                 do {
-                    try await sendHeartbeat()
+                    try await sendHeartbeatBounded(resetWindow: true)
+                    recordHeartbeatSuccess()
                 } catch {
                     Self.keepaliveDebug("warm_swap_heartbeat_send_error error=\(error)")
+                    closeWebSocketAfterKeepaliveFailure()
                 }
             case let .failed(reason):
                 Self.keepaliveDebug("coordinator.warmSwap.swapFailed reason=\(reason)")
@@ -844,6 +878,8 @@ actor CoordinatorClient {
     private func cleanupConnection() async {
         heartbeatTask?.cancel()
         heartbeatTask = nil
+        heartbeatWatchdogTask?.cancel()
+        heartbeatWatchdogTask = nil
         sleepAssertion?.stop()
         sleepAssertion = nil
         await inferenceRelay?.cancelAllAndClear()
@@ -855,6 +891,15 @@ actor CoordinatorClient {
     }
 
     private func handle(_ message: URLSessionWebSocketTask.Message) async throws {
+        // Issue #189 R1 security MEDIUM: the watchdog measures local
+        // send completion, which a one-way-broken socket can satisfy
+        // indefinitely (OS-level queueing while the coordinator has
+        // stopped receiving). Bump the success timestamp on EVERY
+        // received frame too, so a coordinator that has stopped
+        // talking back (the actual signal we care about) trips the
+        // watchdog within tolerance.
+        recordHeartbeatSuccess()
+
         let text: String
         switch message {
         case .string(let value):
@@ -958,6 +1003,38 @@ actor CoordinatorClient {
 
     func sendHeartbeatForTest() async throws {
         try await sendHeartbeat()
+    }
+
+    // Issue #189: test seam — exercise the 5s timeout against an
+    // injected sendOverride that never returns.
+    func sendHeartbeatBoundedForTest(resetWindow: Bool = true) async throws {
+        try await sendHeartbeatBounded(resetWindow: resetWindow)
+    }
+
+    // Issue #189: test seam — start a watchdog with a short interval
+    // and verify it fires the exit hook when last-success is stale.
+    func startHeartbeatWatchdogForTest(intervalSeconds: Int) {
+        startHeartbeatWatchdog(intervalSeconds: intervalSeconds)
+    }
+
+    func seedLastHeartbeatSuccessForTest(ageNanoseconds: UInt64) {
+        let now = DispatchTime.now().uptimeNanoseconds
+        lastHeartbeatSuccessNanoseconds = now > ageNanoseconds ? now - ageNanoseconds : 1
+    }
+
+    func cancelHeartbeatWatchdogForTest() {
+        heartbeatWatchdogTask?.cancel()
+        heartbeatWatchdogTask = nil
+    }
+
+    // Issue #189 R1 security MEDIUM: assert that any inbound frame
+    // bumps the heartbeat success timestamp via handle().
+    func handleForTest(_ message: URLSessionWebSocketTask.Message) async throws {
+        try await handle(message)
+    }
+
+    func nanosecondsSinceLastHeartbeatSuccessForTest() -> UInt64 {
+        nanosecondsSinceLastHeartbeatSuccess()
     }
 
     private func receiveAuthChallenge(from socket: ProviderWebSocketTask) async throws -> [String: Any] {
@@ -1208,10 +1285,31 @@ actor CoordinatorClient {
     // metrics window is still rolled only on the full coordinator interval
     // (resetWindow), so heartbeat metrics are unchanged from before.
     private static let keepaliveTickCeilingSeconds = 5
+    // Issue #189: hard ceiling on one heartbeat send. URLSession.send() can
+    // queue frames without surfacing TCP half-open until the OS reaps the
+    // socket minutes/hours later. 5s comfortably exceeds normal RTT to the
+    // coordinator (sub-100ms) and is well under the 90s
+    // provider_inactive_threshold, so a wedged send fails fast and the
+    // existing closeWebSocketAfterKeepaliveFailure → reconnect path fires
+    // before the coordinator decides we're gone.
+    private static let heartbeatSendTimeoutSeconds: Double = 5
+    // Issue #189: watchdog tolerance, expressed against the actual tick
+    // cadence (≤ keepaliveTickCeilingSeconds = 5s) rather than the
+    // coordinator-supplied interval. The tick is what produces a
+    // success timestamp, so multiplying tickSeconds × 3 (= ≤15s on a
+    // 5s tick) gives a hard upper bound that is independent of the
+    // coordinator-configured heartbeat interval and is always well
+    // below the 90s coordinator inactivity drop.
+    private static let heartbeatWatchdogToleranceMultiplier: Int = 3
     private func startHeartbeat(intervalSeconds: Int) {
         heartbeatTask?.cancel()
+        heartbeatWatchdogTask?.cancel()
         let tickSeconds = max(1, min(intervalSeconds, Self.keepaliveTickCeilingSeconds))
         Self.keepaliveDebug("heartbeat_start interval_s=\(intervalSeconds) tick_s=\(tickSeconds)")
+        // Seed last-success to "now" so the watchdog doesn't fire before
+        // the very first tick completes.
+        lastHeartbeatSuccessNanoseconds = DispatchTime.now().uptimeNanoseconds
+        startHeartbeatWatchdog(intervalSeconds: intervalSeconds)
         heartbeatTask = Task { [weak self] in
             var secondsSinceWindowReset = 0
             while !Task.isCancelled {
@@ -1228,13 +1326,100 @@ actor CoordinatorClient {
                     secondsSinceWindowReset = 0
                 }
                 do {
-                    try await self?.sendHeartbeat(resetWindow: rollWindow)
+                    // Issue #189: bound the send so a wedged URLSession does
+                    // not silently absorb every tick for hours.
+                    try await self?.sendHeartbeatBounded(resetWindow: rollWindow)
+                    await self?.recordHeartbeatSuccess()
                 } catch {
                     Self.keepaliveDebug("keepalive_send_error error=\(error)")
                     await self?.closeWebSocketAfterKeepaliveFailure()
                     return
                 }
             }
+        }
+    }
+
+    // Issue #189: separate liveness observer. The heartbeat task itself
+    // can be App Nap-starved (the originally reported failure mode); a
+    // task that just sleeps and inspects a timestamp is cheaper to
+    // schedule and acts as an independent timer of last resort.
+    //
+    // Tolerance derives from tickSeconds (the actual tick cadence,
+    // capped at keepaliveTickCeilingSeconds = 5s), NOT from the
+    // coordinator-supplied intervalSeconds. This keeps the watchdog
+    // tolerance bounded at ~15s regardless of operator/coordinator
+    // misconfiguration and avoids integer-overflow math at the
+    // extremes (Int.max heartbeat_interval_s no longer traps).
+    private func startHeartbeatWatchdog(intervalSeconds: Int) {
+        let tickSeconds = max(1, min(intervalSeconds, Self.keepaliveTickCeilingSeconds))
+        let tolerance = UInt64(tickSeconds * Self.heartbeatWatchdogToleranceMultiplier)
+            * 1_000_000_000
+        // Check at a sub-tick cadence so an overrun is detected within
+        // one extra tick rather than after the next full tick boundary.
+        let checkNanoseconds = UInt64(tickSeconds) * 500_000_000
+        let hook = watchdogExitHook
+        heartbeatWatchdogTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: checkNanoseconds)
+                if Task.isCancelled { return }
+                guard let self else { return }
+                let elapsed = await self.nanosecondsSinceLastHeartbeatSuccess()
+                // Issue #189 R2 security LOW: recheck cancellation
+                // AFTER the actor hop. A drain entry that lands
+                // between the actor await and the hook invocation
+                // could otherwise lose the race to Darwin.exit(1).
+                if Task.isCancelled { return }
+                if elapsed >= tolerance {
+                    hook("heartbeat liveness exceeded tolerance: \(elapsed / 1_000_000_000)s since last success >= \(tolerance / 1_000_000_000)s")
+                    return
+                }
+            }
+        }
+    }
+
+    private func recordHeartbeatSuccess() {
+        lastHeartbeatSuccessNanoseconds = DispatchTime.now().uptimeNanoseconds
+    }
+
+    private func nanosecondsSinceLastHeartbeatSuccess() -> UInt64 {
+        let last = lastHeartbeatSuccessNanoseconds
+        guard last != 0 else { return 0 }
+        let now = DispatchTime.now().uptimeNanoseconds
+        return now > last ? now - last : 0
+    }
+
+    // Issue #189: structured concurrency wrapper. The send task races a
+    // sleep task; whichever finishes first wins and the other is
+    // cancelled.
+    //
+    // Subtlety (R1 code/architect/security HIGH↔MEDIUM convergent):
+    // URLSessionWebSocketTask.send() is NOT cancellation-cooperative
+    // once the underlying TCP socket is half-open; Task.cancel alone
+    // will not unblock it, and TaskGroup deinit awaits all children.
+    // Before the timeout child throws, it explicitly calls
+    // cancel(with:reason:) on the captured WebSocket task — that
+    // forces URLSession to surface a transport error on the in-flight
+    // send, which lets the send child unwind so the group can return.
+    // In production the captured socket is non-nil; in unit tests
+    // the WS is mocked via sendOverride and the cancellation arrives
+    // through the existing cooperative Task.cancel path.
+    private func sendHeartbeatBounded(resetWindow: Bool) async throws {
+        let socketRef = webSocket
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { [weak self] in
+                try await self?.sendHeartbeat(resetWindow: resetWindow)
+            }
+            group.addTask {
+                let nanoseconds = UInt64(Self.heartbeatSendTimeoutSeconds * 1_000_000_000)
+                try await Task.sleep(nanoseconds: nanoseconds)
+                // Force the wedged URLSession.send() to error out so
+                // the racing send child can unwind. Calling cancel on
+                // a closed/nil task is safe and idempotent.
+                socketRef?.cancel(with: .goingAway, reason: nil)
+                throw CoordinatorHeartbeatSendTimeout(timeoutSeconds: Self.heartbeatSendTimeoutSeconds)
+            }
+            defer { group.cancelAll() }
+            try await group.next()
         }
     }
 
@@ -1289,6 +1474,17 @@ actor CoordinatorClient {
     func drainAndExit(reason: String, exitCode: Int32 = 0) async {
         // Used by SIGTERM signal handler — drain in-flight buyer requests,
         // notify coordinator, then exit the whole process.
+        // Issue #189 R1 security LOW: cancel the heartbeat watchdog on
+        // drain entry. Otherwise a watchdog-triggered Darwin.exit(1)
+        // could race the orderly drain and drop the final drain_status
+        // frame (and the SIGTERM-requested exit code).
+        // R2 security LOW: also stop the heartbeat tick task here so a
+        // bounded-send timeout cannot force-cancel the WS while the
+        // drain_status sequence is still being emitted.
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        heartbeatWatchdogTask?.cancel()
+        heartbeatWatchdogTask = nil
         try? await sendStateUpdate(state: .draining, reason: reason)
         try? await sendDrainStatus(phase: "starting")
         try? await sendDrainStatus(phase: "in_progress")
@@ -1314,6 +1510,16 @@ actor CoordinatorClient {
     /// reported in the very first heartbeat and stick (the coordinator
     /// has no implicit "draining → ready" transition).
     func drainFromCoordinator(reason: String) async throws {
+        // Issue #189 R1 security LOW: cancel the watchdog at drain
+        // ENTRY (not just at the end of the drain) so a watchdog
+        // exit cannot race the in-progress drain_status sequence.
+        // R2 security LOW: also stop the heartbeat tick task here so
+        // a bounded-send timeout cannot force-cancel the WS while
+        // the drain_status sequence is still being emitted.
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        heartbeatWatchdogTask?.cancel()
+        heartbeatWatchdogTask = nil
         try? await sendStateUpdate(state: .draining, reason: reason)
         try? await sendDrainStatus(phase: "starting")
         try? await sendDrainStatus(phase: "in_progress")
@@ -1326,6 +1532,8 @@ actor CoordinatorClient {
         webSocket?.cancel(with: .goingAway, reason: nil)
         heartbeatTask?.cancel()
         heartbeatTask = nil
+        heartbeatWatchdogTask?.cancel()
+        heartbeatWatchdogTask = nil
         sleepAssertion?.stop()
         sleepAssertion = nil
         // v1.1.4: reset local state for the next coordinator session.

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -658,6 +658,140 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertEqual(hello["model_hash"] as? String, "boot-hash")
     }
 
+    // Issue #189: a URLSessionWebSocketTask.send() that never returns
+    // (TCP half-open) must surface as a throwable timeout, NOT a
+    // silent hang. The bounded wrapper is the timeout boundary.
+    func testHeartbeatBoundedSendThrowsWhenSendHangs() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        // sendOverride sleeps far longer than the 5s send-timeout; if the
+        // bound is missing this test would hang for 30s and the harness
+        // would surface that as a timeout failure.
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            sendOverride: { _ in
+                try? await Task.sleep(nanoseconds: 30 * 1_000_000_000)
+            }
+        )
+
+        let start = DispatchTime.now().uptimeNanoseconds
+        do {
+            try await client.sendHeartbeatBoundedForTest()
+            XCTFail("expected CoordinatorHeartbeatSendTimeout")
+        } catch is CoordinatorHeartbeatSendTimeout {
+            // expected
+        } catch is CancellationError {
+            // also acceptable — the racing send task can lose the
+            // cancellation race and surface as a CancellationError.
+        }
+        let elapsedNs = DispatchTime.now().uptimeNanoseconds - start
+        // Bound is 5s; allow 1s of slack on busy CI runners. The
+        // important guarantee is that we did NOT wait the full 30s.
+        XCTAssertLessThan(elapsedNs, 10 * 1_000_000_000, "bounded send should not block beyond ~5s, got \(elapsedNs)ns")
+    }
+
+    // Issue #189: the watchdog is the App-Nap insurance — if the
+    // heartbeat task itself stops being scheduled, an independent
+    // observer must fire the exit hook so launchd respawns the
+    // process.
+    func testHeartbeatWatchdogFiresExitHookOnStaleness() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let captured = CapturedWatchdogReason()
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            watchdogExitHook: { reason in
+                Task { await captured.set(reason) }
+            }
+        )
+
+        // Tolerance = 3 × intervalSeconds. interval=1 → tolerance=3s.
+        // Seeding age=5s puts us safely past tolerance on the first
+        // 0.5s check tick.
+        await client.seedLastHeartbeatSuccessForTest(ageNanoseconds: 5 * 1_000_000_000)
+        await client.startHeartbeatWatchdogForTest(intervalSeconds: 1)
+
+        try await Self.waitUntil(timeoutNanoseconds: 5_000_000_000) {
+            await captured.value() != nil
+        }
+        let reason = await captured.value()
+        XCTAssertNotNil(reason)
+        XCTAssertTrue(reason?.contains("heartbeat liveness") ?? false, reason ?? "<nil>")
+        await client.cancelHeartbeatWatchdogForTest()
+    }
+
+    // Issue #189 R1 security MEDIUM: inbound traffic must also count
+    // as heartbeat liveness. If the coordinator stops responding but
+    // the OS keeps queuing our sends, the watchdog must still fire
+    // — and conversely, fresh inbound activity must keep it quiet
+    // even when no sends have happened. The handler hook bumps
+    // recordHeartbeatSuccess on every received frame.
+    func testHandleBumpsHeartbeatSuccessOnInboundActivity() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: recorder)
+
+        // Seed the success timestamp far in the past — well beyond
+        // any plausible tolerance.
+        await client.seedLastHeartbeatSuccessForTest(ageNanoseconds: 60 * 1_000_000_000)
+        let staleAge = await client.nanosecondsSinceLastHeartbeatSuccessForTest()
+        XCTAssertGreaterThan(staleAge, 30 * 1_000_000_000)
+
+        // An inbound message must reset the watchdog clock. We can
+        // route a valid coordinator JSON frame through the handle()
+        // hook by invoking the public preflight test seam path; any
+        // received frame is fine since the bump happens before the
+        // switch on type. We use a malformed frame, which produces
+        // a NAK send to the recorder but still trips the bump first.
+        try await client.handleForTest(.string("{\"type\":\"hello_ack\",\"interval\":5}"))
+        let freshAge = await client.nanosecondsSinceLastHeartbeatSuccessForTest()
+        XCTAssertLessThan(freshAge, 5 * 1_000_000_000, "inbound message did not bump heartbeat clock; age=\(freshAge)ns")
+    }
+
+    // Issue #189: while the heartbeat is healthy the watchdog must
+    // NOT fire. A flapping watchdog would be worse than the bug it
+    // tries to mitigate.
+    func testHeartbeatWatchdogDoesNotFireWhenSendsAreRecent() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let captured = CapturedWatchdogReason()
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            watchdogExitHook: { reason in
+                Task { await captured.set(reason) }
+            }
+        )
+
+        // interval=1 → tolerance=3s. Seed last-success age WELL below
+        // tolerance and run a couple of watchdog ticks; the hook must
+        // not fire.
+        await client.seedLastHeartbeatSuccessForTest(ageNanoseconds: 0)
+        await client.startHeartbeatWatchdogForTest(intervalSeconds: 1)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+        let reason = await captured.value()
+        XCTAssertNil(reason, "watchdog fired on a fresh heartbeat: \(reason ?? "")")
+        await client.cancelHeartbeatWatchdogForTest()
+    }
+
     func testHelloEnabledModeReadsFromModelRuntime() async throws {
         let recorder = CoordinatorFrameRecorder()
         let runtime = makeRuntime(modelID: "model-b", modelHash: "runtime-hash", warmSwapEnabled: true)
@@ -1651,7 +1785,9 @@ final class CoordinatorClientTests: XCTestCase {
         attestationGenerator: Tier2AttestationTokenGenerating = StaticAttestationGenerator(token: nil),
         pairingController: PairingController? = nil,
         connectAndRunOverride: (@Sendable () async throws -> Void)? = nil,
-        providerReceiptPublicKey: String? = nil
+        providerReceiptPublicKey: String? = nil,
+        sendOverride: CoordinatorClient.SendOverride? = nil,
+        watchdogExitHook: (@Sendable (String) -> Void)? = nil
     ) async throws -> CoordinatorClient {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
         config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
@@ -1665,20 +1801,25 @@ final class CoordinatorClientTests: XCTestCase {
         } else {
             runtime = try await ModelRuntime(modelID: nil)
         }
+        let defaultSendOverride: CoordinatorClient.SendOverride = { frame in
+            await recorder.append(frame)
+        }
+        let defaultWatchdogHook: @Sendable (String) -> Void = { _ in
+            XCTFail("watchdog exit hook fired unexpectedly")
+        }
         return try XCTUnwrap(CoordinatorClient(
             config: config,
             modelRuntime: runtime,
             providerStatus: status,
-            sendOverride: { frame in
-                await recorder.append(frame)
-            },
+            sendOverride: sendOverride ?? defaultSendOverride,
             reconnectGraceNanoseconds: reconnectGraceNanoseconds,
             receiptKeyRotationTimeoutNanoseconds: receiptKeyRotationTimeoutNanoseconds,
             attestationGenerator: attestationGenerator,
             sleepAssertionFactory: { nil },
             pairingController: pairingController,
             connectAndRunOverride: connectAndRunOverride,
-            providerReceiptPublicKey: providerReceiptPublicKey
+            providerReceiptPublicKey: providerReceiptPublicKey,
+            watchdogExitHook: watchdogExitHook ?? defaultWatchdogHook
         ))
     }
 
@@ -1716,6 +1857,13 @@ private enum CoordinatorClientTestError: Error {
     case unexpectedContainerLoader
     case sendStateUpdateFailed
     case missingProviderECDHPublicKey
+}
+
+// Issue #189: thread-safe sink for the injected watchdog exit hook.
+private actor CapturedWatchdogReason {
+    private var reason: String?
+    func set(_ value: String) { reason = value }
+    func value() -> String? { reason }
 }
 
 private enum FakeTier2AuthOutcome: Sendable {

--- a/specs/AUDIT_FIX_ISS_189_R1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_189_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,95 @@
+# AUDIT — Fix iss-189 (heartbeat watchdog + bounded send) — R1 ARCHITECT lane
+
+## Scope (what to audit)
+
+Branch `fix/iss-189-ws-watchdog` (worktree
+`/Users/augstar/macprovider-fix-189`). Diff scope is exactly:
+
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+- `phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift`
+
+Read the diff and the surrounding context. The issue body is at
+GitHub issue #189.
+
+## Context
+
+Issue #189 reports the Swift provider's WS connection wedging silently
+for ~42h, with no logs and no outbound TCP, while the process stays
+alive. The proposed fix has two complementary probes:
+
+1. **Bounded send (probe 3)**: wrap each heartbeat send in a 5s
+   throwable timeout; on throw, route through the existing
+   `closeWebSocketAfterKeepaliveFailure` → `runReconnectLoop` path.
+2. **Watchdog task (probe 2)**: a separate task observes a
+   `lastHeartbeatSuccessNanoseconds` timestamp; if no successful
+   heartbeat in `3 × intervalSeconds`, invoke a `watchdogExitHook`
+   that defaults to `Darwin.exit(1)` so launchd respawns the
+   process.
+
+The issue suggests probes 1, 2, OR 3 individually as acceptable. This
+PR implements 2 + 3 (not 1, the `MACPROVIDER_KEEPALIVE_DEBUG=1`
+investigation flow, which already exists).
+
+## You are the ARCHITECT auditor
+
+Score CRITICAL / HIGH / MEDIUM / LOW / NOTE. Bar is **zero
+C/H/M**.
+
+Focus on whether the design holds up over time, composes with other
+recovery mechanisms, and doesn't paper over a deeper root cause.
+
+Specifically check:
+
+1. **Root cause vs mitigation.** Probe 3 turns a wedged URLSession
+   send into a self-recovering condition. Probe 2 turns a starved
+   Task scheduler into a launchd-restart. Neither diagnoses why
+   App Nap is suspending the scheduler. Should we file a follow-up
+   to capture diagnostics (e.g. `os_log` markers + a process
+   activity assertion via `NSProcessInfo.beginActivity`) so we can
+   tell apart "App Nap" vs "URLSession queue-stall" in production?
+2. **Layering vs the external watchdog.** The issue body mentions
+   an external LaunchAgent watchdog (`ops/macprovider-watchdog/`)
+   already deployed. Does the in-process watchdog (probe 2)
+   compose well with that, or does it create a duplicate-restart
+   risk (in-process exits, then external watchdog also kickstarts)?
+3. **Tolerance choice.** 3 × intervalSeconds. Production heartbeat
+   interval is configured by the coordinator (typically 10s →
+   30s tolerance), with a coordinator-side
+   `provider_inactive_threshold` of 90s. Does the choice align?
+   What if a coordinator pushes a 60s interval — tolerance becomes
+   180s, larger than the inactivity drop. Is that fine because the
+   coordinator's drop already triggers reconnect, and the watchdog
+   is just last-resort?
+4. **5s send timeout choice.** Document the budget reasoning. Is
+   it on the side of "too aggressive" (false positives on a slow
+   transcontinental wifi reconnect) or "too lax" (slow to recover
+   from a wedge)? Is the value plausibly tunable later if needed?
+5. **Test coverage shape.** Three new tests:
+   - `testHeartbeatBoundedSendThrowsWhenSendHangs` — covers probe 3
+   - `testHeartbeatWatchdogFiresExitHookOnStaleness` — covers probe 2 fire path
+   - `testHeartbeatWatchdogDoesNotFireWhenSendsAreRecent` — covers probe 2 no-fire
+   Is there a meaningful integration-level test missing? E.g. the
+   probe-3 timeout firing → `closeWebSocketAfterKeepaliveFailure`
+   being called → `runReconnectLoop` retrying — currently each is
+   tested in isolation.
+6. **Interaction with `warm_swap_heartbeat`.** The warm-swap
+   completion path also calls `sendHeartbeat()` (line ~298) and is
+   NOT bounded. Is that intentional? Could a wedge in the warm-swap
+   completion path leave the swap state-machine stuck without the
+   probe-3 protection?
+7. **Public API churn.** Adding the `watchdogExitHook:` parameter
+   to `CoordinatorClient.init` is a default-value addition — does
+   it break any non-test caller? (Grep the codebase.)
+8. **Naming / readability.** Two pairs of timestamps
+   (`secondsSinceWindowReset`, `lastHeartbeatSuccessNanoseconds`)
+   plus a tolerance and a check interval all live in the same
+   function family. Is the cognitive load reasonable? Anything
+   obviously fixable by a rename?
+
+Out of scope: anything outside the two files in the diff. Do not
+propose unrelated improvements.
+
+## Output format
+
+Same as the CODE prompt — per-finding SEVERITY / Location / What /
+Why it matters / Suggested fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_ISS_189_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_189_R1_CODE_PROMPT.md
@@ -1,0 +1,110 @@
+# AUDIT — Fix iss-189 (heartbeat watchdog + bounded send) — R1 CODE lane
+
+## Scope (what to audit)
+
+Branch `fix/iss-189-ws-watchdog` (worktree
+`/Users/augstar/macprovider-fix-189`). Diff scope is exactly:
+
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+- `phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift`
+
+Read the diff (`git diff origin/main..HEAD`) and the surrounding
+context in those two files. Read `phase3-binary/Package.swift` only if
+you need to confirm Swift version / target. The issue body is at
+GitHub issue #189 (provider WS reconnect loop wedges silently).
+
+## Context
+
+The Swift provider's WebSocket to the coordinator can wedge silently:
+process up, no outbound TCP, no logs for ~42h. Two hypotheses:
+(a) macOS App Nap starves the heartbeat Task scheduler; (b) URLSession
+`send()` queues frames without surfacing TCP half-open.
+
+This PR adds two probes:
+1. **Bounded send**: every `sendHeartbeat()` call from the keepalive
+   loop is wrapped in `sendHeartbeatBounded(resetWindow:)` with a 5s
+   throwable timeout (`CoordinatorHeartbeatSendTimeout`). On throw,
+   the existing `closeWebSocketAfterKeepaliveFailure()` →
+   `runReconnectLoop` path fires.
+2. **Watchdog task**: a separate `heartbeatWatchdogTask` checks
+   `lastHeartbeatSuccessNanoseconds` every ~0.5 × intervalSeconds. If
+   the elapsed time exceeds 3 × intervalSeconds (`tolerance`), it
+   invokes `watchdogExitHook`, which defaults to writing a FATAL line
+   to stderr and calling `Darwin.exit(1)` so launchd respawns. The
+   hook is injectable for tests.
+
+Both helpers are torn down in `stop()`, `cleanupConnection()`, and
+`drainFromCoordinator(reason:)` alongside the heartbeat task.
+
+## You are the CODE auditor
+
+Score severities CRITICAL / HIGH / MEDIUM / LOW / NOTE. Bar is **zero
+CRITICAL, zero HIGH, zero MEDIUM** on diff-introduced surface. Focus
+only on the changes; do NOT propose drive-by refactors of unchanged
+code.
+
+Specifically check:
+
+1. **Cancellation correctness.** `withThrowingTaskGroup` race in
+   `sendHeartbeatBounded` — does `defer { group.cancelAll() }` plus
+   `try await group.next()` correctly cancel the loser? Could the
+   send task leak when the timeout wins (URLSession sends are not
+   freely cancellable)? Is the actor isolation around `webSocket?`
+   safe under cancellation?
+2. **Race conditions on `lastHeartbeatSuccessNanoseconds`.** The
+   writer (`recordHeartbeatSuccess`) runs on the actor; the reader
+   (`nanosecondsSinceLastHeartbeatSuccess`) runs on the actor; the
+   watchdog task hops into the actor on each check via `await`. Are
+   reads/writes correctly synchronized? Could a stale read happen
+   that fires the watchdog incorrectly during a busy actor?
+3. **Watchdog teardown.** Three teardown paths touch
+   `heartbeatWatchdogTask?.cancel()` + `= nil`: `stop()`,
+   `cleanupConnection()`, `drainFromCoordinator()`. Any path missed?
+   What about `startHeartbeat()` itself — it cancels the prior
+   watchdog before starting a new one; is that ordering right?
+4. **Tolerance / check-interval math.**
+   - `tolerance = max(1, intervalSeconds * 3) * 1e9` — when
+     `intervalSeconds <= 0`?
+   - `checkNanoseconds = max(1, intervalSeconds) * 0.5e9` — same.
+   - Could overflow occur with large intervalSeconds (e.g. operator
+     misconfig at INT_MAX)?
+   - Seeded `lastHeartbeatSuccessNanoseconds = DispatchTime.now()`
+     in startHeartbeat — does this race with the watchdog task's
+     first check?
+5. **Timeout boundary.** 5s timeout vs production heartbeat tick =
+   `keepaliveTickCeilingSeconds = 5`. Is the timeout long enough?
+   Could a slow but functional send (e.g. handshake) trigger a false
+   timeout? Is the timeout aligned with the coordinator's 90s
+   `provider_inactive_threshold`?
+6. **Exit hook contract.** Default hook writes to stderr then
+   `Darwin.exit(1)`. Are we leaking file descriptors / partial state
+   on exit? Is `Darwin.exit` correct here vs `exit(EXIT_FAILURE)`?
+   In tests, the hook is `@Sendable` and the test spawns a
+   `Task { await captured.set(reason) }` from inside the hook — is
+   that safe under structured concurrency?
+7. **Behavior preservation.** Was there any behavior of the
+   pre-existing heartbeat loop that is now different (frame
+   ordering, debug logging, error propagation)? In particular, the
+   existing `keepaliveDebug("keepalive_send_error error=...")` line
+   still fires on timeout — desired?
+8. **Test seam pollution.** Five new `*ForTest` methods were added
+   on the actor. Are they correctly marked (not `private`) but not
+   accidentally exposed to production callers?
+
+Out of scope: anything outside the two files in the diff. Do NOT
+propose changes to the broader reconnect loop or unrelated WS plumbing.
+
+## Output format
+
+For each finding:
+
+- **SEVERITY** (CRITICAL/HIGH/MEDIUM/LOW/NOTE)
+- **Location** (file:line)
+- **What** (one sentence)
+- **Why it matters** (one sentence)
+- **Suggested fix** (one or two lines)
+
+End with a single line:
+`SUMMARY: <C>/<H>/<M>/<L>/<N>`
+
+If you find nothing, say `SUMMARY: 0/0/0/0/0` and stop.

--- a/specs/AUDIT_FIX_ISS_189_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_189_R1_SECURITY_PROMPT.md
@@ -1,0 +1,81 @@
+# AUDIT — Fix iss-189 (heartbeat watchdog + bounded send) — R1 SECURITY lane
+
+## Scope (what to audit)
+
+Branch `fix/iss-189-ws-watchdog` (worktree
+`/Users/augstar/macprovider-fix-189`). Diff scope is exactly:
+
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+- `phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift`
+
+Read the diff (`git diff origin/main..HEAD`) and the surrounding
+context. The issue body is at GitHub issue #189.
+
+## Context
+
+Same as the CODE prompt: provider WS reconnect wedges silently for
+~42h; this PR adds a 5s bounded heartbeat send and a separate
+watchdog task that triggers `Darwin.exit(1)` (via injected
+`watchdogExitHook`) when no successful heartbeat has happened within
+`3 × intervalSeconds`.
+
+## You are the SECURITY auditor
+
+Score CRITICAL / HIGH / MEDIUM / LOW / NOTE. Bar is **zero
+C/H/M**.
+
+The provider is the money-path — receipts, attestations, signed
+state updates. A liveness mechanism that can be tricked into firing
+or into NOT firing is a security concern.
+
+Specifically check:
+
+1. **Forced-restart DoS.** Can a remote actor (or a compromised
+   coordinator) cause the provider to restart on demand by holding
+   the WS `send()` open or stalling the read loop? The watchdog
+   only observes successful heartbeat sends; if the coordinator can
+   delay our sends past `3 × intervalSeconds`, we restart. Is that
+   a meaningful new DoS lever vs the pre-existing one (coordinator
+   could already drop us via `provider_inactive_threshold`)?
+2. **Process-crash hidden state loss.** `Darwin.exit(1)` runs
+   without unwinding actors / closing files. Are any
+   security-sensitive flushes lost?
+   - In-flight receipts not yet committed
+   - Drain notifications not sent (coordinator thinks we're up)
+   - Sleep assertion (`caffeinate`) leaked
+   - In-flight receipt key rotation (rotateKey flow)
+   What's the worst case from a tier1/tier2 audit-trail standpoint?
+3. **Log-line injection / forgery.** The watchdog hook writes a
+   `FATAL ...` line to stderr including the elapsed time. Is the
+   reason string subject to any attacker-influenced content? (At
+   the moment it looks like only an integer-second value.)
+4. **Test-seam abuse in production.** Five `*ForTest` methods on
+   `CoordinatorClient` (sendHeartbeatBoundedForTest,
+   startHeartbeatWatchdogForTest, seedLastHeartbeatSuccessForTest,
+   cancelHeartbeatWatchdogForTest). Could a malicious caller in
+   the same process reach in and disable the watchdog?
+5. **`Darwin.exit` from an actor.** Exiting from inside a watchdog
+   `Task` skips any pending `drainAndExit` flows. Is there a
+   misuse / TOCTOU scenario where the watchdog races with a normal
+   SIGTERM-driven drain and the receipt-archive is corrupted?
+6. **5s send timeout fast-fail.** Can a network adversary cause the
+   provider to thrash reconnects (timeout → close → reconnect →
+   timeout → ...) by holding TCP RTT just above 5s? Compare to the
+   existing `runReconnectLoop` exponential backoff — is it
+   sufficient to absorb the storm?
+7. **Watchdog-during-drain.** During `drainFromCoordinator`, the
+   heartbeat is canceled before `sendDrainStatus(phase:"complete")`
+   is sent. Could the watchdog observe `last >= 3 * interval` ago
+   and fire `Darwin.exit(1)` mid-drain, dropping the
+   `drain_status` final frame? (Look at the explicit cancel order
+   in that function.)
+8. **No TLS / auth concerns introduced.** Confirm the changes do
+   NOT touch the auth path (token, attestation, ECDH) or the
+   `NoRedirectURLSessionDelegate` redirect-refusal logic.
+
+Out of scope: anything outside the two files in the diff.
+
+## Output format
+
+Same as the CODE prompt — per-finding SEVERITY / Location / What /
+Why it matters / Suggested fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_ISS_189_R2_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_189_R2_ARCHITECT_PROMPT.md
@@ -1,0 +1,62 @@
+# AUDIT — Fix iss-189 R2 ARCHITECT re-audit
+
+## Scope
+
+Same as R1: the two scoped Swift files. Read `git diff
+origin/main..HEAD`.
+
+## R1 findings now claimed FIXED
+
+R1 ARCHITECT summary was `0C/1H/1M/1L/1N`. Fixes applied:
+
+1. **R1 ARCHITECT HIGH (TaskGroup can't bound non-cooperative send)**
+   **FIX:** see R2 CODE prompt — timeout child force-cancels the
+   captured WS task, URLSession surfaces a transport error on the
+   send, group unwinds.
+
+2. **R1 ARCHITECT MEDIUM (warm-swap heartbeat not bounded)**
+   **FIX:** `consumeSwapSignals` `.completed` branch now calls
+   `sendHeartbeatBounded(resetWindow: true)` and routes errors
+   through `closeWebSocketAfterKeepaliveFailure()` for symmetry
+   with the keepalive tick path. Adds `recordHeartbeatSuccess()`
+   on the success path so this heartbeat also keeps the watchdog
+   quiet.
+
+3. **R1 ARCHITECT LOW (tolerance vs 90s drop)**
+   **FIX:** tolerance is now computed from `tickSeconds` (capped at
+   5s) instead of intervalSeconds. Tolerance is bounded at 15s
+   regardless of coordinator-supplied interval, always firing well
+   before the 90s coord drop.
+
+4. **R1 ARCHITECT NOTE (diagnostics follow-up)**
+   ACK — to be filed as a separate tracking issue (not in this PR).
+
+## Your job (R2)
+
+- Did bounding warm-swap break any guarantee of the warm-swap
+  protocol? The warm-swap state machine expects a final heartbeat
+  to publish the new model hash; if that heartbeat now times out,
+  we call `closeWebSocketAfterKeepaliveFailure` — is that the
+  right composition with warm-swap, or do we leave the
+  swap-completed state un-published until reconnect?
+- Tolerance-from-tickSeconds: with intervalSeconds=30 and
+  tickSeconds=5, tolerance becomes 15s. The watchdog check fires
+  every 2.5s. Worst-case detection time is 15s + ε. Is this
+  consistent with the broader recovery story (RTT-bounded
+  reconnect)?
+- Naming / cognitive load: `lastHeartbeatSuccessNanoseconds`,
+  `nanosecondsSinceLastHeartbeatSuccess`, `recordHeartbeatSuccess`,
+  plus the new inbound-bump call in `handle()`. Is the API
+  surface still readable, or has it crossed a threshold where
+  factoring into a small `HeartbeatLivenessClock` helper would
+  help future readers?
+- Composition with external LaunchAgent watchdog
+  (ops/macprovider-watchdog/): does the inbound-bump change
+  anything about duplicate-restart risk?
+
+Bar: **0 CRIT / 0 HIGH / 0 MEDIUM**.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_ISS_189_R2_CODE_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_189_R2_CODE_PROMPT.md
@@ -1,0 +1,60 @@
+# AUDIT — Fix iss-189 R2 CODE re-audit
+
+## Scope
+
+Same as R1: `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+and `phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift`.
+Read `git diff origin/main..HEAD` to see the current snapshot of fixes
+applied since R1.
+
+## R1 findings now claimed FIXED
+
+R1 CODE summary was `0C/1H/0M/2L/0N`. The fixes applied this round:
+
+1. **R1 CODE HIGH** — `sendHeartbeatBounded` TaskGroup could not unblock a
+   wedged `URLSession.send()`. **FIX:** the timeout child now captures
+   `socketRef = webSocket` BEFORE racing, and calls
+   `socketRef?.cancel(with: .goingAway, reason: nil)` to force the
+   in-flight send to error out before throwing the timeout. URLSession
+   surfaces a transport error on the orphaned send, the racing send
+   child unwinds, the TaskGroup returns. See lines around
+   `sendHeartbeatBounded` for the inline comment block explaining the
+   non-cooperative-cancellation reasoning.
+
+2. **R1 CODE LOW (overflow)** — tolerance math could overflow for
+   pathological `intervalSeconds`. **FIX:** tolerance now derives from
+   `tickSeconds = max(1, min(intervalSeconds, 5))`, which is bounded
+   by `keepaliveTickCeilingSeconds = 5`. The product
+   `tickSeconds * heartbeatWatchdogToleranceMultiplier` (= 3) is at
+   most 15s — well within UInt64 nanosecond range, no overflow path.
+
+3. **R1 CODE LOW (90s ordering)** — at intervalSeconds=30 the watchdog
+   tolerance equaled the coordinator's 90s drop threshold and used
+   `>` instead of `>=`. **FIX:** comparison is now `>=`, AND tolerance
+   is bounded at ≤15s as in (2), so the watchdog always fires before
+   coord drop.
+
+Additional fixes inspired by other lanes (cross-audit, no
+duplication needed in your re-audit but listed so you understand the
+total diff):
+- Warm-swap heartbeat callsite now uses `sendHeartbeatBounded` (R1
+  architect MEDIUM).
+- `handle(_:)` now bumps `recordHeartbeatSuccess()` on inbound (R1
+  security MEDIUM).
+- Watchdog canceled at drain ENTRY in `drainAndExit` and
+  `drainFromCoordinator` (R1 security LOW).
+
+## Your job (R2)
+
+Re-audit the **current** diff against these claims. Confirm each R1
+CODE finding is genuinely resolved. Surface any new code defects
+introduced by the fixes — Sendable correctness in the new
+`socketRef?.cancel(...)` capture, race between the `recordHeartbeatSuccess()`
+calls from the receive path vs the heartbeat tick path, etc.
+
+Bar is **0 CRIT / 0 HIGH / 0 MEDIUM** on R2 diff-introduced surface.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_ISS_189_R2_SECURITY_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_189_R2_SECURITY_PROMPT.md
@@ -1,0 +1,59 @@
+# AUDIT — Fix iss-189 R2 SECURITY re-audit
+
+## Scope
+
+Same as R1: the two scoped Swift files. Read `git diff
+origin/main..HEAD`.
+
+## R1 findings now claimed FIXED
+
+R1 SECURITY summary was `0/0/2/1/2`. Fixes applied:
+
+1. **R1 SECURITY MEDIUM #1 (watchdog only tracks local send success)**
+   **FIX:** `handle(_:)` now calls `recordHeartbeatSuccess()` on
+   EVERY received frame, before any further processing. Inbound
+   coordinator activity is the real liveness signal we want; if the
+   coord stops talking back, this no longer keeps the watchdog
+   quiet. Conversely, fresh inbound traffic keeps the watchdog
+   silent during normal operation. New test
+   `testHandleBumpsHeartbeatSuccessOnInboundActivity` exercises this
+   directly: a stale-seeded timestamp is reset to fresh after a
+   single handled frame.
+
+2. **R1 SECURITY MEDIUM #2 (TaskGroup can't bound uncooperative send)**
+   **FIX:** same as R1 CODE HIGH — the timeout child force-cancels
+   the captured `webSocket` reference before throwing. This makes
+   the send child unwind via URLSession's transport error path,
+   bounding the wrapper at 5s in production.
+
+3. **R1 SECURITY LOW (watchdog active during drain)**
+   **FIX:** both `drainAndExit` (SIGTERM handler) and
+   `drainFromCoordinator` (coordinator-requested drain) now cancel
+   `heartbeatWatchdogTask` at ENTRY, before any drain_status
+   sends. A watchdog firing mid-drain can no longer race with the
+   drain sequence.
+
+## Your job (R2)
+
+Re-audit for:
+
+- Does the inbound-bump in `handle(_:)` introduce a forgeability
+  risk? E.g. an attacker sending unauthenticated frames before
+  auth completes could keep the watchdog quiet. (Where in the
+  receive path is `handle` called? After hello/auth, or before?)
+- Does force-canceling the WS from the timeout child create a
+  cancellation cascade that interferes with an in-flight orderly
+  close (e.g. a `drain_status complete` send happening
+  simultaneously)?
+- The drain-entry cancellation: is the order correct? If a
+  watchdog had already fired Darwin.exit(1) BEFORE drain entry,
+  the cancel is moot — confirm there's no read-then-modify race.
+- Confirm no TLS / auth regression on the receive path now that
+  `recordHeartbeatSuccess` is the first thing done in `handle`.
+
+Bar: **0 CRIT / 0 HIGH / 0 MEDIUM**.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.


### PR DESCRIPTION
## Summary

Closes #189. Adds two complementary recovery probes to the Swift provider's WS keepalive loop so the silent ~42h wedge can no longer happen:

- **Probe 3 — bounded send.** Every keepalive heartbeat (including the warm-swap completion heartbeat) wraps `URLSessionWebSocketTask.send()` in a 5s throwable timeout. On timeout, the timeout child force-cancels the captured WS task so URLSession surfaces a transport error → existing `closeWebSocketAfterKeepaliveFailure` → `runReconnectLoop`.
- **Probe 2 — liveness watchdog.** A separate task observes `lastHeartbeatSuccessNanoseconds` (bumped on send-success AND on every inbound frame). If no liveness in `3 × tickSeconds` (≤15s, tickSeconds capped at 5s, independent of coord-supplied interval), it invokes `watchdogExitHook` → `Darwin.exit(1)` → launchd respawns.

## Audit

Three-lane codex audits, R1 + R2:

| Lane | R1 | R2 |
|---|---|---|
| Code | 0/1H/0/2L/0 | **0/0/0/0/0** ✅ |
| Security | 0/0/2M/1L/2N | **0/0/0/2L/2N** |
| Architect | 0/1H/1M/1L/1N | 0/0/1M/0/1N |

R2 architect MEDIUM is pre-existing v2 auth scope (auditor confirmed: "structural to v2 auth"), deferred to #203. R2 security LOWs are minor cancel-ordering edge cases addressed in the second-pass fixes (watchdog Task.isCancelled recheck after actor hop; heartbeatTask canceled at drain entry alongside the watchdog).

Audit prompt files committed under `specs/AUDIT_FIX_ISS_189_R{1,2}_*_PROMPT.md`.

## Test plan

- [x] `swift test --filter CoordinatorClientTests` → 54/54 pass locally (4 new tests)
  - `testHeartbeatBoundedSendThrowsWhenSendHangs` — 5s bound on a hanging send
  - `testHandleBumpsHeartbeatSuccessOnInboundActivity` — inbound frame resets liveness
  - `testHeartbeatWatchdogFiresExitHookOnStaleness` — stale → hook fires
  - `testHeartbeatWatchdogDoesNotFireWhenSendsAreRecent` — fresh → hook silent
- [x] CI green on the PR
- [ ] Operator-side validation: install on a long-running provider with `MACPROVIDER_KEEPALIVE_DEBUG=1`; observe `keepalive_send_error error=CoordinatorHeartbeatSendTimeout(...)` and `FATAL coordinator heartbeat watchdog: ...` lines if a wedge recurs

## Out of scope

- v2 `authInitialMessage` stale model metadata after warm-swap (filed as #203)
- App Nap vs URLSession queue-stall in-production discrimination diagnostics (R1 architect NOTE; follow-up if recurrence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
