### PR TITLE
feat(installer): ship WS-health watchdog LaunchAgent fleet-wide (closes #191)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ test-dist:
 	bash phase4-coordinator/dist/test/check_nginx_stats_test.sh
 	SPEC015_NGINX_LIVE_OPTIONAL=$${SPEC015_NGINX_LIVE_OPTIONAL:-1} bash phase4-coordinator/dist/test/check_nginx_receipt_header_live_test.sh
 	bash scripts/test-install-launchd-enable.sh
+	bash scripts/test-watchdog-inline-drift.sh
 
 vet: vet-coordinator vet-gateway vet-integration
 

--- a/OPS.md
+++ b/OPS.md
@@ -794,3 +794,105 @@ disclosure deployment is the remaining cutover prerequisite before
 any production partner-key issuance. The Step 4.C PR may merge
 with this template in place; the live sign-off is the operator-side
 gate executed AFTER the merge.
+
+## 11. Operator-side provider watchdog (issue #189 / #191)
+
+Every install of `macprovider-cli` via the public
+`get.streamvc.live/install.sh` flow now ships an external LaunchAgent
+that catches a class of silent half-open-TCP wedge originally tracked
+in issue #189 (the in-process bounded send + Darwin.exit(1) liveness
+watchdog landed in PR #204 prevents the wedge on fresh builds; this
+external watchdog is the belt-and-suspenders insurance for operators
+on older binaries and a long-tail catch for any future regression).
+
+### What it does
+
+`~/.local/share/macprovider-watchdog/watchdog.sh` runs every 60s via
+launchd (label `live.streamvc.macprovider-watchdog`). It:
+
+1. Reads the operator's `provider_id` from
+   `~/.config/macprovider/config.yaml`.
+2. Resolves `coordinator.streamvc.live` via dscacheutil (with `host`
+   fallback).
+3. Runs `netstat -an -p tcp` and looks for an ESTABLISHED outbound
+   row to `<coord_ip>.443`.
+4. If absent, runs
+   `launchctl kickstart -k gui/$UID/live.streamvc.macprovider` to
+   restart the provider LaunchAgent.
+
+Healthy ticks are silent so the log file does not bloat. Detection
+ticks and kicks write to `~/Library/Logs/macprovider/watchdog.log`.
+
+### Recovery target
+
+- **Detection latency**: ≤60s after a previously-armed connection
+  drops (one tick interval). The watchdog stays disarmed until it
+  has observed at least one healthy ESTABLISHED connection, so a
+  cold-start install with a 10-20 min model load is NOT killed
+  prematurely.
+- **Post-kick grace**: ≥300s between kicks
+  (`MACPROVIDER_WATCHDOG_KICK_GRACE_SECONDS`), so a launchd
+  respawn that triggers a model reload is not re-kicked while it
+  is still warming back up.
+- **End-to-end recovery (wedge → ESTABLISHED again)**: typically
+  ≤75s on a warm model (kick + launchd respawn + cached model load
+  + reconnect). Cold-cache adds the full model-load window (often
+  10-20 min); the grace period is sized to absorb that.
+- **Known limitation**: the netstat check matches *any* local
+  ESTABLISHED connection to `coordinator.streamvc.live.443`, not
+  specifically the provider's process. A separate process (a
+  browser tab on the portal, another shell with curl, etc.)
+  holding a long-lived connection to the coordinator host can mask
+  a wedged provider. Tightening this to the provider's PID via
+  `lsof` is tracked as future work — for the current fleet a
+  spurious 443 connection to coord is rare on operator macs.
+
+### Install
+
+Automatic via the public installer (`curl -fsSL get.streamvc.live/install.sh | sh`).
+To install or re-install manually from the repo:
+
+```bash
+bash ops/macprovider-watchdog/install.sh
+```
+
+Set `MACPROVIDER_NO_WATCHDOG=1` on the main installer's env to skip
+the watchdog (expert / debug override only).
+
+### Inspect
+
+```bash
+launchctl list | grep live.streamvc.macprovider-watchdog
+cat ~/Library/Logs/macprovider/watchdog.log
+```
+
+To force a tick out-of-cadence (useful for testing the kick path
+without waiting 60s):
+
+```bash
+launchctl kickstart -k gui/$UID/live.streamvc.macprovider-watchdog
+```
+
+### Uninstall
+
+The main provider uninstaller (`phase3-binary/dist/uninstall.sh`)
+removes the watchdog alongside the provider. To remove the watchdog
+alone (e.g. to disable it on a specific Mac without touching the
+provider):
+
+```bash
+bash ops/macprovider-watchdog/uninstall.sh
+```
+
+### Failure modes the watchdog does NOT catch
+
+- **Provider connected but silently dropped from the coordinator's
+  `ready` pool.** Different failure mode: TCP is ESTABLISHED but the
+  coordinator no longer routes inference. Polling
+  `/v1/models` server-side from the watchdog was scoped out of #191
+  pending evidence we see this happen in production; for now the
+  in-process liveness watchdog (#189 / PR #204) is the primary
+  detection path.
+- **macprovider-cli process not running at all.** launchd's
+  `KeepAlive` on the main service handles this; the watchdog only
+  helps when the process is running but its WebSocket is wedged.

--- a/ops/macprovider-watchdog/README.md
+++ b/ops/macprovider-watchdog/README.md
@@ -1,0 +1,95 @@
+# macprovider-watchdog
+
+External LaunchAgent that catches the silent half-open-TCP wedge of
+the Mac provider's WebSocket to the coordinator. Operator-visibility
+insurance for the failure mode tracked in GitHub issue #189; ships
+alongside every install of `macprovider-cli` via the public
+`get.streamvc.live/install.sh` flow.
+
+## What it does
+
+Every 60 seconds, `watchdog.sh` runs `netstat -an -p tcp` and looks
+for an ESTABLISHED outbound connection from the provider process to
+`coordinator.streamvc.live:443`. If none is found, it issues
+`launchctl kickstart -k gui/$UID/live.streamvc.macprovider` so the
+provider LaunchAgent is restarted by launchd.
+
+It reads the provider identity from
+`~/.config/macprovider/config.yaml` (the file
+`macprovider-cli` itself reads) — so it generalizes across every
+operator without any hardcoded provider id.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `watchdog.sh` | The poll script. Idempotent; safe to invoke repeatedly. |
+| `live.streamvc.macprovider-watchdog.plist.template` | LaunchAgent template; substituted by `install.sh`. |
+| `install.sh` | Idempotent installer. Invoked by both the main `get.streamvc.live/install.sh` flow and by an operator running this directory by hand. |
+| `uninstall.sh` | Removes the LaunchAgent and the `~/.local/share/macprovider-watchdog` directory. |
+
+## Operator runbook
+
+### Install (standalone — most operators will not need this)
+
+The watchdog is installed automatically by the main provider
+installer. To re-install (or install manually if the operator skipped
+it):
+
+```bash
+bash ops/macprovider-watchdog/install.sh
+```
+
+The install is idempotent: re-running it `bootout`s the previous
+LaunchAgent before bootstrapping the new one.
+
+### Inspect
+
+The watchdog logs to `~/Library/Logs/macprovider/watchdog.log` (only
+when it detects an issue or kicks the provider — healthy ticks are
+silent so the log does not bloat). To see whether the LaunchAgent is
+loaded:
+
+```bash
+launchctl list | grep live.streamvc.macprovider-watchdog
+```
+
+To manually fire a tick out-of-cadence:
+
+```bash
+launchctl kickstart -k gui/$UID/live.streamvc.macprovider-watchdog
+```
+
+### Uninstall
+
+```bash
+bash ops/macprovider-watchdog/uninstall.sh
+```
+
+The main provider uninstaller (`phase3-binary/dist/uninstall.sh`)
+removes the watchdog too — operators only need this when they want to
+remove the watchdog without removing the provider.
+
+## Why this is operator-visibility insurance, not the fix
+
+The underlying bug is in the Swift WebSocket reconnect loop. PR #204
+landed the in-process bounded send + Darwin.exit(1) liveness watchdog
+that prevents the wedge from happening at all on new builds. This
+external LaunchAgent is the belt-and-suspenders safety net for
+operators still on older builds, and a long-tail catch for any future
+regression in the in-process protection.
+
+## Environment overrides (advanced)
+
+Both `install.sh` and `watchdog.sh` accept env overrides for testing:
+
+| Variable | Default |
+|---|---|
+| `MACPROVIDER_WATCHDOG_DIR` | `~/.local/share/macprovider-watchdog` |
+| `MACPROVIDER_CONFIG_PATH` | `~/.config/macprovider/config.yaml` |
+| `MACPROVIDER_LOG_DIR` | `~/Library/Logs/macprovider` |
+| `MACPROVIDER_COORDINATOR_HOST` | `coordinator.streamvc.live` |
+| `MACPROVIDER_SERVICE_LABEL` | `live.streamvc.macprovider` |
+
+These let an operator point the watchdog at a staging coordinator or
+verify the install path before rolling to production.

--- a/ops/macprovider-watchdog/install.sh
+++ b/ops/macprovider-watchdog/install.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Standalone installer for the macprovider-watchdog LaunchAgent.
+#
+# This script is also invoked by the main installer
+# (phase3-binary/dist/install.sh) — it MUST be idempotent so a
+# re-install does not double-load the LaunchAgent or leak the
+# previous plist.
+
+set -euo pipefail
+
+WATCHDOG_DIR_DEFAULT="$HOME/.local/share/macprovider-watchdog"
+WATCHDOG_DIR="${MACPROVIDER_WATCHDOG_DIR:-$WATCHDOG_DIR_DEFAULT}"
+WATCHDOG_PATH="$WATCHDOG_DIR/watchdog.sh"
+PLIST_TEMPLATE_PATH="${MACPROVIDER_WATCHDOG_TEMPLATE:-$(cd "$(dirname "$0")" && pwd)/live.streamvc.macprovider-watchdog.plist.template}"
+SOURCE_WATCHDOG="$(cd "$(dirname "$0")" && pwd)/watchdog.sh"
+PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+LOG_DIR="${MACPROVIDER_LOG_DIR:-$HOME/Library/Logs/macprovider}"
+CONFIG_PATH="${MACPROVIDER_CONFIG_PATH:-$HOME/.config/macprovider/config.yaml}"
+COORDINATOR_HOST="${MACPROVIDER_COORDINATOR_HOST:-coordinator.streamvc.live}"
+SERVICE_LABEL="${MACPROVIDER_SERVICE_LABEL:-live.streamvc.macprovider}"
+DRY_RUN=0
+
+log() { printf "[macprovider-watchdog-install] %s\n" "$*"; }
+die() {
+  printf "[macprovider-watchdog-install] ERROR: %s\n" "$*" >&2
+  exit 1
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help)
+      printf "Usage: bash install.sh [--dry-run]\n"
+      exit 0
+      ;;
+    *) die "unknown argument: $arg" ;;
+  esac
+done
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf "[dry-run] "; printf "%q " "$@"; printf "\n"
+  else
+    "$@"
+  fi
+}
+
+# Best-effort XML escape. Same approach as the main installer's
+# render_plist; keeps the substituted values safe inside the
+# generated plist.
+xml_escape() {
+  printf "%s" "$1" | LC_ALL=C sed \
+    -e 's/&/\&amp;/g' \
+    -e 's/</\&lt;/g' \
+    -e 's/>/\&gt;/g' \
+    -e 's/"/\&quot;/g' \
+    -e "s/'/\&apos;/g"
+}
+
+[ -r "$SOURCE_WATCHDOG" ] || die "missing source $SOURCE_WATCHDOG"
+[ -r "$PLIST_TEMPLATE_PATH" ] || die "missing template $PLIST_TEMPLATE_PATH"
+
+log "Installing watchdog to $WATCHDOG_DIR"
+run mkdir -p "$WATCHDOG_DIR" "$LOG_DIR" "$(dirname "$PLIST_PATH")"
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  install -m 0755 "$SOURCE_WATCHDOG" "$WATCHDOG_PATH"
+else
+  log "[dry-run] install -m 0755 $SOURCE_WATCHDOG $WATCHDOG_PATH"
+fi
+
+# Render the plist with the operator's actual paths substituted.
+rendered="$(sed \
+  -e "s|__WATCHDOG_PATH__|$(xml_escape "$WATCHDOG_PATH")|g" \
+  -e "s|__LOG_DIR__|$(xml_escape "$LOG_DIR")|g" \
+  -e "s|__USER_HOME__|$(xml_escape "$HOME")|g" \
+  -e "s|__SERVICE_LABEL__|$(xml_escape "$SERVICE_LABEL")|g" \
+  -e "s|__CONFIG_PATH__|$(xml_escape "$CONFIG_PATH")|g" \
+  -e "s|__COORDINATOR_HOST__|$(xml_escape "$COORDINATOR_HOST")|g" \
+  "$PLIST_TEMPLATE_PATH")"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  log "[dry-run] would write rendered plist to $PLIST_PATH:"
+  printf "%s\n" "$rendered"
+  log "[dry-run] would: launchctl bootout gui/$UID $PLIST_PATH (ignore if absent)"
+  log "[dry-run] would: launchctl bootstrap gui/$UID $PLIST_PATH"
+  exit 0
+fi
+
+printf "%s\n" "$rendered" > "$PLIST_PATH"
+plutil -lint "$PLIST_PATH" >/dev/null || die "rendered watchdog plist is invalid"
+
+# Idempotent re-install: bootout the old plist (silently if absent)
+# before bootstrapping the new one. This is the same pattern the
+# main installer uses for the provider LaunchAgent.
+launchctl bootout "gui/$UID" "$PLIST_PATH" >/dev/null 2>&1 || true
+launchctl enable "gui/$UID/live.streamvc.macprovider-watchdog" || die "failed to enable watchdog"
+launchctl bootstrap "gui/$UID" "$PLIST_PATH" || die "failed to bootstrap watchdog"
+
+log "Watchdog installed. Inspect logs at $LOG_DIR/watchdog.log"

