### PR TITLE
fix(gateway): pad prompt-token estimate to absorb chat-template overhead

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -257,20 +257,24 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 
 	promptEstimate := estimatePromptTokens(body)
-	maxUsageTokens := promptEstimate + maxTokens
+	// Validation cap uses promptCapTokens (with chat-template headroom)
+	// — generous enough to admit valid provider tokenization. Billed
+	// quantities (settle paths below) keep using the bare
+	// promptEstimate so error-path settlement does not over-charge.
+	maxUsageTokens := promptCapTokens(body) + maxTokens
 	if chat.Stream {
 		// ISS-187 R1 architect/code MAJOR: thread the reservation
 		// window through to forwardStreamingChat so the SPEC-006 §
 		// 17.7 fallback usage_events insert in settleAfterCommit
 		// uses the SAME window_date as the original reservation
 		// (avoids drift for streams that cross UTC midnight).
-		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, cancelUpstream, window)
+		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, cancelUpstream, window)
 		return
 	}
-	s.forwardNonStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens)
+	s.forwardNonStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens)
 }
 
-func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens int64) {
+func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64) {
 	body, err := readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
 	if err != nil {
 		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
@@ -322,7 +326,7 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 		writeError(w, http.StatusBadGateway, "api_error", "upstream_provider_error", "Upstream provider error")
 		return
 	}
-	usage, ok, usageErr := usageFromJSON(body, maxUsageTokens)
+	usage, ok, usageErr := usageFromJSON(body, maxUsageTokens, maxTokens)
 	tokenSource := "gateway_estimated"
 	if !ok {
 		usage = tokenUsage{PromptTokens: promptEstimate, CompletionTokens: 0, TotalTokens: promptEstimate}
@@ -344,7 +348,7 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 	_, _ = w.Write(body)
 }
 
-func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens int64, cancelUpstream func(), reservationWindow string) {
+func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64, cancelUpstream func(), reservationWindow string) {
 	if resp.StatusCode == http.StatusServiceUnavailable {
 		body, _ := io.ReadAll(resp.Body)
 		if coordinatorTier2PolicyError(resp.StatusCode, body) {
@@ -414,7 +418,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	invalidReportedUsage := false
 	settleReported := func(outcome string) {
 		usage := *reported
-		observedCompletion := estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens)
+		observedCompletion := estimateStreamingCompletionTokens(emitted, maxTokens)
 		if observedCompletion > usage.CompletionTokens {
 			s.settleAfterCommit(r, subject, promptEstimate, observedCompletion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow)
 			return
@@ -426,7 +430,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			settleReported("stream_truncated")
 			return
 		}
-		s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "stream_truncated", reservationWindow)
+		s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, maxTokens), maxUsageTokens, "gateway_estimated", "stream_truncated", reservationWindow)
 	}
 	forwardLine := func(line []byte) bool {
 		select {
@@ -435,7 +439,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 				settleReported("client_disconnect")
 				return false
 			}
-			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator, reservationWindow)
+			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, maxTokens, cancelCoordinator, reservationWindow)
 			return false
 		default:
 		}
@@ -450,13 +454,13 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 						flusher.Flush()
 					}
 					cancelCoordinator()
-					completion := estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens)
+					completion := estimateStreamingCompletionTokens(emitted, maxTokens)
 					s.settleAfterCommit(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "stream_malformed", reservationWindow)
 					return false
 				}
 				if deltaBytes > 0 {
 					projectedCompletion := estimateTokensFromBytes(emitted + deltaBytes)
-					maxCompletion := maxStreamingCompletionTokens(promptEstimate, maxUsageTokens)
+					maxCompletion := maxStreamingCompletionTokens(maxTokens)
 					if projectedCompletion > maxCompletion {
 						slog.Warn("streaming gateway estimate exceeded request maximum; truncating stream", "request_id", requestID(r), "estimated_completion_tokens", projectedCompletion, "max_completion_tokens", maxCompletion)
 						writeSSEError(w, "Upstream stream exceeded requested max_tokens", "api_error", "stream_output_exceeded")
@@ -469,7 +473,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 					}
 					emitted += deltaBytes
 				}
-				if usage, ok, err := usageFromJSON([]byte(data), maxUsageTokens); ok {
+				if usage, ok, err := usageFromJSON([]byte(data), maxUsageTokens, maxTokens); ok {
 					if err != nil {
 						invalidReportedUsage = true
 						reported = nil
@@ -484,7 +488,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 						flusher.Flush()
 					}
 					cancelCoordinator()
-					completion := estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens)
+					completion := estimateStreamingCompletionTokens(emitted, maxTokens)
 					s.settleAfterCommit(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "stream_malformed", reservationWindow)
 					return false
 				}
@@ -496,7 +500,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 				settleReported("client_disconnect")
 				return false
 			}
-			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator, reservationWindow)
+			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, maxTokens, cancelCoordinator, reservationWindow)
 			return false
 		}
 		if flusher != nil {
@@ -535,7 +539,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 				settleReported("client_disconnect")
 				return
 			}
