### PR TITLE
chore: bump binaryVersion 1.7.0 -> 1.7.1 (unblocks SPEC-023 release cut)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.7.0"
+    static let binaryVersion = "1.7.1"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1481,10 +1481,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.0")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.0")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.7.0")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.7.0")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.1")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.1")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.7.1")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.7.1")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {


### PR DESCRIPTION
## Summary

Bumps `CoordinatorClient.binaryVersion` from `1.7.0` to `1.7.1` so the
next tag+release cut carries the SPEC-023 installer-integrated
autotune-recommend flow.

## The gap this unblocks

SPEC-023 landed on `origin/main` as [`41bab87`](https://github.com/Augustas11/macprovider/pull/313) on 2026-07-02.
`install.sh` at HEAD invokes:

```bash
"$INSTALL_DIR/macprovider-cli" autotune --recommend --apply --config "$CONFIG_PATH"
```

inside `run_autotune_recommend_apply` — which requires the `--recommend` flag added by SPEC-023.

The latest GitHub Release is [`v1.7.0`](https://github.com/Augustas11/macprovider/releases/tag/v1.7.0) from 2026-06-30 — 2 days *pre*-SPEC-023 — so its binary lacks the flag. Consequently every fresh install today via `curl https://get.streamvc.live/install.sh | bash` fails at:

```
[install.sh] die 6 "autotune recommendation failed before service start"
```

Bumping the constant + cutting v1.7.1 immediately after this merges closes that gap.

## Changes

- `CoordinatorClient.binaryVersion`: `"1.7.0"` → `"1.7.1"` (one line)
- `CoordinatorClientTests testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames`: 4 assertion strings updated to match

`MacProviderCLI.configuration.version` references `CoordinatorClient.binaryVersion` symbolically, so `--version` output tracks automatically. `AutoUpdateTests.swift` uses `"1.7.0"` as a **generic semantic constant** for semver comparisons and cooldown-key tests, not as an assertion about this build — those refs are correctly left alone.

## No behavior change

Beyond the reported version string in:
- `/v1/hello` and `/v1/auth` handshake frames (advertised to coord for auto-update surface)
- `--version` CLI output

## Test plan

- [x] `swift build --product macprovider-cli` — clean
- [x] `swift test --filter testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames` — passes
- [ ] Post-merge: `gh workflow run release.yml -f version=v1.7.1` triggers signed+notarized darwin-arm64 build
- [ ] Post-release: `curl https://get.streamvc.live/install.sh | bash` on a fresh Mac completes autotune-recommend + starts serving

## Why via a PR (not direct commit)

Per repo convention in [CLAUDE.md](https://github.com/Augustas11/macprovider/blob/main/CLAUDE.md#pr-workflow-dont-develop-on-local-main): "always work on a feature branch in this repo". Version bumps are the same as anything else — feature branch, PR, squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
