### PR TITLE
Trust gateway stream usage and normalize rate-card keys

### DIFF
--- a/phase4-coordinator/internal/billing/formula.go
+++ b/phase4-coordinator/internal/billing/formula.go
@@ -1,6 +1,10 @@
 package billing
 
-import "math"
+import (
+	"log/slog"
+	"math"
+	"strings"
+)
 
 const (
 	UsageProviderReported = "provider_reported"
@@ -36,11 +40,57 @@ func RateFor(rateCard map[string]RateCardEntry, model string) RateCardEntry {
 		if entry, ok := rateCard[model]; ok {
 			return entry
 		}
+		normalized := normalizeModelKey(model)
+		if normalized != model {
+			if entry, ok := rateCard[normalized]; ok {
+				slog.Info("rate_card_normalized", "event", "rate_card_normalized", "requested", model, "normalized", normalized, "matched", normalized)
+				return entry
+			}
+		}
 		if entry, ok := rateCard["default"]; ok {
+			if normalized != model {
+				slog.Info("rate_card_normalized", "event", "rate_card_normalized", "requested", model, "normalized", normalized, "matched", "default")
+			}
 			return entry
+		}
+		if normalized != model {
+			slog.Info("rate_card_normalized", "event", "rate_card_normalized", "requested", model, "normalized", normalized, "matched", "")
 		}
 	}
 	return RateCardEntry{}
+}
+
+func normalizeModelKey(model string) string {
+	key := strings.ToLower(strings.TrimSpace(model))
+	namespace := ""
+	if slash := strings.IndexByte(key, '/'); slash >= 0 {
+		namespace = key[:slash]
+		if knownModelNamespace(namespace) {
+			key = key[slash+1:]
+		}
+	}
+	for _, suffix := range []string{"-mxfp4-q8", "-4bit", "-8bit"} {
+		key = strings.TrimSuffix(key, suffix)
+	}
+	switch {
+	case namespace == "meta-llama" && strings.HasPrefix(key, "llama-"):
+		return "meta-llama/" + key
+	case strings.HasPrefix(key, "meta-llama-"):
+		return "meta-llama/" + strings.TrimPrefix(key, "meta-")
+	case strings.HasPrefix(key, "gpt-oss-"):
+		return "openai/" + key
+	default:
+		return key
+	}
+}
+
+func knownModelNamespace(namespace string) bool {
+	switch namespace {
+	case "mlx-community", "openai", "google", "meta-llama", "nvidia", "qwen":
+		return true
+	default:
+		return false
+	}
 }
 
 func ParseMultiplierPPM(v float64) int64 {

--- a/phase4-coordinator/internal/billing/formula_test.go
+++ b/phase4-coordinator/internal/billing/formula_test.go
@@ -2,6 +2,95 @@ package billing
 
 import "testing"
 
+func TestRateFor_ExactMatch_Wins(t *testing.T) {
+	rateA := RateCardEntry{PromptCreditsPerMtok: 100, CompletionCreditsPerMtok: 200}
+	rateD := RateCardEntry{PromptCreditsPerMtok: 300, CompletionCreditsPerMtok: 400}
+	got := RateFor(map[string]RateCardEntry{"qwen3-32b": rateA, "default": rateD}, "qwen3-32b")
+	if got != rateA {
+		t.Fatalf("RateFor exact = %+v, want %+v", got, rateA)
+	}
+}
+
+func TestRateFor_VerbatimWinsOverNormalized(t *testing.T) {
+	rateExact := RateCardEntry{PromptCreditsPerMtok: 100, CompletionCreditsPerMtok: 200}
+	rateNorm := RateCardEntry{PromptCreditsPerMtok: 300, CompletionCreditsPerMtok: 400}
+	got := RateFor(map[string]RateCardEntry{"mlx-community/Qwen3-32B-4bit": rateExact, "qwen3-32b": rateNorm}, "mlx-community/Qwen3-32B-4bit")
+	if got != rateExact {
+		t.Fatalf("RateFor verbatim = %+v, want %+v", got, rateExact)
+	}
+}
+
+func TestRateFor_NormalizesMLXCommunityNamespace(t *testing.T) {
+	rateA := RateCardEntry{PromptCreditsPerMtok: 100, CompletionCreditsPerMtok: 200}
+	got := RateFor(map[string]RateCardEntry{"qwen3-32b": rateA}, "mlx-community/Qwen3-32B-4bit")
+	if got != rateA {
+		t.Fatalf("RateFor normalized = %+v, want %+v", got, rateA)
+	}
+}
+
+func TestRateFor_NormalizesQuantizationSuffix(t *testing.T) {
+	rateL := RateCardEntry{PromptCreditsPerMtok: 100, CompletionCreditsPerMtok: 200}
+	got := RateFor(map[string]RateCardEntry{"meta-llama/llama-3.1-8b-instruct": rateL}, "mlx-community/Meta-Llama-3.1-8B-Instruct-4bit")
+	if got != rateL {
+		t.Fatalf("RateFor llama normalized = %+v, want %+v", got, rateL)
+	}
+}
+
+func TestRateFor_NormalizesCanonicalMetaLlamaNamespace(t *testing.T) {
+	rateL := RateCardEntry{PromptCreditsPerMtok: 100, CompletionCreditsPerMtok: 200}
+	got := RateFor(map[string]RateCardEntry{"meta-llama/llama-3.1-8b-instruct": rateL}, "meta-llama/Llama-3.1-8B-Instruct-4bit")
+	if got != rateL {
+		t.Fatalf("RateFor canonical llama normalized = %+v, want %+v", got, rateL)
+	}
+}
+
+func TestRateFor_NormalizesMXFP4Suffix(t *testing.T) {
+	rateOss := RateCardEntry{PromptCreditsPerMtok: 100, CompletionCreditsPerMtok: 200}
+	got := RateFor(map[string]RateCardEntry{"openai/gpt-oss-20b": rateOss}, "mlx-community/gpt-oss-20b-MXFP4-Q8")
+	if got != rateOss {
+		t.Fatalf("RateFor gpt-oss normalized = %+v, want %+v", got, rateOss)
+	}
+}
+
+func TestRateFor_FallsBackToDefault(t *testing.T) {
+	rateD := RateCardEntry{PromptCreditsPerMtok: 100, CompletionCreditsPerMtok: 200}
+	got := RateFor(map[string]RateCardEntry{"default": rateD}, "something-not-in-card")
+	if got != rateD {
+		t.Fatalf("RateFor default = %+v, want %+v", got, rateD)
+	}
+}
+
+func TestRateFor_UnknownNamespaceDoesNotNormalizeToKnownModel(t *testing.T) {
+	rateA := RateCardEntry{PromptCreditsPerMtok: 100, CompletionCreditsPerMtok: 200}
+	rateD := RateCardEntry{PromptCreditsPerMtok: 300, CompletionCreditsPerMtok: 400}
+	got := RateFor(map[string]RateCardEntry{"qwen3-32b": rateA, "default": rateD}, "other/Qwen3-32B-4bit")
+	if got != rateD {
+		t.Fatalf("RateFor unknown namespace = %+v, want default %+v", got, rateD)
+	}
+}
+
+func TestRateFor_NoDefault_ReturnsZero(t *testing.T) {
+	rateA := RateCardEntry{PromptCreditsPerMtok: 100, CompletionCreditsPerMtok: 200}
+	got := RateFor(map[string]RateCardEntry{"qwen3-32b": rateA}, "something-else")
+	if got != (RateCardEntry{}) {
+		t.Fatalf("RateFor no default = %+v, want zero", got)
+	}
+}
+
+func TestRateFor_EmptyCard_ReturnsZero(t *testing.T) {
+	got := RateFor(map[string]RateCardEntry{}, "anything")
+	if got != (RateCardEntry{}) {
+		t.Fatalf("RateFor empty = %+v, want zero", got)
+	}
+}
+
+func TestRateFor_NilCard_ReturnsZero(t *testing.T) {
+	got := RateFor(nil, "anything")
+	if got != (RateCardEntry{}) {
+		t.Fatalf("RateFor nil = %+v, want zero", got)
+	}
+}
+
 func TestComputeCredits_WorkedExamples(t *testing.T) {
 	rate7B := RateCardEntry{PromptCreditsPerMtok: 1000000, CompletionCreditsPerMtok: 2000000}
 	defaultRate := RateCardEntry{PromptCreditsPerMtok: 500000, CompletionCreditsPerMtok: 1000000}

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -519,62 +519,32 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	}
 	settleReported := func(outcome string) {
 		usage := *reported
+		observedRawCompletion := estimateTokensFromBytes(emitted)
 		observedCompletion := estimateStreamingCompletionTokens(emitted, maxTokens)
-		if observedCompletion > usage.CompletionTokens {
-			// Issue #278: the gateway byte estimator can run slightly higher
-			// than the provider's tokenizer on normal English output. Clamp
-			// upward-estimator inflation when the gap sits inside the same
-			// safe window as the downward #255 clamp.
-			//
-			// Outside the window — below floor (benign tokenizer noise) OR
-			// above ceiling (too large to be tokenizer noise; likely stream
-			// truncation or zero-report fraud where the provider's usage chunk
-			// under-reports content actually generated) — trust the gateway's
-			// byte-derived estimate.
-			overshoot := observedCompletion - usage.CompletionTokens
-			if overshoot > clampFloorTokens && overshoot <= clampCeilingTokens {
-				slog.Info("streaming gateway clamped under-reported completion tokens; gateway estimate higher",
+		maxCompletion := maxStreamingCompletionTokens(maxTokens)
+		if usage.CompletionTokens > maxCompletion {
+			outcome = "stream_output_exceeded"
+			if observedRawCompletion < usage.CompletionTokens {
+				slog.Warn("streaming provider usage reported over max_tokens without matching emitted output; falling back to gateway estimate",
 					"request_id", requestID(r),
 					"account_id", subject.AccountID,
 					"reported", usage.CompletionTokens,
-					"observed", observedCompletion,
-					"overshoot", overshoot,
-					"window_floor", clampFloorTokens,
-					"window_ceiling", clampCeilingTokens,
-					"outcome", outcome,
+					"observed", observedRawCompletion,
+					"max_completion_tokens", maxCompletion,
 				)
-				s.settleAfterCommit(r, subject, usage.PromptTokens, usage.CompletionTokens, maxUsageTokens, "provider_reported", outcome, reservationWindow)
+				s.settleAfterCommit(r, subject, promptEstimate, observedCompletion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow)
 				return
 			}
-			s.settleAfterCommit(r, subject, promptEstimate, observedCompletion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow)
-			return
 		}
-		// Issue #255: provider may report MORE completion tokens than were
-		// streamed as delta.content — e.g. a tokenizer counts EOS or
-		// chat-template stop tokens that never reach the buyer as content.
-		// Surfaced on Qwen2.5-Coder-7B-Instruct-4bit with consistent
-		// +4..+7 over-reports vs both harness and coord (which agree).
-		// Clamp downward when the over-report sits inside the safe window
-		// (see clampWindow). Outside the window — too small (benign noise)
-		// or too large (gateway byte-estimate undercounts dense content;
-		// clamping would under-bill the provider) — trust the provider.
-		// R1 security HIGH: keep usage.PromptTokens (provider's authoritative
-		// prompt count); usageFromJSON already proved prompt+completion ≤
-		// maxUsageTokens, so substituting the smaller observedCompletion
-		// can only lower the total.
-		overshoot := usage.CompletionTokens - observedCompletion
-		if overshoot > clampFloorTokens && overshoot <= clampCeilingTokens {
-			slog.Info("streaming gateway clamped over-reported completion tokens",
+		if providerUsageImplausiblyUnderreports(observedCompletion, usage.CompletionTokens) {
+			slog.Warn("streaming provider usage implausibly under-reported completion tokens; falling back to gateway estimate",
 				"request_id", requestID(r),
 				"account_id", subject.AccountID,
 				"reported", usage.CompletionTokens,
 				"observed", observedCompletion,
-				"overshoot", overshoot,
-				"window_floor", clampFloorTokens,
-				"window_ceiling", clampCeilingTokens,
 				"outcome", outcome,
 			)
-			s.settleAfterCommit(r, subject, usage.PromptTokens, observedCompletion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow)
+			s.settleAfterCommit(r, subject, promptEstimate, observedCompletion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow)
 			return
 		}
 		s.settleAfterCommit(r, subject, usage.PromptTokens, usage.CompletionTokens, maxUsageTokens, "provider_reported", outcome, reservationWindow)
@@ -638,8 +608,12 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 				if deltaBytes > 0 {
 					projectedCompletion := estimateTokensFromBytes(emitted + deltaBytes)
 					maxCompletion := maxStreamingCompletionTokens(maxTokens)
-					if projectedCompletion > maxCompletion {
-						slog.Warn("streaming gateway estimate exceeded request maximum; truncating stream", "request_id", requestID(r), "estimated_completion_tokens", projectedCompletion, "max_completion_tokens", maxCompletion)
+					hardByteCeiling := maxCompletion * 8
+					if hardByteCeiling < 1 {
+						hardByteCeiling = 1
+					}
+					if emitted+deltaBytes > hardByteCeiling {
+						slog.Warn("streaming gateway estimate exceeded hard byte ceiling; truncating stream", "request_id", requestID(r), "estimated_completion_tokens", projectedCompletion, "max_completion_tokens", maxCompletion, "emitted_bytes", emitted+deltaBytes, "hard_byte_ceiling", hardByteCeiling)
 						writeSSEError(w, "Upstream stream exceeded requested max_tokens", "api_error", "stream_output_exceeded")
 						if flusher != nil {
 							flusher.Flush()
@@ -650,7 +624,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 					}
 					emitted += deltaBytes
 				}
-				if usage, ok, err := usageFromJSON([]byte(data), maxUsageTokens, maxTokens); ok {
+				if usage, ok, err := usageFromJSON([]byte(data), maxUsageTokens, maxTokens, true); ok {
 					if err != nil {
 						invalidReportedUsage = true
 						reported = nil
@@ -780,7 +754,12 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		settleReported("ok")
 		return
 	}
-	s.settleAfterCommit(r, subject, promptEstimate, estimateStreamingCompletionTokens(emitted, maxTokens), maxUsageTokens, "gateway_estimated", "ok", reservationWindow)
+	completion := estimateStreamingCompletionTokens(emitted, maxTokens)
+	outcome := "ok"
+	if estimateTokensFromBytes(emitted) > maxStreamingCompletionTokens(maxTokens) {
+		outcome = "stream_output_exceeded"
+	}
+	s.settleAfterCommit(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow)
 }
 
 func (s *Server) passThroughNoProviderCoordinatorError(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, body []byte) {
@@ -1066,67 +1045,21 @@ func estimateStreamingCompletionTokens(emitted, maxTokens int64) int64 {
 	return completion
 }
 
-// Shared clamp window for the streaming completion-token symmetric
-// clamp: downward over-report (#255) AND upward estimator inflation
-// (#278). Pure absolute bounds — no percentage scaling, no
-// direction-specific tuning. The two directions are intentionally
-// symmetric and MUST stay so; do not tune one side independently
-// without a fresh 3-lane audit on both.
-//
-// Let `o` be the absolute disagreement between provider's reported
-// `usage.completion_tokens` and the gateway's byte-derived estimate.
-// The clamp fires iff `clampFloorTokens < o <= clampCeilingTokens` in
-// either direction:
-//
-//   - Downward (reported > observed; #255): clamp DOWN to observed,
-//     token_source = "gateway_estimated". The provider over-reported
-//     by a small amount; gateway's byte count wins.
-//
-//   - Upward   (observed > reported; #278): clamp UP to reported,
-//     token_source = "provider_reported". The gateway's byte
-//     estimator inflated above the provider's tokenizer (e.g.
-//     ceil(N/4) overshoots on English where ~4.3-4.7 bytes/token);
-//     provider's tokenizer is authoritative on its own output for
-//     small disagreements. Surfaced by v0.4 scenario 07 (4 of 40
-//     successful streaming pairs over-billed by +6 to +9 tokens).
-//
-// Outside the window neither direction clamps (the existing
-// authority wins):
-//
-//   - Below `clampFloorTokens` (≤ 2 tokens, either direction): benign
-//     tokenizer noise (EOS / chat-template stop tokens not in delta
-//     content; or sub-byte rounding in ceil(N/4)). Downward keeps
-//     `provider_reported`; upward keeps `gateway_estimated`.
-//
-//   - Above `clampCeilingTokens` (> 20 tokens): too large to be
-//     tokenizer noise. Downward: byte estimate unreliable on dense
-//     content (CJK / code / short tokens where 1 token < 4 bytes);
-//     trust the provider. Upward: stream truncation or zero-report
-//     fraud — provider's usage chunk plausibly under-reports content
-//     actually generated; trust the byte estimator.
-//
-// Earlier rounds tried a percentage formula but R2 audits caught a
-// false-positive class: a legitimate moderate-density report
-// (e.g. observed=225 byte-tokens, reported=300 actual tokens) sat
-// inside the percentage window and got clamped, under-billing the
-// provider. Pure absolute bounds eliminate that class — any overshoot
-// > 20 tokens is trusted as density mismatch / truncation.
-//
-// Cost (symmetric in both directions): an adversarial provider can
-// systematically over- or under-report by up to 20 tokens per
-// request. Bounded and small per-request; logged each time the clamp
-// fires for audit visibility. Closing the residual skim surfaces
-// requires a tokenizer-grounded observation (replacing the byte
-// heuristic) — out of scope for #255 and #278.
-const (
-	clampFloorTokens   int64 = 2
-	clampCeilingTokens int64 = 20
-)
-
-// clampWindow returns the (floor, ceiling] bounds as a tuple for
-// callers that want both at once (e.g. log lines, tests).
-func clampWindow() (floor, ceiling int64) {
-	return clampFloorTokens, clampCeilingTokens
+func providerUsageImplausiblyUnderreports(observed, reported int64) bool {
+	if observed <= reported {
+		return false
+	}
+	gap := observed - reported
+	if gap <= 20 {
+		return false
+	}
+	if reported == 0 {
+		return true
+	}
+	if observed > math.MaxInt64/2 || reported > math.MaxInt64/3 {
+		return false
+	}
+	return observed*2 > reported*3
 }
 
 func maxStreamingCompletionTokens(maxTokens int64) int64 {
@@ -1371,12 +1304,11 @@ func parseChatRequest(body []byte) (chatRequest, error) {
 // (computed from promptCapTokens(body) + maxTokens at the call site
 // so the chat-template headroom is included).
 //
-// maxCompletion — independent ceiling on completion_tokens (=
-// buyer's max_tokens). Without this separate check, a malicious
-// provider could spend the prompt-cap headroom as inflated
-// completion tokens, over-billing the buyer above the requested
-// max_tokens. R1 CODE HIGH #1 (2026-06-28).
-func usageFromJSON(body []byte, maxUsageTokens, maxCompletion int64) (tokenUsage, bool, error) {
+// maxCompletion is enforced for non-streaming responses. Streaming
+// callers can allow completion_tokens above max_tokens so a provider
+// usage chunk can settle as stream_output_exceeded instead of being
+// treated as malformed usage.
+func usageFromJSON(body []byte, maxUsageTokens, maxCompletion int64, allowCompletionOverMax ...bool) (tokenUsage, bool, error) {
 	var envelope struct {
 		Usage json.RawMessage `json:"usage"`
 	}
@@ -1409,7 +1341,7 @@ func usageFromJSON(body []byte, maxUsageTokens, maxCompletion int64) (tokenUsage
 	if usage.PromptTokens > math.MaxInt64-usage.CompletionTokens {
 		return tokenUsage{}, true, fmt.Errorf("usage token total overflows int64")
 	}
-	if usage.CompletionTokens > maxCompletion {
+	if len(allowCompletionOverMax) == 0 && usage.CompletionTokens > maxCompletion {
 		return tokenUsage{}, true, fmt.Errorf("usage completion_tokens exceeds request max_tokens")
 	}
 	sum := usage.PromptTokens + usage.CompletionTokens

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -3560,264 +3560,312 @@ func TestStreamingUnderreportedUsageWithHighProviderPromptFallsBackToGatewayEsti
 	}
 }
 
-// TestStreamingProviderReportedOverbillClampedToObserved pins the
-// issue #255 fix: when the provider's WS `usage` frame reports MORE
-// completion tokens than were actually streamed as delta.content
-// (e.g. the tokenizer counts EOS or chat-template stop tokens), the
-// gateway clamps the bill DOWN to the observed value — but ONLY when
-// the overshoot sits inside the pure-absolute clamp window
-// `(clampFloorTokens=2, clampCeilingTokens=20]`.
-//
-// Outside the window — below floor (benign tokenizer noise) OR above
-// ceiling (too large to be tokenizer noise; gateway's byte-estimate
-// is unreliable on dense content where 1 token < 4 bytes, clamping
-// would under-bill the provider for legitimate work) — the gateway
-// trusts the provider's count.
-//
-// R2 security + architect convergence (HIGH): an earlier percentage-
-// based ceiling (50% × observed) still left a moderate-density
-// under-bill class — e.g. observed=225 byte-tokens with legitimate
-// reported=300 actual tokens fell INSIDE the percentage window and
-// got clamped. Switching to pure absolute (≤ 20 tokens) eliminates
-// that false-positive class.
-//
-// Live surfacing: scenario 07 of the v0.3 rerun (2026-06-29) caught
-// +4 / +5 / +7 over-bills on Qwen2.5-Coder-7B-Instruct-4bit hitting
-// air5, all reproducible by the "clamp fires" cases below.
-func TestStreamingProviderReportedOverbillClampedToObserved(t *testing.T) {
-	type tc struct {
-		name              string
-		contentBytes      int   // bytes of delta.content streamed
-		reportedPromptTok int64 // provider's usage.prompt_tokens
-		reportedCompTok   int64 // provider's usage.completion_tokens
-		wantClamp         bool  // true → source=gateway_estimated, comp=observed
-		wantBilledCompTk  int64 // expected completion_tokens in usage_events row
-		wantBilledPromptT int64 // expected prompt_tokens in usage_events row
-	}
-	cases := []tc{
-		// Exact / within-floor: trust provider
-		{name: "exact_match_trusts_provider", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 10, wantClamp: false, wantBilledCompTk: 10, wantBilledPromptT: 7},
-		{name: "1_token_overshoot_within_floor_trusts_provider", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 11, wantClamp: false, wantBilledCompTk: 11, wantBilledPromptT: 7},
-		{name: "2_token_overshoot_at_floor_trusts_provider", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 12, wantClamp: false, wantBilledCompTk: 12, wantBilledPromptT: 7},
-		// In-window clamp: small over-report → clamp; preserve provider prompt
-		{name: "3_token_overshoot_in_window_clamps", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 13, wantClamp: true, wantBilledCompTk: 10, wantBilledPromptT: 7},
-		{name: "iss255_pattern_4_token_overshoot_clamps", contentBytes: 152, reportedPromptTok: 40, reportedCompTok: 42, wantClamp: true, wantBilledCompTk: 38, wantBilledPromptT: 40},
-		{name: "iss255_pattern_5_token_overshoot_clamps", contentBytes: 204, reportedPromptTok: 40, reportedCompTok: 56, wantClamp: true, wantBilledCompTk: 51, wantBilledPromptT: 40},
-		{name: "iss255_pattern_7_token_overshoot_clamps", contentBytes: 152, reportedPromptTok: 40, reportedCompTok: 45, wantClamp: true, wantBilledCompTk: 38, wantBilledPromptT: 40},
-		// At-ceiling-exact: still clamps (closed upper bound).
-		{name: "20_token_overshoot_at_ceiling_clamps", contentBytes: 400, reportedPromptTok: 13, reportedCompTok: 120, wantClamp: true, wantBilledCompTk: 100, wantBilledPromptT: 13},
-		// Just-above-ceiling: trusts provider — density mismatch territory.
-		{name: "21_token_overshoot_just_above_ceiling_trusts_provider", contentBytes: 400, reportedPromptTok: 13, reportedCompTok: 121, wantClamp: false, wantBilledCompTk: 121, wantBilledPromptT: 13},
-		// R2 security + architect convergence (HIGH): moderate-density
-		// scenarios that the old 50%-percentage formula clamped, now
-		// trusted. Example: 900 bytes of CJK-like content with a legit
-		// provider report of 300 tokens — observed=225, overshoot=75,
-		// pure-absolute ceiling=20 → 75 > 20 → trust provider.
-		{name: "moderate_density_33pct_overshoot_trusts_provider", contentBytes: 900, reportedPromptTok: 13, reportedCompTok: 300, wantClamp: false, wantBilledCompTk: 300, wantBilledPromptT: 13},
-		// Extreme density mismatch (4x): trust provider.
-		{name: "dense_content_4x_density_mismatch_trusts_provider", contentBytes: 800, reportedPromptTok: 13, reportedCompTok: 800, wantClamp: false, wantBilledCompTk: 800, wantBilledPromptT: 13},
-		// Tiny observed: floor=2, overshoot in (2, 20] → clamps if
-		// overshoot is e.g. 4. Pure-absolute makes this consistent.
-		{name: "tiny_observed_overshoot_in_absolute_window_clamps", contentBytes: 8, reportedPromptTok: 7, reportedCompTok: 6, wantClamp: true, wantBilledCompTk: 2, wantBilledPromptT: 7}, // observed=2, reported=6, overshoot=4 → clamp
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			output := strings.Repeat("x", c.contentBytes)
-			usageFrame := fmt.Sprintf(`data: {"id":"chatcmpl","usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d},"choices":[{"delta":{},"finish_reason":"stop"}]}`, c.reportedPromptTok, c.reportedCompTok, c.reportedPromptTok+c.reportedCompTok)
-			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-				payload := strings.Join([]string{
-					`data: {"id":"chatcmpl","choices":[{"delta":{"content":"` + output + `"}}]}`,
-					usageFrame,
-					`data: [DONE]`,
-					``,
-				}, "\n\n")
-				return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
-			})}
-			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
-				cfg.Coordinator.BuyerURL = "http://coordinator.test"
-			}, WithHTTPClient(client))
-			accountID := "acct_iss255_" + c.name
-			fullKey := createAccountAndKey(t, store, cfg, accountID)
+func TestSettleFromUsage_Qwen3_32B_Legacy_Baseline(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_qwen3_32b",
+		model:          "mlx-community/Qwen3-32B-4bit",
+		contentBytes:   128,
+		reportedPrompt: 12,
+		reportedComp:   32,
+		maxTokens:      128,
+		wantOutcome:    "ok",
+		wantSource:     "provider_reported",
+		wantCompletion: 32,
+		wantPrompt:     12,
+	})
+}
 
-			body := fmt.Sprintf(`{"model":"llama","stream":true,"max_tokens":%d,"messages":[{"role":"user","content":"ok"}]}`, c.wantBilledCompTk+200)
-			resp := postChat(t, h, fullKey, body, nil)
-			if resp.Code != http.StatusOK {
-				t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
-			}
-			outcome, source, billedComp, billedPrompt := usageEventOutcomeAndTokens(t, dbPath, accountID)
-			if outcome != "ok" {
-				t.Fatalf("outcome = %q, want ok", outcome)
-			}
-			wantSource := "provider_reported"
-			if c.wantClamp {
-				wantSource = "gateway_estimated"
-			}
-			if source != wantSource {
-				t.Errorf("token_source = %q, want %q (clamp=%v: reported=%d observed=%d/%dB window=(%d,%d])",
-					source, wantSource, c.wantClamp, c.reportedCompTok, c.contentBytes/4, c.contentBytes, clampFloorTokens, clampCeilingTokens)
-			}
-			if billedComp != c.wantBilledCompTk {
-				t.Errorf("billed completion_tokens = %d, want %d", billedComp, c.wantBilledCompTk)
-			}
-			if billedPrompt != c.wantBilledPromptT {
-				t.Errorf("billed prompt_tokens = %d, want %d (R1 HIGH: must preserve provider's prompt count)", billedPrompt, c.wantBilledPromptT)
-			}
-		})
+func TestSettleFromUsage_Llama_31_8B_NoOverbill(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_llama_31_8b",
+		model:          "mlx-community/Meta-Llama-3.1-8B-Instruct-4bit",
+		contentBytes:   372,
+		reportedPrompt: 46,
+		reportedComp:   69,
+		maxTokens:      128,
+		wantOutcome:    "ok",
+		wantSource:     "provider_reported",
+		wantCompletion: 69,
+		wantPrompt:     46,
+	})
+}
+
+func TestSettleFromUsage_Qwen25_Coder_32B_NoDownclamp(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_qwen25_coder_32b",
+		model:          "mlx-community/Qwen2.5-Coder-32B-Instruct-4bit",
+		contentBytes:   464,
+		reportedPrompt: 42,
+		reportedComp:   128,
+		maxTokens:      128,
+		wantOutcome:    "ok",
+		wantSource:     "provider_reported",
+		wantCompletion: 128,
+		wantPrompt:     42,
+	})
+}
+
+func TestSettleFromUsage_GptOss_20B_NoMidStreamByteCap(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_gpt_oss_20b",
+		model:          "mlx-community/gpt-oss-20b-MXFP4-Q8",
+		contentBytes:   640,
+		chunks:         5,
+		reportedPrompt: 42,
+		reportedComp:   128,
+		maxTokens:      128,
+		wantOutcome:    "ok",
+		wantSource:     "provider_reported",
+		wantCompletion: 128,
+		wantPrompt:     42,
+	})
+}
+
+func TestSettleFromUsage_Qwen3Coder_30B_A3B_NoMidStreamByteCap(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_qwen3_coder_30b_a3b",
+		model:          "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+		contentBytes:   640,
+		chunks:         4,
+		reportedPrompt: 52,
+		reportedComp:   128,
+		maxTokens:      128,
+		wantOutcome:    "ok",
+		wantSource:     "provider_reported",
+		wantCompletion: 128,
+		wantPrompt:     52,
+	})
+}
+
+func TestSettleFromUsage_NoUsageChunk_FallsBackToByteEstimate(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_no_chunk",
+		model:          "llama",
+		contentBytes:   120,
+		noUsage:        true,
+		maxTokens:      128,
+		wantOutcome:    "ok",
+		wantSource:     "gateway_estimated",
+		wantCompletion: 30,
+	})
+}
+
+func TestSettleFromUsage_InvalidUsageChunk_FallsBackToByteEstimate(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_invalid_chunk",
+		model:          "llama",
+		contentBytes:   120,
+		invalidUsage:   true,
+		maxTokens:      128,
+		wantOutcome:    "ok",
+		wantSource:     "gateway_estimated",
+		wantCompletion: 30,
+	})
+}
+
+func TestSettleFromUsage_TruncatedStream_WithPartialUsage(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_truncated_partial",
+		model:          "llama",
+		contentBytes:   120,
+		reportedPrompt: 12,
+		reportedComp:   42,
+		maxTokens:      128,
+		streamErr:      errors.New("forced upstream stream failure"),
+		wantOutcome:    "stream_truncated",
+		wantSource:     "provider_reported",
+		wantCompletion: 42,
+		wantPrompt:     12,
+	})
+}
+
+func TestSettleFromUsage_RealStreamOutputExceeded_ProviderReports(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_real_output_exceeded",
+		model:          "llama",
+		contentBytes:   800,
+		reportedPrompt: 12,
+		reportedComp:   200,
+		maxTokens:      128,
+		wantOutcome:    "stream_output_exceeded",
+		wantSource:     "provider_reported",
+		wantCompletion: 200,
+		wantPrompt:     12,
+	})
+}
+
+func TestSettleFromUsage_OverMaxWithoutObservedOutput_FallsBackToByteCap(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_overmax_spoof",
+		model:          "llama",
+		contentBytes:   640,
+		reportedPrompt: 12,
+		reportedComp:   200,
+		maxTokens:      128,
+		wantOutcome:    "stream_output_exceeded",
+		wantSource:     "gateway_estimated",
+		wantCompletion: 128,
+	})
+}
+
+func TestSettleFromUsage_TruncatedOverMaxWithoutObservedOutput_FallsBackToByteCap(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_truncated_overmax_spoof",
+		model:          "llama",
+		contentBytes:   640,
+		reportedPrompt: 12,
+		reportedComp:   200,
+		maxTokens:      128,
+		streamErr:      errors.New("forced upstream stream failure"),
+		wantOutcome:    "stream_output_exceeded",
+		wantSource:     "gateway_estimated",
+		wantCompletion: 128,
+	})
+}
+
+func TestSettleFromUsage_RunawayByteStream_HardCap(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_runaway_hard_cap",
+		model:          "llama",
+		contentBytes:   128*8*4 + 1,
+		noUsage:        true,
+		maxTokens:      128,
+		wantOutcome:    "stream_output_exceeded",
+		wantSource:     "gateway_estimated",
+		wantCompletion: 128,
+	})
+}
+
+func TestSettleFromUsage_ClientDisconnectOverMaxWithoutObservedOutput_FallsBackToByteCap(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_client_disconnect_overmax_spoof",
+		model:          "llama",
+		contentBytes:   640,
+		reportedPrompt: 12,
+		reportedComp:   200,
+		maxTokens:      128,
+		failWriteAt:    3,
+		wantOutcome:    "stream_output_exceeded",
+		wantSource:     "gateway_estimated",
+		wantCompletion: 128,
+	})
+}
+
+func TestSettleFromUsage_ClientDisconnect_WithUsage(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_client_disconnect",
+		model:          "llama",
+		contentBytes:   120,
+		reportedPrompt: 12,
+		reportedComp:   42,
+		maxTokens:      128,
+		failWriteAt:    3,
+		wantOutcome:    "client_disconnect",
+		wantSource:     "provider_reported",
+		wantCompletion: 42,
+		wantPrompt:     12,
+	})
+}
+
+func TestSettleFromUsage_MalformedSSEChunk(t *testing.T) {
+	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
+		accountID:      "acct_usage_malformed_sse",
+		model:          "llama",
+		contentBytes:   120,
+		malformed:      true,
+		maxTokens:      128,
+		wantOutcome:    "stream_malformed",
+		wantSource:     "gateway_estimated",
+		wantCompletion: 30,
+	})
+}
+
+type streamingUsageSettlementCase struct {
+	accountID      string
+	model          string
+	contentBytes   int
+	chunks         int
+	reportedPrompt int64
+	reportedComp   int64
+	noUsage        bool
+	invalidUsage   bool
+	malformed      bool
+	streamErr      error
+	failWriteAt    int
+	maxTokens      int64
+	wantOutcome    string
+	wantSource     string
+	wantCompletion int64
+	wantPrompt     int64
+}
+
+func runStreamingUsageSettlementCase(t *testing.T, c streamingUsageSettlementCase) {
+	t.Helper()
+	body := fmt.Sprintf(`{"model":%q,"stream":true,"max_tokens":%d,"messages":[{"role":"user","content":"ok"}]}`, c.model, c.maxTokens)
+	payload := streamingUsagePayload(c)
+	ctx := context.Background()
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		header := http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}
+		if c.streamErr != nil {
+			pr, pw := io.Pipe()
+			go func() {
+				_, _ = pw.Write([]byte(payload))
+				_ = pw.CloseWithError(c.streamErr)
+			}()
+			return &http.Response{StatusCode: http.StatusOK, Header: header, Body: pr}, nil
+		}
+		return responseWithBody(http.StatusOK, header, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, c.accountID)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+fullKey)
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	var resp http.ResponseWriter = recorder
+	if c.failWriteAt > 0 {
+		resp = &failingResponseWriter{ResponseWriter: recorder, failAt: c.failWriteAt}
+	}
+	h.ServeHTTP(resp, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, c.accountID)
+	if outcome != c.wantOutcome || source != c.wantSource || completion != c.wantCompletion {
+		t.Fatalf("usage row outcome/source/completion = %s/%s/%d, want %s/%s/%d; body=%s", outcome, source, completion, c.wantOutcome, c.wantSource, c.wantCompletion, recorder.Body.String())
+	}
+	if c.wantSource == "provider_reported" && prompt != c.wantPrompt {
+		t.Fatalf("usage row prompt_tokens = %d, want %d", prompt, c.wantPrompt)
 	}
 }
 
