### PR TITLE
fix(#245): SPEC-007 v0.5 — reject untyped /admin/explorer/sessions path-segments with 400

### DIFF
--- a/phase4-coordinator/internal/explorer/handlers.go
+++ b/phase4-coordinator/internal/explorer/handlers.go
@@ -182,16 +182,17 @@ func (h *Handler) handleSessionDetail(ctx context.Context, w http.ResponseWriter
 		writeExplorerError(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
-	// #231 SPEC-007 v0.4 path-segment typing (deprecation window):
-	// accept `int_<request_id>` prefix as the typed coordinator form.
-	// Untyped (bare-UUID) segments still resolve as the coordinator-
-	// internal request_id (v0.3 behavior) but emit a deprecation log
-	// row so operators see the upcoming v0.5 break.
-	if stripped, ok := strings.CutPrefix(requestID, "int_"); ok && stripped != "" {
-		requestID = stripped
-	} else {
-		h.logPathSegmentUntyped(r, requestID)
+	// SPEC-007 v0.5 (#245): path-segment MUST carry an `int_` prefix.
+	// Untyped (legacy bare-UUID) calls return 400 session_id_untyped.
+	// The v0.4 deprecation-window log emit is removed; that path is
+	// no longer reachable.
+	stripped, ok := strings.CutPrefix(requestID, "int_")
+	if !ok || stripped == "" {
+		writeExplorerError(w, http.StatusBadRequest, "session_id_untyped",
+			"path-segment must be int_<request_id> — bare ids rejected per SPEC-007 v0.5")
+		return
 	}
+	requestID = stripped
 	detail, err := h.store.SessionDetail(ctx, h.db, requestID)
 	if err != nil {
 		// ISS-212 v0.3 §5.6: path-segment is coordinator-internal
@@ -570,34 +571,6 @@ func (h *Handler) authorized(r *http.Request) bool {
 	}
 	h.logBearerAccepted(r, "operator_key")
 	return true
-}
-
-// logPathSegmentUntyped emits the #231 SPEC-007 v0.4 deprecation
-// WARN when /admin/explorer/sessions/{request_id} is called with a
-// bare-UUID (legacy v0.3) path segment instead of the typed
-// `int_<request_id>` form. v0.5 will reject untyped with 400.
-// Same stdlib-JSON shape as logBearerAccepted; single journald
-// filter (`event=payout_explorer_path_segment_untyped`) catches
-// every untyped call. Uses json.Marshal for the payload so
-// arbitrary characters in request_id/remote_addr don't break the
-// JSON shape (R1 SEC MEDIUM closure: Go's `%q` is not JSON-safe).
-func (h *Handler) logPathSegmentUntyped(r *http.Request, requestID string) {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host = r.RemoteAddr
-	}
-	// #231 R5 code LOW closure: include ts_utc so journald
-	// consumers see the full SPEC §5.6 event shape.
-	payload, _ := json.Marshal(map[string]any{
-		"event":       "payout_explorer_path_segment_untyped",
-		"severity":    "WARN",
-		"endpoint":    "GET /admin/explorer/sessions",
-		"request_id":  requestID,
-		"remote_addr": host,
-		"ts_utc":      time.Now().UTC().Format(time.RFC3339Nano),
-		"deprecation": "v0.5 will reject untyped with 400 session_id_untyped — use int_<request_id>",
-	})
-	stdLog.Println(string(payload))
 }
 
 // logBearerAccepted is the audit-log line the operator watches during

--- a/phase4-coordinator/internal/explorer/handlers.go
+++ b/phase4-coordinator/internal/explorer/handlers.go
@@ -182,14 +182,24 @@ func (h *Handler) handleSessionDetail(ctx context.Context, w http.ResponseWriter
 		writeExplorerError(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
-	// SPEC-007 v0.5 (#245): path-segment MUST carry an `int_` prefix.
-	// Untyped (legacy bare-UUID) calls return 400 session_id_untyped.
+	// SPEC-007 v0.5 §5.6 (#245): path-segment MUST carry an `int_`
+	// prefix. Untyped (legacy bare-UUID) calls return
+	// 400 invalid_request_error + session_id_untyped. Envelope shape
+	// matches the gateway §6.4 emit so dashboard/runbook matchers
+	// behave the same across both phases (R1 SEC LOW-1 closure).
 	// The v0.4 deprecation-window log emit is removed; that path is
 	// no longer reachable.
 	stripped, ok := strings.CutPrefix(requestID, "int_")
 	if !ok || stripped == "" {
-		writeExplorerError(w, http.StatusBadRequest, "session_id_untyped",
-			"path-segment must be int_<request_id> — bare ids rejected per SPEC-007 v0.5")
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error": map[string]any{
+				"type":      "invalid_request_error",
+				"code":      "session_id_untyped",
+				"message":   "path-segment must be int_<request_id> — bare ids rejected per SPEC-007 v0.5",
+				"source":    "coordinator",
+				"retryable": false,
+			},
+		})
 		return
 	}
 	requestID = stripped
@@ -225,12 +235,10 @@ func (h *Handler) handleSessionDetail(ctx context.Context, w http.ResponseWriter
 		// "gateway_identity_unavailable" rather than forwarded.
 		external, account := firstAttemptWithBothFields(detail)
 		if external != "" && account != "" {
-			// #231 SPEC-007 v0.4 (R5 code LOW closure): the gateway
-			// accepts `ext_<external_request_id>` as the typed
-			// path-segment form (v0.5 will reject bare-id). Send
-			// the typed prefix so the coordinator-driven proxy
-			// doesn't trigger the gateway's untyped-deprecation
-			// audit on every operator click.
+			// SPEC-007 §6.4 v0.5 (#245): the gateway REQUIRES the typed
+			// `ext_<external_request_id>` path-segment form. Untyped
+			// calls return 400 session_id_untyped — so the coordinator
+			// MUST send the typed prefix on every proxy.
 			gwPath := "/admin/explorer/sessions/ext_" + url.PathEscape(external)
 			vs := url.Values{}
 			vs.Set("account_id", account)

--- a/phase4-coordinator/internal/explorer/handlers_test.go
+++ b/phase4-coordinator/internal/explorer/handlers_test.go
@@ -109,7 +109,7 @@ func TestAC07_SessionDetailIncludesLocalAndGatewayData(t *testing.T) {
 			Body:       io.NopCloser(strings.NewReader(`{"request_id":"req_seed","gateway_marker":true,"partial":false,"error":null}`)),
 		}, nil
 	})}
-	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/req_seed", "operator-key")
+	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/int_req_seed", "operator-key")
 	if resp.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
 	}
@@ -156,7 +156,7 @@ func TestSessionDetailGatewayProxyUsesExternalRequestIDAndAccountID(t *testing.T
 			Body:       io.NopCloser(strings.NewReader(`{"request_id":"buyer-supplied-X","partial":false,"error":null}`)),
 		}, nil
 	})}
-	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/coord-internal-uuid-aaaa", "operator-key")
+	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/int_coord-internal-uuid-aaaa", "operator-key")
 	if resp.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
 	}
@@ -203,7 +203,7 @@ func TestSessionDetailGatewayProxySkippedOnIncompleteIdentity(t *testing.T) {
 		gatewayCalled = true
 		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
 	})}
-	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/coord-internal-uuid-legacy", "operator-key")
+	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/int_coord-internal-uuid-legacy", "operator-key")
 	if resp.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
 	}
@@ -232,7 +232,7 @@ func TestSessionDetailNoCoordinatorRowReturns404(t *testing.T) {
 		gatewayCalled = true
 		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
 	})}
-	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/no-such-internal-id", "operator-key")
+	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/int_no-such-internal-id", "operator-key")
 	if resp.Code != http.StatusNotFound {
 		t.Fatalf("status=%d body=%s, want 404", resp.Code, resp.Body.String())
 	}
