### PR TITLE
fix(gateway): demo-identity-scoped PK for demo_usage_events (closes #210)

### DIFF
--- a/OPS.md
+++ b/OPS.md
@@ -155,8 +155,9 @@ quota table, which has no BEFORE-DELETE trigger.
 - `phase5-gateway/dist/archive-restore.sh` — forensic-restore path.
   Verifies the `.sha256` checksum, decompresses, runs `PRAGMA
   integrity_check`, refuses if the archive's `schema_migrations` max
-  version exceeds the binary's expected version (currently 2, after
-  issue #196 made `usage_events` PK composite), and
+  version exceeds the binary's expected version (currently 3 — after
+  #196 made `usage_events` PK composite and #210 made
+  `demo_usage_events` PK composite), and
   installs to a tempfile target (default `/tmp/gateway-restored-<ts>.db`).
   `--to-live` does the destructive replace-the-live-DB path; requires
   `ASSUME_YES=1`. Snapshots the existing live DB to a `.pre-restore.<ts>`

--- a/phase5-gateway/dist/archive-restore.sh
+++ b/phase5-gateway/dist/archive-restore.sh
@@ -157,7 +157,7 @@ if [ "$INTEGRITY" != "ok" ]; then
 fi
 
 # Schema-version check.
-EXPECTED_VERSION=2  # bumped 1→2 by issue #196 (usage_events composite PK)
+EXPECTED_VERSION=3  # 1→2 #196 usage_events PK; 2→3 #210 demo_usage_events PK
 ARCHIVE_VERSION=$(sqlite3 "$TMP_DB" "SELECT COALESCE(MAX(version), 0) FROM schema_migrations;" 2>/dev/null || echo 0)
 log "archive schema version=$ARCHIVE_VERSION expected=$EXPECTED_VERSION"
 if [ "$ARCHIVE_VERSION" -gt "$EXPECTED_VERSION" ]; then

