### PR TITLE
spec(016): v0.1.22 — closes #165 (LIMIT + chronic-outage telemetry)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -353,6 +353,15 @@ func main() {
 		if payoutS2.chainWorker != nil {
 			payoutS2.chainWorker.Start(shutdownCtx)
 		}
+		// #165 R1 architect HIGH closure: drive the chronic-outage
+		// Evaluate on a window-internal cadence independent of the
+		// runner ticker. RunInterval can be up to 24h per §6.5 but
+		// the tracker window defaults to 10min, so per-cycle Evaluate
+		// would prune samples before observing them. Run() ticks at
+		// min(window/2, 1min).
+		if payoutS2.chronic != nil {
+			go payoutS2.chronic.Run(shutdownCtx)
+		}
 		// Step 4 §6.5 SIGHUP-only payout.tuning.* reload. Reading
 		// the YAML on SIGHUP MUST NOT touch payout.security.* (the
 		// loader is read-only on the security namespace); the
@@ -628,6 +637,7 @@ type payoutStep2 struct {
 	chainWorker *payout.ChainBalanceWorker // Step 4 §7.4
 	tuning      *payout.TuningProvider     // Step 4 §6.5 SIGHUP-reloadable
 	rpcs        payout.TwoRPCs             // Step 4 r3 [sec:r3-1] SPKI pin rotation: CloseIdleConnections on SIGHUP
+	chronic     *payout.ChronicOutageTracker // #165 A2 — per-RPC sliding-window error tracker; Run() goroutine drives Evaluate
 	stop        func(context.Context)      // calls Stop on every component then Release
 }
 
