### PR TITLE
fix(stats): replace hardcoded 2026-06-01 PartialSince with dynamic recentPartialSince() — unblocks main CI

### DIFF
--- a/phase4-coordinator/internal/stats/handlers_integration_test.go
+++ b/phase4-coordinator/internal/stats/handlers_integration_test.go
@@ -36,6 +36,15 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/stats/store"
 )
 
+// recentPartialSince returns a PartialSince string safely inside the
+// 30-day window used by shouldExposePartialHistorySince. Computed at
+// call time rather than hardcoded so the test suite does not become a
+// time bomb once wall-clock crosses 30 days past a hardcoded date.
+// The 25-day offset leaves headroom for slow CI runs + timezone drift.
+func recentPartialSince() string {
+	return time.Now().UTC().Add(-25 * 24 * time.Hour).Format(time.RFC3339)
+}
+
 // setupStatsHandler wires the Step 3 mux against the per-test
 // Postgres fixture, applies the Step 1 schema, and seeds fresh
 // snapshot rows so the freshness pre-check doesn't trip 503 on
@@ -56,7 +65,7 @@ func setupStatsHandler(t *testing.T) (http.Handler, *sql.DB) {
 			},
 		},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		zerolog.Nop(),
 	)
@@ -496,7 +505,7 @@ func TestAC22_AuthFailureLimiter(t *testing.T) {
 		st,
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		zerolog.Nop(),
 	).Handler()
@@ -574,7 +583,7 @@ func TestPartialHistorySinceBackfillModeGate(t *testing.T) {
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		zerolog.Nop(),
 	).Handler()
@@ -591,7 +600,7 @@ func TestPartialHistorySinceBackfillModeGate(t *testing.T) {
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"full",
-		"2026-06-01T00:00:00Z", // stale config — should be ignored
+		recentPartialSince(), // stale config — should be ignored
 		nil,
 		zerolog.Nop(),
 	).Handler()
@@ -627,7 +636,7 @@ func TestAC15_RedactionSweep(t *testing.T) {
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		logger,
 	).Handler()
@@ -687,7 +696,7 @@ func TestAC6_PartnerProjection(t *testing.T) {
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		zerolog.Nop(),
 	).Handler()
@@ -787,7 +796,7 @@ func TestAC4_BucketedExactEarningsNull(t *testing.T) {
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		zerolog.Nop(),
 	).Handler()
@@ -837,7 +846,7 @@ func TestAC5_ExactProviderExactEarnings(t *testing.T) {
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		zerolog.Nop(),
 	).Handler()
@@ -971,7 +980,7 @@ func TestAC18_TimingEquivalenceRows5_6_7(t *testing.T) {
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		zerolog.Nop(),
 	).Handler()
@@ -1101,7 +1110,7 @@ func TestPartnerProjectionNeverACAOStar(t *testing.T) {
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		zerolog.Nop(),
 	).Handler()
@@ -1277,7 +1286,7 @@ func TestPartnerHEADParity(t *testing.T) {
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		zerolog.Nop(),
 	).Handler()
@@ -1320,7 +1329,7 @@ func TestPartialHistoryAllWindowsCoverage(t *testing.T) {
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
 		"partial",
-		"2026-06-01T00:00:00Z",
+		recentPartialSince(),
 		nil,
 		zerolog.Nop(),
 	).Handler()


### PR DESCRIPTION
## Summary

Fixes the `phase4-coordinator (stats Postgres AC-9/10/19/20)` CI failure on `main` (has been failing on every CI run since 2026-07-01T00:00:00Z).

**Root cause**: time-bomb test. Not a regression from PR #296.

## The bug

`handlers.go::shouldExposePartialHistorySince` correctly gates `partial_history_since` emission on:

```go
return now.Sub(t) < winLen  // winLen = 30 days for window="30d"
```

Tests hardcoded `PartialSince = "2026-06-01T00:00:00Z"`, which was safe when authored (any wall-clock < 2026-07-01T00:00:00Z produced `diff < 30d = true`, field present).

Once CI ran at 2026-07-01T04:29:21Z, the diff = 30 days + 4.5 hours → `30d+4.5h < 30d = false` → field correctly omitted per the gate. But tests still asserted `present=true`.

## The fix

Introduce a helper:

```go
func recentPartialSince() string {
    return time.Now().UTC().Add(-25 * 24 * time.Hour).Format(time.RFC3339)
}
```

Replaces all 12 hardcoded `"2026-06-01T00:00:00Z"` usages in `handlers_integration_test.go`, including the "stale config — should be ignored" callsite (Path B `backfill_mode=full` ignores `PartialSince` entirely, so the fresh value still exercises the same "must be omitted" assertion).

25-day offset chosen to leave headroom for slow CI runs + timezone drift; safely inside the 30-day window.

## What this doesn't touch

- Production code (`handlers.go` unchanged)
- Behavior (`shouldExposePartialHistorySince` logic unchanged)
- Anything in the `internal/stats/rollup` or `internal/stats/store` packages
- PR #296's SPEC-006 §17.7.1 SSE contract corroboration work — that was correctly merged; this test was failing on 2026-07-01 regardless of what merged that day

## What this unblocks

- PR [#297](https://github.com/Augustas11/macprovider/pull/297) — Entry 96 + coordinator.yaml.example docs (blocked on green main)
- Any subsequent PR whose CI runs after this lands
- The recurring flake-that-wasn't-actually-a-flake investigation loop

## Verification

- [x] `go vet ./internal/stats/...` clean
- [x] `go build ./internal/stats/...` clean
- [x] Test file compiles cleanly (`go test -run=TestNever` sanity)
- [ ] Full Postgres integration suite requires testcontainers/docker (CI runs it); fix is deterministic — helper always returns a value <30 days ago, so gate always returns true for `window="30d"`

## Test plan

- [x] No production behavior change
- [x] Deterministic helper (no wall-clock arithmetic in test assertions)
- [ ] Post-merge: `phase4-coordinator (stats Postgres AC-9/10/19/20)` returns to green on `main`
- [ ] Post-merge: rebase + re-check PR #297 CI
