### PR TITLE
fix(gateway): symmetric upward clamp for streaming estimator inflation (closes #278)

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -1066,34 +1066,58 @@ func estimateStreamingCompletionTokens(emitted, maxTokens int64) int64 {
 	return completion
 }
 
-// Clamp window for the streaming over-report fix (#255). Pure
-// absolute bounds — no percentage scaling.
+// Shared clamp window for the streaming completion-token symmetric
+// clamp: downward over-report (#255) AND upward estimator inflation
+// (#278). Pure absolute bounds — no percentage scaling, no
+// direction-specific tuning. The two directions are intentionally
+// symmetric and MUST stay so; do not tune one side independently
+// without a fresh 3-lane audit on both.
 //
-// An over-report `o` (reported - observed) triggers the downward
-// clamp iff `clampFloorTokens < o <= clampCeilingTokens`.
+// Let `o` be the absolute disagreement between provider's reported
+// `usage.completion_tokens` and the gateway's byte-derived estimate.
+// The clamp fires iff `clampFloorTokens < o <= clampCeilingTokens` in
+// either direction:
 //
-// Pure-absolute shape (R2 security + architect HIGH convergence):
+//   - Downward (reported > observed; #255): clamp DOWN to observed,
+//     token_source = "gateway_estimated". The provider over-reported
+//     by a small amount; gateway's byte count wins.
 //
-//   - Below `clampFloorTokens` (≤ 2 tokens): benign tokenizer noise
-//     (EOS / chat-template stop tokens that count as completion but
-//     never stream as delta content). Trust the provider.
+//   - Upward   (observed > reported; #278): clamp UP to reported,
+//     token_source = "provider_reported". The gateway's byte
+//     estimator inflated above the provider's tokenizer (e.g.
+//     ceil(N/4) overshoots on English where ~4.3-4.7 bytes/token);
+//     provider's tokenizer is authoritative on its own output for
+//     small disagreements. Surfaced by v0.4 scenario 07 (4 of 40
+//     successful streaming pairs over-billed by +6 to +9 tokens).
+//
+// Outside the window neither direction clamps (the existing
+// authority wins):
+//
+//   - Below `clampFloorTokens` (≤ 2 tokens, either direction): benign
+//     tokenizer noise (EOS / chat-template stop tokens not in delta
+//     content; or sub-byte rounding in ceil(N/4)). Downward keeps
+//     `provider_reported`; upward keeps `gateway_estimated`.
 //
 //   - Above `clampCeilingTokens` (> 20 tokens): too large to be
-//     tokenizer noise. The gateway's byte-based estimate is
-//     unreliable on dense content (CJK, code, short tokens where
-//     1 token < 4 bytes); clamping here would under-bill a provider
-//     for legitimately-generated content. Trust the provider.
+//     tokenizer noise. Downward: byte estimate unreliable on dense
+//     content (CJK / code / short tokens where 1 token < 4 bytes);
+//     trust the provider. Upward: stream truncation or zero-report
+//     fraud — provider's usage chunk plausibly under-reports content
+//     actually generated; trust the byte estimator.
 //
 // Earlier rounds tried a percentage formula but R2 audits caught a
 // false-positive class: a legitimate moderate-density report
 // (e.g. observed=225 byte-tokens, reported=300 actual tokens) sat
 // inside the percentage window and got clamped, under-billing the
-// provider. Pure absolute bounds eliminate that class — any
-// overshoot > 20 tokens is trusted as density mismatch.
+// provider. Pure absolute bounds eliminate that class — any overshoot
+// > 20 tokens is trusted as density mismatch / truncation.
 //
-// Cost: an adversarial provider can systematically over-report by
-// up to 20 tokens per request. Bounded and small per-request; logged
-// each time the clamp fires for audit visibility.
+// Cost (symmetric in both directions): an adversarial provider can
+// systematically over- or under-report by up to 20 tokens per
+// request. Bounded and small per-request; logged each time the clamp
+// fires for audit visibility. Closing the residual skim surfaces
+// requires a tokenizer-grounded observation (replacing the byte
+// heuristic) — out of scope for #255 and #278.
 const (
 	clampFloorTokens   int64 = 2
 	clampCeilingTokens int64 = 20

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -521,9 +521,31 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		usage := *reported
 		observedCompletion := estimateStreamingCompletionTokens(emitted, maxTokens)
 		if observedCompletion > usage.CompletionTokens {
-			// Provider under-reported relative to streamed bytes. Use the
-			// gateway estimate so the provider isn't under-billed for content
-			// that was actually streamed.
+			// Issue #278: the gateway byte estimator can run slightly higher
+			// than the provider's tokenizer on normal English output. Clamp
+			// upward-estimator inflation when the gap sits inside the same
+			// safe window as the downward #255 clamp.
+			//
+			// Outside the window — below floor (benign tokenizer noise) OR
+			// above ceiling (too large to be tokenizer noise; likely stream
+			// truncation or zero-report fraud where the provider's usage chunk
+			// under-reports content actually generated) — trust the gateway's
+			// byte-derived estimate.
+			overshoot := observedCompletion - usage.CompletionTokens
+			if overshoot > clampFloorTokens && overshoot <= clampCeilingTokens {
+				slog.Info("streaming gateway clamped under-reported completion tokens; gateway estimate higher",
+					"request_id", requestID(r),
+					"account_id", subject.AccountID,
+					"reported", usage.CompletionTokens,
+					"observed", observedCompletion,
+					"overshoot", overshoot,
+					"window_floor", clampFloorTokens,
+					"window_ceiling", clampCeilingTokens,
+					"outcome", outcome,
+				)
+				s.settleAfterCommit(r, subject, usage.PromptTokens, usage.CompletionTokens, maxUsageTokens, "provider_reported", outcome, reservationWindow)
+				return
+			}
 			s.settleAfterCommit(r, subject, promptEstimate, observedCompletion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow)
 			return
 		}

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -3698,6 +3698,14 @@ func TestStreamingProviderReportedUnderbillClampedToReported(t *testing.T) {
 		{name: "9_token_overshoot_in_window_clamps", contentBytes: 76, reportedPromptTok: 13, reportedCompTok: 10, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 10},
 		{name: "15_token_overshoot_in_window_clamps", contentBytes: 100, reportedPromptTok: 17, reportedCompTok: 10, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 10},
 		{name: "20_token_overshoot_at_ceiling_clamps", contentBytes: 400, reportedPromptTok: 19, reportedCompTok: 80, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 80},
+		// Zero-report boundary (R2 SECURITY LOW): a hostile provider may
+		// report 0 completion tokens. At the ceiling boundary the clamp
+		// fires and bills 0 (bounded ≤ 20-token underbill, same as the
+		// symmetric over-report risk accepted in #262). Just above the
+		// ceiling the gateway estimator wins, protecting against
+		// stream-truncation / zero-report fraud with no per-request bound.
+		{name: "zero_report_at_ceiling_clamps_to_zero", contentBytes: 80, reportedPromptTok: 19, reportedCompTok: 0, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 0},
+		{name: "zero_report_just_above_ceiling_trusts_gateway_estimate", contentBytes: 84, reportedPromptTok: 19, reportedCompTok: 0, wantClamp: false, wantSource: "gateway_estimated", wantBilledCompTk: 21},
 		// v0.4 scenario-07 patterns: English Qwen3-32B output where ceil(bytes/4) ran high.
 		{name: "v04_scenario07_reported_55_observed_64_clamps", contentBytes: 256, reportedPromptTok: 23, reportedCompTok: 55, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 55},
 		{name: "v04_scenario07_reported_33_observed_42_clamps", contentBytes: 168, reportedPromptTok: 29, reportedCompTok: 33, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 33},

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2857,7 +2857,7 @@ func TestStreamingScannerErrorSettlesStreamTruncated(t *testing.T) {
 func TestStreamingProviderReportedUsageCannotUnderstateTruncatedOutput(t *testing.T) {
 	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"large line"}]}`
 	accountID := "acct_stream_underreported_truncated"
-	output := strings.Repeat("x", 40)
+	output := strings.Repeat("x", 100)
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		pr, pw := io.Pipe()
 		go func() {
@@ -3482,7 +3482,7 @@ func TestStreamingInvalidUsageAfterValidFallsBackToGatewayEstimate(t *testing.T)
 func TestStreamingProviderReportedUsageCannotUnderstateObservedOutput(t *testing.T) {
 	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"ok"}]}`
 	accountID := "acct_stream_underreported_usage"
-	output := strings.Repeat("x", 40)
+	output := strings.Repeat("x", 100)
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		payload := strings.Join([]string{
 			`data: {"id":"chatcmpl","choices":[{"delta":{"content":"` + output + `"}}]}`,
@@ -3520,9 +3520,9 @@ func TestStreamingProviderReportedUsageCannotUnderstateObservedOutput(t *testing
 }
 
 func TestStreamingUnderreportedUsageWithHighProviderPromptFallsBackToGatewayEstimate(t *testing.T) {
-	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"ok"}]}`
+	body := `{"model":"llama","stream":true,"max_tokens":50,"messages":[{"role":"user","content":"ok"}]}`
 	accountID := "acct_stream_underreported_high_prompt"
-	output := strings.Repeat("x", 40)
+	output := strings.Repeat("x", 100)
 	promptEstimate := estimatePromptTokens([]byte(body))
 	providerPrompt := promptEstimate + 19
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -3550,7 +3550,7 @@ func TestStreamingUnderreportedUsageWithHighProviderPromptFallsBackToGatewayEsti
 	}
 	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
 	quota := readQuota(t, usageResp)
-	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), 20)
+	wantCompletion := estimateStreamingCompletionTokens(int64(len(output)), 50)
 	wantUsed := float64(promptEstimate + wantCompletion)
 	if quota["daily_tokens_used"].(float64) != wantUsed {
 		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
@@ -3666,6 +3666,94 @@ func TestStreamingProviderReportedOverbillClampedToObserved(t *testing.T) {
 	}
 }
 
+// TestStreamingProviderReportedUnderbillClampedToReported pins the
+// issue #278 symmetric fix: when the gateway's byte-derived estimate
+// runs slightly ABOVE the provider's WS usage frame, the gateway clamps
+// back to the provider's authoritative tokenizer count — but ONLY when
+// the upward overshoot sits inside the same pure-absolute window
+// `(clampFloorTokens=2, clampCeilingTokens=20]` used by the #255/#262
+// downward clamp.
+//
+// Outside the window — below floor (benign tokenizer noise) OR above
+// ceiling (too large to be tokenizer noise; likely stream truncation or
+// zero-report fraud) — the gateway keeps the byte estimate.
+func TestStreamingProviderReportedUnderbillClampedToReported(t *testing.T) {
+	type tc struct {
+		name              string
+		contentBytes      int   // bytes of delta.content streamed
+		reportedPromptTok int64 // provider's usage.prompt_tokens
+		reportedCompTok   int64 // provider's usage.completion_tokens
+		wantClamp         bool  // true -> source=provider_reported, comp=reported
+		wantSource        string
+		wantBilledCompTk  int64 // expected completion_tokens in usage_events row
+	}
+	cases := []tc{
+		// Exact / within-floor: keep current gateway-estimate behavior when observed > reported.
+		{name: "exact_match_trusts_provider", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 10, wantClamp: false, wantSource: "provider_reported", wantBilledCompTk: 10},
+		{name: "1_token_overshoot_within_floor_trusts_gateway_estimate", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 9, wantClamp: false, wantSource: "gateway_estimated", wantBilledCompTk: 10},
+		{name: "2_token_overshoot_at_floor_trusts_gateway_estimate", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 8, wantClamp: false, wantSource: "gateway_estimated", wantBilledCompTk: 10},
+		// In-window clamp: small upward estimator inflation -> clamp; preserve provider prompt.
+		{name: "3_token_overshoot_in_window_clamps", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 7, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 7},
+		{name: "5_token_overshoot_in_window_clamps", contentBytes: 60, reportedPromptTok: 11, reportedCompTok: 10, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 10},
+		{name: "9_token_overshoot_in_window_clamps", contentBytes: 76, reportedPromptTok: 13, reportedCompTok: 10, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 10},
+		{name: "15_token_overshoot_in_window_clamps", contentBytes: 100, reportedPromptTok: 17, reportedCompTok: 10, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 10},
+		{name: "20_token_overshoot_at_ceiling_clamps", contentBytes: 400, reportedPromptTok: 19, reportedCompTok: 80, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 80},
+		// v0.4 scenario-07 patterns: English Qwen3-32B output where ceil(bytes/4) ran high.
+		{name: "v04_scenario07_reported_55_observed_64_clamps", contentBytes: 256, reportedPromptTok: 23, reportedCompTok: 55, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 55},
+		{name: "v04_scenario07_reported_33_observed_42_clamps", contentBytes: 168, reportedPromptTok: 29, reportedCompTok: 33, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 33},
+		{name: "v04_scenario07_reported_34_observed_41_clamps", contentBytes: 164, reportedPromptTok: 31, reportedCompTok: 34, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 34},
+		{name: "v04_scenario07_reported_46_observed_52_clamps", contentBytes: 208, reportedPromptTok: 37, reportedCompTok: 46, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 46},
+		// Above ceiling: keep gateway estimate to protect stream-truncation / zero-report fraud cases.
+		{name: "21_token_overshoot_just_above_ceiling_trusts_gateway_estimate", contentBytes: 400, reportedPromptTok: 19, reportedCompTok: 79, wantClamp: false, wantSource: "gateway_estimated", wantBilledCompTk: 100},
+		{name: "100_token_overshoot_large_trusts_gateway_estimate", contentBytes: 600, reportedPromptTok: 19, reportedCompTok: 50, wantClamp: false, wantSource: "gateway_estimated", wantBilledCompTk: 150},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			output := strings.Repeat("x", c.contentBytes)
+			usageFrame := fmt.Sprintf(`data: {"id":"chatcmpl","usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d},"choices":[{"delta":{},"finish_reason":"stop"}]}`, c.reportedPromptTok, c.reportedCompTok, c.reportedPromptTok+c.reportedCompTok)
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				payload := strings.Join([]string{
+					`data: {"id":"chatcmpl","choices":[{"delta":{"content":"` + output + `"}}]}`,
+					usageFrame,
+					`data: [DONE]`,
+					``,
+				}, "\n\n")
+				return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+			})}
+			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+				cfg.Coordinator.BuyerURL = "http://coordinator.test"
+			}, WithHTTPClient(client))
+			accountID := "acct_iss278_" + c.name
+			fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+			observed := estimateTokensFromBytes(int64(c.contentBytes))
+			body := fmt.Sprintf(`{"model":"llama","stream":true,"max_tokens":%d,"messages":[{"role":"user","content":"ok"}]}`, observed+200)
+			resp := postChat(t, h, fullKey, body, nil)
+			if resp.Code != http.StatusOK {
+				t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+			}
+			outcome, source, billedComp, billedPrompt := usageEventOutcomeAndTokens(t, dbPath, accountID)
+			if outcome != "ok" {
+				t.Fatalf("outcome = %q, want ok", outcome)
+			}
+			if source != c.wantSource {
+				t.Errorf("token_source = %q, want %q (clamp=%v: reported=%d observed=%d/%dB window=(%d,%d])",
+					source, c.wantSource, c.wantClamp, c.reportedCompTok, observed, c.contentBytes, clampFloorTokens, clampCeilingTokens)
+			}
+			if billedComp != c.wantBilledCompTk {
+				t.Errorf("billed completion_tokens = %d, want %d", billedComp, c.wantBilledCompTk)
+			}
+			wantPrompt := estimatePromptTokens([]byte(body))
+			if c.wantSource == "provider_reported" {
+				wantPrompt = c.reportedPromptTok
+			}
+			if billedPrompt != wantPrompt {
+				t.Errorf("billed prompt_tokens = %d, want %d", billedPrompt, wantPrompt)
+			}
+		})
+	}
+}
+
 // TestClampWindow pins the issue #255 pure-absolute window:
 //
 //	(clampFloorTokens=2, clampCeilingTokens=20]