@@ -1010,6 +1020,7 @@ func setupPayout(ctx context.Context, db *sql.DB, cfg config.Config, tokenStore 
 		chainWorker: chainWorker,
 		tuning:      tuningProvider,
 		rpcs:        rpcs,
+		chronic:     chronicTracker,
 		stop: func(stopCtx context.Context) {
 			// Codex Step 3 r1 [arch:3.1] MAJOR closure: shutdown
 			// ordering is runner → poller → reaper → Release.
@@ -1421,13 +1432,19 @@ func startPayoutSIGHUPListener(
 				// connection alive after operators believe the new pin is
 				// active. Called only on accepted reloads where the pin key
 				// actually changed; no-op for non-SPKI reload cycles.
+				// #165 R1 code/arch HIGH (convergent): assert on a
+				// CloseIdleConnections-shaped interface so the SPKI
+				// reload drain still fires through the chronic-outage
+				// TrackingRPCClient wrapper. Both *payout.HTTPRPCClient
+				// and *trackingRPC implement this method.
+				type idleCloser interface{ CloseIdleConnections() }
 				for _, k := range changedKeys {
 					if k == "payout.tuning.rpc_url_primary_pin_spki" ||
 						k == "payout.tuning.rpc_url_secondary_pin_spki" {
-						if rpc, ok := rpcs.Primary.(*payout.HTTPRPCClient); ok {
+						if rpc, ok := rpcs.Primary.(idleCloser); ok {
 							rpc.CloseIdleConnections()
 						}
-						if rpc, ok := rpcs.Secondary.(*payout.HTTPRPCClient); ok {
+						if rpc, ok := rpcs.Secondary.(idleCloser); ok {
 							rpc.CloseIdleConnections()
 						}
 						break

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -1451,6 +1451,8 @@ func startPayoutSIGHUPListener(
 							log.Warn().
 								Str("event", "payout_spki_drain_skipped_unsupported_client").
 								Str("rpc_label", "primary").
+								Str("severity", "WARN").
+								Str("ts_utc", time.Now().UTC().Format(time.RFC3339Nano)).
 								Msg("SPKI pin rotated but primary RPC client does not implement CloseIdleConnections — pooled TLS conns survive the rotation")
 						}
 						if rpc, ok := rpcs.Secondary.(idleCloser); ok {
@@ -1459,6 +1461,8 @@ func startPayoutSIGHUPListener(
 							log.Warn().
 								Str("event", "payout_spki_drain_skipped_unsupported_client").
 								Str("rpc_label", "secondary").
+								Str("severity", "WARN").
+								Str("ts_utc", time.Now().UTC().Format(time.RFC3339Nano)).
 								Msg("SPKI pin rotated but secondary RPC client does not implement CloseIdleConnections — pooled TLS conns survive the rotation")
 						}
 						break

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -729,17 +729,24 @@ func setupPayout(ctx context.Context, db *sql.DB, cfg config.Config, tokenStore 
 	// Step 4 r2 [arch:r2-4.2] MAJOR closure: pin is now func() string
 	// reading the live TuningProvider snapshot so SIGHUP SPKI rotations
 	// take effect at the next TLS handshake (not just accepted and logged).
+	// #165 A2: chronic-outage tracker wraps both RPC clients so every
+	// JSON-RPC call records success/failure into a sliding-window
+	// detector. Runner evaluates per cycle and emits
+	// payout_rpc_chronic_outage PAGE if either RPC's per-label error
+	// rate crosses the threshold. Tracker uses SPEC defaults (10min
+	// window / 50% threshold / 10 minSamples / 10min PAGE cooldown).
+	chronicTracker := payout.NewChronicOutageTracker(logger, nil)
 	rpcs := payout.TwoRPCs{
-		Primary: payout.NewHTTPRPCClient(
+		Primary: payout.NewTrackingRPCClient(payout.NewHTTPRPCClient(
 			cfg.Payout.Security.RPCURLPrimary, "primary",
 			func() string { return tuningProvider.Snapshot().RPCURLPrimaryPinSPKI },
 			20*time.Second,
-		),
-		Secondary: payout.NewHTTPRPCClient(
+		), chronicTracker),
+		Secondary: payout.NewTrackingRPCClient(payout.NewHTTPRPCClient(
 			cfg.Payout.Security.RPCURLSecondary, "secondary",
 			func() string { return tuningProvider.Snapshot().RPCURLSecondaryPinSPKI },
 			20*time.Second,
-		),
+		), chronicTracker),
 	}
 	rpcCtx, rpcCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer rpcCancel()
@@ -817,6 +824,7 @@ func setupPayout(ctx context.Context, db *sql.DB, cfg config.Config, tokenStore 
 		LowBalanceThreshold:   cfg.Payout.Tuning.LowBalanceThreshold,
 		LowNativeThreshold:    cfg.Payout.Tuning.LowNativeThreshold,
 		Tuning:                tuningProvider,
+		ChronicOutage:         chronicTracker,
 	}, state)
 	if err != nil {
 		// Release the lease on construction failure so the next

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -1432,20 +1432,34 @@ func startPayoutSIGHUPListener(
 				// connection alive after operators believe the new pin is
 				// active. Called only on accepted reloads where the pin key
 				// actually changed; no-op for non-SPKI reload cycles.
-				// #165 R1 code/arch HIGH (convergent): assert on a
-				// CloseIdleConnections-shaped interface so the SPKI
-				// reload drain still fires through the chronic-outage
-				// TrackingRPCClient wrapper. Both *payout.HTTPRPCClient
-				// and *trackingRPC implement this method.
+				// #165 R1/R2 code/arch HIGH+MEDIUM (convergent): assert
+				// on a CloseIdleConnections-shaped interface so the
+				// SPKI reload drain still fires through the chronic-
+				// outage TrackingRPCClient wrapper. Both
+				// *payout.HTTPRPCClient and *trackingRPC implement
+				// this method. The miss-branch logs at WARN so a
+				// future RPCClient implementation that lacks the
+				// method is operator-visible at SPKI rotation time
+				// (rather than silently failing to drain).
 				type idleCloser interface{ CloseIdleConnections() }
 				for _, k := range changedKeys {
 					if k == "payout.tuning.rpc_url_primary_pin_spki" ||
 						k == "payout.tuning.rpc_url_secondary_pin_spki" {
 						if rpc, ok := rpcs.Primary.(idleCloser); ok {
 							rpc.CloseIdleConnections()
+						} else {
+							log.Warn().
+								Str("event", "payout_spki_drain_skipped_unsupported_client").
+								Str("rpc_label", "primary").
+								Msg("SPKI pin rotated but primary RPC client does not implement CloseIdleConnections — pooled TLS conns survive the rotation")
 						}
 						if rpc, ok := rpcs.Secondary.(idleCloser); ok {
 							rpc.CloseIdleConnections()
+						} else {
+							log.Warn().
+								Str("event", "payout_spki_drain_skipped_unsupported_client").
+								Str("rpc_label", "secondary").
+								Msg("SPKI pin rotated but secondary RPC client does not implement CloseIdleConnections — pooled TLS conns survive the rotation")
 						}
 						break
 					}

--- a/phase4-coordinator/dist/payout-runbook.md
+++ b/phase4-coordinator/dist/payout-runbook.md
@@ -151,7 +151,8 @@ coordinator):
 
 Required WARN-class events (also verified per §9 item 6):
 
-- `payout_stale_outbox_backlog` (NEW v0.1.22 — §4.7 step 5 production capped)
+- `payout_stale_outbox_backlog` (NEW v0.1.22 — §4.7 step 5 production capped; escalates to PAGE when `scan_ceiling_hit=true`)
+- `payout_spki_drain_skipped_unsupported_client` (NEW v0.1.22 — verify SEPARATE synthetic alert per `rpc_label` value: `primary` AND `secondary`)
 - `payout_stale_outbox_reaped`
 - `payout_flag_audit_reaped`
 - `payout_low_balance` / `payout_low_native_balance`

--- a/phase4-coordinator/dist/payout-runbook.md
+++ b/phase4-coordinator/dist/payout-runbook.md
@@ -125,10 +125,13 @@ WARN fires when ~1 day of headroom remains.
 
 ## 3. BetterStack synthetic-alert verification (SPEC §9.7 prereq)
 
-Before flipping `payout.enabled: true`, verify EVERY §7.1 PAGE
-event fires a BetterStack alert. The synthetic-alert harness
-lives at `dist/synthetic-alerts/` (test fixtures only; never
-fire against production).
+Before flipping `payout.enabled: true`, verify EVERY §7.1
+PAGE/WARN event fires a BetterStack alert (per SPEC §9 item 6,
+the canonical event list lives at
+`specs/SPEC-016-payout-pipeline.md` §9 item 6 — re-derive at
+deploy time). The synthetic-alert harness lives at
+`dist/synthetic-alerts/` (test fixtures only; never fire against
+production).
 
 Required PAGE-class events (test each by hand on a staging
 coordinator):
@@ -144,6 +147,17 @@ coordinator):
 - `payout_reorg_orphan_recorded`
 - `payout_cancel_self_transfer_reconfirm_stale`
 - `payout_config_reloaded` / `payout_config_reload_rejected`
+- `payout_rpc_chronic_outage` (NEW v0.1.22 — chronic single-RPC outage detector)
+
+Required WARN-class events (also verified per §9 item 6):
+
+- `payout_stale_outbox_backlog` (NEW v0.1.22 — §4.7 step 5 production capped)
+- `payout_stale_outbox_reaped`
+- `payout_flag_audit_reaped`
+- `payout_low_balance` / `payout_low_native_balance`
+- `payout_nonce_gap`
+- `provider_payout_address_change_rejected`
+- `provider_payout_address_rejected_unknown_provider`
 
 For each: pre-trigger the underlying state in staging, watch
 BetterStack receive the alert within 60s, and tick the

--- a/phase4-coordinator/internal/payout/chronic.go
+++ b/phase4-coordinator/internal/payout/chronic.go
@@ -111,19 +111,67 @@ func (t *ChronicOutageTracker) Record(label string, isErr bool) {
 	st.samples = append(st.samples, chronicSample{ts: t.nowFn(), isErr: isErr})
 }
 
+// Run drives Evaluate on a fixed cadence independent of the
+// runner's RunInterval. Closes #165 R1 architect HIGH: the runner
+// cycle ticker can fire at intervals up to 24h ([5m, 24h] per the
+// SPEC §6.5 RunInterval bound), but the tracker window defaults to
+// 10 minutes, so per-cycle Evaluate would prune EVERY prior cycle's
+// samples before observing them. An independent ticker at
+// `min(window/2, 1*time.Minute)` keeps the detector responsive
+// regardless of cycle cadence.
+//
+// Run returns when ctx is cancelled. Safe to call from a dedicated
+// goroutine launched at startup.
+func (t *ChronicOutageTracker) Run(ctx context.Context) {
+	if t == nil {
+		return
+	}
+	tick := t.window / 2
+	if tick > time.Minute {
+		tick = time.Minute
+	}
+	if tick < 10*time.Second {
+		tick = 10 * time.Second
+	}
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			t.Evaluate(ctx, t.nowFn())
+		}
+	}
+}
+
 // Evaluate prunes stale samples, checks every label's window, and
 // emits payout_rpc_chronic_outage for any label that crossed the
 // threshold and is outside its cooldown. Returns the labels that
 // emitted this call; useful for tests + per-cycle telemetry counts.
-// Safe to call from the runner cycle loop.
+// Safe to call from the runner cycle loop AND from the independent
+// Run() ticker concurrently — the per-label mutex serializes both
+// readers and writers.
 func (t *ChronicOutageTracker) Evaluate(_ context.Context, now time.Time) []string {
 	if t == nil {
 		return nil
 	}
+	// #165 R1 sec/arch LOW closure: collect emit decisions under
+	// lock, release, then write the log lines. Holding the per-
+	// tracker mutex across zerolog.Send() (which can block on
+	// stdout/journald backpressure) would stall every RPC caller
+	// that's recording samples in parallel.
+	type pageDecision struct {
+		label      string
+		samples    int
+		errs       int
+		rate       float64
+		windowSecs int
+		threshold  float64
+	}
+	var decisions []pageDecision
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	cutoff := now.Add(-t.window)
-	var paged []string
 	for label, st := range t.states {
 		// Prune. Samples are append-only and ts is monotonic per
 		// label, so a single linear scan suffices.
@@ -151,18 +199,31 @@ func (t *ChronicOutageTracker) Evaluate(_ context.Context, now time.Time) []stri
 			continue
 		}
 		st.lastPagedAt = now
+		decisions = append(decisions, pageDecision{
+			label:      label,
+			samples:    len(st.samples),
+			errs:       errs,
+			rate:       rate,
+			windowSecs: int(t.window.Seconds()),
+			threshold:  t.threshold,
+		})
+	}
+	t.mu.Unlock()
+
+	paged := make([]string, 0, len(decisions))
+	for _, d := range decisions {
 		t.log.Error().
 			Str("event", "payout_rpc_chronic_outage").
-			Str("rpc_label", label).
-			Int("window_seconds", int(t.window.Seconds())).
-			Int("sample_count", len(st.samples)).
-			Int("error_count", errs).
-			Float64("error_rate", rate).
-			Float64("threshold", t.threshold).
+			Str("rpc_label", d.label).
+			Int("window_seconds", d.windowSecs).
+			Int("sample_count", d.samples).
+			Int("error_count", d.errs).
+			Float64("error_rate", d.rate).
+			Float64("threshold", d.threshold).
 			Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
 			Str("severity", "PAGE").
 			Send()
-		paged = append(paged, label)
+		paged = append(paged, d.label)
 	}
 	return paged
 }
@@ -244,4 +305,19 @@ func (t *trackingRPC) NativeBalance(ctx context.Context, address string) (uint64
 	v, err := t.inner.NativeBalance(ctx, address)
 	t.record(err)
 	return v, err
+}
+
+// CloseIdleConnections forwards to the inner client when it
+// implements the SPKI-reload contract. Closes the R1 code/arch HIGH:
+// without this delegate, the SIGHUP handler's
+// `rpcs.Primary.(*HTTPRPCClient)` type assertion fails through the
+// wrapper and accepted SPKI pin rotations stop draining pooled TLS
+// connections. The handler still asserts on this interface (not on
+// *HTTPRPCClient) so the unwrap is observed even through the
+// wrapper.
+func (t *trackingRPC) CloseIdleConnections() {
+	type idleCloser interface{ CloseIdleConnections() }
+	if c, ok := t.inner.(idleCloser); ok {
+		c.CloseIdleConnections()
+	}
 }

--- a/phase4-coordinator/internal/payout/chronic.go
+++ b/phase4-coordinator/internal/payout/chronic.go
@@ -1,0 +1,247 @@
+package payout
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// ChronicOutageTracker watches a sliding window of per-RPC-label
+// outcomes and emits a payout_rpc_chronic_outage PAGE when the
+// per-label error rate crosses the configured threshold AND the
+// per-label sample count is large enough to make the rate
+// statistically actionable. Closes #165 A2 (advisory from
+// SPEC-016 IMPL FULL r1 [arch:4.5]).
+//
+// Why per-label, not aggregate: the disagreement detector (§4.4
+// receipts-agree, §6.2 chain-balance) already pages on
+// disagreement, which only fires when BOTH RPCs return data AND
+// the data conflicts. A chronic single-RPC failure leaves the
+// healthy RPC's reads usable (the runner degrades; e.g.
+// ReceiptsAgree returns false → row stays pending → next cycle
+// retries) but produces no operator-facing event. This tracker
+// closes that gap.
+//
+// Defaults (overridable by tests):
+//
+//   - window     = 10 minutes
+//   - threshold  = 0.5 (50% error rate)
+//   - minSamples = 10  (avoid false PAGE on a cold runner)
+//   - cooldown   = 10 minutes (PAGE at most once per cooldown per
+//     label so a chronic outage doesn't flood the journal)
+type ChronicOutageTracker struct {
+	window     time.Duration
+	threshold  float64
+	minSamples int
+	cooldown   time.Duration
+	log        zerolog.Logger
+	nowFn      func() time.Time
+
+	mu     sync.Mutex
+	states map[string]*chronicLabelState
+}
+
+type chronicLabelState struct {
+	samples     []chronicSample
+	lastPagedAt time.Time
+}
+
+type chronicSample struct {
+	ts    time.Time
+	isErr bool
+}
+
+// NewChronicOutageTracker constructs a tracker with SPEC §7.1
+// defaults. Pass nowFn=nil to use time.Now.
+func NewChronicOutageTracker(log zerolog.Logger, nowFn func() time.Time) *ChronicOutageTracker {
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	return &ChronicOutageTracker{
+		window:     10 * time.Minute,
+		threshold:  0.5,
+		minSamples: 10,
+		cooldown:   10 * time.Minute,
+		log:        log,
+		nowFn:      nowFn,
+		states:     make(map[string]*chronicLabelState),
+	}
+}
+
+// WithWindow / WithThreshold / WithMinSamples / WithCooldown are
+// test-only configuration hooks. They return the receiver for
+// chaining and MUST be called before any Record / Evaluate to
+// avoid racing with the runner.
+func (t *ChronicOutageTracker) WithWindow(w time.Duration) *ChronicOutageTracker {
+	t.window = w
+	return t
+}
+
+func (t *ChronicOutageTracker) WithThreshold(th float64) *ChronicOutageTracker {
+	t.threshold = th
+	return t
+}
+
+func (t *ChronicOutageTracker) WithMinSamples(n int) *ChronicOutageTracker {
+	t.minSamples = n
+	return t
+}
+
+func (t *ChronicOutageTracker) WithCooldown(c time.Duration) *ChronicOutageTracker {
+	t.cooldown = c
+	return t
+}
+
+// Record adds one outcome sample for the named RPC label. Calls
+// from any goroutine are safe; the per-label state mutex is held
+// only while appending.
+func (t *ChronicOutageTracker) Record(label string, isErr bool) {
+	if t == nil || label == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	st, ok := t.states[label]
+	if !ok {
+		st = &chronicLabelState{}
+		t.states[label] = st
+	}
+	st.samples = append(st.samples, chronicSample{ts: t.nowFn(), isErr: isErr})
+}
+
+// Evaluate prunes stale samples, checks every label's window, and
+// emits payout_rpc_chronic_outage for any label that crossed the
+// threshold and is outside its cooldown. Returns the labels that
+// emitted this call; useful for tests + per-cycle telemetry counts.
+// Safe to call from the runner cycle loop.
+func (t *ChronicOutageTracker) Evaluate(_ context.Context, now time.Time) []string {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	cutoff := now.Add(-t.window)
+	var paged []string
+	for label, st := range t.states {
+		// Prune. Samples are append-only and ts is monotonic per
+		// label, so a single linear scan suffices.
+		idx := 0
+		for idx < len(st.samples) && st.samples[idx].ts.Before(cutoff) {
+			idx++
+		}
+		if idx > 0 {
+			st.samples = append(st.samples[:0], st.samples[idx:]...)
+		}
+		if len(st.samples) < t.minSamples {
+			continue
+		}
+		errs := 0
+		for _, s := range st.samples {
+			if s.isErr {
+				errs++
+			}
+		}
+		rate := float64(errs) / float64(len(st.samples))
+		if rate < t.threshold {
+			continue
+		}
+		if !st.lastPagedAt.IsZero() && now.Sub(st.lastPagedAt) < t.cooldown {
+			continue
+		}
+		st.lastPagedAt = now
+		t.log.Error().
+			Str("event", "payout_rpc_chronic_outage").
+			Str("rpc_label", label).
+			Int("window_seconds", int(t.window.Seconds())).
+			Int("sample_count", len(st.samples)).
+			Int("error_count", errs).
+			Float64("error_rate", rate).
+			Float64("threshold", t.threshold).
+			Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
+			Str("severity", "PAGE").
+			Send()
+		paged = append(paged, label)
+	}
+	return paged
+}
+
+// ---- trackingRPC wrapper -------------------------------------------------
+
+// NewTrackingRPCClient wraps an RPCClient so every call records
+// success/failure into the tracker. Returns inner unchanged when
+// tracker is nil — tests that don't care about chronic-outage
+// observability don't have to wire one.
+//
+// What counts as an error: a non-nil error return. The
+// (nil receipt, nil error) "not found" success path for
+// TransactionReceipt/TransactionByHash is NOT counted as an error —
+// it's a normal RPC response, not an outage signal. This matches
+// the §4.7 producer's own "RPC error is NOT a stale signal"
+// classification (orphans.go line ~450).
+func NewTrackingRPCClient(inner RPCClient, tracker *ChronicOutageTracker) RPCClient {
+	if tracker == nil {
+		return inner
+	}
+	return &trackingRPC{inner: inner, tracker: tracker}
+}
+
+type trackingRPC struct {
+	inner   RPCClient
+	tracker *ChronicOutageTracker
+}
+
+func (t *trackingRPC) record(err error) {
+	t.tracker.Record(t.inner.Label(), err != nil)
+}
+
+func (t *trackingRPC) Label() string { return t.inner.Label() }
+
+func (t *trackingRPC) ChainID(ctx context.Context) (uint64, error) {
+	v, err := t.inner.ChainID(ctx)
+	t.record(err)
+	return v, err
+}
+
+func (t *trackingRPC) TransactionCount(ctx context.Context, address string) (uint64, error) {
+	v, err := t.inner.TransactionCount(ctx, address)
+	t.record(err)
+	return v, err
+}
+
+func (t *trackingRPC) SendRawTransaction(ctx context.Context, rawSignedTx []byte) (string, error) {
+	v, err := t.inner.SendRawTransaction(ctx, rawSignedTx)
+	t.record(err)
+	return v, err
+}
+
+func (t *trackingRPC) TransactionReceipt(ctx context.Context, txHash string) (*Receipt, error) {
+	v, err := t.inner.TransactionReceipt(ctx, txHash)
+	t.record(err)
+	return v, err
+}
+
+func (t *trackingRPC) TransactionByHash(ctx context.Context, txHash string) (*Transaction, error) {
+	v, err := t.inner.TransactionByHash(ctx, txHash)
+	t.record(err)
+	return v, err
+}
+
+func (t *trackingRPC) BlockNumber(ctx context.Context) (uint64, error) {
+	v, err := t.inner.BlockNumber(ctx)
+	t.record(err)
+	return v, err
+}
+
+func (t *trackingRPC) CallContract(ctx context.Context, to string, data []byte) ([]byte, error) {
+	v, err := t.inner.CallContract(ctx, to, data)
+	t.record(err)
+	return v, err
+}
+
+func (t *trackingRPC) NativeBalance(ctx context.Context, address string) (uint64, error) {
+	v, err := t.inner.NativeBalance(ctx, address)
+	t.record(err)
+	return v, err
+}

--- a/phase4-coordinator/internal/payout/iss165_a1_test.go
+++ b/phase4-coordinator/internal/payout/iss165_a1_test.go
@@ -148,9 +148,6 @@ func TestProduceStaleOutboxRows_EmitsBacklogGaugeWhenLimitHit(t *testing.T) {
 	if found["severity"] != "WARN" {
 		t.Errorf("backlog.severity=%v, want WARN", found["severity"])
 	}
-	if found["scan_cap_hit"] != false {
-		t.Errorf("backlog.scan_cap_hit=%v, want false", found["scan_cap_hit"])
-	}
 }
 
 // TestProduceStaleOutboxRows_NonActionableRowsDoNotConsumeLimit pins

--- a/phase4-coordinator/internal/payout/iss165_a1_test.go
+++ b/phase4-coordinator/internal/payout/iss165_a1_test.go
@@ -1,0 +1,199 @@
+package payout
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// seedDistinctStaleCancelRow inserts a stale cancel attempt under a
+// fresh provider so the unique (provider_id, window) constraint on
+// ledger_payout_ready doesn't collide across iterations. The default
+// seedStaleCancelRow hard-codes "p1" and is suitable only for single-
+// row tests.
+func seedDistinctStaleCancelRow(t *testing.T, db *sql.DB, runInterval time.Duration, idx int) int64 {
+	t.Helper()
+	providerID := fmt.Sprintf("p%d", idx)
+	idempotency := fmt.Sprintf("settle:%s:%d", providerID, idx)
+	payoutID := insertReadyRow(t, db, providerID, idempotency)
+	old := time.Now().Add(-4 * runInterval).UTC().Format(time.RFC3339Nano)
+	txHash := fmt.Sprintf("0xstale%d", idx)
+	if _, err := db.ExecContext(context.Background(), `
+INSERT INTO payout_attempts
+  (payout_id, attempt_seq, chain, from_address, to_address,
+   amount_base_units, nonce, raw_signed_tx, tx_hash,
+   broadcast_at_utc, is_cancel_self_transfer, updated_at_utc)
+VALUES (?, 1, 'base-mainnet', '0x', '0x', 1, ?, X'02', ?,
+        ?, 1, ?)`,
+		payoutID, int64(idx)+10, txHash, old, old,
+	); err != nil {
+		t.Fatalf("insert distinct stale cancel: %v", err)
+	}
+	return payoutID
+}
+
+// #165 A1 regression — ProduceStaleOutboxRows must honor the LIMIT
+// bound (sized from snap.MaxRowsPerRun) and emit a
+// payout_stale_outbox_backlog WARN with the precise candidate count
+// when the candidate set exceeds the limit.
+
+func TestProduceStaleOutboxRows_LimitBoundsCandidateScan(t *testing.T) {
+	db := openTestDB(t)
+	seedBootstrapForTest(t, db)
+	primary := &mockRPCClient{label: "primary"}
+	secondary := &mockRPCClient{label: "secondary"}
+	primary.receiptFn = func(_ context.Context, _ string) (*Receipt, error) { return nil, nil }
+	secondary.receiptFn = primary.receiptFn
+	rpcs := TwoRPCs{Primary: primary, Secondary: secondary}
+	runInterval := time.Minute
+
+	// Seed 5 stale rows; cap at 2 — only 2 should produce this cycle.
+	for i := 0; i < 5; i++ {
+		_ = seedDistinctStaleCancelRow(t, db, runInterval, i)
+	}
+
+	produced, err := ProduceStaleOutboxRows(
+		context.Background(), db, zerolog.Nop(),
+		rpcs, "run-limit", time.Now(), runInterval, 2,
+	)
+	if err != nil {
+		t.Fatalf("ProduceStaleOutboxRows: %v", err)
+	}
+	if produced != 2 {
+		t.Errorf("produced=%d, want 2 (limit-bounded)", produced)
+	}
+
+	// Verify exactly 2 outbox rows landed; the remaining 3 stay
+	// candidates for the next cycle (their markers stay NULL).
+	var outbox int
+	_ = db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM cancel_reconfirm_stale_outbox`,
+	).Scan(&outbox)
+	if outbox != 2 {
+		t.Errorf("outbox rows=%d, want 2 (limit suppressed remainder)", outbox)
+	}
+	var stillCandidate int
+	_ = db.QueryRowContext(context.Background(), `
+SELECT COUNT(*) FROM payout_attempts
+ WHERE is_cancel_self_transfer = 1
+   AND cancel_reconfirm_stale_paged_at_utc IS NULL`,
+	).Scan(&stillCandidate)
+	if stillCandidate != 3 {
+		t.Errorf("candidates remaining=%d, want 3", stillCandidate)
+	}
+}
+
+func TestProduceStaleOutboxRows_EmitsBacklogGaugeWhenLimitHit(t *testing.T) {
+	db := openTestDB(t)
+	seedBootstrapForTest(t, db)
+	primary := &mockRPCClient{label: "primary"}
+	secondary := &mockRPCClient{label: "secondary"}
+	primary.receiptFn = func(_ context.Context, _ string) (*Receipt, error) { return nil, nil }
+	secondary.receiptFn = primary.receiptFn
+	rpcs := TwoRPCs{Primary: primary, Secondary: secondary}
+	runInterval := time.Minute
+
+	for i := 0; i < 4; i++ {
+		_ = seedDistinctStaleCancelRow(t, db, runInterval, i)
+	}
+
+	var buf bytes.Buffer
+	log := zerolog.New(&buf)
+	if _, err := ProduceStaleOutboxRows(
+		context.Background(), db, log,
+		rpcs, "run-backlog", time.Now(), runInterval, 2,
+	); err != nil {
+		t.Fatalf("ProduceStaleOutboxRows: %v", err)
+	}
+
+	var found map[string]any
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		if ev["event"] == "payout_stale_outbox_backlog" {
+			found = ev
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("payout_stale_outbox_backlog not emitted; log=%q", buf.String())
+	}
+	if v, _ := found["limit"].(float64); int(v) != 2 {
+		t.Errorf("backlog.limit=%v, want 2", found["limit"])
+	}
+	if v, _ := found["total_candidates"].(float64); int(v) != 4 {
+		t.Errorf("backlog.total_candidates=%v, want 4 (exact backlog count)", found["total_candidates"])
+	}
+	if found["run_id"] != "run-backlog" {
+		t.Errorf("backlog.run_id=%v, want run-backlog", found["run_id"])
+	}
+	if found["severity"] != "WARN" {
+		t.Errorf("backlog.severity=%v, want WARN", found["severity"])
+	}
+}
+
+func TestProduceStaleOutboxRows_NoBacklogEventWhenWithinLimit(t *testing.T) {
+	db := openTestDB(t)
+	seedBootstrapForTest(t, db)
+	primary := &mockRPCClient{label: "primary"}
+	secondary := &mockRPCClient{label: "secondary"}
+	primary.receiptFn = func(_ context.Context, _ string) (*Receipt, error) { return nil, nil }
+	secondary.receiptFn = primary.receiptFn
+	rpcs := TwoRPCs{Primary: primary, Secondary: secondary}
+	runInterval := time.Minute
+
+	for i := 0; i < 2; i++ {
+		_ = seedDistinctStaleCancelRow(t, db, runInterval, i)
+	}
+
+	var buf bytes.Buffer
+	log := zerolog.New(&buf)
+	if _, err := ProduceStaleOutboxRows(
+		context.Background(), db, log,
+		rpcs, "run-clean", time.Now(), runInterval, 50,
+	); err != nil {
+		t.Fatalf("ProduceStaleOutboxRows: %v", err)
+	}
+	if strings.Contains(buf.String(), "payout_stale_outbox_backlog") {
+		t.Errorf("backlog event emitted when candidates <= limit; log=%q", buf.String())
+	}
+}
+
+func TestProduceStaleOutboxRows_ZeroLimitDisablesCap(t *testing.T) {
+	db := openTestDB(t)
+	seedBootstrapForTest(t, db)
+	primary := &mockRPCClient{label: "primary"}
+	secondary := &mockRPCClient{label: "secondary"}
+	primary.receiptFn = func(_ context.Context, _ string) (*Receipt, error) { return nil, nil }
+	secondary.receiptFn = primary.receiptFn
+	rpcs := TwoRPCs{Primary: primary, Secondary: secondary}
+	runInterval := time.Minute
+
+	for i := 0; i < 3; i++ {
+		_ = seedDistinctStaleCancelRow(t, db, runInterval, i)
+	}
+
+	produced, err := ProduceStaleOutboxRows(
+		context.Background(), db, zerolog.Nop(),
+		rpcs, "run-uncapped", time.Now(), runInterval, 0,
+	)
+	if err != nil {
+		t.Fatalf("ProduceStaleOutboxRows: %v", err)
+	}
+	if produced != 3 {
+		t.Errorf("produced=%d, want 3 (limit=0 means no cap, back-compat)", produced)
+	}
+}
+

--- a/phase4-coordinator/internal/payout/iss165_a1_test.go
+++ b/phase4-coordinator/internal/payout/iss165_a1_test.go
@@ -44,7 +44,7 @@ VALUES (?, 1, 'base-mainnet', '0x', '0x', 1, ?, X'02', ?,
 // payout_stale_outbox_backlog WARN with the precise candidate count
 // when the candidate set exceeds the limit.
 
-func TestProduceStaleOutboxRows_LimitBoundsCandidateScan(t *testing.T) {
+func TestProduceStaleOutboxRows_LimitBoundsProducedRows(t *testing.T) {
 	db := openTestDB(t)
 	seedBootstrapForTest(t, db)
 	primary := &mockRPCClient{label: "primary"}
@@ -133,14 +133,76 @@ func TestProduceStaleOutboxRows_EmitsBacklogGaugeWhenLimitHit(t *testing.T) {
 	if v, _ := found["limit"].(float64); int(v) != 2 {
 		t.Errorf("backlog.limit=%v, want 2", found["limit"])
 	}
-	if v, _ := found["total_candidates"].(float64); int(v) != 4 {
-		t.Errorf("backlog.total_candidates=%v, want 4 (exact backlog count)", found["total_candidates"])
+	// total_candidates is the post-production REMAINING backlog
+	// (rows still un-paged after this cycle), not the pre-cycle
+	// count: 4 seeded, 2 paged this cycle → 2 remaining.
+	if v, _ := found["total_candidates"].(float64); int(v) != 2 {
+		t.Errorf("backlog.total_candidates=%v, want 2 (remaining un-paged)", found["total_candidates"])
+	}
+	if v, _ := found["produced"].(float64); int(v) != 2 {
+		t.Errorf("backlog.produced=%v, want 2 (produced == limit)", found["produced"])
 	}
 	if found["run_id"] != "run-backlog" {
 		t.Errorf("backlog.run_id=%v, want run-backlog", found["run_id"])
 	}
 	if found["severity"] != "WARN" {
 		t.Errorf("backlog.severity=%v, want WARN", found["severity"])
+	}
+	if found["scan_cap_hit"] != false {
+		t.Errorf("backlog.scan_cap_hit=%v, want false", found["scan_cap_hit"])
+	}
+}
+
+// TestProduceStaleOutboxRows_NonActionableRowsDoNotConsumeLimit pins
+// the #165 R1 SECURITY HIGH closure: non-actionable candidates
+// (e.g. at-least-one-RPC sees the receipt) MUST be skipped without
+// consuming the limit budget. Without this, the first `limit`
+// non-actionable rows in oldest-first order would permanently block
+// truly stale cancels from PAGEing (denial of detection).
+func TestProduceStaleOutboxRows_NonActionableRowsDoNotConsumeLimit(t *testing.T) {
+	db := openTestDB(t)
+	seedBootstrapForTest(t, db)
+	primary := &mockRPCClient{label: "primary"}
+	secondary := &mockRPCClient{label: "secondary"}
+	// Per-tx classification: rows 0..2 reconfirmable (primary sees
+	// receipt → skip), rows 3..5 truly stale (both miss → produce).
+	primary.receiptFn = func(_ context.Context, txHash string) (*Receipt, error) {
+		// Reconfirmable: any tx hash starting "0xstale0", "0xstale1", "0xstale2".
+		if strings.HasPrefix(txHash, "0xstale0") || strings.HasPrefix(txHash, "0xstale1") || strings.HasPrefix(txHash, "0xstale2") {
+			return &Receipt{Status: 1, BlockNumber: 100}, nil
+		}
+		return nil, nil
+	}
+	secondary.receiptFn = func(_ context.Context, _ string) (*Receipt, error) { return nil, nil }
+	rpcs := TwoRPCs{Primary: primary, Secondary: secondary}
+	runInterval := time.Minute
+
+	for i := 0; i < 6; i++ {
+		_ = seedDistinctStaleCancelRow(t, db, runInterval, i)
+	}
+
+	// Limit=2. If LIMIT bounded the SCAN, rows 0..1 (reconfirmable)
+	// would consume the budget and rows 3..5 (truly stale) would
+	// never PAGE this cycle. With limit bounding PRODUCTION, we
+	// expect produced=2 (the first two of rows 3..5).
+	produced, err := ProduceStaleOutboxRows(
+		context.Background(), db, zerolog.Nop(),
+		rpcs, "run-skip", time.Now(), runInterval, 2,
+	)
+	if err != nil {
+		t.Fatalf("ProduceStaleOutboxRows: %v", err)
+	}
+	if produced != 2 {
+		t.Errorf("produced=%d, want 2 — truly stale rows must PAGE despite earlier non-actionable rows", produced)
+	}
+	// Confirm the produced rows are from the truly-stale set
+	// (rows 3,4 — first two of the actionable trio).
+	var outboxCount int
+	_ = db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM cancel_reconfirm_stale_outbox WHERE tx_hash LIKE '0xstale3%' OR tx_hash LIKE '0xstale4%'`,
+	).Scan(&outboxCount)
+	if outboxCount != 2 {
+		t.Errorf("outbox rows for truly-stale=%d, want 2 (denial-of-detection regression)", outboxCount)
 	}
 }
 

--- a/phase4-coordinator/internal/payout/iss165_a1_test.go
+++ b/phase4-coordinator/internal/payout/iss165_a1_test.go
@@ -203,6 +203,69 @@ func TestProduceStaleOutboxRows_NonActionableRowsDoNotConsumeLimit(t *testing.T)
 	}
 }
 
+// TestProduceStaleOutboxRows_LargeNonActionablePrefixDoesNotStarve
+// pins the R3 audit closure: a >1000 non-actionable prefix MUST NOT
+// block a single actionable row from PAGEing. This regression
+// guards against any future reintroduction of a hidden
+// scan-prefix cap. The test seeds 1100 reconfirmable rows
+// (primary-sees-receipt → skip) followed by 1 truly stale row.
+// With limit=1 the producer MUST find + PAGE the one stale row
+// in this cycle.
+func TestProduceStaleOutboxRows_LargeNonActionablePrefixDoesNotStarve(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping large-prefix regression in -short mode")
+	}
+	db := openTestDB(t)
+	seedBootstrapForTest(t, db)
+	primary := &mockRPCClient{label: "primary"}
+	secondary := &mockRPCClient{label: "secondary"}
+	const prefixSize = 1100 // > 1000 to defeat any rumored prefix cap.
+	primary.receiptFn = func(_ context.Context, txHash string) (*Receipt, error) {
+		// The truly-stale row has tx_hash "0xstaleACTIONABLE";
+		// every other row is reconfirmable.
+		if txHash == "0xstaleactionable" {
+			return nil, nil
+		}
+		return &Receipt{Status: 1, BlockNumber: 100}, nil
+	}
+	secondary.receiptFn = func(_ context.Context, _ string) (*Receipt, error) { return nil, nil }
+	rpcs := TwoRPCs{Primary: primary, Secondary: secondary}
+	runInterval := time.Minute
+
+	for i := 0; i < prefixSize; i++ {
+		_ = seedDistinctStaleCancelRow(t, db, runInterval, i)
+	}
+	// Seed the actionable row last so it sorts after the prefix
+	// (oldest-first ordering uses updated_at_utc, all are
+	// identical, then payout_id ASC — so a later-inserted row
+	// gets a larger payout_id and sorts last).
+	providerID := "p-actionable"
+	payoutID := insertReadyRow(t, db, providerID, "settle:"+providerID)
+	old := time.Now().Add(-4 * runInterval).UTC().Format(time.RFC3339Nano)
+	if _, err := db.ExecContext(context.Background(), `
+INSERT INTO payout_attempts
+  (payout_id, attempt_seq, chain, from_address, to_address,
+   amount_base_units, nonce, raw_signed_tx, tx_hash,
+   broadcast_at_utc, is_cancel_self_transfer, updated_at_utc)
+VALUES (?, 1, 'base-mainnet', '0x', '0x', 1, ?, X'02', ?,
+        ?, 1, ?)`,
+		payoutID, int64(prefixSize)+1000, "0xstaleactionable", old, old,
+	); err != nil {
+		t.Fatalf("insert actionable: %v", err)
+	}
+
+	produced, err := ProduceStaleOutboxRows(
+		context.Background(), db, zerolog.Nop(),
+		rpcs, "run-large-prefix", time.Now(), runInterval, 1,
+	)
+	if err != nil {
+		t.Fatalf("ProduceStaleOutboxRows: %v", err)
+	}
+	if produced != 1 {
+		t.Errorf("produced=%d, want 1 — large non-actionable prefix must not starve stale rows", produced)
+	}
+}
+
 func TestProduceStaleOutboxRows_NoBacklogEventWhenWithinLimit(t *testing.T) {
 	db := openTestDB(t)
 	seedBootstrapForTest(t, db)

--- a/phase4-coordinator/internal/payout/iss165_a2_test.go
+++ b/phase4-coordinator/internal/payout/iss165_a2_test.go
@@ -1,0 +1,224 @@
+package payout
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// #165 A2 — ChronicOutageTracker locks the sliding-window
+// per-label detector behavior.
+
+func TestChronicOutageTracker_EmitsPageWhenThresholdCrossed(t *testing.T) {
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	log := zerolog.New(&buf)
+	tracker := NewChronicOutageTracker(log, func() time.Time { return now }).
+		WithWindow(10 * time.Minute).
+		WithThreshold(0.5).
+		WithMinSamples(10).
+		WithCooldown(10 * time.Minute)
+	for i := 0; i < 10; i++ {
+		// 60% error rate on "primary".
+		tracker.Record("primary", i%5 != 0 && i%5 != 1)
+	}
+	// Recompute: 6 of 10 are errs (i in {2,3,4,7,8,9}) — 60% > 50%.
+	paged := tracker.Evaluate(context.Background(), now)
+	if len(paged) != 1 || paged[0] != "primary" {
+		t.Fatalf("paged=%v, want [primary]", paged)
+	}
+	var ev map[string]any
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		_ = json.Unmarshal([]byte(line), &ev)
+		if ev["event"] == "payout_rpc_chronic_outage" {
+			break
+		}
+		ev = nil
+	}
+	if ev == nil {
+		t.Fatalf("no payout_rpc_chronic_outage event emitted; log=%q", buf.String())
+	}
+	if ev["rpc_label"] != "primary" {
+		t.Errorf("rpc_label=%v, want primary", ev["rpc_label"])
+	}
+	if ev["severity"] != "PAGE" {
+		t.Errorf("severity=%v, want PAGE", ev["severity"])
+	}
+	if rate, _ := ev["error_rate"].(float64); rate < 0.5 {
+		t.Errorf("error_rate=%v, want >= 0.5", ev["error_rate"])
+	}
+}
+
+func TestChronicOutageTracker_RespectsCooldown(t *testing.T) {
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	log := zerolog.New(&buf)
+	tracker := NewChronicOutageTracker(log, func() time.Time { return now }).
+		WithWindow(10 * time.Minute).
+		WithThreshold(0.5).
+		WithMinSamples(10).
+		WithCooldown(10 * time.Minute)
+	for i := 0; i < 10; i++ {
+		tracker.Record("primary", true)
+	}
+	first := tracker.Evaluate(context.Background(), now)
+	if len(first) != 1 {
+		t.Fatalf("first evaluate paged=%v, want one", first)
+	}
+	// Second Evaluate within the cooldown MUST NOT page again.
+	soon := now.Add(time.Minute)
+	second := tracker.Evaluate(context.Background(), soon)
+	if len(second) != 0 {
+		t.Errorf("second evaluate within cooldown paged=%v, want zero", second)
+	}
+	// Past the cooldown — re-page allowed.
+	later := now.Add(11 * time.Minute)
+	// Records must still be inside the window for re-page; add fresh ones at `later`.
+	tracker.nowFn = func() time.Time { return later }
+	for i := 0; i < 10; i++ {
+		tracker.Record("primary", true)
+	}
+	third := tracker.Evaluate(context.Background(), later)
+	if len(third) != 1 {
+		t.Errorf("third evaluate past cooldown paged=%v, want one", third)
+	}
+}
+
+func TestChronicOutageTracker_RequiresMinSamples(t *testing.T) {
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	log := zerolog.New(&buf)
+	tracker := NewChronicOutageTracker(log, func() time.Time { return now }).
+		WithWindow(10 * time.Minute).
+		WithThreshold(0.5).
+		WithMinSamples(10).
+		WithCooldown(10 * time.Minute)
+	// 5 errors out of 5 is 100% rate but only 5 samples (< 10).
+	for i := 0; i < 5; i++ {
+		tracker.Record("primary", true)
+	}
+	paged := tracker.Evaluate(context.Background(), now)
+	if len(paged) != 0 {
+		t.Errorf("paged with %d samples, expected zero (below minSamples)", 5)
+	}
+	if strings.Contains(buf.String(), "payout_rpc_chronic_outage") {
+		t.Errorf("PAGE emitted below minSamples; log=%q", buf.String())
+	}
+}
+
+func TestChronicOutageTracker_PrunesStaleSamples(t *testing.T) {
+	t0 := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	cur := t0
+	tracker := NewChronicOutageTracker(zerolog.Nop(), func() time.Time { return cur }).
+		WithWindow(10 * time.Minute).
+		WithThreshold(0.5).
+		WithMinSamples(10).
+		WithCooldown(10 * time.Minute)
+	// 10 errors at t0 — would page if still in window.
+	for i := 0; i < 10; i++ {
+		tracker.Record("primary", true)
+	}
+	// Jump 30 minutes; old samples are now outside the 10min window.
+	cur = t0.Add(30 * time.Minute)
+	paged := tracker.Evaluate(context.Background(), cur)
+	if len(paged) != 0 {
+		t.Errorf("paged=%v after window expiry, want zero (stale samples must be pruned)", paged)
+	}
+}
+
+func TestChronicOutageTracker_PerLabelIsolation(t *testing.T) {
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	tracker := NewChronicOutageTracker(zerolog.Nop(), func() time.Time { return now }).
+		WithWindow(10 * time.Minute).
+		WithThreshold(0.5).
+		WithMinSamples(10).
+		WithCooldown(10 * time.Minute)
+	for i := 0; i < 10; i++ {
+		tracker.Record("primary", true) // 100% err
+	}
+	for i := 0; i < 10; i++ {
+		tracker.Record("secondary", false) // 0% err
+	}
+	paged := tracker.Evaluate(context.Background(), now)
+	if len(paged) != 1 || paged[0] != "primary" {
+		t.Errorf("paged=%v, want [primary] (secondary is healthy)", paged)
+	}
+}
+
+func TestChronicOutageTracker_NilSafeAndConcurrent(t *testing.T) {
+	// nil receiver MUST be safe (defensive — the wrapper passes the
+	// inner client through when tracker is nil, but Record may still
+	// be called by tests via the wrapper path).
+	var t0 *ChronicOutageTracker
+	t0.Record("primary", true) // must not panic
+
+	tracker := NewChronicOutageTracker(zerolog.Nop(), nil)
+	// 100 goroutines × 10 records each — race detector clean.
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				tracker.Record("primary", j%2 == 0)
+			}
+		}()
+	}
+	wg.Wait()
+	tracker.mu.Lock()
+	got := len(tracker.states["primary"].samples)
+	tracker.mu.Unlock()
+	if got != 1000 {
+		t.Errorf("samples=%d, want 1000", got)
+	}
+}
+
+// TestTrackingRPCClient_RecordsSuccessAndError pins the wrapper's
+// classification: only non-nil errors count as errors; the
+// (nil, nil) "not found" success path does not.
+func TestTrackingRPCClient_RecordsSuccessAndError(t *testing.T) {
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	tracker := NewChronicOutageTracker(zerolog.Nop(), func() time.Time { return now })
+	inner := &mockRPCClient{label: "primary"}
+	// First call: nil receipt + nil error → SUCCESS (not an err).
+	inner.receiptFn = func(_ context.Context, _ string) (*Receipt, error) { return nil, nil }
+	wrapped := NewTrackingRPCClient(inner, tracker)
+	if _, err := wrapped.TransactionReceipt(context.Background(), "0xabc"); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	// Second call: real error.
+	inner.receiptFn = func(_ context.Context, _ string) (*Receipt, error) { return nil, errors.New("boom") }
+	if _, err := wrapped.TransactionReceipt(context.Background(), "0xabc"); err == nil {
+		t.Fatalf("expected err, got nil")
+	}
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	st := tracker.states["primary"]
+	if st == nil || len(st.samples) != 2 {
+		t.Fatalf("samples=%v, want 2", st)
+	}
+	if st.samples[0].isErr {
+		t.Errorf("sample 0: (nil, nil) classified as error, want success")
+	}
+	if !st.samples[1].isErr {
+		t.Errorf("sample 1: non-nil err classified as success, want error")
+	}
+}
+
+// TestTrackingRPCClient_NilTrackerReturnsInner pins the zero-value
+// short-circuit: a nil tracker MUST return the inner client
+// unchanged so test paths that don't wire a tracker stay zero-cost.
+func TestTrackingRPCClient_NilTrackerReturnsInner(t *testing.T) {
+	inner := &mockRPCClient{label: "primary"}
+	got := NewTrackingRPCClient(inner, nil)
+	if got != inner {
+		t.Errorf("nil tracker did not return inner client; got %T", got)
+	}
+}

