### PR TITLE
fix(gateway): account-scoped PK for usage_events (closes #196 P0)

### DIFF
--- a/OPS.md
+++ b/OPS.md
@@ -155,7 +155,8 @@ quota table, which has no BEFORE-DELETE trigger.
 - `phase5-gateway/dist/archive-restore.sh` — forensic-restore path.
   Verifies the `.sha256` checksum, decompresses, runs `PRAGMA
   integrity_check`, refuses if the archive's `schema_migrations` max
-  version exceeds the binary's expected version (currently 1), and
+  version exceeds the binary's expected version (currently 2, after
+  issue #196 made `usage_events` PK composite), and
   installs to a tempfile target (default `/tmp/gateway-restored-<ts>.db`).
   `--to-live` does the destructive replace-the-live-DB path; requires
   `ASSUME_YES=1`. Snapshots the existing live DB to a `.pre-restore.<ts>`

--- a/phase5-gateway/dist/archive-restore.sh
+++ b/phase5-gateway/dist/archive-restore.sh
@@ -157,7 +157,7 @@ if [ "$INTEGRITY" != "ok" ]; then
 fi
 
 # Schema-version check.
-EXPECTED_VERSION=1
+EXPECTED_VERSION=2  # bumped 1→2 by issue #196 (usage_events composite PK)
 ARCHIVE_VERSION=$(sqlite3 "$TMP_DB" "SELECT COALESCE(MAX(version), 0) FROM schema_migrations;" 2>/dev/null || echo 0)
 log "archive schema version=$ARCHIVE_VERSION expected=$EXPECTED_VERSION"
 if [ "$ARCHIVE_VERSION" -gt "$EXPECTED_VERSION" ]; then

--- a/phase5-gateway/dist/deploy-pearl-vps.sh
+++ b/phase5-gateway/dist/deploy-pearl-vps.sh
@@ -197,6 +197,49 @@ EOF
 fi
 log "  ok: $INFLIGHT in-flight requests (or FORCE_RESTART=1 set)"
 
+log "step 5b/8: pre-restart snapshot of gateway.db (rollback safety, issue #196)"
+# The new binary's first start runs Migrate() which may upgrade schema
+# in place (e.g. v1 -> v2 composite-PK rebuild). The old binary CANNOT
+# read the upgraded schema correctly — its WHERE request_id = ? lookup
+# returns wrong-account rows once cross-account collisions exist. So
+# binary-only rollback via gateway.prev is INVALID after a schema
+# upgrade. We snapshot the DB BEFORE the new binary starts; rollback
+# becomes binary.prev + db.pre-deploy.<ts>.
+#
+# Snapshot uses `sqlite3 .backup` (which serializes a WAL-consistent
+# copy from a still-running gateway) rather than a raw `install`/`cp`
+# of just gateway.db. Raw copy misses rows still in gateway.db-wal
+# that have been COMMITTED but not yet checkpointed into the main
+# file — a rollback to that snapshot would silently lose money-path
+# audit rows. ISS-196 R3 codex SECURITY + ARCHITECT HIGH.
+$SSH 'set -e
+  TS=$(date -u +%Y%m%dT%H%M%SZ)
+  DB=/var/lib/macprovider/gateway.db
+  if [ -f "$DB" ]; then
+    SNAP="${DB}.pre-deploy.${TS}"
+    # .backup opens a read txn that pins a consistent WAL view; the
+    # output file is a single .db with WAL already merged in (no
+    # accompanying -wal/-shm sidecars), so rollback restore is a
+    # single-file copy.
+    sudo -u macprovider sqlite3 "$DB" ".backup ${SNAP}"
+    chmod 0600 "$SNAP"
+    chown macprovider:macprovider "$SNAP"
+    INTEG=$(sudo -u macprovider sqlite3 "$SNAP" "PRAGMA integrity_check;" 2>&1 | head -1)
+    if [ "$INTEG" != "ok" ]; then
+      echo "  ERROR: snapshot integrity_check returned: $INTEG" >&2
+      rm -f "$SNAP"
+      exit 5
+    fi
+    echo "  db snapshot saved at $SNAP (WAL-consistent, integrity=ok)"
+    # Retain the 5 most recent pre-deploy snapshots; older ones are
+    # auto-pruned to bound disk growth.
+    ls -1t /var/lib/macprovider/gateway.db.pre-deploy.* 2>/dev/null \
+      | tail -n +6 | xargs -r rm -f
+  else
+    echo "  no live gateway.db at $DB — first deploy, no snapshot needed"
+  fi
+'
+
 log "step 6/8: enable + start gateway service"
 $SSH 'set -e
   systemctl daemon-reload
@@ -240,5 +283,19 @@ $SSH 'journalctl -u macprovider-gateway --no-pager -n 20'
 
 log "DONE. gateway is live at https://$DOMAIN"
 echo
-echo "Rollback (one command on Pearl):"
-echo "  ssh $VPS_USER@$VPS_HOST 'install -o macprovider -g macprovider -m 0755 /opt/macprovider/gateway.prev /opt/macprovider/gateway && systemctl restart macprovider-gateway'"
+echo "Rollback:"
+echo
+echo "  IMPORTANT — issue #196 added a schema upgrade (v1 -> v2) the OLD"
+echo "  binary cannot safely read. After any deploy that crosses schema"
+echo "  versions, restore BOTH the binary AND the pre-deploy DB snapshot:"
+echo
+echo "    ssh $VPS_USER@$VPS_HOST '"
+echo "      systemctl stop macprovider-gateway &&"
+echo "      install -o macprovider -g macprovider -m 0755 /opt/macprovider/gateway.prev /opt/macprovider/gateway &&"
+echo "      LATEST=\$(ls -1t /var/lib/macprovider/gateway.db.pre-deploy.* | head -1) &&"
+echo "      install -o macprovider -g macprovider -m 0600 \"\$LATEST\" /var/lib/macprovider/gateway.db &&"
+echo "      systemctl start macprovider-gateway"
+echo "    '"
+echo
+echo "  Binary-only rollback (gateway.prev only) is SAFE only if no schema"
+echo "  bump happened between the two deploys."

--- a/phase5-gateway/dist/test/archive_rotate_test.sh
+++ b/phase5-gateway/dist/test/archive_rotate_test.sh
@@ -308,7 +308,7 @@ test_schema_mismatch_refused() {
   local db="$w/gateway.db"
   seed_db "$db"
   # Forge an archive-equivalent DB with schema_migrations bumped beyond
-  # expected version (which is 1 in the restore script).
+  # expected version (now 2 after issue #196).
   sqlite3 "$db" "INSERT INTO schema_migrations VALUES (9999, '2099-01-01T00:00:00Z');"
 
   FORCE_ROTATE=1 run_rotate "$db" "$w/archive" 2>"$w/r.stderr" || { cat "$w/r.stderr"; rm -rf "$w"; record_result "T5_schema_mismatch_refused" "0"; return; }

--- a/phase5-gateway/internal/router/explorer.go
+++ b/phase5-gateway/internal/router/explorer.go
@@ -99,10 +99,29 @@ func (s *Server) handleExplorerSessionDetail(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusNotFound, "invalid_request_error", "not_found", "Explorer resource not found")
 		return
 	}
+	// Issue #196: a request_id can now legitimately match rows in
+	// multiple accounts under the composite-PK schema. Operators
+	// disambiguate with ?account_id=<id>.
+	accountID := r.URL.Query().Get("account_id")
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(explorerQueryTimeoutMs)*time.Millisecond)
 	defer cancel()
-	out, err := s.readStore().ExplorerSessionDetail(ctx, requestID)
+	out, err := s.readStore().ExplorerSessionDetail(ctx, accountID, requestID)
 	if err != nil {
+		// Surface the ambiguity case as 409 with the matching
+		// account list so the UI can render a disambiguation
+		// picker rather than a generic 500.
+		if errors.Is(err, storage.ErrExplorerAmbiguousRequestID) {
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"error": map[string]any{
+					"type":    "invalid_request_error",
+					"code":    "ambiguous_request_id",
+					"message": "request_id matches multiple accounts; supply ?account_id= to disambiguate",
+				},
+				"request_id":          requestID,
+				"matched_account_ids": out.MatchedAccountIDs,
+			})
+			return
+		}
 		writeExplorerStorageError(w, err)
 		return
 	}

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2448,14 +2448,16 @@ func TestStreamingSettlementFallbackWritesUsageEventOnMissingReservation(t *test
 	}
 }
 