@@ -3688,6 +3776,39 @@ func TestClampWindow(t *testing.T) {
 	// positive under-bills on moderate-density content.)
 	if clampCeilingTokens <= clampFloorTokens {
 		t.Errorf("clampCeilingTokens (%d) must be > clampFloorTokens (%d)", clampCeilingTokens, clampFloorTokens)
+	}
+}
+
+func TestClampWindowSymmetric(t *testing.T) {
+	floor, ceiling := clampWindow()
+	for _, c := range []struct {
+		name      string
+		reported  int64
+		observed  int64
+		wantClamp bool
+	}{
+		{name: "downward_floor", reported: 12, observed: 10, wantClamp: false},
+		{name: "downward_in_window", reported: 13, observed: 10, wantClamp: true},
+		{name: "downward_ceiling", reported: 30, observed: 10, wantClamp: true},
+		{name: "downward_above_ceiling", reported: 31, observed: 10, wantClamp: false},
+		{name: "upward_floor", reported: 8, observed: 10, wantClamp: false},
+		{name: "upward_in_window", reported: 7, observed: 10, wantClamp: true},
+		{name: "upward_ceiling", reported: 10, observed: 30, wantClamp: true},
+		{name: "upward_above_ceiling", reported: 10, observed: 31, wantClamp: false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var overshoot int64
+			if c.reported > c.observed {
+				overshoot = c.reported - c.observed
+			} else {
+				overshoot = c.observed - c.reported
+			}
+			gotClamp := overshoot > floor && overshoot <= ceiling
+			if gotClamp != c.wantClamp {
+				t.Errorf("symmetric clamp for reported=%d observed=%d overshoot=%d = %v, want %v (window=(%d,%d])",
+					c.reported, c.observed, overshoot, gotClamp, c.wantClamp, floor, ceiling)
+			}
+		})
 	}
 }
 

