### PR TITLE
fix(deploy): +x for others on /opt/macprovider so nginx can traverse to /static/

### DIFF
--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -583,6 +583,16 @@ $SSH "set -e
   # coordinator.streamvc.live/static/*. Files are world-readable
   # (mode 0644) because they are public signed content; nginx runs as
   # www-data. Directory itself is world-executable so www-data can enter.
+  #
+  # /opt/macprovider/ is provisioned as root:macprovider 0750, which
+  # blocks www-data (not in the macprovider group) from traversing INTO
+  # any subdir including /static/. Add +x for others so nginx can walk
+  # the path; contents of siblings (coordinator, coordinator-cli,
+  # coordinator.yaml, coordinator.env) stay unreadable — their own modes
+  # 0750/0640 unchanged, +x on the parent only adds path-traversal, not
+  # listing or reading. Caught 2026-07-02 v1.7.3 first deploy: smoke
+  # returned 404 until the parent chmod was applied.
+  chmod o+x /opt/macprovider
   mkdir -p /opt/macprovider/static
   chown root:root /opt/macprovider/static
   chmod 0755      /opt/macprovider/static


### PR DESCRIPTION
## Summary

Fixes the 404 on `/static/*` smoke check at end of the v1.7.3 first deploy — caught 2026-07-02 within minutes of PR #323 landing.

## Bug

PR #323 added a nginx location block serving `coordinator.streamvc.live/static/*` from `/opt/macprovider/static/`. The install step chmod'd the static dir 0755 with 0644 root:root files — but **the parent /opt/macprovider/ is provisioned at step 3 as root:macprovider 0750**, which blocks any user not in the macprovider group (including nginx's www-data) from traversing into any subdir.

Verified on Pearl:
```
sudo -u www-data cat /opt/macprovider/static/demand-rank.json
-> cat: Permission denied
```

## Fix

`chmod o+x /opt/macprovider` before creating `/static/`. Grants **path-traversal only** (execute-only for others), not read or listing.

Sibling files under /opt/macprovider/ keep their own restrictive modes:
| Path | Mode |
|---|---|
| coordinator | 0750 root:macprovider |
| coordinator-cli | 0750 root:macprovider |
| coordinator.yaml | 0640 root:macprovider |
| coordinator.env | 0640 root:macprovider |

+x on the parent adds ONE new capability: nginx can open a full path like `/opt/macprovider/static/demand-rank.json`. It cannot list what other subdirs exist (needs o+r), cannot read the config or binaries (their own modes exclude others), and cannot execute the coordinator binary (0750, group macprovider only).

## Verified

- [x] Applied via SSH: `chmod o+x /opt/macprovider` then `systemctl reload nginx`; smoke curl returns 200 on all 4 /static/* endpoints
- [x] Sibling files still unreadable to others (`sudo -u nobody cat /opt/macprovider/coordinator.yaml` → Permission denied)
- [ ] Next deploy re-establishes the parent mode idempotently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