-// TestEnsureUsageEventRejectsCrossAccountConflict pins the ISS-187
-// R1 code+security MAJOR: when the gateway's INSERT OR IGNORE
-// silently no-ops on the pre-existing #196 PK-collision attack
-// surface, EnsureUsageEvent now reads the existing row and rejects
-// the call if (account_id, demo_identity, token_source, outcome)
-// don't match — preventing a malicious buyer from skipping their
-// audit row by colliding with an unrelated request_id.
-func TestEnsureUsageEventRejectsCrossAccountConflict(t *testing.T) {
+// TestEnsureUsageEventCrossAccountInsertsBothRows pins the issue
+// #196 schema fix: usage_events PRIMARY KEY is now
+// (account_id, request_id), so a buyer using the same X-Request-ID
+// under two different accounts produces TWO distinct rows — each
+// account is billed independently and the attack surface that
+// motivated the earlier ISS-187 R1 payload-verify defense no longer
+// exists. The verify code is retained as defense in depth against
+// same-account payload drift (covered by the sibling
+// TestEnsureUsageEventRejectsSameIdentityPayloadMismatch).
+func TestEnsureUsageEventCrossAccountInsertsBothRows(t *testing.T) {
 	dir := t.TempDir()
 	st, err := sqlite.Open(context.Background(), dir+"/test.db")
 	if err != nil {
@@ -2464,21 +2466,36 @@ func TestEnsureUsageEventRejectsCrossAccountConflict(t *testing.T) {
 	defer st.Close()
 	rid := "55555555-5555-4555-8555-555555555555"
 	now := time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC)
-	if err := st.InsertUsageEvent(context.Background(), storage.UsageEvent{
+	victim := storage.UsageEvent{
 		RequestID: rid, AccountID: "victim_account",
 		WindowDate: "2026-06-28", PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30,
 		TokenSource: "provider_reported", Outcome: "ok", CreatedAt: now,
-	}); err != nil {
+	}
+	if err := st.InsertUsageEvent(context.Background(), victim); err != nil {
 		t.Fatalf("InsertUsageEvent (victim row): %v", err)
 	}
-	// Attacker tries to write the SAME request_id under a different account.
-	err = st.EnsureUsageEvent(context.Background(), storage.UsageEvent{
+	attacker := storage.UsageEvent{
 		RequestID: rid, AccountID: "attacker_account",
 		WindowDate: "2026-06-28", PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2,
 		TokenSource: "gateway_estimated", Outcome: "stream_truncated", CreatedAt: now,
-	})
-	if !errors.Is(err, storage.ErrUsageEventConflict) {
-		t.Fatalf("EnsureUsageEvent on cross-account PK collision: err=%v, want ErrUsageEventConflict", err)
+	}
+	if err := st.EnsureUsageEvent(context.Background(), attacker); err != nil {
+		t.Fatalf("EnsureUsageEvent for cross-account same-request_id must succeed under composite PK: %v", err)
+	}
+	// Both rows persisted, each billed against its own account.
+	victimUsed, _, err := st.DailyUsage(context.Background(), "victim_account", "2026-06-28")
+	if err != nil {
+		t.Fatalf("DailyUsage(victim): %v", err)
+	}
+	if victimUsed != 30 {
+		t.Errorf("victim used = %d, want 30", victimUsed)
+	}
+	attackerUsed, _, err := st.DailyUsage(context.Background(), "attacker_account", "2026-06-28")
+	if err != nil {
+		t.Fatalf("DailyUsage(attacker): %v", err)
+	}
+	if attackerUsed != 2 {
+		t.Errorf("attacker used = %d, want 2 (must be billed independently from victim)", attackerUsed)
 	}
 }
 

--- a/phase5-gateway/internal/storage/errors.go
+++ b/phase5-gateway/internal/storage/errors.go
@@ -15,4 +15,11 @@ var (
 	// surface: this sentinel forces the caller to refund + log
 	// instead of silently absorbing the duplicate.
 	ErrUsageEventConflict = errors.New("usage event conflicts with existing row for request_id")
+	// ErrExplorerAmbiguousRequestID is returned by ExplorerSessionDetail
+	// when the request_id resolves to rows from multiple accounts and
+	// the caller did not supply an account scope. Issue #196 made
+	// (account_id, request_id) the usage_events PK, which allows
+	// legitimate cross-account collisions; explorer callers must
+	// disambiguate.
+	ErrExplorerAmbiguousRequestID = errors.New("explorer session request_id matches multiple accounts; supply account_id")
 )

--- a/phase5-gateway/internal/storage/interfaces.go
+++ b/phase5-gateway/internal/storage/interfaces.go
@@ -125,7 +125,14 @@ type ExplorerStore interface {
 	ExplorerListBuyers(ctx context.Context, q ExplorerBuyerQuery) (ExplorerBuyerList, error)
 	ExplorerBuyerDetail(ctx context.Context, accountID string, q ExplorerDetailQuery) (ExplorerBuyerDetail, error)
 	ExplorerListSessions(ctx context.Context, q ExplorerSessionQuery) (ExplorerSessionList, error)
-	ExplorerSessionDetail(ctx context.Context, requestID string) (ExplorerSessionDetail, error)
+	// ExplorerSessionDetail looks up the row trail for a request_id.
+	// accountID may be empty for backward-compat callers; when empty
+	// AND the request_id resolves to multiple accounts (allowed since
+	// issue #196 made usage_events PK composite), the call returns
+	// ErrExplorerAmbiguousRequestID and populates
+	// ExplorerSessionDetail.MatchedAccountIDs so the caller can
+	// disambiguate.
+	ExplorerSessionDetail(ctx context.Context, accountID, requestID string) (ExplorerSessionDetail, error)
 	ExplorerActivity(ctx context.Context, q ExplorerActivityQuery) (ExplorerActivityList, error)
 	ExplorerHealth(ctx context.Context, since time.Time) (ExplorerHealth, error)
 }

--- a/phase5-gateway/internal/storage/sqlite/explorer.go
+++ b/phase5-gateway/internal/storage/sqlite/explorer.go
@@ -15,6 +15,12 @@ var _ storage.ExplorerStore = (*Store)(nil)
 type listCursor struct {
 	TS string `json:"ts,omitempty"`
 	ID string `json:"id"`
+	// AccountID was added in issue #196 to break ties when two
+	// accounts share both created_at AND request_id under the new
+	// composite PK. Optional for backward compatibility — pre-#196
+	// cursors lacking AccountID fall through the (?='') predicate
+	// branch and behave as before.
+	AccountID string `json:"acct,omitempty"`
 }
 
 type activityCursor struct {
@@ -216,16 +222,26 @@ func (s *Store) ExplorerListSessions(ctx context.Context, q storage.ExplorerSess
 	if err != nil {
 		return storage.ExplorerSessionList{}, err
 	}
+	// Cursor predicate is lexicographic over (created_at, request_id,
+	// account_id). The account_id tiebreaker is load-bearing post-
+	// #196 because (created_at, request_id) is no longer unique
+	// across accounts. ISS-196 R2 codex CODE MEDIUM.
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT request_id, account_id, demo_identity, window_date, prompt_tokens, completion_tokens, total_tokens, token_source, outcome, created_at
 		FROM usage_events
 		WHERE created_at >= ? AND created_at < ?
 		  AND (? = '' OR account_id = ?)
-		  AND (? = '' OR created_at < ? OR (created_at = ? AND request_id < ?))
-		ORDER BY created_at DESC, request_id DESC
+		  AND (? = '' OR created_at < ?
+		       OR (created_at = ? AND request_id < ?)
+		       OR (created_at = ? AND request_id = ? AND account_id < ?))
+		ORDER BY created_at DESC, request_id DESC, account_id DESC
 		LIMIT ?`,
 		encodeTime(q.From), encodeTime(q.To), q.AccountID, q.AccountID,
-		cursor.TS, cursor.TS, cursor.TS, cursor.ID, q.Limit+1)
+		cursor.TS,
+		cursor.TS,
+		cursor.TS, cursor.ID,
+		cursor.TS, cursor.ID, cursor.AccountID,
+		q.Limit+1)
 	if err != nil {
 		return storage.ExplorerSessionList{}, err
 	}
@@ -243,41 +259,70 @@ func (s *Store) ExplorerListSessions(ctx context.Context, q storage.ExplorerSess
 	}
 	if len(out.Items) > q.Limit {
 		last := out.Items[q.Limit-1]
-		next := encodeListCursor(last.CreatedAt, last.RequestID)
+		next := encodeListCursorWithAccount(last.CreatedAt, last.RequestID, last.AccountID)
 		out.NextCursor = &next
 		out.Items = out.Items[:q.Limit]
 	}
 	return out, nil
 }
 
-func (s *Store) ExplorerSessionDetail(ctx context.Context, requestID string) (storage.ExplorerSessionDetail, error) {
-	out := storage.ExplorerSessionDetail{RequestID: requestID, Partial: false, Error: nil}
-	usage, err := s.explorerUsageEvents(ctx, "", requestID, time.Time{}, time.Time{}, 1)
+// ExplorerSessionDetail looks up the session row trail for a
+// (accountID, requestID). The legacy single-arg call site passed
+// accountID="" — that path still works for backward compatibility,
+// but issue #196 made `usage_events` PK composite, so a request_id
+// can now legitimately match rows in multiple accounts. Pre-fix,
+// the unscoped lookup silently returned one arbitrary row; now it
+// detects ambiguity and returns ErrExplorerAmbiguousRequestID with
+// `MatchedAccountIDs` populated so the caller can re-issue a
+// scoped lookup. The HTTP handler surfaces this as a 409 with the
+// account list.
+func (s *Store) ExplorerSessionDetail(ctx context.Context, accountID, requestID string) (storage.ExplorerSessionDetail, error) {
+	out := storage.ExplorerSessionDetail{RequestID: requestID, AccountID: accountID, Partial: false, Error: nil}
+	// Ambiguity check fires only on the unscoped path. Probe with
+	// limit=2 so we can detect "more than one" without paging the
+	// whole result set.
+	if accountID == "" {
+		// Ambiguity probe spans all three session-detail tables that
+		// share (account_id, request_id) keys. Quota and concurrency
+		// already had composite PKs pre-#196 and could carry
+		// cross-account collisions before usage_events ever has a
+		// row (e.g., reservation reserved but not yet settled).
+		// Caught by ISS-196 R2 codex ARCHITECT HIGH.
+		accountIDs, err := s.explorerAccountIDsForRequest(ctx, requestID)
+		if err != nil {
+			return storage.ExplorerSessionDetail{}, err
+		}
+		if len(accountIDs) > 1 {
+			out.MatchedAccountIDs = accountIDs
+			return out, storage.ErrExplorerAmbiguousRequestID
+		}
+	}
+	usage, err := s.explorerUsageEvents(ctx, accountID, requestID, time.Time{}, time.Time{}, 1)
 	if err != nil {
 		return storage.ExplorerSessionDetail{}, err
 	}
 	if len(usage) > 0 {
 		out.UsageEvent = &usage[0]
 	}
-	quota, err := s.explorerQuotaReservations(ctx, "", requestID, time.Time{}, time.Time{}, 1)
+	quota, err := s.explorerQuotaReservations(ctx, accountID, requestID, time.Time{}, time.Time{}, 1)
 	if err != nil {
 		return storage.ExplorerSessionDetail{}, err
 	}
 	if len(quota) > 0 {
 		out.QuotaReservation = &quota[0]
 	}
-	concurrency, err := s.explorerConcurrencyReservations(ctx, "", requestID, time.Time{}, time.Time{}, 1)
+	concurrency, err := s.explorerConcurrencyReservations(ctx, accountID, requestID, time.Time{}, time.Time{}, 1)
 	if err != nil {
 		return storage.ExplorerSessionDetail{}, err
 	}
 	if len(concurrency) > 0 {
 		out.ConcurrencyReservation = &concurrency[0]
 	}
-	out.FeedbackEvents, err = s.explorerFeedbackEvents(ctx, "", requestID, time.Time{}, time.Time{}, 50)
+	out.FeedbackEvents, err = s.explorerFeedbackEvents(ctx, accountID, requestID, time.Time{}, time.Time{}, 50)
 	if err != nil {
 		return storage.ExplorerSessionDetail{}, err
 	}
-	out.AuditEvents, err = s.explorerAuditEvents(ctx, "", requestID, time.Time{}, time.Time{}, 50)
+	out.AuditEvents, err = s.explorerAuditEvents(ctx, accountID, requestID, time.Time{}, time.Time{}, 50)
 	if err != nil {
 		return storage.ExplorerSessionDetail{}, err
 	}
@@ -285,6 +330,36 @@ func (s *Store) ExplorerSessionDetail(ctx context.Context, requestID string) (st
 		return storage.ExplorerSessionDetail{}, storage.ErrNotFound
 	}
 	return out, nil
+}
+
+// explorerAccountIDsForRequest returns the distinct account_id set
+// for a given request_id across all three session-detail tables
+// (usage_events, quota_reservations, concurrency_reservations). All
+// three are keyed by (account_id, request_id) and can independently
+// carry rows for cross-account collisions, so the ambiguity check
+// must union them. ISS-196 R2 architect HIGH.
+func (s *Store) explorerAccountIDsForRequest(ctx context.Context, requestID string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT DISTINCT account_id FROM (
+			SELECT account_id FROM usage_events WHERE request_id = ?
+			UNION
+			SELECT account_id FROM quota_reservations WHERE request_id = ?
+			UNION
+			SELECT account_id FROM concurrency_reservations WHERE request_id = ?
+		) ORDER BY account_id`, requestID, requestID, requestID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var a string
+		if err := rows.Scan(&a); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) ExplorerActivity(ctx context.Context, q storage.ExplorerActivityQuery) (storage.ExplorerActivityList, error) {
@@ -727,6 +802,14 @@ func decodeListID(raw string) (string, error) {
 
 func encodeListCursor(ts time.Time, id string) string {
 	b, _ := json.Marshal(listCursor{TS: encodeTime(ts), ID: id})
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// encodeListCursorWithAccount is the post-issue-#196 cursor encoder.
+// AccountID is the third tiebreaker so pagination over usage_events
+// is total across the composite (account_id, request_id) PK.
+func encodeListCursorWithAccount(ts time.Time, id, accountID string) string {
+	b, _ := json.Marshal(listCursor{TS: encodeTime(ts), ID: id, AccountID: accountID})
 	return base64.RawURLEncoding.EncodeToString(b)
 }
 

--- a/phase5-gateway/internal/storage/sqlite/migrate.go
+++ b/phase5-gateway/internal/storage/sqlite/migrate.go
@@ -1,5 +1,51 @@
 package sqlite
 
+// usageEventsTableDDL is the canonical CREATE TABLE for usage_events
+// in its post-#196 composite-PK shape. Used both inside schemaSQL
+// (fresh installs) and inside ensureUsageEventsCompositePK
+// (in-place upgrades) so the sqlite_master.sql entry for the table
+// is byte-for-byte identical across paths. ISS-196 R2 architect
+// MEDIUM finding.
+const usageEventsTableDDL = `CREATE TABLE IF NOT EXISTS usage_events (
+	request_id TEXT NOT NULL,
+	account_id TEXT NOT NULL,
+	demo_identity TEXT NOT NULL DEFAULT '',
+	window_date TEXT NOT NULL,
+	prompt_tokens INTEGER NOT NULL CHECK (prompt_tokens >= 0),
+	completion_tokens INTEGER NOT NULL CHECK (completion_tokens >= 0),
+	total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
+	token_source TEXT NOT NULL CHECK (token_source IN ('provider_reported', 'gateway_estimated', 'manual_fixture')),
+	outcome TEXT NOT NULL,
+	created_at TEXT NOT NULL,
+	PRIMARY KEY (account_id, request_id)
+)`
+
+// usageEventsAuxiliaryDDL is the canonical text for the usage_events
+// secondary indexes and append-only triggers. Used both inside
+// schemaSQL (for fresh installs) and by ensureUsageEventsCompositePK
+// (for in-place upgrades from the pre-issue-#196 single-column PK
+// shape) so the post-migration sqlite_master entries are byte-for-byte
+// identical to a fresh install. Architect R1 MEDIUM finding.
+const usageEventsAuxiliaryDDL = `
+CREATE INDEX IF NOT EXISTS idx_usage_account_date ON usage_events(account_id, window_date);
+CREATE INDEX IF NOT EXISTS idx_usage_created_at ON usage_events(created_at);
+-- request_id-leading index restored after issue #196 made the PK
+-- composite (account_id, request_id). Without this, the explorer
+-- "find request by id" path (explorerAccountIDsForRequest, the
+-- ambiguity probe, and SPEC-007 session-detail unscoped lookups)
+-- would full-scan the table.
+CREATE INDEX IF NOT EXISTS idx_usage_request ON usage_events(request_id);
+
+CREATE TRIGGER IF NOT EXISTS usage_events_no_update BEFORE UPDATE ON usage_events
+BEGIN
+	SELECT RAISE(ABORT, 'usage_events are append-only');
+END;
+CREATE TRIGGER IF NOT EXISTS usage_events_no_delete BEFORE DELETE ON usage_events
+BEGIN
+	SELECT RAISE(ABORT, 'usage_events are append-only');
+END;
+`
+
 const schemaSQL = `
 PRAGMA foreign_keys = ON;
 
@@ -65,21 +111,9 @@ CREATE TABLE IF NOT EXISTS api_key_events (
 
 CREATE INDEX IF NOT EXISTS idx_api_key_events_key ON api_key_events(key_id);
 
-CREATE TABLE IF NOT EXISTS usage_events (
-	request_id TEXT PRIMARY KEY,
-	account_id TEXT NOT NULL,
-	demo_identity TEXT NOT NULL DEFAULT '',
-	window_date TEXT NOT NULL,
-	prompt_tokens INTEGER NOT NULL CHECK (prompt_tokens >= 0),
-	completion_tokens INTEGER NOT NULL CHECK (completion_tokens >= 0),
-	total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
-	token_source TEXT NOT NULL CHECK (token_source IN ('provider_reported', 'gateway_estimated', 'manual_fixture')),
-	outcome TEXT NOT NULL,
-	created_at TEXT NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS idx_usage_account_date ON usage_events(account_id, window_date);
-CREATE INDEX IF NOT EXISTS idx_usage_created_at ON usage_events(created_at);
+-- usage_events table: see usageEventsTableDDL constant for the canonical
+-- shape. Executed alongside schemaSQL in Migrate() so both paths share
+-- one source of truth post-#196.
 
 CREATE TABLE IF NOT EXISTS quota_reservations (
 	account_id TEXT NOT NULL,
@@ -181,14 +215,6 @@ CREATE TABLE IF NOT EXISTS runtime_config (
 	updated_at TEXT NOT NULL
 );
 
-CREATE TRIGGER IF NOT EXISTS usage_events_no_update BEFORE UPDATE ON usage_events
-BEGIN
-	SELECT RAISE(ABORT, 'usage_events are append-only');
-END;
-CREATE TRIGGER IF NOT EXISTS usage_events_no_delete BEFORE DELETE ON usage_events
-BEGIN
-	SELECT RAISE(ABORT, 'usage_events are append-only');
-END;
 CREATE TRIGGER IF NOT EXISTS feedback_events_no_update BEFORE UPDATE ON feedback_events
 BEGIN
 	SELECT RAISE(ABORT, 'feedback_events are append-only');

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/augstar/macprovider-gateway/internal/storage"
@@ -85,15 +86,94 @@ func (s *Store) Ping(ctx context.Context) error {
 	return s.db.PingContext(ctx)
 }
 
+// maxKnownSchemaVersion is the highest schema_migrations.version this
+// binary understands. Bumped from 1 → 2 by issue #196 (usage_events
+// composite PK rebuild). At Open time the store reads the current
+// applied version; if it exceeds this constant the binary is older
+// than the DB and refuses to start, preventing the silent data
+// hazards described in the architect R1 HIGH "rollback" finding
+// (e.g., the legacy `WHERE request_id = ?` lookup returning a
+// wrong-account row after the composite PK has allowed cross-account
+// collisions).
+//
+// Operators rolling back the gateway binary on a DB already at
+// version 2 must restore /var/lib/macprovider/gateway.db from the
+// pre-deploy snapshot (deploy-pearl-vps.sh writes one). Future
+// version bumps land here.
+const maxKnownSchemaVersion = 2
+
 func (s *Store) Migrate(ctx context.Context) error {
+	if err := s.checkSchemaVersionGate(ctx); err != nil {
+		return err
+	}
 	if _, err := s.db.ExecContext(ctx, schemaSQL); err != nil {
+		return err
+	}
+	// usage_events table + auxiliary DDL (indexes + append-only
+	// triggers) are kept in shared constants so the in-place upgrade
+	// path (ensureUsageEventsCompositePK) creates them with identical
+	// text, preserving sqlite_master byte-equality across fresh
+	// installs and migrated DBs.
+	if _, err := s.db.ExecContext(ctx, usageEventsTableDDL); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, usageEventsAuxiliaryDDL); err != nil {
 		return err
 	}
 	if err := s.ensureOAuthStateActionColumn(ctx); err != nil {
 		return err
 	}
-	_, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(1, ?)", encodeTime(time.Now().UTC()))
-	return err
+	if err := s.ensureUsageEventsCompositePK(ctx); err != nil {
+		return err
+	}
+	// Stamp the schema version. We always insert v1 (preserves
+	// historical behavior for any tooling that checked exactly that
+	// row) AND the post-#196 marker v2. INSERT OR IGNORE keeps it
+	// idempotent on re-run.
+	//
+	// Note: ensureUsageEventsCompositePK ALSO stamps v2 inside its
+	// rebuild transaction so the shape change and the version marker
+	// commit atomically (ISS-196 R4 architect HIGH). The outer v2
+	// insert here is the no-op repair path for new installs and for
+	// DBs that came through Migrate without needing a rebuild.
+	now := encodeTime(time.Now().UTC())
+	if _, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(1, ?)", now); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(2, ?)", now); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkSchemaVersionGate refuses to run Migrate when the DB carries
+// a schema version higher than this binary knows about. Protects
+// against the silent-corruption rollback scenario flagged in the
+// ISS-196 R1 architect HIGH finding: an older binary opening a
+// DB that has already been migrated to a composite-PK shape would
+// run the legacy `WHERE request_id = ?` query and risk returning
+// a wrong-account row once cross-account request_id duplicates
+// exist. Failing closed at Open is the safe choice.
+func (s *Store) checkSchemaVersionGate(ctx context.Context) error {
+	// schema_migrations may not exist yet on a brand-new DB; the
+	// follow-up schemaSQL run creates it. Tolerate the missing-table
+	// case here.
+	var current sql.NullInt64
+	err := s.db.QueryRowContext(ctx, `SELECT MAX(version) FROM schema_migrations`).Scan(&current)
+	if err != nil {
+		if strings.Contains(err.Error(), "no such table") {
+			return nil
+		}
+		return err
+	}
+	if !current.Valid {
+		return nil
+	}
+	if current.Int64 > maxKnownSchemaVersion {
+		return fmt.Errorf("gateway DB schema_migrations.version=%d exceeds this binary's max-known version %d — refusing to open (issue #196 rollback safety). Restore from pre-deploy snapshot.",
+			current.Int64, maxKnownSchemaVersion)
+	}
+	return nil
 }
 
 // ensureOAuthStateActionColumn handles upgrade-in-place for pre-existing
@@ -128,6 +208,124 @@ func (s *Store) ensureOAuthStateActionColumn(ctx context.Context) error {
 	}
 	_, err = s.db.ExecContext(ctx, `ALTER TABLE oauth_states ADD COLUMN action TEXT NOT NULL DEFAULT ''`)
 	return err
+}
+
+// ensureUsageEventsCompositePK upgrades pre-issue-#196 gateway.db files
+// whose `usage_events` table has PRIMARY KEY (request_id) — a global
+// uniqueness constraint that lets a buyer with two accounts collide on
+// the same X-Request-ID after streaming has flushed, escaping
+// settlement. The fix is composite PK (account_id, request_id).
+//
+// New installs land on the composite PK directly via schemaSQL. Old
+// installs need a table rebuild because SQLite cannot ALTER PRIMARY
+// KEY in place. Detection: PRAGMA table_info pk-column count and
+// names.
+//
+// The rebuild runs inside a single deferred-FK transaction so partial
+// state cannot leak. The append-only DELETE/UPDATE triggers and the
+// two secondary indexes ride along with the renamed table per SQLite
+// ALTER TABLE RENAME semantics (verified against the SQLite docs);
+// no manual recreate is needed.
+func (s *Store) ensureUsageEventsCompositePK(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, `PRAGMA table_info(usage_events)`)
+	if err != nil {
+		return err
+	}
+	type col struct {
+		name string
+		pk   int
+	}
+	var pkCols []col
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if pk > 0 {
+			pkCols = append(pkCols, col{name: name, pk: pk})
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	// Composite (account_id, request_id) — already migrated.
+	if len(pkCols) == 2 &&
+		((pkCols[0].name == "account_id" && pkCols[1].name == "request_id") ||
+			(pkCols[0].name == "request_id" && pkCols[1].name == "account_id")) {
+		return nil
+	}
+	// Anything other than the legacy single-column (request_id) PK is
+	// an unrecognized shape — bail loudly rather than corrupt data.
+	if !(len(pkCols) == 1 && pkCols[0].name == "request_id") {
+		return fmt.Errorf("usage_events PK shape unrecognized: %+v", pkCols)
+	}
+	// Rebuild. PRAGMA foreign_keys is OFF for the duration so the
+	// drop+rename does not trip cascading FK checks (usage_events is
+	// not a FK target today, but defensive). Restored on exit.
+	if _, err := s.db.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = s.db.ExecContext(ctx, `PRAGMA foreign_keys = ON`)
+	}()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	// Sequence: legacy → legacy_old (rename), then create the
+	// canonical usage_events with the new PK using its REAL name
+	// from the start. This keeps sqlite_master.sql for usage_events
+	// byte-equal between fresh installs and migrated DBs (an
+	// ALTER...RENAME would store `CREATE TABLE "usage_events"` with
+	// quotes — caught by ISS-196 R2 architect MEDIUM).
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE usage_events RENAME TO usage_events_legacy`); err != nil {
+		return fmt.Errorf("rename legacy usage_events aside: %w", err)
+	}
+	// Use the SAME usageEventsTableDDL the fresh-install path runs so
+	// sqlite_master.sql for usage_events is byte-equal across paths.
+	if _, err := tx.ExecContext(ctx, usageEventsTableDDL); err != nil {
+		return fmt.Errorf("create new usage_events: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO usage_events
+			(request_id, account_id, demo_identity, window_date,
+			 prompt_tokens, completion_tokens, total_tokens,
+			 token_source, outcome, created_at)
+		SELECT request_id, account_id, demo_identity, window_date,
+		       prompt_tokens, completion_tokens, total_tokens,
+		       token_source, outcome, created_at
+		FROM usage_events_legacy`); err != nil {
+		return fmt.Errorf("copy usage_events rows: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DROP TABLE usage_events_legacy`); err != nil {
+		return fmt.Errorf("drop legacy usage_events table: %w", err)
+	}
+	// Recreate the secondary indexes and append-only triggers. DROP
+	// TABLE removed them. The shared usageEventsAuxiliaryDDL constant
+	// is the SAME text Migrate() executes on a fresh install, so the
+	// post-migration sqlite_master entries are byte-for-byte identical
+	// — addresses architect R1 MEDIUM finding.
+	if _, err := tx.ExecContext(ctx, usageEventsAuxiliaryDDL); err != nil {
+		return fmt.Errorf("recreate usage_events index/trigger: %w", err)
+	}
+	// Stamp schema_migrations version 2 inside the SAME transaction as
+	// the rebuild. Without this atomicity, the rebuild could commit but
+	// the version stamp could fail — leaving a composite-PK DB with no
+	// v2 marker, which the next open (or an old binary) would treat as
+	// v1 and proceed against a shape it doesn't understand. ISS-196 R4
+	// architect HIGH.
+	if _, err := tx.ExecContext(ctx,
+		`INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(2, ?)`,
+		encodeTime(time.Now().UTC())); err != nil {
+		return fmt.Errorf("stamp schema_migrations v2 inside rebuild tx: %w", err)
+	}
+	return tx.Commit()
 }
 
 func (s *Store) CreateAccount(ctx context.Context, account storage.Account) error {
@@ -659,16 +857,30 @@ func (s *Store) InsertUsageEvent(ctx context.Context, event storage.UsageEvent) 
 // is missing or in an unexpected state, the buyer-facing usage record
 // MUST exist after bytes have flowed (issue #187).
 //
-// PK-collision verify (ISS-187 R1 code+security MAJOR): the gateway
-// `usage_events.request_id` is a GLOBAL primary key (issue #196,
-// pre-existing). If INSERT OR IGNORE silently no-ops on conflict,
-// an attacker with two accounts could collide a request_id and skip
-// the audit row. EnsureUsageEvent now checks RowsAffected; on 0, it
-// reads the existing row and confirms (account_id, demo_identity,
-// token_source, outcome) MATCH the incoming event. If they
-// disagree, returns ErrUsageEventConflict so the caller knows the
-// fallback failed and must refund.
+// PK-collision verify (ISS-187 R1 code+security MAJOR): historically
+// the gateway `usage_events.request_id` was a GLOBAL primary key,
+// allowing cross-account collisions (issue #196). The schema is now
+// `(account_id, request_id)`, so the only legitimate INSERT OR IGNORE
+// no-op is a same-account retry — typically a SPEC-006 § 17.7 fallback
+// firing again after the primary settle path. EnsureUsageEvent still
+// checks RowsAffected on 0 and verifies the full billing payload
+// (tokens + window + identity) matches; a mismatch returns
+// ErrUsageEventConflict so the caller knows the fallback failed and
+// must refund. With the composite PK the cross-account branch can no
+// longer occur — the verify is retained as defense in depth against
+// same-account payload drift (e.g. two settle paths racing with
+// different token counts).
 func (s *Store) EnsureUsageEvent(ctx context.Context, event storage.UsageEvent) error {
+	// Normalize identically to insertUsageEventExec so the post-insert
+	// payload comparison below reads the same TotalTokens value that
+	// is persisted on disk. Without this, a benign retry that passes
+	// TotalTokens=0 (with prompt+completion set) would compare 0
+	// against the row's normalized prompt+completion sum and
+	// falsely return ErrUsageEventConflict, triggering a wrong
+	// refund. Caught by ISS-196 R2 codex CODE MEDIUM.
+	if event.TotalTokens == 0 {
+		event.TotalTokens = event.PromptTokens + event.CompletionTokens
+	}
 	result, err := s.insertUsageEventExec(ctx, event, true)
 	if err != nil {
 		return err
@@ -702,7 +914,7 @@ func (s *Store) EnsureUsageEvent(ctx context.Context, event storage.UsageEvent) 
 	}
 	if err := s.db.QueryRowContext(ctx, `
 		SELECT account_id, demo_identity, window_date, prompt_tokens, completion_tokens, total_tokens, token_source, outcome
-		FROM usage_events WHERE request_id = ?`, event.RequestID).Scan(
+		FROM usage_events WHERE account_id = ? AND request_id = ?`, event.AccountID, event.RequestID).Scan(
 		&existing.AccountID, &existing.DemoIdentity, &existing.WindowDate,
 		&existing.PromptTokens, &existing.CompletionTokens, &existing.TotalTokens,
 		&existing.TokenSource, &existing.Outcome,

--- a/phase5-gateway/internal/storage/sqlite/usage_events_pk_test.go
+++ b/phase5-gateway/internal/storage/sqlite/usage_events_pk_test.go
@@ -1,0 +1,527 @@
+// Regression coverage for issue #196 — usage_events PRIMARY KEY is
+// (account_id, request_id). Pre-issue-#196 the PK was just
+// (request_id), which let two accounts collide on the same buyer-
+// supplied X-Request-ID, escaping settlement after the streaming
+// response had already flushed bytes to the buyer.
+//
+// Three checks here:
+//
+//   1. Cross-account collision now SUCCEEDS — both accounts get their
+//      own row. This is the core acceptance criterion for #196.
+//   2. Same-account collision still no-ops via INSERT OR IGNORE and
+//      the EnsureUsageEvent payload verify still returns
+//      ErrUsageEventConflict on a payload mismatch. Confirms the
+//      composite PK didn't accidentally re-open the same-account
+//      double-bill window.
+//   3. A pre-existing gateway.db with the legacy single-column PK
+//      survives Migrate(), gets rebuilt into the composite shape,
+//      preserves all rows, AND the append-only triggers + indexes
+//      are recreated.
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-gateway/internal/storage"
+)
+
+func TestUsageEventsCrossAccountCollisionInsertsBothRows(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	const sharedRequestID = "shared-uuid-1234"
+	eventA := storage.UsageEvent{
+		RequestID: sharedRequestID, AccountID: "acct_A",
+		WindowDate: "2026-06-28", PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15,
+		TokenSource: "provider_reported", Outcome: "ok", CreatedAt: fixedTime(),
+	}
+	eventB := storage.UsageEvent{
+		RequestID: sharedRequestID, AccountID: "acct_B",
+		WindowDate: "2026-06-28", PromptTokens: 20, CompletionTokens: 7, TotalTokens: 27,
+		TokenSource: "provider_reported", Outcome: "ok", CreatedAt: fixedTime(),
+	}
+	if err := store.EnsureUsageEvent(ctx, eventA); err != nil {
+		t.Fatalf("EnsureUsageEvent(A): %v", err)
+	}
+	if err := store.EnsureUsageEvent(ctx, eventB); err != nil {
+		t.Fatalf("EnsureUsageEvent(B) — composite PK should allow cross-account collision, got: %v", err)
+	}
+
+	rows, err := store.db.QueryContext(ctx, `
+		SELECT account_id, total_tokens FROM usage_events WHERE request_id = ? ORDER BY account_id`,
+		sharedRequestID)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	var got []struct {
+		acct   string
+		tokens int64
+	}
+	for rows.Next() {
+		var s struct {
+			acct   string
+			tokens int64
+		}
+		if err := rows.Scan(&s.acct, &s.tokens); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, s)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 rows after cross-account collision, got %d: %+v", len(got), got)
+	}
+	if got[0].acct != "acct_A" || got[0].tokens != 15 {
+		t.Errorf("row 0 = %+v, want {acct_A, 15}", got[0])
+	}
+	if got[1].acct != "acct_B" || got[1].tokens != 27 {
+		t.Errorf("row 1 = %+v, want {acct_B, 27}", got[1])
+	}
+}
+
+func TestUsageEventsSameAccountCollisionStillVerifies(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	base := storage.UsageEvent{
+		RequestID: "req-same-1", AccountID: "acct_A",
+		WindowDate: "2026-06-28", PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15,
+		TokenSource: "provider_reported", Outcome: "ok", CreatedAt: fixedTime(),
+	}
+	if err := store.EnsureUsageEvent(ctx, base); err != nil {
+		t.Fatalf("first EnsureUsageEvent: %v", err)
+	}
+
+	// Same (account, request) with identical payload — must no-op cleanly.
+	if err := store.EnsureUsageEvent(ctx, base); err != nil {
+		t.Fatalf("idempotent retry must succeed: %v", err)
+	}
+
+	// Same (account, request) but the caller is trying to bill MORE
+	// tokens. Must surface ErrUsageEventConflict — same-account
+	// payload-drift attack would otherwise be silenced.
+	drifted := base
+	drifted.CompletionTokens = 500
+	drifted.TotalTokens = 510
+	if err := store.EnsureUsageEvent(ctx, drifted); !errors.Is(err, storage.ErrUsageEventConflict) {
+		t.Fatalf("payload-drift retry: err = %v, want ErrUsageEventConflict", err)
+	}
+}
+
+func TestUsageEventsCompositePKUpgradeFromLegacyPK(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "legacy-gateway.db")
+
+	// Stand up the LEGACY schema directly via raw sql.DB, then close.
+	// This simulates a gateway.db file written by any pre-issue-#196
+	// build. The schema below is the on-disk state from
+	// migrate.go on origin/main prior to this commit.
+	rawDB, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	legacyDDL := []string{
+		`CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)`,
+		`CREATE TABLE accounts (account_id TEXT PRIMARY KEY, status TEXT NOT NULL, quota_class TEXT NOT NULL, concurrency_class TEXT NOT NULL, created_at TEXT NOT NULL)`,
+		`CREATE TABLE usage_events (
+			request_id TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL,
+			demo_identity TEXT NOT NULL DEFAULT '',
+			window_date TEXT NOT NULL,
+			prompt_tokens INTEGER NOT NULL CHECK (prompt_tokens >= 0),
+			completion_tokens INTEGER NOT NULL CHECK (completion_tokens >= 0),
+			total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
+			token_source TEXT NOT NULL CHECK (token_source IN ('provider_reported', 'gateway_estimated', 'manual_fixture')),
+			outcome TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX idx_usage_account_date ON usage_events(account_id, window_date)`,
+		`CREATE INDEX idx_usage_created_at ON usage_events(created_at)`,
+		`CREATE TRIGGER usage_events_no_update BEFORE UPDATE ON usage_events
+			BEGIN SELECT RAISE(ABORT, 'usage_events are append-only'); END`,
+		`CREATE TRIGGER usage_events_no_delete BEFORE DELETE ON usage_events
+			BEGIN SELECT RAISE(ABORT, 'usage_events are append-only'); END`,
+	}
+	for _, d := range legacyDDL {
+		if _, err := rawDB.ExecContext(ctx, d); err != nil {
+			t.Fatalf("legacy DDL %q: %v", strings.SplitN(d, "(", 2)[0], err)
+		}
+	}
+	// Seed two pre-existing rows. The legacy PK forbids two accounts
+	// sharing a request_id, so we use distinct request_ids here.
+	for _, seed := range []struct {
+		req, acct string
+		tokens    int64
+	}{
+		{"legacy-req-1", "acct_X", 100},
+		{"legacy-req-2", "acct_Y", 200},
+	} {
+		if _, err := rawDB.ExecContext(ctx, `
+			INSERT INTO usage_events(request_id, account_id, window_date, prompt_tokens, completion_tokens, total_tokens, token_source, outcome, created_at)
+			VALUES(?, ?, '2026-06-27', 0, ?, ?, 'provider_reported', 'ok', '2026-06-27T00:00:00Z')`,
+			seed.req, seed.acct, seed.tokens, seed.tokens); err != nil {
+			t.Fatalf("seed %s: %v", seed.req, err)
+		}
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	// Open the file via the real Store. Migrate() must detect the
+	// legacy PK shape and rebuild atomically.
+	store, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open (triggers migration): %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Composite PK now in place.
+	pkCols := readPKColumns(t, store, "usage_events")
+	if len(pkCols) != 2 || pkCols[0] != "account_id" || pkCols[1] != "request_id" {
+		t.Fatalf("post-migration PK cols = %v, want [account_id request_id]", pkCols)
+	}
+
+	// Both seeded rows preserved.
+	for _, want := range []struct {
+		req, acct string
+		tokens    int64
+	}{
+		{"legacy-req-1", "acct_X", 100},
+		{"legacy-req-2", "acct_Y", 200},
+	} {
+		var gotAcct string
+		var gotTotal int64
+		if err := store.db.QueryRowContext(ctx, `
+			SELECT account_id, total_tokens FROM usage_events WHERE request_id = ?`,
+			want.req).Scan(&gotAcct, &gotTotal); err != nil {
+			t.Fatalf("lookup %s: %v", want.req, err)
+		}
+		if gotAcct != want.acct || gotTotal != want.tokens {
+			t.Errorf("%s: got (%s, %d), want (%s, %d)", want.req, gotAcct, gotTotal, want.acct, want.tokens)
+		}
+	}
+
+	// Append-only DELETE trigger still fires.
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM usage_events WHERE request_id = 'legacy-req-1'`); err == nil {
+		t.Fatal("DELETE on usage_events after migration unexpectedly succeeded; append-only trigger lost")
+	}
+
+	// Cross-account collision now works.
+	createAccount(t, store, "acct_A")
+	createAccount(t, store, "acct_B")
+	if err := store.EnsureUsageEvent(ctx, storage.UsageEvent{
+		RequestID: "shared-after-migration", AccountID: "acct_A",
+		WindowDate: "2026-06-28", PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2,
+		TokenSource: "provider_reported", Outcome: "ok", CreatedAt: fixedTime(),
+	}); err != nil {
+		t.Fatalf("post-migration insert A: %v", err)
+	}
+	if err := store.EnsureUsageEvent(ctx, storage.UsageEvent{
+		RequestID: "shared-after-migration", AccountID: "acct_B",
+		WindowDate: "2026-06-28", PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2,
+		TokenSource: "provider_reported", Outcome: "ok", CreatedAt: fixedTime(),
+	}); err != nil {
+		t.Fatalf("post-migration cross-account insert B (composite PK was supposed to allow this): %v", err)
+	}
+
+	// Secondary indexes recreated — query the index list and confirm
+	// both are present on the renamed table.
+	var idxNames []string
+	rows, err := store.db.QueryContext(ctx, `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'usage_events' ORDER BY name`)
+	if err != nil {
+		t.Fatalf("query indexes: %v", err)
+	}
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			rows.Close()
+			t.Fatalf("scan index name: %v", err)
+		}
+		idxNames = append(idxNames, n)
+	}
+	rows.Close()
+	wantIdx := map[string]bool{"idx_usage_account_date": true, "idx_usage_created_at": true}
+	for _, n := range idxNames {
+		delete(wantIdx, n)
+	}
+	if len(wantIdx) > 0 {
+		t.Errorf("missing indexes after migration: %v (got: %v)", wantIdx, idxNames)
+	}
+}
+
+// TestExplorerSessionDetailAmbiguityWhenAccountIDOmitted pins the
+// ISS-196 R1 architect + security HIGH finding: with composite PK,
+// a request_id can resolve to multiple accounts. ExplorerSessionDetail
+// MUST detect the unscoped-lookup ambiguity and surface
+// ErrExplorerAmbiguousRequestID with the matching account list,
+// rather than silently returning one arbitrary row.
+func TestExplorerSessionDetailAmbiguityWhenAccountIDOmitted(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	const sharedRequestID = "amb-uuid-0001"
+	createAccount(t, store, "acct_A")
+	createAccount(t, store, "acct_B")
+	for _, acct := range []string{"acct_A", "acct_B"} {
+		if err := store.EnsureUsageEvent(ctx, storage.UsageEvent{
+			RequestID: sharedRequestID, AccountID: acct,
+			WindowDate: "2026-06-28", PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2,
+			TokenSource: "provider_reported", Outcome: "ok", CreatedAt: fixedTime(),
+		}); err != nil {
+			t.Fatalf("EnsureUsageEvent(%s): %v", acct, err)
+		}
+	}
+	// Unscoped lookup — must surface ambiguity, not a silent winner.
+	got, err := store.ExplorerSessionDetail(ctx, "", sharedRequestID)
+	if !errors.Is(err, storage.ErrExplorerAmbiguousRequestID) {
+		t.Fatalf("unscoped lookup: err=%v, want ErrExplorerAmbiguousRequestID", err)
+	}
+	if len(got.MatchedAccountIDs) != 2 {
+		t.Fatalf("MatchedAccountIDs=%v, want both accounts", got.MatchedAccountIDs)
+	}
+	if got.MatchedAccountIDs[0] != "acct_A" || got.MatchedAccountIDs[1] != "acct_B" {
+		t.Errorf("MatchedAccountIDs=%v, want [acct_A acct_B] (sorted)", got.MatchedAccountIDs)
+	}
+	// Scoped lookup — must return the right account's row.
+	scopedA, err := store.ExplorerSessionDetail(ctx, "acct_A", sharedRequestID)
+	if err != nil {
+		t.Fatalf("scoped(acct_A) lookup: %v", err)
+	}
+	if scopedA.UsageEvent == nil || scopedA.UsageEvent.AccountID != "acct_A" {
+		t.Errorf("scoped(acct_A).UsageEvent=%+v, want acct_A row", scopedA.UsageEvent)
+	}
+	// Wrong-account scoped lookup → ErrNotFound, NOT cross-account leak.
+	if _, err := store.ExplorerSessionDetail(ctx, "acct_NONE", sharedRequestID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("scoped(acct_NONE) lookup: err=%v, want ErrNotFound", err)
+	}
+}
+
+// TestSchemaVersionGateRejectsNewerDB pins the ISS-196 R1 architect
+// HIGH "rollback" finding: an older binary opening a DB whose
+// schema_migrations.version exceeds the binary's max-known version
+// MUST refuse to open, preventing the legacy `WHERE request_id = ?`
+// path from returning wrong-account rows on a downgrade.
+func TestSchemaVersionGateRejectsNewerDB(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "future-gateway.db")
+	// Open + Migrate normally, then bump the version past
+	// maxKnownSchemaVersion to simulate a future-binary DB.
+	store, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(?, ?)`,
+		maxKnownSchemaVersion+1, encodeTime(fixedTime())); err != nil {
+		t.Fatalf("stamp future version: %v", err)
+	}
+	_ = store.Close()
+	// Re-open: must fail closed.
+	store2, err := Open(ctx, path)
+	if err == nil {
+		_ = store2.Close()
+		t.Fatal("Open on future-version DB unexpectedly succeeded; rollback safety regressed")
+	}
+	if !strings.Contains(err.Error(), "exceeds this binary's max-known version") {
+		t.Errorf("error = %q, want 'exceeds this binary's max-known version'", err.Error())
+	}
+}
+
+// TestUsageEventsCompositePKAndSchemaV2CommitAtomically pins ISS-196
+// R4 architect HIGH: the table rebuild and the
+// schema_migrations.version=2 stamp MUST commit in the SAME
+// transaction. Otherwise a rebuild that committed but a stamp that
+// failed in a prior run could leave a composite-PK DB with version=1,
+// which an old binary would mishandle. We verify atomicity by
+// inspecting the migrated DB: composite shape AND v2 marker must
+// both be present whenever the rebuild path runs.
+func TestUsageEventsCompositePKAndSchemaV2CommitAtomically(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "atomic-gateway.db")
+	rawDB, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	for _, d := range []string{
+		`CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)`,
+		`CREATE TABLE accounts (account_id TEXT PRIMARY KEY, status TEXT NOT NULL, quota_class TEXT NOT NULL, concurrency_class TEXT NOT NULL, created_at TEXT NOT NULL)`,
+		`CREATE TABLE usage_events (
+			request_id TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL,
+			demo_identity TEXT NOT NULL DEFAULT '',
+			window_date TEXT NOT NULL,
+			prompt_tokens INTEGER NOT NULL CHECK (prompt_tokens >= 0),
+			completion_tokens INTEGER NOT NULL CHECK (completion_tokens >= 0),
+			total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
+			token_source TEXT NOT NULL CHECK (token_source IN ('provider_reported', 'gateway_estimated', 'manual_fixture')),
+			outcome TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)`,
+		`INSERT INTO schema_migrations VALUES (1, '2026-06-01T00:00:00Z')`,
+	} {
+		if _, err := rawDB.ExecContext(ctx, d); err != nil {
+			t.Fatalf("legacy DDL: %v", err)
+		}
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+	store, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open (triggers migration): %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Composite PK installed.
+	pkCols := readPKColumns(t, store, "usage_events")
+	if !(len(pkCols) == 2 && pkCols[0] == "account_id" && pkCols[1] == "request_id") {
+		t.Fatalf("post-migration PK = %v, want composite [account_id request_id]", pkCols)
+	}
+	// And v2 stamp present.
+	var maxVer sql.NullInt64
+	if err := store.db.QueryRowContext(ctx, `SELECT MAX(version) FROM schema_migrations`).Scan(&maxVer); err != nil {
+		t.Fatalf("read schema_migrations: %v", err)
+	}
+	if !maxVer.Valid || maxVer.Int64 < 2 {
+		t.Errorf("schema_migrations max version = %v, want >= 2 (must be stamped atomically with rebuild)", maxVer)
+	}
+}
+
+// TestUsageEventsSqliteMasterByteIdenticalAcrossPaths pins ISS-196
+// R2 architect MEDIUM: schema-comparison tools (sqldiff, dbschema)
+// expect the post-migration sqlite_master.sql entries for
+// usage_events + indexes + triggers to be byte-for-byte identical
+// to a fresh install. The rebuild-and-rename pattern in
+// ensureUsageEventsCompositePK uses the shared usageEventsTableDDL
+// / usageEventsAuxiliaryDDL constants for exactly this reason.
+func TestUsageEventsSqliteMasterByteIdenticalAcrossPaths(t *testing.T) {
+	ctx := context.Background()
+	freshStore := newTestStore(t)
+	freshMaster := readUsageEventsMaster(t, freshStore)
+
+	// Migrated store: build from legacy schema, then Open via the
+	// real Store which runs ensureUsageEventsCompositePK.
+	path := filepath.Join(t.TempDir(), "migrated-gateway.db")
+	rawDB, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	legacyDDL := []string{
+		`CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)`,
+		`CREATE TABLE accounts (account_id TEXT PRIMARY KEY, status TEXT NOT NULL, quota_class TEXT NOT NULL, concurrency_class TEXT NOT NULL, created_at TEXT NOT NULL)`,
+		`CREATE TABLE usage_events (
+			request_id TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL,
+			demo_identity TEXT NOT NULL DEFAULT '',
+			window_date TEXT NOT NULL,
+			prompt_tokens INTEGER NOT NULL CHECK (prompt_tokens >= 0),
+			completion_tokens INTEGER NOT NULL CHECK (completion_tokens >= 0),
+			total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
+			token_source TEXT NOT NULL CHECK (token_source IN ('provider_reported', 'gateway_estimated', 'manual_fixture')),
+			outcome TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX idx_usage_account_date ON usage_events(account_id, window_date)`,
+		`CREATE INDEX idx_usage_created_at ON usage_events(created_at)`,
+		`CREATE TRIGGER usage_events_no_update BEFORE UPDATE ON usage_events
+			BEGIN SELECT RAISE(ABORT, 'usage_events are append-only'); END`,
+		`CREATE TRIGGER usage_events_no_delete BEFORE DELETE ON usage_events
+			BEGIN SELECT RAISE(ABORT, 'usage_events are append-only'); END`,
+	}
+	for _, d := range legacyDDL {
+		if _, err := rawDB.ExecContext(ctx, d); err != nil {
+			t.Fatalf("legacy DDL: %v", err)
+		}
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+	migrated, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open (triggers migration): %v", err)
+	}
+	t.Cleanup(func() { _ = migrated.Close() })
+	migratedMaster := readUsageEventsMaster(t, migrated)
+
+	if len(freshMaster) != len(migratedMaster) {
+		t.Fatalf("master row counts differ: fresh=%d migrated=%d", len(freshMaster), len(migratedMaster))
+	}
+	for name, freshSQL := range freshMaster {
+		migSQL, ok := migratedMaster[name]
+		if !ok {
+			t.Errorf("migrated master missing %q", name)
+			continue
+		}
+		if freshSQL != migSQL {
+			t.Errorf("sqlite_master.sql diverges for %q\n  fresh:    %q\n  migrated: %q", name, freshSQL, migSQL)
+		}
+	}
+}
+
+// readUsageEventsMaster returns name → sql for every sqlite_master
+// row attached to the usage_events table (table itself + indexes +
+// triggers), skipping auto-generated entries.
+func readUsageEventsMaster(t *testing.T, store *Store) map[string]string {
+	t.Helper()
+	rows, err := store.db.QueryContext(context.Background(), `
+		SELECT name, COALESCE(sql, '') FROM sqlite_master
+		WHERE tbl_name = 'usage_events' AND name NOT LIKE 'sqlite_autoindex_%'
+		ORDER BY name`)
+	if err != nil {
+		t.Fatalf("query sqlite_master: %v", err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var name, sqlText string
+		if err := rows.Scan(&name, &sqlText); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out[name] = sqlText
+	}
+	return out
+}
+
+func readPKColumns(t *testing.T, store *Store, table string) []string {
+	t.Helper()
+	rows, err := store.db.QueryContext(context.Background(), `PRAGMA table_info(`+table+`)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	defer rows.Close()
+	type colInfo struct {
+		name string
+		pk   int
+	}
+	var pkCols []colInfo
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if pk > 0 {
+			pkCols = append(pkCols, colInfo{name: name, pk: pk})
+		}
+	}
+	// Sort by pk column index (1, 2, ...).
+	for i := 0; i < len(pkCols); i++ {
+		for j := i + 1; j < len(pkCols); j++ {
+			if pkCols[j].pk < pkCols[i].pk {
+				pkCols[i], pkCols[j] = pkCols[j], pkCols[i]
+			}
+		}
+	}
+	out := make([]string, len(pkCols))
+	for i, c := range pkCols {
+		out[i] = c.name
+	}
+	return out
+}

--- a/phase5-gateway/internal/storage/types.go
+++ b/phase5-gateway/internal/storage/types.go
@@ -344,13 +344,20 @@ type ExplorerSessionList struct {
 
 type ExplorerSessionDetail struct {
 	RequestID              string                          `json:"request_id"`
+	AccountID              string                          `json:"account_id,omitempty"`
 	UsageEvent             *ExplorerUsageEvent             `json:"usage_event"`
 	QuotaReservation       *ExplorerQuotaReservation       `json:"quota_reservation"`
 	ConcurrencyReservation *ExplorerConcurrencyReservation `json:"concurrency_reservation"`
 	FeedbackEvents         []ExplorerFeedbackEvent         `json:"feedback_events"`
 	AuditEvents            []ExplorerAuditEvent            `json:"audit_events"`
-	Partial                bool                            `json:"partial"`
-	Error                  any                             `json:"error"`
+	// MatchedAccountIDs is populated when the lookup is ambiguous —
+	// i.e. accountID was empty AND the request_id resolves to rows
+	// from multiple accounts (issue #196 composite-PK semantics).
+	// Returned together with ErrExplorerAmbiguousRequestID so the
+	// caller can re-issue scoped lookups.
+	MatchedAccountIDs []string `json:"matched_account_ids,omitempty"`
+	Partial           bool     `json:"partial"`
+	Error             any      `json:"error"`
 }
 
 type ExplorerUsageEvent struct {

--- a/specs/AUDIT_ISS_196_R1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,84 @@
+# Audit prompt — ISS-196 R1 ARCHITECT lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` to `(account_id, request_id)` to close [issue #196](https://github.com/Augustas11/macprovider/issues/196).
+
+## Audit lens — ARCHITECTURE / INVARIANTS
+
+You are the architect. Hold the PR to system invariants that span beyond the
+files changed. Severity bar:
+
+- **CRITICAL** — fix violates a spec, breaks a load-bearing invariant, or
+  introduces a new one inconsistent with neighboring tables.
+- **HIGH** — design pattern divergence from existing migrations (e.g.,
+  `ensureOAuthStateActionColumn` set a precedent for in-place upgrade —
+  is the new function consistent with that pattern?), or a missed
+  cross-cutting consequence (explorer queries, reconciler scripts,
+  audit-trail JOINs, deploy gates).
+- **MEDIUM** — documentation drift between spec and implementation;
+  forward-compatibility concerns for downstream tooling.
+- **LOW** — won't file.
+
+## Concrete things to check
+
+1. **SPEC alignment.** SPEC-005 § BL-1 / BL-2 (billing ledger
+   invariants) and SPEC-006 § 17.7 (settle-after-commit fallback).
+   Does the composite PK preserve the documented uniqueness
+   guarantees? Does any spec document need an addendum to describe
+   the change?
+2. **Append-only triggers.** The migration drops + recreates the
+   `usage_events_no_update` and `usage_events_no_delete` triggers
+   manually inside the rebuild. Is this consistent with how
+   `schemaSQL` declares them? Drift between the migration's trigger
+   bodies and the canonical schemaSQL bodies?
+3. **Symmetry with `quota_reservations` / `concurrency_reservations`.**
+   Those tables already have composite PK `(account_id, request_id)`.
+   Does usage_events now match the same shape, conventions,
+   index naming? Any reconcile-script that joins all three tables?
+4. **Per-account ordering / sort columns.** Now that
+   `(account_id, request_id)` is the PK, the natural query order is
+   account-prefixed. Are there explorer/reconciler queries that
+   relied on `request_id`-only sort and now do a full scan? Look at
+   `explorer.go:64` (latest request per account) and `:299`
+   (timeline). Look at SPEC-006 § 14.3 demo audit join.
+5. **Forward-compatibility with SPEC-002 v1.4.2 `external_request_id`
+   work (PR #195 / #192).** That work adds buyer-vs-internal request
+   id distinction. Does this PR's composite-PK rebuild interact
+   correctly with the `external_request_id` column added on the
+   coordinator side? (Different DB, but architectural alignment.)
+6. **Existing in-place upgrade pattern.** `ensureOAuthStateActionColumn`
+   uses `ALTER TABLE ADD COLUMN` — additive, low-risk. This new
+   function does a full table rebuild — more invasive. Is the
+   precedent / blast radius documented? Is there a SPEC-XXX
+   addendum or DECISION_CRITERIA.md entry warranted?
+7. **Downgrade story.** Operator runs deploy, picks up the new
+   binary, migration runs. If they need to roll back to the
+   previous binary, can it open the migrated DB? (Old binary
+   expects single-column PK schema — would it crash on Open or
+   just keep working since CREATE IF NOT EXISTS is a no-op?)
+8. **Naming.** `idx_usage_account_date` was created before this
+   change; the composite PK now provides `(account_id, ...)`
+   index-like access. Is the secondary index redundant? (Probably
+   not — `(account_id, window_date)` is more specific — but worth
+   flagging if it is.)
+9. **`schemaSQL` source of truth.** New installs land at composite
+   PK directly via schemaSQL; old installs go through the upgrade
+   function. The two paths must converge byte-for-byte. Does the
+   trigger-body whitespace in the upgrade function exactly match
+   schemaSQL? (Tabs vs spaces, etc. — affects schema hash
+   comparisons in tools like sqldiff.)
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>  (or "design" / "spec")
+DETAIL: <invariant violated; cross-system impact>
+SUGGESTED FIX: <action — spec amendment, code change, or doc>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.

--- a/specs/AUDIT_ISS_196_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R1_CODE_PROMPT.md
@@ -1,0 +1,103 @@
+# Audit prompt — ISS-196 R1 CODE lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` — a global unique constraint — to
+`(account_id, request_id)` — composite, per-account uniqueness.
+
+This is the fix for [issue #196](https://github.com/Augustas11/macprovider/issues/196):
+a buyer controlling two accounts could supply the same buyer-controlled
+`X-Request-ID` and collide on the global PK after the streaming
+response had already flushed bytes to the buyer, escaping settlement.
+
+## Files in scope
+
+- `phase5-gateway/internal/storage/sqlite/migrate.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/internal/storage/sqlite/usage_events_pk_test.go` (new)
+- `phase5-gateway/internal/router/server_test.go`
+
+## Audit lens — CODE correctness
+
+You are a senior Go reviewer paid to find bugs that ship. Limit findings to the diff
+plus the migration runtime path. Apply this severity bar:
+
+- **CRITICAL** — provable wrong behavior under normal operation, or a
+  data-loss / data-corruption pattern in the migration.
+- **HIGH** — a correctness bug that would fire under specific real-world
+  inputs (race, panic-on-nil, wrong column count, broken sql query,
+  silent ignore of a return value that's load-bearing).
+- **MEDIUM** — pattern that *could* break under refactor or atypical
+  driver behavior; missing test for a non-obvious branch.
+- **LOW / IGNORE** — style, naming, comment polish, alternative idioms
+  with no behavior delta. Do not file.
+
+## Concrete things to look for
+
+1. **Migration atomicity.** The `ensureUsageEventsCompositePK` rebuild
+   runs `CREATE`, `INSERT ... SELECT`, `DROP`, `ALTER ... RENAME`,
+   then four `CREATE INDEX/TRIGGER` inside a single transaction. Are
+   any of those DDL statements implicit-commit on the modernc SQLite
+   driver? Will a failure in step 3 (DROP) actually roll back? Does
+   `PRAGMA foreign_keys = OFF` inside a transaction work as
+   expected?
+2. **Column-order assumption.** The `INSERT INTO usage_events_new
+   SELECT ... FROM usage_events` selects 10 named columns explicitly
+   — is the column list complete vs the legacy schema? Are CHECK
+   constraints preserved?
+3. **PK-shape detection.** `ensureUsageEventsCompositePK` reads
+   `PRAGMA table_info` and inspects `pk > 0`. Confirm SQLite reports
+   pk=1 for a single-column PK and pk=1, pk=2 for a composite. What
+   about a future amendment that adds a third PK column?
+4. **`EnsureUsageEvent` payload-verify.** The lookup query changed
+   from `WHERE request_id = ?` to `WHERE account_id = ? AND
+   request_id = ?`. Does this work for every call site? Are there
+   any callers that don't have `event.AccountID` populated?
+5. **`INSERT OR IGNORE` semantics under composite PK.** Same
+   `(account_id, request_id)` retry must no-op (same-account
+   idempotency); different `(account_id, request_id)` must insert a
+   new row. The new test asserts both. Are there race scenarios the
+   tests miss (e.g., two goroutines retrying the same
+   `(account, request)` concurrently)?
+6. **Idempotency of the migration.** Running `Migrate()` twice on a
+   freshly-built composite-PK DB must be a no-op. Running it on a
+   half-migrated DB (e.g., process killed mid-rebuild) — what
+   happens? Is `usage_events_new` left over?
+7. **`Migrate()` ordering.** `ensureUsageEventsCompositePK` runs
+   AFTER `schemaSQL`. On a new install, schemaSQL creates the table
+   with the composite PK directly, so the upgrade function detects
+   it and returns. On an old install, schemaSQL is a no-op (CREATE
+   IF NOT EXISTS), then the upgrade runs. Both paths converge.
+   Confirm there's no DB state where this ordering produces a
+   broken result.
+8. **Test coverage.** Three new tests in `usage_events_pk_test.go`
+   plus one updated test in `server_test.go`. Are any code paths in
+   the new function untested? Specifically the
+   `len(pkCols) != 1 || pkCols[0].name != "request_id"` defensive
+   bail.
+
+## Output format
+
+Return findings as a JSON-friendly markdown block with this shape:
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>
+DETAIL: <why this is wrong, concrete trigger if needed>
+SUGGESTED FIX: <one-line>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.
+
+## R2 update — what changed since R1
+
+- Rebased onto current main (ad76194 includes #193 — drops the R1 stale-base false positives).
+- Added `usageEventsAuxiliaryDDL` shared constant — Migrate() and ensureUsageEventsCompositePK() both execute it; sqlite_master entries byte-equal.
+- Added `maxKnownSchemaVersion = 2` + `checkSchemaVersionGate` — Open refuses if DB has a higher version (rollback safety).
+- Added `accountID` param to `ExplorerSessionDetail` + ambiguity detection.
+- Filed #210 (demo_usage_events) and #211 (coord request_log) as out-of-scope follow-ups.
+
+Re-audit the diff vs ad76194 against the same severity bar.

--- a/specs/AUDIT_ISS_196_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R1_SECURITY_PROMPT.md
@@ -1,0 +1,87 @@
+# Audit prompt — ISS-196 R1 SECURITY lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` to `(account_id, request_id)` to close the [issue #196](https://github.com/Augustas11/macprovider/issues/196)
+cross-account collision attack.
+
+## The attack we're closing
+
+A buyer controlling two accounts (A, B) supplies the SAME UUIDv4
+`X-Request-ID` from both. Pre-fix:
+
+1. Account A fires a streaming chat completion. Settles cleanly.
+2. Account B fires same prompt + same X-Request-ID. Gateway forwards,
+   streams response back to buyer, attempts to settle. SQLite
+   `INSERT INTO usage_events` fails on global PK collision (request_id
+   already used by A). Account B gets the inference output without
+   being debited.
+
+Post-fix: PK is `(account_id, request_id)` so B's settlement INSERT
+succeeds on the composite key, B is debited, and the audit trail has
+both rows.
+
+## Audit lens — SECURITY
+
+You are a security reviewer pretending to be the attacker. Limit
+findings to the diff. Severity bar:
+
+- **CRITICAL** — a working exploit path that survives this fix.
+- **HIGH** — a different abuse surface (DoS, audit-trail poisoning,
+  reservation leak) opened or unblocked by the schema/runtime change.
+- **MEDIUM** — defense-in-depth gap that compounds another bug.
+- **LOW** — won't file.
+
+## Concrete things to attack
+
+1. **The original exploit, residual paths.** Confirm cross-account
+   collision IS now closed end-to-end. Both `settleAfterCommit` /
+   `SettleReservation` (plain `INSERT`) and the `EnsureUsageEvent`
+   fallback (INSERT OR IGNORE + verify) — does either path still
+   silently swallow a cross-account collision?
+2. **The migration window.** During the table rebuild, a concurrent
+   in-flight inference settle could write to the OLD `usage_events`
+   table after we've already started `INSERT INTO ... SELECT`. Is
+   that handled? (Hint: the gateway is single-process; check if
+   anything else can write during Migrate.)
+3. **`demo_usage_events` parallel surface.** That table still has
+   `request_id PRIMARY KEY` (global). Is it also exploitable for a
+   buyer running through demo tokens? If so, file as a separate
+   issue (don't expand scope of this PR), but note it.
+4. **`audit_events.request_id`.** Has `request_id TEXT NOT NULL` with
+   no uniqueness constraint, only an index. Cross-account collision
+   here doesn't matter for billing, but does it confuse explorer or
+   reconciliation queries?
+5. **`signup_events` / `quota_reservations` / `concurrency_reservations`.**
+   Quota and concurrency reservations are already
+   `PRIMARY KEY (account_id, request_id)` — the right shape. Confirm
+   the PR doesn't accidentally regress them.
+6. **Buyer-supplied X-Request-ID still admitted.** The fix doesn't
+   block buyer-controlled UUIDs (intentional, to preserve buyer
+   correlation). Confirm there's no new path where a malicious
+   X-Request-ID can corrupt indexes, fool the explorer's
+   per-account-last-request lookup, or DoS the gateway.
+7. **`EnsureUsageEvent` payload-verify behavior after fix.** The
+   cross-account branch can no longer occur. Same-account payload
+   drift still triggers `ErrUsageEventConflict`. Is there a scenario
+   where same-account RETRY with legitimately-different tokens
+   (e.g., upstream provider corrected its usage block on retry)
+   gets falsely rejected and causes a refund the buyer didn't
+   deserve?
+8. **Rollback / downgrade.** If a future deploy reverts to the old
+   binary, can the composite-PK DB still serve reads? Writes? Any
+   data-loss risk on downgrade?
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>  (or "behavioral" if not file-bound)
+EXPLOIT: <step-by-step trigger or attack scenario>
+SUGGESTED FIX: <one-line>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.

--- a/specs/AUDIT_ISS_196_R2_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R2_ARCHITECT_PROMPT.md
@@ -1,0 +1,93 @@
+# Audit prompt — ISS-196 R1 ARCHITECT lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` to `(account_id, request_id)` to close [issue #196](https://github.com/Augustas11/macprovider/issues/196).
+
+## Audit lens — ARCHITECTURE / INVARIANTS
+
+You are the architect. Hold the PR to system invariants that span beyond the
+files changed. Severity bar:
+
+- **CRITICAL** — fix violates a spec, breaks a load-bearing invariant, or
+  introduces a new one inconsistent with neighboring tables.
+- **HIGH** — design pattern divergence from existing migrations (e.g.,
+  `ensureOAuthStateActionColumn` set a precedent for in-place upgrade —
+  is the new function consistent with that pattern?), or a missed
+  cross-cutting consequence (explorer queries, reconciler scripts,
+  audit-trail JOINs, deploy gates).
+- **MEDIUM** — documentation drift between spec and implementation;
+  forward-compatibility concerns for downstream tooling.
+- **LOW** — won't file.
+
+## Concrete things to check
+
+1. **SPEC alignment.** SPEC-005 § BL-1 / BL-2 (billing ledger
+   invariants) and SPEC-006 § 17.7 (settle-after-commit fallback).
+   Does the composite PK preserve the documented uniqueness
+   guarantees? Does any spec document need an addendum to describe
+   the change?
+2. **Append-only triggers.** The migration drops + recreates the
+   `usage_events_no_update` and `usage_events_no_delete` triggers
+   manually inside the rebuild. Is this consistent with how
+   `schemaSQL` declares them? Drift between the migration's trigger
+   bodies and the canonical schemaSQL bodies?
+3. **Symmetry with `quota_reservations` / `concurrency_reservations`.**
+   Those tables already have composite PK `(account_id, request_id)`.
+   Does usage_events now match the same shape, conventions,
+   index naming? Any reconcile-script that joins all three tables?
+4. **Per-account ordering / sort columns.** Now that
+   `(account_id, request_id)` is the PK, the natural query order is
+   account-prefixed. Are there explorer/reconciler queries that
+   relied on `request_id`-only sort and now do a full scan? Look at
+   `explorer.go:64` (latest request per account) and `:299`
+   (timeline). Look at SPEC-006 § 14.3 demo audit join.
+5. **Forward-compatibility with SPEC-002 v1.4.2 `external_request_id`
+   work (PR #195 / #192).** That work adds buyer-vs-internal request
+   id distinction. Does this PR's composite-PK rebuild interact
+   correctly with the `external_request_id` column added on the
+   coordinator side? (Different DB, but architectural alignment.)
+6. **Existing in-place upgrade pattern.** `ensureOAuthStateActionColumn`
+   uses `ALTER TABLE ADD COLUMN` — additive, low-risk. This new
+   function does a full table rebuild — more invasive. Is the
+   precedent / blast radius documented? Is there a SPEC-XXX
+   addendum or DECISION_CRITERIA.md entry warranted?
+7. **Downgrade story.** Operator runs deploy, picks up the new
+   binary, migration runs. If they need to roll back to the
+   previous binary, can it open the migrated DB? (Old binary
+   expects single-column PK schema — would it crash on Open or
+   just keep working since CREATE IF NOT EXISTS is a no-op?)
+8. **Naming.** `idx_usage_account_date` was created before this
+   change; the composite PK now provides `(account_id, ...)`
+   index-like access. Is the secondary index redundant? (Probably
+   not — `(account_id, window_date)` is more specific — but worth
+   flagging if it is.)
+9. **`schemaSQL` source of truth.** New installs land at composite
+   PK directly via schemaSQL; old installs go through the upgrade
+   function. The two paths must converge byte-for-byte. Does the
+   trigger-body whitespace in the upgrade function exactly match
+   schemaSQL? (Tabs vs spaces, etc. — affects schema hash
+   comparisons in tools like sqldiff.)
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>  (or "design" / "spec")
+DETAIL: <invariant violated; cross-system impact>
+SUGGESTED FIX: <action — spec amendment, code change, or doc>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.
+
+## R2 update — what changed since R1
+- Rebased onto current main (ad76194 includes #193 — the prior CRITICAL on 503 was a stale-base false positive).
+- Shared usageEventsAuxiliaryDDL constant (addresses R1 MEDIUM byte-match).
+- maxKnownSchemaVersion=2 + checkSchemaVersionGate (addresses R1 HIGH rollback).
+- ExplorerSessionDetail accountID parameter + ambiguity (addresses R1 HIGH explorer).
+- Filed #210 (demo_usage_events) and #211 (coord request_log).
+
+Re-audit against the same bar.

--- a/specs/AUDIT_ISS_196_R2_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R2_CODE_PROMPT.md
@@ -1,0 +1,103 @@
+# Audit prompt — ISS-196 R1 CODE lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` — a global unique constraint — to
+`(account_id, request_id)` — composite, per-account uniqueness.
+
+This is the fix for [issue #196](https://github.com/Augustas11/macprovider/issues/196):
+a buyer controlling two accounts could supply the same buyer-controlled
+`X-Request-ID` and collide on the global PK after the streaming
+response had already flushed bytes to the buyer, escaping settlement.
+
+## Files in scope
+
+- `phase5-gateway/internal/storage/sqlite/migrate.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/internal/storage/sqlite/usage_events_pk_test.go` (new)
+- `phase5-gateway/internal/router/server_test.go`
+
+## Audit lens — CODE correctness
+
+You are a senior Go reviewer paid to find bugs that ship. Limit findings to the diff
+plus the migration runtime path. Apply this severity bar:
+
+- **CRITICAL** — provable wrong behavior under normal operation, or a
+  data-loss / data-corruption pattern in the migration.
+- **HIGH** — a correctness bug that would fire under specific real-world
+  inputs (race, panic-on-nil, wrong column count, broken sql query,
+  silent ignore of a return value that's load-bearing).
+- **MEDIUM** — pattern that *could* break under refactor or atypical
+  driver behavior; missing test for a non-obvious branch.
+- **LOW / IGNORE** — style, naming, comment polish, alternative idioms
+  with no behavior delta. Do not file.
+
+## Concrete things to look for
+
+1. **Migration atomicity.** The `ensureUsageEventsCompositePK` rebuild
+   runs `CREATE`, `INSERT ... SELECT`, `DROP`, `ALTER ... RENAME`,
+   then four `CREATE INDEX/TRIGGER` inside a single transaction. Are
+   any of those DDL statements implicit-commit on the modernc SQLite
+   driver? Will a failure in step 3 (DROP) actually roll back? Does
+   `PRAGMA foreign_keys = OFF` inside a transaction work as
+   expected?
+2. **Column-order assumption.** The `INSERT INTO usage_events_new
+   SELECT ... FROM usage_events` selects 10 named columns explicitly
+   — is the column list complete vs the legacy schema? Are CHECK
+   constraints preserved?
+3. **PK-shape detection.** `ensureUsageEventsCompositePK` reads
+   `PRAGMA table_info` and inspects `pk > 0`. Confirm SQLite reports
+   pk=1 for a single-column PK and pk=1, pk=2 for a composite. What
+   about a future amendment that adds a third PK column?
+4. **`EnsureUsageEvent` payload-verify.** The lookup query changed
+   from `WHERE request_id = ?` to `WHERE account_id = ? AND
+   request_id = ?`. Does this work for every call site? Are there
+   any callers that don't have `event.AccountID` populated?
+5. **`INSERT OR IGNORE` semantics under composite PK.** Same
+   `(account_id, request_id)` retry must no-op (same-account
+   idempotency); different `(account_id, request_id)` must insert a
+   new row. The new test asserts both. Are there race scenarios the
+   tests miss (e.g., two goroutines retrying the same
+   `(account, request)` concurrently)?
+6. **Idempotency of the migration.** Running `Migrate()` twice on a
+   freshly-built composite-PK DB must be a no-op. Running it on a
+   half-migrated DB (e.g., process killed mid-rebuild) — what
+   happens? Is `usage_events_new` left over?
+7. **`Migrate()` ordering.** `ensureUsageEventsCompositePK` runs
+   AFTER `schemaSQL`. On a new install, schemaSQL creates the table
+   with the composite PK directly, so the upgrade function detects
+   it and returns. On an old install, schemaSQL is a no-op (CREATE
+   IF NOT EXISTS), then the upgrade runs. Both paths converge.
+   Confirm there's no DB state where this ordering produces a
+   broken result.
+8. **Test coverage.** Three new tests in `usage_events_pk_test.go`
+   plus one updated test in `server_test.go`. Are any code paths in
+   the new function untested? Specifically the
+   `len(pkCols) != 1 || pkCols[0].name != "request_id"` defensive
+   bail.
+
+## Output format
+
+Return findings as a JSON-friendly markdown block with this shape:
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>
+DETAIL: <why this is wrong, concrete trigger if needed>
+SUGGESTED FIX: <one-line>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.
+
+## R2 update — what changed since R1
+
+- Rebased onto current main (ad76194 includes #193 — drops the R1 stale-base false positives).
+- Added `usageEventsAuxiliaryDDL` shared constant — Migrate() and ensureUsageEventsCompositePK() both execute it; sqlite_master entries byte-equal.
+- Added `maxKnownSchemaVersion = 2` + `checkSchemaVersionGate` — Open refuses if DB has a higher version (rollback safety).
+- Added `accountID` param to `ExplorerSessionDetail` + ambiguity detection.
+- Filed #210 (demo_usage_events) and #211 (coord request_log) as out-of-scope follow-ups.
+
+Re-audit the diff vs ad76194 against the same severity bar.

--- a/specs/AUDIT_ISS_196_R2_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R2_SECURITY_PROMPT.md
@@ -1,0 +1,95 @@
+# Audit prompt — ISS-196 R1 SECURITY lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` to `(account_id, request_id)` to close the [issue #196](https://github.com/Augustas11/macprovider/issues/196)
+cross-account collision attack.
+
+## The attack we're closing
+
+A buyer controlling two accounts (A, B) supplies the SAME UUIDv4
+`X-Request-ID` from both. Pre-fix:
+
+1. Account A fires a streaming chat completion. Settles cleanly.
+2. Account B fires same prompt + same X-Request-ID. Gateway forwards,
+   streams response back to buyer, attempts to settle. SQLite
+   `INSERT INTO usage_events` fails on global PK collision (request_id
+   already used by A). Account B gets the inference output without
+   being debited.
+
+Post-fix: PK is `(account_id, request_id)` so B's settlement INSERT
+succeeds on the composite key, B is debited, and the audit trail has
+both rows.
+
+## Audit lens — SECURITY
+
+You are a security reviewer pretending to be the attacker. Limit
+findings to the diff. Severity bar:
+
+- **CRITICAL** — a working exploit path that survives this fix.
+- **HIGH** — a different abuse surface (DoS, audit-trail poisoning,
+  reservation leak) opened or unblocked by the schema/runtime change.
+- **MEDIUM** — defense-in-depth gap that compounds another bug.
+- **LOW** — won't file.
+
+## Concrete things to attack
+
+1. **The original exploit, residual paths.** Confirm cross-account
+   collision IS now closed end-to-end. Both `settleAfterCommit` /
+   `SettleReservation` (plain `INSERT`) and the `EnsureUsageEvent`
+   fallback (INSERT OR IGNORE + verify) — does either path still
+   silently swallow a cross-account collision?
+2. **The migration window.** During the table rebuild, a concurrent
+   in-flight inference settle could write to the OLD `usage_events`
+   table after we've already started `INSERT INTO ... SELECT`. Is
+   that handled? (Hint: the gateway is single-process; check if
+   anything else can write during Migrate.)
+3. **`demo_usage_events` parallel surface.** That table still has
+   `request_id PRIMARY KEY` (global). Is it also exploitable for a
+   buyer running through demo tokens? If so, file as a separate
+   issue (don't expand scope of this PR), but note it.
+4. **`audit_events.request_id`.** Has `request_id TEXT NOT NULL` with
+   no uniqueness constraint, only an index. Cross-account collision
+   here doesn't matter for billing, but does it confuse explorer or
+   reconciliation queries?
+5. **`signup_events` / `quota_reservations` / `concurrency_reservations`.**
+   Quota and concurrency reservations are already
+   `PRIMARY KEY (account_id, request_id)` — the right shape. Confirm
+   the PR doesn't accidentally regress them.
+6. **Buyer-supplied X-Request-ID still admitted.** The fix doesn't
+   block buyer-controlled UUIDs (intentional, to preserve buyer
+   correlation). Confirm there's no new path where a malicious
+   X-Request-ID can corrupt indexes, fool the explorer's
+   per-account-last-request lookup, or DoS the gateway.
+7. **`EnsureUsageEvent` payload-verify behavior after fix.** The
+   cross-account branch can no longer occur. Same-account payload
+   drift still triggers `ErrUsageEventConflict`. Is there a scenario
+   where same-account RETRY with legitimately-different tokens
+   (e.g., upstream provider corrected its usage block on retry)
+   gets falsely rejected and causes a refund the buyer didn't
+   deserve?
+8. **Rollback / downgrade.** If a future deploy reverts to the old
+   binary, can the composite-PK DB still serve reads? Writes? Any
+   data-loss risk on downgrade?
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>  (or "behavioral" if not file-bound)
+EXPLOIT: <step-by-step trigger or attack scenario>
+SUGGESTED FIX: <one-line>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.
+
+## R2 update — what changed since R1
+- Rebased onto current main (ad76194 includes #193).
+- ExplorerSessionDetail now account-scoped with ambiguity detection (addresses R1 HIGH).
+- Schema version gate added (addresses R1 HIGH rollback).
+- #210 filed for demo_usage_events parallel surface (out of scope for this PR).
+
+Re-audit against the same bar.

--- a/specs/AUDIT_ISS_196_R3_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R3_ARCHITECT_PROMPT.md
@@ -1,0 +1,103 @@
+# Audit prompt — ISS-196 R1 ARCHITECT lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` to `(account_id, request_id)` to close [issue #196](https://github.com/Augustas11/macprovider/issues/196).
+
+## Audit lens — ARCHITECTURE / INVARIANTS
+
+You are the architect. Hold the PR to system invariants that span beyond the
+files changed. Severity bar:
+
+- **CRITICAL** — fix violates a spec, breaks a load-bearing invariant, or
+  introduces a new one inconsistent with neighboring tables.
+- **HIGH** — design pattern divergence from existing migrations (e.g.,
+  `ensureOAuthStateActionColumn` set a precedent for in-place upgrade —
+  is the new function consistent with that pattern?), or a missed
+  cross-cutting consequence (explorer queries, reconciler scripts,
+  audit-trail JOINs, deploy gates).
+- **MEDIUM** — documentation drift between spec and implementation;
+  forward-compatibility concerns for downstream tooling.
+- **LOW** — won't file.
+
+## Concrete things to check
+
+1. **SPEC alignment.** SPEC-005 § BL-1 / BL-2 (billing ledger
+   invariants) and SPEC-006 § 17.7 (settle-after-commit fallback).
+   Does the composite PK preserve the documented uniqueness
+   guarantees? Does any spec document need an addendum to describe
+   the change?
+2. **Append-only triggers.** The migration drops + recreates the
+   `usage_events_no_update` and `usage_events_no_delete` triggers
+   manually inside the rebuild. Is this consistent with how
+   `schemaSQL` declares them? Drift between the migration's trigger
+   bodies and the canonical schemaSQL bodies?
+3. **Symmetry with `quota_reservations` / `concurrency_reservations`.**
+   Those tables already have composite PK `(account_id, request_id)`.
+   Does usage_events now match the same shape, conventions,
+   index naming? Any reconcile-script that joins all three tables?
+4. **Per-account ordering / sort columns.** Now that
+   `(account_id, request_id)` is the PK, the natural query order is
+   account-prefixed. Are there explorer/reconciler queries that
+   relied on `request_id`-only sort and now do a full scan? Look at
+   `explorer.go:64` (latest request per account) and `:299`
+   (timeline). Look at SPEC-006 § 14.3 demo audit join.
+5. **Forward-compatibility with SPEC-002 v1.4.2 `external_request_id`
+   work (PR #195 / #192).** That work adds buyer-vs-internal request
+   id distinction. Does this PR's composite-PK rebuild interact
+   correctly with the `external_request_id` column added on the
+   coordinator side? (Different DB, but architectural alignment.)
+6. **Existing in-place upgrade pattern.** `ensureOAuthStateActionColumn`
+   uses `ALTER TABLE ADD COLUMN` — additive, low-risk. This new
+   function does a full table rebuild — more invasive. Is the
+   precedent / blast radius documented? Is there a SPEC-XXX
+   addendum or DECISION_CRITERIA.md entry warranted?
+7. **Downgrade story.** Operator runs deploy, picks up the new
+   binary, migration runs. If they need to roll back to the
+   previous binary, can it open the migrated DB? (Old binary
+   expects single-column PK schema — would it crash on Open or
+   just keep working since CREATE IF NOT EXISTS is a no-op?)
+8. **Naming.** `idx_usage_account_date` was created before this
+   change; the composite PK now provides `(account_id, ...)`
+   index-like access. Is the secondary index redundant? (Probably
+   not — `(account_id, window_date)` is more specific — but worth
+   flagging if it is.)
+9. **`schemaSQL` source of truth.** New installs land at composite
+   PK directly via schemaSQL; old installs go through the upgrade
+   function. The two paths must converge byte-for-byte. Does the
+   trigger-body whitespace in the upgrade function exactly match
+   schemaSQL? (Tabs vs spaces, etc. — affects schema hash
+   comparisons in tools like sqldiff.)
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>  (or "design" / "spec")
+DETAIL: <invariant violated; cross-system impact>
+SUGGESTED FIX: <action — spec amendment, code change, or doc>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.
+
+## R2 update — what changed since R1
+- Rebased onto current main (ad76194 includes #193 — the prior CRITICAL on 503 was a stale-base false positive).
+- Shared usageEventsAuxiliaryDDL constant (addresses R1 MEDIUM byte-match).
+- maxKnownSchemaVersion=2 + checkSchemaVersionGate (addresses R1 HIGH rollback).
+- ExplorerSessionDetail accountID parameter + ambiguity (addresses R1 HIGH explorer).
+- Filed #210 (demo_usage_events) and #211 (coord request_log).
+
+Re-audit against the same bar.
+
+## R3 update — what changed since R2
+- A1 (gateway-coord join): documented in PR body, deferred to #211 — not a blocker for #196 (gateway-only scope).
+- A2 (rollback safety): deploy-pearl-vps.sh new step 5b snapshots gateway.db pre-restart; rollback hint updated to require both binary.prev AND db.pre-deploy.<ts>; binary-only rollback flagged as unsafe after schema bump.
+- A3 (archive-restore EXPECTED_VERSION): bumped to 2; OPS.md updated; archive_rotate_test comment updated.
+- A4 (request_id lost its index): added `idx_usage_request ON usage_events(request_id)` to usageEventsAuxiliaryDDL.
+- A5 (ambiguity check usage-only): explorerAccountIDsForRequest now UNIONs across usage_events, quota_reservations, concurrency_reservations.
+- A6 (sqlite_master byte mismatch): rebuild now uses rename-aside + create-canonical-name pattern, both paths share `usageEventsTableDDL` constant; new test `TestUsageEventsSqliteMasterByteIdenticalAcrossPaths` asserts byte-equality.
+
+Re-audit on the same bar.

--- a/specs/AUDIT_ISS_196_R3_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R3_CODE_PROMPT.md
@@ -1,0 +1,109 @@
+# Audit prompt — ISS-196 R1 CODE lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` — a global unique constraint — to
+`(account_id, request_id)` — composite, per-account uniqueness.
+
+This is the fix for [issue #196](https://github.com/Augustas11/macprovider/issues/196):
+a buyer controlling two accounts could supply the same buyer-controlled
+`X-Request-ID` and collide on the global PK after the streaming
+response had already flushed bytes to the buyer, escaping settlement.
+
+## Files in scope
+
+- `phase5-gateway/internal/storage/sqlite/migrate.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/internal/storage/sqlite/usage_events_pk_test.go` (new)
+- `phase5-gateway/internal/router/server_test.go`
+
+## Audit lens — CODE correctness
+
+You are a senior Go reviewer paid to find bugs that ship. Limit findings to the diff
+plus the migration runtime path. Apply this severity bar:
+
+- **CRITICAL** — provable wrong behavior under normal operation, or a
+  data-loss / data-corruption pattern in the migration.
+- **HIGH** — a correctness bug that would fire under specific real-world
+  inputs (race, panic-on-nil, wrong column count, broken sql query,
+  silent ignore of a return value that's load-bearing).
+- **MEDIUM** — pattern that *could* break under refactor or atypical
+  driver behavior; missing test for a non-obvious branch.
+- **LOW / IGNORE** — style, naming, comment polish, alternative idioms
+  with no behavior delta. Do not file.
+
+## Concrete things to look for
+
+1. **Migration atomicity.** The `ensureUsageEventsCompositePK` rebuild
+   runs `CREATE`, `INSERT ... SELECT`, `DROP`, `ALTER ... RENAME`,
+   then four `CREATE INDEX/TRIGGER` inside a single transaction. Are
+   any of those DDL statements implicit-commit on the modernc SQLite
+   driver? Will a failure in step 3 (DROP) actually roll back? Does
+   `PRAGMA foreign_keys = OFF` inside a transaction work as
+   expected?
+2. **Column-order assumption.** The `INSERT INTO usage_events_new
+   SELECT ... FROM usage_events` selects 10 named columns explicitly
+   — is the column list complete vs the legacy schema? Are CHECK
+   constraints preserved?
+3. **PK-shape detection.** `ensureUsageEventsCompositePK` reads
+   `PRAGMA table_info` and inspects `pk > 0`. Confirm SQLite reports
+   pk=1 for a single-column PK and pk=1, pk=2 for a composite. What
+   about a future amendment that adds a third PK column?
+4. **`EnsureUsageEvent` payload-verify.** The lookup query changed
+   from `WHERE request_id = ?` to `WHERE account_id = ? AND
+   request_id = ?`. Does this work for every call site? Are there
+   any callers that don't have `event.AccountID` populated?
+5. **`INSERT OR IGNORE` semantics under composite PK.** Same
+   `(account_id, request_id)` retry must no-op (same-account
+   idempotency); different `(account_id, request_id)` must insert a
+   new row. The new test asserts both. Are there race scenarios the
+   tests miss (e.g., two goroutines retrying the same
+   `(account, request)` concurrently)?
+6. **Idempotency of the migration.** Running `Migrate()` twice on a
+   freshly-built composite-PK DB must be a no-op. Running it on a
+   half-migrated DB (e.g., process killed mid-rebuild) — what
+   happens? Is `usage_events_new` left over?
+7. **`Migrate()` ordering.** `ensureUsageEventsCompositePK` runs
+   AFTER `schemaSQL`. On a new install, schemaSQL creates the table
+   with the composite PK directly, so the upgrade function detects
+   it and returns. On an old install, schemaSQL is a no-op (CREATE
+   IF NOT EXISTS), then the upgrade runs. Both paths converge.
+   Confirm there's no DB state where this ordering produces a
+   broken result.
+8. **Test coverage.** Three new tests in `usage_events_pk_test.go`
+   plus one updated test in `server_test.go`. Are any code paths in
+   the new function untested? Specifically the
+   `len(pkCols) != 1 || pkCols[0].name != "request_id"` defensive
+   bail.
+
+## Output format
+
+Return findings as a JSON-friendly markdown block with this shape:
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>
+DETAIL: <why this is wrong, concrete trigger if needed>
+SUGGESTED FIX: <one-line>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.
+
+## R2 update — what changed since R1
+
+- Rebased onto current main (ad76194 includes #193 — drops the R1 stale-base false positives).
+- Added `usageEventsAuxiliaryDDL` shared constant — Migrate() and ensureUsageEventsCompositePK() both execute it; sqlite_master entries byte-equal.
+- Added `maxKnownSchemaVersion = 2` + `checkSchemaVersionGate` — Open refuses if DB has a higher version (rollback safety).
+- Added `accountID` param to `ExplorerSessionDetail` + ambiguity detection.
+- Filed #210 (demo_usage_events) and #211 (coord request_log) as out-of-scope follow-ups.
+
+Re-audit the diff vs ad76194 against the same severity bar.
+
+## R3 update — what changed since R2
+- CODE-M1 (normalization mismatch): EnsureUsageEvent now normalizes TotalTokens before insert so the conflict-verify comparison uses the same value the row holds.
+- CODE-M2 (pagination tie-break): listCursor extended with optional AccountID; ExplorerListSessions cursor predicate is now lexicographic over (created_at, request_id, account_id); existing pre-#196 cursors backwards-compatible via the (?='') predicate branch.
+
+Re-audit on the same bar.

--- a/specs/AUDIT_ISS_196_R3_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R3_SECURITY_PROMPT.md
@@ -1,0 +1,102 @@
+# Audit prompt — ISS-196 R1 SECURITY lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` to `(account_id, request_id)` to close the [issue #196](https://github.com/Augustas11/macprovider/issues/196)
+cross-account collision attack.
+
+## The attack we're closing
+
+A buyer controlling two accounts (A, B) supplies the SAME UUIDv4
+`X-Request-ID` from both. Pre-fix:
+
+1. Account A fires a streaming chat completion. Settles cleanly.
+2. Account B fires same prompt + same X-Request-ID. Gateway forwards,
+   streams response back to buyer, attempts to settle. SQLite
+   `INSERT INTO usage_events` fails on global PK collision (request_id
+   already used by A). Account B gets the inference output without
+   being debited.
+
+Post-fix: PK is `(account_id, request_id)` so B's settlement INSERT
+succeeds on the composite key, B is debited, and the audit trail has
+both rows.
+
+## Audit lens — SECURITY
+
+You are a security reviewer pretending to be the attacker. Limit
+findings to the diff. Severity bar:
+
+- **CRITICAL** — a working exploit path that survives this fix.
+- **HIGH** — a different abuse surface (DoS, audit-trail poisoning,
+  reservation leak) opened or unblocked by the schema/runtime change.
+- **MEDIUM** — defense-in-depth gap that compounds another bug.
+- **LOW** — won't file.
+
+## Concrete things to attack
+
+1. **The original exploit, residual paths.** Confirm cross-account
+   collision IS now closed end-to-end. Both `settleAfterCommit` /
+   `SettleReservation` (plain `INSERT`) and the `EnsureUsageEvent`
+   fallback (INSERT OR IGNORE + verify) — does either path still
+   silently swallow a cross-account collision?
+2. **The migration window.** During the table rebuild, a concurrent
+   in-flight inference settle could write to the OLD `usage_events`
+   table after we've already started `INSERT INTO ... SELECT`. Is
+   that handled? (Hint: the gateway is single-process; check if
+   anything else can write during Migrate.)
+3. **`demo_usage_events` parallel surface.** That table still has
+   `request_id PRIMARY KEY` (global). Is it also exploitable for a
+   buyer running through demo tokens? If so, file as a separate
+   issue (don't expand scope of this PR), but note it.
+4. **`audit_events.request_id`.** Has `request_id TEXT NOT NULL` with
+   no uniqueness constraint, only an index. Cross-account collision
+   here doesn't matter for billing, but does it confuse explorer or
+   reconciliation queries?
+5. **`signup_events` / `quota_reservations` / `concurrency_reservations`.**
+   Quota and concurrency reservations are already
+   `PRIMARY KEY (account_id, request_id)` — the right shape. Confirm
+   the PR doesn't accidentally regress them.
+6. **Buyer-supplied X-Request-ID still admitted.** The fix doesn't
+   block buyer-controlled UUIDs (intentional, to preserve buyer
+   correlation). Confirm there's no new path where a malicious
+   X-Request-ID can corrupt indexes, fool the explorer's
+   per-account-last-request lookup, or DoS the gateway.
+7. **`EnsureUsageEvent` payload-verify behavior after fix.** The
+   cross-account branch can no longer occur. Same-account payload
+   drift still triggers `ErrUsageEventConflict`. Is there a scenario
+   where same-account RETRY with legitimately-different tokens
+   (e.g., upstream provider corrected its usage block on retry)
+   gets falsely rejected and causes a refund the buyer didn't
+   deserve?
+8. **Rollback / downgrade.** If a future deploy reverts to the old
+   binary, can the composite-PK DB still serve reads? Writes? Any
+   data-loss risk on downgrade?
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>  (or "behavioral" if not file-bound)
+EXPLOIT: <step-by-step trigger or attack scenario>
+SUGGESTED FIX: <one-line>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.
+
+## R2 update — what changed since R1
+- Rebased onto current main (ad76194 includes #193).
+- ExplorerSessionDetail now account-scoped with ambiguity detection (addresses R1 HIGH).
+- Schema version gate added (addresses R1 HIGH rollback).
+- #210 filed for demo_usage_events parallel surface (out of scope for this PR).
+
+Re-audit against the same bar.
+
+## R3 update — what changed since R2
+- A5 (ambiguity check usage-only): probe now spans usage_events + quota_reservations + concurrency_reservations via UNION DISTINCT.
+- A2 (rollback safety): deploy script now snapshots gateway.db pre-restart; restore path documented.
+- #210 (demo_usage_events) tracked separately.
+
+Re-audit on the same bar.

--- a/specs/AUDIT_ISS_196_R4_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R4_ARCHITECT_PROMPT.md
@@ -1,0 +1,109 @@
+# Audit prompt — ISS-196 R1 ARCHITECT lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` to `(account_id, request_id)` to close [issue #196](https://github.com/Augustas11/macprovider/issues/196).
+
+## Audit lens — ARCHITECTURE / INVARIANTS
+
+You are the architect. Hold the PR to system invariants that span beyond the
+files changed. Severity bar:
+
+- **CRITICAL** — fix violates a spec, breaks a load-bearing invariant, or
+  introduces a new one inconsistent with neighboring tables.
+- **HIGH** — design pattern divergence from existing migrations (e.g.,
+  `ensureOAuthStateActionColumn` set a precedent for in-place upgrade —
+  is the new function consistent with that pattern?), or a missed
+  cross-cutting consequence (explorer queries, reconciler scripts,
+  audit-trail JOINs, deploy gates).
+- **MEDIUM** — documentation drift between spec and implementation;
+  forward-compatibility concerns for downstream tooling.
+- **LOW** — won't file.
+
+## Concrete things to check
+
+1. **SPEC alignment.** SPEC-005 § BL-1 / BL-2 (billing ledger
+   invariants) and SPEC-006 § 17.7 (settle-after-commit fallback).
+   Does the composite PK preserve the documented uniqueness
+   guarantees? Does any spec document need an addendum to describe
+   the change?
+2. **Append-only triggers.** The migration drops + recreates the
+   `usage_events_no_update` and `usage_events_no_delete` triggers
+   manually inside the rebuild. Is this consistent with how
+   `schemaSQL` declares them? Drift between the migration's trigger
+   bodies and the canonical schemaSQL bodies?
+3. **Symmetry with `quota_reservations` / `concurrency_reservations`.**
+   Those tables already have composite PK `(account_id, request_id)`.
+   Does usage_events now match the same shape, conventions,
+   index naming? Any reconcile-script that joins all three tables?
+4. **Per-account ordering / sort columns.** Now that
+   `(account_id, request_id)` is the PK, the natural query order is
+   account-prefixed. Are there explorer/reconciler queries that
+   relied on `request_id`-only sort and now do a full scan? Look at
+   `explorer.go:64` (latest request per account) and `:299`
+   (timeline). Look at SPEC-006 § 14.3 demo audit join.
+5. **Forward-compatibility with SPEC-002 v1.4.2 `external_request_id`
+   work (PR #195 / #192).** That work adds buyer-vs-internal request
+   id distinction. Does this PR's composite-PK rebuild interact
+   correctly with the `external_request_id` column added on the
+   coordinator side? (Different DB, but architectural alignment.)
+6. **Existing in-place upgrade pattern.** `ensureOAuthStateActionColumn`
+   uses `ALTER TABLE ADD COLUMN` — additive, low-risk. This new
+   function does a full table rebuild — more invasive. Is the
+   precedent / blast radius documented? Is there a SPEC-XXX
+   addendum or DECISION_CRITERIA.md entry warranted?
+7. **Downgrade story.** Operator runs deploy, picks up the new
+   binary, migration runs. If they need to roll back to the
+   previous binary, can it open the migrated DB? (Old binary
+   expects single-column PK schema — would it crash on Open or
+   just keep working since CREATE IF NOT EXISTS is a no-op?)
+8. **Naming.** `idx_usage_account_date` was created before this
+   change; the composite PK now provides `(account_id, ...)`
+   index-like access. Is the secondary index redundant? (Probably
+   not — `(account_id, window_date)` is more specific — but worth
+   flagging if it is.)
+9. **`schemaSQL` source of truth.** New installs land at composite
+   PK directly via schemaSQL; old installs go through the upgrade
+   function. The two paths must converge byte-for-byte. Does the
+   trigger-body whitespace in the upgrade function exactly match
+   schemaSQL? (Tabs vs spaces, etc. — affects schema hash
+   comparisons in tools like sqldiff.)
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>  (or "design" / "spec")
+DETAIL: <invariant violated; cross-system impact>
+SUGGESTED FIX: <action — spec amendment, code change, or doc>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.
+
+## R2 update — what changed since R1
+- Rebased onto current main (ad76194 includes #193 — the prior CRITICAL on 503 was a stale-base false positive).
+- Shared usageEventsAuxiliaryDDL constant (addresses R1 MEDIUM byte-match).
+- maxKnownSchemaVersion=2 + checkSchemaVersionGate (addresses R1 HIGH rollback).
+- ExplorerSessionDetail accountID parameter + ambiguity (addresses R1 HIGH explorer).
+- Filed #210 (demo_usage_events) and #211 (coord request_log).
+
+Re-audit against the same bar.
+
+## R3 update — what changed since R2
+- A1 (gateway-coord join): documented in PR body, deferred to #211 — not a blocker for #196 (gateway-only scope).
+- A2 (rollback safety): deploy-pearl-vps.sh new step 5b snapshots gateway.db pre-restart; rollback hint updated to require both binary.prev AND db.pre-deploy.<ts>; binary-only rollback flagged as unsafe after schema bump.
+- A3 (archive-restore EXPECTED_VERSION): bumped to 2; OPS.md updated; archive_rotate_test comment updated.
+- A4 (request_id lost its index): added `idx_usage_request ON usage_events(request_id)` to usageEventsAuxiliaryDDL.
+- A5 (ambiguity check usage-only): explorerAccountIDsForRequest now UNIONs across usage_events, quota_reservations, concurrency_reservations.
+- A6 (sqlite_master byte mismatch): rebuild now uses rename-aside + create-canonical-name pattern, both paths share `usageEventsTableDDL` constant; new test `TestUsageEventsSqliteMasterByteIdenticalAcrossPaths` asserts byte-equality.
+
+Re-audit on the same bar.
+
+## R4 update — what changed since R3
+- WAL snapshot HIGH fixed: deploy step 5b now uses `sqlite3 .backup` (WAL-consistent) + integrity_check verify; exit 5 on failure.
+- SPEC-007 doc drift filed as #212 (out of scope for this PR per scope control).
+
+Re-audit on the same bar.

--- a/specs/AUDIT_ISS_196_R4_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R4_SECURITY_PROMPT.md
@@ -1,0 +1,108 @@
+# Audit prompt — ISS-196 R1 SECURITY lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` to `(account_id, request_id)` to close the [issue #196](https://github.com/Augustas11/macprovider/issues/196)
+cross-account collision attack.
+
+## The attack we're closing
+
+A buyer controlling two accounts (A, B) supplies the SAME UUIDv4
+`X-Request-ID` from both. Pre-fix:
+
+1. Account A fires a streaming chat completion. Settles cleanly.
+2. Account B fires same prompt + same X-Request-ID. Gateway forwards,
+   streams response back to buyer, attempts to settle. SQLite
+   `INSERT INTO usage_events` fails on global PK collision (request_id
+   already used by A). Account B gets the inference output without
+   being debited.
+
+Post-fix: PK is `(account_id, request_id)` so B's settlement INSERT
+succeeds on the composite key, B is debited, and the audit trail has
+both rows.
+
+## Audit lens — SECURITY
+
+You are a security reviewer pretending to be the attacker. Limit
+findings to the diff. Severity bar:
+
+- **CRITICAL** — a working exploit path that survives this fix.
+- **HIGH** — a different abuse surface (DoS, audit-trail poisoning,
+  reservation leak) opened or unblocked by the schema/runtime change.
+- **MEDIUM** — defense-in-depth gap that compounds another bug.
+- **LOW** — won't file.
+
+## Concrete things to attack
+
+1. **The original exploit, residual paths.** Confirm cross-account
+   collision IS now closed end-to-end. Both `settleAfterCommit` /
+   `SettleReservation` (plain `INSERT`) and the `EnsureUsageEvent`
+   fallback (INSERT OR IGNORE + verify) — does either path still
+   silently swallow a cross-account collision?
+2. **The migration window.** During the table rebuild, a concurrent
+   in-flight inference settle could write to the OLD `usage_events`
+   table after we've already started `INSERT INTO ... SELECT`. Is
+   that handled? (Hint: the gateway is single-process; check if
+   anything else can write during Migrate.)
+3. **`demo_usage_events` parallel surface.** That table still has
+   `request_id PRIMARY KEY` (global). Is it also exploitable for a
+   buyer running through demo tokens? If so, file as a separate
+   issue (don't expand scope of this PR), but note it.
+4. **`audit_events.request_id`.** Has `request_id TEXT NOT NULL` with
+   no uniqueness constraint, only an index. Cross-account collision
+   here doesn't matter for billing, but does it confuse explorer or
+   reconciliation queries?
+5. **`signup_events` / `quota_reservations` / `concurrency_reservations`.**
+   Quota and concurrency reservations are already
+   `PRIMARY KEY (account_id, request_id)` — the right shape. Confirm
+   the PR doesn't accidentally regress them.
+6. **Buyer-supplied X-Request-ID still admitted.** The fix doesn't
+   block buyer-controlled UUIDs (intentional, to preserve buyer
+   correlation). Confirm there's no new path where a malicious
+   X-Request-ID can corrupt indexes, fool the explorer's
+   per-account-last-request lookup, or DoS the gateway.
+7. **`EnsureUsageEvent` payload-verify behavior after fix.** The
+   cross-account branch can no longer occur. Same-account payload
+   drift still triggers `ErrUsageEventConflict`. Is there a scenario
+   where same-account RETRY with legitimately-different tokens
+   (e.g., upstream provider corrected its usage block on retry)
+   gets falsely rejected and causes a refund the buyer didn't
+   deserve?
+8. **Rollback / downgrade.** If a future deploy reverts to the old
+   binary, can the composite-PK DB still serve reads? Writes? Any
+   data-loss risk on downgrade?
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>  (or "behavioral" if not file-bound)
+EXPLOIT: <step-by-step trigger or attack scenario>
+SUGGESTED FIX: <one-line>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.
+
+## R2 update — what changed since R1
+- Rebased onto current main (ad76194 includes #193).
+- ExplorerSessionDetail now account-scoped with ambiguity detection (addresses R1 HIGH).
+- Schema version gate added (addresses R1 HIGH rollback).
+- #210 filed for demo_usage_events parallel surface (out of scope for this PR).
+
+Re-audit against the same bar.
+
+## R3 update — what changed since R2
+- A5 (ambiguity check usage-only): probe now spans usage_events + quota_reservations + concurrency_reservations via UNION DISTINCT.
+- A2 (rollback safety): deploy script now snapshots gateway.db pre-restart; restore path documented.
+- #210 (demo_usage_events) tracked separately.
+
+Re-audit on the same bar.
+
+## R4 update — what changed since R3
+- WAL snapshot HIGH fixed: deploy step 5b now uses `sqlite3 .backup` (WAL-consistent) + integrity_check verify; exit 5 on failure.
+- SPEC-007 doc drift filed as #212 (out of scope for this PR per scope control).
+
+Re-audit on the same bar.

--- a/specs/AUDIT_ISS_196_R5_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_196_R5_ARCHITECT_PROMPT.md
@@ -1,0 +1,115 @@
+# Audit prompt — ISS-196 R1 ARCHITECT lane
+
+## What's under review
+
+`fix/iss-196-account-scoped-pk` against `origin/main` (HEAD `ad76194`).
+Changes the gateway's `usage_events` table PRIMARY KEY from
+`(request_id)` to `(account_id, request_id)` to close [issue #196](https://github.com/Augustas11/macprovider/issues/196).
+
+## Audit lens — ARCHITECTURE / INVARIANTS
+
+You are the architect. Hold the PR to system invariants that span beyond the
+files changed. Severity bar:
+
+- **CRITICAL** — fix violates a spec, breaks a load-bearing invariant, or
+  introduces a new one inconsistent with neighboring tables.
+- **HIGH** — design pattern divergence from existing migrations (e.g.,
+  `ensureOAuthStateActionColumn` set a precedent for in-place upgrade —
+  is the new function consistent with that pattern?), or a missed
+  cross-cutting consequence (explorer queries, reconciler scripts,
+  audit-trail JOINs, deploy gates).
+- **MEDIUM** — documentation drift between spec and implementation;
+  forward-compatibility concerns for downstream tooling.
+- **LOW** — won't file.
+
+## Concrete things to check
+
+1. **SPEC alignment.** SPEC-005 § BL-1 / BL-2 (billing ledger
+   invariants) and SPEC-006 § 17.7 (settle-after-commit fallback).
+   Does the composite PK preserve the documented uniqueness
+   guarantees? Does any spec document need an addendum to describe
+   the change?
+2. **Append-only triggers.** The migration drops + recreates the
+   `usage_events_no_update` and `usage_events_no_delete` triggers
+   manually inside the rebuild. Is this consistent with how
+   `schemaSQL` declares them? Drift between the migration's trigger
+   bodies and the canonical schemaSQL bodies?
+3. **Symmetry with `quota_reservations` / `concurrency_reservations`.**
+   Those tables already have composite PK `(account_id, request_id)`.
+   Does usage_events now match the same shape, conventions,
+   index naming? Any reconcile-script that joins all three tables?
+4. **Per-account ordering / sort columns.** Now that
+   `(account_id, request_id)` is the PK, the natural query order is
+   account-prefixed. Are there explorer/reconciler queries that
+   relied on `request_id`-only sort and now do a full scan? Look at
+   `explorer.go:64` (latest request per account) and `:299`
+   (timeline). Look at SPEC-006 § 14.3 demo audit join.
+5. **Forward-compatibility with SPEC-002 v1.4.2 `external_request_id`
+   work (PR #195 / #192).** That work adds buyer-vs-internal request
+   id distinction. Does this PR's composite-PK rebuild interact
+   correctly with the `external_request_id` column added on the
+   coordinator side? (Different DB, but architectural alignment.)
+6. **Existing in-place upgrade pattern.** `ensureOAuthStateActionColumn`
+   uses `ALTER TABLE ADD COLUMN` — additive, low-risk. This new
+   function does a full table rebuild — more invasive. Is the
+   precedent / blast radius documented? Is there a SPEC-XXX
+   addendum or DECISION_CRITERIA.md entry warranted?
+7. **Downgrade story.** Operator runs deploy, picks up the new
+   binary, migration runs. If they need to roll back to the
+   previous binary, can it open the migrated DB? (Old binary
+   expects single-column PK schema — would it crash on Open or
+   just keep working since CREATE IF NOT EXISTS is a no-op?)
+8. **Naming.** `idx_usage_account_date` was created before this
+   change; the composite PK now provides `(account_id, ...)`
+   index-like access. Is the secondary index redundant? (Probably
+   not — `(account_id, window_date)` is more specific — but worth
+   flagging if it is.)
+9. **`schemaSQL` source of truth.** New installs land at composite
+   PK directly via schemaSQL; old installs go through the upgrade
+   function. The two paths must converge byte-for-byte. Does the
+   trigger-body whitespace in the upgrade function exactly match
+   schemaSQL? (Tabs vs spaces, etc. — affects schema hash
+   comparisons in tools like sqldiff.)
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH|MEDIUM>
+TITLE: <short>
+FILE: <path>:<line>  (or "design" / "spec")
+DETAIL: <invariant violated; cross-system impact>
+SUGGESTED FIX: <action — spec amendment, code change, or doc>
+```
+
+If 0 findings, output exactly: `0 CRITICAL / 0 HIGH / 0 MEDIUM`.
+
+## R2 update — what changed since R1
+- Rebased onto current main (ad76194 includes #193 — the prior CRITICAL on 503 was a stale-base false positive).
+- Shared usageEventsAuxiliaryDDL constant (addresses R1 MEDIUM byte-match).
+- maxKnownSchemaVersion=2 + checkSchemaVersionGate (addresses R1 HIGH rollback).
+- ExplorerSessionDetail accountID parameter + ambiguity (addresses R1 HIGH explorer).
+- Filed #210 (demo_usage_events) and #211 (coord request_log).
+
+Re-audit against the same bar.
+
+## R3 update — what changed since R2
+- A1 (gateway-coord join): documented in PR body, deferred to #211 — not a blocker for #196 (gateway-only scope).
+- A2 (rollback safety): deploy-pearl-vps.sh new step 5b snapshots gateway.db pre-restart; rollback hint updated to require both binary.prev AND db.pre-deploy.<ts>; binary-only rollback flagged as unsafe after schema bump.
+- A3 (archive-restore EXPECTED_VERSION): bumped to 2; OPS.md updated; archive_rotate_test comment updated.
+- A4 (request_id lost its index): added `idx_usage_request ON usage_events(request_id)` to usageEventsAuxiliaryDDL.
+- A5 (ambiguity check usage-only): explorerAccountIDsForRequest now UNIONs across usage_events, quota_reservations, concurrency_reservations.
+- A6 (sqlite_master byte mismatch): rebuild now uses rename-aside + create-canonical-name pattern, both paths share `usageEventsTableDDL` constant; new test `TestUsageEventsSqliteMasterByteIdenticalAcrossPaths` asserts byte-equality.
+
+Re-audit on the same bar.
+
+## R4 update — what changed since R3
+- WAL snapshot HIGH fixed: deploy step 5b now uses `sqlite3 .backup` (WAL-consistent) + integrity_check verify; exit 5 on failure.
+- SPEC-007 doc drift filed as #212 (out of scope for this PR per scope control).
+
+Re-audit on the same bar.
+
+## R5 update — what changed since R4
+- Atomicity HIGH fixed: schema_migrations version=2 is now stamped INSIDE the same transaction as ensureUsageEventsCompositePK's rebuild. Outer Migrate v2 stamp is the no-op repair for new installs.
+- New test `TestUsageEventsCompositePKAndSchemaV2CommitAtomically` confirms.
+
+Re-audit on the same bar.


### PR DESCRIPTION
## Summary

Closes #196 (P0 money-path).

Changes the gateway `usage_events` table PRIMARY KEY from `(request_id)` (global, buyer-controllable via X-Request-ID) to `(account_id, request_id)` (composite, per-account). Closes the cross-account collision attack where a buyer with two accounts could supply the same UUID, stream a chat completion under account B, and have B's settlement INSERT fail on the global PK collision — escaping the debit after bytes had already flowed.

## Acceptance criteria (from issue)

- [x] `usage_events` PRIMARY KEY is `(account_id, request_id)`.
- [x] Cross-account collision: both accounts get their own row, each billed independently (`TestUsageEventsCrossAccountCollisionInsertsBothRows`, `TestEnsureUsageEventCrossAccountInsertsBothRows`).
- [x] Existing settlement tests pass (full gateway suite green).
- [x] Integration test exercises cross-account collision end-to-end.

## What's in the PR

### Core schema fix

- `phase5-gateway/internal/storage/sqlite/migrate.go` — `usage_events` PK is now `(account_id, request_id)`; added `idx_usage_request` so unscoped request_id lookups stay indexed.
- `phase5-gateway/internal/storage/sqlite/store.go`:
  - `ensureUsageEventsCompositePK()` — in-place upgrade for pre-existing gateway.db files via rename-aside + create-canonical + copy + drop. Stamps `schema_migrations.version=2` inside the SAME transaction as the rebuild for atomicity.
  - `maxKnownSchemaVersion = 2` + `checkSchemaVersionGate()` — Open refuses to start if the DB carries a higher version than the binary understands. Future downgrade safety net.
  - `EnsureUsageEvent` payload-verify lookup now scoped to `(account_id, request_id)`; normalizes `TotalTokens=0 → prompt+completion` before insert AND before verify (R2 CODE bug — caller-supplied 0 would falsely conflict with DB's normalized sum).
- `usageEventsTableDDL` + `usageEventsAuxiliaryDDL` shared constants — both fresh-install and rebuild paths use identical text so `sqlite_master.sql` is byte-equal across paths (R2 ARCH MED).

### Explorer / cross-account collision handling

- `ExplorerSessionDetail(accountID, requestID)` — new signature. When `accountID == ""` and the request resolves to rows in multiple accounts (across usage_events, quota_reservations, concurrency_reservations), returns `ErrExplorerAmbiguousRequestID` with the matching account list.
- `handleExplorerSessionDetail` HTTP handler — reads `?account_id=` query param, returns 409 + `matched_account_ids` for the ambiguity case.
- `ExplorerListSessions` cursor extended with optional `AccountID` tiebreaker — the `(created_at, request_id)` pair is no longer unique under the composite PK (R2 CODE MED).

### Deploy / archive safety

- `phase5-gateway/dist/deploy-pearl-vps.sh`:
  - New step 5b — snapshots `gateway.db` BEFORE the new binary starts. Uses `sqlite3 .backup` (WAL-consistent) + `PRAGMA integrity_check` verify; exit 5 on failure. Without this, a deploy that crosses schema v1→v2 followed by binary-only rollback would leave the old binary reading a schema it doesn't understand.
  - Rollback hint updated — restore now requires both `gateway.prev` AND `gateway.db.pre-deploy.<ts>`.
- `phase5-gateway/dist/archive-restore.sh` — `EXPECTED_VERSION` bumped 1→2.
- `phase5-gateway/dist/test/archive_rotate_test.sh` + `OPS.md` updated.

## Audit history — 3-lane codex × 5 rounds

| Round | CODE | SECURITY | ARCHITECT |
|---|---|---|---|
| R1 | 0/0/0 | 0 (HIGH×2 deferred to followups) | 1 CRIT (stale-base false positive) + 1 CRIT (#211) + HIGH×2 + MED×1 |
| R2 | MED×2 (fixed) | 0/0/0 | HIGH×5 + MED×1 (all fixed except #211) |
| R3 | 0/0/0 | HIGH×1 (WAL snapshot — fixed) | HIGH×1 (same WAL — fixed) + MED×1 (filed #212) |
| R4 | — | 0/0/0 | HIGH×1 (atomic stamping — fixed) |
| R5 | — | — | 0/0/0 ✅ |

Audit prompts under `specs/AUDIT_ISS_196_R{1..5}_*_PROMPT.md`; raw findings in `.omc/artifacts/ask/` (local-only).

## Follow-up tracking issues filed (out of scope)

- [#210](https://github.com/Augustas11/macprovider/issues/210) — `demo_usage_events` has the same global-PK shape. Cross-demo collision; needs parallel fix.
- [#211](https://github.com/Augustas11/macprovider/issues/211) — coordinator `request_log` reconciliation key needs account scope. SPEC-002 amendment scope.
- [#212](https://github.com/Augustas11/macprovider/issues/212) — SPEC-007 docs need addendum for the new `?account_id=` param + 409 ambiguity shape.

## Test plan

- [x] `go test ./... -count=1` full gateway suite — green
- [x] New regression tests:
  - `TestUsageEventsCrossAccountCollisionInsertsBothRows`
  - `TestUsageEventsSameAccountCollisionStillVerifies`
  - `TestUsageEventsCompositePKUpgradeFromLegacyPK`
  - `TestExplorerSessionDetailAmbiguityWhenAccountIDOmitted`
  - `TestSchemaVersionGateRejectsNewerDB`
  - `TestUsageEventsSqliteMasterByteIdenticalAcrossPaths`
  - `TestUsageEventsCompositePKAndSchemaV2CommitAtomically`
  - `TestEnsureUsageEventCrossAccountInsertsBothRows` (updated existing)
- [ ] CI green
- [ ] Live verification post-deploy: cross-account curl with same X-Request-ID → both accounts debited

🤖 Generated with [Claude Code](https://claude.com/claude-code)