-			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator, reservationWindow)
+			s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, maxTokens, cancelCoordinator, reservationWindow)
 			return
 		}
 		slog.Error("streaming coordinator read failed", "request_id", requestID(r), "error", err)
@@ -568,14 +572,14 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			settleReported("client_disconnect")
 			return
 		}
-		s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, cancelCoordinator, reservationWindow)
+		s.settleCancelledStream(r, subject, promptEstimate, emitted, maxUsageTokens, maxTokens, cancelCoordinator, reservationWindow)
 		return
 	}
 	if reported != nil && !invalidReportedUsage {
 		settleReported("ok")
 		return
 	}
-	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "ok", reservationWindow)
+	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, maxTokens), maxUsageTokens, "gateway_estimated", "ok", reservationWindow)
 }
 
 func (s *Server) passThroughNoProviderCoordinatorError(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, body []byte) {
@@ -627,9 +631,9 @@ func openAIErrorCode(body []byte) string {
 	return strings.TrimSpace(envelope.Error.Code)
 }
 
-func (s *Server) settleCancelledStream(r *http.Request, subject usageSubject, promptEstimate, emitted, maxUsageTokens int64, cancelCoordinator func(), reservationWindow string) {
+func (s *Server) settleCancelledStream(r *http.Request, subject usageSubject, promptEstimate, emitted, maxUsageTokens, maxTokens int64, cancelCoordinator func(), reservationWindow string) {
 	cancelCoordinator()
-	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens), maxUsageTokens, "gateway_estimated", "client_disconnect", reservationWindow)
+	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, maxTokens), maxUsageTokens, "gateway_estimated", "client_disconnect", reservationWindow)
 }
 
 func (s *Server) settleBeforeResponse(w http.ResponseWriter, r *http.Request, subject usageSubject, prompt, completion, maxTotal int64, source, outcome string) bool {
@@ -798,21 +802,27 @@ func (s *Server) settleRequest(r *http.Request, subject usageSubject, prompt, co
 	return s.store.SettleReservation(context.Background(), settlement)
 }
 
-func estimateStreamingCompletionTokens(emitted, promptEstimate, maxUsageTokens int64) int64 {
+// estimateStreamingCompletionTokens caps the streaming-fallback
+// completion-token estimate at the buyer's max_tokens. Pre-2026-06-28
+// this derived the cap as `maxUsageTokens - promptEstimate`, which
+// silently inflated by the prompt-cap headroom (R1 CODE HIGH #1):
+// a buyer who set max_tokens=1 could be billed 65 completion tokens
+// because maxUsageTokens-promptEstimate = 64 headroom + 1. Now we
+// take maxTokens directly so the billed completion side honors the
+// buyer's stated cap regardless of the cap-headroom-vs-billing split.
+func estimateStreamingCompletionTokens(emitted, maxTokens int64) int64 {
 	completion := estimateTokensFromBytes(emitted)
-	maxCompletion := maxStreamingCompletionTokens(promptEstimate, maxUsageTokens)
-	if completion > maxCompletion {
-		return maxCompletion
+	if completion > maxTokens {
+		return maxTokens
 	}
 	return completion
 }
 
-func maxStreamingCompletionTokens(promptEstimate, maxUsageTokens int64) int64 {
-	maxCompletion := maxUsageTokens - promptEstimate
-	if maxCompletion < 0 {
+func maxStreamingCompletionTokens(maxTokens int64) int64 {
+	if maxTokens < 0 {
 		return 0
 	}
-	return maxCompletion
+	return maxTokens
 }
 
 func estimateTokensFromBytes(n int64) int64 {
@@ -998,7 +1008,18 @@ func parseChatRequest(body []byte) (chatRequest, error) {
 	return req, nil
 }
 
-func usageFromJSON(body []byte, maxUsageTokens int64) (tokenUsage, bool, error) {
+// usageFromJSON validates and parses provider-reported usage.
+//
+// maxUsageTokens — overall ceiling on prompt + completion tokens
+// (computed from promptCapTokens(body) + maxTokens at the call site
+// so the chat-template headroom is included).
+//
+// maxCompletion — independent ceiling on completion_tokens (=
+// buyer's max_tokens). Without this separate check, a malicious
+// provider could spend the prompt-cap headroom as inflated
+// completion tokens, over-billing the buyer above the requested
+// max_tokens. R1 CODE HIGH #1 (2026-06-28).
+func usageFromJSON(body []byte, maxUsageTokens, maxCompletion int64) (tokenUsage, bool, error) {
 	var envelope struct {
 		Usage json.RawMessage `json:"usage"`
 	}
@@ -1031,6 +1052,9 @@ func usageFromJSON(body []byte, maxUsageTokens int64) (tokenUsage, bool, error) 
 	if usage.PromptTokens > math.MaxInt64-usage.CompletionTokens {
 		return tokenUsage{}, true, fmt.Errorf("usage token total overflows int64")
 	}
+	if usage.CompletionTokens > maxCompletion {
+		return tokenUsage{}, true, fmt.Errorf("usage completion_tokens exceeds request max_tokens")
+	}
 	sum := usage.PromptTokens + usage.CompletionTokens
 	if sum > maxUsageTokens {
 		return tokenUsage{}, true, fmt.Errorf("usage token total exceeds request maximum")
@@ -1054,45 +1078,48 @@ func completionFromHeader(header http.Header) int64 {
 	return n
 }
 
-// estimatePromptTokens approximates the provider-side tokenization of
-// the request body. It is used to size the per-request reservation and
-// (via maxUsageTokens) to cap the sum reported back by the provider in
-// usageFromJSON.
+// estimatePromptTokens — billable prompt-token count for the gateway-
+// estimated settlement paths (provider error, invalid_provider_usage
+// fallback, streaming pre-commit cancel, etc.). This is what the
+// buyer actually pays for on those paths, so the value is the
+// conservative byte-heuristic (NO headroom). The value also seeds
+// the streaming completion-token estimate and the receipt audit
+// trail.
 //
-// Pre-2026-06-28 this was bare ceil(bytes/4) — fine for English prose
-// but consistently 5-50 tokens BELOW the provider's actual tokenizer
-// output because the byte-heuristic cannot see:
-//   - chat-template overhead the tokenizer adds AFTER body parse
-//     (im_start/role/content/im_end pairs etc.)
-//   - locale variance (Qwen2.5-Coder tokenizes "hi" through ~30 tokens
-//     vs the heuristic's 29 for the surrounding JSON)
-//
-// The under-estimate caused valid provider responses to fail the
-// usageFromJSON cap (`prompt + completion > maxUsageTokens`) on
-// small-max_tokens requests where the cap headroom is razor-thin.
-// Empirically reproducible on
-// mlx-community/Qwen2.5-Coder-7B-Instruct-4bit during the
-// 2026-06-28 phase-A re-run: a 115-byte body + max_tokens=4 →
-// cap=33; provider tokenized to prompt=30+completion=4=34 → falsely
-// rejected as invalid_provider_usage. Both providers were on the
-// current Swift binary; the gateway's heuristic was at fault.
-//
-// Fix: add fixed promptHeadroomTokens padding to cover the
-// chat-template overhead. Conservative on long prompts (where the
-// bytes/4 heuristic is closer to reality) and decisive on short
-// prompts (where the fixed-cost overhead dominates).
-//
-// The cap remains a safety net against provider over-billing — a
-// malicious provider reporting prompt=10000 for a 100-byte body
-// would still trip the cap because 10000 ≫ ceil(100/4) + 64 +
-// max_tokens.
-const promptHeadroomTokens = 64
-
+// Headroom for the VALIDATION cap is added separately by
+// promptCapTokens; conflating the two would over-charge the buyer on
+// every error path (R1 CODE HIGH #2, 2026-06-28).
 func estimatePromptTokens(body []byte) int64 {
 	if len(body) == 0 {
 		return 0
 	}
-	return int64(math.Ceil(float64(len(body))/4.0)) + promptHeadroomTokens
+	return int64(math.Ceil(float64(len(body)) / 4.0))
+}
+
+// promptHeadroomTokens absorbs the chat-template overhead that the
+// byte-heuristic cannot see (im_start/role/content/im_end markers,
+// BOS token, etc.) — fixed-cost per request, independent of body
+// length. 64 covers the largest chat templates observed in the
+// operator fleet with margin.
+const promptHeadroomTokens = 64
+
+// promptCapTokens — generous upper bound used ONLY in the usage-
+// validation cap (maxUsageTokens). Equal to the billable estimate
+// plus fixed chat-template headroom. Never used as a billed
+// quantity.
+//
+// Background. estimatePromptTokens returns ceil(bytes/4), which is
+// fine for English prose but consistently 5-50 tokens below the
+// provider's actual tokenizer output. The provider's tokenizer
+// applies the chat template AFTER body parse, adding fixed-cost
+// overhead the byte-heuristic cannot see. Empirically reproducible
+// on mlx-community/Qwen2.5-Coder-7B-Instruct-4bit during the
+// 2026-06-28 phase-A re-run: a 115-byte body + max_tokens=4 → bare
+// cap=33; provider tokenized to prompt=30+completion=4=34 → falsely
+// rejected as invalid_provider_usage. Adding +64 to the cap (only)
+// fixes the false reject without inflating any billed quantity.
+func promptCapTokens(body []byte) int64 {
+	return estimatePromptTokens(body) + promptHeadroomTokens
 }
 
 func copyForwardHeaders(dst, src http.Header) {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -1054,11 +1054,45 @@ func completionFromHeader(header http.Header) int64 {
 	return n
 }
 
+// estimatePromptTokens approximates the provider-side tokenization of
+// the request body. It is used to size the per-request reservation and
+// (via maxUsageTokens) to cap the sum reported back by the provider in
+// usageFromJSON.
+//
+// Pre-2026-06-28 this was bare ceil(bytes/4) — fine for English prose
+// but consistently 5-50 tokens BELOW the provider's actual tokenizer
+// output because the byte-heuristic cannot see:
+//   - chat-template overhead the tokenizer adds AFTER body parse
+//     (im_start/role/content/im_end pairs etc.)
+//   - locale variance (Qwen2.5-Coder tokenizes "hi" through ~30 tokens
+//     vs the heuristic's 29 for the surrounding JSON)
+//
+// The under-estimate caused valid provider responses to fail the
+// usageFromJSON cap (`prompt + completion > maxUsageTokens`) on
+// small-max_tokens requests where the cap headroom is razor-thin.
+// Empirically reproducible on
+// mlx-community/Qwen2.5-Coder-7B-Instruct-4bit during the
+// 2026-06-28 phase-A re-run: a 115-byte body + max_tokens=4 →
+// cap=33; provider tokenized to prompt=30+completion=4=34 → falsely
+// rejected as invalid_provider_usage. Both providers were on the
+// current Swift binary; the gateway's heuristic was at fault.
+//
+// Fix: add fixed promptHeadroomTokens padding to cover the
+// chat-template overhead. Conservative on long prompts (where the
+// bytes/4 heuristic is closer to reality) and decisive on short
+// prompts (where the fixed-cost overhead dominates).
+//
+// The cap remains a safety net against provider over-billing — a
+// malicious provider reporting prompt=10000 for a 100-byte body
+// would still trip the cap because 10000 ≫ ceil(100/4) + 64 +
+// max_tokens.
+const promptHeadroomTokens = 64
+
 func estimatePromptTokens(body []byte) int64 {
 	if len(body) == 0 {
 		return 0
 	}
-	return int64(math.Ceil(float64(len(body)) / 4.0))
+	return int64(math.Ceil(float64(len(body))/4.0)) + promptHeadroomTokens
 }
 
 func copyForwardHeaders(dst, src http.Header) {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -319,7 +319,7 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 			s.passThroughReceiptEligibleProviderError(w, r, resp, subject, body)
 			return
 		}
-		completion := completionFromHeader(resp.Header)
+		completion := completionFromHeaderCapped(resp.Header, maxTokens)
 		if !s.settleBeforeResponse(w, r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "upstream_error") {
 			return
 		}
@@ -381,7 +381,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body)
 			return
 		}
-		if !s.settleBeforeResponse(w, r, subject, promptEstimate, completionFromHeader(resp.Header), maxUsageTokens, "gateway_estimated", "upstream_error") {
+		if !s.settleBeforeResponse(w, r, subject, promptEstimate, completionFromHeaderCapped(resp.Header, maxTokens), maxUsageTokens, "gateway_estimated", "upstream_error") {
 			return
 		}
 		writeError(w, http.StatusBadGateway, "api_error", "upstream_provider_error", "Upstream provider error")
@@ -1064,6 +1064,21 @@ func usageFromJSON(body []byte, maxUsageTokens, maxCompletion int64) (tokenUsage
 	}
 	usage.TotalTokens = sum
 	return usage, true, nil
+}
+
+// completionFromHeader reads the upstream's X-MacProvider-Completion-Tokens
+// hint and clamps it to maxTokens. Without the clamp, an upstream that
+// reports a header value above the buyer's max_tokens could over-bill
+// the buyer through the upstream-error and provider-timeout
+// settlement paths — same shape as the inline-usage HIGH #1 closed
+// by usageFromJSON's separate maxCompletion check (R2 CODE HIGH,
+// 2026-06-28).
+func completionFromHeaderCapped(header http.Header, maxTokens int64) int64 {
+	c := completionFromHeader(header)
+	if c > maxTokens {
+		return maxTokens
+	}
+	return c
 }
 
 func completionFromHeader(header http.Header) int64 {

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1964,6 +1964,39 @@ func TestUsageFromJSONValidatesProviderReportedUsage(t *testing.T) {
 	}
 }
 
+// TestEstimatePromptTokensHeadroomCoversAir5 regresses the 2026-06-28
+// phase-A re-run finding where a 115-byte body + max_tokens=4 produced
+// a cap of 33, but mlx-community/Qwen2.5-Coder-7B-Instruct-4bit's
+// tokenizer reported prompt=30 + completion=4 = 34, tripping the
+// usageFromJSON cap as invalid_provider_usage even though the
+// provider's response was correct. The fix adds
+// promptHeadroomTokens (= 64) padding to the byte-heuristic so a
+// 1-token discrepancy between heuristic and actual tokenizer no
+// longer breaks chat completions with small max_tokens.
+func TestEstimatePromptTokensHeadroomCoversAir5(t *testing.T) {
+	body := []byte(`{"model":"mlx-community/Qwen2.5-Coder-7B-Instruct-4bit","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}`)
+	estimate := estimatePromptTokens(body)
+	maxTokens := int64(4)
+	maxUsageTokens := estimate + maxTokens
+	// Provider's actual tokenization for this body.
+	providerUsage := []byte(`{"usage":{"prompt_tokens":30,"completion_tokens":4,"total_tokens":34}}`)
+	usage, ok, err := usageFromJSON(providerUsage, maxUsageTokens)
+	if !ok || err != nil {
+		t.Fatalf("usageFromJSON ok=%v err=%v, want clean accept of provider tokenization within headroom (cap=%d, sum=34)", ok, err, maxUsageTokens)
+	}
+	if usage.PromptTokens != 30 || usage.CompletionTokens != 4 || usage.TotalTokens != 34 {
+		t.Fatalf("usage=%#v, want prompt=30 completion=4 total=34", usage)
+	}
+
+	// Sanity: a malicious provider reporting prompt=10000 for the same
+	// 115-byte body must STILL trip the cap. Headroom doesn't break
+	// the over-billing defense.
+	abusiveUsage := []byte(`{"usage":{"prompt_tokens":10000,"completion_tokens":1,"total_tokens":10001}}`)
+	if _, _, err := usageFromJSON(abusiveUsage, maxUsageTokens); err == nil {
+		t.Fatalf("expected cap rejection for prompt=10000 on a 115-byte body (cap=%d)", maxUsageTokens)
+	}
+}
+
 type settlementFailStore struct {
 	*sqlite.Store
 	settleErr   error

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2009,6 +2009,28 @@ func TestEstimatePromptTokensHeadroomCoversAir5(t *testing.T) {
 	}
 }
 
+// TestCompletionFromHeaderCapsAtMaxTokens — R2 CODE HIGH: the
+// X-MacProvider-Completion-Tokens header path is used on the
+// upstream-error settlement paths. With the +64 prompt-cap
+// headroom, a malicious upstream could send a header value above
+// max_tokens and over-bill the buyer through the gateway-estimated
+// fallback. The completionFromHeaderCapped wrapper clamps to
+// maxTokens, mirroring the JSON-usage maxCompletion check.
+func TestCompletionFromHeaderCapsAtMaxTokens(t *testing.T) {
+	header := http.Header{}
+	header.Set("X-MacProvider-Completion-Tokens", "68")
+	if got := completionFromHeaderCapped(header, 4); got != 4 {
+		t.Fatalf("completionFromHeaderCapped clamped=%d, want 4 (max_tokens cap)", got)
+	}
+	if got := completionFromHeaderCapped(header, 100); got != 68 {
+		t.Fatalf("completionFromHeaderCapped under cap=%d, want 68 (pass-through)", got)
+	}
+	emptyHeader := http.Header{}
+	if got := completionFromHeaderCapped(emptyHeader, 4); got != 0 {
+		t.Fatalf("completionFromHeaderCapped no-header=%d, want 0", got)
+	}
+}
+
 type settlementFailStore struct {
 	*sqlite.Store
 	settleErr   error

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1950,16 +1950,16 @@ func TestUsageFromJSONValidatesProviderReportedUsage(t *testing.T) {
 		{name: "exceeds_request_bound", body: `{"usage":{"prompt_tokens":1,"completion_tokens":10,"total_tokens":11}}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, ok, err := usageFromJSON([]byte(tc.body), 10); !ok || err == nil {
+			if _, ok, err := usageFromJSON([]byte(tc.body), 10, 10); !ok || err == nil {
 				t.Fatalf("usageFromJSON ok=%v err=%v, want provider usage validation error", ok, err)
 			}
 		})
 	}
-	usage, ok, err := usageFromJSON([]byte(`{"usage":{"prompt_tokens":1,"completion_tokens":2}}`), 10)
+	usage, ok, err := usageFromJSON([]byte(`{"usage":{"prompt_tokens":1,"completion_tokens":2}}`), 10, 10)
 	if err != nil || !ok || usage.TotalTokens != 3 {
 		t.Fatalf("valid usage = %#v ok=%v err=%v, want total 3", usage, ok, err)
 	}
-	if _, ok, err := usageFromJSON([]byte(`{"usage":null}`), 10); ok || err != nil {
+	if _, ok, err := usageFromJSON([]byte(`{"usage":null}`), 10, 10); ok || err != nil {
 		t.Fatalf("usage null ok=%v err=%v, want absent usage", ok, err)
 	}
 }
@@ -1975,12 +1975,13 @@ func TestUsageFromJSONValidatesProviderReportedUsage(t *testing.T) {
 // longer breaks chat completions with small max_tokens.
 func TestEstimatePromptTokensHeadroomCoversAir5(t *testing.T) {
 	body := []byte(`{"model":"mlx-community/Qwen2.5-Coder-7B-Instruct-4bit","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}`)
-	estimate := estimatePromptTokens(body)
 	maxTokens := int64(4)
-	maxUsageTokens := estimate + maxTokens
+	// Cap uses promptCapTokens (with chat-template headroom). Billing
+	// paths use bare estimatePromptTokens — see chat_proxy.go split.
+	maxUsageTokens := promptCapTokens(body) + maxTokens
 	// Provider's actual tokenization for this body.
 	providerUsage := []byte(`{"usage":{"prompt_tokens":30,"completion_tokens":4,"total_tokens":34}}`)
-	usage, ok, err := usageFromJSON(providerUsage, maxUsageTokens)
+	usage, ok, err := usageFromJSON(providerUsage, maxUsageTokens, maxTokens)
 	if !ok || err != nil {
 		t.Fatalf("usageFromJSON ok=%v err=%v, want clean accept of provider tokenization within headroom (cap=%d, sum=34)", ok, err, maxUsageTokens)
 	}
@@ -1992,8 +1993,19 @@ func TestEstimatePromptTokensHeadroomCoversAir5(t *testing.T) {
 	// 115-byte body must STILL trip the cap. Headroom doesn't break
 	// the over-billing defense.
 	abusiveUsage := []byte(`{"usage":{"prompt_tokens":10000,"completion_tokens":1,"total_tokens":10001}}`)
-	if _, _, err := usageFromJSON(abusiveUsage, maxUsageTokens); err == nil {
+	if _, _, err := usageFromJSON(abusiveUsage, maxUsageTokens, maxTokens); err == nil {
 		t.Fatalf("expected cap rejection for prompt=10000 on a 115-byte body (cap=%d)", maxUsageTokens)
+	}
+
+	// R1 CODE HIGH #1: a malicious provider must NOT be able to spend
+	// the prompt-cap headroom as inflated completion_tokens. Buyer
+	// asked for max_tokens=4; provider reporting completion=68 (well
+	// under maxUsageTokens=97 thanks to the +64 prompt headroom)
+	// would over-bill the buyer 17× the requested max. Must reject
+	// on the explicit completion check.
+	inflatedCompletion := []byte(`{"usage":{"prompt_tokens":10,"completion_tokens":68,"total_tokens":78}}`)
+	if _, _, err := usageFromJSON(inflatedCompletion, maxUsageTokens, maxTokens); err == nil {
+		t.Fatalf("expected rejection of completion=68 when max_tokens=4 (sum=78 within maxUsageTokens=%d but completion exceeds max)", maxUsageTokens)
 	}
 }
 
@@ -2664,7 +2676,7 @@ func TestStreamingProviderReportedUsageCannotUnderstateTruncatedOutput(t *testin
 	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
 	quota := readQuota(t, usageResp)
 	promptEstimate := estimatePromptTokens([]byte(body))
-	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), promptEstimate, promptEstimate+500)
+	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), 500)
 	wantUsed := float64(promptEstimate + wantCompletion)
 	if quota["daily_tokens_used"].(float64) != wantUsed {
 		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
@@ -3280,7 +3292,7 @@ func TestStreamingProviderReportedUsageCannotUnderstateObservedOutput(t *testing
 	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
 	quota := readQuota(t, usageResp)
 	promptEstimate := estimatePromptTokens([]byte(body))
-	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), promptEstimate, promptEstimate+500)
+	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), 500)
 	wantUsed := float64(promptEstimate + wantCompletion)
 	if quota["daily_tokens_used"].(float64) != wantUsed {
 		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
@@ -3321,7 +3333,7 @@ func TestStreamingUnderreportedUsageWithHighProviderPromptFallsBackToGatewayEsti
 	}
 	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
 	quota := readQuota(t, usageResp)
-	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), promptEstimate, promptEstimate+20)
+	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), 20)
 	wantUsed := float64(promptEstimate + wantCompletion)
 	if quota["daily_tokens_used"].(float64) != wantUsed {
 		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)

--- a/specs/AUDIT_FIX_PROMPT_HEADROOM_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_FIX_PROMPT_HEADROOM_R1_CODE_PROMPT.md
@@ -1,0 +1,108 @@
+# AUDIT — Gateway prompt-token headroom — R1 CODE lane
+
+## Scope
+
+Branch `fix/gateway-prompt-headroom` (worktree
+`/Users/augstar/macprovider-fix-prompt-est`). Read `git diff
+origin/main..HEAD`.
+
+Files:
+- `phase5-gateway/internal/router/chat_proxy.go` (added
+  `promptHeadroomTokens` constant + padded `estimatePromptTokens`)
+- `phase5-gateway/internal/router/server_test.go` (new
+  `TestEstimatePromptTokensHeadroomCoversAir5`)
+
+## Context
+
+During 2026-06-28 phase-A re-run we observed every chat completion
+to `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit` failing with
+HTTP 502 `invalid_provider_usage` when `max_tokens` was small
+(4-16). The same body to `Qwen3-32B` succeeded. Root cause:
+
+- `estimatePromptTokens` returned `ceil(bytes/4)` with no headroom.
+- For "hi" requests: body ~115 bytes → estimate 29.
+- Qwen2.5-Coder tokenizes the body + chat template → 30 tokens.
+- `maxUsageTokens = promptEstimate + maxTokens`. With max_tokens=4:
+  cap=33. Provider reports 30+4=34. `usageFromJSON` rejects.
+- Qwen3-32B happens to tokenize at ≤29 → passes.
+
+The byte-heuristic cannot see the chat-template overhead that the
+provider's tokenizer adds AFTER body parse (`im_start/role/im_end`
+pairs, BOS token, etc.). That overhead is fixed-cost per request,
+independent of body length.
+
+This was a LIVE money-path bug: a buyer with a valid provider got
+back 502 when their other provider would have returned 200.
+
+## Fix
+
+Add `promptHeadroomTokens = 64` fixed padding to
+`estimatePromptTokens`. New regression test
+`TestEstimatePromptTokensHeadroomCoversAir5` asserts:
+- The air5 scenario (115-byte body, max_tokens=4,
+  provider-reported prompt=30+completion=4=34) now accepts cleanly.
+- A malicious provider reporting prompt=10000 for the same
+  100-byte body STILL trips the cap (because 10000 ≫
+  25+64+max_tokens).
+
+Live-deployed to Pearl at `v1.6.1-37-gd82163d`; re-tested with
+max_tokens=4/8/16/32/64 — all succeed against the previously-
+broken provider. Phase-A scenario 01 now shows BOTH providers
+serving traffic (pre-fix: 0 of 3 success-traffic went to the
+Coder model; post-fix: 2 of 3).
+
+## You are the CODE auditor
+
+Score CRITICAL / HIGH / MEDIUM / LOW / NOTE. Bar is **0 C/H/M**.
+
+Specifically check:
+
+1. **Cap headroom adequacy.** 64 tokens covers the largest chat
+   templates seen in the operator fleet with margin. Are there
+   known templates that exceed this? Qwen, Llama-3, GPT-4
+   wrappers all add ≤20 tokens per message in the formats I've
+   surveyed. Could a multi-message conversation push the actual
+   tokenization further off the byte-heuristic so that even +64
+   is insufficient?
+2. **Over-billing defense regression.** The new test asserts
+   `prompt=10000` for a 100-byte body still trips the cap. Is
+   that test sufficient, or are there other adversarial shapes
+   (e.g. provider reporting completion much higher than asked)
+   that need explicit assertions?
+3. **Streaming path.** `maxUsageTokens` is also passed to
+   `forwardStreamingChat` (cancelled-stream estimation,
+   pre-commit settlement, etc.). Does adding +64 to
+   `promptEstimate` impact streaming token accounting in
+   surprising ways? Trace the calls in `forwardStreamingChat`.
+4. **Reservation sizing.** `maxUsageTokens` is also used in the
+   reservation step (`ReserveQuota`). Adding +64 means each
+   request pre-reserves 64 extra tokens against the buyer's
+   daily quota. For a small chat (e.g. max_tokens=10) this is a
+   ~6x reservation inflation. Could this trip
+   `quota_exhausted` early for a buyer near their daily cap?
+   How does the existing `settleBeforeResponse` refund logic
+   handle the over-reserved excess?
+5. **Constant value choice.** Why 64 and not 32 or 128? Is the
+   choice defensible / documented? The PR comment cites "chat
+   template overhead ≤20 tokens per message"; 64 is 3x that
+   for a single-message conversation. Is that headroom
+   reasonable across multi-message conversations too?
+6. **Test coverage shape.** Only one new test
+   (`TestEstimatePromptTokensHeadroomCoversAir5`). Should we
+   also add a test that fires through the full
+   `forwardNonStreamingChat` path with a 200-response upstream
+   to confirm the settlement-side numbers are still correct?
+
+Out of scope: anything outside the two files in the diff.
+
+## Output format
+
+For each finding:
+
+- **SEVERITY** (CRITICAL/HIGH/MEDIUM/LOW/NOTE)
+- **Location** (file:line)
+- **What** (one sentence)
+- **Why it matters** (one sentence)
+- **Suggested fix** (one or two lines)
+
+End with `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_PROMPT_HEADROOM_R2_CODE_PROMPT.md
+++ b/specs/AUDIT_FIX_PROMPT_HEADROOM_R2_CODE_PROMPT.md
@@ -1,0 +1,56 @@
+# AUDIT — Gateway prompt-token headroom — R2 CODE re-audit
+
+## Scope
+
+Branch `fix/gateway-prompt-headroom` (worktree
+`/Users/augstar/macprovider-fix-prompt-est`). Read `git diff origin/main..HEAD`.
+
+## R1 CODE findings claimed FIXED
+
+R1 was `0/2H/0/0/1N`. Fixes applied:
+
+1. **R1 HIGH #1 (over-billing via inflated completion)** — added
+   explicit `maxCompletion` parameter to `usageFromJSON` and a
+   `completion_tokens > maxCompletion` rejection. New regression
+   asserts a provider reporting `completion=68` for `max_tokens=4`
+   (well under the `maxUsageTokens=97` headroom cap) is rejected.
+
+2. **R1 HIGH #2 (settlement debit on fallback paths)** — split
+   `estimatePromptTokens` (bare `bytes/4`, used as the billable
+   prompt count) from `promptCapTokens` (`bytes/4 + 64`, used
+   only in `maxUsageTokens` for validation). Streaming helpers
+   (`estimateStreamingCompletionTokens`, `maxStreamingCompletionTokens`,
+   `settleCancelledStream`) now take `maxTokens` directly so the
+   completion-side cap doesn't silently inflate with the prompt-cap
+   headroom.
+
+3. **R1 NOTE (misleading comment)** — updated.
+
+Full gateway test suite passes (`go test ./... -count=1`). Live
+deploy is at `v1.6.1-38-g363e0e5-dirty-forced` on Pearl;
+verified air5 returns HTTP 200 for `max_tokens=4`.
+
+## Your job (R2)
+
+Confirm R1 findings are genuinely resolved. Surface any NEW defect
+introduced by the split:
+
+- `forwardStreamingChat` now threads `maxTokens` through every
+  settlement variant. Is the value the same `maxTokens` the buyer
+  set (the buyer-controllable cap), or could a code path
+  accidentally pass `maxAllowed` or `maxUsageTokens`?
+- The streaming SSE-parser path at the inline `usageFromJSON(...,
+  maxTokens)` (around line 474): when usage arrives inline in a
+  streaming chunk, the cap is `maxUsageTokens` and the
+  completion-side cap is `maxTokens`. Is that correct for the
+  case where the buyer's max_tokens was hit exactly?
+- `settleCancelledStream` got a new `maxTokens` param. All four
+  call sites in `chat_proxy.go` pass it. Confirm no other call
+  site (test file, etc.) lost a param.
+
+Bar: **0 C/H/M** on R2 diff-introduced surface.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.

--- a/specs/AUDIT_FIX_PROMPT_HEADROOM_R3_CODE_PROMPT.md
+++ b/specs/AUDIT_FIX_PROMPT_HEADROOM_R3_CODE_PROMPT.md
@@ -1,0 +1,37 @@
+# AUDIT — Gateway prompt-token headroom — R3 CODE re-audit
+
+## Scope
+
+Same as R2: 2 files. Read `git diff origin/main..HEAD`.
+
+## R2 finding claimed FIXED
+
+R2 was `0/1H/0/0/0`. Fix applied:
+
+- **R2 HIGH (completionFromHeader unbounded)** — new
+  `completionFromHeaderCapped(header, maxTokens)` wrapper clamps
+  the X-MacProvider-Completion-Tokens header value to maxTokens.
+  Two call sites in chat_proxy.go updated. New
+  `TestCompletionFromHeaderCapsAtMaxTokens` regression.
+
+## Your job (R3)
+
+Final convergence. Confirm R2 HIGH is genuinely resolved. Surface
+any OTHER call site I missed where untrusted provider/coordinator
+data feeds completion tokens into settlement without a maxTokens
+cap — specifically:
+
+- `usageFromHeader` (if exists)
+- Streaming path: `estimateStreamingCompletionTokens` uses
+  byte-counted emitted bytes, which we DO cap at maxTokens via
+  the new signature. Confirm.
+- `settleAfterCommit` / `settleBeforeResponse` direct call sites
+  that pass a completion value — do any of them use a
+  provider-derived count without clamping?
+
+Bar: **0 C/H/M** on R3 diff-introduced surface.
+
+## Output format
+
+Per-finding SEVERITY / Location / What / Why it matters / Suggested
+fix, then `SUMMARY: <C>/<H>/<M>/<L>/<N>`.


### PR DESCRIPTION
## Summary

Hotfix for a live money-path bug surfaced during the 2026-06-28 phase-A re-run after the main batch of fixes deployed to Pearl. The gateway's `estimatePromptTokens` byte-heuristic underestimated actual provider tokenization by 1-15 tokens, causing valid 200 responses to be rejected as `502 invalid_provider_usage` when `max_tokens` was small.

### Repro

```
POST /v1/chat/completions  (115 bytes, max_tokens=4)
Model: mlx-community/Qwen2.5-Coder-7B-Instruct-4bit
→ HTTP 502 invalid_provider_usage  (consistent, every request)

Same body to mlx-community/Qwen3-32B-4bit  →  HTTP 200 ✅
```

The provider was returning valid OpenAI-shape usage. The gateway's pre-tokenization estimate (`ceil(115/4) = 29`) was 1 token below the actual chat-tokenizer output (`30`). With `max_tokens=4`, cap = 33; provider's sum = 30 + 4 = 34 → cap exceeded → rejected.

### Fix

Add a fixed `promptHeadroomTokens = 64` to `estimatePromptTokens` to absorb the chat-template overhead the byte-heuristic cannot see (im_start/role/im_end markers, BOS token, etc.). New regression test asserts both the air5 scenario passes AND a malicious `prompt=10000` for a 100-byte body still trips the cap.

### Live verification

Deployed to Pearl at `v1.6.1-37-gd82163d`. Re-tested:

| max_tokens | Pre-fix | Post-fix |
|---|---|---|
| 4 | 502 invalid_provider_usage | 200 ✅ |
| 8 | 502 | 200 ✅ |
| 16 | 502 | 200 ✅ |
| 32 | 502 | 200 ✅ |
| 64 | 200 | 200 |

Phase-A harness scenario 01 with the hotfix: 3 successful responses across both providers (2 went to Qwen2.5-Coder, 1 to Qwen3-32B). Pre-hotfix: 0 successes ever reached the Coder model. **Both providers now serve traffic.**

### Test plan

- [x] `go test ./internal/router -run "TestUsageFromJSON|TestEstimatePromptTokensHeadroom"` — both pass
- [x] `go test ./... -count=1` — full gateway suite passes
- [x] Live deployment + curl smoke (max_tokens = 4/8/16/32/64) — all 200
- [x] Phase-A scenario 01 re-run — both providers serve, all 4 invariants PASS
- [ ] CI green

### Audit

3-lane codex audit pending. Will converge before merge per locked convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