@@ -807,7 +807,7 @@ func TestDashboardCrossViewLinkWiring(t *testing.T) {
 	raw := readStatic(t, "static/js/dashboard.js")
 	for _, want := range []string{
 		`dataset.view`,
-		`/admin/explorer/sessions/${encodeURIComponent(v)}`,
+		`/admin/explorer/sessions/int_${encodeURIComponent(v)}`,
 		`/admin/explorer/buyers/${encodeURIComponent(v)}`,
 		`/admin/explorer/providers/${encodeURIComponent(v)}`,
 		`/admin/explorer/settlements/${encodeURIComponent(v)}`,
@@ -896,7 +896,7 @@ func TestAC25_CoreExplorerRoutesTraverseSuccessfully(t *testing.T) {
 	for _, path := range []string{
 		"/admin/explorer/overview?include_gateway=false",
 		"/admin/explorer/sessions",
-		"/admin/explorer/sessions/req_seed",
+		"/admin/explorer/sessions/int_req_seed",
 		"/admin/explorer/buyers",
 		"/admin/explorer/providers",
 		"/admin/explorer/providers/provider_seed",

--- a/phase4-coordinator/internal/explorer/handlers_test.go
+++ b/phase4-coordinator/internal/explorer/handlers_test.go
@@ -121,14 +121,15 @@ func TestAC07_SessionDetailIncludesLocalAndGatewayData(t *testing.T) {
 }
 
 // TestSessionDetailGatewayProxyUsesExternalRequestIDAndAccountID pins
-// the ISS-212 v0.3 §5.6 security contract: when the coordinator
-// resolves the path-segment as an internal request_id and the
-// resolved request_log row carries an external_request_id and
-// account_id, the gateway proxy URL MUST be
-// /admin/explorer/sessions/{external_request_id}?account_id=<account_id>.
+// the §5.6 security contract: when the coordinator resolves the
+// path-segment as an internal request_id and the resolved
+// request_log row carries an external_request_id and account_id,
+// the gateway proxy URL MUST be
+// /admin/explorer/sessions/ext_<external_request_id>?account_id=<account_id>.
 // Forwarding the coordinator-internal id risks the gateway
 // interpreting it as a buyer-supplied X-Request-ID and returning a
-// wrong-account 200 (ISS-212 R3 security MEDIUM).
+// wrong-account 200 (ISS-212 R3 security MEDIUM). SPEC-007 v0.5
+// (#245) made the ext_ prefix mandatory.
 func TestSessionDetailGatewayProxyUsesExternalRequestIDAndAccountID(t *testing.T) {
 	h, db := newTestExplorer(t, func(cfg *config.Config) { cfg.Explorer.GatewayBaseURL = "http://gateway.test" })
 	if _, err := db.ExecContext(context.Background(),

--- a/phase4-coordinator/internal/explorer/iss231_test.go
+++ b/phase4-coordinator/internal/explorer/iss231_test.go
@@ -1,10 +1,8 @@
 package explorer
 
 import (
-	"bytes"
 	"context"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"testing"
@@ -16,8 +14,8 @@ import (
 // TestSessionDetail_IntPrefixIsStripped pins SPEC-007 v0.4 §5.6
 // (#231) path-segment typing: the coordinator handler MUST accept
 // an `int_<request_id>` prefix and resolve the stripped value as
-// the coordinator-internal request_id. Backward compatibility is
-// covered by the existing v0.3 tests that pass bare UUIDs.
+// the coordinator-internal request_id. v0.5 (#245) made the prefix
+// the ONLY accepted form — see TestSessionDetail_UntypedReturns400.
 func TestSessionDetail_IntPrefixIsStripped(t *testing.T) {
 	h, db := newTestExplorer(t, nil)
 	if _, err := db.ExecContext(context.Background(),
@@ -32,12 +30,11 @@ func TestSessionDetail_IntPrefixIsStripped(t *testing.T) {
 	}
 }
 
-// TestSessionDetail_UntypedEmitsDeprecationLog pins the v0.4
-// deprecation contract: untyped (bare-UUID) path-segments are still
-// accepted in v0.4 BUT MUST emit a structured
-// payout_explorer_path_segment_untyped log row so operators see
-// the upcoming v0.5 break.
-func TestSessionDetail_UntypedEmitsDeprecationLog(t *testing.T) {
+// TestSessionDetail_UntypedReturns400 pins SPEC-007 v0.5 §5.6
+// (#245): untyped (legacy bare-UUID) path-segments MUST be rejected
+// with 400 session_id_untyped. Replaces the v0.4 deprecation-window
+// log test (which asserted untyped was accepted with a WARN log).
+func TestSessionDetail_UntypedReturns400(t *testing.T) {
 	h, db := newTestExplorer(t, nil)
 	if _, err := db.ExecContext(context.Background(),
 		`INSERT INTO request_log (ts_utc, request_id, external_request_id, account_id, model, latency_ms, routing_ms, status, stream)
@@ -45,52 +42,28 @@ func TestSessionDetail_UntypedEmitsDeprecationLog(t *testing.T) {
 		fixedExplorerTime().Format(time.RFC3339Nano), "untyped-bare-uuid", "", "", "llama", http.StatusOK); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	// Capture stdlib log output (the handler's untyped-deprecation
-	// path uses stdLog.Printf — same mechanism as logBearerAccepted).
-	var buf bytes.Buffer
-	prevOut := log.Writer()
-	log.SetOutput(&buf)
-	defer log.SetOutput(prevOut)
-	prevFlags := log.Flags()
-	log.SetFlags(0)
-	defer log.SetFlags(prevFlags)
-
 	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/untyped-bare-uuid", "operator-key")
-	if resp.Code != http.StatusOK {
-		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s — untyped path-segment MUST return 400", resp.Code, resp.Body.String())
 	}
-	out := buf.String()
-	if !strings.Contains(out, `"event":"payout_explorer_path_segment_untyped"`) {
-		t.Errorf("expected deprecation log line; got: %q", out)
-	}
-	if !strings.Contains(out, `"severity":"WARN"`) {
-		t.Errorf("expected WARN severity; got: %q", out)
-	}
-	if !strings.Contains(out, `"request_id":"untyped-bare-uuid"`) {
-		t.Errorf("expected request_id field; got: %q", out)
+	body := resp.Body.String()
+	if !strings.Contains(body, `"code":"session_id_untyped"`) {
+		t.Errorf("expected session_id_untyped code; body=%s", body)
 	}
 }
 
-// TestSessionDetail_TypedPrefixSuppressesDeprecationLog pins the
-// inverse: when `int_` IS supplied, NO deprecation log fires.
-func TestSessionDetail_TypedPrefixSuppressesDeprecationLog(t *testing.T) {
-	h, db := newTestExplorer(t, nil)
-	if _, err := db.ExecContext(context.Background(),
-		`INSERT INTO request_log (ts_utc, request_id, external_request_id, account_id, model, latency_ms, routing_ms, status, stream)
-		 VALUES (?, ?, ?, ?, ?, 0, 0, ?, 0)`,
-		fixedExplorerTime().Format(time.RFC3339Nano), "typed-uuid-aaaa", "", "", "llama", http.StatusOK); err != nil {
-		t.Fatalf("seed: %v", err)
+// TestSessionDetail_EmptyIntPrefixReturns400 pins that
+// `int_` with nothing after the prefix is treated as untyped
+// (parseTypedSegment-style guard: empty stripped value is not a
+// valid typed segment).
+func TestSessionDetail_EmptyIntPrefixReturns400(t *testing.T) {
+	h, _ := newTestExplorer(t, nil)
+	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/int_", "operator-key")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s — empty int_ prefix MUST 400", resp.Code, resp.Body.String())
 	}
-	var buf bytes.Buffer
-	prevOut := log.Writer()
-	log.SetOutput(&buf)
-	defer log.SetOutput(prevOut)
-	resp := requestExplorer(t, h, http.MethodGet, "/admin/explorer/sessions/int_typed-uuid-aaaa", "operator-key")
-	if resp.Code != http.StatusOK {
-		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
-	}
-	if strings.Contains(buf.String(), "payout_explorer_path_segment_untyped") {
-		t.Errorf("typed prefix MUST NOT emit deprecation log; got: %q", buf.String())
+	if !strings.Contains(resp.Body.String(), `"code":"session_id_untyped"`) {
+		t.Errorf("expected session_id_untyped code; body=%s", resp.Body.String())
 	}
 }
 

--- a/phase4-coordinator/internal/explorer/iss231_test.go
+++ b/phase4-coordinator/internal/explorer/iss231_test.go
@@ -2,13 +2,10 @@ package explorer
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/augstar/macprovider-coordinator/internal/config"
 )
 
 // TestSessionDetail_IntPrefixIsStripped pins SPEC-007 v0.4 §5.6
@@ -50,6 +47,12 @@ func TestSessionDetail_UntypedReturns400(t *testing.T) {
 	if !strings.Contains(body, `"code":"session_id_untyped"`) {
 		t.Errorf("expected session_id_untyped code; body=%s", body)
 	}
+	// R1 SEC LOW-1: envelope MUST carry type=invalid_request_error so
+	// dashboard / runbook matchers behave the same across coordinator
+	// (§5.6) and gateway (§6.4).
+	if !strings.Contains(body, `"type":"invalid_request_error"`) {
+		t.Errorf("expected type=invalid_request_error; body=%s", body)
+	}
 }
 
 // TestSessionDetail_EmptyIntPrefixReturns400 pins that
@@ -67,6 +70,3 @@ func TestSessionDetail_EmptyIntPrefixReturns400(t *testing.T) {
 	}
 }
 
-// ensure unused-import guard
-var _ = io.Discard
-var _ = config.Config{}

--- a/phase4-coordinator/internal/explorer/static/js/dashboard.js
+++ b/phase4-coordinator/internal/explorer/static/js/dashboard.js
@@ -112,11 +112,12 @@ function cell(k, v, row) {
 
 function linkFor(k, v, _row) {
   if (!v) return null;
-  if (k === "request_id") return action("sessions",    `/admin/explorer/sessions/${encodeURIComponent(v)}`, v);
+  // SPEC-007 v0.5 (#245): coordinator-internal request_id MUST be emitted with the `int_` prefix.
+  if (k === "request_id") return action("sessions",    `/admin/explorer/sessions/int_${encodeURIComponent(v)}`, v);
   if (k === "account_id") return action("buyers",      `/admin/explorer/buyers/${encodeURIComponent(v)}`, v);
   if (k === "provider_id") return action("providers",  `/admin/explorer/providers/${encodeURIComponent(v)}`, v);
   if (k === "settlement_id") return action("settlements", `/admin/explorer/settlements/${encodeURIComponent(v)}`, v);
-  if (k === "link_target" && v.startsWith("session:")) return action("sessions", `/admin/explorer/sessions/${encodeURIComponent(v.slice(8))}`, v);
+  if (k === "link_target" && v.startsWith("session:")) return action("sessions", `/admin/explorer/sessions/int_${encodeURIComponent(v.slice(8))}`, v);
   if (k === "link_target" && v.startsWith("buyer:"))   return action("buyers",   `/admin/explorer/buyers/${encodeURIComponent(v.slice(6))}`, v);
   return null;
 }

--- a/phase4-coordinator/internal/explorer/static/js/dashboard.js
+++ b/phase4-coordinator/internal/explorer/static/js/dashboard.js
@@ -112,7 +112,7 @@ function cell(k, v, row) {
 
 function linkFor(k, v, _row) {
   if (!v) return null;
-  // SPEC-007 v0.5 (#245): coordinator-internal request_id MUST be emitted with the `int_` prefix.
+  // SPEC-007 §5.6 v0.5 (#245): coordinator-internal request_id MUST be emitted with the `int_` prefix.
   if (k === "request_id") return action("sessions",    `/admin/explorer/sessions/int_${encodeURIComponent(v)}`, v);
   if (k === "account_id") return action("buyers",      `/admin/explorer/buyers/${encodeURIComponent(v)}`, v);
   if (k === "provider_id") return action("providers",  `/admin/explorer/providers/${encodeURIComponent(v)}`, v);

--- a/phase5-gateway/internal/router/explorer.go
+++ b/phase5-gateway/internal/router/explorer.go
@@ -100,35 +100,15 @@ func (s *Server) handleExplorerSessionDetail(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusNotFound, "invalid_request_error", "not_found", "Explorer resource not found")
 		return
 	}
-	// #231 SPEC-007 v0.4 path-segment typing (deprecation window):
-	// accept `ext_<external_request_id>` prefix as the typed gateway
-	// form. Untyped (bare-id) segments are still resolved AS the
-	// external_request_id (v0.3 behavior) but emit a deprecation
-	// audit row so operators see the upcoming v0.5 break.
+	// SPEC-007 v0.5 (#245): path-segment MUST carry an `ext_` prefix.
+	// Untyped (legacy bare-id) calls return 400 session_id_untyped.
+	// The v0.4 deprecation-window audit emit is removed; that path is
+	// no longer reachable.
 	requestID, typed := parseTypedSegment(rawSegment, "ext_")
 	if !typed {
-		// Fire-and-forget — do not block the request path on audit
-		// emit failure, but surface in audit_events when it works.
-		// json.Marshal-safe payload (R1 SEC MEDIUM closure).
-		// #231 R5 code LOW closure: include request_id + ts_utc in
-		// the payload so a journald-only consumer (no audit_events
-		// row column join) can still see the full event shape per
-		// SPEC §6.4.
-		payloadJSON, _ := json.Marshal(map[string]any{
-			"endpoint":    "GET /admin/explorer/sessions",
-			"request_id":  requestID,
-			"severity":    "WARN",
-			"ts_utc":      s.now().UTC().Format(time.RFC3339Nano),
-			"deprecation": "v0.5 will reject untyped with 400 session_id_untyped — use ext_<external_request_id>",
-		})
-		_ = s.store.InsertAuditEvent(r.Context(), storage.AuditEvent{
-			EventID:   mustID("audit"),
-			RequestID: requestID,
-			Actor:     "explorer",
-			Type:      "payout_explorer_path_segment_untyped",
-			Payload:   string(payloadJSON),
-			CreatedAt: s.now(),
-		})
+		writeError(w, http.StatusBadRequest, "invalid_request_error", "session_id_untyped",
+			"path-segment must be ext_<external_request_id> — bare ids rejected per SPEC-007 v0.5")
+		return
 	}
 	// Issue #196: a request_id can now legitimately match rows in
 	// multiple accounts under the composite-PK schema. Operators

--- a/phase5-gateway/internal/router/iss231_test.go
+++ b/phase5-gateway/internal/router/iss231_test.go
@@ -34,8 +34,9 @@ func TestExplorerSessionDetail_409CapAndTruncationFlag(t *testing.T) {
 		}
 	}
 
+	// SPEC-007 v0.5 (#245): path-segment MUST carry the ext_ prefix.
 	resp := assertStatus(t, h, http.MethodGet,
-		"/admin/explorer/sessions/"+sharedRequestID,
+		"/admin/explorer/sessions/ext_"+sharedRequestID,
 		cfg.Coordinator.OperatorKey, "", "", http.StatusConflict)
 
 	var body map[string]any
@@ -53,7 +54,7 @@ func TestExplorerSessionDetail_409CapAndTruncationFlag(t *testing.T) {
 	// Re-issue the same 409 and confirm the cap holds across calls
 	// (no leftover state from the first invocation).
 	resp2 := assertStatus(t, h, http.MethodGet,
-		"/admin/explorer/sessions/"+sharedRequestID,
+		"/admin/explorer/sessions/ext_"+sharedRequestID,
 		cfg.Coordinator.OperatorKey, "", "", http.StatusConflict)
 	var body2 map[string]any
 	if err := json.Unmarshal(resp2.Body.Bytes(), &body2); err != nil {
@@ -69,15 +70,41 @@ func TestExplorerSessionDetail_409CapAndTruncationFlag(t *testing.T) {
 // typed-prefix contract: `ext_<external_request_id>` strips to the
 // underlying id before SQL lookup. Smoke-tested via the
 // not-found path (no rows seeded) — a successful 404 confirms the
-// prefix strip ran AND the unscoped lookup resolved against the
-// expected bare id.
+// prefix is treated as typed (otherwise the v0.5 untyped guard
+// would have returned 400 instead of 404).
 func TestExplorerSessionDetail_ExtPrefixIsParsed(t *testing.T) {
 	h, _, _, cfg := newTestHarness(t, fakeOAuth{})
-	// Both should produce a 404 (no rows): the typed form proves the
-	// prefix is stripped. If the prefix were NOT stripped, the
-	// storage would look up `ext_<id>` literally — same result, so
-	// we differentiate via the deprecation-audit emit instead.
 	assertStatus(t, h, http.MethodGet,
 		"/admin/explorer/sessions/ext_no-such-id",
 		cfg.Coordinator.OperatorKey, "", "", http.StatusNotFound)
+}
+
+// TestExplorerSessionDetail_UntypedReturns400 pins SPEC-007 v0.5
+// §6.4 (#245): untyped (legacy bare-id) path-segments MUST be
+// rejected with 400 session_id_untyped. Replaces the v0.4
+// deprecation-audit test (which asserted untyped was accepted with
+// a WARN audit_events row).
+func TestExplorerSessionDetail_UntypedReturns400(t *testing.T) {
+	h, _, _, cfg := newTestHarness(t, fakeOAuth{})
+	resp := assertStatus(t, h, http.MethodGet,
+		"/admin/explorer/sessions/untyped-bare-id",
+		cfg.Coordinator.OperatorKey, "", "", http.StatusBadRequest)
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	errBody, _ := body["error"].(map[string]any)
+	if code, _ := errBody["code"].(string); code != "session_id_untyped" {
+		t.Errorf("error.code=%q, want session_id_untyped; body=%s", code, resp.Body.String())
+	}
+}
+
+// TestExplorerSessionDetail_EmptyExtPrefixReturns400 pins that the
+// `ext_` prefix with an empty stripped value is treated as untyped
+// (parseTypedSegment rejects empty stripped IDs).
+func TestExplorerSessionDetail_EmptyExtPrefixReturns400(t *testing.T) {
+	h, _, _, cfg := newTestHarness(t, fakeOAuth{})
+	assertStatus(t, h, http.MethodGet,
+		"/admin/explorer/sessions/ext_",
+		cfg.Coordinator.OperatorKey, "", "", http.StatusBadRequest)
 }

--- a/phase5-gateway/internal/router/iss231_test.go
+++ b/phase5-gateway/internal/router/iss231_test.go
@@ -104,7 +104,15 @@ func TestExplorerSessionDetail_UntypedReturns400(t *testing.T) {
 // (parseTypedSegment rejects empty stripped IDs).
 func TestExplorerSessionDetail_EmptyExtPrefixReturns400(t *testing.T) {
 	h, _, _, cfg := newTestHarness(t, fakeOAuth{})
-	assertStatus(t, h, http.MethodGet,
+	resp := assertStatus(t, h, http.MethodGet,
 		"/admin/explorer/sessions/ext_",
 		cfg.Coordinator.OperatorKey, "", "", http.StatusBadRequest)
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	errBody, _ := body["error"].(map[string]any)
+	if code, _ := errBody["code"].(string); code != "session_id_untyped" {
+		t.Errorf("error.code=%q, want session_id_untyped; body=%s", code, resp.Body.String())
+	}
 }

--- a/specs/AUDIT_ISS245_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS245_ARCHITECT_PROMPT.md
@@ -1,7 +1,7 @@
 # AUDIT — Issue #245 — ARCHITECT lane
 
 ## Goal
-ARCHITECT / SPEC-alignment audit on commit `612c186` (R1 fix-pass on `2743679`) (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+ARCHITECT / SPEC-alignment audit on commit `f41abab` (R2 fix-pass) (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
 
 ## Scope
 

--- a/specs/AUDIT_ISS245_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS245_ARCHITECT_PROMPT.md
@@ -1,7 +1,7 @@
 # AUDIT — Issue #245 — ARCHITECT lane
 
 ## Goal
-ARCHITECT / SPEC-alignment audit on commit `f41abab` (R2 fix-pass) (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+ARCHITECT / SPEC-alignment audit on commit `1dbf876` (R3 fix-pass) (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
 
 ## Scope
 

--- a/specs/AUDIT_ISS245_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS245_ARCHITECT_PROMPT.md
@@ -1,0 +1,52 @@
+# AUDIT — Issue #245 — ARCHITECT lane
+
+## Goal
+ARCHITECT / SPEC-alignment audit on commit `2743679` (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+
+## Scope
+
+- `specs/SPEC-007-explorer.md` — change-log v0.5 entry, §5.6, §6.4
+- Handler code in both phases
+- dashboard.js link emission
+
+## Background
+
+v0.4 (#231) shipped path-segment typing with a deprecation window. The v0.4 SPEC committed to a v0.5 break per three explicit trigger conditions:
+1. 14d telemetry-quiet on `payout_explorer_path_segment_untyped`
+2. Operator UI cutover
+3. Forced 90-day cutoff at ~2026-09-27
+
+The user invoked this flip on 2026-06-30 — only ~1d after v0.4 merged. The dashboard.js update in this PR IS the operator-UI cutover step (trigger #2 retroactively).
+
+## Lens — ARCHITECT
+
+- **Migration risk**: pre-v0.5 callers (operator scripts, runbooks, external bookmarks) that still emit bare-id URLs will receive 400. Was a sweep done for non-dashboard call sites — runbooks under `ops/`, README snippets, integration test fixtures that bypass dashboard.js?
+- **SPEC version semantics**: SPEC-007 jumped v0.4 → v0.5 for a breaking change. The spec corpus convention is v0.X for non-1.0 specs; is the break appropriate at this version level, or should it have waited for v1.0?
+- **§5.6 / §6.4 prose drift**: re-read both sections end-to-end. Are there other paragraphs that still reference the v0.4 deprecation window (mentions of "v0.4 deprecation WARN", "v0.5 will reject", "in v0.4 untyped is accepted")? Stale forward-looking prose is a real ARCH finding.
+- **Cross-spec references**: do any sibling specs (SPEC-005 billing, SPEC-002 coordinator, SPEC-006 buyer API) reference the explorer's `/admin/explorer/sessions/{id}` path shape? If so, do they say "bare id" or "typed prefix"? Drift here is a MEDIUM.
+- **Audit-events schema**: the v0.4 `payout_explorer_path_segment_untyped` event_type is no longer emitted. Does it warrant a SPEC-level "deprecated event_type" registry entry, OR can it be silently dropped because v0.4 was the only place that emitted it?
+- **Dashboard contract**: dashboard.js linkFor now hard-codes the `int_` prefix. This couples the static JS asset to the SPEC-007 v0.5 typing rule. Is the coupling explicit (comment pointing at SPEC §5.6) or implicit?
+- **Audit-prompt convention**: per [[feedback-audit-prompts-file-not-chat]] the audit prompt files MUST stay versioned in `specs/`. Verify this PR includes `specs/AUDIT_ISS245_*_PROMPT.md` so future v0.X bumps can copy-tweak.
+
+## Specific must-check
+
+1. The v0.4 change-log entry contained a paragraph: "**v0.5 (tracked at #245) will reject untyped with `400 session_id_untyped`.**" Does the v0.5 change-log explicitly close that commitment (says "closes the v0.4 deprecation window per the v0.4 §5.6 + §6.4 commitments")?
+2. SPEC-007-explorer-design.md — does it have any path-segment-overload prose that needs to update in lock-step?
+3. The issue #245 body listed 3 trigger conditions. None of telemetry-quiet (14d) or 90-day cutoff are met. The dashboard.js change IS the operator-UI cutover. Should the PR body note this explicitly so future archaeologists understand the override?
+
+## Out of scope
+
+- Style nits (CODE lane)
+- Specific bypass / injection (SECURITY lane)
+
+## Output format
+
+```
+SEVERITY-N (CRITICAL|HIGH|MEDIUM|LOW|INFO) — <one-line title>
+File: <path>:<line>
+Finding: <what>
+Risk / Concern: <why, at architectural layer>
+Recommendation: <concrete fix or "defer to follow-up">
+```
+
+End summary: `C/H/M/L/INFO = a/b/c/d/e`. If 0 C/H/M: `ACCEPT — 0 C/H/M`.

--- a/specs/AUDIT_ISS245_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_ISS245_ARCHITECT_PROMPT.md
@@ -1,7 +1,7 @@
 # AUDIT — Issue #245 — ARCHITECT lane
 
 ## Goal
-ARCHITECT / SPEC-alignment audit on commit `2743679` (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+ARCHITECT / SPEC-alignment audit on commit `612c186` (R1 fix-pass on `2743679`) (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
 
 ## Scope
 

--- a/specs/AUDIT_ISS245_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS245_CODE_PROMPT.md
@@ -1,7 +1,7 @@
 # AUDIT — Issue #245 — CODE lane
 
 ## Goal
-CODE-quality audit on commit `2743679` (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+CODE-quality audit on commit `612c186` (R1 fix-pass on `2743679`) (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
 
 ## Scope (read these files only — do NOT propose changes outside)
 

--- a/specs/AUDIT_ISS245_CODE_PROMPT.md
+++ b/specs/AUDIT_ISS245_CODE_PROMPT.md
@@ -1,0 +1,49 @@
+# AUDIT — Issue #245 — CODE lane
+
+## Goal
+CODE-quality audit on commit `2743679` (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+
+## Scope (read these files only — do NOT propose changes outside)
+
+- `specs/SPEC-007-explorer.md` — change-log row (v0.5), §5.6 path-segment paragraph, §6.4 path-segment paragraph
+- `phase5-gateway/internal/router/explorer.go` — `handleExplorerSessionDetail` (lines ~94-145)
+- `phase4-coordinator/internal/explorer/handlers.go` — `handleSessionDetail` (lines ~180-195); confirm `logPathSegmentUntyped` deleted
+- `phase4-coordinator/internal/explorer/static/js/dashboard.js` — `linkFor` (line ~115, 119)
+- `phase5-gateway/internal/router/iss231_test.go` — TestExplorerSessionDetail_409CapAndTruncationFlag, TestExplorerSessionDetail_ExtPrefixIsParsed, new TestExplorerSessionDetail_UntypedReturns400, new TestExplorerSessionDetail_EmptyExtPrefixReturns400
+- `phase4-coordinator/internal/explorer/iss231_test.go` — TestSessionDetail_IntPrefixIsStripped, new TestSessionDetail_UntypedReturns400, new TestSessionDetail_EmptyIntPrefixReturns400
+- `phase4-coordinator/internal/explorer/handlers_test.go` — TestAC07_SessionDetailIncludesLocalAndGatewayData, TestSessionDetailGatewayProxyUsesExternalRequestIDAndAccountID, TestSessionDetailGatewayProxySkippedOnIncompleteIdentity, TestSessionDetailNoCoordinatorRowReturns404, TestDashboardCrossViewLinkWiring, TestAC25_CoreExplorerRoutesTraverseSuccessfully
+
+## Context
+
+SPEC-007 v0.4 (#231) shipped path-segment typing in deprecation-window mode: `int_<request_id>` (coordinator) and `ext_<external_request_id>` (gateway) prefixes are typed, untyped (bare-id) calls were still accepted but emitted a `payout_explorer_path_segment_untyped` WARN audit row. v0.4 SPEC §5.6 + §6.4 normatively committed that v0.5 would reject untyped with `400 session_id_untyped`.
+
+v0.5 (#245) implements that break:
+- Both handlers return 400 invalid_request_error + code=session_id_untyped on `!typed` (gateway) or `!ok || stripped==""` (coordinator).
+- The v0.4 audit/log emits are deleted (no longer reachable).
+- The coordinator's dashboard.js now emits `int_`-prefixed URLs so coordinator-side navigations don't hit the new 400 gate.
+
+## Lens — CODE
+
+- Style consistency with house conventions
+- Dead code: is anything left over from the deleted `logPathSegmentUntyped` / `payout_explorer_path_segment_untyped` emit path (unused imports, unused fields, vestigial test fixtures)?
+- Symmetry: does the gateway 400 envelope shape match the coordinator's? Both should produce the `session_id_untyped` code; differing keys (`error.code` vs `error.message`) are a CODE finding.
+- Test inversion completeness: do the new tests cover (a) untyped rejected, (b) empty-prefix rejected, AND (c) typed prefix still passes? The latter is the regression guard.
+- dashboard.js migration: are there other static-asset callers of `/admin/explorer/sessions/` that emit untyped URLs (forms, HTMX targets, deep-link templates)?
+- Old test renames vs new test additions — were the v0.4 deprecation-emit tests genuinely replaced (not just commented out)?
+
+## Out of scope
+
+- Security (SECURITY lane) — bypass paths, injection, error-leakage
+- SPEC-alignment (ARCHITECT lane) — invariant ownership, migration plan
+
+## Output format
+
+```
+SEVERITY-N (CRITICAL|HIGH|MEDIUM|LOW|INFO) — <one-line title>
+File: <path>:<line>
+Finding: <what>
+Risk: <why>
+Recommendation: <concrete fix>
+```
+
+At the end: `C/H/M/L/INFO = a/b/c/d/e`. If 0 C/H/M everywhere: `ACCEPT — 0 C/H/M`.

--- a/specs/AUDIT_ISS245_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS245_SECURITY_PROMPT.md
@@ -1,7 +1,7 @@
 # AUDIT — Issue #245 — SECURITY lane
 
 ## Goal
-Adversarial SECURITY audit on commit `2743679` (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+Adversarial SECURITY audit on commit `612c186` (R1 fix-pass on `2743679`) (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
 
 ## Scope
 

--- a/specs/AUDIT_ISS245_SECURITY_PROMPT.md
+++ b/specs/AUDIT_ISS245_SECURITY_PROMPT.md
@@ -1,0 +1,55 @@
+# AUDIT — Issue #245 — SECURITY lane
+
+## Goal
+Adversarial SECURITY audit on commit `2743679` (branch `fix/iss245-spec007-v05-untyped-400`). Bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW + INFO allowed.
+
+## Scope
+
+- `phase5-gateway/internal/router/explorer.go` — `handleExplorerSessionDetail`, `parseTypedSegment`
+- `phase4-coordinator/internal/explorer/handlers.go` — `handleSessionDetail`
+- `phase4-coordinator/internal/explorer/static/js/dashboard.js` — `linkFor`
+- SPEC-007 §5.6 + §6.4 v0.5 paragraphs
+- Test files for both handlers
+
+## Threat model
+
+The path-segment is operator-supplied via the `/admin/explorer/sessions/{id}` URL. Both endpoints are operator-only (bearer-gated). The v0.5 break is about CONTRACT not authentication — a misformed path-segment must be rejected with a predictable envelope rather than accidentally resolving as something else.
+
+Pre-v0.5 the path-segment-overload class was: an untyped value could be interpreted EITHER as a coordinator-internal request_id OR an external_request_id depending on lookup-order. v0.4 added the typed prefix to make the intent explicit. v0.5 closes the deprecation-window so untyped values can no longer revive that ambiguity class.
+
+## Lens — SECURITY
+
+- **400-bypass paths**: is there any path-segment shape that smuggles past `parseTypedSegment` and reaches the SQL lookup without the prefix being stripped? Examples to consider:
+  - URL-encoded prefix: `%69%6e%74%5f<id>` — does the Go HTTP mux normalize this before `r.URL.Path` is read?
+  - Double prefix: `int_int_<id>` — does the stripped value `int_<id>` reach SQL? Acceptable if it just returns 404, problematic if it's interpreted as a "literal int_-prefixed request_id" with a meaning.
+  - Empty `int_` / `ext_` alone — explicitly tested but verify the SPEC matches the code path
+  - Whitespace before prefix: `%20int_<id>` — does `strings.HasPrefix` see it?
+  - Mixed case `Int_`, `EXT_` — current `strings.HasPrefix` is case-sensitive; SPEC should be explicit
+- **Error envelope consistency**: does the 400 carry an `error.code` that the dashboard / runbook can match-on? Could the message field leak attacker-controllable data?
+- **Audit-trail loss**: with the v0.4 `payout_explorer_path_segment_untyped` emit deleted, is there ANY signal that a hostile/buggy caller is hammering untyped URLs? The 400 is logged at the HTTP-server level, but operator visibility is now narrower. Acceptable trade-off, but should be a documented INFO.
+- **Forensic cap path** (gateway): the 409 ambiguity audit emit (`explorer_matched_account_ids_truncated`) is preserved and reachable only when the request DID pass the typed-prefix gate. Verify the v0.5 flip didn't reorder code such that the forensic emit accidentally fires before validation.
+- **dashboard.js**: is there a path where the dashboard emits a bare-id URL that an operator could click and silently hit 400, AND that the operator wouldn't recognize as a v0.5 break (e.g. they see "session lookup failed" without context)? UX-not-security but flag if confusing.
+- **Audit-replay risk**: pre-v0.5 audit_events rows of type `payout_explorer_path_segment_untyped` remain in the gateway DB. After this PR ships, can any operator runbook still trigger that event name? No — but verify no test seeds the old event type and asserts emission.
+
+## Specific must-check
+
+1. Path normalization: confirm Go's `net/http` mux does NOT decode `%2F` etc. before path-routing; `strings.Contains(rawSegment, "/")` early-rejects any URL-encoded slash collision.
+2. Symmetry: gateway uses `parseTypedSegment` helper; coordinator inlines `strings.CutPrefix`. Different implementations of the same gate — any divergent acceptance shape?
+3. SPEC says "the stripped value is empty (`int_` alone)" — does the code actually reject `int_` (the empty-strip case)? Coordinator: yes (`stripped == ""` branch). Gateway: parseTypedSegment returns `(raw, false)` when stripped empty — confirm.
+
+## Out of scope
+
+- Code style (CODE lane)
+- Layering / placement (ARCHITECT lane)
+
+## Output format
+
+```
+SEVERITY-N (CRITICAL|HIGH|MEDIUM|LOW|INFO) — <one-line title>
+File: <path>:<line>
+Finding: <what>
+Risk: <why, cite threat model>
+Recommendation: <concrete fix>
+```
+
+End summary: `C/H/M/L/INFO = a/b/c/d/e`. If 0 C/H/M: `ACCEPT — 0 C/H/M`.

--- a/specs/SPEC-007-explorer-design.md
+++ b/specs/SPEC-007-explorer-design.md
@@ -721,30 +721,37 @@ Filters:
 - `from` - `to` - `status` - `model` - `provider_id` - `account_id` - `request_id` - `error_code` - `quarantined` -
 `limit` - `cursor`
 
-`GET /admin/explorer/sessions/{request_id}`
+`GET /admin/explorer/sessions/int_{request_id}`
 
-Path segment (v0.3):
+Path segment (v0.5 — #245, normative typed prefix):
 
-- `{request_id}` is the coordinator-internal `request_log.request_id`
+- The path-segment MUST carry the `int_` prefix; the underlying
+  value is the coordinator-internal `request_log.request_id`
   (server-minted UUID v4). It is NOT the buyer-supplied
   `X-Request-ID` — that lives in `request_log.external_request_id`.
-  Operators starting from a buyer-facing ticket carrying an
-  `X-Request-ID` MUST resolve the internal id via direct SQL in
-  v0.3 (UI surface for external-id lookup is deferred to v0.4).
-  See SPEC-007 §5.6 v0.3.
+  Untyped (legacy bare-id) calls are rejected with
+  `400 invalid_request_error` + `code: session_id_untyped` per
+  SPEC-007 §5.6 v0.5. Operators starting from a buyer-facing
+  ticket carrying an `X-Request-ID` resolve the internal id
+  either via direct SQL or via the gateway's `?account_id=`-
+  scoped lookup; the coordinator-side dashboard emits typed
+  `int_`-prefixed URLs by construction (see
+  `phase4-coordinator/internal/explorer/static/js/dashboard.js`
+  `linkFor`).
 
-Gateway proxy (v0.3 both-or-nothing):
+Gateway proxy (v0.5 both-or-nothing + typed):
 
 - The coordinator forwards
-  `GET /admin/explorer/sessions/<external_request_id>?account_id=<account_id>`
-  to the gateway ONLY when the resolved coordinator row supplies
-  BOTH a non-empty `external_request_id` AND a non-empty
-  `account_id`. Otherwise the coordinator does NOT proxy and the
-  response carries `gateway: {"error": {"code":
+  `GET /admin/explorer/sessions/ext_<external_request_id>?account_id=<account_id>`
+  (typed `ext_` prefix per SPEC-007 §6.4 v0.5) to the gateway
+  ONLY when the resolved coordinator row supplies BOTH a
+  non-empty `external_request_id` AND a non-empty `account_id`.
+  Otherwise the coordinator does NOT proxy and the response
+  carries `gateway: {"error": {"code":
   "gateway_identity_unavailable"}}`. Gateway-side ambiguity is
-  documented in SPEC-007 §6.4 v0.3 — the coordinator surface
-  never exposes the 409 itself in v0.3 (the path-segment-overload
-  + 409 surfacing is deferred to v0.4).
+  documented in SPEC-007 §6.4 — the coordinator surface
+  surfaces a coordinator-resolved 200 (with the proxy result
+  embedded) or a 404 when no coordinator row matches.
 
 Returns:
 

--- a/specs/SPEC-007-explorer.md
+++ b/specs/SPEC-007-explorer.md
@@ -8,7 +8,7 @@ settlement mutator. It is not a parallel analytics store.
 ## 1. Change log
 | Version | Date | Author | Summary |
 |---|---|---|---|
-| v0.5 | 2026-06-30 | docs+impl (ISS-245) | Closes the v0.4 deprecation window per the v0.4 §5.6 + §6.4 commitments. **§5.6 + §6.4 (path-segment typing, break mode):** the `{request_id}` path-segment MUST carry a typed prefix — `int_<coordinator-internal request_id>` for §5.6, `ext_<external_request_id>` for §6.4. Untyped (legacy bare-id) calls are rejected with `400 invalid_request_error` + `code: session_id_untyped`. The v0.4 `payout_explorer_path_segment_untyped` audit/log emit is removed because the path is no longer reachable. **IMPL:** `phase5-gateway/internal/router/explorer.go::handleExplorerSessionDetail` and `phase4-coordinator/internal/explorer/handlers.go::handleSessionDetail` return 400 when `parseTypedSegment` reports `typed=false` (gateway) or `strings.CutPrefix("int_")` returns `ok=false || stripped==""` (coordinator). `Handler.logPathSegmentUntyped` deleted (no longer reachable). `phase4-coordinator/internal/explorer/static/js/dashboard.js` `linkFor` emits `/admin/explorer/sessions/int_${encodeURIComponent(v)}` for both `request_id` columns and `link_target: session:` rows so coordinator-dashboard navigations match the new typed-prefix contract. **Tests:** `TestSessionDetail_UntypedReturns400` + `TestSessionDetail_EmptyIntPrefixReturns400` (coordinator) and `TestExplorerSessionDetail_UntypedReturns400` + `TestExplorerSessionDetail_EmptyExtPrefixReturns400` (gateway) replace the v0.4 deprecation-emit tests. Pre-v0.5 callers that still pass bare ids will receive 400 — operators MUST migrate to typed prefixes (the coordinator dashboard already emits them as of v0.5). |
+| v0.5 | 2026-06-30 | docs+impl (ISS-245) | Closes the v0.4 deprecation window per the v0.4 §5.6 + §6.4 commitments. **Trigger:** issue #245's option (2) — operator UI cutover — satisfied by this PR's dashboard.js change (the only first-party operator UI). Telemetry-quiet (14d) and 90-day cutoff triggers did NOT fire — the dashboard cutover IS the cutover. **§5.6 + §6.4 (path-segment typing, break mode):** the `{request_id}` path-segment MUST carry a typed prefix — `int_<coordinator-internal request_id>` for §5.6, `ext_<external_request_id>` for §6.4. Untyped (legacy bare-id) calls are rejected with `400 invalid_request_error` + `code: session_id_untyped`. The v0.4 `payout_explorer_path_segment_untyped` audit/log emit is removed because the path is no longer reachable. **IMPL:** `phase5-gateway/internal/router/explorer.go::handleExplorerSessionDetail` and `phase4-coordinator/internal/explorer/handlers.go::handleSessionDetail` return 400 when `parseTypedSegment` reports `typed=false` (gateway) or `strings.CutPrefix("int_")` returns `ok=false || stripped==""` (coordinator). `Handler.logPathSegmentUntyped` deleted (no longer reachable). `phase4-coordinator/internal/explorer/static/js/dashboard.js` `linkFor` emits `/admin/explorer/sessions/int_${encodeURIComponent(v)}` for both `request_id` columns and `link_target: session:` rows so coordinator-dashboard navigations match the new typed-prefix contract. **Tests:** `TestSessionDetail_UntypedReturns400` + `TestSessionDetail_EmptyIntPrefixReturns400` (coordinator) and `TestExplorerSessionDetail_UntypedReturns400` + `TestExplorerSessionDetail_EmptyExtPrefixReturns400` (gateway) replace the v0.4 deprecation-emit tests. Pre-v0.5 callers that still pass bare ids will receive 400 — operators MUST migrate to typed prefixes (the coordinator dashboard already emits them as of v0.5). |
 | v0.4 | 2026-06-29 | docs+impl (ISS-231) | Closes the v0.3 R2 architect lane deferrals from PR #221. **§6.4 v0.4 audit payload:** when truncation fires the gateway emits a bounded forensic sample (cap `N_forensic=100`, scan probed at `N_forensic+1`) to `audit_events` — NOT an unbounded list (closes R1 SEC HIGH collision-flood DoS; an operator-runbook offline-query is the recovery path when a deeper sample is needed). **R1 audit deferrals** (filed as separate follow-ups, not blocking v0.4): (a) SPEC-007 centralized event table — A future SPEC-007 vN.M+1 should add a §-level event registry analogous to SPEC-016 §7.1 so BetterStack alert filters catch new event names by convention. (b) `payout_explorer_path_segment_untyped` channel asymmetry — gateway emits to audit_events DB rows; coordinator emits to journald JSON via stdlib log. Runbook should reflect both. (c) Near-cap 409 audit — only the truncated 409 path emits an audit row; 2–9 account ambiguities are still visible only via the response. The v0.5 break (#245) is the natural place to revisit. **R4 SEC MEDIUM deferred to #246**: the five session-detail fetch helpers (usage_events / quota_reservations / concurrency_reservations / feedback_events / audit_events) use an optional-predicate `(? = '' OR request_id = ?)` shape so the same prepared statement serves both scoped and unscoped paths. SQLite plans this as `SCAN`. Tracked at #246 (not blocking v0.4 — the ambiguity probe AND scoped-path are now indexed; the unscoped 200 path is auth-gated and not a hot path). **R1 closures absorbed in v0.4:** bounded forensic SELECT at N_forensic=100+1 entries (closes SEC HIGH collision-flood DoS class — the unbounded variant was the wrong primitive); `json.Marshal` for ALL audit/log JSON payloads (closes SEC MEDIUM hand-rolled escape gap — C0 controls and U+2028/U+2029 are now correctly handled); `omitempty` dropped from `MatchedAccountIDsTruncated` DTO so a future direct serialization keeps the field present (closes ARCH LOW); cap=10 documented as a security invariant, not an operator knob (closes ARCH LOW); v0.5 break filed as issue #245 with concrete trigger conditions (closes ARCH MEDIUM-2). **§6.4 (gateway session-detail):** `matched_account_ids` MUST be capped at N=10 entries in the 409 ambiguity response; the SQL UNION carries `LIMIT 11` so the handler detects overflow without inflating the row set. When the underlying union produces >10 distinct account_ids the response MUST include `"matched_account_ids_truncated": true` and the gateway MUST emit an `audit_events` row at WARN with a bounded forensic sample (post-hoc investigation; bound N_forensic=100 per §6.4). Bounds operator log noise + protects the 409 response body against malicious collision floods. **§5.6 + §6.4 (path-segment typing, deprecation-window mode):** the `{request_id}` path-segment MAY now carry a typed prefix — `int_<coordinator-internal request_id>` for §5.6, `ext_<external_request_id>` for §6.4. Untyped (legacy bare-id) calls remain accepted in v0.4 BUT both handlers MUST emit a `payout_explorer_path_segment_untyped` audit row (severity=WARN, fields: `endpoint, request_id, ts_utc`) to surface the deprecation. **v0.5 (tracked at #245) will reject untyped with `400 session_id_untyped`.** Typed-prefix mode closes the path-segment-overload class properly — pre-v0.3 lookup-order disambiguation is no longer the contract authority. **IMPL:** `phase5-gateway/internal/storage/sqlite/explorer.go::explorerAccountIDsForRequest` gains `LIMIT 11`; gateway 409 handler computes the truncation flag + emits the WARN audit row; gateway + coordinator session-detail handlers parse the typed prefix when present and emit deprecation WARN when untyped. **Tests:** `TestExplorerAccountIDsForRequest_CapAt10WithTruncationFlag`, `TestExplorerSessionDetail_TypedPrefixIsParsedCorrectly`, `TestExplorerSessionDetail_UntypedEmitsDeprecationAudit` pin the new contracts. Three-lane codex audit findings in `specs/SPEC-007-v0-4-audit.md`. |
 | v0.3 | 2026-06-29 | docs+impl (ISS-212) | Composite-PK addendum reflecting the gateway PK schema landed in #196 + the coordinator-side composite reconciliation key landed in #211 (PR #224 / SPEC-002 v1.5.0). **§6.4 (gateway session-detail):** `(account_id, request_id)` is the physical identity for `usage_events`, `quota_reservations`, `concurrency_reservations`, `feedback_events`, and `audit_events`; `request_id` alone is only a logical join key. Optional `?account_id=` disambiguation query parameter; `409 ambiguous_request_id` response with `matched_account_ids[]` computed over ALL FIVE account-keyed session-detail tables (R2: extended from the three reservation/usage tables to include feedback_events and audit_events — buyer-attachable feedback would otherwise cross-pollinate a 200 response). Window-contract split between scoped/unscoped paths; `idx_usage_request` supports the unscoped path. Forbidden-fields block. **§6.1:** endpoint-specific error-exception note covering §6.4's OpenAI-compatible 409 envelope. **§5.6 (coordinator session-detail):** path-segment is the coordinator-internal `request_id` only in v0.3 (path-segment overload deferred to v0.4). Both-or-nothing gateway-proxy rule: the coordinator MUST forward `external_request_id` + `?account_id=` (NOT the internal id) when proxying, and MUST NOT proxy when either field is missing on the resolved row — incomplete-identity rows return `gateway: {"error": {"code": "gateway_identity_unavailable"}}` with `partial=false` and full coordinator-side detail. Unknown coordinator-internal `request_id` returns 404 regardless of gateway data. §14.7.1 added to document the new identity-unavailable failure mode; UI MUST distinguish it from `gateway_unavailable`. **§7.5 (cross-component join keys):** rewritten to split intra-coordinator joins (on internal `request_id`) from cross-service joins (on the composite `(account_id, external_request_id)` ⇔ `(account_id, request_id)`). **AC-7:** updated to seed coordinator rows carrying composite identity, assert gateway proxy uses `external_request_id` + `?account_id=` (not the internal id), exercise the cross-account isolation case (two coordinator rows with the same external_request_id route to different accounts), and exercise the legacy NULL-account "no proxy → gateway_identity_unavailable" sub-case. **IMPL:** `phase5-gateway/internal/storage/sqlite/explorer.go` `explorerAccountIDsForRequest` extended to union all five tables; new regression `TestExplorerSessionDetailAmbiguityExtendedToFeedbackAndAudit` pins the feedback/audit cross-pollination guard. **Paired:** SPEC-007-explorer-design.md §2.8 GAP-closed pointer updated to SPEC-002 v1.5.0 / #211. Three-lane codex audit findings + dispositions in `specs/SPEC-007-v0-3-audit.md`. |
 | triage 2026-06-26 | 2026-06-26 | docs/OPEN_QUESTIONS.md | M-3 through M-12 (deferred-to-v0.3 audit findings) closed as unrecoverable — the underlying audit document was never persisted to the repo and the findings list is not reconstructible from history. If operator-explorer concerns recur, run a fresh audit cycle and number anew. No version bump; no normative change. |
@@ -404,38 +404,45 @@ Error behavior:
 - Invalid date range MUST return 400.
 - Local timeout MUST return 408.
 - Gateway failure MUST return 200 with `partial=true` when local data succeeds.
-### 5.6 `GET /admin/explorer/sessions/{request_id}`
+### 5.6 `GET /admin/explorer/sessions/int_{request_id}`
 Method and path:
-- `GET /admin/explorer/sessions/{request_id}`.
+- `GET /admin/explorer/sessions/int_{request_id}`.
 Purpose:
 - Return one completed request's attempts and all read-only joined context.
-Identity model (v0.3):
-- The path-segment `{request_id}` is the coordinator-internal
+Identity model (v0.5 — #245):
+- The path-segment MUST be `int_<request_id>`. The underlying
+  `<request_id>` is the coordinator-internal
   `request_log.request_id` (UUID v4 minted server-side per buyer
   request — see SPEC-002 v1.5.0 §11). It is NOT the inbound
   `X-Request-ID`; that buyer-supplied value lives in
-  `request_log.external_request_id`. **v0.3 limitation:** the
-  explorer has no UI / endpoint surface for resolving by
-  `external_request_id` (the §5.5 sessions list does not yet
-  filter by it either). An operator who starts from a buyer-facing
-  ticket carrying a buyer-supplied `X-Request-ID` MUST resolve
-  the corresponding internal `request_id` out-of-band (direct
-  SQL against the operator's SQLite copy:
+  `request_log.external_request_id`. Untyped (legacy bare-UUID)
+  calls are rejected with `400 invalid_request_error` +
+  `code: session_id_untyped` (see Path-segment-overload status
+  below).
+- An operator who starts from a buyer-facing ticket carrying a
+  buyer-supplied `X-Request-ID` either resolves the corresponding
+  internal `request_id` out-of-band (direct SQL against the
+  operator's SQLite copy:
   `SELECT request_id FROM request_log WHERE external_request_id = ? AND account_id = ?`)
-  before navigating to the session-detail surface. The v0.4
-  path-segment-overload future enhancement will surface this in
-  the UI (see "Deferred to v0.4" below).
+  before navigating, OR navigates directly to the gateway-side
+  endpoint (§6.4) under `ext_<external_request_id>` +
+  `?account_id=`. The coordinator-side dashboard emits
+  `int_`-prefixed URLs by construction (see
+  `phase4-coordinator/internal/explorer/static/js/dashboard.js`
+  `linkFor`).
 - For gateway proxy to `GET /admin/explorer/sessions/...` on the
   gateway, the coordinator MUST proxy ONLY when the resolved row
   supplies BOTH a non-empty `external_request_id` AND a non-empty
-  `account_id`. In that case it MUST forward
-  `GET /admin/explorer/sessions/<external_request_id>?account_id=<account_id>`
-  using a real HTTP query parameter (NOT a path-escaped string).
-  When either component is missing (legacy pre-v1.5.0-coordinator
-  row, v1.5.0 row written from a pre-v0.9.1 gateway, or a
-  direct legacy buyer call with no `X-Request-ID`), the
-  coordinator MUST NOT proxy — it returns the coordinator-side
-  detail with a `gateway` object of shape
+  `account_id`. In that case it MUST forward the typed
+  `GET /admin/explorer/sessions/ext_<external_request_id>?account_id=<account_id>`
+  (typed `ext_` prefix is mandatory per §6.4 v0.5; the gateway
+  rejects untyped calls with the same `400 session_id_untyped`
+  envelope), using a real HTTP query parameter (NOT a
+  path-escaped string). When either component is missing (legacy
+  pre-v1.5.0-coordinator row, v1.5.0 row written from a
+  pre-v0.9.1 gateway, or a direct legacy buyer call with no
+  `X-Request-ID`), the coordinator MUST NOT proxy — it returns
+  the coordinator-side detail with a `gateway` object of shape
   `{"error":{"code":"gateway_identity_unavailable"}}`. Forwarding
   with a partial key — unscoped `external_request_id`, OR the
   coordinator-internal `request_id` — would risk the gateway
@@ -463,15 +470,15 @@ Headers:
 - `Authorization: Bearer <coordinator operator bearer>` is required.
 Query parameters:
 - `include_gateway`: optional boolean, default `true`.
-- `account_id`: (v0.4, deferred) optional disambiguator for the
-  path-segment-overload future enhancement; ignored in v0.3.
 Window contract:
 - No time window is required because `request_id` is an indexed key.
-Ambiguity contract (v0.3):
-- v0.3 path-segment is the coordinator-internal `request_id`
-  (UUID v4, unique by construction); 409 cannot fire on this
-  path. The 409 contract is reserved for the v0.4 path-segment-
-  overload future enhancement; see "Deferred to v0.4" above.
+Ambiguity contract:
+- The coordinator path-segment is the coordinator-internal
+  `request_id` (UUID v4, unique by construction); 409 cannot
+  fire on this path. The 409 `ambiguous_request_id` contract is
+  exclusive to the gateway-side endpoint (§6.4) under
+  `ext_<external_request_id>` where the same buyer-supplied
+  X-Request-ID can legitimately appear under multiple accounts.
 - Per the both-or-nothing proxy contract in Identity model, the
   coordinator does NOT fall back to forwarding the
   coordinator-internal `request_id` to the gateway when the
@@ -2530,8 +2537,8 @@ Partial data responses MUST include:
 - `warnings[]`.
 - a source-specific error object where practical.
 Partial data MUST NOT silently omit a failed source.
-### 14.7.1 Gateway-section identity unavailable (v0.3, §5.6)
-The session-detail endpoint MAY return HTTP 200 with `partial: false` AND a gateway section of shape `{"error": {"code": "gateway_identity_unavailable"}}`. This is NOT a partial-data state and NOT a gateway failure. It is the documented outcome when the resolved coordinator `request_log` row lacks `external_request_id`, `account_id`, or both — a legacy-identity-limit on pre-v1.5.0-coordinator rows or v1.5.0 rows written from a pre-v0.9.1 gateway. Coordinator-side detail (attempts, ledger rows, identity snapshots) is fully populated. Retrying does NOT make the gateway data appear; the operator's path is to query gateway storage out-of-band by `external_request_id` (or wait for the v0.4 path-segment-overload that will surface this in the UI). UI rendering MUST distinguish this state from `gateway_unavailable` so it does not appear as a retryable failure.
+### 14.7.1 Gateway-section identity unavailable (§5.6)
+The session-detail endpoint MAY return HTTP 200 with `partial: false` AND a gateway section of shape `{"error": {"code": "gateway_identity_unavailable"}}`. This is NOT a partial-data state and NOT a gateway failure. It is the documented outcome when the resolved coordinator `request_log` row lacks `external_request_id`, `account_id`, or both — a legacy-identity-limit on pre-v1.5.0-coordinator rows or v1.5.0 rows written from a pre-v0.9.1 gateway. Coordinator-side detail (attempts, ledger rows, identity snapshots) is fully populated. Retrying does NOT make the gateway data appear; the operator's path is to navigate directly to the gateway-side endpoint (§6.4) under `ext_<external_request_id>` + `?account_id=`, or to query gateway storage out-of-band by `external_request_id`. UI rendering MUST distinguish this state from `gateway_unavailable` so it does not appear as a retryable failure.
 ### 14.8 Cancellation paths
 If the operator navigates away, the browser SHOULD abort in-flight fetches. The coordinator MUST propagate request context cancellation to SQLite queries and gateway proxy calls. The gateway MUST propagate request context cancellation to SQLite queries. Cancelled requests MUST NOT mutate state.
 ## 15. Acceptance criteria

--- a/specs/SPEC-007-explorer.md
+++ b/specs/SPEC-007-explorer.md
@@ -163,6 +163,7 @@ The coordinator MUST serve a small static bundle under `/admin/explorer/`. The b
 ### 4.7 Read-only invariant
 Every `/admin/explorer/*` route MUST be side-effect-free. Every `/admin/explorer/*` route MUST use `GET`. Every non-`GET` request to `/admin/explorer/*` MUST return 405 or 404. Explorer handlers MUST NOT call mutating coordinator functions. Explorer handlers MUST NOT call mutating gateway functions. Explorer handlers MUST NOT insert, update, or delete rows. Explorer handlers MUST NOT trigger SPEC-005 reconciliation writes.
 ## 5. Read-only endpoint surface (coordinator)
+**Route-template notation:** In §5 and §6 the `{request_id}` route-template segment is the typed form per SPEC-007 v0.5 (#245) — `int_<request_id>` for coordinator endpoints (§5.6), `ext_<external_request_id>` for gateway endpoints (§6.4). Untyped (bare-id) calls return `400 invalid_request_error` + `code: session_id_untyped`. Inventory tables (§8, §12, §13) reuse the `{request_id}` placeholder for brevity; the typed-prefix requirement applies in every call site.
 ### 5.1 Common coordinator endpoint contract
 All coordinator explorer API endpoints live under `/admin/explorer/*`.
 All coordinator explorer API endpoints MUST require:
@@ -1356,9 +1357,9 @@ Underlying gateway tables:
 Forbidden fields:
 - `api_keys.key_hash` MUST NOT be returned.
 - `demo_usage_events.demo_token_hash` MUST NOT be returned.
-### 6.4 `GET /admin/explorer/sessions/{request_id}`
+### 6.4 `GET /admin/explorer/sessions/ext_{external_request_id}`
 Method and path:
-- `GET /admin/explorer/sessions/{request_id}`.
+- `GET /admin/explorer/sessions/ext_{external_request_id}`.
 Purpose:
 - Return gateway-owned request context for a completed request.
 Identity model:

--- a/specs/SPEC-007-explorer.md
+++ b/specs/SPEC-007-explorer.md
@@ -1,13 +1,14 @@
 # SPEC-007 - Internal Operator Protocol Explorer
 Dependency lines: depends on `specs/SPEC-002-coordinator.md`, `specs/SPEC-005-billing.md`, `specs/SPEC-006-buyer-api.md`, `specs/SPEC-007-explorer-design.md`, and `specs/SPEC-007-operator-decisions.md`.
 Normative language in this document uses RFC 2119 meanings for MUST, MUST NOT, SHOULD,
-SHOULD NOT, and MAY. SPEC-007 v0.4 defines an internal, read-only,
+SHOULD NOT, and MAY. SPEC-007 v0.5 defines an internal, read-only,
 single-operator explorer for the Mac Provider protocol. The explorer is an operator
 cockpit. It is not a public explorer. It is not a control plane. It is not a
 settlement mutator. It is not a parallel analytics store.
 ## 1. Change log
 | Version | Date | Author | Summary |
 |---|---|---|---|
+| v0.5 | 2026-06-30 | docs+impl (ISS-245) | Closes the v0.4 deprecation window per the v0.4 §5.6 + §6.4 commitments. **§5.6 + §6.4 (path-segment typing, break mode):** the `{request_id}` path-segment MUST carry a typed prefix — `int_<coordinator-internal request_id>` for §5.6, `ext_<external_request_id>` for §6.4. Untyped (legacy bare-id) calls are rejected with `400 invalid_request_error` + `code: session_id_untyped`. The v0.4 `payout_explorer_path_segment_untyped` audit/log emit is removed because the path is no longer reachable. **IMPL:** `phase5-gateway/internal/router/explorer.go::handleExplorerSessionDetail` and `phase4-coordinator/internal/explorer/handlers.go::handleSessionDetail` return 400 when `parseTypedSegment` reports `typed=false` (gateway) or `strings.CutPrefix("int_")` returns `ok=false || stripped==""` (coordinator). `Handler.logPathSegmentUntyped` deleted (no longer reachable). `phase4-coordinator/internal/explorer/static/js/dashboard.js` `linkFor` emits `/admin/explorer/sessions/int_${encodeURIComponent(v)}` for both `request_id` columns and `link_target: session:` rows so coordinator-dashboard navigations match the new typed-prefix contract. **Tests:** `TestSessionDetail_UntypedReturns400` + `TestSessionDetail_EmptyIntPrefixReturns400` (coordinator) and `TestExplorerSessionDetail_UntypedReturns400` + `TestExplorerSessionDetail_EmptyExtPrefixReturns400` (gateway) replace the v0.4 deprecation-emit tests. Pre-v0.5 callers that still pass bare ids will receive 400 — operators MUST migrate to typed prefixes (the coordinator dashboard already emits them as of v0.5). |
 | v0.4 | 2026-06-29 | docs+impl (ISS-231) | Closes the v0.3 R2 architect lane deferrals from PR #221. **§6.4 v0.4 audit payload:** when truncation fires the gateway emits a bounded forensic sample (cap `N_forensic=100`, scan probed at `N_forensic+1`) to `audit_events` — NOT an unbounded list (closes R1 SEC HIGH collision-flood DoS; an operator-runbook offline-query is the recovery path when a deeper sample is needed). **R1 audit deferrals** (filed as separate follow-ups, not blocking v0.4): (a) SPEC-007 centralized event table — A future SPEC-007 vN.M+1 should add a §-level event registry analogous to SPEC-016 §7.1 so BetterStack alert filters catch new event names by convention. (b) `payout_explorer_path_segment_untyped` channel asymmetry — gateway emits to audit_events DB rows; coordinator emits to journald JSON via stdlib log. Runbook should reflect both. (c) Near-cap 409 audit — only the truncated 409 path emits an audit row; 2–9 account ambiguities are still visible only via the response. The v0.5 break (#245) is the natural place to revisit. **R4 SEC MEDIUM deferred to #246**: the five session-detail fetch helpers (usage_events / quota_reservations / concurrency_reservations / feedback_events / audit_events) use an optional-predicate `(? = '' OR request_id = ?)` shape so the same prepared statement serves both scoped and unscoped paths. SQLite plans this as `SCAN`. Tracked at #246 (not blocking v0.4 — the ambiguity probe AND scoped-path are now indexed; the unscoped 200 path is auth-gated and not a hot path). **R1 closures absorbed in v0.4:** bounded forensic SELECT at N_forensic=100+1 entries (closes SEC HIGH collision-flood DoS class — the unbounded variant was the wrong primitive); `json.Marshal` for ALL audit/log JSON payloads (closes SEC MEDIUM hand-rolled escape gap — C0 controls and U+2028/U+2029 are now correctly handled); `omitempty` dropped from `MatchedAccountIDsTruncated` DTO so a future direct serialization keeps the field present (closes ARCH LOW); cap=10 documented as a security invariant, not an operator knob (closes ARCH LOW); v0.5 break filed as issue #245 with concrete trigger conditions (closes ARCH MEDIUM-2). **§6.4 (gateway session-detail):** `matched_account_ids` MUST be capped at N=10 entries in the 409 ambiguity response; the SQL UNION carries `LIMIT 11` so the handler detects overflow without inflating the row set. When the underlying union produces >10 distinct account_ids the response MUST include `"matched_account_ids_truncated": true` and the gateway MUST emit an `audit_events` row at WARN with a bounded forensic sample (post-hoc investigation; bound N_forensic=100 per §6.4). Bounds operator log noise + protects the 409 response body against malicious collision floods. **§5.6 + §6.4 (path-segment typing, deprecation-window mode):** the `{request_id}` path-segment MAY now carry a typed prefix — `int_<coordinator-internal request_id>` for §5.6, `ext_<external_request_id>` for §6.4. Untyped (legacy bare-id) calls remain accepted in v0.4 BUT both handlers MUST emit a `payout_explorer_path_segment_untyped` audit row (severity=WARN, fields: `endpoint, request_id, ts_utc`) to surface the deprecation. **v0.5 (tracked at #245) will reject untyped with `400 session_id_untyped`.** Typed-prefix mode closes the path-segment-overload class properly — pre-v0.3 lookup-order disambiguation is no longer the contract authority. **IMPL:** `phase5-gateway/internal/storage/sqlite/explorer.go::explorerAccountIDsForRequest` gains `LIMIT 11`; gateway 409 handler computes the truncation flag + emits the WARN audit row; gateway + coordinator session-detail handlers parse the typed prefix when present and emit deprecation WARN when untyped. **Tests:** `TestExplorerAccountIDsForRequest_CapAt10WithTruncationFlag`, `TestExplorerSessionDetail_TypedPrefixIsParsedCorrectly`, `TestExplorerSessionDetail_UntypedEmitsDeprecationAudit` pin the new contracts. Three-lane codex audit findings in `specs/SPEC-007-v0-4-audit.md`. |
 | v0.3 | 2026-06-29 | docs+impl (ISS-212) | Composite-PK addendum reflecting the gateway PK schema landed in #196 + the coordinator-side composite reconciliation key landed in #211 (PR #224 / SPEC-002 v1.5.0). **§6.4 (gateway session-detail):** `(account_id, request_id)` is the physical identity for `usage_events`, `quota_reservations`, `concurrency_reservations`, `feedback_events`, and `audit_events`; `request_id` alone is only a logical join key. Optional `?account_id=` disambiguation query parameter; `409 ambiguous_request_id` response with `matched_account_ids[]` computed over ALL FIVE account-keyed session-detail tables (R2: extended from the three reservation/usage tables to include feedback_events and audit_events — buyer-attachable feedback would otherwise cross-pollinate a 200 response). Window-contract split between scoped/unscoped paths; `idx_usage_request` supports the unscoped path. Forbidden-fields block. **§6.1:** endpoint-specific error-exception note covering §6.4's OpenAI-compatible 409 envelope. **§5.6 (coordinator session-detail):** path-segment is the coordinator-internal `request_id` only in v0.3 (path-segment overload deferred to v0.4). Both-or-nothing gateway-proxy rule: the coordinator MUST forward `external_request_id` + `?account_id=` (NOT the internal id) when proxying, and MUST NOT proxy when either field is missing on the resolved row — incomplete-identity rows return `gateway: {"error": {"code": "gateway_identity_unavailable"}}` with `partial=false` and full coordinator-side detail. Unknown coordinator-internal `request_id` returns 404 regardless of gateway data. §14.7.1 added to document the new identity-unavailable failure mode; UI MUST distinguish it from `gateway_unavailable`. **§7.5 (cross-component join keys):** rewritten to split intra-coordinator joins (on internal `request_id`) from cross-service joins (on the composite `(account_id, external_request_id)` ⇔ `(account_id, request_id)`). **AC-7:** updated to seed coordinator rows carrying composite identity, assert gateway proxy uses `external_request_id` + `?account_id=` (not the internal id), exercise the cross-account isolation case (two coordinator rows with the same external_request_id route to different accounts), and exercise the legacy NULL-account "no proxy → gateway_identity_unavailable" sub-case. **IMPL:** `phase5-gateway/internal/storage/sqlite/explorer.go` `explorerAccountIDsForRequest` extended to union all five tables; new regression `TestExplorerSessionDetailAmbiguityExtendedToFeedbackAndAudit` pins the feedback/audit cross-pollination guard. **Paired:** SPEC-007-explorer-design.md §2.8 GAP-closed pointer updated to SPEC-002 v1.5.0 / #211. Three-lane codex audit findings + dispositions in `specs/SPEC-007-v0-3-audit.md`. |
 | triage 2026-06-26 | 2026-06-26 | docs/OPEN_QUESTIONS.md | M-3 through M-12 (deferred-to-v0.3 audit findings) closed as unrecoverable — the underlying audit document was never persisted to the repo and the findings list is not reconstructible from history. If operator-explorer concerns recur, run a fresh audit cycle and number anew. No version bump; no normative change. |
@@ -443,24 +444,21 @@ Identity model (v0.3):
   under unrelated coordinator-side data. The both-or-nothing
   contract eliminates that risk.
 
-Path-segment-overload status (v0.4 — #231):
-- `int_<request_id>` continues to resolve as a
-  coordinator-internal id; `ext_<external_request_id>` resolves
-  by re-issuing a scoped lookup against
-  `request_log.external_request_id` then proxying to the gateway.
-  The bare-id form remains accepted in v0.4 with a deprecation
-  WARN; v0.5 (tracked at #245) will reject it with
-  `400 session_id_untyped`.
+Path-segment-overload status (v0.5 — #245):
+- `int_<request_id>` is the ONLY accepted form. The prefix is
+  stripped before the SQL lookup runs against
+  `request_log.request_id`. Untyped (legacy bare-UUID) calls are
+  rejected with `400 invalid_request_error` + `code:
+  session_id_untyped`. The v0.4 deprecation-window WARN log emit
+  is removed because the path is no longer reachable.
 Path parameters:
-- `request_id`: required string. **v0.3:** coordinator-internal
-  billing id (UUID v4) only. **v0.4 (#231):** the coordinator
-  handler MAY accept an `int_`-prefixed value (e.g.
-  `int_<uuid>`) to mark the segment as a coordinator-internal
-  `request_id` explicitly; the prefix is stripped before the SQL
-  lookup runs. Untyped (bare-UUID) calls are still accepted in
-  v0.4 BUT the handler MUST emit a
-  `payout_explorer_path_segment_untyped` audit row at severity
-  WARN. v0.5 (tracked at #245) will reject untyped with `400 session_id_untyped`.
+- `request_id`: required string of the form `int_<uuid>`. The
+  coordinator handler MUST strip the `int_` prefix before
+  resolving the underlying coordinator-internal `request_id`
+  against `request_log.request_id`. The handler MUST return
+  `400 invalid_request_error` with `code: session_id_untyped`
+  when the path-segment lacks the `int_` prefix OR when the
+  stripped value is empty (`int_` alone).
 Headers:
 - `Authorization: Bearer <coordinator operator bearer>` is required.
 Query parameters:
@@ -1364,16 +1362,15 @@ Identity model:
   MUST treat `request_id` as account-scoped when reconciling against
   gateway storage.
 Path parameters:
-- `request_id`: required string. **v0.4 path-segment typing
-  (#231):** the gateway handler MAY accept an `ext_`-prefixed value
-  (e.g. `ext_req-abc123`) to mark the segment as an
-  `external_request_id` explicitly; the prefix is stripped before
-  the SQL lookup runs. Untyped (bare) calls are still accepted in
-  v0.4 for backward compatibility BUT the handler MUST emit a
-  `payout_explorer_path_segment_untyped` `audit_events` row at
-  severity WARN with `endpoint, request_id, ts_utc` to surface the
-  upcoming v0.5 break. v0.5 will reject untyped with
-  `400 session_id_untyped`.
+- `request_id`: required string of the form
+  `ext_<external_request_id>`. **v0.5 path-segment typing
+  (#245):** the gateway handler MUST strip the `ext_` prefix
+  before the SQL lookup runs. The handler MUST return
+  `400 invalid_request_error` with `code: session_id_untyped`
+  when the path-segment lacks the `ext_` prefix OR when the
+  stripped value is empty (`ext_` alone). The v0.4 deprecation
+  `payout_explorer_path_segment_untyped` `audit_events` emit is
+  removed because the path is no longer reachable.
 Headers:
 - `Authorization: Bearer <coordinator.operator_key>` is required.
 Query parameters:

--- a/specs/SPEC-007-explorer.md
+++ b/specs/SPEC-007-explorer.md
@@ -2582,61 +2582,61 @@ Verification:
 - Assert no duplicate `request_log_id`.
 - Assert no seeded row older than the first page boundary is skipped.
 ### AC-7: session detail joins request, ledger, and gateway under the composite key
-Verification (v0.3 — path-segment is coordinator-internal `request_id`):
+Verification (v0.5 — typed path-segments `int_` / `ext_`, #245):
 - Seed one row in coordinator `request_log` with internal
   `request_id = R_int`, `external_request_id = X`, `account_id = "acct_A"`.
 - Seed matching `ledger_request_credits` keyed by `R_int`.
 - Seed matching `ledger_operator_credits` keyed by `R_int`.
 - Seed gateway `usage_events` with `(account_id, request_id) =
   ("acct_A", X)`. Coordinator-internal joins use `R_int`; the
-  gateway proxy MUST forward `external_request_id` (`X`) +
+  gateway proxy MUST forward the typed
+  `ext_<external_request_id>` (`ext_X`) +
   `?account_id=acct_A` so the gateway-side composite-PK lookup
   returns the matching account's row.
-- Request `GET /admin/explorer/sessions/R_int`.
+- Request `GET /admin/explorer/sessions/int_R_int`.
 - Assert response contains coordinator attempt fields.
 - Assert response contains ledger credit fields.
 - Assert response contains gateway usage fields, scoped to
   `account_id = "acct_A"`.
-- **Gateway-proxy URL sub-case (v0.3 §5.6 security contract):**
+- **Gateway-proxy URL sub-case (v0.5 §5.6 security contract):**
   inspect the outbound gateway HTTP request and assert the path
-  is `/admin/explorer/sessions/X?account_id=acct_A` — NOT
-  `/admin/explorer/sessions/R_int`. Forwarding the internal id
-  risks the gateway interpreting it as an external_request_id
+  is `/admin/explorer/sessions/ext_X?account_id=acct_A` — NOT
+  `/admin/explorer/sessions/int_R_int`. Forwarding the internal
+  id risks the gateway interpreting it as an external_request_id
   and returning unrelated single-account data.
-- **Cross-account isolation sub-case (v0.3 gateway-proxy
+- **Cross-account isolation sub-case (v0.5 gateway-proxy
   guarantee):**
   - Additionally seed a second coordinator `request_log` row with
     internal `request_id = R_int2`, `external_request_id = X`,
     `account_id = "acct_B"`, plus a matching gateway
     `usage_events` row with `(account_id, request_id) =
     ("acct_B", X)`.
-  - Request `GET /admin/explorer/sessions/R_int2`.
+  - Request `GET /admin/explorer/sessions/int_R_int2`.
   - Assert the gateway-proxy URL is
-    `/admin/explorer/sessions/X?account_id=acct_B` and the
+    `/admin/explorer/sessions/ext_X?account_id=acct_B` and the
     response contains only `acct_B`'s gateway data; `acct_A`'s
     rows MUST NOT appear.
 - **Legacy NULL-account "no proxy" sub-case (both-or-nothing):**
   - Seed a coordinator `request_log` row with NULL `account_id`
     + non-empty `external_request_id` (pre-v0.9.1 gateway shape).
-  - Request the session detail; assert the coordinator-side
-    detail (attempts/ledger/snapshots) is returned with
-    `gateway: {"error": {"code": "gateway_identity_unavailable"}}`.
-    The coordinator MUST NOT proxy to the gateway because
-    `account_id` is missing — the both-or-nothing contract
-    treats this as an expected legacy-identity-limit, not a
-    gateway failure.
+  - Request the session detail (`int_<id>`); assert the
+    coordinator-side detail (attempts/ledger/snapshots) is
+    returned with `gateway: {"error": {"code":
+    "gateway_identity_unavailable"}}`. The coordinator MUST NOT
+    proxy to the gateway because `account_id` is missing — the
+    both-or-nothing contract treats this as an expected
+    legacy-identity-limit, not a gateway failure.
   - Repeat for a row with non-NULL `account_id` but empty
     `external_request_id` (direct legacy buyer call with no
     inbound X-Request-ID): assert the same
     `gateway_identity_unavailable` outcome.
-
-**Deferred to v0.4 (not required by AC-7 in v0.3):**
-- Operator pasting `external_request_id` directly into the path
-  segment and 409 `ambiguous_request_id` on cross-account
-  collision when no `?account_id=` is supplied. The 409 contract
-  for the gateway-side endpoint (§6.4) is normative in v0.3; the
-  coordinator-side path-segment overload that would expose it is
-  v0.4 work.
+- **Untyped-rejection sub-case (v0.5 break, #245):** request
+  `GET /admin/explorer/sessions/R_int` (no `int_` prefix).
+  Assert the coordinator returns
+  `400 invalid_request_error` with `code: session_id_untyped`
+  and does NOT reach SQL. The same untyped-rejection contract
+  applies to the gateway-side `§6.4` endpoint with the `ext_`
+  prefix.
 ### AC-8: provider list reflects live pool
 Verification:
 - Start coordinator with two live providers in registry.

--- a/specs/SPEC-007-explorer.md
+++ b/specs/SPEC-007-explorer.md
@@ -122,7 +122,7 @@ operator browser
        -> HTTPS proxy to gateway /admin/explorer/* with Authorization: Bearer <coordinator.operator_key>
             -> gateway SQLite reads
 ```
-The operator browser MUST call only the coordinator origin. The operator browser MUST NOT call gateway admin endpoints directly. The coordinator MUST NOT proxy mutating gateway admin endpoints. The coordinator MUST NOT perform verb or query translation for pass-through gateway explorer proxy paths. **Exemption (v0.3 / §5.6):** the session-detail endpoint MAY translate its inbound path-segment (coordinator-internal `request_id`) into the gateway-side composite key — `GET /admin/explorer/sessions/<external_request_id>?account_id=<account_id>` — derived from the resolved `request_log` row. This is the both-or-nothing safety contract required to avoid embedding wrong-account gateway data; the translation is a SPEC-007 v0.3 requirement, not a verb/query-translation violation.
+The operator browser MUST call only the coordinator origin. The operator browser MUST NOT call gateway admin endpoints directly. The coordinator MUST NOT proxy mutating gateway admin endpoints. The coordinator MUST NOT perform verb or query translation for pass-through gateway explorer proxy paths. **Exemption (§5.6):** the session-detail endpoint MAY translate its inbound `int_`-prefixed path-segment (coordinator-internal `request_id`) into the gateway-side composite key — `GET /admin/explorer/sessions/ext_<external_request_id>?account_id=<account_id>` — derived from the resolved `request_log` row. The typed `ext_` prefix is mandatory per §6.4 v0.5. This is the both-or-nothing safety contract required to avoid embedding wrong-account gateway data; the translation is a SPEC-007 requirement, not a verb/query-translation violation.
 ### 4.3 Process model
 SPEC-007 MUST NOT introduce a new long-lived service. SPEC-007 MUST NOT introduce a new public DNS target. SPEC-007 MUST NOT introduce a new Vercel project.
 The explorer consists of:
@@ -594,7 +594,7 @@ Underlying coordinator sources (intra-coordinator joins by internal `request_id`
 - `ledger_operator_credits` by `request_id` and `request_credit_id`.
 - `ledger_provider_identity_snapshots` by `request_id`.
 Underlying gateway endpoint:
-- `GET /admin/explorer/sessions/{external_request_id}?account_id=<account_id>`
+- `GET /admin/explorer/sessions/ext_<external_request_id>?account_id=<account_id>` (typed `ext_` prefix required per §6.4 v0.5)
   (coordinator forwards the resolved row's `external_request_id`
   and `account_id`; see Identity model above for the security
   rationale). When either field is missing on the resolved row,


### PR DESCRIPTION
Closes #245. SPEC-007 v0.5 — flips the v0.4 deprecation-window path-segment typing gate to break mode: untyped (legacy bare-id) calls to `/admin/explorer/sessions/{id}` now return `400 invalid_request_error` + `code: session_id_untyped` on BOTH the gateway (`ext_` required) and the coordinator (`int_` required).

## Trigger (#245 gate)

Issue #245 names three trigger conditions for opening this PR; only option **(2) operator UI cutover** applies today:

| # | Trigger | Status |
|---|---|---|
| 1 | 14d telemetry-quiet on `payout_explorer_path_segment_untyped` | NOT fired — only ~1d since v0.4 merged |
| 2 | Operator UI cutover | **Satisfied by this PR** — dashboard.js `linkFor` emits `int_`-prefixed URLs on both `request_id` columns and `link_target: session:` rows; this is the only first-party operator UI |
| 3 | Forced 90-day cutoff (~2026-09-27) | NOT fired — way too early |

The SPEC v0.5 change-log row records this explicitly so future archaeology won't infer telemetry-quiet elapsed.

## What landed

### IMPL — gateway + coordinator handlers
- `phase5-gateway/internal/router/explorer.go::handleExplorerSessionDetail` returns 400 + envelope (`invalid_request_error` / `session_id_untyped`) when `parseTypedSegment(rawSegment, "ext_")` reports `!typed`. The v0.4 `payout_explorer_path_segment_untyped` `audit_events` emit is removed (no longer reachable).
- `phase4-coordinator/internal/explorer/handlers.go::handleSessionDetail` returns 400 + same envelope when `strings.CutPrefix(requestID, "int_")` returns `!ok || stripped==""`. `Handler.logPathSegmentUntyped` deleted. Envelope shape (`type`, `code`, `message`, `source`, `retryable`) symmetric with gateway emit per R1 SEC LOW-1 closure.

### IMPL — dashboard.js (operator UI cutover)
- `phase4-coordinator/internal/explorer/static/js/dashboard.js::linkFor` emits `/admin/explorer/sessions/int_${encodeURIComponent(v)}` for both `request_id` columns and `link_target: session:` rows so coordinator-dashboard navigations match the v0.5 contract.

### IMPL — coordinator-driven gateway proxy
- `handleSessionDetail` was already updated in #231 R5 to send the typed `ext_` prefix; comment now describes the v0.5 hard requirement (was "v0.5 will reject" forward-looking).

### SPEC
- `specs/SPEC-007-explorer.md` → v0.5 (change-log row + §5.6 + §6.4 + §14.7.1 rewrites; AC-7 examples migrated; §4.2 exemption paragraph updated; §6.4 heading carries `ext_{external_request_id}`; added §5-level route-template notation paragraph clarifying inventory placeholders)
- `specs/SPEC-007-explorer-design.md` § path-segment heading rewritten in v0.5 terms

### Tests (v0.4 → v0.5 inversion)
- Coordinator: `TestSessionDetail_UntypedReturns400` + `TestSessionDetail_EmptyIntPrefixReturns400` (replace v0.4 deprecation-emit test); asserts both `code: session_id_untyped` and `type: invalid_request_error`. All bare-id call sites in `handlers_test.go` migrated to `int_` prefix. `TestDashboardCrossViewLinkWiring` assertion updated for the `int_`-prefixed URL.
- Gateway: `TestExplorerSessionDetail_UntypedReturns400` + `TestExplorerSessionDetail_EmptyExtPrefixReturns400` (replace v0.4 deprecation-audit test); both assert `error.code == session_id_untyped`. Cap+truncation test migrated to `ext_` prefix.

## Audit convergence

Per [[feedback-three-lane-codex-audits]]: separate per-lane prompts in `specs/AUDIT_ISS245_{CODE,SECURITY,ARCHITECT}_PROMPT.md`. ARCH took 3 fix-pass rounds; CODE + SEC stayed at R1 ACCEPT throughout per [[feedback-skip-accepted-audit-lanes]].

| Round | CODE codex | SECURITY codex | ARCHITECT codex |
|-------|------------|----------------|-----------------|
| R1 | **0/0/0/2/1 ACCEPT** | **0/0/0/1/1 ACCEPT** | 0/0/**1**/2/2 (AC-7 stale v0.3 examples) |
| R2 | _skipped_ | _skipped_ | 0/0/**1**/1/1 (§5.6 + §14.7.1 stale prose) |
| R3 | _skipped_ | _skipped_ | 0/0/**1**/1/0 (§4.2 + §5.6 bare proxy targets) |
| R4 | _skipped_ | _skipped_ | **0/0/0/2/1 ACCEPT** |

Per [[audit-cycles-are-design-discovery]] the 3 ARCH rounds surfaced genuinely different cross-section drift sites each time — not diminishing-returns repetition. Pattern reinforces the "each fix opens the next 'is this the authority everywhere?' question" rule.

Fix-pass commits: `612c186` (R1) → `f41abab` (R2) → `1dbf876` (R3) → `7fa2faf` (R4).

## Deferred

- SEC R1 INFO-2 (runbook documents new 400 signal) — operator runbook follow-up; out of code scope.

## Test plan

- [x] Full coordinator suite (20 packages) green at `count=1`
- [x] Full gateway suite green at `count=1`
- [x] `go vet ./...` clean both phases
- [x] `gofmt -l` clean on touched files
- [x] Operator UI cutover: dashboard.js linkFor emits typed prefix (`TestDashboardCrossViewLinkWiring` asserts the new URL pattern)
- [x] AC-7 verification examples updated to typed forms; new untyped-rejection sub-case added
- [ ] Runbook follow-up (operator action; non-blocking): document the `400 session_id_untyped` HTTP-server signal as the new operator-visibility surface that replaces the deleted `payout_explorer_path_segment_untyped` audit event
