### PR TITLE
test(explorer): TestAC13 wall-clock independence via explicit from/to

### DIFF
--- a/phase4-coordinator/internal/explorer/handlers_test.go
+++ b/phase4-coordinator/internal/explorer/handlers_test.go
@@ -300,8 +300,16 @@ func TestAC13_ConsumedAndVoidedSettlementsAreImmutable(t *testing.T) {
 	seedSettlement(t, db, "provider_consumed", "consumed", fixedExplorerTime().Add(-48*time.Hour), "settlement_consumed")
 	seedSettlement(t, db, "provider_voided", "voided", fixedExplorerTime().Add(-72*time.Hour), "settlement_voided")
 	before := tableCounts(t, db)
+	// parseWindow defaults `to` to time.Now().UTC(), so the
+	// default window drifts past the fixedExplorerTime() seeds as
+	// wall-clock advances (TestAC13 started failing once real-now
+	// crossed 30 days past 2026-06-01). Pass explicit from/to that
+	// bracket the seeded windowEnd values so the test is wall-
+	// clock-independent.
+	from := fixedExplorerTime().Add(-96 * time.Hour).Format(time.RFC3339)
+	to := fixedExplorerTime().Add(time.Hour).Format(time.RFC3339)
 	for _, status := range []string{"consumed", "voided"} {
-		resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/settlements?status="+status, "operator-key")
+		resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/settlements?status="+status+"&from="+from+"&to="+to, "operator-key")
 		if resp.Code != http.StatusOK {
 			t.Fatalf("%s status=%d body=%s", status, resp.Code, resp.Body.String())
 		}


### PR DESCRIPTION
## Summary

`TestAC13_ConsumedAndVoidedSettlementsAreImmutable` has been failing CI on every run since the real wall-clock crossed 30 days past 2026-06-01.

Root cause: the test seeds settlements at `fixedExplorerTime() - 48h` and `- 72h` (so 2026-05-30 and 2026-05-29), but `parseWindow` defaults `to = time.Now().UTC()` with a 720h (30-day) default window. The "voided" seed at 2026-05-29 fell outside `[now - 30d, now]` as soon as today's date crossed 2026-06-29.

Fix: pass explicit `from`/`to` query parameters bracketing the seeded `windowEnd` values. Decouples the test from real wall-clock.

## Test plan

- [x] Local: `go test ./internal/explorer/ -count=1` passes
- [x] Was failing on PR #205, and on plain `origin/main` checkout
- [ ] CI green on this PR
- [ ] Unblocks PR #205 (closes #190)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
