### PR TITLE
docs: land research audit trail in specs/ (memos + prompts + benchmarks TODO)

### DIFF
--- a/specs/BENCHMARKS_226_TODO.md
+++ b/specs/BENCHMARKS_226_TODO.md
@@ -1,0 +1,158 @@
+# BENCHMARKS — Re-ranked TODO after RESEARCH_223 / 224 / 225
+
+**Status as of 2026-06-30.**
+**Re-ranked from** `RESEARCH_223` Part 6 (10 SCN-223-NN scenarios)
+**Informed by** `RESEARCH_224` (per-model rate-card + tier filter) and
+`RESEARCH_225` (Darkbloom = d-inference, runs mlx-swift, MoE catalog,
+88% subsidy share).
+**Will merge with** `RESEARCH_226` (MoE selection + market demand) SCN-226-NN
+scenarios when that memo lands.
+
+This is a **tracking file**, not a normative SPEC. Update statuses
+inline as bench scenarios are run, deferred, or dropped. Source of
+truth for any measured number lands in a dated `specs/BENCHMARK_BASELINE_*.md`
+file, not here.
+
+---
+
+## Priority bands
+
+### P0 — Gating Track B v2 launch (must run before flipping live rates)
+
+| ID | Scenario | Decision gate | Status |
+|---|---|---|---|
+| `SCN-223-01` | Isolated M4 Air 24GB Qwen3-32B-4bit, verify model config/hash, re-measure single-stream sustained tok/s | Data-integrity: theoretical ceiling 6-7 vs observed 14 must reconcile. Every downstream cell in `RESEARCH_223` Part 2 assumes the bench is correctly attributed. | TODO |
+| `SCN-NEW-01` | Per-model rate-card key matching test against `phase4-coordinator/internal/billing/formula.go` model-string normalization | Silent-overcharge hazard: if buyer hits with `Qwen/Qwen3-32B-Instruct-MLX-4bit` and `rewards.rate_card` row keyed `qwen3-32b` doesn't match, lookup falls back to `default` ($1.00/M). Block Track B live config flip until verified. | TODO |
+| `SCN-NEW-02` | Hardware-tier rejection telemetry: synthetic out-of-tier provider attempts 32B job; confirm rejection in audit-log + useful error code returned | Tier filter ships in next coordinator release per Track B; must observably enforce, not silently accept. | TODO |
+| `SCN-NEW-03` | End-to-end billing smoke at new rates: 1 test buyer + 1 M-Max provider, 1k completions through `qwen3-32b` row, confirm billing rows show $0.220/M (not $1.00 default) | Confirms rate-card row hot-reload (SIGHUP) actually applied; catches normalization mismatch in flight. | TODO |
+
+**Decision gate**: all 4 P0 must return green before `/opt/macprovider/coordinator.yaml`
+gets Track B's rate-card rows in production. SCN-223-01 separately
+gates whether `RESEARCH_223` matrix needs to be re-built.
+
+### P1 — Track B v2 monitoring (run during 90-day beta cohort)
+
+| ID | Scenario | Decision gate | Status |
+|---|---|---|---|
+| `SCN-223-10` | 30-min thermal soak on M4 Air / M4 Max / M2 Ultra during sustained Qwen3-32B-4bit decode; report TPS curve, throttle point | Realistic-sustained TPS != peak. Feeds Track B provider $/hr math for all tiers. Air may drop 10-25%; Max/Ultra should hold. | TODO |
+| `SCN-223-08` | Llama-3.3-70B-4bit on M2 Ultra / M3 Ultra under mlx-swift and llama.cpp; single-stream sustained + 2-stream concurrent | Tier-S serves 70B per Track B at $0.250/M. Need confirmed S=20-30, C=40-65 before quoting Tier-S provider $/hr in cohort onboarding. | TODO |
+| `SCN-NEW-04` | Cohort onboarding dry-run: simulate 5 providers (1 S, 2 A, 1 B, 1 C) registering with hardware probe; verify tier assignment lands correctly and off-chain token ledger writes the expected rows | Token ledger Option α is operator bookkeeping. Confirm the schema works under a realistic provider mix before cohort cap of 120 onboards. | TODO |
+
+### P2 — Strategic-direction-gated (run if dense-32B differentiation locks in)
+
+These were Track A's engineering-roadmap-driving benchmarks. Darkbloom's
+production stack (mlx-swift, MoE-with-small-active) shifts whether
+they're load-bearing. Hold until after `RESEARCH_226` MoE memo lands
+to decide dense-vs-MoE direction.
+
+| ID | Scenario | Decision gate | Status |
+|---|---|---|---|
+| `SCN-223-04` | llama.cpp `--parallel 4 --cont-batching` Qwen3-32B-Q4_K_M on M4 Max; aggregate + per-stream TPS | **Reframe**: compare against mlx-swift baseline on same workload. Decision is "do we swap runtimes?", not "does llama.cpp work." | DEFERRED — gate on RESEARCH_226 strategic pick |
+| `SCN-223-05` | Concurrent-streams ceiling on **mlx-swift** runtime (the actual production stack per Darkbloom) with Qwen3-32B-4bit on M4 Max / M2 Ultra | **Reframe**: original was vllm-mlx / mlx-openai-server which is too new. Replace with current-runtime headroom test. Informs whether continuous-batching engineering is needed at all. | DEFERRED — reframe required |
+| `SCN-223-03` | Qwen3-0.5B drafting Qwen3-32B speculative decode on M4 Air + M4 Max; sustained TPS + draft acceptance rate | Track A #2 engineering bet (1-2 EM, 1.2-2.0× per stream). Only relevant if dense 32B is the lane. | DEFERRED — gate on RESEARCH_226 strategic pick |
+| `SCN-223-07` | 3-bit MLX Qwen3-32B-4bit quality (MMLU + HumanEval delta vs 4-bit baseline) + throughput | If quality holds, +15-35% TPS shifts M4 Max 32B from electricity-plus into meaningful USD margin. Only relevant if dense 32B is the lane. | DEFERRED — gate on RESEARCH_226 strategic pick |
+
+### P3 — Low-priority / hygiene
+
+| ID | Scenario | Status | Rationale |
+|---|---|---|---|
+| `SCN-223-02` | Swift MLX (`ModelRuntime.swift`) vs `mlx_lm.generate` Python reference parity on same model + prompt | LOW-PRI | Runtime-correctness hygiene check. Our runtime should agree with reference within 20%. Useful but not blocking. |
+| `SCN-223-09` | Prefix-cache reuse on repeated agent prompts; TTFT/prefill delta vs decode delta | DEFERRED | Independent of model class; helps any agent traffic. Defer until actual agent workloads exist to optimize against. |
+
+### Superseded / cross off
+
+| ID | Scenario | Why superseded |
+|---|---|---|
+| `SCN-223-06` | KV-cache pressure on M4 Air 24GB with 4×4K-context Qwen3-32B-4bit streams | Track B's hardware-tier filter explicitly prevents routing 32B to Tier-C (M4 Air). Expected outcome (OOM / page pressure) is already encoded in the routing decision; benchmark answers "would it work if we did the thing we're not going to do." Repurpose for MoE 20B-class on M4 Air if/when that lane opens (see SCN-226-NN). |
+
+---
+
+## SCN-226-NN — RESEARCH_226 MoE benchmarks (merged 2026-06-30)
+
+`RESEARCH_226` landed and added MoE rows to Track B's rate-card.
+These 5 scenarios validate the per-cell TPS estimates that the MoE
+rate-card and per-model admission rules depend on.
+
+| ID | Scenario | Decision gate | Status |
+|---|---|---|---|
+| `SCN-226-01` | M4 Air 24GB and 32GB × `openai/gpt-oss-20b` MXFP4/4bit under MLX and llama.cpp GGUF; 4K prompt, 512 completion, 3 runs | Promote `gpt-oss-20b` to Tier-C M4 Air 32GB+ in `model_admission`. Success: ≥30 sustained tok/s, no swap, p95 TTFT ≤2500 ms. | TODO |
+| `SCN-226-02` | M4 Air 32GB, M4 Pro 24GB/48GB × `google/gemma-4-26b-a4b-it` 4bit and QAT-4bit under MLX/VLM and llama.cpp GGUF; 4K text-only + 4K multimodal-disabled text path | Promote `google-gemma-4-26b-a4b-it` to Tier-C 32GB+; gate Tier-B 24GB on this bench. Success: ≥30 tok/s Tier-C, ≥45 tok/s Tier-B, stable memory. | TODO |
+| `SCN-226-03` | M4 Max 64GB/128GB and M3 Ultra 256GB × `qwen/qwen3-30b-a3b` 4bit under MLX/LM Studio and llama.cpp; 4K prompt, 2K completion, `/no_think` and thinking variants | Track A runtime-reliability gate that promotes Qwen3-30B-A3B from ⚠️ to ✅. Success: Tier-A ≥70 tok/s non-thinking; Tier-S ≥90 tok/s. | TODO |
+| `SCN-226-04` | M4 Max 64GB and M2 Ultra 128/192GB × `qwen/qwen3-next-80b-a3b-instruct` 4bit under MLX and GGUF; 4K and 32K prompts | Unlocks Tier-A 64GB+ for Qwen3-Next-80B as a holdout MoE. Success: load without swap; Tier-A ≥35 tok/s at 4K; 32K degradation recorded. | TODO |
+| `SCN-226-05` | M2 Ultra 192GB and M3 Ultra 256GB × `minimax/minimax-m2.7` 4bit GGUF under llama.cpp latest; 4K prompt, 512 completion, batch 1 and 2 | **Prove or kill** Tier-S MiniMax listing. Success: ≥25 tok/s single stream and no swap → list. Fail → drop MiniMax from v2 consideration. | TODO |
+
+### Priority placement
+
+- `SCN-226-01` + `SCN-226-02` → **P0** (gate v2 MoE-row launch — without these the per-model admission rules in `RESEARCH_226` Part 5 are unverified)
+- `SCN-226-03` → **P1** (decides whether `qwen3-30b-a3b` enters at v2 launch ✅ or stays ⚠️)
+- `SCN-226-04` + `SCN-226-05` → **P2** (capability expansion beyond v2 launch; not gating)
+
+### Repurposed SCN-223-06 slot
+
+`SCN-223-06` (KV-cache pressure on M4 Air 24GB × dense Qwen3-32B with
+4×4K-context streams) was superseded by Track B's tier filter. The
+slot is now naturally re-occupied by **SCN-226-01** (same hardware,
+different model: MoE GPT-OSS-20B with 3.6B active fits where dense
+32B doesn't — the bench that proves the per-model admission unlock).
+
+---
+
+## Cross-reference: which research memo each scenario informs
+
+| Scenario | RESEARCH_223 (MLX roadmap) | RESEARCH_224 (pricing v2) | RESEARCH_225 (Darkbloom) | RESEARCH_226 (MoE) |
+|---|:-:|:-:|:-:|:-:|
+| SCN-223-01 | x | x (rate-card math) | | |
+| SCN-223-02 | x | | | |
+| SCN-223-03 | x | | | |
+| SCN-223-04 | x | | x (comp vs darkbloom stack) | |
+| SCN-223-05 | x | | x | |
+| SCN-223-06 | (superseded) | (superseded by tier filter) | | (re-use for MoE on Air) |
+| SCN-223-07 | x | x (margin on M-Max 32B) | | |
+| SCN-223-08 | x | x (Tier-S 70B) | | |
+| SCN-223-09 | x | | | |
+| SCN-223-10 | x | x (sustained vs peak) | | |
+| SCN-NEW-01 | | x (model-key normalization) | | |
+| SCN-NEW-02 | | x (tier filter telemetry) | | |
+| SCN-NEW-03 | | x (rate-card hot-reload smoke) | | |
+| SCN-NEW-04 | | x (token-ledger cohort dry-run) | | |
+| SCN-226-NN | (some) | x (MoE rate-card delta) | | x |
+
+---
+
+## Open questions to resolve as benches run
+
+1. **If SCN-223-01 confirms 14 tok/s is correct** (not bench attribution
+   error), what's the missing factor vs 6-7 theoretical ceiling? Speculative
+   decode silently enabled? Lower quantization than declared? Smaller model
+   variant? This changes the whole `RESEARCH_223` Part 2 matrix downward
+   in expected gap-to-H100, since bandwidth-bound math would then need
+   recalibration.
+
+2. **If SCN-NEW-01 finds model-string normalization mismatch**, decide:
+   patch the rate-card row keys to match actual buyer-requested model
+   strings, or add a class-level rate-card lookup (SPEC delta to SPEC-005,
+   per RESEARCH_224 caveat).
+
+3. **If SCN-223-08 70B numbers come in below the 20-30 / 40-65 range**,
+   Tier-S × 70B at $0.250/M won't even cover electricity. Decision:
+   raise 70B rate-card row, remove 70B eligibility from Tier-S until
+   Ultra fleet TPS improves, or accept it as donor-class for cohort
+   prestige.
+
+4. **If SCN-226-NN MoE TPS matrix shows M4 Air can serve GPT-OSS 20B at
+   ≥50 tok/s sustained**, Track B's tier filter needs an exception: allow
+   Tier-C providers to take MoE-small-active jobs even though they can't
+   take dense-32B. Probably a `min_active_param_gb` field per rate-card
+   row rather than a tier override.
+
+---
+
+## Update protocol
+
+- Run a bench → record raw numbers in `specs/BENCHMARK_BASELINE_<date>.md`
+  (or scenario subdirectory if there are >5 numbers).
+- Update the relevant row's `Status` column here: TODO → RUNNING → DONE-PASS / DONE-FAIL / DEFERRED.
+- If a result contradicts an assumption in `RESEARCH_223/224/225`, flag
+  in conversation immediately — don't silently update the matrix.
+- When `RESEARCH_226` lands, merge SCN-226-NN rows in place above and
+  delete the placeholder block.

--- a/specs/HANDOFF_BETA_PRICING_TOKEN_ROLLOUT_PROMPT.md
+++ b/specs/HANDOFF_BETA_PRICING_TOKEN_ROLLOUT_PROMPT.md
@@ -43,16 +43,16 @@ the *why* before writing code.
 1. [beta/DECISION_CRITERIA.md](beta/DECISION_CRITERIA.md) — **Entry 92** at the tail
    is the locked v2 pricing + token design. Everything below implements it.
 2. [specs/RESEARCH_222_PRICING_PROMPT.md](specs/RESEARCH_222_PRICING_PROMPT.md) +
-   [.omc/artifacts/ask/codex-research-prompt-issue-222-beta-campaign-pricing-decision-run-2026-06-30T05-03-00-134Z.md](.omc/artifacts/ask/codex-research-prompt-issue-222-beta-campaign-pricing-decision-run-2026-06-30T05-03-00-134Z.md) —
+   [specs/RESEARCH_222_PRICING_MEMO.md](specs/RESEARCH_222_PRICING_MEMO.md) —
    v1 (rejected). Skim only; it's the strawman we replaced.
 3. [specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_PROMPT.md](specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_PROMPT.md) +
-   [.omc/artifacts/ask/codex-research-prompt-mlx-continuous-batching-speculative-decoding-2026-06-30T05-30-14-323Z.md](.omc/artifacts/ask/codex-research-prompt-mlx-continuous-batching-speculative-decoding-2026-06-30T05-30-14-323Z.md) —
+   [specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_MEMO.md](specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_MEMO.md) —
    12-month MLX engineering roadmap; per-cell tok/s targets.
 4. [specs/RESEARCH_224_PRICING_V2_PROMPT.md](specs/RESEARCH_224_PRICING_V2_PROMPT.md) +
-   [.omc/artifacts/ask/codex-research-prompt-issue-224-beta-pricing-v2-run-2026-06-30.md](.omc/artifacts/ask/codex-research-prompt-issue-224-beta-pricing-v2-run-2026-06-30.md) —
+   [specs/RESEARCH_224_PRICING_V2_MEMO.md](specs/RESEARCH_224_PRICING_V2_MEMO.md) —
    the primary v2 memo with hardware-tier design + token-ledger design + per-model rate-card YAML.
 5. [specs/RESEARCH_225_DARKBLOOM_COMPARISON_PROMPT.md](specs/RESEARCH_225_DARKBLOOM_COMPARISON_PROMPT.md) +
-   [.omc/artifacts/ask/codex-research-prompt-darkbloom-dev-comparison-pricing-tps-network-2026-06-30T05-44-42-602Z.md](.omc/artifacts/ask/codex-research-prompt-darkbloom-dev-comparison-pricing-tps-network-2026-06-30T05-44-42-602Z.md) —
+   [specs/RESEARCH_225_DARKBLOOM_COMPARISON_MEMO.md](specs/RESEARCH_225_DARKBLOOM_COMPARISON_MEMO.md) —
    competitor analysis. **CRITICAL**: darkbloom.dev = `Layr-Labs/d-inference`
    which is **clean-room restricted** per `CLAUDE.md`. NEVER inspect their source.
 6. [specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_PROMPT.md](specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_PROMPT.md) +

--- a/specs/RESEARCH_222_PRICING_MEMO.md
+++ b/specs/RESEARCH_222_PRICING_MEMO.md
@@ -1,0 +1,484 @@
+# codex advisor artifact
+
+- Provider: codex
+- Exit code: 0
+- Created at: 2026-06-30T05:03:00.134Z
+
+## Original task
+
+# RESEARCH PROMPT — Issue #222 beta-campaign pricing decision
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_222_PRICING_PROMPT.md)"`
+
+This is a **strategy research prompt**, not a code-audit prompt. No
+3-lane discipline required. Single codex call (or run twice with
+different models to cross-check); the output is a recommendation memo,
+not a diff.
+
+---
+
+## Task
+
+Decide pricing for the macprovider **beta campaign**. Today's defaults
+are placeholders inherited from SPEC-005 D3 — never re-tuned with live
+data. Issue #222 quantified the gap: providers earn **~$0.045/hr** at
+default rates × current M-series sustained TPS, which is below the v0.1
+B6 bare-min ($0.30/hr) and ~22× under the $1.00/hr target. The network
+is **not provider-viable** at current settings.
+
+Recommend a concrete rate change (or explicit defer with re-trigger
+criteria), backed by market data and a sensitivity analysis. End with a
+DECISION_CRITERIA.md entry ready to commit.
+
+## Background — current state (verbatim from code/issue/baseline)
+
+**Rate-card defaults** (`phase4-coordinator/internal/config/config.go:548-549`):
+- `PromptCreditsPerMtok: 500_000`
+- `CompletionCreditsPerMtok: 1_000_000`
+- `Rewards.GlobalMultiplier: 1.0` (line ~543)
+- `Rewards.ProviderShare: 0.90`
+- `StatsRollup.UsdPerMillionCredits: 1.0` (`$1` per Mcredit)
+
+**Per 1000 completion tokens math:**
+- gross_credits = 1000 × 1_000_000 / 1_000_000 = 1000 credits
+- provider_credits = 1000 × 0.90 = 900 credits
+- USD = 900 × $1.0 / 1_000_000 = **$0.0009 per 1k completion tokens**
+
+**Observed sustained TPS** (BENCHMARK_BASELINE_2026-06-29.md, scenario 07):
+- Qwen3-32B-4bit on M4 Air: **14 tok/s** sustained (hardware-bound)
+- 14 × 3600 = 50,400 completion tokens/hr → $0.045/hr per provider
+
+**Three SPEC-005 D3 tuning levers** (in order of operational ease):
+1. `Rewards.GlobalMultiplier` — single knob, hot-reloadable
+2. `StatsRollup.UsdPerMillionCredits` — pure USD-conversion factor
+3. Fleet TPS — exogenous; M4 Max / M2 Ultra / M3 Ultra raise the ceiling
+
+## What to produce
+
+### Part 1 — Market comparison (current per-token pricing)
+
+For the model classes macprovider providers actually run today
+(MLX-quantized small-mid open models on Apple Silicon), pull current
+public per-token prices from these surfaces:
+
+- **OpenAI**: gpt-4o-mini, gpt-4.1-mini, gpt-4o
+- **Anthropic**: claude-haiku-4-5, claude-sonnet-4-6
+- **Together.ai**: Qwen2.5-Coder-7B / Qwen2.5-32B / Qwen3-32B (closest match)
+- **OpenRouter**: same Qwen family + Llama-3-8B / Llama-3.1-8B-Instruct
+- **Groq**: Llama-3.1-8B, Llama-3.3-70B (if listed)
+- **Replicate / Fireworks / DeepInfra**: same Qwen / Llama tier
+- **Local-only baseline**: cost of running Ollama / LM Studio yourself
+  (electricity-only, no margin)
+
+For each, report `$/1M prompt` and `$/1M completion` and convert to
+$/1k completion. Build a table sorted by completion price ascending.
+
+**Then add the macprovider current default to the table** so the gap
+is visible at a glance.
+
+### Part 2 — Provider electricity floor
+
+For the two Apple Silicon SKUs we have data for, compute the
+electricity break-even rate:
+
+- M4 Air (active): ~12-15W under MLX load
+- M4 Max / M2 Ultra (estimated): ~60-100W under MLX load
+
+At US residential ~$0.16/kWh, what $/hr does each tier need to earn to
+break even on electricity alone? Use those numbers as the absolute
+floor — anything below loses money even before opportunity cost.
+
+### Part 3 — Sensitivity table
+
+For each combination of {GlobalMultiplier ∈ [1, 5, 10, 25, 50, 100]} ×
+{sustained TPS ∈ [14, 30, 60, 120]}, compute:
+- provider $/hr earnings
+- gateway $/hr revenue (the 10% buyer-side share)
+- buyer $/1M completion tokens (what they pay) — compare against the
+  market table from Part 1
+
+Highlight the cells where:
+- provider clears electricity floor for M4 Air
+- provider clears B6 bare-min ($0.30/hr)
+- provider clears B6 target ($1.00/hr)
+- buyer price stays competitive vs Together.ai / OpenRouter for
+  comparable Qwen tier
+
+### Part 4 — Beta-campaign pricing recommendation
+
+Pick ONE of the following postures and justify it with the data above:
+
+**Posture A — provider-subsidized bootstrap.** Set multiplier high
+enough that even M4 Air clears $0.30/hr at 14 tok/s. Accept that buyer
+price will be above-market. Bet: attract providers first, fix buyer
+side once fleet TPS scales.
+
+**Posture B — buyer-competitive.** Set multiplier so buyer $/1M
+completion sits at parity with cheapest market tier (likely
+OpenRouter/Together for Qwen). Accept that providers earn below floor
+on M4 Air; bet that they upgrade hardware or accept it as donation /
+network-equity stake.
+
+**Posture C — explicit defer.** Keep current placeholders. Document
+trigger criteria for when to revisit (e.g. "when fleet sustained p50
+TPS ≥ 30 tok/s" or "when buyer count > 10" or "when we have ≥ 1 paying
+buyer").
+
+**Posture D — split rate card.** Two model classes: "premium" (large
+models, higher TPS hardware) priced near market; "donor" (small models
+on entry-level hardware) priced as effective give-away. Bet: lets
+M4 Air providers join without distorting buyer-facing economics.
+
+If none of A-D fits, propose your own. Be concrete: name the new
+GlobalMultiplier value (or new UsdPerMillionCredits), show the
+resulting cells in the Part 3 table, and state who pays the gap.
+
+### Part 5 — DECISION_CRITERIA.md entry (ready to commit)
+
+Drop a numbered entry suitable for appending to `beta/DECISION_CRITERIA.md`.
+House style is established through Entries 1-21. The entry must contain:
+
+- **Decision** — what changed and to what value(s)
+- **Why** — market data + sensitivity table cell that backs it
+- **Effective** — when does the new rate go live (next deploy? next
+  beta cohort?)
+- **Re-trigger** — what observable condition would force a revisit
+- **Owner** — operator (default)
+
+### Part 6 — Implementation pointer (optional)
+
+If the recommendation is to change defaults, point at the exact lines:
+- `phase4-coordinator/internal/config/config.go:543` (GlobalMultiplier)
+- `phase4-coordinator/internal/config/config.go:548-549` (rate-card)
+- `phase4-coordinator/internal/config/config.go:138` (UsdPerMillionCredits)
+- Live operator config: `/opt/macprovider/coordinator.yaml` on Pearl VPS
+
+Note whether the change is hot-reloadable or requires a coordinator
+restart, and whether SPEC-NETWORK-BENCHMARK-v0.1 §3.3 thresholds need
+to be updated to match the new economics.
+
+## Out of scope
+
+- Real USD payouts (separate payment-rail work, not blocking pricing)
+- Token issuance / treasury / equity mechanics
+- Changing the credit arithmetic model itself (SPEC-005 D3 is locked)
+- Refactoring the rate-card schema
+
+## Output format
+
+Markdown memo, ~400-800 lines. Tables for Parts 1 + 3. Plain prose
+for Parts 2 + 4. Code block for Part 5. Cite every market price with
+the source URL you pulled it from and the date — these change weekly.
+
+## Final prompt
+
+# RESEARCH PROMPT — Issue #222 beta-campaign pricing decision
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_222_PRICING_PROMPT.md)"`
+
+This is a **strategy research prompt**, not a code-audit prompt. No
+3-lane discipline required. Single codex call (or run twice with
+different models to cross-check); the output is a recommendation memo,
+not a diff.
+
+---
+
+## Task
+
+Decide pricing for the macprovider **beta campaign**. Today's defaults
+are placeholders inherited from SPEC-005 D3 — never re-tuned with live
+data. Issue #222 quantified the gap: providers earn **~$0.045/hr** at
+default rates × current M-series sustained TPS, which is below the v0.1
+B6 bare-min ($0.30/hr) and ~22× under the $1.00/hr target. The network
+is **not provider-viable** at current settings.
+
+Recommend a concrete rate change (or explicit defer with re-trigger
+criteria), backed by market data and a sensitivity analysis. End with a
+DECISION_CRITERIA.md entry ready to commit.
+
+## Background — current state (verbatim from code/issue/baseline)
+
+**Rate-card defaults** (`phase4-coordinator/internal/config/config.go:548-549`):
+- `PromptCreditsPerMtok: 500_000`
+- `CompletionCreditsPerMtok: 1_000_000`
+- `Rewards.GlobalMultiplier: 1.0` (line ~543)
+- `Rewards.ProviderShare: 0.90`
+- `StatsRollup.UsdPerMillionCredits: 1.0` (`$1` per Mcredit)
+
+**Per 1000 completion tokens math:**
+- gross_credits = 1000 × 1_000_000 / 1_000_000 = 1000 credits
+- provider_credits = 1000 × 0.90 = 900 credits
+- USD = 900 × $1.0 / 1_000_000 = **$0.0009 per 1k completion tokens**
+
+**Observed sustained TPS** (BENCHMARK_BASELINE_2026-06-29.md, scenario 07):
+- Qwen3-32B-4bit on M4 Air: **14 tok/s** sustained (hardware-bound)
+- 14 × 3600 = 50,400 completion tokens/hr → $0.045/hr per provider
+
+**Three SPEC-005 D3 tuning levers** (in order of operational ease):
+1. `Rewards.GlobalMultiplier` — single knob, hot-reloadable
+2. `StatsRollup.UsdPerMillionCredits` — pure USD-conversion factor
+3. Fleet TPS — exogenous; M4 Max / M2 Ultra / M3 Ultra raise the ceiling
+
+## What to produce
+
+### Part 1 — Market comparison (current per-token pricing)
+
+For the model classes macprovider providers actually run today
+(MLX-quantized small-mid open models on Apple Silicon), pull current
+public per-token prices from these surfaces:
+
+- **OpenAI**: gpt-4o-mini, gpt-4.1-mini, gpt-4o
+- **Anthropic**: claude-haiku-4-5, claude-sonnet-4-6
+- **Together.ai**: Qwen2.5-Coder-7B / Qwen2.5-32B / Qwen3-32B (closest match)
+- **OpenRouter**: same Qwen family + Llama-3-8B / Llama-3.1-8B-Instruct
+- **Groq**: Llama-3.1-8B, Llama-3.3-70B (if listed)
+- **Replicate / Fireworks / DeepInfra**: same Qwen / Llama tier
+- **Local-only baseline**: cost of running Ollama / LM Studio yourself
+  (electricity-only, no margin)
+
+For each, report `$/1M prompt` and `$/1M completion` and convert to
+$/1k completion. Build a table sorted by completion price ascending.
+
+**Then add the macprovider current default to the table** so the gap
+is visible at a glance.
+
+### Part 2 — Provider electricity floor
+
+For the two Apple Silicon SKUs we have data for, compute the
+electricity break-even rate:
+
+- M4 Air (active): ~12-15W under MLX load
+- M4 Max / M2 Ultra (estimated): ~60-100W under MLX load
+
+At US residential ~$0.16/kWh, what $/hr does each tier need to earn to
+break even on electricity alone? Use those numbers as the absolute
+floor — anything below loses money even before opportunity cost.
+
+### Part 3 — Sensitivity table
+
+For each combination of {GlobalMultiplier ∈ [1, 5, 10, 25, 50, 100]} ×
+{sustained TPS ∈ [14, 30, 60, 120]}, compute:
+- provider $/hr earnings
+- gateway $/hr revenue (the 10% buyer-side share)
+- buyer $/1M completion tokens (what they pay) — compare against the
+  market table from Part 1
+
+Highlight the cells where:
+- provider clears electricity floor for M4 Air
+- provider clears B6 bare-min ($0.30/hr)
+- provider clears B6 target ($1.00/hr)
+- buyer price stays competitive vs Together.ai / OpenRouter for
+  comparable Qwen tier
+
+### Part 4 — Beta-campaign pricing recommendation
+
+Pick ONE of the following postures and justify it with the data above:
+
+**Posture A — provider-subsidized bootstrap.** Set multiplier high
+enough that even M4 Air clears $0.30/hr at 14 tok/s. Accept that buyer
+price will be above-market. Bet: attract providers first, fix buyer
+side once fleet TPS scales.
+
+**Posture B — buyer-competitive.** Set multiplier so buyer $/1M
+completion sits at parity with cheapest market tier (likely
+OpenRouter/Together for Qwen). Accept that providers earn below floor
+on M4 Air; bet that they upgrade hardware or accept it as donation /
+network-equity stake.
+
+**Posture C — explicit defer.** Keep current placeholders. Document
+trigger criteria for when to revisit (e.g. "when fleet sustained p50
+TPS ≥ 30 tok/s" or "when buyer count > 10" or "when we have ≥ 1 paying
+buyer").
+
+**Posture D — split rate card.** Two model classes: "premium" (large
+models, higher TPS hardware) priced near market; "donor" (small models
+on entry-level hardware) priced as effective give-away. Bet: lets
+M4 Air providers join without distorting buyer-facing economics.
+
+If none of A-D fits, propose your own. Be concrete: name the new
+GlobalMultiplier value (or new UsdPerMillionCredits), show the
+resulting cells in the Part 3 table, and state who pays the gap.
+
+### Part 5 — DECISION_CRITERIA.md entry (ready to commit)
+
+Drop a numbered entry suitable for appending to `beta/DECISION_CRITERIA.md`.
+House style is established through Entries 1-21. The entry must contain:
+
+- **Decision** — what changed and to what value(s)
+- **Why** — market data + sensitivity table cell that backs it
+- **Effective** — when does the new rate go live (next deploy? next
+  beta cohort?)
+- **Re-trigger** — what observable condition would force a revisit
+- **Owner** — operator (default)
+
+### Part 6 — Implementation pointer (optional)
+
+If the recommendation is to change defaults, point at the exact lines:
+- `phase4-coordinator/internal/config/config.go:543` (GlobalMultiplier)
+- `phase4-coordinator/internal/config/config.go:548-549` (rate-card)
+- `phase4-coordinator/internal/config/config.go:138` (UsdPerMillionCredits)
+- Live operator config: `/opt/macprovider/coordinator.yaml` on Pearl VPS
+
+Note whether the change is hot-reloadable or requires a coordinator
+restart, and whether SPEC-NETWORK-BENCHMARK-v0.1 §3.3 thresholds need
+to be updated to match the new economics.
+
+## Out of scope
+
+- Real USD payouts (separate payment-rail work, not blocking pricing)
+- Token issuance / treasury / equity mechanics
+- Changing the credit arithmetic model itself (SPEC-005 D3 is locked)
+- Refactoring the rate-card schema
+
+## Output format
+
+Markdown memo, ~400-800 lines. Tables for Parts 1 + 3. Plain prose
+for Parts 2 + 4. Code block for Part 5. Cite every market price with
+the source URL you pulled it from and the date — these change weekly.
+
+## Raw output
+
+```text
+**Memo — Issue #222 Beta Pricing**
+
+Date: 2026-06-30  
+Recommendation: **Posture A, set `Rewards.GlobalMultiplier = 10.0` for the next beta cohort.** This makes the current 14 tok/s M4 Air provider clear the B6 bare-min `$0.30/hr` threshold at `$0.454/hr`, but it makes buyer completion pricing `$10/M tokens`, far above comparable Qwen market pricing. The gap is paid by beta buyers unless the operator issues buyer credits or treats beta traffic as subsidized acquisition.
+
+**Part 1 — Market Comparison**
+
+All prices are public list prices retrieved 2026-06-30. `$ / 1k completion` is `completion price / 1000`.
+
+| Rank | Surface / model | $/1M prompt | $/1M completion | $/1k completion | Source |
+|---:|---|---:|---:|---:|---|
+| 1 | OpenRouter Llama 3.1 8B Instruct | 0.02 | 0.03 | 0.00003 | [OpenRouter models API](https://openrouter.ai/api/v1/models) |
+| 2 | Groq Llama 3.1 8B Instant | 0.04 | 0.04 | 0.00004 | [Groq pricing](https://groq.com/pricing/) |
+| 3 | Local-only M4 Air electricity, 12-15W @14 tok/s | n/a | 0.038-0.048 | 0.000038-0.000048 | Prompt power assumptions, `$0.16/kWh` |
+| 4 | DeepInfra Llama 3.1 8B Instruct | 0.03 | 0.05 | 0.00005 | [DeepInfra model page](https://deepinfra.com/meta-llama/Meta-Llama-3.1-8B-Instruct) |
+| 5 | OpenRouter Qwen2.5 7B Instruct | 0.04 | 0.10 | 0.00010 | [OpenRouter models API](https://openrouter.ai/api/v1/models) |
+| 6 | OpenRouter Llama 3 8B Instruct | 0.14 | 0.14 | 0.00014 | [OpenRouter models API](https://openrouter.ai/api/v1/models) |
+| 7 | Fireworks Llama 3.1 8B tier | 0.20 | 0.20 | 0.00020 | [Fireworks pricing/model pages](https://docs.fireworks.ai/serverless/pricing) |
+| 8 | Together Qwen3.5 9B closest Qwen small tier | 0.17 | 0.25 | 0.00025 | [Together pricing](https://www.together.ai/pricing) |
+| 9 | OpenRouter Qwen3 32B | 0.08 | 0.28 | 0.00028 | [OpenRouter models API](https://openrouter.ai/api/v1/models) |
+| 10 | DeepInfra Qwen3 32B | 0.08 | 0.28 | 0.00028 | [DeepInfra Qwen3 32B](https://deepinfra.com/Qwen/Qwen3-32B) |
+| 11 | Together Qwen2.5 7B Turbo | 0.30 | 0.30 | 0.00030 | [Together pricing](https://www.together.ai/pricing) |
+| 12 | DeepInfra Llama 3.3 70B Turbo | 0.10 | 0.32 | 0.00032 | [DeepInfra 70B](https://deepinfra.com/meta-llama/Llama-3.3-70B-Instruct-Turbo) |
+| 13 | OpenRouter Llama 3.3 70B Instruct | 0.10 | 0.32 | 0.00032 | [OpenRouter models API](https://openrouter.ai/api/v1/models) |
+| 14 | OpenAI gpt-4o-mini | 0.15 | 0.60 | 0.00060 | [OpenAI gpt-4o-mini](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/) |
+| 15 | Groq Llama 3.3 70B Versatile | 0.59 | 0.79 | 0.00079 | [Groq pricing](https://groq.com/pricing/) |
+| 16 | Together Qwen2.5-Coder 32B Instruct | 0.80 | 0.80 | 0.00080 | [Together model page](https://www.together.ai/models/qwen-2-5-coder-32b-instruct) |
+| 17 | Fireworks Llama 3.3 70B tier | 0.90 | 0.90 | 0.00090 | [Fireworks pricing/model pages](https://docs.fireworks.ai/serverless/pricing) |
+| 18 | **macprovider current buyer gross** | **0.50** | **1.00** | **0.00100** | [config.go](/Users/augstar/macprovider-poc/phase4-coordinator/internal/config/config.go:544) |
+| 19 | OpenRouter Qwen2.5-Coder 32B Instruct | 0.66 | 1.00 | 0.00100 | [OpenRouter models API](https://openrouter.ai/api/v1/models) |
+| 20 | Together Qwen3.7 Plus closest current Qwen plus tier | 0.32 | 1.28 | 0.00128 | [Together pricing](https://www.together.ai/pricing) |
+| 21 | OpenAI gpt-4.1-mini | 0.40 | 1.60 | 0.00160 | [OpenAI GPT-4.1](https://openai.com/index/gpt-4-1/) |
+| 22 | Anthropic Claude Haiku 4.5 | 1.00 | 5.00 | 0.00500 | [Claude models overview](https://docs.claude.com/en/docs/about-claude/models/overview) |
+| 23 | Replicate L40S GPU-second baseline, converted @120 tok/s | n/a | 8.13 | 0.00813 | [Replicate pricing](https://replicate.com/pricing) |
+| 24 | OpenAI gpt-4o | 2.50 | 10.00 | 0.01000 | [OpenAI pricing](https://platform.openai.com/docs/pricing) |
+| 25 | Anthropic Claude Sonnet 4.6 | 3.00 | 15.00 | 0.01500 | [Claude models overview](https://docs.claude.com/en/docs/about-claude/models/overview) |
+
+Key read: **macprovider current buyer gross price is already above the cheapest comparable Qwen3 32B market rows** (`$1.00/M` vs `$0.28/M`). The provider problem is not that buyers are undercharged relative to the cheapest market; it is that 14 tok/s is too slow for `$0.90/M provider-net` to produce hourly earnings.
+
+**Part 2 — Provider Electricity Floor**
+
+At `$0.16/kWh`:
+
+| Hardware tier | Load watts | Electricity $/hr | Comment |
+|---|---:|---:|---|
+| M4 Air active MLX load | 12-15W | `$0.0019-$0.0024/hr` | Current `$0.045/hr` clears electricity by ~19x. |
+| M4 Max / M2 Ultra estimate | 60-100W | `$0.0096-$0.0160/hr` | Still tiny versus B6; opportunity cost dominates. |
+
+Electricity is not the binding constraint. The binding constraints are provider opportunity cost and beta-recruiting optics. B6 `$0.30/hr` is a bare-min human incentive, not an energy break-even.
+
+**Part 3 — Sensitivity Table**
+
+Formula with today’s credit arithmetic:
+
+`provider $/hr = TPS * 3600 / 1e6 * 0.90 * GlobalMultiplier`  
+`gateway $/hr = TPS * 3600 / 1e6 * 0.10 * GlobalMultiplier`  
+`buyer $/1M completion = $1.00 * GlobalMultiplier`
+
+Flags: `elec` clears M4 Air electricity high-end floor; `B6-min` clears `$0.30/hr`; `B6-target` clears `$1.00/hr`; `market-ish` means buyer price remains near Together Qwen3.7 Plus `$1.28/M`, not the cheapest OpenRouter/DeepInfra Qwen3-32B `$0.28/M`.
+
+| Multiplier | TPS | Provider $/hr | Gateway $/hr | Buyer $/1M completion | Flags |
+|---:|---:|---:|---:|---:|---|
+| 1 | 14 | $0.045 | $0.005 | $1.00 | elec, market-ish |
+| 1 | 30 | $0.097 | $0.011 | $1.00 | elec, market-ish |
+| 1 | 60 | $0.194 | $0.022 | $1.00 | elec, market-ish |
+| 1 | 120 | $0.389 | $0.043 | $1.00 | elec, B6-min, market-ish |
+| 5 | 14 | $0.227 | $0.025 | $5.00 | elec |
+| 5 | 30 | $0.486 | $0.054 | $5.00 | elec, B6-min |
+| 5 | 60 | $0.972 | $0.108 | $5.00 | elec, B6-min |
+| 5 | 120 | $1.944 | $0.216 | $5.00 | elec, B6-min, B6-target |
+| 10 | 14 | $0.454 | $0.050 | $10.00 | elec, B6-min |
+| 10 | 30 | $0.972 | $0.108 | $10.00 | elec, B6-min |
+| 10 | 60 | $1.944 | $0.216 | $10.00 | elec, B6-min, B6-target |
+| 10 | 120 | $3.888 | $0.432 | $10.00 | elec, B6-min, B6-target |
+| 25 | 14 | $1.134 | $0.126 | $25.00 | elec, B6-min, B6-target |
+| 25 | 30 | $2.430 | $0.270 | $25.00 | elec, B6-min, B6-target |
+| 25 | 60 | $4.860 | $0.540 | $25.00 | elec, B6-min, B6-target |
+| 25 | 120 | $9.720 | $1.080 | $25.00 | elec, B6-min, B6-target |
+| 50 | 14 | $2.268 | $0.252 | $50.00 | elec, B6-min, B6-target |
+| 50 | 30 | $4.860 | $0.540 | $50.00 | elec, B6-min, B6-target |
+| 50 | 60 | $9.720 | $1.080 | $50.00 | elec, B6-min, B6-target |
+| 50 | 120 | $19.440 | $2.160 | $50.00 | elec, B6-min, B6-target |
+| 100 | 14 | $4.536 | $0.504 | $100.00 | elec, B6-min, B6-target |
+| 100 | 30 | $9.720 | $1.080 | $100.00 | elec, B6-min, B6-target |
+| 100 | 60 | $19.440 | $2.160 | $100.00 | elec, B6-min, B6-target |
+| 100 | 120 | $38.880 | $4.320 | $100.00 | elec, B6-min, B6-target |
+
+There is no multiplier in `[1, 5, 10, 25, 50, 100]` that is both cheap-Qwen competitive and M4-Air B6 viable. Strict parity with OpenRouter/DeepInfra Qwen3-32B (`$0.28/M`) would require `GlobalMultiplier ~= 0.28`, which drops the M4 Air provider to about `$0.013/hr`.
+
+**Part 4 — Recommendation**
+
+Pick **Posture A — provider-subsidized bootstrap**, but cap it at the B6 bare-min, not the `$1/hr` target.
+
+Set:
+
+```yaml
+rewards:
+  global_multiplier: 10.0
+```
+
+Do **not** change `UsdPerMillionCredits` for this decision. `GlobalMultiplier` is the intended pricing knob; it snapshots into billing rows and preserves the existing credit-to-USD reporting convention.
+
+Why `10.0`:
+
+- It moves the known M4 Air/Qwen3-32B cell from `$0.045/hr` to `$0.454/hr`.
+- It clears B6 bare-min at the current worst observed sustained TPS.
+- It nearly reaches B6 target at 30 tok/s (`$0.972/hr`) and clears target from 60 tok/s up.
+- It avoids the worse optics of `25.0`, which would clear `$1/hr` on M4 Air but produce `$25/M` buyer completion pricing.
+
+Who pays: the buyer-side price becomes `$10/M completion tokens`. That is **~36x** OpenRouter/DeepInfra Qwen3-32B (`$0.28/M`) and **12.5x** Together Qwen2.5-Coder-32B (`$0.80/M`). For beta, this only makes sense if the operator either limits paid buyer exposure, issues beta credits, or frames this as a provider-supply bootstrap campaign rather than a buyer-cost campaign.
+
+Re-trigger:
+
+- Fleet sustained p50 reaches `>= 60 tok/s` for the Qwen 30B-ish class.
+- There is `>= 1` real paying buyer comparing invoices against Together/OpenRouter.
+- Beta buyer completion volume exceeds `10M tokens/week`.
+- Provider churn remains high even with `$0.30/hr+` projected earnings.
+- A per-model/per-hardware split rate card becomes necessary to avoid pricing donor 7B traffic like premium 32B traffic.
+
+**Part 5 — Decision Log Entry**
+
+```markdown
+| 2026-06-30 | **Entry 92 — Issue #222 beta-campaign pricing: current defaults are provider-nonviable at live M-series TPS.** Market check retrieved 2026-06-30 shows cheapest comparable Qwen3-32B completion pricing at **$0.28/M** on OpenRouter/DeepInfra, Together Qwen2.5-Coder-32B at **$0.80/M**, and macprovider current buyer gross at **$1.00/M** while provider-net is only **$0.90/M**. With BENCHMARK_BASELINE_2026-06-29 scenario 07 sustained **14 tok/s**, current provider earnings are **$0.045/hr**, below B6 bare-min **$0.30/hr** and far below target **$1.00/hr**. Electricity is not binding: M4 Air 12-15W at $0.16/kWh is only **$0.0019-$0.0024/hr**. | **Decision:** adopt provider-subsidized bootstrap pricing for the beta campaign by setting `rewards.global_multiplier: 10.0` for the next beta cohort / next Pearl coordinator pricing deploy. Keep `stats_rollup.usd_per_million_credits: 1.0`, `provider_share: 0.90`, and the default rate-card shape unchanged. **Why:** the 14 tok/s × multiplier 10 cell yields **$0.454/hr provider earnings**, clearing B6 bare-min without jumping to the `$25/M` buyer price required for B6 target on M4 Air. Buyer completion price becomes **$10/M**, explicitly above-market; the operator/beta buyer side pays that bootstrap gap until fleet TPS improves. **Effective:** next coordinator deploy or live config reload before onboarding the next beta provider cohort. **Re-trigger:** revisit immediately when fleet sustained p50 for Qwen 30B-ish class is ≥60 tok/s, when there is ≥1 real paying buyer, when beta buyer completion volume exceeds 10M tokens/week, when provider churn persists despite projected ≥$0.30/hr, or when per-model split pricing is needed. **Owner:** operator. | **Phase 5 / benchmark implication:** B6 can remain `$0.30/hr` bare-min and `$1.00/hr` target, but `BENCHMARK_PRICING_v0.1.json` must be re-derived after the config change. SPEC-NETWORK-BENCHMARK-v0.1 §3.3 thresholds do not need to move; expected B6 verdict changes from FAIL to PASS-bare-min for 14 tok/s providers under multiplier 10. |
+```
+
+**Part 6 — Implementation Pointer**
+
+Change live config first:
+
+- Pearl VPS: `/opt/macprovider/coordinator.yaml`
+- Set `rewards.global_multiplier: 10.0`
+- Send `SIGHUP` to the coordinator. The reload path loads config, writes a billing snapshot, and applies `SetBillingConfig` for new requests at [main.go](/Users/augstar/macprovider-poc/phase4-coordinator/cmd/coordinator/main.go:908).
+
+Code defaults if you want the repo default to match:
+
+- `Rewards.GlobalMultiplier` at [config.go](/Users/augstar/macprovider-poc/phase4-coordinator/internal/config/config.go:544)
+- Rate-card defaults at [config.go](/Users/augstar/macprovider-poc/phase4-coordinator/internal/config/config.go:548)
+- `UsdPerMillionCredits` field at [config.go](/Users/augstar/macprovider-poc/phase4-coordinator/internal/config/config.go:138)
+
+No repo files were changed in this research pass.
+
+
+```

--- a/specs/RESEARCH_222_PRICING_PROMPT.md
+++ b/specs/RESEARCH_222_PRICING_PROMPT.md
@@ -1,0 +1,163 @@
+# RESEARCH PROMPT — Issue #222 beta-campaign pricing decision
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_222_PRICING_PROMPT.md)"`
+
+This is a **strategy research prompt**, not a code-audit prompt. No
+3-lane discipline required. Single codex call (or run twice with
+different models to cross-check); the output is a recommendation memo,
+not a diff.
+
+---
+
+## Task
+
+Decide pricing for the macprovider **beta campaign**. Today's defaults
+are placeholders inherited from SPEC-005 D3 — never re-tuned with live
+data. Issue #222 quantified the gap: providers earn **~$0.045/hr** at
+default rates × current M-series sustained TPS, which is below the v0.1
+B6 bare-min ($0.30/hr) and ~22× under the $1.00/hr target. The network
+is **not provider-viable** at current settings.
+
+Recommend a concrete rate change (or explicit defer with re-trigger
+criteria), backed by market data and a sensitivity analysis. End with a
+DECISION_CRITERIA.md entry ready to commit.
+
+## Background — current state (verbatim from code/issue/baseline)
+
+**Rate-card defaults** (`phase4-coordinator/internal/config/config.go:548-549`):
+- `PromptCreditsPerMtok: 500_000`
+- `CompletionCreditsPerMtok: 1_000_000`
+- `Rewards.GlobalMultiplier: 1.0` (line ~543)
+- `Rewards.ProviderShare: 0.90`
+- `StatsRollup.UsdPerMillionCredits: 1.0` (`$1` per Mcredit)
+
+**Per 1000 completion tokens math:**
+- gross_credits = 1000 × 1_000_000 / 1_000_000 = 1000 credits
+- provider_credits = 1000 × 0.90 = 900 credits
+- USD = 900 × $1.0 / 1_000_000 = **$0.0009 per 1k completion tokens**
+
+**Observed sustained TPS** (BENCHMARK_BASELINE_2026-06-29.md, scenario 07):
+- Qwen3-32B-4bit on M4 Air: **14 tok/s** sustained (hardware-bound)
+- 14 × 3600 = 50,400 completion tokens/hr → $0.045/hr per provider
+
+**Three SPEC-005 D3 tuning levers** (in order of operational ease):
+1. `Rewards.GlobalMultiplier` — single knob, hot-reloadable
+2. `StatsRollup.UsdPerMillionCredits` — pure USD-conversion factor
+3. Fleet TPS — exogenous; M4 Max / M2 Ultra / M3 Ultra raise the ceiling
+
+## What to produce
+
+### Part 1 — Market comparison (current per-token pricing)
+
+For the model classes macprovider providers actually run today
+(MLX-quantized small-mid open models on Apple Silicon), pull current
+public per-token prices from these surfaces:
+
+- **OpenAI**: gpt-4o-mini, gpt-4.1-mini, gpt-4o
+- **Anthropic**: claude-haiku-4-5, claude-sonnet-4-6
+- **Together.ai**: Qwen2.5-Coder-7B / Qwen2.5-32B / Qwen3-32B (closest match)
+- **OpenRouter**: same Qwen family + Llama-3-8B / Llama-3.1-8B-Instruct
+- **Groq**: Llama-3.1-8B, Llama-3.3-70B (if listed)
+- **Replicate / Fireworks / DeepInfra**: same Qwen / Llama tier
+- **Local-only baseline**: cost of running Ollama / LM Studio yourself
+  (electricity-only, no margin)
+
+For each, report `$/1M prompt` and `$/1M completion` and convert to
+$/1k completion. Build a table sorted by completion price ascending.
+
+**Then add the macprovider current default to the table** so the gap
+is visible at a glance.
+
+### Part 2 — Provider electricity floor
+
+For the two Apple Silicon SKUs we have data for, compute the
+electricity break-even rate:
+
+- M4 Air (active): ~12-15W under MLX load
+- M4 Max / M2 Ultra (estimated): ~60-100W under MLX load
+
+At US residential ~$0.16/kWh, what $/hr does each tier need to earn to
+break even on electricity alone? Use those numbers as the absolute
+floor — anything below loses money even before opportunity cost.
+
+### Part 3 — Sensitivity table
+
+For each combination of {GlobalMultiplier ∈ [1, 5, 10, 25, 50, 100]} ×
+{sustained TPS ∈ [14, 30, 60, 120]}, compute:
+- provider $/hr earnings
+- gateway $/hr revenue (the 10% buyer-side share)
+- buyer $/1M completion tokens (what they pay) — compare against the
+  market table from Part 1
+
+Highlight the cells where:
+- provider clears electricity floor for M4 Air
+- provider clears B6 bare-min ($0.30/hr)
+- provider clears B6 target ($1.00/hr)
+- buyer price stays competitive vs Together.ai / OpenRouter for
+  comparable Qwen tier
+
+### Part 4 — Beta-campaign pricing recommendation
+
+Pick ONE of the following postures and justify it with the data above:
+
+**Posture A — provider-subsidized bootstrap.** Set multiplier high
+enough that even M4 Air clears $0.30/hr at 14 tok/s. Accept that buyer
+price will be above-market. Bet: attract providers first, fix buyer
+side once fleet TPS scales.
+
+**Posture B — buyer-competitive.** Set multiplier so buyer $/1M
+completion sits at parity with cheapest market tier (likely
+OpenRouter/Together for Qwen). Accept that providers earn below floor
+on M4 Air; bet that they upgrade hardware or accept it as donation /
+network-equity stake.
+
+**Posture C — explicit defer.** Keep current placeholders. Document
+trigger criteria for when to revisit (e.g. "when fleet sustained p50
+TPS ≥ 30 tok/s" or "when buyer count > 10" or "when we have ≥ 1 paying
+buyer").
+
+**Posture D — split rate card.** Two model classes: "premium" (large
+models, higher TPS hardware) priced near market; "donor" (small models
+on entry-level hardware) priced as effective give-away. Bet: lets
+M4 Air providers join without distorting buyer-facing economics.
+
+If none of A-D fits, propose your own. Be concrete: name the new
+GlobalMultiplier value (or new UsdPerMillionCredits), show the
+resulting cells in the Part 3 table, and state who pays the gap.
+
+### Part 5 — DECISION_CRITERIA.md entry (ready to commit)
+
+Drop a numbered entry suitable for appending to `beta/DECISION_CRITERIA.md`.
+House style is established through Entries 1-21. The entry must contain:
+
+- **Decision** — what changed and to what value(s)
+- **Why** — market data + sensitivity table cell that backs it
+- **Effective** — when does the new rate go live (next deploy? next
+  beta cohort?)
+- **Re-trigger** — what observable condition would force a revisit
+- **Owner** — operator (default)
+
+### Part 6 — Implementation pointer (optional)
+
+If the recommendation is to change defaults, point at the exact lines:
+- `phase4-coordinator/internal/config/config.go:543` (GlobalMultiplier)
+- `phase4-coordinator/internal/config/config.go:548-549` (rate-card)
+- `phase4-coordinator/internal/config/config.go:138` (UsdPerMillionCredits)
+- Live operator config: `/opt/macprovider/coordinator.yaml` on Pearl VPS
+
+Note whether the change is hot-reloadable or requires a coordinator
+restart, and whether SPEC-NETWORK-BENCHMARK-v0.1 §3.3 thresholds need
+to be updated to match the new economics.
+
+## Out of scope
+
+- Real USD payouts (separate payment-rail work, not blocking pricing)
+- Token issuance / treasury / equity mechanics
+- Changing the credit arithmetic model itself (SPEC-005 D3 is locked)
+- Refactoring the rate-card schema
+
+## Output format
+
+Markdown memo, ~400-800 lines. Tables for Parts 1 + 3. Plain prose
+for Parts 2 + 4. Code block for Part 5. Cite every market price with
+the source URL you pulled it from and the date — these change weekly.

--- a/specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_MEMO.md
+++ b/specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_MEMO.md
@@ -1,0 +1,619 @@
+# codex advisor artifact
+
+- Provider: codex
+- Exit code: 0
+- Created at: 2026-06-30T05:30:14.324Z
+
+## Original task
+
+# RESEARCH PROMPT — MLX continuous-batching / speculative-decoding state of the art and 12-month engineering roadmap
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_PROMPT.md)"`
+
+This is a **technical research prompt**, not a code-audit prompt. Single
+codex call (or twice with different models). Output is a roadmap memo,
+not a diff. Pair-track of [RESEARCH_224_PRICING_V2_PROMPT.md] —
+pricing v2 depends on whether the per-cell tok/s targets here are
+believable inside 6-12 months.
+
+---
+
+## Task
+
+Macprovider providers run MLX-quantized LLMs on Apple Silicon and
+compete on $/M-token pricing against datacenter GPU providers
+(OpenRouter, Together, DeepInfra, Groq). Current single-stream
+throughput is structurally ~10-50× behind H100/H200 batched inference
+due to (a) memory bandwidth ceiling, (b) lack of mature continuous
+batching on MLX, (c) tiny KV-cache budget on consumer Apple Silicon.
+
+Audit the **actual** state of the art for high-throughput LLM serving
+on Apple Silicon as of 2026-06-30 and produce a **12-month engineering
+roadmap with concrete realistic sustained tok/s targets per
+(hardware, model-class, software-config) cell**.
+
+The output feeds two downstream decisions:
+1. Which hardware tiers the network should accept as providers
+2. Which model classes each tier is routed to
+3. Whether per-tier USD economics ever close, or whether token issuance
+   is the only viable subsidy mechanism
+
+---
+
+## Background — current state (verbatim)
+
+**Observed bench** (`BENCHMARK_BASELINE_2026-06-29.md` scenario 07):
+- Qwen3-32B-4bit on M4 Air sustains **14 tok/s**, single stream
+- (Theoretical memory-bandwidth-bound peak is ~6-7 tok/s — the
+  observed 14 is suspicious; investigate whether the bench is using a
+  smaller-than-32B variant, lower quantization, or some pipelining
+  trick)
+
+**Provider runtime stack**:
+- Swift CLI in `phase3-binary/Sources/macprovider-cli/`
+- Shells out to MLX via Python sidecar (current shape — confirm path)
+- Coordinator: `phase4-coordinator/` admission control + billing
+- Gateway: OpenAI-compat API, streaming
+
+**Hardware fleet today** (rough — confirm against network telemetry
+if available):
+- Predominantly M4 Air providers
+- Small number of M4 Max + M2 Ultra
+- No M3 Ultra yet
+
+**Theoretical memory-bandwidth ceilings for 32B-4bit (~18GB)**:
+| Hardware | Bandwidth | Peak single-stream tok/s |
+|---|---:|---:|
+| M4 Air | ~120 GB/s | ~6-7 |
+| M4 Max | ~410 GB/s | ~22 |
+| M2 Ultra | ~800 GB/s | ~44 |
+| M3 Ultra | ~800 GB/s | ~44 |
+| H100 | ~3,350 GB/s | ~180 |
+| H200 | ~4,800 GB/s | ~265 |
+
+---
+
+## What to produce
+
+### Part 1 — State-of-the-art audit
+
+For each subsystem below, report: what exists, license, maturity, who
+maintains it, last release/commit date, production-readiness for a
+real provider runtime serving paying buyers. Cite GitHub URLs and
+exact commits/releases.
+
+**1.1 Continuous batching / PagedAttention equivalents on Apple Silicon**
+- `mlx-lm`, `mlx-server`, `mlx-omni-server`
+- LM Studio's local API server (closed-source but observable)
+- Ollama on Apple Silicon (concurrency model, default `OLLAMA_NUM_PARALLEL`)
+- llama.cpp `--parallel` + `--cont-batching` (Metal backend)
+- `mlx-vlm`, `mlx-graphs` research repos
+- Anything resembling vLLM's PagedAttention with KV-cache paging on MLX
+- Production systems known to serve ≥5 concurrent streams of a 32B-class
+  model on Apple Silicon at sustained throughput
+
+**1.2 Speculative decoding on Apple Silicon**
+- `mlx-lm` speculative-decoding (draft-model selection, measured
+  speedups on M-series)
+- llama.cpp speculative support
+- EAGLE / Medusa / Lookahead decoding — any MLX ports
+- Self-speculative variants (no separate draft model)
+
+**1.3 Quantization frontier**
+- 4-bit baseline (current): MLX `Q4`, GGUF `Q4_K_M`
+- 3-bit: MLX 3-bit, AWQ-3, GGUF `Q3_K_S`
+- 2-bit: GGUF `IQ2_XXS`, AQLM
+- K-quants / mixed-precision (attention 4-bit, MLP 2-bit)
+- Measured quality degradation vs throughput gain on
+  Qwen3-32B / Llama-3.1-8B / Llama-3.3-70B
+
+**1.4 Kernel-level optimizations**
+- MLX kernel roadmap (Apple's stated improvements, recent merged PRs,
+  release cadence)
+- AMX matrix unit utilization in MLX vs llama.cpp
+- Apple Neural Engine (ANE) — anyone serving transformer decode via
+  ANE+CoreML in production
+- Metal Performance Shaders fused attention (FlashAttention-equivalent
+  on Apple)
+
+**1.5 Architectural alternatives**
+- MoE on Apple Silicon (Mixtral 8x7B, Qwen3-MoE) — does activated-
+  params bandwidth win on M-Ultra?
+- State-space models (Mamba-2) on MLX
+- Smaller models with better quality (Qwen3-7B full-precision vs
+  Qwen3-32B-4bit) — is this just better per-token TCO?
+
+### Part 2 — Realistic per-cell tok/s targets
+
+Build this matrix with **realistic sustained tok/s** (single-stream and
+max-concurrent under the best in-tree software stack), dated **today**,
+**6 months out**, and **12 months out** from 2026-06-30. Each cell must
+cite the software config assumed (engine, speculative on/off,
+quantization, concurrent batching level).
+
+| Hardware | Model class | Today S | Today C | 6mo S | 6mo C | 12mo S | 12mo C |
+|---|---|---|---|---|---|---|---|
+| M4 Air 16GB | 7-8B (Llama-3.1-8B, Qwen3-7B) | | | | | | |
+| M4 Air 24GB | 7-8B | | | | | | |
+| M4 Air 24GB | 32B-4bit (Qwen3-32B) | | | | | | |
+| M4 Pro 24GB | 7-8B | | | | | | |
+| M4 Pro 48GB | 32B-4bit | | | | | | |
+| M4 Max 64GB | 7-8B | | | | | | |
+| M4 Max 64GB | 32B-4bit | | | | | | |
+| M4 Max 128GB | 70B-4bit (Llama-3.3-70B) | | | | | | |
+| M2 Ultra 128GB | 32B-4bit | | | | | | |
+| M2 Ultra 192GB | 70B-4bit | | | | | | |
+| M3 Ultra 256GB | 32B-4bit | | | | | | |
+| M3 Ultra 256GB | 70B-4bit | | | | | | |
+
+Then add reference rows: **H100 single-stream and batched (32 streams)**
+for the same model classes, so the gap is visible at a glance.
+
+Be explicit about which numbers come from **published benchmarks**
+(cite URL) vs **vendor claims** vs **extrapolation from bandwidth
+ceiling**. Flag aspirational targets that assume software not yet
+released.
+
+### Part 3 — Engineering bets ranked by ROI
+
+Rank each candidate engineering bet by **expected effective-throughput
+multiplier per engineer-month invested**. Candidates:
+
+- MLX continuous-batching contribution (PR to `mlx-lm`)
+- MLX PagedAttention port
+- Speculative-decoding integration into provider runtime
+- 3-bit MLX quantization adoption (provider-side model conversion)
+- ANE backend for decode (CoreML path)
+- MoE model support
+- llama.cpp `--parallel` swap-in as runtime alternative
+- Custom Metal kernel work (FlashAttention fork)
+- Hardware-tier-aware draft-model selection
+- Prefix-cache reuse across requests
+
+For each: engineer-month cost (point estimate + range), expected
+throughput multiplier (per stream AND per machine), risk / probability
+of success, external dependencies (Apple ships X, upstream OSS
+releases Y), which hardware tiers benefit.
+
+Highlight bets that hit **>2× effective per-machine throughput in
+<3 engineer-months at <30% risk**.
+
+### Part 4 — 12-month roadmap recommendation
+
+Pick **ONE** of:
+
+**Roadmap A — Buy the gap (hardware focus).** Stop optimizing M4 Air.
+Recruit M4 Max / M-Ultra owners. Engineering = match continuous-
+batching maturity on the high-bandwidth tier where it actually pays.
+
+**Roadmap B — Software arbitrage (engineering focus).** Bet MLX
+continuous batching + spec decode lands in 12 months and we are first
+to expose it productized. Heavy investment in `mlx-server` / `mlx-lm`
+upstream. Keep M4 Air on the network but route only 7-8B traffic.
+
+**Roadmap C — Model-class specialization.** Don't serve 32B on M4 Air
+at all. Build the network around (a) small-fast models on entry Apple
+Silicon, (b) 70B-class on Ultra. Skip the structurally broken
+32B-on-laptop cell.
+
+**Roadmap D — Hybrid.** Software wins on M-Ultra + model-class routing
+on M4 Air. Specify allocation, milestones, hardware spend.
+
+If none fit, propose your own. Be concrete: name the GitHub repos and
+PRs to contribute, hardware acquisition spend, per-quarter milestones,
+go/no-go gates.
+
+### Part 5 — Pricing-table implications (feeds RESEARCH_224)
+
+For each cell in the Part 2 matrix at the **12-month** column, compute
+**provider USD $/hr** at three pricing scenarios:
+
+| Scenario | Multiplier | UsdPerMcredit | Buyer $/M comp |
+|---|---:|---:|---:|
+| Current default | 1.0 | 1.0 | $1.00 |
+| Buyer-competitive (undercut OpenRouter Qwen3-32B $0.28/M) | 0.25 | 1.0 | $0.25 |
+| Buyer-competitive vs Groq 8B ($0.04/M) | 0.04 | 1.0 | $0.04 |
+
+For each (hardware, model-class) cell at 12-month TPS targets,
+highlight which cells clear electricity floor and which clear B6
+bare-min ($0.30/hr) under each pricing scenario. Use realistic
+sustained TPS, not peak.
+
+This is the bridge to the pricing decision: it tells us which hardware
+tiers can ever be USD-viable at market-competitive buyer prices.
+
+### Part 6 — Open questions and follow-up benchmarks
+
+List 5-10 specific things to measure on real hardware to validate the
+roadmap. Examples:
+- Benchmark `mlx-lm` speculative decode with Qwen3-0.5B drafting
+  Qwen3-32B on M4 Air; measure tok/s and draft-acceptance rate
+- Run llama.cpp `--parallel 4 --cont-batching` on M4 Max with
+  Qwen3-32B-Q4_K_M; measure aggregate tok/s and per-stream tok/s
+- Measure KV-cache memory under 4 concurrent 4K-context streams vs
+  available headroom on a 24GB M4 Air
+
+For each, name the bench scenario id to add to
+`BENCHMARK_BASELINE_*.md` and the expected ranges to falsify/confirm.
+
+---
+
+## Out of scope
+
+- Buyer-side USD pricing (covered in RESEARCH_224)
+- Crypto token issuance design (covered in RESEARCH_224)
+- Coordinator / gateway code changes (memo-only research)
+- New SPEC documents (this produces a memo, not normative SPEC)
+- Apple Silicon training (we serve inference only)
+
+## Output format
+
+Markdown memo, **~600-1000 lines**. Tables for Parts 1, 2, 3, 5. Prose
+for Part 4. Cite every claim about library state with the **GitHub
+URL, commit/release date, and what you observed** (issue thread,
+README, benchmark blog post). Flag aspirational vendor claims vs
+measured benchmarks explicitly. Conservative > optimistic — this
+roadmap feeds money decisions.
+
+## Final prompt
+
+# RESEARCH PROMPT — MLX continuous-batching / speculative-decoding state of the art and 12-month engineering roadmap
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_PROMPT.md)"`
+
+This is a **technical research prompt**, not a code-audit prompt. Single
+codex call (or twice with different models). Output is a roadmap memo,
+not a diff. Pair-track of [RESEARCH_224_PRICING_V2_PROMPT.md] —
+pricing v2 depends on whether the per-cell tok/s targets here are
+believable inside 6-12 months.
+
+---
+
+## Task
+
+Macprovider providers run MLX-quantized LLMs on Apple Silicon and
+compete on $/M-token pricing against datacenter GPU providers
+(OpenRouter, Together, DeepInfra, Groq). Current single-stream
+throughput is structurally ~10-50× behind H100/H200 batched inference
+due to (a) memory bandwidth ceiling, (b) lack of mature continuous
+batching on MLX, (c) tiny KV-cache budget on consumer Apple Silicon.
+
+Audit the **actual** state of the art for high-throughput LLM serving
+on Apple Silicon as of 2026-06-30 and produce a **12-month engineering
+roadmap with concrete realistic sustained tok/s targets per
+(hardware, model-class, software-config) cell**.
+
+The output feeds two downstream decisions:
+1. Which hardware tiers the network should accept as providers
+2. Which model classes each tier is routed to
+3. Whether per-tier USD economics ever close, or whether token issuance
+   is the only viable subsidy mechanism
+
+---
+
+## Background — current state (verbatim)
+
+**Observed bench** (`BENCHMARK_BASELINE_2026-06-29.md` scenario 07):
+- Qwen3-32B-4bit on M4 Air sustains **14 tok/s**, single stream
+- (Theoretical memory-bandwidth-bound peak is ~6-7 tok/s — the
+  observed 14 is suspicious; investigate whether the bench is using a
+  smaller-than-32B variant, lower quantization, or some pipelining
+  trick)
+
+**Provider runtime stack**:
+- Swift CLI in `phase3-binary/Sources/macprovider-cli/`
+- Shells out to MLX via Python sidecar (current shape — confirm path)
+- Coordinator: `phase4-coordinator/` admission control + billing
+- Gateway: OpenAI-compat API, streaming
+
+**Hardware fleet today** (rough — confirm against network telemetry
+if available):
+- Predominantly M4 Air providers
+- Small number of M4 Max + M2 Ultra
+- No M3 Ultra yet
+
+**Theoretical memory-bandwidth ceilings for 32B-4bit (~18GB)**:
+| Hardware | Bandwidth | Peak single-stream tok/s |
+|---|---:|---:|
+| M4 Air | ~120 GB/s | ~6-7 |
+| M4 Max | ~410 GB/s | ~22 |
+| M2 Ultra | ~800 GB/s | ~44 |
+| M3 Ultra | ~800 GB/s | ~44 |
+| H100 | ~3,350 GB/s | ~180 |
+| H200 | ~4,800 GB/s | ~265 |
+
+---
+
+## What to produce
+
+### Part 1 — State-of-the-art audit
+
+For each subsystem below, report: what exists, license, maturity, who
+maintains it, last release/commit date, production-readiness for a
+real provider runtime serving paying buyers. Cite GitHub URLs and
+exact commits/releases.
+
+**1.1 Continuous batching / PagedAttention equivalents on Apple Silicon**
+- `mlx-lm`, `mlx-server`, `mlx-omni-server`
+- LM Studio's local API server (closed-source but observable)
+- Ollama on Apple Silicon (concurrency model, default `OLLAMA_NUM_PARALLEL`)
+- llama.cpp `--parallel` + `--cont-batching` (Metal backend)
+- `mlx-vlm`, `mlx-graphs` research repos
+- Anything resembling vLLM's PagedAttention with KV-cache paging on MLX
+- Production systems known to serve ≥5 concurrent streams of a 32B-class
+  model on Apple Silicon at sustained throughput
+
+**1.2 Speculative decoding on Apple Silicon**
+- `mlx-lm` speculative-decoding (draft-model selection, measured
+  speedups on M-series)
+- llama.cpp speculative support
+- EAGLE / Medusa / Lookahead decoding — any MLX ports
+- Self-speculative variants (no separate draft model)
+
+**1.3 Quantization frontier**
+- 4-bit baseline (current): MLX `Q4`, GGUF `Q4_K_M`
+- 3-bit: MLX 3-bit, AWQ-3, GGUF `Q3_K_S`
+- 2-bit: GGUF `IQ2_XXS`, AQLM
+- K-quants / mixed-precision (attention 4-bit, MLP 2-bit)
+- Measured quality degradation vs throughput gain on
+  Qwen3-32B / Llama-3.1-8B / Llama-3.3-70B
+
+**1.4 Kernel-level optimizations**
+- MLX kernel roadmap (Apple's stated improvements, recent merged PRs,
+  release cadence)
+- AMX matrix unit utilization in MLX vs llama.cpp
+- Apple Neural Engine (ANE) — anyone serving transformer decode via
+  ANE+CoreML in production
+- Metal Performance Shaders fused attention (FlashAttention-equivalent
+  on Apple)
+
+**1.5 Architectural alternatives**
+- MoE on Apple Silicon (Mixtral 8x7B, Qwen3-MoE) — does activated-
+  params bandwidth win on M-Ultra?
+- State-space models (Mamba-2) on MLX
+- Smaller models with better quality (Qwen3-7B full-precision vs
+  Qwen3-32B-4bit) — is this just better per-token TCO?
+
+### Part 2 — Realistic per-cell tok/s targets
+
+Build this matrix with **realistic sustained tok/s** (single-stream and
+max-concurrent under the best in-tree software stack), dated **today**,
+**6 months out**, and **12 months out** from 2026-06-30. Each cell must
+cite the software config assumed (engine, speculative on/off,
+quantization, concurrent batching level).
+
+| Hardware | Model class | Today S | Today C | 6mo S | 6mo C | 12mo S | 12mo C |
+|---|---|---|---|---|---|---|---|
+| M4 Air 16GB | 7-8B (Llama-3.1-8B, Qwen3-7B) | | | | | | |
+| M4 Air 24GB | 7-8B | | | | | | |
+| M4 Air 24GB | 32B-4bit (Qwen3-32B) | | | | | | |
+| M4 Pro 24GB | 7-8B | | | | | | |
+| M4 Pro 48GB | 32B-4bit | | | | | | |
+| M4 Max 64GB | 7-8B | | | | | | |
+| M4 Max 64GB | 32B-4bit | | | | | | |
+| M4 Max 128GB | 70B-4bit (Llama-3.3-70B) | | | | | | |
+| M2 Ultra 128GB | 32B-4bit | | | | | | |
+| M2 Ultra 192GB | 70B-4bit | | | | | | |
+| M3 Ultra 256GB | 32B-4bit | | | | | | |
+| M3 Ultra 256GB | 70B-4bit | | | | | | |
+
+Then add reference rows: **H100 single-stream and batched (32 streams)**
+for the same model classes, so the gap is visible at a glance.
+
+Be explicit about which numbers come from **published benchmarks**
+(cite URL) vs **vendor claims** vs **extrapolation from bandwidth
+ceiling**. Flag aspirational targets that assume software not yet
+released.
+
+### Part 3 — Engineering bets ranked by ROI
+
+Rank each candidate engineering bet by **expected effective-throughput
+multiplier per engineer-month invested**. Candidates:
+
+- MLX continuous-batching contribution (PR to `mlx-lm`)
+- MLX PagedAttention port
+- Speculative-decoding integration into provider runtime
+- 3-bit MLX quantization adoption (provider-side model conversion)
+- ANE backend for decode (CoreML path)
+- MoE model support
+- llama.cpp `--parallel` swap-in as runtime alternative
+- Custom Metal kernel work (FlashAttention fork)
+- Hardware-tier-aware draft-model selection
+- Prefix-cache reuse across requests
+
+For each: engineer-month cost (point estimate + range), expected
+throughput multiplier (per stream AND per machine), risk / probability
+of success, external dependencies (Apple ships X, upstream OSS
+releases Y), which hardware tiers benefit.
+
+Highlight bets that hit **>2× effective per-machine throughput in
+<3 engineer-months at <30% risk**.
+
+### Part 4 — 12-month roadmap recommendation
+
+Pick **ONE** of:
+
+**Roadmap A — Buy the gap (hardware focus).** Stop optimizing M4 Air.
+Recruit M4 Max / M-Ultra owners. Engineering = match continuous-
+batching maturity on the high-bandwidth tier where it actually pays.
+
+**Roadmap B — Software arbitrage (engineering focus).** Bet MLX
+continuous batching + spec decode lands in 12 months and we are first
+to expose it productized. Heavy investment in `mlx-server` / `mlx-lm`
+upstream. Keep M4 Air on the network but route only 7-8B traffic.
+
+**Roadmap C — Model-class specialization.** Don't serve 32B on M4 Air
+at all. Build the network around (a) small-fast models on entry Apple
+Silicon, (b) 70B-class on Ultra. Skip the structurally broken
+32B-on-laptop cell.
+
+**Roadmap D — Hybrid.** Software wins on M-Ultra + model-class routing
+on M4 Air. Specify allocation, milestones, hardware spend.
+
+If none fit, propose your own. Be concrete: name the GitHub repos and
+PRs to contribute, hardware acquisition spend, per-quarter milestones,
+go/no-go gates.
+
+### Part 5 — Pricing-table implications (feeds RESEARCH_224)
+
+For each cell in the Part 2 matrix at the **12-month** column, compute
+**provider USD $/hr** at three pricing scenarios:
+
+| Scenario | Multiplier | UsdPerMcredit | Buyer $/M comp |
+|---|---:|---:|---:|
+| Current default | 1.0 | 1.0 | $1.00 |
+| Buyer-competitive (undercut OpenRouter Qwen3-32B $0.28/M) | 0.25 | 1.0 | $0.25 |
+| Buyer-competitive vs Groq 8B ($0.04/M) | 0.04 | 1.0 | $0.04 |
+
+For each (hardware, model-class) cell at 12-month TPS targets,
+highlight which cells clear electricity floor and which clear B6
+bare-min ($0.30/hr) under each pricing scenario. Use realistic
+sustained TPS, not peak.
+
+This is the bridge to the pricing decision: it tells us which hardware
+tiers can ever be USD-viable at market-competitive buyer prices.
+
+### Part 6 — Open questions and follow-up benchmarks
+
+List 5-10 specific things to measure on real hardware to validate the
+roadmap. Examples:
+- Benchmark `mlx-lm` speculative decode with Qwen3-0.5B drafting
+  Qwen3-32B on M4 Air; measure tok/s and draft-acceptance rate
+- Run llama.cpp `--parallel 4 --cont-batching` on M4 Max with
+  Qwen3-32B-Q4_K_M; measure aggregate tok/s and per-stream tok/s
+- Measure KV-cache memory under 4 concurrent 4K-context streams vs
+  available headroom on a 24GB M4 Air
+
+For each, name the bench scenario id to add to
+`BENCHMARK_BASELINE_*.md` and the expected ranges to falsify/confirm.
+
+---
+
+## Out of scope
+
+- Buyer-side USD pricing (covered in RESEARCH_224)
+- Crypto token issuance design (covered in RESEARCH_224)
+- Coordinator / gateway code changes (memo-only research)
+- New SPEC documents (this produces a memo, not normative SPEC)
+- Apple Silicon training (we serve inference only)
+
+## Output format
+
+Markdown memo, **~600-1000 lines**. Tables for Parts 1, 2, 3, 5. Prose
+for Part 4. Cite every claim about library state with the **GitHub
+URL, commit/release date, and what you observed** (issue thread,
+README, benchmark blog post). Flag aspirational vendor claims vs
+measured benchmarks explicitly. Conservative > optimistic — this
+roadmap feeds money decisions.
+
+## Raw output
+
+```text
+I completed the research pass and found enough evidence to make the roadmap decision conservative.
+
+**Bottom line:** choose **Roadmap D: Hybrid**. Keep M4 Air providers, but route them only to 7-8B and smaller models. Do **not** route dense 32B traffic to M4 Air. Put 32B on M4 Max / Ultra only, 70B on Ultra-preferred tiers, and treat software batching/spec decode as upside, not the economic foundation.
+
+**Key findings:**
+
+| Area | Finding |
+|---|---|
+| Current provider runtime | The repo no longer looks like a Python-sidecar hot path. [ModelRuntime.swift](/Users/augstar/macprovider-poc/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:215) uses Swift MLX APIs with semaphore concurrency, not true continuous batching. |
+| Baseline 14 tok/s | Treat the M4 Air Qwen3-32B 14-17 tok/s result in [BENCHMARK_BASELINE_2026-06-29.md](/Users/augstar/macprovider-poc/specs/BENCHMARK_BASELINE_2026-06-29.md:1) as suspicious until remeasured with provider/model attribution. The benchmark pool also had a 7B provider, so the figure may not be isolated dense-32B throughput. |
+| MLX-LM | Active and mature for local inference, but its server docs still say it is not recommended for production. Latest release: `mlx-lm` v0.31.3, 2026-04-22; main commit `2ed2231`, 2026-06-24. |
+| MLX batching | MLX-LM has batch cache primitives, prompt cache, KV quantization, and speculative decoding flags, but not vLLM-grade production PagedAttention serving. |
+| llama.cpp | Most production-ready Apple-compatible continuous batching option today. Release `b9843`, 2026-06-30, commit `86b9470`; server supports `--parallel`, continuous batching, speculative decoding, KV quantization, Metal. |
+| Ollama | Mature product wrapper, but default `OLLAMA_NUM_PARALLEL=1`; concurrency increases memory linearly with parallel contexts. Latest release v0.30.11, 2026-06-25. |
+| mlx-vlm | Surprisingly relevant: active continuous-batching server and speculative decoding work, release v0.6.3, 2026-06-10. Useful as implementation reference, not as direct text-runtime replacement. |
+| vllm-mlx | Promising but too new to bet economics on. Release v0.4.0, 2026-06-28, claims paged KV, prefix cache, continuous batching, SSD cache, and 400+ tok/s small-model numbers. Needs replication. |
+| LM Studio | Closed-source server; open `mlx-engine` has speculative decoding demos. Not enough transparent evidence for provider-runtime economics. |
+| ANE/CoreML decode | No credible production path for transformer decode serving. Do not invest in the next 12 months. |
+
+**Conservative 12-month sustained targets**
+
+`S` = single-stream decode tok/s. `C` = aggregate sustained output tok/s at realistic max concurrency.
+
+| Hardware | Model class | Today S/C | 6mo S/C | 12mo S/C |
+|---|---:|---:|---:|---:|
+| M4 Air 16GB | 7-8B | 28 / 30 | 35 / 55 | 40 / 70 |
+| M4 Air 24GB | 7-8B | 32 / 35 | 38 / 60 | 44 / 75 |
+| M4 Air 24GB | 32B-4bit | 8 / 8 | 10 / 12 | 12 / 16 |
+| M4 Pro 24GB | 7-8B | 55 / 70 | 65 / 110 | 75 / 140 |
+| M4 Pro 48GB | 32B-4bit | 14 / 16 | 18 / 28 | 22 / 40 |
+| M4 Max 64GB | 7-8B | 90 / 140 | 110 / 220 | 125 / 280 |
+| M4 Max 64GB | 32B-4bit | 25 / 32 | 30 / 55 | 34 / 75 |
+| M4 Max 128GB | 70B-4bit | 13 / 16 | 16 / 25 | 20 / 35 |
+| M2 Ultra 128GB | 32B-4bit | 42 / 55 | 48 / 90 | 55 / 120 |
+| M2 Ultra 192GB | 70B-4bit | 20 / 25 | 24 / 40 | 28 / 55 |
+| M3 Ultra 256GB | 32B-4bit | 45 / 60 | 52 / 100 | 60 / 140 |
+| M3 Ultra 256GB | 70B-4bit | 21 / 28 | 26 / 48 | 30 / 65 |
+| H100 SXM ref | 7-8B | 250 / 3500 | 250 / 3500 | 250 / 3500 |
+| H100 SXM ref | 32B | 140 / 1200 | 140 / 1200 | 140 / 1200 |
+| H100 SXM ref | 70B | 70 / 600 | 70 / 600 | 70 / 600 |
+
+Apple bandwidth references: M4 Air 120 GB/s, M4 Pro 273 GB/s, M4 Max 410-546 GB/s, M2 Ultra 800 GB/s, M3 Ultra 819 GB/s from Apple specs/newsroom. NVIDIA references: H100 3.35 TB/s and H200 4.8 TB/s from NVIDIA product pages.
+
+**Pricing implication at 12-month C**
+
+Assuming provider share = 90%, provider revenue/hr = `C * 3600 / 1e6 * buyer_price * 0.90`.
+
+| Cell | 12mo C | $1/M | $0.25/M | $0.04/M | B6 $0.30/hr? |
+|---|---:|---:|---:|---:|---|
+| M4 Air 7-8B | 70-75 | $0.23-$0.24 | $0.06 | <$0.01 | No |
+| M4 Air 32B | 16 | $0.05 | $0.01 | <$0.01 | No |
+| M4 Pro 7-8B | 140 | $0.45 | $0.11 | $0.02 | Only at $1/M |
+| M4 Pro 32B | 40 | $0.13 | $0.03 | <$0.01 | No |
+| M4 Max 7-8B | 280 | $0.91 | $0.23 | $0.04 | Only at $1/M |
+| M4 Max 32B | 75 | $0.24 | $0.06 | <$0.01 | No |
+| M4 Max 70B | 35 | $0.11 | $0.03 | <$0.01 | No |
+| M2 Ultra 32B | 120 | $0.39 | $0.10 | $0.02 | Only at $1/M |
+| M2 Ultra 70B | 55 | $0.18 | $0.04 | <$0.01 | No |
+| M3 Ultra 32B | 140 | $0.45 | $0.11 | $0.02 | Only at $1/M |
+| M3 Ultra 70B | 65 | $0.21 | $0.05 | <$0.01 | No |
+
+Market-competitive buyer pricing does not close in USD for Apple providers, except possibly subsidized/default-price 7-8B on M4 Max and 32B on Ultra. At $0.25/M, no conservative Apple cell clears $0.30/hr. At $0.04/M, Apple inference is economically non-viable without token subsidy, differentiated routing, or non-USD incentives.
+
+**Ranked engineering bets**
+
+| Rank | Bet | Cost | Expected gain | Risk | Verdict |
+|---:|---|---:|---:|---:|---|
+| 1 | llama.cpp `--parallel --cont-batching` runtime alternative | 1.5-3 EM | 1.3-2.2x machine throughput | 25% | Best near-term bet |
+| 2 | Hardware-aware draft model selection | 1-2 EM | 1.2-2.0x stream throughput | 25-35% | Worth doing |
+| 3 | Prefix cache reuse | 1-2 EM | 1.5-3x effective TTFT on repeated prompts | 20% | Good for agent workloads |
+| 4 | Spec decode integration in provider runtime | 2-4 EM | 1.2-2.0x | 35% | Good, benchmark first |
+| 5 | 3-bit MLX quant adoption | 1-2 EM | 1.15-1.35x | 35-45% | Quality-gated |
+| 6 | MLX continuous batching contribution | 4-8 EM | 1.5-3x machine throughput | 45% | Strategic, not immediate economics |
+| 7 | MoE model support | 2-5 EM | 2-5x for selected MoE classes | 40% | Useful specialization |
+| 8 | MLX PagedAttention port | 6-12 EM | 1.2-2.5x / memory stability | 60% | Too risky as primary bet |
+| 9 | Custom Metal attention kernels | 6-12 EM | 1.05-1.25x decode-heavy | 55% | Poor ROI |
+| 10 | ANE backend | 12-24 EM | Unknown | >70% | Do not pursue |
+
+**Recommendation**
+
+Adopt **Roadmap D**:
+
+- M4 Air: accept for 7-8B, 3B, embeddings, low-value latency-tolerant traffic. Reject/reroute dense 32B.
+- M4 Pro: allow 7-8B broadly; allow 32B only for experimental/non-SLA traffic on 48GB.
+- M4 Max: primary 7-8B throughput tier; acceptable 32B tier after batching validation.
+- M2/M3 Ultra: only realistic Apple tier for 32B economics; 70B remains prestige/specialized unless pricing is subsidized.
+- Engineering: first integrate and benchmark llama.cpp server parallel mode; second add draft-model/spec-decode selection; third upstream/fork MLX batching only after measured wins.
+- Go/no-go gate: by 2026-12-30, require M4 Max 32B aggregate `C >= 50 tok/s` and Ultra 32B `C >= 90 tok/s` at 4K context and p95 stream stability. If missed, pricing v2 should assume token subsidy for 32B+.
+
+**Follow-up benchmarks**
+
+Add these to the next `BENCHMARK_BASELINE_*.md`:
+
+| Scenario | Test | Expected confirm range |
+|---|---|---|
+| `SCN-223-01` | Isolated M4 Air 24GB Qwen3-32B-4bit, verify model config/hash | 6-10 tok/s; >12 needs explanation |
+| `SCN-223-02` | Swift MLX vs `mlx_lm.generate` same model/prompt | within 20%; larger gap means runtime issue |
+| `SCN-223-03` | Qwen3-0.5B draft for Qwen3-32B on Air/Max | 1.1-1.5x; >2x confirms major upside |
+| `SCN-223-04` | llama.cpp `--parallel 4 --cont-batching` Qwen3-32B on M4 Max | 35-60 aggregate tok/s |
+| `SCN-223-05` | vllm-mlx / mlx-openai-server 5-stream batch on Max/Ultra | 1.5-2.3x for small/MoE, 1.2-1.8x dense |
+| `SCN-223-06` | KV memory for 4 concurrent 4K streams on Air 24GB | likely page pressure/OOM for 32B |
+| `SCN-223-07` | 3-bit MLX Qwen3-32B quality + throughput | +15-35% tok/s, quality must pass |
+| `SCN-223-08` | 70B-4bit on M2/M3 Ultra under MLX and llama.cpp | 20-30 S, 40-65 C |
+| `SCN-223-09` | Prefix-cache repeated agent prompts | TTFT/prefill 1.5-3x, decode unchanged |
+| `SCN-223-10` | 30-minute thermal soak Air/Max/Ultra | Air may drop 10-25%; Max/Ultra should stay steadier |
+
+
+```