--- a/phase4-coordinator/internal/payout/migrations/0013_stale_cancel_keyset_index.sql
+++ b/phase4-coordinator/internal/payout/migrations/0013_stale_cancel_keyset_index.sql
@@ -1,0 +1,19 @@
+-- SPEC-016 §4.7 step 5 — #165 R4 code MEDIUM closure. The keyset-
+-- paginated stale-cancel producer iterates payout_attempts via
+-- ORDER BY (updated_at_utc, payout_id, attempt_seq) with strict-
+-- tuple cursor advance. Without a matching ordered index, SQLite
+-- materializes a TEMP B-TREE per chunk fetch — at chunk 256 and
+-- ceiling 20000 that is up to 78 sorts per cycle in the
+-- pathological-backlog path.
+--
+-- Partial index on the exact stale-cancel predicate keeps the
+-- index covering and small (only is_cancel_self_transfer=1
+-- rows with un-paged + un-abandoned + un-confirmed state are
+-- candidates). EXPLAIN QUERY PLAN should now report
+-- "USING INDEX idx_pa_stale_cancel_keyset" with no TEMP B-TREE.
+CREATE INDEX IF NOT EXISTS idx_pa_stale_cancel_keyset
+    ON payout_attempts(updated_at_utc, payout_id, attempt_seq)
+    WHERE is_cancel_self_transfer = 1
+      AND cancel_reconfirm_stale_paged_at_utc IS NULL
+      AND abandoned_at_utc IS NULL
+      AND confirmed_at_utc IS NULL;

