### PR TITLE
impl(005): v0.4 force-void quarantine resolution admin surface (closes #169)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -166,6 +166,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "billing: %v\n", err)
 		os.Exit(1)
 	}
+	// R4 fix (CODE-M2): set the route-layer flag atomic BEFORE the
+	// startup snapshot so the snapshot's canonical hash captures the
+	// initial flag state (SPEC-005 v0.4 §11.6.4 / §13.2). The
+	// "startup" source suppresses the billing_config_flag_changed
+	// audit emit per SPEC §11.6.4 (no prior acknowledged value).
+	if err := billingStore.SetForceVoidEnabled(context.Background(), cfg.Billing.QuarantineResolutionForceVoidEnabled, "startup"); err != nil {
+		fmt.Fprintf(os.Stderr, "billing force-void flag init: %v\n", err)
+		os.Exit(1)
+	}
 	snapshotID, err := billingStore.InsertConfigSnapshot(context.Background(), cfg.Rewards, time.Now().UTC())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "billing config snapshot: %v\n", err)

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -534,6 +534,9 @@ func main() {
 	// gates the §11.6 force-void endpoint at the route layer. Default
 	// false: endpoint returns HTTP 404 until the operator explicitly
 	// flips the flag via the existing config-reload primitive.
+	// The flag is held as an atomic on billingStore; SIGHUP reload
+	// calls billingStore.SetForceVoidEnabled which emits the
+	// `billing_config_flag_changed` audit event on real flips.
 	billingHandler := billingStore.HandlersWithQuarantineGate(
 		cfg.Auth.OperatorKey,
 		tokenStore,
@@ -541,6 +544,11 @@ func main() {
 		cfg.Endpoints.ProviderEarnings.RateLimitPerMinute,
 		cfg.Billing.QuarantineResolutionForceVoidEnabled,
 	)
+	// §11.5 launch-gate item 10 — operator-visible startup state.
+	logger.Info().
+		Bool("billing.quarantine_resolution_force_void_enabled", cfg.Billing.QuarantineResolutionForceVoidEnabled).
+		Str("event", "spec005_v0_4_route_layer_flag_init").
+		Msg("quarantine force-void route-layer flag initialized")
 	providerMux.Handle("/admin/ledger/", billingHandler)
 	if cfg.Auth.RequireProviderTokens {
 		providerMux.Handle("/providers/", billingHandler)
@@ -888,6 +896,17 @@ func reloadTier2Config(configPath string, startupTier2 config.Tier2Config, logge
 		}
 		buyerServer.SetBillingConfig(cfg.Rewards, snapshotID)
 		billingStores[0].SetSettlementConfig(cfg.Settlement)
+		// SPEC-005 v0.4 §11.6.4 + §13.2 — emit
+		// `billing_config_flag_changed` audit event on actual flips
+		// of the route-layer flag. No-op when value is unchanged.
+		if err := billingStores[0].SetForceVoidEnabled(context.Background(), cfg.Billing.QuarantineResolutionForceVoidEnabled, "sighup"); err != nil {
+			logger.Error().Err(err).Msg("billing force-void flag reload failed")
+			return
+		}
+		logger.Info().
+			Bool("billing.quarantine_resolution_force_void_enabled", cfg.Billing.QuarantineResolutionForceVoidEnabled).
+			Str("event", "spec005_v0_4_route_layer_flag_reload").
+			Msg("quarantine force-void route-layer flag reloaded")
 	}
 	updated := wsServer.RefreshTier2HashStatuses()
 	logger.Info().Int("provider_hash_statuses_updated", updated).Msg("tier2 config reloaded")

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -889,20 +889,20 @@ func reloadTier2Config(configPath string, startupTier2 config.Tier2Config, logge
 	wsServer.SetTier2Config(cfg.Tier2)
 	buyerServer.SetTier2Config(cfg.Tier2)
 	if len(billingStores) > 0 && billingStores[0] != nil {
-		snapshotID, err := billingStores[0].InsertConfigSnapshot(context.Background(), cfg.Rewards, time.Now().UTC())
+		// R3 fix (ARCH-H1): snapshot + flag-change audit + in-memory
+		// publish are now ONE atomic operation in
+		// billing.Store.ReloadBillingConfig. If COMMIT fails, the
+		// snapshot is not written, the flag-change audit is not
+		// written, and the force-void flag stays at its prior value.
+		// Only AFTER COMMIT do we publish the rewards / settlement
+		// in-memory configs that depend on the snapshot id.
+		snapshotID, err := billingStores[0].ReloadBillingConfig(context.Background(), cfg.Rewards, cfg.Billing.QuarantineResolutionForceVoidEnabled, "sighup", time.Now().UTC())
 		if err != nil {
-			logger.Error().Err(err).Msg("billing config snapshot reload rejected")
+			logger.Error().Err(err).Msg("billing config reload rejected (snapshot + flag audit atomic)")
 			return
 		}
 		buyerServer.SetBillingConfig(cfg.Rewards, snapshotID)
 		billingStores[0].SetSettlementConfig(cfg.Settlement)
-		// SPEC-005 v0.4 §11.6.4 + §13.2 — emit
-		// `billing_config_flag_changed` audit event on actual flips
-		// of the route-layer flag. No-op when value is unchanged.
-		if err := billingStores[0].SetForceVoidEnabled(context.Background(), cfg.Billing.QuarantineResolutionForceVoidEnabled, "sighup"); err != nil {
-			logger.Error().Err(err).Msg("billing force-void flag reload failed")
-			return
-		}
 		logger.Info().
 			Bool("billing.quarantine_resolution_force_void_enabled", cfg.Billing.QuarantineResolutionForceVoidEnabled).
 			Str("event", "spec005_v0_4_route_layer_flag_reload").

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -530,12 +530,16 @@ func main() {
 	providerMux := http.NewServeMux()
 	providerMux.Handle("/", wsServer.Handler())
 	providerMux.Handle("/internal/", buyerServer.InternalHandler())
-	billingHandler := billingStore.HandlersWithBridge(
+	// SPEC-005 v0.4 (issue #169) — `billing.quarantine_resolution_force_void_enabled`
+	// gates the §11.6 force-void endpoint at the route layer. Default
+	// false: endpoint returns HTTP 404 until the operator explicitly
+	// flips the flag via the existing config-reload primitive.
+	billingHandler := billingStore.HandlersWithQuarantineGate(
 		cfg.Auth.OperatorKey,
-		cfg.Auth.GatewayServiceToken,
 		tokenStore,
 		cfg.Auth.RequireProviderTokens,
 		cfg.Endpoints.ProviderEarnings.RateLimitPerMinute,
+		cfg.Billing.QuarantineResolutionForceVoidEnabled,
 	)
 	providerMux.Handle("/admin/ledger/", billingHandler)
 	if cfg.Auth.RequireProviderTokens {

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -176,6 +176,13 @@ settlement:
   recovery_grace_seconds: 30
   job_enabled: true
 
+# SPEC-005 v0.4 §11.5 launch-gate item 10. Quarantine resolution
+# `/admin/ledger/quarantine/{id}/force-void` admin surface is
+# default-OFF — operators MUST flip this flag deliberately after
+# verifying §13.2 reload + audit semantics.
+billing:
+  quarantine_resolution_force_void_enabled: false
+
 endpoints:
   provider_earnings:
     rate_limit_per_minute: 60

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -112,6 +112,14 @@ logging:
   level: "info"
   format: "json"
 
+# SPEC-005 v0.4 §11.5 launch-gate item 10. Quarantine resolution
+# `/admin/ledger/quarantine/{id}/force-void` admin surface is
+# default-OFF — operators MUST flip this flag deliberately after
+# verifying §13.2 reload + audit semantics. SIGHUP-driven flips
+# emit a `billing_config_flag_changed` audit row.
+billing:
+  quarantine_resolution_force_void_enabled: false
+
 tier2:
   # SPEC-008 catalog-based hash verification. Operator-controlled,
   # observation-only by default per beta/DECISION_CRITERIA Entry 80.

--- a/phase4-coordinator/internal/billing/admin_ratelimit.go
+++ b/phase4-coordinator/internal/billing/admin_ratelimit.go
@@ -1,0 +1,63 @@
+package billing
+
+import (
+	"sync"
+	"time"
+)
+
+// SPEC-005 v0.4 §11.6.6 / §11 — every `/admin/ledger/*` response
+// path consumes the SAME rate-limit bucket. v0.4 IMPL ships a
+// process-global token bucket keyed by the (single) operator-key
+// principal. The bucket is intentionally simple: a token capacity
+// + a refill cadence in tokens-per-second. Future spec versions
+// may replace this with a multi-tenant or persistent limiter; v0.4
+// only needs to satisfy the "every-response consumes" property,
+// not a sophisticated traffic shape.
+
+const (
+	adminBucketCapacity    = 60   // tokens
+	adminBucketRefillPerS  = 60.0 // tokens/sec (1/sec * 60 ≈ same as previous earnings limiter posture)
+	adminBucketWindowReset = 60 * time.Second
+)
+
+type adminRateLimiter struct {
+	mu        sync.Mutex
+	tokens    float64
+	last      time.Time
+	capacity  float64
+	refillPS  float64
+	now       func() time.Time
+}
+
+func newAdminRateLimiter() *adminRateLimiter {
+	return &adminRateLimiter{
+		tokens:   float64(adminBucketCapacity),
+		last:     time.Now(),
+		capacity: float64(adminBucketCapacity),
+		refillPS: adminBucketRefillPerS,
+		now:      time.Now,
+	}
+}
+
+// Allow returns true if a token was consumed, false if the bucket
+// is exhausted. SPEC §11.6.6 requires EVERY response code path
+// (200, 4xx, 5xx) to consume one token — failure responses do NOT
+// bypass.
+func (b *adminRateLimiter) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := b.now()
+	elapsed := now.Sub(b.last).Seconds()
+	if elapsed > 0 {
+		b.tokens += elapsed * b.refillPS
+		if b.tokens > b.capacity {
+			b.tokens = b.capacity
+		}
+		b.last = now
+	}
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}

--- a/phase4-coordinator/internal/billing/admin_ratelimit.go
+++ b/phase4-coordinator/internal/billing/admin_ratelimit.go
@@ -15,8 +15,16 @@ import (
 // not a sophisticated traffic shape.
 
 const (
-	adminBucketCapacity    = 60   // tokens
-	adminBucketRefillPerS  = 60.0 // tokens/sec (1/sec * 60 ≈ same as previous earnings limiter posture)
+	// R3 fix (CODE-H1): SPEC AC-Q049 requires 64 concurrent POSTs to
+	// reach the UNIQUE-race layer. With the previous 60-token cap,
+	// the bucket drained before all 64 callers could hit the
+	// resolution INSERT (4 received 429 instead of 409), which forced
+	// AC-Q049 to test 32 threads instead of the SPEC-mandated 64.
+	// Capacity is raised to 128 — comfortably admits the 64-thread
+	// burst while still keeping a tight ceiling on operator-key abuse
+	// (refill is still 60/sec so steady-state behavior is unchanged).
+	adminBucketCapacity    = 128  // tokens
+	adminBucketRefillPerS  = 60.0 // tokens/sec
 	adminBucketWindowReset = 60 * time.Second
 )
 

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -192,9 +192,16 @@ func (h *handler) providers(w http.ResponseWriter, r *http.Request) {
 	cursor := r.URL.Query().Get("cursor")
 	includeQuarantined := r.URL.Query().Get("include_quarantined") == "true"
 	current := currentMondayUTC(time.Now().UTC()).Format(time.RFC3339Nano)
-	quarantineFilter := "AND quarantined=0"
-	if includeQuarantined {
-		quarantineFilter = ""
+	// R2 fix (CODE-H4): payable aggregates ALWAYS exclude quarantined
+	// rows (CASE on lrc.quarantined=0); quarantined_count ALWAYS uses
+	// OPEN_PREDICATE (quarantined=1 AND no resolution row).
+	// include_quarantined now controls only whether providers that
+	// have ONLY quarantined credits appear in the listing, via a
+	// HAVING clause on payable-row count. The aggregate columns no
+	// longer change shape based on the query parameter.
+	havingClause := ""
+	if !includeQuarantined {
+		havingClause = " HAVING SUM(CASE WHEN lrc.quarantined=0 THEN 1 ELSE 0 END) > 0 "
 	}
 	// Single grouped LEFT JOIN — the prior shape was outer-aggregate +
 	// per-row h.sum(...) on ledger_payout_ready, which (a) deadlocked at
@@ -211,8 +218,8 @@ func (h *handler) providers(w http.ResponseWriter, r *http.Request) {
 	// page, which is strictly cheaper than the per-provider sum loop.
 	rows, err := h.store.db.QueryContext(ctx, `
 SELECT lrc.provider_id,
-       SUM(lrc.provider_credits),
-       SUM(CASE WHEN lrc.ts_utc >= ? THEN lrc.provider_credits ELSE 0 END),
+       SUM(CASE WHEN lrc.quarantined=0 THEN lrc.provider_credits ELSE 0 END),
+       SUM(CASE WHEN lrc.quarantined=0 AND lrc.ts_utc >= ? THEN lrc.provider_credits ELSE 0 END),
        MAX(lrc.ts_utc),
        SUM(CASE WHEN lrc.fault_flag != 'none' THEN 1 ELSE 0 END),
        SUM(CASE WHEN lrc.quarantined=1 AND NOT EXISTS (
@@ -227,8 +234,8 @@ SELECT lrc.provider_id,
          WHERE status = 'ready'
          GROUP BY provider_id
   ) pp ON pp.provider_id = lrc.provider_id
- WHERE lrc.provider_id > ? `+quarantineFilter+`
- GROUP BY lrc.provider_id
+ WHERE lrc.provider_id > ?
+ GROUP BY lrc.provider_id`+havingClause+`
  ORDER BY lrc.provider_id
  LIMIT ?`, current, cursor, limit+1)
 	if err != nil {

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -104,6 +104,16 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	// "matched route + bad id" so we can emit 400 (not 404) per
 	// §11.6.1.1.
 	if m := matchQuarantinePath(r.URL.Path); m.matched {
+		// R3 fix (SEC-M1): when the route-layer flag is disabled the
+		// endpoint must be byte-indistinguishable from a non-existent
+		// route — return 404 universally BEFORE method or id-shape
+		// checks. Otherwise GET / PUT / bad-id requests leak route
+		// existence via 405 / 400 even when the operator has not
+		// turned the surface on.
+		if !h.store.ForceVoidEnabled() {
+			writeError(w, http.StatusNotFound, "not_found", "not found")
+			return
+		}
 		if r.Method != http.MethodPost {
 			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 			return

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -57,11 +57,25 @@ func (s *Store) HandlersWithBridge(operatorKey, _gatewayServiceTokenIgnoredAdmin
 }
 
 func (s *Store) handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool) http.Handler {
-	// SPEC-005 v0.4 (issue #169) — initialize the route-layer flag
-	// via the Store's atomic. After this initial write, subsequent
-	// flips MUST go through SetForceVoidEnabled (which emits the
-	// flag-change audit event).
-	_ = s.SetForceVoidEnabled(context.Background(), forceVoidEnabled, "startup")
+	// SPEC-005 v0.4 (issue #169) — handler CONSTRUCTION must not be
+	// able to silently flip the live route-layer flag. R8 fix
+	// (ARCH-M1) replaces the unconditional SetForceVoidEnabled call
+	// with a monotonic CompareAndSwap that only flips false→true on
+	// FIRST construction. After any caller (production main.go's
+	// startup setter, a prior constructor call, or a SIGHUP reload)
+	// has set the atomic, subsequent constructor calls cannot reset
+	// it. This is the property the codex ARCH-M1 finding required:
+	// a future legacy Handlers() call (default-false) cannot
+	// silently disable a production-enabled flag.
+	//
+	// Production wires up via main.go's explicit
+	// SetForceVoidEnabled(ctx, value, "startup") which precedes the
+	// handler construction and emits no audit (per §11.6.4 startup
+	// carve-out). Tests still pass the desired flag value here for
+	// the first-construction init case.
+	if forceVoidEnabled {
+		s.forceVoidEnabled.CompareAndSwap(false, true)
+	}
 	h := &handler{
 		store:                   s,
 		operatorKey:             operatorKey,

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -57,14 +57,19 @@ func (s *Store) HandlersWithBridge(operatorKey, _gatewayServiceTokenIgnoredAdmin
 }
 
 func (s *Store) handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool) http.Handler {
+	// SPEC-005 v0.4 (issue #169) — initialize the route-layer flag
+	// via the Store's atomic. After this initial write, subsequent
+	// flips MUST go through SetForceVoidEnabled (which emits the
+	// flag-change audit event).
+	_ = s.SetForceVoidEnabled(context.Background(), forceVoidEnabled, "startup")
 	h := &handler{
 		store:                   s,
 		operatorKey:             operatorKey,
 		tokenStore:              tokenStore,
 		requireProviderTokens:   requireProviderTokens,
 		earningsRateLimitPerMin: earningsRateLimitPerMin,
-		forceVoidEnabled:        forceVoidEnabled,
 		lastEarnings:            map[string][]time.Time{},
+		adminBucket:             newAdminRateLimiter(),
 		log:                     zerolog.New(os.Stdout).With().Timestamp().Logger(),
 	}
 	return http.HandlerFunc(h.serveHTTP)
@@ -76,18 +81,40 @@ type handler struct {
 	tokenStore              tokenValidator
 	requireProviderTokens   bool
 	earningsRateLimitPerMin int
-	forceVoidEnabled        bool
 	mu                      sync.Mutex
 	lastEarnings            map[string][]time.Time
+	adminBucket             *adminRateLimiter
 	log                     zerolog.Logger
 }
 
 func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	// SPEC-005 v0.4 §11.6.6 — every /admin/ledger/* response path
+	// consumes the same rate-limit bucket. Charge BEFORE any
+	// further branching so 4xx / 5xx responses count too.
+	isAdminPath := strings.HasPrefix(r.URL.Path, "/admin/ledger/")
+	if isAdminPath {
+		if !h.adminBucket.Allow() {
+			writeError(w, http.StatusTooManyRequests, "rate_limited", "admin rate limit exceeded")
+			return
+		}
+	}
+
 	// SPEC-005 v0.4 §11.6 quarantine surface (issue #169).
-	if id, kind, ok := matchQuarantinePath(r.URL.Path); ok {
-		switch kind {
+	// matchQuarantinePath distinguishes "not this route" from
+	// "matched route + bad id" so we can emit 400 (not 404) per
+	// §11.6.1.1.
+	if m := matchQuarantinePath(r.URL.Path); m.matched {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+			return
+		}
+		if m.badID {
+			writeError(w, http.StatusBadRequest, "bad_request", "request_credit_id must be a base-10 int64")
+			return
+		}
+		switch m.kind {
 		case "force-void":
-			h.forceVoidHandler(w, r, id)
+			h.forceVoidHandler(w, r, m.id)
 			return
 		}
 	}

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -24,6 +24,25 @@ func (s *Store) Handlers(operatorKey string, tokenStore tokenValidator, requireP
 	return s.HandlersWithBridge(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin)
 }
 
+// HandlersWithQuarantineGate is the SPEC-005 v0.4 (issue #169)
+// constructor that lets callers wire the force-void route-layer
+// gate (config flag `billing.quarantine_resolution_force_void_enabled`).
+// Existing callers MAY continue to use Handlers() — that path
+// defaults the gate to false (force-void endpoint returns 404
+// regardless of config).
+//
+// SPEC-005 v0.4 §13.2 mandates that flag-flip audit emission
+// (event_type=billing_config_flag_changed) is the responsibility of
+// the config-reload caller, not the handler. On SIGHUP / HTTP
+// reload, the caller compares old and new config, re-wires this
+// Handler with the new value, and emits the audit row through the
+// billing store's BeginTx path (see EmitConfigFlagChangedAudit
+// below) so it shares atomicity with the ledger_config_snapshots
+// row §13.2 already requires.
+func (s *Store) HandlersWithQuarantineGate(operatorKey string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool) http.Handler {
+	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled)
+}
+
 // HandlersWithBridge mounts the admin/provider handlers. The
 // `/admin/ledger/*` endpoints are operator-only (the codex security
 // audit on PR #73, HIGH-1, flagged that accepting gateway_service_token
@@ -34,12 +53,17 @@ func (s *Store) Handlers(operatorKey string, tokenStore tokenValidator, requireP
 // accepted. Handlers (the legacy single-arg signature) is kept as a
 // thin shim so test fixtures and direct callers don't churn.
 func (s *Store) HandlersWithBridge(operatorKey, _gatewayServiceTokenIgnoredAdminOnly string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int) http.Handler {
+	return s.handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly, tokenStore, requireProviderTokens, earningsRateLimitPerMin, false)
+}
+
+func (s *Store) handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool) http.Handler {
 	h := &handler{
 		store:                   s,
 		operatorKey:             operatorKey,
 		tokenStore:              tokenStore,
 		requireProviderTokens:   requireProviderTokens,
 		earningsRateLimitPerMin: earningsRateLimitPerMin,
+		forceVoidEnabled:        forceVoidEnabled,
 		lastEarnings:            map[string][]time.Time{},
 		log:                     zerolog.New(os.Stdout).With().Timestamp().Logger(),
 	}
@@ -52,12 +76,21 @@ type handler struct {
 	tokenStore              tokenValidator
 	requireProviderTokens   bool
 	earningsRateLimitPerMin int
+	forceVoidEnabled        bool
 	mu                      sync.Mutex
 	lastEarnings            map[string][]time.Time
 	log                     zerolog.Logger
 }
 
 func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	// SPEC-005 v0.4 §11.6 quarantine surface (issue #169).
+	if id, kind, ok := matchQuarantinePath(r.URL.Path); ok {
+		switch kind {
+		case "force-void":
+			h.forceVoidHandler(w, r, id)
+			return
+		}
+	}
 	switch {
 	case r.URL.Path == "/admin/ledger/summary":
 		h.admin(w, r, h.summary)
@@ -104,7 +137,14 @@ func (h *handler) summary(w http.ResponseWriter, r *http.Request) {
 		"current_window_provider_credits":   h.sum(ctx, `SELECT SUM(provider_credits) FROM ledger_request_credits WHERE quarantined=0 AND ts_utc >= ?`, current),
 		"pending_payout_count":              h.sum(ctx, `SELECT COUNT(*) FROM ledger_payout_ready WHERE status='ready'`),
 		"pending_payout_credits":            h.sum(ctx, `SELECT SUM(provider_credits) FROM ledger_payout_ready WHERE status='ready'`),
-		"quarantined_count":                 h.sum(ctx, `SELECT COUNT(*) FROM ledger_request_credits WHERE quarantined=1`),
+		// SPEC-005 v0.4 §11.6.5 OPEN_PREDICATE — `quarantined_count`
+		// surfaces ONLY open quarantines (not force_void-resolved).
+		// Force-voided rows are resolved-and-excluded.
+		"quarantined_count": h.sum(ctx, `
+SELECT COUNT(*) FROM ledger_request_credits lrc
+ WHERE lrc.quarantined=1
+   AND NOT EXISTS (SELECT 1 FROM ledger_quarantine_resolutions r
+                    WHERE r.request_credit_id = lrc.id)`),
 		"fault_count":                       h.sum(ctx, `SELECT COUNT(*) FROM ledger_request_credits WHERE fault_flag != 'none'`),
 		"last_reconciliation_delta_credits": h.sum(ctx, `SELECT reconciliation_delta_credits FROM ledger_reconciliation_runs ORDER BY started_at_utc DESC, id DESC LIMIT 1`),
 	}
@@ -148,7 +188,9 @@ SELECT lrc.provider_id,
        SUM(CASE WHEN lrc.ts_utc >= ? THEN lrc.provider_credits ELSE 0 END),
        MAX(lrc.ts_utc),
        SUM(CASE WHEN lrc.fault_flag != 'none' THEN 1 ELSE 0 END),
-       SUM(CASE WHEN lrc.quarantined=1 THEN 1 ELSE 0 END),
+       SUM(CASE WHEN lrc.quarantined=1 AND NOT EXISTS (
+             SELECT 1 FROM ledger_quarantine_resolutions r WHERE r.request_credit_id = lrc.id
+       ) THEN 1 ELSE 0 END),
        MAX(lrc.attestation_class),
        COALESCE(pp.pending_payout, 0) AS pending_payout
   FROM ledger_request_credits lrc
@@ -242,7 +284,26 @@ SELECT COUNT(*)
 		return
 	}
 	rowsRecovered := int64(0)
-	rowsQuarantined, err := h.sumErr(ctx, `SELECT COUNT(*) FROM ledger_request_credits WHERE ts_utc >= ? AND ts_utc < ? AND quarantined=1`, from.Format(time.RFC3339Nano), to.Format(time.RFC3339Nano))
+	// SPEC-005 v0.4 §11.6.5 OPEN_PREDICATE — narrow rows_quarantined
+	// to open quarantines only (force-voided rows are resolved-and-
+	// excluded).
+	rowsQuarantined, err := h.sumErr(ctx, `
+SELECT COUNT(*) FROM ledger_request_credits lrc
+ WHERE lrc.ts_utc >= ? AND lrc.ts_utc < ? AND lrc.quarantined=1
+   AND NOT EXISTS (SELECT 1 FROM ledger_quarantine_resolutions r
+                    WHERE r.request_credit_id = lrc.id)`,
+		from.Format(time.RFC3339Nano), to.Format(time.RFC3339Nano))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	// SPEC-005 v0.4 §11.6.5 — new mandatory reconcile field. Counts
+	// `force_void` resolutions with created_at_utc in [from, to);
+	// v0.5 will widen to include `force_credit`.
+	rowsForceResolved, err := h.sumErr(ctx, `
+SELECT COUNT(*) FROM ledger_quarantine_resolutions
+ WHERE created_at_utc >= ? AND created_at_utc < ?`,
+		from.Format(time.RFC3339Nano), to.Format(time.RFC3339Nano))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
@@ -264,15 +325,16 @@ INSERT INTO ledger_reconciliation_runs (
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"from_utc":                 from.Format(time.RFC3339),
-		"to_utc":                   to.Format(time.RFC3339),
-		"buyer_equivalent_credits": buyerEquivalent,
-		"provider_gross_credits":   providerGross,
-		"delta_gross_credits":      delta,
-		"split_delta_rows":         splitDelta,
-		"rows_scanned":             rowsScanned,
-		"rows_recovered":           rowsRecovered,
-		"rows_quarantined":         rowsQuarantined,
+		"from_utc":                     from.Format(time.RFC3339),
+		"to_utc":                       to.Format(time.RFC3339),
+		"buyer_equivalent_credits":     buyerEquivalent,
+		"provider_gross_credits":       providerGross,
+		"delta_gross_credits":          delta,
+		"split_delta_rows":             splitDelta,
+		"rows_scanned":                 rowsScanned,
+		"rows_recovered":               rowsRecovered,
+		"rows_quarantined":             rowsQuarantined,
+		"rows_force_resolved_in_range": rowsForceResolved,
 	})
 }
 

--- a/phase4-coordinator/internal/billing/quarantine.go
+++ b/phase4-coordinator/internal/billing/quarantine.go
@@ -1,0 +1,473 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"modernc.org/sqlite"
+	sqlite3errs "modernc.org/sqlite/lib"
+)
+
+// SPEC-005 v0.4 §11.6 quarantine VOID admin endpoint.
+//
+// One POST endpoint: `/admin/ledger/quarantine/{request_credit_id}/force-void`.
+// Force-credit is deferred to v0.5 (see SPEC-005 v0.4 changelog
+// scope-cut rationale). The resolution_kind enum on
+// `ledger_quarantine_resolutions` is constrained to ('force_void')
+// in v0.4; v0.5 widens.
+
+const (
+	quarantinePathPrefix   = "/admin/ledger/quarantine/"
+	forceVoidPathSuffix    = "/force-void"
+	maxReasonLen           = 500
+	maxOperatorIDLen       = 64
+	maxBodyBytes           = 4 * 1024
+	operatorAttribution    = "operator_key_self_asserted"
+	eventForceVoid         = "ledger_quarantine_force_void"
+	eventConfigFlagChanged = "billing_config_flag_changed"
+	resolutionKindVoid     = "force_void"
+)
+
+// matchQuarantinePath returns (request_credit_id, "force-void", ok)
+// when r.URL.Path matches the §11.6 quarantine path shape. ok=false
+// otherwise — the dispatcher then routes to 404.
+func matchQuarantinePath(path string) (int64, string, bool) {
+	if !strings.HasPrefix(path, quarantinePathPrefix) {
+		return 0, "", false
+	}
+	rest := path[len(quarantinePathPrefix):]
+	if !strings.HasSuffix(rest, forceVoidPathSuffix) {
+		return 0, "", false
+	}
+	idStr := rest[:len(rest)-len(forceVoidPathSuffix)]
+	if idStr == "" {
+		return 0, "", false
+	}
+	// path parameter must be a base-10 int64 — SPEC-005 §11.6.1.1
+	// 400 `bad_request` for any non-integer / overflow case.
+	for _, c := range idStr {
+		if c < '0' || c > '9' {
+			return 0, "", false
+		}
+	}
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return 0, "", false
+	}
+	return id, "force-void", true
+}
+
+// forceVoidHandler implements POST /admin/ledger/quarantine/{id}/force-void
+// per SPEC-005 v0.4 §11.6.1.
+func (h *handler) forceVoidHandler(w http.ResponseWriter, r *http.Request, requestCreditID int64) {
+	// Method enforcement (§11.6.1.1).
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+	// Auth — operator-key, matches existing §16.1 contract (403 for
+	// both missing and wrong key).
+	if !auth.OperatorOnlyBearerMatches(r.Header, h.operatorKey) {
+		writeError(w, http.StatusForbidden, "forbidden", "operator key required")
+		return
+	}
+	// Route-layer gate (§11.5 launch-gate item 10). Disabled-flag and
+	// row-not-found both return 404 with byte-identical bodies — no
+	// leak of which case fired.
+	if !h.forceVoidEnabled {
+		writeError(w, http.StatusNotFound, "not_found", "not found")
+		return
+	}
+	// Body shape pre-checks before reading. §11.6.1.1 names 415 and 413.
+	if ct := r.Header.Get("Content-Type"); !isJSONContentType(ct) {
+		writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", "content-type must be application/json")
+		return
+	}
+	if r.ContentLength > maxBodyBytes {
+		writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "body exceeds 4 KiB")
+		return
+	}
+	// Streaming read with a 4 KiB+1 cap so an oversized body never
+	// fully materializes; ContentLength may be -1 or wrong.
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes+1)
+	defer r.Body.Close()
+	body, ok := decodeForceVoidBody(w, r)
+	if !ok {
+		return
+	}
+	// Per-field validation. The §11.6.3 sanitizer is reject-based;
+	// any rejection becomes a 422 with the specific code.
+	if errCode := validateOperatorID(body.OperatorID); errCode != "" {
+		writeValidationError(w, errCode, "operator_id rejected: "+errCode)
+		return
+	}
+	if errCode := validateReason(body.Reason); errCode != "" {
+		writeValidationError(w, errCode, "reason rejected: "+errCode)
+		return
+	}
+	operatorID := strings.TrimSpace(body.OperatorID)
+	reason := strings.TrimSpace(body.Reason)
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	// All operational work happens inside one BEGIN IMMEDIATE
+	// transaction per SPEC-005 §11.6.2 — the resolution INSERT and
+	// the audit_log INSERT share atomicity. The audit row is
+	// written via the same *sql.Tx (NOT via audit.Store.Insert)
+	// because the audit Store opens a separate *sql.DB handle and
+	// cannot participate in this transaction.
+	tx, err := h.store.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "begin tx: "+err.Error())
+		return
+	}
+	defer tx.Rollback()
+
+	// Base-row preconditions (§11.6.2). These are on
+	// ledger_request_credits, NOT on ledger_quarantine_resolutions.
+	var baseExists int
+	var quarantined int
+	var requestID string
+	var attemptN int64
+	var providerID string
+	var quarantineReason sql.NullString
+	row := tx.QueryRowContext(ctx, `
+SELECT 1, quarantined, request_id, attempt_n, provider_id, quarantine_reason
+  FROM ledger_request_credits WHERE id = ?`, requestCreditID)
+	if err := row.Scan(&baseExists, &quarantined, &requestID, &attemptN, &providerID, &quarantineReason); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "not_found", "not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", "lookup: "+err.Error())
+		return
+	}
+	if quarantined != 1 {
+		writeValidationError(w, "not_quarantined", "ledger_request_credits row is not quarantined")
+		return
+	}
+
+	// Resolution INSERT. Race protection is the UNIQUE constraint
+	// (§11.6.6); we do NOT pre-check ledger_quarantine_resolutions.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err = tx.ExecContext(ctx, `
+INSERT INTO ledger_quarantine_resolutions
+    (request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc)
+VALUES (?, ?, ?, ?, ?)`, requestCreditID, resolutionKindVoid, operatorID, reason, now)
+	if err != nil {
+		if isSQLiteUniqueConstraint(err) {
+			// Release the conn (MaxOpenConns(1) on the shared *sql.DB
+			// — issue #21 / ARCH-3) BEFORE re-reading via h.store.db,
+			// otherwise the re-read deadlocks until ctx expires.
+			tx.Rollback()
+			h.respondAlreadyResolved(w, ctx, nil, requestCreditID)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", "insert resolution: "+err.Error())
+		return
+	}
+
+	// Audit-log INSERT through the SAME *sql.Tx (§11.6.4
+	// insertion-path requirement). Must use json.Marshal — no
+	// hand-rolled JSON.
+	payload := map[string]any{
+		"severity":             "WARN",
+		"operator_attribution": operatorAttribution,
+		"operator_id":          operatorID,
+		"request_credit_id":    requestCreditID,
+		"request_id":           requestID,
+		"attempt_n":            attemptN,
+		"provider_id":          providerID,
+		"quarantine_reason":    nullStringOrNil(quarantineReason),
+		"resolution_reason":    reason,
+		"ts_utc":               now,
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "marshal audit payload: "+err.Error())
+		return
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
+VALUES (?, ?, ?, ?)`, now, eventForceVoid, providerID, string(payloadJSON)); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "insert audit: "+err.Error())
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "commit: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"request_credit_id": requestCreditID,
+		"resolution_kind":   resolutionKindVoid,
+		"operator_id":       operatorID,
+		"resolution_reason": reason,
+		"created_at_utc":    now,
+	})
+}
+
+// respondAlreadyResolved reads the existing resolution row and emits
+// the SPEC-005 §11.6.2 409 envelope. tx may be the same transaction
+// (which will be rolled back by the defer); we don't need a fresh
+// reader because the row is committed by definition.
+func (h *handler) respondAlreadyResolved(w http.ResponseWriter, ctx context.Context, _ *sql.Tx, requestCreditID int64) {
+	// Use the DB handle (not the failing tx) so the SELECT sees the
+	// committed winner row even though our tx is about to roll back.
+	var (
+		kind      string
+		opID      string
+		reason    string
+		createdAt string
+	)
+	err := h.store.db.QueryRowContext(ctx, `
+SELECT resolution_kind, operator_id, resolution_reason, created_at_utc
+  FROM ledger_quarantine_resolutions WHERE request_credit_id = ?`,
+		requestCreditID).Scan(&kind, &opID, &reason, &createdAt)
+	if err != nil {
+		// UNIQUE fired but the row vanished? Treat as 500 — should
+		// never happen because the constraint precludes deletion.
+		writeError(w, http.StatusInternalServerError, "internal_error", "re-read existing resolution: "+err.Error())
+		return
+	}
+	body := map[string]any{
+		"error": map[string]any{
+			"code":    "already_resolved",
+			"message": "row already resolved",
+			"existing_resolution": map[string]any{
+				"request_credit_id": requestCreditID,
+				"resolution_kind":   kind,
+				"operator_id":       opID,
+				"resolution_reason": reason,
+				"created_at_utc":    createdAt,
+			},
+		},
+	}
+	writeJSON(w, http.StatusConflict, body)
+}
+
+type forceVoidBody struct {
+	OperatorID string `json:"operator_id"`
+	Reason     string `json:"reason"`
+}
+
+// decodeForceVoidBody parses + validates the JSON shape (presence of
+// fields, no unknown keys, no duplicate keys) per §11.6.1.1.
+func decodeForceVoidBody(w http.ResponseWriter, r *http.Request) (forceVoidBody, bool) {
+	var raw map[string]json.RawMessage
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&raw); err != nil {
+		// http.MaxBytesError → 413; any other JSON error → 400.
+		var mbErr *http.MaxBytesError
+		if errors.As(err, &mbErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "body exceeds 4 KiB")
+		} else {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid json body")
+		}
+		return forceVoidBody{}, false
+	}
+	if dec.More() {
+		writeError(w, http.StatusBadRequest, "bad_request", "body must contain a single JSON object")
+		return forceVoidBody{}, false
+	}
+	body := forceVoidBody{}
+	if raw == nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "body must be a JSON object")
+		return body, false
+	}
+	opRaw, hasOp := raw["operator_id"]
+	if !hasOp {
+		writeValidationError(w, "missing_field", "operator_id is required")
+		return body, false
+	}
+	reasonRaw, hasReason := raw["reason"]
+	if !hasReason {
+		writeValidationError(w, "missing_field", "reason is required")
+		return body, false
+	}
+	if err := json.Unmarshal(opRaw, &body.OperatorID); err != nil {
+		writeValidationError(w, "bad_operator_id", "operator_id must be a JSON string")
+		return body, false
+	}
+	if err := json.Unmarshal(reasonRaw, &body.Reason); err != nil {
+		writeValidationError(w, "unsanitized_reason", "reason must be a JSON string")
+		return body, false
+	}
+	return body, true
+}
+
+// validateOperatorID returns the 422 `code` string for the first
+// rejection condition, or "" if valid.
+func validateOperatorID(s string) string {
+	if !utf8.ValidString(s) {
+		return "invalid_utf8"
+	}
+	t := strings.TrimSpace(s)
+	if t == "" || len(t) > maxOperatorIDLen {
+		return "bad_operator_id"
+	}
+	for _, r := range t {
+		switch {
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '.' || r == '-':
+		default:
+			return "bad_operator_id"
+		}
+	}
+	return ""
+}
+
+// validateReason returns the 422 `code` string for the first
+// rejection condition, or "" if valid. Per SPEC-005 v0.4 §11.6.3.
+func validateReason(s string) string {
+	if !utf8.ValidString(s) {
+		return "invalid_utf8"
+	}
+	t := strings.TrimSpace(s)
+	if t == "" {
+		return "empty_reason"
+	}
+	if utf8.RuneCountInString(t) > maxReasonLen {
+		return "reason_too_long"
+	}
+	for _, r := range t {
+		if isRejectedCodepoint(r) {
+			return "unsanitized_reason"
+		}
+	}
+	return ""
+}
+
+// isRejectedCodepoint returns true for code points SPEC-005 v0.4
+// §11.6.3 rejects: C0 / DEL, C1 controls, Unicode bidi / format,
+// zero-width / BOM, variation selectors, tag chars, private-use,
+// plus the full Unicode 16.0 Default_Ignorable_Code_Point set.
+func isRejectedCodepoint(r rune) bool {
+	// C0 controls (allow tab / newline / CR per §11.6.3 #2).
+	if r < 0x20 {
+		switch r {
+		case '\t', '\n', '\r':
+			return false
+		default:
+			return true
+		}
+	}
+	if r == 0x7F { // DEL
+		return true
+	}
+	// C1 controls.
+	if r >= 0x80 && r <= 0x9F {
+		return true
+	}
+	// Default-ignorable + bidi + zero-width + format ranges per §11.6.3.
+	// Sourced from Unicode 16.0 DerivedCoreProperties.txt
+	// (Default_Ignorable_Code_Point=Yes).
+	switch {
+	case r == 0x00AD: // SOFT HYPHEN
+		return true
+	case r == 0x034F: // COMBINING GRAPHEME JOINER
+		return true
+	case r == 0x061C: // ARABIC LETTER MARK
+		return true
+	case r == 0x115F, r == 0x1160: // HANGUL fillers
+		return true
+	case r == 0x17B4, r == 0x17B5: // KHMER inherent markers
+		return true
+	case r >= 0x180B && r <= 0x180F: // Mongolian variation selectors + MVS + free VS
+		return true
+	case r >= 0x200B && r <= 0x200F: // ZWSP/ZWNJ/ZWJ/LRM/RLM
+		return true
+	case r >= 0x202A && r <= 0x202E: // bidi formatting
+		return true
+	case r >= 0x2060 && r <= 0x2064: // WORD JOINER + invisible operators
+		return true
+	case r == 0x2065: // reserved
+		return true
+	case r >= 0x2066 && r <= 0x2069: // bidi isolates
+		return true
+	case r >= 0x206A && r <= 0x206F: // deprecated format
+		return true
+	case r == 0x3164: // HANGUL FILLER
+		return true
+	case r >= 0xFE00 && r <= 0xFE0F: // variation selectors
+		return true
+	case r == 0xFEFF: // ZWNBSP / BOM
+		return true
+	case r == 0xFFA0: // HALFWIDTH HANGUL FILLER
+		return true
+	case r >= 0xFFF0 && r <= 0xFFF8: // reserved
+		return true
+	case r >= 0xE000 && r <= 0xF8FF: // BMP private-use
+		return true
+	case r >= 0x1BCA0 && r <= 0x1BCA3: // Duployan shorthand format
+		return true
+	case r >= 0x1D173 && r <= 0x1D17A: // musical notation format
+		return true
+	case r >= 0xE0000 && r <= 0xE007F: // tag chars (incl. LANGUAGE TAG)
+		return true
+	case r >= 0xE0080 && r <= 0xE00FF: // reserved tag range
+		return true
+	case r >= 0xE0100 && r <= 0xE01EF: // variation selectors supplement
+		return true
+	case r >= 0xE01F0 && r <= 0xE0FFF: // reserved supplementary tag plane
+		return true
+	case r >= 0xF0000 && r <= 0xFFFFD: // supplementary private-use plane A
+		return true
+	case r >= 0x100000 && r <= 0x10FFFD: // supplementary private-use plane B
+		return true
+	}
+	return false
+}
+
+func isJSONContentType(ct string) bool {
+	// Accept "application/json" with optional ;charset / params.
+	semi := strings.IndexByte(ct, ';')
+	base := ct
+	if semi >= 0 {
+		base = ct[:semi]
+	}
+	return strings.EqualFold(strings.TrimSpace(base), "application/json")
+}
+
+func isSQLiteUniqueConstraint(err error) bool {
+	if err == nil {
+		return false
+	}
+	var sqErr *sqlite.Error
+	if errors.As(err, &sqErr) {
+		switch sqErr.Code() {
+		case sqlite3errs.SQLITE_CONSTRAINT_UNIQUE, sqlite3errs.SQLITE_CONSTRAINT_PRIMARYKEY:
+			return true
+		}
+	}
+	// Defensive fallback for drivers that don't expose Code() —
+	// modernc.org/sqlite does, but if the wrapper changes:
+	return strings.Contains(strings.ToLower(fmt.Sprint(err)), "unique constraint")
+}
+
+func nullStringOrNil(s sql.NullString) any {
+	if !s.Valid {
+		return nil
+	}
+	return s.String
+}
+
+// writeValidationError emits a 422 with the SPEC-005 v0.4 §11.6.1.1
+// `code` enum.
+func writeValidationError(w http.ResponseWriter, code, msg string) {
+	writeError(w, http.StatusUnprocessableEntity, code, msg)
+}

