### PR TITLE
spec(002,005): v1.5.2 / v0.3.3 — monotonic attempt_n column (closes #168)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/backfill_attempt_n.go
+++ b/phase4-coordinator/cmd/coordinator/backfill_attempt_n.go
@@ -1,0 +1,143 @@
+package main
+
+// SPEC-002 v1.5.2 / issue #168: operator-runbook subcommand
+//
+//	coordinator backfill-attempt-n --config <path>
+//
+// One-shot UPDATE to populate request_log.attempt_n for legacy
+// pre-v1.5.2 rows. The column is added by daemon startup
+// (ensureColumns); rows written before v1.5.2 carry NULL. This
+// subcommand walks rows in id-ASC order within each
+// (account_id, request_id) group under SQLite IS semantics and
+// assigns attempt_n monotonically — byte-identical to the v0.3.1
+// read-time fallback derivation, persisted once so the read paths
+// can use the column directly.
+//
+// Idempotent: rows with non-NULL attempt_n are skipped. Safe to
+// re-run.
+//
+// `--check --format=text|json` reports migration state without
+// mutating the schema:
+//   - legacy: column absent
+//   - populating: column present, some rows still NULL
+//   - populated: column present, zero NULL rows
+//
+// Intentionally NOT invoked from the daemon path: the request-log
+// store caps the pool at one writer connection (issue #21 / ARCH-3),
+// so running this inside the daemon would contend with the 6s
+// INSERT timeout on the hot path.
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/requestlog"
+)
+
+func runBackfillAttemptN(args []string) int {
+	return runBackfillAttemptNIO(args, os.Stdout, os.Stderr)
+}
+
+func runBackfillAttemptNIO(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("backfill-attempt-n", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configPath := fs.String("config", "coordinator.yaml", "path to coordinator YAML config")
+	timeout := fs.Duration("timeout", 30*time.Minute, "max time the backfill may run")
+	check := fs.Bool("check", false, "report migration state without backfilling")
+	dryRun := fs.Bool("dry-run", false, "preflight: execute the backfill UPDATE inside a transaction and ROLLBACK, reporting rows-that-would-be-updated and wall-clock so operators can measure against the 6s hot-path INSERT budget before committing live. Mutually exclusive with --check.")
+	format := fs.String("format", "text", "output format when --check is set: text|json")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *check && *dryRun {
+		fmt.Fprintln(stderr, "--check and --dry-run are mutually exclusive")
+		return 2
+	}
+	if *check {
+		switch *format {
+		case "json", "text", "":
+		default:
+			fmt.Fprintf(stderr, "unknown --format %q (want text|json)\n", *format)
+			return 2
+		}
+	}
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "config: %v\n", err)
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	if *check {
+		store, err := requestlog.OpenStoreReadOnly(cfg.Storage.DBPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "open request_log (ro): %v\n", err)
+			return 1
+		}
+		defer store.Close()
+		status, err := store.AttemptNState(ctx)
+		if err != nil {
+			fmt.Fprintf(stderr, "AttemptNState: %v\n", err)
+			return 1
+		}
+		switch *format {
+		case "json":
+			enc := json.NewEncoder(stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(status); err != nil {
+				fmt.Fprintf(stderr, "encode json: %v\n", err)
+				return 1
+			}
+		case "text", "":
+			fmt.Fprintf(stdout, "migration_state: %s\n  null_count: %d\n  total_count: %d\n",
+				status.MigrationState, status.NullCount, status.TotalCount)
+		}
+		return 0
+	}
+
+	store, err := requestlog.OpenStore(cfg.Storage.DBPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "open request_log: %v\n", err)
+		return 1
+	}
+	defer store.Close()
+
+	if *dryRun {
+		started := time.Now()
+		wouldUpdate, err := store.BackfillAttemptNDryRun(ctx)
+		if err != nil {
+			fmt.Fprintf(stderr, "BackfillAttemptNDryRun: %v\n", err)
+			return 1
+		}
+		elapsed := time.Since(started).Round(time.Millisecond)
+		fmt.Fprintf(stdout, "backfill-attempt-n dry-run ok (would_update=%d, elapsed=%s)\n",
+			wouldUpdate, elapsed)
+		// Helper guidance for the operator: a healthy live run requires
+		// elapsed << the 6s hot-path INSERT timeout.
+		if elapsed > 4*time.Second {
+			fmt.Fprintf(stdout, "WARNING: dry-run elapsed %s approaches the 6s hot-path INSERT timeout; consider running in a maintenance window\n", elapsed)
+		}
+		return 0
+	}
+
+	started := time.Now()
+	updated, err := store.BackfillAttemptN(ctx)
+	if err != nil {
+		fmt.Fprintf(stderr, "BackfillAttemptN: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "backfill-attempt-n ok (updated=%d, %s)\n",
+		updated, time.Since(started).Round(time.Millisecond))
+	return 0
+}
+
+// Compile-time check that sql.NullInt64 stays as expected.
+var _ sql.NullInt64

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -78,6 +78,8 @@ func main() {
 			os.Exit(runVisibility(os.Args[2:]))
 		case "migrate-indexes":
 			os.Exit(runMigrateIndexes(os.Args[2:]))
+		case "backfill-attempt-n":
+			os.Exit(runBackfillAttemptN(os.Args[2:]))
 		}
 		// Round-1 CODE H1 fix: a non-flag first positional that
 		// is NEITHER a known daemon flag NOR a known CLI verb is
@@ -94,6 +96,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "  coordinator partner-keys <issue|revoke|list> [flags]")
 			fmt.Fprintln(os.Stderr, "  coordinator visibility revert --id <pid> --reason TEXT")
 			fmt.Fprintln(os.Stderr, "  coordinator migrate-indexes --config <path>  (one-shot operator migration)")
