### PR TITLE
fix(#274): canonical config.ValidateProviderID across all registration paths

### DIFF
--- a/phase4-coordinator/internal/auth/iss274_provider_id_validator_test.go
+++ b/phase4-coordinator/internal/auth/iss274_provider_id_validator_test.go
@@ -1,0 +1,69 @@
+package auth_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+// TestIssueTokenRejectsInvalidProviderID_Iss274 pins that admission
+// IssueToken refuses ProviderIDs that violate the canonical pattern.
+// Pre-#274 the only gate was strings.TrimSpace + non-empty.
+func TestIssueTokenRejectsInvalidProviderID_Iss274(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	cases := map[string]string{
+		"slash_delimiter_collision_seed": "a/b",
+		"space":                          "m4 anon",
+		"colon":                          "m4:anon",
+		"unicode":                        "café",
+		"len_65":                         strings.Repeat("a", 65),
+	}
+	for name, bad := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := store.IssueToken(ctx, bad, "n")
+			if err == nil {
+				t.Fatalf("IssueToken accepted provider_id=%q", bad)
+			}
+			if !strings.Contains(err.Error(), "invalid provider_id") {
+				t.Fatalf("err = %v, want substring %q", err, "invalid provider_id")
+			}
+		})
+	}
+}
+
+// TestMintAdmissionTokenAndPairOTRejectsInvalidProviderID_Iss274 pins the
+// same gate for the provisional-provider mint path.
+func TestMintAdmissionTokenAndPairOTRejectsInvalidProviderID_Iss274(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+
+	for name, bad := range map[string]string{
+		"slash_delimiter_collision_seed": "a/b",
+		"space":                          "m4 anon",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := store.MintAdmissionTokenAndPairOT(ctx, bad, "n", now)
+			if err == nil {
+				t.Fatalf("MintAdmissionTokenAndPairOT accepted provider_id=%q", bad)
+			}
+			if !strings.Contains(err.Error(), "invalid provider_id") {
+				t.Fatalf("err = %v, want substring %q", err, "invalid provider_id")
+			}
+		})
+	}
+}

