### PR TITLE
feat(harness): B1-B6 benchmark invariant module

### DIFF
--- a/test/network-harness/README.md
+++ b/test/network-harness/README.md
@@ -153,18 +153,50 @@ same scenario without reading the artifact bundle first.
 After a run, `--out` contains:
 
 ```
-scenario.yaml          # verbatim copy of the input
-run_meta.json          # scenario name, UTC window, git sha
-per_request.jsonl      # one row per request — the raw evidence
-metrics_summary.json   # aggregated histograms + route distribution
-ledger_reconcile.json  # three-way drift report (omitted when skipped)
-invariants.json        # the 4 hard verdicts
+scenario.yaml             # verbatim copy of the input
+run_meta.json             # scenario name, UTC window, git sha
+per_request.jsonl         # one row per request — the raw evidence
+metrics_summary.json      # aggregated histograms + route distribution
+ledger_reconcile.json     # three-way drift report (omitted when skipped)
+invariants.json           # the 4 hard verdicts
+benchmark_summary.json    # B-invariants source data (only when benchmark.enabled)
+benchmark_verdict.json    # B-invariant PASS/WARN/FAIL list (only when benchmark.enabled)
 ```
 
 For phase-B triage, the artifact bundle is the input. Read
 `metrics_summary.json` for routing distribution and latency shape;
 `ledger_reconcile.json` for billing drift; `per_request.jsonl` for any
 case the summaries elide.
+
+## Phase-B benchmark suite (B1-B6)
+
+Scenarios that declare a `benchmark:` block evaluate the network-
+performance invariants from `specs/SPEC-NETWORK-BENCHMARK-v0.1.md`
+alongside I1-I4. The benchmark is REPORTING-ONLY — FAIL verdicts log
+but do not change the harness exit code (I1-I4 still gate via exit 10).
+
+```yaml
+benchmark:
+  enabled: true
+  invariants: [B1, B2, B3, B4, B5, B6]
+  pricing_source: pearl:/opt/macprovider/tier2-catalog.json   # only needed for B6
+  provider_slots: 3                                            # default 3 (Pearl AccountConcurrency)
+```
+
+| ID | Title | PASS target | Bare-min | SKIP when |
+|---|---|---|---|---|
+| B1 | TTFT p50 | ≤ 800ms | ≤ 2000ms | no streaming samples |
+| B2 | Streaming TPS p50 | ≥ 30 tok/s | ≥ 15 tok/s | non-streaming scenario |
+| B3 | Tail ratio p99/p50 | ≤ 3.0 | ≤ 5.0 | no TTFT distribution |
+| B4 | Error rate /1000 | ≤ 5 | ≤ 25 | 0 requests |
+| B5 | Slot utilization % | ≥ 40 | ≥ 15 | no X-Provider-Id attribution |
+| B6 | Earnings $/hr | ≥ $1.00 | ≥ $0.30 | no pricing manifest or attribution |
+
+Pricing manifests are loaded via local path or `host:/path` SSH spec.
+The loader accepts three JSON shapes: an array of `{model, price_per_1k_*}`,
+a `{models: [...]}` wrapper, or a map `{model_id: {...}}`. Unknown models
+encountered in results are recorded but contribute zero earnings — B6
+reflects only priced traffic.
 
 ## Scenarios committed
 

--- a/test/network-harness/cmd/harness/main.go
+++ b/test/network-harness/cmd/harness/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/augstar/macprovider-network-harness/internal/artifact"
+	"github.com/augstar/macprovider-network-harness/internal/benchmark"
 	"github.com/augstar/macprovider-network-harness/internal/buyer"
 	"github.com/augstar/macprovider-network-harness/internal/chaos"
 	"github.com/augstar/macprovider-network-harness/internal/invariants"
