### PR TITLE
spec(002,005): v1.5.1 / v0.3.2 — R-2 normative clarifications + sanitizer hardening (closes #197)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/migrate_indexes.go
+++ b/phase4-coordinator/cmd/coordinator/migrate_indexes.go
@@ -13,6 +13,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -32,23 +33,73 @@ func runMigrateIndexesIO(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	configPath := fs.String("config", "coordinator.yaml", "path to coordinator YAML config")
 	timeout := fs.Duration("timeout", 30*time.Minute, "max time the index build may run")
+	// SPEC-002 v1.5.1 R-2 / issue #197: --check reports per-key
+	// migration state without mutating the schema. Intended for
+	// reconciliation tooling and operator dashboards.
+	check := fs.Bool("check", false, "report migration state without building indexes")
+	format := fs.String("format", "text", "output format when --check is set: text|json")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+	// SPEC-002 v1.5.1 R-2 / issue #197 R2 code: validate --format BEFORE
+	// touching the store so an invalid --format never causes an open
+	// that could trigger ALTER TABLE on a legacy DB.
+	if *check {
+		switch *format {
+		case "json", "text", "":
+		default:
+			fmt.Fprintf(stderr, "unknown --format %q (want text|json)\n", *format)
+			return 2
+		}
 	}
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "config: %v\n", err)
 		return 1
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	if *check {
+		// Read-only path: do NOT run migrations. A legacy DB MUST be
+		// observable as state `legacy` here; otherwise the operator
+		// can't tell whether they need to run the daemon first.
+		store, err := requestlog.OpenStoreReadOnly(cfg.Storage.DBPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "open request_log store (ro): %v\n", err)
+			return 1
+		}
+		defer store.Close()
+		status, err := store.MigrationState(ctx)
+		if err != nil {
+			fmt.Fprintf(stderr, "MigrationState: %v\n", err)
+			return 1
+		}
+		switch *format {
+		case "json":
+			enc := json.NewEncoder(stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(status); err != nil {
+				fmt.Fprintf(stderr, "encode json: %v\n", err)
+				return 1
+			}
+		case "text", "":
+			fmt.Fprintf(stdout, "migration_state: %s\n", status.Aggregate)
+			for _, k := range status.Keys {
+				fmt.Fprintf(stdout, "  %s: %s (columns_present=%t index=%s index_present=%t)\n",
+					k.Key, k.State, k.ColumnsPresent, k.IndexName, k.IndexPresent)
+			}
+		}
+		return 0
+	}
+
 	store, err := requestlog.OpenStore(cfg.Storage.DBPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "open request_log store: %v\n", err)
 		return 1
 	}
 	defer store.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
-	defer cancel()
 
 	started := time.Now()
 	if err := store.MigrateIndexes(ctx); err != nil {

--- a/phase4-coordinator/cmd/coordinator/migrate_indexes_test.go
+++ b/phase4-coordinator/cmd/coordinator/migrate_indexes_test.go
@@ -1,0 +1,172 @@
+package main
+
+// SPEC-002 v1.5.1 R-2 / issue #197 R2 code: `migrate-indexes --check`
+// MUST be read-only — running the daemon's migrate() inside --check
+// would silently advance a legacy DB to "unindexed" before reporting
+// state, defeating the operator's ability to see the pre-migration
+// state. This test pins that contract.
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestMigrateIndexesCheckIsReadOnly pre-seeds a legacy-schema
+// request_log (no external_request_id / account_id columns) and runs
+// the --check subcommand. The schema MUST be unchanged after the
+// command exits, and the JSON output MUST report aggregate "legacy".
+func TestMigrateIndexesCheckIsReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "coordinator.db")
+	configPath := filepath.Join(dir, "coordinator.yaml")
+
+	// Seed a legacy request_log: only the v1.0 columns the
+	// coordinator originally shipped. external_request_id and
+	// account_id are intentionally absent so MigrationState
+	// reports state "legacy".
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE request_log (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		ts_utc TEXT NOT NULL,
+		request_id TEXT NOT NULL,
+		model TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("seed legacy schema: %v", err)
+	}
+	_ = db.Close()
+
+	if err := os.WriteFile(configPath, []byte("auth:\n  operator_key: test-operator-key\nstorage:\n  db_path: "+dbPath+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	rc := runMigrateIndexesIO([]string{"--config", configPath, "--check", "--format", "json"}, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+
+	var got struct {
+		MigrationState string `json:"migration_state"`
+		Keys           []struct {
+			Key            string `json:"key"`
+			ColumnsPresent bool   `json:"columns_present"`
+			IndexPresent   bool   `json:"index_present"`
+			State          string `json:"state"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode json: %v\nstdout=%s", err, stdout.String())
+	}
+	if got.MigrationState != "legacy" {
+		t.Fatalf("migration_state=%q, want legacy: stdout=%s", got.MigrationState, stdout.String())
+	}
+	if len(got.Keys) == 0 {
+		t.Fatalf("keys empty: %s", stdout.String())
+	}
+	for _, k := range got.Keys {
+		if k.State != "legacy" {
+			t.Errorf("key %q state=%q, want legacy", k.Key, k.State)
+		}
+		if k.ColumnsPresent {
+			t.Errorf("key %q columns_present=true on legacy schema", k.Key)
+		}
+		if k.IndexPresent {
+			t.Errorf("key %q index_present=true on legacy schema", k.Key)
+		}
+	}
+
+	// Critical assertion: --check did NOT run migrate(). Re-open
+	// the raw DB and verify the legacy columns are still missing.
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer db.Close()
+	rows, err := db.QueryContext(context.Background(), `PRAGMA table_info(request_log)`)
+	if err != nil {
+		t.Fatalf("table_info: %v", err)
+	}
+	defer rows.Close()
+	cols := map[string]bool{}
+	for rows.Next() {
+		var cid int
+		var name, ctype, dflt sql.NullString
+		var notnull, pk int
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		cols[name.String] = true
+	}
+	if cols["external_request_id"] {
+		t.Errorf("--check mutated schema: external_request_id column present after read-only invocation")
+	}
+	if cols["account_id"] {
+		t.Errorf("--check mutated schema: account_id column present after read-only invocation")
+	}
+}
+
+// TestMigrateIndexesCheckRejectsBogusFormatBeforeOpen ensures the
+// `--format` validation happens before OpenStore, so an invalid
+// --format never triggers a write to the DB on a legacy schema.
+func TestMigrateIndexesCheckRejectsBogusFormatBeforeOpen(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "coordinator.db")
+	configPath := filepath.Join(dir, "coordinator.yaml")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE request_log (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		ts_utc TEXT NOT NULL,
+		request_id TEXT NOT NULL,
+		model TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_ = db.Close()
+	if err := os.WriteFile(configPath, []byte("auth:\n  operator_key: test-operator-key\nstorage:\n  db_path: "+dbPath+"\n"), 0o644); err != nil {
+		t.Fatalf("config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	rc := runMigrateIndexesIO([]string{"--config", configPath, "--check", "--format", "bogus"}, &stdout, &stderr)
+	if rc != 2 {
+		t.Fatalf("rc=%d, want 2 for bogus --format; stderr=%s", rc, stderr.String())
+	}
+
+	// Verify the legacy schema is still legacy.
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer db.Close()
+	rows, err := db.QueryContext(context.Background(), `PRAGMA table_info(request_log)`)
+	if err != nil {
+		t.Fatalf("table_info: %v", err)
+	}
+	defer rows.Close()
+	cols := map[string]bool{}
+	for rows.Next() {
+		var cid int
+		var name, ctype, dflt sql.NullString
+		var notnull, pk int
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		cols[name.String] = true
+	}
+	if cols["external_request_id"] || cols["account_id"] {
+		t.Errorf("bogus --format triggered schema migration before format validation")
+	}
+}

--- a/phase4-coordinator/internal/buyer/billing_recorder.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder.go
@@ -156,7 +156,7 @@ func (b *billingRecorder) recordRow(
 		RequestID:           b.requestID,
 		ExternalRequestID:   b.externalRequestID,
 		AccountID:           b.accountID,
-		Model:               b.model,
+		Model:               sanitizeRequestLogText(b.model),
 		ProviderAssignedID:  providerAssignedID,
 		PromptTokens:        promptTok,
 		CompletionTokens:    completionTok,

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 	"github.com/augstar/macprovider-coordinator/internal/billing"
@@ -767,7 +768,7 @@ func (s *Server) handlePoolCheck(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusTooManyRequests, "rate_limited", "Pool check rate limit exceeded")
 		return
 	}
-	providerID := strings.TrimSpace(r.URL.Query().Get("provider_id"))
+	providerID := sanitizeRequestLogText(r.URL.Query().Get("provider_id"))
 	if providerID == "" {
 		writeError(w, http.StatusBadRequest, "invalid_request", "Missing provider_id")
 		return
@@ -4987,9 +4988,13 @@ func normalizeIdempotencyKey(value string) string {
 //   - Cap at 128 bytes (UUID v4 is 36; allowing for vendor-prefixed
 //     ids like "req_<48hex>" gives reasonable headroom without
 //     unbounded growth).
-//   - Reject control characters (< 0x20, 0x7f, and the C1 range
-//     0x80-0x9f) to keep the value safe for structured logs and DB
-//     storage.
+//   - Reject control characters byte-by-byte (< 0x20, 0x7f, and the
+//     C1 range 0x80-0x9f) so raw control bytes cannot slip past as
+//     `utf8.RuneError` under rune iteration. (See SPEC-002 v1.5.1 +
+//     issue #197 R1 security: raw 0x9b CSI bytes were bypassing the
+//     prior rune-based loop.)
+//   - Reject invalid UTF-8 outright; the coordinator stores this in
+//     structured logs and SQLite, both of which assume UTF-8.
 //
 // On failure, returns "" — the coordinator treats the value as if no
 // header was present, which is allowed by §11 ("If absent, coordinator
@@ -4997,33 +5002,39 @@ func normalizeIdempotencyKey(value string) string {
 // surfaced to the buyer; logging it as-is would replay any
 // log-injection payload.
 func sanitizeExternalRequestID(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" || len(value) > 128 {
-		return ""
-	}
-	for _, r := range value {
-		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
-			return ""
-		}
-	}
-	return value
+	return sanitizeOpaqueHeader(value)
 }
 
 // sanitizeAccountID normalizes the inbound X-MacProvider-Account header
 // for persistent storage in request_log.account_id (SPEC-002 v1.5.0,
 // issue #211). Same defense-in-depth shape as sanitizeExternalRequestID:
 // trim, cap at 128 bytes (gateway account ids are "acct_<...>" or
-// "demo:<ip>" — both well under 128), reject C0/C1 control characters.
-// On failure, returns "" — the coordinator treats the value as if no
-// header was present, which is allowed by SPEC-002 v1.5.0 ("Absent
-// header MUST be tolerated; the column carries NULL in that case").
+// "demo:<ip>" — both well under 128), reject C0/C1 control characters
+// byte-by-byte, reject invalid UTF-8. On failure, returns "" — the
+// coordinator treats the value as if no header was present, which is
+// allowed by SPEC-002 v1.5.0 ("Absent header MUST be tolerated; the
+// column carries NULL in that case").
 func sanitizeAccountID(value string) string {
+	return sanitizeOpaqueHeader(value)
+}
+
+// sanitizeOpaqueHeader is the shared byte-level defense-in-depth filter
+// for opaque-sanitized-text headers (X-Request-ID, X-MacProvider-Account).
+// SPEC-002 v1.5.1 R-2: 1-128 bytes, valid UTF-8, no control characters
+// in C0 (0x00-0x1f), DEL (0x7f), or C1 (0x80-0x9f). Iterating runes is
+// NOT sufficient — raw bytes in the C1 range decode to utf8.RuneError
+// (U+FFFD) which would pass a rune-only check.
+func sanitizeOpaqueHeader(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" || len(value) > 128 {
 		return ""
 	}
-	for _, r := range value {
-		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+	if !utf8.ValidString(value) {
+		return ""
+	}
+	for i := 0; i < len(value); i++ {
+		b := value[i]
+		if b < 0x20 || b == 0x7f || (b >= 0x80 && b <= 0x9f) {
 			return ""
 		}
 	}
@@ -5050,8 +5061,21 @@ func buyerIP(remoteAddr string) string {
 
 func sanitizeRequestLogText(value string) string {
 	const maxRunes = 256
+	// SPEC-002 v1.5.1 / issue #197 R2 security: text fields persisted in
+	// request_log (error, pref_header, provider_header, model) carry the
+	// same log-injection / terminal-CSI risk as the opaque header IDs.
+	// Reject invalid UTF-8 outright so raw C1 bytes (e.g. 0x9b) cannot
+	// slip through as `utf8.RuneError` (U+FFFD) during rune iteration;
+	// after that gate, strip C0/DEL/C1 codepoints via the rune map.
+	// (Multi-byte UTF-8 continuation bytes 0x80-0xbf are only "in range"
+	// at byte level, but valid UTF-8 sequences resolve to a single
+	// codepoint outside C1 — so the rune-level strip is safe AFTER the
+	// utf8.ValidString gate.)
+	if !utf8.ValidString(value) {
+		return ""
+	}
 	value = strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
 			return -1
 		}
 		return r

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -1259,6 +1259,14 @@ func TestRequestLogExternalRequestIDRejectsMalformedHeader(t *testing.T) {
 		"control_lf":   "req-\nabc",
 		"del_char":     "req-\x7fabc",
 		"over_128":     strings.Repeat("a", 129),
+		// SPEC-002 v1.5.1 R-2 / issue #197 R1 security + code lanes:
+		// raw C1 bytes must be rejected at byte level (rune iteration
+		// would decode 0x80-0x9f to utf8.RuneError and accept them).
+		"c1_low":             "req-\x80abc",
+		"c1_csi":             "req-\x9babc",
+		"c1_high":            "req-\x9fabc",
+		"invalid_utf8_lead":  "req-\xc3abc",
+		"invalid_utf8_alone": "req-\xff",
 	} {
 		t.Run(name, func(t *testing.T) {
 			reqLog, dbPath := openBuyerRequestLog(t)
@@ -1281,6 +1289,53 @@ func TestRequestLogExternalRequestIDRejectsMalformedHeader(t *testing.T) {
 					rows[0].ExternalRequestID)
 			}
 		})
+	}
+}
+
+// TestRequestLogModelFieldSanitized pins SPEC-002 v1.5.1 R3 security:
+// buyer-supplied `model` JSON value must be sanitized before persisting
+// to request_log.model. JSON tolerates `""` (valid UTF-8 for
+// U+009B CSI), so a buyer can land C1 codepoints in the model column
+// unless we sanitize on the way in. The sanitizer strips C1 codepoints
+// so the persisted value loses them (and the model lookup naturally
+// fails because no provider serves a malformed model name).
+func TestRequestLogModelFieldSanitized(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`))
+	}))
+	defer upstream.Close()
+
+	reqLog, dbPath := openBuyerRequestLog(t)
+	defer reqLog.Close()
+	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: upstream.URL}})
+	registerWithEndpoint(registry, "p1", "s1", "model-a", pool.StateReady, 20000, 1, upstream.URL, 20)
+	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0), buyer.WithRequestLog(reqLog))
+
+	// model contains valid UTF-8 for U+009B (CSI). The sanitizer
+	// strips C1 codepoints → "modelabc" lands in request_log; lookup
+	// then 404s because no provider serves that name. The key
+	// assertion is that the persisted column does not contain raw
+	// or escaped C1.
+	body := []byte("{\"model\":\"model\xc2\x9babc\",\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}]}")
+	rr := postChat(t, server, body, nil)
+	if rr.Code == http.StatusOK {
+		t.Fatalf("expected 4xx for C1-bearing model; got status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	// The unknown-model buyer-failure path writes a 4xx request_log
+	// row via logBuyerFailure. That row's model column MUST contain
+	// the SANITIZED value (C1 stripped, "modelabc") - proving the
+	// sanitizer is on the persistence path even for buyer-failure
+	// rows, not just success rows.
+	rows := queryAllRequestLogRows(t, dbPath)
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d, want 1 buyer-failure row: %#v", len(rows), rows)
+	}
+	row := rows[0]
+	if strings.ContainsRune(row.Model, 0x9b) {
+		t.Fatalf("request_log.model contains C1 codepoint U+009B: %q", row.Model)
+	}
+	if row.Model != "modelabc" {
+		t.Fatalf("request_log.model = %q, want %q (C1 stripped)", row.Model, "modelabc")
 	}
 }
 

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -67,6 +67,27 @@ type Row struct {
 	Retried             int
 }
 