--- a/phase4-coordinator/internal/auth/iss274_provider_id_validator_test.go
+++ b/phase4-coordinator/internal/auth/iss274_provider_id_validator_test.go
@@ -27,6 +27,11 @@ func TestIssueTokenRejectsInvalidProviderID_Iss274(t *testing.T) {
 		"colon":                          "m4:anon",
 		"unicode":                        "café",
 		"len_65":                         strings.Repeat("a", 65),
+		// R1 CODE LOW-1: admission paths must validate RAW input, so
+		// leading/trailing whitespace is rejected symmetrically with WS.
+		"leading_whitespace":  " m4-anon",
+		"trailing_whitespace": "m4-anon ",
+		"only_whitespace":     "   ",
 	}
 	for name, bad := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -411,16 +411,15 @@ func (s *Store) ensureProviderIDColumn(ctx context.Context) error {
 }
 
 func (s *Store) IssueToken(ctx context.Context, providerID, providerName string) (TokenRecord, string, error) {
-	providerID = strings.TrimSpace(providerID)
-	providerName = strings.TrimSpace(providerName)
-	if providerID == "" {
-		return TokenRecord{}, "", fmt.Errorf("provider id is required")
-	}
-	// Issue #274: gate every mint path on the canonical provider_id validator
-	// so the pool.Provider.SortKey "/" delimiter stays unambiguous.
+	// Issue #274 R1 CODE LOW-1: validate the RAW provider_id before any
+	// normalization so admission paths apply the same gate semantics as WS
+	// paths (which validate as-received). Leading/trailing whitespace is
+	// already disallowed by providerIDPattern, so this also rejects
+	// `" m4-anon "`-style inputs symmetrically.
 	if err := config.ValidateProviderID(providerID); err != nil {
 		return TokenRecord{}, "", err
 	}
+	providerName = strings.TrimSpace(providerName)
 	if providerName == "" {
 		return TokenRecord{}, "", fmt.Errorf("provider name is required")
 	}
@@ -838,15 +837,15 @@ func (s *Store) HasOwnership(ctx context.Context, providerID string) (bool, erro
 }
 
 func (s *Store) MintAdmissionTokenAndPairOT(ctx context.Context, providerID, providerName string, now time.Time) (AdmissionPairMint, error) {
-	providerID = strings.TrimSpace(providerID)
-	providerName = strings.TrimSpace(providerName)
-	if providerID == "" || providerName == "" {
-		return AdmissionPairMint{}, fmt.Errorf("provider id and name are required")
-	}
-	// Issue #274: gate every mint path on the canonical provider_id validator
-	// so the pool.Provider.SortKey "/" delimiter stays unambiguous.
+	// Issue #274 R1 CODE LOW-1: validate the RAW provider_id before any
+	// normalization so admission paths apply the same gate semantics as WS
+	// paths.
 	if err := config.ValidateProviderID(providerID); err != nil {
 		return AdmissionPairMint{}, err
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return AdmissionPairMint{}, fmt.Errorf("provider id and name are required")
 	}
 	providerToken, err := randomHex(32)
 	if err != nil {

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 	_ "modernc.org/sqlite"
 )
@@ -414,6 +415,11 @@ func (s *Store) IssueToken(ctx context.Context, providerID, providerName string)
 	providerName = strings.TrimSpace(providerName)
 	if providerID == "" {
 		return TokenRecord{}, "", fmt.Errorf("provider id is required")
+	}
+	// Issue #274: gate every mint path on the canonical provider_id validator
+	// so the pool.Provider.SortKey "/" delimiter stays unambiguous.
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return TokenRecord{}, "", err
 	}
 	if providerName == "" {
 		return TokenRecord{}, "", fmt.Errorf("provider name is required")
@@ -836,6 +842,11 @@ func (s *Store) MintAdmissionTokenAndPairOT(ctx context.Context, providerID, pro
 	providerName = strings.TrimSpace(providerName)
 	if providerID == "" || providerName == "" {
 		return AdmissionPairMint{}, fmt.Errorf("provider id and name are required")
+	}
+	// Issue #274: gate every mint path on the canonical provider_id validator
+	// so the pool.Provider.SortKey "/" delimiter stays unambiguous.
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return AdmissionPairMint{}, err
 	}
 	providerToken, err := randomHex(32)
 	if err != nil {

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -14,6 +14,22 @@ import (
 
 var providerIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,64}$`)
 
+// ValidateProviderID is the canonical validator for ProviderID across every
+// registration path. Issue #274: WS self-serve registration previously
+// accepted any non-empty / non-control-char string, while configured pinned
+// providers were already gated on providerIDPattern. The "/" delimiter used
+// by pool.Provider.SortKey (ProviderID + "/" + AssignedID) is only
+// unambiguous when no ProviderID contains "/" — so every code path that
+// onboards a provider (configured pinned, WS Hello, WS auth_request
+// initial/proof, admission IssueToken, MintAdmissionTokenAndPairOT) MUST
+// funnel through this helper to keep that invariant.
+func ValidateProviderID(s string) error {
+	if !providerIDPattern.MatchString(s) {
+		return fmt.Errorf("invalid provider_id %q", s)
+	}
+	return nil
+}
+
 // minAuditLogRetentionDays is the compliance floor for audit_log retention.
 // Operators may not set audit_log_retention_days below this value.
 const minAuditLogRetentionDays = 90
@@ -1021,8 +1037,8 @@ func (c Config) Validate() error {
 	}
 	seen := map[string]struct{}{}
 	for _, p := range c.Providers {
-		if !providerIDPattern.MatchString(p.ProviderID) {
-			return fmt.Errorf("invalid provider_id %q", p.ProviderID)
+		if err := ValidateProviderID(p.ProviderID); err != nil {
+			return err
 		}
 		if _, ok := seen[p.ProviderID]; ok {
 			return fmt.Errorf("duplicate provider_id %q", p.ProviderID)

--- a/phase4-coordinator/internal/config/iss274_provider_id_validator_test.go
+++ b/phase4-coordinator/internal/config/iss274_provider_id_validator_test.go
@@ -1,0 +1,48 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+)
+
+// TestValidateProviderID_Iss274 pins the canonical validator's accept/reject
+// table. The "/" delimiter inside pool.Provider.SortKey
+// (ProviderID + "/" + AssignedID) is only unambiguous when no ProviderID
+// contains "/", so every WS / admission registration path funnels through
+// this helper.
+func TestValidateProviderID_Iss274(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+		want bool // true = accept
+	}{
+		{name: "letters_digits_dash", id: "m4-anon", want: true},
+		{name: "underscore_dot", id: "host_01.prod", want: true},
+		{name: "max_len_64", id: strings.Repeat("a", 64), want: true},
+		{name: "single_char", id: "a", want: true},
+
+		{name: "rejects_slash_delimiter_collision_seed", id: "a/b", want: false},
+		{name: "rejects_double_slash", id: "x//y", want: false},
+		{name: "rejects_empty", id: "", want: false},
+		{name: "rejects_len_65", id: strings.Repeat("a", 65), want: false},
+		{name: "rejects_space", id: "m4 anon", want: false},
+		{name: "rejects_colon", id: "m4:anon", want: false},
+		{name: "rejects_at", id: "m4@anon", want: false},
+		{name: "rejects_unicode", id: "café", want: false},
+		{name: "rejects_newline", id: "m4\nanon", want: false},
+		{name: "rejects_null", id: "m4\x00anon", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := config.ValidateProviderID(tc.id)
+			if tc.want && err != nil {
+				t.Fatalf("ValidateProviderID(%q) err = %v, want nil", tc.id, err)
+			}
+			if !tc.want && err == nil {
+				t.Fatalf("ValidateProviderID(%q) err = nil, want non-nil", tc.id)
+			}
+		})
+	}
+}

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -240,6 +240,14 @@ func (p Provider) IsWSTunneled() bool {
 // and `startRecoveryProbe` had its own inline concat. A single
 // pool method eliminates the divergence trap (R1 ARCH-L1 audit
 // finding on PR #273).
+//
+// PRECONDITION: ProviderID MUST NOT contain "/", otherwise the
+// delimiter is ambiguous and two different (ProviderID, AssignedID)
+// pairs could collide on the same key. The invariant is enforced at
+// every registration site by `config.ValidateProviderID` (issue
+// #274). AssignedID is a coordinator-issued UUID and similarly may
+// not contain "/"; if the AssignedID format ever changes, this
+// docstring AND the key encoding must be revisited.
 func (p Provider) SortKey() string {
 	return p.ProviderID + "/" + p.AssignedID
 }

--- a/phase4-coordinator/internal/ws/iss274_provider_id_validator_test.go
+++ b/phase4-coordinator/internal/ws/iss274_provider_id_validator_test.go
@@ -1,0 +1,94 @@
+package ws
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestParseHelloRejectsInvalidProviderID_Iss274 pins that WS Hello
+// registration rejects ProviderIDs that don't match config.providerIDPattern.
+// Pre-#274 the parser only checked non-empty + non-control-char, so
+// `"a/b"` passed and would have produced an ambiguous pool.Provider.SortKey.
+func TestParseHelloRejectsInvalidProviderID_Iss274(t *testing.T) {
+	base := map[string]any{
+		"type":                    "hello",
+		"version":                 1,
+		"tier":                    1,
+		"hostname":                "h-ok",
+		"model_id":                "m-ok",
+		"model_params_b":          7.0,
+		"ram_gb":                  16,
+		"max_context_tokens":      50000,
+		"max_concurrency":         1,
+		"throughput_tps_estimate": 19.8,
+		"binary_version":          "0.1.0",
+		"attestation":             nil,
+	}
+	for name, bad := range map[string]string{
+		"slash_delimiter_collision_seed": "a/b",
+		"space":                          "m4 anon",
+		"colon":                          "m4:anon",
+		"unicode":                        "café",
+	} {
+		t.Run(name, func(t *testing.T) {
+			payload := make(map[string]any, len(base)+1)
+			for k, v := range base {
+				payload[k] = v
+			}
+			payload["provider_id"] = bad
+			raw, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			_, badField, err := ParseHello(raw)
+			if err == nil {
+				t.Fatalf("ParseHello accepted provider_id=%q", bad)
+			}
+			if badField != "provider_id" {
+				t.Fatalf("badField = %q, want provider_id", badField)
+			}
+		})
+	}
+}
+
+// TestParseAuthRequestInitialRejectsInvalidProviderID_Iss274 pins the same
+// gate for the WS auth_request initial-stage frame.
+func TestParseAuthRequestInitialRejectsInvalidProviderID_Iss274(t *testing.T) {
+	for name, bad := range map[string]string{
+		"slash_delimiter_collision_seed": "a/b",
+		"space":                          "m4 anon",
+	} {
+		t.Run(name, func(t *testing.T) {
+			payload := validAuthRequestInitial()
+			payload["provider_id"] = bad
+			_, _, badField, err := ParseAuthRequest(mustAuthJSON(t, payload))
+			if err == nil {
+				t.Fatalf("ParseAuthRequest(initial) accepted provider_id=%q", bad)
+			}
+			if badField != "provider_id" {
+				t.Fatalf("badField = %q, want provider_id", badField)
+			}
+		})
+	}
+}
+
+// TestParseAuthRequestProofRejectsInvalidProviderID_Iss274 pins the same
+// gate for the WS auth_request proof-stage frame.
+func TestParseAuthRequestProofRejectsInvalidProviderID_Iss274(t *testing.T) {
+	for name, bad := range map[string]string{
+		"slash_delimiter_collision_seed": "a/b",
+		"colon":                          "m4:anon",
+	} {
+		t.Run(name, func(t *testing.T) {
+			payload := validAuthRequestProof()
+			payload["provider_id"] = bad
+			_, _, badField, err := ParseAuthRequest(mustAuthJSON(t, payload))
+			if err == nil {
+				t.Fatalf("ParseAuthRequest(proof) accepted provider_id=%q", bad)
+			}
+			if badField != "provider_id" {
+				t.Fatalf("badField = %q, want provider_id", badField)
+			}
+		})
+	}
+}

--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
 )
 
 type Hello struct {
@@ -285,6 +287,12 @@ func ParseHello(payload []byte) (Hello, string, error) {
 	if err := requireString(raw, "provider_id", &h.ProviderID); err != nil {
 		return Hello{}, err.Field, err
 	}
+	// Issue #274: gate WS self-serve registration on the same
+	// providerIDPattern that pinned-provider config validation enforces, so
+	// the "/" delimiter inside pool.Provider.SortKey stays unambiguous.
+	if err := config.ValidateProviderID(h.ProviderID); err != nil {
+		return Hello{}, "provider_id", err
+	}
 	if err := requireString(raw, "hostname", &h.Hostname); err != nil {
 		return Hello{}, err.Field, err
 	}
@@ -389,6 +397,10 @@ func ParseAuthRequest(payload []byte) (AuthRequest, Spec010Presence, string, err
 func parseAuthInitial(raw map[string]json.RawMessage, req AuthRequest) (AuthRequest, Spec010Presence, string, error) {
 	if err := requireString(raw, "provider_id", &req.ProviderID); err != nil {
 		return AuthRequest{}, Spec010Presence{}, err.Field, err
+	}
+	// Issue #274: see ParseHello comment — same canonical validator.
+	if err := config.ValidateProviderID(req.ProviderID); err != nil {
+		return AuthRequest{}, Spec010Presence{}, "provider_id", err
 	}
 	if err := requireString(raw, "hostname", &req.Hostname); err != nil {
 		return AuthRequest{}, Spec010Presence{}, err.Field, err
@@ -523,6 +535,10 @@ func parseAuthProof(raw map[string]json.RawMessage, req AuthRequest) (AuthReques
 	}
 	if err := requireString(raw, "provider_id", &req.ProviderID); err != nil {
 		return AuthRequest{}, Spec010Presence{}, err.Field, err
+	}
+	// Issue #274: see ParseHello comment — same canonical validator.
+	if err := config.ValidateProviderID(req.ProviderID); err != nil {
+		return AuthRequest{}, Spec010Presence{}, "provider_id", err
 	}
 	if token, ok := raw["attestation_token"]; ok {
 		req.AttestationToken = token

--- a/specs/AUDIT_ISS274_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS274_ARCHITECT_PROMPT.md
@@ -1,0 +1,61 @@
+# AUDIT — Issue #274 — ARCHITECT lane
+
+## Goal
+Architecture / SPEC-alignment audit on PR-pending commit `0e4dce2` (branch `fix/iss274-provider-id-validator`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+
+## Scope
+
+- `phase4-coordinator/internal/config/config.go` — placement of `ValidateProviderID`
+- `phase4-coordinator/internal/ws/messages.go` — gate-application order
+- `phase4-coordinator/internal/auth/tokens.go` — gate-application order in mint paths
+
+## Background
+
+- Issue #266 Tranche 3 (PR #275) consolidated `ProviderID + "/" + AssignedID` derivation onto `pool.Provider.SortKey()`. The "/" delimiter invariant created an implicit contract on every code path that produces a `ProviderID`.
+- Configured pinned providers already enforced this via `config.providerIDPattern`.
+- WS self-serve registration + admission mint paths only validated non-empty / non-control-char.
+- The fix exports `config.ValidateProviderID` and applies it to all five paths.
+- The issue body suggested an alternative: move the pattern to `internal/pool` as the canonical home of the consumer (SortKey).
+
+## Lens — ARCHITECT
+
+Audit for:
+
+- **Layering / placement** — is `internal/config` the right home for `ValidateProviderID`, given that:
+  - The consumer of the invariant (`pool.Provider.SortKey`) lives in `internal/pool`
+  - The producer (config-validated providers, WS-received providers, admission-minted providers) is spread across `config`, `ws`, and `auth`
+  - `internal/pool` already imports `internal/config`
+  - The alternative — `pool.ValidateProviderID` — would force `auth` and `ws` to take a new pool dependency
+  
+  Is `internal/config` the right least-coupled home, or should this live elsewhere?
+
+- **Invariant ownership** — the docstring on `ValidateProviderID` names `pool.Provider.SortKey` as the invariant-owner. Does this docstring drift naturally over time, or is there a more durable way (e.g. a SortKey-side comment that points TO the validator, a test that pins the contract)?
+
+- **SPEC alignment** — is there a SPEC document (SPEC-003 provisional self-serve, SPEC-010 catalog, etc.) that should be amended to name the validator contract? If so, would amending be in-scope for this PR or a follow-up?
+
+- **Future-proofing** — if/when `AssignedID` changes from a UUID (e.g. spec adds a structured assigned-id format), is the SortKey delimiter still safe? Should we record this as a SortKey constraint on `pool.Provider` to prevent future ambiguity?
+
+- **API surface** — is `ValidateProviderID` the right name? Are there existing validator patterns in the repo (`ValidateEndpointURL` is right next to it in config.go) — does the new helper match the established style?
+
+- **Test architecture** — is one regression-test file per package the right shape, or would one shared validator-contract test (in `config_test`) be more discoverable?
+
+- **Deprecation / migration** — pre-#274 providers in the wild may have registered with provider_ids that contain "/". After this fix lands, do they get rejected on next connect (causing a self-DoS)? Is there a transition plan needed?
+
+## Out of scope
+
+- Style nits (CODE lane)
+- Specific vulnerability classes (SECURITY lane)
+
+## Output format
+
+```
+SEVERITY-N (CRITICAL|HIGH|MEDIUM|LOW|INFO) — <one-line title>
+File: <path>:<line>
+Finding: <what>
+Risk / Concern: <why it matters at the architectural layer>
+Recommendation: <concrete change, including whether deferring to a follow-up is appropriate>
+```
+
+Summarize: `C/H/M/L/INFO = a/b/c/d/e`.
+
+If nothing above LOW: `ACCEPT — 0 C/H/M`.

--- a/specs/AUDIT_ISS274_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS274_CODE_PROMPT.md
@@ -1,0 +1,55 @@
+# AUDIT — Issue #274 — CODE lane
+
+## Goal
+Lock-step code-quality audit on PR-pending commit `0e4dce2` (branch `fix/iss274-provider-id-validator`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+
+## Scope (read these files only — do NOT propose changes outside)
+
+- `phase4-coordinator/internal/config/config.go` (lines 15-35 new export; line ~1040 refactored call site)
+- `phase4-coordinator/internal/ws/messages.go` (lines 1-10 imports; ParseHello around line 287; parseAuthInitial around line 395; parseAuthProof around line 530)
+- `phase4-coordinator/internal/auth/tokens.go` (lines 1-22 imports; IssueToken around line 412; MintAdmissionTokenAndPairOT around line 834)
+- `phase4-coordinator/internal/config/iss274_provider_id_validator_test.go` (new)
+- `phase4-coordinator/internal/ws/iss274_provider_id_validator_test.go` (new)
+- `phase4-coordinator/internal/auth/iss274_provider_id_validator_test.go` (new)
+
+## Context
+
+Issue #274 was filed today (2026-06-30) as a SECURITY codex audit follow-up from #266 Tranche 3. The pool.Provider.SortKey method (introduced by #266 T3a) concatenates `ProviderID + "/" + AssignedID` and is used as a map key across the routing pipeline (excluded sets, balanced-score cache, faulted-route tracking). The "/" delimiter is only unambiguous when no ProviderID contains a literal "/".
+
+Pre-#274:
+- Configured pinned providers: gated on `providerIDPattern = ^[a-zA-Z0-9_.-]{1,64}$` via `config.validateProviders`
+- WS self-serve (Hello, auth_request initial/proof): only `requireString` (non-empty + non-control-char)
+- Admission `IssueToken`, `MintAdmissionTokenAndPairOT`: only `strings.TrimSpace` + non-empty
+
+The fix exports `config.ValidateProviderID(s string) error` and wires it through all five paths. Existing config validation refactored to use the new helper.
+
+## Lens — CODE
+
+Audit for:
+
+- Style consistency with house conventions (naming, error-wrapping, log-emission patterns)
+- Test coverage adequacy (positive + negative cases for each new path; do tests exercise what the fix claims)
+- Refactor cleanliness — was the existing `providerIDPattern.MatchString` call site genuinely replaced (no dead branches; no duplicated logic)?
+- Error semantics — does the badField surface to the WS close-frame still produce a usable error envelope?
+- Idiomaticity — is exporting `ValidateProviderID` from `internal/config` the right home, or does it belong on `internal/pool` (where the consumer lives)?
+- Import-cycle risk — does the new edge (`internal/auth` → `internal/config`, `internal/ws` → `internal/config`) introduce new cycles or worsen package coupling?
+- Are the validator call sites placed BEFORE other transformations that would mask the bad ID (e.g. before lookups, before TrimSpace logic)?
+
+## Out of scope
+
+- Security analysis (handled by SECURITY lane)
+- Architectural placement vs SPEC alignment (handled by ARCHITECT lane)
+
+## Output format
+
+```
+SEVERITY-N (CRITICAL|HIGH|MEDIUM|LOW|INFO) — <one-line title>
+File: <path>:<line>
+Finding: <what>
+Risk: <why it matters>
+Recommendation: <concrete fix>
+```
+
+At the end, summarize the count by severity: `C/H/M/L/INFO = a/b/c/d/e`.
+
+If you find nothing above LOW, say `ACCEPT — 0 C/H/M`.

--- a/specs/AUDIT_ISS274_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS274_SECURITY_PROMPT.md
@@ -1,0 +1,61 @@
+# AUDIT — Issue #274 — SECURITY lane
+
+## Goal
+Adversarial security audit on PR-pending commit `0e4dce2` (branch `fix/iss274-provider-id-validator`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+
+## Scope
+
+- `phase4-coordinator/internal/config/config.go` — `ValidateProviderID`
+- `phase4-coordinator/internal/ws/messages.go` — ParseHello, parseAuthInitial, parseAuthProof
+- `phase4-coordinator/internal/auth/tokens.go` — IssueToken, MintAdmissionTokenAndPairOT
+- Test files for the three packages
+
+## Threat model
+
+This fix closes a validator-drift gap surfaced by #266 Tranche 3 codex security review. The trust boundary:
+
+- `pool.Provider.SortKey()` returns `ProviderID + "/" + AssignedID` and is used as a map key for routing decisions (excluded set, balanced-score cache, faulted-route tracking)
+- A hostile or buggy provider that connects via WS self-serve could pre-#274 submit `provider_id: "a/b"` which registered without validation
+- With `AssignedID = c` the SortKey becomes `"a/b/c"` — ambiguous with a legitimate `(provider_id=a, assigned_id=b/c)` if such a value could exist
+
+Current AssignedID values are coordinator-issued UUIDs, so a practical collision is not exploitable today — but the validator drift was real and the fix consolidates the gate at all entry points.
+
+## Lens — SECURITY
+
+Audit for:
+
+- **Bypass paths** — is there any code path that mints a provider_id without going through `ValidateProviderID`? Specifically check:
+  - WS message types beyond Hello + auth_request that carry a `provider_id` field (heartbeat, state_update, etc.) — do they trust an earlier-validated value or re-accept new strings?
+  - Database / storage paths that read a `provider_id` from disk and trust it without re-validating
+  - Any test-only or admin-only paths (coordinator-cli, admin endpoints) that mint tokens
+- **TOCTOU / race conditions** — pre-validation race between Hello and auth_request where one frame passes but the other holds a different value
+- **Injection** — even with the regex `^[a-zA-Z0-9_.-]{1,64}$` are there any downstream contexts (SQL, log emission, file paths, URL paths) where a `.` or `-` could be misinterpreted?
+- **Length / DoS** — the 64-char cap is enforced everywhere?
+- **Error leakage** — does the `fmt.Errorf("invalid provider_id %q", s)` error message leak the attacker-controlled string into logs in a way that could enable log-injection or terminal-CSI sequences? (Note: the regex itself rejects control chars and `\n`, so the `%q` quote is belt-and-braces — but verify.)
+- **Test gaps** — does the test suite cover boundary cases the regex might mishandle (Unicode, RTL, zero-width, byte-vs-rune-length)?
+- **Audit trail** — when a provider_id is rejected, is the rejection visible to operators (audit log / metric / counter) so a hostile provider hammering the gate is observable?
+
+## Specific must-check items
+
+1. Does `parseAuthRequest` validate provider_id in BOTH `initial` and `proof` stages? (the fix claims yes — verify)
+2. Does the `coordinator-cli/main.go` IssueToken call site flow through the new gate? (it should — it calls `store.IssueToken`)
+3. Is there any provisional/legacy registration path that the issue body didn't enumerate?
+
+## Out of scope
+
+- Code style and refactor cleanliness (CODE lane)
+- SPEC alignment (ARCHITECT lane)
+
+## Output format
+
+```
+SEVERITY-N (CRITICAL|HIGH|MEDIUM|LOW|INFO) — <one-line title>
+File: <path>:<line>
+Finding: <what>
+Risk: <why it matters; cite threat model>
+Recommendation: <concrete fix>
+```
+
+Summarize at the end: `C/H/M/L/INFO = a/b/c/d/e`.
+
+If nothing above LOW: `ACCEPT — 0 C/H/M`.

--- a/specs/ISS-274-audit-results.md
+++ b/specs/ISS-274-audit-results.md
@@ -1,0 +1,39 @@
+# ISS-274 — Codex audit results
+
+Single-round convergence. Three-lane codex audit (CODE, SECURITY, ARCHITECT) on commit `0e4dce2`, fix-pass committed afterwards.
+
+## Round 1 — 2026-06-30
+
+| Lane      | C/H/M/L/INFO | Verdict           |
+|-----------|--------------|-------------------|
+| CODE      | 0/0/0/1/0    | ACCEPT — 0 C/H/M  |
+| SECURITY  | 0/0/0/1/1    | ACCEPT — 0 C/H/M  |
+| ARCHITECT | 0/0/0/2/2    | ACCEPT — 0 C/H/M  |
+
+All three lanes converged on R1. Per [[feedback-skip-accepted-audit-lanes]], no R2 needed.
+
+### LOWs absorbed (2)
+
+- **CODE LOW-1** — `IssueToken` and `MintAdmissionTokenAndPairOT` trimmed `provider_id` BEFORE validation, while WS paths validate as-received. Fix: validate raw input first. Added whitespace-rejection regression tests to `internal/auth/iss274_provider_id_validator_test.go`.
+- **ARCH LOW-1** — `pool.Provider.SortKey` documented the format but not the no-slash precondition. Fix: SortKey docstring now points to `config.ValidateProviderID` and names both ProviderID and AssignedID delimiter constraints.
+
+### LOWs deferred (3)
+
+- **SEC LOW-1** — `MintPairOTRefresh` trusts a DB-loaded `provider_id` without re-validating; could pollute `pair_ots` / `pair_ot_mint_log` / `provider_ownership`. Auditor confirms NOT reachable via SortKey collision today (WS parsers reject the bad ID upstream and token/hello mismatch closes the connection). Out of scope for #274 — files a separate validator-drift gap.
+- **ARCH LOW-2** — SPEC documents (SPEC-001 / SPEC-002 / SPEC-003 / SPEC-010) do not yet name the expanded validator contract. Auditor recommends spec follow-up; defer to follow-up.
+- **ARCH INFO-4** — Legacy slash-containing self-serve IDs would self-DoS on next connect. Auditor notes "likely low blast radius because installer-generated UUIDs and pinned config IDs already satisfy the regex." Operator pre-deploy SQL audit covered by separate ops runbook process.
+
+### INFOs
+
+- **SEC INFO-1** — Test gaps for zero-width / RTL characters. Implementation is safe (regex restricts to ASCII), no change needed.
+- **ARCH INFO-3** — Confirms `internal/config` is the least-coupled home for the shared validator.
+
+## Validation
+
+```
+go test ./... -count=1 -- all 20 coordinator packages green
+go vet ./... -- clean
+gofmt -l on touched files -- clean
+```
+
+R1 fix-pass commit: TBD (will be added to PR).


### PR DESCRIPTION
Closes #274.

Surfaced by codex SECURITY audit on PR #275 (#266 Tranche 3 R1 SEC-L1). The `pool.Provider.SortKey()` method introduced by #266 T3a returns `ProviderID + "/" + AssignedID` and is used as a map key across the routing pipeline (excluded set, balanced-score cache, faulted-route tracking). The "/" delimiter is only unambiguous when no ProviderID contains "/".

Pre-#274:
- Configured pinned providers: gated on `providerIDPattern = ^[a-zA-Z0-9_.-]{1,64}$` via `config.validateProviders`
- WS self-serve (Hello, auth_request initial/proof): only `requireString` (non-empty + non-control-char)
- Admission `IssueToken`, `MintAdmissionTokenAndPairOT`: only `strings.TrimSpace` + non-empty

Current AssignedID values are coordinator-issued UUIDs, so a practical collision was not exploitable today — but the validator drift was real and this PR consolidates the gate at every entry point.

## What landed

### Canonical validator
Exports `config.ValidateProviderID(s string) error` backed by `providerIDPattern`. Existing `config.validateProviders` refactored to use it.

### Applied across all 5 registration paths
- `internal/ws/messages.go::ParseHello`
- `internal/ws/messages.go::parseAuthInitial` (auth_request stage=initial)
- `internal/ws/messages.go::parseAuthProof` (auth_request stage=proof)
- `internal/auth/tokens.go::IssueToken`
- `internal/auth/tokens.go::MintAdmissionTokenAndPairOT`

### SortKey-side invariant doc
`pool.Provider.SortKey` docstring now names the no-slash precondition explicitly and points to `config.ValidateProviderID` so future changes to SortKey or AssignedID format will find the invariant.

### Regression tests
- `internal/config/iss274_provider_id_validator_test.go` — accept/reject table including the `"a/b"` delimiter-collision seed
- `internal/ws/iss274_provider_id_validator_test.go` — ParseHello + ParseAuthRequest initial/proof
- `internal/auth/iss274_provider_id_validator_test.go` — IssueToken + MintAdmissionTokenAndPairOT, including leading/trailing whitespace rejection (R1 CODE LOW-1)

## Audit convergence

Per [[feedback-three-lane-codex-audits]]: separate per-lane prompts at `specs/AUDIT_ISS274_{CODE,SECURITY,ARCHITECT}_PROMPT.md`.

| Round | CODE codex | SECURITY codex | ARCHITECT codex |
|-------|------------|----------------|-----------------|
| **R1** | **0/0/0/1/0 ACCEPT** | **0/0/0/1/1 ACCEPT** | **0/0/0/2/2 ACCEPT** |

**First-round convergence** — all three lanes returned 0 C/H/M. 5 LOWs total — 2 absorbed (CODE LOW-1 validate-before-trim symmetry + whitespace tests; ARCH LOW-1 SortKey precondition doc), 3 deferred with rationale recorded in `specs/ISS-274-audit-results.md`.

Per [[feedback-skip-accepted-audit-lanes]]: no R2 needed.

R1 fix commit: `695c122`.

## Test plan

- [x] 3 new test files; 15+ regression cases including `"a/b"`, whitespace, unicode, length cap
- [x] Full coordinator suite (20 packages) green at `count=1`
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on touched files
- [x] No new import cycles (`go list -deps ./internal/auth ./internal/ws ./internal/config`)
- [ ] Deploy follow-up: SQL audit for any pre-#274 self-serve rows with ProviderID containing "/" (operator action; ARCH INFO-4 — auditor: "likely low blast radius because installer-generated UUIDs and pinned config IDs already satisfy the regex")

## Follow-up filed elsewhere
- SEC LOW-1 (`MintPairOTRefresh` DB-loaded ID not re-validated) is a separate validator-drift path; not in scope for #274 closure
- ARCH LOW-2 (SPEC-001/002/003/010 prose amendments) — deferred to spec-only follow-up