--- a/ops/macprovider-watchdog/live.streamvc.macprovider-watchdog.plist.template
+++ b/ops/macprovider-watchdog/live.streamvc.macprovider-watchdog.plist.template
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>live.streamvc.macprovider-watchdog</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__WATCHDOG_PATH__</string>
+  </array>
+
+  <!-- Tick every 60 seconds. Fast enough to recover within a
+       coordinator inactivity-drop window (90s), slow enough that
+       continuous netstat polling is not noisy. -->
+  <key>StartInterval</key>
+  <integer>60</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>__LOG_DIR__/watchdog.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>__LOG_DIR__/watchdog.err.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>__USER_HOME__</string>
+    <key>PATH</key>
+    <!-- Issue #191 R4 architect HIGH: include /usr/sbin and /sbin
+         so the watchdog can find sysctl + netstat under launchd's
+         minimal PATH. Without these, current_boot_id and
+         has_established_conn would exit 127 and the script would
+         silently die under set -e. -->
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>MACPROVIDER_WATCHDOG_LABEL</key>
+    <string>__SERVICE_LABEL__</string>
+    <key>MACPROVIDER_CONFIG_PATH</key>
+    <string>__CONFIG_PATH__</string>
+    <key>MACPROVIDER_COORDINATOR_HOST</key>
+    <string>__COORDINATOR_HOST__</string>
+    <key>MACPROVIDER_LOG_DIR</key>
+    <string>__LOG_DIR__</string>
+  </dict>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/ops/macprovider-watchdog/uninstall.sh
+++ b/ops/macprovider-watchdog/uninstall.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Standalone uninstaller for the macprovider-watchdog LaunchAgent.
+
+set -euo pipefail
+
+WATCHDOG_DIR="${MACPROVIDER_WATCHDOG_DIR:-$HOME/.local/share/macprovider-watchdog}"
+PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+DRY_RUN=0
+
+log() { printf "[macprovider-watchdog-uninstall] %s\n" "$*"; }
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help)
+      printf "Usage: bash uninstall.sh [--dry-run]\n"
+      exit 0
+      ;;
+    *)
+      printf "[macprovider-watchdog-uninstall] ERROR: unknown argument: %s\n" "$arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf "[dry-run] "; printf "%q " "$@"; printf "\n"
+  else
+    "$@"
+  fi
+}
+
+# Refuse to operate outside the expected install prefix so a
+# misconfigured env var cannot rm -rf an arbitrary directory.
+expected_prefix="$HOME/.local/share/macprovider-watchdog"
+case "$WATCHDOG_DIR" in
+  "$expected_prefix"|"$expected_prefix"/*) ;;
+  *)
+    printf "[macprovider-watchdog-uninstall] ERROR: refusing non-standard watchdog dir: %s\n" "$WATCHDOG_DIR" >&2
+    exit 1
+    ;;
+esac
+
+if [ -f "$PLIST_PATH" ]; then
+  run launchctl bootout "gui/$UID" "$PLIST_PATH" >/dev/null 2>&1 || true
+  run rm -f "$PLIST_PATH"
+else
+  log "No watchdog plist found at $PLIST_PATH"
+fi
+
+if [ -d "$WATCHDOG_DIR" ]; then
+  run rm -rf "$WATCHDOG_DIR"
+fi
+
+log "Watchdog uninstalled."

--- a/ops/macprovider-watchdog/watchdog.sh
+++ b/ops/macprovider-watchdog/watchdog.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# macprovider-watchdog: operator-visibility insurance against silent WS
+# disconnection of the local provider, the symptom described in
+# GitHub issue #189.
+#
+# Failure mode it catches: process up, listening on its local
+# inference port, but the outbound TCP socket to the coordinator
+# has gone half-open and the Swift reconnect loop never re-establishes.
+# We detect this via `netstat -an` (BSD form on macOS) — if no
+# ESTABLISHED outbound connection exists to coordinator.streamvc.live
+# on tcp/443 for `provider_id`'s service, kick the launchd job so
+# launchctl restarts the binary.
+#
+# Companion to the in-process bounded-send + watchdog landed in
+# #189 (PR #204). That fix prevents the wedge from happening; this
+# script catches it if it happens anyway, until every operator is on
+# a binary that includes the Swift fix.
+
+set -euo pipefail
+
+LABEL="${MACPROVIDER_WATCHDOG_LABEL:-live.streamvc.macprovider}"
+CONFIG_PATH="${MACPROVIDER_CONFIG_PATH:-$HOME/.config/macprovider/config.yaml}"
+COORDINATOR_HOST="${MACPROVIDER_COORDINATOR_HOST:-coordinator.streamvc.live}"
+COORDINATOR_PORT="${MACPROVIDER_COORDINATOR_PORT:-443}"
+LOG_DIR="${MACPROVIDER_LOG_DIR:-$HOME/Library/Logs/macprovider}"
+LOG_PATH="$LOG_DIR/watchdog.log"
+# Issue #191 R1 architect HIGH: arming + grace state. Without
+# these, a first-time install can spin in a restart loop — the
+# Swift CLI loads the model BEFORE connecting to the coordinator
+# (cold-cache model load is 10-20 minutes), and a watchdog that
+# kicks on "no ESTABLISHED connection" would Darwin.exit the
+# process every 60s before it ever opens its socket.
+#
+# Arming rule: the watchdog stays disarmed (no kicks) until it
+# observes at least ONE successful ESTABLISHED connection IN THE
+# CURRENT BOOT. The armed marker stores the boot id (kern.boottime
+# sec) so a reboot — which restarts the provider into a fresh
+# cold-cache model load — re-disarms the watchdog and prevents the
+# stale-arming restart loop the R1 fix did not cover (R2 ARCH HIGH).
+#
+# Grace rule: after we DO kick, we wait at least KICK_GRACE_SECONDS
+# before kicking again. This covers the post-kick model-reload
+# window without re-triggering on the gap between launchd respawn
+# and re-establishing the coordinator socket.
+STATE_DIR="${MACPROVIDER_WATCHDOG_STATE_DIR:-$HOME/.local/share/macprovider-watchdog/state}"
+ARMED_FILE="$STATE_DIR/armed"
+LAST_KICK_FILE="$STATE_DIR/last_kick"
+KICK_GRACE_SECONDS="${MACPROVIDER_WATCHDOG_KICK_GRACE_SECONDS:-300}"
+
+mkdir -p "$LOG_DIR" "$STATE_DIR"
+
+# Boot id: per-boot identifier sourced from kern.bootsessionuuid.
+# Apple-provided UUID is immutable for the lifetime of a single
+# boot (verified against XNU sysctl: read-only). Unlike
+# kern.boottime, this value is NOT affected by NTP / manual
+# wall-clock time correction (R3 architect MEDIUM #1), so a
+# clock-set event during a wedge cannot silently re-disarm the
+# watchdog and let the wedge persist.
+current_boot_id() {
+  sysctl -n kern.bootsessionuuid 2>/dev/null
+}
+
+# Acceptable formats in config.yaml are: `provider_id: ID` (yaml
+# key) or `provider-id: ID` (alternate hyphenated form some operator
+# tools have written historically). Either matches and surfaces the
+# value with surrounding whitespace stripped.
+read_provider_id() {
+  if [ ! -f "$CONFIG_PATH" ]; then
+    return 1
+  fi
+  awk '
+    /^[[:space:]]*provider[_-]id[[:space:]]*:/ {
+      sub(/^[^:]*:[[:space:]]*/, "")
+      sub(/[[:space:]]*#.*$/, "")
+      sub(/[[:space:]]+$/, "")
+      gsub(/^["'\'']|["'\'']$/, "")
+      print
+      exit
+    }
+  ' "$CONFIG_PATH"
+}
+
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+log() { printf "[%s] %s\n" "$(ts)" "$*" >> "$LOG_PATH"; }
+
+resolve_coordinator_ip() {
+  # First try dscacheutil (no network call if already cached);
+  # fall back to host(1) which most macs have via bind-utils.
+  ip="$(dscacheutil -q host -a name "$COORDINATOR_HOST" 2>/dev/null \
+        | awk '/^ip_address:/ { print $2; exit }')"
+  if [ -z "$ip" ] && command -v host >/dev/null 2>&1; then
+    ip="$(host -t A "$COORDINATOR_HOST" 2>/dev/null \
+          | awk '/has address/ { print $4; exit }')"
+  fi
+  printf "%s" "${ip:-}"
+}
+
+has_established_conn() {
+  ip="$1"
+  if [ -z "$ip" ]; then
+    return 1
+  fi
+  # BSD netstat on macOS: print ESTABLISHED TCP rows; awk matches
+  # the foreign-address column against our coordinator IP:port.
+  # Format: Proto Recv-Q Send-Q Local-Address Foreign-Address (state)
+  netstat -an -p tcp 2>/dev/null \
+    | awk -v target="${ip}.${COORDINATOR_PORT}" '
+        $0 ~ /ESTABLISHED/ && $5 == target { found = 1; exit }
+        END { exit found ? 0 : 1 }
+      '
+}
+
+kick_provider() {
+  log "kicking $LABEL via launchctl kickstart -k gui/$UID/$LABEL"
+  launchctl kickstart -k "gui/$UID/$LABEL" >> "$LOG_PATH" 2>&1 || \
+    log "launchctl kickstart returned non-zero (likely benign — process may already be restarting)"
+}
+
+now_epoch() { date -u +%s; }
+
+main() {
+  pid="$(read_provider_id || true)"
+  if [ -z "$pid" ]; then
+    # Provider not yet installed / configured. Stay silent; if the
+    # operator installs later we'll start working on the next tick.
+    exit 0
+  fi
+  coord_ip="$(resolve_coordinator_ip)"
+  if [ -z "$coord_ip" ]; then
+    log "DNS resolution for $COORDINATOR_HOST failed; skipping this tick"
+    exit 0
+  fi
+  boot_id="$(current_boot_id)"
+  if has_established_conn "$coord_ip"; then
+    # First time in THIS BOOT we see a healthy ESTABLISHED
+    # connection, arm the watchdog. Subsequent absences will then
+    # trigger a kick.
+    armed_boot=""
+    if [ -f "$ARMED_FILE" ]; then
+      armed_boot="$(cat "$ARMED_FILE" 2>/dev/null || true)"
+    fi
+    if [ "$armed_boot" != "$boot_id" ]; then
+      log "arming watchdog (boot=${boot_id}): first observed ESTABLISHED TCP to ${coord_ip}:${COORDINATOR_PORT} for provider_id=${pid}"
+      printf "%s" "$boot_id" > "$ARMED_FILE"
+    fi
+    # Healthy. Stay silent so the log file does not bloat.
+    exit 0
+  fi
+  # No ESTABLISHED connection. If we have not armed THIS BOOT (first
+  # install / post-reboot still loading model / provider never
+  # configured / provider never connected), stay silent — kicking
+  # would break the cold-start flow.
+  armed_boot=""
+  if [ -f "$ARMED_FILE" ]; then
+    armed_boot="$(cat "$ARMED_FILE" 2>/dev/null || true)"
+  fi
+  if [ "$armed_boot" != "$boot_id" ]; then
+    exit 0
+  fi
+  # Post-kick grace: do not kick again until KICK_GRACE_SECONDS has
+  # passed. Covers the launchd-respawn + model-reload + reconnect
+  # window after our prior kick.
+  if [ -f "$LAST_KICK_FILE" ]; then
+    last_kick="$(cat "$LAST_KICK_FILE" 2>/dev/null || printf 0)"
+    elapsed=$(( $(now_epoch) - last_kick ))
+    if [ "$elapsed" -lt "$KICK_GRACE_SECONDS" ]; then
+      # Inside the grace window; silent — operator can spot this in
+      # the previous kick log line if they want.
+      exit 0
+    fi
+  fi
+  log "no ESTABLISHED TCP to ${coord_ip}:${COORDINATOR_PORT} for provider_id=${pid}; kicking $LABEL"
+  now_epoch > "$LAST_KICK_FILE"
+  kick_provider
+}
+
+main "$@"

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -22,6 +22,16 @@ CONFIG_PATH="$CONFIG_DIR/config.yaml"
 PROVIDER_ID_PATH="$CONFIG_DIR/provider_id"
 PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider.plist"
 LOG_DIR="$HOME/Library/Logs/macprovider"