-// TestStreamingProviderReportedUnderbillClampedToReported pins the
-// issue #278 symmetric fix: when the gateway's byte-derived estimate
-// runs slightly ABOVE the provider's WS usage frame, the gateway clamps
-// back to the provider's authoritative tokenizer count — but ONLY when
-// the upward overshoot sits inside the same pure-absolute window
-// `(clampFloorTokens=2, clampCeilingTokens=20]` used by the #255/#262
-// downward clamp.
-//
-// Outside the window — below floor (benign tokenizer noise) OR above
-// ceiling (too large to be tokenizer noise; likely stream truncation or
-// zero-report fraud) — the gateway keeps the byte estimate.
-func TestStreamingProviderReportedUnderbillClampedToReported(t *testing.T) {
-	type tc struct {
-		name              string
-		contentBytes      int   // bytes of delta.content streamed
-		reportedPromptTok int64 // provider's usage.prompt_tokens
-		reportedCompTok   int64 // provider's usage.completion_tokens
-		wantClamp         bool  // true -> source=provider_reported, comp=reported
-		wantSource        string
-		wantBilledCompTk  int64 // expected completion_tokens in usage_events row
+func streamingUsagePayload(c streamingUsageSettlementCase) string {
+	output := strings.Repeat("x", c.contentBytes)
+	chunks := c.chunks
+	if chunks <= 0 {
+		chunks = 1
 	}
-	cases := []tc{
-		// Exact / within-floor: keep current gateway-estimate behavior when observed > reported.
-		{name: "exact_match_trusts_provider", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 10, wantClamp: false, wantSource: "provider_reported", wantBilledCompTk: 10},
-		{name: "1_token_overshoot_within_floor_trusts_gateway_estimate", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 9, wantClamp: false, wantSource: "gateway_estimated", wantBilledCompTk: 10},
-		{name: "2_token_overshoot_at_floor_trusts_gateway_estimate", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 8, wantClamp: false, wantSource: "gateway_estimated", wantBilledCompTk: 10},
-		// In-window clamp: small upward estimator inflation -> clamp; preserve provider prompt.
-		{name: "3_token_overshoot_in_window_clamps", contentBytes: 40, reportedPromptTok: 7, reportedCompTok: 7, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 7},
-		{name: "5_token_overshoot_in_window_clamps", contentBytes: 60, reportedPromptTok: 11, reportedCompTok: 10, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 10},
-		{name: "9_token_overshoot_in_window_clamps", contentBytes: 76, reportedPromptTok: 13, reportedCompTok: 10, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 10},
-		{name: "15_token_overshoot_in_window_clamps", contentBytes: 100, reportedPromptTok: 17, reportedCompTok: 10, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 10},
-		{name: "20_token_overshoot_at_ceiling_clamps", contentBytes: 400, reportedPromptTok: 19, reportedCompTok: 80, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 80},
-		// Zero-report boundary (R2 SECURITY LOW): a hostile provider may
-		// report 0 completion tokens. At the ceiling boundary the clamp
-		// fires and bills 0 (bounded ≤ 20-token underbill, same as the
-		// symmetric over-report risk accepted in #262). Just above the
-		// ceiling the gateway estimator wins, protecting against
-		// stream-truncation / zero-report fraud with no per-request bound.
-		{name: "zero_report_at_ceiling_clamps_to_zero", contentBytes: 80, reportedPromptTok: 19, reportedCompTok: 0, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 0},
-		{name: "zero_report_just_above_ceiling_trusts_gateway_estimate", contentBytes: 84, reportedPromptTok: 19, reportedCompTok: 0, wantClamp: false, wantSource: "gateway_estimated", wantBilledCompTk: 21},
-		// v0.4 scenario-07 patterns: English Qwen3-32B output where ceil(bytes/4) ran high.
-		{name: "v04_scenario07_reported_55_observed_64_clamps", contentBytes: 256, reportedPromptTok: 23, reportedCompTok: 55, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 55},
-		{name: "v04_scenario07_reported_33_observed_42_clamps", contentBytes: 168, reportedPromptTok: 29, reportedCompTok: 33, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 33},
-		{name: "v04_scenario07_reported_34_observed_41_clamps", contentBytes: 164, reportedPromptTok: 31, reportedCompTok: 34, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 34},
-		{name: "v04_scenario07_reported_46_observed_52_clamps", contentBytes: 208, reportedPromptTok: 37, reportedCompTok: 46, wantClamp: true, wantSource: "provider_reported", wantBilledCompTk: 46},
-		// Above ceiling: keep gateway estimate to protect stream-truncation / zero-report fraud cases.
-		{name: "21_token_overshoot_just_above_ceiling_trusts_gateway_estimate", contentBytes: 400, reportedPromptTok: 19, reportedCompTok: 79, wantClamp: false, wantSource: "gateway_estimated", wantBilledCompTk: 100},
-		{name: "100_token_overshoot_large_trusts_gateway_estimate", contentBytes: 600, reportedPromptTok: 19, reportedCompTok: 50, wantClamp: false, wantSource: "gateway_estimated", wantBilledCompTk: 150},
+	parts := make([]string, 0, chunks+3)
+	for i := 0; i < chunks; i++ {
+		start := i * len(output) / chunks
+		end := (i + 1) * len(output) / chunks
+		parts = append(parts, `data: {"id":"chatcmpl","choices":[{"delta":{"content":"`+output[start:end]+`"},"finish_reason":null}]}`)
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			output := strings.Repeat("x", c.contentBytes)
-			usageFrame := fmt.Sprintf(`data: {"id":"chatcmpl","usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d},"choices":[{"delta":{},"finish_reason":"stop"}]}`, c.reportedPromptTok, c.reportedCompTok, c.reportedPromptTok+c.reportedCompTok)
-			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-				payload := strings.Join([]string{
-					`data: {"id":"chatcmpl","choices":[{"delta":{"content":"` + output + `"}}]}`,
-					usageFrame,
-					`data: [DONE]`,
-					``,
-				}, "\n\n")
-				return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
-			})}
-			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
-				cfg.Coordinator.BuyerURL = "http://coordinator.test"
-			}, WithHTTPClient(client))
-			accountID := "acct_iss278_" + c.name
-			fullKey := createAccountAndKey(t, store, cfg, accountID)
-
-			observed := estimateTokensFromBytes(int64(c.contentBytes))
-			body := fmt.Sprintf(`{"model":"llama","stream":true,"max_tokens":%d,"messages":[{"role":"user","content":"ok"}]}`, observed+200)
-			resp := postChat(t, h, fullKey, body, nil)
-			if resp.Code != http.StatusOK {
-				t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
-			}
-			outcome, source, billedComp, billedPrompt := usageEventOutcomeAndTokens(t, dbPath, accountID)
-			if outcome != "ok" {
-				t.Fatalf("outcome = %q, want ok", outcome)
-			}
-			if source != c.wantSource {
-				t.Errorf("token_source = %q, want %q (clamp=%v: reported=%d observed=%d/%dB window=(%d,%d])",
-					source, c.wantSource, c.wantClamp, c.reportedCompTok, observed, c.contentBytes, clampFloorTokens, clampCeilingTokens)
-			}
-			if billedComp != c.wantBilledCompTk {
-				t.Errorf("billed completion_tokens = %d, want %d", billedComp, c.wantBilledCompTk)
-			}
-			wantPrompt := estimatePromptTokens([]byte(body))
-			if c.wantSource == "provider_reported" {
-				wantPrompt = c.reportedPromptTok
-			}
-			if billedPrompt != wantPrompt {
-				t.Errorf("billed prompt_tokens = %d, want %d", billedPrompt, wantPrompt)
-			}
-		})
+	switch {
+	case c.malformed:
+		parts = append(parts, `data: not-json`)
+	case c.invalidUsage:
+		parts = append(parts, `data: {"id":"chatcmpl","usage":{"prompt_tokens":0,"completion_tokens":-5,"total_tokens":-5},"choices":[{"delta":{},"finish_reason":"stop"}]}`)
+	case !c.noUsage:
+		parts = append(parts, fmt.Sprintf(`data: {"id":"chatcmpl","usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d},"choices":[{"delta":{},"finish_reason":"stop"}]}`, c.reportedPrompt, c.reportedComp, c.reportedPrompt+c.reportedComp))
 	}