--- a/specs/AUDIT_278_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_278_ARCHITECT_PROMPT.md
@@ -1,0 +1,26 @@
+# AUDIT 278 ARCHITECT PROMPT — Gateway upward-correction symmetric clamp
+
+You are auditing the current branch for issue #278. This is an architecture and contract-preservation audit.
+
+Target result: verify the patch preserves the streaming settlement contract while making the upward branch symmetric with the landed #262 downward branch.
+
+Files in scope:
+- `phase5-gateway/internal/router/chat_proxy.go`
+- `phase5-gateway/internal/router/server_test.go`
+- `specs/BUILD_GATEWAY_UPWARD_CLAMP_PROMPT.md`
+- `specs/SPEC-006-buyer-api.md` only if needed to validate SPEC-006 section 17.7 settlement semantics
+
+Checks:
+- Does `settleReported` now have symmetric branch shape for reported-vs-observed disagreements?
+- Does SPEC-006 section 17.7's settlement matrix remain true without requiring a normative spec edit?
+- Does `token_source` still distinguish `provider_reported` as provider tokenizer usage and `gateway_estimated` as byte-derived usage?
+- Are exact-match, below-floor, in-window, at-ceiling, above-ceiling, and large-mismatch cases architecturally coherent in both directions?
+- Are fallback paths for malformed stream, client disconnect, provider timeout, and no usage chunk unchanged?
+- Are comments and logs clear enough for future maintainers to avoid changing the byte estimator or unrelated fallback call sites as part of this fix?
+- Does the test suite encode the contract at the correct level, or is it overfit to implementation details?
+
+Output format:
+- Start with `AUDIT_278_ARCHITECT: PASS` if there are 0 CRITICAL/HIGH/MEDIUM findings, otherwise `AUDIT_278_ARCHITECT: FAIL`.
+- Then list counts as `CRITICAL: n`, `HIGH: n`, `MEDIUM: n`, `LOW: n`.
+- For every finding, include severity, file:line, evidence, contract impact, and concrete fix.
+- Explicitly state whether a SPEC change is required; if yes, explain why.