--- a/phase5-gateway/internal/storage/sqlite/demo_usage_events_pk_test.go
+++ b/phase5-gateway/internal/storage/sqlite/demo_usage_events_pk_test.go
@@ -1,0 +1,269 @@
+// Regression coverage for issue #210 — demo_usage_events PRIMARY KEY
+// is (demo_token_hash, request_id). Pre-issue-#210 the PK was just
+// (request_id), which let two demo identities (different
+// demo_token_hash) collide on the same buyer-supplied X-Request-ID
+// and lose the second identity's audit row.
+//
+// Sibling of [[usage_events_pk_test]] (#196) — same exploit class,
+// different table.
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-gateway/internal/storage"
+)
+
+func TestDemoUsageEventsCrossDemoCollisionInsertsBothRows(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	const sharedRequestID = "demo-shared-uuid-1"
+	for _, demoHash := range []string{"demoHash_A", "demoHash_B"} {
+		if err := store.EnsureDemoUsageEvent(ctx, storage.DemoUsageEvent{
+			RequestID: sharedRequestID, ClientIP: "1.2.3.4",
+			DemoTokenHash: demoHash, WindowDate: "2026-06-28", TotalTokens: 5,
+			CreatedAt: fixedTime(),
+		}); err != nil {
+			t.Fatalf("EnsureDemoUsageEvent(%s): %v", demoHash, err)
+		}
+	}
+	rows, err := store.db.QueryContext(ctx, `
+		SELECT demo_token_hash, total_tokens FROM demo_usage_events
+		WHERE request_id = ? ORDER BY demo_token_hash`, sharedRequestID)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	var got []struct {
+		hash   string
+		tokens int64
+	}
+	for rows.Next() {
+		var s struct {
+			hash   string
+			tokens int64
+		}
+		if err := rows.Scan(&s.hash, &s.tokens); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, s)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 rows after cross-demo collision, got %d: %+v", len(got), got)
+	}
+	if got[0].hash != "demoHash_A" || got[1].hash != "demoHash_B" {
+		t.Errorf("rows = %+v, want both demo hashes preserved", got)
+	}
+}
+
+func TestDemoUsageEventsCompositePKUpgradeFromLegacyPK(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "legacy-demo-gateway.db")
+	rawDB, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	legacyDDL := []string{
+		`CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)`,
+		`CREATE TABLE demo_usage_events (
+			request_id TEXT PRIMARY KEY,
+			client_ip TEXT NOT NULL,
+			demo_token_hash TEXT NOT NULL,
+			window_date TEXT NOT NULL,
+			total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX idx_demo_usage_ip_token_date ON demo_usage_events(client_ip, demo_token_hash, window_date)`,
+		`CREATE TRIGGER demo_usage_events_no_update BEFORE UPDATE ON demo_usage_events
+			BEGIN SELECT RAISE(ABORT, 'demo_usage_events are append-only'); END`,
+		`CREATE TRIGGER demo_usage_events_no_delete BEFORE DELETE ON demo_usage_events
+			BEGIN SELECT RAISE(ABORT, 'demo_usage_events are append-only'); END`,
+		`INSERT INTO schema_migrations VALUES (1, '2026-06-01T00:00:00Z')`,
+		`INSERT INTO schema_migrations VALUES (2, '2026-06-15T00:00:00Z')`,
+	}
+	for _, d := range legacyDDL {
+		if _, err := rawDB.ExecContext(ctx, d); err != nil {
+			t.Fatalf("legacy DDL %q: %v", strings.SplitN(d, "(", 2)[0], err)
+		}
+	}
+	// Seed two legacy rows (distinct request_ids — legacy PK forbids
+	// sharing).
+	for _, seed := range []struct{ req, hash string }{
+		{"legacy-req-1", "demoHash_X"},
+		{"legacy-req-2", "demoHash_Y"},
+	} {
+		if _, err := rawDB.ExecContext(ctx, `
+			INSERT INTO demo_usage_events(request_id, client_ip, demo_token_hash, window_date, total_tokens, created_at)
+			VALUES(?, '5.6.7.8', ?, '2026-06-27', 10, '2026-06-27T00:00:00Z')`,
+			seed.req, seed.hash); err != nil {
+			t.Fatalf("seed %s: %v", seed.req, err)
+		}
+	}
+	// Also need usage_events table for the parallel migration to find.
+	if _, err := rawDB.ExecContext(ctx, `CREATE TABLE usage_events (
+		request_id TEXT PRIMARY KEY,
+		account_id TEXT NOT NULL,
+		demo_identity TEXT NOT NULL DEFAULT '',
+		window_date TEXT NOT NULL,
+		prompt_tokens INTEGER NOT NULL CHECK (prompt_tokens >= 0),
+		completion_tokens INTEGER NOT NULL CHECK (completion_tokens >= 0),
+		total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
+		token_source TEXT NOT NULL CHECK (token_source IN ('provider_reported', 'gateway_estimated', 'manual_fixture')),
+		outcome TEXT NOT NULL,
+		created_at TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("legacy usage_events: %v", err)
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	store, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open (triggers migration): %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Composite PK installed.
+	pkCols := readPKColumns(t, store, "demo_usage_events")
+	if !(len(pkCols) == 2 && pkCols[0] == "demo_token_hash" && pkCols[1] == "request_id") {
+		t.Fatalf("post-migration PK = %v, want [demo_token_hash request_id]", pkCols)
+	}
+
+	// Rows preserved.
+	var n int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM demo_usage_events`).Scan(&n); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("rows preserved = %d, want 2", n)
+	}
+
+	// v3 stamp atomic with rebuild.
+	var maxVer sql.NullInt64
+	if err := store.db.QueryRowContext(ctx, `SELECT MAX(version) FROM schema_migrations`).Scan(&maxVer); err != nil {
+		t.Fatalf("read schema_migrations: %v", err)
+	}
+	if !maxVer.Valid || maxVer.Int64 < 3 {
+		t.Errorf("schema_migrations max version = %v, want >= 3", maxVer)
+	}
+
+	// Append-only DELETE trigger preserved.
+	if _, err := store.db.ExecContext(ctx,
+		`DELETE FROM demo_usage_events WHERE request_id = 'legacy-req-1'`); err == nil {
+		t.Fatal("DELETE on demo_usage_events after migration unexpectedly succeeded")
+	}
+
+	// Cross-demo collision now works.
+	if err := store.EnsureDemoUsageEvent(ctx, storage.DemoUsageEvent{
+		RequestID: "post-mig-shared", ClientIP: "9.9.9.9",
+		DemoTokenHash: "demoHash_A", WindowDate: "2026-06-28", TotalTokens: 1,
+		CreatedAt: fixedTime(),
+	}); err != nil {
+		t.Fatalf("post-migration insert A: %v", err)
+	}
+	if err := store.EnsureDemoUsageEvent(ctx, storage.DemoUsageEvent{
+		RequestID: "post-mig-shared", ClientIP: "9.9.9.9",
+		DemoTokenHash: "demoHash_B", WindowDate: "2026-06-28", TotalTokens: 2,
+		CreatedAt: fixedTime(),
+	}); err != nil {
+		t.Fatalf("post-migration cross-demo insert B: %v", err)
+	}
+}
+
+func TestDemoUsageEventsSqliteMasterByteIdenticalAcrossPaths(t *testing.T) {
+	ctx := context.Background()
+	fresh := newTestStore(t)
+	freshMaster := readDemoUsageEventsMaster(t, fresh)
+
+	path := filepath.Join(t.TempDir(), "migrated-demo-gateway.db")
+	rawDB, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	legacyDDL := []string{
+		`CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)`,
+		`CREATE TABLE usage_events (
+			request_id TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL,
+			demo_identity TEXT NOT NULL DEFAULT '',
+			window_date TEXT NOT NULL,
+			prompt_tokens INTEGER NOT NULL CHECK (prompt_tokens >= 0),
+			completion_tokens INTEGER NOT NULL CHECK (completion_tokens >= 0),
+			total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
+			token_source TEXT NOT NULL CHECK (token_source IN ('provider_reported', 'gateway_estimated', 'manual_fixture')),
+			outcome TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE demo_usage_events (
+			request_id TEXT PRIMARY KEY,
+			client_ip TEXT NOT NULL,
+			demo_token_hash TEXT NOT NULL,
+			window_date TEXT NOT NULL,
+			total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX idx_demo_usage_ip_token_date ON demo_usage_events(client_ip, demo_token_hash, window_date)`,
+		`CREATE TRIGGER demo_usage_events_no_update BEFORE UPDATE ON demo_usage_events
+			BEGIN SELECT RAISE(ABORT, 'demo_usage_events are append-only'); END`,
+		`CREATE TRIGGER demo_usage_events_no_delete BEFORE DELETE ON demo_usage_events
+			BEGIN SELECT RAISE(ABORT, 'demo_usage_events are append-only'); END`,
+	}
+	for _, d := range legacyDDL {
+		if _, err := rawDB.ExecContext(ctx, d); err != nil {
+			t.Fatalf("legacy DDL: %v", err)
+		}
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	migrated, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = migrated.Close() })
+	migratedMaster := readDemoUsageEventsMaster(t, migrated)
+
+	if len(freshMaster) != len(migratedMaster) {
+		t.Fatalf("master row counts differ: fresh=%d migrated=%d", len(freshMaster), len(migratedMaster))
+	}
+	for name, freshSQL := range freshMaster {
+		migSQL, ok := migratedMaster[name]
+		if !ok {
+			t.Errorf("migrated master missing %q", name)
+			continue
+		}
+		if freshSQL != migSQL {
+			t.Errorf("sqlite_master.sql diverges for %q\n  fresh:    %q\n  migrated: %q", name, freshSQL, migSQL)
+		}
+	}
+}
+
+func readDemoUsageEventsMaster(t *testing.T, store *Store) map[string]string {
+	t.Helper()
+	rows, err := store.db.QueryContext(context.Background(), `
+		SELECT name, COALESCE(sql, '') FROM sqlite_master
+		WHERE tbl_name = 'demo_usage_events' AND name NOT LIKE 'sqlite_autoindex_%'
+		ORDER BY name`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var name, sqlText string
+		if err := rows.Scan(&name, &sqlText); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out[name] = sqlText
+	}
+	return out
+}
+
+// Silence unused-import linter if errors not used in any case path.
+var _ = errors.Is