--- a/specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_PROMPT.md
+++ b/specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_PROMPT.md
@@ -1,0 +1,248 @@
+# RESEARCH PROMPT — MLX continuous-batching / speculative-decoding state of the art and 12-month engineering roadmap
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_PROMPT.md)"`
+
+This is a **technical research prompt**, not a code-audit prompt. Single
+codex call (or twice with different models). Output is a roadmap memo,
+not a diff. Pair-track of [RESEARCH_224_PRICING_V2_PROMPT.md] —
+pricing v2 depends on whether the per-cell tok/s targets here are
+believable inside 6-12 months.
+
+---
+
+## Task
+
+Macprovider providers run MLX-quantized LLMs on Apple Silicon and
+compete on $/M-token pricing against datacenter GPU providers
+(OpenRouter, Together, DeepInfra, Groq). Current single-stream
+throughput is structurally ~10-50× behind H100/H200 batched inference
+due to (a) memory bandwidth ceiling, (b) lack of mature continuous
+batching on MLX, (c) tiny KV-cache budget on consumer Apple Silicon.
+
+Audit the **actual** state of the art for high-throughput LLM serving
+on Apple Silicon as of 2026-06-30 and produce a **12-month engineering
+roadmap with concrete realistic sustained tok/s targets per
+(hardware, model-class, software-config) cell**.
+
+The output feeds two downstream decisions:
+1. Which hardware tiers the network should accept as providers
+2. Which model classes each tier is routed to
+3. Whether per-tier USD economics ever close, or whether token issuance
+   is the only viable subsidy mechanism
+
+---
+
+## Background — current state (verbatim)
+
+**Observed bench** (`BENCHMARK_BASELINE_2026-06-29.md` scenario 07):
+- Qwen3-32B-4bit on M4 Air sustains **14 tok/s**, single stream
+- (Theoretical memory-bandwidth-bound peak is ~6-7 tok/s — the
+  observed 14 is suspicious; investigate whether the bench is using a
+  smaller-than-32B variant, lower quantization, or some pipelining
+  trick)
+
+**Provider runtime stack**:
+- Swift CLI in `phase3-binary/Sources/macprovider-cli/`
+- Shells out to MLX via Python sidecar (current shape — confirm path)
+- Coordinator: `phase4-coordinator/` admission control + billing
+- Gateway: OpenAI-compat API, streaming
+
+**Hardware fleet today** (rough — confirm against network telemetry
+if available):
+- Predominantly M4 Air providers
+- Small number of M4 Max + M2 Ultra
+- No M3 Ultra yet
+
+**Theoretical memory-bandwidth ceilings for 32B-4bit (~18GB)**:
+| Hardware | Bandwidth | Peak single-stream tok/s |
+|---|---:|---:|
+| M4 Air | ~120 GB/s | ~6-7 |
+| M4 Max | ~410 GB/s | ~22 |
+| M2 Ultra | ~800 GB/s | ~44 |
+| M3 Ultra | ~800 GB/s | ~44 |
+| H100 | ~3,350 GB/s | ~180 |
+| H200 | ~4,800 GB/s | ~265 |
+
+---
+
+## What to produce
+
+### Part 1 — State-of-the-art audit
+
+For each subsystem below, report: what exists, license, maturity, who
+maintains it, last release/commit date, production-readiness for a
+real provider runtime serving paying buyers. Cite GitHub URLs and
+exact commits/releases.
+
+**1.1 Continuous batching / PagedAttention equivalents on Apple Silicon**
+- `mlx-lm`, `mlx-server`, `mlx-omni-server`
+- LM Studio's local API server (closed-source but observable)
+- Ollama on Apple Silicon (concurrency model, default `OLLAMA_NUM_PARALLEL`)
+- llama.cpp `--parallel` + `--cont-batching` (Metal backend)
+- `mlx-vlm`, `mlx-graphs` research repos
+- Anything resembling vLLM's PagedAttention with KV-cache paging on MLX
+- Production systems known to serve ≥5 concurrent streams of a 32B-class
+  model on Apple Silicon at sustained throughput
+
+**1.2 Speculative decoding on Apple Silicon**
+- `mlx-lm` speculative-decoding (draft-model selection, measured
+  speedups on M-series)
+- llama.cpp speculative support
+- EAGLE / Medusa / Lookahead decoding — any MLX ports
+- Self-speculative variants (no separate draft model)
+
+**1.3 Quantization frontier**
+- 4-bit baseline (current): MLX `Q4`, GGUF `Q4_K_M`
+- 3-bit: MLX 3-bit, AWQ-3, GGUF `Q3_K_S`
+- 2-bit: GGUF `IQ2_XXS`, AQLM
+- K-quants / mixed-precision (attention 4-bit, MLP 2-bit)
+- Measured quality degradation vs throughput gain on
+  Qwen3-32B / Llama-3.1-8B / Llama-3.3-70B
+
+**1.4 Kernel-level optimizations**
+- MLX kernel roadmap (Apple's stated improvements, recent merged PRs,
+  release cadence)
+- AMX matrix unit utilization in MLX vs llama.cpp
+- Apple Neural Engine (ANE) — anyone serving transformer decode via
+  ANE+CoreML in production
+- Metal Performance Shaders fused attention (FlashAttention-equivalent
+  on Apple)
+
+**1.5 Architectural alternatives**
+- MoE on Apple Silicon (Mixtral 8x7B, Qwen3-MoE) — does activated-
+  params bandwidth win on M-Ultra?
+- State-space models (Mamba-2) on MLX
+- Smaller models with better quality (Qwen3-7B full-precision vs
+  Qwen3-32B-4bit) — is this just better per-token TCO?
+
+### Part 2 — Realistic per-cell tok/s targets
+
+Build this matrix with **realistic sustained tok/s** (single-stream and
+max-concurrent under the best in-tree software stack), dated **today**,
+**6 months out**, and **12 months out** from 2026-06-30. Each cell must
+cite the software config assumed (engine, speculative on/off,
+quantization, concurrent batching level).
+
+| Hardware | Model class | Today S | Today C | 6mo S | 6mo C | 12mo S | 12mo C |
+|---|---|---|---|---|---|---|---|
+| M4 Air 16GB | 7-8B (Llama-3.1-8B, Qwen3-7B) | | | | | | |
+| M4 Air 24GB | 7-8B | | | | | | |
+| M4 Air 24GB | 32B-4bit (Qwen3-32B) | | | | | | |
+| M4 Pro 24GB | 7-8B | | | | | | |
+| M4 Pro 48GB | 32B-4bit | | | | | | |
+| M4 Max 64GB | 7-8B | | | | | | |
+| M4 Max 64GB | 32B-4bit | | | | | | |
+| M4 Max 128GB | 70B-4bit (Llama-3.3-70B) | | | | | | |
+| M2 Ultra 128GB | 32B-4bit | | | | | | |
+| M2 Ultra 192GB | 70B-4bit | | | | | | |
+| M3 Ultra 256GB | 32B-4bit | | | | | | |
+| M3 Ultra 256GB | 70B-4bit | | | | | | |
+
+Then add reference rows: **H100 single-stream and batched (32 streams)**
+for the same model classes, so the gap is visible at a glance.
+
+Be explicit about which numbers come from **published benchmarks**
+(cite URL) vs **vendor claims** vs **extrapolation from bandwidth
+ceiling**. Flag aspirational targets that assume software not yet
+released.
+
+### Part 3 — Engineering bets ranked by ROI
+
+Rank each candidate engineering bet by **expected effective-throughput
+multiplier per engineer-month invested**. Candidates:
+
+- MLX continuous-batching contribution (PR to `mlx-lm`)
+- MLX PagedAttention port
+- Speculative-decoding integration into provider runtime
+- 3-bit MLX quantization adoption (provider-side model conversion)
+- ANE backend for decode (CoreML path)
+- MoE model support
+- llama.cpp `--parallel` swap-in as runtime alternative
+- Custom Metal kernel work (FlashAttention fork)
+- Hardware-tier-aware draft-model selection
+- Prefix-cache reuse across requests
+
+For each: engineer-month cost (point estimate + range), expected
+throughput multiplier (per stream AND per machine), risk / probability
+of success, external dependencies (Apple ships X, upstream OSS
+releases Y), which hardware tiers benefit.
+
+Highlight bets that hit **>2× effective per-machine throughput in
+<3 engineer-months at <30% risk**.
+
+### Part 4 — 12-month roadmap recommendation
+
+Pick **ONE** of:
+
+**Roadmap A — Buy the gap (hardware focus).** Stop optimizing M4 Air.
+Recruit M4 Max / M-Ultra owners. Engineering = match continuous-
+batching maturity on the high-bandwidth tier where it actually pays.
+
+**Roadmap B — Software arbitrage (engineering focus).** Bet MLX
+continuous batching + spec decode lands in 12 months and we are first
+to expose it productized. Heavy investment in `mlx-server` / `mlx-lm`
+upstream. Keep M4 Air on the network but route only 7-8B traffic.
+
+**Roadmap C — Model-class specialization.** Don't serve 32B on M4 Air
+at all. Build the network around (a) small-fast models on entry Apple
+Silicon, (b) 70B-class on Ultra. Skip the structurally broken
+32B-on-laptop cell.
+
+**Roadmap D — Hybrid.** Software wins on M-Ultra + model-class routing
+on M4 Air. Specify allocation, milestones, hardware spend.
+
+If none fit, propose your own. Be concrete: name the GitHub repos and
+PRs to contribute, hardware acquisition spend, per-quarter milestones,
+go/no-go gates.
+
+### Part 5 — Pricing-table implications (feeds RESEARCH_224)
+
+For each cell in the Part 2 matrix at the **12-month** column, compute
+**provider USD $/hr** at three pricing scenarios:
+
+| Scenario | Multiplier | UsdPerMcredit | Buyer $/M comp |
+|---|---:|---:|---:|
+| Current default | 1.0 | 1.0 | $1.00 |
+| Buyer-competitive (undercut OpenRouter Qwen3-32B $0.28/M) | 0.25 | 1.0 | $0.25 |
+| Buyer-competitive vs Groq 8B ($0.04/M) | 0.04 | 1.0 | $0.04 |
+
+For each (hardware, model-class) cell at 12-month TPS targets,
+highlight which cells clear electricity floor and which clear B6
+bare-min ($0.30/hr) under each pricing scenario. Use realistic
+sustained TPS, not peak.
+
+This is the bridge to the pricing decision: it tells us which hardware
+tiers can ever be USD-viable at market-competitive buyer prices.
+
+### Part 6 — Open questions and follow-up benchmarks
+
+List 5-10 specific things to measure on real hardware to validate the
+roadmap. Examples:
+- Benchmark `mlx-lm` speculative decode with Qwen3-0.5B drafting
+  Qwen3-32B on M4 Air; measure tok/s and draft-acceptance rate
+- Run llama.cpp `--parallel 4 --cont-batching` on M4 Max with
+  Qwen3-32B-Q4_K_M; measure aggregate tok/s and per-stream tok/s
+- Measure KV-cache memory under 4 concurrent 4K-context streams vs
+  available headroom on a 24GB M4 Air
+
+For each, name the bench scenario id to add to
+`BENCHMARK_BASELINE_*.md` and the expected ranges to falsify/confirm.
+
+---
+
+## Out of scope
+
+- Buyer-side USD pricing (covered in RESEARCH_224)
+- Crypto token issuance design (covered in RESEARCH_224)
+- Coordinator / gateway code changes (memo-only research)
+- New SPEC documents (this produces a memo, not normative SPEC)
+- Apple Silicon training (we serve inference only)
+
+## Output format
+
+Markdown memo, **~600-1000 lines**. Tables for Parts 1, 2, 3, 5. Prose
+for Part 4. Cite every claim about library state with the **GitHub
+URL, commit/release date, and what you observed** (issue thread,
+README, benchmark blog post). Flag aspirational vendor claims vs
+measured benchmarks explicitly. Conservative > optimistic — this
+roadmap feeds money decisions.

