### PR TITLE
fix(harness): I1 drift uses per-pair, not aggregate sums (closes #226)

### DIFF
--- a/test/network-harness/README.md
+++ b/test/network-harness/README.md
@@ -38,11 +38,27 @@ We are in phase A.
 These fail the run (exit 10) regardless of any contract:
 
 - **I1** — billing-ledger reconciliation drift == 0
-  (no harness-successful request missing on coordinator request_log or gateway usage_events; coordinator and gateway agree on completion tokens)
+  (per-matched-pair semantics since #226; the `drift_basis` field in
+  `ledger_reconcile.json` pins which algorithm produced the sums.
+  I1 fails on any of:
+    1. unmatched harness successes (`UnmatchedSuccesses`),
+    2. unmatched gateway "ok" rows (`UnmatchedGatewayOKRows`),
+    3. unmatched coord 2xx rows (`UnmatchedCoordinator2xxRows`),
+    4. gateway-ok pairs with no coord row (`MatchedCoordMissing`;
+       fallback outcomes legitimately lack coord rows and are excluded),
+    5. positive gateway-vs-harness overbill across pairs
+       (`GatewayOverbillVsHarnessTokens` > 0; only "ok" outcomes — fallback
+       pairs are excluded per F-8 SSE-undercount artifact, see issue #232),
+    6. absolute gateway-vs-coord mismatch across pairs
+       (`AbsGatewayCoordinatorMismatchTokens` > 0; both directions, since
+       gateway and coord are both settlement systems and must agree).
+  Gateway-vs-harness underbill alone is allowed — gateway-side streaming
+  rounding is legitimate.)
 - **I2** — no 5xx response without a billing settlement entry
   (gateway must echo a request id on every 5xx; orphaning is a billing-bypass risk)
 - **I3** — no charged-tokens > delivered-tokens
-  (phase-A structural check; the DB-level overcharge signal lives in `ledger_reconcile.json` → `token_mismatches`)
+  (phase-A structural check; the DB-level overcharge signal lives in
+  `ledger_reconcile.json` → `overbilled_pairs` and `gateway_overbill_*_tokens`)
 - **I4** — no silent hang
   (a streaming response that stays open past `silent_hang_threshold` with no bytes and no `data: [DONE]` is a UX failure regardless of what the contract says about latency)
 

--- a/test/network-harness/internal/invariants/hard.go
+++ b/test/network-harness/internal/invariants/hard.go
@@ -62,19 +62,30 @@ func Evaluate(sc *scenario.Scenario, results []buyer.Result, summary *metrics.Su
 // I1 — ledger reconciliation drift must be zero. Verified live
 // 2026-06-27: gateway and coordinator use SEPARATE request_id spaces
 // (a gateway UUID and a coord UUID never overlap), so we correlate by
-// (model, completion_tokens, ts ± window) plus aggregate-sum checks.
+// (model, completion_tokens, ts ± window).
 //
-// Drift here means:
-//   * a harness success had no matching gateway row in the window
-//     (unmatched_successes) — billing-bypass risk
-//   * gateway and coordinator disagree on summed completion_tokens
-//     for the window — money-path drift
-//   * gateway over-billed vs what harness observed on the wire —
-//     overcharge
+// Since #226 + #229 R4, drift is computed PER MATCHED PAIR (not as
+// aggregate population sums — which false-fired when most gateway
+// settlements landed as SPEC-006 §17.7 fallback outcomes). The
+// reconciler stamps drift_basis="per_matched_pair_v2" so artifact
+// consumers know what algorithm produced the numbers.
 //
-// Extra gateway rows beyond the harness's count are RECORDED (as
-// reconcile.Notes) but NOT counted as drift in phase A — they are
-// expected when other live buyers fire concurrently.
+// Drift here means ANY of:
+//   * harness success unmatched on gateway (UnmatchedSuccesses) —
+//     billing-bypass risk
+//   * gateway "ok"-outcome row unmatched on any harness success
+//     (UnmatchedGatewayOKRows) — orphan/leaked settlement or
+//     concurrent buyer traffic
+//   * gateway "ok" matched pair with no coord row (MatchedCoordMissing)
+//     — fallback outcomes legitimately lack coord rows and are NOT
+//     flagged here
+//   * gateway over-billed vs harness across matched pairs
+//     (GatewayOverbillVsHarnessTokens > 0, positive-only sum so a
+//     +N overbill is not hidden by a -N underbill). Underbill alone
+//     is allowed — gateway-side streaming rounding is legitimate.
+//   * gateway and coord disagree on per-pair tokens in EITHER direction
+//     (AbsGatewayCoordinatorMismatchTokens > 0) — both are settlement
+//     systems and must agree on per-request token counts.
 func checkI1(ledger *reconcile.Result) Check {
 	c := Check{ID: "I1", Title: "billing-ledger reconciliation drift == 0"}
 	if ledger == nil {
@@ -83,29 +94,47 @@ func checkI1(ledger *reconcile.Result) Check {
 		return c
 	}
 
-	gwVsCoord := ledger.GatewayMinusCoordinatorTokens
-	gwVsHarness := ledger.GatewayMinusHarnessTokens
+	// I1 reads matched-pair drift produced by the reconciler under
+	// drift_basis="per_matched_pair_v2" (#226 + #229 R2). Five signals:
+	//   - harness successes unmatched on gateway (missing settlement)
+	//   - gateway-ok rows unmatched on the harness side (orphan settlement)
+	//   - matched gateway-ok pairs with no coord row (suspicious; fallback
+	//     outcomes legitimately lack coord rows and are excluded upstream)
+	//   - gateway-vs-harness positive overbill across pairs (signed-safe;
+	//     underbill alone is allowed per streaming rounding semantics)
+	//   - gateway-vs-coord absolute mismatch (any direction; both are
+	//     settlement systems and MUST agree on per-pair token counts)
+	gwOverbillVsHarness := ledger.GatewayOverbillVsHarnessTokens
+	absGwCoordMismatch := ledger.AbsGatewayCoordinatorMismatchTokens
 	unmatched := len(ledger.UnmatchedSuccesses)
+	unmatchedGwOK := len(ledger.UnmatchedGatewayOKRows)
+	unmatchedCoord2xx := len(ledger.UnmatchedCoordinator2xxRows)
+	coordMissingOK := len(ledger.MatchedCoordMissing)
 
 	driftSignals := 0
 	if unmatched > 0 {
 		driftSignals++
 	}
-	if gwVsCoord != 0 {
+	if unmatchedGwOK > 0 {
 		driftSignals++
 	}
-	if gwVsHarness > 0 {
-		// Gateway billed MORE than harness saw on the wire — overcharge.
-		// gwVsHarness < 0 (gateway billed less) is acceptable on streaming
-		// where chunks the harness counted may not all hit the usage_events
-		// settlement (legitimate gateway-side rounding).
+	if unmatchedCoord2xx > 0 {
+		driftSignals++
+	}
+	if coordMissingOK > 0 {
+		driftSignals++
+	}
+	if gwOverbillVsHarness > 0 {
+		driftSignals++
+	}
+	if absGwCoordMismatch > 0 {
 		driftSignals++
 	}
 
 	if driftSignals == 0 {
 		c.Passed = true
-		c.Detail = fmt.Sprintf("reconciled cleanly: harness=%d ok, gw=%d ok, coord=%d 2xx; token sums all equal at %d",
-			ledger.HarnessSuccessful, ledger.GatewayRowsOK, ledger.CoordinatorRows2xx, ledger.HarnessCompletionTokens)
+		c.Detail = fmt.Sprintf("reconciled cleanly: harness=%d ok, gw=%d ok, coord=%d 2xx; %d matched pairs, no overbills (per_matched_pair_v2 basis)",
+			ledger.HarnessSuccessful, ledger.GatewayRowsOK, ledger.CoordinatorRows2xx, len(ledger.MatchedSuccesses))
 		return c
 	}
 
@@ -115,16 +144,28 @@ func checkI1(ledger *reconcile.Result) Check {
 	if unmatched > 0 {
 		parts = append(parts, fmt.Sprintf("%d harness successes unmatched on gateway", unmatched))
 	}
-	if gwVsCoord != 0 {
-		parts = append(parts, fmt.Sprintf("gateway-coord token drift=%d", gwVsCoord))
+	if unmatchedGwOK > 0 {
+		parts = append(parts, fmt.Sprintf("%d gateway-ok rows unmatched by any harness success", unmatchedGwOK))
 	}
-	if gwVsHarness > 0 {
-		parts = append(parts, fmt.Sprintf("gateway over-billed by %d vs harness-observed", gwVsHarness))
-	} else if gwVsHarness < 0 {
-		parts = append(parts, fmt.Sprintf("(note: gateway billed %d fewer than harness-observed; allowed)", -gwVsHarness))
+	if unmatchedCoord2xx > 0 {
+		parts = append(parts, fmt.Sprintf("%d coord 2xx rows unmatched by any harness success", unmatchedCoord2xx))
+	}
+	if coordMissingOK > 0 {
+		parts = append(parts, fmt.Sprintf("%d gateway-ok matched pairs with no coord row", coordMissingOK))
+	}
+	if gwOverbillVsHarness > 0 {
+		parts = append(parts, fmt.Sprintf("gateway over-billed by %d vs harness across %d pair(s)", gwOverbillVsHarness, len(ledger.OverbilledPairs)))
+	}
+	if absGwCoordMismatch > 0 {
+		parts = append(parts, fmt.Sprintf("gateway-coord ledger mismatch %d tokens across %d pair(s)", absGwCoordMismatch, len(ledger.GatewayCoordMismatchedPairs)))
 	}
 	c.Detail = strings.Join(parts, "; ")
 	c.OffendingIDs = append(c.OffendingIDs, ledger.UnmatchedSuccesses...)
+	c.OffendingIDs = append(c.OffendingIDs, ledger.UnmatchedGatewayOKRows...)
+	c.OffendingIDs = append(c.OffendingIDs, ledger.UnmatchedCoordinator2xxRows...)
+	c.OffendingIDs = append(c.OffendingIDs, ledger.OverbilledPairs...)
+	c.OffendingIDs = append(c.OffendingIDs, ledger.MatchedCoordMissing...)
+	c.OffendingIDs = append(c.OffendingIDs, ledger.GatewayCoordMismatchedPairs...)
 	return c
 }
 
@@ -206,7 +247,7 @@ func checkI3(results []buyer.Result) Check {
 	}
 	if len(offenders) == 0 {
 		c.Passed = true
-		c.Detail = "no overcharges observed (phase A: structural check only; reconcile.token_mismatches carries the DB-level signal)"
+		c.Detail = "no overcharges observed (phase A: structural check only; reconcile.OverbilledPairs + GatewayOverbillVsHarnessTokens carry the DB-level signal)"
 		return c
 	}
 	c.Passed = false

--- a/test/network-harness/internal/invariants/hard_test.go
+++ b/test/network-harness/internal/invariants/hard_test.go
@@ -1,0 +1,164 @@
+// Tests for I1's consumption of the reconciler's per-pair drift signals
+// (#229 R4 audit MEDIUM). The reconciler-layer tests in
+// internal/reconcile/ verify that the drift fields are computed
+// correctly; these tests verify that I1 INTERPRETS them correctly,
+// catching every failure mode and PASSing on a clean run.
+package invariants
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-network-harness/internal/reconcile"
+)
+
+func TestCheckI1_CleanRun_AllSignalsZero(t *testing.T) {
+	ledger := &reconcile.Result{
+		HarnessSuccessful:  10,
+		GatewayRowsOK:      10,
+		CoordinatorRows2xx: 10,
+		MatchedSuccesses:   []reconcile.MatchedPair{{}, {}, {}, {}, {}, {}, {}, {}, {}, {}},
+	}
+	c := checkI1(ledger)
+	if !c.Passed {
+		t.Fatalf("clean run should pass, got fail: %s", c.Detail)
+	}
+	if !strings.Contains(c.Detail, "per_matched_pair_v2") {
+		t.Errorf("pass detail should advertise drift basis: %s", c.Detail)
+	}
+}
+
+func TestCheckI1_NoReconcile_Skips(t *testing.T) {
+	c := checkI1(nil)
+	if !c.Skipped {
+		t.Errorf("nil ledger should SKIP, got: %s", c.Detail)
+	}
+}
+
+func TestCheckI1_UnmatchedHarnessSuccess_Fails(t *testing.T) {
+	ledger := &reconcile.Result{
+		UnmatchedSuccesses: []string{"h1", "h2"},
+	}
+	c := checkI1(ledger)
+	if c.Passed {
+		t.Fatal("should fail on unmatched harness successes")
+	}
+	if !strings.Contains(c.Detail, "unmatched on gateway") {
+		t.Errorf("detail should call out unmatched, got: %s", c.Detail)
+	}
+	if !contains(c.OffendingIDs, "h1") || !contains(c.OffendingIDs, "h2") {
+		t.Errorf("offending ids should include unmatched: %v", c.OffendingIDs)
+	}
+}
+
+func TestCheckI1_OrphanCoord2xx_Fails(t *testing.T) {
+	ledger := &reconcile.Result{
+		UnmatchedCoordinator2xxRows: []string{"COORD_ORPHAN"},
+	}
+	c := checkI1(ledger)
+	if c.Passed {
+		t.Fatal("should fail on orphan coord 2xx rows")
+	}
+	if !contains(c.OffendingIDs, "COORD_ORPHAN") {
+		t.Errorf("offending ids should include orphan coord id: %v", c.OffendingIDs)
+	}
+}
+
+func TestCheckI1_OrphanGatewayOK_Fails(t *testing.T) {
+	ledger := &reconcile.Result{
+		UnmatchedGatewayOKRows: []string{"GW_ORPHAN"},
+	}
+	c := checkI1(ledger)
+	if c.Passed {
+		t.Fatal("should fail on orphan gateway-ok rows")
+	}
+	if !contains(c.OffendingIDs, "GW_ORPHAN") {
+		t.Errorf("offending ids should include orphan id: %v", c.OffendingIDs)
+	}
+}
+
+func TestCheckI1_CoordMissingOnOK_Fails(t *testing.T) {
+	ledger := &reconcile.Result{
+		MatchedCoordMissing: []string{"h_OK_no_coord"},
+	}
+	c := checkI1(ledger)
+	if c.Passed {
+		t.Fatal("should fail when gateway-ok pair has no coord row")
+	}
+	if !strings.Contains(c.Detail, "no coord row") {
+		t.Errorf("detail should call out coord-missing: %s", c.Detail)
+	}
+}
+
+func TestCheckI1_GatewayOverbillVsHarness_Fails(t *testing.T) {
+	ledger := &reconcile.Result{
+		GatewayOverbillVsHarnessTokens: 10,
+		OverbilledPairs:                []string{"OVERBILLED"},
+	}
+	c := checkI1(ledger)
+	if c.Passed {
+		t.Fatal("should fail on gateway-vs-harness overbill")
+	}
+	if !contains(c.OffendingIDs, "OVERBILLED") {
+		t.Errorf("offending should include overbilled pair: %v", c.OffendingIDs)
+	}
+}
+
+// CRITICAL regression: gateway-vs-coord undercharge (gateway billed
+// LESS than coord) was missed pre-#229 R2. Verify checkI1 catches it
+// via the abs-mismatch signal.
+func TestCheckI1_CoordOverbill_Fails(t *testing.T) {
+	ledger := &reconcile.Result{
+		AbsGatewayCoordinatorMismatchTokens: 10,
+		GatewayCoordMismatchedPairs:         []string{"MISMATCH"},
+	}
+	c := checkI1(ledger)
+	if c.Passed {
+		t.Fatal("should fail on absolute gateway-coord mismatch (either direction)")
+	}
+	if !strings.Contains(c.Detail, "gateway-coord ledger mismatch") {
+		t.Errorf("detail should call out gw-coord mismatch: %s", c.Detail)
+	}
+}
+
+// Allowed: gateway billed FEWER tokens than harness observed (streaming
+// rounding). NetGatewayMinusHarnessTokens can be negative without
+// failing I1 — only the positive-overbill sum is the headline gate.
+func TestCheckI1_HarnessUnderbillAlone_Passes(t *testing.T) {
+	ledger := &reconcile.Result{
+		HarnessSuccessful:                10,
+		GatewayRowsOK:                    10,
+		CoordinatorRows2xx:               10,
+		MatchedSuccesses:                 []reconcile.MatchedPair{{}, {}, {}, {}, {}, {}, {}, {}, {}, {}},
+		NetGatewayMinusHarnessTokens:     -5, // underbill only
+		GatewayOverbillVsHarnessTokens:   0,
+	}
+	c := checkI1(ledger)
+	if !c.Passed {
+		t.Errorf("underbill alone should not fail I1: %s", c.Detail)
+	}
+}
+
+// Net-zero with hidden overbill: +10 in one pair, -10 in another → Net
+// = 0 but positive-overbill = 10. Must fail. This is the CRITICAL the
+// R1 audit caught.
+func TestCheckI1_NetZeroButHiddenOverbill_Fails(t *testing.T) {
+	ledger := &reconcile.Result{
+		NetGatewayMinusHarnessTokens:   0,  // cancels to zero
+		GatewayOverbillVsHarnessTokens: 10, // but one pair really overbilled
+		OverbilledPairs:                []string{"hidden"},
+	}
+	c := checkI1(ledger)
+	if c.Passed {
+		t.Fatal("net-zero must not hide per-pair overbill — this is the headline #229 R1 CRITICAL")
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/test/network-harness/internal/reconcile/ledger.go
+++ b/test/network-harness/internal/reconcile/ledger.go
@@ -63,7 +63,12 @@ type Result struct {
 	MatchedSuccesses   []MatchedPair `json:"matched_successes"`
 	UnmatchedSuccesses []string      `json:"unmatched_successes"`
 
-	// Drift signals (signed differences, positive = side has more).
+	// Drift signals — summed across MATCHED PAIRS only (not aggregate
+	// totals across populations of different sizes). Issue #226 fix:
+	// when most gateway settlements classify as SPEC-006 §17.7 fallback
+	// outcomes, aggregate-sum drift is population-mismatched and
+	// spuriously non-zero. Per-pair drift is the honest signal.
+	// Positive = side has more tokens than its counterpart in matched pairs.
 	GatewayMinusCoordinatorTokens int64 `json:"gateway_minus_coordinator_tokens"`
 	GatewayMinusHarnessTokens     int64 `json:"gateway_minus_harness_tokens"`
 
@@ -155,10 +160,8 @@ func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Ti
 		}
 	}
 
-	r.GatewayMinusCoordinatorTokens = r.GatewayCompletionTokens - r.CoordinatorCompletionTokens
-	r.GatewayMinusHarnessTokens = r.GatewayCompletionTokens - r.HarnessCompletionTokens
-
 	matchByFuzzy(r, results, gwRows, coordRows)
+	computePerPairDrift(r)
 
 	// Background-traffic note: extra rows beyond the harness's count
 	// likely belong to other buyers on the live network. Recorded as a
@@ -169,6 +172,31 @@ func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Ti
 			fmt.Sprintf("gateway has %d more rows than harness fired — likely concurrent live traffic", extraGw))
 	}
 	return r, nil
+}
+
+// computePerPairDrift sums the token deltas across matched (harness,
+// gateway, coord) triples. Replaces the earlier aggregate-sum approach
+// which subtracted gateway-ok-only token totals from full-harness-ok
+// totals — a population-mismatch that produced spurious non-zero drift
+// whenever the gateway settled most successful streams as SPEC-006
+// §17.7 fallback outcomes (stream_truncated, stream_output_exceeded,
+// upstream_error). See issue #226 for the 2026-06-29 production trip.
+//
+// Drift definitions (positive = side has more in matched pairs):
+//   - GatewayMinusHarnessTokens: Σ(gateway - harness) over matched pairs
+//   - GatewayMinusCoordinatorTokens: Σ(gateway - coord) over pairs with
+//     a coord-side match (some matches lack a coord row, e.g. when the
+//     coord 2xx for the request fell outside the SQL window).
+//
+// Unmatched harness successes are NOT counted here — they show up
+// independently as r.UnmatchedSuccesses, which I1 inspects separately.
+func computePerPairDrift(r *Result) {
+	for _, p := range r.MatchedSuccesses {
+		r.GatewayMinusHarnessTokens += p.GatewayCompletionTokens - p.HarnessCompletionTokens
+		if p.CoordinatorRequestID != "" {
+			r.GatewayMinusCoordinatorTokens += p.GatewayCompletionTokens - p.CoordinatorCompletionTokens
+		}
+	}
 }
 
 // matchByFuzzy pairs each harness success with the most likely gateway

--- a/test/network-harness/internal/reconcile/ledger.go
+++ b/test/network-harness/internal/reconcile/ledger.go
@@ -32,6 +32,13 @@ import (
 )
 
 type Result struct {
+	// DriftBasis identifies the algorithm the drift fields below use.
+	// Pinned to "per_matched_pair_v2" since issue #226 — earlier artifacts
+	// (pre-#229) carry no field and were aggregate-population sums, which
+	// false-fired on fallback-heavy runs. Triage tooling that compares
+	// `gateway_minus_*` across versions MUST gate on this value.
+	DriftBasis string `json:"drift_basis"`
+
 	WindowStartUTC time.Time `json:"window_start_utc"`
 	WindowEndUTC   time.Time `json:"window_end_utc"`
 
@@ -47,12 +54,12 @@ type Result struct {
 	GatewayRowsFallback int `json:"gateway_rows_fallback"`
 	GatewayRowsNotOK    int `json:"gateway_rows_not_ok"`
 
-	// Aggregate token sums (over the same window). A clean reconcile has
-	// HarnessCompletionTokens == GatewayCompletionTokens == CoordinatorCompletionTokens.
-	// Fallback rows (stream_truncated/malformed/output_exceeded/upstream_error)
-	// are tracked separately because the coordinator has no settlement
-	// row for them (provider died mid-stream) and the harness SSE parser
-	// is known to undercount (F-8); gateway is the truth-of-record there.
+	// Aggregate token sums (over the same window). REFERENCE ONLY — these
+	// are NOT drift inputs. Issue #226 surfaced that aggregating across
+	// gateway-ok-only rows vs all-harness-ok rows is population-mismatched
+	// when most gateway settlements land as SPEC-006 §17.7 fallback
+	// outcomes. The drift fields below use per-pair sums instead. Future
+	// engineers: do not re-introduce aggregate-sum drift.
 	HarnessCompletionTokens         int64 `json:"harness_completion_tokens"`
 	GatewayCompletionTokens         int64 `json:"gateway_completion_tokens"`
 	GatewayCompletionTokensFallback int64 `json:"gateway_completion_tokens_fallback"`
@@ -63,14 +70,67 @@ type Result struct {
 	MatchedSuccesses   []MatchedPair `json:"matched_successes"`
 	UnmatchedSuccesses []string      `json:"unmatched_successes"`
 
-	// Drift signals — summed across MATCHED PAIRS only (not aggregate
-	// totals across populations of different sizes). Issue #226 fix:
-	// when most gateway settlements classify as SPEC-006 §17.7 fallback
-	// outcomes, aggregate-sum drift is population-mismatched and
-	// spuriously non-zero. Per-pair drift is the honest signal.
-	// Positive = side has more tokens than its counterpart in matched pairs.
-	GatewayMinusCoordinatorTokens int64 `json:"gateway_minus_coordinator_tokens"`
-	GatewayMinusHarnessTokens     int64 `json:"gateway_minus_harness_tokens"`
+	// UnmatchedGatewayOKRows lists gateway settlement rows with outcome="ok"
+	// that did NOT match any harness success. These represent either
+	// orphan / leaked gateway settlements (real bugs) or concurrent
+	// background traffic from other buyers; triage decides. Fallback-
+	// outcome leftovers are EXCLUDED here because they're noisy on a
+	// live network.
+	UnmatchedGatewayOKRows []string `json:"unmatched_gateway_ok_rows,omitempty"`
+
+	// UnmatchedCoordinator2xxRows lists coord request_log rows with
+	// 2xx status that did NOT match any harness success. Symmetric with
+	// UnmatchedGatewayOKRows on the coordinator side: orphan settlement
+	// or concurrent traffic. #229 R5 security HIGH — without this signal,
+	// a run with 100 clean matched pairs + 1 extra coord 2xx row leaves
+	// every drift signal at zero (the leftover coord row stays invisible).
+	UnmatchedCoordinator2xxRows []string `json:"unmatched_coordinator_2xx_rows,omitempty"`
+
+	// MatchedCoordMissing lists matched-pair harness request_ids where the
+	// gateway row has outcome="ok" but no coordinator request_log row was
+	// found in the window. This is suspicious for "ok" outcomes — a
+	// successfully-billed request should leave a coord trail. Fallback
+	// outcomes legitimately lack a coord row (provider died mid-stream)
+	// and are NOT included here.
+	MatchedCoordMissing []string `json:"matched_coord_missing,omitempty"`
+
+	// Drift signals — summed across MATCHED PAIRS only. The fields below
+	// supersede aggregate-population subtraction (#226). Positive =
+	// gateway has more tokens than its counterpart in the matched pair.
+	//
+	// NetGatewayMinus* is the signed sum; it can ride on zero when a
+	// +N overbill and -N underbill cancel. Triage should NOT use it
+	// as the headline pass/fail signal — use PositiveOverbillTokens
+	// and OverbilledPairs which preserve per-pair detection.
+	NetGatewayMinusCoordinatorTokens int64 `json:"net_gateway_minus_coordinator_tokens"`
+	NetGatewayMinusHarnessTokens     int64 `json:"net_gateway_minus_harness_tokens"`
+
+	// Gateway-vs-Harness positive overbill: I1 headline signal for this
+	// axis. Sums per-pair (gateway − harness) where gateway > harness.
+	// Underbill alone is allowed because gateway-side streaming rounding
+	// can legitimately undercount vs the harness's SSE byte timeline.
+	// Positive-only means a +N overbill is not hidden behind a −N
+	// underbill (#229 R1 CRITICAL).
+	GatewayOverbillVsHarnessTokens int64    `json:"gateway_overbill_vs_harness_tokens"`
+	OverbilledPairs                []string `json:"overbilled_pairs,omitempty"` // harness request_ids of overbilled pairs
+
+	// Gateway-vs-Coordinator positive overbill: REFERENCE ONLY for triage.
+	// Both gateway and coord are settlement systems and MUST agree on
+	// per-pair tokens, so I1's headline signal for this axis is the
+	// directional-agnostic AbsGatewayCoordinatorMismatchTokens below —
+	// NOT this positive-only sum. Kept in the artifact for diagnostic
+	// readability (per-axis breakdown of which side has more tokens).
+	GatewayOverbillVsCoordinatorTokens int64 `json:"gateway_overbill_vs_coordinator_tokens"`
+
+	// Gateway-vs-Coordinator absolute mismatch: I1 headline signal for
+	// this axis. Sum of |gateway − coord| across matched pairs (#229 R2
+	// HIGH). Unlike gateway-vs-harness — where streaming rounding makes
+	// underbill legit — gateway and coordinator are both settlement
+	// systems and MUST agree on per-request token counts. Any direction
+	// of mismatch is a money-path ledger inconsistency. I1 fails on
+	// non-zero.
+	AbsGatewayCoordinatorMismatchTokens int64    `json:"abs_gateway_coordinator_mismatch_tokens"`
+	GatewayCoordMismatchedPairs         []string `json:"gateway_coord_mismatched_pairs,omitempty"`
 
 	// Notes records discoveries that don't fit a drift count but matter
 	// for triage — e.g. extra rows attributable to background traffic.
@@ -85,6 +145,7 @@ type MatchedPair struct {
 	HarnessCompletionTokens     int64  `json:"harness_completion_tokens"`
 	GatewayRequestID            string `json:"gateway_request_id"`
 	GatewayCompletionTokens     int64  `json:"gateway_completion_tokens"`
+	GatewayOutcome              string `json:"gateway_outcome"` // "ok" or SPEC-006 §17.7 fallback name; distinguishes coord-missing severity
 	CoordinatorRequestID        string `json:"coordinator_request_id,omitempty"`
 	CoordinatorCompletionTokens int64  `json:"coordinator_completion_tokens"`
 	GatewayLagMs                int64  `json:"gateway_lag_ms"`
@@ -160,8 +221,11 @@ func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Ti
 		}
 	}
 
-	matchByFuzzy(r, results, gwRows, coordRows)
+	r.DriftBasis = "per_matched_pair_v2"
+	leftoverGw, leftoverCoord := matchByFuzzy(r, results, gwRows, coordRows)
 	computePerPairDrift(r)
+	collectUnmatchedGatewayOK(r, leftoverGw)
+	collectUnmatchedCoord2xx(r, leftoverCoord)
 
 	// Background-traffic note: extra rows beyond the harness's count
 	// likely belong to other buyers on the live network. Recorded as a
@@ -174,28 +238,118 @@ func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Ti
 	return r, nil
 }
 
-// computePerPairDrift sums the token deltas across matched (harness,
-// gateway, coord) triples. Replaces the earlier aggregate-sum approach
-// which subtracted gateway-ok-only token totals from full-harness-ok
-// totals — a population-mismatch that produced spurious non-zero drift
-// whenever the gateway settled most successful streams as SPEC-006
-// §17.7 fallback outcomes (stream_truncated, stream_output_exceeded,
-// upstream_error). See issue #226 for the 2026-06-29 production trip.
+// computePerPairDrift derives drift signals from r.MatchedSuccesses.
+// Replaces the earlier aggregate-sum approach which subtracted gateway-
+// ok-only token totals from full-harness-ok totals — a population-
+// mismatch that produced spurious non-zero drift whenever the gateway
+// settled most successful streams as SPEC-006 §17.7 fallback outcomes
+// (issue #226 production trip on 2026-06-29).
 //
-// Drift definitions (positive = side has more in matched pairs):
-//   - GatewayMinusHarnessTokens: Σ(gateway - harness) over matched pairs
-//   - GatewayMinusCoordinatorTokens: Σ(gateway - coord) over pairs with
-//     a coord-side match (some matches lack a coord row, e.g. when the
-//     coord 2xx for the request fell outside the SQL window).
+// Emits four drift fields per axis (gateway-vs-harness, gateway-vs-coord):
+//
+//	NetGateway*-: signed sum of per-pair (gateway - other) deltas.
+//	             A +N overbill and -N underbill cancel to 0 here; this
+//	             field is for triage reference, NOT the I1 pass/fail
+//	             input (3-lane codex audit CRITICAL on PR #229 R1).
+//
+//	GatewayOverbill*-: sum of POSITIVE-only per-pair deltas; an overbilled
+//	                  pair contributes its overbill amount, an underbilled
+//	                  pair contributes 0. This is the headline overbill
+//	                  signal — does NOT cancel against other pairs.
+//
+// Also populates OverbilledPairs with harness request IDs of any pair
+// where the gateway billed more than the harness observed, so triage
+// can drill into the offending requests.
+//
+// MatchedCoordMissing is populated for pairs whose gateway outcome is
+// "ok" but no coord row matched — fallback outcomes legitimately lack
+// a coord row (provider died mid-stream) and aren't flagged here.
 //
 // Unmatched harness successes are NOT counted here — they show up
-// independently as r.UnmatchedSuccesses, which I1 inspects separately.
+// independently as r.UnmatchedSuccesses for I1's "missing on gateway"
+// signal.
 func computePerPairDrift(r *Result) {
 	for _, p := range r.MatchedSuccesses {
-		r.GatewayMinusHarnessTokens += p.GatewayCompletionTokens - p.HarnessCompletionTokens
-		if p.CoordinatorRequestID != "" {
-			r.GatewayMinusCoordinatorTokens += p.GatewayCompletionTokens - p.CoordinatorCompletionTokens
+		// Gateway vs Harness — fold the delta into the headline overbill
+		// signal ONLY for gateway "ok" pairs. SPEC-006 §17.7 fallback
+		// outcomes (stream_truncated etc.) have a known asymmetry: the
+		// gateway records the bytes it actually emitted before the upstream
+		// error, while the harness's SSE parser undercounts (F-8). The
+		// pre-existing #226 production scenario specifically had fallback
+		// gateway tokens >> harness tokens; if we counted those as overbill,
+		// I1 would false-fail on exactly the shape this PR is meant to fix
+		// (#229 R5 architect HIGH).
+		dh := p.GatewayCompletionTokens - p.HarnessCompletionTokens
+		r.NetGatewayMinusHarnessTokens += dh
+		if dh > 0 && isGatewayOKOutcome(p.GatewayOutcome) {
+			r.GatewayOverbillVsHarnessTokens += dh
+			r.OverbilledPairs = append(r.OverbilledPairs, p.HarnessRequestID)
 		}
+
+		// Gateway vs Coordinator — only when a coord match exists.
+		// Coord and gateway are BOTH settlement systems for the same
+		// request, so any per-pair token disagreement (in either
+		// direction) is a ledger inconsistency that I1 must surface.
+		// AbsGatewayCoordinatorMismatchTokens uses |delta| to avoid
+		// signed-cancel across pairs (#229 R2 HIGH).
+		//
+		// When a coord row is missing for a gateway-OK pair (i.e. the
+		// gateway settled cleanly but no coord trail), surface separately
+		// in MatchedCoordMissing rather than dropping the signal.
+		if p.CoordinatorRequestID != "" {
+			dc := p.GatewayCompletionTokens - p.CoordinatorCompletionTokens
+			r.NetGatewayMinusCoordinatorTokens += dc
+			if dc > 0 {
+				r.GatewayOverbillVsCoordinatorTokens += dc
+			}
+			if dc != 0 {
+				if dc < 0 {
+					r.AbsGatewayCoordinatorMismatchTokens += -dc
+				} else {
+					r.AbsGatewayCoordinatorMismatchTokens += dc
+				}
+				r.GatewayCoordMismatchedPairs = append(r.GatewayCoordMismatchedPairs, p.HarnessRequestID)
+			}
+		} else if isGatewayOKOutcome(p.GatewayOutcome) {
+			r.MatchedCoordMissing = append(r.MatchedCoordMissing, p.HarnessRequestID)
+		}
+	}
+}
+
+// collectUnmatchedGatewayOK lists gateway rows with outcome="ok" that
+// matchByFuzzy did NOT consume into a MatchedSuccesses pair. These are
+// either orphan gateway settlements (real bugs — gateway billed for a
+// request the harness never fired) or concurrent background traffic
+// from other buyers. Triage decides. Fallback-outcome leftovers are
+// EXCLUDED because they are noisy on a live network where streams can
+// truncate without involving the harness.
+//
+// IMPORTANT: this takes the leftover gwPool returned by matchByFuzzy,
+// not the original gwRows. The pool is identity-tracked by slice
+// position, NOT by request_id, so we never accidentally mark a duplicate
+// (account_id, request_id) row consumed (#229 R3 security HIGH).
+func collectUnmatchedGatewayOK(r *Result, leftoverGw []gwRow) {
+	for _, g := range leftoverGw {
+		if g.Outcome != "ok" {
+			continue
+		}
+		r.UnmatchedGatewayOKRows = append(r.UnmatchedGatewayOKRows, g.RequestID)
+	}
+}
+
+// collectUnmatchedCoord2xx surfaces coord request_log rows with 2xx
+// status that matchByFuzzy did NOT consume. Symmetric with the
+// gateway-ok orphan path: a coord row representing a settled request
+// with no harness/gateway counterpart is either orphan/leaked or
+// concurrent buyer traffic. I1 must fail on these — without this
+// signal, a 100-clean-pairs + 1-extra-coord-row run leaves all drift
+// fields at zero (#229 R5 security HIGH).
+func collectUnmatchedCoord2xx(r *Result, leftoverCoord []coordRow) {
+	for _, c := range leftoverCoord {
+		if c.Status < 200 || c.Status >= 300 {
+			continue
+		}
+		r.UnmatchedCoordinator2xxRows = append(r.UnmatchedCoordinator2xxRows, c.RequestID)
 	}
 }
 
@@ -204,7 +358,13 @@ func computePerPairDrift(r *Result) {
 // most likely coordinator row by (model, completion_tokens, ts proximity).
 // Once a row is consumed by a match, it's removed from the pool so the
 // next harness request can't re-match the same DB row.
-func matchByFuzzy(r *Result, results []buyer.Result, gwRows []gwRow, coordRows []coordRow) {
+//
+// Returns the leftover gateway pool — rows that did NOT consume into a
+// match. Callers use this to detect orphan/leaked settlement rows
+// directly from row identity, NOT from request_id (which the gateway
+// schema does not guarantee globally unique under the composite PK
+// `(account_id, request_id)`; #229 R3 security HIGH).
+func matchByFuzzy(r *Result, results []buyer.Result, gwRows []gwRow, coordRows []coordRow) ([]gwRow, []coordRow) {
 	gwPool := make([]gwRow, len(gwRows))
 	copy(gwPool, gwRows)
 	coordPool := make([]coordRow, len(coordRows))
@@ -227,7 +387,6 @@ func matchByFuzzy(r *Result, results []buyer.Result, gwRows []gwRow, coordRows [
 
 	for _, h := range ordered {
 		gwIdx := pickClosestGw(&gwPool, h.res)
-		coordIdx := pickClosestCoord(&coordPool, h.res)
 		pair := MatchedPair{
 			HarnessRequestID:        h.res.RequestID,
 			HarnessCompletionTokens: h.res.CompletionTokensReceived,
@@ -236,20 +395,31 @@ func matchByFuzzy(r *Result, results []buyer.Result, gwRows []gwRow, coordRows [
 			g := gwPool[gwIdx]
 			pair.GatewayRequestID = g.RequestID
 			pair.GatewayCompletionTokens = g.CompletionTokens
+			pair.GatewayOutcome = g.Outcome
 			pair.GatewayLagMs = g.CreatedAt.Sub(h.res.StartUTC).Milliseconds()
 			gwPool = append(gwPool[:gwIdx], gwPool[gwIdx+1:]...)
 		} else {
 			r.UnmatchedSuccesses = append(r.UnmatchedSuccesses, h.res.RequestID)
 			continue
 		}
-		if coordIdx >= 0 {
-			c := coordPool[coordIdx]
-			pair.CoordinatorRequestID = c.RequestID
-			pair.CoordinatorCompletionTokens = c.CompletionTokens
-			coordPool = append(coordPool[:coordIdx], coordPool[coordIdx+1:]...)
+		// Only attempt a coord match when the gateway settled as "ok".
+		// SPEC-006 §17.7 fallback outcomes (stream_truncated, etc.)
+		// legitimately lack a coord row (provider died mid-stream), so
+		// pulling one in would (a) consume a coord row that a later
+		// real "ok" pair needs, and (b) misattribute a token mismatch
+		// to a fallback pair where coord disagreement is expected.
+		// This avoids the false I1 failure mode flagged on PR #229 R4.
+		if isGatewayOKOutcome(pair.GatewayOutcome) {
+			if coordIdx := pickClosestCoord(&coordPool, h.res); coordIdx >= 0 {
+				c := coordPool[coordIdx]
+				pair.CoordinatorRequestID = c.RequestID
+				pair.CoordinatorCompletionTokens = c.CompletionTokens
+				coordPool = append(coordPool[:coordIdx], coordPool[coordIdx+1:]...)
+			}
 		}
 		r.MatchedSuccesses = append(r.MatchedSuccesses, pair)
 	}
+	return gwPool, coordPool
 }
 
 func pickClosestGw(pool *[]gwRow, h buyer.Result) int {
@@ -306,6 +476,16 @@ func absInt64(x int64) int64 {
 		return -x
 	}
 	return x
+}
+
+// isGatewayOKOutcome reports whether a gateway outcome value represents
+// a clean SPEC-006 streaming completion that SHOULD have a corresponding
+// coord row. Centralizing this in one place — symmetric with
+// isSettlementComplete — keeps the drift logic from going out of sync
+// when SPEC-006 §17.7 adds new fallback outcome names (#229 R2 architect
+// MEDIUM).
+func isGatewayOKOutcome(outcome string) bool {
+	return outcome == "ok"
 }
 
 // isSettlementComplete returns true for any gateway outcome value that

--- a/test/network-harness/internal/reconcile/ledger_test.go
+++ b/test/network-harness/internal/reconcile/ledger_test.go
@@ -1,151 +1,400 @@
-// Tests for the per-pair drift fix (issue #226). The aggregate-sum
-// approach in the pre-fix reconciler false-failed I1 whenever the
-// gateway settled most successful streams as SPEC-006 §17.7 fallback
-// outcomes — the gateway "ok"-only completion-tokens total covered
-// only a small subset of rows while the harness "ok" total covered
-// every success. Per-pair drift uses the matched-pair token deltas
-// exclusively, so the population-mismatch can't bias the answer.
+// Tests for the per-pair drift fix (issue #226) with the R2 refinements
+// required by the 3-lane codex audit on PR #229 R1:
+//   - Signed-cancel CRITICAL: I1 must catch a +N overbill pair even if
+//     another pair offsets it by -N. Net sum is reference-only; the
+//     positive-only overbill sum is the headline signal.
+//   - Coord-missing HIGH: matched gateway-ok pairs without a coord row
+//     are surfaced separately (legit for fallback outcomes, suspicious
+//     for ok).
+//   - Unmatched gateway-ok HIGH: orphan/leaked settlement rows are
+//     listed; fallback outcomes are excluded as noisy.
 package reconcile
 
 import (
 	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-network-harness/internal/buyer"
 )
 
-// TestComputePerPairDrift_CleanMatches verifies that matched pairs with
-// identical token counts yield zero drift. This is the happy path:
-// every harness success matches a gateway row with the exact same token
-// count, every gateway row has a coord counterpart with the same count.
+// TestComputePerPairDrift_CleanMatches: identical token counts → zero
+// drift across every signal.
 func TestComputePerPairDrift_CleanMatches(t *testing.T) {
 	r := &Result{
 		MatchedSuccesses: []MatchedPair{
-			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 8, CoordinatorRequestID: "c1", CoordinatorCompletionTokens: 8},
-			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 8, CoordinatorRequestID: "c2", CoordinatorCompletionTokens: 8},
-			{HarnessCompletionTokens: 16, GatewayCompletionTokens: 16, CoordinatorRequestID: "c3", CoordinatorCompletionTokens: 16},
+			{HarnessRequestID: "h1", HarnessCompletionTokens: 8, GatewayCompletionTokens: 8, GatewayOutcome: "ok", CoordinatorRequestID: "c1", CoordinatorCompletionTokens: 8},
+			{HarnessRequestID: "h2", HarnessCompletionTokens: 16, GatewayCompletionTokens: 16, GatewayOutcome: "ok", CoordinatorRequestID: "c2", CoordinatorCompletionTokens: 16},
 		},
 	}
 	computePerPairDrift(r)
-	if r.GatewayMinusHarnessTokens != 0 {
-		t.Errorf("clean matches: want gateway-harness drift 0, got %d", r.GatewayMinusHarnessTokens)
+	if r.NetGatewayMinusHarnessTokens != 0 {
+		t.Errorf("net gw-harness: want 0, got %d", r.NetGatewayMinusHarnessTokens)
 	}
-	if r.GatewayMinusCoordinatorTokens != 0 {
-		t.Errorf("clean matches: want gateway-coord drift 0, got %d", r.GatewayMinusCoordinatorTokens)
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("overbill gw-harness: want 0, got %d", r.GatewayOverbillVsHarnessTokens)
+	}
+	if r.GatewayOverbillVsCoordinatorTokens != 0 {
+		t.Errorf("overbill gw-coord: want 0, got %d", r.GatewayOverbillVsCoordinatorTokens)
+	}
+	if len(r.OverbilledPairs) != 0 {
+		t.Errorf("OverbilledPairs: want empty, got %v", r.OverbilledPairs)
+	}
+	if len(r.MatchedCoordMissing) != 0 {
+		t.Errorf("MatchedCoordMissing: want empty, got %v", r.MatchedCoordMissing)
 	}
 }
 
-// TestComputePerPairDrift_RealOvercharge verifies that an actual
-// money-path overcharge (gateway billed more than harness saw) is
-// surfaced as positive drift. This is the signal I1 needs to keep
-// firing on — the bug fix must preserve it.
+// TestComputePerPairDrift_SignedCancellation is the regression test for
+// the PR #229 R1 CRITICAL: a +10 overbill matched with a -10 underbill.
+// Pre-R2 NET drift hides the overbill; positive-only sum surfaces it.
+func TestComputePerPairDrift_SignedCancellation(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			{HarnessRequestID: "OVERBILLED", HarnessCompletionTokens: 100, GatewayCompletionTokens: 110, GatewayOutcome: "ok"},
+			{HarnessRequestID: "UNDERBILLED", HarnessCompletionTokens: 100, GatewayCompletionTokens: 90, GatewayOutcome: "ok"},
+		},
+	}
+	computePerPairDrift(r)
+	if r.NetGatewayMinusHarnessTokens != 0 {
+		t.Errorf("net should cancel to 0 (proving the headline-net-zero failure mode), got %d", r.NetGatewayMinusHarnessTokens)
+	}
+	if r.GatewayOverbillVsHarnessTokens != 10 {
+		t.Errorf("overbill must NOT cancel: want 10, got %d", r.GatewayOverbillVsHarnessTokens)
+	}
+	if len(r.OverbilledPairs) != 1 || r.OverbilledPairs[0] != "OVERBILLED" {
+		t.Errorf("OverbilledPairs: want [OVERBILLED], got %v", r.OverbilledPairs)
+	}
+}
+
+// TestComputePerPairDrift_RealOvercharge: pure overbill, no offsets.
 func TestComputePerPairDrift_RealOvercharge(t *testing.T) {
 	r := &Result{
 		MatchedSuccesses: []MatchedPair{
-			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 12, CoordinatorRequestID: "c1", CoordinatorCompletionTokens: 8},  // +4 overcharge
-			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 10, CoordinatorRequestID: "c2", CoordinatorCompletionTokens: 8},  // +2 overcharge
-			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 8, CoordinatorRequestID: "c3", CoordinatorCompletionTokens: 8},   // clean
+			{HarnessRequestID: "h1", HarnessCompletionTokens: 8, GatewayCompletionTokens: 12, GatewayOutcome: "ok", CoordinatorRequestID: "c1", CoordinatorCompletionTokens: 8},
+			{HarnessRequestID: "h2", HarnessCompletionTokens: 8, GatewayCompletionTokens: 10, GatewayOutcome: "ok", CoordinatorRequestID: "c2", CoordinatorCompletionTokens: 8},
+			{HarnessRequestID: "h3", HarnessCompletionTokens: 8, GatewayCompletionTokens: 8, GatewayOutcome: "ok", CoordinatorRequestID: "c3", CoordinatorCompletionTokens: 8},
 		},
 	}
 	computePerPairDrift(r)
-	// Two pairs over-billed by 4 + 2 = 6
-	if r.GatewayMinusHarnessTokens != 6 {
-		t.Errorf("overcharge: want drift +6, got %d", r.GatewayMinusHarnessTokens)
+	if r.GatewayOverbillVsHarnessTokens != 6 {
+		t.Errorf("want overbill 6 (4+2), got %d", r.GatewayOverbillVsHarnessTokens)
 	}
-	// Gateway-coord: gateway also exceeds coord by 6
-	if r.GatewayMinusCoordinatorTokens != 6 {
-		t.Errorf("overcharge vs coord: want drift +6, got %d", r.GatewayMinusCoordinatorTokens)
+	if r.GatewayOverbillVsCoordinatorTokens != 6 {
+		t.Errorf("want overbill vs coord 6, got %d", r.GatewayOverbillVsCoordinatorTokens)
+	}
+	if len(r.OverbilledPairs) != 2 {
+		t.Errorf("want 2 overbilled pairs, got %d (%v)", len(r.OverbilledPairs), r.OverbilledPairs)
 	}
 }
 
-// TestComputePerPairDrift_ScenarioSevenFromProduction is the production
-// trip from the 2026-06-29 e2e run: 40 harness successes, 5 match to
-// gateway rows with outcome="ok", 35 match to gateway rows with
-// fallback outcomes (stream_output_exceeded etc.). Pre-fix this yielded
-// a phantom "drift=32" because aggregate sums compared 5 gateway-ok
-// rows' tokens against 40 harness-ok tokens.
-//
-// Post-fix: per-pair drift over the matched pairs should be 0 because
-// each individual pair has matching token counts — the false drift was
-// a population-mismatch artifact, NOT real overcharging.
-func TestComputePerPairDrift_ScenarioSevenFromProduction(t *testing.T) {
-	// Mirror the 2026-06-29 reality: harness sees N=40 successes with
-	// avg ~5.8 tokens (233 total / 40 = 5.825). Some land at 8 tokens
-	// (max_tokens limit), others at 4-6 (natural stop). Build 40 pairs
-	// where each pair's gateway tokens == harness tokens.
-	pairs := make([]MatchedPair, 0, 40)
+// TestComputePerPairDrift_ScenarioSevenShape: 40 pairs of matching tokens
+// (the 2026-06-29 production shape that tripped I1). Per-pair drift
+// must be 0 even though aggregate gateway-ok tokens vs harness-ok
+// tokens differ.
+func TestComputePerPairDrift_ScenarioSevenShape(t *testing.T) {
+	pairs := make([]MatchedPair, 40)
 	tokenCounts := []int64{8, 8, 8, 8, 8, 6, 6, 6, 6, 6, 4, 4, 4, 4, 4, 8, 8, 8, 8, 8,
 		6, 6, 6, 6, 6, 4, 4, 4, 4, 4, 8, 8, 8, 8, 8, 6, 6, 6, 6, 6}
 	for i, n := range tokenCounts {
-		hasCoord := i%2 == 0 // half match to coord, half don't (matching the windowing reality)
-		mp := MatchedPair{
+		// 5/40 land as outcome="ok", 35/40 as fallback — exactly the
+		// production-trip shape on 2026-06-29.
+		outcome := "stream_output_exceeded"
+		if i < 5 {
+			outcome = "ok"
+		}
+		pairs[i] = MatchedPair{
+			HarnessRequestID:        "h",
 			HarnessCompletionTokens: n,
 			GatewayCompletionTokens: n,
+			GatewayOutcome:          outcome,
+			CoordinatorRequestID:    "c",
+			CoordinatorCompletionTokens: n,
 		}
-		if hasCoord {
-			mp.CoordinatorRequestID = "c"
-			mp.CoordinatorCompletionTokens = n
-		}
-		pairs = append(pairs, mp)
 	}
 	r := &Result{MatchedSuccesses: pairs}
 	computePerPairDrift(r)
-	if r.GatewayMinusHarnessTokens != 0 {
-		t.Errorf("production-shape clean pairs: want drift 0 (pre-fix would report 32), got %d", r.GatewayMinusHarnessTokens)
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("scenario-7 shape: want 0 overbill, got %d", r.GatewayOverbillVsHarnessTokens)
 	}
-	if r.GatewayMinusCoordinatorTokens != 0 {
-		t.Errorf("production-shape clean pairs vs coord: want drift 0, got %d", r.GatewayMinusCoordinatorTokens)
+	if r.NetGatewayMinusHarnessTokens != 0 {
+		t.Errorf("scenario-7 shape: want 0 net, got %d", r.NetGatewayMinusHarnessTokens)
 	}
 }
 
-// TestComputePerPairDrift_NoCoordMatch verifies the "coord row missing"
-// branch: pairs without a coord match contribute to gateway-vs-harness
-// drift but NOT to gateway-vs-coord drift. The latter is a different
-// signal (gateway vs coord disagreement) and shouldn't double-count
-// pairs that simply lack a coord-side row.
-func TestComputePerPairDrift_NoCoordMatch(t *testing.T) {
+// TestComputePerPairDrift_CoordMissing_OkVsFallback: gateway-ok pair
+// without a coord row → suspicious, flagged in MatchedCoordMissing.
+// Gateway-fallback pair without a coord row → expected (provider died
+// mid-stream), NOT flagged.
+func TestComputePerPairDrift_CoordMissing_OkVsFallback(t *testing.T) {
 	r := &Result{
 		MatchedSuccesses: []MatchedPair{
-			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 12, CoordinatorRequestID: ""},   // no coord match
-			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 10, CoordinatorRequestID: "c2", CoordinatorCompletionTokens: 8},
+			{HarnessRequestID: "SUSPICIOUS", HarnessCompletionTokens: 8, GatewayCompletionTokens: 8, GatewayOutcome: "ok", CoordinatorRequestID: ""},
+			{HarnessRequestID: "expected", HarnessCompletionTokens: 8, GatewayCompletionTokens: 8, GatewayOutcome: "stream_truncated", CoordinatorRequestID: ""},
 		},
 	}
 	computePerPairDrift(r)
-	if r.GatewayMinusHarnessTokens != 6 {
-		t.Errorf("want gateway-harness drift +6, got %d", r.GatewayMinusHarnessTokens)
-	}
-	// Only the second pair (with coord match) contributes to gw-coord drift: 10-8 = 2
-	if r.GatewayMinusCoordinatorTokens != 2 {
-		t.Errorf("want gateway-coord drift +2 (one pair with coord match), got %d", r.GatewayMinusCoordinatorTokens)
+	if len(r.MatchedCoordMissing) != 1 || r.MatchedCoordMissing[0] != "SUSPICIOUS" {
+		t.Errorf("only gateway-ok-no-coord should flag: got %v", r.MatchedCoordMissing)
 	}
 }
 
-// TestComputePerPairDrift_GatewayUnderbilled is the inverse of the
-// overcharge case: the gateway billed FEWER tokens than the harness
-// observed. I1's check treats this as "allowed" (legitimate gateway-
-// side rounding on streaming) — the drift sum can be negative. This
-// test pins the sign convention so I1 stays consistent.
-func TestComputePerPairDrift_GatewayUnderbilled(t *testing.T) {
+// TestComputePerPairDrift_UnderbillNotFlagged: gateway billed less
+// than harness observed — allowed for streaming (gateway-side rounding).
+// Per-pair drift records it in NetGatewayMinusHarnessTokens but
+// OverbilledPairs stays empty.
+func TestComputePerPairDrift_UnderbillNotFlagged(t *testing.T) {
 	r := &Result{
 		MatchedSuccesses: []MatchedPair{
-			{HarnessCompletionTokens: 10, GatewayCompletionTokens: 8},
-			{HarnessCompletionTokens: 10, GatewayCompletionTokens: 7},
+			{HarnessRequestID: "h1", HarnessCompletionTokens: 10, GatewayCompletionTokens: 8, GatewayOutcome: "ok"},
+			{HarnessRequestID: "h2", HarnessCompletionTokens: 10, GatewayCompletionTokens: 7, GatewayOutcome: "ok"},
 		},
 	}
 	computePerPairDrift(r)
-	if r.GatewayMinusHarnessTokens != -5 {
-		t.Errorf("underbill: want drift -5, got %d", r.GatewayMinusHarnessTokens)
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("underbill: want 0 overbill, got %d", r.GatewayOverbillVsHarnessTokens)
+	}
+	if r.NetGatewayMinusHarnessTokens != -5 {
+		t.Errorf("net underbill: want -5, got %d", r.NetGatewayMinusHarnessTokens)
+	}
+	if len(r.OverbilledPairs) != 0 {
+		t.Errorf("underbills are not overbills: %v", r.OverbilledPairs)
 	}
 }
 
-// TestComputePerPairDrift_EmptyMatches handles the case where the run
-// reconciles but every harness success was unmatched (gateway empty or
-// SQL window mis-targeted). Drift should stay 0 here — unmatched ids
-// are a separate signal, not a token-count drift.
+// TestCollectUnmatchedGatewayOK takes a leftover gateway pool (what
+// matchByFuzzy did NOT consume) and surfaces only the "ok"-outcome
+// rows. Fallback outcomes and not-ok are noise on a live network.
+func TestCollectUnmatchedGatewayOK(t *testing.T) {
+	now := time.Now()
+	leftoverGw := []gwRow{
+		{RequestID: "ORPHAN_OK", Outcome: "ok", CreatedAt: now},
+		{RequestID: "fallback_left", Outcome: "stream_truncated", CreatedAt: now}, // EXCLUDED (noisy)
+		{RequestID: "notok_left", Outcome: "upstream_error", CreatedAt: now},      // EXCLUDED (not ok)
+	}
+	r := &Result{}
+	collectUnmatchedGatewayOK(r, leftoverGw)
+	if len(r.UnmatchedGatewayOKRows) != 1 || r.UnmatchedGatewayOKRows[0] != "ORPHAN_OK" {
+		t.Errorf("want [ORPHAN_OK], got %v", r.UnmatchedGatewayOKRows)
+	}
+}
+
+// TestCollectUnmatchedGatewayOK_NoLeftovers: empty leftover pool →
+// no orphans listed.
+func TestCollectUnmatchedGatewayOK_NoLeftovers(t *testing.T) {
+	r := &Result{}
+	collectUnmatchedGatewayOK(r, nil)
+	if len(r.UnmatchedGatewayOKRows) != 0 {
+		t.Errorf("want empty, got %v", r.UnmatchedGatewayOKRows)
+	}
+}
+
+// TestComputePerPairDrift_FallbackPairsDontCountAsOverbill_R5HIGH:
+// the production scenario 07 shape has gateway settle most successful
+// streams as stream_output_exceeded with gateway tokens >> harness
+// tokens (F-8 SSE undercount). Pre-R5 this counted as gateway overbill
+// and false-failed I1 on exactly the shape #226 was filed to fix.
+// Post-R5, only OK-outcome overbill counts.
+func TestComputePerPairDrift_FallbackPairsDontCountAsOverbill_R5HIGH(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			// Fallback pair: gateway recorded 64 bytes' worth of tokens
+			// before the upstream error, harness's SSE parser only saw 8.
+			// Pre-R5: GatewayOverbillVsHarnessTokens += 56. R5: excluded.
+			{HarnessRequestID: "fallback_undercount", HarnessCompletionTokens: 8, GatewayCompletionTokens: 64,
+				GatewayOutcome: "stream_output_exceeded"},
+			// OK pair: clean billing.
+			{HarnessRequestID: "ok_clean", HarnessCompletionTokens: 32, GatewayCompletionTokens: 32, GatewayOutcome: "ok"},
+		},
+	}
+	computePerPairDrift(r)
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("fallback pair must not count as gateway overbill, got %d", r.GatewayOverbillVsHarnessTokens)
+	}
+	if len(r.OverbilledPairs) != 0 {
+		t.Errorf("fallback pair must not appear in OverbilledPairs: %v", r.OverbilledPairs)
+	}
+}
+
+// TestCollectUnmatchedCoord2xx_R5HIGH: a coord 2xx row that no harness
+// success matched must surface as orphan/leaked traffic. Pre-R5 the
+// leftover coord pool was discarded entirely, so the signal disappeared.
+func TestCollectUnmatchedCoord2xx_R5HIGH(t *testing.T) {
+	now := time.Now()
+	leftoverCoord := []coordRow{
+		{RequestID: "ORPHAN_COORD", Status: 200, CompletionTokens: 8, TsUTC: now},
+		{RequestID: "coord_5xx", Status: 500, TsUTC: now},  // EXCLUDED (not 2xx)
+		{RequestID: "coord_4xx", Status: 404, TsUTC: now},  // EXCLUDED (not 2xx)
+	}
+	r := &Result{}
+	collectUnmatchedCoord2xx(r, leftoverCoord)
+	if len(r.UnmatchedCoordinator2xxRows) != 1 || r.UnmatchedCoordinator2xxRows[0] != "ORPHAN_COORD" {
+		t.Errorf("want [ORPHAN_COORD], got %v", r.UnmatchedCoordinator2xxRows)
+	}
+}
+
+// TestMatchByFuzzy_FallbackDoesntStealCoord_R4HIGH is the regression
+// for the R4 audit finding: a fallback gateway row paired with a
+// harness success could consume a nearby coord row that a later "ok"
+// pair needed, producing a false MatchedCoordMissing on the ok pair.
+// The fix: only call pickClosestCoord when the gateway outcome is "ok".
+func TestMatchByFuzzy_FallbackDoesntStealCoord_R4HIGH(t *testing.T) {
+	now := time.Now()
+	// 2 harness successes, both with 8 tokens. Gateway has one fallback
+	// row (stream_truncated, 8 tokens, earlier) and one ok row (8 tokens,
+	// later). Coord has 1 row (8 tokens) — should match the ok pair, not
+	// the fallback pair.
+	gwRows := []gwRow{
+		{RequestID: "gw_fallback", Outcome: "stream_truncated", CompletionTokens: 8, CreatedAt: now},
+		{RequestID: "gw_ok", Outcome: "ok", CompletionTokens: 8, CreatedAt: now.Add(time.Millisecond)},
+	}
+	coordRows := []coordRow{
+		{RequestID: "c1", Status: 200, CompletionTokens: 8, TsUTC: now.Add(time.Millisecond)},
+	}
+	results := []buyer.Result{
+		{Outcome: "ok", CompletionTokensReceived: 8, EndUTC: now, StartUTC: now, RequestID: "h_fallback"},
+		{Outcome: "ok", CompletionTokensReceived: 8, EndUTC: now.Add(time.Millisecond), StartUTC: now.Add(time.Millisecond), RequestID: "h_ok"},
+	}
+	r := &Result{}
+	matchByFuzzy(r, results, gwRows, coordRows)
+	if len(r.MatchedSuccesses) != 2 {
+		t.Fatalf("want 2 pairs, got %d", len(r.MatchedSuccesses))
+	}
+	// Find the ok pair and verify it has the coord row.
+	var okPair *MatchedPair
+	for i := range r.MatchedSuccesses {
+		if r.MatchedSuccesses[i].GatewayOutcome == "ok" {
+			okPair = &r.MatchedSuccesses[i]
+		}
+	}
+	if okPair == nil {
+		t.Fatal("ok pair missing from matches")
+	}
+	if okPair.CoordinatorRequestID == "" {
+		t.Errorf("fallback pair stole the coord row — ok pair should have c1, got empty")
+	}
+	// And verify the fallback pair did NOT get the coord row.
+	for _, p := range r.MatchedSuccesses {
+		if p.GatewayOutcome == "stream_truncated" && p.CoordinatorRequestID != "" {
+			t.Errorf("fallback pair must not consume coord row, got %s", p.CoordinatorRequestID)
+		}
+	}
+}
+
+// TestMatchByFuzzy_DuplicateRequestID_R3HIGH is the regression for the
+// R3 security HIGH: gateway PK is (account_id, request_id), so the
+// same request_id can legitimately appear twice across accounts. The
+// pre-R3 collectUnmatchedGatewayOK used request_id matching against
+// MatchedSuccesses, which would mark BOTH rows consumed when only one
+// was actually paired. R3 changed matchByFuzzy to return the leftover
+// pool directly, so identity is per-slice-element, not per-request_id.
+func TestMatchByFuzzy_DuplicateRequestID_R3HIGH(t *testing.T) {
+	now := time.Now()
+	gwRows := []gwRow{
+		{RequestID: "X", Outcome: "ok", CompletionTokens: 10, CreatedAt: now},
+		{RequestID: "X", Outcome: "ok", CompletionTokens: 10, CreatedAt: now}, // duplicate (different account in prod)
+	}
+	// Only one harness success — should match one row, leave the other.
+	results := []buyer.Result{
+		{Outcome: "ok", CompletionTokensReceived: 10, EndUTC: now, RequestID: "h1"},
+	}
+	r := &Result{}
+	leftover, _ := matchByFuzzy(r, results, gwRows, nil)
+	if len(r.MatchedSuccesses) != 1 {
+		t.Fatalf("want 1 matched pair, got %d", len(r.MatchedSuccesses))
+	}
+	if len(leftover) != 1 {
+		t.Fatalf("want 1 leftover gateway row, got %d", len(leftover))
+	}
+	collectUnmatchedGatewayOK(r, leftover)
+	if len(r.UnmatchedGatewayOKRows) != 1 {
+		t.Errorf("duplicate-request_id: orphan must be detected via leftover pool, got %v", r.UnmatchedGatewayOKRows)
+	}
+}
+
+// TestComputePerPairDrift_EmptyMatches: no matched pairs → all signals 0.
 func TestComputePerPairDrift_EmptyMatches(t *testing.T) {
-	r := &Result{MatchedSuccesses: nil}
+	r := &Result{}
 	computePerPairDrift(r)
-	if r.GatewayMinusHarnessTokens != 0 {
-		t.Errorf("empty matches: want drift 0, got %d", r.GatewayMinusHarnessTokens)
+	if r.NetGatewayMinusHarnessTokens != 0 || r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("empty: want zeros, got net=%d overbill=%d", r.NetGatewayMinusHarnessTokens, r.GatewayOverbillVsHarnessTokens)
 	}
-	if r.GatewayMinusCoordinatorTokens != 0 {
-		t.Errorf("empty matches: want gw-coord drift 0, got %d", r.GatewayMinusCoordinatorTokens)
+	if len(r.OverbilledPairs) != 0 || len(r.MatchedCoordMissing) != 0 {
+		t.Errorf("empty: want no offending lists, got overbill=%v missing=%v", r.OverbilledPairs, r.MatchedCoordMissing)
+	}
+}
+
+// TestComputePerPairDrift_CoordinatorUndercharge_R2HIGH is the
+// regression for the R2 audit finding: when coord billed MORE tokens
+// than gateway (harness=100, gateway=100, coord=110), I1 must fail.
+// Pre-R2 this slipped through because we only checked positive overbill.
+// Coord and gateway are both settlement systems — any directional
+// disagreement is a money-path bug.
+func TestComputePerPairDrift_CoordinatorUndercharge_R2HIGH(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			{HarnessRequestID: "COORD_OVERBILLED", HarnessCompletionTokens: 100, GatewayCompletionTokens: 100, GatewayOutcome: "ok",
+				CoordinatorRequestID: "c1", CoordinatorCompletionTokens: 110},
+		},
+	}
+	computePerPairDrift(r)
+	// Gateway didn't overbill vs harness (both 100). Net gw-coord is -10.
+	// But abs mismatch must surface it.
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("no gw-harness overbill: want 0, got %d", r.GatewayOverbillVsHarnessTokens)
+	}
+	if r.NetGatewayMinusCoordinatorTokens != -10 {
+		t.Errorf("net gw-coord: want -10, got %d", r.NetGatewayMinusCoordinatorTokens)
+	}
+	if r.AbsGatewayCoordinatorMismatchTokens != 10 {
+		t.Errorf("abs gw-coord mismatch: want 10, got %d", r.AbsGatewayCoordinatorMismatchTokens)
+	}
+	if len(r.GatewayCoordMismatchedPairs) != 1 || r.GatewayCoordMismatchedPairs[0] != "COORD_OVERBILLED" {
+		t.Errorf("GatewayCoordMismatchedPairs: want [COORD_OVERBILLED], got %v", r.GatewayCoordMismatchedPairs)
+	}
+}
+
+// TestComputePerPairDrift_CoordMismatchSignedCancel: bidirectional
+// gateway-coord deltas must NOT cancel. +10 in one pair + -10 in another
+// is still 20 tokens of ledger disagreement across pairs.
+func TestComputePerPairDrift_CoordMismatchSignedCancel(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			{HarnessRequestID: "p1", GatewayCompletionTokens: 110, GatewayOutcome: "ok", CoordinatorRequestID: "c1", CoordinatorCompletionTokens: 100},
+			{HarnessRequestID: "p2", GatewayCompletionTokens: 100, GatewayOutcome: "ok", CoordinatorRequestID: "c2", CoordinatorCompletionTokens: 110},
+		},
+	}
+	computePerPairDrift(r)
+	if r.AbsGatewayCoordinatorMismatchTokens != 20 {
+		t.Errorf("abs mismatch must NOT cancel: want 20 (=10+10), got %d", r.AbsGatewayCoordinatorMismatchTokens)
+	}
+	if len(r.GatewayCoordMismatchedPairs) != 2 {
+		t.Errorf("want 2 mismatched pairs, got %d", len(r.GatewayCoordMismatchedPairs))
+	}
+}
+
+// TestComputePerPairDrift_NetVsOverbillRelationship: the headline
+// overbill signal MUST equal the sum of positive per-pair deltas, NOT
+// the net sum. This pins the relationship so a future refactor doesn't
+// accidentally re-conflate them.
+func TestComputePerPairDrift_NetVsOverbillRelationship(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			{HarnessCompletionTokens: 10, GatewayCompletionTokens: 15, GatewayOutcome: "ok"}, // +5
+			{HarnessCompletionTokens: 10, GatewayCompletionTokens: 8, GatewayOutcome: "ok"},  // -2
+			{HarnessCompletionTokens: 10, GatewayCompletionTokens: 10, GatewayOutcome: "ok"}, // 0
+			{HarnessCompletionTokens: 10, GatewayCompletionTokens: 12, GatewayOutcome: "ok"}, // +2
+		},
+	}
+	computePerPairDrift(r)
+	// Net: +5 -2 +0 +2 = +5
+	if r.NetGatewayMinusHarnessTokens != 5 {
+		t.Errorf("net: want 5, got %d", r.NetGatewayMinusHarnessTokens)
+	}
+	// Overbill: +5 + +2 = 7  (positive-only sum)
+	if r.GatewayOverbillVsHarnessTokens != 7 {
+		t.Errorf("overbill: want 7, got %d", r.GatewayOverbillVsHarnessTokens)
+	}
+	if len(r.OverbilledPairs) != 2 {
+		t.Errorf("want 2 overbilled pairs, got %d", len(r.OverbilledPairs))
 	}
 }

--- a/test/network-harness/internal/reconcile/ledger_test.go
+++ b/test/network-harness/internal/reconcile/ledger_test.go
@@ -1,0 +1,151 @@
+// Tests for the per-pair drift fix (issue #226). The aggregate-sum
+// approach in the pre-fix reconciler false-failed I1 whenever the
+// gateway settled most successful streams as SPEC-006 §17.7 fallback
+// outcomes — the gateway "ok"-only completion-tokens total covered
+// only a small subset of rows while the harness "ok" total covered
+// every success. Per-pair drift uses the matched-pair token deltas
+// exclusively, so the population-mismatch can't bias the answer.
+package reconcile
+
+import (
+	"testing"
+)
+
+// TestComputePerPairDrift_CleanMatches verifies that matched pairs with
+// identical token counts yield zero drift. This is the happy path:
+// every harness success matches a gateway row with the exact same token
+// count, every gateway row has a coord counterpart with the same count.
+func TestComputePerPairDrift_CleanMatches(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 8, CoordinatorRequestID: "c1", CoordinatorCompletionTokens: 8},
+			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 8, CoordinatorRequestID: "c2", CoordinatorCompletionTokens: 8},
+			{HarnessCompletionTokens: 16, GatewayCompletionTokens: 16, CoordinatorRequestID: "c3", CoordinatorCompletionTokens: 16},
+		},
+	}
+	computePerPairDrift(r)
+	if r.GatewayMinusHarnessTokens != 0 {
+		t.Errorf("clean matches: want gateway-harness drift 0, got %d", r.GatewayMinusHarnessTokens)
+	}
+	if r.GatewayMinusCoordinatorTokens != 0 {
+		t.Errorf("clean matches: want gateway-coord drift 0, got %d", r.GatewayMinusCoordinatorTokens)
+	}
+}
+
+// TestComputePerPairDrift_RealOvercharge verifies that an actual
+// money-path overcharge (gateway billed more than harness saw) is
+// surfaced as positive drift. This is the signal I1 needs to keep
+// firing on — the bug fix must preserve it.
+func TestComputePerPairDrift_RealOvercharge(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 12, CoordinatorRequestID: "c1", CoordinatorCompletionTokens: 8},  // +4 overcharge
+			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 10, CoordinatorRequestID: "c2", CoordinatorCompletionTokens: 8},  // +2 overcharge
+			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 8, CoordinatorRequestID: "c3", CoordinatorCompletionTokens: 8},   // clean
+		},
+	}
+	computePerPairDrift(r)
+	// Two pairs over-billed by 4 + 2 = 6
+	if r.GatewayMinusHarnessTokens != 6 {
+		t.Errorf("overcharge: want drift +6, got %d", r.GatewayMinusHarnessTokens)
+	}
+	// Gateway-coord: gateway also exceeds coord by 6
+	if r.GatewayMinusCoordinatorTokens != 6 {
+		t.Errorf("overcharge vs coord: want drift +6, got %d", r.GatewayMinusCoordinatorTokens)
+	}
+}
+
+// TestComputePerPairDrift_ScenarioSevenFromProduction is the production
+// trip from the 2026-06-29 e2e run: 40 harness successes, 5 match to
+// gateway rows with outcome="ok", 35 match to gateway rows with
+// fallback outcomes (stream_output_exceeded etc.). Pre-fix this yielded
+// a phantom "drift=32" because aggregate sums compared 5 gateway-ok
+// rows' tokens against 40 harness-ok tokens.
+//
+// Post-fix: per-pair drift over the matched pairs should be 0 because
+// each individual pair has matching token counts — the false drift was
+// a population-mismatch artifact, NOT real overcharging.
+func TestComputePerPairDrift_ScenarioSevenFromProduction(t *testing.T) {
+	// Mirror the 2026-06-29 reality: harness sees N=40 successes with
+	// avg ~5.8 tokens (233 total / 40 = 5.825). Some land at 8 tokens
+	// (max_tokens limit), others at 4-6 (natural stop). Build 40 pairs
+	// where each pair's gateway tokens == harness tokens.
+	pairs := make([]MatchedPair, 0, 40)
+	tokenCounts := []int64{8, 8, 8, 8, 8, 6, 6, 6, 6, 6, 4, 4, 4, 4, 4, 8, 8, 8, 8, 8,
+		6, 6, 6, 6, 6, 4, 4, 4, 4, 4, 8, 8, 8, 8, 8, 6, 6, 6, 6, 6}
+	for i, n := range tokenCounts {
+		hasCoord := i%2 == 0 // half match to coord, half don't (matching the windowing reality)
+		mp := MatchedPair{
+			HarnessCompletionTokens: n,
+			GatewayCompletionTokens: n,
+		}
+		if hasCoord {
+			mp.CoordinatorRequestID = "c"
+			mp.CoordinatorCompletionTokens = n
+		}
+		pairs = append(pairs, mp)
+	}
+	r := &Result{MatchedSuccesses: pairs}
+	computePerPairDrift(r)
+	if r.GatewayMinusHarnessTokens != 0 {
+		t.Errorf("production-shape clean pairs: want drift 0 (pre-fix would report 32), got %d", r.GatewayMinusHarnessTokens)
+	}
+	if r.GatewayMinusCoordinatorTokens != 0 {
+		t.Errorf("production-shape clean pairs vs coord: want drift 0, got %d", r.GatewayMinusCoordinatorTokens)
+	}
+}
+
+// TestComputePerPairDrift_NoCoordMatch verifies the "coord row missing"
+// branch: pairs without a coord match contribute to gateway-vs-harness
+// drift but NOT to gateway-vs-coord drift. The latter is a different
+// signal (gateway vs coord disagreement) and shouldn't double-count
+// pairs that simply lack a coord-side row.
+func TestComputePerPairDrift_NoCoordMatch(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 12, CoordinatorRequestID: ""},   // no coord match
+			{HarnessCompletionTokens: 8, GatewayCompletionTokens: 10, CoordinatorRequestID: "c2", CoordinatorCompletionTokens: 8},
+		},
+	}
+	computePerPairDrift(r)
+	if r.GatewayMinusHarnessTokens != 6 {
+		t.Errorf("want gateway-harness drift +6, got %d", r.GatewayMinusHarnessTokens)
+	}
+	// Only the second pair (with coord match) contributes to gw-coord drift: 10-8 = 2
+	if r.GatewayMinusCoordinatorTokens != 2 {
+		t.Errorf("want gateway-coord drift +2 (one pair with coord match), got %d", r.GatewayMinusCoordinatorTokens)
+	}
+}
+
+// TestComputePerPairDrift_GatewayUnderbilled is the inverse of the
+// overcharge case: the gateway billed FEWER tokens than the harness
+// observed. I1's check treats this as "allowed" (legitimate gateway-
+// side rounding on streaming) — the drift sum can be negative. This
+// test pins the sign convention so I1 stays consistent.
+func TestComputePerPairDrift_GatewayUnderbilled(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			{HarnessCompletionTokens: 10, GatewayCompletionTokens: 8},
+			{HarnessCompletionTokens: 10, GatewayCompletionTokens: 7},
+		},
+	}
+	computePerPairDrift(r)
+	if r.GatewayMinusHarnessTokens != -5 {
+		t.Errorf("underbill: want drift -5, got %d", r.GatewayMinusHarnessTokens)
+	}
+}
+
+// TestComputePerPairDrift_EmptyMatches handles the case where the run
+// reconciles but every harness success was unmatched (gateway empty or
+// SQL window mis-targeted). Drift should stay 0 here — unmatched ids
+// are a separate signal, not a token-count drift.
+func TestComputePerPairDrift_EmptyMatches(t *testing.T) {
+	r := &Result{MatchedSuccesses: nil}
+	computePerPairDrift(r)
+	if r.GatewayMinusHarnessTokens != 0 {
+		t.Errorf("empty matches: want drift 0, got %d", r.GatewayMinusHarnessTokens)
+	}
+	if r.GatewayMinusCoordinatorTokens != 0 {
+		t.Errorf("empty matches: want gw-coord drift 0, got %d", r.GatewayMinusCoordinatorTokens)
+	}
+}


