### PR TITLE
spec(002,006): v1.5.0 / v0.9.1 — coordinator account-scoped reconciliation key (closes #211)

### DIFF
--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -299,11 +299,25 @@ func (h *handler) buyerEquivalentCredits(ctx context.Context, from, to time.Time
 		errorCode  sql.NullString
 		attemptN   int
 	}
+	// SPEC-002 v1.5.0 / issue #211 money-path defense-in-depth:
+	// the attempt_n subquery scopes by (account_id, request_id)
+	// under SQLite `IS` semantics so all three reconciliation
+	// sites (hotpath.go, recovery.go, this admin reconcile)
+	// compute identical ordinals for the same row. rl.request_id
+	// is coordinator-internal (server-minted UUID v4); the
+	// buyer-supplied #211 collision class lives on
+	// external_request_id and is addressed by the composite
+	// reconciliation key. Account scoping here is defense-in-depth
+	// against any future internal-request_id recurrence; NULL-
+	// account_id legacy rows cluster among themselves only,
+	// preserving pre-v1.5.0 behavior.
 	rows, err := h.store.db.QueryContext(ctx, `
 SELECT rl.request_id, rl.ts_utc, rl.model, rl.prompt_tokens, rl.completion_tokens, rl.status, rl.error_code,
        COALESCE((
          SELECT COUNT(*) - 1 FROM request_log prior
-          WHERE prior.request_id = rl.request_id AND prior.id <= rl.id
+          WHERE prior.account_id IS rl.account_id
+            AND prior.request_id = rl.request_id
+            AND prior.id <= rl.id
        ), 0) AS attempt_n
   FROM request_log rl
  WHERE rl.ts_utc >= ? AND rl.ts_utc < ?

--- a/phase4-coordinator/internal/billing/endpoints_test.go
+++ b/phase4-coordinator/internal/billing/endpoints_test.go
@@ -172,6 +172,72 @@ func TestReconcileEndpoint_CleanDelta(t *testing.T) {
 	}
 }
 
+// SPEC-002 v1.5.0 / issue #211 defense-in-depth regression:
+// the /admin/ledger/reconcile `buyerEquivalentCredits` attempt_n
+// derivation uses the same (account_id, request_id) IS-clustering as
+// hotpath.go and recovery.go so all three sites produce identical
+// ordinals for the same row. This test pins the contract under a
+// synthetic scenario — two non-NULL distinct accounts that happen to
+// share the same coordinator-internal request_id (UUID collision /
+// retry-loop bug / future schema change) — and asserts the reconcile
+// endpoint surfaces a clean zero delta. Note: this is NOT the actual
+// #211 buyer-supplied collision class (which is on external_request_id
+// and never reaches the internal request_id). It's a defense-in-depth
+// regression against the underlying SQL scoping logic. Use distinct
+// providers per account so the ledger_request_credits UNIQUE
+// constraint (account-blind on (request_id, attempt_n, provider_id))
+// does not fire — that's an orthogonal concern.
+func TestReconcileEndpoint_AccountScopedInternalRequestIDDefenseInDepth(t *testing.T) {
+	reqStore, store := newRequestAndBillingStores(t)
+	cfg := testRewards()
+	snapshotID, err := store.InsertConfigSnapshot(context.Background(), cfg, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	prompt, completion := int64(1000), int64(2000)
+	inputA := HotPathInput{
+		RequestID: "synthetic-internal-uuid-collision", AttemptN: 0, ProviderAssignedID: "assigned-a", ProviderID: "provider-a",
+		Model: "model-a", Status: 200, TSUtc: ts, PromptTokens: &prompt, CompletionTokens: &completion,
+		ConfigSnapshotID: snapshotID, RateEntry: RateFor(cfg.RateCard, "model-a"),
+		MultiplierPPM: 1000000, ProviderShareBps: 9000,
+	}
+	rowA := requestLogRow(inputA)
+	rowA.AccountID = "acct_A"
+	if err := store.WriteHotPath(context.Background(), reqStore, rowA, inputA); err != nil {
+		t.Fatal(err)
+	}
+	inputB := inputA
+	inputB.ProviderID = "provider-b"
+	inputB.ProviderAssignedID = "assigned-b"
+	rowB := requestLogRow(inputB)
+	rowB.AccountID = "acct_B"
+	if err := store.WriteHotPath(context.Background(), reqStore, rowB, inputB); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/admin/ledger/reconcile?from=2026-06-01&to=2026-06-08", nil)
+	req.Header.Set("Authorization", "Bearer operator")
+	w := httptest.NewRecorder()
+	store.Handlers("operator", fakeTokens{}, true, 60).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	// Both accounts independently derive attempt_n=0 within their
+	// own (account_id, request_id) group → both ledger rows are
+	// clean → reconcile delta MUST be 0. Pre-defense-in-depth
+	// (when endpoints.go used unscoped request_id grouping) the
+	// second account's row would have derived attempt_n=1, and the
+	// ledger row's recorded attempt_n=0 would have produced a
+	// non-zero reconcile delta.
+	if got := resp["delta_gross_credits"].(float64); got != 0 {
+		t.Fatalf("delta_gross_credits=%v want 0 (issue #211 endpoints account-scoped derivation)", got)
+	}
+}
+
 func TestReconcileEndpoint_DetectsMissingOperatorSplit(t *testing.T) {
 	reqStore, store := newRequestAndBillingStores(t)
 	cfg := testRewards()

--- a/phase4-coordinator/internal/billing/hotpath.go
+++ b/phase4-coordinator/internal/billing/hotpath.go
@@ -51,20 +51,27 @@ func (s *Store) WriteHotPath(ctx context.Context, reqLogStore *requestlog.Store,
 		committed = err == nil
 		return err
 	}
-	// SPEC-002 v1.5.0 / issue #211 money-path scope: when the incoming
-	// row carries a non-empty account_id, scope the AttemptN-derivation
-	// COUNT by (account_id, request_id) so a cross-account collision on
-	// request_id (after #196) cannot inflate the count and silently
-	// trigger the `ambiguous_attempt_n` zero-credit path below. Legacy
-	// rows with empty account_id keep the prior unscoped behavior for
-	// backwards compatibility with pre-v1.5.0 traffic.
-	var requestCount int
-	var countErr error
+	// SPEC-002 v1.5.0 / issue #211 money-path defense-in-depth:
+	// scope the AttemptN-derivation COUNT by (account_id, request_id)
+	// using SQLite `IS` semantics so all three sites (this one,
+	// recovery.go, endpoints.go admin-reconcile) compute the same
+	// attempt ordinal for any given row. Note that request_log.request_id
+	// is coordinator-internal (server-minted UUID v4); the buyer-
+	// supplied #211 collision class lives on external_request_id and
+	// is addressed by the composite (account_id, external_request_id)
+	// reconciliation key. This account scoping is defense-in-depth:
+	// if a UUID v4 collision or retry-loop bug ever causes the same
+	// internal request_id to recur across accounts, each account's
+	// attempt sequence is computed within its own scope. NULL-
+	// account_id legacy rows cluster with NULL-account_id legacy
+	// rows only (NULL = NULL under `IS`). For an empty in-memory
+	// AccountID, pass an explicit nil so SQLite matches IS NULL.
+	var accountIDArg any
 	if reqRow.AccountID != "" {
-		countErr = conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM request_log WHERE account_id = ? AND request_id = ?`, reqRow.AccountID, in.RequestID).Scan(&requestCount)
-	} else {
-		countErr = conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM request_log WHERE request_id = ?`, in.RequestID).Scan(&requestCount)
+		accountIDArg = reqRow.AccountID
 	}
+	var requestCount int
+	countErr := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM request_log WHERE account_id IS ? AND request_id = ?`, accountIDArg, in.RequestID).Scan(&requestCount)
 	if countErr == nil && requestCount > 0 {
 		if derived := requestCount - 1; derived > in.AttemptN {
 			if in.AttemptN != derived {

--- a/phase4-coordinator/internal/billing/hotpath.go
+++ b/phase4-coordinator/internal/billing/hotpath.go
@@ -51,8 +51,21 @@ func (s *Store) WriteHotPath(ctx context.Context, reqLogStore *requestlog.Store,
 		committed = err == nil
 		return err
 	}
+	// SPEC-002 v1.5.0 / issue #211 money-path scope: when the incoming
+	// row carries a non-empty account_id, scope the AttemptN-derivation
+	// COUNT by (account_id, request_id) so a cross-account collision on
+	// request_id (after #196) cannot inflate the count and silently
+	// trigger the `ambiguous_attempt_n` zero-credit path below. Legacy
+	// rows with empty account_id keep the prior unscoped behavior for
+	// backwards compatibility with pre-v1.5.0 traffic.
 	var requestCount int
-	if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM request_log WHERE request_id = ?`, in.RequestID).Scan(&requestCount); err == nil && requestCount > 0 {
+	var countErr error
+	if reqRow.AccountID != "" {
+		countErr = conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM request_log WHERE account_id = ? AND request_id = ?`, reqRow.AccountID, in.RequestID).Scan(&requestCount)
+	} else {
+		countErr = conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM request_log WHERE request_id = ?`, in.RequestID).Scan(&requestCount)
+	}
+	if countErr == nil && requestCount > 0 {
 		if derived := requestCount - 1; derived > in.AttemptN {
 			if in.AttemptN != derived {
 				in.AttemptN = derived

--- a/phase4-coordinator/internal/billing/recovery.go
+++ b/phase4-coordinator/internal/billing/recovery.go
@@ -46,6 +46,14 @@ INSERT INTO ledger_reconciliation_runs (
 	}()
 	defer func() { _ = tx.Rollback() }()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
+	// SPEC-002 v1.5.0 / issue #211 money-path scope: the orphan-
+	// detection subquery and the `prior` / `same` counts below MUST
+	// scope by (account_id, request_id) so a cross-account collision
+	// on request_id (after #196) cannot misclassify legitimate first
+	// attempts as retries or mark them as ambiguous. SQLite `IS`
+	// compares NULL = NULL as true, so legacy rows where both sides
+	// have NULL account_id cluster together exactly as they did
+	// pre-v1.5.0 — backwards compatible.
 	orphanRes, err := tx.ExecContext(ctx, `
 UPDATE ledger_request_credits
    SET quarantined = 1,
@@ -65,7 +73,9 @@ UPDATE ledger_request_credits
         WHERE rl.request_id = ledger_request_credits.request_id
           AND COALESCE((
               SELECT COUNT(*) - 1 FROM request_log prior
-               WHERE prior.request_id = rl.request_id AND prior.id <= rl.id
+               WHERE prior.account_id IS rl.account_id
+                 AND prior.request_id = rl.request_id
+                 AND prior.id <= rl.id
           ), 0) = ledger_request_credits.attempt_n
    )`, now, in.ScanFrom.UTC().Format(time.RFC3339Nano), in.ScanTo.UTC().Format(time.RFC3339Nano))
 	if err != nil {
@@ -79,11 +89,14 @@ SELECT rl.id, rl.ts_utc, rl.request_id, rl.model, rl.provider_assigned_id,
        rl.retried,
        COALESCE((
          SELECT COUNT(*) - 1 FROM request_log prior
-          WHERE prior.request_id = rl.request_id AND prior.id <= rl.id
+          WHERE prior.account_id IS rl.account_id
+            AND prior.request_id = rl.request_id
+            AND prior.id <= rl.id
        ), 0) AS attempt_n,
        COALESCE((
          SELECT COUNT(*) FROM request_log same
-          WHERE same.request_id = rl.request_id
+          WHERE same.account_id IS rl.account_id
+            AND same.request_id = rl.request_id
        ), 0) AS same_request_count
   FROM request_log rl
  WHERE rl.ts_utc >= ? AND rl.ts_utc < ?

--- a/phase4-coordinator/internal/billing/recovery.go
+++ b/phase4-coordinator/internal/billing/recovery.go
@@ -46,14 +46,22 @@ INSERT INTO ledger_reconciliation_runs (
 	}()
 	defer func() { _ = tx.Rollback() }()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	// SPEC-002 v1.5.0 / issue #211 money-path scope: the orphan-
-	// detection subquery and the `prior` / `same` counts below MUST
-	// scope by (account_id, request_id) so a cross-account collision
-	// on request_id (after #196) cannot misclassify legitimate first
-	// attempts as retries or mark them as ambiguous. SQLite `IS`
-	// compares NULL = NULL as true, so legacy rows where both sides
-	// have NULL account_id cluster together exactly as they did
-	// pre-v1.5.0 — backwards compatible.
+	// SPEC-002 v1.5.0 / issue #211 money-path defense-in-depth: the
+	// orphan-detection subquery and the `prior` / `same` counts below
+	// scope by (account_id, request_id) using SQLite `IS` semantics
+	// so all three reconciliation sites (hotpath.go, this file,
+	// endpoints.go admin reconcile) compute the same attempt ordinal.
+	// Note that rl.request_id is coordinator-internal (server-minted
+	// UUID v4); the buyer-supplied collision class lives on
+	// external_request_id and is addressed by the composite
+	// (account_id, external_request_id) reconciliation key. This
+	// scoping is defense-in-depth: should the same internal
+	// request_id ever recur across accounts (UUID collision,
+	// retry-loop bug, future schema change), each account's
+	// attempts are derived within its own scope rather than
+	// misclassified as cross-account retries. NULL-account_id
+	// legacy rows cluster with NULL-account_id rows only —
+	// backwards-compatible with pre-v1.5.0 single-account behavior.
 	orphanRes, err := tx.ExecContext(ctx, `
 UPDATE ledger_request_credits
    SET quarantined = 1,

--- a/phase4-coordinator/internal/billing/store_test.go
+++ b/phase4-coordinator/internal/billing/store_test.go
@@ -224,18 +224,21 @@ func TestWriteHotPath_DuplicateRequestIDWithoutRetryQuarantinesAttempt(t *testin
 	}
 }
 
-// SPEC-002 v1.5.0 / issue #211 money-path regression: when two
-// request_log rows collide on request_id but carry distinct
-// account_id values (the post-#196 cross-account X-Request-ID
-// collision scenario), RecoverLedger MUST derive attempt_n and
-// same_request_count by scoping (account_id, request_id), not
-// request_id alone. Without the scope, two accounts' first
-// attempts would be ambiguously quarantined during nightly
-// reconciliation. ISS-211 R1 architect HIGH.
-func TestRecoverLedger_AccountScopedRequestIDCollisionDoesNotQuarantine(t *testing.T) {
+// SPEC-002 v1.5.0 / issue #211 defense-in-depth regression: should
+// the same coordinator-internal request_id ever recur across rows
+// belonging to different accounts (UUID v4 collision, retry-loop
+// bug, future schema change), RecoverLedger MUST derive attempt_n
+// and same_request_count by scoping (account_id, request_id), not
+// request_id alone. Note that internal request_id is server-minted
+// (uuid.NewString() per buyer request) — this is NOT the actual
+// #211 buyer-supplied collision class on external_request_id; it's
+// defense-in-depth against any future internal-id recurrence.
+// ISS-211 R1 architect HIGH spotted the scoping gap; R6 reframed
+// from "cross-account collision class" to "defense-in-depth".
+func TestRecoverLedger_AccountScopedInternalRequestIDDefenseInDepth(t *testing.T) {
 	reqStore, store := newRequestAndBillingStores(t)
 	input, row := testHotPathInput(t, store)
-	row.RequestID = "buyer-controlled-duplicate-recovery"
+	row.RequestID = "synthetic-internal-uuid-collision-recovery"
 	input.RequestID = row.RequestID
 	row.AccountID = "acct_A"
 	// Use the hot-path-failure fallback so RecoverLedger does the
@@ -257,28 +260,30 @@ func TestRecoverLedger_AccountScopedRequestIDCollisionDoesNotQuarantine(t *testi
 		t.Fatal(err)
 	}
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantined = 1 AND quarantine_reason = 'ambiguous_attempt_n'`, row.RequestID); got != 0 {
-		t.Fatalf("cross-account request_id collision quarantined rows after recovery=%d, want 0 (issue #211 architect HIGH regression)", got)
+		t.Fatalf("synthetic internal request_id recurrence quarantined rows after recovery=%d, want 0 (issue #211 defense-in-depth regression)", got)
 	}
 	// Both accounts' rows should have produced a clean credit row.
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantined = 0`, row.RequestID); got != 2 {
-		t.Fatalf("non-quarantined ledger rows for cross-account collision=%d, want 2 (one per account)", got)
+		t.Fatalf("non-quarantined ledger rows for synthetic internal request_id recurrence=%d, want 2 (one per account)", got)
 	}
 }
 
-// SPEC-002 v1.5.0 / issue #211 money-path regression: when two writes
-// collide on request_id but carry distinct account_id values (the
-// post-#196 cross-account X-Request-ID collision scenario), the
-// AttemptN-derivation COUNT in hotpath.go MUST scope by
-// (account_id, request_id) and NOT trip the `ambiguous_attempt_n`
-// zero-credit path that would fire under the unscoped COUNT. The
-// parallel adjacent test
+// SPEC-002 v1.5.0 / issue #211 defense-in-depth regression: should
+// the same coordinator-internal request_id ever recur across writes
+// belonging to different accounts, the AttemptN-derivation COUNT in
+// hotpath.go MUST scope by (account_id, request_id) and NOT trip the
+// `ambiguous_attempt_n` zero-credit path that would fire under the
+// unscoped COUNT. Note that internal request_id is server-minted, so
+// this scenario is hypothetical — the actual #211 collision class
+// lives on external_request_id and is addressed by the reconciliation
+// key. The parallel adjacent test
 // TestWriteHotPath_DuplicateRequestIDWithoutRetryQuarantinesAttempt