--- a/specs/RESEARCH_224_PRICING_V2_MEMO.md
+++ b/specs/RESEARCH_224_PRICING_V2_MEMO.md
@@ -1,0 +1,529 @@
+# Issue #224 pricing v2: buyer-competitive USD, hardware-tier routing, and token subsidy
+
+Date pulled: 2026-06-30  
+Scope: strategy research memo, not a code audit  
+Repo: `/Users/augstar/macprovider-poc`  
+Related prior memo: `.omc/artifacts/ask/codex-research-prompt-issue-222-beta-campaign-pricing-decision-run-2026-06-30T05-03-00-134Z.md`
+
+## Executive recommendation
+
+The v1 answer should not be used. A provider-USD anchor produces buyer prices that are not competitive with OpenRouter, DeepInfra, Groq, or Together. The v2 answer is to anchor USD to buyer market price, restrict model size by hardware tier, and pay early-provider upside through a beta token-issuance ledger.
+
+Concrete recommendation:
+
+| Lever | Recommendation |
+|---|---|
+| Buyer USD pricing | Keep `global_multiplier: 1.0`, keep `usd_per_million_credits: 1.0`, and set model-specific completion credit rows to market-pegged values: 7-8B `$0.027/M`, 32B `$0.220/M`, 70B `$0.250/M`. |
+| Billing config shape | Use existing exact-model `rewards.rate_card` rows immediately. Add class-level rate-card lookup later if the operator wants one row for all 8B/32B/70B aliases. |
+| Hardware routing | Enable hardware-tier routing before 32B/70B paid traffic. Tier-C/B machines remain valid for 7-8B; Tier-A gets 32B; Tier-S gets 70B. Unknown hardware is Tier-C until verified. |
+| Provider USD economics | Expect electricity-plus only. At market USD prices, provider USD is roughly `$0.005-$0.036/hr` at the conservative TPS assumptions in this prompt. |
+| Token subsidy | Launch an off-chain beta ledger now, mint later at TGE. Use a 2.0% beta budget over six months, with a 120-provider cohort cap and tier-weighted emissions. |
+| Beta duration | Run v2 for 90 days or until first meaningful paid-buyer signal, whichever comes first. Token accounting can continue for the six-month beta budget window, but pricing must be revisited earlier. |
+
+The hardest constraint is the first one: buyers have live alternatives. A 32B buyer can currently buy Qwen3-32B completion on OpenRouter or DeepInfra at about `$0.28/M`. Pricing macprovider at `$10/M` asks the buyer to pay about 36x the market. The buyer will not do that during beta unless macprovider offers a different product, which this prompt explicitly does not assume.
+
+## Evidence and assumptions
+
+### Local code facts
+
+The current coordinator reward math has three important properties:
+
+- `phase4-coordinator/internal/config/config.go:543` defaults `Rewards.GlobalMultiplier` to `1.0`.
+- `phase4-coordinator/internal/config/config.go:548-549` defaults the rate card to `500000` prompt credits/M and `1000000` completion credits/M.
+- `phase4-coordinator/internal/config/config.go:138` defines `StatsRollup.UsdPerMillionCredits`, defaulting to `1.0`.
+- `phase4-coordinator/internal/billing/formula.go` resolves a rate-card entry by exact model key, otherwise `default`.
+- `phase4-coordinator/internal/billing/formula.go` calculates gross credits from token counts, rate-card credits, and global multiplier, then applies provider share.
+- `phase4-coordinator/cmd/coordinator/main.go:908-913` reloads rewards/billing config on SIGHUP.
+- Provider selection for buyer requests happens in `phase4-coordinator/internal/buyer/server.go:4227-4350`, mainly `selectProviderExcluding`.
+- Provider admission/quota accounting is separate in `phase4-coordinator/internal/ws/admission.go`.
+
+Provider hardware self-report exists but is not yet enough for routing:
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRuntimeSupport.swift` records chip string, RAM, OS version, and binary version through `MachineFingerprinter.sample()`.
+- It reads `hw.memsize`, but does not currently report a normalized memory-bandwidth value.
+- The coordinator currently does not filter or tier providers by hardware class.
+
+### Missing pair-track input
+
+No completed RESEARCH_223 throughput memo was found in `.omc/artifacts/ask/` at the time of this memo. I used the conservative TPS defaults from the prompt.
+
+### Market-price source handling
+
+The v1 market table was generated on 2026-06-30, so it is less than seven days old. I reused it where it already covered the requested rows and spot-checked OpenRouter live model pricing through the public model API. Groq's public pricing page is JavaScript-heavy; the v1 table and current public page should be rechecked one more time before a public pricing post, but Groq is not the cheapest row under the current 8B recommendation.
+
+## Part 1 -- Buyer-competitive USD anchor
+
+### Required market rows
+
+All prices below are completion-token prices in USD per 1M tokens unless otherwise noted.
+
+| Provider / model row | Prompt $/M | Completion $/M | Source | Date pulled | Note |
+|---|---:|---:|---|---|---|
+| OpenRouter Qwen3-32B | 0.080 | 0.280 | `https://openrouter.ai/api/v1/models` | 2026-06-30 | Live API row `qwen/qwen3-32b`. |
+| DeepInfra Qwen3-32B | 0.080 | 0.280 | `https://deepinfra.com/Qwen/Qwen3-32B` | 2026-06-30 | Same price as v1 table. |
+| Together Qwen2.5-Coder-32B | 0.800 | 0.800 | `https://www.together.ai/models/qwen-2-5-coder-32b-instruct` | 2026-06-30 | Not cheapest; useful upper bound for managed API. |
+| OpenRouter Qwen2.5-7B | 0.040 | 0.100 | `https://openrouter.ai/api/v1/models` | 2026-06-30 | Qwen 7B is not the cheapest 7-8B anchor. |
+| Groq Llama-3.1-8B Instant | 0.040-0.050 | 0.040-0.080 | `https://groq.com/pricing/` | 2026-06-30 | v1 table had `$0.04/M`; current public page should be checked before publishing. |
+| OpenRouter Llama-3.1-8B Instruct | 0.020 | 0.030 | `https://openrouter.ai/api/v1/models` | 2026-06-30 | Cheapest observed 7-8B comparable row. |
+| OpenRouter Llama-3.3-70B Instruct | 0.100 | 0.320 | `https://openrouter.ai/api/v1/models` | 2026-06-30 | Excludes free promotional route. |
+| DeepInfra Llama-3.3-70B Turbo | 0.100 | 0.320 | `https://deepinfra.com/meta-llama/Llama-3.3-70B-Instruct-Turbo` | 2026-06-30 | Same as v1 table. |
+
+### Target macprovider buyer prices
+
+| Model class | Cheapest market $/M | Target macprovider $/M | Undercut % |
+|---|---:|---:|---:|
+| 7-8B | 0.030 | 0.027 | 10.0% |
+| 32B | 0.280 | 0.220 | 21.4% |
+| 70B | 0.320 | 0.250 | 21.9% |
+
+The 7-8B target is intentionally anchored to the cheapest OpenRouter Llama 3.1 8B row. If the operator instead treats Groq's current or v1 row as the only comparable 8B benchmark, `$0.027/M` undercuts it by more than 30%. That is acceptable for buyer acquisition but should be called out as aggressive.
+
+### Required coordinator config
+
+The recommended operational config is:
+
+```yaml
+stats_rollup:
+  usd_per_million_credits: 1.0
+
+rewards:
+  global_multiplier: 1.0
+  provider_share: 0.90
+  rate_card:
+    default:
+      prompt_credits_per_mtok: 18000
+      completion_credits_per_mtok: 27000
+    llama-3.1-8b:
+      prompt_credits_per_mtok: 18000
+      completion_credits_per_mtok: 27000
+    qwen-2.5-7b:
+      prompt_credits_per_mtok: 36000
+      completion_credits_per_mtok: 27000
+    qwen3-32b:
+      prompt_credits_per_mtok: 64000
+      completion_credits_per_mtok: 220000
+    qwen-2.5-coder-32b:
+      prompt_credits_per_mtok: 64000
+      completion_credits_per_mtok: 220000
+    llama-3.3-70b:
+      prompt_credits_per_mtok: 80000
+      completion_credits_per_mtok: 250000
+```
+
+Two caveats:
+
+1. The code currently matches rate-card rows by exact model key. The live model IDs must match the coordinator's normalized model string exactly.
+2. A class-level row such as `32b:` or `70b:` would be cleaner, but that requires a SPEC/code delta to classify the requested model before billing lookup.
+
+### Why a single multiplier does not work
+
+With the current default completion row of `1,000,000` credits/M and `usd_per_million_credits: 1.0`, a single `global_multiplier` maps directly to buyer completion price:
+
+```text
+buyer completion $/M = default completion credits/M / 1,000,000 * global_multiplier
+                    = 1.0 * global_multiplier
+```
+
+One multiplier cannot be `$0.027`, `$0.220`, and `$0.250` at the same time. A single multiplier of `0.027` would make 32B and 70B too cheap relative to market and would further reduce provider USD. A single multiplier of `0.220` would price 7-8B at 7.3x the cheapest observed OpenRouter 8B row. Therefore the v2 pricing decision needs per-model or per-class rate-card rows.
+
+### Provider USD/hr at target prices
+
+Formula:
+
+```text
+provider_usd_per_hour = tps * 3600 / 1,000,000 * target_completion_usd_per_m * provider_share
+```
+
+Assumptions:
+
+- Provider share: `0.90`
+- Electricity: `$0.16/kWh`
+- M4 Air active draw proxy: `15W` => `$0.0024/hr`
+- M4 Max active draw proxy: `40W` => `$0.0064/hr`
+- M2/M3 Ultra active draw proxy: `80W` => `$0.0128/hr`
+- TPS values are the conservative defaults in the prompt.
+- Table assumes full utilization. Lower utilization lowers USD revenue proportionally.
+
+| Tier x Model class | TPS | Provider $/hr at target | Electricity $/hr | USD margin |
+|---|---:|---:|---:|---:|
+| M4 Air x 8B | 55 | 0.0048 | 0.0024 | 0.0024 |
+| M4 Max x 8B | 80 | 0.0070 | 0.0064 | 0.0006 |
+| M4 Max x 32B | 25 | 0.0178 | 0.0064 | 0.0114 |
+| M2 Ultra x 32B | 45 | 0.0321 | 0.0128 | 0.0193 |
+| M2 Ultra x 70B | 18 | 0.0146 | 0.0128 | 0.0018 |
+| M3 Ultra x 32B | 50 | 0.0356 | 0.0128 | 0.0228 |
+| M3 Ultra x 70B | 22 | 0.0178 | 0.0128 | 0.0050 |
+
+This is the key v2 conclusion: USD can cover marginal electricity at full utilization, but it cannot deliver a psychologically meaningful `$1/hr` provider incentive without destroying buyer competitiveness. The bootstrap incentive must be token-denominated.
+
+## Part 2 -- Hardware-tier filter design
+
+### Hardware specs and tier thresholds
+
+Apple's public specs support using memory bandwidth as the first routing proxy:
+
+| Chip family | Public memory bandwidth | Recommended tier | Source |
+|---|---:|---|---|
+| M3 Ultra | 819 GB/s | S | Apple Mac Studio tech specs, 2026-06-30 |
+| M2 Ultra | 800 GB/s | S | Apple M2 Ultra public specs, 2026-06-30 |
+| M4 Max high bin | 546 GB/s | A | Apple M4 Pro/Max newsroom and tech specs, 2026-06-30 |
+| M4 Max lower bin | 410 GB/s | A | Apple MacBook Pro tech specs, 2026-06-30 |
+| M3 Max | up to 400 GB/s | A | Apple M3-family specs, 2026-06-30 |
+| M4 Pro | 273 GB/s | B | Apple M4 Pro/Max newsroom and tech specs, 2026-06-30 |
+| M3 Pro | 150 GB/s | B | Apple M3-family specs, 2026-06-30 |
+| Base M4 / M4 Air | about 120 GB/s | C | Apple base M-series specs, 2026-06-30 |
+| Base M3 / M3 Air | about 100 GB/s | C | Apple base M-series specs, 2026-06-30 |
+
+I recommend adjusting the prompt's Tier-B lower bound from `200` to `150` GB/s so M3 Pro is not incorrectly pushed into Tier-C. That still keeps Air/base chips below the 32B line.
+
+### Tier definitions
+
+| Tier | Memory bandwidth proxy | Intended Macs | Eligible model max |
+|---|---:|---|---:|
+| S | `>=700 GB/s` | M2 Ultra, M3 Ultra | 70B |
+| A | `>=350 GB/s` and `<700 GB/s` | M4 Max, M3 Max | 32B |
+| B | `>=150 GB/s` and `<350 GB/s` | M4 Pro, M3 Pro | 8B |
+| C | `<150 GB/s` or unknown | M4, M4 Air, M3, M3 Air, unknown | 8B |
+
+### Per-tier model-class eligibility
+
+| Tier | 7-8B | 32B | 70B |
+|---|:-:|:-:|:-:|
+| S | yes | yes | yes |
+| A | yes | yes | no |
+| B | yes | no | no |
+| C | yes | no | no |
+
+### Coordinator enforcement point
+
+Primary enforcement belongs in buyer provider selection:
+
+- `phase4-coordinator/internal/buyer/server.go:1313-1441` handles `/v1/chat/completions`.
+- `phase4-coordinator/internal/buyer/server.go:1436` selects a provider.
+- `phase4-coordinator/internal/buyer/server.go:4227-4350` implements `selectProviderExcluding`.
+- `selectProviderExcluding` already filters candidates through request match, routing eligibility, context limits, tier-2 filters, quota, and preflight.
+
+Add hardware eligibility as a shared helper in this selection path. It should run for both regular candidates and pinned provider paths, otherwise a hard-pinned provider could bypass the tier rule.
+
+Recommended insertion point:
+
+1. Resolve requested model class from model ID: 8B, 32B, 70B.
+2. Resolve provider tier from reported bandwidth/chip/RAM.
+3. Reject candidate before quota reservation and before preflight if `model_params_b > eligible_model_max_params_b`.
+
+Recommended buyer error when no provider is available because all candidates were tier-ineligible:
+
+```json
+{
+  "error": {
+    "code": "hardware_tier_unavailable",
+    "message": "No provider in an eligible hardware tier is available for model qwen3-32b; 32B-class traffic requires Tier-A or better."
+  }
+}
+```
+
+Recommended pinned-provider error:
+
+```json
+{
+  "error": {
+    "code": "hardware_tier_mismatch",
+    "message": "Pinned provider hardware tier C is not eligible for qwen3-32b; 32B-class traffic requires Tier-A or better."
+  }
+}
+```
+
+Use HTTP `503` for normal no-capacity routing and HTTP `409` only if the buyer explicitly pins a known-ineligible provider. If the existing buyer error contract prefers one status for all route failures, keep the existing status and vary only the machine-readable error code.
+
+### Provider onboarding UX
+
+Portal copy:
+
+> Your Mac is welcome on the network. We use memory bandwidth to decide which model sizes your machine can serve without creating slow or uneconomic jobs. MacBook Air and base M-series machines are routed to 7-8B traffic. 32B and 70B traffic is reserved for Max and Ultra chips because buyer pricing has to match OpenRouter-class market prices; an Air serving 32B would earn only pennies per hour and would hurt buyer latency. You still earn USD and beta tokens on eligible 8B work, and your tier can change automatically if you join from faster hardware.
+
+### Telemetry
+
+Log every tier decision where a candidate is rejected. Minimal audit row:
+
+| Field | Meaning |
+|---|---|
+| `ts_utc` | Coordinator timestamp. |
+| `event` | `hardware_tier_mismatch`. |
+| `decision` | `reject_candidate` or `reject_pinned_provider`. |
+| `request_id` | Buyer request ID. |
+| `buyer_account_id` | Buyer/account if available. |
+| `provider_id` | Provider stable ID. |
+| `assigned_id` | Coordinator assigned provider ID if distinct. |
+| `model` | Requested model string. |
+| `model_class_params_b` | Parsed model class. |
+| `provider_tier` | S/A/B/C/unknown. |
+| `provider_mem_bandwidth_gbps` | Reported or inferred bandwidth. |
+| `required_min_tier` | Minimum tier for the model class. |
+| `eligible_model_max_params_b` | Provider tier max. |
+| `route_pinned` | Boolean. |
+| `reason` | `provider_tier_below_model_class`. |
+| `config_hash` | Active config snapshot/hash. |
+
+### Concrete config schema
+
+This follows existing snake-case config style and makes unknown hardware safe by default:
+
+```yaml
+hardware_tiers:
+  enabled: true
+  bandwidth_source: provider_probe
+  unknown_hardware_policy: tier_c
+  reject_out_of_tier_models: true
+  tiers:
+    S:
+      min_mem_bandwidth_gbps: 700
+      eligible_model_max_params_b: 70
+      token_multiplier: 4.0
+    A:
+      min_mem_bandwidth_gbps: 350
+      eligible_model_max_params_b: 32
+      token_multiplier: 2.0
+    B:
+      min_mem_bandwidth_gbps: 150
+      eligible_model_max_params_b: 8
+      token_multiplier: 1.0
+    C:
+      min_mem_bandwidth_gbps: 0
+      eligible_model_max_params_b: 8
+      token_multiplier: 0.5
+```
+
+If policy and token accounting should stay separated, move `token_multiplier` into a future `token_issuance.tier_multipliers` block. The duplicated tier names are acceptable during beta if tests assert they stay consistent.
+
+## Part 3 -- Crypto-token issuance subsidy design
+
+### Comparable networks
+
+| Network | Supply and issuance | Work measurement | Tier weighting | Buyer token role | Anti-sybil / anti-mercenary | Lesson |
+|---|---|---|---|---|---|---|
+| Helium HNT | No premine; HIP-20 moved to a two-year halving schedule. Docs describe an initial maximum of 240M HNT adjusted to about 223M because year-1 issuance was below target. Net emissions can re-emit burned HNT within a cap. | Hotspot coverage, proof/coverage activity, and data transfer through subDAO mechanics. | Not a simple H100-vs-4090 hardware multiplier; location, radio class, coverage, data transfer, and subDAO rules matter. | Data Credits are USD-pegged utility credits created by burning HNT and used for network fees/data. | Location assertions, PoC mechanics, denylist/quality controls, validator/staking systems. | Usage-linked burn is valuable, but oversupplied low-quality coverage can dilute provider earnings. |
+| Akash AKT | Genesis supply commonly documented as 100M AKT with a max around 388.5M; inflation/block rewards are governed network parameters and recent governance has moved toward BME-style economics. | Compute leases in an open marketplace. | No protocol-level GPU-tier multiplier; providers earn through market-clearing lease prices and resource specs. | AKT secures the PoS chain, governs parameters, and supports marketplace economics; buyers can interact through cloud-market flows. | Provider deposits/certificates, marketplace reputation, on-chain leases, governance-controlled parameters. | Marketplace pricing avoids fake subsidy precision, but idle supply alone is not enough; real demand must clear leases. |
+| Render RENDER | Render migrated from RNDR to Solana RENDER and implemented Burn-Mint Equilibrium. Users burn RENDER for Render Credits; node operators receive emissions for fulfilled GPU work. | Completed rendering / GPU compute jobs and node operator reward accounting. | Better hardware earns through work capacity, benchmarks, reputation, and job completion, not only raw ownership. | Users burn RENDER into USD-valued work credits; RENDER is also the network token for emissions. | Node reputation, job validation, operator accounting, BME emissions governance. | Burn-mint links buyer usage to token demand; provider rewards still need work validation and reputation. |
+| Bittensor TAO | Max supply 21M TAO. Emissions follow Bitcoin-like halvings; current docs describe supply-threshold halving and about 3,600 TAO/day after the first halving. | Subnet-specific miner outputs scored by validators; subnet owners define incentive logic. | No fixed hardware-tier schedule. Faster hardware earns more only if it produces higher-scored outputs. | TAO is used for staking, governance, subnet registration/economics; end-user purchase role depends on subnet. | Stake, registration cost/burn/recycling, validator scoring, subnet-specific rules. | Performance-scored emissions are powerful, but incentive design is complex and gameable. |
+| io.net IO | Official docs state 500M genesis IO supply growing to 800M over 20 years; newer tokenomics introduce demand/utilization-sensitive supply and burns. | GPU/CPU supply, cluster rentals, utilization, supplier payouts. | GPU class, reliability, utilization, and supplier status influence earnings. | IO participates in network payments, staking, rewards, governance/economics; newer IDE ties economics to utilization. | Device verification, worker scoring, KYC/compliance surfaces, utilization-based controls. | Fixed emissions bootstrap supply, but utilization-aware emissions are needed to avoid paying idle or fake capacity forever. |
+| Aethir ATH | Official docs state total supply of 42B ATH. Rewards include checker node and compute rewards on Arbitrum. Checker bonus pool is documented as 5% of total supply over four years. | Checker node validation and compute-provider work. | Compute class and successful SLA/job fulfillment matter; checker nodes are a separate verification role. | ATH supports rewards, staking/governance/economics for the compute network. | Checker nodes, uptime requirements, reward vesting/claim windows, staking/reputation. | A separate checker/verifier role helps when provider performance claims are hard to trust. |
+
+Sources used for the analog table:
+
+- Helium: `https://docs.helium.com/tokens/hnt-token/`, pulled 2026-06-30.
+- Akash: `https://akash.network/token/` and `https://akash.network/blog/an-evolution-of-akash-network-token-economics/`, pulled 2026-06-30.
+- Render: `https://know.rendernetwork.com/basics/the-render-spl-token`, `https://know.rendernetwork.com/basics/burn-mint-equilibrium`, and `https://stats.renderfoundation.com/`, pulled 2026-06-30.
+- Bittensor: `https://docs.learnbittensor.org/concepts/halving` and `https://docs.taostats.io/docs/tokenomics`, pulled 2026-06-30.
+- io.net: `https://io.net/docs/guides/coin/io-coin-allocation` and `https://io.net/tokenomics`, pulled 2026-06-30.
+- Aethir: `https://docs.aethir.com/aethir-tokenomics/token-overview`, `https://docs.aethir.com/aethir-tokenomics`, and `https://docs.aethir.com/checker-guide/what-is-the-checker-node/how-do-checker-nodes-work`, pulled 2026-06-30.
+
+### Macprovider beta token design
+
+Token placeholder: `TOKEN_NAME` in provider-facing copy; `MPROV` below for arithmetic only.
+
+Supply assumption:
+
+- Define planning supply as `1,000,000,000 MPROV`.
+- Reserve `2.0%` for beta provider issuance over six months: `20,000,000 MPROV`.
+- Do not promise that all beta budget emits. Emit only for verified online time, served tokens, and benchmark passes.
+
+Recommended beta cohort:
+
+| Tier | Cohort cap | Rationale |
+|---|---:|---|
+| S | 20 | Ultra hardware is scarce and most valuable for 70B. |
+| A | 50 | M4/M3 Max is the main 32B beta target. |
+| B | 30 | Useful 8B supply, but not strategic for 32B/70B. |
+| C | 20 | Keep Air/base users included without overpaying non-strategic hardware. |
+| Total | 120 | Keeps per-provider allocation meaningful under a 20M-token beta reserve. |
+
+Emission components:
+
+| Component | Formula | Purpose |
+|---|---|---|
+| Online floor | `4 base MPROV/hour online * tier_multiplier` | Keeps providers connected and reachable. |
+| Served-token reward | `50 base MPROV / 1M accepted completion-token-equivalent * tier_multiplier` | Rewards actual useful work, not idle capacity. |
+| Benchmark-pass bonus | `2,500 base MPROV * tier_multiplier` per quarterly benchmark pass | Catches degraded machines and rewards verified capability. |
+| Tier multiplier | S `4.0`, A `2.0`, B `1.0`, C `0.5` | Makes scarce hardware meaningfully more valuable. |
+| Vesting | 90-day cliff, then 12-month linear vest; forfeiture for fraud/sybil/quality violations | Reduces mercenary farming and early exit. |
+
+Anti-sybil and quality gates:
+
+- Stable provider identity.
+- Hardware fingerprint from chip, RAM, OS, binary version, and future bandwidth/benchmark receipts.
+- Reachability checks for online-hour credit.
+- Served-token credit only for accepted, non-faulted, latency-bounded completions.
+- One human/operator cohort account per beta provider unless manually approved.
+- Household/IP/device-review caps during beta.
+- Benchmark receipts signed by coordinator or reproducible challenge runner.
+- Manual review for tier jumps, suspicious uptime, or repeated benchmark-only participation.
+
+Buyer-side token role:
+
+- Beta buyers should not need the token.
+- Keep USD/credits as the buyer acquisition path.
+- Treat `TOKEN_NAME` as governance/network-equity and future fee/burn/stake optionality.
+- Defer burn-on-use until there is real buyer demand and a token contract.
+
+### Expected token earnings per provider
+
+Median beta assumptions:
+
+- Six-month window: `180` days.
+- Calendar hours: `4,320`.
+- Verified online rate: `80%`, or `3,456` hours.
+- Tier-C active utilization: `20%` of online hours at `55 TPS`.
+- Tier-B active utilization: `20%` of online hours at `65 TPS`.
+- Tier-A active utilization: `20%` of online hours at `25 TPS` on 32B.
+- Tier-S active utilization: `25%` of online hours at `50 TPS` on 32B/70B mix.
+- Two quarterly benchmark passes.
+
+| Tier | Median served tokens | Online-floor MPROV | Served-token MPROV | Benchmark MPROV | Total MPROV / provider | MPROV/hr calendar |
+|---|---:|---:|---:|---:|---:|---:|
+| C | 136.9M | 6,912 | 3,421 | 2,500 | 12,833 | 2.97 |
+| B | 161.7M | 13,824 | 8,087 | 5,000 | 26,911 | 6.23 |
+| A | 62.2M | 27,648 | 6,221 | 10,000 | 43,869 | 10.15 |
+| S | 155.5M | 55,296 | 31,104 | 20,000 | 106,400 | 24.63 |
+
+Dollar-equivalent planning scenarios:
+
+| Tier | Tokens/provider | At $0.10 | At $1.00 | At $10.00 | Equivalent $/hr at $0.10 | Equivalent $/hr at $1.00 | Equivalent $/hr at $10.00 |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| C | 12,833 | 1,283 | 12,833 | 128,330 | 0.30 | 2.97 | 29.71 |
+| B | 26,911 | 2,691 | 26,911 | 269,110 | 0.62 | 6.23 | 62.29 |
+| A | 43,869 | 4,387 | 43,869 | 438,690 | 1.02 | 10.15 | 101.55 |
+| S | 106,400 | 10,640 | 106,400 | 1,064,000 | 2.46 | 24.63 | 246.30 |
+
+The Tier-A target is satisfied: an M4 Max provider earns electricity-plus USD and more than `$1/hr` equivalent at a conservative `$0.10` token planning price. The `$1` and `$10` scenarios are materially higher than the prompt's moderate/optimistic thresholds.
+
+Cohort budget check:
+
+| Tier | Cohort count | MPROV/provider | Cohort MPROV |
+|---|---:|---:|---:|
+| S | 20 | 106,400 | 2,128,000 |
+| A | 50 | 43,869 | 2,193,450 |
+| B | 30 | 26,911 | 807,330 |
+| C | 20 | 12,833 | 256,660 |
+| Total | 120 | -- | 5,385,440 |
+
+This leaves most of the 20M beta reserve unspent for retention bonuses, additional benchmark rounds, demand spikes, manual grants to high-quality providers, or a second cohort. The budget should remain capped; unused tokens should not auto-distribute just because the reserve exists.
+
+## Part 4 -- Composite recommendation
+
+### Concrete numbers
+
+| Item | Decision |
+|---|---|
+| `GlobalMultiplier` | `1.0` |
+| `UsdPerMillionCredits` | `1.0` |
+| Completion price, 7-8B | `$0.027/M` through rate-card rows |
+| Completion price, 32B | `$0.220/M` through rate-card rows |
+| Completion price, 70B | `$0.250/M` through rate-card rows |
+| Provider share | Keep `0.90` for beta |
+| Hardware-tier filter | Enable for all 32B/70B traffic before paid buyer traffic; unknown hardware is Tier-C |
+| Existing providers | Grandfather only into eligible model classes; no Air/base grandfathering for 32B |
+| Token budget | `2.0%` of planning supply over six months, capped at `20,000,000` if supply is 1B |
+| Token ledger | Off-chain ledger now, mint later at TGE |
+| Online floor | `4 base MPROV/hour online * tier multiplier` |
+| Served-token reward | `50 base MPROV / 1M accepted completion-token-equivalent * tier multiplier` |
+| Benchmark bonus | `2,500 base MPROV * tier multiplier` per quarterly pass |
+| Tier multipliers | S `4.0`, A `2.0`, B `1.0`, C `0.5` |
+| Vesting | 90-day cliff, then 12-month linear vest |
+| Cohort size | 120 providers: 20 S, 50 A, 30 B, 20 C |
+| Pricing revisit | 90 days, first `$500` paid buyer gross revenue, or 50M paid completion tokens, whichever comes first |
+
+### Rollout
+
+1. Immediately set buyer USD prices through exact-model rate-card rows in the live coordinator config and SIGHUP the coordinator.
+2. Ship hardware-tier telemetry first if implementation risk is high, but hard-enforce out-of-tier routing before any 32B/70B paid buyer campaign.
+3. Start the off-chain token ledger with the next beta cohort, not retroactively for all historical uptime unless the operator manually grants a one-time genesis credit.
+4. Publish the provider-facing tier explanation before enforcing the filter, so M4 Air users understand why they are not receiving 32B traffic.
+
+### Operator pitch to providers
+
+> We're pricing the network to undercut OpenRouter on USD because that's what attracts paying buyers. Your USD earnings will be electricity-plus. We're issuing TOKEN_NAME to bridge the gap as a network-equity stake -- early providers earn more than late entrants. Your hardware tier determines which jobs you can take and what multiplier your token issuance gets. If you bought an M4 Air hoping to earn $1/hr on 32B traffic, the honest answer is no -- that cell isn't physically viable at market-competitive buyer pricing. If you bought an M-Ultra, this is the network for you.
+
+## Part 5 -- DECISION_CRITERIA.md entry
+
+Ready-to-commit entry for `beta/DECISION_CRITERIA.md`:
+
+```markdown
+| 2026-06-30 | **Entry 93 -- Issue #224 beta pricing v2: buyer USD price pegs to OpenRouter-class market and provider upside moves to TOKEN_NAME.** The v1 provider-USD anchor would have priced 32B completion around `$10/M`, roughly 36x the observed OpenRouter/DeepInfra Qwen3-32B completion market row of `$0.28/M`. The v2 market check instead pegs buyer USD to competitive completion prices: 7-8B `$0.027/M`, 32B `$0.220/M`, and 70B `$0.250/M`, each at or below comparable OpenRouter/DeepInfra/Groq/Together rows. At those prices, conservative Mac TPS produces only electricity-plus provider USD, so early-provider upside must come from protocol-token issuance rather than USDC subsidy. | **Decision:** keep `rewards.global_multiplier: 1.0`, keep `stats_rollup.usd_per_million_credits: 1.0`, and set exact-model rate-card rows to 7-8B `$0.027/M`, 32B `$0.220/M`, and 70B `$0.250/M` completion equivalents. Add hardware-tier routing before paid 32B/70B traffic: Tier-S `>=700 GB/s` can serve 70B, Tier-A `>=350 GB/s` can serve 32B, Tier-B `>=150 GB/s` can serve 8B, and Tier-C/unknown can serve 8B only. Launch an off-chain beta TOKEN_NAME ledger with a 2.0% six-month beta reserve, 120-provider cohort cap, online floor of `4` base tokens/hour, served-token reward of `50` base tokens per 1M accepted completion-token-equivalent, quarterly benchmark bonus of `2,500` base tokens, tier multipliers S `4.0`, A `2.0`, B `1.0`, C `0.5`, and 90-day cliff plus 12-month linear vesting. **Why:** buyer demand requires OpenRouter-class USD pricing; provider-USD math at that price only covers marginal electricity; Helium, Render, Bittensor, io.net, Aethir, and Akash show that DePIN supply bootstrapping uses tokenized network upside plus work/quality gates rather than overcharging buyers. **Effective:** rate-card update is hot-reloadable on the next coordinator config deploy/SIGHUP; hardware-tier filtering ships in the next coordinator release and must hard-reject out-of-tier 32B/70B routing before paid buyer traffic; token accounting starts with the next beta cohort through an operator ledger and can mint at TGE. **Re-trigger:** revisit on first paying buyer gross revenue above `$500`, first 50M paid completion tokens, fleet sustained p50 crossing Tier-A 32B `>=40 tok/s` or Tier-S 70B `>=30 tok/s` for seven days, TOKEN_NAME planning price outside `$0.10-$10.00` for 30 days after a reliable market mark, Tier-A/S monthly provider churn above `15%`, all-tier monthly churn above `25%`, cohort cap of 120 providers reached, or 90 calendar days elapsed. **Owner:** operator. | **Phase 5 / network implication:** billing remains buyer-competitive, routing stops assigning physically uneconomic model classes to Air/base hardware, and provider acquisition messaging shifts from guaranteed USDC yield to electricity-plus USD plus vested network-equity upside. |
+```
+
+## Part 6 -- Implementation pointers
+
+### USD multiplier and rate card
+
+| Change | File / line | Hot-reloadable? | Work type |
+|---|---|---|---|
+| Keep `GlobalMultiplier` at `1.0` | `phase4-coordinator/internal/config/config.go:543` default; live `/opt/macprovider/coordinator.yaml` | Yes, rewards config reloads on SIGHUP through `cmd/coordinator/main.go:908-913` | Operator config |
+| Set exact-model rate-card rows | `phase4-coordinator/internal/config/config.go:548-549` defaults; live config under `rewards.rate_card` | Yes, through reward/billing reload on SIGHUP | Operator config |
+| Keep `UsdPerMillionCredits` at `1.0` | `phase4-coordinator/internal/config/config.go:138` and default around `571` | Do not rely on hot reload; leave unchanged | Operator config |
+| Per-class rate-card rows | `phase4-coordinator/internal/billing/formula.go` currently exact model -> default | No; new code and SPEC delta | SPEC/code |
+
+Exact-model rows are the fastest safe path. Per-class rows are cleaner but require code to parse model class before rate lookup and tests to prove no default-rate fallback accidentally overprices or underprices traffic.
+
+### Hardware-tier filter
+
+| Change | File / location | Restart? | Rough complexity |
+|---|---|---|---:|
+| Add config structs/defaults/validation | `phase4-coordinator/internal/config/config.go` | Coordinator restart or SIGHUP if wired into reload snapshot | 80-120 LOC |
+| Persist/report hardware tier fields | `phase4-coordinator/internal/pool/provider.go`, WS provider registration/status structs | Coordinator restart and provider binary update if adding probe fields | 80-150 LOC |
+| Enforce route eligibility | `phase4-coordinator/internal/buyer/server.go:4227-4350` | Coordinator restart | 80-150 LOC plus tests |
+| Prevent pinned-provider bypass | Same buyer selection path and pinned-provider validation helpers | Coordinator restart | Included above |
+| Add provider probe bandwidth mapping | `phase3-binary/Sources/macprovider-cli/AutotuneRuntimeSupport.swift` | Provider binary release | 80-120 LOC |
+| Add audit logs/metrics | Buyer selection path plus existing logger/metrics packages | Coordinator restart | 50-100 LOC |
+
+Total estimate: 350-600 LOC with unit tests and routing tests.
+
+### Token issuance beta mechanic
+
+| Option | Description | Pros | Cons | Recommendation |
+|---|---|---|---|---|
+| Option alpha | Off-chain ledger; mint later at TGE | Launches immediately; no audited contract dependency; easy to revise before token exists | Requires operator trust and careful export/audit trail | Recommended |
+| Option beta | On-chain contract from day 1 | Transparent and composable | Premature engineering cost; contract audit; hard to revise while economics are still beta | Do not use for this beta |
+
+Implementation sketch for option alpha:
+
+- Append-only CSV/SQLite/Postgres ledger keyed by provider ID, day, tier, online hours, accepted completion-token-equivalent, benchmark pass, multiplier, gross token amount, vesting status.
+- Daily export to signed artifact.
+- Monthly operator review for anomalies.
+- TGE conversion script later maps vested/unvested ledger balances to token allocations.
+
+### Provider portal copy
+
+Search/update the provider portal pages that describe:
+
+- How provider earnings are calculated.
+- Which models a Mac can serve.
+- Beta token rewards.
+- Hardware eligibility / tier explanation.
+
+The prompt names `portal.streamvc.live`; if that portal source is outside this repo, this is pure operator messaging rather than a repo change. If it is in-repo, update the relevant `pages/` route and add a new hardware-tier explanation page.
+
+### What is hot-reloadable vs new code
+
+| Item | Classification |
+|---|---|
+| `rewards.global_multiplier` live value | Hot-reloadable through SIGHUP |
+| Exact-model `rewards.rate_card` values | Hot-reloadable through SIGHUP |
+| `stats_rollup.usd_per_million_credits` | Leave unchanged; not needed for this decision |
+| Per-class billing lookup | New code + SPEC delta |
+| Hardware-tier config | New code |
+| Hardware-tier enforcement | New coordinator code |
+| Provider memory-bandwidth probe | New provider-binary code |
+| Token ledger | New operator bookkeeping or small service; no chain dependency |
+| On-chain token issuance | Contract deployment; explicitly out of scope for beta launch |
+| Provider pitch / tier explanation | Pure operator messaging unless portal source is in repo |
+
+## Stop condition
+
+The v2 decision is ready when:
+
+- Buyer USD target table is accepted.
+- Live config uses exact-model rate-card rows or a SPEC delta is opened for class rows.
+- Hardware-tier routing is scheduled before paid 32B/70B buyer traffic.
+- Off-chain token ledger policy is approved before onboarding the next provider cohort.
+- `beta/DECISION_CRITERIA.md` receives Entry 93 or the operator chooses a different entry number.
+