--- a/phase4-coordinator/internal/billing/quarantine.go
+++ b/phase4-coordinator/internal/billing/quarantine.go
@@ -321,6 +321,15 @@ func decodeForceVoidBody(w http.ResponseWriter, r *http.Request) (forceVoidBody,
 		}
 		return body, false
 	}
+	// R2 fix (SEC-M1 / CODE-H2): MaxBytesReader is set to
+	// maxBodyBytes+1 above so a body of exactly 4097 bytes returns
+	// without a MaxBytesError, but SPEC §11.6.1.1 rejects bodies
+	// strictly greater than 4 KiB. Explicit post-read length check
+	// closes the off-by-one for chunked / unknown-length requests.
+	if len(raw) > maxBodyBytes {
+		writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "body exceeds 4 KiB")
+		return body, false
+	}
 	// SPEC §11.6.3 rule 1: UTF-8 well-formedness BEFORE any
 	// JSON-induced normalization (json.Unmarshal silently replaces
 	// invalid UTF-8 with U+FFFD).
@@ -370,12 +379,19 @@ func decodeForceVoidBody(w http.ResponseWriter, r *http.Request) (forceVoidBody,
 		}
 		rawFields[key] = val
 	}
-	// Closing `}` and EOF.
-	if _, err := dec.Token(); err != nil {
+	// Closing `}`.
+	if tok, err := dec.Token(); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid json body")
+		return body, false
+	} else if d, ok := tok.(json.Delim); !ok || d != '}' {
 		writeError(w, http.StatusBadRequest, "bad_request", "invalid json body")
 		return body, false
 	}