-}
-
-// TestClampWindow pins the issue #255 pure-absolute window:
-//
-//	(clampFloorTokens=2, clampCeilingTokens=20]
-//
-// An over-report `o` clamps iff `2 < o <= 20`. Below floor → trust
-// provider (benign tokenizer noise). Above ceiling → trust provider
-// (gateway byte-estimate is unreliable on dense content; clamping
-// would risk under-billing).
-func TestClampWindow(t *testing.T) {
-	floor, ceiling := clampWindow()
-	if floor != 2 {
-		t.Errorf("clampFloorTokens = %d, want 2", floor)
+	if !c.malformed && c.streamErr == nil {
+		parts = append(parts, `data: [DONE]`, ``)
 	}
-	if ceiling != 20 {
-		t.Errorf("clampCeilingTokens = %d, want 20", ceiling)
-	}
-	// Anti-regression: window does not scale with observed value.
-	// (Earlier versions used max(2, ceil(5% × observed)) for floor
-	// and floor(50% × observed) for ceiling; both led to false-
-	// positive under-bills on moderate-density content.)
-	if clampCeilingTokens <= clampFloorTokens {
-		t.Errorf("clampCeilingTokens (%d) must be > clampFloorTokens (%d)", clampCeilingTokens, clampFloorTokens)
-	}
-}
-
-func TestClampWindowSymmetric(t *testing.T) {
-	floor, ceiling := clampWindow()
-	for _, c := range []struct {
-		name      string
-		reported  int64
-		observed  int64
-		wantClamp bool
-	}{
-		{name: "downward_floor", reported: 12, observed: 10, wantClamp: false},
-		{name: "downward_in_window", reported: 13, observed: 10, wantClamp: true},
-		{name: "downward_ceiling", reported: 30, observed: 10, wantClamp: true},
-		{name: "downward_above_ceiling", reported: 31, observed: 10, wantClamp: false},
-		{name: "upward_floor", reported: 8, observed: 10, wantClamp: false},
-		{name: "upward_in_window", reported: 7, observed: 10, wantClamp: true},
-		{name: "upward_ceiling", reported: 10, observed: 30, wantClamp: true},
-		{name: "upward_above_ceiling", reported: 10, observed: 31, wantClamp: false},
-	} {
-		t.Run(c.name, func(t *testing.T) {
-			var overshoot int64
-			if c.reported > c.observed {
-				overshoot = c.reported - c.observed
-			} else {
-				overshoot = c.observed - c.reported
-			}
-			gotClamp := overshoot > floor && overshoot <= ceiling
-			if gotClamp != c.wantClamp {
-				t.Errorf("symmetric clamp for reported=%d observed=%d overshoot=%d = %v, want %v (window=(%d,%d])",
-					c.reported, c.observed, overshoot, gotClamp, c.wantClamp, floor, ceiling)
-			}
-		})
-	}
+	return strings.Join(parts, "\n\n")
 }
 
 func usageEventOutcomeAndTokens(t *testing.T, dbPath, accountID string) (outcome, source string, completion, prompt int64) {
@@ -4324,6 +4372,58 @@ func (r cancelingReadCloser) Read(_ []byte) (int, error) {
 
 func (r cancelingReadCloser) Close() error {
 	return nil
+}
+
+type failingResponseWriter struct {
+	http.ResponseWriter
+	writes int
+	failAt int
+}
+
+func (w *failingResponseWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes >= w.failAt {
+		return 0, errors.New("forced buyer write failure")
+	}
+	return w.ResponseWriter.Write(p)
+}
+
+type cancelAfterChunksReadCloser struct {
+	chunks [][]byte
+	cancel func()
+	done   bool
+}
+
+func (r *cancelAfterChunksReadCloser) Read(p []byte) (int, error) {
+	if len(r.chunks) > 0 {
+		n := copy(p, r.chunks[0])
+		r.chunks[0] = r.chunks[0][n:]
+		if len(r.chunks[0]) == 0 {
+			r.chunks = r.chunks[1:]
+		}
+		return n, nil
+	}
+	if !r.done {
+		r.done = true
+		r.cancel()
+		return 0, context.Canceled
+	}
+	return 0, io.EOF
+}
+
+func (r *cancelAfterChunksReadCloser) Close() error {
+	return nil
+}
+
+func splitSSEPayloadChunks(payload string) [][]byte {
+	frames := strings.SplitAfter(payload, "\n\n")
+	chunks := make([][]byte, 0, len(frames))
+	for _, frame := range frames {
+		if frame != "" {
+			chunks = append(chunks, []byte(frame))
+		}
+	}
+	return chunks
 }
 
 func responseWithBody(status int, header http.Header, body string) *http.Response {

--- a/specs/AUDIT_SPEC_WAVE_0A_0B_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_SPEC_WAVE_0A_0B_ARCHITECT_PROMPT.md
@@ -1,0 +1,28 @@
+# AUDIT SPEC — Wave 0a/0b ARCHITECT lane
+
+You are auditing the current worktree diff for architecture, boundaries, and maintainability.
+
+Scope:
+- Wave 0a gateway settlement-from-usage changes in `phase5-gateway/internal/router/chat_proxy.go` and tests.
+- Wave 0b coordinator rate-card key normalization in `phase4-coordinator/internal/billing/formula.go` and tests.
+
+Required verdict:
+- Return findings grouped by severity: CRITICAL, HIGH, MEDIUM, LOW.
+- If there are no CRITICAL/HIGH/MEDIUM findings, say exactly that.
+- Ground every finding in concrete file/line references.
+
+Architecture audit requirements:
+1. Enumerate every place the old clamp logic was reachable before this diff, and every place it is reachable after this diff.
+2. Verify the gateway fix is settlement-selection-only: no schema changes, no token_source enum changes, no per-model tokenizer registry, no shared package, no billing arithmetic changes.
+3. Verify the coordinator fix is file-local normalization only: no shared abstraction, no class-aware regex/prefix system beyond the requested defensive minimum, no routing/admission changes.
+4. Verify exact-match rate-card keys preserve operator override semantics before normalization.
+5. Verify normalization behavior and suffix stripping match the Wave 0b requirements and tests.
+6. Enumerate every log-shape regression risk, especially coordinator normalization logs and unchanged gateway chat-completion/stream logs.
+7. Enumerate every billing-arithmetic touch. Expected answer: zero arithmetic changes; this should be selection-only.
+8. Evaluate whether tests are appropriately scoped and not overfitted to helper internals.
+
+Validation evidence available:
+- `( cd phase5-gateway && go vet ./... && go test ./... )`
+- `( cd phase4-coordinator && go vet ./... && go test ./... )`
+
+Do not propose out-of-scope Wave 0c, SPEC-005 v0.3 class-aware lookup, tokenizer ports, schema changes, token_source enum changes, or coordinator routing changes.

--- a/specs/AUDIT_SPEC_WAVE_0A_0B_CODE_PROMPT.md
+++ b/specs/AUDIT_SPEC_WAVE_0A_0B_CODE_PROMPT.md
@@ -1,0 +1,28 @@
+# AUDIT SPEC — Wave 0a/0b CODE lane
+
+You are auditing the current worktree diff for the macprovider repo.
+
+Scope:
+- Wave 0a gateway: `phase5-gateway/internal/router/chat_proxy.go` plus tests under `phase5-gateway/internal/router/`.
+- Wave 0b coordinator: `phase4-coordinator/internal/billing/formula.go` plus tests under `phase4-coordinator/internal/billing/`.
+
+Required verdict:
+- Return findings grouped by severity: CRITICAL, HIGH, MEDIUM, LOW.
+- If there are no CRITICAL/HIGH/MEDIUM findings, say exactly that.
+- Ground every finding in concrete file/line references.
+
+Audit requirements:
+1. Enumerate every place the old streaming completion clamp logic was reachable before this diff, and every place it is reachable after this diff.
+2. Verify clean SSE streams with valid provider usage settle `provider_reported` using `usage.prompt_tokens` and `usage.completion_tokens`.
+3. Verify no-usage and invalid-usage streaming paths still fall back to `gateway_estimated`.
+4. Verify the mid-stream byte guard no longer rejects MoE-like 640-byte/128-token streams before usage arrives, while a hard runaway byte ceiling remains.
+5. Verify provider-reported `completion_tokens > max_tokens` on streaming settles `stream_output_exceeded` from provider usage rather than invalid usage.
+6. Verify coordinator `RateFor` lookup order is exact string, normalized key, default, zero.
+7. Enumerate every billing-arithmetic touch. Expected answer: zero arithmetic changes; this should be selection-only.
+8. Check tests pin the Wave 0a/0b regression matrix from `specs/BUILD_SPEC_WAVE_0A_GATEWAY_USAGE_TRUST_IMPL_PROMPT.md`.
+
+Validation evidence available:
+- `( cd phase5-gateway && go vet ./... && go test ./... )`
+- `( cd phase4-coordinator && go vet ./... && go test ./... )`
+
+Do not suggest out-of-scope work such as provider tokenizer ports, shared packages, schema changes, token_source enum changes, coordinator routing changes, or SPEC-005 class-aware matching.

--- a/specs/AUDIT_SPEC_WAVE_0A_0B_SECURITY_PROMPT.md
+++ b/specs/AUDIT_SPEC_WAVE_0A_0B_SECURITY_PROMPT.md
@@ -1,0 +1,28 @@
+# AUDIT SPEC — Wave 0a/0b SECURITY lane
+
+You are auditing the current worktree diff for money-path security risks.
+
+Scope:
+- Wave 0a gateway settlement-from-usage changes in `phase5-gateway/internal/router/chat_proxy.go` and tests.
+- Wave 0b coordinator rate-card key normalization in `phase4-coordinator/internal/billing/formula.go` and tests.
+
+Required verdict:
+- Return findings grouped by severity: CRITICAL, HIGH, MEDIUM, LOW.
+- If there are no CRITICAL/HIGH/MEDIUM findings, say exactly that.
+- Ground every finding in concrete file/line references.
+
+Security audit requirements:
+1. Enumerate every place the old clamp logic was reachable before this diff, and every place it is reachable after this diff.
+2. Evaluate whether trusting provider usage on valid streaming usage chunks creates a buyer overbilling, provider underbilling, quota bypass, or settlement spoofing path.
+3. Evaluate the remaining validation boundaries for streaming `usage`: non-negative counts, total consistency, max total bound, invalid usage fallback, and provider-reported over-max completion settling as `stream_output_exceeded`.
+4. Evaluate the hard byte ceiling as a runaway-stream defense. Confirm the old soft byte estimate no longer creates false `stream_output_exceeded` on MoE streams before usage arrives.
+5. Evaluate client disconnect, truncated stream, malformed SSE, no usage, and invalid usage settlement paths.
+6. Evaluate coordinator normalization for rate-card mis-selection, default fallback abuse, nil/empty maps, exact-match precedence, and log leakage.
+7. Enumerate every log-shape regression risk, especially required `event=rate_card_normalized requested=<verbatim> normalized=<normalized> matched=<which>` fields and existing gateway log shapes.
+8. Enumerate every billing-arithmetic touch. Expected answer: zero arithmetic changes; this should be selection-only.
+
+Validation evidence available:
+- `( cd phase5-gateway && go vet ./... && go test ./... )`
+- `( cd phase4-coordinator && go vet ./... && go test ./... )`
+
+Do not inspect or rely on Layr-Labs/d-inference source. Do not propose schema, enum, shared-package, routing, or tokenizer-port changes for this PR.

--- a/specs/SPEC-WAVE-0A-0B-r1-audit.md
+++ b/specs/SPEC-WAVE-0A-0B-r1-audit.md
@@ -1,0 +1,26 @@
+# SPEC-WAVE-0A-0B r1 audit
+
+Date: 2026-06-30
+
+Artifacts:
+- Code: `.omc/artifacts/ask/codex-audit-spec-wave-0a-0b-code-lane-you-are-auditing-the-current-2026-06-30T17-02-18-354Z.md`
+- Security: `.omc/artifacts/ask/codex-audit-spec-wave-0a-0b-security-lane-you-are-auditing-the-cur-2026-06-30T17-03-00-935Z.md`
+- Architect: `.omc/artifacts/ask/codex-audit-spec-wave-0a-0b-architect-lane-you-are-auditing-the-cu-2026-06-30T17-01-22-575Z.md`
+
+Verdict:
+- Code: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW.
+- Architect: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 2 LOW.
+- Security: 0 CRITICAL / 0 HIGH / 2 MEDIUM / 0 LOW.
+
+Security findings:
+- MEDIUM: valid streaming usage could severely under-report emitted output and settle `provider_reported`.
+- MEDIUM: coordinator normalization stripped any namespace before `/`, allowing unknown namespaces such as `other/qwen3-32b-4bit` to match known model keys before `default`.
+
+Fixes applied after r1:
+- Added a narrow gateway fallback for implausible provider under-reports.
+- Restricted coordinator namespace stripping to the requested known namespaces.
+- Added unknown-namespace rate-card regression coverage.
+
+Accepted LOWs:
+- Architect LOW: new `rate_card_normalized` hot-path log shape is intentional audit visibility.
+- Architect LOW: gateway hard-byte-ceiling warning message changed from the old soft-cap warning.

--- a/specs/SPEC-WAVE-0A-0B-r2-audit.md
+++ b/specs/SPEC-WAVE-0A-0B-r2-audit.md
@@ -1,0 +1,24 @@
+# SPEC-WAVE-0A-0B r2 audit
+
+Date: 2026-06-30
+
+Artifacts:
+- Security: `.omc/artifacts/ask/codex-audit-spec-wave-0a-0b-security-lane-you-are-auditing-the-cur-2026-06-30T17-08-54-821Z.md`
+
+Skipped lanes:
+- Code accepted in r1.
+- Architect accepted in r1 with LOWs documented.
+
+Verdict:
+- Security: 0 CRITICAL / 2 HIGH / 1 MEDIUM / 1 LOW.
+
+Security findings:
+- HIGH: streaming `usage.completion_tokens > max_tokens` could settle above buyer max because streaming bypassed the parser's independent completion cap and storage only enforced the broader prompt-headroom total cap.
+- HIGH: implausible-underreport fallback allowed large underreports where `reported` stayed above the 25% ratio floor.
+- MEDIUM: canonical `meta-llama/Llama-...-4bit` normalized to `llama-...`, missing `meta-llama/llama-...` rate-card keys.
+- LOW: gateway hard-cap warning message changed.
+
+Fixes applied after r2:
+- Required emitted output to substantiate provider-reported over-`max_tokens` usage before settling above max.
+- Tightened severe-underreport fallback to catch large gaps above a 1.5x observed/reported ratio while preserving the Llama 93-vs-69 production case.
+- Preserved canonical `meta-llama/` namespace during normalization and added coverage.

--- a/specs/SPEC-WAVE-0A-0B-r3-audit.md
+++ b/specs/SPEC-WAVE-0A-0B-r3-audit.md
@@ -1,0 +1,24 @@
+# SPEC-WAVE-0A-0B r3 audit
+
+Date: 2026-06-30
+
+Artifacts:
+- Security: `.omc/artifacts/ask/codex-audit-spec-wave-0a-0b-security-lane-you-are-auditing-the-cur-2026-06-30T17-14-07-977Z.md`
+
+Skipped lanes:
+- Code accepted in r1.
+- Architect accepted in r1 with LOWs documented.
+
+Verdict:
+- Security: 0 CRITICAL / 1 HIGH / 0 MEDIUM / 1 LOW.
+
+Security finding:
+- HIGH: over-`max_tokens` provider usage handling only ran when `outcome == "ok"`, leaving truncated/client-disconnect reported-usage paths able to settle over-max usage without the spoof guard.
+- LOW: rate-card normalization log shape is not pinned by tests.
+
+Fixes applied after r3:
+- Made over-`max_tokens` handling outcome-independent inside `settleReported`.
+- Added truncated and buyer-disconnect over-max spoof regression tests.
+
+Accepted LOWs:
+- Rate-card normalization log shape is present in code and documented; selection behavior is pinned by tests.

--- a/specs/SPEC-WAVE-0A-0B-r4-audit.md
+++ b/specs/SPEC-WAVE-0A-0B-r4-audit.md
@@ -1,0 +1,21 @@
+# SPEC-WAVE-0A-0B r4 audit
+
+Date: 2026-06-30
+
+Artifacts:
+- Security: `.omc/artifacts/ask/codex-audit-spec-wave-0a-0b-security-lane-you-are-auditing-the-cur-2026-06-30T17-18-33-005Z.md`
+
+Skipped lanes:
+- Code accepted in r1.
+- Architect accepted in r1 with LOWs documented.
+
+Verdict:
+- Security: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 1 LOW.
+
+Accepted LOW:
+- Rate-card normalization log shape is not pinned by tests. The required `event=rate_card_normalized requested=<verbatim> normalized=<normalized> matched=<which>` fields are present on normalized match/default/no-match paths. The PR documents this LOW rather than iterating further per stop-on-low guidance.
+
+Final audit convergence:
+- Code: 0 CRITICAL / 0 HIGH / 0 MEDIUM.
+- Security: 0 CRITICAL / 0 HIGH / 0 MEDIUM.
+- Architect: 0 CRITICAL / 0 HIGH / 0 MEDIUM.


### PR DESCRIPTION
## Summary

This is the Entry 94 Wave 0a/0b money-path bundle.

Wave 0a fixes gateway streaming settlement for the three confirmed production failure modes:
- A: MoE streams (`gpt-oss-20b`, `Qwen3-Coder-30B-A3B`) hit `stream_output_exceeded` mid-stream from byte projection before provider usage arrived.
- B: `Qwen2.5-Coder-32B` settled 12 tokens low through the old downclamp path.
- C: `Llama-3.1-8B` settled 24 tokens high through the old trust-byte-estimate path.

Production confirmation: Pearl `usage_events` had all three failure classes settling with `token_source='gateway_estimated'`, plus 15 fresh `gpt-oss-20b` `stream_output_exceeded` rows at 14:54-15:00Z on 2026-06-30, indicating live buyer traffic was being rejected.

Wave 0b fixes coordinator `RateFor` model-key lookup by preserving exact operator keys, then trying file-local normalized keys, then `default`, then zero-rate fallback.

Entry 94 PR reference: https://github.com/Augustas11/macprovider/pull/287

## Failure-mode test map

| Path | Failure mode | Tests |
| --- | --- | --- |
| A | MoE byte estimate exceeded max before usage arrived | `TestSettleFromUsage_GptOss_20B_NoMidStreamByteCap`, `TestSettleFromUsage_Qwen3Coder_30B_A3B_NoMidStreamByteCap`, `TestSettleFromUsage_RunawayByteStream_HardCap` |
| B | Qwen2.5-Coder downclamped 128 to 116 | `TestSettleFromUsage_Qwen25_Coder_32B_NoDownclamp` |
| C | Llama-3.1 overbilled 69 as 93 | `TestSettleFromUsage_Llama_31_8B_NoOverbill` |
| Legacy | Qwen3-32B provider-reported baseline remains stable | `TestSettleFromUsage_Qwen3_32B_Legacy_Baseline` |
| Fallbacks | No usage, invalid usage, malformed, truncated, disconnect, over-max spoof | `TestSettleFromUsage_NoUsageChunk_FallsBackToByteEstimate`, `TestSettleFromUsage_InvalidUsageChunk_FallsBackToByteEstimate`, `TestSettleFromUsage_MalformedSSEChunk`, `TestSettleFromUsage_TruncatedStream_WithPartialUsage`, `TestSettleFromUsage_ClientDisconnect_WithUsage`, `TestSettleFromUsage_OverMaxWithoutObservedOutput_FallsBackToByteCap`, `TestSettleFromUsage_TruncatedOverMaxWithoutObservedOutput_FallsBackToByteCap`, `TestSettleFromUsage_ClientDisconnectOverMaxWithoutObservedOutput_FallsBackToByteCap` |
| Rate card | Exact, normalized, default, zero fallback | `TestRateFor_ExactMatch_Wins`, `TestRateFor_VerbatimWinsOverNormalized`, `TestRateFor_NormalizesMLXCommunityNamespace`, `TestRateFor_NormalizesCanonicalMetaLlamaNamespace`, `TestRateFor_NormalizesMXFP4Suffix`, `TestRateFor_UnknownNamespaceDoesNotNormalizeToKnownModel`, default/zero tests |

## Audits

Codex audit prompts:
- `specs/AUDIT_SPEC_WAVE_0A_0B_CODE_PROMPT.md`
- `specs/AUDIT_SPEC_WAVE_0A_0B_SECURITY_PROMPT.md`
- `specs/AUDIT_SPEC_WAVE_0A_0B_ARCHITECT_PROMPT.md`

Audit rounds:
- `specs/SPEC-WAVE-0A-0B-r1-audit.md`
- `specs/SPEC-WAVE-0A-0B-r2-audit.md`
- `specs/SPEC-WAVE-0A-0B-r3-audit.md`
- `specs/SPEC-WAVE-0A-0B-r4-audit.md`

Final audit status:
- Code: 0 CRITICAL / 0 HIGH / 0 MEDIUM
- Security: 0 CRITICAL / 0 HIGH / 0 MEDIUM
- Architect: 0 CRITICAL / 0 HIGH / 0 MEDIUM

LOWs documented and accepted:
- New `rate_card_normalized` hot-path log shape is intentional audit visibility.
- Gateway hard byte ceiling warning message changed from the old soft-cap warning.
- Rate-card normalization log shape is present but not pinned by tests.

## Validation

- `( cd phase5-gateway && go vet ./... && go test ./... )`
- `( cd phase4-coordinator && go vet ./... && go test ./... )`