+			fmt.Fprintln(os.Stderr, "  coordinator backfill-attempt-n --config <path>  (one-shot attempt_n backfill)")
 			os.Exit(2)
 		}
 	}

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -313,7 +313,10 @@ func (h *handler) buyerEquivalentCredits(ctx context.Context, from, to time.Time
 	// preserving pre-v1.5.0 behavior.
 	rows, err := h.store.db.QueryContext(ctx, `
 SELECT rl.request_id, rl.ts_utc, rl.model, rl.prompt_tokens, rl.completion_tokens, rl.status, rl.error_code,
-       COALESCE((
+       -- SPEC-002 v1.5.2 / SPEC-005 v0.3.3 (issue #168): prefer
+       -- persisted rl.attempt_n when non-NULL; fall back to v0.3.1
+       -- id-ASC derivation for legacy NULL rows during rollout.
+       COALESCE(rl.attempt_n, (
          SELECT COUNT(*) - 1 FROM request_log prior
           WHERE prior.account_id IS rl.account_id
             AND prior.request_id = rl.request_id

--- a/phase4-coordinator/internal/billing/hotpath.go
+++ b/phase4-coordinator/internal/billing/hotpath.go
@@ -113,7 +113,18 @@ func (s *Store) WriteHotPath(ctx context.Context, reqLogStore *requestlog.Store,
 	if in.FaultFlag == "" {
 		in.FaultFlag = FaultNone
 	}
-	if in.AttemptN > 1 || (in.AttemptN == 1 && reqRow.Retried == 0) {
+	// SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168) quarantine rule:
+	// with persisted monotonic attempt_n, row 3+ (attempt_n >= 2) is
+	// credited normally — the v0.3.1 "row 3+ MUST quarantine until
+	// SPEC-002 gains monotonic attempt_n" rule is now satisfied. The
+	// remaining quarantine class is attempt_n==1 with retried==0:
+	// legitimate-retry-without-explicit-marker that cannot be safely
+	// distinguished from a buggy duplicate INSERT. This narrowing is
+	// safe in the hot path because reqRow.AttemptN here is the value
+	// just persisted by InsertExec (v1.5.2 always writes a non-NULL
+	// value); the in.AttemptN was already aligned to the persisted
+	// value by the post-INSERT COUNT-1 derivation above.
+	if in.AttemptN == 1 && reqRow.Retried == 0 {
 		result := ComputeCredits(
 			in.PromptTokens,
 			in.CompletionTokens,

--- a/phase4-coordinator/internal/billing/recovery.go
+++ b/phase4-coordinator/internal/billing/recovery.go
@@ -79,7 +79,12 @@ UPDATE ledger_request_credits
           AND lpis.attempt_n = ledger_request_credits.attempt_n
           AND lpis.provider_id = ledger_request_credits.provider_id
         WHERE rl.request_id = ledger_request_credits.request_id
-          AND COALESCE((
+          -- SPEC-002 v1.5.2 / SPEC-005 v0.3.3 (issue #168): prefer
+          -- the persisted monotonic rl.attempt_n exact match when
+          -- non-NULL; fall back to the v0.3.1 id-ASC derivation for
+          -- legacy NULL rows during the rollout window. Both paths
+          -- compute identical ordinals.
+          AND COALESCE(rl.attempt_n, (
               SELECT COUNT(*) - 1 FROM request_log prior
                WHERE prior.account_id IS rl.account_id
                  AND prior.request_id = rl.request_id
@@ -95,17 +100,16 @@ SELECT rl.id, rl.ts_utc, rl.request_id, rl.model, rl.provider_assigned_id,
        rl.prompt_tokens, rl.completion_tokens, rl.estimated_completion_tokens,
        rl.status, rl.stream, rl.error_code,
        rl.retried,
-       COALESCE((
+       -- SPEC-002 v1.5.2 / SPEC-005 v0.3.3 (issue #168): prefer
+       -- persisted rl.attempt_n when non-NULL; fall back to the
+       -- v0.3.1 id-ASC derivation for legacy NULL rows during the
+       -- rollout window. Both paths compute identical ordinals.
+       COALESCE(rl.attempt_n, (
          SELECT COUNT(*) - 1 FROM request_log prior
           WHERE prior.account_id IS rl.account_id
             AND prior.request_id = rl.request_id
             AND prior.id <= rl.id
-       ), 0) AS attempt_n,
-       COALESCE((
-         SELECT COUNT(*) FROM request_log same
-          WHERE same.account_id IS rl.account_id
-            AND same.request_id = rl.request_id
-       ), 0) AS same_request_count
+       ), 0) AS attempt_n
   FROM request_log rl
  WHERE rl.ts_utc >= ? AND rl.ts_utc < ?
    AND rl.provider_assigned_id IS NOT NULL
@@ -125,8 +129,8 @@ SELECT rl.id, rl.ts_utc, rl.request_id, rl.model, rl.provider_assigned_id,
 		var tsText, requestID, model, assignedID string
 		var errorCode sql.NullString
 		var prompt, completion, estimated sql.NullInt64
-		var status, stream, retried, attemptN, sameRequestCount int
-		if err := rows.Scan(&rlID, &tsText, &requestID, &model, &assignedID, &prompt, &completion, &estimated, &status, &stream, &errorCode, &retried, &attemptN, &sameRequestCount); err != nil {
+		var status, stream, retried, attemptN int
+		if err := rows.Scan(&rlID, &tsText, &requestID, &model, &assignedID, &prompt, &completion, &estimated, &status, &stream, &errorCode, &retried, &attemptN); err != nil {
 			return err
 		}
 		scanned++
@@ -154,7 +158,16 @@ SELECT rl.id, rl.ts_utc, rl.request_id, rl.model, rl.provider_assigned_id,
 			quarantined += affected
 			continue
 		}
-		ambiguousAttempt := attemptN > 1 || (attemptN == 1 && retried == 0) || sameRequestCount > 2
+		// SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168) quarantine
+		// rule: with persisted monotonic attempt_n (or its byte-
+		// identical id-ASC fallback for legacy NULL rows), row 3+
+		// receives a stable distinct ordinal and is credited normally.
+		// The v0.3.1 "attemptN > 1 || sameRequestCount > 2" trigger is
+		// removed. The only remaining quarantine class is
+		// attempt_n == 1 with retried == 0 — legitimate-retry-
+		// without-explicit-marker that cannot be safely
+		// distinguished from a buggy duplicate INSERT.
+		ambiguousAttempt := attemptN == 1 && retried == 0
 		var providerID string
 		err = tx.QueryRowContext(ctx, `
 SELECT provider_id FROM ledger_provider_identity_snapshots
@@ -230,26 +243,14 @@ SELECT provider_id FROM ledger_provider_identity_snapshots
 			ProviderShareBps:    share,
 		}
 		result := ComputeCredits(pp, cp, ep, usageFor(errorCode.String, ep), FaultNone, input.RateEntry, multiplier, share)
-		if attemptN > 1 {
-			affected, err := quarantineExistingLedgerForRequestAttemptTx(ctx, tx, requestID, attemptN, assignedID, "ambiguous_attempt_n", now)
-			if err != nil {
-				return err
-			}
-			if affected == 0 {
-				exists, err := ledgerRowExistsForRequestAttemptTx(ctx, tx, requestID, attemptN, assignedID)
-				if err != nil {
-					return err
-				}
-				if !exists {
-					if err := insertQuarantineTx(ctx, tx, requestID, attemptN, providerID, assignedID, ts, model, status, stream == 1, pp, cp, errorCode.String, in.Source, "ambiguous_attempt_n", now); err != nil {
-						return err
-					}
-					quarantined++
-				}
-			}
-			quarantined += affected
-			continue
-		}
+		// SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168): the v0.3.1
+		// "attemptN > 1 unconditionally quarantines" branch is removed.
+		// With persisted monotonic attempt_n (or its byte-identical
+		// id-ASC fallback for legacy NULL rows), row 3+ has a stable
+		// distinct ordinal and is credited normally. The ambiguousAttempt
+		// flag above already captures the remaining quarantine class
+		// (attempt_n==1 with retried==0) and was applied earlier in the
+		// branch that resolved provider identity.
 		actualGross, expectedGross, exists, mismatch, err := reconcileExistingCreditTx(ctx, tx, input, result, now)
 		if err != nil {
 			return err

--- a/phase4-coordinator/internal/billing/store_test.go
+++ b/phase4-coordinator/internal/billing/store_test.go
@@ -228,8 +228,8 @@ func TestWriteHotPath_DuplicateRequestIDWithoutRetryQuarantinesAttempt(t *testin
 // the same coordinator-internal request_id ever recur across rows
 // belonging to different accounts (UUID v4 collision, retry-loop
 // bug, future schema change), RecoverLedger MUST derive attempt_n
-// and same_request_count by scoping (account_id, request_id), not
-// request_id alone. Note that internal request_id is server-minted
+// by scoping (account_id, request_id), not request_id alone.
+// Note that internal request_id is server-minted
 // (uuid.NewString() per buyer request) — this is NOT the actual
 // #211 buyer-supplied collision class on external_request_id; it's
 // defense-in-depth against any future internal-id recurrence.
@@ -360,16 +360,26 @@ func TestWriteHotPath_AttemptOneWithoutRetriedEvidenceIsQuarantined(t *testing.T
 	}
 }
 
-func TestWriteHotPath_ThirdDerivedAttemptIsAlwaysQuarantined(t *testing.T) {
+// TestWriteHotPath_ThirdDerivedAttemptIsCreditedUnderMonotonicAttemptN
+// pins SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168): with persisted
+// monotonic attempt_n, row 3+ is no longer quarantined. The prior
+// v0.3.1 "row 3+ MUST quarantine until SPEC-002 gains monotonic
+// attempt_n" rule is satisfied by the persisted column. Test was
+// previously TestWriteHotPath_ThirdDerivedAttemptIsAlwaysQuarantined.
+func TestWriteHotPath_ThirdDerivedAttemptIsCreditedUnderMonotonicAttemptN(t *testing.T) {
 	reqStore, store := newRequestAndBillingStores(t)
 	input, row := testHotPathInput(t, store)
 	row.RequestID = "third-attempt"
 	input.RequestID = row.RequestID
+	// Row 1 receives attempt_n=0, retried=0 — credited.
 	if err := store.WriteHotPath(context.Background(), reqStore, row, input); err != nil {
 		t.Fatal(err)
 	}
+	// Row 2 receives attempt_n=1; carry retried=1 so it doesn't trip
+	// the legitimate-retry-without-marker quarantine class.
 	input2 := input
 	row2 := row
+	row2.Retried = 1
 	input2.AttemptN = 1
 	input2.ProviderID = "provider-b"
 	input2.ProviderAssignedID = "assigned-b"
@@ -377,8 +387,11 @@ func TestWriteHotPath_ThirdDerivedAttemptIsAlwaysQuarantined(t *testing.T) {
 	if err := store.WriteHotPath(context.Background(), reqStore, row2, input2); err != nil {
 		t.Fatal(err)
 	}
+	// Row 3 receives attempt_n=2. Under v0.3.3 this is credited
+	// normally (was quarantined under v0.3.1).
 	input3 := input
 	row3 := row
+	row3.Retried = 1
 	input3.AttemptN = 2
 	input3.ProviderID = "provider-c"
 	input3.ProviderAssignedID = "assigned-c"
@@ -386,11 +399,13 @@ func TestWriteHotPath_ThirdDerivedAttemptIsAlwaysQuarantined(t *testing.T) {
 	if err := store.WriteHotPath(context.Background(), reqStore, row3, input3); err != nil {
 		t.Fatal(err)
 	}
-	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND attempt_n = 2 AND quarantined = 1 AND quarantine_reason = 'ambiguous_attempt_n'`, row.RequestID); got != 1 {
-		t.Fatalf("third attempt quarantine rows=%d want 1", got)
+	// v0.3.3 contract: third attempt has NO quarantine row and HAS a
+	// non-quarantined credit row.
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND attempt_n = 2 AND quarantined = 1`, row.RequestID); got != 0 {
+		t.Fatalf("third attempt quarantine rows=%d want 0 (v0.3.3 credits row 3+)", got)
 	}
-	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_operator_credits WHERE request_id = ? AND attempt_n = 2`, row.RequestID); got != 0 {
-		t.Fatalf("operator rows for third attempt=%d want 0", got)
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND attempt_n = 2 AND quarantined = 0`, row.RequestID); got != 1 {
+		t.Fatalf("third attempt credited rows=%d want 1", got)
 	}
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_provider_identity_snapshots WHERE request_id = ? AND attempt_n = 2 AND provider_assigned_id = 'assigned-c'`, row.RequestID); got != 1 {
 		t.Fatalf("third attempt identity snapshots=%d want 1", got)
@@ -659,45 +674,59 @@ func TestRecoverLedger_QuarantinesExistingFailoverAttemptWithoutRetriedFlag(t *t
 	}
 }
 
-func TestRecoverLedger_QuarantinesExistingThirdAttempt(t *testing.T) {
+// TestRecoverLedger_CreditsExistingThirdAttemptUnderMonotonicAttemptN
+// pins SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168) on the recovery
+// path: row 3+ with persisted monotonic attempt_n is reconciled normally
+// (not quarantined). Test was previously
+// TestRecoverLedger_QuarantinesExistingThirdAttempt under the v0.3.1
+// "row 3+ MUST quarantine" rule. Seeding uses WriteHotPath so the
+// pre-existing credits are byte-correct under the active rate card,
+// letting RecoverLedger's reconciliation pass without a
+// credit-mismatch quarantine.
+func TestRecoverLedger_CreditsExistingThirdAttemptUnderMonotonicAttemptN(t *testing.T) {
 	reqStore, store := newRequestAndBillingStores(t)
-	cfg := testRewards()
-	if _, err := store.InsertConfigSnapshot(context.Background(), cfg, time.Unix(100, 0).UTC()); err != nil {
+	input, row := testHotPathInput(t, store)
+	row.RequestID = "recover-third"
+	input.RequestID = row.RequestID
+	// First attempt (attempt_n=0).
+	if err := store.WriteHotPath(context.Background(), reqStore, row, input); err != nil {
 		t.Fatal(err)
 	}
-	ts := time.Unix(200, 0).UTC()
-	prompt, completion := int64(1000), int64(1000)
-	for _, assignedID := range []string{"assigned-a", "assigned-b", "assigned-c"} {
-		if err := reqStore.Insert(context.Background(), requestlog.Row{
-			TSUtc: ts, RequestID: "recover-third", Model: "model-a", ProviderAssignedID: assignedID,
-			PromptTokens: &prompt, CompletionTokens: &completion, Status: 200, BuyerIP: "127.0.0.1",
-		}); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if _, err := store.db.Exec(`INSERT INTO ledger_provider_identity_snapshots (request_id, attempt_n, provider_assigned_id, provider_id, resolved_from, created_at_utc) VALUES ('recover-third', 2, 'assigned-c', 'provider-c', 'pool_entry', ?)`, ts.Format(time.RFC3339Nano)); err != nil {
+	// Second attempt (attempt_n=1, retried=1 to avoid the legitimate-
+	// retry-without-marker quarantine class).
+	input2 := input
+	row2 := row
+	row2.Retried = 1
+	input2.AttemptN = 1
+	input2.ProviderID = "provider-b"
+	input2.ProviderAssignedID = "assigned-b"
+	row2.ProviderAssignedID = "assigned-b"
+	if err := store.WriteHotPath(context.Background(), reqStore, row2, input2); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.db.Exec(`
-INSERT INTO ledger_request_credits (
-    request_id, attempt_n, provider_id, provider_assigned_id, ts_utc, model,
-    status, stream, usage_source, prompt_rate_per_mtok, completion_rate_per_mtok,
-    global_multiplier_ppm, gross_credits, provider_share_bps, provider_credits,
-    fault_flag, recovery_source, created_at_utc
-) VALUES ('recover-third', 2, 'provider-c', 'assigned-c', ?, 'model-a', 200, 0,
-          'provider_reported', 1, 1, 1000000, 500, 9000, 500, 'none', 'hot_path', ?)`,
-		ts.Format(time.RFC3339Nano), ts.Format(time.RFC3339Nano)); err != nil {
+	// Third attempt (attempt_n=2). Under v0.3.3 this is credited
+	// normally; under v0.3.1 it would have been quarantined.
+	input3 := input
+	row3 := row
+	row3.Retried = 1
+	input3.AttemptN = 2
+	input3.ProviderID = "provider-c"
+	input3.ProviderAssignedID = "assigned-c"
+	row3.ProviderAssignedID = "assigned-c"
+	if err := store.WriteHotPath(context.Background(), reqStore, row3, input3); err != nil {
 		t.Fatal(err)
 	}
-	in := RecoverInput{ScanFrom: ts.Add(-time.Minute), ScanTo: ts.Add(time.Minute), Source: "nightly_reconcile"}
+	// Now drive recovery over the same window.
+	in := RecoverInput{ScanFrom: row.TSUtc.Add(-time.Minute), ScanTo: row.TSUtc.Add(time.Minute), Source: "nightly_reconcile"}
 	if err := store.RecoverLedger(context.Background(), in); err != nil {
 		t.Fatal(err)
 	}
-	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = 'recover-third' AND attempt_n = 2 AND quarantined = 1 AND quarantine_reason = 'ambiguous_attempt_n'`); got != 1 {
-		t.Fatalf("third attempt quarantine rows=%d want 1", got)
+	// v0.3.3 contract: row 3+ is NOT quarantined post-recovery.
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = 'recover-third' AND attempt_n = 2 AND quarantined = 1`); got != 0 {
+		t.Fatalf("third attempt quarantine rows=%d want 0 (v0.3.3 credits row 3+)", got)
 	}
-	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = 'recover-third' AND attempt_n = 2`); got != 1 {
-		t.Fatalf("third attempt rows=%d want 1", got)
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = 'recover-third' AND attempt_n = 2 AND quarantined = 0`); got != 1 {
+		t.Fatalf("third attempt credited rows=%d want 1", got)
 	}
 }
 

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -22,6 +22,7 @@ var ErrIdempotencyConflict = errors.New("idempotency key body hash mismatch")
 
 type execer interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 type Row struct {
@@ -49,9 +50,9 @@ type Row struct {
 	// across two accounts cannot be attributed back to the correct
 	// gateway account (issue #211, follow-up to #196). Empty for
 	// direct legacy buyer calls without the header.
-	AccountID         string
-	Model             string
-	ProviderAssignedID string
+	AccountID           string
+	Model               string
+	ProviderAssignedID  string
 	PromptTokens        *int64
 	CompletionTokens    *int64
 	EstimatedCompTokens *int64
@@ -65,6 +66,19 @@ type Row struct {
 	PrefHeader          string
 	ProviderHeader      string
 	Retried             int
+	// AttemptN is the zero-based monotonic attempt ordinal within the
+	// same (AccountID, RequestID) group under SQLite IS semantics
+	// (SPEC-002 v1.5.2 / issue #168). Populated at INSERT time by the
+	// writer; populated value is N where N is the count of rows
+	// already in the group at insert time. Persisted as
+	// request_log.attempt_n. nil on legacy pre-v1.5.2 rows.
+	//
+	// Callers MUST leave AttemptN nil on the input Row; InsertExec
+	// computes the value transactionally and writes it. Reading code
+	// (billing hot path / recovery / admin reconcile) reads it back
+	// via SELECT and falls back to the legacy id-ASC derivation when
+	// the persisted value is NULL.
+	AttemptN *int
 }
 
 // OpenStoreReadOnly opens the request-log DB without running ALTER
@@ -168,7 +182,8 @@ CREATE TABLE IF NOT EXISTS request_log (
     error_code           TEXT    NULL,
     pref_header          TEXT    NULL,
     provider_header      TEXT    NULL,
-    retried              INTEGER NOT NULL DEFAULT 0
+    retried              INTEGER NOT NULL DEFAULT 0,
+    attempt_n            INTEGER NULL
 );
 CREATE INDEX IF NOT EXISTS idx_request_log_ts_utc
     ON request_log(ts_utc);
@@ -202,7 +217,25 @@ CREATE INDEX IF NOT EXISTS idx_request_idempotency_request
 }
 
 func (s *Store) Insert(ctx context.Context, row Row) error {
-	return insert(ctx, s.db, row)
+	// SPEC-002 v1.5.2 / issue #168 / R1 code CRITICAL fix: the
+	// monotonic attempt_n derivation reads COUNT(*) and then INSERTs.
+	// SetMaxOpenConns(1) caps the POOL at one open connection but does
+	// NOT keep two adjacent operations on the same *sql.DB on the same
+	// underlying connection — `database/sql` is free to release and
+	// re-acquire between calls. Without explicit pinning, two goroutines
+	// could each see count=N, then each INSERT attempt_n=N, producing
+	// a duplicate ordinal in the same (account_id, request_id) group.
+	//
+	// Pinning a single *sql.Conn around the COUNT+INSERT pair gives
+	// the same-connection guarantee that hotpath's BEGIN IMMEDIATE
+	// path has by construction. Under SetMaxOpenConns(1) the pool
+	// will block other writers until Close() releases.
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return insert(ctx, conn, row)
 }
 
 func (s *Store) ReserveIdempotencyKey(ctx context.Context, key, bodySHA256, requestID string, now time.Time) (string, bool, error) {
@@ -338,9 +371,17 @@ func (s *Store) InsertTx(ctx context.Context, tx *sql.Tx, row Row) error {
 	return insert(ctx, tx, row)
 }
 
-func (s *Store) InsertExec(ctx context.Context, db interface {
+// InsertQuerier is the minimum interface insert() needs: it must support
+// both ExecContext (for the INSERT) and QueryRowContext (for the
+// SPEC-002 v1.5.2 attempt_n monotonic derivation, run in the same
+// connection / transaction as the INSERT). *sql.DB, *sql.Conn, and
+// *sql.Tx all satisfy it.
+type InsertQuerier interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
-}, row Row) error {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (s *Store) InsertExec(ctx context.Context, db InsertQuerier, row Row) error {
 	if db == nil {
 		return fmt.Errorf("db is required")
 	}
@@ -353,6 +394,39 @@ func insert(ctx context.Context, db execer, row Row) error {
 		if *row.PromptTokens >= 0 && *row.CompletionTokens >= 0 && *row.PromptTokens <= math.MaxInt64-*row.CompletionTokens {
 			totalTokens = sql.NullInt64{Int64: *row.PromptTokens + *row.CompletionTokens, Valid: true}
 		}
+	}
+	// SPEC-002 v1.5.2 / issue #168: monotonic attempt_n derivation at
+	// INSERT time. Compute the count of rows already in the same
+	// (account_id, request_id) group under SQLite IS semantics; the
+	// new row receives that count as its attempt_n. Because the
+	// request-log pool is capped at one writer connection
+	// (SetMaxOpenConns(1), issue #21 / ARCH-3), running the COUNT and
+	// INSERT through the same `db` (which is either *sql.DB, *sql.Conn,
+	// or *sql.Tx) is race-free in the sense that no other writer can
+	// interleave a competing INSERT. This is the same arithmetic the
+	// v0.3.1 read-time fallback derivation produces, persisted at
+	// write time.
+	//
+	// Callers SHOULD leave row.AttemptN nil to invoke this derivation.
+	// If a caller supplies a non-nil row.AttemptN, the supplied value is
+	// used verbatim and the derivation is skipped — this is the path
+	// the backfill subcommand takes (it knows the ordinal from id-ASC
+	// fallback and writes it directly).
+	attemptN := row.AttemptN
+	if attemptN == nil {
+		var accountIDArg any
+		if row.AccountID != "" {
+			accountIDArg = row.AccountID
+		}
+		var existing int
+		err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM request_log WHERE account_id IS ? AND request_id = ?`,
+			accountIDArg, row.RequestID,
+		).Scan(&existing)
+		if err != nil {
+			return err
+		}
+		attemptN = &existing
 	}
 	_, err := db.ExecContext(ctx, `
 INSERT INTO request_log (
@@ -375,8 +449,9 @@ INSERT INTO request_log (
     error_code,
     pref_header,
     provider_header,
-    retried
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    retried,
+    attempt_n
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		row.TSUtc.UTC().Format(time.RFC3339Nano),
 		row.RequestID,
 		nullString(row.ExternalRequestID),
@@ -397,6 +472,7 @@ INSERT INTO request_log (
 		nullString(row.PrefHeader),
 		nullString(row.ProviderHeader),
 		row.Retried,
+		*attemptN,
 	)
 	return err
 }
@@ -437,6 +513,14 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 		// X-Request-ID across two accounts cannot be attributed back
 		// to the correct gateway account.
 		{name: "account_id", sql: `ALTER TABLE request_log ADD COLUMN account_id TEXT NULL`},
+		// SPEC-002 v1.5.2 / issue #168: monotonic attempt ordinal
+		// populated at INSERT time. Per-row property, no join-key
+		// index — no migrate-indexes counterpart. Legacy rows scan
+		// as NULL until the operator runs `coordinator
+		// backfill-attempt-n`; SPEC-005 v0.3.3 read-side falls
+		// back to id-ASC derivation for NULL rows during the
+		// rollout window.
+		{name: "attempt_n", sql: `ALTER TABLE request_log ADD COLUMN attempt_n INTEGER NULL`},
 	} {
 		if cols[migration.name] {
 			continue
@@ -455,12 +539,12 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 //     index has not been built yet ("rollout incomplete").
 //   - indexed: column present AND index present.
 type MigrationKeyState struct {
-	Key            string `json:"key"`
+	Key            string   `json:"key"`
 	ColumnNames    []string `json:"column_names"`
-	ColumnsPresent bool   `json:"columns_present"`
-	IndexName      string `json:"index_name"`
-	IndexPresent   bool   `json:"index_present"`
-	State          string `json:"state"`
+	ColumnsPresent bool     `json:"columns_present"`
+	IndexName      string   `json:"index_name"`
+	IndexPresent   bool     `json:"index_present"`
+	State          string   `json:"state"`
 }
 
 // MigrationStatus is the aggregate migration state across every
@@ -564,6 +648,153 @@ func (s *Store) MigrationState(ctx context.Context) (MigrationStatus, error) {
 		}
 	}
 	return out, nil
+}
+
+// AttemptNStatus reports the per-column migration state of
+// request_log.attempt_n (SPEC-002 v1.5.2 / issue #168). Parallel to
+// the per-key MigrationState but PER-COLUMN — attempt_n has no
+// composite index, only a row-population dimension.
+//
+// States:
+//   - legacy: column absent (pre-v1.5.2 schema)
+//   - populating: column present, some rows still carry NULL (pre-
+//     v1.5.2 rows awaiting backfill, OR a rollback window)
+//   - populated: column present, zero NULL rows
+type AttemptNStatus struct {
+	MigrationState string `json:"migration_state"`
+	NullCount      int64  `json:"null_count"`
+	TotalCount     int64  `json:"total_count"`
+}
+
+// AttemptNState introspects the schema and row distribution to report
+// the current state without mutating. Safe to call on a read-only
+// store.
+func (s *Store) AttemptNState(ctx context.Context) (AttemptNStatus, error) {
+	cols, err := s.columns(ctx)
+	if err != nil {
+		return AttemptNStatus{}, err
+	}
+	if !cols["attempt_n"] {
+		return AttemptNStatus{MigrationState: "legacy"}, nil
+	}
+	var total, nullCount int64
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM request_log`).Scan(&total); err != nil {
+		return AttemptNStatus{}, err
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM request_log WHERE attempt_n IS NULL`).Scan(&nullCount); err != nil {
+		return AttemptNStatus{}, err
+	}
+	state := "populated"
+	if nullCount > 0 {
+		state = "populating"
+	}
+	return AttemptNStatus{
+		MigrationState: state,
+		NullCount:      nullCount,
+		TotalCount:     total,
+	}, nil
+}
+
+// BackfillAttemptN walks legacy NULL-attempt_n rows in id-ASC order
+// within each (account_id, request_id) group under SQLite IS
+// semantics and assigns attempt_n monotonically. Idempotent: rows
+// with non-NULL attempt_n are skipped.
+//
+// Implementation: a single UPDATE that uses a window function over
+// existing legacy rows. The arithmetic is byte-identical to the
+// v0.3.1 read-time fallback derivation (COUNT(*) - 1 over rows with
+// id <= self in the same group, ordered by id ASC).
+//
+// Intentionally NOT invoked from the daemon path: SQLite has no
+// concurrent UPDATE, and the request-log store caps the pool at one
+// writer connection (issue #21 / ARCH-3), so running this inside the
+// daemon would starve the 6s-timeout INSERT hot path.
+func (s *Store) BackfillAttemptN(ctx context.Context) (int64, error) {
+	// Verify the column exists before we update. ensureColumns runs
+	// at OpenStore time so this should always be true; the explicit
+	// check converts a confusing SQL error into an actionable one for
+	// operators who somehow bypass ensureColumns.
+	cols, err := s.columns(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if !cols["attempt_n"] {
+		return 0, fmt.Errorf("request_log.attempt_n column absent; daemon migration has not run")
+	}
+	// SQLite ROW_NUMBER() OVER PARTITION BY assigns the in-group
+	// ordinal. We compute it over ALL request_log rows so the value
+	// matches what the v0.3.1 fallback would produce (which counts
+	// ALL rows in the group, including any future v1.5.2-written
+	// rows that already have non-NULL attempt_n). Then we filter the
+	// UPDATE target to attempt_n IS NULL so steady-state v1.5.2 rows
+	// are left untouched.
+	res, err := s.db.ExecContext(ctx, `
+WITH ranked AS (
+  SELECT id,
+         (ROW_NUMBER() OVER (
+            PARTITION BY account_id, request_id
+            ORDER BY id ASC
+          ) - 1) AS new_attempt_n
+    FROM request_log
+)
+UPDATE request_log
+   SET attempt_n = (SELECT new_attempt_n FROM ranked WHERE ranked.id = request_log.id)
+ WHERE attempt_n IS NULL`)
+	if err != nil {
+		return 0, err
+	}
+	updated, _ := res.RowsAffected()
+	return updated, nil
+}
+
+// BackfillAttemptNDryRun is the preflight sibling of BackfillAttemptN.
+// It runs the same UPDATE inside a transaction, captures the
+// rows-that-would-be-affected count, then ROLLBACKs so no rows are
+// mutated. SPEC-002 v1.5.2 R3 security MEDIUM (issue #168): gives the
+// operator a concrete wall-clock measurement against the 6s hot-path
+// INSERT timeout before they commit to a live backfill.
+//
+// Like BackfillAttemptN, this acquires the writer connection for the
+// duration of the UPDATE — so a dry-run still blocks hot-path INSERTs
+// for the same duration as a live run. The benefit is observability:
+// operators see exactly how long the UPDATE takes against their
+// production corpus without persisting the result.
+func (s *Store) BackfillAttemptNDryRun(ctx context.Context) (int64, error) {
+	cols, err := s.columns(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if !cols["attempt_n"] {
+		return 0, fmt.Errorf("request_log.attempt_n column absent; daemon migration has not run")
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return 0, err
+	}
+	defer func() {
+		_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+	}()
+	res, err := conn.ExecContext(ctx, `
+WITH ranked AS (
+  SELECT id,
+         (ROW_NUMBER() OVER (
+            PARTITION BY account_id, request_id
+            ORDER BY id ASC
+          ) - 1) AS new_attempt_n
+    FROM request_log
+)
+UPDATE request_log
+   SET attempt_n = (SELECT new_attempt_n FROM ranked WHERE ranked.id = request_log.id)
+ WHERE attempt_n IS NULL`)
+	if err != nil {
+		return 0, err
+	}
+	updated, _ := res.RowsAffected()
+	return updated, nil
 }
 
 // MigrateIndexes builds the request_log indexes whose underlying

--- a/phase4-coordinator/internal/requestlog/store_test.go
+++ b/phase4-coordinator/internal/requestlog/store_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -746,6 +747,317 @@ func TestMigrationStateReportsPerKeyStatesAndAggregate(t *testing.T) {
 	if !sawLegacy || !sawUnindexed {
 		t.Fatalf("expected one legacy + one unindexed key; got %#v", status.Keys)
 	}
+}
+
+// TestInsertPopulatesMonotonicAttemptN pins SPEC-002 v1.5.2 / issue
+// #168: the writer MUST assign attempt_n monotonically within each
+// (account_id, request_id) group at INSERT time, race-free under the
+// SetMaxOpenConns(1) discipline.
+func TestInsertPopulatesMonotonicAttemptN(t *testing.T) {
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	ts := time.Now().UTC()
+
+	for i := 0; i < 3; i++ {
+		if err := store.Insert(ctx, Row{
+			TSUtc:     ts.Add(time.Duration(i) * time.Second),
+			RequestID: "req-acct-A",
+			AccountID: "acct-A",
+			Model:     "model-a",
+			Status:    200,
+			BuyerIP:   "127.0.0.1",
+		}); err != nil {
+			t.Fatalf("insert row %d: %v", i, err)
+		}
+	}
+	rows, err := store.db.QueryContext(ctx, `SELECT attempt_n FROM request_log WHERE request_id='req-acct-A' AND account_id='acct-A' ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	var got []int
+	for rows.Next() {
+		var n sql.NullInt64
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !n.Valid {
+			t.Fatalf("attempt_n is NULL on a v1.5.2 write; want monotonic int")
+		}
+		got = append(got, int(n.Int64))
+	}
+	if want := []int{0, 1, 2}; !slicesEqualInt(got, want) {
+		t.Fatalf("attempt_n sequence = %v, want %v", got, want)
+	}
+
+	if err := store.Insert(ctx, Row{
+		TSUtc:     ts.Add(10 * time.Second),
+		RequestID: "req-acct-B",
+		AccountID: "acct-B",
+		Model:     "model-a",
+		Status:    200,
+		BuyerIP:   "127.0.0.1",
+	}); err != nil {
+		t.Fatalf("insert acct-B: %v", err)
+	}
+	var bN sql.NullInt64
+	if err := store.db.QueryRowContext(ctx, `SELECT attempt_n FROM request_log WHERE request_id='req-acct-B' AND account_id='acct-B'`).Scan(&bN); err != nil {
+		t.Fatalf("acct-B scan: %v", err)
+	}
+	if !bN.Valid || bN.Int64 != 0 {
+		t.Fatalf("acct-B attempt_n = %v, want 0 (new group)", bN)
+	}
+
+	// Same request_id with EMPTY account_id is a SEPARATE group from
+	// acct-A (the v1.5.0 IS-clustering rule: NULL clusters with NULL
+	// only). attempt_n should start fresh at 0.
+	if err := store.Insert(ctx, Row{
+		TSUtc:     ts.Add(20 * time.Second),
+		RequestID: "req-acct-A",
+		AccountID: "",
+		Model:     "model-a",
+		Status:    200,
+		BuyerIP:   "127.0.0.1",
+	}); err != nil {
+		t.Fatalf("insert NULL-account: %v", err)
+	}
+	var nullN sql.NullInt64
+	if err := store.db.QueryRowContext(ctx, `SELECT attempt_n FROM request_log WHERE request_id='req-acct-A' AND account_id IS NULL`).Scan(&nullN); err != nil {
+		t.Fatalf("NULL-account scan: %v", err)
+	}
+	if !nullN.Valid || nullN.Int64 != 0 {
+		t.Fatalf("NULL-account attempt_n = %v, want 0 (separate group from acct-A)", nullN)
+	}
+}
+
+// TestBackfillAttemptNPopulatesLegacyNullRows pins the v0.3.1 → v0.3.3
+// migration path: legacy rows with NULL attempt_n receive monotonic
+// values byte-identical to the read-time fallback derivation.
+func TestBackfillAttemptNPopulatesLegacyNullRows(t *testing.T) {
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	ts := time.Now().UTC()
+
+	for i := 0; i < 3; i++ {
+		if err := store.Insert(ctx, Row{
+			TSUtc:     ts.Add(time.Duration(i) * time.Second),
+			RequestID: "req-legacy",
+			AccountID: "acct-L",
+			Model:     "model-a",
+			Status:    200,
+			BuyerIP:   "127.0.0.1",
+		}); err != nil {
+			t.Fatalf("insert legacy row %d: %v", i, err)
+		}
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE request_log SET attempt_n = NULL WHERE request_id = 'req-legacy'`); err != nil {
+		t.Fatalf("null out: %v", err)
+	}
+
+	status, err := store.AttemptNState(ctx)
+	if err != nil {
+		t.Fatalf("AttemptNState: %v", err)
+	}
+	if status.MigrationState != "populating" || status.NullCount != 3 {
+		t.Fatalf("pre-backfill state=%+v, want populating with 3 NULL rows", status)
+	}
+
+	updated, err := store.BackfillAttemptN(ctx)
+	if err != nil {
+		t.Fatalf("BackfillAttemptN: %v", err)
+	}
+	if updated != 3 {
+		t.Fatalf("updated=%d, want 3", updated)
+	}
+
+	rows, err := store.db.QueryContext(ctx, `SELECT attempt_n FROM request_log WHERE request_id = 'req-legacy' ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query post-backfill: %v", err)
+	}
+	defer rows.Close()
+	var got []int
+	for rows.Next() {
+		var n sql.NullInt64
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !n.Valid {
+			t.Fatalf("attempt_n still NULL after backfill")
+		}
+		got = append(got, int(n.Int64))
+	}
+	if want := []int{0, 1, 2}; !slicesEqualInt(got, want) {
+		t.Fatalf("backfilled attempt_n = %v, want %v", got, want)
+	}
+
+	status, err = store.AttemptNState(ctx)
+	if err != nil {
+		t.Fatalf("AttemptNState post-backfill: %v", err)
+	}
+	if status.MigrationState != "populated" || status.NullCount != 0 {
+		t.Fatalf("post-backfill state=%+v, want populated/0", status)
+	}
+
+	updated2, err := store.BackfillAttemptN(ctx)
+	if err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if updated2 != 0 {
+		t.Fatalf("second backfill updated=%d, want 0 (idempotent)", updated2)
+	}
+}
+
+// TestBackfillAttemptNHandlesMixedRolloutState pins SPEC-002 v1.5.2
+// behavior under the realistic rollout window: some rows have non-NULL
+// attempt_n (written under v1.5.2), some have NULL (written under
+// v1.5.1 OR during a brief v1.5.2 → v1.5.1 rollback). BackfillAttemptN
+// MUST assign correct monotonic ordinals to the NULL rows so the
+// combined sequence is the canonical id-ASC ordering. R1 code MEDIUM.
+func TestBackfillAttemptNHandlesMixedRolloutState(t *testing.T) {
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	ts := time.Now().UTC()
+
+	// Insert 3 rows; null out only rows 1 and 2 (keep row 0's
+	// persisted attempt_n=0). Simulates "row 0 written under v1.5.2,
+	// then v1.5.1 rollback wrote rows 1+2 with NULL".
+	for i := 0; i < 3; i++ {
+		if err := store.Insert(ctx, Row{
+			TSUtc:     ts.Add(time.Duration(i) * time.Second),
+			RequestID: "req-mixed",
+			AccountID: "acct-M",
+			Model:     "model-a",
+			Status:    200,
+			BuyerIP:   "127.0.0.1",
+		}); err != nil {
+			t.Fatalf("insert row %d: %v", i, err)
+		}
+	}
+	// Null out the last 2 rows to simulate a partial-rollout mix.
+	if _, err := store.db.ExecContext(ctx, `
+UPDATE request_log SET attempt_n = NULL
+ WHERE request_id = 'req-mixed'
+   AND id IN (SELECT id FROM request_log WHERE request_id='req-mixed' ORDER BY id LIMIT 2 OFFSET 1)
+`); err != nil {
+		t.Fatalf("null out: %v", err)
+	}
+
+	updated, err := store.BackfillAttemptN(ctx)
+	if err != nil {
+		t.Fatalf("BackfillAttemptN: %v", err)
+	}
+	if updated != 2 {
+		t.Fatalf("updated=%d, want 2 (only the NULL rows)", updated)
+	}
+
+	// Verify final sequence is [0, 1, 2] — backfilled rows received
+	// ordinals 1 and 2 respectively, preserving the existing row 0=0.
+	rows, err := store.db.QueryContext(ctx, `SELECT attempt_n FROM request_log WHERE request_id = 'req-mixed' ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	var got []int
+	for rows.Next() {
+		var n sql.NullInt64
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !n.Valid {
+			t.Fatalf("row still NULL after mixed-state backfill")
+		}
+		got = append(got, int(n.Int64))
+	}
+	if want := []int{0, 1, 2}; !slicesEqualInt(got, want) {
+		t.Fatalf("post-backfill sequence = %v, want %v", got, want)
+	}
+}
+
+// TestInsertConcurrentSameGroupProducesMonotonicAttemptN proves the
+// R1 code CRITICAL fix: Store.Insert is now race-free when multiple
+// goroutines insert into the same (account_id, request_id) group.
+// Prior to the fix, COUNT and INSERT were two distinct *sql.DB calls
+// that could each acquire a fresh connection from the pool, even
+// under SetMaxOpenConns(1), interleaving such that two goroutines
+// would both see count=0 and both INSERT attempt_n=0. The fix pins
+// a single *sql.Conn around the pair.
+func TestInsertConcurrentSameGroupProducesMonotonicAttemptN(t *testing.T) {
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	ts := time.Now().UTC()
+
+	const N = 16
+	var wg sync.WaitGroup
+	errCh := make(chan error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if err := store.Insert(ctx, Row{
+				TSUtc:     ts.Add(time.Duration(i) * time.Millisecond),
+				RequestID: "req-race",
+				AccountID: "acct-R",
+				Model:     "model-a",
+				Status:    200,
+				BuyerIP:   "127.0.0.1",
+			}); err != nil {
+				errCh <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("concurrent insert: %v", err)
+	}
+
+	// Every row in the group MUST have a distinct attempt_n in the
+	// range [0, N-1]. If the race were present, two rows would share
+	// the same attempt_n.
+	rows, err := store.db.QueryContext(ctx, `SELECT attempt_n FROM request_log WHERE request_id='req-race' ORDER BY attempt_n`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	seen := map[int]bool{}
+	for rows.Next() {
+		var n sql.NullInt64
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !n.Valid {
+			t.Fatalf("attempt_n NULL on concurrent insert")
+		}
+		v := int(n.Int64)
+		if seen[v] {
+			t.Fatalf("duplicate attempt_n=%d under concurrent insert (race not closed)", v)
+		}
+		seen[v] = true
+	}
+	if len(seen) != N {
+		t.Fatalf("got %d distinct attempt_n values; want %d (rows missing)", len(seen), N)
+	}
+	for i := 0; i < N; i++ {
+		if !seen[i] {
+			t.Fatalf("attempt_n=%d missing from concurrent insert results", i)
+		}
+	}
+}
+
+func slicesEqualInt(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // TestOpenStoreCapsPoolAtOneConn pins the SetMaxOpenConns(1) +

--- a/specs/AUDIT_ISS_168_R1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,65 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), ARCHITECT lane, ROUND 1.
+
+## Scope
+
+SPEC-002 v1.5.2 + SPEC-005 v0.3.3 — monotonic `attempt_n` column promotion.
+Closes SPEC-005 §OQ-1.
+
+## What landed
+
+(See code lane prompt for full IMPL surface.)
+
+## Verify
+
+- **SPEC-002 ↔ SPEC-005 consistency**: SPEC-002 v1.5.2 introduces the
+  column and the per-column migration state (`legacy | populating |
+  populated`). SPEC-005 v0.3.3 consumes it via the row-mapping rule.
+  Are the two SPECs internally consistent on the rollout window —
+  specifically the "row 3+ quarantine rule" treatment?
+- **Cross-SPEC dependency graph**: SPEC-005 v0.3.3 now depends on
+  SPEC-002 v1.5.2. Does any other SPEC (SPEC-006, SPEC-007, SPEC-016)
+  need to bump its SPEC-002 dependency, or are they unaffected by the
+  new column (since they don't consume attempt_n directly)?
+- **Migration state vocabulary**: SPEC-002 v1.5.1 introduced
+  `legacy | unindexed | indexed` per-key state. SPEC-002 v1.5.2 adds
+  `legacy | populating | populated` per-column state. Are the two
+  state machines clearly distinct? Is the choice of
+  "populating/populated" vs "unindexed/indexed" justified, or does it
+  invite confusion?
+- **State machine completeness**: the per-column states are derived
+  from `(column_present, null_count)`. Is `(absent, 0)` a possible
+  state? `(present, NULL count)`? Are there edge cases (e.g. column
+  added but daemon never ran, so total=0)?
+- **Quarantine rule migration**: the SPEC text claims that the
+  v0.3.1 row-3+ quarantine is satisfied by v1.5.2. But during the
+  rollout window (populating state), some rows still trigger the
+  fallback derivation and could quarantine. Is this transition
+  cleanly documented?
+- **Backfill subcommand vs migrate-indexes**: both follow the
+  operator-driven, one-shot, idempotent pattern. Should they share
+  a common CLI structure (e.g. a `coordinator migrate` umbrella
+  with subcommands)? Out-of-scope for #168 but worth flagging.
+- **CLI machine-readable enum vocabulary**: v1.5.1 pinned
+  `"legacy" | "unindexed" | "indexed"` as canonical strings.
+  v1.5.2 pins `"legacy" | "populating" | "populated"`. Should these
+  share a top-level "schema migration state" type? Or are they
+  intentionally separate because they describe different dimensions
+  (per-key index state vs per-column population state)?
+- **`coordinator backfill-attempt-n` write-side safety**: SPEC says
+  the operator MAY run this with the daemon up (single-writer cap
+  serializes). Should the SPEC RECOMMEND a maintenance window, or
+  is the under-the-cap behavior actually safe and well-defined?
+- **No new dependencies on OpenStore vs OpenStoreReadOnly**: the
+  `--check` path uses OpenStoreReadOnly (no schema mutation). The
+  backfill path uses OpenStore (which runs migrate()). Is this
+  ordering correct?
+
+## Severity rubric
+
+- **CRITICAL**: contradiction with another normative SPEC.
+- **HIGH**: ambiguity that would split implementations.
+- **MEDIUM**: cross-SPEC pointer gaps, scope-clarity issues.
+- **LOW / NIT**: phrasing, edge cases.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_168_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R1_CODE_PROMPT.md
@@ -1,0 +1,101 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), CODE lane, ROUND 1.
+
+## Scope
+
+SPEC-002 v1.5.2 + SPEC-005 v0.3.3 add a monotonic `attempt_n INTEGER NULL`
+column to `request_log` populated at INSERT time, with a backfill subcommand
+for legacy NULL rows.
+
+## What landed
+
+**SPEC** (`specs/SPEC-002-coordinator.md` v1.5.2, `specs/SPEC-005-billing.md`
+v0.3.3): new column; INSERT-time monotonic write-path; backfill subcommand;
+per-column migration state machine `legacy | populating | populated`;
+read-side discipline (prefer persisted attempt_n, fall back to v0.3.1 id-ASC
+derivation for NULL rows).
+
+**IMPL** (`phase4-coordinator/`):
+- `internal/requestlog/store.go`:
+  - `Row.AttemptN *int` field added.
+  - Schema: `attempt_n INTEGER NULL` in CREATE TABLE + ensureColumns ALTER.
+  - `insert()` reworked: computes `COUNT(*) FROM request_log WHERE
+    account_id IS ? AND request_id = ?` in the same `execer` (sql.DB /
+    Conn / Tx — `execer` interface now includes both ExecContext and
+    QueryRowContext), then INSERTs with `attempt_n=count`. If caller
+    supplies non-nil `row.AttemptN`, derivation is skipped and supplied
+    value is used verbatim (for backfill).
+  - `AttemptNStatus` + `AttemptNState(ctx)` reports `legacy |
+    populating | populated` + `NullCount` + `TotalCount`.
+  - `BackfillAttemptN(ctx)` — one-shot UPDATE using
+    `ROW_NUMBER() OVER (PARTITION BY account_id, request_id ORDER BY id
+    ASC) - 1` filtered to `attempt_n IS NULL`. Idempotent.
+- `cmd/coordinator/backfill_attempt_n.go`: new subcommand
+  `coordinator backfill-attempt-n [--check] [--format text|json]`
+  routing through OpenStoreReadOnly when `--check`, OpenStore when
+  actually backfilling.
+- `cmd/coordinator/main.go`: dispatcher + usage text updated.
+- `internal/billing/recovery.go` (orphan-detection subquery + main
+  SELECT): `COALESCE(rl.attempt_n, id_asc_count_derivation)` so persisted
+  attempt_n wins when non-NULL, fallback derivation handles NULL legacy
+  rows.
+- `internal/billing/endpoints.go` (admin reconcile SELECT): same
+  COALESCE pattern.
+- `internal/billing/hotpath.go`: **unchanged** — the existing post-INSERT
+  `COUNT(*)-1` derivation produces the same value as the just-written
+  attempt_n column (since the INSERT populated it inside the same tx).
+  No code change needed.
+
+## Tests added
+
+- `TestInsertPopulatesMonotonicAttemptN`: 3 rows in
+  `(acct-A, req-A)` → `attempt_n=0,1,2`; new account → new group starting
+  at 0; same request_id with NULL account → separate group starting at 0
+  (preserves v1.5.0 IS clustering).
+- `TestBackfillAttemptNPopulatesLegacyNullRows`: insert 3 rows, null out
+  attempt_n to simulate legacy state, run backfill, assert values
+  `0,1,2` + state transition `populating → populated` + idempotence on
+  second run.
+
+## Verify
+
+- **Race-freeness of INSERT-time COUNT-then-INSERT** under the
+  `SetMaxOpenConns(1)` discipline. Is it actually race-free? The COUNT
+  and INSERT happen on the SAME connection (`execer` param). Could a
+  parallel INSERT through a different goroutine using the same `s.db`
+  interleave? (Single-writer pool says no, but verify the ordering
+  guarantee against `database/sql` semantics.)
+- **Backfill query correctness**: the ROW_NUMBER() OVER PARTITION
+  computes ordinals over ALL rows in each group (including any v1.5.2-
+  written rows that already have attempt_n). Then the UPDATE filters
+  to `attempt_n IS NULL`. Does this produce the SAME values that the
+  v0.3.1 fallback derivation would have computed? Specifically: if a
+  group has rows in state [populated=0, NULL, NULL] (e.g. row 1 was
+  written under v1.5.2, then a v1.5.1 rollback wrote rows 2 and 3 as
+  NULL), the backfill must assign `1, 2` not `0, 1` to preserve
+  monotonic order.
+- **Read-side COALESCE** in recovery.go and endpoints.go — does it
+  actually produce the right ordinals during the mixed-state window?
+- **Hotpath unchanged claim**: verify hotpath.go's post-INSERT COUNT-1
+  derivation actually equals the persisted attempt_n in the v1.5.2
+  steady state. (It should: the INSERT wrote `count-before-insert` as
+  attempt_n; the post-INSERT COUNT returns `count-before-insert + 1`;
+  `count-after-insert - 1 = count-before-insert = attempt_n`.)
+- **`execer` interface change** — adding `QueryRowContext` to the
+  required set is backwards-incompatible for any third-party callers
+  that pass a bare execer. Are there any?
+- **Test corpus alignment** — any existing test that previously
+  expected `attempt_n` to be derived at read time, that might now see
+  a persisted value that differs from the expected derivation?
+- **Full suite**: `go test ./...` from `phase4-coordinator` — green?
+
+## Severity rubric
+
+- **CRITICAL**: money-path regression; race in INSERT-time derivation;
+  backfill produces wrong ordinals.
+- **HIGH**: SPEC↔IMPL divergence; read-side prefers wrong column.
+- **MEDIUM**: ambiguity in cross-spec contract; missed test coverage on
+  a documented MUST.
+- **LOW / NIT**: wording, defensive checks, idempotence on edge cases.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_168_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R1_SECURITY_PROMPT.md
@@ -1,0 +1,70 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), SECURITY lane, ROUND 1.
+
+## Scope
+
+SPEC-002 v1.5.2 + SPEC-005 v0.3.3 + IMPL — monotonic `attempt_n` column at
+write time, backfill subcommand for legacy rows.
+
+## What landed
+
+(See code lane prompt for full surface — `request_log.attempt_n` column,
+INSERT-time COUNT-then-INSERT derivation, BackfillAttemptN UPDATE via
+ROW_NUMBER() window function, new `coordinator backfill-attempt-n
+[--check]` subcommand.)
+
+## Verify
+
+- **Money-path correctness**: the v0.3.1 quarantine rule "row 3+ MUST
+  be quarantined until SPEC-002 gains monotonic attempt_n" was a
+  load-bearing safety net. With v1.5.2 persisting attempt_n, row 3+
+  receives `attempt_n=2,3,...` and is credited normally. Is this a
+  safety regression in any scenario the v0.3.1 rule was actually
+  catching? Specifically — was the v0.3.1 quarantine catching ANY
+  legitimate-attack class (e.g. duplicate INSERT by a misbehaving
+  retry path) that v1.5.2 now silently credits?
+- **Persistence channel for the SPEC-002 v1.5.0 internal-request_id
+  collision class**: a UUID v4 collision across accounts would
+  produce attempt_n=0 in each (different) account group. The
+  account-IS clustering preserves that. Verify the v1.5.2 INSERT-time
+  COUNT respects the same IS-clustering as the v1.5.0 read-time
+  derivation (both clause: `account_id IS ?`).
+- **Backfill non-malicious-state preservation**: the ROW_NUMBER()
+  window function is computed over ALL rows including any v1.5.2-
+  written rows. Verify a partial backfill (interrupted mid-run)
+  doesn't leave the DB in an inconsistent state — e.g. if rows 0, 2
+  are backfilled but row 1 is missed (impossible under the
+  WHERE attempt_n IS NULL filter, but worth tracing).
+- **Race during ALTER TABLE rollout**: between daemon startup
+  (column added) and `backfill-attempt-n` running (column populated),
+  new writes correctly populate attempt_n while old rows have NULL.
+  The read-side COALESCE handles this. But what about an out-of-
+  process tool that reads request_log directly without using the
+  COALESCE? Does the SPEC adequately document the read-side discipline
+  for external tools (similar to the v1.5.1 reconciliation tooling
+  binding)?
+- **Operator-induced state issues**: an operator who runs
+  `backfill-attempt-n` on a partially-rolled-out fleet (some nodes
+  v1.5.2, some v1.5.1) could create a confused state if the daemon
+  is also writing. Is the SPEC text clear that backfill SHOULD run
+  while the daemon is up (the single-writer cap serializes), or that
+  it MUST be run during a maintenance window?
+- **Money-path attribution**: the v1.5.2 attempt_n is used by SPEC-005
+  ledger row keys `(request_id, attempt_n, provider_id)`. Persisting
+  a value at write time means it's stable across reconciliation runs.
+  Does this close any prior race where the read-time derivation could
+  give different values on different reconciliation passes (and thus
+  different ledger keys)?
+- **CLI surface**: `coordinator backfill-attempt-n --check --format
+  json` — does it leak any sensitive info beyond null/total counts?
+  Should it gate on operator_key for the non-check path?
+
+## Severity rubric
+
+- **CRITICAL**: real money-path regression or new attack class.
+- **HIGH**: SPEC contract gap that lets two implementations diverge
+  in a money-path-observable way.
+- **MEDIUM**: hardening that should land but didn't.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_168_R2_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R2_ARCHITECT_PROMPT.md
@@ -1,0 +1,68 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), ARCHITECT lane, ROUND 2.
+
+R1 returned 1 CRITICAL + 1 HIGH + 2 LOW. R2 fixes:
+
+1. **CRITICAL: SPEC-005 stale row-3+ references.** Rewrote 5+
+   locations across §D10 (line 334), v0.3.3 quarantine narrative
+   (line 746), AC-D10 expected text (line 1270), AC-D10 fixture
+   detail (line 1383), §15.2 legacy fallback (line 1115), OQ-1
+   resolution narrative (line 1577), AC-D10 fixture oracle
+   (line 2378). All now describe row 3+ as credited normally.
+
+2. **HIGH: legacy-quarantine resolution claim.** Reworded change-log
+   to be honest: v0.3.3 closes the quarantine CREATION class for
+   row 3+. Pre-existing quarantines from v0.3.1 remain immutable
+   per ledger schema (`quarantined` is `0 → 1` monotonic transition).
+   Resolution requires the §OQ-5 force-credit/force-void admin
+   surface (issue #169) — explicitly out of scope for #168.
+
+3. **LOW: backfill live-safety SHOULD vs MAY.** SPEC-002 change-log
+   now: SHOULD run during a maintenance window; MAY run live but
+   operators MUST accept that the UPDATE holds the writer lock and
+   could trigger 6s INSERT timeouts → buyer 503s. Small corpora
+   MAY skip the window.
+
+4. **LOW: future umbrella subcommand** — deferred, out of scope.
+
+## Verify
+
+- SPEC-005 internal consistency: are there ANY remaining
+  references to "row 3+ MUST quarantine" or "row 3+ is quarantined"
+  in the SPEC body? Should turn up zero. (`rg "row 3\\+ .* quarantin"
+  specs/SPEC-005-billing.md` should match only historical/legacy
+  references explicitly framed as resolved.)
+- The "pre-existing quarantines are immutable" narrative — is the
+  cross-link to #169 sufficient? Should SPEC-005 explicitly recommend
+  that an operator who wants to clear legacy quarantines wait for
+  #169, OR is "manual SQL UPDATE under explicit operator authority"
+  acceptable?
+- Cross-SPEC consistency: SPEC-002 v1.5.2 change-log + SPEC-005
+  v0.3.3 change-log + the SPEC-005 §15.2 legacy fallback text —
+  do they agree on the row-3+ contract? Look for divergence.
+- The backfill SHOULD-vs-MAY language: is "tens of milliseconds for
+  single-digit-thousand legacy rows" empirically defensible, or
+  should the SPEC offer a row-count threshold for operators to
+  use as a decision point?
+- SPEC-002 v1.5.2 change-log says backfill MAY run live but the
+  v0.3.3 quarantine class transition isn't fully covered: during
+  the rollout window, a NULL `attempt_n` row going through the
+  id-ASC fallback derivation could still land in the row-3+ slot
+  and be credited normally. That's consistent with v0.3.3. But
+  during the BACKFILL UPDATE itself (which is a single transaction),
+  could a concurrent hot-path INSERT see a partially-applied state?
+  (Answer: no, because BACKFILL UPDATE is atomic. Worth checking
+  the UPDATE SQL again.)
+- Cross-spec dep: SPEC-005 v0.3.3 depends on SPEC-002 v1.5.2.
+  Does anything else need to bump its SPEC-002 dependency? SPEC-006,
+  SPEC-007, SPEC-016 don't consume attempt_n directly, but check.
+
+## Severity rubric
+
+- **CRITICAL**: contradiction with another normative SPEC remains.
+- **HIGH**: ambiguity that splits implementations on observable
+  behavior.
+- **MEDIUM**: cross-SPEC pointer / scope gaps.
+- **LOW / NIT**: phrasing, defensive clauses.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_168_R2_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R2_CODE_PROMPT.md
@@ -1,0 +1,68 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), CODE lane, ROUND 2.
+
+R1 returned 1 CRITICAL + 1 MEDIUM + 1 LOW. R2 fixes:
+
+1. **CRITICAL: `Store.Insert` race fix.** `Store.Insert` now acquires a
+   single `*sql.Conn` via `s.db.Conn(ctx)` and runs both COUNT and
+   INSERT through it. Under SetMaxOpenConns(1), holding the conn blocks
+   other writers. Hotpath callers (`InsertExec(ctx, conn, ...)` inside
+   BEGIN IMMEDIATE) were already safe.
+   New test `TestInsertConcurrentSameGroupProducesMonotonicAttemptN`:
+   16 goroutines insert into the same `(account_id, request_id)` group;
+   assert each receives a distinct `attempt_n ∈ [0, 15]`.
+
+2. **MEDIUM: mixed-rollout-state regression test.** New
+   `TestBackfillAttemptNHandlesMixedRolloutState`: 3 rows inserted (all
+   populated), rows 1+2 nulled out, backfill run, asserts final sequence
+   is `[0, 1, 2]` — proving the ROW_NUMBER computes over ALL rows
+   (preserving row 0's persisted=0 and assigning rows 1,2 to backfilled
+   slots), and the UPDATE WHERE attempt_n IS NULL leaves the populated
+   row untouched.
+
+3. **LOW: external API break** — noted, acceptable for internal package.
+
+Also (cross-lane CRITICAL ARCHITECT + HIGH SECURITY): hotpath.go +
+recovery.go quarantine rule narrowed from "row 3+ always quarantines"
+to "only attempt_n==1 with retried==0 quarantines"; the
+`if attemptN > 1 { unconditional quarantine }` branch in recovery.go
+removed; corresponding billing tests rewritten to assert row 3+ is
+CREDITED, not quarantined.
+
+## Verify
+
+- The `Store.Insert` race fix correctly serializes COUNT+INSERT. Is
+  the held-conn pattern actually defended against goroutine
+  interleaving? Verify by tracing the database/sql Conn lifecycle:
+  Conn() acquires from the pool, exclusive until Close().
+- The concurrent-insert test runs 16 goroutines under the
+  Go runtime's GOMAXPROCS. Is this a meaningful race test?
+- The mixed-state test covers `[populated=0, NULL, NULL]`. Does it
+  also need to cover `[NULL, populated=1, NULL]` or
+  `[NULL, NULL, populated=2]` to prove the ROW_NUMBER respects
+  pre-existing values in any position? Edge case worth thinking
+  about — though ROW_NUMBER respects the OVER ORDER BY id ASC
+  ordering, so it always assigns deterministically.
+- The hotpath/recovery quarantine narrowing: does the new contract
+  correctly handle the `attempt_n=1 retried=0` case across both
+  hotpath and recovery? Look for divergence between the two paths.
+- The test rename `TestWriteHotPath_ThirdDerivedAttemptIsAlways
+  Quarantined` → `TestWriteHotPath_ThirdDerivedAttemptIsCredited
+  UnderMonotonicAttemptN` — was the old test's setup correct? Did
+  it actually exercise the row-3+ class, or some other class that
+  now needs separate coverage?
+- `recovery.go::sameRequestCount` is now unused (`_ = sameRequestCount`).
+  Should we remove the variable + the SQL subquery that computes it,
+  or keep it for future use?
+- Full coordinator test suite `go test ./...` — green?
+- Any new race detector findings under `go test -race ./...`?
+
+## Severity rubric
+
+- **CRITICAL**: race still reachable; OR a money-path regression.
+- **HIGH**: an R1 finding not actually closed; OR a new contract
+  violation between SPEC and IMPL.
+- **MEDIUM**: missed test coverage on a MUST.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_168_R2_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R2_SECURITY_PROMPT.md
@@ -1,0 +1,67 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), SECURITY lane, ROUND 2.
+
+R1 returned 2 HIGH:
+1. hotpath.go + recovery.go still implemented v0.3.1 "row 3+ MUST
+   quarantine" rule, contradicting SPEC-005 v0.3.3.
+2. SPEC-005 internally inconsistent — multiple stale "row 3+ MUST
+   quarantine" references in §D10, AC text, oracle text.
+
+R2 fixes:
+
+1. **hotpath.go**: quarantine condition narrowed from
+   `in.AttemptN > 1 || (in.AttemptN == 1 && reqRow.Retried == 0)`
+   to just `in.AttemptN == 1 && reqRow.Retried == 0`.
+2. **recovery.go**: `ambiguousAttempt` flag narrowed similarly;
+   `_ = sameRequestCount` since it's no longer a quarantine trigger;
+   the unconditional `if attemptN > 1 { quarantine }` branch removed.
+3. **SPEC-005**: rewrote stale references at 5+ locations to describe
+   row 3+ as credited normally under both the persisted attempt_n
+   path AND the byte-identical id-ASC fallback path.
+4. **Cross-spec narrative**: change-log now says v0.3.3 closes the
+   quarantine CREATION class for row 3+. Pre-existing quarantines
+   from the v0.3.1 era remain immutable per ledger schema
+   (`quarantined` is `0 → 1` monotonic). Resolution requires the
+   §OQ-5 force-credit/force-void admin surface (issue #169).
+5. **`Store.Insert` race closed** via held-conn pattern.
+
+## Verify
+
+- The narrowed quarantine rule correctly preserves the
+  legitimate-retry-without-marker class (`attempt_n=1, retried=0`).
+  Is this the right safety baseline? An attacker who replays a
+  request without setting `retried=1` would still hit this class —
+  preserved behavior.
+- Are there any other code paths that historically quarantined on
+  row-3+ that I missed? Sweep:
+  - `quarantineExistingLedgerForRequestAttemptTx` calls
+  - `insertQuarantineTx` calls
+  - `quarantine_reason = 'ambiguous_attempt_n'` references
+- Money-path discipline: does the new rule introduce any class of
+  credits that DIDN'T exist under v0.3.1? Specifically: a buyer
+  who sends 5+ retries to the same coordinator-internal request_id
+  used to get rows 3, 4, 5 quarantined → 0 credits. Now they get
+  credits for all 5. Is that the intended contract? It is — the
+  monotonic attempt_n makes each attempt a separate, legitimate
+  billable ledger row. The v0.3.1 quarantine was a safety net for
+  the row-mapping ambiguity, not a deliberate anti-abuse measure.
+- Pre-existing quarantine rows from v0.3.1 era — does the SPEC
+  text adequately handle the case where the operator wants to
+  resolve them but #169 hasn't shipped? "Operator action required"
+  is honest but leaves the operator with no path. Is this an
+  acceptable boundary or does it block #168 ship?
+- The `Store.Insert` race fix — could a concurrent BACKFILL UPDATE
+  during a daemon insert hit a lock contention? The hot-path
+  INSERT pins the conn for COUNT+INSERT (fast). The backfill
+  UPDATE pins it for the duration of the table scan. Both serialize
+  cleanly under SetMaxOpenConns(1) but the live-safety window
+  worsens — is the SPEC text honest about this?
+
+## Severity rubric
+
+- **CRITICAL**: real money-path regression OR a new attack class.
+- **HIGH**: an R1 finding not actually closed.
+- **MEDIUM**: hardening that should land but didn't.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_168_R3_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R3_ARCHITECT_PROMPT.md
@@ -1,0 +1,50 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), ARCHITECT lane, ROUND 3.
+
+R2 returned 1 CRITICAL (rollout-window row-3+ behavior still
+contradictory at SPEC-005 §8.2 + SPEC-002 lines 75-76) + 2 LOW
+(SPEC-007 design notes stale `[GAP]`; "tens of ms" empirical wording).
+
+R3 fixes:
+- **CRITICAL**: SPEC-005 §8.2 quarantine paragraph + SPEC-002
+  change-log both reworded to say row 3+ is credited normally in BOTH
+  the persisted-attempt_n path AND the byte-identical id-ASC fallback
+  path. Only attempt_n=1 retried=0 remains as a quarantine class.
+- **LOW**: SPEC-007 design notes `[GAP]` for stored attempt_n updated
+  to `[GAP-CLOSED]` pointing at SPEC-002 v1.5.2 / issue #168.
+- **LOW**: SPEC-002 backfill live-safety wording removed the "tens of
+  ms" empirical claim; replaced with operator-discretion-based
+  wording.
+- Cross-lane: SPEC-005 §10.5 + AC-ATTEMPT-FALLBACK fixture detail
+  (line 2510) also reworded; ban on direct SQL `UPDATE
+  quarantined=0` added explicitly.
+
+## Verify
+
+- Cross-SPEC consistency: SPEC-002 v1.5.2 change-log + SPEC-005
+  v0.3.3 change-log + SPEC-005 §8.2 + §15.2 + §10.5 + AC-D10 + AC-
+  ATTEMPT-FALLBACK + OQ-1 + SPEC-007 design notes — do they ALL
+  agree that row 3+ is credited normally in BOTH paths and that
+  only attempt_n=1 retried=0 is the remaining quarantine class?
+- Are there ANY remaining contradictions or scope ambiguities in
+  the SPEC text?
+- The "direct SQL unquarantine ban" sentence — is the cross-link to
+  #169 strong enough that operators don't try to side-step?
+- The backfill live-safety wording — is it operator-actionable now,
+  or does it just shift the burden ("measure it yourself") without
+  guidance?
+- SPEC-007 design notes `[GAP-CLOSED]` annotation: should normative
+  SPEC-007 ALSO get a sentence acknowledging the closed gap, or is
+  the design-doc annotation sufficient?
+- Any other spec files that reference attempt_n derivation outside
+  what I've audited (SPEC-001, SPEC-003, SPEC-004, SPEC-016)? Do
+  they need updates?
+
+## Severity rubric
+
+- **CRITICAL**: contradiction with another SPEC remains.
+- **HIGH**: ambiguity that splits implementations.
+- **MEDIUM**: cross-SPEC pointer / scope gaps.
+- **LOW / NIT**: phrasing, defensive clauses.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_168_R3_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R3_CODE_PROMPT.md
@@ -1,0 +1,43 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), CODE lane, ROUND 3.
+
+R2 returned 0 CRITICAL / 0 HIGH / 0 MEDIUM and 1 LOW (dead-code
+`same_request_count` subquery + scan + `_ = sameRequestCount`).
+
+R3 fixes the LOW:
+- Removed `same_request_count` SELECT subquery from `recovery.go`.
+- Removed `sameRequestCount` from the rows.Scan target list.
+- Removed `_ = sameRequestCount` placeholder.
+
+Also (cross-lane LOW cleanup from architect):
+- SPEC-007 design notes `[GAP]` for stored `attempt_n` updated to `[GAP-CLOSED]` pointing at SPEC-002 v1.5.2 / issue #168.
+- SPEC-002 backfill live-safety wording: removed the "tens of ms"
+  empirical claim; replaced with "operators who have measured the
+  UPDATE wall-clock against their corpus on representative storage
+  and observed it completes within their 6s INSERT budget MAY run
+  it live; uncertain or unmeasured runs SHOULD use a maintenance
+  window."
+- SPEC-005 v0.3.3 change-log: added an explicit "operators MUST NOT
+  execute direct `UPDATE ledger_request_credits SET quarantined=0`
+  SQL" sentence to close the side-channel resolution path.
+
+## Verify
+
+- Dead-code removal: are there any remaining references to
+  `sameRequestCount` or `same_request_count` anywhere in the
+  recovery.go / billing tests / SPEC docs?
+- The `recovery.go::Scan` argument count now matches the SELECT
+  column count? Build + targeted test would fail if not.
+- Full coordinator suite + race detector still green?
+- Any other code paths that would benefit from the held-conn pattern
+  applied to `Store.Insert`? (e.g. other Store methods that do
+  multi-statement work over `s.db`)
+
+## Severity rubric
+
+- **CRITICAL**: regression.
+- **HIGH**: any R1/R2 finding still open.
+- **MEDIUM**: SPEC↔IMPL divergence; missed MUST.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_168_R3_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R3_SECURITY_PROMPT.md
@@ -1,0 +1,54 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), SECURITY lane, ROUND 3.
+
+R2 returned 1 HIGH: stale "row 3+ remains quarantined until backfill"
+references at SPEC-005 §8.2 (line 749), SPEC-002 v1.5.2 change-log
+(lines 75-76), SPEC-005 §10.5 (line 850), and AC fixture detail
+(line 2510).
+
+R3 fixes all four:
+- SPEC-005 §8.2 quarantine paragraph: now says "row 3+ in BOTH the
+  persisted path AND the byte-identical id-ASC fallback is credited
+  normally; only attempt_n=1 retried=0 remains".
+- SPEC-002 v1.5.2 change-log: same correction.
+- SPEC-005 §10.5: "Ambiguous attempt_n fallback quarantines rows" →
+  "Ambiguous attempt_n=1 with retried=0 (legitimate retry without
+  explicit marker) quarantines rows. (v0.3.3: row 3+ is no longer in
+  this class — see §15.2.)"
+- SPEC-005 AC-ATTEMPT-FALLBACK fixture detail (line 2510): two
+  fixture variants (persisted attempt_n + NULL fallback) with the
+  v0.3.3 row-3+ credit oracle.
+- SPEC-005 change-log: added "Operators MUST NOT execute direct
+  `UPDATE ledger_request_credits SET quarantined=0` SQL" — closes
+  the side-channel resolution path the audit flagged.
+
+## Verify
+
+- Are there ANY remaining "row 3+ … quarantin" references anywhere
+  in the SPEC corpus? (`rg "row 3.* quarantin" specs/`) Should be
+  zero. (Historical references that are explicitly framed as
+  resolved are OK.)
+- Money-path correctness still preserved: the new contract credits
+  row 3+ in both paths; the attempt_n=1 retried=0 class remains the
+  only quarantine creation surface. Re-trace the WriteHotPath,
+  RecoverLedger, and admin reconcile paths to confirm.
+- Direct-SQL-unquarantine ban — does the SPEC text describe ALL the
+  consequences (audit log bypass, credit_mismatch risk, missing
+  provider_identity risk)? Or should it enumerate more cases?
+- Backfill live-safety wording: is "measured the UPDATE wall-clock
+  against your corpus" actionable enough for an operator? Specifically,
+  does the SPEC say HOW to measure (e.g. `EXPLAIN QUERY PLAN`, a
+  dry-run SELECT before the UPDATE)?
+- Defense-in-depth: the writer-conn pin from `Store.Insert` race
+  fix — does it interact with any other long-running UPDATE pattern
+  in the codebase that could starve hot-path INSERTs? Scan billing/
+  for transactions that hold the writer lock for non-trivial time.
+
+## Severity rubric
+
+- **CRITICAL**: real money-path regression or new attack class.
+- **HIGH**: R2 finding still open.
+- **MEDIUM**: hardening that should land but didn't.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_168_R4_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R4_ARCHITECT_PROMPT.md
@@ -1,0 +1,51 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), ARCHITECT lane, ROUND 4.
+
+R3 returned 1 CRITICAL (SPEC-002 line 46 `legacy` state contradicted
+v0.3.3 row-3+ crediting) + 1 HIGH (line 1703 v1.5.0 AttemptN
+defense-in-depth paragraph still said all three sites "derive from
+COUNT") + 1 LOW (SPEC-007 line 567 stale `[GAP]` for stored attempt_n).
+
+R4 fixes all three:
+1. **CRITICAL**: SPEC-002 `legacy` state text updated to apply v0.3.3
+   fallback rules: row 3+ credited normally via byte-identical id-ASC
+   arithmetic; only `attempt_n=1 retried=0` quarantined.
+2. **HIGH**: SPEC-002 line 1703 paragraph renamed "AttemptN read-side
+   discipline (v1.5.2; supersedes v1.5.0 derivation rule)" and rewritten
+   to say: read persisted `request_log.attempt_n` when non-NULL, fall
+   back to v1.5.0 COUNT-based derivation only when NULL. Final sentence
+   pins the row-3+ rule explicitly.
+3. **LOW**: SPEC-007 line 567 `[GAP]` updated to `[GAP-CLOSED]` per
+   SPEC-002 v1.5.2 / #168.
+
+R3 security MEDIUM additionally fixed via `--dry-run` (see security
+lane prompt).
+
+## Verify
+
+- SPEC-002 v1.5.2 internal consistency: do `legacy` / `populating` /
+  `populated` state descriptions agree with the v0.3.3 row-3+ rule?
+- SPEC-002 line 1703 paragraph: does the new text correctly describe
+  the v1.5.2 column-first read with v1.5.0 COUNT-based fallback?
+  Any residual contradiction with §request_log table or §15.2?
+- SPEC-007 design-doc internal consistency: §2.3 and §3.4 both
+  show `[GAP-CLOSED]` for stored attempt_n now?
+- Cross-SPEC sweep one more time: SPEC-001, SPEC-003, SPEC-004,
+  SPEC-005, SPEC-006, SPEC-016 — do they all agree on the v0.3.3
+  contract?
+- Are there ANY remaining stale "row 3+ MUST quarantine" / "row 3+
+  is quarantined" / "Row 3+ quarantined until SPEC-002" references
+  anywhere in `specs/`?
+- The `--dry-run` operator surface: does the SPEC text accurately
+  describe how operators decide between live and maintenance-window?
+  Is "4s warning threshold = 75% of 6s budget" mentioned in SPEC,
+  or only in the CLI emit?
+
+## Severity rubric
+
+- **CRITICAL**: contradiction with another SPEC remains.
+- **HIGH**: ambiguity that splits implementations.
+- **MEDIUM**: cross-SPEC pointer / scope gaps.
+- **LOW / NIT**: phrasing, edge cases.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/AUDIT_ISS_168_R4_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_168_R4_SECURITY_PROMPT.md
@@ -1,0 +1,56 @@
+You are reviewing branch `spec/iss-168-monotonic-attempt-n` of the macprovider
+repo (working tree `/Users/augstar/macprovider-iss168`), SECURITY lane, ROUND 4.
+
+R3 returned 1 MEDIUM (backfill preflight not operator-actionable) + 2 LOW
+(quarantine reason strings; existing long-tx patterns).
+
+R4 fixes:
+
+1. **MEDIUM**: added `coordinator backfill-attempt-n --dry-run`. The
+   `--dry-run` path runs the same UPDATE inside a transaction and
+   ROLLBACKs, capturing the rows-that-would-be-updated count plus
+   wall-clock elapsed time on the operator's actual production
+   corpus. Mutually exclusive with `--check`. The CLI emits a
+   WARNING if elapsed exceeds 4s (75% of the 6s hot-path INSERT
+   budget). SPEC-002 v1.5.2 backfill live-safety paragraph
+   rewritten: operators MUST use `--dry-run` to measure before
+   committing to a live backfill; warning means use a maintenance
+   window; clean dry-run authorizes a live run.
+2. **LOW (reason strings)**: SPEC-005 v0.3.3 direct-SQL ban now
+   lists the actual coordinator quarantine reason strings:
+   `ambiguous_attempt_n`, `missing_request_log`,
+   `missing_provider_identity`, `missing_config_snapshot`,
+   `invalid_usage_tokens`, `reconciliation_mismatch`,
+   `operator_split_mismatch`. Notes that only the first is a
+   candidate for unquarantine — others reflect real invariant
+   violations.
+3. **LOW (long-tx patterns)**: not addressed in code — existing
+   `RecoverLedger` and settlement transactions are part of the
+   existing operational reality, not new in #168. The backfill
+   live-safety wording acknowledges this implicitly via the
+   measurement discipline.
+
+## Verify
+
+- `--dry-run` actually measures wall-clock on the real UPDATE
+  (full BEGIN IMMEDIATE → UPDATE → ROLLBACK), not just a fast no-op.
+- The 4s WARNING threshold is reasonable for the 6s hot-path INSERT
+  budget (75% margin).
+- The reason-string list is accurate — `rg -n
+  "quarantine_reason.*=" phase4-coordinator/` to verify.
+- Is there ANY new attack class introduced by the `--dry-run`
+  surface? E.g. could an operator running `--dry-run` repeatedly
+  starve hot-path writes via repeated writer-lock acquisitions?
+  (The dry-run is operator-authenticated via config, not buyer-
+  reachable, so DOS via this surface requires operator collusion.)
+- Money-path correctness re-verify on the full hotpath →
+  recovery → admin reconcile chain.
+
+## Severity rubric
+
+- **CRITICAL**: real money-path regression or new attack class.
+- **HIGH**: R3 finding still open.
+- **MEDIUM**: hardening that should land but didn't.
+- **LOW / NIT**: defensive suggestions.
+
+Bar for convergence: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

--- a/specs/SPEC-002-coordinator.md
+++ b/specs/SPEC-002-coordinator.md
@@ -1,7 +1,111 @@
 # SPEC-002 — Phase 4 Coordinator: Mac Provider Request Router
 
-**Version:** 1.5.1 (2026-06-29, R-2 normative clarifications — issue #197)
+**Version:** 1.5.2 (2026-06-29, monotonic `attempt_n` column — issue #168)
 **Depends on:** SPEC-001 v1.4 (Phase 3 binary wire protocol, locked; v1.4 adds installer custom-model selection + `models browse` + fit guard on top of the v1.3 absorbed in §7.8/§7.9); SPEC-003 FR-C9.4 composed contract — base AuthState enum (`bearer_validated`, `self_minted`, `bearerless_duplicate`) introduced in v0.8.3; `mint_failed` reserved value added in v0.8.4.
+
+**Change log v1.5.2 (2026-06-29, issue #168 — monotonic `attempt_n` column on `request_log`):**
+- **New column.** `request_log` gains `attempt_n INTEGER NULL` (zero-based
+  monotonic attempt ordinal). NULL on legacy rows written before
+  v1.5.2; non-NULL on all v1.5.2+ writes. Existing reconciliation
+  contracts (SPEC-005 v0.3+, SPEC-007 v0.3+) continue to work in the
+  rollout window because the read-side prefers the persisted
+  `attempt_n` when non-NULL and falls back to the v0.3.1 id-ASC
+  derivation when NULL.
+- **Write-time population semantics.** At `request_log` INSERT,
+  `attempt_n` MUST be assigned monotonically as `COUNT(*) FROM
+  request_log WHERE account_id IS ? AND request_id = ?` over the
+  rows already in the same `(account_id, request_id)` group under
+  SQLite `IS` semantics, computed in the same writer transaction.
+  Because the request-log store caps the pool at one writer
+  connection (`SetMaxOpenConns(1)` per the v1.4.2 R-2 + #21 / ARCH-3
+  discipline), this read-then-insert is race-free. The first row in
+  any group receives `attempt_n=0`; the n-th row receives
+  `attempt_n=n-1`. This is the same arithmetic the prior v0.3.1
+  read-time derivation produced; v1.5.2 just persists it at write
+  time so the value is stable across audit, reconciliation, and
+  replay.
+- **Read-side discipline.** SPEC-005 v0.3.3+ MUST consume
+  `request_log.attempt_n` directly when non-NULL. When NULL (legacy
+  pre-v1.5.2 row OR rollback window), the read-side falls back to
+  the v0.3.1 id-ASC derivation within the same
+  `(account_id, request_id)` group. The fallback is exactly the
+  arithmetic the writer would have produced, so a backfilled row and
+  a derivation-time row are byte-identical.
+- **Backfill subcommand.** A new operator subcommand
+  `coordinator backfill-attempt-n` walks legacy rows in id-ASC order
+  within each `(account_id, request_id)` group and assigns
+  `attempt_n` monotonically (the same arithmetic the v0.3.1 fallback
+  produces, executed once as a one-shot DDL-class operation rather
+  than per-read). Idempotent: rows that already have non-NULL
+  `attempt_n` are skipped. Read-only `--check --format=text|json`
+  reports a count of NULL vs populated rows so operators can verify
+  completion before they consider the migration done.
+- **Migration state machine.** Three observable states, parallel to
+  the v1.5.1 per-key state machine but PER-COLUMN (no index, since
+  `attempt_n` is a per-row ordinal, not a join key):
+  - `legacy` — column absent. Read-side MUST fall back to id-ASC
+    derivation; SPEC-005 v0.3.3 fallback rules apply (row 3+ credited
+    normally via the byte-identical id-ASC arithmetic; only
+    `attempt_n=1` with `retried=0` quarantined as the legitimate-
+    retry-without-marker class).
+  - `populating` — column present, some rows have NULL `attempt_n`
+    (either pre-v1.5.2 rows awaiting backfill OR a rollback window
+    where the v1.5.2 binary briefly ran then reverted). Read-side
+    prefers persisted `attempt_n` on non-NULL rows, falls back to
+    id-ASC derivation on NULL rows. Both paths produce byte-
+    identical ordinals because the writer derivation matches the
+    fallback derivation.
+  - `populated` — column present, zero NULL rows. Steady-state.
+  Tooling MAY check state via `backfill-attempt-n --check --format
+  json` which returns `{"migration_state": "legacy|populating|
+  populated", "null_count": N, "total_count": M}`.
+- **No race with the v1.5.0 AttemptN derivation.** The v1.5.0
+  AttemptN scoping in `hotpath.go` / `recovery.go` /
+  `endpoints.go` (defense-in-depth COUNT-based derivation
+  scoped by `(account_id, request_id) IS`) remains correct on
+  legacy rows. v1.5.2 writes populate `attempt_n` BEFORE the
+  derivation point so the derivation simply prefers the
+  persisted column when non-NULL — same arithmetic either
+  way.
+- **Quarantine rule change (cross-spec, see SPEC-005 v0.3.3).**
+  With persisted monotonic `attempt_n`, the v0.3.1 "row 3+ MUST
+  be quarantined until SPEC-002 gains monotonic attempt_n" rule
+  is satisfied in BOTH paths — the persisted monotonic `attempt_n`
+  path AND the byte-identical id-ASC fallback path. Row 3+ in either
+  path receives a stable `attempt_n=2, 3, ...` ordinal and is credited
+  normally (subject to the existing `retried` flag and identity-
+  snapshot rules). Quarantining is reserved for one genuine ambiguity
+  class: `attempt_n=1` with `retried=0` (legitimate retry without an
+  explicit `retried` marker — see SPEC-005 §OQ-5, issue #169).
+- **Deploy ordering.** Coordinator v1.5.2 MUST be deployed before
+  any out-of-process tooling that reads `attempt_n` directly. The
+  ALTER TABLE runs at daemon startup; the operator runs
+  `coordinator backfill-attempt-n` once per deployment. During the
+  `populating` window (column present, some NULL rows), the read-side
+  discipline above keeps every consumer correct.
+- **Backfill live-safety.** `coordinator backfill-attempt-n` SHOULD
+  run during a maintenance window (the same window as
+  `migrate-indexes` is the natural choice). It MAY run live against
+  a running daemon — the request-log writer-connection cap from
+  issue #21 / ARCH-3 serializes the backfill UPDATE against new
+  hot-path INSERTs, preserving correctness — but operators MUST
+  accept that the backfill UPDATE will hold the writer lock for the
+  duration of its scan, potentially exceeding the 6s INSERT timeout
+  on the hot path and triggering buyer-visible 503s. The
+  recommended sequence is: take the deploy briefly offline, run
+  `backfill-attempt-n`, then restore traffic.
+  **Preflight wall-clock measurement.** `coordinator
+  backfill-attempt-n --dry-run` executes the same UPDATE inside a
+  transaction and ROLLBACKs without persisting; it reports the
+  rows-that-would-be-updated count plus the wall-clock elapsed
+  time on the operator's actual production corpus. Operators MUST
+  use this dry-run to measure against the 6s hot-path INSERT budget
+  BEFORE deciding whether to run a live backfill — the dry-run
+  itself holds the writer lock for the same duration as a live run
+  would, but is observability-only (no row mutation). The CLI emits
+  a WARNING if dry-run elapsed exceeds 4 seconds (75% of the 6s
+  budget). A dry-run that warns means the operator SHOULD use a
+  maintenance window; a clean dry-run authorizes a live backfill.
 
 **Change log v1.5.1 (2026-06-29, issue #197 — R-2 normative clarifications + sanitizer hardening):**
 - **`external_request_id` UUID-tolerance clause.** Formalizes the
@@ -1548,11 +1652,14 @@ Every buyer request is logged to the `request_log` table in SQLite:
 | `pref_header` | TEXT | Value of X-MacProvider-Pref if present |
 | `provider_header` | TEXT | Value of X-MacProvider-Provider if present |
 | `retried` | INTEGER | Always 0 in v1 (no coordinator-managed retry). Column reserved for SPEC-004 / SPEC-006 retry policies. |
+| `attempt_n` | INTEGER NULL | (v1.5.2) Zero-based monotonic attempt ordinal within the same `(account_id, request_id)` group under SQLite `IS` semantics. Populated at INSERT time by the writer via `COUNT(*) FROM request_log WHERE account_id IS ? AND request_id = ?` in the same transaction. NULL only on legacy rows written before v1.5.2 (or written during a v1.5.2 → v1.5.1 rollback window); SPEC-005 v0.3.3 read-side falls back to id-ASC derivation for NULL rows during the migration window. Backfilled by the operator subcommand `coordinator backfill-attempt-n`. |
 
 Token counts are extracted from the provider's response `usage` field.
 For streaming responses, they come from the usage chunk (SPEC-001 FR-7).
 
-Each provider attempt for a given `request_id` MUST produce its own `request_log` row. The only uniqueness constraint is on (`id`). `request_id` MAY recur across rows when SPEC-004 retry logic produces multiple attempts within a single account. Note that `request_log.request_id` is coordinator-internal (server-minted UUID v4 per buyer request — see `requestIDForBuyerRequest()`); it is NOT the inbound `X-Request-ID` (which is persisted as `external_request_id`). The cross-account collision class motivating #211 lives on `external_request_id`, not on internal `request_id`. The `retried` column counts additional explicit-retry attempts beyond the first per SPEC-004 v0.3.1; the row order within a single `(account_id, request_id)` group is determined by `id ASC` under SQLite `IS` clustering — account scoping here is defense-in-depth so that if a UUID v4 collision or future schema change ever causes the same internal `request_id` to appear in rows from different accounts, each account's attempt sequence is computed within its own scope. This contract is load-bearing for SPEC-005 v0.3.1 multi-attempt attribution.
+Each provider attempt for a given `request_id` MUST produce its own `request_log` row. The only uniqueness constraint is on (`id`). `request_id` MAY recur across rows when SPEC-004 retry logic produces multiple attempts within a single account. Note that `request_log.request_id` is coordinator-internal (server-minted UUID v4 per buyer request — see `requestIDForBuyerRequest()`); it is NOT the inbound `X-Request-ID` (which is persisted as `external_request_id`). The cross-account collision class motivating #211 lives on `external_request_id`, not on internal `request_id`. The `retried` column counts additional explicit-retry attempts beyond the first per SPEC-004 v0.3.1.
+
+**Attempt ordinal (v1.5.2).** The canonical attempt ordinal within a single `(account_id, request_id)` group is `request_log.attempt_n` — a zero-based monotonic integer populated at INSERT time by the writer (`COUNT(*) FROM request_log WHERE account_id IS ? AND request_id = ?` in the same transaction; the single-writer pool cap from #21 / ARCH-3 makes this race-free). For legacy NULL-`attempt_n` rows (written pre-v1.5.2 or during a rollback window), the read-side falls back to id-ASC derivation within the same `(account_id, request_id)` group under SQLite `IS` clustering — the same arithmetic the writer would have produced, so backfilled and derivation-time ordinals are byte-identical. Account scoping is defense-in-depth so that if a UUID v4 collision or future schema change ever causes the same internal `request_id` to appear in rows from different accounts, each account's attempt sequence is computed within its own scope. This contract is load-bearing for SPEC-005 v0.3.3 multi-attempt attribution.
 
 `request_id` MUST be indexed. Any service in the request path that fails to propagate `X-Request-ID` degrades cross-layer debuggability; new buyer/request log surfaces MUST include X-Request-ID propagation.
 
@@ -1568,7 +1675,7 @@ CREATE INDEX idx_request_log_account_external_request_id ON request_log(account_
 
 The `idx_request_log_ts_utc` index supports SPEC-005 v0.3 reconciliation scans (24h startup, 7d nightly, ad-hoc admin ranges) at 10K-provider scale. The composite `(request_id, id)` index supports the SPEC-005 § 8.2 attempt-ordinal fallback and SPEC-004 multi-attempt log queries. The partial-NULL `external_request_id` and `(account_id, external_request_id)` indexes support closing-the-books reconciliation joins to gateway `usage_events` and `audit_events` (whether run as out-of-process harnesses or via a future coordinator-hosted reconciliation endpoint).
 
-Migration: existing deployments MUST apply `ALTER TABLE request_log ADD COLUMN error_code TEXT NULL`, `ALTER TABLE request_log ADD COLUMN external_request_id TEXT NULL` (v1.4.2 R-2), and `ALTER TABLE request_log ADD COLUMN account_id TEXT NULL` (v1.5.0), and create the four indexes above. The two partial-NULL reconciliation indexes are built via `coordinator migrate-indexes`, NOT from daemon startup.
+Migration: existing deployments MUST apply `ALTER TABLE request_log ADD COLUMN error_code TEXT NULL`, `ALTER TABLE request_log ADD COLUMN external_request_id TEXT NULL` (v1.4.2 R-2), `ALTER TABLE request_log ADD COLUMN account_id TEXT NULL` (v1.5.0), and `ALTER TABLE request_log ADD COLUMN attempt_n INTEGER NULL` (v1.5.2), and create the four indexes above. The two partial-NULL reconciliation indexes are built via `coordinator migrate-indexes`, NOT from daemon startup. The `attempt_n` column requires no index (it is a per-row ordinal, not a join key); the operator backfill subcommand `coordinator backfill-attempt-n` populates legacy NULL rows once per deployment.
 
 **Per-key migration-state machine (v1.5.1).** Because ALTER TABLE migrations run at daemon startup but the partial-NULL composite indexes are built only by the operator subcommand `coordinator migrate-indexes`, each composite reconciliation key on `request_log` has its OWN three-state migration:
 
@@ -1603,7 +1710,7 @@ In-scope tooling MUST fail closed when it observes state `unindexed` (or `legacy
 
 **Deploy ordering (v1.5.0).** Coordinator MUST be deployed first; it accepts and persists `X-MacProvider-Account` whether or not the gateway sends it. Gateway then deploys with the unconditional header. Auditor tooling MUST detect the boundary at row granularity (not schema granularity): rows with NULL `account_id` are either (a) pre-v1.5.0-coordinator rows, (b) v1.5.0-coordinator rows from a pre-v0.9.1 gateway, or (c) v1.5.0-coordinator rows written during a v1.4.x rollback window where the column existed but the writer didn't populate it. In all three cases the join MUST fall back to the prior `external_request_id`-only key and accept the documented ambiguity. Tooling MUST NOT use `PRAGMA table_info(request_log)` column-presence as a switch — that would misclassify rollback-window rows as scoped-ready. Use `account_id IS NOT NULL` as the per-row gate instead.
 
-**Money-path: AttemptN derivation defense-in-depth (v1.5.0).** `internal/billing/hotpath.go`, `internal/billing/recovery.go`, and `internal/billing/endpoints.go` admin-reconcile all derive `AttemptN` from a COUNT over `request_log` rows sharing the same internal `request_id`. **Note on identity:** `request_log.request_id` is the coordinator-internal billing id (server-minted UUID v4 per buyer request — see `requestIDForBuyerRequest()`), NOT the inbound `X-Request-ID` (which is persisted as `external_request_id`). The buyer-supplied collision class motivating #211 lives on `external_request_id` and is fully addressed by the composite `(account_id, external_request_id)` reconciliation key; it does NOT naturally manifest as collisions on internal `request_id`. Account-scoping the AttemptN derivation by `(account_id, request_id)` using SQLite `IS` semantics is therefore defense-in-depth — it ensures that if a UUID v4 collision, a misconfigured retry path, or any future schema-level change ever causes the same internal `request_id` to appear in `request_log` rows belonging to different accounts, each account's first attempt is correctly counted within its own scope rather than silently quarantined by `ambiguous_attempt_n`. All three sites MUST use identical `IS` semantics so the same row gets the same `AttemptN` derivation regardless of which path scans it. The pre-v1.5.0 same-account multi-attempt grouping (legacy NULL-`account_id` rows cluster among themselves) is preserved exactly.
+**Money-path: AttemptN read-side discipline (v1.5.2; supersedes v1.5.0 derivation rule).** `internal/billing/hotpath.go`, `internal/billing/recovery.go`, and `internal/billing/endpoints.go` admin-reconcile MUST read `request_log.attempt_n` (SPEC-002 v1.5.2 monotonic ordinal, populated at INSERT time) when non-NULL. For legacy NULL-`attempt_n` rows (pre-v1.5.2 OR rollback window), the read-side falls back to the v1.5.0 COUNT-based derivation over `request_log` rows sharing the same `(account_id, request_id)` group — same arithmetic the writer would have persisted, so backfilled and derivation-time ordinals are byte-identical. **Note on identity:** `request_log.request_id` is the coordinator-internal billing id (server-minted UUID v4 per buyer request — see `requestIDForBuyerRequest()`), NOT the inbound `X-Request-ID` (which is persisted as `external_request_id`). The buyer-supplied collision class motivating #211 lives on `external_request_id` and is fully addressed by the composite `(account_id, external_request_id)` reconciliation key; it does NOT naturally manifest as collisions on internal `request_id`. Account-scoping the AttemptN derivation (whether persisted at INSERT time under v1.5.2 OR computed at read time under the v1.5.0 fallback) by `(account_id, request_id)` using SQLite `IS` semantics is defense-in-depth — it ensures that if a UUID v4 collision, a misconfigured retry path, or any future schema-level change ever causes the same internal `request_id` to appear in `request_log` rows belonging to different accounts, each account's first attempt is correctly counted within its own scope. All three sites MUST use identical `IS` semantics so the same row gets the same `AttemptN` regardless of which path scans it. The pre-v1.5.0 same-account multi-attempt grouping (legacy NULL-`account_id` rows cluster among themselves) is preserved exactly. **Quarantine class (v0.3.3): only `attempt_n=1` with `retried=0` is quarantined — see SPEC-005 v0.3.3 §15.2; the v0.3.1 "row 3+ MUST quarantine" rule is satisfied in both the persisted and fallback paths.**
 
 ### Routing logic
 

--- a/specs/SPEC-002-v1-5-2-audit.md
+++ b/specs/SPEC-002-v1-5-2-audit.md
@@ -1,0 +1,80 @@
+# SPEC-002 v1.5.2 / SPEC-005 v0.3.3 audit trail (issue #168)
+
+Three-lane codex audit on the monotonic `attempt_n` column work.
+
+## Scope
+
+1. **SPEC-002 v1.5.2** — adds `attempt_n INTEGER NULL` to `request_log` with monotonic INSERT-time write-path semantics, per-column migration state machine (`legacy | populating | populated`), backfill subcommand.
+2. **SPEC-005 v0.3.3** — promotes the row-mapping rule to prefer the persisted `attempt_n` exact match; retains v0.3.1 id-ASC derivation as back-compat fallback for legacy NULL rows. Closes §OQ-1.
+3. **Coordinator IMPL** — column + schema migration + INSERT-time COUNT-then-INSERT in `requestlog.insert()`; read-side `COALESCE(rl.attempt_n, fallback_derivation)` in recovery.go + endpoints.go; backfill subcommand + `--check --format json` surface.
+
+## Round dispositions
+
+### R1 (3 lanes)
+- CODE: 1 CRITICAL (`Store.Insert` race — multi-op through `*sql.DB` interleaves) + 1 MEDIUM (missing mixed-state regression test) + 1 LOW (external API break note).
+- SECURITY: 2 HIGH (hotpath.go + recovery.go still implement v0.3.1 row-3+ quarantine; SPEC-005 internally inconsistent — multiple stale "row 3+ MUST quarantine" references).
+- ARCHITECT: 1 CRITICAL (SPEC-005 stale "row 3+ MUST quarantine until SPEC-002 gains monotonic attempt_n" in §D10 + AC + oracle at lines 334, 1272, 1386, 1577-1578, 2378) + 1 HIGH (claim "legacy quarantines auto-resolve via §OQ-5 or deterministic re-derivation" contradicts ledger schema: `quarantined` is `0 → 1` immutable transition, §OQ-5 not yet defined) + 2 LOW (backfill live-safety SHOULD vs MAY; future umbrella subcommand).
+
+### R2 fixes
+
+**CRITICAL CODE: `Store.Insert` race fix.**
+- `Store.Insert` now acquires a single `*sql.Conn` via `s.db.Conn(ctx)` and runs COUNT+INSERT through it. The pool cap blocks other writers while the conn is held. Hotpath callers via `InsertExec(ctx, conn, ...)` were already safe (BEGIN IMMEDIATE on held conn); only `Store.Insert` (called from `buyer/billing_recorder.go::record`) was vulnerable.
+- New test `TestInsertConcurrentSameGroupProducesMonotonicAttemptN` spawns 16 goroutines inserting into the same group; asserts each receives a distinct `attempt_n ∈ [0, 15]`. Pre-fix would race; post-fix passes.
+
+**CRITICAL ARCHITECT + HIGH SECURITY: SPEC-005 stale row-3+ text + IMPL still implements the old rule.**
+- Rewrote 5+ stale references across SPEC-005 (§D10 line 334; v0.3.3 quarantine paragraph 746; AC-D10 line 1270; AC-D10 fixture 1383; OQ-1 1577; AC-D10 fixture detail 2378) — all now describe row 3+ as credited normally under both the persisted `attempt_n` path AND the byte-identical id-ASC fallback.
+- `hotpath.go`: quarantine condition narrowed from `in.AttemptN > 1 || (in.AttemptN == 1 && reqRow.Retried == 0)` to just `in.AttemptN == 1 && reqRow.Retried == 0` (legitimate-retry-without-marker).
+- `recovery.go`: same narrowing on the `ambiguousAttempt` flag (was `attemptN > 1 || (attemptN == 1 && retried == 0) || sameRequestCount > 2`); the unconditional `if attemptN > 1 { quarantine }` branch at line 252 removed entirely.
+- Tests: `TestWriteHotPath_ThirdDerivedAttemptIsAlwaysQuarantined` → renamed `TestWriteHotPath_ThirdDerivedAttemptIsCreditedUnderMonotonicAttemptN` with inverted assertion. `TestRecoverLedger_QuarantinesExistingThirdAttempt` → `TestRecoverLedger_CreditsExistingThirdAttemptUnderMonotonicAttemptN` (also rewritten to seed via `WriteHotPath` so credits match the active rate card).
+
+**HIGH ARCHITECT: legacy-quarantine resolution claim.**
+- Rewrote the change-log narrative: pre-existing quarantine rows from the v0.3.1 era remain immutable per ledger schema; v0.3.3 closes the **CREATION** class for row 3+ but does NOT introduce an unquarantine flow. Resolution of pre-existing quarantines requires the §OQ-5 admin surface (issue #169). Honest about the scope boundary.
+
+**MEDIUM CODE: mixed-state regression test.**
+- `TestBackfillAttemptNHandlesMixedRolloutState`: insert 3 rows (all populated), null out only rows 1+2, run backfill, assert sequence is `[0, 1, 2]` (row 0's persisted value preserved). Proves the ROW_NUMBER OVER PARTITION computes ordinals over ALL rows including the v1.5.2-written one, and the UPDATE filter `attempt_n IS NULL` leaves the populated row untouched.
+
+**LOW ARCHITECT: backfill live-safety SHOULD vs MAY.**
+- SPEC-002 change-log now says: SHOULD run during a maintenance window; MAY run live but operators MUST accept that the backfill UPDATE will hold the writer lock and potentially trigger 6s INSERT timeouts → buyer-visible 503s. Small corpora (single-digit-thousand legacy rows) MAY skip the window since backfill completes in tens of ms.
+
+**LOW CODE: external API break note** — acceptable, `InsertExec` is internal-only.
+
+**LOW ARCHITECT: future umbrella subcommand** — out of scope for #168, deferred.
+
+### R2 audit returned
+- CODE: 0 C/H/M, 1 LOW (dead `same_request_count` subquery + scan + placeholder).
+- SECURITY: 1 HIGH (4 stale "row 3+ remains quarantined" references at SPEC-005 §8.2 + §10.5 + AC-ATTEMPT-FALLBACK fixture + SPEC-002 v1.5.2 change-log lines 75-76).
+- ARCHITECT: 1 CRITICAL (same convergent stale text on SPEC-005 §8.2 + SPEC-002 lines 75-76) + 2 LOW (SPEC-007 design `[GAP]`; "tens of ms" empirical wording).
+
+### R3 fixes
+- Removed dead `same_request_count` subquery + scan target + placeholder in `recovery.go`.
+- Rewrote ALL 4 stale references: SPEC-005 §8.2 quarantine paragraph, §10.5 "ambiguous attempt_n fallback", AC-ATTEMPT-FALLBACK fixture detail, SPEC-002 v1.5.2 change-log row-3+ wording. All now say row 3+ is credited in BOTH paths; only `attempt_n=1 retried=0` quarantined.
+- SPEC-007 design notes `[GAP]` for stored `attempt_n` → `[GAP-CLOSED]` pointing at SPEC-002 v1.5.2 / #168 (both §2.3 and §3.4).
+- SPEC-002 "tens of ms" empirical claim → operator-discretion-based wording.
+- SPEC-005 direct-SQL-unquarantine ban added explicitly (with audit-log + invariant + cross-quarantine-class risks enumerated).
+
+### R3 audit returned
+- CODE: 0 C/H/M, 3 LOW (gofmt store.go, stale test comment, InsertExec docs).
+- SECURITY: 1 MEDIUM (backfill preflight not operator-actionable — can't measure wall-clock before live commit) + 2 LOW (wrong quarantine reason strings; existing long-tx patterns).
+- ARCHITECT: 1 CRITICAL (SPEC-002 `legacy` state still applied "v0.3.1 quarantine rules unchanged" — contradicts v0.3.3 row-3+ credit) + 1 HIGH (line 1703 v1.5.0 AttemptN paragraph still said "derive from COUNT" without v1.5.2 column-first read) + 1 LOW (SPEC-007 §3.4 second stale `[GAP]`).
+
+### R4 fixes
+- **CRITICAL** (architect): SPEC-002 `legacy` state text rewritten to apply v0.3.3 fallback rules (row 3+ credited normally; only `attempt_n=1 retried=0` quarantined).
+- **HIGH** (architect): SPEC-002 line 1703 paragraph renamed "AttemptN read-side discipline (v1.5.2; supersedes v1.5.0 derivation rule)" and rewritten: read persisted `attempt_n` when non-NULL, fall back to v1.5.0 COUNT only when NULL, final sentence pins the row-3+ contract explicitly.
+- **MEDIUM** (security): added `coordinator backfill-attempt-n --dry-run` — runs the same UPDATE inside BEGIN IMMEDIATE + ROLLBACK, captures wall-clock + rows-affected, emits a WARNING if elapsed > 4s (75% of 6s hot-path INSERT budget). Mutually exclusive with `--check`. SPEC-002 backfill live-safety paragraph rewritten to mandate `--dry-run` as operator preflight discipline.
+- **LOW** (security reason strings): SPEC-005 direct-SQL ban now lists the actual quarantine reason strings.
+- **LOW** (architect SPEC-007): §3.4 `[GAP]` → `[GAP-CLOSED]`.
+- **LOW** (code): gofmt on store.go; updated stale `same_request_count` reference in billing test comment.
+
+### R4 audit returned
+- ARCHITECT: 0 C/H/M — **converged**.
+- SECURITY: 0 C/H/M + 1 LOW (missing `conflicting_settlement_id` from the reason-string list).
+
+### R5 NOT REQUIRED — Converged.
+
+All three lanes at **0 CRITICAL / 0 HIGH / 0 MEDIUM**:
+- CODE lane: R3 0 C/H/M (3 LOW cleanup done in R4).
+- SECURITY lane: R4 0 C/H/M (final LOW — `conflicting_settlement_id` added — fixed inline before commit).
+- ARCHITECT lane: R4 0 C/H/M.
+
+Loop closed.
+

--- a/specs/SPEC-005-billing.md
+++ b/specs/SPEC-005-billing.md
@@ -1,7 +1,72 @@
 # SPEC-005 - Billing, Settlement, and Provider Rewards
 
-**Version:** 0.3.2 (2026-06-29, SPEC-002 v1.5.1 per-key migration-state dependency — issue #197)
-**Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.1, SPEC-003 v0.7, SPEC-004 v0.3.1, SPEC-006 v0.9.1
+**Version:** 0.3.3 (2026-06-29, monotonic `attempt_n` column promotion — issue #168)
+**Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.2, SPEC-003 v0.7, SPEC-004 v0.3.1, SPEC-006 v0.9.1
+
+**Change log v0.3.3 (2026-06-29, issue #168 — SPEC-002 v1.5.2 monotonic `attempt_n` adoption, closes §OQ-1):**
+- Dependency bump: SPEC-002 v1.5.1 → v1.5.2 to absorb the new
+  `request_log.attempt_n` column (zero-based monotonic ordinal
+  populated at INSERT time by the writer, scoped to
+  `(account_id, request_id)` under SQLite `IS`).
+- **Row-mapping rule promotion.** §8.2 / §10.4 / §15.2 attempt-
+  ordinal derivation MUST prefer `request_log.attempt_n` exact match
+  when non-NULL. When NULL (legacy pre-SPEC-002-v1.5.2 row OR
+  rollback window), the derivation falls back to the v0.3.1 id-ASC
+  arithmetic within the same `(account_id, request_id)` group under
+  SQLite `IS` clustering. Both paths produce byte-identical ordinals
+  because the writer's INSERT-time COUNT and the fallback's read-time
+  COUNT compute the same value over the same row set; v0.3.3 just
+  persists it.
+- **Quarantine rule narrowing.** v0.3.1's "row 3+ MUST be quarantined
+  until SPEC-002 gains monotonic `attempt_n`" rule is satisfied as of
+  SPEC-002 v1.5.2 — both via the persisted `attempt_n` column AND via
+  the byte-identical id-ASC fallback derivation. Row 3+ in BOTH the
+  v1.5.2 write path and the legacy NULL-`attempt_n` fallback path
+  receives a stable `attempt_n=2, 3, ...` ordinal and is credited
+  normally on a fresh reconciliation pass.
+
+  The only remaining steady-state quarantine class is `attempt_n=1`
+  with `retried=0` — legitimate retry without an explicit `retried`
+  marker. Cannot be safely distinguished from a buggy duplicate
+  insert; quarantined for operator review per §OQ-5 (issue #169).
+- **Pre-existing quarantine rows are immutable.** Quarantine rows
+  written under the v0.3.1 row-3+ rule BEFORE the SPEC-005 v0.3.3
+  IMPL deploy remain in their existing quarantined=1 state. The
+  ledger schema constrains `quarantined` to a `0 → 1` monotonic
+  transition; SPEC-005 v0.3.3 does NOT introduce an unquarantine
+  flow. **Operator action is required to resolve these legacy
+  quarantines** — the SPEC-005 §OQ-5 force-credit / force-void admin
+  surface (issue #169) is the natural counterpart. v0.3.3 closes the
+  quarantine **CREATION** class for row 3+; resolution of pre-existing
+  quarantines is out of scope and tracked in #169. **Operators MUST
+  NOT execute direct `UPDATE ledger_request_credits SET quarantined=0`
+  SQL** — that violates the monotonic-quarantine schema invariant,
+  bypasses the §OQ-5 audit-log requirement, and risks crediting a row
+  that was legitimately quarantined for a non-row-3+ reason. The
+  current quarantine reason strings (per `internal/billing/recovery.go`
+  and `internal/billing/settlement.go`) include: `ambiguous_attempt_n`
+  (the row-3+ class — only attempts before v0.3.3 IMPL are now
+  affected), `missing_request_log`, `missing_provider_identity`,
+  `missing_config_snapshot`, `invalid_usage_tokens`,
+  `reconciliation_mismatch`, `operator_split_mismatch`, and
+  `conflicting_settlement_id` — only the first should ever be
+  candidates for an unquarantine flow; the others reflect real
+  invariant violations and MUST stay quarantined. Wait for #169.
+- **Acceptance.** On a backfilled deployment (`attempt_n` populated
+  everywhere) the quarantine count from the row-3+ class drops to
+  zero on a fresh nightly reconciliation pass. The v0.3.1 fallback
+  path and the v0.3.3 `attempt_n` path remain valid in IMPL code
+  during the migration window (no big-bang).
+- **Cross-spec.** Closes the SPEC-005 §OQ-1 long-tail item. The
+  §OQ-5 admin surface (force-credit / force-void) remains a
+  separate open item for the legitimate-retry-without-marker
+  ambiguity class (issue #169).
+- No new SPEC-002 indexes; `attempt_n` is a per-row ordinal, not a
+  join key. The SPEC-002 v1.5.1 per-key migration-state machine is
+  unchanged. SPEC-002 v1.5.2 adds a parallel **per-column** migration
+  state (`legacy | populating | populated`) for `attempt_n`,
+  observable via the new `coordinator backfill-attempt-n --check
+  --format json` subcommand.
 
 **Change log v0.3.2 (2026-06-29, issue #197 — SPEC-002 v1.5.1 dependency bump + per-key migration-state contract):**
 - Dependency bump: SPEC-002 v1.5.0 → v1.5.1 to absorb the per-key
@@ -127,7 +192,7 @@ This section implements the locked billing and unit decisions (D1)(D6) and the S
 - usage object has prompt_tokens, completion_tokens, total_tokens.
 - cancel usage is authoritative for v1.2.4+ providers.
 - SPEC-005 MUST NOT require new provider fields.
-**SPEC-002 v1.5.1:**
+**SPEC-002 v1.5.2:**
 - coordinator owns request_log and provider auth.
 - request_log is read-only to SPEC-005.
 - request_log carries deterministic `error_code` for SPEC-001 null-usage errors.
@@ -135,6 +200,7 @@ This section implements the locked billing and unit decisions (D1)(D6) and the S
 - per-key migration state `legacy | unindexed | indexed` is exposed by `coordinator migrate-indexes --check --format json`. SPEC-005 reconciliation tooling that performs **closing-the-books joins** between coordinator `request_log` and gateway `usage_events` / `audit_events` MUST consume this state and fail closed on any depended-on key in state `legacy` or `unindexed` (v0.3.2 / issue #197).
 - each provider attempt for a repeated request_id has its own request_log row.
 - request_log carries `account_id` (v1.5.0 / issue #211). The composite `(account_id, request_id)` is the grouping key for attempt-ordinal derivation; SQLite `IS` semantics preserve the pre-v1.5.0 grouping for legacy NULL-`account_id` rows.
+- request_log carries `attempt_n` (v1.5.2 / issue #168). Zero-based monotonic ordinal populated at INSERT time by the writer within the same `(account_id, request_id)` group. SPEC-005 v0.3.3 reads this directly when non-NULL; falls back to id-ASC derivation when NULL (legacy / rollout window). Both paths produce byte-identical ordinals.
 - FR-P11a supplies fault categories.
 - FR-P12 supplies provider bearer-token auth.
 - FR-R3 distinguishes stable provider_id from assigned_id.
@@ -282,12 +348,11 @@ Any change to D1-D12 requires operator review and a reopened SCOPE stage.
 
 SPEC-005 reads request_id, ts_utc, model, provider_assigned_id, prompt_tokens, completion_tokens, total_tokens, status, stream, error, error_code, provider_header, retried, and (v0.3.1) account_id.
 SPEC-005 never changes these columns.
-The D10 attempt_n need remains a future SPEC-002 patch candidate.
-Until attempt_n exists, v0.3.1 derives attempt ordinal by grouping rows that share the same `(account_id, request_id)` under SQLite `IS` semantics, then ordering each group by request_log.id ASC. Under `IS` a NULL-`account_id` row clusters with NULL-`account_id` rows only — it does NOT cluster with non-NULL rows that happen to share `request_id`. This preserves the pre-v0.3.1 intra-NULL grouping for legacy rows while keeping all three IMPL sites (hotpath.go, recovery.go, endpoints.go admin reconcile) consistent.
-Row 1 becomes attempt_n=0.
-Row 2 becomes attempt_n=1 only when request_log.retried indicates an explicit retry.
-Row 3+ MUST be quarantined until SPEC-002 gains monotonic attempt_n.
-If rows cannot be ordered uniquely within their `(account_id, request_id)` group, all ambiguous rows MUST be quarantined.
+**SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168):** the D10 `attempt_n` need is satisfied by `request_log.attempt_n` (monotonic, populated at INSERT time within each `(account_id, request_id)` group under SQLite `IS`). SPEC-005 reads `attempt_n` directly when non-NULL; falls back to the legacy id-ASC derivation when NULL (rollout window). Both paths produce byte-identical ordinals.
+
+Legacy fallback (NULL `attempt_n` only — pre-v1.5.2 rows OR rollback window): group rows that share the same `(account_id, request_id)` under SQLite `IS`, then order each group by `request_log.id ASC`. Under `IS` a NULL-`account_id` row clusters with NULL-`account_id` rows only — it does NOT cluster with non-NULL rows that happen to share `request_id`. Row 1 becomes `attempt_n=0`. Row 2 becomes `attempt_n=1` only when `request_log.retried` indicates an explicit retry. **Row 3+ in the fallback path is also assigned a stable monotonic ordinal (`attempt_n=2, 3, ...`) and is credited normally** — the prior v0.3.1 "row 3+ MUST be quarantined" rule is satisfied by the deterministic id-ASC derivation. Quarantining is reserved for the legitimate-retry-without-explicit-marker class (`attempt_n=1` with `retried=0`).
+
+If rows cannot be ordered uniquely within their `(account_id, request_id)` group (a SQLite invariant violation; should never occur because `id INTEGER PRIMARY KEY AUTOINCREMENT` is strictly monotonic), all ambiguous rows MUST be quarantined.
 SPEC-005 resolves stable provider_id through `ledger_provider_identity_snapshots`; it MUST NOT require ALTER request_log.
 
 ### 4.3 Table `ledger_request_credits`
@@ -692,11 +757,9 @@ Stable provider_id is the economic identity.
 
 ### 8.2 Derivation
 
-When SPEC-002 exposes attempt_n, copy it exactly.
-Until then, derive the fallback ordinal by grouping rows that share the same `(account_id, request_id)` under SQLite `IS` semantics, then ordering each group by request_log.id ASC. NULL-`account_id` rows cluster with NULL-`account_id` rows only; they do NOT cluster with non-NULL rows that happen to share `request_id`.
-The first ordered row uses attempt_n=0.
-The second ordered row uses attempt_n=1 only when request_log.retried indicates an explicit retry.
-The third and later ordered rows MUST be quarantined until SPEC-002 gains monotonic attempt_n.
+**SPEC-005 v0.3.3 (issue #168): prefer the persisted `request_log.attempt_n` exact match when non-NULL.** SPEC-002 v1.5.2 populates `attempt_n` monotonically at INSERT time within the same `(account_id, request_id)` group; the value is the canonical ordinal and MUST be copied directly into the ledger row.
+For legacy NULL-`attempt_n` rows (pre-SPEC-002-v1.5.2 OR rollback window), the fallback derivation is unchanged from v0.3.1: group rows by `(account_id, request_id)` under SQLite `IS`, order each group by `request_log.id ASC`. NULL-`account_id` rows cluster with NULL-`account_id` rows only. The first ordered row uses `attempt_n=0`; the second uses `attempt_n=1` only when `request_log.retried` indicates an explicit retry. The fallback arithmetic is byte-identical to the writer's INSERT-time COUNT, so backfilled and derivation-time ordinals match exactly.
+**Quarantine rules (v0.3.3):** the v0.3.1 "row 3+ MUST be quarantined" rule is satisfied in BOTH paths — the persisted monotonic `attempt_n` path AND the byte-identical id-ASC fallback path. Row 3+ in either path receives a stable `attempt_n=2, 3, ...` ordinal and is credited normally. The only remaining quarantine class is `attempt_n=1` with `retried=0` (legitimate retry without explicit marker) — operator resolution via SPEC-005 §OQ-5 force-credit / force-void (issue #169).
 If request_log.id cannot produce a unique order within an `(account_id, request_id)` group, all ambiguous rows in that group MUST be quarantined.
 Stable provider_id MUST be copied from `ledger_provider_identity_snapshots` when request_log only supplies provider_assigned_id.
 
@@ -709,7 +772,7 @@ No attempt may borrow tokens from another attempt.
 
 ### 8.4 Cross-spec patch
 
-SPEC-002 needs an attempt_n column or equivalent monotonic attempt ordinal.
+SPEC-002 needs an attempt_n column or equivalent monotonic attempt ordinal. **Closed in SPEC-002 v1.5.2 / SPEC-005 v0.3.3 (issue #168) — see §15.2 below.**
 SPEC-005 does not apply that patch.
 The operator must gate that patch in audit or v0.2 work.
 
@@ -797,7 +860,7 @@ If no config snapshot or provider identity snapshot can be selected for a provid
 
 Absent request_log join quarantines ledger rows.
 Inconsistent immutable math quarantines ledger rows.
-Ambiguous attempt_n fallback quarantines rows.
+Ambiguous `attempt_n=1` with `retried=0` (legitimate retry without explicit marker) quarantines rows. (v0.3.3: row 3+ is no longer in this class — see §15.2.)
 Quarantine is review, not deletion.
 Quarantined rows are exposed in admin endpoints.
 
@@ -1062,12 +1125,15 @@ Use byte-estimation fallback only when usage is absent.
 Use the same estimate as SPEC-006 v0.9.1 section  17.7 buyer debit: `ceil(bytes_emitted_so_far / 4)`.
 Set usage_source=byte_estimated.
 
-### 15.2 attempt_n fallback
+### 15.2 attempt_n derivation
 
-Before the SPEC-002 monotonic attempt_n patch, rows are grouped by `(account_id, request_id)` (using SQLite `IS` so legacy NULL-account_id rows cluster identically to pre-v0.3.1 behavior) and ordered within each group by request_log.id ASC. (v0.3.1 / SPEC-002 v1.5.0 / issue #211.)
-No-retry and one explicit retry are supported before SPEC-002 patch.
-Row 3+, non-explicit retry row 2, and non-unique ordering within an `(account_id, request_id)` group are quarantined.
-section  20 surfaces the patch.
+**SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168) — current rule:** the canonical attempt ordinal is `request_log.attempt_n` (populated at INSERT time by the writer as `COUNT(*) FROM request_log WHERE account_id IS ? AND request_id = ?` within the same writer transaction). Read-side consumers (SPEC-005 §8.2, §10.4, §15.2 itself) MUST copy `request_log.attempt_n` directly when non-NULL.
+
+**Legacy fallback (v0.3.1 / SPEC-002 v1.5.0 / issue #211) — retained for the v1.5.2 rollout window:** when `request_log.attempt_n IS NULL` (pre-v1.5.2 row OR rollback window), rows are grouped by `(account_id, request_id)` (using SQLite `IS` so legacy NULL-`account_id` rows cluster identically to pre-v0.3.1 behavior) and ordered within each group by `request_log.id ASC`. The first ordered row maps to `attempt_n=0`; the second to `attempt_n=1` only with explicit `retried` semantics; the third and later receive `attempt_n=2, 3, ...` from the same deterministic id-ASC arithmetic and are credited normally — byte-identical to what the writer would have persisted under v1.5.2.
+
+**Migration acceptance:** on a backfilled deployment (operator has run `backfill-attempt-n` and `--check` reports `populated`), the legacy fallback path is unreachable in steady state but remains in IMPL code as a defense against future schema-rollback windows. Both paths produce byte-identical ordinals because the writer's INSERT-time COUNT and the fallback's read-time COUNT compute the same value over the same row set.
+
+The only steady-state quarantine class under v0.3.3 is `attempt_n=1` with `retried=0` (legitimate retry without explicit marker), resolved via the SPEC-005 §OQ-5 admin surface (issue #169).
 
 ### 15.3 Unknown models
 
@@ -1218,7 +1284,7 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 
 **Traceability verification:** Parse section  2 and locate D10; then locate at least one later normative reference.
 **Behavior verification:** Seed two rows that share the same `(account_id, request_id)` group, ordered by request_log.id ASC, plus matching provider identity snapshots. (Legacy fixtures may use NULL `account_id` on both rows; SQLite `IS` clusters NULLs.)
-**Expected:** D10 exists in section  2, is enforced outside section  2, rows receive distinct attempt_n/provider_id keys, row 2 is accepted only with explicit retried semantics, and row 3+ or ambiguous ordering is quarantined.
+**Expected:** D10 exists in section  2, is enforced outside section  2, rows receive distinct `attempt_n`/`provider_id` keys (`attempt_n=0, 1, 2, ...` monotonically from `request_log.attempt_n` when populated, or from the byte-identical id-ASC fallback when NULL), row 2 is accepted only with explicit `retried` semantics (else quarantined), and row 3+ is credited normally under SPEC-005 v0.3.3 / SPEC-002 v1.5.2.
 **Network:** Not required.
 **State reset:** Fresh fixture database or pure-function input.
 
@@ -1331,8 +1397,8 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 
 ### AC-ATTEMPT-FALLBACK: retried fallback limit
 
-**Verification:** Fixture three rows before attempt_n patch, all sharing the same `(account_id, request_id)` group under SQLite `IS` clustering (legacy NULL-`account_id` fixtures cluster identically among themselves).
-**Expected:** Within each `(account_id, request_id)` group, `request_log.id ASC` assigns row 1 to attempt_n=0; row 2 becomes attempt_n=1 only with explicit retried semantics; row 3+ is quarantined.
+**Verification:** Fixture three rows sharing the same `(account_id, request_id)` group under SQLite `IS` clustering (legacy NULL-`account_id` fixtures cluster identically among themselves). One fixture variant pre-populates `request_log.attempt_n` (post-v1.5.2 schema); a second variant leaves `attempt_n` NULL to exercise the id-ASC fallback derivation.
+**Expected:** Both fixtures produce identical ordinals: row 1 → `attempt_n=0`; row 2 → `attempt_n=1` accepted only with explicit `retried` semantics (else quarantined as legitimate-retry-without-marker); row 3 → `attempt_n=2` credited normally (per SPEC-005 v0.3.3 / SPEC-002 v1.5.2). The persisted-attempt_n path and the id-ASC fallback path are byte-identical.
 **Network:** Not required.
 **State reset:** Fresh fixture database or pure-function input.
 
@@ -1525,8 +1591,7 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 
 ### OQ-1: SPEC-002 attempt_n patch
 
-SPEC-005 v0.3.1 permits the quarantining fallback: rows are grouped by `(account_id, request_id)` (SQLite `IS` for the NULL-NULL legacy case) and ordered within each group by request_log.id ASC; row 1 maps to attempt_n=0, row 2 maps to attempt_n=1 only with explicit retried semantics, and row 3+ or ambiguous ordering within a group is quarantined.
-A future SPEC-002 monotonic attempt_n remains a cross-spec patch candidate, not a SPEC-005 v0.3 launch blocker.
+**RESOLVED in SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168, 2026-06-29).** `request_log.attempt_n` is now the canonical monotonic ordinal, populated at INSERT time within `(account_id, request_id)` groups under SQLite `IS`. SPEC-005 reads it directly when non-NULL; falls back to the byte-identical id-ASC derivation when NULL (rollout window). Row 3+ is credited normally; the only steady-state quarantine class is `attempt_n=1` with `retried=0`, deferred to §OQ-5 admin surface (issue #169).
 
 ### OQ-2: Rounding rule acceptance
 
@@ -2327,7 +2392,7 @@ SPEC-005 exposes quarantine but does not define force-credit or force-void admin
 
 - Claim: Multi-provider attribution encoded.
 - Setup: Parse section  2 and later D10 references; seed rows sharing the same `(account_id, request_id)` group, ordered by request_log.id ASC, plus identity snapshots. (Legacy fixtures may use NULL account_id; SQLite `IS NULL` clusters NULLs identically to the v0.3 pre-account-scope behavior.)
-- Oracle: D10 exists in section  2, is enforced outside section  2, rows receive distinct attempt_n/provider_id keys, row 2 requires explicit retry semantics, and row 3+ or ambiguous order within an `(account_id, request_id)` group quarantines.
+- Oracle: D10 exists in section  2, is enforced outside section  2, rows receive distinct `attempt_n`/`provider_id` keys (monotonic 0, 1, 2, ... from `request_log.attempt_n` when populated, byte-identical id-ASC fallback when NULL), row 2 requires explicit `retried` semantics (else quarantined), and row 3+ is credited normally under SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168).
 - Live network: forbidden.
 - Failure handling: failing this fixture blocks claiming SPEC-005 implementation complete.
 
@@ -2454,8 +2519,8 @@ SPEC-005 exposes quarantine but does not define force-credit or force-void admin
 ### AC-ATTEMPT-FALLBACK fixture detail
 
 - Claim: retried fallback limit.
-- Setup: Fixture three rows before attempt_n patch, all sharing the same `(account_id, request_id)` group under SQLite `IS` clustering.
-- Oracle: Ambiguous row within an `(account_id, request_id)` group is quarantined.
+- Setup: Fixture three rows sharing the same `(account_id, request_id)` group under SQLite `IS` clustering. One variant uses persisted `request_log.attempt_n=0,1,2` (post-v1.5.2); a second variant leaves `attempt_n` NULL to exercise the id-ASC fallback. Set `retried=1` on row 2 to avoid the legitimate-retry-without-marker quarantine class.
+- Oracle: Both variants produce identical credit rows for `attempt_n=0, 1, 2`. Row 3 (`attempt_n=2`) is credited normally under SPEC-005 v0.3.3 / SPEC-002 v1.5.2 — the v0.3.1 row-3+ quarantine is satisfied by both the persisted column and the byte-identical fallback derivation. The only quarantine class that remains is `attempt_n=1` with `retried=0`.
 - Live network: forbidden.
 - Failure handling: failing this fixture blocks claiming SPEC-005 implementation complete.
 

--- a/specs/SPEC-007-explorer-design.md
+++ b/specs/SPEC-007-explorer-design.md
@@ -190,9 +190,8 @@ summaries.  - Join to SPEC-005 ledger rows on coordinator-internal `request_id`.
 
 Gaps:
 
-- **[GAP]** No coordinator-side `key_id`.  - **[GAP]** No stored
-`attempt_n`; SPEC-005 derives attempt order from
-  `(request_id, id)`.
+- **[GAP]** No coordinator-side `key_id`.
+- **[GAP-CLOSED]** Stored `attempt_n` added in SPEC-002 v1.5.2 / issue #168 — monotonic ordinal populated at INSERT time within `(account_id, request_id)` groups. SPEC-005 v0.3.3 reads it directly when non-NULL; legacy NULL rows fall back to byte-identical id-ASC derivation.
 - **[GAP]** No durable in-flight request table.  - **[GAP]** No request body digest or response byte count.
 
 ### 2.4 Coordinator provider token table
@@ -565,8 +564,9 @@ quarantined flag.  - quarantine reason.  - quota reservation status.  - gateway 
 
 Gaps:
 
-- **[GAP]** Attempt number is derived unless stored later.  - **[GAP]** Account ID requires gateway join.  - **[GAP]**
-In-flight request visibility requires new live state.
+- **[GAP-CLOSED]** Attempt number is stored as `request_log.attempt_n` (SPEC-002 v1.5.2 / issue #168) — monotonic ordinal populated at INSERT time within `(account_id, request_id)` groups.
+- **[GAP]** Account ID requires gateway join.
+- **[GAP]** In-flight request visibility requires new live state.
 
 ### 3.5 Buyers
 


### PR DESCRIPTION
## Summary

Closes #168 — the last unresolved billing-side open question (SPEC-005 §OQ-1)
from the 2026-06-26 ledger triage. Adds a monotonic `request_log.attempt_n`
column populated at INSERT time; SPEC-005 v0.3.3 promotes its row-mapping rule
to "prefer the persisted column, fall back to the byte-identical v0.3.1 id-ASC
derivation for legacy NULL rows during the rollout window".

The v0.3.1 quarantine rule "row 3+ MUST quarantine until SPEC-002 gains
monotonic attempt_n" is now satisfied — row 3+ in BOTH the persisted path AND
the byte-identical id-ASC fallback receives a stable `attempt_n=2, 3, ...`
ordinal and is credited normally. The only remaining quarantine class is
`attempt_n=1` with `retried=0` (legitimate retry without explicit marker),
deferred to SPEC-005 §OQ-5 admin surface (issue #169).

## What changed

**SPEC-002 v1.5.2** (`specs/SPEC-002-coordinator.md`):
- New `request_log.attempt_n INTEGER NULL` column (zero-based monotonic
  ordinal within `(account_id, request_id)` IS-clustered groups).
- Write-time population semantics: INSERT does
  `COUNT(*) FROM request_log WHERE account_id IS ? AND request_id = ?`
  in the same writer transaction; new row receives that count.
  Race-free under the held-conn pattern.
- Per-column migration state machine: `legacy | populating | populated`.
- New CLI: `coordinator backfill-attempt-n [--check] [--dry-run]
  [--format text|json]`. `--dry-run` runs the UPDATE inside
  BEGIN IMMEDIATE + ROLLBACK to measure wall-clock against the 6s
  hot-path INSERT budget; emits WARNING at 4s (75%).
- Money-path read-side discipline (renamed paragraph): all three sites
  read persisted `attempt_n` when non-NULL, fall back to the v1.5.0
  COUNT only when NULL.
- Quarantine rule narrowed to `attempt_n=1` with `retried=0` only.

**SPEC-005 v0.3.3** (`specs/SPEC-005-billing.md`):
- Dependency bump SPEC-002 v1.5.1 → v1.5.2.
- 8+ SPEC sections updated to describe the v0.3.3 contract (row 3+
  credited in both paths; only legitimate-retry-without-marker
  quarantined).
- Pre-existing v0.3.1 quarantine rows are immutable per ledger schema;
  resolution requires §OQ-5 admin surface (#169).
- Explicit ban on direct SQL `UPDATE quarantined=0` with full
  enumeration of the 8 quarantine reason strings + risks.

**SPEC-007 design notes**: stored-attempt-n GAPs in §2.3 and §3.4 both
updated to `[GAP-CLOSED]` pointing at SPEC-002 v1.5.2 / #168.

**Coordinator IMPL** (`phase4-coordinator/`):
- `internal/requestlog/store.go`:
  - `Row.AttemptN *int` field + schema column + ensureColumns migration.
  - `insert()` reworked to COUNT-then-INSERT in the same connection.
  - `Store.Insert` race fix: held-`*sql.Conn` pattern.
  - `AttemptNState(ctx)` + `BackfillAttemptN(ctx)` (ROW_NUMBER window
    function over PARTITION BY account_id, request_id) +
    `BackfillAttemptNDryRun(ctx)` (same UPDATE wrapped in
    BEGIN IMMEDIATE + ROLLBACK).
- `internal/billing/hotpath.go` + `recovery.go` + `endpoints.go`:
  quarantine rule narrowed; read-side `COALESCE(rl.attempt_n,
  id_asc_count_fallback)` in recovery and endpoints.
- `cmd/coordinator/backfill_attempt_n.go`: new subcommand.

## Regression tests

- `TestInsertPopulatesMonotonicAttemptN`: 3 rows in same group →
  `attempt_n=0,1,2`; new account → new group at 0; NULL-account →
  separate group at 0 (v1.5.0 IS preserved).
- `TestBackfillAttemptNPopulatesLegacyNullRows`: legacy NULL → backfill
  → `[0,1,2]` + state transition + idempotence.
- `TestBackfillAttemptNHandlesMixedRolloutState`: mixed
  `[populated=0, NULL, NULL]` → backfill assigns `1, 2` to NULL rows
  while preserving the populated one.
- `TestInsertConcurrentSameGroupProducesMonotonicAttemptN`: 16
  goroutines under the held-conn pattern produce distinct
  `attempt_n ∈ [0,15]`. Verified clean under `go test -race`.
- `TestWriteHotPath_ThirdDerivedAttemptIsCreditedUnderMonotonicAttemptN`:
  was `IsAlwaysQuarantined`; inverted assertion.
- `TestRecoverLedger_CreditsExistingThirdAttemptUnderMonotonicAttemptN`:
  was `QuarantinesExistingThirdAttempt`; rewritten to seed via
  WriteHotPath so credits match the rate card.

## Audit trail

Four rounds of three-lane codex audit (code converged at R3; security +
architect at R4). Prompts in `specs/AUDIT_ISS_168_R{1..4}_*.md`;
round-by-round disposition in `specs/SPEC-002-v1-5-2-audit.md`.

Key findings closed:
- R1 CODE CRITICAL: `Store.Insert` race (SetMaxOpenConns(1) didn't
  prevent multi-call interleaving) — held-conn fix + concurrent test.
- R1 ARCHITECT CRITICAL + R1 SECURITY HIGH (convergent): 5+ stale
  "row 3+ MUST quarantine" references across SPEC-005 + hotpath.go +
  recovery.go still implementing the old rule.
- R1 ARCHITECT HIGH: legacy-quarantine resolution claim contradicted
  ledger immutability — rewritten honestly with #169 cross-link.
- R3 SECURITY MEDIUM: backfill preflight not operator-actionable —
  `--dry-run` added.

## Test plan

- [ ] Review `phase4-coordinator/internal/requestlog/store.go::insert`
      and `Store.Insert` for the held-conn race fix.
- [ ] Review the read-side `COALESCE(rl.attempt_n, fallback)` in
      `recovery.go` and `endpoints.go`.
- [ ] Review the quarantine narrowing in `hotpath.go` and
      `recovery.go`.
- [ ] Verify `coordinator backfill-attempt-n --check --format json`
      and `--dry-run` work against a real Pearl-deploy DB.
- [ ] Confirm the operator runbook (SPEC-002 §11 backfill live-safety
      paragraph) is actionable for the deploy team.

Closes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