-	if dec.More() {
+	// R2 fix (CODE-H3): dec.More() only reports remaining elements
+	// inside the current array/object; once we've consumed the
+	// top-level `}` we must explicitly require io.EOF, otherwise
+	// `{...} {}` or `{...} 42` would be accepted.
+	if _, err := dec.Token(); err != io.EOF {
 		writeError(w, http.StatusBadRequest, "bad_request", "body must contain a single JSON object")
 		return body, false
 	}

--- a/phase4-coordinator/internal/billing/quarantine.go
+++ b/phase4-coordinator/internal/billing/quarantine.go
@@ -1,11 +1,13 @@
 package billing
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -37,33 +39,45 @@ const (
 	resolutionKindVoid     = "force_void"
 )
 
-// matchQuarantinePath returns (request_credit_id, "force-void", ok)
-// when r.URL.Path matches the §11.6 quarantine path shape. ok=false
-// otherwise — the dispatcher then routes to 404.
-func matchQuarantinePath(path string) (int64, string, bool) {
+// quarantinePathMatch distinguishes three cases:
+//   - matched=false: path doesn't look like /admin/ledger/quarantine/.../force-void;
+//     dispatcher should fall through to existing routing.
+//   - matched=true, badID=true: the route shape matches but the id is
+//     malformed (non-decimal or int64 overflow). SPEC-005 §11.6.1.1
+//     requires HTTP 400 `bad_request`.
+//   - matched=true, badID=false: id parsed cleanly; handler proceeds.
+type quarantinePathMatch struct {
+	matched bool
+	badID   bool
+	id      int64
+	kind    string
+}
+
+func matchQuarantinePath(path string) quarantinePathMatch {
 	if !strings.HasPrefix(path, quarantinePathPrefix) {
-		return 0, "", false
+		return quarantinePathMatch{}
 	}
 	rest := path[len(quarantinePathPrefix):]
 	if !strings.HasSuffix(rest, forceVoidPathSuffix) {
-		return 0, "", false
+		return quarantinePathMatch{}
 	}
 	idStr := rest[:len(rest)-len(forceVoidPathSuffix)]
+	// At this point the path SHAPE matches the force-void route.
+	// Anything wrong with the id field is now a §11.6.1.1 400, not a
+	// 404 fall-through.
 	if idStr == "" {
-		return 0, "", false
+		return quarantinePathMatch{matched: true, badID: true, kind: "force-void"}
 	}
-	// path parameter must be a base-10 int64 — SPEC-005 §11.6.1.1
-	// 400 `bad_request` for any non-integer / overflow case.
 	for _, c := range idStr {
 		if c < '0' || c > '9' {
-			return 0, "", false
+			return quarantinePathMatch{matched: true, badID: true, kind: "force-void"}
 		}
 	}
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		return 0, "", false
+		return quarantinePathMatch{matched: true, badID: true, kind: "force-void"}
 	}
-	return id, "force-void", true
+	return quarantinePathMatch{matched: true, badID: false, id: id, kind: "force-void"}
 }
 
 // forceVoidHandler implements POST /admin/ledger/quarantine/{id}/force-void
@@ -82,8 +96,10 @@ func (h *handler) forceVoidHandler(w http.ResponseWriter, r *http.Request, reque
 	}
 	// Route-layer gate (§11.5 launch-gate item 10). Disabled-flag and
 	// row-not-found both return 404 with byte-identical bodies — no
-	// leak of which case fired.
-	if !h.forceVoidEnabled {
+	// leak of which case fired. Read the flag via the Store atomic
+	// so SIGHUP-driven flips take effect on the next request without
+	// rewiring the http.Handler.
+	if !h.store.ForceVoidEnabled() {
 		writeError(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
@@ -114,8 +130,8 @@ func (h *handler) forceVoidHandler(w http.ResponseWriter, r *http.Request, reque
 		writeValidationError(w, errCode, "reason rejected: "+errCode)
 		return
 	}
-	operatorID := strings.TrimSpace(body.OperatorID)
-	reason := strings.TrimSpace(body.Reason)
+	operatorID := trimSpaceASCII(body.OperatorID)
+	reason := trimSpaceASCII(body.Reason)
 
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 	defer cancel()
@@ -126,12 +142,29 @@ func (h *handler) forceVoidHandler(w http.ResponseWriter, r *http.Request, reque
 	// written via the same *sql.Tx (NOT via audit.Store.Insert)
 	// because the audit Store opens a separate *sql.DB handle and
 	// cannot participate in this transaction.
-	tx, err := h.store.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	//
+	// modernc.org/sqlite's `BeginTx(LevelSerializable)` does NOT map
+	// to `BEGIN IMMEDIATE` unless the driver is configured with
+	// `?_txlock=immediate` in the DSN. We don't control the DSN here
+	// (shared with requestlog), so we acquire a dedicated conn and
+	// execute `BEGIN IMMEDIATE` explicitly. The same conn is then
+	// used for the resolution + audit INSERTs and the COMMIT.
+	conn, err := h.store.db.Conn(ctx)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal_error", "begin tx: "+err.Error())
+		writeError(w, http.StatusInternalServerError, "internal_error", "acquire conn: "+err.Error())
 		return
 	}
-	defer tx.Rollback()
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "begin immediate: "+err.Error())
+		return
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
 
 	// Base-row preconditions (§11.6.2). These are on
 	// ledger_request_credits, NOT on ledger_quarantine_resolutions.
@@ -141,7 +174,7 @@ func (h *handler) forceVoidHandler(w http.ResponseWriter, r *http.Request, reque
 	var attemptN int64
 	var providerID string
 	var quarantineReason sql.NullString
-	row := tx.QueryRowContext(ctx, `
+	row := conn.QueryRowContext(ctx, `
 SELECT 1, quarantined, request_id, attempt_n, provider_id, quarantine_reason
   FROM ledger_request_credits WHERE id = ?`, requestCreditID)
 	if err := row.Scan(&baseExists, &quarantined, &requestID, &attemptN, &providerID, &quarantineReason); err != nil {
@@ -160,16 +193,19 @@ SELECT 1, quarantined, request_id, attempt_n, provider_id, quarantine_reason
 	// Resolution INSERT. Race protection is the UNIQUE constraint
 	// (§11.6.6); we do NOT pre-check ledger_quarantine_resolutions.
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	_, err = tx.ExecContext(ctx, `
+	_, err = conn.ExecContext(ctx, `
 INSERT INTO ledger_quarantine_resolutions
     (request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc)
 VALUES (?, ?, ?, ?, ?)`, requestCreditID, resolutionKindVoid, operatorID, reason, now)
 	if err != nil {
 		if isSQLiteUniqueConstraint(err) {
-			// Release the conn (MaxOpenConns(1) on the shared *sql.DB
-			// — issue #21 / ARCH-3) BEFORE re-reading via h.store.db,
-			// otherwise the re-read deadlocks until ctx expires.
-			tx.Rollback()
+			// ROLLBACK + release conn (MaxOpenConns(1) on the shared
+			// *sql.DB — issue #21 / ARCH-3) BEFORE re-reading via
+			// h.store.db, otherwise the re-read deadlocks until ctx
+			// expires.
+			_, _ = conn.ExecContext(ctx, `ROLLBACK`)
+			committed = true // suppress the deferred ROLLBACK
+			conn.Close()
 			h.respondAlreadyResolved(w, ctx, nil, requestCreditID)
 			return
 		}
@@ -197,17 +233,18 @@ VALUES (?, ?, ?, ?, ?)`, requestCreditID, resolutionKindVoid, operatorID, reason
 		writeError(w, http.StatusInternalServerError, "internal_error", "marshal audit payload: "+err.Error())
 		return
 	}
-	if _, err := tx.ExecContext(ctx, `
+	if _, err := conn.ExecContext(ctx, `
 INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
 VALUES (?, ?, ?, ?)`, now, eventForceVoid, providerID, string(payloadJSON)); err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "insert audit: "+err.Error())
 		return
 	}
 
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "commit: "+err.Error())
 		return
 	}
+	committed = true
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"request_credit_id": requestCreditID,
@@ -219,9 +256,10 @@ VALUES (?, ?, ?, ?)`, now, eventForceVoid, providerID, string(payloadJSON)); err
 }
 
 // respondAlreadyResolved reads the existing resolution row and emits
-// the SPEC-005 §11.6.2 409 envelope. tx may be the same transaction
-// (which will be rolled back by the defer); we don't need a fresh
-// reader because the row is committed by definition.
+// the SPEC-005 §11.6.2 409 envelope. The caller MUST release the
+// transaction's connection BEFORE calling this — re-reading via
+// `h.store.db` while a tx still holds the only conn deadlocks at
+// `MaxOpenConns(1)` (issue #21 / ARCH-3).
 func (h *handler) respondAlreadyResolved(w http.ResponseWriter, ctx context.Context, _ *sql.Tx, requestCreditID int64) {
 	// Use the DB handle (not the failing tx) so the SELECT sees the
 	// committed winner row even though our tx is about to roll back.
@@ -262,37 +300,91 @@ type forceVoidBody struct {
 	Reason     string `json:"reason"`
 }
 
-// decodeForceVoidBody parses + validates the JSON shape (presence of
-// fields, no unknown keys, no duplicate keys) per §11.6.1.1.
+// decodeForceVoidBody enforces §11.6.1.1 JSON strictness:
+//   - reject invalid UTF-8 in the raw body (BEFORE json decode would
+//     normalize to U+FFFD)
+//   - reject duplicate top-level keys (json.Decoder + map silently
+//     collapses; we token-scan to catch them)
+//   - reject unknown top-level keys (DisallowUnknownFields only
+//     applies to struct decode; map decode ignores it)
+//   - reject non-object top-level / multi-value bodies
+//   - distinguish 413 (body too large) from 400 (other JSON errors).
 func decodeForceVoidBody(w http.ResponseWriter, r *http.Request) (forceVoidBody, bool) {
-	var raw map[string]json.RawMessage
-	dec := json.NewDecoder(r.Body)
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&raw); err != nil {
-		// http.MaxBytesError → 413; any other JSON error → 400.
+	body := forceVoidBody{}
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
 		var mbErr *http.MaxBytesError
 		if errors.As(err, &mbErr) {
 			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "body exceeds 4 KiB")
 		} else {
-			writeError(w, http.StatusBadRequest, "bad_request", "invalid json body")
+			writeError(w, http.StatusBadRequest, "bad_request", "failed to read body")
 		}
-		return forceVoidBody{}, false
+		return body, false
 	}
-	if dec.More() {
-		writeError(w, http.StatusBadRequest, "bad_request", "body must contain a single JSON object")
-		return forceVoidBody{}, false
+	// SPEC §11.6.3 rule 1: UTF-8 well-formedness BEFORE any
+	// JSON-induced normalization (json.Unmarshal silently replaces
+	// invalid UTF-8 with U+FFFD).
+	if !utf8.Valid(raw) {
+		writeValidationError(w, "invalid_utf8", "body is not valid UTF-8")
+		return body, false
 	}
-	body := forceVoidBody{}
-	if raw == nil {
+	// Token-scan the top-level object to enforce SPEC §11.6.1.1
+	// duplicate / unknown key rules.
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid json body")
+		return body, false
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
 		writeError(w, http.StatusBadRequest, "bad_request", "body must be a JSON object")
 		return body, false
 	}
-	opRaw, hasOp := raw["operator_id"]
+	seenKeys := map[string]bool{}
+	allowedKeys := map[string]bool{"operator_id": true, "reason": true}
+	rawFields := map[string]json.RawMessage{}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid json body")
+			return body, false
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid json body")
+			return body, false
+		}
+		if seenKeys[key] {
+			writeError(w, http.StatusBadRequest, "bad_request", "duplicate key: "+key)
+			return body, false
+		}
+		seenKeys[key] = true
+		if !allowedKeys[key] {
+			writeError(w, http.StatusBadRequest, "bad_request", "unknown key: "+key)
+			return body, false
+		}
+		var val json.RawMessage
+		if err := dec.Decode(&val); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid json value for "+key)
+			return body, false
+		}
+		rawFields[key] = val
+	}
+	// Closing `}` and EOF.
+	if _, err := dec.Token(); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid json body")
+		return body, false
+	}
+	if dec.More() {
+		writeError(w, http.StatusBadRequest, "bad_request", "body must contain a single JSON object")
+		return body, false
+	}
+	opRaw, hasOp := rawFields["operator_id"]
 	if !hasOp {
 		writeValidationError(w, "missing_field", "operator_id is required")
 		return body, false
 	}
-	reasonRaw, hasReason := raw["reason"]
+	reasonRaw, hasReason := rawFields["reason"]
 	if !hasReason {
 		writeValidationError(w, "missing_field", "reason is required")
 		return body, false
@@ -305,7 +397,47 @@ func decodeForceVoidBody(w http.ResponseWriter, r *http.Request) (forceVoidBody,
 		writeValidationError(w, "unsanitized_reason", "reason must be a JSON string")
 		return body, false
 	}
+	// Defense-in-depth: even though we pre-validated raw body UTF-8,
+	// the post-unmarshal value MAY contain U+FFFD from a
+	// well-formed-UTF-8 JSON `\uXXXX` escape that decodes to a lone
+	// surrogate. Reject as `invalid_utf8` so the audit log byte
+	// content matches the operator's input.
+	if strings.ContainsRune(body.OperatorID, utf8.RuneError) {
+		writeValidationError(w, "invalid_utf8", "operator_id contains invalid surrogate escape")
+		return body, false
+	}
+	if strings.ContainsRune(body.Reason, utf8.RuneError) {
+		writeValidationError(w, "invalid_utf8", "reason contains invalid surrogate escape")
+		return body, false
+	}
 	return body, true
+}
+
+// trimSpaceASCII trims ONLY the §11.6.3 whitespace set (`\t \n \r
+// \v \f` + ASCII space 0x20). Avoids `strings.TrimSpace`, which
+// removes Unicode whitespace like U+0085 (NEL) — those bytes are
+// part of the C1 control range that §11.6.3 wants the sanitizer to
+// REJECT, not silently strip.
+func trimSpaceASCII(s string) string {
+	start := 0
+	for start < len(s) {
+		c := s[start]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f' {
+			start++
+			continue
+		}
+		break
+	}
+	end := len(s)
+	for end > start {
+		c := s[end-1]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f' {
+			end--
+			continue
+		}
+		break
+	}
+	return s[start:end]
 }
 
 // validateOperatorID returns the 422 `code` string for the first
@@ -314,7 +446,7 @@ func validateOperatorID(s string) string {
 	if !utf8.ValidString(s) {
 		return "invalid_utf8"
 	}
-	t := strings.TrimSpace(s)
+	t := trimSpaceASCII(s)
 	if t == "" || len(t) > maxOperatorIDLen {
 		return "bad_operator_id"
 	}
@@ -337,7 +469,7 @@ func validateReason(s string) string {
 	if !utf8.ValidString(s) {
 		return "invalid_utf8"
 	}
-	t := strings.TrimSpace(s)
+	t := trimSpaceASCII(s)
 	if t == "" {
 		return "empty_reason"
 	}

--- a/phase4-coordinator/internal/billing/quarantine.go
+++ b/phase4-coordinator/internal/billing/quarantine.go
@@ -405,12 +405,20 @@ func decodeForceVoidBody(w http.ResponseWriter, r *http.Request) (forceVoidBody,
 		writeValidationError(w, "missing_field", "reason is required")
 		return body, false
 	}
+	// R5 fix (CODE-M1): wrong field TYPES are body-shape errors, not
+	// value-content validation errors. Mapping them to 400 bad_request
+	// (rather than 422 bad_operator_id / unsanitized_reason) is the
+	// semantically correct posture: the body's JSON structure is
+	// malformed, not the operator's chosen identity. 422 is reserved
+	// for cases where the JSON shape is valid but the field value is
+	// rejected by the §11.6.3 sanitizer (control chars, charset,
+	// length, etc.).
 	if err := json.Unmarshal(opRaw, &body.OperatorID); err != nil {
-		writeValidationError(w, "bad_operator_id", "operator_id must be a JSON string")
+		writeError(w, http.StatusBadRequest, "bad_request", "operator_id must be a JSON string")
 		return body, false
 	}
 	if err := json.Unmarshal(reasonRaw, &body.Reason); err != nil {
-		writeValidationError(w, "unsanitized_reason", "reason must be a JSON string")
+		writeError(w, http.StatusBadRequest, "bad_request", "reason must be a JSON string")
 		return body, false
 	}
 	// Defense-in-depth: even though we pre-validated raw body UTF-8,

--- a/phase4-coordinator/internal/billing/quarantine_test.go
+++ b/phase4-coordinator/internal/billing/quarantine_test.go
@@ -904,6 +904,44 @@ func TestForceVoidRejectsDuplicateTopLevelKey(t *testing.T) {
 	}
 }
 
+// R5 (CODE-M1): wrong JSON field TYPES are body-shape errors → 400
+// bad_request, not 422 validation. operator_id=42 (number) and
+// reason=null both fail json.Unmarshal into string; both must
+// surface as 400 with code=bad_request so 422 stays reserved for
+// the §11.6.3 sanitizer's value-content rejections.
+func TestForceVoidWrongFieldTypeIsBadRequest(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-type")
+	// Note: JSON null coerces to "" via json.Unmarshal into string, so
+	// null arms fall through to the §11.6.3 sanitizer and surface as
+	// 422 bad_operator_id / empty_reason — a legitimate
+	// value-content rejection, NOT a type mismatch. Only true type
+	// mismatches (number, bool, object, array) reach the bad_request
+	// path below.
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"operator_id_number", `{"operator_id":42,"reason":"x"}`},
+		{"operator_id_bool", `{"operator_id":true,"reason":"x"}`},
+		{"operator_id_object", `{"operator_id":{"k":"v"},"reason":"x"}`},
+		{"reason_number", `{"operator_id":"alice","reason":99}`},
+		{"reason_array", `{"operator_id":"alice","reason":["x"]}`},
+		{"reason_object", `{"operator_id":"alice","reason":{"k":"v"}}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := doForceVoid(t, store, true, id, c.body, "application/json")
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s want 400", w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), `"code":"bad_request"`) {
+				t.Fatalf("body=%s does not contain bad_request envelope", w.Body.String())
+			}
+		})
+	}
+}
+
 // R2 (CODE-M1): JSON strictness — unknown top-level key returns 400.
 func TestForceVoidRejectsUnknownTopLevelKey(t *testing.T) {
 	store := quarantineFixture(t)

--- a/phase4-coordinator/internal/billing/quarantine_test.go
+++ b/phase4-coordinator/internal/billing/quarantine_test.go
@@ -320,6 +320,44 @@ func TestACQ045_ReaderSideNarrowing(t *testing.T) {
 	if got := summary["total_provider_credits"]; got != 100 {
 		t.Fatalf("total_provider_credits=%d want 100 (force-void does NOT add to payable set)", got)
 	}
+	// R3 fix (CODE-M1): SPEC AC-Q045 also requires hitting
+	// `/providers/{id}/earnings`. Force-voided rows must NOT appear
+	// in the provider earnings response. Verify against each of the
+	// three providers in the fixture: p-q045 (payable) sees 100,
+	// p-q045-b (open quarantined) sees 0, p-q045-c (force-voided)
+	// sees 0.
+	earningsTokens := fakeTokens{
+		"t-a": "p-q045",
+		"t-b": "p-q045-b",
+		"t-c": "p-q045-c",
+	}
+	earningsHandler := store.HandlersWithQuarantineGate("operator", earningsTokens, true, 60, true)
+	hitEarnings := func(t *testing.T, providerID, token string) int64 {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/providers/"+providerID+"/earnings", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		earningsHandler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("/providers/%s/earnings status=%d body=%s", providerID, rec.Code, rec.Body.String())
+		}
+		var resp struct {
+			TotalCredits int64 `json:"total_credits"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+		return resp.TotalCredits
+	}
+	if got := hitEarnings(t, "p-q045", "t-a"); got != 100 {
+		t.Fatalf("/providers/p-q045/earnings total=%d want 100", got)
+	}
+	if got := hitEarnings(t, "p-q045-b", "t-b"); got != 0 {
+		t.Fatalf("/providers/p-q045-b/earnings total=%d want 0 (open quarantined excluded)", got)
+	}
+	if got := hitEarnings(t, "p-q045-c", "t-c"); got != 0 {
+		t.Fatalf("/providers/p-q045-c/earnings total=%d want 0 (force-voided excluded)", got)
+	}
 }
 
 // AC-Q047: same-transaction audit atomicity — drop audit_log before
