### PR TITLE
fix(gateway): refund + passthrough on coordinator idempotency 409 (closes #200)

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -314,6 +314,10 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body)
 		return
 	}
+	if coordinatorIdempotencyError(resp.StatusCode, body) {
+		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body)
+		return
+	}
 	if resp.StatusCode != http.StatusOK {
 		if isNullUsageProviderError(body) {
 			s.passThroughReceiptEligibleProviderError(w, r, resp, subject, body)
@@ -377,6 +381,10 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			return
 		}
 		body, _ := io.ReadAll(resp.Body)
+		if coordinatorIdempotencyError(resp.StatusCode, body) {
+			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body)
+			return
+		}
 		if coordinatorTier2PolicyError(resp.StatusCode, body) {
 			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body)
 			return
@@ -605,6 +613,30 @@ func isNullUsageProviderError(body []byte) bool {
 	default:
 		return false
 	}
+}
+
+// coordinatorIdempotencyError detects coordinator-issued 409 responses
+// that signal "no provider work happened, no charge due" — the two
+// known cases for buyer-supplied Idempotency-Key:
+//
+//   - idempotency_key_replayed: same key + same body. The original
+//     request already settled; the retry hit dedupe.
+//   - idempotency_key_body_mismatch: same key + different body (buyer
+//     error).
+//
+// In either case the gateway must refund the reservation it just
+// made (the request never reached a provider) and pass the coord
+// response through verbatim so the buyer sees the idempotency
+// semantics, not an opaque 502. Closes #200.
+func coordinatorIdempotencyError(status int, body []byte) bool {
+	if status != http.StatusConflict {
+		return false
+	}
+	switch openAIErrorCode(body) {
+	case "idempotency_key_replayed", "idempotency_key_body_mismatch":
+		return true
+	}
+	return false
 }
 
 func coordinatorTier2PolicyError(status int, body []byte) bool {

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -4039,6 +4039,71 @@ func TestCoordinatorTier2PolicyErrorsPassThroughAndDoNotChargeQuota(t *testing.T
 	}
 }
 
+// TestCoordinatorIdempotencyReplayPassesThroughAndRefunds pins
+// issue #200: when the coordinator returns 409
+// idempotency_key_replayed (or idempotency_key_body_mismatch), the
+// gateway MUST refund the reservation it made and pass the
+// coordinator response body through verbatim. Pre-fix it fell
+// through the generic !=200 branch, called settleBeforeResponse
+// with outcome="upstream_error" (billing the buyer for the prompt
+// estimate even though no provider work ran), and remapped the
+// response to a 502.
+func TestCoordinatorIdempotencyReplayPassesThroughAndRefunds(t *testing.T) {
+	cases := []struct {
+		name string
+		code string
+	}{
+		{"replayed", "idempotency_key_replayed"},
+		{"body_mismatch", "idempotency_key_body_mismatch"},
+	}
+	for _, tc := range cases {
+		for _, stream := range []bool{false, true} {
+			name := tc.name + "_non_stream"
+			if stream {
+				name = tc.name + "_stream"
+			}
+			t.Run(name, func(t *testing.T) {
+				coordBody := fmt.Sprintf(`{"error":{"code":%q,"message":"idempotency","param":null,"type":"invalid_request_error"}}`, tc.code)
+				client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					return responseWithBody(http.StatusConflict, http.Header{"Content-Type": []string{"application/json"}}, coordBody), nil
+				})}
+				h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+					cfg.Coordinator.BuyerURL = "http://coordinator.test"
+				}, WithHTTPClient(client))
+				fullKey := createAccountAndKey(t, store, cfg, "acct_"+name)
+
+				body := `{"model":"model-a","max_tokens":1000,"messages":[{"role":"user","content":"x"}]}`
+				if stream {
+					body = `{"model":"model-a","max_tokens":1000,"stream":true,"messages":[{"role":"user","content":"x"}]}`
+				}
+				resp := postChat(t, h, fullKey, body, nil)
+
+				// (a) Buyer sees the coordinator 409 + envelope verbatim,
+				//     NOT a remapped 502 / upstream_provider_error.
+				if resp.Code != http.StatusConflict {
+					t.Fatalf("status=%d, want 409, body=%s", resp.Code, resp.Body.String())
+				}
+				if !strings.Contains(resp.Body.String(), `"code":"`+tc.code+`"`) {
+					t.Fatalf("body lost coord error envelope: %s", resp.Body.String())
+				}
+				if strings.Contains(resp.Body.String(), "upstream_provider_error") {
+					t.Fatalf("body remapped to upstream_provider_error: %s", resp.Body.String())
+				}
+
+				// (b) No quota burn — refund must have fired.
+				usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+				quota := readQuota(t, usageResp)
+				if used := quota["daily_tokens_used"].(float64); used != 0 {
+					t.Fatalf("daily_tokens_used=%v, want 0 — idempotency 409 must not charge quota", used)
+				}
+				if reserved := quota["daily_tokens_reserved"].(float64); reserved != 0 {
+					t.Fatalf("daily_tokens_reserved=%v, want 0 — reservation must be refunded on idempotency 409", reserved)
+				}
+			})
+		}
+	}
+}
+
 // TestConversationKeyIsAccountScoped pins the structural cross-account
 // collision guarantee: account A with tag T MUST derive a different conv:
 // than account B with the same tag T. Regression-locks the SPEC-006 v0.8.1

