### PR TITLE
fix(harness): close late-settlement leak in I1 reconciler snapshot window (closes #243, #248)

### DIFF
--- a/test/network-harness/cmd/harness/main.go
+++ b/test/network-harness/cmd/harness/main.go
@@ -137,6 +137,29 @@ func cmdRun(args []string) error {
 	hasRemoteDBs := sc.Target.CoordinatorDBSSH != "" && sc.Target.GatewayDBSSH != ""
 	switch {
 	case hasLocalDBs || hasRemoteDBs:
+		// Quiesce before snapshotting: gateway settlement can lag the
+		// harness's response observation by tens of seconds (v0.3
+		// baseline data: 26–76s). Sleep until endUTC +
+		// reconcile.SnapshotForwardPad before pulling the SQLite
+		// snapshot so late settlements have landed. The pad constant
+		// is shared with snapshotWindow's SQL upper bound and the
+		// exact-ID matcher tolerance — they must move together.
+		//
+		// Sleep is context-aware: SIGINT/SIGTERM during quiesce
+		// cancels promptly via the signal-notify context set up at
+		// the top of main().
+		quiesceTarget := meta.EndUTC.Add(reconcile.SnapshotForwardPad)
+		if d := time.Until(quiesceTarget); d > 0 {
+			log.Printf("scenario %q: quiescing %v for gateway settlement before reconcile", sc.Name, d.Round(time.Second))
+			timer := time.NewTimer(d)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				log.Printf("scenario %q: quiesce interrupted by context cancel", sc.Name)
+				return ctx.Err()
+			}
+		}
 		// Money-path gate: when DBs are configured, the harness asked
 		// for reconciliation. If reconcile.Run errors (DB schema
 		// mismatch, snapshot fetch failure, etc.) we must NOT silently

--- a/test/network-harness/internal/reconcile/ledger.go
+++ b/test/network-harness/internal/reconcile/ledger.go
@@ -44,13 +44,34 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-// matchWindow is the per-request temporal tolerance for accepting a
-// candidate row as a match for a harness observation. Used by both
-// exact-id and fuzzy paths so they cannot silently diverge. The
-// reconciler's SQL snapshot pads the run window by 30s; this tighter
-// per-request window further constrains which rows are eligible.
+// SnapshotForwardPad is the canonical forward pad applied to the
+// reconciler's SQL snapshot window AND the runner's pre-snapshot
+// quiesce sleep (cmd/harness/main.go). They MUST share the same
+// value: the runner sleeps long enough for settlements to land, and
+// the snapshot extends to the same horizon so those settlements are
+// in the pulled rows. Exported so cmd/harness can reference it
+// directly instead of redeclaring.
+const SnapshotForwardPad = 90 * time.Second
+
+// matchWindow is the per-request temporal tolerance applied by the
+// FUZZY matching path as a defense against accidental
+// token+timestamp false-positives across the run. Exact-ID matches
+// have their own wider tolerance (exactMatchSettleWindow) because
+// the request_id + account consensus already discriminate strongly,
+// and gateway settlements can lag the harness's observation by tens
+// of seconds (live v0.3 max: 76s).
 const matchWindow = 60 * time.Second
 const matchWindowMs = int64(matchWindow / time.Millisecond)
+
+// exactMatchSettleWindow is the temporal tolerance applied when a
+// row matches a harness result by request_id AND passes the account-
+// consensus guard. Sized to compose with SnapshotForwardPad so any
+// row inside the snapshot is also matchable. Without this split a
+// 76s-late gateway settlement would be pulled into the snapshot but
+// rejected by the matcher's tighter 60s window, surfacing as a
+// false-positive UnmatchedSuccesses signal (#243 R3 finding).
+const exactMatchSettleWindow = SnapshotForwardPad
+const exactMatchSettleWindowMs = int64(exactMatchSettleWindow / time.Millisecond)
 
 // Match-method labels persisted on MatchedPair. Kept as private
 // typed-string consts so tests and future helpers can reference them
@@ -223,14 +244,38 @@ type MatchedPair struct {
 	GatewayLagMs                int64  `json:"gateway_lag_ms"`
 }
 
+// snapshotWindow returns the SQL query bounds for a reconcile run.
+// Forward-only pad: gateway settlement happens AFTER the harness
+// observes the response, so the upper bound extends `endUTC` forward
+// to catch settlement lag (inference duration + async settle path).
+// The lower bound stays at `startUTC` — gateway can never CAUSALLY
+// settle before the harness sends. Backward pad pre-fix pulled tail
+// rows from a prior scenario's window into the next scenario's
+// reconcile, surfacing already-matched rows as false-positive
+// orphans (#243).
+//
+// The forward pad is sized to v0.3 baseline live data (gateway
+// settlement lag 26–76s) plus headroom, and matches the runner's
+// pre-snapshot quiesce sleep at cmd/harness/main.go so all
+// settlements for this scenario have landed before the snapshot is
+// pulled. Quiesce + forward-pad composition closes the late-
+// settlement leak fully (was issue #248, fixed inline here).
+//
+// Clock-skew on the lower bound: a gateway whose clock trails the
+// harness can write `created_at < startUTC` for a row the harness
+// owns, dropping it from the time-window query. Run() handles this
+// via a separate by-ID recovery pass (queryGatewayByIDs /
+// queryCoordinatorByIDs) for harness-owned request IDs, bypassing
+// the time bound entirely. So the lower bound's wall-clock vs
+// causal divergence is moot for harness-owned rows.
+func snapshotWindow(startUTC, endUTC time.Time) (time.Time, time.Time) {
+	return startUTC, endUTC.Add(SnapshotForwardPad)
+}
+
 // Run pulls coordinator + gateway SQLite (locally or via SSH snapshot)
 // and reconciles harness results against rows in the run window.
 func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Time) (*Result, error) {
-	// Generous pad — gateway settlement can lag coord write-back by
-	// a few seconds (the inference duration).
-	pad := 30 * time.Second
-	winStart := startUTC.Add(-pad)
-	winEnd := endUTC.Add(pad)
+	winStart, winEnd := snapshotWindow(startUTC, endUTC)
 
 	r := &Result{
 		WindowStartUTC:  winStart,
@@ -265,6 +310,27 @@ func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Ti
 	gwRows, gwHasAcct, err := queryGateway(gwPath, winStart, winEnd)
 	if err != nil {
 		return r, fmt.Errorf("gateway query: %w", err)
+	}
+
+	// ID-recovery pass for harness-owned request IDs whose timestamps
+	// landed outside the forward-only snapshot window. Surfaced by the
+	// 3-lane codex audit on #243 (security/code HIGH-1): a gateway/coord
+	// clock skewed slightly behind the harness's startUTC would drop
+	// legitimate rows from the time-window query. By-ID recovery is
+	// safe to merge directly — these rows can never be cross-scenario
+	// orphans (the harness issued the ID this scenario).
+	harnessIDs := harnessRequestIDs(results)
+	if len(harnessIDs) > 0 {
+		extraGw, err := queryGatewayByIDs(gwPath, harnessIDs)
+		if err != nil {
+			return r, fmt.Errorf("gateway id-recovery: %w", err)
+		}
+		gwRows = mergeGwByID(gwRows, extraGw)
+		extraCoord, err := queryCoordinatorByIDs(coordPath, harnessIDs)
+		if err != nil {
+			return r, fmt.Errorf("coordinator id-recovery: %w", err)
+		}
+		coordRows = mergeCoordByID(coordRows, extraCoord)
 	}
 	r.GatewayHasAccountID = gwHasAcct
 	r.CoordHasAccountID = coordHasAcct
@@ -674,7 +740,7 @@ func pickExactGwByRequestID(pool *[]gwRow, h buyer.Result, requireAccountID stri
 		if g.RequestID != h.RequestID {
 			continue
 		}
-		if absInt64(g.CreatedAt.Sub(h.EndUTC).Milliseconds()) > matchWindowMs {
+		if absInt64(g.CreatedAt.Sub(h.EndUTC).Milliseconds()) > exactMatchSettleWindowMs {
 			continue
 		}
 		if !rowAccountIDMatches(g.AccountID, requireAccountID, schemaHasAccountID) {
@@ -706,7 +772,7 @@ func pickExactCoordByRequestID(pool *[]coordRow, h buyer.Result, requireAccountI
 		if c.ExternalRequestID != h.RequestID {
 			continue
 		}
-		if absInt64(c.TsUTC.Sub(h.StartUTC).Milliseconds()) > matchWindowMs {
+		if absInt64(c.TsUTC.Sub(h.StartUTC).Milliseconds()) > exactMatchSettleWindowMs {
 			continue
 		}
 		if !rowAccountIDMatches(c.AccountID, requireAccountID, schemaHasAccountID) {
@@ -997,6 +1063,178 @@ func queryGateway(path string, start, end time.Time) ([]gwRow, bool, error) {
 		out = append(out, g)
 	}
 	return out, hasAcct, rows.Err()
+}
+
+// harnessRequestIDs extracts the unique non-empty request IDs the
+// harness recorded from gateway responses. Used by the by-ID recovery
+// pass to bypass the forward-only snapshot window for rows the harness
+// definitively owns (clock-skew mitigation; see snapshotWindow).
+func harnessRequestIDs(results []buyer.Result) []string {
+	if len(results) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(results))
+	out := make([]string, 0, len(results))
+	for _, res := range results {
+		if res.RequestID == "" || seen[res.RequestID] {
+			continue
+		}
+		seen[res.RequestID] = true
+		out = append(out, res.RequestID)
+	}
+	return out
+}
+
+// queryGatewayByIDs returns gateway rows whose request_id is in the
+// supplied set, regardless of created_at. Companion to queryGateway
+// for the by-ID recovery pass.
+func queryGatewayByIDs(path string, ids []string) ([]gwRow, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	db, err := openRO(path)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	hasAcct, err := columnExists(db, "usage_events", "account_id")
+	if err != nil {
+		return nil, fmt.Errorf("probe usage_events.account_id: %w", err)
+	}
+	acctExpr := "''"
+	if hasAcct {
+		acctExpr = "COALESCE(account_id, '')"
+	}
+	placeholders, args := inClause(ids)
+	rows, err := db.Query(fmt.Sprintf(`
+		SELECT request_id, %s, completion_tokens, outcome, created_at
+		FROM usage_events
+		WHERE request_id IN (%s)
+	`, acctExpr, placeholders), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []gwRow
+	for rows.Next() {
+		var g gwRow
+		var ts string
+		if err := rows.Scan(&g.RequestID, &g.AccountID, &g.CompletionTokens, &g.Outcome, &ts); err != nil {
+			return nil, err
+		}
+		g.CreatedAt, _ = time.Parse(time.RFC3339Nano, ts)
+		out = append(out, g)
+	}
+	return out, rows.Err()
+}
+
+// queryCoordinatorByIDs returns coord rows whose external_request_id
+// is in the supplied set, regardless of ts_utc. Companion to
+// queryCoordinator for the by-ID recovery pass. Returns no rows when
+// the coord schema pre-dates external_request_id (legacy snapshot,
+// no cross-service id to filter on).
+func queryCoordinatorByIDs(path string, ids []string) ([]coordRow, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	db, err := openRO(path)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	hasExt, err := columnExists(db, "request_log", "external_request_id")
+	if err != nil {
+		return nil, fmt.Errorf("probe request_log.external_request_id: %w", err)
+	}
+	if !hasExt {
+		return nil, nil
+	}
+	hasAcct, err := columnExists(db, "request_log", "account_id")
+	if err != nil {
+		return nil, fmt.Errorf("probe request_log.account_id: %w", err)
+	}
+	acctExpr := "''"
+	if hasAcct {
+		acctExpr = "COALESCE(account_id, '')"
+	}
+	placeholders, args := inClause(ids)
+	rows, err := db.Query(fmt.Sprintf(`
+		SELECT request_id, COALESCE(external_request_id, ''), %s, model, COALESCE(completion_tokens, 0), status, ts_utc
+		FROM request_log
+		WHERE external_request_id IN (%s)
+	`, acctExpr, placeholders), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []coordRow
+	for rows.Next() {
+		var c coordRow
+		var ts string
+		if err := rows.Scan(&c.RequestID, &c.ExternalRequestID, &c.AccountID, &c.Model, &c.CompletionTokens, &c.Status, &ts); err != nil {
+			return nil, err
+		}
+		c.TsUTC, _ = time.Parse(time.RFC3339Nano, ts)
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// inClause builds a `?, ?, ?` placeholder list and the matching args
+// slice for an `IN (...)` SQL clause. Caller guarantees ids is non-
+// empty (queryGatewayByIDs / queryCoordinatorByIDs short-circuit).
+func inClause(ids []string) (string, []any) {
+	placeholders := strings.Repeat("?,", len(ids))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	return placeholders, args
+}
+
+// mergeGwByID appends rows from b that are not already present in a,
+// keyed on (account_id, request_id) — gateway's composite PK shape.
+// Falls back to request_id alone when account_id is empty (legacy
+// snapshot). Stable order: existing a-rows kept in place, novel
+// b-rows appended.
+func mergeGwByID(a, b []gwRow) []gwRow {
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]bool, len(a)+len(b))
+	for _, r := range a {
+		seen[r.AccountID+"|"+r.RequestID] = true
+	}
+	for _, r := range b {
+		k := r.AccountID + "|" + r.RequestID
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		a = append(a, r)
+	}
+	return a
+}
+
+// mergeCoordByID appends rows from b that are not already present in
+// a, keyed on the coord-internal request_id (the PK of request_log).
+func mergeCoordByID(a, b []coordRow) []coordRow {
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]bool, len(a)+len(b))
+	for _, r := range a {
+		seen[r.RequestID] = true
+	}
+	for _, r := range b {
+		if seen[r.RequestID] {
+			continue
+		}
+		seen[r.RequestID] = true
+		a = append(a, r)
+	}
+	return a
 }
 
 func openRO(path string) (*sql.DB, error) {

--- a/test/network-harness/internal/reconcile/ledger_test.go
+++ b/test/network-harness/internal/reconcile/ledger_test.go
@@ -11,11 +11,41 @@
 package reconcile
 
 import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/augstar/macprovider-network-harness/internal/buyer"
+	"github.com/augstar/macprovider-network-harness/internal/scenario"
+
+	_ "modernc.org/sqlite"
 )
+
+// TestSnapshotWindow_NoBackwardPad is the regression test for the
+// "false-positive orphan when scenarios run back-to-back" bug. The
+// snapshot window MUST start exactly at the harness's startUTC,
+// never earlier — backward padding pulls tail rows from a prior
+// scenario into the next scenario's query, surfacing already-matched
+// rows as orphans in the second scenario's leftover pool.
+//
+// The forward pad (endUTC + 30s) stays, because gateway settlement
+// can legitimately lag the harness's observation of the response.
+func TestSnapshotWindow_NoBackwardPad(t *testing.T) {
+	start := time.Date(2026, 6, 29, 13, 7, 47, 0, time.UTC)
+	end := time.Date(2026, 6, 29, 13, 8, 35, 0, time.UTC)
+	winStart, winEnd := snapshotWindow(start, end)
+	if !winStart.Equal(start) {
+		t.Errorf("winStart must equal startUTC (no backward pad), got %v vs %v", winStart, start)
+	}
+	if !winEnd.After(end) {
+		t.Errorf("winEnd must extend past endUTC (forward pad), got %v vs %v", winEnd, end)
+	}
+	if got := winEnd.Sub(end); got != 90*time.Second {
+		t.Errorf("forward pad must be 90s, got %v", got)
+	}
+}
 
 // TestComputePerPairDrift_CleanMatches: identical token counts → zero
 // drift across every signal.
@@ -921,5 +951,343 @@ func TestComputePerPairDrift_NetVsOverbillRelationship(t *testing.T) {
 	}
 	if len(r.OverbilledPairs) != 2 {
 		t.Errorf("want 2 overbilled pairs, got %d", len(r.OverbilledPairs))
+	}
+}
+
+// --- DB fixtures for the snapshot-window integration tests ----------
+
+// newTestGatewayDB creates an empty usage_events table in a fresh
+// temp SQLite file and returns its path. Schema is the read-side
+// projection of the production phase5-gateway DDL — only columns the
+// reconciler actually SELECTs.
+func newTestGatewayDB(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gateway.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open gateway db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE usage_events (
+		request_id        TEXT NOT NULL,
+		account_id        TEXT NOT NULL DEFAULT '',
+		completion_tokens INTEGER NOT NULL DEFAULT 0,
+		outcome           TEXT NOT NULL,
+		created_at        TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("create usage_events: %v", err)
+	}
+	return path
+}
+
+func insertGwRow(t *testing.T, path, requestID, accountID string, completionTokens int64, outcome string, createdAt time.Time) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open gateway db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(
+		`INSERT INTO usage_events(request_id, account_id, completion_tokens, outcome, created_at) VALUES (?, ?, ?, ?, ?)`,
+		requestID, accountID, completionTokens, outcome, createdAt.UTC().Format(time.RFC3339Nano),
+	); err != nil {
+		t.Fatalf("insert gw row: %v", err)
+	}
+}
+
+// newTestCoordDB creates an empty request_log table in a fresh temp
+// SQLite file and returns its path. Same read-side projection rule
+// as newTestGatewayDB.
+func newTestCoordDB(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "coord.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open coord db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE request_log (
+		request_id          TEXT NOT NULL,
+		external_request_id TEXT NULL,
+		account_id          TEXT NULL,
+		model               TEXT NOT NULL DEFAULT '',
+		completion_tokens   INTEGER NULL,
+		status              INTEGER NOT NULL,
+		ts_utc              TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("create request_log: %v", err)
+	}
+	return path
+}
+
+func insertCoordRow(t *testing.T, path, requestID, externalRequestID, accountID, model string, completionTokens int64, status int, ts time.Time) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open coord db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(
+		`INSERT INTO request_log(request_id, external_request_id, account_id, model, completion_tokens, status, ts_utc) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		requestID, externalRequestID, accountID, model, completionTokens, status, ts.UTC().Format(time.RFC3339Nano),
+	); err != nil {
+		t.Fatalf("insert coord row: %v", err)
+	}
+}
+
+func makeScenario(coordPath, gwPath string) *scenario.Scenario {
+	return &scenario.Scenario{
+		Target: scenario.Target{
+			CoordinatorDBPath: coordPath,
+			GatewayDBPath:     gwPath,
+		},
+	}
+}
+
+// TestRun_IDRecoveryRescuesClockSkewedRows asserts the HIGH-1 fix
+// from the 3-lane codex audit on #243: when a gateway row's
+// `created_at` lands just before `startUTC` (clock-skew or scheduling
+// jitter), the by-ID recovery pass MUST still pull the row in so the
+// matcher pairs it with the harness result and it does NOT show up
+// as unmatched.
+//
+// Without the by-ID recovery, the row is dropped by the SQL
+// `created_at >= startUTC` predicate and the harness sees a false-
+// negative "harness success unmatched" billing-gap signal.
+func TestRun_IDRecoveryRescuesClockSkewedRows(t *testing.T) {
+	gwPath := newTestGatewayDB(t)
+	coordPath := newTestCoordDB(t)
+
+	startUTC := time.Date(2026, 6, 29, 14, 0, 0, 0, time.UTC)
+	endUTC := startUTC.Add(10 * time.Second)
+
+	// Gateway row stamped 5s BEFORE the harness's startUTC (simulates
+	// gateway clock trailing harness). Without by-ID recovery this row
+	// is invisible to the snapshot-window query.
+	insertGwRow(t, gwPath, "req-skewed-1", "acct-A", 12, "ok", startUTC.Add(-5*time.Second))
+
+	// Coord row also stamped just before startUTC, joined back to the
+	// harness id via external_request_id.
+	insertCoordRow(t, coordPath, "coord-internal-1", "req-skewed-1", "acct-A", "test-model", 12, 200, startUTC.Add(-4*time.Second))
+
+	results := []buyer.Result{{
+		RequestID:                "req-skewed-1",
+		Model:                    "test-model",
+		Outcome:                  "ok",
+		CompletionTokensReceived: 12,
+		StartUTC:                 startUTC.Add(time.Second),
+		EndUTC:                   startUTC.Add(2 * time.Second),
+	}}
+
+	sc := makeScenario(coordPath, gwPath)
+	r, err := Run(sc, results, startUTC, endUTC)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(r.UnmatchedSuccesses) != 0 {
+		t.Errorf("clock-skewed harness-owned row must NOT appear as unmatched, got %v", r.UnmatchedSuccesses)
+	}
+	if len(r.MatchedSuccesses) != 1 {
+		t.Fatalf("want 1 matched pair, got %d (matched=%v)", len(r.MatchedSuccesses), r.MatchedSuccesses)
+	}
+	if got := r.MatchedSuccesses[0].GatewayCompletionTokens; got != 12 {
+		t.Errorf("matched gateway tokens: want 12, got %d", got)
+	}
+	if got := r.MatchedSuccesses[0].CoordinatorCompletionTokens; got != 12 {
+		t.Errorf("matched coord tokens: want 12, got %d", got)
+	}
+	if len(r.UnmatchedGatewayOKRows) != 0 {
+		t.Errorf("by-ID-recovered row must not appear as gateway orphan, got %v", r.UnmatchedGatewayOKRows)
+	}
+}
+
+// TestRun_NoDoubleCountingAcrossAdjacentScenarios asserts the #243
+// no-double-counting contract: a gateway row stamped inside scenario
+// N's window MUST NOT surface as an orphan in scenario N+1's
+// reconcile, even when N+1 starts immediately after N ends. This is
+// the end-to-end behavioral test the R1 code-lane MEDIUM finding
+// asked for — the existing TestSnapshotWindow_NoBackwardPad only
+// asserts the helper's arithmetic.
+func TestRun_NoDoubleCountingAcrossAdjacentScenarios(t *testing.T) {
+	gwPath := newTestGatewayDB(t)
+	coordPath := newTestCoordDB(t)
+
+	scn1Start := time.Date(2026, 6, 29, 14, 0, 0, 0, time.UTC)
+	scn1End := scn1Start.Add(10 * time.Second)
+	scn2Start := scn1End // back-to-back, like 02→03 in the v0.3 baseline run
+	scn2End := scn2Start.Add(10 * time.Second)
+
+	// Scenario 1's row, stamped 8s in (well inside scenario 1's window).
+	insertGwRow(t, gwPath, "req-scn1", "acct-A", 7, "ok", scn1Start.Add(8*time.Second))
+	insertCoordRow(t, coordPath, "coord-scn1", "req-scn1", "acct-A", "test-model", 7, 200, scn1Start.Add(8*time.Second))
+
+	// Scenario 1 has the harness result for req-scn1. Run it: should
+	// reconcile cleanly with one matched pair.
+	scn1Results := []buyer.Result{{
+		RequestID:                "req-scn1",
+		Model:                    "test-model",
+		Outcome:                  "ok",
+		CompletionTokensReceived: 7,
+		StartUTC:                 scn1Start.Add(7 * time.Second),
+		EndUTC:                   scn1Start.Add(9 * time.Second),
+	}}
+	sc := makeScenario(coordPath, gwPath)
+	r1, err := Run(sc, scn1Results, scn1Start, scn1End)
+	if err != nil {
+		t.Fatalf("scenario 1 Run: %v", err)
+	}
+	if len(r1.MatchedSuccesses) != 1 {
+		t.Fatalf("scn1 want 1 matched pair, got %d", len(r1.MatchedSuccesses))
+	}
+	if len(r1.UnmatchedGatewayOKRows) != 0 {
+		t.Errorf("scn1 unexpected gateway orphans: %v", r1.UnmatchedGatewayOKRows)
+	}
+
+	// Scenario 2: no harness result for req-scn1 (different scenario).
+	// Pre-fix, the backward pad pulled scn1's tail row into scn2's
+	// window and surfaced req-scn1 as a false-positive orphan in scn2.
+	// Post-fix, scn2's window starts at scn2Start = scn1End, so the
+	// scn1 row at scn1Start+8s is outside scn2's pull AND not in scn2's
+	// harness IDs → must not appear.
+	scn2Results := []buyer.Result{} // empty: simulates a scenario where no harness fires against this row
+	r2, err := Run(sc, scn2Results, scn2Start, scn2End)
+	if err != nil {
+		t.Fatalf("scenario 2 Run: %v", err)
+	}
+	if len(r2.UnmatchedGatewayOKRows) != 0 {
+		t.Errorf("scenario 2 must not see scenario 1's gateway row as orphan, got %v", r2.UnmatchedGatewayOKRows)
+	}
+	if len(r2.UnmatchedCoordinator2xxRows) != 0 {
+		t.Errorf("scenario 2 must not see scenario 1's coord row as orphan, got %v", r2.UnmatchedCoordinator2xxRows)
+	}
+}
+
+// TestSnapshotWindow_BoundaryNanoseconds locks the inclusive nature
+// of the snapshot window bounds in SQL: a row stamped exactly at
+// startUTC is included; a row stamped 1ns before is excluded; a row
+// at endUTC+30s is included; a row 1ns past the pad is excluded.
+// LOW finding from the R1 security lane: the test should anchor the
+// `>=` / `<=` semantics so future "tighten the bound" edits cannot
+// silently flip exact-boundary behavior.
+//
+// Sub-second component is 9-significant-digits so time.RFC3339Nano
+// emits a uniform 9-digit fraction across all boundary timestamps;
+// SQL string comparison of variable-length trimmed fractions is a
+// separate pre-existing harness quirk, out of scope for #243.
+func TestSnapshotWindow_BoundaryNanoseconds(t *testing.T) {
+	gwPath := newTestGatewayDB(t)
+	coordPath := newTestCoordDB(t)
+	startUTC := time.Date(2026, 6, 29, 14, 0, 0, 123_456_789, time.UTC)
+	endUTC := startUTC.Add(10 * time.Second)
+
+	// Four rows: one each at start-1ns (excl), start (incl), end+90s
+	// (incl), end+90s+1ns (excl). No harness results → none get
+	// id-rescued. Orphans tell us which rows the snapshot query saw.
+	insertGwRow(t, gwPath, "before-window", "acct-A", 1, "ok", startUTC.Add(-time.Nanosecond))
+	insertGwRow(t, gwPath, "at-start", "acct-A", 1, "ok", startUTC)
+	insertGwRow(t, gwPath, "at-end-pad", "acct-A", 1, "ok", endUTC.Add(90*time.Second))
+	insertGwRow(t, gwPath, "past-end-pad", "acct-A", 1, "ok", endUTC.Add(90*time.Second).Add(time.Nanosecond))
+
+	sc := makeScenario(coordPath, gwPath)
+	r, err := Run(sc, nil, startUTC, endUTC)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got := map[string]bool{}
+	for _, id := range r.UnmatchedGatewayOKRows {
+		got[id] = true
+	}
+	if got["before-window"] {
+		t.Errorf("row 1ns before startUTC must be excluded, got it as orphan")
+	}
+	if !got["at-start"] {
+		t.Errorf("row at startUTC must be included (inclusive lower bound)")
+	}
+	if !got["at-end-pad"] {
+		t.Errorf("row at endUTC+30s must be included (inclusive upper bound)")
+	}
+	if got["past-end-pad"] {
+		t.Errorf("row 1ns past endUTC+30s must be excluded")
+	}
+}
+
+// TestRun_LateSettlement_ExactIDMatchesPastFuzzyWindow asserts the
+// #243 R3 fix: a gateway row whose `created_at` is 76s after the
+// harness's `EndUTC` (within live v0.3 baseline lag) MUST still
+// match by exact request_id, because the snapshot pad + quiesce
+// were widened to 90s but the FUZZY matchWindow stayed at 60s as a
+// defensive guard against accidental token+timestamp false-positives.
+// Without the exactMatchSettleWindow split, this row would be in the
+// snapshot pool but rejected by the matcher, surfacing as a false-
+// positive UnmatchedSuccesses + orphan gateway row.
+//
+// 3-of-3 R3 codex audit lanes converged on this finding before the
+// fix landed. The test pins the contract so future "tighten the
+// match window" edits cannot silently re-open the bug.
+func TestRun_LateSettlement_ExactIDMatchesPastFuzzyWindow(t *testing.T) {
+	gwPath := newTestGatewayDB(t)
+	coordPath := newTestCoordDB(t)
+
+	startUTC := time.Date(2026, 6, 29, 14, 0, 0, 0, time.UTC)
+	harnessEnd := startUTC.Add(2 * time.Second)
+	endUTC := startUTC.Add(10 * time.Second)
+
+	// Gateway settles 76s after the harness's observed end (live
+	// v0.3 max lag). Inside the 90s snapshot pad, OUTSIDE the 60s
+	// fuzzy matchWindow.
+	gwCreated := harnessEnd.Add(76 * time.Second)
+	insertGwRow(t, gwPath, "req-late-76s", "acct-A", 18, "ok", gwCreated)
+	// Coord settles at a similar lag from harness start.
+	insertCoordRow(t, coordPath, "coord-late-1", "req-late-76s", "acct-A", "test-model", 18, 200, startUTC.Add(75*time.Second))
+
+	results := []buyer.Result{{
+		RequestID:                "req-late-76s",
+		Model:                    "test-model",
+		Outcome:                  "ok",
+		CompletionTokensReceived: 18,
+		StartUTC:                 startUTC.Add(time.Second),
+		EndUTC:                   harnessEnd,
+	}}
+
+	sc := makeScenario(coordPath, gwPath)
+	r, err := Run(sc, results, startUTC, endUTC)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(r.UnmatchedSuccesses) != 0 {
+		t.Errorf("76s-late harness-owned row must match by exact id, got unmatched=%v", r.UnmatchedSuccesses)
+	}
+	if len(r.MatchedSuccesses) != 1 {
+		t.Fatalf("want 1 matched pair, got %d", len(r.MatchedSuccesses))
+	}
+	if got := r.MatchedSuccesses[0].GatewayCompletionTokens; got != 18 {
+		t.Errorf("matched gateway tokens: want 18, got %d", got)
+	}
+	if got := r.MatchedSuccesses[0].CoordinatorCompletionTokens; got != 18 {
+		t.Errorf("matched coord tokens: want 18, got %d", got)
+	}
+	if len(r.UnmatchedGatewayOKRows) != 0 {
+		t.Errorf("late settle row must not appear as gateway orphan, got %v", r.UnmatchedGatewayOKRows)
+	}
+}
+
+// TestHarnessRequestIDs_DedupAndFilter pins the helper that feeds the
+// by-ID recovery pass: empty strings are filtered, duplicates are
+// collapsed, original order is preserved. Cheap unit test.
+func TestHarnessRequestIDs_DedupAndFilter(t *testing.T) {
+	results := []buyer.Result{
+		{RequestID: "a"},
+		{RequestID: ""},
+		{RequestID: "b"},
+		{RequestID: "a"}, // duplicate
+		{RequestID: "c"},
+	}
+	got := harnessRequestIDs(results)
+	want := []string{"a", "b", "c"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("want %v, got %v", want, got)
+	}
+	if harnessRequestIDs(nil) != nil {
+		t.Errorf("nil input must return nil")
 	}
 }


### PR DESCRIPTION
## Summary

Three-part fix to the harness's I1 reconciler snapshot window, surfaced by the v0.3 baseline rerun and converged across 3 rounds of 3-lane codex audit. Closes #243 and folds in #248 (initially filed as a deferred follow-up, then folded in after user pushback — same surface, cheap inline fix).

### What broke

1. **Cross-scenario false-positive orphans.** When scenarios ran back-to-back (e.g. 02 ENDs 13:07:47, 03 STARTs 13:07:47), the 30s backward pad pulled tail gateway rows from 02 into 03's reconcile. Same row reconciled twice — once cleanly, once as a phantom orphan on the next scenario's I1.
2. **Clock-skew dropped harness-owned rows.** Gateway `created_at < startUTC` (sub-second clock skew) was dropped by the SQL window predicate, then surfaced as false-positive `UnmatchedSuccesses` (R2 HIGH from security + code lanes).
3. **76s-late settlements rejected by matcher even when in snapshot.** v0.3 live data showed gateway settlements lagging 26–76s. The original 30s forward pad missed them; bumping to 90s + adding 90s quiesce got them into the snapshot pool, but `matchWindow = 60s` then rejected them at match-time — same false-positive UnmatchedSuccesses class (R3 HIGH, 3-of-3 lane convergence).

### What changed

- `snapshotWindow`: backward pad dropped, forward pad 30s → 90s, anchored on new exported `reconcile.SnapshotForwardPad`.
- `queryGatewayByIDs` / `queryCoordinatorByIDs`: by-ID recovery pass for harness-owned request IDs, bypassing the lower-bound time predicate. Composite-key dedup merge.
- `exactMatchSettleWindow`: per-request settle tolerance for exact-id matches, sized to `SnapshotForwardPad`. `matchWindow` (60s) stays as the FUZZY guard against accidental token+timestamp false positives.
- `cmd/harness/main.go`: 90s context-aware quiesce sleep before reconcile snapshot. `select { time.After(d); ctx.Done() }` so SIGINT exits promptly.

### Audit trajectory

- R1 (3-lane codex): 2 HIGH (clock-skew lower bound; forward pad inadequate) + 1 MEDIUM (test contract).
- R2 (3-lane codex): 0 C/H/M on by-ID recovery + merge; LOWs only.
- R3 (3-lane codex): 1 HIGH 3-of-3 convergent on the matcher window gap; 1 MEDIUM on cancellable quiesce; fix inline. No R4.

### Tests (all green)

- `TestSnapshotWindow_NoBackwardPad` (R0)
- `TestRun_IDRecoveryRescuesClockSkewedRows` (R2 HIGH)
- `TestRun_NoDoubleCountingAcrossAdjacentScenarios` (R2 MEDIUM)
- `TestSnapshotWindow_BoundaryNanoseconds` (R2 LOW)
- `TestRun_LateSettlement_ExactIDMatchesPastFuzzyWindow` (R3 HIGH)
- `TestHarnessRequestIDs_DedupAndFilter` (unit)

## Test plan

- [x] `go test ./...` in `test/network-harness/` — all packages green
- [x] `go build ./...` clean
- [ ] Post-merge: re-run v0.3 baseline; expect 1–6 + 8 cleanly pass (residual is scenario 07 gateway-side +9 tok counting offset, a real money-path bug, NOT a harness issue)