@@ -503,15 +541,16 @@ func TestForceVoidNoNestedQueryDeadlock(t *testing.T) {
 }
 
 // AC-Q049: concurrent POSTs against the same id — exactly one 200
-// + (N-1) × 409; one resolution row; one audit row.
-// N is intentionally < adminBucketCapacity so this AC tests the
-// UNIQUE-constraint race, not the rate-limit bucket (which is
-// tested separately).
+// + (N-1) × 409; one resolution row; one audit row. SPEC says
+// "Fire 64 parallel POST" and "All 64 responses count against the
+// /admin/* rate-limit bucket". N=64 < adminBucketCapacity=128 so
+// no 429 is expected — the bucket admits all 64, and the AC tests
+// the UNIQUE-constraint race only.
 func TestACQ049_ConcurrentUNIQUEConflict(t *testing.T) {
 	store := quarantineFixture(t)
 	id := insertQuarantinedCredit(t, store, "p-q049")
 	handler := store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true)
-	const N = 32
+	const N = 64
 	var wg sync.WaitGroup
 	var ok200 int64
 	var ok409 int64
@@ -589,6 +628,25 @@ func TestACQ053_ReloadEmitsFlagChangedAuditAndFlipTakesEffect(t *testing.T) {
 	}
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='billing_config_flag_changed'`); got != 1 {
 		t.Fatalf("reload-no-change emitted spurious audit row: got %d total", got)
+	}
+	// R3 fix (CODE-M2): SPEC AC-Q053 third leg — reload back to
+	// false. Must emit a SECOND billing_config_flag_changed audit
+	// row and a fresh POST against a DIFFERENT quarantined row must
+	// return the byte-identical 404 envelope.
+	if err := store.SetForceVoidEnabled(context.Background(), false, "sighup"); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='billing_config_flag_changed'`); got != 2 {
+		t.Fatalf("flag-change audit rows=%d want 2 after true→false flip", got)
+	}
+	id2 := insertQuarantinedCredit(t, store, "p-q053c")
+	req3 := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/"+itoa(id2)+"/force-void", strings.NewReader(`{"operator_id":"alice","reason":"x"}`))
+	req3.Header.Set("Authorization", "Bearer operator")
+	req3.Header.Set("Content-Type", "application/json")
+	w3 := httptest.NewRecorder()
+	handler.ServeHTTP(w3, req3)
+	if w3.Code != http.StatusNotFound {
+		t.Fatalf("post-back-to-disabled status=%d body=%s want 404", w3.Code, w3.Body.String())
 	}
 }
 
@@ -875,6 +933,135 @@ func TestProviderRollupPayableIndependentOfFilter(t *testing.T) {
 	}
 	t.Run("default", func(t *testing.T) { check(t, "", 100, 1) })
 	t.Run("include_quarantined_true", func(t *testing.T) { check(t, "?include_quarantined=true", 100, 1) })
+}
+
+// R3 (SEC-M1): when the route-layer flag is DISABLED the entire
+// quarantine endpoint surface MUST be byte-indistinguishable from a
+// non-existent route. Method-not-allowed, bad-id, and force-void
+// POSTs all must return 404 (not 405/400) while the flag is off so
+// the surface is not discoverable.
+func TestQuarantineRouteHidesShapeWhenDisabled(t *testing.T) {
+	store := quarantineFixture(t)
+	// flag explicitly false
+	handler := store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, false)
+	id := insertQuarantinedCredit(t, store, "p-hide")
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get_well_formed_id", http.MethodGet, "/admin/ledger/quarantine/" + itoa(id) + "/force-void"},
+		{"put_well_formed_id", http.MethodPut, "/admin/ledger/quarantine/" + itoa(id) + "/force-void"},
+		{"delete_well_formed_id", http.MethodDelete, "/admin/ledger/quarantine/" + itoa(id) + "/force-void"},
+		{"post_bad_id", http.MethodPost, "/admin/ledger/quarantine/notanid/force-void"},
+		{"post_well_formed_id", http.MethodPost, "/admin/ledger/quarantine/" + itoa(id) + "/force-void"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest(c.method, c.path, strings.NewReader(`{"operator_id":"alice","reason":"x"}`))
+			req.Header.Set("Authorization", "Bearer operator")
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != http.StatusNotFound {
+				t.Fatalf("status=%d body=%s want 404 (route must be invisible while flag disabled)", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// R3 (ARCH-H1): Store.ReloadBillingConfig must atomically commit the
+// config snapshot row AND the billing_config_flag_changed audit row
+// (when the flag is actually changing), or neither. If the audit
+// INSERT fails the snapshot must NOT be written and the in-memory
+// flag must remain at its prior value.
+func TestReloadBillingConfigAtomicAuditAndSnapshot(t *testing.T) {
+	store := quarantineFixture(t)
+	if store.ForceVoidEnabled() {
+		t.Fatal("precondition: forceVoidEnabled must start false")
+	}
+	cfg := RewardsConfig{
+		ProviderShare:    0.90,
+		GlobalMultiplier: 1.0,
+		RateCard: map[string]RateCardEntry{
+			"default": {PromptCreditsPerMtok: 500000, CompletionCreditsPerMtok: 1000000},
+		},
+	}
+	// Successful reload that flips the flag false→true: must write
+	// one snapshot row + one audit row + publish the atomic.
+	now := time.Now().UTC()
+	snapID, err := store.ReloadBillingConfig(context.Background(), cfg, true, "sighup", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapID == 0 {
+		t.Fatal("snapshot id is zero")
+	}
+	if !store.ForceVoidEnabled() {
+		t.Fatal("flag did not publish after successful reload")
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_config_snapshots`); got != 1 {
+		t.Fatalf("snapshots=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='billing_config_flag_changed'`); got != 1 {
+		t.Fatalf("flag-change audit rows=%d want 1", got)
+	}
+
+	// Drop audit_log so the flag-change INSERT fails; flag is
+	// currently true, attempt to flip to false. Both snapshot and
+	// audit must roll back; the in-memory flag must remain true.
+	if _, err := store.db.Exec(`DROP TABLE audit_log`); err != nil {
+		t.Fatal(err)
+	}
+	preSnapshots := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_config_snapshots`)
+	if _, err := store.ReloadBillingConfig(context.Background(), cfg, false, "sighup", now.Add(time.Second)); err == nil {
+		t.Fatal("expected error from ReloadBillingConfig when audit_log is missing")
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_config_snapshots`); got != preSnapshots {
+		t.Fatalf("snapshots=%d want %d (atomic rollback required when audit insert fails)", got, preSnapshots)
+	}
+	if !store.ForceVoidEnabled() {
+		t.Fatal("flag flipped to false despite atomic audit failure — race regression")
+	}
+
+	// Recreate audit_log; reload should now succeed and flip to false.
+	createAuditLogForTest(t, store.db)
+	if _, err := store.ReloadBillingConfig(context.Background(), cfg, false, "sighup", now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if store.ForceVoidEnabled() {
+		t.Fatal("flag did not flip false after successful reload")
+	}
+}
+
+// R3 (also ARCH-H1): same-value reload through ReloadBillingConfig
+// writes a NEW snapshot row but does NOT emit a billing_config_flag_changed
+// audit row (SPEC §11.6.4 "reload-no-change" rule). Validates that
+// our atomic-tx path preserves the no-change semantics.
+func TestReloadBillingConfigSameValueNoFlagAudit(t *testing.T) {
+	store := quarantineFixture(t)
+	cfg := RewardsConfig{
+		ProviderShare:    0.90,
+		GlobalMultiplier: 1.0,
+		RateCard:         map[string]RateCardEntry{"default": {PromptCreditsPerMtok: 500000, CompletionCreditsPerMtok: 1000000}},
+	}
+	now := time.Now().UTC()
+	if _, err := store.ReloadBillingConfig(context.Background(), cfg, true, "sighup", now); err != nil {
+		t.Fatal(err)
+	}
+	auditAfterFirst := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='billing_config_flag_changed'`)
+	// Same value, must NOT emit a second audit row.
+	if _, err := store.ReloadBillingConfig(context.Background(), cfg, true, "sighup", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='billing_config_flag_changed'`); got != auditAfterFirst {
+		t.Fatalf("same-value reload emitted spurious audit row: count=%d want %d", got, auditAfterFirst)
+	}
+	// But snapshot row should still be inserted (snapshot is
+	// per-reload, independent of flag-flip).
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_config_snapshots`); got != 2 {
+		t.Fatalf("snapshots=%d want 2 (each reload writes a snapshot)", got)
+	}
 }
 
 // R2 (ARCH-H1): if the flag-change audit COMMIT fails, the route-layer

--- a/phase4-coordinator/internal/billing/quarantine_test.go
+++ b/phase4-coordinator/internal/billing/quarantine_test.go
@@ -463,18 +463,14 @@ func TestACQ053_RouteLayerConfigFlagGate(t *testing.T) {
 	if w2.Code != http.StatusOK {
 		t.Fatalf("enabled status=%d body=%s want 200", w2.Code, w2.Body.String())
 	}
-	// 404 for disabled-flag case is byte-identical to row-not-found
-	// — assert by comparing bodies.
+	// R4 fix (CODE-M3): byte-identity is the actual SPEC requirement.
+	// Compare the response bodies exactly, not via strings.Contains.
 	wNotFound := doForceVoid(t, store, true, 99999999, `{"operator_id":"alice","reason":"x"}`, "application/json")
 	if wNotFound.Code != http.StatusNotFound {
 		t.Fatalf("row-not-found status=%d want 404", wNotFound.Code)
 	}
-	// Both 404 bodies use the same {"error":{"code":"not_found",...}} envelope.
-	if !strings.Contains(w.Body.String(), `"code":"not_found"`) {
-		t.Fatalf("disabled-flag 404 missing not_found code: %s", w.Body.String())
-	}
-	if !strings.Contains(wNotFound.Body.String(), `"code":"not_found"`) {
-		t.Fatalf("row-not-found 404 missing not_found code: %s", wNotFound.Body.String())
+	if w.Body.String() != wNotFound.Body.String() {
+		t.Fatalf("disabled-flag 404 body NOT byte-identical to row-not-found:\n  disabled  = %q\n  not_found = %q", w.Body.String(), wNotFound.Body.String())
 	}
 }
 
@@ -554,6 +550,12 @@ func TestACQ049_ConcurrentUNIQUEConflict(t *testing.T) {
 	var wg sync.WaitGroup
 	var ok200 int64
 	var ok409 int64
+	// R4 fix (CODE-M5): SPEC AC-Q049 requires that EVERY 409 carries
+	// the {"error":{"code":"already_resolved","existing_resolution":
+	// {...winner...}}} envelope. Decode each 409 body and assert
+	// structure rather than just counting status codes.
+	bodies := make([][]byte, N)
+	var bodiesMu sync.Mutex
 	for i := 0; i < N; i++ {
 		wg.Add(1)
 		go func(i int) {
@@ -570,6 +572,9 @@ func TestACQ049_ConcurrentUNIQUEConflict(t *testing.T) {
 			case http.StatusConflict:
 				atomic.AddInt64(&ok409, 1)
 			}
+			bodiesMu.Lock()
+			bodies[i] = append([]byte(nil), w.Body.Bytes()...)
+			bodiesMu.Unlock()
 		}(i)
 	}
 	wg.Wait()
@@ -584,6 +589,61 @@ func TestACQ049_ConcurrentUNIQUEConflict(t *testing.T) {
 	}
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='ledger_quarantine_force_void'`); got != 1 {
 		t.Fatalf("audit rows=%d want 1", got)
+	}
+	// R4 fix (CODE-M5): inspect each 409 body. All must share the
+	// SAME winner identity in existing_resolution and the same
+	// already_resolved code.
+	var winnerCreatedAt, winnerOpID, winnerReason string
+	conflictCount := 0
+	for i, raw := range bodies {
+		var resp struct {
+			Error struct {
+				Code               string `json:"code"`
+				ExistingResolution struct {
+					RequestCreditID  int64  `json:"request_credit_id"`
+					ResolutionKind   string `json:"resolution_kind"`
+					OperatorID       string `json:"operator_id"`
+					ResolutionReason string `json:"resolution_reason"`
+					CreatedAtUTC     string `json:"created_at_utc"`
+				} `json:"existing_resolution"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(raw, &resp); err != nil {
+			// 200 winner is a different envelope; skip JSON-decode
+			// failures on the winner and on any non-409 bodies.
+			continue
+		}
+		if resp.Error.Code == "" {
+			// Winner envelope — no error.code field.
+			continue
+		}
+		if resp.Error.Code != "already_resolved" {
+			t.Fatalf("worker %d 409 body code=%q want already_resolved (body=%s)", i, resp.Error.Code, string(raw))
+		}
+		if resp.Error.ExistingResolution.RequestCreditID != id {
+			t.Fatalf("worker %d existing_resolution.request_credit_id=%d want %d", i, resp.Error.ExistingResolution.RequestCreditID, id)
+		}
+		if resp.Error.ExistingResolution.ResolutionKind != "force_void" {
+			t.Fatalf("worker %d existing_resolution.resolution_kind=%q want force_void", i, resp.Error.ExistingResolution.ResolutionKind)
+		}
+		if resp.Error.ExistingResolution.CreatedAtUTC == "" {
+			t.Fatalf("worker %d existing_resolution.created_at_utc is empty", i)
+		}
+		if winnerCreatedAt == "" {
+			winnerCreatedAt = resp.Error.ExistingResolution.CreatedAtUTC
+			winnerOpID = resp.Error.ExistingResolution.OperatorID
+			winnerReason = resp.Error.ExistingResolution.ResolutionReason
+		} else {
+			if resp.Error.ExistingResolution.CreatedAtUTC != winnerCreatedAt ||
+				resp.Error.ExistingResolution.OperatorID != winnerOpID ||
+				resp.Error.ExistingResolution.ResolutionReason != winnerReason {
+				t.Fatalf("worker %d existing_resolution disagrees with prior conflicts (race coherence violated): got %+v", i, resp.Error.ExistingResolution)
+			}
+		}
+		conflictCount++
+	}
+	if int64(conflictCount) != ok409 {
+		t.Fatalf("decoded conflict bodies=%d want %d", conflictCount, ok409)
 	}
 }
 
@@ -933,6 +993,118 @@ func TestProviderRollupPayableIndependentOfFilter(t *testing.T) {
 	}
 	t.Run("default", func(t *testing.T) { check(t, "", 100, 1) })
 	t.Run("include_quarantined_true", func(t *testing.T) { check(t, "?include_quarantined=true", 100, 1) })
+}
+
+// R4 (CODE-M1): pin the precedence of disabled-flag hide vs
+// operator-key auth on the quarantine surface. The actual order
+// in serveHTTP for /admin/ledger/quarantine/{id}/force-void is:
+//
+//  1. Rate-limit bucket charge.
+//  2. matchQuarantinePath → matched.
+//  3. Flag-disabled check → 404 universal (SEC-M1 hide).
+//     This precedes auth so the route is invisible to BOTH
+//     unauthenticated and authenticated probes when flag is off.
+//  4. Method check / bad-id check / forceVoidHandler.
+//  5. forceVoidHandler internals: method check / auth check / flag
+//     check (defense-in-depth) / body validation.
+//
+// Trade-off: the disabled-flag hide returns 404 even to
+// unauthenticated callers. This is preferable to leaking the
+// quarantine surface's existence to anyone with network reach to
+// the coordinator — operators with the wrong key can't even tell
+// the surface is real. When the flag is ENABLED, auth runs inside
+// the handler and missing/wrong keys get 403.
+func TestQuarantineRoutePrecedenceAuthThenFlag(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-prec")
+	// HandlersWithQuarantineGate calls
+	// SetForceVoidEnabled(..., "startup") which MUTATES the shared
+	// store atomic. Rebuild the handler when we want the flag flipped
+	// rather than building both handlers up-front (would leak
+	// enabled-state into the disabled cases).
+	handlerDisabled := store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, false)
+
+	// Flag DISABLED + NO auth → 404 (hide precedes auth; route is
+	// invisible to network-reachable callers regardless of credentials).
+	{
+		req := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", strings.NewReader(`{"operator_id":"alice","reason":"x"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handlerDisabled.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("disabled+no-auth status=%d want 404 (hide precedes auth)", w.Code)
+		}
+	}
+	// Flag DISABLED + WRONG bearer → 404 (same hide).
+	{
+		req := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", strings.NewReader(`{"operator_id":"alice","reason":"x"}`))
+		req.Header.Set("Authorization", "Bearer wrong")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handlerDisabled.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("disabled+wrong-bearer status=%d want 404", w.Code)
+		}
+	}
+	// Flag DISABLED + GOOD auth + GET → 404 (auth passes, route-match
+	// hits, flag-disabled hides the method-not-allowed distinction).
+	{
+		req := httptest.NewRequest(http.MethodGet, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", nil)
+		req.Header.Set("Authorization", "Bearer operator")
+		w := httptest.NewRecorder()
+		handlerDisabled.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("disabled+good-auth+GET status=%d want 404 (flag hide must mask 405)", w.Code)
+		}
+	}
+	// Flag DISABLED + GOOD auth + bad-id POST → 404 (flag-disabled
+	// hides the bad-id 400).
+	{
+		req := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/notanid/force-void", strings.NewReader(`{"operator_id":"alice","reason":"x"}`))
+		req.Header.Set("Authorization", "Bearer operator")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handlerDisabled.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("disabled+good-auth+bad-id status=%d want 404 (flag hide must mask 400)", w.Code)
+		}
+	}
+
+	// Now flip to enabled and verify auth/method/id checks run.
+	handlerEnabled := store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true)
+
+	// Flag ENABLED + NO auth → 403.
+	{
+		req := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", strings.NewReader(`{"operator_id":"alice","reason":"x"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handlerEnabled.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden && w.Code != http.StatusUnauthorized {
+			t.Fatalf("enabled+no-auth status=%d want 401/403", w.Code)
+		}
+	}
+	// Flag ENABLED + GOOD auth + GET → 405 (method check runs).
+	{
+		req := httptest.NewRequest(http.MethodGet, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", nil)
+		req.Header.Set("Authorization", "Bearer operator")
+		w := httptest.NewRecorder()
+		handlerEnabled.ServeHTTP(w, req)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("enabled+good-auth+GET status=%d want 405", w.Code)
+		}
+	}
+	// Flag ENABLED + GOOD auth + bad-id POST → 400 (id-shape check
+	// runs).
+	{
+		req := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/notanid/force-void", strings.NewReader(`{"operator_id":"alice","reason":"x"}`))
+		req.Header.Set("Authorization", "Bearer operator")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handlerEnabled.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("enabled+good-auth+bad-id status=%d want 400", w.Code)
+		}
+	}
 }
 
 // R3 (SEC-M1): when the route-layer flag is DISABLED the entire

--- a/phase4-coordinator/internal/billing/quarantine_test.go
+++ b/phase4-coordinator/internal/billing/quarantine_test.go
@@ -691,3 +691,220 @@ func TestForceVoidChargesAdminBucket(t *testing.T) {
 		t.Fatalf("force-void POSTs should consume the same bucket; got 0 × 429 after draining via /summary")
 	}
 }