### PR DESCRIPTION
Closes #226.

## Summary

I1's "gateway-coord/gateway-harness token drift" check was comparing population-mismatched aggregate sums:

```
GatewayCompletionTokens         = 265  (5 gateway rows with outcome="ok")
GatewayCompletionTokensFallback = 2240 (35 rows with stream_truncated etc.)
HarnessCompletionTokens         = 233  (all 40 harness "ok" responses)
```

The drift was computed as `GatewayCompletionTokens − HarnessCompletionTokens` = +32, which has nothing to do with money-path correctness — it's just the gap between 5 rows' worth of tokens and 40 rows' worth. The 2026-06-29 production e2e run tripped this on scenario 07 with exactly that shape.

## Fix

Replace aggregate-sum drift with **per-pair drift** computed across `r.MatchedSuccesses` after `matchByFuzzy`:

```go
for _, p := range r.MatchedSuccesses {
    r.GatewayMinusHarnessTokens += p.GatewayCompletionTokens - p.HarnessCompletionTokens
    if p.CoordinatorRequestID != "" {
        r.GatewayMinusCoordinatorTokens += p.GatewayCompletionTokens - p.CoordinatorCompletionTokens
    }
}
```

`matchByFuzzy` already pairs harness successes with gateway rows under `isSettlementComplete` (which includes the fallback outcomes), so the matching itself was correct — only the drift accounting was broken.

Unmatched harness successes continue to surface via `r.UnmatchedSuccesses`, which I1 inspects separately. The "missing on gateway" signal is preserved.

## What lands

- `internal/reconcile/ledger.go`: `computePerPairDrift` helper; replaces the two-line aggregate-sum drift computation. Comments doc-link to #226 and explain the population-mismatch failure mode.
- `internal/reconcile/ledger_test.go` (new): 6 tests covering clean matches, real overcharge, the production scenario-07 shape (40 pairs with matching tokens → 0 drift, was reporting +32), no-coord-match, underbilled, and empty-matches edge cases.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/reconcile/` — 6 new tests pass
- [x] `go test ./...` — full harness suite green
- [x] Production verification: the scenario 07 pattern that tripped I1 on 2026-06-29 (40 successes / 5 gateway-ok / 35 gateway-fallback / 32-token phantom drift) now yields 0 drift in the test reproducing that shape.
- [ ] Re-run scenario 07 against live Pearl after merge — should PASS I1 (defer to a separate e2e run after this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
