### PR TITLE
fix(gateway): surface provider peer id via X-Provider-Id response header (unblocks B5/B6 + #222 measurement)

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -740,6 +740,15 @@ func (s *Server) passThroughNoProviderCoordinatorError(w http.ResponseWriter, r 
 
 func (s *Server) passThroughReceiptEligibleProviderError(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, body []byte) {
 	_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+	// PR #250 R1 code MEDIUM: this path serves provider-SELECTED
+	// errors (null-usage 5xx, etc.) where the coord did pick a
+	// provider before the failure (server.go:1886, :1909 set
+	// X-MacProvider-Provider on selected-provider non-200 responses).
+	// Without emitting attribution here, B5/B6 benchmark verdicts
+	// would still mis-attribute provider-side failures as anonymous.
+	// passThroughNoProviderCoordinatorError stays unchanged because
+	// no provider was selected on its callers' paths.
+	emitProviderAttribution(w.Header(), resp.Header)
 	copyReceiptEligibleHeaders(w.Header(), resp.Header)
 	w.Header().Set("Content-Type", contentTypeOrJSON(resp.Header))
 	w.WriteHeader(resp.StatusCode)

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -407,10 +407,37 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 	if !s.settleBeforeResponse(w, r, subject, usage.PromptTokens, usage.CompletionTokens, maxUsageTokens, tokenSource, "ok") {
 		return
 	}
+	emitProviderAttribution(w.Header(), resp.Header)
 	copyReceiptEligibleHeaders(w.Header(), resp.Header)
 	w.Header().Set("Content-Type", contentTypeOrJSON(resp.Header))
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(body)
+}
+
+// emitProviderAttribution surfaces the provider peer id under a public
+// buyer-facing header name (X-Provider-Id) on the gateway response.
+//
+// Required by harness B5/B6 verdicts (slot utilization, per-provider
+// earnings) and any downstream buyer that wants per-request provider
+// attribution. The internal `X-MacProvider-Provider` header carrying
+// the peer id is stripped by copyCleanHeaders /
+// copyReceiptEligibleHeaders via isMacProviderHeader, so this MUST
+// run BEFORE the copy/strip — and emit under a different prefix so it
+// survives the strip.
+//
+// Only the peer id is surfaced. The companion `X-MacProvider-Route`
+// header on coord responses carries a session-assigned routing token
+// (auth-shaped, not a pure identifier) and is deliberately NOT
+// emitted to buyers.
+//
+// Empty source values produce no output header (avoids leaking
+// "X-Provider-Id: " sentinels on coord paths that don't carry
+// provider attribution — coordinator policy errors, cold-start 503s
+// without a peer selected, etc.).
+func emitProviderAttribution(dst, src http.Header) {
+	if v := src.Get("X-MacProvider-Provider"); v != "" {
+		dst.Set("X-Provider-Id", v)
+	}
 }
 
 func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64, cancelUpstream func(), upstreamCtx context.Context, structuredStreaming bool, reservationWindow string) {
@@ -456,6 +483,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		writeError(w, http.StatusBadGateway, "api_error", "upstream_provider_error", "Upstream provider error")
 		return
 	}
+	emitProviderAttribution(w.Header(), resp.Header)
 	copyCleanHeaders(w.Header(), resp.Header)
 	w.Header().Set("X-MacProvider-Gateway-FirstByte-Unix-Ms", strconv.FormatInt(s.now().UnixMilli(), 10))
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1577,6 +1577,44 @@ func TestProviderAttributionHeadersEmitted(t *testing.T) {
 		}
 	})
 
