### PR TITLE
impl(020): SPEC-020 v0.1.4 provider autoupdate + v1.7.0 binaryVersion bump (5-round 3-lane IMPL audit)

### DIFF
--- a/ops/macprovider-watchdog/Scripts/test-ac-19-20-watchdog-recovery.sh
+++ b/ops/macprovider-watchdog/Scripts/test-ac-19-20-watchdog-recovery.sh
@@ -24,11 +24,27 @@ chmod 700 "$HOME_DIR" "$HOME_DIR/.local" "$HOME_DIR/.local/share" "$HOME_DIR/.lo
 cat > "$FAKE_BIN/launchctl" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = "print" ]; then
-  printf 'pid = 123\nlast exit status = 0\n'
+  case "${TEST_LAUNCHCTL_PRINT:-healthy}" in
+    crash)
+      printf 'pid = 123\nlast exit status = 7\n'
+      ;;
+    missing_pid)
+      printf 'last exit status = 0\n'
+      ;;
+    *)
+      printf 'pid = 123\nlast exit status = 0\n'
+      ;;
+  esac
 fi
 exit 0
 SH
 chmod 700 "$FAKE_BIN/launchctl"
+
+cat > "$FAKE_BIN/curl" <<'SH'
+#!/usr/bin/env bash
+exit "${TEST_CURL_EXIT:-0}"
+SH
+chmod 700 "$FAKE_BIN/curl"
 
 write_fixture() {
   local backup_body="$1"
@@ -81,6 +97,19 @@ run_watchdog_tick() {
   bash "$WATCHDOG"
 }
 
+run_watchdog_tick_with_health() {
+  HOME="$HOME_DIR" \
+  PATH="$FAKE_BIN:$PATH" \
+  MACPROVIDER_AUTOUPDATE_STATE_ROOT="$STATE_ROOT" \
+  MACPROVIDER_BINARY_DIR="$BIN_DIR" \
+  MACPROVIDER_CONFIG_PATH="$TMP_ROOT/missing-config.yaml" \
+  MACPROVIDER_CURL="$FAKE_BIN/curl" \
+  MACPROVIDER_HEALTHCHECK_URL="http://127.0.0.1:9/healthz" \
+  MACPROVIDER_LOG_DIR="$LOG_DIR" \
+  MACPROVIDER_WATCHDOG_STATE_DIR="$WATCHDOG_STATE" \
+  bash "$WATCHDOG"
+}
+
 write_fixture $'old-version\n' $'new-version\n'
 run_watchdog_tick
 
@@ -116,4 +145,37 @@ if ! grep -q '"failure_class":"rollback_backup_corrupt"' "$LOG_DIR/watchdog.log"
   exit 1
 fi
 
-echo "AC-19/20 watchdog recovery PASS"
+rm -f "$STATE_ROOT"/pending-quarantined-*.json "$LOG_DIR/watchdog.log"
+write_fixture $'old-version\n' $'new-version\n'
+TEST_LAUNCHCTL_PRINT=crash run_watchdog_tick
+if ! grep -q '"failure_class":"post_start_crash"' "$LOG_DIR/watchdog.log"; then
+  echo "AC-10 FAIL: post_start_crash event missing" >&2
+  exit 1
+fi
+
+rm -f "$STATE_ROOT"/pending-quarantined-*.json "$LOG_DIR/watchdog.log"
+write_fixture $'old-version\n' $'new-version\n'
+TEST_CURL_EXIT=22 run_watchdog_tick_with_health
+if ! grep -q '"failure_class":"post_start_health_failed"' "$LOG_DIR/watchdog.log"; then
+  echo "AC-10 FAIL: post_start_health_failed event missing" >&2
+  exit 1
+fi
+
+rm -f "$STATE_ROOT"/pending-quarantined-*.json "$LOG_DIR/watchdog.log"
+write_fixture $'old-version\n' $'new-version\n'
+cat > "$TARGET" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+  echo "macprovider-cli 1.6.0"
+  exit 0
+fi
+exit 0
+SH
+chmod 700 "$TARGET"
+run_watchdog_tick
+if ! grep -q '"failure_class":"post_start_rejoin_timeout"' "$LOG_DIR/watchdog.log"; then
+  echo "AC-10 FAIL: post_start_rejoin_timeout event missing" >&2
+  exit 1
+fi
+
+echo "AC-10/19/20 watchdog recovery PASS"

--- a/ops/macprovider-watchdog/Scripts/test-ac-19-20-watchdog-recovery.sh
+++ b/ops/macprovider-watchdog/Scripts/test-ac-19-20-watchdog-recovery.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHDOG_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WATCHDOG="$WATCHDOG_DIR/watchdog.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/macprovider-watchdog-ac19-20.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+HOME_DIR="$TMP_ROOT/home"
+STATE_ROOT="$HOME_DIR/.local/share/macprovider/autoupdate"
+BIN_DIR="$TMP_ROOT/bin"
+LOG_DIR="$TMP_ROOT/logs"
+WATCHDOG_STATE="$TMP_ROOT/watchdog-state"
+FAKE_BIN="$TMP_ROOT/fake-bin"
+
+mkdir -p "$STATE_ROOT" "$BIN_DIR" "$LOG_DIR" "$WATCHDOG_STATE" "$FAKE_BIN"
+chmod 700 "$HOME_DIR" "$HOME_DIR/.local" "$HOME_DIR/.local/share" "$HOME_DIR/.local/share/macprovider" "$STATE_ROOT" "$BIN_DIR"
+
+cat > "$FAKE_BIN/launchctl" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "print" ]; then
+  printf 'pid = 123\nlast exit status = 0\n'
+fi
+exit 0
+SH
+chmod 700 "$FAKE_BIN/launchctl"
+
+write_fixture() {
+  local backup_body="$1"
+  local target_body="$2"
+  python3 - "$STATE_ROOT" "$BIN_DIR" "$backup_body" "$target_body" <<'PY'
+import datetime
+import hashlib
+import json
+import os
+import sys
+
+root, binary_dir, backup_body, target_body = sys.argv[1:5]
+update_id = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+target = os.path.join(binary_dir, "macprovider-cli")
+backup = os.path.join(binary_dir, f".macprovider-cli.rollback-{update_id}")
+with open(target, "w", encoding="utf-8") as fh:
+    fh.write(target_body)
+with open(backup, "w", encoding="utf-8") as fh:
+    fh.write(backup_body)
+os.chmod(target, 0o700)
+os.chmod(backup, 0o600)
+deadline = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+marker = {
+    "update_id": update_id,
+    "target_version": "1.7.0",
+    "target_path": target,
+    "backup_path": backup,
+    "size": len(backup_body.encode("utf-8")),
+    "mode": 0o700,
+    "sha256": hashlib.sha256(b"old-version\n").hexdigest(),
+    "marker_deadline": deadline,
+}
+with open(os.path.join(root, "pending.json"), "w", encoding="utf-8") as fh:
+    json.dump(marker, fh, sort_keys=True, separators=(",", ":"))
+os.chmod(os.path.join(root, "pending.json"), 0o600)
+with open(os.path.join(root, "update.lock"), "w", encoding="utf-8") as fh:
+    fh.write("")
+os.chmod(os.path.join(root, "update.lock"), 0o600)
+PY
+}
+
+run_watchdog_tick() {
+  HOME="$HOME_DIR" \
+  PATH="$FAKE_BIN:$PATH" \
+  MACPROVIDER_AUTOUPDATE_STATE_ROOT="$STATE_ROOT" \
+  MACPROVIDER_BINARY_DIR="$BIN_DIR" \
+  MACPROVIDER_CONFIG_PATH="$TMP_ROOT/missing-config.yaml" \
+  MACPROVIDER_LOG_DIR="$LOG_DIR" \
+  MACPROVIDER_WATCHDOG_STATE_DIR="$WATCHDOG_STATE" \
+  bash "$WATCHDOG"
+}
+
+write_fixture $'old-version\n' $'new-version\n'
+run_watchdog_tick
+
+TARGET="$BIN_DIR/macprovider-cli"
+BACKUP="$BIN_DIR/.macprovider-cli.rollback-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+if [ "$(cat "$TARGET")" != $'old-version' ]; then
+  echo "AC-19 FAIL: valid backup was not restored" >&2
+  exit 1
+fi
+if [ -e "$STATE_ROOT/pending.json" ] || [ -e "$BACKUP" ] || [ -e "$STATE_ROOT/update.lock" ]; then
+  echo "AC-19 FAIL: restored marker/backup/lock were not cleaned up" >&2
+  exit 1
+fi
+
+rm -f "$STATE_ROOT"/pending-quarantined-*.json
+write_fixture $'corrupt-version\n' $'new-version\n'
+run_watchdog_tick
+
+if [ "$(cat "$TARGET")" != $'new-version' ]; then
+  echo "AC-20 FAIL: corrupt backup changed live binary" >&2
+  exit 1
+fi
+if [ -e "$STATE_ROOT/pending.json" ] || ! compgen -G "$STATE_ROOT/pending-quarantined-*.json" >/dev/null; then
+  echo "AC-20 FAIL: corrupt marker was not quarantined" >&2
+  exit 1
+fi
+if [ ! -e "$BACKUP" ]; then
+  echo "AC-20 FAIL: corrupt backup should be left for forensics" >&2
+  exit 1
+fi
+if ! grep -q '"failure_class":"rollback_backup_corrupt"' "$LOG_DIR/watchdog.log"; then
+  echo "AC-20 FAIL: rollback_backup_corrupt event missing" >&2
+  exit 1
+fi
+
+echo "AC-19/20 watchdog recovery PASS"

--- a/ops/macprovider-watchdog/watchdog.sh
+++ b/ops/macprovider-watchdog/watchdog.sh
@@ -128,7 +128,9 @@ import fcntl
 import hashlib
 import json
 import os
+import pwd
 import re
+import shutil
 import stat
 import subprocess
 import sys
@@ -140,6 +142,7 @@ log_path = os.environ["LOG_PATH"]
 pending = os.path.join(root, "pending.json")
 lock_path = os.path.join(root, "update.lock")
 uid = os.getuid()
+provider_user = pwd.getpwuid(uid).pw_name
 
 def ts():
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -179,6 +182,16 @@ def reject_path(path, must_exist=True):
         raise RuntimeError(f"hardlink_rejected:{path}")
     if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
         raise RuntimeError(f"writable_rejected:{path}")
+    try:
+        acl = subprocess.run(["/bin/ls", "-le", path], check=False, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
+        for line in acl.stdout.splitlines():
+            stripped = line.strip().lower()
+            if not re.match(r"^[0-9]+:", stripped):
+                continue
+            if ("write" in stripped or "append" in stripped or "add_file" in stripped) and f"user:{provider_user.lower()}" not in stripped:
+                raise RuntimeError(f"acl_write_rejected:{path}")
+    except FileNotFoundError:
+        pass
     return st
 
 def verify_root():
@@ -203,10 +216,39 @@ def read_marker():
     finally:
         os.close(fd)
     marker = json.loads(raw.decode("utf-8"))
+    validate_marker_strict(marker)
+    return marker
+
+def validate_marker_strict(marker):
     required = {"update_id", "target_version", "target_path", "backup_path", "size", "mode", "sha256", "marker_deadline"}
     if not required.issubset(marker.keys()):
         raise RuntimeError("marker_missing_required_fields")
-    return marker
+    if not re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", str(marker["update_id"])):
+        raise RuntimeError("marker_update_id_invalid")
+    if not re.match(r"^[0-9]+\.[0-9]+\.[0-9]+$", str(marker["target_version"])):
+        raise RuntimeError("marker_target_version_invalid")
+    for key in ("target_path", "backup_path"):
+        value = str(marker[key])
+        if not os.path.isabs(value) or value.endswith("/") or "/../" in value or "/./" in value:
+            raise RuntimeError(f"marker_{key}_invalid")
+    size = int(marker["size"])
+    mode = int(marker["mode"])
+    if size < 0 or size > 1024 * 1024 * 1024:
+        raise RuntimeError("marker_size_invalid")
+    if mode < 0 or mode > 0o7777:
+        raise RuntimeError("marker_mode_invalid")
+    if not re.match(r"^[0-9a-f]{64}$", str(marker["sha256"])):
+        raise RuntimeError("marker_sha256_invalid")
+    raw_deadline = str(marker["marker_deadline"])
+    if not raw_deadline.endswith("Z"):
+        raise RuntimeError("marker_deadline_invalid")
+    try:
+        deadline = datetime.datetime.strptime(raw_deadline, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=datetime.timezone.utc)
+    except ValueError:
+        raise RuntimeError("marker_deadline_invalid")
+    now = datetime.datetime.now(datetime.timezone.utc)
+    if deadline < now - datetime.timedelta(seconds=300) or deadline > now + datetime.timedelta(hours=24):
+        raise RuntimeError("marker_deadline_out_of_bounds")
 
 def current_binary_version(path):
     try:
@@ -271,6 +313,54 @@ def sha256(path):
         os.close(fd)
     return h.hexdigest()
 
+def binary_path_without_pending():
+    candidate = os.environ.get("MACPROVIDER_BINARY_PATH", "")
+    if candidate:
+        return candidate
+    return shutil.which("macprovider-cli") or ""
+
+def scan_without_pending():
+    binary = binary_path_without_pending()
+    if not binary:
+        return
+    binary_dir = os.path.dirname(binary)
+    for name in os.listdir(binary_dir):
+        path = os.path.join(binary_dir, name)
+        if name.startswith(".macprovider-cli.success-"):
+            try:
+                reject_path(path)
+                fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+                try:
+                    payload = json.loads(os.read(fd, 65536).decode("utf-8"))
+                finally:
+                    os.close(fd)
+                sentinel_version = str(payload.get("binary_version", ""))
+                current_version = current_binary_version(binary)
+                if sentinel_version and sentinel_version == current_version:
+                    update_id = str(payload.get("update_id", ""))
+                    backup = os.path.join(binary_dir, f".macprovider-cli.rollback-{update_id}")
+                    try:
+                        os.unlink(backup)
+                    except FileNotFoundError:
+                        pass
+                    try:
+                        os.unlink(lock_path)
+                    except FileNotFoundError:
+                        pass
+                    os.unlink(path)
+                    event("success", "post_start", None, "success_sentinel_cleanup_completed", {"update_id": update_id, "target_version": current_version})
+                else:
+                    os.unlink(path)
+                    event("failure", "post_start", "orphaned_success_sentinel", "success_sentinel_version_mismatch", {"update_id": str(payload.get("update_id", "")), "target_version": sentinel_version})
+            except Exception as exc:
+                log(f"success_sentinel_scan_error={exc}")
+        elif name.startswith(".macprovider-cli.rollback-"):
+            try:
+                os.unlink(path)
+                log(f"deleted_stale_backup={path}")
+            except FileNotFoundError:
+                pass
+
 def quarantine(reason, marker=None):
     stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     dest = os.path.join(root, f"pending-quarantined-{stamp}.json")
@@ -299,13 +389,26 @@ def lock_is_held_by_other_process():
 def restore(marker):
     backup = marker["backup_path"]
     target = marker["target_path"]
+    update_id = marker["update_id"]
+    expected_backup = os.path.join(os.path.dirname(target), f".macprovider-cli.rollback-{update_id}")
+    if backup != expected_backup:
+        raise RuntimeError("backup_path_derivation_mismatch")
+    trusted_dir = os.path.realpath(os.path.dirname(target))
+    for checked in (target, backup):
+        parent = os.path.realpath(os.path.dirname(checked))
+        if parent != trusted_dir:
+            raise RuntimeError("path_outside_trusted_binary_dir")
+        cursor = checked
+        while os.path.realpath(os.path.dirname(cursor)) == trusted_dir and cursor != trusted_dir:
+            reject_path(cursor, must_exist=os.path.exists(cursor))
+            break
     backup_st = reject_path(backup)
     reject_path(os.path.dirname(target))
     if not os.path.isabs(target) or target.endswith("/"):
         raise RuntimeError("target_path_invalid")
     if backup_st.st_size != int(marker["size"]):
         raise RuntimeError("backup_size_mismatch")
-    if sha256(backup) != str(marker["sha256"]).lower():
+    if sha256(backup) != str(marker["sha256"]):
         raise RuntimeError("backup_sha256_mismatch")
     os.chmod(backup, int(marker["mode"]))
     os.replace(backup, target)
@@ -323,16 +426,48 @@ def restore(marker):
         os.unlink(pending)
     except FileNotFoundError:
         pass
-    event("failure", "rollback", "orphaned_pending_marker", "restored_prior_binary", marker)
+    event("failure", "rollback", classify_post_start_failure(), "restored_prior_binary", marker)
+
+def classify_post_start_failure():
+    try:
+        printed = subprocess.run(["launchctl", "print", f"gui/{uid}/{label}"], check=False, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=5).stdout.lower()
+        if "last exit status" in printed and not re.search(r"last exit status\s*=\s*0", printed):
+            return "post_start_crash"
+        if "pid =" not in printed:
+            return "post_start_crash"
+    except Exception:
+        return "post_start_crash"
+    health_url = os.environ.get("MACPROVIDER_HEALTHCHECK_URL", "")
+    if health_url:
+        try:
+            probe = subprocess.run(["/usr/bin/curl", "-fsS", "--max-time", "2", health_url], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if probe.returncode != 0:
+                return "post_start_health_failed"
+        except Exception:
+            return "post_start_health_failed"
+    return "post_start_rejoin_timeout"
 
 try:
     if not os.path.exists(pending):
+        scan_without_pending()
         sys.exit(0)
     verify_root()
     reject_path(pending)
     if lock_is_held_by_other_process():
         sys.exit(0)
-    marker = read_marker()
+    try:
+        marker = read_marker()
+    except Exception as exc:
+        event("failure", "rollback", "orphaned_pending_marker", f"marker_malformed:{exc}", None)
+        try:
+            os.unlink(pending)
+        except FileNotFoundError:
+            pass
+        try:
+            os.unlink(lock_path)
+        except FileNotFoundError:
+            pass
+        sys.exit(0)
     if process_success_sentinel(marker):
         sys.exit(0)
     try:

--- a/ops/macprovider-watchdog/watchdog.sh
+++ b/ops/macprovider-watchdog/watchdog.sh
@@ -319,6 +319,29 @@ def binary_path_without_pending():
         return candidate
     return shutil.which("macprovider-cli") or ""
 
+def known_binary_dir():
+    configured = os.environ.get("MACPROVIDER_BINARY_DIR", "")
+    if configured:
+        return os.path.realpath(configured)
+    plist_path = os.path.expanduser("~/Library/LaunchAgents/live.streamvc.macprovider.plist")
+    try:
+        result = subprocess.run(
+            ["/usr/libexec/PlistBuddy", "-c", "Print ProgramArguments:0", plist_path],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return os.path.realpath(os.path.dirname(result.stdout.strip()))
+    except Exception:
+        pass
+    binary = binary_path_without_pending()
+    if binary:
+        return os.path.realpath(os.path.dirname(binary))
+    return ""
+
 def scan_without_pending():
     binary = binary_path_without_pending()
     if not binary:
@@ -366,9 +389,14 @@ def quarantine(reason, marker=None):
     dest = os.path.join(root, f"pending-quarantined-{stamp}.json")
     try:
         os.replace(pending, dest)
-        event("failure", "rollback", "rollback_backup_corrupt", reason, marker)
+        log(f"pending_marker_quarantined={dest} reason={reason}")
     except FileNotFoundError:
         pass
+
+def marker_deadline_expired(marker):
+    raw_deadline = str(marker["marker_deadline"])
+    deadline = datetime.datetime.strptime(raw_deadline, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=datetime.timezone.utc)
+    return datetime.datetime.now(datetime.timezone.utc) >= deadline
 
 def lock_is_held_by_other_process():
     os.makedirs(root, mode=0o700, exist_ok=True)
@@ -393,11 +421,14 @@ def restore(marker):
     expected_backup = os.path.join(os.path.dirname(target), f".macprovider-cli.rollback-{update_id}")
     if backup != expected_backup:
         raise RuntimeError("backup_path_derivation_mismatch")
-    trusted_dir = os.path.realpath(os.path.dirname(target))
+    trusted_dir = known_binary_dir()
+    if not trusted_dir:
+        raise RuntimeError("unsupported_install_topology:binary_dir_unknown")
+    target_parent = os.path.realpath(os.path.dirname(target))
+    backup_parent = os.path.realpath(os.path.dirname(backup))
+    if target_parent != trusted_dir or backup_parent != trusted_dir:
+        raise RuntimeError("unsupported_install_topology:path_outside_binary_dir")
     for checked in (target, backup):
-        parent = os.path.realpath(os.path.dirname(checked))
-        if parent != trusted_dir:
-            raise RuntimeError("path_outside_trusted_binary_dir")
         cursor = checked
         while os.path.realpath(os.path.dirname(cursor)) == trusted_dir and cursor != trusted_dir:
             reject_path(cursor, must_exist=os.path.exists(cursor))
@@ -426,9 +457,13 @@ def restore(marker):
         os.unlink(pending)
     except FileNotFoundError:
         pass
-    event("failure", "rollback", classify_post_start_failure(), "restored_prior_binary", marker)
+    try:
+        os.unlink(lock_path)
+    except FileNotFoundError:
+        pass
+    event("failure", "rollback", classify_post_start_failure(marker), "restored_prior_binary", marker)
 
-def classify_post_start_failure():
+def classify_post_start_failure(marker):
     try:
         printed = subprocess.run(["launchctl", "print", f"gui/{uid}/{label}"], check=False, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=5).stdout.lower()
         if "last exit status" in printed and not re.search(r"last exit status\s*=\s*0", printed):
@@ -445,6 +480,9 @@ def classify_post_start_failure():
                 return "post_start_health_failed"
         except Exception:
             return "post_start_health_failed"
+    current_version = current_binary_version(marker["target_path"])
+    if current_version and current_version != str(marker["target_version"]):
+        return "post_start_rejoin_timeout"
     return "post_start_rejoin_timeout"
 
 try:
@@ -458,11 +496,8 @@ try:
     try:
         marker = read_marker()
     except Exception as exc:
-        event("failure", "rollback", "orphaned_pending_marker", f"marker_malformed:{exc}", None)
-        try:
-            os.unlink(pending)
-        except FileNotFoundError:
-            pass
+        event("failure", "rollback", "orphaned_pending_marker", "marker_invalid", None)
+        quarantine(f"marker_invalid:{exc}", None)
         try:
             os.unlink(lock_path)
         except FileNotFoundError:
@@ -470,10 +505,14 @@ try:
         sys.exit(0)
     if process_success_sentinel(marker):
         sys.exit(0)
+    if not marker_deadline_expired(marker):
+        log("pending_marker_still_inside_post_start_window")
+        sys.exit(0)
     try:
         restore(marker)
     except Exception as exc:
-        event("failure", "rollback", "rollback_backup_corrupt", str(exc), marker)
+        failure_class = "unsupported_install_topology" if str(exc).startswith("unsupported_install_topology") else "rollback_backup_corrupt"
+        event("failure", "rollback", failure_class, str(exc), marker)
         quarantine(str(exc), marker)
 except Exception as exc:
     log(f"recovery_error={exc}")

--- a/ops/macprovider-watchdog/watchdog.sh
+++ b/ops/macprovider-watchdog/watchdog.sh
@@ -118,7 +118,235 @@ kick_provider() {
 
 now_epoch() { date -u +%s; }
 
+autoupdate_recovery_tick() {
+  AUTUPDATE_STATE_ROOT="${MACPROVIDER_AUTOUPDATE_STATE_ROOT:-$HOME/.local/share/macprovider/autoupdate}" \
+  MACPROVIDER_LABEL="$LABEL" \
+  LOG_PATH="$LOG_PATH" \
+  python3 <<'PY'
+import datetime
+import fcntl
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import time
+
+root = os.environ["AUTUPDATE_STATE_ROOT"]
+label = os.environ["MACPROVIDER_LABEL"]
+log_path = os.environ["LOG_PATH"]
+pending = os.path.join(root, "pending.json")
+lock_path = os.path.join(root, "update.lock")
+uid = os.getuid()
+
+def ts():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+def log(message):
+    with open(log_path, "a", encoding="utf-8") as fh:
+        fh.write(f"[{ts()}] autoupdate {message}\n")
+
+def event(outcome, phase, failure_class, reason, marker=None):
+    payload = {
+        "event": "provider_autoupdate_watchdog",
+        "source": "coordinator",
+        "outcome": outcome,
+        "phase": phase,
+        "reason": reason,
+        "timestamp": ts(),
+    }
+    if failure_class:
+        payload["failure_class"] = failure_class
+    if marker:
+        payload["update_id"] = marker.get("update_id", "")
+        payload["target_version"] = marker.get("target_version", "")
+    log(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+def reject_path(path, must_exist=True):
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        if must_exist:
+            raise
+        return None
+    if stat.S_ISLNK(st.st_mode):
+        raise RuntimeError(f"symlink_rejected:{path}")
+    if st.st_uid != uid:
+        raise RuntimeError(f"owner_rejected:{path}")
+    if st.st_nlink != 1 and not stat.S_ISDIR(st.st_mode):
+        raise RuntimeError(f"hardlink_rejected:{path}")
+    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise RuntimeError(f"writable_rejected:{path}")
+    return st
+
+def verify_root():
+    current = root
+    parts = []
+    while True:
+        parts.append(current)
+        parent = os.path.dirname(current)
+        if parent == current or current == os.path.expanduser("~"):
+            break
+        current = parent
+    for path in reversed(parts):
+        if os.path.exists(path):
+            st = reject_path(path)
+            if not stat.S_ISDIR(st.st_mode):
+                raise RuntimeError(f"not_directory:{path}")
+
+def read_marker():
+    fd = os.open(pending, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        raw = os.read(fd, 65536)
+    finally:
+        os.close(fd)
+    marker = json.loads(raw.decode("utf-8"))
+    required = {"update_id", "target_version", "target_path", "backup_path", "size", "mode", "sha256", "marker_deadline"}
+    if not required.issubset(marker.keys()):
+        raise RuntimeError("marker_missing_required_fields")
+    return marker
+
+def current_binary_version(path):
+    try:
+        result = subprocess.run([path, "--version"], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=5)
+    except Exception:
+        return ""
+    output = f"{result.stdout}\n{result.stderr}"
+    match = re.search(r"([0-9]+(?:\.[0-9]+){2}(?:[-+][0-9A-Za-z.-]+)?)", output)
+    return match.group(1) if match else ""
+
+def process_success_sentinel(marker):
+    binary_dir = os.path.dirname(marker["target_path"])
+    sentinel = os.path.join(binary_dir, f".macprovider-cli.success-{marker['update_id']}")
+    if not os.path.exists(sentinel):
+        return False
+    try:
+        reject_path(sentinel)
+        fd = os.open(sentinel, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            payload = json.loads(os.read(fd, 65536).decode("utf-8"))
+        finally:
+            os.close(fd)
+        sentinel_version = str(payload.get("binary_version", ""))
+        current_version = current_binary_version(marker["target_path"])
+        if sentinel_version and sentinel_version == current_version:
+            try:
+                os.unlink(pending)
+            except FileNotFoundError:
+                pass
+            try:
+                os.unlink(marker["backup_path"])
+            except FileNotFoundError:
+                pass
+            try:
+                os.unlink(lock_path)
+            except FileNotFoundError:
+                pass
+            os.unlink(sentinel)
+            event("success", "post_start", None, "success_sentinel_cleanup_completed", marker)
+            return True
+        event("failure", "post_start", "orphaned_success_sentinel", "success_sentinel_version_mismatch", marker)
+        os.unlink(sentinel)
+        return False
+    except Exception as exc:
+        event("failure", "post_start", "orphaned_success_sentinel", str(exc), marker)
+        try:
+            os.unlink(sentinel)
+        except FileNotFoundError:
+            pass
+        return False
+
+def sha256(path):
+    h = hashlib.sha256()
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                break
+            h.update(chunk)
+    finally:
+        os.close(fd)
+    return h.hexdigest()
+
+def quarantine(reason, marker=None):
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    dest = os.path.join(root, f"pending-quarantined-{stamp}.json")
+    try:
+        os.replace(pending, dest)
+        event("failure", "rollback", "rollback_backup_corrupt", reason, marker)
+    except FileNotFoundError:
+        pass
+
+def lock_is_held_by_other_process():
+    os.makedirs(root, mode=0o700, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0), 0o600)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        return False
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(fd)
+
+def restore(marker):
+    backup = marker["backup_path"]
+    target = marker["target_path"]
+    backup_st = reject_path(backup)
+    reject_path(os.path.dirname(target))
+    if not os.path.isabs(target) or target.endswith("/"):
+        raise RuntimeError("target_path_invalid")
+    if backup_st.st_size != int(marker["size"]):
+        raise RuntimeError("backup_size_mismatch")
+    if sha256(backup) != str(marker["sha256"]).lower():
+        raise RuntimeError("backup_sha256_mismatch")
+    os.chmod(backup, int(marker["mode"]))
+    os.replace(backup, target)
+    dir_fd = os.open(os.path.dirname(target), os.O_RDONLY)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+    try:
+        subprocess.run(["launchctl", "bootstrap", f"gui/{uid}", os.path.expanduser("~/Library/LaunchAgents/live.streamvc.macprovider.plist")], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(["launchctl", "kickstart", "-k", f"gui/{uid}/{label}"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception as exc:
+        log(f"launchctl_restore_warning={exc}")
+    try:
+        os.unlink(pending)
+    except FileNotFoundError:
+        pass
+    event("failure", "rollback", "orphaned_pending_marker", "restored_prior_binary", marker)
+
+try:
+    if not os.path.exists(pending):
+        sys.exit(0)
+    verify_root()
+    reject_path(pending)
+    if lock_is_held_by_other_process():
+        sys.exit(0)
+    marker = read_marker()
+    if process_success_sentinel(marker):
+        sys.exit(0)
+    try:
+        restore(marker)
+    except Exception as exc:
+        event("failure", "rollback", "rollback_backup_corrupt", str(exc), marker)
+        quarantine(str(exc), marker)
+except Exception as exc:
+    log(f"recovery_error={exc}")
+PY
+}
+
 main() {
+  autoupdate_recovery_tick
   pid="$(read_provider_id || true)"
   if [ -z "$pid" ]; then
     # Provider not yet installed / configured. Stay silent; if the

--- a/ops/macprovider-watchdog/watchdog.sh
+++ b/ops/macprovider-watchdog/watchdog.sh
@@ -514,8 +514,10 @@ try:
     try:
         restore(marker)
     except Exception as exc:
-        failure_class = "unsupported_install_topology" if str(exc).startswith("unsupported_install_topology") else "rollback_backup_corrupt"
-        event("failure", "rollback", failure_class, str(exc), marker)
+        unsupported_topology = str(exc).startswith("unsupported_install_topology")
+        failure_class = "other" if unsupported_topology else "rollback_backup_corrupt"
+        reason = "unsupported_install_topology" if unsupported_topology else str(exc)
+        event("failure", "rollback", failure_class, reason, marker)
         quarantine(str(exc), marker)
 except Exception as exc:
     log(f"recovery_error={exc}")

--- a/ops/macprovider-watchdog/watchdog.sh
+++ b/ops/macprovider-watchdog/watchdog.sh
@@ -247,7 +247,9 @@ def validate_marker_strict(marker):
     except ValueError:
         raise RuntimeError("marker_deadline_invalid")
     now = datetime.datetime.now(datetime.timezone.utc)
-    if deadline < now - datetime.timedelta(seconds=300) or deadline > now + datetime.timedelta(hours=24):
+    post_start_window = 60
+    future_tolerance = post_start_window + 30 * 60
+    if deadline < now - datetime.timedelta(seconds=300) or deadline > now + datetime.timedelta(seconds=future_tolerance):
         raise RuntimeError("marker_deadline_out_of_bounds")
 
 def current_binary_version(path):
@@ -259,21 +261,39 @@ def current_binary_version(path):
     match = re.search(r"([0-9]+(?:\.[0-9]+){2}(?:[-+][0-9A-Za-z.-]+)?)", output)
     return match.group(1) if match else ""
 
+def read_success_sentinel(path):
+    reject_path(path)
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        payload = json.loads(os.read(fd, 65536).decode("utf-8"))
+    finally:
+        os.close(fd)
+    update_id = str(payload.get("update_id", ""))
+    if not re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", update_id):
+        raise RuntimeError("sentinel_update_id_invalid")
+    return {
+        "update_id": update_id,
+        "binary_version": str(payload.get("binary_version", "")),
+    }
+
 def process_success_sentinel(marker):
     binary_dir = os.path.dirname(marker["target_path"])
-    sentinel = os.path.join(binary_dir, f".macprovider-cli.success-{marker['update_id']}")
-    if not os.path.exists(sentinel):
-        return False
-    try:
-        reject_path(sentinel)
-        fd = os.open(sentinel, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    for name in os.listdir(binary_dir):
+        if not name.startswith(".macprovider-cli.success-"):
+            continue
+        sentinel = os.path.join(binary_dir, name)
         try:
-            payload = json.loads(os.read(fd, 65536).decode("utf-8"))
-        finally:
-            os.close(fd)
-        sentinel_version = str(payload.get("binary_version", ""))
-        current_version = current_binary_version(marker["target_path"])
-        if sentinel_version and sentinel_version == current_version:
+            payload = read_success_sentinel(sentinel)
+            sentinel_version = payload["binary_version"]
+            current_version = current_binary_version(marker["target_path"])
+            if not sentinel_version or sentinel_version != current_version:
+                event("failure", "post_start", "orphaned_success_sentinel", "binary_version_mismatch", {"update_id": payload["update_id"], "target_version": sentinel_version})
+                os.unlink(sentinel)
+                continue
+            if payload["update_id"] != str(marker["update_id"]):
+                event("failure", "post_start", "orphaned_success_sentinel", "update_id_mismatch", {"update_id": payload["update_id"], "target_version": sentinel_version})
+                os.unlink(sentinel)
+                continue
             try:
                 os.unlink(pending)
             except FileNotFoundError:
@@ -289,16 +309,13 @@ def process_success_sentinel(marker):
             os.unlink(sentinel)
             event("success", "post_start", None, "success_sentinel_cleanup_completed", marker)
             return True
-        event("failure", "post_start", "orphaned_success_sentinel", "success_sentinel_version_mismatch", marker)
-        os.unlink(sentinel)
-        return False
-    except Exception as exc:
-        event("failure", "post_start", "orphaned_success_sentinel", str(exc), marker)
-        try:
-            os.unlink(sentinel)
-        except FileNotFoundError:
-            pass
-        return False
+        except Exception as exc:
+            event("failure", "post_start", "orphaned_success_sentinel", str(exc), marker)
+            try:
+                os.unlink(sentinel)
+            except FileNotFoundError:
+                pass
+    return False
 
 def sha256(path):
     h = hashlib.sha256()
@@ -351,30 +368,15 @@ def scan_without_pending():
         path = os.path.join(binary_dir, name)
         if name.startswith(".macprovider-cli.success-"):
             try:
-                reject_path(path)
-                fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
-                try:
-                    payload = json.loads(os.read(fd, 65536).decode("utf-8"))
-                finally:
-                    os.close(fd)
-                sentinel_version = str(payload.get("binary_version", ""))
+                payload = read_success_sentinel(path)
+                sentinel_version = payload["binary_version"]
                 current_version = current_binary_version(binary)
                 if sentinel_version and sentinel_version == current_version:
-                    update_id = str(payload.get("update_id", ""))
-                    backup = os.path.join(binary_dir, f".macprovider-cli.rollback-{update_id}")
-                    try:
-                        os.unlink(backup)
-                    except FileNotFoundError:
-                        pass
-                    try:
-                        os.unlink(lock_path)
-                    except FileNotFoundError:
-                        pass
                     os.unlink(path)
-                    event("success", "post_start", None, "success_sentinel_cleanup_completed", {"update_id": update_id, "target_version": current_version})
+                    event("failure", "post_start", "orphaned_success_sentinel", "no_matching_pending", {"update_id": payload["update_id"], "target_version": current_version})
                 else:
                     os.unlink(path)
-                    event("failure", "post_start", "orphaned_success_sentinel", "success_sentinel_version_mismatch", {"update_id": str(payload.get("update_id", "")), "target_version": sentinel_version})
+                    event("failure", "post_start", "orphaned_success_sentinel", "binary_version_mismatch", {"update_id": payload["update_id"], "target_version": sentinel_version})
             except Exception as exc:
                 log(f"success_sentinel_scan_error={exc}")
         elif name.startswith(".macprovider-cli.rollback-"):
@@ -475,7 +477,8 @@ def classify_post_start_failure(marker):
     health_url = os.environ.get("MACPROVIDER_HEALTHCHECK_URL", "")
     if health_url:
         try:
-            probe = subprocess.run(["/usr/bin/curl", "-fsS", "--max-time", "2", health_url], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            curl = os.environ.get("MACPROVIDER_CURL", "/usr/bin/curl")
+            probe = subprocess.run([curl, "-fsS", "--max-time", "2", health_url], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             if probe.returncode != 0:
                 return "post_start_health_failed"
         except Exception:

--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -24,6 +24,7 @@ public struct AppConfig: Equatable, Sendable {
     public var endpointURL: String?
     public var wsTunneledMode: Bool?
     public var autoUpdateEnabled: Bool?
+    public var autoupdateEnabled: Bool?
     public var configPath: String
     public var logLevel: LogLevel
     public var logFormat: LogFormat
@@ -69,6 +70,7 @@ public struct AppConfig: Equatable, Sendable {
             endpointURL: nil,
             wsTunneledMode: nil,
             autoUpdateEnabled: nil,
+            autoupdateEnabled: nil,
             configPath: configPath,
             logLevel: .info,
             logFormat: .json,
@@ -239,6 +241,9 @@ public enum ConfigLoader {
         try assign(&config.endpointURL, from: dict, key: "endpoint_url", expected: "string")
         try assign(&config.wsTunneledMode, from: dict, key: "ws_tunneled_mode", expected: "boolean")
         try assign(&config.autoUpdateEnabled, from: dict, key: "auto_update_enabled", expected: "boolean")
+        if let nested = dict["autoupdate"] as? [String: Any] {
+            try assign(&config.autoupdateEnabled, from: nested, key: "enabled", expected: "boolean")
+        }
         try assign(&config.logFormat, from: dict, key: "log_format", expected: "json or text")
         try assign(&config.logFile, from: dict, key: "log_file", expected: "string")
         try assign(&config.maxContextOverride, from: dict, key: "max_context_override", expected: "integer")
@@ -271,6 +276,7 @@ public enum ConfigLoader {
         try assign(&config.endpointURL, from: environment, env: "MACPROVIDER_ENDPOINT_URL", expected: "string")
         try assign(&config.wsTunneledMode, from: environment, env: "MACPROVIDER_WS_TUNNELED_MODE", expected: "boolean")
         try assign(&config.autoUpdateEnabled, from: environment, env: "MACPROVIDER_AUTO_UPDATE_ENABLED", expected: "boolean")
+        try assign(&config.autoupdateEnabled, from: environment, env: "MACPROVIDER_AUTOUPDATE", expected: "boolean")
         try assign(&config.logLevel, from: environment, env: "MACPROVIDER_LOG_LEVEL", expected: "valid log level")
         try assign(&config.logFormat, from: environment, env: "MACPROVIDER_LOG_FORMAT", expected: "json or text")
         try assign(&config.logFile, from: environment, env: "MACPROVIDER_LOG_FILE", expected: "string")

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
@@ -51,6 +51,7 @@ enum AutoUpdateFailureClass: String, CaseIterable, Sendable {
     case selfTestFailed = "self_test_failed"
     case drainTimeout = "drain_timeout"
     case trustStateLost = "trust_state_lost"
+    case signedPolicyPersistFailed = "signed_policy_persist_failed"
     case postStartCrash = "post_start_crash"
     case postStartHealthFailed = "post_start_health_failed"
     case postStartRejoinTimeout = "post_start_rejoin_timeout"

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
@@ -256,6 +256,10 @@ actor AutoUpdateEventStore {
         event.emitLocal()
     }
 
+    func clear() {
+        last = nil
+    }
+
     func lastWireObject() -> [String: Any]? {
         last?.wireObject()
     }

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
@@ -1,0 +1,242 @@
+import CryptoKit
+import Foundation
+
+enum AutoUpdateSource: String, CaseIterable, Sendable {
+    case coordinator
+    case githubPoll = "github_poll"
+    case manual
+}
+
+enum AutoUpdateOutcome: String, CaseIterable, Sendable {
+    case success
+    case failure
+    case skipped
+    case noop
+    case inProgress = "in_progress"
+}
+
+enum AutoUpdatePhase: String, CaseIterable, Sendable {
+    case detection
+    case eligibility
+    case cooldown
+    case freeSpace = "free_space"
+    case download
+    case signature
+    case checksum
+    case archive
+    case selfTest = "self_test"
+    case drain
+    case backup
+    case swap
+    case restart
+    case postStart = "post_start"
+    case rollback
+}
+
+enum AutoUpdateFailureClass: String, CaseIterable, Sendable {
+    case rollbackObserverUnavailable = "rollback_observer_unavailable"
+    case targetReleaseNotFound = "target_release_not_found"
+    case releaseAssetMissing = "release_asset_missing"
+    case recommendedVersionInvalid = "recommended_version_invalid"
+    case versionTooLong = "version_too_long"
+    case versionComponentTooLong = "version_component_too_long"
+    case autoupdateAlreadyPending = "autoupdate_already_pending"
+    case orphanedPendingMarker = "orphaned_pending_marker"
+    case orphanedSuccessSentinel = "orphaned_success_sentinel"
+    case rollbackBackupCorrupt = "rollback_backup_corrupt"
+    case targetRevokedOrBelowMinimum = "target_revoked_or_below_minimum"
+    case signatureInvalid = "signature_invalid"
+    case checksumMismatch = "checksum_mismatch"
+    case selfTestFailed = "self_test_failed"
+    case drainTimeout = "drain_timeout"
+    case trustStateLost = "trust_state_lost"
+    case postStartCrash = "post_start_crash"
+    case postStartHealthFailed = "post_start_health_failed"
+    case postStartRejoinTimeout = "post_start_rejoin_timeout"
+    case insufficientDiskSpace = "insufficient_disk_space"
+    case eventPayloadTooLarge = "event_payload_too_large"
+    case other
+}
+
+struct AutoUpdateEvent: Sendable {
+    static let maxWireBytes = 4096
+
+    let updateID: String
+    let currentVersion: String
+    let targetVersion: String
+    let source: AutoUpdateSource
+    let phase: AutoUpdatePhase
+    let outcome: AutoUpdateOutcome
+    let reason: String
+    let attempt: Int
+    let timestamp: Date
+    let failureClass: AutoUpdateFailureClass?
+    let inflightRequests: Int?
+    let recommendedBinaryVersionSHA256: String?
+    let extraMetadata: [String: String]
+    let attemptHistory: [String]
+    let releaseURL: String?
+
+    init(
+        updateID: String,
+        currentVersion: String,
+        targetVersion: String,
+        source: AutoUpdateSource = .coordinator,
+        phase: AutoUpdatePhase,
+        outcome: AutoUpdateOutcome,
+        reason: String,
+        attempt: Int,
+        timestamp: Date = Date(),
+        failureClass: AutoUpdateFailureClass? = nil,
+        inflightRequests: Int? = nil,
+        recommendedBinaryVersionSHA256: String? = nil,
+        extraMetadata: [String: String] = [:],
+        attemptHistory: [String] = [],
+        releaseURL: String? = nil
+    ) {
+        self.updateID = updateID
+        self.currentVersion = currentVersion
+        self.targetVersion = targetVersion
+        self.source = source
+        self.phase = phase
+        self.outcome = outcome
+        self.reason = AutoUpdateEvent.redact(reason)
+        self.attempt = attempt
+        self.timestamp = timestamp
+        self.failureClass = failureClass
+        self.inflightRequests = inflightRequests
+        self.recommendedBinaryVersionSHA256 = recommendedBinaryVersionSHA256
+        self.extraMetadata = extraMetadata.mapValues(Self.redact)
+        self.attemptHistory = attemptHistory.map(Self.redact)
+        self.releaseURL = releaseURL.flatMap(Self.redactedURL)
+    }
+
+    func wireObject() -> [String: Any] {
+        let minimalReason = reason.isEmpty ? "\(phase.rawValue)_\(outcome.rawValue)" : reason
+        var object = baseObject(reason: minimalReason)
+        object["extra_metadata"] = extraMetadata
+        object["attempt_history"] = attemptHistory
+        if let releaseURL {
+            object["release_url"] = releaseURL
+        }
+        if Self.encodedByteCount(object) <= Self.maxWireBytes {
+            return object
+        }
+        object.removeValue(forKey: "extra_metadata")
+        if Self.encodedByteCount(object) <= Self.maxWireBytes {
+            return object
+        }
+        object.removeValue(forKey: "attempt_history")
+        if Self.encodedByteCount(object) <= Self.maxWireBytes {
+            return object
+        }
+        object.removeValue(forKey: "release_url")
+        if Self.encodedByteCount(object) <= Self.maxWireBytes {
+            return object
+        }
+        object["reason"] = "\(phase.rawValue)_\(outcome.rawValue)"
+        if Self.encodedByteCount(object) <= Self.maxWireBytes {
+            return object
+        }
+        return [
+            "event": "provider_autoupdate",
+            "update_id": updateID,
+            "current_version": currentVersion,
+            "target_version": targetVersion,
+            "source": source.rawValue,
+            "phase": AutoUpdatePhase.eligibility.rawValue,
+            "outcome": AutoUpdateOutcome.failure.rawValue,
+            "reason": "event_payload_too_large",
+            "attempt": attempt,
+            "timestamp": Self.format(timestamp),
+            "failure_class": AutoUpdateFailureClass.eventPayloadTooLarge.rawValue,
+        ]
+    }
+
+    func emitLocal() {
+        var object = wireObject()
+        object["event"] = "provider_autoupdate"
+        if var data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) {
+            data.append(0x0A)
+            FileHandle.standardError.write(data)
+        }
+    }
+
+    static func sha256Hex(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func baseObject(reason: String) -> [String: Any] {
+        var object: [String: Any] = [
+            "event": "provider_autoupdate",
+            "update_id": updateID,
+            "current_version": currentVersion,
+            "target_version": targetVersion,
+            "source": source.rawValue,
+            "phase": phase.rawValue,
+            "outcome": outcome.rawValue,
+            "reason": reason,
+            "attempt": attempt,
+            "timestamp": Self.format(timestamp),
+        ]
+        if let failureClass {
+            object["failure_class"] = failureClass.rawValue
+        }
+        if let inflightRequests {
+            object["inflight_requests"] = inflightRequests
+        }
+        if let recommendedBinaryVersionSHA256 {
+            object["recommended_binary_version_sha256"] = recommendedBinaryVersionSHA256
+        }
+        return object
+    }
+
+    private static func encodedByteCount(_ object: [String: Any]) -> Int {
+        (try? JSONSerialization.data(withJSONObject: object, options: [])).map(\.count) ?? Int.max
+    }
+
+    private static func format(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: date)
+    }
+
+    private static func redactedURL(_ raw: String) -> String? {
+        guard var components = URLComponents(string: raw) else { return nil }
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string
+    }
+
+    private static func redact(_ value: String) -> String {
+        var redacted = value
+        let patterns = [
+            #"(?i)authorization:\s*bearer\s+[A-Za-z0-9._~+/=-]+"#,
+            #"(?i)(token|password|secret|credential)=([^&\s]+)"#,
+            #"/Users/[^/\s]+"#,
+            #"file://[^ \n\t]+"#,
+            #"-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+PRIVATE KEY-----"#,
+        ]
+        for pattern in patterns {
+            redacted = redacted.replacingOccurrences(of: pattern, with: "[REDACTED]", options: .regularExpression)
+        }
+        return redacted
+    }
+}
+
+actor AutoUpdateEventStore {
+    static let shared = AutoUpdateEventStore()
+    private var last: AutoUpdateEvent?
+
+    func record(_ event: AutoUpdateEvent) {
+        last = event
+        event.emitLocal()
+    }
+
+    func lastWireObject() -> [String: Any]? {
+        last?.wireObject()
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
@@ -35,6 +35,7 @@ enum AutoUpdatePhase: String, CaseIterable, Sendable {
 
 enum AutoUpdateFailureClass: String, CaseIterable, Sendable {
     case rollbackObserverUnavailable = "rollback_observer_unavailable"
+    case unsupportedInstallTopology = "unsupported_install_topology"
     case targetReleaseNotFound = "target_release_not_found"
     case releaseAssetMissing = "release_asset_missing"
     case recommendedVersionInvalid = "recommended_version_invalid"
@@ -213,11 +214,30 @@ struct AutoUpdateEvent: Sendable {
 
     private static func redact(_ value: String) -> String {
         var redacted = value
+        if let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) {
+            let range = NSRange(redacted.startIndex ..< redacted.endIndex, in: redacted)
+            for match in detector.matches(in: redacted, options: [], range: range).reversed() {
+                guard let url = match.url, var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { continue }
+                components.path = ""
+                components.query = nil
+                components.fragment = nil
+                components.user = nil
+                components.password = nil
+                if let hostOnly = components.string,
+                   let swiftRange = Range(match.range, in: redacted)
+                {
+                    redacted.replaceSubrange(swiftRange, with: hostOnly)
+                }
+            }
+        }
         let patterns = [
             #"(?i)authorization:\s*bearer\s+[A-Za-z0-9._~+/=-]+"#,
             #"(?i)(token|password|secret|credential)=([^&\s]+)"#,
-            #"/Users/[^/\s]+"#,
+            #"/Users/[^ \n\t:]+"#,
+            #"/private/(tmp|var)/[^ \n\t:]+"#,
+            #"/tmp/[^ \n\t:]+"#,
             #"file://[^ \n\t]+"#,
+            #"\b[0-9a-fA-F]{17,}\b"#,
             #"-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+PRIVATE KEY-----"#,
         ]
         for pattern in patterns {

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
@@ -135,15 +135,23 @@ struct AutoUpdateEvent: Sendable {
         if Self.encodedByteCount(object) <= Self.maxWireBytes {
             return object
         }
+        object.removeValue(forKey: "inflight_requests")
+        if Self.encodedByteCount(object) <= Self.maxWireBytes {
+            return object
+        }
+        object.removeValue(forKey: "recommended_binary_version_sha256")
+        if Self.encodedByteCount(object) <= Self.maxWireBytes {
+            return object
+        }
         object["reason"] = "\(phase.rawValue)_\(outcome.rawValue)"
         if Self.encodedByteCount(object) <= Self.maxWireBytes {
             return object
         }
         return [
             "event": "provider_autoupdate",
-            "update_id": updateID,
-            "current_version": currentVersion,
-            "target_version": targetVersion,
+            "update_id": Self.boundedRequiredField(updateID),
+            "current_version": Self.boundedRequiredField(currentVersion),
+            "target_version": Self.boundedRequiredField(targetVersion),
             "source": source.rawValue,
             "phase": AutoUpdatePhase.eligibility.rawValue,
             "outcome": AutoUpdateOutcome.failure.rawValue,
@@ -194,6 +202,13 @@ struct AutoUpdateEvent: Sendable {
 
     private static func encodedByteCount(_ object: [String: Any]) -> Int {
         (try? JSONSerialization.data(withJSONObject: object, options: [])).map(\.count) ?? Int.max
+    }
+
+    private static func boundedRequiredField(_ value: String) -> String {
+        if value.utf8.count <= 128 {
+            return value
+        }
+        return "sha256:\(sha256Hex(value))"
     }
 
     private static func format(_ date: Date) -> String {

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift
@@ -35,7 +35,6 @@ enum AutoUpdatePhase: String, CaseIterable, Sendable {
 
 enum AutoUpdateFailureClass: String, CaseIterable, Sendable {
     case rollbackObserverUnavailable = "rollback_observer_unavailable"
-    case unsupportedInstallTopology = "unsupported_install_topology"
     case targetReleaseNotFound = "target_release_not_found"
     case releaseAssetMissing = "release_asset_missing"
     case recommendedVersionInvalid = "recommended_version_invalid"
@@ -51,7 +50,6 @@ enum AutoUpdateFailureClass: String, CaseIterable, Sendable {
     case selfTestFailed = "self_test_failed"
     case drainTimeout = "drain_timeout"
     case trustStateLost = "trust_state_lost"
-    case signedPolicyPersistFailed = "signed_policy_persist_failed"
     case postStartCrash = "post_start_crash"
     case postStartHealthFailed = "post_start_health_failed"
     case postStartRejoinTimeout = "post_start_rejoin_timeout"

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
@@ -410,9 +410,9 @@ struct AutoUpdateMarkerStore: Sendable {
                 targetVersion: marker?.targetVersion ?? "<unknown>",
                 phase: .swap,
                 outcome: .failure,
-                reason: String(describing: error).prefix(128).description,
+                reason: "signed_policy_persist_failed",
                 attempt: 1,
-                failureClass: .signedPolicyPersistFailed
+                failureClass: .other
             ))
             SessionAutoupdateGate.shared.disable(reason: "signed_policy_persist_failed")
             throw AutoUpdateSignedPolicyPersistError(underlying: String(describing: error).prefix(128).description)

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
@@ -1,0 +1,432 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+struct AutoUpdatePendingMarker: Codable, Equatable {
+    let updateID: String
+    let targetVersion: String
+    let targetPath: String
+    let backupPath: String
+    let size: Int
+    let mode: Int
+    let sha256: String
+    let markerDeadline: String
+
+    enum CodingKeys: String, CodingKey {
+        case updateID = "update_id"
+        case targetVersion = "target_version"
+        case targetPath = "target_path"
+        case backupPath = "backup_path"
+        case size
+        case mode
+        case sha256
+        case markerDeadline = "marker_deadline"
+    }
+}
+
+enum AutoUpdateMarkerError: Error, CustomStringConvertible, Equatable {
+    case trustedRootInvalid(String)
+    case lockContended
+    case openFailed(String, Int32)
+    case writeFailed(String, Int32)
+    case invalidMarker
+    case backupCorrupt
+
+    var description: String {
+        switch self {
+        case let .trustedRootInvalid(reason): return "trusted autoupdate root invalid: \(reason)"
+        case .lockContended: return "autoupdate lock is held by another process"
+        case let .openFailed(path, errnoValue): return "open failed for \(path): errno \(errnoValue)"
+        case let .writeFailed(path, errnoValue): return "write failed for \(path): errno \(errnoValue)"
+        case .invalidMarker: return "pending marker is invalid"
+        case .backupCorrupt: return "rollback backup is missing or hash-mismatched"
+        }
+    }
+}
+
+final class AutoUpdateLock: @unchecked Sendable {
+    let fd: Int32
+    let path: URL
+
+    init(fd: Int32, path: URL) {
+        self.fd = fd
+        self.path = path
+    }
+
+    deinit {
+        flock(fd, LOCK_UN)
+        close(fd)
+    }
+}
+
+struct AutoUpdateMarkerStore: Sendable {
+    let homeDirectory: URL
+    let fileManager: FileManager
+
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) {
+        self.homeDirectory = homeDirectory
+        self.fileManager = fileManager
+    }
+
+    var root: URL {
+        homeDirectory.appendingPathComponent(".local/share/macprovider/autoupdate", isDirectory: true)
+    }
+
+    var pendingURL: URL {
+        root.appendingPathComponent("pending.json")
+    }
+
+    var lockURL: URL {
+        root.appendingPathComponent("update.lock")
+    }
+
+    var cooldownURL: URL {
+        root.appendingPathComponent("cooldowns.json")
+    }
+
+    var policyURL: URL {
+        root.appendingPathComponent("signed-policy.json")
+    }
+
+    func ensureTrustedRoot() throws {
+        try ensureTrustedDirectory(homeDirectory.appendingPathComponent(".local", isDirectory: true))
+        try ensureTrustedDirectory(homeDirectory.appendingPathComponent(".local/share", isDirectory: true))
+        try ensureTrustedDirectory(homeDirectory.appendingPathComponent(".local/share/macprovider", isDirectory: true))
+        try ensureTrustedDirectory(root)
+        try rejectUnexpectedMountCrossing()
+    }
+
+    func acquireLock() throws -> AutoUpdateLock {
+        try ensureTrustedRoot()
+        let fd = open(lockURL.path, O_CREAT | O_RDWR | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else {
+            throw AutoUpdateMarkerError.openFailed(lockURL.path, errno)
+        }
+        if flock(fd, LOCK_EX | LOCK_NB) != 0 {
+            let errnoValue = errno
+            close(fd)
+            if errnoValue == EWOULDBLOCK {
+                throw AutoUpdateMarkerError.lockContended
+            }
+            throw AutoUpdateMarkerError.openFailed(lockURL.path, errnoValue)
+        }
+        fchmod(fd, S_IRUSR | S_IWUSR)
+        return AutoUpdateLock(fd: fd, path: lockURL)
+    }
+
+    func rollbackBackupPath(binaryURL: URL, updateID: String) -> URL {
+        binaryURL.deletingLastPathComponent()
+            .appendingPathComponent(".macprovider-cli.rollback-\(updateID)")
+    }
+
+    func successSentinelPath(binaryURL: URL, updateID: String) -> URL {
+        binaryURL.deletingLastPathComponent()
+            .appendingPathComponent(".macprovider-cli.success-\(updateID)")
+    }
+
+    func preserveRollbackBackup(binaryURL: URL, updateID: String) throws -> AutoUpdatePendingMarker {
+        let attrs = try fileManager.attributesOfItem(atPath: binaryURL.path)
+        let mode = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? 0o755
+        let size = (attrs[.size] as? NSNumber)?.intValue ?? 0
+        let sha = try Self.sha256(file: binaryURL)
+        let backup = rollbackBackupPath(binaryURL: binaryURL, updateID: updateID)
+        try atomicCopyNoFollow(from: binaryURL, to: backup, mode: mode)
+        let deadline = ISO8601DateFormatter.autoupdate.string(from: Date().addingTimeInterval(60 + 300))
+        return AutoUpdatePendingMarker(
+            updateID: updateID,
+            targetVersion: "",
+            targetPath: binaryURL.path,
+            backupPath: backup.path,
+            size: size,
+            mode: mode,
+            sha256: sha,
+            markerDeadline: deadline
+        )
+    }
+
+    func writePending(_ marker: AutoUpdatePendingMarker) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(marker)
+        try atomicWrite(data: data, finalURL: pendingURL, mode: S_IRUSR | S_IWUSR)
+    }
+
+    func readPending() throws -> AutoUpdatePendingMarker? {
+        guard fileManager.fileExists(atPath: pendingURL.path) else { return nil }
+        try rejectSymlinkOrHardLink(pendingURL)
+        let data = try Data(contentsOf: pendingURL)
+        return try JSONDecoder().decode(AutoUpdatePendingMarker.self, from: data)
+    }
+
+    func clearPending() {
+        try? fileManager.removeItem(at: pendingURL)
+    }
+
+    func writeSuccessSentinel(binaryURL: URL, updateID: String, targetVersion: String) throws {
+        let payload: [String: String] = [
+            "update_id": updateID,
+            "binary_version": targetVersion,
+            "success_at": ISO8601DateFormatter.autoupdate.string(from: Date()),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        try atomicWrite(data: data, finalURL: successSentinelPath(binaryURL: binaryURL, updateID: updateID), mode: S_IRUSR | S_IWUSR)
+    }
+
+    func validateBackup(_ marker: AutoUpdatePendingMarker) throws {
+        let backupURL = URL(fileURLWithPath: marker.backupPath)
+        try rejectSymlinkOrHardLink(backupURL)
+        let attrs = try fileManager.attributesOfItem(atPath: backupURL.path)
+        guard (attrs[.size] as? NSNumber)?.intValue == marker.size,
+              try Self.sha256(file: backupURL).lowercased() == marker.sha256.lowercased()
+        else {
+            throw AutoUpdateMarkerError.backupCorrupt
+        }
+    }
+
+    func restoreBackup(_ marker: AutoUpdatePendingMarker) throws {
+        try validateBackup(marker)
+        let backupURL = URL(fileURLWithPath: marker.backupPath)
+        let targetURL = URL(fileURLWithPath: marker.targetPath)
+        let staged = targetURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(targetURL.lastPathComponent).rollback-\(UUID().uuidString)")
+        try atomicCopyNoFollow(from: backupURL, to: staged, mode: marker.mode)
+        if rename(staged.path, targetURL.path) != 0 {
+            let errnoValue = errno
+            try? fileManager.removeItem(at: staged)
+            throw AutoUpdateMarkerError.writeFailed(targetURL.path, errnoValue)
+        }
+        fsyncDirectory(targetURL.deletingLastPathComponent())
+    }
+
+    func cooldown(target: String, failureClass: AutoUpdateFailureClass) -> (attempt: Int, until: Date)? {
+        guard let object = readCooldowns()["\(target)|\(failureClass.rawValue)"] as? [String: Any],
+              let attempt = object["attempt"] as? Int,
+              let untilRaw = object["until"] as? String,
+              let until = ISO8601DateFormatter.autoupdate.date(from: untilRaw),
+              until > Date()
+        else {
+            return nil
+        }
+        return (attempt, until)
+    }
+
+    func activeCooldown(target: String) -> (failureClass: AutoUpdateFailureClass, attempt: Int, until: Date)? {
+        for failureClass in AutoUpdateFailureClass.allCases {
+            if let cooldown = cooldown(target: target, failureClass: failureClass) {
+                return (failureClass, cooldown.attempt, cooldown.until)
+            }
+        }
+        return nil
+    }
+
+    func recordCooldown(target: String, failureClass: AutoUpdateFailureClass) {
+        var cooldowns = readCooldowns()
+        let key = "\(target)|\(failureClass.rawValue)"
+        let existing = cooldowns[key] as? [String: Any]
+        let attempt = (existing?["attempt"] as? Int ?? 0) + 1
+        let seconds = min(300 * (1 << min(max(attempt - 1, 0), 8)), 3600)
+        cooldowns[key] = [
+            "attempt": attempt,
+            "until": ISO8601DateFormatter.autoupdate.string(from: Date().addingTimeInterval(TimeInterval(seconds))),
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: cooldowns, options: [.sortedKeys]) {
+            try? atomicWrite(data: data, finalURL: cooldownURL, mode: S_IRUSR | S_IWUSR)
+        }
+    }
+
+    func completeSuccessfulUpdate(_ marker: AutoUpdatePendingMarker) throws {
+        let binaryURL = URL(fileURLWithPath: marker.targetPath)
+        try writeSuccessSentinel(
+            binaryURL: binaryURL,
+            updateID: marker.updateID,
+            targetVersion: marker.targetVersion
+        )
+        clearPending()
+        try? fileManager.removeItem(atPath: marker.backupPath)
+        try? fileManager.removeItem(at: lockURL)
+        try? fileManager.removeItem(at: successSentinelPath(binaryURL: binaryURL, updateID: marker.updateID))
+    }
+
+    func updateSignedPolicy(minimum: String?, revoked: [String]) {
+        var policy = (try? readPolicy()) ?? SignedPolicy()
+        if let minimum, !minimum.isEmpty,
+           policy.persistedMinimum.isEmpty || SelfUpdate.compareSemver(policy.persistedMinimum, minimum) == .orderedAscending {
+            policy.persistedMinimum = minimum
+        }
+        policy.persistedRevoked.formUnion(revoked)
+        if let data = try? JSONEncoder().encode(policy) {
+            try? atomicWrite(data: data, finalURL: policyURL, mode: S_IRUSR | S_IWUSR)
+        }
+    }
+
+    func effectivePolicy(localMinimum: String? = nil, localRevoked: [String] = []) -> (minimum: String?, revoked: Set<String>) {
+        let policy = (try? readPolicy()) ?? SignedPolicy()
+        let minimum = [localMinimum, policy.persistedMinimum].compactMap { value in
+            value?.isEmpty == false ? value : nil
+        }.max { SelfUpdate.compareSemver($0, $1) == .orderedAscending }
+        return (minimum, policy.persistedRevoked.union(localRevoked))
+    }
+
+    private func ensureTrustedDirectory(_ url: URL) throws {
+        var st = stat()
+        if lstat(url.path, &st) != 0 {
+            try fileManager.createDirectory(at: url, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+            if lstat(url.path, &st) != 0 {
+                throw AutoUpdateMarkerError.trustedRootInvalid("lstat_failed")
+            }
+        }
+        guard (st.st_mode & S_IFMT) == S_IFDIR else {
+            throw AutoUpdateMarkerError.trustedRootInvalid("not_directory")
+        }
+        guard st.st_uid == getuid() else {
+            throw AutoUpdateMarkerError.trustedRootInvalid("wrong_owner")
+        }
+        if (st.st_mode & (S_IWGRP | S_IWOTH)) != 0 {
+            chmod(url.path, S_IRWXU)
+        }
+        let attrs = try fileManager.attributesOfItem(atPath: url.path)
+        if (attrs[.posixPermissions] as? NSNumber)?.intValue != 0o700 {
+            try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+        }
+    }
+
+    private func rejectUnexpectedMountCrossing() throws {
+        var home = stat()
+        var rootStat = stat()
+        guard lstat(homeDirectory.path, &home) == 0, lstat(root.path, &rootStat) == 0 else {
+            throw AutoUpdateMarkerError.trustedRootInvalid("stat_failed")
+        }
+        guard home.st_dev == rootStat.st_dev else {
+            throw AutoUpdateMarkerError.trustedRootInvalid("mount_crossing")
+        }
+    }
+
+    private func rejectSymlinkOrHardLink(_ url: URL) throws {
+        var st = stat()
+        guard lstat(url.path, &st) == 0 else {
+            throw AutoUpdateMarkerError.openFailed(url.path, errno)
+        }
+        guard (st.st_mode & S_IFMT) != S_IFLNK, st.st_nlink == 1 else {
+            throw AutoUpdateMarkerError.trustedRootInvalid("symlink_or_hardlink")
+        }
+    }
+
+    private func atomicCopyNoFollow(from source: URL, to finalURL: URL, mode: Int) throws {
+        let input = open(source.path, O_RDONLY | O_NOFOLLOW)
+        guard input >= 0 else { throw AutoUpdateMarkerError.openFailed(source.path, errno) }
+        defer { close(input) }
+        let tempURL = finalURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(finalURL.lastPathComponent).tmp-\(UUID().uuidString)")
+        let output = open(tempURL.path, O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW, mode_t(mode))
+        guard output >= 0 else { throw AutoUpdateMarkerError.openFailed(tempURL.path, errno) }
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let n = read(input, &buffer, buffer.count)
+            if n < 0 {
+                let errnoValue = errno
+                close(output)
+                try? fileManager.removeItem(at: tempURL)
+                throw AutoUpdateMarkerError.writeFailed(tempURL.path, errnoValue)
+            }
+            if n == 0 { break }
+            try buffer.withUnsafeBytes { raw in
+                var written = 0
+                while written < n {
+                    let m = write(output, raw.baseAddress!.advanced(by: written), n - written)
+                    if m <= 0 {
+                        let errnoValue = errno
+                        close(output)
+                        try? fileManager.removeItem(at: tempURL)
+                        throw AutoUpdateMarkerError.writeFailed(tempURL.path, errnoValue)
+                    }
+                    written += m
+                }
+            }
+        }
+        fchmod(output, mode_t(mode))
+        fsync(output)
+        close(output)
+        if rename(tempURL.path, finalURL.path) != 0 {
+            let errnoValue = errno
+            try? fileManager.removeItem(at: tempURL)
+            throw AutoUpdateMarkerError.writeFailed(finalURL.path, errnoValue)
+        }
+        fsyncDirectory(finalURL.deletingLastPathComponent())
+    }
+
+    private func atomicWrite(data: Data, finalURL: URL, mode: mode_t) throws {
+        let tempURL = finalURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(finalURL.lastPathComponent).tmp-\(UUID().uuidString)")
+        let fd = open(tempURL.path, O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW, mode)
+        guard fd >= 0 else { throw AutoUpdateMarkerError.openFailed(tempURL.path, errno) }
+        try data.withUnsafeBytes { raw in
+            var offset = 0
+            while offset < raw.count {
+                let wrote = write(fd, raw.baseAddress!.advanced(by: offset), raw.count - offset)
+                if wrote <= 0 {
+                    let errnoValue = errno
+                    close(fd)
+                    try? fileManager.removeItem(at: tempURL)
+                    throw AutoUpdateMarkerError.writeFailed(tempURL.path, errnoValue)
+                }
+                offset += wrote
+            }
+        }
+        fchmod(fd, mode)
+        fsync(fd)
+        close(fd)
+        if rename(tempURL.path, finalURL.path) != 0 {
+            let errnoValue = errno
+            try? fileManager.removeItem(at: tempURL)
+            throw AutoUpdateMarkerError.writeFailed(finalURL.path, errnoValue)
+        }
+        fsyncDirectory(finalURL.deletingLastPathComponent())
+    }
+
+    private func fsyncDirectory(_ url: URL) {
+        let fd = open(url.path, O_RDONLY)
+        if fd >= 0 {
+            fsync(fd)
+            close(fd)
+        }
+    }
+
+    private func readCooldowns() -> [String: Any] {
+        guard let data = try? Data(contentsOf: cooldownURL),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [:] }
+        return object
+    }
+
+    private func readPolicy() throws -> SignedPolicy {
+        let data = try Data(contentsOf: policyURL)
+        return try JSONDecoder().decode(SignedPolicy.self, from: data)
+    }
+
+    static func sha256(file: URL) throws -> String {
+        let data = try Data(contentsOf: file)
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+private struct SignedPolicy: Codable {
+    var persistedMinimum: String = ""
+    var persistedRevoked: Set<String> = []
+
+    enum CodingKeys: String, CodingKey {
+        case persistedMinimum = "persisted_signed_policy_minimum"
+        case persistedRevoked = "persisted_signed_policy_revoked"
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let autoupdate: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+}

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
@@ -44,6 +44,39 @@ enum AutoUpdateMarkerError: Error, CustomStringConvertible, Equatable {
     }
 }
 
+struct AutoUpdateSignedPolicyPersistError: Error, CustomStringConvertible {
+    let underlying: String
+
+    var description: String {
+        "signed policy persist failed: \(underlying)"
+    }
+}
+
+final class SessionAutoupdateGate: @unchecked Sendable {
+    static let shared = SessionAutoupdateGate()
+
+    private let lock = NSLock()
+    private var disabledReason: String?
+
+    var isDisabled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return disabledReason != nil
+    }
+
+    func disable(reason: String) {
+        lock.lock()
+        disabledReason = reason
+        lock.unlock()
+    }
+
+    func resetForTest() {
+        lock.lock()
+        disabledReason = nil
+        lock.unlock()
+    }
+}
+
 enum AutoUpdateOrphanRecoveryOutcome: Equatable {
     case restored(AutoUpdatePendingMarker)
     case markerInvalid
@@ -354,15 +387,35 @@ struct AutoUpdateMarkerStore: Sendable {
         try? fileManager.removeItem(at: lockURL)
     }
 
-    func updateSignedPolicy(minimum: String?, revoked: [String]) {
+    func updateSignedPolicy(minimum: String?, revoked: [String]) async throws {
         var policy = (try? readPolicy()) ?? SignedPolicy()
         if let minimum, !minimum.isEmpty,
            policy.persistedMinimum.isEmpty || SelfUpdate.compareSemver(policy.persistedMinimum, minimum) == .orderedAscending {
             policy.persistedMinimum = minimum
         }
         policy.persistedRevoked.formUnion(revoked)
-        if let data = try? JSONEncoder().encode(policy) {
-            try? atomicWrite(data: data, finalURL: policyURL, mode: S_IRUSR | S_IWUSR)
+        do {
+            let data = try JSONEncoder().encode(policy)
+            try atomicWrite(data: data, finalURL: policyURL, mode: S_IRUSR | S_IWUSR)
+        } catch {
+            if let marker = try? readPending(),
+               fileManager.fileExists(atPath: marker.backupPath)
+            {
+                try? restoreBackup(marker)
+            }
+            let marker = try? readPending()
+            await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                updateID: marker?.updateID ?? UUID().uuidString.lowercased(),
+                currentVersion: "",
+                targetVersion: marker?.targetVersion ?? "<unknown>",
+                phase: .swap,
+                outcome: .failure,
+                reason: String(describing: error).prefix(128).description,
+                attempt: 1,
+                failureClass: .signedPolicyPersistFailed
+            ))
+            SessionAutoupdateGate.shared.disable(reason: "signed_policy_persist_failed")
+            throw AutoUpdateSignedPolicyPersistError(underlying: String(describing: error).prefix(128).description)
         }
     }
 
@@ -404,8 +457,10 @@ struct AutoUpdateMarkerStore: Sendable {
             throw AutoUpdateMarkerError.invalidMarker
         }
         let now = Date()
+        let postStartWindowSeconds: TimeInterval = 60
+        let futureToleranceSeconds: TimeInterval = postStartWindowSeconds + 30 * 60
         guard deadline > now.addingTimeInterval(-300),
-              deadline < now.addingTimeInterval(24 * 60 * 60)
+              deadline <= now.addingTimeInterval(futureToleranceSeconds)
         else {
             throw AutoUpdateMarkerError.invalidMarker
         }

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
@@ -44,6 +44,12 @@ enum AutoUpdateMarkerError: Error, CustomStringConvertible, Equatable {
     }
 }
 
+enum AutoUpdateOrphanRecoveryOutcome: Equatable {
+    case restored(AutoUpdatePendingMarker)
+    case markerInvalid
+    case backupCorrupt(AutoUpdatePendingMarker, String)
+}
+
 final class AutoUpdateLock: @unchecked Sendable {
     let fd: Int32
     let path: URL
@@ -115,6 +121,17 @@ struct AutoUpdateMarkerStore: Sendable {
         }
         fchmod(fd, S_IRUSR | S_IWUSR)
         return AutoUpdateLock(fd: fd, path: lockURL)
+    }
+
+    func updateLockIsLive() -> Bool {
+        let fd = open(lockURL.path, O_RDWR | O_NOFOLLOW)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+        if flock(fd, LOCK_EX | LOCK_NB) == 0 {
+            _ = flock(fd, LOCK_UN)
+            return false
+        }
+        return errno == EWOULDBLOCK
     }
 
     func rollbackBackupPath(binaryURL: URL, updateID: String) -> URL {
@@ -247,22 +264,93 @@ struct AutoUpdateMarkerStore: Sendable {
             updateID: marker.updateID,
             targetVersion: marker.targetVersion
         )
+        clearPending()
+        try? fileManager.removeItem(atPath: marker.backupPath)
+        removeLockFile()
     }
 
     func finalizeSuccessfulUpdate(_ marker: AutoUpdatePendingMarker) throws {
         try validateMarker(marker)
-        let binaryURL = URL(fileURLWithPath: marker.targetPath)
-        clearPending()
-        try? fileManager.removeItem(atPath: marker.backupPath)
-        try? fileManager.removeItem(at: lockURL)
-        try? fileManager.removeItem(at: successSentinelPath(binaryURL: binaryURL, updateID: marker.updateID))
+        finalizeSuccessfulUpdate(
+            updateID: marker.updateID,
+            binaryURL: URL(fileURLWithPath: marker.targetPath)
+        )
     }
 
-    func orphanPendingMarker(target: String?, failureClass: AutoUpdateFailureClass = .orphanedPendingMarker) {
+    func finalizeSuccessfulUpdate(updateID: String, binaryURL: URL) {
+        try? fileManager.removeItem(at: successSentinelPath(binaryURL: binaryURL, updateID: updateID))
+    }
+
+    func clearPendingAndLock(target: String?, failureClass: AutoUpdateFailureClass = .orphanedPendingMarker) {
         clearPending()
         if let target {
             recordCooldown(target: target, failureClass: failureClass)
         }
+        removeLockFile()
+    }
+
+    func recoverOrphanedMarker(_ marker: AutoUpdatePendingMarker) -> AutoUpdateOrphanRecoveryOutcome {
+        do {
+            try validateMarker(marker)
+        } catch {
+            quarantinePendingMarker()
+            removeBackupIfSafe(marker.backupPath)
+            removeLockFile()
+            return .markerInvalid
+        }
+        do {
+            try validateBackup(marker)
+        } catch {
+            quarantinePendingMarker()
+            removeLockFile()
+            return .backupCorrupt(marker, "backup_missing_or_hash_mismatch")
+        }
+        do {
+            try restoreBackup(marker)
+            clearPending()
+            try? fileManager.removeItem(atPath: marker.backupPath)
+            recordCooldown(target: marker.targetVersion, failureClass: .orphanedPendingMarker)
+            removeLockFile()
+            return .restored(marker)
+        } catch {
+            quarantinePendingMarker()
+            removeLockFile()
+            return .backupCorrupt(marker, String(describing: error))
+        }
+    }
+
+    func recoverInvalidPendingMarker() {
+        quarantinePendingMarker()
+        removeLockFile()
+    }
+
+    private func quarantinePendingMarker() {
+        guard fileManager.fileExists(atPath: pendingURL.path) else { return }
+        let stamp = ISO8601DateFormatter.autoupdate
+            .string(from: Date())
+            .replacingOccurrences(of: ":", with: "")
+        let destination = root.appendingPathComponent("pending-quarantined-\(stamp).json")
+        if fileManager.fileExists(atPath: destination.path) {
+            let fallback = root.appendingPathComponent("pending-quarantined-\(stamp)-\(UUID().uuidString).json")
+            try? fileManager.moveItem(at: pendingURL, to: fallback)
+        } else {
+            try? fileManager.moveItem(at: pendingURL, to: destination)
+        }
+        fsyncDirectory(root)
+    }
+
+    private func removeBackupIfSafe(_ path: String) {
+        guard isCanonicalAbsolutePath(path) else { return }
+        let url = URL(fileURLWithPath: path)
+        do {
+            _ = try regularFileStatNoFollow(url)
+            try fileManager.removeItem(at: url)
+        } catch {
+            return
+        }
+    }
+
+    private func removeLockFile() {
         try? fileManager.removeItem(at: lockURL)
     }
 

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
@@ -148,6 +148,7 @@ struct AutoUpdateMarkerStore: Sendable {
     }
 
     func writePending(_ marker: AutoUpdatePendingMarker) throws {
+        try validateMarker(marker)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         let data = try encoder.encode(marker)
@@ -156,9 +157,10 @@ struct AutoUpdateMarkerStore: Sendable {
 
     func readPending() throws -> AutoUpdatePendingMarker? {
         guard fileManager.fileExists(atPath: pendingURL.path) else { return nil }
-        try rejectSymlinkOrHardLink(pendingURL)
-        let data = try Data(contentsOf: pendingURL)
-        return try JSONDecoder().decode(AutoUpdatePendingMarker.self, from: data)
+        let data = try readRegularFileNoFollow(pendingURL)
+        let marker = try JSONDecoder().decode(AutoUpdatePendingMarker.self, from: data)
+        try validateMarker(marker)
+        return marker
     }
 
     func clearPending() {
@@ -176,11 +178,11 @@ struct AutoUpdateMarkerStore: Sendable {
     }
 
     func validateBackup(_ marker: AutoUpdatePendingMarker) throws {
+        try validateMarker(marker)
         let backupURL = URL(fileURLWithPath: marker.backupPath)
-        try rejectSymlinkOrHardLink(backupURL)
-        let attrs = try fileManager.attributesOfItem(atPath: backupURL.path)
-        guard (attrs[.size] as? NSNumber)?.intValue == marker.size,
-              try Self.sha256(file: backupURL).lowercased() == marker.sha256.lowercased()
+        let st = try regularFileStatNoFollow(backupURL)
+        guard st.st_size == marker.size,
+              try Self.sha256(file: backupURL) == marker.sha256
         else {
             throw AutoUpdateMarkerError.backupCorrupt
         }
@@ -238,16 +240,30 @@ struct AutoUpdateMarkerStore: Sendable {
     }
 
     func completeSuccessfulUpdate(_ marker: AutoUpdatePendingMarker) throws {
+        try validateMarker(marker)
         let binaryURL = URL(fileURLWithPath: marker.targetPath)
         try writeSuccessSentinel(
             binaryURL: binaryURL,
             updateID: marker.updateID,
             targetVersion: marker.targetVersion
         )
+    }
+
+    func finalizeSuccessfulUpdate(_ marker: AutoUpdatePendingMarker) throws {
+        try validateMarker(marker)
+        let binaryURL = URL(fileURLWithPath: marker.targetPath)
         clearPending()
         try? fileManager.removeItem(atPath: marker.backupPath)
         try? fileManager.removeItem(at: lockURL)
         try? fileManager.removeItem(at: successSentinelPath(binaryURL: binaryURL, updateID: marker.updateID))
+    }
+
+    func orphanPendingMarker(target: String?, failureClass: AutoUpdateFailureClass = .orphanedPendingMarker) {
+        clearPending()
+        if let target {
+            recordCooldown(target: target, failureClass: failureClass)
+        }
+        try? fileManager.removeItem(at: lockURL)
     }
 
     func updateSignedPolicy(minimum: String?, revoked: [String]) {
@@ -268,6 +284,69 @@ struct AutoUpdateMarkerStore: Sendable {
             value?.isEmpty == false ? value : nil
         }.max { SelfUpdate.compareSemver($0, $1) == .orderedAscending }
         return (minimum, policy.persistedRevoked.union(localRevoked))
+    }
+
+    func validateMarker(_ pending: AutoUpdatePendingMarker) throws {
+        let uuidV4 = #"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"#
+        guard pending.updateID.range(of: uuidV4, options: .regularExpression) != nil else {
+            throw AutoUpdateMarkerError.invalidMarker
+        }
+        guard let normalized = try? AutoUpdateRecommendation.validate(pending.targetVersion).normalized,
+              normalized == pending.targetVersion
+        else {
+            throw AutoUpdateMarkerError.invalidMarker
+        }
+        guard isCanonicalAbsolutePath(pending.targetPath),
+              isCanonicalAbsolutePath(pending.backupPath)
+        else {
+            throw AutoUpdateMarkerError.invalidMarker
+        }
+        guard pending.size >= 0, pending.size <= 1024 * 1024 * 1024 else {
+            throw AutoUpdateMarkerError.invalidMarker
+        }
+        guard (0 ... 0o7777).contains(pending.mode) else {
+            throw AutoUpdateMarkerError.invalidMarker
+        }
+        guard pending.sha256.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil else {
+            throw AutoUpdateMarkerError.invalidMarker
+        }
+        guard let deadline = ISO8601DateFormatter.autoupdate.date(from: pending.markerDeadline),
+              pending.markerDeadline.hasSuffix("Z")
+        else {
+            throw AutoUpdateMarkerError.invalidMarker
+        }
+        let now = Date()
+        guard deadline > now.addingTimeInterval(-300),
+              deadline < now.addingTimeInterval(24 * 60 * 60)
+        else {
+            throw AutoUpdateMarkerError.invalidMarker
+        }
+    }
+
+    func successSentinels(in binaryDirectory: URL) -> [URL] {
+        guard let contents = try? fileManager.contentsOfDirectory(at: binaryDirectory, includingPropertiesForKeys: nil) else {
+            return []
+        }
+        return contents.filter { $0.lastPathComponent.hasPrefix(".macprovider-cli.success-") }
+    }
+
+    func rollbackBackups(in binaryDirectory: URL) -> [URL] {
+        guard let contents = try? fileManager.contentsOfDirectory(at: binaryDirectory, includingPropertiesForKeys: nil) else {
+            return []
+        }
+        return contents.filter { $0.lastPathComponent.hasPrefix(".macprovider-cli.rollback-") }
+    }
+
+    func readSuccessSentinel(_ url: URL) throws -> (updateID: String, binaryVersion: String) {
+        let data = try readRegularFileNoFollow(url)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let updateID = object["update_id"] as? String,
+              let binaryVersion = object["binary_version"] as? String,
+              updateID.range(of: #"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"#, options: .regularExpression) != nil
+        else {
+            throw AutoUpdateMarkerError.invalidMarker
+        }
+        return (updateID, binaryVersion)
     }
 
     private func ensureTrustedDirectory(_ url: URL) throws {
@@ -291,6 +370,7 @@ struct AutoUpdateMarkerStore: Sendable {
         if (attrs[.posixPermissions] as? NSNumber)?.intValue != 0o700 {
             try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
         }
+        try rejectWritableACL(url)
     }
 
     private func rejectUnexpectedMountCrossing() throws {
@@ -314,7 +394,8 @@ struct AutoUpdateMarkerStore: Sendable {
         }
     }
 
-    private func atomicCopyNoFollow(from source: URL, to finalURL: URL, mode: Int) throws {
+    func atomicCopyNoFollow(from source: URL, to finalURL: URL, mode: Int) throws {
+        try validateTrustedBinaryDirectory(finalURL.deletingLastPathComponent())
         let input = open(source.path, O_RDONLY | O_NOFOLLOW)
         guard input >= 0 else { throw AutoUpdateMarkerError.openFailed(source.path, errno) }
         defer { close(input) }
@@ -355,6 +436,94 @@ struct AutoUpdateMarkerStore: Sendable {
             throw AutoUpdateMarkerError.writeFailed(finalURL.path, errnoValue)
         }
         fsyncDirectory(finalURL.deletingLastPathComponent())
+    }
+
+    func validateTrustedBinaryDirectory(_ url: URL) throws {
+        var st = stat()
+        guard lstat(url.path, &st) == 0 else {
+            throw AutoUpdateMarkerError.trustedRootInvalid("binary_dir_lstat_failed")
+        }
+        guard (st.st_mode & S_IFMT) == S_IFDIR,
+              (st.st_mode & S_IFMT) != S_IFLNK,
+              st.st_uid == getuid(),
+              (st.st_mode & (S_IWGRP | S_IWOTH)) == 0
+        else {
+            throw AutoUpdateMarkerError.trustedRootInvalid("binary_dir_untrusted")
+        }
+        try rejectWritableACL(url)
+    }
+
+    private func isCanonicalAbsolutePath(_ path: String) -> Bool {
+        guard path.hasPrefix("/"), !path.hasSuffix("/") else { return false }
+        let parts = path.split(separator: "/", omittingEmptySubsequences: false)
+        return !parts.contains { $0 == "." || $0 == ".." }
+    }
+
+    private func regularFileStatNoFollow(_ url: URL) throws -> stat {
+        var st = stat()
+        let fd = open(url.path, O_RDONLY | O_NOFOLLOW)
+        guard fd >= 0 else { throw AutoUpdateMarkerError.openFailed(url.path, errno) }
+        defer { close(fd) }
+        guard fstat(fd, &st) == 0 else {
+            throw AutoUpdateMarkerError.openFailed(url.path, errno)
+        }
+        guard (st.st_mode & S_IFMT) == S_IFREG,
+              st.st_uid == getuid(),
+              st.st_nlink == 1
+        else {
+            throw AutoUpdateMarkerError.trustedRootInvalid("regular_file_invalid")
+        }
+        return st
+    }
+
+    private func readRegularFileNoFollow(_ url: URL) throws -> Data {
+        var st = stat()
+        let fd = open(url.path, O_RDONLY | O_NOFOLLOW)
+        guard fd >= 0 else { throw AutoUpdateMarkerError.openFailed(url.path, errno) }
+        defer { close(fd) }
+        guard fstat(fd, &st) == 0 else {
+            throw AutoUpdateMarkerError.openFailed(url.path, errno)
+        }
+        guard (st.st_mode & S_IFMT) == S_IFREG,
+              st.st_uid == getuid(),
+              st.st_nlink == 1
+        else {
+            throw AutoUpdateMarkerError.trustedRootInvalid("regular_file_invalid")
+        }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let n = read(fd, &buffer, buffer.count)
+            if n < 0 {
+                throw AutoUpdateMarkerError.openFailed(url.path, errno)
+            }
+            if n == 0 { break }
+            data.append(buffer, count: n)
+        }
+        return data
+    }
+
+    private func rejectWritableACL(_ url: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ls")
+        process.arguments = ["-led", url.path]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return }
+        let output = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        let currentUser = NSUserName()
+        for line in output.split(separator: "\n").map(String.init) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.range(of: #"^[0-9]+:"#, options: .regularExpression) != nil else { continue }
+            let lower = trimmed.lowercased()
+            guard lower.contains("write") || lower.contains("append") || lower.contains("add_file") else { continue }
+            guard lower.contains("user:\(currentUser.lowercased()) ") || lower.contains("user:\(currentUser.lowercased()):") else {
+                throw AutoUpdateMarkerError.trustedRootInvalid("acl_write_grant")
+            }
+        }
     }
 
     private func atomicWrite(data: Data, finalURL: URL, mode: mode_t) throws {
@@ -407,7 +576,26 @@ struct AutoUpdateMarkerStore: Sendable {
     }
 
     static func sha256(file: URL) throws -> String {
-        let data = try Data(contentsOf: file)
+        let fd = open(file.path, O_RDONLY | O_NOFOLLOW)
+        guard fd >= 0 else { throw AutoUpdateMarkerError.openFailed(file.path, errno) }
+        defer { close(fd) }
+        var st = stat()
+        guard fstat(fd, &st) == 0,
+              (st.st_mode & S_IFMT) == S_IFREG,
+              st.st_nlink == 1
+        else {
+            throw AutoUpdateMarkerError.trustedRootInvalid("regular_file_invalid")
+        }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024 * 1024)
+        while true {
+            let n = read(fd, &buffer, buffer.count)
+            if n < 0 {
+                throw AutoUpdateMarkerError.openFailed(file.path, errno)
+            }
+            if n == 0 { break }
+            data.append(buffer, count: n)
+        }
         return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateTrustState.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateTrustState.swift
@@ -24,6 +24,31 @@ struct AutoUpdateTrustState: Sendable {
     let tokenValidated: Bool
     let bearerlessDuplicate: Bool
     let connected: Bool
+    let stableReason: String?
+
+    init(
+        v2Accepted: Bool,
+        tier: String?,
+        encryptedLegValid: Bool,
+        attestationRequired: Bool,
+        attestationSatisfied: Bool,
+        tokenConfigured: Bool,
+        tokenValidated: Bool,
+        bearerlessDuplicate: Bool,
+        connected: Bool,
+        stableReason: String? = nil
+    ) {
+        self.v2Accepted = v2Accepted
+        self.tier = tier
+        self.encryptedLegValid = encryptedLegValid
+        self.attestationRequired = attestationRequired
+        self.attestationSatisfied = attestationSatisfied
+        self.tokenConfigured = tokenConfigured
+        self.tokenValidated = tokenValidated
+        self.bearerlessDuplicate = bearerlessDuplicate
+        self.connected = connected
+        self.stableReason = stableReason
+    }
 
     var verdict: AutoUpdateTrustVerdict {
         guard connected else { return .coordinatorDisconnected }
@@ -38,6 +63,10 @@ struct AutoUpdateTrustState: Sendable {
 
     var isEligible: Bool {
         verdict == .eligible
+    }
+
+    var lossReason: String {
+        stableReason ?? verdict.rawValue
     }
 
     static func fromCoordinatorPayload(

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateTrustState.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateTrustState.swift
@@ -1,0 +1,104 @@
+import Foundation
+import MacProviderCore
+
+enum AutoUpdateTrustVerdict: String, Sendable {
+    case eligible
+    case legacyHelloAck = "legacy_hello_ack"
+    case unauthenticated
+    case authRejected = "auth_rejected"
+    case provisional
+    case bearerlessDuplicate = "bearerless_duplicate"
+    case encryptedLegFailed = "encrypted_leg_failed"
+    case attestationFailed = "attestation_failed"
+    case tokenRejected = "token_rejected"
+    case coordinatorDisconnected = "coordinator_disconnected"
+}
+
+struct AutoUpdateTrustState: Sendable {
+    let v2Accepted: Bool
+    let tier: String?
+    let encryptedLegValid: Bool
+    let attestationRequired: Bool
+    let attestationSatisfied: Bool
+    let tokenConfigured: Bool
+    let tokenValidated: Bool
+    let bearerlessDuplicate: Bool
+    let connected: Bool
+
+    var verdict: AutoUpdateTrustVerdict {
+        guard connected else { return .coordinatorDisconnected }
+        guard v2Accepted else { return .legacyHelloAck }
+        if bearerlessDuplicate { return .bearerlessDuplicate }
+        guard tier == "pinned" else { return .provisional }
+        guard encryptedLegValid else { return .encryptedLegFailed }
+        guard !attestationRequired || attestationSatisfied else { return .attestationFailed }
+        guard !tokenConfigured || tokenValidated else { return .tokenRejected }
+        return .eligible
+    }
+
+    var isEligible: Bool {
+        verdict == .eligible
+    }
+
+    static func fromCoordinatorPayload(
+        _ payload: [String: Any],
+        isV2: Bool,
+        session: Tier2ProviderSession?,
+        providerToken: String?,
+        assignedProviderTokenAdopted: Bool
+    ) -> AutoUpdateTrustState {
+        let tier = payload["tier"] as? String
+        let attestationStatus = (((payload["tier2_session"] as? [String: Any])?["attestation"] as? [String: Any])?["status"] as? String)
+        let tokenConfigured = providerToken?.isEmpty == false || (payload["assigned_provider_token"] as? String)?.isEmpty == false
+        return AutoUpdateTrustState(
+            v2Accepted: isV2,
+            tier: tier,
+            encryptedLegValid: isV2 && session != nil,
+            attestationRequired: attestationStatus != nil,
+            attestationSatisfied: attestationStatus == nil || attestationStatus == "attested" || attestationStatus == "not_required",
+            tokenConfigured: tokenConfigured,
+            tokenValidated: !tokenConfigured || providerToken?.isEmpty == false || assignedProviderTokenAdopted,
+            bearerlessDuplicate: tokenConfigured && providerToken == nil && !assignedProviderTokenAdopted,
+            connected: true
+        )
+    }
+}
+
+struct AutoUpdateRecommendation: Sendable, Equatable {
+    let raw: String
+    let normalized: String
+    let oversizedSHA256: String?
+
+    static func validate(_ raw: String) throws -> AutoUpdateRecommendation {
+        let rawBytes = raw.utf8.count
+        if rawBytes > 32 {
+            throw AutoUpdateValidationError.versionTooLong(AutoUpdateEvent.sha256Hex(raw))
+        }
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #"^[vV]"#, with: "", options: .regularExpression)
+        let parts = normalized.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              normalized.range(of: #"^[0-9]+\.[0-9]+\.[0-9]+$"#, options: .regularExpression) != nil
+        else {
+            throw AutoUpdateValidationError.invalid
+        }
+        if parts.contains(where: { $0.utf8.count > 8 }) {
+            throw AutoUpdateValidationError.componentTooLong
+        }
+        return AutoUpdateRecommendation(raw: raw, normalized: normalized, oversizedSHA256: nil)
+    }
+}
+
+enum AutoUpdateValidationError: Error, Equatable {
+    case invalid
+    case versionTooLong(String)
+    case componentTooLong
+}
+
+enum AutoUpdateConfig {
+    static func enabled(_ config: AppConfig) -> Bool {
+        if config.autoUpdateEnabled == false { return false }
+        if config.autoupdateEnabled == false { return false }
+        return true
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -6,16 +6,16 @@ enum AutoUpdateError: Error, CustomStringConvertible {
     case trustStateLost(String)
     case drainTimeout
     case observerUnavailable
-    case unsupportedInstallTopology
     case currentBinaryUnknown
+    case other(String)
 
     var description: String {
         switch self {
         case let .trustStateLost(reason): return "autoupdate trust state lost: \(reason)"
         case .drainTimeout: return "autoupdate drain timed out"
         case .observerUnavailable: return "rollback observer unavailable"
-        case .unsupportedInstallTopology: return "unsupported install topology"
         case .currentBinaryUnknown: return "current binary unknown"
+        case let .other(reason): return reason
         }
     }
 }
@@ -123,7 +123,7 @@ struct AutoUpdater: Sendable {
                 return
             }
             guard launchdProviderAvailable() else {
-                await fail(updateID: updateID, target: target, phase: .eligibility, failure: .unsupportedInstallTopology, reason: "unsupported_install_topology")
+                await fail(updateID: updateID, target: target, phase: .eligibility, failure: .other, reason: "unsupported_install_topology")
                 return
             }
             guard rollbackObserverAvailable() else {
@@ -189,7 +189,7 @@ struct AutoUpdater: Sendable {
             }
             await fail(updateID: updateID, target: target, phase: .eligibility, failure: .trustStateLost, reason: reason)
         } catch is AutoUpdateSignedPolicyPersistError {
-            markerStore.recordCooldown(target: target, failureClass: .signedPolicyPersistFailed)
+            markerStore.recordCooldown(target: target, failureClass: .other)
         } catch {
             await fail(updateID: updateID, target: target, phase: .eligibility, failure: .other, reason: Self.redactedReason(for: error))
         }
@@ -317,8 +317,8 @@ struct AutoUpdater: Sendable {
             return "signed_policy_persist_failed"
         case AutoUpdateError.observerUnavailable:
             return "rollback_observer_unavailable"
-        case AutoUpdateError.unsupportedInstallTopology:
-            return "unsupported_install_topology"
+        case AutoUpdateError.other(let reason):
+            return reason
         default:
             return String(describing: error).prefix(64).description
         }
@@ -362,7 +362,7 @@ struct AutoUpdater: Sendable {
         let plist = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
         guard FileManager.default.fileExists(atPath: plist.path) else {
-            throw AutoUpdateError.unsupportedInstallTopology
+            throw AutoUpdateError.other("unsupported_install_topology")
         }
         let domain = "gui/\(getuid())"
         try runProcess("/bin/launchctl", arguments: ["bootout", domain, "live.streamvc.macprovider"], allowFailure: true)

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -161,6 +161,9 @@ struct AutoUpdater: Sendable {
             }
             try await ensureEligible(phase: .backup)
             try await preserveMarkerAndSwap(updateID: updateID, target: target, newBinary: prepared.newBinary, tracker: commitTracker)
+            if let signedPolicy = prepared.signedPolicy {
+                markerStore.updateSignedPolicy(minimum: signedPolicy.minimum, revoked: signedPolicy.revoked)
+            }
             await record(updateID: updateID, target: target, phase: .swap, outcome: .success, reason: "binary_swap_complete", attempt: 1)
             try await ensureEligible(phase: .restart)
             try restartLaunchd()
@@ -176,7 +179,7 @@ struct AutoUpdater: Sendable {
                     try? markerStore.restoreBackup(marker)
                 }
                 if commitTracker.committedMarker || commitTracker.committedBackup {
-                    markerStore.orphanPendingMarker(target: nil)
+                    markerStore.clearPendingAndLock(target: nil)
                     try? FileManager.default.removeItem(atPath: marker.backupPath)
                 }
             }

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -1,0 +1,336 @@
+import Darwin
+import Foundation
+import MacProviderCore
+
+enum AutoUpdateError: Error, CustomStringConvertible {
+    case trustStateLost(String)
+    case drainTimeout
+    case observerUnavailable
+    case currentBinaryUnknown
+
+    var description: String {
+        switch self {
+        case let .trustStateLost(reason): return "autoupdate trust state lost: \(reason)"
+        case .drainTimeout: return "autoupdate drain timed out"
+        case .observerUnavailable: return "rollback observer unavailable"
+        case .currentBinaryUnknown: return "current binary unknown"
+        }
+    }
+}
+
+struct AutoUpdater: Sendable {
+    typealias TrustProvider = @Sendable () async -> AutoUpdateTrustState
+    typealias Drain = @Sendable (_ target: String) async throws -> Bool
+    typealias SendReady = @Sendable () async throws -> Void
+    typealias Restart = @Sendable () throws -> Void
+
+    let config: AppConfig
+    let currentVersion: String
+    let providerStatus: ProviderStatus
+    let releasesAPIURL: String?
+    let markerStore: AutoUpdateMarkerStore
+    let session: URLSession
+    let trustProvider: TrustProvider
+    let drain: Drain
+    let sendReady: SendReady
+    let restartLaunchd: Restart
+    let currentBinaryURL: @Sendable () -> URL?
+    let rollbackObserverAvailable: @Sendable () -> Bool
+
+    init(
+        config: AppConfig,
+        currentVersion: String,
+        providerStatus: ProviderStatus,
+        releasesAPIURL: String? = nil,
+        markerStore: AutoUpdateMarkerStore = AutoUpdateMarkerStore(),
+        session: URLSession = .shared,
+        trustProvider: @escaping TrustProvider,
+        drain: @escaping Drain,
+        sendReady: @escaping SendReady,
+        restartLaunchd: @escaping Restart = { try AutoUpdater.restartLaunchdIfInstalled() },
+        currentBinaryURL: @escaping @Sendable () -> URL? = { Bundle.main.executableURL },
+        rollbackObserverAvailable: @escaping @Sendable () -> Bool = { AutoUpdater.defaultRollbackObserverAvailable() }
+    ) {
+        self.config = config
+        self.currentVersion = currentVersion
+        self.providerStatus = providerStatus
+        self.releasesAPIURL = releasesAPIURL
+        self.markerStore = markerStore
+        self.session = session
+        self.trustProvider = trustProvider
+        self.drain = drain
+        self.sendReady = sendReady
+        self.restartLaunchd = restartLaunchd
+        self.currentBinaryURL = currentBinaryURL
+        self.rollbackObserverAvailable = rollbackObserverAvailable
+    }
+
+    func handleCoordinatorRecommendation(_ rawRecommended: String) async {
+        let updateID = UUID().uuidString.lowercased()
+        let validated: AutoUpdateRecommendation
+        do {
+            validated = try AutoUpdateRecommendation.validate(rawRecommended)
+        } catch let AutoUpdateValidationError.versionTooLong(sha) {
+            await record(updateID: updateID, target: "<redacted>", phase: .eligibility, outcome: .failure, reason: "version_too_long", attempt: 1, failure: .recommendedVersionInvalid, sha: sha)
+            return
+        } catch AutoUpdateValidationError.componentTooLong {
+            await record(updateID: updateID, target: "<invalid>", phase: .eligibility, outcome: .failure, reason: "version_component_too_long", attempt: 1, failure: .recommendedVersionInvalid)
+            return
+        } catch {
+            await record(updateID: updateID, target: "<invalid>", phase: .eligibility, outcome: .failure, reason: "recommended_version_invalid", attempt: 1, failure: .recommendedVersionInvalid)
+            return
+        }
+
+        let target = validated.normalized
+        await record(updateID: updateID, target: target, phase: .detection, outcome: .inProgress, reason: "recommended_binary_version_detected", attempt: 1)
+
+        guard SelfUpdate.compareSemver(currentVersion, target) == .orderedAscending else {
+            await record(updateID: updateID, target: target, phase: .eligibility, outcome: .noop, reason: "target_not_newer", attempt: 1)
+            return
+        }
+        guard AutoUpdateConfig.enabled(config) else {
+            print("A newer version is available (v\(target)), but autoupdate is disabled.")
+            await record(updateID: updateID, target: target, phase: .eligibility, outcome: .skipped, reason: "autoupdate_disabled", attempt: 1)
+            return
+        }
+        do {
+            try markerStore.ensureTrustedRoot()
+            let policy = markerStore.effectivePolicy()
+            if let minimum = policy.minimum, SelfUpdate.compareSemver(target, minimum) == .orderedAscending || policy.revoked.contains(target) {
+                await fail(updateID: updateID, target: target, phase: .eligibility, failure: .targetRevokedOrBelowMinimum, reason: "target_revoked_or_below_minimum")
+                return
+            }
+            guard rollbackObserverAvailable() else {
+                await fail(updateID: updateID, target: target, phase: .eligibility, failure: .rollbackObserverUnavailable, reason: "rollback_observer_unavailable")
+                return
+            }
+            if let activeCooldown = markerStore.activeCooldown(target: target) {
+                await record(updateID: updateID, target: target, phase: .cooldown, outcome: .skipped, reason: "cooldown_\(activeCooldown.failureClass.rawValue)_until_\(ISO8601DateFormatter.autoupdate.string(from: activeCooldown.until))", attempt: activeCooldown.attempt)
+                return
+            }
+            try await ensureEligible(phase: .eligibility)
+            let lock = try markerStore.acquireLock()
+            _ = lock
+            let update = SelfUpdate(currentVersion: currentVersion, releasesAPIURL: releasesAPIURL, session: session)
+            let release: GitHubRelease
+            do {
+                try await ensureEligible(phase: .download)
+                release = try await update.resolveReleaseByTags(normalizedTarget: target)
+            } catch UpdateError.releaseNotFound {
+                markerStore.recordCooldown(target: target, failureClass: .targetReleaseNotFound)
+                await fail(updateID: updateID, target: target, phase: .download, failure: .targetReleaseNotFound, reason: "target_release_not_found")
+                return
+            }
+            let prepared: PreparedSelfUpdate
+            do {
+                prepared = try await update.prepareValidatedUpdate(from: release)
+            } catch {
+                let failure = Self.failureClass(for: error)
+                markerStore.recordCooldown(target: target, failureClass: failure)
+                await fail(updateID: updateID, target: target, phase: Self.phase(for: error), failure: failure, reason: String(describing: error))
+                return
+            }
+            defer { prepared.cleanup() }
+            try await ensureEligible(phase: .drain)
+            let drained = try await drain(target)
+            guard drained else {
+                markerStore.recordCooldown(target: target, failureClass: .drainTimeout)
+                await fail(updateID: updateID, target: target, phase: .drain, failure: .drainTimeout, reason: "drain_timeout")
+                try? await sendReady()
+                return
+            }
+            try await ensureEligible(phase: .backup)
+            try await preserveMarkerAndSwap(updateID: updateID, target: target, newBinary: prepared.newBinary)
+            await record(updateID: updateID, target: target, phase: .swap, outcome: .success, reason: "binary_swap_complete", attempt: 1)
+            try await ensureEligible(phase: .restart)
+            try restartLaunchd()
+            await record(updateID: updateID, target: target, phase: .restart, outcome: .inProgress, reason: "launchctl_bootstrap_invoked", attempt: 1)
+        } catch AutoUpdateMarkerError.lockContended {
+            await fail(updateID: updateID, target: target, phase: .eligibility, failure: .autoupdateAlreadyPending, reason: "autoupdate_already_pending")
+        } catch AutoUpdateError.trustStateLost(let reason) {
+            await fail(updateID: updateID, target: target, phase: .eligibility, failure: .trustStateLost, reason: reason)
+        } catch {
+            markerStore.recordCooldown(target: target, failureClass: .other)
+            await fail(updateID: updateID, target: target, phase: .eligibility, failure: .other, reason: String(describing: error))
+        }
+    }
+
+    private func preserveMarkerAndSwap(updateID: String, target: String, newBinary: URL) async throws {
+        guard let current = currentBinaryURL() else {
+            throw AutoUpdateError.currentBinaryUnknown
+        }
+        let backup = markerStore.rollbackBackupPath(binaryURL: current, updateID: updateID)
+        let attrs = try FileManager.default.attributesOfItem(atPath: current.path)
+        let mode = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? 0o755
+        let size = (attrs[.size] as? NSNumber)?.intValue ?? 0
+        let sha = try AutoUpdateMarkerStore.sha256(file: current)
+        try copyNoFollow(from: current, to: backup, mode: mode)
+        let deadline = ISO8601DateFormatter.autoupdate.string(from: Date().addingTimeInterval(60 + 300))
+        try markerStore.writePending(AutoUpdatePendingMarker(
+            updateID: updateID,
+            targetVersion: target,
+            targetPath: current.path,
+            backupPath: backup.path,
+            size: size,
+            mode: mode,
+            sha256: sha,
+            markerDeadline: deadline
+        ))
+        try await ensureEligible(phase: .swap)
+        let staged = current.deletingLastPathComponent()
+            .appendingPathComponent(".\(current.lastPathComponent).update-\(UUID().uuidString)")
+        try copyNoFollow(from: newBinary, to: staged, mode: 0o755)
+        if rename(staged.path, current.path) != 0 {
+            let errnoValue = errno
+            try? FileManager.default.removeItem(at: staged)
+            try? markerStore.restoreBackup(AutoUpdatePendingMarker(
+                updateID: updateID,
+                targetVersion: target,
+                targetPath: current.path,
+                backupPath: backup.path,
+                size: size,
+                mode: mode,
+                sha256: sha,
+                markerDeadline: deadline
+            ))
+            throw UpdateError.renameFailed(errnoValue)
+        }
+    }
+
+    private func copyNoFollow(from source: URL, to finalURL: URL, mode: Int) throws {
+        let input = open(source.path, O_RDONLY | O_NOFOLLOW)
+        guard input >= 0 else { throw AutoUpdateMarkerError.openFailed(source.path, errno) }
+        defer { close(input) }
+        let tempURL = finalURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(finalURL.lastPathComponent).tmp-\(UUID().uuidString)")
+        let output = open(tempURL.path, O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW, mode_t(mode))
+        guard output >= 0 else { throw AutoUpdateMarkerError.openFailed(tempURL.path, errno) }
+        defer { close(output) }
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let readCount = read(input, &buffer, buffer.count)
+            if readCount < 0 {
+                try? FileManager.default.removeItem(at: tempURL)
+                throw AutoUpdateMarkerError.writeFailed(tempURL.path, errno)
+            }
+            if readCount == 0 { break }
+            try buffer.withUnsafeBytes { raw in
+                var offset = 0
+                while offset < readCount {
+                    let wrote = write(output, raw.baseAddress!.advanced(by: offset), readCount - offset)
+                    if wrote <= 0 {
+                        try? FileManager.default.removeItem(at: tempURL)
+                        throw AutoUpdateMarkerError.writeFailed(tempURL.path, errno)
+                    }
+                    offset += wrote
+                }
+            }
+        }
+        fchmod(output, mode_t(mode))
+        fsync(output)
+        if rename(tempURL.path, finalURL.path) != 0 {
+            let errnoValue = errno
+            try? FileManager.default.removeItem(at: tempURL)
+            throw AutoUpdateMarkerError.writeFailed(finalURL.path, errnoValue)
+        }
+    }
+
+    private func ensureEligible(phase: AutoUpdatePhase) async throws {
+        let trust = await trustProvider()
+        guard trust.isEligible else {
+            throw AutoUpdateError.trustStateLost(trust.verdict.rawValue)
+        }
+        _ = phase
+    }
+
+    private func fail(updateID: String, target: String, phase: AutoUpdatePhase, failure: AutoUpdateFailureClass, reason: String) async {
+        markerStore.recordCooldown(target: target, failureClass: failure)
+        await record(updateID: updateID, target: target, phase: phase, outcome: .failure, reason: reason, attempt: 1, failure: failure)
+    }
+
+    private func record(updateID: String, target: String, phase: AutoUpdatePhase, outcome: AutoUpdateOutcome, reason: String, attempt: Int, failure: AutoUpdateFailureClass? = nil, sha: String? = nil) async {
+        let inflight = await providerStatus.snapshot().requestsInFlight
+        await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+            updateID: updateID,
+            currentVersion: currentVersion,
+            targetVersion: target,
+            phase: phase,
+            outcome: outcome,
+            reason: reason,
+            attempt: attempt,
+            failureClass: failure,
+            inflightRequests: phase == .drain ? inflight : nil,
+            recommendedBinaryVersionSHA256: sha
+        ))
+    }
+
+    private static func failureClass(for error: Error) -> AutoUpdateFailureClass {
+        switch error {
+        case UpdateError.missingAsset, UpdateError.checksumMissing:
+            return .releaseAssetMissing
+        case UpdateError.checksumSignatureInvalid:
+            return .signatureInvalid
+        case UpdateError.checksumMismatch:
+            return .checksumMismatch
+        case UpdateError.processFailed:
+            return .selfTestFailed
+        case UpdateError.insufficientDiskSpace:
+            return .insufficientDiskSpace
+        default:
+            return .other
+        }
+    }
+
+    private static func phase(for error: Error) -> AutoUpdatePhase {
+        switch error {
+        case UpdateError.checksumSignatureInvalid:
+            return .signature
+        case UpdateError.checksumMismatch, UpdateError.checksumMissing:
+            return .checksum
+        case UpdateError.unsafeArchiveEntry, UpdateError.missingExtractedBinary:
+            return .archive
+        case UpdateError.processFailed:
+            return .selfTest
+        case UpdateError.insufficientDiskSpace:
+            return .freeSpace
+        default:
+            return .download
+        }
+    }
+
+    static func defaultRollbackObserverAvailable() -> Bool {
+        let plist = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist")
+        return FileManager.default.fileExists(atPath: plist.path)
+            || ProcessInfo.processInfo.environment["MACPROVIDER_ROLLBACK_OBSERVER_TEST_AVAILABLE"] == "1"
+    }
+
+    static func restartLaunchdIfInstalled() throws {
+        let plist = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
+        guard FileManager.default.fileExists(atPath: plist.path) else { return }
+        let domain = "gui/\(getuid())"
+        try runProcess("/bin/launchctl", arguments: ["bootout", domain, "live.streamvc.macprovider"], allowFailure: true)
+        try runProcess("/bin/launchctl", arguments: ["bootstrap", domain, plist.path])
+    }
+
+    private static func runProcess(_ executable: String, arguments: [String], allowFailure: Bool = false) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        try process.run()
+        process.waitUntilExit()
+        if !allowFailure, process.terminationStatus != 0 {
+            throw UpdateError.processFailed(executable, process.terminationStatus)
+        }
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let autoupdate: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+}

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -6,6 +6,7 @@ enum AutoUpdateError: Error, CustomStringConvertible {
     case trustStateLost(String)
     case drainTimeout
     case observerUnavailable
+    case unsupportedInstallTopology
     case currentBinaryUnknown
 
     var description: String {
@@ -13,9 +14,17 @@ enum AutoUpdateError: Error, CustomStringConvertible {
         case let .trustStateLost(reason): return "autoupdate trust state lost: \(reason)"
         case .drainTimeout: return "autoupdate drain timed out"
         case .observerUnavailable: return "rollback observer unavailable"
+        case .unsupportedInstallTopology: return "unsupported install topology"
         case .currentBinaryUnknown: return "current binary unknown"
         }
     }
+}
+
+private final class AutoUpdateCommitTracker {
+    var marker: AutoUpdatePendingMarker?
+    var committedMarker = false
+    var committedBackup = false
+    var committedSwap = false
 }
 
 struct AutoUpdater: Sendable {
@@ -23,6 +32,7 @@ struct AutoUpdater: Sendable {
     typealias Drain = @Sendable (_ target: String) async throws -> Bool
     typealias SendReady = @Sendable () async throws -> Void
     typealias Restart = @Sendable () throws -> Void
+    typealias Availability = @Sendable () -> Bool
 
     let config: AppConfig
     let currentVersion: String
@@ -35,7 +45,8 @@ struct AutoUpdater: Sendable {
     let sendReady: SendReady
     let restartLaunchd: Restart
     let currentBinaryURL: @Sendable () -> URL?
-    let rollbackObserverAvailable: @Sendable () -> Bool
+    let rollbackObserverAvailable: Availability
+    let launchdProviderAvailable: Availability
 
     init(
         config: AppConfig,
@@ -49,7 +60,8 @@ struct AutoUpdater: Sendable {
         sendReady: @escaping SendReady,
         restartLaunchd: @escaping Restart = { try AutoUpdater.restartLaunchdIfInstalled() },
         currentBinaryURL: @escaping @Sendable () -> URL? = { Bundle.main.executableURL },
-        rollbackObserverAvailable: @escaping @Sendable () -> Bool = { AutoUpdater.defaultRollbackObserverAvailable() }
+        rollbackObserverAvailable: @escaping Availability = { AutoUpdater.defaultRollbackObserverAvailable() },
+        launchdProviderAvailable: @escaping Availability = { AutoUpdater.defaultLaunchdProviderAvailable() }
     ) {
         self.config = config
         self.currentVersion = currentVersion
@@ -63,10 +75,16 @@ struct AutoUpdater: Sendable {
         self.restartLaunchd = restartLaunchd
         self.currentBinaryURL = currentBinaryURL
         self.rollbackObserverAvailable = rollbackObserverAvailable
+        self.launchdProviderAvailable = launchdProviderAvailable
     }
 
     func handleCoordinatorRecommendation(_ rawRecommended: String) async {
         let updateID = UUID().uuidString.lowercased()
+        let entryTrust = await trustProvider()
+        guard entryTrust.isEligible else {
+            await record(updateID: updateID, target: "<notify-only>", phase: .eligibility, outcome: .skipped, reason: entryTrust.lossReason, attempt: 1)
+            return
+        }
         let validated: AutoUpdateRecommendation
         do {
             validated = try AutoUpdateRecommendation.validate(rawRecommended)
@@ -83,6 +101,7 @@ struct AutoUpdater: Sendable {
 
         let target = validated.normalized
         await record(updateID: updateID, target: target, phase: .detection, outcome: .inProgress, reason: "recommended_binary_version_detected", attempt: 1)
+        let commitTracker = AutoUpdateCommitTracker()
 
         guard SelfUpdate.compareSemver(currentVersion, target) == .orderedAscending else {
             await record(updateID: updateID, target: target, phase: .eligibility, outcome: .noop, reason: "target_not_newer", attempt: 1)
@@ -94,16 +113,20 @@ struct AutoUpdater: Sendable {
             return
         }
         do {
-            try markerStore.ensureTrustedRoot()
             let policy = markerStore.effectivePolicy()
             if let minimum = policy.minimum, SelfUpdate.compareSemver(target, minimum) == .orderedAscending || policy.revoked.contains(target) {
                 await fail(updateID: updateID, target: target, phase: .eligibility, failure: .targetRevokedOrBelowMinimum, reason: "target_revoked_or_below_minimum")
+                return
+            }
+            guard launchdProviderAvailable() else {
+                await fail(updateID: updateID, target: target, phase: .eligibility, failure: .unsupportedInstallTopology, reason: "unsupported_install_topology")
                 return
             }
             guard rollbackObserverAvailable() else {
                 await fail(updateID: updateID, target: target, phase: .eligibility, failure: .rollbackObserverUnavailable, reason: "rollback_observer_unavailable")
                 return
             }
+            try markerStore.ensureTrustedRoot()
             if let activeCooldown = markerStore.activeCooldown(target: target) {
                 await record(updateID: updateID, target: target, phase: .cooldown, outcome: .skipped, reason: "cooldown_\(activeCooldown.failureClass.rawValue)_until_\(ISO8601DateFormatter.autoupdate.string(from: activeCooldown.until))", attempt: activeCooldown.attempt)
                 return
@@ -117,7 +140,6 @@ struct AutoUpdater: Sendable {
                 try await ensureEligible(phase: .download)
                 release = try await update.resolveReleaseByTags(normalizedTarget: target)
             } catch UpdateError.releaseNotFound {
-                markerStore.recordCooldown(target: target, failureClass: .targetReleaseNotFound)
                 await fail(updateID: updateID, target: target, phase: .download, failure: .targetReleaseNotFound, reason: "target_release_not_found")
                 return
             }
@@ -126,21 +148,19 @@ struct AutoUpdater: Sendable {
                 prepared = try await update.prepareValidatedUpdate(from: release)
             } catch {
                 let failure = Self.failureClass(for: error)
-                markerStore.recordCooldown(target: target, failureClass: failure)
-                await fail(updateID: updateID, target: target, phase: Self.phase(for: error), failure: failure, reason: String(describing: error))
+                await fail(updateID: updateID, target: target, phase: Self.phase(for: error), failure: failure, reason: Self.redactedReason(for: error))
                 return
             }
             defer { prepared.cleanup() }
             try await ensureEligible(phase: .drain)
             let drained = try await drain(target)
             guard drained else {
-                markerStore.recordCooldown(target: target, failureClass: .drainTimeout)
                 await fail(updateID: updateID, target: target, phase: .drain, failure: .drainTimeout, reason: "drain_timeout")
                 try? await sendReady()
                 return
             }
             try await ensureEligible(phase: .backup)
-            try await preserveMarkerAndSwap(updateID: updateID, target: target, newBinary: prepared.newBinary)
+            try await preserveMarkerAndSwap(updateID: updateID, target: target, newBinary: prepared.newBinary, tracker: commitTracker)
             await record(updateID: updateID, target: target, phase: .swap, outcome: .success, reason: "binary_swap_complete", attempt: 1)
             try await ensureEligible(phase: .restart)
             try restartLaunchd()
@@ -148,14 +168,25 @@ struct AutoUpdater: Sendable {
         } catch AutoUpdateMarkerError.lockContended {
             await fail(updateID: updateID, target: target, phase: .eligibility, failure: .autoupdateAlreadyPending, reason: "autoupdate_already_pending")
         } catch AutoUpdateError.trustStateLost(let reason) {
+            if let marker = commitTracker.marker ?? (try? markerStore.readPending()) {
+                if commitTracker.committedSwap,
+                   FileManager.default.fileExists(atPath: marker.targetPath),
+                   (try? AutoUpdateMarkerStore.sha256(file: URL(fileURLWithPath: marker.targetPath))) != marker.sha256
+                {
+                    try? markerStore.restoreBackup(marker)
+                }
+                if commitTracker.committedMarker || commitTracker.committedBackup {
+                    markerStore.orphanPendingMarker(target: nil)
+                    try? FileManager.default.removeItem(atPath: marker.backupPath)
+                }
+            }
             await fail(updateID: updateID, target: target, phase: .eligibility, failure: .trustStateLost, reason: reason)
         } catch {
-            markerStore.recordCooldown(target: target, failureClass: .other)
-            await fail(updateID: updateID, target: target, phase: .eligibility, failure: .other, reason: String(describing: error))
+            await fail(updateID: updateID, target: target, phase: .eligibility, failure: .other, reason: Self.redactedReason(for: error))
         }
     }
 
-    private func preserveMarkerAndSwap(updateID: String, target: String, newBinary: URL) async throws {
+    private func preserveMarkerAndSwap(updateID: String, target: String, newBinary: URL, tracker: AutoUpdateCommitTracker) async throws {
         guard let current = currentBinaryURL() else {
             throw AutoUpdateError.currentBinaryUnknown
         }
@@ -164,9 +195,10 @@ struct AutoUpdater: Sendable {
         let mode = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? 0o755
         let size = (attrs[.size] as? NSNumber)?.intValue ?? 0
         let sha = try AutoUpdateMarkerStore.sha256(file: current)
-        try copyNoFollow(from: current, to: backup, mode: mode)
+        try markerStore.atomicCopyNoFollow(from: current, to: backup, mode: mode)
+        tracker.committedBackup = true
         let deadline = ISO8601DateFormatter.autoupdate.string(from: Date().addingTimeInterval(60 + 300))
-        try markerStore.writePending(AutoUpdatePendingMarker(
+        let marker = AutoUpdatePendingMarker(
             updateID: updateID,
             targetVersion: target,
             targetPath: current.path,
@@ -175,70 +207,27 @@ struct AutoUpdater: Sendable {
             mode: mode,
             sha256: sha,
             markerDeadline: deadline
-        ))
+        )
+        try markerStore.writePending(marker)
+        tracker.marker = marker
+        tracker.committedMarker = true
         try await ensureEligible(phase: .swap)
         let staged = current.deletingLastPathComponent()
             .appendingPathComponent(".\(current.lastPathComponent).update-\(UUID().uuidString)")
-        try copyNoFollow(from: newBinary, to: staged, mode: 0o755)
+        try markerStore.atomicCopyNoFollow(from: newBinary, to: staged, mode: 0o755)
         if rename(staged.path, current.path) != 0 {
             let errnoValue = errno
             try? FileManager.default.removeItem(at: staged)
-            try? markerStore.restoreBackup(AutoUpdatePendingMarker(
-                updateID: updateID,
-                targetVersion: target,
-                targetPath: current.path,
-                backupPath: backup.path,
-                size: size,
-                mode: mode,
-                sha256: sha,
-                markerDeadline: deadline
-            ))
+            try? markerStore.restoreBackup(marker)
             throw UpdateError.renameFailed(errnoValue)
         }
-    }
-
-    private func copyNoFollow(from source: URL, to finalURL: URL, mode: Int) throws {
-        let input = open(source.path, O_RDONLY | O_NOFOLLOW)
-        guard input >= 0 else { throw AutoUpdateMarkerError.openFailed(source.path, errno) }
-        defer { close(input) }
-        let tempURL = finalURL.deletingLastPathComponent()
-            .appendingPathComponent(".\(finalURL.lastPathComponent).tmp-\(UUID().uuidString)")
-        let output = open(tempURL.path, O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW, mode_t(mode))
-        guard output >= 0 else { throw AutoUpdateMarkerError.openFailed(tempURL.path, errno) }
-        defer { close(output) }
-        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
-        while true {
-            let readCount = read(input, &buffer, buffer.count)
-            if readCount < 0 {
-                try? FileManager.default.removeItem(at: tempURL)
-                throw AutoUpdateMarkerError.writeFailed(tempURL.path, errno)
-            }
-            if readCount == 0 { break }
-            try buffer.withUnsafeBytes { raw in
-                var offset = 0
-                while offset < readCount {
-                    let wrote = write(output, raw.baseAddress!.advanced(by: offset), readCount - offset)
-                    if wrote <= 0 {
-                        try? FileManager.default.removeItem(at: tempURL)
-                        throw AutoUpdateMarkerError.writeFailed(tempURL.path, errno)
-                    }
-                    offset += wrote
-                }
-            }
-        }
-        fchmod(output, mode_t(mode))
-        fsync(output)
-        if rename(tempURL.path, finalURL.path) != 0 {
-            let errnoValue = errno
-            try? FileManager.default.removeItem(at: tempURL)
-            throw AutoUpdateMarkerError.writeFailed(finalURL.path, errnoValue)
-        }
+        tracker.committedSwap = true
     }
 
     private func ensureEligible(phase: AutoUpdatePhase) async throws {
         let trust = await trustProvider()
         guard trust.isEligible else {
-            throw AutoUpdateError.trustStateLost(trust.verdict.rawValue)
+            throw AutoUpdateError.trustStateLost(trust.lossReason)
         }
         _ = phase
     }
@@ -281,6 +270,49 @@ struct AutoUpdater: Sendable {
         }
     }
 
+    static func redactedReason(for error: Error) -> String {
+        switch error {
+        case UpdateError.invalidURL:
+            return "invalid_release_api_url"
+        case UpdateError.httpStatus:
+            return "release_api_http_status"
+        case UpdateError.releaseNotFound:
+            return "target_release_not_found"
+        case UpdateError.missingAsset:
+            return "release_asset_missing"
+        case UpdateError.checksumMissing:
+            return "checksum_missing"
+        case UpdateError.checksumMismatch:
+            return "checksum_mismatch"
+        case UpdateError.checksumSignatureInvalid:
+            return "signature_invalid"
+        case UpdateError.missingExtractedBinary:
+            return "missing_extracted_binary"
+        case UpdateError.currentBinaryUnknown:
+            return "current_binary_unknown"
+        case UpdateError.processFailed:
+            return "process_failed"
+        case UpdateError.renameFailed:
+            return "rename_failed"
+        case UpdateError.untrustedDownloadURL:
+            return "untrusted_download_url"
+        case UpdateError.untrustedReleaseAPIURL:
+            return "untrusted_release_api_url"
+        case UpdateError.unsafeArchiveEntry:
+            return "unsafe_archive_entry"
+        case UpdateError.insufficientDiskSpace:
+            return "insufficient_disk_space"
+        case AutoUpdateError.trustStateLost(let reason):
+            return reason
+        case AutoUpdateError.observerUnavailable:
+            return "rollback_observer_unavailable"
+        case AutoUpdateError.unsupportedInstallTopology:
+            return "unsupported_install_topology"
+        default:
+            return String(describing: error).prefix(64).description
+        }
+    }
+
     private static func phase(for error: Error) -> AutoUpdatePhase {
         switch error {
         case UpdateError.checksumSignatureInvalid:
@@ -299,19 +331,49 @@ struct AutoUpdater: Sendable {
     }
 
     static func defaultRollbackObserverAvailable() -> Bool {
+        if ProcessInfo.processInfo.environment["MACPROVIDER_ROLLBACK_OBSERVER_TEST_AVAILABLE"] == "1" {
+            return true
+        }
+        return launchctlServiceLoaded(label: "live.streamvc.macprovider-watchdog")
+    }
+
+    static func defaultLaunchdProviderAvailable() -> Bool {
+        if ProcessInfo.processInfo.environment["MACPROVIDER_LAUNCHD_PROVIDER_TEST_AVAILABLE"] == "1" {
+            return true
+        }
         let plist = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist")
+            .appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
         return FileManager.default.fileExists(atPath: plist.path)
-            || ProcessInfo.processInfo.environment["MACPROVIDER_ROLLBACK_OBSERVER_TEST_AVAILABLE"] == "1"
+            && launchctlServiceLoaded(label: "live.streamvc.macprovider")
     }
 
     static func restartLaunchdIfInstalled() throws {
         let plist = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
-        guard FileManager.default.fileExists(atPath: plist.path) else { return }
+        guard FileManager.default.fileExists(atPath: plist.path) else {
+            throw AutoUpdateError.unsupportedInstallTopology
+        }
         let domain = "gui/\(getuid())"
         try runProcess("/bin/launchctl", arguments: ["bootout", domain, "live.streamvc.macprovider"], allowFailure: true)
         try runProcess("/bin/launchctl", arguments: ["bootstrap", domain, plist.path])
+    }
+
+    private static func launchctlServiceLoaded(label: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = ["print", "gui/\(getuid())/\(label)"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return false
+        }
+        guard process.terminationStatus == 0 else { return false }
+        let output = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        return !output.lowercased().contains("disabled = true")
     }
 
     private static func runProcess(_ executable: String, arguments: [String], allowFailure: Bool = false) throws {

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -81,6 +81,10 @@ struct AutoUpdater: Sendable {
     func handleCoordinatorRecommendation(_ rawRecommended: String) async {
         let updateID = UUID().uuidString.lowercased()
         let entryTrust = await trustProvider()
+        guard !SessionAutoupdateGate.shared.isDisabled else {
+            await record(updateID: updateID, target: "<session-disabled>", phase: .eligibility, outcome: .skipped, reason: "signed_policy_persist_failed", attempt: 1)
+            return
+        }
         guard entryTrust.isEligible else {
             await record(updateID: updateID, target: "<notify-only>", phase: .eligibility, outcome: .skipped, reason: entryTrust.lossReason, attempt: 1)
             return
@@ -162,7 +166,7 @@ struct AutoUpdater: Sendable {
             try await ensureEligible(phase: .backup)
             try await preserveMarkerAndSwap(updateID: updateID, target: target, newBinary: prepared.newBinary, tracker: commitTracker)
             if let signedPolicy = prepared.signedPolicy {
-                markerStore.updateSignedPolicy(minimum: signedPolicy.minimum, revoked: signedPolicy.revoked)
+                try await markerStore.updateSignedPolicy(minimum: signedPolicy.minimum, revoked: signedPolicy.revoked)
             }
             await record(updateID: updateID, target: target, phase: .swap, outcome: .success, reason: "binary_swap_complete", attempt: 1)
             try await ensureEligible(phase: .restart)
@@ -184,6 +188,8 @@ struct AutoUpdater: Sendable {
                 }
             }
             await fail(updateID: updateID, target: target, phase: .eligibility, failure: .trustStateLost, reason: reason)
+        } catch is AutoUpdateSignedPolicyPersistError {
+            markerStore.recordCooldown(target: target, failureClass: .signedPolicyPersistFailed)
         } catch {
             await fail(updateID: updateID, target: target, phase: .eligibility, failure: .other, reason: Self.redactedReason(for: error))
         }
@@ -307,6 +313,8 @@ struct AutoUpdater: Sendable {
             return "insufficient_disk_space"
         case AutoUpdateError.trustStateLost(let reason):
             return reason
+        case is AutoUpdateSignedPolicyPersistError:
+            return "signed_policy_persist_failed"
         case AutoUpdateError.observerUnavailable:
             return "rollback_observer_unavailable"
         case AutoUpdateError.unsupportedInstallTopology:

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,10 +165,11 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.6.1"
+    static let binaryVersion = "1.7.0"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL
+    private let appConfig: AppConfig
     private let providerStatus: ProviderStatus
     private let drainTimeoutSeconds: Int
     private let providerID: String
@@ -208,6 +209,19 @@ actor CoordinatorClient {
     private let pairingController: PairingController
     private var inferenceRelay: InferenceRelay?
     private var tier2Session: Tier2ProviderSession?
+    private var autoupdateTrustState = AutoUpdateTrustState(
+        v2Accepted: false,
+        tier: nil,
+        encryptedLegValid: false,
+        attestationRequired: false,
+        attestationSatisfied: false,
+        tokenConfigured: false,
+        tokenValidated: false,
+        bearerlessDuplicate: false,
+        connected: false
+    )
+    private var autoupdateDrainExtensions = false
+    private var autoupdateAttemptedTargets = Set<String>()
     private var webSocket: ProviderWebSocketTask?
     private var runTask: Task<Void, Never>?
     private var heartbeatTask: Task<Void, Never>?
@@ -249,6 +263,7 @@ actor CoordinatorClient {
             return nil
         }
         self.coordinatorURL = url
+        self.appConfig = config
         self.providerStatus = providerStatus
         self.drainTimeoutSeconds = config.drainTimeoutSeconds
         // SPEC-001 v1.1.2 / SPEC-002 v1.0.4 F-2: provider_id is the operator-issued
@@ -303,6 +318,17 @@ actor CoordinatorClient {
         inferenceRelay = nil
         tier2Session = nil
         webSocket?.cancel(with: .goingAway, reason: nil)
+        autoupdateTrustState = AutoUpdateTrustState(
+            v2Accepted: false,
+            tier: nil,
+            encryptedLegValid: false,
+            attestationRequired: false,
+            attestationSatisfied: false,
+            tokenConfigured: false,
+            tokenValidated: false,
+            bearerlessDuplicate: false,
+            connected: false
+        )
         await providerStatus.setCoordinatorSession(connected: false)
         runTask = nil
         heartbeatTask = nil
@@ -887,6 +913,17 @@ actor CoordinatorClient {
         tier2Session = nil
         webSocket?.cancel(with: .goingAway, reason: nil)
         webSocket = nil
+        autoupdateTrustState = AutoUpdateTrustState(
+            v2Accepted: false,
+            tier: nil,
+            encryptedLegValid: false,
+            attestationRequired: false,
+            attestationSatisfied: false,
+            tokenConfigured: false,
+            tokenValidated: false,
+            bearerlessDuplicate: false,
+            connected: false
+        )
         await providerStatus.setCoordinatorSession(connected: false)
     }
 
@@ -1103,6 +1140,7 @@ actor CoordinatorClient {
 
     private func acceptAuthResponse(_ response: [String: Any], session: Tier2ProviderSession) async throws {
         try validateAcceptedAuthResponse(response, session: session)
+        tier2Session = session
         try await acceptCoordinatorSession(response, reason: "coordinator auth_response accepted")
     }
 
@@ -1153,13 +1191,13 @@ actor CoordinatorClient {
     /// scratch and the legitimate provider can mint cleanly. The
     /// asymmetry "coordinator has token / binary doesn't" never appears
     /// in this design.
-    private func adoptAssignedProviderTokenIfPresent(_ payload: [String: Any]) async {
+    private func adoptAssignedProviderTokenIfPresent(_ payload: [String: Any]) async -> Bool {
         guard let assigned = payload["assigned_provider_token"] as? String else {
-            return
+            return false
         }
         let trimmed = assigned.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
-            return
+            return false
         }
         let path = configPath
         let result: Result<Void, Error> = await Task.detached(priority: .utility) {
@@ -1174,8 +1212,10 @@ actor CoordinatorClient {
         case .success:
             self.providerToken = trimmed
             Self.emitTokenPersistEvent(event: "provider_token_persisted", path: path, error: nil)
+            return true
         case .failure(let error):
             Self.emitTokenPersistEvent(event: "provider_token_persist_failed", path: path, error: error)
+            return false
         }
     }
 
@@ -1209,7 +1249,7 @@ actor CoordinatorClient {
         // and v2 (auth_response) ack paths since both funnel here.
         // Awaited so that persist-before-adopt holds: see
         // adoptAssignedProviderTokenIfPresent doc-comment.
-        await adoptAssignedProviderTokenIfPresent(payload)
+        let assignedProviderTokenAdopted = await adoptAssignedProviderTokenIfPresent(payload)
         do {
             try pairingController.handlePairingMaterial(
                 pairOT: payload["pair_ot"] as? String,
@@ -1220,6 +1260,16 @@ actor CoordinatorClient {
             Self.emitClaimURLHandoffEvent(error: error)
         }
         let interval = max(Self.intValue(payload["heartbeat_interval_s"]) ?? 30, 1)
+        let isV2 = payload["type"] as? String == "auth_response" && payload["status"] as? String == "accepted"
+        autoupdateTrustState = AutoUpdateTrustState.fromCoordinatorPayload(
+            payload,
+            isV2: isV2,
+            session: tier2Session,
+            providerToken: providerToken,
+            assignedProviderTokenAdopted: assignedProviderTokenAdopted
+        )
+        autoupdateDrainExtensions = payload["autoupdate_drain_extensions"] as? Bool == true
+        autoupdateAttemptedTargets.removeAll()
         await providerStatus.setCoordinatorSession(
             connected: true,
             assignedID: payload["assigned_id"] as? String,
@@ -1229,15 +1279,20 @@ actor CoordinatorClient {
         if let tier = payload["tier"] as? String {
             print("Coordinator tier: \(tier)")
         }
-        if let recommended = payload["recommended_binary_version"] as? String,
-           Self.compareSemver(Self.binaryVersion, recommended) == .orderedAscending
-        {
-            print("A newer version is available (v\(recommended)). Run 'macprovider-cli update' to upgrade.")
-        }
         sleepAssertion?.stop()
         sleepAssertion = sleepAssertionFactory()
         startHeartbeat(intervalSeconds: interval)
+        await completeSuccessfulAutoupdateIfPending()
         try await sendStateUpdate(state: nil, reason: reason)
+        if let recommended = payload["recommended_binary_version"] as? String {
+            if let parsed = try? AutoUpdateRecommendation.validate(recommended),
+               SelfUpdate.compareSemver(Self.binaryVersion, parsed.normalized) == .orderedAscending,
+               !autoupdateTrustState.isEligible
+            {
+                print("A newer version is available (v\(parsed.normalized)). Run 'macprovider-cli update' to upgrade.")
+            }
+            await runAutoupdateIfEligible(recommended)
+        }
     }
 
     private static func emitClaimURLHandoffEvent(error: Error) {
@@ -1251,6 +1306,38 @@ actor CoordinatorClient {
             FileHandle.standardError.write(data)
         } catch {
             FileHandle.standardError.write(Data("{\"event\":\"claim_url_handoff_failed\"}\n".utf8))
+        }
+    }
+
+    private func completeSuccessfulAutoupdateIfPending() async {
+        let markerStore = AutoUpdateMarkerStore()
+        guard let marker = try? markerStore.readPending(),
+              marker.targetVersion == Self.binaryVersion
+        else {
+            return
+        }
+        do {
+            try markerStore.completeSuccessfulUpdate(marker)
+            await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                updateID: marker.updateID,
+                currentVersion: Self.binaryVersion,
+                targetVersion: marker.targetVersion,
+                phase: .postStart,
+                outcome: .success,
+                reason: "post_start_rejoin_succeeded",
+                attempt: 1
+            ))
+        } catch {
+            await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                updateID: marker.updateID,
+                currentVersion: Self.binaryVersion,
+                targetVersion: marker.targetVersion,
+                phase: .postStart,
+                outcome: .failure,
+                reason: "post_start_success_cleanup_failed: \(error)",
+                attempt: 1,
+                failureClass: .other
+            ))
         }
     }
 
@@ -1541,6 +1628,70 @@ actor CoordinatorClient {
         await providerStatus.setState(.ready)
     }
 
+    private func runAutoupdateIfEligible(_ recommended: String) async {
+        if let parsed = try? AutoUpdateRecommendation.validate(recommended) {
+            guard !autoupdateAttemptedTargets.contains(parsed.normalized) else {
+                await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                    updateID: UUID().uuidString.lowercased(),
+                    currentVersion: Self.binaryVersion,
+                    targetVersion: parsed.normalized,
+                    phase: .cooldown,
+                    outcome: .skipped,
+                    reason: "already_attempted_this_session",
+                    attempt: 1
+                ))
+                return
+            }
+            autoupdateAttemptedTargets.insert(parsed.normalized)
+        }
+        let updater = AutoUpdater(
+            config: appConfig,
+            currentVersion: Self.binaryVersion,
+            providerStatus: providerStatus,
+            trustProvider: { await self.currentAutoupdateTrustState() },
+            drain: { target in try await self.autoupdateDrain(target: target) },
+            sendReady: { try await self.sendStateUpdate(state: .ready, reason: "autoupdate_timeout_skipped_ready") }
+        )
+        await updater.handleCoordinatorRecommendation(recommended)
+    }
+
+    private func currentAutoupdateTrustState() -> AutoUpdateTrustState {
+        autoupdateTrustState
+    }
+
+    private func autoupdateDrain(target: String) async throws -> Bool {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        heartbeatWatchdogTask?.cancel()
+        heartbeatWatchdogTask = nil
+        try await sendStateUpdate(state: .draining, reason: "autoupdate_to_\(target)")
+        try await sendDrainStatus(phase: "starting")
+        try await sendDrainStatus(phase: "in_progress")
+        let softDrained = await providerStatus.waitUntilDrained(timeoutSeconds: 120)
+        if softDrained {
+            try await sendDrainStatus(phase: "complete")
+            return true
+        }
+        let snapshot = await providerStatus.snapshot()
+        await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+            updateID: UUID().uuidString.lowercased(),
+            currentVersion: Self.binaryVersion,
+            targetVersion: target,
+            phase: .drain,
+            outcome: .inProgress,
+            reason: "soft_drain_timeout",
+            attempt: 1,
+            inflightRequests: snapshot.requestsInFlight
+        ))
+        let hardDrained = await providerStatus.waitUntilDrained(timeoutSeconds: 30)
+        if hardDrained {
+            try await sendDrainStatus(phase: "complete")
+            return true
+        }
+        try await sendDrainStatus(phase: autoupdateDrainExtensions ? "timeout_skipped" : "complete")
+        return false
+    }
+
     // resetWindow=true rolls the since-last metrics window (the coordinator-
     // interval heartbeat). Intermediate keepalive heartbeats (sent on the short
     // sub-interval tick to keep the connection alive) pass resetWindow=false so
@@ -1571,6 +1722,9 @@ actor CoordinatorClient {
             }
             payload["loading"] = runtimeSnapshot.state == .loading || runtimeSnapshot.state == .draining
         }
+        if let event = await AutoUpdateEventStore.shared.lastWireObject() {
+            payload["last_autoupdate_event"] = event
+        }
         try await send(payload)
     }
 
@@ -1579,7 +1733,7 @@ actor CoordinatorClient {
             await providerStatus.setState(newState)
         }
         let snapshot = await providerStatus.snapshot()
-        try await send([
+        var payload: [String: Any] = [
             "type": "state_update",
             "state": snapshot.status.rawValue,
             "reason": reason,
@@ -1591,7 +1745,11 @@ actor CoordinatorClient {
                 "avg_latency_ms_since_last": nullableNumber(snapshot.avgLatencyMSSinceLast),
                 "throughput_tps_since_last": nullableNumber(snapshot.throughputTPSSinceLast),
             ],
-        ])
+        ]
+        if let event = await AutoUpdateEventStore.shared.lastWireObject() {
+            payload["last_autoupdate_event"] = event
+        }
+        try await send(payload)
     }
 
     private func sendDrainStatus(phase: String) async throws {
@@ -1805,17 +1963,6 @@ actor CoordinatorClient {
         return value
     }
 
-    private static func compareSemver(_ lhs: String, _ rhs: String) -> ComparisonResult {
-        let left = lhs.trimmingCharacters(in: CharacterSet(charactersIn: "vV")).split(separator: ".").map { Int($0) ?? 0 }
-        let right = rhs.trimmingCharacters(in: CharacterSet(charactersIn: "vV")).split(separator: ".").map { Int($0) ?? 0 }
-        for index in 0 ..< max(left.count, right.count) {
-            let l = index < left.count ? left[index] : 0
-            let r = index < right.count ? right[index] : 0
-            if l < r { return .orderedAscending }
-            if l > r { return .orderedDescending }
-        }
-        return .orderedSame
-    }
 }
 
 extension CoordinatorClient: ReceiptKeyRotatingCoordinatorClient {}

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -224,6 +224,7 @@ actor CoordinatorClient {
     private var autoupdateCoordinatorPayloadIsV2 = false
     private var autoupdateAssignedProviderTokenAdopted = false
     private var autoupdateDemotionReason: String?
+    private var autoupdateDisabledForSessionReason: String?
     private var autoupdateDrainExtensions = false
     private var autoupdateAttemptedTargets = Set<String>()
     private var webSocket: ProviderWebSocketTask?
@@ -327,6 +328,7 @@ actor CoordinatorClient {
         autoupdateCoordinatorPayloadIsV2 = false
         autoupdateAssignedProviderTokenAdopted = false
         autoupdateDemotionReason = "coordinator_disconnected"
+        autoupdateDisabledForSessionReason = nil
         autoupdateTrustState = AutoUpdateTrustState(
             v2Accepted: false,
             tier: nil,
@@ -1306,27 +1308,32 @@ actor CoordinatorClient {
         sleepAssertion?.stop()
         sleepAssertion = sleepAssertionFactory()
         startHeartbeat(intervalSeconds: interval)
-        await completeSuccessfulAutoupdateIfPending()
+        let completedAutoupdate = await completeSuccessfulAutoupdateIfPending()
         try await sendStateUpdate(state: nil, reason: reason)
+        if let completedAutoupdate {
+            try? AutoUpdateMarkerStore().finalizeSuccessfulUpdate(completedAutoupdate)
+        }
         if let recommended = payload["recommended_binary_version"] as? String {
             let trust = currentAutoupdateTrustState()
-            if let parsed = try? AutoUpdateRecommendation.validate(recommended),
-               SelfUpdate.compareSemver(Self.binaryVersion, parsed.normalized) == .orderedAscending,
-               !trust.isEligible
-            {
-                print("A newer version is available (v\(parsed.normalized)). Run 'macprovider-cli update' to upgrade.")
+            guard trust.isEligible else {
+                let parsed = try? AutoUpdateRecommendation.validate(recommended)
+                if let parsed,
+                   SelfUpdate.compareSemver(Self.binaryVersion, parsed.normalized) == .orderedAscending
+                {
+                    print("A newer version is available (v\(parsed.normalized)). Run 'macprovider-cli update' to upgrade.")
+                }
                 await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
                     updateID: UUID().uuidString.lowercased(),
                     currentVersion: Self.binaryVersion,
-                    targetVersion: parsed.normalized,
+                    targetVersion: parsed?.normalized ?? "<notify-only>",
                     phase: .eligibility,
                     outcome: .skipped,
                     reason: trust.lossReason,
                     attempt: 1
                 ))
-            } else {
-                await runAutoupdateIfEligible(recommended)
+                return
             }
+            await runAutoupdateIfEligible(recommended)
         }
     }
 
@@ -1344,12 +1351,12 @@ actor CoordinatorClient {
         }
     }
 
-    private func completeSuccessfulAutoupdateIfPending() async {
+    private func completeSuccessfulAutoupdateIfPending() async -> AutoUpdatePendingMarker? {
         let markerStore = AutoUpdateMarkerStore()
         guard let marker = try? markerStore.readPending(),
               marker.targetVersion == Self.binaryVersion
         else {
-            return
+            return nil
         }
         do {
             try markerStore.completeSuccessfulUpdate(marker)
@@ -1362,7 +1369,7 @@ actor CoordinatorClient {
                 reason: "post_start_rejoin_succeeded",
                 attempt: 1
             ))
-            try markerStore.finalizeSuccessfulUpdate(marker)
+            return marker
         } catch {
             await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
                 updateID: marker.updateID,
@@ -1374,6 +1381,7 @@ actor CoordinatorClient {
                 attempt: 1,
                 failureClass: .other
             ))
+            return nil
         }
     }
 
@@ -1385,14 +1393,14 @@ actor CoordinatorClient {
         do {
             pending = try markerStore.readPending()
         } catch {
-            markerStore.orphanPendingMarker(target: nil)
+            markerStore.recoverInvalidPendingMarker()
             await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
                 updateID: UUID().uuidString.lowercased(),
                 currentVersion: Self.binaryVersion,
                 targetVersion: "<invalid>",
                 phase: .rollback,
                 outcome: .failure,
-                reason: "orphaned_pending_marker_malformed",
+                reason: "marker_invalid",
                 attempt: 1,
                 failureClass: .orphanedPendingMarker
             ))
@@ -1402,17 +1410,12 @@ actor CoordinatorClient {
             do {
                 let payload = try markerStore.readSuccessSentinel(sentinel)
                 if payload.binaryVersion == Self.binaryVersion {
-                    let marker = pending ?? AutoUpdatePendingMarker(
-                        updateID: payload.updateID,
-                        targetVersion: Self.binaryVersion,
-                        targetPath: binaryURL.path,
-                        backupPath: markerStore.rollbackBackupPath(binaryURL: binaryURL, updateID: payload.updateID).path,
-                        size: 0,
-                        mode: 0o755,
-                        sha256: String(repeating: "0", count: 64),
-                        markerDeadline: Self.autoupdateTimestamp(Date().addingTimeInterval(300))
-                    )
-                    try? markerStore.finalizeSuccessfulUpdate(marker)
+                    if let pending {
+                        try? markerStore.completeSuccessfulUpdate(pending)
+                        try? markerStore.finalizeSuccessfulUpdate(pending)
+                    } else {
+                        markerStore.finalizeSuccessfulUpdate(updateID: payload.updateID, binaryURL: binaryURL)
+                    }
                     await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
                         updateID: payload.updateID,
                         currentVersion: Self.binaryVersion,
@@ -1440,18 +1443,47 @@ actor CoordinatorClient {
             }
         }
         if let marker = pending {
-            if !FileManager.default.fileExists(atPath: markerStore.lockURL.path) {
-                markerStore.orphanPendingMarker(target: marker.targetVersion)
-                await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
-                    updateID: marker.updateID,
-                    currentVersion: Self.binaryVersion,
-                    targetVersion: marker.targetVersion,
-                    phase: .rollback,
-                    outcome: .failure,
-                    reason: "orphaned_pending_marker_recovered",
-                    attempt: 1,
-                    failureClass: .orphanedPendingMarker
-                ))
+            guard Self.autoupdateMarkerDeadlineExpired(marker.markerDeadline) else {
+                return
+            }
+            if !markerStore.updateLockIsLive() {
+                let outcome = markerStore.recoverOrphanedMarker(marker)
+                switch outcome {
+                case .restored(let recovered):
+                    await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                        updateID: recovered.updateID,
+                        currentVersion: Self.binaryVersion,
+                        targetVersion: recovered.targetVersion,
+                        phase: .rollback,
+                        outcome: .failure,
+                        reason: "orphaned_pending_marker_recovered",
+                        attempt: 1,
+                        failureClass: .orphanedPendingMarker
+                    ))
+                case .markerInvalid:
+                    await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                        updateID: UUID().uuidString.lowercased(),
+                        currentVersion: Self.binaryVersion,
+                        targetVersion: "<invalid>",
+                        phase: .rollback,
+                        outcome: .failure,
+                        reason: "marker_invalid",
+                        attempt: 1,
+                        failureClass: .orphanedPendingMarker
+                    ))
+                case let .backupCorrupt(recovered, reason):
+                    autoupdateDisabledForSessionReason = "rollback_backup_corrupt"
+                    await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                        updateID: recovered.updateID,
+                        currentVersion: Self.binaryVersion,
+                        targetVersion: recovered.targetVersion,
+                        phase: .rollback,
+                        outcome: .failure,
+                        reason: reason,
+                        attempt: 1,
+                        failureClass: .rollbackBackupCorrupt
+                    ))
+                }
             }
         } else {
             for backup in markerStore.rollbackBackups(in: binaryDir) {
@@ -1788,6 +1820,20 @@ actor CoordinatorClient {
     }
 
     private func currentAutoupdateTrustState() -> AutoUpdateTrustState {
+        if let reason = autoupdateDisabledForSessionReason {
+            return AutoUpdateTrustState(
+                v2Accepted: false,
+                tier: nil,
+                encryptedLegValid: false,
+                attestationRequired: false,
+                attestationSatisfied: false,
+                tokenConfigured: providerToken?.isEmpty == false,
+                tokenValidated: false,
+                bearerlessDuplicate: false,
+                connected: false,
+                stableReason: reason
+            )
+        }
         guard !autoupdateCoordinatorPayload.isEmpty else {
             return AutoUpdateTrustState(
                 v2Accepted: false,
@@ -1887,6 +1933,16 @@ actor CoordinatorClient {
         formatter.formatOptions = [.withInternetDateTime]
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter.string(from: date)
+    }
+
+    private static func autoupdateMarkerDeadlineExpired(_ raw: String) -> Bool {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let deadline = formatter.date(from: raw) else {
+            return true
+        }
+        return Date() >= deadline
     }
 
     private func autoupdateDrain(target: String) async throws -> Bool {

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -1308,10 +1308,12 @@ actor CoordinatorClient {
         sleepAssertion?.stop()
         sleepAssertion = sleepAssertionFactory()
         startHeartbeat(intervalSeconds: interval)
-        let completedAutoupdate = await completeSuccessfulAutoupdateIfPending()
+        let completedAutoupdate = await pendingSuccessfulAutoupdate()
         try await sendStateUpdate(state: nil, reason: reason)
         if let completedAutoupdate {
-            try? AutoUpdateMarkerStore().finalizeSuccessfulUpdate(completedAutoupdate)
+            let markerStore = AutoUpdateMarkerStore()
+            try? markerStore.completeSuccessfulUpdate(completedAutoupdate)
+            try? markerStore.finalizeSuccessfulUpdate(completedAutoupdate)
         }
         if let recommended = payload["recommended_binary_version"] as? String {
             let trust = currentAutoupdateTrustState()
@@ -1351,43 +1353,34 @@ actor CoordinatorClient {
         }
     }
 
-    private func completeSuccessfulAutoupdateIfPending() async -> AutoUpdatePendingMarker? {
-        let markerStore = AutoUpdateMarkerStore()
+    private func pendingSuccessfulAutoupdate(markerStore: AutoUpdateMarkerStore = AutoUpdateMarkerStore()) async -> AutoUpdatePendingMarker? {
         guard let marker = try? markerStore.readPending(),
               marker.targetVersion == Self.binaryVersion
         else {
             return nil
         }
-        do {
-            try markerStore.completeSuccessfulUpdate(marker)
-            await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
-                updateID: marker.updateID,
-                currentVersion: Self.binaryVersion,
-                targetVersion: marker.targetVersion,
-                phase: .postStart,
-                outcome: .success,
-                reason: "post_start_rejoin_succeeded",
-                attempt: 1
-            ))
-            return marker
-        } catch {
-            await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
-                updateID: marker.updateID,
-                currentVersion: Self.binaryVersion,
-                targetVersion: marker.targetVersion,
-                phase: .postStart,
-                outcome: .failure,
-                reason: "post_start_success_cleanup_failed: \(error)",
-                attempt: 1,
-                failureClass: .other
-            ))
-            return nil
-        }
+        await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+            updateID: marker.updateID,
+            currentVersion: Self.binaryVersion,
+            targetVersion: marker.targetVersion,
+            phase: .postStart,
+            outcome: .success,
+            reason: "post_start_rejoin_succeeded",
+            attempt: 1
+        ))
+        return marker
     }
 
     private func runStartupAutoupdateRecovery() async {
-        let markerStore = AutoUpdateMarkerStore()
         guard let binaryURL = Bundle.main.executableURL else { return }
+        await runStartupAutoupdateRecovery(binaryURL: binaryURL, markerStore: AutoUpdateMarkerStore())
+    }
+
+    func runStartupAutoupdateRecoveryForTest(binaryURL: URL, markerStore: AutoUpdateMarkerStore) async {
+        await runStartupAutoupdateRecovery(binaryURL: binaryURL, markerStore: markerStore)
+    }
+
+    private func runStartupAutoupdateRecovery(binaryURL: URL, markerStore: AutoUpdateMarkerStore) async {
         let binaryDir = binaryURL.deletingLastPathComponent()
         let pending: AutoUpdatePendingMarker?
         do {
@@ -1407,39 +1400,64 @@ actor CoordinatorClient {
             return
         }
         for sentinel in markerStore.successSentinels(in: binaryDir) {
+            let payload: (updateID: String, binaryVersion: String)
             do {
-                let payload = try markerStore.readSuccessSentinel(sentinel)
-                if payload.binaryVersion == Self.binaryVersion {
-                    if let pending {
-                        try? markerStore.completeSuccessfulUpdate(pending)
-                        try? markerStore.finalizeSuccessfulUpdate(pending)
-                    } else {
-                        markerStore.finalizeSuccessfulUpdate(updateID: payload.updateID, binaryURL: binaryURL)
-                    }
-                    await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
-                        updateID: payload.updateID,
-                        currentVersion: Self.binaryVersion,
-                        targetVersion: Self.binaryVersion,
-                        phase: .postStart,
-                        outcome: .success,
-                        reason: "success_sentinel_cleanup_completed",
-                        attempt: 1
-                    ))
-                } else {
-                    try? FileManager.default.removeItem(at: sentinel)
-                    await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
-                        updateID: payload.updateID,
-                        currentVersion: Self.binaryVersion,
-                        targetVersion: payload.binaryVersion,
-                        phase: .postStart,
-                        outcome: .failure,
-                        reason: "success_sentinel_version_mismatch",
-                        attempt: 1,
-                        failureClass: .orphanedSuccessSentinel
-                    ))
-                }
+                payload = try markerStore.readSuccessSentinel(sentinel)
             } catch {
                 try? FileManager.default.removeItem(at: sentinel)
+                continue
+            }
+            guard payload.binaryVersion == Self.binaryVersion else {
+                await recordOrphanedSuccessSentinel(
+                    updateID: payload.updateID,
+                    targetVersion: payload.binaryVersion,
+                    reason: "binary_version_mismatch",
+                    sentinel: sentinel
+                )
+                continue
+            }
+            guard let pending else {
+                await recordOrphanedSuccessSentinel(
+                    updateID: payload.updateID,
+                    targetVersion: payload.binaryVersion,
+                    reason: "no_matching_pending",
+                    sentinel: sentinel
+                )
+                continue
+            }
+            guard pending.updateID == payload.updateID else {
+                await recordOrphanedSuccessSentinel(
+                    updateID: payload.updateID,
+                    targetVersion: payload.binaryVersion,
+                    reason: "update_id_mismatch",
+                    sentinel: sentinel
+                )
+                continue
+            }
+            await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                updateID: payload.updateID,
+                currentVersion: Self.binaryVersion,
+                targetVersion: pending.targetVersion,
+                phase: .postStart,
+                outcome: .success,
+                reason: "post_start_rejoin_succeeded",
+                attempt: 1
+            ))
+            do {
+                try await sendStateUpdate(state: nil, reason: "autoupdate_post_start_success")
+                try markerStore.completeSuccessfulUpdate(pending)
+                try markerStore.finalizeSuccessfulUpdate(pending)
+            } catch {
+                await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                    updateID: payload.updateID,
+                    currentVersion: Self.binaryVersion,
+                    targetVersion: pending.targetVersion,
+                    phase: .postStart,
+                    outcome: .failure,
+                    reason: "post_start_success_publish_or_cleanup_failed",
+                    attempt: 1,
+                    failureClass: .other
+                ))
             }
         }
         if let marker = pending {
@@ -1490,6 +1508,20 @@ actor CoordinatorClient {
                 try? FileManager.default.removeItem(at: backup)
             }
         }
+    }
+
+    private func recordOrphanedSuccessSentinel(updateID: String, targetVersion: String, reason: String, sentinel: URL) async {
+        try? FileManager.default.removeItem(at: sentinel)
+        await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+            updateID: updateID,
+            currentVersion: Self.binaryVersion,
+            targetVersion: targetVersion,
+            phase: .postStart,
+            outcome: .failure,
+            reason: reason,
+            attempt: 1,
+            failureClass: .orphanedSuccessSentinel
+        ))
     }
 
     // Provider WS keepalive fix. The coordinator advertises heartbeat_interval_s

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -220,6 +220,10 @@ actor CoordinatorClient {
         bearerlessDuplicate: false,
         connected: false
     )
+    private var autoupdateCoordinatorPayload: [String: Any] = [:]
+    private var autoupdateCoordinatorPayloadIsV2 = false
+    private var autoupdateAssignedProviderTokenAdopted = false
+    private var autoupdateDemotionReason: String?
     private var autoupdateDrainExtensions = false
     private var autoupdateAttemptedTargets = Set<String>()
     private var webSocket: ProviderWebSocketTask?
@@ -298,7 +302,8 @@ actor CoordinatorClient {
         self.watchdogExitHook = watchdogExitHook
     }
 
-    func start() {
+    func start() async {
+        await runStartupAutoupdateRecovery()
         startReconnectTask()
         if warmSwapEnabled, swapHeartbeatTask == nil {
             swapHeartbeatTask = Task { [weak self] in
@@ -318,6 +323,10 @@ actor CoordinatorClient {
         inferenceRelay = nil
         tier2Session = nil
         webSocket?.cancel(with: .goingAway, reason: nil)
+        autoupdateCoordinatorPayload = [:]
+        autoupdateCoordinatorPayloadIsV2 = false
+        autoupdateAssignedProviderTokenAdopted = false
+        autoupdateDemotionReason = "coordinator_disconnected"
         autoupdateTrustState = AutoUpdateTrustState(
             v2Accepted: false,
             tier: nil,
@@ -754,10 +763,17 @@ actor CoordinatorClient {
             tier2Session: session,
             receiptBuilder: receiptBuilder,
             receiptProviderID: providerID,
+            demoteAutoupdateTrust: { [weak self] reason in
+                await self?.markAutoupdateTrustDemoted(reason: reason)
+            },
             sendFrame: { payload in
                 try await Self.send(payload, to: socket)
             }
         )
+    }
+
+    private func markAutoupdateTrustDemoted(reason: String) {
+        autoupdateDemotionReason = reason
     }
 
     private func runAuthenticatedSocketThenReconnect(_ socket: ProviderWebSocketTask) async {
@@ -913,6 +929,10 @@ actor CoordinatorClient {
         tier2Session = nil
         webSocket?.cancel(with: .goingAway, reason: nil)
         webSocket = nil
+        autoupdateCoordinatorPayload = [:]
+        autoupdateCoordinatorPayloadIsV2 = false
+        autoupdateAssignedProviderTokenAdopted = false
+        autoupdateDemotionReason = "coordinator_disconnected"
         autoupdateTrustState = AutoUpdateTrustState(
             v2Accepted: false,
             tier: nil,
@@ -1261,6 +1281,10 @@ actor CoordinatorClient {
         }
         let interval = max(Self.intValue(payload["heartbeat_interval_s"]) ?? 30, 1)
         let isV2 = payload["type"] as? String == "auth_response" && payload["status"] as? String == "accepted"
+        autoupdateCoordinatorPayload = payload
+        autoupdateCoordinatorPayloadIsV2 = isV2
+        autoupdateAssignedProviderTokenAdopted = assignedProviderTokenAdopted
+        autoupdateDemotionReason = nil
         autoupdateTrustState = AutoUpdateTrustState.fromCoordinatorPayload(
             payload,
             isV2: isV2,
@@ -1285,13 +1309,24 @@ actor CoordinatorClient {
         await completeSuccessfulAutoupdateIfPending()
         try await sendStateUpdate(state: nil, reason: reason)
         if let recommended = payload["recommended_binary_version"] as? String {
+            let trust = currentAutoupdateTrustState()
             if let parsed = try? AutoUpdateRecommendation.validate(recommended),
                SelfUpdate.compareSemver(Self.binaryVersion, parsed.normalized) == .orderedAscending,
-               !autoupdateTrustState.isEligible
+               !trust.isEligible
             {
                 print("A newer version is available (v\(parsed.normalized)). Run 'macprovider-cli update' to upgrade.")
+                await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                    updateID: UUID().uuidString.lowercased(),
+                    currentVersion: Self.binaryVersion,
+                    targetVersion: parsed.normalized,
+                    phase: .eligibility,
+                    outcome: .skipped,
+                    reason: trust.lossReason,
+                    attempt: 1
+                ))
+            } else {
+                await runAutoupdateIfEligible(recommended)
             }
-            await runAutoupdateIfEligible(recommended)
         }
     }
 
@@ -1327,6 +1362,7 @@ actor CoordinatorClient {
                 reason: "post_start_rejoin_succeeded",
                 attempt: 1
             ))
+            try markerStore.finalizeSuccessfulUpdate(marker)
         } catch {
             await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
                 updateID: marker.updateID,
@@ -1338,6 +1374,89 @@ actor CoordinatorClient {
                 attempt: 1,
                 failureClass: .other
             ))
+        }
+    }
+
+    private func runStartupAutoupdateRecovery() async {
+        let markerStore = AutoUpdateMarkerStore()
+        guard let binaryURL = Bundle.main.executableURL else { return }
+        let binaryDir = binaryURL.deletingLastPathComponent()
+        let pending: AutoUpdatePendingMarker?
+        do {
+            pending = try markerStore.readPending()
+        } catch {
+            markerStore.orphanPendingMarker(target: nil)
+            await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                updateID: UUID().uuidString.lowercased(),
+                currentVersion: Self.binaryVersion,
+                targetVersion: "<invalid>",
+                phase: .rollback,
+                outcome: .failure,
+                reason: "orphaned_pending_marker_malformed",
+                attempt: 1,
+                failureClass: .orphanedPendingMarker
+            ))
+            return
+        }
+        for sentinel in markerStore.successSentinels(in: binaryDir) {
+            do {
+                let payload = try markerStore.readSuccessSentinel(sentinel)
+                if payload.binaryVersion == Self.binaryVersion {
+                    let marker = pending ?? AutoUpdatePendingMarker(
+                        updateID: payload.updateID,
+                        targetVersion: Self.binaryVersion,
+                        targetPath: binaryURL.path,
+                        backupPath: markerStore.rollbackBackupPath(binaryURL: binaryURL, updateID: payload.updateID).path,
+                        size: 0,
+                        mode: 0o755,
+                        sha256: String(repeating: "0", count: 64),
+                        markerDeadline: Self.autoupdateTimestamp(Date().addingTimeInterval(300))
+                    )
+                    try? markerStore.finalizeSuccessfulUpdate(marker)
+                    await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                        updateID: payload.updateID,
+                        currentVersion: Self.binaryVersion,
+                        targetVersion: Self.binaryVersion,
+                        phase: .postStart,
+                        outcome: .success,
+                        reason: "success_sentinel_cleanup_completed",
+                        attempt: 1
+                    ))
+                } else {
+                    try? FileManager.default.removeItem(at: sentinel)
+                    await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                        updateID: payload.updateID,
+                        currentVersion: Self.binaryVersion,
+                        targetVersion: payload.binaryVersion,
+                        phase: .postStart,
+                        outcome: .failure,
+                        reason: "success_sentinel_version_mismatch",
+                        attempt: 1,
+                        failureClass: .orphanedSuccessSentinel
+                    ))
+                }
+            } catch {
+                try? FileManager.default.removeItem(at: sentinel)
+            }
+        }
+        if let marker = pending {
+            if !FileManager.default.fileExists(atPath: markerStore.lockURL.path) {
+                markerStore.orphanPendingMarker(target: marker.targetVersion)
+                await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                    updateID: marker.updateID,
+                    currentVersion: Self.binaryVersion,
+                    targetVersion: marker.targetVersion,
+                    phase: .rollback,
+                    outcome: .failure,
+                    reason: "orphaned_pending_marker_recovered",
+                    attempt: 1,
+                    failureClass: .orphanedPendingMarker
+                ))
+            }
+        } else {
+            for backup in markerStore.rollbackBackups(in: binaryDir) {
+                try? FileManager.default.removeItem(at: backup)
+            }
         }
     }
 
@@ -1630,6 +1749,19 @@ actor CoordinatorClient {
 
     private func runAutoupdateIfEligible(_ recommended: String) async {
         if let parsed = try? AutoUpdateRecommendation.validate(recommended) {
+            let trust = currentAutoupdateTrustState()
+            guard trust.isEligible else {
+                await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                    updateID: UUID().uuidString.lowercased(),
+                    currentVersion: Self.binaryVersion,
+                    targetVersion: parsed.normalized,
+                    phase: .eligibility,
+                    outcome: .skipped,
+                    reason: trust.lossReason,
+                    attempt: 1
+                ))
+                return
+            }
             guard !autoupdateAttemptedTargets.contains(parsed.normalized) else {
                 await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
                     updateID: UUID().uuidString.lowercased(),
@@ -1656,7 +1788,105 @@ actor CoordinatorClient {
     }
 
     private func currentAutoupdateTrustState() -> AutoUpdateTrustState {
-        autoupdateTrustState
+        guard !autoupdateCoordinatorPayload.isEmpty else {
+            return AutoUpdateTrustState(
+                v2Accepted: false,
+                tier: nil,
+                encryptedLegValid: false,
+                attestationRequired: false,
+                attestationSatisfied: false,
+                tokenConfigured: providerToken?.isEmpty == false,
+                tokenValidated: providerToken?.isEmpty == false,
+                bearerlessDuplicate: false,
+                connected: false,
+                stableReason: autoupdateDemotionReason ?? "coordinator_disconnected"
+            )
+        }
+        var state = AutoUpdateTrustState.fromCoordinatorPayload(
+            autoupdateCoordinatorPayload,
+            isV2: autoupdateCoordinatorPayloadIsV2,
+            session: tier2Session,
+            providerToken: providerToken,
+            assignedProviderTokenAdopted: autoupdateAssignedProviderTokenAdopted
+        )
+        if let reason = autoupdateDemotionReason {
+            switch reason {
+            case "encrypted_leg_invalidated":
+                state = AutoUpdateTrustState(
+                    v2Accepted: state.v2Accepted,
+                    tier: state.tier,
+                    encryptedLegValid: false,
+                    attestationRequired: state.attestationRequired,
+                    attestationSatisfied: state.attestationSatisfied,
+                    tokenConfigured: state.tokenConfigured,
+                    tokenValidated: state.tokenValidated,
+                    bearerlessDuplicate: state.bearerlessDuplicate,
+                    connected: state.connected,
+                    stableReason: reason
+                )
+            case "tier_demoted":
+                state = AutoUpdateTrustState(
+                    v2Accepted: state.v2Accepted,
+                    tier: "provisional",
+                    encryptedLegValid: state.encryptedLegValid,
+                    attestationRequired: state.attestationRequired,
+                    attestationSatisfied: state.attestationSatisfied,
+                    tokenConfigured: state.tokenConfigured,
+                    tokenValidated: state.tokenValidated,
+                    bearerlessDuplicate: state.bearerlessDuplicate,
+                    connected: state.connected,
+                    stableReason: reason
+                )
+            case "token_revoked":
+                state = AutoUpdateTrustState(
+                    v2Accepted: state.v2Accepted,
+                    tier: state.tier,
+                    encryptedLegValid: state.encryptedLegValid,
+                    attestationRequired: state.attestationRequired,
+                    attestationSatisfied: state.attestationSatisfied,
+                    tokenConfigured: true,
+                    tokenValidated: false,
+                    bearerlessDuplicate: state.bearerlessDuplicate,
+                    connected: state.connected,
+                    stableReason: reason
+                )
+            case "attestation_state_degraded":
+                state = AutoUpdateTrustState(
+                    v2Accepted: state.v2Accepted,
+                    tier: state.tier,
+                    encryptedLegValid: state.encryptedLegValid,
+                    attestationRequired: true,
+                    attestationSatisfied: false,
+                    tokenConfigured: state.tokenConfigured,
+                    tokenValidated: state.tokenValidated,
+                    bearerlessDuplicate: state.bearerlessDuplicate,
+                    connected: state.connected,
+                    stableReason: reason
+                )
+            default:
+                state = AutoUpdateTrustState(
+                    v2Accepted: state.v2Accepted,
+                    tier: state.tier,
+                    encryptedLegValid: state.encryptedLegValid,
+                    attestationRequired: state.attestationRequired,
+                    attestationSatisfied: state.attestationSatisfied,
+                    tokenConfigured: state.tokenConfigured,
+                    tokenValidated: state.tokenValidated,
+                    bearerlessDuplicate: state.bearerlessDuplicate,
+                    connected: false,
+                    stableReason: reason
+                )
+            }
+        }
+        autoupdateTrustState = state
+        return state
+    }
+
+    private static func autoupdateTimestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: date)
     }
 
     private func autoupdateDrain(target: String) async throws -> Bool {

--- a/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
+++ b/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
@@ -3,6 +3,7 @@ import MacProviderCore
 
 actor InferenceRelay {
     typealias SendFrame = @Sendable (sending [String: Any]) async throws -> Void
+    typealias TrustDemotion = @Sendable (_ reason: String) async -> Void
 
     private struct ActiveRequest {
         let task: Task<Void, Never>
@@ -19,6 +20,7 @@ actor InferenceRelay {
     private let tier2Session: Tier2ProviderSession?
     private let receiptBuilder: ReceiptBuilder?
     private let receiptProviderID: String?
+    private let demoteAutoupdateTrust: TrustDemotion?
     private var active: [String: ActiveRequest] = [:]
 
     init(
@@ -31,6 +33,7 @@ actor InferenceRelay {
         tier2Session: Tier2ProviderSession? = nil,
         receiptBuilder: ReceiptBuilder? = nil,
         receiptProviderID: String? = nil,
+        demoteAutoupdateTrust: TrustDemotion? = nil,
         sendFrame: @escaping SendFrame
     ) {
         self.modelRuntime = modelRuntime
@@ -42,6 +45,7 @@ actor InferenceRelay {
         self.tier2Session = tier2Session
         self.receiptBuilder = receiptBuilder
         self.receiptProviderID = receiptProviderID
+        self.demoteAutoupdateTrust = demoteAutoupdateTrust
         self.sendFrame = sendFrame
     }
 
@@ -61,6 +65,7 @@ actor InferenceRelay {
             do {
                 body = try tier2Session.openRequestBody(message: message, requestID: requestID, stream: stream)
             } catch {
+                await demoteAutoupdateTrust?("encrypted_leg_invalidated")
                 try await sendNAK(inReplyTo: requestID, code: "tier2_aead_decrypt_failed", message: "Encrypted inference_request failed authentication")
                 return
             }

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -56,6 +56,7 @@ struct SelfUpdate {
         let prepared = try await prepareValidatedUpdate(from: release)
         defer { prepared.cleanup() }
         try await applyValidatedUpdate(newBinary: prepared.newBinary)
+        persistSignedPolicyIfPresent(prepared.signedPolicy)
         print("Update complete. Restart macprovider-cli to use v\(latest).")
     }
 
@@ -64,6 +65,7 @@ struct SelfUpdate {
         let prepared = try await prepareValidatedUpdate(from: release)
         defer { prepared.cleanup() }
         try await applyValidatedUpdate(newBinary: prepared.newBinary)
+        persistSignedPolicyIfPresent(prepared.signedPolicy)
     }
 
     func resolveReleaseByTags(normalizedTarget: String) async throws -> GitHubRelease {
@@ -97,9 +99,6 @@ struct SelfUpdate {
             try await download(from: checksums.browserDownloadURL, to: checksumsURL)
             try await download(from: checksumsSignature.browserDownloadURL, to: checksumsSignatureURL)
             try verifyChecksumSignature(checksumsURL: checksumsURL, signatureURL: checksumsSignatureURL, tempDir: tempDir)
-            if let signedPolicy = release.signedPolicy {
-                markerStore.updateSignedPolicy(minimum: signedPolicy.minimum, revoked: signedPolicy.revoked)
-            }
             let checksumsText = try String(contentsOf: checksumsURL, encoding: .utf8)
             let expectedSHA = try Self.expectedSHA256(for: tarball.name, in: checksumsText)
             try await download(from: tarball.browserDownloadURL, to: tarballURL)
@@ -116,7 +115,7 @@ struct SelfUpdate {
             let newBinary = try Self.findBinary(in: extractDir)
 
             try runProcess(newBinary.path, arguments: ["self-test"])
-            return PreparedSelfUpdate(tempDir: tempDir, newBinary: newBinary)
+            return PreparedSelfUpdate(tempDir: tempDir, newBinary: newBinary, signedPolicy: release.signedPolicy)
         } catch {
             try? FileManager.default.removeItem(at: tempDir)
             throw error
@@ -125,6 +124,11 @@ struct SelfUpdate {
 
     func applyValidatedUpdateForTest(newBinary: URL) async throws {
         try await applyValidatedUpdate(newBinary: newBinary)
+    }
+
+    func persistSignedPolicyIfPresent(_ signedPolicy: GitHubSignedPolicy?) {
+        guard let signedPolicy else { return }
+        markerStore.updateSignedPolicy(minimum: signedPolicy.minimum, revoked: signedPolicy.revoked)
     }
 
     func resolvedReleasesAPIURLForTest() -> String {
@@ -413,6 +417,7 @@ struct SelfUpdate {
 struct PreparedSelfUpdate {
     let tempDir: URL
     let newBinary: URL
+    let signedPolicy: GitHubSignedPolicy?
 
     func cleanup() {
         try? FileManager.default.removeItem(at: tempDir)

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -50,6 +50,28 @@ struct SelfUpdate {
             return
         }
 
+        let prepared = try await prepareValidatedUpdate(from: release)
+        defer { prepared.cleanup() }
+        try await applyValidatedUpdate(newBinary: prepared.newBinary)
+        print("Update complete. Restart macprovider-cli to use v\(latest).")
+    }
+
+    func runByTag(tag: String) async throws {
+        let release = try await releaseByTag(tag)
+        let prepared = try await prepareValidatedUpdate(from: release)
+        defer { prepared.cleanup() }
+        try await applyValidatedUpdate(newBinary: prepared.newBinary)
+    }
+
+    func resolveReleaseByTags(normalizedTarget: String) async throws -> GitHubRelease {
+        do {
+            return try await releaseByTag("v\(normalizedTarget)")
+        } catch UpdateError.releaseNotFound {
+            return try await releaseByTag(normalizedTarget)
+        }
+    }
+
+    func prepareValidatedUpdate(from release: GitHubRelease) async throws -> PreparedSelfUpdate {
         guard let tarball = release.assets.first(where: { $0.name.hasSuffix("darwin-arm64.tar.gz") }),
               let checksums = release.assets.first(where: { $0.name == "checksums.txt" }),
               let checksumsSignature = release.assets.first(where: { $0.name == "checksums.txt.sig" })
@@ -60,37 +82,39 @@ struct SelfUpdate {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("macprovider-update-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        defer {
+
+        do {
+            try validateDownloadURL(tarball.browserDownloadURL)
+            try validateDownloadURL(checksums.browserDownloadURL)
+            try validateDownloadURL(checksumsSignature.browserDownloadURL)
+
+            let tarballURL = tempDir.appendingPathComponent(tarball.name)
+            let checksumsURL = tempDir.appendingPathComponent(checksums.name)
+            let checksumsSignatureURL = tempDir.appendingPathComponent(checksumsSignature.name)
+            try await download(from: checksums.browserDownloadURL, to: checksumsURL)
+            try await download(from: checksumsSignature.browserDownloadURL, to: checksumsSignatureURL)
+            try verifyChecksumSignature(checksumsURL: checksumsURL, signatureURL: checksumsSignatureURL, tempDir: tempDir)
+            let checksumsText = try String(contentsOf: checksumsURL, encoding: .utf8)
+            let expectedSHA = try Self.expectedSHA256(for: tarball.name, in: checksumsText)
+            try await download(from: tarball.browserDownloadURL, to: tarballURL)
+            try validateFreeSpace(for: tempDir, requiredForKnownTarballAt: tarballURL)
+            let actualSHA = try Self.sha256(file: tarballURL)
+            guard actualSHA.lowercased() == expectedSHA.lowercased() else {
+                throw UpdateError.checksumMismatch(expected: expectedSHA, actual: actualSHA)
+            }
+
+            let extractDir = tempDir.appendingPathComponent("extract", isDirectory: true)
+            try FileManager.default.createDirectory(at: extractDir, withIntermediateDirectories: true)
+            try validateTarball(tarballURL)
+            try runProcess("/usr/bin/tar", arguments: ["-xzf", tarballURL.path, "-C", extractDir.path])
+            let newBinary = try Self.findBinary(in: extractDir)
+
+            try runProcess(newBinary.path, arguments: ["self-test"])
+            return PreparedSelfUpdate(tempDir: tempDir, newBinary: newBinary)
+        } catch {
             try? FileManager.default.removeItem(at: tempDir)
+            throw error
         }
-
-        try validateDownloadURL(tarball.browserDownloadURL)
-        try validateDownloadURL(checksums.browserDownloadURL)
-        try validateDownloadURL(checksumsSignature.browserDownloadURL)
-
-        let tarballURL = tempDir.appendingPathComponent(tarball.name)
-        let checksumsURL = tempDir.appendingPathComponent(checksums.name)
-        let checksumsSignatureURL = tempDir.appendingPathComponent(checksumsSignature.name)
-        try await download(from: checksums.browserDownloadURL, to: checksumsURL)
-        try await download(from: checksumsSignature.browserDownloadURL, to: checksumsSignatureURL)
-        try verifyChecksumSignature(checksumsURL: checksumsURL, signatureURL: checksumsSignatureURL, tempDir: tempDir)
-        let checksumsText = try String(contentsOf: checksumsURL, encoding: .utf8)
-        let expectedSHA = try Self.expectedSHA256(for: tarball.name, in: checksumsText)
-        try await download(from: tarball.browserDownloadURL, to: tarballURL)
-        let actualSHA = try Self.sha256(file: tarballURL)
-        guard actualSHA.lowercased() == expectedSHA.lowercased() else {
-            throw UpdateError.checksumMismatch(expected: expectedSHA, actual: actualSHA)
-        }
-
-        let extractDir = tempDir.appendingPathComponent("extract", isDirectory: true)
-        try FileManager.default.createDirectory(at: extractDir, withIntermediateDirectories: true)
-        try validateTarball(tarballURL)
-        try runProcess("/usr/bin/tar", arguments: ["-xzf", tarballURL.path, "-C", extractDir.path])
-        let newBinary = try Self.findBinary(in: extractDir)
-
-        try runProcess(newBinary.path, arguments: ["self-test"])
-        try await applyValidatedUpdate(newBinary: newBinary)
-        print("Update complete. Restart macprovider-cli to use v\(latest).")
     }
 
     func applyValidatedUpdateForTest(newBinary: URL) async throws {
@@ -146,6 +170,45 @@ struct SelfUpdate {
             throw UpdateError.httpStatus(http.statusCode)
         }
         return try JSONDecoder().decode(GitHubRelease.self, from: data)
+    }
+
+    private func releaseByTag(_ tag: String) async throws -> GitHubRelease {
+        guard let url = releaseTagURL(tag: tag) else {
+            throw UpdateError.invalidURL(releasesAPIURL)
+        }
+        try validateReleaseAPIURL(url)
+        var request = URLRequest(url: url)
+        request.addValue("application/vnd.github+json", forHTTPHeaderField: "accept")
+        request.addValue("macprovider-cli/\(currentVersion)", forHTTPHeaderField: "user-agent")
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse {
+            if http.statusCode == 404 {
+                throw UpdateError.releaseNotFound
+            }
+            if !(200 ..< 300).contains(http.statusCode) {
+                throw UpdateError.httpStatus(http.statusCode)
+            }
+        }
+        return try JSONDecoder().decode(GitHubRelease.self, from: data)
+    }
+
+    private func releaseTagURL(tag: String) -> URL? {
+        guard var components = URLComponents(string: releasesAPIURL) else {
+            return nil
+        }
+        let escapedTag = tag.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? tag
+        if components.path.hasSuffix("/releases/latest") {
+            components.path = String(components.path.dropLast("/latest".count)) + "/tags/\(escapedTag)"
+        } else if components.path.contains("/releases/tags/") {
+            let prefix = components.path.split(separator: "/").dropLast().joined(separator: "/")
+            components.path = "/" + prefix + "/\(escapedTag)"
+        } else {
+            components.path = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/tags/\(escapedTag)"
+            if !components.path.hasPrefix("/") {
+                components.path = "/" + components.path
+            }
+        }
+        return components.url
     }
 
     private func fetchText(from url: URL) async throws -> String {
@@ -256,6 +319,16 @@ struct SelfUpdate {
         }
     }
 
+    private func validateFreeSpace(for directory: URL, requiredForKnownTarballAt tarball: URL?) throws {
+        let attrs = try FileManager.default.attributesOfFileSystem(forPath: directory.path)
+        let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value ?? 0
+        let tarballSize = tarball.flatMap { (try? FileManager.default.attributesOfItem(atPath: $0.path)[.size] as? NSNumber)?.int64Value } ?? 0
+        let required = max(512 * 1024 * 1024, tarballSize * 3)
+        guard free >= required else {
+            throw UpdateError.insufficientDiskSpace(required: required, available: free)
+        }
+    }
+
     private func verifyChecksumSignature(checksumsURL: URL, signatureURL: URL, tempDir _: URL) throws {
         do {
             let publicKey = try P256.Signing.PublicKey(pemRepresentation: Self.checksumPublicKeyPEM)
@@ -331,7 +404,16 @@ struct SelfUpdate {
     }
 }
 
-private struct GitHubRelease: Decodable {
+struct PreparedSelfUpdate {
+    let tempDir: URL
+    let newBinary: URL
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+}
+
+struct GitHubRelease: Decodable {
     let tagName: String
     let assets: [GitHubAsset]
 
@@ -341,7 +423,7 @@ private struct GitHubRelease: Decodable {
     }
 }
 
-private struct GitHubAsset: Decodable {
+struct GitHubAsset: Decodable {
     let name: String
     let browserDownloadURL: URL
 
@@ -354,6 +436,7 @@ private struct GitHubAsset: Decodable {
 enum UpdateError: Error, CustomStringConvertible {
     case invalidURL(String)
     case httpStatus(Int)
+    case releaseNotFound
     case missingAsset
     case checksumMissing(String)
     case checksumMismatch(expected: String, actual: String)
@@ -365,6 +448,7 @@ enum UpdateError: Error, CustomStringConvertible {
     case untrustedDownloadURL(String)
     case untrustedReleaseAPIURL(String)
     case unsafeArchiveEntry(String)
+    case insufficientDiskSpace(required: Int64, available: Int64)
 
     var description: String {
         switch self {
@@ -372,6 +456,8 @@ enum UpdateError: Error, CustomStringConvertible {
             return "Invalid release API URL: \(url)"
         case .httpStatus(let status):
             return "GitHub API returned HTTP \(status)"
+        case .releaseNotFound:
+            return "GitHub release tag not found"
         case .missingAsset:
             return "Release is missing darwin-arm64 tarball, checksums.txt, or checksums.txt.sig"
         case .checksumMissing(let filename):
@@ -394,6 +480,8 @@ enum UpdateError: Error, CustomStringConvertible {
             return "Untrusted release API URL: \(url)"
         case .unsafeArchiveEntry(let entry):
             return "Release archive contains unsafe entry: \(entry)"
+        case let .insufficientDiskSpace(required, available):
+            return "Insufficient disk space: required \(required), available \(available)"
         }
     }
 }

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -18,11 +18,13 @@ struct SelfUpdate {
     private let drainBeforeReplace: (() async throws -> Void)?
     private let replaceBinary: ((URL) throws -> Void)?
     private let restartLaunchd: (() throws -> Void)?
+    private let markerStore: AutoUpdateMarkerStore
 
     init(
         currentVersion: String,
         releasesAPIURL: String?,
         session: URLSession = .shared,
+        markerStore: AutoUpdateMarkerStore = AutoUpdateMarkerStore(),
         drainBeforeReplace: (() async throws -> Void)? = nil,
         replaceBinary: ((URL) throws -> Void)? = nil,
         restartLaunchd: (() throws -> Void)? = nil
@@ -30,6 +32,7 @@ struct SelfUpdate {
         self.currentVersion = currentVersion
         self.releasesAPIURL = releasesAPIURL ?? Self.defaultReleasesAPIURL
         self.session = session
+        self.markerStore = markerStore
         self.drainBeforeReplace = drainBeforeReplace
         self.replaceBinary = replaceBinary
         self.restartLaunchd = restartLaunchd
@@ -94,6 +97,9 @@ struct SelfUpdate {
             try await download(from: checksums.browserDownloadURL, to: checksumsURL)
             try await download(from: checksumsSignature.browserDownloadURL, to: checksumsSignatureURL)
             try verifyChecksumSignature(checksumsURL: checksumsURL, signatureURL: checksumsSignatureURL, tempDir: tempDir)
+            if let signedPolicy = release.signedPolicy {
+                markerStore.updateSignedPolicy(minimum: signedPolicy.minimum, revoked: signedPolicy.revoked)
+            }
             let checksumsText = try String(contentsOf: checksumsURL, encoding: .utf8)
             let expectedSHA = try Self.expectedSHA256(for: tarball.name, in: checksumsText)
             try await download(from: tarball.browserDownloadURL, to: tarballURL)
@@ -416,11 +422,51 @@ struct PreparedSelfUpdate {
 struct GitHubRelease: Decodable {
     let tagName: String
     let assets: [GitHubAsset]
+    let body: String?
+    let signedPolicy: GitHubSignedPolicy?
 
     enum CodingKeys: String, CodingKey {
         case tagName = "tag_name"
         case assets
+        case body
+        case signedPolicyMinimum = "signed_policy_minimum"
+        case signedPolicyRevoked = "signed_policy_revoked"
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        tagName = try container.decode(String.self, forKey: .tagName)
+        assets = try container.decode([GitHubAsset].self, forKey: .assets)
+        body = try container.decodeIfPresent(String.self, forKey: .body)
+        let directMinimum = try container.decodeIfPresent(String.self, forKey: .signedPolicyMinimum)
+        let directRevoked = try container.decodeIfPresent([String].self, forKey: .signedPolicyRevoked)
+        if directMinimum != nil || directRevoked != nil {
+            signedPolicy = GitHubSignedPolicy(minimum: directMinimum, revoked: directRevoked ?? [])
+        } else {
+            signedPolicy = Self.extractSignedPolicy(from: body)
+        }
+    }
+
+    private static func extractSignedPolicy(from body: String?) -> GitHubSignedPolicy? {
+        guard let body,
+              let range = body.range(of: #"```json\s*(\{[\s\S]*?"signed_policy_[\s\S]*?\})\s*```"#, options: .regularExpression)
+        else { return nil }
+        let block = String(body[range])
+            .replacingOccurrences(of: #"^```json\s*"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: #"\s*```$"#, with: "", options: .regularExpression)
+        guard let data = block.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return GitHubSignedPolicy(
+            minimum: object["signed_policy_minimum"] as? String,
+            revoked: object["signed_policy_revoked"] as? [String] ?? []
+        )
+    }
+}
+
+struct GitHubSignedPolicy: Equatable {
+    let minimum: String?
+    let revoked: [String]
 }
 
 struct GitHubAsset: Decodable {

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -56,7 +56,7 @@ struct SelfUpdate {
         let prepared = try await prepareValidatedUpdate(from: release)
         defer { prepared.cleanup() }
         try await applyValidatedUpdate(newBinary: prepared.newBinary)
-        persistSignedPolicyIfPresent(prepared.signedPolicy)
+        try await persistSignedPolicyIfPresent(prepared.signedPolicy)
         print("Update complete. Restart macprovider-cli to use v\(latest).")
     }
 
@@ -65,7 +65,7 @@ struct SelfUpdate {
         let prepared = try await prepareValidatedUpdate(from: release)
         defer { prepared.cleanup() }
         try await applyValidatedUpdate(newBinary: prepared.newBinary)
-        persistSignedPolicyIfPresent(prepared.signedPolicy)
+        try await persistSignedPolicyIfPresent(prepared.signedPolicy)
     }
 
     func resolveReleaseByTags(normalizedTarget: String) async throws -> GitHubRelease {
@@ -126,9 +126,9 @@ struct SelfUpdate {
         try await applyValidatedUpdate(newBinary: newBinary)
     }
 
-    func persistSignedPolicyIfPresent(_ signedPolicy: GitHubSignedPolicy?) {
+    func persistSignedPolicyIfPresent(_ signedPolicy: GitHubSignedPolicy?) async throws {
         guard let signedPolicy else { return }
-        markerStore.updateSignedPolicy(minimum: signedPolicy.minimum, revoked: signedPolicy.revoked)
+        try await markerStore.updateSignedPolicy(minimum: signedPolicy.minimum, revoked: signedPolicy.revoked)
     }
 
     func resolvedReleasesAPIURLForTest() -> String {

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -293,6 +293,71 @@ final class AutoUpdateTests: XCTestCase {
         XCTAssertEqual(event?["reason"] as? String, "tier_demoted")
     }
 
+    func testTrustLossBetweenAuthAndSwapAbortsAutoupdate() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        let binaryDir = fixture.url.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binaryDir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let binary = binaryDir.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: binary)
+        let status = ProviderStatus(
+            modelID: "mlx-community/Test-Model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let trustCalls = AutoUpdateCounter()
+        await AutoUpdateEventStore.shared.clear()
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.6.0",
+            providerStatus: status,
+            markerStore: store,
+            trustProvider: {
+                if trustCalls.incrementAndGet() == 1 {
+                    return AutoUpdateTrustState(
+                        v2Accepted: true,
+                        tier: "pinned",
+                        encryptedLegValid: true,
+                        attestationRequired: false,
+                        attestationSatisfied: true,
+                        tokenConfigured: true,
+                        tokenValidated: true,
+                        bearerlessDuplicate: false,
+                        connected: true
+                    )
+                }
+                return AutoUpdateTrustState(
+                    v2Accepted: true,
+                    tier: "provisional",
+                    encryptedLegValid: true,
+                    attestationRequired: false,
+                    attestationSatisfied: true,
+                    tokenConfigured: true,
+                    tokenValidated: true,
+                    bearerlessDuplicate: false,
+                    connected: true,
+                    stableReason: "tier_demoted"
+                )
+            },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            currentBinaryURL: { binary },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        await updater.handleCoordinatorRecommendation("1.7.0")
+
+        XCTAssertEqual(try String(contentsOf: binary), "old-binary")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.pendingURL.path))
+        let event = await AutoUpdateEventStore.shared.lastWireObject()
+        XCTAssertEqual(event?["failure_class"] as? String, AutoUpdateFailureClass.trustStateLost.rawValue)
+        XCTAssertEqual(event?["reason"] as? String, "tier_demoted")
+    }
+
     func testAutoupdateReasonRedactionUsesStableCodes() {
         let errors: [Error] = [
             UpdateError.invalidURL("https://example.com/update?token=secret"),
@@ -308,16 +373,16 @@ final class AutoUpdateTests: XCTestCase {
         }
     }
 
-    func testSignedPolicyPersistenceIsMonotonic() throws {
+    func testSignedPolicyPersistenceIsMonotonic() async throws {
         let fixture = try TempHome()
         let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
         try store.ensureTrustedRoot()
-        store.updateSignedPolicy(minimum: "1.7.0", revoked: ["1.6.1"])
-        store.updateSignedPolicy(minimum: "1.6.0", revoked: [])
+        try await store.updateSignedPolicy(minimum: "1.7.0", revoked: ["1.6.1"])
+        try await store.updateSignedPolicy(minimum: "1.6.0", revoked: [])
         var policy = store.effectivePolicy()
         XCTAssertEqual(policy.minimum, "1.7.0")
         XCTAssertTrue(policy.revoked.contains("1.6.1"))
-        store.updateSignedPolicy(minimum: "1.8.0", revoked: ["1.7.1"])
+        try await store.updateSignedPolicy(minimum: "1.8.0", revoked: ["1.7.1"])
         policy = store.effectivePolicy()
         XCTAssertEqual(policy.minimum, "1.8.0")
         XCTAssertTrue(policy.revoked.contains("1.6.1"))
@@ -390,6 +455,18 @@ private final class TempHome {
 
     deinit {
         try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private final class AutoUpdateCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func incrementAndGet() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+        return value
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -46,6 +46,36 @@ final class AutoUpdateTests: XCTestCase {
         XCTAssertFalse(String(data: data, encoding: .utf8)!.contains("token=secret"))
     }
 
+    func testEventPayloadTooLargeFallsBackToMinimalStablePayload() {
+        let event = AutoUpdateEvent(
+            updateID: UUID().uuidString.lowercased(),
+            currentVersion: String(repeating: "1", count: 5000),
+            targetVersion: "1.7.0",
+            phase: .rollback,
+            outcome: .failure,
+            reason: String(repeating: "oversized", count: 1200),
+            attempt: 1,
+            failureClass: .orphanedPendingMarker,
+            inflightRequests: 42,
+            recommendedBinaryVersionSHA256: String(repeating: "a", count: 5000),
+            extraMetadata: ["blob": String(repeating: "x", count: 5000)],
+            attemptHistory: [String(repeating: "y", count: 5000)],
+            releaseURL: "https://github.com/Augustas11/macprovider/releases/download/v1.7.0/a.tar.gz?token=secret"
+        )
+
+        let object = event.wireObject()
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [])
+
+        XCTAssertLessThanOrEqual(data.count, AutoUpdateEvent.maxWireBytes)
+        XCTAssertEqual(object["reason"] as? String, "event_payload_too_large")
+        XCTAssertEqual(object["failure_class"] as? String, AutoUpdateFailureClass.eventPayloadTooLarge.rawValue)
+        XCTAssertNil(object["extra_metadata"])
+        XCTAssertNil(object["attempt_history"])
+        XCTAssertNil(object["release_url"])
+        XCTAssertNil(object["inflight_requests"])
+        XCTAssertNil(object["recommended_binary_version_sha256"])
+    }
+
     func testAutoupdateOptOutReadsLegacyAndSpecSources() throws {
         let yaml = """
         coordinator_url: wss://example.invalid/ws/provider
@@ -117,11 +147,19 @@ final class AutoUpdateTests: XCTestCase {
         )
         try store.writePending(marker)
 
+        XCTAssertFalse(store.updateLockIsLive())
+        do {
+            let lock = try store.acquireLock()
+            XCTAssertTrue(store.updateLockIsLive())
+            withExtendedLifetime(lock) {}
+        }
+        XCTAssertFalse(store.updateLockIsLive())
+
         try store.completeSuccessfulUpdate(marker)
 
-        XCTAssertTrue(FileManager.default.fileExists(atPath: store.pendingURL.path))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: backup.path))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: store.lockURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.pendingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.lockURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: store.successSentinelPath(binaryURL: binary, updateID: marker.updateID).path))
 
         try store.finalizeSuccessfulUpdate(marker)
@@ -130,6 +168,68 @@ final class AutoUpdateTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: store.lockURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: store.successSentinelPath(binaryURL: binary, updateID: marker.updateID).path))
+    }
+
+    func testOrphanPendingMarkerWithValidBackupRestoresBeforeCleanup() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        let (marker, binary, backup) = try makePendingMarkerFixture(store: store, fixture: fixture, backupContents: "old", targetContents: "new")
+
+        let outcome = store.recoverOrphanedMarker(marker)
+
+        XCTAssertEqual(outcome, .restored(marker))
+        XCTAssertEqual(try String(contentsOf: binary), "old")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.pendingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.lockURL.path))
+        XCTAssertEqual(store.cooldown(target: marker.targetVersion, failureClass: .orphanedPendingMarker)?.attempt, 1)
+    }
+
+    func testOrphanPendingMarkerWithMissingOrCorruptBackupQuarantinesWithoutRestore() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        let (marker, binary, backup) = try makePendingMarkerFixture(store: store, fixture: fixture, backupContents: "wrong", targetContents: "new")
+
+        let outcome = store.recoverOrphanedMarker(marker)
+
+        guard case .backupCorrupt(let recovered, _) = outcome else {
+            return XCTFail("expected backupCorrupt, got \(outcome)")
+        }
+        XCTAssertEqual(recovered, marker)
+        XCTAssertEqual(try String(contentsOf: binary), "new")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.pendingURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backup.path))
+        let quarantined = try FileManager.default.contentsOfDirectory(atPath: store.root.path)
+            .filter { $0.hasPrefix("pending-quarantined-") && $0.hasSuffix(".json") }
+        XCTAssertEqual(quarantined.count, 1)
+        XCTAssertNil(store.cooldown(target: marker.targetVersion, failureClass: .orphanedPendingMarker))
+    }
+
+    func testSuccessCleanupIsIdempotentAcrossCrashSteps() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        let (marker, binary, backup) = try makePendingMarkerFixture(store: store, fixture: fixture, backupContents: "old", targetContents: "new")
+        let sentinel = store.successSentinelPath(binaryURL: binary, updateID: marker.updateID)
+
+        try store.writeSuccessSentinel(binaryURL: binary, updateID: marker.updateID, targetVersion: marker.targetVersion)
+        try store.completeSuccessfulUpdate(marker)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.pendingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.lockURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sentinel.path))
+
+        try store.writePending(marker)
+        try Data("old".utf8).write(to: backup)
+        FileManager.default.createFile(atPath: store.lockURL.path, contents: Data(), attributes: [.posixPermissions: 0o600])
+        store.clearPending()
+        try store.completeSuccessfulUpdate(marker)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.pendingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.lockURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sentinel.path))
+
+        try store.finalizeSuccessfulUpdate(marker)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sentinel.path))
     }
 
     func testMarkerValidationRejectsUppercaseShaAndNonCanonicalVersion() throws {
@@ -239,6 +339,34 @@ final class AutoUpdateTests: XCTestCase {
         let release = try await update.resolveReleaseByTags(normalizedTarget: "1.7.0")
 
         XCTAssertEqual(release.tagName, "1.7.0")
+    }
+
+    private func makePendingMarkerFixture(
+        store: AutoUpdateMarkerStore,
+        fixture: TempHome,
+        backupContents: String,
+        targetContents: String
+    ) throws -> (AutoUpdatePendingMarker, URL, URL) {
+        try store.ensureTrustedRoot()
+        FileManager.default.createFile(atPath: store.lockURL.path, contents: Data(), attributes: [.posixPermissions: 0o600])
+        let binaryDir = fixture.url.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binaryDir, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let binary = binaryDir.appendingPathComponent("macprovider-cli")
+        let backup = binaryDir.appendingPathComponent(".macprovider-cli.rollback-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+        try Data(targetContents.utf8).write(to: binary)
+        try Data(backupContents.utf8).write(to: backup)
+        let marker = AutoUpdatePendingMarker(
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "1.7.0",
+            targetPath: binary.path,
+            backupPath: backup.path,
+            size: 3,
+            mode: 0o755,
+            sha256: AutoUpdateEvent.sha256Hex("old"),
+            markerDeadline: ISO8601DateFormatter.autoupdateTest.string(from: Date().addingTimeInterval(300))
+        )
+        try store.writePending(marker)
+        return (marker, binary, backup)
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -84,9 +84,17 @@ final class AutoUpdateTests: XCTestCase {
         let second = try XCTUnwrap(store.cooldown(target: "1.7.0", failureClass: .targetReleaseNotFound))
         XCTAssertEqual(second.attempt, 2)
         XCTAssertGreaterThan(second.until.timeIntervalSince(first.until), 250)
+        store.recordCooldown(target: "1.7.0", failureClass: .targetReleaseNotFound)
+        let third = try XCTUnwrap(store.cooldown(target: "1.7.0", failureClass: .targetReleaseNotFound))
+        XCTAssertEqual(third.attempt, 3)
+        XCTAssertGreaterThan(third.until.timeIntervalSinceNow, 1_000)
+        store.recordCooldown(target: "1.7.0", failureClass: .targetReleaseNotFound)
+        let fourth = try XCTUnwrap(store.cooldown(target: "1.7.0", failureClass: .targetReleaseNotFound))
+        XCTAssertEqual(fourth.attempt, 4)
+        XCTAssertLessThan(fourth.until.timeIntervalSinceNow, 3_700)
     }
 
-    func testSuccessCleanupWritesSentinelThenClearsPendingBackupAndLock() throws {
+    func testSuccessCleanupLeavesSentinelUntilFinalize() throws {
         let fixture = try TempHome()
         let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
         try store.ensureTrustedRoot()
@@ -105,16 +113,115 @@ final class AutoUpdateTests: XCTestCase {
             size: 3,
             mode: 0o755,
             sha256: AutoUpdateEvent.sha256Hex("old"),
-            markerDeadline: "2026-06-29T15:06:00Z"
+            markerDeadline: ISO8601DateFormatter.autoupdateTest.string(from: Date().addingTimeInterval(300))
         )
         try store.writePending(marker)
 
         try store.completeSuccessfulUpdate(marker)
 
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.pendingURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.lockURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.successSentinelPath(binaryURL: binary, updateID: marker.updateID).path))
+
+        try store.finalizeSuccessfulUpdate(marker)
+
         XCTAssertFalse(FileManager.default.fileExists(atPath: store.pendingURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: store.lockURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: store.successSentinelPath(binaryURL: binary, updateID: marker.updateID).path))
+    }
+
+    func testMarkerValidationRejectsUppercaseShaAndNonCanonicalVersion() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        let binary = fixture.url.appendingPathComponent("bin/macprovider-cli")
+        try FileManager.default.createDirectory(at: binary.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let marker = AutoUpdatePendingMarker(
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "v1.7.0",
+            targetPath: binary.path,
+            backupPath: binary.deletingLastPathComponent().appendingPathComponent(".macprovider-cli.rollback-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee").path,
+            size: 0,
+            mode: 0o755,
+            sha256: String(repeating: "A", count: 64),
+            markerDeadline: ISO8601DateFormatter.autoupdateTest.string(from: Date().addingTimeInterval(300))
+        )
+        XCTAssertThrowsError(try store.validateMarker(marker))
+    }
+
+    func testNotifyOnlyTrustDoesNotCreateAutoupdateState() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        let status = ProviderStatus(
+            modelID: "mlx-community/Test-Model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.6.0",
+            providerStatus: status,
+            markerStore: store,
+            trustProvider: {
+                AutoUpdateTrustState(
+                    v2Accepted: true,
+                    tier: "provisional",
+                    encryptedLegValid: true,
+                    attestationRequired: false,
+                    attestationSatisfied: true,
+                    tokenConfigured: false,
+                    tokenValidated: true,
+                    bearerlessDuplicate: false,
+                    connected: true,
+                    stableReason: "tier_demoted"
+                )
+            },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        await updater.handleCoordinatorRecommendation("1.7.0")
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.root.path))
+        let event = await AutoUpdateEventStore.shared.lastWireObject()
+        XCTAssertEqual(event?["reason"] as? String, "tier_demoted")
+    }
+
+    func testAutoupdateReasonRedactionUsesStableCodes() {
+        let errors: [Error] = [
+            UpdateError.invalidURL("https://example.com/update?token=secret"),
+            UpdateError.checksumMismatch(expected: String(repeating: "a", count: 64), actual: String(repeating: "b", count: 64)),
+            UpdateError.unsafeArchiveEntry("/Users/example/.ssh/id_rsa"),
+            UpdateError.processFailed("/tmp/macprovider-cli", 1),
+        ]
+        for error in errors {
+            let reason = AutoUpdater.redactedReason(for: error)
+            XCTAssertFalse(reason.contains("https://"))
+            XCTAssertFalse(reason.contains("/tmp/"))
+            XCTAssertFalse(reason.range(of: #"[0-9a-fA-F]{17,}"#, options: .regularExpression) != nil)
+        }
+    }
+
+    func testSignedPolicyPersistenceIsMonotonic() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        store.updateSignedPolicy(minimum: "1.7.0", revoked: ["1.6.1"])
+        store.updateSignedPolicy(minimum: "1.6.0", revoked: [])
+        var policy = store.effectivePolicy()
+        XCTAssertEqual(policy.minimum, "1.7.0")
+        XCTAssertTrue(policy.revoked.contains("1.6.1"))
+        store.updateSignedPolicy(minimum: "1.8.0", revoked: ["1.7.1"])
+        policy = store.effectivePolicy()
+        XCTAssertEqual(policy.minimum, "1.8.0")
+        XCTAssertTrue(policy.revoked.contains("1.6.1"))
+        XCTAssertTrue(policy.revoked.contains("1.7.1"))
     }
 
     func testSelfUpdateResolvesReleaseByVTagThenBareTag() async throws {
@@ -133,6 +240,15 @@ final class AutoUpdateTests: XCTestCase {
 
         XCTAssertEqual(release.tagName, "1.7.0")
     }
+}
+
+private extension ISO8601DateFormatter {
+    static let autoupdateTest: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
 }
 
 private final class TempHome {

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import XCTest
+@testable import MacProviderCore
+@testable import macprovider_cli
+
+final class AutoUpdateTests: XCTestCase {
+    func testRecommendedVersionValidationNormalizesAndRejectsOversize() throws {
+        XCTAssertEqual(try AutoUpdateRecommendation.validate("v1.7.0").normalized, "1.7.0")
+        XCTAssertEqual(try AutoUpdateRecommendation.validate("V1.7.0").normalized, "1.7.0")
+        XCTAssertThrowsError(try AutoUpdateRecommendation.validate("1.7")) { error in
+            XCTAssertEqual(error as? AutoUpdateValidationError, .invalid)
+        }
+        XCTAssertThrowsError(try AutoUpdateRecommendation.validate("1.123456789.0")) { error in
+            XCTAssertEqual(error as? AutoUpdateValidationError, .componentTooLong)
+        }
+        let oversized = "v" + String(repeating: "1", count: 40) + ".2.3"
+        XCTAssertThrowsError(try AutoUpdateRecommendation.validate(oversized)) { error in
+            guard case let AutoUpdateValidationError.versionTooLong(sha)? = error as? AutoUpdateValidationError else {
+                return XCTFail("expected versionTooLong, got \(error)")
+            }
+            XCTAssertEqual(sha.count, 64)
+            XCTAssertEqual(sha, AutoUpdateEvent.sha256Hex(oversized))
+        }
+    }
+
+    func testEventPayloadDropsOptionalFieldsBeforeFallback() {
+        let event = AutoUpdateEvent(
+            updateID: UUID().uuidString.lowercased(),
+            currentVersion: "1.6.1",
+            targetVersion: "1.7.0",
+            phase: .download,
+            outcome: .failure,
+            reason: String(repeating: "reason", count: 1200),
+            attempt: 2,
+            failureClass: .targetReleaseNotFound,
+            extraMetadata: ["blob": String(repeating: "x", count: 5000)],
+            attemptHistory: [String(repeating: "y", count: 5000)],
+            releaseURL: "https://github.com/Augustas11/macprovider/releases/download/v1.7.0/a.tar.gz?token=secret"
+        )
+        let object = event.wireObject()
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [])
+        XCTAssertLessThanOrEqual(data.count, AutoUpdateEvent.maxWireBytes)
+        XCTAssertNil(object["extra_metadata"])
+        XCTAssertNil(object["attempt_history"])
+        XCTAssertNil(object["release_url"])
+        XCTAssertFalse(String(data: data, encoding: .utf8)!.contains("token=secret"))
+    }
+
+    func testAutoupdateOptOutReadsLegacyAndSpecSources() throws {
+        let yaml = """
+        coordinator_url: wss://example.invalid/ws/provider
+        autoupdate:
+          enabled: false
+        auto_update_enabled: true
+        """
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(configPath: "/tmp/provider.yaml"),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in yaml }
+        )
+        XCTAssertFalse(AutoUpdateConfig.enabled(config))
+
+        let env = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: ["MACPROVIDER_AUTOUPDATE": "off"],
+            fileExists: { _ in false },
+            readFile: { _ in "" }
+        )
+        XCTAssertFalse(AutoUpdateConfig.enabled(env))
+    }
+
+    func testCooldownBackoffIsKeyedByTargetAndFailureClass() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        store.recordCooldown(target: "1.7.0", failureClass: .targetReleaseNotFound)
+        let first = try XCTUnwrap(store.cooldown(target: "1.7.0", failureClass: .targetReleaseNotFound))
+        XCTAssertEqual(first.attempt, 1)
+        XCTAssertGreaterThan(first.until.timeIntervalSinceNow, 250)
+        XCTAssertNil(store.cooldown(target: "1.7.0", failureClass: .signatureInvalid))
+        XCTAssertEqual(store.activeCooldown(target: "1.7.0")?.failureClass, .targetReleaseNotFound)
+        store.recordCooldown(target: "1.7.0", failureClass: .targetReleaseNotFound)
+        let second = try XCTUnwrap(store.cooldown(target: "1.7.0", failureClass: .targetReleaseNotFound))
+        XCTAssertEqual(second.attempt, 2)
+        XCTAssertGreaterThan(second.until.timeIntervalSince(first.until), 250)
+    }
+
+    func testSuccessCleanupWritesSentinelThenClearsPendingBackupAndLock() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        _ = try store.acquireLock()
+        let binaryDir = fixture.url.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binaryDir, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let binary = binaryDir.appendingPathComponent("macprovider-cli")
+        let backup = binaryDir.appendingPathComponent(".macprovider-cli.rollback-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+        try Data("new".utf8).write(to: binary)
+        try Data("old".utf8).write(to: backup)
+        let marker = AutoUpdatePendingMarker(
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "1.7.0",
+            targetPath: binary.path,
+            backupPath: backup.path,
+            size: 3,
+            mode: 0o755,
+            sha256: AutoUpdateEvent.sha256Hex("old"),
+            markerDeadline: "2026-06-29T15:06:00Z"
+        )
+        try store.writePending(marker)
+
+        try store.completeSuccessfulUpdate(marker)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.pendingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.lockURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.successSentinelPath(binaryURL: binary, updateID: marker.updateID).path))
+    }
+
+    func testSelfUpdateResolvesReleaseByVTagThenBareTag() async throws {
+        let latest = URL(string: "https://api.github.com/repos/Augustas11/macprovider/releases/latest")!
+        let vTag = URL(string: "https://api.github.com/repos/Augustas11/macprovider/releases/tags/v1.7.0")!
+        let bare = URL(string: "https://api.github.com/repos/Augustas11/macprovider/releases/tags/1.7.0")!
+        AutoUpdateMockURLProtocol.responses = [
+            vTag: (404, Data("{}".utf8)),
+            bare: (200, Data(#"{"tag_name":"1.7.0","assets":[]}"#.utf8)),
+        ]
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [AutoUpdateMockURLProtocol.self]
+        let update = SelfUpdate(currentVersion: "1.6.1", releasesAPIURL: latest.absoluteString, session: URLSession(configuration: configuration))
+
+        let release = try await update.resolveReleaseByTags(normalizedTarget: "1.7.0")
+
+        XCTAssertEqual(release.tagName, "1.7.0")
+    }
+}
+
+private final class TempHome {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AutoUpdateTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private final class AutoUpdateMockURLProtocol: URLProtocol {
+    static var responses: [URL: (status: Int, body: Data)] = [:]
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url, let response = Self.responses[url] else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+            return
+        }
+        client?.urlProtocol(
+            self,
+            didReceive: HTTPURLResponse(url: url, statusCode: response.status, httpVersion: "HTTP/1.1", headerFields: nil)!,
+            cacheStoragePolicy: .notAllowed
+        )
+        client?.urlProtocol(self, didLoad: response.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -4,6 +4,33 @@ import XCTest
 @testable import macprovider_cli
 
 final class AutoUpdateTests: XCTestCase {
+    func testFailureClassEnumMatchesSpecR65() {
+        XCTAssertEqual(AutoUpdateFailureClass.allCases.map(\.rawValue), [
+            "rollback_observer_unavailable",
+            "target_release_not_found",
+            "release_asset_missing",
+            "recommended_version_invalid",
+            "version_too_long",
+            "version_component_too_long",
+            "autoupdate_already_pending",
+            "orphaned_pending_marker",
+            "orphaned_success_sentinel",
+            "rollback_backup_corrupt",
+            "target_revoked_or_below_minimum",
+            "signature_invalid",
+            "checksum_mismatch",
+            "self_test_failed",
+            "drain_timeout",
+            "trust_state_lost",
+            "post_start_crash",
+            "post_start_health_failed",
+            "post_start_rejoin_timeout",
+            "insufficient_disk_space",
+            "event_payload_too_large",
+            "other",
+        ])
+    }
+
     func testRecommendedVersionValidationNormalizesAndRejectsOversize() throws {
         XCTAssertEqual(try AutoUpdateRecommendation.validate("v1.7.0").normalized, "1.7.0")
         XCTAssertEqual(try AutoUpdateRecommendation.validate("V1.7.0").normalized, "1.7.0")

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1388,7 +1388,7 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertNil(proof["provider_receipt_public_key"])
     }
 
-    func testBinaryVersion_AdvertisesSPEC001V16AcrossHandshakeFrames() async throws {
+    func testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames() async throws {
         let recorder = CoordinatorFrameRecorder()
         let status = ProviderStatus(
             modelID: "model-a",
@@ -1401,10 +1401,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.6.1")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.6.1")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.6.1")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.6.1")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.0")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.0")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.7.0")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.7.0")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1024,6 +1024,85 @@ final class CoordinatorClientTests: XCTestCase {
         await client.stop()
     }
 
+    func testPreStagedSuccessSentinelMismatchDoesNotCleanupPendingOrBackup() async throws {
+        let fixture = try Self.makeAutoupdateRecoveryFixture(targetVersion: CoordinatorClient.binaryVersion)
+        let mismatchedUpdateID = "bbbbbbbb-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        try fixture.store.writeSuccessSentinel(
+            binaryURL: fixture.binary,
+            updateID: mismatchedUpdateID,
+            targetVersion: CoordinatorClient.binaryVersion
+        )
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let recorder = CoordinatorFrameRecorder()
+        let client = try await makeClient(status: status, recorder: recorder)
+        await AutoUpdateEventStore.shared.clear()
+
+        await client.runStartupAutoupdateRecoveryForTest(binaryURL: fixture.binary, markerStore: fixture.store)
+
+        XCTAssertEqual(try String(contentsOf: fixture.binary), "new")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.store.pendingURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.backup.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.store.lockURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.store.successSentinelPath(binaryURL: fixture.binary, updateID: mismatchedUpdateID).path))
+        let event = await AutoUpdateEventStore.shared.lastWireObject()
+        XCTAssertEqual(event?["failure_class"] as? String, AutoUpdateFailureClass.orphanedSuccessSentinel.rawValue)
+        XCTAssertEqual(event?["reason"] as? String, "update_id_mismatch")
+        let frames = await recorder.frames
+        XCTAssertTrue(frames.isEmpty)
+    }
+
+    func testSuccessFinalizeOnlyAfterCoordSendReturns() async throws {
+        let fixture = try Self.makeAutoupdateRecoveryFixture(targetVersion: CoordinatorClient.binaryVersion)
+        try fixture.store.writeSuccessSentinel(
+            binaryURL: fixture.binary,
+            updateID: fixture.marker.updateID,
+            targetVersion: CoordinatorClient.binaryVersion
+        )
+        let sentinel = fixture.store.successSentinelPath(binaryURL: fixture.binary, updateID: fixture.marker.updateID)
+        let gate = SentinelSendGate(sentinel: sentinel)
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(
+            status: status,
+            recorder: CoordinatorFrameRecorder(),
+            sendOverride: { frame in
+                if frame["type"] as? String == "state_update" {
+                    await gate.markSendStarted()
+                    await gate.waitForRelease()
+                    await gate.markSendReturned()
+                }
+            }
+        )
+        await AutoUpdateEventStore.shared.clear()
+
+        let recovery = Task {
+            await client.runStartupAutoupdateRecoveryForTest(binaryURL: fixture.binary, markerStore: fixture.store)
+        }
+        try await Self.waitUntil(timeoutNanoseconds: 1_000_000_000) {
+            await gate.started
+        }
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sentinel.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.store.pendingURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.backup.path))
+
+        await gate.release()
+        await recovery.value
+
+        let sendEvents = await gate.events
+        XCTAssertEqual(sendEvents, ["send-start", "send-return"])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sentinel.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.store.pendingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.backup.path))
+    }
+
     func testReceiptRotationRestoreTimeoutDoesNotHangAfterCandidateRejection() async throws {
         let committed = LockedBox(false)
         let status = ProviderStatus(
@@ -1821,6 +1900,32 @@ final class CoordinatorClientTests: XCTestCase {
         return dir
     }
 
+    private static func makeAutoupdateRecoveryFixture(targetVersion: String) throws -> (home: URL, store: AutoUpdateMarkerStore, marker: AutoUpdatePendingMarker, binary: URL, backup: URL) {
+        let home = try makeTemporaryDirectory(prefix: "coordinator-autoupdate-")
+        let store = AutoUpdateMarkerStore(homeDirectory: home)
+        try store.ensureTrustedRoot()
+        try Data().write(to: store.lockURL)
+        let binaryDir = home.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binaryDir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let updateID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        let binary = binaryDir.appendingPathComponent("macprovider-cli")
+        let backup = binaryDir.appendingPathComponent(".macprovider-cli.rollback-\(updateID)")
+        try Data("new".utf8).write(to: binary)
+        try Data("old".utf8).write(to: backup)
+        let marker = AutoUpdatePendingMarker(
+            updateID: updateID,
+            targetVersion: targetVersion,
+            targetPath: binary.path,
+            backupPath: backup.path,
+            size: 3,
+            mode: 0o755,
+            sha256: AutoUpdateEvent.sha256Hex("old"),
+            markerDeadline: ISO8601DateFormatter.coordinatorAutoupdateTest.string(from: Date().addingTimeInterval(300))
+        )
+        try store.writePending(marker)
+        return (home, store, marker, binary, backup)
+    }
+
     private static func minimalDERSequenceBase64URL() -> String {
         Data([0x30, 0x03, 0x02, 0x01, 0x05]).base64URLUnpadded()
     }
@@ -1928,6 +2033,46 @@ private actor CapturedWatchdogReason {
 private enum FakeTier2AuthOutcome: Sendable {
     case accepted
     case rejected(code: String, message: String)
+}
+
+private actor SentinelSendGate {
+    private let sentinel: URL
+    private(set) var started = false
+    private(set) var events: [String] = []
+    private var released = false
+
+    init(sentinel: URL) {
+        self.sentinel = sentinel
+    }
+
+    func markSendStarted() {
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sentinel.path))
+        started = true
+        events.append("send-start")
+    }
+
+    func waitForRelease() async {
+        while !released {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    func markSendReturned() {
+        events.append("send-return")
+    }
+
+    func release() {
+        released = true
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let coordinatorAutoupdateTest: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
 }
 
 private actor FakeTier2AuthResponder {

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -506,6 +506,7 @@ final class CoordinatorClientTests: XCTestCase {
             modelHash: String(repeating: "a", count: 64)
         )
         let client = try await makeClient(status: status, recorder: recorder, enableWarmSwap: false)
+        await AutoUpdateEventStore.shared.clear()
 
         try await client.sendHeartbeatForTest()
         let frames = await recorder.frames

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -1249,7 +1249,414 @@ kick_provider() {
 
 now_epoch() { date -u +%s; }
 
+autoupdate_recovery_tick() {
+  AUTUPDATE_STATE_ROOT="${MACPROVIDER_AUTOUPDATE_STATE_ROOT:-$HOME/.local/share/macprovider/autoupdate}" \
+  MACPROVIDER_LABEL="$LABEL" \
+  LOG_PATH="$LOG_PATH" \
+  python3 <<'PY'
+import datetime
+import fcntl
+import hashlib
+import json
+import os
+import pwd
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import time
+
+root = os.environ["AUTUPDATE_STATE_ROOT"]
+label = os.environ["MACPROVIDER_LABEL"]
+log_path = os.environ["LOG_PATH"]
+pending = os.path.join(root, "pending.json")
+lock_path = os.path.join(root, "update.lock")
+uid = os.getuid()
+provider_user = pwd.getpwuid(uid).pw_name
+
+def ts():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+def log(message):
+    with open(log_path, "a", encoding="utf-8") as fh:
+        fh.write(f"[{ts()}] autoupdate {message}\n")
+
+def event(outcome, phase, failure_class, reason, marker=None):
+    payload = {
+        "event": "provider_autoupdate_watchdog",
+        "source": "coordinator",
+        "outcome": outcome,
+        "phase": phase,
+        "reason": reason,
+        "timestamp": ts(),
+    }
+    if failure_class:
+        payload["failure_class"] = failure_class
+    if marker:
+        payload["update_id"] = marker.get("update_id", "")
+        payload["target_version"] = marker.get("target_version", "")
+    log(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+def reject_path(path, must_exist=True):
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        if must_exist:
+            raise
+        return None
+    if stat.S_ISLNK(st.st_mode):
+        raise RuntimeError(f"symlink_rejected:{path}")
+    if st.st_uid != uid:
+        raise RuntimeError(f"owner_rejected:{path}")
+    if st.st_nlink != 1 and not stat.S_ISDIR(st.st_mode):
+        raise RuntimeError(f"hardlink_rejected:{path}")
+    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise RuntimeError(f"writable_rejected:{path}")
+    try:
+        acl = subprocess.run(["/bin/ls", "-le", path], check=False, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
+        for line in acl.stdout.splitlines():
+            stripped = line.strip().lower()
+            if not re.match(r"^[0-9]+:", stripped):
+                continue
+            if ("write" in stripped or "append" in stripped or "add_file" in stripped) and f"user:{provider_user.lower()}" not in stripped:
+                raise RuntimeError(f"acl_write_rejected:{path}")
+    except FileNotFoundError:
+        pass
+    return st
+
+def verify_root():
+    current = root
+    parts = []
+    while True:
+        parts.append(current)
+        parent = os.path.dirname(current)
+        if parent == current or current == os.path.expanduser("~"):
+            break
+        current = parent
+    for path in reversed(parts):
+        if os.path.exists(path):
+            st = reject_path(path)
+            if not stat.S_ISDIR(st.st_mode):
+                raise RuntimeError(f"not_directory:{path}")
+
+def read_marker():
+    fd = os.open(pending, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        raw = os.read(fd, 65536)
+    finally:
+        os.close(fd)
+    marker = json.loads(raw.decode("utf-8"))
+    validate_marker_strict(marker)
+    return marker
+
+def validate_marker_strict(marker):
+    required = {"update_id", "target_version", "target_path", "backup_path", "size", "mode", "sha256", "marker_deadline"}
+    if not required.issubset(marker.keys()):
+        raise RuntimeError("marker_missing_required_fields")
+    if not re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", str(marker["update_id"])):
+        raise RuntimeError("marker_update_id_invalid")
+    if not re.match(r"^[0-9]+\.[0-9]+\.[0-9]+$", str(marker["target_version"])):
+        raise RuntimeError("marker_target_version_invalid")
+    for key in ("target_path", "backup_path"):
+        value = str(marker[key])
+        if not os.path.isabs(value) or value.endswith("/") or "/../" in value or "/./" in value:
+            raise RuntimeError(f"marker_{key}_invalid")
+    size = int(marker["size"])
+    mode = int(marker["mode"])
+    if size < 0 or size > 1024 * 1024 * 1024:
+        raise RuntimeError("marker_size_invalid")
+    if mode < 0 or mode > 0o7777:
+        raise RuntimeError("marker_mode_invalid")
+    if not re.match(r"^[0-9a-f]{64}$", str(marker["sha256"])):
+        raise RuntimeError("marker_sha256_invalid")
+    raw_deadline = str(marker["marker_deadline"])
+    if not raw_deadline.endswith("Z"):
+        raise RuntimeError("marker_deadline_invalid")
+    try:
+        deadline = datetime.datetime.strptime(raw_deadline, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=datetime.timezone.utc)
+    except ValueError:
+        raise RuntimeError("marker_deadline_invalid")
+    now = datetime.datetime.now(datetime.timezone.utc)
+    post_start_window = 60
+    future_tolerance = post_start_window + 30 * 60
+    if deadline < now - datetime.timedelta(seconds=300) or deadline > now + datetime.timedelta(seconds=future_tolerance):
+        raise RuntimeError("marker_deadline_out_of_bounds")
+
+def current_binary_version(path):
+    try:
+        result = subprocess.run([path, "--version"], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=5)
+    except Exception:
+        return ""
+    output = f"{result.stdout}\n{result.stderr}"
+    match = re.search(r"([0-9]+(?:\.[0-9]+){2}(?:[-+][0-9A-Za-z.-]+)?)", output)
+    return match.group(1) if match else ""
+
+def read_success_sentinel(path):
+    reject_path(path)
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        payload = json.loads(os.read(fd, 65536).decode("utf-8"))
+    finally:
+        os.close(fd)
+    update_id = str(payload.get("update_id", ""))
+    if not re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", update_id):
+        raise RuntimeError("sentinel_update_id_invalid")
+    return {
+        "update_id": update_id,
+        "binary_version": str(payload.get("binary_version", "")),
+    }
+
+def process_success_sentinel(marker):
+    binary_dir = os.path.dirname(marker["target_path"])
+    for name in os.listdir(binary_dir):
+        if not name.startswith(".macprovider-cli.success-"):
+            continue
+        sentinel = os.path.join(binary_dir, name)
+        try:
+            payload = read_success_sentinel(sentinel)
+            sentinel_version = payload["binary_version"]
+            current_version = current_binary_version(marker["target_path"])
+            if not sentinel_version or sentinel_version != current_version:
+                event("failure", "post_start", "orphaned_success_sentinel", "binary_version_mismatch", {"update_id": payload["update_id"], "target_version": sentinel_version})
+                os.unlink(sentinel)
+                continue
+            if payload["update_id"] != str(marker["update_id"]):
+                event("failure", "post_start", "orphaned_success_sentinel", "update_id_mismatch", {"update_id": payload["update_id"], "target_version": sentinel_version})
+                os.unlink(sentinel)
+                continue
+            try:
+                os.unlink(pending)
+            except FileNotFoundError:
+                pass
+            try:
+                os.unlink(marker["backup_path"])
+            except FileNotFoundError:
+                pass
+            try:
+                os.unlink(lock_path)
+            except FileNotFoundError:
+                pass
+            os.unlink(sentinel)
+            event("success", "post_start", None, "success_sentinel_cleanup_completed", marker)
+            return True
+        except Exception as exc:
+            event("failure", "post_start", "orphaned_success_sentinel", str(exc), marker)
+            try:
+                os.unlink(sentinel)
+            except FileNotFoundError:
+                pass
+    return False
+
+def sha256(path):
+    h = hashlib.sha256()
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                break
+            h.update(chunk)
+    finally:
+        os.close(fd)
+    return h.hexdigest()
+
+def binary_path_without_pending():
+    candidate = os.environ.get("MACPROVIDER_BINARY_PATH", "")
+    if candidate:
+        return candidate
+    return shutil.which("macprovider-cli") or ""
+
+def known_binary_dir():
+    configured = os.environ.get("MACPROVIDER_BINARY_DIR", "")
+    if configured:
+        return os.path.realpath(configured)
+    plist_path = os.path.expanduser("~/Library/LaunchAgents/live.streamvc.macprovider.plist")
+    try:
+        result = subprocess.run(
+            ["/usr/libexec/PlistBuddy", "-c", "Print ProgramArguments:0", plist_path],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return os.path.realpath(os.path.dirname(result.stdout.strip()))
+    except Exception:
+        pass
+    binary = binary_path_without_pending()
+    if binary:
+        return os.path.realpath(os.path.dirname(binary))
+    return ""
+
+def scan_without_pending():
+    binary = binary_path_without_pending()
+    if not binary:
+        return
+    binary_dir = os.path.dirname(binary)
+    for name in os.listdir(binary_dir):
+        path = os.path.join(binary_dir, name)
+        if name.startswith(".macprovider-cli.success-"):
+            try:
+                payload = read_success_sentinel(path)
+                sentinel_version = payload["binary_version"]
+                current_version = current_binary_version(binary)
+                if sentinel_version and sentinel_version == current_version:
+                    os.unlink(path)
+                    event("failure", "post_start", "orphaned_success_sentinel", "no_matching_pending", {"update_id": payload["update_id"], "target_version": current_version})
+                else:
+                    os.unlink(path)
+                    event("failure", "post_start", "orphaned_success_sentinel", "binary_version_mismatch", {"update_id": payload["update_id"], "target_version": sentinel_version})
+            except Exception as exc:
+                log(f"success_sentinel_scan_error={exc}")
+        elif name.startswith(".macprovider-cli.rollback-"):
+            try:
+                os.unlink(path)
+                log(f"deleted_stale_backup={path}")
+            except FileNotFoundError:
+                pass
+
+def quarantine(reason, marker=None):
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    dest = os.path.join(root, f"pending-quarantined-{stamp}.json")
+    try:
+        os.replace(pending, dest)
+        log(f"pending_marker_quarantined={dest} reason={reason}")
+    except FileNotFoundError:
+        pass
+
+def marker_deadline_expired(marker):
+    raw_deadline = str(marker["marker_deadline"])
+    deadline = datetime.datetime.strptime(raw_deadline, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=datetime.timezone.utc)
+    return datetime.datetime.now(datetime.timezone.utc) >= deadline
+
+def lock_is_held_by_other_process():
+    os.makedirs(root, mode=0o700, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0), 0o600)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        return False
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(fd)
+
+def restore(marker):
+    backup = marker["backup_path"]
+    target = marker["target_path"]
+    update_id = marker["update_id"]
+    expected_backup = os.path.join(os.path.dirname(target), f".macprovider-cli.rollback-{update_id}")
+    if backup != expected_backup:
+        raise RuntimeError("backup_path_derivation_mismatch")
+    trusted_dir = known_binary_dir()
+    if not trusted_dir:
+        raise RuntimeError("unsupported_install_topology:binary_dir_unknown")
+    target_parent = os.path.realpath(os.path.dirname(target))
+    backup_parent = os.path.realpath(os.path.dirname(backup))
+    if target_parent != trusted_dir or backup_parent != trusted_dir:
+        raise RuntimeError("unsupported_install_topology:path_outside_binary_dir")
+    for checked in (target, backup):
+        cursor = checked
+        while os.path.realpath(os.path.dirname(cursor)) == trusted_dir and cursor != trusted_dir:
+            reject_path(cursor, must_exist=os.path.exists(cursor))
+            break
+    backup_st = reject_path(backup)
+    reject_path(os.path.dirname(target))
+    if not os.path.isabs(target) or target.endswith("/"):
+        raise RuntimeError("target_path_invalid")
+    if backup_st.st_size != int(marker["size"]):
+        raise RuntimeError("backup_size_mismatch")
+    if sha256(backup) != str(marker["sha256"]):
+        raise RuntimeError("backup_sha256_mismatch")
+    os.chmod(backup, int(marker["mode"]))
+    os.replace(backup, target)
+    dir_fd = os.open(os.path.dirname(target), os.O_RDONLY)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+    try:
+        subprocess.run(["launchctl", "bootstrap", f"gui/{uid}", os.path.expanduser("~/Library/LaunchAgents/live.streamvc.macprovider.plist")], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(["launchctl", "kickstart", "-k", f"gui/{uid}/{label}"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception as exc:
+        log(f"launchctl_restore_warning={exc}")
+    try:
+        os.unlink(pending)
+    except FileNotFoundError:
+        pass
+    try:
+        os.unlink(lock_path)
+    except FileNotFoundError:
+        pass
+    event("failure", "rollback", classify_post_start_failure(marker), "restored_prior_binary", marker)
+
+def classify_post_start_failure(marker):
+    try:
+        printed = subprocess.run(["launchctl", "print", f"gui/{uid}/{label}"], check=False, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=5).stdout.lower()
+        if "last exit status" in printed and not re.search(r"last exit status\s*=\s*0", printed):
+            return "post_start_crash"
+        if "pid =" not in printed:
+            return "post_start_crash"
+    except Exception:
+        return "post_start_crash"
+    health_url = os.environ.get("MACPROVIDER_HEALTHCHECK_URL", "")
+    if health_url:
+        try:
+            curl = os.environ.get("MACPROVIDER_CURL", "/usr/bin/curl")
+            probe = subprocess.run([curl, "-fsS", "--max-time", "2", health_url], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if probe.returncode != 0:
+                return "post_start_health_failed"
+        except Exception:
+            return "post_start_health_failed"
+    current_version = current_binary_version(marker["target_path"])
+    if current_version and current_version != str(marker["target_version"]):
+        return "post_start_rejoin_timeout"
+    return "post_start_rejoin_timeout"
+
+try:
+    if not os.path.exists(pending):
+        scan_without_pending()
+        sys.exit(0)
+    verify_root()
+    reject_path(pending)
+    if lock_is_held_by_other_process():
+        sys.exit(0)
+    try:
+        marker = read_marker()
+    except Exception as exc:
+        event("failure", "rollback", "orphaned_pending_marker", "marker_invalid", None)
+        quarantine(f"marker_invalid:{exc}", None)
+        try:
+            os.unlink(lock_path)
+        except FileNotFoundError:
+            pass
+        sys.exit(0)
+    if process_success_sentinel(marker):
+        sys.exit(0)
+    if not marker_deadline_expired(marker):
+        log("pending_marker_still_inside_post_start_window")
+        sys.exit(0)
+    try:
+        restore(marker)
+    except Exception as exc:
+        unsupported_topology = str(exc).startswith("unsupported_install_topology")
+        failure_class = "other" if unsupported_topology else "rollback_backup_corrupt"
+        reason = "unsupported_install_topology" if unsupported_topology else str(exc)
+        event("failure", "rollback", failure_class, reason, marker)
+        quarantine(str(exc), marker)
+except Exception as exc:
+    log(f"recovery_error={exc}")
+PY
+}
+
 main() {
+  autoupdate_recovery_tick
   pid="$(read_provider_id || true)"
   if [ -z "$pid" ]; then
     # Provider not yet installed / configured. Stay silent; if the
@@ -1306,6 +1713,7 @@ main() {
 }
 
 main "$@"
+
 WATCHDOG_EOF
   chmod 0755 "$WATCHDOG_PATH"
 }

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
@@ -151,9 +152,10 @@ type Provider struct {
 	// count for this live session. Zero is omitted from generic Provider JSON
 	// to preserve L-1 default wire compatibility; /poolz adds the field
 	// explicitly for every provider.
-	CanaryFailCount     int        `json:"canary_fail_count,omitempty"`
-	CanaryLastCheckedAt *time.Time `json:"canary_last_checked_at,omitempty"`
-	CanaryLastFailedAt  *time.Time `json:"canary_last_failed_at,omitempty"`
+	CanaryFailCount     int             `json:"canary_fail_count,omitempty"`
+	CanaryLastCheckedAt *time.Time      `json:"canary_last_checked_at,omitempty"`
+	CanaryLastFailedAt  *time.Time      `json:"canary_last_failed_at,omitempty"`
+	LastAutoupdateEvent json.RawMessage `json:"last_autoupdate_event,omitempty"`
 
 	// SPEC-002 v1.3.5 §3.X.1 — populated from v2 auth_request initial-stage
 	// supported_models[] per SPEC-010 v1.5 R-3.3.1; nil for the L-1 baseline.
@@ -1143,9 +1145,10 @@ type HeartbeatUpdate struct {
 	// Loading is the value of the heartbeat's optional `loading` field; absent
 	// on the wire (= LoadingPresent false) is equivalent to false per SPEC-011
 	// v0.5 R-3.3.4.
-	Loading        bool
-	LoadingPresent bool
-	At             time.Time
+	Loading             bool
+	LoadingPresent      bool
+	LastAutoupdateEvent json.RawMessage
+	At                  time.Time
 }
 
 func (r *Registry) ApplyHeartbeat(providerID, assignedID string, hb HeartbeatUpdate) (*Provider, time.Duration, bool) {
@@ -1198,6 +1201,9 @@ func (r *Registry) applyHeartbeatLocked(providerID, assignedID string, hb Heartb
 	p.SlotsFree = hb.SlotsFree
 	p.SlotsTotal = hb.SlotsTotal
 	p.ThroughputTPSEstimate = hb.ThroughputTPSEstimate
+	if len(hb.LastAutoupdateEvent) > 0 {
+		p.LastAutoupdateEvent = append(p.LastAutoupdateEvent[:0], hb.LastAutoupdateEvent...)
+	}
 	r.recordSeenModelLocked(p.ProviderID, hb.ModelID)
 	if hb.Status != "" && hb.Status != p.State {
 		if r.canApplyProviderStateLocked(p, hb.Status) {
@@ -1337,10 +1343,11 @@ func (r *Registry) ModelKnown(modelID string) bool {
 }
 
 type StateUpdate struct {
-	State      State
-	SlotsFree  *int
-	SlotsTotal *int
-	At         time.Time
+	State               State
+	SlotsFree           *int
+	SlotsTotal          *int
+	LastAutoupdateEvent json.RawMessage
+	At                  time.Time
 }
 
 func (r *Registry) ApplyStateUpdate(providerID, assignedID string, update StateUpdate) (*Provider, bool) {
@@ -1358,6 +1365,9 @@ func (r *Registry) ApplyStateUpdate(providerID, assignedID string, update StateU
 	}
 	if update.SlotsTotal != nil {
 		p.SlotsTotal = *update.SlotsTotal
+	}
+	if len(update.LastAutoupdateEvent) > 0 {
+		p.LastAutoupdateEvent = append(p.LastAutoupdateEvent[:0], update.LastAutoupdateEvent...)
 	}
 	at := update.At
 	if at.IsZero() {

--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -26,13 +26,14 @@ type Hello struct {
 }
 
 type HelloAck struct {
-	Type                     string `json:"type"`
-	CoordinatorVersion       int    `json:"coordinator_version"`
-	AssignedID               string `json:"assigned_id"`
-	HeartbeatIntervalS       int    `json:"heartbeat_interval_s"`
-	Tier                     string `json:"tier,omitempty"`
-	RecommendedBinaryVersion string `json:"recommended_binary_version,omitempty"`
-	RequiredBinaryVersion    string `json:"required_binary_version,omitempty"`
+	Type                      string `json:"type"`
+	CoordinatorVersion        int    `json:"coordinator_version"`
+	AssignedID                string `json:"assigned_id"`
+	HeartbeatIntervalS        int    `json:"heartbeat_interval_s"`
+	Tier                      string `json:"tier,omitempty"`
+	RecommendedBinaryVersion  string `json:"recommended_binary_version,omitempty"`
+	RequiredBinaryVersion     string `json:"required_binary_version,omitempty"`
+	AutoupdateDrainExtensions bool   `json:"autoupdate_drain_extensions,omitempty"`
 	// SPEC-003 v0.8 FR-C9.2 — populated only when a tokenless provisional
 	// provider was just self-minted on this connect. Binary persists to
 	// the top-level `provider_token` YAML key (FR-C9.3) so the next
@@ -95,16 +96,17 @@ type AuthChallenge struct {
 }
 
 type AuthResponse struct {
-	Type                     string             `json:"type"`
-	Version                  int                `json:"version"`
-	Status                   string             `json:"status"`
-	AssignedID               string             `json:"assigned_id,omitempty"`
-	HeartbeatIntervalS       int                `json:"heartbeat_interval_s,omitempty"`
-	Tier                     string             `json:"tier,omitempty"`
-	RecommendedBinaryVersion string             `json:"recommended_binary_version,omitempty"`
-	RequiredBinaryVersion    string             `json:"required_binary_version,omitempty"`
-	Tier2Session             *AuthTier2Session  `json:"tier2_session,omitempty"`
-	Error                    *AuthResponseError `json:"error,omitempty"`
+	Type                      string             `json:"type"`
+	Version                   int                `json:"version"`
+	Status                    string             `json:"status"`
+	AssignedID                string             `json:"assigned_id,omitempty"`
+	HeartbeatIntervalS        int                `json:"heartbeat_interval_s,omitempty"`
+	Tier                      string             `json:"tier,omitempty"`
+	RecommendedBinaryVersion  string             `json:"recommended_binary_version,omitempty"`
+	RequiredBinaryVersion     string             `json:"required_binary_version,omitempty"`
+	AutoupdateDrainExtensions bool               `json:"autoupdate_drain_extensions,omitempty"`
+	Tier2Session              *AuthTier2Session  `json:"tier2_session,omitempty"`
+	Error                     *AuthResponseError `json:"error,omitempty"`
 	// SPEC-003 v0.8 FR-C9.2 — populated only on proof-stage acceptance
 	// when a tokenless provisional provider was just self-minted on this
 	// connect. Never present on rejection-shaped responses.
@@ -150,21 +152,22 @@ type AuthModelHashSession struct {
 }
 
 type Heartbeat struct {
-	Type                    string  `json:"type"`
-	Status                  string  `json:"status"`
-	ModelID                 string  `json:"model_id"`
-	ModelParamsB            float64 `json:"model_params_b"`
-	RAMGB                   int     `json:"ram_gb"`
-	MaxContextTokens        int     `json:"max_context_tokens"`
-	MaxConcurrency          int     `json:"max_concurrency"`
-	SlotsFree               int     `json:"slots_free"`
-	SlotsTotal              int     `json:"slots_total"`
-	ThroughputTPSEstimate   float64 `json:"throughput_tps_estimate"`
-	RequestsServedSinceLast int     `json:"requests_served_since_last"`
-	AvgLatencyMSSinceLast   float64 `json:"avg_latency_ms_since_last"`
-	ThroughputTPSSinceLast  float64 `json:"throughput_tps_since_last"`
-	ModelHash               string  `json:"model_hash,omitempty"`
-	Loading                 bool    `json:"loading,omitempty"`
+	Type                    string          `json:"type"`
+	Status                  string          `json:"status"`
+	ModelID                 string          `json:"model_id"`
+	ModelParamsB            float64         `json:"model_params_b"`
+	RAMGB                   int             `json:"ram_gb"`
+	MaxContextTokens        int             `json:"max_context_tokens"`
+	MaxConcurrency          int             `json:"max_concurrency"`
+	SlotsFree               int             `json:"slots_free"`
+	SlotsTotal              int             `json:"slots_total"`
+	ThroughputTPSEstimate   float64         `json:"throughput_tps_estimate"`
+	RequestsServedSinceLast int             `json:"requests_served_since_last"`
+	AvgLatencyMSSinceLast   float64         `json:"avg_latency_ms_since_last"`
+	ThroughputTPSSinceLast  float64         `json:"throughput_tps_since_last"`
+	ModelHash               string          `json:"model_hash,omitempty"`
+	Loading                 bool            `json:"loading,omitempty"`
+	LastAutoupdateEvent     json.RawMessage `json:"last_autoupdate_event,omitempty"`
 }
 
 type HeartbeatPresence struct {
@@ -173,11 +176,12 @@ type HeartbeatPresence struct {
 }
 
 type StateUpdate struct {
-	Type            string          `json:"type"`
-	State           string          `json:"state"`
-	Reason          string          `json:"reason"`
-	Since           string          `json:"since"`
-	MetricsSnapshot MetricsSnapshot `json:"metrics_snapshot"`
+	Type                string          `json:"type"`
+	State               string          `json:"state"`
+	Reason              string          `json:"reason"`
+	Since               string          `json:"since"`
+	MetricsSnapshot     MetricsSnapshot `json:"metrics_snapshot"`
+	LastAutoupdateEvent json.RawMessage `json:"last_autoupdate_event,omitempty"`
 }
 
 type PreflightAck struct {
@@ -600,7 +604,7 @@ func requireString(raw map[string]json.RawMessage, field string, out *string) *f
 // (`<0x20`), DEL (`0x7f`), or C1 control (`0x80-0x9f`) codepoint.
 // SPEC-002 v1.5.1 R-2 / issue #197 R4-R5 security: provider-controlled
 // strings reaching structured logs or close-frame reason fields MUST
-// be rejected when they carry these codepoints. JSON `` decodes
+// be rejected when they carry these codepoints. JSON “ decodes
 // to U+009B and is valid UTF-8 but would otherwise inject a terminal
 // CSI sequence into log sinks.
 func containsControlChar(s string) bool {
@@ -704,6 +708,12 @@ func ParseHeartbeat(payload []byte) (Heartbeat, HeartbeatPresence, string, error
 			return Heartbeat{}, presence, "loading", err
 		}
 	}
+	if v, ok := raw["last_autoupdate_event"]; ok && string(v) != "null" {
+		if !validAutoupdateEventObject(v) {
+			return Heartbeat{}, presence, "last_autoupdate_event", fieldError{Field: "last_autoupdate_event"}
+		}
+		hb.LastAutoupdateEvent = append([]byte(nil), v...)
+	}
 	return hb, presence, "", nil
 }
 
@@ -739,7 +749,24 @@ func ParseStateUpdate(payload []byte) (StateUpdate, string, error) {
 			return StateUpdate{}, "metrics_snapshot", err
 		}
 	}
+	if v, ok := raw["last_autoupdate_event"]; ok && string(v) != "null" {
+		if !validAutoupdateEventObject(v) {
+			return StateUpdate{}, "last_autoupdate_event", fieldError{Field: "last_autoupdate_event"}
+		}
+		update.LastAutoupdateEvent = append([]byte(nil), v...)
+	}
 	return update, "", nil
+}
+
+func validAutoupdateEventObject(raw json.RawMessage) bool {
+	if len(raw) == 0 || len(raw) > 4096 {
+		return false
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return false
+	}
+	return object != nil
 }
 
 func ParsePreflightAck(payload []byte) (PreflightAck, string, error) {
@@ -773,7 +800,7 @@ func ParseDrainStatus(payload []byte) (DrainStatus, string, error) {
 		return DrainStatus{}, "type", fmt.Errorf("expected drain_status, got %q", status.Type)
 	}
 	switch status.Phase {
-	case "starting", "in_progress", "complete":
+	case "starting", "in_progress", "complete", "timeout_skipped":
 	default:
 		return DrainStatus{}, "phase", fieldError{Field: "invalid phase"}
 	}

--- a/phase4-coordinator/internal/ws/messages_test.go
+++ b/phase4-coordinator/internal/ws/messages_test.go
@@ -80,6 +80,73 @@ func TestParseHeartbeatAcceptsSPEC011Fields(t *testing.T) {
 	}
 }
 
+func TestParseHeartbeatAcceptsLastAutoupdateEventObject(t *testing.T) {
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"mlx-community/Qwen2.5-7B-Instruct-4bit","model_params_b":7.0,"ram_gb":16,"max_context_tokens":50000,"max_concurrency":2,"slots_free":1,"slots_total":2,"throughput_tps_estimate":19.8,"requests_served_since_last":12,"avg_latency_ms_since_last":450.0,"throughput_tps_since_last":18.5,"last_autoupdate_event":{"event":"provider_autoupdate","phase":"download","outcome":"failure","failure_class":"target_release_not_found"}}`)
+
+	hb, _, field, err := ParseHeartbeat(payload)
+	if err != nil {
+		t.Fatalf("ParseHeartbeat field=%q err=%v", field, err)
+	}
+	if !json.Valid(hb.LastAutoupdateEvent) || !strings.Contains(string(hb.LastAutoupdateEvent), "target_release_not_found") {
+		t.Fatalf("last_autoupdate_event = %s", hb.LastAutoupdateEvent)
+	}
+}
+
+func TestParseHeartbeatRejectsOversizedLastAutoupdateEvent(t *testing.T) {
+	large := `{"event":"provider_autoupdate","extra":"` + strings.Repeat("x", 4096) + `"}`
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"mlx-community/Qwen2.5-7B-Instruct-4bit","model_params_b":7.0,"ram_gb":16,"max_context_tokens":50000,"max_concurrency":2,"slots_free":1,"slots_total":2,"throughput_tps_estimate":19.8,"requests_served_since_last":12,"avg_latency_ms_since_last":450.0,"throughput_tps_since_last":18.5,"last_autoupdate_event":` + large + `}`)
+
+	_, _, field, err := ParseHeartbeat(payload)
+	if err == nil {
+		t.Fatal("ParseHeartbeat err = nil")
+	}
+	if field != "last_autoupdate_event" {
+		t.Fatalf("field = %q", field)
+	}
+}
+
+func TestParseStateUpdateAcceptsLastAutoupdateEvent(t *testing.T) {
+	payload := []byte(`{"type":"state_update","state":"draining","reason":"autoupdate_to_1.7.0","since":"2026-06-29T15:00:00Z","metrics_snapshot":{"slots_free":0,"slots_total":1},"last_autoupdate_event":{"event":"provider_autoupdate","phase":"drain","outcome":"in_progress"}}`)
+
+	update, field, err := ParseStateUpdate(payload)
+	if err != nil {
+		t.Fatalf("ParseStateUpdate field=%q err=%v", field, err)
+	}
+	if update.Reason != "autoupdate_to_1.7.0" {
+		t.Fatalf("reason = %q", update.Reason)
+	}
+	if !json.Valid(update.LastAutoupdateEvent) {
+		t.Fatalf("last_autoupdate_event invalid: %s", update.LastAutoupdateEvent)
+	}
+}
+
+func TestParseDrainStatusAcceptsAutoupdateTimeoutSkipped(t *testing.T) {
+	status, field, err := ParseDrainStatus([]byte(`{"type":"drain_status","phase":"timeout_skipped","inflight_requests":1,"estimated_drain_seconds":0}`))
+	if err != nil {
+		t.Fatalf("ParseDrainStatus field=%q err=%v", field, err)
+	}
+	if status.Phase != "timeout_skipped" {
+		t.Fatalf("phase = %q", status.Phase)
+	}
+}
+
+func TestAdmissionFramesAdvertiseAutoupdateDrainExtensions(t *testing.T) {
+	ackBytes, err := json.Marshal(HelloAck{Type: "hello_ack", AutoupdateDrainExtensions: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(ackBytes), `"autoupdate_drain_extensions":true`) {
+		t.Fatalf("hello_ack = %s", ackBytes)
+	}
+	responseBytes, err := json.Marshal(AuthResponse{Type: "auth_response", Version: 2, Status: "accepted", AutoupdateDrainExtensions: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(responseBytes), `"autoupdate_drain_extensions":true`) {
+		t.Fatalf("auth_response = %s", responseBytes)
+	}
+}
+
 func TestParseHeartbeatRejectsModelHashWrongType(t *testing.T) {
 	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"mlx-community/Qwen2.5-7B-Instruct-4bit","model_params_b":7.0,"ram_gb":16,"max_context_tokens":50000,"max_concurrency":2,"slots_free":1,"slots_total":2,"throughput_tps_estimate":19.8,"requests_served_since_last":12,"avg_latency_ms_since_last":450.0,"throughput_tps_since_last":18.5,"model_hash":123}`)
 
@@ -349,7 +416,7 @@ func bytesOf(value byte, count int) []byte {
 // strings on a hello (provider_id, hostname, model_id, binary_version)
 // MUST be rejected at parse time when they contain control characters
 // (C0, DEL, C1) so they cannot inject terminal-CSI sequences into
-// structured logs or close-frame reason strings. JSON `` decodes
+// structured logs or close-frame reason strings. JSON “ decodes
 // to U+009B and is valid UTF-8 but would otherwise pass the parser.
 func TestParseHelloRejectsControlCharsInRequiredStrings(t *testing.T) {
 	base := map[string]any{

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -725,16 +725,17 @@ func (s *Server) handleV1Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	releaseUnauth()
 
 	ack := HelloAck{
-		Type:                     "hello_ack",
-		CoordinatorVersion:       1,
-		AssignedID:               entry.AssignedID,
-		HeartbeatIntervalS:       int(s.cfg.HeartbeatInterval().Seconds()),
-		Tier:                     string(entry.Tier),
-		RecommendedBinaryVersion: s.cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion,
-		RequiredBinaryVersion:    s.cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion,
-		AssignedProviderToken:    assignedProviderToken,
-		PairOT:                   pairOT,
-		ClaimURL:                 claimURL,
+		Type:                      "hello_ack",
+		CoordinatorVersion:        1,
+		AssignedID:                entry.AssignedID,
+		HeartbeatIntervalS:        int(s.cfg.HeartbeatInterval().Seconds()),
+		Tier:                      string(entry.Tier),
+		RecommendedBinaryVersion:  s.cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion,
+		RequiredBinaryVersion:     s.cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion,
+		AutoupdateDrainExtensions: true,
+		AssignedProviderToken:     assignedProviderToken,
+		PairOT:                    pairOT,
+		ClaimURL:                  claimURL,
 	}
 	b, err := json.Marshal(ack)
 	if err != nil {
@@ -982,17 +983,18 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	}
 	releaseUnauth()
 	response := AuthResponse{
-		Type:                     "auth_response",
-		Version:                  2,
-		Status:                   "accepted",
-		AssignedID:               entry.AssignedID,
-		HeartbeatIntervalS:       int(s.cfg.HeartbeatInterval().Seconds()),
-		Tier:                     string(entry.Tier),
-		RecommendedBinaryVersion: s.cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion,
-		RequiredBinaryVersion:    s.cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion,
-		AssignedProviderToken:    assignedProviderToken,
-		PairOT:                   pairOT,
-		ClaimURL:                 claimURL,
+		Type:                      "auth_response",
+		Version:                   2,
+		Status:                    "accepted",
+		AssignedID:                entry.AssignedID,
+		HeartbeatIntervalS:        int(s.cfg.HeartbeatInterval().Seconds()),
+		Tier:                      string(entry.Tier),
+		RecommendedBinaryVersion:  s.cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion,
+		RequiredBinaryVersion:     s.cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion,
+		AutoupdateDrainExtensions: true,
+		AssignedProviderToken:     assignedProviderToken,
+		PairOT:                    pairOT,
+		ClaimURL:                  claimURL,
 		Tier2Session: &AuthTier2Session{
 			EncryptedLeg: AuthEncryptedLegSession{
 				Enabled:            true,
@@ -2361,6 +2363,7 @@ func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, p
 		ModelHashPresent:      presence.ModelHash,
 		Loading:               hb.Loading,
 		LoadingPresent:        presence.Loading,
+		LastAutoupdateEvent:   hb.LastAutoupdateEvent,
 		At:                    s.now(),
 	})
 	if !ok {
@@ -2406,10 +2409,11 @@ func (s *Server) handleStateUpdate(providerID, assignedID string, payload []byte
 		state = pool.StateDegraded
 	}
 	entry, ok := s.pool.ApplyStateUpdate(providerID, assignedID, pool.StateUpdate{
-		State:      state,
-		SlotsFree:  update.MetricsSnapshot.SlotsFree,
-		SlotsTotal: update.MetricsSnapshot.SlotsTotal,
-		At:         s.now(),
+		State:               state,
+		SlotsFree:           update.MetricsSnapshot.SlotsFree,
+		SlotsTotal:          update.MetricsSnapshot.SlotsTotal,
+		LastAutoupdateEvent: update.LastAutoupdateEvent,
+		At:                  s.now(),
 	})
 	if !ok {
 		s.log.Warn().Str("provider_id", providerID).Msg("state_update for unknown provider")

--- a/specs/AUDIT_SPEC_020_v0_1_IMPL_r1_ABSORPTION_PROMPT.md
+++ b/specs/AUDIT_SPEC_020_v0_1_IMPL_r1_ABSORPTION_PROMPT.md
@@ -1,0 +1,320 @@
+# SPEC-020 IMPL r1 → r2 absorption prompt
+
+You are absorbing IMPL round-1 audit findings on commit `37514b9` of
+`impl/spec-020-provider-autoupdate` in worktree
+`/Users/augstar/macprovider-spec-020-impl`.
+
+**Bar:** IMPL r2 must return 0 CRITICAL + 0 HIGH + 0 MEDIUM across the
+three lanes (architect / code / security).
+
+Read `specs/SPEC-020-IMPL-r1-audit.md` for the full per-finding narrative
+with file:line citations. r1 totals were 0C + 12H + 6M across 3 lanes.
+
+## Absorption plan — themes first, fixes in priority order
+
+### T-1: Trust-state lifecycle (3 lanes, ALL HIGH — load-bearing)
+
+This is the single most important fix. Three coordinated changes:
+
+**1. Pre-gate notify-only BEFORE calling `runAutoupdateIfEligible`** (A-r1-H-1).
+
+In `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift` at
+the `acceptCoordinatorSession` call site (~line 1287), evaluate
+`AutoUpdateTrustState.evaluate(...)` FIRST. If verdict is notify-only,
+emit a notify-status event ONLY — do NOT call
+`runAutoupdateIfEligible`. Specifically: do NOT insert into
+`autoupdateAttemptedTargets`, do NOT take the update lock, do NOT
+record cooldown, do NOT do any state mutation.
+
+In `phase3-binary/Sources/macprovider-cli/AutoUpdater.swift`, the
+first action in `run()` MUST be a trust-state check; on notify-only
+verdict at entry, return immediately without ANY state mutation.
+
+**2. Restore on late trust-loss (after committed swap/marker/backup)**
+(A-r1-H-2 + C-r1-H-1).
+
+In `phase3-binary/Sources/macprovider-cli/AutoUpdater.swift`:
+
+- Track `committedMarker: Bool`, `committedBackup: Bool`, `committedSwap: Bool` flags in the run pipeline.
+- The catch block that handles `trustStateLost` (around line 150) MUST:
+  - If `committedSwap == true`: invoke `AutoUpdateMarkerStore.restoreBackup(...)` to restore the prior binary.
+  - If `committedMarker == true || committedBackup == true`: delete committed marker + backup.
+  - Release `update.lock`.
+  - Suppress `launchctl bootstrap` of the new binary.
+  - Emit `failure_class:"trust_state_lost"` with stable trigger reason (`encrypted_leg_invalidated`, `tier_demoted`, `token_revoked`, `coordinator_disconnected`, `attestation_state_degraded`).
+  - Mark session-disabled for autoupdate (no retry until next coord session).
+
+Add AC-V0.1-22 test: trust loss between auth_response and swap → no swap occurs; if swap committed, prior binary is restored.
+
+**3. Live predicate, not handshake snapshot** (A-r1-H-3).
+
+In `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`:
+
+- `currentAutoupdateTrustState()` MUST re-evaluate from current
+  session facts (tier, encrypted-leg session live, token validity,
+  attestation state) each time it's called, NOT return a cached
+  value.
+- On AEAD decrypt failure in
+  `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift` (around
+  line 57), DEMOTE the trust state with reason
+  `encrypted_leg_invalidated`. Same for tier demotion, token
+  revocation, attestation degradation events — emit a stable demotion
+  reason and update the live predicate.
+- The 5 re-eval points in `AutoUpdater.swift` (before download, drain,
+  marker, swap, bootstrap) MUST call `currentAutoupdateTrustState()`
+  AT THE CALL SITE, not read a cached value.
+
+### T-2: Rollback backup crash-safety (B-r1-H-2 + C-r1-M-1)
+
+In `phase3-binary/Sources/macprovider-cli/AutoUpdater.swift`:
+
+Route backup preservation through the hardened marker-store primitive,
+NOT the local `copyNoFollow`. Either:
+- (a) Delete `copyNoFollow` and have `preserveMarkerAndSwap` call
+  `AutoUpdateMarkerStore.atomicCopyNoFollow(from: liveBinary, to: backupPath)`, which already includes parent-dir fsync.
+- (b) Keep `copyNoFollow` but add `fsync(parent_dir_fd)` immediately
+  after the atomic rename, AND lstat-validate the binary-dir ancestry
+  (mode 0700, provider-UID-owned, no symlinks) before placing the
+  backup.
+
+(a) is the safer route; consolidates the trust invariant on a single
+hardened path.
+
+### T-3: Recovery state machine (B-r1-H-3..H-6 + C-r1-M-2)
+
+**B-r1-H-3 — shared marker validator**:
+
+Add a `validateMarker(_ pending: PendingMarker) throws` function in
+`phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift` that:
+- Validates `update_id` is canonical UUIDv4 (RFC 4122 §3, 36-char with dashes, version nibble = 4).
+- Validates `target_version` matches the version regex AND is the normalized form (no leading `v`).
+- Validates `target_path` and `backup_path` are absolute, no trailing slash.
+- Validates `size` >= 0 and within a sane bound (e.g., ≤ 1 GiB).
+- Validates `mode` is a decimal int in [0, 0o7777].
+- Validates `sha256` matches `^[0-9a-f]{64}$` (lowercase only, not `.lowercased()`-coerced).
+- Validates `marker_deadline` parses as RFC 3339 UTC; passes the tolerance check (R-4.10 future-beyond / expired / malformed).
+
+Call `validateMarker` from `readPending()` and `validateBackup()`.
+Malformed → R-4.10 orphan-recovery path (delete + cooldown +
+`failure_class:"orphaned_pending_marker"`).
+
+Update `watchdog.sh` `read_marker()` to perform the same validations
+(reject any deviation). Add a helper `validate_marker_strict()` that
+exits 1 on any deviation.
+
+Also remove `.lowercased()` from `validateBackup()` SHA comparison —
+require the marker's `sha256` to already be lowercase.
+
+**B-r1-H-4 — startup recovery scan BEFORE handshake**:
+
+In `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`,
+introduce a startup recovery routine that runs in `main` / startup
+sequence BEFORE the first coordinator connection attempt. The routine:
+
+1. Scan `$BINARY_DIR` for any `.macprovider-cli.success-*` sentinel.
+   - If sentinel's `binary_version` matches current `binaryVersion`:
+     this is a delayed success cleanup. Unlink matching `pending.json`
+     (no orphan recovery), delete matching rollback backup, release
+     any held `update.lock`, delete the sentinel. Treat as
+     `outcome:"success"`.
+   - If sentinel exists but `binary_version` does NOT match current:
+     emit `failure_class:"orphaned_success_sentinel"`, delete the
+     sentinel, continue.
+2. Scan `$TRUSTED_ROOT/pending.json`:
+   - If present AND `update.lock` not held AND no observer process
+     running: orphan-recovery (R-4.10).
+3. Scan `$BINARY_DIR` for stale `.macprovider-cli.rollback-*` backups
+   with no matching pending marker: delete without restoring.
+
+Watchdog `watchdog.sh` MUST also run these scans on its tick — not
+just exit when `pending.json` is absent. Update the tick handler.
+
+**B-r1-H-5 — sentinel as durable recovery anchor**:
+
+In `AutoUpdateMarker.swift` `completeSuccessfulUpdate()`:
+
+Reorder the cleanup to leave the sentinel as the durable recovery
+anchor UNTIL after the success event is emitted by the caller. New
+sequence:
+
+1. Write success sentinel atomically (this is the durable marker).
+2. Return from `completeSuccessfulUpdate(...)` — caller now emits the success event.
+3. After the caller has confirmed the event reached the coordinator
+   (or after a soft timeout for offline mode), the caller calls a new
+   `finalizeSuccessfulUpdate(updateId:)` which:
+   - Unlinks `pending.json`.
+   - Deletes the rollback backup.
+   - Releases `update.lock`.
+   - Deletes the sentinel LAST.
+
+On next provider startup, if the sentinel is still present and
+`binary_version` matches current, run the same finalize sequence (the
+startup recovery routine).
+
+**B-r1-H-6 — post-start classification**:
+
+In `phase3-binary/Sources/macprovider-cli/AutoUpdater.swift` and
+`ops/macprovider-watchdog/watchdog.sh`, add post-start observation
+state tracking:
+
+- After `launchctl bootstrap`, the observer (watchdog OR in-process)
+  watches for:
+  - **`post_start_crash`**: new binary exits with non-zero status
+    within 60s (`launchctl print` shows last_exit_status != 0 OR
+    process not in process table).
+  - **`post_start_health_failed`**: new binary is running but
+    `/healthz` probe (or equivalent local readiness check) fails
+    within 60s.
+  - **`post_start_rejoin_timeout`**: new binary is running AND
+    healthy locally but did NOT rejoin coordinator with
+    `binary_version == NORMALIZED_TARGET` within 60s.
+- Each rollback event MUST emit one of the three classes (NOT
+  `orphaned_pending_marker` — that's reserved for marker recovery
+  with no observer).
+
+**C-r1-M-2 — watchdog restore path containment**:
+
+In `ops/macprovider-watchdog/watchdog.sh`, the `restore` function MUST:
+
+- Read `update_id` and `target_path` from validated marker.
+- Compute expected backup path as `<dir(target_path)>/.macprovider-cli.rollback-<update_id>`.
+- Read marker's `backup_path` field; reject restore if it does NOT
+  match the expected derivation.
+- Canonicalize parents of `target_path` and `backup_path`; reject if
+  either is outside the trusted binary directory.
+- Reject if either path crosses a symlink, has non-provider-owner, or
+  has group/world/non-owner-ACL write.
+
+### T-4: Convergence boundary enforcement (A-r1-H-4)
+
+In `phase3-binary/Sources/macprovider-cli/AutoUpdater.swift`:
+
+- Replace `fileExists(watchdogPlist)` check with active enablement
+  detection: run `launchctl print gui/<uid>/live.streamvc.macprovider-watchdog`
+  and verify the service is loaded AND not disabled. If unavailable,
+  fail closed with `failure_class:"rollback_observer_unavailable"`.
+- For the main LaunchAgent: `restartLaunchdIfInstalled` MUST NOT
+  silently return if plist is absent AFTER swap. Refactor:
+  pre-validate the LaunchAgent plist is present AND loaded BEFORE
+  any state mutation. If not, fail closed with
+  `failure_class:"unsupported_install_topology"`.
+
+Add `unsupported_install_topology` to the failure_class enum in
+`AutoUpdateEvent.swift` if not present.
+
+### T-5: ACL checks on trusted root (C-r1-H-2)
+
+In `phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift`
+`validateTrustedRoot()` (~line 273):
+
+For each ancestor of `$HOME/.local/share/macprovider/autoupdate/`:
+- Call `acl_get_link_np(path, ACL_TYPE_EXTENDED)`.
+- Iterate entries with `acl_get_entry(...)`.
+- For each entry, get tag (`acl_get_tag_type`) and permset (`acl_get_permset`).
+- Reject if the entry grants `ACL_WRITE_DATA` / `ACL_APPEND_DATA` /
+  `ACL_ADD_FILE` to any tag OTHER than `ACL_USER` matching provider's
+  effective UID, or to `ACL_GROUP` / `ACL_OTHER`.
+
+In `ops/macprovider-watchdog/watchdog.sh` `validate_trusted_root()`
+(~line 167):
+
+Use `ls -le <path>` (macOS) to display ACL entries; parse each `0:`,
+`1:`, etc. line; reject if any line shows write/append for non-owner.
+
+Helper invocation example:
+```sh
+ls -le "$path" | awk '/^[ 0-9]+:/ {if ($0 ~ /write|append/ && $0 !~ /^ *[0-9]+: user:'"$PROVIDER_USER"'/) exit 1}'
+```
+
+### Cooldown double-count (B-r1-H-1)
+
+In `phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift`
+`recordCooldown(target:failureClass:)` (~line 225):
+
+This is the ONE site that owns cooldown persistence. It increments
+attempt AND applies the formula. Other paths (`fail()` and friends
+in `AutoUpdater.swift` lines 120, 129, 137, 153, 246) MUST NOT also
+call `recordCooldown` for the same logical failure.
+
+Refactor: `AutoUpdater.fail(reason: FailureClass)` calls
+`recordCooldown` exactly once per outer attempt; callers that already
+called `fail()` MUST NOT also call `recordCooldown` directly.
+
+Add a unit test that asserts: 1 failure → attempt 1, cooldown 300s.
+3 consecutive failures → attempt 3, cooldown 1200s. 4+ → 3600s cap.
+
+## Non-convergent MEDIUMs
+
+**C-r1-M-3 — wire signed-policy persistence**:
+
+In `SelfUpdate.swift`:
+- Extend `GitHubRelease` to decode signed-policy metadata if present
+  (probably embedded in the release body or via a separate signed
+  artifact like `signed_policy.json` adjacent to `checksums.txt`).
+- After signature/checksum validation passes, before applying the
+  update, call `AutoUpdateMarkerStore.updateSignedPolicy(...)` to
+  fold the observed `signed_policy_minimum` / `signed_policy_revoked`
+  into the persisted monotonic state.
+- Add unit tests for: attempting to lower the floor (rejected),
+  attempting to remove from revoked set (rejected), legitimate
+  raise/add (accepted + persisted).
+
+**C-r1-M-4 — event reason redaction**:
+
+In `AutoUpdater.swift` (lines 130, 154 and similar):
+
+Replace `String(describing: error)` with a mapping function that
+returns a stable `failure_class` enum value + a redacted reason
+string. The reason MUST NOT include:
+- Full URLs (strip query string + fragment; keep only host).
+- Absolute paths (replace with `<binary-dir>` / `<state-root>` placeholders).
+- Raw checksum / signature material.
+- Free-text error strings (truncate to enum-tagged structured reason).
+
+Add a test that takes every `UpdateError` case, runs it through the
+redaction pipeline, and asserts the output contains no raw URLs /
+paths / hex over 16 chars.
+
+**C-r1-M-5 — O_NOFOLLOW on reads**:
+
+In `AutoUpdateMarker.swift` `readPending()`, `validateBackup()`, and
+the SHA helper (~lines 157, 178, 409):
+
+Replace `Data(contentsOf: url)` with:
+```swift
+let fd = open(url.path, O_RDONLY | O_NOFOLLOW)
+defer { close(fd) }
+var st = stat()
+fstat(fd, &st)
+// verify inode/mode/links/owner against expected
+// read data via Data(fileDescriptor:)
+```
+
+Pattern: lstat-then-open is TOCTOU; use O_NOFOLLOW + fstat instead.
+
+**B-r1-M-1 — AC coverage**:
+
+Add focused unit tests in
+`phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift`:
+- AC-V0.1-10: each of `post_start_crash`, `post_start_health_failed`, `post_start_rejoin_timeout` triggers rollback with the correct failure_class.
+- AC-V0.1-17: `event_payload_too_large` fallback emits a minimal stable payload.
+- AC-V0.1-19: orphaned pending marker recovery path.
+- AC-V0.1-20: corrupt rollback backup recovery path.
+- AC-V0.1-22: trust-state-lost between auth_response and swap → no swap occurs.
+- AC-V0.1-23: success cleanup happy path + crash-between-each-step recovery.
+
+Add a watchdog integration test (shell-level) for AC-V0.1-19/20.
+
+## Process
+
+1. Read `specs/SPEC-020-IMPL-r1-audit.md` for context.
+2. Apply each fix above (be liberal about adding small refactor commits
+   if it improves clarity; squash later or keep as commit history).
+3. Update tests for each absorbed finding.
+4. Run `swift test` from `phase3-binary/` and `go test ./internal/ws/... ./internal/pool/...` from `phase4-coordinator/`. Both green.
+5. Run `bash -n ops/macprovider-watchdog/watchdog.sh`.
+6. Update `failure_class` enum if new values were added
+   (`unsupported_install_topology`).
+7. Output: commits on `impl/spec-020-provider-autoupdate`. Tests green.
+
+You are absorbing — not re-auditing. Goal: r2 = 0/0/0.

--- a/specs/AUDIT_SPEC_020_v0_1_IMPL_r1_PROMPT.md
+++ b/specs/AUDIT_SPEC_020_v0_1_IMPL_r1_PROMPT.md
@@ -1,0 +1,171 @@
+# SPEC-020 v0.1.4 IMPL — Round 1 audit prompt (per-lane)
+
+You are auditing the **IMPL** of SPEC-020 v0.1.4 LOCKED at commit
+`37514b9` on `impl/spec-020-provider-autoupdate` in worktree
+`/Users/augstar/macprovider-spec-020-impl`.
+
+**Bar: 0 CRITICAL + 0 HIGH + 0 MEDIUM before the IMPL PR opens.**
+Findings get absorbed and another round fires.
+
+## What you are auditing
+
+The IMPL of SPEC-020 v0.1.4 provider autoupdate. The SPEC is normative
+and is at `specs/SPEC-020-provider-autoupdate.md` (LOCKED, do not
+audit). Your job: does the IMPL faithfully execute every R-N.M
+normative requirement and every AC-V0.1-N acceptance criterion?
+
+The IMPL changes (14 files, +1997 / -133):
+
+**New Swift files** (`phase3-binary/Sources/macprovider-cli/`):
+- `AutoUpdater.swift` (336 lines) — orchestrator
+- `AutoUpdateTrustState.swift` (104 lines) — trust-state matrix + live predicate
+- `AutoUpdateMarker.swift` (432 lines) — marker/backup/lock/recovery
+- `AutoUpdateEvent.swift` (242 lines) — structured event envelope
+
+**Modified Swift files**:
+- `SelfUpdate.swift` (+148 lines) — added `runByTag` + `release_asset_missing`
+- `CoordinatorClient.swift` (+193 lines) — auto-invocation wiring + `autoupdate_drain_extensions` parsing + `last_autoupdate_event` emission + binaryVersion 1.6.1 → 1.7.0
+- `MacProviderCore/Config.swift` (+6) — opt-out compat for both legacy + SPEC keys
+
+**Coordinator (Go)**:
+- `internal/ws/messages.go` (+105) — `AutoupdateDrainExtensions` on HelloAck/AuthResponse; `LastAutoupdateEvent` on Heartbeat/StateUpdate; `timeout_skipped` drain phase accepted
+- `internal/ws/messages_test.go` (+69) — tests for above
+- `internal/ws/server.go` (+54) — advertise `AutoupdateDrainExtensions:true`; round-trip event
+- `internal/pool/provider.go` (+30) — pool-side event accommodation
+
+**Watchdog (shell)**:
+- `ops/macprovider-watchdog/watchdog.sh` (+228) — rollback-observer extensions
+
+**Tests**:
+- `phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift` (173 lines, new)
+- `phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift` (+10)
+
+## Smoke status
+
+- `swift test` 651 tests pass / 0 fail
+- `go test ./internal/ws/... ./internal/pool/...` PASS
+- `bash -n ops/macprovider-watchdog/watchdog.sh` PASS
+- `binaryVersion` constant: 1.7.0 ✓
+- SPEC file unmodified ✓
+
+## How to return your verdict
+
+`VERDICT: READY TO MERGE` if zero blocking findings. Otherwise
+`VERDICT: NEEDS REVISION` with C/H/M counts + ID-prefixed findings
+(`A-r1-H-1`, `B-r1-M-1`, etc.) including file:line citations + the
+SPEC R-N.M or AC-V0.1-N being violated + a concrete fix.
+
+## Lane-specific focus
+
+### Lane A — Codex architect
+
+- **Live trust-state predicate completeness**: does the IMPL actually
+  re-evaluate trust before EACH of the 5 phases (download, drain,
+  marker, swap, launchctl bootstrap)? Or does it check once at the
+  top of `AutoUpdater.run()`? File:line citations.
+- **Comparator binding**: every place that compares versions
+  (recommendation check, downgrade refusal, status display, cooldown
+  key) MUST use `SelfUpdate.compareSemver` (per SPEC R-1.1 +
+  A-r1-M-3 from SPEC audit). Trace each call site. Flag any duplicate
+  comparator implementation.
+- **NORMALIZED_TARGET propagation**: target normalization at one site,
+  used everywhere downstream (release lookup, marker `target_version`,
+  drain reason `state_update.reason`, cooldown key). Trace every use.
+- **Drain protocol**: is the autoupdate drain (provider-initiated)
+  distinguishable from coord-initiated drain at the wire level? Does
+  it emit `state_update.reason = "autoupdate_to_<NORMALIZED_TARGET>"`?
+- **Capability gate**: provider only emits `drain_status.phase:"timeout_skipped"`
+  when coord has advertised `autoupdate_drain_extensions:true`. If
+  capability missing, fall back to `complete`. Confirm.
+- **Convergence boundary**: are opt-out + watchdog-disabled paths
+  handled per SPEC's convergence-boundary paragraph?
+- **Cross-spec interaction**: in-flight SPEC-018/019 streaming
+  requests during drain — does the IMPL honor "in-flight takes
+  precedence" per the SPEC?
+
+### Lane B — Codex code
+
+- **Citation verify**: any SPEC R-N.M cite in code comments must
+  resolve to the SPEC's actual line numbers.
+- **Trusted state root invariants**: `O_NOFOLLOW` + `O_EXCL` + mode
+  0600/0700 + `fsync` + atomic rename + lstat ancestor checks for
+  marker, backup, sentinel, lock. Are ALL invariants present in the
+  Swift code? Specifically:
+  - `AutoUpdateMarker.swift` should `open(..., O_CREAT|O_EXCL|O_NOFOLLOW)`
+    on create paths.
+  - `flock(LOCK_EX|LOCK_NB)` (or `fcntl(F_SETLK)`) for `update.lock`.
+  - `fsync()` file + parent dir before rename.
+  - lstat each ancestor of `$HOME/.local/share/macprovider/autoupdate/`
+    to reject symlinks / non-owner ownership / unexpected mount
+    boundaries.
+- **Marker JSON schema**: `pending.json` field types match SPEC
+  (update_id UUIDv4 36-char, target_version normalized, mode decimal
+  int of octal, sha256 lowercase 64-hex, marker_deadline RFC3339).
+- **Cooldown formula**: `min(300s × 2^(attempt-1), 3600s)`. Where
+  is `attempt` stored across restarts? Is the persistence
+  crash-safe?
+- **Crash recovery state machine**: on every provider startup, IMPL
+  scans for success sentinel + orphaned pending marker + corrupt
+  rollback backup. Trace AutoUpdateMarker / watchdog code paths.
+  Verify the 5-step ordered cleanup sequence on success
+  (sentinel → unlink pending → delete backup → release lock → emit
+  event) is atomic-recoverable on crash between any pair of steps.
+- **Watchdog interaction**: `ops/macprovider-watchdog/watchdog.sh`
+  must lstat marker/backup, reject symlinks, validate backup SHA-256
+  before restore. Spot-check the shell.
+- **failure_class enum exhaustive**: every emit-side `failure_class`
+  string is in the SPEC's R-6.5 enum AND in the IMPL's enum/switch.
+  No raw "other" used where a specific class would fit.
+- **Event payload bound**: 4096 bytes on `last_autoupdate_event`
+  object alone before embedding. Where is the size check? Where is
+  optional-field-drop logic? Test coverage for `event_payload_too_large`
+  fallback path.
+- **Test coverage for AC-V0.1-1..23**: do `AutoUpdateTests.swift` +
+  watchdog tests cover EVERY AC? Specifically:
+  - AC-22 trust-state-lost between auth_response and swap
+  - AC-23 success-cleanup happy path + each crash-between-step path
+  - AC-10 (post_start_crash / post_start_health_failed / post_start_rejoin_timeout)
+  - Orphaned-marker recovery
+  - Rollback-backup-corrupt recovery
+- **Opt-out compat**: BOTH `auto_update_enabled` AND `autoupdate.enabled`
+  honored; BOTH `MACPROVIDER_AUTO_UPDATE_ENABLED` AND `MACPROVIDER_AUTOUPDATE`
+  honored. Explicit-disabled wins. Trace `Config.swift` changes.
+- **Compiler warnings**: any `warning:` in Swift build output for
+  the new files? Sendable, Result-builder, deprecated APIs?
+
+### Lane C — Codex security
+
+- **`O_NOFOLLOW` + `O_EXCL` on all file creates**: marker, backup,
+  sentinel, lock. Audit every `open()`, `creat()`, `FileManager.create*`
+  in the new files. Any missed?
+- **`lstat` (NOT `stat`) on ancestor checks**: stat follows symlinks,
+  lstat doesn't. The trusted-state-root invariant requires lstat.
+  Confirm `AutoUpdateMarker.swift` uses lstat-based checks.
+- **SHA-256 verification before restore**: watchdog rollback path
+  MUST hash-verify the backup before invoking restore. Audit
+  `watchdog.sh` for the verification step.
+- **Live trust-state matrix coverage**: does
+  `AutoUpdateTrustState.swift` actually distinguish (a) v2 accepted +
+  pinned + encrypted-leg succeeded + attestation satisfied + token
+  validated = eligible from (b) v2 accepted + pinned + encrypted-leg
+  failed = notify-only? Trace the trust-state evaluator.
+- **`update_id` randomness**: UUIDv4 from cryptographic RNG (Swift
+  `UUID()` uses `arc4random` which is CSPRNG — verify) vs predictable
+  source. If predictable, attacker can pre-stage a success sentinel.
+- **Persisted monotonic signed-policy state**: where is
+  `persisted_signed_policy_minimum` / `persisted_signed_policy_revoked`
+  written? Same trusted-state-root invariants apply. Audit.
+- **Event payload secret-leak**: redaction priority list (drop
+  `extra_metadata`, `attempt_history`, `release_url`, free-text
+  `reason`) implemented? Tests for no-leak invariant?
+- **Coordinator-attacker DoS**: malicious coord advertises 5000-byte
+  `recommended_binary_version` → SPEC mandates 32-byte cap +
+  redaction. Where is the check? Test coverage?
+
+---
+
+## Output format
+
+`VERDICT: READY TO MERGE` if 0/0/0. Else `VERDICT: NEEDS REVISION`
+with counts + findings. Include file:line citations for every
+finding. Convergent cross-lane findings = strongest signal.

--- a/specs/AUDIT_SPEC_020_v0_1_IMPL_r2_ABSORPTION_PROMPT.md
+++ b/specs/AUDIT_SPEC_020_v0_1_IMPL_r2_ABSORPTION_PROMPT.md
@@ -1,0 +1,176 @@
+# SPEC-020 IMPL r2 → r3 absorption prompt
+
+You are absorbing IMPL round-2 audit findings in worktree
+`/Users/augstar/macprovider-spec-020-impl` on `impl/spec-020-provider-autoupdate`.
+
+**Bar:** IMPL r3 must return 0/0/0. Read `specs/SPEC-020-IMPL-r2-audit.md`
+for full per-finding text. r2 totals: 0C + 4H + 4M (down from r1's 12H/6M).
+
+## Convergent fix (B+C, both HIGH)
+
+**Restore-before-cleanup in orphan recovery (B-r2-H-2 + C-r2-H-1).**
+
+In `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift` (~line 1442):
+
+Replace the `fileExists(updateLockPath)` check with an active-flock test:
+```swift
+private func updateLockIsLive(at path: URL) -> Bool {
+    let fd = open(path.path, O_RDWR | O_NOFOLLOW)
+    guard fd >= 0 else { return false }
+    defer { close(fd) }
+    var fl = flock(l_start: 0, l_len: 0, l_pid: 0, l_type: Int16(F_WRLCK), l_whence: Int16(SEEK_SET))
+    // F_GETLK probes without acquiring; on macOS prefer flock(LOCK_EX|LOCK_NB).
+    let rc = Darwin.flock(fd, LOCK_EX | LOCK_NB)
+    if rc == 0 {
+        // Acquired: lock is stale. Release.
+        _ = Darwin.flock(fd, LOCK_UN)
+        return false
+    }
+    return errno == EWOULDBLOCK  // live lock held by another process
+}
+```
+
+(Implementation detail — pick whichever works on macOS. The semantics: return `true` only when another live process holds the lock.)
+
+In `AutoUpdateMarker.swift` `orphanPendingMarker` (~line 261), rewrite
+to `recoverOrphanedMarker(marker:)`:
+
+```
+1. Validate marker shape via existing shared `validateMarker(_:)`.
+   If invalid → quarantine (rename pending.json → pending-quarantined-<timestamp>.json),
+   delete backup if present, emit failure_class:"orphaned_pending_marker" with reason "marker_invalid", record cooldown, release lock, return.
+2. Compute backup hash. If backup missing OR hash mismatch:
+   - Emit failure_class:"rollback_backup_corrupt".
+   - Quarantine marker, leave live binary alone (do NOT restore, do NOT delete).
+   - Disable autoupdate for this session.
+   - Release lock. Return.
+3. Backup valid → call AutoUpdateMarkerStore.restoreBackup(updateID:),
+   which atomically renames backup → target_path (the live binary).
+4. Delete marker + backup.
+5. Record cooldown keyed by (NORMALIZED_TARGET, "orphaned_pending_marker").
+6. Emit failure_class:"orphaned_pending_marker" with outcome:"failure", phase:"rollback".
+7. Release lock.
+```
+
+Watchdog: `ops/macprovider-watchdog/watchdog.sh` `restore` function (~line 389+) should mirror the same restore-then-delete pattern. Currently `restore` does call the backup-validate path; verify it's invoked from BOTH the stale-pending-marker path AND the post-start-failure path. If a code path goes "no sentinel → restore" without verifying backup hash first, fix it.
+
+## Lane B HIGHs
+
+### B-r2-H-1: Watchdog must respect 60s post-start window
+
+In `ops/macprovider-watchdog/watchdog.sh`:
+
+- Around line 471 (`restore(marker)` call when no sentinel): add a deadline check first.
+- Around line 448 (classifies running provider as `post_start_rejoin_timeout`): same.
+
+Logic:
+1. Parse `marker_deadline` from `pending.json` (RFC 3339).
+2. Compute `now = date -u +%s` and `deadline = date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$deadline_str" +%s`.
+3. If `now < deadline`: still inside post-start window. Do NOT roll back. Exit cleanly.
+4. If `now >= deadline`: classify the rollback reason:
+   - Check `launchctl print gui/<uid>/live.streamvc.macprovider`:
+     - If last exit status non-zero / process not running → `post_start_crash`.
+     - If running but `/healthz` probe fails → `post_start_health_failed`.
+     - If running + healthy but `binary_version` (from `--version` or healthz response) != NORMALIZED_TARGET → `post_start_rejoin_timeout`.
+5. Call `restore(marker)` with classified reason.
+
+(Swift side: equivalent check in `AutoUpdateMarker.swift` startup recovery — verify marker_deadline expired before triggering rollback.)
+
+### B-r2-H-3: Success sentinel durable until coord-visible event
+
+Reorder `AutoUpdater.swift` post-start success sequence:
+
+Current order (broken):
+1. Sentinel write.
+2. Pending unlink.
+3. Backup delete.
+4. Sentinel delete (during finalize).
+5. sendStateUpdate with success.
+
+New order:
+1. Sentinel write (durable anchor).
+2. Pending unlink.
+3. Backup delete.
+4. Lock release.
+5. **sendStateUpdate** with `outcome:"success", phase:"post_start", target_version, binary_version` (sentinel still present).
+6. AWAIT send completion (synchronously, via `try await send(...)`).
+7. **THEN** delete sentinel.
+
+Crash between (6) and (7) → next startup sees sentinel + current binary_version matches target → delayed cleanup path (idempotent: just delete the sentinel).
+
+Crash between (4) and (5) → sentinel still present → same delayed cleanup.
+
+Crash between (1)–(3) → existing recovery handles via orphan marker.
+
+In `CoordinatorClient.swift` (around lines 1309, 1355):
+
+- Move sentinel deletion from `completeSuccessfulUpdate()` to a separate
+  `finalizeSuccessfulUpdate(updateID:)` call.
+- `completeSuccessfulUpdate()` returns AFTER (4). Caller invokes `sendStateUpdate(...)` to emit success. Then caller invokes `finalizeSuccessfulUpdate(updateID:)` to delete sentinel.
+
+Update AC-V0.1-23 tests to cover the new sequence: crash between each of (1)→(7) must be recoverable.
+
+## Lane MEDIUMs
+
+### A-r2-M-1: Notify-only pre-gate complete short-circuit
+
+In `CoordinatorClient.swift` ~line 1311:
+
+Current logic: only short-circuits notify-only when recommendation parses AND is newer.
+
+Replace with: if trust verdict is notify-only, emit notify event and return — regardless of recommendation parse/compare. The version check matters only for the eligible path:
+
+```swift
+let trust = await AutoUpdateTrustState.evaluate(...)
+if !trust.isEligible {
+    emitNotifyOnlyEvent(trust)
+    return
+}
+// only past this point do we parse + compare version, take lock, etc.
+```
+
+### C-r2-M-1: Watchdog binary-dir containment
+
+In `ops/macprovider-watchdog/watchdog.sh`:
+
+- Read `MACPROVIDER_BINARY_DIR` from env OR detect from launchd plist `ProgramArguments[0]`:
+  ```sh
+  plist_path="$HOME/Library/LaunchAgents/live.streamvc.macprovider.plist"
+  binary_dir=$(/usr/libexec/PlistBuddy -c 'Print ProgramArguments:0' "$plist_path" 2>/dev/null | xargs dirname)
+  ```
+- In `restore`: require `realpath(dirname(target_path)) == realpath(binary_dir)`. Reject otherwise with `failure_class:"unsupported_install_topology"`.
+- Same check for `backup_path`.
+
+### C-r2-M-2: Signed-policy persistence deferred to post-apply
+
+In `phase3-binary/Sources/macprovider-cli/SelfUpdate.swift`:
+
+- Remove `updateSignedPolicy` call at ~line 100 (currently fires after checksum signature verification, BEFORE tarball validation).
+- Move the `updateSignedPolicy` call to AFTER `applyValidatedUpdate` completes successfully. The new binary is now live; the signed policy is real.
+- For coordinator-triggered updates that pass through `runByTag`: same deferral.
+
+(Alternative — bind `signed_policy.json` into the signed `checksums.txt` — defer to v0.2.)
+
+### B-r2-M-1: AC coverage tests
+
+Add focused unit tests in `AutoUpdateTests.swift`:
+
+- **AC-10**: 3 cases (`post_start_crash`, `post_start_health_failed`, `post_start_rejoin_timeout`) — each triggers rollback with correct failure_class. Mock `launchctl print` / healthz probe outputs.
+- **AC-17**: `event_payload_too_large` fallback — synthesize an event whose JSON-minified size exceeds 4096; assert all optional fields dropped in priority order; final fallback is minimal stable payload.
+- **AC-19**: orphan-pending-marker with valid backup → restore + delete marker.
+- **AC-20**: orphan-pending-marker with missing/corrupt backup → quarantine + no restore + autoupdate disabled for session.
+- **AC-22**: trust-loss-between-auth-and-swap (build on existing notify-only test).
+- **AC-23**: crash-between-each-step in the success cleanup sequence — simulate by partially completing the sequence then re-running startup recovery; assert idempotent + safe outcome.
+
+Watchdog: add shell-level integration test under `phase3-binary/Scripts/` or `ops/macprovider-watchdog/Scripts/` named `test-ac-19-20-watchdog-recovery.sh`. Create fake marker + backup; invoke watchdog tick; assert correct behavior.
+
+## Process
+
+1. Read `specs/SPEC-020-IMPL-r2-audit.md` for context.
+2. Apply each fix above.
+3. Run `swift test` from `phase3-binary/` AND `go test ./internal/ws/... ./internal/pool/...` from `phase4-coordinator/`. Both must be green.
+4. Run `bash -n ops/macprovider-watchdog/watchdog.sh`.
+5. Confirm no new `failure_class` values added that are absent from R-6.5 enum.
+6. Output: commits on `impl/spec-020-provider-autoupdate`. Tests green.
+
+You are absorbing — not re-auditing. Goal: r3 = 0/0/0.

--- a/specs/AUDIT_SPEC_020_v0_1_IMPL_r2_PROMPT.md
+++ b/specs/AUDIT_SPEC_020_v0_1_IMPL_r2_PROMPT.md
@@ -1,0 +1,126 @@
+# SPEC-020 v0.1.4 IMPL — Round 2 audit prompt (per-lane)
+
+You are auditing the **IMPL** of SPEC-020 v0.1.4 LOCKED at HEAD of
+`impl/spec-020-provider-autoupdate` in worktree
+`/Users/augstar/macprovider-spec-020-impl`.
+
+**Bar: 0 CRITICAL + 0 HIGH + 0 MEDIUM. Return `VERDICT: READY TO MERGE`
+if zero blocking findings.**
+
+## Trend
+
+- r1: 0C + 12H + 6M (3 lanes; trust-state lifecycle dominant convergence)
+- r2 target: 0/0/0
+
+## What changed since r1
+
+Three commits on top of the merged SPEC:
+
+1. **`37514b9`** — initial IMPL (the r1 audit target).
+2. **`d276886` — Absorb SPEC-020 autoupdate trust and recovery audit**
+   (+918 / -87 across 9 files). Read
+   `specs/SPEC-020-IMPL-r1-audit.md` for the r1 narrative the absorption
+   targeted, and `specs/AUDIT_SPEC_020_v0_1_IMPL_r1_ABSORPTION_PROMPT.md`
+   for the specific fixes applied.
+3. **`7941a49` — test: clear AutoUpdateEventStore in disabled-mode
+   heartbeat test** (5 lines) — minor: pre-existing
+   `testHeartbeatDisabledModeOmitsBothFields` was written before
+   `last_autoupdate_event` existed; absorption added a clear at test
+   setup to preserve the original test contract.
+
+The absorption targeted:
+- **T-1 Trust-state lifecycle** (A-r1-H-1 + A-r1-H-2 + A-r1-H-3 + C-r1-H-1): pre-gate notify-only BEFORE state mutation; track committed marker/backup/swap and rollback on late trust-loss; live predicate that re-evaluates from current session facts; demote on AEAD/tier/token/attestation events.
+- **T-2 Backup crash-safety** (B-r1-H-2 + C-r1-M-1): parent-dir fsync + ancestor validation.
+- **T-3 Recovery state machine** (B-r1-H-3..H-6 + C-r1-M-2): shared marker validator; startup recovery BEFORE handshake; sentinel as durable anchor; post-start classification; watchdog containment.
+- **T-4 Convergence boundary** (A-r1-H-4): fail-closed if rollback observer absent / launchd topology unsupported.
+- **T-5 ACL checks** (C-r1-H-2): non-owner-write ACL detection in Swift + watchdog.
+- **Cooldown double-count** (B-r1-H-1): exactly one path owns persistence.
+- **MEDIUMs**: signed-policy wired; event reason redaction; O_NOFOLLOW reads; AC coverage tests.
+
+## Smoke status
+
+- `swift test` from `phase3-binary/`: 655 tests pass / 0 fail / 7 skipped
+- `go test ./internal/ws/... ./internal/pool/...` from `phase4-coordinator/`: PASS
+- `bash -n ops/macprovider-watchdog/watchdog.sh`: PASS
+- `binaryVersion` constant: 1.7.0 ✓
+- SPEC file unmodified ✓
+
+## Lane-specific focus
+
+Lanes A + B + C: same lens as r1 IMPL audit. Re-verify each r1 finding
+was actually absorbed (not just superficially addressed). New findings
+welcome.
+
+### Lane A — Codex architect
+
+Specifically re-verify trust-state lifecycle fixes:
+- **A-r1-H-1 absorption**: pre-gate path. Notify-only verdict at
+  `acceptCoordinatorSession` MUST emit notify event only AND NOT call
+  any state-mutation code (`runAutoupdateIfEligible`, cooldown record,
+  attempt tracking, lock acquisition). Confirm.
+- **A-r1-H-2 + C-r1-H-1 absorption**: trust-loss-rollback. Trace the
+  catch path for `trustStateLost` in `AutoUpdater.swift`. After a
+  committed swap, does it call `AutoUpdateMarkerStore.restoreBackup`?
+  Does it clear pending + backup? Does it suppress launchctl
+  bootstrap?
+- **A-r1-H-3 absorption**: live predicate. `currentAutoupdateTrustState()`
+  must re-evaluate, not return cached. AEAD failure in
+  `InferenceRelay.swift` must demote with `encrypted_leg_invalidated`.
+- **A-r1-H-4 absorption**: convergence boundary. Watchdog availability
+  active-enablement detection (launchctl print, not just fileExists).
+  Pre-validate LaunchAgent loaded BEFORE swap.
+- Anything new architecturally that the absorption introduced?
+
+### Lane B — Codex code
+
+Re-verify each B-r1-H-N:
+- **B-r1-H-1 cooldown**: single owner. Trace every `recordCooldown` call
+  site. First-failure-attempt-1, 3-failures-attempt-3, 4+-capped-3600s.
+  Test exists.
+- **B-r1-H-2 backup crash-safety**: route through
+  `atomicCopyNoFollow` OR parent-dir fsync after rename. Inspect
+  `AutoUpdater.swift` rollback backup path.
+- **B-r1-H-3 marker validator**: shared `validateMarker` with all the
+  field checks (UUIDv4, normalized target, paths, mode bounds,
+  lowercase SHA, RFC3339 deadline). Used from `readPending` AND
+  `validateBackup` AND watchdog `read_marker`. Confirm.
+- **B-r1-H-4 startup recovery**: routine runs BEFORE handshake. Scans
+  pending markers, success sentinels, stale rollback backups. All 3
+  cases handled.
+- **B-r1-H-5 sentinel anchor**: sentinel preserved UNTIL after event
+  emission. Caller has access to `finalizeSuccessfulUpdate` (or
+  equivalent). Startup recovery handles sentinel-only states.
+- **B-r1-H-6 post-start classification**: `post_start_crash` vs
+  `post_start_health_failed` vs `post_start_rejoin_timeout` — observer
+  emits the correct one.
+- **B-r1-M-1 AC coverage**: ACs 10, 17, 19, 20, 22, 23 all have tests.
+- Anything new? `failure_class` enum exhaustive? `NORMALIZED_TARGET`
+  propagation still consistent? Compiler warnings introduced?
+
+### Lane C — Codex security
+
+Re-verify each C-r1-H/M:
+- **C-r1-H-1 trust-loss rollback** (= A-r1-H-2): confirm absorption.
+- **C-r1-H-2 ACL checks**: Swift inspects ACLs via `acl_get_link_np` /
+  `acl_get_entry` on every trusted-root ancestor; rejects non-owner
+  write ACLs. Watchdog uses `ls -le` equivalent. Trace.
+- **C-r1-M-1 backup fsync**: parent dir fsync added.
+- **C-r1-M-2 watchdog containment**: restore path derives expected
+  backup path from `target_path` + `update_id`, rejects mismatch,
+  canonicalizes parents, rejects out-of-trust-boundary.
+- **C-r1-M-3 signed-policy wired**: `updateSignedPolicy` called from
+  validated-release path. Tests for monotonic invariant.
+- **C-r1-M-4 redaction**: error reasons mapped to stable codes, no
+  raw URLs / paths / hex over N chars.
+- **C-r1-M-5 O_NOFOLLOW reads**: `Data(contentsOf:)` replaced with
+  `open(O_RDONLY|O_NOFOLLOW)` + `fstat`.
+- Anything new? Persistent monotonic state vulnerable to local
+  tampering?
+
+---
+
+## Output format
+
+`VERDICT: READY TO MERGE` if 0/0/0. Else `VERDICT: NEEDS REVISION`
+with counts + ID-prefixed findings (`A-r2-H-1` etc.) + file:line.
+Convergent cross-lane findings = strongest signal.

--- a/specs/AUDIT_SPEC_020_v0_1_IMPL_r3_ABSORPTION_PROMPT.md
+++ b/specs/AUDIT_SPEC_020_v0_1_IMPL_r3_ABSORPTION_PROMPT.md
@@ -1,0 +1,138 @@
+# SPEC-020 IMPL r3 → r4 absorption prompt
+
+You are absorbing IMPL round-3 audit findings in worktree
+`/Users/augstar/macprovider-spec-020-impl` on `impl/spec-020-provider-autoupdate`.
+
+**Bar:** IMPL r4 must return 0/0/0. Read `specs/SPEC-020-IMPL-r3-audit.md`
+for full per-finding text. r3 totals: 0C + 3H + 2M (down from r2's 4H/4M).
+
+## Convergent fix (A+C, both HIGH) — sentinel/recovery integrity
+
+In `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift` startup
+recovery (~lines 1409-1419):
+
+Replace the current sentinel-scan logic with:
+
+```
+For each .macprovider-cli.success-<uuid> sentinel in <binary-dir>:
+  1. Load sentinel payload (atomic O_NOFOLLOW read + JSON decode + validate UUIDv4).
+  2. Validate sentinel.binary_version == CoordinatorClient.binaryVersion.
+     - Mismatch: emit failure_class:"orphaned_success_sentinel"
+       with reason "binary_version_mismatch", delete just the sentinel,
+       do NOT touch pending/backup, continue.
+  3. Look up matching pending.json:
+     - If pending absent: emit failure_class:"orphaned_success_sentinel"
+       with reason "no_matching_pending", delete just the sentinel,
+       do NOT touch backup (the backup, if present, is stale and will
+       be cleaned by the stale-backup-without-pending scan).
+     - If pending present BUT pending.update_id != sentinel.update_id:
+       this is the pre-staged-sentinel attack path or a leftover from
+       a prior failed update. Emit failure_class:"orphaned_success_sentinel"
+       with reason "update_id_mismatch", delete just the sentinel,
+       do NOT touch pending/backup. The orphan-pending-recovery routine
+       will handle the legitimate pending marker on its own.
+     - If pending present AND update_id matches: continue to step 4.
+  4. Send the coord-visible success event FIRST via sendStateUpdate
+     (outcome:"success", phase:"post_start", target_version, binary_version).
+     AWAIT delivery to coordinator.
+  5. Call completeSuccessfulUpdate(pending) — unlinks pending,
+     deletes backup, releases lock.
+  6. Call finalizeSuccessfulUpdate(updateID:) — deletes the sentinel.
+```
+
+Sentinel remains durable across crash between any pair of steps. Crash between (4) and (5) → next startup re-runs the recovery and the send is idempotent at the coord side; pending+backup still present. Crash between (5) and (6) → next startup finds sentinel without matching pending → goes to step 3's "no_matching_pending" path which is safe.
+
+Add tests for AC-22 covering pre-staged sentinel attack (sentinel exists with `update_id` not matching pending) → assert no swap-cleanup occurs + correct event emitted.
+
+## Standalone HIGH — C-r3-H-2 marker_deadline tolerance
+
+In `phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift` `validateMarker` (~line 401):
+
+Replace `now + 24h` upper bound with `now + post_start_window + 30 min`.
+
+```swift
+let postStartWindowSeconds: TimeInterval = 60   // current default
+let futureToleranceSeconds: TimeInterval = postStartWindowSeconds + 30 * 60  // 1860 s
+let upperBound = Date().addingTimeInterval(futureToleranceSeconds)
+guard marker.markerDeadline <= upperBound else {
+    throw MarkerValidationError.markerDeadlineFutureBeyondTolerance
+}
+```
+
+Lower bound stays at `now - 300s` (5 min tolerance for slight clock drift on otherwise valid markers).
+
+In `ops/macprovider-watchdog/watchdog.sh` (~line 249):
+
+```sh
+post_start_window=60
+future_tolerance=$(( post_start_window + 30 * 60 ))
+upper_bound=$(( now + future_tolerance ))
+if [ "$deadline_epoch" -gt "$upper_bound" ]; then
+    emit_failure "orphaned_pending_marker" "marker_deadline_future_beyond_tolerance"
+    quarantine_marker
+    exit 0
+fi
+```
+
+Both Swift and shell sides must use the same tolerance.
+
+## Standalone MEDIUMs
+
+### C-r3-M-1: Replace `try?` on signed-policy persist
+
+In `phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift` `updateSignedPolicy` (~line 364):
+
+```swift
+do {
+    let data = try encoder.encode(combinedPolicy)
+    try data.write(to: signedPolicyPath, options: [.atomic, .completeFileProtection])
+} catch {
+    // Persist failed. Best-effort rollback:
+    //   - If backup is still present, restore it (we just swapped successfully,
+    //     so backup exists until finalizeSuccessfulUpdate).
+    //   - Emit failure_class:"signed_policy_persist_failed".
+    //   - Disable autoupdate for the session.
+    if FileManager.default.fileExists(atPath: backupPath.path) {
+        try? AutoUpdateMarkerStore.restoreBackup(updateID: updateID)
+    }
+    AutoUpdateEventStore.shared.record(.failure(
+        failureClass: "signed_policy_persist_failed",
+        reason: String(describing: error).redacted()
+    ))
+    SessionAutoupdateGate.shared.disable(reason: "signed_policy_persist_failed")
+    throw error
+}
+```
+
+Add `signed_policy_persist_failed` to R-6.5 enum in `AutoUpdateEvent.swift`.
+
+### B-r3-M-1: Test assertions for AC-10 + AC-22 + AC-23
+
+**AC-10 watchdog tests**: Extend `ops/macprovider-watchdog/Scripts/test-ac-19-20-watchdog-recovery.sh` (or new `test-ac-10-post-start-classifications.sh`) to cover:
+
+1. `post_start_crash`: fake `launchctl print` showing last_exit_status != 0 → assert rollback emitted with this failure_class.
+2. `post_start_health_failed`: fake /healthz returning 5xx → assert this class.
+3. `post_start_rejoin_timeout`: fake healthz 200 + version probe returning != target → assert this class.
+
+Each fake can be a small shell function or test fixture file the watchdog reads from when `TEST_MODE=1` env var is set.
+
+**AC-22 Swift test**: Add `testTrustLossBetweenAuthAndSwapAbortsAutoupdate` in `AutoUpdateTests.swift`. Setup:
+- Mock AutoUpdateTrustState.evaluate to return eligible at first call, then notify-only at subsequent calls.
+- Drive AutoUpdater.run() to completion.
+- Assert: no swap occurred (binary unchanged), `trust_state_lost` event emitted, partial state cleaned.
+
+**AC-23 Swift test**: Add `testSuccessFinalizeOnlyAfterCoordSendReturns` in `AutoUpdateTests.swift`. Setup:
+- Mock CoordinatorFrameRecorder to delay/track sendStateUpdate calls.
+- Drive completeSuccessfulUpdate + sendStateUpdate + finalizeSuccessfulUpdate.
+- Assert: finalize is called AFTER send returns. Sentinel still on disk between send-initiate and send-return.
+
+## Process
+
+1. Read `specs/SPEC-020-IMPL-r3-audit.md` for context.
+2. Apply each fix above.
+3. Run `swift test` from `phase3-binary/` AND `go test ./internal/ws/... ./internal/pool/...` from `phase4-coordinator/`. Both must be green.
+4. Run `bash -n ops/macprovider-watchdog/watchdog.sh` AND `bash ops/macprovider-watchdog/Scripts/test-ac-19-20-watchdog-recovery.sh` (and the new AC-10 test if you split it).
+5. Confirm `signed_policy_persist_failed` value is added to the R-6.5 enum in `AutoUpdateEvent.swift` and the watchdog enum.
+6. Output: commits on `impl/spec-020-provider-autoupdate`. Tests green.
+
+You are absorbing — not re-auditing. Goal: r4 = 0/0/0.

--- a/specs/AUDIT_SPEC_020_v0_1_IMPL_r3_PROMPT.md
+++ b/specs/AUDIT_SPEC_020_v0_1_IMPL_r3_PROMPT.md
@@ -1,0 +1,78 @@
+# SPEC-020 v0.1.4 IMPL — Round 3 audit prompt (per-lane)
+
+You are auditing the **IMPL** of SPEC-020 v0.1.4 LOCKED at HEAD of
+`impl/spec-020-provider-autoupdate` in worktree
+`/Users/augstar/macprovider-spec-020-impl`.
+
+**Bar: 0 CRITICAL + 0 HIGH + 0 MEDIUM. Return `VERDICT: READY TO MERGE`
+if zero blocking findings.**
+
+## Trend
+
+- IMPL r1: 0C + 12H + 6M
+- IMPL r2: 0C +  4H + 4M
+- IMPL r3 target: 0/0/0
+
+## What changed since r2
+
+Commit `8161aab` — "Restore before autoupdate recovery cleanup"
+(+520 / -67 across 8 files). Read `specs/SPEC-020-IMPL-r2-audit.md`
+for r2 narrative and `specs/AUDIT_SPEC_020_v0_1_IMPL_r2_ABSORPTION_PROMPT.md`
+for the absorption fixes.
+
+The absorption targeted:
+- **Convergent (B+C, both HIGH)**: orphan-marker recovery restores backup BEFORE cleanup (active-flock test, validate marker, validate backup hash, restore-if-valid OR quarantine-if-corrupt, THEN delete marker + record cooldown).
+- **B-r2-H-1**: watchdog respects 60s post-start window via `marker_deadline` parse; classifies into `post_start_crash` / `post_start_health_failed` / `post_start_rejoin_timeout` based on launchctl print + healthz probe.
+- **B-r2-H-3**: success sentinel preserved across the coord-visible event send. New order: write sentinel → unlink pending → delete backup → release lock → sendStateUpdate (sentinel still alive) → AWAIT send completion → delete sentinel.
+- **A-r2-M-1**: notify-only pre-gate short-circuits ALL notify-only verdicts regardless of recommendation parse/compare.
+- **C-r2-M-1**: watchdog binary-dir containment — derive binary_dir from launchd plist ProgramArguments[0]; reject if target/backup not in real binary dir.
+- **C-r2-M-2**: signed-policy persistence deferred to AFTER `applyValidatedUpdate` completes.
+- **B-r2-M-1**: AC coverage — added tests for AC-10 (3 classifications), AC-17 (event_payload_too_large fallback), AC-19 (orphan restore), AC-20 (corrupt quarantine), AC-22 (trust-loss after auth), AC-23 (crash-between-cleanup-step). Also new shell-level watchdog integration test `phase3-binary/Scripts/test-ac-19-20-watchdog-recovery.sh`.
+
+Counts: 659 swift tests pass (was 655; +4 ACs), Go tests pass, watchdog syntax pass.
+
+## Authoritative inputs
+
+- IMPL at HEAD of `impl/spec-020-provider-autoupdate`
+- SPEC at `specs/SPEC-020-provider-autoupdate.md` (LOCKED, do not audit)
+- r1 narrative at `specs/SPEC-020-IMPL-r1-audit.md`
+- r2 narrative at `specs/SPEC-020-IMPL-r2-audit.md`
+
+## Lane-specific focus
+
+Re-verify each r2 finding was actually absorbed.
+
+### Lane A — Codex architect
+
+- **Convergent restore-before-cleanup**: trace `recoverOrphanedMarker` (or renamed equivalent) end-to-end. Active-flock test correctness? Hash-mismatch quarantine path?
+- **B-r2-H-1 absorption**: marker_deadline-respecting watchdog timing. Is there still a window where watchdog can roll back a normal still-starting binary?
+- **B-r2-H-3 absorption**: success sentinel lifecycle. Trace AutoUpdater + CoordinatorClient. Confirm sentinel survives across `sendStateUpdate`.
+- **A-r2-M-1 absorption**: pre-gate completeness for all notify-only paths (invalid / equal / older / malformed).
+- New architectural issues: any cycle, contradiction, or invariant broken by the absorption?
+
+### Lane B — Codex code
+
+- Same restore-before-cleanup trace, with file:line citations.
+- `marker_deadline` parsing correctness in both Swift and shell (cross-platform date handling).
+- Sentinel finalize ordering — is `finalizeSuccessfulUpdate(updateID:)` invoked exactly once per success, AFTER `sendStateUpdate` returns?
+- Watchdog binary-dir detection: PlistBuddy invocation correct? Handles missing plist gracefully?
+- Signed-policy deferral: now after `applyValidatedUpdate` — confirm call site moved.
+- AC tests landed: AC-10, AC-17, AC-19, AC-20, AC-22, AC-23. Confirm each has a real assertion (not just a stub).
+- Compiler warnings? Anything in the absorbed code raises Swift 6 strict concurrency warnings?
+
+### Lane C — Codex security
+
+- Restore-before-cleanup adversarial trace: can a stale lockfile + malformed marker cause incorrect restore?
+- `marker_deadline` clock manipulation: if attacker sets future deadline via marker tampering, does it get caught by validation?
+- Sentinel persistence: if attacker pre-stages sentinel with valid update_id + binary_version match, can they bypass the success path? (Should require: trusted-state-root invariants on sentinel write).
+- Watchdog binary-dir containment: PlistBuddy reads attacker-writable plist? Or only the trusted plist path?
+- Signed-policy post-apply: now persisted AFTER swap. If swap succeeds + persist fails, what happens? Rollback?
+
+---
+
+## Output format
+
+`VERDICT: READY TO MERGE` if 0/0/0. Else `VERDICT: NEEDS REVISION`
+with counts + ID-prefixed findings (`A-r3-H-1` etc.) with file:line.
+
+Convergent cross-lane findings = strongest signal.

--- a/specs/AUDIT_SPEC_020_v0_1_IMPL_r4_PROMPT.md
+++ b/specs/AUDIT_SPEC_020_v0_1_IMPL_r4_PROMPT.md
@@ -1,0 +1,111 @@
+# SPEC-020 v0.1.4 IMPL — Round 4 audit prompt (per-lane)
+
+You are auditing the **IMPL** of SPEC-020 v0.1.4 LOCKED at HEAD of
+`impl/spec-020-provider-autoupdate` in worktree
+`/Users/augstar/macprovider-spec-020-impl`.
+
+**Bar: 0 CRITICAL + 0 HIGH + 0 MEDIUM. Return `VERDICT: READY TO MERGE`
+if zero blocking findings.**
+
+## Trend
+
+- r1: 0C + 12H + 6M
+- r2: 0C +  4H + 4M
+- r3: 0C +  3H + 2M
+- r4 target: 0/0/0
+
+## What changed since r3
+
+Commit `6774559` — "Preserve autoupdate recovery evidence before
+cleanup" (+501 / -118 across 9 files). Read
+`specs/SPEC-020-IMPL-r3-audit.md` for r3 narrative and
+`specs/AUDIT_SPEC_020_v0_1_IMPL_r3_ABSORPTION_PROMPT.md` for the
+applied fixes.
+
+The absorption targeted:
+- **Convergent A+C HIGH (sentinel/recovery integrity)**: startup
+  recovery now requires `pending.update_id == sentinel.update_id`
+  match; pre-staged sentinel detection via `orphaned_success_sentinel`
+  with structured reason (`binary_version_mismatch`,
+  `no_matching_pending`, `update_id_mismatch`); send coord-visible
+  success event BEFORE finalize for both happy-path AND startup-
+  recovery paths.
+- **C-r3-H-2 marker_deadline tolerance**: tightened to
+  `now + post_start_window + 30 min` (~31 min) in both Swift validator
+  and watchdog. Was `now + 24h`.
+- **C-r3-M-1 signed-policy persist failure**: replaced `try?` with
+  do/catch; on failure restores backup if present, emits
+  `signed_policy_persist_failed` failure_class (new in R-6.5),
+  disables autoupdate for session.
+- **B-r3-M-1 AC test coverage**: added AC-10 (3 classifications),
+  AC-22 (trust-loss after auth), AC-23 (send-before-finalize ordering).
+
+Counts: 662 swift tests pass (was 659; +3 from new ACs), Go pass,
+watchdog syntax pass.
+
+## Authoritative inputs
+
+- IMPL at HEAD of `impl/spec-020-provider-autoupdate`
+- SPEC at `specs/SPEC-020-provider-autoupdate.md` (LOCKED, do not audit)
+- r1 + r2 + r3 narratives in `specs/SPEC-020-IMPL-r{1,2,3}-audit.md`
+
+## Lane-specific focus
+
+This is the defensive round. Re-verify EVERY prior finding was
+absorbed AND that absorption didn't introduce new issues.
+
+### Lane A — Codex architect
+
+Re-verify previously absorbed and confirm no regressions:
+- Sentinel/recovery integrity (A-r3-H-1 + C-r3-H-1):
+  - Sentinel scan validates `binary_version` AND `update_id` match
+    pending marker.
+  - All three mismatch paths emit `orphaned_success_sentinel` with
+    correct structured reason.
+  - Coord-visible event sent BEFORE finalize (both happy-path and
+    startup-recovery).
+- `marker_deadline` tolerance is `now + post_start_window + 30 min`
+  in Swift AND shell. Consistent.
+- Signed-policy persist failure rollback path: restore-on-failure
+  doesn't create a worse state (e.g., partial restore that breaks
+  rollback observer's expected state).
+- New AC tests don't introduce architectural assumptions that
+  contradict the SPEC.
+
+### Lane B — Codex code
+
+- File:line citations resolve to actual code.
+- `update_id` validation against pending: case-insensitive UUID
+  comparison? Or strict lowercase per UUID v4 canonical form?
+- `marker_deadline` upper bound: 90 minutes in seconds = 5400. Both
+  sides use the same constant?
+- `signed_policy_persist_failed`: is it in the failure_class enum?
+  Properly classified as terminal vs retryable?
+- AC tests: are they actually exercising the production code path
+  (not stubs)? Specifically check AC-10 watchdog tests use real
+  shell + test fixtures; AC-22 + AC-23 Swift tests assert ordering.
+
+### Lane C — Codex security
+
+- Pre-staged sentinel attack: confirmed `update_id` mismatch path
+  rejects.
+- `marker_deadline` upper bound: 31 minutes is enough? Could an
+  attacker pin a binary for 31 min via clock skew + valid signed
+  release? Acceptable residual?
+- Signed-policy persist failure: when rollback fails too, what's
+  the worst-case state? Operator must manually recover — is this
+  surfaced loud enough?
+- Any new attack surface from the test fixtures (e.g., TEST_MODE=1
+  env var bypass)?
+- Cross-process race: pending.json deleted between startup-recovery
+  send and finalize — recovery runs again on next startup — is this
+  idempotent / safe?
+
+---
+
+## Output format
+
+`VERDICT: READY TO MERGE` if 0/0/0. Else `VERDICT: NEEDS REVISION`
+with counts + ID-prefixed findings (`A-r4-H-1` etc.) with file:line.
+
+Convergent cross-lane findings = strongest signal.

--- a/specs/AUDIT_SPEC_020_v0_1_IMPL_r5_PROMPT.md
+++ b/specs/AUDIT_SPEC_020_v0_1_IMPL_r5_PROMPT.md
@@ -1,0 +1,79 @@
+# SPEC-020 v0.1.4 IMPL — Round 5 audit prompt (per-lane, DEFENSIVE)
+
+You are auditing the IMPL of SPEC-020 v0.1.4 at HEAD of
+`impl/spec-020-provider-autoupdate` (commit `17bd811`) in worktree
+`/Users/augstar/macprovider-spec-020-impl`.
+
+**Bar: 0 CRITICAL + 0 HIGH + 0 MEDIUM. Return `VERDICT: READY TO MERGE`
+if zero blocking findings. This is the final defensive round before
+opening the IMPL PR.**
+
+## Trend
+
+- r1: 0C + 12H + 6M
+- r2: 0C +  4H + 4M
+- r3: 0C +  3H + 2M
+- r4: 0C +  0H + 1M (Lane B + C already READY TO MERGE; Lane A 1M absorbed)
+- r5 target: 0/0/0 across all three lanes → IMPL PR opens
+
+## What changed since r4
+
+Commit `17bd811` — "fix(020): remap two off-spec failure_class values
+to 'other'" (5 files, 40 insertions, 13 deletions).
+
+Removed `unsupported_install_topology` and `signed_policy_persist_failed`
+from the IMPL's `AutoUpdateFailureClass` enum (both were absent from
+LOCKED SPEC R-6.5). All emission sites remapped to `.other` with the
+original semantic preserved in the structured `reason` field. Added
+`testFailureClassEnumMatchesSpecR65` to lock IMPL enum at exactly 22
+cases matching SPEC.
+
+Behavior (restore-on-failure, session disable, cooldown) unchanged.
+
+Counts: 663 swift tests pass, Go pass, watchdog scripts pass.
+
+## Authoritative inputs
+
+- IMPL at HEAD of `impl/spec-020-provider-autoupdate` (commit `17bd811`)
+- SPEC at `specs/SPEC-020-provider-autoupdate.md` (LOCKED v0.1.4)
+- Audit narratives in `specs/SPEC-020-IMPL-r{1,2,3,4}-audit.md`
+
+## Lane-specific focus — defensive checks
+
+Each lane: re-verify prior absorbed findings + spot-check for
+anything missed.
+
+### Lane A — Codex architect
+
+- Confirm SPEC R-6.5 ↔ IMPL enum parity (22 cases, no drift).
+- Confirm remap of the two removed values preserves operator-visible
+  diagnostic capability via structured `reason`.
+- No new architectural issues introduced by the remap.
+
+### Lane B — Codex code
+
+- IMPL enum has EXACTLY 22 cases — verified by `testFailureClassEnumMatchesSpecR65`.
+- All emission sites use enum values that exist in the IMPL enum (no
+  hardcoded strings).
+- No regressions on the prior AC tests.
+- `reason: "unsupported_install_topology"` and
+  `reason: "signed_policy_persist_failed"` are now in structured `reason`
+  field, NOT in `failure_class` — verify with grep.
+
+### Lane C — Codex security
+
+- Remap doesn't reduce the security posture: rollback-on-failure and
+  session-disable behavior still triggers in the two affected paths.
+- `failure_class:"other"` is broad — confirm coordinator-side logs can
+  still differentiate via the structured `reason` field.
+- No coordinator-visible payload growth that could trip 4096-byte bound.
+
+---
+
+## Output format
+
+`VERDICT: READY TO MERGE` if 0/0/0. Else `VERDICT: NEEDS REVISION`
+with counts + ID-prefixed findings.
+
+Convergent cross-lane findings = strongest signal. This is defensive —
+no new exploratory findings expected.

--- a/specs/BUILD_SPEC_020_v0_1_IMPL_PROMPT.md
+++ b/specs/BUILD_SPEC_020_v0_1_IMPL_PROMPT.md
@@ -1,0 +1,96 @@
+# BUILD_SPEC_020_v0_1_IMPL_PROMPT — Provider Autoupdate
+
+You are implementing SPEC-020 v0.1.4 LOCKED in this worktree
+(`/Users/augstar/macprovider-spec-020-impl`, branch
+`impl/spec-020-provider-autoupdate`, based on `origin/main` at `ffb40dc`).
+
+The SPEC is normative — every R-N.M numbered requirement and every
+AC-V0.1-N acceptance criterion is in scope. Read
+`specs/SPEC-020-provider-autoupdate.md` end-to-end before writing code.
+
+## Scope summary (per SPEC §Goal)
+
+Wire the existing manual `SelfUpdate` flow into automatic invocation
+when the coordinator advertises a newer `recommended_binary_version`.
+The cryptographic update mechanism already exists at
+`phase3-binary/Sources/macprovider-cli/SelfUpdate.swift`; this IMPL
+adds:
+
+- **Trigger semantics** — live trust-state predicate + version regex/length validation + NORMALIZED_TARGET normalization + GitHub release-by-tag resolution + cooldown backoff math
+- **Drain semantics** — provider-initiated drain distinct from coord-initiated, `state_update.reason = "autoupdate_to_<NORMALIZED_TARGET>"` discriminator, `drain_status.phase:"timeout_skipped"` gated on `autoupdate_drain_extensions:true` capability
+- **Trusted state root** — `$HOME/.local/share/macprovider/autoupdate/` provider-UID-owned mode 0700, no symlinks/ACLs/mount-crossings, `update.lock` (flock), `pending.json` (atomic write + fsync), rollback backup
+- **Crash recovery state machine** — orphaned-pending-marker, orphaned-success-sentinel, rollback-backup-corrupt
+- **Rollback observer** — extend `ops/macprovider-watchdog/watchdog.sh` (or equivalent in-process observer) to scan markers, restore on failure, validate hash/owner/mode
+- **Observability** — structured `last_autoupdate_event` with `source`/`outcome`/`phase`/`failure_class` enums, 4096-byte bound on event object alone, redaction invariant
+- **Opt-out** — accept BOTH `auto_update_enabled` / `MACPROVIDER_AUTO_UPDATE_ENABLED` (existing) AND `autoupdate.enabled` / `MACPROVIDER_AUTOUPDATE` (SPEC); explicit-disabled wins
+- **Signed-policy monotonic persistence** — `persisted_signed_policy_minimum` (max) and `persisted_signed_policy_revoked` (union) write-once-grow-only
+- **Coordinator wire amendments** — accept `autoupdate_drain_extensions:true` advertise from coord; accept `last_autoupdate_event` from provider on heartbeat / `state_update`
+
+## What's already in place (do NOT rewrite)
+
+The cryptographic update path is implemented and proven at:
+
+- `phase3-binary/Sources/macprovider-cli/SelfUpdate.swift` — GitHub Releases lookup (currently uses `/releases/latest`; you'll need to add release-by-tag for coord-triggered), ECDSA P-256 pinned-pubkey verification on `checksums.txt.sig`, SHA-256 against signed checksums, HTTPS + GitHub-host validation, path-traversal-safe tarball extraction, `self-test` invocation on new binary before swap, POSIX rename, launchctl bootout/bootstrap, 1h cached latest-release lookup.
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:1232-1236` — current notify-only branch (`"A newer version is available... Run 'macprovider-cli update' to upgrade."`). Wire this into automatic invocation.
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:168` — `binaryVersion = "1.6.1"` constant. **Bump to `"1.7.0"`** as part of this IMPL (per operator decision: minor bump because autoupdate is a new operator-facing feature).
+- `ops/macprovider-watchdog/watchdog.sh` — existing rollback observer candidate. Extend to handle SPEC-020 markers + rollback path.
+
+## Concrete file-level deliverables
+
+Add or modify (codex MUST decide actual file split based on Swift package boundaries; below is illustrative):
+
+1. **`phase3-binary/Sources/macprovider-cli/AutoUpdater.swift`** (new) — orchestrator for the autoupdate sequence: eligibility check → cooldown check → release-by-tag resolution → download via SelfUpdate primitives → drain → marker/backup creation → swap → restart. Holds `autoupdate_trust_state` and live-predicate hooks.
+
+2. **`phase3-binary/Sources/macprovider-cli/AutoUpdateTrustState.swift`** (new) — trust-state matrix evaluator with live re-evaluation hooks. The 5 re-eval points (download / drain / marker / swap / launchctl bootstrap) call into this.
+
+3. **`phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift`** (new) — pending.json schema + atomic write + lock acquisition + crash-recovery state machine + trusted-state-root invariants (O_NOFOLLOW, O_EXCL, mode 0700/0600, mount-boundary, ACL checks).
+
+4. **`phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift`** (new) — `last_autoupdate_event` JSON envelope with strict enums, 4096-byte bound, redaction priority list, optional-field-drop logic.
+
+5. **`phase3-binary/Sources/macprovider-cli/SelfUpdate.swift`** (modify) — add `runByTag(tag:)` and asset-missing handling (`failure_class:"release_asset_missing"`); existing `run(checkOnly:)` stays for manual command.
+
+6. **`phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`** (modify) — line 1232 notify-only branch now invokes AutoUpdater. Add `autoupdate_drain_extensions` parsing from `hello_ack` / v2 `auth_response`. Add `last_autoupdate_event` field emission on heartbeat / `state_update`. Bump `binaryVersion` line 168 to `"1.7.0"`.
+
+7. **`phase3-binary/Sources/macprovider-cli/UpdateCommand.swift`** (modify if needed) — the existing manual `update` subcommand should share AutoUpdater primitives where it makes sense (per SPEC's comparator-binding requirement).
+
+8. **`phase4-coordinator/internal/...`** (modify) — accept and round-trip `last_autoupdate_event` field on heartbeat / `state_update`; advertise `autoupdate_drain_extensions:true` in `hello_ack` and v2 `auth_response`; accept `drain_status.phase:"timeout_skipped"` (currently `ParseDrainStatus` rejects unknown values — extend).
+
+9. **`ops/macprovider-watchdog/watchdog.sh`** (modify) — scan trusted state root for pending.json on each tick. If marker present + lock not held + observer-process not running → orphaned-recovery (validate backup hash, restore via launchctl bootstrap of prior binary, atomically clear marker). Add the various failure_class emissions.
+
+10. **`ops/macprovider-watchdog/live.streamvc.macprovider-watchdog.plist.template`** (probably modify) — if the watchdog gets new dependencies / paths to scan.
+
+11. **Tests** — Swift tests under `phase3-binary/Tests/macprovider-cliTests/` covering AC-V0.1-1 through AC-V0.1-23. Coordinator Go tests under `phase4-coordinator/internal/...` for the wire extensions. Smoke shell script(s) under `phase3-binary/Scripts/` or `test/integration/` if useful.
+
+## Specific normative invariants to honor (do NOT relax)
+
+- **Live trust-state re-evaluation at 5 points** is the load-bearing safety invariant. If you find the IMPL only checks once, that is wrong.
+- **`O_NOFOLLOW` + `O_EXCL` + `fsync` + atomic rename** for marker / backup / sentinel files. No `cp`. No naive `write_atomic` without O_NOFOLLOW.
+- **`SelfUpdate.compareSemver`** is the ONE semver comparator. Do not introduce a parallel comparator anywhere (manual update, coord recommendation, downgrade refusal, status display, cooldown key all use this one).
+- **`NORMALIZED_TARGET`** propagation to release lookup, marker, drain reason, cooldown key — must be consistent.
+- **Cooldown formula**: `min(300s × 2^(attempt-1), 3600s)` keyed by `(NORMALIZED_TARGET, failure_class)`. 3600s cap is fixed in v0.1.0.
+- **Crash-recovery state machine** must handle every documented scenario (orphan, success sentinel, corrupt backup).
+- **`failure_class` enum exhaustive** — every `failure_class:"X"` in body must appear in R-6.5 enum and in the IMPL's emit-side enum/switch.
+- **Opt-out compatibility** — BOTH legacy and SPEC config keys + env vars MUST be honored; explicit-disabled wins.
+- **Signed-policy monotonic persistence** — `persisted_signed_policy_minimum`/`revoked` write-once-grow-only; signed releases CANNOT shrink.
+- **Eligible only when v2 + pinned + encrypted-leg + (Tier2 satisfied or not required) + (token validated or not configured)** per the normative table. Notify-only otherwise.
+
+## Process
+
+1. Read the SPEC end-to-end. Read existing `SelfUpdate.swift`, `CoordinatorClient.swift`, and `ops/macprovider-watchdog/` to understand the foundation.
+2. Implement IMPL in the worktree. Bias toward small Swift files with clear responsibility split (AutoUpdater orchestrator, TrustState evaluator, Marker manager, Event emitter).
+3. Coordinator-side Go changes: accept `last_autoupdate_event`, advertise `autoupdate_drain_extensions:true`, accept `drain_status.phase:"timeout_skipped"`.
+4. Bump `binaryVersion` constant `"1.6.1"` → `"1.7.0"`.
+5. Add tests for every AC-V0.1-N. Coordinator tests for wire extensions.
+6. Run `swift test` in `phase3-binary/` and `go test ./...` in `phase4-coordinator/`. Both green.
+7. Output: a single commit (or small handful of well-scoped commits) on `impl/spec-020-provider-autoupdate`. No SPEC edits.
+
+## Coordinator + watchdog config: required vs deferred
+
+Some IMPL bits are operator-side and may live outside this PR (e.g., setting `coordinator_advertised_version.latest_binary_version` on the live coordinator). What MUST land in this PR vs what can ship as a deploy artifact:
+
+- IN this PR: coordinator code accepting / round-tripping `last_autoupdate_event`, advertising `autoupdate_drain_extensions:true`, accepting `timeout_skipped` drain phase; provider code implementing the autoupdate orchestration; watchdog code implementing the rollback observer; binaryVersion bump to 1.7.0.
+- OUTSIDE this PR (deploy-time only): the operator setting the actual `latest_binary_version` advertised by the production coordinator; the GitHub release v1.7.0 itself (created by the tag-triggered workflow after this PR merges).
+
+## Output expectation
+
+A complete, compilable IMPL in `/Users/augstar/macprovider-spec-020-impl`. Swift package builds. Go modules build. Tests pass. No TODO stubs in production code paths; if something is genuinely deferred, mark it via a structured event / `failure_class` rather than `// TODO`. SPEC §Open Questions are answered or explicitly deferred to v0.2 — they should NOT block IMPL completion.

--- a/specs/SPEC-020-IMPL-r1-audit.md
+++ b/specs/SPEC-020-IMPL-r1-audit.md
@@ -1,0 +1,86 @@
+# SPEC-020 v0.1.4 IMPL — Round 1 audit narrative
+
+**Audited IMPL:** commit `37514b9` on `impl/spec-020-provider-autoupdate`
+**Worktree:** `/Users/augstar/macprovider-spec-020-impl`
+**Round:** r1
+**Lanes:** 3 codex (architect, code, security)
+
+## Per-lane verdicts
+
+| Lane | Verdict | C | H | M |
+|---|---|---|---|---|
+| A architect | NEEDS REVISION | 0 | 4 | 0 |
+| B code | NEEDS REVISION | 0 | 6 | 1 |
+| C security | NEEDS REVISION | 0 | 2 | 5 |
+
+**Totals: 0 CRITICAL, 12 HIGH, 6 MEDIUM.**
+
+Smoke status: swift test 651/0, go test ws+pool PASS, watchdog syntax PASS, binaryVersion 1.7.0, SPEC unmodified. IMPL is structurally correct; the audit findings target specific normative-invariant violations.
+
+## Convergent themes
+
+### T-1: Trust-state lifecycle broken (3 lanes, all HIGH)
+
+A-r1-H-1 + A-r1-H-2 + A-r1-H-3 + C-r1-H-1. The single load-bearing safety invariant from SPEC R-1 / live trust-state predicate is not faithfully implemented.
+
+- **A-r1-H-1**: `acceptCoordinatorSession` ([CoordinatorClient.swift:1287](phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:1287)) calls `runAutoupdateIfEligible` unconditionally even for notify-only trust states. `runAutoupdateIfEligible` inserts the target into `autoupdateAttemptedTargets` ([CoordinatorClient.swift:1631](phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:1631)) BEFORE trust gating, then `AutoUpdater` performs trusted-root/observer/cooldown work BEFORE `ensureEligible` ([AutoUpdater.swift:96](phase3-binary/Sources/macprovider-cli/AutoUpdater.swift:96)). Initial ineligible trust falls into `trustStateLost` which records cooldown ([AutoUpdater.swift:150,246](phase3-binary/Sources/macprovider-cli/AutoUpdater.swift:150)). SPEC line 106 says notify-only MUST NOT trigger cooldown/state mutation. **Fix**: pre-gate before calling `runAutoupdateIfEligible`; for initial notify-only verdicts, emit notify/status only.
+
+- **A-r1-H-2 + C-r1-H-1** (convergent): late trust-loss between marker/backup commit and launchctl bootstrap does NOT execute rollback. `preserveMarkerAndSwap` commits backup + `pending.json` then renames the live binary ([AutoUpdater.swift:167](phase3-binary/Sources/macprovider-cli/AutoUpdater.swift:167)); if trust lost at line 145 or 179, the catch at line 150 only records `trust_state_lost` failure — does NOT call `restoreBackup`, clear pending, or remove backup. SPEC lines 64-90 + AC-V0.1-22 require rollback. **Fix**: track committed state through pipeline; on `trustStateLost`, if any of marker/backup/swap committed, restore via `AutoUpdateMarkerStore.restoreBackup`, clear marker/backup, release lock, suppress launchctl bootstrap.
+
+- **A-r1-H-3**: `autoupdateTrustState` is computed once from auth payload ([CoordinatorClient.swift:1264](phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:1264)) and never updated. `currentAutoupdateTrustState` returns the stored value ([CoordinatorClient.swift:1658](phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:1658)). AEAD decrypt failure in relay sends NAK but doesn't demote trust ([InferenceRelay.swift:57](phase3-binary/Sources/macprovider-cli/InferenceRelay.swift:57)). SPEC line 64 explicitly says NOT a handshake-time snapshot. **Fix**: recompute trust from current session facts at each predicate call, or update/demote on encrypted-leg/token/attestation/session invalidation events with stable reasons (`encrypted_leg_invalidated`, etc.).
+
+### T-2: Rollback backup crash-safety (B+C convergent)
+
+B-r1-H-2 + C-r1-M-1. `AutoUpdater.copyNoFollow()` fsyncs file then renames ([AutoUpdater.swift:229-231](phase3-binary/Sources/macprovider-cli/AutoUpdater.swift:229)) but never fsyncs the parent directory. Also doesn't lstat/verify binary-dir ancestry as provider-owned mode 0700 before placing the backup. SPEC R-4.7 requires fsync(file) + fsync(parent) and trusted-ancestry. **Fix**: route backup preservation through `AutoUpdateMarkerStore.atomicCopyNoFollow` (the hardened helper) or add parent-dir fsync + ancestry check.
+
+### T-3: Recovery state machine gaps (B internal cluster + C-r1-M-2)
+
+- **B-r1-H-3**: `readPending()` ([AutoUpdateMarker.swift:157](phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift:157)) only rejects symlink/hardlink + JSON-decodes. Missing: UUIDv4 validation, normalized target check, absolute-path/no-trailing-slash check, decimal mode bounds, lowercase 64-hex SHA, RFC3339 deadline tolerance. `validateBackup()` even accepts uppercase SHA via `.lowercased()` ([AutoUpdateMarker.swift:182](phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift:182)). Watchdog `read_marker()` same issue ([watchdog.sh:199](ops/macprovider-watchdog/watchdog.sh:199)). **Fix**: add shared marker validator; malformed → R-4.10 orphan-recovery path.
+
+- **B-r1-H-4**: Provider startup recovery scan runs AFTER coordinator handshake instead of BEFORE. `completeSuccessfulAutoupdateIfPending()` called only after auth/session setup ([CoordinatorClient.swift:1285](phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:1285)) and only when both `pending.json` exists AND `targetVersion == binaryVersion` ([CoordinatorClient.swift:1312](phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:1312)). Watchdog exits immediately if `pending.json` absent ([watchdog.sh:328](ops/macprovider-watchdog/watchdog.sh:328)), so sentinel-without-pending and stale-backup-without-pending are NOT recovered. SPEC R-4.10a requires scan-before-handshake covering all 3 states. **Fix**: dedicated startup recovery routine BEFORE handshake; scan pending markers, success sentinels, stale rollback backups; handle all 3 invariant states.
+
+- **B-r1-H-5**: `completeSuccessfulUpdate()` ([AutoUpdateMarker.swift:240](phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift:240)) writes sentinel → unlink pending → delete backup → remove lock → DELETES sentinel; the success event is emitted only after this helper returns. Crash after pending unlink OR after sentinel deletion leaves no recoverable success state. SPEC R-4.10a says sentinel MUST be durable recovery anchor until event emission, and on next startup, sentinel-only / sentinel-binary-mismatch states must be handled. **Fix**: keep sentinel until AFTER event emission; handle sentinel-only states on next startup recovery scan.
+
+- **B-r1-H-6**: Watchdog restore emits only `orphaned_pending_marker` ([watchdog.sh:299](ops/macprovider-watchdog/watchdog.sh:299)). Enum has the 3 post-start classes ([AutoUpdateEvent.swift:53](phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift:53)) but observer doesn't classify by crash / start / health / rejoin per AC-V0.1-10. **Fix**: add post-start observation state and map each rollback trigger to the required failure class (`post_start_crash`, `post_start_health_failed`, `post_start_rejoin_timeout`).
+
+- **C-r1-M-2**: Watchdog `restore` ([watchdog.sh:299](ops/macprovider-watchdog/watchdog.sh:299)) trusts marker-supplied `backup_path` + `target_path` without deriving expected `.macprovider-cli.rollback-<update_id>` shape, and without rejecting paths outside binary/trusted dirs. **Fix**: derive expected backup path from `target_path` + `update_id`, require exact match, canonicalize/validate parent directories.
+
+### T-4: Convergence boundary not enforced (A-r1-H-4, standalone HIGH)
+
+Rollback-observer availability is only `fileExists` for the watchdog plist or a test env var ([AutoUpdater.swift:301](phase3-binary/Sources/macprovider-cli/AutoUpdater.swift:301)); does NOT detect a disabled/unloaded watchdog. Separately, `restartLaunchdIfInstalled` silently returns when LaunchAgent plist is absent ([AutoUpdater.swift:308](phase3-binary/Sources/macprovider-cli/AutoUpdater.swift:308)) — AFTER the binary may have been swapped. SPEC line 36 + R-4.4 + R-3.7 require fail-closed before download/drain/swap. **Fix**: eligibility requires launchd-managed provider + loaded/enabled rollback observer; else fail closed with `rollback_observer_unavailable` / unsupported-topology reason before any state mutation.
+
+### T-5: ACL checks missing (C-r1-H-2, standalone HIGH)
+
+Both `AutoUpdateMarker.swift:273` and `watchdog.sh:167` check lstat + UID + mode + chmod only; SPEC R-4.9 + AC-V0.1-21 require rejecting non-owner-write ACLs. **Fix**: inspect ACLs for every trusted-root ancestor in both Swift (`acl_get_link_np()` + check entries) and watchdog (`ls -le` parse).
+
+## Cooldown bug (B-r1-H-1, standalone HIGH)
+
+`recordCooldown()` increments attempt + applies formula ([AutoUpdateMarker.swift:225](phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift:225)), AND callers `fail()` records again ([AutoUpdater.swift:120,129,137,153,246](phase3-binary/Sources/macprovider-cli/AutoUpdater.swift:120)). Double-counted: first failure becomes attempt 2 / 600s instead of attempt 1 / 300s. Violates R-1.6 + R-4.2. **Fix**: make exactly one path own cooldown persistence per failed attempt.
+
+## Non-convergent MEDIUMs
+
+- **C-r1-M-3**: Persisted signed-policy state: `updateSignedPolicy` defined ([AutoUpdateMarker.swift:253](phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift:253)) but never called. `GitHubRelease` decodes only `tag_name` + assets ([SelfUpdate.swift:416](phase3-binary/Sources/macprovider-cli/SelfUpdate.swift:416)); `prepareValidatedUpdate` never persists observed signed policy. **Fix**: decode signed policy from signed release metadata, persist max/union after validation, add tests for attempted lowering/removal.
+
+- **C-r1-M-4**: Event reasons can include raw URLs/paths/error data. `String(describing: error)` ([AutoUpdater.swift:130,154](phase3-binary/Sources/macprovider-cli/AutoUpdater.swift:130)); `UpdateError.description` includes URLs, checksum values, archive entries ([SelfUpdate.swift:453](phase3-binary/Sources/macprovider-cli/SelfUpdate.swift:453)). Redactor narrow pattern list ([AutoUpdateEvent.swift:214](phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift:214)). **Fix**: map errors to stable reason codes before coordinator emission; strip URL queries/fragments, absolute paths, raw checksum material; add no-leak tests.
+
+- **C-r1-M-5**: Marker/backup reads use lstat-then-open TOCTOU. `readPending` lstat-checks then `Data(contentsOf:)` ([AutoUpdateMarker.swift:157,178,409](phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift:157)). **Fix**: replace with `open(O_RDONLY|O_NOFOLLOW)` + `fstat` + verify inode/mode/link/owner + read from fd.
+
+- **B-r1-M-1**: AC coverage below AC-V0.1-1..23. `AutoUpdateTests.swift` covers version validation, optional event-field drops, opt-out, cooldown keying, happy-path success cleanup, release tag fallback. Missing: AC-10 rollback classifications, AC-17 `event_payload_too_large` fallback, AC-19 orphan recovery, AC-20 corrupt backup recovery, AC-22 trust-loss after auth, AC-23 crash-between-cleanup-step recovery. **Fix**: add focused unit/integration tests for each missing AC including watchdog recovery tests.
+
+## Trend
+
+This is the first IMPL round. 12H is a meaningful count but they cluster into 5 themes, 3 of which are convergent across lanes (T-1 trust lifecycle is the dominant one and it's the SAME root cause that took 3 SPEC audit rounds to converge — IMPL inherited the same understanding gap). The fixes are all concrete with file:line citations.
+
+Expect r2 to land at 0/0/0–2H if absorption is faithful.
+
+## Next action
+
+Absorb r1 findings into the IMPL → commit on top of `37514b9`. Then fire r2 audit across all three lanes.
+
+Absorption prompt: `specs/AUDIT_SPEC_020_v0_1_IMPL_r1_ABSORPTION_PROMPT.md`.
+
+## Raw artifacts
+
+- Lane A: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-1-audit-prompt-per-lane-you-are-a-2026-06-29T16-25-04-521Z.md`
+- Lane B: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-1-audit-prompt-per-lane-you-are-a-2026-06-29T16-25-41-678Z.md`
+- Lane C: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-1-audit-prompt-per-lane-you-are-a-2026-06-29T16-24-38-191Z.md`

--- a/specs/SPEC-020-IMPL-r2-audit.md
+++ b/specs/SPEC-020-IMPL-r2-audit.md
@@ -1,0 +1,116 @@
+# SPEC-020 v0.1.4 IMPL — Round 2 audit narrative
+
+**Audited:** commit `7941a49` (test-fix on top of absorbed `d276886`)
+**Round:** r2
+**Lanes:** 3 codex (architect, code, security)
+
+## Per-lane verdicts
+
+| Lane | Verdict | C | H | M |
+|---|---|---|---|---|
+| A architect | NEEDS REVISION | 0 | 0 | 1 |
+| B code | NEEDS REVISION | 0 | 3 | 1 |
+| C security | NEEDS REVISION | 0 | 1 | 2 |
+
+**Totals: 0 CRITICAL, 4 HIGH, 4 MEDIUM.**
+
+Trend r1→r2: HIGH 12→4 (-8), MEDIUM 6→4 (-2). Big drop on trust-state cluster; recovery state machine cluster remains the focus.
+
+## Convergent theme — restore-before-cleanup (B+C, both HIGH)
+
+**B-r2-H-2 + C-r2-H-1**: orphan-marker recovery still doesn't restore. Both lanes hit:
+
+- `CoordinatorClient.swift:1442` checks `fileExists(update.lock)` (NOT whether advisory lock is LIVE) → if lockfile absent → calls `orphanPendingMarker`.
+- `AutoUpdateMarker.swift:261` `orphanPendingMarker` only deletes `pending.json`, records cooldown, removes lock. Does NOT call `restoreBackup`.
+- Missing: AC-19 (orphaned pending with valid backup MUST restore before marker deletion) + AC-20 (`rollback_backup_corrupt` quarantine path).
+- Startup runs before handshake, so it can consume the marker before watchdog recovery has a chance.
+
+**Combined absorption**:
+- Replace `fileExists(update.lock)` check with active-flock test (open + try-flock; if acquire succeeds, lock is stale → safe to recover; if EWOULDBLOCK, another process holds it).
+- `orphanPendingMarker` (or new `recoverOrphanedMarker`) MUST:
+  1. Validate marker JSON shape using shared validator.
+  2. Validate backup hash against marker's `sha256`.
+  3. If backup is missing → emit `failure_class:"rollback_backup_corrupt"`, quarantine marker (rename to `pending-quarantined-<timestamp>.json`), disable autoupdate for session, do NOT delete live binary.
+  4. If backup hash matches → call `restoreBackup` (atomic rename backup → target_path), THEN delete marker + backup, THEN record cooldown + emit `outcome:"failure", phase:"rollback", failure_class:"orphaned_pending_marker"`.
+  5. Release lock.
+
+## Standalone HIGHs
+
+### B-r2-H-1: Watchdog rolls back before 60s post-start window expires
+
+`watchdog.sh:471` calls `restore(marker)` immediately when no success sentinel exists; `:448` classifies a running provider as `post_start_rejoin_timeout` without checking elapsed time or `marker_deadline`. A watchdog tick that lands seconds after swap can roll back a normal still-starting binary.
+
+**Fix**: read `marker_deadline` from pending.json; only roll back if `now > marker_deadline` (RFC 3339 parse + comparison). For pre-deadline ticks where the binary is still starting, no-op. Add a "still starting" classification that exits without action.
+
+### B-r2-H-3: Success sentinel deleted before coordinator-visible event sent
+
+Current sequence at `CoordinatorClient.swift:1309` + `:1355` + `AutoUpdateMarker.swift:252`:
+1. Sentinel written.
+2. Pending unlinked.
+3. Backup deleted.
+4. Sentinel deleted (during finalize).
+5. (LATER) sendStateUpdate emits success event.
+
+If crash between (4) and (5), both the durable anchor AND coord-visible event are lost. AC-23 says sentinel MUST be durable until event is on the wire.
+
+**Fix**: reorder.
+1. Sentinel written.
+2. Pending unlinked.
+3. Backup deleted.
+4. Lock released.
+5. **sendStateUpdate** with `outcome:"success", phase:"post_start", binary_version=<TARGET>` (sentinel STILL present).
+6. AFTER state update confirmed delivered (await `send` to return), THEN delete sentinel.
+
+Crash between (5) and (6) → next startup sees sentinel + current binary_version matches → delayed cleanup path (R-4.10a) runs, idempotent. Crash between (4) and (5) → sentinel still present → same delayed cleanup path on next startup, but coord may see a stale `last_autoupdate_event` from prior session. Acceptable trade.
+
+Alternative: emit event BEFORE cleanup (step 0), then run cleanup. Sentinel + pending both alive across crash → recovery handles it. Either works.
+
+## MEDIUMs
+
+### A-r2-M-1: Notify-only pre-gate incomplete for invalid/older/equal versions
+
+`CoordinatorClient.swift:1311` only short-circuits notify-only when recommendation parses AND is newer. If notify-only AND recommendation is malformed / equal / older → falls through to `runAutoupdateIfEligible`. Downstream guard at `:1751` prevents state mutation, so MEDIUM not HIGH.
+
+**Fix**: short-circuit ALL notify-only verdicts before `runAutoupdateIfEligible` — regardless of recommendation parse / compare result. Logic: if trust == notify-only, emit notify event and RETURN. The recommendation version check matters only for the eligible path.
+
+### C-r2-M-1: Watchdog restore containment not bounded to actual binary dir
+
+`watchdog.sh:389` derives `expected_backup` from marker's `target_path`, then sets `trusted_dir = realpath(dirname(target))`. Proves backup + target share a parent, but doesn't compare that parent to a KNOWN binary directory. A malformed marker can define its own "trusted" dir.
+
+**Fix**: maintain a config value or env var `MACPROVIDER_BINARY_DIR` (or detect from the launchd plist's `ProgramArguments[0]`); validate `realpath(dirname(target_path))` == realpath(known binary dir). Reject otherwise.
+
+### C-r2-M-2: Signed-policy persisted before full validation
+
+`SelfUpdate.swift:100` persists `release.signedPolicy` immediately after `checksums.txt.sig` verification — BEFORE tarball checksum validation, archive validation, self-test, or installation. The policy is decoded from GitHub API fields / release body (NOT content covered by checksum signature). Lets unauthenticated metadata permanently raise floor / add revocations for a release that may never install.
+
+**Fix**: defer `updateSignedPolicy` to AFTER:
+1. Tarball SHA-256 matches signed checksums.
+2. Archive validation (no path traversal).
+3. `self-test` on new binary passes.
+4. Atomic swap succeeded.
+
+Persist only when the signed release is actually applied (post-`applyValidatedUpdate`).
+
+OR: bind the signed-policy content to the checksum signature (include `signed_policy.json` in `checksums.txt`). v0.1.0 may not require this — simplest: defer persistence to post-apply.
+
+### B-r2-M-1: AC coverage gap persists
+
+`AutoUpdateTests.swift` covers cooldown, sentinel happy path, notify-only, redaction, signed policy, tag fallback. Still missing: AC-10 rollback classifications (3 cases), AC-17 minimal `event_payload_too_large` fallback, AC-19 orphan restore, AC-20 corrupt backup quarantine, AC-22 trust-loss after auth, AC-23 crash-between-each-cleanup-step recovery. No watchdog integration tests for AC-19/20.
+
+**Fix**: add focused unit tests for each. Watchdog tests can be shell-level under `phase3-binary/Scripts/test-*.sh` or similar — pick an existing test pattern in repo.
+
+## Non-blocking confirmations from Lane A
+
+- ✓ Late `trustStateLost` after committed swap calls `restoreBackup`, clears pending/backup, does not reach `restartLaunchd` (T-1 absorption from r1 confirmed).
+- ✓ `currentAutoupdateTrustState()` recomputes from current payload/session/token facts; AEAD failure demotes via `encrypted_leg_invalidated`.
+- ✓ Rollback observer + provider topology checks use `launchctl print` active-state checks before download/drain/swap.
+
+## Next action
+
+Absorb r2 → IMPL commit on top of `7941a49`. Then fire r3. Trend suggests r3 should land near 0/0/0.
+
+## Raw artifacts
+
+- Lane A architect: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-2-audit-prompt-per-lane-you-are-a-2026-06-29T16-53-49-222Z.md`
+- Lane B code: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-2-audit-prompt-per-lane-you-are-a-2026-06-29T16-54-37-359Z.md`
+- Lane C security: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-2-audit-prompt-per-lane-you-are-a-2026-06-29T16-53-52-168Z.md`

--- a/specs/SPEC-020-IMPL-r3-audit.md
+++ b/specs/SPEC-020-IMPL-r3-audit.md
@@ -1,0 +1,76 @@
+# SPEC-020 v0.1.4 IMPL — Round 3 audit narrative
+
+**Audited:** commits `8161aab` + `29443ab` on `impl/spec-020-provider-autoupdate`
+**Round:** r3
+**Lanes:** 3 codex (architect, code, security)
+
+## Per-lane verdicts
+
+| Lane | Verdict | C | H | M |
+|---|---|---|---|---|
+| A architect | NEEDS REVISION | 0 | 1 | 0 |
+| B code | NEEDS REVISION | 0 | 0 | 1 |
+| C security | NEEDS REVISION | 0 | 2 | 1 |
+
+**Totals: 0 CRITICAL, 3 HIGH, 2 MEDIUM.**
+
+Trend r1→r2→r3: HIGH 12→4→3, MEDIUM 6→4→2.
+
+## Convergent theme — sentinel/recovery integrity (A+C, both HIGH)
+
+**A-r3-H-1**: startup recovery path deletes sentinel before `sendStateUpdate` is called. `CoordinatorClient.swift:1409-1419` runs startup recovery before reconnect; finalizes sentinel at `:1418`; records event in-memory at `:1419`. Coord-visible send happens later through `sendStateUpdate` at `:2035`. Crash between finalize and next `sendStateUpdate` → neither durable anchor NOR coord-visible event.
+
+**C-r3-H-1**: pre-staged sentinel bypass. `CoordinatorClient.swift:1409` scans every `.macprovider-cli.success-*` before handshake; only checks `payload.binaryVersion == Self.binaryVersion`. Does NOT require sentinel's `update_id` to match the pending marker's `update_id`. Same-UID attacker / bad new binary can pre-stage a valid-version sentinel and force `completeSuccessfulUpdate(pending)` of a legitimate pending update — deleting backup before real coord-visible success.
+
+**Combined absorption**: tighten startup recovery in `CoordinatorClient.swift:1409-1419`:
+
+1. When scanning a sentinel, REQUIRE BOTH:
+   - `sentinel.binaryVersion == Self.binaryVersion`, AND
+   - A pending marker exists AND `pending.updateID == sentinel.updateID`.
+2. If pending marker absent but sentinel claims success for current version: this is a delayed-publish-only state. Emit a `failure_class:"orphaned_success_sentinel"` event (already in enum) and delete just the sentinel — do NOT touch pending/backup.
+3. If pending marker present and update_id matches: send the success state update FIRST (coord-visible), AWAIT delivery, THEN call `completeSuccessfulUpdate(pending)` + `finalizeSuccessfulUpdate(updateID:)`. The sentinel is durable until after coord sees the event.
+
+This treats startup recovery exactly the same as the happy-path success: send-then-finalize, sentinel as anchor until coord confirms.
+
+## Standalone HIGH
+
+### C-r3-H-2: `marker_deadline` tolerance too wide
+
+Swift validation accepts `now - 300s` to `now + 24h` at `AutoUpdateMarker.swift:401`. Watchdog accepts `now + 24h` at `watchdog.sh:249`. SPEC says future-beyond-tolerance is `marker_deadline > now + post_start_window + 30 min` (where post_start_window = 60s default), so the practical upper bound should be `now + ~31 min`, NOT 24h.
+
+**Fix**: tighten both Swift and shell deadline upper bound to `now + post_start_window + 30 min` (i.e., `now + 90 * 60` seconds = 5400s). Anything beyond → reject as malformed → orphan-recovery + cooldown + autoupdate disabled for session.
+
+## Standalone MEDIUMs
+
+### C-r3-M-1: `try?` silent-swallow on signed-policy persist
+
+`AutoUpdateMarker.swift:364` uses `try?` for encode/write of signed-policy state. If swap succeeds + policy persist fails → provider continues with no rollback, no event, no durable floor.
+
+**Fix**: replace `try?` with `do/catch`. On failure: emit `failure_class:"signed_policy_persist_failed"` (add to R-6.5 enum), best-effort rollback of the just-applied update (restore prior binary from backup if still present), disable autoupdate for the session. If rollback also fails, structured-fatal log so operator can manually recover.
+
+### B-r3-M-1: AC test assertion gaps
+
+`AutoUpdateTests.swift` covers AC-17, AC-19, AC-20, sentinel persistence. Missing:
+- **AC-10**: 3 post-start classifications (`post_start_crash`, `post_start_health_failed`, `post_start_rejoin_timeout`) implemented only in watchdog code, no test assertions.
+- **AC-22**: trust-loss-after-auth — only notify-only-at-entry is tested, not the live demotion path between auth and swap.
+- **AC-23**: production awaits `sendStateUpdate` before finalize (correct), but tests call marker-store cleanup directly without asserting coord send/finalize ordering.
+
+**Fix**: add tests for each missing AC. For AC-10 watchdog tests, extend `Scripts/test-ac-19-20-watchdog-recovery.sh` to cover the 3 classifications (fake launchctl outputs + healthz responses + binary_version mismatch). For AC-22, add a test where `AutoUpdateTrustState.evaluate` returns eligible at entry but a subsequent re-evaluation (mid-pipeline) returns notify-only; assert no swap occurs and `trust_state_lost` emitted. For AC-23, mock the send pipeline and assert finalize is called only after send returns.
+
+## Non-blocking confirmations
+
+Lane A confirms: restore-before-cleanup validates marker + backup before restore/quarantine ✓; both watchdog + Swift respect `marker_deadline` ✓; notify-only pre-gate returns for all ineligible states ✓; signed-policy persistence is post-apply ✓.
+
+Lane B confirms: production `sendStateUpdate` awaited before finalize on happy path ✓; watchdog integration test for AC-19/20 passes ✓.
+
+Lane C confirms: restore-before-cleanup works on the validated path; `marker_deadline` parsing works (just tolerance is too wide).
+
+## Next action
+
+Absorb r3 → IMPL commit on top of `8161aab`. Then fire r4. If trend holds, r4 should land at 0/0/0.
+
+## Raw artifacts
+
+- Lane A architect: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-3-audit-prompt-per-lane-you-are-a-2026-06-29T17-13-51-147Z.md`
+- Lane B code: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-3-audit-prompt-per-lane-you-are-a-2026-06-29T17-14-33-650Z.md`
+- Lane C security: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-3-audit-prompt-per-lane-you-are-a-2026-06-29T17-14-16-793Z.md`

--- a/specs/SPEC-020-IMPL-r4-audit.md
+++ b/specs/SPEC-020-IMPL-r4-audit.md
@@ -1,0 +1,71 @@
+# SPEC-020 v0.1.4 IMPL — Round 4 audit narrative
+
+**Audited:** commit `6774559` (r3 absorption)
+**Round:** r4 (post-r3 absorption defensive)
+**Lanes:** 3 codex (architect, code, security)
+
+## Per-lane verdicts
+
+| Lane | Verdict | C | H | M |
+|---|---|---|---|---|
+| A architect | NEEDS REVISION | 0 | 0 | 1 |
+| B code | **READY TO MERGE** | 0 | 0 | 0 |
+| C security | **READY TO MERGE** | 0 | 0 | 0 |
+
+**Totals: 0 CRITICAL, 0 HIGH, 1 MEDIUM.**
+
+Trend r1→r2→r3→r4: HIGH 12→4→3→**0**, MEDIUM 6→4→2→**1**.
+
+## Lane A finding
+
+**A-r4-M-1**: `signed_policy_persist_failed` is emitted in the IMPL enum but the LOCKED SPEC R-6.5 enum doesn't list it. Implementation has drifted from the spec.
+
+Investigation revealed TWO drifts (Lane A flagged one):
+1. `signed_policy_persist_failed` (added during r3 absorption for C-r3-M-1)
+2. `unsupported_install_topology` (added during r1 absorption for A-r1-H-4)
+
+Both were added without realizing SPEC v0.1.4 was LOCKED.
+
+## Absorption — commit `17bd811`
+
+Per [[feedback-bundle-spec-impl-one-pr]] SPEC-020 is net-new so the SPEC cannot be amended in this IMPL PR. Instead:
+
+- Removed both enum cases from `AutoUpdateFailureClass` in
+  `phase3-binary/Sources/macprovider-cli/AutoUpdateEvent.swift`.
+- Remapped all emissions to `AutoUpdateFailureClass.other` with the
+  original semantic preserved in the structured `reason` field.
+- Updated watchdog rollback classification accordingly.
+- Added `testFailureClassEnumMatchesSpecR65` asserting the IMPL enum
+  has exactly 22 cases matching SPEC R-6.5.
+
+Behavior (restore-on-failure, session disable, cooldown) unchanged. Only
+the wire-visible `failure_class` string changes.
+
+Counts: 663 swift tests pass (was 662; +1 for new enum-conformance test), Go pass, watchdog scripts pass.
+
+## Lane B + C READY TO MERGE confirmations
+
+**Lane B** confirmed (Lane C also confirmed independently):
+- `update_id` validation strict lowercase UUIDv4.
+- `marker_deadline` upper bound 1860s consistent Swift + shell.
+- `signed_policy_persist_failed` was handled as terminal-for-session before remap (now folded into `other`).
+- AC-10 watchdog tests cover all 3 classifications.
+- AC-22 / AC-23 Swift tests exercise production paths.
+
+**Lane C** further confirmed (security):
+- Pre-staged sentinel rejection (`update_id_mismatch`, `binary_version_mismatch`, `no_matching_pending`).
+- `marker_deadline` tightened to spec tolerance.
+- No `TEST_MODE` production bypass.
+- Cross-process recovery idempotent.
+
+## Next action
+
+Fire IMPL r5 (defensive) across all three lanes against `17bd811`. If
+all three return READY TO MERGE → open IMPL PR and proceed to v1.7.0
+release tag.
+
+## Raw artifacts
+
+- Lane A architect: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-4-audit-prompt-per-lane-you-are-a-2026-06-29T17-33-11-423Z.md`
+- Lane B code: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-4-audit-prompt-per-lane-you-are-a-2026-06-29T17-33-14-686Z.md`
+- Lane C security: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-4-audit-prompt-per-lane-you-are-a-2026-06-29T17-34-10-583Z.md`

--- a/specs/SPEC-020-IMPL-r5-audit.md
+++ b/specs/SPEC-020-IMPL-r5-audit.md
@@ -1,0 +1,85 @@
+# SPEC-020 v0.1.4 IMPL — Round 5 audit narrative — **READY TO MERGE**
+
+**Audited:** commit `17bd811` on `impl/spec-020-provider-autoupdate`
+**Round:** r5 (defensive, post-r4 enum-drift fix)
+**Lanes:** 3 codex (architect, code, security)
+
+## Per-lane verdicts
+
+| Lane | Verdict | C | H | M |
+|---|---|---|---|---|
+| A architect | **READY TO MERGE** | 0 | 0 | 0 |
+| B code | **READY TO MERGE** | 0 | 0 | 0 |
+| C security | **READY TO MERGE** | 0 | 0 | 0 |
+
+**Totals: 0 CRITICAL, 0 HIGH, 0 MEDIUM across all three lanes ✅**
+
+## Convergence trend
+
+| Round | C | H | M | Notes |
+|---|---|---|---|---|
+| r1 | 0 | 12 | 6 | Trust-state lifecycle dominant convergence |
+| r2 | 0 | 4 | 10 | Trust-state matrix + FS hardening |
+| r3 | 0 | 3 | 2 | Recovery state machine, sentinel handling |
+| r4 | 0 | 0 | 1 | Lane B+C at lock; A flagged enum drift |
+| **r5** | **0** | **0** | **0** | **ALL LANES READY TO MERGE ✅** |
+
+## Final state
+
+Commits on `impl/spec-020-provider-autoupdate`:
+- `37514b9` Enable trusted provider autoupdate from coordinator recommendations
+- `d276886` Absorb SPEC-020 autoupdate trust and recovery audit (r1)
+- `7941a49` test: clear AutoUpdateEventStore in disabled-mode heartbeat test
+- `8161aab` Restore before autoupdate recovery cleanup (r2)
+- `29443ab` docs(020): add IMPL r2 audit specs
+- `6774559` Preserve autoupdate recovery evidence before cleanup (r3)
+- `4bd4ca6` docs(020): add IMPL r3 audit specs
+- `17bd811` fix(020): remap two off-spec failure_class values to 'other' (r4 absorption)
+
+Final stats:
+- 14 files changed in initial IMPL commit
+- ~2000+ new lines across 4 new Swift modules (AutoUpdater, AutoUpdateTrustState, AutoUpdateMarker, AutoUpdateEvent)
+- 663 swift tests pass (was 651 baseline; +12 net new for AC coverage + enum parity)
+- Go tests pass (ws + pool packages)
+- Watchdog shell scripts pass syntax + integration tests
+- `binaryVersion` = "1.7.0" (bumped from "1.6.1" in initial IMPL)
+- `AutoUpdateFailureClass` enum exactly 22 cases matching SPEC R-6.5 (locked by test)
+
+## Confirmations from all three lanes
+
+**Lane A architect**:
+- SPEC R-6.5 ↔ IMPL enum parity (22 cases, no drift)
+- Remap preserves operator-visible diagnostics via structured `reason`
+- No architectural regressions from remap
+
+**Lane B code**:
+- IMPL enum exactly 22 cases; locked by `testFailureClassEnumMatchesSpecR65`
+- All emission sites use enum values from the IMPL enum
+- No regressions on prior AC tests (10, 17, 19, 20, 22, 23)
+- `reason` field carries the previously-distinct semantic
+
+**Lane C security**:
+- Signed-policy persist failure still attempts rollback, disables session, records cooldown
+- Unsupported topology fails before mutation; differentiated by structured reason
+- Coord-visible diagnostics intact via `last_autoupdate_event.reason`
+- 4096-byte event bound enforced
+- No remaining off-spec enum symbols in `phase3-binary` or `ops`
+
+## Ready for IMPL PR
+
+The IMPL is complete and matches LOCKED SPEC-020 v0.1.4 exactly. Per
+[[feedback-bundle-spec-impl-one-pr]] SPEC-020 is net-new so SPEC and IMPL
+shipped in separate PRs:
+- SPEC PR #251 (merged as `ffb40dc`)
+- IMPL PR (to be opened)
+
+After IMPL PR merges, tag `v1.7.0` to trigger the release workflow.
+Operators auto-update from v1.6.1 → v1.7.0 via the existing manual
+update path; subsequent versions will use SPEC-020 autoupdate
+automatically.
+
+## Raw artifacts
+
+- Lane A architect: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-5-audit-prompt-per-lane-defensive-2026-06-29T17-45-22-756Z.md`
+- Lane B code: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-5-audit-prompt-per-lane-defensive-2026-06-29T17-45-48-681Z.md`
+- Lane C security: `.omc/artifacts/ask/codex-spec-020-v0-1-4-impl-round-5-audit-prompt-per-lane-defensive-2026-06-29T17-45-39-869Z.md`


### PR DESCRIPTION
## Summary

Provider-side autoupdate for SPEC-020 v0.1.4 (LOCKED via #251). Wires the existing manual `SelfUpdate` flow into automatic invocation when the coordinator advertises a newer `recommended_binary_version`. Live trust-state predicate re-evaluated before every irreversible phase (download, drain, marker, swap, launchctl bootstrap). Crash-safe rollback observer via watchdog. Monotonic signed-policy persistence. 22 `failure_class` enum values matching SPEC R-6.5 exactly (locked by test).

**Bumps `binaryVersion` 1.6.1 → 1.7.0.** After merge, tag `v1.7.0` to trigger the GitHub release workflow.

## What's new (Swift)

- **`AutoUpdater.swift`** (336 lines) — orchestrator: eligibility → cooldown → release-by-tag → download → drain → marker/backup → swap → restart.
- **`AutoUpdateTrustState.swift`** (104 lines) — live trust-state matrix evaluator; re-evaluated at each irreversible phase.
- **`AutoUpdateMarker.swift`** (432 lines) — marker JSON schema, atomic write (O_NOFOLLOW + O_EXCL + fsync + atomic rename), flock-based update.lock, trusted-state-root invariants (mode 0700, ancestor lstat, ACL checks), crash-recovery state machine.
- **`AutoUpdateEvent.swift`** (242 lines) — structured event envelope, 4096-byte bound, optional-field-drop, redaction, `AutoUpdateFailureClass` enum (22 cases parity-locked).
- **`SelfUpdate.swift`** — added `runByTag` for coordinator-triggered installs + `release_asset_missing` failure class.
- **`CoordinatorClient.swift`** — auto-invocation wiring, `autoupdate_drain_extensions` parsing, `last_autoupdate_event` emission, binaryVersion 1.6.1 → 1.7.0.

## What's new (coordinator + watchdog)

- **`phase4-coordinator/internal/ws/messages.go`** — accept `last_autoupdate_event` on heartbeat / state_update; advertise `autoupdate_drain_extensions:true` in hello_ack / v2 auth_response; accept `drain_status.phase:"timeout_skipped"`.
- **`ops/macprovider-watchdog/watchdog.sh`** — rollback observer with marker validation, deadline-respecting timing (5400s tolerance), classified rollback (post_start_crash / post_start_health_failed / post_start_rejoin_timeout), binary-dir containment, restore-then-cleanup.
- **`ops/macprovider-watchdog/Scripts/test-ac-19-20-watchdog-recovery.sh`** — shell integration test for AC-19/20.

## Audit trail

Five-round 3-lane codex IMPL audit (architect + code + security):

| Round | C | H | M |
|---|---|---|---|
| r1 | 0 | 12 | 6 |
| r2 | 0 | 4 | 4 |
| r3 | 0 | 3 | 2 |
| r4 | 0 | 0 | 1 |
| **r5** | **0** | **0** | **0** |

Convergent themes resolved across rounds:
- Trust-state lifecycle (r1 → r3): notify-only pre-gate, late-trust-loss rollback, live predicate re-evaluation, AEAD demotion
- Recovery state machine (r1 → r3): orphan-marker restore-before-cleanup, success-sentinel-as-durable-anchor, post-start classification, deadline-respecting watchdog
- Filesystem hardening (r1 → r2): trusted-state-root mode 0700, ACL checks, O_NOFOLLOW + O_EXCL, parent-dir fsync, binary-dir containment
- Enum parity (r4): removed 2 off-spec values, remapped to `other` with structured reason

## Test plan

- [x] 663 swift tests pass (was 651 baseline; +12 for AC coverage + enum parity)
- [x] Go tests pass (ws + pool packages)
- [x] Watchdog shell scripts syntax + integration tests pass
- [x] `AutoUpdateFailureClass` enum exactly 22 cases matching SPEC R-6.5 (locked by `testFailureClassEnumMatchesSpecR65`)
- [x] `binaryVersion = "1.7.0"` confirmed
- [x] SPEC unmodified (no changes to `specs/SPEC-020-provider-autoupdate.md`)
- [ ] antfleet-ops approves
- [ ] Augustas11 squash-merges
- [ ] tag `v1.7.0` → GitHub release workflow publishes self-updating binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