--- a/phase5-gateway/internal/storage/sqlite/migrate.go
+++ b/phase5-gateway/internal/storage/sqlite/migrate.go
@@ -26,6 +26,40 @@ const usageEventsTableDDL = `CREATE TABLE IF NOT EXISTS usage_events (
 // (for in-place upgrades from the pre-issue-#196 single-column PK
 // shape) so the post-migration sqlite_master entries are byte-for-byte
 // identical to a fresh install. Architect R1 MEDIUM finding.
+// demoUsageEventsTableDDL is the canonical CREATE TABLE for
+// demo_usage_events in its post-#210 composite-PK shape. The PK
+// `(demo_token_hash, request_id)` closes the cross-demo collision
+// where two demo identities could share a buyer-controlled
+// X-Request-ID and have the second settlement silently drop the
+// audit row.
+const demoUsageEventsTableDDL = `CREATE TABLE IF NOT EXISTS demo_usage_events (
+	request_id TEXT NOT NULL,
+	client_ip TEXT NOT NULL,
+	demo_token_hash TEXT NOT NULL,
+	window_date TEXT NOT NULL,
+	total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
+	created_at TEXT NOT NULL,
+	PRIMARY KEY (demo_token_hash, request_id)
+)`
+
+// demoUsageEventsAuxiliaryDDL covers the secondary index + append-only
+// triggers for demo_usage_events. Mirrors usageEventsAuxiliaryDDL.
+const demoUsageEventsAuxiliaryDDL = `
+CREATE INDEX IF NOT EXISTS idx_demo_usage_ip_token_date ON demo_usage_events(client_ip, demo_token_hash, window_date);
+-- request_id-leading index keeps unscoped audit-trail lookups indexed
+-- (explorer activity view, future reconciliation tooling).
+CREATE INDEX IF NOT EXISTS idx_demo_usage_request ON demo_usage_events(request_id);
+
+CREATE TRIGGER IF NOT EXISTS demo_usage_events_no_update BEFORE UPDATE ON demo_usage_events
+BEGIN
+	SELECT RAISE(ABORT, 'demo_usage_events are append-only');
+END;
+CREATE TRIGGER IF NOT EXISTS demo_usage_events_no_delete BEFORE DELETE ON demo_usage_events
+BEGIN
+	SELECT RAISE(ABORT, 'demo_usage_events are append-only');
+END;
+`
+
 const usageEventsAuxiliaryDDL = `
 CREATE INDEX IF NOT EXISTS idx_usage_account_date ON usage_events(account_id, window_date);
 CREATE INDEX IF NOT EXISTS idx_usage_created_at ON usage_events(created_at);
