### PR TITLE
feat(spec-023): move signed static feeds off CF to Pearl nginx + bump v1.7.3

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -685,8 +685,8 @@ struct AutotuneStaticInputs {
         let bakedValue = (try? decode(bakedBytes))!
         let bakedGeneratedAt = generatedAt(in: bakedBytes) ?? .distantFuture
         do {
-            let jsonURL = URL(string: "https://get.streamvc.live/\(name).json")!
-            let sigURL = URL(string: "https://get.streamvc.live/\(name).json.sig")!
+            let jsonURL = URL(string: "https://coordinator.streamvc.live/static/\(name).json")!
+            let sigURL = URL(string: "https://coordinator.streamvc.live/static/\(name).json.sig")!
             let jsonBytes = try await fetch(jsonURL)
             let sigBytes = try await fetch(sigURL)
             guard sidecarIsValid(sigBytes), verifySignature(jsonBytes, sigBytes) else {
@@ -1693,7 +1693,7 @@ extension AutotuneStaticInputs {
     // fixtures depending on runtime_status="listed" (qwen3-32b, qwen2.5-coder-32b)
     // and runtime_status="blocked" (google-gemma, nvidia-nemotron) stay stable.
     // Real per-user experience gets M-Base unblocking via published feeds at
-    // get.streamvc.live/autotune-candidates.json (v2 keypair signed).
+    // coordinator.streamvc.live/static/autotune-candidates.json (v2 keypair signed).
     static let bakedDemandRankJSON = """
     {"version":"baked-2026-07-02","generated_at":"2026-07-02T00:00:00Z","source":"openrouter_completion_token_rank_operator_curated","cold_start_floor":0.15,"diversification_band":0.85,"rows":{"meta-llama/llama-3.1-8b-instruct":{"demand_weight":0.45,"rank":3,"recommendable":true,"min_provider_target":20},"openai/gpt-oss-20b":{"demand_weight":0.60,"rank":2,"recommendable":true,"min_provider_target":20},"qwen3-32b":{"demand_weight":0.35,"rank":8,"recommendable":false,"min_provider_target":10},"qwen3-coder-30b-a3b-instruct":{"demand_weight":0.80,"rank":1,"recommendable":true,"min_provider_target":20},"qwen2.5-coder-32b-instruct":{"demand_weight":0.40,"rank":7,"recommendable":false,"min_provider_target":10},"google-gemma-4-26b-a4b-it":{"demand_weight":0.20,"rank":null,"recommendable":false,"min_provider_target":0},"nvidia/nemotron-3-nano-30b-a3b":{"demand_weight":0.20,"rank":null,"recommendable":false,"min_provider_target":0}}}
     """

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.7.2"
+    static let binaryVersion = "1.7.3"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1481,10 +1481,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.2")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.2")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.7.2")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.7.2")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.3")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.3")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.7.3")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.7.3")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
@@ -256,7 +256,7 @@ final class ServeCommandTests: XCTestCase {
         let rateCardBytes = Data(rateCardJSON.utf8)
         let staticInputs = AutotuneStaticInputs(
             fetch: { url in
-                if url.host == "coordinator.streamvc.live" {
+                if url.path == "/v1/rate-card" {
                     return rateCardBytes
                 }
                 if url.path.hasSuffix(".sig") {

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -106,6 +106,16 @@ NGINX_STATS_SECHEADERS="$DIST_DIR/nginx-snippets/stats-security-headers.conf"
 NGINX_STATS_SITE="$DIST_DIR/nginx-stats.streamvc.live.conf"
 CATALOG_SOURCE="${CATALOG_SOURCE:-$DIST_DIR/../../.omc/tier2/tier2-catalog.json}"
 
+# SPEC-023 v1.7.3 — signed static feeds (demand-rank + autotune-candidates)
+# served by nginx from /opt/macprovider/static/ under the /static/ prefix.
+# Files live in phase3-binary/dist/static/ in the repo. Deploy installs
+# them alongside the coordinator config.
+STATIC_FEEDS_DIR="$DIST_DIR/../../phase3-binary/dist/static"
+STATIC_DEMAND_JSON="$STATIC_FEEDS_DIR/demand-rank.json"
+STATIC_DEMAND_SIG="$STATIC_FEEDS_DIR/demand-rank.json.sig"
+STATIC_AUTOTUNE_JSON="$STATIC_FEEDS_DIR/autotune-candidates.json"
+STATIC_AUTOTUNE_SIG="$STATIC_FEEDS_DIR/autotune-candidates.json.sig"
+
 # coordinator-cli is required ALONGSIDE the daemon (SPEC-003 v0.8.3
 # FR-C9.4 strict-reject path still requires `coordinator-cli
 # revoke-token` for the used-token-persist-failure case; routine
@@ -113,7 +123,9 @@ CATALOG_SOURCE="${CATALOG_SOURCE:-$DIST_DIR/../../.omc/tier2/tier2-catalog.json}
 # operator forgot to run build-linux.sh after the M2 update that
 # extended it. Fail closed — do NOT silently deploy with a stale CLI.
 for f in "$BINARY" "$CLI_BINARY" "$CONFIG" "$SERVICE" "$NGINX_SITE" \
-         "$NGINX_STATS_SHARED" "$NGINX_STATS_SECHEADERS" "$NGINX_STATS_SITE"; do
+         "$NGINX_STATS_SHARED" "$NGINX_STATS_SECHEADERS" "$NGINX_STATS_SITE" \
+         "$STATIC_DEMAND_JSON" "$STATIC_DEMAND_SIG" \
+         "$STATIC_AUTOTUNE_JSON" "$STATIC_AUTOTUNE_SIG"; do
   [ -f "$f" ] || { echo "missing required file: $f" >&2; exit 1; }
 done
 
@@ -494,6 +506,11 @@ $SCP "$NGINX_SITE"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-coordinator-full.conf
 $SCP "$NGINX_STATS_SHARED"     "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-stats-shared.conf"
 $SCP "$NGINX_STATS_SECHEADERS" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-stats-security-headers.conf"
 $SCP "$NGINX_STATS_SITE"       "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-stats.streamvc.live.conf"
+# SPEC-023 v1.7.3 signed static feeds
+$SCP "$STATIC_DEMAND_JSON"     "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/demand-rank.json"
+$SCP "$STATIC_DEMAND_SIG"      "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/demand-rank.json.sig"
+$SCP "$STATIC_AUTOTUNE_JSON"   "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/autotune-candidates.json"
+$SCP "$STATIC_AUTOTUNE_SIG"    "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/autotune-candidates.json.sig"
 if [ -n "$CATALOG_REMOTE_PATH" ]; then
   $SCP "$CATALOG_SOURCE" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/tier2-catalog.json"
 fi
@@ -526,6 +543,17 @@ $SSH "set -e
   install -o root -g macprovider -m 0750 $DEPLOY_TMP/coordinator-cli-linux-amd64 /opt/macprovider/coordinator-cli
   install -o root -g macprovider -m 0640 $DEPLOY_TMP/coordinator.yaml /opt/macprovider/coordinator.yaml
   install -o root -g root       -m 0644 $DEPLOY_TMP/macprovider-coordinator.service /etc/systemd/system/macprovider-coordinator.service
+  # SPEC-023 v1.7.3 signed static feeds — served by nginx as
+  # coordinator.streamvc.live/static/*. Files are world-readable
+  # (mode 0644) because they are public signed content; nginx runs as
+  # www-data. Directory itself is world-executable so www-data can enter.
+  mkdir -p /opt/macprovider/static
+  chown root:root /opt/macprovider/static
+  chmod 0755      /opt/macprovider/static
+  install -o root -g root -m 0644 $DEPLOY_TMP/demand-rank.json          /opt/macprovider/static/demand-rank.json
+  install -o root -g root -m 0644 $DEPLOY_TMP/demand-rank.json.sig      /opt/macprovider/static/demand-rank.json.sig
+  install -o root -g root -m 0644 $DEPLOY_TMP/autotune-candidates.json  /opt/macprovider/static/autotune-candidates.json
+  install -o root -g root -m 0644 $DEPLOY_TMP/autotune-candidates.json.sig /opt/macprovider/static/autotune-candidates.json.sig
 "
 if [ -n "$CATALOG_REMOTE_PATH" ]; then
   # R4: no more `install -d` on a dynamic dirname. /opt/macprovider is
@@ -1034,6 +1062,21 @@ if [ -n "$CATALOG_REMOTE_PATH" ]; then
   }
   echo "  catalog OK: $CATALOG_SUMMARY"
 fi
+
+# SPEC-023 v1.7.3 signed static feeds smoke.
+for STATIC_PATH in \
+    /static/demand-rank.json \
+    /static/demand-rank.json.sig \
+    /static/autotune-candidates.json \
+    /static/autotune-candidates.json.sig; do
+  echo "  GET https://$DOMAIN$STATIC_PATH -> expect 200"
+  STATUS=$(curl -sS -o /tmp/macprovider-static-probe -w '%{http_code}' --max-time 10 --max-filesize 65536 "https://$DOMAIN$STATIC_PATH")
+  if [ "$STATUS" != "200" ]; then
+    echo "SPEC-023 static feed smoke failed: $STATIC_PATH status=$STATUS body=$(head -c 200 /tmp/macprovider-static-probe)" >&2
+    exit 1
+  fi
+done
+echo "  SPEC-023 static feeds OK"
 
 # R3+R4+R5 stats smoke check on STATS_DOMAIN.
 #

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -213,6 +213,27 @@ server {
     }
 
     # ---------------------------------------------------------------------
+    # /static/{demand-rank,autotune-candidates}.{json,json.sig} — SPEC-023
+    # signed static feeds. Introduced in v1.7.3 to move feed hosting off
+    # get.streamvc.live (Cloudflare Pages) onto Pearl so feed updates ship
+    # via `git commit + deploy-pearl-vps.sh` instead of Cloudflare dashboard
+    # config. Ed25519-signed with key `streamvc-autotune-static-v2` whose
+    # public key is baked into macprovider-cli at
+    # AutotuneRecommend.swift:625. Files live in /opt/macprovider/static/,
+    # installed by deploy-pearl-vps.sh step 6b from
+    # phase3-binary/dist/static/.
+    #
+    # Cache-Control: 5 min max-age matches the /v1/rate-card cadence.
+    # ---------------------------------------------------------------------
+    location /static/ {
+        alias /opt/macprovider/static/;
+        add_header Cache-Control "public, max-age=300" always;
+        try_files $uri =404;
+        types { application/json json; application/octet-stream sig; }
+        default_type application/json;
+    }
+
+    # ---------------------------------------------------------------------
     # SPEC-017 v0.1.8 Step 4.B — /v1/stats/* allow-through. Public
     # Network Stats API endpoints, mounted on the coordinator's
     # provider port (8444) per main.go:525. The dedicated vhost


### PR DESCRIPTION
## Summary

Eliminates the Cloudflare-dashboard bottleneck on publishing SPEC-023 signed static feeds. Instead of relying on 4 CF redirect rules mapping `get.streamvc.live/*` to `raw.githubusercontent.com/*`, this PR moves the feeds directly onto Pearl's already-live coordinator nginx under `coordinator.streamvc.live/static/*`.

**Every future feed edit is now `git commit → deploy-pearl-vps.sh` with no dashboard clicks.**

## Motivation

Follow-up to [PR #319](https://github.com/Augustas11/macprovider/pull/319) (v1.7.2) which shipped Ed25519-signed `demand-rank.json` + `autotune-candidates.json` for the M-Base fresh-install UX fix. That PR's deploy blocker was **4 Cloudflare redirect rules that only the operator can add via the CF dashboard** — the redirects control routing on the get.streamvc.live zone (CF Pages).

Alternative asked by operator: can we use Pearl instead? **Yes** — and it's cleaner because:

- Everything visible in git / nginx config, no hidden CF state
- Deploy script already handles nginx for Pearl (used it 4 hours ago for `/v1/rate-card`)
- Same pattern as `/v1/rate-card` — public JSON endpoint served from Pearl nginx
- One clean commit closes it out; no operator dashboard clicks
- Feeds update on `git push + deploy-pearl-vps.sh`, not on merged-into-main + CF cache invalidation

Tradeoff: one v1.7.3 release cycle vs 5-min dashboard work. But this pattern is a permanent win going forward.

## Changes

### Swift URL constants ([`AutotuneRecommend.swift:688-689`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L688-L689))

```diff
-  let jsonURL = URL(string: "https://get.streamvc.live/\(name).json")!
-  let sigURL = URL(string: "https://get.streamvc.live/\(name).json.sig")!
+  let jsonURL = URL(string: "https://coordinator.streamvc.live/static/\(name).json")!
+  let sigURL = URL(string: "https://coordinator.streamvc.live/static/\(name).json.sig")!
```

### New nginx location block ([`nginx-coordinator.streamvc.live.conf`](phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf))

Serves `/opt/macprovider/static/{demand-rank,autotune-candidates}.{json,json.sig}` with 5-min `Cache-Control: public, max-age=300`. Declared before the `/v1/` catch-all 404. World-readable — the content is public signed JSON.

### Deploy script ([`deploy-pearl-vps.sh`](phase4-coordinator/dist/deploy-pearl-vps.sh))

- **Preflight**: all 4 static feed files must be present before deploy runs.
- **Upload**: 4 `$SCP` lines alongside the existing coord binary/config/service uploads.
- **Install**: `install -o root -g root -m 0644` into `/opt/macprovider/static/` (mode 0755 dir).
- **Smoke check**: after nginx reload, curls all 4 URLs, aborts deploy if any returns non-200.

### bump binaryVersion 1.7.2 → 1.7.3

Same pattern as [PR #315](https://github.com/Augustas11/macprovider/pull/315) + [PR #319](https://github.com/Augustas11/macprovider/pull/319).

### ServeCommandTests fixture mock update

The mock fetcher previously dispatched based on `url.host == "coordinator.streamvc.live"` to identify rate-card fetches. With v1.7.3, static feeds ALSO use that host — so we dispatch on `url.path == "/v1/rate-card"` instead. Minimal targeted fix.

## No changes to

- Coord Go code
- Gateway
- Signing key (v2 keypair keeps working, just served from a different host)
- Feed JSON content (identical to v1.7.2)

## Existing v1.7.2 users

Will keep hitting `get.streamvc.live/*` → 404 (feeds are not served there in v1.7.3). They fall back to the **baked-2026-07-02 catalog** shipped in v1.7.2, which already has qwen3-coder-30b-a3b `min_ram_gb: 28` unblocking M-Base. So no regression during the transition — they get the baked good UX until they auto-update to v1.7.3.

## Test plan

- [x] `swift build --product macprovider-cli` clean at v1.7.3 label
- [x] `swift test` full suite: 763 tests, 7 skipped, **0 failures**
- [x] `AutotuneRecommendTests`: 41/41 pass
- [x] `CoordinatorClientTests testBinaryVersion_AdvertisesSPEC020V17...`: updated + passes for `"1.7.3"`
- [x] `ServeCommandTests` catalog-bound snapshot tests: pass with updated fetch-mock dispatcher
- [ ] Post-merge: `gh workflow run release.yml -f version=v1.7.3`
- [ ] Post-release: `ALLOW_CONFIG_DRIFT=1 FORCE_RESTART=1 bash phase4-coordinator/dist/deploy-pearl-vps.sh` (installs static/, nginx reloads, smoke check confirms 4×200)
- [ ] Post-deploy: `curl https://coordinator.streamvc.live/static/demand-rank.json` returns 200 with published JSON
- [ ] Fresh install on M5 via `curl get.streamvc.live/install.sh | bash` with `MACPROVIDER_PORT=18080` recommends `qwen3-coder-30b-a3b-instruct` + starts provider service (not donor mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
