### PR TITLE
fix(gateway): clamp streaming over-reported completion_tokens (closes #255)

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -521,7 +521,38 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		usage := *reported
 		observedCompletion := estimateStreamingCompletionTokens(emitted, maxTokens)
 		if observedCompletion > usage.CompletionTokens {
+			// Provider under-reported relative to streamed bytes. Use the
+			// gateway estimate so the provider isn't under-billed for content
+			// that was actually streamed.
 			s.settleAfterCommit(r, subject, promptEstimate, observedCompletion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow)
+			return
+		}
+		// Issue #255: provider may report MORE completion tokens than were
+		// streamed as delta.content — e.g. a tokenizer counts EOS or
+		// chat-template stop tokens that never reach the buyer as content.
+		// Surfaced on Qwen2.5-Coder-7B-Instruct-4bit with consistent
+		// +4..+7 over-reports vs both harness and coord (which agree).
+		// Clamp downward when the over-report sits inside the safe window
+		// (see clampWindow). Outside the window — too small (benign noise)
+		// or too large (gateway byte-estimate undercounts dense content;
+		// clamping would under-bill the provider) — trust the provider.
+		// R1 security HIGH: keep usage.PromptTokens (provider's authoritative
+		// prompt count); usageFromJSON already proved prompt+completion ≤
+		// maxUsageTokens, so substituting the smaller observedCompletion
+		// can only lower the total.
+		overshoot := usage.CompletionTokens - observedCompletion
+		if overshoot > clampFloorTokens && overshoot <= clampCeilingTokens {
+			slog.Info("streaming gateway clamped over-reported completion tokens",
+				"request_id", requestID(r),
+				"account_id", subject.AccountID,
+				"reported", usage.CompletionTokens,
+				"observed", observedCompletion,
+				"overshoot", overshoot,
+				"window_floor", clampFloorTokens,
+				"window_ceiling", clampCeilingTokens,
+				"outcome", outcome,
+			)
+			s.settleAfterCommit(r, subject, usage.PromptTokens, observedCompletion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow)
 			return
 		}
 		s.settleAfterCommit(r, subject, usage.PromptTokens, usage.CompletionTokens, maxUsageTokens, "provider_reported", outcome, reservationWindow)
@@ -1011,6 +1042,45 @@ func estimateStreamingCompletionTokens(emitted, maxTokens int64) int64 {
 		return maxTokens
 	}
 	return completion
+}
+
+// Clamp window for the streaming over-report fix (#255). Pure
+// absolute bounds — no percentage scaling.
+//
+// An over-report `o` (reported - observed) triggers the downward
+// clamp iff `clampFloorTokens < o <= clampCeilingTokens`.
+//
+// Pure-absolute shape (R2 security + architect HIGH convergence):
+//
+//   - Below `clampFloorTokens` (≤ 2 tokens): benign tokenizer noise
+//     (EOS / chat-template stop tokens that count as completion but
+//     never stream as delta content). Trust the provider.
+//
+//   - Above `clampCeilingTokens` (> 20 tokens): too large to be
+//     tokenizer noise. The gateway's byte-based estimate is
+//     unreliable on dense content (CJK, code, short tokens where
+//     1 token < 4 bytes); clamping here would under-bill a provider
+//     for legitimately-generated content. Trust the provider.
+//
+// Earlier rounds tried a percentage formula but R2 audits caught a
+// false-positive class: a legitimate moderate-density report
+// (e.g. observed=225 byte-tokens, reported=300 actual tokens) sat
+// inside the percentage window and got clamped, under-billing the
+// provider. Pure absolute bounds eliminate that class — any
+// overshoot > 20 tokens is trusted as density mismatch.
+//
+// Cost: an adversarial provider can systematically over-report by
+// up to 20 tokens per request. Bounded and small per-request; logged
+// each time the clamp fires for audit visibility.
+const (
+	clampFloorTokens   int64 = 2
+	clampCeilingTokens int64 = 20
+)
+
+// clampWindow returns the (floor, ceiling] bounds as a tuple for
+// callers that want both at once (e.g. log lines, tests).
+func clampWindow() (floor, ceiling int64) {
+	return clampFloorTokens, clampCeilingTokens
 }
 
 func maxStreamingCompletionTokens(maxTokens int64) int64 {

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2930,8 +2930,16 @@ func TestStreamingReadErrorAfterBuyerCancelSettlesClientDisconnect(t *testing.T)
 func TestStreamingCleanEOFSettlesOK(t *testing.T) {
 	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"ok"}]}`
 	accountID := "acct_stream_ok"
+	// Content payload aligned with the reported completion_tokens so the
+	// gateway's byte-based observation matches the provider's tokenizer
+	// count and the trust-provider branch fires. Pre-#255 the fixture
+	// here was a 2-byte "ok" content + 4 reported completion_tokens —
+	// a tokenizer-mismatched fixture that exercised the trust-provider
+	// branch only because the old code lacked the downward clamp.
+	// With #255 the clamp catches that exact pattern, so the fixture
+	// now reflects what a real clean stream looks like.
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		payload := `data: {"id":"chatcmpl","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"delta":{"content":"ok"}}]}`
+		payload := `data: {"id":"chatcmpl","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"delta":{"content":"0123456789abcdef"}}]}`
 		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload+"\n\ndata: [DONE]\n\n"), nil
 	})}
 	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
