### PR TITLE
chore: gitignore phase5-gateway/dist/gateway.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,15 @@ phase5-gateway/dist/gateway-linux-amd64
 # Use coordinator.yaml.example as a template; keep real config local.
 phase4-coordinator/dist/coordinator.yaml
 
+# Phase 5 production config: local snapshot of what's running on Pearl,
+# consumed by dist/deploy-pearl-vps.sh's C2 drift-check gate. Use
+# gateway.yaml.example as a template; keep real config local. Without
+# this rule the file shows as untracked in phase5-gateway/dist/, which
+# trips build-linux.sh's dirty guard and forces FORCE_DIRTY=1 on every
+# rebuild — producing -dirty-forced binaries when none is actually
+# warranted. Mirrors the coordinator.yaml convention above.
+phase5-gateway/dist/gateway.yaml
+
 # Phase 1 experiment artifacts (removed from tracking in M3-5; DEVE-8)
 /logs/
 /results/


### PR DESCRIPTION
## Summary
- Add `phase5-gateway/dist/gateway.yaml` to `.gitignore`, mirroring the existing rule for `phase4-coordinator/dist/coordinator.yaml`.
- The deploy script consumes this file at step 0/8 for its C2 cross-config drift check (and intentionally refuses `gateway.yaml.example` as a substitute), so every operator has it sitting untracked locally. On every gateway rebuild, `build-linux.sh`'s dirty guard catches it and forces `FORCE_DIRTY=1` → unnecessary `-dirty-forced` binaries.

## Why this matters
Production gateway was running `v1.6.1-39-gbd0a437-dirty-forced` until today's clean re-deploy. The `-dirty-forced` suffix was structurally correct (the build-time override flag was used as designed), but it was firing on a no-op untracked file, not real local modifications. Result: `/healthz` reads as if prod is running an unaudited override build when in reality it's running merged-and-reviewed code. This rule removes the false signal.

## Test plan
- [x] `git status -- phase5-gateway/` reports clean after this lands and `dist/gateway.yaml` exists locally.
- [x] `git check-ignore -v phase5-gateway/dist/gateway.yaml` matches the new rule.
- [x] `phase5-gateway/scripts/build-linux.sh` no longer trips the dirty guard when only `dist/gateway.yaml` is present → stamps a clean `vX.Y.Z-N-g<sha>` version (verified locally; today's prod gateway re-deploy used the same clean-tree build path via a temporary file-move).
- [x] Mirror rule is already proven in production for the coordinator (line 46) — no behavioral surprises.

## Out of scope
- Coordinator is currently 3 commits behind main (incl. PR #193's coordinator-side change). Separate follow-up.
- The stale MEMORY note claiming `FORCE_DIRTY=1` misses untracked-only dirty state is also wrong; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
