### PR TITLE
Implement SPEC-023 installer recommendations

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -19,6 +19,14 @@ public enum LogLevel: String, Sendable {
 public struct AppConfig: Equatable, Sendable {
     public var port: Int
     public var model: String?
+    public var modelArtifactPath: String?
+    public var modelArtifactSHA256: String?
+    public var modelCatalogKey: String?
+    public var modelCatalogModelID: String?
+    public var modelCatalogRevision: String?
+    public var modelCatalogSHA256: String?
+    public var modelCatalogVersion: String?
+    public var modelCatalogHash: String?
     public var coordinatorURL: String?
     public var providerID: String?
     public var endpointURL: String?
@@ -48,6 +56,7 @@ public struct AppConfig: Equatable, Sendable {
     public var swapDrainTimeoutSeconds: Int
     public var ctlSocketPath: String?
     public var switchStatePath: String?
+    public var donorMode: Bool
     // SPEC-001: provider authentication token (closes XSEC-1 from
     // audits/2026-06-10/REPO_AUDIT.md). When set, the binary sends
     // "Authorization: Bearer <token>" on the WS connect and the
@@ -65,6 +74,14 @@ public struct AppConfig: Equatable, Sendable {
         AppConfig(
             port: 8080,
             model: nil,
+            modelArtifactPath: nil,
+            modelArtifactSHA256: nil,
+            modelCatalogKey: nil,
+            modelCatalogModelID: nil,
+            modelCatalogRevision: nil,
+            modelCatalogSHA256: nil,
+            modelCatalogVersion: nil,
+            modelCatalogHash: nil,
             coordinatorURL: nil,
             providerID: nil,
             endpointURL: nil,
@@ -89,6 +106,7 @@ public struct AppConfig: Equatable, Sendable {
             swapDrainTimeoutSeconds: 30,
             ctlSocketPath: nil,
             switchStatePath: nil,
+            donorMode: false,
             providerToken: nil
         )
     }
@@ -236,6 +254,14 @@ public enum ConfigLoader {
         var config = base
         try assign(&config.port, from: dict, key: "port", expected: "integer")
         try assign(&config.model, from: dict, key: "model", expected: "string")
+        try assign(&config.modelArtifactPath, from: dict, key: "model_artifact_path", expected: "string")
+        try assign(&config.modelArtifactSHA256, from: dict, key: "model_artifact_sha256", expected: "string")
+        try assign(&config.modelCatalogKey, from: dict, key: "model_catalog_key", expected: "string")
+        try assign(&config.modelCatalogModelID, from: dict, key: "model_catalog_model_id", expected: "string")
+        try assign(&config.modelCatalogRevision, from: dict, key: "model_catalog_revision", expected: "string")
+        try assign(&config.modelCatalogSHA256, from: dict, key: "model_catalog_sha256", expected: "string")
+        try assign(&config.modelCatalogVersion, from: dict, key: "model_catalog_version", expected: "string")
+        try assign(&config.modelCatalogHash, from: dict, key: "model_catalog_hash", expected: "string")
         try assign(&config.coordinatorURL, from: dict, key: "coordinator_url", expected: "string")
         try assign(&config.providerID, from: dict, key: "provider_id", expected: "string")
         try assign(&config.endpointURL, from: dict, key: "endpoint_url", expected: "string")
@@ -260,6 +286,7 @@ public enum ConfigLoader {
         try assign(&config.swapDrainTimeoutSeconds, from: dict, key: "swap_drain_timeout_s", expected: "integer")
         try assign(&config.ctlSocketPath, from: dict, key: "ctl_socket_path", expected: "string")
         try assign(&config.switchStatePath, from: dict, key: "switch_state_path", expected: "string")
+        try assign(&config.donorMode, from: dict, key: "donor_mode", expected: "boolean")
         try assign(&config.providerToken, from: dict, key: "provider_token", expected: "string")
         return config
     }
@@ -271,6 +298,7 @@ public enum ConfigLoader {
         var config = base
         try assign(&config.port, from: environment, env: "MACPROVIDER_PORT", expected: "integer")
         try assign(&config.model, from: environment, env: "MACPROVIDER_MODEL", expected: "string")
+        try assign(&config.modelArtifactSHA256, from: environment, env: "MACPROVIDER_MODEL_ARTIFACT_SHA256", expected: "string")
         try assign(&config.coordinatorURL, from: environment, env: "MACPROVIDER_COORDINATOR_URL", expected: "string")
         try assign(&config.providerID, from: environment, env: "MACPROVIDER_PROVIDER_ID", expected: "string")
         try assign(&config.endpointURL, from: environment, env: "MACPROVIDER_ENDPOINT_URL", expected: "string")
@@ -294,6 +322,7 @@ public enum ConfigLoader {
         try assign(&config.swapDrainTimeoutSeconds, from: environment, env: "MACPROVIDER_SWAP_DRAIN_TIMEOUT_S", expected: "integer")
         try assign(&config.ctlSocketPath, from: environment, env: "MACPROVIDER_CTL_SOCKET_PATH", expected: "string")
         try assign(&config.switchStatePath, from: environment, env: "MACPROVIDER_SWITCH_STATE_PATH", expected: "string")
+        try assign(&config.donorMode, from: environment, env: "MACPROVIDER_DONOR_MODE", expected: "boolean")
         try assign(&config.providerToken, from: environment, env: "MACPROVIDER_PROVIDER_TOKEN", expected: "string")
         return config
     }

--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -4,6 +4,8 @@ import Foundation
 import MacProviderCore
 
 struct AutotuneCommand: AsyncParsableCommand {
+    static let spec023RecommendationProbeContext = 4_000
+
     static let configuration = CommandConfiguration(
         commandName: "autotune",
         abstract: "Find the biggest feasible model for this Mac and recommend serve knobs."
@@ -63,6 +65,21 @@ struct AutotuneCommand: AsyncParsableCommand {
     @Flag(name: .customLong("json"), help: "Emit recommendation as JSON.")
     var emitJSON = false
 
+    @Flag(help: "Recommend the best paid-yield model for this Mac from the signed/static market inputs.")
+    var recommend = false
+
+    @Flag(help: "With --recommend, check whether the stored recommendation is fresh without benchmarking.")
+    var freshnessCheck = false
+
+    @Flag(help: "Allow local donor-mode configuration for non-paid-yield rows.")
+    var donorMode = false
+
+    @Option(help: "Electricity price in USD/kWh for net capacity estimate.")
+    var electricityUSDPerKWH: Double?
+
+    @Option(help: "Assumed utilization in [0.0, 1.0] for net capacity estimate.")
+    var assumedUtilization = 1.0
+
     @Flag(help: "Write the final recommendation to config.yaml.")
     var apply = false
 
@@ -109,6 +126,15 @@ struct AutotuneCommand: AsyncParsableCommand {
     }
 
     func run(dependencies: AutotuneRunDependencies) async throws {
+        if recommend {
+            if freshnessCheck {
+                try await runRecommendationFreshnessCheck()
+                return
+            }
+            try await runAutotuneRecommend()
+            return
+        }
+
         let plan = try candidatePlan()
 
         if dryRun {
@@ -643,6 +669,15 @@ struct AutotuneCommand: AsyncParsableCommand {
         guard tpsTieEpsilon >= 0 else {
             throw ValidationError("--tps-tie-epsilon must be >= 0")
         }
+        if let electricityUSDPerKWH, electricityUSDPerKWH < 0 {
+            throw ValidationError("--electricity-usd-per-kwh must be >= 0")
+        }
+        if freshnessCheck && !recommend {
+            throw ValidationError("--freshness-check requires --recommend")
+        }
+        guard (0.0...1.0).contains(assumedUtilization) else {
+            throw ValidationError("--assumed-utilization must be in 0.0...1.0")
+        }
         guard maxDuration > 0 else {
             throw ValidationError("--max-duration must be > 0")
         }
@@ -658,6 +693,122 @@ struct AutotuneCommand: AsyncParsableCommand {
         _ = try Self.parseKvBitsAxis(kvBitsAxis)
         _ = try Self.parsePositiveIntAxis(maxBatchAxis, flag: "--max-batch-axis")
         _ = try Self.parseMaxContextAxis(maxContextAxis, targetContext: targetContext)
+    }
+
+    private func runAutotuneRecommend() async throws {
+        let staticInputs = AutotuneStaticInputs()
+        let demand = await staticInputs.loadDemandRank()
+        let catalog = await staticInputs.loadCandidateCatalog()
+        let rateCard = await staticInputs.loadRateCard()
+
+        let fingerprint = MachineFingerprinter().sample()
+        let resolvedConfig = try? ConfigLoader.load(cli: CLIOverrides(configPath: config))
+        let secret = try AutotuneHMACSecretStore(path: AutotuneHMACSecretStore.defaultPath).loadOrCreate()
+        let identity = HMACIdentity.derive(secret: secret, fingerprint: fingerprint, providerID: resolvedConfig?.providerID)
+        let hardware = AutotuneRecommendHardware(fingerprint: fingerprint, hmacIdentity: identity)
+        let catalogSHA = AutotuneStaticInputs.candidateCatalogSHA256(bytes: catalog.selectedBytes)
+        let now = Date()
+        var warnings = Set<AutotuneRecommendWarning>()
+        warnings.formUnion(demand.warnings)
+        warnings.formUnion(catalog.warnings)
+        warnings.formUnion(rateCard.warnings)
+
+        var request = AutotuneRecommendRequest(
+            hardware: hardware,
+            demandRank: demand.value,
+            candidateCatalog: catalog.value,
+            candidateCatalogSHA256: catalogSHA,
+            rateCard: rateCard.value,
+            benchmarks: [:],
+            warnings: warnings,
+            generatedAt: now,
+            electricityUSDPerKWH: electricityUSDPerKWH,
+            assumedUtilization: assumedUtilization,
+            availabilityHoursPerDay: 24,
+            donorMode: donorMode
+        )
+        request.benchmarks = try await AutotuneRecommendationBenchmarker().benchmarks(
+            request: request,
+            targetContext: Self.spec023RecommendationProbeContext,
+            gateTTFTMS: gateTTFTMS,
+            replicates: stage1Replicates,
+            port: port
+        )
+        let result = AutotuneRecommendEngine().recommend(request)
+        try RecommendationStateStore.write(result)
+        let paidSelected = result.recommendedModel.flatMap { recommendedModel in
+            result.selectedCandidate.flatMap { $0.model == recommendedModel ? $0 : nil }
+        }
+        if apply, result.recommendedModel != nil, paidSelected == nil, !donorMode {
+            throw ValidationError("selected paid recommendation was not available for config apply")
+        }
+        let donorSelected = donorMode ? result.donorFallbackCandidate : nil
+        if apply, donorMode, result.donorFallbackModel != nil, donorSelected == nil {
+            throw ValidationError("selected donor recommendation was not available for config apply")
+        }
+        if apply, let selected = paidSelected ?? donorSelected {
+            let applyingDonorFallback = paidSelected == nil && selected == donorSelected
+            guard let selectedBenchmark = request.benchmarks[selected.catalogKey] else {
+                throw ValidationError("selected recommendation lacks verified benchmark artifact")
+            }
+            guard let selectedRow = catalog.value.rows[selected.catalogKey] else {
+                throw ValidationError("selected recommendation lacks signed catalog row")
+            }
+            if applyingDonorFallback {
+                FileHandle.standardError.write(Data("DONOR MODE: no paid model clears $0.0050/hr on this Mac; \(selected.model) is for network support only.\n".utf8))
+            }
+            let rawPath = config ?? AppConfig.defaultConfigPath
+            let expanded = ConfigLoader.expandTilde(rawPath)
+            let core = RecommendationCore(
+                model: selected.model,
+                targetContext: Self.spec023RecommendationProbeContext,
+                knobs: WinningKnobs(kvBits: nil, maxBatch: 1, maxContext: Self.spec023RecommendationProbeContext),
+                tpsMedian: selected.tokensPerSecond,
+                ttftP95MS: 0,
+                replicates: 0,
+                modelArtifactPath: selectedBenchmark.modelArtifactPath,
+                modelArtifactSHA256: selectedBenchmark.artifactSHA256,
+                modelCatalogKey: selected.catalogKey,
+                modelCatalogModelID: selectedRow.modelID,
+                modelCatalogRevision: selectedRow.modelRevision,
+                modelCatalogSHA256: selectedRow.modelSHA256,
+                modelCatalogVersion: catalog.value.version,
+                modelCatalogHash: catalogSHA
+            )
+            let applied = try ConfigApplier(configPath: URL(fileURLWithPath: expanded)).apply(
+                recommendation: core,
+                now: now,
+                donorMode: applyingDonorFallback
+            )
+            if emitJSON {
+                FileHandle.standardError.write(Data("\(applied.summary)\n".utf8))
+            } else {
+                print(applied.summary)
+            }
+        }
+        if emitJSON {
+            print(result.jsonString())
+        } else {
+            print(result.humanTranscript())
+        }
+        for warning in result.warnings {
+            FileHandle.standardError.write(Data("\(warning.rawValue)\n".utf8))
+        }
+    }
+
+    private func runRecommendationFreshnessCheck() async throws {
+        let resolvedConfig = try? ConfigLoader.load(cli: CLIOverrides(configPath: config))
+        let status = await RecommendationFreshnessChecker(providerID: resolvedConfig?.providerID).status()
+        switch status {
+        case .fresh:
+            print("recommendation_fresh")
+        case .missing:
+            FileHandle.standardError.write(Data("recommendation_stale: missing stored recommendation\n".utf8))
+            throw ExitCode(10)
+        case .stale(let generatedAt):
+            FileHandle.standardError.write(Data("recommendation_stale: inputs changed since \(ISO8601DateFormatter.autotuneInternet.string(from: generatedAt))\n".utf8))
+            throw ExitCode(10)
+        }
     }
 
     /// Tolerant CSV split: trims each token and DROPS empty tokens.

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -1,0 +1,1701 @@
+import CryptoKit
+import Darwin
+import Foundation
+import MacProviderCore
+import Security
+
+enum AutotuneRecommendError: Error, Equatable, CustomStringConvertible {
+    case invalidStaticJSON(String)
+    case invalidRateCard(String)
+    case invalidArtifact(String)
+    case noHMACSecret
+
+    var description: String {
+        switch self {
+        case .invalidStaticJSON(let message):
+            return "invalid static JSON: \(message)"
+        case .invalidRateCard(let message):
+            return "invalid rate card: \(message)"
+        case .invalidArtifact(let message):
+            return "invalid model artifact: \(message)"
+        case .noHMACSecret:
+            return "HMAC secret unavailable"
+        }
+    }
+}
+
+enum AutotuneRecommendWarning: String, CaseIterable {
+    case candidateCatalogFallbackUsed = "candidate_catalog_fallback_used"
+    case candidateCatalogStale = "candidate_catalog_stale"
+    case demandRankFallbackUsed = "demand_rank_fallback_used"
+    case demandRankStale = "demand_rank_stale"
+    case electricityNotIncluded = "electricity_not_included"
+    case hardwareTierUnknown = "hardware_tier_unknown"
+    case rateCardFallbackUsed = "rate_card_fallback_used"
+    case recommendationBelowThreshold = "recommendation_below_threshold"
+    case noEligiblePaidModel = "no_eligible_paid_model"
+}
+
+enum BandwidthTier: String, Codable, CaseIterable, Comparable {
+    case c = "C"
+    case b = "B"
+    case a = "A"
+    case s = "S"
+    case unknown = "unknown"
+
+    private var order: Int {
+        switch self {
+        case .unknown, .c: return 0
+        case .b: return 1
+        case .a: return 2
+        case .s: return 3
+        }
+    }
+
+    static func < (lhs: BandwidthTier, rhs: BandwidthTier) -> Bool {
+        lhs.order < rhs.order
+    }
+
+    func satisfies(minimum: BandwidthTier) -> Bool {
+        self.order >= minimum.order
+    }
+
+    static func derive(chip: String) -> BandwidthTier {
+        let normalized = chip.lowercased()
+        if normalized.contains("ultra") {
+            if let generation = appleSiliconGeneration(normalized) {
+                return generation >= 3 ? .s : .a
+            }
+            if normalized.contains("m3") || normalized.contains("m4") {
+                return .s
+            }
+            if normalized.contains("m1") || normalized.contains("m2") {
+                return .a
+            }
+            return .s
+        }
+        if normalized.contains("max") {
+            if let generation = appleSiliconGeneration(normalized) {
+                return generation >= 3 ? .a : .b
+            }
+            return .a
+        }
+        if normalized.contains("pro") {
+            return .b
+        }
+        return .c
+    }
+
+    private static func appleSiliconGeneration(_ normalizedChip: String) -> Int? {
+        guard let match = normalizedChip.range(of: #"m[0-9]+"#, options: .regularExpression) else {
+            return nil
+        }
+        return Int(normalizedChip[match].dropFirst())
+    }
+}
+
+struct AutotuneRecommendHardware: Equatable {
+    var machine: String?
+    var chip: String
+    var memoryGB: Int
+    var bandwidthTier: BandwidthTier
+    var detected: Bool
+    var osVersion: String
+    var binaryVersion: String
+    var diversificationID: String
+    var hardwareIdentityHash: String
+
+    init(machine: String? = nil, fingerprint: MachineFingerprint, hmacIdentity: HMACIdentity) {
+        self.machine = machine
+        self.chip = fingerprint.chip
+        self.memoryGB = max(1, fingerprint.ramGB)
+        self.bandwidthTier = BandwidthTier.derive(chip: fingerprint.chip)
+        self.detected = true
+        self.osVersion = fingerprint.osVersion
+        self.binaryVersion = fingerprint.binaryVersion
+        self.diversificationID = hmacIdentity.diversificationID
+        self.hardwareIdentityHash = hmacIdentity.cacheIdentityHash
+    }
+
+    init(
+        machine: String?,
+        chip: String,
+        memoryGB: Int,
+        bandwidthTier: BandwidthTier,
+        detected: Bool = true,
+        osVersion: String,
+        binaryVersion: String,
+        diversificationID: String,
+        hardwareIdentityHash: String
+    ) {
+        self.machine = machine
+        self.chip = chip
+        self.memoryGB = max(1, memoryGB)
+        self.bandwidthTier = bandwidthTier
+        self.detected = detected
+        self.osVersion = osVersion
+        self.binaryVersion = binaryVersion
+        self.diversificationID = diversificationID
+        self.hardwareIdentityHash = hardwareIdentityHash
+    }
+}
+
+struct HMACIdentity: Equatable {
+    static let diversificationDomain = "macprovider-autotune-diversification-v1"
+    static let cacheIdentityDomain = "macprovider-autotune-cache-identity-v1"
+
+    var diversificationID: String
+    var cacheIdentityHash: String
+
+    static func derive(secret: Data, fingerprint: MachineFingerprint, providerID: String? = nil) -> HMACIdentity {
+        let trimmedProviderID = providerID?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stableIdentity = trimmedProviderID?.isEmpty == false
+            ? "provider:\(trimmedProviderID!)"
+            : "local:\(sha256Hex(secret))"
+        let material = "\(stableIdentity)|\(fingerprint.ramGB)|\(fingerprint.chip)"
+        return HMACIdentity(
+            diversificationID: hmacHex(secret: secret, domain: diversificationDomain, material: material),
+            cacheIdentityHash: hmacHex(secret: secret, domain: cacheIdentityDomain, material: material)
+        )
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func hmacHex(secret: Data, domain: String, material: String) -> String {
+        let key = SymmetricKey(data: secret)
+        let bytes = Data("\(domain)\n\(material)".utf8)
+        let mac = HMAC<SHA256>.authenticationCode(for: bytes, using: key)
+        return Data(mac).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+struct AutotuneHMACSecretStore {
+    var path: URL
+    var randomBytes: (Int) throws -> Data = Self.secureRandomBytes
+
+    func loadOrCreate() throws -> Data {
+        if usesDefaultPath {
+            if let keychainSecret = try? Self.loadKeychainSecret(), keychainSecret.count == 32 {
+                return keychainSecret
+            }
+        }
+        if FileManager.default.fileExists(atPath: path.path) {
+            do {
+                return try loadExistingFileSecret()
+            } catch {
+                return try rotateRecoverableFileSecret()
+            }
+        }
+        if usesDefaultPath,
+           let created = try? Self.createKeychainSecret(randomBytes: randomBytes),
+           created.count == 32 {
+            return created
+        }
+        return try createFileSecret()
+    }
+
+    private func createFileSecret() throws -> Data {
+        let secret = try randomBytes(32)
+        guard secret.count == 32 else { throw AutotuneRecommendError.noHMACSecret }
+        try ensurePrivateParentDirectory()
+        if try writeNewFileSecret(secret) {
+            return secret
+        }
+        if errno == EEXIST {
+            return try loadExistingFileSecret()
+        }
+        throw AutotuneRecommendError.noHMACSecret
+    }
+
+    static var defaultPath: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/macprovider/autotune-hmac-secret", isDirectory: false)
+    }
+
+    private var usesDefaultPath: Bool {
+        path.standardizedFileURL.path == Self.defaultPath.standardizedFileURL.path
+    }
+
+    private func ensurePrivateParentDirectory() throws {
+        let parent = path.deletingLastPathComponent()
+        var st = stat()
+        if lstat(parent.path, &st) == 0 {
+            guard (st.st_mode & S_IFMT) == S_IFDIR,
+                  st.st_uid == getuid()
+            else {
+                throw AutotuneRecommendError.noHMACSecret
+            }
+            return
+        }
+        var current = URL(fileURLWithPath: "/", isDirectory: true)
+        for component in parent.pathComponents.dropFirst() {
+            current.appendPathComponent(component, isDirectory: true)
+            if lstat(current.path, &st) == 0 {
+                guard (st.st_mode & S_IFMT) == S_IFDIR else {
+                    throw AutotuneRecommendError.noHMACSecret
+                }
+                continue
+            }
+            guard mkdir(current.path, 0o700) == 0 || errno == EEXIST else {
+                throw AutotuneRecommendError.noHMACSecret
+            }
+        }
+        guard lstat(parent.path, &st) == 0,
+              (st.st_mode & S_IFMT) == S_IFDIR,
+              st.st_uid == getuid()
+        else {
+            throw AutotuneRecommendError.noHMACSecret
+        }
+    }
+
+    private func loadExistingFileSecret() throws -> Data {
+        var st = stat()
+        guard lstat(path.path, &st) == 0,
+              (st.st_mode & S_IFMT) == S_IFREG,
+              st.st_uid == getuid(),
+              (st.st_mode & 0o777) == 0o600
+        else {
+            throw AutotuneRecommendError.noHMACSecret
+        }
+        let data = try Data(contentsOf: path, options: [.mappedIfSafe])
+        guard data.count == 32 else { throw AutotuneRecommendError.noHMACSecret }
+        return data
+    }
+
+    private func rotateRecoverableFileSecret() throws -> Data {
+        var st = stat()
+        guard lstat(path.path, &st) == 0,
+              (st.st_mode & S_IFMT) == S_IFREG,
+              st.st_uid == getuid()
+        else {
+            throw AutotuneRecommendError.noHMACSecret
+        }
+        try ensurePrivateParentDirectory()
+        let quarantine = path.deletingLastPathComponent()
+            .appendingPathComponent("\(path.lastPathComponent).invalid-\(UUID().uuidString)")
+        guard rename(path.path, quarantine.path) == 0 else {
+            throw AutotuneRecommendError.noHMACSecret
+        }
+        do {
+            return try createFileSecret()
+        } catch {
+            _ = rename(quarantine.path, path.path)
+            throw error
+        }
+    }
+
+    private func writeNewFileSecret(_ secret: Data) throws -> Bool {
+        let fd = path.path.withCString { open($0, O_CREAT | O_EXCL | O_WRONLY, 0o600) }
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+        try secret.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            var written = 0
+            while written < secret.count {
+                let n = write(fd, base.advanced(by: written), secret.count - written)
+                if n < 0 {
+                    if errno == EINTR { continue }
+                    throw AutotuneRecommendError.noHMACSecret
+                }
+                written += n
+            }
+        }
+        return true
+    }
+
+    private static func loadKeychainSecret() throws -> Data {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data, data.count == 32 else {
+            throw AutotuneRecommendError.noHMACSecret
+        }
+        return data
+    }
+
+    private static func createKeychainSecret(randomBytes: (Int) throws -> Data) throws -> Data {
+        let secret = try randomBytes(32)
+        guard secret.count == 32 else { throw AutotuneRecommendError.noHMACSecret }
+        let attributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecValueData as String: secret,
+        ]
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        if status == errSecDuplicateItem {
+            return try loadKeychainSecret()
+        }
+        guard status == errSecSuccess else { throw AutotuneRecommendError.noHMACSecret }
+        return secret
+    }
+
+    private static let keychainService = "live.streamvc.macprovider.autotune"
+    private static let keychainAccount = "hmac-secret-v1"
+
+    private static func secureRandomBytes(count: Int) throws -> Data {
+        var data = Data(count: count)
+        let rc = data.withUnsafeMutableBytes { raw in
+            SecRandomCopyBytes(kSecRandomDefault, count, raw.baseAddress!)
+        }
+        guard rc == errSecSuccess else { throw AutotuneRecommendError.noHMACSecret }
+        return data
+    }
+}
+
+struct DemandRank: Decodable, Equatable {
+    struct Row: Decodable, Equatable {
+        var demandWeight: Double
+        var rank: Int?
+        var recommendable: Bool
+        var minProviderTarget: Int
+
+        enum CodingKeys: String, CodingKey {
+            case demandWeight = "demand_weight"
+            case rank
+            case recommendable
+            case minProviderTarget = "min_provider_target"
+        }
+    }
+
+    var version: String
+    var generatedAt: Date
+    var source: String
+    var coldStartFloor: Double
+    var diversificationBand: Double
+    var rows: [String: Row]
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case generatedAt = "generated_at"
+        case source
+        case coldStartFloor = "cold_start_floor"
+        case diversificationBand = "diversification_band"
+        case rows
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decode(String.self, forKey: .version)
+        source = try c.decode(String.self, forKey: .source)
+        coldStartFloor = try c.decode(Double.self, forKey: .coldStartFloor)
+        diversificationBand = try c.decode(Double.self, forKey: .diversificationBand)
+        rows = try c.decode([String: Row].self, forKey: .rows)
+        let rawDate = try c.decode(String.self, forKey: .generatedAt)
+        guard let date = ISO8601DateFormatter.autotuneInternet.date(from: rawDate) else {
+            throw DecodingError.dataCorruptedError(forKey: .generatedAt, in: c, debugDescription: "generated_at must be RFC3339")
+        }
+        generatedAt = date
+    }
+
+    func validated() throws -> DemandRank {
+        guard source == "openrouter_completion_token_rank_operator_curated" else {
+            throw AutotuneRecommendError.invalidStaticJSON("demand-rank source")
+        }
+        guard coldStartFloor == 0.15, diversificationBand == 0.85 else {
+            throw AutotuneRecommendError.invalidStaticJSON("demand-rank constants")
+        }
+        for (key, row) in rows {
+            guard row.demandWeight.isFinite, (0.0...1.0).contains(row.demandWeight) else {
+                throw AutotuneRecommendError.invalidStaticJSON("demand weight for \(key)")
+            }
+            if let rank = row.rank, rank <= 0 {
+                throw AutotuneRecommendError.invalidStaticJSON("rank for \(key)")
+            }
+            guard row.minProviderTarget >= 0 else {
+                throw AutotuneRecommendError.invalidStaticJSON("min_provider_target for \(key)")
+            }
+        }
+        return self
+    }
+}
+
+struct CandidateCatalog: Decodable, Equatable {
+    struct BenchGate: Decodable, Equatable {
+        var minSustainedTPS: Double
+        var max4KTTFTMS: Int
+
+        enum CodingKeys: String, CodingKey {
+            case minSustainedTPS = "min_sustained_tps"
+            case max4KTTFTMS = "max_4k_ttft_ms"
+        }
+    }
+
+    struct Row: Decodable, Equatable {
+        var modelID: String
+        var modelRevision: String?
+        var modelSHA256: String?
+        var minRAMGB: Int
+        var minBandwidthTier: BandwidthTier
+        var benchGate: BenchGate
+        var runtimeStatus: String
+        var notes: String?
+
+        enum CodingKeys: String, CodingKey {
+            case modelID = "model_id"
+            case modelRevision = "model_revision"
+            case modelSHA256 = "model_sha256"
+            case minRAMGB = "min_ram_gb"
+            case minBandwidthTier = "min_bandwidth_tier"
+            case benchGate = "bench_gate"
+            case runtimeStatus = "runtime_status"
+            case notes
+        }
+    }
+
+    var version: String
+    var generatedAt: Date
+    var source: String
+    var rows: [String: Row]
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case generatedAt = "generated_at"
+        case source
+        case rows
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decode(String.self, forKey: .version)
+        source = try c.decode(String.self, forKey: .source)
+        rows = try c.decode([String: Row].self, forKey: .rows)
+        let rawDate = try c.decode(String.self, forKey: .generatedAt)
+        guard let date = ISO8601DateFormatter.autotuneInternet.date(from: rawDate) else {
+            throw DecodingError.dataCorruptedError(forKey: .generatedAt, in: c, debugDescription: "generated_at must be RFC3339")
+        }
+        generatedAt = date
+    }
+
+    func validated() throws -> CandidateCatalog {
+        guard source == "operator_curated_autotune_candidate_catalog" else {
+            throw AutotuneRecommendError.invalidStaticJSON("candidate catalog source")
+        }
+        let allowedStatuses = Set(["candidate", "listed", "recommendable", "blocked"])
+        for (key, row) in rows {
+            guard allowedStatuses.contains(row.runtimeStatus) else {
+                throw AutotuneRecommendError.invalidStaticJSON("runtime_status for \(key)")
+            }
+            guard row.minRAMGB >= 0,
+                  row.benchGate.minSustainedTPS >= 0,
+                  row.benchGate.minSustainedTPS.isFinite,
+                  row.benchGate.max4KTTFTMS >= 0
+            else {
+                throw AutotuneRecommendError.invalidStaticJSON("negative gate for \(key)")
+            }
+            if row.runtimeStatus != "blocked" {
+                guard let revision = row.modelRevision, Self.isHex(revision, count: 40) else {
+                    throw AutotuneRecommendError.invalidStaticJSON("model_revision for \(key)")
+                }
+                guard let sha = row.modelSHA256, Self.isHex(sha, count: 64) else {
+                    throw AutotuneRecommendError.invalidStaticJSON("model_sha256 for \(key)")
+                }
+            }
+        }
+        return self
+    }
+
+    private static func isHex(_ value: String, count: Int) -> Bool {
+        value.count == count && value.allSatisfy { ("0"..."9").contains($0) || ("a"..."f").contains($0) }
+    }
+}
+
+struct RateCardProjection: Decodable, Equatable {
+    struct Row: Decodable, Equatable {
+        var promptRatePerMtok: Int64
+        var completionRatePerMtok: Int64
+        var providerShareBPS: Int64
+        var globalMultiplierPPM: Int64
+
+        enum CodingKeys: String, CodingKey {
+            case promptRatePerMtok = "prompt_rate_per_mtok"
+            case completionRatePerMtok = "completion_rate_per_mtok"
+            case providerShareBPS = "provider_share_bps"
+            case globalMultiplierPPM = "global_multiplier_ppm"
+        }
+    }
+
+    var version: String
+    var generatedAt: Date
+    var usdPerMillionCredits: Double
+    var rows: [String: Row]
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case generatedAt = "generated_at"
+        case usdPerMillionCredits = "usd_per_million_credits"
+        case rows
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decode(String.self, forKey: .version)
+        usdPerMillionCredits = try c.decode(Double.self, forKey: .usdPerMillionCredits)
+        rows = try c.decode([String: Row].self, forKey: .rows)
+        let rawDate = try c.decode(String.self, forKey: .generatedAt)
+        guard let date = ISO8601DateFormatter.autotuneInternet.date(from: rawDate) else {
+            throw DecodingError.dataCorruptedError(forKey: .generatedAt, in: c, debugDescription: "generated_at must be RFC3339")
+        }
+        generatedAt = date
+    }
+
+    func validated() throws -> RateCardProjection {
+        guard !version.isEmpty, usdPerMillionCredits.isFinite, usdPerMillionCredits >= 0 else {
+            throw AutotuneRecommendError.invalidRateCard("version/usd_per_million_credits")
+        }
+        for (key, row) in rows {
+            guard row.promptRatePerMtok >= 0,
+                  row.completionRatePerMtok >= 0,
+                  row.providerShareBPS >= 0,
+                  row.globalMultiplierPPM >= 0
+            else {
+                throw AutotuneRecommendError.invalidRateCard("negative value for \(key)")
+            }
+        }
+        return self
+    }
+
+    func rowForRecommendation(modelKey: String) -> (key: String, row: Row)? {
+        if let row = rows[modelKey] {
+            return (modelKey, row)
+        }
+        let normalized = AutotuneModelKeyNormalizer.normalize(modelKey)
+        if normalized == "default", modelKey != "default" {
+            return nil
+        }
+        if normalized != modelKey, let row = rows[normalized] {
+            return (normalized, row)
+        }
+        if modelKey == "default", let row = rows["default"] {
+            return ("default", row)
+        }
+        return nil
+    }
+}
+
+enum AutotuneModelKeyNormalizer {
+    static func normalize(_ model: String) -> String {
+        var key = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var namespace = ""
+        if let slash = key.firstIndex(of: "/") {
+            namespace = String(key[..<slash])
+            if knownNamespace(namespace) {
+                key = String(key[key.index(after: slash)...])
+            }
+        }
+        for suffix in ["-mxfp4-q8", "-4bit", "-8bit"] where key.hasSuffix(suffix) {
+            key.removeLast(suffix.count)
+        }
+        if namespace == "meta-llama", key.hasPrefix("llama-") {
+            return "meta-llama/\(key)"
+        }
+        if key.hasPrefix("meta-llama-") {
+            return "meta-llama/\(key.dropFirst("meta-".count))"
+        }
+        if key.hasPrefix("gpt-oss-") {
+            return "openai/\(key)"
+        }
+        return key
+    }
+
+    private static func knownNamespace(_ namespace: String) -> Bool {
+        ["mlx-community", "openai", "google", "meta-llama", "nvidia", "qwen"].contains(namespace)
+    }
+}
+
+struct AutotuneStaticSelection<T> {
+    var value: T
+    var selectedBytes: Data
+    var warnings: Set<AutotuneRecommendWarning>
+    var usedFallback: Bool
+}
+
+struct AutotuneStaticInputs {
+    static let keyID = "streamvc-autotune-static-v1"
+    static let publicKeyName = "autotune_static_json_ed25519_v1"
+    static let autotune_static_json_ed25519_v1 = "f4krxryNFog9nFhTOcssHasyWwGb8aqvBED+YcWFguM="
+    static let publicKeyBase64 = autotune_static_json_ed25519_v1
+
+    var fetch: (URL) async throws -> Data
+    var verifySignature: (Data, Data) -> Bool
+    var now: () -> Date
+
+    init(
+        fetch: @escaping (URL) async throws -> Data = { url in
+            let (data, response) = try await URLSession.shared.data(from: url)
+            if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
+                throw AutotuneRecommendError.invalidStaticJSON("HTTP \(http.statusCode)")
+            }
+            return data
+        },
+        verifySignature: @escaping (Data, Data) -> Bool = Self.defaultSignatureVerifier,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.fetch = fetch
+        self.verifySignature = verifySignature
+        self.now = now
+    }
+
+    func loadDemandRank() async -> AutotuneStaticSelection<DemandRank> {
+        await loadSignedStatic(
+            name: "demand-rank",
+            bakedBytes: Data(Self.bakedDemandRankJSON.utf8),
+            fallbackWarning: .demandRankFallbackUsed,
+            staleWarning: .demandRankStale
+        ) { try Self.decodeDemandRank($0) }
+    }
+
+    func loadCandidateCatalog() async -> AutotuneStaticSelection<CandidateCatalog> {
+        await loadSignedStatic(
+            name: "autotune-candidates",
+            bakedBytes: Data(Self.bakedCandidateCatalogJSON.utf8),
+            fallbackWarning: .candidateCatalogFallbackUsed,
+            staleWarning: .candidateCatalogStale
+        ) { try Self.decodeCandidateCatalog($0) }
+    }
+
+    func loadRateCard() async -> AutotuneStaticSelection<RateCardProjection> {
+        let baked = Data(Self.bakedRateCardJSON.utf8)
+        let bakedValue = (try? Self.decodeRateCard(baked))!
+        do {
+            let bytes = try await fetch(URL(string: "https://coordinator.streamvc.live/v1/rate-card")!)
+            let value = try Self.decodeRateCard(bytes)
+            return AutotuneStaticSelection(value: value, selectedBytes: bytes, warnings: [], usedFallback: false)
+        } catch {
+            return AutotuneStaticSelection(value: bakedValue, selectedBytes: baked, warnings: [.rateCardFallbackUsed], usedFallback: true)
+        }
+    }
+
+    private func loadSignedStatic<T>(
+        name: String,
+        bakedBytes: Data,
+        fallbackWarning: AutotuneRecommendWarning,
+        staleWarning: AutotuneRecommendWarning,
+        decode: (Data) throws -> T
+    ) async -> AutotuneStaticSelection<T> {
+        let bakedValue = (try? decode(bakedBytes))!
+        let bakedGeneratedAt = generatedAt(in: bakedBytes) ?? .distantFuture
+        do {
+            let jsonURL = URL(string: "https://get.streamvc.live/\(name).json")!
+            let sigURL = URL(string: "https://get.streamvc.live/\(name).json.sig")!
+            let jsonBytes = try await fetch(jsonURL)
+            let sigBytes = try await fetch(sigURL)
+            guard sidecarIsValid(sigBytes), verifySignature(jsonBytes, sigBytes) else {
+                throw AutotuneRecommendError.invalidStaticJSON("signature \(name)")
+            }
+            let value = try decode(jsonBytes)
+            guard let fetchedGeneratedAt = generatedAt(in: jsonBytes) else {
+                throw AutotuneRecommendError.invalidStaticJSON("generated_at \(name)")
+            }
+            let current = now()
+            guard fetchedGeneratedAt >= bakedGeneratedAt,
+                  fetchedGeneratedAt <= current.addingTimeInterval(10 * 60),
+                  current.timeIntervalSince(fetchedGeneratedAt) <= 30 * 24 * 3600
+            else {
+                throw AutotuneRecommendError.invalidStaticJSON("freshness \(name)")
+            }
+            var warnings = Set<AutotuneRecommendWarning>()
+            if current.timeIntervalSince(fetchedGeneratedAt) >= 14 * 24 * 3600 {
+                warnings.insert(staleWarning)
+            }
+            return AutotuneStaticSelection(value: value, selectedBytes: jsonBytes, warnings: warnings, usedFallback: false)
+        } catch {
+            return AutotuneStaticSelection(value: bakedValue, selectedBytes: bakedBytes, warnings: [fallbackWarning], usedFallback: true)
+        }
+    }
+
+    private func sidecarIsValid(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              Set(object.keys) == Set(["key_id", "alg", "signature"]),
+              object["key_id"] as? String == Self.keyID,
+              object["alg"] as? String == "ed25519",
+              let signature = object["signature"] as? String,
+              Data(base64Encoded: signature) != nil
+        else {
+            return false
+        }
+        return true
+    }
+
+    static func defaultSignatureVerifier(jsonBytes: Data, sidecarBytes: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: sidecarBytes) as? [String: Any],
+              let signature = object["signature"] as? String,
+              let signatureBytes = Data(base64Encoded: signature),
+              let publicKeyBytes = Data(base64Encoded: publicKeyBase64),
+              let publicKey = try? Curve25519.Signing.PublicKey(rawRepresentation: publicKeyBytes)
+        else {
+            return false
+        }
+        return publicKey.isValidSignature(signatureBytes, for: jsonBytes)
+    }
+
+    static func decodeDemandRank(_ data: Data) throws -> DemandRank {
+        try JSONDecoder.autotune.decode(DemandRank.self, from: data).validated()
+    }
+
+    static func decodeCandidateCatalog(_ data: Data) throws -> CandidateCatalog {
+        try JSONDecoder.autotune.decode(CandidateCatalog.self, from: data).validated()
+    }
+
+    static func decodeRateCard(_ data: Data) throws -> RateCardProjection {
+        try JSONDecoder.autotune.decode(RateCardProjection.self, from: data).validated()
+    }
+
+    static func candidateCatalogSHA256(bytes: Data) -> String {
+        Data(SHA256.hash(data: bytes)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func generatedAt(in data: Data) -> Date? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let raw = object["generated_at"] as? String
+        else {
+            return nil
+        }
+        return ISO8601DateFormatter.autotuneInternet.date(from: raw)
+    }
+}
+
+struct CandidateBenchmark: Equatable {
+    var modelKey: String
+    var sustainedTPS: Double
+    var ttftMS: Int
+    var swapDetected: Bool
+    var thermalThrottleDetected: Bool
+    var artifactSHA256: String
+    var modelArtifactPath: String
+    var benchmarkID: String?
+    var generatedAt: Date
+    var candidateCatalogSHA256: String
+    var binaryVersion: String
+    var modelID: String
+    var hardwareIdentityHash: String
+}
+
+struct AutotuneRecommendRequest {
+    var hardware: AutotuneRecommendHardware
+    var demandRank: DemandRank
+    var candidateCatalog: CandidateCatalog
+    var candidateCatalogSHA256: String
+    var rateCard: RateCardProjection
+    var benchmarks: [String: CandidateBenchmark]
+    var warnings: Set<AutotuneRecommendWarning>
+    var generatedAt: Date
+    var electricityUSDPerKWH: Double?
+    var assumedUtilization: Double
+    var availabilityHoursPerDay: Int
+    var donorMode: Bool
+}
+
+struct AutotuneCandidateScore: Equatable {
+    var rank: Int
+    var catalogKey: String
+    var model: String
+    var eligible: Bool
+    var expectedGrossUSDPerHour: Double
+    var expectedNetUSDPerHour: Double
+    var electricityUSDPerHour: Double?
+    var platformFeeUSDPerHour: Double
+    var tokensPerSecond: Double
+    var memoryHeadroomGB: Double
+    var confidence: String
+    var why: String
+    var rawScore: Double
+}
+
+struct AutotuneRecommendResult: Equatable {
+    var generatedAt: Date
+    var hardware: AutotuneRecommendHardware
+    var rateCardVersion: String
+    var demandRankVersion: String
+    var candidateCatalogVersion: String
+    var candidateCatalogSHA256: String
+    var benchmarkID: String?
+    var benchmarkGeneratedAt: Date?
+    var recommendedModel: String?
+    var selectedCandidate: AutotuneCandidateScore?
+    var candidates: [AutotuneCandidateScore]
+    var defaultModel: String?
+    var donorFallbackModel: String?
+    var donorFallbackCandidate: AutotuneCandidateScore?
+    var donorFallbackNetUSDPerHour: Double?
+    var recommendedDeltaUSDPerHour: Double
+    var recommendedDeltaPercent: Double
+    var warnings: [AutotuneRecommendWarning]
+    var assumedUtilization: Double
+    var availabilityHoursPerDay: Int
+    var electricityUSDPerKWH: Double?
+}
+
+struct AutotuneRecommendEngine {
+    static let paidThreshold = 0.0050
+    static let safetyMarginGB = 4
+    static let maxBenchmarkAge: TimeInterval = 7 * 24 * 3600
+
+    func recommend(_ request: AutotuneRecommendRequest) -> AutotuneRecommendResult {
+        var warnings = request.warnings
+        if request.electricityUSDPerKWH == nil {
+            warnings.insert(.electricityNotIncluded)
+        }
+        if request.hardware.bandwidthTier == .unknown {
+            warnings.insert(.hardwareTierUnknown)
+        }
+
+        let scored = request.candidateCatalog.rows.keys.sorted().compactMap { modelKey -> AutotuneCandidateScore? in
+            guard let candidate = request.candidateCatalog.rows[modelKey],
+                  let demand = request.demandRank.rows[modelKey]
+            else {
+                return nil
+            }
+            let rateMatch = request.rateCard.rowForRecommendation(modelKey: modelKey)
+            let benchmark = request.benchmarks[modelKey]
+            let eligible = isEligible(
+                modelKey: modelKey,
+                candidate: candidate,
+                demand: demand,
+                rateCardRow: rateMatch?.row,
+                benchmark: benchmark,
+                request: request
+            )
+            let tps = benchmark?.sustainedTPS ?? 0
+            let rateRow = rateMatch?.row
+            let usdPerMillionCompletion = Double(rateRow?.completionRatePerMtok ?? 0)
+                * (Double(rateRow?.globalMultiplierPPM ?? 0) / 1_000_000.0)
+                * (request.rateCard.usdPerMillionCredits / 1_000_000.0)
+            let gross = tps * 3600.0 * usdPerMillionCompletion / 1_000_000.0
+            let providerShare = Double(rateRow?.providerShareBPS ?? 0) / 10_000.0
+            let platformFee = gross * max(0, 1 - providerShare)
+            let electricity = request.electricityUSDPerKWH.map {
+                $0 * Self.estimatedWatts(for: request.hardware.bandwidthTier) / 1_000.0 * request.assumedUtilization
+            }
+            let net = (gross - platformFee) * request.assumedUtilization - (electricity ?? 0)
+            let demandWeight = max(demand.demandWeight, request.demandRank.coldStartFloor)
+            let raw = tps * 3600.0 * usdPerMillionCompletion * providerShare * demandWeight
+            let headroom = Double(request.hardware.memoryGB - Self.safetyMarginGB - candidate.minRAMGB)
+            let confidence = confidence(warnings: warnings, benchmark: benchmark)
+            return AutotuneCandidateScore(
+                rank: 0,
+                catalogKey: modelKey,
+                model: rateMatch?.key ?? modelKey,
+                eligible: eligible,
+                expectedGrossUSDPerHour: gross.rounded6,
+                expectedNetUSDPerHour: net.rounded6,
+                electricityUSDPerHour: electricity?.rounded6,
+                platformFeeUSDPerHour: platformFee.rounded6,
+                tokensPerSecond: tps.rounded6,
+                memoryHeadroomGB: headroom.rounded6,
+                confidence: confidence,
+                why: why(modelKey: modelKey, eligible: eligible, net: net),
+                rawScore: raw
+            )
+        }
+        .sorted {
+            if $0.eligible != $1.eligible { return $0.eligible && !$1.eligible }
+            if $0.rawScore != $1.rawScore { return $0.rawScore > $1.rawScore }
+            return $0.model < $1.model
+        }
+        .enumerated()
+        .map { offset, value in
+            var next = value
+            next.rank = offset + 1
+            return next
+        }
+
+        let eligible = scored.filter(\.eligible)
+        let bestRaw = eligible.map(\.rawScore).max() ?? 0
+        let pool = eligible.filter { $0.rawScore >= request.demandRank.diversificationBand * bestRaw }
+        let selected = pool.isEmpty ? nil : pool[stableHashIndex(request.hardware.diversificationID, count: pool.count)]
+        var recommended = selected
+        if let selected, selected.expectedNetUSDPerHour < Self.paidThreshold {
+            recommended = nil
+            warnings.insert(.recommendationBelowThreshold)
+        }
+        if eligible.isEmpty {
+            warnings.insert(.noEligiblePaidModel)
+        }
+
+        let defaultModel = scored.first?.model
+        let delta = (recommended?.expectedNetUSDPerHour ?? 0) - (scored.first(where: { $0.model == defaultModel })?.expectedNetUSDPerHour ?? 0)
+        let denominator = abs(scored.first(where: { $0.model == defaultModel })?.expectedNetUSDPerHour ?? 0)
+        let percent = denominator > 0 ? delta / denominator * 100.0 : 0.0
+        let selectedBenchmark = recommended.flatMap { request.benchmarks[$0.catalogKey] } ?? eligible.compactMap { request.benchmarks[$0.catalogKey] }.first
+        let donorFallback = scored.first { score in
+            Self.donorModeCompatible(
+                modelKey: score.catalogKey,
+                candidate: request.candidateCatalog.rows[score.catalogKey],
+                request: request
+            )
+        }
+
+        let resultCandidates = eligible.isEmpty ? Array(scored.prefix(5)) : Array(eligible.prefix(5))
+
+        return AutotuneRecommendResult(
+            generatedAt: request.generatedAt,
+            hardware: request.hardware,
+            rateCardVersion: request.rateCard.version,
+            demandRankVersion: request.demandRank.version,
+            candidateCatalogVersion: request.candidateCatalog.version,
+            candidateCatalogSHA256: request.candidateCatalogSHA256,
+            benchmarkID: selectedBenchmark?.benchmarkID,
+            benchmarkGeneratedAt: selectedBenchmark?.generatedAt,
+            recommendedModel: recommended?.model,
+            selectedCandidate: recommended,
+            candidates: resultCandidates,
+            defaultModel: defaultModel,
+            donorFallbackModel: donorFallback?.model,
+            donorFallbackCandidate: donorFallback,
+            donorFallbackNetUSDPerHour: donorFallback?.expectedNetUSDPerHour,
+            recommendedDeltaUSDPerHour: delta.rounded6,
+            recommendedDeltaPercent: percent.rounded6,
+            warnings: warnings.map(\.rawValue).sorted().compactMap(AutotuneRecommendWarning.init(rawValue:)),
+            assumedUtilization: request.assumedUtilization,
+            availabilityHoursPerDay: request.availabilityHoursPerDay,
+            electricityUSDPerKWH: request.electricityUSDPerKWH
+        )
+    }
+
+    func isEligible(
+        modelKey: String,
+        candidate: CandidateCatalog.Row,
+        demand: DemandRank.Row,
+        rateCardRow: RateCardProjection.Row?,
+        benchmark: CandidateBenchmark?,
+        request: AutotuneRecommendRequest
+    ) -> Bool {
+        if !demand.recommendable { return false }
+        if candidate.runtimeStatus != "recommendable" { return false }
+        guard rateCardRow != nil else { return false }
+        guard candidate.modelRevision != nil, candidate.modelSHA256 != nil else { return false }
+        guard candidate.minRAMGB <= request.hardware.memoryGB - Self.safetyMarginGB else { return false }
+        guard request.hardware.bandwidthTier.satisfies(minimum: candidate.minBandwidthTier) else { return false }
+        guard let benchmark else { return false }
+        guard benchmark.sustainedTPS >= candidate.benchGate.minSustainedTPS,
+              benchmark.ttftMS <= candidate.benchGate.max4KTTFTMS,
+              !benchmark.swapDetected,
+              !benchmark.thermalThrottleDetected
+        else {
+            return false
+        }
+        return Self.cachedBenchmarkAdmitted(benchmark, request: request, modelKey: modelKey)
+    }
+
+    static func donorModeAdmitted(
+        modelKey: String,
+        candidate: CandidateCatalog.Row?,
+        request: AutotuneRecommendRequest
+    ) -> Bool {
+        request.donorMode && donorModeCompatible(modelKey: modelKey, candidate: candidate, request: request)
+    }
+
+    private static func donorModeCompatible(
+        modelKey: String,
+        candidate: CandidateCatalog.Row?,
+        request: AutotuneRecommendRequest
+    ) -> Bool {
+        guard let candidate,
+              ["candidate", "listed", "recommendable"].contains(candidate.runtimeStatus),
+              candidate.modelRevision != nil,
+              candidate.modelSHA256 != nil,
+              candidate.minRAMGB <= request.hardware.memoryGB - safetyMarginGB,
+              request.hardware.bandwidthTier.satisfies(minimum: candidate.minBandwidthTier),
+              let benchmark = request.benchmarks[modelKey],
+              benchmark.sustainedTPS >= candidate.benchGate.minSustainedTPS,
+              benchmark.ttftMS <= candidate.benchGate.max4KTTFTMS,
+              !benchmark.swapDetected,
+              !benchmark.thermalThrottleDetected
+        else {
+            return false
+        }
+        return cachedBenchmarkAdmitted(benchmark, request: request, modelKey: modelKey)
+    }
+
+    static func cachedBenchmarkAdmitted(_ benchmark: CandidateBenchmark, request: AutotuneRecommendRequest, modelKey: String) -> Bool {
+        guard benchmark.candidateCatalogSHA256 == request.candidateCatalogSHA256,
+              benchmark.binaryVersion == request.hardware.binaryVersion,
+              benchmark.modelID == request.candidateCatalog.rows[modelKey]?.modelID,
+              benchmark.artifactSHA256 == request.candidateCatalog.rows[modelKey]?.modelSHA256,
+              benchmark.hardwareIdentityHash == request.hardware.hardwareIdentityHash,
+              benchmark.modelArtifactPath.hasPrefix("/")
+        else {
+            return false
+        }
+        return request.generatedAt.timeIntervalSince(benchmark.generatedAt) <= maxBenchmarkAge
+    }
+
+    private static func estimatedWatts(for tier: BandwidthTier) -> Double {
+        switch tier {
+        case .s: return 120
+        case .a: return 95
+        case .b: return 65
+        case .c: return 40
+        case .unknown: return 50
+        }
+    }
+
+    private func stableHashIndex(_ input: String, count: Int) -> Int {
+        let digest = SHA256.hash(data: Data(input.utf8))
+        let first8 = digest.prefix(8).reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+        return Int(first8 % UInt64(count))
+    }
+
+    private func confidence(warnings: Set<AutotuneRecommendWarning>, benchmark: CandidateBenchmark?) -> String {
+        if (warnings.contains(.rateCardFallbackUsed) && warnings.contains(.demandRankFallbackUsed))
+            || warnings.contains(.hardwareTierUnknown)
+            || warnings.contains(.electricityNotIncluded)
+            || warnings.contains(.demandRankStale)
+            || warnings.contains(.candidateCatalogStale) {
+            return "low"
+        }
+        if warnings.contains(.rateCardFallbackUsed) || warnings.contains(.demandRankFallbackUsed) || warnings.contains(.candidateCatalogFallbackUsed) || benchmark == nil {
+            return "medium"
+        }
+        return "high"
+    }
+
+    private func why(modelKey: String, eligible: Bool, net: Double) -> String {
+        if eligible {
+            return "\(modelKey) has the strongest demand-weighted expected net capacity for this Mac.".prefixString(140)
+        }
+        return "\(modelKey) did not clear one or more paid recommendation gates.".prefixString(140)
+    }
+}
+
+extension AutotuneRecommendResult {
+    func jsonString() -> String {
+        let warningsJSON = warnings.map { "\"\($0.rawValue)\"" }.joined(separator: ",")
+        let candidatesJSON = candidates.map { candidate in
+            """
+            {"rank":\(candidate.rank),"model":\(candidate.model.jsonEscaped),"eligible":\(candidate.eligible),"expected_gross_usd_per_hour":\(candidate.expectedGrossUSDPerHour.jsonNumber),"expected_net_usd_per_hour":\(candidate.expectedNetUSDPerHour.jsonNumber),"electricity_usd_per_hour":\(candidate.electricityUSDPerHour?.jsonNumber ?? "null"),"platform_fee_usd_per_hour":\(candidate.platformFeeUSDPerHour.jsonNumber),"tokens_per_second":\(candidate.tokensPerSecond.jsonNumber),"memory_headroom_gb":\(candidate.memoryHeadroomGB.jsonNumber),"confidence":\(candidate.confidence.jsonEscaped),"why":\(candidate.why.jsonEscaped)}
+            """
+        }.joined(separator: ",")
+        return """
+        {"schema_version":"autotune_recommend.v1","generated_at":\(ISO8601DateFormatter.autotuneInternet.string(from: generatedAt).jsonEscaped),"hardware":{"machine":\(hardware.machine?.jsonEscaped ?? "null"),"chip":\(hardware.chip.jsonEscaped),"memory_gb":\(hardware.memoryGB),"bandwidth_tier":\(hardware.bandwidthTier.rawValue.jsonEscaped),"detected":\(hardware.detected),"os_version":\(hardware.osVersion.jsonEscaped),"binary_version":\(hardware.binaryVersion.jsonEscaped)},"inputs":{"rate_card_version":\(rateCardVersion.jsonEscaped),"demand_rank_version":\(demandRankVersion.jsonEscaped),"candidate_catalog_version":\(candidateCatalogVersion.jsonEscaped),"electricity_usd_per_kwh":\(electricityUSDPerKWH?.jsonNumber ?? "null"),"assumed_utilization":\(assumedUtilization.jsonNumber),"availability_hours_per_day":\(availabilityHoursPerDay)},"recommended_model":\(recommendedModel?.jsonEscaped ?? "null"),"candidates":[\(candidatesJSON)],"comparison":{"default_model":\(defaultModel?.jsonEscaped ?? "null"),"recommended_delta_usd_per_hour":\(recommendedDeltaUSDPerHour.jsonNumber),"recommended_delta_percent":\(recommendedDeltaPercent.jsonNumber)},"warnings":[\(warningsJSON)]}
+        """
+    }
+
+    func storedStateJSON() -> String {
+        """
+        {"generated_at":\(ISO8601DateFormatter.autotuneInternet.string(from: generatedAt).jsonEscaped),"rate_card_version":\(rateCardVersion.jsonEscaped),"demand_rank_version":\(demandRankVersion.jsonEscaped),"candidate_catalog_version":\(candidateCatalogVersion.jsonEscaped),"candidate_catalog_sha256":\(candidateCatalogSHA256.jsonEscaped),"benchmark_id":\(benchmarkID?.jsonEscaped ?? "null"),"benchmark_generated_at":\(benchmarkGeneratedAt.map { ISO8601DateFormatter.autotuneInternet.string(from: $0).jsonEscaped } ?? "null"),"binary_version":\(hardware.binaryVersion.jsonEscaped),"hardware_identity_hash":\(hardware.hardwareIdentityHash.jsonEscaped),"recommended_model":\(recommendedModel?.jsonEscaped ?? "null")}
+        """
+    }
+
+    func humanTranscript() -> String {
+        let machineOrChip = hardware.machine ?? hardware.chip
+        if let recommendedModel,
+           let candidate = selectedCandidate ?? candidates.first(where: { $0.model == recommendedModel }) {
+            return """
+            Detected \(machineOrChip), \(hardware.memoryGB) GB unified memory, Tier \(hardware.bandwidthTier.rawValue).
+            Benchmarked \(candidates.filter(\.eligible).count) compatible models against rate card \(rateCardVersion) and demand rank \(demandRankVersion).
+
+            Recommended: \(recommendedModel)
+            Expected net capacity: \(formatUSD(candidate.expectedNetUSDPerHour))/hr at \(Int(assumedUtilization * 100))% utilization
+            Why: \(formatUSD(recommendedDeltaUSDPerHour))/hr vs default \(defaultModel ?? "none"); \(String(format: "%.1f", candidate.memoryHeadroomGB)) GB memory headroom
+
+            This is an estimate, not a guarantee. Actual earnings depend on buyer demand, uptime, thermal state, electricity, and rate-card changes.
+
+            Start provider with \(recommendedModel)? [Y/n]
+            """
+        }
+        let best = donorFallbackModel ?? "none"
+        let value = donorFallbackNetUSDPerHour.map { formatUSD($0) } ?? "$0.0000"
+        return """
+        Detected \(machineOrChip), \(hardware.memoryGB) GB unified memory, Tier \(hardware.bandwidthTier.rawValue).
+        No paid model currently clears the minimum net-yield threshold of $0.0050/hr.
+
+        Best compatible option: \(best)
+        Expected net capacity: \(value)/hr before demand risk
+        Recommendation: donor mode only
+
+        You can keep this Mac configured for donor-mode testing, but it is not expected to earn meaningful revenue on the current rate card.
+        Enable donor mode? [y/N]
+        """
+    }
+
+    private func formatUSD(_ value: Double) -> String {
+        String(format: "$%.4f", value)
+    }
+}
+
+struct LastRecommendationState: Decodable, Equatable {
+    var generatedAt: Date
+    var rateCardVersion: String
+    var demandRankVersion: String
+    var candidateCatalogVersion: String
+    var candidateCatalogSHA256: String
+    var benchmarkID: String?
+    var benchmarkGeneratedAt: Date?
+    var binaryVersion: String
+    var hardwareIdentityHash: String
+    var recommendedModel: String?
+
+    enum CodingKeys: String, CodingKey {
+        case generatedAt = "generated_at"
+        case rateCardVersion = "rate_card_version"
+        case demandRankVersion = "demand_rank_version"
+        case candidateCatalogVersion = "candidate_catalog_version"
+        case candidateCatalogSHA256 = "candidate_catalog_sha256"
+        case benchmarkID = "benchmark_id"
+        case benchmarkGeneratedAt = "benchmark_generated_at"
+        case binaryVersion = "binary_version"
+        case hardwareIdentityHash = "hardware_identity_hash"
+        case recommendedModel = "recommended_model"
+    }
+
+    init(
+        generatedAt: Date,
+        rateCardVersion: String,
+        demandRankVersion: String,
+        candidateCatalogVersion: String,
+        candidateCatalogSHA256: String,
+        benchmarkID: String?,
+        benchmarkGeneratedAt: Date?,
+        binaryVersion: String,
+        hardwareIdentityHash: String,
+        recommendedModel: String?
+    ) {
+        self.generatedAt = generatedAt
+        self.rateCardVersion = rateCardVersion
+        self.demandRankVersion = demandRankVersion
+        self.candidateCatalogVersion = candidateCatalogVersion
+        self.candidateCatalogSHA256 = candidateCatalogSHA256
+        self.benchmarkID = benchmarkID
+        self.benchmarkGeneratedAt = benchmarkGeneratedAt
+        self.binaryVersion = binaryVersion
+        self.hardwareIdentityHash = hardwareIdentityHash
+        self.recommendedModel = recommendedModel
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let generated = try c.decode(String.self, forKey: .generatedAt)
+        generatedAt = ISO8601DateFormatter.autotuneInternet.date(from: generated) ?? .distantPast
+        rateCardVersion = try c.decode(String.self, forKey: .rateCardVersion)
+        demandRankVersion = try c.decode(String.self, forKey: .demandRankVersion)
+        candidateCatalogVersion = try c.decode(String.self, forKey: .candidateCatalogVersion)
+        candidateCatalogSHA256 = try c.decode(String.self, forKey: .candidateCatalogSHA256)
+        benchmarkID = try c.decodeIfPresent(String.self, forKey: .benchmarkID)
+        if let raw = try c.decodeIfPresent(String.self, forKey: .benchmarkGeneratedAt) {
+            benchmarkGeneratedAt = ISO8601DateFormatter.autotuneInternet.date(from: raw)
+        } else {
+            benchmarkGeneratedAt = nil
+        }
+        binaryVersion = try c.decode(String.self, forKey: .binaryVersion)
+        hardwareIdentityHash = try c.decode(String.self, forKey: .hardwareIdentityHash)
+        recommendedModel = try c.decodeIfPresent(String.self, forKey: .recommendedModel)
+    }
+}
+
+enum RecommendationStateStore {
+    static var defaultURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/macprovider/last-recommendation.json")
+    }
+
+    static func write(_ result: AutotuneRecommendResult, to url: URL = defaultURL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try result.storedStateJSON().data(using: .utf8)!.write(to: url, options: .atomic)
+    }
+
+    static func read(from url: URL = defaultURL) throws -> LastRecommendationState {
+        try JSONDecoder.autotune.decode(LastRecommendationState.self, from: Data(contentsOf: url))
+    }
+
+    static func isStale(stored: LastRecommendationState, current: LastRecommendationState, now: Date) -> Bool {
+        if stored.rateCardVersion != current.rateCardVersion { return true }
+        if stored.demandRankVersion != current.demandRankVersion { return true }
+        if stored.candidateCatalogVersion != current.candidateCatalogVersion { return true }
+        if stored.candidateCatalogSHA256 != current.candidateCatalogSHA256 { return true }
+        if stored.binaryVersion != current.binaryVersion { return true }
+        if stored.hardwareIdentityHash != current.hardwareIdentityHash { return true }
+        guard let benchmarkGeneratedAt = stored.benchmarkGeneratedAt else { return true }
+        return now.timeIntervalSince(benchmarkGeneratedAt) > AutotuneRecommendEngine.maxBenchmarkAge
+    }
+}
+
+struct RecommendationFreshnessChecker {
+    var staticInputs: AutotuneStaticInputs = AutotuneStaticInputs()
+    var fingerprint: MachineFingerprint = MachineFingerprinter().sample()
+    var providerID: String?
+    var hmacSecretURL: URL = AutotuneHMACSecretStore.defaultPath
+    var stateURL: URL = RecommendationStateStore.defaultURL
+    var now: Date = Date()
+
+    enum Status: Equatable {
+        case missing
+        case fresh
+        case stale(Date)
+    }
+
+    func status() async -> Status {
+        guard let stored = try? RecommendationStateStore.read(from: stateURL) else {
+            return .missing
+        }
+        let secret: Data
+        do {
+            secret = try AutotuneHMACSecretStore(path: hmacSecretURL).loadOrCreate()
+        } catch {
+            return .stale(stored.generatedAt)
+        }
+
+        let demand = await staticInputs.loadDemandRank()
+        let catalog = await staticInputs.loadCandidateCatalog()
+        let rateCard = await staticInputs.loadRateCard()
+        let identity = HMACIdentity.derive(secret: secret, fingerprint: fingerprint, providerID: providerID)
+        let current = LastRecommendationState(
+            generatedAt: now,
+            rateCardVersion: rateCard.value.version,
+            demandRankVersion: demand.value.version,
+            candidateCatalogVersion: catalog.value.version,
+            candidateCatalogSHA256: AutotuneStaticInputs.candidateCatalogSHA256(bytes: catalog.selectedBytes),
+            benchmarkID: stored.benchmarkID,
+            benchmarkGeneratedAt: stored.benchmarkGeneratedAt,
+            binaryVersion: fingerprint.binaryVersion,
+            hardwareIdentityHash: identity.cacheIdentityHash,
+            recommendedModel: stored.recommendedModel
+        )
+        return RecommendationStateStore.isStale(stored: stored, current: current, now: now)
+            ? .stale(stored.generatedAt)
+            : .fresh
+    }
+
+    func staleRecommendationSince() async -> Date? {
+        if case let .stale(generatedAt) = await status() {
+            return generatedAt
+        }
+        return nil
+    }
+}
+
+struct VerifiedModelArtifact {
+    var modelArgument: String
+    var sha256: String
+}
+
+struct ProbeSafetySample: Equatable {
+    var pageouts: UInt64?
+    var thermalState: ProcessInfo.ThermalState?
+}
+
+protocol ProbeSafetySampling {
+    func sample() -> ProbeSafetySample
+}
+
+struct ProbeSafetyAssessment: Equatable {
+    var swapDetected: Bool
+    var thermalThrottleDetected: Bool
+
+    static func assess(before: ProbeSafetySample, after: ProbeSafetySample) -> ProbeSafetyAssessment {
+        let swapDetected: Bool
+        if let beforePageouts = before.pageouts, let afterPageouts = after.pageouts {
+            swapDetected = afterPageouts > beforePageouts
+        } else {
+            swapDetected = true
+        }
+        let states = [before.thermalState, after.thermalState]
+        let thermalKnown = states.allSatisfy { $0 != nil }
+        let thermalThrottleDetected = !thermalKnown || states.compactMap { $0 }.contains { ThermalGate.shouldThrottle($0) }
+        return ProbeSafetyAssessment(
+            swapDetected: swapDetected,
+            thermalThrottleDetected: thermalThrottleDetected
+        )
+    }
+}
+
+struct SystemProbeSafetySampler: ProbeSafetySampling {
+    func sample() -> ProbeSafetySample {
+        ProbeSafetySample(
+            pageouts: Self.vmStatCounter(named: "Pageouts"),
+            thermalState: ProcessInfo.processInfo.thermalState
+        )
+    }
+
+    private static func vmStatCounter(named key: String) -> UInt64? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/vm_stat")
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+        guard process.terminationStatus == 0 else { return nil }
+        let output = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        for line in output.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("\(key):") else { continue }
+            let digits = trimmed.dropFirst(key.count + 1).filter(\.isNumber)
+            return UInt64(digits)
+        }
+        return nil
+    }
+}
+
+struct HuggingFaceSnapshotDownloader {
+    struct ModelInfo: Decodable {
+        var siblings: [Sibling]
+    }
+
+    struct Sibling: Decodable {
+        var rfilename: String
+    }
+
+    private static let guardedSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        return URLSession(configuration: config)
+    }()
+
+    var fetch: (URLRequest) async throws -> (Data, URLResponse) = { request in
+        try await HuggingFaceSnapshotDownloader.guardedSession.data(for: request, delegate: HFRedirectGuard())
+    }
+    var download: (URLRequest) async throws -> (URL, URLResponse) = { request in
+        try await HuggingFaceSnapshotDownloader.guardedSession.download(for: request, delegate: HFAssetRedirectGuard())
+    }
+
+    func downloadSnapshot(modelID: String, revision: String, to snapshot: URL) async throws {
+        let siblings = try await modelSiblings(modelID: modelID, revision: revision)
+        guard !siblings.isEmpty else {
+            throw AutotuneRecommendError.invalidArtifact("empty HuggingFace snapshot \(modelID)@\(revision)")
+        }
+        let staging = snapshot.deletingLastPathComponent()
+            .appendingPathComponent(".download-\(revision)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+        do {
+            for sibling in siblings {
+                try validateRelativeHFPath(sibling.rfilename)
+                let destination = staging.appendingPathComponent(sibling.rfilename, isDirectory: false)
+                try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+                var request = URLRequest(url: resolveURL(modelID: modelID, revision: revision, filename: sibling.rfilename))
+                addTokenHeader(&request)
+                let (temporary, response) = try await download(request)
+                guard (response as? HTTPURLResponse).map({ (200..<300).contains($0.statusCode) }) ?? true else {
+                    throw AutotuneRecommendError.invalidArtifact("download failed \(sibling.rfilename)")
+                }
+                try? FileManager.default.removeItem(at: destination)
+                try FileManager.default.moveItem(at: temporary, to: destination)
+                _ = chmod(destination.path, 0o600)
+            }
+            try FileManager.default.createDirectory(at: snapshot.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? FileManager.default.removeItem(at: snapshot)
+            try FileManager.default.moveItem(at: staging, to: snapshot)
+        } catch {
+            try? FileManager.default.removeItem(at: staging)
+            throw error
+        }
+    }
+
+    private func modelSiblings(modelID: String, revision: String) async throws -> [Sibling] {
+        var request = URLRequest(url: apiURL(modelID: modelID, revision: revision))
+        addTokenHeader(&request)
+        let (data, response) = try await fetch(request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw AutotuneRecommendError.invalidArtifact("HuggingFace API failed \(modelID)@\(revision)")
+        }
+        return try JSONDecoder.autotune.decode(ModelInfo.self, from: data).siblings
+    }
+
+    private func apiURL(modelID: String, revision: String) -> URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        components.path = "/api/models/\(modelID)/revision/\(revision)"
+        components.queryItems = [URLQueryItem(name: "blobs", value: "true")]
+        return components.url!
+    }
+
+    private func resolveURL(modelID: String, revision: String, filename: String) -> URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        components.path = "/\(modelID)/resolve/\(revision)/\(filename)"
+        return components.url!
+    }
+
+    private func addTokenHeader(_ request: inout URLRequest) {
+        guard let token = ProcessInfo.processInfo.environment["HF_TOKEN"], !token.isEmpty else { return }
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+
+    private func validateRelativeHFPath(_ path: String) throws {
+        guard !path.isEmpty,
+              !path.hasPrefix("/"),
+              !path.split(separator: "/").contains("..")
+        else {
+            throw AutotuneRecommendError.invalidArtifact("unsafe HuggingFace path \(path)")
+        }
+    }
+}
+
+final class HFAssetRedirectGuard: NSObject, URLSessionTaskDelegate {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let originalURL = task.originalRequest?.url,
+              let newURL = request.url,
+              originalURL.scheme == "https",
+              newURL.scheme == "https",
+              let originalHost = originalURL.host,
+              let newHost = newURL.host
+        else {
+            completionHandler(nil)
+            return
+        }
+        if originalHost == newHost {
+            completionHandler(request)
+            return
+        }
+        guard originalHost == "huggingface.co", Self.allowedAssetHost(newHost) else {
+            completionHandler(nil)
+            return
+        }
+        var stripped = request
+        stripped.setValue(nil, forHTTPHeaderField: "Authorization")
+        completionHandler(stripped)
+    }
+
+    private static func allowedAssetHost(_ host: String) -> Bool {
+        host == "cdn-lfs.huggingface.co"
+            || host == "cas-bridge.xethub.hf.co"
+            || host == "transfer.xethub.hf.co"
+            || host.hasSuffix(".aws.cdn.hf.co")
+    }
+}
+
+struct CachedModelArtifactResolver {
+    var hubRoot: URL = defaultHubRoot
+    var downloader: HuggingFaceSnapshotDownloader = HuggingFaceSnapshotDownloader()
+
+    static var defaultHubRoot: URL {
+        if let hfHome = ProcessInfo.processInfo.environment["HF_HOME"], !hfHome.isEmpty {
+            return URL(fileURLWithPath: hfHome).appendingPathComponent("hub", isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
+    }
+
+    func verifiedArtifact(for row: CandidateCatalog.Row) async throws -> VerifiedModelArtifact {
+        guard let revision = row.modelRevision, let expected = row.modelSHA256 else {
+            throw AutotuneRecommendError.invalidArtifact("missing revision/hash")
+        }
+        let snapshot = snapshotURL(modelID: row.modelID, revision: revision)
+        var st = stat()
+        if lstat(snapshot.path, &st) != 0 || (st.st_mode & S_IFMT) != S_IFDIR {
+            try await downloader.downloadSnapshot(modelID: row.modelID, revision: revision, to: snapshot)
+        }
+        let actual = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        guard actual == expected else {
+            throw AutotuneRecommendError.invalidArtifact("hash mismatch \(row.modelID)@\(revision)")
+        }
+        return VerifiedModelArtifact(modelArgument: snapshot.path, sha256: actual)
+    }
+
+    func verifiedExistingArtifact(for row: CandidateCatalog.Row) throws -> VerifiedModelArtifact {
+        guard let revision = row.modelRevision, let expected = row.modelSHA256 else {
+            throw AutotuneRecommendError.invalidArtifact("missing revision/hash")
+        }
+        let snapshot = snapshotURL(modelID: row.modelID, revision: revision)
+        var st = stat()
+        guard lstat(snapshot.path, &st) == 0,
+              (st.st_mode & S_IFMT) == S_IFDIR
+        else {
+            throw AutotuneRecommendError.invalidArtifact("missing pinned snapshot \(row.modelID)@\(revision)")
+        }
+        let actual = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        guard actual == expected else {
+            throw AutotuneRecommendError.invalidArtifact("hash mismatch \(row.modelID)@\(revision)")
+        }
+        return VerifiedModelArtifact(modelArgument: snapshot.path, sha256: actual)
+    }
+
+    func snapshotURL(modelID: String, revision: String) -> URL {
+        let repoDirectory = "models--" + modelID.replacingOccurrences(of: "/", with: "--")
+        return hubRoot
+            .appendingPathComponent(repoDirectory, isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(revision, isDirectory: true)
+    }
+}
+
+struct AutotuneRecommendationBenchmarker {
+    var artifactResolver: CachedModelArtifactResolver = CachedModelArtifactResolver()
+    var runnerFactory: () throws -> CandidateProviderRunner = { try CandidateProviderRunner() }
+    var prober: any Stage1Probing = Stage1Prober()
+    var safetySampler: ProbeSafetySampling = SystemProbeSafetySampler()
+    var clock: () -> Date = Date.init
+
+    func benchmarks(
+        request: AutotuneRecommendRequest,
+        targetContext: Int,
+        gateTTFTMS: Int,
+        replicates: Int,
+        port: Int
+    ) async throws -> [String: CandidateBenchmark] {
+        var results: [String: CandidateBenchmark] = [:]
+        for modelKey in request.candidateCatalog.rows.keys.sorted() {
+            guard let row = request.candidateCatalog.rows[modelKey],
+                  row.runtimeStatus != "blocked",
+                  row.minRAMGB <= request.hardware.memoryGB - AutotuneRecommendEngine.safetyMarginGB,
+                  request.hardware.bandwidthTier.satisfies(minimum: row.minBandwidthTier)
+            else {
+                continue
+            }
+            do {
+                let artifact = try await artifactResolver.verifiedArtifact(for: row)
+                let runner = try runnerFactory()
+                let before = safetySampler.sample()
+                let probe = try await prober.probe(
+                    model: artifact.modelArgument,
+                    port: port,
+                    runner: runner,
+                    targetContext: targetContext,
+                    gateTTFTMS: gateTTFTMS,
+                    replicates: replicates
+                )
+                let after = safetySampler.sample()
+                let safety = ProbeSafetyAssessment.assess(before: before, after: after)
+                if case .feasible(let medianTPS, let p95TTFTMS) = probe {
+                    let generatedAt = clock()
+                    results[modelKey] = CandidateBenchmark(
+                        modelKey: modelKey,
+                        sustainedTPS: medianTPS,
+                        ttftMS: Int(p95TTFTMS.rounded(.up)),
+                        swapDetected: safety.swapDetected,
+                        thermalThrottleDetected: safety.thermalThrottleDetected,
+                        artifactSHA256: artifact.sha256,
+                        modelArtifactPath: artifact.modelArgument,
+                        benchmarkID: "spec-023-\(modelKey)-\(Int(generatedAt.timeIntervalSince1970))",
+                        generatedAt: generatedAt,
+                        candidateCatalogSHA256: request.candidateCatalogSHA256,
+                        binaryVersion: request.hardware.binaryVersion,
+                        modelID: row.modelID,
+                        hardwareIdentityHash: request.hardware.hardwareIdentityHash
+                    )
+                }
+            } catch {
+                throw error
+            }
+        }
+        return results
+    }
+}
+
+enum ModelArtifactVerifier {
+    static func canonicalArtifactHash(directory: URL) throws -> String {
+        let fm = FileManager.default
+        var root = stat()
+        guard lstat(directory.path, &root) == 0,
+              (root.st_mode & S_IFMT) == S_IFDIR
+        else {
+            throw AutotuneRecommendError.invalidArtifact("root is not a directory")
+        }
+        guard let enumerator = fm.enumerator(at: directory, includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey], options: []) else {
+            throw AutotuneRecommendError.invalidArtifact("cannot enumerate")
+        }
+        let basePath = directory.resolvingSymlinksInPath().path
+        var entries: [(path: String, size: UInt64, sha: String)] = []
+        for case let url as URL in enumerator {
+            let path = url.resolvingSymlinksInPath().path
+            guard path.hasPrefix(basePath + "/") else {
+                throw AutotuneRecommendError.invalidArtifact("path escape \(url.lastPathComponent)")
+            }
+            let rel = String(path.dropFirst(basePath.count + 1))
+            guard !rel.hasPrefix("/"), !rel.split(separator: "/").contains("..") else {
+                throw AutotuneRecommendError.invalidArtifact("unsafe path \(rel)")
+            }
+            var statbuf = stat()
+            guard lstat(url.path, &statbuf) == 0 else {
+                throw AutotuneRecommendError.invalidArtifact("lstat \(rel)")
+            }
+            if (statbuf.st_mode & S_IFMT) == S_IFLNK {
+                throw AutotuneRecommendError.invalidArtifact("symlink \(rel)")
+            }
+            if (statbuf.st_mode & S_IFMT) == S_IFDIR {
+                continue
+            }
+            guard (statbuf.st_mode & S_IFMT) == S_IFREG else {
+                throw AutotuneRecommendError.invalidArtifact("non-regular \(rel)")
+            }
+            guard statbuf.st_nlink <= 1 else {
+                throw AutotuneRecommendError.invalidArtifact("hardlink \(rel)")
+            }
+            let data = try Data(contentsOf: url)
+            entries.append((rel, UInt64(data.count), Data(SHA256.hash(data: data)).hexLower))
+        }
+        let manifest = entries.sorted { $0.path < $1.path }
+            .map { "\($0.path)\n\($0.size)\n\($0.sha)\n" }
+            .joined()
+        return Data(SHA256.hash(data: Data(manifest.utf8))).hexLower
+    }
+}
+
+extension ISO8601DateFormatter {
+    static var autotuneInternet: ISO8601DateFormatter {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }
+}
+
+private extension JSONDecoder {
+    static let autotune: JSONDecoder = JSONDecoder()
+}
+
+private extension Data {
+    var hexLower: String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+private extension Double {
+    var rounded6: Double {
+        (self * 1_000_000).rounded() / 1_000_000
+    }
+
+    var jsonNumber: String {
+        if isFinite {
+            return String(format: "%.6f", self).replacingOccurrences(of: #"\.?0+$"#, with: "", options: .regularExpression)
+        }
+        return "0"
+    }
+}
+
+private extension String {
+    var jsonEscaped: String {
+        let data = try! JSONSerialization.data(withJSONObject: [self], options: [])
+        let array = String(decoding: data, as: UTF8.self)
+        return String(array.dropFirst().dropLast())
+    }
+
+    func prefixString(_ count: Int) -> String {
+        String(prefix(count))
+    }
+}
+
+extension AutotuneStaticInputs {
+    static let bakedDemandRankJSON = """
+    {"version":"baked-2026-07-01","generated_at":"2026-07-01T00:00:00Z","source":"openrouter_completion_token_rank_operator_curated","cold_start_floor":0.15,"diversification_band":0.85,"rows":{"meta-llama/llama-3.1-8b-instruct":{"demand_weight":0.45,"rank":3,"recommendable":true,"min_provider_target":20},"openai/gpt-oss-20b":{"demand_weight":0.60,"rank":2,"recommendable":true,"min_provider_target":20},"qwen3-32b":{"demand_weight":0.35,"rank":8,"recommendable":false,"min_provider_target":10},"qwen3-coder-30b-a3b-instruct":{"demand_weight":0.80,"rank":1,"recommendable":true,"min_provider_target":20},"qwen2.5-coder-32b-instruct":{"demand_weight":0.40,"rank":7,"recommendable":false,"min_provider_target":10},"google-gemma-4-26b-a4b-it":{"demand_weight":0.20,"rank":null,"recommendable":false,"min_provider_target":0},"nvidia/nemotron-3-nano-30b-a3b":{"demand_weight":0.20,"rank":null,"recommendable":false,"min_provider_target":0}}}
+    """
+
+    static let bakedCandidateCatalogJSON = """
+    {"version":"baked-2026-07-01","generated_at":"2026-07-01T00:00:00Z","source":"operator_curated_autotune_candidate_catalog","rows":{"meta-llama/llama-3.1-8b-instruct":{"model_id":"mlx-community/Meta-Llama-3.1-8B-Instruct-4bit","model_revision":"241a666dad6cb93c8ff213d39a7f34a36bf26db4","model_sha256":"67b26d6b1c50dc8836ab3705b06276a43c74c8f66247f9b112e232b58abbd99f","min_ram_gb":16,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":20,"max_4k_ttft_ms":2500},"runtime_status":"recommendable","notes":"baked"},"openai/gpt-oss-20b":{"model_id":"mlx-community/gpt-oss-20b-MXFP4-Q8","model_revision":"773a7da77e569019bb0fd17a554b263738d669a3","model_sha256":"f25592861e0b7f4eb8489d9103214f3f0dc4f798bb0e4e0cd817ff2f4191f1b1","min_ram_gb":24,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":30,"max_4k_ttft_ms":2500},"runtime_status":"recommendable","notes":"baked"},"qwen3-32b":{"model_id":"mlx-community/Qwen3-32B-4bit","model_revision":"bcaaf7f538adf166c1080a2befdb4f6019f66639","model_sha256":"69169cceb643f108755f96dba26d8647862e38a7f82cb1b5b25aff8f204967aa","min_ram_gb":32,"min_bandwidth_tier":"A","bench_gate":{"min_sustained_tps":30,"max_4k_ttft_ms":3000},"runtime_status":"listed","notes":"baked"},"qwen3-coder-30b-a3b-instruct":{"model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","model_revision":"6e302ea604ad9ab206367e2c501d1571023e7b6d","model_sha256":"10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0","min_ram_gb":32,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":25,"max_4k_ttft_ms":3000},"runtime_status":"recommendable","notes":"baked"},"qwen2.5-coder-32b-instruct":{"model_id":"mlx-community/Qwen2.5-Coder-32B-Instruct-4bit","model_revision":"d1e3b690c8e225d7795bccddf971ca6be68b2012","model_sha256":"b7749cc57f37f7e9239d0f9b091bcffe6d7629e48af75e8cb84c1cdca1780973","min_ram_gb":64,"min_bandwidth_tier":"A","bench_gate":{"min_sustained_tps":30,"max_4k_ttft_ms":3500},"runtime_status":"listed","notes":"baked"},"google-gemma-4-26b-a4b-it":{"model_id":"mlx-community/gemma-4-26b-a4b-it-4bit","min_ram_gb":32,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":30,"max_4k_ttft_ms":3000},"runtime_status":"blocked","notes":"baked"},"nvidia/nemotron-3-nano-30b-a3b":{"model_id":"mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit","min_ram_gb":32,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":30,"max_4k_ttft_ms":3000},"runtime_status":"blocked","notes":"baked"}}}
+    """
+
+    static let bakedRateCardJSON = """
+    {"version":"baked-2026-07-01","generated_at":"2026-07-01T00:00:00Z","usd_per_million_credits":1.0,"rows":{"meta-llama/llama-3.1-8b-instruct":{"prompt_rate_per_mtok":50000,"completion_rate_per_mtok":100000,"provider_share_bps":9000,"global_multiplier_ppm":1000000},"openai/gpt-oss-20b":{"prompt_rate_per_mtok":50000,"completion_rate_per_mtok":120000,"provider_share_bps":9000,"global_multiplier_ppm":1000000},"qwen3-coder-30b-a3b-instruct":{"prompt_rate_per_mtok":60000,"completion_rate_per_mtok":140000,"provider_share_bps":9000,"global_multiplier_ppm":1000000},"qwen3-32b":{"prompt_rate_per_mtok":60000,"completion_rate_per_mtok":120000,"provider_share_bps":9000,"global_multiplier_ppm":1000000},"qwen2.5-coder-32b-instruct":{"prompt_rate_per_mtok":60000,"completion_rate_per_mtok":120000,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
+    """
+}

--- a/phase3-binary/Sources/macprovider-cli/ConfigApplier.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConfigApplier.swift
@@ -42,7 +42,8 @@ struct ConfigApplier {
 
     func apply(
         recommendation: RecommendationCore,
-        now: Date
+        now: Date,
+        donorMode: Bool = false
     ) throws -> AppliedConfig {
         let fileManager = FileManager.default
         let directory = configPath.deletingLastPathComponent()
@@ -55,7 +56,7 @@ struct ConfigApplier {
         let unixTS = Int(now.timeIntervalSince1970)
         let backupPath = try writeBackupExclusively(originalData, unixTS: unixTS)
 
-        let updatedText = try updatedConfigText(originalText, recommendation: recommendation)
+        let updatedText = try updatedConfigText(originalText, recommendation: recommendation, donorMode: donorMode)
         guard let updatedData = updatedText.data(using: .utf8) else {
             throw ConfigApplierError.stringEncodingFailed(configPath.path)
         }
@@ -63,7 +64,7 @@ struct ConfigApplier {
 
         return AppliedConfig(
             backupPath: backupPath,
-            summary: Self.summary(recommendation: recommendation, backupPath: backupPath)
+            summary: Self.summary(recommendation: recommendation, backupPath: backupPath, donorMode: donorMode)
         )
     }
 
@@ -91,7 +92,7 @@ struct ConfigApplier {
         for counter in 0...maxBackupCounter {
             let candidate = directory
                 .appendingPathComponent("\(configPath.lastPathComponent).bak-\(unixTS)-\(counter)")
-            let fd = candidate.path.withCString { open($0, O_CREAT | O_EXCL | O_WRONLY, 0o644) }
+            let fd = candidate.path.withCString { open($0, O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW, 0o600) }
             if fd >= 0 {
                 defer { _ = close(fd) }
                 try writeAll(fd: fd, data: data, destination: candidate.path)
@@ -132,7 +133,19 @@ struct ConfigApplier {
 
     private func atomicWrite(_ data: Data, to destination: URL, unixTS: Int) throws {
         let tempURL = tempFileNamer(destination, unixTS)
-        try data.write(to: tempURL, options: [])
+        let fd = tempURL.path.withCString { open($0, O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW, 0o600) }
+        guard fd >= 0 else {
+            throw ConfigApplierError.backupWriteFailed(destination: tempURL.path, errno: errno)
+        }
+        do {
+            try writeAll(fd: fd, data: data, destination: tempURL.path)
+            _ = fsync(fd)
+            _ = close(fd)
+        } catch {
+            _ = close(fd)
+            try? FileManager.default.removeItem(at: tempURL)
+            throw error
+        }
         if rename(tempURL.path, destination.path) != 0 {
             let renameErrno = errno
             try? FileManager.default.removeItem(at: tempURL)
@@ -146,15 +159,39 @@ struct ConfigApplier {
 
     private func updatedConfigText(
         _ original: String,
-        recommendation: RecommendationCore
+        recommendation: RecommendationCore,
+        donorMode: Bool
     ) throws -> String {
         let values: [String: String?] = [
             "model": recommendation.model,
+            "model_artifact_path": recommendation.modelArtifactPath,
+            "model_artifact_sha256": recommendation.modelArtifactSHA256,
+            "model_catalog_key": recommendation.modelCatalogKey,
+            "model_catalog_model_id": recommendation.modelCatalogModelID,
+            "model_catalog_revision": recommendation.modelCatalogRevision,
+            "model_catalog_sha256": recommendation.modelCatalogSHA256,
+            "model_catalog_version": recommendation.modelCatalogVersion,
+            "model_catalog_hash": recommendation.modelCatalogHash,
             "kv_bits": recommendation.knobs.kvBits.map(String.init),
             "max_context_override": String(recommendation.knobs.maxContext),
             "max_concurrency_override": String(recommendation.knobs.maxBatch),
+            "donor_mode": donorMode ? "true" : nil,
         ]
-        let ownedKeys = ["model", "kv_bits", "max_context_override", "max_concurrency_override"]
+        let ownedKeys = [
+            "model",
+            "model_artifact_path",
+            "model_artifact_sha256",
+            "model_catalog_key",
+            "model_catalog_model_id",
+            "model_catalog_revision",
+            "model_catalog_sha256",
+            "model_catalog_version",
+            "model_catalog_hash",
+            "kv_bits",
+            "max_context_override",
+            "max_concurrency_override",
+            "donor_mode",
+        ]
 
         if original.isEmpty {
             return renderOwnedConfig(values: values)
@@ -202,8 +239,29 @@ struct ConfigApplier {
             "max_context_override: \(values["max_context_override"]!!)",
             "max_concurrency_override: \(values["max_concurrency_override"]!!)",
         ]
+        if let artifactSHA = values["model_artifact_sha256"] ?? nil {
+            lines.insert("model_artifact_sha256: \(artifactSHA)", at: 1)
+        }
+        if let artifactPath = values["model_artifact_path"] ?? nil {
+            lines.insert("model_artifact_path: \(artifactPath)", at: 1)
+        }
+        for key in [
+            "model_catalog_key",
+            "model_catalog_model_id",
+            "model_catalog_revision",
+            "model_catalog_sha256",
+            "model_catalog_version",
+            "model_catalog_hash",
+        ].reversed() {
+            if let value = values[key] ?? nil {
+                lines.insert("\(key): \(value)", at: 1)
+            }
+        }
         if let kvBits = values["kv_bits"] ?? nil {
             lines.insert("kv_bits: \(kvBits)", at: 1)
+        }
+        if let donorMode = values["donor_mode"] ?? nil {
+            lines.append("donor_mode: \(donorMode)")
         }
         return lines.joined(separator: "\n") + "\n"
     }
@@ -227,9 +285,10 @@ struct ConfigApplier {
         return ""
     }
 
-    private static func summary(recommendation: RecommendationCore, backupPath: URL) -> String {
+    private static func summary(recommendation: RecommendationCore, backupPath: URL, donorMode: Bool) -> String {
         let kvBits = recommendation.knobs.kvBits.map(String.init) ?? "unset"
-        return "applied: model=\(recommendation.model) kv_bits=\(kvBits) max_concurrency_override=\(recommendation.knobs.maxBatch) max_context_override=\(recommendation.knobs.maxContext) (backup at \(backupPath.path))"
+        let donorSuffix = donorMode ? " donor_mode=true" : ""
+        return "applied: model=\(recommendation.model) kv_bits=\(kvBits) max_concurrency_override=\(recommendation.knobs.maxBatch) max_context_override=\(recommendation.knobs.maxContext)\(donorSuffix) (backup at \(backupPath.path))"
     }
 
     private static func defaultTempFileName(destination: URL, unixTS: Int) -> URL {

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -128,11 +128,137 @@ struct ServeCommand: AsyncParsableCommand {
         }
     }
 
+    static func runModelArtifactPreflight(
+        _ resolved: AppConfig,
+        joiningCoordinator: Bool = true,
+        staticInputs: AutotuneStaticInputs = AutotuneStaticInputs(),
+        artifactResolver: CachedModelArtifactResolver = CachedModelArtifactResolver()
+    ) async throws {
+        guard let expected = resolved.modelArtifactSHA256 else {
+            if resolved.modelArtifactPath != nil {
+                FileHandle.standardError.write(Data("model_artifact_path requires model_artifact_sha256 for a verified local snapshot\n".utf8))
+                throw ExitCode(2)
+            }
+            if resolved.donorMode {
+                FileHandle.standardError.write(Data("donor_mode requires model_artifact_sha256 for a verified local snapshot\n".utf8))
+                throw ExitCode(2)
+            }
+            if joiningCoordinator {
+                FileHandle.standardError.write(Data("coordinator join requires model_artifact_sha256 from autotune --recommend --apply\n".utf8))
+                throw ExitCode(2)
+            }
+            return
+        }
+        guard expected.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil else {
+            FileHandle.standardError.write(Data("model_artifact_sha256 must be 64 lowercase hex characters\n".utf8))
+            throw ExitCode(2)
+        }
+        let artifactPath = resolved.modelArtifactPath ?? ((resolved.donorMode || joiningCoordinator) ? nil : resolved.model)
+        guard let artifactPath, artifactPath.hasPrefix("/") else {
+            FileHandle.standardError.write(Data("model_artifact_sha256 requires model_artifact_path to be a verified local snapshot path\n".utf8))
+            throw ExitCode(2)
+        }
+        let actual: String
+        do {
+            actual = try ModelArtifactVerifier.canonicalArtifactHash(directory: URL(fileURLWithPath: artifactPath))
+            guard actual == expected else {
+                FileHandle.standardError.write(Data("model artifact hash mismatch for \(artifactPath)\n".utf8))
+                throw ExitCode(2)
+            }
+        } catch let exit as ExitCode {
+            throw exit
+        } catch {
+            FileHandle.standardError.write(Data("model artifact verification failed for \(artifactPath): \(error)\n".utf8))
+            throw ExitCode(2)
+        }
+        if resolved.donorMode || joiningCoordinator {
+            try await runModelCatalogPreflight(
+                resolved,
+                modelPath: artifactPath,
+                actualArtifactSHA256: actual,
+                requireRecommendable: !resolved.donorMode,
+                staticInputs: staticInputs,
+                artifactResolver: artifactResolver
+            )
+        }
+    }
+
+    private static func runModelCatalogPreflight(
+        _ resolved: AppConfig,
+        modelPath: String,
+        actualArtifactSHA256: String,
+        requireRecommendable: Bool,
+        staticInputs: AutotuneStaticInputs,
+        artifactResolver: CachedModelArtifactResolver
+    ) async throws {
+        guard let key = resolved.modelCatalogKey,
+              let modelID = resolved.modelCatalogModelID,
+              let revision = resolved.modelCatalogRevision,
+              let catalogSHA256 = resolved.modelCatalogSHA256,
+              let version = resolved.modelCatalogVersion,
+              let storedCatalogHash = resolved.modelCatalogHash,
+              !key.isEmpty,
+              !modelID.isEmpty,
+              !revision.isEmpty,
+              !catalogSHA256.isEmpty,
+              !version.isEmpty,
+              !storedCatalogHash.isEmpty
+        else {
+            FileHandle.standardError.write(Data("model_artifact_sha256 requires model_catalog_* provenance from autotune --recommend --apply\n".utf8))
+            throw ExitCode(2)
+        }
+
+        let expectedPublicModel: String
+        if requireRecommendable {
+            let rateCard = await staticInputs.loadRateCard()
+            guard let match = rateCard.value.rowForRecommendation(modelKey: key) else {
+                FileHandle.standardError.write(Data("model artifact is not admitted by the signed rate card\n".utf8))
+                throw ExitCode(2)
+            }
+            expectedPublicModel = match.key
+        } else {
+            expectedPublicModel = key
+        }
+        guard resolved.model == expectedPublicModel else {
+            FileHandle.standardError.write(Data("model must match model_catalog_key/rate-card key from autotune --recommend --apply\n".utf8))
+            throw ExitCode(2)
+        }
+
+        let expectedSnapshot = artifactResolver
+            .snapshotURL(modelID: modelID, revision: revision)
+            .standardizedFileURL
+            .path
+        let configuredSnapshot = URL(fileURLWithPath: modelPath).standardizedFileURL.path
+        guard configuredSnapshot == expectedSnapshot else {
+            FileHandle.standardError.write(Data("model must be the catalog-pinned Hugging Face snapshot path\n".utf8))
+            throw ExitCode(2)
+        }
+
+        let catalog = await staticInputs.loadCandidateCatalog()
+        let actualCatalogHash = AutotuneStaticInputs.candidateCatalogSHA256(bytes: catalog.selectedBytes)
+        guard catalog.value.version == version, actualCatalogHash == storedCatalogHash else {
+            FileHandle.standardError.write(Data("model catalog provenance is stale; rerun autotune --recommend --apply\n".utf8))
+            throw ExitCode(2)
+        }
+        guard let row = catalog.value.rows[key],
+              (requireRecommendable ? row.runtimeStatus == "recommendable" : ["candidate", "listed", "recommendable"].contains(row.runtimeStatus)),
+              row.modelID == modelID,
+              row.modelRevision == revision,
+              row.modelSHA256 == catalogSHA256,
+              catalogSHA256 == actualArtifactSHA256
+        else {
+            FileHandle.standardError.write(Data("model artifact is not admitted by the signed candidate catalog\n".utf8))
+            throw ExitCode(2)
+        }
+    }
+
     static func makeCoordinatorClient(
         noJoin: Bool,
+        donorMode: Bool = false,
         factory: () -> CoordinatorClient?
     ) -> CoordinatorClient? {
         guard !noJoin else { return nil }
+        guard !donorMode else { return nil }
         return factory()
     }
 
@@ -163,11 +289,13 @@ struct ServeCommand: AsyncParsableCommand {
         try Self.runSupportedModelsPreflight(&resolved)
         try Self.runDrainTimeoutPreflight(resolved)
         try Self.runServingKnobsPreflight(resolved)
+        try await Self.runModelArtifactPreflight(resolved, joiningCoordinator: !noJoin)
 
         printResolvedConfiguration(resolved)
 
         let modelRuntime = try await ModelRuntime(
             modelID: resolved.model,
+            modelLoadPath: resolved.modelArtifactPath,
             maxContextTokensOverride: resolved.maxContextOverride,
             kvBitsOverride: resolved.kvBitsOverride,
             maxBatch: resolved.maxConcurrencyOverride ?? 1,
@@ -205,7 +333,10 @@ struct ServeCommand: AsyncParsableCommand {
         await modelRuntime.setProviderStatus(providerStatus)
         let receiptKeyStore = KeychainReceiptKeyStore()
         let receiptRuntime = try Self.makeReceiptRuntime(config: resolved, keyStore: receiptKeyStore)
-        let coordinatorClient = Self.makeCoordinatorClient(noJoin: noJoin) {
+        if resolved.donorMode {
+            FileHandle.standardError.write(Data("DONOR MODE: coordinator join disabled; serving local HTTP only.\n".utf8))
+        }
+        let coordinatorClient = Self.makeCoordinatorClient(noJoin: noJoin, donorMode: resolved.donorMode) {
             CoordinatorClient(
                 config: resolved,
                 modelRuntime: modelRuntime,
@@ -315,7 +446,26 @@ struct StatusCommand: AsyncParsableCommand {
         )
         let status = try await LocalStatusClient.fetch(port: resolved.port)
         let latest = try? await SelfUpdate(currentVersion: CoordinatorClient.binaryVersion, releasesAPIURL: nil).latestVersionCached()
-        print(LocalStatusFormatter.format(status, latestVersion: latest, ownerLogin: OwnerFileReader.githubLogin(configPath: resolved.configPath)))
+        let staleSince = await Self.staleRecommendationSince(providerID: resolved.providerID)
+        print(LocalStatusFormatter.format(status, latestVersion: latest, ownerLogin: OwnerFileReader.githubLogin(configPath: resolved.configPath), donorMode: resolved.donorMode, staleRecommendationSince: staleSince))
+    }
+
+    static func staleRecommendationSince(
+        staticInputs: AutotuneStaticInputs = AutotuneStaticInputs(),
+        fingerprint: MachineFingerprint = MachineFingerprinter().sample(),
+        providerID: String? = nil,
+        hmacSecretURL: URL = AutotuneHMACSecretStore.defaultPath,
+        stateURL: URL = RecommendationStateStore.defaultURL,
+        now: Date = Date()
+    ) async -> Date? {
+        await RecommendationFreshnessChecker(
+            staticInputs: staticInputs,
+            fingerprint: fingerprint,
+            providerID: providerID,
+            hmacSecretURL: hmacSecretURL,
+            stateURL: stateURL,
+            now: now
+        ).staleRecommendationSince()
     }
 }
 
@@ -331,12 +481,18 @@ struct SelfTestCommand: AsyncParsableCommand {
     @Option(help: "HuggingFace model identifier or local model path. Overrides MACPROVIDER_MODEL and config file model.")
     var model: String?
 
+    static func modelLoadPath(for resolved: AppConfig) -> String? {
+        resolved.modelArtifactPath
+    }
+
     func run() async throws {
         let resolved = try ConfigLoader.load(
             cli: CLIOverrides(model: model, configPath: config)
         )
+        try await ServeCommand.runModelArtifactPreflight(resolved, joiningCoordinator: false)
         let runtime = try await ModelRuntime(
             modelID: resolved.model,
+            modelLoadPath: Self.modelLoadPath(for: resolved),
             maxContextTokensOverride: resolved.maxContextOverride
         )
         guard await runtime.isLoaded else {
@@ -367,6 +523,15 @@ struct UpdateCommand: AsyncParsableCommand {
             currentVersion: CoordinatorClient.binaryVersion,
             releasesAPIURL: releasesAPIURL
         ).run(checkOnly: check)
+        let resolvedConfig = try? ConfigLoader.load(cli: CLIOverrides())
+        if let staleSince = await RecommendationFreshnessChecker(providerID: resolvedConfig?.providerID).staleRecommendationSince() {
+            FileHandle.standardError.write(Data("""
+
+            Recommendation stale: recommendation inputs changed since \(ISO8601DateFormatter.autotuneInternet.string(from: staleSince)).
+            Run: macprovider-cli autotune --recommend
+
+            """.utf8))
+        }
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -259,6 +259,7 @@ actor ModelRuntime: ModelRuntimeServing {
 
     init(
         modelID: String?,
+        modelLoadPath: String? = nil,
         maxContextTokensOverride: Int? = nil,
         kvBitsOverride: Int? = nil,
         maxBatch: Int = 1,
@@ -289,7 +290,7 @@ actor ModelRuntime: ModelRuntimeServing {
             return
         }
 
-        let configuration = Self.configuration(for: modelID)
+        let configuration = Self.configuration(for: modelLoadPath ?? modelID)
         let container = try await LLMModelFactory.shared.loadContainer(configuration: configuration)
         self.currentContainer = container
 

--- a/phase3-binary/Sources/macprovider-cli/RecommendationEmitter.swift
+++ b/phase3-binary/Sources/macprovider-cli/RecommendationEmitter.swift
@@ -32,6 +32,14 @@ struct RecommendationCore {
     var ttftP95MS: Double
     var replicates: Int
     var partial: Bool = false
+    var modelArtifactPath: String? = nil
+    var modelArtifactSHA256: String? = nil
+    var modelCatalogKey: String? = nil
+    var modelCatalogModelID: String? = nil
+    var modelCatalogRevision: String? = nil
+    var modelCatalogSHA256: String? = nil
+    var modelCatalogVersion: String? = nil
+    var modelCatalogHash: String? = nil
 }
 
 struct InfeasibleEntry {

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -620,7 +620,7 @@ struct LocalStatusClient {
 }
 
 struct LocalStatusFormatter {
-    static func format(_ status: [String: Any], latestVersion: String? = nil, ownerLogin: String? = nil) -> String {
+    static func format(_ status: [String: Any], latestVersion: String? = nil, ownerLogin: String? = nil, donorMode: Bool = false, staleRecommendationSince: Date? = nil) -> String {
         let capacity = status["capacity"] as? [String: Any] ?? [:]
         let coordinator = status["coordinator"] as? [String: Any] ?? [:]
         let version = status["binary_version"] as? String ?? CoordinatorClient.binaryVersion
@@ -636,6 +636,10 @@ struct LocalStatusFormatter {
         } else {
             latestLine = "unknown (run 'macprovider-cli update --check')"
         }
+        let donorBadge = donorMode ? " DONOR MODE" : ""
+        let staleBlock = staleRecommendationSince.map {
+            "\nRecommendation stale: recommendation inputs changed since \(ISO8601DateFormatter.autotuneInternet.string(from: $0)).\nRun: macprovider-cli autotune --recommend\n"
+        } ?? ""
 
         return """
         macprovider-cli v\(version)
@@ -643,7 +647,7 @@ struct LocalStatusFormatter {
         Local:
           Provider ID:  \(string(status["provider_id"]))
           Owner: \(ownerLine)
-          Model:       \(string(status["model"]))
+          Model:       \(string(status["model"]))\(donorBadge)
           Status:      \(string(status["status"]))
           Uptime:      \(uptime)
           Requests:    \(status["requests_total"] ?? 0) served, \(status["errors_total"] ?? 0) errors
@@ -661,6 +665,7 @@ struct LocalStatusFormatter {
         Update:
           Current:     v\(version)
           Latest:      \(latestLine)
+        \(staleBlock)
         """
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift
@@ -147,4 +147,47 @@ final class AutotuneCommandTests: XCTestCase {
         let command = try AutotuneCommand.parse(["--restart-foreground", "--dry-run"])
         XCTAssertTrue(command.restartForeground)
     }
+
+    func testRecommendFlagsParse() throws {
+        let command = try AutotuneCommand.parse([
+            "--recommend",
+            "--freshness-check",
+            "--donor-mode",
+            "--electricity-usd-per-kwh", "0.21",
+            "--assumed-utilization", "0.75",
+        ])
+
+        XCTAssertTrue(command.recommend)
+        XCTAssertTrue(command.freshnessCheck)
+        XCTAssertTrue(command.donorMode)
+        XCTAssertEqual(command.electricityUSDPerKWH, 0.21)
+        XCTAssertEqual(command.assumedUtilization, 0.75)
+    }
+
+    func testRecommendUsesSpec023FourKProbeContext() throws {
+        let command = try AutotuneCommand.parse(["--recommend"])
+
+        XCTAssertEqual(command.targetContext, 2_000)
+        XCTAssertEqual(AutotuneCommand.spec023RecommendationProbeContext, 4_000)
+    }
+
+    func testFreshnessCheckRequiresRecommend() {
+        XCTAssertThrowsError(try AutotuneCommand.parse([
+            "--freshness-check",
+        ]))
+    }
+
+    func testRecommendRejectsNegativeElectricityPrice() {
+        XCTAssertThrowsError(try AutotuneCommand.parse([
+            "--recommend",
+            "--electricity-usd-per-kwh", "-0.01",
+        ]))
+    }
+
+    func testRecommendRejectsUtilizationOutsideUnitRange() {
+        XCTAssertThrowsError(try AutotuneCommand.parse([
+            "--recommend",
+            "--assumed-utilization", "1.01",
+        ]))
+    }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -1,0 +1,969 @@
+import CryptoKit
+import Darwin
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class AutotuneRecommendTests: XCTestCase {
+    func testRecommendationSelectsPaidEligibleRowAboveThreshold() throws {
+        let request = try makeRequest()
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(result.recommendedModel, "qwen3-coder-30b-a3b-instruct")
+        XCTAssertFalse(result.warnings.contains(.noEligiblePaidModel))
+        XCTAssertGreaterThan(try XCTUnwrap(result.candidates.first?.expectedNetUSDPerHour), 0.0050)
+    }
+
+    func testAllRowsFailingEligibilityEmitsNoEligibleWarning() throws {
+        var request = try makeRequest()
+        request.benchmarks = [:]
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertNil(result.recommendedModel)
+        XCTAssertTrue(result.warnings.contains(.noEligiblePaidModel))
+        XCTAssertTrue(result.humanTranscript().contains("Recommendation: donor mode only"))
+        XCTAssertTrue(result.humanTranscript().contains("Best compatible option: none"))
+    }
+
+    func testBelowThresholdEmitsRecommendationBelowThreshold() throws {
+        var request = try makeRequest()
+        request.rateCard.rows["qwen3-coder-30b-a3b-instruct"]?.completionRatePerMtok = 1_000
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertNil(result.recommendedModel)
+        XCTAssertTrue(result.warnings.contains(.recommendationBelowThreshold))
+    }
+
+    func testDonorModeDoesNotTurnListedRowsIntoPaidDefaults() throws {
+        var request = try makeRequest(modelKey: "qwen3-32b")
+        request.donorMode = true
+        request.hardware.bandwidthTier = .a
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertNil(result.recommendedModel)
+        XCTAssertTrue(AutotuneRecommendEngine.donorModeAdmitted(
+            modelKey: "qwen3-32b",
+            candidate: request.candidateCatalog.rows["qwen3-32b"],
+            request: request
+        ))
+    }
+
+    func testNormalRecommendationTranscriptNamesListedDonorCompatibleFallback() throws {
+        var request = try makeRequest(modelKey: "qwen3-32b")
+        request.donorMode = false
+        request.hardware.bandwidthTier = .a
+        request.demandRank.rows["qwen3-32b"]?.recommendable = false
+        request.candidateCatalog.rows["qwen3-32b"]?.runtimeStatus = "listed"
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertNil(result.recommendedModel)
+        XCTAssertEqual(result.donorFallbackModel, "qwen3-32b")
+        XCTAssertTrue(result.humanTranscript().contains("Best compatible option: qwen3-32b"))
+    }
+
+    func testDonorFallbackOutsideTopFiveIsStillCarriedForApplyLookup() throws {
+        var request = try makeRequest()
+        request.donorMode = true
+        let candidateTemplate = try XCTUnwrap(request.candidateCatalog.rows.values.first)
+        let demandTemplate = try XCTUnwrap(request.demandRank.rows.values.first)
+        let rateTemplate = try XCTUnwrap(request.rateCard.rows.values.first)
+        request.candidateCatalog.rows = [:]
+        request.demandRank.rows = [:]
+        request.rateCard.rows = [:]
+        request.benchmarks = [:]
+
+        for index in 0..<6 {
+            let key = "blocked-high-raw-\(index)"
+            var candidate = candidateTemplate
+            candidate.runtimeStatus = "blocked"
+            request.candidateCatalog.rows[key] = candidate
+            var demand = demandTemplate
+            demand.demandWeight = 10
+            demand.rank = index + 1
+            demand.recommendable = true
+            request.demandRank.rows[key] = demand
+            request.rateCard.rows[key] = RateCardProjection.Row(
+                promptRatePerMtok: rateTemplate.promptRatePerMtok,
+                completionRatePerMtok: 9_000_000,
+                providerShareBPS: rateTemplate.providerShareBPS,
+                globalMultiplierPPM: rateTemplate.globalMultiplierPPM
+            )
+            request.benchmarks[key] = CandidateBenchmark(
+                modelKey: key,
+                sustainedTPS: 1_000,
+                ttftMS: 1,
+                swapDetected: false,
+                thermalThrottleDetected: false,
+                artifactSHA256: candidate.modelSHA256!,
+                modelArtifactPath: "/tmp/\(key)",
+                benchmarkID: "bench-\(key)",
+                generatedAt: request.generatedAt,
+                candidateCatalogSHA256: request.candidateCatalogSHA256,
+                binaryVersion: request.hardware.binaryVersion,
+                modelID: candidate.modelID,
+                hardwareIdentityHash: request.hardware.hardwareIdentityHash
+            )
+        }
+
+        let donorKey = "listed-donor-fallback"
+        var donorCandidate = candidateTemplate
+        donorCandidate.runtimeStatus = "listed"
+        request.candidateCatalog.rows[donorKey] = donorCandidate
+        var donorDemand = demandTemplate
+        donorDemand.demandWeight = 0.1
+        donorDemand.rank = 99
+        donorDemand.recommendable = false
+        request.demandRank.rows[donorKey] = donorDemand
+        request.rateCard.rows[donorKey] = rateTemplate
+        request.benchmarks[donorKey] = CandidateBenchmark(
+            modelKey: donorKey,
+            sustainedTPS: 100,
+            ttftMS: 1,
+            swapDetected: false,
+            thermalThrottleDetected: false,
+            artifactSHA256: donorCandidate.modelSHA256!,
+            modelArtifactPath: "/tmp/\(donorKey)",
+            benchmarkID: "bench-\(donorKey)",
+            generatedAt: request.generatedAt,
+            candidateCatalogSHA256: request.candidateCatalogSHA256,
+            binaryVersion: request.hardware.binaryVersion,
+            modelID: donorCandidate.modelID,
+            hardwareIdentityHash: request.hardware.hardwareIdentityHash
+        )
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertNil(result.recommendedModel)
+        XCTAssertEqual(result.candidates.count, 5)
+        XCTAssertFalse(result.candidates.contains { $0.catalogKey == donorKey })
+        XCTAssertEqual(result.donorFallbackModel, donorKey)
+        XCTAssertEqual(result.donorFallbackCandidate?.catalogKey, donorKey)
+        XCTAssertFalse(result.jsonString().contains("donorFallbackCandidate"))
+        XCTAssertFalse(result.jsonString().contains("donor_fallback_candidate"))
+    }
+
+    func testDonorModeRejectsBlockedRows() throws {
+        var request = try makeRequest(modelKey: "google-gemma-4-26b-a4b-it")
+        request.donorMode = true
+        request.candidateCatalog.rows["google-gemma-4-26b-a4b-it"]?.modelRevision = String(repeating: "6", count: 40)
+        request.candidateCatalog.rows["google-gemma-4-26b-a4b-it"]?.modelSHA256 = String(repeating: "f", count: 64)
+
+        XCTAssertFalse(AutotuneRecommendEngine.donorModeAdmitted(
+            modelKey: "google-gemma-4-26b-a4b-it",
+            candidate: request.candidateCatalog.rows["google-gemma-4-26b-a4b-it"],
+            request: request
+        ))
+    }
+
+    func testDonorTranscriptDoesNotNameBlockedRowsAsCompatible() throws {
+        var request = try makeRequest(modelKey: "google-gemma-4-26b-a4b-it")
+        request.donorMode = true
+        request.candidateCatalog.rows["google-gemma-4-26b-a4b-it"]?.modelRevision = String(repeating: "6", count: 40)
+        request.candidateCatalog.rows["google-gemma-4-26b-a4b-it"]?.modelSHA256 = String(repeating: "f", count: 64)
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertNil(result.recommendedModel)
+        XCTAssertTrue(result.humanTranscript().contains("Best compatible option: none"))
+        XCTAssertFalse(result.humanTranscript().contains("Best compatible option: google-gemma-4-26b-a4b-it"))
+    }
+
+    func testCachedBenchmarkAdmissionRejectsEveryMismatch() throws {
+        let request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        let baseline = try XCTUnwrap(request.benchmarks[modelKey])
+        XCTAssertTrue(AutotuneRecommendEngine.cachedBenchmarkAdmitted(baseline, request: request, modelKey: modelKey))
+
+        var catalogMismatch = baseline
+        catalogMismatch.candidateCatalogSHA256 = "mismatch"
+        XCTAssertFalse(AutotuneRecommendEngine.cachedBenchmarkAdmitted(catalogMismatch, request: request, modelKey: modelKey))
+
+        var binaryMismatch = baseline
+        binaryMismatch.binaryVersion = "other"
+        XCTAssertFalse(AutotuneRecommendEngine.cachedBenchmarkAdmitted(binaryMismatch, request: request, modelKey: modelKey))
+
+        var modelMismatch = baseline
+        modelMismatch.modelID = "other/model"
+        XCTAssertFalse(AutotuneRecommendEngine.cachedBenchmarkAdmitted(modelMismatch, request: request, modelKey: modelKey))
+
+        var artifactMismatch = baseline
+        artifactMismatch.artifactSHA256 = String(repeating: "0", count: 64)
+        XCTAssertFalse(AutotuneRecommendEngine.cachedBenchmarkAdmitted(artifactMismatch, request: request, modelKey: modelKey))
+
+        var hardwareMismatch = baseline
+        hardwareMismatch.hardwareIdentityHash = "other"
+        XCTAssertFalse(AutotuneRecommendEngine.cachedBenchmarkAdmitted(hardwareMismatch, request: request, modelKey: modelKey))
+
+        var stale = baseline
+        stale.generatedAt = request.generatedAt.addingTimeInterval(-(AutotuneRecommendEngine.maxBenchmarkAge + 1))
+        XCTAssertFalse(AutotuneRecommendEngine.cachedBenchmarkAdmitted(stale, request: request, modelKey: modelKey))
+    }
+
+    func testNoCoordinatorDefaultFallbackUnlessCandidateKeyIsDefault() throws {
+        let rateCard = try AutotuneStaticInputs.decodeRateCard(Data("""
+        {"version":"test","generated_at":"2026-07-01T00:00:00Z","usd_per_million_credits":1.0,"rows":{"default":{"prompt_rate_per_mtok":1,"completion_rate_per_mtok":1,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
+        """.utf8))
+
+        XCTAssertNil(rateCard.rowForRecommendation(modelKey: "qwen3-coder-30b-a3b-instruct"))
+        XCTAssertNil(rateCard.rowForRecommendation(modelKey: "DEFAULT"))
+        XCTAssertNil(rateCard.rowForRecommendation(modelKey: " default "))
+        XCTAssertNil(rateCard.rowForRecommendation(modelKey: "mlx-community/default-4bit"))
+        XCTAssertNotNil(rateCard.rowForRecommendation(modelKey: "default"))
+    }
+
+    func testNormalizedRateCardLookupRecordsNormalizedKey() throws {
+        let rateCard = try AutotuneStaticInputs.decodeRateCard(Data(AutotuneStaticInputs.bakedRateCardJSON.utf8))
+
+        let row = rateCard.rowForRecommendation(modelKey: "mlx-community/gpt-oss-20b-MXFP4-Q8")
+
+        XCTAssertEqual(row?.key, "openai/gpt-oss-20b")
+    }
+
+    func testNormalizedRecommendationKeepsCatalogKeyForBenchmarkLookup() throws {
+        let alias = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+        let normalized = "openai/gpt-oss-20b"
+        var request = try makeRequest(modelKey: normalized)
+        request.candidateCatalog.rows[alias] = request.candidateCatalog.rows.removeValue(forKey: normalized)
+        request.demandRank.rows[alias] = request.demandRank.rows.removeValue(forKey: normalized)
+        var benchmark = try XCTUnwrap(request.benchmarks.removeValue(forKey: normalized))
+        benchmark.modelKey = alias
+        benchmark.benchmarkID = "bench-alias"
+        request.benchmarks[alias] = benchmark
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(result.recommendedModel, normalized)
+        XCTAssertEqual(result.candidates.first?.model, normalized)
+        XCTAssertEqual(result.candidates.first?.catalogKey, alias)
+        XCTAssertEqual(result.benchmarkID, "bench-alias")
+        XCTAssertFalse(result.jsonString().contains("catalogKey"))
+        XCTAssertFalse(result.jsonString().contains("catalog_key"))
+    }
+
+    func testRecommendedCandidateOutsideTopFiveIsStillCarriedForApplyLookup() throws {
+        var request = try makeRequest()
+        let candidateTemplate = try XCTUnwrap(request.candidateCatalog.rows.values.first)
+        let demandTemplate = try XCTUnwrap(request.demandRank.rows.values.first)
+        let rateTemplate = try XCTUnwrap(request.rateCard.rows.values.first)
+        request.candidateCatalog.rows = [:]
+        request.demandRank.rows = [:]
+        request.rateCard.rows = [:]
+        request.benchmarks = [:]
+
+        for index in 0..<6 {
+            let key = "candidate-\(index)"
+            var candidate = candidateTemplate
+            candidate.modelID = "test/\(key)"
+            candidate.modelRevision = String(repeating: "\(index)", count: 40)
+            candidate.modelSHA256 = String(repeating: "a", count: 64)
+            candidate.runtimeStatus = "recommendable"
+            request.candidateCatalog.rows[key] = candidate
+            request.demandRank.rows[key] = demandTemplate
+            request.rateCard.rows[key] = rateTemplate
+            request.benchmarks[key] = CandidateBenchmark(
+                modelKey: key,
+                sustainedTPS: 100,
+                ttftMS: 1,
+                swapDetected: false,
+                thermalThrottleDetected: false,
+                artifactSHA256: candidate.modelSHA256!,
+                modelArtifactPath: "/tmp/\(key)",
+                benchmarkID: "bench-\(key)",
+                generatedAt: request.generatedAt,
+                candidateCatalogSHA256: request.candidateCatalogSHA256,
+                binaryVersion: request.hardware.binaryVersion,
+                modelID: candidate.modelID,
+                hardwareIdentityHash: request.hardware.hardwareIdentityHash
+            )
+        }
+
+        var foundDiversifiedSelectionOutsideTopFive = false
+        for seed in 0..<500 {
+            request.hardware.diversificationID = "seed-\(seed)"
+            let result = AutotuneRecommendEngine().recommend(request)
+            guard let recommendedModel = result.recommendedModel,
+                  let selected = result.selectedCandidate,
+                  selected.model == recommendedModel
+            else {
+                continue
+            }
+            if selected.rank > 5 {
+                foundDiversifiedSelectionOutsideTopFive = true
+                XCTAssertFalse(result.candidates.contains { $0.model == recommendedModel })
+                XCTAssertEqual(result.candidates.map(\.rank), [1, 2, 3, 4, 5])
+                XCTAssertFalse(result.jsonString().contains("selectedCandidate"))
+                XCTAssertFalse(result.jsonString().contains("selected_candidate"))
+                break
+            }
+        }
+        XCTAssertTrue(foundDiversifiedSelectionOutsideTopFive)
+    }
+
+    func testJSONCandidatesExcludeIneligibleDiagnosticsWhenEligibleRowsExist() throws {
+        let eligibleKey = "qwen3-coder-30b-a3b-instruct"
+        let diagnosticKey = "diagnostic-listed-row"
+        var request = try makeRequest(modelKey: eligibleKey)
+        var diagnosticRow = try XCTUnwrap(request.candidateCatalog.rows[eligibleKey])
+        diagnosticRow.runtimeStatus = "listed"
+        request.candidateCatalog.rows[diagnosticKey] = diagnosticRow
+        request.demandRank.rows[diagnosticKey] = DemandRank.Row(
+            demandWeight: 0.5,
+            rank: 2,
+            recommendable: false,
+            minProviderTarget: 0
+        )
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(result.candidates.map(\.catalogKey), [eligibleKey])
+    }
+
+    func testBandwidthTierOrderingAndDerivation() {
+        XCTAssertTrue(BandwidthTier.a.satisfies(minimum: .b))
+        XCTAssertFalse(BandwidthTier.b.satisfies(minimum: .a))
+        XCTAssertEqual(BandwidthTier.derive(chip: "Apple M4 Ultra"), .s)
+        XCTAssertEqual(BandwidthTier.derive(chip: "Apple M3 Max"), .a)
+        XCTAssertEqual(BandwidthTier.derive(chip: "Apple M5 Max"), .a)
+        XCTAssertEqual(BandwidthTier.derive(chip: "Apple M2 Max"), .b)
+        XCTAssertEqual(BandwidthTier.derive(chip: "Apple M2 Pro"), .b)
+    }
+
+    func testMinProviderTargetDoesNotAffectScoringOrEligibility() throws {
+        var request = try makeRequest()
+        let first = AutotuneRecommendEngine().recommend(request)
+        request.demandRank.rows["qwen3-coder-30b-a3b-instruct"]?.minProviderTarget = 999_999
+        let second = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(first.recommendedModel, second.recommendedModel)
+        XCTAssertEqual(first.candidates.first?.expectedNetUSDPerHour, second.candidates.first?.expectedNetUSDPerHour)
+    }
+
+    func testRecommendationIsDeterministicForSameDiversificationID() throws {
+        let request = try makeRequest()
+
+        let first = AutotuneRecommendEngine().recommend(request)
+        let second = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(first.recommendedModel, second.recommendedModel)
+        XCTAssertEqual(first.candidates, second.candidates)
+    }
+
+    func testJSONFieldOrderStartsWithLockedSchemaOrder() throws {
+        let result = AutotuneRecommendEngine().recommend(try makeRequest())
+        let json = result.jsonString()
+
+        XCTAssertTrue(json.hasPrefix(#"{"schema_version":"autotune_recommend.v1","generated_at":"#), json)
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""hardware":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""inputs":"#)?.lowerBound))
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""inputs":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""recommended_model":"#)?.lowerBound))
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""recommended_model":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""candidates":"#)?.lowerBound))
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""candidates":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""comparison":"#)?.lowerBound))
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""comparison":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""warnings":"#)?.lowerBound))
+    }
+
+    func testSignedStaticFallbackAndStaleWarnings() async throws {
+        let validFetched = Data(AutotuneStaticInputs.bakedDemandRankJSON
+            .replacingOccurrences(of: "baked-2026-07-01", with: "fetched-2026-07-10")
+            .replacingOccurrences(of: "2026-07-01T00:00:00Z", with: "2026-07-10T00:00:00Z")
+            .utf8)
+        let sidecar = Data(#"{"key_id":"streamvc-autotune-static-v1","alg":"ed25519","signature":"AA=="}"#.utf8)
+        let staleInputs = AutotuneStaticInputs(
+            fetch: { url in url.path.hasSuffix(".sig") ? sidecar : validFetched },
+            verifySignature: { _, _ in true },
+            now: { Self.date("2026-07-30T00:00:00Z") }
+        )
+
+        let stale = await staleInputs.loadDemandRank()
+
+        XCTAssertFalse(stale.usedFallback)
+        XCTAssertEqual(stale.value.version, "fetched-2026-07-10")
+        XCTAssertTrue(stale.warnings.contains(.demandRankStale))
+
+        let fallbackInputs = AutotuneStaticInputs(
+            fetch: { _ in validFetched },
+            verifySignature: { _, _ in false },
+            now: { Self.date("2026-07-30T00:00:00Z") }
+        )
+        let fallback = await fallbackInputs.loadDemandRank()
+        XCTAssertTrue(fallback.usedFallback)
+        XCTAssertTrue(fallback.warnings.contains(.demandRankFallbackUsed))
+    }
+
+    func testSignedStaticRejectsSidecarWithExtraFields() async throws {
+        let fetched = Data(AutotuneStaticInputs.bakedDemandRankJSON
+            .replacingOccurrences(of: "baked-2026-07-01", with: "fetched-2026-07-10")
+            .replacingOccurrences(of: "2026-07-01T00:00:00Z", with: "2026-07-10T00:00:00Z")
+            .utf8)
+        let sidecar = Data(#"{"key_id":"streamvc-autotune-static-v1","alg":"ed25519","signature":"AA==","extra":true}"#.utf8)
+        let inputs = AutotuneStaticInputs(
+            fetch: { url in url.path.hasSuffix(".sig") ? sidecar : fetched },
+            verifySignature: { _, _ in true },
+            now: { Self.date("2026-07-11T00:00:00Z") }
+        )
+
+        let selection = await inputs.loadDemandRank()
+
+        XCTAssertTrue(selection.usedFallback)
+        XCTAssertTrue(selection.warnings.contains(.demandRankFallbackUsed))
+    }
+
+    func testPinnedPublicKeyIsValidCurve25519SigningKey() {
+        let keyData = Data(base64Encoded: AutotuneStaticInputs.autotune_static_json_ed25519_v1)
+
+        XCTAssertEqual(keyData?.count, 32)
+        XCTAssertNotNil(try? Curve25519.Signing.PublicKey(rawRepresentation: try XCTUnwrap(keyData)))
+    }
+
+    func testCandidateCatalogHashChangesWithWhitespace() {
+        let compact = Data(AutotuneStaticInputs.bakedCandidateCatalogJSON.utf8)
+        let spaced = Data((AutotuneStaticInputs.bakedCandidateCatalogJSON + "\n").utf8)
+
+        XCTAssertNotEqual(
+            AutotuneStaticInputs.candidateCatalogSHA256(bytes: compact),
+            AutotuneStaticInputs.candidateCatalogSHA256(bytes: spaced)
+        )
+    }
+
+    func testCandidateCatalogRejectsUppercaseRevisionAndSHA() throws {
+        let json = """
+        {"version":"test","generated_at":"2026-07-01T00:00:00Z","source":"operator_curated_autotune_candidate_catalog","rows":{"model-a":{"model_id":"namespace/model","model_revision":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","model_sha256":"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB","min_ram_gb":1,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":1,"max_4k_ttft_ms":1000},"runtime_status":"recommendable"}}}
+        """
+
+        XCTAssertThrowsError(try AutotuneStaticInputs.decodeCandidateCatalog(Data(json.utf8)))
+    }
+
+    func testHFAssetRedirectAllowsKnownCDNAndStripsAuthorization() {
+        let session = URLSession.shared
+        let original = URL(string: "https://huggingface.co/mlx-community/model/resolve/rev/model.safetensors")!
+        let task = session.dataTask(with: original)
+        let response = HTTPURLResponse(
+            url: original,
+            statusCode: 302,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Location": "https://us.aws.cdn.hf.co/model.safetensors"]
+        )!
+        var newRequest = URLRequest(url: URL(string: "https://us.aws.cdn.hf.co/model.safetensors")!)
+        newRequest.setValue("Bearer secret", forHTTPHeaderField: "Authorization")
+
+        let waiter = expectation(description: "redirect completion")
+        var redirected: URLRequest?
+        HFAssetRedirectGuard().urlSession(
+            session,
+            task: task,
+            willPerformHTTPRedirection: response,
+            newRequest: newRequest
+        ) { request in
+            redirected = request
+            waiter.fulfill()
+        }
+        wait(for: [waiter], timeout: 1)
+        task.cancel()
+
+        XCTAssertEqual(redirected?.url?.host, "us.aws.cdn.hf.co")
+        XCTAssertNil(redirected?.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    func testHFAssetRedirectRejectsUnknownHost() {
+        let session = URLSession.shared
+        let original = URL(string: "https://huggingface.co/mlx-community/model/resolve/rev/model.safetensors")!
+        let task = session.dataTask(with: original)
+        let response = HTTPURLResponse(
+            url: original,
+            statusCode: 302,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Location": "https://evil.example.com/model.safetensors"]
+        )!
+        let newRequest = URLRequest(url: URL(string: "https://evil.example.com/model.safetensors")!)
+
+        let waiter = expectation(description: "redirect completion")
+        var redirected: URLRequest?
+        HFAssetRedirectGuard().urlSession(
+            session,
+            task: task,
+            willPerformHTTPRedirection: response,
+            newRequest: newRequest
+        ) { request in
+            redirected = request
+            waiter.fulfill()
+        }
+        wait(for: [waiter], timeout: 1)
+        task.cancel()
+
+        XCTAssertNil(redirected)
+    }
+
+    func testHMACIdentityUsesSeparateDomainsAndSecretFileIs0600() throws {
+        let dir = try tempDir()
+        let secretURL = dir.appendingPathComponent("autotune-hmac-secret")
+        let secret = try AutotuneHMACSecretStore(path: secretURL, randomBytes: { Data(repeating: 7, count: $0) }).loadOrCreate()
+        let fingerprint = MachineFingerprint(ramGB: 64, chip: "Apple M4 Pro", osVersion: "macOS 15", binaryVersion: "test")
+        let identity = HMACIdentity.derive(secret: secret, fingerprint: fingerprint)
+        let upgraded = MachineFingerprint(ramGB: 64, chip: "Apple M4 Pro", osVersion: "macOS 15.1", binaryVersion: "next")
+        let upgradedIdentity = HMACIdentity.derive(secret: secret, fingerprint: upgraded)
+        let providerIdentity = HMACIdentity.derive(secret: secret, fingerprint: fingerprint, providerID: "provider-a")
+        let providerUpgradeIdentity = HMACIdentity.derive(secret: secret, fingerprint: upgraded, providerID: "provider-a")
+        let otherProviderIdentity = HMACIdentity.derive(secret: secret, fingerprint: fingerprint, providerID: "provider-b")
+        let otherLocalIdentity = HMACIdentity.derive(secret: Data(repeating: 8, count: 32), fingerprint: fingerprint)
+
+        XCTAssertNotEqual(identity.diversificationID, identity.cacheIdentityHash)
+        XCTAssertEqual(identity.diversificationID, upgradedIdentity.diversificationID)
+        XCTAssertEqual(identity.cacheIdentityHash, upgradedIdentity.cacheIdentityHash)
+        XCTAssertEqual(providerIdentity.diversificationID, providerUpgradeIdentity.diversificationID)
+        XCTAssertNotEqual(providerIdentity.diversificationID, otherProviderIdentity.diversificationID)
+        XCTAssertNotEqual(identity.diversificationID, otherLocalIdentity.diversificationID)
+        var st = stat()
+        XCTAssertEqual(lstat(secretURL.path, &st), 0)
+        XCTAssertEqual(st.st_mode & 0o777, 0o600)
+    }
+
+    func testHMACSecretFileRotatesRecoverableRegularFileFailuresAndRejectsSymlink() throws {
+        let worldDir = try tempDir()
+        let worldURL = worldDir.appendingPathComponent("secret")
+        try Data(repeating: 1, count: 32).write(to: worldURL)
+        XCTAssertEqual(chmod(worldURL.path, 0o644), 0)
+        let worldSecret = try AutotuneHMACSecretStore(path: worldURL, randomBytes: { Data(repeating: 2, count: $0) }).loadOrCreate()
+        XCTAssertEqual(worldSecret, Data(repeating: 2, count: 32))
+        var st = stat()
+        XCTAssertEqual(lstat(worldURL.path, &st), 0)
+        XCTAssertEqual(st.st_mode & 0o777, 0o600)
+
+        let shortDir = try tempDir()
+        let shortURL = shortDir.appendingPathComponent("secret")
+        try Data(repeating: 1, count: 31).write(to: shortURL)
+        XCTAssertEqual(chmod(shortURL.path, 0o600), 0)
+        let shortSecret = try AutotuneHMACSecretStore(path: shortURL, randomBytes: { Data(repeating: 3, count: $0) }).loadOrCreate()
+        XCTAssertEqual(shortSecret, Data(repeating: 3, count: 32))
+
+        let symlinkDir = try tempDir()
+        let target = symlinkDir.appendingPathComponent("target")
+        let linkURL = symlinkDir.appendingPathComponent("secret")
+        try Data(repeating: 1, count: 32).write(to: target)
+        XCTAssertEqual(chmod(target.path, 0o600), 0)
+        XCTAssertEqual(symlink("target", linkURL.path), 0)
+        XCTAssertThrowsError(try AutotuneHMACSecretStore(path: linkURL).loadOrCreate())
+    }
+
+    func testModelArtifactHashRejectsSymlinkAndHardlink() throws {
+        let symlinkDir = try tempDir()
+        try Data("model".utf8).write(to: symlinkDir.appendingPathComponent("weights.bin"))
+        XCTAssertEqual(symlink("weights.bin", symlinkDir.appendingPathComponent("link.bin").path), 0)
+        XCTAssertThrowsError(try ModelArtifactVerifier.canonicalArtifactHash(directory: symlinkDir))
+
+        let hardlinkDir = try tempDir()
+        let original = hardlinkDir.appendingPathComponent("weights.bin")
+        let hardlink = hardlinkDir.appendingPathComponent("weights-copy.bin")
+        try Data("model".utf8).write(to: original)
+        guard link(original.path, hardlink.path) == 0 else {
+            throw XCTSkip("hardlinks are unavailable on this filesystem")
+        }
+        XCTAssertThrowsError(try ModelArtifactVerifier.canonicalArtifactHash(directory: hardlinkDir))
+    }
+
+    func testModelArtifactHashIsDeterministicForSameFiles() throws {
+        let first = try tempDir()
+        let second = try tempDir()
+        try Data("a".utf8).write(to: first.appendingPathComponent("a.bin"))
+        try Data("b".utf8).write(to: first.appendingPathComponent("b.bin"))
+        try Data("b".utf8).write(to: second.appendingPathComponent("b.bin"))
+        try Data("a".utf8).write(to: second.appendingPathComponent("a.bin"))
+
+        XCTAssertEqual(
+            try ModelArtifactVerifier.canonicalArtifactHash(directory: first),
+            try ModelArtifactVerifier.canonicalArtifactHash(directory: second)
+        )
+    }
+
+    func testModelArtifactHashIncludesHiddenFiles() throws {
+        let dir = try tempDir()
+        try Data("visible".utf8).write(to: dir.appendingPathComponent("weights.bin"))
+        let withoutHidden = try ModelArtifactVerifier.canonicalArtifactHash(directory: dir)
+        try Data("hidden".utf8).write(to: dir.appendingPathComponent(".weights.index"))
+
+        XCTAssertNotEqual(withoutHidden, try ModelArtifactVerifier.canonicalArtifactHash(directory: dir))
+    }
+
+    func testCachedArtifactResolverRequiresExactRevisionAndHash() throws {
+        let hub = try tempDir()
+        let revision = String(repeating: "a", count: 40)
+        let snapshot = hub
+            .appendingPathComponent("models--namespace--model", isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(revision, isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
+        let expected = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        let row = CandidateCatalog.Row(
+            modelID: "namespace/model",
+            modelRevision: revision,
+            modelSHA256: expected,
+            minRAMGB: 1,
+            minBandwidthTier: .c,
+            benchGate: CandidateCatalog.BenchGate(minSustainedTPS: 1, max4KTTFTMS: 1_000),
+            runtimeStatus: "recommendable",
+            notes: nil
+        )
+
+        let verified = try CachedModelArtifactResolver(hubRoot: hub).verifiedExistingArtifact(for: row)
+
+        XCTAssertEqual(verified.sha256, expected)
+        XCTAssertEqual(verified.modelArgument, snapshot.path)
+
+        var mismatch = row
+        mismatch.modelSHA256 = String(repeating: "0", count: 64)
+        XCTAssertThrowsError(try CachedModelArtifactResolver(hubRoot: hub).verifiedExistingArtifact(for: mismatch))
+    }
+
+    func testBenchmarkingFailsClosedOnArtifactHashMismatch() async throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        let row = try XCTUnwrap(request.candidateCatalog.rows[modelKey])
+        let revision = try XCTUnwrap(row.modelRevision)
+        let hub = try tempDir()
+        let snapshot = hub
+            .appendingPathComponent("models--mlx-community--Qwen3-Coder-30B-A3B-Instruct-4bit", isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(revision, isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("corrupt".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
+        request.benchmarks = [:]
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: CachedModelArtifactResolver(hubRoot: hub),
+            runnerFactory: { throw AutotuneRecommendError.invalidStaticJSON("runner should not start") }
+        )
+
+        do {
+            _ = try await benchmarker.benchmarks(
+                request: request,
+                targetContext: 4_000,
+                gateTTFTMS: 3_000,
+                replicates: 1,
+                port: 18080
+            )
+            XCTFail("artifact mismatch must fail closed")
+        } catch AutotuneRecommendError.invalidArtifact {
+            // expected
+        }
+    }
+
+    func testBenchmarkingRethrowsUnexpectedRunnerFailures() async throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        let row = try XCTUnwrap(request.candidateCatalog.rows[modelKey])
+        let revision = try XCTUnwrap(row.modelRevision)
+        let hub = try tempDir()
+        let snapshot = hub
+            .appendingPathComponent("models--mlx-community--Qwen3-Coder-30B-A3B-Instruct-4bit", isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(revision, isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
+        request.candidateCatalog.rows[modelKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        request.benchmarks = [:]
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: CachedModelArtifactResolver(hubRoot: hub),
+            runnerFactory: { throw AutotuneRecommendError.invalidStaticJSON("runner failed") }
+        )
+
+        do {
+            _ = try await benchmarker.benchmarks(
+                request: request,
+                targetContext: 4_000,
+                gateTTFTMS: 3_000,
+                replicates: 1,
+                port: 18080
+            )
+            XCTFail("unexpected benchmark infrastructure errors must fail closed")
+        } catch AutotuneRecommendError.invalidStaticJSON(let message) {
+            XCTAssertEqual(message, "runner failed")
+        }
+    }
+
+    func testBenchmarkingIncludesListedDonorCompatibleRowsBeforeDonorMode() async throws {
+        let modelKey = "qwen3-32b"
+        var request = try makeRequest(modelKey: modelKey)
+        request.donorMode = false
+        request.hardware.bandwidthTier = .a
+        request.demandRank.rows[modelKey]?.recommendable = false
+        request.candidateCatalog.rows[modelKey]?.runtimeStatus = "listed"
+        let row = try XCTUnwrap(request.candidateCatalog.rows[modelKey])
+        let revision = try XCTUnwrap(row.modelRevision)
+        let hub = try tempDir()
+        let resolver = CachedModelArtifactResolver(hubRoot: hub)
+        let snapshot = resolver.snapshotURL(modelID: row.modelID, revision: revision)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
+        request.candidateCatalog.rows[modelKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        request.benchmarks = [:]
+        let prober = RecordingStage1Prober(results: [
+            snapshot.path: .feasible(medianTPS: 12, p95TTFTMS: 900),
+        ])
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: resolver,
+            runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
+            prober: prober,
+            safetySampler: StaticProbeSafetySampler()
+        )
+
+        let benchmarks = try await benchmarker.benchmarks(
+            request: request,
+            targetContext: 4_000,
+            gateTTFTMS: 3_000,
+            replicates: 1,
+            port: 18080
+        )
+
+        XCTAssertNotNil(benchmarks[modelKey])
+        XCTAssertEqual(prober.probedModels, [snapshot.path])
+    }
+
+    func testProbeSafetyAssessmentFailsClosedOnUnavailableTelemetry() {
+        let unavailable = ProbeSafetyAssessment.assess(
+            before: ProbeSafetySample(pageouts: nil, thermalState: nil),
+            after: ProbeSafetySample(pageouts: nil, thermalState: nil)
+        )
+        XCTAssertTrue(unavailable.swapDetected)
+        XCTAssertTrue(unavailable.thermalThrottleDetected)
+
+        let safe = ProbeSafetyAssessment.assess(
+            before: ProbeSafetySample(pageouts: 10, thermalState: .nominal),
+            after: ProbeSafetySample(pageouts: 10, thermalState: .fair)
+        )
+        XCTAssertFalse(safe.swapDetected)
+        XCTAssertFalse(safe.thermalThrottleDetected)
+
+        let unsafe = ProbeSafetyAssessment.assess(
+            before: ProbeSafetySample(pageouts: 10, thermalState: .nominal),
+            after: ProbeSafetySample(pageouts: 11, thermalState: .serious)
+        )
+        XCTAssertTrue(unsafe.swapDetected)
+        XCTAssertTrue(unsafe.thermalThrottleDetected)
+    }
+
+    func testElectricityInputReducesExpectedNet() throws {
+        var request = try makeRequest()
+        let withoutElectricity = AutotuneRecommendEngine().recommend(request)
+        request.electricityUSDPerKWH = 1.0
+
+        let withElectricity = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertLessThan(
+            try XCTUnwrap(withElectricity.candidates.first?.expectedNetUSDPerHour),
+            try XCTUnwrap(withoutElectricity.candidates.first?.expectedNetUSDPerHour)
+        )
+    }
+
+    func testBothMarketFallbacksProduceLowConfidence() throws {
+        var request = try makeRequest()
+        request.warnings = [.rateCardFallbackUsed, .demandRankFallbackUsed]
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(result.candidates.first?.confidence, "low")
+    }
+
+    func testStaleMarketInputsProduceLowConfidence() throws {
+        var request = try makeRequest()
+        request.warnings = [.candidateCatalogStale]
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(result.candidates.first?.confidence, "low")
+    }
+
+    func testStatusStaleHelperComparesStoredAndCurrentState() async throws {
+        let dir = try tempDir()
+        let secretURL = dir.appendingPathComponent("secret")
+        try Data(repeating: 9, count: 32).write(to: secretURL)
+        XCTAssertEqual(chmod(secretURL.path, 0o600), 0)
+        let stateURL = dir.appendingPathComponent("last-recommendation.json")
+        try Data("""
+        {"generated_at":"2026-07-01T00:00:00Z","rate_card_version":"old","demand_rank_version":"baked-2026-07-01","candidate_catalog_version":"baked-2026-07-01","candidate_catalog_sha256":"old","benchmark_id":"bench-1","benchmark_generated_at":"2026-07-01T00:00:00Z","binary_version":"test","hardware_identity_hash":"old","recommended_model":"qwen3-coder-30b-a3b-instruct"}
+        """.utf8).write(to: stateURL)
+        let staticInputs = AutotuneStaticInputs(
+            fetch: { _ in throw AutotuneRecommendError.invalidStaticJSON("offline") },
+            now: { Self.date("2026-07-02T00:00:00Z") }
+        )
+        let fingerprint = MachineFingerprint(ramGB: 64, chip: "Apple M4 Pro", osVersion: "macOS 15", binaryVersion: "test")
+
+        let staleSince = await StatusCommand.staleRecommendationSince(
+            staticInputs: staticInputs,
+            fingerprint: fingerprint,
+            hmacSecretURL: secretURL,
+            stateURL: stateURL,
+            now: Self.date("2026-07-02T00:00:00Z")
+        )
+
+        XCTAssertEqual(staleSince, Optional(Self.date("2026-07-01T00:00:00Z")))
+    }
+
+    func testStatusStaleHelperMarksStoredStateStaleWhenSecretCannotBeReused() async throws {
+        let dir = try tempDir()
+        let secretURL = dir.appendingPathComponent("secret")
+        try Data(repeating: 9, count: 32).write(to: secretURL)
+        XCTAssertEqual(chmod(secretURL.path, 0o644), 0)
+        let stateURL = dir.appendingPathComponent("last-recommendation.json")
+        try Data("""
+        {"generated_at":"2026-07-01T00:00:00Z","rate_card_version":"baked-2026-07-01","demand_rank_version":"baked-2026-07-01","candidate_catalog_version":"baked-2026-07-01","candidate_catalog_sha256":"old","benchmark_id":"bench-1","benchmark_generated_at":"2026-07-01T00:00:00Z","binary_version":"test","hardware_identity_hash":"old","recommended_model":"qwen3-coder-30b-a3b-instruct"}
+        """.utf8).write(to: stateURL)
+        let staticInputs = AutotuneStaticInputs(
+            fetch: { _ in throw AutotuneRecommendError.invalidStaticJSON("offline") },
+            now: { Self.date("2026-07-02T00:00:00Z") }
+        )
+        let fingerprint = MachineFingerprint(ramGB: 64, chip: "Apple M4 Pro", osVersion: "macOS 15", binaryVersion: "test")
+
+        let staleSince = await StatusCommand.staleRecommendationSince(
+            staticInputs: staticInputs,
+            fingerprint: fingerprint,
+            hmacSecretURL: secretURL,
+            stateURL: stateURL,
+            now: Self.date("2026-07-02T00:00:00Z")
+        )
+
+        XCTAssertEqual(staleSince, Optional(Self.date("2026-07-01T00:00:00Z")))
+    }
+
+    func testStatusFreshnessUsesConfiguredProviderIDIdentity() async throws {
+        let dir = try tempDir()
+        let secretURL = dir.appendingPathComponent("secret")
+        let secret = Data(repeating: 9, count: 32)
+        try secret.write(to: secretURL)
+        XCTAssertEqual(chmod(secretURL.path, 0o600), 0)
+        let stateURL = dir.appendingPathComponent("last-recommendation.json")
+        let staticInputs = AutotuneStaticInputs(
+            fetch: { _ in throw AutotuneRecommendError.invalidStaticJSON("offline") },
+            now: { Self.date("2026-07-02T00:00:00Z") }
+        )
+        let fingerprint = MachineFingerprint(ramGB: 64, chip: "Apple M4 Pro", osVersion: "macOS 15", binaryVersion: "test")
+        let catalogSHA = AutotuneStaticInputs.candidateCatalogSHA256(bytes: Data(AutotuneStaticInputs.bakedCandidateCatalogJSON.utf8))
+        let identity = HMACIdentity.derive(secret: secret, fingerprint: fingerprint, providerID: "provider-a")
+        try Data("""
+        {"generated_at":"2026-07-02T00:00:00Z","rate_card_version":"baked-2026-07-01","demand_rank_version":"baked-2026-07-01","candidate_catalog_version":"baked-2026-07-01","candidate_catalog_sha256":"\(catalogSHA)","benchmark_id":"bench-1","benchmark_generated_at":"2026-07-02T00:00:00Z","binary_version":"test","hardware_identity_hash":"\(identity.cacheIdentityHash)","recommended_model":"qwen3-coder-30b-a3b-instruct"}
+        """.utf8).write(to: stateURL)
+
+        let staleSince = await StatusCommand.staleRecommendationSince(
+            staticInputs: staticInputs,
+            fingerprint: fingerprint,
+            providerID: "provider-a",
+            hmacSecretURL: secretURL,
+            stateURL: stateURL,
+            now: Self.date("2026-07-02T00:00:00Z")
+        )
+        let staleWithDifferentProvider = await StatusCommand.staleRecommendationSince(
+            staticInputs: staticInputs,
+            fingerprint: fingerprint,
+            providerID: "provider-b",
+            hmacSecretURL: secretURL,
+            stateURL: stateURL,
+            now: Self.date("2026-07-02T00:00:00Z")
+        )
+
+        XCTAssertNil(staleSince)
+        XCTAssertEqual(staleWithDifferentProvider, Optional(Self.date("2026-07-02T00:00:00Z")))
+    }
+
+    private func makeRequest(modelKey: String = "qwen3-coder-30b-a3b-instruct") throws -> AutotuneRecommendRequest {
+        var demand = try AutotuneStaticInputs.decodeDemandRank(Data(AutotuneStaticInputs.bakedDemandRankJSON.utf8))
+        var catalog = try AutotuneStaticInputs.decodeCandidateCatalog(Data(AutotuneStaticInputs.bakedCandidateCatalogJSON.utf8))
+        var rateCard = try AutotuneStaticInputs.decodeRateCard(Data(AutotuneStaticInputs.bakedRateCardJSON.utf8))
+        demand.rows = demand.rows.filter { $0.key == modelKey }
+        catalog.rows = catalog.rows.filter { $0.key == modelKey }
+        rateCard.rows = rateCard.rows.filter { $0.key == modelKey }
+
+        if modelKey == "google-gemma-4-26b-a4b-it" {
+            rateCard.rows[modelKey] = RateCardProjection.Row(
+                promptRatePerMtok: 60_000,
+                completionRatePerMtok: 120_000,
+                providerShareBPS: 9_000,
+                globalMultiplierPPM: 1_000_000
+            )
+        }
+
+        let catalogSHA = AutotuneStaticInputs.candidateCatalogSHA256(bytes: Data(AutotuneStaticInputs.bakedCandidateCatalogJSON.utf8))
+        let generatedAt = Self.date("2026-07-02T00:00:00Z")
+        let hardware = AutotuneRecommendHardware(
+            machine: "Mac-test",
+            chip: "Apple M4 Pro",
+            memoryGB: 64,
+            bandwidthTier: .c,
+            osVersion: "macOS 15",
+            binaryVersion: "test-bin",
+            diversificationID: "diversification",
+            hardwareIdentityHash: "hardware"
+        )
+        let candidate = try XCTUnwrap(catalog.rows[modelKey])
+        let benchmark = CandidateBenchmark(
+            modelKey: modelKey,
+            sustainedTPS: 100,
+            ttftMS: max(1, candidate.benchGate.max4KTTFTMS - 1),
+            swapDetected: false,
+            thermalThrottleDetected: false,
+            artifactSHA256: candidate.modelSHA256 ?? String(repeating: "f", count: 64),
+            modelArtifactPath: "/tmp/\(modelKey)",
+            benchmarkID: "bench-\(modelKey)",
+            generatedAt: generatedAt,
+            candidateCatalogSHA256: catalogSHA,
+            binaryVersion: hardware.binaryVersion,
+            modelID: candidate.modelID,
+            hardwareIdentityHash: hardware.hardwareIdentityHash
+        )
+        return AutotuneRecommendRequest(
+            hardware: hardware,
+            demandRank: demand,
+            candidateCatalog: catalog,
+            candidateCatalogSHA256: catalogSHA,
+            rateCard: rateCard,
+            benchmarks: [modelKey: benchmark],
+            warnings: [],
+            generatedAt: generatedAt,
+            electricityUSDPerKWH: nil,
+            assumedUtilization: 1.0,
+            availabilityHoursPerDay: 24,
+            donorMode: false
+        )
+    }
+
+    private static func date(_ raw: String) -> Date {
+        ISO8601DateFormatter.autotuneInternet.date(from: raw)!
+    }
+
+    private func tempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macprovider-autotune-recommend-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        return dir
+    }
+}
+
+private final class RecordingStage1Prober: Stage1Probing {
+    private let results: [String: Stage1ProbeResult]
+    private(set) var probedModels: [String] = []
+
+    init(results: [String: Stage1ProbeResult]) {
+        self.results = results
+    }
+
+    func probe(
+        model: String,
+        port: Int,
+        runner: Stage1ProviderRunning,
+        targetContext: Int,
+        gateTTFTMS: Int,
+        replicates: Int
+    ) async throws -> Stage1ProbeResult {
+        probedModels.append(model)
+        return results[model] ?? .infeasible(reason: "missing stub probe result", nErr: 1)
+    }
+}
+
+private struct StaticProbeSafetySampler: ProbeSafetySampling {
+    func sample() -> ProbeSafetySample {
+        ProbeSafetySample(pageouts: 10, thermalState: .nominal)
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ConfigApplierTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConfigApplierTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import MacProviderCore
 import XCTest
@@ -13,6 +14,8 @@ final class ConfigApplierTests: XCTestCase {
         XCTAssertEqual(applied.backupPath.lastPathComponent, "config.yaml.bak-1718712345-0")
         XCTAssertEqual(try String(contentsOf: applied.backupPath), sampleConfig())
         XCTAssertTrue(applied.summary.contains("backup at \(applied.backupPath.path)"))
+        XCTAssertEqual(try fileMode(applied.backupPath) & 0o777, 0o600)
+        XCTAssertEqual(try fileMode(fixture.configURL) & 0o777, 0o600)
     }
 
     func testApplyIncrementsCounterWhenBackupExists() throws {
@@ -87,6 +90,72 @@ final class ConfigApplierTests: XCTestCase {
 
         let post = try String(contentsOf: fixture.configURL)
         XCTAssertFalse(post.contains("kv_bits:"))
+    }
+
+    func testApplyWritesArtifactHashAndConfigLoaderReadsIt() throws {
+        let fixture = try ConfigFixture()
+        try fixture.writeConfig(sampleConfig())
+        let artifactSHA = String(repeating: "a", count: 64)
+        var recommendation = recommendation()
+        recommendation.model = "test-public-model"
+        recommendation.modelArtifactPath = "/tmp/macprovider-test-snapshot"
+        recommendation.modelArtifactSHA256 = artifactSHA
+
+        _ = try fixture.applier().apply(recommendation: recommendation, now: fixture.now)
+
+        let post = try String(contentsOf: fixture.configURL)
+        XCTAssertTrue(post.contains("model: test-public-model\n"))
+        XCTAssertTrue(post.contains("model_artifact_path: /tmp/macprovider-test-snapshot\n"))
+        XCTAssertTrue(post.contains("model_artifact_sha256: \(artifactSHA)\n"))
+        let loaded = try ConfigLoader.load(
+            cli: CLIOverrides(configPath: fixture.configURL.path),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in post }
+        )
+        XCTAssertEqual(loaded.model, "test-public-model")
+        XCTAssertEqual(loaded.modelArtifactPath, "/tmp/macprovider-test-snapshot")
+        XCTAssertEqual(loaded.modelArtifactSHA256, artifactSHA)
+    }
+
+    func testApplyWritesDonorCatalogBindingAndConfigLoaderReadsIt() throws {
+        let fixture = try ConfigFixture()
+        try fixture.writeConfig(sampleConfig())
+        let artifactSHA = String(repeating: "b", count: 64)
+        let catalogHash = String(repeating: "c", count: 64)
+        var recommendation = recommendation()
+        recommendation.model = "test-model"
+        recommendation.modelArtifactPath = "/tmp/macprovider-test-snapshot"
+        recommendation.modelArtifactSHA256 = artifactSHA
+        recommendation.modelCatalogKey = "test-model"
+        recommendation.modelCatalogModelID = "test/model"
+        recommendation.modelCatalogRevision = String(repeating: "1", count: 40)
+        recommendation.modelCatalogSHA256 = artifactSHA
+        recommendation.modelCatalogVersion = "test-catalog"
+        recommendation.modelCatalogHash = catalogHash
+
+        _ = try fixture.applier().apply(recommendation: recommendation, now: fixture.now, donorMode: true)
+
+        let post = try String(contentsOf: fixture.configURL)
+        XCTAssertTrue(post.contains("model_catalog_key: test-model\n"))
+        XCTAssertTrue(post.contains("model_catalog_model_id: test/model\n"))
+        XCTAssertTrue(post.contains("model_catalog_revision: \(String(repeating: "1", count: 40))\n"))
+        XCTAssertTrue(post.contains("model_catalog_sha256: \(artifactSHA)\n"))
+        XCTAssertTrue(post.contains("model_catalog_version: test-catalog\n"))
+        XCTAssertTrue(post.contains("model_catalog_hash: \(catalogHash)\n"))
+        let loaded = try ConfigLoader.load(
+            cli: CLIOverrides(configPath: fixture.configURL.path),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in post }
+        )
+        XCTAssertTrue(loaded.donorMode)
+        XCTAssertEqual(loaded.modelCatalogKey, "test-model")
+        XCTAssertEqual(loaded.modelCatalogModelID, "test/model")
+        XCTAssertEqual(loaded.modelCatalogRevision, String(repeating: "1", count: 40))
+        XCTAssertEqual(loaded.modelCatalogSHA256, artifactSHA)
+        XCTAssertEqual(loaded.modelCatalogVersion, "test-catalog")
+        XCTAssertEqual(loaded.modelCatalogHash, catalogHash)
     }
 
     func testApplyIsIdempotent() throws {
@@ -199,6 +268,38 @@ final class ConfigApplierTests: XCTestCase {
         XCTAssertEqual(loaded.maxConcurrencyOverride, 1)
     }
 
+    func testApplyDonorModeWritesConfigAndSummary() throws {
+        let fixture = try ConfigFixture()
+        try fixture.writeConfig(sampleConfig())
+
+        let applied = try fixture.applier().apply(recommendation: recommendation(), now: fixture.now, donorMode: true)
+
+        let post = try String(contentsOf: fixture.configURL)
+        XCTAssertTrue(post.contains("donor_mode: true\n"))
+        XCTAssertTrue(applied.summary.contains("donor_mode=true"))
+        let loaded = try ConfigLoader.load(cli: CLIOverrides(configPath: fixture.configURL.path), environment: [:])
+        XCTAssertTrue(loaded.donorMode)
+    }
+
+    func testApplyDonorModeRendersForNewConfig() throws {
+        let fixture = try ConfigFixture()
+
+        _ = try fixture.applier().apply(recommendation: recommendation(), now: fixture.now, donorMode: true)
+
+        let post = try String(contentsOf: fixture.configURL)
+        XCTAssertTrue(post.contains("donor_mode: true\n"))
+    }
+
+    func testConfigLoaderReadsDonorModeFromEnvironment() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: ["MACPROVIDER_DONOR_MODE": "true"],
+            fileExists: { _ in false }
+        )
+
+        XCTAssertTrue(config.donorMode)
+    }
+
     func testLaunchdRestartHintIncludesAllRequiredSubstrings() {
         let hint = RecommendationEmitter.launchdRestartHint()
 
@@ -247,7 +348,11 @@ final class ConfigApplierTests: XCTestCase {
 
     private func nonOwnedLines(_ text: String) -> [String] {
         let ownedKeys: Set<String> = [
-            "model", "kv_bits", "max_context_override", "max_concurrency_override",
+            "model", "model_artifact_sha256", "model_catalog_key", "model_catalog_model_id",
+            "model_artifact_path", "model_catalog_revision", "model_catalog_sha256",
+            "model_catalog_version", "model_catalog_hash", "kv_bits", "max_context_override",
+            "max_concurrency_override",
+            "donor_mode",
         ]
         return text.split(separator: "\n", omittingEmptySubsequences: false).compactMap { sub in
             let line = String(sub)
@@ -259,6 +364,12 @@ final class ConfigApplierTests: XCTestCase {
             }
             return isOwned ? nil : line
         }
+    }
+
+    private func fileMode(_ url: URL) throws -> mode_t {
+        var st = stat()
+        XCTAssertEqual(lstat(url.path, &st), 0)
+        return st.st_mode
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
@@ -49,6 +49,18 @@ final class ServeCommandTests: XCTestCase {
         XCTAssertTrue(factoryInvoked)
     }
 
+    func testDonorModeSkipsCoordinatorClientInstantiation() {
+        var factoryInvoked = false
+
+        let client = ServeCommand.makeCoordinatorClient(noJoin: false, donorMode: true) {
+            factoryInvoked = true
+            return nil
+        }
+
+        XCTAssertNil(client)
+        XCTAssertFalse(factoryInvoked)
+    }
+
     func testReceiptBuilderDisabledByDefault() throws {
         var config = AppConfig.defaults()
         config.providerID = "provider-a"
@@ -86,5 +98,250 @@ final class ServeCommandTests: XCTestCase {
 
         XCTAssertNotNil(runtime.builder)
         XCTAssertEqual(runtime.publicKeyBase64, Data(current.publicKey.rawRepresentation).base64EncodedString())
+    }
+
+    func testNoJoinModelArtifactPreflightAcceptsMatchingLocalSnapshotHash() async throws {
+        let snapshot = try makeSnapshot()
+        let expected = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        var config = AppConfig.defaults()
+        config.model = "test-public-model"
+        config.modelArtifactPath = snapshot.path
+        config.modelArtifactSHA256 = expected
+
+        try await ServeCommand.runModelArtifactPreflight(config, joiningCoordinator: false)
+    }
+
+    func testSelfTestUsesVerifiedArtifactPathForRuntimeLoad() {
+        var config = AppConfig.defaults()
+        config.model = "test-public-model"
+        config.modelArtifactPath = "/tmp/macprovider-test-snapshot"
+
+        XCTAssertEqual(SelfTestCommand.modelLoadPath(for: config), "/tmp/macprovider-test-snapshot")
+    }
+
+    func testCoordinatorJoinRequiresCatalogBindingForVerifiedArtifact() async throws {
+        let snapshot = try makeSnapshot()
+        let expected = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        var config = AppConfig.defaults()
+        config.model = "test-public-model"
+        config.modelArtifactPath = snapshot.path
+        config.modelArtifactSHA256 = expected
+
+        do {
+            try await ServeCommand.runModelArtifactPreflight(config, joiningCoordinator: true)
+            XCTFail("coordinator-joining paid mode must require catalog provenance")
+        } catch {
+            // expected
+        }
+    }
+
+    func testCoordinatorJoinRequiresVerifiedModelArtifactMetadata() async throws {
+        var config = AppConfig.defaults()
+        config.model = "test-public-model"
+
+        do {
+            try await ServeCommand.runModelArtifactPreflight(config, joiningCoordinator: true)
+            XCTFail("coordinator-joining paid mode must require a verified artifact hash")
+        } catch {
+            // expected
+        }
+    }
+
+    func testDonorModeRequiresVerifiedModelArtifactHash() async throws {
+        var config = AppConfig.defaults()
+        config.donorMode = true
+        config.model = "/tmp/arbitrary-model"
+
+        do {
+            try await ServeCommand.runModelArtifactPreflight(config)
+            XCTFail("donor mode must require an artifact hash")
+        } catch {
+            // expected
+        }
+    }
+
+    func testDonorModeRequiresCatalogBindingForVerifiedArtifact() async throws {
+        let snapshot = try makeSnapshot()
+        let expected = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        var config = AppConfig.defaults()
+        config.donorMode = true
+        config.model = "test-public-model"
+        config.modelArtifactPath = snapshot.path
+        config.modelArtifactSHA256 = expected
+
+        do {
+            try await ServeCommand.runModelArtifactPreflight(config)
+            XCTFail("donor mode must require catalog provenance")
+        } catch {
+            // expected
+        }
+    }
+
+    func testDonorModeAcceptsCatalogBoundSnapshot() async throws {
+        try await assertCatalogBoundSnapshotPreflight(runtimeStatus: "listed", donorMode: true)
+    }
+
+    func testCoordinatorJoinAcceptsCatalogBoundRecommendableSnapshot() async throws {
+        try await assertCatalogBoundSnapshotPreflight(runtimeStatus: "recommendable", donorMode: false)
+    }
+
+    func testCoordinatorJoinAcceptsNormalizedPublicKeyForCatalogBoundSnapshot() async throws {
+        try await assertCatalogBoundSnapshotPreflight(
+            runtimeStatus: "recommendable",
+            donorMode: false,
+            catalogKey: "mlx-community/gpt-oss-20b-MXFP4-Q8",
+            configuredModel: "openai/gpt-oss-20b",
+            rateCardKey: "openai/gpt-oss-20b"
+        )
+    }
+
+    func testCoordinatorJoinRejectsCatalogBoundListedSnapshot() async throws {
+        do {
+            try await assertCatalogBoundSnapshotPreflight(runtimeStatus: "listed", donorMode: false)
+            XCTFail("paid coordinator join must require a recommendable catalog row")
+        } catch {
+            // expected
+        }
+    }
+
+    func testCoordinatorJoinRejectsPublicModelKeyMismatchForCatalogBoundSnapshot() async throws {
+        do {
+            try await assertCatalogBoundSnapshotPreflight(
+                runtimeStatus: "recommendable",
+                donorMode: false,
+                catalogKey: "test-model",
+                configuredModel: "different-public-model",
+                rateCardKey: "test-model"
+            )
+            XCTFail("paid coordinator join must bind public model key to verified catalog provenance")
+        } catch {
+            // expected
+        }
+    }
+
+    private func assertCatalogBoundSnapshotPreflight(runtimeStatus: String, donorMode: Bool) async throws {
+        try await assertCatalogBoundSnapshotPreflight(
+            runtimeStatus: runtimeStatus,
+            donorMode: donorMode,
+            catalogKey: "test-model",
+            configuredModel: nil,
+            rateCardKey: "test-model"
+        )
+    }
+
+    private func assertCatalogBoundSnapshotPreflight(
+        runtimeStatus: String,
+        donorMode: Bool,
+        catalogKey: String,
+        configuredModel: String?,
+        rateCardKey: String
+    ) async throws {
+        let hub = try tempDir()
+        let resolver = CachedModelArtifactResolver(hubRoot: hub)
+        let key = catalogKey
+        let modelID = "test/model"
+        let revision = String(repeating: "1", count: 40)
+        let snapshot = resolver.snapshotURL(modelID: modelID, revision: revision)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("model.safetensors"))
+        try Data("{}".utf8).write(to: snapshot.appendingPathComponent("config.json"))
+        let artifactSHA = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        let catalogJSON = """
+        {"version":"test-catalog","generated_at":"2026-07-02T00:00:00Z","source":"operator_curated_autotune_candidate_catalog","rows":{"\(key)":{"model_id":"\(modelID)","model_revision":"\(revision)","model_sha256":"\(artifactSHA)","min_ram_gb":1,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":1,"max_4k_ttft_ms":1000},"runtime_status":"\(runtimeStatus)"}}}
+        """
+        let rateCardJSON = """
+        {"version":"test-rate-card","generated_at":"2026-07-02T00:00:00Z","usd_per_million_credits":1.0,"rows":{"\(rateCardKey)":{"prompt_rate_per_mtok":1,"completion_rate_per_mtok":1,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
+        """
+        let catalogBytes = Data(catalogJSON.utf8)
+        let rateCardBytes = Data(rateCardJSON.utf8)
+        let staticInputs = AutotuneStaticInputs(
+            fetch: { url in
+                if url.host == "coordinator.streamvc.live" {
+                    return rateCardBytes
+                }
+                if url.path.hasSuffix(".sig") {
+                    return Data(#"{"key_id":"streamvc-autotune-static-v1","alg":"ed25519","signature":"AA=="}"#.utf8)
+                }
+                return catalogBytes
+            },
+            verifySignature: { _, _ in true },
+            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-07-02T12:00:00Z")! }
+        )
+        var config = AppConfig.defaults()
+        config.donorMode = donorMode
+        config.model = configuredModel ?? key
+        config.modelArtifactPath = snapshot.path
+        config.modelArtifactSHA256 = artifactSHA
+        config.modelCatalogKey = key
+        config.modelCatalogModelID = modelID
+        config.modelCatalogRevision = revision
+        config.modelCatalogSHA256 = artifactSHA
+        config.modelCatalogVersion = "test-catalog"
+        config.modelCatalogHash = AutotuneStaticInputs.candidateCatalogSHA256(bytes: catalogBytes)
+
+        try await ServeCommand.runModelArtifactPreflight(
+            config,
+            joiningCoordinator: true,
+            staticInputs: staticInputs,
+            artifactResolver: resolver
+        )
+    }
+
+    func testModelArtifactPreflightRejectsMismatch() async throws {
+        let snapshot = try makeSnapshot()
+        var config = AppConfig.defaults()
+        config.model = snapshot.path
+        config.modelArtifactSHA256 = String(repeating: "b", count: 64)
+
+        do {
+            try await ServeCommand.runModelArtifactPreflight(config)
+            XCTFail("artifact mismatch must fail")
+        } catch {
+            // expected
+        }
+    }
+
+    func testModelArtifactPreflightRequiresLocalPathWhenHashSet() async throws {
+        var config = AppConfig.defaults()
+        config.model = "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit"
+        config.modelArtifactSHA256 = String(repeating: "a", count: 64)
+
+        do {
+            try await ServeCommand.runModelArtifactPreflight(config)
+            XCTFail("artifact hash must require a local path")
+        } catch {
+            // expected
+        }
+    }
+
+    func testModelArtifactPreflightRequiresHashWhenArtifactPathSet() async throws {
+        let snapshot = try makeSnapshot()
+        var config = AppConfig.defaults()
+        config.model = "test-public-model"
+        config.modelArtifactPath = snapshot.path
+
+        do {
+            try await ServeCommand.runModelArtifactPreflight(config, joiningCoordinator: false)
+            XCTFail("artifact path must require a verification hash")
+        } catch {
+            // expected
+        }
+    }
+
+    private func makeSnapshot() throws -> URL {
+        let root = try tempDir()
+        try Data("weights".utf8).write(to: root.appendingPathComponent("model.safetensors"))
+        try Data("{}".utf8).write(to: root.appendingPathComponent("config.json"))
+        return root
+    }
+
+    private func tempDir() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ServeCommandTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        return root
     }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift
@@ -62,6 +62,29 @@ final class StatusCommandTests: XCTestCase {
         XCTAssertTrue(output.contains("Owner: (unclaimed — run `macprovider-cli claim`)"), output)
     }
 
+    func testStatusShowsDonorModeBadge() {
+        let output = LocalStatusFormatter.format(
+            status(providerID: "provider-a"),
+            latestVersion: nil,
+            donorMode: true
+        )
+
+        XCTAssertTrue(output.contains("Model:       model-a DONOR MODE"), output)
+    }
+
+    func testStatusShowsStaleRecommendationWarning() {
+        let staleSince = ISO8601DateFormatter.autotuneInternet.date(from: "2026-07-01T00:00:00Z")!
+
+        let output = LocalStatusFormatter.format(
+            status(providerID: "provider-a"),
+            latestVersion: nil,
+            staleRecommendationSince: staleSince
+        )
+
+        XCTAssertTrue(output.contains("Recommendation stale: recommendation inputs changed since 2026-07-01T00:00:00Z."), output)
+        XCTAssertTrue(output.contains("Run: macprovider-cli autotune --recommend"), output)
+    }
+
     private func makeFixture(prefix: String) throws -> StatusFixture {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -38,6 +38,7 @@ NO_LAUNCHD="${MACPROVIDER_NO_LAUNCHD:-0}"
 TMPDIR_PATH=""
 LAUNCHD_INSTALLED=0
 MANUAL_PID=""
+SKIP_PROVIDER_START=0
 
 log() { printf "[macprovider-install] %s\n" "$*"; }
 die() {
@@ -958,6 +959,154 @@ coordinator_url: "$(yaml_escape "$coordinator_url")"
 provider_id: "$(yaml_escape "$provider_id")"
 port: $PORT
 EOF
+  chmod 600 "$CONFIG_PATH" "$PROVIDER_ID_PATH" 2>/dev/null || true
+}
+
+read_config_model() {
+  [ -f "$CONFIG_PATH" ] || return 1
+  awk -F: '
+    /^model:/ {
+      value=$0
+      sub(/^model:[[:space:]]*/, "", value)
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "$CONFIG_PATH"
+}
+
+read_config_artifact_sha() {
+  [ -f "$CONFIG_PATH" ] || return 1
+  awk -F: '
+    /^model_artifact_sha256:/ {
+      value=$0
+      sub(/^model_artifact_sha256:[[:space:]]*/, "", value)
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "$CONFIG_PATH"
+}
+
+read_config_artifact_path() {
+  [ -f "$CONFIG_PATH" ] || return 1
+  awk -F: '
+    /^model_artifact_path:/ {
+      value=$0
+      sub(/^model_artifact_path:[[:space:]]*/, "", value)
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "$CONFIG_PATH"
+}
+
+read_config_donor_mode() {
+  [ -f "$CONFIG_PATH" ] || return 1
+  awk -F: '
+    /^donor_mode:/ {
+      value=$0
+      sub(/^donor_mode:[[:space:]]*/, "", value)
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "$CONFIG_PATH"
+}
+
+run_autotune_recommend_apply() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "Would run paid-yield recommendation before service start."
+    return 0
+  fi
+  if [ ! -x "$INSTALL_DIR/macprovider-cli" ]; then
+    die 5 "installed macprovider-cli missing before autotune recommendation"
+  fi
+  log "Running paid-yield recommendation before service start."
+  if "$INSTALL_DIR/macprovider-cli" autotune --recommend --apply --config "$CONFIG_PATH"; then
+    recommended_model="$(read_config_model || true)"
+    artifact_path="$(read_config_artifact_path || true)"
+    artifact_sha="$(read_config_artifact_sha || true)"
+    if [ -n "$recommended_model" ] && [ -n "$artifact_path" ] && [ -n "$artifact_sha" ]; then
+      case "$artifact_path" in
+        /*)
+          if prompt_yes_no "Start provider with $recommended_model? [Y/n]" "Y"; then
+            model="$recommended_model"
+            log "Recommendation selected verified model: $model (artifact: $artifact_path)"
+            return 0
+          fi
+          SKIP_PROVIDER_START=1
+          log "Provider start declined. macprovider-cli is installed, but the provider service will not be started."
+          return 0
+          ;;
+      esac
+    fi
+    log "No paid model currently clears the minimum net-yield threshold on this Mac."
+    if prompt_yes_no "Enable donor mode? [y/N]" "N"; then
+      log "Applying donor-mode configuration."
+      "$INSTALL_DIR/macprovider-cli" autotune --recommend --apply --donor-mode --config "$CONFIG_PATH" \
+        || die 6 "donor-mode recommendation failed before service start"
+      recommended_model="$(read_config_model || true)"
+      artifact_path="$(read_config_artifact_path || true)"
+      artifact_sha="$(read_config_artifact_sha || true)"
+      if [ -n "$recommended_model" ] && [ -n "$artifact_path" ] && [ -n "$artifact_sha" ]; then
+        case "$artifact_path" in
+          /*)
+            model="$recommended_model"
+            log "Donor mode selected verified model: $model (artifact: $artifact_path)"
+            SKIP_PROVIDER_START=1
+            log "Donor-mode configuration applied. Provider service will not be started automatically."
+            return 0
+            ;;
+        esac
+      fi
+      die 6 "donor mode did not apply a verified local model artifact before service start"
+    fi
+    SKIP_PROVIDER_START=1
+    log "Donor mode declined. macprovider-cli is installed, but the provider service will not be started."
+    return 0
+  fi
+  die 6 "autotune recommendation failed before service start"
+}
+
+use_fresh_recommendation_if_available() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    return 1
+  fi
+  if [ ! -x "$INSTALL_DIR/macprovider-cli" ] || [ ! -f "$CONFIG_PATH" ]; then
+    return 1
+  fi
+
+  if "$INSTALL_DIR/macprovider-cli" autotune --recommend --freshness-check --config "$CONFIG_PATH" >/dev/null; then
+    recommended_model="$(read_config_model || true)"
+    artifact_path="$(read_config_artifact_path || true)"
+    artifact_sha="$(read_config_artifact_sha || true)"
+    donor_mode="$(read_config_donor_mode || true)"
+    if [ "$donor_mode" = "true" ]; then
+      SKIP_PROVIDER_START=1
+      log "Stored donor-mode recommendation is fresh; provider service will not be started automatically."
+      return 0
+    fi
+    if [ -n "$recommended_model" ] && [ -n "$artifact_path" ] && [ -n "$artifact_sha" ]; then
+      case "$artifact_path" in
+        /*)
+          model="$recommended_model"
+          log "Stored paid-yield recommendation is fresh; skipping re-tune."
+          log "Using verified model from existing config: $model (artifact: $artifact_path)"
+          return 0
+          ;;
+      esac
+    fi
+    log "Stored recommendation is fresh but config lacks a verified local model; re-running recommendation."
+    return 1
+  else
+    rc=$?
+    if [ "$rc" -eq 10 ]; then
+      log "Stored recommendation is stale or missing; running recommendation."
+      return 1
+    fi
+    die 6 "recommendation freshness check failed before service start"
+  fi
 }
 
 install_binary() {
@@ -2035,6 +2184,8 @@ print_autotune_handoff() {
   provider_id="$1"
   printf "To tune throughput / latency parameters for your specific Mac, run:\n"
   printf "  macprovider-cli autotune --provider-id %s\n" "$provider_id"
+  printf "To refresh the paid-model recommendation after install or update, run:\n"
+  printf "  macprovider-cli autotune --recommend --apply\n"
 }
 
 main() {
@@ -2077,7 +2228,18 @@ main() {
   check_path_hint
   clear_quarantine
   ensure_port_free
-  write_config "$model" "$provider_id" "$coordinator_url"
+  if ! use_fresh_recommendation_if_available; then
+    write_config "$model" "$provider_id" "$coordinator_url"
+    run_autotune_recommend_apply
+  fi
+  if [ "$SKIP_PROVIDER_START" -eq 1 ]; then
+    log "Install complete without starting a provider service."
+    log "To re-check paid-yield recommendation later, run:"
+    log "  macprovider-cli autotune --recommend --apply"
+    log "To opt into local donor-mode testing, run:"
+    log "  macprovider-cli autotune --recommend --apply --donor-mode"
+    exit 0
+  fi
   install_plist "$model" "$provider_id" "$coordinator_url"
   install_watchdog "$coordinator_url"
   start_manual_service "$model" "$provider_id" "$coordinator_url"

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -530,6 +530,7 @@ func main() {
 		buyer.WithRequestLog(reqLogStore),
 		buyer.WithBilling(billingStore, cfg.Rewards),
 		buyer.WithBillingSnapshotID(snapshotID),
+		buyer.WithRateCardUSDPerMillionCredits(cfg.Stats.Rollup.UsdPerMillionCredits),
 		buyer.WithPreflight(func(provider pool.Provider, requestID string, estimatedTokens int, timeout time.Duration) (buyer.PreflightResult, bool, error) {
 			ack, ok, err := wsServer.Preflight(provider, requestID, estimatedTokens, timeout)
 			return buyer.PreflightResult{Accepted: ack.Accepted, Reason: ack.Reason}, ok, err
@@ -911,7 +912,7 @@ func reloadTier2Config(configPath string, startupTier2 config.Tier2Config, logge
 			logger.Error().Err(err).Msg("billing config reload rejected (snapshot + flag audit atomic)")
 			return
 		}
-		buyerServer.SetBillingConfig(cfg.Rewards, snapshotID)
+		buyerServer.SetBillingConfig(cfg.Rewards, snapshotID, cfg.Stats.Rollup.UsdPerMillionCredits)
 		billingStores[0].SetSettlementConfig(cfg.Settlement)
 		logger.Info().
 			Bool("billing.quarantine_resolution_force_void_enabled", cfg.Billing.QuarantineResolutionForceVoidEnabled).

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -197,6 +197,22 @@ server {
     }
 
     # ---------------------------------------------------------------------
+    # /v1/rate-card — public read-only recommendation projection per
+    # SPEC-023. Lives on the coordinator buyer mux (8443), not the
+    # provider/admin mux. This exposes only recommendation economics
+    # derived from the active rewards config and stats USD conversion.
+    # MUST be declared BEFORE the catch-all `location /v1/ { return 404; }`.
+    # ---------------------------------------------------------------------
+    location = /v1/rate-card {
+        proxy_pass http://127.0.0.1:8443/v1/rate-card$is_args$args;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 10s;
+    }
+
+    # ---------------------------------------------------------------------
     # SPEC-017 v0.1.8 Step 4.B — /v1/stats/* allow-through. Public
     # Network Stats API endpoints, mounted on the coordinator's
     # provider port (8444) per main.go:525. The dedicated vhost

--- a/phase4-coordinator/internal/billing/formula.go
+++ b/phase4-coordinator/internal/billing/formula.go
@@ -40,7 +40,7 @@ func RateFor(rateCard map[string]RateCardEntry, model string) RateCardEntry {
 		if entry, ok := rateCard[model]; ok {
 			return entry
 		}
-		normalized := normalizeModelKey(model)
+		normalized := NormalizeModelKey(model)
 		if normalized != model {
 			if entry, ok := rateCard[normalized]; ok {
 				slog.Info("rate_card_normalized", "event", "rate_card_normalized", "requested", model, "normalized", normalized, "matched", normalized)
@@ -60,7 +60,7 @@ func RateFor(rateCard map[string]RateCardEntry, model string) RateCardEntry {
 	return RateCardEntry{}
 }
 
-func normalizeModelKey(model string) string {
+func NormalizeModelKey(model string) string {
 	key := strings.ToLower(strings.TrimSpace(model))
 	namespace := ""
 	if slash := strings.IndexByte(key, '/'); slash >= 0 {

--- a/phase4-coordinator/internal/buyer/rate_card.go
+++ b/phase4-coordinator/internal/buyer/rate_card.go
@@ -1,0 +1,151 @@
+package buyer
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/billing"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+)
+
+type recommendationRateCardResponse struct {
+	Version              string                               `json:"version"`
+	GeneratedAt          string                               `json:"generated_at"`
+	USDPerMillionCredits float64                              `json:"usd_per_million_credits"`
+	Rows                 map[string]recommendationRateCardRow `json:"rows"`
+}
+
+type recommendationRateCardRow struct {
+	PromptRatePerMtok     int64 `json:"prompt_rate_per_mtok"`
+	CompletionRatePerMtok int64 `json:"completion_rate_per_mtok"`
+	ProviderShareBPS      int64 `json:"provider_share_bps"`
+	GlobalMultiplierPPM   int64 `json:"global_multiplier_ppm"`
+}
+
+type recommendationRateCardVersionProjection struct {
+	GlobalMultiplierPPM  int64                                `json:"global_multiplier_ppm"`
+	ProviderShareBPS     int64                                `json:"provider_share_bps"`
+	Rows                 map[string]recommendationRateCardRow `json:"rows"`
+	USDPerMillionCredits json.RawMessage                      `json:"usd_per_million_credits"`
+}
+
+func (s *Server) handleRateCard(w http.ResponseWriter, r *http.Request) {
+	rewards, usdPerMillionCredits := s.recommendationRateCardState()
+	rows := buildRecommendationRateCardRows(rewards)
+	version := recommendationRateCardVersion(rows, billing.ParseShareBps(rewards.ProviderShare), billing.ParseMultiplierPPM(rewards.GlobalMultiplier), usdPerMillionCredits)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(recommendationRateCardResponse{
+		Version:              version,
+		GeneratedAt:          s.now().UTC().Format(time.RFC3339),
+		USDPerMillionCredits: usdPerMillionCredits,
+		Rows:                 rows,
+	})
+}
+
+func buildRecommendationRateCardRows(rewards config.RewardsConfig) map[string]recommendationRateCardRow {
+	rows := make(map[string]recommendationRateCardRow, len(rewards.RateCard))
+	providerShareBPS := billing.ParseShareBps(rewards.ProviderShare)
+	globalMultiplierPPM := billing.ParseMultiplierPPM(rewards.GlobalMultiplier)
+	keys := make([]string, 0, len(rewards.RateCard))
+	for key := range rewards.RateCard {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		normalized := recommendationRateCardProjectionKey(key)
+		if normalized == "" {
+			continue
+		}
+		if normalized != key {
+			continue
+		}
+		rows[normalized] = recommendationRateCardRowFromEntry(rewards.RateCard[key], providerShareBPS, globalMultiplierPPM)
+	}
+	for _, key := range keys {
+		normalized := recommendationRateCardProjectionKey(key)
+		if normalized == "" {
+			continue
+		}
+		if _, exists := rows[normalized]; exists {
+			continue
+		}
+		rows[normalized] = recommendationRateCardRowFromEntry(rewards.RateCard[key], providerShareBPS, globalMultiplierPPM)
+	}
+	return rows
+}
+
+func recommendationRateCardProjectionKey(key string) string {
+	if key == "default" {
+		return key
+	}
+	normalized := billing.NormalizeModelKey(key)
+	if normalized == "default" {
+		return ""
+	}
+	return normalized
+}
+
+func recommendationRateCardRowFromEntry(entry config.RateCardEntry, providerShareBPS, globalMultiplierPPM int64) recommendationRateCardRow {
+	return recommendationRateCardRow{
+		PromptRatePerMtok:     entry.PromptCreditsPerMtok,
+		CompletionRatePerMtok: entry.CompletionCreditsPerMtok,
+		ProviderShareBPS:      providerShareBPS,
+		GlobalMultiplierPPM:   globalMultiplierPPM,
+	}
+}
+
+func recommendationRateCardVersion(rows map[string]recommendationRateCardRow, providerShareBPS, globalMultiplierPPM int64, usdPerMillionCredits float64) string {
+	b, err := canonicalRecommendationRateCardVersionBytes(rows, providerShareBPS, globalMultiplierPPM, usdPerMillionCredits)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func canonicalRecommendationRateCardVersionBytes(rows map[string]recommendationRateCardRow, providerShareBPS, globalMultiplierPPM int64, usdPerMillionCredits float64) ([]byte, error) {
+	keys := make([]string, 0, len(rows))
+	for key := range rows {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteString(`{"global_multiplier_ppm":`)
+	b.WriteString(strconv.FormatInt(globalMultiplierPPM, 10))
+	b.WriteString(`,"provider_share_bps":`)
+	b.WriteString(strconv.FormatInt(providerShareBPS, 10))
+	b.WriteString(`,"rows":{`)
+	for i, key := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		encodedKey, err := json.Marshal(key)
+		if err != nil {
+			return nil, err
+		}
+		row := rows[key]
+		b.Write(encodedKey)
+		b.WriteString(`:{"completion_rate_per_mtok":`)
+		b.WriteString(strconv.FormatInt(row.CompletionRatePerMtok, 10))
+		b.WriteString(`,"global_multiplier_ppm":`)
+		b.WriteString(strconv.FormatInt(row.GlobalMultiplierPPM, 10))
+		b.WriteString(`,"prompt_rate_per_mtok":`)
+		b.WriteString(strconv.FormatInt(row.PromptRatePerMtok, 10))
+		b.WriteString(`,"provider_share_bps":`)
+		b.WriteString(strconv.FormatInt(row.ProviderShareBPS, 10))
+		b.WriteByte('}')
+	}
+	b.WriteString(`},"usd_per_million_credits":`)
+	b.WriteString(strconv.FormatFloat(usdPerMillionCredits, 'f', -1, 64))
+	b.WriteByte('}')
+	return []byte(b.String()), nil
+}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -164,6 +164,7 @@ type Server struct {
 	billing           *billing.Store
 	billingCfg        config.RewardsConfig
 	billingSnapshotID int64
+	rateCardUSDPerM   float64
 	now               func() time.Time
 	version           string
 }
@@ -431,6 +432,16 @@ func WithBillingSnapshotID(snapshotID int64) Option {
 	}
 }
 
+func WithRateCardUSDPerMillionCredits(v float64) Option {
+	return func(s *Server) {
+		s.billingMu.Lock()
+		defer s.billingMu.Unlock()
+		if v >= 0 && !math.IsNaN(v) && !math.IsInf(v, 0) {
+			s.rateCardUSDPerM = v
+		}
+	}
+}
+
 func WithPoolCheckLimiter(maxEntries int, ttl time.Duration) Option {
 	return func(s *Server) {
 		if maxEntries > 0 {
@@ -442,17 +453,26 @@ func WithPoolCheckLimiter(maxEntries int, ttl time.Duration) Option {
 	}
 }
 
-func (s *Server) SetBillingConfig(cfg config.RewardsConfig, snapshotID int64) {
+func (s *Server) SetBillingConfig(cfg config.RewardsConfig, snapshotID int64, usdPerMillionCredits float64) {
 	s.billingMu.Lock()
 	defer s.billingMu.Unlock()
 	s.billingCfg = cfg
 	s.billingSnapshotID = snapshotID
+	if usdPerMillionCredits >= 0 && !math.IsNaN(usdPerMillionCredits) && !math.IsInf(usdPerMillionCredits, 0) {
+		s.rateCardUSDPerM = usdPerMillionCredits
+	}
 }
 
 func (s *Server) billingState() (*billing.Store, config.RewardsConfig, int64) {
 	s.billingMu.RLock()
 	defer s.billingMu.RUnlock()
 	return s.billing, s.billingCfg, s.billingSnapshotID
+}
+
+func (s *Server) recommendationRateCardState() (config.RewardsConfig, float64) {
+	s.billingMu.RLock()
+	defer s.billingMu.RUnlock()
+	return s.billingCfg, s.rateCardUSDPerM
 }
 
 func NewServer(registry *pool.Registry, logger zerolog.Logger, startedAt time.Time, opts ...Option) *Server {
@@ -490,9 +510,10 @@ func NewServer(registry *pool.Registry, logger zerolog.Logger, startedAt time.Ti
 		// loopback behavior (X-Real-IP / X-Forwarded-For honored only
 		// when r.RemoteAddr is 127.0.0.0/8 or ::1). WithTrustedProxies
 		// replaces this set. Issue #125.
-		trustedProxies: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8"), netip.MustParsePrefix("::1/128")},
-		now:            func() time.Time { return time.Now().UTC() },
-		version:        "dev",
+		trustedProxies:  []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8"), netip.MustParsePrefix("::1/128")},
+		rateCardUSDPerM: 1.0,
+		now:             func() time.Time { return time.Now().UTC() },
+		version:         "dev",
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -519,6 +540,7 @@ func (s *Server) Handler() http.Handler {
 	r := chi.NewRouter()
 	r.Get("/healthz", s.handleHealthz)
 	r.Get("/v1/models", s.handleModels)
+	r.Get("/v1/rate-card", s.handleRateCard)
 	r.Get("/v1/pool/check", s.handlePoolCheck)
 	r.Get("/v1/receipt-keys/{provider_id}", s.handleReceiptKeys)
 	// SPEC-015 §M.4 — SPEC-002 v1.6 candidate annotations.

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -3,14 +3,17 @@ package buyer_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -82,6 +85,305 @@ func TestModelsAggregatesUniqueReadyProviderModels(t *testing.T) {
 	if got.Data[1].ID != "model-b" || got.Data[1].ProviderCount != 1 || got.Data[1].MaxContextTokens != 120000 || got.Data[1].TotalSlots != 1 {
 		t.Fatalf("model-b aggregation wrong: %#v", got.Data[1])
 	}
+}
+
+func TestRateCardProjectionReturnsRecommendationSchema(t *testing.T) {
+	rewards := config.RewardsConfig{
+		GlobalMultiplier: 1.25,
+		ProviderShare:    0.875,
+		RateCard: map[string]config.RateCardEntry{
+			"model-a": {
+				PromptCreditsPerMtok:     100000,
+				CompletionCreditsPerMtok: 200000,
+			},
+			"mlx-community/gpt-oss-20b-MXFP4-Q8": {
+				PromptCreditsPerMtok:     300000,
+				CompletionCreditsPerMtok: 400000,
+			},
+			"openai/gpt-oss-20b": {
+				PromptCreditsPerMtok:     500000,
+				CompletionCreditsPerMtok: 600000,
+			},
+		},
+	}
+	server := buyer.NewServer(
+		pool.NewRegistry(nil),
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithBilling(nil, rewards),
+		buyer.WithRateCardUSDPerMillionCredits(1.5),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/rate-card", nil)
+	rr := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var got struct {
+		Version              string  `json:"version"`
+		GeneratedAt          string  `json:"generated_at"`
+		USDPerMillionCredits float64 `json:"usd_per_million_credits"`
+		Rows                 map[string]struct {
+			PromptRatePerMtok     int64 `json:"prompt_rate_per_mtok"`
+			CompletionRatePerMtok int64 `json:"completion_rate_per_mtok"`
+			ProviderShareBPS      int64 `json:"provider_share_bps"`
+			GlobalMultiplierPPM   int64 `json:"global_multiplier_ppm"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if got.Version == "" {
+		t.Fatalf("version empty: %s", rr.Body.String())
+	}
+	if _, err := time.Parse(time.RFC3339, got.GeneratedAt); err != nil {
+		t.Fatalf("generated_at not RFC3339: %q", got.GeneratedAt)
+	}
+	if got.USDPerMillionCredits != 1.5 {
+		t.Fatalf("usd_per_million_credits=%v want 1.5", got.USDPerMillionCredits)
+	}
+	row, ok := got.Rows["model-a"]
+	if !ok {
+		t.Fatalf("model-a row missing: %s", rr.Body.String())
+	}
+	if row.PromptRatePerMtok != 100000 || row.CompletionRatePerMtok != 200000 || row.ProviderShareBPS != 8750 || row.GlobalMultiplierPPM != 1250000 {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+	if _, ok := got.Rows["mlx-community/gpt-oss-20b-MXFP4-Q8"]; ok {
+		t.Fatalf("raw alias row leaked into recommendation projection: %s", rr.Body.String())
+	}
+	normalized, ok := got.Rows["openai/gpt-oss-20b"]
+	if !ok {
+		t.Fatalf("normalized gpt-oss row missing: %s", rr.Body.String())
+	}
+	if normalized.PromptRatePerMtok != 500000 || normalized.CompletionRatePerMtok != 600000 {
+		t.Fatalf("canonical row did not win normalized collision: %+v", normalized)
+	}
+	canonical := `{"global_multiplier_ppm":1250000,"provider_share_bps":8750,"rows":{"model-a":{"completion_rate_per_mtok":200000,"global_multiplier_ppm":1250000,"prompt_rate_per_mtok":100000,"provider_share_bps":8750},"openai/gpt-oss-20b":{"completion_rate_per_mtok":600000,"global_multiplier_ppm":1250000,"prompt_rate_per_mtok":500000,"provider_share_bps":8750}},"usd_per_million_credits":1.5}`
+	sum := sha256.Sum256([]byte(canonical))
+	if got.Version != hex.EncodeToString(sum[:]) {
+		t.Fatalf("version hash mismatch: got %s want hash of %s", got.Version, canonical)
+	}
+}
+
+func TestRateCardProjectionDoesNotNormalizeDefaultAliases(t *testing.T) {
+	rewards := config.RewardsConfig{
+		GlobalMultiplier: 1,
+		ProviderShare:    0.9,
+		RateCard: map[string]config.RateCardEntry{
+			"default": {
+				PromptCreditsPerMtok:     100000,
+				CompletionCreditsPerMtok: 200000,
+			},
+			"DEFAULT": {
+				PromptCreditsPerMtok:     300000,
+				CompletionCreditsPerMtok: 400000,
+			},
+			" default ": {
+				PromptCreditsPerMtok:     500000,
+				CompletionCreditsPerMtok: 600000,
+			},
+			"mlx-community/default-4bit": {
+				PromptCreditsPerMtok:     700000,
+				CompletionCreditsPerMtok: 800000,
+			},
+		},
+	}
+	server := buyer.NewServer(
+		pool.NewRegistry(nil),
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithBilling(nil, rewards),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/rate-card", nil)
+	rr := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var got struct {
+		Rows map[string]struct {
+			PromptRatePerMtok     int64 `json:"prompt_rate_per_mtok"`
+			CompletionRatePerMtok int64 `json:"completion_rate_per_mtok"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if len(got.Rows) != 1 {
+		t.Fatalf("rows=%#v, want only literal default", got.Rows)
+	}
+	row, ok := got.Rows["default"]
+	if !ok {
+		t.Fatalf("literal default row missing: %#v", got.Rows)
+	}
+	if row.PromptRatePerMtok != 100000 || row.CompletionRatePerMtok != 200000 {
+		t.Fatalf("default alias overrode literal default: %+v", row)
+	}
+}
+
+func TestRateCardProjectionBuyerMuxOnly(t *testing.T) {
+	server := buyer.NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/rate-card", nil)
+	buyerRR := httptest.NewRecorder()
+	server.Handler().ServeHTTP(buyerRR, req)
+	if buyerRR.Code != http.StatusOK {
+		t.Fatalf("buyer mux status=%d body=%s", buyerRR.Code, buyerRR.Body.String())
+	}
+
+	internalRR := httptest.NewRecorder()
+	server.InternalHandler().ServeHTTP(internalRR, req)
+	if internalRR.Code != http.StatusNotFound {
+		t.Fatalf("internal/provider mux status=%d want 404", internalRR.Code)
+	}
+}
+
+func TestRateCardProjectionVersionChangesOnlyForProjectionFields(t *testing.T) {
+	base := config.RewardsConfig{
+		GlobalMultiplier: 1.0,
+		ProviderShare:    0.90,
+		RateCard: map[string]config.RateCardEntry{
+			"model-a": {
+				PromptCreditsPerMtok:     100000,
+				CompletionCreditsPerMtok: 200000,
+			},
+		},
+	}
+	baseVersion := rateCardVersionFromServer(t,
+		buyer.NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0), buyer.WithBilling(nil, base), buyer.WithRateCardUSDPerMillionCredits(1.0)),
+	)
+
+	rowsChanged := base
+	rowsChanged.RateCard = map[string]config.RateCardEntry{
+		"model-a": {PromptCreditsPerMtok: 100000, CompletionCreditsPerMtok: 200001},
+	}
+	assertRateCardVersionChanged(t, baseVersion, rowsChanged, 1.0)
+
+	shareChanged := base
+	shareChanged.ProviderShare = 0.91
+	assertRateCardVersionChanged(t, baseVersion, shareChanged, 1.0)
+
+	multiplierChanged := base
+	multiplierChanged.GlobalMultiplier = 1.1
+	assertRateCardVersionChanged(t, baseVersion, multiplierChanged, 1.0)
+
+	usdChangedVersion := rateCardVersionFromServer(t,
+		buyer.NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0), buyer.WithBilling(nil, base), buyer.WithRateCardUSDPerMillionCredits(2.0)),
+	)
+	if usdChangedVersion == baseVersion {
+		t.Fatalf("version did not change when usd_per_million_credits changed: %s", baseVersion)
+	}
+
+	unrelatedVersion := rateCardVersionFromServer(t,
+		buyer.NewServer(
+			pool.NewRegistry(nil),
+			zerolog.Nop(),
+			time.Unix(1716768000, 0),
+			buyer.WithBilling(nil, base),
+			buyer.WithBillingSnapshotID(999),
+			buyer.WithInternalAuthKey("operator-key-does-not-affect-rate-card"),
+			buyer.WithRateCardUSDPerMillionCredits(1.0),
+		),
+	)
+	if unrelatedVersion != baseVersion {
+		t.Fatalf("version changed for unrelated operator/snapshot state: got %s want %s", unrelatedVersion, baseVersion)
+	}
+}
+
+func TestSetBillingConfigReloadsRateCardUSDCredits(t *testing.T) {
+	rewards := config.RewardsConfig{
+		GlobalMultiplier: 1.0,
+		ProviderShare:    0.90,
+		RateCard: map[string]config.RateCardEntry{
+			"model-a": {PromptCreditsPerMtok: 100000, CompletionCreditsPerMtok: 200000},
+		},
+	}
+	server := buyer.NewServer(
+		pool.NewRegistry(nil),
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithBilling(nil, rewards),
+		buyer.WithRateCardUSDPerMillionCredits(1.0),
+	)
+	baseVersion := rateCardVersionFromServer(t, server)
+
+	server.SetBillingConfig(rewards, 2, 2.0)
+
+	gotVersion := rateCardVersionFromServer(t, server)
+	wantVersion := rateCardVersionFromServer(t,
+		buyer.NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0), buyer.WithBilling(nil, rewards), buyer.WithRateCardUSDPerMillionCredits(2.0)),
+	)
+	if gotVersion == baseVersion {
+		t.Fatalf("version did not change after SetBillingConfig usd reload: %s", gotVersion)
+	}
+	if gotVersion != wantVersion {
+		t.Fatalf("reloaded rate-card version=%s want %s", gotVersion, wantVersion)
+	}
+}
+
+func TestNginxRateCardAllowThroughBeforeV1CatchAll(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("..", "..", "dist", "nginx-coordinator.streamvc.live.conf"))
+	if err != nil {
+		t.Fatalf("read nginx config: %v", err)
+	}
+	cfg := string(b)
+	location := strings.Index(cfg, "location = /v1/rate-card")
+	catchAll := strings.Index(cfg, "location /v1/ {\n        return 404;")
+	if location < 0 {
+		t.Fatalf("rate-card location missing")
+	}
+	if catchAll < 0 {
+		t.Fatalf("/v1/ 404 catch-all missing")
+	}
+	if location > catchAll {
+		t.Fatalf("rate-card location appears after /v1/ catch-all")
+	}
+	for _, needle := range []string{
+		"proxy_pass http://127.0.0.1:8443/v1/rate-card$is_args$args;",
+		"proxy_set_header Host $host;",
+		"proxy_set_header X-Real-IP $remote_addr;",
+		"proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;",
+		"proxy_set_header X-Forwarded-Proto $scheme;",
+	} {
+		if !strings.Contains(cfg[location:catchAll], needle) {
+			t.Fatalf("rate-card nginx block missing %q", needle)
+		}
+	}
+}
+
+func assertRateCardVersionChanged(t *testing.T, baseVersion string, rewards config.RewardsConfig, usdPerMillionCredits float64) {
+	t.Helper()
+	got := rateCardVersionFromServer(t,
+		buyer.NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0), buyer.WithBilling(nil, rewards), buyer.WithRateCardUSDPerMillionCredits(usdPerMillionCredits)),
+	)
+	if got == baseVersion {
+		t.Fatalf("version did not change: %s", got)
+	}
+}
+
+func rateCardVersionFromServer(t *testing.T, server *buyer.Server) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/rate-card", nil)
+	rr := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var got struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if got.Version == "" {
+		t.Fatalf("version empty: %s", rr.Body.String())
+	}
+	return got.Version
 }
 
 func TestModelsReturnsEmptyListWhenNoReadyProviders(t *testing.T) {

--- a/scripts/test-install-autotune-recommend-config.sh
+++ b/scripts/test-install-autotune-recommend-config.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Hermetic guard for installer SPEC-023 recommendation config parsing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+
+die() {
+  printf '[install-autotune-config-test] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+[ -f "$INSTALL_SH" ] || die "missing installer: $INSTALL_SH"
+
+lib="$(mktemp "${TMPDIR:-/tmp}/macprovider-install-autotune-lib.XXXXXX")"
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/macprovider-install-autotune.XXXXXX")"
+trap 'rm -f "$lib"; rm -rf "$workdir"' EXIT
+
+awk '
+  /^read_config_model\(\)/ { emit = 1 }
+  /^install_binary\(\)/ { emit = 0 }
+  emit { print }
+' "$INSTALL_SH" > "$lib"
+
+# shellcheck source=/dev/null
+. "$lib"
+
+CONFIG_PATH="$workdir/config.yaml"
+INSTALL_DIR="$workdir/install"
+DRY_RUN=0
+SKIP_PROVIDER_START=0
+model="initial/model"
+mkdir -p "$INSTALL_DIR"
+
+log() {
+  printf '[macprovider-install] %s\n' "$*" >/dev/null
+}
+
+die() {
+  if [ "$#" -eq 1 ]; then
+    printf '[install-autotune-config-test] ERROR: %s\n' "$1" >&2
+    exit 1
+  fi
+  printf '[install-autotune-config-test] ERROR: %s\n' "$2" >&2
+  exit "$1"
+}
+
+prompt_yes_no() {
+  return 0
+}
+
+write_recommendation_config() {
+  cat > "$CONFIG_PATH" <<EOF_CONFIG
+model: "$1"
+model_artifact_path: "$2"
+model_artifact_sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+EOF_CONFIG
+}
+
+write_donor_recommendation_config() {
+  cat > "$CONFIG_PATH" <<'EOF_CONFIG'
+model: "org/donor-model"
+model_artifact_path: "/tmp/macprovider-donor-snapshot"
+model_artifact_sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+donor_mode: true
+EOF_CONFIG
+}
+
+cat > "$INSTALL_DIR/macprovider-cli" <<'EOF_CLI'
+#!/usr/bin/env bash
+set -euo pipefail
+
+config=""
+donor=0
+freshness=0
+for arg in "$@"; do
+  case "$arg" in
+    --donor-mode) donor=1 ;;
+    --freshness-check) freshness=1 ;;
+  esac
+done
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--config" ]; then
+    shift
+    config="$1"
+  fi
+  shift || true
+done
+
+[ -n "$config" ] || exit 64
+
+if [ "$freshness" -eq 1 ]; then
+  exit "${FAKE_FRESHNESS_RC:-0}"
+fi
+
+if [ "$donor" -eq 1 ]; then
+  cat > "$config" <<EOF_DONOR
+model: "org/donor-model"
+model_artifact_path: "/tmp/macprovider-donor-snapshot"
+model_artifact_sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+EOF_DONOR
+  exit 0
+fi
+
+if [ "${FAKE_PAID_EMPTY:-0}" -eq 1 ]; then
+  cat > "$config" <<'EOF_EMPTY'
+model: "org/unusable-paid-model"
+EOF_EMPTY
+  exit 0
+fi
+
+cat > "$config" <<'EOF_PAID'
+model: "org/paid-model"
+model_artifact_path: "/tmp/macprovider-paid-snapshot"
+model_artifact_sha256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+EOF_PAID
+EOF_CLI
+chmod +x "$INSTALL_DIR/macprovider-cli"
+
+run_paid_apply_case() {
+  model="initial/model"
+  SKIP_PROVIDER_START=0
+  rm -f "$CONFIG_PATH"
+  export FAKE_PAID_EMPTY=0
+  run_autotune_recommend_apply
+  unset FAKE_PAID_EMPTY
+  [ "$model" = "org/paid-model" ] || die "paid apply used $model instead of public model key"
+  [ "$SKIP_PROVIDER_START" -eq 0 ] || die "paid apply unexpectedly skipped provider start"
+}
+
+run_donor_apply_case() {
+  model="initial/model"
+  SKIP_PROVIDER_START=0
+  rm -f "$CONFIG_PATH"
+  export FAKE_PAID_EMPTY=1
+  run_autotune_recommend_apply
+  unset FAKE_PAID_EMPTY
+  [ "$model" = "org/donor-model" ] || die "donor apply used $model instead of public model key"
+  [ "$SKIP_PROVIDER_START" -eq 1 ] || die "donor apply should write config without auto-starting provider"
+}
+
+run_fresh_reuse_case() {
+  model="initial/model"
+  SKIP_PROVIDER_START=0
+  write_recommendation_config "org/fresh-model" "/tmp/macprovider-fresh-snapshot"
+  export FAKE_FRESHNESS_RC=0
+  use_fresh_recommendation_if_available
+  unset FAKE_FRESHNESS_RC
+  [ "$model" = "org/fresh-model" ] || die "fresh reuse used $model instead of public model key"
+}
+
+run_fresh_donor_reuse_case() {
+  model="initial/model"
+  SKIP_PROVIDER_START=0
+  write_donor_recommendation_config
+  export FAKE_FRESHNESS_RC=0
+  use_fresh_recommendation_if_available
+  unset FAKE_FRESHNESS_RC
+  [ "$model" = "initial/model" ] || die "fresh donor reuse should not select launch model $model"
+  [ "$SKIP_PROVIDER_START" -eq 1 ] || die "fresh donor reuse should not auto-start provider"
+}
+
+run_paid_apply_case
+run_donor_apply_case
+run_fresh_reuse_case
+run_fresh_donor_reuse_case
+
+printf '[install-autotune-config-test] installer recommendation config parsing ok\n'

--- a/specs/AUDIT_BUILD_SPEC_023_v0_1_IMPL_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_BUILD_SPEC_023_v0_1_IMPL_ARCHITECT_PROMPT.md
@@ -1,0 +1,61 @@
+# AUDIT_BUILD_SPEC_023_v0_1_IMPL_ARCHITECT_PROMPT
+
+You are the ARCHITECT auditor for the SPEC-023 v0.1 implementation prompt.
+
+Work read-only in the macprovider repo. Do not edit files.
+
+## Required Reading
+
+Read these files fully before auditing:
+
+- `specs/SPEC-023-installer-autotune-recommend.md`
+- `specs/SPEC-023-v0_1-r7-audit.md`
+- `specs/BUILD_SPEC_023_v0_1_IMPL_PROMPT.md`
+- Relevant current repo architecture surfaces named by the build prompt:
+  - `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift`
+  - `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+  - `phase3-binary/Sources/macprovider-cli/ConfigApplier.swift`
+  - `phase4-coordinator/internal/buyer/server.go`
+  - `phase4-coordinator/cmd/coordinator/main.go`
+  - `phase5-gateway/README.md`
+
+## Scope
+
+Audit only the implementation prompt. Do not audit implementation code, because no SPEC-023 implementation has been written yet.
+
+## Architecture Checklist
+
+Find prompt defects that would make the implementation structurally wrong:
+
+- Prompt reopens or contradicts SPEC-023 non-goals.
+- Prompt crosses coordinator/gateway/provider boundaries incorrectly.
+- Prompt under-specifies the `/v1/rate-card` buyer-mux/nginx route or accidentally changes gateway buyer API behavior.
+- Prompt creates a hidden new control plane beyond static JSON + rate-card endpoint.
+- Prompt does not preserve the existing autotune benchmark path while adding `--recommend`.
+- Prompt omits retune/status lifecycle, stored state, or deterministic stale detection.
+- Prompt creates a local donor mode that requires coordinator/gateway donor routing in v0.1.
+- Prompt decomposes implementation in an order that makes tests or integration unworkable.
+- Prompt lacks a credible acceptance-criteria ownership matrix or final verification contract.
+- Prompt implies SPEC text edits, PR opening, or implementation work before prompt-audit convergence.
+
+## Severity Guide
+
+- CRITICAL: prompt requires an architecture that violates locked non-goals or money-path/gateway boundaries.
+- HIGH: prompt misses a required subsystem or orders work so the implementation cannot converge safely.
+- MEDIUM: prompt ambiguity could create incompatible subsystem boundaries or lifecycle behavior.
+- LOW: citation, wording, or process issue unlikely to change architecture.
+
+## Output Contract
+
+Return:
+
+- Verdict: `READY TO BUILD` or `NEEDS FIX PASS`.
+- Counts: Critical / High / Medium / Low.
+- Findings ordered by severity. Each finding must include:
+  - ID
+  - severity
+  - file:line
+  - evidence from prompt and/or locked SPEC/current repo
+  - impact
+  - required prompt fix
+- If no Critical/High/Medium findings remain, state that explicitly.

--- a/specs/AUDIT_BUILD_SPEC_023_v0_1_IMPL_CODE_PROMPT.md
+++ b/specs/AUDIT_BUILD_SPEC_023_v0_1_IMPL_CODE_PROMPT.md
@@ -1,0 +1,62 @@
+# AUDIT_BUILD_SPEC_023_v0_1_IMPL_CODE_PROMPT
+
+You are the CODE auditor for the SPEC-023 v0.1 implementation prompt.
+
+Work read-only in the macprovider repo. Do not edit files.
+
+## Required Reading
+
+Read these files fully before auditing:
+
+- `specs/SPEC-023-installer-autotune-recommend.md`
+- `specs/SPEC-023-v0_1-r7-audit.md`
+- `specs/BUILD_SPEC_023_v0_1_IMPL_PROMPT.md`
+- Current repo code surfaces named by the build prompt, especially:
+  - `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift`
+  - `phase3-binary/Sources/macprovider-cli/AutotuneRuntimeSupport.swift`
+  - `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+  - `phase3-binary/Sources/macprovider-cli/ConfigApplier.swift`
+  - `phase4-coordinator/internal/buyer/server.go`
+  - `phase4-coordinator/cmd/coordinator/main.go`
+  - `phase4-coordinator/internal/billing/formula.go`
+  - `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`
+
+## Scope
+
+Audit only the implementation prompt. Do not audit implementation code, because no SPEC-023 implementation has been written yet.
+
+## Code-Mechanics Checklist
+
+Find prompt defects that would make a conforming implementer write the wrong code:
+
+- Wrong file paths, command names, branch/worktree instructions, or repo surfaces.
+- Missing implementation slice for any locked SPEC-023 requirement or AC.
+- Incorrect mapping from AC-1 through AC-39 to implementation/test slices.
+- Prompt instructions that contradict current Swift or Go package patterns.
+- Prompt instructions that accidentally require changing money-path schemas, `RateCardEntry`, billing formula, ledger, settlement, request logs, or gateway routing.
+- Unclear `--recommend` integration with the existing `autotune` command and existing benchmark behavior.
+- Missing deterministic algorithms needed for tests: field order, hash derivation, stable selection, rate-card version, catalog hash, artifact hash, bandwidth tier order.
+- Test plan gaps where a SPEC AC can be tested but the prompt leaves it to prose.
+- Any stale command name such as `macprovider` instead of `macprovider-cli`.
+
+## Severity Guide
+
+- CRITICAL: prompt would drive implementation that violates money-path boundaries, omits a mandatory safety gate, or cannot be implemented without major redesign.
+- HIGH: prompt would likely produce code that fails a locked SPEC-023 AC or uses the wrong repo surface.
+- MEDIUM: prompt is ambiguous enough that two competent implementers could produce incompatible behavior for a required v0.1 contract.
+- LOW: citation, wording, or hygiene issue unlikely to change implementation behavior.
+
+## Output Contract
+
+Return:
+
+- Verdict: `READY TO BUILD` or `NEEDS FIX PASS`.
+- Counts: Critical / High / Medium / Low.
+- Findings ordered by severity. Each finding must include:
+  - ID
+  - severity
+  - file:line
+  - evidence from prompt and/or locked SPEC/current repo
+  - impact
+  - required prompt fix
+- If no Critical/High/Medium findings remain, state that explicitly.

--- a/specs/AUDIT_BUILD_SPEC_023_v0_1_IMPL_SECURITY_PROMPT.md
+++ b/specs/AUDIT_BUILD_SPEC_023_v0_1_IMPL_SECURITY_PROMPT.md
@@ -1,0 +1,60 @@
+# AUDIT_BUILD_SPEC_023_v0_1_IMPL_SECURITY_PROMPT
+
+You are the SECURITY auditor for the SPEC-023 v0.1 implementation prompt.
+
+Work read-only in the macprovider repo. Do not edit files.
+
+## Required Reading
+
+Read these files fully before auditing:
+
+- `specs/SPEC-023-installer-autotune-recommend.md`
+- `specs/SPEC-023-v0_1-r7-audit.md`
+- `specs/BUILD_SPEC_023_v0_1_IMPL_PROMPT.md`
+- Current repo security-relevant surfaces named by the build prompt, especially:
+  - `phase3-binary/Sources/macprovider-cli/ReceiptKeyStore.swift`
+  - `phase3-binary/Sources/macprovider-cli/AutotuneRuntimeSupport.swift`
+  - `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift`
+  - `phase3-binary/Sources/macprovider-cli/ConfigApplier.swift`
+  - `phase4-coordinator/internal/buyer/server.go`
+  - `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`
+
+## Scope
+
+Audit only the implementation prompt. Do not audit implementation code, because no SPEC-023 implementation has been written yet.
+
+## Security Checklist
+
+Find prompt defects that would weaken SPEC-023 security/privacy guarantees:
+
+- Static JSON signature/key/sidecar rules missing, ambiguous, or incorrectly scoped.
+- Fallback rules that could accept tampered, stale, replayed, future-dated, or unsigned static JSON.
+- Candidate catalog trust gaps that allow download/benchmark/recommend/donor commit without signed metadata.
+- Mutable model artifact gaps: missing immutable revision, missing canonical hash verification, missing path-safety rejection, or tests that only check presence.
+- Donor-mode bypass gaps, including arbitrary local model paths or paid network registration for non-recommendable rows.
+- HMAC identity privacy gaps: missing CSPRNG local secret, unsafe storage, missing domain separation, raw fingerprint leakage, support bundle/log leakage.
+- Benchmark gaming or cache poisoning gaps: stale cache identity, binary/catalog/model/hardware mismatch, swap/thermal omission.
+- Rate-card public endpoint exposure or nginx route instructions that overexpose operator/provider/admin surfaces.
+- Any instruction to inspect Darkbloom / d-inference source.
+
+## Severity Guide
+
+- CRITICAL: prompt would likely cause a bypass of signed catalog/static JSON trust, donor-mode paid-serving boundary, or raw secret/fingerprint leakage.
+- HIGH: prompt omits a required security control or test for a locked SPEC-023 safety boundary.
+- MEDIUM: prompt ambiguity could produce inconsistent or weaker security behavior.
+- LOW: hygiene issue unlikely to weaken the shipped implementation.
+
+## Output Contract
+
+Return:
+
+- Verdict: `READY TO BUILD` or `NEEDS FIX PASS`.
+- Counts: Critical / High / Medium / Low.
+- Findings ordered by severity. Each finding must include:
+  - ID
+  - severity
+  - file:line
+  - evidence from prompt and/or locked SPEC/current repo
+  - impact
+  - required prompt fix
+- If no Critical/High/Medium findings remain, state that explicitly.

--- a/specs/AUDIT_SPEC_023_v0_1_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_v0_1_ARCHITECT_PROMPT.md
@@ -1,0 +1,47 @@
+# AUDIT_SPEC_023 v0.1 — ARCHITECT LANE
+
+Audit target: `specs/SPEC-023-installer-autotune-recommend.md`
+
+Role: architect auditor. Review the SPEC for system boundaries, lifecycle sequencing, control-plane design, forward compatibility, and consistency with Wave 0c / Wave 1 / v0.2 responsibilities.
+
+Required local reads:
+
+- `specs/SPEC-023-installer-autotune-recommend.md`
+- `specs/SPEC-023-v0_1-KICKSTART-PROMPT.md`
+- `beta/DECISION_CRITERIA.md` entries 92-95 and, if present, later Wave 1 entries
+- `specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_MEMO.md`
+- `specs/RESEARCH_227_RATE_CARD_V3_MEMO.md`
+- `specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_MEMO.md`
+- `specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_MEMO.md`
+
+Findings to prioritize:
+
+- Boundary violations between provider-side recommendation and coordinator/gateway money-path behavior.
+- Under-specified static JSON lifecycle, release fallback, and stale-data handling.
+- Formula or diversification choices that undermine fleet coverage or contradict Goodhart mitigations.
+- Stored-state and upgrade/status lifecycle gaps.
+- v0.1/v0.2 deferral mismatches.
+- Incorrect sequencing or stale references to earlier Wave 1 state.
+
+Severity rubric:
+
+- CRITICAL: architectural contradiction or boundary error that blocks the SPEC.
+- HIGH: design ambiguity likely to cause wrong product behavior or incompatible future migration.
+- MEDIUM: lifecycle/testability gap that should be fixed before locking.
+- LOW: non-blocking improvement.
+
+Return format:
+
+```text
+Verdict: READY TO LOCK | NEEDS FIX PASS
+Counts: CRITICAL=n HIGH=n MEDIUM=n LOW=n
+
+Findings:
+- [SEVERITY-CODE] Title
+  Evidence: file/section reference
+  Impact:
+  Required fix:
+
+Accepted LOWs:
+- ...
+```

--- a/specs/AUDIT_SPEC_023_v0_1_CODE_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_v0_1_CODE_PROMPT.md
@@ -1,0 +1,45 @@
+# AUDIT_SPEC_023 v0.1 — CODE LANE
+
+Audit target: `specs/SPEC-023-installer-autotune-recommend.md`
+
+Role: code auditor. Review the SPEC for implementation clarity, testability, compatibility with current code surfaces, and contradictions that would cause an implementer to build the wrong behavior.
+
+Required local reads:
+
+- `specs/SPEC-023-installer-autotune-recommend.md`
+- `specs/SPEC-023-v0_1-KICKSTART-PROMPT.md`
+- `phase3-binary/dist/install.sh` around `choose_model()`
+- `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift` around `defaultCandidates`
+- `phase3-binary/Sources/macprovider-cli/AutotuneRuntimeSupport.swift` around `MachineFingerprinter.sample()`
+- `phase4-coordinator/internal/billing/formula.go` around `RateFor` and `normalizeModelKey`
+
+Findings to prioritize:
+
+- Spec requirements that cannot be implemented from the current code structure without hidden extra product decisions.
+- Ambiguous formulas, rounding, field types, fallback behavior, or model-key normalization rules.
+- Missing acceptance criteria for required behavior.
+- Contradictions between JSON schema, transcript copy, donor-mode behavior, eligibility gates, and stored state.
+- Accidental implementation scope creep into gateway/coordinator money-path code.
+
+Severity rubric:
+
+- CRITICAL: would make v0.1 unsafe or impossible to implement correctly.
+- HIGH: would likely cause a wrong implementation, bad provider recommendation, or breaking incompatibility.
+- MEDIUM: testability or ambiguity gap likely to create rework.
+- LOW: editorial or non-blocking clarity issue.
+
+Return format:
+
+```text
+Verdict: READY TO LOCK | NEEDS FIX PASS
+Counts: CRITICAL=n HIGH=n MEDIUM=n LOW=n
+
+Findings:
+- [SEVERITY-CODE] Title
+  Evidence: file/section reference
+  Impact:
+  Required fix:
+
+Accepted LOWs:
+- ...
+```

--- a/specs/AUDIT_SPEC_023_v0_1_SECURITY_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_v0_1_SECURITY_PROMPT.md
@@ -1,0 +1,47 @@
+# AUDIT_SPEC_023 v0.1 — SECURITY LANE
+
+Audit target: `specs/SPEC-023-installer-autotune-recommend.md`
+
+Role: security auditor. Review the SPEC for provider trust, tamper resistance, abusive inputs, misleading earnings claims, privacy leakage, and clean-room / production-claim discipline.
+
+Required local reads:
+
+- `specs/SPEC-023-installer-autotune-recommend.md`
+- `specs/SPEC-023-v0_1-KICKSTART-PROMPT.md`
+- `beta/DECISION_CRITERIA.md` entries 92-95
+- `specs/RESEARCH_229_GOODHART_DEMAND_SIGNAL_PROBE_MEMO.md`
+- `specs/RESEARCH_230_COMPETITIVE_INSTALLER_UX_PROBE_MEMO.md`
+- `CLAUDE.md`
+
+Findings to prioritize:
+
+- Unsigned or weakly validated static JSON control-plane risks.
+- Fingerprint/provider ID privacy leakage.
+- Provider-gamed benchmark or donor-mode bypass hazards.
+- Any implication of guaranteed earnings or buyer demand.
+- Any accidental claim that Wave 0a/0b fixed an active third-party buyer incident.
+- Any clean-room violation around Darkbloom / `d-inference`.
+- Any path that lets untrusted static metadata cause unsafe model download or model execution.
+
+Severity rubric:
+
+- CRITICAL: security/privacy/compliance failure that should block locking.
+- HIGH: exploitable tampering or materially misleading provider-safety behavior.
+- MEDIUM: important guardrail missing or underspecified.
+- LOW: non-blocking hardening or wording issue.
+
+Return format:
+
+```text
+Verdict: READY TO LOCK | NEEDS FIX PASS
+Counts: CRITICAL=n HIGH=n MEDIUM=n LOW=n
+
+Findings:
+- [SEVERITY-CODE] Title
+  Evidence: file/section reference
+  Impact:
+  Required fix:
+
+Accepted LOWs:
+- ...
+```

--- a/specs/BUILD_SPEC_023_v0_1_IMPL_PROMPT.md
+++ b/specs/BUILD_SPEC_023_v0_1_IMPL_PROMPT.md
@@ -1,0 +1,279 @@
+# BUILD_SPEC_023_v0_1_IMPL_PROMPT — Installer-Integrated Autotune Recommend
+
+You are starting a fresh implementation session in the macprovider repo. You have no memory of prior conversations. Read this prompt end-to-end before writing code.
+
+## 0. Workspace And Authority
+
+Before editing anything, verify:
+
+```bash
+pwd
+git status -sb
+git fetch origin
+ls specs/SPEC-023-installer-autotune-recommend.md
+```
+
+Work on a feature branch or isolated worktree, never local `main`. If `specs/SPEC-023-installer-autotune-recommend.md` is not present at HEAD, STOP: the SPEC-023 LOCK has not landed in your implementation base.
+
+Controlling contract:
+
+- `specs/SPEC-023-installer-autotune-recommend.md` v0.1 LOCKED.
+- Final SPEC audit record: `specs/SPEC-023-v0_1-r7-audit.md`, with code/security/architect all at 0 critical/high/medium/low.
+- Repo rules: `AGENTS.md` and `CLAUDE.md`.
+
+This prompt implements the locked SPEC. Do not re-litigate the product decisions. If the code reveals a true SPEC ambiguity, stop and surface it as a SPEC follow-up; do not silently change the contract in code.
+
+Clean-room boundary: do not inspect Darkbloom / layr-labs `d-inference` source. SPEC-023 competitive framing already used public surfaces only.
+
+## 1. Scope Summary
+
+Implement SPEC-023 v0.1:
+
+- A public, read-only coordinator `GET /v1/rate-card` recommendation projection on the buyer mux, reachable through production nginx.
+- A Swift CLI recommendation path for `macprovider-cli autotune --recommend`, including JSON/human output, baked/live static inputs, deterministic scoring, stale-state persistence, and donor-mode local-only UX.
+- Static JSON integrity and fallback for `demand-rank.json` and `autotune-candidates.json`.
+- Deterministic hardware identity, bandwidth-tier assignment, model admission gates, and canonical model artifact hash verification.
+- Installer/update/status hooks for prompting re-tune and surfacing stale/donor status.
+- Focused tests proving every SPEC-023 acceptance criterion AC-1 through AC-39.
+
+Out of scope:
+
+- No coordinator `/v1/demand-signal` endpoint.
+- No auto-switching models without operator action.
+- No provider quota/coverage allocation policy. Do not query live provider counts for recommendation. Parse/store `min_provider_target` only for operator planning and future v0.2 migration.
+- No gateway billing, coordinator settlement, ledger, request-log, or `RateCardEntry` YAML schema changes.
+- No coordinator/gateway donor-routing or donor settlement behavior.
+- No arbitrary local-model/custom donor-mode path override.
+- No Darkbloom source inspection.
+
+## 2. Mandatory Implementation Slices
+
+Implement in the order below. Each slice must include targeted tests before moving on.
+
+### Slice A — Coordinator Rate-Card Projection
+
+Files likely touched:
+
+- `phase4-coordinator/internal/buyer/server.go`
+- `phase4-coordinator/cmd/coordinator/main.go` only if construction needs option wiring
+- `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`
+- `phase4-coordinator/internal/buyer/*_test.go`
+
+Requirements:
+
+1. Add unauthenticated `GET /v1/rate-card` on the coordinator buyer mux (`buyer_port: 8443`), not provider/operator mux (`provider_port: 8444`).
+2. Return JSON:
+
+```json
+{
+  "version": "string",
+  "generated_at": "RFC3339 timestamp",
+  "usd_per_million_credits": 1.0,
+  "rows": {
+    "<model_key>": {
+      "prompt_rate_per_mtok": 0,
+      "completion_rate_per_mtok": 0,
+      "provider_share_bps": 9000,
+      "global_multiplier_ppm": 1000000
+    }
+  }
+}
+```
+
+3. Build the projection from existing loaded config/runtime values only: `Rewards.RateCard`, `Rewards.ProviderShare`, `Rewards.GlobalMultiplier`, and `stats.rollup.usd_per_million_credits`.
+4. Do not alter billing, settlement, routing, provider state, request logs, `RateCardEntry`, YAML schema, ledger schema, or settlement arithmetic.
+5. Compute `version` as SPEC §3.3 defines: SHA-256 over the canonical recommendation projection only, excluding quarantine/force-void, request-log, operator, ledger, and settlement runtime state.
+6. Add an exact nginx `location = /v1/rate-card` before the existing generic `/v1/` 404 block, proxying to `http://127.0.0.1:8443/v1/rate-card$is_args$args` and forwarding `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto`.
+7. Tests:
+   - Unauthenticated handler returns the schema.
+   - Handler is wired on buyer mux, not provider/operator mux.
+   - `version` changes when rows/provider share/global multiplier/USD conversion changes.
+   - `version` does not change for unrelated quarantine/request-log/operator/settlement runtime state.
+   - Nginx config contains exact allow-through before the `/v1/` 404 block.
+
+### Slice B — Swift Static Inputs And Integrity
+
+Files likely added/touched:
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend*.swift` new files, split by responsibility.
+- `phase3-binary/Sources/macprovider-cli/AutotuneRuntimeSupport.swift`
+- `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommend*Tests.swift`
+
+Requirements:
+
+1. Add typed models for:
+   - candidate catalog
+   - demand rank
+   - rate-card projection
+   - recommendation JSON output
+   - stored `last-recommendation.json`
+2. Add baked snapshots compiled into the CLI release. The baked candidate catalog must include at least the SPEC §3.2 rows. Every non-`blocked` baked row must include immutable `model_revision` and canonical `model_sha256`.
+3. Add a CLI rate-card input fetcher:
+   - Fetch `https://coordinator.streamvc.live/v1/rate-card`.
+   - Validate the §3.3 schema before use.
+   - Fall back to the baked rate-card snapshot on timeout, non-2xx, malformed JSON, schema-validation failure, missing required fields, non-finite/negative values, or unavailable network.
+   - Emit `rate_card_fallback_used` to JSON `warnings[]` and stderr when baked fallback is used.
+   - Persist the selected `rate_card_version` in `last-recommendation.json`.
+   - Tests must cover AC-5, including failed fetch and schema-validation failure.
+4. Implement static fetch from `https://get.streamvc.live/{demand-rank,autotune-candidates}.json` plus `{name}.json.sig`.
+5. Verify detached Ed25519 sidecar exactly:
+
+```json
+{
+  "key_id": "streamvc-autotune-static-v1",
+  "alg": "ed25519",
+  "signature": "<base64>"
+}
+```
+
+6. Use release-pinned public key `autotune_static_json_ed25519_v1` and key ID `streamvc-autotune-static-v1`.
+7. Parse JSON only after signature verification succeeds.
+8. Validate schemas before admitting fetched JSON:
+   - `demand-rank.json`: locked `source`, `cold_start_floor = 0.15`, `diversification_band = 0.85`, RFC3339 `generated_at`, finite `[0,1]` `demand_weight`, positive or null rank, boolean `recommendable`, non-negative integer `min_provider_target`.
+   - `autotune-candidates.json`: locked `source`, RFC3339 `generated_at`, required row fields, allowed `runtime_status`, allowed bandwidth tiers, non-negative gates, non-`blocked` rows carrying `model_revision` and `model_sha256`.
+   - Schema-validation failure falls back to baked and emits `demand_rank_fallback_used` or `candidate_catalog_fallback_used`.
+9. Reject fetched file and fall back to baked snapshot when sidecar is missing/malformed, key/alg wrong, signature invalid, schema invalid, `generated_at` older than baked, more than 10 minutes in the future, or more than 30 days old.
+10. Emit `demand_rank_stale` or `candidate_catalog_stale` for valid fetched files 14-30 days old.
+11. Compute `candidate_catalog_sha256` over exact selected catalog JSON bytes after fetched/baked selection and before parsing normalization.
+12. Tests cover fallback and warning behavior for every §3.5 rejection/allow path and AC-4/AC-6 schema-validation failure.
+
+### Slice C — Recommendation Engine
+
+Files likely added/touched:
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift`
+- `phase3-binary/Sources/macprovider-cli/RecommendationEmitter.swift`
+- new recommendation engine files under `phase3-binary/Sources/macprovider-cli/`
+- Swift tests under `phase3-binary/Tests/macprovider-cliTests/`
+
+Requirements:
+
+1. Add `macprovider-cli autotune --recommend` and `--json` behavior without breaking existing autotune benchmark flags.
+2. Preserve current full benchmark/autotune behavior for existing invocations. If needed, implement recommendation as a distinct mode gated by `--recommend`.
+3. Hardware:
+   - Extend/derive `bandwidth_tier`, `diversification_id`, benchmark status, swap, thermal, and binary identity without weakening `MachineFingerprinter.sample()`.
+   - HMAC local secret is per-install CSPRNG-generated, stored in Keychain or a `0600` local file, never emitted/logged/bundled/sent.
+   - Use separate HMAC domain labels for diversification and cache identity.
+   - Tier order is `S >= A >= B >= C`; implement the SPEC §3.1 chip mapping exactly.
+4. Candidate gates:
+   - Missing selected-catalog metadata makes row ineligible before download/benchmark.
+   - `blocked` rows are never downloaded, benchmarked, recommended, or donor-committed.
+   - Require immutable `model_revision` and canonical `model_sha256` for every downloadable row.
+   - Download by immutable revision, not branch/tag.
+   - Reject model snapshots containing non-regular entries, symlinks, hardlinks with link count >1, device nodes, sockets, FIFOs, absolute paths, path escapes, or `..` path segments.
+   - Compute canonical artifact-set hash exactly as SPEC §3.2 says before benchmark, recommendation, donor commit, or provider run.
+   - Cached benchmark admission is fail-closed: a current `benchmark_id` from the active run is acceptable; otherwise a cached run may be reused only when selected `candidate_catalog_sha256`, binary version, model ID, HMAC-derived hardware identity hash, and benchmark `generated_at` age <= 7 days all match.
+   - Add negative tests for each cached-benchmark mismatch: catalog hash, binary version, model ID, hardware identity hash, and age > 7 days.
+5. Rate-card recommendation lookup:
+   - Exact key, then Wave 0b `normalizeModelKey`.
+   - Do not use coordinator `default` fallback unless candidate key is literally `default`.
+6. Formula:
+   - Use the locked §4 formula, including `cold_start_floor = 0.15`, `diversification_band = 0.85`, provider share, tier weight, and deterministic stable hash pool selection.
+   - Paid recommendation requires all §5 gates and `expected_net_usd_per_hour >= 0.0050`.
+   - Below threshold emits `recommended_model = null`, `recommendation_below_threshold`, and donor-tier transcript.
+   - `min_provider_target` is parsed and preserved only; it must not affect v0.1 scoring, eligibility, diversification, or live provider-count queries.
+7. JSON:
+   - Deterministic field order matching SPEC §6.
+   - Stable warning vocabulary sorted lexicographically.
+   - Unknown optional fields use `null`, not omitted.
+8. Human transcript:
+   - Exact §7.1 and §7.2 text and `$%.4f/hr` formatting.
+   - Earnings language remains estimate-only; no guaranteed earnings.
+9. Tests:
+   - Unit tests for scoring, threshold, top-band diversification, stable hash, no-default fallback, normalized lookup, tier comparison, stale warnings, and JSON field order.
+   - Unit tests proving `min_provider_target` does not affect scoring or eligibility and no provider quota/count policy is consulted in v0.1.
+   - Fixture tests for all SPEC ACs that do not require real model downloads.
+   - Download/hash behavior can use local temp directories and mocked fetchers; do not hit external networks in unit tests.
+
+### Slice D — Donor Mode, Apply, Status, Update, Installer Hooks
+
+Files likely touched:
+
+- `phase3-binary/Sources/macprovider-cli/ConfigApplier.swift`
+- `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+- `phase3-binary/Sources/macprovider-cli/SelfUpdate.swift` / update command surfaces if retune hook belongs there
+- `phase3-binary/Sources/macprovider-cli/ProviderStatus.swift` or status command files
+- installer scripts under `phase3-binary/dist/` if they own post-install prompting
+
+Requirements:
+
+1. Add `--donor-mode` boolean on the configuration/apply path and `donor_mode: true` YAML config support.
+2. Donor mode may skip only paid-yield threshold and demand-rank `recommendable == true` default-selection gate.
+3. Donor mode must not bypass signed selected catalog metadata, immutable revision, canonical artifact digest, runtime status not blocked, model allowlist, RAM headroom, no-swap, no-thermal, or runtime support.
+4. Donor mode is local-only for non-recommendable rows: applying it may write local config/status, but must not auto-start or auto-register a network-connected paid provider for a non-recommendable donor row.
+5. No arbitrary local model/custom donor-mode path override in v0.1.
+6. `macprovider-cli status` shows `DONOR MODE` when `donor_mode: true`.
+7. Store recommendation state at `~/.config/macprovider/last-recommendation.json` with all §9 fields.
+8. `macprovider-cli update` and installer rerun compare stored/live `rate_card_version`, `demand_rank_version`, `candidate_catalog_version/hash`, `binary_version`, `hardware_identity_hash`, and benchmark age; prompt re-tune on changes/expiry.
+9. Status emits:
+
+```text
+Recommendation stale: recommendation inputs changed since {generated_at}.
+Run: macprovider-cli autotune --recommend
+```
+
+10. Tests:
+    - Donor-mode config write and warning.
+    - No donor auto-start/auto-register for non-recommendable rows.
+    - Status donor badge.
+    - Stale recommendation detection for each stored field.
+    - Update/installer hook unit tests where practical; shell smoke for installer rerun if needed.
+
+## 3. Acceptance-Criteria Ownership Matrix
+
+Every AC from SPEC §11 must have at least one test or explicit verification note:
+
+- Slice B/C: AC-1 through AC-21.
+- Slice D: AC-22 through AC-27.
+- Slice C/D security and privacy: AC-28 through AC-36.
+- Slice A: AC-37 and AC-38.
+- Slice B/D: AC-39.
+
+If an AC needs an integration or manual smoke rather than a unit test, create a named verification command or script and document the residual requirement in the final handoff. Do not mark an AC satisfied by prose alone when it can be tested.
+
+## 4. Implementation Constraints
+
+- Keep diffs small and local to SPEC-023 surfaces.
+- Prefer existing Swift patterns in `AutotuneCommand`, `RecommendationEmitter`, `ConfigApplier`, `SelfUpdate`, and existing test fixture style.
+- Prefer existing Go patterns in `internal/buyer` and `cmd/coordinator`; do not introduce a new router framework.
+- Do not add dependencies unless the implementation is unreasonable without them. If adding a dependency, justify it in the commit body.
+- Do not change billing formula, ledger writes, settlement math, request logs, gateway routing, or `RateCardEntry` YAML shape.
+- Do not make live network calls in unit tests.
+- Do not hardcode secrets. The Ed25519 public key is not a secret; the HMAC local secret is.
+- Do not inspect Darkbloom source.
+
+## 5. Verification Commands
+
+Run the smallest relevant tests as you work, then finish with:
+
+```bash
+cd phase4-coordinator && go test ./internal/buyer ./cmd/coordinator
+cd phase3-binary && swift test --filter Autotune
+cd phase3-binary && swift test --filter Recommendation
+```
+
+If time permits or touched surfaces are broad:
+
+```bash
+cd phase4-coordinator && go test ./...
+cd phase3-binary && swift test
+```
+
+Before final handoff:
+
+```bash
+git diff --check
+git status -sb
+```
+
+## 6. Required Final Handoff
+
+Final response from the implementation session must include:
+
+- Branch/worktree used.
+- Files changed grouped by coordinator, CLI, installer/status, tests.
+- Acceptance criteria covered and any explicit gaps.
+- Exact verification commands and outcomes.
+- Confirmation that no product-design lane, no Darkbloom source inspection, and no money-path schema/settlement changes occurred.
+
+Do not open a PR unless the operator explicitly asks.

--- a/specs/SPEC-023-IMPL-PROMPT-r1-audit.md
+++ b/specs/SPEC-023-IMPL-PROMPT-r1-audit.md
@@ -1,0 +1,55 @@
+# SPEC-023 Implementation Prompt Audit — Round 1
+
+Date: 2026-07-02
+
+Scope: `specs/BUILD_SPEC_023_v0_1_IMPL_PROMPT.md`
+
+Auditor lanes run: code, security, architect. No product-design lane was run.
+
+## Verdict
+
+NEEDS FIX PASS
+
+| Lane | Critical | High | Medium | Low | Verdict |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Code | 0 | 2 | 1 | 0 | NEEDS FIX PASS |
+| Security | 0 | 1 | 0 | 0 | NEEDS FIX PASS |
+| Architect | 0 | 0 | 0 | 0 | READY TO BUILD |
+
+## Findings And Fixes Applied
+
+### CODE-H1 — CLI rate-card fetch and baked fallback path missing
+
+Severity: HIGH
+
+The implementation prompt described the coordinator `GET /v1/rate-card` endpoint and rate-card lookup, but did not explicitly require the Swift CLI to fetch `https://coordinator.streamvc.live/v1/rate-card`, validate the schema, fall back to a baked snapshot, emit `rate_card_fallback_used`, persist `rate_card_version`, and test AC-5 fallback paths.
+
+Fix applied: Slice B now requires a CLI rate-card input fetcher, schema validation, baked fallback on network/HTTP/malformed/schema/value failures, warning emission, stored `rate_card_version`, and tests for failed fetch plus schema-validation failure.
+
+### CODE-H2 — Static JSON schema-validation fallback missing
+
+Severity: HIGH
+
+The implementation prompt required signature/freshness checks for `demand-rank.json` and `autotune-candidates.json`, but did not explicitly require schema validation before admitting fetched JSON. This could let a conforming implementer accept signed but invalid static inputs.
+
+Fix applied: Slice B now requires schema validation for locked source, constants, timestamps, enum/range checks, required row fields, required metadata for downloadable rows, fallback warning emission on schema failure, and tests for AC-4/AC-6 schema-validation failure.
+
+### CODE-M1 — Provider quota policy non-goal omitted
+
+Severity: MEDIUM
+
+SPEC-023 v0.1 treats `min_provider_target` as operator-planning metadata, not as a recommendation quota or live-provider-count policy. The prompt did not say this explicitly, leaving room for incompatible scoring or eligibility behavior.
+
+Fix applied: Out-of-scope text now forbids provider quota/coverage allocation policy and live provider-count queries. Slice C now requires `min_provider_target` parse/preserve only and tests proving it does not affect v0.1 scoring or eligibility.
+
+### SEC-H1 — Cache-poisoning guard not test-explicit
+
+Severity: HIGH
+
+The implementation prompt required benchmark status, binary identity, and catalog metadata, but did not explicitly require cached benchmark reuse to be fail-closed on all cache identity dimensions.
+
+Fix applied: Slice C now requires cached benchmark reuse only when selected `candidate_catalog_sha256`, binary version, model ID, HMAC-derived hardware identity hash, and benchmark age all match, with negative tests for every mismatch and age greater than 7 days.
+
+## Round 2 Requirement
+
+Run the same three read-only audit lanes against the revised implementation prompt. Continue fixing and re-auditing until code, security, and architect all report 0 critical / 0 high / 0 medium findings.

--- a/specs/SPEC-023-IMPL-PROMPT-r2-audit.md
+++ b/specs/SPEC-023-IMPL-PROMPT-r2-audit.md
@@ -1,0 +1,31 @@
+# SPEC-023 Implementation Prompt Audit — Round 2
+
+Date: 2026-07-02
+
+Scope: `specs/BUILD_SPEC_023_v0_1_IMPL_PROMPT.md`
+
+Auditor lanes run: code, security, architect. No product-design lane was run.
+
+## Verdict
+
+READY TO BUILD
+
+| Lane | Critical | High | Medium | Low | Verdict |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Code | 0 | 0 | 0 | 0 | READY TO BUILD |
+| Security | 0 | 0 | 0 | 0 | READY TO BUILD |
+| Architect | 0 | 0 | 0 | 0 | READY TO BUILD |
+
+## Findings
+
+No critical, high, medium, or low findings remain.
+
+## Evidence Notes
+
+- Code lane confirmed the revised implementation prompt has no remaining code-mechanics findings.
+- Security lane confirmed the revised implementation prompt has no remaining security findings.
+- Architect lane confirmed the prompt preserves SPEC non-goals and subsystem boundaries, including buyer-mux rate-card scope, retune/status lifecycle, acceptance ownership, and final verification.
+
+## Stop Condition
+
+The BUILD implementation prompt audit loop is complete for the requested lanes. Stop before implementation work unless the operator explicitly requests the implementation phase.

--- a/specs/SPEC-023-installer-autotune-recommend.md
+++ b/specs/SPEC-023-installer-autotune-recommend.md
@@ -1,0 +1,655 @@
+# SPEC-023 — Installer-Integrated Autotune Recommend
+version: v0.1
+status: LOCKED
+owner: operator (a11)
+last-locked: 2026-07-01
+
+## 1. Mission
+
+`autotune --recommend` scores rate-card-eligible models against the operator's detected Mac hardware, local benchmark results, the current rate card, and an operator-curated static demand signal, then recommends the model with the best demand-weighted expected provider net `$/hr` among eligible rows. It serves every new provider installer and every operator who runs `macprovider-cli autotune --recommend` after install. Wave 0c lands now because beta launch readiness depends on the 120-provider acquisition cohort reaching a low-friction install path and a correct first-model choice instead of the current donor-default behavior that often selects the largest RAM-fitting dense model rather than the best paid-yield row.
+
+## 2. Non-goals
+
+- This SPEC does not solve "will buyers show up." It recommends a model from available market and hardware signals; it does not create market demand.
+- This SPEC does not auto-switch models without operator action. NiceHash QuickMiner-style profit switching is out of scope for v0.1.
+- This SPEC does not change rate-card content. Wave 1 owns the rate-card rows and prices.
+- This SPEC does not change gateway billing or coordinator settlement. Waves 0a/0b already shipped the money-path settlement and model-key normalization fixes.
+- This SPEC does not add provider-side TPS reputation feedback to the coordinator. That is deferred to v0.2.
+- This SPEC does not implement a live coordinator `/v1/demand-signal` endpoint. That is deferred to v0.2.
+- This SPEC does not implement utilization-adjusted realized-earnings projection. That is deferred to v0.2 after real buyer history exists.
+- This SPEC does not claim a live-buyer production incident as motivation. Per Decision Log Entry 95, the Wave 0a/0b urgency came from harness-driven pre-launch bug discovery; Wave 0c urgency comes from beta onboarding readiness.
+- This SPEC does not inspect or depend on Darkbloom / `d-inference` source. Competitive framing uses only public-surface findings preserved in RESEARCH_230.
+
+## 3. Inputs
+
+### 3.1 Hardware properties
+
+Hardware fields come from `MachineFingerprinter.sample()` plus local autotune benchmark measurements. The current code samples RAM, chip string, OS version, and binary version; SPEC-023 requires the implementation to extend or derive the remaining fields without weakening the existing sample.
+
+Required hardware fields:
+
+| Field | Type | Source | Rule |
+|---|---|---|---|
+| `ram_gb` | integer | `MachineFingerprinter.sample().ramGB` | Rounded unified memory in GiB. Must be at least `1`; unknown hardware is not represented as `0`. |
+| `chip` | string | `MachineFingerprinter.sample().chip` | Apple chip family or `"unknown"`. |
+| `os_version` | string | `MachineFingerprinter.sample().osVersion` | Used only for support/debug output. |
+| `binary_version` | string | `MachineFingerprinter.sample().binaryVersion` | Used for reproducibility and support/debug output. |
+| `bandwidth_tier` | string enum: `S`, `A`, `B`, `C`, `unknown` | derived from chip family / benchmark table | Unknown hardware maps to `C` for eligibility conservatism unless a benchmark-derived tier is available. |
+| `diversification_id` | string | HMAC-SHA256-derived provider ID if configured, otherwise HMAC-SHA256-derived stable machine identity | Input to deterministic diversification. Raw machine fingerprints MUST NOT be persisted, logged, emitted in JSON, included in support bundles, or sent to coordinator/gateway as part of v0.1 recommendation. |
+| `candidate_benchmarks[model_key].sustained_tps` | float | local autotune benchmark | Warm steady-state decode tokens/sec for each candidate. |
+| `candidate_benchmarks[model_key].ttft_ms` | integer | local autotune benchmark | Time to first token under the v0.1 benchmark prompt shape. |
+| `candidate_benchmarks[model_key].swap_detected` | boolean | local probe | Any swap observed during the candidate probe fails eligibility. |
+| `candidate_benchmarks[model_key].thermal_throttle_detected` | boolean | local probe | Thermal throttle during probe fails eligibility. |
+
+HMAC identity rules:
+
+- The HMAC key MUST be a per-install local secret generated with a CSPRNG during first setup.
+- The secret MUST be stored only in a local protected store: macOS Keychain when available, otherwise a root/operator-readable file with `0600` permissions under the macprovider config directory.
+- The secret MUST NOT be sent to coordinator/gateway, emitted in JSON, logged, included in support bundles, or copied into `last-recommendation.json`.
+- Diversification and cache identity MUST use separate domain labels, at minimum `macprovider-autotune-diversification-v1` and `macprovider-autotune-cache-identity-v1`, before HMAC-SHA256.
+- If the local secret is missing or unreadable, the CLI MUST create a new secret and mark any prior recommendation cache stale because the derived identity changed.
+
+Bandwidth tier rules:
+
+- Tier order is `S >= A >= B >= C`; `unknown` is treated as `C` for eligibility.
+- v0.1 derives `bandwidth_tier` from the normalized `chip` string before benchmark overrides:
+
+| Chip family match | bandwidth_tier |
+|---|---|
+| `M3 Ultra`, `M4 Ultra`, or later `Ultra` | `S` |
+| `M1 Ultra`, `M2 Ultra`, `M3 Max`, `M4 Max`, or later `Max` | `A` |
+| `M1 Max`, `M2 Max`, any `Pro` | `B` |
+| `M1`, `M2`, `M3`, `M4`, `unknown`, or unrecognized chip string | `C` |
+
+- A benchmark-derived tier override MAY raise the chip-derived tier only when the benchmark table is compiled into the same binary release and the table row names the benchmark ID, threshold, and resulting tier. It MUST NOT lower a known chip-derived tier in v0.1.
+- `min_bandwidth_tier` passes when `mac.bandwidth_tier >= model.min_bandwidth_tier` under the order above.
+
+Optional hardware fields:
+
+| Field | Type | Rule |
+|---|---|---|
+| `machine` | string | Human-readable Mac product name if available. |
+| `power_watts` | float | Used only when an electricity estimate is available. Absence must not fail recommendation. |
+| `measured_memory_pressure` | string enum | May be used for confidence; hard failure remains `swap_detected == true`. |
+| `benchmark_id` | string | Stable ID of the local benchmark run, included when available. |
+
+### 3.2 Candidate/admission catalog
+
+Candidate metadata is a separate signed control-plane input. Demand rank may score rows, but it never defines model download IDs, RAM gates, tier gates, benchmark gates, or runtime status.
+
+Primary source:
+
+```text
+https://get.streamvc.live/autotune-candidates.json
+```
+
+Fallback source:
+
+```text
+baked autotune-candidates snapshot compiled into the installer/CLI release
+```
+
+Catalog selection happens before row eligibility. If the fetched catalog is missing, invalid, unsigned, or stale beyond §3.5 limits, the CLI MUST reject the fetched catalog, use the baked catalog snapshot, and emit `candidate_catalog_fallback_used` per AC-6. After selecting either a valid fetched catalog or the baked catalog, a demand/rate-card row missing metadata in the selected catalog is ineligible and MUST NOT be downloaded or benchmarked. The baked catalog is part of the release artifact and is trusted only for that binary version.
+
+The v0.1 candidate catalog schema is:
+
+```json
+{
+  "version": "string",
+  "generated_at": "RFC3339 timestamp",
+  "source": "operator_curated_autotune_candidate_catalog",
+  "rows": {
+    "<model_key>": {
+      "model_id": "org/repo",
+      "model_revision": "40-hex content commit",
+      "model_sha256": "64-hex canonical artifact-set hash",
+      "min_ram_gb": 0,
+      "min_bandwidth_tier": "C",
+      "bench_gate": {
+        "min_sustained_tps": 0.0,
+        "max_4k_ttft_ms": 0
+      },
+      "runtime_status": "candidate",
+      "notes": "string"
+    }
+  }
+}
+```
+
+Field rules:
+
+- `model_key` is the normalized key used for rate-card and demand-rank joins.
+- `model_id` is the HuggingFace MLX model ID allowed for download/benchmark.
+- `model_revision` is a content-addressed immutable model-host revision, such as a 40-hex HuggingFace repository commit. The CLI MUST download by this revision, not by a mutable branch or tag.
+- `model_sha256` is a lowercase hex SHA-256 digest of the canonical artifact-set manifest for the release-pinned model snapshot. After downloading by `model_revision`, the CLI MUST reject the snapshot if any filesystem entry is not a regular file or directory; symlinks, hardlinks with link count greater than one, device nodes, sockets, FIFOs, absolute paths, path escapes, and relative paths containing `..` are forbidden. The CLI then enumerates every regular file, computes each file SHA-256, sorts entries by normalized POSIX relative path, serializes each entry as `path LF size_decimal LF sha256_hex LF`, concatenates those UTF-8 entries, and SHA-256s the concatenated bytes. A mismatch fails closed before benchmark, recommendation, local donor-mode commit, or provider run.
+- Every downloadable row (`candidate`, `listed`, or `recommendable`) MUST include both `model_revision` and `model_sha256`. If either is absent, the row is ineligible before download or benchmark, including donor mode.
+- `min_ram_gb`, `min_bandwidth_tier`, and `bench_gate` are authoritative for §5.
+- `runtime_status` is one of `candidate`, `listed`, `recommendable`, or `blocked`. Only `recommendable` rows may become paid defaults, and the demand-rank row must also have `recommendable: true`.
+
+The table below lists the minimum v0.1 rows and gate values. The baked JSON release artifact MUST also include a release-pinned `model_revision` and `model_sha256` for every non-`blocked` row; the long immutable bindings are omitted from this table for readability.
+
+The v0.1 baked catalog MUST contain at least these rows:
+
+| model_key | model_id | min_ram_gb | min_bandwidth_tier | min_sustained_tps | max_4k_ttft_ms | runtime_status |
+|---|---|---:|---|---:|---:|---|
+| `meta-llama/llama-3.1-8b-instruct` | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` | 16 | `C` | 20 | 2500 | `recommendable` |
+| `openai/gpt-oss-20b` | `mlx-community/gpt-oss-20b-MXFP4-Q8` | 24 | `C` | 30 | 2500 | `recommendable` |
+| `qwen3-32b` | `mlx-community/Qwen3-32B-4bit` | 32 | `A` | 30 | 3000 | `listed` |
+| `qwen3-coder-30b-a3b-instruct` | `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | 32 | `C` | 25 | 3000 | `recommendable` |
+| `qwen2.5-coder-32b-instruct` | `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | 64 | `A` | 30 | 3500 | `listed` |
+| `google-gemma-4-26b-a4b-it` | `mlx-community/gemma-4-26b-a4b-it-4bit` | 32 | `C` | 30 | 3000 | `blocked` |
+| `nvidia/nemotron-3-nano-30b-a3b` | `mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit` | 32 | `C` | 30 | 3000 | `blocked` |
+
+`blocked` rows may be shown only as diagnostics when useful; they are never downloaded, benchmarked, or recommended by default in v0.1.
+
+### 3.3 Rate card
+
+The recommendation engine fetches the current rate card from `https://coordinator.streamvc.live/v1/rate-card`. If the fetch fails, it uses the baked rate-card snapshot compiled into the installer/CLI release and emits a warning to stderr and JSON `warnings[]`.
+
+`GET /v1/rate-card` is a read-only coordinator endpoint. It MUST NOT alter billing, settlement, routing, provider state, request logs, `RateCardEntry`, YAML schema, ledger schema, or settlement arithmetic. It is public-read in v0.1 because it exposes only prices already used for buyer/provider economics; no provider or buyer credential is required. The endpoint returns a recommendation-only projection derived from the running coordinator's existing `Rewards.RateCard`, `Rewards.ProviderShare`, `Rewards.GlobalMultiplier`, and `stats.rollup.usd_per_million_credits` after config load.
+
+Repository routing contract:
+
+- The handler lives on the coordinator buyer HTTP mux (`buyer_port: 8443`), not the provider/operator mux (`provider_port: 8444`).
+- Production nginx MUST include an exact `location = /v1/rate-card` allow-through before the generic `location /v1/ { return 404; }` block in `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`.
+- The nginx location proxies to `http://127.0.0.1:8443/v1/rate-card$is_args$args`, forwards `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto`, and does not require `Authorization`.
+
+The v0.1 rate-card JSON schema is:
+
+```json
+{
+  "version": "string",
+  "generated_at": "RFC3339 timestamp",
+  "usd_per_million_credits": 1.0,
+  "rows": {
+    "<model_key>": {
+      "prompt_rate_per_mtok": 0,
+      "completion_rate_per_mtok": 0,
+      "provider_share_bps": 9000,
+      "global_multiplier_ppm": 1000000
+    }
+  }
+}
+```
+
+`prompt_rate_per_mtok` and `completion_rate_per_mtok` are coordinator credits per million tokens, matching `phase4-coordinator/internal/billing/formula.go::RateCardEntry` semantics and ledger `*_rate_per_mtok` columns. `usd_per_million_credits` is the active `stats.rollup.usd_per_million_credits` conversion used for recommendation math; v0.1 expects `1.0` but the endpoint value is authoritative. A model is rate-card-enabled for recommendation only if lookup succeeds by exact key or by Wave 0b `normalizeModelKey`. Recommendation lookup MUST NOT use the coordinator `default` fallback unless the candidate key itself is literally `default`. Unknown/missing `provider_share_bps` is non-compliant for fetched rate-card rows; baked fallback rows may use `9000` only when the release snapshot explicitly records that fallback.
+
+`version` is a recommendation-projection version, not the existing billing snapshot hash. It is the lowercase hex SHA-256 of the canonical projection bytes after config load:
+
+1. Build a JSON object containing only `usd_per_million_credits`, `provider_share_bps`, `global_multiplier_ppm`, and `rows`.
+2. Sort `rows` by normalized model key.
+3. Serialize JSON with sorted object keys, no insignificant whitespace, decimal integers for all rates/BPS/PPM values, and decimal number syntax for `usd_per_million_credits`.
+4. Exclude unrelated config and ledger fields, including quarantine/force-void state, request-log state, operator settings, and settlement runtime state.
+
+### 3.4 Demand signal
+
+The recommendation engine fetches `https://get.streamvc.live/demand-rank.json` and falls back to a baked snapshot when the static fetch fails, times out, fails Ed25519 detached-signature verification, or fails schema validation. The demand signal is operator-curated OpenRouter-prior metadata, not a coordinator demand endpoint.
+
+The v0.1 demand-rank JSON schema is locked as:
+
+```json
+{
+  "version": "string",
+  "generated_at": "RFC3339 timestamp",
+  "source": "openrouter_completion_token_rank_operator_curated",
+  "cold_start_floor": 0.15,
+  "diversification_band": 0.85,
+  "rows": {
+    "<model_key>": {
+      "demand_weight": 0.0,
+      "rank": null,
+      "recommendable": false,
+      "min_provider_target": 0
+    }
+  }
+}
+```
+
+Field rules:
+
+- `version` is an opaque operator-controlled version string and must be persisted with the recommendation.
+- `generated_at` must parse as RFC3339. A stale file is allowed in v0.1 but must add a warning when older than 14 days.
+- `source` must equal `openrouter_completion_token_rank_operator_curated` in v0.1.
+- `cold_start_floor` must equal `0.15` for v0.1.
+- `diversification_band` must equal `0.85` for v0.1.
+- `rows.<model_key>.demand_weight` is a finite number in `[0.0, 1.0]`.
+- `rows.<model_key>.rank` is either a positive integer OpenRouter completion-token rank or `null` for operator-curated rows without a current rank.
+- `rows.<model_key>.recommendable` is the operator's deployability switch. `true` means runtime support, billing/settlement, and minimum bench gates are green enough for defaults.
+- `rows.<model_key>.min_provider_target` is retained for operator coverage planning and v0.2 migration. v0.1 records it but does not query live provider counts.
+
+### 3.5 Static JSON integrity
+
+Fetched `demand-rank.json` and `autotune-candidates.json` MUST be verified before parsing into the recommendation engine:
+
+1. Fetch `{name}.json` and detached `{name}.json.sig` from `https://get.streamvc.live/`.
+2. Parse `{name}.json.sig` as UTF-8 JSON exactly in this shape:
+
+```json
+{
+  "key_id": "streamvc-autotune-static-v1",
+  "alg": "ed25519",
+  "signature": "<base64>"
+}
+```
+
+3. Verify `signature` as base64-encoded Ed25519 over the exact UTF-8 bytes of `{name}.json`.
+4. Use the release-embedded public key `autotune_static_json_ed25519_v1` and release-embedded key ID `streamvc-autotune-static-v1`.
+5. Parse `{name}.json` only after signature verification succeeds.
+6. Reject the fetched file and fall back to the baked snapshot when the signature sidecar is missing, malformed, uses the wrong `key_id`, uses any `alg` other than `ed25519`, or fails verification.
+7. Reject the fetched file and fall back to the baked snapshot when `generated_at` is older than the baked snapshot's `generated_at`.
+8. Emit `demand_rank_stale` for stale `demand-rank.json` or `candidate_catalog_stale` for stale `autotune-candidates.json`, but allow the fetched file when `generated_at` is 14-30 days old.
+9. Reject the fetched file and fall back to the baked snapshot when `generated_at` is more than 10 minutes in the future relative to the local clock.
+10. Reject the fetched file and fall back to the baked snapshot when `generated_at` is more than 30 days old.
+
+Key rotation is deferred to v0.2, but v0.1 clients MUST keep the public key and key ID release-pinned. A new key requires a new binary release.
+
+## 4. Formula (locked v0.1)
+
+The recommendation engine MUST use this v0.1 formula shape:
+
+```text
+eligible_rows = rows where:
+  rate_card_enabled AND
+  recommendable == true AND
+  hardware_fits(model, mac) AND
+  local_autotune_passes(model, mac)
+
+raw_score(row | mac) =
+  measured_tps(row, mac)
+  × 3600
+  × usd_per_million_completion_tok(row)
+  × provider_share(row)
+  × max(demand_weight(row), cold_start_floor)
+  × tier_weight(row, mac.tier)
+
+recommendation_pool =
+  all eligible rows where raw_score >= 0.85 × max(raw_score)
+
+default_model =
+  pool[ stable_hash(diversification_id) % len(pool) ]
+```
+
+Constants locked in v0.1:
+
+| Constant | Value | Rule |
+|---|---:|---|
+| `cold_start_floor` | `0.15` | From demand-rank JSON; schema validation fails if the fetched value differs. |
+| `diversification_band` | `0.85` | All eligible rows within 85% of the best raw score join the diversification pool. |
+| `provider_share` | `0.90` | Represented by rate-card row `provider_share_bps = 9000`; the row value is authoritative, but v0.1 rows are expected to use 0.90. |
+| `tier_weight` | `1.0` | Applies to all rows and tiers in v0.1. Tier-specific calibration is deferred to v0.2. |
+| ranked output length | `5` | The JSON `candidates[]` array defaults to the top 5 rows after ranking, including eligible rows first and then selected ineligible diagnostic rows only when no eligible row exists. |
+| `stable_hash` | SHA-256 over UTF-8 `diversification_id` | Interpret the first 8 bytes as unsigned big-endian integer for modulo. |
+
+`usd_per_million_completion_tok(row)` is:
+
+```text
+completion_rate_per_mtok
+× (global_multiplier_ppm / 1_000_000)
+× (usd_per_million_credits / 1_000_000)
+```
+
+Example: `completion_rate_per_mtok = 100000`, `global_multiplier_ppm = 1000000`, and `usd_per_million_credits = 1.0` yields `$0.100000/M` completion tokens. `provider_share(row)` is `provider_share_bps / 10_000.0`.
+
+Displayed earning fields are not allowed to overstate demand certainty:
+
+- `expected_gross_usd_per_hour` is full-utilization buyer gross capacity: `measured_tps × 3600 × usd_per_million_completion_tok / 1_000_000`.
+- `platform_fee_usd_per_hour` is `expected_gross_usd_per_hour × (1 - provider_share)`.
+- `expected_net_usd_per_hour` is provider-side capacity at `inputs.assumed_utilization`, minus electricity only when electricity is supplied: `(expected_gross_usd_per_hour - platform_fee_usd_per_hour) × assumed_utilization - electricity_usd_per_hour`.
+- `raw_score` is for ranking only and includes `demand_weight`; the transcript must still say the result is an estimate, not guaranteed realized earnings.
+
+## 5. Eligibility gates (mandatory pre-filter)
+
+A row is eligible only if every gate passes:
+
+1. `recommendable == true` in `demand-rank.json`.
+2. `hardware_fits(model, mac)` passes.
+3. `local_autotune_passes(model, mac)` passes.
+4. The candidate catalog row has `runtime_status == "recommendable"`.
+5. The coordinator rate card has a row for the model either verbatim or through `normalizeModelKey`, using the recommendation-specific no-default lookup from §3.3.
+
+`hardware_fits(model, mac)` rules:
+
+- v0.1 uses a fixed `safety_margin_gb = 4`.
+- The signed candidate catalog must expose `model.min_ram_gb` as the resident-fit floor excluding this safety margin.
+- The RAM headroom check is `model.min_ram_gb <= mac.ram_gb - safety_margin_gb`.
+- The signed candidate catalog must expose `min_bandwidth_tier`. Dense 32B/70B and developer dense rows must honor their tier gates; small-active MoE rows may pass on Tier-C when RAM and local probes pass.
+- Unknown hardware tier is treated as `C`; `min_bandwidth_tier` comparison uses the §3.1 order `S >= A >= B >= C`.
+
+`local_autotune_passes(model, mac)` rules:
+
+- `sustained_tps >= model.bench_gate.min_sustained_tps`.
+- `ttft_ms <= model.bench_gate.max_4k_ttft_ms`.
+- `swap_detected == false`.
+- `thermal_throttle_detected == false`.
+- The candidate benchmark must be from the current `benchmark_id` or from a cached run whose candidate catalog hash, binary version, model ID, and HMAC-derived hardware identity hash match and whose `generated_at` is no older than 7 days.
+
+If no rows pass all gates, or if the best selected row fails the `$0.0050/hr` paid-yield threshold in §7, `autotune --recommend` must emit no paid recommendation, JSON `recommended_model = null`, and the donor-tier transcript in §7.2.
+
+## 6. Output JSON contract (`autotune --recommend`)
+
+`autotune --recommend --json` MUST emit deterministic field order exactly as shown below. Unknown optional data uses `null`; fields are not reordered, renamed, or omitted in v0.1.
+
+```json
+{
+  "schema_version": "autotune_recommend.v1",
+  "generated_at": "<RFC3339>",
+  "hardware": {
+    "machine": null,
+    "chip": "<string>",
+    "memory_gb": 0,
+    "bandwidth_tier": "C",
+    "detected": true,
+    "os_version": "<string>",
+    "binary_version": "<string>"
+  },
+  "inputs": {
+    "rate_card_version": "<string>",
+    "demand_rank_version": "<string>",
+    "candidate_catalog_version": "<string>",
+    "electricity_usd_per_kwh": null,
+    "assumed_utilization": 1.0,
+    "availability_hours_per_day": 24
+  },
+  "recommended_model": "<model_key-or-null>",
+  "candidates": [
+    {
+      "rank": 1,
+      "model": "<model_key>",
+      "eligible": true,
+      "expected_gross_usd_per_hour": 0.0,
+      "expected_net_usd_per_hour": 0.0,
+      "electricity_usd_per_hour": null,
+      "platform_fee_usd_per_hour": 0.0,
+      "tokens_per_second": 0.0,
+      "memory_headroom_gb": 0.0,
+      "confidence": "low",
+      "why": "<one-line reason>"
+    }
+  ],
+  "comparison": {
+    "default_model": "<model_key-or-null>",
+    "recommended_delta_usd_per_hour": 0.0,
+    "recommended_delta_percent": 0.0
+  },
+  "warnings": []
+}
+```
+
+Schema rules:
+
+- `schema_version` is exactly `autotune_recommend.v1`.
+- `generated_at` is RFC3339 UTC.
+- `hardware.memory_gb` is an integer greater than or equal to `1`.
+- `hardware.bandwidth_tier` is one of `S`, `A`, `B`, `C`, or `unknown`.
+- `inputs.electricity_usd_per_kwh` is `null` unless the operator supplied it or the CLI has an explicit configured default. When `null`, candidate `electricity_usd_per_hour` is also `null`, electricity is omitted from net calculation, and `warnings[]` includes `electricity_not_included`.
+- `inputs.assumed_utilization` defaults to `1.0` and is in `[0.0, 1.0]`.
+- `inputs.availability_hours_per_day` defaults to `24` and is in `[0, 24]`.
+- `recommended_model` is a model key string only when a paid recommendation clears all §5 gates and `expected_net_usd_per_hour >= 0.0050`; otherwise it is `null`.
+- `candidates[]` default length is at most 5. It is sorted by eligibility first, then `raw_score` descending, then `model` lexicographically for deterministic ties.
+- `expected_*_usd_per_hour`, `platform_fee_usd_per_hour`, `tokens_per_second`, and `memory_headroom_gb` are rounded to 6 decimal places in JSON.
+- `confidence` is:
+  - `high` when rate-card fetch, signed demand-rank fetch, signed candidate-catalog fetch, current local benchmark, no-swap, and no-thermal checks all used live/current data.
+  - `medium` when rate card, demand rank, or candidate catalog used a valid baked fallback, or the benchmark used a valid cache.
+  - `low` when both market inputs used baked fallback, hardware tier is unknown, or any non-fatal diagnostic warning affects the recommended row.
+- `why` is a single line under 140 characters, contains no newline, and must not promise realized buyer demand.
+- `warnings[]` is an array of stable machine-readable strings, sorted lexicographically. v0.1 warning vocabulary is: `candidate_catalog_fallback_used`, `candidate_catalog_stale`, `demand_rank_fallback_used`, `demand_rank_stale`, `electricity_not_included`, `hardware_tier_unknown`, `rate_card_fallback_used`, `recommendation_below_threshold`, `no_eligible_paid_model`.
+
+## 7. Install transcript copy (locked text)
+
+All `$/hr` human transcript values MUST render as `$%.4f/hr`. The minimum paid-yield threshold is `$0.0050/hr` after provider share, assumed utilization, and available electricity adjustment.
+
+### 7.1 Happy path
+
+Use this text verbatim, replacing braces with computed values:
+
+```text
+Detected {machine_or_chip}, {memory_gb} GB unified memory, Tier {bandwidth_tier}.
+Benchmarked {benchmarked_count} compatible models against rate card {rate_card_version} and demand rank {demand_rank_version}.
+
+Recommended: {recommended_model}
+Expected net capacity: {expected_net_usd_per_hour}/hr at {assumed_utilization_percent}% utilization
+Why: {recommended_delta_usd_per_hour}/hr vs default {default_model}; {memory_headroom_gb} GB memory headroom
+
+This is an estimate, not a guarantee. Actual earnings depend on buyer demand, uptime, thermal state, electricity, and rate-card changes.
+
+Start provider with {recommended_model}? [Y/n]
+```
+
+Happy path applies only when at least one recommendable model is eligible and the selected recommendation has `expected_net_usd_per_hour >= 0.0050`.
+
+### 7.2 Donor-tier path
+
+Use this text verbatim, replacing braces with computed values:
+
+```text
+Detected {machine_or_chip}, {memory_gb} GB unified memory, Tier {bandwidth_tier}.
+No paid model currently clears the minimum net-yield threshold of $0.0050/hr.
+
+Best compatible option: {best_compatible_model}
+Expected net capacity: {expected_net_range_or_value}/hr before demand risk
+Recommendation: donor mode only
+
+You can keep this Mac configured for donor-mode testing, but it is not expected to earn meaningful revenue on the current rate card.
+Enable donor mode? [y/N]
+```
+
+Donor-tier path applies when no recommendable model has `expected_net_usd_per_hour >= 0.0050` or no row passes all §5 gates.
+
+## 8. Donor-mode UX
+
+v0.1 locks an explicit local donor-mode override:
+
+- CLI flag: `--donor-mode` as a boolean flag on the configuration/apply path.
+- YAML config: `donor_mode: true` as a boolean.
+- Install prompt default: No (`[y/N]`).
+
+When `donor_mode == true`:
+
+- The CLI may skip only the paid-yield threshold and demand-rank `recommendable == true` default-selection gate.
+- The CLI MUST NOT bypass signed candidate-catalog presence, immutable model revision, canonical artifact-set digest check, `runtime_status != "blocked"`, model ID allowlist, RAM headroom, no-swap, no-thermal, or runtime-support gates.
+- A donor-mode row must have signed candidate metadata with `runtime_status` equal to `candidate`, `listed`, or `recommendable`; `blocked` rows remain forbidden.
+- SPEC-023 does not add coordinator/gateway donor-routing or settlement behavior. Applying donor mode may write local config and status only; it MUST NOT auto-start or auto-register a network-connected paid provider for a non-recommendable donor row. Network-connected donor serving requires a separate donor-routing/settlement spec or build prerequisite.
+- The CLI must print an explicit warning before commit:
+
+```text
+DONOR MODE: {selected_model} is estimated to earn {delta_usd_per_hour}/hr less than the recommended model on this Mac.
+```
+
+- When no paid recommendation exists, use:
+
+```text
+DONOR MODE: no paid model clears $0.0050/hr on this Mac; {selected_model} is for network support only.
+```
+
+- `macprovider-cli status` must show a `DONOR MODE` badge alongside the configured model while `donor_mode: true`.
+
+## 9. Re-tune cadence + UX
+
+`autotune --recommend` re-runs or prompts the operator in exactly these v0.1 cases:
+
+1. Manual invocation: `macprovider-cli autotune --recommend`.
+2. `macprovider-cli update` or installer rerun after install, when the live rate-card version, live demand-rank version, signed candidate-catalog version/hash, binary version, stable hardware identity hash, or benchmark age differs from stored recommendation state.
+3. Installer rerun when no stored recommendation exists.
+
+v0.1 explicitly does not re-run automatically on coordinator SIGHUP or rate-card hot reload. Coordinator broadcast of recommendation changes is deferred to v0.2.
+
+The CLI stores the last recommendation result at:
+
+```text
+~/.config/macprovider/last-recommendation.json
+```
+
+Stored state MUST include at least:
+
+```json
+{
+  "generated_at": "<RFC3339>",
+  "rate_card_version": "<string>",
+  "demand_rank_version": "<string>",
+  "candidate_catalog_version": "<string>",
+  "candidate_catalog_sha256": "<hex>",
+  "benchmark_id": "<string-or-null>",
+  "benchmark_generated_at": "<RFC3339-or-null>",
+  "binary_version": "<string>",
+  "hardware_identity_hash": "<hex>",
+  "recommended_model": "<model_key-or-null>"
+}
+```
+
+`hardware_identity_hash` is an HMAC-SHA256-derived local identity hash. It MUST NOT be a raw serial number, MAC address, device UUID, or unhashed hardware fingerprint.
+
+Stored hash/version derivation:
+
+- `candidate_catalog_sha256` is the lowercase hex SHA-256 over the exact selected catalog JSON bytes after fetched/baked selection and before parsing normalization.
+- `rate_card_version` is the `/v1/rate-card.version` recommendation-projection hash from §3.3. It MUST NOT reuse broader coordinator config or billing snapshot hashes that include unrelated ledger, quarantine, request-log, operator, or settlement state.
+- `demand_rank_version` is the selected demand-rank JSON `version`; v0.1 does not require an additional stored demand-rank hash.
+
+`macprovider-cli status` MUST emit a stale-recommendation warning when the live rate-card version, demand-rank version, candidate-catalog version/hash, binary version, stable hardware identity hash, or benchmark freshness differs from this stored state:
+
+```text
+Recommendation stale: recommendation inputs changed since {generated_at}.
+Run: macprovider-cli autotune --recommend
+```
+
+## 10. Goodhart mitigations
+
+| ID | Mitigation | SPEC-023 implementation |
+|---|---|---|
+| M1 | Deterministic diversification | §4 defines `recommendation_pool` as all eligible rows within 85% of best score and `stable_hash(...) % len(pool)`. |
+| M3 | Cold-start floor | §3.4 and §4 lock `cold_start_floor = 0.15` and `max(demand_weight, cold_start_floor)`. |
+| M4 | Row lifecycle states | §3.2 and §3.4 lock `runtime_status` and `recommendable`; §5 requires both before default recommendations. |
+| M7 | Rate-card version binding | §3.3, §6, and §9 persist `rate_card_version`. |
+| M8 | Retune hint | §9 defines upgrade/manual triggers and stale status text. |
+| M12 | Hard eligibility gates | §5 requires RAM, benchmark, no-swap, no-thermal, and rate-card gates before scoring. |
+| M16 | Deployability gate | §3.2 and §3.4 define deployability via `runtime_status` + `recommendable`; §5 enforces both. |
+| M18 | Full-utilization wording | §4 separates ranking from displayed capacity; §7 says "estimate, not a guarantee." |
+| M20 | Static JSON demand control plane | §3.4 requires `get.streamvc.live/demand-rank.json` with baked fallback and version metadata. |
+
+## 11. Acceptance criteria
+
+AC-1: `macprovider-cli autotune --recommend --json` output validates against `autotune_recommend.v1` for any Mac where `MachineFingerprinter.sample()` returns at least `ram_gb = 1`.
+
+AC-2: JSON field order is deterministic and matches §6 exactly for stable diffs and snapshot tests.
+
+AC-3: When all rows fail eligibility, JSON emits `recommended_model = null`, warnings include `no_eligible_paid_model`, and human output uses the §7.2 donor-tier transcript.
+
+AC-4: When `https://get.streamvc.live/demand-rank.json` returns 404, times out, fails schema validation, fails Ed25519 detached-signature validation, is older than the baked snapshot, is more than 10 minutes in the future, or is more than 30 days old, the CLI falls back to the baked demand-rank snapshot and emits `demand_rank_fallback_used`.
+
+AC-5: When `/v1/rate-card` cannot be fetched, the CLI falls back to the baked rate-card snapshot and emits `rate_card_fallback_used`.
+
+AC-6: When `https://get.streamvc.live/autotune-candidates.json` returns 404, times out, fails schema validation, fails Ed25519 detached-signature validation, is older than the baked snapshot, is more than 10 minutes in the future, or is more than 30 days old, the CLI falls back to the baked candidate catalog and emits `candidate_catalog_fallback_used`.
+
+AC-7: `stable_hash(diversification_id) % len(pool)` produces the same recommendation for the same stable input and same pool across repeated runs.
+
+AC-8: For a pool length of at least 3, a deterministic-hash distribution test over 100 synthetic provider IDs selects at least 2 distinct models.
+
+AC-9: Rows outside the 85% diversification band are not chosen as `recommended_model` unless all higher rows become ineligible.
+
+AC-10: A row with demand `recommendable: false` or candidate `runtime_status != "recommendable"` is never selected as the paid default recommendation.
+
+AC-11: A row whose `model.min_ram_gb > mac.ram_gb - 4` fails `hardware_fits` and is not benchmarked. v0.1 has no arbitrary local-model or custom donor-mode path override; any donor-mode selection must still select a row from the signed selected candidate catalog and pass §3.2, §5, §8, and AC-22 controls.
+
+AC-12: A row whose local benchmark records swap or thermal throttle fails eligibility even if its raw TPS is highest.
+
+AC-13: A row whose benchmark misses either `min_sustained_tps` or `max_4k_ttft_ms` fails eligibility.
+
+AC-14: A buyer/model string that matches the rate-card only after `normalizeModelKey` is treated as rate-card-enabled and records the normalized key in the candidate model field.
+
+AC-15: A candidate that would match only the coordinator `default` rate-card row is not rate-card-enabled for recommendation and cannot become `recommended_model`.
+
+AC-16: Missing candidate metadata, missing immutable `model_revision`, or missing canonical `model_sha256` for a demand/rate-card row makes the row ineligible before model download or benchmark.
+
+AC-17: Missing electricity input leaves `electricity_usd_per_kwh = null`, `electricity_usd_per_hour = null`, omits electricity from `expected_net_usd_per_hour`, and emits `electricity_not_included`.
+
+AC-18: Supplied electricity input subtracts estimated electricity cost from `expected_net_usd_per_hour` and removes `electricity_not_included`.
+
+AC-19: A selected row with `expected_net_usd_per_hour < 0.0050` emits `recommended_model = null`, `recommendation_below_threshold`, and the §7.2 donor-tier transcript.
+
+AC-20: The happy-path transcript exactly matches §7.1 with `$%.4f/hr` formatting.
+
+AC-21: The donor-tier transcript exactly matches §7.2 with threshold `$0.0050/hr` and prompt default No.
+
+AC-22: `--donor-mode` allows a non-recommendable or below-threshold model to be locally committed only after printing the §8 warning, writing `donor_mode: true`, and verifying signed catalog metadata, immutable model revision, canonical artifact-set digest, `runtime_status != "blocked"`, model allowlist, RAM headroom, no-swap, no-thermal, and runtime support.
+
+AC-23: Applying donor mode for a non-recommendable row does not auto-start or auto-register a network-connected paid provider. Any network-connected donor serving is blocked until a separate donor-routing/settlement prerequisite exists.
+
+AC-24: `macprovider-cli status` shows `DONOR MODE` when `donor_mode: true`.
+
+AC-25: `macprovider-cli update` and installer rerun compare stored `rate_card_version`, `demand_rank_version`, `candidate_catalog_version/hash`, `binary_version`, `hardware_identity_hash`, and benchmark age with live/current values and prompt re-tune when any changed or expired.
+
+AC-26: `macprovider-cli status` emits the stale-recommendation warning in §9 when stored recommendation metadata differs from live metadata.
+
+AC-27: The recommendation cache at `~/.config/macprovider/last-recommendation.json` is written after a successful recommendation and contains every field listed in §9 stored state.
+
+AC-28: Raw hardware fingerprints, serial numbers, MAC addresses, device UUIDs, and the local HMAC secret do not appear in JSON output, logs, warnings, support bundles, or `last-recommendation.json`; only domain-separated HMAC-derived identifiers are persisted.
+
+AC-29: Human output never states or implies guaranteed earnings; it uses "Expected net capacity" and the exact estimate disclaimer from §7.
+
+AC-30: v0.1 implementation does not add or require a coordinator `/v1/demand-signal` endpoint, provider quota policy, or automatic model switch.
+
+AC-31: Static JSON whose `generated_at` is more than 10 minutes in the future relative to the local clock falls back to the baked snapshot and emits the matching fallback warning.
+
+AC-32: A non-`blocked` candidate catalog row without immutable `model_revision` or without canonical `model_sha256` is not downloaded, benchmarked, recommended, or locally committed in donor mode.
+
+AC-33: The local HMAC secret is generated with a CSPRNG, stored in Keychain or a `0600` local file, never emitted outside the host, and uses separate domain labels for diversification and recommendation-cache identity.
+
+AC-34: After downloading a model by immutable `model_revision`, the CLI computes the canonical artifact-set hash exactly as specified in §3.2 and fails closed before benchmark, recommendation, local donor-mode commit, or provider run when it differs from catalog `model_sha256`.
+
+AC-35: Bandwidth-tier eligibility is deterministic: a Tier-C Mac fails a row with `min_bandwidth_tier = "A"` when all other gates pass, while a Tier-A or Tier-S Mac passes that row when all other gates pass.
+
+AC-36: A downloaded model snapshot containing symlinks, hardlinks with link count greater than one, special files, absolute paths, path escapes, or `..` path segments fails artifact verification before benchmark, recommendation, local donor-mode commit, or provider run.
+
+AC-37: Unauthenticated `GET https://coordinator.streamvc.live/v1/rate-card` reaches the coordinator buyer mux through nginx and returns the §3.3 schema; the nginx route is declared before the generic `/v1/` 404 block.
+
+AC-38: `rate_card_version` changes when the recommendation projection rows, provider share, global multiplier, or `usd_per_million_credits` change, and does not change when unrelated quarantine, request-log, operator, ledger runtime, or settlement runtime state changes.
+
+AC-39: `candidate_catalog_sha256` is computed over the exact selected catalog JSON bytes, so changing catalog whitespace changes the stored hash while preserving schema validation behavior.
+
+## 12. Open questions / v0.2 candidates
+
+Q1: Live coordinator `/v1/demand-signal` endpoint and switch trigger. v0.2 may use local attempted-demand stats only after at least 60 days history, 50M paid or auth-valid requested completion-token equivalent, 5 buyer accounts or partner keys with non-test traffic, and no single buyer contributing more than 50% of model demand.
+
+Q2: Tier-specific `tier_weight` calibration. v0.1 locks all tier weights to `1.0`.
+
+Q3: Provider TPS reputation downweighting from production traffic.
+
+Q4: Utilization-adjusted realized-earnings projection once buyer history exists.
+
+Q5: Coordinator broadcast of "recommendation changed" on hot reload, with provider auto-prompt.
+
+Q6: Per-provider quota / coverage allocation policy.
+
+Q7: Collusion detection / cartel monitoring.
+
+Q8: Cross-Mac transfer of recommendation, such as an operator cloning config to a second Mac.
+
+Q9: Donor-mode time-limited grant of token rewards and any `TOKEN_NAME` ledger interaction.
+
+Q10: Static JSON key rotation policy after the release-pinned Ed25519 v0.1 key ages out.
+
+Q11: How to represent model quality and buyer-acceptance scores without creating a new Goodhart target.
+
+Q12: Whether minimum provider coverage targets should become an active recommendation input once provider-count telemetry exists.
+
+## 13. Differentiation framing
+
+macprovider's provider-install UX sits in a gap left by most decentralized GPU networks. Vast, RunPod, io.net, Akash, Aethir, Render, and Bittensor generally expose raw capacity, bids, node eligibility, subnet incentives, or buyer-selected workloads; their public provider flows do not show an installer-time recommendation that says "given this hardware, run this model to earn the most." That difference follows from their market structure: the buyer brings a container, manifest, render job, or subnet task, while the provider supplies capacity or competes under a protocol.
+
+The closest competitive exception is Darkbloom. Its public pages show an Apple-Silicon inference network, a CLI provider install path, and an earnings calculator that auto-selects the "most profitable" model for a chosen Mac hardware profile. macprovider should not claim the whole idea is unobserved. The sharper wedge is that SPEC-023 makes the recommendation local, installer-integrated, benchmark-backed, and machine-readable via `autotune --recommend`, rather than only a web estimate.
+
+The right UX lineage is not generic cloud hosting. It is staking calculators and mining profitability calculators: ranked yield options, transparent assumptions, power/rate inputs, confidence, and stale-data warnings. macprovider has the same shape: detected hardware plus measured tokens/sec plus a per-model rate card plus demand assumptions yields a ranked recommendation.
+
+This will not create demand where none exists. SPEC-023 answers "which model should this provider run, given known rates and measured local performance?" It does not answer "will buyers show up?" The UX must say that clearly: expected `$/hr` is an estimate conditioned on demand, utilization, uptime, electricity, and the current rate card.
+
+## 14. Threat model
+
+| Threat | Capability | v0.1 defense | Deferred |
+|---|---|---|---|
+| Static JSON tampering | DNS, CDN, or static-host compromise attempts to alter demand weights, `recommendable`, or candidate gates | §3.5 Ed25519 detached signatures, release-pinned public key, fallback to baked snapshot on invalid/missing/stale signed data | Key rotation automation in v0.2 |
+| Static JSON replay | Attacker serves an old but once-valid static file | §3.5 rejects files older than baked snapshot and files older than 30 days; 14-30 days emits `demand_rank_stale` or `candidate_catalog_stale` | Transparency log or monotonic operator epoch in v0.2 |
+| Untrusted candidate metadata or mutable model artifact | Malicious metadata points to oversized/unsafe model, weak gates, or a mutable model-host branch that changes after signing | §3.2 signed candidate catalog, allowlisted model IDs, immutable `model_revision`, required canonical `model_sha256`, and missing metadata/digest fail-closed before download/benchmark | Richer artifact transparency log in v0.2 |
+| Provider benchmark gaming | Provider optimizes or tampers with local benchmark | §5 requires CLI-owned benchmark, sustained TPS, TTFT, no-swap, no-thermal checks; production TPS reputation deferred | Coordinator production feedback in v0.2 |
+| Donor-mode abuse | Operator commits non-recommendable row and receives paid buyer traffic | §8 keeps donor mode local-only for non-recommendable rows and blocks network-connected paid registration until a separate donor-routing/settlement prerequisite exists | Explicit donor traffic class or rewards policy in v0.2 |
+| Fingerprint leakage | Stable hardware identity links provider across runs or support bundles | §3.1 and §9 require per-install-secret, domain-separated HMAC-derived identities only; AC-28 and AC-33 ban raw fingerprints and HMAC secrets in persisted/output paths | Formal privacy review if identities become network-visible |
+| Misleading earnings claims | Provider interprets capacity as guaranteed realized income | §4 separates ranking score from displayed capacity; §7 locks estimate disclaimer; AC-29 enforces wording | Utilization-adjusted realized projection in v0.2 |
+| Clean-room violation | Competitive framing accidentally depends on Darkbloom source | §2 and §13 restrict Darkbloom references to public surfaces only | None; source inspection remains prohibited |

--- a/specs/SPEC-023-v0_1-r1-audit.md
+++ b/specs/SPEC-023-v0_1-r1-audit.md
@@ -1,0 +1,75 @@
+# SPEC-023 v0.1 — Round 1 Audit
+
+Date: 2026-07-01
+
+Scope: three-lane Codex audit only: code, security, architect. No product-design lane was run per operator instruction.
+
+Target: `specs/SPEC-023-installer-autotune-recommend.md`
+
+## Round verdict
+
+NEEDS FIX PASS.
+
+Aggregate blockers before fix pass:
+
+- CRITICAL: 0
+- HIGH: 9
+- MEDIUM: 6
+- LOW: 0
+
+## Lane verdicts
+
+| Lane | Verdict | Counts |
+|---|---|---|
+| Code | NEEDS FIX PASS | 0C / 5H / 1M / 0L |
+| Security | NEEDS FIX PASS | 0C / 2H / 3M / 0L |
+| Architect | NEEDS FIX PASS | 0C / 2H / 2M / 0L |
+
+## Findings and fixes applied
+
+### Code lane
+
+- HIGH-CODE-001: Earnings formula used ambiguous rate units and omitted credits-to-USD conversion.
+  - Fix: §3.3 now includes `usd_per_million_credits`; §4 defines `usd_per_million_completion_tok` from `completion_rate_per_mtok`, `global_multiplier_ppm`, and `usd_per_million_credits`.
+- HIGH-CODE-002: Paid recommendation threshold contradicted happy-path eligibility.
+  - Fix: §5, §6, §7, and AC-19 now consistently require `expected_net_usd_per_hour >= 0.0050` for a paid recommendation.
+- HIGH-CODE-003: `/v1/rate-card` fetch lacked endpoint contract.
+  - Fix: §3.3 now locks `GET /v1/rate-card` as read-only, public-read, non-mutating, and sourced from the effective coordinator rate-card snapshot.
+- HIGH-CODE-004: Current `RateFor` default fallback could silently enable unknown models.
+  - Fix: §3.3 and AC-15 now require recommendation-specific lookup: exact key, then `normalizeModelKey`, with no `default` fallback except literal `default`.
+- HIGH-CODE-005: Candidate metadata source and values were not locked.
+  - Fix: §3.2 now defines signed `autotune-candidates.json`, baked fallback, schema, fail-closed behavior, and v0.1 baked rows.
+- MEDIUM-CODE-006: Demand-rank checksum/signature validation format was deferred.
+  - Fix: §3.5 now locks Ed25519 detached-signature validation over exact JSON bytes.
+
+### Security lane
+
+- HIGH-SEC-01: Static demand-rank control-plane verification was not locked.
+  - Fix: §3.5 locks the v0.1 Ed25519 verification mechanism, replay/staleness behavior, release-pinned key ID, and fallback behavior.
+- HIGH-SEC-02: Donor-mode non-recommendable rows were not partitioned from paid routing/settlement.
+  - Fix: §8 and AC-23 require donor-mode config/heartbeat and paid routing/settlement exclusion for non-recommendable donor rows.
+- MEDIUM-SEC-03: Candidate model metadata trust boundary was undefined.
+  - Fix: §3.2 locks signed candidate metadata, allowlisted model IDs, optional digest, and fail-closed no-download behavior.
+- MEDIUM-SEC-04: Threat model section was missing.
+  - Fix: §14 now enumerates static JSON tampering/replay, untrusted metadata, benchmark gaming, donor abuse, fingerprint leakage, misleading earnings, and clean-room boundaries.
+- MEDIUM-SEC-05: Fingerprint privacy guardrail was too narrow.
+  - Fix: §3.1, §9, AC-28, and §14 require HMAC-derived identities only and ban raw fingerprint persistence/output.
+
+### Architect lane
+
+- HIGH-ARCH-01: Candidate/admission metadata was an implicit control plane with no source or version lifecycle.
+  - Fix: §3.2 defines the signed candidate/admission catalog; §9 stores and invalidates on candidate catalog version/hash.
+- HIGH-ARCH-02: Paid recommendation threshold was internally contradictory.
+  - Fix: same as HIGH-CODE-002.
+- MEDIUM-ARCH-03: Demand-rank signature validation was required but not specified.
+  - Fix: same as HIGH-SEC-01.
+- MEDIUM-ARCH-04: Stored recommendation freshness ignored benchmark, binary, hardware, and candidate metadata invalidation.
+  - Fix: §9 and AC-25/AC-27 now persist and compare candidate catalog hash, benchmark ID/time, binary version, and HMAC-derived hardware identity hash.
+
+## Accepted LOWs
+
+None.
+
+## Next round target
+
+Re-run code, security, and architect lanes only. Lock condition remains 0 CRITICAL / 0 HIGH / 0 MEDIUM across all three lanes.

--- a/specs/SPEC-023-v0_1-r2-audit.md
+++ b/specs/SPEC-023-v0_1-r2-audit.md
@@ -1,0 +1,84 @@
+# SPEC-023 v0.1 Round 2 Audit
+
+Date: 2026-07-01
+Spec under audit: `specs/SPEC-023-installer-autotune-recommend.md`
+Scope: three-lane Codex audit only: code, security, architect. No product-design lane was run per operator instruction.
+
+## Result
+
+Round 2 did not pass. The three requested audit lanes reported the following critical/high/medium findings:
+
+| Lane | Critical | High | Medium | Low | Status |
+| --- | ---: | ---: | ---: | ---: | --- |
+| code | 0 | 1 | 3 | 1 | Needs fix pass |
+| security | 0 | 0 | 1 | 1 | Needs fix pass |
+| architect | 1 | 0 | 0 | 2 | Needs fix pass |
+
+## Blocking findings and resolutions
+
+### CRITICAL-ARCH-01: donor-mode scope crossed the SPEC-023 boundary
+
+Finding: the round 1 donor-mode fix introduced coordinator/gateway routing and settlement behavior while §2 says SPEC-023 does not change gateway billing or coordinator settlement.
+
+Resolution:
+- §8 now defines donor mode as a local provider-side override only for v0.1.
+- SPEC-023 no longer specifies coordinator/gateway donor routing, heartbeat, or settlement changes.
+- Applying donor mode for a non-recommendable row MUST NOT auto-start or auto-register a network-connected paid provider.
+- Network-connected donor serving is deferred to a separate donor-routing/settlement spec or build prerequisite.
+- AC-23 and the threat model now encode that boundary explicitly.
+
+### HIGH-CODE-R2-001: `/v1/rate-card` risked money-path schema changes
+
+Finding: the rate-card endpoint description could be implemented by changing `RateCardEntry`, YAML schema, billing, settlement, or ledger behavior.
+
+Resolution:
+- §3.3 now states `GET /v1/rate-card` is a read-only recommendation-only projection.
+- It MUST NOT alter billing, settlement, routing, provider state, request logs, `RateCardEntry`, YAML schema, ledger schema, or settlement arithmetic.
+- The endpoint derives its response from existing `Rewards.RateCard`, `Rewards.ProviderShare`, `Rewards.GlobalMultiplier`, and `stats.rollup.usd_per_million_credits` after config load.
+
+### MEDIUM-SEC-01: donor mode could bypass runtime and deployability guardrails
+
+Finding: donor mode bypass rules were too broad and could allow blocked, unsupported, unsafe, or non-deployable rows.
+
+Resolution:
+- §8 now says donor mode may skip only paid-yield and demand-rank `recommendable` default-selection gates.
+- Donor mode MUST NOT bypass signed catalog metadata, `runtime_status != "blocked"`, model allowlist, digest checks when present, RAM headroom, no-swap, no-thermal, or runtime support.
+- AC-22 now requires those checks before any local donor-mode commit.
+
+### MEDIUM-CODE-R2-002: signature sidecar key validation was underspecified
+
+Finding: §3.5 referenced `key_id` but did not define a sidecar schema, making key validation ambiguous.
+
+Resolution:
+- §3.5 now defines the detached signature sidecar as JSON with `key_id`, `alg`, and base64 `signature`.
+- Verification rejects missing, malformed, wrong-key, wrong-algorithm, or failed-signature sidecars.
+
+### MEDIUM-CODE-R2-003: donor-mode exclusion was not pinned to current surfaces
+
+Finding: the donor-mode exclusion referenced routing/status behavior without a clear implementation boundary.
+
+Resolution:
+- The spec now uses a provider-side-only boundary for SPEC-023.
+- Local config/status may reflect donor mode, but network-connected paid serving for non-recommendable donor rows is blocked until a separate prerequisite defines coordinator/gateway behavior.
+
+### MEDIUM-CODE-R2-004: retune trigger named a nonexistent command
+
+Finding: §9 referenced `macprovider upgrade`, while the current flow uses `macprovider-cli update` and installer rerun.
+
+Resolution:
+- §9 and AC-25 now use `macprovider-cli update` and installer rerun as the post-install retune triggers.
+
+## Low findings handled opportunistically
+
+- §3.2 now references §3.5 for integrity rules instead of the incorrect §3.4 reference.
+- The demand-rank fallback wording now names Ed25519 detached-signature verification instead of generic checksum/signature language.
+
+## Round 3 requirement
+
+Run only the requested three Codex audit lanes again:
+
+- code
+- security
+- architect
+
+Continue fixing and re-auditing until all three lanes report zero critical, high, and medium findings.

--- a/specs/SPEC-023-v0_1-r3-audit.md
+++ b/specs/SPEC-023-v0_1-r3-audit.md
@@ -1,0 +1,72 @@
+# SPEC-023 v0.1 Round 3 Audit
+
+Date: 2026-07-01
+Spec under audit: `specs/SPEC-023-installer-autotune-recommend.md`
+Scope: three-lane Codex audit only: code, security, architect. No product-design lane was run per operator instruction.
+
+## Result
+
+Round 3 did not pass. The three requested audit lanes reported the following critical/high/medium findings:
+
+| Lane | Critical | High | Medium | Low | Status |
+| --- | ---: | ---: | ---: | ---: | --- |
+| code | 0 | 0 | 2 | 0 | Needs fix pass |
+| security | 0 | 1 | 1 | 1 | Needs fix pass |
+| architect | 0 | 0 | 0 | 1 | Pass on blocking threshold |
+
+## Blocking findings and resolutions
+
+### HIGH-SEC-R3-001: mutable model artifacts were trusted when `model_sha256` was null
+
+Finding: a signed candidate catalog could point to a mutable model-host repository while `model_sha256` was null, allowing the downloaded artifact to differ from what the catalog author intended.
+
+Resolution:
+- §3.2 now requires every downloadable row to include a content-addressed immutable `model_revision`.
+- §3.2 also requires at least one artifact binding: `artifact_manifest_sha256` or `model_sha256`.
+- The CLI must download by immutable revision, not mutable branch or tag.
+- Rows missing immutable revision or artifact binding are ineligible before download or benchmark, including donor mode.
+- AC-16 and AC-32 cover this fail-closed behavior.
+- The threat model now treats mutable model artifacts as a v0.1 defended threat, not a deferred digest problem.
+
+### MEDIUM-SEC-R3-002: HMAC identity privacy depended on unspecified key scope
+
+Finding: `diversification_id` and `hardware_identity_hash` were HMAC-derived, but the key source, storage, and domain separation were unspecified.
+
+Resolution:
+- §3.1 now requires a per-install CSPRNG-generated local secret.
+- The secret must be stored in Keychain or a `0600` local file and must never be emitted, logged, bundled, or sent to coordinator/gateway.
+- Diversification and cache identity use separate HMAC domain labels.
+- Missing/unreadable local secret causes regeneration and marks previous recommendation cache stale.
+- AC-28 and AC-33 cover the secret handling and domain separation.
+
+### MEDIUM-CODE-R3-001: spec named nonexistent `macprovider` commands
+
+Finding: the repo installs and exposes `macprovider-cli`, while the spec still used `macprovider autotune --recommend` and `macprovider status`.
+
+Resolution:
+- Live command references now use `macprovider-cli autotune --recommend`, `macprovider-cli update`, and `macprovider-cli status`.
+- AC-1, AC-24, and AC-26 now use `macprovider-cli`.
+
+### MEDIUM-CODE-R3-002: donor-mode `runtime_status` rules contradicted each other
+
+Finding: §8 said donor mode may not bypass `runtime_status != "blocked"` but then narrowed donor rows to `candidate` or `listed`, excluding below-threshold `recommendable` rows. AC-22 only required non-blocked status.
+
+Resolution:
+- §8 now allows donor-mode local commit for signed candidate metadata with `runtime_status` equal to `candidate`, `listed`, or `recommendable`.
+- `blocked` rows remain forbidden.
+- AC-22 now describes non-recommendable or below-threshold local donor-mode commit with the same non-blocked rule.
+
+## Low findings handled opportunistically
+
+- §3.5 and AC-31 now reject fetched static JSON whose `generated_at` is more than 10 minutes in the future.
+- §9 stale warning copy now says recommendation inputs changed, matching the full stale trigger set.
+
+## Round 4 requirement
+
+Run only the requested three Codex audit lanes again:
+
+- code
+- security
+- architect
+
+Continue fixing and re-auditing until all three lanes report zero critical, high, and medium findings.

--- a/specs/SPEC-023-v0_1-r4-audit.md
+++ b/specs/SPEC-023-v0_1-r4-audit.md
@@ -1,0 +1,62 @@
+# SPEC-023 v0.1 Round 4 Audit
+
+Date: 2026-07-01
+Spec under audit: `specs/SPEC-023-installer-autotune-recommend.md`
+Scope: three-lane Codex audit only: code, security, architect. No product-design lane was run per operator instruction.
+
+## Result
+
+Round 4 did not pass. The three requested audit lanes reported the following critical/high/medium findings:
+
+| Lane | Critical | High | Medium | Low | Status |
+| --- | ---: | ---: | ---: | ---: | --- |
+| code | 0 | 0 | 1 | 0 | Needs fix pass |
+| security | 0 | 0 | 1 | 0 | Needs fix pass |
+| architect | 0 | 0 | 1 | 1 | Needs fix pass |
+
+## Blocking findings and resolutions
+
+### MEDIUM-CODE-R4-001: candidate catalog fallback rules were internally contradictory
+
+Finding: §3.2 said a missing/invalid/unsigned/stale fetched catalog made rows ineligible, while §3.5 and AC-6 said the CLI must reject the fetched catalog and use the baked snapshot.
+
+Resolution:
+- §3.2 now separates catalog selection from row eligibility.
+- If the fetched catalog fails integrity/freshness checks, the CLI rejects it, uses the baked catalog, and emits `candidate_catalog_fallback_used`.
+- Only after selecting a valid fetched or baked catalog can a row be marked ineligible for missing metadata in that selected catalog.
+
+### MEDIUM-SEC-R4-001: artifact binding verification was not explicit on the paid path
+
+Finding: §3.2 required an artifact binding but did not explicitly require pre-benchmark/pre-run verification for paid recommendations. Donor-mode AC-22 had clearer digest wording than the default paid path.
+
+Resolution:
+- v0.1 no longer supports a separate `artifact_manifest_sha256` mode.
+- §3.2 now requires every downloadable row to include immutable `model_revision` and canonical `model_sha256`.
+- §3.2 defines the canonical artifact-set hash algorithm over sorted relative file path, file size, and file SHA-256 entries.
+- A mismatch fails closed before benchmark, recommendation, local donor-mode commit, or provider run.
+- AC-16, AC-22, AC-32, and AC-34 encode the same rule.
+
+### MEDIUM-ARCH-R4-001: artifact-manifest lifecycle was undefined
+
+Finding: `artifact_manifest_sha256` introduced another lifecycle without specifying source, schema, signature/hash verification, downloaded-file checks, or persistence.
+
+Resolution:
+- Removed `artifact_manifest_sha256` from v0.1.
+- Required direct canonical `model_sha256` verification for all downloadable rows.
+- The threat model now names immutable `model_revision` plus canonical `model_sha256` as the v0.1 defense.
+
+## Low findings handled opportunistically
+
+- Replaced undefined `top-K` wording with `diversification_band`.
+- §4 now defines `recommendation_pool` as all eligible rows within 85% of the best raw score.
+- AC-9 and Goodhart M1 now use the same diversification-band vocabulary.
+
+## Round 5 requirement
+
+Run only the requested three Codex audit lanes again:
+
+- code
+- security
+- architect
+
+Continue fixing and re-auditing until all three lanes report zero critical, high, and medium findings.

--- a/specs/SPEC-023-v0_1-r5-audit.md
+++ b/specs/SPEC-023-v0_1-r5-audit.md
@@ -1,0 +1,53 @@
+# SPEC-023 v0.1 Round 5 Audit
+
+Date: 2026-07-01
+Spec under audit: `specs/SPEC-023-installer-autotune-recommend.md`
+Scope: three-lane Codex audit only: code, security, architect. No product-design lane was run per operator instruction.
+
+## Result
+
+Round 5 did not pass. The three requested audit lanes reported the following critical/high/medium findings:
+
+| Lane | Critical | High | Medium | Low | Status |
+| --- | ---: | ---: | ---: | ---: | --- |
+| code | 0 | 0 | 1 | 0 | Needs fix pass |
+| security | 0 | 0 | 1 | 1 | Needs fix pass |
+| architect | 0 | 0 | 0 | 0 | Pass |
+
+## Blocking findings and resolutions
+
+### MEDIUM-CODE-R5-001: bandwidth-tier eligibility was not deterministic
+
+Finding: the spec required `bandwidth_tier` and `min_bandwidth_tier` gates but did not define S/A/B/C ordering or a v0.1 chip-to-tier mapping.
+
+Resolution:
+- §3.1 now defines tier order as `S >= A >= B >= C`, with `unknown` treated as `C`.
+- §3.1 now includes a v0.1 chip-family mapping table for Ultra/Max/Pro/base/unknown chips.
+- Benchmark-derived tier overrides may raise, but not lower, the chip-derived tier only when the benchmark table is compiled into the same binary release.
+- §5 now references the §3.1 tier order for `min_bandwidth_tier`.
+- AC-35 covers Tier-C failure against Tier-A rows and Tier-A/S success when other gates pass.
+
+### MEDIUM-SEC-R5-001: canonical model hash omitted non-regular file handling
+
+Finding: the artifact-set hash enumerated regular files but did not define symlink, hardlink, special file, absolute path, path escape, or `..` path-segment behavior.
+
+Resolution:
+- §3.2 now requires rejecting any downloaded snapshot containing filesystem entries other than regular files or directories.
+- Symlinks, hardlinks with link count greater than one, device nodes, sockets, FIFOs, absolute paths, path escapes, and relative paths containing `..` are forbidden.
+- The hash algorithm now sorts by normalized POSIX relative path and fails closed before benchmark, recommendation, donor commit, or provider run.
+- AC-36 covers malicious/noncanonical filesystem entries.
+
+## Low findings handled opportunistically
+
+- §3.5 now maps stale signed static JSON warnings to the explicit vocabulary: `demand_rank_stale` and `candidate_catalog_stale`.
+- The threat model now uses those same warning names.
+
+## Round 6 requirement
+
+Run only the requested three Codex audit lanes again:
+
+- code
+- security
+- architect
+
+Continue fixing and re-auditing until all three lanes report zero critical, high, and medium findings.

--- a/specs/SPEC-023-v0_1-r6-audit.md
+++ b/specs/SPEC-023-v0_1-r6-audit.md
@@ -1,0 +1,56 @@
+# SPEC-023 v0.1 Round 6 Audit
+
+Date: 2026-07-01
+Spec under audit: `specs/SPEC-023-installer-autotune-recommend.md`
+Scope: three-lane Codex audit only: code, security, architect. No product-design lane was run per operator instruction.
+
+## Result
+
+Round 6 did not pass. The three requested audit lanes reported the following critical/high/medium findings:
+
+| Lane | Critical | High | Medium | Low | Status |
+| --- | ---: | ---: | ---: | ---: | --- |
+| code | 0 | 0 | 2 | 0 | Needs fix pass |
+| security | 0 | 0 | 1 | 0 | Needs fix pass |
+| architect | 0 | 0 | 0 | 0 | Pass |
+
+## Blocking findings and resolutions
+
+### MEDIUM-CODE-R6-001: `/v1/rate-card` exposure path was not pinned to current routing
+
+Finding: the spec defined public `GET /v1/rate-card`, but the coordinator has split buyer/provider ports and nginx returns 404 for generic `/v1/` unless explicit exceptions are declared before the catch-all block.
+
+Resolution:
+- §3.3 now pins the installer fetch URL to `https://coordinator.streamvc.live/v1/rate-card`.
+- §3.3 requires the handler to live on the coordinator buyer HTTP mux (`buyer_port: 8443`), not the provider/operator mux (`provider_port: 8444`).
+- §3.3 requires an exact nginx `location = /v1/rate-card` allow-through before the generic `/v1/` 404 block.
+- AC-37 verifies unauthenticated public reachability through nginx to the buyer mux.
+
+### MEDIUM-CODE-R6-002: stored catalog/rate-card version hashes were not deterministic
+
+Finding: `candidate_catalog_sha256` and `rate_card_version` were used for stale detection without defining their algorithms. Reusing existing broader billing/config hashes would couple recommendation freshness to unrelated state.
+
+Resolution:
+- §3.3 now defines `/v1/rate-card.version` as a recommendation-projection SHA-256 hash over only rows, provider share, global multiplier, and `usd_per_million_credits`.
+- The rate-card version explicitly excludes unrelated quarantine/force-void, request-log, operator, ledger, and settlement runtime state.
+- §9 defines `candidate_catalog_sha256` as SHA-256 over the exact selected catalog JSON bytes after fetched/baked selection and before parsing normalization.
+- AC-38 and AC-39 cover these hash/version semantics.
+
+### MEDIUM-SEC-R6-001: undefined custom donor-mode path weakened signed-catalog/digest controls
+
+Finding: AC-11 allowed a "custom donor-mode path" exception that could be interpreted as an arbitrary local model/path override bypassing signed catalog, immutable revision, canonical digest, and path-safety controls.
+
+Resolution:
+- AC-11 now removes the arbitrary custom path exception.
+- v0.1 has no arbitrary local-model or custom donor-mode path override.
+- Any donor-mode selection must still select a row from the signed selected candidate catalog and pass §3.2, §5, §8, and AC-22 controls.
+
+## Round 7 requirement
+
+Run only the requested three Codex audit lanes again:
+
+- code
+- security
+- architect
+
+Continue fixing and re-auditing until all three lanes report zero critical, high, and medium findings.

--- a/specs/SPEC-023-v0_1-r7-audit.md
+++ b/specs/SPEC-023-v0_1-r7-audit.md
@@ -1,0 +1,44 @@
+# SPEC-023 v0.1 Round 7 Audit
+
+Date: 2026-07-01
+Spec under audit: `specs/SPEC-023-installer-autotune-recommend.md`
+Scope: three-lane Codex audit only: code, security, architect. No product-design lane was run per operator instruction.
+
+## Result
+
+Round 7 passed. The three requested audit lanes reported zero critical, high, and medium findings.
+
+| Lane | Critical | High | Medium | Low | Status |
+| --- | ---: | ---: | ---: | ---: | --- |
+| code | 0 | 0 | 0 | 0 | Ready to lock |
+| security | 0 | 0 | 0 | 0 | Ready to lock |
+| architect | 0 | 0 | 0 | 0 | Ready to lock |
+
+## Closure evidence
+
+Code lane verified:
+
+- `/v1/rate-card` is pinned to the coordinator buyer mux and nginx allow-through path.
+- Recommendation rate-card lookup avoids the coordinator `default` fallback unless the candidate key is literally `default`.
+- `rate_card_version` and `candidate_catalog_sha256` are deterministic and testable.
+- Bandwidth-tier mapping and ordering are deterministic.
+- Candidate catalog fallback and canonical artifact hash rules are internally consistent.
+- Command names match current repo surfaces: `macprovider-cli autotune`, `macprovider-cli update`, and `macprovider-cli status`.
+
+Security lane verified:
+
+- Static JSON integrity uses Ed25519 detached signatures, release-pinned key metadata, stale/future fallback rules, and explicit stale warning names.
+- Candidate/model trust requires a signed catalog, immutable `model_revision`, canonical `model_sha256`, and rejection of non-regular/path-escaping model snapshot entries.
+- Donor mode has no arbitrary local/custom path bypass and remains local-only for non-recommendable rows without paid network registration.
+- HMAC identity handling uses a local CSPRNG secret, protected storage, domain separation, and no secret/raw-fingerprint emission.
+- Threat model covers static JSON tampering/replay, benchmark gaming, donor abuse, fingerprint leakage, misleading earnings, and clean-room boundaries.
+
+Architecture lane verified:
+
+- Non-goals preserve boundaries: no auto-switching, no rate-card content change, no gateway billing/coordinator settlement change, no live demand endpoint, and no production-incident claim.
+- `/v1/rate-card` is a read-only recommendation projection and not a money-path mutation.
+- Retune/status lifecycle, static JSON freshness, deterministic stored hashes, bandwidth tiers, immutable artifact lifecycle, donor-mode boundaries, and diversification pool are architecturally consistent.
+
+## Stop condition
+
+The requested stop condition is satisfied: code, security, and architect Codex audit lanes have zero critical/high/medium findings remaining.


### PR DESCRIPTION
## Summary
- Implements SPEC-023 installer/autotune recommendation flow with signed/static market inputs, catalog-bound artifact provenance, donor-mode local reuse, and paid-mode fail-closed coordinator joins.
- Adds public coordinator /v1/rate-card projection and installer config application for recommendation reuse/freshness.
- Adds focused Swift, Go, and installer shell coverage plus the SPEC-023 build/audit prompt trail.

## Validation
- swift test (phase3-binary): 763 tests, 7 skipped, 0 failures
- go test ./... (phase4-coordinator): passed
- git diff --check: passed
- bash -n phase3-binary/dist/install.sh: passed
- bash scripts/test-install-autotune-recommend-config.sh: passed
- bash scripts/test-install-launchd-enable.sh: passed
- 3-lane audits round 12: code/security/architecture all PASS with 0 critical/high/medium findings

## Notes
- Not live-tested against production CDN or real Hugging Face model downloads.
