### PR TITLE
spec(023): land Wave 0c pre-SPEC research + SPEC-023 v0.1 kickstart prompt

### DIFF
--- a/specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_MEMO.md
+++ b/specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_MEMO.md
@@ -1,0 +1,608 @@
+<!-- Preface added during commit (the codex probe was fired before operator caught SPEC-018 was already taken by SPEC-018-agentic-tool-calling). All references to "SPEC-018" in this memo should be read as "SPEC-023 — Installer-Integrated Autotune Recommend." The codex output is preserved verbatim below for audit-trail integrity. -->
+
+# SPEC-018 v0.1 Goodhart Probe Memo
+
+Read-only probe. No code or spec files modified. Local context used: [CLAUDE.md](/Users/augstar/macprovider-poc/CLAUDE.md:1), [RESEARCH_229 prompt](/Users/augstar/macprovider-poc/specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_PROMPT.md:1), Entry 92/93/94 in [beta/DECISION_CRITERIA.md](/Users/augstar/macprovider-poc/beta/DECISION_CRITERIA.md:394), and supporting rate-card research in [RESEARCH_226](/Users/augstar/macprovider-poc/specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_MEMO.md:1) / [RESEARCH_227](/Users/augstar/macprovider-poc/specs/RESEARCH_227_RATE_CARD_V3_MEMO.md:1).
+
+## Part 1 — Failure-Mode Catalog
+
+### FM-1 — Winner-Take-All Herding On Rank
+
+| Field | Assessment |
+|---|---|
+| Scenario | 50 Tier-A providers install in the same launch week. If `demand_signal` strongly favors OpenRouter rank, all 50 see `gpt-oss-20b` as the highest expected `$/hr`: on M5-class data, `gpt-oss-20b` is ~35-37 tok/s at `$0.100/M`; qwen3-coder is also strong, but if rank weight dominates, the recommendation collapses to one row. |
+| What formula does wrong | It treats each provider’s recommendation as independent, but the network outcome is coupled. The 50th `gpt-oss-20b` provider adds much less buyer coverage than the first provider on Qwen3-Coder, Llama, or another eligible SKU. |
+| Corrupted intent | “Recommend the model that earns this provider most” becomes “herd the fleet into yesterday’s single highest public demand row,” which destroys catalog coverage. |
+| Severity | **Network-killing** if unmitigated for buyer-visible SKUs: buyer requests for uncovered models return `503 no provider`. |
+| Goodhart analogue | PageRank made “importance” measurable, then SEO optimized links around the measure rather than page quality. Here, rank becomes the target instead of buyer availability. |
+
+### FM-2 — Cold-Start Exclusion For New Rows
+
+| Field | Assessment |
+|---|---|
+| Scenario | A new deployable row lands, e.g. `deepseek-v3-distill` or a new qwen coder variant. If `demand_signal = last_7d_macprovider_requests`, the row starts at zero. Recommendation score is zero even if TPS and price are excellent. No provider installs it, so no buyer can use it, so demand remains zero. |
+| What formula does wrong | It confuses “not yet served by macprovider” with “not demanded by buyers.” |
+| Corrupted intent | Demand signal should estimate latent buyer demand; historical served traffic instead measures the current fleet’s past ability to serve. |
+| Severity | **Network-degrading** for optional rows; **network-killing** if new rows are required for market relevance. |
+| Goodhart analogue | Recommender systems that only show historically high-click items suppress new items; the metric becomes self-fulfilling exposure, not true preference. |
+
+### FM-3 — TPS Gaming / Benchmark Overfit
+
+| Field | Assessment |
+|---|---|
+| Scenario | Providers learn the autotune probe shape: short prompts, fixed max tokens, cool machine, no concurrent load. They run install in ideal conditions, close other apps, or patch local CLI output. A model appears to be 60 tok/s during install but later serves at 25 tok/s under heat, memory pressure, or real prompts. |
+| What formula does wrong | It assumes local measured TPS is stable, honest, and representative of production. The current design avoids simple self-reported TPS, which closes the easiest attack, but not all gaming. |
+| Corrupted intent | TPS should represent buyer-observed sustained throughput; install-time TPS can become a benchmark target. |
+| Severity | **Network-degrading**. It misroutes providers into fragile lanes and causes lower real `$/hr`, timeouts, and churn. |
+| Goodhart analogue | BLEU-score optimization in machine translation improved metric scores without always improving human-perceived translation quality. A fixed autotune fixture can similarly become the target. |
+
+### FM-4 — Rate-Card Update Lag / Stale Recommendation
+
+| Field | Assessment |
+|---|---|
+| Scenario | Pearl hot-reloads a rate card: qwen3-coder drops from `$0.235/M` to `$0.160/M`, or a new row becomes best. 50 installed providers keep serving the install-time recommended model. Their projected earnings change, but they do not retune. |
+| What formula does wrong | It optimizes at install time, but the inputs are not all install-time constants. Price and demand can change faster than providers naturally reinstall. |
+| Corrupted intent | “Expected $/hr” becomes a stale promise. Providers experience unexpected earnings decay and may churn before re-running autotune. |
+| Severity | **Network-degrading**; can become network-killing if stale supply remains on deprecated rows while buyers move. |
+| Local context | Entry 92 says price-setting goes through exact rate-card rows hot-reloadable by SIGHUP; Wave 0c install recommendation must survive that reality. |
+
+### FM-5 — Demand-Signal Source Mismatch
+
+| Field | Assessment |
+|---|---|
+| Scenario | OpenRouter rank says `gpt-oss-20b` and Gemma are high-volume. macprovider’s first paying buyers are coding agents requesting qwen3-coder and qwen2.5-coder. The installer keeps recommending general chat rows because public market rank is not macprovider’s actual buyer mix. |
+| What formula does wrong | It imports a global market proxy as if it were local demand. Conversely, coord stats are locally relevant but bootstrap at zero and are supply-constrained. |
+| Corrupted intent | Demand signal should estimate “probability this provider will receive paid work on this model.” Neither global rank nor local served traffic directly equals that during beta. |
+| Severity | **Network-degrading**. Wrong mix means low utilization even when individual model economics look good. |
+| Goodhart analogue | Ad platforms optimize for click-through rate even when advertisers care about conversion. Proxy demand is not the same as local paid utilization. |
+
+### FM-6 — Hardware Tier Tail Pathologies
+
+| Field | Assessment |
+|---|---|
+| Scenario | Tier-S M4 Max/Ultra and Tier-C M1/M4 Air use the same formula. Tier-C sees a high `$/M` dense 32B row and barely passes a short probe, then serves painful TTFT or swaps. Tier-S gets steered to small-active MoE because rank×TPS wins, leaving 70B/dense capacity uncovered. |
+| What formula does wrong | It multiplies throughput by price but does not encode model-class coverage value or tier-specific opportunity cost. |
+| Corrupted intent | Each hardware tier should serve the models it is uniquely good at. A uniform argmax can waste scarce high-memory/high-bandwidth hosts and overburden low-tier machines. |
+| Severity | **Network-degrading**, possibly **network-killing** for high-end rows if all Tier-S machines choose the same small-active MoE rows as Tier-C. |
+| Local context | Entry 92 already pivots to per-model RAM-first admission and keeps dense 32B/70B bandwidth gates; the installer must mirror that, not merely score all rows uniformly. |
+
+### FM-7 — Bid-Shading / Provider Coordination
+
+| Field | Assessment |
+|---|---|
+| Scenario | A provider Discord coordinates: “Tier-S operators all pick qwen2.5-coder-32b, Tier-A pick qwen3-coder, Tier-C pick gpt-oss-20b.” They avoid competition or try to dominate scarce model lanes. |
+| What formula does wrong | The formula assumes independent providers and no strategic response. Once recommendations are public and earnings visible, providers can coordinate around scarcity. |
+| Corrupted intent | Recommendations should improve network coverage and provider earnings, not create cartel-like lane allocation. |
+| Severity | **Cosmetic to network-degrading** in beta. With 120 providers and fixed rate card, the more realistic issue is herding, not cartel control. |
+| Goodhart analogue | Mining pools and ASIC concentration: participants optimize around the reward function and centralize behavior even when the protocol intended decentralization. |
+
+### FM-8 — Availability / Quality Blindness
+
+| Field | Assessment |
+|---|---|
+| Scenario | A model has strong install-time TPS but poor real reliability: high TTFT on 4K prompts, unsupported tokenizer/accounting path, high swap risk, or frequent `stream_output_exceeded`. The formula still recommends it because TPS×price×rank is high. |
+| What formula does wrong | It scores speed and price, but not “can this provider reliably serve paid buyer traffic end-to-end?” |
+| Corrupted intent | Expected `$/hr` should be paid accepted work, not local decode speed. |
+| Severity | **Network-killing** if it recommends rows that fail billing/accounting or runtime support; otherwise **network-degrading**. |
+| Local context | Entry 93/94 found real new-row gateway/accounting issues and runtime blockers. SPEC-018 v0.1 must not recommend rows until deployability gates are green. |
+
+### FM-9 — Supply-Constraint Feedback Loop In Coord Stats
+
+| Field | Assessment |
+|---|---|
+| Scenario | `coordinator.streamvc.live/v1/demand-signal` counts served tokens by model. Models with many providers get more served tokens because they are available. Models with zero providers get zero served tokens even if buyers attempted them and got `503`. |
+| What formula does wrong | It measures fulfilled supply, not attempted demand. |
+| Corrupted intent | Demand signal should guide supply into missing demand. Served-token stats guide supply toward already-served rows. |
+| Severity | **Network-degrading**; **network-killing** when it locks out uncovered models. |
+| Goodhart analogue | Marketplace ranking based only on completed sales disadvantages listings that are never shown or are out of stock. |
+
+### FM-10 — Projection Misinterpretation / Provider Churn
+
+| Field | Assessment |
+|---|---|
+| Scenario | Installer prints “expected `$0.021/hr`” for qwen3-coder from TPS×rate×share, but actual utilization is 5-20%. Provider receives `$0.001-$0.004/hr` cash plus token subsidy. They perceive the recommendation as false advertising. |
+| What formula does wrong | It computes full-utilization earning capacity, not expected realized earnings under fleet utilization and buyer volume. |
+| Corrupted intent | Onboarding should set provider expectations and reduce churn. A precise-looking formula can overpromise. |
+| Severity | **Network-degrading** via provider trust and retention. |
+| Local context | Entry 92 explicitly says USD economics are electricity-plus and token subsidy carries beta provider incentive; SPEC-018 wording must preserve that honesty. |
+
+**Part 1 conclusion:** The v0.1 risk is not one bad demand multiplier; it is turning a per-provider argmax into a fleet-wide coordination signal without coverage floors, cold-start priors, deployability gates, and stale-input handling.
+
+## Part 2 — Mitigation Library
+
+| ID | Failure modes | Mechanism | Where it lives | LOC | Adds UX / state / endpoints? | Downside | Bake into v0.1? |
+|---|---|---|---|---:|---|---|---|
+| M1 | FM-1, FM-6 | **Deterministic top-K diversification.** Instead of always selecting rank 1 score, compute eligible top 3 and choose default by stable hash of provider ID or machine fingerprint across the top band, e.g. choose among candidates within 85-90% of best score. | Formula / autotune logic | Small | No new endpoint; tiny install text may show “recommended” plus alternatives | Some providers get slightly lower projected capacity than pure argmax | **Yes** |
+| M2 | FM-1, FM-2, FM-9 | **Minimum catalog coverage floor.** SPEC says every rate-card-eligible, deployable, buyer-visible model needs at least N healthy providers by tier class before demand weighting can suppress it. For beta, N can be small, e.g. 2-3 total and at least 1 non-low-tier where required. | Operator config / formula constants | Small | No new endpoint if encoded in static demand file or release config | Requires operator to maintain row status | **Yes, if static config only** |
+| M3 | FM-2, FM-9 | **Cold-start prior / floor.** Clamp `demand_signal` to a nonzero floor for deployable rows, e.g. `max(raw_demand, 0.15)` or rank-prior fallback when local stats are empty. | Formula | Small | None | Can over-recommend speculative rows | **Yes** |
+| M4 | FM-2, FM-5 | **Row lifecycle states: candidate / listed / recommended.** New rows are not automatically recommended; they graduate only after runtime, billing, and minimum bench gates pass. Candidate rows can appear as alternatives but not default. | Operator config consumed by install/autotune | Small-medium | No new endpoint if static JSON | Slows launch of hot models | **Yes** |
+| M5 | FM-3 | **Benchmark anti-gaming guardrails.** Use CLI-owned local probe, not provider-entered TPS; require warmup + sustained window + TTFT cap + no-swap/thermal sanity. Store measured TPS locally with timestamp and candidate hash. | Autotune logic | Medium | No endpoint; no operator UX beyond progress text | Adds install time | **Yes if minimal; deeper attestation v0.2** |
+| M6 | FM-3 | **Production feedback correction.** Coordinator later compares provider-observed request TPS against install TPS and downweights bad actors. | Coord stats / routing | Large | Adds network state and policy | Can punish providers for buyer prompt variance | **Defer v0.2** |
+| M7 | FM-4 | **Rate-card version binding.** Recommendation records the rate-card/demand-file version used. Provider heartbeat or status can expose current model; install can warn on next run if config is stale. | Install.sh / autotune metadata | Small | Minimal local UX; no endpoint required | Does not auto-retune existing providers | **Yes** |
+| M8 | FM-4 | **Retune hint on upgrade / model reload.** `macprovider upgrade` or install rerun fetches current demand/rate metadata and says “recommendation changed from X to Y.” | install.sh / CLI | Small | Operator-visible UX | Providers must act manually | **Yes** |
+| M9 | FM-4 | **Coordinator push retune notices.** Broadcast “recommended model changed” to providers after hot reload. | Coord endpoint / provider protocol | Medium-large | Adds network state and provider UX | Scope creep for v0.1 | **Defer v0.2** |
+| M10 | FM-5, FM-9 | **Hybrid demand signal with bootstrap source.** v0.1 uses static/live OpenRouter rank prior; v0.2 switches to blended local attempted-demand stats after sufficient history. | Demand JSON / formula | Small now, medium later | No v0.1 endpoint if static URL | Global rank mismatch remains | **Yes for v0.1 prior; defer local blend** |
+| M11 | FM-5, FM-9 | **Track attempted demand, not just served tokens.** Count buyer requests by requested model, including `503 no provider`, auth-valid only. | Coord stats rollup | Medium-large | New coord stats surface or internal table | Abuse/spam filtering needed | **Defer v0.2** |
+| M12 | FM-6 | **Hard eligibility gates before scoring.** Filter candidates by RAM, bandwidth tier, runtime support, benchmark pass, model admission, and billing deployability before applying score. | Autotune + operator config | Small-medium | None if silent; install can show only eligible rows | Risk of hiding rows operator expected | **Yes** |
+| M13 | FM-6 | **Tier-specific opportunity-cost bonus.** Add small operator-set weights by tier: Tier-S may reserve some probability for high-end rows; Tier-C biased toward small-active MoE. | Formula config | Small | None | Hand-tuned and can become stale | **Maybe v0.1 only as static weights; otherwise defer** |
+| M14 | FM-7 | **Do nothing special in v0.1; monitor concentration.** Collusion is lower-probability than herding. The diversification and coverage floors already reduce its effect. | Spec risk register | None | None | Does not detect cartel behavior | **Yes as explicit deferral** |
+| M15 | FM-7 | **Per-provider quotas or lane caps.** Coordinator limits provider counts per model or assigns quotas. | Coord/network policy | Large | Adds network state and operator/admin surface | Heavy-handed; can reduce provider autonomy | **Defer v0.2+** |
+| M16 | FM-8 | **Deployability gate is mandatory.** A row must be marked `recommendable: true` only after end-to-end request, gateway settlement, tokenizer/accounting, and runtime architecture support are green. | Operator config / demand JSON | Small | No new endpoint | Manual bookkeeping | **Yes** |
+| M17 | FM-8 | **Quality-adjusted score factor.** Multiply by `quality_gate` or `reliability_score` from production errors and TTFT. | Coord stats / formula | Medium-large | Network state and possibly endpoint | Needs enough traffic; can feedback-loop | **Defer v0.2** |
+| M18 | FM-10 | **Label projection as full-utilization capacity.** Installer must say “at 100% utilization” or “capacity, not guaranteed earnings,” and keep token subsidy messaging separate. | install.sh UX | Small | Operator-visible UX | Less exciting onboarding copy | **Yes** |
+| M19 | FM-10 | **Utilization-adjusted expected earnings.** Use local buyer volume / fleet supply to estimate realized earnings. | Coord stats endpoint | Large | New endpoint/state | Bootstrap zero and noisy | **Defer v0.2** |
+| M20 | FM-1, FM-4, FM-5 | **Static demand-rank JSON with version and row metadata.** Serve `get.streamvc.live/demand-rank.json` containing row weights, lifecycle state, min provider coverage, and generated timestamp. Installer fetches it with baked fallback. | Static URL + install/autotune | Small-medium | No coord endpoint; no new provider state | Static file can go stale; needs operator discipline | **Yes** |
+
+### Recommended v0.1 Bake-In Set
+
+| Mechanism | Why it belongs in v0.1 |
+|---|---|
+| M1 deterministic top-K diversification | Cheaply prevents pure argmax herding without a coordinator endpoint. |
+| M3 cold-start floor | Prevents zero-demand permanent exclusion. |
+| M4 row lifecycle states | Keeps speculative or broken rows out of default recommendations. |
+| M7/M8 version binding + retune hint | Handles rate-card/demand-file drift without protocol changes. |
+| M12 hard eligibility gates | Prevents impossible or tail-pathological recommendations. |
+| M16 deployability gate | Critical after Entry 93/94: do not recommend rows until end-to-end billing/runtime is green. |
+| M18 full-utilization wording | Prevents provider trust damage from overstated “expected $/hr.” |
+| M20 static/live demand JSON | Gives operator a cheap control plane without waiting for coord stats. |
+
+### v0.1 Formula Shape
+
+Recommended v0.1 scoring should be closer to:
+
+```text
+eligible_rows = rows where:
+  rate_card_enabled
+  recommendable == true
+  model_admission passes hardware
+  local_autotune passes sustained TPS + TTFT + no-swap gates
+
+raw_score =
+  measured_tps
+  * 3600
+  * usd_per_million
+  * provider_share
+  * max(demand_weight, cold_start_floor)
+  * optional_tier_weight
+
+recommendation_pool =
+  top eligible rows within 85-90% of best raw_score
+  plus any coverage-floor row still under min_provider_target
+
+default =
+  stable_hash(provider_id_or_machine_fingerprint) across recommendation_pool
+```
+
+### v0.1 Non-Goals
+
+| Deferred item | Reason |
+|---|---|
+| Live coord `/v1/demand-signal` endpoint | Bootstrap-zero and supply-feedback risks; adds new surface. |
+| Provider quota/cap allocation | Too much market-design complexity for 120-provider beta. |
+| Production TPS reputation downweighting | Needs traffic, prompt normalization, and anti-abuse design. |
+| Utilization-adjusted earnings | Honest but data-poor before paying buyer history exists. |
+| Collusion enforcement | Lower priority than accidental herding and coverage failure. |
+
+**Part 2 conclusion:** SPEC-018 v0.1 should bake in cheap static controls: eligibility gates, deployability states, cold-start floors, top-K diversification, metadata versioning, and honest “capacity not guaranteed earnings” wording; defer live market allocation to v0.2.
+
+## Part 3 — Recommended v0.1 Demand-Signal Source
+
+### Ranking Of Options
+
+| Rank | Option | Verdict |
+|---:|---|---|
+| 1 | **(b) OpenRouter top-50 rank fetched live from static URL** | Best v0.1 choice. It avoids binary-baked staleness, works before macprovider has buyer history, and gives the operator a safe, cheap control plane. |
+| 2 | **(e) Hybrid: v0.1 OpenRouter prior, v0.2 local coord stats after 60+ days** | Correct lifecycle strategy. For v0.1 this reduces to option (b) plus an explicit migration trigger. |
+| 3 | **(a) OpenRouter rank baked into binary** | Safe fallback if network fetch fails, but too stale for a fast-changing model market. Refresh only on `macprovider upgrade` is not enough. |
+| 4 | **(d) Constant 1.0** | Simple and avoids rank herding, but price×TPS alone will over-select high-price/low-demand rows and ignore buyer market evidence. Useful as a fallback, not primary. |
+| 5 | **(c) Coord last-7-day macprovider stats** | Locally relevant later, wrong for v0.1. With ~2 providers and zero paying history, it mostly measures bootstrap accidents and current supply gaps. |
+
+### Recommended Source
+
+Use **option (b)** for v0.1:
+
+```text
+Primary: get.streamvc.live/demand-rank.json
+Fallback: baked demand-rank snapshot in the installer/CLI
+Future: switch or blend with coord attempted-demand stats after 60+ days
+```
+
+The static JSON should not be just rank. It should carry enough operator-controlled metadata to avoid separate v0.1 surfaces:
+
+```json
+{
+  "version": "2026-06-30.1",
+  "generated_at": "2026-06-30T00:00:00Z",
+  "source": "openrouter_completion_token_rank_operator_curated",
+  "cold_start_floor": 0.15,
+  "top_k_band": 0.90,
+  "rows": {
+    "openai/gpt-oss-20b": {
+      "demand_weight": 1.00,
+      "rank": 24,
+      "recommendable": true,
+      "min_provider_target": 8
+    },
+    "qwen/qwen3-coder-30b-a3b-instruct": {
+      "demand_weight": 0.85,
+      "rank": null,
+      "recommendable": true,
+      "min_provider_target": 6
+    },
+    "meta-llama/llama-3.1-8b-instruct": {
+      "demand_weight": 0.55,
+      "rank": 49,
+      "recommendable": true,
+      "min_provider_target": 3
+    }
+  }
+}
+```
+
+### Why Not Coord Stats In v0.1
+
+Coord stats are attractive because they reflect macprovider’s buyer mix, but v0.1 has three bootstrap defects:
+
+1. **Zero history:** there is not enough paying buyer traffic to estimate demand.
+2. **Supply censoring:** a model with no providers cannot accumulate served tokens.
+3. **Launch coupling:** if install recommendations are driven by served traffic, early install randomness becomes permanent market structure.
+
+If v0.2 uses coord stats, it should use **attempted demand**, not just served tokens:
+
+```text
+demand_signal_v0.2 =
+  blend(
+    OpenRouter prior,
+    auth-valid buyer requested-model counts,
+    no-provider 503 counts,
+    served paid completion tokens
+  )
+```
+
+Switch trigger should be explicit:
+
+```text
+Use local demand only after:
+  >= 60 days history
+  >= 50M paid or auth-valid requested completion-token equivalent
+  >= 5 buyer accounts or partner keys with non-test traffic
+  no single buyer contributes >50% of model demand
+```
+
+### Why Not Constant 1.0
+
+Constant demand is better than bad local stats for cold start, but it turns the formula into price×TPS. That would likely over-recommend rows like high-priced coder/dense rows even where buyer demand is thin, and it removes the one signal that distinguishes “technically fast” from “marketable.” It should be a fallback when the static JSON cannot be fetched, not the primary source.
+
+### Required v0.1 Safeguards With Option (b)
+
+| Safeguard | Reason |
+|---|---|
+| Baked fallback snapshot | Installer must work offline or if `get.streamvc.live` fails. |
+| JSON signature or checksum | Prevents accidental or tampered recommendation weights. |
+| `recommendable` flag | Operator can block rows with runtime/billing/deployability failures. |
+| Cold-start floor | Prevents permanent exclusion of new rows. |
+| Top-K diversification band | Prevents all 120 providers choosing the same highest-weight row. |
+| Version/timestamp display | Makes stale recommendation diagnosis possible. |
+| No exact earnings guarantee | Demand rank is a utilization proxy, not a guarantee. |
+
+**Part 3 conclusion:** For SPEC-018 v0.1, use operator-curated OpenRouter-prior demand weights fetched from `get.streamvc.live/demand-rank.json` with a baked fallback, then graduate to blended coord attempted-demand stats only after 60+ days of real buyer history.
+
+## Part 4 — One-Line Conclusions
+
+| Part | Liftable conclusion |
+|---|---|
+| Part 1 | The v0.1 risk is not one bad demand multiplier; it is turning a per-provider argmax into a fleet-wide coordination signal without coverage floors, cold-start priors, deployability gates, and stale-input handling. |
+| Part 2 | SPEC-018 v0.1 should bake in cheap static controls: eligibility gates, deployability states, cold-start floors, top-K diversification, metadata versioning, and honest “capacity not guaranteed earnings” wording; defer live market allocation to v0.2. |
+| Part 3 | For SPEC-018 v0.1, use operator-curated OpenRouter-prior demand weights fetched from `get.streamvc.live/demand-rank.json` with a baked fallback, then graduate to blended coord attempted-demand stats only after 60+ days of real buyer history. |
+| Overall | Ship v0.1 as a conservative installer recommendation system, not an autonomous market maker: recommend only deployable eligible rows, diversify defaults, preserve cold-start, and keep live coord demand optimization for v0.2. |
+
+
+OpenAI Codex v0.142.2
+# SPEC-018 v0.1 Goodhart Probe Memo
+
+Read-only probe. No code or spec files modified. Local context used: [CLAUDE.md](/Users/augstar/macprovider-poc/CLAUDE.md:1), [RESEARCH_229 prompt](/Users/augstar/macprovider-poc/specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_PROMPT.md:1), Entry 92/93/94 in [beta/DECISION_CRITERIA.md](/Users/augstar/macprovider-poc/beta/DECISION_CRITERIA.md:394), and supporting rate-card research in [RESEARCH_226](/Users/augstar/macprovider-poc/specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_MEMO.md:1) / [RESEARCH_227](/Users/augstar/macprovider-poc/specs/RESEARCH_227_RATE_CARD_V3_MEMO.md:1).
+
+## Part 1 — Failure-Mode Catalog
+
+### FM-1 — Winner-Take-All Herding On Rank
+
+| Field | Assessment |
+|---|---|
+| Scenario | 50 Tier-A providers install in the same launch week. If `demand_signal` strongly favors OpenRouter rank, all 50 see `gpt-oss-20b` as the highest expected `$/hr`: on M5-class data, `gpt-oss-20b` is ~35-37 tok/s at `$0.100/M`; qwen3-coder is also strong, but if rank weight dominates, the recommendation collapses to one row. |
+| What formula does wrong | It treats each provider’s recommendation as independent, but the network outcome is coupled. The 50th `gpt-oss-20b` provider adds much less buyer coverage than the first provider on Qwen3-Coder, Llama, or another eligible SKU. |
+| Corrupted intent | “Recommend the model that earns this provider most” becomes “herd the fleet into yesterday’s single highest public demand row,” which destroys catalog coverage. |
+| Severity | **Network-killing** if unmitigated for buyer-visible SKUs: buyer requests for uncovered models return `503 no provider`. |
+| Goodhart analogue | PageRank made “importance” measurable, then SEO optimized links around the measure rather than page quality. Here, rank becomes the target instead of buyer availability. |
+
+### FM-2 — Cold-Start Exclusion For New Rows
+
+| Field | Assessment |
+|---|---|
+| Scenario | A new deployable row lands, e.g. `deepseek-v3-distill` or a new qwen coder variant. If `demand_signal = last_7d_macprovider_requests`, the row starts at zero. Recommendation score is zero even if TPS and price are excellent. No provider installs it, so no buyer can use it, so demand remains zero. |
+| What formula does wrong | It confuses “not yet served by macprovider” with “not demanded by buyers.” |
+| Corrupted intent | Demand signal should estimate latent buyer demand; historical served traffic instead measures the current fleet’s past ability to serve. |
+| Severity | **Network-degrading** for optional rows; **network-killing** if new rows are required for market relevance. |
+| Goodhart analogue | Recommender systems that only show historically high-click items suppress new items; the metric becomes self-fulfilling exposure, not true preference. |
+
+### FM-3 — TPS Gaming / Benchmark Overfit
+
+| Field | Assessment |
+|---|---|
+| Scenario | Providers learn the autotune probe shape: short prompts, fixed max tokens, cool machine, no concurrent load. They run install in ideal conditions, close other apps, or patch local CLI output. A model appears to be 60 tok/s during install but later serves at 25 tok/s under heat, memory pressure, or real prompts. |
+| What formula does wrong | It assumes local measured TPS is stable, honest, and representative of production. The current design avoids simple self-reported TPS, which closes the easiest attack, but not all gaming. |
+| Corrupted intent | TPS should represent buyer-observed sustained throughput; install-time TPS can become a benchmark target. |
+| Severity | **Network-degrading**. It misroutes providers into fragile lanes and causes lower real `$/hr`, timeouts, and churn. |
+| Goodhart analogue | BLEU-score optimization in machine translation improved metric scores without always improving human-perceived translation quality. A fixed autotune fixture can similarly become the target. |
+
+### FM-4 — Rate-Card Update Lag / Stale Recommendation
+
+| Field | Assessment |
+|---|---|
+| Scenario | Pearl hot-reloads a rate card: qwen3-coder drops from `$0.235/M` to `$0.160/M`, or a new row becomes best. 50 installed providers keep serving the install-time recommended model. Their projected earnings change, but they do not retune. |
+| What formula does wrong | It optimizes at install time, but the inputs are not all install-time constants. Price and demand can change faster than providers naturally reinstall. |
+| Corrupted intent | “Expected $/hr” becomes a stale promise. Providers experience unexpected earnings decay and may churn before re-running autotune. |
+| Severity | **Network-degrading**; can become network-killing if stale supply remains on deprecated rows while buyers move. |
+| Local context | Entry 92 says price-setting goes through exact rate-card rows hot-reloadable by SIGHUP; Wave 0c install recommendation must survive that reality. |
+
+### FM-5 — Demand-Signal Source Mismatch
+
+| Field | Assessment |
+|---|---|
+| Scenario | OpenRouter rank says `gpt-oss-20b` and Gemma are high-volume. macprovider’s first paying buyers are coding agents requesting qwen3-coder and qwen2.5-coder. The installer keeps recommending general chat rows because public market rank is not macprovider’s actual buyer mix. |
+| What formula does wrong | It imports a global market proxy as if it were local demand. Conversely, coord stats are locally relevant but bootstrap at zero and are supply-constrained. |
+| Corrupted intent | Demand signal should estimate “probability this provider will receive paid work on this model.” Neither global rank nor local served traffic directly equals that during beta. |
+| Severity | **Network-degrading**. Wrong mix means low utilization even when individual model economics look good. |
+| Goodhart analogue | Ad platforms optimize for click-through rate even when advertisers care about conversion. Proxy demand is not the same as local paid utilization. |
+
+### FM-6 — Hardware Tier Tail Pathologies
+
+| Field | Assessment |
+|---|---|
+| Scenario | Tier-S M4 Max/Ultra and Tier-C M1/M4 Air use the same formula. Tier-C sees a high `$/M` dense 32B row and barely passes a short probe, then serves painful TTFT or swaps. Tier-S gets steered to small-active MoE because rank×TPS wins, leaving 70B/dense capacity uncovered. |
+| What formula does wrong | It multiplies throughput by price but does not encode model-class coverage value or tier-specific opportunity cost. |
+| Corrupted intent | Each hardware tier should serve the models it is uniquely good at. A uniform argmax can waste scarce high-memory/high-bandwidth hosts and overburden low-tier machines. |
+| Severity | **Network-degrading**, possibly **network-killing** for high-end rows if all Tier-S machines choose the same small-active MoE rows as Tier-C. |
+| Local context | Entry 92 already pivots to per-model RAM-first admission and keeps dense 32B/70B bandwidth gates; the installer must mirror that, not merely score all rows uniformly. |
+
+### FM-7 — Bid-Shading / Provider Coordination
+
+| Field | Assessment |
+|---|---|
+| Scenario | A provider Discord coordinates: “Tier-S operators all pick qwen2.5-coder-32b, Tier-A pick qwen3-coder, Tier-C pick gpt-oss-20b.” They avoid competition or try to dominate scarce model lanes. |
+| What formula does wrong | The formula assumes independent providers and no strategic response. Once recommendations are public and earnings visible, providers can coordinate around scarcity. |
+| Corrupted intent | Recommendations should improve network coverage and provider earnings, not create cartel-like lane allocation. |
+| Severity | **Cosmetic to network-degrading** in beta. With 120 providers and fixed rate card, the more realistic issue is herding, not cartel control. |
+| Goodhart analogue | Mining pools and ASIC concentration: participants optimize around the reward function and centralize behavior even when the protocol intended decentralization. |
+
+### FM-8 — Availability / Quality Blindness
+
+| Field | Assessment |
+|---|---|
+| Scenario | A model has strong install-time TPS but poor real reliability: high TTFT on 4K prompts, unsupported tokenizer/accounting path, high swap risk, or frequent `stream_output_exceeded`. The formula still recommends it because TPS×price×rank is high. |
+| What formula does wrong | It scores speed and price, but not “can this provider reliably serve paid buyer traffic end-to-end?” |
+| Corrupted intent | Expected `$/hr` should be paid accepted work, not local decode speed. |
+| Severity | **Network-killing** if it recommends rows that fail billing/accounting or runtime support; otherwise **network-degrading**. |
+| Local context | Entry 93/94 found real new-row gateway/accounting issues and runtime blockers. SPEC-018 v0.1 must not recommend rows until deployability gates are green. |
+
+### FM-9 — Supply-Constraint Feedback Loop In Coord Stats
+
+| Field | Assessment |
+|---|---|
+| Scenario | `coordinator.streamvc.live/v1/demand-signal` counts served tokens by model. Models with many providers get more served tokens because they are available. Models with zero providers get zero served tokens even if buyers attempted them and got `503`. |
+| What formula does wrong | It measures fulfilled supply, not attempted demand. |
+| Corrupted intent | Demand signal should guide supply into missing demand. Served-token stats guide supply toward already-served rows. |
+| Severity | **Network-degrading**; **network-killing** when it locks out uncovered models. |
+| Goodhart analogue | Marketplace ranking based only on completed sales disadvantages listings that are never shown or are out of stock. |
+
+### FM-10 — Projection Misinterpretation / Provider Churn
+
+| Field | Assessment |
+|---|---|
+| Scenario | Installer prints “expected `$0.021/hr`” for qwen3-coder from TPS×rate×share, but actual utilization is 5-20%. Provider receives `$0.001-$0.004/hr` cash plus token subsidy. They perceive the recommendation as false advertising. |
+| What formula does wrong | It computes full-utilization earning capacity, not expected realized earnings under fleet utilization and buyer volume. |
+| Corrupted intent | Onboarding should set provider expectations and reduce churn. A precise-looking formula can overpromise. |
+| Severity | **Network-degrading** via provider trust and retention. |
+| Local context | Entry 92 explicitly says USD economics are electricity-plus and token subsidy carries beta provider incentive; SPEC-018 wording must preserve that honesty. |
+
+**Part 1 conclusion:** The v0.1 risk is not one bad demand multiplier; it is turning a per-provider argmax into a fleet-wide coordination signal without coverage floors, cold-start priors, deployability gates, and stale-input handling.
+
+## Part 2 — Mitigation Library
+
+| ID | Failure modes | Mechanism | Where it lives | LOC | Adds UX / state / endpoints? | Downside | Bake into v0.1? |
+|---|---|---|---|---:|---|---|---|
+| M1 | FM-1, FM-6 | **Deterministic top-K diversification.** Instead of always selecting rank 1 score, compute eligible top 3 and choose default by stable hash of provider ID or machine fingerprint across the top band, e.g. choose among candidates within 85-90% of best score. | Formula / autotune logic | Small | No new endpoint; tiny install text may show “recommended” plus alternatives | Some providers get slightly lower projected capacity than pure argmax | **Yes** |
+| M2 | FM-1, FM-2, FM-9 | **Minimum catalog coverage floor.** SPEC says every rate-card-eligible, deployable, buyer-visible model needs at least N healthy providers by tier class before demand weighting can suppress it. For beta, N can be small, e.g. 2-3 total and at least 1 non-low-tier where required. | Operator config / formula constants | Small | No new endpoint if encoded in static demand file or release config | Requires operator to maintain row status | **Yes, if static config only** |
+| M3 | FM-2, FM-9 | **Cold-start prior / floor.** Clamp `demand_signal` to a nonzero floor for deployable rows, e.g. `max(raw_demand, 0.15)` or rank-prior fallback when local stats are empty. | Formula | Small | None | Can over-recommend speculative rows | **Yes** |
+| M4 | FM-2, FM-5 | **Row lifecycle states: candidate / listed / recommended.** New rows are not automatically recommended; they graduate only after runtime, billing, and minimum bench gates pass. Candidate rows can appear as alternatives but not default. | Operator config consumed by install/autotune | Small-medium | No new endpoint if static JSON | Slows launch of hot models | **Yes** |
+| M5 | FM-3 | **Benchmark anti-gaming guardrails.** Use CLI-owned local probe, not provider-entered TPS; require warmup + sustained window + TTFT cap + no-swap/thermal sanity. Store measured TPS locally with timestamp and candidate hash. | Autotune logic | Medium | No endpoint; no operator UX beyond progress text | Adds install time | **Yes if minimal; deeper attestation v0.2** |
+| M6 | FM-3 | **Production feedback correction.** Coordinator later compares provider-observed request TPS against install TPS and downweights bad actors. | Coord stats / routing | Large | Adds network state and policy | Can punish providers for buyer prompt variance | **Defer v0.2** |
+| M7 | FM-4 | **Rate-card version binding.** Recommendation records the rate-card/demand-file version used. Provider heartbeat or status can expose current model; install can warn on next run if config is stale. | Install.sh / autotune metadata | Small | Minimal local UX; no endpoint required | Does not auto-retune existing providers | **Yes** |
+| M8 | FM-4 | **Retune hint on upgrade / model reload.** `macprovider upgrade` or install rerun fetches current demand/rate metadata and says “recommendation changed from X to Y.” | install.sh / CLI | Small | Operator-visible UX | Providers must act manually | **Yes** |
+| M9 | FM-4 | **Coordinator push retune notices.** Broadcast “recommended model changed” to providers after hot reload. | Coord endpoint / provider protocol | Medium-large | Adds network state and provider UX | Scope creep for v0.1 | **Defer v0.2** |
+| M10 | FM-5, FM-9 | **Hybrid demand signal with bootstrap source.** v0.1 uses static/live OpenRouter rank prior; v0.2 switches to blended local attempted-demand stats after sufficient history. | Demand JSON / formula | Small now, medium later | No v0.1 endpoint if static URL | Global rank mismatch remains | **Yes for v0.1 prior; defer local blend** |
+| M11 | FM-5, FM-9 | **Track attempted demand, not just served tokens.** Count buyer requests by requested model, including `503 no provider`, auth-valid only. | Coord stats rollup | Medium-large | New coord stats surface or internal table | Abuse/spam filtering needed | **Defer v0.2** |
+| M12 | FM-6 | **Hard eligibility gates before scoring.** Filter candidates by RAM, bandwidth tier, runtime support, benchmark pass, model admission, and billing deployability before applying score. | Autotune + operator config | Small-medium | None if silent; install can show only eligible rows | Risk of hiding rows operator expected | **Yes** |
+| M13 | FM-6 | **Tier-specific opportunity-cost bonus.** Add small operator-set weights by tier: Tier-S may reserve some probability for high-end rows; Tier-C biased toward small-active MoE. | Formula config | Small | None | Hand-tuned and can become stale | **Maybe v0.1 only as static weights; otherwise defer** |
+| M14 | FM-7 | **Do nothing special in v0.1; monitor concentration.** Collusion is lower-probability than herding. The diversification and coverage floors already reduce its effect. | Spec risk register | None | None | Does not detect cartel behavior | **Yes as explicit deferral** |
+| M15 | FM-7 | **Per-provider quotas or lane caps.** Coordinator limits provider counts per model or assigns quotas. | Coord/network policy | Large | Adds network state and operator/admin surface | Heavy-handed; can reduce provider autonomy | **Defer v0.2+** |
+| M16 | FM-8 | **Deployability gate is mandatory.** A row must be marked `recommendable: true` only after end-to-end request, gateway settlement, tokenizer/accounting, and runtime architecture support are green. | Operator config / demand JSON | Small | No new endpoint | Manual bookkeeping | **Yes** |
+| M17 | FM-8 | **Quality-adjusted score factor.** Multiply by `quality_gate` or `reliability_score` from production errors and TTFT. | Coord stats / formula | Medium-large | Network state and possibly endpoint | Needs enough traffic; can feedback-loop | **Defer v0.2** |
+| M18 | FM-10 | **Label projection as full-utilization capacity.** Installer must say “at 100% utilization” or “capacity, not guaranteed earnings,” and keep token subsidy messaging separate. | install.sh UX | Small | Operator-visible UX | Less exciting onboarding copy | **Yes** |
+| M19 | FM-10 | **Utilization-adjusted expected earnings.** Use local buyer volume / fleet supply to estimate realized earnings. | Coord stats endpoint | Large | New endpoint/state | Bootstrap zero and noisy | **Defer v0.2** |
+| M20 | FM-1, FM-4, FM-5 | **Static demand-rank JSON with version and row metadata.** Serve `get.streamvc.live/demand-rank.json` containing row weights, lifecycle state, min provider coverage, and generated timestamp. Installer fetches it with baked fallback. | Static URL + install/autotune | Small-medium | No coord endpoint; no new provider state | Static file can go stale; needs operator discipline | **Yes** |
+
+### Recommended v0.1 Bake-In Set
+
+| Mechanism | Why it belongs in v0.1 |
+|---|---|
+| M1 deterministic top-K diversification | Cheaply prevents pure argmax herding without a coordinator endpoint. |
+| M3 cold-start floor | Prevents zero-demand permanent exclusion. |
+| M4 row lifecycle states | Keeps speculative or broken rows out of default recommendations. |
+| M7/M8 version binding + retune hint | Handles rate-card/demand-file drift without protocol changes. |
+| M12 hard eligibility gates | Prevents impossible or tail-pathological recommendations. |
+| M16 deployability gate | Critical after Entry 93/94: do not recommend rows until end-to-end billing/runtime is green. |
+| M18 full-utilization wording | Prevents provider trust damage from overstated “expected $/hr.” |
+| M20 static/live demand JSON | Gives operator a cheap control plane without waiting for coord stats. |
+
+### v0.1 Formula Shape
+
+Recommended v0.1 scoring should be closer to:
+
+```text
+eligible_rows = rows where:
+  rate_card_enabled
+  recommendable == true
+  model_admission passes hardware
+  local_autotune passes sustained TPS + TTFT + no-swap gates
+
+raw_score =
+  measured_tps
+  * 3600
+  * usd_per_million
+  * provider_share
+  * max(demand_weight, cold_start_floor)
+  * optional_tier_weight
+
+recommendation_pool =
+  top eligible rows within 85-90% of best raw_score
+  plus any coverage-floor row still under min_provider_target
+
+default =
+  stable_hash(provider_id_or_machine_fingerprint) across recommendation_pool
+```
+
+### v0.1 Non-Goals
+
+| Deferred item | Reason |
+|---|---|
+| Live coord `/v1/demand-signal` endpoint | Bootstrap-zero and supply-feedback risks; adds new surface. |
+| Provider quota/cap allocation | Too much market-design complexity for 120-provider beta. |
+| Production TPS reputation downweighting | Needs traffic, prompt normalization, and anti-abuse design. |
+| Utilization-adjusted earnings | Honest but data-poor before paying buyer history exists. |
+| Collusion enforcement | Lower priority than accidental herding and coverage failure. |
+
+**Part 2 conclusion:** SPEC-018 v0.1 should bake in cheap static controls: eligibility gates, deployability states, cold-start floors, top-K diversification, metadata versioning, and honest “capacity not guaranteed earnings” wording; defer live market allocation to v0.2.
+
+## Part 3 — Recommended v0.1 Demand-Signal Source
+
+### Ranking Of Options
+
+| Rank | Option | Verdict |
+|---:|---|---|
+| 1 | **(b) OpenRouter top-50 rank fetched live from static URL** | Best v0.1 choice. It avoids binary-baked staleness, works before macprovider has buyer history, and gives the operator a safe, cheap control plane. |
+| 2 | **(e) Hybrid: v0.1 OpenRouter prior, v0.2 local coord stats after 60+ days** | Correct lifecycle strategy. For v0.1 this reduces to option (b) plus an explicit migration trigger. |
+| 3 | **(a) OpenRouter rank baked into binary** | Safe fallback if network fetch fails, but too stale for a fast-changing model market. Refresh only on `macprovider upgrade` is not enough. |
+| 4 | **(d) Constant 1.0** | Simple and avoids rank herding, but price×TPS alone will over-select high-price/low-demand rows and ignore buyer market evidence. Useful as a fallback, not primary. |
+| 5 | **(c) Coord last-7-day macprovider stats** | Locally relevant later, wrong for v0.1. With ~2 providers and zero paying history, it mostly measures bootstrap accidents and current supply gaps. |
+
+### Recommended Source
+
+Use **option (b)** for v0.1:
+
+```text
+Primary: get.streamvc.live/demand-rank.json
+Fallback: baked demand-rank snapshot in the installer/CLI
+Future: switch or blend with coord attempted-demand stats after 60+ days
+```
+
+The static JSON should not be just rank. It should carry enough operator-controlled metadata to avoid separate v0.1 surfaces:
+
+```json
+{
+  "version": "2026-06-30.1",
+  "generated_at": "2026-06-30T00:00:00Z",
+  "source": "openrouter_completion_token_rank_operator_curated",
+  "cold_start_floor": 0.15,
+  "top_k_band": 0.90,
+  "rows": {
+    "openai/gpt-oss-20b": {
+      "demand_weight": 1.00,
+      "rank": 24,
+      "recommendable": true,
+      "min_provider_target": 8
+    },
+    "qwen/qwen3-coder-30b-a3b-instruct": {
+      "demand_weight": 0.85,
+      "rank": null,
+      "recommendable": true,
+      "min_provider_target": 6
+    },
+    "meta-llama/llama-3.1-8b-instruct": {
+      "demand_weight": 0.55,
+      "rank": 49,
+      "recommendable": true,
+      "min_provider_target": 3
+    }
+  }
+}
+```
+
+### Why Not Coord Stats In v0.1
+
+Coord stats are attractive because they reflect macprovider’s buyer mix, but v0.1 has three bootstrap defects:
+
+1. **Zero history:** there is not enough paying buyer traffic to estimate demand.
+2. **Supply censoring:** a model with no providers cannot accumulate served tokens.
+3. **Launch coupling:** if install recommendations are driven by served traffic, early install randomness becomes permanent market structure.
+
+If v0.2 uses coord stats, it should use **attempted demand**, not just served tokens:
+
+```text
+demand_signal_v0.2 =
+  blend(
+    OpenRouter prior,
+    auth-valid buyer requested-model counts,
+    no-provider 503 counts,
+    served paid completion tokens
+  )
+```
+
+Switch trigger should be explicit:
+
+```text
+Use local demand only after:
+  >= 60 days history
+  >= 50M paid or auth-valid requested completion-token equivalent
+  >= 5 buyer accounts or partner keys with non-test traffic
+  no single buyer contributes >50% of model demand
+```
+
+### Why Not Constant 1.0
+
+Constant demand is better than bad local stats for cold start, but it turns the formula into price×TPS. That would likely over-recommend rows like high-priced coder/dense rows even where buyer demand is thin, and it removes the one signal that distinguishes “technically fast” from “marketable.” It should be a fallback when the static JSON cannot be fetched, not the primary source.
+
+### Required v0.1 Safeguards With Option (b)
+
+| Safeguard | Reason |
+|---|---|
+| Baked fallback snapshot | Installer must work offline or if `get.streamvc.live` fails. |
+| JSON signature or checksum | Prevents accidental or tampered recommendation weights. |
+| `recommendable` flag | Operator can block rows with runtime/billing/deployability failures. |
+| Cold-start floor | Prevents permanent exclusion of new rows. |
+| Top-K diversification band | Prevents all 120 providers choosing the same highest-weight row. |
+| Version/timestamp display | Makes stale recommendation diagnosis possible. |
+| No exact earnings guarantee | Demand rank is a utilization proxy, not a guarantee. |
+
+**Part 3 conclusion:** For SPEC-018 v0.1, use operator-curated OpenRouter-prior demand weights fetched from `get.streamvc.live/demand-rank.json` with a baked fallback, then graduate to blended coord attempted-demand stats only after 60+ days of real buyer history.
+
+## Part 4 — One-Line Conclusions
+
+| Part | Liftable conclusion |
+|---|---|
+| Part 1 | The v0.1 risk is not one bad demand multiplier; it is turning a per-provider argmax into a fleet-wide coordination signal without coverage floors, cold-start priors, deployability gates, and stale-input handling. |
+| Part 2 | SPEC-018 v0.1 should bake in cheap static controls: eligibility gates, deployability states, cold-start floors, top-K diversification, metadata versioning, and honest “capacity not guaranteed earnings” wording; defer live market allocation to v0.2. |
+| Part 3 | For SPEC-018 v0.1, use operator-curated OpenRouter-prior demand weights fetched from `get.streamvc.live/demand-rank.json` with a baked fallback, then graduate to blended coord attempted-demand stats only after 60+ days of real buyer history. |
+| Overall | Ship v0.1 as a conservative installer recommendation system, not an autonomous market maker: recommend only deployable eligible rows, diversify defaults, preserve cold-start, and keep live coord demand optimization for v0.2. |
+tokens used
+89 775
+
+```
+
+## Concise summary
+
+Provider completed successfully. Review the raw output for details.
+
+## Action items
+
+- Review the response and extract decisions you want to apply.
+- Capture follow-up implementation tasks if needed.

--- a/specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_PROMPT.md
+++ b/specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_PROMPT.md
@@ -1,0 +1,85 @@
+# RESEARCH PROBE — Goodhart failure modes in marketplace recommender formulas (SPEC-018 v0.1 input)
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_PROMPT.md)"`
+
+This is a **scoped pre-SPEC probe**, not a full research memo. Single codex call, ~20-40 min wall time, ~200-400 line output. Feeds directly into `specs/SPEC-018-installer-autotune-recommend-v0.1.md` drafting on the same day.
+
+## Context
+
+macprovider is a P2P Apple-Silicon LLM inference network. Buyers call `https://api.streamvc.live/v1/chat/completions`, gateway routes to coordinator, coordinator picks a provider Mac running the requested model. Providers earn per-token rate-card revenue.
+
+Wave 0c (the SPEC-018 surface) introduces a provider-side install/autotune recommendation: when a new operator runs `macprovider install` on their Mac, the script scores each rate-card-eligible model on their hardware and recommends the one with the highest expected `$/hr` so they earn the most:
+
+```
+score(model | mac) = TPS(model, mac) × 3600 × $/M × provider_share × demand_signal(model)
+recommend = argmax(score)
+```
+
+Inputs:
+- `TPS(model, mac)` — measured locally by autotune probe on this Mac (not provider self-report).
+- `$/M` — from rate card (Entry 92 v2: gpt-oss-20b $0.10/M, qwen3-coder-30b-a3b $0.235/M, qwen3-32b $0.220/M, llama-3.1-8b $0.027/M, qwen2.5-coder-32b $0.850/M, etc.).
+- `provider_share = 0.90` (fixed).
+- `demand_signal(model)` — open design question. Candidates: (a) OpenRouter rank baked at install time, (b) live `stats_*` rollup from coord (SPEC-017 surface), (c) static operator-set weight per row, (d) constant 1.0 with price competing.
+
+This formula is the lever providers will optimise around. Beta launch is preparing for a 120-provider cohort (Tier-S 20 + Tier-A 50 + Tier-B 30 + Tier-C 20 per Entry 92).
+
+## Task
+
+Identify Goodhart-class failure modes that arise when this formula becomes the population-wide signal driving 120+ provider model choices, AND propose concrete bake-in-the-SPEC-v0.1 mitigations for each.
+
+Specifically:
+
+### Part 1 — Failure-mode catalog
+
+For each failure mode:
+- Concrete scenario (specific numbers if useful — assume 120 providers across tiers, current rate card)
+- What the formula does wrong
+- What the underlying intent was that gets corrupted
+- Severity rating (network-killing / network-degrading / cosmetic)
+
+At minimum, address these candidates (add more if you spot them):
+1. **Winner-take-all on rank** — all 50 Tier-A providers install in week 1, all get recommended gpt-oss-20b → oversupply on rank-19, no provider chose Qwen3-Coder or Llama → buyer requesting those models gets `503 no provider`.
+2. **Cold-start exclusion** — when a new rate-card row lands (e.g., DeepSeek-V3 distill ships), historical demand_signal = 0 → no provider gets recommended it → no traffic → permanent demand_signal = 0.
+3. **TPS gaming** — providers learn to self-report inflated TPS to get recommended into high-$/M lanes. (Note: current design uses local autotune probe, not self-report — assess whether this fully closes the gaming surface.)
+4. **Rate-card update lag** — operator hot-reloads rate card on Pearl; 50 installed providers have stale baked recommendation; week-on-week earnings drop; providers churn before re-tuning.
+5. **Demand-signal source choice** — OpenRouter rank reflects the broader market, not macprovider's actual buyer mix; coord stats reflect macprovider's mix but bootstrap zero. Which is least-bad?
+6. **Tier interaction** — Tier-S providers (M4 Max/Ultra) get the same recommendation logic as Tier-C (M1 Air); does the formula degrade gracefully across the 8× hardware spread, or does it produce pathological recommendations at the tails?
+7. **Bid-shading / collusion** — providers coordinate off-network to pick complementary models (worth flagging even if unlikely).
+
+### Part 2 — Mitigation library
+
+For each failure mode in Part 1, propose 1-3 concrete v0.1 SPEC mechanisms. Each mitigation must specify:
+- What the mechanism is (in 1-2 sentences)
+- Where it lives in the design (formula vs install.sh vs autotune logic vs operator config)
+- LOC estimate (rough — "small / medium / large")
+- Whether it adds operator-visible UX, network state, or coord endpoints
+- Whether it has downside risk worth flagging (e.g., a mitigation for cold-start that hides earnings projection from providers)
+
+Bake the mitigation into v0.1 ONLY if:
+- It addresses a failure mode rated network-killing or network-degrading
+- It's cheap (small LOC, no new operator surface)
+- It composes cleanly with the other mitigations
+
+Defer to v0.2+ if it's expensive, adds operator surface, or addresses cosmetic-tier failure modes.
+
+### Part 3 — Recommended v0.1 demand-signal source
+
+Given (a) beta has ~120 providers in 6 months, (b) macprovider currently has ~2 providers + zero paying buyer history, (c) Wave 1 rate-card hot-reload will broadcast price updates within seconds, (d) Wave 0c is the install-time recommendation that needs to survive Wave 1 changes — recommend ONE concrete source choice for v0.1 with reasoning. Optional: stage to a v0.2 evolution.
+
+Options to evaluate (rank them):
+- (a) OpenRouter top-50 rank, baked into binary at release time (refreshed on `macprovider upgrade`)
+- (b) OpenRouter top-50 rank, fetched live at install/autotune from a static URL (`get.streamvc.live/demand-rank.json`)
+- (c) Coord stats rollup of last-7-day macprovider buyer requests, fetched live (`coordinator.streamvc.live/v1/demand-signal`)
+- (d) Constant 1.0 — let price compete naturally
+- (e) Hybrid: (a) or (b) for v0.1; switch to (c) at v0.2 once 60+ days of real macprovider buyer history exist
+
+### Part 4 — One-line summary per Part
+
+Each Part section ends with a single-line conclusion the SPEC author can lift verbatim into SPEC-018 v0.1.
+
+## Constraints
+
+- Read-only. Do NOT modify code, write specs, or fire other prompts.
+- Cite real-world Goodhart manifestations where helpful (PageRank → SEO arms race, BLEU score → translation gaming, mining-pool difficulty → ASIC concentration, etc.) but ground every claim in the macprovider context.
+- Do NOT inspect `Layr-Labs/d-inference` source per CLAUDE.md clean-room rule. Public docs only.
+- Output: markdown memo, ~200-400 lines. Structure: Part 1 catalog (table per failure mode), Part 2 library (table mitigation × failure mode), Part 3 recommendation, Part 4 one-line conclusions.

