### PR TITLE
impl(004 #266): Tranche 2 — extract objective/dispatch/retry into routing pkg

### DIFF
--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1885,7 +1885,7 @@ func (s *Server) forwardHTTPSequence(
 			upstreamURL := state.provider.EndpointURL + "/v1/chat/completions"
 			attemptCtx := r.Context()
 			cancelAttempt := func() {}
-			retryRequested := s.maxRetries > 0 && retryHeaderLimit(r.Header.Get("X-MacProvider-Retry")) > 0
+			retryRequested := s.maxRetries > 0 && routing.RetryHeaderLimit(r.Header.Get("X-MacProvider-Retry")) > 0
 			if retryRequested && s.retryPerAttemptTimeout > 0 {
 				attemptCtx, cancelAttempt = context.WithTimeout(r.Context(), s.retryPerAttemptTimeout)
 			}
@@ -2098,7 +2098,7 @@ func (s *Server) advanceToNextProvider(
 }
 
 func (s *Server) attemptTimeout(r *http.Request) time.Duration {
-	if s.maxRetries > 0 && retryHeaderLimit(r.Header.Get("X-MacProvider-Retry")) > 0 && s.retryPerAttemptTimeout > 0 {
+	if s.maxRetries > 0 && routing.RetryHeaderLimit(r.Header.Get("X-MacProvider-Retry")) > 0 && s.retryPerAttemptTimeout > 0 {
 		return s.retryPerAttemptTimeout
 	}
 	return s.requestTimeout
@@ -3647,86 +3647,13 @@ func countTopLevelField(body []byte, field string) (int, bool, error) {
 	return count, nonCanonical, nil
 }
 
+// dispatchBodyForProvider delegates to routing.RewriteModel. The
+// pre-PR JSON-surgical model-field rewrite moved into the routing
+// package as part of issue #266 T2; this wrapper preserves the
+// chatRequest-typed call sites in forward*Sequence without leaking
+// the buyer-internal chatRequest type past the package boundary.
 func dispatchBodyForProvider(req chatRequest, provider pool.Provider) ([]byte, error) {
-	if modelIDEqual(req.Model, provider.ModelID) {
-		return append([]byte(nil), req.raw...), nil
-	}
-
-	dec := json.NewDecoder(bytes.NewReader(req.raw))
-	token, err := dec.Token()
-	if err != nil {
-		return nil, err
-	}
-	if delim, ok := token.(json.Delim); !ok || delim != '{' {
-		return nil, errors.New("chat request body is not a JSON object")
-	}
-	type replacement struct {
-		start int
-		end   int
-	}
-	var replacements []replacement
-	for dec.More() {
-		keyToken, err := dec.Token()
-		if err != nil {
-			return nil, err
-		}
-		key, ok := keyToken.(string)
-		if !ok {
-			return nil, errors.New("chat request body contains a non-string object key")
-		}
-		keyEnd := int(dec.InputOffset())
-		valueStart, err := jsonValueStart(req.raw, keyEnd)
-		if err != nil {
-			return nil, err
-		}
-		var value json.RawMessage
-		if err := dec.Decode(&value); err != nil {
-			return nil, err
-		}
-		if key == "model" {
-			replacements = append(replacements, replacement{start: valueStart, end: int(dec.InputOffset())})
-		} else if strings.EqualFold(key, "model") {
-			return nil, errors.New("chat request body contains non-canonical model field")
-		}
-	}
-	if _, err := dec.Token(); err != nil {
-		return nil, err
-	}
-	if len(replacements) == 0 {
-		return nil, errors.New("chat request body missing model field")
-	}
-	if len(replacements) > 1 {
-		return nil, errors.New("chat request body contains duplicate model fields")
-	}
-	model, err := json.Marshal(provider.ModelID)
-	if err != nil {
-		return nil, err
-	}
-	out := append([]byte(nil), req.raw...)
-	r := replacements[0]
-	next := make([]byte, 0, len(out)-(r.end-r.start)+len(model))
-	next = append(next, out[:r.start]...)
-	next = append(next, model...)
-	next = append(next, out[r.end:]...)
-	return next, nil
-}
-
-func jsonValueStart(raw []byte, keyEnd int) (int, error) {
-	i := keyEnd
-	for i < len(raw) && (raw[i] == ' ' || raw[i] == '\n' || raw[i] == '\r' || raw[i] == '\t') {
-		i++
-	}
-	if i >= len(raw) || raw[i] != ':' {
-		return 0, errors.New("chat request body object key missing colon")
-	}
-	i++
-	for i < len(raw) && (raw[i] == ' ' || raw[i] == '\n' || raw[i] == '\r' || raw[i] == '\t') {
-		i++
-	}
-	if i >= len(raw) {
-		return 0, errors.New("chat request body object key missing value")
-	}
-	return i, nil
+	return routing.RewriteModel(req.raw, req.Model, provider.ModelID)
 }
 
 func validateOptionalFields(raw map[string]json.RawMessage, stream bool) (int, string, string) {
@@ -4562,58 +4489,13 @@ func (s *Server) objectiveForRequest(headers http.Header, class *config.ModelCla
 	}
 }
 
+// sortCandidates delegates to routing.SortCandidates. The pre-PR
+// inline 4-branch comparator moved into the routing package as part
+// of issue #266 T2 (deferred Pillar D refactor). Weights are derived
+// from the Server's per-provisional-tier downweight so the sort
+// honours SPEC-002 v1.1 §5 Step 2.5 the same way it did before.
 func (s *Server) sortCandidates(candidates []pool.Provider, objective string) {
-	switch objective {
-	case "fast":
-		sort.SliceStable(candidates, func(i, j int) bool {
-			ti := s.effectiveThroughput(candidates[i])
-			tj := s.effectiveThroughput(candidates[j])
-			if ti == tj {
-				return candidates[i].SlotsFree < candidates[j].SlotsFree
-			}
-			return ti > tj
-		})
-	case "accurate":
-		sort.SliceStable(candidates, func(i, j int) bool {
-			if candidates[i].ModelParamsB == candidates[j].ModelParamsB {
-				ti := s.effectiveThroughput(candidates[i])
-				tj := s.effectiveThroughput(candidates[j])
-				if ti != tj {
-					return ti > tj
-				}
-				return candidates[i].SlotsFree < candidates[j].SlotsFree
-			}
-			return candidates[i].ModelParamsB > candidates[j].ModelParamsB
-		})
-	case "balanced":
-		scores := balancedScores(candidates)
-		sort.SliceStable(candidates, func(i, j int) bool {
-			if scores[routeKey(candidates[i])] == scores[routeKey(candidates[j])] {
-				return candidates[i].SlotsFree < candidates[j].SlotsFree
-			}
-			return scores[routeKey(candidates[i])] > scores[routeKey(candidates[j])]
-		})
-	default:
-		sort.SliceStable(candidates, func(i, j int) bool {
-			if candidates[i].SlotsFree == candidates[j].SlotsFree {
-				return s.effectiveThroughput(candidates[i]) > s.effectiveThroughput(candidates[j])
-			}
-			return candidates[i].SlotsFree < candidates[j].SlotsFree
-		})
-	}
-}
-
-// balancedScores adapts routing.BalancedScores (which returns an
-// indexed slice — the canonical SPEC-004 FR-SR-8 normative formula
-// home) to the buyer-internal routeKey-shape map the rest of
-// selectProvider consumes.
-func balancedScores(candidates []pool.Provider) map[string]float64 {
-	indexed := routing.BalancedScores(candidates)
-	out := make(map[string]float64, len(candidates))
-	for i, p := range candidates {
-		out[routeKey(p)] = indexed[i]
-	}
-	return out
+	routing.SortCandidates(candidates, routing.Objective(objective), routing.Weights{Pinned: 1.0, Provisional: s.provisionalWeight})
 }
 
 func (s *Server) applyRandomTiebreak(requestID string, candidates []pool.Provider, objective, dailyKey string) ([]pool.Provider, int64, float64, string) {
@@ -4736,60 +4618,35 @@ func (s *Server) purgeStickyAccount(accountID string) int {
 	return s.stickyMap.PurgeAccount(accountID)
 }
 
+// shouldRetry delegates to routing.ShouldRetry. The pure-policy
+// gate moved out of buyer in #266 T2; this wrapper threads the
+// Server's per-request inputs (headers, clock, operator-config caps)
+// into the explicit ShouldRetryInput so the routing package can be
+// unit-tested without spinning up a buyer.Server.
 func (s *Server) shouldRetry(r *http.Request, startedAt time.Time, explicitRetries, faultedProviders, status int, err error) bool {
-	requestedRetries := retryHeaderLimit(r.Header.Get("X-MacProvider-Retry"))
-	if s.maxRetries <= 0 || requestedRetries <= 0 || hasPinnedRoute(r.Header) {
-		return false
-	}
-	if r.Context().Err() != nil {
-		return false
-	}
-	if explicitRetries >= min(s.maxRetries, requestedRetries) {
-		return false
-	}
-	if s.maxFaultedPerRequest > 0 && faultedProviders >= s.maxFaultedPerRequest {
-		return false
-	}
-	if s.requestTimeout > 0 && s.now().Sub(startedAt)+s.retryPerAttemptTimeout > s.requestTimeout {
-		return false
-	}
-	if err != nil {
-		return true
-	}
-	return status == http.StatusBadGateway || status == http.StatusGatewayTimeout
+	return routing.ShouldRetry(routing.ShouldRetryInput{
+		MaxRetries:             s.maxRetries,
+		RequestedRetries:       routing.RetryHeaderLimit(r.Header.Get("X-MacProvider-Retry")),
+		HasPinnedRoute:         hasPinnedRoute(r.Header),
+		ContextErr:             r.Context().Err(),
+		ExplicitRetries:        explicitRetries,
+		FaultedProviders:       faultedProviders,
+		MaxFaultedPerRequest:   s.maxFaultedPerRequest,
+		Now:                    s.now(),
+		StartedAt:              startedAt,
+		RequestTimeout:         s.requestTimeout,
+		RetryPerAttemptTimeout: s.retryPerAttemptTimeout,
+		Status:                 status,
+		Err:                    err,
+	})
 }
 
+// routingScores delegates to routing.ObjectiveScores. Moved out of
+// buyer in #266 T2; the result is keyed by ProviderID+/+AssignedID
+// (matching buyer.routeKey) so callers that look up per-candidate
+// scores via routeKey(p) continue to work unchanged.
 func (s *Server) routingScores(candidates []pool.Provider, objective string) map[string]float64 {
-	if objective == "balanced" {
-		return balancedScores(candidates)
-	}
-	out := map[string]float64{}
-	for _, p := range candidates {
-		switch objective {
-		case "fast":
-			out[routeKey(p)] = s.effectiveThroughput(p)
-		case "accurate":
-			out[routeKey(p)] = p.ModelParamsB
-		default:
-			out[routeKey(p)] = s.effectiveThroughput(p)
-		}
-	}
-	return out
-}
-
-func retryHeaderLimit(value string) int {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return 0
-	}
-	if strings.EqualFold(value, "true") {
-		return int(^uint(0) >> 1)
-	}
-	var n int
-	if _, err := fmt.Sscanf(value, "%d", &n); err != nil || n <= 0 {
-		return 0
-	}
-	return n
+	return routing.ObjectiveScores(candidates, routing.Objective(objective), routing.Weights{Pinned: 1.0, Provisional: s.provisionalWeight})
 }
 
 // inEpsilonCohort delegates to routing.InEpsilonCohort so the
@@ -4802,7 +4659,7 @@ func (s *Server) inEpsilonCohort(top, candidate pool.Provider, objective string,
 	weights := routing.Weights{Pinned: 1.0, Provisional: s.provisionalWeight}
 	var scoreFn func(pool.Provider) float64
 	if objective == "balanced" {
-		scores := balancedScores(candidates)
+		scores := routing.KeyedBalancedScores(candidates)
 		scoreFn = func(p pool.Provider) float64 { return scores[routeKey(p)] }
 	}
 	return routing.InEpsilonCohort(top, candidate, routing.Objective(objective), s.tiebreakEpsilon, weights, scoreFn)
@@ -5246,14 +5103,6 @@ func (c *eligibilityCtx) Tier2Decision(p pool.Provider) (routing.RejectionReason
 
 func (c *eligibilityCtx) QuotaPermits(p pool.Provider) bool {
 	return c.s.checkQuota(p)
-}
-
-func (s *Server) effectiveThroughput(provider pool.Provider) float64 {
-	weight := 1.0
-	if provider.Tier == pool.TierProvisional {
-		weight = s.provisionalWeight
-	}
-	return provider.ThroughputTPSEstimate * weight
 }
 
 func modelIDEqual(a, b string) bool {

--- a/phase4-coordinator/internal/routing/candidate.go
+++ b/phase4-coordinator/internal/routing/candidate.go
@@ -20,13 +20,24 @@
 // stickyStore / purgeStickyAccount delegate to sticky.Map and
 // the inline stickyEntry has been removed.
 //
-// Still deferred to follow-up commits (not in this PR): objective.go
-// sort-comparator extraction, dispatch.go RewriteModel extraction,
-// retry.go retry-loop extraction, InvalidateClass SIGHUP trigger
-// wiring, per-attempt FR-SR-17 log threading at retry/preflight
-// call sites, mid-request stable seed across UTC midnight,
-// BalancedScores compute caching, more AC-SR-1 byte-identity
-// scenarios.
+// Issue #266 Tranche 1 (PR #270) closed the operator-green-light
+// safety/correctness items: SIGHUP InvalidateClass wiring, per-
+// attempt FR-SR-17 log threading at retry/preflight call sites,
+// mid-request stable seed across UTC midnight,
+// sticky_account_mismatch warn-log rate-limit.
+//
+// Issue #266 Tranche 2 (this PR) closed the refactor-only
+// extractions: objective.go (SortCandidates + ObjectiveScores +
+// KeyedBalancedScores), dispatch.go (RewriteModel + jsonValueStart),
+// retry.go (RetryHeaderLimit + ShouldRetry + ShouldRetryInput).
+// Buyer-side `sortCandidates` / `routingScores` / `dispatchBodyForProvider`
+// / `shouldRetry` are now thin delegators.
+//
+// Still deferred to follow-up commits (not in this PR): BalancedScores
+// compute caching threaded through SortCandidates + epsilon + log
+// (deferred #266 Tranche 3), more AC-SR-1 byte-identity scenarios
+// (T3), HTTP-path integration test for `sticky_account_mismatch`
+// warn emission (T3).
 //
 // AC-SR-1 default-config regression (byte-identical selection vs
 // current SPEC-002 v1.5.2 origin/main behavior) is locked by

--- a/phase4-coordinator/internal/routing/dispatch.go
+++ b/phase4-coordinator/internal/routing/dispatch.go
@@ -24,7 +24,7 @@ import (
 //     preserved verbatim — billing keys off the raw body hash and
 //     must observe the same bytes the buyer sent.
 //
-// Errors:
+// Errors (rewrite path only — see "precondition" below):
 //   - body is not a JSON object
 //   - body contains a non-string object key
 //   - body has zero `model` fields
@@ -36,6 +36,21 @@ import (
 // scenarios where a buyer-trusted gateway might match on "model"
 // but a downstream provider might match on "Model"; rejecting at
 // the rewrite boundary keeps the canonical-name contract intact.
+//
+// **Precondition**: when `requestedModel` and `providerModelID`
+// compare equal under `strings.EqualFold`, the match-skip path
+// fires AND DOES NOT validate the JSON body shape (duplicate /
+// non-canonical / non-object checks all run only on the rewrite
+// branch). The match-skip path is byte-identical to the pre-#266
+// `buyer.dispatchBodyForProvider` behaviour; in the buyer flow
+// the body is already validated upstream by `validateChatRequest`
+// before reaching dispatch. **Callers outside the buyer pipeline
+// MUST run their own JSON-shape validation before invoking
+// `RewriteModel` if they need the dup/case/object checks** —
+// this helper alone is not sufficient to enforce them on the
+// match-skip path. Issue #266 T2 R1 SEC audit LOW (documented;
+// not changing the production flow because the validateChatRequest
+// upstream gate already covers it).
 func RewriteModel(rawBody []byte, requestedModel, providerModelID string) ([]byte, error) {
 	if strings.EqualFold(requestedModel, providerModelID) {
 		return append([]byte(nil), rawBody...), nil

--- a/phase4-coordinator/internal/routing/dispatch.go
+++ b/phase4-coordinator/internal/routing/dispatch.go
@@ -1,0 +1,126 @@
+package routing
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// RewriteModel rewrites the `model` field in an OpenAI-style chat-
+// completions request body so the upstream provider receives the
+// provider's actual model_id rather than the buyer's class-name (or
+// model-alias) request. Byte-identical to pre-extraction
+// `buyer.dispatchBodyForProvider` (issue #266 T2 refactor):
+//
+//   - When the buyer-requested model already EQUALS the provider's
+//     model_id (case-insensitive), the raw body is returned unchanged
+//     except for being copied to a fresh slice (so callers may safely
+//     keep `rawBody` for retry use).
+//   - Otherwise the body is parsed as a single JSON object, the
+//     UNIQUE top-level `model` field is located, and ONLY the value
+//     bytes are replaced with `json.Marshal(providerModelID)`. All
+//     surrounding whitespace, key ordering, and non-model fields are
+//     preserved verbatim — billing keys off the raw body hash and
+//     must observe the same bytes the buyer sent.
+//
+// Errors:
+//   - body is not a JSON object
+//   - body contains a non-string object key
+//   - body has zero `model` fields
+//   - body has duplicate `model` fields
+//   - body has a non-canonical-cased model field (e.g. "Model": ...)
+//   - underlying json.Decoder errors
+//
+// The non-canonical-case check defends against header-smuggling
+// scenarios where a buyer-trusted gateway might match on "model"
+// but a downstream provider might match on "Model"; rejecting at
+// the rewrite boundary keeps the canonical-name contract intact.
+func RewriteModel(rawBody []byte, requestedModel, providerModelID string) ([]byte, error) {
+	if strings.EqualFold(requestedModel, providerModelID) {
+		return append([]byte(nil), rawBody...), nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(rawBody))
+	token, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return nil, errors.New("chat request body is not a JSON object")
+	}
+	type replacement struct {
+		start int
+		end   int
+	}
+	var replacements []replacement
+	for dec.More() {
+		keyToken, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return nil, errors.New("chat request body contains a non-string object key")
+		}
+		keyEnd := int(dec.InputOffset())
+		valueStart, err := jsonValueStart(rawBody, keyEnd)
+		if err != nil {
+			return nil, err
+		}
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return nil, err
+		}
+		if key == "model" {
+			replacements = append(replacements, replacement{start: valueStart, end: int(dec.InputOffset())})
+		} else if strings.EqualFold(key, "model") {
+			return nil, errors.New("chat request body contains non-canonical model field")
+		}
+	}
+	if _, err := dec.Token(); err != nil {
+		return nil, err
+	}
+	if len(replacements) == 0 {
+		return nil, errors.New("chat request body missing model field")
+	}
+	if len(replacements) > 1 {
+		return nil, errors.New("chat request body contains duplicate model fields")
+	}
+	model, err := json.Marshal(providerModelID)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]byte(nil), rawBody...)
+	r := replacements[0]
+	next := make([]byte, 0, len(out)-(r.end-r.start)+len(model))
+	next = append(next, out[:r.start]...)
+	next = append(next, model...)
+	next = append(next, out[r.end:]...)
+	return next, nil
+}
+
+// jsonValueStart locates the byte offset of the first character of a
+// JSON object value, given the byte offset immediately past the key
+// (i.e. after the closing quote of the key string). Skips JSON
+// whitespace, requires a `:` separator, then skips trailing
+// whitespace before the value. Used by RewriteModel to compute the
+// EXACT byte range to splice out when replacing the `model` field's
+// value without disturbing surrounding formatting.
+func jsonValueStart(raw []byte, keyEnd int) (int, error) {
+	i := keyEnd
+	for i < len(raw) && (raw[i] == ' ' || raw[i] == '\n' || raw[i] == '\r' || raw[i] == '\t') {
+		i++
+	}
+	if i >= len(raw) || raw[i] != ':' {
+		return 0, errors.New("chat request body object key missing colon")
+	}
+	i++
+	for i < len(raw) && (raw[i] == ' ' || raw[i] == '\n' || raw[i] == '\r' || raw[i] == '\t') {
+		i++
+	}
+	if i >= len(raw) {
+		return 0, errors.New("chat request body object key missing value")
+	}
+	return i, nil
+}

--- a/phase4-coordinator/internal/routing/dispatch_test.go
+++ b/phase4-coordinator/internal/routing/dispatch_test.go
@@ -1,0 +1,127 @@
+package routing_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/routing"
+)
+
+// TestRewriteModel pins the byte-identical JSON-surgical model-field
+// rewrite extracted from buyer.dispatchBodyForProvider in #266 T2.
+
+func TestRewriteModel_PreservesBodyWhenModelMatches(t *testing.T) {
+	body := []byte(`{"model":"qwen3-32b","messages":[]}`)
+	got, err := routing.RewriteModel(body, "qwen3-32b", "qwen3-32b")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("byte-identical expected; got %s", got)
+	}
+}
+
+func TestRewriteModel_CaseInsensitiveMatchSkipsRewrite(t *testing.T) {
+	body := []byte(`{"model":"Qwen3-32B","messages":[]}`)
+	got, err := routing.RewriteModel(body, "QWEN3-32B", "qwen3-32b")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("EqualFold-matched buyer model should NOT rewrite; got %s", got)
+	}
+}
+
+func TestRewriteModel_ReplacesModelValuePreservingWhitespace(t *testing.T) {
+	body := []byte(`{ "model"  :  "fast-class"  , "messages": [] }`)
+	got, err := routing.RewriteModel(body, "fast-class", "qwen3-32b")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(string(got), `"qwen3-32b"`) {
+		t.Fatalf("expected provider model to appear; got %s", got)
+	}
+	if !strings.Contains(string(got), `"messages": [] `) {
+		t.Fatalf("expected surrounding whitespace + fields preserved; got %s", got)
+	}
+}
+
+func TestRewriteModel_ReplacesModelValuePreservingByteIdentityOutsideModelField(t *testing.T) {
+	body := []byte(`{"model":"alias","temperature":0.7,"messages":[{"role":"user","content":"hi"}]}`)
+	got, err := routing.RewriteModel(body, "alias", "qwen3-32b")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("rewritten body must still parse: %v", err)
+	}
+	if got, want := string(parsed["model"]), `"qwen3-32b"`; got != want {
+		t.Fatalf("expected model=%q, got %s", want, got)
+	}
+	if string(parsed["temperature"]) != "0.7" {
+		t.Fatalf("temperature must be preserved verbatim; got %s", parsed["temperature"])
+	}
+}
+
+func TestRewriteModel_RejectsNonObjectBody(t *testing.T) {
+	body := []byte(`[1,2,3]`)
+	_, err := routing.RewriteModel(body, "a", "b")
+	if err == nil || !strings.Contains(err.Error(), "JSON object") {
+		t.Fatalf("expected JSON-object error, got %v", err)
+	}
+}
+
+func TestRewriteModel_RejectsMissingModelField(t *testing.T) {
+	body := []byte(`{"messages":[]}`)
+	_, err := routing.RewriteModel(body, "a", "b")
+	if err == nil || !strings.Contains(err.Error(), "missing model field") {
+		t.Fatalf("expected missing-model error, got %v", err)
+	}
+}
+
+func TestRewriteModel_RejectsDuplicateModelField(t *testing.T) {
+	body := []byte(`{"model":"a","model":"b"}`)
+	_, err := routing.RewriteModel(body, "a", "x")
+	if err == nil || !strings.Contains(err.Error(), "duplicate model") {
+		t.Fatalf("expected duplicate-model error, got %v", err)
+	}
+}
+
+func TestRewriteModel_RejectsNonCanonicalCasing(t *testing.T) {
+	// "Model" must be rejected — defense against header-smuggling
+	// where a downstream layer might match case-insensitively.
+	body := []byte(`{"Model":"a","messages":[]}`)
+	_, err := routing.RewriteModel(body, "a", "b")
+	if err == nil || !strings.Contains(err.Error(), "non-canonical model field") {
+		t.Fatalf("expected non-canonical-case error, got %v", err)
+	}
+}
+
+func TestRewriteModel_EmptyProviderModelIDIsLiteralRewrite(t *testing.T) {
+	// Empty provider model_id is a degenerate but valid input — the
+	// rewritten body should contain "" as the model value.
+	body := []byte(`{"model":"alias"}`)
+	got, err := routing.RewriteModel(body, "alias", "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if string(got) != `{"model":""}` {
+		t.Fatalf("expected empty model rewrite, got %s", got)
+	}
+}
+
+func TestRewriteModel_CopiesInputWhenSkippingRewrite(t *testing.T) {
+	// Match-skip path returns a FRESH slice so callers can mutate
+	// the rawBody for retry use without corrupting the dispatch body.
+	body := []byte(`{"model":"a"}`)
+	got, err := routing.RewriteModel(body, "a", "a")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	got[0] = 'X'
+	if body[0] == 'X' {
+		t.Fatalf("returned slice must not alias input")
+	}
+}

--- a/phase4-coordinator/internal/routing/objective.go
+++ b/phase4-coordinator/internal/routing/objective.go
@@ -1,0 +1,124 @@
+package routing
+
+import (
+	"sort"
+
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+// SortCandidates sorts the candidate slice in-place by the SPEC-004
+// §6 per-objective ranking. Behaviour is byte-identical to the
+// pre-extraction `buyer.Server.sortCandidates` (PR #266 T2 — issue
+// #266 deferred refactor):
+//
+//	"fast"      → effective_throughput desc, slots_free asc tiebreak
+//	"accurate"  → model_params_b desc, then eff_tps desc, then slots_free asc
+//	"balanced"  → BalancedScores desc, slots_free asc tiebreak
+//	default     → slots_free asc, eff_tps desc tiebreak
+//
+// Stable sort everywhere so providers that compare equal under the
+// objective retain their input ordering — this matters because the
+// caller may have applied sticky-affinity (applySticky) BEFORE the
+// sort and the sticky-target candidate must not drift down the cohort.
+//
+// EffectiveThroughput receives Weights so the per-provisional-tier
+// downweight (default 0.3 per SPEC-002 v1.1 §5 Step 2.5) is honored;
+// callers should pass DefaultWeights().With(provisional=s.provisionalWeight).
+//
+// `balanced` uses the SPEC-004 FR-SR-8 normative score formula via
+// BalancedScores. Scores are pre-keyed by ProviderID+/+AssignedID
+// (mirroring buyer.routeKey) so the comparator can look them up
+// across sort-driven candidate swaps.
+func SortCandidates(candidates []pool.Provider, objective Objective, weights Weights) {
+	switch objective {
+	case ObjectiveFast:
+		sort.SliceStable(candidates, func(i, j int) bool {
+			ti := EffectiveThroughput(candidates[i], weights)
+			tj := EffectiveThroughput(candidates[j], weights)
+			if ti == tj {
+				return candidates[i].SlotsFree < candidates[j].SlotsFree
+			}
+			return ti > tj
+		})
+	case ObjectiveAccurate:
+		sort.SliceStable(candidates, func(i, j int) bool {
+			if candidates[i].ModelParamsB == candidates[j].ModelParamsB {
+				ti := EffectiveThroughput(candidates[i], weights)
+				tj := EffectiveThroughput(candidates[j], weights)
+				if ti != tj {
+					return ti > tj
+				}
+				return candidates[i].SlotsFree < candidates[j].SlotsFree
+			}
+			return candidates[i].ModelParamsB > candidates[j].ModelParamsB
+		})
+	case ObjectiveBalanced:
+		scores := KeyedBalancedScores(candidates)
+		sort.SliceStable(candidates, func(i, j int) bool {
+			si := scores[providerSortKey(candidates[i])]
+			sj := scores[providerSortKey(candidates[j])]
+			if si == sj {
+				return candidates[i].SlotsFree < candidates[j].SlotsFree
+			}
+			return si > sj
+		})
+	default:
+		sort.SliceStable(candidates, func(i, j int) bool {
+			if candidates[i].SlotsFree == candidates[j].SlotsFree {
+				return EffectiveThroughput(candidates[i], weights) > EffectiveThroughput(candidates[j], weights)
+			}
+			return candidates[i].SlotsFree < candidates[j].SlotsFree
+		})
+	}
+}
+
+// ObjectiveScores returns a per-candidate scalar score keyed by
+// ProviderID+/+AssignedID for the given objective. Used by the
+// routing-decision log surface (CandidateLogEntry.ObjectiveMetric)
+// to record what the sort comparator ranked on. For "balanced" the
+// SPEC-004 FR-SR-8 formula applies (BalancedScores); for "fast" and
+// default it's effective_throughput; for "accurate" it's
+// model_params_b. Byte-identical to pre-extraction
+// `buyer.Server.routingScores`.
+func ObjectiveScores(candidates []pool.Provider, objective Objective, weights Weights) map[string]float64 {
+	if objective == ObjectiveBalanced {
+		return KeyedBalancedScores(candidates)
+	}
+	out := make(map[string]float64, len(candidates))
+	for _, p := range candidates {
+		switch objective {
+		case ObjectiveFast:
+			out[providerSortKey(p)] = EffectiveThroughput(p, weights)
+		case ObjectiveAccurate:
+			out[providerSortKey(p)] = p.ModelParamsB
+		default:
+			out[providerSortKey(p)] = EffectiveThroughput(p, weights)
+		}
+	}
+	return out
+}
+
+// KeyedBalancedScores wraps the indexed BalancedScores and re-keys
+// by ProviderID+/+AssignedID so comparators that survive
+// sort-driven candidate swaps can look up scores by stable identity.
+// Pre-extraction buyer code did this via a local `balancedScores`
+// helper; consolidated here so log + sort surfaces share one
+// implementation.
+func KeyedBalancedScores(candidates []pool.Provider) map[string]float64 {
+	indexed := BalancedScores(candidates)
+	out := make(map[string]float64, len(candidates))
+	for i, p := range candidates {
+		out[providerSortKey(p)] = indexed[i]
+	}
+	return out
+}
+
+// providerSortKey mirrors buyer.routeKey (ProviderID+"/"+AssignedID).
+// Kept internal to the routing package so the package owns its own
+// stable key derivation; buyer can continue to use its own routeKey
+// for log + sticky surfaces (the strings happen to match exactly,
+// which is required because the routing-decision log emits the same
+// shape).
+func providerSortKey(p pool.Provider) string {
+	return p.ProviderID + "/" + p.AssignedID
+}

--- a/phase4-coordinator/internal/routing/objective_test.go
+++ b/phase4-coordinator/internal/routing/objective_test.go
@@ -1,0 +1,149 @@
+package routing_test
+
+import (
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/routing"
+)
+
+// TestSortCandidates pins the SPEC-004 §6 per-objective ranking
+// extracted from buyer.Server.sortCandidates in issue #266 T2. Each
+// case exercises ONE objective branch + its tiebreak rule.
+
+func makeProvider(id string, tps, params float64, slotsFree int, tier pool.Tier) pool.Provider {
+	return pool.Provider{
+		ProviderID:            id,
+		AssignedID:            id,
+		State:                 pool.StateReady,
+		Tier:                  tier,
+		SlotsFree:             slotsFree,
+		SlotsTotal:            1,
+		ThroughputTPSEstimate: tps,
+		ModelParamsB:          params,
+	}
+}
+
+func TestSortCandidates_Fast_ThroughputDescThenSlotsAsc(t *testing.T) {
+	cands := []pool.Provider{
+		makeProvider("a", 100, 0, 5, pool.TierPinned),
+		makeProvider("b", 200, 0, 3, pool.TierPinned),
+		makeProvider("c", 200, 0, 1, pool.TierPinned), // ties with b on tps; lower slots wins tiebreak
+	}
+	routing.SortCandidates(cands, routing.ObjectiveFast, routing.DefaultWeights())
+	if cands[0].ProviderID != "c" {
+		t.Fatalf("expected c (top tps + low slots) first, got %s", cands[0].ProviderID)
+	}
+	if cands[1].ProviderID != "b" {
+		t.Fatalf("expected b second, got %s", cands[1].ProviderID)
+	}
+}
+
+func TestSortCandidates_Accurate_ParamsDescThenTpsThenSlots(t *testing.T) {
+	cands := []pool.Provider{
+		makeProvider("a", 100, 7.0, 3, pool.TierPinned),
+		makeProvider("b", 100, 70.0, 3, pool.TierPinned), // higher params wins
+		makeProvider("c", 200, 70.0, 5, pool.TierPinned), // ties b on params; higher tps wins
+	}
+	routing.SortCandidates(cands, routing.ObjectiveAccurate, routing.DefaultWeights())
+	if cands[0].ProviderID != "c" {
+		t.Fatalf("expected c (top params + top tps) first, got %s", cands[0].ProviderID)
+	}
+	if cands[1].ProviderID != "b" {
+		t.Fatalf("expected b (top params + lower tps) second, got %s", cands[1].ProviderID)
+	}
+}
+
+func TestSortCandidates_Default_SlotsAscThenTpsDesc(t *testing.T) {
+	cands := []pool.Provider{
+		makeProvider("a", 100, 0, 5, pool.TierPinned),
+		makeProvider("b", 200, 0, 5, pool.TierPinned), // ties a on slots; higher tps wins
+		makeProvider("c", 100, 0, 1, pool.TierPinned), // lowest slots wins overall
+	}
+	routing.SortCandidates(cands, routing.ObjectiveDefault, routing.DefaultWeights())
+	if cands[0].ProviderID != "c" {
+		t.Fatalf("expected c (lowest slots) first, got %s", cands[0].ProviderID)
+	}
+	if cands[1].ProviderID != "b" {
+		t.Fatalf("expected b (tied slots, higher tps) second, got %s", cands[1].ProviderID)
+	}
+}
+
+func TestSortCandidates_StableUnderEqualOrdering(t *testing.T) {
+	// All-equal candidates must retain input order — sticky-affinity
+	// targets land in a specific position before sort and must not
+	// drift down the cohort. Stable-sort invariant pinned here.
+	cands := []pool.Provider{
+		makeProvider("a", 100, 1, 1, pool.TierPinned),
+		makeProvider("b", 100, 1, 1, pool.TierPinned),
+		makeProvider("c", 100, 1, 1, pool.TierPinned),
+	}
+	routing.SortCandidates(cands, routing.ObjectiveFast, routing.DefaultWeights())
+	want := []string{"a", "b", "c"}
+	for i, w := range want {
+		if cands[i].ProviderID != w {
+			t.Fatalf("expected stable order %v, got %v at index %d", want, cands[i].ProviderID, i)
+		}
+	}
+}
+
+func TestSortCandidates_BalancedScoresRouteFromBalancedScores(t *testing.T) {
+	// Balanced objective uses BalancedScores; verify the comparator
+	// reads the keyed score (not a raw field) by giving one candidate
+	// every dimension's max.
+	cands := []pool.Provider{
+		makeProvider("low", 1, 1, 99, pool.TierPinned),
+		makeProvider("top", 1000, 1000, 0, pool.TierPinned), // wins tps + params + ctx; slots small but balanced dominates
+	}
+	cands[1].MaxContextTokens = 1000
+	routing.SortCandidates(cands, routing.ObjectiveBalanced, routing.DefaultWeights())
+	if cands[0].ProviderID != "top" {
+		t.Fatalf("expected top (balanced wins) first, got %s", cands[0].ProviderID)
+	}
+}
+
+func TestSortCandidates_ProvisionalDownweightedUnderFast(t *testing.T) {
+	// Provisional tier multiplies tps by Weights.Provisional. With
+	// the SPEC-002 v1.1 default (0.3), a provisional provider at
+	// 333 raw tps becomes ~99 effective and ranks BELOW a pinned
+	// provider at 100 raw tps.
+	weights := routing.Weights{Pinned: 1.0, Provisional: 0.3}
+	cands := []pool.Provider{
+		makeProvider("provis", 333, 0, 3, pool.TierProvisional),
+		makeProvider("pinned", 100, 0, 3, pool.TierPinned),
+	}
+	routing.SortCandidates(cands, routing.ObjectiveFast, weights)
+	if cands[0].ProviderID != "pinned" {
+		t.Fatalf("expected pinned (effective 100) first over provisional (effective 99.9), got %s", cands[0].ProviderID)
+	}
+}
+
+func TestObjectiveScores_FastReturnsEffectiveThroughput(t *testing.T) {
+	cands := []pool.Provider{
+		makeProvider("a", 100, 0, 0, pool.TierPinned),
+	}
+	scores := routing.ObjectiveScores(cands, routing.ObjectiveFast, routing.DefaultWeights())
+	if got := scores["a/a"]; got != 100 {
+		t.Fatalf("expected fast score = effective tps 100, got %v", got)
+	}
+}
+
+func TestObjectiveScores_AccurateReturnsParams(t *testing.T) {
+	cands := []pool.Provider{makeProvider("a", 100, 42, 0, pool.TierPinned)}
+	scores := routing.ObjectiveScores(cands, routing.ObjectiveAccurate, routing.DefaultWeights())
+	if got := scores["a/a"]; got != 42 {
+		t.Fatalf("expected accurate score = params 42, got %v", got)
+	}
+}
+
+func TestObjectiveScores_BalancedDelegatesToKeyedBalancedScores(t *testing.T) {
+	cands := []pool.Provider{
+		makeProvider("a", 100, 10, 5, pool.TierPinned),
+		makeProvider("b", 200, 20, 3, pool.TierPinned),
+	}
+	scores := routing.ObjectiveScores(cands, routing.ObjectiveBalanced, routing.DefaultWeights())
+	keyed := routing.KeyedBalancedScores(cands)
+	if scores["a/a"] != keyed["a/a"] || scores["b/b"] != keyed["b/b"] {
+		t.Fatalf("balanced ObjectiveScores must match KeyedBalancedScores; got %v vs %v", scores, keyed)
+	}
+}

--- a/phase4-coordinator/internal/routing/retry.go
+++ b/phase4-coordinator/internal/routing/retry.go
@@ -1,0 +1,153 @@
+package routing
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// RetryHeaderLimit parses the `X-MacProvider-Retry` buyer header
+// into a per-request retry budget. Issue #266 T2 refactor —
+// byte-identical to pre-extraction `buyer.retryHeaderLimit`:
+//
+//   - empty / whitespace-only → 0 (no retries requested)
+//   - "true" (case-insensitive) → math.MaxInt (buyer accepts any
+//     number of retries up to the operator-configured server cap)
+//   - positive integer N → N
+//   - any other shape (zero, negative, non-numeric) → 0
+//
+// Returning 0 disables retry entirely for the request, even when
+// the operator's `routing.max_retries` is >0. The header is the
+// buyer's opt-in; the operator config is the cap.
+func RetryHeaderLimit(value string) int {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if strings.EqualFold(value, "true") {
+		return math.MaxInt
+	}
+	var n int
+	if _, err := fmt.Sscanf(value, "%d", &n); err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
+// ShouldRetryInput bundles the inputs to ShouldRetry so the call
+// site documents WHY each parameter matters without growing a
+// long positional signature. Every field is consumed at least
+// once by the gate logic; none is optional.
+type ShouldRetryInput struct {
+	// MaxRetries is the operator-configured `routing.max_retries`
+	// cap. When ≤ 0 the request gets zero retries regardless of
+	// other inputs.
+	MaxRetries int
+
+	// RequestedRetries is the parsed RetryHeaderLimit value (see
+	// above). When ≤ 0 the buyer opted out of retries.
+	RequestedRetries int
+
+	// HasPinnedRoute is true when the buyer pinned to a specific
+	// provider via X-MacProvider-Provider or X-MacProvider-Session.
+	// Pinned requests do NOT retry — the failure attribution
+	// surface requires the buyer-named provider to be the one
+	// that failed.
+	HasPinnedRoute bool
+
+	// ContextErr is `r.Context().Err()` at the gate point. When
+	// non-nil the request is already cancelled / deadline-exceeded
+	// and no further attempts are worth dispatching.
+	ContextErr error
+
+	// ExplicitRetries is forwardState.explicitRetries — the count
+	// of advances driven by retry (NOT failover) so far. Gated
+	// against min(MaxRetries, RequestedRetries).
+	ExplicitRetries int
+
+	// FaultedProviders is forwardState.faultedProviders — the
+	// count of providers we have marked faulted on this request.
+	// Gated against MaxFaultedPerRequest when that is > 0.
+	FaultedProviders int
+
+	// MaxFaultedPerRequest is the operator-configured
+	// `routing.max_providers_faulted_per_request` cap. When ≤ 0
+	// the cap is disabled.
+	MaxFaultedPerRequest int
+
+	// Now is the current wall-clock at the gate point; used with
+	// StartedAt + RequestTimeout + RetryPerAttemptTimeout to
+	// short-circuit when the next attempt would overrun the
+	// per-request deadline.
+	Now time.Time
+
+	// StartedAt is the wall-clock at which handleChatCompletions
+	// began processing this request.
+	StartedAt time.Time
+
+	// RequestTimeout is the operator-configured per-request
+	// budget. When ≤ 0 the time-budget gate is disabled.
+	RequestTimeout time.Duration
+
+	// RetryPerAttemptTimeout is the per-attempt budget reserved
+	// for the NEXT attempt if we allow the retry. Added to
+	// Now-StartedAt and compared against RequestTimeout to avoid
+	// dispatching an attempt that cannot complete before the
+	// per-request deadline.
+	RetryPerAttemptTimeout time.Duration
+
+	// Status is the HTTP status code from the just-completed
+	// attempt (0 when err is non-nil and no status was reached).
+	Status int
+
+	// Err is the dispatch-level error from the just-completed
+	// attempt, or nil if the attempt produced a status.
+	Err error
+}
+
+// ShouldRetry reports whether the request is eligible to retry the
+// just-failed attempt. Byte-identical to pre-extraction
+// `buyer.Server.shouldRetry`, factored as a pure function so the
+// retry policy can be unit-tested without spinning up a buyer
+// Server. Issue #266 T2 refactor.
+//
+// Gate order (ALL must pass for retry to fire):
+//  1. MaxRetries > 0 AND RequestedRetries > 0 AND !HasPinnedRoute
+//  2. ContextErr is nil
+//  3. ExplicitRetries < min(MaxRetries, RequestedRetries)
+//  4. MaxFaultedPerRequest is 0 OR FaultedProviders < MaxFaultedPerRequest
+//  5. RequestTimeout is 0 OR (Now-StartedAt) + RetryPerAttemptTimeout ≤ RequestTimeout
+//  6. Err is non-nil OR Status is BadGateway/GatewayTimeout
+//
+// The order matters for the audit narrative: pin-check first (cheap),
+// then context, then explicit-retry cap, then fault cap, then
+// time-budget, then status-class. A request that fails the pin
+// check never even consults the timeout — the audit row reads as
+// "pinned therefore no retry" not "timed out".
+func ShouldRetry(in ShouldRetryInput) bool {
+	if in.MaxRetries <= 0 || in.RequestedRetries <= 0 || in.HasPinnedRoute {
+		return false
+	}
+	if in.ContextErr != nil {
+		return false
+	}
+	cap := in.MaxRetries
+	if in.RequestedRetries < cap {
+		cap = in.RequestedRetries
+	}
+	if in.ExplicitRetries >= cap {
+		return false
+	}
+	if in.MaxFaultedPerRequest > 0 && in.FaultedProviders >= in.MaxFaultedPerRequest {
+		return false
+	}
+	if in.RequestTimeout > 0 && in.Now.Sub(in.StartedAt)+in.RetryPerAttemptTimeout > in.RequestTimeout {
+		return false
+	}
+	if in.Err != nil {
+		return true
+	}
+	return in.Status == http.StatusBadGateway || in.Status == http.StatusGatewayTimeout
+}

--- a/phase4-coordinator/internal/routing/retry_test.go
+++ b/phase4-coordinator/internal/routing/retry_test.go
@@ -1,0 +1,197 @@
+package routing_test
+
+import (
+	"context"
+	"errors"
+	"math"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/routing"
+)
+
+// TestRetryHeaderLimit pins the buyer-header parser extracted into
+// routing/retry.go in #266 T2.
+
+func TestRetryHeaderLimit_Empty(t *testing.T) {
+	if got := routing.RetryHeaderLimit(""); got != 0 {
+		t.Fatalf("empty header → 0; got %d", got)
+	}
+}
+
+func TestRetryHeaderLimit_Whitespace(t *testing.T) {
+	if got := routing.RetryHeaderLimit("   "); got != 0 {
+		t.Fatalf("whitespace header → 0; got %d", got)
+	}
+}
+
+func TestRetryHeaderLimit_TrueIsMaxInt(t *testing.T) {
+	if got := routing.RetryHeaderLimit("true"); got != math.MaxInt {
+		t.Fatalf("'true' → MaxInt; got %d", got)
+	}
+	if got := routing.RetryHeaderLimit("TRUE"); got != math.MaxInt {
+		t.Fatalf("'TRUE' → MaxInt (case-insensitive); got %d", got)
+	}
+}
+
+func TestRetryHeaderLimit_PositiveInteger(t *testing.T) {
+	if got := routing.RetryHeaderLimit("3"); got != 3 {
+		t.Fatalf("'3' → 3; got %d", got)
+	}
+}
+
+func TestRetryHeaderLimit_ZeroAndNegativeReturnZero(t *testing.T) {
+	if got := routing.RetryHeaderLimit("0"); got != 0 {
+		t.Fatalf("'0' → 0; got %d", got)
+	}
+	if got := routing.RetryHeaderLimit("-2"); got != 0 {
+		t.Fatalf("'-2' → 0; got %d", got)
+	}
+}
+
+func TestRetryHeaderLimit_GarbageReturnsZero(t *testing.T) {
+	if got := routing.RetryHeaderLimit("abc"); got != 0 {
+		t.Fatalf("'abc' → 0; got %d", got)
+	}
+}
+
+// TestShouldRetry pins each gate in the policy extracted into
+// routing/retry.go in #266 T2. Each case fails ONE gate so a
+// regression trips one targeted test.
+
+func baseInput() routing.ShouldRetryInput {
+	return routing.ShouldRetryInput{
+		MaxRetries:             3,
+		RequestedRetries:       3,
+		HasPinnedRoute:         false,
+		ContextErr:             nil,
+		ExplicitRetries:        0,
+		FaultedProviders:       0,
+		MaxFaultedPerRequest:   0,
+		Now:                    time.Unix(1_700_000_000, 0),
+		StartedAt:              time.Unix(1_700_000_000, 0),
+		RequestTimeout:         60 * time.Second,
+		RetryPerAttemptTimeout: 5 * time.Second,
+		Status:                 http.StatusBadGateway,
+		Err:                    nil,
+	}
+}
+
+func TestShouldRetry_BaseCaseAllows(t *testing.T) {
+	if !routing.ShouldRetry(baseInput()) {
+		t.Fatalf("base case must allow")
+	}
+}
+
+func TestShouldRetry_MaxRetriesZeroDenies(t *testing.T) {
+	in := baseInput()
+	in.MaxRetries = 0
+	if routing.ShouldRetry(in) {
+		t.Fatalf("MaxRetries=0 → no retry")
+	}
+}
+
+func TestShouldRetry_RequestedRetriesZeroDenies(t *testing.T) {
+	in := baseInput()
+	in.RequestedRetries = 0
+	if routing.ShouldRetry(in) {
+		t.Fatalf("RequestedRetries=0 → no retry")
+	}
+}
+
+func TestShouldRetry_PinnedRouteDenies(t *testing.T) {
+	in := baseInput()
+	in.HasPinnedRoute = true
+	if routing.ShouldRetry(in) {
+		t.Fatalf("pinned route → no retry")
+	}
+}
+
+func TestShouldRetry_CancelledContextDenies(t *testing.T) {
+	in := baseInput()
+	in.ContextErr = context.Canceled
+	if routing.ShouldRetry(in) {
+		t.Fatalf("cancelled context → no retry")
+	}
+}
+
+func TestShouldRetry_ExplicitRetriesAtCapDenies(t *testing.T) {
+	in := baseInput()
+	in.ExplicitRetries = 3 // equals min(MaxRetries=3, RequestedRetries=3)
+	if routing.ShouldRetry(in) {
+		t.Fatalf("at-cap explicit retries → no retry")
+	}
+}
+
+func TestShouldRetry_RequestedCapTighterThanOperatorCap(t *testing.T) {
+	in := baseInput()
+	in.MaxRetries = 10      // operator cap loose
+	in.RequestedRetries = 1 // buyer cap tight
+	in.ExplicitRetries = 1  // at buyer cap, NOT at operator cap
+	if routing.ShouldRetry(in) {
+		t.Fatalf("buyer-cap-tighter case must take the min")
+	}
+}
+
+func TestShouldRetry_FaultCapAtCapDenies(t *testing.T) {
+	in := baseInput()
+	in.MaxFaultedPerRequest = 2
+	in.FaultedProviders = 2
+	if routing.ShouldRetry(in) {
+		t.Fatalf("at-fault-cap → no retry")
+	}
+}
+
+func TestShouldRetry_FaultCapZeroIsDisabled(t *testing.T) {
+	in := baseInput()
+	in.MaxFaultedPerRequest = 0
+	in.FaultedProviders = 999
+	if !routing.ShouldRetry(in) {
+		t.Fatalf("MaxFaultedPerRequest=0 disables the cap; should allow")
+	}
+}
+
+func TestShouldRetry_TimeBudgetExhaustedDenies(t *testing.T) {
+	in := baseInput()
+	in.Now = in.StartedAt.Add(58 * time.Second)
+	// Now-StartedAt=58s + RetryPerAttemptTimeout=5s = 63s > 60s budget
+	if routing.ShouldRetry(in) {
+		t.Fatalf("time-budget exhausted → no retry")
+	}
+}
+
+func TestShouldRetry_TimeBudgetZeroIsDisabled(t *testing.T) {
+	in := baseInput()
+	in.RequestTimeout = 0
+	in.Now = in.StartedAt.Add(24 * time.Hour)
+	if !routing.ShouldRetry(in) {
+		t.Fatalf("RequestTimeout=0 disables the gate; should allow")
+	}
+}
+
+func TestShouldRetry_NonRetryableStatusDenies(t *testing.T) {
+	in := baseInput()
+	in.Status = http.StatusOK
+	if routing.ShouldRetry(in) {
+		t.Fatalf("200 OK → no retry")
+	}
+}
+
+func TestShouldRetry_GatewayTimeoutAllows(t *testing.T) {
+	in := baseInput()
+	in.Status = http.StatusGatewayTimeout
+	if !routing.ShouldRetry(in) {
+		t.Fatalf("504 → allow retry")
+	}
+}
+
+func TestShouldRetry_ErrTrumpsStatus(t *testing.T) {
+	// When err is non-nil, status is ignored and retry fires.
+	in := baseInput()
+	in.Status = http.StatusOK
+	in.Err = errors.New("dial timeout")
+	if !routing.ShouldRetry(in) {
+		t.Fatalf("non-nil err → allow retry regardless of status")
+	}
+}

--- a/specs/AUDIT_ISS266_T2_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS266_T2_ARCHITECT_PROMPT.md
@@ -1,0 +1,50 @@
+# Issue #266 Tranche 2 — ARCHITECT audit prompt
+
+You are an independent architecture auditor. Report findings with severities CRITICAL / HIGH / MEDIUM / LOW. **MEDIUM and above gate merge.**
+
+## Context
+
+Issue #266 Tranche 2 (this PR) extracts three refactor-only items into the `internal/routing/` package:
+
+1. **`internal/routing/objective.go`** — `SortCandidates(candidates, objective, weights)` + `ObjectiveScores` + `KeyedBalancedScores`
+2. **`internal/routing/dispatch.go`** — `RewriteModel(rawBody, requestedModel, providerModelID)` + `jsonValueStart`
+3. **`internal/routing/retry.go`** — `RetryHeaderLimit(value)` + `ShouldRetry(ShouldRetryInput)` + `ShouldRetryInput` struct
+
+REFACTOR-ONLY — no new functional behaviour at any flag setting. Buyer methods become thin delegators; helpers `effectiveThroughput`, `balancedScores`, `retryHeaderLimit` deleted.
+
+This advances the SPEC-004 architecture goal of `internal/routing/` owning the canonical routing logic (filter, sort, tiebreak, dispatch, retry policy) so the buyer package focuses on transport orchestration. PR #263 extracted candidate/epsilon/exclusion/filter/log/class; this PR adds the remaining three of the Phase D deferred set.
+
+## Changed files
+
+- `phase4-coordinator/internal/routing/objective.go` (NEW)
+- `phase4-coordinator/internal/routing/dispatch.go` (NEW)
+- `phase4-coordinator/internal/routing/retry.go` (NEW)
+- `phase4-coordinator/internal/routing/{objective,dispatch,retry}_test.go` (NEW)
+- `phase4-coordinator/internal/buyer/server.go` (modified — delegations + helper deletions)
+
+Compare against `origin/main` commit `798e57b`.
+
+## What to audit (ARCHITECT lens)
+
+1. **`providerSortKey` duplication.** `routing.providerSortKey` is internal and produces `ProviderID+"/"+AssignedID`; `buyer.routeKey` produces the same string. Two implementations of the same key derivation is a latent divergence trap. Should `buyer.routeKey` call into `routing.providerSortKey` (exported), or should both share a `pool.Provider.SortKey()` method on the pool type? Argue.
+2. **`SortCandidates` ergonomics.** The signature is `(candidates, objective, weights)`. A caller that wants BOTH the sorted slice AND the per-candidate scores must call `SortCandidates` then `ObjectiveScores`, computing BalancedScores twice for balanced objective. Is this acceptable per the deferred #266 "BalancedScores compute caching" item, or should T2 land a `SortAndScore` helper that returns both in one pass?
+3. **`ShouldRetryInput` struct vs positional args.** Pre-extraction signature: `shouldRetry(r, startedAt, explicit, faulted, status, err)` — 6 positional args. Post-extraction: a 13-field struct. Trade-off: explicit struct documents which inputs matter (good for unit tests) vs heavier call surface (every caller must populate every field, even ones it doesn't care about). Is the struct the right call?
+4. **`buyer.Server.shouldRetry` wrapper stays.** Pre-extraction call sites of `s.shouldRetry(r, ...)` continue to work unchanged — the wrapper bundles Server state into `ShouldRetryInput` and calls `routing.ShouldRetry`. Should the wrapper STAY (keep call sites stable; deferred to a follow-up) or be INLINED at the four call sites (one fewer indirection; deeper diff)?
+5. **`RewriteModel` returns []byte; downstream consumers may mutate.** The function copies the input slice in BOTH the match-skip path AND the rewrite path. Confirm callers (forwardStreamSequence / WS-non / HTTP) don't accidentally rely on the input being mutated in place — and confirm the copy isn't wasteful for the match-skip path (could it return the original slice + a "do not mutate" contract? Argue trade-off).
+6. **routing package import-cycle hygiene.** `internal/routing/` imports `internal/pool` but NOT `internal/config` (which would create a cycle when config grows to reference routing types). Extracted code keeps this invariant?
+7. **Test-coverage delta.** 26 new unit tests added; pre-extraction buyer tests covered the same surfaces. Is the test coverage net-additive (good — new tests at the new boundary), or are buyer tests now redundant duplicates of routing tests?
+8. **Future T3 readiness.** Tranche 3 (the remaining #266 items) needs to add `BalancedScores` compute caching, more AC-SR-1 byte-identity scenarios, and an HTTP-path integration test. Does the T2 extraction set the stage cleanly for those — i.e., is `KeyedBalancedScores` the right caching target, or does T3 need to thread a cache through `SortCandidates` directly?
+
+## Output format
+
+For each finding:
+- **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+- **Location**: file:line OR "design-level"
+- **Issue**: 1-2 sentences
+- **Evidence**: quoted code, architectural trade-off
+- **Fix sketch**: what would resolve it, OR "accepted with rationale"
+
+Final line MUST be:
+```
+SUMMARY: CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n>
+```

--- a/specs/AUDIT_ISS266_T2_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS266_T2_CODE_PROMPT.md
@@ -1,0 +1,53 @@
+# Issue #266 Tranche 2 — CODE audit prompt
+
+You are an independent code auditor. Report findings with severities CRITICAL / HIGH / MEDIUM / LOW. **MEDIUM and above gate merge.**
+
+## Context
+
+Issue #266 closes deferred follow-ups from PR #263. Tranche 2 (this PR) extracts three refactor-only items into the `internal/routing/` package, with ZERO behaviour change at any flag setting:
+
+1. **`internal/routing/objective.go`** — `SortCandidates(candidates, objective, weights)` + `ObjectiveScores` + `KeyedBalancedScores`, extracted from `buyer.Server.sortCandidates` / `routingScores` / `balancedScores` on `origin/main` commit `798e57b`.
+2. **`internal/routing/dispatch.go`** — `RewriteModel(rawBody, requestedModel, providerModelID)` + internal `jsonValueStart`, extracted from `buyer.dispatchBodyForProvider`.
+3. **`internal/routing/retry.go`** — `RetryHeaderLimit(value)` + `ShouldRetry(in ShouldRetryInput)` extracted from `buyer.Server.shouldRetry` + `buyer.retryHeaderLimit`.
+
+Buyer-side methods become thin delegators. Buyer helpers `effectiveThroughput`, `balancedScores`, `retryHeaderLimit` are DELETED — sole callers migrated to routing primitives.
+
+**Audit question**: Does the extracted code produce byte-identical behaviour to the pre-extraction inline code at every input shape?
+
+## Changed files
+
+- `phase4-coordinator/internal/routing/objective.go` (NEW)
+- `phase4-coordinator/internal/routing/objective_test.go` (NEW)
+- `phase4-coordinator/internal/routing/dispatch.go` (NEW)
+- `phase4-coordinator/internal/routing/dispatch_test.go` (NEW)
+- `phase4-coordinator/internal/routing/retry.go` (NEW)
+- `phase4-coordinator/internal/routing/retry_test.go` (NEW)
+- `phase4-coordinator/internal/buyer/server.go` (modified — delegations + helper deletions)
+
+Compare against `origin/main` commit `798e57b`.
+
+## What to audit (CODE lens)
+
+1. **Behaviour preservation per extraction.** For each of the three extractions, walk through the pre-extraction code and the new code side-by-side. Are the comparator branches identical? Is the JSON-rewrite byte-stream identical? Is the ShouldRetry gate sequence identical?
+2. **`SortCandidates` vs pre-extraction `sortCandidates`** — verify the four objective branches map exactly (fast → tps desc + slots asc; accurate → params desc + tps desc + slots asc; balanced → balanced-score desc + slots asc; default → slots asc + tps desc). Verify `sort.SliceStable` is preserved everywhere (stable sort matters for sticky-affinity pre-sort ordering).
+3. **`ObjectiveScores` vs pre-extraction `routingScores`** — verify the map keys (ProviderID+/+AssignedID) match what `buyer.routeKey` produces. Verify the per-objective value source is correct (fast→eff_tps, accurate→params, default→eff_tps, balanced→KeyedBalancedScores).
+4. **`KeyedBalancedScores`** — verify it produces the same map shape that the pre-extraction `buyer.balancedScores` produced (indexed slice from `BalancedScores` mapped onto routeKey).
+5. **`RewriteModel`** — diff against pre-extraction `dispatchBodyForProvider`. Verify: model-match-skip path (uses `strings.EqualFold`, mirroring pre-extraction `modelIDEqual`); JSON-decoder + jsonValueStart byte-position tracking; replacement-set accumulation; non-canonical-case rejection; duplicate / missing rejection; final byte splice. Argue byte-for-byte equivalence.
+6. **`ShouldRetry`** — diff against pre-extraction `buyer.Server.shouldRetry`. Verify gate order matches exactly. Verify the `min(MaxRetries, RequestedRetries)` calculation matches pre-extraction. Verify the time-budget arithmetic preserves the inequality direction.
+7. **`RetryHeaderLimit`** — diff against pre-extraction `buyer.retryHeaderLimit`. Note the change from `int(^uint(0)>>1)` to `math.MaxInt` — verify these are bit-identical.
+8. **Wrapper completeness.** `buyer.Server.shouldRetry` wrapper bundles caller state into `ShouldRetryInput`. Confirm via grep that all pre-PR call sites of the wrapper continue to work without modification.
+9. **Buyer-side helper deletions.** `effectiveThroughput`, `balancedScores`, `retryHeaderLimit` (buyer-side) were deleted. Confirm no remaining references via grep. Confirm imports stayed correct (`bytes`, `encoding/json`, `errors`, `fmt`, `sort`, `strings` are still needed by other code in server.go).
+
+## Output format
+
+For each finding:
+- **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+- **Location**: file:line
+- **Issue**: 1-2 sentences
+- **Evidence**: quoted code or contradicting diff
+- **Fix sketch**: what would resolve it
+
+Final line MUST be:
+```
+SUMMARY: CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n>
+```

--- a/specs/AUDIT_ISS266_T2_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS266_T2_SECURITY_PROMPT.md
@@ -1,0 +1,48 @@
+# Issue #266 Tranche 2 — SECURITY audit prompt
+
+You are an independent security auditor. Report findings with severities CRITICAL / HIGH / MEDIUM / LOW. **MEDIUM and above gate merge.**
+
+## Context
+
+Issue #266 Tranche 2 (this PR) extracts three refactor-only items into `internal/routing/`:
+
+1. **`internal/routing/objective.go`** — `SortCandidates` / `ObjectiveScores` / `KeyedBalancedScores`
+2. **`internal/routing/dispatch.go`** — `RewriteModel(rawBody, requestedModel, providerModelID)` + `jsonValueStart`
+3. **`internal/routing/retry.go`** — `RetryHeaderLimit(value)` + `ShouldRetry(ShouldRetryInput)`
+
+REFACTOR-ONLY — no new functional behaviour at any flag setting.
+
+## Changed files
+
+- `phase4-coordinator/internal/routing/objective.go` (NEW)
+- `phase4-coordinator/internal/routing/dispatch.go` (NEW)
+- `phase4-coordinator/internal/routing/retry.go` (NEW)
+- `phase4-coordinator/internal/routing/{objective,dispatch,retry}_test.go` (NEW)
+- `phase4-coordinator/internal/buyer/server.go` (modified — delegations + helper deletions)
+
+Compare against `origin/main` commit `798e57b`.
+
+## What to audit (SECURITY lens)
+
+1. **`RewriteModel` attack surface.** The function decodes buyer-controlled JSON. Verify no new injection paths: the non-canonical-case rejection ("Model" vs "model") survives the extraction — it's the defence against header-smuggling where a downstream layer might match case-insensitively while routing matches case-sensitively. Verify the duplicate-model rejection survives (buyer can't sneak a second model field past the surgical rewrite).
+2. **Empty / nil rawBody.** Does RewriteModel handle nil or empty input safely? The JSON decoder produces a defined error in both cases — verify no panic or silent acceptance.
+3. **Oversized rawBody.** RewriteModel allocates a copy of the input twice (match-skip path: 1 copy; rewrite path: 1 source copy + 1 destination splice). The original buyer body size is operator-capped via `MaxChatRequestBodyBytes`. Verify the routing-package extraction doesn't accidentally bypass that cap (e.g., by being called from a code path that doesn't go through the limit reader).
+4. **Integer overflow in RetryHeaderLimit.** `math.MaxInt` on 32-bit Go is smaller than on 64-bit. Could a buyer driving a header value past 64-bit MaxInt overflow? `fmt.Sscanf("%d", &n)` parses into a native `int`; on overflow it returns an error which the function maps to 0. Verify.
+5. **ShouldRetry input untrustedness.** Fields are derived from a mix of operator config (MaxRetries) and buyer-controlled headers (RequestedRetries, HasPinnedRoute). Confirm the gate logic doesn't trust RequestedRetries to bound any allocation — it only gates a boolean.
+6. **Removed `int(^uint(0)>>1)` → `math.MaxInt` substitution.** On 32-bit platforms, `^uint(0)>>1` produces `math.MaxInt32` (2^31 - 1), but on 64-bit it produces `math.MaxInt64`. `math.MaxInt` resolves to the same per-platform value. Bit-identical? Yes — confirm.
+7. **`providerSortKey` vs `routeKey` divergence.** `routing.providerSortKey` returns `ProviderID+"/"+AssignedID`; `buyer.routeKey` does the same. Sticky-affinity correctness depends on these matching exactly — if they ever diverge, the sort uses one key and downstream lookups (e.g., sticky-affinity hit detection) use another, potentially leaking sticky attribution across accounts.
+8. **Default-OFF posture preserved.** No new code path activates new behaviour at default config; verify the routing package's exported API is only consumed via the existing buyer delegators, not via any new entry point that bypasses default-OFF.
+
+## Output format
+
+For each finding:
+- **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+- **Location**: file:line
+- **Issue**: 1-2 sentences
+- **Evidence**: quoted code or attack scenario
+- **Fix sketch**: what would resolve it
+
+Final line MUST be:
+```
+SUMMARY: CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n>
+```

--- a/specs/ISS-266-T2-audit-results.md
+++ b/specs/ISS-266-T2-audit-results.md
@@ -1,0 +1,49 @@
+# Issue #266 Tranche 2 — audit results
+
+Three-lane codex audit on PR for issue #266 Tranche 2 (refactor-only extractions: objective.go / dispatch.go / retry.go).
+
+## R1 — 2026-06-30
+
+Commit audited: `1084c71` (initial extractions) + `2943f99` (audit prompts).
+
+| Lane | C | H | M | L | Status |
+|------|---|---|---|---|--------|
+| CODE | 0 | 0 | 0 | 0 | ✅ ACCEPT |
+| SECURITY | 0 | 0 | 0 | 1 | ✅ ACCEPT |
+| ARCHITECT | 0 | 0 | 0 | 10 | ✅ ACCEPT |
+
+**All three lanes at C/H/M = 0. Merge bar met on R1.**
+
+### R1 findings — fixed
+
+**SEC-L1** (RewriteModel precondition undocumented on match-skip path): match-skip path skips dup/case/non-object validation; pre-extraction `buyer.dispatchBodyForProvider` had the same behaviour but the new exported routing-package surface deserves explicit documentation. Fixed: added a `**Precondition**` block to RewriteModel's docstring stating callers outside the buyer pipeline must run JSON-shape validation themselves.
+
+**ARCH-L10** (stale package doc on candidate.go): `routing` package comment listed objective.go / dispatch.go / retry.go as deferred — they now ship in this PR. Fixed: rewrote the package doc to mark T1 (PR #270) and T2 (this PR) as closed and describe what remains for T3.
+
+### R1 findings — accepted with rationale (no code change)
+
+**ARCH-L1** (providerSortKey vs routeKey duplication): the right fix is `pool.Provider.SortKey()` method on the pool type. Cross-package refactor; deferred to a follow-up that owns the pool API change.
+
+**ARCH-L2** (SortCandidates + ObjectiveScores recompute BalancedScores for balanced): aligns with the deferred #266 T3 "BalancedScores compute caching" item. T3 will thread a reusable score cache through sort + epsilon + log.
+
+**ARCH-L3** (ShouldRetryInput struct vs positional args): the struct names every policy input and supports clean unit testing. Accepted.
+
+**ARCH-L4** (buyer.Server.shouldRetry wrapper stays): centralises server-state bundling in one place; inlining at all four call sites would duplicate the bundling for no architecture win. Accepted.
+
+**ARCH-L5** (RewriteModel returns copied []byte in both paths): conservative copy semantics; the WS / HTTP / streaming dispatch all build readers from the returned body, never mutate in place. Adding a "do not mutate" alias contract would be fragile. Accepted.
+
+**ARCH-L6** (config→routing import-cycle constraint): new routing files don't import internal/config; routing imports pool, pool imports config. Constraint is unchanged from pre-T2 state. Accepted.
+
+**ARCH-L7** (coverage net-additive vs redundant): routing tests pin the new pure boundary; buyer tests still cover integration paths and transport behaviour. Both layers stay. Accepted.
+
+**ARCH-L8** (KeyedBalancedScores cache target, but SortCandidates has no cache-threading API yet): T3 will introduce SortAndScore or thread a score cache through sort/epsilon/log. Accepted for T2.
+
+**ARCH-L9** (RetryHeaderLimit fmt.Sscanf accepts `3abc` as `3`): pre-existing behaviour, not a T2 regression. Follow-up could switch to `strconv.Atoi(strings.TrimSpace(value))` + test for `3abc → 0`. Tracked as a future cleanup; not gating T2 since behaviour is byte-identical to `798e57b`.
+
+## Convergence
+
+R1 absorbed 0 CRITICAL / 0 HIGH / 0 MEDIUM and acknowledged 11 LOWs (2 fixed, 9 accepted with rationale). All three lanes locked at C/H/M = 0 on the first round. The "refactor-only" goal was met cleanly.
+
+Per [[feedback-skip-accepted-audit-lanes]], no R2 is needed: the fix-pass touches only documentation comments (`dispatch.go` docstring + `candidate.go` package doc), no code semantics. All three lanes would sustain ACCEPT.
+
+Ready for PR + merge.


### PR DESCRIPTION
Closes 3 more of the 10 deferred items from #266 — the refactor-only extractions identified in PR #263's deferred-work list. **No behaviour change at any flag setting**; all four T1 areas + AC-SR-1 byte-identity preserved.

Per [[feedback-bundle-multi-phase-impl-prs]]: bundled as one PR.

## What landed (3 more #266 items)

### `internal/routing/objective.go`
- `SortCandidates(candidates, objective, weights)` — extracted from `buyer.Server.sortCandidates`. Four objective branches (fast / accurate / balanced / default) byte-identical to pre-extraction comparators; `sort.SliceStable` preserved everywhere (sticky-affinity pre-sort ordering depends on stable sort).
- `ObjectiveScores(candidates, objective, weights) map[string]float64` — extracted from `buyer.Server.routingScores`. Map keyed by `ProviderID+"/"+AssignedID` matching `buyer.routeKey`.
- `KeyedBalancedScores(candidates) map[string]float64` — consolidated home for the indexed-to-keyed adapter that pre-extraction lived in three places (`buyer.balancedScores`, the balanced branch of `sortCandidates`, the balanced branch of `routingScores`).
- Buyer-side `sortCandidates` / `routingScores` become one-line delegators; `balancedScores` + `effectiveThroughput` deleted.

### `internal/routing/dispatch.go`
- `RewriteModel(rawBody, requestedModel, providerModelID) ([]byte, error)` — extracted from `buyer.dispatchBodyForProvider`. Signature changed to take only the three string/byte values the function actually uses (no more `chatRequest` type leak across the package boundary).
- `jsonValueStart` moved alongside (internal helper). Match-skip path + JSON-surgical rewrite path byte-identical to pre-extraction.
- Buyer-side `dispatchBodyForProvider` becomes a one-line wrapper.

### `internal/routing/retry.go`
- `RetryHeaderLimit(value string) int` — extracted from `buyer.retryHeaderLimit`. Pre-extraction `int(^uint(0)>>1)` MaxInt sentinel replaced with `math.MaxInt` (bit-identical).
- `ShouldRetry(in ShouldRetryInput) bool` + `ShouldRetryInput` struct — extracted from `buyer.Server.shouldRetry`. The 13-field struct names every policy input explicitly so the routing package is unit-testable without spinning up a buyer Server. Gate sequence + `min(MaxRetries, RequestedRetries)` cap math + time-budget inequality preserved verbatim.
- Buyer-side `shouldRetry` becomes a wrapper that bundles Server state into `ShouldRetryInput`. Buyer-side `retryHeaderLimit` deleted; two other call sites (handleHTTPRequest preflight check + `attemptTimeout`) redirected to `routing.RetryHeaderLimit`.

## Audit convergence

Per [[feedback-three-lane-codex-audits]] + [[feedback-build-audit-loop]]:

| Round | CODE codex | SECURITY codex | ARCHITECT codex |
|-------|------------|----------------|-----------------|
| **R1** | **0/0/0/0 ACCEPT** | **0/0/0/1 ACCEPT** | **0/0/0/10 ACCEPT** |

**First-round convergence**: all three lanes at C/H/M = 0 on R1. 11 LOWs total — 2 fixed (SEC-L1 RewriteModel precondition docstring; ARCH-L10 stale routing package doc), 9 accepted with rationale (1 deferred to a separate `pool.Provider.SortKey()` refactor, 3 deferred to T3 BalancedScores caching, 5 design choices accepted as-is).

R1 fix commit: `6d46b7c`. Audit-results artifact: `specs/ISS-266-T2-audit-results.md`.

**Per [[feedback-skip-accepted-audit-lanes]]: no R2 needed.** The fix-pass touches only documentation comments — all three lanes would sustain ACCEPT.

## Test plan

- [x] 26 new unit tests across the three extracted surfaces:
  - `objective_test.go` × 9 (per-objective sort + stable-order preservation + provisional downweight + ObjectiveScores per branch)
  - `dispatch_test.go` × 10 (match-skip, byte-identity, JSON-shape errors, copy semantics)
  - `retry_test.go` × 7 + `ShouldRetry` × 15 (every gate fail-mode + cap-min + budget arithmetic + err-trumps-status)
- [x] Full coordinator suite green (`./internal/buyer ./internal/routing ./internal/routing/sticky ./cmd/coordinator`)
- [x] Integration suite green (`test/integration` + spec015 + spec_014_v0_2_pairing)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on the 6 new + 1 modified file
- [x] AC-SR-1 default-config byte-identity preserved (no new flag activated; behaviour unchanged at defaults)
- [ ] Smoke deploy to Pearl VPS (operator follow-up; default-OFF posture preserved)

## Deferred (remaining on #266 for Tranche 3)

- `BalancedScores` compute caching threaded through `SortCandidates` + epsilon + log (1 ARCH LOW accepted)
- More AC-SR-1 byte-identity scenarios (empty pool, all-quota-blocked, tier2-mismatch combos)
- HTTP-path integration test for `sticky_account_mismatch` warn emission
- `pool.Provider.SortKey()` consolidation (1 ARCH LOW accepted; separate pool-API refactor)
- `RetryHeaderLimit` Sscanf → strconv tightening (1 ARCH LOW accepted; pre-existing behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
