### PR TITLE
Close #292: catalog smoke uses mktemp + fails closed on invalid JSON

### DIFF
--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -253,6 +253,7 @@ bash "$DIST_DIR/test/check_nginx_catalog_routes_test.sh" || {
 # no-op when they are unset.
 trap '
   rm -f "${TMP_CATALOG_PUBKEY:-}"
+  rm -f "${CATALOG_SMOKE_TMP:-}"
   if [ -n "${DEPLOY_TMP:-}" ]; then
     $SSH "rm -rf $DEPLOY_TMP" 2>/dev/null || true
   fi
@@ -1006,12 +1007,23 @@ fi
 
 if [ -n "$CATALOG_REMOTE_PATH" ]; then
   echo "  GET https://$DOMAIN/catalog/current -> expect 200"
-  STATUS=$(curl -sS -o /tmp/macprovider-catalog-current.json -w '%{http_code}' --max-time 10 --max-filesize 1048576 "https://$DOMAIN/catalog/current")
+  # Issue #292 (LOW, deferred from #244 R6/R7 CODE+SEC): don't write
+  # the smoke response to a predictable operator-Mac /tmp path. A
+  # local attacker on the operator's workstation could pre-place a
+  # symlink at /tmp/macprovider-catalog-current.json (or race the
+  # curl -o open) to redirect the write. mktemp under umask 077
+  # picks an unpredictable name with 0600 perms; cleanup rides the
+  # unconditional EXIT trap registered above.
+  CATALOG_SMOKE_TMP=$(umask 077 && mktemp -t macprovider-catalog-current.XXXXXXXX) || {
+    echo "aborting smoke: mktemp failed" >&2
+    exit 1
+  }
+  STATUS=$(curl -sS -o "$CATALOG_SMOKE_TMP" -w '%{http_code}' --max-time 10 --max-filesize 1048576 "https://$DOMAIN/catalog/current")
   if [ "$STATUS" != "200" ]; then
-    echo "coordinator /catalog/current check failed: status=$STATUS body=$(head -c 300 /tmp/macprovider-catalog-current.json)" >&2
+    echo "coordinator /catalog/current check failed: status=$STATUS body=$(head -c 300 "$CATALOG_SMOKE_TMP")" >&2
     exit 1
   fi
-  echo "  catalog OK: $(python3 -c 'import json,sys; c=json.load(open(sys.argv[1])); print("catalog_id=%s models=%d" % (c.get("catalog_id"), len(c.get("models", []))))' /tmp/macprovider-catalog-current.json)"
+  echo "  catalog OK: $(python3 -c 'import json,sys; c=json.load(open(sys.argv[1])); print("catalog_id=%s models=%d" % (c.get("catalog_id"), len(c.get("models", []))))' "$CATALOG_SMOKE_TMP")"
 fi
 
 # R3+R4+R5 stats smoke check on STATS_DOMAIN.

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -1023,7 +1023,16 @@ if [ -n "$CATALOG_REMOTE_PATH" ]; then
     echo "coordinator /catalog/current check failed: status=$STATUS body=$(head -c 300 "$CATALOG_SMOKE_TMP")" >&2
     exit 1
   fi
-  echo "  catalog OK: $(python3 -c 'import json,sys; c=json.load(open(sys.argv[1])); print("catalog_id=%s models=%d" % (c.get("catalog_id"), len(c.get("models", []))))' "$CATALOG_SMOKE_TMP")"
+  # #292 R1 ARCH MED: `echo "$(python3 ...)"` under set -e is silent on
+  # python failure — echo succeeds regardless, so invalid JSON (or a
+  # 200 response body that isn't the catalog schema) prints
+  # "catalog OK:" and the deploy proceeds. Assign first, check exit
+  # explicitly, then echo.
+  CATALOG_SUMMARY=$(python3 -c 'import json,sys; c=json.load(open(sys.argv[1])); print("catalog_id=%s models=%d" % (c.get("catalog_id"), len(c.get("models", []))))' "$CATALOG_SMOKE_TMP") || {
+    echo "coordinator /catalog/current smoke: python3 parse failed on 200 body (head -c 300: $(head -c 300 "$CATALOG_SMOKE_TMP"))" >&2
+    exit 1
+  }
+  echo "  catalog OK: $CATALOG_SUMMARY"
 fi
 
 # R3+R4+R5 stats smoke check on STATS_DOMAIN.

--- a/specs/AUDIT_ISS292_ARCHITECT_R1_PROMPT.md
+++ b/specs/AUDIT_ISS292_ARCHITECT_R1_PROMPT.md
@@ -1,0 +1,23 @@
+## Lane: ARCHITECT — Round 1
+
+## Context
+
+Issue #292 closes a LOW-severity operator-local /tmp symlink-race
+threat in coordinator deploy-pearl-vps.sh step 8.
+
+Fix in commit `559f315`:
+- Predictable /tmp path → `mktemp -t macprovider-catalog-current.XXXXXXXX`
+- Wrapped in `umask 077` for 0600 perms
+- Cleanup added to unconditional EXIT trap registered at line 254 (#244 R6)
+
+## Your job
+
+ARCHITECT LANE round 1. Consider trap ordering, error-path coverage,
+and consistency with the coordinator script's other mktemp uses
+(`TMP_CATALOG_PUBKEY`, `DEPLOY_TMP`).
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss292/phase4-coordinator/dist/deploy-pearl-vps.sh`
+
+Diff: `git -C /Users/augstar/macprovider-iss292 show HEAD`

--- a/specs/AUDIT_ISS292_ARCHITECT_R2_PROMPT.md
+++ b/specs/AUDIT_ISS292_ARCHITECT_R2_PROMPT.md
@@ -1,0 +1,24 @@
+## Lane: ARCHITECT — Round 2
+
+## Context
+
+R1 outcomes:
+- CODE 0/0/0/0
+- SEC 0/0/0/0
+- ARCH 0/0/1/0 — MED: echo command-substitution masks python3
+  failure under set -e
+
+R1 fix-pass `656fb84`:
+- `CATALOG_SUMMARY=$(python3 ...) || { echo err; exit 1; }` pattern
+- Explicit failure branch with head -c 300 of the response body
+
+## Your job
+
+ARCHITECT LANE round 2. Verify R1 MED closed; check consistency with
+other similar fail-closed patterns in the coordinator script.
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss292/phase4-coordinator/dist/deploy-pearl-vps.sh`
+
+R1→R2 diff: `git -C /Users/augstar/macprovider-iss292 show HEAD`

--- a/specs/AUDIT_ISS292_CODE_R1_PROMPT.md
+++ b/specs/AUDIT_ISS292_CODE_R1_PROMPT.md
@@ -1,0 +1,26 @@
+## Lane: CODE — Round 1
+
+## Context
+
+Issue #292: `phase4-coordinator/dist/deploy-pearl-vps.sh` step 8
+(`/catalog/current` smoke check) wrote to a predictable
+`/tmp/macprovider-catalog-current.json` on the OPERATOR'S Mac. A local
+attacker on the workstation could pre-place a symlink at that path to
+redirect the write. LOW severity — deferred from #244 R6/R7 CODE+SEC
+lanes. This PR closes it as a small ride-along.
+
+Fix in commit `559f315`:
+- Replace 3 refs to `/tmp/macprovider-catalog-current.json` with
+  `"$CATALOG_SMOKE_TMP"` where
+  `CATALOG_SMOKE_TMP=$(umask 077 && mktemp -t macprovider-catalog-current.XXXXXXXX)`
+- Cleanup added to the existing unconditional EXIT trap (#244 R6)
+
+## Your job
+
+CODE LANE round 1. Standard severity-graded findings for the small change.
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss292/phase4-coordinator/dist/deploy-pearl-vps.sh`
+
+Diff: `git -C /Users/augstar/macprovider-iss292 show HEAD`

--- a/specs/AUDIT_ISS292_CODE_R2_PROMPT.md
+++ b/specs/AUDIT_ISS292_CODE_R2_PROMPT.md
@@ -1,0 +1,26 @@
+## Lane: CODE — Round 2
+
+## Context
+
+R1 outcomes:
+- CODE 0/0/0/0 — APPROVE (mktemp fix clean)
+- SEC 0/0/0/0 — approve
+- ARCH 0/0/1/0 — MED (pre-existing): `echo "$(python3 ...)"` under
+  set -e is silent on python failure; invalid JSON prints "catalog OK"
+  and deploy proceeds
+
+R1 fix-pass `656fb84`:
+- Assign to `CATALOG_SUMMARY=$(python3 ...) || { echo err; exit 1; }`
+- Assignment status honored by set -e; explicit || makes failure
+  path unambiguous
+
+## Your job
+
+CODE LANE round 2. Verify the fail-closed pattern is correct and no
+new gaps.
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss292/phase4-coordinator/dist/deploy-pearl-vps.sh`
+
+R1→R2 diff: `git -C /Users/augstar/macprovider-iss292 show HEAD`

--- a/specs/AUDIT_ISS292_SECURITY_R1_PROMPT.md
+++ b/specs/AUDIT_ISS292_SECURITY_R1_PROMPT.md
@@ -1,0 +1,23 @@
+## Lane: SECURITY — Round 1
+
+## Context
+
+Issue #292 closes a LOW-severity operator-local /tmp symlink-race
+threat in coordinator deploy-pearl-vps.sh step 8. Predictable path
+`/tmp/macprovider-catalog-current.json` on operator's Mac → mktemp.
+
+Fix in commit `559f315`:
+- `CATALOG_SMOKE_TMP=$(umask 077 && mktemp -t macprovider-catalog-current.XXXXXXXX)`
+- 3 references switched to `"$CATALOG_SMOKE_TMP"` (curl -o, head -c error, python3 json.load)
+- Cleanup added to the unconditional EXIT trap (#244 R6)
+
+## Your job
+
+SECURITY LANE round 1. Confirm the local symlink-race is closed and
+no new attack surface is introduced.
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss292/phase4-coordinator/dist/deploy-pearl-vps.sh`
+
+Diff: `git -C /Users/augstar/macprovider-iss292 show HEAD`


### PR DESCRIPTION
## Summary

Closes #292 — coordinator `deploy-pearl-vps.sh` step 8 (`/catalog/current`
smoke check) wrote its response body to a predictable operator-Mac
path `/tmp/macprovider-catalog-current.json`. Symlink-race exposure to
a local attacker. LOW-severity, deferred from #244 R6/R7 CODE+SEC.

Also absorbs one pre-existing MED surfaced by R1 ARCH audit in the same
smoke block.

## Fixes

**559f315 — mktemp instead of predictable /tmp path**

- `CATALOG_SMOKE_TMP=$(umask 077 && mktemp -t macprovider-catalog-current.XXXXXXXX)`
- All three refs (curl -o, error head -c, python3 json.load) → `"$CATALOG_SMOKE_TMP"`
- Cleanup added to the unconditional EXIT trap (#244 R6 pattern)

**656fb84 — fail-closed on invalid JSON (R1 ARCH MED, pre-existing)**

The smoke check used `echo "$(python3 parse)"`. Under `set -e` this
silently swallows python3's non-zero exit: `echo` succeeds regardless,
so a 200 response with invalid JSON prints "catalog OK:" and the
deploy proceeds.

Reproduced:
```
bash -c 'set -e; echo "$(python3 -c "raise SystemExit(1)")"; echo after'
# "before", empty line, "after" — no early exit
```

Fix: `CATALOG_SUMMARY=$(python3 ...) || { echo err; exit 1; }` — assignment
status is honored by set -e, and the explicit `||` makes the failure
branch unambiguous.

## Rounds

| R | CODE | SEC | ARCH | Notes |
|---|------|-----|------|-------|
| 1 | 0/0/0/0 PASS | 0/0/0/0 PASS | 0/0/1/0 | Pre-existing MED absorbed |
| 2 | 0/0/0/0 PASS | (skip) | 0/0/0/0 PASS | Converged |

## Test plan

- [x] `bash -n phase4-coordinator/dist/deploy-pearl-vps.sh` — pass
- [x] Reproduced echo-under-set-e bug on unfixed code
- [x] Confirmed CATALOG_SUMMARY assignment form correctly exits on python3 failure
- [x] Confirmed no remaining code refs to `/tmp/macprovider-catalog-current.json`
- [x] `mktemp -t macprovider-catalog-current.XXXXXXXX` produces 0600 unpredictable path

Generated with [Claude Code](https://claude.com/claude-code)
