### PR TITLE
Fix updater LaunchAgent restart after binary swap

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -170,8 +170,14 @@ struct AutoUpdater: Sendable {
             }
             await record(updateID: updateID, target: target, phase: .swap, outcome: .success, reason: "binary_swap_complete", attempt: 1)
             try await ensureEligible(phase: .restart)
-            try restartLaunchd()
-            await record(updateID: updateID, target: target, phase: .restart, outcome: .inProgress, reason: "launchctl_bootstrap_invoked", attempt: 1)
+            do {
+                try restartLaunchd()
+            } catch {
+                try? rollbackCommittedSwapAfterRestartFailure(commitTracker)
+                await fail(updateID: updateID, target: target, phase: .restart, failure: .other, reason: Self.redactedReason(for: error))
+                return
+            }
+            await record(updateID: updateID, target: target, phase: .restart, outcome: .inProgress, reason: "launchctl_restart_invoked", attempt: 1)
         } catch AutoUpdateMarkerError.lockContended {
             await fail(updateID: updateID, target: target, phase: .eligibility, failure: .autoupdateAlreadyPending, reason: "autoupdate_already_pending")
         } catch AutoUpdateError.trustStateLost(let reason) {
@@ -231,6 +237,24 @@ struct AutoUpdater: Sendable {
             throw UpdateError.renameFailed(errnoValue)
         }
         tracker.committedSwap = true
+    }
+
+    func rollbackCommittedSwapAfterRestartFailureForTest(_ marker: AutoUpdatePendingMarker) {
+        let tracker = AutoUpdateCommitTracker()
+        tracker.marker = marker
+        tracker.committedMarker = true
+        tracker.committedBackup = true
+        tracker.committedSwap = true
+        try? rollbackCommittedSwapAfterRestartFailure(tracker)
+    }
+
+    private func rollbackCommittedSwapAfterRestartFailure(_ tracker: AutoUpdateCommitTracker) throws {
+        guard tracker.committedSwap, let marker = tracker.marker ?? (try? markerStore.readPending()) else {
+            return
+        }
+        try markerStore.restoreBackup(marker)
+        markerStore.clearPendingAndLock(target: nil)
+        try? FileManager.default.removeItem(atPath: marker.backupPath)
     }
 
     private func ensureEligible(phase: AutoUpdatePhase) async throws {
@@ -364,9 +388,11 @@ struct AutoUpdater: Sendable {
         guard FileManager.default.fileExists(atPath: plist.path) else {
             throw AutoUpdateError.other("unsupported_install_topology")
         }
-        let domain = "gui/\(getuid())"
-        try runProcess("/bin/launchctl", arguments: ["bootout", domain, "live.streamvc.macprovider"], allowFailure: true)
-        try runProcess("/bin/launchctl", arguments: ["bootstrap", domain, plist.path])
+        let loaded = launchctlServiceLoaded(label: SelfUpdate.launchdLabel)
+        try runProcess(
+            "/bin/launchctl",
+            arguments: SelfUpdate.launchdRestartArguments(serviceLoaded: loaded, plistPath: plist.path)
+        )
     }
 
     private static func launchctlServiceLoaded(label: String) -> Bool {

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -3,8 +3,18 @@ import Darwin
 import Foundation
 import MacProviderCore
 
+struct LaunchdRestartFailure: Error, CustomStringConvertible {
+    let error: Error
+    let recoveryCommand: String
+
+    var description: String {
+        String(describing: error)
+    }
+}
+
 struct SelfUpdate {
     static let defaultReleasesAPIURL = "https://api.github.com/repos/Augustas11/macprovider/releases/latest"
+    static let launchdLabel = "live.streamvc.macprovider"
     static let checksumPublicKeyPEM = """
     -----BEGIN PUBLIC KEY-----
     MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwwd0Vzj35OP8DlZU+0lUa8vI9gHK
@@ -55,8 +65,13 @@ struct SelfUpdate {
 
         let prepared = try await prepareValidatedUpdate(from: release)
         defer { prepared.cleanup() }
-        try await applyValidatedUpdate(newBinary: prepared.newBinary)
+        let restartError = try await applyValidatedUpdate(newBinary: prepared.newBinary)
         try await persistSignedPolicyIfPresent(prepared.signedPolicy)
+        if let restartError {
+            print("Binary upgraded to v\(latest), but automatic restart failed: \(restartError)")
+            print("Run: \(restartError.recoveryCommand)")
+            return
+        }
         print("Update complete. Restart macprovider-cli to use v\(latest).")
     }
 
@@ -64,7 +79,7 @@ struct SelfUpdate {
         let release = try await releaseByTag(tag)
         let prepared = try await prepareValidatedUpdate(from: release)
         defer { prepared.cleanup() }
-        try await applyValidatedUpdate(newBinary: prepared.newBinary)
+        _ = try await applyValidatedUpdate(newBinary: prepared.newBinary)
         try await persistSignedPolicyIfPresent(prepared.signedPolicy)
     }
 
@@ -122,7 +137,8 @@ struct SelfUpdate {
         }
     }
 
-    func applyValidatedUpdateForTest(newBinary: URL) async throws {
+    @discardableResult
+    func applyValidatedUpdateForTest(newBinary: URL) async throws -> LaunchdRestartFailure? {
         try await applyValidatedUpdate(newBinary: newBinary)
     }
 
@@ -253,43 +269,57 @@ struct SelfUpdate {
         }
     }
 
-    private func applyValidatedUpdate(newBinary: URL) async throws {
+    private func applyValidatedUpdate(newBinary: URL) async throws -> LaunchdRestartFailure? {
         if let drainBeforeReplace {
             try await drainBeforeReplace()
-        } else {
-            try drainLaunchdIfInstalled()
         }
         if let replaceBinary {
             try replaceBinary(newBinary)
         } else {
             try replaceCurrentBinary(with: newBinary)
         }
-        if let restartLaunchd {
-            try restartLaunchd()
-        } else {
-            try restartLaunchdIfInstalled()
+        do {
+            if let restartLaunchd {
+                try restartLaunchd()
+            } else {
+                try restartLaunchdIfInstalled()
+            }
+        } catch let failure as LaunchdRestartFailure {
+            return failure
+        } catch {
+            return LaunchdRestartFailure(error: error, recoveryCommand: restartRecoveryCommand())
         }
-    }
-
-    private func drainLaunchdIfInstalled() throws {
-        let plist = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
-        guard FileManager.default.fileExists(atPath: plist.path) else {
-            return
-        }
-        let domain = "gui/\(getuid())"
-        try runProcess("/bin/launchctl", arguments: ["bootout", domain, "live.streamvc.macprovider"], allowFailure: true)
+        return nil
     }
 
     private func restartLaunchdIfInstalled() throws {
         let plist = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
+            .appendingPathComponent("Library/LaunchAgents/\(Self.launchdLabel).plist")
         guard FileManager.default.fileExists(atPath: plist.path) else {
             return
         }
-        let domain = "gui/\(getuid())"
-        try runProcess("/bin/launchctl", arguments: ["bootout", domain, "live.streamvc.macprovider"], allowFailure: true)
-        try runProcess("/bin/launchctl", arguments: ["bootstrap", domain, plist.path])
+        let loaded = launchctlServiceLoaded(label: Self.launchdLabel)
+        do {
+            try runProcess(
+                "/bin/launchctl",
+                arguments: Self.launchdRestartArguments(serviceLoaded: loaded, plistPath: plist.path)
+            )
+        } catch {
+            throw LaunchdRestartFailure(
+                error: error,
+                recoveryCommand: Self.launchdRestartRecoveryCommand(serviceLoaded: loaded, plistPath: plist.path)
+            )
+        }
+    }
+
+    private func restartRecoveryCommand() -> String {
+        let plist = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents/\(Self.launchdLabel).plist")
+        guard FileManager.default.fileExists(atPath: plist.path) else {
+            return Self.launchdRestartRecoveryCommand()
+        }
+        let loaded = launchctlServiceLoaded(label: Self.launchdLabel)
+        return Self.launchdRestartRecoveryCommand(serviceLoaded: loaded, plistPath: plist.path)
     }
 
     private func runProcess(_ executable: String, arguments: [String], allowFailure: Bool = false) throws {
@@ -301,6 +331,44 @@ struct SelfUpdate {
         if !allowFailure, process.terminationStatus != 0 {
             throw UpdateError.processFailed(executable, process.terminationStatus)
         }
+    }
+
+    private func launchctlServiceLoaded(label: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = ["print", Self.launchdServiceTarget(label: label)]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return false
+        }
+        guard process.terminationStatus == 0 else { return false }
+        let output = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        return !output.lowercased().contains("disabled = true")
+    }
+
+    static func launchdRestartArguments(serviceLoaded: Bool, uid: uid_t = getuid(), plistPath: String) -> [String] {
+        let domain = "gui/\(uid)"
+        if serviceLoaded {
+            return ["kickstart", "-k", "\(domain)/\(launchdLabel)"]
+        }
+        return ["bootstrap", domain, plistPath]
+    }
+
+    static func launchdRestartRecoveryCommand(serviceLoaded: Bool = true, uid: uid_t = getuid(), plistPath: String? = nil) -> String {
+        if serviceLoaded {
+            return "launchctl kickstart -k \(launchdServiceTarget(uid: uid))"
+        }
+        let plist = plistPath ?? "~/Library/LaunchAgents/\(launchdLabel).plist"
+        return "launchctl bootstrap gui/\(uid) \(plist)"
+    }
+
+    private static func launchdServiceTarget(label: String = launchdLabel, uid: uid_t = getuid()) -> String {
+        "gui/\(uid)/\(label)"
     }
 
     private func validateDownloadURL(_ url: URL) throws {

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -385,6 +385,54 @@ final class AutoUpdateTests: XCTestCase {
         XCTAssertEqual(event?["reason"] as? String, "tier_demoted")
     }
 
+    func testRestartFailureRollbackRestoresBinaryAndClearsPendingState() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        let (marker, binary, backup) = try makePendingMarkerFixture(
+            store: store,
+            fixture: fixture,
+            backupContents: "old",
+            targetContents: "new"
+        )
+        let status = ProviderStatus(
+            modelID: "mlx-community/Test-Model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.6.0",
+            providerStatus: status,
+            markerStore: store,
+            trustProvider: {
+                AutoUpdateTrustState(
+                    v2Accepted: true,
+                    tier: "pinned",
+                    encryptedLegValid: true,
+                    attestationRequired: false,
+                    attestationSatisfied: true,
+                    tokenConfigured: true,
+                    tokenValidated: true,
+                    bearerlessDuplicate: false,
+                    connected: true
+                )
+            },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            currentBinaryURL: { binary },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        updater.rollbackCommittedSwapAfterRestartFailureForTest(marker)
+
+        XCTAssertEqual(try String(contentsOf: binary), "old")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.pendingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.lockURL.path))
+    }
+
     func testAutoupdateReasonRedactionUsesStableCodes() {
         let errors: [Error] = [
             UpdateError.invalidURL("https://example.com/update?token=secret"),

--- a/phase3-binary/Tests/macprovider-cliTests/SelfUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/SelfUpdateTests.swift
@@ -83,6 +83,66 @@ final class SelfUpdateTests: XCTestCase {
         ])
     }
 
+    func testRestartFailureAfterBinaryReplaceDoesNotFailValidatedUpdate() async throws {
+        let recorder = UpdateActionRecorder()
+        let binary = URL(fileURLWithPath: "/tmp/macprovider-cli-test")
+        let update = SelfUpdate(
+            currentVersion: "1.2.0",
+            releasesAPIURL: nil,
+            drainBeforeReplace: {
+                recorder.append("drain")
+            },
+            replaceBinary: { _ in
+                recorder.append("replace")
+            },
+            restartLaunchd: {
+                recorder.append("restart")
+                throw UpdateError.processFailed("/bin/launchctl", 5)
+            }
+        )
+
+        let restartError = try await update.applyValidatedUpdateForTest(newBinary: binary)
+
+        XCTAssertEqual(recorder.snapshot(), ["drain", "replace", "restart"])
+        XCTAssertEqual(restartError.map { String(describing: $0) }, "/bin/launchctl exited with status 5")
+    }
+
+    func testLaunchdRestartUsesKickstartForLoadedService() {
+        XCTAssertEqual(
+            SelfUpdate.launchdRestartArguments(
+                serviceLoaded: true,
+                uid: 501,
+                plistPath: "/Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist"
+            ),
+            ["kickstart", "-k", "gui/501/live.streamvc.macprovider"]
+        )
+    }
+
+    func testLaunchdRestartBootstrapsOnlyWhenServiceIsNotLoaded() {
+        let plist = "/Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist"
+
+        XCTAssertEqual(
+            SelfUpdate.launchdRestartArguments(serviceLoaded: false, uid: 501, plistPath: plist),
+            ["bootstrap", "gui/501", plist]
+        )
+    }
+
+    func testRestartFailureRecoveryCommandUsesKickstart() {
+        XCTAssertEqual(
+            SelfUpdate.launchdRestartRecoveryCommand(uid: 501),
+            "launchctl kickstart -k gui/501/live.streamvc.macprovider"
+        )
+    }
+
+    func testRestartFailureRecoveryCommandUsesBootstrapForUnloadedService() {
+        let plist = "/Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist"
+
+        XCTAssertEqual(
+            SelfUpdate.launchdRestartRecoveryCommand(serviceLoaded: false, uid: 501, plistPath: plist),
+            "launchctl bootstrap gui/501 \(plist)"
+        )
+    }
+
     func testUpdateRequiresSignedChecksumAsset() async throws {
         let releaseURL = URL(string: "https://api.github.com/repos/Augustas11/macprovider/releases/latest")!
         MockURLProtocol.responses = [


### PR DESCRIPTION
## Summary
- restart loaded provider LaunchAgents with `launchctl kickstart -k` instead of `bootout` + `bootstrap`
- keep manual `macprovider-cli update` successful when only the post-swap restart fails, with a matching recovery command
- roll back managed autoupdate swaps if launchd restart fails after the binary replacement

## Root Cause
`launchctl bootout` can intermittently return EIO for a busy live service, and the old flow then attempted `bootstrap` after an incomplete stop. That left the upgraded binary on disk while the old launchd-managed process continued running.

## Validation
- `swift test --filter SelfUpdateTests`
- `swift test --filter AutoUpdateTests`
- `git diff --check`
- 3-lane code/security/architecture audit converged to zero critical/high/medium findings

## Notes
- Not hardware-tested against a live installed LaunchAgent in this PR branch.