@@ -145,6 +146,25 @@ func cmdRun(args []string) error {
 
 	inv := invariants.Evaluate(sc, results, summary, ledger)
 
+	var bench *benchmark.Result
+	if sc.Benchmark.Enabled {
+		var pricing *benchmark.Pricing
+		if sc.Benchmark.PricingSource != "" {
+			p, perr := benchmark.LoadPricing(sc.Benchmark.PricingSource)
+			if perr != nil {
+				log.Printf("benchmark: pricing load failed (%v) — B6 will SKIP", perr)
+			} else {
+				pricing = p
+				if len(p.Notes) > 0 {
+					log.Printf("benchmark: pricing loaded with %d skipped entries", len(p.Notes))
+				}
+			}
+		}
+		windowSec := meta.EndUTC.Sub(meta.StartUTC).Seconds()
+		runID := meta.StartUTC.Format("20060102T150405Z")
+		bench = benchmark.Evaluate(sc, results, summary, ledger, pricing, runID, windowSec)
+	}
+
 	var chaosResults []chaos.EventResult
 	if chaosRunner != nil {
 		chaosResults = chaosRunner.Results()
@@ -157,6 +177,7 @@ func cmdRun(args []string) error {
 		Summary:      summary,
 		Reconcile:    ledger,
 		Invariants:   inv,
+		Benchmark:    bench,
 		Meta:         meta,
 		ChaosEvents:  chaosResults,
 	}
@@ -166,6 +187,9 @@ func cmdRun(args []string) error {
 
 	log.Printf("artifact bundle written to %s", filepath.Clean(*outDir))
 	logInvariantSummary(inv)
+	if bench != nil {
+		logBenchmarkSummary(bench)
+	}
 
 	if inv.AnyFailed() {
 		os.Exit(10)
@@ -227,4 +251,13 @@ func logInvariantSummary(inv *invariants.Result) {
 		return
 	}
 	log.Printf("HARD INVARIANT FAILURE — triage %s", time.Now().UTC().Format(time.RFC3339))
+}
+
+// logBenchmarkSummary mirrors logInvariantSummary for the B-invariants.
+// Unlike I1-I4, FAIL does not change the process exit code in v0.1 —
+// the benchmark suite reports, it does not gate. Triage decides.
+func logBenchmarkSummary(b *benchmark.Result) {
+	for _, v := range b.Verdicts {
+		log.Printf("benchmark %s [%s]: %s — %s", v.ID, v.Status, v.Title, v.Detail)
+	}
 }

--- a/test/network-harness/internal/artifact/bundle.go
+++ b/test/network-harness/internal/artifact/bundle.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/augstar/macprovider-network-harness/internal/benchmark"
 	"github.com/augstar/macprovider-network-harness/internal/buyer"
 	"github.com/augstar/macprovider-network-harness/internal/chaos"
 	"github.com/augstar/macprovider-network-harness/internal/invariants"
@@ -26,6 +27,7 @@ type Bundle struct {
 	Summary      *metrics.Summary
 	Reconcile    *reconcile.Result
 	Invariants   *invariants.Result
+	Benchmark    *benchmark.Result
 	Meta         *runmeta.Meta
 	ChaosEvents  []chaos.EventResult
 }
@@ -58,6 +60,14 @@ func (b *Bundle) Write(outDir string) error {
 	}
 	if err := writeJSON(filepath.Join(outDir, "invariants.json"), b.Invariants); err != nil {
 		return err
+	}
+	if b.Benchmark != nil && b.Benchmark.Summary != nil {
+		if err := writeJSON(filepath.Join(outDir, "benchmark_summary.json"), b.Benchmark.Summary); err != nil {
+			return err
+		}
+		if err := writeJSON(filepath.Join(outDir, "benchmark_verdict.json"), b.Benchmark.Verdicts); err != nil {
+			return err
+		}
 	}
 	if len(b.ChaosEvents) > 0 {
 		if err := writeJSON(filepath.Join(outDir, "chaos_events.json"), b.ChaosEvents); err != nil {

--- a/test/network-harness/internal/benchmark/benchmark.go
+++ b/test/network-harness/internal/benchmark/benchmark.go
@@ -1,0 +1,606 @@
+// Package benchmark implements the phase-B network performance suite
+// defined in specs/SPEC-NETWORK-BENCHMARK-v0.1.md.
+//
+// Where phase-A invariants (I1-I4) are pass/fail correctness gates
+// ("the network does not lie"), the benchmark invariants (B1-B6) are
+// quantitative performance verdicts:
+//
+//   B1  TTFT p50 within target
+//   B2  Streaming TPS p50 within target
+//   B3  Tail ratio (p99/p50) bounded
+//   B4  Error rate per 1000 requests bounded
+//   B5  Provider slot utilization reasonable
+//   B6  Earnings/hr viable at current tier-2 pricing
+//
+// Each verdict carries a Status (PASS / WARN / FAIL / SKIP), the
+// measured value, the target and bare-min thresholds, and a one-line
+// detail string for the artifact bundle. B5 + B6 SKIP when the
+// underlying data source is unavailable (no DB snapshot, no pricing
+// manifest) — they never falsely PASS.
+package benchmark
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/augstar/macprovider-network-harness/internal/buyer"
+	"github.com/augstar/macprovider-network-harness/internal/metrics"
+	"github.com/augstar/macprovider-network-harness/internal/reconcile"
+	"github.com/augstar/macprovider-network-harness/internal/scenario"
+)
+
+// Status is the verdict for one B-invariant.
+type Status string
+
+const (
+	StatusPass Status = "PASS"
+	StatusWarn Status = "WARN"
+	StatusFail Status = "FAIL"
+	StatusSkip Status = "SKIP"
+)
+
+// Verdict is one B-invariant's outcome.
+type Verdict struct {
+	ID      string  `json:"id"`
+	Title   string  `json:"title"`
+	Status  Status  `json:"status"`
+	Value   float64 `json:"value"`
+	Target  float64 `json:"target,omitempty"`
+	BareMin float64 `json:"bare_min,omitempty"`
+	Unit    string  `json:"unit"`
+	Detail  string  `json:"detail"`
+}
+
+// Histogram is the subset of percentiles benchmark verdicts assert on.
+// Distinct from metrics.Histogram because benchmark sources its own
+// derivations (e.g. streaming-only TPS rather than wall-time TPS).
+type Histogram struct {
+	Count int     `json:"count"`
+	P50   float64 `json:"p50"`
+	P95   float64 `json:"p95"`
+	P99   float64 `json:"p99"`
+	Mean  float64 `json:"mean"`
+	Max   float64 `json:"max"`
+}
+
+// BuyerMetrics is the buyer-side cross-section per spec §5.
+type BuyerMetrics struct {
+	TTFTMs          Histogram      `json:"ttft_ms"`
+	StreamingTPS    Histogram      `json:"streaming_tps"`
+	WallTimeMs      Histogram      `json:"wall_time_ms"`
+	TailRatioP99P50 float64        `json:"tail_ratio_p99_p50"`
+	ErrorRatePer1k  float64        `json:"error_rate_per_1k"`
+	TotalRequests   int            `json:"total_requests"`
+	SuccessCount    int            `json:"success_count"`
+	Non2xxBreakdown map[string]int `json:"non_2xx_breakdown"`
+}
+
+// PerProvider is the provider-side cross-section per spec §5.
+type PerProvider struct {
+	ProviderID       string  `json:"provider_id"`
+	RequestsAdmitted int     `json:"requests_admitted"`
+	TokensDelivered  int64   `json:"tokens_delivered"`
+	BusySeconds      float64 `json:"busy_seconds"`
+	SlotUtilPct      float64 `json:"slot_util_pct"`
+	EarningsUSDPerHr float64 `json:"earnings_usd_per_hr"`
+	SessionDurationS float64 `json:"session_duration_s"`
+}
+
+// ProviderAggregate is the cross-fleet rollup.
+type ProviderAggregate struct {
+	SlotUtilPct      float64 `json:"slot_util_pct"`
+	EarningsUSDPerHr float64 `json:"earnings_usd_per_hr"`
+	TokensDelivered  int64   `json:"tokens_delivered"`
+	ProvidersSeen    int     `json:"providers_seen"`
+}
+
+// ProviderMetrics is the per-provider + aggregate rollup.
+type ProviderMetrics struct {
+	PerProvider []PerProvider     `json:"per_provider"`
+	Aggregate   ProviderAggregate `json:"aggregate"`
+
+	// AttributionMissing is true when the gateway did not echo a
+	// provider-id header on any successful request, so per-provider
+	// breakdown could not be computed. B5/B6 SKIP in that state.
+	AttributionMissing bool `json:"attribution_missing"`
+}
+
+// Summary is the top-level artifact emitted as benchmark_summary.json.
+type Summary struct {
+	Scenario        string          `json:"scenario"`
+	ScenarioVersion string          `json:"scenario_version"`
+	RunID           string          `json:"run_id"`
+	DurationSeconds float64         `json:"duration_seconds"`
+	BuyerMetrics    BuyerMetrics    `json:"buyer_metrics"`
+	ProviderMetrics ProviderMetrics `json:"provider_metrics"`
+	PricingSource   string          `json:"pricing_source,omitempty"`
+}
+
+// Result bundles the summary with its per-invariant verdicts.
+// Emitted as benchmark_verdict.json (verdicts) + benchmark_summary.json
+// (summary).
+type Result struct {
+	Summary  *Summary  `json:"summary"`
+	Verdicts []Verdict `json:"verdicts"`
+}
+
+// AnyFailed reports whether any non-skipped verdict is FAIL.
+func (r *Result) AnyFailed() bool {
+	for _, v := range r.Verdicts {
+		if v.Status == StatusFail {
+			return true
+		}
+	}
+	return false
+}
+
+// Thresholds for v0.1 (from spec §3.3). Keeping them as exported
+// constants makes future tuning visible and testable.
+const (
+	TTFTp50TargetMs  = 800.0
+	TTFTp50BareMinMs = 2000.0
+
+	StreamingTPSp50Target  = 30.0
+	StreamingTPSp50BareMin = 15.0
+
+	TailRatioTarget  = 3.0
+	TailRatioBareMin = 5.0
+
+	ErrorRateTargetPer1k  = 5.0
+	ErrorRateBareMinPer1k = 25.0
+
+	SlotUtilTargetPct  = 40.0
+	SlotUtilBareMinPct = 15.0
+
+	EarningsTargetUSDPerHr  = 1.00
+	EarningsBareMinUSDPerHr = 0.30
+)
+
+// Evaluate computes the benchmark summary and per-invariant verdicts.
+// pricing is nil when no pricing manifest was loaded; verdicts that
+// depend on it (B6) will SKIP.
+//
+// windowSeconds is the actual wall-clock duration of the run (meta
+// EndUTC - StartUTC), used for rate-type derivations. Passing 0
+// degrades B5 + B6 to SKIP.
+func Evaluate(
+	sc *scenario.Scenario,
+	results []buyer.Result,
+	mSummary *metrics.Summary,
+	ledger *reconcile.Result,
+	pricing *Pricing,
+	runID string,
+	windowSeconds float64,
+) *Result {
+	requested := sc.Benchmark.Invariants
+	if len(requested) == 0 {
+		return &Result{Summary: nil, Verdicts: nil}
+	}
+
+	buyerMetrics := computeBuyerMetrics(results)
+	providerMetrics := computeProviderMetrics(results, sc.Benchmark.ProviderSlots, windowSeconds, pricing)
+
+	summary := &Summary{
+		Scenario:        sc.Name,
+		ScenarioVersion: "v0.1",
+		RunID:           runID,
+		DurationSeconds: windowSeconds,
+		BuyerMetrics:    buyerMetrics,
+		ProviderMetrics: providerMetrics,
+	}
+	if pricing != nil {
+		summary.PricingSource = pricing.Source
+	}
+
+	verdicts := make([]Verdict, 0, len(requested))
+	for _, id := range requested {
+		switch id {
+		case "B1":
+			verdicts = append(verdicts, evalB1(buyerMetrics))
+		case "B2":
+			verdicts = append(verdicts, evalB2(buyerMetrics, results))
+		case "B3":
+			verdicts = append(verdicts, evalB3(buyerMetrics))
+		case "B4":
+			verdicts = append(verdicts, evalB4(buyerMetrics))
+		case "B5":
+			verdicts = append(verdicts, evalB5(providerMetrics, windowSeconds))
+		case "B6":
+			verdicts = append(verdicts, evalB6(providerMetrics, pricing, windowSeconds))
+		default:
+			verdicts = append(verdicts, Verdict{
+				ID:     id,
+				Title:  "unknown",
+				Status: StatusSkip,
+				Detail: fmt.Sprintf("unknown invariant id %q", id),
+			})
+		}
+	}
+	_ = ledger // reserved for future B-invariants that need DB-side data
+	return &Result{Summary: summary, Verdicts: verdicts}
+}
+
+// --- buyer-side compute -----------------------------------------------------
+
+func computeBuyerMetrics(results []buyer.Result) BuyerMetrics {
+	var ttfts, walls, tps []float64
+	non2xx := map[string]int{}
+	success := 0
+	non2xxCount := 0
+	for _, r := range results {
+		if r.HTTPStatus >= 400 || r.Outcome != "ok" {
+			non2xxCount++
+			key := fmt.Sprintf("%d", r.HTTPStatus)
+			if r.HTTPStatus == 0 {
+				key = r.Outcome
+				if key == "" {
+					key = "unknown"
+				}
+			}
+			non2xx[key]++
+			continue
+		}
+		success++
+		if r.TTFTMillis > 0 {
+			ttfts = append(ttfts, float64(r.TTFTMillis))
+		}
+		if r.TotalMillis > 0 {
+			walls = append(walls, float64(r.TotalMillis))
+		}
+		// Streaming TPS = tokens / (last_byte - first_byte). The harness
+		// captures LastByteUTC + an effective first-byte timestamp via
+		// (StartUTC + TTFTMillis). We approximate first-byte from those
+		// because there's no explicit FirstByteUTC field.
+		if r.Stream && r.CompletionTokensReceived > 0 && r.TTFTMillis > 0 && !r.LastByteUTC.IsZero() {
+			firstByte := r.StartUTC.Add(time.Duration(r.TTFTMillis) * time.Millisecond)
+			streamDur := r.LastByteUTC.Sub(firstByte).Seconds()
+			if streamDur > 0 {
+				tps = append(tps, float64(r.CompletionTokensReceived)/streamDur)
+			}
+		}
+	}
+
+	bm := BuyerMetrics{
+		TTFTMs:          newHistogram(ttfts),
+		StreamingTPS:    newHistogram(tps),
+		WallTimeMs:      newHistogram(walls),
+		TotalRequests:   len(results),
+		SuccessCount:    success,
+		Non2xxBreakdown: non2xx,
+	}
+	if bm.TTFTMs.P50 > 0 {
+		bm.TailRatioP99P50 = bm.TTFTMs.P99 / bm.TTFTMs.P50
+	}
+	if bm.TotalRequests > 0 {
+		bm.ErrorRatePer1k = 1000.0 * float64(non2xxCount) / float64(bm.TotalRequests)
+	}
+	return bm
+}
+
+// --- provider-side compute --------------------------------------------------
+
+func computeProviderMetrics(results []buyer.Result, providerSlots int, windowSeconds float64, pricing *Pricing) ProviderMetrics {
+	type acc struct {
+		Requests    int
+		Tokens      int64
+		Busy        float64
+		Earnings    float64
+		FirstSeen   time.Time
+		LastSeen    time.Time
+		PromptTok   int64
+	}
+	perID := map[string]*acc{}
+	attributionFound := false
+	for _, r := range results {
+		if r.Outcome != "ok" {
+			continue
+		}
+		pid := r.RouteProviderID
+		if pid == "" {
+			continue
+		}
+		attributionFound = true
+		a := perID[pid]
+		if a == nil {
+			a = &acc{FirstSeen: r.StartUTC, LastSeen: r.EndUTC}
+			perID[pid] = a
+		}
+		a.Requests++
+		a.Tokens += r.CompletionTokensReceived
+		a.PromptTok += r.PromptTokensReported
+		dur := r.EndUTC.Sub(r.StartUTC).Seconds()
+		if dur > 0 {
+			a.Busy += dur
+		}
+		if r.StartUTC.Before(a.FirstSeen) {
+			a.FirstSeen = r.StartUTC
+		}
+		if r.EndUTC.After(a.LastSeen) {
+			a.LastSeen = r.EndUTC
+		}
+		if pricing != nil {
+			a.Earnings += pricing.EarningsFor(r.Model, r.PromptTokensReported, r.CompletionTokensReceived)
+		}
+	}
+
+	pm := ProviderMetrics{}
+	if !attributionFound {
+		pm.AttributionMissing = true
+		return pm
+	}
+
+	// Stable ordering for the artifact: by descending requests.
+	ids := make([]string, 0, len(perID))
+	for id := range perID {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		ai, aj := perID[ids[i]], perID[ids[j]]
+		if ai.Requests != aj.Requests {
+			return ai.Requests > aj.Requests
+		}
+		return ids[i] < ids[j]
+	})
+
+	var totalBusy float64
+	var totalEarnings float64
+	var totalTokens int64
+	for _, id := range ids {
+		a := perID[id]
+		var utilPct float64
+		if windowSeconds > 0 && providerSlots > 0 {
+			utilPct = 100.0 * a.Busy / (float64(providerSlots) * windowSeconds)
+		}
+		var earningsPerHr float64
+		if windowSeconds > 0 && a.Earnings > 0 {
+			earningsPerHr = 3600.0 * a.Earnings / windowSeconds
+		}
+		pm.PerProvider = append(pm.PerProvider, PerProvider{
+			ProviderID:       id,
+			RequestsAdmitted: a.Requests,
+			TokensDelivered:  a.Tokens,
+			BusySeconds:      a.Busy,
+			SlotUtilPct:      utilPct,
+			EarningsUSDPerHr: earningsPerHr,
+			SessionDurationS: a.LastSeen.Sub(a.FirstSeen).Seconds(),
+		})
+		totalBusy += a.Busy
+		totalEarnings += a.Earnings
+		totalTokens += a.Tokens
+	}
+
+	if windowSeconds > 0 && providerSlots > 0 && len(perID) > 0 {
+		pm.Aggregate.SlotUtilPct = 100.0 * totalBusy / (float64(providerSlots) * windowSeconds * float64(len(perID)))
+	}
+	if windowSeconds > 0 && totalEarnings > 0 {
+		pm.Aggregate.EarningsUSDPerHr = 3600.0 * totalEarnings / windowSeconds
+	}
+	pm.Aggregate.TokensDelivered = totalTokens
+	pm.Aggregate.ProvidersSeen = len(perID)
+	return pm
+}
+
+// --- B-invariant evaluators -------------------------------------------------
+
+func evalB1(bm BuyerMetrics) Verdict {
+	v := Verdict{ID: "B1", Title: "TTFT p50 within target", Unit: "ms",
+		Target: TTFTp50TargetMs, BareMin: TTFTp50BareMinMs}
+	if bm.TTFTMs.Count == 0 {
+		v.Status = StatusSkip
+		v.Detail = "no streaming-success samples with TTFT > 0"
+		return v
+	}
+	v.Value = bm.TTFTMs.P50
+	switch {
+	case v.Value <= TTFTp50TargetMs:
+		v.Status = StatusPass
+		v.Detail = fmt.Sprintf("TTFT p50 %.0fms ≤ target %.0fms (n=%d)", v.Value, v.Target, bm.TTFTMs.Count)
+	case v.Value <= TTFTp50BareMinMs:
+		v.Status = StatusWarn
+		v.Detail = fmt.Sprintf("TTFT p50 %.0fms over target %.0fms but ≤ bare-min %.0fms (n=%d)", v.Value, v.Target, v.BareMin, bm.TTFTMs.Count)
+	default:
+		v.Status = StatusFail
+		v.Detail = fmt.Sprintf("TTFT p50 %.0fms exceeds bare-min %.0fms (n=%d)", v.Value, v.BareMin, bm.TTFTMs.Count)
+	}
+	return v
+}
+
+func evalB2(bm BuyerMetrics, results []buyer.Result) Verdict {
+	v := Verdict{ID: "B2", Title: "streaming TPS p50 within target", Unit: "tok/s",
+		Target: StreamingTPSp50Target, BareMin: StreamingTPSp50BareMin}
+	if bm.StreamingTPS.Count == 0 {
+		v.Status = StatusSkip
+		// Distinguish "no streaming scenario" from "no usable samples".
+		anyStream := false
+		for _, r := range results {
+			if r.Stream {
+				anyStream = true
+				break
+			}
+		}
+		if !anyStream {
+			v.Detail = "scenario is non-streaming — streaming TPS not applicable"
+		} else {
+			v.Detail = "no streaming-success samples with measurable post-TTFT duration"
+		}
+		return v
+	}
+	v.Value = bm.StreamingTPS.P50
+	switch {
+	case v.Value >= StreamingTPSp50Target:
+		v.Status = StatusPass
+		v.Detail = fmt.Sprintf("streaming TPS p50 %.1f tok/s ≥ target %.0f tok/s (n=%d)", v.Value, v.Target, bm.StreamingTPS.Count)
+	case v.Value >= StreamingTPSp50BareMin:
+		v.Status = StatusWarn
+		v.Detail = fmt.Sprintf("streaming TPS p50 %.1f tok/s under target %.0f tok/s but ≥ bare-min %.0f tok/s (n=%d)", v.Value, v.Target, v.BareMin, bm.StreamingTPS.Count)
+	default:
+		v.Status = StatusFail
+		v.Detail = fmt.Sprintf("streaming TPS p50 %.1f tok/s under bare-min %.0f tok/s (n=%d)", v.Value, v.BareMin, bm.StreamingTPS.Count)
+	}
+	return v
+}
+
+func evalB3(bm BuyerMetrics) Verdict {
+	v := Verdict{ID: "B3", Title: "TTFT tail ratio p99/p50 bounded", Unit: "ratio",
+		Target: TailRatioTarget, BareMin: TailRatioBareMin}
+	if bm.TTFTMs.Count == 0 || bm.TTFTMs.P50 == 0 {
+		v.Status = StatusSkip
+		v.Detail = "no TTFT distribution to score"
+		return v
+	}
+	v.Value = bm.TailRatioP99P50
+	switch {
+	case v.Value <= TailRatioTarget:
+		v.Status = StatusPass
+		v.Detail = fmt.Sprintf("tail ratio %.2f ≤ target %.1f (p50=%.0fms p99=%.0fms)", v.Value, v.Target, bm.TTFTMs.P50, bm.TTFTMs.P99)
+	case v.Value <= TailRatioBareMin:
+		v.Status = StatusWarn
+		v.Detail = fmt.Sprintf("tail ratio %.2f over target %.1f but ≤ bare-min %.1f", v.Value, v.Target, v.BareMin)
+	default:
+		v.Status = StatusFail
+		v.Detail = fmt.Sprintf("tail ratio %.2f exceeds bare-min %.1f", v.Value, v.BareMin)
+	}
+	return v
+}
+
+func evalB4(bm BuyerMetrics) Verdict {
+	v := Verdict{ID: "B4", Title: "error rate per 1000 requests bounded", Unit: "errors/1000",
+		Target: ErrorRateTargetPer1k, BareMin: ErrorRateBareMinPer1k}
+	if bm.TotalRequests == 0 {
+		v.Status = StatusSkip
+		v.Detail = "no requests fired"
+		return v
+	}
+	v.Value = bm.ErrorRatePer1k
+	switch {
+	case v.Value <= ErrorRateTargetPer1k:
+		v.Status = StatusPass
+		v.Detail = fmt.Sprintf("%.1f errors/1k ≤ target %.0f (%d non-2xx of %d)", v.Value, v.Target, bm.TotalRequests-bm.SuccessCount, bm.TotalRequests)
+	case v.Value <= ErrorRateBareMinPer1k:
+		v.Status = StatusWarn
+		v.Detail = fmt.Sprintf("%.1f errors/1k over target %.0f but ≤ bare-min %.0f — likely scenario-tuning (overload), not network", v.Value, v.Target, v.BareMin)
+	default:
+		v.Status = StatusFail
+		v.Detail = fmt.Sprintf("%.1f errors/1k exceeds bare-min %.0f — scenario re-tuning or real saturation", v.Value, v.BareMin)
+	}
+	return v
+}
+
+func evalB5(pm ProviderMetrics, windowSeconds float64) Verdict {
+	v := Verdict{ID: "B5", Title: "provider slot utilization reasonable", Unit: "%",
+		Target: SlotUtilTargetPct, BareMin: SlotUtilBareMinPct}
+	if pm.AttributionMissing {
+		v.Status = StatusSkip
+		v.Detail = "gateway did not expose X-Provider-Id headers — per-provider attribution unavailable"
+		return v
+	}
+	if windowSeconds <= 0 {
+		v.Status = StatusSkip
+		v.Detail = "window duration is zero"
+		return v
+	}
+	v.Value = pm.Aggregate.SlotUtilPct
+	switch {
+	case v.Value >= SlotUtilTargetPct:
+		v.Status = StatusPass
+		v.Detail = fmt.Sprintf("aggregate slot util %.1f%% ≥ target %.0f%% across %d providers", v.Value, v.Target, pm.Aggregate.ProvidersSeen)
+	case v.Value >= SlotUtilBareMinPct:
+		v.Status = StatusWarn
+		v.Detail = fmt.Sprintf("aggregate slot util %.1f%% over bare-min %.0f%% but under target %.0f%% (%d providers)", v.Value, v.BareMin, v.Target, pm.Aggregate.ProvidersSeen)
+	default:
+		v.Status = StatusFail
+		v.Detail = fmt.Sprintf("aggregate slot util %.1f%% under bare-min %.0f%% — providers idle most of the window", v.Value, v.BareMin)
+	}
+	return v
+}
+
+func evalB6(pm ProviderMetrics, pricing *Pricing, windowSeconds float64) Verdict {
+	v := Verdict{ID: "B6", Title: "earnings/hr viable at current tier-2 pricing", Unit: "USD/hr",
+		Target: EarningsTargetUSDPerHr, BareMin: EarningsBareMinUSDPerHr}
+	if pricing == nil {
+		v.Status = StatusSkip
+		v.Detail = "pricing manifest not loaded — set benchmark.pricing_source"
+		return v
+	}
+	if pm.AttributionMissing {
+		v.Status = StatusSkip
+		v.Detail = "per-provider attribution unavailable (no X-Provider-Id header)"
+		return v
+	}
+	if windowSeconds <= 0 {
+		v.Status = StatusSkip
+		v.Detail = "window duration is zero"
+		return v
+	}
+	if pm.Aggregate.TokensDelivered == 0 {
+		v.Status = StatusSkip
+		v.Detail = "no completion tokens delivered in window"
+		return v
+	}
+	// B6 measures per-provider median earnings/hr: a single high-earner
+	// shouldn't mask a fleet that's losing money. Take the median across
+	// providers seen.
+	earnings := make([]float64, 0, len(pm.PerProvider))
+	for _, p := range pm.PerProvider {
+		earnings = append(earnings, p.EarningsUSDPerHr)
+	}
+	median := percentile(earnings, 0.50)
+	v.Value = median
+	switch {
+	case v.Value >= EarningsTargetUSDPerHr:
+		v.Status = StatusPass
+		v.Detail = fmt.Sprintf("per-provider median earnings $%.2f/hr ≥ target $%.2f/hr (%d providers, aggregate $%.2f/hr)", v.Value, v.Target, pm.Aggregate.ProvidersSeen, pm.Aggregate.EarningsUSDPerHr)
+	case v.Value >= EarningsBareMinUSDPerHr:
+		v.Status = StatusWarn
+		v.Detail = fmt.Sprintf("per-provider median earnings $%.2f/hr over bare-min $%.2f/hr but under target $%.2f/hr", v.Value, v.BareMin, v.Target)
+	default:
+		v.Status = StatusFail
+		v.Detail = fmt.Sprintf("per-provider median earnings $%.2f/hr under bare-min $%.2f/hr — not M-series viable at current pricing", v.Value, v.BareMin)
+	}
+	return v
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func newHistogram(xs []float64) Histogram {
+	h := Histogram{Count: len(xs)}
+	if len(xs) == 0 {
+		return h
+	}
+	sorted := append([]float64(nil), xs...)
+	sort.Float64s(sorted)
+	sum := 0.0
+	for _, v := range sorted {
+		sum += v
+	}
+	h.Mean = sum / float64(len(sorted))
+	h.P50 = percentile(sorted, 0.50)
+	h.P95 = percentile(sorted, 0.95)
+	h.P99 = percentile(sorted, 0.99)
+	h.Max = sorted[len(sorted)-1]
+	return h
+}
+
+// percentile returns the nearest-rank percentile from a sorted-or-unsorted
+// slice (sorts if not already sorted). q is in [0,1].
+func percentile(xs []float64, q float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	// Detect already-sorted to avoid double work in newHistogram.
+	sorted := xs
+	if !sort.Float64sAreSorted(xs) {
+		sorted = append([]float64(nil), xs...)
+		sort.Float64s(sorted)
+	}
+	idx := int(math.Ceil(q*float64(len(sorted)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}

--- a/test/network-harness/internal/benchmark/benchmark_test.go
+++ b/test/network-harness/internal/benchmark/benchmark_test.go
@@ -1,0 +1,438 @@
+package benchmark
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-network-harness/internal/buyer"
+	"github.com/augstar/macprovider-network-harness/internal/scenario"
+)
+
+// Helpers ---------------------------------------------------------------
+
+func makeResult(ttftMs, totalMs int64, tokens int64, stream bool, provider, model string, status int) buyer.Result {
+	start := time.Now().UTC()
+	end := start.Add(time.Duration(totalMs) * time.Millisecond)
+	r := buyer.Result{
+		StartUTC:                 start,
+		EndUTC:                   end,
+		TTFTMillis:               ttftMs,
+		TotalMillis:              totalMs,
+		CompletionTokensReceived: tokens,
+		HTTPStatus:               status,
+		Stream:                   stream,
+		RouteProviderID:          provider,
+		Model:                    model,
+		Outcome:                  "ok",
+	}
+	if status >= 400 {
+		r.Outcome = "http_error"
+	}
+	if stream && status < 400 {
+		r.LastByteUTC = end
+	}
+	return r
+}
+
+func sc(invs ...string) *scenario.Scenario {
+	return &scenario.Scenario{
+		Name: "test",
+		Benchmark: scenario.Benchmark{
+			Enabled:       true,
+			Invariants:    invs,
+			ProviderSlots: 3,
+		},
+	}
+}
+
+// Tests -----------------------------------------------------------------
+
+func TestB1_TTFT_Pass(t *testing.T) {
+	// 100 results, all TTFT 300ms — well under 800ms target.
+	var results []buyer.Result
+	for i := 0; i < 100; i++ {
+		results = append(results, makeResult(300, 2000, 64, true, "p1", "m", 200))
+	}
+	res := Evaluate(sc("B1"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusPass {
+		t.Fatalf("B1 expected PASS at p50=300ms, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB1_TTFT_Warn(t *testing.T) {
+	// p50 = 1500ms → over target 800ms, under bare-min 2000ms → WARN.
+	var results []buyer.Result
+	for i := 0; i < 100; i++ {
+		results = append(results, makeResult(1500, 3000, 64, true, "p1", "m", 200))
+	}
+	res := Evaluate(sc("B1"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusWarn {
+		t.Fatalf("B1 expected WARN at p50=1500ms, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB1_TTFT_Fail(t *testing.T) {
+	// p50 = 3000ms → over bare-min 2000ms → FAIL.
+	var results []buyer.Result
+	for i := 0; i < 100; i++ {
+		results = append(results, makeResult(3000, 4000, 64, true, "p1", "m", 200))
+	}
+	res := Evaluate(sc("B1"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusFail {
+		t.Fatalf("B1 expected FAIL at p50=3000ms, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB1_TTFT_Skip_NoSamples(t *testing.T) {
+	// All requests failed → no TTFT samples → SKIP.
+	results := []buyer.Result{makeResult(0, 1000, 0, true, "p1", "m", 500)}
+	res := Evaluate(sc("B1"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusSkip {
+		t.Fatalf("B1 expected SKIP, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB2_StreamingTPS_Pass(t *testing.T) {
+	// 64 tokens over 1.6s post-TTFT = 40 tok/s → over target 30.
+	r := makeResult(200, 1800, 64, true, "p1", "m", 200)
+	// Adjust LastByteUTC so post-TTFT duration is 1.6s
+	r.LastByteUTC = r.StartUTC.Add(200 * time.Millisecond).Add(1600 * time.Millisecond)
+	var results []buyer.Result
+	for i := 0; i < 30; i++ {
+		results = append(results, r)
+	}
+	res := Evaluate(sc("B2"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusPass {
+		t.Fatalf("B2 expected PASS at ~40 tok/s, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB2_StreamingTPS_Warn(t *testing.T) {
+	// 64 tokens over 3.2s post-TTFT = 20 tok/s → under target 30, over bare-min 15.
+	r := makeResult(200, 3400, 64, true, "p1", "m", 200)
+	r.LastByteUTC = r.StartUTC.Add(200 * time.Millisecond).Add(3200 * time.Millisecond)
+	var results []buyer.Result
+	for i := 0; i < 30; i++ {
+		results = append(results, r)
+	}
+	res := Evaluate(sc("B2"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusWarn {
+		t.Fatalf("B2 expected WARN at ~20 tok/s, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB2_StreamingTPS_Skip_NonStream(t *testing.T) {
+	results := []buyer.Result{makeResult(0, 1000, 64, false, "p1", "m", 200)}
+	res := Evaluate(sc("B2"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusSkip {
+		t.Fatalf("B2 expected SKIP for non-streaming, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB3_TailRatio_Pass(t *testing.T) {
+	// Mostly 300ms TTFT, one 600ms outlier → p99/p50 ≈ 2.0 → PASS.
+	var results []buyer.Result
+	for i := 0; i < 99; i++ {
+		results = append(results, makeResult(300, 1000, 64, true, "p1", "m", 200))
+	}
+	results = append(results, makeResult(600, 1000, 64, true, "p1", "m", 200))
+	res := Evaluate(sc("B3"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusPass {
+		t.Fatalf("B3 expected PASS, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB3_TailRatio_Fail(t *testing.T) {
+	// p50=300ms, p99=6000ms, ratio=20 → FAIL (>5).
+	// Nearest-rank p99 at n=100 needs ≥2 samples in the top 1% bucket.
+	var results []buyer.Result
+	for i := 0; i < 98; i++ {
+		results = append(results, makeResult(300, 1000, 64, true, "p1", "m", 200))
+	}
+	for i := 0; i < 2; i++ {
+		results = append(results, makeResult(6000, 7000, 64, true, "p1", "m", 200))
+	}
+	res := Evaluate(sc("B3"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusFail {
+		t.Fatalf("B3 expected FAIL at large tail, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB4_ErrorRate_Pass(t *testing.T) {
+	// 1000 reqs, 3 errors → 3/1000 → PASS (≤5).
+	var results []buyer.Result
+	for i := 0; i < 997; i++ {
+		results = append(results, makeResult(300, 1000, 64, true, "p1", "m", 200))
+	}
+	for i := 0; i < 3; i++ {
+		results = append(results, makeResult(0, 0, 0, true, "p1", "m", 503))
+	}
+	res := Evaluate(sc("B4"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusPass {
+		t.Fatalf("B4 expected PASS, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB4_ErrorRate_Warn(t *testing.T) {
+	// 1000 reqs, 15 errors → 15/1000 → WARN (>5, ≤25).
+	var results []buyer.Result
+	for i := 0; i < 985; i++ {
+		results = append(results, makeResult(300, 1000, 64, true, "p1", "m", 200))
+	}
+	for i := 0; i < 15; i++ {
+		results = append(results, makeResult(0, 0, 0, true, "p1", "m", 503))
+	}
+	res := Evaluate(sc("B4"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusWarn {
+		t.Fatalf("B4 expected WARN, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB4_ErrorRate_Fail(t *testing.T) {
+	// 100 reqs, 50 errors → 500/1000 → FAIL.
+	var results []buyer.Result
+	for i := 0; i < 50; i++ {
+		results = append(results, makeResult(300, 1000, 64, true, "p1", "m", 200))
+	}
+	for i := 0; i < 50; i++ {
+		results = append(results, makeResult(0, 0, 0, true, "p1", "m", 503))
+	}
+	res := Evaluate(sc("B4"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusFail {
+		t.Fatalf("B4 expected FAIL, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB5_SlotUtil_Skip_NoAttribution(t *testing.T) {
+	// No provider id → attribution missing → SKIP.
+	results := []buyer.Result{makeResult(300, 1000, 64, true, "", "m", 200)}
+	res := Evaluate(sc("B5"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusSkip {
+		t.Fatalf("B5 expected SKIP, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB5_SlotUtil_Pass(t *testing.T) {
+	// One provider, slots=3, window=60s, busy=72s (50%). Need a provider id.
+	// 12 requests × 6s each = 72s busy → 72/(3*60) = 40% → PASS at target boundary.
+	var results []buyer.Result
+	for i := 0; i < 12; i++ {
+		results = append(results, makeResult(300, 6000, 64, true, "p1", "m", 200))
+	}
+	res := Evaluate(sc("B5"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusPass {
+		t.Fatalf("B5 expected PASS at 40%% util, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB5_SlotUtil_Warn(t *testing.T) {
+	// 6 requests × 6s = 36s busy → 36/(3*60) = 20% → WARN.
+	var results []buyer.Result
+	for i := 0; i < 6; i++ {
+		results = append(results, makeResult(300, 6000, 64, true, "p1", "m", 200))
+	}
+	res := Evaluate(sc("B5"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusWarn {
+		t.Fatalf("B5 expected WARN at 20%% util, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB6_Earnings_Skip_NoPricing(t *testing.T) {
+	results := []buyer.Result{makeResult(300, 1000, 64, true, "p1", "m", 200)}
+	res := Evaluate(sc("B6"), results, nil, nil, nil, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusSkip {
+		t.Fatalf("B6 expected SKIP without pricing, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB6_Earnings_Pass(t *testing.T) {
+	// Price $5/1k completion tokens, 6 reqs × 64 tokens = 384 tokens × $0.005 = $1.92 over 60s.
+	// Earnings/hr = 3600/60 × $1.92 = $115.20/hr → PASS.
+	pricing := &Pricing{
+		Source:        "test",
+		ByModel:       map[string]ModelPrice{"m": {ModelID: "m", CompletionPricePer1k: 5.0}},
+		UnknownModels: map[string]int{},
+	}
+	var results []buyer.Result
+	for i := 0; i < 6; i++ {
+		results = append(results, makeResult(300, 1000, 64, true, "p1", "m", 200))
+	}
+	res := Evaluate(sc("B6"), results, nil, nil, pricing, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusPass {
+		t.Fatalf("B6 expected PASS at $115/hr, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB6_Earnings_Fail(t *testing.T) {
+	// Price $0.0001/1k completion tokens, 6 reqs × 64 tokens × $0.0001/1k = ~$0.0000384 over 60s
+	// → ~$0.0023/hr → under $0.30 bare-min → FAIL.
+	pricing := &Pricing{
+		Source:        "test",
+		ByModel:       map[string]ModelPrice{"m": {ModelID: "m", CompletionPricePer1k: 0.0001}},
+		UnknownModels: map[string]int{},
+	}
+	var results []buyer.Result
+	for i := 0; i < 6; i++ {
+		results = append(results, makeResult(300, 1000, 64, true, "p1", "m", 200))
+	}
+	res := Evaluate(sc("B6"), results, nil, nil, pricing, "test", 60)
+	if got := res.Verdicts[0].Status; got != StatusFail {
+		t.Fatalf("B6 expected FAIL at $0.002/hr, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+// Pricing loader tests ---------------------------------------------------
+
+func TestLoadPricing_ArrayShape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.json")
+	contents := `[
+		{"model": "qwen3-32b", "price_per_1k_prompt_tokens": 0.001, "price_per_1k_completion_tokens": 0.005},
+		{"model": "qwen-coder-7b", "price_per_1k_prompt_tokens": 0.0005, "price_per_1k_completion_tokens": 0.002}
+	]`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p, err := LoadPricing(path)
+	if err != nil {
+		t.Fatalf("LoadPricing: %v", err)
+	}
+	if len(p.ByModel) != 2 {
+		t.Fatalf("want 2 models, got %d", len(p.ByModel))
+	}
+	if p.ByModel["qwen3-32b"].CompletionPricePer1k != 0.005 {
+		t.Fatalf("wrong completion price: %+v", p.ByModel["qwen3-32b"])
+	}
+}
+
+func TestLoadPricing_MapShape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.json")
+	contents := `{
+		"qwen3-32b": {"price_per_1k_prompt_tokens": 0.001, "price_per_1k_completion_tokens": 0.005}
+	}`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p, err := LoadPricing(path)
+	if err != nil {
+		t.Fatalf("LoadPricing: %v", err)
+	}
+	if _, ok := p.ByModel["qwen3-32b"]; !ok {
+		t.Fatalf("model missing: %+v", p.ByModel)
+	}
+}
+
+func TestLoadPricing_WrappedShape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.json")
+	contents := `{
+		"models": [
+			{"model_id": "qwen3-32b", "completion_per_1k": 0.005}
+		]
+	}`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p, err := LoadPricing(path)
+	if err != nil {
+		t.Fatalf("LoadPricing: %v", err)
+	}
+	if _, ok := p.ByModel["qwen3-32b"]; !ok {
+		t.Fatalf("model missing: %+v", p.ByModel)
+	}
+}
+
+func TestLoadPricing_UnknownModel(t *testing.T) {
+	p := &Pricing{
+		Source:        "test",
+		ByModel:       map[string]ModelPrice{"a": {ModelID: "a", CompletionPricePer1k: 1}},
+		UnknownModels: map[string]int{},
+	}
+	got := p.EarningsFor("unknown", 100, 100)
+	if got != 0 {
+		t.Fatalf("unknown model should be zero, got %v", got)
+	}
+	if p.UnknownModels["unknown"] != 1 {
+		t.Fatalf("UnknownModels should record the miss: %+v", p.UnknownModels)
+	}
+}
+
+func TestLoadPricing_EarningsMath(t *testing.T) {
+	p := &Pricing{
+		Source:        "test",
+		ByModel:       map[string]ModelPrice{"m": {ModelID: "m", PromptPricePer1k: 0.001, CompletionPricePer1k: 0.01}},
+		UnknownModels: map[string]int{},
+	}
+	// 500 prompt × $0.001/1k = $0.0005
+	// 1000 completion × $0.01/1k = $0.01
+	// total = $0.0105
+	got := p.EarningsFor("m", 500, 1000)
+	want := 0.0105
+	if got != want {
+		t.Fatalf("earnings math: got %v want %v", got, want)
+	}
+}
+
+// Compute tests ----------------------------------------------------------
+
+func TestComputeBuyerMetrics_TailRatio(t *testing.T) {
+	// 98 × 100ms + 2 × 500ms → p50=100, p99=500, ratio=5.0
+	// Two outliers needed to land at p99 under nearest-rank with n=100.
+	var results []buyer.Result
+	for i := 0; i < 98; i++ {
+		results = append(results, makeResult(100, 1000, 64, true, "p1", "m", 200))
+	}
+	for i := 0; i < 2; i++ {
+		results = append(results, makeResult(500, 1000, 64, true, "p1", "m", 200))
+	}
+	bm := computeBuyerMetrics(results)
+	if bm.TTFTMs.P50 != 100 {
+		t.Fatalf("p50 want 100, got %v", bm.TTFTMs.P50)
+	}
+	if bm.TTFTMs.P99 != 500 {
+		t.Fatalf("p99 want 500, got %v", bm.TTFTMs.P99)
+	}
+	if bm.TailRatioP99P50 != 5.0 {
+		t.Fatalf("tail ratio want 5.0, got %v", bm.TailRatioP99P50)
+	}
+}
+
+func TestComputeProviderMetrics_TwoProviders(t *testing.T) {
+	results := []buyer.Result{
+		makeResult(300, 6000, 100, true, "p1", "m", 200),
+		makeResult(300, 6000, 100, true, "p1", "m", 200),
+		makeResult(300, 6000, 200, true, "p2", "m", 200),
+	}
+	pm := computeProviderMetrics(results, 3, 60, nil)
+	if pm.AttributionMissing {
+		t.Fatal("attribution should be present")
+	}
+	if len(pm.PerProvider) != 2 {
+		t.Fatalf("want 2 providers, got %d", len(pm.PerProvider))
+	}
+	// p1 first (2 requests) then p2 (1 request)
+	if pm.PerProvider[0].ProviderID != "p1" {
+		t.Fatalf("sort by request count failed: %+v", pm.PerProvider)
+	}
+	if pm.PerProvider[0].RequestsAdmitted != 2 {
+		t.Fatalf("p1 should have 2 requests, got %d", pm.PerProvider[0].RequestsAdmitted)
+	}
+	// p1 busy = 12s → 12/(3*60) = 6.67% individual util
+	if pm.PerProvider[0].SlotUtilPct < 6.0 || pm.PerProvider[0].SlotUtilPct > 7.0 {
+		t.Fatalf("p1 util want ~6.67%%, got %v", pm.PerProvider[0].SlotUtilPct)
+	}
+	if pm.Aggregate.ProvidersSeen != 2 {
+		t.Fatalf("aggregate providers want 2, got %d", pm.Aggregate.ProvidersSeen)
+	}
+}
+
+func TestEvaluate_NoBenchmark(t *testing.T) {
+	sc := &scenario.Scenario{Name: "t", Benchmark: scenario.Benchmark{Enabled: true, Invariants: nil}}
+	res := Evaluate(sc, nil, nil, nil, nil, "t", 60)
+	if res.Summary != nil || res.Verdicts != nil {
+		t.Fatalf("empty invariants list should produce empty result, got %+v", res)
+	}
+}

--- a/test/network-harness/internal/benchmark/pricing.go
+++ b/test/network-harness/internal/benchmark/pricing.go
@@ -1,0 +1,200 @@
+package benchmark
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Pricing is a tier-2 pricing manifest loaded for B6 (earnings/hr).
+// The on-disk schema is the operator-facing tier2-catalog.json at
+// /opt/macprovider/tier2-catalog.json on Pearl. v0.1 expects an array
+// of entries with model + per-1k token prices; unknown shapes are
+// reported via Notes rather than failing the run.
+type Pricing struct {
+	// Source is the path or "host:path" the manifest came from. Echoed
+	// into benchmark_summary.json for traceability.
+	Source string
+
+	// ByModel is the normalized lookup: model id → per-1k token prices.
+	ByModel map[string]ModelPrice
+
+	// UnknownModels is filled by EarningsFor when a request hits a model
+	// not in the manifest. Triage may use this to spot stale pricing.
+	UnknownModels map[string]int
+
+	// Notes accumulates structural surprises (extra fields, malformed
+	// entries) the loader skipped over.
+	Notes []string
+}
+
+// ModelPrice is the per-1000-token cost of one tier-2 model. USD.
+type ModelPrice struct {
+	ModelID                string  `json:"model"`
+	PromptPricePer1k       float64 `json:"price_per_1k_prompt_tokens"`
+	CompletionPricePer1k   float64 `json:"price_per_1k_completion_tokens"`
+}
+
+// rawCatalogEntry is the JSON-side mirror. Kept separate so we can grow
+// the manifest schema (e.g. tier identifiers, hash fields) without
+// forcing pricing math to know about them.
+type rawCatalogEntry struct {
+	Model                string  `json:"model"`
+	ModelID              string  `json:"model_id"`
+	PromptPer1k          float64 `json:"price_per_1k_prompt_tokens"`
+	CompletionPer1k      float64 `json:"price_per_1k_completion_tokens"`
+	PromptPer1kAlt       float64 `json:"prompt_per_1k"`
+	CompletionPer1kAlt   float64 `json:"completion_per_1k"`
+}
+
+// LoadPricing reads a tier-2 pricing manifest from a local path or
+// from an "host:/path" SSH spec. Returns nil + error on hard failures
+// (cannot read, file invalid); returns a partial Pricing with Notes
+// when entries were skipped but at least one was loaded.
+func LoadPricing(source string) (*Pricing, error) {
+	if source == "" {
+		return nil, fmt.Errorf("empty pricing source")
+	}
+	var data []byte
+	var err error
+	if strings.Contains(source, ":") && !strings.HasPrefix(source, "/") {
+		data, err = fetchSSH(source)
+	} else {
+		data, err = os.ReadFile(source)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read pricing manifest %q: %w", source, err)
+	}
+	return parsePricing(source, data)
+}
+
+func parsePricing(source string, data []byte) (*Pricing, error) {
+	p := &Pricing{
+		Source:        source,
+		ByModel:       map[string]ModelPrice{},
+		UnknownModels: map[string]int{},
+	}
+
+	// Try array shape first: [{model, price_per_1k_*}, ...].
+	var arr []rawCatalogEntry
+	if err := json.Unmarshal(data, &arr); err == nil && len(arr) > 0 {
+		for i, e := range arr {
+			id, mp, ok := normalizeEntry(e)
+			if !ok {
+				p.Notes = append(p.Notes, fmt.Sprintf("entry %d: missing model or zero prices, skipped", i))
+				continue
+			}
+			p.ByModel[id] = mp
+		}
+		if len(p.ByModel) == 0 {
+			return nil, fmt.Errorf("pricing manifest %q parsed as array but yielded no usable entries", source)
+		}
+		return p, nil
+	}
+
+	// Try object-shape wrapper: {"models": [...]}.
+	var wrapped struct {
+		Models []rawCatalogEntry `json:"models"`
+	}
+	if err := json.Unmarshal(data, &wrapped); err == nil && len(wrapped.Models) > 0 {
+		for i, e := range wrapped.Models {
+			id, mp, ok := normalizeEntry(e)
+			if !ok {
+				p.Notes = append(p.Notes, fmt.Sprintf("models[%d]: missing model or zero prices, skipped", i))
+				continue
+			}
+			p.ByModel[id] = mp
+		}
+		if len(p.ByModel) == 0 {
+			return nil, fmt.Errorf("pricing manifest %q parsed as {models:[...]} but yielded no usable entries", source)
+		}
+		return p, nil
+	}
+
+	// Try map shape: {"model-id": {price_per_1k_*}, ...}.
+	var m map[string]rawCatalogEntry
+	if err := json.Unmarshal(data, &m); err == nil && len(m) > 0 {
+		for k, e := range m {
+			e.Model = k
+			id, mp, ok := normalizeEntry(e)
+			if !ok {
+				p.Notes = append(p.Notes, fmt.Sprintf("%s: missing model or zero prices, skipped", k))
+				continue
+			}
+			p.ByModel[id] = mp
+		}
+		if len(p.ByModel) == 0 {
+			return nil, fmt.Errorf("pricing manifest %q parsed as map but yielded no usable entries", source)
+		}
+		return p, nil
+	}
+
+	return nil, fmt.Errorf("pricing manifest %q: unrecognized JSON shape", source)
+}
+
+func normalizeEntry(e rawCatalogEntry) (string, ModelPrice, bool) {
+	id := e.Model
+	if id == "" {
+		id = e.ModelID
+	}
+	if id == "" {
+		return "", ModelPrice{}, false
+	}
+	prompt := e.PromptPer1k
+	if prompt == 0 {
+		prompt = e.PromptPer1kAlt
+	}
+	completion := e.CompletionPer1k
+	if completion == 0 {
+		completion = e.CompletionPer1kAlt
+	}
+	if prompt == 0 && completion == 0 {
+		return "", ModelPrice{}, false
+	}
+	return id, ModelPrice{
+		ModelID:              id,
+		PromptPricePer1k:     prompt,
+		CompletionPricePer1k: completion,
+	}, true
+}
+
+// EarningsFor returns the USD earnings for one request given the model
+// and token counts. Unknown models contribute zero and are recorded in
+// UnknownModels so B6 verdict detail can call them out.
+func (p *Pricing) EarningsFor(model string, promptTokens, completionTokens int64) float64 {
+	if p == nil || model == "" {
+		return 0
+	}
+	mp, ok := p.ByModel[model]
+	if !ok {
+		p.UnknownModels[model]++
+		return 0
+	}
+	return float64(promptTokens)*mp.PromptPricePer1k/1000.0 +
+		float64(completionTokens)*mp.CompletionPricePer1k/1000.0
+}
+
+// fetchSSH reads a remote file via `ssh host cat /path`. Mirrors the
+// reconcile.sshCat helper but emits to a buffer rather than disk —
+// the pricing manifest is small enough for in-memory parsing.
+func fetchSSH(spec string) ([]byte, error) {
+	colon := strings.Index(spec, ":")
+	if colon < 0 {
+		return nil, fmt.Errorf("ssh spec must be host:/path (got %q)", spec)
+	}
+	host := spec[:colon]
+	remote := spec[colon+1:]
+	if host == "" || remote == "" {
+		return nil, fmt.Errorf("ssh spec missing host or path: %q", spec)
+	}
+	cmd := exec.Command("ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=15", host, fmt.Sprintf("cat %q", remote))
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ssh fetch failed: %w (stderr: %s)", err, strings.TrimSpace(stderr.String()))
+	}
+	return out, nil
+}

--- a/test/network-harness/internal/scenario/schema.go
+++ b/test/network-harness/internal/scenario/schema.go
@@ -58,6 +58,29 @@ type Scenario struct {
 	// throttles for chaos scenarios. Each command runs via /bin/sh -c;
 	// stdout/stderr/exit are captured into run_meta.json.
 	ChaosEvents []ChaosEvent `yaml:"chaos_events"`
+
+	// Benchmark, when Enabled, runs the phase-B benchmark suite (B1-B6)
+	// against this scenario's results. See specs/SPEC-NETWORK-BENCHMARK-v0.1.md.
+	Benchmark Benchmark `yaml:"benchmark"`
+}
+
+// Benchmark declares which B-invariants this scenario should evaluate
+// and where to source pricing for B6 (earnings/hr). Enabled=false (or
+// the whole block omitted) skips the benchmark suite.
+type Benchmark struct {
+	Enabled    bool     `yaml:"enabled"`
+	Invariants []string `yaml:"invariants"`
+
+	// PricingSource locates a tier-2 pricing manifest for B6. Two forms:
+	//   * local path:     "/abs/path/to/tier2-catalog.json"
+	//   * SSH host:path:  "pearl:/opt/macprovider/tier2-catalog.json"
+	// Unset → B6 SKIP.
+	PricingSource string `yaml:"pricing_source"`
+
+	// ProviderSlots is the assumed per-provider concurrency cap used by
+	// B5 (slot utilization). Defaults to 3 — the Pearl coordinator's
+	// AccountConcurrency at the time this spec landed (PR #205).
+	ProviderSlots int `yaml:"provider_slots"`
 }
 
 // ChaosEvent is one scheduled shell action. `At` is measured from
@@ -166,6 +189,9 @@ func (s *Scenario) applyDefaults() {
 	if s.Buyers.RequestsPerBuyer == 0 {
 		s.Buyers.RequestsPerBuyer = 1
 	}
+	if s.Benchmark.Enabled && s.Benchmark.ProviderSlots == 0 {
+		s.Benchmark.ProviderSlots = 3
+	}
 }
 
 // Validate returns a non-nil error if the scenario is missing required
@@ -228,6 +254,20 @@ func (s *Scenario) Validate() error {
 	}
 	if s.Duration <= 0 && s.Buyers.Pattern != "burst" {
 		return fmt.Errorf("duration must be > 0 unless pattern=burst")
+	}
+	if s.Benchmark.Enabled {
+		if len(s.Benchmark.Invariants) == 0 {
+			return fmt.Errorf("benchmark.invariants must list at least one B-ID when benchmark.enabled=true")
+		}
+		known := map[string]bool{"B1": true, "B2": true, "B3": true, "B4": true, "B5": true, "B6": true}
+		for _, id := range s.Benchmark.Invariants {
+			if !known[id] {
+				return fmt.Errorf("benchmark.invariants: unknown id %q (known: B1-B6)", id)
+			}
+		}
+		if s.Benchmark.ProviderSlots < 1 {
+			return fmt.Errorf("benchmark.provider_slots must be >= 1")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds the `internal/benchmark/` package implementing the phase-B invariants from [SPEC-NETWORK-BENCHMARK-v0.1.md](specs/SPEC-NETWORK-BENCHMARK-v0.1.md). Mirrors the I1-I4 pattern from `internal/invariants/hard.go` but with PASS/WARN/FAIL/SKIP verdicts + measured values + thresholds.

**Stacked on top of #182** — that PR ships the spec + scenarios + baseline; this PR ships the Go module that encodes the verdicts so future runs do not need manual JSON reading.

## What lands

| ID | Title | PASS target | Bare-min |
|---|---|---|---|
| B1 | TTFT p50 | ≤ 800ms | ≤ 2000ms |
| B2 | Streaming TPS p50 | ≥ 30 tok/s | ≥ 15 tok/s |
| B3 | Tail ratio p99/p50 | ≤ 3.0 | ≤ 5.0 |
| B4 | Error rate /1000 | ≤ 5 | ≤ 25 |
| B5 | Slot utilization % | ≥ 40 | ≥ 15 |
| B6 | Earnings/hr | ≥ $1.00 | ≥ $0.30 |

B5/B6 SKIP when the source data is unavailable (no `X-Provider-Id` attribution, no pricing manifest) — they never falsely PASS.

## Design choices

- **Reporting-only at v0.1**: benchmark FAIL does NOT change the harness exit code. I1-I4 still gate via exit 10. Promotion to a gate comes after baselines accumulate (spec §3.4).
- **Streaming TPS is post-TTFT**: `tokens / (last_byte - first_byte)`, matching spec §3.2. The existing `metrics.TokensPerSec` folds TTFT in and is left untouched.
- **Pricing manifest is tolerant**: loader accepts three shapes (array, `{models:[...]}`, `{id:{...}}`) and supports both local paths and `host:/path` SSH specs. Unknown models contribute zero earnings and are recorded in `UnknownModels` for triage.
- **B6 takes the per-provider median**: a single high-earner should not mask a fleet that is losing money.

## Files

- `internal/benchmark/benchmark.go` (600 lines) — types, compute, B1-B6 evaluators
- `internal/benchmark/pricing.go` (200 lines) — tier-2 catalog loader
- `internal/benchmark/benchmark_test.go` (438 lines, 26 tests) — PASS/WARN/FAIL/SKIP coverage for each invariant
- `internal/scenario/schema.go` — `Benchmark{Enabled, Invariants, PricingSource, ProviderSlots}` + Validate()
- `cmd/harness/main.go` — wire `benchmark.Evaluate` + log verdicts
- `internal/artifact/bundle.go` — emit `benchmark_summary.json` + `benchmark_verdict.json`
- `README.md` — phase-B benchmark suite section

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/benchmark/` — 26 tests pass
- [ ] Smoke against live: run scenario 07 against api.streamvc.live, confirm `benchmark_verdict.json` matches the baseline doc (`specs/BENCHMARK_BASELINE_2026-06-28.md`)
- [ ] Confirm B6 SKIPs cleanly when `pricing_source` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