--- a/specs/AUDIT_278_CODE_PROMPT.md
+++ b/specs/AUDIT_278_CODE_PROMPT.md
@@ -1,0 +1,27 @@
+# AUDIT 278 CODE PROMPT — Gateway upward-correction symmetric clamp
+
+You are auditing the current branch for issue #278. This is a code-implementation audit, not a research task.
+
+Target result: verify the implementation matches `specs/BUILD_GATEWAY_UPWARD_CLAMP_PROMPT.md` and is a direct symmetric twin of the landed #262 downward clamp.
+
+Files in scope:
+- `phase5-gateway/internal/router/chat_proxy.go`
+- `phase5-gateway/internal/router/server_test.go`
+- this audit may read `specs/BUILD_GATEWAY_UPWARD_CLAMP_PROMPT.md` for acceptance criteria
+
+Checks:
+- In `settleReported`, the upward branch (`observedCompletion > usage.CompletionTokens`) computes `overshoot := observedCompletion - usage.CompletionTokens`.
+- It reuses `clampFloorTokens` and `clampCeilingTokens`; no duplicate or new constants.
+- It clamps only when `clampFloorTokens < overshoot && overshoot <= clampCeilingTokens`.
+- In-window upward clamp settles to `usage.PromptTokens` and `usage.CompletionTokens` with `token_source = "provider_reported"`.
+- Outside-window upward cases preserve the old behavior: gateway prompt estimate, observed completion estimate, `token_source = "gateway_estimated"`.
+- The existing downward clamp behavior and other `estimateStreamingCompletionTokens` call sites are untouched.
+- The new log line mirrors the downward clamp log shape and includes `request_id`, `account_id`, `reported`, `observed`, `overshoot`, `window_floor`, `window_ceiling`, and `outcome`, with a direction-specific message.
+- Tests cover exact match, floor boundary, in-window values, ceiling boundary, above-ceiling, large overshoot, the four v0.4 scenario-07 fixtures, and a symmetry pin for the shared window.
+- Regression tests still preserve the #262 downward-clamp behavior.
+
+Output format:
+- Start with `AUDIT_278_CODE: PASS` if there are 0 CRITICAL/HIGH/MEDIUM findings, otherwise `AUDIT_278_CODE: FAIL`.
+- Then list counts as `CRITICAL: n`, `HIGH: n`, `MEDIUM: n`, `LOW: n`.
+- For every finding, include severity, file:line, evidence, impact, and concrete fix.
+- Do not propose scope expansion unless the current patch violates the prompt or introduces a correctness risk.

--- a/specs/AUDIT_278_SECURITY_PROMPT.md
+++ b/specs/AUDIT_278_SECURITY_PROMPT.md
@@ -1,0 +1,31 @@
+# AUDIT 278 SECURITY PROMPT — Gateway upward-correction symmetric clamp
+
+You are auditing the current branch for issue #278. This is a security and abuse-resistance audit.
+
+Target result: determine whether the symmetric upward clamp creates an exploitable under-billing path while preserving the #262 risk model.
+
+Files in scope:
+- `phase5-gateway/internal/router/chat_proxy.go`
+- `phase5-gateway/internal/router/server_test.go`
+- `specs/BUILD_GATEWAY_UPWARD_CLAMP_PROMPT.md`
+- existing spec text may be read only if needed to validate the billing contract
+
+Threat model:
+- A hostile provider may deliberately report `usage.completion_tokens = ceil(bytes/4) - k` on every streaming request.
+- The most important case is `k` inside `(2, 20]`, where the new upward clamp would settle at the lower provider-reported value.
+- The audit should compare this risk against the symmetric #262 downward-clamp attack surface, where a provider could over-report by a small bounded amount but the gateway clamps inside the same absolute window.
+
+Checks:
+- Is the `(2, 20]` upward clamp small and bounded enough to ship as a symmetric correction?
+- Does the above-ceiling behavior still protect against zero-report fraud and stream-truncation underreports?
+- Does the floor behavior avoid churn from benign 1-2 token noise without opening material abuse?
+- Does the patch preserve settlement bounds enforced by parsed usage and reservation limits?
+- Does `token_source = "provider_reported"` remain truthful for in-window upward clamps?
+- Are there missing tests for hostile-provider cases just above the ceiling or large underreports?
+- Are there logs sufficient to audit clamp fires post-deploy?
+
+Output format:
+- Start with `AUDIT_278_SECURITY: PASS` if there are 0 CRITICAL/HIGH/MEDIUM findings, otherwise `AUDIT_278_SECURITY: FAIL`.
+- Then list counts as `CRITICAL: n`, `HIGH: n`, `MEDIUM: n`, `LOW: n`.
+- For every finding, include severity, file:line, evidence, exploit or impact, and concrete fix.
+- LOW findings may be documentation-only; CRITICAL/HIGH/MEDIUM must be actionable before merge.