+	t.Run("provider-selected-error-attributed", func(t *testing.T) {
+		// PR #250 R1 code MEDIUM: provider-SELECTED errors (null-usage
+		// 5xx via passThroughReceiptEligibleProviderError) must also
+		// surface attribution. Coord sets X-MacProvider-Provider on
+		// selected-provider non-200 responses (phase4-coordinator
+		// server.go:1886 + :1909) so B5/B6 can attribute per-Mac
+		// failures, not just successes.
+		client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			h := http.Header{}
+			h.Set("Content-Type", "application/json")
+			h.Set("X-MacProvider-Provider", peerID)
+			h.Set("X-MacProvider-Route", routeToken)
+			return responseWithBody(http.StatusBadGateway, h, `{"error":{"message":"model not loaded","type":"api_error","param":null,"code":"error_model_not_loaded"}}`), nil
+		})}
+		h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+			cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		}, WithHTTPClient(client))
+		fullKey := createAccountAndKey(t, store, cfg, "acct_attr_provider_err")
+
+		resp := postChat(t, h, fullKey, `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`, nil)
+
+		if resp.Code != http.StatusBadGateway {
+			t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+		}
+		if got := resp.Header().Get("X-Provider-Id"); got != peerID {
+			t.Errorf("provider-selected error X-Provider-Id = %q, want %q", got, peerID)
+		}
+		if got := resp.Header().Get("X-MacProvider-Provider"); got != "" {
+			t.Errorf("provider-selected error leaked internal X-MacProvider-Provider = %q", got)
+		}
+		if got := resp.Header().Get("X-MacProvider-Route"); got != "" {
+			t.Errorf("provider-selected error leaked X-MacProvider-Route = %q", got)
+		}
+		if got := resp.Header().Get("X-Provider-Assigned-Id"); got != "" {
+			t.Errorf("provider-selected error surfaced X-Provider-Assigned-Id = %q", got)
+		}
+	})
+
 	t.Run("empty-source-suppresses-output", func(t *testing.T) {
 		// Coord paths that don't carry provider attribution (policy
 		// errors, cold-start 503s without a peer selected) must not

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1499,6 +1499,110 @@ func TestStreamingReceiptHeaderStripped(t *testing.T) {
 	}
 }
 
+// TestProviderAttributionHeadersEmitted asserts the gateway surfaces
+// the coord-internal provider peer id (X-MacProvider-Provider) under
+// the public X-Provider-Id header on the buyer-facing response, for
+// BOTH non-streaming and streaming paths. Required for harness B5/B6
+// verdicts (slot utilization, per-provider earnings) which were
+// SKIP-ing on every benchmark run because there was no per-request
+// provider attribution surface. The internal-prefixed header is
+// still stripped, and the session-assigned-token X-MacProvider-Route
+// is NOT surfaced (auth-shaped value, deliberately not leaked).
+func TestProviderAttributionHeadersEmitted(t *testing.T) {
+	const peerID = "m4-air-augstar"
+	const routeToken = "session-route-token-do-not-leak"
+
+	t.Run("non-streaming", func(t *testing.T) {
+		client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			h := http.Header{}
+			h.Set("Content-Type", "application/json")
+			h.Set("X-MacProvider-Provider", peerID)
+			h.Set("X-MacProvider-Route", routeToken)
+			return responseWithBody(http.StatusOK, h, `{"id":"chatcmpl","object":"chat.completion","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), nil
+		})}
+		h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+			cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		}, WithHTTPClient(client))
+		fullKey := createAccountAndKey(t, store, cfg, "acct_attr_nonstream")
+
+		resp := postChat(t, h, fullKey, `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`, nil)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+		}
+		if got := resp.Header().Get("X-Provider-Id"); got != peerID {
+			t.Errorf("non-streaming X-Provider-Id = %q, want %q", got, peerID)
+		}
+		if got := resp.Header().Get("X-MacProvider-Provider"); got != "" {
+			t.Errorf("non-streaming buyer response leaked internal X-MacProvider-Provider = %q", got)
+		}
+		if got := resp.Header().Get("X-MacProvider-Route"); got != "" {
+			t.Errorf("non-streaming buyer response leaked X-MacProvider-Route = %q (session token must not be exposed)", got)
+		}
+		if got := resp.Header().Get("X-Provider-Assigned-Id"); got != "" {
+			t.Errorf("non-streaming response surfaced X-Provider-Assigned-Id = %q (route token is not for buyers)", got)
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			payload := `data: {"id":"chatcmpl","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"delta":{"content":"ok"}}]}`
+			h := http.Header{}
+			h.Set("Content-Type", "text/event-stream; charset=utf-8")
+			h.Set("X-MacProvider-Provider", peerID)
+			h.Set("X-MacProvider-Route", routeToken)
+			return responseWithBody(http.StatusOK, h, payload+"\n\ndata: [DONE]\n\n"), nil
+		})}
+		h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+			cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		}, WithHTTPClient(client))
+		fullKey := createAccountAndKey(t, store, cfg, "acct_attr_stream")
+
+		resp := postChat(t, h, fullKey, `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`, nil)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+		}
+		if got := resp.Header().Get("X-Provider-Id"); got != peerID {
+			t.Errorf("streaming X-Provider-Id = %q, want %q", got, peerID)
+		}
+		if got := resp.Header().Get("X-MacProvider-Provider"); got != "" {
+			t.Errorf("streaming buyer response leaked internal X-MacProvider-Provider = %q", got)
+		}
+		if got := resp.Header().Get("X-MacProvider-Route"); got != "" {
+			t.Errorf("streaming buyer response leaked X-MacProvider-Route = %q", got)
+		}
+		if got := resp.Header().Get("X-Provider-Assigned-Id"); got != "" {
+			t.Errorf("streaming response surfaced X-Provider-Assigned-Id = %q", got)
+		}
+	})
+
+	t.Run("empty-source-suppresses-output", func(t *testing.T) {
+		// Coord paths that don't carry provider attribution (policy
+		// errors, cold-start 503s without a peer selected) must not
+		// produce a sentinel `X-Provider-Id: ""` on the buyer
+		// response.
+		client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return responseWithBody(http.StatusOK, http.Header{
+				"Content-Type": []string{"application/json"},
+			}, `{"id":"chatcmpl","object":"chat.completion","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), nil
+		})}
+		h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+			cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		}, WithHTTPClient(client))
+		fullKey := createAccountAndKey(t, store, cfg, "acct_attr_empty")
+
+		resp := postChat(t, h, fullKey, `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`, nil)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+		}
+		if _, present := resp.Header()["X-Provider-Id"]; present {
+			t.Errorf("X-Provider-Id must not be set when source is missing, got %q", resp.Header().Get("X-Provider-Id"))
+		}
+	})
+}
+
 func TestProviderPinningHeadersStripped(t *testing.T) {
 	var captured http.Header
 	failing := false


### PR DESCRIPTION
## Summary

The gateway already receives `X-MacProvider-Provider` on every coord response (peer id of the Mac selected for this request) but strips it before the buyer sees it. The harness has been **ready to read `X-Provider-Id`** since v0.1 of the benchmark suite ([`buyer/loadgen.go:204`](test/network-harness/internal/buyer/loadgen.go#L204)), but every **B5 (slot utilization)** and **B6 (per-provider earnings)** verdict in [`specs/BENCHMARK_BASELINE_2026-06-29.md`](specs/BENCHMARK_BASELINE_2026-06-29.md) has come back **SKIP** because the value never reached the buyer.

This blocks measurement on [#222](https://github.com/Augustas11/macprovider/issues/222) (providers earn ~$0.045/hr vs $0.30–$1.00 target band) — without per-request provider attribution we can't measure per-Mac earnings or identify which Mac is bottlenecking sustained throughput.

## Change

New `emitProviderAttribution()` helper runs on both forward paths BEFORE the strip:

- `forwardNonStreamingChat` → [`chat_proxy.go:410`](phase5-gateway/internal/router/chat_proxy.go#L410)
- `forwardStreamingChat` → [`chat_proxy.go:486`](phase5-gateway/internal/router/chat_proxy.go#L486)

Mapping:
- `X-MacProvider-Provider` (coord-internal) → `X-Provider-Id` (buyer-facing)

The companion `X-MacProvider-Route` (session-assigned routing token, auth-shaped) is **deliberately NOT** surfaced. Empty source values produce no output header (no sentinel `X-Provider-Id: ""` on coord paths without provider attribution — policy errors, cold-start 503s).

## Tests

`TestProviderAttributionHeadersEmitted` (3 subtests):
- **non-streaming**: `X-Provider-Id` surfaced; `X-MacProvider-Provider` stripped; `X-MacProvider-Route` NOT surfaced; `X-Provider-Assigned-Id` absent
- **streaming**: same assertions on SSE path
- **empty-source-suppresses-output**: no sentinel header when coord response carries no provider attribution

Existing `TestProviderPinningHeadersStripped` still passes (internal pin-headers still stripped, change is additive).

## Why this took two days to surface

The B5/B6 SKIP gap was flagged in [`BENCHMARK_BASELINE_2026-06-28.md`](specs/BENCHMARK_BASELINE_2026-06-28.md) and again in the [`-06-29`](specs/BENCHMARK_BASELINE_2026-06-29.md) version under "Issues to file" item 3. It sat for ~24h while harness audit cycles ran. Acting on the finding now per operator pushback.

## Test plan

- [x] `go test ./internal/router/... -count=1` (5.1s, all green)
- [x] `go vet ./...` clean (build)
- [ ] Post-deploy: re-run v0.3 benchmark suite; expect B5+B6 verdicts to PASS/FAIL with real signal instead of SKIP, surfacing per-Mac earnings for #222 analysis