### PR TITLE
chore(harness): retune 07/09 using wall_p95 (closes #227)

### DIFF
--- a/test/network-harness/scenarios/07_sustained_throughput.yaml
+++ b/test/network-harness/scenarios/07_sustained_throughput.yaml
@@ -5,21 +5,26 @@
 # (TTFT p50), B2 (streaming TPS p50), B3 (tail ratio p99/p50), B4
 # (error rate /1000), B5 (slot util %).
 #
-# Pacing math (2026-06-28 baseline):
-#   B=2 buyers, wall ≈ 5.5s (TTFT ~300ms + 64 tokens @ ~14 tok/s).
-#   Pearl AccountConcurrency N=3.
-#   mean_active = B × wall / interval = 2 × 5.5 / 5.0 = 2.2 → under N.
-# The initial v0.1 run used interval=2500ms → mean_active=4.4 → 48%
-# non-2xx from queue contention. 5000ms is the tightest interval that
-# keeps mean_active under N with margin for tail jitter.
+# Pacing math (2026-06-29 e2e measurement):
+#   B=2 buyers, wall_p50=5.6s, wall_p95=11.8s, wall_p99=12.4s.
+#   Pearl AccountConcurrency N=3, margin 0.5 → effective cap N_eff=2.5.
+#   The 2026-06-28 retune used wall_p50 → interval=5000ms → mean_active
+#   at p95 spiked to 4.7 → 42% non-2xx (issue #227 production trip).
 #
-# requests_per_buyer = 50 gives 50 × 5s = 250s firing window, leaving
-# ~50s tail buffer for last-request completion within the 300s duration.
+# Use wall_p95 as the input so tail-spike concurrency stays under N_eff:
+#   interval ≥ B × wall_p95 / N_eff = 2 × 11791 / 2.5 = 9433ms
+#   Round up to 10000ms.
+#   mean_active at p95: 2 × 11.8 / 10 = 2.36 < N_eff ✓
+#   mean_active at p50: 2 × 5.6 / 10 = 1.12 (lots of headroom)
+#
+# requests_per_buyer = 30 gives 30 × 10s = 300s firing window per buyer.
+# Bumping duration to 360s leaves a 60s tail buffer for last-request
+# completion under p95 wall.
 #
 # Not a chaos test — providers should stay up the whole window. Any
 # 5xx in the error_taxonomy is real signal worth investigating.
 #
-# Cost estimate (~100 requests × 64 max_tokens): order of $0.05-0.10.
+# Cost estimate (~60 requests × 64 max_tokens): order of $0.03-0.06.
 #
 # See specs/SPEC-NETWORK-BENCHMARK-v0.1.md for thresholds + invariants.
 name: sustained_throughput
@@ -30,7 +35,7 @@ description: |
 
 expected_shape: |
   Phase B benchmark (descriptive, B-invariants asserted):
-   - ~100 requests over 5 min, all 200 (pacing keeps mean_active < N=3).
+   - ~60 requests over 6 min, all 200 (pacing uses wall_p95, not wall_p50).
    - 2 providers should both serve roughly half each.
    - TTFT p50 ≤ 800ms (target), ≤ 2000ms (bare-min).
    - Streaming TPS p50 ≥ 30 tok/s (target), ≥ 15 tok/s (bare-min).
@@ -49,10 +54,10 @@ buyers:
   count: 2
   stream: true
   pattern: interval
-  interval_ms: 5000
-  requests_per_buyer: 50
+  interval_ms: 10000
+  requests_per_buyer: 30
 
-duration: 300s
+duration: 360s
 request_timeout: 30s
 silent_hang_threshold: 15s
 

--- a/test/network-harness/scenarios/09_streaming_ttft_distribution.yaml
+++ b/test/network-harness/scenarios/09_streaming_ttft_distribution.yaml
@@ -4,18 +4,26 @@
 # 100 short streaming requests sequenced so each completes before the
 # next fires — gives a clean TTFT signal uncontaminated by queue wait.
 #
-# Pacing math (2026-06-28 baseline):
-#   B=1 buyer, wall ≈ 1.5s (TTFT ~300ms + 8 tokens @ ~14 tok/s).
-#   Pearl AccountConcurrency N=3.
-#   mean_active = B × wall / interval = 1 × 1.5 / 1.5 = 1.0 → well under N.
-# The initial v0.1 run used interval=500ms → mean_active=3.0 → 72% 503s.
-# 1500ms is the tightest interval that keeps the success path clean
-# without bloating wall-clock (100 × 1.5s = 150s, fits 180s duration).
+# Pacing math (2026-06-29 e2e measurement):
+#   B=1 buyer, wall_p50=2535ms (much higher than the 06-28 estimate of
+#   1500ms — even single short-stream completion takes 2.5s of WS routing
+#   + provider inference). wall_p95 inferred ~3000ms.
+#   Pearl AccountConcurrency N=3, margin 0.5 → N_eff=2.5.
+#
+#   At interval=1500ms (the 06-28 retune), mean_active at observed
+#   wall_p50 = 1 × 2.535 / 1.5 = 1.69. Under N_eff but not by much, and
+#   the 2026-06-29 run still saw 39% non-2xx. That residual rate is
+#   provider-pool instability at low load (file separately), not pure
+#   overload — but bumping interval to 2000ms gives more margin.
+#
+#   interval ≥ B × wall_p95 / N_eff = 1 × 3000 / 2.5 = 1200ms (theory)
+#   Set 2000ms for belt + suspenders, mean_active at p95 = 1.5 (under N_eff).
+#   100 × 2s = 200s firing window, fits 240s duration.
 #
 # Cost estimate (100 × 8 max_tokens): negligible.
 name: streaming_ttft_distribution
 description: |
-  100 sequential short streaming requests (max_tokens=8), 1500ms gap.
+  100 sequential short streaming requests (max_tokens=8), 2000ms gap.
   Characterizes the TTFT histogram; enough samples for stable
   percentiles. Benchmark — B1, B3.
 
@@ -39,10 +47,10 @@ buyers:
   count: 1
   stream: true
   pattern: interval
-  interval_ms: 1500
+  interval_ms: 2000
   requests_per_buyer: 100
 
-duration: 180s
+duration: 240s
 request_timeout: 30s
 silent_hang_threshold: 15s
 


### PR DESCRIPTION
Closes #227.

## Summary

The 2026-06-29 e2e run validated the v0.1→v0.2 retune was directionally right but undersized — error rates improved (52→58% on 07, 28→61% on 09) but stayed well above target. Root cause: the tail, not the median, drives overload.

```
scenario 07 measured (2026-06-29):
  wall_p50=5637ms   mean_active at p50/5000ms interval = 2.25 ✓
  wall_p95=11791ms  mean_active at p95/5000ms interval = 4.72 ✗  (over N=3)
```

This PR uses wall_p95 as the input to the pacing formula instead of wall_p50.

## Math

```
interval ≥ B × wall_p95 / N_eff      where N_eff = N - margin (margin = 0.5 → 2.5)
```

| Scenario | B | wall_p95 | new interval | mean_active@p95 | duration |
|---|---|---|---|---|---|
| 07 | 2 | 11791ms | 10000ms (was 5000) | 2.36 < N_eff | 300s → 360s |
| 09 | 1 | ~3000ms | 2000ms (was 1500) | 1.5 < N_eff | 180s → 240s |

Scenario 07: requests_per_buyer drops 50 → 30 to keep firing window ≤ duration (30 × 10s = 300s + 60s tail buffer).

Scenario 09: requests_per_buyer unchanged at 100. The 39% non-2xx on 06-29 is NOT pure overload at the new pacing — even at interval=2000ms with wall_p95=3000ms, mean_active is 1.5, well under N_eff. The residual is provider-pool instability at low load (scenario 08 also dropped 4/20 successes at 60s spacing), filed for separate investigation.

## What lands

- `scenarios/07_sustained_throughput.yaml`:
  - `interval_ms`: 5000 → **10000**
  - `requests_per_buyer`: 50 → **30**
  - `duration`: 300s → **360s**
  - Pacing-math comment block rewritten to cite 06-29 measurements + wall_p95 input.
- `scenarios/09_streaming_ttft_distribution.yaml`:
  - `interval_ms`: 1500 → **2000**
  - `requests_per_buyer`: 100 (unchanged)
  - `duration`: 180s → **240s**
  - Same comment rewrite.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full harness suite green
- [x] Dry-run both retuned scenarios — parse + Validate() clean
- [ ] Re-run against live Pearl post-merge — expected success rates ≥ 95% for 07, residual 09 rate documented as pool-instability separate from this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