--- a/specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_MEMO.md
+++ b/specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_MEMO.md
@@ -1,0 +1,430 @@
+<!-- Preface added during commit (the codex probe was fired before operator caught SPEC-018 was already taken by SPEC-018-agentic-tool-calling). All references to "SPEC-018" in this memo should be read as "SPEC-023 — Installer-Integrated Autotune Recommend." The codex output is preserved verbatim below for audit-trail integrity. -->
+
+**Part 1 — Competitive Sweep**
+
+Scope note: I did not inspect `Layr-Labs/d-inference` source. Darkbloom findings below use only public marketing / console pages.
+
+| Network | Provider install flow shape | Hardware-specific workload recommendation? | Who picks workload? | Earnings projected before commit? | Mapping to macprovider |
+|---|---|---:|---|---:|---|
+| vast.ai | Host setup + web host dashboard; host installs Ubuntu/drivers/Vast host software and lists GPU capacity. Vast describes hosts as sellers of GPU resources. ([docs.vast.ai](https://docs.vast.ai/host/hosting-overview?utm_source=openai)) | No model/job recommendation found in public provider docs; docs emphasize host pricing and market metrics, not workload choice. ([docs.vast.ai](https://docs.vast.ai/guides/instances/pricing?utm_source=openai)) ([docs.vast.ai](https://docs.vast.ai/host/market-metrics?utm_source=openai)) | Buyer/client brings workload; host lists capacity and sets terms/prices. ([vast.ai](https://vast.ai/hosting?srsltid=AfmBOoqEBAEhejjVEzuGkxyUicg5GYBql6zwXO9tsjXXikIq2FdMlU2y&utm_source=openai)) | Partial: earnings/pricing tools exist, but not “this model on this Mac earns $X/hr.” Market metrics help hosts price machines. ([docs.vast.ai](https://docs.vast.ai/host/market-metrics?utm_source=openai)) | Raw GPU marketplace; closest pattern is pricing guidance, not model recommendation. |
+| RunPod | Buyer-side pods/serverless; formerly Community Cloud, but docs now say RunPod is no longer accepting new Community Cloud hosts. ([docs.runpod.io](https://docs.runpod.io/pods/choose-a-pod?utm_source=openai)) | No provider-side workload recommendation found. Public docs focus on users selecting GPU/template/image. ([docs.runpod.io](https://docs.runpod.io/runpodctl/reference/runpodctl-pod?utm_source=openai)) | Buyer chooses GPU type/template/image; platform assigns machine. ([docs.runpod.io](https://docs.runpod.io/api-reference/pods/POST/pods?utm_source=openai)) | Buyer sees cost per hour for pods; no public provider earnings recommendation. ([docs.runpod.io](https://docs.runpod.io/pods/pricing?utm_source=openai)) | Not a current open provider onboarding analogue. |
+| io.net | IO Worker portal + OS-specific worker install + dashboard. ([io.net](https://io.net/docs/guides/workers/quick-start-guide)) | No model/job recommendation found; docs describe adding GPU/CPU and network orchestration/assignment. ([io.net](https://io.net/docs/guides/workers/io-worker)) | Network/customer jobs use supplied compute; supplier manages device, not model choice. ([io.net](https://io.net/docs/guides/workers/io-worker)) | Yes after/through dashboard: real-time earnings and compute-job metrics, not pre-commit model-ranked earnings. ([io.net](https://io.net/docs/guides/workers/rewards-wallets)) | Supplier dashboard, not installer recommendation. |
+| Akash Network | Provider Console / Kubernetes provider service / Helm-style provider build; tenants deploy SDL manifests. ([akash.network](https://akash.network/providers/)) | No workload recommendation; provider bid engine evaluates tenant orders and submits bids. ([akash.network](https://akash.network/docs/providers/architecture/overview/?utm_source=openai)) | Tenant defines workload in SDL; providers bid; tenant accepts lease. ([akash.network](https://akash.network/docs/getting-started/core-concepts/?utm_source=openai)) | Yes, but at provider-capacity level: Akash advertises a Provider Calculator to estimate earnings. ([akash.network](https://akash.network/providers/)) | Has provider earnings estimation, but not “which model should I run?” |
+| Aethir | Cloud Host portal / registration / staking / server registration. ([docs.aethir.com](https://docs.aethir.com/aethir-cloud/aethir-cloud-host/cloud-host-portal-guide/get-started?utm_source=openai)) | No public workload recommendation found; docs/blog describe Cloud Hosts providing GPUs for AI, gaming, training, Web3 workloads. ([aethir.com](https://aethir.com/blog-posts/step-by-step-guide-onboarding-as-an-aethir-cloud-host?utm_source=openai)) | Network/client demand uses supplied GPU resources; host does not appear to pick a model. | Public materials claim rewards based on GPU usage, uptime, and performance; no inspected pre-commit per-workload projection. ([ecosystem.aethir.com](https://ecosystem.aethir.com/blog-posts/how-to-monetize-gpus-with-decentralized-cloud-hosting-a-comprehensive-guide?utm_source=openai)) | Managed DePIN supply pool; recommendation problem mostly hidden from host. |
+| Render Network | Node operator waitlist/onboarding; docs say team follows up with onboarding info. ([know.rendernetwork.com](https://know.rendernetwork.com/general-render-network/what-role-am-i/how-to-get-started-1?utm_source=openai)) | No model/job recommendation; node eligibility/benchmarking uses GPU/OctaneBench-style assessment. ([know.rendernetwork.com](https://know.rendernetwork.com/general-render-network/what-role-am-i/how-to-get-started-1/render-compute-network-gpu-compute-node-waitlist-faq?utm_source=openai)) | Creator/network assigns render or compute jobs to suitable nodes. Public docs frame GPU owners loaning compute to creators. ([know.rendernetwork.com](https://know.rendernetwork.com/?utm_source=openai)) | Partial: reward/emissions docs and node requirements exist; no public “this workload earns $X/hr” installer projection. ([medium.com](https://medium.com/render-token/compute-client-node-reward-mechanism-update-6b867e348030?utm_source=openai)) | Benchmarking/eligibility analogue, not choice recommendation. |
+| Bittensor / Targon / Templar | Subnet-specific miner setup; Bittensor says miners research subnets based on expertise/hardware. ([docs.learnbittensor.org](https://docs.learnbittensor.org/miners?utm_source=openai)) | No central recommendation; each subnet defines its own incentive mechanism. ([docs.learnbittensor.org](https://docs.learnbittensor.org/subnets/understanding-subnets?utm_source=openai)) Targon docs are miner setup for confidential compute. ([docs.targon.com](https://docs.targon.com/providers/miner/?utm_source=openai)) Templar miners train on assigned data/share gradients. ([docs.tplr.ai](https://docs.tplr.ai/miners/?utm_source=openai)) | Subnet protocol defines work; validators score miner output and rewards. ([docs.tplr.ai](https://docs.tplr.ai/validators/weight-setting/?utm_source=openai)) | Not as simple pre-commit $/hr; emissions depend on subnet competition, quality, weights. ([docs.learnbittensor.org](https://docs.learnbittensor.org/subnets/understanding-subnets?utm_source=openai)) | Closest “choose a subnet” problem, but no installer-level ranked yield UX. |
+| Helium | Mobile app / gateway onboarding; hotspot location and device setup. ([apps.apple.com](https://apps.apple.com/us/app/helium-hotspot/id1450463605?utm_source=openai)) | Not workload recommendation; rewards depend on coverage/data transfer. ([docs.helium.com](https://docs.helium.com/mobile/5g-on-helium/?utm_source=openai)) | Network protocols assign rewards for coverage/data, not operator-selected workload. ([medium.com](https://medium.com/helium-foundation/off-chain-proof-of-coverage-is-live-e5f0493e2bca?utm_source=openai)) | Third-party tools exist, but official docs focus on reward mechanics, not pre-commit workload projection. | Tokenomics/location-density analogue, not compute/model analogue. |
+| Together.ai | Buyer/developer cloud API: serverless models, dedicated endpoints, GPU clusters. ([docs.together.ai](https://docs.together.ai/intro?utm_source=openai)) ([docs.together.ai](https://docs.together.ai/docs/gpu-clusters-overview?utm_source=openai)) | No public provider onboarding surface found. | Together operates/aggregates infrastructure; user picks model/endpoint. ([docs.together.ai](https://docs.together.ai/docs/serverless/models?utm_source=openai)) | Buyer-side pricing, no provider earnings projection. | Not a provider-marketplace UX. |
+| Lepton / NVIDIA DGX Cloud Lepton | Managed AI platform / marketplace connecting developers to cloud providers. ([docs.nvidia.com](https://docs.nvidia.com/dgx-cloud/lepton/guides/?utm_source=openai)) | No public independent provider onboarding UX found in inspected docs. | Buyer/developer deploys endpoints/jobs; Lepton abstracts providers. | Buyer-side cost/availability surface, not provider yield. | Marketplace broker, but provider UX is not public/self-serve. |
+| Modal | Developer serverless GPU functions; users specify GPU requirements/fallback ordering. ([modal.com](https://modal.com/docs/guide/gpu?utm_source=openai)) | No provider onboarding. | Developer chooses workload/function and GPU request. | Buyer-side usage pricing, not provider earnings. | Useful only as buyer-side GPU selection UX. |
+| Replicate | Developer model hosting; custom models are deployed on Replicate GPU cluster. ([replicate.com](https://replicate.com/docs/get-started/deploy-a-custom-model?utm_source=openai)) | No provider onboarding; docs cover choosing deployment hardware. ([replicate.com](https://replicate.com/docs/topics/models/hardware?utm_source=openai)) | Model owner/user picks model and hardware; Replicate runs infrastructure. ([replicate.com](https://replicate.com/docs?utm_source=openai)) | Buyer/model-owner cost control, not provider yield. | Not competitive provider-side surface. |
+| Darkbloom / d-inference public pages only | CLI installer during alpha; native menu bar app planned. ([darkbloom.dev](https://darkbloom.dev/)) | **Yes, public earnings calculator shows “Auto-selected: most profitable for your hardware.”** It takes Mac type/chip/memory and model catalog compatibility. ([darkbloom.dev](https://darkbloom.dev/)) ([console.darkbloom.dev](https://console.darkbloom.dev/earn)) | Public pages say coordinator matches demand to verified Mac providers; installer page says provider chooses availability. ([darkbloom.dev](https://darkbloom.dev/)) | Yes: earnings calculator estimates usage earnings plus base reward, with demand/utilization caveats. ([console.darkbloom.dev](https://console.darkbloom.dev/earn)) | This partially refutes the hypothesis: not a large generic GPU marketplace, but a close Apple-Silicon inference competitor has a public hardware-to-model earnings calculator. |
+
+**Part 1 conclusion:** Major raw-GPU/decentralized compute networks do not show an installer-time “best model for your hardware” UX, but Darkbloom publicly ships a close earnings-calculator version of the pattern, so SPEC-018 should frame macprovider’s wedge as “installer-integrated, local autotune recommendation,” not “no one has any model-yield recommender.”
+
+**Part 2 — Closest UX Analogues**
+
+1. **StakingRewards.com**
+   - Pattern: compare many assets/providers by yield and risk, not just headline APR; StakingRewards describes itself as comparing 90+ providers and 120+ assets with risk grades. ([stakingrewards.com](https://www.stakingrewards.com/?utm_source=openai))
+   - Apply: `autotune --recommend` should rank by expected net `$/hr`, but also show risk/confidence fields: demand confidence, thermal risk, memory headroom, and staleness.
+   - Pattern: calculator starts from input stake amount and compares returns across assets/providers. ([stakingrewards.com](https://www.stakingrewards.com/calculator?utm_source=openai))
+   - Apply: Mac hardware should be auto-detected, then projected across model candidates rather than making the operator manually inspect a rate card.
+
+2. **Lido / RocketPool-style staking dashboards**
+   - Pattern: Lido’s calculator displays stake amount, APR, monthly rewards, yearly rewards, and a direct action. ([lido.fi](https://lido.fi/how-lido-works/apr-and-rewards-calculator?utm_source=openai))
+   - Apply: install transcript should show “recommended model,” “expected hourly,” “monthly at assumed utilization,” and “start provider” in one compact decision block.
+   - Pattern: single-pool dashboards are good at explaining assumptions next to the number.
+   - Apply: show assumptions inline: utilization, electricity estimate, rate-card version, benchmark date.
+
+3. **WhatToMine**
+   - Pattern: user enters hashrate/power; output is a profitability table, with caveat that final results vary and calculations use mean values. ([whattomine.com](https://whattomine.com/?utm_source=openai))
+   - Apply: output should be a ranked table of 3-5 models with mean estimate plus caveat: demand varies, thermal throttling can change realized yield.
+   - Pattern: defaults are adapted for known GPU configurations. ([whattomine.com](https://whattomine.com/?utm_source=openai))
+   - Apply: auto-detect Mac profile and use known benchmark defaults, but allow override for electricity price / availability hours.
+
+4. **NiceHash**
+   - Pattern: profitability calculator supports hashrate, device, and device comparison modes. ([nicehash.com](https://www.nicehash.com/profitability-calculator?utm_source=openai))
+   - Apply: support `--json` for machines and a human table for install; include “this Mac vs default Mac tier” comparison.
+   - Pattern: QuickMiner benchmarks GPUs and automatically profit-switches to the most profitable algorithm at the moment. ([nicehash.com](https://www.nicehash.com/support/mining-help/quickminer/quickminer-profit-switching?utm_source=openai))
+   - Apply: macprovider v0.1 should not auto-switch silently, but it should make re-running recommendation cheap and explicit.
+
+5. **Yield aggregators: Yearn / Beefy / Convex class**
+   - Pattern: Beefy shows predicted APY, includes compounding, and says displayed APY includes vault fees. ([docs.beefy.finance](https://docs.beefy.finance/beefy-products/vaults?utm_source=openai))
+   - Apply: `expected_net_usd_per_hour` should be net of platform fee and estimated electricity, not just gross token revenue.
+   - Pattern: Yearn docs emphasize APY methodology and vault risk inheritance. ([docs.yearn.fi](https://docs.yearn.fi/getting-started/guides/how-apy-works?utm_source=openai)) ([docs.yearn.fi](https://docs.yearn.fi/developers/security/risks/?utm_source=openai))
+   - Apply: expose formula/inputs: rate card, measured tokens/sec, expected utilization, electricity, memory tier, and demand confidence.
+
+6. **Cloud cost calculators: AWS / GCP**
+   - Pattern: AWS Pricing Calculator estimates workloads/resources/architecture changes in real time, but warns actual fees depend on usage. ([aws.amazon.com](https://aws.amazon.com/aws-cost-management/aws-pricing-calculator/?utm_source=openai)) ([docs.aws.amazon.com](https://docs.aws.amazon.com/cost-management/latest/userguide/pricing-calculator.html?utm_source=openai))
+   - Apply: recommendation should state it is an estimate, not a guarantee; realized earnings depend on buyer traffic.
+   - Pattern: GCP calculator lets users add/configure products and share estimates. ([cloud.google.com](https://cloud.google.com/products/calculator?utm_source=openai))
+   - Apply: JSON output should be reproducible/shareable for support: include `rate_card_version`, `benchmark_id`, and `generated_at`.
+
+7. **Electricity-plan comparison sites**
+   - Pattern: plan comparison starts with ZIP/usage and ranks plans using current rates/preferences; some update rates daily. ([choosetexaspower.org](https://www.choosetexaspower.org/?utm_source=openai))
+   - Apply: recommendation should include local electricity as a first-class input and show data freshness.
+   - Pattern: savings calculators show monthly/yearly estimates, annual savings, and savings percentage. ([energyogre.com](https://www.energyogre.com/savings?utm_source=openai))
+   - Apply: show “recommended vs default” delta: `+$0.18/hr`, `+23% vs default`, or “donor-tier, expected net near zero.”
+   - Pattern: utility tools compare current plan vs alternatives using past usage. ([sce.com](https://www.sce.com/save-money/rates-financing/rate-plan-comparison-tool?utm_source=openai))
+   - Apply: `macprovider status` should compare current configured model against the latest recommendation.
+
+**Part 2 conclusion:** The best import pattern is WhatToMine/NiceHash ranking plus staking-dashboard assumption disclosure: ranked candidates, net yield, confidence, staleness, and explicit “recommended vs alternatives” deltas.
+
+**Part 3 — Differentiation Framing**
+
+macprovider’s provider-install UX sits in a gap left by most decentralized GPU networks. Vast, RunPod, io.net, Akash, Aethir, Render, and Bittensor generally expose raw capacity, bids, node eligibility, subnet incentives, or buyer-selected workloads; their public provider flows do not show an installer-time recommendation that says “given this hardware, run this model to earn the most.” That difference follows from their market structure: the buyer brings a container, manifest, render job, or subnet task, while the provider supplies capacity or competes under a protocol.
+
+The closest competitive exception is Darkbloom. Its public pages show an Apple-Silicon inference network, a CLI provider install path, and an earnings calculator that auto-selects the “most profitable” model for a chosen Mac hardware profile. That means macprovider should not claim the entire idea is unobserved. The sharper wedge is that SPEC-018 makes the recommendation local, installer-integrated, benchmark-backed, and machine-readable via `autotune --recommend`, rather than only a web estimate.
+
+The right UX lineage is not generic cloud hosting. It is staking calculators and mining profitability calculators. StakingRewards-style surfaces rank heterogeneous yield options and disclose risk; WhatToMine/NiceHash-style surfaces translate hardware, power, rates, and current market data into ranked profitability. macprovider has the same shape: detected hardware plus measured tokens/sec plus a per-model rate card plus demand assumptions yields a ranked recommendation.
+
+This will not create demand where none exists. SPEC-018 answers “which model should this provider run, given known rates and measured local performance?” It does not answer “will buyers show up?” The UX must say that clearly: expected `$/hr` is an estimate conditioned on demand, utilization, uptime, electricity, and the current rate card.
+
+**Part 3 conclusion:** Frame SPEC-018 as installer-integrated yield recommendation for inference providers: competitive against raw-capacity marketplaces, informed by staking/mining calculators, and honest that recommendation optimizes model choice, not market demand.
+
+**Part 4 — v0.1 SPEC Implications**
+
+1. **Output schema for `autotune --recommend`**
+   - Tie-back: WhatToMine/NiceHash rank alternatives; Beefy/Yearn disclose net APY/risk; AWS/GCP preserve estimate assumptions.
+   - Suggested JSON shape:
+
+```json
+{
+  "schema_version": "autotune_recommend.v1",
+  "generated_at": "2026-06-30T12:00:00Z",
+  "hardware": {
+    "machine": "MacBook Pro",
+    "chip": "M4 Max",
+    "memory_gb": 48,
+    "detected": true
+  },
+  "inputs": {
+    "rate_card_version": "2026-06-30",
+    "electricity_usd_per_kwh": 0.15,
+    "assumed_utilization": 0.8,
+    "availability_hours_per_day": 18
+  },
+  "recommended_model": "qwen3-14b",
+  "candidates": [
+    {
+      "rank": 1,
+      "model": "qwen3-14b",
+      "fits": true,
+      "expected_net_usd_per_hour": 0.42,
+      "expected_gross_usd_per_hour": 0.47,
+      "electricity_usd_per_hour": 0.03,
+      "platform_fee_usd_per_hour": 0.02,
+      "tokens_per_second": 41.2,
+      "memory_headroom_gb": 8.1,
+      "confidence": "medium",
+      "why": "highest net yield among compatible models"
+    }
+  ],
+  "comparison": {
+    "default_model": "gemma-7b",
+    "recommended_delta_usd_per_hour": 0.18,
+    "recommended_delta_percent": 75
+  },
+  "warnings": [
+    "Earnings depend on buyer demand and realized utilization."
+  ]
+}
+```
+
+2. **Install transcript copy**
+   - Tie-back: Lido gives monthly/yearly rewards next to APR; electricity-plan tools show savings vs current/default; Darkbloom discloses demand caveats.
+   - Happy path:
+
+```text
+Detected MacBook Pro M4 Max, 48 GB unified memory.
+Benchmarked 4 compatible models against rate card 2026-06-30.
+
+Recommended: qwen3-14b
+Expected net: $0.42/hr at 80% utilization
+Why: +$0.18/hr vs default gemma-7b, 8.1 GB memory headroom
+
+This is an estimate, not a guarantee. Actual earnings depend on buyer demand,
+uptime, thermal state, and rate-card changes.
+
+Start provider with qwen3-14b? [Y/n]
+```
+
+   - Donor-tier path:
+
+```text
+Detected MacBook Air M1, 8 GB unified memory.
+No paid model currently clears the minimum net-yield threshold.
+
+Best compatible option: tinyllama
+Expected net: $0.00-$0.01/hr before demand risk
+Recommendation: donor mode only
+
+You can still run a provider to support network coverage, but this Mac is
+not expected to earn meaningful revenue on the current rate card.
+Enable donor mode? [y/N]
+```
+
+3. **Re-tune cadence + UX**
+   - Tie-back: NiceHash profit-switching shows market-aware re-optimization, but automatic switching is risky for inference provider stability.
+   - v0.1 decision: make `autotune --recommend` rerunnable and idempotent; do not silently switch models.
+   - Trigger recommendation prompts on install, manual `macprovider autotune --recommend`, and rate-card version change.
+   - Store last recommendation summary with `generated_at`, `rate_card_version`, and `benchmark_id`.
+
+4. **Donor-mode opt-in**
+   - Tie-back: electricity-plan sites show “you could save $X” before switching; macprovider should show “you would earn $X less” before override.
+   - v0.1 decision: require explicit opt-in for non-recommended or below-threshold operation:
+     - CLI: `macprovider configure --model tinyllama --donor-mode`
+     - YAML: `donor_mode: true`
+     - Install prompt default: No
+   - Warning copy: “This choice is estimated to earn `$X/hr` less than the recommended model” or “below minimum revenue threshold.”
+
+5. **Status-command integration**
+   - Tie-back: utility tools compare current plan vs alternatives using actual/past usage; io.net dashboards show earnings and compute job metrics.
+   - v0.1 decision: `macprovider status` should include:
+     - current model
+     - last measured `tokens/sec`
+     - observed earnings last hour/day if available
+     - estimate from last recommendation
+     - stale recommendation warning
+     - better available model, if any
+
+```text
+Model: gemma-7b
+Estimated net: $0.24/hr
+Observed last 24h: $3.10 total
+Recommendation stale: rate card changed 2026-06-30
+
+Run: macprovider autotune --recommend
+Potential improvement: qwen3-14b estimated $0.42/hr (+$0.18/hr)
+```
+
+**Part 4 conclusion:** SPEC-018 v0.1 should specify a ranked, net-yield JSON contract; install copy with assumptions and deltas; explicit re-tune triggers; donor-mode guardrails; and status integration that compares current model to the latest recommendation.
+
+**Part 5 — Liftable One-Line Conclusions**
+
+- Part 1: Major decentralized GPU networks mostly avoid the provider model-choice problem; Darkbloom is the notable close exception with a public hardware-to-model earnings calculator.
+- Part 2: Import the WhatToMine/NiceHash ranked-profitability pattern and the staking-dashboard assumption/risk-disclosure pattern.
+- Part 3: macprovider’s wedge is installer-integrated, benchmark-backed model yield recommendation for heterogeneous consumer inference hardware.
+- Part 4: v0.1 should lock the recommendation as a transparent ranked estimate, not a guaranteed income claim or silent auto-switcher.
+
+
+OpenAI Codex v0.142.2
+**Part 1 — Competitive Sweep**
+
+Scope note: I did not inspect `Layr-Labs/d-inference` source. Darkbloom findings below use only public marketing / console pages.
+
+| Network | Provider install flow shape | Hardware-specific workload recommendation? | Who picks workload? | Earnings projected before commit? | Mapping to macprovider |
+|---|---|---:|---|---:|---|
+| vast.ai | Host setup + web host dashboard; host installs Ubuntu/drivers/Vast host software and lists GPU capacity. Vast describes hosts as sellers of GPU resources. ([docs.vast.ai](https://docs.vast.ai/host/hosting-overview?utm_source=openai)) | No model/job recommendation found in public provider docs; docs emphasize host pricing and market metrics, not workload choice. ([docs.vast.ai](https://docs.vast.ai/guides/instances/pricing?utm_source=openai)) ([docs.vast.ai](https://docs.vast.ai/host/market-metrics?utm_source=openai)) | Buyer/client brings workload; host lists capacity and sets terms/prices. ([vast.ai](https://vast.ai/hosting?srsltid=AfmBOoqEBAEhejjVEzuGkxyUicg5GYBql6zwXO9tsjXXikIq2FdMlU2y&utm_source=openai)) | Partial: earnings/pricing tools exist, but not “this model on this Mac earns $X/hr.” Market metrics help hosts price machines. ([docs.vast.ai](https://docs.vast.ai/host/market-metrics?utm_source=openai)) | Raw GPU marketplace; closest pattern is pricing guidance, not model recommendation. |
+| RunPod | Buyer-side pods/serverless; formerly Community Cloud, but docs now say RunPod is no longer accepting new Community Cloud hosts. ([docs.runpod.io](https://docs.runpod.io/pods/choose-a-pod?utm_source=openai)) | No provider-side workload recommendation found. Public docs focus on users selecting GPU/template/image. ([docs.runpod.io](https://docs.runpod.io/runpodctl/reference/runpodctl-pod?utm_source=openai)) | Buyer chooses GPU type/template/image; platform assigns machine. ([docs.runpod.io](https://docs.runpod.io/api-reference/pods/POST/pods?utm_source=openai)) | Buyer sees cost per hour for pods; no public provider earnings recommendation. ([docs.runpod.io](https://docs.runpod.io/pods/pricing?utm_source=openai)) | Not a current open provider onboarding analogue. |
+| io.net | IO Worker portal + OS-specific worker install + dashboard. ([io.net](https://io.net/docs/guides/workers/quick-start-guide)) | No model/job recommendation found; docs describe adding GPU/CPU and network orchestration/assignment. ([io.net](https://io.net/docs/guides/workers/io-worker)) | Network/customer jobs use supplied compute; supplier manages device, not model choice. ([io.net](https://io.net/docs/guides/workers/io-worker)) | Yes after/through dashboard: real-time earnings and compute-job metrics, not pre-commit model-ranked earnings. ([io.net](https://io.net/docs/guides/workers/rewards-wallets)) | Supplier dashboard, not installer recommendation. |
+| Akash Network | Provider Console / Kubernetes provider service / Helm-style provider build; tenants deploy SDL manifests. ([akash.network](https://akash.network/providers/)) | No workload recommendation; provider bid engine evaluates tenant orders and submits bids. ([akash.network](https://akash.network/docs/providers/architecture/overview/?utm_source=openai)) | Tenant defines workload in SDL; providers bid; tenant accepts lease. ([akash.network](https://akash.network/docs/getting-started/core-concepts/?utm_source=openai)) | Yes, but at provider-capacity level: Akash advertises a Provider Calculator to estimate earnings. ([akash.network](https://akash.network/providers/)) | Has provider earnings estimation, but not “which model should I run?” |
+| Aethir | Cloud Host portal / registration / staking / server registration. ([docs.aethir.com](https://docs.aethir.com/aethir-cloud/aethir-cloud-host/cloud-host-portal-guide/get-started?utm_source=openai)) | No public workload recommendation found; docs/blog describe Cloud Hosts providing GPUs for AI, gaming, training, Web3 workloads. ([aethir.com](https://aethir.com/blog-posts/step-by-step-guide-onboarding-as-an-aethir-cloud-host?utm_source=openai)) | Network/client demand uses supplied GPU resources; host does not appear to pick a model. | Public materials claim rewards based on GPU usage, uptime, and performance; no inspected pre-commit per-workload projection. ([ecosystem.aethir.com](https://ecosystem.aethir.com/blog-posts/how-to-monetize-gpus-with-decentralized-cloud-hosting-a-comprehensive-guide?utm_source=openai)) | Managed DePIN supply pool; recommendation problem mostly hidden from host. |
+| Render Network | Node operator waitlist/onboarding; docs say team follows up with onboarding info. ([know.rendernetwork.com](https://know.rendernetwork.com/general-render-network/what-role-am-i/how-to-get-started-1?utm_source=openai)) | No model/job recommendation; node eligibility/benchmarking uses GPU/OctaneBench-style assessment. ([know.rendernetwork.com](https://know.rendernetwork.com/general-render-network/what-role-am-i/how-to-get-started-1/render-compute-network-gpu-compute-node-waitlist-faq?utm_source=openai)) | Creator/network assigns render or compute jobs to suitable nodes. Public docs frame GPU owners loaning compute to creators. ([know.rendernetwork.com](https://know.rendernetwork.com/?utm_source=openai)) | Partial: reward/emissions docs and node requirements exist; no public “this workload earns $X/hr” installer projection. ([medium.com](https://medium.com/render-token/compute-client-node-reward-mechanism-update-6b867e348030?utm_source=openai)) | Benchmarking/eligibility analogue, not choice recommendation. |
+| Bittensor / Targon / Templar | Subnet-specific miner setup; Bittensor says miners research subnets based on expertise/hardware. ([docs.learnbittensor.org](https://docs.learnbittensor.org/miners?utm_source=openai)) | No central recommendation; each subnet defines its own incentive mechanism. ([docs.learnbittensor.org](https://docs.learnbittensor.org/subnets/understanding-subnets?utm_source=openai)) Targon docs are miner setup for confidential compute. ([docs.targon.com](https://docs.targon.com/providers/miner/?utm_source=openai)) Templar miners train on assigned data/share gradients. ([docs.tplr.ai](https://docs.tplr.ai/miners/?utm_source=openai)) | Subnet protocol defines work; validators score miner output and rewards. ([docs.tplr.ai](https://docs.tplr.ai/validators/weight-setting/?utm_source=openai)) | Not as simple pre-commit $/hr; emissions depend on subnet competition, quality, weights. ([docs.learnbittensor.org](https://docs.learnbittensor.org/subnets/understanding-subnets?utm_source=openai)) | Closest “choose a subnet” problem, but no installer-level ranked yield UX. |
+| Helium | Mobile app / gateway onboarding; hotspot location and device setup. ([apps.apple.com](https://apps.apple.com/us/app/helium-hotspot/id1450463605?utm_source=openai)) | Not workload recommendation; rewards depend on coverage/data transfer. ([docs.helium.com](https://docs.helium.com/mobile/5g-on-helium/?utm_source=openai)) | Network protocols assign rewards for coverage/data, not operator-selected workload. ([medium.com](https://medium.com/helium-foundation/off-chain-proof-of-coverage-is-live-e5f0493e2bca?utm_source=openai)) | Third-party tools exist, but official docs focus on reward mechanics, not pre-commit workload projection. | Tokenomics/location-density analogue, not compute/model analogue. |
+| Together.ai | Buyer/developer cloud API: serverless models, dedicated endpoints, GPU clusters. ([docs.together.ai](https://docs.together.ai/intro?utm_source=openai)) ([docs.together.ai](https://docs.together.ai/docs/gpu-clusters-overview?utm_source=openai)) | No public provider onboarding surface found. | Together operates/aggregates infrastructure; user picks model/endpoint. ([docs.together.ai](https://docs.together.ai/docs/serverless/models?utm_source=openai)) | Buyer-side pricing, no provider earnings projection. | Not a provider-marketplace UX. |
+| Lepton / NVIDIA DGX Cloud Lepton | Managed AI platform / marketplace connecting developers to cloud providers. ([docs.nvidia.com](https://docs.nvidia.com/dgx-cloud/lepton/guides/?utm_source=openai)) | No public independent provider onboarding UX found in inspected docs. | Buyer/developer deploys endpoints/jobs; Lepton abstracts providers. | Buyer-side cost/availability surface, not provider yield. | Marketplace broker, but provider UX is not public/self-serve. |
+| Modal | Developer serverless GPU functions; users specify GPU requirements/fallback ordering. ([modal.com](https://modal.com/docs/guide/gpu?utm_source=openai)) | No provider onboarding. | Developer chooses workload/function and GPU request. | Buyer-side usage pricing, not provider earnings. | Useful only as buyer-side GPU selection UX. |
+| Replicate | Developer model hosting; custom models are deployed on Replicate GPU cluster. ([replicate.com](https://replicate.com/docs/get-started/deploy-a-custom-model?utm_source=openai)) | No provider onboarding; docs cover choosing deployment hardware. ([replicate.com](https://replicate.com/docs/topics/models/hardware?utm_source=openai)) | Model owner/user picks model and hardware; Replicate runs infrastructure. ([replicate.com](https://replicate.com/docs?utm_source=openai)) | Buyer/model-owner cost control, not provider yield. | Not competitive provider-side surface. |
+| Darkbloom / d-inference public pages only | CLI installer during alpha; native menu bar app planned. ([darkbloom.dev](https://darkbloom.dev/)) | **Yes, public earnings calculator shows “Auto-selected: most profitable for your hardware.”** It takes Mac type/chip/memory and model catalog compatibility. ([darkbloom.dev](https://darkbloom.dev/)) ([console.darkbloom.dev](https://console.darkbloom.dev/earn)) | Public pages say coordinator matches demand to verified Mac providers; installer page says provider chooses availability. ([darkbloom.dev](https://darkbloom.dev/)) | Yes: earnings calculator estimates usage earnings plus base reward, with demand/utilization caveats. ([console.darkbloom.dev](https://console.darkbloom.dev/earn)) | This partially refutes the hypothesis: not a large generic GPU marketplace, but a close Apple-Silicon inference competitor has a public hardware-to-model earnings calculator. |
+
+**Part 1 conclusion:** Major raw-GPU/decentralized compute networks do not show an installer-time “best model for your hardware” UX, but Darkbloom publicly ships a close earnings-calculator version of the pattern, so SPEC-018 should frame macprovider’s wedge as “installer-integrated, local autotune recommendation,” not “no one has any model-yield recommender.”
+
+**Part 2 — Closest UX Analogues**
+
+1. **StakingRewards.com**
+   - Pattern: compare many assets/providers by yield and risk, not just headline APR; StakingRewards describes itself as comparing 90+ providers and 120+ assets with risk grades. ([stakingrewards.com](https://www.stakingrewards.com/?utm_source=openai))
+   - Apply: `autotune --recommend` should rank by expected net `$/hr`, but also show risk/confidence fields: demand confidence, thermal risk, memory headroom, and staleness.
+   - Pattern: calculator starts from input stake amount and compares returns across assets/providers. ([stakingrewards.com](https://www.stakingrewards.com/calculator?utm_source=openai))
+   - Apply: Mac hardware should be auto-detected, then projected across model candidates rather than making the operator manually inspect a rate card.
+
+2. **Lido / RocketPool-style staking dashboards**
+   - Pattern: Lido’s calculator displays stake amount, APR, monthly rewards, yearly rewards, and a direct action. ([lido.fi](https://lido.fi/how-lido-works/apr-and-rewards-calculator?utm_source=openai))
+   - Apply: install transcript should show “recommended model,” “expected hourly,” “monthly at assumed utilization,” and “start provider” in one compact decision block.
+   - Pattern: single-pool dashboards are good at explaining assumptions next to the number.
+   - Apply: show assumptions inline: utilization, electricity estimate, rate-card version, benchmark date.
+
+3. **WhatToMine**
+   - Pattern: user enters hashrate/power; output is a profitability table, with caveat that final results vary and calculations use mean values. ([whattomine.com](https://whattomine.com/?utm_source=openai))
+   - Apply: output should be a ranked table of 3-5 models with mean estimate plus caveat: demand varies, thermal throttling can change realized yield.
+   - Pattern: defaults are adapted for known GPU configurations. ([whattomine.com](https://whattomine.com/?utm_source=openai))
+   - Apply: auto-detect Mac profile and use known benchmark defaults, but allow override for electricity price / availability hours.
+
+4. **NiceHash**
+   - Pattern: profitability calculator supports hashrate, device, and device comparison modes. ([nicehash.com](https://www.nicehash.com/profitability-calculator?utm_source=openai))
+   - Apply: support `--json` for machines and a human table for install; include “this Mac vs default Mac tier” comparison.
+   - Pattern: QuickMiner benchmarks GPUs and automatically profit-switches to the most profitable algorithm at the moment. ([nicehash.com](https://www.nicehash.com/support/mining-help/quickminer/quickminer-profit-switching?utm_source=openai))
+   - Apply: macprovider v0.1 should not auto-switch silently, but it should make re-running recommendation cheap and explicit.
+
+5. **Yield aggregators: Yearn / Beefy / Convex class**
+   - Pattern: Beefy shows predicted APY, includes compounding, and says displayed APY includes vault fees. ([docs.beefy.finance](https://docs.beefy.finance/beefy-products/vaults?utm_source=openai))
+   - Apply: `expected_net_usd_per_hour` should be net of platform fee and estimated electricity, not just gross token revenue.
+   - Pattern: Yearn docs emphasize APY methodology and vault risk inheritance. ([docs.yearn.fi](https://docs.yearn.fi/getting-started/guides/how-apy-works?utm_source=openai)) ([docs.yearn.fi](https://docs.yearn.fi/developers/security/risks/?utm_source=openai))
+   - Apply: expose formula/inputs: rate card, measured tokens/sec, expected utilization, electricity, memory tier, and demand confidence.
+
+6. **Cloud cost calculators: AWS / GCP**
+   - Pattern: AWS Pricing Calculator estimates workloads/resources/architecture changes in real time, but warns actual fees depend on usage. ([aws.amazon.com](https://aws.amazon.com/aws-cost-management/aws-pricing-calculator/?utm_source=openai)) ([docs.aws.amazon.com](https://docs.aws.amazon.com/cost-management/latest/userguide/pricing-calculator.html?utm_source=openai))
+   - Apply: recommendation should state it is an estimate, not a guarantee; realized earnings depend on buyer traffic.
+   - Pattern: GCP calculator lets users add/configure products and share estimates. ([cloud.google.com](https://cloud.google.com/products/calculator?utm_source=openai))
+   - Apply: JSON output should be reproducible/shareable for support: include `rate_card_version`, `benchmark_id`, and `generated_at`.
+
+7. **Electricity-plan comparison sites**
+   - Pattern: plan comparison starts with ZIP/usage and ranks plans using current rates/preferences; some update rates daily. ([choosetexaspower.org](https://www.choosetexaspower.org/?utm_source=openai))
+   - Apply: recommendation should include local electricity as a first-class input and show data freshness.
+   - Pattern: savings calculators show monthly/yearly estimates, annual savings, and savings percentage. ([energyogre.com](https://www.energyogre.com/savings?utm_source=openai))
+   - Apply: show “recommended vs default” delta: `+$0.18/hr`, `+23% vs default`, or “donor-tier, expected net near zero.”
+   - Pattern: utility tools compare current plan vs alternatives using past usage. ([sce.com](https://www.sce.com/save-money/rates-financing/rate-plan-comparison-tool?utm_source=openai))
+   - Apply: `macprovider status` should compare current configured model against the latest recommendation.
+
+**Part 2 conclusion:** The best import pattern is WhatToMine/NiceHash ranking plus staking-dashboard assumption disclosure: ranked candidates, net yield, confidence, staleness, and explicit “recommended vs alternatives” deltas.
+
+**Part 3 — Differentiation Framing**
+
+macprovider’s provider-install UX sits in a gap left by most decentralized GPU networks. Vast, RunPod, io.net, Akash, Aethir, Render, and Bittensor generally expose raw capacity, bids, node eligibility, subnet incentives, or buyer-selected workloads; their public provider flows do not show an installer-time recommendation that says “given this hardware, run this model to earn the most.” That difference follows from their market structure: the buyer brings a container, manifest, render job, or subnet task, while the provider supplies capacity or competes under a protocol.
+
+The closest competitive exception is Darkbloom. Its public pages show an Apple-Silicon inference network, a CLI provider install path, and an earnings calculator that auto-selects the “most profitable” model for a chosen Mac hardware profile. That means macprovider should not claim the entire idea is unobserved. The sharper wedge is that SPEC-018 makes the recommendation local, installer-integrated, benchmark-backed, and machine-readable via `autotune --recommend`, rather than only a web estimate.
+
+The right UX lineage is not generic cloud hosting. It is staking calculators and mining profitability calculators. StakingRewards-style surfaces rank heterogeneous yield options and disclose risk; WhatToMine/NiceHash-style surfaces translate hardware, power, rates, and current market data into ranked profitability. macprovider has the same shape: detected hardware plus measured tokens/sec plus a per-model rate card plus demand assumptions yields a ranked recommendation.
+
+This will not create demand where none exists. SPEC-018 answers “which model should this provider run, given known rates and measured local performance?” It does not answer “will buyers show up?” The UX must say that clearly: expected `$/hr` is an estimate conditioned on demand, utilization, uptime, electricity, and the current rate card.
+
+**Part 3 conclusion:** Frame SPEC-018 as installer-integrated yield recommendation for inference providers: competitive against raw-capacity marketplaces, informed by staking/mining calculators, and honest that recommendation optimizes model choice, not market demand.
+
+**Part 4 — v0.1 SPEC Implications**
+
+1. **Output schema for `autotune --recommend`**
+   - Tie-back: WhatToMine/NiceHash rank alternatives; Beefy/Yearn disclose net APY/risk; AWS/GCP preserve estimate assumptions.
+   - Suggested JSON shape:
+
+```json
+{
+  "schema_version": "autotune_recommend.v1",
+  "generated_at": "2026-06-30T12:00:00Z",
+  "hardware": {
+    "machine": "MacBook Pro",
+    "chip": "M4 Max",
+    "memory_gb": 48,
+    "detected": true
+  },
+  "inputs": {
+    "rate_card_version": "2026-06-30",
+    "electricity_usd_per_kwh": 0.15,
+    "assumed_utilization": 0.8,
+    "availability_hours_per_day": 18
+  },
+  "recommended_model": "qwen3-14b",
+  "candidates": [
+    {
+      "rank": 1,
+      "model": "qwen3-14b",
+      "fits": true,
+      "expected_net_usd_per_hour": 0.42,
+      "expected_gross_usd_per_hour": 0.47,
+      "electricity_usd_per_hour": 0.03,
+      "platform_fee_usd_per_hour": 0.02,
+      "tokens_per_second": 41.2,
+      "memory_headroom_gb": 8.1,
+      "confidence": "medium",
+      "why": "highest net yield among compatible models"
+    }
+  ],
+  "comparison": {
+    "default_model": "gemma-7b",
+    "recommended_delta_usd_per_hour": 0.18,
+    "recommended_delta_percent": 75
+  },
+  "warnings": [
+    "Earnings depend on buyer demand and realized utilization."
+  ]
+}
+```
+
+2. **Install transcript copy**
+   - Tie-back: Lido gives monthly/yearly rewards next to APR; electricity-plan tools show savings vs current/default; Darkbloom discloses demand caveats.
+   - Happy path:
+
+```text
+Detected MacBook Pro M4 Max, 48 GB unified memory.
+Benchmarked 4 compatible models against rate card 2026-06-30.
+
+Recommended: qwen3-14b
+Expected net: $0.42/hr at 80% utilization
+Why: +$0.18/hr vs default gemma-7b, 8.1 GB memory headroom
+
+This is an estimate, not a guarantee. Actual earnings depend on buyer demand,
+uptime, thermal state, and rate-card changes.
+
+Start provider with qwen3-14b? [Y/n]
+```
+
+   - Donor-tier path:
+
+```text
+Detected MacBook Air M1, 8 GB unified memory.
+No paid model currently clears the minimum net-yield threshold.
+
+Best compatible option: tinyllama
+Expected net: $0.00-$0.01/hr before demand risk
+Recommendation: donor mode only
+
+You can still run a provider to support network coverage, but this Mac is
+not expected to earn meaningful revenue on the current rate card.
+Enable donor mode? [y/N]
+```
+
+3. **Re-tune cadence + UX**
+   - Tie-back: NiceHash profit-switching shows market-aware re-optimization, but automatic switching is risky for inference provider stability.
+   - v0.1 decision: make `autotune --recommend` rerunnable and idempotent; do not silently switch models.
+   - Trigger recommendation prompts on install, manual `macprovider autotune --recommend`, and rate-card version change.
+   - Store last recommendation summary with `generated_at`, `rate_card_version`, and `benchmark_id`.
+
+4. **Donor-mode opt-in**
+   - Tie-back: electricity-plan sites show “you could save $X” before switching; macprovider should show “you would earn $X less” before override.
+   - v0.1 decision: require explicit opt-in for non-recommended or below-threshold operation:
+     - CLI: `macprovider configure --model tinyllama --donor-mode`
+     - YAML: `donor_mode: true`
+     - Install prompt default: No
+   - Warning copy: “This choice is estimated to earn `$X/hr` less than the recommended model” or “below minimum revenue threshold.”
+
+5. **Status-command integration**
+   - Tie-back: utility tools compare current plan vs alternatives using actual/past usage; io.net dashboards show earnings and compute job metrics.
+   - v0.1 decision: `macprovider status` should include:
+     - current model
+     - last measured `tokens/sec`
+     - observed earnings last hour/day if available
+     - estimate from last recommendation
+     - stale recommendation warning
+     - better available model, if any
+
+```text
+Model: gemma-7b
+Estimated net: $0.24/hr
+Observed last 24h: $3.10 total
+Recommendation stale: rate card changed 2026-06-30
+
+Run: macprovider autotune --recommend
+Potential improvement: qwen3-14b estimated $0.42/hr (+$0.18/hr)
+```
+
+**Part 4 conclusion:** SPEC-018 v0.1 should specify a ranked, net-yield JSON contract; install copy with assumptions and deltas; explicit re-tune triggers; donor-mode guardrails; and status integration that compares current model to the latest recommendation.
+
+**Part 5 — Liftable One-Line Conclusions**
+
+- Part 1: Major decentralized GPU networks mostly avoid the provider model-choice problem; Darkbloom is the notable close exception with a public hardware-to-model earnings calculator.
+- Part 2: Import the WhatToMine/NiceHash ranked-profitability pattern and the staking-dashboard assumption/risk-disclosure pattern.
+- Part 3: macprovider’s wedge is installer-integrated, benchmark-backed model yield recommendation for heterogeneous consumer inference hardware.
+- Part 4: v0.1 should lock the recommendation as a transparent ranked estimate, not a guaranteed income claim or silent auto-switcher.
+tokens used
+248 684
+
+```
+
+## Concise summary
+
+Provider completed successfully. Review the raw output for details.
+
+## Action items
+
+- Review the response and extract decisions you want to apply.
+- Capture follow-up implementation tasks if needed.

--- a/specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_PROMPT.md
+++ b/specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_PROMPT.md
@@ -1,0 +1,98 @@
+# RESEARCH PROBE — competitive provider-installer UX + analogous yield-recommendation surfaces (SPEC-018 v0.1 input)
+
+Run as: `omc ask codex "$(cat specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_PROMPT.md)"`
+
+This is a **scoped pre-SPEC probe**, not a full research memo. Single codex call, ~20-40 min wall time, ~200-400 line output. Feeds directly into `specs/SPEC-018-installer-autotune-recommend-v0.1.md` drafting on the same day.
+
+## Context
+
+macprovider's Wave 0c (SPEC-018) ships a provider-side install UX that scores each model on the operator's Mac and recommends the highest-expected-`$/hr` model to run. This is a net-new product surface; the operator (macprovider) needs to know whether anyone else in the GPU/compute marketplace space has shipped something analogous, and if not, which adjacent product UXes solve the same input-hardware → output-yield-projection-with-recommendation problem worth importing patterns from.
+
+Current operator hypothesis (to confirm or refute):
+
+> No major decentralized GPU/compute network has a provider-install "we recommend this model for your hardware to earn most" UX. Their provider model is different: vast.ai/RunPod/io.net rent raw GPU capacity (buyer brings the workload), Akash uses manifest-based bidding (provider doesn't pick a model), Darkbloom assigns the catalog top-down. None of them face macprovider's combination of (inference-as-service + heterogeneous consumer hardware + per-model rate card), so none of them face the "what model should this provider run to earn most?" problem.
+>
+> If true, the closest UX analogues are crypto staking-rewards calculators (StakingRewards.com, Lido dashboard) and mining-pool profitability calculators (WhatToMine.com) — both solve "input hardware/capital → ranked yield projection → recommendation" for heterogeneous-hardware-per-asset-rate markets.
+
+## Task
+
+### Part 1 — Competitive sweep
+
+Confirm or refute the operator hypothesis above by checking the provider-onboarding UX for each network below. For each, answer:
+
+- **Provider install flow shape**: CLI / desktop app / web dashboard / container manifest / hybrid?
+- **Does it recommend a workload (model / job type) for the provider's specific hardware?** If yes, what's the recommendation logic + UX surface?
+- **Does the provider pick the workload, or is it assigned by the network / buyer?**
+- **Does it project earnings before commit?** (Either "this hardware will earn $X/hr" or "this workload on this hardware will earn $X/hr".)
+- **One-line summary** of how this maps to macprovider's design space.
+
+Networks to cover (add others if you spot them — Together.ai, Lepton, Modal, Replicate-provider-side, etc.):
+
+1. **vast.ai** — public docs at https://vast.ai/docs/
+2. **RunPod** — public docs at https://docs.runpod.io/
+3. **io.net** — public docs at https://docs.io.net/
+4. **Akash Network** — public docs at https://akash.network/docs/
+5. **Aethir** — public docs / whitepaper
+6. **Render Network** — public docs
+7. **Bittensor** — subnet provider onboarding (Templar, Targon, any subnet handling inference)
+8. **Helium** (legacy comparison only — different domain but inspiration source for tokenomics)
+9. **Together.ai**, **Lepton.ai**, **Modal**, **Replicate** — closed-source provider sides; check public docs for any provider-onboarding surface (likely none — these are centrally-owned compute, not marketplaces)
+10. **Layr-Labs/d-inference (darkbloom.dev)** — **DO NOT inspect source code per CLAUDE.md clean-room rule.** Public docs / whitepaper only. Confirm whether their provider onboarding has any model-recommendation surface or just runs the assigned catalog.
+
+Output as a single comparison table.
+
+### Part 2 — Closest UX analogues (non-competitive)
+
+Survey the following analogous-shape products (input hardware/capital → ranked yield projection → recommendation), and for each pull 2-4 concrete design patterns that translate to macprovider's `autotune --recommend` output:
+
+1. **StakingRewards.com** — heterogeneous staking options (validators, networks) ranked by APR for input stake amount
+2. **Lido / RocketPool dashboards** — single-pool but rich yield projection UX
+3. **WhatToMine.com** — input GPU model, output ranked profitability per coin
+4. **NiceHash dashboard** — heterogeneous mining algorithm allocation per hardware
+5. **Yield aggregators**: Yearn / Beefy / Convex — input asset, see ranked yield-per-pool
+6. **Cloud cost calculators**: AWS Pricing Calculator, GCP Calculator — input workload, project cost (inverted yield but similar input-hardware shape)
+7. **Power Compare / electricity-plan comparison sites** — input usage profile, get ranked best-plan recommendation with savings projection
+
+For each: 2-4 design patterns with concrete examples and how they apply to macprovider. Categories worth checking:
+
+- Input form UX (how is hardware specified — auto-detected vs operator-entered)
+- Output ranking presentation (table / cards / chart / sortable)
+- Projection confidence (single number / range / risk-adjusted)
+- Alternatives display ("you chose X; here's what you would have earned with Y, Z")
+- Refresh/staleness handling ("data 6h old", "refresh recommendation")
+- Override / donor-mode pattern ("I want to pick a non-recommended option anyway")
+- Transparency of formula ("why this recommendation" / "expected yield breakdown")
+- Comparison vs network-wide average ("you earn 23% more than median provider in your tier")
+
+### Part 3 — Differentiation framing
+
+Given the Part 1 finding, write a 3-4 paragraph "wedge" framing for the SPEC-018 v0.1 preamble that operator (macprovider) can lift verbatim. The framing should:
+
+- Cite the gap in Part 1 (no decentralized GPU network has this UX, and why — their model is different)
+- Cite the closest analogues from Part 2 (staking calculator + mining profitability calculator UX patterns)
+- Articulate why macprovider's combination forces this UX (heterogeneous consumer hardware + per-model rate card + inference-as-service)
+- Be honest about what this WON'T do (e.g., it won't make providers earn money if there are no buyers; it solves the "which model" question, not the "is there demand" question)
+
+### Part 4 — v0.1 SPEC implications
+
+Concrete list of design decisions Part 1-3 should drive into SPEC-018 v0.1:
+
+- **Output schema** for `autotune --recommend` (JSON shape with 3-5 ranked candidates, score breakdown, comparison vs default)
+- **Install transcript copy** (what the operator sees during install — 1-2 example transcripts: happy path + "this Mac is donor-tier")
+- **Re-tune cadence + UX** (`autotune --recommend` rerunnable? auto-prompt on rate-card change? operator-triggered only?)
+- **Donor-mode opt-in pattern** (CLI flag? YAML config? install-time prompt with explicit "you'd earn $X less" warning?)
+- **Status-command integration** (`macprovider status` showing "you're earning $X/hr on model Y; you could earn $Z/hr on model W")
+
+Each implication ties back to a concrete Part 2 pattern + Part 1 confirmation.
+
+### Part 5 — One-line summary per Part
+
+Each Part section ends with a single-line conclusion the SPEC author can lift into SPEC-018 v0.1.
+
+## Constraints
+
+- Read-only. Do NOT modify code, write specs, fire other prompts, or sign up for accounts on any of the surveyed services.
+- Web/doc inspection allowed for everything EXCEPT Layr-Labs/d-inference source (clean-room per CLAUDE.md). For d-inference, only public docs / whitepaper / public marketing pages allowed.
+- Cite every claim with a URL or "public docs ¶X" reference. If a service's docs don't address a question, say so explicitly ("docs do not mention X").
+- Conservative > speculative. If a network has a private provider-recommendation surface you can't verify, flag it as unknown rather than asserting it doesn't exist.
+- Output: markdown memo, ~200-400 lines. Structure: Part 1 table, Part 2 patterns, Part 3 wedge framing, Part 4 implications list, Part 5 one-line conclusions.

--- a/specs/SPEC-023-v0_1-KICKSTART-PROMPT.md
+++ b/specs/SPEC-023-v0_1-KICKSTART-PROMPT.md
@@ -1,0 +1,391 @@
+# SPEC-023 v0.1 — Installer-Integrated Autotune Recommend — KICKSTART PROMPT
+
+Run as: `omc ask codex "$(cat specs/SPEC-023-v0_1-KICKSTART-PROMPT.md)"` in a fresh codex session, OR open a fresh `codex` session manually and paste this file's contents as the first message.
+
+This is a **self-contained SPEC drafting + audit prompt**. The codex session will NOT have prior conversation context, so this file carries everything needed.
+
+---
+
+## Mission
+
+Produce a **locked normative SPEC document** at `specs/SPEC-023-installer-autotune-recommend.md` (version `v0.1`) for the macprovider Wave 0c product surface: installer-integrated `autotune --recommend` that scores rate-card-eligible models against the operator's Mac hardware and recommends the one with the highest expected net `$/hr`, replacing the current donor-default install behavior.
+
+Run the SPEC through a **4-lane codex audit loop** (code / security / architect / product-design) until convergence at **0 CRITICAL / 0 HIGH / 0 MEDIUM** per `[[feedback-three-lane-codex-audits]]` (4 lanes here because this is a product surface, not pure backend money-path — matches the SPEC-018 agentic-tool-calling pattern).
+
+**Do NOT** write any IMPL code, BUILD prompt, or open any PR. The operator will write the BUILD prompt and open the PR after reviewing the locked SPEC.
+
+---
+
+## Required reading (read all before drafting)
+
+### 1. Decision log entries (most recent first)
+
+- `beta/DECISION_CRITERIA.md` Entry 95 — Entry 94 misattribution correction (going-forward gate for "active production bug" claims)
+- `beta/DECISION_CRITERIA.md` Entry 94 — Wave 0a/0b shape correction (no per-model registry; settle from provider usage on clean SSE streams) — note that Entry 94's "live buyer traffic" framing was wrong per Entry 95; the bug is real, framing was misattributed
+- `beta/DECISION_CRITERIA.md` Entry 93 — 4-wave plan (Wave 0a gateway, 0b coord, 0c provider-side install/autotune defaults, 1 rate-card hot reload)
+- `beta/DECISION_CRITERIA.md` Entry 92 — Beta pricing v2 LOCKED (per-model rate-card rows, per-model RAM-first admission, off-chain TOKEN_NAME ledger)
+
+### 2. Research memos (locked inputs)
+
+- `specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_MEMO.md` — MoE model selection + market demand rankings (OpenRouter top-50, ranks for gpt-oss-20b, gemma-4, qwen3-30b-a3b)
+- `specs/RESEARCH_227_RATE_CARD_V3_MEMO.md` — Rate-card v3 (5-row deployable subset + RESEARCH_227 Part 5 install/autotune donor-default diagnosis)
+- `specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_MEMO.md` — Goodhart probe output: 10 failure modes (FM-1 through FM-10), 20-row mitigation library, 8 v0.1 bake-in set (M1, M3, M4, M7/M8, M12, M16, M18, M20), recommended v0.1 formula shape, demand-signal source = option (b) static JSON. (Memo internally says "SPEC-018"; the preface clarifies it's SPEC-023.) Companion prompt at `specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_PROMPT.md`.
+- `specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_MEMO.md` — Competitive UX probe output: vast.ai/RunPod/io.net/Akash/Bittensor/Aethir/Together/Lepton/Modal/Replicate sweep + Darkbloom counter-finding + 7 UX-pattern imports (StakingRewards, Lido, WhatToMine, NiceHash, Yearn/Beefy, AWS/GCP, electricity-plan tools) + proposed JSON schema + install transcripts. (Memo internally says "SPEC-018"; the preface clarifies it's SPEC-023.) Companion prompt at `specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_PROMPT.md`.
+
+### 3. Code surfaces this SPEC affects (read for current state, do NOT modify)
+
+- `phase3-binary/dist/install.sh` lines 649-657 (`choose_model()`) — current donor-default logic that needs replacing
+- `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift` lines 84-90 (`defaultCandidates`) — current zero-MoE candidate list
+- `phase3-binary/Sources/macprovider-cli/AutotuneRuntimeSupport.swift` (`MachineFingerprinter.sample()`) — current hardware probe
+- `phase4-coordinator/internal/billing/formula.go` (`RateFor` + `normalizeModelKey` — Wave 0b shipped 2026-06-30 as `origin/main:a3149e3`)
+
+### 4. Convention references (must follow)
+
+- `CLAUDE.md` — git identity, PR workflow, money-path discipline, Darkbloom clean-room rule
+- `specs/SPEC-017-network-stats-api.md` (or whichever version is locked) — exemplar locked SPEC format for product surfaces
+- `specs/SPEC-018-agentic-tool-calling.md` v0.1.5 — exemplar locked SPEC that used 4-lane audit (code / security / architect / product-design)
+
+---
+
+## Deliverables
+
+### A. The locked SPEC
+
+`specs/SPEC-023-installer-autotune-recommend.md`
+
+Header (lines 1-5):
+```
+# SPEC-023 — Installer-Integrated Autotune Recommend
+version: v0.1
+status: LOCKED
+owner: operator (a11)
+last-locked: <YYYY-MM-DD>
+```
+
+### B. Per-audit-round narrative files
+
+`specs/SPEC-023-v0_1-rN-audit.md` for each round, listing per-lane verdict + findings + fixes applied + accepted LOWs. Match the format used in `specs/SPEC-017-r{1..7}-audit.md` / `specs/SPEC-WAVE-0A-0B-r{1..4}-audit.md`.
+
+### C. Per-audit-lane prompt files
+
+`specs/AUDIT_SPEC_023_v0_1_CODE_PROMPT.md`
+`specs/AUDIT_SPEC_023_v0_1_SECURITY_PROMPT.md`
+`specs/AUDIT_SPEC_023_v0_1_ARCHITECT_PROMPT.md`
+`specs/AUDIT_SPEC_023_v0_1_PRODUCT_DESIGN_PROMPT.md`
+
+Each prompt enumerates what that lane is looking for. See "Audit lane scope" section below.
+
+### D. NO IMPL prompt, NO BUILD prompt, NO PR open
+
+Operator writes the BUILD prompt and opens the PR after reviewing the locked SPEC.
+
+---
+
+## SPEC content requirements
+
+The locked SPEC must contain these sections in this order:
+
+### §1 — Mission
+
+One paragraph: what `autotune --recommend` does, who it serves (every new provider installer + every operator running `autotune --recommend` post-install), and why Wave 0c lands now (beta launch readiness; provider acquisition cohort 120 needs frictionless install + correct first-model choice).
+
+### §2 — Non-goals
+
+Explicit list of what this SPEC does NOT do. At minimum:
+- Does not solve "will buyers show up" — recommends model, not market demand
+- Does not auto-switch models without operator action (no NiceHash QuickMiner-style behavior in v0.1)
+- Does not change rate-card content (Wave 1 owns that)
+- Does not change gateway billing or coord settlement (Waves 0a/0b already shipped)
+- Does not add provider-side TPS reputation feedback to coord (deferred to v0.2)
+- Does not implement live `/v1/demand-signal` coord endpoint (deferred to v0.2)
+- Does not implement utilization-adjusted realized-earnings projection (deferred to v0.2 once buyer history exists)
+
+### §3 — Inputs
+
+Three input families:
+
+1. **Hardware properties** — auto-detected by `MachineFingerprinter.sample()`. Includes RAM (GB), bandwidth tier (S/A/B/C), chip family, sustained-TPS-per-candidate (probed locally on each candidate via autotune benchmark). Lists exactly which fields are required vs optional.
+
+2. **Rate card** — fetched from coordinator (`/v1/rate-card` endpoint) OR baked into binary at release time (offline fallback). Lists the schema: `{version, generated_at, rows: {<model_key>: {prompt_rate_per_mtok, completion_rate_per_mtok, provider_share_bps, global_multiplier_ppm}}}`. Note this matches `phase4-coordinator/internal/billing/formula.go::RateCardEntry`. Wave 0b's `normalizeModelKey` lookup applies to the model_key.
+
+3. **Demand signal** — fetched from static URL `get.streamvc.live/demand-rank.json` with baked fallback in binary. Per RESEARCH_229 conclusion: option (b). JSON schema includes `version, generated_at, source, cold_start_floor, top_k_band, rows: {<model_key>: {demand_weight, rank, recommendable, min_provider_target}}`. SPEC must lock the JSON schema verbatim.
+
+### §4 — Formula (locked v0.1)
+
+```
+eligible_rows = rows where:
+  rate_card_enabled AND
+  recommendable == true AND
+  hardware_fits(model, mac) AND
+  local_autotune_passes(model, mac)
+
+raw_score(row | mac) =
+  measured_tps(row, mac)
+  × 3600
+  × usd_per_million_completion_tok(row)
+  × provider_share(row)
+  × max(demand_weight(row), cold_start_floor)
+  × tier_weight(row, mac.tier)
+
+recommendation_pool =
+  top-K eligible rows where raw_score >= 0.85 × max(raw_score)
+
+default_model =
+  pool[ stable_hash(provider_id_or_machine_fingerprint) % len(pool) ]
+```
+
+Constants locked in v0.1:
+- `cold_start_floor = 0.15`
+- `top_k_band = 0.85` (i.e., 85% of best score)
+- `provider_share = 0.90` (from existing rate-card row)
+- `tier_weight` defaults to `1.0` for all (tier interaction is documented as a known v0.2 lever)
+
+### §5 — Eligibility gates (mandatory pre-filter)
+
+A row is eligible ONLY if ALL pass:
+- `recommendable == true` in demand-rank JSON (operator can disable broken rows here)
+- `hardware_fits(model, mac)` — RAM headroom check: `model.min_ram_gb <= mac.ram_gb - safety_margin` (define safety_margin)
+- `local_autotune_passes(model, mac)` — measured TPS, TTFT, no-swap, no-thermal-throttle during probe
+- Coord rate-card has a row for the model (verbatim or via `normalizeModelKey`)
+
+If no rows pass all gates: install transcript shows donor-mode-only path (see §7), no recommendation.
+
+### §6 — Output JSON contract (`autotune --recommend`)
+
+Lock the JSON schema verbatim. Use the structure from RESEARCH_230's proposal as the starting point; refine if needed. Required top-level fields:
+
+```json
+{
+  "schema_version": "autotune_recommend.v1",
+  "generated_at": "<RFC3339>",
+  "hardware": {...},
+  "inputs": {
+    "rate_card_version": "...",
+    "demand_rank_version": "...",
+    "electricity_usd_per_kwh": null|float,
+    "assumed_utilization": 0.0..1.0,
+    "availability_hours_per_day": 0..24
+  },
+  "recommended_model": "<model_key>",
+  "candidates": [
+    {
+      "rank": 1,
+      "model": "<model_key>",
+      "eligible": true,
+      "expected_gross_usd_per_hour": float,
+      "expected_net_usd_per_hour": float,
+      "electricity_usd_per_hour": float,
+      "platform_fee_usd_per_hour": float,
+      "tokens_per_second": float,
+      "memory_headroom_gb": float,
+      "confidence": "low|medium|high",
+      "why": "<one-line reason>"
+    }
+  ],
+  "comparison": {
+    "default_model": "<model_key>",
+    "recommended_delta_usd_per_hour": float,
+    "recommended_delta_percent": float
+  },
+  "warnings": [...]
+}
+```
+
+Lock decisions: ranked array length default = 5; `electricity_usd_per_kwh` default behavior when absent (omit electricity row from net calc, warn); `confidence` derivation rules; deterministic field order for stable diff/test.
+
+### §7 — Install transcript copy (locked text)
+
+Two transcript paths, locked verbatim:
+
+1. **Happy path** — Mac fits ≥1 recommendable model with `expected_net_usd_per_hour > 0`. Show: detected hardware, count of benchmarked candidates, recommended model + expected net, why (delta vs default), assumption disclosure ("estimate, not a guarantee"), `[Y/n]` start prompt.
+
+2. **Donor-tier path** — no recommendable model has `expected_net > minimum_threshold` (lock the threshold value). Show: detected hardware, "no paid model clears the minimum net-yield threshold," best compatible option as donor-only, "Enable donor mode? [y/N]" with default No.
+
+Lock exact wording. Lock the threshold (e.g., `$0.005/hr`). Lock the format string for `$/hr` rendering (4 decimals? 3?).
+
+### §8 — Donor-mode UX
+
+CLI flag: `--donor-mode` (boolean).
+YAML config: `donor_mode: true` (boolean).
+Install prompt default: No.
+
+Behavior when `donor_mode == true`:
+- Skip the eligibility-gate "no rows pass" abort
+- Allow any RAM-fits model regardless of `recommendable` status
+- Print explicit "$X/hr less than recommended" warning before commit
+- `macprovider status` shows "DONOR MODE" badge alongside model
+
+### §9 — Re-tune cadence + UX
+
+Triggers that cause `autotune --recommend` to re-run (or prompt the operator):
+1. Manual operator invocation: `macprovider autotune --recommend`
+2. `macprovider upgrade` post-install (check if rate-card or demand-rank version changed)
+3. NOT: automatic on coord SIGHUP / rate-card reload (deferred to v0.2 — defer the broadcast mechanism)
+
+Stored state: last recommendation result saved to `~/.config/macprovider/last-recommendation.json` with `generated_at, rate_card_version, demand_rank_version, recommended_model`.
+
+Stale-recommendation warning emitted by `macprovider status` when the live rate-card or demand-rank version differs from the stored one.
+
+### §10 — Goodhart mitigations (cite by ID from RESEARCH_229)
+
+For each of the 8 v0.1 bake-in mitigations from RESEARCH_229 (M1 top-K diversification, M3 cold-start floor, M4 row lifecycle states, M7 rate-card version binding, M8 retune hint, M12 hard eligibility gates, M16 deployability gate, M18 full-utilization wording, M20 static JSON), state which §X section of this SPEC implements it. Every mitigation must be traceable to a SPEC section.
+
+### §11 — Acceptance criteria
+
+Numbered list (~15-25 items) of verifiable behaviors. Examples:
+- AC-1: `autotune --recommend --json` output validates against `autotune_recommend.v1` schema for any Mac.
+- AC-2: When all rows fail eligibility, output emits donor-tier transcript and `recommended_model = null`.
+- AC-3: When `demand_rank.json` 404s, installer falls back to baked snapshot and emits warning to stderr.
+- AC-4: `stable_hash(provider_id) % len(pool)` produces deterministic recommendation for same provider_id + same pool.
+- AC-5: Two distinct provider_ids on identical hardware get distinct recommendations from the same top-K pool (with statistical probability > 50% for K=3+).
+- ... (continue through AC-15+)
+
+Each AC is testable by either a unit test in IMPL or an end-to-end install script smoke test.
+
+### §12 — Open questions / v0.2 candidates
+
+Numbered list (Q1, Q2, ...) of decisions deferred to v0.2 or later. At minimum:
+- Q1: Live coord `/v1/demand-signal` endpoint and switch trigger (RESEARCH_229: ≥60 days history + ≥50M paid tokens + ≥5 buyer accounts + no single buyer >50%)
+- Q2: Tier-specific `tier_weight` calibration (currently 1.0 across the board)
+- Q3: Provider TPS reputation downweighting from production traffic
+- Q4: Utilization-adjusted realized-earnings projection
+- Q5: Coord broadcast of "recommendation changed" on hot-reload (provider auto-prompt)
+- Q6: Per-provider quota / coverage allocation policy
+- Q7: Collusion detection / cartel monitoring
+- Q8: Cross-Mac transfer of recommendation (e.g., operator clones config to second Mac)
+- Q9: Donor-mode time-limited grant of token rewards (TOKEN_NAME ledger interaction)
+
+### §13 — Differentiation framing (lift from RESEARCH_230 Part 3)
+
+3-4 paragraph "wedge" framing for the operator to use in beta-launch messaging. Acknowledges Darkbloom as the closest existing surface; positions macprovider as installer-integrated + locally-benchmark-backed + machine-readable JSON output vs Darkbloom's web calculator.
+
+### §14 — Threat model
+
+Enumerate adversary capabilities + what SPEC v0.1 defends:
+
+| Adversary | Capability | v0.1 defense | Deferred to v0.2 |
+|---|---|---|---|
+| Provider self-reports inflated TPS | Local autotune probes own Mac | Probe is CLI-owned; rejected | Cross-check vs coord-observed TPS |
+| Provider tampers with `last-recommendation.json` | Reads/writes local file | None — operator owns their Mac | Sign the recommendation with provider key |
+| Adversary serves bogus `demand-rank.json` via DNS hijack | Replaces static URL response | Pin TLS cert + checksum/sig the JSON | — |
+| Provider group coordinates to all pick same row | Discord/off-network coordination | M1 top-K diversification limits worst-case | Coord quota policy |
+| Provider opts into donor mode then claims earnings later | YAML config flip | Donor mode is logged; coord rejects non-recommendable rows for billing | — |
+
+Lock the v0.1 defenses; defer the v0.2 ones explicitly.
+
+### §15 — Acceptance & success metrics
+
+Post-deployment metrics that mean "v0.1 worked":
+- Median new-provider install time to first request served: < N seconds (lock N)
+- % of new providers that DON'T pick the donor-class default: > 90%
+- % of recommendations whose `expected_net_usd_per_hour` is within ±20% of realized net 7 days post-install: > 75% (assumes buyer demand)
+- Operator-visible audit: every `event=rate_card_normalized` log line has a matching `event=recommendation_emitted` for the same model within the 24h preceding install
+
+### §16 — Migration & backwards compatibility
+
+How does this SPEC interact with already-installed providers (currently 2 on the network, both pre-Wave-0c)?
+
+- Existing providers continue serving their currently-configured model; no forced switch.
+- `macprovider upgrade` for existing providers prompts to run `autotune --recommend` once, showing potential delta.
+- `~/.config/macprovider/config.yaml` `model:` field continues to override any recommendation — operator choice always wins.
+
+### §17 — Audit-trail commitments
+
+Per `[[feedback-spec-audit-file-convention]]`: this SPEC v0.1 ships with per-round audit narrative files (`SPEC-023-v0_1-rN-audit.md`) capturing the codex convergence trajectory.
+
+Per `[[feedback-stop-iterating-on-low-audits]]`: convergence at 0 C/H/M is the stop condition; documented LOWs ship in v0.1.
+
+Per `[[feedback-bundle-spec-impl-one-pr]]`: SPEC v0.1 ships in its own PR; IMPL bundles with v0.2 deltas in a later cycle.
+
+---
+
+## Audit lane scope (4 lanes)
+
+After the SPEC draft is complete, run THREE rounds (minimum) of all 4 lanes via `omc ask codex "$(cat specs/AUDIT_SPEC_023_v0_1_<LANE>_PROMPT.md)"`. Each round's findings → fix-pass → re-audit until ALL lanes return 0 C/H/M.
+
+Per `[[feedback-skip-accepted-audit-lanes]]`: once a lane returns 0 C/H/M, do NOT re-fire it in subsequent rounds UNLESS the next fix-pass touched its scope.
+
+### Code lane
+
+- Are all referenced struct fields, function names, and file paths correct against current `origin/main`?
+- Are the JSON schema field names consistent everywhere they appear in the SPEC?
+- Are the math expressions (formula, thresholds, defaults) internally consistent and dimensionally correct?
+- Are the acceptance criteria (§11) each testable by a single unit test or integration test?
+- Are the migration steps (§16) safe wrt the deployed Wave 0a/0b code at `a3149e3`?
+
+### Security lane
+
+- Threat model (§14) — is every realistic adversary capability covered, or are defenses deferred without justification?
+- Can a malicious `demand-rank.json` (DNS hijack, MITM, replay of old rank file) cause unsafe recommendations?
+- Can a malicious provider game the eligibility gates (e.g., fake autotune probe output)?
+- Does any recommended row's billing arithmetic interact with Wave 0a/0b in a way that allows over-billing buyers?
+- Are donor-mode rows safely partitioned from rate-card billing (donor providers must not earn on `recommendable=false` rows)?
+- Does the SPEC introduce any new authentication, authorization, or trust boundary that needs explicit treatment?
+
+### Architect lane
+
+- Does §4 formula compose cleanly with Wave 0a/0b (rate-card normalization, settlement-from-usage)?
+- Is the v0.1 / v0.2 split clean (no v0.2 work is implicitly required for v0.1 to ship)?
+- Does the JSON schema have a clean versioning story (`autotune_recommend.v1` — what's v2)?
+- Does the static-URL demand-rank approach scale to 120-provider cohort without operator burden?
+- Are eligible-gate filtering + scoring + diversification independently testable and replaceable?
+- Does the SPEC overlap with any other locked SPEC's surface (SPEC-005 billing, SPEC-017 stats, SPEC-018 agentic, SPEC-021 protocol-hub, etc.)?
+
+### Product-design lane
+
+- Are install transcripts (§7) clear, honest, non-confusing for a new operator?
+- Does donor-tier transcript wording avoid implying "you've been rejected" (it's a hardware-tier reality, not a quality judgment)?
+- Does the "$/hr" claim avoid over-promising? Does the warning (§7) appear before the `[Y/n]` prompt?
+- Is the donor-mode opt-in path explicit enough that an operator can't accidentally enable it?
+- Does `macprovider status` (§9) provide a clear "switch now" affordance, or does it bury the upgrade path?
+- Does the wedge framing (§13) sound credible vs Darkbloom's existing earnings calculator, or does it overstate the differentiation?
+- For operators whose Mac genuinely earns ~$0/hr today (M1 Air 8GB), does the SPEC offer a dignified path (donor mode + token rewards) or push them away?
+
+---
+
+## Process / stop conditions
+
+1. Read all required reading.
+2. Draft `specs/SPEC-023-installer-autotune-recommend.md` v0.1 with all 17 sections.
+3. Write `specs/AUDIT_SPEC_023_v0_1_CODE_PROMPT.md`, `_SECURITY_PROMPT.md`, `_ARCHITECT_PROMPT.md`, `_PRODUCT_DESIGN_PROMPT.md` — each a self-contained audit prompt for that lane.
+4. Fire round 1 audit: 4 lanes in parallel via `omc ask codex "$(cat specs/AUDIT_SPEC_023_v0_1_<LANE>_PROMPT.md)"`. Save each lane's output to a known artifact path.
+5. Write `specs/SPEC-023-v0_1-r1-audit.md` summarizing all 4 lane verdicts + findings + fixes applied to SPEC + accepted LOWs.
+6. Apply fixes to SPEC for findings rated CRITICAL / HIGH / MEDIUM. Do NOT iterate on LOWs.
+7. Re-fire lanes that had C/H/M findings OR whose scope was touched by the fix-pass. Skip lanes that returned 0 C/H/M in round N unless fixed scope overlaps.
+8. Write `specs/SPEC-023-v0_1-rN-audit.md` for each subsequent round.
+9. Stop when ALL 4 lanes return 0 C/H/M in a single round (LOWs allowed and documented).
+10. Print to stdout:
+    - Final SPEC path: `specs/SPEC-023-installer-autotune-recommend.md`
+    - Final round audit file path
+    - Documented LOWs to surface in the PR body
+    - Suggested PR title: `spec: SPEC-023 v0.1 LOCK — installer-integrated autotune recommend (Wave 0c)`
+    - Suggested PR body summary (3-5 bullets)
+11. STOP. Do NOT open a PR, do NOT write IMPL code, do NOT write a BUILD prompt. The operator will review the locked SPEC, open the PR as `Augustas11` per `[[macprovider-no-required-reviewers-merge-pattern]]`, and write the IMPL prompt in a separate cycle.
+
+---
+
+## Constraints
+
+- **Money-path adjacent.** This SPEC affects provider economic routing. Wrong recommendation → wrong revenue → provider churn. Treat with money-path discipline.
+- **Clean-room rule (Darkbloom / Layr-Labs/d-inference).** Per `CLAUDE.md`: do NOT inspect their source. Public marketing / docs / earnings calculator UI only. RESEARCH_230 already established what public pages show — use that, do not re-inspect.
+- **Append-only audit trail.** Each audit round file is a new file, not an edit of the prior one.
+- **Audit prompts go in files.** Per `[[feedback-audit-prompts-file-not-chat]]`: each audit lane prompt lives in `specs/AUDIT_SPEC_023_v0_1_<LANE>_PROMPT.md`, NOT in chat.
+- **No spawn_task chips.** Per `[[feedback-no-spawn-task-chips]]`: any follow-up work that should be a separate session gets a recommended-next-step bullet in the SPEC's §12 (open questions), not a background-task chip.
+- **Concrete, not aspirational.** Lock decisions. If you cannot decide between two options for a §X section, document both options as Q-N in §12 and pick one for v0.1.
+- **No silent caps.** Per `[[feedback-audit-prompts-log-shape-backcompat]]`: if any audit round bounds findings (top-N, no-retry, sampling), surface what was dropped.
+- **Three audit-lane convention (CODE / SECURITY / ARCHITECT) is well-known. PRODUCT-DESIGN is the fourth lane.** Per the SPEC-018 v0.1.5 pattern, product-design lane catches UX over-promising, copy-tone issues, and adversary-perspective on user behavior.
+
+---
+
+## Final preflight checklist (codex must verify before declaring done)
+
+- [ ] SPEC has all 17 sections numbered §1 through §17.
+- [ ] Every locked decision in §3-§9 is concrete (no "TBD," no "see below" without resolution).
+- [ ] Every Goodhart mitigation (M1, M3, M4, M7, M8, M12, M16, M18, M20) is referenced by ID in §10 with a §X back-pointer.
+- [ ] JSON schema for `autotune --recommend` is locked verbatim with all field names + types.
+- [ ] JSON schema for `demand-rank.json` is locked verbatim with all field names + types.
+- [ ] Install transcripts in §7 are locked exact strings (not paraphrases).
+- [ ] All 4 audit lanes returned 0 C/H/M in the final round.
+- [ ] Each round audit file lists all 4 lane verdicts (even if skipped-because-converged).
+- [ ] No IMPL code written. No PR opened. No BUILD prompt written.
+- [ ] Final stdout summary printed with SPEC path + audit-round file path + suggested PR title + body bullets.


### PR DESCRIPTION
## Summary

Lands 5 research/prep files for the upcoming SPEC-023 (Wave 0c — installer-integrated autotune recommend) drafting cycle. No code touched. All files are read-only context for a separate codex session the operator will fire to draft SPEC-023 v0.1.

## Files

| File | Lines | Purpose |
|---|---:|---|
| `specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_PROMPT.md` | 85 | Codex prompt for Goodhart failure-mode probe |
| `specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_MEMO.md` | 608 | Codex output — 10 failure modes, 20 mitigations, 8 v0.1 bake-in set |
| `specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_PROMPT.md` | 98 | Codex prompt for competitive UX probe |
| `specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_MEMO.md` | 430 | Codex output — competitor sweep + Darkbloom counter-finding + 7 UX-pattern imports |
| `specs/SPEC-023-v0_1-KICKSTART-PROMPT.md` | 391 | Self-contained instruction prompt for a fresh codex session to draft SPEC-023 v0.1 + run 4-lane audit loop |

## RESEARCH_229 findings (Goodhart)

10 failure modes catalogued:
- FM-1 Winner-take-all herding on rank — network-killing
- FM-2 Cold-start exclusion for new rows — network-degrading→killing
- FM-3 TPS gaming / benchmark overfit — network-degrading
- FM-4 Rate-card update lag / stale recommendation — network-degrading
- FM-5 Demand-signal source mismatch (OpenRouter ≠ macprovider buyer mix) — network-degrading
- FM-6 Hardware tier tail pathologies — network-degrading
- FM-7 Bid-shading / provider coordination — cosmetic→degrading
- FM-8 Availability/quality blindness (Entry 93/94-class bugs) — network-killing
- FM-9 Supply-constraint feedback loop in coord stats — network-degrading→killing
- FM-10 Projection misinterpretation / provider churn — network-degrading

8 v0.1 bake-in mitigations: M1 top-K diversification, M3 cold-start floor (0.15), M4 row lifecycle states, M7/M8 rate-card version binding + retune hint, M12 hard eligibility gates, M16 deployability gate, M18 honest "capacity not guaranteed" wording, M20 static demand JSON.

Demand-signal source locked to **option (b)** — static `get.streamvc.live/demand-rank.json` with baked fallback. Switch trigger to coord-stats-blended (v0.2): ≥60 days history + ≥50M paid completion tokens + ≥5 buyer accounts + no single buyer >50%.

## RESEARCH_230 findings (Competitive UX)

Competitive sweep result: **no major decentralized GPU/compute network has installer-time model-recommendation UX** — vast.ai/RunPod/io.net/Akash/Aethir/Render/Bittensor/Together/Lepton/Modal/Replicate all have different provider models (raw GPU rental, manifest bidding, subnet protocol assignment).

**Counter-finding**: Darkbloom (Layr-Labs/d-inference) DOES have a public web earnings calculator at darkbloom.dev + console.darkbloom.dev/earn that auto-selects "most profitable for your hardware" given Mac type/chip/memory. Verified via public marketing pages only per CLAUDE.md clean-room rule — no source inspection.

**Sharper wedge for macprovider**: installer-integrated (CLI, not web), locally-benchmark-backed (autotune probes THIS Mac), machine-readable JSON output, rerunnable on rate-card change — vs Darkbloom's web calculator.

7 UX-pattern imports: StakingRewards (risk disclosure), Lido/Beefy (assumption inline with yield), WhatToMine (ranked table with caveats), NiceHash (CLI+JSON), Yearn/Beefy (net APY methodology), AWS/GCP (estimate-not-guarantee + reproducible JSON), electricity-plan tools (current-vs-alternative deltas).

Proposed `autotune_recommend.v1` JSON schema + happy-path + donor-tier install transcripts (both with explicit `[Y/n]` confirmation).

## SPEC-023 kickstart prompt

Instructs codex to:
1. Read 4 decision-log entries (92, 93, 94, 95) + 4 research memos (226, 227, 229, 230) + 4 code surfaces (do NOT modify: install.sh, AutotuneCommand.swift, AutotuneRuntimeSupport.swift, formula.go)
2. Draft `specs/SPEC-023-installer-autotune-recommend.md` v0.1 with 17 locked sections
3. Write 4 audit-lane prompts (code / security / architect / product-design — 4 lanes per SPEC-018 v0.1.5 product-surface pattern)
4. Run audit loop until 0 C/H/M on all 4 lanes
5. Write per-round audit narrative files (`specs/SPEC-023-v0_1-rN-audit.md`)
6. STOP before opening PR or writing IMPL — operator does that in a separate cycle

## SPEC-018 → SPEC-023 renumber note

The probes were fired before checking SPEC numbering and reference "SPEC-018" internally. Memo files have a `<!-- preface -->` clarifying the target is SPEC-023 (SPEC-018 was already taken by the agentic-tool-calling SPEC). Codex output preserved verbatim for audit-trail integrity.

## Test plan

- [x] Decision-log adjacent / research-prep only; no code paths exercised
- [x] Memo preface clarifies SPEC-018 → SPEC-023 renumber
- [x] Kickstart prompt references committed `specs/RESEARCH_*_MEMO.md` paths (not gitignored `.omc/artifacts/`)
- [ ] Operator triggers separate codex session against `omc ask codex "$(cat specs/SPEC-023-v0_1-KICKSTART-PROMPT.md)"` from a fresh worktree off `origin/main` after this PR merges