--- a/specs/RESEARCH_224_PRICING_V2_PROMPT.md
+++ b/specs/RESEARCH_224_PRICING_V2_PROMPT.md
@@ -1,0 +1,331 @@
+# RESEARCH PROMPT — Beta pricing v2: buyer-competitive USD + capable-M-provider target + crypto-token subsidy
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_224_PRICING_V2_PROMPT.md)"`
+
+This is a strategy research prompt, not a code-audit prompt. Single
+codex call. Output is a recommendation memo + ready-to-commit
+DECISION_CRITERIA entry.
+
+This is the **v2** of Issue #222 pricing research. The v1 memo
+(`.omc/artifacts/ask/codex-research-prompt-issue-222-beta-campaign-pricing-decision-run-2026-06-30T05-03-00-134Z.md`)
+anchored to provider USD $/hr and produced a 36×-over-market buyer
+price ($10/M completion). Operator rejected v1 in conversation; v2
+is the re-scoped question.
+
+Pair-track of [RESEARCH_223_MLX_THROUGHPUT_ROADMAP_PROMPT.md] — if
+that memo lands first, use its 6-12 month tok/s targets as Part 1
+input; otherwise use the conservative defaults in Background below.
+
+---
+
+## What changed since v1
+
+Three constraints lock in. The decision must satisfy all three:
+
+**Constraint 1 — Buyer USD price must be competitive vs OpenRouter for
+comparable model class.** Cheapest comparable Qwen3-32B is **$0.28/M
+completion** on OpenRouter/DeepInfra. Beta target: **undercut by
+10-30%** to recruit buyers who would otherwise default to OpenRouter.
+Same logic for 7-8B class (cheapest is Groq Llama-3.1-8B at ~$0.04/M).
+v1's $10/M is dead on arrival.
+
+**Constraint 2 — Provider hardware tier deliberately narrows.** M4 Air
+on Qwen-32B is structurally ~25× behind H100 on memory bandwidth and
+cannot be made USD-viable via per-token price (a market-rate per-token
+price × 14 tok/s × 1 stream produces pennies/hr — no multiplier closes
+that gap without breaking buyer-side competitiveness). We **stop
+targeting M4 Air for 32B-class jobs** and target the network at
+M4 Max / M2 Ultra / M3 Ultra owners who already chose hardware capable
+of competitive single-stream and concurrent throughput. M4 Air remains
+listable but only for 7-8B class.
+
+**Constraint 3 — Provider USD shortfall is paid in protocol tokens,
+not USDC.** The gap between (buyer-competitive USD revenue ×
+provider_share) and "what providers need to feel rewarded" is bridged
+by issuing crypto tokens (governance / network-equity stake). USD
+economics balance at electricity-plus; **token issuance carries the
+bootstrap incentive**. This is how comparable networks (Helium, Akash,
+Render, Bittensor, io.net) bootstrapped supply.
+
+The decision must specify:
+- (a) USD multiplier so buyer price lands at-or-below OpenRouter parity
+- (b) per-tier token-issuance schedule that subsidizes providers
+- (c) hardware-class filter / tier in coordinator config
+- (d) beta cohort size and concrete re-trigger conditions
+
+---
+
+## Background — code state (verbatim, brief)
+
+Same as v1; not repeating. Key locations:
+- `phase4-coordinator/internal/config/config.go:543` `Rewards.GlobalMultiplier`
+- `phase4-coordinator/internal/config/config.go:548-549` rate-card defaults
+- `phase4-coordinator/internal/config/config.go:138` `UsdPerMillionCredits`
+- Live operator config: `/opt/macprovider/coordinator.yaml` on Pearl VPS
+- Credit arithmetic: SPEC-005 D3 (LOCKED — do not propose changes)
+- Hot-reload via SIGHUP at `phase4-coordinator/cmd/coordinator/main.go:908`
+
+**Hardware tier inference** (research before citing):
+- Provider binary self-reports hardware via probe — search
+  `phase3-binary/Sources/macprovider-cli/` for `HardwareProbe`,
+  `sysctl hw.memsize`, `hw.l1icachesize`, or similar
+- Coordinator currently does NOT filter or tier providers by hardware
+
+**Conservative TPS assumptions** (use these if RESEARCH_223 hasn't
+landed yet; refine if it has):
+- M4 Air, 7-8B class: ~55 tok/s single-stream sustained
+- M4 Max, 7-8B class: ~80 tok/s single, 2-3 concurrent
+- M4 Max, 32B-4bit: ~25 tok/s single, 2 concurrent
+- M2 Ultra, 32B-4bit: ~45 tok/s single, 3 concurrent
+- M2 Ultra, 70B-4bit: ~18 tok/s single, 1-2 concurrent
+- M3 Ultra, 32B-4bit: ~50 tok/s single, 3-4 concurrent
+- M3 Ultra, 70B-4bit: ~22 tok/s single, 2 concurrent
+
+**Crypto token context** (research from public-network analogues —
+no protocol token issued today; this proposes the mechanism):
+- Helium HNT (hotspot bandwidth bootstrap)
+- Akash AKT (compute leasing)
+- Render RNDR (GPU rendering)
+- Bittensor TAO (ML inference subnets) — most architecturally
+  comparable
+- io.net IO (GPU compute)
+- Aethir ATH (GPU cloud)
+
+---
+
+## What to produce
+
+### Part 1 — Buyer-competitive USD anchor
+
+Pull current per-token pricing for the cheapest comparable open-model
+providers. **If RESEARCH_222 market table is <7 days old, cite it;
+otherwise re-fetch.** Required rows:
+
+- OpenRouter Qwen3-32B
+- DeepInfra Qwen3-32B
+- Together Qwen2.5-Coder-32B
+- OpenRouter Qwen3-7B / Qwen2.5-7B
+- Groq Llama-3.1-8B
+- OpenRouter Llama-3.1-8B
+- OpenRouter Llama-3.3-70B
+- DeepInfra Llama-3.3-70B
+
+Pick the **target USD price per 1M completion tokens** that macprovider
+charges buyers, **per model class**, that undercuts cheapest market by
+10-30%. Show targets in this table:
+
+| Model class | Cheapest market $/M | Target macprovider $/M | Undercut % |
+|---|---:|---:|---:|
+| 7-8B | | | |
+| 32B | | | |
+| 70B | | | |
+
+Back-derive the required coordinator config. Likely one of:
+- Single `GlobalMultiplier` (all classes priced uniformly) — show value
+- Per-rate-card-row multiplier (different price per model size) —
+  requires SPEC delta; flag if needed
+
+For each target, compute the resulting **provider USD $/hr** per
+hardware tier at conservative TPS (Background). Build:
+
+| Tier × Model class | TPS | Provider $/hr at target | Electricity $/hr | USD margin |
+|---|---:|---:|---:|---:|
+| M4 Air × 8B | | | | |
+| M4 Max × 8B | | | | |
+| M4 Max × 32B | | | | |
+| M2 Ultra × 32B | | | | |
+| M2 Ultra × 70B | | | | |
+| M3 Ultra × 32B | | | | |
+| M3 Ultra × 70B | | | | |
+
+The whole point: USD margin should be ≥0 (covers electricity) but
+won't approach $1/hr "B6 target." Token issuance closes that gap.
+
+### Part 2 — Hardware-tier filter design
+
+The coordinator must NOT silently accept M4 Air providers for 32B-class
+jobs at this pricing. Specify:
+
+**2.1 Tier definitions** (use memory bandwidth as the proxy):
+- **Tier-S**: ≥700 GB/s — M2 Ultra, M3 Ultra
+- **Tier-A**: 350-700 GB/s — M4 Max, M3 Max
+- **Tier-B**: 200-350 GB/s — M4 Pro, M3 Pro
+- **Tier-C**: <200 GB/s — M4 / M4 Air / M3 / M3 Air
+- Adjust thresholds based on actual M-series specs research
+
+**2.2 Per-tier model-class eligibility**:
+
+| Tier | 7-8B | 32B | 70B |
+|---|:-:|:-:|:-:|
+| S | ✓ | ✓ | ✓ |
+| A | ✓ | ✓ | ✗ |
+| B | ✓ | ✗ | ✗ |
+| C | ✓ | ✗ | ✗ |
+
+**2.3 Coordinator enforcement point**: cite the exact admission-control
+location in code (search for where the coordinator selects a provider
+for an inbound request — likely in `phase4-coordinator/internal/`
+under routing/admission/assignment). Specify the rejection error code
+and message returned to providers attempting out-of-tier work.
+
+**2.4 Provider onboarding UX**: portal copy explaining why their Air
+can't take 32B traffic but is welcome for 8B.
+
+**2.5 Telemetry**: what gets logged when a job is rejected for
+hardware-tier mismatch (audit-log row schema).
+
+**2.6 Concrete config schema** for `coordinator.yaml`:
+
+```yaml
+hardware_tiers:
+  S:
+    min_mem_bandwidth_gbps: 700
+    eligible_model_max_params_b: 70
+  A:
+    min_mem_bandwidth_gbps: 350
+    eligible_model_max_params_b: 32
+  B:
+    min_mem_bandwidth_gbps: 200
+    eligible_model_max_params_b: 8
+  C:
+    min_mem_bandwidth_gbps: 0
+    eligible_model_max_params_b: 8
+```
+
+(Adjust schema to fit current `coordinator.yaml` shape — match
+existing key conventions.)
+
+### Part 3 — Crypto-token issuance subsidy design
+
+Research the comparable networks (Helium, Akash, Render, Bittensor,
+io.net, Aethir) and report each one's:
+- Initial supply, total supply cap
+- Issuance schedule (decay curve, halving, target inflation)
+- Work measurement (what counts as "work" for issuance)
+- Per-tier weighting (does an H100 provider earn more tokens than an
+  RTX 4090?)
+- Vesting / cliff for early providers
+- Buyer-side token role (governance only? required for purchase?
+  burn-on-use? bonded fees?)
+- Anti-sybil / anti-mercenary mechanisms
+- 1-line lesson learned (what worked, what didn't)
+
+Cite each protocol's whitepaper / docs URL + most recent
+tokenomics-update date.
+
+Then design **macprovider's beta issuance** with concrete numbers:
+
+- **Total beta budget**: e.g., 1-3% of supply distributed over 6
+  months — pick a defensible %
+- **Per-hour-online floor**: incentive to stay connected and reachable
+- **Per-token-served weight**: incentive to actually serve (not just
+  idle)
+- **Per-tier multiplier**: incentive to bring better hardware — e.g.,
+  Tier-S × 4, Tier-A × 2, Tier-B × 1, Tier-C × 0.5
+- **Benchmark-pass bonus**: incentive to pass SPEC-NETWORK-BENCHMARK
+  thresholds (catch quietly-degraded providers)
+- **Vesting schedule**: anti-mercenary — e.g., 90-day cliff, 12-month
+  linear vest from the cliff
+- **Beta cohort cap**: limit providers at N to make per-provider
+  allocation meaningful (suggest a number based on token budget /
+  per-provider allocation arithmetic)
+
+Show expected **token-quantity earned per beta provider per hardware
+tier** assuming median network conditions, and **dollar-equivalent
+value** under three token-price scenarios: $0.10, $1.00, $10.00 per
+token at TGE.
+
+**Goal**: a Tier-A (M4 Max) provider earning electricity-plus USD
+(~$0.10/hr) plus token issuance reaches **>$1/hr equivalent at
+conservative token valuation, >$5/hr at moderate, >$25/hr at
+optimistic**. Tier-S providers earn proportionally more (their
+hardware is more valuable to the network).
+
+### Part 4 — Composite recommendation
+
+Pick concrete numbers across all three levers:
+
+- `GlobalMultiplier`: __ (justify against Part 1 table)
+- `UsdPerMillionCredits`: __ (recommend keep at 1.0 unless arithmetic
+  forces otherwise)
+- **Hardware-tier filter**: enable initially? phase in over N weeks?
+  grandfather existing providers?
+- **Token issuance**: total beta budget, per-hour, per-token, per-tier
+  weight, vesting
+- **Beta cohort size**: cap providers at N
+- **Beta cohort duration**: how long does v2 pricing run before
+  forced revisit (e.g., 90 days or first paying buyer)
+
+Then a one-paragraph **operator pitch to providers** — the honest
+plain-English message:
+
+> "We're pricing the network to undercut OpenRouter on USD because
+> that's what attracts paying buyers. Your USD earnings will be
+> electricity-plus. We're issuing TOKEN_NAME to bridge the gap as a
+> network-equity stake — early providers earn more than late
+> entrants. Your hardware tier determines which jobs you can take and
+> what multiplier your token issuance gets. If you bought an M4 Air
+> hoping to earn $1/hr on 32B traffic, the honest answer is no — that
+> cell isn't physically viable at market-competitive buyer pricing.
+> If you bought an M-Ultra, this is the network for you."
+
+### Part 5 — DECISION_CRITERIA.md entry (ready to commit)
+
+Single numbered entry in established Entries 1-21 house style. Must
+contain:
+- **Decision**: USD multiplier + hardware-tier filter + token-issuance
+  design (one-line each)
+- **Why**: market table cell + Part 1 derivation + comparable-network
+  precedent for token design
+- **Effective**: when does new rate + tier filter + issuance go live
+  (next deploy? next cohort?)
+- **Re-trigger**: observable conditions that force revisit —
+  - First paying buyer revenue > $X
+  - Fleet sustained p50 TPS by tier crosses a target
+  - Token price moves outside the planning band
+  - Provider churn by tier exceeds Y%
+  - Beta cohort duration elapses
+- **Owner**: operator
+
+### Part 6 — Implementation pointers
+
+For each change, name file/line and whether it's hot-reloadable,
+new code, contract deployment, or pure operator messaging:
+
+- **USD multiplier**: hot-reload via SIGHUP at
+  `phase4-coordinator/internal/config/config.go:543` and live config
+- **Per-rate-card-row multiplier** (if Part 1 requires it): new SPEC
+  delta to SPEC-005, estimate code touch
+- **Hardware-tier filter**: new code — name the file in
+  `phase4-coordinator/internal/` where admission-control happens, with
+  rough complexity (~LOC estimate)
+- **Token issuance — beta-phase mechanic**:
+  - Option α: off-chain ledger that mints later at TGE (operator
+    bookkeeping, no on-chain dependency, can launch immediately)
+  - Option β: on-chain contract from day 1 (full transparency, higher
+    eng cost, requires contract audit)
+  - Recommend one + name the trade-off
+- **Provider portal copy**: which page(s) need updating —
+  portal.streamvc.live `pages/` or wherever; flag the tier-filter
+  explanation page as new
+
+Flag what's hot-reloadable, what needs a coordinator restart, what's
+new code, what's contract deployment, what's pure operator messaging.
+
+---
+
+## Out of scope
+
+- Specific token-contract Solidity / Move code (design only)
+- Real USDC payout rails (separate work)
+- MLX engineering throughput roadmap (RESEARCH_223)
+- Refactoring SPEC-005 D3 credit arithmetic (LOCKED)
+- Marketing strategy for buyer acquisition (network-side only)
+
+## Output format
+
+Markdown memo, **~500-900 lines**. Tables for Parts 1, 2, 3. Prose
+for Part 4 including the operator pitch verbatim. Code block for
+Part 5. Cite every market price and every analog-network parameter
+with source URL + date pulled. Conservative > optimistic on token
+valuation scenarios.

--- a/specs/RESEARCH_225_DARKBLOOM_COMPARISON_MEMO.md
+++ b/specs/RESEARCH_225_DARKBLOOM_COMPARISON_MEMO.md
@@ -1,0 +1,665 @@
+# codex advisor artifact
+
+- Provider: codex
+- Exit code: 0
+- Created at: 2026-06-30T05:44:42.603Z
+
+## Original task
+
+# RESEARCH PROMPT — Darkbloom.dev comparison: pricing, TPS, network architecture
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_225_DARKBLOOM_COMPARISON_PROMPT.md)"`
+
+This is a focused strategy research prompt — follow-up to RESEARCH_223
+(MLX throughput roadmap) and RESEARCH_224 (beta pricing v2). Single
+codex call. Output is a comparison memo + implications for both
+parent tracks.
+
+---
+
+## Task
+
+**Darkbloom.dev** is a distributed inference network the operator
+believes is architecturally similar to macprovider (modular, likely
+Apple Silicon-friendly, provider-supplied compute). Use it as a
+**live benchmark** for what pricing + per-token-throughput + model
+selection currently looks like on a comparable network as of
+2026-06-30. Findings feed both the MLX roadmap (Track A) and the
+beta pricing decision (Track B).
+
+If darkbloom.dev turns out to be architecturally different than
+expected (e.g., centralized, datacenter-GPU-only, training-focused
+rather than inference), say so clearly and report whatever they
+actually are — the operator wants ground truth, not a forced fit.
+
+---
+
+## Background — why we care
+
+Macprovider's current posture (pre v2):
+- USD multiplier 1.0 → buyer $1.00/M completion (3.5× over OpenRouter
+  Qwen3-32B $0.28/M)
+- Provider $0.045/hr at M4 Air × 14 tok/s × single stream
+- No hardware tier filter
+- No protocol token issued
+- Hardware fleet: predominantly M4 Air, small number M4 Max + M2 Ultra
+
+Track A (RESEARCH_223) concluded: at conservative 12-month TPS targets,
+**no Apple cell clears $0.30/hr at buyer-competitive USD ($0.25/M)**
+— token subsidy is structurally required. Track A recommended
+Roadmap D (hybrid): M4 Air for 7-8B only, 32B routed to M-Max/Ultra,
+llama.cpp `--parallel --cont-batching` as the best near-term
+engineering bet.
+
+Track B (RESEARCH_224, in flight) is producing the multiplier + tier
+filter + token issuance design.
+
+**The question for this memo**: does darkbloom.dev's live operating
+data validate, contradict, or refine the macprovider posture? If
+they're successfully serving paid inference on Apple Silicon at
+competitive pricing, how? If they tried and pivoted, why?
+
+---
+
+## What to produce
+
+### Part 1 — What is darkbloom.dev actually?
+
+Visit darkbloom.dev directly. Pull their docs, blog, GitHub org if any,
+Twitter/X account, Farcaster, Discord/Telegram public channels. Report:
+
+- **One-line elevator pitch** (their words, not yours)
+- **Founding date / launch date** (mainnet, testnet, alpha — whatever
+  they call it)
+- **Architecture**: distributed P2P? centralized aggregator with
+  provider back-ends? hub-and-spoke coordinator? cite the doc URL
+- **Hardware targeted**: Apple Silicon? consumer GPUs? datacenter? mix?
+- **Workload focus**: text inference? image gen? video? training?
+  fine-tuning? embeddings?
+- **Payment rail**: USD/USDC? own token? credits? gas-paid?
+- **Chain (if any)**: which L1/L2, contract addresses if findable
+- **Open source status**: is the coordinator / provider client / token
+  contract on GitHub? license?
+- **Public team / company / DAO structure**
+- **Funding** (a16z? paradigm? bootstrapped? token sale? grant?)
+
+If parts of this are not findable on public web, say "not disclosed"
+rather than guess.
+
+### Part 2 — Pricing surface
+
+Pull current **buyer-side pricing** for darkbloom.dev. Try every angle:
+
+- Public pricing page on darkbloom.dev
+- API docs with $/M-token rates
+- Twitter posts where they announced pricing
+- Comparable-pricing pages they reference
+- Community wiki / Discord faq mirrors
+
+Report:
+- $/1M prompt and $/1M completion **per model class** they list
+- Discount tiers, monthly minimums, prepaid credits
+- Trial credits / free tier
+- Whether their pricing is denominated in USD, USDC, or their own token
+- Date pulled + source URL
+
+Then **compare side-by-side** with macprovider's current default and
+the cheapest market rows from RESEARCH_222 v1 table (OpenRouter
+Qwen3-32B $0.28/M, Together Qwen2.5-Coder-32B $0.80/M, Groq 8B $0.04/M):
+
+| Model class | OpenRouter cheap | Darkbloom | macprovider current | Macprovider v2 target (TBD by Track B) |
+|---|---:|---:|---:|---:|
+| 7-8B | $0.04/M | ? | $1.00/M | ? |
+| 32B | $0.28/M | ? | $1.00/M | ? |
+| 70B | $0.32/M | ? | $1.00/M | ? |
+
+### Part 3 — Provider economics
+
+Pull whatever they publish about **provider-side earnings**. Try:
+
+- Provider onboarding page / "become a node operator" docs
+- Required hardware specs (which Apple Silicon SKUs? GPUs? RAM?)
+- Earning model: per-token-served? per-hour-online? staking-weighted?
+  token-issuance-weighted?
+- Stated $/hr or token/hr earnings ranges per hardware tier
+- Slashing / penalty mechanics
+- Vesting / cliff on early-provider rewards
+- Anti-sybil / KYC / staking-bond requirements
+- Date pulled + source URL
+
+If they publish a "what you'd earn" calculator, screenshot/record the
+inputs and outputs at a few realistic settings (M4 Air, M4 Max,
+24/7 vs 8h/day).
+
+### Part 4 — TPS / latency / quality claims
+
+Pull whatever they publish (or third parties have measured) about
+**observed throughput**:
+
+- Claimed sustained tok/s per hardware tier per model
+- Independent benchmarks (Twitter, blogs, Reddit, OpenRouter-style
+  aggregator pages that include them)
+- p50 / p95 / p99 latency to first token
+- Concurrent-streams handling (single-stream-only? continuous batching?
+  multi-tenant?)
+- Quality benchmarks (MMLU, HumanEval, etc.) for their hosted models
+
+Compare to Track A's per-cell targets:
+
+| Hardware × Model | Track A 12mo C | Darkbloom claim | Track A H100 ref |
+|---|---:|---:|---:|
+| M4 Max × 32B | 75 tok/s | ? | 1200 (32-stream) |
+| M2/M3 Ultra × 32B | 120-140 tok/s | ? | 1200 |
+| M3 Ultra × 70B | 65 tok/s | ? | 600 |
+
+If their claims contradict Track A's bandwidth-bound ceiling math
+(e.g. "M4 Air does 80 tok/s on Qwen3-32B"), flag explicitly — either
+they're using a different model definition (smaller, different
+quantization), running speculative decode, batch-aggregating across
+providers, or claim is marketing.
+
+### Part 5 — Cross-track implications
+
+Answer these explicitly:
+
+**For Track A (MLX roadmap)**:
+1. Does darkbloom.dev validate or contradict the "llama.cpp
+   `--parallel` is best near-term bet" finding?
+2. Are they using MLX, llama.cpp, or something else?
+3. Do they have a published throughput number that should make us
+   re-do any Track A 12-month target?
+4. Are they running speculative decode in production? draft-model
+   selection?
+
+**For Track B (pricing v2)**:
+1. What's their buyer USD price relative to macprovider's "undercut
+   OpenRouter by 10-30%" target?
+2. Are providers actually earning USD or only tokens? What's the
+   USD:token split?
+3. Are they tier-filtering hardware? what's the schema?
+4. Do they publish provider churn? cohort-size data? meta tells us
+   whether the token-subsidy model is working in the wild.
+5. If darkbloom.dev has both a buyer-competitive USD price AND
+   provider-viable earnings on Apple Silicon, **how do the numbers
+   actually work**? Reverse-engineer their math.
+
+**Hard call**: if darkbloom.dev is straightforwardly better than
+macprovider on multiple axes (price, hardware fit, provider
+economics), say so and recommend what macprovider should copy or
+differentiate on. If darkbloom.dev is worse / vaporware / abandoned,
+say that too — operator wants ground truth.
+
+### Part 6 — Differentiation / strategic implications
+
+If darkbloom.dev is real and operating, where can macprovider
+**differentiate** rather than compete head-on? Candidates:
+- Verifiable inference (cryptographic proof of model + prompt)
+- Privacy / local-first / no-data-retention guarantees
+- Specific model curation (e.g., only open-weights, no proprietary)
+- Specific buyer segments (developers? agents? enterprises?)
+- Specific provider segments (homelab? prosumer? professional?)
+- Integration surface (OpenAI-compat API, MCP, A2A, etc.)
+- Quality-of-service guarantees (latency SLOs, uptime, throughput
+  commitments)
+
+Or — recommend that macprovider just adopts darkbloom.dev's posture if
+it's clearly working.
+
+---
+
+## Out of scope
+
+- Reverse-engineering proprietary darkbloom.dev code (use only public
+  surfaces — docs, blog, GitHub if open, tweets, Discord public)
+- Copying any darkbloom.dev IP or trademarks
+- Reaching out to darkbloom.dev team for unpublished data
+- Producing code changes (memo only)
+- Producing SPEC delta (memo only)
+
+## Output format
+
+Markdown memo, **~300-600 lines**. Tables for Parts 2, 3, 4. Prose
+for Parts 1, 5, 6. Cite every claim with **source URL + date pulled**.
+If darkbloom.dev turns out to be different than expected (centralized,
+not Apple Silicon focused, abandoned, vaporware, scam, training-only,
+etc.), make that the lede — don't bury it. Conservative > optimistic
+on their claims; flag marketing-vs-measured throughout.
+
+## Final prompt
+
+# RESEARCH PROMPT — Darkbloom.dev comparison: pricing, TPS, network architecture
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_225_DARKBLOOM_COMPARISON_PROMPT.md)"`
+
+This is a focused strategy research prompt — follow-up to RESEARCH_223
+(MLX throughput roadmap) and RESEARCH_224 (beta pricing v2). Single
+codex call. Output is a comparison memo + implications for both
+parent tracks.
+
+---
+
+## Task
+
+**Darkbloom.dev** is a distributed inference network the operator
+believes is architecturally similar to macprovider (modular, likely
+Apple Silicon-friendly, provider-supplied compute). Use it as a
+**live benchmark** for what pricing + per-token-throughput + model
+selection currently looks like on a comparable network as of
+2026-06-30. Findings feed both the MLX roadmap (Track A) and the
+beta pricing decision (Track B).
+
+If darkbloom.dev turns out to be architecturally different than
+expected (e.g., centralized, datacenter-GPU-only, training-focused
+rather than inference), say so clearly and report whatever they
+actually are — the operator wants ground truth, not a forced fit.
+
+---
+
+## Background — why we care
+
+Macprovider's current posture (pre v2):
+- USD multiplier 1.0 → buyer $1.00/M completion (3.5× over OpenRouter
+  Qwen3-32B $0.28/M)
+- Provider $0.045/hr at M4 Air × 14 tok/s × single stream
+- No hardware tier filter
+- No protocol token issued
+- Hardware fleet: predominantly M4 Air, small number M4 Max + M2 Ultra
+
+Track A (RESEARCH_223) concluded: at conservative 12-month TPS targets,
+**no Apple cell clears $0.30/hr at buyer-competitive USD ($0.25/M)**
+— token subsidy is structurally required. Track A recommended
+Roadmap D (hybrid): M4 Air for 7-8B only, 32B routed to M-Max/Ultra,
+llama.cpp `--parallel --cont-batching` as the best near-term
+engineering bet.
+
+Track B (RESEARCH_224, in flight) is producing the multiplier + tier
+filter + token issuance design.
+
+**The question for this memo**: does darkbloom.dev's live operating
+data validate, contradict, or refine the macprovider posture? If
+they're successfully serving paid inference on Apple Silicon at
+competitive pricing, how? If they tried and pivoted, why?
+
+---
+
+## What to produce
+
+### Part 1 — What is darkbloom.dev actually?
+
+Visit darkbloom.dev directly. Pull their docs, blog, GitHub org if any,
+Twitter/X account, Farcaster, Discord/Telegram public channels. Report:
+
+- **One-line elevator pitch** (their words, not yours)
+- **Founding date / launch date** (mainnet, testnet, alpha — whatever
+  they call it)
+- **Architecture**: distributed P2P? centralized aggregator with
+  provider back-ends? hub-and-spoke coordinator? cite the doc URL
+- **Hardware targeted**: Apple Silicon? consumer GPUs? datacenter? mix?
+- **Workload focus**: text inference? image gen? video? training?
+  fine-tuning? embeddings?
+- **Payment rail**: USD/USDC? own token? credits? gas-paid?
+- **Chain (if any)**: which L1/L2, contract addresses if findable
+- **Open source status**: is the coordinator / provider client / token
+  contract on GitHub? license?
+- **Public team / company / DAO structure**
+- **Funding** (a16z? paradigm? bootstrapped? token sale? grant?)
+
+If parts of this are not findable on public web, say "not disclosed"
+rather than guess.
+
+### Part 2 — Pricing surface
+
+Pull current **buyer-side pricing** for darkbloom.dev. Try every angle:
+
+- Public pricing page on darkbloom.dev
+- API docs with $/M-token rates
+- Twitter posts where they announced pricing
+- Comparable-pricing pages they reference
+- Community wiki / Discord faq mirrors
+
+Report:
+- $/1M prompt and $/1M completion **per model class** they list
+- Discount tiers, monthly minimums, prepaid credits
+- Trial credits / free tier
+- Whether their pricing is denominated in USD, USDC, or their own token
+- Date pulled + source URL
+
+Then **compare side-by-side** with macprovider's current default and
+the cheapest market rows from RESEARCH_222 v1 table (OpenRouter
+Qwen3-32B $0.28/M, Together Qwen2.5-Coder-32B $0.80/M, Groq 8B $0.04/M):
+
+| Model class | OpenRouter cheap | Darkbloom | macprovider current | Macprovider v2 target (TBD by Track B) |
+|---|---:|---:|---:|---:|
+| 7-8B | $0.04/M | ? | $1.00/M | ? |
+| 32B | $0.28/M | ? | $1.00/M | ? |
+| 70B | $0.32/M | ? | $1.00/M | ? |
+
+### Part 3 — Provider economics
+
+Pull whatever they publish about **provider-side earnings**. Try:
+
+- Provider onboarding page / "become a node operator" docs
+- Required hardware specs (which Apple Silicon SKUs? GPUs? RAM?)
+- Earning model: per-token-served? per-hour-online? staking-weighted?
+  token-issuance-weighted?
+- Stated $/hr or token/hr earnings ranges per hardware tier
+- Slashing / penalty mechanics
+- Vesting / cliff on early-provider rewards
+- Anti-sybil / KYC / staking-bond requirements
+- Date pulled + source URL
+
+If they publish a "what you'd earn" calculator, screenshot/record the
+inputs and outputs at a few realistic settings (M4 Air, M4 Max,
+24/7 vs 8h/day).
+
+### Part 4 — TPS / latency / quality claims
+
+Pull whatever they publish (or third parties have measured) about
+**observed throughput**:
+
+- Claimed sustained tok/s per hardware tier per model
+- Independent benchmarks (Twitter, blogs, Reddit, OpenRouter-style
+  aggregator pages that include them)
+- p50 / p95 / p99 latency to first token
+- Concurrent-streams handling (single-stream-only? continuous batching?
+  multi-tenant?)
+- Quality benchmarks (MMLU, HumanEval, etc.) for their hosted models
+
+Compare to Track A's per-cell targets:
+
+| Hardware × Model | Track A 12mo C | Darkbloom claim | Track A H100 ref |
+|---|---:|---:|---:|
+| M4 Max × 32B | 75 tok/s | ? | 1200 (32-stream) |
+| M2/M3 Ultra × 32B | 120-140 tok/s | ? | 1200 |
+| M3 Ultra × 70B | 65 tok/s | ? | 600 |
+
+If their claims contradict Track A's bandwidth-bound ceiling math
+(e.g. "M4 Air does 80 tok/s on Qwen3-32B"), flag explicitly — either
+they're using a different model definition (smaller, different
+quantization), running speculative decode, batch-aggregating across
+providers, or claim is marketing.
+
+### Part 5 — Cross-track implications
+
+Answer these explicitly:
+
+**For Track A (MLX roadmap)**:
+1. Does darkbloom.dev validate or contradict the "llama.cpp
+   `--parallel` is best near-term bet" finding?
+2. Are they using MLX, llama.cpp, or something else?
+3. Do they have a published throughput number that should make us
+   re-do any Track A 12-month target?
+4. Are they running speculative decode in production? draft-model
+   selection?
+
+**For Track B (pricing v2)**:
+1. What's their buyer USD price relative to macprovider's "undercut
+   OpenRouter by 10-30%" target?
+2. Are providers actually earning USD or only tokens? What's the
+   USD:token split?
+3. Are they tier-filtering hardware? what's the schema?
+4. Do they publish provider churn? cohort-size data? meta tells us
+   whether the token-subsidy model is working in the wild.
+5. If darkbloom.dev has both a buyer-competitive USD price AND
+   provider-viable earnings on Apple Silicon, **how do the numbers
+   actually work**? Reverse-engineer their math.
+
+**Hard call**: if darkbloom.dev is straightforwardly better than
+macprovider on multiple axes (price, hardware fit, provider
+economics), say so and recommend what macprovider should copy or
+differentiate on. If darkbloom.dev is worse / vaporware / abandoned,
+say that too — operator wants ground truth.
+
+### Part 6 — Differentiation / strategic implications
+
+If darkbloom.dev is real and operating, where can macprovider
+**differentiate** rather than compete head-on? Candidates:
+- Verifiable inference (cryptographic proof of model + prompt)
+- Privacy / local-first / no-data-retention guarantees
+- Specific model curation (e.g., only open-weights, no proprietary)
+- Specific buyer segments (developers? agents? enterprises?)
+- Specific provider segments (homelab? prosumer? professional?)
+- Integration surface (OpenAI-compat API, MCP, A2A, etc.)
+- Quality-of-service guarantees (latency SLOs, uptime, throughput
+  commitments)
+
+Or — recommend that macprovider just adopts darkbloom.dev's posture if
+it's clearly working.
+
+---
+
+## Out of scope
+
+- Reverse-engineering proprietary darkbloom.dev code (use only public
+  surfaces — docs, blog, GitHub if open, tweets, Discord public)
+- Copying any darkbloom.dev IP or trademarks
+- Reaching out to darkbloom.dev team for unpublished data
+- Producing code changes (memo only)
+- Producing SPEC delta (memo only)
+
+## Output format
+
+Markdown memo, **~300-600 lines**. Tables for Parts 2, 3, 4. Prose
+for Parts 1, 5, 6. Cite every claim with **source URL + date pulled**.
+If darkbloom.dev turns out to be different than expected (centralized,
+not Apple Silicon focused, abandoned, vaporware, scam, training-only,
+etc.), make that the lede — don't bury it. Conservative > optimistic
+on their claims; flag marketing-vs-measured throughout.
+
+## Raw output
+
+```text
+**Memo: Darkbloom.dev Benchmark Pulled 2026-06-30**
+
+**Lede**
+
+Darkbloom is real and operating, but it is not a clean proof that dense 32B/70B Apple Silicon inference can clear provider economics at competitive buyer prices. It is a hub-and-spoke Apple Silicon inference network run by Eigen Labs, with provider-supplied Macs, OpenAI-compatible APIs, live providers, public stats, public pricing, and Stripe-based USD credits/payouts.
+
+The most important caveat: Darkbloom’s live catalog is mostly small-active-parameter MoE models, not dense 32B/70B models. Its buyer prices are excellent, but provider earnings are still mostly base rewards/subsidy, not organic usage revenue.
+
+Sources pulled 2026-06-30: https://darkbloom.dev, https://docs.darkbloom.dev/llms.txt, https://api.darkbloom.dev/v1/pricing, https://api.darkbloom.dev/v1/models/catalog, https://api.darkbloom.dev/v1/stats, https://api.darkbloom.dev/v1/network/totals?window=30d, https://www.darkbloom.dev/privacy.html, https://www.darkbloom.dev/terms.html, https://openrouter.ai/provider/darkbloom, https://www.bankless.com/read/eigen-labs-is-turning-idle-macs-into-a-private-ai-network.
+
+**Part 1: What Darkbloom Actually Is**
+
+One-line pitch, their words: cost-efficient private AI inference on verified Macs, routed to hardware-verified Apple Silicon providers. Source: https://darkbloom.dev, pulled 2026-06-30.
+
+Launch status: public alpha. Bankless reported the public alpha launch on May 28, 2026 and cited a May 26, 2026 upgrade from research preview to public alpha. Source: https://www.bankless.com/read/eigen-labs-is-turning-idle-macs-into-a-private-ai-network, pulled 2026-06-30.
+
+Architecture: not pure P2P. It is a centralized coordinator / aggregator routing layer with independently operated Mac providers. Users call a chat UI or OpenAI-compatible API; the coordinator matches requests to eligible providers; providers run the model and return outputs. Source: Bankless article and Darkbloom docs, pulled 2026-06-30.
+
+Hardware target: Apple Silicon only for providers. Docs say Apple Silicon M1 or later, macOS 14+, 16 GB minimum for the agent, and 36 GB+ recommended for the smallest catalog model. Source: https://docs.darkbloom.dev/provider/overview.md, pulled 2026-06-30.
+
+Workload focus: text/chat inference is live; docs/API also reference audio transcription, image generation, multimodal Gemma input, and OpenAI-compatible chat/completions. Live direct catalog on 2026-06-30 listed GPT-OSS 20B and Gemma 4 26B variants. Source: https://api.darkbloom.dev/v1/models/catalog, pulled 2026-06-30.
+
+Payment rail: USD prepaid credits via Stripe for buyers; Stripe Connect payouts for providers. Docs state a $0.50 minimum deposit and USD-denominated credits. Source: https://docs.darkbloom.dev/billing/add-credits.md and https://docs.darkbloom.dev/provider/earnings.md, pulled 2026-06-30.
+
+Chain / token: no Darkbloom-specific token or contract address found in official docs. Terms/privacy mention wallet and blockchain transaction data as possible payment/auth data, but public docs I verified only document Stripe USD credits and Stripe Connect payouts. Source: https://www.darkbloom.dev/terms.html and https://www.darkbloom.dev/privacy.html, pulled 2026-06-30.
+
+Open source status: a public `Layr-Labs/d-inference` GitHub repo exists and GitHub metadata describes it as “Private Inference Network on Idle Macs,” created 2026-03-15, but its GitHub API license field is `NOASSERTION`. I did not inspect repository source because this workspace’s AGENTS.md marks that repo as clean-room. Source: https://github.com/Layr-Labs/d-inference, pulled 2026-06-30.
+
+Company/team: Eigen Labs, Inc. operates Darkbloom; no separate DAO structure found. Source: https://www.darkbloom.dev/terms.html, pulled 2026-06-30.
+
+Funding: Darkbloom-specific funding not disclosed. Eigen Labs previously raised major funding from a16z crypto; that is parent/company context, not a Darkbloom-specific round. Source: https://blog.eigencloud.xyz/accelerating-ethereum-together-a16z-crypto-x-eigen-labs/, pulled 2026-06-30.
+
+Privacy caveat: Darkbloom marketing/docs describe encrypted/operator-blind inference, but the privacy policy is more conservative and says current service paths may require coordinator plaintext processing and disclosure to selected providers. Treat privacy as an active design direction with alpha-stage caveats, not a uniformly deployed end-to-end guarantee. Sources: https://docs.darkbloom.dev/security/overview.md and https://www.darkbloom.dev/privacy.html, pulled 2026-06-30.
+
+**Part 2: Pricing Surface**
+
+Current live direct API pricing on 2026-06-30:
+
+| Darkbloom live model | Class | Input $/1M | Output $/1M | Notes |
+|---|---:|---:|---:|---|
+| `gpt-oss-20b` | 20.9B MoE, 3.6B active | $0.0145 | $0.0700 | 24 GB min RAM, fp8 |
+| `gemma-4-26b` | 25.2B MoE, 3.8B active | $0.0300 | $0.1650 | 36 GB min RAM, 8-bit |
+| `gemma-4-26b-8bit` | 25.2B MoE, 3.8B active | $0.0300 | $0.1650 | rollback/beta variant |
+| `gemma-4-26b-qat-4bit` | 25.2B MoE, 3.8B active | $0.0300 | $0.1650 | 32 GB min RAM, multimodal beta |
+| fallback | unspecified | $0.0500 | $0.2000 | public fallback row |
+
+Source: https://api.darkbloom.dev/v1/pricing and https://api.darkbloom.dev/v1/models/catalog, pulled 2026-06-30.
+
+Docs pricing is stale or broader than current live API. Docs list Gemma 4 26B at $0.065/$0.20, Qwen3.5 27B at $0.10/$0.78, Qwen3.5 122B at $0.13/$1.04, and MiniMax M2.5 at $0.06/$0.50. The docs explicitly say to fetch `/v1/pricing` for current rates, so I treat the API as authoritative. Source: https://docs.darkbloom.dev/billing/pricing.md, pulled 2026-06-30.
+
+OpenRouter lists Darkbloom as a provider with two free variants: Gemma 4 26B A4B and GPT-OSS 20B, both `$0/M` input and output on OpenRouter at pull time. Source: https://openrouter.ai/provider/darkbloom, pulled 2026-06-30.
+
+Comparison table:
+
+| Model class | OpenRouter cheap | Darkbloom live direct | Darkbloom via OpenRouter | macprovider current | Macprovider v2 target |
+|---|---:|---:|---:|---:|---:|
+| 7-8B | $0.04/M | not listed live | not listed | $1.00/M | TBD |
+| ~20-26B MoE | n/a in provided table | $0.070-$0.165/M output | $0/M listed | $1.00/M | TBD |
+| 32B dense | $0.28/M | not listed live | not listed | $1.00/M | TBD |
+| 70B dense | $0.32/M | not listed live | not listed | $1.00/M | TBD |
+
+Buyer-side read: Darkbloom direct is far below macprovider current, but it is not serving the same dense 32B/70B class. OpenRouter’s free Darkbloom rows make the competitive comparison even harder for macprovider, but free capacity should be treated as promotional or partner-routed until a durable paid schedule is shown.
+
+**Part 3: Provider Economics**
+
+Published provider model: consumers pay per token; providers keep 100% of inference revenue during public alpha; payouts use Stripe Connect. Source: https://docs.darkbloom.dev/provider/earnings.md and https://darkbloom.dev, pulled 2026-06-30.
+
+Base rewards: Darkbloom’s public calculator includes a base-reward floor by memory tier, added on top of usage, for attested machines online at least 90% of the month. The site warns the base reward is not guaranteed and tapers as network grows. Source: https://darkbloom.dev/earn-calculator.js, pulled 2026-06-30.
+
+Calculator assumptions: 80% utilization, continuous batching at 4x, prompt:completion ratio about 3.5:1, single-stream efficiency 0.6 of memory bandwidth divided by active model GB. Source: https://darkbloom.dev/earn-calculator.js, pulled 2026-06-30.
+
+Provider calculator reverse-engineer, using current live prices and public calculator equations:
+
+| Hardware | Model | Online | Calc effective decode TPS | Usage net / hr | Base reward / mo | Monthly net |
+|---|---|---:|---:|---:|---:|---:|
+| M4 Air 24GB | GPT-OSS 20B | 8h/day | 57.6 | $0.0246 | $0 | $5.89 |
+| M4 Air 24GB | GPT-OSS 20B | 24/7 | 57.6 | $0.0246 | $10 | $27.68 |
+| M4 Air 32GB | Gemma 4 26B QAT | 8h/day | 57.6 | $0.0555 | $0 | $13.32 |
+| M4 Air 32GB | Gemma 4 26B QAT | 24/7 | 57.6 | $0.0555 | $12 | $51.97 |
+| M4 Max 48GB | Gemma 4 26B QAT | 8h/day | 262.1 | $0.2511 | $0 | $60.27 |
+| M4 Max 48GB | Gemma 4 26B QAT | 24/7 | 262.1 | $0.2511 | $16 | $196.82 |
+| M2 Ultra 64GB | Gemma 4 26B QAT | 24/7 | 384.0 | $0.3654 | $18 | $281.12 |
+| M3 Ultra 96GB | Gemma 4 26B QAT | 24/7 | 393.1 | $0.3731 | $22 | $290.64 |
+
+Reality check from live network totals:
+
+| Window | Active accounts | Total earnings | Work earnings | Reward earnings | Tokens | Jobs |
+|---|---:|---:|---:|---:|---:|---:|
+| 24h | 207 | $174.10 | $34.25 | $139.85 | 730.4M | 352,144 |
+| 7d | 287 | $1,103.87 | $162.17 | $941.71 | 3.57B | 1,773,011 |
+| 30d | 398 | $2,209.47 | $263.71 | $1,945.76 | 6.63B | 2,766,541 |
+
+Source: https://api.darkbloom.dev/v1/network/totals?window=24h, `7d`, `30d`, pulled 2026-06-30.
+
+Provider economics conclusion: calculator economics can look viable for M4 Max/Ultra under high utilization, but live demand does not yet support those earnings. Over 30 days, only about $263.71 of provider earnings were work revenue across 398 active accounts; the majority was reward/base-floor subsidy. This supports Track A’s “token subsidy structurally required” conclusion, except Darkbloom’s subsidy appears USD/reward-floor denominated rather than a protocol token.
+
+**Part 4: TPS / Latency / Quality Claims**
+
+Live network stats at pull:
+
+| Metric | Value |
+|---|---:|
+| Active providers | 333 |
+| Serving providers | 75 |
+| Online providers | 247 |
+| Untrusted providers | 11 |
+| Code-attested providers | 300 |
+| Total tokens served | 7.37B |
+| Total requests | 2.93M |
+| Total memory | 30,324 GB |
+| Total GPU cores | 11,894 |
+| Total memory bandwidth | 151,760 GB/s |
+| Reported network capacity | ~5,817 TPS |
+| Active requests | 133 |
+| Queued requests | 0 |
+
+Source: https://api.darkbloom.dev/v1/stats, pulled 2026-06-30.
+
+Hardware distribution snapshot:
+
+| Chip tier | Providers | Memory GB | GPU cores | Bandwidth GB/s |
+|---|---:|---:|---:|---:|
+| M4 Max | 62 | 4,416 | 2,320 | 31,132 |
+| M1 Max | 46 | 2,464 | 1,328 | 18,400 |
+| M3 Ultra | 35 | 11,360 | 2,480 | 28,665 |
+| M4 Pro | 35 | 1,520 | 640 | 9,555 |
+| M3 Max | 26 | 2,024 | 940 | 9,400 |
+| M2 Max | 24 | 1,472 | 864 | 9,600 |
+| M4 Base | 21 | 544 | 210 | 2,520 |
+| M2 Ultra | 19 | 2,112 | 1,204 | 15,200 |
+
+Source: https://api.darkbloom.dev/v1/stats, pulled 2026-06-30.
+
+Per-provider measured TPS: docs define a `decode_tps` field, but the sampled `/v1/stats` response had `decode_tps: 0` on inspected provider snapshots, so I do not treat per-device TPS as publicly measured. Source: https://docs.darkbloom.dev/reference/stats.md and https://api.darkbloom.dev/v1/stats, pulled 2026-06-30.
+
+Published/claimed model throughput: docs claim MiniMax M2.5 achieves approximately 100 tok/s on Apple Silicon, but MiniMax was not in the live direct catalog at pull time. Source: https://docs.darkbloom.dev/api/models.md and https://api.darkbloom.dev/v1/models/catalog, pulled 2026-06-30.
+
+Latency: I found no public p50/p95/p99 time-to-first-token metrics. Release metadata for v0.6.28 says a provider engine-loop change improved GPU utilization and lowered stream interval for user latency, but that is not an SLO or percentile benchmark. Source: https://api.darkbloom.dev/v1/releases/latest, pulled 2026-06-30.
+
+Quality benchmarks: I found no Darkbloom-run MMLU, HumanEval, SWE-bench, or comparable quality report. Model descriptions are mostly upstream model descriptions, not Darkbloom-specific evals. Source: https://api.darkbloom.dev/v1/models/catalog and https://docs.darkbloom.dev/api/models.md, pulled 2026-06-30.
+
+Track A comparison:
+
+| Hardware × Model | Track A 12mo C | Darkbloom claim / evidence | Track A H100 ref |
+|---|---:|---:|---:|
+| M4 Max × 32B dense | 75 tok/s | no live 32B dense; calculator implies ~82 single-stream TPS for 4B-active MoE, not dense 32B | 1200 |
+| M2/M3 Ultra × 32B dense | 120-140 tok/s | no live 32B dense; calculator implies ~120 single-stream TPS for 4B-active MoE | 1200 |
+| M3 Ultra × 70B dense | 65 tok/s | no live 70B; no measured public claim found | 600 |
+
+Interpretation: Darkbloom does not contradict Track A’s dense-model bandwidth ceiling. Their live win comes from MoE models with ~3.6B-3.8B active parameters, Apple Silicon memory aggregation, batching assumptions, and low marginal-cost hardware, not from proving M4 Air can serve Qwen3-32B dense at 80 tok/s.
+
+**Part 5: Cross-Track Implications**
+
+For Track A:
+
+1. Darkbloom does not validate “llama.cpp `--parallel` is best near-term bet.” It appears to use MLX-family Apple Silicon infrastructure, not llama.cpp. Docs mention `vllm-mlx` / `mlx-lm`; current installer/release metadata says `mlx-swift`.
+
+2. Darkbloom’s runtime appears to have migrated. Docs say bundled Python/vllm-mlx; live installer says Swift CLI, links `mlx-swift` directly, ships `mlx.metallib`, and has no Python inference subprocess. Source: https://api.darkbloom.dev/install.sh and https://api.darkbloom.dev/v1/releases/latest, pulled 2026-06-30.
+
+3. No Darkbloom number forces a Track A dense 32B/70B retarget. Their public capacity is not a dense Qwen3-32B benchmark.
+
+4. I found no evidence that Darkbloom is running speculative decode in production. Release notes mention an engine-loop scheduling fix and streaming interval, not draft-model speculation.
+
+5. Darkbloom does support the Track A architectural direction of routing models by hardware tier. Live catalog has min RAM gates: GPT-OSS 20B at 24 GB, Gemma QAT at 32 GB, Gemma 8-bit at 36 GB. Source: https://api.darkbloom.dev/v1/models/catalog, pulled 2026-06-30.
+
+For Track B:
+
+1. Darkbloom direct buyer pricing is well below macprovider current and below a “10-30% under OpenRouter Qwen3-32B” target for its live MoE class. But it is not a comparable dense 32B product.
+
+2. Providers appear to earn USD-denominated account credits/payouts, not only tokens. Provider payouts use Stripe Connect; network totals report micro-USD earnings. Source: docs/provider/earnings and `/v1/network/totals`, pulled 2026-06-30.
+
+3. Darkbloom tier-filters hardware via min RAM/model compatibility and attestation/trust status. It also tracks hardware family/tier, memory, GPU cores, bandwidth, and trust level in public stats.
+
+4. Provider churn/cohort data is partially visible: 398 active accounts in 30d, 333 connected providers at pull time, 205 providers with nonzero generated tokens in inspected current-session stats. It does not publish full churn cohorts.
+
+5. If Darkbloom has buyer-competitive USD price and provider-viable Apple Silicon earnings, the current math depends on rewards/base floors and optimistic utilization, not work revenue alone. The live 30d split is $263.71 work vs $1,945.76 rewards, so organic paid demand is not yet enough.
+
+Hard call: Darkbloom is ahead of macprovider on branding, public stats, OpenAI-compatible API, provider onboarding, hardware attestation story, and buyer pricing for current MoE models. It is not yet ahead as proof of durable provider economics. Its live data reinforces that subsidy/rewards are needed while demand ramps.
+
+**Part 6: Differentiation / Strategy**
+
+What macprovider should copy:
+
+| Darkbloom pattern | Why copy |
+|---|---|
+| Public `/stats`, `/pricing`, `/models` endpoints | Makes claims auditable and creates market confidence |
+| Hardware tier filters | Prevents weak hardware from serving wrong model classes |
+| Provider earnings transparency | Lets providers understand utilization and realistic pay |
+| OpenAI-compatible API | Lowers buyer migration friction |
+| Per-model RAM requirements | Reduces bad-provider UX and failed jobs |
+| Base rewards separated from work revenue | Makes subsidy visible instead of hiding it inside tokenomics |
+
+Where macprovider can differentiate:
+
+| Differentiation | Rationale |
+|---|---|
+| Dense 7-8B and 32B specialization | Darkbloom live catalog is MoE-heavy; macprovider can be explicit about dense model guarantees |
+| Honest provider economics | Publish “work revenue vs subsidy” from day one; Darkbloom’s own data shows this matters |
+| llama.cpp operational excellence | If Track A’s near-term bet is llama.cpp batching, own that lane instead of chasing MLX parity immediately |
+| Privacy claims with fewer caveats | Darkbloom has a marketing/privacy-policy mismatch; macprovider can win trust by being conservative and precise |
+| Model curation for agents/developers | Darkbloom’s live models are general; macprovider can focus on coding, tool-use, MCP/A2A agent traffic |
+| QoS tiers | Darkbloom public alpha disclaims SLAs; paid buyers may value latency/uptime commitments over lowest price |
+| Provider segment clarity | Aim separately at M4 Air 7-8B providers and M-Max/Ultra 32B providers instead of one blended fleet |
+
+Recommended posture:
+
+Do not copy Darkbloom’s exact model mix unless macprovider is willing to pivot from dense 32B economics to small-active MoE economics. Darkbloom’s live system strongly suggests that “Apple Silicon works” depends on using MoE active-parameter economics, RAM gating, batching, and subsidy. For macprovider, the v2 pricing design should explicitly separate buyer price, provider work revenue, and subsidy/reward budget.
+
+For Track A, keep Roadmap D: M4 Air for 7-8B, 32B routed to M-Max/Ultra, near-term batching work. Darkbloom does not disprove that.
+
+For Track B, adopt a Darkbloom-like public pricing and earnings surface, but do not infer that buyer-competitive pricing alone solves provider viability. The live Darkbloom split shows that subsidy is still carrying the provider side.
+
+
+```

