### PR TITLE
fix(harness): I1 matcher uses exact request_id + account_id consensus, two-pass

### DIFF
--- a/phase4-coordinator/internal/buyer/receipt_keys_test.go
+++ b/phase4-coordinator/internal/buyer/receipt_keys_test.go
@@ -106,15 +106,21 @@ func TestReceiptKeysReturnsPreviousKeyInGraceWindow(t *testing.T) {
 	registry := pool.NewRegistry(nil)
 	current := bytes.Repeat([]byte{0x42}, 32)
 	previous := bytes.Repeat([]byte{0x43}, 32)
-	rotatedAt := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
-	expiresAt := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
-	registerReceiptKeyProvider(registry, "p1", current, &pool.ReceiptPubkeyPrevious{
+	// Anchor times to `frozen` and register via the time-aware
+	// RegisterAt to keep the test independent of real wall clock.
+	// Originally rotatedAt/expiresAt were hardcoded calendar dates and
+	// registerReceiptKeyProvider() called time.Now() internally; once
+	// real time passed expiresAt the registry filtered the previous
+	// key at registration time, before server.now ever ran (#240).
+	frozen := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	rotatedAt := frozen.Add(-24 * time.Hour)    // 1 day before frozen
+	expiresAt := frozen.Add(6 * 24 * time.Hour) // 6 days after frozen — in grace window
+	registerReceiptKeyProviderAt(registry, "p1", current, &pool.ReceiptPubkeyPrevious{
 		Pubkey:    previous,
 		RotatedAt: rotatedAt,
 		ExpiresAt: expiresAt,
-	})
+	}, frozen)
 	server := NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0))
-	frozen := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
 	server.now = func() time.Time { return frozen }
 
 	rr := serveReceiptKeys(server, "p1", "198.51.100.2:12345")
@@ -301,6 +307,39 @@ func serveReceiptKeys(server *Server, providerID, remoteAddr string) *httptest.R
 	rr := httptest.NewRecorder()
 	server.Handler().ServeHTTP(rr, req)
 	return rr