+// OpenStoreReadOnly opens the request-log DB without running ALTER
+// TABLE migrations or any other schema-mutating DDL. SPEC-002 v1.5.1
+// R-2 / issue #197 R2 code: the `coordinator migrate-indexes --check`
+// path MUST be read-only — running the daemon's migrate() inside
+// --check would silently advance a legacy DB to "unindexed" before
+// reporting state, defeating the operator's ability to inspect the
+// pre-migration state. `MigrationState` is the only supported
+// operation on a read-only store.
+func OpenStoreReadOnly(dbPath string) (*Store, error) {
+	if dbPath == "" {
+		return nil, fmt.Errorf("db path is required")
+	}
+	db, err := sql.Open("sqlite", sqliteutil.ReadOnlyDSN(dbPath))
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	return &Store{db: db}, nil
+}
+
 func OpenStore(dbPath string) (*Store, error) {
 	if dbPath == "" {
 		return nil, fmt.Errorf("db path is required")
@@ -427,6 +448,124 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 	return s.requireColumns(ctx, []string{"id", "ts_utc", "request_id", "model"})
 }
 
+// MigrationKeyState reports the migration state of a single
+// composite reconciliation key (SPEC-002 v1.5.1 R-2):
+//   - legacy: required column absent.
+//   - unindexed: column present but the partial-NULL composite
+//     index has not been built yet ("rollout incomplete").
+//   - indexed: column present AND index present.
+type MigrationKeyState struct {
+	Key            string `json:"key"`
+	ColumnNames    []string `json:"column_names"`
+	ColumnsPresent bool   `json:"columns_present"`
+	IndexName      string `json:"index_name"`
+	IndexPresent   bool   `json:"index_present"`
+	State          string `json:"state"`
+}
+
+// MigrationStatus is the aggregate migration state across every
+// composite reconciliation key on request_log. Aggregate rule:
+//   - "legacy" if ANY key has columns absent.
+//   - "indexed" only if EVERY key is indexed.
+//   - "unindexed" otherwise (columns present everywhere; one or more
+//     indexes still missing).
+//
+// SPEC-002 v1.5.1 R-2 names "legacy" | "unindexed" | "indexed" as the
+// canonical migration_state enum; tooling MUST use these strings rather
+// than inventing private vocabulary.
+type MigrationStatus struct {
+	Aggregate string              `json:"migration_state"`
+	Keys      []MigrationKeyState `json:"keys"`
+}
+
+// migrationKeyDefs is the registry of composite reconciliation keys on
+// request_log. Order is normative — the JSON output of `migrate-indexes
+// --check --format json` enumerates entries in this order, and the
+// `key` strings are stable contract. Append-only: future SPEC versions
+// add composite reconciliation keys by appending new entries and MUST
+// NOT rename existing key strings. Consumers MUST match by `key` and
+// tolerate additional entries. Same registry drives `MigrationState`
+// (read) and `MigrateIndexes` (build) — DDL and index name live here
+// to prevent drift.
+//
+// MUST be non-empty: an empty registry is an implementation error, NOT
+// an `indexed` deployment.
+var migrationKeyDefs = []struct {
+	Key       string
+	Columns   []string
+	IndexName string
+	DDL       string
+}{
+	{
+		// SPEC-002 v1.4.2 R-2.
+		Key:       "external_request_id",
+		Columns:   []string{"external_request_id"},
+		IndexName: "idx_request_log_external_request_id",
+		DDL:       `CREATE INDEX idx_request_log_external_request_id ON request_log(external_request_id) WHERE external_request_id IS NOT NULL`,
+	},
+	{
+		// SPEC-002 v1.5.0 / issue #211.
+		Key:       "account_external_request_id",
+		Columns:   []string{"account_id", "external_request_id"},
+		IndexName: "idx_request_log_account_external_request_id",
+		DDL:       `CREATE INDEX idx_request_log_account_external_request_id ON request_log(account_id, external_request_id) WHERE account_id IS NOT NULL AND external_request_id IS NOT NULL`,
+	},
+}
+
+// MigrationState introspects PRAGMA table_info(request_log) and
+// sqlite_master and returns the migration state per composite key plus
+// the aggregate. Read-only — safe to call concurrently with daemon
+// inserts. SPEC-002 v1.5.1 R-2: reconciliation tooling MUST use this
+// (or the equivalent direct introspection) to decide join strategy,
+// and MUST report the "unindexed" state distinctly rather than falling
+// back to fuzzy match.
+func (s *Store) MigrationState(ctx context.Context) (MigrationStatus, error) {
+	cols, err := s.columns(ctx)
+	if err != nil {
+		return MigrationStatus{}, err
+	}
+	out := MigrationStatus{Aggregate: "indexed"}
+	for _, def := range migrationKeyDefs {
+		ks := MigrationKeyState{
+			Key:         def.Key,
+			ColumnNames: append([]string{}, def.Columns...),
+			IndexName:   def.IndexName,
+		}
+		ks.ColumnsPresent = true
+		for _, c := range def.Columns {
+			if !cols[c] {
+				ks.ColumnsPresent = false
+				break
+			}
+		}
+		var existing string
+		switch err := s.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='index' AND name=?`, def.IndexName).Scan(&existing); err {
+		case nil:
+			ks.IndexPresent = true
+		case sql.ErrNoRows:
+			ks.IndexPresent = false
+		default:
+			return MigrationStatus{}, err
+		}
+		switch {
+		case !ks.ColumnsPresent:
+			ks.State = "legacy"
+		case !ks.IndexPresent:
+			ks.State = "unindexed"
+		default:
+			ks.State = "indexed"
+		}
+		out.Keys = append(out.Keys, ks)
+		switch {
+		case ks.State == "legacy":
+			out.Aggregate = "legacy"
+		case ks.State == "unindexed" && out.Aggregate != "legacy":
+			out.Aggregate = "unindexed"
+		}
+	}
+	return out, nil
+}
+
 // MigrateIndexes builds the request_log indexes whose underlying
 // columns ensureColumns has already added.
 //
@@ -443,29 +582,12 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 // calls are cheap: a sqlite_master point lookup decides whether the
 // DDL runs at all.
 func (s *Store) MigrateIndexes(ctx context.Context) error {
-	// SPEC-002 v1.4.2 R-2: reconciliation scans join gateway
-	// usage_events to request_log on external_request_id; the
-	// partial-NULL index keeps the index small (legacy rows have
-	// NULL and are not indexed).
-	indexes := []struct {
-		name string
-		ddl  string
-	}{
-		{
-			name: "idx_request_log_external_request_id",
-			ddl:  `CREATE INDEX idx_request_log_external_request_id ON request_log(external_request_id) WHERE external_request_id IS NOT NULL`,
-		},
-		// SPEC-002 v1.5.0 / issue #211: composite reconciliation-key
-		// index. Partial-NULL keeps the index small (legacy rows
-		// have NULL on either column and are not indexed).
-		{
-			name: "idx_request_log_account_external_request_id",
-			ddl:  `CREATE INDEX idx_request_log_account_external_request_id ON request_log(account_id, external_request_id) WHERE account_id IS NOT NULL AND external_request_id IS NOT NULL`,
-		},
-	}
-	for _, ix := range indexes {
+	// SPEC-002 v1.5.1 R-2 / issue #197: iterate the shared
+	// migrationKeyDefs registry so MigrateIndexes and MigrationState
+	// cannot drift on index names.
+	for _, def := range migrationKeyDefs {
 		var existing string
-		switch err := s.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='index' AND name=?`, ix.name).Scan(&existing); err {
+		switch err := s.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='index' AND name=?`, def.IndexName).Scan(&existing); err {
 		case nil:
 			continue
 		case sql.ErrNoRows:
@@ -473,7 +595,7 @@ func (s *Store) MigrateIndexes(ctx context.Context) error {
 		default:
 			return err
 		}
-		if _, err := s.db.ExecContext(ctx, ix.ddl); err != nil {
+		if _, err := s.db.ExecContext(ctx, def.DDL); err != nil {
 			return err
 		}
 	}

--- a/phase4-coordinator/internal/requestlog/store_test.go
+++ b/phase4-coordinator/internal/requestlog/store_test.go
@@ -652,6 +652,102 @@ func openTestStore(t *testing.T) *Store {
 	return store
 }
 
+// TestMigrationStateReportsPerKeyStatesAndAggregate exercises SPEC-002
+// v1.5.1 R-2 / issue #197: MigrationState MUST report per-key state
+// (legacy | unindexed | indexed) plus an aggregate, distinguishing
+// "column-present + index-absent" (unindexed) from "column-absent"
+// (legacy) so reconciliation tooling can fail closed under state (B)
+// rather than silently fuzzy-matching.
+func TestMigrationStateReportsPerKeyStatesAndAggregate(t *testing.T) {
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	// Fresh OpenStore: both columns present (ensureColumns ran), no
+	// composite-PK indexes (MigrateIndexes is operator-driven). This
+	// is the "unindexed" / state (B) rollout window for both keys.
+	status, err := store.MigrationState(ctx)
+	if err != nil {
+		t.Fatalf("MigrationState: %v", err)
+	}
+	if status.Aggregate != "unindexed" {
+		t.Fatalf("aggregate=%q, want unindexed (state B both keys)", status.Aggregate)
+	}
+	if len(status.Keys) != 2 {
+		t.Fatalf("len(keys)=%d, want 2: %#v", len(status.Keys), status.Keys)
+	}
+	for _, k := range status.Keys {
+		if k.State != "unindexed" {
+			t.Errorf("key %q state=%q, want unindexed", k.Key, k.State)
+		}
+		if !k.ColumnsPresent {
+			t.Errorf("key %q columns_present=false, want true", k.Key)
+		}
+		if k.IndexPresent {
+			t.Errorf("key %q index_present=true, want false", k.Key)
+		}
+	}
+
+	if err := store.MigrateIndexes(ctx); err != nil {
+		t.Fatalf("MigrateIndexes: %v", err)
+	}
+	status, err = store.MigrationState(ctx)
+	if err != nil {
+		t.Fatalf("MigrationState post-migrate: %v", err)
+	}
+	if status.Aggregate != "indexed" {
+		t.Fatalf("aggregate post-migrate=%q, want indexed", status.Aggregate)
+	}
+	for _, k := range status.Keys {
+		if k.State != "indexed" {
+			t.Errorf("key %q post-migrate state=%q, want indexed", k.Key, k.State)
+		}
+		if !k.IndexPresent {
+			t.Errorf("key %q post-migrate index_present=false", k.Key)
+		}
+	}
+
+	// Simulate a partial-rollout legacy mix: drop both indexes (their
+	// account_id reference would block DROP COLUMN), then drop the
+	// account_id column. account_external_request_id key → legacy
+	// (column absent). external_request_id key → unindexed (column
+	// present, no index). Aggregate MUST be legacy (any-legacy wins).
+	if _, err := store.db.ExecContext(ctx, `DROP INDEX idx_request_log_account_external_request_id`); err != nil {
+		t.Fatalf("DROP INDEX composite: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `DROP INDEX idx_request_log_external_request_id`); err != nil {
+		t.Fatalf("DROP INDEX ext: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `ALTER TABLE request_log DROP COLUMN account_id`); err != nil {
+		t.Skipf("DROP COLUMN unsupported on this sqlite build (need 3.35+): %v", err)
+	}
+	status, err = store.MigrationState(ctx)
+	if err != nil {
+		t.Fatalf("MigrationState mixed: %v", err)
+	}
+	if status.Aggregate != "legacy" {
+		t.Fatalf("aggregate mixed=%q, want legacy (any-legacy wins)", status.Aggregate)
+	}
+	var sawLegacy, sawUnindexed bool
+	for _, k := range status.Keys {
+		switch k.Key {
+		case "account_external_request_id":
+			if k.State != "legacy" {
+				t.Errorf("account key state=%q, want legacy", k.State)
+			}
+			sawLegacy = true
+		case "external_request_id":
+			if k.State != "unindexed" {
+				t.Errorf("ext key state=%q, want unindexed", k.State)
+			}
+			sawUnindexed = true
+		}
+	}
+	if !sawLegacy || !sawUnindexed {
+		t.Fatalf("expected one legacy + one unindexed key; got %#v", status.Keys)
+	}
+}
+
 // TestOpenStoreCapsPoolAtOneConn pins the SetMaxOpenConns(1) +
 // SetMaxIdleConns(1) discipline at the constructor that owns it. Issue
 // #21 / ARCH-3: billing reuses this *sql.DB via

--- a/phase4-coordinator/internal/sqliteutil/dsn.go
+++ b/phase4-coordinator/internal/sqliteutil/dsn.go
@@ -29,3 +29,26 @@ func WithPragmas(path string) string {
 	}
 	return path + separator + values.Encode()
 }
+
+// ReadOnlyDSN builds a strictly read-only modernc.org/sqlite DSN.
+// Opens with mode=ro and applies PRAGMA query_only=ON at connection
+// init via a pragma — no journal_mode toggle, no synchronous toggle,
+// no writable connection. SPEC-002 v1.5.1 R-2 / issue #197 R3 code:
+// used by `coordinator migrate-indexes --check` so the read-only
+// introspection never persists journal-mode metadata or runs ALTER
+// TABLE on a legacy DB.
+func ReadOnlyDSN(path string) string {
+	values := url.Values{}
+	values.Set("mode", "ro")
+	for _, pragma := range []string{
+		"busy_timeout=5000",
+		"query_only(true)",
+	} {
+		values.Add("_pragma", pragma)
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + values.Encode()
+}

--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -291,6 +291,9 @@ func ParseHello(payload []byte) (Hello, string, error) {
 		if err := json.Unmarshal(v, &h.ModelHash); err != nil {
 			return Hello{}, "model_hash", err
 		}
+		if containsControlChar(h.ModelHash) {
+			return Hello{}, "model_hash", fieldError{Field: "model_hash"}
+		}
 	}
 	if err := requireFloat(raw, "model_params_b", &h.ModelParamsB); err != nil {
 		return Hello{}, err.Field, err
@@ -323,6 +326,9 @@ func ParseHello(payload []byte) (Hello, string, error) {
 		var endpoint string
 		if err := json.Unmarshal(v, &endpoint); err != nil {
 			return Hello{}, "endpoint_url", err
+		}
+		if containsControlChar(endpoint) {
+			return Hello{}, "endpoint_url", fieldError{Field: "endpoint_url"}
 		}
 		h.EndpointURL = &endpoint
 	}
@@ -390,6 +396,9 @@ func parseAuthInitial(raw map[string]json.RawMessage, req AuthRequest) (AuthRequ
 		if err := json.Unmarshal(v, &req.ModelHash); err != nil {
 			return AuthRequest{}, Spec010Presence{}, "model_hash", err
 		}
+		if containsControlChar(req.ModelHash) {
+			return AuthRequest{}, Spec010Presence{}, "model_hash", fieldError{Field: "model_hash"}
+		}
 	}
 	if err := requireFloat(raw, "model_params_b", &req.ModelParamsB); err != nil {
 		return AuthRequest{}, Spec010Presence{}, err.Field, err
@@ -418,6 +427,9 @@ func parseAuthInitial(raw map[string]json.RawMessage, req AuthRequest) (AuthRequ
 		var endpoint string
 		if err := json.Unmarshal(v, &endpoint); err != nil {
 			return AuthRequest{}, Spec010Presence{}, "endpoint_url", err
+		}
+		if containsControlChar(endpoint) {
+			return AuthRequest{}, Spec010Presence{}, "endpoint_url", fieldError{Field: "endpoint_url"}
 		}
 		req.EndpointURL = &endpoint
 	}
@@ -578,7 +590,26 @@ func requireString(raw map[string]json.RawMessage, field string, out *string) *f
 	if err := json.Unmarshal(v, out); err != nil || *out == "" {
 		return &fieldError{Field: field}
 	}
+	if containsControlChar(*out) {
+		return &fieldError{Field: field}
+	}
 	return nil
+}
+
+// containsControlChar reports whether s contains any C0 control
+// (`<0x20`), DEL (`0x7f`), or C1 control (`0x80-0x9f`) codepoint.
+// SPEC-002 v1.5.1 R-2 / issue #197 R4-R5 security: provider-controlled
+// strings reaching structured logs or close-frame reason fields MUST
+// be rejected when they carry these codepoints. JSON `` decodes
+// to U+009B and is valid UTF-8 but would otherwise inject a terminal
+// CSI sequence into log sinks.
+func containsControlChar(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			return true
+		}
+	}
+	return false
 }
 
 func requireInt(raw map[string]json.RawMessage, field string, out *int) *fieldError {
@@ -660,6 +691,9 @@ func ParseHeartbeat(payload []byte) (Heartbeat, HeartbeatPresence, string, error
 		if err := json.Unmarshal(v, &hb.ModelHash); err != nil {
 			return Heartbeat{}, presence, "model_hash", err
 		}
+		if containsControlChar(hb.ModelHash) {
+			return Heartbeat{}, presence, "model_hash", fieldError{Field: "model_hash"}
+		}
 	}
 	if v, ok := raw["loading"]; ok {
 		presence.Loading = true
@@ -690,9 +724,15 @@ func ParseStateUpdate(payload []byte) (StateUpdate, string, error) {
 	}
 	if v, ok := raw["reason"]; ok {
 		_ = json.Unmarshal(v, &update.Reason)
+		if containsControlChar(update.Reason) {
+			return StateUpdate{}, "reason", fieldError{Field: "reason"}
+		}
 	}
 	if v, ok := raw["since"]; ok {
 		_ = json.Unmarshal(v, &update.Since)
+		if containsControlChar(update.Since) {
+			return StateUpdate{}, "since", fieldError{Field: "since"}
+		}
 	}
 	if v, ok := raw["metrics_snapshot"]; ok && string(v) != "null" {
 		if err := json.Unmarshal(v, &update.MetricsSnapshot); err != nil {
@@ -712,6 +752,9 @@ func ParsePreflightAck(payload []byte) (PreflightAck, string, error) {
 	}
 	if ack.RequestID == "" {
 		return PreflightAck{}, "request_id", fieldError{Field: "missing request_id"}
+	}
+	if containsControlChar(ack.RequestID) {
+		return PreflightAck{}, "request_id", fieldError{Field: "request_id"}
 	}
 	if !ack.Accepted {
 		if _, ok := preflightRejectionReasons[ack.Reason]; !ok {
@@ -756,6 +799,19 @@ func ParseNak(payload []byte) (Nak, string, error) {
 	}
 	if nak.Error.Code == "" {
 		return Nak{}, "error.code", fieldError{Field: "missing error.code"}
+	}
+	// SPEC-002 v1.5.1 R-2 / issue #197 R5 security: nak.in_reply_to,
+	// nak.error.code, and nak.error.message all reach structured logs
+	// on the inference-failure path; reject control-character payloads
+	// at parse time to prevent terminal-CSI log injection.
+	if containsControlChar(nak.InReplyTo) {
+		return Nak{}, "in_reply_to", fieldError{Field: "in_reply_to"}
+	}
+	if containsControlChar(nak.Error.Code) {
+		return Nak{}, "error.code", fieldError{Field: "error.code"}
+	}
+	if containsControlChar(nak.Error.Message) {
+		return Nak{}, "error.message", fieldError{Field: "error.message"}
 	}
 	return nak, "", nil
 }

--- a/phase4-coordinator/internal/ws/messages_test.go
+++ b/phase4-coordinator/internal/ws/messages_test.go
@@ -343,3 +343,57 @@ func bytesOf(value byte, count int) []byte {
 	}
 	return out
 }
+
+// TestParseHelloRejectsControlCharsInRequiredStrings pins SPEC-002
+// v1.5.1 R-2 / issue #197 R4 security: provider-supplied required
+// strings on a hello (provider_id, hostname, model_id, binary_version)
+// MUST be rejected at parse time when they contain control characters
+// (C0, DEL, C1) so they cannot inject terminal-CSI sequences into
+// structured logs or close-frame reason strings. JSON `` decodes
+// to U+009B and is valid UTF-8 but would otherwise pass the parser.
+func TestParseHelloRejectsControlCharsInRequiredStrings(t *testing.T) {
+	base := map[string]any{
+		"type":                    "hello",
+		"version":                 1,
+		"tier":                    1,
+		"provider_id":             "p-ok",
+		"hostname":                "h-ok",
+		"model_id":                "m-ok",
+		"model_params_b":          7.0,
+		"ram_gb":                  16,
+		"max_context_tokens":      50000,
+		"max_concurrency":         1,
+		"throughput_tps_estimate": 19.8,
+		"binary_version":          "0.1.0",
+		"attestation":             nil,
+	}
+	for _, field := range []string{"provider_id", "hostname", "model_id", "binary_version"} {
+		for name, bad := range map[string]string{
+			"c0_null":      "p-\x00",
+			"c0_lf":        "p-\n",
+			"c1_csi_utf8":  "p-",
+			"c1_low_utf8":  "p-",
+			"c1_high_utf8": "p-",
+			"del":          "p-\x7f",
+		} {
+			t.Run(field+"/"+name, func(t *testing.T) {
+				payload := make(map[string]any, len(base))
+				for k, v := range base {
+					payload[k] = v
+				}
+				payload[field] = bad
+				raw, err := json.Marshal(payload)
+				if err != nil {
+					t.Fatalf("marshal: %v", err)
+				}
+				_, badField, err := ParseHello(raw)
+				if err == nil {
+					t.Fatalf("ParseHello accepted %s=%q", field, bad)
+				}
+				if badField != field {
+					t.Fatalf("badField=%q, want %q", badField, field)
+				}
+			})
+		}
+	}
+}

--- a/phase4-coordinator/internal/ws/relay.go
+++ b/phase4-coordinator/internal/ws/relay.go
@@ -586,6 +586,17 @@ func (s *Server) handleInferenceChunk(providerID, assignedID string, payload []b
 		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("invalid inference_response_chunk")
 		return
 	}
+	// SPEC-002 v1.5.1 R-2 / issue #197 R6 code: reject control-character
+	// payloads in envelope.RequestID and decoded AAD request_id BEFORE any
+	// log statement or tier2 log helper call. Otherwise a malicious
+	// provider can route through the encrypted-frame failure paths
+	// (closeProviderForTier2AEADFailure, LogAEADDecryptFailed,
+	// LogEncryptedLegSessionClosed) and reach structured logs with raw
+	// C1/CSI before the post-parse containsControlChar check fires.
+	if containsControlChar(envelope.RequestID) {
+		s.log.Warn().Str("provider_id", providerID).Msg("inference_response_chunk envelope.request_id contains control chars; dropping")
+		return
+	}
 	session, ok := s.sessionFor(providerID, assignedID)
 	if !ok {
 		s.log.Warn().Str("provider_id", providerID).Str("request_id", envelope.RequestID).Msg("chunk from unknown provider session")
@@ -601,6 +612,10 @@ func (s *Server) handleInferenceChunk(providerID, assignedID string, payload []b
 		requestID := aad.RequestID
 		if requestID == "" {
 			requestID = envelope.RequestID
+		}
+		if containsControlChar(requestID) {
+			s.log.Warn().Str("provider_id", providerID).Msg("encrypted inference_response_chunk AAD request_id contains control chars; dropping")
+			return
 		}
 		active, ok := session.activeFor(requestID)
 		if !ok {
@@ -638,6 +653,10 @@ func (s *Server) handleInferenceChunk(providerID, assignedID string, payload []b
 		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("invalid inference_response_chunk")
 		return
 	}
+	if containsControlChar(chunk.RequestID) {
+		s.log.Warn().Str("provider_id", providerID).Msg("invalid inference_response_chunk request_id (control chars)")
+		return
+	}
 	active, ok := session.activeFor(chunk.RequestID)
 	if !ok {
 		s.log.Warn().Str("provider_id", providerID).Str("request_id", chunk.RequestID).Msg("unknown inference_response_chunk request_id")
@@ -668,6 +687,12 @@ func (s *Server) handleInferenceEnd(providerID, assignedID string, payload []byt
 		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("invalid inference_response_end")
 		return
 	}
+	// SPEC-002 v1.5.1 R-2 / issue #197 R6 code: reject control-character
+	// envelope.RequestID before any tier2 log helper or structured log.
+	if containsControlChar(envelope.RequestID) {
+		s.log.Warn().Str("provider_id", providerID).Msg("inference_response_end envelope.request_id contains control chars; dropping")
+		return
+	}
 	if envelope.Encrypted {
 		aad, _, err := tier2.DecodeAEADAAD(envelope.Enc.AAD)
 		if err != nil {
@@ -677,6 +702,10 @@ func (s *Server) handleInferenceEnd(providerID, assignedID string, payload []byt
 		requestID := aad.RequestID
 		if requestID == "" {
 			requestID = envelope.RequestID
+		}
+		if containsControlChar(requestID) {
+			s.log.Warn().Str("provider_id", providerID).Msg("encrypted inference_response_end AAD request_id contains control chars; dropping")
+			return
 		}
 		active, ok := session.activeFor(requestID)
 		if !ok {
@@ -707,6 +736,10 @@ func (s *Server) handleInferenceEnd(providerID, assignedID string, payload []byt
 		return
 	} else if err := json.Unmarshal(payload, &end); err != nil {
 		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("invalid inference_response_end")
+		return
+	}
+	if containsControlChar(end.RequestID) {
+		s.log.Warn().Str("provider_id", providerID).Msg("invalid inference_response_end request_id (control chars)")
 		return
 	}
 	active, ok := session.removeActive(end.RequestID)

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -1577,7 +1577,15 @@ func (s *Server) handleMessage(conn net.Conn, providerID, assignedID string, pay
 	case "drain_status":
 		s.handleDrainStatus(conn, providerID, assignedID, payload)
 	default:
-		s.log.Warn().Str("provider_id", providerID).Str("type", envelope.Type).Msg("unknown provider message type")
+		// SPEC-002 v1.5.1 R-2 / issue #197 R5 security: envelope.Type
+		// is provider-controlled and reaches structured logs only on
+		// this unknown-message path. Reject control characters before
+		// logging to defeat terminal-CSI log injection.
+		safeType := envelope.Type
+		if containsControlChar(safeType) {
+			safeType = "[redacted_control_chars]"
+		}
+		s.log.Warn().Str("provider_id", providerID).Str("type", safeType).Msg("unknown provider message type")
 	}
 }
 

--- a/specs/AUDIT_ISS_197_R1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,92 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), ARCHITECT lane.
+
+## Scope
+
+SPEC-002 v1.5.1 R-2 normative clarifications, doc-only, additive on top of v1.5.0
+(merged via PR #224 on 2026-06-29).
+
+The two clauses (in `specs/SPEC-002-coordinator.md`):
+
+1. **`external_request_id` UUID-tolerance**: opaque sanitized text 1-128 bytes;
+   coordinator MUST NOT reject non-UUID-shaped IDs but MUST apply sanitization;
+   cross-service reconciliation MUST NOT assume UUIDv4 shape.
+
+2. **Column-present / index-absent state semantics**: three states (A) legacy,
+   (B) unindexed/rollout-incomplete, (C) fully migrated; tooling MUST introspect
+   both `PRAGMA table_info` AND `sqlite_master`; MUST report state (B) as
+   `"unindexed"` distinct from state (A) "legacy".
+
+The original issue #197 framed these as additions to v1.4.3 R-2 of SPEC-002,
+but v1.4.3 never shipped (we leapfrogged to v1.5.0 via #211). v1.5.1 is the
+landing zone.
+
+## What to verify
+
+- **Cross-SPEC consistency**:
+  - SPEC-006 v0.9.1 (gateway forward contract — R-G3 UUIDv4 minting).
+    Does v1.5.1's "MAY carry any non-control 1-128-byte text" on the
+    direct buyer-port path conflict with SPEC-006's gateway-side R-G3,
+    or is the boundary clearly drawn (gateway=UUIDv4, coordinator=opaque
+    text)?
+  - SPEC-005 v0.3.1 reconciliation contract — does the v1.5.1 "state (B) MUST
+    be reported as unindexed" requirement propagate cleanly to SPEC-005's
+    reconciliation tooling, or does SPEC-005 still describe a binary
+    legacy/migrated state model?
+  - SPEC-007 v0.3 explorer addendum (PR #221) — does the explorer surface
+    introspect column AND index state per the v1.5.1 contract, or does it
+    still use column-only PRAGMA-based gating?
+
+- **Implementation extensibility**: v1.5.1 says tooling MUST introspect both
+  `PRAGMA table_info` AND `sqlite_master`. Does the current
+  `coordinator migrate-indexes` output expose that state machine in a
+  machine-readable way? Should v1.5.1 also require the coordinator to expose
+  a `/admin/migration-state` or `migrate-indexes --check` mode that returns
+  the three-state status, so external tooling has a single source of truth?
+
+- **Naming consistency**: v1.5.1 uses "state (A) / (B) / (C)". Other SPEC
+  sections use "rollout window", "deploy ordering", "pre-v1.5.0", etc. Is
+  the state-letter notation introduced cleanly, or does it conflict with
+  any existing notation in SPEC-002 / SPEC-005 / SPEC-006?
+
+- **Migration ordering with v1.5.0**: v1.5.0 added a SECOND partial-NULL
+  composite index (`idx_request_log_account_external_request_id`) on top of
+  v1.4.2 R-2's `idx_request_log_external_request_id`. Both ship via
+  `coordinator migrate-indexes`. The v1.5.1 state machine assumes "one
+  column ↔ one index"; in reality, post-v1.5.0, the schema has two
+  separately-migratable composite indexes. Does v1.5.1 need to clarify
+  whether the state machine is per-key (separate for each composite
+  reconciliation key) or whole-schema (single migrate-indexes run covers
+  both)? `coordinator migrate-indexes` is whole-schema — one CLI
+  invocation, all partial-NULL indexes built atomically.
+
+- **Audit tooling contract**: v1.5.1 says tooling MUST report state (B)
+  as `"unindexed"`. Is there a canonical naming for the three states the
+  SPEC should standardize on (e.g. `migration_state: "legacy" | "unindexed"
+  | "indexed"`)? This bites if multiple downstream teams write tooling
+  that uses different strings.
+
+- **Scope creep risk**: the issue scope was "two clarifications to the
+  freshly-merged R-2". Did the v1.5.1 text drift beyond that — e.g. by
+  adding implicit MUSTs that weren't in v1.5.0 / v1.4.2?
+
+- **Reconciler false-positive class**: if state (B) tooling correctly
+  reports "unindexed" but uses the slow exact-composite-key join, does
+  this introduce a window where the reconciler is so slow it falls
+  behind the steady-state ingest rate? (See `tracking-issue-scope-control`
+  memory and the existing reconciler at issue #226.)
+
+## Severity rubric
+
+- **CRITICAL**: a contradiction between v1.5.1 and another normative SPEC
+  that an implementer cannot resolve.
+- **HIGH**: v1.5.1 introduces an ambiguity that would cause two SPEC-conformant
+  implementations to disagree on observable behavior.
+- **MEDIUM**: cross-SPEC pointer / naming / state-machine cleanups that
+  improve operator and tooling-author ergonomics.
+- **LOW / NIT**: phrasing, grammar.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.
+
+Return a structured findings list with severity, file:line (or section),
+evidence, and recommended fix.

--- a/specs/AUDIT_ISS_197_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R1_CODE_PROMPT.md
@@ -1,0 +1,67 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), CODE lane.
+
+## Scope
+
+SPEC-002 v1.5.1 R-2 normative clarifications, doc-only, additive on top of v1.5.0
+(merged via PR #224 on 2026-06-29). No code changes; the two clauses describe
+contracts the implementation already exhibits as of v1.4.2 R-2 + v1.5.0.
+
+The two clauses (in `specs/SPEC-002-coordinator.md`):
+
+1. **`external_request_id` UUID-tolerance** — coordinator MUST NOT reject non-
+   UUID-shaped inbound `X-Request-ID`; MUST apply `sanitizeExternalRequestID`
+   (trim; cap 128; reject `<0x20`, `0x7f`, `0x80-0x9f`; on failure treat as
+   absent and do NOT echo malformed payload to logs). Gateway-routed traffic
+   gets UUIDv4 per SPEC-006 R-G3; direct buyer-port traffic MAY carry any
+   sanitized printable 1-128-byte string.
+
+2. **Column-present / index-absent state semantics** — three states:
+   (A) column-absent + index-absent (legacy);
+   (B) column-present + index-absent ("rollout incomplete, unindexed");
+   (C) column-present + index-present (fully migrated).
+   Tooling MUST introspect BOTH `PRAGMA table_info` AND `sqlite_master`
+   and report state (B) explicitly rather than falling back to fuzzy match.
+
+## What to verify
+
+For each clause, verify the SPEC text accurately describes the
+**implementation as it currently is** in:
+
+- `phase4-coordinator/internal/buyer/server.go` (`sanitizeExternalRequestID`
+  at around line 4981; usage at around line 1312).
+- `phase4-coordinator/internal/requestlog/store.go` (column definitions,
+  ensureColumns migration, `MigrateIndexes`).
+- `phase4-coordinator/cmd/coordinator/main.go` or whatever subcommand path
+  hosts `coordinator migrate-indexes`.
+
+Look for:
+
+- **Mismatches** between the new normative text and the actual code paths
+  (e.g. cap is 256, not 128; rejected ranges differ; `migrate-indexes` is
+  daemon-side not subcommand-side; etc.).
+- **Missing-but-implied** code paths: does the SPEC promise something the
+  code doesn't yet do (e.g. a `--diagnostics` flag that doesn't exist)?
+- **Hidden divergence between v1.4.2 and v1.5.0 patterns**: did v1.4.2's
+  `external_request_id` migration ship with both DDLs at once, contradicting
+  the new "two-state-machines" framing?
+- **Test corpus alignment**: any existing test that pins behavior the new
+  SPEC text now restricts or relaxes? Particularly:
+  - `phase4-coordinator/internal/buyer/server_test.go` sanitize tests
+  - `phase4-coordinator/internal/requestlog/store_test.go` migration tests
+
+## Severity rubric
+
+- **CRITICAL**: the new SPEC clauses contradict shipped behavior such that
+  the v1.5.1 normative text would block a real audit harness from working
+  correctly.
+- **HIGH**: a normative MUST in the new clauses is not what the code does
+  (e.g. SPEC says "reject control characters" but code accepts them).
+- **MEDIUM**: ambiguity in the SPEC text that would cause two reasonable
+  reconciliation harness authors to produce divergent outputs.
+- **LOW / NIT**: wording, grammar, cross-reference fixes.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.
+
+Return a structured findings list with severity, file:line, evidence,
+and recommended fix.

--- a/specs/AUDIT_ISS_197_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R1_SECURITY_PROMPT.md
@@ -1,0 +1,76 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), SECURITY lane.
+
+## Scope
+
+SPEC-002 v1.5.1 R-2 normative clarifications, doc-only, additive on top of v1.5.0
+(merged via PR #224 on 2026-06-29).
+
+The two clauses (in `specs/SPEC-002-coordinator.md`):
+
+1. **`external_request_id` UUID-tolerance** — opaque sanitized text 1-128
+   bytes, non-control chars; cross-service reconciliation MUST NOT assume
+   UUIDv4 shape.
+
+2. **Column-present / index-absent state semantics** — reconciliation
+   tooling MUST introspect both `PRAGMA table_info` and `sqlite_master`;
+   MUST surface "unindexed" state distinctly from "legacy".
+
+## What to verify
+
+Look for security implications of the new normative contract that the
+v1.5.1 text either creates, fails to close, or makes worse than v1.5.0:
+
+- **Log-injection / log-forgery surface**: the UUID-tolerance clause says
+  the coordinator "MUST NOT echo the malformed payload to logs". Does any
+  current log statement in `phase4-coordinator/internal/buyer/server.go`,
+  `phase4-coordinator/internal/requestlog/store.go`, billing, or recovery
+  log the raw header before sanitization? Does the v1.5.1 text adequately
+  forbid future code from doing so, or is it advisory-only?
+
+- **Confused-deputy via `external_request_id` shape**: by formalizing
+  "opaque 1-128 byte text" the SPEC now allows IDs like
+  `acct_other_account_id_here_123456` that could be misinterpreted by
+  downstream tooling expecting UUIDv4. Is the v1.5.1 text sufficient to
+  prevent an audit harness from naively casting `external_request_id` to
+  `account_id` based on prefix matching?
+
+- **Cross-account ID smuggling**: a buyer sending a crafted X-Request-ID
+  designed to collide with another account's external_request_id was the
+  driving #196/#211 fix. v1.5.1 reaffirms the composite key
+  `(account_id, external_request_id)` is the reconciliation key — does
+  it adequately re-state that `external_request_id` alone MUST NOT be
+  used for any identity decision?
+
+- **State (B) → fuzzy fallback risk**: if a tool ignores v1.5.1's
+  introspection MUST and falls back to fuzzy match under state (B),
+  does the audit miss a class of cross-account collisions that would
+  have been caught by an exact composite-key join? Severity ladder it.
+
+- **SPEC consistency with SPEC-006 v0.9.1 (UUIDv4-minting at gateway)**:
+  v1.5.1 says gateway traffic gets UUIDv4 per R-G3 but direct buyer-port
+  traffic MAY carry arbitrary text. Does this create a path for a
+  malicious operator to bypass UUIDv4 by reaching the buyer port
+  directly? What does the production deployment topology look like —
+  is the buyer port publicly exposed, or only accessible via the
+  gateway in production?
+
+- **Sanitization defense-in-depth gaps**: 0x80-0x9f C1 range rejection
+  was added to defeat CSI escape sequences (per memory
+  `c1-control-chars-terminal-sanitizer-bypass`). Does the v1.5.1 text
+  reference this and pin it as load-bearing, or merely incidental?
+
+## Severity rubric
+
+- **CRITICAL**: v1.5.1 normative text opens a security regression vs v1.5.0.
+- **HIGH**: v1.5.1 fails to close a security hole that v1.5.0 / v1.4.2 R-2
+  left ambiguous, and an audit harness following v1.5.1 verbatim would
+  miss a real exploit class.
+- **MEDIUM**: ambiguity that allows two reasonable implementations to
+  diverge in security-relevant ways.
+- **LOW / NIT**: hardening suggestions, additional cross-references.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.
+
+Return a structured findings list with severity, file:line, evidence,
+and recommended fix.

--- a/specs/AUDIT_ISS_197_R2_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R2_ARCHITECT_PROMPT.md
@@ -1,0 +1,71 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), ARCHITECT lane, ROUND 2.
+
+R1 returned 2 HIGH + 1 MEDIUM + 1 LOW. R2 fixes:
+
+- HIGH #1 (state-(B) operational binding): SPEC §11 v1.5.1 now binds
+  production reconciliation tooling to fail closed under state
+  `unindexed`. Override (`--allow-unindexed-scan`) is allowed but MUST
+  NOT be default.
+- HIGH #2 (per-key state machine): SPEC §11 v1.5.1 + the v1.5.1
+  change-log block recast the state machine as PER-KEY (each composite
+  reconciliation key has its own legacy/unindexed/indexed state);
+  aggregate is min-wise. Implementation:
+  `requestlog.Store.MigrationState` returns `{Aggregate, Keys[]}`.
+- MEDIUM (machine-readable enum + CLI surface): canonical vocabulary
+  `"legacy"|"unindexed"|"indexed"` pinned normatively. New CLI surface
+  `coordinator migrate-indexes --check --format json`.
+- LOW (naming clash with state (C)): renamed "Phase-C reconciliation
+  tooling" → "reconciliation tooling" throughout.
+
+## Verify
+
+- **Per-key vs whole-schema clarity**: does the SPEC text consistently
+  describe the state machine as per-key with aggregate, or are there
+  any remaining whole-schema-only phrasings that would mislead an
+  implementer?
+- **Aggregate definition completeness**: the rule is `legacy if any
+  legacy; indexed iff all indexed; unindexed otherwise`. Are there
+  edge cases (e.g. zero keys in `migrationKeyDefs` — should that be
+  `indexed` or undefined)? Is the rule reversible — given an
+  aggregate, can you infer the per-key set? (Probably not; verify the
+  SPEC doesn't promise that.)
+- **SPEC-005 alignment**: does SPEC-005 still describe a binary
+  legacy/migrated schema-check model? If so, does the v1.5.1 cross-
+  reference adequately update SPEC-005's contract, or does SPEC-005
+  need a separate version bump? Check `specs/SPEC-005-billing.md`.
+- **SPEC-007 cross-reference**: v1.5.1 says SPEC-007 explorer gates by
+  resolved row fields (not schema state) so it's independent. Verify
+  this against the current PR #221-merged SPEC-007 v0.3 text.
+- **`coordinator migrate-indexes --check` placement**: is this CLI
+  surface adequately documented? Should the SPEC also describe the
+  text-format output, or is JSON-only normative?
+- **migrationKeyDefs registry**: future SPEC versions adding more
+  composite indexes will extend `migrationKeyDefs`. Is the SPEC text
+  clear that this is the extension point, so downstream tools can
+  rely on the JSON shape being stable?
+- **Operational binding scope**: the v1.5.1 MUST applies to
+  "production reconciliation tooling running in steady-state closing-
+  the-books". Is that scope crisp enough to avoid arguments about
+  whether e.g. dev harnesses, the harness reconciler (issue #226), or
+  the explorer's gateway proxy qualify?
+- **Override-bound semantics**: `--allow-unindexed-scan` is described
+  as bounded by row-count or wall-clock budget. Does the SPEC need to
+  specify a default budget, or leave it to the tool? Either is
+  defensible — flag if the current "MAY support" language is too vague.
+
+## Severity rubric
+
+- **CRITICAL**: a contradiction with another normative SPEC remains, OR
+  the per-key state machine + aggregate rule is internally inconsistent.
+- **HIGH**: ambiguity that would cause two SPEC-conformant implementations
+  to disagree on observable state-machine behavior.
+- **MEDIUM**: cross-SPEC alignment gap (SPEC-005 schema-check text not
+  updated; SPEC-007 cross-reference loose).
+- **LOW / NIT**: phrasing, registry-extension docs, default-budget
+  specificity.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.
+
+Return a structured findings list with severity, file:line (or section),
+evidence, and recommended fix.

--- a/specs/AUDIT_ISS_197_R2_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R2_CODE_PROMPT.md
@@ -1,0 +1,58 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), CODE lane, ROUND 2.
+
+R1 returned 1 HIGH (raw C1 bytes bypass `sanitizeExternalRequestID` because
+the rune-based loop decoded `0x80-0x9f` to `utf8.RuneError`) plus a LOW
+on the workflow narrative. R2 fixes:
+
+1. `phase4-coordinator/internal/buyer/server.go`: extracted
+   `sanitizeOpaqueHeader` shared by `sanitizeExternalRequestID` and
+   `sanitizeAccountID`. New shape: trim → cap 128 → `utf8.ValidString` →
+   byte-by-byte reject `<0x20`, `0x7f`, `0x80-0x9f`.
+2. `phase4-coordinator/internal/buyer/server_test.go`:
+   `TestRequestLogExternalRequestIDRejectsMalformedHeader` extended with
+   `c1_low` (0x80), `c1_csi` (0x9b), `c1_high` (0x9f),
+   `invalid_utf8_lead`, `invalid_utf8_alone`.
+3. New `phase4-coordinator/internal/requestlog/store.go::MigrationState`
+   returning per-key + aggregate state.
+4. New CLI: `coordinator migrate-indexes --check --format json` in
+   `phase4-coordinator/cmd/coordinator/migrate_indexes.go`.
+5. New test `TestMigrationStateReportsPerKeyStatesAndAggregate` exercises
+   `legacy`, `unindexed`, `indexed` states.
+
+## Verify
+
+- The byte-level sanitizer correctly rejects raw 0x80-0x9f AND invalid
+  UTF-8. Does the implementation match the SPEC text? Are there any
+  remaining bypasses (e.g. percent-encoded payloads that decode later)?
+- `MigrationState` and `MigrateIndexes` share `migrationKeyDefs` — are
+  they consistent? Could the index name in `migrationKeyDefs` drift from
+  the DDL in `MigrateIndexes`?
+- `--check --format json` is read-only — does any error path mutate
+  state? Does it handle `--format` values other than `text|json`?
+- Is the aggregate min-wise rule (`legacy if any, indexed iff all,
+  unindexed otherwise`) correctly implemented? Look for off-by-one /
+  early-exit bugs.
+- Are there any new test gaps — places where the SPEC says a MUST but
+  no test pins the contract? Particularly the production-tooling
+  fail-closed behavior under state `unindexed`.
+- Did the new `MigrationState` introduce any concurrent-access concern
+  given the request-log store's `SetMaxOpenConns(1)` cap? (It's
+  read-only so should not contend with INSERT writes, but verify.)
+- Full coordinator test suite — `go test ./...` — still passes? (I ran
+  this once; please re-verify if you touch anything.)
+
+## Severity rubric
+
+- **CRITICAL**: code lands a regression vs v1.5.0 / v1.4.2 or a real
+  bypass in the sanitizer remains.
+- **HIGH**: an R1 finding was not actually fixed, OR the new code has
+  a money-path-adjacent gap.
+- **MEDIUM**: the new state-machine implementation diverges from the
+  SPEC text, OR test coverage misses a documented MUST.
+- **LOW / NIT**: wording, naming, defensive checks.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.
+
+Return a structured findings list with severity, file:line, evidence,
+and recommended fix.

--- a/specs/AUDIT_ISS_197_R2_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R2_SECURITY_PROMPT.md
@@ -1,0 +1,61 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), SECURITY lane, ROUND 2.
+
+R1 returned 1 HIGH: raw C1 bytes bypassed `sanitizeExternalRequestID`
+via rune iteration that decoded 0x80-0x9f to `utf8.RuneError`. The fix
+in R2:
+
+- `phase4-coordinator/internal/buyer/server.go`: byte-level sanitizer
+  `sanitizeOpaqueHeader` rejects invalid UTF-8 and iterates the C0/DEL/C1
+  reject set byte-by-byte before any rune decode. Both
+  `sanitizeExternalRequestID` and `sanitizeAccountID` route through it.
+- Regression tests added for 0x80, 0x9b, 0x9f, invalid UTF-8 leads.
+
+## Verify
+
+- The byte-level loop closes the CSI / terminal-control class fully:
+  - 0x9b standalone — rejected?
+  - Percent-encoded `%9b` if the buyer/gateway middleware ever decodes
+    before passing to the sanitizer — does any layer between transport
+    and `sanitizeExternalRequestID` percent-decode?
+  - Overlong UTF-8 encoding of C1 (e.g. `0xc2 0x9b`) — this is VALID
+    UTF-8 and decodes to U+009B. Is `0xc2 0x9b` byte-level-passed by
+    the byte loop (since neither byte alone is in C1 range)? If yes,
+    is this acceptable? The C1 codepoint U+009B is what we want to
+    reject; overlong UTF-8 encoding of it would slip past byte-wise
+    rejection but rune iteration would catch it.
+- Does the v1.5.1 SPEC text mandate rejection at both byte-level AND
+  codepoint-level, or only byte-level? If only byte-level, the
+  overlong-UTF-8 C1 codepoints slip through. Recommend the SPEC
+  require BOTH layers.
+- Are there other coordinator paths that accept buyer-controlled text
+  into structured logs WITHOUT going through `sanitizeOpaqueHeader`?
+  Look for: `X-MacProvider-Pref`, `X-MacProvider-Provider`,
+  `Authorization` bearer, model name, prompt content.
+- State `unindexed` operational binding: does v1.5.1 close the
+  silent-fuzzy-match fallback class? Is there a way for an audit
+  harness to read the `migration_state` JSON and ignore it?
+- The new `coordinator migrate-indexes --check` reads the DB without
+  mutating — is there any path where `--check` could be invoked with
+  a malicious config file (path traversal, symlink) that escalates?
+  The `--config` flag is operator-supplied; reasonable to trust, but
+  worth flagging if a privilege boundary changed.
+- Cross-reference SPEC-005 v0.3.1 reconciliation contract: does the
+  v1.5.1 normative MUST on state `unindexed` propagate to the
+  reconciliation tooling in `phase4-coordinator/internal/billing/recovery.go`
+  or wherever the schema-check happens?
+
+## Severity rubric
+
+- **CRITICAL**: a remaining bypass in the sanitizer or a new
+  vulnerability introduced by the v1.5.1 surface.
+- **HIGH**: a HIGH that v1.5.1 claims to close but doesn't (e.g.
+  overlong-UTF-8 C1 bypass).
+- **MEDIUM**: hardening that v1.5.1 should adopt but didn't (e.g.
+  rejecting at both byte and codepoint level).
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.
+
+Return a structured findings list with severity, file:line, evidence,
+and recommended fix.

--- a/specs/AUDIT_ISS_197_R3_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R3_ARCHITECT_PROMPT.md
@@ -1,0 +1,68 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), ARCHITECT lane, ROUND 3.
+
+R2 returned 1 MEDIUM + 2 LOW. R3 fixes:
+
+1. (R2 MEDIUM: SPEC-005 alignment) Bumped SPEC-005 v0.3.1 → v0.3.2.
+   - `Depends on:` now pins `SPEC-002 v1.5.1`.
+   - New change-log entry at top describing the per-key migration-
+     state dependency and the `legacy | unindexed | indexed` MUST
+     for out-of-process reconciliation tooling.
+   - §10.4 "missing indexes in fixture MAY scan, but production
+     startup MUST fail the schema check" rewritten to reference the
+     per-key state contract and the
+     `coordinator migrate-indexes --check --format json` surface.
+
+2. (R2 LOW: zero-key edge) New SPEC clause: "Registry invariant —
+   `migrationKeyDefs` MUST be non-empty; append-only; consumers MUST
+   match by `key` and tolerate additional entries (forward-compat)."
+
+3. (R2 LOW: registry-extension docs) Same clause names `migrationKeyDefs`
+   as the registry and pins the contract on `key` strings as stable.
+
+4. (R2 architect cross-finding from code lane: scope of operational
+   binding) R3 sharpened §11 + the change-log entry: the
+   `MUST fail closed on unindexed` rule applies to **out-of-process
+   reconciliation tooling** (SPEC-005 v0.3+ closing-the-books surface),
+   NOT to coordinator's in-process `RecoverLedger` / admin reconcile /
+   hot-path AttemptN derivation. The latter use SQLite `IS` clustering
+   and are correct (just unindexed-slow) under state `unindexed`. The
+   daemon-startup `unindexed` rollout window is by design and the
+   daemon must serve traffic in it.
+
+## Verify
+
+- Does SPEC-002 §11 and the v1.5.1 change-log entry now consistently
+  carve in/out the same scope? Look for any remaining sentence that
+  would force in-process recovery to fail closed.
+- Is SPEC-005 v0.3.2 internally consistent with the new SPEC-002
+  v1.5.1 dependency? Specifically, the §10.4 rewrite — does it
+  still leave any ambiguity about whether RecoverLedger itself
+  reads `MigrationState`?
+- Does the SPEC-005 v0.3.2 change-log entry need to also mention
+  that v0.3.1 stays the production-shipping version on the
+  pre-v0.3.2 reconciliation tooling, and v0.3.2 is the contract
+  for new tooling? Or is in-place version evolution sufficient
+  (existing tooling presumed updated)?
+- Is the "out-of-process tooling" scope sufficiently bounded that an
+  implementer can tell what counts? Examples:
+  - The harness reconciler (issue #226) — out-of-process? Yes.
+  - A future `/admin/explorer/reconcile` HTTP endpoint that returns
+    composite-key joins — out-of-process? It's a coordinator endpoint
+    serving an external auditor — ambiguous.
+- Does the registry-invariant clause foreclose future SPEC versions
+  from RENAMING a `key` string (which would break consumers)? Is
+  there a versioning path if a key REALLY must be renamed (e.g.
+  deprecate-and-add)? Probably not in scope of v1.5.1, but flag.
+- Does the SPEC text adequately distinguish "registry order is
+  normative" (so the JSON array is stable) from "consumers MUST
+  tolerate additional entries"?
+
+## Severity rubric
+
+- **CRITICAL**: contradiction with another normative SPEC remains.
+- **HIGH**: ambiguity that would split conformant implementations.
+- **MEDIUM**: cross-SPEC pointer gaps, scope-clarity issues.
+- **LOW / NIT**: phrasing, versioning notes.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R3_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R3_CODE_PROMPT.md
@@ -1,0 +1,73 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), CODE lane, ROUND 3.
+
+R2 returned 2 MEDIUM + 1 LOW. R3 fixes:
+
+1. (R2 MEDIUM #1) `--check` mutated schema via `OpenStore`. R3 added
+   `requestlog.OpenStoreReadOnly` (sets `PRAGMA query_only=ON`, skips
+   `migrate()`/`ensureColumns()`). `migrate-indexes --check` now routes
+   through this read-only store. `--format` validation is hoisted
+   BEFORE config-load + store-open. New tests:
+   - `TestMigrateIndexesCheckIsReadOnly` — pre-seeds a legacy
+     request_log (only id/ts_utc/request_id/model), runs `--check
+     --format json`, asserts aggregate=`legacy`, asserts schema is
+     STILL legacy after the command (external_request_id / account_id
+     columns absent).
+   - `TestMigrateIndexesCheckRejectsBogusFormatBeforeOpen` — passes
+     `--format bogus`, asserts rc=2 and the legacy schema is
+     unchanged (proving validation happens before OpenStore).
+
+2. (R2 MEDIUM #2) Production reconciliation MUST fail closed on
+   `unindexed`. R3 sharpened the SPEC scope: the operational binding
+   applies to **out-of-process reconciliation tooling** (SPEC-005 v0.3+
+   closing-the-books surface) — NOT to coordinator's in-process
+   `RecoverLedger` / admin reconcile / hot-path AttemptN, which use
+   SQLite `IS` clustering and are correct (just unindexed-slow) under
+   state `unindexed`. The daemon-startup `unindexed` rollout window is
+   by design and must serve traffic. SPEC-005 v0.3.2 cross-links the
+   per-key state contract. The in-process recovery paths are
+   intentionally NOT changed.
+
+3. (R2 LOW: registry drift) R3 consolidated `migrationKeyDefs` to be
+   the single source of truth for both `MigrationState` and
+   `MigrateIndexes` — DDL + index name live on the registry; both
+   functions iterate it.
+
+4. SPEC §11 v1.5.1 now states: `migrationKeyDefs` MUST be non-empty;
+   append-only; consumers MUST match by `key` and tolerate additional
+   entries.
+
+5. `sanitizeRequestLogText` strengthened to reject invalid UTF-8 and
+   strip C1 codepoints (addresses R2 security MEDIUM #1 — see also
+   the SECURITY lane prompt).
+
+## Verify
+
+- Does `OpenStoreReadOnly` actually prevent schema mutation? Are there
+  any DDL/DML paths reachable via `MigrationState` that would still
+  fire under `PRAGMA query_only=ON`? Verify `PRAGMA table_info` and
+  `SELECT name FROM sqlite_master` work in this mode (they should —
+  both are reads).
+- Does the new dispatch order (`--format` validation before OpenStore)
+  actually prevent the mutation? Look for any pre-validation path
+  that could open the store anyway.
+- Is `migrationKeyDefs` truly the single source of truth now? Are
+  there any remaining places in the codebase that hardcode index
+  names (`idx_request_log_external_request_id`,
+  `idx_request_log_account_external_request_id`) that should reference
+  the registry instead?
+- Does the LOW about empty `migrationKeyDefs` need a runtime guard, or
+  is the SPEC text + Go's compile-time slice-literal sufficient?
+- Are there any test gaps — places where R3 added a normative MUST
+  but no test pins it?
+- Full coordinator test suite `go test ./...` — still green?
+
+## Severity rubric
+
+- **CRITICAL**: regression vs v1.5.0; OR sanitizer still has a bypass;
+  OR `--check` still mutates schema.
+- **HIGH**: an R2 finding not actually fixed in R3.
+- **MEDIUM**: new code diverges from SPEC; test coverage misses a MUST.
+- **LOW / NIT**: wording, defensive checks.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R3_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R3_SECURITY_PROMPT.md
@@ -1,0 +1,65 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), SECURITY lane, ROUND 3.
+
+R2 returned 2 MEDIUM. R3 fixes:
+
+1. (R2 MEDIUM #1) Other persisted text fields (`error`, `pref_header`,
+   `provider_header`, `model`) used the weaker `sanitizeRequestLogText`
+   which stripped C0/DEL via rune iteration but missed raw C1 bytes
+   (decoded as `utf8.RuneError`) and didn't validate UTF-8. R3
+   strengthened `sanitizeRequestLogText`:
+   - reject invalid UTF-8 outright (return "");
+   - after the UTF-8 gate, strip C0/DEL/C1 codepoints (0x00-0x1f,
+     0x7f, 0x80-0x9f) via the existing rune map. The UTF-8 gate makes
+     rune iteration safe for the strip step — raw C1 bytes can't
+     survive as `utf8.RuneError` because the input was rejected first.
+   The strip-vs-reject distinction is intentional: opaque headers
+   (X-Request-ID, X-MacProvider-Account) reject the whole value;
+   multi-character text fields (error messages, model names) strip
+   the bad codepoints and keep the rest.
+
+2. (R2 MEDIUM #2) The "MUST fail closed on `unindexed`" scope was
+   ambiguous. R3 sharpened it to **out-of-process reconciliation
+   tooling only** — not coordinator's in-process `RecoverLedger` /
+   admin reconcile / hot-path AttemptN, which use SQLite `IS`
+   clustering and are correct under unindexed. SPEC-005 v0.3.2
+   pins the dependency.
+
+## Verify
+
+- Does the strengthened `sanitizeRequestLogText` actually close the
+  C1 bypass for `error` / `pref_header` / `provider_header` / `model`?
+  Try:
+  - `error` containing raw `0x9b` — should be rejected at UTF-8 gate.
+  - `model` JSON value `""` (which is valid UTF-8 for U+009B)
+    — does the rune-map strip catch this?
+  - `pref_header` / `provider_header` with raw C1 bytes from the HTTP
+    request — does the call path persist them via
+    `sanitizeRequestLogText` or some other untreated path?
+- Are there any OTHER buyer-controlled text fields that land in
+  `request_log` or structured logs without going through
+  `sanitizeOpaqueHeader` or `sanitizeRequestLogText`? Look for
+  prompt/message content if it lands in logs, finish_reason,
+  provider id, model name from the upstream response, etc.
+- The new SPEC scope clarification — does it preserve safety? An
+  attacker can no longer force-close in-process recovery via raw
+  control bytes (those are pre-sanitized) but a state-`unindexed`
+  daemon still serves traffic. Is there ANY in-process money-path
+  computation that would silently produce wrong credits under
+  state `unindexed`? (I think no — the IS-clustering only affects
+  AttemptN derivation, which doesn't depend on the partial-NULL
+  composite index for correctness — but verify.)
+- `OpenStoreReadOnly` uses `PRAGMA query_only=ON`. Is there any
+  escape from query_only (e.g. via attach, savepoint, vacuum)? In
+  particular, does any `sqliteutil.WithPragmas` setting bypass it?
+
+## Severity rubric
+
+- **CRITICAL**: new bypass introduced by R3 OR an R2 finding still
+  open.
+- **HIGH**: real exploit class still reachable through a path R3
+  didn't address.
+- **MEDIUM**: hardening that should land but didn't.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R4_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R4_ARCHITECT_PROMPT.md
@@ -1,0 +1,64 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), ARCHITECT lane, ROUND 4.
+
+R3 returned 2 MEDIUM + 2 LOW. R4 fixes:
+
+1. (R3 MEDIUM #1: SPEC-005 §1.4 still labeled v1.5.0) Updated to
+   `**SPEC-002 v1.5.1:**` plus a new bullet enumerating the per-key
+   migration-state surface and the closing-the-books fail-closed MUST.
+
+2. (R3 MEDIUM #2: scope by data-surface contract, not process
+   placement) Rewrote the operational-binding paragraph in SPEC-002
+   §11 v1.5.1 AND the change-log entry AND the SPEC-005 v0.3.2
+   change-log entry to use the data-surface phrasing:
+   - **In scope** = any reconciliation surface that performs
+     closing-the-books joins between coordinator `request_log` and
+     gateway `usage_events` / `audit_events` by composite key —
+     out-of-process harnesses AND any future coordinator-hosted
+     endpoint exposing the same join.
+   - **Out of scope** = coordinator's in-process AttemptN paths
+     (`hotpath.go`, `recovery.go`, `endpoints.go`
+     `/admin/ledger/reconcile`) which use single-table SQLite `IS`
+     clustering.
+
+3. (R3 LOW: deprecate-and-add escape hatch) Added the deprecation
+   path to the registry-invariant clause: when a `key` must be
+   replaced, deprecate-and-add for one minor SPEC version, then drop
+   the old in a later version.
+
+4. (R3 LOW: array order normative) Added explicit "the JSON `keys`
+   array order is **normative**" sentence in the registry-invariant
+   clause.
+
+## Verify
+
+- Does the SPEC-002 §11 + change-log + SPEC-005 v0.3.2 phrasing
+  agree on the data-surface scope? Look for residual "out-of-process"
+  language that wasn't replaced.
+- Future coordinator-hosted closing-the-books endpoint — is the
+  SPEC clear that it IS in scope, even though it lives in the
+  coordinator process?
+- Does the deprecate-and-add escape hatch handle the case where the
+  new `key` covers the SAME composite columns as the old `key` but
+  with a different name? Specifically the SPEC says "keep emitting
+  the old key for one minor SPEC version" — does that mean both
+  keys point to the same index (and indicate the same state), or
+  the old key emits a deprecated marker and the new one is the live
+  one? Probably the latter, but worth clarifying.
+- Is the array-order-normative clause sufficient for stable
+  enumeration, or does the SPEC also need to require that consumers
+  may rely on the i-th entry being a particular `key` (which is
+  stronger)?
+- Cross-spec: SPEC-006 (gateway forward contract), SPEC-007
+  (explorer) — do they need v1.5.1 dependency updates, or are they
+  unaffected (since the new MUST applies only to closing-the-books
+  reconciliation, which neither does)?
+
+## Severity rubric
+
+- **CRITICAL**: contradiction with another SPEC remains.
+- **HIGH**: ambiguity that splits implementations.
+- **MEDIUM**: cross-SPEC pointer / scope gaps.
+- **LOW / NIT**: phrasing, edge-case clarifications.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R4_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R4_CODE_PROMPT.md
@@ -1,0 +1,52 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), CODE lane, ROUND 4.
+
+R3 returned 1 CRITICAL + 1 LOW. R4 fixes:
+
+1. (R3 CRITICAL convergent with security) `request_log.model` was
+   stored unsanitized. R4 wraps `b.model` with `sanitizeRequestLogText`
+   in [phase4-coordinator/internal/buyer/billing_recorder.go:159] and
+   adds regression test
+   `TestRequestLogModelFieldSanitized` (sends JSON model containing
+   valid UTF-8 for U+009B; asserts no C1 codepoint survives in
+   request_log.model).
+
+   Also (R3 security HIGH) `/v1/pool/check?provider_id=` was logged
+   unsanitized. R4 sanitizes via `sanitizeRequestLogText`
+   in `handlePoolCheck`.
+
+2. (R3 LOW) `OpenStoreReadOnly` previously called `sqliteutil.WithPragmas`
+   which sets `journal_mode(WAL)` — that's a metadata write on a fresh
+   read-only open. R4 added `sqliteutil.ReadOnlyDSN` that opens with
+   `mode=ro` and `_pragma=query_only(true)` only (no WAL/synchronous
+   pragmas, no PRAGMA execs after open). `OpenStoreReadOnly` routes
+   through it.
+
+## Verify
+
+- `sanitizeRequestLogText(b.model)` — does the sanitizer correctly
+  strip C0/DEL/C1 codepoints from valid UTF-8 model strings? Are
+  there any callers of `b.model` further down the path that still
+  see the unsanitized version? (b.model is set once at recorder
+  construction; verify that's the only mutation point.)
+- The new `TestRequestLogModelFieldSanitized` skips assertion when
+  no rows land. Is that the right behavior — should we instead
+  require a 4xx response with NO row written? Audit whether C1 in
+  model lands a request_log row in the current code path.
+- `ReadOnlyDSN` — does `mode=ro` actually prevent the journal-mode
+  metadata write? Confirm by running `--check` against a freshly-
+  created legacy DB and checking that the WAL/SHM files are NOT
+  created.
+- Any other buyer-controlled text that lands in `request_log` /
+  structured logs unsanitized? (Look beyond `provider_id` in
+  `handlePoolCheck` for the wider class.)
+- Full suite still green?
+
+## Severity rubric
+
+- **CRITICAL**: sanitizer bypass remains; or new regression.
+- **HIGH**: an R3 finding still open.
+- **MEDIUM**: SPEC↔impl divergence; missed MUST.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R4_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R4_SECURITY_PROMPT.md
@@ -1,0 +1,50 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), SECURITY lane, ROUND 4.
+
+R3 returned 1 CRITICAL + 1 HIGH. R4 fixes:
+
+1. (R3 CRITICAL) `request_log.model` is now sanitized via
+   `sanitizeRequestLogText(b.model)` in
+   `phase4-coordinator/internal/buyer/billing_recorder.go:159`.
+   Regression test `TestRequestLogModelFieldSanitized` pins it.
+
+2. (R3 HIGH) `/v1/pool/check?provider_id=` query value now passes
+   through `sanitizeRequestLogText` before any structured log call
+   in `phase4-coordinator/internal/buyer/server.go::handlePoolCheck`.
+
+## Verify
+
+- The model-field fix actually defeats valid-UTF-8 C1 (0xc2 0x9b)
+  injection through `"model":"..."` paths.
+- The provider_id fix — does any OTHER structured-log call along
+  `/v1/pool/check`'s path still see the pre-sanitize value? Are
+  there middleware loggers or access loggers that capture raw
+  query strings?
+- Are there OTHER buyer-controlled text fields that land in
+  structured logs unsanitized? Specifically:
+  - The 404 / unknown-model log line on the buyer path.
+  - The Authorization bearer log lines (these should NEVER log raw
+    bearer values, but if any C1-bearing buyer-supplied path leaks
+    in...).
+  - Provider-side: provider's `hello.provider_id`, `error.message`
+    from upstream WS, `assigned_id`. These come from the provider
+    side, not the buyer, but C1 from a malicious provider also
+    qualifies.
+- Defense-in-depth question: does the v1.5.1 SPEC text adequately
+  describe the entire buyer→log surface as covered, or does the
+  prose still imply only the two header fields are the concern?
+- The state `unindexed` scope clarification (data-surface contract
+  vs process placement) — does it now leave any path where an
+  in-process money-path computation could silently produce wrong
+  credits under state `unindexed`? Audit hot/recovery/admin
+  reconcile one more time.
+
+## Severity rubric
+
+- **CRITICAL**: real sanitizer bypass or money-path bug remains.
+- **HIGH**: a previously-flagged finding still open, OR a new
+  exploit class introduced by R4.
+- **MEDIUM**: hardening that should land but didn't.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R5_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R5_ARCHITECT_PROMPT.md
@@ -1,0 +1,63 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), ARCHITECT lane, ROUND 5.
+
+R4 returned 0 CRITICAL / 0 HIGH / 1 MEDIUM / 1 LOW.
+
+R5 fixes:
+
+1. (R4 MEDIUM: SPEC-005 §10.4 + SPEC-002 line 1560 still said
+   "out-of-process") Rewrote both to data-surface-contract phrasing.
+   - SPEC-002 §11 line 1560: "support closing-the-books reconciliation
+     joins to gateway `usage_events` and `audit_events` (whether run
+     as out-of-process harnesses or via a future coordinator-hosted
+     reconciliation endpoint)".
+   - SPEC-005 §10.4: "Any reconciliation surface that performs
+     closing-the-books joins between coordinator `request_log` and
+     gateway `usage_events` / `audit_events` by composite reconciliation
+     key — whether run as an out-of-process harness OR as a future
+     coordinator-hosted reconciliation endpoint — MUST read per-key
+     migration state ... and fail closed ..."
+
+2. (R4 LOW: deprecate-and-add same-columns-different-name) Expanded the
+   registry-invariant clause: the state-enum vocabulary is NOT extended;
+   the OLD `key` continues to enumerate with its real state; if rename
+   is cosmetic both entries share state; if shape changed the old
+   entry reports `unindexed` (its index dropped) or `legacy` (its
+   column dropped). SPEC change-log explicitly marks old-as-deprecated
+   and names the new replacement.
+
+3. Added a new top-level "Buyer-controlled text sanitization (v1.5.1)"
+   paragraph in SPEC-002 §11 enumerating EVERY buyer-controlled
+   persisted text column and its sanitizer (security architect
+   visibility into the full surface).
+
+## Verify
+
+- Does SPEC-002 §11 + the v1.5.1 change-log + SPEC-005 v0.3.2 now
+  agree consistently on the data-surface scope? `rg "out-of-process"`
+  should turn up only the EXAMPLES of the in-scope set (e.g.
+  "harness, OR future coordinator endpoint"), not the SCOPE itself.
+- The deprecate-and-add clarification — is the cosmetic-rename
+  vs shape-change distinction clear, and does it foreclose a
+  future SPEC version from accidentally introducing a fourth
+  state value? The state enum invariant should be airtight.
+- The "Buyer-controlled text sanitization" paragraph — does it
+  fully describe the security contract, and is it discoverable by
+  someone reading SPEC-002 cold? Should there be a forward
+  reference from FR-B9 or §17?
+- Cross-spec: SPEC-006 (gateway forward contract) and SPEC-007
+  (explorer) — do they need to acknowledge the v1.5.1 sanitization
+  contract, or is the buyer→coordinator boundary the right place
+  to enforce and SPEC-006 already does its own gateway-side
+  sanitization?
+- Any SPEC-001 / SPEC-003 / SPEC-004 / SPEC-016 pointers that
+  reference the prior R-2 sanitization wording and need updating?
+
+## Severity rubric
+
+- **CRITICAL**: contradiction with another normative SPEC.
+- **HIGH**: ambiguity that splits implementations.
+- **MEDIUM**: cross-SPEC pointer / scope gaps.
+- **LOW / NIT**: phrasing, edge cases.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R5_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R5_CODE_PROMPT.md
@@ -1,0 +1,40 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), CODE lane, ROUND 5.
+
+R4 returned 0 CRITICAL / 0 HIGH / 0 MEDIUM and 1 LOW (model-sanitize test
+was too permissive — accepted "0 rows" as passing). R5 fix: tightened
+the test to require exactly 1 buyer-failure row with `model == "modelabc"`
+(C1 stripped) and ContainsRune(U+009B) absent. R5 also touched code
+in unrelated lanes:
+
+- `phase4-coordinator/internal/ws/messages.go::requireString` now rejects
+  C0/DEL/C1 control characters in any provider-supplied required string
+  on a hello (provider_id, hostname, model_id, binary_version,
+  attestation-related fields). Closes R4 security MEDIUM #1 (provider-
+  controlled C1 reaching structured logs via hello.provider_id).
+  New test: `TestParseHelloRejectsControlCharsInRequiredStrings` covers
+  all four fields × {C0 null, C0 LF, C1 CSI U+009B, C1 low U+0080,
+  C1 high U+009F, DEL}.
+
+## Verify
+
+- The tightened model-sanitize test is now strict: 1 row required,
+  `model == "modelabc"`. Does any existing test rely on the previous
+  loose behavior? Run the full suite to confirm.
+- The hello requireString hardening — does it break any legitimate
+  provider flow? Check `validHello` fixtures across the test corpus.
+- Are there other ws messages where required strings flow into
+  structured logs unsanitized? Check ParseAuthInitial /
+  ParseAuthResponse / ParseInference / ParseNak — they share
+  requireString, so the hardening covers them automatically, but
+  verify no other parse function bypasses requireString.
+- Full coordinator test suite — `go test ./...` — still green?
+
+## Severity rubric
+
+- **CRITICAL**: regression vs prior versions.
+- **HIGH**: an R4 finding still open.
+- **MEDIUM**: SPEC↔impl divergence; missed MUST.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R5_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R5_SECURITY_PROMPT.md
@@ -1,0 +1,53 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), SECURITY lane, ROUND 5.
+
+R4 returned 0 CRITICAL / 0 HIGH / 2 MEDIUM:
+
+1. (R4 MEDIUM #1) Provider-side `hello.provider_id` accepted valid-UTF-8
+   C1 chars and reached structured logs / close-frame reason. R5 fix:
+   `requireString` in `phase4-coordinator/internal/ws/messages.go` now
+   rejects control characters (C0, DEL, C1) at parse time, covering all
+   provider-supplied required strings on a hello. New regression test
+   `TestParseHelloRejectsControlCharsInRequiredStrings` pins it.
+
+2. (R4 MEDIUM #2) SPEC v1.5.1 prose described sanitizer hardening as
+   mostly `external_request_id` / `X-MacProvider-Account` only; FR-B9
+   listed `model`, `error`, `pref_header`, `provider_header` as plain
+   text. R5 fix: SPEC-002 §11 now has a top-level "Buyer-controlled
+   text sanitization (v1.5.1)" paragraph enumerating EVERY
+   buyer-controlled persisted text column and the sanitizer that
+   covers it (opaque headers → `sanitizeOpaqueHeader`; text fields →
+   `sanitizeRequestLogText`; WS hello strings → `requireString`).
+   FR-B9 row for `model` now includes the sanitization note pointing
+   at that paragraph.
+
+## Verify
+
+- The new `requireString` reject for C0/DEL/C1 covers all hello
+  required strings, but does the WS server have OTHER provider-
+  controlled values that bypass `requireString` and reach logs?
+  Check JSON-parsed objects like `attestation`, `model_hash`,
+  `tier_proof` — anything that goes into structured logs without
+  passing through the new control-char check.
+- Buyer-side: are there OTHER buyer-controlled fields reaching
+  request_log or logs that aren't covered by `sanitizeRequestLogText`
+  or `sanitizeOpaqueHeader`? E.g. `buyer_ip` (server-derived from
+  RemoteAddr, low risk), `provider_assigned_id` (coordinator-
+  generated, low risk).
+- The SPEC §11 paragraph and FR-B9 row — do they accurately
+  describe what the code does? Look for divergence between SPEC
+  text and the actual sanitizer signatures.
+- Does the v1.5.1 SPEC text adequately convey that the sanitization
+  contract is a load-bearing security property (not just hygiene)?
+- Re-verify the operational binding scope: no in-process money-path
+  computation silently produces wrong credits under state
+  `unindexed`.
+
+## Severity rubric
+
+- **CRITICAL**: real sanitizer bypass or money-path bug remains.
+- **HIGH**: an R4 MEDIUM still open OR a new exploit class.
+- **MEDIUM**: hardening that should land but didn't.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R6_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R6_CODE_PROMPT.md
@@ -1,0 +1,39 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), CODE lane, ROUND 6.
+
+R5 returned 1 MEDIUM (other provider-frame parsers bypass control-char
+check). R6 fixes:
+
+1. Extracted `containsControlChar(s string) bool` in
+   `phase4-coordinator/internal/ws/messages.go`. Applied at:
+   - `ParseHello`: `model_hash`, `endpoint_url` (also from `parseAuthInitial`).
+   - `parseAuthInitial`: `model_hash`, `endpoint_url`.
+   - `ParseStateUpdate`: `reason`, `since`.
+   - `ParseHeartbeat`: `model_hash`.
+   - `ParsePreflightAck`: `request_id`.
+   - `ParseNak`: `in_reply_to`, `error.code`, `error.message`.
+   - `handleInferenceChunk` / `handleInferenceEnd` in `relay.go`:
+     `chunk.RequestID` / `end.RequestID` reject before structured log.
+   - `server.go::handleMessage` unknown-envelope-type log site:
+     redact to `"[redacted_control_chars]"` if control chars present.
+
+## Verify
+
+- Are there any remaining provider-controlled strings that reach
+  structured logs without the control-char check? Particularly:
+  - `ParseDrainStatus` — its `reason` field.
+  - tier2 / receipts JSON.
+  - admission / auth log paths.
+- Does the inference chunk/end fix break any legitimate flow? The
+  request_id is internally minted as a UUID in non-malicious flow,
+  so rejecting C1/CSI should be safe.
+- Full suite still green?
+
+## Severity rubric
+
+- **CRITICAL**: regression.
+- **HIGH**: R5 finding still open.
+- **MEDIUM**: SPEC↔impl divergence; missed MUST.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R6_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R6_SECURITY_PROMPT.md
@@ -1,0 +1,48 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), SECURITY lane, ROUND 6.
+
+R5 returned 1 HIGH (provider-controlled WS strings bypass control-char
+check beyond the narrow required-hello-string path). R6 fixes:
+
+Shared helper `containsControlChar(s string) bool` extracted in
+`phase4-coordinator/internal/ws/messages.go` and applied at every
+provider-controlled string that flows to structured logs or close-
+frame reason strings:
+- Hello: model_hash, endpoint_url.
+- AuthRequest (initial): model_hash, endpoint_url.
+- StateUpdate: reason, since.
+- Heartbeat: model_hash.
+- PreflightAck: request_id.
+- Nak: in_reply_to, error.code, error.message.
+- Inference response chunk/end: request_id (in `relay.go` before the
+  unknown-request_id log call).
+- Unknown envelope `type`: redacted to a literal sentinel before
+  logging in `server.go::handleMessage`.
+
+## Verify
+
+- Are there OTHER provider-controlled values that reach structured
+  logs unsanitized? Sweep:
+  - `ParseDrainStatus.reason` (logged in handleDrainStatus).
+  - Any tier2 receipt fields that the coordinator logs.
+  - Any provider HTTP path values reaching access logs (provider
+    HTTP is on a different boundary, but verify).
+- Are there gateway-side surfaces that also need this hardening?
+  (Out of scope for #197 — gateway has its own UUIDv4 minting for
+  X-Request-ID per SPEC-006 R-G3 — but flag for follow-up if found.)
+- Does any close-frame reason string we send to the provider (or to
+  the buyer) include control characters via provider-or-buyer
+  controlled values?
+- The redact-vs-reject choice on the unknown-envelope path: is
+  "redact to sentinel and log" the right discipline, or should we
+  reject the whole message earlier (return without any log line)?
+- Money-path scope re-verify under state `unindexed`.
+
+## Severity rubric
+
+- **CRITICAL**: real exploit class still reachable.
+- **HIGH**: R5 finding not closed; or new exploit class.
+- **MEDIUM**: hardening that should land but didn't.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R7_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R7_CODE_PROMPT.md
@@ -1,0 +1,47 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), CODE lane, ROUND 7.
+
+R6 returned 1 HIGH (encrypted-frame `envelope.RequestID` / `aad.RequestID`
+were logged in `handleInferenceChunk` / `handleInferenceEnd` BEFORE the
+post-parse `containsControlChar` check fired, via tier2 log helpers and
+direct structured log calls). R7 fix:
+
+In `phase4-coordinator/internal/ws/relay.go`:
+- `handleInferenceChunk`: added `containsControlChar(envelope.RequestID)`
+  reject at the TOP of the function, immediately after the
+  `json.Unmarshal` returns successfully and before any other log call.
+- `handleInferenceChunk` encrypted-branch: added a SECOND
+  `containsControlChar(requestID)` reject AFTER `DecodeAEADAAD` returns
+  but BEFORE `session.activeFor(requestID)` / any log statement using
+  the AAD-decoded id.
+- `handleInferenceEnd`: same TWO guards (top-of-function on envelope,
+  post-AAD on requestID).
+
+The plaintext-branch post-parse `containsControlChar(chunk.RequestID)` /
+`containsControlChar(end.RequestID)` guards from R5 remain in place.
+
+## Verify
+
+- Are the new top-of-function guards in the correct position — BEFORE
+  `s.sessionFor(...)` and BEFORE any tier2.Log* helper invocation?
+- The AAD-decoded `requestID` (after `DecodeAEADAAD`) — is the guard
+  positioned before BOTH `s.closeProviderForTier2AEADFailure` AND
+  `session.activeFor(requestID)`?
+- Could a provider craft a payload that triggers the
+  `closeProviderForTier2AEADFailure` log path BEFORE either guard
+  (e.g. by failing `DecodeAEADAAD` but leaving `envelope.RequestID`
+  with control chars)? Trace each branch.
+- Are there OTHER tier2 log helpers (`LogAEADDecryptFailed`,
+  `LogEncryptedLegSessionClosed`, etc.) called from elsewhere in
+  the codebase with provider-controlled request_id values that
+  bypass the new guards?
+- Full coordinator test suite still green?
+
+## Severity rubric
+
+- **CRITICAL**: regression OR new bypass introduced.
+- **HIGH**: R6 finding still open in the encrypted-frame paths.
+- **MEDIUM**: SPEC↔impl divergence; missed MUST.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_197_R7_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_197_R7_SECURITY_PROMPT.md
@@ -1,0 +1,44 @@
+You are reviewing branch `spec/iss-197-v1-4-3-clarifications` of the macprovider repo
+(working tree `/Users/augstar/macprovider-iss197`), SECURITY lane, ROUND 7.
+
+R6 returned 1 HIGH on the encrypted-frame paths. R7 fix (same as code
+lane prompt):
+
+In `phase4-coordinator/internal/ws/relay.go`:
+- `handleInferenceChunk` + `handleInferenceEnd` each get a
+  `containsControlChar(envelope.RequestID)` reject AT THE TOP of the
+  function, before any session/log/tier2-helper call.
+- The encrypted branch in each function gets a SECOND
+  `containsControlChar(requestID)` reject AFTER `DecodeAEADAAD` decodes
+  the AAD, before `session.activeFor(...)` and before any log statement
+  using the decoded id.
+
+## Verify
+
+- The two-layer guard (envelope + AAD) closes the R6 class fully.
+  Trace every path:
+  - Unencrypted plaintext: post-parse guard at `chunk.RequestID` /
+    `end.RequestID` (R5).
+  - Encrypted + session-known: top-of-function guard catches it.
+  - Encrypted + AAD decode succeeds + session-unknown: AAD guard
+    catches it.
+  - Encrypted + AAD decode fails: top-of-function guard on
+    envelope.RequestID protects the AAD-failure log.
+  - Encrypted-required but unencrypted frame: top-of-function guard
+    catches it before tier2.LogAEADDecryptFailed.
+- Are there ANY other call sites of tier2 log helpers
+  (LogAEADDecryptFailed, LogEncryptedLegSessionClosed) where a
+  provider-controlled request_id reaches them without the guard?
+  Sweep the entire repo, not just `relay.go`.
+- Any other provider-controlled string that lands in close-frame
+  reason strings sent to the buyer or other providers?
+- Operational binding scope still holds — money-path unaffected.
+
+## Severity rubric
+
+- **CRITICAL**: real exploit class still reachable.
+- **HIGH**: R6 finding not closed; or new exploit class.
+- **MEDIUM**: hardening that should land but didn't.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/SPEC-002-coordinator.md
+++ b/specs/SPEC-002-coordinator.md
@@ -1,7 +1,151 @@
 # SPEC-002 — Phase 4 Coordinator: Mac Provider Request Router
 
-**Version:** 1.5.0 (2026-06-29, account-scoped reconciliation key — issue #211 follow-up to #196)
+**Version:** 1.5.1 (2026-06-29, R-2 normative clarifications — issue #197)
 **Depends on:** SPEC-001 v1.4 (Phase 3 binary wire protocol, locked; v1.4 adds installer custom-model selection + `models browse` + fit guard on top of the v1.3 absorbed in §7.8/§7.9); SPEC-003 FR-C9.4 composed contract — base AuthState enum (`bearer_validated`, `self_minted`, `bearerless_duplicate`) introduced in v0.8.3; `mint_failed` reserved value added in v0.8.4.
+
+**Change log v1.5.1 (2026-06-29, issue #197 — R-2 normative clarifications + sanitizer hardening):**
+- **`external_request_id` UUID-tolerance clause.** Formalizes the
+  pre-existing implementation contract for the inbound `X-Request-ID`
+  header: `request_log.external_request_id` is **opaque sanitized
+  text**, not a UUIDv4-shape-required field. Gateway-routed traffic
+  carries a UUIDv4 per SPEC-006 R-G3 (the gateway middleware mints a
+  UUIDv4 if the inbound `X-Request-ID` is absent or non-UUIDv4-like).
+  Direct coordinator buyer-port traffic (no gateway in front) MAY
+  carry an arbitrary printable, sanitized string up to 128 bytes.
+  Coordinator implementations MUST NOT reject non-UUID-shaped
+  inbound IDs but MUST apply the sanitization documented in this
+  section: trim whitespace; cap at 128 bytes; reject invalid UTF-8;
+  reject control bytes **at byte granularity** (`< 0x20`, `0x7f`,
+  and the C1 range `0x80-0x9f`). Rune-based iteration is NOT
+  sufficient — raw bytes in `0x80-0x9f` decode to `utf8.RuneError`
+  (U+FFFD) and would otherwise pass a rune-only check, bypassing
+  the load-bearing C1/CSI rejection that the
+  `c1-control-chars-terminal-sanitizer-bypass` hardening was added
+  for. On failure the value is treated as if the header was absent
+  and the malformed payload MUST NOT be echoed to structured logs
+  (re-introduces the log-injection class the sanitizer exists to
+  defeat). Cross-service reconciliation MUST NOT assume UUIDv4
+  shape when joining gateway `usage_events` to coordinator
+  `request_log` by `external_request_id`; parity is byte-exact on
+  the sanitized string. The same sanitization applies to
+  `X-MacProvider-Account` → `request_log.account_id` (SPEC-002
+  v1.5.0); both headers share `sanitizeOpaqueHeader`.
+- **Registry invariant.** The composite-key registry
+  (`migrationKeyDefs` in code, table in this SPEC) MUST be non-empty.
+  Entries are append-only: future SPEC versions add reconciliation keys
+  by appending entries and MUST NOT rename existing `key` strings. The
+  JSON `keys` array order is **normative** — consumers MAY rely on the
+  i-th entry being stable across coordinator versions; new entries
+  append at the end. If a `key` ever must be replaced
+  (irreconcilable shape change — including cosmetic rename or
+  same-columns-different-name), the path is **deprecate-and-add**:
+  the OLD `key` entry continues to enumerate with its real
+  `legacy | unindexed | indexed` state — the state-enum vocabulary
+  is NOT extended, no new `deprecated` state value is introduced —
+  while the SPEC change-log explicitly marks the old `key` as
+  deprecated and names the new `key` as its replacement. If the
+  rename is cosmetic (same columns + same index), both entries
+  report the same state derived from the same underlying schema;
+  if the shape changed, the old `key` reports `unindexed` (its
+  index dropped) or `legacy` (its column dropped) while the new
+  `key` reports the new shape's state. The deprecated `key` is
+  dropped in a later SPEC version after at least one minor-version
+  deprecation window. Tooling MUST match by `key` and MUST
+  tolerate additional entries beyond what it knows about
+  (forward-compat).
+- **Per-key migration-state machine.** Each composite reconciliation
+  key on `request_log` has its OWN three-state migration:
+  - state `legacy` — required column(s) absent in
+    `PRAGMA table_info(request_log)`. Exact composite-key
+    reconciliation is unavailable; downstream tooling MAY fall
+    back to the prior-version key (e.g.
+    `account_external_request_id` legacy → `external_request_id`
+    alone, documented ambiguity).
+  - state `unindexed` — column(s) present but the partial-NULL
+    composite index is absent in `sqlite_master`. Exact
+    reconciliation is **available** but unindexed, with the
+    operator-visible performance penalty of a full `request_log`
+    scan per join. This is NOT legacy.
+  - state `indexed` — column(s) AND partial-NULL composite index
+    present. Steady-state.
+  The aggregate `migration_state` across all keys is `legacy` if
+  ANY key is legacy; `indexed` only if EVERY key is indexed;
+  `unindexed` otherwise. Reconciliation tooling MUST decide join
+  strategy per-key, not whole-schema, because v1.4.2 R-2 and
+  v1.5.0 added separate composite keys at different times
+  (`idx_request_log_external_request_id` and
+  `idx_request_log_account_external_request_id` respectively) and
+  may be at different states on the same deployment.
+- **Canonical state vocabulary.** The strings `"legacy"`,
+  `"unindexed"`, `"indexed"` are normative. Reconciliation
+  harnesses, dashboards, and operator tooling MUST emit these
+  literal strings (no synonyms, no casing variation) so that
+  cross-team tooling is interoperable.
+- **Machine-readable surface.** The coordinator MUST expose this
+  state via `coordinator migrate-indexes --check --format json`
+  (a read-only sibling of the existing build path). JSON shape:
+  ```json
+  {
+    "migration_state": "legacy|unindexed|indexed",
+    "keys": [
+      {
+        "key": "<key-name>",
+        "column_names": ["<col>", ...],
+        "columns_present": true|false,
+        "index_name": "<idx>",
+        "index_present": true|false,
+        "state": "legacy|unindexed|indexed"
+      }
+    ]
+  }
+  ```
+  Implementation: `requestlog.Store.MigrationState(ctx)`. The
+  `--check` form does NOT mutate the schema; it is the canonical
+  state probe for external tooling.
+- **State `(unindexed)` operational binding.** Scope is by
+  **data-surface contract, not process placement**. In scope:
+  any reconciliation surface that performs **closing-the-books
+  joins** between coordinator `request_log` and gateway
+  `usage_events` / `audit_events` by composite reconciliation
+  key — out-of-process harnesses AND any future coordinator-
+  hosted endpoint that exposes the same join. Out of scope:
+  coordinator's own in-process AttemptN paths (`hotpath.go`,
+  `recovery.go`, `endpoints.go` `/admin/ledger/reconcile`)
+  which derive ordinals via single-table SQLite `IS`
+  clustering on `(account_id, request_id)` and are correct
+  (just unindexed-slow) under state `unindexed`. In-scope
+  tooling MUST fail closed when it observes state `unindexed`
+  for a composite key it depends on. Operator response: run
+  `coordinator migrate-indexes` once, then resume. Tooling MAY
+  support an explicit override (`--allow-unindexed-scan`,
+  bounded by row-count or wall-clock budget) for fixture, dev,
+  or one-shot recovery use; the override MUST NOT be the
+  default. Falling back silently to fuzzy match under state
+  `unindexed` is a SPEC violation — it conflates with state
+  `legacy` and hides an operator-action gap.
+- **Expected operator workflow.** Normal sequence is (A) daemon
+  startup applies ALTER TABLE migrations (legacy → unindexed),
+  then (B) operator runs `coordinator migrate-indexes`
+  (unindexed → indexed). The `migrate-indexes` subcommand also
+  calls `requestlog.OpenStore` and so applies any pending ALTER
+  TABLE migrations itself before building indexes; running it
+  against a legacy DB takes the schema directly to indexed in
+  one invocation.
+- **Sanitizer hardening (code change).** v1.5.1 ships byte-level
+  C1 rejection + invalid-UTF-8 rejection in
+  `sanitizeExternalRequestID` and `sanitizeAccountID` via a
+  shared `sanitizeOpaqueHeader` helper. Pre-v1.5.1 the rune-based
+  loop accepted raw C1 bytes via `utf8.RuneError` decoding;
+  v1.5.1 closes that bypass and pins it with regression tests
+  for `0x80`, `0x9b`, `0x9f`, and invalid UTF-8 leads.
+- **Cross-SPEC alignment.** SPEC-005 reconciliation tooling that
+  enforces schema-check (failing closed on missing indexes) MUST
+  read the per-key state vocabulary defined here. SPEC-007 v0.3
+  explorer surface gates by resolved row fields (not schema
+  state) and is independent of this state machine. SPEC-006
+  R-G3 (gateway UUIDv4 minting) is unchanged — gateway-routed
+  traffic remains UUIDv4-shaped; the v1.5.1 opaque-text tolerance
+  is scoped to the direct coordinator buyer-port input.
 
 **Change log v1.5.0 (2026-06-29, issue #211 — coordinator-side counterpart to #196 composite-PK):**
 - `request_log` gains an `account_id TEXT NULL` column. The
@@ -1389,7 +1533,7 @@ Every buyer request is logged to the `request_log` table in SQLite:
 | `request_id` | TEXT | Coordinator-internal request/billing id (NOT the inbound `X-Request-ID`). On the non-pinned retry path multiple `request_log` rows for one logical buyer request share this value; pinned-client retries get distinct values. |
 | `external_request_id` | TEXT NULL | Inbound `X-Request-ID` header value. Shared across all `request_log` rows for one logical request and across the gateway's `usage_events.request_id` for the same logical request, enabling end-to-end billing reconciliation. NULL when the inbound request carried no `X-Request-ID`. (v1.4.2 R-2; formally documented here.) |
 | `account_id` | TEXT NULL | (v1.5.0) Gateway account id propagated via `X-MacProvider-Account` on the gateway → coordinator forward. NULL on legacy rows and on direct legacy buyer calls without the header. The composite `(account_id, external_request_id)` is the reconciliation key joining to gateway `usage_events`; `external_request_id` alone is a logical join key only. |
-| `model` | TEXT | Requested model |
+| `model` | TEXT | Requested model. **Sanitized at the buyer-handler boundary (v1.5.1):** valid-UTF-8 only; C0 / DEL / C1 codepoints stripped via `sanitizeRequestLogText`. The same sanitizer applies to `error`, `pref_header`, `provider_header` below. |
 | `provider_assigned_id` | TEXT | Pool ID of serving provider (null if 503) |
 | `prompt_tokens` | INTEGER | From provider response usage (null if failed) |
 | `completion_tokens` | INTEGER | From provider response usage (null if failed) |
@@ -1422,9 +1566,40 @@ CREATE INDEX idx_request_log_account_external_request_id ON request_log(account_
     WHERE account_id IS NOT NULL AND external_request_id IS NOT NULL;
 ```
 
-The `idx_request_log_ts_utc` index supports SPEC-005 v0.3 reconciliation scans (24h startup, 7d nightly, ad-hoc admin ranges) at 10K-provider scale. The composite `(request_id, id)` index supports the SPEC-005 § 8.2 attempt-ordinal fallback and SPEC-004 multi-attempt log queries. The partial-NULL `external_request_id` and `(account_id, external_request_id)` indexes support out-of-process reconciliation joins to gateway `usage_events`.
+The `idx_request_log_ts_utc` index supports SPEC-005 v0.3 reconciliation scans (24h startup, 7d nightly, ad-hoc admin ranges) at 10K-provider scale. The composite `(request_id, id)` index supports the SPEC-005 § 8.2 attempt-ordinal fallback and SPEC-004 multi-attempt log queries. The partial-NULL `external_request_id` and `(account_id, external_request_id)` indexes support closing-the-books reconciliation joins to gateway `usage_events` and `audit_events` (whether run as out-of-process harnesses or via a future coordinator-hosted reconciliation endpoint).
 
 Migration: existing deployments MUST apply `ALTER TABLE request_log ADD COLUMN error_code TEXT NULL`, `ALTER TABLE request_log ADD COLUMN external_request_id TEXT NULL` (v1.4.2 R-2), and `ALTER TABLE request_log ADD COLUMN account_id TEXT NULL` (v1.5.0), and create the four indexes above. The two partial-NULL reconciliation indexes are built via `coordinator migrate-indexes`, NOT from daemon startup.
+
+**Per-key migration-state machine (v1.5.1).** Because ALTER TABLE migrations run at daemon startup but the partial-NULL composite indexes are built only by the operator subcommand `coordinator migrate-indexes`, each composite reconciliation key on `request_log` has its OWN three-state migration:
+
+| State | Column(s) | Index | Meaning |
+|---|---|---|---|
+| `legacy` | absent | n/a | pre-migration; exact composite-key reconciliation unavailable |
+| `unindexed` | present | absent | rollout incomplete; exact reconciliation **available** but unindexed |
+| `indexed` | present | present | steady-state |
+
+The state machine is PER-KEY because v1.4.2 R-2 (`external_request_id`) and v1.5.0 (`account_external_request_id`) added their composite indexes at different points in time; the same deployment may be at different states on each. The aggregate `migration_state` across all keys is `legacy` if ANY key is legacy; `indexed` only if EVERY key is indexed; `unindexed` otherwise. **`unindexed` is NOT legacy** — exact composite-key reconciliation is available but unindexed (full-scan), and reconciliation tooling MUST distinguish it. Reconciliation tooling MUST introspect BOTH `PRAGMA table_info(request_log)` (column presence) AND `sqlite_master` (index presence) per key. The canonical state vocabulary is `"legacy" | "unindexed" | "indexed"` — tooling MUST emit these literal strings.
+
+**Machine-readable state surface (v1.5.1).** The coordinator exposes per-key migration state via `coordinator migrate-indexes --check --format json` (a read-only sibling of the existing build path), backed by `requestlog.Store.MigrationState`. JSON shape:
+
+```json
+{
+  "migration_state": "unindexed",
+  "keys": [
+    { "key": "external_request_id", "column_names": ["external_request_id"], "columns_present": true, "index_name": "idx_request_log_external_request_id", "index_present": false, "state": "unindexed" },
+    { "key": "account_external_request_id", "column_names": ["account_id", "external_request_id"], "columns_present": true, "index_name": "idx_request_log_account_external_request_id", "index_present": false, "state": "unindexed" }
+  ]
+}
+```
+
+**State `unindexed` operational binding (v1.5.1).** **Scope is defined by data-surface contract, not process placement:**
+
+- **In scope (MUST fail closed on state `unindexed`/`legacy`):** any reconciliation surface that performs **closing-the-books joins** between coordinator `request_log` and gateway `usage_events` / `audit_events` by the composite reconciliation key — the SPEC-005 v0.3+ closing-the-books contract. This includes both out-of-process harnesses (e.g. nightly reconciler, issue #226 harness) AND any future coordinator-hosted endpoint that exposes the same join (e.g. a hypothetical `/admin/explorer/reconcile` returning cross-table joined rows for external auditors).
+- **Out of scope (MUST NOT fail closed during the `unindexed` rollout window):** coordinator's own in-process AttemptN derivation paths — `internal/billing/hotpath.go`, `internal/billing/recovery.go`, `internal/billing/endpoints.go` `/admin/ledger/reconcile`. These derive attempt ordinals via SQLite `IS` clustering on `(account_id, request_id)` over a single table (`request_log`); they do NOT join gateway tables. They are correct (just unindexed-slow) under state `unindexed`, and the daemon-startup `legacy → unindexed` rollout window is by design a transient state the daemon serves traffic in.
+
+In-scope tooling MUST fail closed when it observes state `unindexed` (or `legacy`) for a composite key it depends on, until the operator runs `coordinator migrate-indexes`. Tooling MAY support an explicit `--allow-unindexed-scan` override (bounded by row-count or wall-clock budget) for fixture, dev, or one-shot recovery use; the override MUST NOT be the default. Silently falling back to fuzzy match under state `unindexed` is a SPEC violation — it conflates with state `legacy` and hides an operator-action gap.
+
+**Expected operator workflow.** Daemon startup applies ALTER TABLE migrations (`legacy → unindexed`), then operator runs `coordinator migrate-indexes` (`unindexed → indexed`). The `migrate-indexes` subcommand also calls `requestlog.OpenStore` and so applies any pending ALTER TABLE migrations itself before building indexes; running it against a `legacy` DB takes the schema directly to `indexed` in one invocation.
 
 **Deploy ordering (v1.5.0).** Coordinator MUST be deployed first; it accepts and persists `X-MacProvider-Account` whether or not the gateway sends it. Gateway then deploys with the unconditional header. Auditor tooling MUST detect the boundary at row granularity (not schema granularity): rows with NULL `account_id` are either (a) pre-v1.5.0-coordinator rows, (b) v1.5.0-coordinator rows from a pre-v0.9.1 gateway, or (c) v1.5.0-coordinator rows written during a v1.4.x rollback window where the column existed but the writer didn't populate it. In all three cases the join MUST fall back to the prior `external_request_id`-only key and accept the documented ambiguity. Tooling MUST NOT use `PRAGMA table_info(request_log)` column-presence as a switch — that would misclassify rollback-window rows as scoped-ready. Use `account_id IS NOT NULL` as the per-row gate instead.
 
@@ -2346,6 +2521,15 @@ Wire-compatible with SPEC-001 section 6.2. The harness (`beta/harness.py`)
 is the first buyer and generates SPEC-001-shaped requests.
 
 Coordinator MUST honor any inbound `X-Request-ID` header on buyer-facing `/v1/*` requests and persist it as `request_log.external_request_id` (v1.4.2 R-2). If absent, coordinator's internal `request_log.request_id` is generated locally as a UUID v4 and `external_request_id` is NULL. The `request_log` schema includes a partial-NULL `external_request_id` index for cross-service reconciliation.
+
+**Buyer-controlled text sanitization (v1.5.1).** Every column in `request_log` whose value originates from buyer-controlled input — `external_request_id` (from `X-Request-ID`), `account_id` (from `X-MacProvider-Account`), `model` (from JSON body), `error` (provider/upstream error message), `pref_header` (from `X-MacProvider-Pref`), `provider_header` (from `X-MacProvider-Provider`) — MUST pass through a sanitizer at the buyer-handler boundary:
+- **Opaque headers** (`external_request_id`, `account_id`): `sanitizeOpaqueHeader` — reject the whole value on UTF-8 invalid OR control bytes (C0 `<0x20`, DEL `0x7f`, C1 `0x80-0x9f`) at byte granularity, cap at 128 bytes.
+- **Text fields** (`model`, `error`, `pref_header`, `provider_header`): `sanitizeRequestLogText` — reject UTF-8 invalid; strip C0/DEL/C1 codepoints; cap at 256 runes.
+- **WS provider hello required strings** (`provider_id`, `hostname`, `model_id`, `binary_version` — provider-controlled, not buyer-controlled, but they reach the same structured-log surface): `requireString` rejects control characters at parse time so a malicious provider cannot inject CSI sequences via the hello.
+
+Reason: terminal-control-character (CSI / OSC) sequences in structured logs and SQLite text columns are a load-bearing log-injection class — the `c1-control-chars-terminal-sanitizer-bypass` audit established this for opaque headers and v1.5.1 extends the contract to every buyer-controlled persisted text column.
+
+**UUID-tolerance (v1.5.1).** `external_request_id` is **opaque sanitized text**, not UUIDv4-shape-required. Gateway-routed traffic carries a UUIDv4 per SPEC-006 R-G3 (the gateway middleware mints a UUIDv4 if the inbound `X-Request-ID` is absent or non-UUIDv4-like). Direct coordinator buyer-port traffic MAY carry any non-control 1-128-byte ASCII/UTF-8 string. Coordinator implementations MUST NOT reject non-UUID-shaped inbound IDs but MUST apply `sanitizeExternalRequestID` (trim whitespace; cap at 128 bytes; reject invalid UTF-8; reject control bytes `< 0x20`, `0x7f`, and the C1 range `0x80-0x9f` **at byte granularity** — rune iteration is insufficient because raw C1 bytes decode to `utf8.RuneError` and would otherwise slip through, defeating the load-bearing C1/CSI rejection; on failure treat as absent and DO NOT echo the malformed payload to logs). Cross-service reconciliation MUST NOT assume UUIDv4 shape; the value is opaque text and parity is byte-exact on the sanitized string.
 
 When forwarding work to a provider over the SPEC-001 § 6.6 `inference_request` message, coordinator MUST preserve the request ID it recorded for the buyer request. Providers MAY echo `X-Request-ID` back in usage reporting; this is OPTIONAL under SPEC-001 v1.2.4 and is filed as a SPEC-001 v1.2.3 candidate.
 

--- a/specs/SPEC-002-v1-5-1-audit.md
+++ b/specs/SPEC-002-v1-5-1-audit.md
@@ -1,0 +1,99 @@
+# SPEC-002 v1.5.1 audit trail (issue #197)
+
+Three-lane codex audit on the v1.5.1 R-2 normative clarifications + sanitizer hardening.
+
+## Scope
+
+v1.5.1 closes the SPEC text gaps identified by codex on PR #195 (architect R7/R8) plus the C1 sanitizer-bypass class surfaced by the v1.5.1 R1 code + security lanes:
+
+1. **UUID-tolerance** — `external_request_id` is opaque sanitized text, not UUIDv4-shape-required. Sanitization is byte-level (raw C1 bytes must be rejected, not just runes).
+2. **Per-key migration-state machine** — each composite reconciliation key has its own `legacy | unindexed | indexed` state; aggregate is min-wise. Canonical vocabulary `"legacy"|"unindexed"|"indexed"` MUST be emitted by tooling.
+3. **Machine-readable state surface** — `coordinator migrate-indexes --check --format json` exposes per-key + aggregate state via `requestlog.Store.MigrationState`.
+4. **State `unindexed` operational binding** — production reconciliation tooling MUST fail closed; explicit override MUST NOT be default.
+5. **Sanitizer hardening code change** — `sanitizeExternalRequestID` / `sanitizeAccountID` consolidated into `sanitizeOpaqueHeader`; byte-level C1 rejection + invalid UTF-8 rejection; tests pinned for 0x80, 0x9b, 0x9f, and invalid UTF-8 leads.
+
+## R1 → R2 disposition
+
+R1 returned 0 CRITICAL / 4 HIGH (1 CODE + 1 SECURITY convergent on C1 sanitizer; 2 ARCHITECT on state-machine + state-(B) operational binding) / 1 MEDIUM / 2 LOW.
+
+Convergent CODE+SECURITY HIGH (C1 raw-byte bypass via `utf8.RuneError`):
+- Fixed in [phase4-coordinator/internal/buyer/server.go](../phase4-coordinator/internal/buyer/server.go): `sanitizeExternalRequestID` and `sanitizeAccountID` now route through a shared `sanitizeOpaqueHeader` that validates UTF-8 then iterates byte-by-byte over the C0/DEL/C1 reject set.
+- Regression tests added in [phase4-coordinator/internal/buyer/server_test.go](../phase4-coordinator/internal/buyer/server_test.go) `TestRequestLogExternalRequestIDRejectsMalformedHeader`: new cases `c1_low` (0x80), `c1_csi` (0x9b), `c1_high` (0x9f), `invalid_utf8_lead`, `invalid_utf8_alone`.
+
+ARCHITECT HIGH #1 (state-(B) operational binding ambiguous vs SPEC-005 schema-check):
+- SPEC §11 v1.5.1 block now binds production reconciliation tooling to fail closed under state `unindexed`; explicit `--allow-unindexed-scan` override allowed for fixture/dev/recovery only.
+
+ARCHITECT HIGH #2 (state machine must be per-key, not whole-schema):
+- SPEC §11 v1.5.1 block restructured: per-key state machine; aggregate is min(states) with `legacy` if any key legacy, `indexed` only if all keys indexed, `unindexed` otherwise.
+- Implemented in [phase4-coordinator/internal/requestlog/store.go](../phase4-coordinator/internal/requestlog/store.go) `MigrationState` returning `MigrationStatus{Aggregate, Keys[]}` with per-key `MigrationKeyState`.
+- Test: [phase4-coordinator/internal/requestlog/store_test.go](../phase4-coordinator/internal/requestlog/store_test.go) `TestMigrationStateReportsPerKeyStatesAndAggregate` exercises all three states and the legacy-wins aggregation.
+
+ARCHITECT MEDIUM (machine-readable enum + CLI surface):
+- Canonical vocabulary `"legacy"|"unindexed"|"indexed"` pinned normatively.
+- New CLI: `coordinator migrate-indexes --check --format json` in [phase4-coordinator/cmd/coordinator/migrate_indexes.go](../phase4-coordinator/cmd/coordinator/migrate_indexes.go); read-only, does not mutate schema.
+
+ARCHITECT LOW (naming clash "Phase-C reconciliation tooling" with state (C)):
+- Removed; SPEC text now refers to "reconciliation tooling" without the Phase-C qualifier.
+
+CODE LOW (workflow note: `migrate-indexes` against legacy DB takes A → C directly):
+- Clarified in the "Expected operator workflow" paragraph.
+
+## Round dispositions
+
+### R1 (3 lanes)
+- CODE: 1 HIGH (raw C1 bytes bypass sanitizer via `utf8.RuneError`) + 1 LOW (workflow note).
+- SECURITY: 1 HIGH (same C1 raw-byte bypass — terminal CSI injection).
+- ARCHITECT: 2 HIGH (state-(B) operational binding ambiguous; state machine should be per-key, not whole-schema) + 1 MEDIUM (machine-readable enum + CLI surface) + 1 LOW (Phase-C naming clash with state C).
+
+### R2 fixes (5 MEDIUM emerged from R2 audit)
+- Byte-level `sanitizeOpaqueHeader` (closes convergent R1 CODE+SECURITY HIGH).
+- Per-key state machine: `MigrationState` returns per-key + aggregate `legacy | unindexed | indexed`.
+- Canonical state vocabulary pinned normatively.
+- New CLI `coordinator migrate-indexes --check --format json`.
+- Registry invariant clause (non-empty, append-only).
+- SPEC §11 + change-log restructured.
+- R2 audit returned: CODE 2 MEDIUM (`--check` mutates schema; billing.Store doesn't enforce MUST); SECURITY 2 MEDIUM (other fields use weaker sanitizer; same MUST gap); ARCHITECT 1 MEDIUM (SPEC-005 alignment).
+
+### R3 fixes
+- `OpenStoreReadOnly` + route `--check` through it; validate `--format` before opening.
+- `sanitizeRequestLogText` strengthened (UTF-8 validation + C1 strip).
+- Sharpened operational-binding SPEC scope: applies to closing-the-books out-of-process tooling, NOT in-process recovery.
+- Bumped SPEC-005 → v0.3.2; depend on SPEC-002 v1.5.1.
+- Shared registry between MigrationState and MigrateIndexes (single source of truth).
+- R3 audit returned: CODE 1 CRITICAL (`model` field not sanitized); SECURITY 1 CRITICAL (same) + 1 HIGH (`/v1/pool/check?provider_id=`); ARCHITECT 2 MEDIUM (SPEC-005 §1.4 stale; scope by data-surface contract) + 2 LOW.
+
+### R4 fixes
+- `sanitizeRequestLogText(b.model)` on persistence; sanitize `/v1/pool/check?provider_id=` before log.
+- New `sqliteutil.ReadOnlyDSN` (mode=ro + query_only=ON; no WAL/synchronous pragmas).
+- SPEC scope rewritten by data-surface contract (in-scope = closing-the-books joins to gateway `usage_events` / `audit_events`; out-of-scope = in-process AttemptN over single-table `request_log`).
+- SPEC-005 §1.4 bumped to v1.5.1.
+- Deprecate-and-add escape hatch + JSON array order normative.
+- R4 audit returned: CODE 0 C/H/M + 1 LOW (test strength); SECURITY 0 C/H + 2 MEDIUM (provider-side `hello.provider_id`; SPEC FR-B9 prose gap); ARCHITECT 0 C/H + 1 MEDIUM (SPEC-005 §10.4 + SPEC-002 line 1560 residual "out-of-process") + 1 LOW.
+
+### R5 fixes
+- `requireString` hardened to reject control characters at WS parse time.
+- New "Buyer-controlled text sanitization" §11 paragraph enumerating every column + sanitizer.
+- SPEC-005 §10.4 + SPEC-002 line 1560 rewritten to data-surface contract phrasing.
+- Tightened model-sanitize test to assert exactly 1 row with `model == "modelabc"`.
+- `TestParseHelloRejectsControlCharsInRequiredStrings` regression test added.
+- R5 audit returned: CODE 1 MEDIUM (other parsers bypass `requireString`); SECURITY 1 HIGH (same — `endpoint_url`, `model_hash`, `state_update.reason`, `heartbeat.model_hash`, unknown envelope `type`); ARCHITECT 0 C/H/M + 2 LOW. ARCHITECT lane converged.
+
+### R6 fixes (security + code, architect skipped)
+- Extracted shared `containsControlChar(s)` helper.
+- Applied at: `ParseHello`/`parseAuthInitial` (model_hash + endpoint_url); `ParseStateUpdate` (reason, since); `ParseHeartbeat` (model_hash); `ParsePreflightAck` (request_id); `ParseNak` (in_reply_to, error.code, error.message); inference chunk/end relay handlers (post-parse).
+- Unknown-envelope `type` redacted to sentinel before logging.
+- R6 audit returned: CODE 1 HIGH (encrypted-frame `envelope.RequestID` / `aad.RequestID` log before guard); SECURITY 1 HIGH (same).
+
+### R7 fixes (security + code)
+- Two-layer guard in `handleInferenceChunk` / `handleInferenceEnd`: top-of-function on `envelope.RequestID` (before any tier2 log helper or `sessionFor` lookup), and post-AAD-decode on `requestID` (before `session.activeFor` and any decoded-id log).
+- Plaintext-branch post-parse `chunk.RequestID` / `end.RequestID` guards from R5 remain in place.
+- R7 audit: CODE 0 C/H/M (1 LOW cosmetic ordering); SECURITY 0 C/H/M.
+
+### R8 NOT REQUIRED — Converged.
+
+All three lanes at **0 CRITICAL / 0 HIGH / 0 MEDIUM**:
+- CODE lane: R7 0 C/H/M (1 LOW cosmetic).
+- SECURITY lane: R7 0 C/H/M.
+- ARCHITECT lane: R5 0 C/H/M (2 LOW).
+
+Loop closed.

--- a/specs/SPEC-005-billing.md
+++ b/specs/SPEC-005-billing.md
@@ -1,7 +1,32 @@
 # SPEC-005 - Billing, Settlement, and Provider Rewards
 
-**Version:** 0.3.1 (2026-06-29, SPEC-002 v1.5.0 dependency bump — issue #211)
-**Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.0, SPEC-003 v0.7, SPEC-004 v0.3.1, SPEC-006 v0.9.1
+**Version:** 0.3.2 (2026-06-29, SPEC-002 v1.5.1 per-key migration-state dependency — issue #197)
+**Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.1, SPEC-003 v0.7, SPEC-004 v0.3.1, SPEC-006 v0.9.1
+
+**Change log v0.3.2 (2026-06-29, issue #197 — SPEC-002 v1.5.1 dependency bump + per-key migration-state contract):**
+- Dependency bump: SPEC-002 v1.5.0 → v1.5.1 to absorb the per-key
+  `legacy | unindexed | indexed` migration-state machine. The §10.4
+  "production startup MUST fail the schema check" sentence below is
+  reworded to read the per-key state instead of the prior binary
+  legacy/migrated model. Schema-check failure conditions are now:
+  - any depended-on composite reconciliation key in state `legacy`
+    (column absent) → production reconciliation MUST fail closed;
+  - any depended-on composite reconciliation key in state `unindexed`
+    (column present, partial-NULL composite index absent) →
+    production reconciliation MUST fail closed unless an explicit
+    bounded `--allow-unindexed-scan` override is provided (operator
+    response: run `coordinator migrate-indexes`).
+  Scope is by **data-surface contract, not process placement**: this
+  binding governs any reconciliation surface that performs **closing-
+  the-books joins** between coordinator `request_log` and gateway
+  `usage_events` / `audit_events` (the SPEC-005 v0.3+ contract) —
+  out-of-process harnesses AND any future coordinator-hosted endpoint
+  that exposes the same join. The coordinator's own in-process
+  `RecoverLedger`, admin reconcile, and hot-path AttemptN paths
+  derive ordinals via single-table SQLite `IS` clustering and are
+  correct (just unindexed-slow) under state `unindexed`; they do NOT
+  fail closed during the daemon-startup rollout window. No code
+  change in this version.
 
 **Change log v0.3.1 (2026-06-29, issue #211):**
 - Dependency bump: SPEC-002 v1.3.4 → v1.5.0 and SPEC-006 v0.8.2 → v0.9.1
@@ -102,11 +127,12 @@ This section implements the locked billing and unit decisions (D1)(D6) and the S
 - usage object has prompt_tokens, completion_tokens, total_tokens.
 - cancel usage is authoritative for v1.2.4+ providers.
 - SPEC-005 MUST NOT require new provider fields.
-**SPEC-002 v1.5.0:**
+**SPEC-002 v1.5.1:**
 - coordinator owns request_log and provider auth.
 - request_log is read-only to SPEC-005.
 - request_log carries deterministic `error_code` for SPEC-001 null-usage errors.
 - request_log has `ts_utc`, `(request_id, id)`, `external_request_id` (partial-NULL), and `(account_id, external_request_id)` (partial-NULL composite) indexes for reconciliation scans and attempt fallback. (Composite index added in v1.5.0 / issue #211.)
+- per-key migration state `legacy | unindexed | indexed` is exposed by `coordinator migrate-indexes --check --format json`. SPEC-005 reconciliation tooling that performs **closing-the-books joins** between coordinator `request_log` and gateway `usage_events` / `audit_events` MUST consume this state and fail closed on any depended-on key in state `legacy` or `unindexed` (v0.3.2 / issue #197).
 - each provider attempt for a repeated request_id has its own request_log row.
 - request_log carries `account_id` (v1.5.0 / issue #211). The composite `(account_id, request_id)` is the grouping key for attempt-ordinal derivation; SQLite `IS` semantics preserve the pre-v1.5.0 grouping for legacy NULL-`account_id` rows.
 - FR-P11a supplies fault categories.
@@ -763,7 +789,7 @@ Same inputs produce byte-identical outputs.
 Time is explicit input.
 No live network call may affect output.
 `scanWindow.to_utc` MUST be no closer to wall-clock now than `settlement.recovery_grace_seconds` (default 30s). Rows with `request_log.ts_utc` newer than this cutoff are excluded from the scan to prevent races with in-flight hot-path transactions.
-SPEC-002 v1.5.0 indexes `request_log.ts_utc`, `(request_id, id)`, `external_request_id` (partial-NULL), and `(account_id, external_request_id)` (partial-NULL composite) are preconditions for production-scale reconciliation scans; missing indexes in a fixture MAY use a bounded chunked scan, but production startup MUST fail the schema check. (v0.3.1 / issue #211.)
+SPEC-002 v1.5.1 indexes `request_log.ts_utc`, `(request_id, id)`, `external_request_id` (partial-NULL), and `(account_id, external_request_id)` (partial-NULL composite) are preconditions for production-scale reconciliation scans. Any reconciliation surface that performs closing-the-books joins between coordinator `request_log` and gateway `usage_events` / `audit_events` by composite reconciliation key — whether run as an out-of-process harness OR as a future coordinator-hosted reconciliation endpoint — MUST read per-key migration state via `coordinator migrate-indexes --check --format json` (`requestlog.Store.MigrationState`) and fail closed when any depended-on composite key is in state `legacy` or `unindexed`, per the SPEC-002 v1.5.1 operational binding. Fixture / dev / one-shot recovery runs MAY pass an explicit bounded `--allow-unindexed-scan` override; the override MUST NOT be the default. Coordinator's own in-process AttemptN paths (`hotpath.go`, `recovery.go`, `endpoints.go` `/admin/ledger/reconcile`) use single-table SQLite `IS` clustering and are correct (just unindexed-slow) under state `unindexed`; they do NOT fail closed during the rollout window. (v0.3.2 / issue #197; v0.3.1 / issue #211 added the composite index dependency.)
 For each recoverable request_log row, the algorithm selects the latest config snapshot whose effective_at_utc is less than or equal to request_log.ts_utc.
 If no config snapshot or provider identity snapshot can be selected for a provider-reached row, the row is quarantined.
 


### PR DESCRIPTION
## Summary

Closes #197. Issue framed two SPEC-002 R-2 clarifications deferred from PR #195's
codex audit. As doc-only the change was modest; the seven-round three-lane codex
audit expanded scope to a real sanitizer-hardening + per-key migration-state
implementation pass.

## What changed

**SPEC-002 v1.5.1** (`specs/SPEC-002-coordinator.md`):
- `external_request_id` UUID-tolerance clause (opaque sanitized text, not
  UUIDv4-shape-required; sanitizer is byte-level).
- Per-key `legacy | unindexed | indexed` migration-state machine; aggregate
  is `legacy` if any key legacy, `indexed` iff all indexed, `unindexed`
  otherwise.
- Canonical state vocabulary pinned; `migrate-indexes --check --format json`
  exposes machine-readable state per key.
- State `unindexed` operational binding scoped by **data-surface contract,
  not process placement**: applies to any reconciliation surface that
  performs closing-the-books joins between coordinator `request_log` and
  gateway `usage_events` / `audit_events`. Does NOT apply to in-process
  AttemptN paths (which use SQLite `IS` clustering and are correct under
  `unindexed`).
- Registry invariant + deprecate-and-add escape hatch for the rare
  key-rename case.
- New "Buyer-controlled text sanitization" §11 paragraph enumerating
  every persisted buyer-controlled text column and its sanitizer.

**SPEC-005 v0.3.2** (`specs/SPEC-005-billing.md`):
- Dependency bump SPEC-002 v1.5.0 → v1.5.1.
- §1.4 + §10.4 schema-check rewritten to the per-key state contract.

**Coordinator IMPL** (`phase4-coordinator/`):
- `internal/buyer/server.go`:
  - `sanitizeOpaqueHeader` (byte-level C0/DEL/C1 reject + UTF-8 validation)
    closes the raw-C1-byte-via-`utf8.RuneError` bypass for opaque headers.
  - `sanitizeRequestLogText` hardened (UTF-8 validation + C1 strip) closes
    the same class for `error`, `pref_header`, `provider_header`, `model`.
  - `handlePoolCheck`: sanitize `?provider_id=` query before logging.
- `internal/buyer/billing_recorder.go`: wrap `b.model` with sanitizer
  before persistence.
- `internal/requestlog/store.go`:
  - `MigrationKeyState` + `MigrationStatus` + `MigrationState(ctx)` —
    per-key + aggregate state.
  - `migrationKeyDefs` consolidated registry (Columns + IndexName + DDL)
    shared by `MigrationState` and `MigrateIndexes`.
  - `OpenStoreReadOnly` strictly read-only path (no `migrate()` call).
- `internal/sqliteutil/dsn.go`: `ReadOnlyDSN` helper (`mode=ro` +
  `query_only=ON`, no WAL/synchronous pragmas).
- `cmd/coordinator/migrate_indexes.go`: `--check --format=text|json`
  routes through `OpenStoreReadOnly`; `--format` validated BEFORE
  config-load + open.
- `internal/ws/messages.go`: shared `containsControlChar(s)` helper
  applied at every provider-controlled string that reaches structured
  logs — `requireString` (provider_id, hostname, model_id,
  binary_version), `ParseHello` + `parseAuthInitial` (model_hash,
  endpoint_url), `ParseStateUpdate` (reason, since), `ParseHeartbeat`
  (model_hash), `ParsePreflightAck` (request_id), `ParseNak`
  (in_reply_to, error.code, error.message).
- `internal/ws/relay.go`: `handleInferenceChunk` + `handleInferenceEnd`
  each get a two-layer guard — top-of-function on `envelope.RequestID`
  (before any tier2 log helper or session lookup), and post-AAD-decode
  on `requestID` (before `session.activeFor` and unknown-encrypted log).
- `internal/ws/server.go::handleMessage`: unknown-envelope `type`
  redacted to `"[redacted_control_chars]"` if control chars present.

## Regression tests

- `TestRequestLogExternalRequestIDRejectsMalformedHeader` extended for
  raw C1 bytes (0x80, 0x9b, 0x9f) + invalid UTF-8 leads.
- `TestRequestLogModelFieldSanitized` — JSON `model` with U+009B
  (valid UTF-8) → 4xx + exactly 1 request_log row with `model ==
  "modelabc"`.
- `TestMigrationStateReportsPerKeyStatesAndAggregate` — all three
  states + the `legacy`-wins aggregate rule.
- `TestMigrateIndexesCheckIsReadOnly` — `--check` against a legacy DB
  reports `aggregate=legacy` AND leaves schema unchanged.
- `TestMigrateIndexesCheckRejectsBogusFormatBeforeOpen` — invalid
  `--format` returns `rc=2` without triggering schema migration.
- `TestParseHelloRejectsControlCharsInRequiredStrings` — 4 fields ×
  {C0 null, C0 LF, C1 CSI U+009B, C1 low U+0080, C1 high U+009F, DEL}.

## Audit trail

Seven rounds of three-lane codex audit (architect converged at R5,
code + security at R7). Prompts and per-round disposition in:

- `specs/AUDIT_ISS_197_R{1..7}_*.md`
- `specs/SPEC-002-v1-5-1-audit.md` (round narrative)

Notable findings closed:
- R1 CODE+SECURITY HIGH (convergent): raw C1 bytes bypassed
  `sanitizeExternalRequestID` because rune iteration decoded them to
  `utf8.RuneError`.
- R1 ARCHITECT HIGH: state machine should be per-key, not
  whole-schema.
- R3 CRITICAL (CODE+SECURITY convergent): `request_log.model` bypassed
  sanitization.
- R5 SECURITY HIGH: provider-side `hello.provider_id` + other required
  strings reached structured logs unsanitized.
- R6 HIGH (CODE+SECURITY convergent): encrypted-frame `envelope.
  RequestID` and AAD-decoded `requestID` logged before guard.

## Test plan

- [ ] Review `phase4-coordinator/internal/buyer/server.go::sanitizeOpaqueHeader`
      and `sanitizeRequestLogText` byte-vs-rune semantics.
- [ ] Review `phase4-coordinator/internal/requestlog/store.go::MigrationState`
      and the shared `migrationKeyDefs` registry.
- [ ] Review the operational-binding scope in SPEC-002 §11 + SPEC-005
      §10.4 — does the data-surface-contract framing read correctly?
- [ ] Confirm the WS guards (`containsControlChar` at every
      provider-controlled string boundary) don't break legitimate
      provider flows in your environment.
- [ ] Confirm `migrate-indexes --check` works against a real Pearl-deploy
      DB and reports `indexed` (or `unindexed` if `migrate-indexes`
      hasn't been run yet on that deploy).

Closes #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