+
+// R2 (CODE-H2 / SEC-M1): body cap is strictly > 4 KiB → 413. A body of
+// exactly 4096 bytes is accepted (and rejected later for unrelated
+// schema issues); 4097 bytes is 413 regardless of validation outcome.
+func TestForceVoidBodyCapOffByOne(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-cap")
+	// Build a 4097-byte body whose JSON is otherwise valid. Pad the
+	// reason value with ASCII 'a' so it remains a syntactically valid
+	// JSON object whose top-level length is 4097.
+	prefix := `{"operator_id":"alice","reason":"`
+	suffix := `"}`
+	padLen := 4097 - len(prefix) - len(suffix)
+	body := prefix + strings.Repeat("a", padLen) + suffix
+	if len(body) != 4097 {
+		t.Fatalf("test body construction wrong: len=%d want 4097", len(body))
+	}
+	w := doForceVoid(t, store, true, id, body, "application/json")
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status=%d want 413 (body=4097 must exceed cap)", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "request_too_large") {
+		t.Fatalf("body=%s does not contain request_too_large", w.Body.String())
+	}
+	// Sanity: a 4096-byte body passes the cap (downstream may still
+	// reject for schema reasons, but NOT with 413).
+	padLen4096 := 4096 - len(prefix) - len(suffix)
+	body4096 := prefix + strings.Repeat("a", padLen4096) + suffix
+	if len(body4096) != 4096 {
+		t.Fatalf("4096 body construction wrong: len=%d", len(body4096))
+	}
+	w2 := doForceVoid(t, store, true, id, body4096, "application/json")
+	if w2.Code == http.StatusRequestEntityTooLarge {
+		t.Fatalf("4096-byte body wrongly returned 413; should pass cap")
+	}
+}
+
+// R2 (CODE-H3): the decoder must require io.EOF after the closing `}`.
+// `{...} {}` or `{...} 42` must be 400 bad_request, not accepted.
+func TestForceVoidRejectsExtraTopLevelJSON(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-extra")
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"trailing_object", `{"operator_id":"alice","reason":"x"} {}`},
+		{"trailing_number", `{"operator_id":"alice","reason":"x"} 42`},
+		{"trailing_string", `{"operator_id":"alice","reason":"x"} "extra"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := doForceVoid(t, store, true, id, c.body, "application/json")
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s want 400", w.Code, w.Body.String())
+			}
+		})
+	}
+	// Sanity: no resolution / audit rows from the rejected calls.
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions`); got != 0 {
+		t.Fatalf("rejected calls leaked %d resolution rows", got)
+	}
+}
+
+// R2 (CODE-H2 also): invalid UTF-8 in the raw body is rejected as
+// 422 invalid_utf8 BEFORE the JSON parser would silently normalize
+// to U+FFFD.
+func TestForceVoidRejectsInvalidUTF8RawBody(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-utf8")
+	// Lone 0xFF byte inside the JSON string is invalid UTF-8.
+	body := "{\"operator_id\":\"alice\",\"reason\":\"hi\xffx\"}"
+	w := doForceVoid(t, store, true, id, body, "application/json")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d body=%s want 422", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "invalid_utf8") {
+		t.Fatalf("body=%s does not contain invalid_utf8", w.Body.String())
+	}
+}
+
+// R2 (CODE-M1): JSON strictness — duplicate top-level key returns 400.
+func TestForceVoidRejectsDuplicateTopLevelKey(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-dup")
+	body := `{"operator_id":"alice","operator_id":"bob","reason":"x"}`
+	w := doForceVoid(t, store, true, id, body, "application/json")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s want 400", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "duplicate") {
+		t.Fatalf("body=%s does not contain duplicate-key error", w.Body.String())
+	}
+}
+
+// R2 (CODE-M1): JSON strictness — unknown top-level key returns 400.
+func TestForceVoidRejectsUnknownTopLevelKey(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-unk")
+	body := `{"operator_id":"alice","reason":"x","extra":"nope"}`
+	w := doForceVoid(t, store, true, id, body, "application/json")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s want 400", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "unknown") {
+		t.Fatalf("body=%s does not contain unknown-key error", w.Body.String())
+	}
+}
+
+// R2 (CODE-H4): /admin/ledger/providers payable totals are computed
+// from non-quarantined rows ONLY, regardless of include_quarantined.
+// quarantined_count uses OPEN_PREDICATE independent of the row filter.
+// Fixture: one provider with three credit rows — payable (100),
+// open-quarantined (200), force-voided (300). Default response and
+// include_quarantined=true must agree on payable=100, open=1, and
+// must NOT report payable=600 or quarantined_count=0.
+func TestProviderRollupPayableIndependentOfFilter(t *testing.T) {
+	store := quarantineFixture(t)
+	now := time.Now().UTC()
+	insertCredit(t, store.db, "p-rollup", now, 100) // payable row
+	// open-quarantined row (200)
+	openReq := "openq-" + now.Format("150405.000000000")
+	insertCreditWithRequest(t, store.db, openReq, "p-rollup", now, 200)
+	if _, err := store.db.Exec(`UPDATE ledger_request_credits SET quarantined=1 WHERE request_id=?`, openReq); err != nil {
+		t.Fatal(err)
+	}
+	// force-voided row (300)
+	voidedReq := "voidedq-" + now.Format("150405.000000000")
+	insertCreditWithRequest(t, store.db, voidedReq, "p-rollup", now, 300)
+	if _, err := store.db.Exec(`UPDATE ledger_request_credits SET quarantined=1 WHERE request_id=?`, voidedReq); err != nil {
+		t.Fatal(err)
+	}
+	var voidedID int64
+	if err := store.db.QueryRow(`SELECT id FROM ledger_request_credits WHERE request_id=?`, voidedReq).Scan(&voidedID); err != nil {
+		t.Fatal(err)
+	}
+	w := doForceVoid(t, store, true, voidedID, `{"operator_id":"alice","reason":"x"}`, "application/json")
+	if w.Code != http.StatusOK {
+		t.Fatalf("force-void prep: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	check := func(t *testing.T, query string, wantPayable, wantOpenQ int64) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/admin/ledger/providers"+query, nil)
+		req.Header.Set("Authorization", "Bearer operator")
+		rec := httptest.NewRecorder()
+		store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var resp struct {
+			Providers []struct {
+				ProviderID           string `json:"provider_id"`
+				TotalProviderCredits int64  `json:"total_provider_credits"`
+				QuarantinedCount     int64  `json:"quarantined_count"`
+			} `json:"providers"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+		var got struct {
+			payable, openq int64
+			seen           bool
+		}
+		for _, p := range resp.Providers {
+			if p.ProviderID == "p-rollup" {
+				got.payable = p.TotalProviderCredits
+				got.openq = p.QuarantinedCount
+				got.seen = true
+				break
+			}
+		}
+		if !got.seen {
+			t.Fatalf("provider p-rollup missing from response %s", rec.Body.String())
+		}
+		if got.payable != wantPayable {
+			t.Fatalf("total_provider_credits=%d want %d (payable excludes quarantined+voided)", got.payable, wantPayable)
+		}
+		if got.openq != wantOpenQ {
+			t.Fatalf("quarantined_count=%d want %d (OPEN_PREDICATE only)", got.openq, wantOpenQ)
+		}
+	}
+	t.Run("default", func(t *testing.T) { check(t, "", 100, 1) })
+	t.Run("include_quarantined_true", func(t *testing.T) { check(t, "?include_quarantined=true", 100, 1) })
+}
+
+// R2 (ARCH-H1): if the flag-change audit COMMIT fails, the route-layer
+// flag MUST remain at the prior value. Otherwise a SIGHUP could
+// publish an enable/disable with no durable audit trail.
+func TestSetForceVoidEnabledRollsBackOnAuditFailure(t *testing.T) {
+	store := quarantineFixture(t)
+	// Start at false (constructor default).
+	if store.ForceVoidEnabled() {
+		t.Fatal("precondition: forceVoidEnabled must start false")
+	}
+	// Drop audit_log so the INSERT inside SetForceVoidEnabled fails.
+	if _, err := store.db.Exec(`DROP TABLE audit_log`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetForceVoidEnabled(context.Background(), true, "sighup"); err == nil {
+		t.Fatal("expected error from SetForceVoidEnabled when audit_log is missing")
+	}
+	if store.ForceVoidEnabled() {
+		t.Fatal("forceVoidEnabled flipped to true despite audit failure — race regression")
+	}
+	// Recreate audit_log; the same call now succeeds and publishes.
+	createAuditLogForTest(t, store.db)
+	if err := store.SetForceVoidEnabled(context.Background(), true, "sighup"); err != nil {
+		t.Fatal(err)
+	}
+	if !store.ForceVoidEnabled() {
+		t.Fatal("forceVoidEnabled did not publish after successful audit commit")
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='billing_config_flag_changed'`); got != 1 {
+		t.Fatalf("audit row count=%d want 1 (only the successful flip emits)", got)
+	}
+}

--- a/phase4-coordinator/internal/billing/quarantine_test.go
+++ b/phase4-coordinator/internal/billing/quarantine_test.go
@@ -141,6 +141,29 @@ func TestACQ040_SchemaShape(t *testing.T) {
 	if err == nil {
 		t.Fatal("second INSERT must hit UNIQUE constraint")
 	}
+	// R6 fix (CODE-M2): pin the §4.10 length CHECK constraints on
+	// operator_id and resolution_reason. Empty values and over-cap
+	// values must fail INSERT regardless of the API-layer sanitizer.
+	id2 := insertQuarantinedCredit(t, store, "p-q040b")
+	checkCases := []struct {
+		name, opID, reason string
+	}{
+		{"empty_operator_id", "", "x"},
+		{"empty_resolution_reason", "alice", ""},
+		{"operator_id_65_chars", strings.Repeat("a", 65), "x"},
+		{"resolution_reason_501_chars", "alice", strings.Repeat("r", 501)},
+	}
+	for _, c := range checkCases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc) VALUES (?, 'force_void', ?, ?, ?)`, id2, c.opID, c.reason, now)
+			if err == nil {
+				t.Fatalf("INSERT (%s) must hit length CHECK", c.name)
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), "check") {
+				t.Fatalf("error must mention CHECK, got: %v", err)
+			}
+		})
+	}
 }
 
 // AC-Q042: force-void happy path.
@@ -248,6 +271,10 @@ func TestACQ044_ValidationMatrix(t *testing.T) {
 		// JSON \uXXXX escapes so the JSON parser accepts the
 		// string and the §11.6.3 sanitizer is the one that
 		// rejects (HTTP 422 unsanitized_reason).
+		// R6 fix (CODE-M3): SPEC AC-Q044 names ASCII ESC (U+001B,
+		// C0 control) — added explicit `` case alongside the
+		// pre-existing C1 / bidi / DICP set.
+		{"ascii_esc_in_reason", `{"operator_id":"alice","reason":"hi\u001bx"}`, "application/json", id, http.StatusUnprocessableEntity, "unsanitized_reason"},
 		{"c1_csi_in_reason", `{"operator_id":"alice","reason":"hix"}`, "application/json", id, http.StatusUnprocessableEntity, "unsanitized_reason"},
 		{"bidi_rlo_in_reason", `{"operator_id":"alice","reason":"hi‮x"}`, "application/json", id, http.StatusUnprocessableEntity, "unsanitized_reason"},
 		{"zwsp_in_reason", `{"operator_id":"alice","reason":"hi​x"}`, "application/json", id, http.StatusUnprocessableEntity, "unsanitized_reason"},

--- a/phase4-coordinator/internal/billing/quarantine_test.go
+++ b/phase4-coordinator/internal/billing/quarantine_test.go
@@ -1,0 +1,500 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// SPEC-005 v0.4 (issue #169) — acceptance tests for the quarantine
+// VOID admin surface. ACs Q040, Q042, Q043, Q044, Q045, Q047, Q048,
+// Q051, Q053, Q055 per the v0.4 §18 AC block.
+
+// quarantineFixture builds a billing store and ensures the audit_log
+// table exists in the same SQLite file (production wires
+// audit.Store.OpenStore + billing.NewStore on the same DB file at
+// startup; in tests we only spin billing, so we create audit_log
+// here for the §11.6.4 same-tx INSERT path).
+func quarantineFixture(t *testing.T) *Store {
+	t.Helper()
+	_, store := newRequestAndBillingStores(t)
+	createAuditLogForTest(t, store.db)
+	return store
+}
+
+func createAuditLogForTest(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_utc TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    provider_id TEXT,
+    payload_json TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_audit_log_event_type ON audit_log(event_type);
+`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// insertQuarantinedCredit seeds a ledger_request_credits row with
+// quarantined=1 and returns its id.
+func insertQuarantinedCredit(t *testing.T, store *Store, providerID string) int64 {
+	t.Helper()
+	requestID := providerID + "-q-" + time.Now().UTC().Format("20060102150405.000000000")
+	insertCreditWithRequest(t, store.db, requestID, providerID, time.Now().UTC(), 1000)
+	id := scalar(t, store.db, `SELECT id FROM ledger_request_credits WHERE request_id = ?`, requestID)
+	if _, err := store.db.Exec(`UPDATE ledger_request_credits SET quarantined=1, quarantine_reason=? WHERE id=?`, "test_quarantine", id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func doForceVoid(t *testing.T, store *Store, gateEnabled bool, id int64, body string, ct string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer operator")
+	if ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	w := httptest.NewRecorder()
+	store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, gateEnabled).ServeHTTP(w, req)
+	return w
+}
+
+func itoa(i int64) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := false
+	if i < 0 {
+		neg = true
+		i = -i
+	}
+	var buf [20]byte
+	n := len(buf)
+	for i > 0 {
+		n--
+		buf[n] = byte('0' + (i % 10))
+		i /= 10
+	}
+	if neg {
+		n--
+		buf[n] = '-'
+	}
+	return string(buf[n:])
+}
+
+// AC-Q040: schema shape — UNIQUE(request_credit_id),
+// CHECK(resolution_kind IN ('force_void')), idx_lqr_kind_created
+// present, no separate idx_lqr_request_credit index.
+func TestACQ040_SchemaShape(t *testing.T) {
+	store := quarantineFixture(t)
+	// Columns present?
+	rows, err := store.db.Query(`PRAGMA table_info(ledger_quarantine_resolutions)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	cols := map[string]string{}
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dflt, &pk); err != nil {
+			t.Fatal(err)
+		}
+		cols[name] = typ
+	}
+	want := []string{"id", "request_credit_id", "resolution_kind", "operator_id", "resolution_reason", "created_at_utc"}
+	for _, c := range want {
+		if _, ok := cols[c]; !ok {
+			t.Fatalf("missing column %q", c)
+		}
+	}
+	// UNIQUE auto-index present, idx_lqr_kind_created present.
+	if !indexExists(t, store.db, "ledger_quarantine_resolutions", "idx_lqr_kind_created") {
+		t.Fatal("idx_lqr_kind_created missing")
+	}
+	// No non-unique idx_lqr_request_credit (the UNIQUE auto-index
+	// covers the read path).
+	if indexExists(t, store.db, "ledger_quarantine_resolutions", "idx_lqr_request_credit") {
+		t.Fatal("idx_lqr_request_credit must not exist in v0.4")
+	}
+	// UNIQUE constraint: try INSERT twice with same request_credit_id.
+	id := insertQuarantinedCredit(t, store, "p-q040")
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc) VALUES (?, 'force_void', 'alice', 'reason', ?)`, id, now); err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc) VALUES (?, 'force_void', 'alice', 'reason', ?)`, id, now)
+	if err == nil {
+		t.Fatal("second INSERT must hit UNIQUE constraint")
+	}
+}
+
+// AC-Q042: force-void happy path.
+func TestACQ042_ForceVoidHappyPath(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-q042")
+	w := doForceVoid(t, store, true, id, `{"operator_id":"alice","reason":"Duplicate row confirmed"}`, "application/json")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["resolution_kind"] != "force_void" {
+		t.Fatalf("resolution_kind=%v want force_void", resp["resolution_kind"])
+	}
+	// One resolution row, one audit row.
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions WHERE request_credit_id=?`, id); got != 1 {
+		t.Fatalf("resolution row count=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='ledger_quarantine_force_void'`); got != 1 {
+		t.Fatalf("audit row count=%d want 1", got)
+	}
+	// Base row's quarantined column unchanged.
+	if got := scalar(t, store.db, `SELECT quarantined FROM ledger_request_credits WHERE id=?`, id); got != 1 {
+		t.Fatalf("base row quarantined=%d want 1", got)
+	}
+	// Audit payload has operator_attribution constant + all 10 fields.
+	var payloadJSON string
+	if err := store.db.QueryRow(`SELECT payload_json FROM audit_log WHERE event_type='ledger_quarantine_force_void'`).Scan(&payloadJSON); err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["operator_attribution"] != "operator_key_self_asserted" {
+		t.Fatalf("operator_attribution=%v want operator_key_self_asserted", payload["operator_attribution"])
+	}
+	if payload["severity"] != "WARN" {
+		t.Fatalf("severity=%v want WARN", payload["severity"])
+	}
+}
+
+// AC-Q043: idempotent UNIQUE conflict — second POST returns 409
+// with existing_resolution.
+func TestACQ043_IdempotentConflict(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-q043")
+	w1 := doForceVoid(t, store, true, id, `{"operator_id":"alice","reason":"first"}`, "application/json")
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first POST status=%d body=%s", w1.Code, w1.Body.String())
+	}
+	w2 := doForceVoid(t, store, true, id, `{"operator_id":"bob","reason":"second"}`, "application/json")
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("second POST status=%d body=%s want 409", w2.Code, w2.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w2.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing error envelope: %s", w2.Body.String())
+	}
+	if errObj["code"] != "already_resolved" {
+		t.Fatalf("error.code=%v want already_resolved", errObj["code"])
+	}
+	existing, ok := errObj["existing_resolution"].(map[string]any)
+	if !ok {
+		t.Fatal("missing existing_resolution")
+	}
+	if existing["operator_id"] != "alice" {
+		t.Fatalf("existing.operator_id=%v want alice (the winner)", existing["operator_id"])
+	}
+	// Exactly one resolution row, one audit row.
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions WHERE request_credit_id=?`, id); got != 1 {
+		t.Fatalf("resolution row count=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='ledger_quarantine_force_void'`); got != 1 {
+		t.Fatalf("audit row count=%d want 1", got)
+	}
+}
+
+// AC-Q044: validation matrix.
+func TestACQ044_ValidationMatrix(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-q044")
+	cases := []struct {
+		name     string
+		body     string
+		ct       string
+		path     int64
+		wantCode int
+		wantErr  string
+	}{
+		{"missing_operator_id", `{"reason":"x"}`, "application/json", id, http.StatusUnprocessableEntity, "missing_field"},
+		{"missing_reason", `{"operator_id":"alice"}`, "application/json", id, http.StatusUnprocessableEntity, "missing_field"},
+		{"empty_reason", `{"operator_id":"alice","reason":"   "}`, "application/json", id, http.StatusUnprocessableEntity, "empty_reason"},
+		{"reason_too_long", `{"operator_id":"alice","reason":"` + strings.Repeat("a", 501) + `"}`, "application/json", id, http.StatusUnprocessableEntity, "reason_too_long"},
+		{"bad_ct", `{"operator_id":"alice","reason":"x"}`, "text/plain", id, http.StatusUnsupportedMediaType, "unsupported_media_type"},
+		{"bad_operator_charset", `{"operator_id":"alice bob","reason":"x"}`, "application/json", id, http.StatusUnprocessableEntity, "bad_operator_id"},
+		// Per-codepoint reject cases (§11.6.3). Each body uses
+		// JSON \uXXXX escapes so the JSON parser accepts the
+		// string and the §11.6.3 sanitizer is the one that
+		// rejects (HTTP 422 unsanitized_reason).
+		{"c1_csi_in_reason", `{"operator_id":"alice","reason":"hix"}`, "application/json", id, http.StatusUnprocessableEntity, "unsanitized_reason"},
+		{"bidi_rlo_in_reason", `{"operator_id":"alice","reason":"hi‮x"}`, "application/json", id, http.StatusUnprocessableEntity, "unsanitized_reason"},
+		{"zwsp_in_reason", `{"operator_id":"alice","reason":"hi​x"}`, "application/json", id, http.StatusUnprocessableEntity, "unsanitized_reason"},
+		{"cgj_in_reason", `{"operator_id":"alice","reason":"hi͏x"}`, "application/json", id, http.StatusUnprocessableEntity, "unsanitized_reason"},
+		{"shy_in_reason", `{"operator_id":"alice","reason":"hi­x"}`, "application/json", id, http.StatusUnprocessableEntity, "unsanitized_reason"},
+		{"word_joiner_in_reason", `{"operator_id":"alice","reason":"hi⁠x"}`, "application/json", id, http.StatusUnprocessableEntity, "unsanitized_reason"},
+		{"not_found_id", `{"operator_id":"alice","reason":"x"}`, "application/json", 999999, http.StatusNotFound, "not_found"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := doForceVoid(t, store, true, c.path, c.body, c.ct)
+			if w.Code != c.wantCode {
+				t.Fatalf("status=%d want %d (body=%s)", w.Code, c.wantCode, w.Body.String())
+			}
+			if c.wantErr != "" && !strings.Contains(w.Body.String(), c.wantErr) {
+				t.Fatalf("body=%s does not contain %q", w.Body.String(), c.wantErr)
+			}
+		})
+	}
+	// "not_quarantined": insert a non-quarantined row and POST.
+	requestID := "p-not-q-" + time.Now().UTC().Format("20060102150405.000000000")
+	insertCreditWithRequest(t, store.db, requestID, "p-q044", time.Now().UTC(), 100)
+	nonQuarantinedID := scalar(t, store.db, `SELECT id FROM ledger_request_credits WHERE request_id=?`, requestID)
+	w := doForceVoid(t, store, true, nonQuarantinedID, `{"operator_id":"alice","reason":"x"}`, "application/json")
+	if w.Code != http.StatusUnprocessableEntity || !strings.Contains(w.Body.String(), "not_quarantined") {
+		t.Fatalf("not_quarantined: status=%d body=%s", w.Code, w.Body.String())
+	}
+	// Sanity: no resolution rows / audit rows from rejected calls.
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions`); got != 0 {
+		t.Fatalf("rejected calls leaked %d resolution rows", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log`); got != 0 {
+		t.Fatalf("rejected calls leaked %d audit rows", got)
+	}
+}
+
+// AC-Q045: reader-side narrowing — `total_provider_credits` UNCHANGED
+// (force-void doesn't add to payable set); `quarantined_count`
+// excludes voided rows.
+func TestACQ045_ReaderSideNarrowing(t *testing.T) {
+	store := quarantineFixture(t)
+	now := time.Now().UTC()
+	// (a) quarantined=0 row
+	insertCredit(t, store.db, "p-q045", now, 100)
+	// (b) quarantined=1 row, no resolution
+	insertQuarantinedCredit(t, store, "p-q045-b")
+	// (c) quarantined=1 row + force-void resolution
+	idC := insertQuarantinedCredit(t, store, "p-q045-c")
+	w := doForceVoid(t, store, true, idC, `{"operator_id":"alice","reason":"voided"}`, "application/json")
+	if w.Code != http.StatusOK {
+		t.Fatalf("force-void prep failed: status=%d body=%s", w.Code, w.Body.String())
+	}
+	// Hit summary.
+	req := httptest.NewRequest(http.MethodGet, "/admin/ledger/summary", nil)
+	req.Header.Set("Authorization", "Bearer operator")
+	sw := httptest.NewRecorder()
+	store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true).ServeHTTP(sw, req)
+	if sw.Code != http.StatusOK {
+		t.Fatalf("summary status=%d body=%s", sw.Code, sw.Body.String())
+	}
+	var summary map[string]int64
+	if err := json.Unmarshal(sw.Body.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if got := summary["quarantined_count"]; got != 1 {
+		t.Fatalf("quarantined_count=%d want 1 (only the open row (b))", got)
+	}
+	// total_provider_credits covers ONLY (a) — the payable set is
+	// UNCHANGED from v0.3.3.
+	if got := summary["total_provider_credits"]; got != 100 {
+		t.Fatalf("total_provider_credits=%d want 100 (force-void does NOT add to payable set)", got)
+	}
+}
+
+// AC-Q047: same-transaction audit atomicity — drop audit_log before
+// the INSERT, assert resolution INSERT also rolls back.
+func TestACQ047_SameTransactionAtomicity(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-q047")
+	// Drop audit_log to force the second INSERT to fail.
+	if _, err := store.db.Exec(`DROP TABLE audit_log`); err != nil {
+		t.Fatal(err)
+	}
+	w := doForceVoid(t, store, true, id, `{"operator_id":"alice","reason":"x"}`, "application/json")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d want 500 (audit-INSERT must fail)", w.Code)
+	}
+	// Resolution row must NOT exist (transaction rolled back).
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions WHERE request_credit_id=?`, id); got != 0 {
+		t.Fatalf("resolution row leaked: count=%d want 0", got)
+	}
+	// Re-create audit_log; a retry of the same POST should now
+	// succeed (no UNIQUE conflict because the first attempt rolled
+	// back fully).
+	createAuditLogForTest(t, store.db)
+	w2 := doForceVoid(t, store, true, id, `{"operator_id":"alice","reason":"x"}`, "application/json")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("retry status=%d body=%s want 200", w2.Code, w2.Body.String())
+	}
+}
+
+// AC-Q048: method enforcement — non-POST returns 405.
+func TestACQ048_MethodEnforcement(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-q048")
+	for _, m := range []string{http.MethodGet, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		req := httptest.NewRequest(m, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", nil)
+		req.Header.Set("Authorization", "Bearer operator")
+		w := httptest.NewRecorder()
+		store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true).ServeHTTP(w, req)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("method=%s status=%d want 405", m, w.Code)
+		}
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions`); got != 0 {
+		t.Fatalf("405 cases leaked %d resolution rows", got)
+	}
+}
+
+// AC-Q051: reconcile rows_force_resolved_in_range.
+func TestACQ051_ReconcileForceResolvedField(t *testing.T) {
+	store := quarantineFixture(t)
+	// request_log already created by requestlog.OpenStore in the
+	// fixture; do not double-create.
+	// Seed 5 quarantined rows, force-void 3 of them.
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		id := insertQuarantinedCredit(t, store, "p-q051")
+		if i < 3 {
+			w := doForceVoid(t, store, true, id, `{"operator_id":"alice","reason":"v"}`, "application/json")
+			if w.Code != http.StatusOK {
+				t.Fatalf("force-void %d status=%d body=%s", i, w.Code, w.Body.String())
+			}
+		}
+	}
+	from := now.Add(-1 * time.Hour).Format("2006-01-02")
+	to := now.Add(24 * time.Hour).Format("2006-01-02")
+	req := httptest.NewRequest(http.MethodGet, "/admin/ledger/reconcile?from="+from+"&to="+to, nil)
+	req.Header.Set("Authorization", "Bearer operator")
+	w := httptest.NewRecorder()
+	store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reconcile status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := resp["rows_force_resolved_in_range"]; !ok {
+		t.Fatal("rows_force_resolved_in_range missing from reconcile response")
+	} else if int64(got.(float64)) != 3 {
+		t.Fatalf("rows_force_resolved_in_range=%v want 3", got)
+	}
+	if got, ok := resp["rows_quarantined"]; !ok {
+		t.Fatal("rows_quarantined missing")
+	} else if int64(got.(float64)) != 2 {
+		t.Fatalf("rows_quarantined=%v want 2 (open quarantines only — voided rows are resolved-and-excluded)", got)
+	}
+}
+
+// AC-Q053: route-layer config flag gate.
+func TestACQ053_RouteLayerConfigFlagGate(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-q053")
+	// Flag disabled (default) → 404
+	w := doForceVoid(t, store, false, id, `{"operator_id":"alice","reason":"x"}`, "application/json")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("disabled status=%d want 404", w.Code)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions`); got != 0 {
+		t.Fatalf("disabled flag leaked %d rows", got)
+	}
+	// Flag enabled → 200
+	w2 := doForceVoid(t, store, true, id, `{"operator_id":"alice","reason":"x"}`, "application/json")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("enabled status=%d body=%s want 200", w2.Code, w2.Body.String())
+	}
+	// 404 for disabled-flag case is byte-identical to row-not-found
+	// — assert by comparing bodies.
+	wNotFound := doForceVoid(t, store, true, 99999999, `{"operator_id":"alice","reason":"x"}`, "application/json")
+	if wNotFound.Code != http.StatusNotFound {
+		t.Fatalf("row-not-found status=%d want 404", wNotFound.Code)
+	}
+	// Both 404 bodies use the same {"error":{"code":"not_found",...}} envelope.
+	if !strings.Contains(w.Body.String(), `"code":"not_found"`) {
+		t.Fatalf("disabled-flag 404 missing not_found code: %s", w.Body.String())
+	}
+	if !strings.Contains(wNotFound.Body.String(), `"code":"not_found"`) {
+		t.Fatalf("row-not-found 404 missing not_found code: %s", wNotFound.Body.String())
+	}
+}
+
+// AC-Q055: v0.4 force-credit schema rejection — direct INSERT with
+// resolution_kind='force_credit' must fail the CHECK constraint.
+func TestACQ055_ForceCreditSchemaRejection(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-q055")
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc) VALUES (?, 'force_credit', 'alice', 'x', ?)`, id, now)
+	if err == nil {
+		t.Fatal("INSERT with resolution_kind=force_credit must hit CHECK constraint in v0.4")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "check") {
+		t.Fatalf("error must mention CHECK constraint, got: %v", err)
+	}
+}
+
+// Verify the v0.4 §11.6.6 — failed validation responses STILL count
+// against the operator-key rate-limit bucket (no bypass). v0.4 IMPL
+// inherits the existing /admin/* bucket; this test asserts the route
+// hits the bucket by checking that the response is the §11 envelope
+// (not a different code-path shortcut).
+func TestRateLimitBucketSharedForFailures(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-rate")
+	// Invalid body → 422. Response uses the §11 error envelope.
+	w := doForceVoid(t, store, true, id, `{"operator_id":"   ","reason":"x"}`, "application/json")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d want 422", w.Code)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resp["error"]; !ok {
+		t.Fatalf("422 response missing standard error envelope: %s", w.Body.String())
+	}
+}
+
+// Sanity: forceVoid does not deadlock under the MaxOpenConns(1)
+// constraint shared by requestlog + billing on the same SQLite file
+// (issue #21 / ARCH-3 nested-query history). The §11.6.4 same-tx
+// path opens BeginTx → INSERT lqr → INSERT audit_log → Commit, all
+// on ONE connection by design.
+func TestForceVoidNoNestedQueryDeadlock(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-deadlock")
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	done := make(chan bool, 1)
+	go func() {
+		w := doForceVoid(t, store, true, id, `{"operator_id":"alice","reason":"x"}`, "application/json")
+		done <- (w.Code == http.StatusOK)
+	}()
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("force-void POST failed")
+		}
+	case <-ctx.Done():
+		t.Fatal("force-void POST timed out (suspected deadlock)")
+	}
+}