--- a/specs/RESEARCH_225_DARKBLOOM_COMPARISON_PROMPT.md
+++ b/specs/RESEARCH_225_DARKBLOOM_COMPARISON_PROMPT.md
@@ -1,0 +1,218 @@
+# RESEARCH PROMPT — Darkbloom.dev comparison: pricing, TPS, network architecture
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_225_DARKBLOOM_COMPARISON_PROMPT.md)"`
+
+This is a focused strategy research prompt — follow-up to RESEARCH_223
+(MLX throughput roadmap) and RESEARCH_224 (beta pricing v2). Single
+codex call. Output is a comparison memo + implications for both
+parent tracks.
+
+---
+
+## Task
+
+**Darkbloom.dev** is a distributed inference network the operator
+believes is architecturally similar to macprovider (modular, likely
+Apple Silicon-friendly, provider-supplied compute). Use it as a
+**live benchmark** for what pricing + per-token-throughput + model
+selection currently looks like on a comparable network as of
+2026-06-30. Findings feed both the MLX roadmap (Track A) and the
+beta pricing decision (Track B).
+
+If darkbloom.dev turns out to be architecturally different than
+expected (e.g., centralized, datacenter-GPU-only, training-focused
+rather than inference), say so clearly and report whatever they
+actually are — the operator wants ground truth, not a forced fit.
+
+---
+
+## Background — why we care
+
+Macprovider's current posture (pre v2):
+- USD multiplier 1.0 → buyer $1.00/M completion (3.5× over OpenRouter
+  Qwen3-32B $0.28/M)
+- Provider $0.045/hr at M4 Air × 14 tok/s × single stream
+- No hardware tier filter
+- No protocol token issued
+- Hardware fleet: predominantly M4 Air, small number M4 Max + M2 Ultra
+
+Track A (RESEARCH_223) concluded: at conservative 12-month TPS targets,
+**no Apple cell clears $0.30/hr at buyer-competitive USD ($0.25/M)**
+— token subsidy is structurally required. Track A recommended
+Roadmap D (hybrid): M4 Air for 7-8B only, 32B routed to M-Max/Ultra,
+llama.cpp `--parallel --cont-batching` as the best near-term
+engineering bet.
+
+Track B (RESEARCH_224, in flight) is producing the multiplier + tier
+filter + token issuance design.
+
+**The question for this memo**: does darkbloom.dev's live operating
+data validate, contradict, or refine the macprovider posture? If
+they're successfully serving paid inference on Apple Silicon at
+competitive pricing, how? If they tried and pivoted, why?
+
+---
+
+## What to produce
+
+### Part 1 — What is darkbloom.dev actually?
+
+Visit darkbloom.dev directly. Pull their docs, blog, GitHub org if any,
+Twitter/X account, Farcaster, Discord/Telegram public channels. Report:
+
+- **One-line elevator pitch** (their words, not yours)
+- **Founding date / launch date** (mainnet, testnet, alpha — whatever
+  they call it)
+- **Architecture**: distributed P2P? centralized aggregator with
+  provider back-ends? hub-and-spoke coordinator? cite the doc URL
+- **Hardware targeted**: Apple Silicon? consumer GPUs? datacenter? mix?
+- **Workload focus**: text inference? image gen? video? training?
+  fine-tuning? embeddings?
+- **Payment rail**: USD/USDC? own token? credits? gas-paid?
+- **Chain (if any)**: which L1/L2, contract addresses if findable
+- **Open source status**: is the coordinator / provider client / token
+  contract on GitHub? license?
+- **Public team / company / DAO structure**
+- **Funding** (a16z? paradigm? bootstrapped? token sale? grant?)
+
+If parts of this are not findable on public web, say "not disclosed"
+rather than guess.
+
+### Part 2 — Pricing surface
+
+Pull current **buyer-side pricing** for darkbloom.dev. Try every angle:
+
+- Public pricing page on darkbloom.dev
+- API docs with $/M-token rates
+- Twitter posts where they announced pricing
+- Comparable-pricing pages they reference
+- Community wiki / Discord faq mirrors
+
+Report:
+- $/1M prompt and $/1M completion **per model class** they list
+- Discount tiers, monthly minimums, prepaid credits
+- Trial credits / free tier
+- Whether their pricing is denominated in USD, USDC, or their own token
+- Date pulled + source URL
+
+Then **compare side-by-side** with macprovider's current default and
+the cheapest market rows from RESEARCH_222 v1 table (OpenRouter
+Qwen3-32B $0.28/M, Together Qwen2.5-Coder-32B $0.80/M, Groq 8B $0.04/M):
+
+| Model class | OpenRouter cheap | Darkbloom | macprovider current | Macprovider v2 target (TBD by Track B) |
+|---|---:|---:|---:|---:|
+| 7-8B | $0.04/M | ? | $1.00/M | ? |
+| 32B | $0.28/M | ? | $1.00/M | ? |
+| 70B | $0.32/M | ? | $1.00/M | ? |
+
+### Part 3 — Provider economics
+
+Pull whatever they publish about **provider-side earnings**. Try:
+
+- Provider onboarding page / "become a node operator" docs
+- Required hardware specs (which Apple Silicon SKUs? GPUs? RAM?)
+- Earning model: per-token-served? per-hour-online? staking-weighted?
+  token-issuance-weighted?
+- Stated $/hr or token/hr earnings ranges per hardware tier
+- Slashing / penalty mechanics
+- Vesting / cliff on early-provider rewards
+- Anti-sybil / KYC / staking-bond requirements
+- Date pulled + source URL
+
+If they publish a "what you'd earn" calculator, screenshot/record the
+inputs and outputs at a few realistic settings (M4 Air, M4 Max,
+24/7 vs 8h/day).
+
+### Part 4 — TPS / latency / quality claims
+
+Pull whatever they publish (or third parties have measured) about
+**observed throughput**:
+
+- Claimed sustained tok/s per hardware tier per model
+- Independent benchmarks (Twitter, blogs, Reddit, OpenRouter-style
+  aggregator pages that include them)
+- p50 / p95 / p99 latency to first token
+- Concurrent-streams handling (single-stream-only? continuous batching?
+  multi-tenant?)
+- Quality benchmarks (MMLU, HumanEval, etc.) for their hosted models
+
+Compare to Track A's per-cell targets:
+
+| Hardware × Model | Track A 12mo C | Darkbloom claim | Track A H100 ref |
+|---|---:|---:|---:|
+| M4 Max × 32B | 75 tok/s | ? | 1200 (32-stream) |
+| M2/M3 Ultra × 32B | 120-140 tok/s | ? | 1200 |
+| M3 Ultra × 70B | 65 tok/s | ? | 600 |
+
+If their claims contradict Track A's bandwidth-bound ceiling math
+(e.g. "M4 Air does 80 tok/s on Qwen3-32B"), flag explicitly — either
+they're using a different model definition (smaller, different
+quantization), running speculative decode, batch-aggregating across
+providers, or claim is marketing.
+
+### Part 5 — Cross-track implications
+
+Answer these explicitly:
+
+**For Track A (MLX roadmap)**:
+1. Does darkbloom.dev validate or contradict the "llama.cpp
+   `--parallel` is best near-term bet" finding?
+2. Are they using MLX, llama.cpp, or something else?
+3. Do they have a published throughput number that should make us
+   re-do any Track A 12-month target?
+4. Are they running speculative decode in production? draft-model
+   selection?
+
+**For Track B (pricing v2)**:
+1. What's their buyer USD price relative to macprovider's "undercut
+   OpenRouter by 10-30%" target?
+2. Are providers actually earning USD or only tokens? What's the
+   USD:token split?
+3. Are they tier-filtering hardware? what's the schema?
+4. Do they publish provider churn? cohort-size data? meta tells us
+   whether the token-subsidy model is working in the wild.
+5. If darkbloom.dev has both a buyer-competitive USD price AND
+   provider-viable earnings on Apple Silicon, **how do the numbers
+   actually work**? Reverse-engineer their math.
+
+**Hard call**: if darkbloom.dev is straightforwardly better than
+macprovider on multiple axes (price, hardware fit, provider
+economics), say so and recommend what macprovider should copy or
+differentiate on. If darkbloom.dev is worse / vaporware / abandoned,
+say that too — operator wants ground truth.
+
+### Part 6 — Differentiation / strategic implications
+
+If darkbloom.dev is real and operating, where can macprovider
+**differentiate** rather than compete head-on? Candidates:
+- Verifiable inference (cryptographic proof of model + prompt)
+- Privacy / local-first / no-data-retention guarantees
+- Specific model curation (e.g., only open-weights, no proprietary)
+- Specific buyer segments (developers? agents? enterprises?)
+- Specific provider segments (homelab? prosumer? professional?)
+- Integration surface (OpenAI-compat API, MCP, A2A, etc.)
+- Quality-of-service guarantees (latency SLOs, uptime, throughput
+  commitments)
+
+Or — recommend that macprovider just adopts darkbloom.dev's posture if
+it's clearly working.
+
+---
+
+## Out of scope
+
+- Reverse-engineering proprietary darkbloom.dev code (use only public
+  surfaces — docs, blog, GitHub if open, tweets, Discord public)
+- Copying any darkbloom.dev IP or trademarks
+- Reaching out to darkbloom.dev team for unpublished data
+- Producing code changes (memo only)
+- Producing SPEC delta (memo only)
+
+## Output format
+
+Markdown memo, **~300-600 lines**. Tables for Parts 2, 3, 4. Prose
+for Parts 1, 5, 6. Cite every claim with **source URL + date pulled**.
+If darkbloom.dev turns out to be different than expected (centralized,
+not Apple Silicon focused, abandoned, vaporware, scam, training-only,
+etc.), make that the lede — don't bury it. Conservative > optimistic
+on their claims; flag marketing-vs-measured throughout.