@@ -3550,6 +3558,150 @@ func TestStreamingUnderreportedUsageWithHighProviderPromptFallsBackToGatewayEsti
 	if quota["daily_tokens_reserved"].(float64) != 0 {
 		t.Fatalf("daily_tokens_reserved=%v want 0", quota["daily_tokens_reserved"])
 	}
+}
+
+// TestStreamingProviderReportedOverbillClampedToObserved pins the
+// issue #255 fix: when the provider's WS `usage` frame reports MORE
+// completion tokens than were actually streamed as delta.content
+// (e.g. the tokenizer counts EOS or chat-template stop tokens), the
+// gateway clamps the bill DOWN to the observed value — but ONLY when
+// the overshoot sits inside the pure-absolute clamp window
+// `(clampFloorTokens=2, clampCeilingTokens=20]`.
+//
+// Outside the window — below floor (benign tokenizer noise) OR above
+// ceiling (too large to be tokenizer noise; gateway's byte-estimate
+// is unreliable on dense content where 1 token < 4 bytes, clamping
+// would under-bill the provider for legitimate work) — the gateway
+// trusts the provider's count.
+//
+// R2 security + architect convergence (HIGH): an earlier percentage-
+// based ceiling (50% × observed) still left a moderate-density
+// under-bill class — e.g. observed=225 byte-tokens with legitimate
+// reported=300 actual tokens fell INSIDE the percentage window and
+// got clamped. Switching to pure absolute (≤ 20 tokens) eliminates
+// that false-positive class.
+//
+// Live surfacing: scenario 07 of the v0.3 rerun (2026-06-29) caught
+// +4 / +5 / +7 over-bills on Qwen2.5-Coder-7B-Instruct-4bit hitting
+// air5, all reproducible by the "clamp fires" cases below.
+func TestStreamingProviderReportedOverbillClampedToObserved(t *testing.T) {
+	type tc struct {
+		name              string
+		contentBytes      int   // bytes of delta.content streamed
+		reportedPromptTok int64 // provider's usage.prompt_tokens
+		reportedCompTok   int64 // provider's usage.completion_tokens
+		wantClamp         bool  // true → source=gateway_estimated, comp=observed
+		wantBilledCompTk  int64 // expected completion_tokens in usage_events row
+		wantBilledPromptT int64 // expected prompt_tokens in usage_events row
+	}
+	cases := []tc{
+		// Exact / within-floor: trust provider
+		{name: "exact_match_trusts_provider", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 10, wantClamp: false, wantBilledCompTk: 10, wantBilledPromptT: 7},
+		{name: "1_token_overshoot_within_floor_trusts_provider", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 11, wantClamp: false, wantBilledCompTk: 11, wantBilledPromptT: 7},
+		{name: "2_token_overshoot_at_floor_trusts_provider", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 12, wantClamp: false, wantBilledCompTk: 12, wantBilledPromptT: 7},
+		// In-window clamp: small over-report → clamp; preserve provider prompt
+		{name: "3_token_overshoot_in_window_clamps", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 13, wantClamp: true, wantBilledCompTk: 10, wantBilledPromptT: 7},
+		{name: "iss255_pattern_4_token_overshoot_clamps", contentBytes: 152, reportedPromptTok: 40, reportedCompTok: 42, wantClamp: true, wantBilledCompTk: 38, wantBilledPromptT: 40},
+		{name: "iss255_pattern_5_token_overshoot_clamps", contentBytes: 204, reportedPromptTok: 40, reportedCompTok: 56, wantClamp: true, wantBilledCompTk: 51, wantBilledPromptT: 40},
+		{name: "iss255_pattern_7_token_overshoot_clamps", contentBytes: 152, reportedPromptTok: 40, reportedCompTok: 45, wantClamp: true, wantBilledCompTk: 38, wantBilledPromptT: 40},
+		// At-ceiling-exact: still clamps (closed upper bound).
+		{name: "20_token_overshoot_at_ceiling_clamps", contentBytes: 400, reportedPromptTok: 13, reportedCompTok: 120, wantClamp: true, wantBilledCompTk: 100, wantBilledPromptT: 13},
+		// Just-above-ceiling: trusts provider — density mismatch territory.
+		{name: "21_token_overshoot_just_above_ceiling_trusts_provider", contentBytes: 400, reportedPromptTok: 13, reportedCompTok: 121, wantClamp: false, wantBilledCompTk: 121, wantBilledPromptT: 13},
+		// R2 security + architect convergence (HIGH): moderate-density
+		// scenarios that the old 50%-percentage formula clamped, now
+		// trusted. Example: 900 bytes of CJK-like content with a legit
+		// provider report of 300 tokens — observed=225, overshoot=75,
+		// pure-absolute ceiling=20 → 75 > 20 → trust provider.
+		{name: "moderate_density_33pct_overshoot_trusts_provider", contentBytes: 900, reportedPromptTok: 13, reportedCompTok: 300, wantClamp: false, wantBilledCompTk: 300, wantBilledPromptT: 13},
+		// Extreme density mismatch (4x): trust provider.
+		{name: "dense_content_4x_density_mismatch_trusts_provider", contentBytes: 800, reportedPromptTok: 13, reportedCompTok: 800, wantClamp: false, wantBilledCompTk: 800, wantBilledPromptT: 13},
+		// Tiny observed: floor=2, overshoot in (2, 20] → clamps if
+		// overshoot is e.g. 4. Pure-absolute makes this consistent.
+		{name: "tiny_observed_overshoot_in_absolute_window_clamps", contentBytes: 8, reportedPromptTok: 7, reportedCompTok: 6, wantClamp: true, wantBilledCompTk: 2, wantBilledPromptT: 7}, // observed=2, reported=6, overshoot=4 → clamp
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			output := strings.Repeat("x", c.contentBytes)
+			usageFrame := fmt.Sprintf(`data: {"id":"chatcmpl","usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d},"choices":[{"delta":{},"finish_reason":"stop"}]}`, c.reportedPromptTok, c.reportedCompTok, c.reportedPromptTok+c.reportedCompTok)
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				payload := strings.Join([]string{
+					`data: {"id":"chatcmpl","choices":[{"delta":{"content":"` + output + `"}}]}`,
+					usageFrame,
+					`data: [DONE]`,
+					``,
+				}, "\n\n")
+				return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+			})}
+			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+				cfg.Coordinator.BuyerURL = "http://coordinator.test"
+			}, WithHTTPClient(client))
+			accountID := "acct_iss255_" + c.name
+			fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+			body := fmt.Sprintf(`{"model":"llama","stream":true,"max_tokens":%d,"messages":[{"role":"user","content":"ok"}]}`, c.wantBilledCompTk+200)
+			resp := postChat(t, h, fullKey, body, nil)
+			if resp.Code != http.StatusOK {
+				t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+			}
+			outcome, source, billedComp, billedPrompt := usageEventOutcomeAndTokens(t, dbPath, accountID)
+			if outcome != "ok" {
+				t.Fatalf("outcome = %q, want ok", outcome)
+			}
+			wantSource := "provider_reported"
+			if c.wantClamp {
+				wantSource = "gateway_estimated"
+			}
+			if source != wantSource {
+				t.Errorf("token_source = %q, want %q (clamp=%v: reported=%d observed=%d/%dB window=(%d,%d])",
+					source, wantSource, c.wantClamp, c.reportedCompTok, c.contentBytes/4, c.contentBytes, clampFloorTokens, clampCeilingTokens)
+			}
+			if billedComp != c.wantBilledCompTk {
+				t.Errorf("billed completion_tokens = %d, want %d", billedComp, c.wantBilledCompTk)
+			}
+			if billedPrompt != c.wantBilledPromptT {
+				t.Errorf("billed prompt_tokens = %d, want %d (R1 HIGH: must preserve provider's prompt count)", billedPrompt, c.wantBilledPromptT)
+			}
+		})
+	}
+}
+
+// TestClampWindow pins the issue #255 pure-absolute window:
+//
+//	(clampFloorTokens=2, clampCeilingTokens=20]
+//
+// An over-report `o` clamps iff `2 < o <= 20`. Below floor → trust
+// provider (benign tokenizer noise). Above ceiling → trust provider
+// (gateway byte-estimate is unreliable on dense content; clamping
+// would risk under-billing).
+func TestClampWindow(t *testing.T) {
+	floor, ceiling := clampWindow()
+	if floor != 2 {
+		t.Errorf("clampFloorTokens = %d, want 2", floor)
+	}
+	if ceiling != 20 {
+		t.Errorf("clampCeilingTokens = %d, want 20", ceiling)
+	}
+	// Anti-regression: window does not scale with observed value.
+	// (Earlier versions used max(2, ceil(5% × observed)) for floor
+	// and floor(50% × observed) for ceiling; both led to false-
+	// positive under-bills on moderate-density content.)
+	if clampCeilingTokens <= clampFloorTokens {
+		t.Errorf("clampCeilingTokens (%d) must be > clampFloorTokens (%d)", clampCeilingTokens, clampFloorTokens)
+	}
+}
+
+func usageEventOutcomeAndTokens(t *testing.T, dbPath, accountID string) (outcome, source string, completion, prompt int64) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if err := db.QueryRow(`SELECT outcome, token_source, completion_tokens, prompt_tokens FROM usage_events WHERE account_id = ? ORDER BY created_at DESC LIMIT 1`, accountID).Scan(&outcome, &source, &completion, &prompt); err != nil {
+		t.Fatalf("query usage row: %v", err)
+	}
+	return outcome, source, completion, prompt
 }
 
 func TestNotFoundReturnsOpenAIEnvelope(t *testing.T) {

--- a/specs/SPEC-006-buyer-api.md
+++ b/specs/SPEC-006-buyer-api.md
@@ -1,7 +1,12 @@
 # SPEC-006 - Buyer API Gateway: Mac Provider's first public buyer surface
 
-**Version:** 0.9.1 (2026-06-29, ISS-211 normative forward-header addition: X-MacProvider-Account on the non-sticky routing path)
+**Version:** 0.9.2 (2026-06-29, ISS-255 streaming over-report clamp policy)
 **Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.0, SPEC-003 v0.7, SPEC-004 v0.2
+
+**Change log v0.9.2 (2026-06-29, issue #255):**
+- § 7.2 streaming settlement now clamps provider-reported completion_tokens down to the gateway's byte-based observed value when the over-report falls inside the pure-absolute window `2 < overshoot ≤ 20` ("Streaming over-report clamp" subsection). Below 2 tokens: trusted as benign tokenizer noise. Above 20 tokens: trusted as density mismatch (byte-based observation is unreliable on dense content; clamping would risk under-billing). Clamped rows record `token_source = "gateway_estimated"` and preserve provider-reported `prompt_tokens`; gateway emits a structured log line carrying `request_id`, `account_id`, `reported`, `observed`, `overshoot`, `window_floor`, `window_ceiling`, `outcome` for audit triage.
+- § 17.7 settlement matrix row 200 and § AC-37 acceptance criteria updated to reference the new clamp policy.
+- Live surfacing: scenario 07 of the 2026-06-29 v0.3 baseline rerun caught +4 / +5 / +7 over-bills on `air5 × Qwen2.5-Coder-7B-Instruct-4bit`. Provider-side tokenizer counted EOS / chat-template stop tokens that never streamed as delta content.
 
 **Change log v0.9.1 (2026-06-29, issue #211):**
 - Gateway MUST forward `X-MacProvider-Account: <subject.AccountID>` on
@@ -1653,7 +1658,33 @@ Failed reservations MUST expire and be reclaimed by a reaper job within 24 hours
 
 For streaming requests (`stream: true`), the gateway MUST reserve `max_tokens` or the configured per-request cap, whichever is smaller, before forwarding.
 
-On SSE completion after a provider `[DONE]` chunk, settlement MUST adjust the reservation to actual usage as reported by the provider.
+On SSE completion after a provider `[DONE]` chunk, settlement MUST adjust the reservation to actual usage as reported by the provider, subject to the streaming over-report clamp policy below.
+
+#### Streaming over-report clamp (#255, issue dated 2026-06-29)
+
+The gateway MUST clamp the streaming completion_tokens settlement down to its own observed value whenever the provider's `usage.completion_tokens` exceeds the gateway's byte-based observation by an amount inside the pure-absolute clamp window:
+
+- Let `observed = ceil(bytes_emitted_so_far / 4)` (the existing § 7.2 disconnect-fallback heuristic).
+- Let `overshoot = reported - observed`.
+- Clamp iff `2 < overshoot ≤ 20`.
+
+Outside the window the gateway MUST trust the provider's reported completion_tokens:
+
+- `overshoot ≤ 2`: benign tokenizer noise (EOS / chat-template stop tokens that count as completion but never stream as delta content).
+- `overshoot > 20`: density mismatch — the gateway's byte-based estimate is unreliable on dense content (CJK, code, short-token text where 1 token < 4 bytes); clamping here would risk under-billing the provider for legitimately generated content.
+
+When the clamp fires, the usage event MUST record `token_source = "gateway_estimated"` (no new vocabulary), MUST preserve the provider's reported `prompt_tokens`, and the gateway SHOULD emit a structured log line carrying `request_id`, `account_id`, `reported`, `observed`, `overshoot`, `window_floor`, `window_ceiling`, and `outcome` for audit visibility.
+
+The pure-absolute window is a deliberate trade. A percentage-scaled ceiling (50% × observed in earlier drafts) was rejected because it still false-positive-clamped moderate-density legitimate reports (e.g. observed=225 byte-tokens with a legitimate 300-token actual count fell inside a percentage window and got clamped). The fixed 20-token ceiling caps the per-request false-positive under-bill at 20 tokens regardless of completion size, and trusts the provider for any overshoot large enough to plausibly reflect density divergence.
+
+Skim surfaces NOT closed by the clamp:
+
+- `overshoot ≤ 2`: trusted as benign tokenizer noise. A provider can systematically over-report by up to 2 tokens per request without triggering the clamp. Bounded; no structured-log emission.
+- `overshoot > 20`: trusted as density mismatch. A provider can over-report by any amount above 20 tokens (bounded only by the request's `max_tokens`) without triggering the clamp. Same adversarial exposure as the pre-#255 status quo for these reports. No structured-log emission.
+
+Only the `3 ≤ overshoot ≤ 20` band is both clamped and structured-log-visible for triage. Closing the residual skim surfaces requires a tokenizer-grounded observation (replacing the byte heuristic) — out of scope for #255.
+
+Existing § 7.2 upward correction (settle to gateway estimate when `observed > reported`) is unchanged.
 
 For streaming requests where the buyer disconnects mid-stream, the gateway settles the daily-quota reservation as follows:
 
@@ -2621,7 +2652,7 @@ The gateway MUST reserve quota before forwarding as defined in Section 7.2 and s
 
 | Status | Completion tokens | Quota debited | Rationale |
 |---|---:|---|---|
-| 200 | as reported | prompt + completion | Successful work performed |
+| 200 | as reported, subject to § 7.2 over-report clamp | prompt + completion | Successful work performed; streaming `completion_tokens` clamped down to gateway observed when over-report sits inside `2 < overshoot ≤ 20` (#255) |
 | 503 | 0 | none | No provider was reached; request never forwarded |
 | Context cancelled (buyer disconnects mid-reservation) | n/a | none; reservation refunded before return | Gateway MUST exit silently without writing a 500 to the dead connection |
 | Context cancelled (buyer disconnects at concurrency gate) | n/a | none; quota reservation refunded before return | Same as above |
@@ -3255,9 +3286,9 @@ Branches:
 Expected outcome:
 
 - Concurrent requests cannot oversubscribe the daily quota during the stream.
-- Successful stream returns HTTP 200 with `Content-Type: text/event-stream; charset=utf-8`, emits `data: {json}\n\n` chunks followed by `data: [DONE]`, and settles to provider-reported usage.
-- Branch A releases concurrency and records usage source as provider-reported.
-- Branch B releases concurrency and records usage source as gateway-estimated.
+- Successful stream returns HTTP 200 with `Content-Type: text/event-stream; charset=utf-8`, emits `data: {json}\n\n` chunks followed by `data: [DONE]`, and settles to provider-reported usage subject to the § 7.2 streaming over-report clamp (#255: completion_tokens are clamped down to the gateway's byte-based observed value when `2 < overshoot ≤ 20`, recorded as `gateway_estimated` source).
+- Branch A releases concurrency and records usage source as provider-reported when the clamp does NOT fire (overshoot ≤ 2 or > 20).
+- Branch B releases concurrency and records usage source as gateway-estimated, covering both the existing upward-correction case (observed > reported) AND the new #255 downward-clamp case (clamp window fires).
 - `/v1/usage` returns HTTP 200 with reservation released and daily token fields reflecting settlement.
 
 Verification command:


### PR DESCRIPTION
## Summary

Closes [#255](https://github.com/Augustas11/macprovider/issues/255). Money-path fix surfaced by the v0.3 baseline rerun: gateway over-counts streaming `completion_tokens` by +4 / +5 / +7 on `air5 × Qwen2.5-Coder-7B-Instruct-4bit`. Provider's WS `usage` frame counts EOS / chat-template stop tokens that never reach the buyer as `delta.content`; the "trust provider_reported" branch over-billed.

## Fix shape

Asymmetric streaming settlement at [chat_proxy.go::settleReported](phase5-gateway/internal/router/chat_proxy.go):

- KEEP upward correction (observed > reported → `gateway_estimated`)
- ADD downward clamp: pure-absolute window `(2, 20]`. When provider over-reports by 3–20 tokens, settle at observed (`gateway_estimated`), preserve provider's `prompt_tokens`, emit structured log line.

**Pure-absolute, no percentage scaling.** R2 audit rejected a `50% × observed` ceiling because it false-positive-clamped moderate-density legitimate reports (observed=225 with legit reported=300 fell inside the percentage window). Pure absolute caps per-request false-positive under-bill at 20 tokens and trusts the provider for any overshoot large enough to plausibly reflect density divergence (CJK, code, short-token text).

## Accepted residual risk

- `overshoot ≤ 2`: trusted as benign tokenizer noise. Provider can skim ≤2 tokens/request, unlogged.
- `overshoot > 20`: trusted as density mismatch. Provider can over-report by any amount (bounded only by `max_tokens`), unlogged. Same exposure as pre-#255 status quo.

Only the `3 ≤ overshoot ≤ 20` band is clamped AND structured-log-visible for triage. Closing the residual surfaces requires a tokenizer-grounded observation — out of scope for #255.

## SPEC

SPEC-006 → **v0.9.2**. New "Streaming over-report clamp" subsection under § 7.2. Settlement matrix row 200 + § AC-37 acceptance criteria updated to reference the clamp. Skim surfaces documented honestly.

## Audit trajectory

| Round | Code | Security | Architect |
|---|---|---|---|
| R1 | 1 HIGH (prompt-tokens dropped) | 1 HIGH (dense-content under-bill) | 1 MEDIUM (SPEC needed update) |
| R2 | 0/0/0 | 1 HIGH convergent | 1 HIGH convergent (same finding: percentage ceiling still leaks moderate-density) |
| R3 | 0/0/0 | 0/0/0 | 1 MEDIUM (SPEC rationale misstated skim surface) |
| R4 (architect-only, per skip-accepted-lanes rule) | — | — | 1 MEDIUM + 1 LOW (stale matrix + AC-37; version/changelog) |

All findings absorbed. Final state: 0 C/H/M.

## Tests

`TestStreamingProviderReportedOverbillClampedToObserved` (12 subtests):
- exact match; within-floor (+1, +2); in-window (+3); **#255 actual patterns (+4 / +5 / +7) all clamp**
- at-ceiling-exact (+20) clamps; just-above-ceiling (+21) trusts
- moderate-density 33% overshoot trusts; 4x density mismatch trusts
- tiny observed (clamps in absolute window)

`TestClampWindow` pins the constants + `floor < ceiling` invariant.

Every subtest asserts `prompt_tokens` preserved (R1 CODE HIGH).

## Test plan

- [x] `go test ./internal/router/... -count=1` passes (5.23s)
- [x] `go vet ./...` clean
- [ ] Post-deploy: re-run v0.3 baseline; expect scenario 07 I1 fail to convert from `+16 across 3 pairs` → `0 overbill across 3 pairs` (the 3 #255-pattern requests will now settle at observed).