--- a/phase4-coordinator/internal/billing/quarantine_test.go
+++ b/phase4-coordinator/internal/billing/quarantine_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -496,5 +499,195 @@ func TestForceVoidNoNestedQueryDeadlock(t *testing.T) {
 		}
 	case <-ctx.Done():
 		t.Fatal("force-void POST timed out (suspected deadlock)")
+	}
+}
+
+// AC-Q049: concurrent POSTs against the same id — exactly one 200
+// + (N-1) × 409; one resolution row; one audit row.
+// N is intentionally < adminBucketCapacity so this AC tests the
+// UNIQUE-constraint race, not the rate-limit bucket (which is
+// tested separately).
+func TestACQ049_ConcurrentUNIQUEConflict(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-q049")
+	handler := store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true)
+	const N = 32
+	var wg sync.WaitGroup
+	var ok200 int64
+	var ok409 int64
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			body := fmt.Sprintf(`{"operator_id":"alice","reason":"r%d"}`, i)
+			req := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", strings.NewReader(body))
+			req.Header.Set("Authorization", "Bearer operator")
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			switch w.Code {
+			case http.StatusOK:
+				atomic.AddInt64(&ok200, 1)
+			case http.StatusConflict:
+				atomic.AddInt64(&ok409, 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if ok200 != 1 {
+		t.Fatalf("200 count=%d want 1", ok200)
+	}
+	if ok409 != N-1 {
+		t.Fatalf("409 count=%d want %d", ok409, N-1)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions`); got != 1 {
+		t.Fatalf("resolution rows=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='ledger_quarantine_force_void'`); got != 1 {
+		t.Fatalf("audit rows=%d want 1", got)
+	}
+}
+
+// AC-Q053 deeper: SIGHUP-driven reload via Store.SetForceVoidEnabled
+// emits the billing_config_flag_changed audit event on actual flips
+// AND the endpoint sees the new flag value on the next request
+// (no http.Handler re-wire needed).
+func TestACQ053_ReloadEmitsFlagChangedAuditAndFlipTakesEffect(t *testing.T) {
+	store := quarantineFixture(t)
+	handler := store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, false)
+	id := insertQuarantinedCredit(t, store, "p-q053b")
+	// flag false → 404
+	req := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", strings.NewReader(`{"operator_id":"alice","reason":"x"}`))
+	req.Header.Set("Authorization", "Bearer operator")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("pre-flip status=%d want 404", w.Code)
+	}
+	// SIGHUP-style flip: false → true. Expect a
+	// billing_config_flag_changed audit row.
+	if err := store.SetForceVoidEnabled(context.Background(), true, "sighup"); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='billing_config_flag_changed'`); got != 1 {
+		t.Fatalf("flag-change audit rows=%d want 1", got)
+	}
+	// Same handler — flag flip MUST take effect immediately, no
+	// http.Handler re-wire. POST now should produce 200.
+	req2 := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", strings.NewReader(`{"operator_id":"alice","reason":"x"}`))
+	req2.Header.Set("Authorization", "Bearer operator")
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("post-flip status=%d body=%s want 200", w2.Code, w2.Body.String())
+	}
+	// Reload-no-change: same value → NO new flag-change audit row.
+	if err := store.SetForceVoidEnabled(context.Background(), true, "sighup"); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='billing_config_flag_changed'`); got != 1 {
+		t.Fatalf("reload-no-change emitted spurious audit row: got %d total", got)
+	}
+}
+
+// AC-Q050: SPEC-007 explorer detail surface — LEFT JOIN to
+// ledger_quarantine_resolutions exposes resolution_kind /
+// resolution_operator_id / resolution_reason / resolution_at_utc as
+// aliased columns on the ledger row when a resolution exists.
+func TestACQ050_ExplorerAliasColumns(t *testing.T) {
+	store := quarantineFixture(t)
+	id := insertQuarantinedCredit(t, store, "p-q050")
+	// Force-void via the handler to land both the resolution + audit.
+	w := doForceVoid(t, store, true, id, `{"operator_id":"alice","reason":"audited"}`, "application/json")
+	if w.Code != http.StatusOK {
+		t.Fatalf("prep force-void status=%d body=%s", w.Code, w.Body.String())
+	}
+	// Read the request_id we used to seed the row.
+	var requestID string
+	if err := store.db.QueryRow(`SELECT request_id FROM ledger_request_credits WHERE id = ?`, id).Scan(&requestID); err != nil {
+		t.Fatal(err)
+	}
+	// Mirror the explorer query against the same DB.
+	row := store.db.QueryRow(`
+SELECT lqr.resolution_kind, lqr.operator_id, lqr.resolution_reason, lqr.created_at_utc
+  FROM ledger_request_credits lrc
+  LEFT JOIN ledger_quarantine_resolutions lqr ON lqr.request_credit_id = lrc.id
+ WHERE lrc.request_id = ?`, requestID)
+	var kind, opID, reason, createdAt sql.NullString
+	if err := row.Scan(&kind, &opID, &reason, &createdAt); err != nil {
+		t.Fatal(err)
+	}
+	if !kind.Valid || kind.String != "force_void" {
+		t.Fatalf("resolution_kind=%v want force_void", kind)
+	}
+	if !opID.Valid || opID.String != "alice" {
+		t.Fatalf("resolution_operator_id=%v want alice", opID)
+	}
+	if !reason.Valid || reason.String != "audited" {
+		t.Fatalf("resolution_reason=%v want audited", reason)
+	}
+	if !createdAt.Valid || createdAt.String == "" {
+		t.Fatal("resolution_at_utc unset")
+	}
+}
+
+// Admin rate-limit bucket — every response code path (200, 404,
+// 422) consumes one token. With a 60-token capacity and 60/sec
+// refill, a burst of 600 requests in a tight loop MUST produce a
+// significant number of 429s (the bucket cannot refill faster than
+// it drains under burst).
+func TestAdminRateLimitBucketConsumesFailures(t *testing.T) {
+	store := quarantineFixture(t)
+	handler := store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true)
+	const burst = 600
+	var ok429 int64
+	for i := 0; i < burst; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/admin/ledger/summary", nil)
+		req.Header.Set("Authorization", "Bearer operator")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			ok429++
+		}
+	}
+	// With capacity 60 and a tight burst, expect at least 100 of the
+	// 600 calls to be rate-limited (defensive lower-bound — burst
+	// drain dominates timing-jitter refills).
+	if ok429 < 100 {
+		t.Fatalf("rate-limit fired only %d times in burst of %d — limiter is not consuming tokens", ok429, burst)
+	}
+}
+
+// Force-void path also charges the admin bucket.
+func TestForceVoidChargesAdminBucket(t *testing.T) {
+	store := quarantineFixture(t)
+	handler := store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true)
+	// Drain the bucket via cheap GETs.
+	for i := 0; i < adminBucketCapacity+1; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/admin/ledger/summary", nil)
+		req.Header.Set("Authorization", "Bearer operator")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+	// Send 50 quick force-void POSTs (no row exists for any of
+	// them, so they'd otherwise be 404 / 422). The drained bucket
+	// should produce a 429 in at least some of them.
+	id := insertQuarantinedCredit(t, store, "p-q-rate-fv")
+	var ok429 int64
+	for i := 0; i < 50; i++ {
+		body := fmt.Sprintf(`{"operator_id":"alice","reason":"r%d"}`, i)
+		req := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/"+itoa(id)+"/force-void", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer operator")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			ok429++
+		}
+	}
+	if ok429 == 0 {
+		t.Fatalf("force-void POSTs should consume the same bucket; got 0 × 429 after draining via /summary")
 	}
 }

--- a/phase4-coordinator/internal/billing/snapshot.go
+++ b/phase4-coordinator/internal/billing/snapshot.go
@@ -48,6 +48,122 @@ INSERT INTO ledger_config_snapshots (
 	return res.LastInsertId()
 }
 
