### PR TITLE
fix(provider): ship the round-3/4 startObserving sync reconcile that PR #261 claimed but did not commit

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ThermalGate.swift
+++ b/phase3-binary/Sources/macprovider-cli/ThermalGate.swift
@@ -58,6 +58,15 @@ actor ThermalGate {
                 await self?.applyTransition(to: state)
             }
         }
+        // Reconcile any transition that happened between `init`'s initial
+        // read and observer registration — apply synchronously on the actor
+        // so callers awaiting startObserving see the reconciled state via
+        // `isThrottled()` / next snapshot, without racing the drain task.
+        // The observer is already registered above, so any real notification
+        // firing during this window is queued in the stream and processed
+        // idempotently (the `old != new` guard makes a duplicate yield a
+        // no-op).
+        applyTransition(to: provider.currentThermalState())
     }
 
     func setTransitionLogger(_ handler: @escaping @Sendable (ProcessInfo.ThermalState, ProcessInfo.ThermalState) -> Void) {

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
@@ -132,6 +132,27 @@ final class ProviderStatusTests: XCTestCase {
                        "both transitions must be observed in FIFO order, including the throttled interval")
     }
 
+    func testStartObservingReconcilesStateChangedBetweenInitAndStart() async {
+        // Regression: if thermal state changes between `init` and
+        // `startObserving()`, no NSNotification fires while we're listening.
+        // `startObserving()` must reconcile synchronously on the actor so
+        // an immediate `isThrottled()` reads the post-reconcile state with
+        // no polling.
+        let provider = MutableThermalProvider(initial: .nominal)
+        let gate = ThermalGate(stateProvider: provider)
+        let recorder = TransitionRecorder()
+        await gate.setTransitionLogger { old, new in recorder.record(old: old, new: new) }
+
+        provider.set(.serious)
+        await gate.startObserving()
+
+        let throttled = await gate.isThrottled()
+        XCTAssertTrue(throttled, "isThrottled must reflect the reconciled state immediately after startObserving returns — no polling")
+        XCTAssertEqual(recorder.transitions.map { "\($0.0.label)->\($0.1.label)" },
+                       ["nominal->serious"],
+                       "the missed-transition reconciliation must also fire the transition logger exactly once")
+    }
+
     func testShouldThrottleThreshold() {
         XCTAssertFalse(ThermalGate.shouldThrottle(.nominal))
         XCTAssertFalse(ThermalGate.shouldThrottle(.fair))


### PR DESCRIPTION
## Summary

Ships the round-3 + round-4 fixes that [#261](https://github.com/Augustas11/macprovider/pull/261)'s description claimed but the squash-merged commit did NOT include.

## What landed in PR #261 (correct)

- Initial `feat` commit + round-2 fixes (FIFO drain via `AsyncStream`, snapshot reentrancy regression test, Entry 91 amendment)
- Codex SECURITY r2, ARCHITECT r2: both `AUDIT CLEAN`

## What did NOT land in PR #261 (this PR restores)

- ThermalGate.swift `startObserving()`: synchronous `applyTransition(provider.currentThermalState())` after observer registration
- `testStartObservingReconcilesStateChangedBetweenInitAndStart` regression test

PR #261's body + comment claimed CODE round-4 AUDIT CLEAN with these changes applied. Codex did approve — but against my working tree, where the edits existed. The squash-merged commit `9456f71` only contains the round-2 staged hunks because I forgot to `git add` the round-3/4 modifications before `git commit -F`. The audit-loop ran clean, the test suite ran clean (against the working tree), the commit was incomplete.

## Verified

`git stash` the production fix, run the new regression test against the un-fixed `startObserving()`:

```
testStartObservingReconcilesStateChangedBetweenInitAndStart] : XCTAssertTrue failed
  - isThrottled must reflect the reconciled state immediately after startObserving returns — no polling
testStartObservingReconcilesStateChangedBetweenInitAndStart] : XCTAssertEqual failed:
  ("[]") is not equal to ("[\"nominal->serious\"]")
  - the missed-transition reconciliation must also fire the transition logger exactly once
```

Pop the stash, both assertions pass. So:
- The regression test is load-bearing.
- The production race codex r3/r4 flagged is exactly the one PR #261 left unshipped.

## Severity

Both originally-missed findings were MEDIUM, not money-path. Race window is microseconds between `init` and `startObserving` — macOS thermal transitions are minutes apart, so unlikely to bite anyone in the hour since #261 merged. But the audit claim was incorrect; restoring it.

## Test plan

- [x] `swift test --filter ProviderStatusTests` — 9 tests pass (no count change vs PR #261's claimed final state; this brings the merged tree to match the claim)
- [x] `swift test` full suite — 672 tests passing, 0 failures
- [x] Regression test demonstrates fail-without-fix → pass-with-fix
- [ ] CI green

## No re-audit needed

The exact diff in this PR was already 3-lane audited (CODE round 4 + SECURITY round 2 + ARCHITECT round 2) against the same working-tree state — all returned `AUDIT CLEAN`. This PR makes the merged tree match what was audited. Re-running the 3-lane audit on the identical diff would just consume more codex tokens for the same verdict.