--- a/specs/BUILD_GATEWAY_UPWARD_CLAMP_PROMPT.md
+++ b/specs/BUILD_GATEWAY_UPWARD_CLAMP_PROMPT.md
@@ -1,0 +1,200 @@
+# BUILD PROMPT — Gateway upward-correction symmetric clamp (closes #278)
+
+Run as: `omc ask codex "$(cat specs/BUILD_GATEWAY_UPWARD_CLAMP_PROMPT.md)"`
+
+This is an IMPL build prompt, not a research prompt. Single PR. Same
+3-lane audit discipline as #262: code / security / architect. Converge
+to 0 CRITICAL/HIGH/MEDIUM in every lane before push. Audit prompts go
+in `specs/AUDIT_278_*_PROMPT.md` and are fired via
+`omc ask codex` in a loop (per memory:
+`feedback-audit-prompts-file-not-chat`,
+`feedback-three-lane-codex-audits`).
+
+This fix is a **direct mirror of PR #262 on the opposite branch** —
+read PR #262's final landed code first, then write the upward-clamp
+twin with the same idioms, same log shape, same test style.
+
+## Scope
+
+Fix issue [#278](https://github.com/Augustas11/macprovider/issues/278).
+ONE file changed:
+`phase5-gateway/internal/router/chat_proxy.go`. Plus tests in
+`phase5-gateway/internal/router/server_test.go`. No SPEC changes
+required (the clamp shape was already documented for #262 and the
+upward fix is a straightforward symmetric extension within the same
+contract — but if your audit lane says SPEC needs touching, surface
+the case before changing it).
+
+## The bug, one paragraph
+
+`settleReported` in `chat_proxy.go:520` has two branches: upward
+(observed > reported → settle at observed) and downward (reported >
+observed → maybe-clamp per the #262 window). #262 fixed the downward
+direction by introducing a (2, 20] clamp window. The upward direction
+was untouched and still settles at the inflated byte-estimate
+unconditionally. Empirical data from v0.4 scenario 07 (full repro in
+#278) shows the `ceil(content_bytes / 4)` estimator runs ~7-15% higher
+than the provider's authoritative tokenizer on English Qwen3-32B
+output. Result: gateway DB overbills by 6-9 tokens per request when
+the upward branch fires.
+
+## What to build
+
+In `settleReported` (the function at `chat_proxy.go:520`, NOT every
+other `estimateStreamingCompletionTokens` call site):
+
+1. Inside the existing `if observedCompletion > usage.CompletionTokens`
+   block, compute `overshoot := observedCompletion - usage.CompletionTokens`.
+
+2. Apply the **same `clampFloorTokens` / `clampCeilingTokens` constants**
+   (no new constants — reuse `clampFloorTokens = 2`,
+   `clampCeilingTokens = 20` from `chat_proxy.go:1076-1078`).
+
+3. If `clampFloorTokens < overshoot <= clampCeilingTokens`:
+   - Settle at `usage.PromptTokens` + `usage.CompletionTokens`
+     (the provider's reported count).
+   - `token_source = "provider_reported"`.
+   - Emit a `slog.Info` log line mirroring the downward-clamp log at
+     `chat_proxy.go:545-553` — same field names where applicable, swap
+     "over-reported" → "under-reported by provider; gateway estimate
+     higher" or similar accurate wording. Include `reported`,
+     `observed`, `overshoot`, `window_floor`, `window_ceiling`,
+     `request_id`, `account_id`, `outcome`. The event-level field name
+     for the log message (the message string itself) is the place to
+     make the direction explicit so log search can disambiguate
+     upward vs downward clamp fires.
+   - Return.
+
+4. Otherwise (overshoot ≤ floor OR overshoot > ceiling): preserve
+   current behavior — settle at `observedCompletion` with
+   `token_source = "gateway_estimated"`. Comment the rationale inline
+   matching the downward-clamp comment at `chat_proxy.go:1055-1063`:
+   - `overshoot ≤ 2`: benign tokenizer noise (matches downward floor
+     rationale by symmetry).
+   - `overshoot > 20`: too large to be tokenizer error — likely a
+     stream truncation case where the provider's `usage` chunk
+     under-reports what was actually generated (or a zero-report fraud
+     pattern). The byte estimator is the right answer here. Trust it.
+
+## What NOT to build
+
+- **Do NOT change the downward clamp** (the existing `overshoot >
+  clampFloorTokens && overshoot <= clampCeilingTokens` block at
+  `chat_proxy.go:544`). That was #262, audited 0/0/0, working.
+- **Do NOT change the byte-to-token constant** (`ceil(n/4)` at
+  `chat_proxy.go:1093-1095`). That is a separate question with its own
+  failure modes (model-specific calibration, dense-content under-bill
+  resurrection). Out of scope for this PR; file as a follow-up if you
+  see compelling evidence the constant itself needs revisiting.
+- **Do NOT touch other call sites** of `estimateStreamingCompletionTokens`
+  (e.g. `chat_proxy.go:612`, `:646`, `:735`, `:761`, `:862`). Those are
+  fallback paths for stream-malformed / client-disconnect /
+  provider-timeout / no-usage-chunk where the provider report is
+  unavailable; the byte estimate is the only signal and remains
+  correct. The clamp only applies in `settleReported`, where we have
+  BOTH a reported usage block AND a byte-derived estimate.
+- **Do NOT widen scope** to non-streaming paths. This bug is streaming-
+  only; non-streaming uses the provider's `usage` block directly from
+  the response body and doesn't go through the byte estimator.
+
+## Tests
+
+Add these to `phase5-gateway/internal/router/server_test.go`. Follow
+the style of the existing `TestStreamingProviderReportedOverbillClampedToObserved`
+function (downward clamp test) — same fixture pattern, same DB
+assertion helper.
+
+1. `TestStreamingProviderReportedUnderbillClampedToReported` — 12+
+   subtests:
+   - **Exact match**: bytes/4 == reported, no clamp, settled at reported.
+   - **Within floor (overshoot=1, 2)**: trust byte estimate (existing
+     behavior — bytes/4 is settled).
+   - **In window (overshoot=3, 5, 9, 15, 20)**: clamp to reported,
+     `token_source = provider_reported`.
+   - **The v0.4 scenario-07 patterns** as concrete fixtures:
+     - reported=55, bytes ≈ 256 → ceil=64, overshoot=9 → clamp.
+     - reported=33, bytes ≈ 168 → ceil=42, overshoot=9 → clamp.
+     - reported=34, bytes ≈ 164 → ceil=41, overshoot=7 → clamp.
+     - reported=46, bytes ≈ 208 → ceil=52, overshoot=6 → clamp.
+   - **At ceiling (overshoot=20)**: clamp (boundary).
+   - **Just above ceiling (overshoot=21)**: trust byte estimate
+     (token_source=gateway_estimated) — protects against zero-report
+     fraud.
+   - **Large overshoot (overshoot=100)**: trust byte estimate (this is
+     the stream-truncation case where provider's usage chunk
+     genuinely under-reports).
+
+2. `TestClampWindowSymmetric` — verify both directions use the same
+   `(clampFloorTokens, clampCeilingTokens]` constants. Pin the
+   constants by importing `clampWindow()` if helpful.
+
+3. **Regression test for #262**: confirm all existing downward-clamp
+   subtests still pass unchanged.
+
+## Audit prompts (3 lanes, written to specs/)
+
+After IMPL is done, write three audit prompts and fire each via
+`omc ask codex`:
+
+- `specs/AUDIT_278_CODE_PROMPT.md` — does the implementation match the
+  prompt? Are the constants reused, not duplicated? Are existing call
+  sites untouched? Is the log line consistent with the downward-clamp
+  log shape? Are tests exhaustive on the window boundaries?
+- `specs/AUDIT_278_SECURITY_PROMPT.md` — can a hostile provider exploit
+  this to under-bill systematically? (E.g. provider deliberately
+  reports `usage.completion_tokens = ceil(bytes/4) - 3` on every
+  request to slip just into the clamp window and ride the gateway-
+  estimate-minus-3 lower number for every request, defrauding the
+  network by 3 tokens × every-request × forever.) Is the (2, 20]
+  ceiling tight enough? Compare against the symmetric attack surface
+  #262 analyzed.
+- `specs/AUDIT_278_ARCHITECT_PROMPT.md` — is the contract preserved?
+  Does SPEC-006 §17.7 settlement matrix still hold? Does the
+  `token_source` field still distinguish meaningfully between
+  `provider_reported` (provider's authoritative count) and
+  `gateway_estimated` (gateway's byte-derived count)? Are the two
+  branches now symmetric in shape, not just in name?
+
+Run each via `omc ask codex "$(cat specs/AUDIT_278_<LANE>_PROMPT.md)"`.
+Fix all CRITICAL / HIGH / MEDIUM findings, re-run that specific lane.
+LOW findings can ship if the PR body documents them. Skip-accepted-lane
+rule applies: once a lane returns 0 C/H/M and the next fix-pass doesn't
+touch that lane's scope, don't re-fire it (per
+[[feedback-skip-accepted-audit-lanes]]).
+
+## Verification before push
+
+1. Run `go test ./phase5-gateway/internal/router/...` — green.
+2. Grep `git show --stat HEAD` to confirm the new clamp code is
+   actually in the diff (per
+   [[feedback-verify-commit-content-not-just-message]]).
+3. Build and deploy the patched gateway to Pearl (after PR merges).
+4. Re-run v0.4 scenario 07 against patched gateway: I1 drift should
+   drop to 0 or very small (<5 tokens across the full window). If it
+   doesn't, the upward path isn't where the bug actually lives —
+   investigate before claiming done.
+
+## PR
+
+Branch: `fix/iss-278-gateway-upward-clamp` (per
+[[feedback-always-fresh-worktree-for-code-work]] — fresh worktree off
+`origin/main`). Single bundled PR. Title format:
+`fix(gateway): symmetric upward clamp for streaming estimator inflation (closes #278)`.
+
+In the PR body include:
+- The 4-pair reproduction table from #278.
+- Pointer to v0.4 scenario 07 artifact bundle and the gateway DB
+  confirmation query.
+- 3-lane audit trail summary (R1 findings, R2 deltas, terminal 0/0/0/0
+  state).
+- Confirmation of the post-merge re-run that the I1 drift went to ~0.
+
+## Auth + merge
+
+- Push routes to Augustas11 automatically (per repo's `.git/config`
+  helper).
+- After 1 approving review (from antfleet-ops), squash-merge as
+  Augustas11: `GH_TOKEN=$(gh auth token -u Augustas11) gh pr merge
+  <num> --squash --delete-branch`.
+- After merge: `git reset --hard origin/main` on local main per
+  [[pr-merge-workflow-rule]].

--- a/specs/SPEC-006-buyer-api.md
+++ b/specs/SPEC-006-buyer-api.md
@@ -1,7 +1,12 @@
 # SPEC-006 - Buyer API Gateway: Mac Provider's first public buyer surface
 
-**Version:** 0.9.2 (2026-06-29, ISS-255 streaming over-report clamp policy)
+**Version:** 0.9.3 (2026-06-30, ISS-278 streaming under-report symmetric clamp policy)
 **Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.0, SPEC-003 v0.7, SPEC-004 v0.2
+
+**Change log v0.9.3 (2026-06-30, issue #278):**
+- § 7.2 streaming settlement now also clamps the *upward*-correction direction (provider's reported completion_tokens is *under* the gateway's byte-based observation) using the SAME pure-absolute window `2 < overshoot ≤ 20`. In-window upward gaps settle at the provider-reported count with `token_source = "provider_reported"` (the provider's tokenizer is authoritative on its own output when the disagreement is small). Below 2 tokens: still trust the byte estimate (existing behavior, byte-based observation drives settlement). Above 20 tokens: still trust the byte estimate (stream-truncation / zero-report-fraud guard). Clamp window constants `clampFloorTokens=2`, `clampCeilingTokens=20` are shared between both directions — no direction-specific tuning.
+- § 17.7 settlement matrix row 200 and § AC-37 acceptance criteria updated to describe the symmetric clamp shape in both directions.
+- Live surfacing: scenario 07 of the 2026-06-30 v0.4 baseline rerun caught +6 / +7 / +9 / +9 over-bills across 4 of 40 successful streaming pairs on `augustass-macbook-air × Qwen3-32B-4bit` after PR #262 closed the downward channel. Gateway's `ceil(content_bytes / 4)` estimator runs ~7-15% high on English Qwen3-32B output; provider's tokenizer is authoritative. Surfaced as `token_source = "gateway_estimated"` rows that override the (correct) provider report. Fix mirrors PR #262 on the opposite branch of `settleReported`.
 
 **Change log v0.9.2 (2026-06-29, issue #255):**
 - § 7.2 streaming settlement now clamps provider-reported completion_tokens down to the gateway's byte-based observed value when the over-report falls inside the pure-absolute window `2 < overshoot ≤ 20` ("Streaming over-report clamp" subsection). Below 2 tokens: trusted as benign tokenizer noise. Above 20 tokens: trusted as density mismatch (byte-based observation is unreliable on dense content; clamping would risk under-billing). Clamped rows record `token_source = "gateway_estimated"` and preserve provider-reported `prompt_tokens`; gateway emits a structured log line carrying `request_id`, `account_id`, `reported`, `observed`, `overshoot`, `window_floor`, `window_ceiling`, `outcome` for audit triage.
@@ -1658,33 +1663,43 @@ Failed reservations MUST expire and be reclaimed by a reaper job within 24 hours
 
 For streaming requests (`stream: true`), the gateway MUST reserve `max_tokens` or the configured per-request cap, whichever is smaller, before forwarding.
 
-On SSE completion after a provider `[DONE]` chunk, settlement MUST adjust the reservation to actual usage as reported by the provider, subject to the streaming over-report clamp policy below.
+On SSE completion after a provider `[DONE]` chunk, settlement MUST adjust the reservation to actual usage as reported by the provider, subject to the symmetric streaming clamp policy below.
 
-#### Streaming over-report clamp (#255, issue dated 2026-06-29)
+#### Streaming completion-token symmetric clamp (#255 downward, #278 upward)
 
-The gateway MUST clamp the streaming completion_tokens settlement down to its own observed value whenever the provider's `usage.completion_tokens` exceeds the gateway's byte-based observation by an amount inside the pure-absolute clamp window:
+The gateway runs two checks on every successful streaming settlement, sharing the SAME pure-absolute clamp window:
 
 - Let `observed = ceil(bytes_emitted_so_far / 4)` (the existing § 7.2 disconnect-fallback heuristic).
-- Let `overshoot = reported - observed`.
-- Clamp iff `2 < overshoot ≤ 20`.
+- Let `reported = usage.completion_tokens` (provider's tokenizer count from the final usage chunk).
+- Let `clampFloorTokens = 2`, `clampCeilingTokens = 20` (shared constants; no direction-specific tuning).
 
-Outside the window the gateway MUST trust the provider's reported completion_tokens:
+**Downward direction (#255, 2026-06-29): provider reported more than observed.**
 
-- `overshoot ≤ 2`: benign tokenizer noise (EOS / chat-template stop tokens that count as completion but never stream as delta content).
-- `overshoot > 20`: density mismatch — the gateway's byte-based estimate is unreliable on dense content (CJK, code, short-token text where 1 token < 4 bytes); clamping here would risk under-billing the provider for legitimately generated content.
+- Let `overshoot_down = reported - observed`.
+- Clamp DOWN to `observed` iff `clampFloorTokens < overshoot_down ≤ clampCeilingTokens`.
+- In-window: usage event records `token_source = "gateway_estimated"`, preserves provider's reported `prompt_tokens`.
 
-When the clamp fires, the usage event MUST record `token_source = "gateway_estimated"` (no new vocabulary), MUST preserve the provider's reported `prompt_tokens`, and the gateway SHOULD emit a structured log line carrying `request_id`, `account_id`, `reported`, `observed`, `overshoot`, `window_floor`, `window_ceiling`, and `outcome` for audit visibility.
+**Upward direction (#278, 2026-06-30): byte-estimator ran higher than reported.**
 
-The pure-absolute window is a deliberate trade. A percentage-scaled ceiling (50% × observed in earlier drafts) was rejected because it still false-positive-clamped moderate-density legitimate reports (e.g. observed=225 byte-tokens with a legitimate 300-token actual count fell inside a percentage window and got clamped). The fixed 20-token ceiling caps the per-request false-positive under-bill at 20 tokens regardless of completion size, and trusts the provider for any overshoot large enough to plausibly reflect density divergence.
+- Let `overshoot_up = observed - reported`.
+- Clamp UP to `reported` (i.e. trust the provider's tokenizer) iff `clampFloorTokens < overshoot_up ≤ clampCeilingTokens`.
+- In-window: usage event records `token_source = "provider_reported"`, preserves provider's reported `prompt_tokens` AND `completion_tokens`.
 
-Skim surfaces NOT closed by the clamp:
+**Outside the window the gateway MUST NOT clamp:**
 
-- `overshoot ≤ 2`: trusted as benign tokenizer noise. A provider can systematically over-report by up to 2 tokens per request without triggering the clamp. Bounded; no structured-log emission.
-- `overshoot > 20`: trusted as density mismatch. A provider can over-report by any amount above 20 tokens (bounded only by the request's `max_tokens`) without triggering the clamp. Same adversarial exposure as the pre-#255 status quo for these reports. No structured-log emission.
+- `overshoot ≤ 2` (either direction): benign tokenizer noise (EOS / chat-template stop tokens that count as completion but never stream as delta content; or sub-byte rounding noise in the `ceil(N/4)` estimator). Existing settlement source applies — downward branch trusts the provider (`provider_reported`); upward branch trusts the byte estimate (`gateway_estimated`).
+- `overshoot > 20` (either direction): too large to be tokenizer noise. Downward: density mismatch — byte-based estimate is unreliable on dense content (CJK, code, short-token text where 1 token < 4 bytes); clamping would risk under-billing the provider for legitimately generated content; trust provider (`provider_reported`). Upward: stream truncation or zero-report-fraud guard — the provider's usage chunk plausibly under-reports content actually generated; trust byte estimate (`gateway_estimated`).
 
-Only the `3 ≤ overshoot ≤ 20` band is both clamped and structured-log-visible for triage. Closing the residual skim surfaces requires a tokenizer-grounded observation (replacing the byte heuristic) — out of scope for #255.
+When EITHER clamp fires, the gateway SHOULD emit a structured log line carrying `request_id`, `account_id`, `reported`, `observed`, `overshoot`, `window_floor`, `window_ceiling`, and `outcome` for audit visibility. The log MESSAGE field MUST distinguish direction (e.g. "clamped over-reported" vs "clamped under-reported").
 
-Existing § 7.2 upward correction (settle to gateway estimate when `observed > reported`) is unchanged.
+The pure-absolute window is a deliberate trade and applies symmetrically. A percentage-scaled ceiling (50% × observed in earlier #255 drafts) was rejected because it still false-positive-clamped moderate-density legitimate reports (e.g. observed=225 byte-tokens with a legitimate 300-token actual count fell inside a percentage window and got clamped). The fixed 20-token ceiling caps the per-request adversarial exposure at 20 tokens regardless of completion size in EITHER direction, and trusts the more-reliable source for any overshoot large enough to plausibly reflect a real disagreement.
+
+Skim surfaces NOT closed by the clamp (symmetric in both directions):
+
+- `overshoot ≤ 2`: trusted as benign noise. Bounded; no structured-log emission. A provider can over- or under-report by up to 2 tokens per request without triggering the clamp.
+- `overshoot > 20`: trusted as legitimate density / truncation. A provider can over- or under-report by any amount above 20 tokens (bounded only by `max_tokens`) without triggering the clamp.
+
+Only the `3 ≤ overshoot ≤ 20` band (either direction) is both clamped and structured-log-visible for triage. Closing the residual skim surfaces requires a tokenizer-grounded observation (replacing the byte heuristic) — out of scope.
 
 For streaming requests where the buyer disconnects mid-stream, the gateway settles the daily-quota reservation as follows:
 
@@ -2652,7 +2667,7 @@ The gateway MUST reserve quota before forwarding as defined in Section 7.2 and s
 
 | Status | Completion tokens | Quota debited | Rationale |
 |---|---:|---|---|
-| 200 | as reported, subject to § 7.2 over-report clamp | prompt + completion | Successful work performed; streaming `completion_tokens` clamped down to gateway observed when over-report sits inside `2 < overshoot ≤ 20` (#255) |
+| 200 | as reported, subject to § 7.2 symmetric clamp | prompt + completion | Successful work performed; streaming `completion_tokens` symmetric-clamped within `2 < overshoot ≤ 20`: downward (#255) clamps to gateway observed (`token_source = "gateway_estimated"`); upward (#278) clamps to provider reported (`token_source = "provider_reported"`) |
 | 503 | 0 | none | No provider was reached; request never forwarded |
 | Context cancelled (buyer disconnects mid-reservation) | n/a | none; reservation refunded before return | Gateway MUST exit silently without writing a 500 to the dead connection |
 | Context cancelled (buyer disconnects at concurrency gate) | n/a | none; quota reservation refunded before return | Same as above |
@@ -3286,9 +3301,9 @@ Branches:
 Expected outcome:
 
 - Concurrent requests cannot oversubscribe the daily quota during the stream.
-- Successful stream returns HTTP 200 with `Content-Type: text/event-stream; charset=utf-8`, emits `data: {json}\n\n` chunks followed by `data: [DONE]`, and settles to provider-reported usage subject to the § 7.2 streaming over-report clamp (#255: completion_tokens are clamped down to the gateway's byte-based observed value when `2 < overshoot ≤ 20`, recorded as `gateway_estimated` source).
-- Branch A releases concurrency and records usage source as provider-reported when the clamp does NOT fire (overshoot ≤ 2 or > 20).
-- Branch B releases concurrency and records usage source as gateway-estimated, covering both the existing upward-correction case (observed > reported) AND the new #255 downward-clamp case (clamp window fires).
+- Successful stream returns HTTP 200 with `Content-Type: text/event-stream; charset=utf-8`, emits `data: {json}\n\n` chunks followed by `data: [DONE]`, and settles to provider-reported usage subject to the § 7.2 symmetric clamp (#255 downward + #278 upward). The symmetric clamp shares the same `2 < overshoot ≤ 20` pure-absolute window in both directions but settles in opposite directions: downward gaps (reported > observed, in window) clamp DOWN to observed with `token_source = "gateway_estimated"`; upward gaps (observed > reported, in window) clamp UP to reported with `token_source = "provider_reported"`.
+- Branch A releases concurrency and records usage source as `provider_reported` in two cases: (i) NO clamp fires (overshoot ≤ 2 in either direction, or > 20 downward), or (ii) the #278 upward clamp fires in-window (gateway estimate was inflated; provider tokenizer wins).
+- Branch B releases concurrency and records usage source as `gateway_estimated` in two cases: (i) the #255 downward clamp fires in-window (provider over-reported; gateway estimate wins), or (ii) upward case with `overshoot > 20` (likely stream truncation / zero-report fraud; gateway estimate wins).
 - `/v1/usage` returns HTTP 200 with reservation released and daily token fields reflecting settlement.
 
 Verification command:


### PR DESCRIPTION
## Summary

Closes #278 by mirroring the landed #262 streaming clamp in the opposite direction inside `settleReported` only.

When the gateway byte estimate is slightly higher than the provider usage frame, and the overshoot is inside the shared `(2, 20]` clamp window, settlement now uses the provider tokenizer count with `token_source = "provider_reported"`. Below the floor and above the ceiling keep the old `gateway_estimated` behavior, preserving protection for benign 1-2 token noise and large stream-truncation / zero-report cases.

No byte-estimator constant changes, no non-streaming changes, and no unrelated fallback `estimateStreamingCompletionTokens` call-site changes.

## Reproduction table from #278

v0.4 scenario 07 artifact bundle:
`test/network-harness/artifacts/07_sustained_throughput-20260630T111741Z/`

| request_id | provider report (harness + coord) | gateway DB | overshoot |
|---|---:|---:|---:|
| `3f3ec2c0-7ea5-4918-a544-c0a381c1f58d` | 55 | 64 | +9 |
| `41043e24-b983-49d5-bf84-fd3ce7fbd929` | 33 | 42 | +9 |
| `643cb620-33c1-42cd-8d49-0c2d0002e784` | 34 | 41 | +7 |
| `5031fc92-54ab-4840-ab9b-fe577c001e61` | 46 | 52 | +6 |

All four rows confirmed via direct gateway DB query — `token_source = gateway_estimated` and inflated completion counts shown above.

## Commits in this PR

1. **`ce731d1` — IMPL** (chat_proxy.go + server_test.go) — the symmetric upward clamp itself, plus 3 audit prompts under `specs/AUDIT_278_*_PROMPT.md`.
2. **`b75785d` — SPEC-006 v0.9.3** — describes both clamp directions sharing the same window in §7.2 and §17.7 row 200 + §AC-37. Closes the convergent R1 LOW from architect + security (SPEC text was still downward-only).
3. **`66dde94` — R2 LOW fixes** — symmetric-clamp doc comment on the shared `clampFloorTokens` / `clampCeilingTokens` constants + zero-report boundary test fixtures (`observed=20 reported=0` clamps to 0 with `provider_reported`; `observed=21 reported=0` does not clamp, settles at `gateway_estimated`).

## Audit trail

Audit prompts: `specs/AUDIT_278_{CODE,SECURITY,ARCHITECT}_PROMPT.md`. All runs via `omc ask codex "$(cat ...)"`.

| Round | Lane | Verdict | C | H | M | L | Notes |
|---|---|---|---:|---:|---:|---:|---|
| R1 | code | PASS | 0 | 0 | 0 | 0 | IMPL matches build prompt |
| R1 | security | PASS | 0 | 0 | 0 | 1 | LOW: SPEC-006 stale upward-correction wording |
| R1 | architect | PASS | 0 | 0 | 0 | 1 | LOW: same SPEC-006 stale wording (convergent) |
| R2 | code | SKIPPED | — | — | — | — | Per skip-accepted-lanes rule (scope untouched) |
| R2 | security | PASS | 0 | 0 | 0 | 1 | LOW: zero-report boundary not pinned by tests |
| R2 | architect | PASS | 0 | 0 | 0 | 1 | LOW: shared-constants doc comment downward-only |

**Merge bar reached at R2:** every active lane returned 0 CRITICAL / 0 HIGH / 0 MEDIUM. Residual LOWs from R2 were applied in commit `66dde94` (cheap mechanical fixes) but no further audit round was fired — per the convention that LOW findings ship with PR-body documentation, not with another R+1 cycle.

## Validation

- `go test -count=1 ./internal/router/...` from `phase5-gateway` green (R1 IMPL state).
- `go test -count=1 -run 'TestStreamingProviderReportedUnderbillClampedToReported|TestStreamingProviderReportedOverbillClampedToObserved|TestClampWindow' ./internal/router/...` green after the R2-LOW-fix commit (covers new zero-report boundary fixtures + regression on #262 downward clamp).
- `git show --stat HEAD` on each commit confirms the diff matches the message.

## Post-merge validation (operator step)

Pending after squash-merge and Pearl deploy:

1. Build and deploy the patched gateway to Pearl.
2. Re-run v0.4 scenario 07 against the patched gateway.
3. Confirm I1 drift drops to 0 or very small (`<5` tokens across the full window).

This PR does not claim that post-merge re-run; it must be completed after the merged build is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