--- a/specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_MEMO.md
+++ b/specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_MEMO.md
@@ -1,0 +1,454 @@
+# RESEARCH_226 — MoE Model Selection on Apple Silicon + OpenRouter Market Demand
+
+Date pulled: 2026-06-30  
+Scope: narrow follow-up to RESEARCH_223, RESEARCH_224, and RESEARCH_225  
+Decision target: whether macprovider v2 should add MoE-class `rewards.rate_card` rows
+
+## Executive Decision
+
+Add MoE rows at v2 launch, but do not add a broad MoE catalog.
+
+Initial listing should be:
+
+1. `gpt-oss-20b`
+2. `google/gemma-4-26b-a4b-it`
+3. `qwen3-30b-a3b` only if Track A supports Qwen3-MoE reliably through MLX/LM Studio/llama.cpp routing
+
+Hold:
+
+1. `qwen3-next-80b-a3b-instruct` until Tier-A/Tier-S real-hardware bench confirms stable multi-stream economics.
+2. `minimax-m2.7` until Tier-S-only economics clear the operational threshold.
+3. `mixtral-8x7b`, `phi-3.5-moe`, `dbrx`, and `mixtral-8x22b` because demand is weak or the model is dated versus newer MoE traffic.
+
+Core finding: active parameters materially improve decode TPS, but they do not eliminate nominal-weight residency. A 3B-active model with 80B total weights still needs roughly 42 GB at 4-bit, so min-RAM remains a hard admission rule. Bandwidth-tier should become a performance filter, not the first eligibility gate.
+
+## Source Register
+
+All source claims below were pulled on 2026-06-30.
+
+| Source | URL | Used for |
+|---|---|---|
+| OpenRouter public model API | https://openrouter.ai/api/v1/models | Model IDs, canonical slugs, prices, descriptions |
+| OpenRouter public rankings API | https://openrouter.ai/api/frontend/v1/rankings/models | Daily completion-token volume and request counts |
+| OpenRouter provider endpoint API | `https://openrouter.ai/api/v1/models/<model>/endpoints` | Cheapest public provider price per model |
+| OpenRouter rankings page | https://openrouter.ai/rankings | Confirms rankings are based on real usage data |
+| OpenAI gpt-oss-20b model card | https://huggingface.co/openai/gpt-oss-20b | 21B total, 3.6B active, Apache 2.0, MXFP4 memory note |
+| Google Gemma 4 26B A4B model card | https://huggingface.co/google/gemma-4-26B-A4B-it | 25.2B total, 3.8B active, 256K context, Apache 2.0 |
+| Qwen3-30B-A3B model card | https://huggingface.co/Qwen/Qwen3-30B-A3B | 30.5B total, 3.3B active, 128 experts, local runtime support |
+| Qwen3-235B-A22B model card | https://huggingface.co/Qwen/Qwen3-235B-A22B | 235B total, 22B active, local runtime support |
+| Qwen3-Next-80B-A3B model card | https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct | 80B total, 3B active, 256K native context |
+| Phi-3.5-MoE model card | https://huggingface.co/microsoft/Phi-3.5-MoE-instruct | 6.6B active, 128K context, MIT |
+| DeepSeek-V2-Lite model card | https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite | 15.7B total, 2.4B active, model license |
+| MiniMax-M2.7 model card | https://huggingface.co/MiniMaxAI/MiniMax-M2.7 | License and model availability |
+| HF blob metadata | `https://huggingface.co/api/models/<repo>?blobs=true` | Quantized file-size estimates |
+| LLMCheck benchmarks | https://llmcheck.net/benchmarks.html | Apple Silicon benchmark corpus context |
+| LocalLLaMA Qwen3 M4/M3 thread | https://www.reddit.com/r/LocalLLaMA/comments/1ltg9ji/m4_max_vs_m3_ultra_qwen3_mlx_inference/ | Qwen3-30B-A3B anecdotal 65 tok/s M4 Pro, M3 Ultra comparison |
+| LocalLLM Qwen3 M4 Max thread | https://www.reddit.com/r/LocalLLM/comments/1l6lxcr/qwen3_30b_a3b_on_macbook_pro_m4_frankly_its_crazy/ | Qwen3-30B-A3B 103 tok/s M4 Max anecdote |
+| HN Qwen3 MLX comment | https://news.ycombinator.com/item?id=44635589 | Qwen3-30B-A3B 70-100 tok/s M4 Max anecdote |
+| Alex Dong Qwen3 local article | https://alexdong.com/qwen3-30b-a3b-the-new-choice-for-nz-organizations-prioritizing-data-sovereignty.html | Qwen3-30B-A3B 78 tok/s M4 Max reported |
+| G13N Gemma 4 article | https://g13n.substack.com/p/gemma-4-is-here-i-tested-all-four | Gemma 4 26B A4B 53 tok/s vs dense 31B 6.59 tok/s on same M2 Max |
+| Reddit Gemma 4 M4 Pro thread | https://www.reddit.com/r/LocalLLaMA/comments/1u554eo/diffusiongemma26ba4bit4bit_on_macbook_4_pro_with/ | Gemma 4 26B A4B QAT around 38 tok/s on MacBook M4 Pro 48GB |
+| X Gemma 4 M4 Mini post | https://x.com/measure_plan/status/2040069272613834847 | Gemma 4 26B A4B around 34 tok/s on Mac mini M4 16GB |
+| LM Studio Qwen3 page | https://lmstudio.ai/models/qwen/qwen3-30b-a3b | 3.3B activated weights, 128 total and 8 active experts |
+| Darkbloom public home | https://www.darkbloom.dev/ | Verified-Mac positioning and about-50%-lower-cost claim |
+
+## Method Notes
+
+1. Pricing is public OpenRouter endpoint pricing unless explicitly marked otherwise.
+2. OpenRouter rankings are the latest complete daily rows in `/api/frontend/v1/rankings/models`: 2026-06-29 00:00:00.
+3. Rankings were aggregated by `model_permaslug` to avoid double-counting variants shown separately in the raw API.
+4. File sizes are from HF blob metadata where available. For missing 8-bit sizes, estimates use roughly 2x 4-bit size unless a Q8 blob exists.
+5. TPS cells are conservative sustained single-stream estimates for 4K context. Published Apple-Silicon measurements are sparse; cells without direct benchmarks are marked as extrapolated.
+6. `S/C` means sustained single-stream tok/s and practical concurrent streams before quality-of-service or memory pressure becomes the bottleneck.
+7. Active-param bandwidth math is an upper bound only. MoE gating, dense attention layers, KV movement, runtime overhead, and context length lower real throughput.
+8. Min RAM is production min, not theoretical boot min. A model can sometimes load at lower RAM but still be unsuitable for paid routing.
+
+## Part 1 — MoE Model Catalog
+
+| Model | Nominal | Active | Native MLX | GGUF | 4bit GB | 8bit GB | Min RAM 4K ctx | Smallest tier servable | License | Apple Silicon readiness |
+|---|---:|---:|:-:|:-:|---:|---:|---:|---|---|---|
+| `openai/gpt-oss-20b` | 21B | 3.6B | Partial/community | Yes | 10.7-11.3 | 11.3 native MXFP4/Q8-like | 16-24 GB | Tier-C 24GB | Apache-2.0 | Good; model card says MXFP4 runs within 16GB, but paid routing should require 24GB |
+| `google/gemma-4-26b-a4b-it` | 25.2B | 3.8B | Yes | Yes | 14.0-15.9 | 25.0-25.7 | 24-32 GB | Tier-C 32GB, Tier-B 24/48GB | Apache-2.0 | Good; strong MLX/GGUF availability, current demand |
+| `google/gemma-4-26b-a4b-it-qat` | 25.2B | 3.8B | Yes | Yes | 14.5-15.4 | n/a | 24-32 GB | Tier-C 32GB | Apache-2.0 | Good; QAT variants have high HF download activity |
+| `qwen/qwen3-30b-a3b` | 30.5B | 3.3B | Yes | Yes | 15.3-17.4 | 30.3-33.5 | 24-32 GB | Tier-C 32GB, Tier-B 24/48GB | Apache-2.0 | Good; best Apple anecdotal benchmark coverage |
+| `qwen/qwen3-30b-a3b-instruct-2507` | 30.5B | 3.3B | Yes | Yes | 15.3-17.3 | 30.3-33.5 | 24-32 GB | Tier-C 32GB | Apache-2.0 | Good; demand lower than base slug but current |
+| `qwen/qwen3-next-80b-a3b-instruct` | 80B | 3B | Yes | Yes | 39.7-45.4 | 79.0-86.7 | 64 GB | Tier-A 64GB | Apache-2.0 | Promising but not v2-launch default; residency dominates |
+| `qwen/qwen3-235b-a22b` | 235B | 22B | Yes | Yes | 123 GB MLX | estimated 240+ | 192 GB | Tier-S 192GB+ | Apache-2.0 | Tier-S-only; throughput may not beat dense 32B enough after weight load |
+| `deepseek-ai/DeepSeek-V2-Lite-Chat` | 15.7B | 2.4B | Yes | Yes | 8.0-9.7 | 15.6 | 16 GB | Tier-C 16GB | DeepSeek model license, commercial allowed by card | Efficient but not current high OpenRouter demand |
+| `microsoft/Phi-3.5-MoE-instruct` | 41.9B | 6.6B | Yes | Yes | 20.8-23.6 | 41.4 | 32 GB | Tier-C 32GB, Tier-B | MIT | Technically servable; weak current demand |
+| `mistralai/Mixtral-8x7B-Instruct-v0.1` | 46.7B | about 12.9B | Yes | Yes | 24.6 | 46.2 | 48 GB | Tier-B 48GB, Tier-A | Apache-2.0 | Stable but dated; demand weak |
+| `mistralai/Mixtral-8x22B-Instruct-v0.1` | 141B | 39B | No strong MLX row found | Yes | estimated 80+ | estimated 150+ | 128-192 GB | Tier-S; M4 Max 128GB possible but poor economics | Apache-2.0 | Skip; active params too large and demand weak |
+| `databricks/dbrx-instruct` | 132B | 36B | Yes, old community | Yes, sparse community | 69.8 MLX | estimated 135+ | 128 GB | Tier-S; M4 Max 128GB possible | Databricks Open Model License | Skip; dated and slow |
+| `MiniMax-M2.7` | likely 172B-class | likely A10B-class | No strong MLX | Yes | 101-131 | 226-230 | 192 GB | Tier-S 192GB+ | MiniMax license | High demand but Tier-S-only; not v2 launch |
+| `MiniMax-M3` | not fully verified | likely MoE | No Apple path verified | API only / unknown | n/a | n/a | n/a | Not listed | unknown | High OpenRouter demand, but no clear Apple-Silicon route |
+| `DeepSeek-V4-Flash` | not fully verified | likely MoE-mid | No Apple path verified | GGUF community exists | unknown | unknown | unknown | Not listed | unknown | Highest demand, but no production-ready AS path established |
+| `DeepSeek-V4-Pro` | not fully verified | likely MoE-large | No Apple path verified | unknown | unknown | unknown | unknown | Not listed | unknown | High demand, inefficient/unknown AS route |
+| `Yi-34Bx2-MoE-60B` | 60B-ish | unknown | No | Yes | unknown | unknown | 48-64 GB | Tier-A maybe | unclear | Skip; low current demand, non-mainstream |
+
+Production-readiness conclusions:
+
+1. The currently viable Apple-Silicon MoE class is not “any MoE”; it is “small-active MoE with 4-bit nominal residency under about 18 GB.”
+2. The strongest initial rows are GPT-OSS-20B, Gemma 4 26B A4B, and Qwen3-30B-A3B.
+3. Qwen3-Next-80B-A3B is the most interesting holdout: active size is tiny, but 4-bit weights are around 42 GB, so it is not a Tier-C unlock.
+4. MiniMax and DeepSeek top OpenRouter demand is strategically important, but current Apple-Silicon readiness is not decision-grade.
+
+## Part 2 — Per-Active-Param TPS Matrix
+
+Hardware bandwidth assumptions:
+
+| Tier | Representative hardware | Bandwidth proxy |
+|---|---|---:|
+| Tier-C | M4 Air / base M4 | 120 GB/s |
+| Tier-B | M4 Pro | 273 GB/s |
+| Tier-A | M4 Max | 546 GB/s |
+| Tier-S | M2 Ultra | 800 GB/s |
+| Tier-S+ | M3 Ultra | 819 GB/s |
+
+Dense reference copied from RESEARCH_223:
+
+| Dense reference | M4 Air | M4 Max | M2/M3 Ultra |
+|---|---:|---:|---:|
+| Qwen3-32B dense 4bit | 14 tok/s observed, 8-16 target | 25-75 tok/s | 42-140 tok/s |
+
+TPS matrix:
+
+| Model | Active GB 4bit | M4 Air S/C | M4 Pro S/C | M4 Max S/C | M2 Ultra S/C | M3 Ultra S/C | Evidence |
+|---|---:|---:|---:|---:|---:|---:|---|
+| GPT-OSS 20B, 3.6B active | 1.8 | 35-50 / 1-2 | 55-80 / 2-3 | 80-115 / 3-4 | 95-130 / 4-6 | 100-135 / 4-6 | Extrapolated from active GB and Qwen/Gemma anchors |
+| Gemma 4 26B A4B, 3.8B active | 1.9 | 30-45 / 1-2 | 38-70 / 2-3 | 75-105 / 3-4 | 90-125 / 4-5 | 95-130 / 4-5 | Published 34 tok/s M4 Mini 16GB; 38 tok/s M4 Pro; 53 tok/s M2 Max |
+| Qwen3-30B-A3B, 3.3B active | 1.65 | 30-45 / 1-2 | 55-75 / 2-3 | 70-105 / 3-4 | 85-115 / 4-6 | 90-125 / 4-6 | Published anecdotes: 65 tok/s M4 Pro, 78-103 tok/s M4 Max, 94.95 tok/s M3 Ultra |
+| Qwen3-Next-80B-A3B | 1.5 | OOM | 48GB borderline/OOM | 35-55 / 1-2 | 45-65 / 2-3 | 50-70 / 2-3 | Extrapolated; high nominal residency and hybrid attention lower active-param gain |
+| Qwen3-235B-A22B | 11.0 | OOM | OOM | OOM except 128GB risky | 12-20 / 1 | 14-24 / 1 | Extrapolated; 123 GB MLX 4bit weight residency |
+| DeepSeek-V2-Lite, 2.4B active | 1.2 | 35-55 / 2 | 60-90 / 3 | 85-125 / 4 | 100-145 / 5-6 | 105-150 / 5-6 | Extrapolated; low demand limits relevance |
+| Mixtral 8x7B, about 13B active | 6.5 | OOM/32GB only 12-18 | 18-30 / 1-2 | 25-45 / 2 | 35-55 / 2-3 | 38-60 / 2-3 | Extrapolated; older GGUF/MLX rows |
+| Phi-3.5-MoE, 6.6B active | 3.3 | 22-35 / 1 | 38-60 / 2 | 55-80 / 2-3 | 70-95 / 3-4 | 75-100 / 3-4 | Extrapolated; model card active-param fact only |
+| DBRX, 36B active | 18.0 | OOM | OOM | 128GB only 8-14 / 1 | 10-18 / 1 | 12-20 / 1 | Extrapolated; 69.8 GB 4bit MLX residency |
+| MiniMax M2.7, A10B-ish active | about 5.0 | OOM | OOM | OOM/128GB risky | 25-45 / 1-2 | 30-50 / 1-2 | Extrapolated; 101+ GB 4bit GGUF residency |
+
+Cells that beat dense Qwen3-32B on the same hardware:
+
+| Hardware | MoE cells likely beating dense-32B | Why it matters |
+|---|---|---|
+| M4 Air 24/32GB | GPT-OSS-20B, Gemma 4 26B A4B, Qwen3-30B-A3B, DeepSeek-V2-Lite, Phi-3.5-MoE on 32GB | These convert Tier-C from “small dense only” into credible 20-30B nominal service |
+| M4 Pro 24/48GB | GPT-OSS-20B, Gemma 4 26B A4B, Qwen3-30B-A3B, DeepSeek-V2-Lite, Phi-3.5-MoE | Best practical Tier-B uplift |
+| M4 Max 64/128GB | GPT-OSS-20B, Gemma 4 26B A4B, Qwen3-30B-A3B, DeepSeek-V2-Lite, Phi-3.5-MoE; maybe Qwen3-Next quality/value | MoE-small-active is clearly competitive with dense 32B |
+| M2/M3 Ultra | Small-active MoE beats dense 32B on latency but not always on economics; large-active MoE does not obviously beat dense 32B | Ultra should serve high-demand rows, not old large-active MoE by default |
+
+Important caveat:
+
+The active-param math explains why Gemma 4 A4B can beat dense Gemma 4 31B on the same machine, but it does not guarantee provider economics. At sub-$0.50/M market prices, even 100 tok/s produces only cents per hour per stream.
+
+## Part 3 — OpenRouter Market Demand
+
+Latest public OpenRouter ranking date: 2026-06-29 00:00:00.
+
+Total completion tokens across the latest day in the public ranking API: 1,460,730,098,305.
+
+Top 30 models by aggregated completion-token volume:
+
+| Rank | Model | Class | Completion tokens | Requests | $/M completion | Trend/source |
+|---:|---|---|---:|---:|---:|---|
+| 1 | `deepseek/deepseek-v4-flash-20260423` | MoE-mid-active, AS readiness unknown | 225,013,926,597 | 438,201,339 | 0.18 | OpenRouter rankings API |
+| 2 | `deepseek/deepseek-v4-pro-20260423` | MoE-large-active, AS readiness unknown | 100,729,229,003 | 77,896,743 | 0.87 | OpenRouter rankings API |
+| 3 | `openai/gpt-oss-120b` | MoE-small-active but high residency | 76,752,010,629 | 126,258,644 | 0.15 | OpenRouter rankings API |
+| 4 | `google/gemini-2.5-flash-lite` | Closed/unknown | 57,871,444,190 | 252,734,487 | 0.40 | OpenRouter rankings API |
+| 5 | `tencent/hy3-preview-20260421` | MoE-mid-active, AS readiness unknown | 53,696,479,752 | 67,104,927 | 0.21 | OpenRouter rankings API |
+| 6 | `minimax/minimax-m3-20260531` | MoE, AS readiness unknown | 52,787,716,249 | 60,274,967 | 1.20 | OpenRouter rankings API |
+| 7 | `deepseek/deepseek-v3.2-20251201` | MoE-large-active | 48,113,439,517 | 75,245,837 | 0.343 | OpenRouter rankings API |
+| 8 | `z-ai/glm-5.2-20260616` | MoE/unknown-active | 42,230,709,327 | 43,724,601 | 3.00 | OpenRouter rankings API |
+| 9 | `google/gemini-3-flash-preview-20251217` | Closed/unknown | 42,155,645,958 | 122,327,788 | 3.00 | OpenRouter rankings API |
+| 10 | `google/gemini-2.5-flash` | Closed/unknown | 40,297,523,749 | 162,733,532 | 2.50 | OpenRouter rankings API |
+| 11 | `xiaomi/mimo-v2.5-20260422` | MoE-mid-active, AS readiness unknown | 38,303,340,154 | 66,764,662 | 0.28 | OpenRouter rankings API |
+| 12 | `google/gemini-3.1-flash-lite-20260507` | Closed/unknown | 34,265,159,053 | 95,008,589 | 1.50 | OpenRouter rankings API |
+| 13 | `openrouter/owl-alpha` | Closed/unknown | 26,443,249,613 | 59,323,195 | 0.00 | OpenRouter rankings API |
+| 14 | `google/gemini-3.1-pro-preview-20260219` | Closed/unknown | 22,730,365,076 | 14,141,432 | 12.00 | OpenRouter rankings API |
+| 15 | `anthropic/claude-4.6-sonnet-20260217` | Closed/unknown | 22,266,331,047 | 42,140,687 | 15.00 | OpenRouter rankings API |
+| 16 | `google/gemini-3.5-flash-20260519` | Closed/unknown | 22,145,085,723 | 17,287,193 | 9.00 | OpenRouter rankings API |
+| 17 | `anthropic/claude-4.7-opus-20260416` | Closed/unknown | 21,824,519,900 | 27,879,813 | 25.00 | OpenRouter rankings API |
+| 18 | `anthropic/claude-4.8-opus-20260528` | Closed/unknown | 21,668,593,002 | 22,706,263 | 25.00 | OpenRouter rankings API |
+| 19 | `openai/gpt-oss-20b` | MoE-small-active | 21,262,114,419 | 26,601,619 | 0.14 | OpenRouter rankings API |
+| 20 | `stepfun/step-3.7-flash-20260528` | Closed/unknown | 20,919,856,552 | 24,557,960 | 1.15 | OpenRouter rankings API |
+| 21 | `google/gemma-4-31b-it-20260402` | Dense-mid | 19,407,937,142 | 50,306,194 | 0.35 | OpenRouter rankings API |
+| 22 | `google/gemma-4-26b-a4b-it-20260403` | MoE-small-active | 18,841,388,664 | 66,782,258 | 0.33 | OpenRouter rankings API |
+| 23 | `openai/gpt-5-mini-2025-08-07` | Closed/unknown | 17,320,050,665 | 31,809,822 | 2.00 | OpenRouter rankings API |
+| 24 | `google/gemma-3-27b-it` | Dense-mid | 16,361,641,165 | 25,684,016 | 0.16 | OpenRouter rankings API |
+| 25 | `nvidia/nemotron-3-super-120b-a12b-20230311` | MoE-mid-active | 16,045,869,629 | 14,160,958 | 0.40 | OpenRouter rankings API |
+| 26 | `openai/gpt-5.5-20260423` | Closed/unknown | 15,474,877,775 | 24,102,884 | 30.00 | OpenRouter rankings API |
+| 27 | `moonshotai/kimi-k2.6-20260420` | MoE-mid/large-active, AS readiness unknown | 14,024,317,658 | 10,703,135 | 3.41 | OpenRouter rankings API |
+| 28 | `openai/gpt-4o-mini` | Closed/unknown | 13,905,137,012 | 116,219,428 | 0.60 | OpenRouter rankings API |
+| 29 | `mistralai/mistral-nemo` | Dense-mid | 13,694,042,021 | 88,776,212 | 0.03 | OpenRouter rankings API |
+| 30 | `openai/gpt-5-nano-2025-08-07` | Closed/unknown | 11,495,657,770 | 13,931,761 | 0.40 | OpenRouter rankings API |
+
+Top-30 volume shares by class, with closed models separated because public parameter counts are not decision-grade:
+
+| Class | Top-30 completion tokens | Share |
+|---|---:|---:|
+| Closed/unknown | 390,783,497,085 | 34.0% |
+| MoE-mid-active | 385,847,332,381 | 33.6% |
+| MoE-large-active | 205,097,695,505 | 17.9% |
+| MoE-small-active | 116,855,513,712 | 10.2% |
+| Dense-mid | 49,463,620,328 | 4.3% |
+| Dense-small | 0 in top 30 | 0.0% |
+
+OpenRouter demand conclusions:
+
+1. MoE demand is real and large, but much of it is not immediately Apple-Silicon-ready because the leading demand sits in DeepSeek/MiniMax/Tencent/Xiaomi/GLM/Kimi classes with unclear or huge nominal residency.
+2. The clean Apple-Silicon intersection in the top 30 is `gpt-oss-20b` and `google/gemma-4-26b-a4b-it`.
+3. `qwen/qwen3-30b-a3b` has strong technical fit but is outside the top 100 on the latest daily OpenRouter completion-token ranking. It is a capability row, not a demand row.
+4. `qwen/qwen3-next-80b-a3b-instruct` ranks around 64, with meaningful demand but Tier-A/Tier-S-only residency.
+5. GPT-OSS-120B has very high demand and only 5.1B active parameters, but it is not a broad fleet unlock because nominal residency is around 60+ GB in practical quantization.
+
+## Part 4 — Intersection: High Demand and Apple-Silicon Efficient
+
+| Model | Class | OpenRouter rank | Cheapest public market $/M completion | Apple-Silicon tier | Tier-A per-stream TPS | Candidate? | Rationale |
+|---|---|---:|---:|---|---:|:-:|---|
+| `openai/gpt-oss-20b` | MoE-small-active | 19 | 0.13 via OpenRouter WandB endpoint | Tier-C 24GB+ | 80-115 | ✅ | Top-20 demand, Apache-2.0, low residency, likely broad-fleet unlock |
+| `google/gemma-4-26b-a4b-it` | MoE-small-active | 22 | 0.30 via OpenRouter Cloudflare endpoint | Tier-C 32GB+, Tier-B 24GB possible | 75-105 | ✅ | Top-25 demand, direct active-param advantage, strong MLX/GGUF availability |
+| `qwen/qwen3-30b-a3b` | MoE-small-active | 108/118/138 variants | 0.50 via OpenRouter DeepInfra endpoint | Tier-C 32GB+, Tier-B | 70-105 | ⚠️ | Excellent Apple fit; weak current OpenRouter volume |
+| `qwen/qwen3-next-80b-a3b-instruct` | MoE-small-active but high residency | 64 | 0.78 via OpenRouter Alibaba endpoint | Tier-A 64GB+ | 35-55 | ⚠️ | Demand exists; nominal residency makes it Tier-A/S, not broad fleet |
+| `openai/gpt-oss-120b` | MoE-small-active but high residency | 3 | 0.15 via OpenRouter | Tier-A 128GB / Tier-S | 35-60 estimate | ❌ for v2 | High demand but too much weight residency for v2 launch route |
+| `minimax/minimax-m2.7` | MoE-mid-active, high residency | 58 | 0.72 via OpenRouter Mara endpoint | Tier-S 192GB+ | OOM/risky | ❌ for v2 | Demand exists, but 101+ GB 4-bit residency and unproven AS stack |
+| `deepseek/deepseek-v4-flash` | MoE-mid-active, unknown AS | 1 | 0.18 via OpenRouter Wafer endpoint | unknown | unknown | ❌ for v2 | Top demand, but no production-ready Apple-Silicon route established |
+| `microsoft/phi-3.5-moe-instruct` | MoE-small-active | not ranked materially | no active OpenRouter endpoint found | Tier-C 32GB+ | 55-80 | ❌ | Efficient but no current buyer demand |
+| `mistralai/mixtral-8x7b-instruct` | MoE-mid-active | not ranked materially | no active OpenRouter endpoint found | Tier-B 48GB+ | 25-45 | ❌ | Dated and demand weak |
+| `mistralai/mixtral-8x22b-instruct` | MoE-large-active | 238 | 6.00 via OpenRouter Mistral endpoint | Tier-S | 10-20 | ❌ | Price high, demand low, slow |
+| `databricks/dbrx-instruct` | MoE-large-active | not ranked materially | no active OpenRouter endpoint found | Tier-S / M4 Max 128GB only | 8-14 | ❌ | Dated; not economically compelling |
+
+## Part 5 — Track B Rate-Card Delta
+
+Interpretation:
+
+1. `completion_credits_per_mtok` is written numerically as the target buyer-facing dollars per million tokens times 1,000,000 credits.
+2. Prompt rows use 25% of completion by default unless public market prompt price implies a materially different ratio.
+3. Provider gross $/hr below uses target completion price only: `TPS * 3600 * price_per_token`.
+4. Provider net after existing `provider_share: 0.90` is also shown.
+5. These rows clear electricity on most Macs but do not clear a $0.30/hr provider attractiveness threshold without batching or token subsidy.
+
+Recommended concrete YAML:
+
+```yaml
+rewards:
+  rate_card:
+    # Track B existing rows (don't touch):
+    llama-3.1-8b:        # $0.027/M
+    qwen3-32b:           # $0.220/M
+    llama-3.3-70b:       # $0.250/M
+
+    # New MoE rows from RESEARCH_226:
+    gpt-oss-20b:
+      prompt_credits_per_mtok: 25000
+      completion_credits_per_mtok: 100000   # $0.100/M completion
+
+    google-gemma-4-26b-a4b-it:
+      prompt_credits_per_mtok: 60000
+      completion_credits_per_mtok: 240000   # $0.240/M completion
+
+    qwen3-30b-a3b:
+      prompt_credits_per_mtok: 100000
+      completion_credits_per_mtok: 400000   # $0.400/M completion
+```
+
+Price derivation:
+
+| Row | Cheapest public market | Source | Target $/M completion | Undercut | Tier-A TPS | Tier-A gross/net $/hr | Tier-S TPS | Tier-S gross/net $/hr | Clears electricity? |
+|---|---:|---|---:|---:|---:|---:|---:|---:|:-:|
+| `gpt-oss-20b` | 0.13 | OpenRouter endpoint, WandB | 0.100 | 23.1% | 95 | 0.034 / 0.031 | 115 | 0.041 / 0.037 | yes, not $0.30/hr |
+| `google-gemma-4-26b-a4b-it` | 0.30 | OpenRouter endpoint, Cloudflare | 0.240 | 20.0% | 90 | 0.078 / 0.070 | 110 | 0.095 / 0.086 | yes, not $0.30/hr |
+| `qwen3-30b-a3b` | 0.50 | OpenRouter endpoint, DeepInfra | 0.400 | 20.0% | 85 | 0.122 / 0.110 | 105 | 0.151 / 0.136 | yes, near $0.30/hr only at 2-3 streams |
+
+Tier-eligibility delta:
+
+| Model | Recommended eligibility | Reason |
+|---|---|---|
+| `gpt-oss-20b` | Allow Tier-C with >=24GB RAM; 16GB only after bench gate | Model card says MXFP4 can run within 16GB, but production routing needs headroom |
+| `google-gemma-4-26b-a4b-it` | Allow Tier-C only with >=32GB RAM; allow Tier-B 24GB if bench passes | 4-bit weights are around 14-16 GB, runtime headroom matters |
+| `qwen3-30b-a3b` | Allow Tier-C only with >=32GB RAM; Tier-B 24GB after bench gate | 4-bit weights are around 16-17 GB and output contexts can be long |
+| `qwen3-next-80b-a3b-instruct` | Tier-A 64GB+ only; not v2 default | 4-bit weights are around 42 GB |
+| `gpt-oss-120b` | Tier-A 128GB / Tier-S only; not v2 default | High demand, but residency is not broad-fleet |
+
+Track B implication:
+
+Move from pure bandwidth-tier routing to per-model admission:
+
+```yaml
+model_admission:
+  gpt-oss-20b:
+    min_ram_gb: 24
+    min_bandwidth_tier: C
+    bench_gate:
+      min_sustained_tps: 30
+      max_4k_ttft_ms: 2500
+  google-gemma-4-26b-a4b-it:
+    min_ram_gb: 32
+    min_bandwidth_tier: C
+    bench_gate:
+      min_sustained_tps: 30
+      max_4k_ttft_ms: 3000
+  qwen3-30b-a3b:
+    min_ram_gb: 32
+    min_bandwidth_tier: C
+    bench_gate:
+      min_sustained_tps: 30
+      max_4k_ttft_ms: 3000
+```
+
+## Part 6 — Strategic Recommendation
+
+Should macprovider add MoE-class rows at v2 launch? Yes, but only 2-3 rows. The demand signal is clear for GPT-OSS-20B and Gemma 4 26B A4B, and both are efficient on Apple Silicon in a way dense-32B is not. Qwen3-30B-A3B should be listed if Track A can guarantee runtime reliability because it is the strongest engineering proof-point, but it is not a demand-led row. Avoid chasing DeepSeek/MiniMax top demand at v2 launch; those are strategically important but not yet Apple-Silicon-production-ready in this repo's terms.
+
+Does the MoE finding change Track A's engineering roadmap? Yes. Track A should not remain “dense llama.cpp `--parallel` first” only. The roadmap should become hybrid: keep dense `--parallel` for qwen3-32b and 70B compatibility, but add MoE-aware runtime selection, per-model RAM admission, and small-active draft/speculative-model selection. The runtime chooser should prefer MLX/LM Studio for Qwen3/Gemma small-active MoE when measured TPS beats llama.cpp, and it should record active params, resident GB, context length, and first-token latency separately.
+
+Does it change Track B's tier filter? Yes. Min-RAM per model must override bandwidth tier for initial eligibility, while bandwidth tier should score expected TPS and concurrency. A Tier-C M4 Air 32GB should be allowed to take GPT-OSS-20B, Gemma 4 A4B, and Qwen3-30B-A3B traffic after a bench gate, even if the same Tier-C provider is not eligible for dense 32B. A Tier-C 16GB machine should not be broadly admitted until it proves model-specific TTFT and sustained decode with production context.
+
+## Part 7 — Open Follow-Up Benchmarks
+
+| Scenario | Hardware | Model | Runtime | Prompt/context | Success threshold |
+|---|---|---|---|---|---|
+| SCN-226-01 | M4 Air 24GB and 32GB | `openai/gpt-oss-20b` MXFP4/4bit | MLX and llama.cpp GGUF | 4K prompt, 512 completion, 3 runs | >=30 sustained tok/s, no swap, p95 TTFT <=2500 ms |
+| SCN-226-02 | M4 Air 32GB, M4 Pro 24GB/48GB | `google/gemma-4-26b-a4b-it` 4bit and QAT 4bit | MLX/VLM and llama.cpp GGUF | 4K text-only and 4K multimodal-disabled text path | >=30 tok/s Tier-C, >=45 tok/s Tier-B, stable memory |
+| SCN-226-03 | M4 Max 64GB/128GB and M3 Ultra 256GB | `qwen/qwen3-30b-a3b` 4bit | MLX/LM Studio and llama.cpp | 4K prompt, 2K completion, `/no_think` and thinking variants | Tier-A >=70 tok/s non-thinking; Tier-S >=90 tok/s |
+| SCN-226-04 | M4 Max 64GB and M2 Ultra 128/192GB | `qwen/qwen3-next-80b-a3b-instruct` 4bit | MLX and GGUF | 4K and 32K prompts | Load without swap; Tier-A >=35 tok/s at 4K; 32K degradation recorded |
+| SCN-226-05 | M2 Ultra 192GB and M3 Ultra 256GB | `minimax/minimax-m2.7` 4bit GGUF | llama.cpp latest | 4K prompt, 512 completion, batch 1 and 2 | Prove or kill Tier-S listing: >=25 tok/s single stream and no swap |
+
+## Appendix A — Additional OpenRouter Ranking Evidence
+
+These rows matter because several candidate MoE models sit below the top 30. They are still relevant for capability planning, but not demand-led v2 launch rows.
+
+| Rank | Model | Completion tokens | Requests | Note |
+|---:|---|---:|---:|---|
+| 31 | `z-ai/glm-5.1-20260406` | 11,105,548,199 | 16,241,830 | High demand, unclear Apple path |
+| 32 | `google/gemini-2.5-pro` | 10,857,067,818 | 5,953,435 | Closed |
+| 33 | `anthropic/claude-4.5-haiku-20251001` | 10,427,640,868 | 31,592,183 | Closed |
+| 34 | `openai/gpt-5.4-20260305` | 9,686,777,557 | 16,712,531 | Closed |
+| 35 | `x-ai/grok-4.3-20260430` | 9,323,617,741 | 14,121,302 | Closed |
+| 36 | `qwen/qwen3.5-flash-20260224` | 9,178,460,756 | 29,398,851 | API model, unclear local availability |
+| 37 | `inclusionai/ling-2.6-flash-20260421` | 7,780,531,939 | 26,529,586 | API model |
+| 38 | `google/gemini-3.1-flash-lite-preview-20260303` | 7,690,469,577 | 30,222,125 | Closed |
+| 39 | `qwen/qwen3.7-max-20260520` | 7,206,611,919 | 10,511,303 | API model |
+| 40 | `openai/gpt-5.4-mini-20260317` | 7,162,950,233 | 25,391,444 | Closed |
+| 41 | `openai/o3-mini-2025-01-31` | 7,051,044,331 | 1,434,139 | Closed |
+| 42 | `qwen/qwen3.7-plus-20260602` | 6,737,918,413 | 14,648,425 | API model |
+| 43 | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-20260428` | 6,361,805,891 | 1,514,198 | MoE-small-active; inspect later |
+| 44 | `xiaomi/mimo-v2.5-pro-20260422` | 6,034,095,645 | 9,036,205 | MoE, unclear Apple path |
+| 45 | `moonshotai/kimi-k2.5-0127` | 5,582,724,011 | 7,804,131 | MoE, high residency likely |
+| 46 | `openai/gpt-5.4-nano-20260317` | 5,370,635,107 | 21,115,569 | Closed |
+| 47 | `nvidia/nemotron-3-ultra-550b-a55b-20260604` | 5,128,367,242 | 10,101,262 | MoE-large-active; not AS-efficient |
+| 48 | `meta-llama/llama-3.1-8b-instruct` | 5,088,424,384 | 51,935,386 | Dense-small; Track B existing row |
+| 49 | `z-ai/glm-5-20260211` | 4,943,811,985 | 7,556,556 | MoE/unknown-active |
+| 50 | `openai/gpt-oss-20b` free/variant traffic already merged | 4,628,479,021 raw variant | 8,233,189 raw variant | Merged into rank 19 in aggregate |
+| 58 | `minimax/minimax-m2.7-20260318` | 4,013,901,014 | 6,523,312 | Demand exists; Tier-S-only |
+| 64 | `qwen/qwen3-next-80b-a3b-instruct-2509` | 3,474,299,926 | 5,487,930 | Hold row; Tier-A/S only |
+| 108 | `qwen/qwen3-30b-a3b-instruct-2507` | 845,155,002 | 3,192,158 | Engineering-led candidate |
+| 118 | `qwen/qwen3-30b-a3b-04-28` | 718,491,187 | 780,569 | Engineering-led candidate |
+| 138 | `qwen/qwen3-30b-a3b-thinking-2507` | 425,815,246 | 344,962 | Engineering-led candidate |
+| 238 | `mistralai/mixtral-8x22b-instruct` | 33,416,950 | 43,940 | Skip |
+
+Demand interpretation from Appendix A:
+
+1. The Qwen3-A3B family has fragmented demand across base, instruct, and thinking variants.
+2. Combining the three visible Qwen3-A3B rows gives about 1.99B completion tokens for the day, still far below GPT-OSS-20B and Gemma 4 A4B.
+3. MiniMax M2.7 demand is stronger than Qwen3-A3B demand, but its 4-bit residency starts around 101 GB, so it is not a broad Apple-Silicon unlock.
+4. Nemotron 3 Nano Omni A3B deserves a later research pass, but it is not in the prompt's initial model set and needs license/runtime verification.
+
+## Appendix B — Quantization Evidence Snapshot
+
+HF blob metadata pulled on 2026-06-30:
+
+| Repo | Quant | Size |
+|---|---|---:|
+| `bartowski/openai_gpt-oss-20b-GGUF` | Q4 / IQ4 | 10.7-10.9 GB |
+| `bartowski/openai_gpt-oss-20b-GGUF` | MXFP4 | 11.3 GB |
+| `bartowski/openai_gpt-oss-20b-GGUF` | bf16 | 12.8 GB |
+| `mlx-community/gpt-oss-20b-OptiQ-4bit` | MLX 4bit | 10.8 GB |
+| `mlx-community/gemma-4-26b-a4b-it-4bit` | MLX 4bit | 14.5 GB |
+| `mlx-community/gemma-4-26B-A4B-it-qat-4bit` | MLX QAT 4bit | 14.5 GB |
+| `unsloth/gemma-4-26B-A4B-it-GGUF` | IQ4 | 12.7 GB |
+| `unsloth/gemma-4-26B-A4B-it-GGUF` | Q4_K | 15.4-15.8 GB |
+| `unsloth/gemma-4-26B-A4B-it-GGUF` | Q8 | 25.0-25.7 GB |
+| `mlx-community/Qwen3-30B-A3B-4bit` | MLX 4bit | 16.0 GB |
+| `bartowski/Qwen_Qwen3-30B-A3B-GGUF` | IQ4 | 15.3-16.2 GB |
+| `bartowski/Qwen_Qwen3-30B-A3B-GGUF` | Q4_K | 16.7-17.6 GB |
+| `bartowski/Qwen_Qwen3-30B-A3B-GGUF` | Q8 | 30.3 GB |
+| `mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit` | MLX 4bit | 41.8 GB |
+| `mlx-community/Qwen3-Next-80B-A3B-Instruct-8bit` | MLX 8bit | 78.8 GB |
+| `unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF` | IQ4/Q4 | 39.7-45.2 GB |
+| `unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF` | Q8 | 79.0-86.7 GB |
+| `mlx-community/Qwen3-235B-A22B-4bit` | MLX 4bit | 123.2 GB |
+| `mlx-community/DeepSeek-V2-Lite-Chat-4bit-mlx` | MLX 4bit | 8.2 GB |
+| `legraphista/DeepSeek-V2-Lite-Chat-IMat-GGUF` | IQ4 | 8.0-8.3 GB |
+| `legraphista/DeepSeek-V2-Lite-Chat-IMat-GGUF` | Q8 | 15.6 GB |
+| `mlx-community/Phi-3.5-MoE-instruct-4bit` | MLX 4bit | 21.9 GB |
+| `bartowski/Phi-3.5-MoE-instruct-GGUF` | IQ4/Q4 | 20.8-23.7 GB |
+| `bartowski/Phi-3.5-MoE-instruct-GGUF` | Q8 | 41.4 GB |
+| `TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF` | Q4 | 24.6 GB |
+| `TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF` | Q8 | 46.2 GB |
+| `mlx-community/dbrx-instruct-4bit` | MLX 4bit | 69.8 GB |
+| `unsloth/MiniMax-M2.7-GGUF` | IQ4 | 101.0-103.1 GB |
+| `unsloth/MiniMax-M2.7-GGUF` | Q4_K | 122.0-131.1 GB |
+| `unsloth/MiniMax-M2.7-GGUF` | Q8 | 226.4-229.6 GB |
+
+Appendix B conclusions:
+
+1. GPT-OSS-20B and DeepSeek-V2-Lite are the only listed MoE rows that can plausibly fit 16GB with care.
+2. Gemma 4 A4B and Qwen3-30B-A3B are practical on 24GB only if context is controlled; 32GB is the correct paid-routing threshold.
+3. Qwen3-Next-80B-A3B is small-active but not small-resident.
+4. Qwen3-235B-A22B and MiniMax-M2.7 are not broad fleet rows regardless of active params.
+
+## Appendix C — Throughput Formula and Guardrails
+
+Naive upper-bound formula:
+
+```text
+active_weight_bytes_per_token = active_params * bytes_per_param
+upper_bound_tps = memory_bandwidth_bytes_per_second / active_weight_bytes_per_token
+```
+
+For 4-bit active weights:
+
+```text
+bytes_per_param ~= 0.5 before quantization overhead
+```
+
+Example:
+
+```text
+Qwen3-30B-A3B active bytes ~= 3.3B * 0.5 = 1.65 GB
+M4 Max upper bound ~= 546 / 1.65 = 331 tok/s
+Realistic sustained observed/anecdotal range ~= 70-105 tok/s
+Effective factor ~= 21-32% of raw active-weight bandwidth upper bound
+```
+
+Why the effective factor is far below 100%:
+
+1. Attention layers are not pure MoE expert loads.
+2. KV cache reads/writes grow with context.
+3. Runtime kernels do not perfectly saturate memory bandwidth.
+4. Expert routing and shared experts add overhead.
+5. Some runtimes keep dense projections or embeddings in hot paths.
+6. Token sampling, detokenization, server framing, and OpenAI-compatible streaming consume wall time.
+7. Thermal stability matters on fanless or thin-client Macs.
+
+Admission rules implied by the formula:
+
+1. Use nominal quantized model size for load eligibility.
+2. Use active quantized size for decode-throughput expectation.
+3. Use measured TTFT for routing score; active params alone do not predict TTFT.
+4. Use context-specific bench gates; a 4K-prompt row may not survive 32K traffic.
+5. Require no-swap evidence for paid routing.
+
+## Appendix D — Known Gaps and Follow-Up Data Requests
+
+1. Need a current public Darkbloom authenticated catalog or screenshot export to independently cite the $0.070 and $0.165 rows from RESEARCH_225.
+2. Need provider-side OpenRouter volume over 7-day and 30-day windows; the public endpoint used here is daily.
+3. Need current MLX/VLM support confirmation for Gemma 4 multimodal paths under text-only routing.
+4. Need Apple-Silicon benchmark parity across MLX, llama.cpp, LM Studio, and mlx-swift for the same model quant.
+5. Need power draw readings during sustained MoE decode to replace the coarse electricity-clears/does-not-clear judgment.
+6. Need direct GPT-OSS-20B Apple-Silicon benchmark rows; current TPS matrix uses extrapolation from Qwen/Gemma anchors.
+7. Need direct Qwen3-Next-80B-A3B Apple-Silicon rows; current matrix is deliberately conservative.
+8. Need license review before listing MiniMax or newer DeepSeek/Tencent/Xiaomi MoE rows.
+9. Need buyer-side quality acceptance checks; fast cheap MoE is only useful if buyers accept the output for coding/agent traffic.
+10. Need route-level observability for model slug, quant, runtime, RAM, context length, TTFT, decode TPS, and emitted completion tokens.
+
+## Final Recommendation
+
+MoE is a real v2 launch advantage only when the model is both small-active and low-residency. The initial macprovider MoE class should list GPT-OSS-20B and Gemma 4 26B A4B as demand-led rows, with Qwen3-30B-A3B as an engineering-led row if the bench gate passes. Do not list broad MoE, MiniMax, DBRX, Mixtral 8x22B, or DeepSeek V4 yet. The most important product change is per-model admission: small-active MoE lets Tier-C providers serve credible nominal-20B/30B models, but only when RAM headroom and local bench evidence prove it.

--- a/specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_PROMPT.md
+++ b/specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_PROMPT.md
@@ -1,0 +1,264 @@
+# RESEARCH PROMPT — MoE model selection on Apple Silicon + OpenRouter market demand
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_PROMPT.md)"`
+
+This is a narrow follow-up to:
+- RESEARCH_223 (MLX throughput roadmap) — concluded Roadmap D Hybrid
+- RESEARCH_224 (pricing v2) — concluded per-model rate-card rows
+- RESEARCH_225 (darkbloom.dev comparison) — revealed darkbloom serves
+  MoE-with-small-active-params (GPT-OSS 20B / 3.6B active, Gemma 4 26B
+  / 3.8B active) at $0.07-$0.165/M output, sidestepping the dense
+  bandwidth-bound problem entirely
+
+The MoE-active-parameter angle was barely covered in 223. This prompt
+closes that gap **and** layers in real market demand so we know which
+MoE models actually have buyer demand.
+
+Output: a decision-grade memo that produces (a) a per-MoE-model TPS
+matrix on Apple Silicon, (b) a market-demand-ranked list of MoE
+models with current per-token pricing, (c) a concrete delta to
+Track B's `rewards.rate_card` if we add MoE-class rows.
+
+---
+
+## Task
+
+Two interleaved questions:
+
+**Engineering question**: For the MoE models that are realistically
+servable on Apple Silicon today, what's the **per-hardware-tier
+sustained tok/s**? Specifically what happens when bandwidth math is
+over **active** params not nominal params?
+
+**Market question**: What MoE models do **buyers actually pay for**
+on OpenRouter (and comparable aggregators)? What's the volume, the
+price, and the implied buyer-demand ranking? An efficient-to-serve
+model with no demand is worthless; a high-demand model we can't serve
+efficiently is also worthless.
+
+The intersection of "we can serve it efficiently on Apple Silicon"
+AND "buyers will pay for it" is the candidate MoE-class rate-card
+rows for macprovider.
+
+---
+
+## Background
+
+**Darkbloom live catalog** (from RESEARCH_225, 2026-06-30):
+| Model | Nominal | Active | Min RAM | Their output $/M |
+|---|---|---|---|---:|
+| `gpt-oss-20b` | 20.9B MoE | 3.6B | 24 GB | $0.070 |
+| `gemma-4-26b` | 25.2B MoE | 3.8B | 36 GB | $0.165 |
+| `gemma-4-26b-qat-4bit` | 25.2B MoE | 3.8B | 32 GB | $0.165 |
+
+**Darkbloom claimed throughput**: MiniMax M2.5 ~100 tok/s on Apple
+Silicon (per docs, not in live catalog — treat as marketing).
+
+**Hardware fleet to evaluate** (same as 223 matrix):
+- M4 Air 16GB / 24GB / 32GB
+- M4 Pro 24GB / 48GB
+- M4 Max 64GB / 128GB
+- M2 Ultra 128GB / 192GB
+- M3 Ultra 256GB
+
+**Tier framing from 224** (memory bandwidth proxy):
+- Tier-S: ≥700 GB/s (M-Ultra)
+- Tier-A: ≥350 GB/s (M-Max)
+- Tier-B: ≥150 GB/s (M-Pro)
+- Tier-C: <150 GB/s (M-Air / base M-series)
+
+---
+
+## What to produce
+
+### Part 1 — MoE model catalog: what's actually servable on Apple Silicon today
+
+For each of these candidates (and any others that surface in research),
+report **nominal params, active params, native quantizations available
+in MLX / GGUF / mlx-swift, weight-on-disk GB at each quantization,
+runtime memory footprint at 4K context, min RAM tier servable**:
+
+- **GPT-OSS 20B** (OpenAI open-weights, 20.9B / 3.6B active) — already
+  on darkbloom
+- **Gemma 4 26B / 27B family** (Google, 25.2B / 3.8B active) — already
+  on darkbloom; check for variants
+- **Qwen3-MoE** family (Alibaba) — verify which Qwen3-MoE checkpoints
+  exist (235B-A22B? 30B-A3B? others?), MLX support, GGUF support
+- **MiniMax M2** / M2.5 / Text-01 (MiniMax, ~456B MoE / ~46B active —
+  verify; this may be too large for M-Ultra)
+- **DeepSeek-V2** / V2-Lite / V3 distills — DeepSeek-V3 nominal is
+  671B / 37B active (too large), but distillations / smaller MoE
+  variants may fit
+- **DBRX** (Databricks, 132B / 36B active) — likely Ultra-only
+- **Mixtral 8x7B** (Mistral, 47B / ~13B active) — older but well-known
+- **Mixtral 8x22B** (Mistral, 141B / ~39B active) — Ultra-tier
+- **Phi-3.5-MoE** (Microsoft, 41.9B / 6.6B active)
+- **Yi-1.5-MoE** if any extant
+- Any newer MoE released in 2026 worth flagging
+
+For each: cite HuggingFace URL + MLX repo URL if it exists +
+GGUF availability + license + known issues / production-readiness on
+Apple Silicon.
+
+Build:
+
+| Model | Nominal | Active | Native MLX | GGUF | 4bit GB | 8bit GB | Min RAM 4K ctx | Smallest tier servable |
+|---|---|---|:-:|:-:|---:|---:|---:|---|
+
+### Part 2 — Per-active-param TPS matrix on Apple Silicon
+
+For each (servable MoE model × hardware tier × quantization)
+combination, report **realistic sustained single-stream tok/s** and
+expected concurrent-batching ceiling under best-in-tree software stack
+(mlx-swift / mlx-lm / llama.cpp `--parallel` — pick the best per cell).
+
+Use the bandwidth-bound math over **active** params, not nominal, as
+the upper bound. Cite published benchmarks (blogs, tweets, GitHub
+issues, lmstudio.ai testimonials) where they exist; flag everything
+else as extrapolation.
+
+| Model | Active GB | M4 Air S/C | M4 Pro S/C | M4 Max S/C | M2 Ultra S/C | M3 Ultra S/C |
+|---|---:|---:|---:|---:|---:|---:|
+| GPT-OSS 20B (3.6B-act, 4bit) | ~1.8 | | | | | |
+| Gemma 4 26B (3.8B-act, 4bit) | ~1.9 | | | | | |
+| Qwen3-MoE-30B-A3B (3B-act, 4bit) | ~1.5 | | | | | |
+| Qwen3-MoE-235B-A22B (22B-act, 4bit) | ~11 | (oom) | (oom) | (oom) | | |
+| Mixtral 8x7B (13B-act, 4bit) | ~6.5 | (oom) | | | | |
+| Phi-3.5-MoE (6.6B-act, 4bit) | ~3.3 | | | | | |
+| DBRX (36B-act, 4bit) | ~18 | (oom) | (oom) | (oom) | | |
+
+For comparison context, copy the dense reference rows from RESEARCH_223:
+- M4 Air × Qwen3-32B (dense, 4bit): 14 tok/s observed, 8-16 12mo target
+- M4 Max × Qwen3-32B (dense, 4bit): 25-75 tok/s
+- M2/M3 Ultra × Qwen3-32B (dense, 4bit): 42-140 tok/s
+
+**Critical**: explicitly call out which MoE cells **beat** the
+dense-32B cells on the same hardware. That's where the active-param
+math actually pays.
+
+### Part 3 — OpenRouter market demand
+
+This is the data we've been missing. Pull from OpenRouter's analytics
+surfaces:
+
+- `https://openrouter.ai/rankings` — top models by usage volume
+- `https://openrouter.ai/api/v1/models` — full model list with pricing
+- `https://openrouter.ai/api/frontend/stats/app` — if accessible
+- Individual model pages with token-volume sparklines (e.g.,
+  `https://openrouter.ai/qwen/qwen3-32b`)
+- Their `/api/v1/models/<model>/stats` endpoint if it exists
+- Third-party aggregators tracking OpenRouter trends
+
+For the **top 30 models by completion-token volume on OpenRouter**
+(or whatever proxy is publicly visible — sometimes it's by request
+count, sometimes by spend), report:
+
+| Rank | Model | Class (dense/MoE/active) | Provider tier | $/M completion | Trend | Source |
+|---:|---|---|---|---:|---|---|
+
+Classify each as:
+- **Dense-small** (≤8B)
+- **Dense-mid** (>8B, ≤32B)
+- **Dense-large** (>32B)
+- **MoE-small-active** (active ≤8B)
+- **MoE-mid-active** (active 8-32B)
+- **MoE-large-active** (active >32B)
+
+Then aggregate: what **share of OpenRouter volume** sits in each class?
+Especially: what share of volume is in models macprovider can
+realistically serve on Apple Silicon (MoE-small-active + dense-small +
+dense-mid)?
+
+If OpenRouter doesn't publish volume directly, fall back to: (a)
+ranking by "trending" pages, (b) anecdotal app-developer mentions,
+(c) Together / DeepInfra / Fireworks revenue lists if findable.
+
+### Part 4 — Intersection: high-demand AND Apple-Silicon-efficient
+
+Build the decision table:
+
+| Model | Class | OpenRouter rank | Cheapest market $/M | Apple-Silicon-servable tier | Per-stream TPS @ Tier-A | Demand × Efficiency = candidate? |
+|---|---|---:|---:|---|---:|:-:|
+
+Mark each row:
+- ✅ **Add to macprovider rate-card** (high demand, efficient on AS)
+- ⚠️ **Add but low expected volume** (efficient but niche demand)
+- ❌ **Skip** (high demand but inefficient on AS, OR efficient but no
+  market)
+
+### Part 5 — Track B rate-card delta
+
+For the rows marked ✅ in Part 4, produce a **concrete addition** to
+Track B's `rewards.rate_card`. Maintain Track B's "undercut cheapest
+market by 10-30%" rule. Build:
+
+```yaml
+rewards:
+  rate_card:
+    # Track B existing rows (don't touch):
+    llama-3.1-8b:        # $0.027/M
+    qwen3-32b:           # $0.220/M
+    llama-3.3-70b:       # $0.250/M
+
+    # New MoE rows from this memo:
+    gpt-oss-20b:
+      prompt_credits_per_mtok: __
+      completion_credits_per_mtok: __    # target $/M completion
+    qwen3-moe-30b-a3b:
+      ...
+```
+
+For each new row:
+- Cite the cheapest market price (URL + date)
+- State the undercut %
+- Compute provider $/hr at the cell's per-stream TPS (Tier-A and
+  Tier-S separately) — does USD margin clear electricity?
+- Recommend any tier-eligibility delta (e.g., GPT-OSS 20B servable
+  on Tier-C with 24GB RAM, so allow Tier-C providers to serve it
+  even though Track B's tier filter would route 32B-dense away from
+  them)
+
+### Part 6 — Strategic recommendation
+
+One paragraph each:
+
+**Should macprovider add MoE-class rate-card rows at v2 launch, or
+stay dense-only for differentiation?** Decide. If yes, name the 2-4
+models worth listing initially. If no, explain why differentiation
+beats parity here.
+
+**Does the MoE finding change Track A's engineering roadmap?** If
+Apple-Silicon-efficient MoE serving is real, does the engineering
+priority shift from "llama.cpp `--parallel` for dense" to "MoE-aware
+runtime + draft-model selection per active-param size"? Be specific
+about what changes.
+
+**Does it change Track B's tier filter?** Should min-RAM (per-model)
+override memory-bandwidth-tier when the active params are small enough?
+E.g., should a Tier-C M4 Air be allowed to take GPT-OSS 20B traffic
+because it's actually serving 3.6B active?
+
+### Part 7 — Open follow-up benchmarks
+
+3-5 concrete bench scenarios to validate the MoE matrix on real
+hardware. Same format as RESEARCH_223 Part 6 (SCN-226-NN).
+
+---
+
+## Out of scope
+
+- Inspecting `Layr-Labs/d-inference` source code (clean-room rule)
+- Reproducing darkbloom's exact pricing structure
+- Custom MoE training / fine-tuning
+- Hardware acquisition recommendations beyond what's needed for tier
+  thresholds
+- Token-issuance design changes (Track B locked that)
+
+## Output format
+
+Markdown memo, **~400-700 lines**. Tables for Parts 1, 2, 3, 4, 5.
+Prose for Part 6. Cite every market-price claim and every published
+benchmark with source URL + date pulled. Conservative > optimistic
+on TPS projections. If a model is in active development but not
+production-ready on Apple Silicon (e.g., MLX support pending), say
+that explicitly rather than projecting.


