### PR TITLE
Close #291: extract Pearl TLS state machine into dist/lib + fixture tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ test-dist:
 	bash phase4-coordinator/dist/test/check_nginx_receipt_buffers_test.sh
 	bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh
 	bash phase4-coordinator/dist/test/check_nginx_stats_test.sh
+	bash phase4-coordinator/dist/test/check_pearl_tls_test.sh
 	SPEC015_NGINX_LIVE_OPTIONAL=$${SPEC015_NGINX_LIVE_OPTIONAL:-1} bash phase4-coordinator/dist/test/check_nginx_receipt_header_live_test.sh
 	bash scripts/test-install-launchd-enable.sh
 	bash scripts/test-watchdog-inline-drift.sh

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -40,9 +40,26 @@ set -euo pipefail
 
 # TLS state machine (classify/plan/message) lives in a sourced helper
 # (lib/pearl_tls.sh) so it can be exercised by fixture tests without a
-# real deploy. Issue #291. Resolve path via BASH_SOURCE so the script
-# works from any CWD and from a symlink.
-_PEARL_TLS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# real deploy. Issue #291.
+#
+# R1 SEC MED — resolve the PHYSICAL script path (walk symlinks) before
+# sourcing. Plain `dirname "${BASH_SOURCE[0]}"` returns the symlink's
+# parent, not the real target's parent, which would let a symlink
+# invocation from an attacker-writable dir source a hostile helper.
+# macOS bash 3.2 has no `readlink -f`, so we walk symlinks by hand.
+_pearl_resolve_symlink() {
+  local src="$1" dir
+  while [ -h "$src" ]; do
+    dir="$(cd "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    case "$src" in
+      /*) ;;             # absolute — use as-is
+      *) src="$dir/$src" ;;
+    esac
+  done
+  cd "$(dirname "$src")" && pwd
+}
+_PEARL_TLS_SCRIPT_DIR="$(_pearl_resolve_symlink "${BASH_SOURCE[0]}")"
 # shellcheck source=lib/pearl_tls.sh
 . "$_PEARL_TLS_SCRIPT_DIR/lib/pearl_tls.sh"
 

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -38,6 +38,14 @@
 
 set -euo pipefail
 
+# TLS state machine (classify/plan/message) lives in a sourced helper
+# (lib/pearl_tls.sh) so it can be exercised by fixture tests without a
+# real deploy. Issue #291. Resolve path via BASH_SOURCE so the script
+# works from any CWD and from a symlink.
+_PEARL_TLS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/pearl_tls.sh
+. "$_PEARL_TLS_SCRIPT_DIR/lib/pearl_tls.sh"
+
 SSH_KEY="${SSH_KEY:-$HOME/.ssh/pearl_operator_ed25519}"
 VPS_HOST="${VPS_HOST:-159.223.165.194}"
 VPS_USER="${VPS_USER:-root}"
@@ -655,108 +663,15 @@ STATS_DOMAIN="${STATS_DOMAIN:-stats.streamvc.live}"
 # via parallel array + linear scan; only 2 domains, no perf concern.
 log "step 4b/9: classify domains by cert state"
 DOMAINS_ALL=("$DOMAIN" "$STATS_DOMAIN")
-DOMAINS_HAVE_CERT=()
-DOMAINS_NEED_CERT=()
-DOMAINS_NEED_STUB=()
-# Track per-domain "what state was this in BEFORE certbot" so failure
-# messaging at end-of-step-6b can give the operator the truth (R3 LOW).
-DOMAINS_STATE_KEYS=()
-DOMAINS_STATE_VALS=()
-# Pass domains via positional args; single-quoted remote heredoc for safety.
-CERT_STATUS=$($SSH "bash -s -- '$DOMAIN' '$STATS_DOMAIN'" <<'REMOTE_PROBE'
-set -e
-if ! command -v openssl >/dev/null 2>&1; then
-  echo "ABORT openssl-missing-on-remote" >&2
-  exit 1
-fi
-for d in "$@"; do
-  full="/etc/letsencrypt/live/$d/fullchain.pem"
-  priv="/etc/letsencrypt/live/$d/privkey.pem"
-  if [ -f "$full" ] && [ -f "$priv" ]; then
-    # R3 ARCH MED: split RENEW (still valid right now) from EXPIRED
-    # (already expired or malformed). EXPIRED behaves like MISSING.
-    if ! openssl x509 -checkend 0 -noout -in "$full" >/dev/null 2>&1; then
-      echo "EXPIRED $d"
-    elif openssl x509 -checkend 86400 -noout -in "$full" >/dev/null 2>&1; then
-      echo "HAVE $d"
-    else
-      echo "RENEW $d"
-    fi
-  else
-    echo "MISSING $d"
-  fi
-done
+# TLS classification + planning + messaging factored into
+# dist/lib/pearl_tls.sh so the state machine can be exercised without
+# a real deploy (dist/test/check_pearl_tls_test.sh). Issue #291.
+CERT_STATUS=$($SSH "bash -s -- '$DOMAIN' '$STATS_DOMAIN'" <<REMOTE_PROBE
+$(pearl_tls_remote_probe_script)
 REMOTE_PROBE
 ) || { echo "cert-status probe failed (see ABORT line above)" >&2; exit 1; }
 
-# Strict parsing (R2 CODE LOW): use `read -r` to enforce exactly two
-# fields per line — "<STATE> <DOMAIN>". Anything else fatal. R3 dropped
-# the vhost flag (R3 ARCH+CODE convergent MED): MISSING/EXPIRED always
-# install the stub for safety; the flag was over-coarse.
-_seen=()  # parallel array, linear scan (bash 3.2 — no `declare -A`)
-while IFS= read -r line; do
-  [ -z "$line" ] && continue
-  read -r status domain extra <<<"$line"
-  if [ -n "$extra" ]; then
-    echo "aborting deploy: malformed cert-status line (extra field): '$line'" >&2
-    exit 1
-  fi
-  case "$status" in
-    HAVE|RENEW|EXPIRED|MISSING) ;;
-    *) echo "aborting deploy: unknown cert-status state: '$status' in '$line'" >&2; exit 1 ;;
-  esac
-  # Reject unexpected domains.
-  expected=0
-  for d in "${DOMAINS_ALL[@]}"; do
-    [ "$d" = "$domain" ] && expected=1 && break
-  done
-  if [ "$expected" -ne 1 ]; then
-    echo "aborting deploy: unexpected domain in cert-status: '$domain'" >&2
-    exit 1
-  fi
-  # bash 3.2 + set -u: guard empty-array expansion with ${arr[@]+...}.
-  for s in ${_seen[@]+"${_seen[@]}"}; do
-    if [ "$s" = "$domain" ]; then
-      echo "aborting deploy: duplicate cert-status line for: '$domain'" >&2
-      exit 1
-    fi
-  done
-  _seen+=("$domain")
-  DOMAINS_STATE_KEYS+=("$domain")
-  DOMAINS_STATE_VALS+=("$status")
-  case "$status" in
-    HAVE)
-      DOMAINS_HAVE_CERT+=("$domain")
-      ;;
-    RENEW)
-      # Currently-valid cert; need certbot to refresh, but do NOT
-      # install the stub — existing vhost stays in place so a certbot
-      # failure leaves the soon-expiring cert serving instead of
-      # replacing it with an HTTP-only stub.
-      DOMAINS_NEED_CERT+=("$domain")
-      ;;
-    EXPIRED|MISSING)
-      # No usable cert today: stub install is safe (no working TLS
-      # vhost to clobber) and needed (so certbot webroot has a
-      # /.well-known/acme-challenge/ listener). Always install the
-      # stub, regardless of whether some other vhost happens to be
-      # enabled at this hostname.
-      DOMAINS_NEED_CERT+=("$domain")
-      DOMAINS_NEED_STUB+=("$domain")
-      ;;
-  esac
-done <<< "$CERT_STATUS"
-# Coverage check — every expected domain accounted for.
-for d in "${DOMAINS_ALL[@]}"; do
-  found=0
-  for s in ${_seen[@]+"${_seen[@]}"}; do
-    [ "$s" = "$d" ] && found=1 && break
-  done
-  if [ "$found" -eq 0 ]; then
-    echo "aborting deploy: cert-status missing for domain: '$d'" >&2
-    exit 1
-  fi
-done
+pearl_tls_classify "$CERT_STATUS" || exit 1
 log "  cert status: have=[${DOMAINS_HAVE_CERT[*]:-none}] need_cert=[${DOMAINS_NEED_CERT[*]:-none}] need_stub=[${DOMAINS_NEED_STUB[*]:-none}]"
 
 log "step 5/9: install port-80 ACME-stub for EXPIRED + MISSING domains"
@@ -811,25 +726,15 @@ else
       log "    ok: cert issued for $d"
     else
       DOMAINS_ISSUED_FAIL+=("$d")
-      # R3 CODE+ARCH LOW: state-aware messaging so the operator knows
-      # which fallback applies to this specific failed domain.
-      prior_state=""
-      i=0
-      for k in ${DOMAINS_STATE_KEYS[@]+"${DOMAINS_STATE_KEYS[@]}"}; do
-        if [ "$k" = "$d" ]; then prior_state="${DOMAINS_STATE_VALS[$i]}"; break; fi
-        i=$((i+1))
-      done
-      case "$prior_state" in
-        RENEW)            log "    WARN: certbot failed for $d (was RENEW) — existing full TLS vhost left in place; soon-expiring cert keeps serving until next deploy" ;;
-        EXPIRED|MISSING)  log "    WARN: certbot failed for $d (was $prior_state) — ACME stub left in place; HTTPS unavailable for $d until next deploy" ;;
-        *)                log "    WARN: certbot failed for $d (state=$prior_state) — continuing deploy" ;;
-      esac
+      # State-aware messaging (lib/pearl_tls.sh — issue #291).
+      log "    $(pearl_tls_certbot_fail_warn "$d")"
     fi
   done
 fi
 
-# Final set of domains that should get a full TLS vhost installed.
-DOMAINS_FULL_TLS=(${DOMAINS_HAVE_CERT[@]+"${DOMAINS_HAVE_CERT[@]}"} ${DOMAINS_ISSUED_OK[@]+"${DOMAINS_ISSUED_OK[@]}"})
+# Final set of domains that should get a full TLS vhost installed
+# (lib/pearl_tls.sh — issue #291).
+pearl_tls_plan_full_tls
 log "step 6b/9: install nginx artifacts + full TLS vhost for [${DOMAINS_FULL_TLS[*]:-none}]"
 # Shared http-context snippets always go in — no cert dependency.
 $SSH "set -e
@@ -880,46 +785,13 @@ fi
 # must not break primary deploy); STATS_REQUIRED=1 promotes any non-
 # primary failure to a fail-closed exit so operators with strict
 # uptime SLOs can enforce it.
-_primary_failed=0
-_nonprimary_failed=0
-for d in ${DOMAINS_ISSUED_FAIL[@]+"${DOMAINS_ISSUED_FAIL[@]}"}; do
-  if [ "$d" = "$DOMAIN" ]; then
-    _primary_failed=1
-  else
-    _nonprimary_failed=1
-  fi
-done
-if [ "$_primary_failed" -eq 1 ]; then
-  # R4 ARCH MED-1: state-aware abort. For RENEW the existing TLS vhost
-  # is kept and the soon-expiring cert is still serving; for EXPIRED/
-  # MISSING the ACME stub is in place and HTTPS is gone.
-  primary_prior_state=""
-  i=0
-  for k in ${DOMAINS_STATE_KEYS[@]+"${DOMAINS_STATE_KEYS[@]}"}; do
-    if [ "$k" = "$DOMAIN" ]; then primary_prior_state="${DOMAINS_STATE_VALS[$i]}"; break; fi
-    i=$((i+1))
-  done
-  echo "" >&2
-  echo "  ABORT-EXIT: primary domain $DOMAIN failed cert issuance during this deploy." >&2
-  case "$primary_prior_state" in
-    RENEW)
-      echo "             Prior state was RENEW — existing TLS vhost left in place;" >&2
-      echo "             soon-expiring cert keeps serving until next deploy." >&2
-      echo "             Fix DNS/certbot and re-run; do not wait beyond cert expiry." >&2
-      ;;
-    EXPIRED|MISSING)
-      echo "             Prior state was $primary_prior_state — ACME stub is in place;" >&2
-      echo "             HTTPS is unavailable on $DOMAIN until DNS/certbot is fixed" >&2
-      echo "             and this script is re-run." >&2
-      ;;
-    *)
-      echo "             Prior state was $primary_prior_state — re-run after fixing DNS/certbot." >&2
-      ;;
-  esac
-  echo "             Coordinator binary NOT restarted — old binary still serving." >&2
+pearl_tls_check_issuance_failures "$DOMAIN"
+if [ "$PEARL_TLS_PRIMARY_FAILED" -eq 1 ]; then
+  # State-aware abort (lib/pearl_tls.sh — issue #291).
+  pearl_tls_primary_abort_msg "$DOMAIN" >&2
   exit 9
 fi
-if [ "$_nonprimary_failed" -eq 1 ] && [ "${STATS_REQUIRED:-0}" = "1" ]; then
+if [ "$PEARL_TLS_NONPRIMARY_FAILED" -eq 1 ] && [ "${STATS_REQUIRED:-0}" = "1" ]; then
   echo "" >&2
   echo "  ABORT-EXIT: STATS_REQUIRED=1 set and a non-primary domain failed cert" >&2
   echo "             issuance ([${DOMAINS_ISSUED_FAIL[*]}]). Refusing to restart." >&2

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -113,7 +113,13 @@ if [ "${STATS_DOMAIN:-stats.streamvc.live}" != "stats.streamvc.live" ]; then
   exit 1
 fi
 
-DIST_DIR="$(cd "$(dirname "$0")" && pwd)"
+# R3 SEC MED — reuse the already-resolved physical dir from the
+# symlink walker rather than recomputing from `$0` (which is the
+# symlink path) + logical `pwd`. All later artifact reads,
+# check-deploy-config, config uploads, and vhost templates hang
+# off DIST_DIR, so any parent-symlink retargeting attack that
+# survives helper sourcing would still land here.
+DIST_DIR="$_PEARL_TLS_SCRIPT_DIR"
 BINARY="$DIST_DIR/coordinator-linux-amd64"
 CLI_BINARY="$DIST_DIR/coordinator-cli-linux-amd64"
 CONFIG="$DIST_DIR/coordinator.yaml"

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -48,16 +48,21 @@ set -euo pipefail
 # invocation from an attacker-writable dir source a hostile helper.
 # macOS bash 3.2 has no `readlink -f`, so we walk symlinks by hand.
 _pearl_resolve_symlink() {
+  # R2 SEC MED: use `pwd -P` so PARENT-directory symlinks also
+  # resolve to the physical path. Plain `pwd` returns the logical
+  # path, which would leave e.g. `/attacker/dist-link/deploy.sh` →
+  # source `/attacker/dist-link/lib/pearl_tls.sh` — retargetable
+  # between resolution and source.
   local src="$1" dir
   while [ -h "$src" ]; do
-    dir="$(cd "$(dirname "$src")" && pwd)"
+    dir="$(cd "$(dirname "$src")" && pwd -P)"
     src="$(readlink "$src")"
     case "$src" in
       /*) ;;             # absolute — use as-is
       *) src="$dir/$src" ;;
     esac
   done
-  cd "$(dirname "$src")" && pwd
+  cd "$(dirname "$src")" && pwd -P
 }
 _PEARL_TLS_SCRIPT_DIR="$(_pearl_resolve_symlink "${BASH_SOURCE[0]}")"
 # shellcheck source=lib/pearl_tls.sh

--- a/phase4-coordinator/dist/lib/pearl_tls.sh
+++ b/phase4-coordinator/dist/lib/pearl_tls.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# pearl_tls.sh — TLS classification + planning + messaging for the
+# Pearl VPS deploy script. Sourced from deploy-pearl-vps.sh; also
+# sourced by check_pearl_tls_test.sh for fixture-driven unit testing.
+#
+# Design constraints:
+#   - bash 3.2 compatible (Pearl runs Ubuntu with bash 5, but the
+#     operator Mac runs bash 3.2; the deploy script executes on the
+#     operator Mac and shells out to Pearl via SSH).
+#   - No `declare -A`, no `mapfile`, no `readarray` — 3.2 lacks all.
+#   - Parallel arrays with linear scan (the domain set is 2, later
+#     3 if a third public hostname is added).
+#   - Pure functions: no side effects except population of documented
+#     global arrays, no `set -e` reliance for control flow, no `exit`
+#     (callers handle exit; caller may be a test that continues past
+#     a failure so it can assert on downstream state).
+#
+# Globals populated by pearl_tls_classify (all reset each call):
+#   DOMAINS_HAVE_CERT   — HAVE-state domains (no work needed)
+#   DOMAINS_NEED_CERT   — RENEW/EXPIRED/MISSING (certbot targets)
+#   DOMAINS_NEED_STUB   — EXPIRED/MISSING (install ACME stub)
+#   DOMAINS_STATE_KEYS  — parallel-array keys (domains)
+#   DOMAINS_STATE_VALS  — parallel-array values (states)
+#
+# Globals populated by pearl_tls_plan_full_tls:
+#   DOMAINS_FULL_TLS    — HAVE ∪ ISSUED_OK
+#
+# Globals populated by pearl_tls_check_issuance_failures:
+#   PEARL_TLS_PRIMARY_FAILED    — 0 or 1
+#   PEARL_TLS_NONPRIMARY_FAILED — 0 or 1
+
+# pearl_tls_remote_probe_script
+#   Emits the shell script that must run on the REMOTE Pearl host to
+#   classify each domain's cert state. The caller pipes it into
+#   `ssh <host> bash -s -- <domain1> <domain2> ...`. Emitting as a
+#   function (not a heredoc inside the caller) lets tests exercise
+#   this exact same script under a controlled `/etc/letsencrypt/`
+#   fake.
+pearl_tls_remote_probe_script() {
+  cat <<'REMOTE_PROBE'
+set -e
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "ABORT openssl-missing-on-remote" >&2
+  exit 1
+fi
+for d in "$@"; do
+  full="/etc/letsencrypt/live/$d/fullchain.pem"
+  priv="/etc/letsencrypt/live/$d/privkey.pem"
+  if [ -f "$full" ] && [ -f "$priv" ]; then
+    # Split RENEW (still valid right now) from EXPIRED (already
+    # expired or malformed). EXPIRED behaves like MISSING.
+    if ! openssl x509 -checkend 0 -noout -in "$full" >/dev/null 2>&1; then
+      echo "EXPIRED $d"
+    elif openssl x509 -checkend 86400 -noout -in "$full" >/dev/null 2>&1; then
+      echo "HAVE $d"
+    else
+      echo "RENEW $d"
+    fi
+  else
+    echo "MISSING $d"
+  fi
+done
+REMOTE_PROBE
+}
+
+# pearl_tls_classify <status_text>
+#   Parses the STDOUT of the remote probe (one "<STATE> <DOMAIN>"
+#   line per expected domain), validates format + coverage + no
+#   duplicates + no unexpected domains, and populates the 5 output
+#   globals listed above. Reads DOMAINS_ALL as input (the expected
+#   domain set).
+#
+#   Returns 0 on success; on validation failure, echoes the
+#   diagnostic to stderr and returns non-zero. Does NOT exit — the
+#   caller decides whether the failure is fatal (deploy: yes; test:
+#   assert on stderr).
+pearl_tls_classify() {
+  local status_text="$1"
+
+  DOMAINS_HAVE_CERT=()
+  DOMAINS_NEED_CERT=()
+  DOMAINS_NEED_STUB=()
+  DOMAINS_STATE_KEYS=()
+  DOMAINS_STATE_VALS=()
+
+  local _seen=()  # parallel array, linear scan (bash 3.2 — no declare -A)
+  local line status domain extra found expected d s k
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    read -r status domain extra <<<"$line"
+    if [ -n "$extra" ]; then
+      echo "aborting deploy: malformed cert-status line (extra field): '$line'" >&2
+      return 1
+    fi
+    case "$status" in
+      HAVE|RENEW|EXPIRED|MISSING) ;;
+      *) echo "aborting deploy: unknown cert-status state: '$status' in '$line'" >&2; return 1 ;;
+    esac
+    expected=0
+    for d in ${DOMAINS_ALL[@]+"${DOMAINS_ALL[@]}"}; do
+      [ "$d" = "$domain" ] && expected=1 && break
+    done
+    if [ "$expected" -ne 1 ]; then
+      echo "aborting deploy: unexpected domain in cert-status: '$domain'" >&2
+      return 1
+    fi
+    # bash 3.2 + set -u: guard empty-array expansion with ${arr[@]+...}.
+    for s in ${_seen[@]+"${_seen[@]}"}; do
+      if [ "$s" = "$domain" ]; then
+        echo "aborting deploy: duplicate cert-status line for: '$domain'" >&2
+        return 1
+      fi
+    done
+    _seen+=("$domain")
+    DOMAINS_STATE_KEYS+=("$domain")
+    DOMAINS_STATE_VALS+=("$status")
+    case "$status" in
+      HAVE)
+        DOMAINS_HAVE_CERT+=("$domain")
+        ;;
+      RENEW)
+        # Currently-valid cert; certbot renews, but do NOT install
+        # the stub — the existing vhost stays so a certbot failure
+        # leaves the soon-expiring cert serving instead of replacing
+        # it with an HTTP-only stub.
+        DOMAINS_NEED_CERT+=("$domain")
+        ;;
+      EXPIRED|MISSING)
+        # No usable cert today: stub install is safe (no working
+        # TLS vhost to clobber) and needed (so certbot webroot has
+        # a /.well-known/acme-challenge/ listener). Always install
+        # the stub.
+        DOMAINS_NEED_CERT+=("$domain")
+        DOMAINS_NEED_STUB+=("$domain")
+        ;;
+    esac
+  done <<< "$status_text"
+
+  # Coverage check — every expected domain accounted for.
+  for d in ${DOMAINS_ALL[@]+"${DOMAINS_ALL[@]}"}; do
+    found=0
+    for s in ${_seen[@]+"${_seen[@]}"}; do
+      [ "$s" = "$d" ] && found=1 && break
+    done
+    if [ "$found" -eq 0 ]; then
+      echo "aborting deploy: cert-status missing for domain: '$d'" >&2
+      return 1
+    fi
+  done
+  return 0
+}
+
+# pearl_tls_prior_state <domain>
+#   Echoes the classified prior state for <domain> (or empty if
+#   not found). Reads DOMAINS_STATE_KEYS / DOMAINS_STATE_VALS.
+pearl_tls_prior_state() {
+  local target="$1" i k
+  i=0
+  for k in ${DOMAINS_STATE_KEYS[@]+"${DOMAINS_STATE_KEYS[@]}"}; do
+    if [ "$k" = "$target" ]; then
+      echo "${DOMAINS_STATE_VALS[$i]}"
+      return 0
+    fi
+    i=$((i+1))
+  done
+  echo ""
+  return 0
+}
+
+# pearl_tls_certbot_fail_warn <domain>
+#   Echoes the state-aware WARN line body for a certbot-failed
+#   domain. Caller wraps with its own "    WARN: certbot failed …"
+#   preamble if needed. This function returns the fully-formatted
+#   line matching the deploy script's pre-extraction output.
+pearl_tls_certbot_fail_warn() {
+  local d="$1"
+  local prior_state
+  prior_state=$(pearl_tls_prior_state "$d")
+  case "$prior_state" in
+    RENEW)
+      echo "WARN: certbot failed for $d (was RENEW) — existing full TLS vhost left in place; soon-expiring cert keeps serving until next deploy"
+      ;;
+    EXPIRED|MISSING)
+      echo "WARN: certbot failed for $d (was $prior_state) — ACME stub left in place; HTTPS unavailable for $d until next deploy"
+      ;;
+    *)
+      echo "WARN: certbot failed for $d (state=$prior_state) — continuing deploy"
+      ;;
+  esac
+}
+
+# pearl_tls_plan_full_tls
+#   Populates DOMAINS_FULL_TLS = DOMAINS_HAVE_CERT ∪ DOMAINS_ISSUED_OK.
+#   Caller ensures DOMAINS_HAVE_CERT + DOMAINS_ISSUED_OK are set (may
+#   be empty).
+pearl_tls_plan_full_tls() {
+  DOMAINS_FULL_TLS=(${DOMAINS_HAVE_CERT[@]+"${DOMAINS_HAVE_CERT[@]}"} ${DOMAINS_ISSUED_OK[@]+"${DOMAINS_ISSUED_OK[@]}"})
+}
+
+# pearl_tls_check_issuance_failures <primary_domain>
+#   Reads DOMAINS_ISSUED_FAIL. Sets PEARL_TLS_PRIMARY_FAILED and
+#   PEARL_TLS_NONPRIMARY_FAILED to 0/1.
+pearl_tls_check_issuance_failures() {
+  local primary_domain="$1" d
+  PEARL_TLS_PRIMARY_FAILED=0
+  PEARL_TLS_NONPRIMARY_FAILED=0
+  for d in ${DOMAINS_ISSUED_FAIL[@]+"${DOMAINS_ISSUED_FAIL[@]}"}; do
+    if [ "$d" = "$primary_domain" ]; then
+      PEARL_TLS_PRIMARY_FAILED=1
+    else
+      PEARL_TLS_NONPRIMARY_FAILED=1
+    fi
+  done
+}
+
+# pearl_tls_primary_abort_msg <primary_domain>
+#   Echoes the multi-line ABORT-EXIT message for a primary-domain
+#   cert-issuance failure, state-aware on prior state.
+pearl_tls_primary_abort_msg() {
+  local primary_domain="$1"
+  local prior_state
+  prior_state=$(pearl_tls_prior_state "$primary_domain")
+  echo ""
+  echo "  ABORT-EXIT: primary domain $primary_domain failed cert issuance during this deploy."
+  case "$prior_state" in
+    RENEW)
+      echo "             Prior state was RENEW — existing TLS vhost left in place;"
+      echo "             soon-expiring cert keeps serving until next deploy."
+      echo "             Fix DNS/certbot and re-run; do not wait beyond cert expiry."
+      ;;
+    EXPIRED|MISSING)
+      echo "             Prior state was $prior_state — ACME stub is in place;"
+      echo "             HTTPS is unavailable on $primary_domain until DNS/certbot is fixed"
+      echo "             and this script is re-run."
+      ;;
+    *)
+      echo "             Prior state was $prior_state — re-run after fixing DNS/certbot."
+      ;;
+  esac
+  echo "             Coordinator binary NOT restarted — old binary still serving."
+}

--- a/phase4-coordinator/dist/test/check_pearl_tls_test.sh
+++ b/phase4-coordinator/dist/test/check_pearl_tls_test.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# check_pearl_tls_test.sh — fixture-driven tests for the extracted
+# TLS state machine in dist/lib/pearl_tls.sh. Issue #291.
+#
+# Coverage matrix (all cells run without a real VPS):
+#   T01 HAVE + HAVE            → no stub, no certbot
+#   T02 RENEW + HAVE           → certbot for RENEW, no stub, HAVE full TLS
+#   T03 EXPIRED + HAVE         → stub + certbot for EXPIRED
+#   T04 MISSING + HAVE         → stub + certbot for MISSING
+#   T05 EXPIRED + MISSING      → stub + certbot for both
+#   T06 RENEW + RENEW          → certbot both, no stubs
+#   T07 primary MISSING + certbot fail   → PRIMARY_FAILED=1
+#   T08 non-primary MISSING + fail       → NONPRIMARY_FAILED=1
+#   T09 plan_full_tls picks HAVE ∪ ISSUED_OK, drops ISSUED_FAIL
+#   T10 certbot_fail_warn: RENEW  → "was RENEW … keeps serving"
+#   T11 certbot_fail_warn: MISSING → "was MISSING … HTTPS unavailable"
+#   T12 primary_abort_msg RENEW  → mentions "existing TLS vhost left"
+#   T13 primary_abort_msg MISSING → mentions "ACME stub is in place"
+#   T14 malformed cert-status line (extra field) → non-zero + stderr
+#   T15 unknown state token → non-zero + stderr
+#   T16 unexpected domain → non-zero + stderr
+#   T17 duplicate domain line → non-zero + stderr
+#   T18 coverage gap (missing expected domain) → non-zero + stderr
+#   T19 bash 3.2 + set -u: empty DOMAINS_ISSUED_FAIL iteration
+#   T20 remote probe script: HAVE fixture (openssl -checkend passes)
+#   T21 remote probe script: EXPIRED fixture (openssl -checkend fails)
+#   T22 remote probe script: MISSING fixture (files absent)
+#   T23 remote probe script: RENEW fixture (valid <86400s remaining)
+#   T24 remote probe script: openssl missing → ABORT
+#
+# Run: bash phase4-coordinator/dist/test/check_pearl_tls_test.sh
+# Exit: 0 all-pass, 1 any-fail.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../lib/pearl_tls.sh"
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: lib not found at $LIB" >&2
+  exit 1
+fi
+# shellcheck source=../lib/pearl_tls.sh
+. "$LIB"
+
+PASS=0
+FAIL=0
+LOG=""
+
+_assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+    LOG="${LOG}  PASS  $name
+"
+  else
+    FAIL=$((FAIL+1))
+    LOG="${LOG}  FAIL  $name
+        expected: '$expected'
+        actual:   '$actual'
+"
+  fi
+}
+
+_assert_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*)
+      PASS=$((PASS+1))
+      LOG="${LOG}  PASS  $name
+"
+      ;;
+    *)
+      FAIL=$((FAIL+1))
+      LOG="${LOG}  FAIL  $name
+        expected substring: '$needle'
+        in:                 '$haystack'
+"
+      ;;
+  esac
+}
+
+_reset() {
+  DOMAINS_ALL=("$@")
+  DOMAINS_HAVE_CERT=()
+  DOMAINS_NEED_CERT=()
+  DOMAINS_NEED_STUB=()
+  DOMAINS_STATE_KEYS=()
+  DOMAINS_STATE_VALS=()
+  DOMAINS_ISSUED_OK=()
+  DOMAINS_ISSUED_FAIL=()
+  DOMAINS_FULL_TLS=()
+  PEARL_TLS_PRIMARY_FAILED=0
+  PEARL_TLS_NONPRIMARY_FAILED=0
+}
+
+# T01 HAVE + HAVE → no stub, no certbot
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "HAVE coordinator.streamvc.live
+HAVE stats.streamvc.live"
+_assert_eq "T01 have_cert count"    "2" "${#DOMAINS_HAVE_CERT[@]}"
+_assert_eq "T01 need_cert count"    "0" "${#DOMAINS_NEED_CERT[@]}"
+_assert_eq "T01 need_stub count"    "0" "${#DOMAINS_NEED_STUB[@]}"
+
+# T02 RENEW + HAVE → certbot RENEW, no stub
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "RENEW coordinator.streamvc.live
+HAVE stats.streamvc.live"
+_assert_eq "T02 have_cert count"    "1" "${#DOMAINS_HAVE_CERT[@]}"
+_assert_eq "T02 need_cert count"    "1" "${#DOMAINS_NEED_CERT[@]}"
+_assert_eq "T02 need_stub count"    "0" "${#DOMAINS_NEED_STUB[@]}"
+_assert_eq "T02 need_cert domain"   "coordinator.streamvc.live" "${DOMAINS_NEED_CERT[0]}"
+
+# T03 EXPIRED + HAVE → stub + certbot for EXPIRED
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "EXPIRED coordinator.streamvc.live
+HAVE stats.streamvc.live"
+_assert_eq "T03 have_cert count"    "1" "${#DOMAINS_HAVE_CERT[@]}"
+_assert_eq "T03 need_cert count"    "1" "${#DOMAINS_NEED_CERT[@]}"
+_assert_eq "T03 need_stub count"    "1" "${#DOMAINS_NEED_STUB[@]}"
+_assert_eq "T03 need_stub domain"   "coordinator.streamvc.live" "${DOMAINS_NEED_STUB[0]}"
+
+# T04 MISSING + HAVE → stub + certbot for MISSING
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "MISSING coordinator.streamvc.live
+HAVE stats.streamvc.live"
+_assert_eq "T04 need_stub count"    "1" "${#DOMAINS_NEED_STUB[@]}"
+_assert_eq "T04 need_stub domain"   "coordinator.streamvc.live" "${DOMAINS_NEED_STUB[0]}"
+
+# T05 EXPIRED + MISSING → stub for both, certbot for both
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "EXPIRED coordinator.streamvc.live
+MISSING stats.streamvc.live"
+_assert_eq "T05 have_cert count"    "0" "${#DOMAINS_HAVE_CERT[@]}"
+_assert_eq "T05 need_cert count"    "2" "${#DOMAINS_NEED_CERT[@]}"
+_assert_eq "T05 need_stub count"    "2" "${#DOMAINS_NEED_STUB[@]}"
+
+# T06 RENEW + RENEW → certbot both, no stubs
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "RENEW coordinator.streamvc.live
+RENEW stats.streamvc.live"
+_assert_eq "T06 need_cert count"    "2" "${#DOMAINS_NEED_CERT[@]}"
+_assert_eq "T06 need_stub count"    "0" "${#DOMAINS_NEED_STUB[@]}"
+
+# T07 primary MISSING + certbot fail → PRIMARY_FAILED=1
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "MISSING coordinator.streamvc.live
+HAVE stats.streamvc.live"
+DOMAINS_ISSUED_FAIL=("coordinator.streamvc.live")
+pearl_tls_check_issuance_failures "coordinator.streamvc.live"
+_assert_eq "T07 primary_failed"     "1" "$PEARL_TLS_PRIMARY_FAILED"
+_assert_eq "T07 nonprimary_failed"  "0" "$PEARL_TLS_NONPRIMARY_FAILED"
+
+# T08 non-primary MISSING + fail → NONPRIMARY_FAILED=1
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "HAVE coordinator.streamvc.live
+MISSING stats.streamvc.live"
+DOMAINS_ISSUED_FAIL=("stats.streamvc.live")
+pearl_tls_check_issuance_failures "coordinator.streamvc.live"
+_assert_eq "T08 primary_failed"     "0" "$PEARL_TLS_PRIMARY_FAILED"
+_assert_eq "T08 nonprimary_failed"  "1" "$PEARL_TLS_NONPRIMARY_FAILED"
+
+# T09 plan_full_tls picks HAVE ∪ ISSUED_OK
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "RENEW coordinator.streamvc.live
+HAVE stats.streamvc.live"
+DOMAINS_ISSUED_OK=("coordinator.streamvc.live")
+DOMAINS_ISSUED_FAIL=()
+pearl_tls_plan_full_tls
+_assert_eq "T09 full_tls count"     "2" "${#DOMAINS_FULL_TLS[@]}"
+
+# T10 certbot_fail_warn: RENEW mentions "keeps serving"
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "RENEW coordinator.streamvc.live
+HAVE stats.streamvc.live"
+warn=$(pearl_tls_certbot_fail_warn "coordinator.streamvc.live")
+_assert_contains "T10 renew warn" "was RENEW" "$warn"
+_assert_contains "T10 renew warn body" "keeps serving" "$warn"
+
+# T11 certbot_fail_warn: MISSING mentions "HTTPS unavailable"
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "MISSING coordinator.streamvc.live
+HAVE stats.streamvc.live"
+warn=$(pearl_tls_certbot_fail_warn "coordinator.streamvc.live")
+_assert_contains "T11 missing warn" "was MISSING" "$warn"
+_assert_contains "T11 missing warn body" "HTTPS unavailable" "$warn"
+
+# T12 primary_abort_msg RENEW mentions "existing TLS vhost"
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "RENEW coordinator.streamvc.live
+HAVE stats.streamvc.live"
+abort=$(pearl_tls_primary_abort_msg "coordinator.streamvc.live")
+_assert_contains "T12 abort RENEW" "existing TLS vhost left in place" "$abort"
+
+# T13 primary_abort_msg MISSING mentions "ACME stub is in place"
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "MISSING coordinator.streamvc.live
+HAVE stats.streamvc.live"
+abort=$(pearl_tls_primary_abort_msg "coordinator.streamvc.live")
+_assert_contains "T13 abort MISSING" "ACME stub is in place" "$abort"
+
+# T14 malformed line (extra field) → non-zero + stderr mentions "extra field"
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+err=$(pearl_tls_classify "HAVE coordinator.streamvc.live extra
+HAVE stats.streamvc.live" 2>&1) && rc=0 || rc=$?
+_assert_eq "T14 rc"       "1" "$rc"
+_assert_contains "T14 stderr" "extra field" "$err"
+
+# T15 unknown state token → non-zero
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+err=$(pearl_tls_classify "BOGUS coordinator.streamvc.live
+HAVE stats.streamvc.live" 2>&1) && rc=0 || rc=$?
+_assert_eq "T15 rc"       "1" "$rc"
+_assert_contains "T15 stderr" "unknown cert-status state" "$err"
+
+# T16 unexpected domain → non-zero
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+err=$(pearl_tls_classify "HAVE some.other.host
+HAVE stats.streamvc.live" 2>&1) && rc=0 || rc=$?
+_assert_eq "T16 rc"       "1" "$rc"
+_assert_contains "T16 stderr" "unexpected domain" "$err"
+
+# T17 duplicate line → non-zero
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+err=$(pearl_tls_classify "HAVE coordinator.streamvc.live
+HAVE coordinator.streamvc.live" 2>&1) && rc=0 || rc=$?
+_assert_eq "T17 rc"       "1" "$rc"
+_assert_contains "T17 stderr" "duplicate cert-status line" "$err"
+
+# T18 coverage gap → non-zero
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+err=$(pearl_tls_classify "HAVE coordinator.streamvc.live" 2>&1) && rc=0 || rc=$?
+_assert_eq "T18 rc"       "1" "$rc"
+_assert_contains "T18 stderr" "cert-status missing for domain" "$err"
+
+# T19 bash-3.2 + set -u guard: empty DOMAINS_ISSUED_FAIL iteration doesn't unbound
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+pearl_tls_classify "HAVE coordinator.streamvc.live
+HAVE stats.streamvc.live"
+DOMAINS_ISSUED_FAIL=()
+# Turn set -u on locally to prove the ${arr[@]+"${arr[@]}"} guard works
+(set -u; pearl_tls_check_issuance_failures "coordinator.streamvc.live") && rc=0 || rc=$?
+_assert_eq "T19 empty-array under set -u" "0" "$rc"
+
+# T20-T24 exercise the actual remote probe script against local fixtures.
+# The probe script does openssl x509 -checkend on ${d}/fullchain.pem
+# under /etc/letsencrypt/live. We can't touch /etc as a test user, but
+# we can drive the script directly by faking `openssl` via PATH shim
+# and by short-circuiting the file existence checks with a fake
+# /etc/letsencrypt tree using LETSENCRYPT_ROOT override — the script
+# has no such env, so we drive it through a tmp-dir fixture with a
+# minimal `bash -c` harness that substitutes the /etc/letsencrypt/
+# prefix. Instead of a PATH shim, we feed the script real cert bytes
+# for HAVE/RENEW/EXPIRED and rely on real openssl.
+_probe_fixture_dir=$(mktemp -d -t pearl_tls_test.XXXXXXXX)
+trap 'rm -rf "$_probe_fixture_dir"' EXIT
+
+_gen_cert() {
+  # Args: <days_valid> <out_dir> — writes fullchain.pem + privkey.pem.
+  # For expired fixtures, pass a negative-or-zero days value; the
+  # helper signs via `openssl x509 -req -days 0` so notAfter equals
+  # notBefore = now, making the cert immediately expired.
+  local days="$1" dir="$2"
+  mkdir -p "$dir"
+  if [ "$days" -le 0 ]; then
+    # Two-step: CSR + sign with -days 0 (notAfter=now → -checkend 0 fails)
+    local csr="$dir/csr.pem"
+    openssl req -newkey rsa:2048 -keyout "$dir/privkey.pem" -out "$csr" \
+      -nodes -subj "/CN=test" >/dev/null 2>&1
+    openssl x509 -req -in "$csr" -signkey "$dir/privkey.pem" -days 0 \
+      -out "$dir/fullchain.pem" >/dev/null 2>&1
+    rm -f "$csr"
+  else
+    openssl req -x509 -newkey rsa:2048 -keyout "$dir/privkey.pem" \
+      -out "$dir/fullchain.pem" -sha256 -days "$days" -nodes \
+      -subj "/CN=test" >/dev/null 2>&1
+  fi
+}
+
+# Rewrite the probe script to use fixture root instead of /etc/letsencrypt.
+_run_probe() {
+  local fixture_root="$1"
+  shift  # remaining args are domains
+  local probe
+  probe=$(pearl_tls_remote_probe_script | \
+    sed "s|/etc/letsencrypt/live|$fixture_root/live|g")
+  bash -c "$probe" -- "$@"
+}
+
+# T20 HAVE fixture: fullchain valid for 90 days
+_gen_cert 90 "$_probe_fixture_dir/live/have.example"
+out=$(_run_probe "$_probe_fixture_dir" "have.example" 2>&1)
+_assert_eq "T20 HAVE" "HAVE have.example" "$out"
+
+# T21 EXPIRED fixture: cert issued with -days 0 is invalid now (past yesterday)
+_gen_cert -1 "$_probe_fixture_dir/live/expired.example"
+out=$(_run_probe "$_probe_fixture_dir" "expired.example" 2>&1)
+_assert_eq "T21 EXPIRED" "EXPIRED expired.example" "$out"
+
+# T22 MISSING fixture: dir does not exist
+out=$(_run_probe "$_probe_fixture_dir" "no-such.example" 2>&1)
+_assert_eq "T22 MISSING" "MISSING no-such.example" "$out"
+
+# T23 RENEW fixture: cert is valid right now but expires < 86400s from now.
+# Generate a cert valid 1 day (86400s), sleep briefly so <86400 remains.
+_gen_cert 1 "$_probe_fixture_dir/live/renew.example"
+# 1-day cert has exactly 86400s left immediately; -checkend 86400 tests
+# for MORE than 86400. So a 1-day cert should classify as RENEW right
+# after creation (< 86400s strictly remaining).
+sleep 2
+out=$(_run_probe "$_probe_fixture_dir" "renew.example" 2>&1)
+_assert_eq "T23 RENEW" "RENEW renew.example" "$out"
+
+# T24 openssl missing: run probe with PATH set to a dir that lacks
+# openssl so `command -v openssl` returns non-zero. Use a full path
+# to bash directly (invoking `bash` via env would need bash on PATH,
+# defeating the purpose).
+_empty_dir="$_probe_fixture_dir/empty_path"
+mkdir -p "$_empty_dir"
+_bash_exe="$(command -v bash)"
+probe_text=$(pearl_tls_remote_probe_script | sed "s|/etc/letsencrypt/live|$_probe_fixture_dir/live|g")
+out=$(PATH="$_empty_dir" "$_bash_exe" -c "$probe_text" -- "have.example" 2>&1) && rc=0 || rc=$?
+_assert_eq "T24 rc"       "1" "$rc"
+_assert_contains "T24 stderr" "ABORT openssl-missing-on-remote" "$out"
+
+# ---- summary ----
+printf '%s\n' "$LOG"
+printf 'pearl_tls_test: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/phase4-coordinator/dist/test/check_pearl_tls_test.sh
+++ b/phase4-coordinator/dist/test/check_pearl_tls_test.sh
@@ -408,44 +408,73 @@ out=$(PATH="$_empty_dir" "$_bash_exe" -c "$probe_text" -- "have.example" 2>&1) &
 _assert_eq "T24 rc"       "1" "$rc"
 _assert_contains "T24 stderr" "ABORT openssl-missing-on-remote" "$out"
 
-# T25 SEC R1 MED: sourcing via symlink resolves to the REAL script's
-# lib dir, not the symlink's parent dir. Prove by placing a hostile
-# lib in the symlink's parent — sourcing must ignore it.
+# T25 SEC R1+R2 MED: sourcing via symlink resolves to the REAL
+# script's lib dir, not the symlink's parent dir. Prove by placing
+# a hostile lib in the symlink's parent — resolver must ignore it,
+# AND we source the resolved lib to prove the hostile sentinel
+# NEVER gets set.
+#
+# T25 covers:
+#   T25a: absolute symlink pointing at the real script
+#   T25b: symlink-to-symlink chain
+#   T25c: parent-DIRECTORY symlink (R2 SEC MED — pwd -P fix)
+#   T25d: end-to-end sourcing — hostile lib planted next to symlink
+#         is NOT sourced (sentinel var must stay unset)
 _symlink_dir="$_probe_fixture_dir/symlink_test"
 mkdir -p "$_symlink_dir/lib"
-# Point the deploy symlink at the real deploy script under the
-# canonical dist/ location.
 _real_deploy="$SCRIPT_DIR/../deploy-pearl-vps.sh"
+_real_dist_dir=$(cd "$SCRIPT_DIR/.." && pwd -P)
 if [ -f "$_real_deploy" ]; then
   ln -sf "$_real_deploy" "$_symlink_dir/deploy-fake.sh"
-  # Plant a hostile lib in the symlink's parent that would set a
-  # sentinel if sourced. If the resolver walks the symlink correctly,
-  # THIS lib must NOT be sourced.
+  # Hostile helper — MUST NOT be sourced by the resolver.
   cat > "$_symlink_dir/lib/pearl_tls.sh" <<'HOSTILE'
-export PEARL_TLS_HOSTILE_SOURCED=1
+PEARL_TLS_HOSTILE_SOURCED=1
 HOSTILE
-  # Extract just the sourcing block and run it in isolation.
+
+  # The resolver snippet — kept in one place so tests exercise the
+  # same code the deploy script sources.
   _resolve_snippet='
 _pearl_resolve_symlink() {
   local src="$1" dir
   while [ -h "$src" ]; do
-    dir="$(cd "$(dirname "$src")" && pwd)"
+    dir="$(cd "$(dirname "$src")" && pwd -P)"
     src="$(readlink "$src")"
     case "$src" in
       /*) ;;
       *) src="$dir/$src" ;;
     esac
   done
-  cd "$(dirname "$src")" && pwd
+  cd "$(dirname "$src")" && pwd -P
 }
-resolved="$(_pearl_resolve_symlink "'"$_symlink_dir/deploy-fake.sh"'")"
-echo "$resolved"
 '
-  resolved_dir=$(bash -c "$_resolve_snippet" 2>&1)
-  _real_dist_dir=$(cd "$SCRIPT_DIR/.." && pwd)
-  _assert_eq "T25 symlink resolves to real dist" "$_real_dist_dir" "$resolved_dir"
+
+  # T25a: absolute-target symlink
+  resolved_dir=$(bash -c "$_resolve_snippet"'echo "$(_pearl_resolve_symlink "'"$_symlink_dir/deploy-fake.sh"'")"' 2>&1)
+  _assert_eq "T25a absolute symlink → real dist" "$_real_dist_dir" "$resolved_dir"
+
+  # T25b: symlink-to-symlink chain
+  ln -sf "$_symlink_dir/deploy-fake.sh" "$_symlink_dir/deploy-chain.sh"
+  resolved_dir=$(bash -c "$_resolve_snippet"'echo "$(_pearl_resolve_symlink "'"$_symlink_dir/deploy-chain.sh"'")"' 2>&1)
+  _assert_eq "T25b chain symlink → real dist" "$_real_dist_dir" "$resolved_dir"
+
+  # T25c: parent-DIRECTORY symlink (R2 SEC MED). Point a directory
+  # symlink at the real dist/ dir, invoke via that alias, ensure
+  # the resolver still lands on the physical real path.
+  _parent_alias="$_probe_fixture_dir/dist-alias"
+  ln -sf "$_real_dist_dir" "$_parent_alias"
+  resolved_dir=$(bash -c "$_resolve_snippet"'echo "$(_pearl_resolve_symlink "'"$_parent_alias/deploy-pearl-vps.sh"'")"' 2>&1)
+  _assert_eq "T25c parent-dir symlink → real dist (pwd -P)" "$_real_dist_dir" "$resolved_dir"
+
+  # T25d: END-TO-END. Actually source the resolved lib in a
+  # subshell and prove the hostile sentinel never gets set.
+  end_to_end=$(bash -c "$_resolve_snippet"'
+    resolved="$(_pearl_resolve_symlink "'"$_symlink_dir/deploy-fake.sh"'")"
+    unset PEARL_TLS_HOSTILE_SOURCED
+    . "$resolved/lib/pearl_tls.sh"
+    echo "hostile=${PEARL_TLS_HOSTILE_SOURCED:-unset}"
+  ' 2>&1)
+  _assert_eq "T25d hostile lib NOT sourced" "hostile=unset" "$end_to_end"
 else
-  # Deploy script not present in this worktree state — assert-skip
   PASS=$((PASS+1))
   LOG="${LOG}  PASS  T25 (skipped: real deploy script not present)
 "

--- a/phase4-coordinator/dist/test/check_pearl_tls_test.sh
+++ b/phase4-coordinator/dist/test/check_pearl_tls_test.sh
@@ -474,6 +474,52 @@ _pearl_resolve_symlink() {
     echo "hostile=${PEARL_TLS_HOSTILE_SOURCED:-unset}"
   ' 2>&1)
   _assert_eq "T25d hostile lib NOT sourced" "hostile=unset" "$end_to_end"
+
+  # T25e: R3 SEC MED — DIST_DIR (deploy artifact root) hangs off
+  # `$_PEARL_TLS_SCRIPT_DIR`, not a logical recomputation from `$0`.
+  # Grep the assignment line to prove that dependency at rest,
+  # then invoke deploy through the parent-alias symlink so
+  # BASH_SOURCE[0] IS the symlinked path, and verify DIST_DIR
+  # settles on the physical real path.
+  #
+  # Static check: the assignment must reuse the physically-
+  # resolved var. Codex R3 SEC MED flagged the previous
+  # `DIST_DIR="$(cd "$(dirname "$0")" && pwd)"` shape.
+  dist_dir_line=$(grep '^DIST_DIR=' "$_real_deploy" | head -1)
+  _assert_eq "T25e DIST_DIR reuses resolved dir" \
+    'DIST_DIR="$_PEARL_TLS_SCRIPT_DIR"' "$dist_dir_line"
+
+  # T25f: dynamic check — extract the prelude WITH BASH_SOURCE
+  # captured before the resolver runs. We do this by writing a
+  # tiny driver at the symlinked path that sources the extracted
+  # prelude, then reads DIST_DIR. Because the driver lives at
+  # `$_parent_alias/driver.sh` (the parent-DIR symlink), BASH_SOURCE
+  # naturally reflects the symlinked path.
+  # Extract only the two blocks needed to prove DIST_DIR resolution:
+  # (1) the _pearl_resolve_symlink function + its invocation, and
+  # (2) the DIST_DIR assignment line. Skip all downstream validation
+  # (SSH key checks, EMAIL regex, DNS probes) which would otherwise
+  # abort the driver before DIST_DIR is even reached.
+  _resolver=$(sed -n '/^_pearl_resolve_symlink()/,/^\. "\$_PEARL_TLS_SCRIPT_DIR/p' "$_real_deploy")
+  _dist_line=$(grep '^DIST_DIR=' "$_real_deploy" | head -1)
+  _prelude=$(printf '#!/usr/bin/env bash\nset -u\n%s\n%s\n' "$_resolver" "$_dist_line")
+  # Write the driver into the REAL dist dir (so it exists inside
+  # $_parent_alias, which is a symlink to it), name unique to avoid
+  # collision with dist artifacts.
+  _driver_name="__pearl_tls_test_driver_$$.sh"
+  _driver_real="$_real_dist_dir/$_driver_name"
+  _driver_via_alias="$_parent_alias/$_driver_name"
+  {
+    printf '%s\n' "$_prelude"
+    printf 'echo "DIST_DIR=$DIST_DIR"\n'
+    printf 'exit 0\n'
+  } > "$_driver_real"
+  # Register cleanup on top of the existing trap.
+  trap 'rm -f "'"$_driver_real"'"; rm -rf "$_probe_fixture_dir"' EXIT
+
+  dist_dir_out=$(bash "$_driver_via_alias" 2>&1 | tail -1)
+  _assert_eq "T25f DIST_DIR resolves to physical real dist via parent-alias" \
+    "DIST_DIR=$_real_dist_dir" "$dist_dir_out"
 else
   PASS=$((PASS+1))
   LOG="${LOG}  PASS  T25 (skipped: real deploy script not present)

--- a/phase4-coordinator/dist/test/check_pearl_tls_test.sh
+++ b/phase4-coordinator/dist/test/check_pearl_tls_test.sh
@@ -93,9 +93,20 @@ _reset() {
   PEARL_TLS_NONPRIMARY_FAILED=0
 }
 
+# _classify_ok — CODE R1 MED fix: success-path calls MUST assert rc=0.
+# Without this, a bug where pearl_tls_classify returns nonzero AFTER
+# correctly mutating arrays would pass all downstream assertions but
+# make deploy-pearl-vps.sh exit at `|| exit 1`.
+_classify_ok() {
+  local name="$1" status_text="$2"
+  local rc=0
+  pearl_tls_classify "$status_text" 2>/dev/null || rc=$?
+  _assert_eq "$name (classify rc=0)" "0" "$rc"
+}
+
 # T01 HAVE + HAVE → no stub, no certbot
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "HAVE coordinator.streamvc.live
+_classify_ok "T01" "HAVE coordinator.streamvc.live
 HAVE stats.streamvc.live"
 _assert_eq "T01 have_cert count"    "2" "${#DOMAINS_HAVE_CERT[@]}"
 _assert_eq "T01 need_cert count"    "0" "${#DOMAINS_NEED_CERT[@]}"
@@ -103,7 +114,7 @@ _assert_eq "T01 need_stub count"    "0" "${#DOMAINS_NEED_STUB[@]}"
 
 # T02 RENEW + HAVE → certbot RENEW, no stub
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "RENEW coordinator.streamvc.live
+_classify_ok "T02" "RENEW coordinator.streamvc.live
 HAVE stats.streamvc.live"
 _assert_eq "T02 have_cert count"    "1" "${#DOMAINS_HAVE_CERT[@]}"
 _assert_eq "T02 need_cert count"    "1" "${#DOMAINS_NEED_CERT[@]}"
@@ -112,7 +123,7 @@ _assert_eq "T02 need_cert domain"   "coordinator.streamvc.live" "${DOMAINS_NEED_
 
 # T03 EXPIRED + HAVE → stub + certbot for EXPIRED
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "EXPIRED coordinator.streamvc.live
+_classify_ok "T03" "EXPIRED coordinator.streamvc.live
 HAVE stats.streamvc.live"
 _assert_eq "T03 have_cert count"    "1" "${#DOMAINS_HAVE_CERT[@]}"
 _assert_eq "T03 need_cert count"    "1" "${#DOMAINS_NEED_CERT[@]}"
@@ -121,14 +132,14 @@ _assert_eq "T03 need_stub domain"   "coordinator.streamvc.live" "${DOMAINS_NEED_
 
 # T04 MISSING + HAVE → stub + certbot for MISSING
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "MISSING coordinator.streamvc.live
+_classify_ok "T04" "MISSING coordinator.streamvc.live
 HAVE stats.streamvc.live"
 _assert_eq "T04 need_stub count"    "1" "${#DOMAINS_NEED_STUB[@]}"
 _assert_eq "T04 need_stub domain"   "coordinator.streamvc.live" "${DOMAINS_NEED_STUB[0]}"
 
 # T05 EXPIRED + MISSING → stub for both, certbot for both
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "EXPIRED coordinator.streamvc.live
+_classify_ok "T05" "EXPIRED coordinator.streamvc.live
 MISSING stats.streamvc.live"
 _assert_eq "T05 have_cert count"    "0" "${#DOMAINS_HAVE_CERT[@]}"
 _assert_eq "T05 need_cert count"    "2" "${#DOMAINS_NEED_CERT[@]}"
@@ -136,14 +147,14 @@ _assert_eq "T05 need_stub count"    "2" "${#DOMAINS_NEED_STUB[@]}"
 
 # T06 RENEW + RENEW → certbot both, no stubs
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "RENEW coordinator.streamvc.live
+_classify_ok "T06" "RENEW coordinator.streamvc.live
 RENEW stats.streamvc.live"
 _assert_eq "T06 need_cert count"    "2" "${#DOMAINS_NEED_CERT[@]}"
 _assert_eq "T06 need_stub count"    "0" "${#DOMAINS_NEED_STUB[@]}"
 
 # T07 primary MISSING + certbot fail → PRIMARY_FAILED=1
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "MISSING coordinator.streamvc.live
+_classify_ok "T07" "MISSING coordinator.streamvc.live
 HAVE stats.streamvc.live"
 DOMAINS_ISSUED_FAIL=("coordinator.streamvc.live")
 pearl_tls_check_issuance_failures "coordinator.streamvc.live"
@@ -152,25 +163,40 @@ _assert_eq "T07 nonprimary_failed"  "0" "$PEARL_TLS_NONPRIMARY_FAILED"
 
 # T08 non-primary MISSING + fail → NONPRIMARY_FAILED=1
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "HAVE coordinator.streamvc.live
+_classify_ok "T08" "HAVE coordinator.streamvc.live
 MISSING stats.streamvc.live"
 DOMAINS_ISSUED_FAIL=("stats.streamvc.live")
 pearl_tls_check_issuance_failures "coordinator.streamvc.live"
 _assert_eq "T08 primary_failed"     "0" "$PEARL_TLS_PRIMARY_FAILED"
 _assert_eq "T08 nonprimary_failed"  "1" "$PEARL_TLS_NONPRIMARY_FAILED"
 
-# T09 plan_full_tls picks HAVE ∪ ISSUED_OK
+# T09 plan_full_tls picks HAVE ∪ ISSUED_OK and DROPS ISSUED_FAIL.
+# R1 CODE LOW + ARCH MED: original T09 set ISSUED_FAIL=() and only
+# checked count — a bug that included ISSUED_FAIL would pass. Now
+# populate a real failed domain and assert exact contents.
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "RENEW coordinator.streamvc.live
+_classify_ok "T09" "EXPIRED coordinator.streamvc.live
+HAVE stats.streamvc.live"
+DOMAINS_ISSUED_OK=()
+DOMAINS_ISSUED_FAIL=("coordinator.streamvc.live")   # certbot failed for primary
+pearl_tls_plan_full_tls
+_assert_eq "T09 full_tls count (fail excluded)"  "1" "${#DOMAINS_FULL_TLS[@]}"
+_assert_eq "T09 full_tls content"                "stats.streamvc.live" "${DOMAINS_FULL_TLS[0]}"
+
+# T09b plan_full_tls with HAVE ∪ ISSUED_OK when a RENEW succeeds
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+_classify_ok "T09b" "RENEW coordinator.streamvc.live
 HAVE stats.streamvc.live"
 DOMAINS_ISSUED_OK=("coordinator.streamvc.live")
 DOMAINS_ISSUED_FAIL=()
 pearl_tls_plan_full_tls
-_assert_eq "T09 full_tls count"     "2" "${#DOMAINS_FULL_TLS[@]}"
+_assert_eq "T09b full_tls count"                 "2" "${#DOMAINS_FULL_TLS[@]}"
+_assert_eq "T09b full_tls has HAVE first"        "stats.streamvc.live" "${DOMAINS_FULL_TLS[0]}"
+_assert_eq "T09b full_tls has ISSUED_OK second"  "coordinator.streamvc.live" "${DOMAINS_FULL_TLS[1]}"
 
 # T10 certbot_fail_warn: RENEW mentions "keeps serving"
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "RENEW coordinator.streamvc.live
+_classify_ok "T10" "RENEW coordinator.streamvc.live
 HAVE stats.streamvc.live"
 warn=$(pearl_tls_certbot_fail_warn "coordinator.streamvc.live")
 _assert_contains "T10 renew warn" "was RENEW" "$warn"
@@ -178,7 +204,7 @@ _assert_contains "T10 renew warn body" "keeps serving" "$warn"
 
 # T11 certbot_fail_warn: MISSING mentions "HTTPS unavailable"
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "MISSING coordinator.streamvc.live
+_classify_ok "T11" "MISSING coordinator.streamvc.live
 HAVE stats.streamvc.live"
 warn=$(pearl_tls_certbot_fail_warn "coordinator.streamvc.live")
 _assert_contains "T11 missing warn" "was MISSING" "$warn"
@@ -186,17 +212,71 @@ _assert_contains "T11 missing warn body" "HTTPS unavailable" "$warn"
 
 # T12 primary_abort_msg RENEW mentions "existing TLS vhost"
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "RENEW coordinator.streamvc.live
+_classify_ok "T12" "RENEW coordinator.streamvc.live
 HAVE stats.streamvc.live"
 abort=$(pearl_tls_primary_abort_msg "coordinator.streamvc.live")
 _assert_contains "T12 abort RENEW" "existing TLS vhost left in place" "$abort"
 
 # T13 primary_abort_msg MISSING mentions "ACME stub is in place"
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "MISSING coordinator.streamvc.live
+_classify_ok "T13" "MISSING coordinator.streamvc.live
 HAVE stats.streamvc.live"
 abort=$(pearl_tls_primary_abort_msg "coordinator.streamvc.live")
 _assert_contains "T13 abort MISSING" "ACME stub is in place" "$abort"
+
+# R1 ARCH MED — add missing prior-state × certbot-fail × primary/non-primary combos.
+# T13a: RENEW + certbot fail on PRIMARY → PRIMARY_FAILED=1, abort text "existing TLS vhost"
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+_classify_ok "T13a" "RENEW coordinator.streamvc.live
+HAVE stats.streamvc.live"
+DOMAINS_ISSUED_FAIL=("coordinator.streamvc.live")
+pearl_tls_check_issuance_failures "coordinator.streamvc.live"
+_assert_eq "T13a RENEW primary_failed"     "1" "$PEARL_TLS_PRIMARY_FAILED"
+_assert_eq "T13a RENEW nonprimary_failed"  "0" "$PEARL_TLS_NONPRIMARY_FAILED"
+abort=$(pearl_tls_primary_abort_msg "coordinator.streamvc.live")
+_assert_contains "T13a RENEW abort text" "existing TLS vhost left in place" "$abort"
+
+# T13b: EXPIRED + certbot fail on PRIMARY → PRIMARY_FAILED=1, abort text "ACME stub"
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+_classify_ok "T13b" "EXPIRED coordinator.streamvc.live
+HAVE stats.streamvc.live"
+DOMAINS_ISSUED_FAIL=("coordinator.streamvc.live")
+pearl_tls_check_issuance_failures "coordinator.streamvc.live"
+_assert_eq "T13b EXPIRED primary_failed"     "1" "$PEARL_TLS_PRIMARY_FAILED"
+abort=$(pearl_tls_primary_abort_msg "coordinator.streamvc.live")
+_assert_contains "T13b EXPIRED abort text" "ACME stub is in place" "$abort"
+
+# T13c: RENEW + certbot fail on NON-PRIMARY (stats) → NONPRIMARY_FAILED=1 only
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+_classify_ok "T13c" "HAVE coordinator.streamvc.live
+RENEW stats.streamvc.live"
+DOMAINS_ISSUED_FAIL=("stats.streamvc.live")
+pearl_tls_check_issuance_failures "coordinator.streamvc.live"
+_assert_eq "T13c RENEW nonprim primary_failed"     "0" "$PEARL_TLS_PRIMARY_FAILED"
+_assert_eq "T13c RENEW nonprim nonprimary_failed"  "1" "$PEARL_TLS_NONPRIMARY_FAILED"
+# Non-primary WARN text
+warn=$(pearl_tls_certbot_fail_warn "stats.streamvc.live")
+_assert_contains "T13c nonprim RENEW warn" "was RENEW" "$warn"
+
+# T13d: EXPIRED + certbot fail on NON-PRIMARY
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+_classify_ok "T13d" "HAVE coordinator.streamvc.live
+EXPIRED stats.streamvc.live"
+DOMAINS_ISSUED_FAIL=("stats.streamvc.live")
+pearl_tls_check_issuance_failures "coordinator.streamvc.live"
+_assert_eq "T13d EXPIRED nonprim primary_failed"     "0" "$PEARL_TLS_PRIMARY_FAILED"
+_assert_eq "T13d EXPIRED nonprim nonprimary_failed"  "1" "$PEARL_TLS_NONPRIMARY_FAILED"
+warn=$(pearl_tls_certbot_fail_warn "stats.streamvc.live")
+_assert_contains "T13d nonprim EXPIRED warn" "was EXPIRED" "$warn"
+
+# T13e: BOTH primary + non-primary fail simultaneously → both flags set
+_reset "coordinator.streamvc.live" "stats.streamvc.live"
+_classify_ok "T13e" "MISSING coordinator.streamvc.live
+MISSING stats.streamvc.live"
+DOMAINS_ISSUED_FAIL=("coordinator.streamvc.live" "stats.streamvc.live")
+pearl_tls_check_issuance_failures "coordinator.streamvc.live"
+_assert_eq "T13e both primary_failed"     "1" "$PEARL_TLS_PRIMARY_FAILED"
+_assert_eq "T13e both nonprimary_failed"  "1" "$PEARL_TLS_NONPRIMARY_FAILED"
 
 # T14 malformed line (extra field) → non-zero + stderr mentions "extra field"
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
@@ -234,7 +314,7 @@ _assert_contains "T18 stderr" "cert-status missing for domain" "$err"
 
 # T19 bash-3.2 + set -u guard: empty DOMAINS_ISSUED_FAIL iteration doesn't unbound
 _reset "coordinator.streamvc.live" "stats.streamvc.live"
-pearl_tls_classify "HAVE coordinator.streamvc.live
+_classify_ok "T19" "HAVE coordinator.streamvc.live
 HAVE stats.streamvc.live"
 DOMAINS_ISSUED_FAIL=()
 # Turn set -u on locally to prove the ${arr[@]+"${arr[@]}"} guard works
@@ -316,11 +396,60 @@ _assert_eq "T23 RENEW" "RENEW renew.example" "$out"
 # defeating the purpose).
 _empty_dir="$_probe_fixture_dir/empty_path"
 mkdir -p "$_empty_dir"
-_bash_exe="$(command -v bash)"
+# R1 SEC LOW harden: prefer $BASH (set by bash itself) over PATH-
+# resolved lookup so a poisoned PATH cannot substitute a fake bash.
+_bash_exe="${BASH:-/bin/bash}"
+case "$_bash_exe" in
+  /*) ;;
+  *)  echo "FAIL: \$BASH resolved to non-absolute path '$_bash_exe'"; exit 1 ;;
+esac
 probe_text=$(pearl_tls_remote_probe_script | sed "s|/etc/letsencrypt/live|$_probe_fixture_dir/live|g")
 out=$(PATH="$_empty_dir" "$_bash_exe" -c "$probe_text" -- "have.example" 2>&1) && rc=0 || rc=$?
 _assert_eq "T24 rc"       "1" "$rc"
 _assert_contains "T24 stderr" "ABORT openssl-missing-on-remote" "$out"
+
+# T25 SEC R1 MED: sourcing via symlink resolves to the REAL script's
+# lib dir, not the symlink's parent dir. Prove by placing a hostile
+# lib in the symlink's parent — sourcing must ignore it.
+_symlink_dir="$_probe_fixture_dir/symlink_test"
+mkdir -p "$_symlink_dir/lib"
+# Point the deploy symlink at the real deploy script under the
+# canonical dist/ location.
+_real_deploy="$SCRIPT_DIR/../deploy-pearl-vps.sh"
+if [ -f "$_real_deploy" ]; then
+  ln -sf "$_real_deploy" "$_symlink_dir/deploy-fake.sh"
+  # Plant a hostile lib in the symlink's parent that would set a
+  # sentinel if sourced. If the resolver walks the symlink correctly,
+  # THIS lib must NOT be sourced.
+  cat > "$_symlink_dir/lib/pearl_tls.sh" <<'HOSTILE'
+export PEARL_TLS_HOSTILE_SOURCED=1
+HOSTILE
+  # Extract just the sourcing block and run it in isolation.
+  _resolve_snippet='
+_pearl_resolve_symlink() {
+  local src="$1" dir
+  while [ -h "$src" ]; do
+    dir="$(cd "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    case "$src" in
+      /*) ;;
+      *) src="$dir/$src" ;;
+    esac
+  done
+  cd "$(dirname "$src")" && pwd
+}
+resolved="$(_pearl_resolve_symlink "'"$_symlink_dir/deploy-fake.sh"'")"
+echo "$resolved"
+'
+  resolved_dir=$(bash -c "$_resolve_snippet" 2>&1)
+  _real_dist_dir=$(cd "$SCRIPT_DIR/.." && pwd)
+  _assert_eq "T25 symlink resolves to real dist" "$_real_dist_dir" "$resolved_dir"
+else
+  # Deploy script not present in this worktree state — assert-skip
+  PASS=$((PASS+1))
+  LOG="${LOG}  PASS  T25 (skipped: real deploy script not present)
+"
+fi
 
 # ---- summary ----
 printf '%s\n' "$LOG"

--- a/specs/AUDIT_ISS291_ARCHITECT_R1_PROMPT.md
+++ b/specs/AUDIT_ISS291_ARCHITECT_R1_PROMPT.md
@@ -1,0 +1,49 @@
+## Lane: ARCHITECT — Round 1
+
+## Context
+
+Issue #291: extract 4-state TLS classifier (HAVE / RENEW / EXPIRED /
+MISSING) + planner + messaging out of
+`phase4-coordinator/dist/deploy-pearl-vps.sh` (steps 4b–6c) into
+`phase4-coordinator/dist/lib/pearl_tls.sh`, add fixture tests, wire
+into `make test-dist`.
+
+Origin: #244 R2 ARCH M3 + R3 ARCH "Architectural Verdict" + R6 ARCH
+recurring recommendation.
+
+Fix in commit `871dd31`. Design:
+- Bash 3.2 compatible (operator Mac); no `declare -A`, no `mapfile`.
+- Parallel-array pattern preserved (2-4 domain scale, linear scan
+  acceptable).
+- Functions mutate documented global arrays instead of returning
+  values (bash idiom, consistent with the surrounding script).
+- Functions return non-zero instead of exit-ing — caller decides
+  whether the failure is fatal (deploy: yes; test: assert on stderr
+  and continue).
+- Sourcing pattern: `. "$(dirname BASH_SOURCE)/lib/pearl_tls.sh"` at
+  script top, before any array is referenced.
+
+## Your job
+
+ARCHITECT LANE round 1. Evaluate:
+- Is the lib's API surface sound? Is the parallel-array + mutation
+  contract clear to future readers, or would a struct-style pattern
+  (e.g. echoing `KEY=VAL` lines to be `eval`'d) be worth the
+  bash-3.2 pain?
+- Is the split boundary in the right place? Should more of the
+  certbot loop / stub install move into the lib for testability,
+  or does the SSH boundary correctly stop where it does?
+- Is fixture-test coverage complete relative to the 32-cell matrix
+  described in the issue (HAVE/RENEW/EXPIRED/MISSING × cert-ok/fail
+  × primary/non-primary)?
+- Does the sourced-lib pattern scale to a future 3rd hostname
+  (per-N-hostname loop or hardcoded pair)?
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/lib/pearl_tls.sh` (NEW, ~241 lines)
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/test/check_pearl_tls_test.sh` (NEW, ~330 lines)
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/deploy-pearl-vps.sh` (MODIFIED, ~150 lines removed, ~15 added)
+- `/Users/augstar/macprovider-iss291/Makefile` (MODIFIED, +1 line)
+
+Diff: `git -C /Users/augstar/macprovider-iss291 show HEAD`

--- a/specs/AUDIT_ISS291_ARCHITECT_R2_PROMPT.md
+++ b/specs/AUDIT_ISS291_ARCHITECT_R2_PROMPT.md
@@ -1,0 +1,31 @@
+## Lane: ARCHITECT — Round 2
+
+## Context
+
+R1 outcomes:
+- CODE 0/0/1/2
+- SEC  0/0/1/2
+- ARCH 0/0/1/1 — MED: fixture coverage sampled; LOW: deploy wiring pair-shaped
+
+R1 fix-pass `14e9bb2` (ARCH-relevant slice):
+- T09 rewritten with real ISSUED_FAIL + content ordering assertion
+- T09b for HAVE-first + ISSUED_OK-second ordering
+- T13a-T13e cover 5 additional prior-state × primary-role combos
+  (RENEW+fail-primary, EXPIRED+fail-primary, RENEW+fail-nonprimary,
+  EXPIRED+fail-nonprimary, BOTH-fail)
+- 84 tests, was 46
+
+## Your job
+
+ARCHITECT LANE round 2. Verify coverage is now adequate for the
+described 32-cell matrix (HAVE/RENEW/EXPIRED/MISSING × cert-ok/fail
+× primary/non-primary). The R1 LOW (deploy wiring pair-shaped)
+remains — evaluate whether it should upgrade or defer.
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/lib/pearl_tls.sh`
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/test/check_pearl_tls_test.sh`
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/deploy-pearl-vps.sh`
+
+R1→R2 diff: `git -C /Users/augstar/macprovider-iss291 show HEAD`

--- a/specs/AUDIT_ISS291_CODE_R1_PROMPT.md
+++ b/specs/AUDIT_ISS291_CODE_R1_PROMPT.md
@@ -1,0 +1,52 @@
+## Lane: CODE — Round 1
+
+## Context
+
+Issue #291: extract the 4-state TLS classifier + planner + messaging
+out of `phase4-coordinator/dist/deploy-pearl-vps.sh` (steps 4b–6c,
+~150 lines) into `phase4-coordinator/dist/lib/pearl_tls.sh`, plus add
+fixture tests in `phase4-coordinator/dist/test/check_pearl_tls_test.sh`.
+
+Fix in commit `871dd31`:
+- New: `lib/pearl_tls.sh` — 7 pure functions, bash 3.2 compatible,
+  parallel-array pattern preserved from original.
+- New: `test/check_pearl_tls_test.sh` — 46 assertions across 24 test
+  cases (full HAVE/RENEW/EXPIRED/MISSING matrix, primary/non-primary
+  cert-failure classifier, validation error paths, bash 3.2 empty-
+  array-under-set-u guard, real-openssl fixture tests for the remote
+  probe script).
+- `deploy-pearl-vps.sh` — sources the lib, replaces inline heredoc +
+  classification loop + certbot-fail messaging + primary-abort block
+  with function calls. Behavior byte-preserved (same log lines, same
+  exit codes, same array shapes).
+- `Makefile` — `test-dist` target runs the new suite (already wired
+  into the CI `dist-tooling` job).
+
+## Your job
+
+CODE LANE round 1. This is a money-adjacent refactor — the deploy
+script is the sole path to shipping the coordinator binary to Pearl,
+and the TLS state machine determines whether HTTPS keeps working
+after a deploy. Standard severity-graded findings.
+
+Focus areas:
+- Did any behavior drift between the original inline blocks and the
+  extracted functions?
+- Did I introduce any race between `set -e` in the caller and
+  `return N` in the lib functions?
+- Did the array-mutation contract stay consistent (all callers still
+  see the same DOMAINS_HAVE_CERT/NEED_CERT/etc. arrays)?
+- Is bash 3.2 compatibility preserved everywhere?
+- Do the fixture tests actually exercise the assertions their names
+  claim, or is there a false-positive shape?
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/lib/pearl_tls.sh` (NEW)
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/test/check_pearl_tls_test.sh` (NEW)
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/deploy-pearl-vps.sh` (MODIFIED)
+- `/Users/augstar/macprovider-iss291/Makefile` (MODIFIED)
+
+Diff: `git -C /Users/augstar/macprovider-iss291 show HEAD`
+
+Base state: `git -C /Users/augstar/macprovider-iss291 show HEAD:phase4-coordinator/dist/deploy-pearl-vps.sh` (main-side original before extraction)

--- a/specs/AUDIT_ISS291_CODE_R2_PROMPT.md
+++ b/specs/AUDIT_ISS291_CODE_R2_PROMPT.md
@@ -1,0 +1,29 @@
+## Lane: CODE — Round 2
+
+## Context
+
+R1 outcomes:
+- CODE 0/0/1/2 — MED: success-path calls didn't assert rc=0; LOWs on T09 content
+- SEC  0/0/1/2 — MED: symlink hijack of sourcing path
+- ARCH 0/0/1/1 — MED: fixture coverage sampled
+
+R1 fix-pass `14e9bb2`:
+- `_classify_ok` helper asserts rc=0 on all 12 success paths
+  (T01-T13e, T19)
+- T09 rewritten with real ISSUED_FAIL, content assertion, exclusion
+  proof; T09b added for RENEW+ISSUED_OK ordering
+- T13a-T13e cover RENEW+fail-primary, EXPIRED+fail-primary, RENEW+
+  fail-nonprimary, EXPIRED+fail-nonprimary, BOTH-fail combos
+- 84 tests pass, was 46
+
+## Your job
+
+CODE LANE round 2. Verify convergence.
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/lib/pearl_tls.sh`
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/test/check_pearl_tls_test.sh`
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/deploy-pearl-vps.sh`
+
+R1→R2 diff: `git -C /Users/augstar/macprovider-iss291 show HEAD`

--- a/specs/AUDIT_ISS291_SECURITY_R1_PROMPT.md
+++ b/specs/AUDIT_ISS291_SECURITY_R1_PROMPT.md
@@ -1,0 +1,40 @@
+## Lane: SECURITY — Round 1
+
+## Context
+
+Issue #291: extract TLS state machine from
+`phase4-coordinator/dist/deploy-pearl-vps.sh` into
+`phase4-coordinator/dist/lib/pearl_tls.sh` + add fixture tests.
+
+Fix in commit `871dd31`. Pure refactor — no new features. The
+extracted functions run entirely on the operator's Mac (LOCAL), not
+on Pearl. The remote probe script is generated locally via
+`pearl_tls_remote_probe_script` then fed via `ssh $VPS bash -s -- $D1 $D2 ...`.
+
+## Your job
+
+SECURITY LANE round 1. This is deploy-code — the only path to shipping
+new binaries to a production coordinator that handles money-path
+traffic. Standard severity-graded findings.
+
+Focus areas:
+- Does the extracted `pearl_tls_remote_probe_script` still produce
+  the exact same shell script that was previously inline heredoc?
+  Any character-set drift (quoting, escapes, newlines) that would
+  allow shell metacharacter injection under a malicious DOMAIN /
+  STATS_DOMAIN?
+- Does the `. $_PEARL_TLS_SCRIPT_DIR/lib/pearl_tls.sh` sourcing pattern
+  open a path-traversal / library-hijack vector? (BASH_SOURCE
+  resolution + `cd` + `pwd`.)
+- Do the fixture tests introduce any local-path race (`mktemp -d -t`
+  is used — is that adequate on macOS 3.2 bash?)
+- Does the `PATH="$_empty_dir" "$_bash_exe" -c ...` test invocation
+  in T24 open a path-hijack surface if run under CI?
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/lib/pearl_tls.sh` (NEW)
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/test/check_pearl_tls_test.sh` (NEW)
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/deploy-pearl-vps.sh` (MODIFIED)
+
+Diff: `git -C /Users/augstar/macprovider-iss291 show HEAD`

--- a/specs/AUDIT_ISS291_SECURITY_R2_PROMPT.md
+++ b/specs/AUDIT_ISS291_SECURITY_R2_PROMPT.md
@@ -1,0 +1,32 @@
+## Lane: SECURITY — Round 2
+
+## Context
+
+R1 outcomes:
+- CODE 0/0/1/2 — MED classify-rc; LOWs on T09
+- SEC  0/0/1/2 — MED symlink hijack; LOWs on probe-comment drift + T24 bash lookup
+- ARCH 0/0/1/1 — MED coverage
+
+R1 fix-pass `14e9bb2` (SEC-relevant slice):
+- Added `_pearl_resolve_symlink` in deploy-pearl-vps.sh — walks
+  symlink chain (macOS bash 3.2 has no `readlink -f`) so sourcing
+  always resolves to the REAL script's dist/lib/pearl_tls.sh, not
+  the symlink's parent dir
+- T25 test: plants a hostile `lib/pearl_tls.sh` next to a symlink
+  and asserts the resolver picks the real dist/, not the decoy
+- T24 hardened: `_bash_exe="${BASH:-/bin/bash}"` (skips PATH
+  lookup) + absolute-path assertion
+
+## Your job
+
+SECURITY LANE round 2. Verify symlink-hijack path is fully closed,
+including edge cases: relative-symlink chains, symlink-to-symlink
+chains, symlinks with `..` segments.
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/lib/pearl_tls.sh`
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/deploy-pearl-vps.sh`
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/test/check_pearl_tls_test.sh`
+
+R1→R2 diff: `git -C /Users/augstar/macprovider-iss291 show HEAD`

--- a/specs/AUDIT_ISS291_SECURITY_R3_PROMPT.md
+++ b/specs/AUDIT_ISS291_SECURITY_R3_PROMPT.md
@@ -1,0 +1,31 @@
+## Lane: SECURITY — Round 3
+
+## Context
+
+R2 outcomes:
+- CODE 0/0/0/0 PASS (converged)
+- SEC  0/0/1/1 — MED: `pwd` should be `pwd -P` (parent-dir symlink
+  bypass); LOW: T25 didn't source hostile lib to prove non-sourcing
+- ARCH 0/0/0/0 PASS
+
+R2 fix-pass `ca48d69`:
+- `_pearl_resolve_symlink` uses `pwd -P` at both cd sites so
+  parent-DIRECTORY symlinks are physically resolved
+- T25 expanded to 4 sub-tests: T25a absolute, T25b chain, T25c
+  parent-dir symlink (R2 SEC MED coverage), T25d END-TO-END
+  sources the resolved lib in a subshell and asserts the hostile
+  sentinel var PEARL_TLS_HOSTILE_SOURCED stays UNSET
+
+## Your job
+
+SECURITY LANE round 3. Verify the parent-dir symlink hijack is
+fully closed. Any remaining path-traversal / TOCTOU / hostile-
+sourcing surface.
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/lib/pearl_tls.sh`
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/deploy-pearl-vps.sh`
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/test/check_pearl_tls_test.sh`
+
+R2→R3 diff: `git -C /Users/augstar/macprovider-iss291 show HEAD`

--- a/specs/AUDIT_ISS291_SECURITY_R4_PROMPT.md
+++ b/specs/AUDIT_ISS291_SECURITY_R4_PROMPT.md
@@ -1,0 +1,32 @@
+## Lane: SECURITY — Round 4
+
+## Context
+
+R3 outcomes:
+- CODE 0/0/0/0 PASS at R2, skipped R3 (scope unchanged)
+- SEC  0/0/1/1 — MED: DIST_DIR still uses logical `$0` + plain `pwd`
+- ARCH 0/0/0/0 PASS at R2, skipped R3
+
+R3 fix-pass `bbfa59b`:
+- `DIST_DIR="$_PEARL_TLS_SCRIPT_DIR"` — reuses the physically-
+  resolved path so a parent-DIR symlink cannot redirect deploy
+  artifact reads/uploads
+- T25e static regression guard on the assignment shape
+- T25f end-to-end driver via parent-alias symlink proves
+  DIST_DIR settles on the physical real path
+
+89/89 tests pass.
+
+## Your job
+
+SECURITY LANE round 4. Verify all symlink-related surfaces are
+closed. Any other logical-path recomputation site in
+deploy-pearl-vps.sh that could be exploited the same way.
+
+## Files in scope
+
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/lib/pearl_tls.sh`
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/deploy-pearl-vps.sh`
+- `/Users/augstar/macprovider-iss291/phase4-coordinator/dist/test/check_pearl_tls_test.sh`
+
+R3→R4 diff: `git -C /Users/augstar/macprovider-iss291 show HEAD`


### PR DESCRIPTION
## Summary

Closes #291. Extracts the 4-state TLS classifier (HAVE / RENEW /
EXPIRED / MISSING) + planner + operator messaging out of
`phase4-coordinator/dist/deploy-pearl-vps.sh` (steps 4b–6c, ~150
lines) into a sourced helper `phase4-coordinator/dist/lib/pearl_tls.sh`,
plus 89 fixture tests exercising the state machine without a real
Pearl deploy.

Origin: #244 R2 ARCH M3 + R3 ARCH "Architectural Verdict" + R6 ARCH
recurring recommendation. Every TLS-safety change until now required
a real deploy or hours of dry-runs to validate.

## Extracted API

`phase4-coordinator/dist/lib/pearl_tls.sh` — 7 pure functions,
bash 3.2 compatible, parallel-array pattern preserved:

- `pearl_tls_remote_probe_script` — emits the openssl-checkend
  script the deploy runs on the remote VPS
- `pearl_tls_classify` — parses probe stdout, validates format +
  coverage + no-dup + no-unexpected, populates 5 output arrays
- `pearl_tls_prior_state` — parallel-array key→value lookup
- `pearl_tls_certbot_fail_warn` — state-aware WARN body for the
  post-certbot failure branch
- `pearl_tls_plan_full_tls` — DOMAINS_FULL_TLS = HAVE ∪ ISSUED_OK
- `pearl_tls_check_issuance_failures` — primary/non-primary
  classifier
- `pearl_tls_primary_abort_msg` — state-aware ABORT-EXIT text

Behavior byte-preserved: same log lines, same exit codes, same
array shapes, same `${arr[@]+"${arr[@]}"}` bash-3.2 guards.

## Test suite

`phase4-coordinator/dist/test/check_pearl_tls_test.sh` — 89
assertions:

- **State classification** (T01-T06): full HAVE/RENEW/EXPIRED/MISSING
  × 2-domain matrix, all combinations
- **Failure branch** (T07-T08, T13a-T13e): primary vs non-primary
  certbot failure for MISSING, RENEW, EXPIRED, plus simultaneous
  primary+non-primary
- **Planning** (T09, T09b): plan_full_tls picks HAVE ∪ ISSUED_OK,
  drops ISSUED_FAIL, orders HAVE first then ISSUED_OK
- **Messaging** (T10-T13): state-aware WARN and ABORT text
- **Validation errors** (T14-T18): malformed line / unknown state /
  unexpected domain / duplicate / coverage gap
- **Bash 3.2 + set -u** (T19): empty-array iteration doesn't unbound
- **Remote probe** (T20-T23): real self-signed cert fixtures drive
  the actual probe script for HAVE / EXPIRED / MISSING / RENEW
- **Openssl missing** (T24): ABORT path with hardened bash lookup
- **Symlink invocation** (T25a-T25f): 4 sub-tests + 2 static
  regression guards proving the sourcing walker and DIST_DIR both
  resolve to the physical real path across absolute / chain /
  parent-dir symlinks, including END-TO-END hostile-lib
  non-sourcing proof

Wired into `make test-dist` so it runs in the `deploy tooling
(check-deploy-config gate)` CI job.

## Rounds

| R | CODE | SEC | ARCH | Notes |
|---|------|-----|------|-------|
| 1 | 0/0/1/2 | 0/0/1/2 | 0/0/1/1 | 3 MEDs absorbed |
| 2 | **0/0/0/0 PASS** | 0/0/1/1 | **0/0/0/0 PASS** | SEC pwd -P for parent-dir |
| 3 | (skip) | 0/0/1/1 | (skip) | DIST_DIR still logical $0 |
| 4 | (skip) | **0/0/0/0 PASS** | (skip) | **Converged** |

## Security hardening (deferred audit-loop MEDs absorbed)

The extraction surfaced 3 latent symlink-hijack surfaces in the
existing deploy script — closed as part of this PR:

1. **Sourcing path** (R1 SEC MED): `BASH_SOURCE[0]` + plain
   `dirname` + `pwd` picked up the symlink parent instead of the
   real script parent. Fixed by `_pearl_resolve_symlink` walker.
2. **Parent-directory symlink** (R2 SEC MED): my R1 walker used
   plain `pwd`, so a parent-DIR symlink still bypassed. Fixed by
   `pwd -P` at both cd sites.
3. **DIST_DIR recomputation** (R3 SEC MED): the deploy artifact
   root was still computed via `$0` + logical `pwd`, keeping
   parent-symlink-retargeting alive for artifact reads / uploads.
   Fixed by `DIST_DIR="$_PEARL_TLS_SCRIPT_DIR"`.

## Test plan

- [x] `bash -n` on all 3 shell files: pass
- [x] `make test-dist`: pass (89/89 pearl_tls + all pre-existing dist tests)
- [x] Byte-preserved behavior: same log lines / exit codes / array shapes
- [x] End-to-end symlink resolution proven via parent-alias driver

Generated with [Claude Code](https://claude.com/claude-code)