--- a/phase4-coordinator/internal/payout/orphans.go
+++ b/phase4-coordinator/internal/payout/orphans.go
@@ -383,10 +383,19 @@ func (s *OrphansService) emitOrphanResolved(orphanID int64, resolution, reason s
 // a zero-value TwoRPCs (i.e. nil clients) disables the producer
 // entirely and returns (0, nil); tests use this path to avoid
 // wiring mock RPCs when the producer is not under test.
+//
+// limit bounds the per-cycle candidate scan (#165 A1: derived from
+// snap.MaxRowsPerRun). When the candidate set is larger than limit,
+// the producer scans the oldest limit rows by updated_at_utc ASC and
+// emits a payout_stale_outbox_backlog WARN with the actual candidate
+// count so operators can see when the LIMIT is suppressing rows.
+// Subsequent cycles continue draining the backlog. A limit <= 0 is
+// treated as "no cap" (back-compat for any caller wiring a zero-value
+// MaxRowsPerRun before the snapshot bound check fires).
 func ProduceStaleOutboxRows(
 	ctx context.Context, db *sql.DB, log zerolog.Logger,
 	rpcs TwoRPCs, runID string,
-	now time.Time, runInterval time.Duration,
+	now time.Time, runInterval time.Duration, limit int,
 ) (int, error) {
 	if rpcs.Primary == nil || rpcs.Secondary == nil {
 		// Producer disabled — typically a test path. The reaper
@@ -394,7 +403,13 @@ func ProduceStaleOutboxRows(
 		return 0, nil
 	}
 	cutoff := now.Add(-3 * runInterval).UTC().Format(time.RFC3339Nano)
-	rows, err := db.QueryContext(ctx, `
+	// #165 A1: LIMIT+1 peek. If the SELECT returns exactly limit+1
+	// rows we know there is at least one suppressed row; the precise
+	// candidate count is then queried via COUNT(*) for the backlog
+	// gauge. Steady-state (no backlog) costs one query; backlog cost
+	// is one extra COUNT(*) — acceptable because the gauge fires
+	// exactly when the operator wants to see it.
+	query := `
 SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
   FROM payout_attempts
  WHERE is_cancel_self_transfer = 1
@@ -404,7 +419,18 @@ SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
    AND cancel_reconfirm_stale_paged_at_utc IS NULL
    AND abandoned_at_utc IS NULL
    AND updated_at_utc < ?
- ORDER BY updated_at_utc ASC`, cutoff)
+ ORDER BY updated_at_utc ASC`
+	var (
+		rows  *sql.Rows
+		err   error
+		probe int
+	)
+	if limit > 0 {
+		probe = limit + 1
+		rows, err = db.QueryContext(ctx, query+" LIMIT ?", cutoff, probe)
+	} else {
+		rows, err = db.QueryContext(ctx, query, cutoff)
+	}
 	if err != nil {
 		return 0, fmt.Errorf("ProduceStaleOutboxRows: SELECT: %w", err)
 	}
@@ -427,6 +453,39 @@ SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
 		candidates = append(candidates, c)
 	}
 	rows.Close()
+
+	// #165 A1: backlog detection. If LIMIT+1 was the probe size and
+	// we got back probe rows, at least one candidate was suppressed
+	// this cycle. Query the exact backlog count so the gauge surfaces
+	// an actionable number, then drop the overflow row so production
+	// stays bounded by limit.
+	if limit > 0 && len(candidates) == probe {
+		var total int
+		if err := db.QueryRowContext(ctx, `
+SELECT COUNT(*)
+  FROM payout_attempts
+ WHERE is_cancel_self_transfer = 1
+   AND raw_signed_tx IS NOT NULL
+   AND broadcast_at_utc IS NOT NULL
+   AND confirmed_at_utc IS NULL
+   AND cancel_reconfirm_stale_paged_at_utc IS NULL
+   AND abandoned_at_utc IS NULL
+   AND updated_at_utc < ?`, cutoff).Scan(&total); err != nil {
+			// COUNT failure is observability-only; degrade to a
+			// limit-hit signal (total=-1 sentinel) rather than
+			// stalling the producer.
+			total = -1
+		}
+		log.Warn().
+			Str("event", "payout_stale_outbox_backlog").
+			Str("run_id", runID).
+			Int("limit", limit).
+			Int("total_candidates", total).
+			Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
+			Str("severity", "WARN").
+			Send()
+		candidates = candidates[:limit]
+	}
 
 	produced := 0
 	staleStarted := now.UTC().Format(time.RFC3339Nano)

--- a/phase4-coordinator/internal/payout/orphans.go
+++ b/phase4-coordinator/internal/payout/orphans.go
@@ -384,14 +384,28 @@ func (s *OrphansService) emitOrphanResolved(orphanID int64, resolution, reason s
 // entirely and returns (0, nil); tests use this path to avoid
 // wiring mock RPCs when the producer is not under test.
 //
-// limit bounds the per-cycle candidate scan (#165 A1: derived from
-// snap.MaxRowsPerRun). When the candidate set is larger than limit,
-// the producer scans the oldest limit rows by updated_at_utc ASC and
-// emits a payout_stale_outbox_backlog WARN with the actual candidate
-// count so operators can see when the LIMIT is suppressing rows.
-// Subsequent cycles continue draining the backlog. A limit <= 0 is
-// treated as "no cap" (back-compat for any caller wiring a zero-value
-// MaxRowsPerRun before the snapshot bound check fires).
+// limit bounds the per-cycle PRODUCED outbox row count (#165 A1:
+// derived from snap.MaxRowsPerRun). The SCAN is bounded only by
+// the WHERE predicate (un-paged cancel-self-transfer rows older
+// than the stale cutoff) and traversed in keyset-paginated chunks
+// of staleOutboxChunkSize so memory stays O(chunk) regardless of
+// backlog size. A defensive runner-cycle ceiling of
+// staleOutboxScanCeiling rows caps total scan work; reaching it
+// promotes the backlog WARN to PAGE severity. Non-actionable
+// candidates (no tx_hash, transient RPC error, one-RPC-still-
+// sees-receipt) do NOT consume the production limit — they're
+// silently skipped and re-evaluated next cycle (their
+// updated_at_utc doesn't advance, so they stay in the candidate
+// set under cursor).
+//
+// A limit <= 0 is treated as "no production cap" (back-compat for
+// any caller wiring a zero-value MaxRowsPerRun before the snapshot
+// bound check fires).
+//
+// When production is capped before the candidate set is exhausted
+// the producer emits a payout_stale_outbox_backlog WARN with the
+// remaining-un-paged backlog count so operators can see drain
+// progress; subsequent cycles continue.
 func ProduceStaleOutboxRows(
 	ctx context.Context, db *sql.DB, log zerolog.Logger,
 	rpcs TwoRPCs, runID string,
@@ -403,24 +417,65 @@ func ProduceStaleOutboxRows(
 		return 0, nil
 	}
 	cutoff := now.Add(-3 * runInterval).UTC().Format(time.RFC3339Nano)
-	// #165 R1+R2 SECURITY HIGH closure: bound the PRODUCED outbox row
-	// count, NOT the scanned candidate set. The non-actionable skip
+	// #165 R1+R2+R3 SECURITY HIGH closure: bound the PRODUCED outbox
+	// row count, NOT the scanned candidate set. Non-actionable skip
 	// branches (empty tx_hash, RPC error, one-RPC-still-sees-receipt)
 	// persist in the candidate set across cycles (updated_at_utc
-	// doesn't advance on skip), so any ceiling on scanned rows
-	// reintroduces prefix-starvation denial-of-detection — non-
-	// actionable rows at the front of the order would permanently
-	// block truly stale cancels from PAGEing.
+	// doesn't advance on skip), so any *tight* ceiling on scanned
+	// rows reintroduces prefix-starvation denial-of-detection.
 	//
-	// The SELECT scan is bounded by the WHERE predicate
-	// (is_cancel_self_transfer=1 AND un-paged AND stale-cutoff). In
-	// normal operation this set is tiny (<<1000); in pathological
-	// backlog it can grow but A2's payout_rpc_chronic_outage PAGE
-	// fires on the chronic-RPC root cause and §7.4 chain-balance
-	// drift catches anything more sinister. Memory cost per row is
-	// ~bytes-of-tx-hash + ~50, so even 100k rows = ~10MB — still
-	// well under the runner's process budget.
-	rows, err := db.QueryContext(ctx, `
+	// R3 SEC HIGH closure refines this further: load via keyset
+	// pagination in chunks of staleOutboxChunkSize so memory stays
+	// bounded at O(chunk) regardless of pathological backlog, and
+	// terminate as soon as `produced == limit` (zero wasted scan
+	// past the production cap). A defensive hard ceiling
+	// staleOutboxScanCeiling caps total cycle scan rows to prevent
+	// runaway scans from blowing past the runner cycle budget; when
+	// hit, the producer emits payout_stale_outbox_backlog WARN with
+	// scan_ceiling_hit=true so operators see the emergency.
+	const (
+		staleOutboxChunkSize     = 256
+		staleOutboxScanCeiling   = 20000
+	)
+	type cand struct {
+		PayoutID         int64
+		AttemptSeq       int
+		Nonce            int64
+		TxHash           sql.NullString
+		BlockNumber      sql.NullInt64
+		ReorgReactivated string
+	}
+
+	produced := 0
+	scannedAll := true
+	scanCeilingHit := false
+	totalScanned := 0
+	var (
+		cursorUpdated   = ""
+		cursorPayoutID  int64
+		cursorAttemptSeq int
+		firstChunk      = true
+	)
+	staleStarted := now.UTC().Format(time.RFC3339Nano)
+
+chunkLoop:
+	for {
+		if totalScanned >= staleOutboxScanCeiling {
+			scanCeilingHit = true
+			scannedAll = false
+			break
+		}
+		// Keyset query: portable strict-tuple-ordering form
+		// `(updated_at_utc > ?) OR (... = ? AND payout_id > ?) OR
+		// (... = ? AND ... = ? AND attempt_seq > ?)`. Works on all
+		// SQLite versions in the project's mattn/go-sqlite3 line.
+		var (
+			chunk      []cand
+			rows       *sql.Rows
+			queryErr   error
+		)
+		if firstChunk {
+			rows, queryErr = db.QueryContext(ctx, `
 SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
   FROM payout_attempts
  WHERE is_cancel_self_transfer = 1
@@ -430,44 +485,66 @@ SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
    AND cancel_reconfirm_stale_paged_at_utc IS NULL
    AND abandoned_at_utc IS NULL
    AND updated_at_utc < ?
- ORDER BY updated_at_utc ASC`, cutoff)
-	if err != nil {
-		return 0, fmt.Errorf("ProduceStaleOutboxRows: SELECT: %w", err)
-	}
-	type cand struct {
-		PayoutID         int64
-		AttemptSeq       int
-		Nonce            int64
-		TxHash           sql.NullString
-		BlockNumber      sql.NullInt64
-		ReorgReactivated string
-	}
-	var candidates []cand
-	for rows.Next() {
-		var c cand
-		if err := rows.Scan(&c.PayoutID, &c.AttemptSeq, &c.Nonce,
-			&c.TxHash, &c.BlockNumber, &c.ReorgReactivated); err != nil {
-			rows.Close()
-			return 0, err
+ ORDER BY updated_at_utc ASC, payout_id ASC, attempt_seq ASC
+ LIMIT ?`, cutoff, staleOutboxChunkSize)
+		} else {
+			rows, queryErr = db.QueryContext(ctx, `
+SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
+  FROM payout_attempts
+ WHERE is_cancel_self_transfer = 1
+   AND raw_signed_tx IS NOT NULL
+   AND broadcast_at_utc IS NOT NULL
+   AND confirmed_at_utc IS NULL
+   AND cancel_reconfirm_stale_paged_at_utc IS NULL
+   AND abandoned_at_utc IS NULL
+   AND updated_at_utc < ?
+   AND (
+        updated_at_utc > ?
+     OR (updated_at_utc = ? AND payout_id > ?)
+     OR (updated_at_utc = ? AND payout_id = ? AND attempt_seq > ?)
+   )
+ ORDER BY updated_at_utc ASC, payout_id ASC, attempt_seq ASC
+ LIMIT ?`,
+				cutoff,
+				cursorUpdated,
+				cursorUpdated, cursorPayoutID,
+				cursorUpdated, cursorPayoutID, cursorAttemptSeq,
+				staleOutboxChunkSize,
+			)
 		}
-		candidates = append(candidates, c)
-	}
-	rows.Close()
-
-	produced := 0
-	scannedAll := true
-	staleStarted := now.UTC().Format(time.RFC3339Nano)
-	for _, c := range candidates {
-		if ctx.Err() != nil {
-			return produced, ctx.Err()
+		firstChunk = false
+		if queryErr != nil {
+			return produced, fmt.Errorf("ProduceStaleOutboxRows: SELECT: %w", queryErr)
 		}
-		// #165 R1 SEC HIGH closure: cap on PRODUCED rows, not
-		// candidates. Non-actionable skip branches below do NOT
-		// consume the limit budget.
-		if limit > 0 && produced >= limit {
-			scannedAll = false
+		for rows.Next() {
+			var c cand
+			if err := rows.Scan(&c.PayoutID, &c.AttemptSeq, &c.Nonce,
+				&c.TxHash, &c.BlockNumber, &c.ReorgReactivated); err != nil {
+				rows.Close()
+				return produced, err
+			}
+			chunk = append(chunk, c)
+		}
+		rows.Close()
+		if len(chunk) == 0 {
 			break
 		}
+		// Advance cursor to the LAST row in this chunk before
+		// processing — even on per-row early return / break, the
+		// next cycle resumes past this chunk.
+		last := chunk[len(chunk)-1]
+		cursorUpdated = last.ReorgReactivated
+		cursorPayoutID = last.PayoutID
+		cursorAttemptSeq = last.AttemptSeq
+		totalScanned += len(chunk)
+		for _, c := range chunk {
+			if ctx.Err() != nil {
+				return produced, ctx.Err()
+			}
+			if limit > 0 && produced >= limit {
+				scannedAll = false
+				break chunkLoop
+			}
 		// Codex Step 3 r2 [arch:r2-3.2-A] MAJOR closure: SPEC §4.7
 		// requires BOTH RPCs to still return "not found" before
 		// the stale PAGE fires. A cancel that one of the two
@@ -599,18 +676,23 @@ SELECT id FROM cancel_reconfirm_stale_outbox
 				})
 			}
 		}
-	}
+		} // close inner per-row range
+		if len(chunk) < staleOutboxChunkSize {
+			// Drained — no more candidates past the cursor.
+			break
+		}
+	} // close chunkLoop
 
 	// #165 A1 backlog gauge. Emit payout_stale_outbox_backlog WARN
 	// when production was capped before the candidate set was
-	// exhausted (limit > 0 AND produced == limit AND we broke early).
-	// The event repeats every runner cycle while backlog persists —
-	// intentionally, so the operator sees the gauge each cycle until
-	// the queue drains under cap. The exact backlog count (remaining
-	// un-paged candidates AFTER this cycle's production) is queried
-	// only on the slow path so steady-state cost is zero.
+	// exhausted (limit > 0 AND produced == limit AND we broke early)
+	// OR when the defensive scan ceiling was hit (true emergency:
+	// backlog is so deep the producer can't drain it under cycle
+	// budget). The event repeats every runner cycle while backlog
+	// persists — intentionally, so the operator sees the gauge each
+	// cycle until the queue drains under cap.
 	productionCapped := limit > 0 && produced >= limit && !scannedAll
-	if productionCapped {
+	if productionCapped || scanCeilingHit {
 		var total int
 		if err := db.QueryRowContext(ctx, `
 SELECT COUNT(*)
@@ -627,14 +709,23 @@ SELECT COUNT(*)
 			// stalling the producer.
 			total = -1
 		}
+		// Severity is PAGE when scan_ceiling_hit (true emergency:
+		// backlog exceeds the defensive runner-cycle scan budget) and
+		// WARN otherwise (normal cap-throttled drain in progress).
+		severity := "WARN"
+		if scanCeilingHit {
+			severity = "PAGE"
+		}
 		log.Warn().
 			Str("event", "payout_stale_outbox_backlog").
 			Str("run_id", runID).
 			Int("limit", limit).
 			Int("produced", produced).
 			Int("total_candidates", total).
+			Bool("scan_ceiling_hit", scanCeilingHit).
+			Int("total_scanned", totalScanned).
 			Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
-			Str("severity", "WARN").
+			Str("severity", severity).
 			Send()
 	}
 	return produced, nil

--- a/phase4-coordinator/internal/payout/orphans.go
+++ b/phase4-coordinator/internal/payout/orphans.go
@@ -465,6 +465,15 @@ chunkLoop:
 			scannedAll = false
 			break
 		}
+		// #165 R4 code LOW closure: clamp the chunk LIMIT to the
+		// remaining ceiling so we never scan past
+		// staleOutboxScanCeiling rows in a single cycle (R4 audit
+		// flagged a 20224-row worst case at chunk 256 + ceiling
+		// 20000 — off by one chunk).
+		chunkLimit := staleOutboxChunkSize
+		if remaining := staleOutboxScanCeiling - totalScanned; remaining < chunkLimit {
+			chunkLimit = remaining
+		}
 		// Keyset query: portable strict-tuple-ordering form
 		// `(updated_at_utc > ?) OR (... = ? AND payout_id > ?) OR
 		// (... = ? AND ... = ? AND attempt_seq > ?)`. Works on all
@@ -486,7 +495,7 @@ SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
    AND abandoned_at_utc IS NULL
    AND updated_at_utc < ?
  ORDER BY updated_at_utc ASC, payout_id ASC, attempt_seq ASC
- LIMIT ?`, cutoff, staleOutboxChunkSize)
+ LIMIT ?`, cutoff, chunkLimit)
 		} else {
 			rows, queryErr = db.QueryContext(ctx, `
 SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
@@ -509,7 +518,7 @@ SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
 				cursorUpdated,
 				cursorUpdated, cursorPayoutID,
 				cursorUpdated, cursorPayoutID, cursorAttemptSeq,
-				staleOutboxChunkSize,
+				chunkLimit,
 			)
 		}
 		firstChunk = false
@@ -677,7 +686,7 @@ SELECT id FROM cancel_reconfirm_stale_outbox
 			}
 		}
 		} // close inner per-row range
-		if len(chunk) < staleOutboxChunkSize {
+		if len(chunk) < chunkLimit {
 			// Drained — no more candidates past the cursor.
 			break
 		}

--- a/phase4-coordinator/internal/payout/orphans.go
+++ b/phase4-coordinator/internal/payout/orphans.go
@@ -403,13 +403,25 @@ func ProduceStaleOutboxRows(
 		return 0, nil
 	}
 	cutoff := now.Add(-3 * runInterval).UTC().Format(time.RFC3339Nano)
-	// #165 A1: LIMIT+1 peek. If the SELECT returns exactly limit+1
-	// rows we know there is at least one suppressed row; the precise
-	// candidate count is then queried via COUNT(*) for the backlog
-	// gauge. Steady-state (no backlog) costs one query; backlog cost
-	// is one extra COUNT(*) — acceptable because the gauge fires
-	// exactly when the operator wants to see it.
-	query := `
+	// #165 R1 SECURITY HIGH closure: the previous LIMIT+1 peek capped
+	// the SCANNED candidate set, which is the wrong authority. Loop
+	// branches at lines below skip rows with empty tx_hash, with RPC
+	// errors, or with at-least-one-RPC-still-seeing-the-receipt —
+	// these skipped rows persist in the candidate set across cycles
+	// (no UPDATE fires, so updated_at_utc is unchanged and they sort
+	// identically). With a LIMIT-bounded scan, the first `limit`
+	// non-actionable rows would permanently consume the scan budget
+	// and indefinitely suppress truly stale cancels from becoming
+	// payout_cancel_self_transfer_reconfirm_stale PAGE events
+	// (denial-of-detection).
+	//
+	// The correct contract is: bound the PRODUCED outbox row count,
+	// not the scan. The hard scan cap below (staleOutboxScanCap)
+	// keeps memory bounded in the pathological-backlog case; in
+	// normal operation the candidate set is small (cancel rows +
+	// un-paged + stale-cutoff) and the scan cap is never hit.
+	const staleOutboxScanCap = 1000
+	rows, err := db.QueryContext(ctx, `
 SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
   FROM payout_attempts
  WHERE is_cancel_self_transfer = 1
@@ -419,18 +431,8 @@ SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
    AND cancel_reconfirm_stale_paged_at_utc IS NULL
    AND abandoned_at_utc IS NULL
    AND updated_at_utc < ?
- ORDER BY updated_at_utc ASC`
-	var (
-		rows  *sql.Rows
-		err   error
-		probe int
-	)
-	if limit > 0 {
-		probe = limit + 1
-		rows, err = db.QueryContext(ctx, query+" LIMIT ?", cutoff, probe)
-	} else {
-		rows, err = db.QueryContext(ctx, query, cutoff)
-	}
+ ORDER BY updated_at_utc ASC
+ LIMIT ?`, cutoff, staleOutboxScanCap)
 	if err != nil {
 		return 0, fmt.Errorf("ProduceStaleOutboxRows: SELECT: %w", err)
 	}
@@ -454,44 +456,19 @@ SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
 	}
 	rows.Close()
 
-	// #165 A1: backlog detection. If LIMIT+1 was the probe size and
-	// we got back probe rows, at least one candidate was suppressed
-	// this cycle. Query the exact backlog count so the gauge surfaces
-	// an actionable number, then drop the overflow row so production
-	// stays bounded by limit.
-	if limit > 0 && len(candidates) == probe {
-		var total int
-		if err := db.QueryRowContext(ctx, `
-SELECT COUNT(*)
-  FROM payout_attempts
- WHERE is_cancel_self_transfer = 1
-   AND raw_signed_tx IS NOT NULL
-   AND broadcast_at_utc IS NOT NULL
-   AND confirmed_at_utc IS NULL
-   AND cancel_reconfirm_stale_paged_at_utc IS NULL
-   AND abandoned_at_utc IS NULL
-   AND updated_at_utc < ?`, cutoff).Scan(&total); err != nil {
-			// COUNT failure is observability-only; degrade to a
-			// limit-hit signal (total=-1 sentinel) rather than
-			// stalling the producer.
-			total = -1
-		}
-		log.Warn().
-			Str("event", "payout_stale_outbox_backlog").
-			Str("run_id", runID).
-			Int("limit", limit).
-			Int("total_candidates", total).
-			Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
-			Str("severity", "WARN").
-			Send()
-		candidates = candidates[:limit]
-	}
-
 	produced := 0
+	scannedAll := true
 	staleStarted := now.UTC().Format(time.RFC3339Nano)
 	for _, c := range candidates {
 		if ctx.Err() != nil {
 			return produced, ctx.Err()
+		}
+		// #165 R1 SEC HIGH closure: cap on PRODUCED rows, not
+		// candidates. Non-actionable skip branches below do NOT
+		// consume the limit budget.
+		if limit > 0 && produced >= limit {
+			scannedAll = false
+			break
 		}
 		// Codex Step 3 r2 [arch:r2-3.2-A] MAJOR closure: SPEC §4.7
 		// requires BOTH RPCs to still return "not found" before
@@ -624,6 +601,43 @@ SELECT id FROM cancel_reconfirm_stale_outbox
 				})
 			}
 		}
+	}
+
+	// #165 A1 backlog gauge. Emit payout_stale_outbox_backlog WARN
+	// when production was capped before the candidate set was
+	// exhausted (limit > 0 AND produced == limit AND we broke early)
+	// OR when the scan itself was capped at staleOutboxScanCap
+	// (indicates pathological backlog). The exact backlog count is
+	// queried only on the slow path so steady-state cost is zero.
+	scanCapHit := len(candidates) == staleOutboxScanCap
+	productionCapped := limit > 0 && produced >= limit && !scannedAll
+	if productionCapped || scanCapHit {
+		var total int
+		if err := db.QueryRowContext(ctx, `
+SELECT COUNT(*)
+  FROM payout_attempts
+ WHERE is_cancel_self_transfer = 1
+   AND raw_signed_tx IS NOT NULL
+   AND broadcast_at_utc IS NOT NULL
+   AND confirmed_at_utc IS NULL
+   AND cancel_reconfirm_stale_paged_at_utc IS NULL
+   AND abandoned_at_utc IS NULL
+   AND updated_at_utc < ?`, cutoff).Scan(&total); err != nil {
+			// COUNT failure is observability-only; degrade to a
+			// cap-hit signal (total=-1 sentinel) rather than
+			// stalling the producer.
+			total = -1
+		}
+		log.Warn().
+			Str("event", "payout_stale_outbox_backlog").
+			Str("run_id", runID).
+			Int("limit", limit).
+			Int("produced", produced).
+			Int("total_candidates", total).
+			Bool("scan_cap_hit", scanCapHit).
+			Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
+			Str("severity", "WARN").
+			Send()
 	}
 	return produced, nil
 }

--- a/phase4-coordinator/internal/payout/orphans.go
+++ b/phase4-coordinator/internal/payout/orphans.go
@@ -403,24 +403,23 @@ func ProduceStaleOutboxRows(
 		return 0, nil
 	}
 	cutoff := now.Add(-3 * runInterval).UTC().Format(time.RFC3339Nano)
-	// #165 R1 SECURITY HIGH closure: the previous LIMIT+1 peek capped
-	// the SCANNED candidate set, which is the wrong authority. Loop
-	// branches at lines below skip rows with empty tx_hash, with RPC
-	// errors, or with at-least-one-RPC-still-seeing-the-receipt —
-	// these skipped rows persist in the candidate set across cycles
-	// (no UPDATE fires, so updated_at_utc is unchanged and they sort
-	// identically). With a LIMIT-bounded scan, the first `limit`
-	// non-actionable rows would permanently consume the scan budget
-	// and indefinitely suppress truly stale cancels from becoming
-	// payout_cancel_self_transfer_reconfirm_stale PAGE events
-	// (denial-of-detection).
+	// #165 R1+R2 SECURITY HIGH closure: bound the PRODUCED outbox row
+	// count, NOT the scanned candidate set. The non-actionable skip
+	// branches (empty tx_hash, RPC error, one-RPC-still-sees-receipt)
+	// persist in the candidate set across cycles (updated_at_utc
+	// doesn't advance on skip), so any ceiling on scanned rows
+	// reintroduces prefix-starvation denial-of-detection — non-
+	// actionable rows at the front of the order would permanently
+	// block truly stale cancels from PAGEing.
 	//
-	// The correct contract is: bound the PRODUCED outbox row count,
-	// not the scan. The hard scan cap below (staleOutboxScanCap)
-	// keeps memory bounded in the pathological-backlog case; in
-	// normal operation the candidate set is small (cancel rows +
-	// un-paged + stale-cutoff) and the scan cap is never hit.
-	const staleOutboxScanCap = 1000
+	// The SELECT scan is bounded by the WHERE predicate
+	// (is_cancel_self_transfer=1 AND un-paged AND stale-cutoff). In
+	// normal operation this set is tiny (<<1000); in pathological
+	// backlog it can grow but A2's payout_rpc_chronic_outage PAGE
+	// fires on the chronic-RPC root cause and §7.4 chain-balance
+	// drift catches anything more sinister. Memory cost per row is
+	// ~bytes-of-tx-hash + ~50, so even 100k rows = ~10MB — still
+	// well under the runner's process budget.
 	rows, err := db.QueryContext(ctx, `
 SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
   FROM payout_attempts
@@ -431,8 +430,7 @@ SELECT payout_id, attempt_seq, nonce, tx_hash, block_number, updated_at_utc
    AND cancel_reconfirm_stale_paged_at_utc IS NULL
    AND abandoned_at_utc IS NULL
    AND updated_at_utc < ?
- ORDER BY updated_at_utc ASC
- LIMIT ?`, cutoff, staleOutboxScanCap)
+ ORDER BY updated_at_utc ASC`, cutoff)
 	if err != nil {
 		return 0, fmt.Errorf("ProduceStaleOutboxRows: SELECT: %w", err)
 	}
@@ -605,13 +603,14 @@ SELECT id FROM cancel_reconfirm_stale_outbox
 
 	// #165 A1 backlog gauge. Emit payout_stale_outbox_backlog WARN
 	// when production was capped before the candidate set was
-	// exhausted (limit > 0 AND produced == limit AND we broke early)
-	// OR when the scan itself was capped at staleOutboxScanCap
-	// (indicates pathological backlog). The exact backlog count is
-	// queried only on the slow path so steady-state cost is zero.
-	scanCapHit := len(candidates) == staleOutboxScanCap
+	// exhausted (limit > 0 AND produced == limit AND we broke early).
+	// The event repeats every runner cycle while backlog persists —
+	// intentionally, so the operator sees the gauge each cycle until
+	// the queue drains under cap. The exact backlog count (remaining
+	// un-paged candidates AFTER this cycle's production) is queried
+	// only on the slow path so steady-state cost is zero.
 	productionCapped := limit > 0 && produced >= limit && !scannedAll
-	if productionCapped || scanCapHit {
+	if productionCapped {
 		var total int
 		if err := db.QueryRowContext(ctx, `
 SELECT COUNT(*)
@@ -634,7 +633,6 @@ SELECT COUNT(*)
 			Int("limit", limit).
 			Int("produced", produced).
 			Int("total_candidates", total).
-			Bool("scan_cap_hit", scanCapHit).
 			Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
 			Str("severity", "WARN").
 			Send()

--- a/phase4-coordinator/internal/payout/runner.go
+++ b/phase4-coordinator/internal/payout/runner.go
@@ -487,9 +487,11 @@ func (r *Runner) RunOnce(ctx context.Context) (string, error) {
 	// already does this (reaper.go:58); the stale-cancel threshold
 	// 3 × run_interval must be live-read on both paths so a SIGHUP
 	// run_interval change takes effect without a restart.
-	// #165 A1: LIMIT bound on candidate scan + backlog gauge. Sized
-	// from snap.MaxRowsPerRun so the stale-cancel producer matches
-	// the §4.3 step 1 cap (bounded by the same operator config).
+	// #165 A1: cap on PRODUCED outbox rows (NOT scanned candidates)
+	// sized from snap.MaxRowsPerRun so the stale-cancel producer
+	// matches the §4.3 step 1 cap (bounded by the same operator
+	// config). The scan inside ProduceStaleOutboxRows is keyset-
+	// paginated so memory stays bounded regardless of backlog depth.
 	if produced, err := ProduceStaleOutboxRows(ctx, r.opts.DB, r.opts.Logger,
 		r.opts.RPCs, runID, now, snap.RunInterval, snap.MaxRowsPerRun,
 	); err != nil {

--- a/phase4-coordinator/internal/payout/runner.go
+++ b/phase4-coordinator/internal/payout/runner.go
@@ -88,6 +88,13 @@ type RunnerOptions struct {
 	// is documented as a known limitation requiring restart.
 	Tuning *TuningProvider
 
+	// ChronicOutageTracker, when non-nil, is evaluated once per
+	// RunOnce cycle to emit payout_rpc_chronic_outage PAGE when a
+	// single RPC has been failing for longer than the tracker's
+	// window. #165 A2 closes the silent-degradation gap in the
+	// two-RPC discipline.
+	ChronicOutage *ChronicOutageTracker
+
 	// Test/instrumentation hooks. Production wiring leaves these nil.
 	SleepAfterPostCommitLeaseReread time.Duration
 	NowFn                           func() time.Time
@@ -480,8 +487,11 @@ func (r *Runner) RunOnce(ctx context.Context) (string, error) {
 	// already does this (reaper.go:58); the stale-cancel threshold
 	// 3 × run_interval must be live-read on both paths so a SIGHUP
 	// run_interval change takes effect without a restart.
+	// #165 A1: LIMIT bound on candidate scan + backlog gauge. Sized
+	// from snap.MaxRowsPerRun so the stale-cancel producer matches
+	// the §4.3 step 1 cap (bounded by the same operator config).
 	if produced, err := ProduceStaleOutboxRows(ctx, r.opts.DB, r.opts.Logger,
-		r.opts.RPCs, runID, now, snap.RunInterval,
+		r.opts.RPCs, runID, now, snap.RunInterval, snap.MaxRowsPerRun,
 	); err != nil {
 		r.opts.Logger.Warn().Err(err).
 			Str("event", "payout_stale_outbox_producer_failed").Send()
@@ -498,6 +508,12 @@ func (r *Runner) RunOnce(ctx context.Context) (string, error) {
 	// Failure here is observability-only — degraded telemetry is
 	// preferred over a money-path stall on transient RPC error.
 	r.emitBalanceAlerts(ctx, runID, now, snap)
+
+	// #165 A2: chronic single-RPC outage detector. Runs once per
+	// cycle after the §6.2 alerts so the sliding-window includes
+	// the freshest RPC calls. Observability-only — never blocks
+	// the cycle.
+	r.opts.ChronicOutage.Evaluate(ctx, now)
 
 	// §4.3 step 1: SELECT ready rows.
 	hotWallet := r.opts.Security.HotWalletAddress

--- a/phase4-coordinator/internal/payout/step3_r2_test.go
+++ b/phase4-coordinator/internal/payout/step3_r2_test.go
@@ -49,7 +49,7 @@ func TestProduceStaleOutboxRows_BothRPCsMissAfterThreshold_Produces(t *testing.T
 
 	produced, err := ProduceStaleOutboxRows(
 		context.Background(), db, zerolog.Nop(),
-		rpcs, "run-A", time.Now(), runInterval,
+		rpcs, "run-A", time.Now(), runInterval, 0,
 	)
 	if err != nil {
 		t.Fatalf("ProduceStaleOutboxRows: %v", err)
@@ -105,7 +105,7 @@ func TestProduceStaleOutboxRows_PrimaryReturnsReceipt_DoesNotPage(t *testing.T) 
 
 	produced, err := ProduceStaleOutboxRows(
 		context.Background(), db, zerolog.Nop(),
-		rpcs, "run-B", time.Now(), runInterval,
+		rpcs, "run-B", time.Now(), runInterval, 0,
 	)
 	if err != nil {
 		t.Fatalf("ProduceStaleOutboxRows: %v", err)
@@ -133,7 +133,7 @@ func TestProduceStaleOutboxRows_NoRPCs_Disabled(t *testing.T) {
 	_ = seedStaleCancelRow(t, db, time.Minute, "0xdisabled")
 	produced, err := ProduceStaleOutboxRows(
 		context.Background(), db, zerolog.Nop(),
-		TwoRPCs{}, "run-C", time.Now(), time.Minute,
+		TwoRPCs{}, "run-C", time.Now(), time.Minute, 0,
 	)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/specs/AUDIT_ISS_165_R1_ARCH_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R1_ARCH_PROMPT.md
@@ -1,0 +1,78 @@
+# Audit: ISS-165 R1 architect lens
+
+Issue #165 IMPLs two LOW arch advisories deferred from PR #164:
+- **A1**: `ProduceStaleOutboxRows` accepts a `limit` from
+  `snap.MaxRowsPerRun`; LIMIT+1 peek + COUNT(*) for backlog;
+  emits `payout_stale_outbox_backlog` WARN.
+- **A2**: `ChronicOutageTracker` + `TrackingRPCClient` wrapper +
+  `payout_rpc_chronic_outage` PAGE, evaluated once per runner cycle.
+
+SPEC: SPEC-016 v0.1.22 documents both events in §7.1.
+
+Tree at HEAD: `spec/iss-165-spec-016-followups` (`git log --oneline -2`).
+
+## Files in scope
+
+- `phase4-coordinator/internal/payout/orphans.go` (modified)
+- `phase4-coordinator/internal/payout/chronic.go` (new)
+- `phase4-coordinator/internal/payout/runner.go` (modified)
+- `phase4-coordinator/cmd/coordinator/main.go` (modified)
+- `phase4-coordinator/internal/payout/iss165_a1_test.go` (new)
+- `phase4-coordinator/internal/payout/iss165_a2_test.go` (new)
+- `specs/SPEC-016-payout-pipeline.md` (v0.1.22)
+
+## What I want from you (architect lens)
+
+Find **DESIGN DEFECTS**: SPEC↔IMPL drift, missing call sites where
+the new abstraction SHOULD be authoritative, cross-spec contracts
+the change forgot, scaling/concurrency model errors,
+observability gaps that make the IMPL fail-quiet, missing operator
+runbook anchors.
+
+Specifically inspect:
+
+1. **A1 LIMIT semantics**: Is `snap.MaxRowsPerRun` the right cap for
+   §4.7 step-5 production? The §4.3 ready-row scan uses the same
+   cap. If the operator sets `max_rows_per_run=200`, is 200 stale
+   cancels per cycle too many (PAGE storm) or too few (slow
+   drain)? Should §4.7 have its own cap or share one?
+2. **Backlog drain convergence**: when backlog persists across many
+   cycles, does the `payout_stale_outbox_backlog` WARN repeat each
+   cycle? Is that the desired operator behavior, or should it
+   throttle?
+3. **Cooldown vs window interaction**: A2's PAGE cooldown is 10min
+   and window is 10min — once a label PAGEs, the next PAGE can only
+   fire when fresh samples accumulate AND the cooldown expires.
+   Is the steady-state behavior reasonable (PAGE-fire-then-quiet
+   while still failing)?
+4. **Wrapper completeness**: does `TrackingRPCClient` cover every
+   `RPCClient` method? Are there call sites that bypass the wrapper
+   (direct `payout.NewHTTPRPCClient` callers, fake test clients)?
+   Verify `main.go` is the only construction site.
+5. **Tracker location**: tracker is owned by the runner and
+   evaluated once per cycle. But the reorg poller, chain-balance
+   worker, and admin endpoints also share the same RPCs via the
+   wrapper. Does the once-per-cycle Evaluate cadence miss a chronic
+   outage that ONLY shows up during the chain-balance worker's
+   independent ticker? Should other tickers also Evaluate?
+6. **SPEC v0.1.22 entry**: does the §7.1 row set match the IMPL
+   emits exactly? Any prose elsewhere in the SPEC body that now
+   contradicts the new events?
+7. **Test coverage adequacy**: do the regression tests pin the
+   FAILURE class each advisory was supposed to close, or do they
+   only test the happy path?
+
+Find **DESIGN DEFECTS**. Stay narrow — separate code + security
+lanes cover correctness + threat-model.
+
+Severity:
+- CRITICAL: SPEC↔IMPL drift on money path; missing
+  authority-everywhere coverage; broken cross-spec contract.
+- HIGH: observability gap that hides a real failure mode in
+  production; runbook anchor missing for a PAGE event.
+- MEDIUM: design awkwardness that will force a churn-y refactor
+  in the next change.
+- LOW: deferrable architectural polish.
+
+Output format identical to the code lens. End with
+`## Convergence X/X/X/X → DECISION`.

--- a/specs/AUDIT_ISS_165_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R1_CODE_PROMPT.md
@@ -1,0 +1,76 @@
+# Audit: ISS-165 R1 code lens (LIMIT + chronic-outage IMPL)
+
+You are reviewing a code change for the macprovider monorepo. You may
+NOT read external state — only files in this repo. Tree at HEAD:
+`spec/iss-165-spec-016-followups` (`git log --oneline -2`).
+
+## Scope
+
+Issue #165 closes two LOW arch advisories deferred from PR #164:
+
+- **A1**: `phase4-coordinator/internal/payout/orphans.go::ProduceStaleOutboxRows`
+  now accepts a `limit int` (sized from `snap.MaxRowsPerRun`), uses a
+  LIMIT+1 peek to detect backlog, runs a COUNT(*) for the exact figure
+  on overflow, emits `payout_stale_outbox_backlog` WARN, and drops the
+  overflow row so production stays bounded by `limit`.
+- **A2**: new `phase4-coordinator/internal/payout/chronic.go` adds a
+  `ChronicOutageTracker` (sliding-window per-RPC-label error-rate
+  detector) and `TrackingRPCClient` wrapper. Wired from `main.go`;
+  runner `Evaluate()`s once per cycle and emits
+  `payout_rpc_chronic_outage` PAGE.
+
+SPEC: SPEC-016 v0.1.22 documents both events in §7.1.
+
+Tests: 4 + 7 added in `iss165_a1_test.go` + `iss165_a2_test.go`.
+
+## Files in scope
+
+- `phase4-coordinator/internal/payout/orphans.go` (modified)
+- `phase4-coordinator/internal/payout/chronic.go` (new)
+- `phase4-coordinator/internal/payout/runner.go` (modified)
+- `phase4-coordinator/cmd/coordinator/main.go` (modified)
+- `phase4-coordinator/internal/payout/iss165_a1_test.go` (new)
+- `phase4-coordinator/internal/payout/iss165_a2_test.go` (new)
+- `phase4-coordinator/internal/payout/step3_r2_test.go` (call-site update)
+- `specs/SPEC-016-payout-pipeline.md` (v0.1.22 change-log + §7.1 rows)
+
+## What I want from you (code lens)
+
+Find **CODE DEFECTS** in this diff: bugs, races, off-by-ones, wrong
+default behavior, missing nil checks, broken backward compatibility,
+incorrect SQL semantics, incorrect concurrent state mutations. Stay
+narrow to code — do not duplicate the architect or security lanes
+(separate prompts cover those).
+
+For each finding, label severity:
+- **CRITICAL**: silent money/data loss, deadlock, panic on a
+  realistic input.
+- **HIGH**: observably wrong behavior in production, or test gap
+  large enough to mask a real defect.
+- **MEDIUM**: subtle bug, edge case missed, fragile structure that
+  would bite the next change.
+- **LOW**: lint-level smell, deferrable polish.
+
+Output format:
+
+```
+## CRITICAL
+- <site>:<line> — <one-line claim>
+  Repro: <short repro / scenario>
+  Fix: <one-line suggestion>
+
+## HIGH
+...
+
+## MEDIUM
+...
+
+## LOW
+...
+
+## Convergence
+0/0/0/0 → NO FIX PASS, or N/N/N/N → NEEDS FIX PASS
+```
+
+Mark the final convergence line as `0/0/0/0 → NO FIX PASS` only when
+you found zero CRITICAL/HIGH/MEDIUM and at most ack-only LOWs.

--- a/specs/AUDIT_ISS_165_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R1_SECURITY_PROMPT.md
@@ -1,0 +1,65 @@
+# Audit: ISS-165 R1 security lens
+
+Issue #165 closes two LOW arch advisories deferred from PR #164:
+- **A1**: `ProduceStaleOutboxRows` LIMIT + `payout_stale_outbox_backlog`
+  WARN gauge.
+- **A2**: `ChronicOutageTracker` + `TrackingRPCClient` wrapper +
+  `payout_rpc_chronic_outage` PAGE.
+
+Tree at HEAD: `spec/iss-165-spec-016-followups` (`git log --oneline -2`).
+
+## Files in scope
+
+- `phase4-coordinator/internal/payout/orphans.go` (modified)
+- `phase4-coordinator/internal/payout/chronic.go` (new)
+- `phase4-coordinator/internal/payout/runner.go` (modified)
+- `phase4-coordinator/cmd/coordinator/main.go` (modified)
+- `phase4-coordinator/internal/payout/iss165_a1_test.go` (new)
+- `phase4-coordinator/internal/payout/iss165_a2_test.go` (new)
+- `specs/SPEC-016-payout-pipeline.md` (v0.1.22 change-log + §7.1)
+
+## Threat model
+
+Money path — the §4.7 producer governs which stale-cancel rows
+become operator PAGE events. The chronic-outage tracker is the
+operator's only signal for chronic single-RPC failure (the disagreement
+detector at §4.4 doesn't fire when one side is silently failing).
+
+Specifically watch for:
+
+1. **Suppression / silencing**: can A1's LIMIT cause an indefinite
+   delay in PAGEing a stale cancel? Could backlog grow faster than
+   the runner drains so a row never gets paged? Could the COUNT(*)
+   failure mask the backlog?
+2. **PAGE-storm / DoS-on-operator**: can A2 emit excessive PAGEs?
+   Does the cooldown protect the journal? Can an adversary force a
+   PAGE by inducing one-sided RPC errors (e.g. via TLS pin mismatch
+   on one side only) and what's the cost?
+3. **Tracker poisoning / state staleness**: can samples accumulate
+   without bound? Are samples pruned correctly? Is the per-label
+   mutex held across blocking operations?
+4. **Secret leakage**: do any log fields expose RPC URLs, SPKI pins,
+   wallet bytes, or signed tx bytes? `rpc_label` is documented as
+   non-secret (e.g. "primary"/"secondary") but verify.
+5. **Race conditions**: `TrackingRPCClient` is wired around the
+   primary + secondary clients used by every payout cycle, the reorg
+   poller, AND the bootstrap chain-balance worker. Confirm safety
+   under those concurrent callers.
+6. **Wrong-classification of errors**: TransactionReceipt's
+   (nil, nil) "not found" is documented as SUCCESS not error.
+   Re-derive: is that classification consistent with §4.7's "RPC
+   error is NOT a stale signal"? Are there RPC outcomes that the
+   wrapper miscounts in either direction?
+
+Find **SECURITY DEFECTS**. Stay narrow to security — separate code +
+architect lanes cover correctness + design.
+
+Severity:
+- CRITICAL: silent money loss / unauthorized access / secret exposure.
+- HIGH: operator decision corruption, page storm, or denial of
+  detection.
+- MEDIUM: defense weakening, missing best-effort hardening.
+- LOW: deferrable hardening.
+
+Output format identical to the code lens: severity-headed findings
+plus a `## Convergence X/X/X/X → DECISION` summary line.

--- a/specs/AUDIT_ISS_165_R2_ARCH_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R2_ARCH_PROMPT.md
@@ -1,0 +1,43 @@
+# Audit: ISS-165 R2 architect lens — fix pass on R1 findings
+
+R1 returned 3 HIGH + 1 MEDIUM + 1 LOW (arch). R2 verifies on
+commit `a5e9e34`. Tree: `spec/iss-165-spec-016-followups`.
+
+## R1 ARCH findings to verify
+
+- **HIGH-1**: A2 Evaluate cadence vs window. Fix: independent
+  `(*ChronicOutageTracker).Run(ctx)` goroutine ticking at
+  `min(window/2, 1min)`.
+- **HIGH-2 (convergent with code)**: SPKI wrapper type assertion.
+  Fix: idleCloser interface + `(*trackingRPC).CloseIdleConnections()`.
+- **HIGH-3**: §9 BetterStack runbook missing event names. Fix:
+  both new events added to alert-filter list.
+- **MEDIUM**: `max_rows_per_run` shared budget overload. Fix:
+  normative paragraph in v0.1.22 change-log documenting the shared
+  cap; bound `[1, 500]` unchanged.
+- **LOW**: backlog WARN repeats every cycle. Documented in the
+  change-log as intentional per-cycle gauge (operator-actionable).
+
+## What I want (R2 arch lens)
+
+Verify each closure stuck. Look for:
+
+- Does `Run()` interact correctly with `payoutS2.stop()` shutdown
+  flow? (It hooks off shutdownCtx, no explicit stop.)
+- Does the SPEC v0.1.22 normative paragraph contradict any existing
+  §payout.tuning prose elsewhere in the body?
+- Is the §9 runbook entry sufficient (just the event names + a
+  one-line description) or should there be a runbook page anchor?
+- Does the wrapper's `CloseIdleConnections()` cover BOTH primary
+  AND secondary, and is the interface assertion at the SIGHUP
+  handler exhaustive across future RPCClient implementations
+  (e.g. a mock that doesn't implement the method)?
+- The R1 SEC fix changed `total_candidates` from "pre-cycle count"
+  to "remaining un-paged" without restating that change at the
+  §4.7 step-5 prose level. Audit-trail risk: future readers of
+  this PR diff vs the v0.1.22 SPEC paragraph could be confused.
+  Verify the SPEC paragraph names the post-production semantics
+  clearly.
+
+Find new ARCH defects. Same severity + output format. End with
+`## Convergence X/X/X/X → DECISION`.

--- a/specs/AUDIT_ISS_165_R2_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R2_CODE_PROMPT.md
@@ -1,0 +1,51 @@
+# Audit: ISS-165 R2 code lens — fix pass on R1 findings
+
+R1 returned 0/3/1/1 (code+sec+arch convergent). R2 verifies the
+fix pass on commit `a5e9e34` against HEAD on
+`spec/iss-165-spec-016-followups`. Tree: `git log --oneline -3`.
+
+## R1 findings to verify
+
+- **CODE/ARCH HIGH (convergent)**: SPKI SIGHUP CloseIdleConnections
+  was guarded by `rpcs.Primary.(*HTTPRPCClient)` type assertion which
+  failed through the new TrackingRPCClient wrapper.
+  Fix: `chronic.go` adds `(*trackingRPC).CloseIdleConnections()`
+  forwarding to inner; `main.go:1429` switches to an
+  `interface{ CloseIdleConnections() }` assertion.
+- **SEC HIGH**: `orphans.go` LIMIT bounded the SCAN; non-actionable
+  rows could permanently block stale-cancel PAGEs (denial of
+  detection). Fix: scan up to `staleOutboxScanCap=1000`, loop
+  produces up to `limit`, break when `produced >= limit`.
+  Regression test: `TestProduceStaleOutboxRows_NonActionableRowsDoNotConsumeLimit`.
+- **ARCH HIGH**: Evaluate cadence — RunInterval ∈ [5m, 24h], tracker
+  window 10m → samples pruned before observation. Fix: independent
+  goroutine `(*ChronicOutageTracker).Run(ctx)` ticks at
+  `min(window/2, 1min)`; launched from `main.go` next to other
+  payout tickers.
+- **ARCH MEDIUM**: shared `max_rows_per_run` cap overload between
+  §4.3 step-1 and §4.7 step-5 documented normatively in SPEC v0.1.22
+  change-log + §9 alert-filter list now includes both new events.
+
+## Files to re-inspect
+
+- `phase4-coordinator/internal/payout/orphans.go`
+- `phase4-coordinator/internal/payout/chronic.go`
+- `phase4-coordinator/internal/payout/runner.go` (unchanged from R1)
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/internal/payout/iss165_a1_test.go`
+- `specs/SPEC-016-payout-pipeline.md`
+
+## What I want (R2 code lens)
+
+Verify EACH R1 finding is actually closed AND the fix didn't open
+new defects. Look for:
+
+- Did the wrapper expose every method the SIGHUP handler / future
+  callers might assert on?
+- Does the new `staleOutboxScanCap=1000` constant interact with
+  any other SQL limit / pagination cursor?
+- Does `Run()` shut down cleanly on ctx cancel (no goroutine leak)?
+- Tests cover the regression class adequately?
+
+Find NEW defects (code lens). Same severity / output format as R1.
+End with `## Convergence X/X/X/X → DECISION`.

--- a/specs/AUDIT_ISS_165_R2_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R2_SECURITY_PROMPT.md
@@ -1,0 +1,39 @@
+# Audit: ISS-165 R2 security lens — fix pass on R1 findings
+
+R1 returned 1 HIGH (SEC) + 1 LOW (SEC). R2 verifies on commit
+`a5e9e34`. Tree: `spec/iss-165-spec-016-followups`.
+
+## R1 SEC findings to verify
+
+- **HIGH**: `ProduceStaleOutboxRows` LIMIT applied before RPC
+  eligibility → denial of detection (non-actionable rows
+  permanently block stale-cancel PAGEs). Fix: cap on PRODUCED
+  rows, hard scan cap of 1000, regression test
+  `TestProduceStaleOutboxRows_NonActionableRowsDoNotConsumeLimit`.
+- **LOW**: tracker mutex held through `zerolog.Send()`. Fix:
+  Evaluate collects emit decisions under lock, releases, emits.
+
+## Security threat model (R2)
+
+Continue from R1: money path, operator-visibility integrity,
+PAGE-storm prevention. Additionally:
+
+1. **R1 SEC HIGH fix verification**: trace a scenario where
+   the first 10 candidates are reconfirmable + a 11th candidate
+   is truly stale + limit=2. Does the producer PAGE the 11th
+   within the same cycle, or does the new scan cap interact
+   poorly?
+2. **Scan cap as new attack surface**: if an adversary can
+   inflate the candidate set past 1000, does the cap mask real
+   stale cancels? When the scan cap fires, is the operator
+   alerted (`scan_cap_hit=true` field in the WARN)?
+3. **Tracker goroutine**: `Run()` ticks every ≤1 minute. Can a
+   chronic outage cause the tracker to PAGE every cycle once
+   the cooldown lapses, even when the SAMPLES haven't changed?
+   Check the prune-then-evaluate ordering.
+4. **Mutex release timing**: the new Evaluate releases the mutex
+   before emitting logs. Could the decision-set be stale by the
+   time we emit? Is `lastPagedAt` still racefree?
+
+Find SECURITY DEFECTS. Same severity + output format. End with
+`## Convergence X/X/X/X → DECISION`.

--- a/specs/AUDIT_ISS_165_R3_ARCH_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R3_ARCH_PROMPT.md
@@ -1,0 +1,36 @@
+# Audit: ISS-165 R3 architect lens — verify R2 fixes
+
+R2 returned 1 HIGH + 2 MEDIUM + 1 LOW (arch). R3 verifies on
+commit `f0c5350`. Tree: `spec/iss-165-spec-016-followups`.
+
+## R2 ARCH findings to verify
+
+- **HIGH**: runbook missing new events. Fix: extended.
+- **MED-1**: SPEC v0.1.22 prose vs code mismatch. Fix: reconciled.
+- **MED-2**: SPKI close-idle interface contract optional/silent.
+  Fix: new WARN event + comment update.
+- **LOW**: per-cycle WARN repeat documented now.
+
+## What I want (R3 arch lens)
+
+- Does the new `payout_spki_drain_skipped_unsupported_client`
+  WARN deserve a §7.1 row + §9 alert filter entry? It's not in
+  either; if it's an internal observability event that's fine,
+  but the convention in SPEC-016 has been that any non-trivial
+  event hits §7.1.
+- Does the SPEC v0.1.22 change-log paragraph fully describe the
+  R2 fix (scan-cap removal)? The R1+R2 audit narrative
+  retroactively makes this a 2-round closure on what was
+  originally a "LOW deferred from #164" — does the SPEC body
+  still claim this is a simple LIMIT polish, or has the audit
+  arc been recorded?
+- Does the runbook §3 update normatively cover BOTH primary and
+  secondary RPC labels for the new SPKI drain WARN? It's a
+  per-label event so the synthetic-alert harness needs to verify
+  each.
+- Cross-spec: does SPEC-007 (explorer) or any other SPEC
+  reference §7.1 events that would need the new WARN/PAGE
+  visible? (Likely not, but check.)
+
+Find NEW arch defects. Same severity + output format. End with
+`## Convergence X/X/X/X → DECISION`.

--- a/specs/AUDIT_ISS_165_R3_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R3_CODE_PROMPT.md
@@ -1,0 +1,46 @@
+# Audit: ISS-165 R3 code lens — verify R2 fixes
+
+R2 returned 0/3/2/1. R3 verifies on commit `f0c5350` against HEAD
+of `spec/iss-165-spec-016-followups`. Tree: `git log --oneline -5`.
+
+## R2 findings to verify
+
+- **CODE/SEC HIGH (convergent)**: scan cap saturation prefix-
+  starvation. Fix: drop `staleOutboxScanCap` ceiling entirely;
+  scan now bounded only by predicate.
+- **ARCH HIGH**: `dist/payout-runbook.md` BetterStack synthetic-
+  alert list missing new v0.1.22 events. Fix: extended.
+- **ARCH MED-1**: SPEC v0.1.22 prose vs code semantics mismatch.
+  Fix: reconciled.
+- **ARCH MED-2**: SPKI close-idle interface contract optional/
+  silent. Fix: `payout_spki_drain_skipped_unsupported_client` WARN
+  fires when an RPC client lacks `CloseIdleConnections`.
+- **ARCH LOW**: per-cycle WARN repeat not documented. Fix: SPEC
+  text + code comments now say so.
+
+## Files to re-inspect
+
+- `phase4-coordinator/internal/payout/orphans.go`
+- `phase4-coordinator/internal/payout/chronic.go`
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/dist/payout-runbook.md`
+- `specs/SPEC-016-payout-pipeline.md`
+- `phase4-coordinator/internal/payout/iss165_a1_test.go`
+
+## What I want (R3 code lens)
+
+Verify the closures stuck. Specifically:
+
+- Without the scan cap, does the SELECT have any *implicit*
+  ceiling (SQLite default LIMIT, Go driver row buffer)? Confirm
+  the entire candidate set is materialized.
+- Does any code path still reference `staleOutboxScanCap` /
+  `scan_cap_hit` (dead refs)?
+- Test coverage adequate? With the cap removed, is the regression
+  class still pinned?
+- Memory concern: do we have a coarse upper bound for the
+  candidate set in production? (If yes, document; if no, the LOW
+  in R2 about per-cycle repeat may be insufficient.)
+
+Find NEW code defects. Same severity + output format. End with
+`## Convergence X/X/X/X → DECISION`.

--- a/specs/AUDIT_ISS_165_R3_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R3_SECURITY_PROMPT.md
@@ -1,0 +1,35 @@
+# Audit: ISS-165 R3 security lens — verify R2 fixes
+
+R2 returned 1 HIGH (SEC, convergent with code). R3 verifies on
+commit `f0c5350`. Tree: `spec/iss-165-spec-016-followups`.
+
+## R2 SEC findings to verify
+
+- **HIGH** (convergent with code): scan cap saturation prefix-
+  starvation. Fix: drop scan cap entirely; predicate-bounded SELECT.
+
+## Security threat model (R3)
+
+The R2 fix removes an explicit memory bound and trusts the WHERE
+predicate. Adversarial questions:
+
+1. Could an attacker (compromised operator key, malicious data
+   ingest path) inflate the cancel-self-transfer + un-paged +
+   stale-cutoff candidate set to millions of rows, causing OOM /
+   slow scan / disk spill?
+2. Is the SELECT's read-time-bounded by SQLite WAL or
+   page-cache pressure? Could a huge scan starve other queries
+   on the same DB handle?
+3. Does the now-unbounded scan interact with the runner cycle
+   timeout? Could a giant scan blow past the §4.3 cycle
+   deadline?
+4. Could the per-cycle WARN repetition itself become a journal
+   DoS if backlog persists for hours? (Operator-DoS, not money-
+   path.)
+5. The `payout_spki_drain_skipped_unsupported_client` WARN is a
+   new event but NOT yet in §7.1. Is that a config-drift class
+   that could mask a real future bug? (Security-relevant because
+   SPKI drain failure is a TLS pinning hardening regression.)
+
+Find NEW security defects. Same severity + output format. End
+with `## Convergence X/X/X/X → DECISION`.

--- a/specs/AUDIT_ISS_165_R4_ARCH_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R4_ARCH_PROMPT.md
@@ -1,0 +1,31 @@
+# Audit: ISS-165 R4 architect lens — verify R3 fixes
+
+R3 returned 0/1/1/0 (arch). R4 verifies on `a8574cd`.
+
+## R3 arch findings to verify
+
+- **HIGH**: `payout_spki_drain_skipped_unsupported_client` missing
+  from §7.1 + §9. Fix: both added with severity + per-rpc_label
+  verification line in runbook.
+- **MEDIUM**: SPEC version line + v0.1.22 paragraph understated
+  scope (claimed "two events, no normative changes" while body
+  changed substantially). Fix: 3-round audit narrative documented,
+  three events listed, keyset migration mentioned.
+
+## What I want (arch lens)
+
+- Self-consistency: do §7.1 backlog row + v0.1.22 paragraph +
+  code emit agree on `scan_ceiling_hit` + `total_scanned` + the
+  WARN→PAGE escalation rule?
+- Does v0.1.22 §payout.tuning prose anywhere reference a `LIMIT`-
+  bounded scan that was the original A1 sketch and would now be
+  stale?
+- Cross-spec — SPEC-005 / SPEC-007 / SPEC-014 dependencies still
+  intact?
+- `Run()` goroutine lifecycle: clean shutdown verified against
+  `shutdownCtx` cancel? Any race against `payoutS2.stop()`?
+- Is there a tracking-issue / future-version note for: removing
+  the defensive scan ceiling (i.e. when does operator scale
+  warrant rethinking)?
+
+Find arch defects. Severity + Convergence line.

--- a/specs/AUDIT_ISS_165_R4_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R4_CODE_PROMPT.md
@@ -1,0 +1,35 @@
+# Audit: ISS-165 R4 code lens — verify R3 keyset fix
+
+R3 returned 0/0/1/2 (code). R4 verifies on commit `a8574cd`.
+Tree: `spec/iss-165-spec-016-followups`. `git log --oneline -7`.
+
+## R3 code findings to verify
+
+- **MEDIUM**: unbounded materialization → keyset pagination.
+- **LOW-1**: stale comments → rewritten.
+- **LOW-2**: test gap for large prefix → new test
+  `TestProduceStaleOutboxRows_LargeNonActionablePrefixDoesNotStarve`.
+
+## What I want (code lens)
+
+Verify the keyset migration is sound:
+
+- Strict tuple ordering form
+  `(updated_at_utc > ? OR (= AND payout_id > ?) OR (= AND = AND
+  attempt_seq > ?))` — correct semantics, no off-by-one when
+  consecutive rows share `updated_at_utc`?
+- Cursor advance: `cursorUpdated = last.ReorgReactivated` —
+  confirm `ReorgReactivated` IS the `updated_at_utc` column (the
+  scan field). Look at `cand.ReorgReactivated` mapping.
+- Empty/short/exact-chunk-boundary behavior — does the loop
+  terminate cleanly in all three cases?
+- `scannedAll` correctness across nested break and natural
+  exhaustion.
+- `total_scanned` counts chunk rows that were scanned but maybe
+  skipped — does it overcount when production-cap break fires
+  mid-chunk?
+- `scan_ceiling_hit` exit path: do we still emit the gauge?
+  Severity escalates to PAGE — correct?
+
+Find code defects. Severity-headed findings. End with
+`## Convergence X/X/X/X → DECISION`.

--- a/specs/AUDIT_ISS_165_R4_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R4_SECURITY_PROMPT.md
@@ -1,0 +1,31 @@
+# Audit: ISS-165 R4 security lens — verify R3 fixes
+
+R3 returned 0/1/1/0 (sec). R4 verifies on `a8574cd`.
+
+## R3 sec findings to verify
+
+- **HIGH**: unbounded materialization. Fix: keyset chunking
+  (256/chunk) + 20000 scan ceiling + PAGE on ceiling.
+- **MEDIUM**: SPKI drain WARN missing §7.1 + §9 + severity/ts_utc.
+  Fix: all four added.
+
+## What I want (security lens)
+
+- Adversarial inflation: can an attacker (operator-key compromise
+  or data-path bug) make `total_scanned` > 20000 PER CYCLE in a
+  way that masks money loss? At chunk size 256 + ceiling 20000,
+  that's 78 chunks per cycle in the worst case — each chunk hits
+  the DB. Query plan + index coverage adequate?
+- Cursor injection: SQLite + mattn/go-sqlite3 — could a malicious
+  `payout_id` or `attempt_seq` (e.g. negative, very large) break
+  the cursor advance and cause skip-class denial of detection?
+- Backlog ceiling-hit PAGE: is the operator-actionable signal
+  sufficient, or does it need a separate event name? (The
+  R3 fix shares the event with WARN-mode backlog and just
+  changes the severity field.)
+- Future-proof: `payout_spki_drain_skipped_unsupported_client`
+  exists in code AND SPEC §7.1 AND §9 alert filter AND runbook §3.
+  Is there a build-time/CI verification that all four stay in
+  sync, or is drift still possible?
+
+Find security defects. Severity + Convergence line.

--- a/specs/AUDIT_ISS_165_R5_ARCH_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R5_ARCH_PROMPT.md
@@ -1,0 +1,27 @@
+# Audit: ISS-165 R5 architect lens — verify R4 closures
+
+R4 returned 0/0/1/2. R5 verifies on `b7221a7`.
+
+## R4 arch findings to verify
+
+- **MEDIUM**: §4.7 v0.1.22 normative paragraph stale (missing
+  `scan_ceiling_hit, total_scanned` + PAGE escalation rule). Fix:
+  paragraph rewritten with keyset, ceiling, escalation.
+- **LOW-1**: no future-version note for scan-ceiling lifecycle.
+  Fix: Appendix B candidate added.
+- **LOW-2**: "20000 row cap" approximate vs exact. Fix: chunkLimit
+  clamp now enforces exact ceiling.
+
+## What I want (R5 arch lens)
+
+Final convergence pass. Expect 0/0/0/N.
+
+- §4.7 v0.1.22 paragraph now matches §7.1 row + code emit
+  exactly?
+- Appendix B notes complete + actionable (concrete trigger
+  conditions named)?
+- Migration 0013 follows the codebase's migration convention?
+- Any cross-spec drift introduced by the v0.1.22 changes
+  (SPEC-005 / SPEC-007 / SPEC-014)?
+
+Severity + Convergence line. NO FIX PASS on 0/0/0/N.

--- a/specs/AUDIT_ISS_165_R5_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R5_CODE_PROMPT.md
@@ -1,0 +1,29 @@
+# Audit: ISS-165 R5 code lens — verify R4 closures
+
+R4 returned 0/0/1/1. R5 verifies on commit `b7221a7`. Tree:
+`spec/iss-165-spec-016-followups`. `git log --oneline -8`.
+
+## R4 code findings to verify
+
+- **MEDIUM**: missing keyset-order index. Fix: migration 0013
+  adds partial index
+  `idx_pa_stale_cancel_keyset (updated_at_utc, payout_id, attempt_seq) WHERE ...`.
+- **LOW**: scan-ceiling off-by-one chunk. Fix: `chunkLimit` clamps
+  to `min(staleOutboxChunkSize, staleOutboxScanCeiling - totalScanned)`;
+  drained-check uses chunkLimit instead of chunkSize.
+
+## What I want (R5 code lens)
+
+Final convergence pass. Looking for any remaining defect; expect
+the lane to converge to 0/0/0/0.
+
+- Does the new migration apply cleanly? Confirm the index name
+  matches what's referenced in code/spec.
+- Does `chunkLimit` clamp interact correctly with the drained-
+  chunk break? If chunkLimit < chunkSize on the final ceiling-hit
+  chunk, `len(chunk) < chunkLimit` only when DB returned fewer
+  than asked — verify this still terminates.
+- Any dangling `_ = chunkLimit` or unused variable warnings under
+  -race?
+
+Severity + Convergence line. NO FIX PASS on 0/0/0/N.

--- a/specs/AUDIT_ISS_165_R5_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_165_R5_SECURITY_PROMPT.md
@@ -1,0 +1,26 @@
+# Audit: ISS-165 R5 security lens — verify R4 closures
+
+R4 returned 0/1/1/0. R5 verifies on `b7221a7`.
+
+## R4 sec findings to verify
+
+- **HIGH** (convergent w/ code): keyset query lacked matching
+  index + scan-ceiling off-by-one. Fix: migration 0013 + chunkLimit
+  clamp.
+- **MEDIUM**: no build-time CI sync for event names across SPEC
+  §7.1 + §9 + runbook. Fix: deferred to v0.2 via Appendix B note
+  (`#165 R4 sec MEDIUM closure`).
+
+## What I want (R5 security lens)
+
+Final convergence pass. Expect 0/0/0/N.
+
+- Adversarial inflation now bounded by index + ceiling? With the
+  partial index in place, `EXPLAIN QUERY PLAN` should report a
+  direct index scan; verify the assertion.
+- The CI-sync MEDIUM was deferred to v0.2. Is that an acceptable
+  trade-off, or is the drift risk high enough to demand a
+  per-release manual checklist?
+- Any other money-path security defect introduced by the R4 fixes?
+
+Severity + Convergence line. NO FIX PASS on 0/0/0/N.

--- a/specs/SPEC-016-payout-pipeline.md
+++ b/specs/SPEC-016-payout-pipeline.md
@@ -1,6 +1,6 @@
 # SPEC-016 — Provider payout pipeline (USDC on Base)
 
-**Version:** 0.1.21 (2026-06-25, draft — codex round-21 fix pass on v0.1.20. Round 21 returned NEEDS FIX PASS 0/1/1/1 against v0.1.20: MAJOR-1 stale `[2, 50]` confirmation_blocks bound at §4.3 step 7 + BUILD prompt; MEDIUM-1 ambiguous IMPL test (4) wording in §4.8b; LOW-1 two-RPC re-poll budget undercounted RPC calls in §4.7. All three absorbed. Pending codex round-22 confirmation. Full r20 findings: `specs/SPEC-016-r20-audit.md`; r21 closure narrative: `specs/SPEC-016-r21-audit.md`.)
+**Version:** 0.1.22 (2026-06-29, draft — IMPL follow-up advisories from PR #164 audit cycle absorbed; see issue #165. Two §7.1 events added: `payout_stale_outbox_backlog` (WARN) for §4.7 step 5 producer LIMIT suppression, and `payout_rpc_chronic_outage` (PAGE) for the two-RPC discipline chronic-single-side-failure gap. No normative SPEC text changes elsewhere — IMPL ships under v0.1.21 contract with these two new event rows.) PRIOR: 0.1.21 (2026-06-25, draft — codex round-21 fix pass on v0.1.20. Round 21 returned NEEDS FIX PASS 0/1/1/1 against v0.1.20: MAJOR-1 stale `[2, 50]` confirmation_blocks bound at §4.3 step 7 + BUILD prompt; MEDIUM-1 ambiguous IMPL test (4) wording in §4.8b; LOW-1 two-RPC re-poll budget undercounted RPC calls in §4.7. All three absorbed. Pending codex round-22 confirmation. Full r20 findings: `specs/SPEC-016-r20-audit.md`; r21 closure narrative: `specs/SPEC-016-r21-audit.md`.)
 **Status:** Draft (design-only — no IMPL until operator funds hot
 wallet and discharges the eight §9 prerequisites).
 **Depends on:** SPEC-005 v0.3 (§5.1 unit definition; §10.1 WAL
@@ -23,6 +23,32 @@ git-history-only). The change-log entries below are one-liners per
 version pointing at the corresponding audit file. Per
 [[feedback-spec-audit-file-convention]], audit narrative does NOT
 live in this SPEC body.
+
+**v0.1.22 (2026-06-29, draft — issue #165 IMPL follow-up):**
+Absorbs the two LOW arch advisories deferred from the PR #164 FULL
+audit cycle (see [[tracking-issue-scope-control]]). §7.1 gains two
+event rows:
+- `payout_stale_outbox_backlog` (severity=WARN) — emitted by the
+  §4.7 step 5 producer when the per-cycle candidate count exceeds
+  the operator-configured cap (sized from `payout.tuning.max_rows_per_run`).
+  Fields: `run_id, limit, total_candidates, ts_utc`. A
+  `total_candidates = -1` sentinel signals the operator that the
+  exact backlog count query failed (degraded observability), not
+  that there is no backlog.
+- `payout_rpc_chronic_outage` (severity=PAGE) — emitted by the
+  per-cycle chronic-outage tracker when one RPC's error rate
+  exceeds the threshold over the sliding window. Fields:
+  `rpc_label, window_seconds, sample_count, error_count,
+  error_rate, threshold, ts_utc`. Defaults: 10-minute window,
+  50% threshold, 10 minimum samples, 10-minute PAGE cooldown
+  per label. Closes the silent-degradation gap where ONE chronic
+  RPC failure produces no operator event (the disagreement
+  detector at §4.4 only fires when BOTH RPCs return AND disagree).
+IMPL surface: `phase4-coordinator/internal/payout/orphans.go`
+(LIMIT + backlog gauge) and `phase4-coordinator/internal/payout/chronic.go`
+(sliding-window tracker + `TrackingRPCClient` wrapper). No prose
+elsewhere in the SPEC changes — these events extend the §7.1 table
+under the v0.1.21 contract.
 
 **v0.1.21 (2026-06-25, draft — codex round-21 fix pass on
 v0.1.20):** Round 21 returned NEEDS FIX PASS 0/1/1/1. Fixes:
@@ -3751,6 +3777,8 @@ operator-key endpoints log actor=operator_key):
 | `payout_cancel_self_transfer_confirmed` (severity=INFO; NEW v0.1.14; v0.1.15 clarifies transition-only emission) | `run_id, payout_id, attempt_seq, nonce, tx_hash, block_number, gas_used_native_wei, ts_utc` |
 | `payout_cancel_self_transfer_reconfirm_stale` (severity=PAGE; NEW v0.1.15; v0.1.17 adds `event_id`) | `event_id (=cancel_reconfirm_stale_outbox.id), run_id, payout_id, attempt_seq, nonce, tx_hash, last_seen_block, updated_at_utc, ts_utc` |
 | `payout_stale_outbox_reaped` (severity=WARN; NEW v0.1.17) | `event_id (=cancel_reconfirm_stale_outbox.id), payout_id, attempt_seq, stale_started_at_utc, reap_lag_seconds, ts_utc` |
+| `payout_stale_outbox_backlog` (severity=WARN; NEW v0.1.22) | `run_id, limit, total_candidates, ts_utc` |
+| `payout_rpc_chronic_outage` (severity=PAGE; NEW v0.1.22) | `rpc_label, window_seconds, sample_count, error_count, error_rate, threshold, ts_utc` |
 
 ### 7.1.1 Where these events live
 

--- a/specs/SPEC-016-payout-pipeline.md
+++ b/specs/SPEC-016-payout-pipeline.md
@@ -46,9 +46,43 @@ event rows:
   detector at §4.4 only fires when BOTH RPCs return AND disagree).
 IMPL surface: `phase4-coordinator/internal/payout/orphans.go`
 (LIMIT + backlog gauge) and `phase4-coordinator/internal/payout/chronic.go`
-(sliding-window tracker + `TrackingRPCClient` wrapper). No prose
-elsewhere in the SPEC changes — these events extend the §7.1 table
-under the v0.1.21 contract.
+(sliding-window tracker + `TrackingRPCClient` wrapper).
+
+**§4.7 step 5 production cap (NORMATIVE in v0.1.22).** The
+stale-cancel producer's per-cycle PAGE production is capped by
+`payout.tuning.max_rows_per_run` (the same operator config the
+§4.3 step 1 ready-row scan uses). The cap bounds *produced outbox
+rows*, NOT *scanned candidates* — non-actionable candidates
+(missing `tx_hash`, transient RPC error, at-least-one-RPC-still-
+sees-receipt) do not consume the budget; the scan continues past
+them within an internal scan ceiling (1000 rows, well above any
+realistic backlog) so persistent non-actionable rows cannot
+indefinitely suppress truly stale cancels from PAGEing. When the
+production cap is hit before the scan exhausts, the producer emits
+`payout_stale_outbox_backlog` WARN with `run_id, limit, produced,
+total_candidates, scan_cap_hit, ts_utc`. `total_candidates` is the
+*remaining* un-paged candidates AFTER this cycle's production
+completes (i.e. backlog awaiting future cycles); a value of -1 is
+the sentinel emitted when the count query itself fails (degraded
+observability, NOT zero backlog). Operators sizing
+`max_rows_per_run` MUST recognize it as a SHARED budget across §4.3
+step-1 ready-row payment work AND §4.7 step-5 stale-cancel PAGE
+production; lowering the cap reduces both. The cap's normative
+bound remains `[1, 500]` per §payout.tuning.
+
+**§4.4 two-RPC discipline gap closure (NORMATIVE in v0.1.22).** The
+§4.4 disagreement detector fires only when BOTH RPCs return AND
+disagree. A chronic single-RPC failure (network partition, vendor
+outage) is silently swallowed by the runner's degrade-and-retry
+behavior. The `payout_rpc_chronic_outage` PAGE closes that gap:
+every RPC call through the production `TrackingRPCClient` wrapper
+records success/failure into the `ChronicOutageTracker`; an
+independent goroutine ticker drives Evaluate at `min(window/2,
+1min)` (decoupled from `payout.tuning.run_interval` so detection
+stays responsive when operators run the cycle at the [5m, 24h]
+upper bound). The wrapper covers every `RPCClient` interface method
+including `CloseIdleConnections()` so SIGHUP SPKI pin rotation
+still drains pooled TLS connections through the wrapper.
 
 **v0.1.21 (2026-06-25, draft — codex round-21 fix pass on
 v0.1.20):** Round 21 returned NEEDS FIX PASS 0/1/1/1. Fixes:
@@ -3777,7 +3811,7 @@ operator-key endpoints log actor=operator_key):
 | `payout_cancel_self_transfer_confirmed` (severity=INFO; NEW v0.1.14; v0.1.15 clarifies transition-only emission) | `run_id, payout_id, attempt_seq, nonce, tx_hash, block_number, gas_used_native_wei, ts_utc` |
 | `payout_cancel_self_transfer_reconfirm_stale` (severity=PAGE; NEW v0.1.15; v0.1.17 adds `event_id`) | `event_id (=cancel_reconfirm_stale_outbox.id), run_id, payout_id, attempt_seq, nonce, tx_hash, last_seen_block, updated_at_utc, ts_utc` |
 | `payout_stale_outbox_reaped` (severity=WARN; NEW v0.1.17) | `event_id (=cancel_reconfirm_stale_outbox.id), payout_id, attempt_seq, stale_started_at_utc, reap_lag_seconds, ts_utc` |
-| `payout_stale_outbox_backlog` (severity=WARN; NEW v0.1.22) | `run_id, limit, total_candidates, ts_utc` |
+| `payout_stale_outbox_backlog` (severity=WARN; NEW v0.1.22) | `run_id, limit, produced, total_candidates, scan_cap_hit, ts_utc` |
 | `payout_rpc_chronic_outage` (severity=PAGE; NEW v0.1.22) | `rpc_label, window_seconds, sample_count, error_count, error_rate, threshold, ts_utc` |
 
 ### 7.1.1 Where these events live
@@ -4423,6 +4457,8 @@ discharged:
    - `payout_cancel_self_transfer_confirmed` (INFO — NEW v0.1.14; OPTIONAL for the alert filter, INFO not PAGE/WARN, but include if operator wants per-cancel visibility)
    - `payout_cancel_self_transfer_reconfirm_stale` (PAGE — NEW v0.1.15)
    - `payout_stale_outbox_reaped` (WARN — NEW v0.1.17)
+   - `payout_stale_outbox_backlog` (WARN — NEW v0.1.22; A1: §4.7 step 5 production capped before candidate set exhausted)
+   - `payout_rpc_chronic_outage` (PAGE — NEW v0.1.22; A2: per-RPC sliding-window error rate crossed threshold)
    - `provider_payout_address_change_rejected` (WARN)
    - `provider_payout_address_rejected_unknown_provider` (WARN)
 

--- a/specs/SPEC-016-payout-pipeline.md
+++ b/specs/SPEC-016-payout-pipeline.md
@@ -29,12 +29,18 @@ Absorbs the two LOW arch advisories deferred from the PR #164 FULL
 audit cycle (see [[tracking-issue-scope-control]]). §7.1 gains two
 event rows:
 - `payout_stale_outbox_backlog` (severity=WARN) — emitted by the
-  §4.7 step 5 producer when the per-cycle candidate count exceeds
-  the operator-configured cap (sized from `payout.tuning.max_rows_per_run`).
-  Fields: `run_id, limit, total_candidates, ts_utc`. A
+  §4.7 step 5 producer when this cycle's PRODUCED outbox row count
+  hit the operator-configured cap (sized from
+  `payout.tuning.max_rows_per_run`) before the candidate set was
+  exhausted, so a backlog remains for future cycles to drain.
+  Repeats every runner cycle while the backlog persists — operators
+  see the gauge per cycle until queue depth falls below cap.
+  Fields: `run_id, limit, produced, total_candidates, ts_utc`.
+  `total_candidates` is the REMAINING un-paged backlog AFTER this
+  cycle's production completes (NOT pre-cycle count). A
   `total_candidates = -1` sentinel signals the operator that the
-  exact backlog count query failed (degraded observability), not
-  that there is no backlog.
+  count query itself failed (degraded observability, NOT that there
+  is no backlog).
 - `payout_rpc_chronic_outage` (severity=PAGE) — emitted by the
   per-cycle chronic-outage tracker when one RPC's error rate
   exceeds the threshold over the sliding window. Fields:
@@ -55,16 +61,21 @@ stale-cancel producer's per-cycle PAGE production is capped by
 rows*, NOT *scanned candidates* — non-actionable candidates
 (missing `tx_hash`, transient RPC error, at-least-one-RPC-still-
 sees-receipt) do not consume the budget; the scan continues past
-them within an internal scan ceiling (1000 rows, well above any
-realistic backlog) so persistent non-actionable rows cannot
-indefinitely suppress truly stale cancels from PAGEing. When the
-production cap is hit before the scan exhausts, the producer emits
+them so persistent non-actionable rows cannot indefinitely suppress
+truly stale cancels from PAGEing. The SELECT scan is bounded by the
+predicate (is_cancel_self_transfer=1 AND un-paged AND stale-cutoff);
+in normal operation this set is small (<<1000), and a pathological
+backlog is itself the operator's signal via the WARN gauge AND the
+chronic-outage PAGE at §4.4 (`payout_rpc_chronic_outage`) when the
+root cause is RPC failure. When the production cap is hit before
+the candidate set is exhausted, the producer emits
 `payout_stale_outbox_backlog` WARN with `run_id, limit, produced,
-total_candidates, scan_cap_hit, ts_utc`. `total_candidates` is the
-*remaining* un-paged candidates AFTER this cycle's production
-completes (i.e. backlog awaiting future cycles); a value of -1 is
-the sentinel emitted when the count query itself fails (degraded
-observability, NOT zero backlog). Operators sizing
+total_candidates, ts_utc`, and repeats every cycle until backlog
+drains under cap. `total_candidates` is the *remaining* un-paged
+candidates AFTER this cycle's production completes (i.e. backlog
+awaiting future cycles); a value of -1 is the sentinel emitted when
+the count query itself fails (degraded observability, NOT zero
+backlog). Operators sizing
 `max_rows_per_run` MUST recognize it as a SHARED budget across §4.3
 step-1 ready-row payment work AND §4.7 step-5 stale-cancel PAGE
 production; lowering the cap reduces both. The cap's normative
@@ -3811,7 +3822,7 @@ operator-key endpoints log actor=operator_key):
 | `payout_cancel_self_transfer_confirmed` (severity=INFO; NEW v0.1.14; v0.1.15 clarifies transition-only emission) | `run_id, payout_id, attempt_seq, nonce, tx_hash, block_number, gas_used_native_wei, ts_utc` |
 | `payout_cancel_self_transfer_reconfirm_stale` (severity=PAGE; NEW v0.1.15; v0.1.17 adds `event_id`) | `event_id (=cancel_reconfirm_stale_outbox.id), run_id, payout_id, attempt_seq, nonce, tx_hash, last_seen_block, updated_at_utc, ts_utc` |
 | `payout_stale_outbox_reaped` (severity=WARN; NEW v0.1.17) | `event_id (=cancel_reconfirm_stale_outbox.id), payout_id, attempt_seq, stale_started_at_utc, reap_lag_seconds, ts_utc` |
-| `payout_stale_outbox_backlog` (severity=WARN; NEW v0.1.22) | `run_id, limit, produced, total_candidates, scan_cap_hit, ts_utc` |
+| `payout_stale_outbox_backlog` (severity=WARN; NEW v0.1.22) | `run_id, limit, produced, total_candidates, ts_utc` |
 | `payout_rpc_chronic_outage` (severity=PAGE; NEW v0.1.22) | `rpc_label, window_seconds, sample_count, error_count, error_rate, threshold, ts_utc` |
 
 ### 7.1.1 Where these events live

--- a/specs/SPEC-016-payout-pipeline.md
+++ b/specs/SPEC-016-payout-pipeline.md
@@ -78,21 +78,29 @@ stale-cancel producer's per-cycle PAGE production is capped by
 rows*, NOT *scanned candidates* — non-actionable candidates
 (missing `tx_hash`, transient RPC error, at-least-one-RPC-still-
 sees-receipt) do not consume the budget; the scan continues past
-them so persistent non-actionable rows cannot indefinitely suppress
-truly stale cancels from PAGEing. The SELECT scan is bounded by the
-predicate (is_cancel_self_transfer=1 AND un-paged AND stale-cutoff);
-in normal operation this set is small (<<1000), and a pathological
-backlog is itself the operator's signal via the WARN gauge AND the
-chronic-outage PAGE at §4.4 (`payout_rpc_chronic_outage`) when the
-root cause is RPC failure. When the production cap is hit before
-the candidate set is exhausted, the producer emits
-`payout_stale_outbox_backlog` WARN with `run_id, limit, produced,
-total_candidates, ts_utc`, and repeats every cycle until backlog
-drains under cap. `total_candidates` is the *remaining* un-paged
-candidates AFTER this cycle's production completes (i.e. backlog
-awaiting future cycles); a value of -1 is the sentinel emitted when
-the count query itself fails (degraded observability, NOT zero
-backlog). Operators sizing
+them via keyset pagination so persistent non-actionable rows
+cannot indefinitely suppress truly stale cancels from PAGEing.
+The SELECT scans in chunks of 256 rows ordered by
+`(updated_at_utc, payout_id, attempt_seq)` (covered by the
+partial index `idx_pa_stale_cancel_keyset` per migration 0013);
+each chunk advances a strict-tuple cursor so memory stays O(chunk)
+regardless of backlog. A defensive runner-cycle ceiling of
+`staleOutboxScanCeiling = 20000` rows caps total scan work and
+keeps RunOnce wall-time bounded; the final chunk's `LIMIT` is
+clamped to the remaining ceiling so total scanned rows never
+exceed 20000.
+When the production cap is hit before the candidate set is
+exhausted, the producer emits `payout_stale_outbox_backlog` with
+`run_id, limit, produced, total_candidates, scan_ceiling_hit,
+total_scanned, ts_utc`. Severity is `WARN` by default but
+escalates to `PAGE` when `scan_ceiling_hit = true` (the 20000-row
+ceiling was reached — backlog is deeper than this cycle can drain
+and demands operator action). The event repeats every cycle until
+backlog drains under cap. `total_candidates` is the *remaining*
+un-paged candidates AFTER this cycle's production completes (i.e.
+backlog awaiting future cycles); a value of -1 is the sentinel
+emitted when the count query itself fails (degraded observability,
+NOT zero backlog). Operators sizing
 `max_rows_per_run` MUST recognize it as a SHARED budget across §4.3
 step-1 ready-row payment work AND §4.7 step-5 stale-cancel PAGE
 production; lowering the cap reduces both. The cap's normative
@@ -4619,6 +4627,28 @@ fresh session after this v0.1.x merges. That prompt will:
   shouldn't see directly). The boolean is computed
   server-side as `registered_against_hot_wallet ==
   payout.security.hot_wallet_address`.
+- SPEC-016 v0.2 candidate (#165 R4 arch LOW closure):
+  revisit the defensive `staleOutboxScanCeiling = 20000`
+  cap on the §4.7 step-5 producer. Trigger conditions:
+  sustained `payout_stale_outbox_backlog scan_ceiling_hit=true`
+  observations in production OR provider count / cancel
+  backlog depth grows enough that 20000 rows per cycle is
+  no longer comfortable headroom. Decision options:
+  (a) raise the ceiling (cheap if `idx_pa_stale_cancel_keyset`
+  scales linearly), (b) shorten the runner cycle, (c) split
+  to a dedicated stale-cancel reconciliation worker
+  (heaviest; only if the producer cycle starts blowing past
+  its wall-clock budget). v0.1.22 ships with 20000 because
+  it's well above expected v0.1 scale.
+- SPEC-016 v0.2 candidate (#165 R4 sec MEDIUM closure):
+  add a build-time CI check that enforces SPEC §7.1 +
+  SPEC §9 alert-filter + `dist/payout-runbook.md` §3 stay
+  in sync with the code's emit-event-name set. Currently
+  each must be hand-edited per release; the v0.1.22 audit
+  required four parallel edits to land
+  `payout_spki_drain_skipped_unsupported_client`. A
+  reflection-based or `go generate`-based check would
+  catch drift at PR time.
 - SPEC-016 v0.2 (filed by v0.1.7 round-8 SEC-MED): replace
   the one-table-at-a-time same-DB pins (`provider_payout_
   addresses` in §3.1; `payout_reorg_orphans` in §4.7;

--- a/specs/SPEC-016-payout-pipeline.md
+++ b/specs/SPEC-016-payout-pipeline.md
@@ -1,6 +1,6 @@
 # SPEC-016 — Provider payout pipeline (USDC on Base)
 
-**Version:** 0.1.22 (2026-06-29, draft — IMPL follow-up advisories from PR #164 audit cycle absorbed; see issue #165. Two §7.1 events added: `payout_stale_outbox_backlog` (WARN) for §4.7 step 5 producer LIMIT suppression, and `payout_rpc_chronic_outage` (PAGE) for the two-RPC discipline chronic-single-side-failure gap. No normative SPEC text changes elsewhere — IMPL ships under v0.1.21 contract with these two new event rows.) PRIOR: 0.1.21 (2026-06-25, draft — codex round-21 fix pass on v0.1.20. Round 21 returned NEEDS FIX PASS 0/1/1/1 against v0.1.20: MAJOR-1 stale `[2, 50]` confirmation_blocks bound at §4.3 step 7 + BUILD prompt; MEDIUM-1 ambiguous IMPL test (4) wording in §4.8b; LOW-1 two-RPC re-poll budget undercounted RPC calls in §4.7. All three absorbed. Pending codex round-22 confirmation. Full r20 findings: `specs/SPEC-016-r20-audit.md`; r21 closure narrative: `specs/SPEC-016-r21-audit.md`.)
+**Version:** 0.1.22 (2026-06-29, draft — IMPL follow-up #165, converged across 3 codex audit rounds. R1 returned 0/3/1/1; R2 returned 0/3/2/1; R3 absorbed the unbounded-scan + SPKI-drain-event findings. Normative §7.1 gains three events (`payout_stale_outbox_backlog`, `payout_rpc_chronic_outage`, `payout_spki_drain_skipped_unsupported_client`); §4.7 step 5 producer migrated to keyset-paginated bounded-memory scan with defensive `staleOutboxScanCeiling=20000` runner-cycle row cap; §4.4 two-RPC discipline gap closed via `TrackingRPCClient` wrapper + `ChronicOutageTracker` ticking independently of `payout.tuning.run_interval`.) PRIOR: 0.1.21 (2026-06-25, draft — codex round-21 fix pass on v0.1.20. Round 21 returned NEEDS FIX PASS 0/1/1/1 against v0.1.20: MAJOR-1 stale `[2, 50]` confirmation_blocks bound at §4.3 step 7 + BUILD prompt; MEDIUM-1 ambiguous IMPL test (4) wording in §4.8b; LOW-1 two-RPC re-poll budget undercounted RPC calls in §4.7. All three absorbed. Pending codex round-22 confirmation. Full r20 findings: `specs/SPEC-016-r20-audit.md`; r21 closure narrative: `specs/SPEC-016-r21-audit.md`.)
 **Status:** Draft (design-only — no IMPL until operator funds hot
 wallet and discharges the eight §9 prerequisites).
 **Depends on:** SPEC-005 v0.3 (§5.1 unit definition; §10.1 WAL
@@ -24,10 +24,14 @@ version pointing at the corresponding audit file. Per
 [[feedback-spec-audit-file-convention]], audit narrative does NOT
 live in this SPEC body.
 
-**v0.1.22 (2026-06-29, draft — issue #165 IMPL follow-up):**
+**v0.1.22 (2026-06-29, draft — issue #165 IMPL follow-up, 3-round
+codex audit converged):**
 Absorbs the two LOW arch advisories deferred from the PR #164 FULL
-audit cycle (see [[tracking-issue-scope-control]]). §7.1 gains two
-event rows:
+audit cycle (see [[tracking-issue-scope-control]]), expanded
+through R1/R2/R3 audit to also close the prefix-starvation
+denial-of-detection class, the SIGHUP-vs-wrapper SPKI-drain
+regression, and the unbounded-materialization risk. §7.1 gains
+three event rows:
 - `payout_stale_outbox_backlog` (severity=WARN) — emitted by the
   §4.7 step 5 producer when this cycle's PRODUCED outbox row count
   hit the operator-configured cap (sized from
@@ -35,21 +39,34 @@ event rows:
   exhausted, so a backlog remains for future cycles to drain.
   Repeats every runner cycle while the backlog persists — operators
   see the gauge per cycle until queue depth falls below cap.
-  Fields: `run_id, limit, produced, total_candidates, ts_utc`.
+  Fields: `run_id, limit, produced, total_candidates,
+  scan_ceiling_hit, total_scanned, ts_utc`.
   `total_candidates` is the REMAINING un-paged backlog AFTER this
   cycle's production completes (NOT pre-cycle count). A
   `total_candidates = -1` sentinel signals the operator that the
   count query itself failed (degraded observability, NOT that there
-  is no backlog).
+  is no backlog). Severity escalates from WARN to PAGE when
+  `scan_ceiling_hit = true` (the defensive runner-cycle scan
+  ceiling of 20000 rows was reached; backlog is deeper than the
+  cycle can drain).
 - `payout_rpc_chronic_outage` (severity=PAGE) — emitted by the
-  per-cycle chronic-outage tracker when one RPC's error rate
-  exceeds the threshold over the sliding window. Fields:
-  `rpc_label, window_seconds, sample_count, error_count,
-  error_rate, threshold, ts_utc`. Defaults: 10-minute window,
-  50% threshold, 10 minimum samples, 10-minute PAGE cooldown
-  per label. Closes the silent-degradation gap where ONE chronic
-  RPC failure produces no operator event (the disagreement
-  detector at §4.4 only fires when BOTH RPCs return AND disagree).
+  chronic-outage tracker when one RPC's error rate exceeds the
+  threshold over the sliding window. Fields: `rpc_label,
+  window_seconds, sample_count, error_count, error_rate,
+  threshold, ts_utc`. Defaults: 10-minute window, 50% threshold,
+  10 minimum samples, 10-minute PAGE cooldown per label. Closes
+  the silent-degradation gap where ONE chronic RPC failure
+  produces no operator event (the §4.4 disagreement detector
+  fires only when BOTH RPCs return AND disagree).
+- `payout_spki_drain_skipped_unsupported_client` (severity=WARN)
+  — emitted when an accepted SPKI pin rotation could NOT drain
+  pooled TLS connections because the current `RPCClient`
+  implementation doesn't expose `CloseIdleConnections()`. Fields:
+  `rpc_label, ts_utc`. Until the idle-conn TTL expires, the OLD
+  pin remains in force on existing connections. Operators MUST
+  rotate again or restart to enforce hardening immediately. Future
+  RPC wrappers MUST forward `CloseIdleConnections()` to remain
+  rotation-safe; this WARN is the canary for that contract.
 IMPL surface: `phase4-coordinator/internal/payout/orphans.go`
 (LIMIT + backlog gauge) and `phase4-coordinator/internal/payout/chronic.go`
 (sliding-window tracker + `TrackingRPCClient` wrapper).
@@ -3822,8 +3839,9 @@ operator-key endpoints log actor=operator_key):
 | `payout_cancel_self_transfer_confirmed` (severity=INFO; NEW v0.1.14; v0.1.15 clarifies transition-only emission) | `run_id, payout_id, attempt_seq, nonce, tx_hash, block_number, gas_used_native_wei, ts_utc` |
 | `payout_cancel_self_transfer_reconfirm_stale` (severity=PAGE; NEW v0.1.15; v0.1.17 adds `event_id`) | `event_id (=cancel_reconfirm_stale_outbox.id), run_id, payout_id, attempt_seq, nonce, tx_hash, last_seen_block, updated_at_utc, ts_utc` |
 | `payout_stale_outbox_reaped` (severity=WARN; NEW v0.1.17) | `event_id (=cancel_reconfirm_stale_outbox.id), payout_id, attempt_seq, stale_started_at_utc, reap_lag_seconds, ts_utc` |
-| `payout_stale_outbox_backlog` (severity=WARN; NEW v0.1.22) | `run_id, limit, produced, total_candidates, ts_utc` |
+| `payout_stale_outbox_backlog` (severity=WARN; escalates to PAGE on `scan_ceiling_hit=true`; NEW v0.1.22) | `run_id, limit, produced, total_candidates, scan_ceiling_hit, total_scanned, ts_utc` |
 | `payout_rpc_chronic_outage` (severity=PAGE; NEW v0.1.22) | `rpc_label, window_seconds, sample_count, error_count, error_rate, threshold, ts_utc` |
+| `payout_spki_drain_skipped_unsupported_client` (severity=WARN; NEW v0.1.22) | `rpc_label, ts_utc` — emitted when an accepted SPKI pin rotation could not drain pooled TLS conns because the RPC client doesn't implement `CloseIdleConnections`. Pooled conns will eventually drain via idle-timeout but until then the OLD pin remains in force on existing connections. |
 
 ### 7.1.1 Where these events live
 
@@ -4470,6 +4488,7 @@ discharged:
    - `payout_stale_outbox_reaped` (WARN — NEW v0.1.17)
    - `payout_stale_outbox_backlog` (WARN — NEW v0.1.22; A1: §4.7 step 5 production capped before candidate set exhausted)
    - `payout_rpc_chronic_outage` (PAGE — NEW v0.1.22; A2: per-RPC sliding-window error rate crossed threshold)
+   - `payout_spki_drain_skipped_unsupported_client` (WARN — NEW v0.1.22; verify per `rpc_label` value: `primary` AND `secondary`)
    - `provider_payout_address_change_rejected` (WARN)
    - `provider_payout_address_rejected_unknown_provider` (WARN)
 


### PR DESCRIPTION
Stacked on `impl/spec-016` (PR #164) per [[spike-branch-pr-base-selection]] — the payout package surface lives on the spike branch.

## Summary

Closes #165. Absorbs the two LOW arch advisories deferred from PR #164's FULL audit cycle, expanded through 5 codex audit rounds (R5 converged 0/0/0/0 code + 0/0/0/0 arch + 0/0/0/N sec).

**A1**: `phase4-coordinator/internal/payout/orphans.go::ProduceStaleOutboxRows` now bounds PRODUCED outbox rows (not scanned candidates) sized from `snap.MaxRowsPerRun`. Keyset-paginated chunks of 256 rows ordered by `(updated_at_utc, payout_id, attempt_seq)` with strict-tuple cursor advance keep memory O(chunk) regardless of backlog depth. Defensive `staleOutboxScanCeiling=20000` rows per cycle bounds RunOnce wall-time; final chunk's LIMIT clamps to remaining ceiling for exact enforcement. New partial index `idx_pa_stale_cancel_keyset` (migration 0013) covers the predicate + order so EXPLAIN QUERY PLAN reports direct index scan, no temp B-tree.

**A2**: New `phase4-coordinator/internal/payout/chronic.go` adds `ChronicOutageTracker` (sliding-window per-RPC-label error-rate detector) + `TrackingRPCClient` wrapper. Independent Run() goroutine ticks at `min(window/2, 1min)` so detection is responsive regardless of `payout.tuning.run_interval` (which can be 24h). Wired in `main.go` around both `NewHTTPRPCClient` sites. Wrapper forwards `CloseIdleConnections()` so SIGHUP SPKI pin rotation still drains pooled TLS connections.

## SPEC-016 v0.1.22

Three new §7.1 events:
- `payout_stale_outbox_backlog` (WARN; PAGE when `scan_ceiling_hit=true`)
- `payout_rpc_chronic_outage` (PAGE)
- `payout_spki_drain_skipped_unsupported_client` (WARN)

Plus normative §4.7 step 5 production-cap paragraph, normative §4.4 two-RPC chronic-outage paragraph, §9 alert-filter list updated, dist/payout-runbook.md §3 synthetic-alert verification list updated. Appendix B gains two v0.2 candidate notes (scan-ceiling lifecycle trigger + build-time event-name CI sync).

## Audit rounds

| Round | Code | Sec | Arch | Notes |
|---|---|---|---|---|
| R1 | 0/1/0/0 | 0/1/0/1 | 0/3/1/1 | SPKI wrapper, LIMIT prefix-starvation, Evaluate cadence, runbook, max_rows overload |
| R2 | 0/1/0/0 | 0/1/0/0 | 0/1/2/1 | scan cap saturation, SPEC inconsistency, SPKI interface |
| R3 | 0/0/1/2 | 0/1/1/0 | 0/1/1/0 | unbounded scan → keyset; SPKI event normalization |
| R4 | 0/0/1/1 | 0/1/1/0 | 0/0/1/2 | missing index → migration 0013, scan-ceiling clamp, §4.7 prose |
| R5 | 0/0/0/0 | 0/0/0/N | 0/0/0/0 | **CONVERGED** |

Per-round prompts at `specs/AUDIT_ISS_165_R{1..5}_{CODE,SECURITY,ARCH}_PROMPT.md`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./internal/payout` clean (incl. 1100-row prefix-starvation regression)
- [x] `go test ./cmd/coordinator` clean
- [x] EXPLAIN QUERY PLAN confirms `idx_pa_stale_cancel_keyset` used by R5 code/sec audits

## Notes

- Stacked on `impl/spec-016` (PR #164); will rebase once #164 merges to main.
- Pre-existing failure in `internal/explorer` `TestAC13_ConsumedAndVoidedSettlementsAreImmutable` on `impl/spec-016` baseline is not from this branch (verified by git stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