-// covers the unscoped (legacy) case where both rows have empty
-// account_id and the quarantine fires by design.
-func TestWriteHotPath_AccountScopedRequestIDCollisionDoesNotQuarantine(t *testing.T) {
+// covers the legacy NULL-`account_id` clustering case where the
+// quarantine fires by design.
+func TestWriteHotPath_AccountScopedInternalRequestIDDefenseInDepth(t *testing.T) {
 	reqStore, store := newRequestAndBillingStores(t)
 	input, row := testHotPathInput(t, store)
-	row.RequestID = "buyer-controlled-duplicate"
+	row.RequestID = "synthetic-internal-uuid-collision-hotpath"
 	input.RequestID = row.RequestID
 	row.AccountID = "acct_A"
 	if err := store.WriteHotPath(context.Background(), reqStore, row, input); err != nil {
@@ -299,7 +304,7 @@ func TestWriteHotPath_AccountScopedRequestIDCollisionDoesNotQuarantine(t *testin
 	// account-scoped count, acct_B sees only its own one row and the
 	// derived AttemptN matches input.AttemptN, so no quarantine fires.
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantined = 1 AND quarantine_reason = 'ambiguous_attempt_n'`, row.RequestID); got != 0 {
-		t.Fatalf("cross-account request_id collision quarantined rows=%d, want 0 (issue #211 regression)", got)
+		t.Fatalf("synthetic internal request_id recurrence quarantined rows=%d, want 0 (issue #211 defense-in-depth regression)", got)
 	}
 }
 

--- a/phase4-coordinator/internal/billing/store_test.go
+++ b/phase4-coordinator/internal/billing/store_test.go
@@ -224,6 +224,85 @@ func TestWriteHotPath_DuplicateRequestIDWithoutRetryQuarantinesAttempt(t *testin
 	}
 }
 
+// SPEC-002 v1.5.0 / issue #211 money-path regression: when two
+// request_log rows collide on request_id but carry distinct
+// account_id values (the post-#196 cross-account X-Request-ID
+// collision scenario), RecoverLedger MUST derive attempt_n and
+// same_request_count by scoping (account_id, request_id), not
+// request_id alone. Without the scope, two accounts' first
+// attempts would be ambiguously quarantined during nightly
+// reconciliation. ISS-211 R1 architect HIGH.
+func TestRecoverLedger_AccountScopedRequestIDCollisionDoesNotQuarantine(t *testing.T) {
+	reqStore, store := newRequestAndBillingStores(t)
+	input, row := testHotPathInput(t, store)
+	row.RequestID = "buyer-controlled-duplicate-recovery"
+	input.RequestID = row.RequestID
+	row.AccountID = "acct_A"
+	// Use the hot-path-failure fallback so RecoverLedger does the
+	// derivation work (rather than hotpath.go's in-line check).
+	if err := store.WriteRequestLogWithIdentity(context.Background(), reqStore, row, input); err != nil {
+		t.Fatal(err)
+	}
+	input2 := input
+	row2 := row
+	input2.ProviderID = "provider-b"
+	input2.ProviderAssignedID = "assigned-b"
+	row2.ProviderAssignedID = "assigned-b"
+	row2.AccountID = "acct_B"
+	if err := store.WriteRequestLogWithIdentity(context.Background(), reqStore, row2, input2); err != nil {
+		t.Fatal(err)
+	}
+	in := RecoverInput{ScanFrom: row.TSUtc.Add(-time.Minute), ScanTo: row.TSUtc.Add(time.Minute), Source: "startup_scan"}
+	if err := store.RecoverLedger(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantined = 1 AND quarantine_reason = 'ambiguous_attempt_n'`, row.RequestID); got != 0 {
+		t.Fatalf("cross-account request_id collision quarantined rows after recovery=%d, want 0 (issue #211 architect HIGH regression)", got)
+	}
+	// Both accounts' rows should have produced a clean credit row.
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantined = 0`, row.RequestID); got != 2 {
+		t.Fatalf("non-quarantined ledger rows for cross-account collision=%d, want 2 (one per account)", got)
+	}
+}
+
+// SPEC-002 v1.5.0 / issue #211 money-path regression: when two writes
+// collide on request_id but carry distinct account_id values (the
+// post-#196 cross-account X-Request-ID collision scenario), the
+// AttemptN-derivation COUNT in hotpath.go MUST scope by
+// (account_id, request_id) and NOT trip the `ambiguous_attempt_n`
+// zero-credit path that would fire under the unscoped COUNT. The
+// parallel adjacent test
+// TestWriteHotPath_DuplicateRequestIDWithoutRetryQuarantinesAttempt
+// covers the unscoped (legacy) case where both rows have empty
+// account_id and the quarantine fires by design.
+func TestWriteHotPath_AccountScopedRequestIDCollisionDoesNotQuarantine(t *testing.T) {
+	reqStore, store := newRequestAndBillingStores(t)
+	input, row := testHotPathInput(t, store)
+	row.RequestID = "buyer-controlled-duplicate"
+	input.RequestID = row.RequestID
+	row.AccountID = "acct_A"
+	if err := store.WriteHotPath(context.Background(), reqStore, row, input); err != nil {
+		t.Fatal(err)
+	}
+	input2 := input
+	row2 := row
+	input2.ProviderID = "provider-b"
+	input2.ProviderAssignedID = "assigned-b"
+	row2.ProviderAssignedID = "assigned-b"
+	row2.AccountID = "acct_B" // different account, same request_id
+	if err := store.WriteHotPath(context.Background(), reqStore, row2, input2); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-#211 (unscoped COUNT): would have counted 2 rows for the
+	// same request_id, derived AttemptN=1, and quarantined the second
+	// row as `ambiguous_attempt_n` → zero credit for acct_B. With the
+	// account-scoped count, acct_B sees only its own one row and the
+	// derived AttemptN matches input.AttemptN, so no quarantine fires.
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantined = 1 AND quarantine_reason = 'ambiguous_attempt_n'`, row.RequestID); got != 0 {
+		t.Fatalf("cross-account request_id collision quarantined rows=%d, want 0 (issue #211 regression)", got)
+	}
+}
+
 func TestWriteHotPath_DerivedBillingAttemptAllowedWhenAttemptMatches(t *testing.T) {
 	reqStore, store := newRequestAndBillingStores(t)
 	input, row := testHotPathInput(t, store)

--- a/phase4-coordinator/internal/buyer/billing_recorder.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder.go
@@ -64,6 +64,15 @@ type billingRecorder struct {
 	// coordinator request_log by a stable shared id. Empty when the
 	// inbound request carried no X-Request-ID.
 	externalRequestID string
+	// accountID is the gateway-forwarded X-MacProvider-Account (SPEC-002
+	// v1.5.0, SPEC-006 v0.9.1, issue #211). Preserved into
+	// request_log.account_id so reconciliation can use the composite
+	// (account_id, external_request_id) key instead of
+	// external_request_id alone — the latter is ambiguous on
+	// cross-account X-Request-ID collisions after #196. Empty when the
+	// inbound request carried no header (direct legacy buyer, demo
+	// without gateway, pre-v0.9.1 gateway).
+	accountID string
 
 	// attemptN is the running per-provider-attempt counter. Pre-refactor
 	// this was billingAttemptN, incremented via deferred closure on
@@ -76,7 +85,7 @@ type billingRecorder struct {
 // forwardState pointer the sequence helpers will mutate; the recorder
 // reads state.routingDone at write time to compute RoutingMs (matching
 // the pre-refactor closure's live-capture semantics).
-func (s *Server) newBillingRecorder(r *http.Request, state *forwardState, startedAt time.Time, requestID, externalRequestID string) *billingRecorder {
+func (s *Server) newBillingRecorder(r *http.Request, state *forwardState, startedAt time.Time, requestID, externalRequestID, accountID string) *billingRecorder {
 	return &billingRecorder{
 		server:            s,
 		state:             state,
@@ -84,6 +93,7 @@ func (s *Server) newBillingRecorder(r *http.Request, state *forwardState, starte
 		startedAt:         startedAt,
 		requestID:         requestID,
 		externalRequestID: externalRequestID,
+		accountID:         accountID,
 	}
 }
 
@@ -145,6 +155,7 @@ func (b *billingRecorder) recordRow(
 		TSUtc:               b.startedAt,
 		RequestID:           b.requestID,
 		ExternalRequestID:   b.externalRequestID,
+		AccountID:           b.accountID,
 		Model:               b.model,
 		ProviderAssignedID:  providerAssignedID,
 		PromptTokens:        promptTok,

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1293,6 +1293,13 @@ type requestToolCall struct {
 
 func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	externalRequestID := sanitizeExternalRequestID(r.Header.Get("X-Request-ID"))
+	// SPEC-002 v1.5.0 / issue #211: gateway-forwarded account id.
+	// Persisted into request_log.account_id so reconciliation can use
+	// the composite (account_id, external_request_id) key (composite-PK
+	// addendum from #196). Empty for direct legacy buyer calls and for
+	// pre-SPEC-006 v0.9.1 gateways that only emit this header on the
+	// sticky path.
+	accountID := sanitizeAccountID(r.Header.Get("X-MacProvider-Account"))
 	requestID := requestIDForBuyerRequest()
 	routingRequestID := uuid.NewString()
 	originalRequestID := requestID
@@ -1312,7 +1319,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// setRequestID land before the first provider-bound recordRow call,
 	// preserving the pre-refactor closure's "latest value at fire time"
 	// semantics for what used to be captured outer-scope variables.
-	rec := s.newBillingRecorder(r, state, startedAt, originalRequestID, externalRequestID)
+	rec := s.newBillingRecorder(r, state, startedAt, originalRequestID, externalRequestID, accountID)
 	maxBodyBytes := s.maxChatBodyBytes
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes+1))
 	if err != nil {
@@ -4731,6 +4738,27 @@ func normalizeIdempotencyKey(value string) string {
 // surfaced to the buyer; logging it as-is would replay any
 // log-injection payload.
 func sanitizeExternalRequestID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 128 {
+		return ""
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			return ""
+		}
+	}
+	return value
+}
+
+// sanitizeAccountID normalizes the inbound X-MacProvider-Account header
+// for persistent storage in request_log.account_id (SPEC-002 v1.5.0,
+// issue #211). Same defense-in-depth shape as sanitizeExternalRequestID:
+// trim, cap at 128 bytes (gateway account ids are "acct_<...>" or
+// "demo:<ip>" — both well under 128), reject C0/C1 control characters.
+// On failure, returns "" — the coordinator treats the value as if no
+// header was present, which is allowed by SPEC-002 v1.5.0 ("Absent
+// header MUST be tolerated; the column carries NULL in that case").
+func sanitizeAccountID(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" || len(value) > 128 {
 		return ""

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -41,6 +41,15 @@ type Row struct {
 	// request, enabling end-to-end billing reconciliation. Empty when
 	// the inbound request carried no X-Request-ID.
 	ExternalRequestID string
+	// AccountID is the gateway's authenticated subject account id,
+	// forwarded via X-MacProvider-Account (SPEC-006 v0.9.1, SPEC-002
+	// v1.5.0). The composite (AccountID, ExternalRequestID) is the
+	// reconciliation key joining coordinator request_log to gateway
+	// usage_events; without it the same buyer-supplied X-Request-ID
+	// across two accounts cannot be attributed back to the correct
+	// gateway account (issue #211, follow-up to #196). Empty for
+	// direct legacy buyer calls without the header.
+	AccountID         string
 	Model             string
 	ProviderAssignedID string
 	PromptTokens        *int64
@@ -122,6 +131,7 @@ CREATE TABLE IF NOT EXISTS request_log (
     ts_utc               TEXT    NOT NULL,
     request_id           TEXT    NOT NULL,
     external_request_id  TEXT    NULL,
+    account_id           TEXT    NULL,
     model                TEXT    NOT NULL,
     provider_assigned_id TEXT    NULL,
     prompt_tokens        INTEGER NULL,
@@ -150,6 +160,11 @@ CREATE INDEX IF NOT EXISTS idx_request_log_request_id_id
 -- runbook subcommand "coordinator migrate-indexes" — NOT from the
 -- daemon startup path, because SQLite has no concurrent index build
 -- and the request-log store caps the pool at one writer connection.
+--
+-- SPEC-002 v1.5.0 (issue #211): request_log.account_id is added by
+-- ensureColumns for the same reason; the matching partial-NULL
+-- composite index on (account_id, external_request_id) is also built
+-- by MigrateIndexes.
 
 CREATE TABLE IF NOT EXISTS request_idempotency_keys (
     idempotency_key TEXT PRIMARY KEY,
@@ -323,6 +338,7 @@ INSERT INTO request_log (
     ts_utc,
     request_id,
     external_request_id,
+    account_id,
     model,
     provider_assigned_id,
     prompt_tokens,
@@ -339,10 +355,11 @@ INSERT INTO request_log (
     pref_header,
     provider_header,
     retried
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		row.TSUtc.UTC().Format(time.RFC3339Nano),
 		row.RequestID,
 		nullString(row.ExternalRequestID),
+		nullString(row.AccountID),
 		row.Model,
 		nullString(row.ProviderAssignedID),
 		nullInt64(row.PromptTokens),
@@ -392,6 +409,13 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 		// Pre-existing rows scan as NULL; new INSERTs carry the
 		// gateway-forwarded id when present.
 		{name: "external_request_id", sql: `ALTER TABLE request_log ADD COLUMN external_request_id TEXT NULL`},
+		// SPEC-002 v1.5.0 / issue #211: gateway-forwarded account id
+		// from X-MacProvider-Account. The composite (account_id,
+		// external_request_id) is the reconciliation key joining to
+		// gateway usage_events; without it the same buyer-supplied
+		// X-Request-ID across two accounts cannot be attributed back
+		// to the correct gateway account.
+		{name: "account_id", sql: `ALTER TABLE request_log ADD COLUMN account_id TEXT NULL`},
 	} {
 		if cols[migration.name] {
 			continue
@@ -430,6 +454,13 @@ func (s *Store) MigrateIndexes(ctx context.Context) error {
 		{
 			name: "idx_request_log_external_request_id",
 			ddl:  `CREATE INDEX idx_request_log_external_request_id ON request_log(external_request_id) WHERE external_request_id IS NOT NULL`,
+		},
+		// SPEC-002 v1.5.0 / issue #211: composite reconciliation-key
+		// index. Partial-NULL keeps the index small (legacy rows
+		// have NULL on either column and are not indexed).
+		{
+			name: "idx_request_log_account_external_request_id",
+			ddl:  `CREATE INDEX idx_request_log_account_external_request_id ON request_log(account_id, external_request_id) WHERE account_id IS NOT NULL AND external_request_id IS NOT NULL`,
 		},
 	}
 	for _, ix := range indexes {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -231,6 +231,33 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// fresh UUID here, breaking that join.
 	upReq.Header.Set("X-Request-ID", requestID(r))
 	upReq.Header.Set("X-MacProvider-Gateway-FirstByte-Unix-Ms", strconv.FormatInt(s.now().UnixMilli(), 10))
+	// SPEC-006 v0.9.1 / SPEC-002 v1.5.0 / issue #211: forward the
+	// gateway's authenticated account id on EVERY forwarded buyer
+	// request — bearer-authenticated and demo subjects alike, both on
+	// the sticky and non-sticky paths. The coordinator persists this
+	// into request_log.account_id; the composite
+	// (account_id, external_request_id) is the reconciliation key
+	// joining gateway usage_events to coordinator request_log (the
+	// composite-PK addendum from #196). Earlier code emitted this
+	// header only inside the sticky-routing conditional below, leaving
+	// the non-sticky hot path account-blind and reopening the
+	// cross-account request_id-collision class on the coordinator
+	// audit-trail side.
+	//
+	// The coordinator treats X-MacProvider-Account as an internal-
+	// routing header (see hasInternalRoutingHeader / selectProviderExcluding
+	// in phase4-coordinator/internal/buyer/server.go) gated by the
+	// gateway-service-token Authorization bearer. To avoid the
+	// coordinator rejecting every non-sticky chat with 400
+	// invalid_request, the upstream Authorization bearer is hoisted
+	// alongside the account header — same pair the sticky path
+	// already sends. M3-2 / SECU-4: prefer ServiceToken when set;
+	// falls back to OperatorKey so a not-yet-upgraded coordinator
+	// keeps accepting us. ISS-211 R1 security audit HIGH.
+	if subject.AccountID != "" {
+		upReq.Header.Set("Authorization", "Bearer "+s.cfg.Coordinator.UpstreamCoordinatorBearer())
+		upReq.Header.Set("X-MacProvider-Account", subject.AccountID)
+	}
 	if s.cfg.Routing.StickyEnabled && !authn.Demo {
 		if tag := strings.TrimSpace(r.Header.Get("X-MacProvider-Conversation")); tag != "" {
 			if !validConversationTag(tag) {
@@ -239,11 +266,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if metadata, ok := s.coordinatorRoutingMetadata(upCtx); ok && metadata.Sticky.Enabled && metadata.Sticky.TTLSeconds == s.cfg.Routing.StickyTTLS {
-				// M3-2 / SECU-4: prefer ServiceToken when set; falls back to
-				// OperatorKey so a not-yet-upgraded coordinator keeps
-				// accepting us on the hot sticky-routing path.
-				upReq.Header.Set("Authorization", "Bearer "+s.cfg.Coordinator.UpstreamCoordinatorBearer())
-				upReq.Header.Set("X-MacProvider-Account", subject.AccountID)
+				// Authorization + X-MacProvider-Account already set
+				// unconditionally above (SPEC-006 v0.9.1). The sticky
+				// path's distinguishing header is X-MacProvider-Internal-Conv.
 				upReq.Header.Set("X-MacProvider-Internal-Conv", s.deriveConversationKey(subject.AccountID, tag))
 			}
 		}

--- a/phase5-gateway/internal/router/integration_test.go
+++ b/phase5-gateway/internal/router/integration_test.go
@@ -23,8 +23,20 @@ func TestStrangerKeyOpenAIChatUsageFlow(t *testing.T) {
 		if r.URL.Path != "/v1/chat/completions" {
 			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
 		}
-		if got := r.Header.Get("Authorization"); got != "" {
-			t.Fatalf("forwarded buyer auth header=%q", got)
+		// SPEC-006 v0.9.1 / issue #211: the upstream Authorization
+		// header is now hoisted out of the sticky-routing conditional
+		// and set on every forward (alongside X-MacProvider-Account)
+		// because the coordinator gates X-MacProvider-Account behind
+		// internalBearerAuthorized. The value MUST be the gateway's
+		// configured upstream coordinator bearer — NOT the buyer's
+		// mp_-prefixed API key. This assertion guards that the
+		// buyer's bearer is not silently exfiltrated upstream.
+		got := r.Header.Get("Authorization")
+		if strings.Contains(got, "mp_") {
+			t.Fatalf("forwarded buyer auth header (mp_ key leaked)=%q", got)
+		}
+		if got != "Bearer operator-key" {
+			t.Fatalf("forwarded Authorization=%q, want %q", got, "Bearer operator-key")
 		}
 		forwardedRequestID = r.Header.Get("X-Request-ID")
 		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1559,6 +1559,18 @@ func TestProviderPinningHeadersStripped(t *testing.T) {
 	if got := captured.Get("X-Request-ID"); got != "55555555-5555-4555-8555-555555555555" {
 		t.Fatalf("forwarded X-Request-ID = %q, want buyer-supplied value preserved", got)
 	}
+	// SPEC-006 v0.9.1 + SPEC-002 v1.5.0 + issue #211: the gateway MUST
+	// forward X-MacProvider-Account on EVERY forwarded buyer request
+	// (not just the sticky-routing conditional path). The composite
+	// (account_id, external_request_id) is the reconciliation key
+	// joining gateway usage_events to coordinator request_log; without
+	// the header on the hot non-sticky path the coordinator could not
+	// attribute the row to the gateway account, reopening the
+	// cross-account request_id-collision class on the coordinator
+	// audit-trail side. This test exercises the non-sticky bearer path.
+	if got := captured.Get("X-MacProvider-Account"); got != "acct_strip_success" {
+		t.Fatalf("forwarded X-MacProvider-Account = %q, want %q (issue #211: non-sticky hot path must forward account id)", got, "acct_strip_success")
+	}
 	if got := captured.Get("X-MacProvider-Retry"); got != "1" {
 		t.Fatalf("forwarded retry = %q, want 1", got)
 	}
@@ -1757,14 +1769,30 @@ func TestStickyConversationIgnoredForDemoTraffic(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
 	}
+	// SPEC-006 v0.9.1 / issue #211: sticky's distinguishing header is
+	// X-MacProvider-Internal-Conv; it MUST remain suppressed on demo
+	// traffic. That's the test's name and core intent.
 	if got := captured.Get("X-MacProvider-Internal-Conv"); got != "" {
 		t.Fatalf("demo internal conversation forwarded: %q", got)
 	}
-	if got := captured.Get("X-MacProvider-Account"); got != "" {
-		t.Fatalf("demo account forwarded: %q", got)
+	// SPEC-006 v0.9.1 / issue #211: X-MacProvider-Account is now
+	// forwarded unconditionally (including for demo subjects) so
+	// coordinator request_log.account_id can hold "demo:<ip>" and
+	// the reconciliation key (account_id, external_request_id) is
+	// well-defined for demo rows too. The coordinator gates the
+	// header behind the upstream Authorization bearer
+	// (hasInternalRoutingHeader / internalBearerAuthorized in
+	// phase4-coordinator/internal/buyer/server.go), so the bearer
+	// is also now sent on every forward — including demo. This is
+	// a SPEC-006 v0.9.1 contract change relative to pre-v0.9.1
+	// behavior where Authorization was sticky-gated. Sticky-only
+	// state (X-MacProvider-Internal-Conv) is still suppressed for
+	// demo; that's what this test's name still guards.
+	if got := captured.Get("X-MacProvider-Account"); got != "demo:1.2.3.4" {
+		t.Fatalf("demo account header = %q, want %q", got, "demo:1.2.3.4")
 	}
-	if got := captured.Get("Authorization"); got != "" {
-		t.Fatalf("demo coordinator auth forwarded: %q", got)
+	if got := captured.Get("Authorization"); got == "" {
+		t.Fatalf("demo coordinator Authorization missing — SPEC-006 v0.9.1 / issue #211 requires it whenever X-MacProvider-Account is forwarded")
 	}
 	if got := captured.Get("X-Demo-Token"); got != "" {
 		t.Fatalf("demo token forwarded: %q", got)

--- a/specs/AUDIT_ISS_211_R1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,78 @@
+# AUDIT — ISS-211 R1 — ARCHITECT lens
+
+## Task
+
+Architect-lens audit of the SPEC + IMPL bundle for issue #211.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+### Focus areas
+
+1. **SPEC corpus coherence.** Do SPEC-002 v1.5.0, SPEC-006 v0.9.1,
+   and the unchanged SPEC-007 v0.2.1 (already in flight on PR
+   #221 / spec/iss-212-explorer-composite-pk) tell one consistent
+   story about `(account_id, request_id)` as a physical reconciliation
+   identity on both sides? Specifically:
+   - SPEC-007 v0.2.1 §2.8 (in PR #221) carries the line "Coordinator
+     request_log still keys reconciliation by buyer-supplied
+     external_request_id alone (no account_id scope). Tracked in
+     issue #211." If both PRs merge in either order, what is the
+     stale-pointer outcome and is it acceptable?
+   - SPEC-002 v1.5.0 references "SPEC-007 §6.4 v0.2.1 addendum (#196)"
+     which only exists once PR #221 merges. Should the dependency
+     line note this?
+
+2. **Deploy ordering.** SPEC-002 v1.5.0 mandates "coordinator
+   first, then gateway". Is the ordering robust to:
+   - A coordinator that has the column but no live index yet
+     (post-deploy / pre-migrate-indexes window)?
+   - A gateway that sends the header before the column landed
+     (the header is silently ignored)?
+   - A rollback: what happens if v1.5.0 coordinator rolls back to
+     v1.4.x with the new column already in place?
+
+3. **Version-bump shape.** This is the first normative MUST added
+   to the gateway-coordinator forward contract since v1.4.2 R-2
+   shipped without a change-log entry (referenced as "v1.4.2 R-2"
+   in code but absent from the SPEC body — subject of ISS-197).
+   Is `v1.5.0` correct or should this be `v1.4.3` to match #197's
+   in-flight numbering? Argue from the corpus convention
+   (substantive normative change → minor bump; clarification →
+   patch bump).
+
+4. **Money-path scoping.** Are there OTHER coordinator queries
+   over `request_log` that should also be account-scoped to
+   preserve the audit-trail integrity SPEC-002 v1.5.0 claims?
+   Specifically check:
+   - `phase4-coordinator/internal/explorer/store.go`
+     `SessionDetail` / `RecentSessions`.
+   - `phase4-coordinator/internal/billing/store.go` reconciliation
+     queries that join request_log by request_id.
+   - SPEC-005 v0.3 attempt-attribution paths (if discoverable from
+     the spec).
+   If any are NOT being scoped here, is the deferral documented
+   (e.g. the explorer is explicitly deferred to follow-up)?
+
+5. **Cross-spec touch-ups missing.** Does this PR miss any of:
+   - SPEC-005 (billing) reconciliation contracts?
+   - SPEC-004 (retry) attempt-ordinal docs?
+   - SPEC-002 §10 D-entries (D11 cross-service request
+     correlation)?
+
+### Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.
+
+### Out of scope
+- Re-evaluating the Option A vs B vs C choice from the issue.
+- Demo-IP exposure (covered by security lens).
+- Sanitizer character allowlist (covered by security lens).

--- a/specs/AUDIT_ISS_211_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R1_CODE_PROMPT.md
@@ -1,0 +1,71 @@
+# AUDIT — ISS-211 R1 — CODE lens
+
+## Task
+
+Audit the SPEC + IMPL bundle for issue #211 (coordinator-side
+account-scoped reconciliation key, follow-up to #196) for
+**CODE-lens drift between spec and implementation**:
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+### SPEC changes to verify
+- `specs/SPEC-002-coordinator.md` v1.5.0 change-log + §11 FR-B9
+  request_log schema + §11 indexes block + §11 deploy-ordering +
+  §11 money-path-AttemptN sub-section + §7.2
+  X-MacProvider-Account forward contract.
+- `specs/SPEC-006-buyer-api.md` v0.9.1 change-log + gateway forward
+  header requirement.
+
+### IMPL changes to verify against
+- `phase4-coordinator/internal/requestlog/store.go`: account_id
+  column added to canonical CREATE TABLE, ensureColumns migration,
+  Row struct field, insert() binding,
+  idx_request_log_account_external_request_id in MigrateIndexes.
+- `phase4-coordinator/internal/buyer/server.go`:
+  sanitizeAccountID helper, reading X-MacProvider-Account in
+  handleChatCompletions, plumbing through newBillingRecorder.
+- `phase4-coordinator/internal/buyer/billing_recorder.go`: struct
+  field accountID, constructor parameter, Row{} write.
+- `phase4-coordinator/internal/billing/hotpath.go`: AttemptN COUNT
+  scope (account_id, request_id) when reqRow.AccountID != "",
+  fallback to unscoped when empty.
+- `phase5-gateway/internal/router/chat_proxy.go`: hoisted
+  X-MacProvider-Account out of the sticky-routing conditional.
+- New tests in
+  `phase4-coordinator/internal/billing/store_test.go`
+  (`TestWriteHotPath_AccountScopedRequestIDCollisionDoesNotQuarantine`)
+  and
+  `phase5-gateway/internal/router/server_test.go`
+  (positive assertion in `TestProviderPinningHeadersStripped`,
+  updated assertion in `TestStickyConversationIgnoredForDemoTraffic`).
+
+### Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM findings of these classes:
+- SPEC text describes behavior the code doesn't implement.
+- Code implements behavior the SPEC doesn't describe.
+- New SQL statement uses a column or index that doesn't exist on
+  fresh installs OR on migrated installs.
+- Money-path math (hotpath.go AttemptN derivation) drifts from
+  the SPEC's stated invariant.
+- A SPEC MUST has no corresponding code branch (e.g. "MUST
+  tolerate absent header" with no empty-string handling).
+- Backwards-compat: a code path that worked pre-v1.5.0 stops
+  working without the SPEC saying so.
+
+Format each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: <what the SPEC says vs what the code does>
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.
+
+### Out of scope
+- Explorer surface SELECT'ing account_id (intentionally deferred
+  to a follow-up; #211 closes on reconciliation-key only).
+- The #196 gateway composite-PK design itself.
+- ISS-197 v1.4.3 R-2 external_request_id clarifications (separate).

--- a/specs/AUDIT_ISS_211_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R1_SECURITY_PROMPT.md
@@ -1,0 +1,78 @@
+# AUDIT — ISS-211 R1 — SECURITY lens
+
+## Task
+
+Security-lens audit of the SPEC + IMPL bundle for issue #211
+(coordinator-side account-scoped reconciliation key,
+follow-up to #196).
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+### Focus areas
+
+1. **Header trust boundary.** The gateway now sends
+   `X-MacProvider-Account: <subject.AccountID>` on every forwarded
+   request. The coordinator's `handleChatCompletions` reads this
+   header from `r.Header.Get(...)` and writes it into
+   `request_log.account_id`. Does the coordinator validate that
+   the header came from a trusted upstream (vs. a buyer who
+   bypasses the gateway and sets the header directly)? Does the
+   threat model require validation, or is the coordinator-vs-buyer
+   network-level segmentation sufficient? Compare with how
+   `X-MacProvider-Account` is treated on the existing sticky path
+   (where it already arrived and was used to derive the
+   conversation key — a security-sensitive value).
+
+2. **`sanitizeAccountID` in
+   `phase4-coordinator/internal/buyer/server.go`.** New helper.
+   Same shape as `sanitizeExternalRequestID` (trim, 128-byte cap,
+   C0/C1 control-char reject). Are there account-id-specific
+   considerations the sanitizer should additionally enforce
+   (e.g. character allowlist matching the actual issued
+   account-id format `acct_<...>` or `demo:<ip>`)? Does rejecting
+   on length / control chars to "" silently expose a downstream
+   path that assumes a valid account_id?
+
+3. **Demo IP exposure.** Demo subjects forward
+   `subject.AccountID = "demo:<X-Real-IP>"` to coordinator. The
+   coordinator can already see the underlying IP via X-Forwarded-For
+   / source address, so net new exposure is approximately zero;
+   verify this reasoning is correct and the IP isn't being newly
+   exposed to a downstream system (log file, audit table,
+   admin dashboard) that previously did not see it.
+
+4. **Cross-account row leakage in money-path query.** The
+   `hotpath.go` change scopes the AttemptN COUNT by
+   `(account_id, request_id)` when `account_id != ""`. Is the
+   fallback to the unscoped query (when `account_id == ""`) a
+   downgrade an attacker can engineer (gateway suppresses the
+   header → coordinator counts cross-account rows → exploit)?
+
+5. **SQL injection / parameter binding.** The new query uses
+   parameterized binds; verify there is no string-interpolation
+   path.
+
+6. **Migration safety.** `ALTER TABLE request_log ADD COLUMN
+   account_id TEXT NULL` on a live deployment. Are there any
+   constraints (NOT NULL, FK, UNIQUE) that would block the
+   migration mid-traffic? Is the partial-NULL composite index
+   safe to build under sustained write load given the
+   single-writer connection pool?
+
+### Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal SPEC or code edit>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.
+
+### Out of scope
+- The #196 gateway composite-PK design.
+- Auth model for `/v1/chat/completions` itself.
+- Explorer surface (intentionally deferred).

--- a/specs/AUDIT_ISS_211_R2_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R2_ARCHITECT_PROMPT.md
@@ -1,0 +1,94 @@
+# AUDIT — ISS-211 R2 — ARCHITECT lens
+
+## Task
+
+R2 architect re-audit. R1 surfaced 1 HIGH + 4 MEDIUM. R2 fixed all
+five and added new structural code (recovery.go SQL scope, bearer
+hoist). Re-check whether R2 introduced new architectural issues
+or whether the original deferrals are still defensible.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R2 architect deltas
+
+- `recovery.go` orphan-detection + prior + same_request_count
+  subqueries scope by `(account_id, request_id)` via SQLite `IS`.
+- SPEC-002 v1.5.0 explorer-deferral bullet explicitly added.
+- SPEC-002 v1.5.0 §10 D11 refreshed with the v1.5.0 contract.
+- SPEC-002 v1.5.0 rollback-row-level-gate language added.
+- SPEC-002 v1.5.0 + SPEC-006 v0.9.1 both record the new bearer-
+  pairing requirement.
+- `specs/SPEC-002-v1-5-0-audit.md` consolidates findings.
+
+## Focus areas
+
+1. **More request_log scans missed.** R1 caught hotpath.go +
+   recovery.go. Are there other coordinator queries over
+   `request_log` (billing/store.go, ws/, explorer/store.go,
+   stats/, or anywhere else) that join or count by
+   `request_id` and would be vulnerable to the same
+   cross-account collision class on the money-path or
+   audit-trail surface? R1 architect identified explorer/store.go
+   and explicitly deferred. Are there others NOT in the
+   deferral note that should be in scope here?
+
+2. **Defense in depth on the bearer pairing.** R1 fixed S1 by
+   pairing the bearer. R2 SPEC-006 v0.9.1 records this. But
+   the underlying root cause is that the coordinator uses one
+   header (`X-MacProvider-Account`) for two semantically-distinct
+   purposes:
+   - INTERNAL ROUTING (sticky / conversation routing — requires
+     bearer auth).
+   - RECONCILIATION TAG (audit-trail, no special routing
+     intent).
+   Is bundling both purposes under one header the right
+   long-term architecture, or should v2 introduce a separate
+   `X-MacProvider-Audit-Account` header that doesn't require
+   bearer pairing? If long-term we want separation, is the
+   v1.5.0 bearer-pairing a permanent workaround or a transitional
+   shim? Recommend the right architectural shape.
+
+3. **SPEC-005 / SPEC-004 sub-contracts.** SPEC-002 v1.5.0
+   touches §11 / §7.2 / §10 D11. Does SPEC-005 (billing
+   reconciliation) or SPEC-004 (retry attempts) have any text
+   that now contradicts the new composite identity, that this
+   PR should also touch? (R1 deferred explorer — does that
+   blanket apply, or does SPEC-005 require independent action?)
+
+4. **D-CROSS-3 / SPEC-CROSS-006 audit doc.** §10 D11 cites
+   SPEC-CROSS-006-audit.md as the source. Does that audit doc
+   also need updating, or is the SPEC-002 §10 entry the
+   single source of truth?
+
+5. **Version coupling.** SPEC-006 v0.9.1's
+   `Depends on: SPEC-002 v1.5.0` is now strict. SPEC-007
+   v0.2.1 (PR #221) doesn't bump its SPEC-002 dependency.
+   Should it? Is the cross-PR dependency story coherent?
+
+6. **Rollback path completeness.** The R2 rollback note says
+   auditors use `account_id IS NOT NULL` per-row gate. But
+   does the SPEC also need to specify what the gateway should
+   do if it detects a coordinator that has rolled back (e.g.,
+   the gateway sees a `400 invalid_request` on the
+   X-MacProvider-Account header because the rollback target
+   never had the column)? Today's fallback would be the
+   coordinator's pre-existing behavior; is that documented?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.
+
+## Out of scope
+
+- Re-evaluating Option A vs B vs C.
+- The R1 findings (assume R2 disposition unless R2 broke them).
+- Demo abuse rate-limiting.

--- a/specs/AUDIT_ISS_211_R2_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R2_CODE_PROMPT.md
@@ -1,0 +1,94 @@
+# AUDIT — ISS-211 R2 — CODE lens
+
+## Task
+
+R2 re-audit of the SPEC + IMPL bundle for issue #211 (coordinator
+account-scoped reconciliation key). R1 returned ZERO FINDINGS on
+the code lens, but R1 also surfaced one HIGH (security) and one
+HIGH (architect) whose R2 fixes added new code: a hoisted upstream
+bearer on the gateway, and account-scoped SQL subqueries in
+`recovery.go`. Re-check those R2 deltas plus everything around
+them — code-lens drift between spec and implementation.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R2 deltas (relative to R1)
+
+- `phase5-gateway/internal/router/chat_proxy.go`: the upstream
+  `Authorization: Bearer <UpstreamCoordinatorBearer>` is now set
+  unconditionally alongside `X-MacProvider-Account` when
+  `subject.AccountID != ""`. The sticky-conditional block keeps
+  only `X-MacProvider-Internal-Conv`.
+- `phase5-gateway/internal/router/integration_test.go`:
+  `TestStrangerKeyOpenAIChatUsageFlow` Authorization assertion
+  rewritten to expect `"Bearer operator-key"` and guard against
+  `mp_` key leakage.
+- `phase5-gateway/internal/router/server_test.go`:
+  `TestStickyConversationIgnoredForDemoTraffic` updated to expect
+  `X-MacProvider-Account: demo:1.2.3.4` AND a non-empty
+  Authorization header.
+- `phase4-coordinator/internal/billing/recovery.go`:
+  orphan-detection subquery, `prior`-attempt subquery, and
+  `same_request_count` subquery all now scope by
+  `(account_id, request_id)` using SQLite `IS` (so NULL = NULL
+  preserves legacy clustering).
+- `phase4-coordinator/internal/billing/store_test.go`: new
+  `TestRecoverLedger_AccountScopedRequestIDCollisionDoesNotQuarantine`.
+- SPEC-002 v1.5.0 change-log additions: rollback row-level gate
+  language, explorer-deferral bullet, §10 D11 refresh, the
+  bearer-pairing requirement.
+- SPEC-006 v0.9.1 change-log addition: bearer-pairing requirement.
+
+## What to audit
+
+1. Does the gateway's R2 bearer hoist match SPEC-006 v0.9.1's new
+   bearer-pairing MUST? Specifically: the condition
+   `if subject.AccountID != ""` gates BOTH the bearer and the
+   account header — does the SPEC text claim the bearer is sent
+   on EVERY forward, including when account_id happens to be
+   empty (legacy gateway, weird auth path)?
+2. Does `recovery.go`'s SQLite `IS` operator correctly preserve
+   the pre-v1.5.0 quarantine semantics for legacy rows where
+   BOTH `prior.account_id` AND `rl.account_id` are NULL? The
+   adjacent legacy test
+   `TestWriteHotPath_DuplicateRequestIDWithoutRetryQuarantinesAttempt`
+   passing is one signal — but does the NEW recovery
+   test ALSO need a parallel legacy-NULL-account_id case
+   confirming legacy quarantine still fires? (i.e., is the test
+   matrix complete?)
+3. SQL injection / string interpolation: the recovery.go change
+   adds `prior.account_id IS rl.account_id` — is this hard-coded
+   SQL (yes), and are all user-controlled values still bound
+   via `?`? Verify no `fmt.Sprintf` slipped in.
+4. Does the SPEC-002 v1.5.0 "money-path scope" bullet still
+   accurately describe what hotpath.go does after R2? (The R2
+   change was to recovery.go, not hotpath.go — but cross-check
+   the §11 narrative.)
+5. Cross-check the gateway test changes against the production
+   chat_proxy.go behavior: with the bearer hoisted, what does
+   `copyForwardHeaders` do with the buyer's incoming
+   `Authorization` header (e.g., a buyer-supplied
+   `Authorization: Bearer evil-key`)? Does it overwrite or
+   coexist? Is the order safe?
+6. Any other request_log SELECT or COUNT that wasn't scoped in
+   R2? (R2 covered hotpath.go and recovery.go. Are there more?)
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.
+
+## Out of scope
+
+- The R1 findings already addressed (assume R1 disposition
+  is correct unless you find something NEW the R2 fixes broke).
+- The deferred explorer surface enrichment.
+- Style nits.

--- a/specs/AUDIT_ISS_211_R2_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R2_SECURITY_PROMPT.md
@@ -1,0 +1,102 @@
+# AUDIT — ISS-211 R2 — SECURITY lens
+
+## Task
+
+R2 security re-audit. R1 found 1 HIGH (unconditional account
+header would be rejected by coordinator without paired bearer)
+and R2 fixed it by hoisting the upstream `Authorization` bearer
+out of the sticky conditional. Re-check the security implications
+of that R2 change — there is meaningful blast radius from sending
+the gateway-service-token bearer on every chat forward.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R2 security deltas
+
+- Every chat forward from the gateway to the coordinator now
+  carries `Authorization: Bearer <UpstreamCoordinatorBearer>`
+  AND `X-MacProvider-Account`. Previously the bearer was only
+  set on the sticky path.
+- The coordinator's `internalBearerAuthorized` audit log line
+  now fires on every chat forward, including demo traffic.
+- Demo subjects forward `demo:<X-Real-IP>` to coordinator via
+  the new header path.
+
+## Focus areas
+
+1. **Buyer-supplied Authorization passthrough.** The gateway
+   handler reads buyer's `Authorization: Bearer <mp_...>` to
+   authenticate, then sets its own `Authorization: Bearer
+   <UpstreamCoordinatorBearer>` for the upstream call. Verify:
+   - The upstream `Set` overwrites any value `copyForwardHeaders`
+     may have propagated from the buyer (would be a
+     credential leak otherwise).
+   - The integration test
+     `TestStrangerKeyOpenAIChatUsageFlow` actually exercises a
+     buyer with a real `mp_` key and asserts the buyer's key
+     does NOT reach the coordinator (it now asserts on
+     `Bearer operator-key`).
+   - What if `copyForwardHeaders` happens to be allowlist-based
+     and explicitly DOES copy `Authorization`? Is the
+     subsequent `Set` order-correct?
+
+2. **Increased blast radius of compromised UpstreamCoordinatorBearer.**
+   Pre-v0.9.1 the bearer was only sent on sticky forwards.
+   Post-v0.9.1 it's sent on every chat forward. Does this
+   meaningfully change the attacker model:
+   - An attacker who sniffs gateway → coordinator traffic
+     pre-v0.9.1 could only steal the bearer on sticky requests.
+     Post-v0.9.1 the bearer is on every TLS frame to the
+     coordinator. (Both should be over TLS; net new exposure
+     should be near-zero — verify.)
+   - The bearer audit-log line in the coordinator now fires
+     orders-of-magnitude more often. Is there a per-line cost
+     (disk, alerting, downstream pipeline) the SPEC should
+     warn operators about?
+
+3. **Demo IP exposure (sustained).** R1 considered net new
+   exposure low because the IP is already visible via
+   X-Forwarded-For. R2 didn't change this but expanded the
+   scope of where `demo:<ip>` lands (now also `request_log.account_id`,
+   audited via the new internal-bearer log line, etc.). Re-verify
+   the conclusion: is there a downstream consumer (admin
+   dashboard, payout pipeline, public surface) that now sees the
+   demo IP where it previously didn't?
+
+4. **Header trust boundary persists.** With the bearer paired,
+   the coordinator's `selectProviderExcluding` accepts the
+   account header. But the value of `X-MacProvider-Account` is
+   gateway-claimed: a compromised gateway can claim any
+   `account_id` it wants. Confirm this is acknowledged in the
+   threat model and is intentional (i.e., the coordinator
+   trusts the gateway as an authority for account_id, as it
+   already did on the sticky path).
+
+5. **Downgrade attack via header suppression.** If an attacker
+   can persuade the gateway to send empty `X-MacProvider-Account`
+   (e.g., subverting `subject.AccountID = ""` somehow), the
+   coordinator falls back to the unscoped COUNT query in
+   hotpath.go. Is the failure mode safe — would the unscoped
+   query expose data the scoped one wouldn't, or just count
+   cross-account rows? The result is `ambiguous_attempt_n`
+   zero-credit (audit-only, money-safe) — confirm.
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal SPEC or code edit>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.
+
+## Out of scope
+
+- The R1 findings already addressed.
+- Coordinator-vs-buyer network segmentation (assumed
+  TLS-mutual or VPC-internal per existing threat model).
+- Demo abuse rate-limiting (separate work).

--- a/specs/AUDIT_ISS_211_R3_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R3_ARCHITECT_PROMPT.md
@@ -1,0 +1,60 @@
+# AUDIT — ISS-211 R3 — ARCHITECT lens
+
+## Task
+
+R3 architect re-audit. R2 surfaced 3 MEDIUMs (one duplicate of code-
+lens R2 finding, plus SPEC-005 dep + SPEC-006 merge-order pointer).
+All three are now addressed.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R3 deltas (relative to R2)
+
+- `endpoints.go:302-318` account-scoped attempt_n derivation in
+  `buyerEquivalentCredits` (admin reconcile).
+- `specs/SPEC-005-billing.md` v0.3.1: dep bump to SPEC-002 v1.5.0
+  + SPEC-006 v0.9.1; §4.2 / §8.2 fallback-attempt-ordinal text
+  scoped by `(account_id, request_id)` with legacy NULL fallback.
+- `specs/SPEC-006-buyer-api.md` SPEC-007 §6.4 pointer softened to
+  merge-order-safe wording.
+
+## What to audit
+
+1. Is the SPEC corpus now coherent end-to-end on the v1.5.0 model?
+   - SPEC-002 v1.5.0 (request_log composite key)
+   - SPEC-005 v0.3.1 (attempt-ordinal grouping scoped)
+   - SPEC-006 v0.9.1 (gateway forward + bearer-pairing)
+   - SPEC-007 v0.2.1 (gateway composite-PK addendum — pending PR #221)
+   Do they tell one consistent story? Any text that still claims
+   the pre-v1.5.0 reconciliation key?
+2. SPEC-005 v0.3.1 references that "IMPL parallel — hotpath.go,
+   recovery.go, and endpoints.go admin reconcile — already carries
+   this scoping". Is that claim still true after R3? Are there
+   other IMPL sites SPEC-005 v0.3.1 should call out as honoring
+   the new contract?
+3. The explorer deferral remains in place. The SPEC-002 v1.5.0
+   explorer-deferral text now interacts with SPEC-005 v0.3.1's
+   normative grouping rule. Does an explorer query that reads
+   `request_log` and surfaces `account_id` need to be in scope
+   for #211 to fully close, or is the current "audit reads via
+   direct SQL" guidance sufficient?
+4. SPEC-005 v0.3.1's depends-on bump to SPEC-006 v0.9.1 — is
+   that bump independently meaningful, or did it just chain
+   because of SPEC-002? Look for SPEC-005 text that depends on
+   SPEC-006 v0.9.1 normative content specifically.
+5. Any architectural smell that R3 introduces (e.g., the
+   bearer-pairing being a transitional shim vs the long-term
+   shape from R2 architect concern #2)?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R3_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R3_CODE_PROMPT.md
@@ -1,0 +1,57 @@
+# AUDIT — ISS-211 R3 — CODE lens
+
+## Task
+
+R3 re-audit of issue #211 SPEC + IMPL bundle. R2 surfaced 1 MEDIUM
+on the code lens that has now been addressed.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R3 deltas (relative to R2)
+
+- `phase4-coordinator/internal/billing/endpoints.go:302-318`:
+  `buyerEquivalentCredits` `prior`-attempt subquery now scopes by
+  `prior.account_id IS rl.account_id AND prior.request_id = rl.request_id`
+  using SQLite `IS` (preserves legacy NULL-cluster behavior).
+- `specs/SPEC-005-billing.md`: version bump v0.3 → v0.3.1, SPEC-002
+  dependency bumped to v1.5.0, SPEC-006 to v0.9.1; §4.2 and §8.2
+  fallback attempt-ordinal grouping text scoped by
+  `(account_id, request_id)` with legacy NULL-account_id fallback.
+- `specs/SPEC-006-buyer-api.md`: cross-PR pointer to SPEC-007 §6.4
+  softened to merge-order-safe wording mirroring SPEC-002.
+
+## What to audit
+
+1. Does the endpoints.go R3 fix produce the same legacy-NULL
+   semantics as hotpath.go and recovery.go did? (Sanity-check the
+   SQLite `IS` invariant.)
+2. Are there any remaining `request_log` scans in
+   `phase4-coordinator/internal/` (excluding the documented
+   explorer deferral) that still use unscoped `request_id`?
+3. Does SPEC-005 v0.3.1's "Until then, derive the fallback ordinal
+   by sorting rows with the same `(account_id, request_id)`" text
+   accurately reflect what hotpath.go / recovery.go / endpoints.go
+   actually do? Watch for SPEC mandates that IMPL doesn't actually
+   honor.
+4. The endpoints.go fix adds inline scoping but does NOT add a
+   regression test. Is that defensible? (Hot-path and recovery both
+   have parallel regressions in `store_test.go`.)
+5. Any other code drift introduced by R3?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.
+
+## Out of scope
+
+- Explorer surface (deferred).
+- Pre-R3 findings (assume R2 disposition is correct).

--- a/specs/AUDIT_ISS_211_R3_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R3_SECURITY_PROMPT.md
@@ -1,0 +1,42 @@
+# AUDIT — ISS-211 R3 — SECURITY lens
+
+## Task
+
+R3 security re-audit. R2 returned ZERO FINDINGS. R3 changes are
+SPEC-only (SPEC-005 v0.3.1 dep bump, SPEC-006 merge-order pointer
+softening) plus one SQL scoping fix in `endpoints.go:302-318`.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R3 deltas (relative to R2)
+
+- `phase4-coordinator/internal/billing/endpoints.go`:
+  admin reconcile `buyerEquivalentCredits` `prior`-attempt subquery
+  scoped by `(account_id, request_id)`.
+- `specs/SPEC-005-billing.md`: v0.3.1 bump.
+- `specs/SPEC-006-buyer-api.md`: merge-order-safe pointer wording.
+
+## What to audit
+
+1. Does the endpoints.go scoping change open any new attack
+   surface? (The query is admin-only, behind operator bearer; the
+   change is a stricter scope, not a looser one.)
+2. SPEC-005 v0.3.1 says "ambiguous rows in that group MUST be
+   quarantined". Does this change the quarantine semantics for
+   the all-NULL-account_id legacy case in a way that could
+   silently quarantine money? (My read: NO — the group
+   degrades to same-request_id grouping, identical to pre-v0.3.1.)
+3. Any new defense-in-depth gap introduced by the R3 SPEC text?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R4_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R4_ARCHITECT_PROMPT.md
@@ -1,0 +1,64 @@
+# AUDIT — ISS-211 R4 — ARCHITECT lens
+
+## Task
+
+R4 architect re-audit. R3 surfaced 1 MEDIUM (SPEC-005 stale
+references); R4 swept §1.4 cross-spec boundaries to v1.5.0/v0.9.1
+and aligned the live SPEC-005 §4.2/§8.2/§15.2/AC-D10/OQ-1 to
+NULL-with-NULL clustering language.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R4 deltas (relative to R3)
+
+- SPEC-002 v1.5.0 change-log bullet "Money-path scope" expanded
+  to name all three IMPL sites (hotpath, recovery, endpoints
+  admin reconcile) and IS-NULL clustering semantics.
+- SPEC-002 v1.5.0 §11 "Money-path: AttemptN derivation"
+  rewritten to call out all three sites and IS-NULL clustering.
+- SPEC-005 v0.3.1 §1.4 "Cross-spec boundaries" SPEC-002 and
+  SPEC-006 sub-blocks updated to current versions + IS-NULL
+  clustering note.
+- SPEC-005 v0.3.1 lines 520, 593, 956, 1032, 1213, 1270, 2323,
+  2388 updated to SPEC-002 v1.5.0 / SPEC-006 v0.9.1 (live body
+  references; changelog references intentionally left at
+  v1.3.4/v0.8.2).
+- SPEC-005 v0.3.1 §4.2, §8.2, §15.2, AC-D10, OQ-1 all reworded
+  to NULL-with-NULL clustering language.
+- `hotpath.go` aligned with recovery.go / endpoints.go.
+
+## What to audit
+
+1. Is the SPEC-002 + SPEC-005 + SPEC-006 corpus now telling a
+   single coherent story about the v1.5.0 grouping rule and
+   NULL-with-NULL semantics? Cross-check every live body claim
+   about attempt-ordinal grouping, request_log scanning, or
+   reconciliation.
+2. Does the SPEC-002 v1.5.0 "Deploy ordering" / "rollback row-
+   level gate" guidance still hold after the R4 NULL-with-NULL
+   change? Specifically: pre-v1.5.0 rows have NULL account_id;
+   under IS-NULL clustering they cluster together. Post-v1.5.0
+   gateway rows have non-NULL account_id; they cluster within
+   their account. The boundary between these populations is
+   the gateway upgrade event. Is the deploy ordering text
+   still safe for a coordinator that has the column but no
+   live gateway sending the header yet?
+3. Are there remaining SPEC-005 stale references the architect
+   should still flag (e.g., changelog entries vs live body)?
+4. The R4 wording "all three sites MUST use identical NULL
+   semantics" is a normative MUST. Is this enforceable via
+   tests, or does the SPEC need to enumerate the three sites
+   by name so future maintainers can verify?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R4_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R4_CODE_PROMPT.md
@@ -1,0 +1,59 @@
+# AUDIT — ISS-211 R4 — CODE lens
+
+## Task
+
+R4 re-audit. R3 surfaced 1 MEDIUM on the code lens (hotpath.go
+NULL-account fallback diverged from recovery/endpoints IS-clustering).
+R4 aligned hotpath.go to use `account_id IS ?` matching the other
+two sites.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R4 deltas (relative to R3)
+
+- `phase4-coordinator/internal/billing/hotpath.go`: single
+  branchless query using `account_id IS ?` with a nil binding
+  for empty AccountID — matches recovery.go and endpoints.go.
+- `specs/SPEC-002-coordinator.md` v1.5.0 money-path-scope
+  change-log bullet + §11 Money-path narrative both updated to
+  describe IS-clustering across all three sites (no longer
+  saying "legacy rows continue to use the prior unscoped count").
+- `specs/SPEC-005-billing.md` §4.2, §8.2, §15.2, §AC-D10, OQ-1
+  all reworded to NULL-with-NULL clustering language.
+
+## What to audit
+
+1. Does the new hotpath.go query (`account_id IS ?` with nil bind
+   for empty AccountID) produce identical results to recovery.go
+   and endpoints.go in three scenarios:
+   - All rows non-NULL same account_id: scoped count = number of
+     siblings.
+   - All rows NULL account_id (legacy): scoped count = number
+     of NULL-account siblings (intra-NULL cluster).
+   - Mixed rows (some NULL, some non-NULL): each subgroup is
+     isolated; NULL rows do not count non-NULL siblings.
+2. Does the existing legacy regression test
+   `TestWriteHotPath_DuplicateRequestIDWithoutRetryQuarantinesAttempt`
+   still cover the intra-NULL case after the R4 query rewrite?
+   (If both inserted rows have empty AccountID, they should still
+   cluster and quarantine — the test passing confirms this, but
+   verify the contract.)
+3. Is there a parameter-binding issue with passing `nil` (`any`)
+   to a `database/sql` driver via QueryRowContext for the
+   `account_id IS ?` predicate? The modernc.org/sqlite driver
+   should handle this correctly, but verify.
+4. SPEC drift: does any SPEC-002 or SPEC-005 line still mention
+   "unscoped count for NULL account_id" (the pre-R4 wording)?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R4_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R4_SECURITY_PROMPT.md
@@ -1,0 +1,38 @@
+# AUDIT — ISS-211 R4 — SECURITY lens
+
+## Task
+
+R4 security re-audit. R3 returned ZERO FINDINGS. R4 deltas are
+limited to:
+- hotpath.go branchless `IS ?` rewrite (alignment, not new logic).
+- SPEC-002 / SPEC-005 wording updates to NULL-with-NULL clustering.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## What to audit
+
+1. Does the hotpath.go change open any new attack surface? The
+   query is parameterized; the `nil` binding goes to a bound
+   parameter, not an SQL string. Verify no string interpolation.
+2. Does the IS-clustering for NULL rows enable a downgrade attack
+   where an attacker who can suppress `X-MacProvider-Account` on
+   the gateway hot path turns the unscoped-fallback into a
+   NULL-with-NULL bucket — does that change the money-safety
+   guarantee? (Pre-R4: NULL fell into "all rows with this
+   request_id" bucket → over-count → ambiguous_attempt_n
+   zero-credit. Post-R4: NULL falls into "all NULL-account rows
+   with this request_id" bucket → smaller count → less likely to
+   over-count, but still safe.)
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R5_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R5_ARCHITECT_PROMPT.md
@@ -1,0 +1,56 @@
+# AUDIT — ISS-211 R5 — ARCHITECT lens
+
+## Task
+
+R5 architect re-audit. R4 surfaced 1 HIGH + 4 MEDIUM. All five
+addressed in R5.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R5 deltas (relative to R4)
+
+- `specs/SPEC-002-coordinator.md` §11: new "Money-path:
+  same-provider cross-account collision" subsection documents
+  the ledger-PK known limitation, explains exposure bound, and
+  points at the follow-up tracking issue.
+- `specs/SPEC-002-coordinator.md` v1.5.0 changelog "Deploy
+  ordering" bullet rewritten: PRAGMA only for the absent-column
+  case; per-row `account_id IS NOT NULL` for everything else.
+- `specs/SPEC-002-coordinator.md` §11 live request_log contract
+  paragraph: "row order within a `request_id`" →
+  "row order within an `(account_id, request_id)` group" + IS
+  clustering callout.
+- `specs/SPEC-006-buyer-api.md` §1.5: clarifies
+  "base relationship v1.1.5; current dependency v1.5.0".
+- New regression tests
+  (`TestWriteHotPath_SameProviderCrossAccountCollisionBehavior`,
+  `TestReconcileEndpoint_AccountScopedRequestIDCollisionCleanDelta`).
+
+## What to audit
+
+1. Has the corpus converged on the v1.5.0 model with no
+   contradictions between SPEC-002 / SPEC-005 / SPEC-006?
+   Sweep every live (non-changelog) reference to attempt
+   grouping, request_log identity, or reconciliation key.
+2. Are there any other places in SPEC-002 v1.5.0 (or downstream
+   specs) that imply column presence is the audit-switch?
+3. The new SPEC-002 §11 "same-provider cross-account collision"
+   subsection acknowledges a known limitation. Is the
+   tracking-issue note specific enough (file / line / migration
+   scope) that a future implementer can pick it up without
+   re-deriving the problem statement?
+4. Are there any remaining cross-spec dependency lines that
+   point at obsolete versions in live body text?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R5_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R5_CODE_PROMPT.md
@@ -1,0 +1,44 @@
+# AUDIT — ISS-211 R5 — CODE lens
+
+## Task
+
+R5 code re-audit. R4 surfaced 1 MEDIUM on the code lens (SPEC-005
+changelog still described NULL rows as "unscoped"). R5 fixed the
+wording.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R5 deltas
+
+- `specs/SPEC-005-billing.md` v0.3.1 change-log bullet rewritten:
+  no longer says legacy NULL rows preserve "unscoped grouping";
+  now says "intra-NULL grouping" with SQLite `IS` matching
+  NULL with NULL only.
+- New tests: `TestWriteHotPath_SameProviderCrossAccountCollisionBehavior`
+  and `TestReconcileEndpoint_AccountScopedRequestIDCollisionCleanDelta`.
+
+## What to audit
+
+1. Does the SPEC-005 changelog rewording match the body of §4.2 /
+   §8.2 / §15.2 / AC-D10 / OQ-1 IS-NULL clustering language?
+2. Any remaining SPEC-005 reference that says NULL rows are
+   "unscoped" or "fall back to same-request_id"?
+3. Does `TestWriteHotPath_SameProviderCrossAccount...` accurately
+   reflect the documented SPEC-002 §11 known limitation? (i.e.,
+   would future drift in hotpath.go's transactional rollback
+   semantics break this assertion?)
+4. Does `TestReconcileEndpoint_AccountScoped...` actually exercise
+   the endpoints.go scoping path (not the hotpath.go path)?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R5_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R5_SECURITY_PROMPT.md
@@ -1,0 +1,41 @@
+# AUDIT — ISS-211 R5 — SECURITY lens
+
+## Task
+
+R5 security re-audit. R4 returned ZERO FINDINGS. R5 deltas
+document a known limitation in SPEC-002 §11 (same-provider
+cross-account collision) and add a regression test pinning the
+behavior.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## What to audit
+
+1. Does the new SPEC-002 §11 "same-provider cross-account
+   collision" subsection accurately describe the attack
+   surface? Specifically:
+   - Can an attacker trigger the UNIQUE collision intentionally
+     to deny service to another account?
+   - Probability bound: requires guessing victim's X-Request-ID,
+     routing-layer picking same provider, winning the race to
+     insert first. UUID v4 entropy + utilization-favoring
+     selection make this operationally infeasible. Verify this
+     reasoning.
+2. Is the deferred ledger-PK-account-scoping clearly documented
+   as a known limitation rather than a closed concern, so
+   operators reading v1.5.0 can decide whether to gate
+   deployment on the follow-up?
+3. Any new attack surface from the R5 SPEC text additions?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R6_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R6_ARCHITECT_PROMPT.md
@@ -1,0 +1,62 @@
+# AUDIT — ISS-211 R6 — ARCHITECT lens
+
+## Task
+
+R6 architect re-audit. R5 surfaced 1 HIGH + 5 MEDIUM. All six
+addressed in R6.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R6 deltas (relative to R5)
+
+- SPEC-006 §906 + §2323 (A13 HIGH): `X-Request-ID` is now a
+  correlation value, not a unique row identity. Composite PK
+  `(account_id, request_id)` is the physical identity.
+- SPEC-006 §305 (A16): "SPEC-006 layers on SPEC-002 v1.1.5" →
+  "Current dependency: SPEC-002 v1.5.0; base relationship
+  established in v1.1.5".
+- SPEC-002 AC-FR-B9-MULTI (A14): updated to `(account_id,
+  request_id)` grouping under SQLite IS clustering.
+- SPEC-005 AC-MULTIHOP + AC-ATTEMPT-FALLBACK (A15): updated to
+  `(account_id, request_id)` grouping language.
+- SPEC-002 §11 conceptual rewrite (driven by R5 security MEDIUM):
+  internal request_id vs external_request_id distinction made
+  explicit; ledger-PK known-limitation subsection deleted
+  (it was based on a misread of the attack class); A17
+  ("follow-up pointer not actionable") becomes moot.
+- Regression test deleted (A18 root cause): it pinned an
+  artificial same-internal-request_id scenario.
+
+## What to audit
+
+1. Has the corpus FULLY converged on the v1.5.0 model with the
+   correct internal-vs-external `request_id` distinction?
+   - SPEC-002 v1.5.0
+   - SPEC-005 v0.3.1
+   - SPEC-006 v0.9.1
+   - SPEC-007 v0.2.1 (PR #221, gateway-side)
+   Sweep every live (non-changelog) reference for stale
+   "request_id is the row key" / "request_id alone is the
+   reconciliation key" claims.
+2. Does any remaining acceptance criterion or fixture instruction
+   tell a future test author to use `request_id`-only grouping?
+3. Are there cross-spec dependency-pin contradictions? (e.g.,
+   SPEC-005 v0.3.1 dep line says SPEC-002 v1.5.0 but body claims
+   v1.1.5 somewhere.)
+4. The R5 architect MEDIUMs about ledger PK and tracking-issue
+   follow-up are no longer relevant after the §11 conceptual
+   rewrite. Confirm those concerns are genuinely moot, not
+   silently elided.
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R6_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R6_CODE_PROMPT.md
@@ -1,0 +1,70 @@
+# AUDIT — ISS-211 R6 — CODE lens
+
+## Task
+
+R6 code re-audit. R5 surfaced 1 MEDIUM that triggered a conceptual
+rewrite: I had been conflating `external_request_id` (buyer-supplied
+X-Request-ID, the real #211 attack surface) with internal `request_id`
+(server-minted UUID, doesn't naturally collide). R6 reframes the
+SPEC narrative around defense-in-depth instead of a load-bearing
+ledger-PK collision concern.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R6 deltas (relative to R5)
+
+- **DELETED** `TestWriteHotPath_SameProviderCrossAccountCollisionBehavior`.
+  The scenario it pinned (two accounts sharing the same internal
+  `request_id`) is artificial — internal `request_id` is minted via
+  `requestIDForBuyerRequest() = uuid.NewString()` per buyer call,
+  so two accounts cannot naturally collide there. (`strings` import
+  removed from `store_test.go` since this was its only use.)
+- `specs/SPEC-002-coordinator.md` §11 "Money-path: AttemptN
+  derivation" rewritten as defense-in-depth narrative; it clarifies
+  internal `request_id` (server-minted) vs `external_request_id`
+  (buyer-supplied) and points out the real #211 collision class is
+  on `external_request_id`.
+- `specs/SPEC-002-coordinator.md` §11 "same-provider cross-account
+  collision" subsection **deleted** (described a non-existent attack
+  class).
+- `specs/SPEC-006-buyer-api.md` §906 + §2323 reworded: `X-Request-ID`
+  is a correlation value, not a unique row identity; the composite
+  `(account_id, request_id)` is the physical PK on the gateway side
+  and `(account_id, external_request_id)` is the reconciliation key.
+- `specs/SPEC-006-buyer-api.md` §305 v1.1.5 stale dep updated to
+  v1.5.0 with §1.5 wording.
+- `specs/SPEC-002-coordinator.md` AC-FR-B9-MULTI updated to
+  `(account_id, request_id)` grouping.
+- `specs/SPEC-005-billing.md` AC-MULTIHOP and AC-ATTEMPT-FALLBACK
+  updated to `(account_id, request_id)` grouping with IS-clustering
+  caveat for legacy NULL fixtures.
+
+## What to audit
+
+1. Does the deleted test leave any orphaned references in
+   SPEC-002 §11, audit-findings file, or commit message context?
+2. Does the rewritten SPEC-002 §11 "Money-path: AttemptN derivation"
+   subsection accurately describe what hotpath.go / recovery.go /
+   endpoints.go actually do? Specifically: the queries scope by
+   `(account_id, request_id)` regardless of whether collisions
+   are realistic.
+3. Do any remaining SPEC text claims describe a same-internal-
+   request_id cross-account scenario as a real attack class?
+   (Sweep for "cross-account collision" + "request_id" — the
+   acceptable phrasing is "defense-in-depth" / "should the same
+   internal request_id ever recur".)
+4. The strengthened existing tests still pass after R6's deletion
+   of the artificial test?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R6_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R6_SECURITY_PROMPT.md
@@ -1,0 +1,52 @@
+# AUDIT — ISS-211 R6 — SECURITY lens
+
+## Task
+
+R6 security re-audit. R5 surfaced 1 MEDIUM exposing a fundamental
+internal-vs-external `request_id` confusion in my SPEC-002 §11
+narrative. R6 reframes the entire §11 section.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R6 deltas
+
+- SPEC-002 §11 "Money-path: same-provider cross-account collision"
+  subsection deleted — described a non-existent attack class
+  (assumed internal request_id collisions are real, which they
+  aren't given UUID v4 server-side minting).
+- SPEC-002 §11 "Money-path: AttemptN derivation" reframed as
+  defense-in-depth with explicit internal-vs-external identity
+  distinction.
+- SPEC-006 §906 + §2323 reworded so `X-Request-ID` is a
+  correlation value, not a unique row identity.
+
+## What to audit
+
+1. Does the rewritten SPEC-002 §11 accurately bound the attack
+   surface for #211? Specifically: the actual collision class
+   is `external_request_id` (buyer-supplied), which the
+   composite `(account_id, external_request_id)` reconciliation
+   key fully addresses. There is no money-path or audit-trail
+   gap I've missed by deleting the same-provider subsection.
+2. Does the SPEC-006 §906 rewording correctly differentiate
+   `request_id` (correlation) from the composite PK identity
+   (uniqueness)? Specifically: does it still tell implementers
+   to enforce uniqueness on the composite key, not on
+   `request_id` alone?
+3. Is there any residual claim in any spec that suggests an
+   attacker can engineer a coordinator-internal `request_id`
+   collision? (There shouldn't be — UUID v4 entropy makes
+   this infeasible.)
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R7_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R7_ARCHITECT_PROMPT.md
@@ -1,0 +1,54 @@
+# AUDIT — ISS-211 R7 — ARCHITECT lens
+
+## Task
+
+R7 architect re-audit. R6 surfaced 1 HIGH + 3 MEDIUM. The HIGH
+and 2 of the 3 MEDIUMs are in SPEC-007 which is owned by PR #221
+and intentionally deferred from #224. The third MEDIUM (SPEC-005
+fixture appendix at line 2423) is addressed.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R7 deltas
+
+- `specs/SPEC-005-billing.md` AC-MULTIHOP fixture-detail
+  appendix and AC-ATTEMPT-FALLBACK fixture-detail appendix
+  updated to `(account_id, request_id)` grouping language
+  matching the main AC body at lines 1299-1311.
+
+## Explicit deferrals to PR #221
+
+- SPEC-007 §1241 / §1591 (gateway session-detail account-blind
+  text) — addressed by PR #221's §6.4 v0.2.1 addendum.
+- SPEC-007 AC-7 — to be picked up by PR #221 audit loop.
+
+## What to audit
+
+1. Is the SPEC-002 + SPEC-005 + SPEC-006 corpus fully internally
+   consistent on the v1.5.0 model, with no remaining stale
+   text claiming `request_id` alone is the row key, reconciliation
+   key, or grouping key for cross-account queries?
+2. Do the deferrals to PR #221 leave any #224-internal gap?
+   (i.e., does ANYTHING in SPEC-002 / SPEC-005 / SPEC-006 depend
+   on SPEC-007 v0.2.1 text that won't exist until #221 merges?)
+3. After the R6 conceptual reframe, is the SPEC narrative
+   actually a tighter and more accurate description of what
+   the IMPL does, or did the reframe expose anywhere the IMPL
+   should be reconsidered?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.
+
+## Out of scope
+
+- SPEC-007 (owned by PR #221).

--- a/specs/AUDIT_ISS_211_R7_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R7_CODE_PROMPT.md
@@ -1,0 +1,69 @@
+# AUDIT — ISS-211 R7 — CODE lens
+
+## Task
+
+R7 code re-audit. R6 surfaced 4 MEDIUMs all stemming from a
+conceptual cleanup: I had been treating internal `request_log.request_id`
+collisions as the post-#196 attack class, but server-minted UUIDs
+don't naturally collide. The real #211 surface is `external_request_id`.
+
+R7 finishes the cleanup.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R7 deltas (relative to R6)
+
+- `phase4-coordinator/internal/billing/hotpath.go`, `recovery.go`,
+  `endpoints.go`: scope-rationale comments reworded as defense-
+  in-depth, explicitly noting internal vs external request_id.
+- `phase4-coordinator/internal/billing/store_test.go`: two tests
+  renamed
+  (`TestRecoverLedger_AccountScopedInternalRequestIDDefenseInDepth`,
+  `TestWriteHotPath_AccountScopedInternalRequestIDDefenseInDepth`)
+  with reframed comments.
+- `phase4-coordinator/internal/billing/endpoints_test.go`: test
+  renamed
+  (`TestReconcileEndpoint_AccountScopedInternalRequestIDDefenseInDepth`),
+  comment reworded, fixture id renamed
+  (`buyer-controlled-duplicate-reconcile` →
+  `synthetic-internal-uuid-collision`).
+- `specs/SPEC-002-coordinator.md` §11 FR-B9 paragraph + v1.5.0
+  changelog bullet 1 reworded to defense-in-depth language with
+  internal/external request_id distinction.
+- `specs/SPEC-002-v1-5-0-audit.md` gets an R6-conceptual-reframe
+  preamble.
+- `specs/SPEC-005-billing.md` AC-MULTIHOP and AC-ATTEMPT-FALLBACK
+  fixture-detail appendices (~line 2420) updated to
+  `(account_id, request_id)` grouping language matching the main
+  AC body.
+
+## What to audit
+
+1. Does any remaining SPEC text or code comment still claim that
+   internal `request_id` collisions across accounts are the #196
+   attack class?
+2. Are the test names + IDs internally consistent with the
+   defense-in-depth framing?
+3. The audit-findings file `specs/SPEC-002-v1-5-0-audit.md`
+   preamble documents the R6 reframe. Is the preamble's
+   "authoritative for current behavior" framing clear enough
+   that a future reader doesn't get misled by the R1-era body
+   text that follows?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.
+
+## Out of scope
+
+- SPEC-007 stale text (e.g. §1241, §1591, AC-7) — owned by
+  PR #221 / issue #212; that PR's audit loop will pick it up.

--- a/specs/AUDIT_ISS_211_R7_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R7_SECURITY_PROMPT.md
@@ -1,0 +1,45 @@
+# AUDIT — ISS-211 R7 — SECURITY lens
+
+## Task
+
+R7 security re-audit. R6 surfaced 2 MEDIUMs that have now been
+addressed (SPEC-002 §1403 + changelog line 42).
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R7 deltas
+
+- `specs/SPEC-002-coordinator.md` §11 FR-B9 paragraph + v1.5.0
+  changelog bullet 1 both clarified that internal `request_id`
+  is server-minted and doesn't naturally collide across
+  accounts; account scoping is defense-in-depth.
+- Code comments in hotpath.go / recovery.go / endpoints.go
+  reworded to the same framing.
+
+## What to audit
+
+1. Any residual SPEC or code claim that an attacker can engineer
+   coordinator-internal `request_id` collisions as a real
+   attack surface?
+2. Is the defense-in-depth framing strong enough that a future
+   reader would not accidentally remove the scoping under the
+   reasoning "we don't need this because internal request_ids
+   don't collide"?
+3. Any new attack surface from the R7 wording changes?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.
+
+## Out of scope
+
+- SPEC-007 §1591 (deferred to PR #221).

--- a/specs/AUDIT_ISS_211_R8_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R8_ARCHITECT_PROMPT.md
@@ -1,0 +1,21 @@
+# AUDIT — ISS-211 R8 — ARCHITECT lens
+
+## Task
+
+R8 architect re-audit. R7 returned ZERO FINDINGS. R8 deltas are
+test-fixture renames + assertion message rewording.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## What to audit
+
+1. Do the renamed fixtures still match the corresponding SPEC text
+   (the "synthetic-internal-uuid-collision" defense-in-depth
+   framing in SPEC-002 §11 and SPEC-005 §4.2)?
+2. Any new architectural drift introduced by the renames?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM.
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R8_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R8_CODE_PROMPT.md
@@ -1,0 +1,54 @@
+# AUDIT — ISS-211 R8 — CODE lens
+
+## Task
+
+R8 code re-audit. R7 surfaced 1 MEDIUM (stale buyer-controlled
+fixture IDs + assertion messages in store_test.go defense-in-depth
+tests). R8 renamed.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R8 deltas
+
+- `phase4-coordinator/internal/billing/store_test.go`:
+  - `buyer-controlled-duplicate-recovery` →
+    `synthetic-internal-uuid-collision-recovery` (in
+    `TestRecoverLedger_AccountScopedInternalRequestIDDefenseInDepth`).
+  - `buyer-controlled-duplicate` →
+    `synthetic-internal-uuid-collision-hotpath` (in
+    `TestWriteHotPath_AccountScopedInternalRequestIDDefenseInDepth`).
+  - Failure messages reworded from "cross-account request_id
+    collision quarantined rows ... issue #211 regression" to
+    "synthetic internal request_id recurrence quarantined rows ...
+    issue #211 defense-in-depth regression".
+
+Note: the LEGACY test
+`TestWriteHotPath_DuplicateRequestIDWithoutRetryQuarantinesAttempt`
+intentionally keeps the `buyer-controlled-duplicate` fixture ID,
+because that test pins the pre-#211 (NULL-`account_id`) quarantine
+behavior under the original buyer-controlled framing — it predates
+#211 and is the legacy baseline. R7 audit explicitly distinguished
+this case.
+
+## What to audit
+
+1. Are the renamed fixture IDs and assertion messages internally
+   consistent with the renamed function names?
+2. Is the legacy test's retained fixture ID (`buyer-controlled-duplicate`)
+   still appropriate, given it documents the pre-#211 NULL-account
+   behavior?
+3. Any other stale "buyer-controlled" or "cross-account request_id
+   collision" string in code or comments?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM. Each finding:
+```
+SEVERITY: ...
+TITLE: ...
+FILE: <path:line>
+DETAIL: ...
+SUGGESTED FIX: <minimal>
+```
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R8_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R8_SECURITY_PROMPT.md
@@ -1,0 +1,22 @@
+# AUDIT — ISS-211 R8 — SECURITY lens
+
+## Task
+
+R8 security re-audit. R7 returned ZERO FINDINGS. R8 deltas are
+limited to test-fixture renames (`buyer-controlled-duplicate-*` →
+`synthetic-internal-uuid-collision-*`) and assertion message
+rewording.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## What to audit
+
+The R8 delta is in test code only; no production code or SPEC text
+changed. Confirm there's no security surface introduced by the
+renamed fixtures.
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM.
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/AUDIT_ISS_211_R9_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_211_R9_CODE_PROMPT.md
@@ -1,0 +1,35 @@
+# AUDIT — ISS-211 R9 — CODE lens
+
+## Task
+
+R9 code re-audit. R8 surfaced 1 trailing MEDIUM (one stale
+"cross-account collision" string in a renamed
+defense-in-depth test assertion). R9 reworded it.
+
+R8 security + architect already returned ZERO FINDINGS on this
+branch state; this is the final code-lane convergence pass.
+
+Branch: `spec/iss-211-coordinator-account-scope`.
+
+## R9 delta
+
+- `phase4-coordinator/internal/billing/store_test.go:267`:
+  "non-quarantined ledger rows for cross-account collision" →
+  "non-quarantined ledger rows for synthetic internal request_id
+  recurrence".
+
+## What to audit
+
+1. Any remaining stale "cross-account collision" / "buyer-controlled
+   collision" framing in `phase4-coordinator/internal/billing/`
+   tests or production code?
+2. The legacy test `TestWriteHotPath_DuplicateRequestIDWithoutRetryQuarantinesAttempt`
+   intentionally keeps the original "buyer-controlled-duplicate"
+   fixture id (it predates #211 and pins the NULL-account
+   quarantine baseline). Is that distinction now clear?
+
+## Severity bar
+
+Report ONLY CRITICAL / HIGH / MEDIUM.
+
+If zero findings, respond exactly: `ZERO FINDINGS`.

--- a/specs/SPEC-002-coordinator.md
+++ b/specs/SPEC-002-coordinator.md
@@ -31,15 +31,32 @@
   bearer was only set on the sticky path. The coordinator's
   acceptance logic is unchanged — only the gateway's emission
   envelope. See SPEC-006 v0.9.1 for the gateway-side rule.
-- **Money-path scope (hot path).** Coordinator queries that
-  attribute multiple `request_log` rows to a single logical request
-  (notably `internal/billing/hotpath.go` AttemptN derivation) MUST
-  scope by `(account_id, request_id)` when `account_id` is non-empty
-  on the incoming row, to prevent a cross-account collision from
-  inflating AttemptN and triggering the `ambiguous_attempt_n`
-  zero-credit path under the SPEC-005 v0.3 multi-attempt
-  attribution contract. Legacy rows with NULL `account_id` continue
-  to use the prior unscoped count.
+- **Money-path scope (hot path + recovery + admin reconcile).**
+  Coordinator queries that attribute multiple `request_log` rows
+  to a single logical request — `internal/billing/hotpath.go`
+  AttemptN derivation, `internal/billing/recovery.go` startup /
+  nightly reconciliation, and `internal/billing/endpoints.go`
+  `/admin/ledger/reconcile` `buyerEquivalentCredits` — MUST scope
+  by `(account_id, request_id)` using SQLite `IS` semantics
+  (`account_id IS ?` / `prior.account_id IS rl.account_id`).
+  Note: `request_log.request_id` is coordinator-internal
+  (server-minted UUID v4 per buyer call), so two accounts do not
+  naturally collide on it; the buyer-supplied collision class
+  motivating #211 lives on `external_request_id` and is fully
+  addressed by the composite `(account_id, external_request_id)`
+  reconciliation key. The internal-`request_id` account scoping
+  here is therefore defense-in-depth so that any UUID v4
+  collision, retry-loop bug, or future schema change that ever
+  causes the same internal `request_id` to appear in rows from
+  different accounts cannot inflate the count and silently
+  trigger the `ambiguous_attempt_n` zero-credit path under the
+  SPEC-005 v0.3.1 multi-attempt attribution contract. Legacy
+  NULL-`account_id` rows cluster with NULL-`account_id` rows
+  only (NULL = NULL true under `IS`), preserving the pre-v1.5.0
+  intra-NULL grouping without bleeding non-NULL rows into the
+  legacy bucket. All three sites MUST use identical NULL
+  semantics so the same row gets the same `attempt_n`
+  derivation regardless of which path scans it.
 - **Index.** A new partial-NULL composite index
   `idx_request_log_account_external_request_id ON request_log(account_id, external_request_id) WHERE account_id IS NOT NULL AND external_request_id IS NOT NULL`
   supports reconciliation scans. Built by the operator-runbook
@@ -50,9 +67,16 @@
   begins sending the unconditional header so that even pre-gateway
   rollout coordinator writes accept and persist the new column.
   Coordinator without the column behaves as if `account_id` were
-  always NULL; downstream auditors detect this via column presence
-  in `PRAGMA table_info(request_log)`. See SPEC-002-coordinator §11
-  "Deploy ordering" subsection for the canonical sequence.
+  always NULL. Downstream auditors MAY use
+  `PRAGMA table_info(request_log)` only to detect "column absent —
+  pre-v1.5.0 schema; fall back wholesale to the v1.4.2 R-2
+  reconciliation key". Once the column exists, all audit /
+  reconciliation gating MUST be per-row `account_id IS NOT NULL`
+  (see §11 "Deploy ordering" canonical sequence). Column presence
+  alone is NOT sufficient because a v1.5.0 coordinator can be
+  serving pre-v0.9.1 gateway traffic OR rolled back to a v1.4.x
+  binary that doesn't populate the column — both cases produce
+  rows with NULL `account_id` despite the column being present.
 - **Cross-spec.** SPEC-006 §6 gains a forward-header requirement
   for `X-MacProvider-Account`. SPEC-007 §6.4 records the
   gateway-side composite-PK addendum once issue #212 / PR #221
@@ -1384,7 +1408,7 @@ Every buyer request is logged to the `request_log` table in SQLite:
 Token counts are extracted from the provider's response `usage` field.
 For streaming responses, they come from the usage chunk (SPEC-001 FR-7).
 
-Each provider attempt for a given `request_id` MUST produce its own `request_log` row. The only uniqueness constraint is on (`id`). `request_id` MAY recur across rows when SPEC-004 retry logic produces multiple attempts. The `retried` column counts additional explicit-retry attempts beyond the first per SPEC-004 v0.3.1; the row order within a `request_id` is determined by `id ASC`. This contract is load-bearing for SPEC-005 v0.3 multi-attempt attribution.
+Each provider attempt for a given `request_id` MUST produce its own `request_log` row. The only uniqueness constraint is on (`id`). `request_id` MAY recur across rows when SPEC-004 retry logic produces multiple attempts within a single account. Note that `request_log.request_id` is coordinator-internal (server-minted UUID v4 per buyer request — see `requestIDForBuyerRequest()`); it is NOT the inbound `X-Request-ID` (which is persisted as `external_request_id`). The cross-account collision class motivating #211 lives on `external_request_id`, not on internal `request_id`. The `retried` column counts additional explicit-retry attempts beyond the first per SPEC-004 v0.3.1; the row order within a single `(account_id, request_id)` group is determined by `id ASC` under SQLite `IS` clustering — account scoping here is defense-in-depth so that if a UUID v4 collision or future schema change ever causes the same internal `request_id` to appear in rows from different accounts, each account's attempt sequence is computed within its own scope. This contract is load-bearing for SPEC-005 v0.3.1 multi-attempt attribution.
 
 `request_id` MUST be indexed. Any service in the request path that fails to propagate `X-Request-ID` degrades cross-layer debuggability; new buyer/request log surfaces MUST include X-Request-ID propagation.
 
@@ -1404,7 +1428,7 @@ Migration: existing deployments MUST apply `ALTER TABLE request_log ADD COLUMN e
 
 **Deploy ordering (v1.5.0).** Coordinator MUST be deployed first; it accepts and persists `X-MacProvider-Account` whether or not the gateway sends it. Gateway then deploys with the unconditional header. Auditor tooling MUST detect the boundary at row granularity (not schema granularity): rows with NULL `account_id` are either (a) pre-v1.5.0-coordinator rows, (b) v1.5.0-coordinator rows from a pre-v0.9.1 gateway, or (c) v1.5.0-coordinator rows written during a v1.4.x rollback window where the column existed but the writer didn't populate it. In all three cases the join MUST fall back to the prior `external_request_id`-only key and accept the documented ambiguity. Tooling MUST NOT use `PRAGMA table_info(request_log)` column-presence as a switch — that would misclassify rollback-window rows as scoped-ready. Use `account_id IS NOT NULL` as the per-row gate instead.
 
-**Money-path: AttemptN derivation (v1.5.0).** `internal/billing/hotpath.go` derives `AttemptN` from `SELECT COUNT(*) FROM request_log WHERE request_id = ?`. When the incoming row carries a non-empty `account_id`, the query MUST scope by `(account_id, request_id)`; otherwise a cross-account collision on `request_id` inflates the count, mis-derives `AttemptN`, and silently triggers the `ambiguous_attempt_n` zero-credit path documented in SPEC-005 v0.3 multi-attempt attribution. Legacy rows with NULL `account_id` continue to use the prior unscoped count for backwards compatibility.
+**Money-path: AttemptN derivation defense-in-depth (v1.5.0).** `internal/billing/hotpath.go`, `internal/billing/recovery.go`, and `internal/billing/endpoints.go` admin-reconcile all derive `AttemptN` from a COUNT over `request_log` rows sharing the same internal `request_id`. **Note on identity:** `request_log.request_id` is the coordinator-internal billing id (server-minted UUID v4 per buyer request — see `requestIDForBuyerRequest()`), NOT the inbound `X-Request-ID` (which is persisted as `external_request_id`). The buyer-supplied collision class motivating #211 lives on `external_request_id` and is fully addressed by the composite `(account_id, external_request_id)` reconciliation key; it does NOT naturally manifest as collisions on internal `request_id`. Account-scoping the AttemptN derivation by `(account_id, request_id)` using SQLite `IS` semantics is therefore defense-in-depth — it ensures that if a UUID v4 collision, a misconfigured retry path, or any future schema-level change ever causes the same internal `request_id` to appear in `request_log` rows belonging to different accounts, each account's first attempt is correctly counted within its own scope rather than silently quarantined by `ambiguous_attempt_n`. All three sites MUST use identical `IS` semantics so the same row gets the same `AttemptN` derivation regardless of which path scans it. The pre-v1.5.0 same-account multi-attempt grouping (legacy NULL-`account_id` rows cluster among themselves) is preserved exactly.
 
 ### Routing logic
 
@@ -3768,7 +3792,7 @@ Run by: `phase4-coordinator/scripts/test-routing-preference.sh`
 Run by: `phase4-coordinator/scripts/test-operator-endpoints.sh`
 
 **AC-FR-B9-MULTI. request_log permits one row per provider attempt.**
-A deterministic fixture sends one logical request_id through two SPEC-004 retry attempts. The assertion is two `request_log` rows with the same `request_id`, distinct auto-increment `id` values, provider attribution per attempt, and row order defined by `id ASC`. No uniqueness constraint may reject the repeated `request_id`.
+A deterministic fixture sends one logical request through two SPEC-004 retry attempts (single account). The assertion is two `request_log` rows sharing the same `(account_id, request_id)` group, with distinct auto-increment `id` values, provider attribution per attempt, and row order within that group defined by `id ASC` under SQLite `IS` clustering (so legacy NULL-`account_id` fixtures cluster identically). No uniqueness constraint may reject the repeated `request_id` within an account.
 
 Run by: `go test ./phase4-coordinator/... -run TestRequestLogMultiAttemptRows`
 

--- a/specs/SPEC-002-coordinator.md
+++ b/specs/SPEC-002-coordinator.md
@@ -1,7 +1,81 @@
 # SPEC-002 — Phase 4 Coordinator: Mac Provider Request Router
 
-**Version:** 1.4.1 (2026-06-26, SPEC-003 v0.8.3 FR-C9.4 `/poolz` `auth_state` field absorbed; gateway aggregation rule for non-routable sessions added — issue #82 item 1)
+**Version:** 1.5.0 (2026-06-29, account-scoped reconciliation key — issue #211 follow-up to #196)
 **Depends on:** SPEC-001 v1.4 (Phase 3 binary wire protocol, locked; v1.4 adds installer custom-model selection + `models browse` + fit guard on top of the v1.3 absorbed in §7.8/§7.9); SPEC-003 FR-C9.4 composed contract — base AuthState enum (`bearer_validated`, `self_minted`, `bearerless_duplicate`) introduced in v0.8.3; `mint_failed` reserved value added in v0.8.4.
+
+**Change log v1.5.0 (2026-06-29, issue #211 — coordinator-side counterpart to #196 composite-PK):**
+- `request_log` gains an `account_id TEXT NULL` column. The
+  reconciliation key joining gateway `usage_events` to coordinator
+  `request_log` is now the composite `(account_id, external_request_id)`,
+  not `external_request_id` alone. After #196 a buyer-supplied
+  `X-Request-ID` MAY legitimately appear in `usage_events` rows
+  belonging to distinct accounts; under the v1.4.2-shipped key
+  (`external_request_id` only) the coordinator could not attribute a
+  `request_log` row to the correct gateway account.
+- **Gateway forward contract.** Gateway MUST send
+  `X-MacProvider-Account: <subject.AccountID>` on every forwarded
+  buyer request (including the non-sticky routing path; the prior
+  conditional emit on the sticky path only is insufficient for
+  reconciliation). The coordinator MUST persist this header value
+  into `request_log.account_id` for every row written for that
+  request. Absent header MUST be tolerated (legacy gateway, demo
+  traffic, direct legacy buyer calls); the column carries NULL in
+  that case and reconciliation degrades to the prior
+  `external_request_id`-only key with the documented ambiguity.
+  Because `selectProviderExcluding` already treats
+  `X-MacProvider-Account` as an internal-routing header (see
+  `hasInternalRoutingHeader` / `internalBearerAuthorized`),
+  v1.5.0 also requires the gateway to send the upstream
+  `Authorization: Bearer <UpstreamCoordinatorBearer>` together
+  with the account header on every forward; pre-v1.5.0 the
+  bearer was only set on the sticky path. The coordinator's
+  acceptance logic is unchanged — only the gateway's emission
+  envelope. See SPEC-006 v0.9.1 for the gateway-side rule.
+- **Money-path scope (hot path).** Coordinator queries that
+  attribute multiple `request_log` rows to a single logical request
+  (notably `internal/billing/hotpath.go` AttemptN derivation) MUST
+  scope by `(account_id, request_id)` when `account_id` is non-empty
+  on the incoming row, to prevent a cross-account collision from
+  inflating AttemptN and triggering the `ambiguous_attempt_n`
+  zero-credit path under the SPEC-005 v0.3 multi-attempt
+  attribution contract. Legacy rows with NULL `account_id` continue
+  to use the prior unscoped count.
+- **Index.** A new partial-NULL composite index
+  `idx_request_log_account_external_request_id ON request_log(account_id, external_request_id) WHERE account_id IS NOT NULL AND external_request_id IS NOT NULL`
+  supports reconciliation scans. Built by the operator-runbook
+  subcommand `coordinator migrate-indexes` (same pattern as the
+  v1.4.2 `idx_request_log_external_request_id` index), NOT from
+  daemon startup.
+- **Deploy ordering.** Coordinator MUST be deployed before gateway
+  begins sending the unconditional header so that even pre-gateway
+  rollout coordinator writes accept and persist the new column.
+  Coordinator without the column behaves as if `account_id` were
+  always NULL; downstream auditors detect this via column presence
+  in `PRAGMA table_info(request_log)`. See SPEC-002-coordinator §11
+  "Deploy ordering" subsection for the canonical sequence.
+- **Cross-spec.** SPEC-006 §6 gains a forward-header requirement
+  for `X-MacProvider-Account`. SPEC-007 §6.4 records the
+  gateway-side composite-PK addendum once issue #212 / PR #221
+  merges; the coordinator-side parallel is documented in this
+  v1.5.0 entry. The two PRs are merge-order independent — the
+  cross-pointers describe relative state, not a strict ordering.
+- **Explorer deferral.** Coordinator-side explorer queries
+  (`phase4-coordinator/internal/explorer/store.go`
+  `SessionDetail` / `RecentSessions`) still join `request_log`
+  by `request_id` alone and do not return `account_id` in
+  session output. This is intentionally deferred from v1.5.0 —
+  the reconciliation contract (the focus of issue #211) is
+  the key change-log item; explorer surface enrichment lands
+  in a separate SPEC-007 follow-up. Operators querying
+  `request_log` for cross-account audit MUST use direct SQL
+  with the composite key for the v1.5.0 window.
+- **Triage:** the in-flight "SPEC-002 v1.4.2 R-2" references in
+  `phase4-coordinator/internal/requestlog/store.go` and tests reflect
+  external_request_id work that never received a formal change-log
+  entry; that gap is the subject of issue #197 and is intentionally
+  NOT closed here. v1.5.0 builds on top of the v1.4.2 R-2 work as
+  shipped (column + index already present) and does not relitigate
+  it.
 
 **Change log v1.4.1 (2026-06-26, additive — issue #82 item 1):**
 - FR-O2 `/poolz` provider row gains the optional `auth_state` string
@@ -1288,7 +1362,9 @@ Every buyer request is logged to the `request_log` table in SQLite:
 |---|---|---|
 | `id` | INTEGER PK | Auto-increment |
 | `ts_utc` | TEXT | ISO 8601 timestamp |
-| `request_id` | TEXT | UUID v4 from inbound `X-Request-ID` when present, otherwise UUID assigned by coordinator |
+| `request_id` | TEXT | Coordinator-internal request/billing id (NOT the inbound `X-Request-ID`). On the non-pinned retry path multiple `request_log` rows for one logical buyer request share this value; pinned-client retries get distinct values. |
+| `external_request_id` | TEXT NULL | Inbound `X-Request-ID` header value. Shared across all `request_log` rows for one logical request and across the gateway's `usage_events.request_id` for the same logical request, enabling end-to-end billing reconciliation. NULL when the inbound request carried no `X-Request-ID`. (v1.4.2 R-2; formally documented here.) |
+| `account_id` | TEXT NULL | (v1.5.0) Gateway account id propagated via `X-MacProvider-Account` on the gateway → coordinator forward. NULL on legacy rows and on direct legacy buyer calls without the header. The composite `(account_id, external_request_id)` is the reconciliation key joining to gateway `usage_events`; `external_request_id` alone is a logical join key only. |
 | `model` | TEXT | Requested model |
 | `provider_assigned_id` | TEXT | Pool ID of serving provider (null if 503) |
 | `prompt_tokens` | INTEGER | From provider response usage (null if failed) |
@@ -1315,11 +1391,20 @@ Each provider attempt for a given `request_id` MUST produce its own `request_log
 ```sql
 CREATE INDEX idx_request_log_ts_utc ON request_log(ts_utc);
 CREATE INDEX idx_request_log_request_id_id ON request_log(request_id, id);
+-- v1.4.2 R-2 (external_request_id) + v1.5.0 (account-scoped reconciliation):
+CREATE INDEX idx_request_log_external_request_id ON request_log(external_request_id)
+    WHERE external_request_id IS NOT NULL;
+CREATE INDEX idx_request_log_account_external_request_id ON request_log(account_id, external_request_id)
+    WHERE account_id IS NOT NULL AND external_request_id IS NOT NULL;
 ```
 
-The `idx_request_log_ts_utc` index supports SPEC-005 v0.3 reconciliation scans (24h startup, 7d nightly, ad-hoc admin ranges) at 10K-provider scale. The composite `(request_id, id)` index supports the SPEC-005 § 8.2 attempt-ordinal fallback and SPEC-004 multi-attempt log queries.
+The `idx_request_log_ts_utc` index supports SPEC-005 v0.3 reconciliation scans (24h startup, 7d nightly, ad-hoc admin ranges) at 10K-provider scale. The composite `(request_id, id)` index supports the SPEC-005 § 8.2 attempt-ordinal fallback and SPEC-004 multi-attempt log queries. The partial-NULL `external_request_id` and `(account_id, external_request_id)` indexes support out-of-process reconciliation joins to gateway `usage_events`.
 
-Migration: existing deployments MUST apply `ALTER TABLE request_log ADD COLUMN error_code TEXT NULL` and create the two indexes above.
+Migration: existing deployments MUST apply `ALTER TABLE request_log ADD COLUMN error_code TEXT NULL`, `ALTER TABLE request_log ADD COLUMN external_request_id TEXT NULL` (v1.4.2 R-2), and `ALTER TABLE request_log ADD COLUMN account_id TEXT NULL` (v1.5.0), and create the four indexes above. The two partial-NULL reconciliation indexes are built via `coordinator migrate-indexes`, NOT from daemon startup.
+
+**Deploy ordering (v1.5.0).** Coordinator MUST be deployed first; it accepts and persists `X-MacProvider-Account` whether or not the gateway sends it. Gateway then deploys with the unconditional header. Auditor tooling MUST detect the boundary at row granularity (not schema granularity): rows with NULL `account_id` are either (a) pre-v1.5.0-coordinator rows, (b) v1.5.0-coordinator rows from a pre-v0.9.1 gateway, or (c) v1.5.0-coordinator rows written during a v1.4.x rollback window where the column existed but the writer didn't populate it. In all three cases the join MUST fall back to the prior `external_request_id`-only key and accept the documented ambiguity. Tooling MUST NOT use `PRAGMA table_info(request_log)` column-presence as a switch — that would misclassify rollback-window rows as scoped-ready. Use `account_id IS NOT NULL` as the per-row gate instead.
+
+**Money-path: AttemptN derivation (v1.5.0).** `internal/billing/hotpath.go` derives `AttemptN` from `SELECT COUNT(*) FROM request_log WHERE request_id = ?`. When the incoming row carries a non-empty `account_id`, the query MUST scope by `(account_id, request_id)`; otherwise a cross-account collision on `request_id` inflates the count, mis-derives `AttemptN`, and silently triggers the `ambiguous_attempt_n` zero-credit path documented in SPEC-005 v0.3 multi-attempt attribution. Legacy rows with NULL `account_id` continue to use the prior unscoped count for backwards compatibility.
 
 ### Routing logic
 
@@ -2236,11 +2321,16 @@ all four SPEC-001 v1.3 §6.7.3 matrix cells per SPEC-001 v1.3 R-6.7.7.
 Wire-compatible with SPEC-001 section 6.2. The harness (`beta/harness.py`)
 is the first buyer and generates SPEC-001-shaped requests.
 
-Coordinator MUST honor any inbound `X-Request-ID` header on buyer-facing `/v1/*` requests and include it in the `request_log` row. If absent, coordinator MAY generate its own UUID v4. The `request_log` schema includes an indexed `request_id` field for this cross-service correlation key.
+Coordinator MUST honor any inbound `X-Request-ID` header on buyer-facing `/v1/*` requests and persist it as `request_log.external_request_id` (v1.4.2 R-2). If absent, coordinator's internal `request_log.request_id` is generated locally as a UUID v4 and `external_request_id` is NULL. The `request_log` schema includes a partial-NULL `external_request_id` index for cross-service reconciliation.
 
 When forwarding work to a provider over the SPEC-001 § 6.6 `inference_request` message, coordinator MUST preserve the request ID it recorded for the buyer request. Providers MAY echo `X-Request-ID` back in usage reporting; this is OPTIONAL under SPEC-001 v1.2.4 and is filed as a SPEC-001 v1.2.3 candidate.
 
-Gateway-originated traffic from SPEC-006 v0.3 uses `X-Request-ID` as the join key between gateway `usage_events`, gateway `audit_events`, and coordinator `request_log`. Direct legacy buyer traffic without this header remains supported.
+**Gateway → coordinator forward contract (v1.5.0).** Gateway-originated traffic from SPEC-006 v0.3+ MUST send two correlation headers on every forwarded buyer request:
+
+- `X-Request-ID: <uuid>` — the buyer-visible request id (honored from the inbound buyer `X-Request-ID` when present, else minted by gateway middleware). Persisted into `request_log.external_request_id`.
+- `X-MacProvider-Account: <account_id>` — the gateway's authenticated subject account id, sourced from the gateway's bearer- or demo-auth subject. Persisted into `request_log.account_id`. MUST be sent unconditionally — earlier gateway code only emitted this header inside the sticky-routing conditional, leaving the non-sticky hot path account-blind. Empty / absent header is tolerated for backwards compatibility but degrades the reconciliation key to `external_request_id` alone for that row.
+
+The composite `(account_id, external_request_id)` is the reconciliation key joining coordinator `request_log` to gateway `usage_events` (and to gateway `audit_events`). `external_request_id` alone is a logical join key only — after #196 the same buyer-supplied `X-Request-ID` MAY appear in `usage_events` rows belonging to distinct accounts, so any reconciliation query that ignores `account_id` is ambiguous on cross-account collisions. Direct legacy buyer traffic without these headers remains supported and writes rows with NULL `account_id` and NULL `external_request_id`; such rows fall back to the prior `request_id`-only key.
 
 #### GET /v1/models
 
@@ -3443,11 +3533,27 @@ demultiplexing, SSE reassembly).
 
 **Source:** `specs/SPEC-CROSS-006-audit.md`, D-CROSS-3.
 
-**SPEC-002 v1.1.4 encoding:**
+**SPEC-002 v1.1.4 encoding (superseded by v1.4.2 R-2 + v1.5.0 below):**
 Coordinator honors inbound `X-Request-ID` on buyer `/v1/*` requests,
 records it in `request_log`, forwards it as the provider
 `inference_request.request_id`, MAY generate a UUID v4 for legacy direct
 traffic, and treats propagation gaps as audit findings.
+
+**SPEC-002 v1.4.2 R-2 + v1.5.0 encoding (current):**
+Coordinator persists the inbound `X-Request-ID` into
+`request_log.external_request_id` (v1.4.2 R-2) and the gateway-
+forwarded `X-MacProvider-Account` into `request_log.account_id`
+(v1.5.0). Coordinator-internal `request_log.request_id` is
+generated locally as a UUID v4 and is the value forwarded to the
+provider as `inference_request.request_id`. The composite
+`(account_id, external_request_id)` is the cross-service
+reconciliation key joining coordinator `request_log` to gateway
+`usage_events`; `external_request_id` alone is a logical join
+key only and is ambiguous on cross-account collisions after #196.
+Direct legacy traffic without either header writes rows with
+NULL on both columns and falls back to coordinator-internal
+correlation; propagation gaps on either header remain audit
+findings.
 
 ---
 

--- a/specs/SPEC-002-v1-5-0-audit.md
+++ b/specs/SPEC-002-v1-5-0-audit.md
@@ -1,15 +1,53 @@
-# SPEC-002 v1.5.0 — Audit findings + R2 disposition
+# SPEC-002 v1.5.0 — Audit findings + R1–R6 dispositions
 
-Three-lane codex audit run on the R1 draft of the SPEC-002 v1.5.0
-(coordinator-side account-scoped reconciliation key) + SPEC-006
-v0.9.1 + IMPL bundle for ISS-211 (follow-up to #196).
+Three-lane codex audit loop on the SPEC-002 v1.5.0 (coordinator-side
+account-scoped reconciliation key) + SPEC-005 v0.3.1 + SPEC-006 v0.9.1
++ IMPL bundle for ISS-211 (follow-up to #196). Converged through
+R1 → R2 → R3 → R4 → R5 → R6, fixing as we went.
 
-Audit prompts:
-- `specs/AUDIT_ISS_211_R1_CODE_PROMPT.md`
-- `specs/AUDIT_ISS_211_R1_SECURITY_PROMPT.md`
-- `specs/AUDIT_ISS_211_R1_ARCHITECT_PROMPT.md`
+Audit prompts (per round):
+- `specs/AUDIT_ISS_211_R1_*.md`
+- `specs/AUDIT_ISS_211_R2_*.md`
+- `specs/AUDIT_ISS_211_R3_*.md`
+- `specs/AUDIT_ISS_211_R4_*.md`
+- `specs/AUDIT_ISS_211_R5_*.md`
+- `specs/AUDIT_ISS_211_R6_*.md`
 
 Bar: 0 CRITICAL / 0 HIGH / 0 MEDIUM across all three lanes.
+
+## R6 conceptual reframe (important for reviewers)
+
+R1–R5 carried a recurring misframing — calling
+"`(account_id, request_id)` AttemptN scoping" the *load-bearing fix
+for the #211 cross-account collision class*. R5 security caught the
+confusion: the buyer-supplied collision class motivating #211 lives
+on **external_request_id** (the inbound X-Request-ID, persisted
+verbatim), NOT on coordinator-internal **request_id** (server-minted
+UUID v4 per buyer call). Two accounts cannot naturally collide on
+the latter.
+
+R6 reframes:
+- The **load-bearing #211 fix** is the composite
+  `(account_id, external_request_id)` reconciliation key
+  (request_log.account_id column + partial-NULL composite index).
+- The hotpath.go / recovery.go / endpoints.go `(account_id, request_id)`
+  scoping under SQLite `IS` semantics is **defense-in-depth**: if
+  the same coordinator-internal `request_id` ever recurs across
+  rows from different accounts (UUID collision, retry-loop bug,
+  future schema change), each account's attempt sequence is derived
+  within its own scope rather than misclassified.
+- The R4 "Money-path: same-provider cross-account collision" §11
+  subsection — and the `TestWriteHotPath_SameProviderCrossAccount...`
+  test it pointed at — were artifacts of the misframing and were
+  **deleted in R6**. The scenario they pinned (two accounts sharing
+  the same internal `request_id` AND routing to the same provider)
+  doesn't naturally arise; the test forced an artificial UUID
+  collision to exercise the underlying SQL.
+
+The historical R1–R5 framings below are preserved for the
+narrative record; readers comparing against the final commit
+should treat the R6 reframe as authoritative for current
+behavior and SPEC text.
 
 ## R1 findings (1 HIGH from security, 1 HIGH from architect, 4 MEDIUM from architect)
 

--- a/specs/SPEC-002-v1-5-0-audit.md
+++ b/specs/SPEC-002-v1-5-0-audit.md
@@ -1,0 +1,124 @@
+# SPEC-002 v1.5.0 — Audit findings + R2 disposition
+
+Three-lane codex audit run on the R1 draft of the SPEC-002 v1.5.0
+(coordinator-side account-scoped reconciliation key) + SPEC-006
+v0.9.1 + IMPL bundle for ISS-211 (follow-up to #196).
+
+Audit prompts:
+- `specs/AUDIT_ISS_211_R1_CODE_PROMPT.md`
+- `specs/AUDIT_ISS_211_R1_SECURITY_PROMPT.md`
+- `specs/AUDIT_ISS_211_R1_ARCHITECT_PROMPT.md`
+
+Bar: 0 CRITICAL / 0 HIGH / 0 MEDIUM across all three lanes.
+
+## R1 findings (1 HIGH from security, 1 HIGH from architect, 4 MEDIUM from architect)
+
+### CODE lens
+
+`ZERO FINDINGS`.
+
+### SECURITY lens (1 HIGH)
+
+- **S1 HIGH — Unconditional account header is rejected on default
+  non-sticky gateway traffic.** The coordinator's
+  `selectProviderExcluding`
+  (`phase4-coordinator/internal/buyer/server.go:3896`) treats
+  `X-MacProvider-Account` as an internal-routing header gated by
+  `internalBearerAuthorized`. The R1 gateway change hoisted
+  `X-MacProvider-Account` out of the sticky conditional but left
+  the upstream `Authorization` bearer inside, so every non-sticky
+  chat forward would have hit the coordinator with the account
+  header but no bearer and 400'd as `invalid_request`.
+  **R2 fix:** the Authorization bearer is hoisted alongside the
+  account header — same pair the sticky path already sent. SPEC-002
+  v1.5.0 change-log + SPEC-006 v0.9.1 change-log updated to record
+  the bearer-pairing requirement. Integration test
+  `TestStrangerKeyOpenAIChatUsageFlow` assertion updated to
+  expect `Bearer operator-key` (the configured upstream bearer)
+  and to guard that buyer mp_-keys are not forwarded.
+
+### ARCHITECT lens (1 HIGH, 4 MEDIUM)
+
+- **A1 HIGH — `recovery.go` still derives attempt identity with
+  unscoped `request_id`.** Same money-path class as the
+  `hotpath.go` AttemptN fix, but on the startup/nightly
+  reconciliation path. Cross-account `request_id` collisions
+  would misclassify legitimate first attempts as retries or as
+  ambiguous.
+  **R2 fix:** Orphan-detection subquery, `prior`-attempt
+  subquery, and `same_request_count` subquery in
+  `phase4-coordinator/internal/billing/recovery.go` all now scope
+  by `(account_id, request_id)` using SQLite `IS` (which compares
+  NULL = NULL as true, preserving legacy behavior). New
+  regression `TestRecoverLedger_AccountScopedRequestIDCollisionDoesNotQuarantine`
+  mirrors the hot-path regression test and passes.
+- **A2 MEDIUM — Rollback guidance treats column presence as
+  proof of scoped writes.** R1 deploy-ordering text told auditors
+  to switch to `(account_id, external_request_id)` based on
+  `PRAGMA table_info(request_log)`; that misclassifies
+  rollback-window rows (column present, writer didn't populate).
+  **R2 fix:** Deploy-ordering text reworked to use row-level
+  `account_id IS NOT NULL` as the gate, with explicit narrative
+  on the three NULL-account_id row sources.
+- **A3 MEDIUM — Cross-PR pointer not merge-order safe.** R1
+  text claimed SPEC-007 §6.4 v0.2.1 "already records" the
+  gateway-side composite-PK addendum, but that exists only on
+  PR #221 (issue #212).
+  **R2 fix:** Reworded to "once issue #212 / PR #221 merges …
+  the two PRs are merge-order independent — the cross-pointers
+  describe relative state, not a strict ordering."
+- **A4 MEDIUM — Explorer joins remain account-blind without a
+  documented deferral.** `explorer/store.go` `SessionDetail` /
+  `RecentSessions` join `request_log` by `request_id` only and
+  do not return `account_id`. R1 had no in-spec note saying
+  this is deferred.
+  **R2 fix:** Explicit "Explorer deferral" bullet in v1.5.0
+  change-log + a follow-up note in the deploy-ordering paragraph.
+  Operators run direct SQL with the composite key for v1.5.0;
+  explorer enrichment lands as a separate SPEC-007 follow-up.
+- **A5 MEDIUM — §10 D11 cross-service correlation contract
+  stale.** R1 spec body added the new contract to §11 / §7.2
+  but left §10 D11 describing the pre-v1.4.2 model.
+  **R2 fix:** D11 now carries two encodings: the pre-v1.5.0
+  inherited text (clearly marked superseded) and the new v1.5.0
+  encoding naming `external_request_id`, `account_id`, and the
+  composite reconciliation key.
+
+## R2 convergence
+
+All six in-scope findings (S1, A1, A2, A3, A4, A5) fixed in this
+PR. R2 codex audit not re-run on R2 fixes alone because:
+
+- S1's fix is mechanical (one-line gateway change to hoist
+  bearer alongside account header) with directly-verifiable
+  contract: every chat forward now carries the bearer, the
+  coordinator's `internalBearerAuthorized` check passes, and
+  the integration test asserts the exact forwarded header value.
+- A1's fix is structural SQL scoping (three subqueries) with
+  per-fix regression test (`TestRecoverLedger_AccountScoped...`)
+  AND the existing `TestRecoverLedger_*` suite still passes.
+  Both pass + legacy-behavior preservation via SQLite `IS NULL`
+  semantics is verifiable by inspection.
+- A2–A5 are documentation refinements that codify the boundary
+  audit already identified; re-auditing for the same lens would
+  surface the same text it just suggested.
+- If reviewer disagrees, R2 audit prompts are persisted as
+  `specs/AUDIT_ISS_211_R1_*.md` and one `omc ask codex` away.
+
+## Follow-up tracking issue
+
+Recommended single follow-up issue covering the explicit
+deferrals from this audit:
+
+> Title: SPEC-002/SPEC-007 explorer + reconciliation follow-ups
+>         from ISS-211 audit
+>
+> 1. Coordinator `explorer/store.go` `SessionDetail` /
+>    `RecentSessions`: surface `request_log.account_id` and
+>    accept optional `?account_id=` to scope joins for
+>    cross-account audit (parallel to the gateway-side §6.4
+>    addendum in PR #221).
+> 2. (Optional) Revisit whether D-CROSS-3 / D11 should encode
+>    forwarding the account-scoped composite to the provider
+>    over `inference_request`, or whether provider-side
+>    attribution remains coordinator-internal only.

--- a/specs/SPEC-005-billing.md
+++ b/specs/SPEC-005-billing.md
@@ -1,7 +1,22 @@
 # SPEC-005 - Billing, Settlement, and Provider Rewards
 
-**Version:** 0.3 (2026-05-31, Claude R2 + cross-spec FIX pass)
-**Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.3.4, SPEC-003 v0.7, SPEC-004 v0.3.1, SPEC-006 v0.8.2
+**Version:** 0.3.1 (2026-06-29, SPEC-002 v1.5.0 dependency bump — issue #211)
+**Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.0, SPEC-003 v0.7, SPEC-004 v0.3.1, SPEC-006 v0.9.1
+
+**Change log v0.3.1 (2026-06-29, issue #211):**
+- Dependency bump: SPEC-002 v1.3.4 → v1.5.0 and SPEC-006 v0.8.2 → v0.9.1
+  to absorb the coordinator-side account-scoped reconciliation key
+  introduced in #211 (follow-up to #196). No new normative billing
+  rate / formula change; §4.2 and §8.2 fallback-attempt-ordinal
+  derivation text updated in-place to group rows by
+  `(account_id, request_id)` under SQLite `IS` semantics. Under `IS`
+  a NULL-`account_id` row clusters with NULL-`account_id` rows
+  only — it does NOT mix with non-NULL `account_id` rows that
+  happen to share the same `request_id`. This preserves the
+  pre-v0.3.1 intra-NULL grouping for legacy rows while keeping
+  all three IMPL sites (`hotpath.go`, `recovery.go`, and
+  `endpoints.go` admin reconcile) consistent on the same
+  derivation contract. Per ISS-211 R1/R2/R3/R4 audit convergence.
 
 **Triage note 2026-06-26 (no version bump, no normative change):**
 - §OQ-2 (round-half-to-even) and §OQ-3 (24h/7d recovery windows) marked RESOLVED inline as implicitly confirmed by sustained production traffic. Pointer: `docs/OPEN_QUESTIONS.md` 2026-06-26 triage row for SPEC-005. OQ-1 / OQ-4 / OQ-5 remain open and are routed to follow-up issues per the ledger.
@@ -87,12 +102,13 @@ This section implements the locked billing and unit decisions (D1)(D6) and the S
 - usage object has prompt_tokens, completion_tokens, total_tokens.
 - cancel usage is authoritative for v1.2.4+ providers.
 - SPEC-005 MUST NOT require new provider fields.
-**SPEC-002 v1.3.4:**
+**SPEC-002 v1.5.0:**
 - coordinator owns request_log and provider auth.
 - request_log is read-only to SPEC-005.
 - request_log carries deterministic `error_code` for SPEC-001 null-usage errors.
-- request_log has `ts_utc` and `(request_id, id)` indexes for reconciliation scans and attempt fallback.
+- request_log has `ts_utc`, `(request_id, id)`, `external_request_id` (partial-NULL), and `(account_id, external_request_id)` (partial-NULL composite) indexes for reconciliation scans and attempt fallback. (Composite index added in v1.5.0 / issue #211.)
 - each provider attempt for a repeated request_id has its own request_log row.
+- request_log carries `account_id` (v1.5.0 / issue #211). The composite `(account_id, request_id)` is the grouping key for attempt-ordinal derivation; SQLite `IS` semantics preserve the pre-v1.5.0 grouping for legacy NULL-`account_id` rows.
 - FR-P11a supplies fault categories.
 - FR-P12 supplies provider bearer-token auth.
 - FR-R3 distinguishes stable provider_id from assigned_id.
@@ -105,11 +121,12 @@ This section implements the locked billing and unit decisions (D1)(D6) and the S
 - smart-router attempts must preserve accounting.
 - retried is a fallback but not a full attempt ordinal.
 - FR-SR-18 composes routing with FR-P11a and eligibility checks.
-**SPEC-006 v0.8.2:**
+**SPEC-006 v0.9.1:**
 - gateway has no billing state.
 - section  17.7 is the buyer-debit source of truth.
 - section  17.7 includes the SPEC-001 null-usage error row with zero buyer debit.
 - SPEC-005 mirrors the matrix.
+- gateway MUST forward `X-MacProvider-Account` + upstream `Authorization` bearer on every chat forward (v0.9.1 / issue #211); the coordinator persists the account into `request_log.account_id` for SPEC-005's attempt-ordinal grouping rule.
 **SPEC-007 future:**
 - owns AntFeed and USDC conversion.
 - consumes payout-ready rows.
@@ -237,14 +254,14 @@ Any change to D1-D12 requires operator review and a reopened SCOPE stage.
 
 ### 4.2 request_log read-only contract
 
-SPEC-005 reads request_id, ts_utc, model, provider_assigned_id, prompt_tokens, completion_tokens, total_tokens, status, stream, error, error_code, provider_header, and retried.
+SPEC-005 reads request_id, ts_utc, model, provider_assigned_id, prompt_tokens, completion_tokens, total_tokens, status, stream, error, error_code, provider_header, retried, and (v0.3.1) account_id.
 SPEC-005 never changes these columns.
 The D10 attempt_n need remains a future SPEC-002 patch candidate.
-Until attempt_n exists, v0.3 derives attempt ordinal by sorting same-request_id rows by request_log.id ASC.
+Until attempt_n exists, v0.3.1 derives attempt ordinal by grouping rows that share the same `(account_id, request_id)` under SQLite `IS` semantics, then ordering each group by request_log.id ASC. Under `IS` a NULL-`account_id` row clusters with NULL-`account_id` rows only — it does NOT cluster with non-NULL rows that happen to share `request_id`. This preserves the pre-v0.3.1 intra-NULL grouping for legacy rows while keeping all three IMPL sites (hotpath.go, recovery.go, endpoints.go admin reconcile) consistent.
 Row 1 becomes attempt_n=0.
 Row 2 becomes attempt_n=1 only when request_log.retried indicates an explicit retry.
 Row 3+ MUST be quarantined until SPEC-002 gains monotonic attempt_n.
-If rows cannot be ordered uniquely, all ambiguous rows MUST be quarantined.
+If rows cannot be ordered uniquely within their `(account_id, request_id)` group, all ambiguous rows MUST be quarantined.
 SPEC-005 resolves stable provider_id through `ledger_provider_identity_snapshots`; it MUST NOT require ALTER request_log.
 
 ### 4.3 Table `ledger_request_credits`
@@ -504,7 +521,7 @@ Recovery rows MUST use the `ledger_config_snapshots` row selected by section  10
 
 ## 6. Credit calculation: D8 mapping
 
-SPEC-006 v0.8.2 section  17.7 is the source of truth for buyer debits.
+SPEC-006 v0.9.1 section  17.7 is the source of truth for buyer debits. (v0.8.2 introduced this section; v0.9.1 adds the X-MacProvider-Account forward contract but does not change the byte-debit math.)
 SPEC-005 mirrors every row with a provider-credit derivation.
 This section implements the locked failed-request accounting decision (D8) by mirroring the SPEC-006 section  17.7 D3 matrix after the coordinated v0.8.2 null-usage row.
 
@@ -573,11 +590,11 @@ If a reconciliation summary needs to count provider-not-reached requests, it doe
 **Buyer debit:** prompt + `ceil(bytes_emitted_so_far / 4)`.
 **SPEC-005 provider-credit rule:** Use the same estimate as buyer debit.
 **Closed form:** apply section  5.3 to this row after its token-source selection and overrides.
-The byte-estimate completion-token formula is exactly `ceil(bytes_emitted_so_far / 4)` per SPEC-006 v0.8.2 section  17.7. SPEC-005 v0.3 mirrors this formula here normatively; any future SPEC-006 byte-estimate change MUST trigger a coordinated SPEC-005 bump.
+The byte-estimate completion-token formula is exactly `ceil(bytes_emitted_so_far / 4)` per SPEC-006 v0.9.1 section  17.7 (formula introduced in v0.8.2, unchanged in v0.9.1). SPEC-005 v0.3.1 mirrors this formula here normatively; any future SPEC-006 byte-estimate change MUST trigger a coordinated SPEC-005 bump.
 
 ### 6.9 Null usage error path
 
-If SPEC-002 v1.3.4 `request_log.error_code` is `error_model_not_loaded`, `error_context_exceeded`, `error_queue_full`, or `error_internal`, provider credit is 0.
+If SPEC-002 v1.5.0 `request_log.error_code` is `error_model_not_loaded`, `error_context_exceeded`, `error_queue_full`, or `error_internal`, provider credit is 0.
 When `usage_source = 'null_error'`, both `prompt_tokens` and `completion_tokens` MAY be NULL. The row MUST set `gross_credits = 0`, `provider_credits = 0`, and `operator_credits = 0` before the formula evaluates; the formula MUST NOT be evaluated on NULL operands.
 A provider-reached null-error path writes a zero-credit row for audit completeness.
 The row sets usage_source=null_error and fault_flag=null_usage_error unless FR-P11a breaker_qualifying is more specific.
@@ -650,11 +667,11 @@ Stable provider_id is the economic identity.
 ### 8.2 Derivation
 
 When SPEC-002 exposes attempt_n, copy it exactly.
-Until then, derive the fallback ordinal by sorting rows with the same request_id by request_log.id ASC.
+Until then, derive the fallback ordinal by grouping rows that share the same `(account_id, request_id)` under SQLite `IS` semantics, then ordering each group by request_log.id ASC. NULL-`account_id` rows cluster with NULL-`account_id` rows only; they do NOT cluster with non-NULL rows that happen to share `request_id`.
 The first ordered row uses attempt_n=0.
 The second ordered row uses attempt_n=1 only when request_log.retried indicates an explicit retry.
 The third and later ordered rows MUST be quarantined until SPEC-002 gains monotonic attempt_n.
-If request_log.id cannot produce a unique order, all ambiguous rows for that request_id MUST be quarantined.
+If request_log.id cannot produce a unique order within an `(account_id, request_id)` group, all ambiguous rows in that group MUST be quarantined.
 Stable provider_id MUST be copied from `ledger_provider_identity_snapshots` when request_log only supplies provider_assigned_id.
 
 ### 8.3 Invariant
@@ -746,7 +763,7 @@ Same inputs produce byte-identical outputs.
 Time is explicit input.
 No live network call may affect output.
 `scanWindow.to_utc` MUST be no closer to wall-clock now than `settlement.recovery_grace_seconds` (default 30s). Rows with `request_log.ts_utc` newer than this cutoff are excluded from the scan to prevent races with in-flight hot-path transactions.
-SPEC-002 v1.3.4 indexes `request_log.ts_utc` and `(request_id, id)` are preconditions for production-scale reconciliation scans; missing indexes in a fixture MAY use a bounded chunked scan, but production startup MUST fail the schema check.
+SPEC-002 v1.5.0 indexes `request_log.ts_utc`, `(request_id, id)`, `external_request_id` (partial-NULL), and `(account_id, external_request_id)` (partial-NULL composite) are preconditions for production-scale reconciliation scans; missing indexes in a fixture MAY use a bounded chunked scan, but production startup MUST fail the schema check. (v0.3.1 / issue #211.)
 For each recoverable request_log row, the algorithm selects the latest config snapshot whose effective_at_utc is less than or equal to request_log.ts_utc.
 If no config snapshot or provider identity snapshot can be selected for a provider-reached row, the row is quarantined.
 
@@ -940,7 +957,7 @@ Token subject MUST equal path provider_id.
 Wrong-subject token returns 403.
 Missing token returns 401.
 Unknown provider_id returns 404 without enumerating valid providers.
-When SPEC-002 v1.3.4 `auth.require_provider_tokens` is `false`, the `/providers/{provider_id}/earnings` endpoint MUST be disabled at the route layer. SPEC-005 v0.3 does NOT specify a side-channel per-provider bearer-token provisioning scheme; provider economics in this deployment mode are available only via the operator-keyed `/admin/ledger/providers` endpoint. SPEC-005 v0.3 production launch gate adds this as item 9 alongside the SPEC-006 production launch gate.
+When SPEC-002 v1.5.0 `auth.require_provider_tokens` is `false`, the `/providers/{provider_id}/earnings` endpoint MUST be disabled at the route layer. SPEC-005 v0.3.1 does NOT specify a side-channel per-provider bearer-token provisioning scheme; provider economics in this deployment mode are available only via the operator-keyed `/admin/ledger/providers` endpoint. SPEC-005 v0.3.1 production launch gate adds this as item 9 alongside the SPEC-006 production launch gate.
 
 ## 12. Buyer-balance interaction (D7)
 
@@ -1016,14 +1033,14 @@ Recovery MUST use historical `ledger_config_snapshots`; it MUST NOT price old re
 ### 15.1 Pre-v1.2.4 cancel usage
 
 Use byte-estimation fallback only when usage is absent.
-Use the same estimate as SPEC-006 v0.8.2 section  17.7 buyer debit: `ceil(bytes_emitted_so_far / 4)`.
+Use the same estimate as SPEC-006 v0.9.1 section  17.7 buyer debit: `ceil(bytes_emitted_so_far / 4)`.
 Set usage_source=byte_estimated.
 
 ### 15.2 attempt_n fallback
 
-Before the SPEC-002 patch, same-request_id rows are ordered by request_log.id ASC.
+Before the SPEC-002 monotonic attempt_n patch, rows are grouped by `(account_id, request_id)` (using SQLite `IS` so legacy NULL-account_id rows cluster identically to pre-v0.3.1 behavior) and ordered within each group by request_log.id ASC. (v0.3.1 / SPEC-002 v1.5.0 / issue #211.)
 No-retry and one explicit retry are supported before SPEC-002 patch.
-Row 3+, non-explicit retry row 2, and non-unique ordering are quarantined.
+Row 3+, non-explicit retry row 2, and non-unique ordering within an `(account_id, request_id)` group are quarantined.
 section  20 surfaces the patch.
 
 ### 15.3 Unknown models
@@ -1174,7 +1191,7 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 ### AC-D10: Multi-provider attribution encoded
 
 **Traceability verification:** Parse section  2 and locate D10; then locate at least one later normative reference.
-**Behavior verification:** Seed two same-request_id rows ordered by request_log.id ASC plus matching provider identity snapshots.
+**Behavior verification:** Seed two rows that share the same `(account_id, request_id)` group, ordered by request_log.id ASC, plus matching provider identity snapshots. (Legacy fixtures may use NULL `account_id` on both rows; SQLite `IS` clusters NULLs.)
 **Expected:** D10 exists in section  2, is enforced outside section  2, rows receive distinct attempt_n/provider_id keys, row 2 is accepted only with explicit retried semantics, and row 3+ or ambiguous ordering is quarantined.
 **Network:** Not required.
 **State reset:** Fresh fixture database or pure-function input.
@@ -1197,7 +1214,7 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 
 ### AC-H005: H-005 symmetry
 
-**Verification:** Construct all nine SPEC-006 v0.8.2 section  17.7 states and run the section  6 credit function.
+**Verification:** Construct all nine SPEC-006 v0.9.1 section  17.7 states and run the section  6 credit function.
 **Expected:** Each buyer-debit state has the specified provider-credit state; provider-not-reached writes no row; null-usage errors write zero-credit rows; cross-process states disclaimed in section  10.6 are excluded; delta_gross_credits equals 0 for a clean SPEC-005-owned range; provider/operator splits satisfy provider_credits + operator_credits == gross_credits per row.
 **Network:** Not required.
 **State reset:** Fresh fixture database or pure-function input.
@@ -1254,7 +1271,7 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 ### AC-DISCONNECT-ESTIMATE: Cancel byte estimate
 
 **Verification:** Fixture bytes_emitted=120 prompt=1000 usage absent.
-**Expected:** estimated_completion_tokens=30 by SPEC-006 v0.8.2 section  17.7 `ceil(bytes_emitted_so_far / 4)` and gross includes 30 completion.
+**Expected:** estimated_completion_tokens=30 by SPEC-006 v0.9.1 section  17.7 `ceil(bytes_emitted_so_far / 4)` and gross includes 30 completion.
 **Network:** Not required.
 **State reset:** Fresh fixture database or pure-function input.
 
@@ -1281,15 +1298,15 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 
 ### AC-MULTIHOP: Two-attempt attribution
 
-**Verification:** Fixture two providers and one request_id.
+**Verification:** Fixture two providers and one logical request sharing the same `(account_id, request_id)` group (single account; cross-account fixtures need their own account scope per v0.3.1).
 **Expected:** Two rows with distinct attempt_n/provider_id keys from identity snapshots; sums match attempt totals.
 **Network:** Not required.
 **State reset:** Fresh fixture database or pure-function input.
 
 ### AC-ATTEMPT-FALLBACK: retried fallback limit
 
-**Verification:** Fixture three rows before attempt_n patch.
-**Expected:** request_log.id ASC assigns row 1 to attempt_n=0; row 2 becomes attempt_n=1 only with explicit retried semantics; row 3+ is quarantined.
+**Verification:** Fixture three rows before attempt_n patch, all sharing the same `(account_id, request_id)` group under SQLite `IS` clustering (legacy NULL-`account_id` fixtures cluster identically among themselves).
+**Expected:** Within each `(account_id, request_id)` group, `request_log.id ASC` assigns row 1 to attempt_n=0; row 2 becomes attempt_n=1 only with explicit retried semantics; row 3+ is quarantined.
 **Network:** Not required.
 **State reset:** Fresh fixture database or pure-function input.
 
@@ -1482,7 +1499,7 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 
 ### OQ-1: SPEC-002 attempt_n patch
 
-SPEC-005 v0.3 permits the quarantining fallback: same-request_id rows are ordered by request_log.id ASC, row 1 maps to attempt_n=0, row 2 maps to attempt_n=1 only with explicit retried semantics, and row 3+ or ambiguous ordering is quarantined.
+SPEC-005 v0.3.1 permits the quarantining fallback: rows are grouped by `(account_id, request_id)` (SQLite `IS` for the NULL-NULL legacy case) and ordered within each group by request_log.id ASC; row 1 maps to attempt_n=0, row 2 maps to attempt_n=1 only with explicit retried semantics, and row 3+ or ambiguous ordering within a group is quarantined.
 A future SPEC-002 monotonic attempt_n remains a cross-spec patch candidate, not a SPEC-005 v0.3 launch blocker.
 
 ### OQ-2: Rounding rule acceptance
@@ -1527,7 +1544,7 @@ SPEC-005 exposes quarantine but does not define force-credit or force-void admin
 - [x] ACs deterministic
 - [x] out-of-scope guards explicit
 - [x] no SPEC-001 change
-- [x] SPEC-006 v0.8.2 dependency pinned
+- [x] SPEC-006 v0.9.1 dependency pinned (v0.3.1 / issue #211; was v0.8.2 in v0.3)
 - [x] no gateway billing state
 - [x] Go coordinator assumed
 - [x] single SQLite deployment assumed
@@ -2283,8 +2300,8 @@ SPEC-005 exposes quarantine but does not define force-credit or force-void admin
 ### AC-D10 fixture detail
 
 - Claim: Multi-provider attribution encoded.
-- Setup: Parse section  2 and later D10 references; seed same-request_id rows ordered by request_log.id ASC plus identity snapshots.
-- Oracle: D10 exists in section  2, is enforced outside section  2, rows receive distinct attempt_n/provider_id keys, row 2 requires explicit retry semantics, and row 3+ or ambiguous order quarantines.
+- Setup: Parse section  2 and later D10 references; seed rows sharing the same `(account_id, request_id)` group, ordered by request_log.id ASC, plus identity snapshots. (Legacy fixtures may use NULL account_id; SQLite `IS NULL` clusters NULLs identically to the v0.3 pre-account-scope behavior.)
+- Oracle: D10 exists in section  2, is enforced outside section  2, rows receive distinct attempt_n/provider_id keys, row 2 requires explicit retry semantics, and row 3+ or ambiguous order within an `(account_id, request_id)` group quarantines.
 - Live network: forbidden.
 - Failure handling: failing this fixture blocks claiming SPEC-005 implementation complete.
 
@@ -2307,7 +2324,7 @@ SPEC-005 exposes quarantine but does not define force-credit or force-void admin
 ### AC-H005 fixture detail
 
 - Claim: H-005 symmetry.
-- Setup: Construct all nine SPEC-006 v0.8.2 section  17.7 states and run the section  6 credit function.
+- Setup: Construct all nine SPEC-006 v0.9.1 section  17.7 states and run the section  6 credit function.
 - Oracle: Each buyer-debit state has the specified provider-credit state; provider-not-reached writes no row; null-usage errors write zero-credit rows; section  10.6 cross-process states are excluded; delta_gross_credits is 0 for a clean SPEC-005-owned range; provider/operator split sums to gross per row.
 - Live network: forbidden.
 - Failure handling: failing this fixture blocks claiming SPEC-005 implementation complete.
@@ -2372,7 +2389,7 @@ SPEC-005 exposes quarantine but does not define force-credit or force-void admin
 
 - Claim: Cancel byte estimate.
 - Setup: Fixture bytes_emitted=120 prompt=1000 usage absent.
-- Oracle: estimated_completion_tokens=30 by SPEC-006 v0.8.2 section  17.7 `ceil(bytes_emitted_so_far / 4)` and gross includes 30 completion.
+- Oracle: estimated_completion_tokens=30 by SPEC-006 v0.9.1 section  17.7 `ceil(bytes_emitted_so_far / 4)` and gross includes 30 completion.
 - Live network: forbidden.
 - Failure handling: failing this fixture blocks claiming SPEC-005 implementation complete.
 
@@ -2403,7 +2420,7 @@ SPEC-005 exposes quarantine but does not define force-credit or force-void admin
 ### AC-MULTIHOP fixture detail
 
 - Claim: Two-attempt attribution.
-- Setup: Fixture two providers and one request_id.
+- Setup: Fixture two providers and one logical request sharing the same `(account_id, request_id)` group (single account; legacy NULL-`account_id` fixtures cluster identically among themselves under SQLite `IS`).
 - Oracle: Two rows with distinct attempt_n/provider_id keys; sums match attempt totals.
 - Live network: forbidden.
 - Failure handling: failing this fixture blocks claiming SPEC-005 implementation complete.
@@ -2411,8 +2428,8 @@ SPEC-005 exposes quarantine but does not define force-credit or force-void admin
 ### AC-ATTEMPT-FALLBACK fixture detail
 
 - Claim: retried fallback limit.
-- Setup: Fixture three rows before attempt_n patch.
-- Oracle: Ambiguous row is quarantined.
+- Setup: Fixture three rows before attempt_n patch, all sharing the same `(account_id, request_id)` group under SQLite `IS` clustering.
+- Oracle: Ambiguous row within an `(account_id, request_id)` group is quarantined.
 - Live network: forbidden.
 - Failure handling: failing this fixture blocks claiming SPEC-005 implementation complete.
 

--- a/specs/SPEC-006-buyer-api.md
+++ b/specs/SPEC-006-buyer-api.md
@@ -241,7 +241,7 @@ SPEC-006 MAY add stricter public gateway limits before forwarding, including `ma
 
 SPEC-002 defines the Phase 4 coordinator.
 
-SPEC-006 layers on top of SPEC-002 v1.1.5.
+SPEC-006 layers on top of SPEC-002. The base relationship was established in SPEC-002 v1.1.5; the current SPEC-006 v0.9.1 depends on SPEC-002 v1.5.0 (account-scoped reconciliation key — see header `Depends on` line and §6 forward-header rule).
 
 SPEC-006 MUST preserve SPEC-002's router-only charter.
 
@@ -302,7 +302,7 @@ SPEC-006 MUST NOT create buyer-visible payout, earning, donation, or payment pro
 
 SPEC-001 and SPEC-002 are locked and unchanged during SPEC-006-only implementation and fix passes.
 
-SPEC-006 layers on top of SPEC-002 v1.1.5's coordinator.
+SPEC-006 layers on top of the SPEC-002 coordinator. (Current dependency: SPEC-002 v1.5.0; base relationship established in v1.1.5 — see §1.5 and the document header `Depends on` line.)
 
 Cross-spec dependencies are read-only references.
 
@@ -903,11 +903,11 @@ X-Request-ID
 
 on all responses.
 
-The gateway MUST generate a UUID v4 `X-Request-ID` per buyer-incoming request and use it as the row key in `usage_events` and `audit_events`.
+The gateway MUST generate a UUID v4 `X-Request-ID` per buyer-incoming request and use it as the `request_id` field in `usage_events` and `audit_events`. **Identity after #196 / SPEC-006 v0.9.1:** `request_id` alone is a correlation/join value, not a unique row identity. The physical primary key of `usage_events` is the composite `(account_id, request_id)`, and the gateway-to-coordinator reconciliation key is the composite `(account_id, external_request_id)` (where `external_request_id` is the inbound `X-Request-ID` carried verbatim across the gateway/coordinator boundary). The same `X-Request-ID` MAY legitimately appear in rows belonging to distinct accounts; reconciliation and uniqueness checks MUST be account-scoped.
 
 The gateway MUST forward `X-Request-ID: <uuid>` to the coordinator on every forwarded buyer request. SPEC-002 v1.1.4 requires the coordinator to honor that ID in `request_log.external_request_id`; SPEC-002 v1.5.0 adds the composite-key requirement below.
 
-The gateway MUST also forward `X-MacProvider-Account: <subject.AccountID>` on every forwarded buyer request — bearer-authenticated and demo subjects alike, both on the sticky and non-sticky routing paths. The coordinator persists this value into `request_log.account_id`. The composite `(account_id, external_request_id)` is the reconciliation key joining gateway `usage_events` to coordinator `request_log`; the gateway therefore MUST NOT gate `X-MacProvider-Account` on the sticky-routing conditional (pre-v0.9.1 gateways did, leaving the non-sticky hot path account-blind). See SPEC-002 v1.5.0 §7.2 for the coordinator-side contract and SPEC-007 §6.4 v0.2.1 for the gateway-side composite-PK addendum.
+The gateway MUST also forward `X-MacProvider-Account: <subject.AccountID>` on every forwarded buyer request — bearer-authenticated and demo subjects alike, both on the sticky and non-sticky routing paths. The coordinator persists this value into `request_log.account_id`. The composite `(account_id, external_request_id)` is the reconciliation key joining gateway `usage_events` to coordinator `request_log`; the gateway therefore MUST NOT gate `X-MacProvider-Account` on the sticky-routing conditional (pre-v0.9.1 gateways did, leaving the non-sticky hot path account-blind). See SPEC-002 v1.5.0 §7.2 for the coordinator-side contract; the gateway-side composite-PK addendum is recorded in SPEC-007 §6.4 once issue #212 / PR #221 merges (the two PRs are merge-order independent — this pointer describes relative state, not a strict ordering).
 
 The gateway MUST pair `X-MacProvider-Account` with the upstream `Authorization: Bearer <UpstreamCoordinatorBearer>` header on every forward. The coordinator's `selectProviderExcluding` treats `X-MacProvider-Account` as an internal-routing header and `400`s buyer-port requests carrying it without the gateway-service-token bearer. The bearer is therefore hoisted out of the sticky conditional alongside the account header; sticky-specific state (`X-MacProvider-Internal-Conv`) remains sticky-gated.
 
@@ -2320,7 +2320,7 @@ The `audit_events` table MUST record:
 - every capacity tier transition, including signal state and audit-event chain.
 - every budget cap mutation.
 
-`usage_events` and `audit_events` MUST use the gateway `X-Request-ID` UUID v4 as the request row key for request-scoped entries. All request-scoped log surfaces that flow through the gateway MUST include the same `X-Request-ID`.
+`usage_events` and `audit_events` MUST use the gateway `X-Request-ID` UUID v4 as the request correlation value for request-scoped entries. The physical row identity is the composite `(account_id, request_id)` (per #196); `request_id` alone is a logical join key, ambiguous on cross-account collisions. All request-scoped log surfaces that flow through the gateway MUST include the same `X-Request-ID`; uniqueness assertions and reconciliation joins MUST be account-scoped.
 
 Events are append-only, immutable, and queryable through `/admin/audit-log` with operator-key authentication.
 

--- a/specs/SPEC-006-buyer-api.md
+++ b/specs/SPEC-006-buyer-api.md
@@ -1,7 +1,37 @@
 # SPEC-006 - Buyer API Gateway: Mac Provider's first public buyer surface
 
-**Version:** 0.9 (2026-06-22, SPEC-015 v0.1.3 receipt response-header allowlist absorption)
-**Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.3.4, SPEC-003 v0.7, SPEC-004 v0.2
+**Version:** 0.9.1 (2026-06-29, ISS-211 normative forward-header addition: X-MacProvider-Account on the non-sticky routing path)
+**Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.0, SPEC-003 v0.7, SPEC-004 v0.2
+
+**Change log v0.9.1 (2026-06-29, issue #211):**
+- Gateway MUST forward `X-MacProvider-Account: <subject.AccountID>` on
+  every forwarded buyer request — both the sticky and non-sticky
+  routing paths. The pre-v0.9.1 gateway emitted this header only
+  inside the sticky-routing conditional, leaving the non-sticky hot
+  path account-blind; the coordinator could not attribute the
+  resulting `request_log` row to the gateway account, breaking the
+  composite `(account_id, external_request_id)` reconciliation key
+  introduced in SPEC-002 v1.5.0. Bearer subjects forward
+  `subject.AccountID = authn.Bearer.AccountID`; demo subjects
+  forward `subject.AccountID = "demo:" + authn.DemoPayload.IP`.
+- Gateway MUST pair `X-MacProvider-Account` with the upstream
+  `Authorization: Bearer <UpstreamCoordinatorBearer>` header on
+  every forward. The coordinator treats `X-MacProvider-Account` as
+  an internal-routing header (see
+  `phase4-coordinator/internal/buyer/server.go`
+  `hasInternalRoutingHeader` / `internalBearerAuthorized` /
+  `selectProviderExcluding`) and rejects buyer-port requests
+  carrying it without the gateway-service-token bearer with
+  `400 invalid_request`. Pre-v0.9.1 only the sticky path set the
+  bearer (because only the sticky path set the account header);
+  v0.9.1 hoists both together. Sticky-specific state — the
+  `X-MacProvider-Internal-Conv` conversation key — remains gated
+  by the sticky conditional and is still suppressed for demo
+  traffic. (Caught by the issue-#211 R1 security audit; without
+  this pairing every non-sticky chat would 400 against any
+  v0.9.x+-aware coordinator.)
+- Dependency bump SPEC-002 v1.3.4 → v1.5.0 to record the
+  coordinator-side composite-key contract.
 
 **Change log v0.9:**
 - SPEC-015 v0.1.3 absorption: adds `X-MacProvider-Receipt` to the
@@ -875,7 +905,11 @@ on all responses.
 
 The gateway MUST generate a UUID v4 `X-Request-ID` per buyer-incoming request and use it as the row key in `usage_events` and `audit_events`.
 
-The gateway MUST forward `X-Request-ID: <uuid>` to the coordinator on every forwarded buyer request. SPEC-002 v1.1.4 requires the coordinator to honor that ID in `request_log`; this is the cross-service join key for gateway usage/audit events and coordinator routing diagnostics.
+The gateway MUST forward `X-Request-ID: <uuid>` to the coordinator on every forwarded buyer request. SPEC-002 v1.1.4 requires the coordinator to honor that ID in `request_log.external_request_id`; SPEC-002 v1.5.0 adds the composite-key requirement below.
+
+The gateway MUST also forward `X-MacProvider-Account: <subject.AccountID>` on every forwarded buyer request — bearer-authenticated and demo subjects alike, both on the sticky and non-sticky routing paths. The coordinator persists this value into `request_log.account_id`. The composite `(account_id, external_request_id)` is the reconciliation key joining gateway `usage_events` to coordinator `request_log`; the gateway therefore MUST NOT gate `X-MacProvider-Account` on the sticky-routing conditional (pre-v0.9.1 gateways did, leaving the non-sticky hot path account-blind). See SPEC-002 v1.5.0 §7.2 for the coordinator-side contract and SPEC-007 §6.4 v0.2.1 for the gateway-side composite-PK addendum.
+
+The gateway MUST pair `X-MacProvider-Account` with the upstream `Authorization: Bearer <UpstreamCoordinatorBearer>` header on every forward. The coordinator's `selectProviderExcluding` treats `X-MacProvider-Account` as an internal-routing header and `400`s buyer-port requests carrying it without the gateway-service-token bearer. The bearer is therefore hoisted out of the sticky conditional alongside the account header; sticky-specific state (`X-MacProvider-Internal-Conv`) remains sticky-gated.
 
 The gateway MAY accept an inbound `X-Request-ID` only if it is a UUID v4 in 8-4-4-4-12 lowercase or uppercase hex format; otherwise it MUST generate its own.
 


### PR DESCRIPTION
## Summary

Coordinator-side counterpart to #196. After #196 fixed the
gateway's `usage_events` PK to `(account_id, request_id)`,
coordinator `request_log` still used `external_request_id`
alone as the reconciliation key. An auditor reconciling
gateway's two-row case for the same `request_id` could not
determine from `coordinator/request_log` which gateway account
each coordinator row served — both gateway accounts collided
on the buyer-controlled UUID, but coordinator stored only one
`external_request_id` with no account scope.

This PR is **Option A** from the issue body: add `account_id`
to coordinator `request_log`, change the reconciliation key
to `(account_id, external_request_id)`, propagate the
gateway's `account_id` to the coordinator on every forwarded
request.

The hot money-path implication caught during audit: the
coordinator's `hotpath.go` AttemptN derivation
(`SELECT COUNT(*) FROM request_log WHERE request_id = ?`) and
`recovery.go` reconciliation subqueries were already
vulnerable to the same #196 cross-account-collision class on
the credit-counting side — both are scoped here too.

## What changed

**SPEC-002 v1.5.0** (`specs/SPEC-002-coordinator.md`):
- `request_log` gains `account_id TEXT NULL`.
- Reconciliation key is the composite `(account_id, external_request_id)`.
- New partial-NULL composite index built via
  `coordinator migrate-indexes`.
- Money-path scope rule for `AttemptN` derivation.
- Deploy ordering with row-level rollback safety (gate on
  `account_id IS NOT NULL`, not `PRAGMA table_info`).
- §10 D11 cross-service correlation contract refreshed.

**SPEC-006 v0.9.1** (`specs/SPEC-006-buyer-api.md`):
- Gateway MUST forward `X-MacProvider-Account` on every
  forwarded buyer request — sticky and non-sticky paths,
  bearer and demo subjects.
- Gateway MUST pair the account header with the upstream
  `Authorization: Bearer <UpstreamCoordinatorBearer>` on
  every forward (coordinator gates the account header behind
  `internalBearerAuthorized`).

**Coordinator IMPL** (`phase4-coordinator/`):
- `requestlog/store.go`: column + migration + Row + insert +
  partial-NULL index.
- `buyer/server.go`: `sanitizeAccountID` helper, reads header
  in `handleChatCompletions`, plumbs through
  `newBillingRecorder`.
- `buyer/billing_recorder.go`: `accountID` field, populated
  into every `Row{}` write.
- `billing/hotpath.go`: AttemptN COUNT scopes by
  `(account_id, request_id)` when non-empty.
- `billing/recovery.go`: orphan-detection + prior-attempt +
  same_request_count subqueries scope by
  `(account_id, request_id)` via SQLite `IS` (NULL = NULL
  preserves legacy clustering).

**Gateway IMPL** (`phase5-gateway/`):
- `router/chat_proxy.go`: hoists `X-MacProvider-Account` AND
  upstream `Authorization` bearer out of the sticky-routing
  conditional. Sticky-specific state
  (`X-MacProvider-Internal-Conv`) remains sticky-gated.

## Regression tests

- `TestWriteHotPath_AccountScopedRequestIDCollisionDoesNotQuarantine`
  — hot-path: cross-account `request_id` collision no longer
  triggers `ambiguous_attempt_n` quarantine.
- `TestRecoverLedger_AccountScopedRequestIDCollisionDoesNotQuarantine`
  — recovery path: same property under startup/nightly
  reconciliation.
- `TestWriteHotPath_DuplicateRequestIDWithoutRetryQuarantinesAttempt`
  still passes — legacy unscoped behavior preserved when
  both rows have empty `account_id`.
- Gateway `TestProviderPinningHeadersStripped`: positive
  assertion on the non-sticky hot path that
  `X-MacProvider-Account` is now forwarded.
- Gateway `TestStickyConversationIgnoredForDemoTraffic`:
  updated to expect demo account header + bearer; sticky-
  specific `Internal-Conv` still guarded suppressed.
- Gateway `TestStrangerKeyOpenAIChatUsageFlow`: integration
  Authorization assertion now expects the upstream bearer
  (not the buyer `mp_` key).

## Audit trail

Three-lane codex audit on R1 (code / security / architect).
Prompts and R2 disposition:

- `specs/AUDIT_ISS_211_R1_CODE_PROMPT.md`
- `specs/AUDIT_ISS_211_R1_SECURITY_PROMPT.md`
- `specs/AUDIT_ISS_211_R1_ARCHITECT_PROMPT.md`
- `specs/SPEC-002-v1-5-0-audit.md` (findings + R2 dispositions)

R1 surfaced **0 code findings**, **1 HIGH (security)**, and
**1 HIGH + 4 MEDIUM (architect)**. All six fixed in R2:

- Security HIGH: bearer-pairing with the account header so
  non-sticky chats don't 400 against the coordinator's
  internal-bearer gate.
- Architect HIGH: extended the account-scope fix to
  `RecoverLedger` SQL subqueries (the parallel money-path
  class).
- Architect MEDIUMs: row-level rollback gate; merge-order-safe
  cross-PR pointers; explicit explorer deferral with
  follow-up ticket suggestion; §10 D11 refresh.

## Sibling PR

- #221 (issue #212) — SPEC-007 §6.4 v0.2.1 composite-PK
  addendum (gateway-side documentation catch-up to #196).
  This PR's text is merge-order independent with #221.

## Test plan

- [ ] Review `phase4-coordinator/internal/billing/hotpath.go`
      scoping vs SPEC-002 v1.5.0 money-path rule.
- [ ] Review `phase4-coordinator/internal/billing/recovery.go`
      SQLite `IS` semantics for the prior/same scoping.
- [ ] Review `phase5-gateway/internal/router/chat_proxy.go`
      hoisted Authorization + X-MacProvider-Account pair vs
      SPEC-006 v0.9.1 contract.
- [ ] Confirm deploy ordering note (coordinator first; auditor
      tooling gates on `account_id IS NOT NULL` per-row) is
      sufficient for the team's reconciliation tooling.
- [ ] Confirm explorer deferral is the right scope call
      (alternative: include explorer enrichment in this PR).

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
