### PR TITLE
audit: deepsec pilot eval — adopt for sensitive-path PR scans

### DIFF
--- a/audits/2026-06-28/deepsec-pilot/BUG/macprovider-other-error-suppression-46111188a9.md
+++ b/audits/2026-06-28/deepsec-pilot/BUG/macprovider-other-error-suppression-46111188a9.md
@@ -1,0 +1,27 @@
+# [BUG] Read endpoint database errors are reported as zero or empty data
+
+**File:** [`phase4-coordinator/internal/billing/endpoints.go`](https://github.com/Augustas11/macprovider/blob/main/phase4-coordinator/internal/billing/endpoints.go#L101-L574) (lines 101, 109, 427, 444, 450, 486, 489, 526, 550, 563, 574)
+**Project:** macprovider
+**Severity:** BUG  •  **Confidence:** high  •  **Slug:** `other-error-suppression`
+
+## Owners
+
+**Suggested assignee:** `augstar@gmail.com` _(via last-committer)_
+
+## Finding
+
+The h.sum helper returns 0 for any database error, and several endpoint helpers return empty/nil values on query or decode failures. /admin/ledger/summary can therefore return HTTP 200 with zeroed totals during a database failure, while /providers/{id}/earnings can return 404 or partial zero earnings instead of the required JSON error envelope with no ledger data.
+
+## Recommendation
+
+Use sumErr or typed helper methods that distinguish NULL aggregates from query failures, and propagate failures to writeError with an appropriate 5xx response. Keep zero defaults only for successful NULL aggregate results.
+
+## Revalidation
+
+**Verdict:** true-positive
+
+The helper h.sum calls h.sumErr and returns 0 on any error at lines 486-490, conflating a real query failure with a successful NULL aggregate. /admin/ledger/summary builds every numeric field with h.sum and then unconditionally writes HTTP 200, so a database error can produce a zeroed summary instead of the standard error envelope. The provider earnings path uses h.sum for the provider-existence check, so a database error on COUNT can become a 404 provider not found. The same endpoint also uses h.sum for total/current/fault/share values, and helpers like modelsServed, rateCardExcerpt, and lastPayout return empty or nil data on query, scan, or JSON decode failure. Admin auth and provider-token checks still protect these endpoints, so this is not an auth bypass, but it is a real observability and reconciliation-integrity bug. The current code has no mitigation that distinguishes database failure from valid empty results on these read paths.
+
+## Recent committers (`git log`)
+
+- a11 <augstar@gmail.com> (2026-06-26)

--- a/audits/2026-06-28/deepsec-pilot/BUG/macprovider-other-nondeterministic-recovery-15c237d087.md
+++ b/audits/2026-06-28/deepsec-pilot/BUG/macprovider-other-nondeterministic-recovery-15c237d087.md
@@ -1,0 +1,27 @@
+# [BUG] Malformed non-503 timestamps are recovered using the current time
+
+**File:** [`phase4-coordinator/internal/billing/recovery.go`](https://github.com/Augustas11/macprovider/blob/main/phase4-coordinator/internal/billing/recovery.go#L112-L251) (lines 112, 114, 157, 251)
+**Project:** macprovider
+**Severity:** BUG  •  **Confidence:** high  •  **Slug:** `other-nondeterministic-recovery`
+
+## Owners
+
+**Suggested assignee:** `augstar@gmail.com` _(via last-committer)_
+
+## Finding
+
+When RecoverLedger cannot parse request_log.ts_utc, it substitutes time.Now().UTC(). That makes recovery nondeterministic and can select the wrong config snapshot/rate card for billing, or write quarantine rows with a recovery-time timestamp instead of failing or quarantining the malformed source row. The 503 path is filtered before parsing, but non-503 malformed rows can still be billed or classified using the wrong time.
+
+## Recommendation
+
+Treat malformed non-503 timestamps as a deterministic quarantine reason or fail the reconciliation run; do not substitute the wall-clock time for billing or snapshot selection.
+
+## Revalidation
+
+**Verdict:** true-positive
+
+RecoverLedger selects non-503 request_log rows and then parses rl.ts_utc with time.Parse(time.RFC3339Nano). If parsing fails, the code assigns ts = time.Now().UTC() and continues instead of failing or quarantining deterministically. That substituted timestamp is then used for snapshotAtTx, HotPathInput.TSUtc, insertQuarantineTx, and insertRequestCreditTx, so the same persisted request_log row can use a different rate snapshot or quarantine timestamp depending on when recovery runs. The SQL status != 503 filter does preserve the intentional malformed-503 skip behavior, but it does nothing for malformed non-503 rows. Normal requestlog.Insert writes a valid formatted time.Time, so I did not find a public buyer/provider path that directly sets malformed ts_utc in current code. However, the schema stores ts_utc as unconstrained TEXT, recovery is explicitly for persisted ledger/request-log repair, and malformed legacy/manual/corrupt non-503 rows are handled nondeterministically today. This is a real recovery integrity bug with a narrower precondition than a remotely supplied timestamp.
+
+## Recent committers (`git log`)
+
+- a11 <augstar@gmail.com> (2026-06-26)

--- a/audits/2026-06-28/deepsec-pilot/BUG/macprovider-other-silent-settlement-failure-9b81aef20d.md
+++ b/audits/2026-06-28/deepsec-pilot/BUG/macprovider-other-silent-settlement-failure-9b81aef20d.md
@@ -1,0 +1,27 @@
+# [BUG] Weekly settlement job drops settlement errors
+
+**File:** [`phase4-coordinator/internal/billing/settlement.go`](https://github.com/Augustas11/macprovider/blob/main/phase4-coordinator/internal/billing/settlement.go#L152) (lines 152)
+**Project:** macprovider
+**Severity:** BUG  •  **Confidence:** medium  •  **Slug:** `other-silent-settlement-failure`
+
+## Owners
+
+**Suggested assignee:** `augstar@gmail.com` _(via last-committer)_
+
+## Finding
+
+StartWeeklySettlement invokes RunSettlement and discards the returned error. A DB error, lock timeout, or migration/schema problem would make the weekly payout job fail without an audit row, log, retry signal, or caller-visible failure, delaying payouts until someone notices operationally.
+
+## Recommendation
+
+Record failed settlement attempts in the reconciliation/audit table or structured logs, and expose enough status for operators to alert and retry.
+
+## Revalidation
+
+**Verdict:** true-positive
+
+StartWeeklySettlement invokes RunSettlement in its timer goroutine and assigns the returned error to _. RunSettlement can return errors from BeginTx, every Exec/Query/Scan, rows.Err, or Commit, and it does not write a failed reconciliation/audit row on those paths. StartWeeklySettlement has no logger parameter, no status sink, and no retry signal; main.go simply starts the goroutine and cannot observe per-run failures. If SQLite is locked, the schema is broken, or a commit fails at the weekly boundary, the job silently returns to the loop. Because NextMondayUTC is recomputed after the timer cycle, the next automatic attempt is the following week, not an immediate retry. This is therefore a real operational payout failure mode, not just missing polish.
+
+## Recent committers (`git log`)
+
+- a11 <augstar@gmail.com> (2026-06-01)

--- a/audits/2026-06-28/deepsec-pilot/HIGH/macprovider-other-payment-integrity-8718b733f6.md
+++ b/audits/2026-06-28/deepsec-pilot/HIGH/macprovider-other-payment-integrity-8718b733f6.md
@@ -1,0 +1,27 @@
+# [HIGH] Provider-reported prompt_tokens can inflate payouts
+
+**File:** [`phase4-coordinator/internal/billing/formula.go`](https://github.com/Augustas11/macprovider/blob/main/phase4-coordinator/internal/billing/formula.go#L119-L141) (lines 119, 136, 141)
+**Project:** macprovider
+**Severity:** HIGH  •  **Confidence:** high  •  **Slug:** `other-payment-integrity`
+
+## Owners
+
+**Suggested assignee:** `augstar@gmail.com` _(via last-committer)_
+
+## Finding
+
+ComputeCredits copies promptTokens directly into the billable prompt count, only rejecting negative values or values above maxBillableTokens, then multiplies that value by the prompt rate. The completion side is protected by billableCompletion(), which clamps provider-reported completion_tokens to the coordinator-observed estimated_completion_tokens, but there is no equivalent coordinator-derived bound for prompt_tokens. In production flow, provider usage.prompt_tokens reaches HotPathInput.PromptTokens and then ComputeCredits; a malicious onboarded provider can report an inflated prompt token count up to 10,000,000 for a small buyer request and receive inflated prompt-side provider credits while still passing the current range checks.
+
+## Recommendation
+
+Carry a coordinator-observed prompt token estimate or reservation into billing, clamp provider-reported prompt_tokens to that value plus a tight tolerance, and quarantine or zero-credit rows with implausible prompt usage. Apply the same rule in hot path and recovery, and add regression tests for prompt over-reporting.
+
+## Revalidation
+
+**Verdict:** true-positive
+
+ComputeCredits copies promptTokens into the billable prompt count at lines 119-122 and only applies invalidBillableTokenCount before multiplying by the prompt rate at line 141. The completion path is different: billableCompletion receives estimatedCompletionTokens and clamps provider-reported completion to the coordinator-observed estimate when present. I traced the hot path through buyer.billingRecorder.recordRow into billing.HotPathInput and WriteHotPath, and provider response usage is parsed directly by tokenPointersFromChatResponse/tokenPointersFromUsageObject. The only coordinator-derived prompt value I found is a fallback estimate when prompt tokens are absent on certain error/estimated-completion paths; it is not used as a cap when the provider supplies prompt_tokens. Recovery also reads request_log.prompt_tokens and passes it through to ComputeCredits. A malicious onboarded provider can return usage.prompt_tokens=10000000 for a small request, stay within the current maxBillableTokens check, and inflate gross/provider credits on the prompt-rate side while completion remains clamped.
+
+## Recent committers (`git log`)
+
+- a11 <augstar@gmail.com> (2026-06-03)

--- a/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-billing-integrity-969d206e83.md
+++ b/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-billing-integrity-969d206e83.md
@@ -1,0 +1,27 @@
+# [HIGH_BUG] Reconcile fallback ignores coordinator-estimated completion tokens
+
+**File:** [`phase4-coordinator/internal/billing/endpoints.go`](https://github.com/Augustas11/macprovider/blob/main/phase4-coordinator/internal/billing/endpoints.go#L303-L357) (lines 303, 343, 353, 357)
+**Project:** macprovider
+**Severity:** HIGH_BUG  •  **Confidence:** high  •  **Slug:** `other-billing-integrity`
+
+## Owners
+
+**Suggested assignee:** `augstar@gmail.com` _(via last-committer)_
+
+## Finding
+
+buyerEquivalentCredits recomputes buyer-equivalent credits from request_log when there is not exactly one matching byte_estimated ledger row, but the request_log scan does not select estimated_completion_tokens. The fallback builds cp from provider-reported completion_tokens and calls ComputeCredits with a nil estimate and usageFor(..., nil), so billableCompletion cannot clamp provider-reported completion to the coordinator-observed estimate. A provider that over-reports completion_tokens can therefore corrupt admin reconciliation totals whenever the ledger row is missing or duplicate, violating the package invariant that provider-reported completion must be bounded by estimated_completion_tokens.
+
+## Recommendation
+
+Select rl.estimated_completion_tokens into the scratch row, build an ep pointer, and call usageFor(errorCode, ep) and ComputeCredits(pp, cp, ep, ...). Add a reconcile regression where completion_tokens exceeds estimated_completion_tokens and the ledger row is absent or duplicated.
+
+## Revalidation
+
+**Verdict:** true-positive
+
+buyerEquivalentCredits scans request_log into requestLogScan, but the SELECT at lines 303-307 includes prompt_tokens and completion_tokens and omits estimated_completion_tokens. If byteEstimatedLedgerGross finds exactly one non-quarantined byte_estimated ledger row, it safely recomputes using that ledger estimate. When that safe path is unavailable because the ledger row is missing, duplicated, not byte_estimated, or lacks an estimate, the fallback builds pp/cp from request_log and calls ComputeCredits with estimatedCompletionTokens set to nil at line 357. usageFor is also called with nil, so billableCompletion has no coordinator-observed bound and will accept provider-reported completion_tokens up to the global maximum. request_log does store estimated_completion_tokens elsewhere and recovery uses it, so this is a local omission in the admin reconcile fallback. The impact is reconciliation integrity rather than direct payout creation: an over-reporting provider can corrupt buyer-equivalent admin totals whenever reconciliation falls back to request_log instead of a single byte_estimated ledger row.
+
+## Recent committers (`git log`)
+
+- a11 <augstar@gmail.com> (2026-06-26)

--- a/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-idempotency-invariant-a4a2ed2fad.md
+++ b/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-idempotency-invariant-a4a2ed2fad.md
@@ -1,0 +1,27 @@
+# [HIGH_BUG] Schema does not enforce one active credit per request attempt
+
+**File:** [`phase4-coordinator/internal/billing/store.go`](https://github.com/Augustas11/macprovider/blob/main/phase4-coordinator/internal/billing/store.go#L73) (lines 73)
+**Project:** macprovider
+**Severity:** HIGH_BUG  •  **Confidence:** medium  •  **Slug:** `other-idempotency-invariant`
+
+## Owners
+
+**Suggested assignee:** `augstar@gmail.com` _(via last-committer)_
+
+## Finding
+
+The ledger_request_credits uniqueness constraint is on (request_id, attempt_n, provider_id), so the database permits multiple non-quarantined rows for the same (request_id, attempt_n) if provider_id differs. The hot path and recovery code try to quarantine ambiguous attempts, but the money-path invariant is not enforced at the storage boundary; any recovery/admin/code-path regression can create duplicate active credits that settlement will later pay independently.
+
+## Recommendation
+
+Add a partial unique index such as UNIQUE(request_id, attempt_n) WHERE quarantined = 0, after migrating or quarantining any existing duplicates. Keep separate quarantined rows allowed if needed for forensic history.
+
+## Revalidation
+
+**Verdict:** true-positive
+
+The ledger_request_credits table still has UNIQUE(request_id, attempt_n, provider_id), not a partial unique constraint on request_id and attempt_n for quarantined = 0. That means SQLite accepts two non-quarantined rows for the same request attempt when provider_id differs. Settlement does not detect that invariant violation: it groups active unsettled rows by provider_id and will include each duplicate row in payout-ready totals independently. I traced the current production write paths and did not find an HTTP endpoint that inserts arbitrary ledger rows; WriteHotPath and RecoverLedger try to derive attempts and quarantine ambiguous cases. That application logic reduces direct remote exploitability, but it is not a storage-boundary enforcement of the stated money-path invariant. Any internal recovery/import/admin regression, or direct DB repair mistake, can create a duplicate active state that the current settlement code will pay rather than reject. The current schema and git history show no partial unique index or equivalent database guard has been added.
+
+## Recent committers (`git log`)
+
+- a11 <augstar@gmail.com> (2026-06-26)

--- a/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-payout-state-corruption-d15b0e9e36.md
+++ b/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-payout-state-corruption-d15b0e9e36.md
@@ -1,0 +1,27 @@
+# [HIGH_BUG] Payout can be irreversibly consumed without external payout evidence
+
+**File:** [`phase4-coordinator/internal/billing/payout.go`](https://github.com/Augustas11/macprovider/blob/main/phase4-coordinator/internal/billing/payout.go#L28-L37) (lines 28, 30, 36, 37)
+**Project:** macprovider
+**Severity:** HIGH_BUG  •  **Confidence:** high  •  **Slug:** `other-payout-state-corruption`
+
+## Owners
+
+**Suggested assignee:** `augstar@gmail.com` _(via last-committer)_
+
+## Finding
+
+ClaimPayoutReady transitions a ready payout to consumed when the gross amount matches, but it does not require payoutExternalID or payoutCurrency to be non-empty. Because nullString converts empty strings to NULL, a caller can permanently consume a payout row with no external transaction id and/or no currency. The terminal-status trigger then prevents repairing the status, leaving a payout that appears consumed but cannot be reconciled to an external rail.
+
+## Recommendation
+
+Reject empty payoutExternalID and payoutCurrency before the UPDATE. For the current payout rail, enforce the canonical currency value expected by the caller, or at minimum require non-empty strings and add tests for empty values.
+
+## Revalidation
+
+**Verdict:** true-positive
+
+ClaimPayoutReady validates that the payout exists, is ready, and has the expected gross amount, but it does not validate payoutExternalID or payoutCurrency before the UPDATE. It passes both values through nullString at lines 36-37, and nullString converts empty strings into sql.NullString with Valid=false. The ledger_payout_ready schema explicitly allows payout_currency and payout_external_id to be NULL while status can become consumed. The terminal-status trigger prevents moving a consumed row back to ready or voided, and ClaimPayoutReady itself cannot be called again because the row is no longer status='ready'. I found no current production endpoint directly exposing this method outside tests/spec consumers, so this is an API-level money-out primitive bug rather than a remote unauthenticated path. It is still real for any payout rail or operator caller: passing an empty tx id or currency can mark funds as consumed without durable external payout evidence.
+
+## Recent committers (`git log`)
+
+- a11 <augstar@gmail.com> (2026-06-01)

--- a/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-reconciliation-integrity-71e8097800.md
+++ b/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-reconciliation-integrity-71e8097800.md
@@ -1,0 +1,27 @@
+# [HIGH_BUG] Reconcile silently skips rows when config snapshot lookup fails
+
+**File:** [`phase4-coordinator/internal/billing/endpoints.go`](https://github.com/Augustas11/macprovider/blob/main/phase4-coordinator/internal/billing/endpoints.go#L250-L355) (lines 250, 253, 353, 355)
+**Project:** macprovider
+**Severity:** HIGH_BUG  •  **Confidence:** high  •  **Slug:** `other-reconciliation-integrity`
+
+## Owners
+
+**Suggested assignee:** `augstar@gmail.com` _(via last-committer)_
+
+## Finding
+
+For non-503 request_log rows, buyerEquivalentCredits calls snapshotAt and simply continues on any error, including ErrNoSnapshot, malformed snapshot JSON, context cancellation, or database errors. The caller then inserts ledger_reconciliation_runs with status='complete'. This can make a range with unreconciled request_log rows appear clean, especially when both providerGross and buyerEquivalent are reduced to zero for the skipped work.
+
+## Recommendation
+
+Do not silently omit contributing rows. Propagate snapshot lookup errors so /admin/ledger/reconcile returns a failure envelope and does not insert a complete run, or explicitly account for/quarantine missing-snapshot rows consistently with recovery.
+
+## Revalidation
+
+**Verdict:** true-positive
+
+In buyerEquivalentCredits, after the request_log row is parsed and no byte_estimated ledger gross is available, the code calls h.store.snapshotAt(ctx, ts). On any error it executes continue at lines 353-355 instead of returning an error or accounting for the row. snapshotAt can return ErrNoSnapshot, database errors, or JSON unmarshal errors from malformed rate_card_json. The outer reconcile handler treats a nil error from buyerEquivalentCredits as success and inserts a ledger_reconciliation_runs row with status='complete'. This means a reconcile range can report clean completion while omitting non-503 request_log rows from buyer_equivalent_credits. Recovery handles missing snapshots by quarantining or surfacing the condition, but the admin endpoint fallback does not. Some context-cancellation cases may be caught by neighboring queries, but missing/corrupt snapshot cases are enough to make the finding real.
+
+## Recent committers (`git log`)
+
+- a11 <augstar@gmail.com> (2026-06-26)

--- a/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-settled-ledger-corruption-8903a1b791.md
+++ b/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-settled-ledger-corruption-8903a1b791.md
@@ -1,0 +1,27 @@
+# [HIGH_BUG] Recovery can quarantine already-settled ledger rows
+
+**File:** [`phase4-coordinator/internal/billing/recovery.go`](https://github.com/Augustas11/macprovider/blob/main/phase4-coordinator/internal/billing/recovery.go#L117-L446) (lines 117, 159, 213, 446)
+**Project:** macprovider
+**Severity:** HIGH_BUG  •  **Confidence:** medium  •  **Slug:** `other-settled-ledger-corruption`
+
+## Owners
+
+**Suggested assignee:** `augstar@gmail.com` _(via last-committer)_
+
+## Finding
+
+Several recovery branches call quarantineExistingLedgerForRequestAttemptTx before the settled-row mismatch guard in reconcileExistingCreditTx. The helper updates any non-quarantined matching ledger row and does not exclude settled rows or rows with settlement_id set. If a settled/payout-backed row later hits the invalid_usage_tokens, missing_config_snapshot, or ambiguous_attempt_n branch, recovery can retroactively mark it quarantined while the payout row remains intact, corrupting settlement reconciliation and provider earnings history.
+
+## Recommendation
+
+Do not quarantine settled rows in this helper. Add `settled = 0 AND settlement_id IS NULL` to the UPDATE and return an explicit error/page condition if a settled row would otherwise need quarantine, matching the existing settled mismatch behavior.
+
+## Revalidation
+
+**Verdict:** true-positive
+
+The current recovery flow still has quarantine branches before the settled-row guard in reconcileExistingCreditTx. The invalid_usage_tokens branch, missing_config_snapshot branch, and attempt_n > 1 ambiguous branch all call quarantineExistingLedgerForRequestAttemptTx directly. That helper updates ledger_request_credits by request_id, attempt_n, provider_assigned_id or resolved provider_id, and quarantined = 0, but it does not filter on settled = 0 or settlement_id IS NULL. The later guard in reconcileExistingCreditTx only protects rows that reach the recomputation mismatch path; these early branches skip that path entirely. A concrete corruption scenario is a request_log row with invalid usage tokens: request_log has no non-negative CHECK, hot-path billing can zero the ledger row, settlement can still mark it settled as part of a provider window, and later recovery will quarantine the settled row from the request_log token check. The payout_ready row and settlement_id remain intact, so reconciliation and earnings history now disagree about whether a payout-backed source row is active. The finding is not fixed in current HEAD; git blame shows the helper and its callers still have no settled-row exclusion.
+
+## Recent committers (`git log`)
+
+- a11 <augstar@gmail.com> (2026-06-26)

--- a/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-settlement-window-skew-98a0093342.md
+++ b/audits/2026-06-28/deepsec-pilot/HIGH_BUG/macprovider-other-settlement-window-skew-98a0093342.md
@@ -1,0 +1,27 @@
+# [HIGH_BUG] Settlement uses lexicographic RFC3339Nano timestamp cutoffs
+
+**File:** [`phase4-coordinator/internal/billing/settlement.go`](https://github.com/Augustas11/macprovider/blob/main/phase4-coordinator/internal/billing/settlement.go#L23-L120) (lines 23, 37, 61, 120)
+**Project:** macprovider
+**Severity:** HIGH_BUG  •  **Confidence:** high  •  **Slug:** `other-settlement-window-skew`
+
+## Owners
+
+**Suggested assignee:** `augstar@gmail.com` _(via last-committer)_
+
+## Finding
+
+RunSettlement compares ts_utc TEXT directly to windowEnd formatted with time.RFC3339Nano. RFC3339Nano is variable-width, so a row at 2026-06-08T00:00:00.5Z sorts lexicographically before 2026-06-08T00:00:00Z because '.' < 'Z'. That lets work completed just after a settlement boundary be quarantined or settled into the prior window, breaking payout-window integrity and letting a provider time requests around the cutoff for earlier payout inclusion.
+
+## Recommendation
+
+Do not range-filter RFC3339Nano strings lexicographically. Store a fixed-width UTC timestamp or integer unix nanoseconds, or use SQLite time functions consistently for cutoff comparisons; add a regression test for rows in the first fractional second after windowEnd.
+
+## Revalidation
+
+**Verdict:** true-positive
+
+RunSettlement compares ledger_request_credits.ts_utc as TEXT against windowEnd.UTC().Format(time.RFC3339Nano) in the quarantine, grouping, and settled-update queries. The hot path and request-log store also write timestamps with time.RFC3339Nano, which is variable-width. For a weekly boundary like 2026-06-08T00:00:00Z, a row at 2026-06-08T00:00:00.5Z compares lexicographically less than the boundary because '.' sorts before 'Z'. That row is chronologically after the window end but satisfies ts_utc < windowEnd, so settlement can include it in the prior payout window and then mark it settled. The request-log pruning code in another package explicitly documents this same RFC3339Nano lexicographic hazard and uses julianday for that reason, but settlement does not. There is no lower-bound filter that would save this, since old under-threshold rows intentionally roll forward and the settlement query only uses ts_utc < end. A buyer/provider timing work just after the cutoff can therefore be paid in the earlier window.
+
+## Recent committers (`git log`)
+
+- a11 <augstar@gmail.com> (2026-06-01)

--- a/audits/2026-06-28/deepsec-pilot/STAGE2_EVAL.md
+++ b/audits/2026-06-28/deepsec-pilot/STAGE2_EVAL.md
@@ -1,0 +1,259 @@
+# Stage 2 — hand-evaluation of deepsec pilot findings
+
+**Scope:** 8 novel findings from `audits/2026-06-28/deepsec-pilot/SUMMARY.md`
+(Findings #1 and #4 are pre-classified TP-known per the handoff brief —
+they correlate with commit `9bd77f4 Close audited billing and idempotency
+gaps`).
+**Method:** opened each finding's named source line, traced the claim
+against current `phase4-coordinator/internal/billing/` HEAD, cross-checked
+`audits/2026-06-{03,10,24}/`, `specs/SPEC-005-*`, `specs/SPEC-016-*`, and
+the ARC-3 nested-queries audit set for prior coverage.
+
+## Verdict table
+
+| # | File:line | Claim | Classification | Reasoning summary |
+|---|---|---|---|---|
+| 1 | `endpoints.go:303,343,353,357` | Reconcile fallback bypasses 9bd77f4's completion-clamp | TP-known | Pre-classified per brief; generalization of 9bd77f4 |
+| 2 | `endpoints.go:353-355` | `buyerEquivalentCredits` silently `continue`s on `snapshotAt` errors, parent records `status='complete'` | TP-novel | ARC-3 SEC audit Q3 explicitly green-lit this path on the basis that errors propagate — but only `time.Parse` and `byteEstimatedLedgerGross` return; `snapshotAt` uses `continue`. Real gap that survived a prior audit asking exactly this question. |
+| 3 | `endpoints.go:486-490` (`h.sum`) | `h.sum` returns 0 on DB error, summary returns 200 with zeroed totals, earnings returns 404 | TP-known | ARC-3 SECURITY audit (`specs/ARC_3_NESTED_QUERIES_SECURITY_audit.md` SEC-2) flagged the exact `endpoints.go:492-496` `h.sum` swallow-error pattern and recommended `sumErr`. Fix landed only in the providers handler (commit `4f73f5d`, PR #175); summary / earnings / lastPayout / modelsServed / rateCardExcerpt still use `h.sum` or `return nil/empty` on error. Class in backlog; broader sweep is the novel scope. |
+| 4 | `formula.go:119,136,141` | `prompt_tokens` not clamped against coordinator estimate | TP-known | Pre-classified per brief; symmetric complement of 9bd77f4 |
+| 5 | `payout.go:28-37` | `ClaimPayoutReady` accepts empty `payoutExternalID` / `payoutCurrency`, writes NULL, terminal-status trigger prevents repair | TP-known | SPEC-016 §4.3 step 8 (line 1309-1320) explicitly mandates the caller pass non-empty `"USDC-BASE"` and §7.4 reconciliation surfaces NULL `payout_currency` on `consumed` rows as a separate failure class. Spec acknowledged the same concern and chose caller-discipline + post-hoc detection over primitive-side validation. |
+| 6 | `recovery.go:446` (`quarantineExistingLedgerForRequestAttemptTx`) | Helper lacks `settled=0 AND settlement_id IS NULL` filter; `invalid_usage_tokens` / `missing_config_snapshot` / `ambiguous_attempt_n` branches can quarantine settled rows | TP-novel | Confirmed at recovery.go:446-470: only `quarantined = 0` filter. The settled-row guard at reconcileExistingCreditTx:406 is only reached on the recomputation-mismatch path; early branches at lines 117, 159, 213 skip it. Not covered in any prior audit; ARC-3 looked at `RecoverLedger` for deadlock only. |
+| 7 | `recovery.go:112-114` | `time.Now().UTC()` substituted for unparseable `ts_utc`; nondeterministic snapshot selection | TP-novel | Confirmed at recovery.go:112-115. Precondition is narrow (request_log writes via `Insert` use a valid `time.Time`, so only legacy/manual/corrupt rows hit this), but the fallback path is real and silently selects a wrong-window rate-card snapshot. Not covered. |
+| 8 | `settlement.go:23,37,61,120` | RFC3339Nano lexicographic compare of `ts_utc TEXT` vs window-end cutoff lets `.5Z` rows sort before `Z` rows | TP-novel | Confirmed: `NextMondayUTC` returns midnight (no fractional), formatted windowEnd is `2026-06-08T00:00:00Z`. `.` (0x2E) < `Z` (0x5A) so `2026-06-08T00:00:00.5Z` lexically precedes the boundary. The hazard CLASS was documented in `audits/2026-06-10/REMAINING_WORK.md` lines 31, 126 — but scoped only to `phase4-coordinator/internal/requestlog/store.go` retention pruning, framed "Low risk now; degrades as request_log grows." The settlement.go instance was not in backlog; it has a materially worse blast radius (provider payout window vs. retention prune). |
+| 9 | `settlement.go:152` | `StartWeeklySettlement` discards `RunSettlement` error; weekly payout job fails silently | TP-known | Same pattern flagged in `audits/2026-06-03/ARCHITECTURE_AUDIT.md` line 103 for `StartNightlyReconcile`'s `_ = s.RecoverLedger(...)` and called out as a recurring theme at line 274 ("money-path durability is eventually-consistent and best-effort, with no alarming on the degradation rate") and line 278 ("discarded settle errors are silent"). Class in backlog; this is the weekly-settlement instance that 2026-06-03 missed. |
+| 10 | `store.go:73` | `UNIQUE(request_id, attempt_n, provider_id)` permits multiple non-quarantined rows for same (request_id, attempt_n) across different provider_ids | TP-novel | The schema literal is consistent with SPEC-005 D10's chosen key, but the application logic (recovery's `ambiguous_attempt_n` quarantine at recovery.go:212, hot-path deterministic provider derivation) implements "one provider per (request_id, attempt_n)". The storage boundary doesn't enforce that. SPEC-005-r2-audit X-2 covered the related `request_log` row-uniqueness gap but did not address `ledger_request_credits`. Defense-in-depth gap; no remote write path, but real for internal recovery/import/admin regressions. |
+
+## Per-finding evaluation
+
+### Finding #1 (HIGH_BUG, endpoints.go reconcile fallback) — TP-known
+Pre-classified per the handoff brief. Generalization of commit `9bd77f4`'s
+`billableCompletion` clamp to the `buyerEquivalentCredits` reconcile
+fallback path that 9bd77f4 did not touch. Not re-evaluated here.
+
+### Finding #2 (HIGH_BUG, endpoints.go reconcile silent skip) — TP-novel
+At endpoints.go:330-360 the loop body propagates errors from
+`time.Parse` (line 336) and `byteEstimatedLedgerGross` (line 348) via
+`return 0, err`, but the `h.store.snapshotAt(ctx, ts)` call at line 353
+uses `continue` on error. The outer `reconcile` handler treats a nil
+return from `buyerEquivalentCredits` as success and inserts a
+`ledger_reconciliation_runs` row with hard-coded `status='complete'` at
+endpoints.go:259. `specs/ARC_3_NESTED_QUERIES_SECURITY_audit.md` Q3
+specifically asserted "the second-pass `buyerEquivalentCredits` error
+path returns before [...] inserts `ledger_reconciliation_runs`, so no
+partial reconciliation row is committed when per-row work fails" — that
+assertion is overbroad. The recovery path handles `snapshotAt` failure by
+quarantining (`missing_config_snapshot`, recovery.go:159); the admin
+reconcile path silently undercounts. Real asymmetry. Defense-in-depth
+fix: change `continue` to a quarantine row + counter increment OR
+propagate the error and let the run record `status='failed'`.
+
+### Finding #3 (BUG, endpoints.go h.sum) — TP-known
+At endpoints.go:486-490, `h.sum` discards the error and returns 0. The
+`/admin/ledger/summary` handler (lines 97-112) builds every field via
+`h.sum` and unconditionally writes 200. `/providers/{id}/earnings` uses
+`h.sum` for both the provider-existence check at line 427 (DB error →
+404) and the total/current/fault values at lines 444-450. `lastPayout`,
+`modelsServed`, `rateCardExcerpt`, `latestShareBps` all return
+empty/nil/0 on error. `specs/ARC_3_NESTED_QUERIES_SECURITY_audit.md`
+SEC-2 explicitly recommended "Use `sumErr` in the second pass" for the
+providers handler — that fix landed in PR #175 (commit `4f73f5d`) but
+was scoped to the providers N+1, not swept across the other endpoints.
+The endpoints.go:138-142 comment block written for that PR even
+acknowledges "h.sum swallows errors" was a problem and references the
+specific shape that was fixed. Class is in backlog; broader instance
+remains. Lower-severity finding (observability, not money loss).
+
+### Finding #4 (HIGH, formula.go prompt_tokens unbounded) — TP-known
+Pre-classified per the handoff brief. Symmetric complement of `9bd77f4`'s
+completion-side `billableCompletion` clamp. Not re-evaluated here.
+
+### Finding #5 (HIGH_BUG, payout.go ClaimPayoutReady) — TP-known
+Confirmed at payout.go:28-40: the UPDATE does not validate
+`payoutExternalID` or `payoutCurrency` before passing them through
+`nullString()` (store.go:323-328), which converts `""` to
+`sql.NullString{Valid:false}` (NULL). `ledger_payout_ready` schema
+(store.go:111-117) allows both columns NULL, and
+`trg_lpr_terminal_status_guard` (store.go:121-126) prevents repair once
+status is `consumed`. SPEC-016 v0.1 §4.3 step 8 (line 1309-1320)
+acknowledges this exact concern: "`payoutCurrency` MUST be the literal
+string `\"USDC-BASE\"` (never empty, never NULL). IMPL MUST add a unit
+test asserting the literal is passed; the §7.4 reconciliation surfaces a
+NULL `payout_currency` on a `consumed` row as a separate failure class
+to catch any regression." Spec consciously chose caller-discipline +
+reconciliation-detection over primitive-side validation. Deepsec's
+recommendation is a reasonable defense-in-depth tightening but the bug
+is already in the spec's awareness.
+
+### Finding #6 (HIGH_BUG, recovery.go quarantine settled rows) — TP-novel
+Confirmed at recovery.go:446-470: the UPDATE filters only
+`quarantined = 0`, not `settled = 0 AND settlement_id IS NULL`. Callers
+that bypass `reconcileExistingCreditTx`'s settled-row guard
+(recovery.go:406): `invalid_usage_tokens` branch (line 117),
+`missing_config_snapshot` branch (line 159), `ambiguous_attempt_n`
+branch for `attemptN > 1` (line 213). The deepsec revalidation traces a
+concrete scenario: a settled row whose source `request_log` row has
+invalid usage tokens hits the line-117 branch and gets retroactively
+quarantined while its `payout_ready` row remains intact. ARC-3 audited
+`RecoverLedger` for deadlock only; SPEC-005's audits (r1, r2) did not
+cover this. Real corruption scenario for the recovery path; trigger
+requires either malformed legacy request_log rows or admin operations on
+the rate-card snapshot table after a settlement window closes. Fix is
+~1 line per call site or one predicate added to the helper.
+
+### Finding #7 (BUG, recovery.go time.Now() fallback) — TP-novel
+Confirmed at recovery.go:112-115:
+```go
+ts, err := time.Parse(time.RFC3339Nano, tsText)
+if err != nil {
+    ts = time.Now().UTC()
+}
+```
+That `ts` is then passed to `snapshotAtTx`, `HotPathInput.TSUtc`,
+`insertQuarantineTx`, and `insertRequestCreditTx`. Same persisted
+request_log row recovered at different wall-clock times can select
+different rate-card snapshots. `requestlog.Insert` writes a valid
+formatted time.Time so there is no public path to inject malformed
+`ts_utc` — precondition is narrow (legacy data, manual repair, schema
+drift). Not in any audit or spec. Lower severity. Fix is one line: treat
+parse failure as a deterministic quarantine.
+
+### Finding #8 (HIGH_BUG, settlement.go RFC3339Nano lex compare) — TP-novel
+Confirmed: `RunSettlement` (settlement.go:23,37,61,120) compares
+`ts_utc TEXT` against `windowEnd.UTC().Format(time.RFC3339Nano)`.
+`NextMondayUTC` returns midnight UTC (no fractional seconds), so
+windowEnd is `2026-06-08T00:00:00Z`. A row written at
+`2026-06-08T00:00:00.000000001Z` (chronologically just after the
+boundary) compares lexicographically less than the boundary because
+`'.'` (0x2E) sorts before `'Z'` (0x5A). That row is then included in
+the prior settlement window and marked `settled=1`. The hazard CLASS
+was documented at `audits/2026-06-10/REMAINING_WORK.md` line 126: "RFC3339Nano
+writes are variable-width (`.` 0x2E < `Z` 0x5A) so lexicographic compare
+is silently wrong at fractional-second boundaries. PERF-3 batched-DELETE
+shipped, but the index is still defeated by julianday(). Low risk now;
+degrades as request_log grows." That entry scoped the concern strictly
+to `phase4-coordinator/internal/requestlog/store.go` retention pruning.
+The settlement.go application of the same class was not in backlog and
+has materially worse blast radius (provider payout window assignment vs.
+retention prune wall-clock skew). Strictly TP-novel because the
+settlement-specific instance is unaddressed; the class is recognized
+elsewhere. The deepsec agent's own revalidation note caught the
+requestlog pruner using `julianday(...)` for this reason — strong recall
+signal. Fix is store-as-fixed-width or use `julianday()` in the
+settlement queries.
+
+### Finding #9 (BUG, settlement.go silent RunSettlement) — TP-known
+Confirmed at settlement.go:152: `_ = s.RunSettlement(ctx, cfg, start, end)`.
+`StartWeeklySettlement` has no logger, no status sink, no retry signal;
+on failure it returns to the timer loop and the next attempt is the
+following Monday. Exact same `_ = ...` swallow-pattern flagged in
+`audits/2026-06-03/ARCHITECTURE_AUDIT.md` line 103 for
+`StartNightlyReconcile`'s `_ = s.RecoverLedger(...)` and called out as a
+recurring theme at lines 274 and 278. Class in 2026-06-03 backlog; the
+specific weekly-settlement instance was missed.
+
+### Finding #10 (HIGH_BUG, store.go missing partial unique) — TP-novel
+Confirmed: store.go:73 — `UNIQUE(request_id, attempt_n, provider_id)`,
+not a partial unique on `(request_id, attempt_n) WHERE quarantined = 0`.
+The literal schema is consistent with SPEC-005 D10's stated key choice,
+but the application enforces a tighter invariant: recovery's
+`ambiguous_attempt_n` quarantine (recovery.go:212) and hot-path
+deterministic single-provider derivation both behave as if
+`(request_id, attempt_n)` maps to one provider. The deepsec agent
+correctly notes the storage boundary doesn't enforce what application
+code does. SPEC-005-r2-audit X-2 covered an adjacent gap (`request_log`
+row uniqueness) but punted it to a future SPEC-002 patch; it did not
+address `ledger_request_credits`. Severity is moderate because no remote
+write path exposes raw ledger inserts and the application logic
+quarantines ambiguous cases — real risk is internal recovery/import/admin
+regressions. Defense-in-depth fix.
+
+## Tally
+
+| Classification | Count |
+|---|---|
+| TP-novel | 5 (#2, #6, #7, #8, #10) |
+| TP-known | 5 (#1, #3, #4, #5, #9) |
+| FP-plausible | 0 |
+| FP-noise | 0 |
+
+- TP-novel ≥ 1 ✓
+- (TP-novel + TP-known) / 10 = 100% ≥ 30% ✓
+
+## Decision recommendation: **Adopt**
+
+The 100% real-rate against a money-path package, with 5 genuinely novel
+real bugs (no FPs), exceeds the Adopt threshold by a wide margin. Two of
+the TP-novel findings (#6 settled-row corruption, #8 settlement-window
+skew) are correctness defects on the highest-blast-radius code path
+(weekly payout). One TP-novel (#2) caught a real gap that a previous
+codex audit pass had explicitly green-lit. That's the strongest possible
+signal: deepsec catches real bugs that focused audits miss.
+
+The TP-known findings are also useful — they generalize known patterns
+(silent `_ =` settle errors, `h.sum` swallow-error) to instances the
+focused audits missed. Lower-severity but high-recall.
+
+### Adoption scope
+
+Scoped per `AGENTS.md` §3 sensitive paths. Both phase4 and phase5
+money/auth packages:
+
+| Directory | Files (total) | Est. cost @ $0.72/file |
+|---|---|---|
+| `phase4-coordinator/internal/billing/` | 12 | $8.64 (Stage 1 baseline: $9.30) |
+| `phase4-coordinator/internal/buyer/` | 18 | $12.96 |
+| `phase4-coordinator/internal/auth/` | 3 | $2.16 |
+| `phase4-coordinator/internal/requestlog/` | 2 | $1.44 |
+| `phase5-gateway/internal/router/` | 17 | $12.24 |
+| `phase5-gateway/internal/auth/` | 4 | $2.88 |
+| **Total** | **56** | **~$40** |
+
+Wall-clock at Stage 1 burn-rate (12 files / 17 min ≈ 1.4 min/file) is
+~80 min for a full sensitive-path sweep. Comfortably inside one Plus
+5-hour window with headroom for revalidation.
+
+### Operational shape
+
+Three structural decisions, in priority order:
+
+1. **`--files-from` direct mode, not custom matcher pack.** The Stage 1
+   matcher-recall floor (1/12 files flagged by default scan, ~8%
+   recall on Go money-path) makes the default `scan → process` pipeline
+   effectively inert. The fix is direct mode with a curated per-package
+   manifest (`find <dir> -maxdepth 1 -name '*.go' -not -name '*_test.go'`),
+   not a custom Go-matcher pack. Reasons: (a) deepsec docs flag
+   `writing-matchers.md` as a non-trivial workflow needing TP corpus to
+   seed; (b) `--files-from` is documented behavior and gives full,
+   predictable coverage with no recall guesswork; (c) the 56-file
+   universe is small enough that per-file cost dominates regardless of
+   matcher gating; (d) money-path sensitive-paths are stable — the
+   manifest doesn't churn.
+
+2. **Cross-model revalidation pass.** Stage 1's "10/10 TP" is
+   codex-self-confirmed. For adoption-grade decisions, run a second
+   `--agent claude` revalidation against the same finding set. The
+   Stage 1 caveat (b) — same-model revalidation will rubber-stamp
+   same-model errors — is load-bearing for the credibility of any
+   finding the next sweep produces. A claude pass would have either
+   raised confidence on the 100% TP rate or surfaced the FP we should
+   have flagged.
+
+3. **Trigger discipline: PR-diff scans on the 6 sensitive paths, not
+   monthly full-tree.** Run deepsec when a PR touches one of the
+   sensitive paths; manifest is the changed files plus their adjacent
+   reads, not the whole package. Stage 1's 12-file pass was a
+   thorough-package sweep; PR-diff would typically be 3-8 files, ~$2-6
+   per scan. Adds one CI lane on the sensitive-path changeset.
+
+### Out of scope for this adoption
+
+- Non-money-path Go code (`phase4-coordinator/internal/{pool,config,...}`,
+  `phase5-gateway/internal/{storage,...}`). Diminishing returns: no
+  ground-truth corpus, lower blast radius, and the Stage 1 recall-on-Go
+  finding suggests we'd need direct-mode-everything which gets expensive
+  fast.
+- Swift/TypeScript packages (CLI, console, portal). Default matcher set
+  has reasonable React/TS coverage; the matcher-recall problem is Go-
+  specific.
+- d-inference references — clean-room boundary per AGENTS.md §4.

--- a/audits/2026-06-28/deepsec-pilot/SUMMARY.md
+++ b/audits/2026-06-28/deepsec-pilot/SUMMARY.md
@@ -1,0 +1,161 @@
+# deepsec pilot — phase4-coordinator/internal/billing
+
+**Pilot scope:** `phase4-coordinator/internal/billing/**` (12 Go files,
+~3.4k LoC).
+**Harness:** `vercel-labs/deepsec` v2.1.2 (npm).
+**Agent:** `codex` (gpt-5.5, effort=xhigh), via the codex CLI's logged-in
+ChatGPT Plus subscription — no API keys, no AI_GATEWAY_API_KEY.
+**Working dir:** `/tmp/deepsec-pilot/.deepsec/` (zero footprint in
+the macprovider repo — repo accessed via symlink, no git changes, no
+PR, no branch).
+**Concurrency / batch:** `--concurrency 2 --batch-size 3` (per brief).
+
+## Run summary
+
+| Phase | Wall time | Subscription burn (gateway-equivalent $) | Tokens |
+|---|---|---|---|
+| `scan` (regex matchers) | <1s | – | – |
+| `process` (12 files, 4 batches) | 690s (~11.5 min) | $6.25 | 558,722 |
+| `revalidate` (10 findings, 2 batches) | 329s (~5.5 min) | $3.05 | ~400k est. |
+| `export` (md-dir) | <1s | – | – |
+| **Total** | **~17 min wall-clock** | **~$9.30 equivalent** | **~960k** |
+
+**Zero 429s, zero retries, zero timeouts.** Codex subscription quota
+held cleanly for the full run; nowhere near the 5-hour Plus window.
+
+## Critical first-run signal — matcher recall on Go
+
+deepsec's built-in regex matcher set is heavily web-framework oriented:
+74 of 198 matchers fired (the others gated themselves off — no React,
+Express, Next, Django, FastAPI, etc.), and the 74 that ran produced
+**1 candidate site inside billing**: `snapshot.go` flagged by
+`crypto-usage` (the `crypto/sha256` import — informational, not a
+vuln claim). That's 1 candidate across 12 Go files = **~8% recall** on
+money-path Go code, vs. the `data/macprovider/files/*.json` mirror that
+shows 0 candidates would have been investigated by default.
+
+A naive `pnpm deepsec scan && pnpm deepsec process --project-id macprovider`
+would have produced **0 useful billing findings**. To get the 10
+findings below I bypassed the matcher gate with
+`pnpm deepsec process --files-from <12-file manifest>` (`--files-from`
+is direct mode and runs the AI on every listed file regardless of
+matcher hits). This is documented behavior, not a workaround, but it
+means **default `scan → process` on Go money-path code is effectively
+inert**. Two follow-ups are available in the harness:
+
+1. Write Go-specific matchers via the `writing-matchers.md` workflow
+   (grow from a confirmed TP — we now have 10 to seed from).
+2. Always operate in direct mode with a curated `--files-from` manifest
+   per money-path package.
+
+## Findings (severity distribution)
+
+| CRITICAL | HIGH | MEDIUM | HIGH_BUG | BUG | LOW |
+|---|---|---|---|---|---|
+| 0 | 1 | 0 | 6 | 3 | 0 |
+
+**Revalidation verdict: 10 TP, 0 FP, 0 fixed, 0 uncertain.** Codex
+re-checked each finding against the actual code in a second pass and
+confirmed all 10 as true-positive. *Caveat: same-model revalidation
+will rubber-stamp same-model errors; treat the TP labels as
+"codex-self-confirmed" rather than independently verified.*
+
+deepsec severity legend (per docs):
+- `HIGH`/`MEDIUM` — security severity (auth, payment integrity, etc.)
+- `HIGH_BUG`/`BUG` — correctness / reliability bugs in security-adjacent code
+
+## Per-finding one-liners
+
+| # | File:lines | Sev | Slug | Claim | Snap judgement |
+|---|---|---|---|---|---|
+| 1 | `endpoints.go:303,343,353,357` | HIGH_BUG | other-billing-integrity | `buyerEquivalentCredits` reconcile fallback re-runs `ComputeCredits` without `estimated_completion_tokens`, so the completion-clamp from 9bd77f4 is bypassed on the reconcile code path. | **Looks real.** Extension of 9bd77f4 — same bug class, second code path. |
+| 2 | `endpoints.go:250,253,353,355` | HIGH_BUG | other-reconciliation-integrity | Reconcile silently `continue`s on `snapshotAt` errors (incl. `ErrNoSnapshot`, decode error, DB error, ctx cancel) then writes `status='complete'`. Unreconciled rows are invisible. | **Looks real.** Specific failure mode is clear; check whether `ErrNoSnapshot` is expected-and-recoverable in steady state. |
+| 3 | `endpoints.go:101,109,427,…` | BUG | other-error-suppression | `h.sum` returns `0` on any DB error, so `/admin/ledger/summary` can 200 with zeroed totals during a DB outage; per-provider earnings can 404 instead of 5xx. | **Looks real.** Modest impact (observability), correct claim. |
+| 4 | `formula.go:119,136,141` | HIGH | other-payment-integrity | **Provider-reported `prompt_tokens` is NOT clamped against any coordinator estimate** — only the completion side got the `billableCompletion` clamp in 9bd77f4. A malicious provider can over-report prompt tokens to 10M and inflate prompt-side credits. | **Looks real and high-value.** This is the *symmetric complement* of the 9bd77f4 fix — same threat model, prompt side. Almost certainly a real gap. |
+| 5 | `payout.go:28,30,36,37` | HIGH_BUG | other-payout-state-corruption | `ClaimPayoutReady` doesn't reject empty `payoutExternalID` / `payoutCurrency`; `nullString("")` writes NULL; terminal-state trigger then prevents repair. | **Looks real.** Direct read of payout.go confirms no non-empty check. |
+| 6 | `recovery.go:117,159,213,446` | HIGH_BUG | other-settled-ledger-corruption | `quarantineExistingLedgerForRequestAttemptTx` lacks a `settled = 0 AND settlement_id IS NULL` predicate, so several recovery branches (invalid_usage_tokens, missing_config_snapshot, ambiguous_attempt_n) can retroactively quarantine an already-settled / paid-out row. | **Plausible but needs trace.** Confidence "medium" — confirm whether other guards earlier in the call chain already prevent reaching this for settled rows. |
+| 7 | `recovery.go:112,114,157,251` | BUG | other-nondeterministic-recovery | When `ts_utc` fails to parse, recovery substitutes `time.Now().UTC()` — making rate-card snapshot selection nondeterministic for malformed rows. | **Looks real.** Modest impact (malformed rows are rare). |
+| 8 | `settlement.go:23,37,61,120` | HIGH_BUG | other-settlement-window-skew | `RunSettlement` compares `ts_utc TEXT` lexicographically against an `RFC3339Nano` cutoff. RFC3339Nano is **variable-width** — `2026-06-08T00:00:00.500Z` sorts BEFORE `2026-06-08T00:00:00Z` because `'.' < 'Z'`. Rows in the first fractional second after the boundary can spill into the wrong payout window. | **Looks real and clever.** This is the kind of subtle textual-time bug audits usually miss. Worth verifying with a regression test. |
+| 9 | `settlement.go:152` | BUG | other-silent-settlement-failure | `StartWeeklySettlement` discards `RunSettlement` errors; weekly payout job can fail silently with no audit row or operator-visible signal. | **Looks real.** Observability gap. |
+| 10 | `store.go:73` | HIGH_BUG | other-idempotency-invariant | `ledger_request_credits` UNIQUE is `(request_id, attempt_n, provider_id)` — schema permits multiple non-quarantined rows for the same `(request_id, attempt_n)` across different `provider_id`s. The hot-path / recovery code tries to enforce the SPEC-005 invariant, but the storage boundary doesn't. | **Looks real if the SPEC invariant is "one provider per attempt"** (which the INFO.md asserts). Recommend partial unique index `WHERE quarantined = 0`. |
+
+Detailed per-finding markdown lives at:
+- `/tmp/deepsec-pilot-billing/HIGH/` — 1 finding
+- `/tmp/deepsec-pilot-billing/HIGH_BUG/` — 6 findings
+- `/tmp/deepsec-pilot-billing/BUG/` — 3 findings
+
+## Known-fixed mapping (vs `9bd77f4 Close audited billing and idempotency gaps`)
+
+The ground-truth fix in 9bd77f4 was: add `billableCompletion()` in
+`formula.go` to clamp provider-reported `completion_tokens` against
+coordinator-observed `estimated_completion_tokens`, and thread the
+estimate through `recovery.go` (HotPathInput.EstimatedCompTokens,
+`invalidRecoveryEstimate` / `invalidRecoveryCompletion`).
+
+### Confirms (deepsec re-found the bug *concept* on a *different code path*)
+
+- **Finding #1** (endpoints.go `buyerEquivalentCredits`) — same
+  completion-clamp omission as 9bd77f4 fixed in the main path, but on
+  the **reconcile fallback path**. 9bd77f4's diff did NOT touch
+  endpoints.go's reconcile fallback. **High recall signal** — deepsec
+  generalized the threat model and found a missed instance.
+
+### Novel — clean miss by 9bd77f4
+
+- **Finding #4** (formula.go, prompt_tokens) — the **symmetric
+  complement** of 9bd77f4. The original fix bounded completion against
+  the coordinator's byte estimate; prompt tokens have no equivalent
+  clamp and the buyer-side server *does* know the prompt content
+  (so the coordinator could compute its own prompt-token count). If
+  real, this is arguably the single highest-impact finding in the run.
+
+### Novel — outside 9bd77f4 scope entirely
+
+- Findings **#2, #3, #5, #6, #7, #8, #9, #10** — none of these touch
+  the billable-completion clamp. They span: error swallowing
+  (#3, #9), reconciliation-completeness invariants (#2), payout-state
+  hygiene (#5), recovery vs settled-row safety (#6, #7), time-handling
+  correctness (#8), and a schema-level invariant gap (#10). Of those,
+  #4, #5, #8, #10 are the ones I'd hand-prioritize for genuine fix
+  work first.
+
+### Regressions of audited-and-closed bugs
+
+- **None observed.** Findings do not duplicate items from
+  `audits/2026-06-03/` or any locked SPEC-005 audit round.
+
+## Pilot decision input
+
+**Signal — strong on the high-context, code-reading side.** The 10
+findings are substantive: every one is a specific, line-anchored
+claim with a clear failure mode, and revalidation found 0 FP at
+codex self-check. The agent burned ~$9 of gateway-equivalent on
+~960k tokens to investigate 12 files end-to-end and read SPEC-005
++ cross-package context (buyer/server.go, requestlog/store.go,
+ws/relay.go) to validate claims. That's competitive with a careful
+codex audit lane, with the added structure of per-file JSON +
+markdown export.
+
+**Signal — weak on the matcher pre-filter for Go money-path.**
+Default `scan → process` pipeline would have produced ~1 finding
+total. The harness is built around a regex pre-filter that doesn't
+cover Go billing-style code well. Operationally usable only via
+`--files-from` direct mode or a custom matcher set.
+
+**Caveats before adopting:**
+- All 10 findings are codex-self-confirmed, not independently
+  verified. A cross-model revalidation pass (`--agent claude`) would
+  raise confidence further.
+- 9bd77f4 ground-truth coverage: deepsec found 1 confirmed
+  *generalization* of the original bug class (Finding #1) and 1 clean
+  *symmetric miss* (Finding #4). Good recall, no false claims of
+  pre-existing fixes being broken.
+- This run cost ~17 wall-clock minutes on one package; scaling to the
+  full `phase4-coordinator/` would be ~10× — order $90 gateway-
+  equivalent for one full coordinator pass, well within one Plus
+  window if metering stays linear.
+
+**Recommendation:** worth a second pilot with cross-model revalidation
+(claude pass over the same 10 findings) before committing to ongoing
+use. The findings themselves are a useful work item regardless of the
+adoption decision.


### PR DESCRIPTION
## Summary

Stage 1 + Stage 2 of a deepsec (`vercel-labs/deepsec`) pilot on `phase4-coordinator/internal/billing/`. Pilot scoped to a money-path package with ground truth (commit `9bd77f4 Close audited billing and idempotency gaps`) so findings could be judged against known-fixed / known-broken.

**Recommendation: Adopt** for PR-diff scans on AGENTS.md §3 sensitive paths.

## What's in this PR

- `audits/2026-06-28/deepsec-pilot/SUMMARY.md` — Stage 1 run summary, severity distribution, recall caveats, known-fixed mapping vs `9bd77f4`.
- `audits/2026-06-28/deepsec-pilot/{HIGH,HIGH_BUG,BUG}/*.md` — 10 raw findings (1 HIGH, 6 HIGH_BUG, 3 BUG), all codex-self-revalidated TP.
- `audits/2026-06-28/deepsec-pilot/STAGE2_EVAL.md` — hand-evaluation of all 10 findings against current HEAD + cross-check against prior audits (`audits/2026-06-{03,10,24}/`) and SPEC-005 / SPEC-016 / ARC-3 audit set.

## Stage 2 verdict (full table in `STAGE2_EVAL.md`)

| Class | Count | Findings |
|---|---|---|
| TP-novel | 5 | #2 reconcile silent skip, #6 quarantine settled rows, #7 ts_utc time.Now() fallback, #8 RFC3339Nano settlement window skew, #10 missing partial unique on (request_id, attempt_n) |
| TP-known | 5 | #1, #4 (correlate with `9bd77f4`); #3 h.sum error→0 (ARC-3 SEC class); #5 ClaimPayoutReady empty validation (SPEC-016 §4.3 step 8); #9 silent RunSettlement error (2026-06-03 ARC theme) |
| FP-plausible | 0 | — |
| FP-noise | 0 | — |

100% real-rate. Two TP-novel findings (#6, #8) are correctness defects on the highest-blast-radius code path (weekly payout). Finding #2 caught a real gap that the ARC-3 SEC audit Q3 had explicitly green-lit.

## Adoption scope (per AGENTS.md §3)

| Directory | Files | Est. cost @ $0.72/file |
|---|---|---|
| `phase4-coordinator/internal/billing/` | 12 | $8.64 (Stage 1 baseline: $9.30) |
| `phase4-coordinator/internal/buyer/` | 18 | $12.96 |
| `phase4-coordinator/internal/auth/` | 3 | $2.16 |
| `phase4-coordinator/internal/requestlog/` | 2 | $1.44 |
| `phase5-gateway/internal/router/` | 17 | $12.24 |
| `phase5-gateway/internal/auth/` | 4 | $2.88 |
| **Total** | **56** | **~$40** |

Wall-clock ~80 min for a full sensitive-path sweep at Stage 1 burn-rate. Inside one Plus 5-hour window with headroom.

## Operational shape (3 decisions, priority order)

1. **`--files-from` direct mode, not a custom matcher pack.** Stage 1's default `scan → process` produced 1 candidate across 12 Go billing files (~8% recall). Direct mode with a curated per-package manifest is the documented escape hatch and gives full predictable coverage. Custom Go matcher pack is deferrable until we have more TP corpus to seed from.
2. **Cross-model revalidation pass (`--agent claude`).** Stage 1's "10/10 TP" is codex-self-confirmed; a claude pass over the same finding set is the credibility-multiplier and should run before the first production sweep.
3. **PR-diff trigger discipline.** Run when a PR touches one of the 6 sensitive paths; manifest = changed files plus adjacent reads. Typical PR-diff is 3-8 files / $2-6 per scan. Adds one CI lane on the sensitive-path changeset.

## What's NOT in this PR

- The 10 findings themselves are NOT addressed here. They become follow-up issues / PRs after the adoption decision. The Stage 2 eval is the input for triage, not the fix.
- No CI/scripts/matchers are added here. Those are the next adoption steps if approved.
- Branch contains two WIP commits (pilot bundle + STAGE2_EVAL) — squash-merge will collapse them into one clean commit on `main` per repo convention.

## Test plan

- [ ] Reviewer reads `STAGE2_EVAL.md` and spot-checks 2-3 finding classifications against the named source lines (recommended: #2 endpoints.go:330-360, #8 settlement.go:23-65, #10 store.go:73).
- [ ] Reviewer confirms the adoption scope matches AGENTS.md §3 sensitive paths.
- [ ] Reviewer confirms the cost projection rationale ($9.30 / 13 files = $0.72/file Stage 1 burn-rate) is acceptable.
- [ ] No code under `phase4-coordinator/` or `phase5-gateway/` is modified by this PR — verify with `git diff --stat origin/main...HEAD` (only `audits/2026-06-28/deepsec-pilot/` paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
