### PR TITLE
fix(coordinator): bump receipt-keys grace-window test dates to 2099 (defuse 2026-06-29 12:00 UTC time-bomb)

### DIFF
--- a/phase4-coordinator/internal/buyer/receipt_keys_test.go
+++ b/phase4-coordinator/internal/buyer/receipt_keys_test.go
@@ -106,15 +106,22 @@ func TestReceiptKeysReturnsPreviousKeyInGraceWindow(t *testing.T) {
 	registry := pool.NewRegistry(nil)
 	current := bytes.Repeat([]byte{0x42}, 32)
 	previous := bytes.Repeat([]byte{0x43}, 32)
-	rotatedAt := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
-	expiresAt := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	// `Registry.Register` (called by `registerReceiptKeyProvider`) uses
+	// real `time.Now()` internally to gate `activeReceiptPubkeyPrev`
+	// at `phase4-coordinator/internal/pool/provider.go:550`. The test's
+	// `server.now` override only takes effect AFTER Register completes,
+	// so `expiresAt` MUST stay in the real-wall-clock future or the
+	// registry drops the previous key before the test can observe it.
+	// Use 2099 so this test never time-bombs again.
+	rotatedAt := time.Date(2099, 6, 22, 12, 0, 0, 0, time.UTC)
+	expiresAt := time.Date(2099, 6, 29, 12, 0, 0, 0, time.UTC)
 	registerReceiptKeyProvider(registry, "p1", current, &pool.ReceiptPubkeyPrevious{
 		Pubkey:    previous,
 		RotatedAt: rotatedAt,
 		ExpiresAt: expiresAt,
 	})
 	server := NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0))
-	frozen := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	frozen := time.Date(2099, 6, 23, 12, 0, 0, 0, time.UTC)
 	server.now = func() time.Time { return frozen }
 
 	rr := serveReceiptKeys(server, "p1", "198.51.100.2:12345")


### PR DESCRIPTION
## Summary

`TestReceiptKeysReturnsPreviousKeyInGraceWindow` (introduced by [#124](https://github.com/Augustas11/macprovider/pull/124) — SPEC-015 receipts) started failing on every run after 2026-06-29 12:00 UTC. **It's currently blocking `ci-required` for every PR in the repo** (including [#239](https://github.com/Augustas11/macprovider/pull/239) which discovered this).

## Root cause

`Registry.Register` (called through `registerReceiptKeyProvider`) uses real `time.Now()` internally to gate `activeReceiptPubkeyPrev` at `phase4-coordinator/internal/pool/provider.go:550`. That gating runs **before** the test's `server.now` override takes effect — so the registry drops the previous key the moment real wall-clock crosses the hardcoded `expiresAt: 2026-06-29 12:00 UTC`.

The test only passed for ~6 days from when it landed (2026-06-23) to today.

## Fix

Bump the hardcoded date to `2099-06-29`. The 2099 date makes the time-bomb a non-issue for >70 years.

This is the smallest of three options:
1. **(this PR)** Bump the date to a far future year.
2. (better) Thread a clock parameter through `registerReceiptKeyProvider`.
3. (best) Add optional clock injection on `Registry.Register`.

(2) and (3) are bigger surface changes that should land on their own merits, not as side-effects of unblocking CI.

Inline comment in the test now documents the registry-clock-vs-`server.now` race so the next person to touch this code knows why the date is specifically in the far future.

## Test plan

- [x] `cd phase4-coordinator && go test ./internal/buyer/... -count=1` — green (includes all receipt-keys variants)
- [ ] CI green on this PR (will unblock PR #239 once merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