@@ -174,16 +208,10 @@ CREATE TABLE IF NOT EXISTS demo_session_events (
 
 CREATE INDEX IF NOT EXISTS idx_demo_session_ip_created ON demo_session_events(client_ip, created_at);
 
-CREATE TABLE IF NOT EXISTS demo_usage_events (
-	request_id TEXT PRIMARY KEY,
-	client_ip TEXT NOT NULL,
-	demo_token_hash TEXT NOT NULL,
-	window_date TEXT NOT NULL,
-	total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
-	created_at TEXT NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS idx_demo_usage_ip_token_date ON demo_usage_events(client_ip, demo_token_hash, window_date);
+-- demo_usage_events table: see demoUsageEventsTableDDL constant.
+-- See [[usageEventsTableDDL]] for the parallel pattern on usage_events
+-- (#196). Both fresh installs and in-place upgrades execute the same
+-- DDL constants so sqlite_master entries are byte-equal.
 
 CREATE TABLE IF NOT EXISTS audit_events (
 	event_id TEXT PRIMARY KEY,
@@ -239,14 +267,8 @@ CREATE TRIGGER IF NOT EXISTS api_key_events_no_delete BEFORE DELETE ON api_key_e
 BEGIN
 	SELECT RAISE(ABORT, 'api_key_events are append-only');
 END;
-CREATE TRIGGER IF NOT EXISTS demo_usage_events_no_update BEFORE UPDATE ON demo_usage_events
-BEGIN
-	SELECT RAISE(ABORT, 'demo_usage_events are append-only');
-END;
-CREATE TRIGGER IF NOT EXISTS demo_usage_events_no_delete BEFORE DELETE ON demo_usage_events
-BEGIN
-	SELECT RAISE(ABORT, 'demo_usage_events are append-only');
-END;
+-- demo_usage_events auxiliary DDL (index + triggers) lives in
+-- demoUsageEventsAuxiliaryDDL, mirroring the #196 usage_events pattern.
 CREATE TRIGGER IF NOT EXISTS capacity_signal_events_no_update BEFORE UPDATE ON capacity_signal_events
 BEGIN
 	SELECT RAISE(ABORT, 'capacity_signal_events are append-only');

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -87,20 +87,21 @@ func (s *Store) Ping(ctx context.Context) error {
 }
 
 // maxKnownSchemaVersion is the highest schema_migrations.version this
-// binary understands. Bumped from 1 → 2 by issue #196 (usage_events
-// composite PK rebuild). At Open time the store reads the current
-// applied version; if it exceeds this constant the binary is older
-// than the DB and refuses to start, preventing the silent data
-// hazards described in the architect R1 HIGH "rollback" finding
-// (e.g., the legacy `WHERE request_id = ?` lookup returning a
-// wrong-account row after the composite PK has allowed cross-account
-// collisions).
+// binary understands. Version history:
+//   v1 — original schema.
+//   v2 — issue #196: usage_events PK (account_id, request_id).
+//   v3 — issue #210: demo_usage_events PK (demo_token_hash, request_id).
 //
-// Operators rolling back the gateway binary on a DB already at
-// version 2 must restore /var/lib/macprovider/gateway.db from the
-// pre-deploy snapshot (deploy-pearl-vps.sh writes one). Future
-// version bumps land here.
-const maxKnownSchemaVersion = 2
+// At Open time the store reads the current applied version; if it
+// exceeds this constant the binary is older than the DB and refuses
+// to start, preventing silent data hazards on rollback (e.g., a
+// legacy `WHERE request_id = ?` lookup returning a wrong-identity
+// row once cross-identity collisions exist).
+//
+// Operators rolling back the gateway binary on a DB at a higher
+// version must restore /var/lib/macprovider/gateway.db from the
+// pre-deploy snapshot (deploy-pearl-vps.sh step 5b writes one).
+const maxKnownSchemaVersion = 3
 
 func (s *Store) Migrate(ctx context.Context) error {
 	if err := s.checkSchemaVersionGate(ctx); err != nil {
@@ -120,10 +121,19 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, usageEventsAuxiliaryDDL); err != nil {
 		return err
 	}
+	if _, err := s.db.ExecContext(ctx, demoUsageEventsTableDDL); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, demoUsageEventsAuxiliaryDDL); err != nil {
+		return err
+	}
 	if err := s.ensureOAuthStateActionColumn(ctx); err != nil {
 		return err
 	}
 	if err := s.ensureUsageEventsCompositePK(ctx); err != nil {
+		return err
+	}
+	if err := s.ensureDemoUsageEventsCompositePK(ctx); err != nil {
 		return err
 	}
 	// Stamp the schema version. We always insert v1 (preserves
@@ -141,6 +151,9 @@ func (s *Store) Migrate(ctx context.Context) error {
 		return err
 	}
 	if _, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(2, ?)", now); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(3, ?)", now); err != nil {
 		return err
 	}
 	return nil
@@ -324,6 +337,92 @@ func (s *Store) ensureUsageEventsCompositePK(ctx context.Context) error {
 		`INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(2, ?)`,
 		encodeTime(time.Now().UTC())); err != nil {
 		return fmt.Errorf("stamp schema_migrations v2 inside rebuild tx: %w", err)
+	}
+	return tx.Commit()
+}
+
+// ensureDemoUsageEventsCompositePK is the issue #210 sibling of
+// ensureUsageEventsCompositePK. Migrates `demo_usage_events` from
+// PRIMARY KEY (request_id) — pre-existing global uniqueness across
+// all demo identities, exploitable when two demo_token_hash values
+// collide on the same buyer-supplied X-Request-ID — to composite
+// PRIMARY KEY (demo_token_hash, request_id).
+//
+// Same rebuild pattern as the v2 migration: detect legacy shape,
+// rename-aside + create-canonical + copy + drop, stamp v3 inside
+// the same transaction so the shape change and the version marker
+// commit atomically.
+func (s *Store) ensureDemoUsageEventsCompositePK(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, `PRAGMA table_info(demo_usage_events)`)
+	if err != nil {
+		return err
+	}
+	type col struct {
+		name string
+		pk   int
+	}
+	var pkCols []col
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if pk > 0 {
+			pkCols = append(pkCols, col{name: name, pk: pk})
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	// Composite (demo_token_hash, request_id) — already migrated.
+	if len(pkCols) == 2 &&
+		((pkCols[0].name == "demo_token_hash" && pkCols[1].name == "request_id") ||
+			(pkCols[0].name == "request_id" && pkCols[1].name == "demo_token_hash")) {
+		return nil
+	}
+	if !(len(pkCols) == 1 && pkCols[0].name == "request_id") {
+		return fmt.Errorf("demo_usage_events PK shape unrecognized: %+v", pkCols)
+	}
+	if _, err := s.db.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = s.db.ExecContext(ctx, `PRAGMA foreign_keys = ON`)
+	}()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE demo_usage_events RENAME TO demo_usage_events_legacy`); err != nil {
+		return fmt.Errorf("rename legacy demo_usage_events aside: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, demoUsageEventsTableDDL); err != nil {
+		return fmt.Errorf("create new demo_usage_events: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO demo_usage_events
+			(request_id, client_ip, demo_token_hash, window_date, total_tokens, created_at)
+		SELECT request_id, client_ip, demo_token_hash, window_date, total_tokens, created_at
+		FROM demo_usage_events_legacy`); err != nil {
+		return fmt.Errorf("copy demo_usage_events rows: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DROP TABLE demo_usage_events_legacy`); err != nil {
+		return fmt.Errorf("drop legacy demo_usage_events table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, demoUsageEventsAuxiliaryDDL); err != nil {
+		return fmt.Errorf("recreate demo_usage_events index/trigger: %w", err)
+	}
+	// Stamp v3 inside the same transaction — atomicity per ISS-196 R4.
+	if _, err := tx.ExecContext(ctx,
+		`INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(3, ?)`,
+		encodeTime(time.Now().UTC())); err != nil {
+		return fmt.Errorf("stamp schema_migrations v3 inside rebuild tx: %w", err)
 	}
 	return tx.Commit()
 }

--- a/specs/AUDIT_ISS_210_R1_PROMPT.md
+++ b/specs/AUDIT_ISS_210_R1_PROMPT.md
@@ -1,0 +1,124 @@
+# Audit prompt — ISS-210 R1
+
+## What's under review
+
+Branch `fix/iss-210-demo-usage-events-pk` against `origin/main`
+(HEAD `3019238`).
+
+Closes [#210](https://github.com/Augustas11/macprovider/issues/210).
+Direct structural sibling of #196 (which shipped as PR #213,
+landed `38d03db`). Changes the gateway `demo_usage_events` table
+PRIMARY KEY from `(request_id)` to `(demo_token_hash, request_id)`,
+closing the cross-demo collision attack where two demo identities
+could collide on a buyer-supplied X-Request-ID and have the second
+identity's settlement silently drop the audit row.
+
+## What's the same as #196
+
+- Migration pattern: `ensureDemoUsageEventsCompositePK` mirrors
+  `ensureUsageEventsCompositePK` exactly — detect legacy shape,
+  rename-aside, create canonical, copy, drop, recreate aux DDL,
+  stamp v3 inside the same tx.
+- Shared `demoUsageEventsTableDDL` + `demoUsageEventsAuxiliaryDDL`
+  constants used by both fresh-install and rebuild paths so
+  sqlite_master is byte-equal.
+- Schema version bump 2 → 3.
+- archive-restore.sh + OPS.md updated.
+- `maxKnownSchemaVersion = 3` keeps the rollback gate intact.
+
+## What this PR does NOT touch
+
+- Coordinator side (already deferred to #211).
+- SPEC-007 explorer docs (deferred to #212).
+- `usage_events` table from #196 — already migrated to v2 in PR #213.
+- The `SettleDemoReservation` / `EnsureDemoUsageEvent` Go call sites —
+  the existing INSERT OR IGNORE semantics remain valid; the new
+  composite PK makes the (demo_token_hash, request_id) duplicate the
+  only legitimate idempotent no-op.
+
+## Severity bar (TIGHT — user feedback on R5 audit churn)
+
+Three independent lanes (code / security / architect). Report ONLY
+CRITICAL or HIGH. MEDIUM findings should be filed as comments
+inline in the prompt response but NOT iterated on.
+
+- **CRITICAL** — provable wrong behavior, data corruption, or new
+  exploit surface introduced by this PR.
+- **HIGH** — a real bug/risk that would fire under realistic inputs,
+  OR a #196-style invariant gap.
+- (Report MEDIUM as advisory only, do not gate merge on it.)
+
+## CODE lane
+
+Files in scope:
+- `phase5-gateway/internal/storage/sqlite/migrate.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/internal/storage/sqlite/demo_usage_events_pk_test.go`
+- `phase5-gateway/dist/archive-restore.sh`
+- `OPS.md`
+
+Things to check:
+1. `ensureDemoUsageEventsCompositePK` rebuild atomicity — same
+   pattern as v2 (rename-aside, create canonical, copy, drop, stamp
+   v3 in same tx). Any divergence from the v2 reference?
+2. Column order in the INSERT...SELECT — does it match
+   `demoUsageEventsTableDDL`?
+3. PK detection — does `(len(pkCols) == 2 && both names match)`
+   handle the SQLite-pk-ordering correctly when composite PK was
+   declared `PRIMARY KEY (demo_token_hash, request_id)`?
+4. Schema version stamping path — v3 stamped inside rebuild tx AND
+   in the outer Migrate() unconditional stamp loop. Idempotent on
+   re-run?
+
+## SECURITY lane
+
+The attack:
+1. Demo identity D1 (demo_token_hash=H1) fires a streaming chat
+   completion with X-Request-ID=R. Settles cleanly; row written.
+2. Demo identity D2 (H2 != H1) fires same prompt + same X-Request-ID.
+   Streams response back. Settlement attempts:
+   - usage_events: composite PK (account_id, request_id) — succeeds.
+   - demo_usage_events PRE-FIX: single PK (request_id) collides; row
+     for D2 is silently lost.
+   - demo_usage_events POST-FIX: composite (demo_token_hash, request_id)
+     — second row inserted, audit trail intact.
+
+Verify:
+1. The fix actually closes the exploit end-to-end (cross-demo
+   inserts both succeed).
+2. No NEW exploit surface opened — e.g., does the unscoped
+   `WHERE request_id = ?` lookup somewhere now leak the wrong
+   demo's data?
+3. `SettleDemoReservation` write path (plain INSERT) and
+   `EnsureDemoUsageEvent` fallback path (INSERT OR IGNORE) — both
+   compatible with the new PK?
+
+## ARCHITECT lane
+
+1. Consistency with #196 invariants — does this PR follow the same
+   conventions (shared DDL constants, byte-equal sqlite_master,
+   atomic schema stamp, archive-restore version)?
+2. SPEC-006 § N (demo path) — does any spec text constrain the
+   demo_usage_events PK shape? If so, addendum needed.
+3. Downgrade story — rollback path documented in deploy-pearl-vps.sh
+   step 5b (added in #196) already snapshots gateway.db. Any
+   demo-specific concern?
+4. demo_usage_events does NOT have account_id (it has
+   demo_token_hash + client_ip). Is the PK choice
+   `(demo_token_hash, request_id)` correct given that the
+   exploit is about demo_token_hash collision? Or should it be
+   `(client_ip, demo_token_hash, request_id)` for defense in depth?
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH>
+TITLE: <short>
+FILE: <path>:<line>
+DETAIL: <why this is wrong / what fires>
+SUGGESTED FIX: <action>
+```
+
+Plus optional advisory MEDIUMs (will not gate merge).
+
+If 0 CRITICAL/HIGH: output exactly `0 CRITICAL / 0 HIGH`.


### PR DESCRIPTION
## Summary

Closes #210. Direct structural sibling of #196 (shipped as PR #213, `38d03db`).

Changes the gateway `demo_usage_events` PRIMARY KEY from `(request_id)` (global, buyer-controllable via `X-Request-ID`) to `(demo_token_hash, request_id)` (composite, per-demo-identity). Closes the cross-demo collision where two demo identities sharing a buyer-supplied UUID would have the second identity's settlement silently drop the audit row.

## What's in the PR

- `phase5-gateway/internal/storage/sqlite/migrate.go` — `demoUsageEventsTableDDL` + `demoUsageEventsAuxiliaryDDL` shared constants (composite PK + index + append-only triggers). Schema text removed from `schemaSQL`; both fresh and migrated paths now use the same constants for byte-equal sqlite_master.
- `phase5-gateway/internal/storage/sqlite/store.go`:
  - `Migrate()` now calls both new DDL constants + the new migration function.
  - `ensureDemoUsageEventsCompositePK()` — mirrors `ensureUsageEventsCompositePK` exactly: rename-aside + create canonical + copy + drop + recreate aux DDL + stamp v3 inside the same tx (atomic per #196 R4).
  - `maxKnownSchemaVersion` bumped 2→3.
  - Added `idx_demo_usage_request` for unscoped request_id lookups.
- `phase5-gateway/dist/archive-restore.sh` — `EXPECTED_VERSION` 2→3.
- `OPS.md` — schema version doc update.
- New test file `demo_usage_events_pk_test.go` (3 tests):
  - `TestDemoUsageEventsCrossDemoCollisionInsertsBothRows`
  - `TestDemoUsageEventsCompositePKUpgradeFromLegacyPK`
  - `TestDemoUsageEventsSqliteMasterByteIdenticalAcrossPaths`

## Audit

3-lane codex (CODE / SECURITY / ARCHITECT) — single R1 round, tight CRITICAL/HIGH bar:

| Lane | Verdict |
|---|---|
| CODE | 0 CRITICAL / 0 HIGH |
| SECURITY | 0 CRITICAL / 0 HIGH |
| ARCHITECT | 0 CRITICAL / 0 HIGH |

Converged on R1 — the pattern was established by #196's 5-round convergence (PR #213); this sibling needed no iteration. Audit prompt at `specs/AUDIT_ISS_210_R1_PROMPT.md`.

## Test plan

- [x] `go test ./... -count=1` — green
- [x] 3 new regression tests pass
- [ ] CI green
- [ ] Live verification post-deploy: cross-demo curl with shared X-Request-ID writes 2 rows in demo_usage_events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