--- a/specs/AUDIT_ISS_200_R1_PROMPT.md
+++ b/specs/AUDIT_ISS_200_R1_PROMPT.md
@@ -1,0 +1,101 @@
+# Audit prompt — ISS-200 R1
+
+## What's under review
+
+Branch `fix/iss-200-idempotency-replay-refund` against `origin/main`
+(HEAD `3019238`). Closes [#200](https://github.com/Augustas11/macprovider/issues/200).
+
+## Background — investigation completed
+
+The issue body asked for empirical investigation of coordinator
+behavior before picking Option A (gateway cache) vs B (refund-on-409)
+vs C (composed). The investigation:
+
+- Coordinator (`phase4-coordinator/internal/buyer/server.go:1337-1366`)
+  enforces Idempotency-Key by storing `(key, body_hash, request_id)`
+  in `request_idempotency_keys` table.
+- On REPLAY (same key + same body): returns
+  `409 idempotency_key_replayed` with no provider work.
+- On KEY-BUT-BODY-DIFFERS: returns
+  `409 idempotency_key_body_mismatch`.
+- The coordinator does NOT serve cached responses (Option A
+  scenario doesn't fire).
+
+So Option B (refund-on-409 + passthrough) is the correct fix — no
+gateway-side cache needed.
+
+## What this PR does
+
+1. New `coordinatorIdempotencyError(status, body) bool` in
+   `phase5-gateway/internal/router/chat_proxy.go` — detects the two
+   coord-issued 409 idempotency codes.
+2. Adds a check for that condition at the top of the `!= 200`
+   handling in both `forwardNonStreamingChat` and
+   `forwardStreamingChat`, before the existing
+   `settleBeforeResponse(... "upstream_error")` path.
+3. On match: calls existing `passThroughNoProviderCoordinatorError`
+   helper — refunds reservation + passes through coord status/body.
+4. Regression test `TestCoordinatorIdempotencyReplayPassesThroughAndRefunds`
+   asserts: 409 preserved (not remapped to 502), envelope intact,
+   no quota burn, no reservation hold. Covers both codes × both
+   transports (stream / non-stream) = 4 subtests.
+
+## Severity bar (CRITICAL/HIGH only)
+
+Three independent lanes (code / security / architect). Report ONLY
+CRITICAL or HIGH. Optional MEDIUM advisory below.
+
+## CODE lane
+
+1. Is the check ordering correct in both forward functions? Could
+   any later branch (Tier-2, null-usage, completion-from-header)
+   ever fire for a 409 and conflict with the new refund path?
+2. `coordinatorIdempotencyError` reads `openAIErrorCode(body)` —
+   any pitfall when coord returns 409 with no body or a malformed
+   body?
+3. The streaming path reads body via `io.ReadAll(resp.Body)` —
+   same as the existing Tier-2 detection. Compatible?
+4. `passThroughNoProviderCoordinatorError` refunds + passes
+   through. Is the refund truly idempotent when called twice (e.g.,
+   if the check accidentally also matches a non-idempotency 409
+   that someone adds in the future)?
+
+## SECURITY lane
+
+1. Could a malicious coordinator-side actor (or a bug in the coord
+   binary) return a 409 with `code=idempotency_key_replayed` to
+   AVOID being billed for a legitimate completion? (Risk model:
+   coord is trusted but bugs happen.)
+2. Could a buyer SDK abuse this path — e.g., send a request that
+   coord processes successfully but then send a duplicate to
+   trigger refund? (Note: original request still settled normally,
+   so no double-refund scenario.)
+3. Body-mismatch case: same key + different body. Should the
+   gateway treat this differently from clean replay? Both currently
+   refund + passthrough — is that the right outcome?
+
+## ARCHITECT lane
+
+1. SPEC alignment — does any spec text constrain how the gateway
+   handles coord 409? SPEC-006 / SPEC-002 idempotency contract.
+2. Consistency — the existing Tier-2 and 404 passthrough paths
+   follow the same shape. New 409 path matches their pattern?
+3. Forward-compat — if coord adds NEW 409 codes (e.g.
+   `idempotency_key_expired`), should they automatically refund
+   too, or is the explicit code-list approach safer?
+4. Should the gateway track "saw idempotency replay" anywhere for
+   ops visibility (audit_events row)?
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH>
+TITLE: <short>
+FILE: <path>:<line>
+DETAIL: <what fires / why wrong>
+SUGGESTED FIX: <action>
+```
+
+Plus optional advisory MEDIUMs.
+
+If 0 CRITICAL/HIGH: output exactly `0 CRITICAL / 0 HIGH`.


### PR DESCRIPTION
## Summary

Closes #200.

When a buyer retries a chat completion with the same `Idempotency-Key`, the coordinator returns `409 idempotency_key_replayed` (or `idempotency_key_body_mismatch` on key reuse with different body) and performs no provider work.

**Pre-fix bug**: the gateway treated this `409` as an opaque non-200, called `settleBeforeResponse` with `outcome="upstream_error"`, **billed the buyer for the prompt-token estimate** even though no inference ran, and remapped the response to `502 upstream_provider_error`. Net effect on every retry: spurious quota burn + the buyer loses the idempotency semantics they explicitly requested.

## Investigation outcome (Option B picked over A)

Per the issue's "investigate first" recommendation, I traced the coordinator's behavior:

- `phase4-coordinator/internal/buyer/server.go:1337-1366` reserves the `Idempotency-Key` in `request_idempotency_keys` keyed by `(key, body_hash, request_id)`.
- On REPLAY (same key + same body): returns `409 idempotency_key_replayed`.
- On KEY-BUT-BODY-DIFFERS: returns `409 idempotency_key_body_mismatch`.
- Coordinator does NOT serve cached response bodies, so no gateway-side cache is needed (Option A in the issue isn't the right fix).

**Option B**: refund-on-409 + passthrough. Smallest correct change.

## Changes

- `phase5-gateway/internal/router/chat_proxy.go`:
  - New `coordinatorIdempotencyError(status, body) bool` helper — detects the two coord-issued 409 idempotency codes.
  - Added check in both `forwardNonStreamingChat` and `forwardStreamingChat` before the existing `settleBeforeResponse(... "upstream_error")` path.
  - On match: `passThroughNoProviderCoordinatorError` (existing helper) refunds the reservation + passes the coord status/body through verbatim.
- `phase5-gateway/internal/router/server_test.go`:
  - New `TestCoordinatorIdempotencyReplayPassesThroughAndRefunds` covers both codes × both transports (4 subtests).

## Acceptance per issue

- [x] Buyer-visible response on retry is the coord-issued 409 (not remapped to 502 / `upstream_provider_error`).
- [x] No `usage_events` row created on the retry — `settleBeforeResponse` is skipped.
- [x] Reservation refunded so `daily_tokens_used` and `daily_tokens_reserved` stay at 0 for the retry.
- [x] Existing single-request flow unchanged (covered by existing test suite — all green).

## Audit

3-lane codex (CODE / SECURITY / ARCHITECT) — single R1 round, CRITICAL/HIGH bar:

| Lane | Verdict |
|---|---|
| CODE | 0 CRITICAL / 0 HIGH |
| SECURITY | 0 CRITICAL / 0 HIGH |
| ARCHITECT | 0 CRITICAL / 0 HIGH |

Audit prompt: `specs/AUDIT_ISS_200_R1_PROMPT.md`.

## Test plan

- [x] `go test ./... -count=1` — green
- [x] New regression test passes (4 subtests)
- [ ] CI green
- [ ] Post-deploy live verification: fire same `Idempotency-Key` twice, second returns `409`, no quota burn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