+}
+
+// registerReceiptKeyProviderAt is the time-aware variant of
+// registerReceiptKeyProvider for tests that need a controlled clock
+// (e.g. grace-window assertions whose expiresAt would otherwise drift
+// past wall-clock time — #240).
+func registerReceiptKeyProviderAt(registry *pool.Registry, providerID string, receiptPubkey []byte, prev *pool.ReceiptPubkeyPrevious, now time.Time) {
+	assignedID := providerID + "-session"
+	registry.RegisterAt(&pool.Provider{
+		ProviderID:            providerID,
+		AssignedID:            assignedID,
+		Hostname:              providerID + ".local",
+		ModelID:               "model-a",
+		ModelParamsB:          7,
+		RAMGB:                 16,
+		MaxContextTokens:      20000,
+		MaxConcurrency:        1,
+		SlotsFree:             1,
+		SlotsTotal:            1,
+		ThroughputTPSEstimate: 20,
+		EndpointURL:           "https://" + providerID + ".example",
+		Tier:                  pool.TierPinned,
+		InferencePath:         pool.InferencePathHTTPForwarding,
+		State:                 pool.StateReady,
+		LastHeartbeatAt:       now,
+		LastActivityAt:        now,
+		ConnectedAt:           now,
+		BinaryVersion:         "0.1.0",
+		ReceiptPubkey:         append([]byte(nil), receiptPubkey...),
+		ReceiptPubkeyPrev:     cloneTestReceiptPubkeyPrevious(prev),
+	}, nil, now)
+	slotsFree := 1
+	registry.ApplyStateUpdate(providerID, assignedID, pool.StateUpdate{State: pool.StateReady, SlotsFree: &slotsFree, At: now})
 }
 
 func registerReceiptKeyProvider(registry *pool.Registry, providerID string, receiptPubkey []byte, prev *pool.ReceiptPubkeyPrevious) {

--- a/test/network-harness/cmd/harness/main.go
+++ b/test/network-harness/cmd/harness/main.go
@@ -137,9 +137,23 @@ func cmdRun(args []string) error {
 	hasRemoteDBs := sc.Target.CoordinatorDBSSH != "" && sc.Target.GatewayDBSSH != ""
 	switch {
 	case hasLocalDBs || hasRemoteDBs:
+		// Money-path gate: when DBs are configured, the harness asked
+		// for reconciliation. If reconcile.Run errors (DB schema
+		// mismatch, snapshot fetch failure, etc.) we must NOT silently
+		// produce a partial artifact and let invariants run with
+		// ledger=nil — checkI1 would then SKIP, producing a green
+		// run that hides drift. The sentinel ledger sets ReconcileError,
+		// which checkI1 treats as a hard fail signal independent of
+		// the per-pair drift signals.
 		ledger, err = reconcile.Run(sc, results, meta.StartUTC, meta.EndUTC)
 		if err != nil {
-			log.Printf("reconcile: %v (continuing with partial artifact)", err)
+			log.Printf("reconcile: %v (failing I1 closed)", err)
+			ledger = &reconcile.Result{
+				DriftBasis:     "per_matched_pair_v2",
+				WindowStartUTC: meta.StartUTC,
+				WindowEndUTC:   meta.EndUTC,
+				ReconcileError: err.Error(),
+			}
 		}
 	default:
 		log.Printf("reconcile: skipped (no coordinator_db_path/_ssh and gateway_db_path/_ssh in target)")

--- a/test/network-harness/internal/invariants/hard.go
+++ b/test/network-harness/internal/invariants/hard.go
@@ -93,6 +93,15 @@ func checkI1(ledger *reconcile.Result) Check {
 		c.Detail = "reconciliation skipped: target.coordinator_db_path / _ssh not configured"
 		return c
 	}
+	// Fail-closed: reconcile.Run errored. Even if every drift signal
+	// below would be zero, the audit pipeline must NOT silently pass
+	// when reconciliation didn't actually run. R3 audit code HIGH.
+	if ledger.ReconcileError != "" {
+		c.Passed = false
+		c.EvidenceCount = 1
+		c.Detail = "reconcile errored: " + ledger.ReconcileError
+		return c
+	}
 
 	// I1 reads matched-pair drift produced by the reconciler under
 	// drift_basis="per_matched_pair_v2" (#226 + #229 R2). Five signals:
@@ -110,6 +119,11 @@ func checkI1(ledger *reconcile.Result) Check {
 	unmatchedGwOK := len(ledger.UnmatchedGatewayOKRows)
 	unmatchedCoord2xx := len(ledger.UnmatchedCoordinator2xxRows)
 	coordMissingOK := len(ledger.MatchedCoordMissing)
+	// Ambiguity — ≥2 exact-id candidates within window+account after
+	// the matcher's filters. Hard I1 signal (PK collision evidence
+	// across accounts, or duplicate settlements within one account).
+	ambiguousGw := len(ledger.AmbiguousExactGatewayIDs)
+	ambiguousCoord := len(ledger.AmbiguousExactCoordIDs)
 
 	driftSignals := 0
 	if unmatched > 0 {
@@ -128,6 +142,12 @@ func checkI1(ledger *reconcile.Result) Check {
 		driftSignals++
 	}
 	if absGwCoordMismatch > 0 {
+		driftSignals++
+	}
+	if ambiguousGw > 0 {
+		driftSignals++
+	}
+	if ambiguousCoord > 0 {
 		driftSignals++
 	}
 
@@ -159,6 +179,12 @@ func checkI1(ledger *reconcile.Result) Check {
 	if absGwCoordMismatch > 0 {
 		parts = append(parts, fmt.Sprintf("gateway-coord ledger mismatch %d tokens across %d pair(s)", absGwCoordMismatch, len(ledger.GatewayCoordMismatchedPairs)))
 	}
+	if ambiguousGw > 0 {
+		parts = append(parts, fmt.Sprintf("%d gateway exact-id ambiguities (id collision within window+account)", ambiguousGw))
+	}
+	if ambiguousCoord > 0 {
+		parts = append(parts, fmt.Sprintf("%d coord exact-id ambiguities", ambiguousCoord))
+	}
 	c.Detail = strings.Join(parts, "; ")
 	c.OffendingIDs = append(c.OffendingIDs, ledger.UnmatchedSuccesses...)
 	c.OffendingIDs = append(c.OffendingIDs, ledger.UnmatchedGatewayOKRows...)
@@ -166,6 +192,8 @@ func checkI1(ledger *reconcile.Result) Check {
 	c.OffendingIDs = append(c.OffendingIDs, ledger.OverbilledPairs...)
 	c.OffendingIDs = append(c.OffendingIDs, ledger.MatchedCoordMissing...)
 	c.OffendingIDs = append(c.OffendingIDs, ledger.GatewayCoordMismatchedPairs...)
+	c.OffendingIDs = append(c.OffendingIDs, ledger.AmbiguousExactGatewayIDs...)
+	c.OffendingIDs = append(c.OffendingIDs, ledger.AmbiguousExactCoordIDs...)
 	return c
 }
 

--- a/test/network-harness/internal/invariants/hard_test.go
+++ b/test/network-harness/internal/invariants/hard_test.go
@@ -154,6 +154,60 @@ func TestCheckI1_NetZeroButHiddenOverbill_Fails(t *testing.T) {
 	}
 }
 
+// TestCheckI1_ReconcileError_Fails is the R3 audit code HIGH
+// regression: when reconcile.Run errored, the harness sets
+// ReconcileError. I1 must hard-fail on that signal independently of
+// the drift counters, otherwise a snapshot-failure run with zero
+// successes (and zero per-pair signals) would pass green.
+func TestCheckI1_ReconcileError_Fails(t *testing.T) {
+	ledger := &reconcile.Result{
+		ReconcileError: "coordinator query: no such column: account_id",
+	}
+	c := checkI1(ledger)
+	if c.Passed {
+		t.Fatal("reconcile error must fail I1 closed")
+	}
+	if c.Skipped {
+		t.Fatal("reconcile error must FAIL, not SKIP — fail-closed money-path gate")
+	}
+	if !strings.Contains(c.Detail, "reconcile errored") {
+		t.Errorf("detail should call out reconcile error: %s", c.Detail)
+	}
+}
+
+// TestCheckI1_AmbiguousExactGatewayIDs_Fails is the R2 audit HIGH
+// regression: ambiguous exact-id MUST fail I1, not silently fall to
+// fuzzy. Even one ambiguous id is hard evidence of cross-account PK
+// collision or duplicate settlement.
+func TestCheckI1_AmbiguousExactGatewayIDs_Fails(t *testing.T) {
+	ledger := &reconcile.Result{
+		AmbiguousExactGatewayIDs: []string{"AMBIG_GW"},
+	}
+	c := checkI1(ledger)
+	if c.Passed {
+		t.Fatal("ambiguous exact-id must fail I1")
+	}
+	if !contains(c.OffendingIDs, "AMBIG_GW") {
+		t.Errorf("offending ids should include ambiguous id, got %v", c.OffendingIDs)
+	}
+	if !strings.Contains(c.Detail, "ambiguities") {
+		t.Errorf("detail should call out ambiguity, got: %s", c.Detail)
+	}
+}
+
+func TestCheckI1_AmbiguousExactCoordIDs_Fails(t *testing.T) {
+	ledger := &reconcile.Result{
+		AmbiguousExactCoordIDs: []string{"AMBIG_COORD"},
+	}
+	c := checkI1(ledger)
+	if c.Passed {
+		t.Fatal("ambiguous coord exact-id must fail I1")
+	}
+	if !contains(c.OffendingIDs, "AMBIG_COORD") {
+		t.Errorf("offending should include ambiguous coord id, got %v", c.OffendingIDs)
+	}
+}
+
 func contains(s []string, want string) bool {
 	for _, v := range s {
 		if v == want {

--- a/test/network-harness/internal/reconcile/ledger.go
+++ b/test/network-harness/internal/reconcile/ledger.go
@@ -1,12 +1,25 @@
 // Package reconcile compares the harness's per-request observations
 // against the coordinator's request_log and the gateway's usage_events.
 //
-// IMPORTANT: gateway and coordinator each generate their OWN request_id
-// (verified live 2026-06-27 — gateway returns UUID X to buyer, coord
-// writes UUID Y in request_log; X and Y never overlap). Correlation by
-// request_id is therefore impossible across the two sides. We instead
-// correlate by (model, completion_tokens, ts ± window) and report
-// drift at both per-request and aggregate level.
+// Cross-service request_id semantics:
+//   - Gateway's usage_events.request_id is the gateway-issued PK.
+//     The gateway echoes it back to the buyer via the X-Request-Id
+//     response header, so the harness records it as
+//     buyer.Result.RequestID (loadgen.go:199).
+//   - Coordinator's request_log.request_id is INTERNAL and not
+//     correlatable across services. The gateway-issued id is
+//     persisted on coord side as
+//     request_log.external_request_id (phase4-coordinator/internal/
+//     requestlog/store.go:38-46).
+//
+// matchPairs uses exact id correlation when available:
+//   - gateway: buyer.Result.RequestID == gateway.usage_events.request_id
+//   - coord:   buyer.Result.RequestID == coord.request_log.external_request_id
+//
+// Falls back to fuzzy (completion_tokens, ts ± window) match when no
+// exact-id candidate is found, or when an exact-id hit is ambiguous
+// (multiple candidates from the gateway's composite
+// `(account_id, request_id)` PK; #229 R3).
 //
 // Phase A goals (what I1 actually catches):
 //   - "harness success but gateway/coord has no matching row" — billing
@@ -29,6 +42,22 @@ import (
 	"github.com/augstar/macprovider-network-harness/internal/scenario"
 
 	_ "modernc.org/sqlite"
+)
+
+// matchWindow is the per-request temporal tolerance for accepting a
+// candidate row as a match for a harness observation. Used by both
+// exact-id and fuzzy paths so they cannot silently diverge. The
+// reconciler's SQL snapshot pads the run window by 30s; this tighter
+// per-request window further constrains which rows are eligible.
+const matchWindow = 60 * time.Second
+const matchWindowMs = int64(matchWindow / time.Millisecond)
+
+// Match-method labels persisted on MatchedPair. Kept as private
+// typed-string consts so tests and future helpers can reference them
+// without retyping the literal.
+const (
+	methodExactID = "exact_id"
+	methodFuzzy   = "fuzzy_token_ts"
 )
 
 type Result struct {
@@ -132,22 +161,65 @@ type Result struct {
 	AbsGatewayCoordinatorMismatchTokens int64    `json:"abs_gateway_coordinator_mismatch_tokens"`
 	GatewayCoordMismatchedPairs         []string `json:"gateway_coord_mismatched_pairs,omitempty"`
 
+	// HarnessAccountID is the account_id consensus from the first
+	// exact-id gateway hit. The harness is one buyer = one account, but
+	// the gateway/coord DBs contain rows for every buyer; the consensus
+	// pins the matcher to that account and prevents a foreign-account
+	// row from consuming a match by id collision alone. Empty when no
+	// row carried a non-empty account_id (legacy snapshot).
+	HarnessAccountID string `json:"harness_account_id,omitempty"`
+
+	// Schema flags from the snapshot's PRAGMA table_info probe.
+	// When true, queryGateway / queryCoordinator confirmed the
+	// column exists, so the matcher must treat per-row blanks as
+	// missing data rather than "legacy noop". When false, the column
+	// is absent from the whole snapshot (pre-migration) — the matcher
+	// relaxes the account constraint to maintain rollout compatibility.
+	GatewayHasAccountID bool `json:"gateway_has_account_id,omitempty"`
+	CoordHasAccountID   bool `json:"coord_has_account_id,omitempty"`
+
+	// ReconcileError records a fatal error during reconciliation when
+	// the harness configured DBs but couldn't reach them or query them.
+	// I1 hard-fails when this is non-empty even if every other drift
+	// signal is zero — the audit pipeline must not silently pass when
+	// it didn't actually reconcile. Distinct from `Notes`, which is
+	// soft-signal triage detail.
+	ReconcileError string `json:"reconcile_error,omitempty"`
+
+	// AmbiguousExactGatewayIDs holds harness request_ids where the
+	// gateway exact-id pool returned ≥2 candidates after window +
+	// account filters. Treated as a HARD I1 signal — the matcher does
+	// NOT fall back to unrestricted fuzzy on ambiguity. Either the
+	// gateway echoed a colliding id (PK collision across accounts) or
+	// the snapshot somehow contains two settled rows for the same id;
+	// both demand triage rather than silent attribution.
+	AmbiguousExactGatewayIDs []string `json:"ambiguous_exact_gateway_ids,omitempty"`
+	AmbiguousExactCoordIDs   []string `json:"ambiguous_exact_coord_ids,omitempty"`
+
 	// Notes records discoveries that don't fit a drift count but matter
 	// for triage — e.g. extra rows attributable to background traffic.
 	Notes []string `json:"notes,omitempty"`
 }
 
-// MatchedPair records a fuzzy match between a harness request and the
-// gateway+coordinator rows it most likely produced. Phase B triage uses
-// these to spot patterns (large ts gaps, persistent token drift, etc.).
+// MatchedPair records a matched pair (harness ↔ gateway[, coord]).
+// matchPairs tries exact-id correlation first and falls back to a
+// token+ts fuzzy heuristic; GatewayMatchMethod / CoordinatorMatchMethod
+// record which path produced each side. Phase B triage uses these to
+// spot patterns (a run dominated by fuzzy matches signals a
+// header-propagation issue; a `gateway_lag_ms` outlier on a fuzzy match
+// signals attribution drift).
 type MatchedPair struct {
 	HarnessRequestID            string `json:"harness_request_id"`
 	HarnessCompletionTokens     int64  `json:"harness_completion_tokens"`
 	GatewayRequestID            string `json:"gateway_request_id"`
+	GatewayAccountID            string `json:"gateway_account_id,omitempty"`
 	GatewayCompletionTokens     int64  `json:"gateway_completion_tokens"`
 	GatewayOutcome              string `json:"gateway_outcome"` // "ok" or SPEC-006 §17.7 fallback name; distinguishes coord-missing severity
+	GatewayMatchMethod          string `json:"gateway_match_method,omitempty"` // "exact_id" | "fuzzy_token_ts"
 	CoordinatorRequestID        string `json:"coordinator_request_id,omitempty"`
+	CoordinatorAccountID        string `json:"coordinator_account_id,omitempty"`
 	CoordinatorCompletionTokens int64  `json:"coordinator_completion_tokens"`
+	CoordinatorMatchMethod      string `json:"coordinator_match_method,omitempty"` // "exact_id" | "fuzzy_token_ts"
 	GatewayLagMs                int64  `json:"gateway_lag_ms"`
 }
 
@@ -186,14 +258,16 @@ func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Ti
 	}
 	defer cleanupG()
 
-	coordRows, err := queryCoordinator(coordPath, winStart, winEnd)
+	coordRows, coordHasAcct, err := queryCoordinator(coordPath, winStart, winEnd)
 	if err != nil {
 		return r, fmt.Errorf("coordinator query: %w", err)
 	}
-	gwRows, err := queryGateway(gwPath, winStart, winEnd)
+	gwRows, gwHasAcct, err := queryGateway(gwPath, winStart, winEnd)
 	if err != nil {
 		return r, fmt.Errorf("gateway query: %w", err)
 	}
+	r.GatewayHasAccountID = gwHasAcct
+	r.CoordHasAccountID = coordHasAcct
 
 	r.CoordinatorRows = len(coordRows)
 	for _, c := range coordRows {
@@ -222,7 +296,7 @@ func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Ti
 	}
 
 	r.DriftBasis = "per_matched_pair_v2"
-	leftoverGw, leftoverCoord := matchByFuzzy(r, results, gwRows, coordRows)
+	leftoverGw, leftoverCoord := matchPairs(r, results, gwRows, coordRows)
 	computePerPairDrift(r)
 	collectUnmatchedGatewayOK(r, leftoverGw)
 	collectUnmatchedCoord2xx(r, leftoverCoord)
@@ -317,14 +391,14 @@ func computePerPairDrift(r *Result) {
 }
 
 // collectUnmatchedGatewayOK lists gateway rows with outcome="ok" that
-// matchByFuzzy did NOT consume into a MatchedSuccesses pair. These are
+// matchPairs did NOT consume into a MatchedSuccesses pair. These are
 // either orphan gateway settlements (real bugs — gateway billed for a
 // request the harness never fired) or concurrent background traffic
 // from other buyers. Triage decides. Fallback-outcome leftovers are
 // EXCLUDED because they are noisy on a live network where streams can
 // truncate without involving the harness.
 //
-// IMPORTANT: this takes the leftover gwPool returned by matchByFuzzy,
+// IMPORTANT: this takes the leftover gwPool returned by matchPairs,
 // not the original gwRows. The pool is identity-tracked by slice
 // position, NOT by request_id, so we never accidentally mark a duplicate
 // (account_id, request_id) row consumed (#229 R3 security HIGH).
@@ -338,7 +412,7 @@ func collectUnmatchedGatewayOK(r *Result, leftoverGw []gwRow) {
 }
 
 // collectUnmatchedCoord2xx surfaces coord request_log rows with 2xx
-// status that matchByFuzzy did NOT consume. Symmetric with the
+// status that matchPairs did NOT consume. Symmetric with the
 // gateway-ok orphan path: a coord row representing a settled request
 // with no harness/gateway counterpart is either orphan/leaked or
 // concurrent buyer traffic. I1 must fail on these — without this
@@ -353,24 +427,41 @@ func collectUnmatchedCoord2xx(r *Result, leftoverCoord []coordRow) {
 	}
 }
 
-// matchByFuzzy pairs each harness success with the most likely gateway
-// row by (model, completion_tokens, ts proximity) and then with the
-// most likely coordinator row by (model, completion_tokens, ts proximity).
-// Once a row is consumed by a match, it's removed from the pool so the
-// next harness request can't re-match the same DB row.
+// matchPairs pairs each harness success with the gateway row (and
+// where applicable a coordinator row) it actually produced. Strategy
+// per side, in order:
+//   1. exact id — gateway request_id == harness id, or coord
+//      external_request_id == harness id. Requires a single
+//      settlement-complete candidate inside the per-request 60s window
+//      and matching account_id (when schema has the column).
+//   2. fuzzy (token+ts) — the legacy heuristic, used ONLY when exact-id
+//      yields zero candidates (exactPickNone).
 //
-// Returns the leftover gateway pool — rows that did NOT consume into a
-// match. Callers use this to detect orphan/leaked settlement rows
-// directly from row identity, NOT from request_id (which the gateway
-// schema does not guarantee globally unique under the composite PK
-// `(account_id, request_id)`; #229 R3 security HIGH).
-func matchByFuzzy(r *Result, results []buyer.Result, gwRows []gwRow, coordRows []coordRow) ([]gwRow, []coordRow) {
+// Ambiguity (≥2 surviving exact-id candidates) is NOT a fuzzy
+// fallback — it's a hard signal recorded in r.AmbiguousExactGatewayIDs
+// / r.AmbiguousExactCoordIDs, and the harness row is left unmatched.
+// Without this gate, R2 fuzzy fallback could still pick an unrelated
+// row by token+ts coincidence (R2 audit security HIGH).
+//
+// Each MatchedPair records which strategy ran for each side
+// (GatewayMatchMethod / CoordinatorMatchMethod). Once a row is consumed
+// by a match, it's removed from the pool so the next harness request
+// can't re-match the same row.
+//
+// Returns the leftover gateway and coordinator pools — rows that did
+// NOT consume into a match. Callers use the leftover pools to detect
+// orphan/leaked settlement rows via slice identity, NOT request_id
+// (gateway PK is composite `(account_id, request_id)`; #229 R3
+// security HIGH).
+func matchPairs(r *Result, results []buyer.Result, gwRows []gwRow, coordRows []coordRow) ([]gwRow, []coordRow) {
 	gwPool := make([]gwRow, len(gwRows))
 	copy(gwPool, gwRows)
 	coordPool := make([]coordRow, len(coordRows))
 	copy(coordPool, coordRows)
 
-	// Walk harness successes in the order they completed.
+	// Walk harness successes in the order they completed. We sort once
+	// and reuse the ordering across both passes to keep pair attribution
+	// deterministic.
 	type harnessIdx struct {
 		idx int
 		res buyer.Result
@@ -385,55 +476,281 @@ func matchByFuzzy(r *Result, results []buyer.Result, gwRows []gwRow, coordRows [
 		return ordered[i].res.EndUTC.Before(ordered[j].res.EndUTC)
 	})
 
+	// Two-pass matching: exact-only first to establish consensus,
+	// fuzzy second over deferred items.
+	deferredResults := make([]buyer.Result, 0, len(ordered))
 	for _, h := range ordered {
-		gwIdx := pickClosestGw(&gwPool, h.res)
-		pair := MatchedPair{
-			HarnessRequestID:        h.res.RequestID,
-			HarnessCompletionTokens: h.res.CompletionTokensReceived,
-		}
-		if gwIdx >= 0 {
-			g := gwPool[gwIdx]
-			pair.GatewayRequestID = g.RequestID
-			pair.GatewayCompletionTokens = g.CompletionTokens
-			pair.GatewayOutcome = g.Outcome
-			pair.GatewayLagMs = g.CreatedAt.Sub(h.res.StartUTC).Milliseconds()
-			gwPool = append(gwPool[:gwIdx], gwPool[gwIdx+1:]...)
-		} else {
-			r.UnmatchedSuccesses = append(r.UnmatchedSuccesses, h.res.RequestID)
-			continue
-		}
-		// Only attempt a coord match when the gateway settled as "ok".
-		// SPEC-006 §17.7 fallback outcomes (stream_truncated, etc.)
-		// legitimately lack a coord row (provider died mid-stream), so
-		// pulling one in would (a) consume a coord row that a later
-		// real "ok" pair needs, and (b) misattribute a token mismatch
-		// to a fallback pair where coord disagreement is expected.
-		// This avoids the false I1 failure mode flagged on PR #229 R4.
-		if isGatewayOKOutcome(pair.GatewayOutcome) {
-			if coordIdx := pickClosestCoord(&coordPool, h.res); coordIdx >= 0 {
-				c := coordPool[coordIdx]
-				pair.CoordinatorRequestID = c.RequestID
-				pair.CoordinatorCompletionTokens = c.CompletionTokens
-				coordPool = append(coordPool[:coordIdx], coordPool[coordIdx+1:]...)
-			}
-		}
-		r.MatchedSuccesses = append(r.MatchedSuccesses, pair)
+		deferredResults = append(deferredResults, h.res)
 	}
+	stillDeferred := matchExactPass(r, deferredResults, &gwPool, &coordPool)
+	matchFuzzyPass(r, stillDeferred, &gwPool, &coordPool)
 	return gwPool, coordPool
 }
 
-func pickClosestGw(pool *[]gwRow, h buyer.Result) int {
+// exactPickStatus distinguishes "no exact candidate" from "ambiguous"
+// so the caller can decide between fuzzy fallback and skipping the row
+// with a hard signal.
+type exactPickStatus int
+
+const (
+	// exactPickNone — no exact-id candidate survived the filters.
+	// Caller should fall back to fuzzy.
+	exactPickNone exactPickStatus = iota
+	// exactPickFound — exactly one candidate survived. Use it.
+	exactPickFound
+	// exactPickAmbiguous — ≥2 candidates survived (same id, same
+	// window, same account constraint). Caller MUST NOT fuzzy-pick;
+	// emit ambiguity signal and leave the row unmatched.
+	exactPickAmbiguous
+)
+
+// matchExactPass is pass 1 of matchPairs: walk every harness success
+// and try ONLY pickExactGw / pickExactCoord. Successful exact-id hits
+// build MatchedPairs immediately and pin r.HarnessAccountID. Ambiguity
+// surfaces as a hard signal and marks the row unmatched. Items with no
+// exact-id candidate are returned for pass 2 to fuzzy-fallback.
+//
+// Pass 1 deliberately avoids fuzzy because, on a modern account-aware
+// snapshot, fuzzy without consensus could consume a foreign-account
+// row by token-proximity coincidence and pin consensus to the wrong
+// account (R5 audit code/architect HIGH).
+func matchExactPass(r *Result, ordered []buyer.Result, gwPool *[]gwRow, coordPool *[]coordRow) []buyer.Result {
+	var deferred []buyer.Result
+	for _, h := range ordered {
+		gwIdx, gwStatus := pickExactGwByRequestID(gwPool, h, r.HarnessAccountID, r.GatewayHasAccountID)
+		if gwStatus == exactPickAmbiguous {
+			r.AmbiguousExactGatewayIDs = append(r.AmbiguousExactGatewayIDs, h.RequestID)
+			r.UnmatchedSuccesses = append(r.UnmatchedSuccesses, h.RequestID)
+			continue
+		}
+		if gwStatus != exactPickFound {
+			deferred = append(deferred, h)
+			continue
+		}
+		g := (*gwPool)[gwIdx]
+		pair := MatchedPair{
+			HarnessRequestID:        h.RequestID,
+			HarnessCompletionTokens: h.CompletionTokensReceived,
+			GatewayMatchMethod:      methodExactID,
+			GatewayRequestID:        g.RequestID,
+			GatewayAccountID:        g.AccountID,
+			GatewayCompletionTokens: g.CompletionTokens,
+			GatewayOutcome:          g.Outcome,
+			GatewayLagMs:            g.CreatedAt.Sub(h.StartUTC).Milliseconds(),
+		}
+		*gwPool = append((*gwPool)[:gwIdx], (*gwPool)[gwIdx+1:]...)
+		// Pin consensus from the first exact-id hit with a non-empty
+		// account_id. Legacy snapshots (account_id absent) leave it
+		// empty — the schema flag in rowAccountIDMatches makes that a
+		// noop on the constraint.
+		if r.HarnessAccountID == "" && g.AccountID != "" {
+			r.HarnessAccountID = g.AccountID
+		}
+		attachCoord(r, &pair, h, coordPool, true /* exactOnly: pass 1 also gates coord to exact-id */)
+		r.MatchedSuccesses = append(r.MatchedSuccesses, pair)
+	}
+	return deferred
+}
+
+// matchFuzzyPass is pass 2 of matchPairs: walk items that pass 1
+// deferred and try the fuzzy heuristic. Consensus (r.HarnessAccountID)
+// is now whatever pass 1 established. pickClosestGw / pickClosestCoord
+// enforce account equality through rowAccountIDMatches, AND refuse to
+// match entirely on a modern snapshot with no consensus (every
+// deferred item then surfaces in UnmatchedSuccesses).
+func matchFuzzyPass(r *Result, deferred []buyer.Result, gwPool *[]gwRow, coordPool *[]coordRow) {
+	for _, h := range deferred {
+		gwIdx := pickClosestGw(gwPool, h, r.HarnessAccountID, r.GatewayHasAccountID)
+		if gwIdx < 0 {
+			r.UnmatchedSuccesses = append(r.UnmatchedSuccesses, h.RequestID)
+			continue
+		}
+		g := (*gwPool)[gwIdx]
+		pair := MatchedPair{
+			HarnessRequestID:        h.RequestID,
+			HarnessCompletionTokens: h.CompletionTokensReceived,
+			GatewayMatchMethod:      methodFuzzy,
+			GatewayRequestID:        g.RequestID,
+			GatewayAccountID:        g.AccountID,
+			GatewayCompletionTokens: g.CompletionTokens,
+			GatewayOutcome:          g.Outcome,
+			GatewayLagMs:            g.CreatedAt.Sub(h.StartUTC).Milliseconds(),
+		}
+		*gwPool = append((*gwPool)[:gwIdx], (*gwPool)[gwIdx+1:]...)
+		attachCoord(r, &pair, h, coordPool, false /* allow fuzzy on coord */)
+		r.MatchedSuccesses = append(r.MatchedSuccesses, pair)
+	}
+}
+
+// attachCoord populates the coord side of a pair from the coordPool
+// when the gateway settled as "ok" (SPEC-006 §17.7 fallback outcomes
+// legitimately lack a coord row — PR #229 R4). On pass 1 (exactOnly),
+// only the exact-id picker runs; on pass 2, fuzzy fallback is allowed.
+func attachCoord(r *Result, pair *MatchedPair, h buyer.Result, coordPool *[]coordRow, exactOnly bool) {
+	if !isGatewayOKOutcome(pair.GatewayOutcome) {
+		return
+	}
+	coordIdx, coordStatus := pickExactCoordByRequestID(coordPool, h, r.HarnessAccountID, r.CoordHasAccountID)
+	if coordStatus == exactPickAmbiguous {
+		r.AmbiguousExactCoordIDs = append(r.AmbiguousExactCoordIDs, h.RequestID)
+		// Leave coord fields empty — computePerPairDrift will surface in MatchedCoordMissing.
+		return
+	}
+	if coordStatus == exactPickFound {
+		c := (*coordPool)[coordIdx]
+		pair.CoordinatorRequestID = c.RequestID
+		pair.CoordinatorAccountID = c.AccountID
+		pair.CoordinatorCompletionTokens = c.CompletionTokens
+		pair.CoordinatorMatchMethod = methodExactID
+		*coordPool = append((*coordPool)[:coordIdx], (*coordPool)[coordIdx+1:]...)
+		return
+	}
+	if exactOnly {
+		return
+	}
+	if fuzzyIdx := pickClosestCoord(coordPool, h, r.HarnessAccountID, r.CoordHasAccountID); fuzzyIdx >= 0 {
+		c := (*coordPool)[fuzzyIdx]
+		pair.CoordinatorRequestID = c.RequestID
+		pair.CoordinatorAccountID = c.AccountID
+		pair.CoordinatorCompletionTokens = c.CompletionTokens
+		pair.CoordinatorMatchMethod = methodFuzzy
+		*coordPool = append((*coordPool)[:fuzzyIdx], (*coordPool)[fuzzyIdx+1:]...)
+	}
+}
+
+// rowAccountIDMatches centralizes the schema-aware account check used
+// by every picker. Logic, in priority order:
+//   1. schema lacks the column → legacy snapshot, constraint is a
+//      global noop (rollout compatibility). Accept regardless of
+//      consensus state.
+//   2. schema has the column but the row value is empty (NULL/blank)
+//      → unconditionally REJECT, EVEN ON BOOTSTRAP (no consensus yet).
+//      We cannot prove this row belongs to the harness's buyer; the
+//      first match would otherwise pin consensus to a phantom account
+//      and corrupt every subsequent match (R4 audit security HIGH).
+//   3. consensus not yet pinned → accept (the first non-empty row's
+//      account_id becomes the consensus in matchPairs).
+//   4. consensus pinned → require equality with the row's account_id.
+//
+// This shape ensures that on modern (account_id-present) snapshots, an
+// attacker cannot bootstrap consensus through a NULL-account row.
+func rowAccountIDMatches(rowAcct, requireAccountID string, schemaHasAccountID bool) bool {
+	if !schemaHasAccountID {
+		return true
+	}
+	if rowAcct == "" {
+		return false
+	}
+	if requireAccountID == "" {
+		return true
+	}
+	return rowAcct == requireAccountID
+}
+
+// pickExactGwByRequestID returns (idx, status) for the gateway pool.
+// A candidate must:
+//   - have a non-empty harness id,
+//   - be settlement-complete,
+//   - carry the harness's RequestID,
+//   - fall inside the per-request matchWindow (defense against stale /
+//     cross-window id collisions even when the SQL snapshot is wider),
+//   - have a matching account_id when the harness's account consensus
+//     is established (defense against cross-account id collisions on a
+//     shared gateway; gateway PK is composite (account_id, request_id)
+//     per ISS-196).
+//
+// One survivor → exactPickFound.  Two or more → exactPickAmbiguous
+// (caller must NOT fall back to unrestricted fuzzy).  None →
+// exactPickNone (caller falls back to fuzzy).
+func pickExactGwByRequestID(pool *[]gwRow, h buyer.Result, requireAccountID string, schemaHasAccountID bool) (int, exactPickStatus) {
+	if h.RequestID == "" {
+		return -1, exactPickNone
+	}
+	hit := -1
+	for i, g := range *pool {
+		if !isSettlementComplete(g.Outcome) {
+			continue
+		}
+		if g.RequestID != h.RequestID {
+			continue
+		}
+		if absInt64(g.CreatedAt.Sub(h.EndUTC).Milliseconds()) > matchWindowMs {
+			continue
+		}
+		if !rowAccountIDMatches(g.AccountID, requireAccountID, schemaHasAccountID) {
+			continue
+		}
+		if hit >= 0 {
+			return -1, exactPickAmbiguous
+		}
+		hit = i
+	}
+	if hit < 0 {
+		return -1, exactPickNone
+	}
+	return hit, exactPickFound
+}
+
+// pickExactCoordByRequestID is the coord-side analog. The id join is on
+// external_request_id (NOT internal request_id); account_id is
+// enforced symmetrically.
+func pickExactCoordByRequestID(pool *[]coordRow, h buyer.Result, requireAccountID string, schemaHasAccountID bool) (int, exactPickStatus) {
+	if h.RequestID == "" {
+		return -1, exactPickNone
+	}
+	hit := -1
+	for i, c := range *pool {
+		if c.Status < 200 || c.Status >= 300 {
+			continue
+		}
+		if c.ExternalRequestID != h.RequestID {
+			continue
+		}
+		if absInt64(c.TsUTC.Sub(h.StartUTC).Milliseconds()) > matchWindowMs {
+			continue
+		}
+		if !rowAccountIDMatches(c.AccountID, requireAccountID, schemaHasAccountID) {
+			continue
+		}
+		if hit >= 0 {
+			return -1, exactPickAmbiguous
+		}
+		hit = i
+	}
+	if hit < 0 {
+		return -1, exactPickNone
+	}
+	return hit, exactPickFound
+}
+
+// pickClosestGw is the fuzzy fallback when exact-id yielded
+// exactPickNone. It enforces the same window + account constraints as
+// the exact picker so cross-account/cross-window rows can't sneak in
+// via the heuristic.
+//
+// On a modern (account_id-aware) snapshot with no consensus pinned,
+// pickClosestGw refuses to match — a token+ts heuristic without
+// account anchoring could otherwise consume a foreign-account row
+// and corrupt every downstream pair (R5 audit code/architect HIGH).
+// Items refused here surface in UnmatchedSuccesses upstream.
+func pickClosestGw(pool *[]gwRow, h buyer.Result, requireAccountID string, schemaHasAccountID bool) int {
+	if schemaHasAccountID && requireAccountID == "" {
+		return -1
+	}
 	best := -1
 	bestScore := int64(-1)
 	for i, g := range *pool {
 		if !isSettlementComplete(g.Outcome) {
 			continue
 		}
+		if !rowAccountIDMatches(g.AccountID, requireAccountID, schemaHasAccountID) {
+			continue
+		}
 		// Model is not in usage_events on gateway side (verified live
 		// 2026-06-27 — only request_id + tokens + outcome). We match
 		// only by (completion_tokens, ts proximity).
 		dt := absInt64(g.CreatedAt.Sub(h.EndUTC).Milliseconds())
-		if dt > 60_000 {
+		if dt > matchWindowMs {
 			continue
 		}
 		tokenDiff := absInt64(g.CompletionTokens - h.CompletionTokensReceived)
@@ -447,18 +764,27 @@ func pickClosestGw(pool *[]gwRow, h buyer.Result) int {
 	return best
 }
 
-func pickClosestCoord(pool *[]coordRow, h buyer.Result) int {
+// pickClosestCoord is the coord fuzzy fallback, with the same
+// account + window constraints as pickClosestGw — including the
+// modern-schema-no-consensus refuse.
+func pickClosestCoord(pool *[]coordRow, h buyer.Result, requireAccountID string, schemaHasAccountID bool) int {
+	if schemaHasAccountID && requireAccountID == "" {
+		return -1
+	}
 	best := -1
 	bestScore := int64(-1)
 	for i, c := range *pool {
 		if c.Status < 200 || c.Status >= 300 {
 			continue
 		}
+		if !rowAccountIDMatches(c.AccountID, requireAccountID, schemaHasAccountID) {
+			continue
+		}
 		if c.Model != "" && h.Model != "" && c.Model != h.Model {
 			continue
 		}
 		dt := absInt64(c.TsUTC.Sub(h.StartUTC).Milliseconds())
-		if dt > 60_000 {
+		if dt > matchWindowMs {
 			continue
 		}
 		tokenDiff := absInt64(c.CompletionTokens - h.CompletionTokensReceived)
@@ -512,7 +838,21 @@ func isSettlementComplete(outcome string) bool {
 }
 
 type coordRow struct {
-	RequestID        string
+	// RequestID is the coordinator's internal id; it is NEVER equal to
+	// the inbound X-Request-ID and is unsafe to join across services
+	// (phase4-coordinator/internal/requestlog/store.go:34-46). For
+	// cross-service correlation use ExternalRequestID, the
+	// gateway-issued id that the coord echoes from
+	// X-Request-ID on the inbound request.
+	RequestID         string
+	ExternalRequestID string
+	// AccountID is the buyer's stable account identifier. Per SPEC-002
+	// the reconciliation join key is (account_id, external_request_id);
+	// matching on external_request_id alone can hit a cross-account row
+	// on a shared gateway/coord. Empty string means the source DB
+	// pre-dates the column (legacy snapshot) — the matcher treats that
+	// as a noop on the account constraint.
+	AccountID        string
 	Model            string
 	CompletionTokens int64
 	Status           int
@@ -520,66 +860,143 @@ type coordRow struct {
 }
 
 type gwRow struct {
-	RequestID        string
+	RequestID string
+	// AccountID is the buyer's stable account identifier. usage_events
+	// PK is composite (account_id, request_id); matching on request_id
+	// alone can hit a cross-account row on a shared gateway. Empty
+	// string means the snapshot pre-dates the column (legacy / partial
+	// migration), in which case the matcher treats it as a noop.
+	AccountID        string
 	CompletionTokens int64
 	Outcome          string
 	CreatedAt        time.Time
 }
 
-func queryCoordinator(path string, start, end time.Time) ([]coordRow, error) {
+// queryCoordinator returns coordinator rows + a schema flag reporting
+// whether the request_log.account_id column exists in this snapshot.
+// Callers thread the flag through the matcher: column present → blank
+// per-row account_ids are real data (NULL = unknown buyer; matcher
+// skips), column absent → constraint is a global noop.
+func queryCoordinator(path string, start, end time.Time) ([]coordRow, bool, error) {
 	db, err := openRO(path)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer db.Close()
-	rows, err := db.Query(`
-		SELECT request_id, model, COALESCE(completion_tokens, 0), status, ts_utc
+	// SELECT external_request_id and account_id when the columns exist.
+	// Schema flags are returned to the matcher so it can distinguish
+	// "column absent globally" (legacy snapshot → relax constraint)
+	// from "column present but this row's value is NULL/blank"
+	// (real missing data → matcher must NOT cross-account-match).
+	hasExt, err := columnExists(db, "request_log", "external_request_id")
+	if err != nil {
+		return nil, false, fmt.Errorf("probe request_log.external_request_id: %w", err)
+	}
+	hasAcct, err := columnExists(db, "request_log", "account_id")
+	if err != nil {
+		return nil, false, fmt.Errorf("probe request_log.account_id: %w", err)
+	}
+	extExpr := "''"
+	if hasExt {
+		extExpr = "COALESCE(external_request_id, '')"
+	}
+	acctExpr := "''"
+	if hasAcct {
+		acctExpr = "COALESCE(account_id, '')"
+	}
+	rows, err := db.Query(fmt.Sprintf(`
+		SELECT request_id, %s, %s, model, COALESCE(completion_tokens, 0), status, ts_utc
 		FROM request_log
 		WHERE ts_utc >= ? AND ts_utc <= ?
-	`, start.Format(time.RFC3339Nano), end.Format(time.RFC3339Nano))
+	`, extExpr, acctExpr), start.Format(time.RFC3339Nano), end.Format(time.RFC3339Nano))
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer rows.Close()
 	var out []coordRow
 	for rows.Next() {
 		var c coordRow
 		var ts string
-		if err := rows.Scan(&c.RequestID, &c.Model, &c.CompletionTokens, &c.Status, &ts); err != nil {
-			return nil, err
+		if err := rows.Scan(&c.RequestID, &c.ExternalRequestID, &c.AccountID, &c.Model, &c.CompletionTokens, &c.Status, &ts); err != nil {
+			return nil, false, err
 		}
 		c.TsUTC, _ = time.Parse(time.RFC3339Nano, ts)
 		out = append(out, c)
 	}
-	return out, rows.Err()
+	return out, hasAcct, rows.Err()
 }
 
-func queryGateway(path string, start, end time.Time) ([]gwRow, error) {
+// columnExists reports whether a column exists on a table via
+// PRAGMA table_info, used by the reconcile queries to stay
+// backward-compatible with older coord/gateway schemas that lack
+// account_id and/or external_request_id (added by ALTER TABLE
+// migrations).
+func columnExists(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			typ     string
+			notnull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// queryGateway returns gateway usage_events rows + a schema flag
+// reporting whether the usage_events.account_id column exists in the
+// snapshot. Same shape as queryCoordinator.
+func queryGateway(path string, start, end time.Time) ([]gwRow, bool, error) {
 	db, err := openRO(path)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer db.Close()
-	rows, err := db.Query(`
-		SELECT request_id, completion_tokens, outcome, created_at
+	// SELECT account_id alongside request_id when the column exists.
+	// usage_events PK is composite (account_id, request_id) per
+	// ISS-196; older snapshots pre-date the migration. Same
+	// schema-tolerance shape as queryCoordinator.
+	hasAcct, err := columnExists(db, "usage_events", "account_id")
+	if err != nil {
+		return nil, false, fmt.Errorf("probe usage_events.account_id: %w", err)
+	}
+	acctExpr := "''"
+	if hasAcct {
+		acctExpr = "COALESCE(account_id, '')"
+	}
+	rows, err := db.Query(fmt.Sprintf(`
+		SELECT request_id, %s, completion_tokens, outcome, created_at
 		FROM usage_events
 		WHERE created_at >= ? AND created_at <= ?
-	`, start.Format(time.RFC3339Nano), end.Format(time.RFC3339Nano))
+	`, acctExpr), start.Format(time.RFC3339Nano), end.Format(time.RFC3339Nano))
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer rows.Close()
 	var out []gwRow
 	for rows.Next() {
 		var g gwRow
 		var ts string
-		if err := rows.Scan(&g.RequestID, &g.CompletionTokens, &g.Outcome, &ts); err != nil {
-			return nil, err
+		if err := rows.Scan(&g.RequestID, &g.AccountID, &g.CompletionTokens, &g.Outcome, &ts); err != nil {
+			return nil, false, err
 		}
 		g.CreatedAt, _ = time.Parse(time.RFC3339Nano, ts)
 		out = append(out, g)
 	}
-	return out, rows.Err()
+	return out, hasAcct, rows.Err()
 }
 
 func openRO(path string) (*sql.DB, error) {

--- a/test/network-harness/internal/reconcile/ledger_test.go
+++ b/test/network-harness/internal/reconcile/ledger_test.go
@@ -162,7 +162,7 @@ func TestComputePerPairDrift_UnderbillNotFlagged(t *testing.T) {
 }
 
 // TestCollectUnmatchedGatewayOK takes a leftover gateway pool (what
-// matchByFuzzy did NOT consume) and surfaces only the "ok"-outcome
+// matchPairs did NOT consume) and surfaces only the "ok"-outcome
 // rows. Fallback outcomes and not-ok are noise on a live network.
 func TestCollectUnmatchedGatewayOK(t *testing.T) {
 	now := time.Now()
@@ -232,12 +232,12 @@ func TestCollectUnmatchedCoord2xx_R5HIGH(t *testing.T) {
 	}
 }
 
-// TestMatchByFuzzy_FallbackDoesntStealCoord_R4HIGH is the regression
+// TestMatchPairs_FallbackDoesntStealCoord_R4HIGH is the regression
 // for the R4 audit finding: a fallback gateway row paired with a
 // harness success could consume a nearby coord row that a later "ok"
 // pair needed, producing a false MatchedCoordMissing on the ok pair.
 // The fix: only call pickClosestCoord when the gateway outcome is "ok".
-func TestMatchByFuzzy_FallbackDoesntStealCoord_R4HIGH(t *testing.T) {
+func TestMatchPairs_FallbackDoesntStealCoord_R4HIGH(t *testing.T) {
 	now := time.Now()
 	// 2 harness successes, both with 8 tokens. Gateway has one fallback
 	// row (stream_truncated, 8 tokens, earlier) and one ok row (8 tokens,
@@ -255,7 +255,7 @@ func TestMatchByFuzzy_FallbackDoesntStealCoord_R4HIGH(t *testing.T) {
 		{Outcome: "ok", CompletionTokensReceived: 8, EndUTC: now.Add(time.Millisecond), StartUTC: now.Add(time.Millisecond), RequestID: "h_ok"},
 	}
 	r := &Result{}
-	matchByFuzzy(r, results, gwRows, coordRows)
+	matchPairs(r, results, gwRows, coordRows)
 	if len(r.MatchedSuccesses) != 2 {
 		t.Fatalf("want 2 pairs, got %d", len(r.MatchedSuccesses))
 	}
@@ -280,14 +280,14 @@ func TestMatchByFuzzy_FallbackDoesntStealCoord_R4HIGH(t *testing.T) {
 	}
 }
 
-// TestMatchByFuzzy_DuplicateRequestID_R3HIGH is the regression for the
+// TestMatchPairs_DuplicateRequestID_R3HIGH is the regression for the
 // R3 security HIGH: gateway PK is (account_id, request_id), so the
 // same request_id can legitimately appear twice across accounts. The
 // pre-R3 collectUnmatchedGatewayOK used request_id matching against
 // MatchedSuccesses, which would mark BOTH rows consumed when only one
-// was actually paired. R3 changed matchByFuzzy to return the leftover
+// was actually paired. R3 changed matchPairs to return the leftover
 // pool directly, so identity is per-slice-element, not per-request_id.
-func TestMatchByFuzzy_DuplicateRequestID_R3HIGH(t *testing.T) {
+func TestMatchPairs_DuplicateRequestID_R3HIGH(t *testing.T) {
 	now := time.Now()
 	gwRows := []gwRow{
 		{RequestID: "X", Outcome: "ok", CompletionTokens: 10, CreatedAt: now},
@@ -298,7 +298,7 @@ func TestMatchByFuzzy_DuplicateRequestID_R3HIGH(t *testing.T) {
 		{Outcome: "ok", CompletionTokensReceived: 10, EndUTC: now, RequestID: "h1"},
 	}
 	r := &Result{}
-	leftover, _ := matchByFuzzy(r, results, gwRows, nil)
+	leftover, _ := matchPairs(r, results, gwRows, nil)
 	if len(r.MatchedSuccesses) != 1 {
 		t.Fatalf("want 1 matched pair, got %d", len(r.MatchedSuccesses))
 	}
@@ -308,6 +308,531 @@ func TestMatchByFuzzy_DuplicateRequestID_R3HIGH(t *testing.T) {
 	collectUnmatchedGatewayOK(r, leftover)
 	if len(r.UnmatchedGatewayOKRows) != 1 {
 		t.Errorf("duplicate-request_id: orphan must be detected via leftover pool, got %v", r.UnmatchedGatewayOKRows)
+	}
+}
+
+// TestMatchPairs_ExactIDWinsOverFuzzy is the regression for the v0.3
+// scenario-07 finding: harness SSE parser undercounted 2 of 39 requests
+// to 0 tokens, and pickClosestGw's tokenDiff*100_000 + dt scoring
+// snapped the harness 0-token rows onto a different gateway row that
+// happened to have low tokens, leaving the gateway-OK rows to drift
+// 55+s onto wrong harness requests. Cross-check showed pair 1's matched
+// gateway_request_id literally equaled pair 3's harness_request_id. The
+// fix prefers exact request_id (gateway echoes it via X-Request-Id
+// response header, loadgen.go:199) before falling back to token+ts
+// fuzzy.
+func TestMatchPairs_ExactIDWinsOverFuzzy(t *testing.T) {
+	now := time.Now()
+	// Harness h_A undercounted to 0 tokens (SSE parser missed deltas).
+	// Gateway row for h_A is "gw_A" with 36 tokens. Another gateway row
+	// "gw_B" with 0 tokens exists for a different harness request h_B.
+	// Pre-fix: pickClosestGw would snap h_A onto gw_B (exact 0=0 match);
+	// post-fix: exact request_id match snaps h_A onto gw_A.
+	gwRows := []gwRow{
+		{RequestID: "gw_A", Outcome: "ok", CompletionTokens: 36, CreatedAt: now},
+		{RequestID: "gw_B", Outcome: "ok", CompletionTokens: 0, CreatedAt: now.Add(time.Millisecond)},
+	}
+	results := []buyer.Result{
+		{Outcome: "ok", CompletionTokensReceived: 0, EndUTC: now, StartUTC: now, RequestID: "gw_A"},
+		{Outcome: "ok", CompletionTokensReceived: 0, EndUTC: now.Add(time.Millisecond), StartUTC: now.Add(time.Millisecond), RequestID: "gw_B"},
+	}
+	r := &Result{}
+	matchPairs(r, results, gwRows, nil)
+	if len(r.MatchedSuccesses) != 2 {
+		t.Fatalf("want 2 pairs, got %d", len(r.MatchedSuccesses))
+	}
+	for _, p := range r.MatchedSuccesses {
+		if p.HarnessRequestID != p.GatewayRequestID {
+			t.Errorf("exact-id match failed: harness=%s gateway=%s", p.HarnessRequestID, p.GatewayRequestID)
+		}
+	}
+}
+
+// TestMatchPairs_ExactIDPrefersOverFallback: when a harness request's
+// exact gateway counterpart is a fallback row (e.g. stream_truncated),
+// the matcher must still prefer the exact-id row over fuzzing onto a
+// different OK row that happens to have a closer token count. Without
+// this, the production #226 shape causes phantom OK pairs.
+func TestMatchPairs_ExactIDPrefersOverFallback(t *testing.T) {
+	now := time.Now()
+	gwRows := []gwRow{
+		{RequestID: "h1", Outcome: "stream_truncated", CompletionTokens: 64, CreatedAt: now},
+		{RequestID: "h2", Outcome: "ok", CompletionTokens: 0, CreatedAt: now.Add(time.Millisecond)},
+	}
+	results := []buyer.Result{
+		{Outcome: "ok", CompletionTokensReceived: 0, EndUTC: now, StartUTC: now, RequestID: "h1"},
+	}
+	r := &Result{}
+	matchPairs(r, results, gwRows, nil)
+	if len(r.MatchedSuccesses) != 1 {
+		t.Fatalf("want 1 pair, got %d", len(r.MatchedSuccesses))
+	}
+	p := r.MatchedSuccesses[0]
+	if p.GatewayRequestID != "h1" {
+		t.Errorf("want exact-id match h1 (fallback) over fuzz to h2 (ok), got gw=%s outcome=%s", p.GatewayRequestID, p.GatewayOutcome)
+	}
+	if p.GatewayOutcome != "stream_truncated" {
+		t.Errorf("want fallback outcome preserved, got %s", p.GatewayOutcome)
+	}
+}
+
+// TestMatchPairs_FallsBackToFuzzyWhenNoExact: legacy gateways that
+// don't echo X-Request-Id (or rows missing from the snapshot window)
+// must still match via the token+ts heuristic.
+func TestMatchPairs_FallsBackToFuzzyWhenNoExact(t *testing.T) {
+	now := time.Now()
+	gwRows := []gwRow{
+		{RequestID: "legacy_gw_uuid", Outcome: "ok", CompletionTokens: 10, CreatedAt: now},
+	}
+	results := []buyer.Result{
+		{Outcome: "ok", CompletionTokensReceived: 10, EndUTC: now, StartUTC: now, RequestID: "harness_native_id"},
+	}
+	r := &Result{}
+	matchPairs(r, results, gwRows, nil)
+	if len(r.MatchedSuccesses) != 1 || r.MatchedSuccesses[0].GatewayRequestID != "legacy_gw_uuid" {
+		t.Errorf("fuzzy fallback should still match when no exact id, got %+v", r.MatchedSuccesses)
+	}
+}
+
+// TestPickExactGwByRequestID_SkipsIncompleteSettlement: in-flight row
+// (no outcome) must not match by exact-id.
+func TestPickExactGwByRequestID_SkipsIncompleteSettlement(t *testing.T) {
+	now := time.Now()
+	pool := []gwRow{
+		{RequestID: "x", Outcome: "", CompletionTokens: 0, CreatedAt: now},
+		{RequestID: "x", Outcome: "ok", CompletionTokens: 8, CreatedAt: now},
+	}
+	idx, status := pickExactGwByRequestID(&pool, buyer.Result{RequestID: "x", EndUTC: now}, "", false)
+	if status != exactPickFound || idx != 1 {
+		t.Errorf("want (1, found), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactGwByRequestID_EmptyIDReturnsNone: defensive — empty
+// harness id → exactPickNone (caller falls back to fuzzy).
+func TestPickExactGwByRequestID_EmptyIDReturnsNone(t *testing.T) {
+	now := time.Now()
+	pool := []gwRow{{RequestID: "", Outcome: "ok", CompletionTokens: 0, CreatedAt: now}}
+	idx, status := pickExactGwByRequestID(&pool, buyer.Result{RequestID: "", EndUTC: now}, "", false)
+	if status != exactPickNone || idx != -1 {
+		t.Errorf("want (-1, none), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactCoordByRequestID_SkipsNon2xx + joins on external_request_id.
+func TestPickExactCoordByRequestID_SkipsNon2xx(t *testing.T) {
+	now := time.Now()
+	pool := []coordRow{
+		{RequestID: "coord-internal-1", ExternalRequestID: "x", Status: 503, CompletionTokens: 0, TsUTC: now},
+		{RequestID: "coord-internal-2", ExternalRequestID: "x", Status: 200, CompletionTokens: 8, TsUTC: now},
+	}
+	idx, status := pickExactCoordByRequestID(&pool, buyer.Result{RequestID: "x", StartUTC: now}, "", false)
+	if status != exactPickFound || idx != 1 {
+		t.Errorf("want (1, found), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactCoordByRequestID_JoinsOnExternalIDNotInternalID is the
+// regression for the R1 code-lane HIGH: coord.request_id is internal
+// and NEVER equals the inbound X-Request-ID. Cross-service join key is
+// external_request_id (phase4-coordinator/internal/requestlog/store.go:34-46).
+func TestPickExactCoordByRequestID_JoinsOnExternalIDNotInternalID(t *testing.T) {
+	now := time.Now()
+	pool := []coordRow{
+		{RequestID: "harness-id", ExternalRequestID: "different-external", Status: 200, CompletionTokens: 8, TsUTC: now},
+		{RequestID: "coord-internal", ExternalRequestID: "harness-id", Status: 200, CompletionTokens: 16, TsUTC: now},
+	}
+	idx, status := pickExactCoordByRequestID(&pool, buyer.Result{RequestID: "harness-id", StartUTC: now}, "", false)
+	if status != exactPickFound || idx != 1 {
+		t.Errorf("must join on ExternalRequestID — want (1, found), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactGwByRequestID_RejectsAmbiguity is the regression for the
+// R1 security HIGH: gateway PK is (account_id, request_id); ambiguity
+// must surface as a distinct status (exactPickAmbiguous), NOT silently
+// fall back to fuzzy which would let an unrelated row consume the
+// match (R2 audit HIGH).
+func TestPickExactGwByRequestID_RejectsAmbiguity(t *testing.T) {
+	now := time.Now()
+	pool := []gwRow{
+		{RequestID: "x", Outcome: "ok", CompletionTokens: 10, CreatedAt: now},
+		{RequestID: "x", Outcome: "ok", CompletionTokens: 999, CreatedAt: now},
+	}
+	idx, status := pickExactGwByRequestID(&pool, buyer.Result{RequestID: "x", EndUTC: now}, "", false)
+	if status != exactPickAmbiguous || idx != -1 {
+		t.Errorf("want (-1, ambiguous), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactCoordByRequestID_RejectsAmbiguity: same on coord side.
+func TestPickExactCoordByRequestID_RejectsAmbiguity(t *testing.T) {
+	now := time.Now()
+	pool := []coordRow{
+		{RequestID: "c1", ExternalRequestID: "x", Status: 200, CompletionTokens: 8, TsUTC: now},
+		{RequestID: "c2", ExternalRequestID: "x", Status: 200, CompletionTokens: 999, TsUTC: now},
+	}
+	idx, status := pickExactCoordByRequestID(&pool, buyer.Result{RequestID: "x", StartUTC: now}, "", false)
+	if status != exactPickAmbiguous || idx != -1 {
+		t.Errorf("want (-1, ambiguous), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactGwByRequestID_EnforcesTimeWindow — stale row rejected.
+func TestPickExactGwByRequestID_EnforcesTimeWindow(t *testing.T) {
+	now := time.Now()
+	stale := now.Add(-2 * time.Minute)
+	pool := []gwRow{
+		{RequestID: "x", Outcome: "ok", CompletionTokens: 10, CreatedAt: stale},
+	}
+	idx, status := pickExactGwByRequestID(&pool, buyer.Result{RequestID: "x", EndUTC: now}, "", false)
+	if status != exactPickNone || idx != -1 {
+		t.Errorf("stale row must be rejected — want (-1, none), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactCoordByRequestID_EnforcesTimeWindow: same on coord.
+func TestPickExactCoordByRequestID_EnforcesTimeWindow(t *testing.T) {
+	now := time.Now()
+	stale := now.Add(-2 * time.Minute)
+	pool := []coordRow{
+		{RequestID: "c1", ExternalRequestID: "x", Status: 200, CompletionTokens: 8, TsUTC: stale},
+	}
+	idx, status := pickExactCoordByRequestID(&pool, buyer.Result{RequestID: "x", StartUTC: now}, "", false)
+	if status != exactPickNone || idx != -1 {
+		t.Errorf("stale coord row must be rejected — want (-1, none), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactGwByRequestID_EnforcesAccountConsensus is the regression
+// for the R2 code/security HIGH: the gateway PK is composite
+// `(account_id, request_id)`. On a shared gateway, a row from a
+// foreign account can carry the same request_id; the matcher must
+// reject it when a consensus account_id is established.
+func TestPickExactGwByRequestID_EnforcesAccountConsensus(t *testing.T) {
+	now := time.Now()
+	pool := []gwRow{
+		{RequestID: "x", Outcome: "ok", AccountID: "other_account", CompletionTokens: 10, CreatedAt: now},
+		{RequestID: "x", Outcome: "ok", AccountID: "harness_account", CompletionTokens: 20, CreatedAt: now},
+	}
+	idx, status := pickExactGwByRequestID(&pool, buyer.Result{RequestID: "x", EndUTC: now}, "harness_account", true)
+	if status != exactPickFound || idx != 1 {
+		t.Errorf("want (1, found) for harness_account, got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactGwByRequestID_LegacyNoColumnIsNoop: a pre-migration
+// snapshot (schemaHasAccountID=false) → constraint is a global noop,
+// even with consensus set. Row's empty AccountID is meaningless
+// because the column isn't real on this snapshot. Verifies the
+// rollout-safety leg of rowAccountIDMatches (R4).
+func TestPickExactGwByRequestID_LegacyNoColumnIsNoop(t *testing.T) {
+	now := time.Now()
+	pool := []gwRow{
+		{RequestID: "x", Outcome: "ok", AccountID: "", CompletionTokens: 10, CreatedAt: now},
+	}
+	idx, status := pickExactGwByRequestID(&pool, buyer.Result{RequestID: "x", EndUTC: now}, "harness_account", false /* legacy snapshot */)
+	if status != exactPickFound || idx != 0 {
+		t.Errorf("legacy snapshot (no account_id column) → constraint noop — want (0, found), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactGwByRequestID_ModernEmptyAccountRejectedAtBootstrap is
+// the R4 audit security/architect HIGH regression: even before
+// consensus is pinned (requireAccountID == ""), a modern-schema
+// blank-account row MUST be rejected. R4 had the empty-consensus
+// shortcut first, so the bootstrap row could be a phantom-account
+// match that then pinned the wrong consensus for the rest of the run.
+func TestPickExactGwByRequestID_ModernEmptyAccountRejectedAtBootstrap(t *testing.T) {
+	now := time.Now()
+	pool := []gwRow{
+		{RequestID: "x", Outcome: "ok", AccountID: "", CompletionTokens: 10, CreatedAt: now},
+	}
+	idx, status := pickExactGwByRequestID(&pool, buyer.Result{RequestID: "x", EndUTC: now}, "" /* bootstrap — no consensus yet */, true /* modern */)
+	if status != exactPickNone || idx != -1 {
+		t.Errorf("modern schema + blank account row at bootstrap → must be rejected — want (-1, none), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactGwByRequestID_ModernSchemaEmptyAccountIsRejected is the
+// R3 audit security HIGH regression: when the schema HAS the
+// account_id column but the row's value is empty (real NULL/blank),
+// the matcher cannot prove same buyer → MUST skip the row. Earlier
+// (R3) wrongly treated this as a noop.
+func TestPickExactGwByRequestID_ModernSchemaEmptyAccountIsRejected(t *testing.T) {
+	now := time.Now()
+	pool := []gwRow{
+		{RequestID: "x", Outcome: "ok", AccountID: "", CompletionTokens: 10, CreatedAt: now},
+	}
+	idx, status := pickExactGwByRequestID(&pool, buyer.Result{RequestID: "x", EndUTC: now}, "harness_account", true /* modern snapshot */)
+	if status != exactPickNone || idx != -1 {
+		t.Errorf("modern snapshot + empty row account_id → must skip — want (-1, none), got (%d, %v)", idx, status)
+	}
+}
+
+// TestPickExactCoordByRequestID_EnforcesAccountConsensus: same on coord.
+func TestPickExactCoordByRequestID_EnforcesAccountConsensus(t *testing.T) {
+	now := time.Now()
+	pool := []coordRow{
+		{ExternalRequestID: "x", AccountID: "other", Status: 200, CompletionTokens: 10, TsUTC: now},
+		{ExternalRequestID: "x", AccountID: "harness_account", Status: 200, CompletionTokens: 20, TsUTC: now},
+	}
+	idx, status := pickExactCoordByRequestID(&pool, buyer.Result{RequestID: "x", StartUTC: now}, "harness_account", true)
+	if status != exactPickFound || idx != 1 {
+		t.Errorf("want (1, found) for harness_account, got (%d, %v)", idx, status)
+	}
+}
+
+// TestMatchPairs_AmbiguityDoesNotConsumeViaFuzzy is the R2-HIGH
+// regression: when exact-id is ambiguous (≥2 candidates), the matcher
+// must NOT fall through to unrestricted fuzzy where an unrelated row
+// could consume the match. The harness row stays unmatched, the
+// ambiguity surfaces as a hard signal, and the candidate rows stay
+// in the leftover pool.
+func TestMatchPairs_AmbiguityDoesNotConsumeViaFuzzy(t *testing.T) {
+	now := time.Now()
+	gwRows := []gwRow{
+		// Two same-id candidates (cross-account collision on a shared gw).
+		{RequestID: "h1", Outcome: "ok", AccountID: "A", CompletionTokens: 8, CreatedAt: now},
+		{RequestID: "h1", Outcome: "ok", AccountID: "B", CompletionTokens: 999, CreatedAt: now},
+		// An unrelated row whose token count would be a "good" fuzzy
+		// hit for the harness row. Pre-fix, fuzzy fallback would have
+		// consumed THIS row after the ambiguous exact-id reject.
+		{RequestID: "unrelated", Outcome: "ok", AccountID: "C", CompletionTokens: 8, CreatedAt: now},
+	}
+	results := []buyer.Result{
+		{Outcome: "ok", CompletionTokensReceived: 8, EndUTC: now, StartUTC: now, RequestID: "h1"},
+	}
+	r := &Result{}
+	leftover, _ := matchPairs(r, results, gwRows, nil)
+	if len(r.AmbiguousExactGatewayIDs) != 1 || r.AmbiguousExactGatewayIDs[0] != "h1" {
+		t.Errorf("want ambiguous id surfaced, got %v", r.AmbiguousExactGatewayIDs)
+	}
+	if len(r.UnmatchedSuccesses) != 1 {
+		t.Errorf("ambiguous harness row must stay unmatched, got %v", r.UnmatchedSuccesses)
+	}
+	if len(r.MatchedSuccesses) != 0 {
+		t.Errorf("no pairs should match, got %d", len(r.MatchedSuccesses))
+	}
+	if len(leftover) != 3 {
+		t.Errorf("all 3 gateway rows must stay in leftover, got %d", len(leftover))
+	}
+}
+
+// TestMatchPairs_AccountConsensusPinnedFromFirstExactID: the first
+// exact-id gateway hit pins r.HarnessAccountID; subsequent matches
+// reject foreign-account rows even when they have a matching id.
+func TestMatchPairs_AccountConsensusPinnedFromFirstExactID(t *testing.T) {
+	now := time.Now()
+	gwRows := []gwRow{
+		// First harness request pins consensus to "acct_harness".
+		{RequestID: "h1", Outcome: "ok", AccountID: "acct_harness", CompletionTokens: 10, CreatedAt: now},
+		// Second harness id matches a foreign-account row only.
+		{RequestID: "h2", Outcome: "ok", AccountID: "acct_other", CompletionTokens: 10, CreatedAt: now.Add(time.Millisecond)},
+	}
+	results := []buyer.Result{
+		{Outcome: "ok", CompletionTokensReceived: 10, EndUTC: now, StartUTC: now, RequestID: "h1"},
+		{Outcome: "ok", CompletionTokensReceived: 10, EndUTC: now.Add(time.Millisecond), StartUTC: now.Add(time.Millisecond), RequestID: "h2"},
+	}
+	r := &Result{GatewayHasAccountID: true}
+	matchPairs(r, results, gwRows, nil)
+	if r.HarnessAccountID != "acct_harness" {
+		t.Errorf("want consensus pinned to acct_harness, got %q", r.HarnessAccountID)
+	}
+	if len(r.MatchedSuccesses) != 1 || r.MatchedSuccesses[0].HarnessRequestID != "h1" {
+		t.Errorf("only h1 should match (h2's only candidate is foreign-account), got %d pairs", len(r.MatchedSuccesses))
+	}
+	if len(r.UnmatchedSuccesses) != 1 || r.UnmatchedSuccesses[0] != "h2" {
+		t.Errorf("h2 must be unmatched, got %v", r.UnmatchedSuccesses)
+	}
+}
+
+// TestMatchPairs_FuzzyRefusedOnModernSchemaWithoutConsensus is the
+// R5-HIGH regression: with the two-pass matcher (R6), fuzzy fallback
+// must NEVER run on a modern (account_id-aware) snapshot when
+// consensus is empty. Pre-R6, the first harness row with no exact
+// gateway counterpart could fuzzy-match a foreign-account row by
+// token-proximity and pin consensus to the wrong account.
+//
+// Setup: harness has a single result with a harness-prefix RequestID
+// the gateway didn't echo. The gateway has ONE row from a foreign
+// account with a matching token count. On modern schema, fuzzy must
+// refuse — the harness row stays unmatched, consensus stays empty.
+func TestMatchPairs_FuzzyRefusedOnModernSchemaWithoutConsensus(t *testing.T) {
+	now := time.Now()
+	gwRows := []gwRow{
+		{RequestID: "foreign_uuid", Outcome: "ok", AccountID: "acct_attacker", CompletionTokens: 8, CreatedAt: now},
+	}
+	results := []buyer.Result{
+		{Outcome: "ok", CompletionTokensReceived: 8, EndUTC: now, StartUTC: now, RequestID: "harness-prefix-id"},
+	}
+	r := &Result{GatewayHasAccountID: true}
+	leftover, _ := matchPairs(r, results, gwRows, nil)
+	if r.HarnessAccountID != "" {
+		t.Errorf("consensus must remain empty (no exact-id hit pinned it), got %q", r.HarnessAccountID)
+	}
+	if len(r.MatchedSuccesses) != 0 {
+		t.Errorf("no fuzzy match should occur — got %d pairs", len(r.MatchedSuccesses))
+	}
+	if len(r.UnmatchedSuccesses) != 1 || r.UnmatchedSuccesses[0] != "harness-prefix-id" {
+		t.Errorf("harness row must be unmatched, got %v", r.UnmatchedSuccesses)
+	}
+	if len(leftover) != 1 {
+		t.Errorf("foreign-account row stays in leftover (orphan signal), got %d", len(leftover))
+	}
+}
+
+// TestMatchPairs_TwoPassOrderRescuesEarlyDeferral verifies the
+// two-pass shape rescues an early harness row whose exact-id failed:
+// pass 1 defers it; a later harness row's exact-id pins consensus;
+// pass 2 then fuzzy-matches the deferred row.
+//
+// Without the second pass, harness rows would be processed in
+// arrival order with no chance to rescue early items once consensus
+// is later established.
+func TestMatchPairs_TwoPassOrderRescuesEarlyDeferral(t *testing.T) {
+	t0 := time.Now()
+	t1 := t0.Add(10 * time.Millisecond)
+	gwRows := []gwRow{
+		// Will be fuzzy-matched to h_early — same account, same tokens, close ts.
+		{RequestID: "gw_unrelated_uuid", Outcome: "ok", AccountID: "acct_harness", CompletionTokens: 8, CreatedAt: t0},
+		// Exact match for h_late — pins consensus.
+		{RequestID: "h_late", Outcome: "ok", AccountID: "acct_harness", CompletionTokens: 16, CreatedAt: t1},
+	}
+	results := []buyer.Result{
+		// h_early ordered first by EndUTC. Pass 1: no exact-id candidate
+		// (gateway row's request_id is different) → deferred.
+		{Outcome: "ok", CompletionTokensReceived: 8, EndUTC: t0, StartUTC: t0, RequestID: "harness-prefix-early"},
+		// h_late comes second. Pass 1: exact-id match → consensus pinned.
+		{Outcome: "ok", CompletionTokensReceived: 16, EndUTC: t1, StartUTC: t1, RequestID: "h_late"},
+	}
+	r := &Result{GatewayHasAccountID: true}
+	matchPairs(r, results, gwRows, nil)
+	if r.HarnessAccountID != "acct_harness" {
+		t.Errorf("want consensus acct_harness, got %q", r.HarnessAccountID)
+	}
+	if len(r.MatchedSuccesses) != 2 {
+		t.Fatalf("want both pairs matched (early via pass-2 fuzzy, late via pass-1 exact), got %d", len(r.MatchedSuccesses))
+	}
+	methods := map[string]string{}
+	for _, p := range r.MatchedSuccesses {
+		methods[p.HarnessRequestID] = p.GatewayMatchMethod
+	}
+	if methods["h_late"] != methodExactID {
+		t.Errorf("h_late should be exact_id, got %q", methods["h_late"])
+	}
+	if methods["harness-prefix-early"] != methodFuzzy {
+		t.Errorf("harness-prefix-early should be rescued via fuzzy pass 2, got %q", methods["harness-prefix-early"])
+	}
+}
+
+// TestMatchPairs_RecordsMatchMethod: every matched pair records which
+// strategy resolved each side. Architect-lane R1 LOW.
+func TestMatchPairs_RecordsMatchMethod(t *testing.T) {
+	now := time.Now()
+	gwRows := []gwRow{
+		{RequestID: "h_exact", Outcome: "ok", CompletionTokens: 10, CreatedAt: now},
+		{RequestID: "different_id", Outcome: "ok", CompletionTokens: 8, CreatedAt: now.Add(time.Millisecond)},
+	}
+	coordRows := []coordRow{
+		{RequestID: "c1", ExternalRequestID: "h_exact", Status: 200, CompletionTokens: 10, TsUTC: now},
+	}
+	results := []buyer.Result{
+		// First resolves to gateway via exact id, coord via exact id.
+		{Outcome: "ok", CompletionTokensReceived: 10, EndUTC: now, StartUTC: now, RequestID: "h_exact"},
+		// Second has no exact-id counterpart on gateway → fuzzy. No coord
+		// counterpart either → coord method stays empty.
+		{Outcome: "ok", CompletionTokensReceived: 8, EndUTC: now.Add(time.Millisecond), StartUTC: now.Add(time.Millisecond), RequestID: "h_fuzzy"},
+	}
+	r := &Result{}
+	matchPairs(r, results, gwRows, coordRows)
+	if len(r.MatchedSuccesses) != 2 {
+		t.Fatalf("want 2 pairs, got %d", len(r.MatchedSuccesses))
+	}
+	for _, p := range r.MatchedSuccesses {
+		switch p.HarnessRequestID {
+		case "h_exact":
+			if p.GatewayMatchMethod != "exact_id" {
+				t.Errorf("h_exact gateway method: want exact_id, got %q", p.GatewayMatchMethod)
+			}
+			if p.CoordinatorMatchMethod != "exact_id" {
+				t.Errorf("h_exact coord method: want exact_id, got %q", p.CoordinatorMatchMethod)
+			}
+		case "h_fuzzy":
+			if p.GatewayMatchMethod != "fuzzy_token_ts" {
+				t.Errorf("h_fuzzy gateway method: want fuzzy_token_ts, got %q", p.GatewayMatchMethod)
+			}
+			// No coord candidate at all → method empty (no attempt path).
+			if p.CoordinatorMatchMethod != "" {
+				t.Errorf("h_fuzzy no-coord-candidate: want empty, got %q", p.CoordinatorMatchMethod)
+			}
+		}
+	}
+}
+
+// TestMatchPairs_MixedExactAndFuzzyPool integrates both strategies in a
+// single pool: one harness request consumes via exact-id, the next via
+// fuzzy fallback from the remaining rows. Architect-lane R1 LOW.
+func TestMatchPairs_MixedExactAndFuzzyPool(t *testing.T) {
+	now := time.Now()
+	gwRows := []gwRow{
+		{RequestID: "h_exact", Outcome: "ok", CompletionTokens: 5, CreatedAt: now},
+		// fuzzy candidate for h2 (no matching id, but token=7 matches harness)
+		{RequestID: "different_id", Outcome: "ok", CompletionTokens: 7, CreatedAt: now.Add(time.Millisecond)},
+	}
+	results := []buyer.Result{
+		{Outcome: "ok", CompletionTokensReceived: 5, EndUTC: now, StartUTC: now, RequestID: "h_exact"},
+		{Outcome: "ok", CompletionTokensReceived: 7, EndUTC: now.Add(time.Millisecond), StartUTC: now.Add(time.Millisecond), RequestID: "h2"},
+	}
+	r := &Result{}
+	leftover, _ := matchPairs(r, results, gwRows, nil)
+	if len(r.MatchedSuccesses) != 2 {
+		t.Fatalf("want 2 pairs, got %d", len(r.MatchedSuccesses))
+	}
+	if len(leftover) != 0 {
+		t.Errorf("both rows should be consumed, got leftover %d", len(leftover))
+	}
+	for _, p := range r.MatchedSuccesses {
+		if p.HarnessRequestID == "h_exact" && p.GatewayMatchMethod != "exact_id" {
+			t.Errorf("h_exact: want exact_id, got %q", p.GatewayMatchMethod)
+		}
+		if p.HarnessRequestID == "h2" && p.GatewayMatchMethod != "fuzzy_token_ts" {
+			t.Errorf("h2: want fuzzy_token_ts, got %q", p.GatewayMatchMethod)
+		}
+	}
+}
+
+// TestMatchPairs_FallbackExactMatchEndToEnd is the R1 code-lane LOW:
+// a harness OK whose exact gateway match is a fallback outcome must
+// (a) match by exact id, (b) NOT count as gateway overbill,
+// (c) NOT trigger MatchedCoordMissing, (d) NOT leak into
+// UnmatchedGatewayOKRows.
+func TestMatchPairs_FallbackExactMatchEndToEnd(t *testing.T) {
+	now := time.Now()
+	gwRows := []gwRow{
+		{RequestID: "h1", Outcome: "stream_truncated", CompletionTokens: 64, CreatedAt: now},
+	}
+	results := []buyer.Result{
+		{Outcome: "ok", CompletionTokensReceived: 8, EndUTC: now, StartUTC: now, RequestID: "h1"},
+	}
+	r := &Result{}
+	leftoverGw, _ := matchPairs(r, results, gwRows, nil)
+	computePerPairDrift(r)
+	collectUnmatchedGatewayOK(r, leftoverGw)
+	if len(r.MatchedSuccesses) != 1 {
+		t.Fatalf("want 1 matched pair, got %d", len(r.MatchedSuccesses))
+	}
+	if r.MatchedSuccesses[0].GatewayMatchMethod != "exact_id" {
+		t.Errorf("want exact_id match on fallback row, got %q", r.MatchedSuccesses[0].GatewayMatchMethod)
+	}
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("fallback exact-match must not count as overbill, got %d", r.GatewayOverbillVsHarnessTokens)
+	}
+	if len(r.MatchedCoordMissing) != 0 {
+		t.Errorf("fallback pair must not trigger coord-missing, got %v", r.MatchedCoordMissing)
+	}
+	if len(r.UnmatchedGatewayOKRows) != 0 {
+		t.Errorf("fallback row consumed → no orphan, got %v", r.UnmatchedGatewayOKRows)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a harness reconciler attribution bug discovered during the v0.3
baseline run on scenario 07: a phantom 93-tok gateway overbill across
3 OK pairs was a matcher bug, NOT real gateway over-billing. Cross-check
proved attribution swap (pair 1 matched `gateway_request_id` = pair 3
`harness_request_id`).

Replaces `matchByFuzzy` (token+ts heuristic) with `matchPairs`:
exact-request-id-first, fuzzy fallback, two-pass with account_id
consensus enforcement. The gateway already echoes `X-Request-Id` and
the harness records it as `Result.RequestID` — the reconciler now uses
it.

## Architecture

**Two-pass matcher:**
1. **Pass 1 (`matchExactPass`)** — exact-id only on gateway (PK
   `(account_id, request_id)`) and coord (`(account_id,
   external_request_id)`). Hits pin `r.HarnessAccountID` consensus.
   Ambiguity surfaces as hard I1 signal; no fuzzy fallback.
2. **Pass 2 (`matchFuzzyPass`)** — fuzzy fallback over deferred items.
   Consensus now pinned (or empty); fuzzy pickers refuse to match
   on modern schemas with no consensus.

**Schema-aware account constraint** via `rowAccountIDMatches`:
- legacy snapshot (no `account_id` column) → constraint is noop
- modern + blank row → reject (NULL/blank real data)
- modern + non-empty row → equality or bootstrap

**Schema-tolerant SQL** — queries probe `PRAGMA table_info` and SELECT
account_id / external_request_id conditionally. Pearl coord pre-dates
ISS-211; the harness still reconciles against it (constraint noop on
that side).

**Fail-closed I1** — when `reconcile.Run` errors, `r.ReconcileError`
is set; `checkI1` hard-fails on it independent of drift signals.

**New `MatchedPair` fields**:
- `GatewayMatchMethod` / `CoordinatorMatchMethod` (`"exact_id"` |
  `"fuzzy_token_ts"`) — attribution telemetry
- `GatewayAccountID` / `CoordinatorAccountID` — triage data

**New `Result` fields**:
- `HarnessAccountID` — pinned consensus
- `GatewayHasAccountID` / `CoordHasAccountID` — schema flags
- `AmbiguousExactGatewayIDs` / `AmbiguousExactCoordIDs` — hard signals
- `ReconcileError` — fail-closed trigger

`drift_basis` stays `"per_matched_pair_v2"` — drift math unchanged,
only attribution changed.

## Audit trail

6 rounds of 3-lane codex audit (code/security/architect). Each round
re-ran against api.streamvc.live + Pearl coord:

| Round | Fixes |
|---|---|
| R1 | exact-id-first matching |
| R2 | coord exact uses `external_request_id`, ambiguity rejection, time window on exact-id, rename `matchByFuzzy`→`matchPairs`, match-method telemetry |
| R3 | account_id plumbing through queries + pickers, schema-tolerant SQL, fail-closed via `ReconcileError`, ambiguity-as-hard-signal in I1 |
| R4 | schema-flag distinction (column absent vs row blank) |
| R5 | bootstrap circularity — modern blank rows rejected unconditionally |
| R6 | two-pass shape — fuzzy refused on modern-schema-no-consensus |

R6 audit also surfaced:
- 1 HIGH (security) — pre-seed `HarnessAccountID` from trusted source
  to close malicious-gateway-echoes-foreign-id bootstrap attack
- 1 MEDIUM (architect) — coord fuzzy after gateway exact-hit

Both filed as [#237](https://github.com/Augustas11/macprovider/issues/237).
Treated as defense-in-depth beyond the harness's actual
trust-the-gateway threat model; not blocking.

## Live verification

Scenario 07 (sustained_throughput, 6min, 2 buyers, api.streamvc.live):

| Round | Phantom overbill | Coord orphans | Match strategy |
|---|---|---|---|
| pre-fix | 93 toks / 3 pairs | 36 | fuzzy token+ts |
| R1 | 5 toks / 1 pair | 18 | exact-id-first |
| R2 | 24 toks / 2 pairs | 26 | + coord `external_request_id` |
| R3 | 24 toks / 2 pairs | 27 | + account_id + ambiguity |
| R4 | 22 toks / 2 pairs | 36 | + schema flag (consensus pinned) |
| R5 | — / 0 OK pairs | 25 | + bootstrap blank reject |
| R6 | 8 toks / 1 pair | 18 | + two-pass |

Residual real signals:
- 5-22 tok overbill on 1-2 OK pairs — consistent gateway counting
  offset (~5-12 toks/pair); investigation deferred
- 18-36 coord-2xx orphans — F-8 / #226 production-shape (gateway
  fell back, coord 2xx'd); sibling of [#232](https://github.com/Augustas11/macprovider/issues/232)

## Tests

- `internal/reconcile/ledger_test.go` — 38 cases:
  - Ambiguity detection (gateway + coord)
  - Account consensus pinning + foreign-account rejection
  - Schema-flag matrix (legacy / modern empty / modern populated)
  - Bootstrap blank-row rejection on modern schema
  - Two-pass deferred rescue ordering
  - Fuzzy refused on modern-schema-no-consensus
  - End-to-end fallback exact match
- `internal/invariants/hard_test.go` — 13 cases:
  - Reconcile-error fail-closed
  - Ambiguity-as-hard-signal
  - Every drift signal interpretation

## Test plan

- [x] `go test ./internal/reconcile/... ./internal/invariants/...` — all pass
- [x] Live re-run on scenario 07 vs production gateway + coord
- [x] Confirm `gateway_match_method = "exact_id"` on 100% of matched pairs
- [x] Confirm `harness_account_id` pinned from gateway-side consensus

🤖 Generated with [Claude Code](https://claude.com/claude-code)