### PR TITLE
fix(provider): authInitialMessage reads warm-swap modelID from ModelRuntime (closes #203)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -1620,14 +1620,35 @@ actor CoordinatorClient {
         providerReceiptPublicKeyOverride: String? = nil
     ) async -> [String: Any] {
         let snapshot = await providerStatus.snapshot()
+        // Issue #203: when warm-swap is enabled, the authoritative
+        // post-swap model metadata lives in `ModelRuntime.currentSnapshot()`,
+        // not in `ProviderStatus` (which carries boot-time / pre-swap
+        // values that drift). helloMessage already routes through the
+        // runtime snapshot; authInitialMessage (v2 auth) historically
+        // missed this, so a reconnect AFTER a completed warm-swap
+        // re-admitted the provider with the STALE pre-swap model_id
+        // until the next regular heartbeat corrected it. Coordinator
+        // routing decisions in that window used the wrong metadata.
+        // Fix: source modelID + modelHash from the same place
+        // helloMessage does.
+        let resolvedModelID: String
+        let resolvedModelHash: String?
+        if warmSwapEnabled {
+            let runtimeSnapshot = await modelRuntime.currentSnapshot()
+            resolvedModelID = runtimeSnapshot.modelID ?? ""
+            resolvedModelHash = runtimeSnapshot.modelHash
+        } else {
+            resolvedModelID = snapshot.modelID ?? ""
+            resolvedModelHash = snapshot.modelHash
+        }
         var message: [String: Any] = [
             "type": "auth_request",
             "version": 2,
             "stage": "initial",
             "provider_id": providerID,
             "hostname": Host.current().localizedName ?? "unknown",
-            "model_id": snapshot.modelID ?? "",
-            "model_params_b": snapshot.capacity.modelParamsB(modelID: snapshot.modelID),
+            "model_id": resolvedModelID,
+            "model_params_b": snapshot.capacity.modelParamsB(modelID: resolvedModelID),
             "ram_gb": snapshot.capacity.ramGB,
             "max_context_tokens": snapshot.capacity.maxContextTokens,
             "max_concurrency": snapshot.capacity.maxConcurrency,
@@ -1643,11 +1664,11 @@ actor CoordinatorClient {
         let resolvedCatalog: [String]
         do {
             resolvedCatalog = try SupportedModels.validate(
-                model: snapshot.modelID ?? "",
+                model: resolvedModelID,
                 supportedModels: supportedModels
             )
         } catch {
-            resolvedCatalog = [snapshot.modelID ?? ""]
+            resolvedCatalog = [resolvedModelID]
         }
         message["supported_models"] = resolvedCatalog
         if publishesSupportedModels {
@@ -1660,7 +1681,7 @@ actor CoordinatorClient {
         if let endpointURL {
             message["endpoint_url"] = endpointURL
         }
-        if let modelHash = snapshot.modelHash {
+        if let modelHash = resolvedModelHash {
             message["model_hash"] = modelHash
         }
         return message

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -813,6 +813,64 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertFalse(json.contains("boot-hash"), json)
     }
 
+    // Issue #203: authInitialMessage (v2 auth on connect/reconnect) must
+    // source model_id and model_hash from ModelRuntime.currentSnapshot()
+    // when warm-swap is enabled, exactly like helloMessage does. Without
+    // this, a reconnect after a completed warm-swap re-admits the
+    // provider with stale pre-swap metadata until the next regular
+    // heartbeat corrects it — coordinator routing decisions in that
+    // window use the wrong model_id.
+    func testAuthInitialEnabledModeReadsFromModelRuntime() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let runtime = makeRuntime(modelID: "model-b", modelHash: "runtime-hash", warmSwapEnabled: true)
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1),
+            modelHash: "boot-hash"
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: true, modelRuntime: runtime)
+
+        let attempt = Tier2AuthAttempt()
+        let auth = await client.authInitialMessage(attempt: attempt)
+        let json = Self.jsonString(auth)
+
+        XCTAssertEqual(auth["model_id"] as? String, "model-b",
+                       "auth_request must publish runtime modelID, not ProviderStatus's pre-swap value")
+        XCTAssertEqual(auth["model_hash"] as? String, "runtime-hash",
+                       "auth_request must publish runtime modelHash, not ProviderStatus's boot-time value")
+        let supportedModels = try XCTUnwrap(auth["supported_models"] as? [String])
+        XCTAssertTrue(supportedModels.contains("model-b"),
+                      "supported_models must validate against post-swap modelID: \(supportedModels)")
+        XCTAssertFalse(json.contains("boot-hash"),
+                       "auth payload must not leak the pre-swap boot hash: \(json)")
+        XCTAssertFalse(json.contains("\"model_id\":\"model-a\""),
+                       "auth payload must not leak the pre-swap modelID: \(json)")
+    }
+
+    // Counterpart to testHelloDisabledModeReadsFromProviderStatus —
+    // when warm-swap is disabled, authInitialMessage continues to
+    // source from ProviderStatus (no behavioral change for the
+    // default path).
+    func testAuthInitialDisabledModeReadsFromProviderStatus() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        // Runtime would carry a different value, but warmSwapEnabled=false
+        // makes authInitialMessage ignore it.
+        let runtime = makeRuntime(modelID: "model-runtime", modelHash: "runtime-hash", warmSwapEnabled: false)
+        let status = ProviderStatus(
+            modelID: "model-status",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1),
+            modelHash: "status-hash"
+        )
+        let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: false, modelRuntime: runtime)
+
+        let auth = await client.authInitialMessage(attempt: Tier2AuthAttempt())
+
+        XCTAssertEqual(auth["model_id"] as? String, "model-status")
+        XCTAssertEqual(auth["model_hash"] as? String, "status-hash")
+    }
+
     func testHelloDuringInFlightSwapReturnsOldHash() async throws {
         let recorder = CoordinatorFrameRecorder()
         let gate = SwapLoaderGate()

--- a/specs/AUDIT_ISS_203_R1_PROMPT.md
+++ b/specs/AUDIT_ISS_203_R1_PROMPT.md
@@ -1,0 +1,105 @@
+# Audit prompt — ISS-203 R1
+
+## What's under review
+
+Branch `fix/iss-203-v2-auth-stale-model` against `origin/main`
+(HEAD `327b02e`). Closes [#203](https://github.com/Augustas11/macprovider/issues/203).
+
+## Background
+
+Pre-existing bug in `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+`authInitialMessage(attempt:providerReceiptPublicKeyOverride:)` (the
+v2 auth payload sent on initial connect AND on every reconnect)
+sourced `model_id`, `model_hash`, and `supported_models` from
+`ProviderStatus.snapshot()` rather than `ModelRuntime.currentSnapshot()`.
+
+`helloMessage()` already routed through the runtime snapshot when
+`warmSwapEnabled` is true. `authInitialMessage` historically did
+not.
+
+## Failure mode
+
+1. Warm-swap completes from model A → model B.
+2. Heartbeat send wedges (#189-class hang).
+3. Bounded-send timeout → close → reconnect.
+4. Reconnect calls `authInitialMessage`.
+5. PRE-FIX: payload reports model A (stale ProviderStatus).
+6. Coordinator re-admits provider under stale routing metadata.
+7. Routing decisions in the window between reconnect and the next
+   regular heartbeat use the wrong `model_id`.
+
+POST-FIX: `authInitialMessage` mirrors `helloMessage`'s warm-swap
+branch — sources `model_id` and `model_hash` from
+`modelRuntime.currentSnapshot()` when `warmSwapEnabled`; falls back
+to `ProviderStatus` otherwise. `supported_models` validation now
+uses the resolved (post-swap) model id.
+
+## What this PR does (small)
+
+- `CoordinatorClient.swift` `authInitialMessage`: extract
+  `resolvedModelID` + `resolvedModelHash` via the same
+  warm-swap branch helloMessage uses; thread them into `model_id`,
+  `model_params_b` (which is per-modelID), `supported_models`
+  validation, and `model_hash`.
+- 2 new XCTests:
+  - `testAuthInitialEnabledModeReadsFromModelRuntime` — mirror of
+    `testHelloEnabledModeReadsFromModelRuntime`. Asserts post-swap
+    runtime values appear; pre-swap values do NOT leak.
+  - `testAuthInitialDisabledModeReadsFromProviderStatus` —
+    confirms warmSwapEnabled=false path is unchanged.
+
+## Severity bar (CRITICAL/HIGH only)
+
+Three independent lanes. Report only CRITICAL or HIGH. Optional
+advisory MEDIUM noted but doesn't gate merge.
+
+## CODE lane
+
+1. Does the new resolved-modelID get threaded through ALL relevant
+   payload fields? (model_id, model_params_b, supported_models,
+   model_hash — anything else that depends on the model identity?)
+2. `model_params_b` switched from `snapshot.modelID` to
+   `resolvedModelID`. Is `ProviderCapacity.modelParamsB(modelID:)`
+   safe when modelID changes mid-flight?
+3. `supported_models` validation: pre-fix validated against
+   `snapshot.modelID`; post-fix uses `resolvedModelID`. Could this
+   change reject a previously-accepted catalog (e.g., if runtime
+   modelID is empty in some boot state)?
+4. Concurrency: `providerStatus.snapshot()` and
+   `modelRuntime.currentSnapshot()` are two separate async reads.
+   Could they tear if a swap completes between them? (helloMessage
+   has the same pattern — is the race acceptable there too?)
+
+## SECURITY lane
+
+1. Could a malicious provider exploit the auth_request payload by
+   triggering an in-flight swap during reconnect to publish a
+   model_id it doesn't actually have loaded? (Risk model: provider
+   is semi-trusted; coordinator routes based on this metadata.)
+2. `model_hash` semantic change — coordinator may use it for
+   integrity verification. Does publishing the runtime hash (vs
+   boot hash) on reconnect open any pinning/verification gap?
+
+## ARCHITECT lane
+
+1. SPEC-002 / SPEC-010 — any contract that constrains
+   auth_request `model_id` to be the boot-time value?
+2. Consistency: `helloMessage` and `authInitialMessage` now share
+   the same warm-swap source. Should they share a helper to make
+   future divergence harder?
+3. The fix doesn't address `sendHeartbeat`'s already-correct
+   warm-swap branch (line ~1566). Does this PR create any
+   inconsistency with other auth-related messages (auth_step2,
+   etc.)?
+
+## Output format
+
+```
+SEVERITY: <CRITICAL|HIGH>
+TITLE: <short>
+FILE: <path>:<line>
+DETAIL: <what fires / why wrong>
+SUGGESTED FIX: <action>
+```
+
+If 0 CRITICAL/HIGH: output exactly `0 CRITICAL / 0 HIGH`.


### PR DESCRIPTION
## Summary

Closes #203.

Pre-fix `CoordinatorClient.authInitialMessage` (v2 auth payload sent on every connect/reconnect) sourced `model_id`, `model_hash`, and `supported_models` from `ProviderStatus.snapshot()` even when warm-swap was enabled. `helloMessage` already routed through `modelRuntime.currentSnapshot()` under `warmSwapEnabled` — `authInitialMessage` historically did not.

## Failure mode (per issue body)

1. Warm-swap completes from model A → model B.
2. Heartbeat send wedges (PR-189-class hang).
3. Bounded-send timeout closes the WS → reconnect.
4. Reconnect runs v2 auth via `authInitialMessage`.
5. PRE-FIX: payload publishes the stale pre-swap `model_id` from `ProviderStatus`. Coordinator re-admits the provider under wrong routing metadata until the next regular heartbeat corrects it.

## Fix (small)

- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`: `authInitialMessage` now resolves `modelID` + `modelHash` via the same `warmSwapEnabled` branch `helloMessage` uses. The resolved `modelID` flows through `model_id`, `model_params_b(modelID:)`, AND `SupportedModels.validate(model:)` (so the catalog matches the actually-loaded model). `model_hash` reads from the runtime snapshot too.
- Disabled-warm-swap path unchanged.

## Tests

- `testAuthInitialEnabledModeReadsFromModelRuntime` — mirrors the existing `testHelloEnabledModeReadsFromModelRuntime`. Asserts post-swap runtime values appear in the payload AND pre-swap values do NOT leak (`model_id`, `model_hash`, `supported_models`).
- `testAuthInitialDisabledModeReadsFromProviderStatus` — pins the `warmSwapEnabled=false` path to existing behavior.

## Audit

3-lane codex (CODE / SECURITY / ARCHITECT) — single R1 round, CRITICAL/HIGH bar:

| Lane | Verdict |
|---|---|
| CODE | 0 CRITICAL / 0 HIGH |
| SECURITY | 0 CRITICAL / 0 HIGH |
| ARCHITECT | 0 CRITICAL / 0 HIGH |

Audit prompt: `specs/AUDIT_ISS_203_R1_PROMPT.md`.

## Test plan

- [x] `swift test --filter AuthInitial` — all 10 auth tests pass (8 existing + 2 new)
- [ ] CI green
- [ ] Live verification post-deploy: trigger warm-swap A→B, force reconnect, confirm coord receives B in v2 auth payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