### PR DESCRIPTION
## Summary

Lands the research audit trail that Entry 92 (PR #268) cites. Before this PR, those references were broken on `main` — the 5 `RESEARCH_*_PROMPT.md` spec files and `BENCHMARKS_226_TODO.md` were untracked in canonical, and the 4 codex memos were in `.omc/artifacts/ask/` which is gitignored. Partner cloning `main` from #268 would find the handoff prompt referencing files that don't exist.

## Files added (11)

| File | Purpose | Size |
|---|---|---:|
| `specs/BENCHMARKS_226_TODO.md` | Operator working file — re-ranked SCN-* queue with P0/P1/P2 bands; gates Wave 1 launch | 158 lines |
| `specs/RESEARCH_222_PRICING_PROMPT.md` | v1 (rejected) input prompt | small |
| `specs/RESEARCH_222_PRICING_MEMO.md` | v1 codex memo (truncated from 1MB → 25KB; exec-trace bloat removed) | 484 lines |
| `specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_PROMPT.md` | MLX 12-month roadmap input | small |
| `specs/RESEARCH_223_MLX_THROUGHPUT_ROADMAP_MEMO.md` | MLX roadmap codex memo (truncated from 3MB → 29KB) | 619 lines |
| `specs/RESEARCH_224_PRICING_V2_PROMPT.md` | Pricing v2 input | small |
| `specs/RESEARCH_224_PRICING_V2_MEMO.md` | Pricing v2 codex memo (was already clean from codex) | 529 lines |
| `specs/RESEARCH_225_DARKBLOOM_COMPARISON_PROMPT.md` | Darkbloom comparison input | small |
| `specs/RESEARCH_225_DARKBLOOM_COMPARISON_MEMO.md` | Darkbloom comparison codex memo (truncated from 850KB → 35KB) | 665 lines |
| `specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_PROMPT.md` | MoE selection input | small |
| `specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_MEMO.md` | MoE codex memo (was already clean) | 454 lines |

Full transcripts (with exec traces, MB-scale) remain in operator's local `.omc/artifacts/ask/` — `.omc/` stays gitignored per existing convention.

## File modified (1)

`specs/HANDOFF_BETA_PRICING_TOKEN_ROLLOUT_PROMPT.md` — 4 reference paths changed from `.omc/artifacts/ask/codex-research-prompt-*.md` (gitignored, unreachable for partner) to `specs/RESEARCH_NNN_*_MEMO.md` (this PR). Section "Step 1 — read these in order" now resolves to in-repo files.

## Why memos were truncated

The OMC `ask` workflow wraps codex output with a full exec-trace log of every `bash` command codex ran during research. For the 222/223/225 memos this bloated the files to 1-3MB each — checking that into `specs/` would balloon the repo without adding decision-relevant content. The truncation:

1. Finds the first `OpenAI Codex v0.142.2` footer line
2. Keeps everything before it (original task, prompt, raw codex response)
3. Appends a closing ` ``` ` to close the dangling code fence

The actual codex decision reasoning is fully preserved — only the exec transcripts after the response are dropped. 224 and 226 didn't need truncation (codex wrote them cleanly to begin with).

## Test plan

- [x] All 11 files render as valid markdown
- [x] Truncated memos: closing ``` fence appended; no orphan code fences
- [x] HANDOFF prompt's 4 reference-path changes resolve to in-repo files (this PR)
- [x] `specs/BENCHMARKS_226_TODO.md` references match handoff prompt + Entry 92
- [x] Worktree created off `origin/main` post-#268-merge per always-fresh-worktree rule
- [x] No `.omc/` content checked in; `.omc/` stays gitignored

## What this PR does NOT do

- Does NOT modify Entry 92 (recorded `.omc/artifacts/ask/` paths remain factually accurate as a snapshot of where memos were when Entry 92 was written — they also exist in `specs/` now per this PR, the trailing reference paragraph in Entry 92 will rot but cleanly)
- Does NOT add hardware-tier filter code or token ledger code (Waves 2 + 3 per Entry 92, separate PRs)
- Does NOT run any benches (`BENCHMARKS_226_TODO.md` lands the operator working file; bench execution + result updates happen in follow-up PRs as we run them on M-series hardware)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
