### PR TITLE
feat(harness): send X-MacProvider-Conversation for sticky affinity

### DIFF
--- a/test/network-harness/internal/buyer/loadgen.go
+++ b/test/network-harness/internal/buyer/loadgen.go
@@ -178,6 +178,16 @@ func fireOnce(ctx context.Context, client *http.Client, sc *scenario.Scenario, p
 	req.Header.Set("X-Request-Id", hReqID)
 	res.RequestID = hReqID
 
+	// SPEC-004 Pillar A sticky affinity — per-buyer conversation tag.
+	// Gateway (with routing.sticky_enabled=true and key_hash_secret set)
+	// derives an HMAC internal key from (account_id, tag) and forwards
+	// it to coord as X-MacProvider-Internal-Conv. Coord routes by that
+	// key when its own routing.sticky_enabled is true. Empty template =
+	// header not emitted, sticky path stays inert.
+	if sc.Buyers.StickyConversationKey != "" {
+		req.Header.Set("X-MacProvider-Conversation", fmt.Sprintf(sc.Buyers.StickyConversationKey, buyerIdx))
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		res.EndUTC = time.Now().UTC()

--- a/test/network-harness/internal/buyer/sticky_header_test.go
+++ b/test/network-harness/internal/buyer/sticky_header_test.go
@@ -1,0 +1,154 @@
+package buyer
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-network-harness/internal/scenario"
+)
+
+// TestFireRequest_StickyHeader_EmittedWhenTemplateSet asserts that the
+// buyer client sets the X-MacProvider-Conversation header when the
+// scenario's Buyers.StickyConversationKey template is non-empty. The
+// template's %d verb resolves to the buyer index.
+func TestFireRequest_StickyHeader_EmittedWhenTemplateSet(t *testing.T) {
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-MacProvider-Conversation")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer srv.Close()
+
+	sc := &scenario.Scenario{
+		Target: scenario.Target{
+			GatewayURL: srv.URL,
+			BuyerToken: "test-token",
+		},
+		Buyers: scenario.Buyers{
+			Count:                 3,
+			Stream:                false,
+			StickyConversationKey: "harness-scenario-03-buyer-%d",
+		},
+		Prompts: []scenario.Prompt{
+			{Model: "test-model", User: "hi", MaxTokens: 4},
+		},
+		RequestTimeout:      5 * time.Second,
+		SilentHangThreshold: 30 * time.Second,
+	}
+
+	res := fireOnce(context.Background(), http.DefaultClient, sc, sc.Prompts[0], 7, 0)
+	if res.HTTPStatus != 200 {
+		t.Fatalf("expected 200 (mock ok), got %d — err=%q", res.HTTPStatus, res.ErrorMsg)
+	}
+	want := "harness-scenario-03-buyer-7"
+	if gotHeader != want {
+		t.Errorf("X-MacProvider-Conversation = %q, want %q", gotHeader, want)
+	}
+}
+
+// TestFireRequest_StickyHeader_OmittedWhenTemplateEmpty asserts that
+// the header is NOT sent when the sticky_conversation_key template is
+// empty (the default). This preserves the pre-sticky behavior for every
+// scenario that hasn't opted into sticky affinity.
+func TestFireRequest_StickyHeader_OmittedWhenTemplateEmpty(t *testing.T) {
+	var seenHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-MacProvider-Conversation") != "" {
+			seenHeader = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer srv.Close()
+
+	sc := &scenario.Scenario{
+		Target: scenario.Target{
+			GatewayURL: srv.URL,
+			BuyerToken: "test-token",
+		},
+		Buyers: scenario.Buyers{
+			Count:                 2,
+			Stream:                false,
+			StickyConversationKey: "", // explicit empty
+		},
+		Prompts: []scenario.Prompt{
+			{Model: "test-model", User: "hi", MaxTokens: 4},
+		},
+		RequestTimeout:      5 * time.Second,
+		SilentHangThreshold: 30 * time.Second,
+	}
+
+	res := fireOnce(context.Background(), http.DefaultClient, sc, sc.Prompts[0], 0, 0)
+	if res.HTTPStatus != 200 {
+		t.Fatalf("expected 200, got %d — err=%q", res.HTTPStatus, res.ErrorMsg)
+	}
+	if seenHeader {
+		t.Errorf("X-MacProvider-Conversation must be OMITTED when template is empty")
+	}
+}
+
+// TestFireRequest_StickyHeader_TemplateExpandsBuyerIndex asserts the %d
+// verb resolves to the buyer index passed to fireRequest, so per-buyer
+// tags are actually distinct across the fleet.
+func TestFireRequest_StickyHeader_TemplateExpandsBuyerIndex(t *testing.T) {
+	seen := map[int]string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if h := r.Header.Get("X-MacProvider-Conversation"); h != "" {
+			// crude: buyer index is the trailing integer
+			parts := strings.Split(h, "-")
+			if len(parts) > 0 {
+				seen[len(seen)] = parts[len(parts)-1]
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer srv.Close()
+
+	sc := &scenario.Scenario{
+		Target: scenario.Target{
+			GatewayURL: srv.URL,
+			BuyerToken: "test-token",
+		},
+		Buyers: scenario.Buyers{
+			Count:                 3,
+			Stream:                false,
+			StickyConversationKey: "buyer-%d",
+		},
+		Prompts: []scenario.Prompt{
+			{Model: "test-model", User: "hi", MaxTokens: 4},
+		},
+		RequestTimeout:      5 * time.Second,
+		SilentHangThreshold: 30 * time.Second,
+	}
+
+	for buyerIdx := 0; buyerIdx < 3; buyerIdx++ {
+		_ = fireOnce(context.Background(), http.DefaultClient, sc, sc.Prompts[0], buyerIdx, 0)
+	}
+	if len(seen) != 3 {
+		t.Fatalf("expected 3 headers seen, got %d — %v", len(seen), seen)
+	}
+	for i := 0; i < 3; i++ {
+		want := ""
+		switch i {
+		case 0:
+			want = "0"
+		case 1:
+			want = "1"
+		case 2:
+			want = "2"
+		}
+		if seen[i] != want {
+			t.Errorf("call %d saw buyer suffix %q, want %q", i, seen[i], want)
+		}
+	}
+}

--- a/test/network-harness/internal/scenario/schema.go
+++ b/test/network-harness/internal/scenario/schema.go
@@ -160,6 +160,28 @@ type Buyers struct {
 	// provider to drop in-flight state but short enough for 10 pairs to
 	// fit in ~15min wall-clock.
 	InterPairIdleSeconds int `yaml:"inter_pair_idle_seconds"`
+
+	// StickyConversationKey is a printf-style template with a single %d
+	// verb for the buyer index. When set, each buyer sends
+	//
+	//   X-MacProvider-Conversation: <expanded-template>
+	//
+	// on every request, activating SPEC-004 Pillar A sticky affinity —
+	// the gateway HMAC-derives the internal key and forwards to coord
+	// as X-MacProvider-Internal-Conv. Coord routes by that key when
+	// its routing.sticky_enabled flag is true. Requires both:
+	//
+	//   1. gateway routing.sticky_enabled: true + auth.key_hash_secret set
+	//   2. coordinator routing.sticky_enabled: true
+	//
+	// Empty string (default) leaves the header off — pre-existing
+	// scenarios behave exactly as before. Non-sticky scenarios should
+	// keep this empty so their B4/B5 numbers stay comparable to prior
+	// baselines.
+	//
+	// Example: "harness-buyer-%d" → buyer 0 sends
+	// "X-MacProvider-Conversation: harness-buyer-0" on every request.
+	StickyConversationKey string `yaml:"sticky_conversation_key"`
 }
 
 // Prompt is one item in the rotating prompt pool. Buyers pick by index

--- a/test/network-harness/scenarios/03_sticky_multi_turn.yaml
+++ b/test/network-harness/scenarios/03_sticky_multi_turn.yaml
@@ -1,34 +1,33 @@
-# 03_sticky_multi_turn.yaml — 3 buyers each fire 5 sequential prompts.
+# 03_sticky_multi_turn.yaml — 3 buyers each fire 5 sequential prompts,
+# each sending a per-buyer X-MacProvider-Conversation tag to exercise
+# SPEC-004 Pillar A sticky affinity.
 #
-# Live /v1/models reports `sticky_affinity.enabled: false` for tier1
-# disclosure. This scenario will confirm that finding empirically: with
-# sticky off, each buyer's 5 requests should scatter across providers
-# (when multiple providers serve the requested model).
+# Requires both sides ON:
+#   - gateway: routing.sticky_enabled=true + auth.key_hash_secret set
+#   - coordinator: routing.sticky_enabled=true
 #
-# What we want to learn (phase A, descriptive — recorded only):
-#  - Phase B will judge: do we WANT sticky for beta? If providers cache
-#    model context, sticky reduces TTFT. If not, sticky just trades
-#    fairness for stickiness with no benefit.
-#  - The fact that tier1 disclosure ALREADY says sticky_affinity.enabled=false
-#    is itself a finding — if we want sticky for beta, the disclosure
-#    and the routing default both need to flip.
+# What we assert descriptively (phase A, no verdict):
+#  - Each buyer's 5 requests should land on ONE provider consistently.
+#    Group per_request.jsonl by buyer_index and check that
+#    route_provider_id is single-valued per buyer (modulo drain/failover
+#    edge cases).
 #
 # What gets asserted (the 4 hard invariants): all 4 run.
 #
-# Cost estimate (15 requests x 32 max_tokens): order of cents.
+# Cost estimate (15 requests x 24 max_tokens): order of cents.
 name: sticky_multi_turn
 description: |
-  3 buyers, each sends 5 sequential non-streaming requests. Used to
-  detect whether sticky routing fires on multi-turn workloads (it
-  should NOT, per live disclosure).
+  3 buyers, each sends 5 sequential non-streaming requests with a per-
+  buyer X-MacProvider-Conversation tag. Confirms sticky affinity fires
+  when both gateway and coord have routing.sticky_enabled=true.
 
 expected_shape: |
   Phase A note (descriptive, not asserted):
    - 15 total requests (3 buyers x 5 each).
-   - With sticky OFF (current live state): each buyer's requests
-     scatter across providers serving the model.
-   - per_request.jsonl is the authoritative source — group by buyer_index
-     and look at route_provider_id distribution.
+   - With sticky ON on both sides: each buyer's 5 requests land on the
+     same provider (per_request.route_provider_id column, grouped by
+     buyer_index).
+   - With sticky OFF (or header unset): each buyer's requests scatter.
 
 target:
   gateway_url: https://api.streamvc.live
@@ -44,6 +43,9 @@ buyers:
   pattern: interval
   interval_ms: 1500
   requests_per_buyer: 5
+  # SPEC-004 Pillar A: per-buyer conversation tag. Gateway HMACs it with
+  # account_id to produce X-MacProvider-Internal-Conv for coord routing.
+  sticky_conversation_key: "harness-scenario-03-buyer-%d"
 
 duration: 300s
 request_timeout: 60s


### PR DESCRIPTION
## Summary

Closes the buyer-side wiring gap for SPEC-004 Pillar A sticky affinity.

Adds a per-buyer `sticky_conversation_key` template on
`scenario.Buyers`. When set, the harness buyer client emits
`X-MacProvider-Conversation` on every request; gateway HMAC-derives
`X-MacProvider-Internal-Conv` from `(account_id, tag)` under
`MACPROVIDER_KEY_HASH_SECRET` and forwards to coord. Coord routes by
that key when its own `routing.sticky_enabled` is true.

Empty template (default) leaves the header off — all pre-existing
scenarios behave exactly as before, so v0.4 baseline numbers remain
directly comparable.

## Background

Sticky affinity code landed in PR #263 (Pillars B/C/D/A) with
follow-on tranches #270/#273/#275. Default was `sticky_enabled: false`
on both sides. Live Pearl state as of this session:

- Gateway: `routing.sticky_enabled: true` (previously flipped) +
  `auth.key_hash_secret: env:MACPROVIDER_KEY_HASH_SECRET` set.
- Coordinator: `routing.sticky_enabled: true` (flipped this session
  before this PR was written).

But the sticky path was inert because the harness (and any buyer SDK
not sending the tag) never emitted the `X-MacProvider-Conversation`
header the gateway checks at `phase5-gateway/internal/router/chat_proxy.go:290`.
This PR is the client-side counterpart to those flag flips.

## Changes

- `test/network-harness/internal/scenario/schema.go` — new
  `Buyers.StickyConversationKey` (printf template with %d for buyer
  index). Documented empty-default preserves prior behavior.
- `test/network-harness/internal/buyer/loadgen.go` — emit
  `X-MacProvider-Conversation` when the template is non-empty.
- `test/network-harness/scenarios/03_sticky_multi_turn.yaml` —
  actually exercises sticky now (was previously observing default
  routing since the harness didn't send the tag). Template:
  `harness-scenario-03-buyer-%d`.

## Tests

`test/network-harness/internal/buyer/sticky_header_test.go` (3 subtests):

- `TestFireRequest_StickyHeader_EmittedWhenTemplateSet` — pins the
  expanded value against a mock server.
- `TestFireRequest_StickyHeader_OmittedWhenTemplateEmpty` —
  regression on default behavior (no header emitted).
- `TestFireRequest_StickyHeader_TemplateExpandsBuyerIndex` — pins the
  `%d` verb resolution across a 3-buyer fleet, proving per-buyer tags
  are actually distinct.

`go test -count=1 ./...` from `test/network-harness` green including
the full pre-existing regression.

## No 3-lane audit

Harness-only test-side change with narrow scope (208 lines including
tests). No money-path code, no gateway, no coord. Per repo audit
convention: 3-lane codex audits are reserved for money-path IMPL. LOW
findings on a client-side test change would ship in PR body anyway.

## Post-merge

- Rebuild harness from origin/main.
- Fire the v0.5 baseline rerun (smoke + 01 + 03 + 07 + 10) with
  scenario 03 exercising sticky end-to-end.
- Compare B4/B5 vs v0.4 (2026-07-01) baseline. Sticky should tighten
  routing decisions and reduce buyer-to-slot contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