+// ReloadBillingConfig writes the config-snapshot row and (if the
+// route-layer flag is actually changing) the
+// `billing_config_flag_changed` audit row in ONE `BEGIN IMMEDIATE`
+// transaction, then publishes the in-memory force-void flag only
+// after COMMIT.
+//
+// R3 fix (ARCH-H1): the prior reload sequence wrote
+// `ledger_config_snapshots` first, applied the in-memory rewards /
+// settlement configs second, and emitted the flag-change audit row
+// last. If the flag-change audit INSERT failed, the snapshot row
+// and the in-memory configs were already published — a partially
+// applied reload with no audit trail for the flag flip.
+//
+// This method atomically commits the snapshot row and the optional
+// flag-change audit row, and only THEN (after COMMIT) publishes the
+// new force-void value via `forceVoidEnabled.Store`. If COMMIT
+// fails the in-memory flag remains at the prior value. The caller
+// continues to publish the rewards/settlement in-memory state via
+// the returned snapshot id.
+//
+// reloadSource MUST be "sighup" or "http_reload"; "startup" callers
+// continue to use InsertConfigSnapshot (which never writes a flag
+// audit) and HandlersWithQuarantineGate (which uses
+// SetForceVoidEnabled with reloadSource="startup").
+func (s *Store) ReloadBillingConfig(ctx context.Context, cfg RewardsConfig, forceVoidEnabled bool, reloadSource string, now time.Time) (int64, error) {
+	if reloadSource != "sighup" && reloadSource != "http_reload" {
+		return 0, errors.New("ReloadBillingConfig: reloadSource must be sighup or http_reload")
+	}
+	s.forceVoidReloadMu.Lock()
+	defer s.forceVoidReloadMu.Unlock()
+
+	canon := canonicalConfig{
+		ProviderShareBps:    ParseShareBps(cfg.ProviderShare),
+		GlobalMultiplierPPM: ParseMultiplierPPM(cfg.GlobalMultiplier),
+		RateCard:            cfg.RateCard,
+	}
+	rateJSON, err := json.Marshal(canon.RateCard)
+	if err != nil {
+		return 0, err
+	}
+	fullJSON, err := json.Marshal(canon)
+	if err != nil {
+		return 0, err
+	}
+	sum := sha256.Sum256(fullJSON)
+	hash := hex.EncodeToString(sum[:])
+	ts := now.UTC().Format(time.RFC3339Nano)
+
+	oldFlag := s.forceVoidEnabled.Load()
+	flagChanged := oldFlag != forceVoidEnabled
+
+	var flagPayloadJSON []byte
+	if flagChanged {
+		flagPayload := map[string]any{
+			"flag":          "quarantine_resolution_force_void_enabled",
+			"old_value":     oldFlag,
+			"new_value":     forceVoidEnabled,
+			"reload_source": reloadSource,
+			"ts_utc":        ts,
+		}
+		flagPayloadJSON, err = json.Marshal(flagPayload)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return 0, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+
+	res, err := conn.ExecContext(ctx, `
+INSERT INTO ledger_config_snapshots (
+    effective_at_utc, config_hash, provider_share_bps, global_multiplier_ppm,
+    rate_card_json, created_at_utc
+) VALUES (?, ?, ?, ?, ?, ?)`,
+		ts, hash, canon.ProviderShareBps, canon.GlobalMultiplierPPM, string(rateJSON), ts,
+	)
+	if err != nil {
+		return 0, err
+	}
+	snapshotID, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	if flagChanged {
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
+VALUES (?, 'billing_config_flag_changed', NULL, ?)`, ts, string(flagPayloadJSON)); err != nil {
+			return 0, err
+		}
+	}
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return 0, err
+	}
+	committed = true
+	// Only after the snapshot row and (optional) flag-change audit
+	// row are durably committed do we publish the in-memory force-
+	// void flag. Handlers cannot observe the new value before the
+	// COMMIT lands.
+	if flagChanged {
+		s.forceVoidEnabled.Store(forceVoidEnabled)
+	}
+	return snapshotID, nil
+}
+
 func (s *Store) LatestConfigSnapshotAt(ctx context.Context, t time.Time) (int64, error) {
 	var id int64
 	err := s.db.QueryRowContext(ctx, `

--- a/phase4-coordinator/internal/billing/snapshot.go
+++ b/phase4-coordinator/internal/billing/snapshot.go
@@ -16,13 +16,20 @@ type canonicalConfig struct {
 	ProviderShareBps    int64                    `json:"provider_share_bps"`
 	GlobalMultiplierPPM int64                    `json:"global_multiplier_ppm"`
 	RateCard            map[string]RateCardEntry `json:"rate_card"`
+	// R4 fix (CODE-M2): SPEC-005 v0.4 §11.6.4 / §13.2 require the
+	// startup `ledger_config_snapshots` row to capture the initial
+	// `quarantine_resolution_force_void_enabled` value. Including
+	// the boolean in the canonical hash makes the snapshot a
+	// forensic record of the flag state at that reload.
+	QuarantineResolutionForceVoidEnabled bool `json:"quarantine_resolution_force_void_enabled"`
 }
 
 func (s *Store) InsertConfigSnapshot(ctx context.Context, cfg RewardsConfig, now time.Time) (int64, error) {
 	canon := canonicalConfig{
-		ProviderShareBps:    ParseShareBps(cfg.ProviderShare),
-		GlobalMultiplierPPM: ParseMultiplierPPM(cfg.GlobalMultiplier),
-		RateCard:            cfg.RateCard,
+		ProviderShareBps:                     ParseShareBps(cfg.ProviderShare),
+		GlobalMultiplierPPM:                  ParseMultiplierPPM(cfg.GlobalMultiplier),
+		RateCard:                             cfg.RateCard,
+		QuarantineResolutionForceVoidEnabled: s.forceVoidEnabled.Load(),
 	}
 	rateJSON, err := json.Marshal(canon.RateCard)
 	if err != nil {
@@ -79,10 +86,14 @@ func (s *Store) ReloadBillingConfig(ctx context.Context, cfg RewardsConfig, forc
 	s.forceVoidReloadMu.Lock()
 	defer s.forceVoidReloadMu.Unlock()
 
+	// R4 fix (CODE-M2): snapshot captures the POST-reload force-void
+	// value so the ledger_config_snapshots row reflects what the
+	// next handler-request observes (not the pre-reload value).
 	canon := canonicalConfig{
-		ProviderShareBps:    ParseShareBps(cfg.ProviderShare),
-		GlobalMultiplierPPM: ParseMultiplierPPM(cfg.GlobalMultiplier),
-		RateCard:            cfg.RateCard,
+		ProviderShareBps:                     ParseShareBps(cfg.ProviderShare),
+		GlobalMultiplierPPM:                  ParseMultiplierPPM(cfg.GlobalMultiplier),
+		RateCard:                             cfg.RateCard,
+		QuarantineResolutionForceVoidEnabled: forceVoidEnabled,
 	}
 	rateJSON, err := json.Marshal(canon.RateCard)
 	if err != nil {

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -384,6 +384,15 @@ func (s *Store) ForceVoidEnabled() bool {
 // "startup" callers MUST pass a zero-value old (we infer first-time
 // init from changed == false on the swap).
 func (s *Store) SetForceVoidEnabled(ctx context.Context, newValue bool, reloadSource string) error {
+	// R6 fix (CODE-M1): reloadSource enum is documented as restricted
+	// to "startup" | "sighup" | "http_reload". Validate before doing
+	// any state mutation or DB write — otherwise a typo in a caller
+	// silently writes a malformed audit row.
+	switch reloadSource {
+	case "startup", "sighup", "http_reload":
+	default:
+		return fmt.Errorf("SetForceVoidEnabled: invalid reloadSource %q (want startup|sighup|http_reload)", reloadSource)
+	}
 	// Serialize so that the (audit insert, publish) pair is atomic:
 	// no other reloader can change the value between our Load() and
 	// Store(), and no handler can observe a value whose audit row has

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -3,9 +3,12 @@ package billing
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	_ "modernc.org/sqlite"
@@ -19,6 +22,12 @@ type Store struct {
 	db           *sql.DB
 	settlementMu sync.RWMutex
 	settlement   SettlementConfig
+	// SPEC-005 v0.4 §13.2 — billing.quarantine_resolution_force_void_enabled
+	// route-layer flag. Held as atomic.Bool so the handler reads it on
+	// every request (no re-wire of the HTTP handler on reload).
+	// SetForceVoidEnabled is the only writer and emits the
+	// billing_config_flag_changed audit event on actual flips.
+	forceVoidEnabled atomic.Bool
 }
 
 func NewStore(db *sql.DB) (*Store, error) {
@@ -351,4 +360,66 @@ func nullInt64(v *int64) sql.NullInt64 {
 		return sql.NullInt64{}
 	}
 	return sql.NullInt64{Int64: *v, Valid: true}
+}
+
+// ForceVoidEnabled returns the current value of the SPEC-005 v0.4
+// route-layer flag. Reads are atomic; safe under concurrent flips
+// from SIGHUP-driven config reload.
+func (s *Store) ForceVoidEnabled() bool {
+	return s.forceVoidEnabled.Load()
+}
+
+// SetForceVoidEnabled atomically updates the route-layer flag and,
+// on actual flips (old != new), emits the SPEC-005 v0.4 §11.6.4
+// `billing_config_flag_changed` audit-log row inside the billing
+// store's `audit_log` table via a dedicated BEGIN IMMEDIATE tx. No
+// audit row is written when the value is unchanged (SPEC §13.2
+// "reload-no-change" rule).
+//
+// reloadSource MUST be one of "startup" | "sighup" | "http_reload".
+// "startup" callers MUST pass a zero-value old (we infer first-time
+// init from changed == false on the swap).
+func (s *Store) SetForceVoidEnabled(ctx context.Context, newValue bool, reloadSource string) error {
+	oldValue := s.forceVoidEnabled.Swap(newValue)
+	if oldValue == newValue {
+		return nil
+	}
+	// Startup writes do NOT emit an audit row per SPEC §11.6.4:
+	// "v0.4 does NOT emit at startup, because 'no prior acknowledged
+	// value' has no defined `old_value` and the startup
+	// `ledger_config_snapshots` row already captures the initial
+	// state."
+	if reloadSource == "startup" {
+		return nil
+	}
+	payload := map[string]any{
+		"flag":          "quarantine_resolution_force_void_enabled",
+		"old_value":     oldValue,
+		"new_value":     newValue,
+		"reload_source": reloadSource,
+		"ts_utc":        time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal flag-change payload: %w", err)
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire conn for flag-change audit: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return fmt.Errorf("begin immediate for flag-change audit: %w", err)
+	}
+	now := payload["ts_utc"].(string)
+	if _, err := conn.ExecContext(ctx, `
+INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
+VALUES (?, 'billing_config_flag_changed', NULL, ?)`, now, string(payloadJSON)); err != nil {
+		_, _ = conn.ExecContext(ctx, `ROLLBACK`)
+		return fmt.Errorf("insert flag-change audit: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return fmt.Errorf("commit flag-change audit: %w", err)
+	}
+	return nil
 }

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -169,6 +169,25 @@ CREATE TABLE IF NOT EXISTS ledger_provider_identity_snapshots (
 );
 CREATE INDEX IF NOT EXISTS idx_lpis_request ON ledger_provider_identity_snapshots(request_id, attempt_n);
 CREATE INDEX IF NOT EXISTS idx_lpis_provider ON ledger_provider_identity_snapshots(provider_id, created_at_utc);
+
+-- SPEC-005 v0.4 (issue #169) — MIG-005-010
+-- ledger_quarantine_resolutions records the operator-issued force-void
+-- decision for a quarantined ledger_request_credits row. v0.4 ships
+-- force-void only; CHECK widens in v0.5 to include 'force_credit' once
+-- the pre-payout hold primitive lands.
+-- UNIQUE(request_credit_id) makes the resolution terminal; the implicit
+-- sqlite_autoindex covers the LEFT JOIN read path (no separate
+-- non-unique index is added).
+CREATE TABLE IF NOT EXISTS ledger_quarantine_resolutions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_credit_id INTEGER NOT NULL REFERENCES ledger_request_credits(id),
+    resolution_kind TEXT NOT NULL CHECK(resolution_kind IN ('force_void')),
+    operator_id TEXT NOT NULL CHECK(length(operator_id) BETWEEN 1 AND 64),
+    resolution_reason TEXT NOT NULL CHECK(length(resolution_reason) BETWEEN 1 AND 500),
+    created_at_utc TEXT NOT NULL,
+    UNIQUE(request_credit_id)
+);
+CREATE INDEX IF NOT EXISTS idx_lqr_kind_created ON ledger_quarantine_resolutions(resolution_kind, created_at_utc);
 `); err != nil {
 		return err
 	}

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -27,7 +27,11 @@ type Store struct {
 	// every request (no re-wire of the HTTP handler on reload).
 	// SetForceVoidEnabled is the only writer and emits the
 	// billing_config_flag_changed audit event on actual flips.
-	forceVoidEnabled atomic.Bool
+	// forceVoidReloadMu serializes writes so that the (audit, publish)
+	// pair is atomic and the published value is durable in audit_log
+	// before any handler can observe it (R2 fix for flag-flip race).
+	forceVoidReloadMu sync.Mutex
+	forceVoidEnabled  atomic.Bool
 }
 
 func NewStore(db *sql.DB) (*Store, error) {
@@ -380,7 +384,14 @@ func (s *Store) ForceVoidEnabled() bool {
 // "startup" callers MUST pass a zero-value old (we infer first-time
 // init from changed == false on the swap).
 func (s *Store) SetForceVoidEnabled(ctx context.Context, newValue bool, reloadSource string) error {
-	oldValue := s.forceVoidEnabled.Swap(newValue)
+	// Serialize so that the (audit insert, publish) pair is atomic:
+	// no other reloader can change the value between our Load() and
+	// Store(), and no handler can observe a value whose audit row has
+	// not been committed yet (R2: ARCH-H1 / SEC-M2 / CODE-H4 fix).
+	s.forceVoidReloadMu.Lock()
+	defer s.forceVoidReloadMu.Unlock()
+
+	oldValue := s.forceVoidEnabled.Load()
 	if oldValue == newValue {
 		return nil
 	}
@@ -390,6 +401,7 @@ func (s *Store) SetForceVoidEnabled(ctx context.Context, newValue bool, reloadSo
 	// `ledger_config_snapshots` row already captures the initial
 	// state."
 	if reloadSource == "startup" {
+		s.forceVoidEnabled.Store(newValue)
 		return nil
 	}
 	payload := map[string]any{
@@ -419,7 +431,14 @@ VALUES (?, 'billing_config_flag_changed', NULL, ?)`, now, string(payloadJSON)); 
 		return fmt.Errorf("insert flag-change audit: %w", err)
 	}
 	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		// Audit row may or may not be durable; assume not. Leave the
+		// route flag unchanged and surface the error so the operator
+		// can re-attempt.
 		return fmt.Errorf("commit flag-change audit: %w", err)
 	}
+	// Audit is durable: publish the new value. No handler could
+	// observe newValue before this point because the only reader is
+	// h.store.ForceVoidEnabled() which reads s.forceVoidEnabled.
+	s.forceVoidEnabled.Store(newValue)
 	return nil
 }

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Logging                      LoggingConfig                `yaml:"logging"`
 	Rewards                      RewardsConfig                `yaml:"rewards"`
 	Settlement                   SettlementConfig             `yaml:"settlement"`
+	Billing                      BillingConfig                `yaml:"billing"`
 	Endpoints                    EndpointsConfig              `yaml:"endpoints"`
 	Explorer                     ExplorerConfig               `yaml:"explorer"`
 	Stats                        StatsConfig                  `yaml:"stats"`
@@ -391,6 +392,20 @@ type SettlementConfig struct {
 	NightlyReconcileWindowDays  int   `yaml:"nightly_reconcile_window_days"`
 	RecoveryGraceSeconds        int   `yaml:"recovery_grace_seconds"`
 	JobEnabled                  bool  `yaml:"job_enabled"`
+}
+
+// BillingConfig is the SPEC-005 v0.4 (issue #169) billing-side
+// operator-toggleable surface. v0.4 ships one flag gating the
+// quarantine-VOID admin endpoint at the route layer; v0.5 will
+// add a force-credit flag alongside the pre-payout hold.
+type BillingConfig struct {
+	// QuarantineResolutionForceVoidEnabled gates POST
+	// /admin/ledger/quarantine/{id}/force-void (SPEC-005 v0.4
+	// §11.6.1). Default false — the endpoint returns HTTP 404
+	// `not_found` (route-layer gate per §11.5 launch-gate item
+	// 10) until the operator explicitly flips this to true via
+	// the existing config-reload primitive.
+	QuarantineResolutionForceVoidEnabled bool `yaml:"quarantine_resolution_force_void_enabled"`
 }
 
 type EndpointsConfig struct {

--- a/phase4-coordinator/internal/explorer/store.go
+++ b/phase4-coordinator/internal/explorer/store.go
@@ -250,11 +250,17 @@ func (Store) Overview(ctx context.Context, q ReadDB, from, to time.Time) (map[st
 	if err != nil {
 		return nil, err
 	}
+	// R3 fix (SEC-M2): payable totals (current_window_provider_credits,
+	// total_gross_credits, total_provider_credits) must mirror the
+	// SPEC-005 v0.4 §11 payable predicate (lrc.quarantined=0). Without
+	// this filter, quarantined and force-voided rows inflate the
+	// explorer overview totals, which then disagree with the
+	// /admin/ledger/summary numbers operators read.
 	ledgerRows, err := queryMaps(ctx, q, `
-		SELECT COALESCE(SUM(CASE WHEN lrc.ts_utc >= ? AND lrc.ts_utc < ? THEN lrc.provider_credits ELSE 0 END), 0) AS current_window_provider_credits,
-		       COALESCE(SUM(lrc.gross_credits), 0) AS total_gross_credits,
-		       COALESCE(SUM(lrc.provider_credits), 0) AS total_provider_credits,
-		       COALESCE(SUM(loc.operator_credits), 0) AS total_operator_credits,
+		SELECT COALESCE(SUM(CASE WHEN lrc.quarantined=0 AND lrc.ts_utc >= ? AND lrc.ts_utc < ? THEN lrc.provider_credits ELSE 0 END), 0) AS current_window_provider_credits,
+		       COALESCE(SUM(CASE WHEN lrc.quarantined=0 THEN lrc.gross_credits ELSE 0 END), 0) AS total_gross_credits,
+		       COALESCE(SUM(CASE WHEN lrc.quarantined=0 THEN lrc.provider_credits ELSE 0 END), 0) AS total_provider_credits,
+		       COALESCE(SUM(CASE WHEN lrc.quarantined=0 THEN loc.operator_credits ELSE 0 END), 0) AS total_operator_credits,
 		       COALESCE((SELECT COUNT(*) FROM ledger_payout_ready WHERE status = 'ready'), 0) AS pending_payout_count,
 		       COALESCE((SELECT SUM(provider_credits) FROM ledger_payout_ready WHERE status = 'ready'), 0) AS pending_payout_credits,
 		       -- SPEC-005 v0.4 §11.6.5 OPEN_PREDICATE: surface only

--- a/phase4-coordinator/internal/explorer/store.go
+++ b/phase4-coordinator/internal/explorer/store.go
@@ -69,15 +69,26 @@ func (Store) SessionDetail(ctx context.Context, q ReadDB, requestID string) (map
 	if err != nil {
 		return nil, err
 	}
+	// SPEC-005 v0.4 §11.6.5 — LEFT JOIN ledger_quarantine_resolutions
+	// and surface resolution_kind / resolution_operator_id /
+	// resolution_reason / resolution_at_utc as the contract aliases
+	// the explorer client reads. Force-voided rows have
+	// `lrc.quarantined=1` AND a matching resolution row; the alias
+	// columns are non-null only when a resolution exists.
 	ledger, err := queryMaps(ctx, q, `
 		SELECT lrc.id, lrc.request_id, lrc.attempt_n, lrc.provider_id, lrc.provider_assigned_id,
 		       lrc.ts_utc, lrc.model, lrc.status, lrc.stream, lrc.prompt_tokens,
 		       lrc.completion_tokens, lrc.estimated_completion_tokens, lrc.usage_source,
 		       lrc.gross_credits, lrc.provider_credits, loc.operator_credits,
 		       lrc.fault_flag, lrc.settled, lrc.settlement_id, lrc.quarantined,
-		       lrc.quarantine_reason, lrc.recovery_source
+		       lrc.quarantine_reason, lrc.recovery_source,
+		       lqr.resolution_kind   AS resolution_kind,
+		       lqr.operator_id       AS resolution_operator_id,
+		       lqr.resolution_reason AS resolution_reason,
+		       lqr.created_at_utc    AS resolution_at_utc
 		FROM ledger_request_credits lrc
 		LEFT JOIN ledger_operator_credits loc ON loc.request_credit_id = lrc.id
+		LEFT JOIN ledger_quarantine_resolutions lqr ON lqr.request_credit_id = lrc.id
 		WHERE lrc.request_id = ?
 		ORDER BY lrc.attempt_n ASC, lrc.id ASC`, requestID)
 	if err != nil {
@@ -148,15 +159,22 @@ func (Store) ProviderDetail(ctx context.Context, q ReadDB, p pool.Provider) (map
 }
 
 func (Store) Ledger(ctx context.Context, q ReadDB, from, to time.Time, limit int) ([]map[string]any, error) {
+	// SPEC-005 v0.4 §11.6.5 — LEFT JOIN ledger_quarantine_resolutions
+	// surfaces the resolution alias columns on the ledger list view.
 	return queryMaps(ctx, q, `
 		SELECT lrc.id, lrc.request_id, lrc.attempt_n, lrc.provider_id, lrc.provider_assigned_id,
 		       lrc.ts_utc, lrc.model, lrc.status, lrc.stream, lrc.prompt_tokens,
 		       lrc.completion_tokens, lrc.estimated_completion_tokens, lrc.usage_source,
 		       lrc.gross_credits, lrc.provider_credits, loc.operator_credits,
 		       lrc.fault_flag, lrc.settled, lrc.settlement_id, lrc.quarantined,
-		       lrc.quarantine_reason, lrc.recovery_source
+		       lrc.quarantine_reason, lrc.recovery_source,
+		       lqr.resolution_kind   AS resolution_kind,
+		       lqr.operator_id       AS resolution_operator_id,
+		       lqr.resolution_reason AS resolution_reason,
+		       lqr.created_at_utc    AS resolution_at_utc
 		FROM ledger_request_credits lrc
 		LEFT JOIN ledger_operator_credits loc ON loc.request_credit_id = lrc.id
+		LEFT JOIN ledger_quarantine_resolutions lqr ON lqr.request_credit_id = lrc.id
 		WHERE lrc.ts_utc >= ? AND lrc.ts_utc < ?
 		ORDER BY lrc.ts_utc DESC, lrc.id DESC
 		LIMIT ?`, encodeTime(from), encodeTime(to), limit)
@@ -239,7 +257,12 @@ func (Store) Overview(ctx context.Context, q ReadDB, from, to time.Time) (map[st
 		       COALESCE(SUM(loc.operator_credits), 0) AS total_operator_credits,
 		       COALESCE((SELECT COUNT(*) FROM ledger_payout_ready WHERE status = 'ready'), 0) AS pending_payout_count,
 		       COALESCE((SELECT SUM(provider_credits) FROM ledger_payout_ready WHERE status = 'ready'), 0) AS pending_payout_credits,
-		       COALESCE(SUM(CASE WHEN lrc.quarantined != 0 THEN 1 ELSE 0 END), 0) AS quarantined_count,
+		       -- SPEC-005 v0.4 §11.6.5 OPEN_PREDICATE: surface only
+		       -- quarantined rows AWAITING operator decision
+		       -- (force-voided rows are resolved-and-excluded).
+		       COALESCE(SUM(CASE WHEN lrc.quarantined != 0 AND NOT EXISTS (
+		             SELECT 1 FROM ledger_quarantine_resolutions r WHERE r.request_credit_id = lrc.id
+		       ) THEN 1 ELSE 0 END), 0) AS quarantined_count,
 		       COALESCE(SUM(CASE WHEN lrc.fault_flag != '' AND lrc.fault_flag != 'none' THEN 1 ELSE 0 END), 0) AS fault_count
 		FROM ledger_request_credits lrc
 		LEFT JOIN ledger_operator_credits loc ON loc.request_credit_id = lrc.id`, encodeTime(from), encodeTime(to))

--- a/phase4-coordinator/internal/explorer/store_test.go
+++ b/phase4-coordinator/internal/explorer/store_test.go
@@ -32,6 +32,71 @@ func TestStoreSessionDetailReturnsLedgerJoin(t *testing.T) {
 	}
 }
 
+// R4 fix (CODE-M4): SPEC-005 v0.4 §11.6.5 explorer LEFT JOIN must
+// surface the resolution_* alias columns. Earlier AC-Q050 (in
+// billing package) ran the expected SQL directly against store.db,
+// which could mask an explorer-layer regression. This test exercises
+// the REAL explorer API — Store{}.SessionDetail and Store{}.Ledger —
+// against a fixture that has a force-void resolution row.
+func TestStoreSessionDetail_SurfacesQuarantineResolutionAliases(t *testing.T) {
+	_, db := newTestExplorer(t, nil)
+	now := fixedExplorerTime()
+	// Mark the seed ledger row as quarantined + force-voided.
+	if _, err := db.Exec(`UPDATE ledger_request_credits SET quarantined=1, quarantine_reason='test_quarantine' WHERE request_id='req_seed'`); err != nil {
+		t.Fatalf("mark seed quarantined: %v", err)
+	}
+	if _, err := db.Exec(`
+INSERT INTO ledger_quarantine_resolutions
+    (request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc)
+SELECT id, 'force_void', 'alice', 'real-explorer-test', ?
+  FROM ledger_request_credits WHERE request_id='req_seed'`,
+		now.Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("insert quarantine resolution: %v", err)
+	}
+	detail, err := Store{}.SessionDetail(context.Background(), db, "req_seed")
+	if err != nil {
+		t.Fatalf("SessionDetail: %v", err)
+	}
+	rows := detail["ledger_rows"].([]map[string]any)
+	if len(rows) != 1 {
+		t.Fatalf("ledger_rows=%d want 1", len(rows))
+	}
+	row := rows[0]
+	if got, _ := row["resolution_kind"].(string); got != "force_void" {
+		t.Fatalf("resolution_kind=%v want force_void", row["resolution_kind"])
+	}
+	if got, _ := row["resolution_operator_id"].(string); got != "alice" {
+		t.Fatalf("resolution_operator_id=%v want alice", row["resolution_operator_id"])
+	}
+	if got, _ := row["resolution_reason"].(string); got != "real-explorer-test" {
+		t.Fatalf("resolution_reason=%v want real-explorer-test", row["resolution_reason"])
+	}
+	if got, _ := row["resolution_at_utc"].(string); got == "" {
+		t.Fatalf("resolution_at_utc is empty")
+	}
+	// Also verify the Ledger() list view surfaces the same aliases.
+	ledger, err := Store{}.Ledger(context.Background(), db, now.Add(-time.Hour), now.Add(time.Hour), 10)
+	if err != nil {
+		t.Fatalf("Ledger: %v", err)
+	}
+	if len(ledger) == 0 {
+		t.Fatalf("ledger list empty")
+	}
+	var found bool
+	for _, lr := range ledger {
+		if id, _ := lr["request_id"].(string); id == "req_seed" {
+			found = true
+			if got, _ := lr["resolution_kind"].(string); got != "force_void" {
+				t.Fatalf("Ledger list resolution_kind=%v want force_void", lr["resolution_kind"])
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("req_seed missing from ledger list")
+	}
+}
+
 func TestStoreActivitySinceCursorOnlyReturnsNewerRows(t *testing.T) {
 	_, db := newTestExplorer(t, nil)
 	result, err := Store{}.Activity(context.Background(), db, fixedExplorerTime().Add(-time.Hour), fixedExplorerTime().Add(time.Hour), "", "", "", 10)

--- a/specs/AUDIT_ISS_169_IMPL_R1_ARCH_PROMPT.md
+++ b/specs/AUDIT_ISS_169_IMPL_R1_ARCH_PROMPT.md
@@ -1,0 +1,76 @@
+You are auditing the SPEC-005 v0.4 IMPL (issue #169) from an
+ARCHITECT lens.
+
+# Repository context
+
+- Branch `impl/spec-005-v0-4-force-void` in `Augustas11/macprovider`.
+- Spec: `specs/SPEC-005-billing.md` v0.4 (locked).
+- The IMPL adds one POST endpoint, a new SQLite table, validation
+  helpers, and reader narrowing across §11.1/§11.2/§11.3.
+
+# Audit scope (ARCHITECT lens)
+
+- **Composition with existing endpoints.** Does the new
+  `/admin/ledger/quarantine/{id}/force-void` route fit cleanly
+  into the existing `serveHTTP` dispatch? Any conflicts with
+  `/admin/ledger/summary` / `providers` / `reconcile`?
+- **Composition with SPEC-007 explorer.** The explorer LEFT JOIN
+  named in §11.6.5 is NOT included in this PR (SPEC-007 is owned
+  by a separate spec). Is that OK to defer to a SPEC-007 patch
+  PR, or does it cause v0.4 IMPL to ship with an inconsistent
+  user surface?
+- **Reload story.** §13.2 / §11.6.4 mandates a
+  `billing_config_flag_changed` audit event on every actual flip
+  of `billing.quarantine_resolution_force_void_enabled`. The IMPL
+  does NOT yet emit this event (the handler is re-wired at
+  startup; SIGHUP / HTTP-reload integration is not in this PR).
+  Is this an acceptable v0.4 IMPL gap (operator must restart for
+  the flag to take effect) or should the IMPL ship the flip-audit
+  too?
+- **Forward-compatibility with v0.5.** v0.5 adds force-credit +
+  pre-payout hold + UNIQUE relaxation. Does the v0.4 IMPL choose
+  data structures / function signatures that v0.5 can extend
+  cleanly? Specifically:
+  - The CHECK constraint must be ALTERed (SQLite drop + recreate).
+  - The UNIQUE constraint must be relaxed.
+  - The handler split (force-void only) needs to host force-credit.
+  Will v0.5 IMPL be a clean addition or a rewrite?
+- **MaxOpenConns(1) interaction.** The billing store shares a DB
+  handle with requestlog (issue #21 ARCH-3 history). The new
+  handler opens a BeginTx that holds the only conn. Does any
+  reader path (admin/summary, providers, reconcile) become
+  blocked while a force-void POST is in flight?
+- **Test independence.** The new tests share a fixture and
+  assume audit_log is created manually (production wires audit
+  via a different path). Is this acceptable, or should the
+  billing migrate ALSO ensure audit_log exists (defensive
+  coupling)?
+- **Operator UX.** v0.4 ships POST-by-id only — no list endpoint
+  for open quarantines (deferred to v0.5 per the SPEC change-log).
+  Is this acceptable for an operator about to force-void a
+  handful of rows? Or does v0.4 IMPL need an interim discovery
+  mechanism (e.g., the existing `/admin/ledger/summary`
+  `quarantined_count` field is sufficient)?
+- **Production launch gate item 10.** §11.5 says the operator
+  MUST flip the flag deliberately. Does the IMPL surface a clean
+  way to verify the flag state at startup (e.g., a log line)?
+
+# Severity
+
+- **CRITICAL** = fundamental design defect.
+- **HIGH** = architectural gap compounding with v0.5.
+- **MEDIUM** = scoping question.
+- **LOW** = framing.
+
+# Output
+
+```
+[SEVERITY] <short title>
+
+Location: <file/symbol or topic>
+Concern: <architectural question>
+Evidence: <quote>
+Fix: <one-sentence or "name as defer with rationale">
+```
+
+End: `Tally: <C>/<H>/<M>/<L>` or `Tally: 0/0/0/0 ACCEPT`.

--- a/specs/AUDIT_ISS_169_IMPL_R1_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS_169_IMPL_R1_CODE_PROMPT.md
@@ -1,0 +1,85 @@
+You are auditing the SPEC-005 v0.4 IMPL (issue #169 — manual
+quarantine VOID admin surface) for CODE-correctness concerns.
+
+# Repository context
+
+- Branch `impl/spec-005-v0-4-force-void` in `Augustas11/macprovider`.
+- Spec contract: `specs/SPEC-005-billing.md` v0.4 (locked on `main`,
+  landed in PR #252).
+- IMPL files added/touched in this PR:
+  - `phase4-coordinator/internal/billing/quarantine.go` (NEW —
+    handler + validation)
+  - `phase4-coordinator/internal/billing/quarantine_test.go` (NEW —
+    acceptance tests)
+  - `phase4-coordinator/internal/billing/store.go` (MIG-005-010
+    table)
+  - `phase4-coordinator/internal/billing/endpoints.go` (route
+    dispatch + handler struct + §11.1/§11.2/§11.3 reader narrowing)
+  - `phase4-coordinator/internal/config/config.go` (BillingConfig)
+  - `phase4-coordinator/cmd/coordinator/main.go` (wire-up)
+
+# Audit scope (CODE lens)
+
+Verify the IMPL faithfully implements SPEC-005 v0.4. Specifically:
+
+- **Schema (MIG-005-010).** Does the new CREATE TABLE statement
+  match SPEC §4.10 exactly? CHECK constraints; UNIQUE; index
+  surface (must NOT have a separate idx_lqr_request_credit per
+  the SPEC).
+- **Handler request flow.** Does `forceVoidHandler` follow the
+  §11.6.1 / §11.6.1.1 / §11.6.2 contract? Trace each branch:
+  method, auth, route-flag, content-type, body cap, JSON parse,
+  validation, BEGIN IMMEDIATE, base-row preconditions, INSERT,
+  audit INSERT, COMMIT, response. Are there reachable code paths
+  the SPEC does not specify a response for?
+- **Audit-log atomicity (§11.6.4).** Verify the audit_log INSERT
+  is on the SAME `*sql.Tx` as the resolution INSERT. Verify
+  `audit.Store.Insert` is NOT used. Verify rollback semantics on
+  audit-INSERT failure.
+- **Reader narrowing.** Trace the `/admin/ledger/summary` and
+  `/admin/ledger/providers` query changes. Do they match §11.6.5
+  `OPEN_PREDICATE`? Are the SQL queries syntactically correct?
+- **Reconcile widening.** Does `/admin/ledger/reconcile` now emit
+  `rows_force_resolved_in_range` AND narrow `rows_quarantined` to
+  OPEN_PREDICATE? Trace the SQL.
+- **UNIQUE race handling.** §11.6.2 forbids check-then-INSERT. Does
+  `forceVoidHandler` rely solely on the UNIQUE constraint for race
+  protection? Verify that `respondAlreadyResolved` does NOT hit a
+  deadlock at MaxOpenConns(1) (tx must be released before re-read).
+- **isRejectedCodepoint coverage.** Does the function reject every
+  codepoint named in SPEC §11.6.3? The DICP set is large — list
+  any Unicode 16.0 DICP=Yes codepoint MISSING from the function.
+- **Validation order.** Does the handler validate BEFORE the
+  resolution INSERT (not after)? Are CHECK constraint failures
+  unreachable as the spec requires?
+- **Config wiring.** Is `cfg.Billing.QuarantineResolutionForceVoidEnabled`
+  threaded correctly into the handler? Reload story acknowledged?
+- **AC coverage.** Verify the ACs in `quarantine_test.go` actually
+  pin the §11.6 contract. Any AC missing? Any test that passes
+  vacuously?
+- **Composition with existing tests.** Did the changes break any
+  existing test (e.g. the §11.1 summary query)?
+
+# Severity
+
+- **CRITICAL** = IMPL defect that would corrupt the ledger or cause
+  silent money loss.
+- **HIGH** = IMPL defect violating §11.6 contract / reachable
+  incorrect response.
+- **MEDIUM** = clarity gap, missing test, unspecified branch.
+- **LOW** = style, comment, redundancy.
+
+# Output
+
+```
+[SEVERITY] <short title>
+
+Location: <file:line or symbol>
+Concern: <what is wrong>
+Evidence: <quote>
+Fix: <one-sentence>
+```
+
+End: `Tally: <C>/<H>/<M>/<L>` or `Tally: 0/0/0/0 ACCEPT`.
+
+Audit the IMPL AS WRITTEN against the LOCKED v0.4 SPEC.

--- a/specs/AUDIT_ISS_169_IMPL_R1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS_169_IMPL_R1_SECURITY_PROMPT.md
@@ -1,0 +1,73 @@
+You are auditing the SPEC-005 v0.4 IMPL (issue #169) for SECURITY
+concerns.
+
+# Repository context
+
+- Branch `impl/spec-005-v0-4-force-void` in `Augustas11/macprovider`.
+- Spec: `specs/SPEC-005-billing.md` v0.4 (locked).
+- New money-path admin endpoint: `POST /admin/ledger/quarantine/{id}/force-void`.
+- Files: `phase4-coordinator/internal/billing/quarantine.go`,
+  `quarantine_test.go`, plus migrations/wiring in `store.go`,
+  `endpoints.go`, `config.go`, `cmd/coordinator/main.go`.
+
+# Audit scope (SECURITY lens)
+
+- **Auth/authz.** Operator-key gating: any reachable bypass? CORS
+  preflight, OPTIONS, gateway service-token confusion? Does the
+  endpoint enforce the same posture as existing /admin/ledger/*?
+- **Input validation completeness.** Trace `validateReason` and
+  `validateOperatorID`. Any reject class named in SPEC §11.6.3
+  missed? Are there codepoints / byte sequences that bypass the
+  sanitizer (e.g., over-long UTF-8 encodings, surrogates,
+  non-canonical forms)?
+- **Audit-log poisoning.** Does the payload use `json.Marshal` (no
+  hand-rolled JSON)? Can an attacker (with operator key) inject a
+  control sequence that mangles downstream log consumers? Does
+  `operator_id` flow through the sanitizer too (or just `reason`)?
+- **Money-path correctness.** Force-void is supposed to produce NO
+  money-out. Trace: does the resolution INSERT ever cause a
+  downstream credit / payout to fire? Does the §11.6.5 reader
+  narrowing actually keep force-voided rows OUT of the payable
+  set?
+- **Race/TOCTOU.** §11.6.2 says single INSERT against UNIQUE
+  constraint. Does the IMPL ever pre-check
+  ledger_quarantine_resolutions? Does the base-row precondition
+  check have a TOCTOU window?
+- **Information disclosure.** Distinct status codes (404 / 422 /
+  409) leak whether a row exists / is quarantined / is resolved.
+  This is operator-key-gated (acceptable per SPEC §11.6.6) but
+  verify the 404 body for the disabled-flag case is byte-identical
+  to the row-not-found 404 body — no leak of which case fired.
+- **DoS.** Body cap (4 KiB) enforced via http.MaxBytesReader BEFORE
+  full body read? Path parameter overflow handled? Rate-limit
+  bucket shared with existing /admin/*?
+- **Concurrency.** Concurrent POSTs against the same id — does the
+  IMPL produce exactly one 200 + many 409? Does it deadlock at
+  MaxOpenConns(1)?
+- **Tx-rollback semantics on audit-INSERT failure.** Does the IMPL
+  guarantee no orphan resolution row when audit-INSERT fails?
+- **CHECK-constraint bypass.** v0.4 forbids force_credit via CHECK.
+  Is there any code path that could attempt force_credit?
+- **Operator-id self-assertion.** §11.6.4 caveat — does the IMPL
+  emit `operator_attribution: "operator_key_self_asserted"`
+  constant so forensic readers see the limitation?
+
+# Severity
+
+- **CRITICAL** = exploitable, money loss or auth bypass.
+- **HIGH** = significant security gap.
+- **MEDIUM** = hardening item.
+- **LOW** = wording.
+
+# Output
+
+```
+[SEVERITY] <short title>
+
+Location: <file:line>
+Concern: <what is wrong>
+Evidence: <quote>
+Fix: <one-sentence>
+```
+
+End: `Tally: <C>/<H>/<M>/<L>` or `Tally: 0/0/0/0 ACCEPT`.


### PR DESCRIPTION
Closes #169 IMPL surface (SPEC contract landed in PR #252 / commit `ff046af`).

## Summary

- SPEC-005 v0.4 §11.6 quarantine VOID admin surface: `POST /admin/ledger/quarantine/{id}/force-void`
- 9 commits: 1 initial IMPL + 8 audit-round fix-passes converged to **0/0/0/0 ACCEPT** across CODE / SECURITY / ARCHITECT lanes (codex three-lane discipline)

## Audit convergence (9 rounds, three-lane codex)

| Round | CODE | SEC | ARCH | Fixes |
|-------|------|-----|------|-------|
| R1 | 0/8/1/0 | 0/0/2/2 | 0/1/2/1 | 9 HIGH + 5 MEDIUM (path-shape 400, JSON strictness, UTF-8 pre-validate, ASCII trim, BEGIN IMMEDIATE, SIGHUP flip-audit, explorer LEFT JOIN, /admin/* rate-limit) |
| R2 | 0/4/1/0 | 0/0/2/0 | 0/1/0/0 | 4 HIGH + 1 MEDIUM (flag-flip race, 4097 cap, JSON EOF, provider rollup, AC coverage) |
| R3 | 0/1/2/0 | 0/0/2/0 | 0/1/0/0 | 2 HIGH + 4 MEDIUM (atomic snapshot+flag-audit reload, bucket 60→128, 404 hide, explorer SUM filter, AC-Q045 earnings, AC-Q053 back-to-disabled) |
| R4 | 0/0/5/0 | 0/0/0/0 ✅ | 0/0/0/0 ✅ | 5 MEDIUM (snapshot captures flag, byte-identity ==, real explorer API, 409-body verify, precedence pin) |
| R5 | 0/0/1/0 | 0/0/0/0 ✅ | 0/0/0/1 | 1 MEDIUM (type-mismatch → 400) |
| R6 | 0/0/3/0 | 0/0/0/0 ✅ | 0/0/0/0 ✅ | 3 MEDIUM (reloadSource enum, schema CHECK AC, ASCII ESC AC) |
| R7 | 0/0/0/0 ✅ | 0/0/0/0 ✅ | 0/0/1/0 | 1 MEDIUM (coordinator.yaml templates) |
| R8 | 0/0/0/0 ✅ | 0/0/0/0 ✅ | 0/0/1/1 | 1 MEDIUM (constructor monotonic CompareAndSwap) |
| **R9** | **0/0/0/0 ACCEPT** ✅ | **0/0/0/0 ACCEPT** ✅ | **0/0/0/0 ACCEPT** ✅ | **All three lanes converged** |

## What's in this PR

**Endpoint:** `POST /admin/ledger/quarantine/{request_credit_id}/force-void`
- Atomic `(resolution INSERT, audit_log INSERT)` inside one explicit `BEGIN IMMEDIATE` (`db.Conn` + `conn.ExecContext("BEGIN IMMEDIATE")` — modernc.org/sqlite's `BeginTx(LevelSerializable)` doesn't auto-map)
- Token-scan JSON strictness: duplicate/unknown key reject, EOF after closing brace, UTF-8 pre-validated on raw body before JSON-induced U+FFFD normalization, type-mismatch returns 400 bad_request (reserves 422 for value-content sanitizer rejections)
- Unicode 16.0 DICP reject set on `reason` (full Default_Ignorable_Code_Point coverage)
- 4 KiB body cap with explicit `len(raw)>4096` post-check (no chunked-encoding off-by-one)
- 404-universal hide when route-layer flag disabled (auth + method + id-shape all invisible)

**Route-layer flag (`billing.quarantine_resolution_force_void_enabled`):**
- `atomic.Bool` on `Store`, read on every request (no http.Handler re-wire)
- Hot-reload via SIGHUP: `Store.ReloadBillingConfig` writes `ledger_config_snapshots` row + `billing_config_flag_changed` audit row atomically in one tx; publishes in-memory state only after COMMIT
- Constructor uses monotonic `CompareAndSwap(false, true)` — never silently resets a production-enabled flag
- `billing_config_flag_changed` audit emitted on actual flips; suppressed on startup carve-out and no-change reloads

**SPEC-007 explorer LEFT JOIN:**
- `SessionDetail` + `Ledger` views surface `resolution_kind / resolution_operator_id / resolution_reason / resolution_at_utc` alias columns
- Explorer overview `total_*_credits` aggregates now exclude quarantined rows (`CASE WHEN lrc.quarantined=0`)

**Reader narrowing (§11.1/§11.2/§11.3):**
- `quarantined_count` everywhere uses `OPEN_PREDICATE` (`quarantined=1 AND NOT EXISTS resolution`)
- `/admin/ledger/providers`: payable totals always use `CASE WHEN quarantined=0`; `quarantined_count` always uses OPEN_PREDICATE; `include_quarantined` controls only a HAVING-clause row filter
- Reconcile reports `rows_force_resolved_in_range` alongside `rows_quarantined`

**Operational surface:**
- `/admin/*` token bucket (capacity 128, refill 60/sec); every response path consumes one token regardless of status (200/4xx/5xx/429)
- Startup log: `spec005_v0_4_route_layer_flag_init` Info row exposes boot-time flag value
- Reload log: `spec005_v0_4_route_layer_flag_reload` Info row on SIGHUP
- Both `coordinator.yaml.example` and `dist/coordinator.yaml.example` carry a default-OFF `billing:` section with launch-gate comment

**Schema:** New `ledger_quarantine_resolutions` table — `UNIQUE(request_credit_id)`, `CHECK(resolution_kind IN ('force_void'))` (v0.5 widens), length CHECKs on `operator_id` (1..64) and `resolution_reason` (1..500), `idx_lqr_kind_created` covering index.

**AC test coverage:** 17 AC-Q* tests (Q040 schema + length CHECKs, Q042-Q053 deep, Q055), plus rate-limit / no-deadlock / byte-identity 404 / atomic-rollback / real-explorer-API / type-mismatch / DICP / ESC regression tests. All 18 coordinator packages green.

## Test plan

- [x] `go test ./...` from `phase4-coordinator` — 18 packages all green
- [x] Three-lane codex audit converged to 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW across CODE / SEC / ARCH in R9
- [x] Money-path semantics preserved (force-void adds no row to the payable set; v0.3.3 `quarantined=0` filter unchanged)
- [ ] Smoke deploy to Pearl VPS after merge (operator follow-up; flag stays default-OFF until they flip)
- [ ] After Pearl deploy: operator flips `billing.quarantine_resolution_force_void_enabled: true`, SIGHUP, verify `billing_config_flag_changed` audit row in `audit_log`

## Scope note

v0.4 ships **force-void only**. v0.5 (tracking issue #253) adds the force-credit resolution + pre-payout hold primitive together — the scope cut was a R3 SPEC-audit finding (force-credit unsafe without a pre-payout hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)