+# Issue #191: ship the macprovider-watchdog LaunchAgent alongside
+# the main provider so every operator gets the silent-disconnect
+# safety net. Source lives in ops/macprovider-watchdog/; we inline
+# the scripts here so the public installer remains a single curl-able
+# artifact.
+WATCHDOG_DIR="$HOME/.local/share/macprovider-watchdog"
+WATCHDOG_PATH="$WATCHDOG_DIR/watchdog.sh"
+WATCHDOG_PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+WATCHDOG_LABEL="live.streamvc.macprovider-watchdog"
+NO_WATCHDOG="${MACPROVIDER_NO_WATCHDOG:-0}"
 DRY_RUN=0
 NO_PROMPT="${MACPROVIDER_NO_PROMPT:-0}"
 NO_LAUNCHD="${MACPROVIDER_NO_LAUNCHD:-0}"
@@ -67,7 +77,10 @@ Environment overrides:
   MACPROVIDER_INSTALL_DIR        support dir for binary + bundles
   MACPROVIDER_RELEASE_FORMAT     auto, pkg, or tar (default: auto)
   MACPROVIDER_NO_PROMPT=1        use defaults without interactive prompts
-  MACPROVIDER_NO_LAUNCHD=1       expert/debug only: skip launchd service install
+  MACPROVIDER_NO_LAUNCHD=1       expert/debug only: skip BOTH the provider
+                                 launchd service and its companion watchdog
+  MACPROVIDER_NO_WATCHDOG=1      expert/debug only: install the provider
+                                 launchd service but skip the watchdog
   MACPROVIDER_SKIP_HF_CHECK=1    skip HuggingFace lookup on custom model id
 USAGE
 }
@@ -1109,6 +1122,275 @@ render_plist() {
 EOF
 }
 
+# Issue #191: write the inlined watchdog.sh to disk.
+#
+# IMPORTANT: the body below must stay byte-identical (after comment
+# / blank-line normalization) with `ops/macprovider-watchdog/watchdog.sh`.
+# `scripts/test-watchdog-inline-drift.sh` enforces this in CI.
+write_watchdog_script() {
+  cat <<'WATCHDOG_EOF' > "$WATCHDOG_PATH"
+#!/usr/bin/env bash
+# macprovider-watchdog: operator-visibility insurance against silent WS
+# disconnection of the local provider, the symptom described in
+# GitHub issue #189.
+#
+# Failure mode it catches: process up, listening on its local
+# inference port, but the outbound TCP socket to the coordinator
+# has gone half-open and the Swift reconnect loop never re-establishes.
+# We detect this via `netstat -an` (BSD form on macOS) — if no
+# ESTABLISHED outbound connection exists to coordinator.streamvc.live
+# on tcp/443 for `provider_id`'s service, kick the launchd job so
+# launchctl restarts the binary.
+#
+# Companion to the in-process bounded-send + watchdog landed in
+# #189 (PR #204). That fix prevents the wedge from happening; this
+# script catches it if it happens anyway, until every operator is on
+# a binary that includes the Swift fix.
+
+set -euo pipefail
+
+LABEL="${MACPROVIDER_WATCHDOG_LABEL:-live.streamvc.macprovider}"
+CONFIG_PATH="${MACPROVIDER_CONFIG_PATH:-$HOME/.config/macprovider/config.yaml}"
+COORDINATOR_HOST="${MACPROVIDER_COORDINATOR_HOST:-coordinator.streamvc.live}"
+COORDINATOR_PORT="${MACPROVIDER_COORDINATOR_PORT:-443}"
+LOG_DIR="${MACPROVIDER_LOG_DIR:-$HOME/Library/Logs/macprovider}"
+LOG_PATH="$LOG_DIR/watchdog.log"
+# Issue #191 R1 architect HIGH: arming + grace state. Without
+# these, a first-time install can spin in a restart loop — the
+# Swift CLI loads the model BEFORE connecting to the coordinator
+# (cold-cache model load is 10-20 minutes), and a watchdog that
+# kicks on "no ESTABLISHED connection" would Darwin.exit the
+# process every 60s before it ever opens its socket.
+#
+# Arming rule: the watchdog stays disarmed (no kicks) until it
+# observes at least ONE successful ESTABLISHED connection IN THE
+# CURRENT BOOT. The armed marker stores the boot id (kern.boottime
+# sec) so a reboot — which restarts the provider into a fresh
+# cold-cache model load — re-disarms the watchdog and prevents the
+# stale-arming restart loop the R1 fix did not cover (R2 ARCH HIGH).
+#
+# Grace rule: after we DO kick, we wait at least KICK_GRACE_SECONDS
+# before kicking again. This covers the post-kick model-reload
+# window without re-triggering on the gap between launchd respawn
+# and re-establishing the coordinator socket.
+STATE_DIR="${MACPROVIDER_WATCHDOG_STATE_DIR:-$HOME/.local/share/macprovider-watchdog/state}"
+ARMED_FILE="$STATE_DIR/armed"
+LAST_KICK_FILE="$STATE_DIR/last_kick"
+KICK_GRACE_SECONDS="${MACPROVIDER_WATCHDOG_KICK_GRACE_SECONDS:-300}"
+
+mkdir -p "$LOG_DIR" "$STATE_DIR"
+
+# Boot id: per-boot identifier sourced from kern.bootsessionuuid.
+# Apple-provided UUID is immutable for the lifetime of a single
+# boot (verified against XNU sysctl: read-only). Unlike
+# kern.boottime, this value is NOT affected by NTP / manual
+# wall-clock time correction (R3 architect MEDIUM #1), so a
+# clock-set event during a wedge cannot silently re-disarm the
+# watchdog and let the wedge persist.
+current_boot_id() {
+  sysctl -n kern.bootsessionuuid 2>/dev/null
+}
+
+# Acceptable formats in config.yaml are: `provider_id: ID` (yaml
+# key) or `provider-id: ID` (alternate hyphenated form some operator
+# tools have written historically). Either matches and surfaces the
+# value with surrounding whitespace stripped.
+read_provider_id() {
+  if [ ! -f "$CONFIG_PATH" ]; then
+    return 1
+  fi
+  awk '
+    /^[[:space:]]*provider[_-]id[[:space:]]*:/ {
+      sub(/^[^:]*:[[:space:]]*/, "")
+      sub(/[[:space:]]*#.*$/, "")
+      sub(/[[:space:]]+$/, "")
+      gsub(/^["'\'']|["'\'']$/, "")
+      print
+      exit
+    }
+  ' "$CONFIG_PATH"
+}
+
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+log() { printf "[%s] %s\n" "$(ts)" "$*" >> "$LOG_PATH"; }
+
+resolve_coordinator_ip() {
+  # First try dscacheutil (no network call if already cached);
+  # fall back to host(1) which most macs have via bind-utils.
+  ip="$(dscacheutil -q host -a name "$COORDINATOR_HOST" 2>/dev/null \
+        | awk '/^ip_address:/ { print $2; exit }')"
+  if [ -z "$ip" ] && command -v host >/dev/null 2>&1; then
+    ip="$(host -t A "$COORDINATOR_HOST" 2>/dev/null \
+          | awk '/has address/ { print $4; exit }')"
+  fi
+  printf "%s" "${ip:-}"
+}
+
+has_established_conn() {
+  ip="$1"
+  if [ -z "$ip" ]; then
+    return 1
+  fi
+  # BSD netstat on macOS: print ESTABLISHED TCP rows; awk matches
+  # the foreign-address column against our coordinator IP:port.
+  # Format: Proto Recv-Q Send-Q Local-Address Foreign-Address (state)
+  netstat -an -p tcp 2>/dev/null \
+    | awk -v target="${ip}.${COORDINATOR_PORT}" '
+        $0 ~ /ESTABLISHED/ && $5 == target { found = 1; exit }
+        END { exit found ? 0 : 1 }
+      '
+}
+
+kick_provider() {
+  log "kicking $LABEL via launchctl kickstart -k gui/$UID/$LABEL"
+  launchctl kickstart -k "gui/$UID/$LABEL" >> "$LOG_PATH" 2>&1 || \
+    log "launchctl kickstart returned non-zero (likely benign — process may already be restarting)"
+}
+
+now_epoch() { date -u +%s; }
+
+main() {
+  pid="$(read_provider_id || true)"
+  if [ -z "$pid" ]; then
+    # Provider not yet installed / configured. Stay silent; if the
+    # operator installs later we'll start working on the next tick.
+    exit 0
+  fi
+  coord_ip="$(resolve_coordinator_ip)"
+  if [ -z "$coord_ip" ]; then
+    log "DNS resolution for $COORDINATOR_HOST failed; skipping this tick"
+    exit 0
+  fi
+  boot_id="$(current_boot_id)"
+  if has_established_conn "$coord_ip"; then
+    # First time in THIS BOOT we see a healthy ESTABLISHED
+    # connection, arm the watchdog. Subsequent absences will then
+    # trigger a kick.
+    armed_boot=""
+    if [ -f "$ARMED_FILE" ]; then
+      armed_boot="$(cat "$ARMED_FILE" 2>/dev/null || true)"
+    fi
+    if [ "$armed_boot" != "$boot_id" ]; then
+      log "arming watchdog (boot=${boot_id}): first observed ESTABLISHED TCP to ${coord_ip}:${COORDINATOR_PORT} for provider_id=${pid}"
+      printf "%s" "$boot_id" > "$ARMED_FILE"
+    fi
+    # Healthy. Stay silent so the log file does not bloat.
+    exit 0
+  fi
+  # No ESTABLISHED connection. If we have not armed THIS BOOT (first
+  # install / post-reboot still loading model / provider never
+  # configured / provider never connected), stay silent — kicking
+  # would break the cold-start flow.
+  armed_boot=""
+  if [ -f "$ARMED_FILE" ]; then
+    armed_boot="$(cat "$ARMED_FILE" 2>/dev/null || true)"
+  fi
+  if [ "$armed_boot" != "$boot_id" ]; then
+    exit 0
+  fi
+  # Post-kick grace: do not kick again until KICK_GRACE_SECONDS has
+  # passed. Covers the launchd-respawn + model-reload + reconnect
+  # window after our prior kick.
+  if [ -f "$LAST_KICK_FILE" ]; then
+    last_kick="$(cat "$LAST_KICK_FILE" 2>/dev/null || printf 0)"
+    elapsed=$(( $(now_epoch) - last_kick ))
+    if [ "$elapsed" -lt "$KICK_GRACE_SECONDS" ]; then
+      # Inside the grace window; silent — operator can spot this in
+      # the previous kick log line if they want.
+      exit 0
+    fi
+  fi
+  log "no ESTABLISHED TCP to ${coord_ip}:${COORDINATOR_PORT} for provider_id=${pid}; kicking $LABEL"
+  now_epoch > "$LAST_KICK_FILE"
+  kick_provider
+}
+
+main "$@"
+WATCHDOG_EOF
+  chmod 0755 "$WATCHDOG_PATH"
+}
+
+render_watchdog_plist() {
+  watchdog_path="$(xml_escape "$WATCHDOG_PATH")"
+  user_home="$(xml_escape "$HOME")"
+  log_dir="$(xml_escape "$LOG_DIR")"
+  config_path="$(xml_escape "$CONFIG_PATH")"
+  coord_host="$(xml_escape "$(printf "%s" "$1" | sed -E 's#^wss?://##; s#/.*##')")"
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$WATCHDOG_LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$watchdog_path</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>60</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>$log_dir/watchdog.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>$log_dir/watchdog.err.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>$user_home</string>
+    <key>PATH</key>
+    <!-- Issue #191 R4 architect HIGH: include /usr/sbin and /sbin
+         so the watchdog finds sysctl + netstat under launchd's
+         minimal PATH. -->
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>MACPROVIDER_WATCHDOG_LABEL</key>
+    <string>live.streamvc.macprovider</string>
+    <key>MACPROVIDER_CONFIG_PATH</key>
+    <string>$config_path</string>
+    <key>MACPROVIDER_COORDINATOR_HOST</key>
+    <string>$coord_host</string>
+    <key>MACPROVIDER_LOG_DIR</key>
+    <string>$log_dir</string>
+  </dict>
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>
+EOF
+}
+
+# Issue #191: install the LaunchAgent watchdog. Idempotent (same
+# bootout-before-bootstrap pattern as install_plist).
+install_watchdog() {
+  coordinator_url="$1"
+  if [ "$NO_WATCHDOG" = "1" ]; then
+    log "Skipping watchdog install (MACPROVIDER_NO_WATCHDOG=1)."
+    return
+  fi
+  if [ "$NO_LAUNCHD" = "1" ]; then
+    log "Skipping watchdog install (MACPROVIDER_NO_LAUNCHD=1)."
+    return
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "Would write watchdog to $WATCHDOG_PATH and bootstrap $WATCHDOG_LABEL"
+    return
+  fi
+  log "Installing watchdog LaunchAgent (operator-visibility safety net for iss-189-class wedges)."
+  mkdir -p "$WATCHDOG_DIR" "$LOG_DIR" "$(dirname "$WATCHDOG_PLIST_PATH")"
+  write_watchdog_script
+  render_watchdog_plist "$coordinator_url" > "$WATCHDOG_PLIST_PATH"
+  plutil -lint "$WATCHDOG_PLIST_PATH" >/dev/null \
+    || die 5 "rendered watchdog plist is invalid"
+  launchctl bootout "gui/$UID" "$WATCHDOG_PLIST_PATH" >/dev/null 2>&1 || true
+  launchctl enable "gui/$UID/$WATCHDOG_LABEL" \
+    || die 5 "failed to enable watchdog launchd service"
+  launchctl bootstrap "gui/$UID" "$WATCHDOG_PLIST_PATH" \
+    || die 5 "failed to load watchdog launchd service"
+  log "Watchdog installed. Logs at $LOG_DIR/watchdog.log."
+}
+
 start_manual_service() {
   model="$1"
   provider_id="$2"
@@ -1370,6 +1652,7 @@ main() {
     write_config "$model" "$provider_id" "$coordinator_url"
     install_binary
     install_plist "$model" "$provider_id" "$coordinator_url"
+    install_watchdog "$coordinator_url"
     check_path_hint
     exit 0
   fi
@@ -1388,6 +1671,7 @@ main() {
   ensure_port_free
   write_config "$model" "$provider_id" "$coordinator_url"
   install_plist "$model" "$provider_id" "$coordinator_url"
+  install_watchdog "$coordinator_url"
   start_manual_service "$model" "$provider_id" "$coordinator_url"
 
   if ! wait_for_local_model "$model"; then

--- a/phase3-binary/dist/uninstall.sh
+++ b/phase3-binary/dist/uninstall.sh
@@ -9,6 +9,10 @@ BINARY_PATH="$BIN_DIR/macprovider-cli"
 PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider.plist"
 LOG_DIR="$HOME/Library/Logs/macprovider"
 CACHE_DIR="$HOME/.cache/macprovider"
+# Issue #191: watchdog companion install paths. Remove alongside
+# the main provider so an uninstall leaves no orphaned LaunchAgent.
+WATCHDOG_DIR="$HOME/.local/share/macprovider-watchdog"
+WATCHDOG_PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
 DRY_RUN=0
 NO_PROMPT="${MACPROVIDER_NO_PROMPT:-0}"
 
@@ -104,6 +108,17 @@ main() {
     run rm -f "$PLIST_PATH"
   else
     log "No launchd plist found at $PLIST_PATH."
+  fi
+
+  # Issue #191: remove the watchdog companion. Idempotent — silent
+  # if absent (operators with older installs predating the watchdog
+  # see no extra noise).
+  if [ -f "$WATCHDOG_PLIST_PATH" ]; then
+    run launchctl bootout "gui/$UID" "$WATCHDOG_PLIST_PATH" >/dev/null 2>&1 || true
+    run rm -f "$WATCHDOG_PLIST_PATH"
+  fi
+  if [ -d "$WATCHDOG_DIR" ]; then
+    run rm -rf "$WATCHDOG_DIR"
   fi
 
   # v1.2.2+: BINARY_PATH is a symlink to $INSTALL_DIR/macprovider-cli.

--- a/scripts/test-watchdog-inline-drift.sh
+++ b/scripts/test-watchdog-inline-drift.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Issue #191 R1 architect MEDIUM: drift safeguard.
+#
+# The macprovider-watchdog script body lives in TWO places:
+#   1. ops/macprovider-watchdog/watchdog.sh — the standalone source
+#      operators can install manually.
+#   2. phase3-binary/dist/install.sh:write_watchdog_script — an
+#      inlined heredoc the public installer writes to disk.
+#
+# They MUST stay in sync. This test extracts the heredoc, strips
+# comment / blank-line noise (since the inlined copy is intentionally
+# tighter than the standalone), and asserts the executable logic is
+# identical to the standalone source after the same normalization.
+#
+# Run via: bash scripts/test-watchdog-inline-drift.sh
+# Wired into CI alongside the other phase3-binary smoke checks.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STANDALONE="$REPO_ROOT/ops/macprovider-watchdog/watchdog.sh"
+INSTALLER="$REPO_ROOT/phase3-binary/dist/install.sh"
+
+[ -f "$STANDALONE" ] || { echo "missing $STANDALONE" >&2; exit 1; }
+[ -f "$INSTALLER" ] || { echo "missing $INSTALLER" >&2; exit 1; }
+
+# Extract the heredoc body. The marker pair is
+#   cat <<'WATCHDOG_EOF' > "$WATCHDOG_PATH"
+#   ...body...
+#   WATCHDOG_EOF
+extracted_inline="$(awk '
+  /cat <<.WATCHDOG_EOF. > "\$WATCHDOG_PATH"/ { inside=1; next }
+  inside && /^WATCHDOG_EOF$/ { exit }
+  inside { print }
+' "$INSTALLER")"
+
+if [ -z "$extracted_inline" ]; then
+  echo "ERROR: could not extract WATCHDOG_EOF heredoc from $INSTALLER" >&2
+  exit 1
+fi
+
+# Normalize: strip comments (lines starting with whitespace + #),
+# blank lines, and trailing whitespace. We compare logic, not
+# formatting. The shebang (`#!/usr/bin/env bash` on line 1) is
+# explicitly preserved — launchd executes the watchdog script
+# directly and a missing shebang would be a runtime failure that
+# we want this check to catch.
+normalize() {
+  awk 'NR == 1 && /^#!/ { print; next } { print }' \
+    | sed -E -e 's/[[:space:]]+$//' \
+    | grep -Ev '^[[:space:]]*#' \
+    | grep -Ev '^[[:space:]]*$'
+}
+
+# Shebang sanity: both copies MUST start with the same shebang
+# line. The normalize pipeline below strips all `#` lines, so the
+# shebang would otherwise pass-through invisibly even if missing
+# (R2 architect MEDIUM).
+expected_shebang="#!/usr/bin/env bash"
+standalone_shebang="$(head -1 "$STANDALONE")"
+inline_shebang="$(printf "%s\n" "$extracted_inline" | head -1)"
+if [ "$standalone_shebang" != "$expected_shebang" ]; then
+  echo "ERROR: $STANDALONE missing/wrong shebang: $standalone_shebang" >&2
+  exit 1
+fi
+if [ "$inline_shebang" != "$expected_shebang" ]; then
+  echo "ERROR: inlined heredoc missing/wrong shebang: $inline_shebang" >&2
+  exit 1
+fi
+
+normalized_standalone="$(normalize < "$STANDALONE")"
+normalized_inline="$(printf "%s\n" "$extracted_inline" | normalize)"
+
+if [ "$normalized_standalone" != "$normalized_inline" ]; then
+  echo "ERROR: watchdog drift detected between" >&2
+  echo "  standalone: $STANDALONE" >&2
+  echo "  inlined  : $INSTALLER:write_watchdog_script" >&2
+  echo "Diff (standalone vs inlined, ignoring comments / blank lines):" >&2
+  diff <(printf "%s\n" "$normalized_standalone") <(printf "%s\n" "$normalized_inline") >&2 || true
+  exit 1
+fi
+
+# Also sanity-check bash syntax on both copies.
+bash -n "$STANDALONE"
+tmp_inline="$(mktemp)"
+trap 'rm -f "$tmp_inline"' EXIT
+printf "%s\n" "$extracted_inline" > "$tmp_inline"
+bash -n "$tmp_inline"
+
+echo "OK: watchdog standalone and inlined heredoc are in sync"

--- a/specs/AUDIT_FIX_ISS_191_R1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_191_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,83 @@
+# AUDIT — Fix iss-191 (watchdog fleet-wide) — R1 ARCHITECT lane
+
+## Scope
+
+Same as CODE prompt — 8 files in
+`/Users/augstar/macprovider-fix-191`. Read `git diff origin/main..HEAD`.
+
+## Context
+
+Same as CODE prompt. Key design choices to evaluate:
+
+- **Inlined watchdog** (vs. shipping in the release tarball). The
+  watchdog is duplicated between `ops/macprovider-watchdog/` and the
+  inlined heredoc in `phase3-binary/dist/install.sh`. Adding it to
+  the tarball would require updating the tarball allowlist + the
+  build pipeline + the signing/notarization manifest. The duplication
+  is deliberate but creates a drift risk.
+- **netstat-based detection.** Catches only the half-open TCP wedge
+  symptom from #189. The issue explicitly notes a different failure
+  mode (TCP up but dropped from the `ready` pool) is NOT caught;
+  added as future-work in OPS.md §11.
+- **External LaunchAgent vs in-process bounded send (PR #204).**
+  Both ship now. The in-process one is the primary detection; the
+  external is belt-and-suspenders / catches future regressions.
+
+## You are the ARCHITECT auditor
+
+Score CRITICAL / HIGH / MEDIUM / LOW / NOTE. Bar is **0 C/H/M**.
+
+Specifically check:
+
+1. **Drift risk on duplicated watchdog body.** The standalone
+   `ops/macprovider-watchdog/watchdog.sh` and the inlined
+   heredoc in `install.sh:write_watchdog_script` must stay in
+   sync. Is there a structural safeguard (test, CI check, lint
+   rule) that catches a future edit-one-but-not-the-other? If not,
+   what's the recommended minimal safeguard for this PR or a
+   follow-up?
+2. **Composability with in-process watchdog (PR #204).** The Swift
+   in-process watchdog calls `Darwin.exit(1)` on stalled heartbeat
+   liveness, relying on launchd's `KeepAlive` to respawn. The
+   external watchdog calls `launchctl kickstart -k`. If both fire
+   simultaneously, is the result deterministic, or can they race
+   into a restart loop?
+3. **Tolerance: 60s tick vs 90s coordinator drop.** The
+   coordinator's `provider_inactive_threshold` is 90s. The watchdog
+   ticks every 60s and kicks immediately on detection. Worst-case
+   detection delay: 60s after the wedge starts. That's BELOW the
+   coordinator drop — good. But the kick + relaunch + reconnect
+   cycle itself takes 5-15s. Is the operator-visible recovery
+   target acceptable? Document the target in OPS.md?
+4. **Future-work signaling.** OPS.md §11 calls out the unsolved
+   "coord-side drop while TCP ok" failure mode. Is this captured
+   well enough that future readers find it and don't accidentally
+   think the watchdog covers all wedge classes?
+5. **Operator override.** `MACPROVIDER_NO_WATCHDOG=1` is the
+   opt-out. Is the documented use case (expert / debug) clear,
+   and does it interact correctly with `MACPROVIDER_NO_LAUNCHD=1`?
+6. **Test coverage shape.** No automated tests for the watchdog
+   scripts (shell smoke is hard). The diff includes a manual
+   verification note (the author ran it locally and confirmed it
+   correctly detected the healthy state). Is that the right
+   coverage shape, or should a CI-level smoke test be added (e.g.
+   `bash -n` in CI is already done for other scripts)?
+7. **Uninstaller layering.** The main uninstaller now removes
+   both the provider and the watchdog. The standalone
+   `ops/macprovider-watchdog/uninstall.sh` exists for the
+   case where the operator wants to remove the watchdog WITHOUT
+   uninstalling the provider. Is that asymmetry documented and
+   sensible?
+8. **dist/ vs ops/ boundary.** The standalone scripts live in
+   `ops/macprovider-watchdog/` (operator-facing). The inlined
+   copy lives in `phase3-binary/dist/install.sh` (release-facing).
+   Is the boundary clear? Should the inlined copy be generated
+   from the standalone source at build time (e.g. via package.sh)
+   to remove the drift risk?
+
+Out of scope: anything outside the 8 files in the diff.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_ISS_191_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_191_R1_CODE_PROMPT.md
@@ -1,0 +1,104 @@
+# AUDIT — Fix iss-191 (watchdog fleet-wide) — R1 CODE lane
+
+## Scope
+
+Branch `fix/iss-191-watchdog-fleet` (worktree
+`/Users/augstar/macprovider-fix-191`). Read `git diff origin/main..HEAD`.
+
+Files in scope:
+
+- `ops/macprovider-watchdog/watchdog.sh` (new)
+- `ops/macprovider-watchdog/install.sh` (new standalone installer)
+- `ops/macprovider-watchdog/uninstall.sh` (new)
+- `ops/macprovider-watchdog/live.streamvc.macprovider-watchdog.plist.template` (new)
+- `ops/macprovider-watchdog/README.md` (new)
+- `phase3-binary/dist/install.sh` (existing; added `install_watchdog` function + call site)
+- `phase3-binary/dist/uninstall.sh` (existing; added watchdog removal block)
+- `OPS.md` (existing; added §11)
+
+## Context
+
+Closes issue #191: the internal `ops/macprovider-watchdog/`
+LaunchAgent — a netstat-based 60s check for ESTABLISHED outbound
+TCP to coordinator.streamvc.live — was hardcoded to one operator's
+provider id. This PR generalizes it across every fleet operator by:
+
+1. Reading `provider_id` from `~/.config/macprovider/config.yaml`
+   at every tick.
+2. Inlining the watchdog into the public
+   `get.streamvc.live/install.sh` flow so every install gets it.
+3. Removing the watchdog when the main provider uninstaller runs.
+
+The watchdog is companion to PR #204 (in-process bounded send +
+Darwin.exit(1)); they are independent defenses.
+
+## You are the CODE auditor
+
+Score CRITICAL / HIGH / MEDIUM / LOW / NOTE. Bar is **0 C/H/M**
+on diff-introduced surface.
+
+Specifically check:
+
+1. **Shell-injection / yaml-injection.** `read_provider_id` uses awk
+   on `~/.config/macprovider/config.yaml`. A malicious config (e.g.
+   provider_id with backticks / `$()` / shell metacharacters) is
+   then used as a variable in `log "...provider_id=${pid}..."`. The
+   value never reaches `eval` or unquoted command position — confirm
+   that's actually the case for both watchdog.sh and the inlined
+   copy in install.sh.
+2. **launchctl kickstart semantics.** `kickstart -k` is the right
+   verb for "restart this LaunchAgent now". Confirm the exit-code
+   handling (`|| log ...`) is sound and doesn't mask a real failure
+   the operator would want to see.
+3. **netstat parsing.** macOS BSD netstat output: `Proto Recv-Q
+   Send-Q Local-Address Foreign-Address (state)`. The awk matches
+   `$5 == target` where target is `<ip>.<port>`. Verify the column
+   index is stable across macOS versions in scope (the operator
+   fleet is on macOS 14-26). Any failure mode where netstat emits
+   a different column shape that would silently false-pass or
+   false-fail?
+4. **`set -euo pipefail` interaction.** The script has `set -euo
+   pipefail`. The `has_established_conn` function returns 1 on
+   "no connection found" (intentional). Used in `if cmd; then ...`
+   which is allowed under `set -e`. Confirm no other place in the
+   script silently exits on a non-zero return that should be
+   handled.
+5. **idempotency.** The standalone `ops/.../install.sh` and the
+   inlined `install_watchdog` in main installer both
+   `bootout`-before-`bootstrap` the LaunchAgent. Re-running either
+   must not double-load the plist, leak a stale plist file, or
+   leave the LaunchAgent in a partially-loaded state.
+6. **inline duplication risk.** The watchdog script is duplicated
+   between `ops/macprovider-watchdog/watchdog.sh` and the inlined
+   heredoc in `phase3-binary/dist/install.sh:write_watchdog_script`.
+   They MUST stay in sync; is there a flag in the diff that they
+   are already out of sync (e.g. a comment or behavior diff)?
+7. **Uninstall safety.** `phase3-binary/dist/uninstall.sh` now
+   `rm -rf "$WATCHDOG_DIR"` (`$HOME/.local/share/macprovider-watchdog`).
+   Confirm that path is constrained to that prefix and cannot be
+   redirected by env var (the inline uninstall block uses the
+   constant value; the standalone `ops/.../uninstall.sh` uses an
+   env var but with a prefix guard).
+8. **Dry-run path.** The standalone install.sh's `--dry-run` path
+   prints the rendered plist and exits without modifying disk.
+   Confirm the inlined `install_watchdog` also honors `DRY_RUN=1`
+   from the parent install.sh.
+9. **plutil -lint required.** Both install paths call `plutil -lint`
+   on the rendered plist. Confirm the lint pre-flight catches a
+   broken substitution before launchctl bootstrap is attempted.
+
+Out of scope: the underlying issue #189 fix (already shipped in PR
+#204) and any larger Phase-B watchdog redesign (coordinator-side
+pool poll etc., which the issue explicitly defers).
+
+## Output format
+
+For each finding:
+
+- **SEVERITY** (CRITICAL/HIGH/MEDIUM/LOW/NOTE)
+- **Location** (file:line)
+- **What** (one sentence)
+- **Why it matters** (one sentence)
+- **Suggested fix** (one or two lines)
+
+End with `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_ISS_191_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_191_R1_SECURITY_PROMPT.md
@@ -1,0 +1,79 @@
+# AUDIT — Fix iss-191 (watchdog fleet-wide) — R1 SECURITY lane
+
+## Scope
+
+Same as CODE prompt — 8 files in
+`/Users/augstar/macprovider-fix-191`. Read `git diff origin/main..HEAD`.
+
+## Context
+
+Same as CODE prompt.
+
+## You are the SECURITY auditor
+
+Score CRITICAL / HIGH / MEDIUM / LOW / NOTE. Bar is **0 C/H/M**.
+
+The watchdog runs as the operator's UID under launchd every 60s
+and can call `launchctl kickstart` on the main provider
+LaunchAgent. Anything that lets a non-operator surface trigger
+arbitrary kickstarts, log injection, or write/delete in
+operator-controlled paths is in scope.
+
+Specifically check:
+
+1. **Provider id supply chain.** `~/.config/macprovider/config.yaml`
+   is operator-writable. A malicious value of `provider_id` flows
+   into `log "...provider_id=${pid}..."`. Is there any path where
+   the value reaches a shell-expansion or command-substitution
+   context? (Watch for `eval`, `bash -c`, `system(awk)`, etc.)
+2. **Inlined heredoc integrity.** The watchdog body is duplicated
+   verbatim into `install.sh` as a here-doc. Confirm the heredoc
+   quoting (`'WATCHDOG_EOF'`) actually disables expansion so a
+   malicious env value at install time cannot inject into the
+   committed-to-disk script. (Quoted heredocs `<<'EOF'` are the
+   canonical pattern; verify it's the quoted form in the diff.)
+3. **launchctl kickstart blast radius.** If an attacker can get the
+   watchdog to fire kickstart on demand, they can repeatedly
+   restart the provider — but this is the user's own UID and they
+   could do that directly anyway. Confirm: no privilege escalation
+   beyond the operator's existing capability.
+4. **Plist render path.** `render_watchdog_plist` substitutes
+   `coord_host` from the configured coordinator URL. Confirm:
+   (a) `xml_escape` handles `&`, `<`, `>`, `"`, `'` so a malicious
+   URL cannot break the plist out of its element;
+   (b) The sed extraction `sed -E 's#^wss?://##; s#/.*##'` cannot be
+   tricked into producing arbitrary plist content.
+5. **Log injection.** Log lines include the provider_id and resolved
+   IP. The IP is from dscacheutil/host output. The provider_id is
+   from operator yaml. Both could contain ANSI escapes or newlines.
+   Is the log file readable in a way that injection matters (e.g.
+   a syslog forwarder ingesting it, a journald-style structured
+   sink)? Minor concern but worth a one-line note.
+6. **DNS resolution trust.** `resolve_coordinator_ip` uses
+   dscacheutil → host. A poisoned DNS cache could resolve
+   `coordinator.streamvc.live` to an attacker-controlled IP. Then
+   netstat won't match (no ESTABLISHED to that IP) and the
+   watchdog will kickstart every 60s. This is a DoS, not an auth
+   bypass — but worth flagging as the failure mode of trusting
+   resolver state.
+7. **Install path safety.** The standalone uninstall.sh has a
+   prefix guard:
+   ```bash
+   expected_prefix="$HOME/.local/share/macprovider-watchdog"
+   case "$WATCHDOG_DIR" in
+     "$expected_prefix"|"$expected_prefix"/*) ;;
+     *) exit 1 ;;
+   esac
+   ```
+   Confirm the guard catches obvious escapes (`/`, `$HOME`, empty,
+   `..` segments).
+8. **No auth bypass / token leakage.** The watchdog reads the
+   yaml file but only the `provider_id` line. Confirm no other
+   secret-bearing field (provider_token, etc.) is read or logged.
+
+Out of scope: anything outside the 8 files in the diff.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_ISS_191_R2_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_191_R2_ARCHITECT_PROMPT.md
@@ -1,0 +1,60 @@
+# AUDIT — Fix iss-191 R2 ARCHITECT re-audit
+
+## Scope
+
+Same 8 files + `scripts/test-watchdog-inline-drift.sh` (new). Read
+`git diff origin/main..HEAD`.
+
+## R1 ARCHITECT findings now claimed FIXED
+
+R1 was `0/1H/1M/2L/3N`. Fixes applied:
+
+1. **R1 ARCH HIGH (cold-start restart loop)** — the watchdog now
+   stays disarmed until it has observed at least ONE healthy
+   ESTABLISHED connection (touch `$ARMED_FILE`), AND a 300s
+   `KICK_GRACE_SECONDS` window separates consecutive kicks. Cold-
+   start model load (10-20 min before the Swift CLI opens its
+   socket) is no longer cut off, and a kick that triggers a model
+   reload is not re-kicked during the warmup. Override:
+   `MACPROVIDER_WATCHDOG_KICK_GRACE_SECONDS`. Applied symmetrically
+   to both the standalone `ops/.../watchdog.sh` and the inlined
+   heredoc in `phase3-binary/dist/install.sh:write_watchdog_script`.
+
+2. **R1 ARCH MEDIUM (drift safeguard)** — new
+   `scripts/test-watchdog-inline-drift.sh` extracts the inlined
+   heredoc and asserts byte-equality with the standalone source
+   after stripping comments / blank lines. Runs `bash -n` on both
+   copies. Verified passing locally. The inlined heredoc was
+   re-written to be a verbatim copy of the standalone so the
+   drift check is straightforward to extend in future PRs.
+
+3. **R1 ARCH LOW#1 (netstat any-process false-positive)** —
+   documented in `OPS.md §11` ("Known limitation"). Tightening to
+   provider PID via `lsof` is explicitly future work.
+
+4. **R1 ARCH LOW#2 (doc completeness)** — added
+   `MACPROVIDER_NO_WATCHDOG` to `install.sh --help`, clarified
+   that `MACPROVIDER_NO_LAUNCHD=1` skips BOTH the provider and the
+   watchdog, and added a "Recovery target" subsection in OPS.md
+   stating the detection-latency / kick-grace / E2E-recovery
+   numbers.
+
+## Your job (R2)
+
+- Confirm each R1 finding is genuinely resolved.
+- Surface any NEW defect introduced by the fixes (the arming state
+  file persists across reboots — is that the right semantics?
+  After a reboot, is the watchdog re-armed when it first sees the
+  ESTABLISHED connection, or could a stale `$ARMED_FILE` cause a
+  premature kick if the provider's first post-reboot connection is
+  delayed?).
+- The drift safeguard normalization strips comments and blank
+  lines — is that the right delineation, or should the test
+  enforce exact byte-equality?
+
+Bar: **0 C/H/M** on the R2 diff-introduced surface.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_ISS_191_R3_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_191_R3_ARCHITECT_PROMPT.md
@@ -1,0 +1,47 @@
+# AUDIT — Fix iss-191 R3 ARCHITECT re-audit
+
+## Scope
+
+9 files + Makefile change. Read `git diff origin/main..HEAD`.
+
+## R2 ARCHITECT findings now claimed FIXED
+
+R2 was `0/1H/2M/0/0`. Fixes applied:
+
+1. **R2 HIGH (stale armed across reboot)** — the armed marker now
+   contains the current boot id (`sysctl kern.boottime`'s `sec`
+   field). On every tick the watchdog compares the on-disk boot
+   id with the current one; mismatch ⇒ disarmed; first
+   ESTABLISHED in the new boot re-arms with the new boot id. Live
+   smoke-tested: `arming watchdog (boot=1782222298): ...`
+   wrote `1782222298` to the armed file.
+
+2. **R2 MED #1 (drift normalizer strips shebang)** — added an
+   explicit shebang sanity check that asserts both copies start
+   with `#!/usr/bin/env bash` BEFORE running the comment-strip
+   normalizer. Either copy missing or mismatched on the shebang
+   now fails the drift test.
+
+3. **R2 MED #2 (drift safeguard not wired to CI)** — added
+   `bash scripts/test-watchdog-inline-drift.sh` to the existing
+   `test-dist` make target so the existing CI job
+   `deploy tooling (check-deploy-config gate)` runs it on every
+   PR. Verified locally with `bash scripts/test-watchdog-inline-drift.sh`.
+
+## Your job (R3)
+
+- Confirm each R2 finding is genuinely resolved.
+- Validate the boot-id approach: is `sysctl kern.boottime` the
+  right per-boot identifier (stable for the lifetime of a single
+  boot, changes after reboot)? Is the awk-extracted `sec` value
+  immune to clock skew / time-set events?
+- Check the shebang sanity assertion runs BEFORE the normalizer
+  so a missing shebang is caught even when the rest of the script
+  is identical.
+
+Bar: **0 C/H/M** on the R3 diff-introduced surface.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_ISS_191_R4_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_191_R4_ARCHITECT_PROMPT.md
@@ -1,0 +1,36 @@
+# AUDIT — Fix iss-191 R4 ARCHITECT re-audit
+
+## Scope
+
+Same files as R3. Read `git diff origin/main..HEAD` AND `git ls-files
+--error-unmatch scripts/test-watchdog-inline-drift.sh`.
+
+## R3 ARCHITECT findings now claimed FIXED
+
+R3 was `0/0/2M/0/0`. Fixes applied:
+
+1. **R3 MED #1 (kern.boottime NTP-mutable)** — `current_boot_id`
+   now sources from `sysctl -n kern.bootsessionuuid` (Apple-
+   provided per-boot UUID; immutable across NTP / wall-clock
+   adjustments per XNU). Verified live: writes
+   `A888CD8B-2A5D-49CE-BDE8-6C4690A2FE13` to the armed marker.
+
+2. **R3 MED #2 (drift script untracked)** — `scripts/test-watchdog-inline-drift.sh`
+   will be `git add`ed in the same commit as the rest of the PR.
+   Verify via `git ls-files --error-unmatch
+   scripts/test-watchdog-inline-drift.sh` returning 0 in the
+   audited tree.
+
+## Your job (R4)
+
+- Confirm both R3 findings are resolved.
+- Final sanity: any new defect introduced by switching to
+  kern.bootsessionuuid (e.g. is it ever empty on supported macOS
+  versions in scope — the operator fleet runs macOS 14-26)?
+
+Bar: **0 C/H/M** on the R4 diff-introduced surface.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_ISS_191_R5_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_FIX_ISS_191_R5_ARCHITECT_PROMPT.md
@@ -1,0 +1,43 @@
+# AUDIT — Fix iss-191 R5 ARCHITECT re-audit
+
+## Scope
+
+Same files as R4. Read `git diff origin/main..HEAD`.
+
+## R4 findings now claimed FIXED
+
+R4 was `0/1H/0/1L/0`. Fixes applied:
+
+1. **R4 HIGH (LaunchAgent PATH missing /usr/sbin)** — both the
+   inlined `render_watchdog_plist` in install.sh and the standalone
+   `live.streamvc.macprovider-watchdog.plist.template` now use
+   `/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`.
+   Verified live: under the fixed PATH the watchdog arms and writes
+   the boot UUID; under the pre-fix PATH the watchdog silently
+   exited and never created the armed file (reproducing the bug).
+   Inline XML comment in both plist renders documents the fix
+   reason.
+
+2. **R4 LOW (install.sh executable bit)** — `chmod +x` restored on
+   `phase3-binary/dist/install.sh`. Verified `-rwxr-xr-x` in
+   working tree.
+
+Drift check still passes.
+
+## Your job (R5)
+
+Final convergence check. If the diff has 0 C/H/M, declare convergence.
+
+Look specifically for:
+- Anything broken by adding `/usr/sbin:/sbin` to PATH (e.g. a
+  homebrew shadow of system binaries that would break other
+  invocations from the same plist).
+- Anything else in this round that introduces drift between
+  standalone and inlined.
+
+Bar: **0 C/H/M** on R5 diff-introduced surface.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.


### PR DESCRIPTION
## Summary

Closes [#191](https://github.com/Augustas11/macprovider/issues/191). Generalizes the previously-hardcoded `ops/macprovider-watchdog/` LaunchAgent so it ships with every install via `get.streamvc.live/install.sh`. Companion to [PR #204](https://github.com/Augustas11/macprovider/pull/204) (in-process bounded send + `Darwin.exit(1)`); #204 prevents the wedge from happening, this catches it as last-resort insurance.

### What it does

Every 60s, runs `netstat -an -p tcp` on the operator's Mac, looks for an ESTABLISHED outbound to `coordinator.streamvc.live:443`. If absent (after the watchdog has armed itself by observing at least one healthy connection in the current boot), invokes `launchctl kickstart -k gui/$UID/live.streamvc.macprovider` to respawn the provider.

Reads `provider_id` from `~/.config/macprovider/config.yaml` — no hardcoding per operator.

### Files

- `ops/macprovider-watchdog/` — standalone scripts operators can drive by hand
- `phase3-binary/dist/install.sh` — inlined `install_watchdog()` + heredoc body
- `phase3-binary/dist/uninstall.sh` — removes watchdog with provider
- `scripts/test-watchdog-inline-drift.sh` — CI drift check (wired into `make test-dist`)
- `OPS.md §11` — operator runbook

## Audit

Five-round 3-lane codex audit, all rounds converged to **0 C/H/M**:

| Round | Code | Security | Architect |
|---|---|---|---|
| R1 | 0/0/0/3L/1N ✅ | 0/0/0/2L/1N ✅ | 0/**1H**/1M/2L/3N |
| R2 | — | — | 0/**1H**/2M/0/0 |
| R3 | — | — | 0/0/**2M**/0/0 |
| R4 | — | — | 0/**1H**/0/1L/0 |
| R5 | — | — | **0/0/0/0/0** ✅ |

Each round caught a real bug:
- R1 HIGH: cold-start restart loop — added arming gate
- R2 HIGH: stale armed across reboot — boot-scoped marker
- R3 MEDIUM: `kern.boottime` is NTP-mutable — switched to `kern.bootsessionuuid`
- R4 HIGH: LaunchAgent PATH missed `/usr/sbin` — `sysctl` / `netstat` would silently fail under `set -e`. **Verified live**: pre-fix PATH never wrote the armed file; post-fix wrote the boot UUID
- R5: clean

Audit prompts committed under `specs/AUDIT_FIX_ISS_191_R{1,2,3,4,5}_*_PROMPT.md`.

## Test plan

- [x] `bash -n` on all 3 watchdog shell scripts + edited install.sh / uninstall.sh
- [x] Live smoke: standalone watchdog correctly detects the existing local provider's healthy connection (UUID `A888CD8B-...` written to armed marker)
- [x] Drift check: standalone vs inlined heredoc byte-identical after normalization
- [x] Negative control: with `/usr/sbin` removed from PATH the watchdog silently fails (reproduces the R4 bug); with the fix it works
- [ ] CI green
- [ ] Operator-side post-merge: a fresh `curl get.streamvc.live/install.sh | sh` deploys the watchdog alongside the provider

## Out of scope (issue #191 mentions, deferred)

- Coordinator-side `/v1/models` poll (catches "TCP up, dropped from ready pool" — different failure mode; in-process Swift watchdog from #204 is the primary detection for this class).
- Tightening detection to provider PID via `lsof` (documented as known limitation in OPS.md §11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
