### PR TITLE
fix(spec-023): HF download retry-with-resume + bump v1.7.4 (3-lane audit converged R1)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -1355,11 +1355,108 @@ struct HuggingFaceSnapshotDownloader {
         return URLSession(configuration: config)
     }()
 
+    // Retry-with-resume policy for the transient network errors that URLSession
+    // serializes into NSURLSessionDownloadTaskResumeData on -1005 / -1001 /
+    // -1009 / -1004 / -1006 (network connection lost, timeout, offline, host
+    // routing failure, DNS lookup failure). Multi-GB HF safetensors shards
+    // reliably trip these over ~10-30 min continuous transfers on residential
+    // links; without resume, one drop wipes gigabytes of prior progress and
+    // fails install with die 6.
+    struct DownloadRetryPolicy {
+        var maxAttempts: Int
+        var baseDelaySeconds: Double
+        var backoffMultiplier: Double
+        var sleep: @Sendable (UInt64) async throws -> Void
+
+        static let production = DownloadRetryPolicy(
+            maxAttempts: 3,
+            baseDelaySeconds: 5.0,
+            backoffMultiplier: 4.0,
+            sleep: { ns in try await Task.sleep(nanoseconds: ns) }
+        )
+    }
+
     var fetch: (URLRequest) async throws -> (Data, URLResponse) = { request in
         try await HuggingFaceSnapshotDownloader.guardedSession.data(for: request, delegate: HFRedirectGuard())
     }
     var download: (URLRequest) async throws -> (URL, URLResponse) = { request in
-        try await HuggingFaceSnapshotDownloader.guardedSession.download(for: request, delegate: HFAssetRedirectGuard())
+        try await HuggingFaceSnapshotDownloader.downloadWithResume(
+            request: request,
+            policy: .production,
+            initialDownload: { req in
+                try await HuggingFaceSnapshotDownloader.guardedSession.download(
+                    for: req, delegate: HFAssetRedirectGuard()
+                )
+            },
+            resumeDownload: { data in
+                try await HuggingFaceSnapshotDownloader.guardedSession.download(
+                    resumeFrom: data, delegate: HFAssetRedirectGuard()
+                )
+            }
+        )
+    }
+
+    // Retry-with-resume shell. Delegates the actual network operation to
+    // injectable closures so unit tests can drive the retry state machine
+    // without a live URLSession or real backoff delays.
+    //
+    // Loop invariants:
+    //  - resumeData starts nil (first attempt is a fresh download).
+    //  - On transient URLError, capture resume data from userInfo (may be nil
+    //    if the failure was too early for URLSession to serialize state).
+    //  - On next attempt, if resumeData is non-nil use resumeDownload; else
+    //    fall back to initialDownload (fresh start).
+    //  - Non-transient URLError or non-URLError bubbles up immediately.
+    //  - After maxAttempts failures, throw the last recorded error.
+    //  - Cancellation cooperates through policy.sleep (Task.sleep participates
+    //    in Swift structured concurrency cancellation).
+    static func downloadWithResume(
+        request: URLRequest,
+        policy: DownloadRetryPolicy,
+        initialDownload: @Sendable (URLRequest) async throws -> (URL, URLResponse),
+        resumeDownload: @Sendable (Data) async throws -> (URL, URLResponse)
+    ) async throws -> (URL, URLResponse) {
+        var lastError: Error?
+        var resumeData: Data?
+        for attempt in 0..<max(1, policy.maxAttempts) {
+            do {
+                if let data = resumeData {
+                    return try await resumeDownload(data)
+                }
+                return try await initialDownload(request)
+            } catch let error as URLError where isTransientDownloadError(error) {
+                lastError = error
+                if let extracted = extractResumeData(from: error) {
+                    resumeData = extracted
+                }
+                if attempt + 1 < policy.maxAttempts {
+                    let delaySeconds = policy.baseDelaySeconds
+                        * pow(policy.backoffMultiplier, Double(attempt))
+                    let delayNanoseconds = UInt64(max(0, delaySeconds) * 1_000_000_000)
+                    try await policy.sleep(delayNanoseconds)
+                }
+            }
+        }
+        throw lastError ?? URLError(.unknown)
+    }
+
+    static func isTransientDownloadError(_ error: URLError) -> Bool {
+        switch error.code {
+        case .networkConnectionLost,
+             .timedOut,
+             .notConnectedToInternet,
+             .cannotConnectToHost,
+             .cannotFindHost,
+             .dnsLookupFailed,
+             .resourceUnavailable:
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func extractResumeData(from error: URLError) -> Data? {
+        error.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
     }
 
     func downloadSnapshot(modelID: String, revision: String, to snapshot: URL) async throws {

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.7.3"
+    static let binaryVersion = "1.7.4"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -496,6 +496,239 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertNil(redirected)
     }
 
+    // MARK: - downloadWithResume (v1.7.4 retry-with-resume for HF -1005 drops)
+
+    private static func makeDownloadRetryPolicyNoDelay(
+        maxAttempts: Int,
+        sleepCalls: SleepCounter
+    ) -> HuggingFaceSnapshotDownloader.DownloadRetryPolicy {
+        HuggingFaceSnapshotDownloader.DownloadRetryPolicy(
+            maxAttempts: maxAttempts,
+            baseDelaySeconds: 0.0,
+            backoffMultiplier: 1.0,
+            sleep: { ns in await sleepCalls.record(ns) }
+        )
+    }
+
+    private actor SleepCounter {
+        var invocations: [UInt64] = []
+        func record(_ ns: UInt64) { invocations.append(ns) }
+        func snapshot() -> [UInt64] { invocations }
+    }
+
+    private static let dummyOKResponse: HTTPURLResponse = HTTPURLResponse(
+        url: URL(string: "https://huggingface.co/repo/resolve/main/file.safetensors")!,
+        statusCode: 200,
+        httpVersion: "HTTP/1.1",
+        headerFields: nil
+    )!
+
+    private static func fakeDownloadedFileURL(name: String) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("hf-download-resume-\(UUID().uuidString)-\(name)")
+        try Data("stub".utf8).write(to: url)
+        return url
+    }
+
+    func testDownloadWithResumeSucceedsOnFirstAttempt() async throws {
+        let counter = SleepCounter()
+        let policy = Self.makeDownloadRetryPolicyNoDelay(maxAttempts: 3, sleepCalls: counter)
+        let request = URLRequest(url: URL(string: "https://huggingface.co/repo/resolve/main/file.safetensors")!)
+        let temp = try Self.fakeDownloadedFileURL(name: "first-attempt")
+
+        let initialCalls = SleepCounter()
+        let (localURL, response) = try await HuggingFaceSnapshotDownloader.downloadWithResume(
+            request: request,
+            policy: policy,
+            initialDownload: { req in
+                await initialCalls.record(UInt64(req.url?.absoluteString.count ?? 0))
+                return (temp, Self.dummyOKResponse)
+            },
+            resumeDownload: { _ in
+                XCTFail("resume should not be invoked when initial download succeeds")
+                return (temp, Self.dummyOKResponse)
+            }
+        )
+
+        XCTAssertEqual(localURL, temp)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        let calls = await initialCalls.snapshot()
+        XCTAssertEqual(calls.count, 1)
+        let sleeps = await counter.snapshot()
+        XCTAssertTrue(sleeps.isEmpty, "no backoff sleep expected on first-try success")
+        try? FileManager.default.removeItem(at: temp)
+    }
+
+    func testDownloadWithResumeUsesResumeDataOnTransientFailure() async throws {
+        let counter = SleepCounter()
+        let policy = Self.makeDownloadRetryPolicyNoDelay(maxAttempts: 3, sleepCalls: counter)
+        let request = URLRequest(url: URL(string: "https://huggingface.co/repo/resolve/main/file.safetensors")!)
+        let resumeBlob = Data("resume-state-bytes".utf8)
+        let temp = try Self.fakeDownloadedFileURL(name: "resume-hit")
+
+        let resumeCalls = SleepCounter()
+        let (localURL, _) = try await HuggingFaceSnapshotDownloader.downloadWithResume(
+            request: request,
+            policy: policy,
+            initialDownload: { _ in
+                throw URLError(
+                    .networkConnectionLost,
+                    userInfo: [NSURLSessionDownloadTaskResumeData: resumeBlob]
+                )
+            },
+            resumeDownload: { data in
+                XCTAssertEqual(data, resumeBlob, "resume must carry the exact bytes URLSession serialized")
+                await resumeCalls.record(UInt64(data.count))
+                return (temp, Self.dummyOKResponse)
+            }
+        )
+
+        XCTAssertEqual(localURL, temp)
+        let calls = await resumeCalls.snapshot()
+        XCTAssertEqual(calls.count, 1)
+        let sleeps = await counter.snapshot()
+        XCTAssertEqual(sleeps.count, 1, "one backoff sleep expected between attempts 1 and 2")
+        try? FileManager.default.removeItem(at: temp)
+    }
+
+    func testDownloadWithResumeRetriesFreshWhenNoResumeDataProvided() async throws {
+        let counter = SleepCounter()
+        let policy = Self.makeDownloadRetryPolicyNoDelay(maxAttempts: 3, sleepCalls: counter)
+        let request = URLRequest(url: URL(string: "https://huggingface.co/repo/resolve/main/file.safetensors")!)
+        let temp = try Self.fakeDownloadedFileURL(name: "no-resume-fresh")
+
+        let initialCalls = SleepCounter()
+        _ = try await HuggingFaceSnapshotDownloader.downloadWithResume(
+            request: request,
+            policy: policy,
+            initialDownload: { req in
+                await initialCalls.record(UInt64(req.url?.absoluteString.count ?? 0))
+                let count = await initialCalls.snapshot().count
+                if count == 1 {
+                    throw URLError(.timedOut)
+                }
+                return (temp, Self.dummyOKResponse)
+            },
+            resumeDownload: { _ in
+                XCTFail("resume must not run when no resume data was captured")
+                return (temp, Self.dummyOKResponse)
+            }
+        )
+
+        let calls = await initialCalls.snapshot()
+        XCTAssertEqual(calls.count, 2, "second attempt is a fresh initialDownload when no resume data")
+        try? FileManager.default.removeItem(at: temp)
+    }
+
+    func testDownloadWithResumeExhaustsAttemptsThenThrowsLast() async throws {
+        let counter = SleepCounter()
+        let policy = Self.makeDownloadRetryPolicyNoDelay(maxAttempts: 3, sleepCalls: counter)
+        let request = URLRequest(url: URL(string: "https://huggingface.co/repo/resolve/main/file.safetensors")!)
+        let final = URLError(.networkConnectionLost)
+
+        do {
+            _ = try await HuggingFaceSnapshotDownloader.downloadWithResume(
+                request: request,
+                policy: policy,
+                initialDownload: { _ in throw URLError(.timedOut) },
+                resumeDownload: { _ in throw final }
+            )
+            XCTFail("expected throw after all attempts fail")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .timedOut, "no resume data ever captured, initial keeps running; last=timedOut")
+        }
+        let sleeps = await counter.snapshot()
+        XCTAssertEqual(sleeps.count, 2, "sleeps=maxAttempts-1 between failing attempts")
+    }
+
+    func testDownloadWithResumeRethrowsNonTransientImmediately() async throws {
+        let counter = SleepCounter()
+        let policy = Self.makeDownloadRetryPolicyNoDelay(maxAttempts: 3, sleepCalls: counter)
+        let request = URLRequest(url: URL(string: "https://huggingface.co/repo/resolve/main/file.safetensors")!)
+
+        // .cancelled (-999) is programmatic cancel — never retry.
+        do {
+            _ = try await HuggingFaceSnapshotDownloader.downloadWithResume(
+                request: request,
+                policy: policy,
+                initialDownload: { _ in throw URLError(.cancelled) },
+                resumeDownload: { _ in
+                    XCTFail("resume must not run on non-transient error")
+                    return (URL(fileURLWithPath: "/tmp/x"), Self.dummyOKResponse)
+                }
+            )
+            XCTFail("expected cancellation to propagate")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .cancelled)
+        }
+        let sleeps = await counter.snapshot()
+        XCTAssertTrue(sleeps.isEmpty, "non-transient errors skip backoff and skip retry")
+    }
+
+    func testDownloadWithResumeRethrowsNonURLErrorImmediately() async throws {
+        struct SpecificError: Error, Equatable {}
+        let counter = SleepCounter()
+        let policy = Self.makeDownloadRetryPolicyNoDelay(maxAttempts: 3, sleepCalls: counter)
+        let request = URLRequest(url: URL(string: "https://huggingface.co/repo/resolve/main/file.safetensors")!)
+
+        do {
+            _ = try await HuggingFaceSnapshotDownloader.downloadWithResume(
+                request: request,
+                policy: policy,
+                initialDownload: { _ in throw SpecificError() },
+                resumeDownload: { _ in
+                    XCTFail("resume must not run on non-URLError")
+                    return (URL(fileURLWithPath: "/tmp/x"), Self.dummyOKResponse)
+                }
+            )
+            XCTFail("expected non-URLError to propagate")
+        } catch is SpecificError {
+            // expected
+        } catch {
+            XCTFail("expected SpecificError; got \(error)")
+        }
+        let sleeps = await counter.snapshot()
+        XCTAssertTrue(sleeps.isEmpty)
+    }
+
+    func testIsTransientDownloadErrorCoversExpectedSet() {
+        let transient: [URLError.Code] = [
+            .networkConnectionLost, .timedOut, .notConnectedToInternet,
+            .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed,
+            .resourceUnavailable
+        ]
+        for code in transient {
+            XCTAssertTrue(
+                HuggingFaceSnapshotDownloader.isTransientDownloadError(URLError(code)),
+                "\(code) should be considered transient"
+            )
+        }
+        let nonTransient: [URLError.Code] = [
+            .cancelled, .badURL, .unsupportedURL, .badServerResponse,
+            .userAuthenticationRequired, .fileDoesNotExist
+        ]
+        for code in nonTransient {
+            XCTAssertFalse(
+                HuggingFaceSnapshotDownloader.isTransientDownloadError(URLError(code)),
+                "\(code) should NOT be considered transient"
+            )
+        }
+    }
+
+    func testExtractResumeDataReturnsNilWhenAbsent() {
+        let e = URLError(.networkConnectionLost)
+        XCTAssertNil(HuggingFaceSnapshotDownloader.extractResumeData(from: e))
+    }
+
+    func testExtractResumeDataReturnsBytesWhenPresent() {
+        let blob = Data("captured-resume-state".utf8)
+        let e = URLError(
+            .networkConnectionLost,
+            userInfo: [NSURLSessionDownloadTaskResumeData: blob]
+        )
+        XCTAssertEqual(HuggingFaceSnapshotDownloader.extractResumeData(from: e), blob)
+    }
+
     func testHMACIdentityUsesSeparateDomainsAndSecretFileIs0600() throws {
         let dir = try tempDir()
         let secretURL = dir.appendingPathComponent("autotune-hmac-secret")

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1481,10 +1481,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.3")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.3")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.7.3")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.7.3")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.4")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.4")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.7.4")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.7.4")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_ARCHITECT_PROMPT.md
@@ -1,0 +1,89 @@
+# AUDIT (ARCHITECT lane) — SPEC-023 HuggingFaceSnapshotDownloader retry-with-resume
+
+## Context
+
+macprovider-cli's SPEC-023 installer-integrated autotune-recommend downloads HuggingFace model shards during install. On operator's M5, every 2026-07-02 v1.7.3 install failed at real-network `NSURLErrorDomain -1005 "The network connection was lost."` mid-transfer.
+
+Root cause: `HuggingFaceSnapshotDownloader.download` closure at `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:1361-1394` treats any URLSession download failure as fatal. No retry, no resume-data extraction, no partial-progress preservation. Entire staging directory (potentially 10+ GB of previously-completed shards) wiped on any error.
+
+## The change
+
+- New `DownloadRetryPolicy` struct (injectable production defaults: 3 attempts, 5s base delay, 4x backoff, `Task.sleep`)
+- New `HuggingFaceSnapshotDownloader.downloadWithResume` static function taking `initialDownload` + `resumeDownload` as `@Sendable` closures
+- The instance-level `download` closure now delegates to `downloadWithResume` with production defaults
+- Bump binaryVersion 1.7.3 → 1.7.4
+
+Related surrounding code (unchanged):
+- `HuggingFaceSnapshotDownloader.downloadSnapshot(modelID:revision:to:)` iterates siblings sequentially, wraps in try/catch that wipes staging on error. **Still wipes on terminal failure after all retries exhausted.**
+- `HFAssetRedirectGuard` delegate rejects redirects to non-HF hosts, strips Authorization header
+- `guardedSession` is a static `.ephemeral` URLSession
+- `addTokenHeader` reads HF_TOKEN env var, sets `Authorization: Bearer ...` on request
+
+## Files changed (repo-relative)
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift` (+99 / -6)
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift` (+1 / -1)
+- `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift` (+233)
+- `phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift` (+4 / -4)
+
+## Your instructions (ARCHITECT lane, this file)
+
+You are the ARCHITECT lens. Focus exclusively on:
+
+- **Placement of retry.** Is `downloadWithResume` at the right layer? Should retry live at the per-sibling level (inside the for-loop in `downloadSnapshot`) versus per-request (inside the closure)? Trade-off: sibling-level catches per-file failures but misses cross-sibling patterns; request-level (current) doesn't preserve completed siblings on terminal failure.
+- **Staging-dir wipe on terminal failure.** After `downloadWithResume` exhausts retries and throws, `downloadSnapshot`'s catch still wipes the whole staging dir (line ~1392). Should this PR ALSO fix that so partial progress across siblings survives to the next `autotune --recommend` invocation? Or is that out of scope, with a follow-up PR?
+- **Sequential vs parallel sibling downloads.** Line 1374 loops siblings serially. On a 4-shard model (~22 GB total), that means 4 sequential downloads. Parallelism could halve wall-clock but adds concurrent-connection cost, HF rate-limit risk, and memory pressure. Trade-off — is the current serial approach still the right choice given retries now handle transient drops? Any latent bug from concurrent-safe assumption vs actual serial invariant?
+- **Backoff schedule sanity.** 5s → 20s → cap at 80s (but only 3 attempts total so only 5s + 20s = 25s wall-clock added). Reasonable for install-time UX? For headless CI/scripting?
+- **Configuration surface.** The `DownloadRetryPolicy` struct is public/internal-scoped. Should operators be able to override via env var (`MACPROVIDER_HF_MAX_ATTEMPTS`, `MACPROVIDER_HF_BASE_DELAY`) for degraded environments? Or is that YAGNI?
+- **Test injection design.** `downloadWithResume` accepts closures for `initialDownload` + `resumeDownload`. Alternative: accept a session + delegate factory. Trade-off in test overhead vs production directness.
+- **Layering vs mlx-swift-examples.** The mlx-swift-examples package (2.29.1) has its own HF download machinery via MLXLLM/MLXLMCommon. SPEC-023 uses its own downloader instead to enforce hash+revision provenance. Given this PR adds retry logic that mlx-swift-examples' downloader may already have (or may not), any risk of duplicated / conflicting behavior when both hit HF for the same model?
+- **Task cancellation semantics.** Structured concurrency: does a `Task.cancel()` propagate correctly through `policy.sleep` + the retry loop? Should it? What's the UX contract during a Ctrl-C mid-install?
+- **Version bump appropriateness.** 1.7.3 → 1.7.4 (patch). Change is behavior-affecting (users who previously failed will now succeed). Is patch correct or should this be a minor bump (1.8.0)?
+- **Observability.** No new log line emitted on retry. Should the retry emit a stderr line so users see "retrying download after 5s (attempt 2/3)…"? SPEC-023 already emits "Running paid-yield recommendation before service start." from install.sh — should the retries be visible?
+
+Do NOT critique code correctness (state machine, edge cases) or security surface — those go to sibling audit lanes.
+
+Return findings as a structured list. For each finding: **file:line, severity (CRITICAL/HIGH/MEDIUM/LOW), one-sentence summary, architectural concern, minimal fix.**
+
+Bar for STOP: 0 CRITICAL, 0 HIGH, 0 MEDIUM in your final response. Iterate the actual codebase and re-audit only after fixes if invited. Absent an invitation, single pass.
+
+## Excerpted code under audit
+
+### phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift (relevant excerpt)
+
+Same excerpts as CODE + SECURITY lanes; see those files. Key architectural context:
+
+```swift
+// UNCHANGED — caller of the (now retrying) download closure:
+func downloadSnapshot(modelID: String, revision: String, to snapshot: URL) async throws {
+    let siblings = try await modelSiblings(modelID: modelID, revision: revision)
+    guard !siblings.isEmpty else {
+        throw AutotuneRecommendError.invalidArtifact("empty HuggingFace snapshot \(modelID)@\(revision)")
+    }
+    let staging = snapshot.deletingLastPathComponent()
+        .appendingPathComponent(".download-\(revision)-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+    do {
+        for sibling in siblings {
+            try validateRelativeHFPath(sibling.rfilename)
+            let destination = staging.appendingPathComponent(sibling.rfilename, isDirectory: false)
+            try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+            var request = URLRequest(url: resolveURL(modelID: modelID, revision: revision, filename: sibling.rfilename))
+            addTokenHeader(&request)
+            let (temporary, response) = try await download(request)  // <-- NOW retries under the hood
+            guard (response as? HTTPURLResponse).map({ (200..<300).contains($0.statusCode) }) ?? true else {
+                throw AutotuneRecommendError.invalidArtifact("download failed \(sibling.rfilename)")
+            }
+            try? FileManager.default.removeItem(at: destination)
+            try FileManager.default.moveItem(at: temporary, to: destination)
+            _ = chmod(destination.path, 0o600)
+        }
+        try FileManager.default.createDirectory(at: snapshot.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? FileManager.default.removeItem(at: snapshot)
+        try FileManager.default.moveItem(at: staging, to: snapshot)
+    } catch {
+        try? FileManager.default.removeItem(at: staging)  // <-- STILL wipes on terminal failure
+        throw error
+    }
+}
+```

--- a/specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_CODE_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_CODE_PROMPT.md
@@ -1,0 +1,168 @@
+# AUDIT (CODE lane) — SPEC-023 HuggingFaceSnapshotDownloader retry-with-resume
+
+## Context
+
+macprovider-cli's SPEC-023 installer-integrated autotune-recommend downloads HuggingFace model shards during install. Every 2026-07-02 v1.7.3 install attempt on operator's M5 (real production QA) failed at `AutotuneCommand.swift::run_autotune_recommend_apply` when a large safetensors shard download dropped with `NSURLErrorDomain -1005 "The network connection was lost."` mid-transfer.
+
+Root cause discovered via `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:1361-1394`:
+1. The `download` closure used `URLSession.download(for:delegate:)` and did NOT catch the URLError to extract `NSURLSessionDownloadTaskResumeData` from `userInfo`.
+2. On any error inside the per-sibling loop, the entire staging directory (potentially with 10+ GB of already-downloaded shards) got wiped.
+3. Zero retry: one shard drop = complete install failure.
+
+Verification B (empirical Swift test at scratchpad/verify-resume.swift) confirmed:
+- HF CDN returns `HTTP/2 206 Partial Content` with `Content-Range: bytes N-M/TOTAL` on Range requests
+- URLSession's resume-data blob (11-12 KB opaque bytes) correctly encodes byte offset
+- `URLSession.download(resumeFrom:delegate:)` async API resumes from that offset, produces a byte-identical complete file (4,517,488,999 bytes == expected total)
+
+## The change
+
+New static function `downloadWithResume` on `HuggingFaceSnapshotDownloader`. Retries transient network errors (7 specific `URLError.Code` values), extracts resume data from `error.userInfo[NSURLSessionDownloadTaskResumeData]`, calls `URLSession.download(resumeFrom:)` on next attempt. Backoff exponential 5s/20s. Max 3 attempts. Non-transient errors or non-URLError bubble immediately.
+
+New unit tests (9) cover:
+- Success on first attempt (no retry, no backoff)
+- Resume-data captured on transient → next attempt uses resume path
+- No resume-data captured on transient → next attempt is fresh
+- All attempts fail → last error thrown
+- Non-transient URLError (.cancelled) → immediate rethrow, no backoff
+- Non-URLError → immediate rethrow, no backoff
+- `isTransientDownloadError` covers 7 codes, excludes 6 sample non-transient codes
+- `extractResumeData` returns nil when absent, bytes when present
+
+Version bump: 1.7.3 → 1.7.4. Test assertions updated to match.
+
+## Files changed (repo-relative)
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift` (+99 / -6, retry-with-resume logic on `HuggingFaceSnapshotDownloader`)
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift` (+1 / -1, `binaryVersion = "1.7.4"`)
+- `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift` (+233, 9 new tests)
+- `phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift` (+4 / -4, `"1.7.4"` assertions)
+
+## Your instructions (CODE lane, this file)
+
+You are the CODE lens. Focus exclusively on:
+- Correctness of the retry state machine (attempt counting, resume-data lifecycle, error propagation)
+- Loop invariants (does `attempt + 1 < maxAttempts` guard sleep correctly on the last iteration?)
+- Edge cases: `maxAttempts = 0` (does `max(1, ...)` prevent zero-attempt exit?); `maxAttempts = 1` (should skip sleep entirely — verify); simultaneous URLError with BOTH transient code AND missing resume-data
+- Thread safety: closures marked `@Sendable`, no shared mutable state? Actor usage in tests (`SleepCounter`)?
+- Task cancellation: does `Task.sleep` cooperate with `Task.cancel()`? Does cancellation during a retry loop bubble correctly?
+- Dead code / unused parameters
+- Test coverage completeness for the invariants named in the spec
+- Any place where Swift compiler warnings should exist but don't (Sendable, strict concurrency)
+
+Do NOT critique architectural placement or security surface — those go to sibling audit lanes.
+
+Return findings as a structured list. For each finding: **file:line, severity (CRITICAL/HIGH/MEDIUM/LOW), one-sentence summary, why it matters, minimal fix.** If a finding is speculative or "I'd write it slightly differently" style, mark it LOW.
+
+Bar for STOP: 0 CRITICAL, 0 HIGH, 0 MEDIUM in your final response. Iterate the actual codebase and re-audit only after fixes if invited. Absent an invitation, single pass.
+
+## Excerpted code under audit (both source + tests)
+
+### phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift (relevant excerpt around lines 1344-1470)
+
+```swift
+struct HuggingFaceSnapshotDownloader {
+    struct ModelInfo: Decodable {
+        var siblings: [Sibling]
+    }
+
+    struct Sibling: Decodable {
+        var rfilename: String
+    }
+
+    private static let guardedSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        return URLSession(configuration: config)
+    }()
+
+    struct DownloadRetryPolicy {
+        var maxAttempts: Int
+        var baseDelaySeconds: Double
+        var backoffMultiplier: Double
+        var sleep: @Sendable (UInt64) async throws -> Void
+
+        static let production = DownloadRetryPolicy(
+            maxAttempts: 3,
+            baseDelaySeconds: 5.0,
+            backoffMultiplier: 4.0,
+            sleep: { ns in try await Task.sleep(nanoseconds: ns) }
+        )
+    }
+
+    var fetch: (URLRequest) async throws -> (Data, URLResponse) = { request in
+        try await HuggingFaceSnapshotDownloader.guardedSession.data(for: request, delegate: HFRedirectGuard())
+    }
+    var download: (URLRequest) async throws -> (URL, URLResponse) = { request in
+        try await HuggingFaceSnapshotDownloader.downloadWithResume(
+            request: request,
+            policy: .production,
+            initialDownload: { req in
+                try await HuggingFaceSnapshotDownloader.guardedSession.download(
+                    for: req, delegate: HFAssetRedirectGuard()
+                )
+            },
+            resumeDownload: { data in
+                try await HuggingFaceSnapshotDownloader.guardedSession.download(
+                    resumeFrom: data, delegate: HFAssetRedirectGuard()
+                )
+            }
+        )
+    }
+
+    static func downloadWithResume(
+        request: URLRequest,
+        policy: DownloadRetryPolicy,
+        initialDownload: @Sendable (URLRequest) async throws -> (URL, URLResponse),
+        resumeDownload: @Sendable (Data) async throws -> (URL, URLResponse)
+    ) async throws -> (URL, URLResponse) {
+        var lastError: Error?
+        var resumeData: Data?
+        for attempt in 0..<max(1, policy.maxAttempts) {
+            do {
+                if let data = resumeData {
+                    return try await resumeDownload(data)
+                }
+                return try await initialDownload(request)
+            } catch let error as URLError where isTransientDownloadError(error) {
+                lastError = error
+                if let extracted = extractResumeData(from: error) {
+                    resumeData = extracted
+                }
+                if attempt + 1 < policy.maxAttempts {
+                    let delaySeconds = policy.baseDelaySeconds
+                        * pow(policy.backoffMultiplier, Double(attempt))
+                    let delayNanoseconds = UInt64(max(0, delaySeconds) * 1_000_000_000)
+                    try await policy.sleep(delayNanoseconds)
+                }
+            }
+        }
+        throw lastError ?? URLError(.unknown)
+    }
+
+    static func isTransientDownloadError(_ error: URLError) -> Bool {
+        switch error.code {
+        case .networkConnectionLost,
+             .timedOut,
+             .notConnectedToInternet,
+             .cannotConnectToHost,
+             .cannotFindHost,
+             .dnsLookupFailed,
+             .resourceUnavailable:
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func extractResumeData(from error: URLError) -> Data? {
+        error.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
+    }
+
+    func downloadSnapshot(modelID: String, revision: String, to snapshot: URL) async throws {
+        // ... unchanged in this PR; still wipes staging dir on error ...
+    }
+}
+```
+
+### phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift (new tests block, ~233 lines)
+
+See git diff — 9 tests + 2 helpers (`SleepCounter` actor and `makeDownloadRetryPolicyNoDelay`). Tests marked at the top of the block with `// MARK: - downloadWithResume`.

--- a/specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_SECURITY_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_SECURITY_PROMPT.md
@@ -1,0 +1,144 @@
+# AUDIT (SECURITY lane) — SPEC-023 HuggingFaceSnapshotDownloader retry-with-resume
+
+## Context
+
+macprovider-cli's SPEC-023 installer-integrated autotune-recommend downloads HuggingFace model shards during install. Every 2026-07-02 v1.7.3 install attempt failed at real-network `NSURLErrorDomain -1005 "The network connection was lost."` mid-transfer of a multi-GB `model-*-of-*.safetensors` shard. Root cause: no retry, no resume-data extraction from `URLSession.download(for:)`'s userInfo, whole-model staging directory wiped on any error.
+
+This PR (v1.7.4) adds `HuggingFaceSnapshotDownloader.downloadWithResume` that catches transient URLError codes, extracts `error.userInfo[NSURLSessionDownloadTaskResumeData]`, retries via `URLSession.download(resumeFrom:delegate:)`.
+
+## The change (security-facing summary)
+
+- Adds retry-with-resume behavior inside the existing `HuggingFaceSnapshotDownloader.guardedSession` (an `.ephemeral` URLSession)
+- Preserves the existing `HFAssetRedirectGuard` delegate on both initial AND resumed downloads
+- Does NOT change `addTokenHeader` (HF_TOKEN handling), the redirect-guard implementation, the artifact SHA256 verification post-download, or the caller (`downloadSnapshot`) semantics
+- Max 3 attempts, exponential backoff 5s → 20s → cap. Ceiling on total wall-clock ~25s of sleep across retries.
+- No new files opened, no new secrets read, no new network hosts contacted
+
+## Files changed (repo-relative)
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift` (+99 / -6)
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift` (+1 / -1)
+- `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift` (+233 unit tests)
+- `phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift` (+4 / -4)
+
+## Your instructions (SECURITY lane, this file)
+
+You are the SECURITY lens. Focus exclusively on:
+
+- **Auth token exposure through retry.** The initial request carries `HF_TOKEN` via `Authorization: Bearer ...` header if the env var is set (added at line 1424 of AutotuneRecommend.swift). Does the resume path preserve or re-expose that token? Does resume-data serialization include the header, and if so is that persisted in a place attacker-controllable?
+- **Redirect guard on resumed downloads.** The initial download uses `HFAssetRedirectGuard()` as the delegate. The resume path *also* uses `HFAssetRedirectGuard()`. Are both codepaths equally protected against redirect to malicious host? Is the resume data an opaque URLSession blob or does it contain a URL that could bypass the guard?
+- **Sig-verification / SHA post-download.** After download completes, is the artifact still SHA-256-checked against the signed catalog value? Nothing in this PR touches that check but confirm the retry doesn't skip it.
+- **Bypass of catalog-bound provenance.** SPEC-023 pins model_revision + model_sha256. If a resume completes a download from a partial that started from a different revision (e.g., HF changed the revision mid-attempt), does the post-download verification still catch it, or could a modified file get accepted?
+- **Info leak via error propagation.** URL and Authorization header can appear in error `userInfo`. If the retry logic surfaces error content anywhere (logs, error messages, telemetry), does it redact Authorization? Note existing error strings look opaque ("download failed <filename>") — verify no new leak surface.
+- **DoS / retry storm.** 3 attempts × 25s backoff ceiling. What if downloadSnapshot() has 4 siblings? Could this multiply into visible resource pressure? Reasonable ceiling?
+- **Race on shared state.** The class-level `guardedSession` is `.ephemeral`. Does retry-with-resume touch any URLSession-cached state (cookies, credentials cache) that could persist across attempts inappropriately? An ephemeral session shouldn't but confirm.
+- **Cancellation-vs-retry semantics.** User Ctrl-C during a retry sleep — does the loop honor cancellation (bubble URLError.cancelled) or does it swallow it and continue retrying?
+- **Test injection surface as attack surface.** The `downloadWithResume` static function takes `initialDownload` and `resumeDownload` as @Sendable closures. Production code passes closures that call the real URLSession. Test code passes closures that return synthetic data. If an attacker could somehow reach `downloadWithResume` with custom closures, would that be exploitable? (This is really a check that the entry point is private/internal-scoped correctly.)
+
+Do NOT critique code style, dead vars, or architectural placement — those go to sibling audit lanes.
+
+Return findings as a structured list. For each finding: **file:line, severity (CRITICAL/HIGH/MEDIUM/LOW), one-sentence summary, attack scenario or exposure vector, minimal fix.**
+
+Bar for STOP: 0 CRITICAL, 0 HIGH, 0 MEDIUM in your final response. Iterate the actual codebase and re-audit only after fixes if invited. Absent an invitation, single pass.
+
+## Excerpted code under audit
+
+### phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift (relevant excerpt)
+
+Full source at path above. Key context for security:
+
+```swift
+// Existing token handling — UNCHANGED in this PR:
+private func addTokenHeader(_ request: inout URLRequest) {
+    guard let token = ProcessInfo.processInfo.environment["HF_TOKEN"], !token.isEmpty else { return }
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+}
+
+// Existing redirect guard — UNCHANGED:
+final class HFAssetRedirectGuard: NSObject, URLSessionTaskDelegate {
+    // Rejects redirects to hosts not in the HF allowlist,
+    // strips Authorization header on cross-origin redirects
+    // (see phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift around line 1439)
+}
+
+// NEW in this PR:
+struct DownloadRetryPolicy {
+    var maxAttempts: Int
+    var baseDelaySeconds: Double
+    var backoffMultiplier: Double
+    var sleep: @Sendable (UInt64) async throws -> Void
+
+    static let production = DownloadRetryPolicy(
+        maxAttempts: 3,
+        baseDelaySeconds: 5.0,
+        backoffMultiplier: 4.0,
+        sleep: { ns in try await Task.sleep(nanoseconds: ns) }
+    )
+}
+
+var download: (URLRequest) async throws -> (URL, URLResponse) = { request in
+    try await HuggingFaceSnapshotDownloader.downloadWithResume(
+        request: request,
+        policy: .production,
+        initialDownload: { req in
+            try await HuggingFaceSnapshotDownloader.guardedSession.download(
+                for: req, delegate: HFAssetRedirectGuard()
+            )
+        },
+        resumeDownload: { data in
+            try await HuggingFaceSnapshotDownloader.guardedSession.download(
+                resumeFrom: data, delegate: HFAssetRedirectGuard()
+            )
+        }
+    )
+}
+
+static func downloadWithResume(
+    request: URLRequest,
+    policy: DownloadRetryPolicy,
+    initialDownload: @Sendable (URLRequest) async throws -> (URL, URLResponse),
+    resumeDownload: @Sendable (Data) async throws -> (URL, URLResponse)
+) async throws -> (URL, URLResponse) {
+    var lastError: Error?
+    var resumeData: Data?
+    for attempt in 0..<max(1, policy.maxAttempts) {
+        do {
+            if let data = resumeData {
+                return try await resumeDownload(data)
+            }
+            return try await initialDownload(request)
+        } catch let error as URLError where isTransientDownloadError(error) {
+            lastError = error
+            if let extracted = extractResumeData(from: error) {
+                resumeData = extracted
+            }
+            if attempt + 1 < policy.maxAttempts {
+                let delaySeconds = policy.baseDelaySeconds
+                    * pow(policy.backoffMultiplier, Double(attempt))
+                let delayNanoseconds = UInt64(max(0, delaySeconds) * 1_000_000_000)
+                try await policy.sleep(delayNanoseconds)
+            }
+        }
+    }
+    throw lastError ?? URLError(.unknown)
+}
+
+static func isTransientDownloadError(_ error: URLError) -> Bool {
+    switch error.code {
+    case .networkConnectionLost,
+         .timedOut,
+         .notConnectedToInternet,
+         .cannotConnectToHost,
+         .cannotFindHost,
+         .dnsLookupFailed,
+         .resourceUnavailable:
+        return true
+    default:
+        return false
+    }
+}
+
+static func extractResumeData(from error: URLError) -> Data? {
+    error.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
+}
+```


### PR DESCRIPTION
## Summary

Closes the **"SPEC-023 fresh install fails on transient HF CDN drop"** gap caught during 2026-07-02 v1.7.3 fresh-install QA on operator's M5. Every install attempt (2 in a row, different sessions) died at `install.sh:die 6` when a multi-GB safetensors shard hit `NSURLErrorDomain -1005 "The network connection was lost."` mid-transfer.

## Root cause chain (from source inspection)

At [`AutotuneRecommend.swift:1361-1394`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L1361-L1394):

1. The `download` closure called `URLSession.download(for:)` and did NOT catch the `URLError` to extract `NSURLSessionDownloadTaskResumeData` from `userInfo`.
2. On any error in the per-sibling for-loop, the entire staging directory (potentially 10+ GB of completed shards) got wiped by the outer catch block.
3. Zero retry logic: one drop = complete install failure.

## Verification B (empirical Swift script confirmed the plumbing works)

Ran `scratchpad/verify-resume.swift` on operator's M5 against real HF CDN:

- ✅ HF CDN returns `HTTP/2 206 Partial Content` with `Content-Range: bytes N-M/TOTAL` on Range requests (`Accept-Ranges: bytes` advertised)
- ✅ URLSession's resume-data blob (11-12 KB opaque bytes) correctly encodes byte offset
- ✅ `URLSession.download(resumeFrom:delegate:)` async API resumes from that offset, produces a byte-identical complete file (4,517,488,999 bytes == expected total)

Test used the exact shard type that failed operator's install: MLX-community 4-bit safetensors from `us.aws.cdn.hf.co`.

## The change

New static function `HuggingFaceSnapshotDownloader.downloadWithResume` that:
- Retries transient network errors (7 specific `URLError.Code` values)
- Extracts resume data from `error.userInfo[NSURLSessionDownloadTaskResumeData]`
- Calls `URLSession.download(resumeFrom:)` on next attempt
- Bubbles non-transient errors and non-URLError immediately

### Retry policy

`DownloadRetryPolicy` struct, injectable for tests:

| Field | Production value |
|---|---|
| `maxAttempts` | 3 |
| `baseDelaySeconds` | 5.0 |
| `backoffMultiplier` | 4.0 |
| `sleep` | `Task.sleep(nanoseconds:)` — participates in structured-concurrency cancellation |

Wall-clock added: 5s + 20s = **25s max** for a fully-failing 3-attempt sequence. Test-side `sleep` is a no-op actor that counts invocations.

### Transient error set

```swift
case .networkConnectionLost,     // -1005: the exact error we hit
     .timedOut,                   // -1001
     .notConnectedToInternet,     // -1009
     .cannotConnectToHost,        // -1004
     .cannotFindHost,             // -1003
     .dnsLookupFailed,            // -1006
     .resourceUnavailable:        // -1008
    return true
```

## What's preserved (unchanged)

- Existing test-injection surface (tests still override the whole `download` closure)
- `HFAssetRedirectGuard` delegate applied to both initial AND resumed downloads
- `HF_TOKEN` env-var handling
- Post-download SHA256 verification against signed catalog value
- All existing tests (41 → 50 total after adding 9)

## 3-lane codex audit — Round 1 convergence

Per `feedback-three-lane-codex-audits`: three independent codex invocations (code / security / architect). Per `feedback-audit-prompts-file-not-chat`: prompts committed to repo.

| Lane | CRITICAL | HIGH | MEDIUM | LOW | Verdict |
|---|:---:|:---:|:---:|:---:|---|
| CODE | 0 | 0 | 0 | 3 | ✅ PASS |
| SECURITY | 0 | 0 | 0 | 0 | ✅ PASS |
| ARCHITECT | 0 | 0 | 0 | 2 | ✅ PASS |

Per `feedback-stop-iterating-on-low-audits`: R1 CONVERGED at 0/0/0. **No R2 fixed-then-re-audit cycle** — LOWs shipped documented below.

Audit prompts at:
- [`specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_CODE_PROMPT.md`](specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_CODE_PROMPT.md)
- [`specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_SECURITY_PROMPT.md`](specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_SECURITY_PROMPT.md)
- [`specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_ARCHITECT_PROMPT.md`](specs/AUDIT_SPEC_023_HF_DOWNLOAD_RESUME_ARCHITECT_PROMPT.md)

### LOW findings shipped (documented deferrals)

**CODE-LOW-1** ([`AutotuneRecommend.swift:1429`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L1429)): `resumeData` persistence across sequential retries where a later transient failure carries no fresh resume data. Behavior is deliberate — reusing the last known resume state is safer than falling back to fresh, which would restart the download from byte 0.

**CODE-LOW-2** (`AutotuneRecommendTests.swift:627`): `testDownloadWithResumeExhaustsAttemptsThenThrowsLast` intentionally exercises only the initial-only failure sequence (no resume data captured); the `resumeDownload` failure branch is covered by other tests.

**CODE-LOW-3** (`AutotuneRecommendTests.swift:499`): boundary tests for `maxAttempts=0/1` and cancellation-during-sleep not in coverage. Guarded by `max(1, ...)` at line 1428 and Task.sleep cancellation semantics — correct by inspection.

**ARCH-LOW-1** ([`AutotuneRecommend.swift:1488`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L1488)): terminal failure after all retries exhausted still deletes previously-completed sibling files. Cross-invocation partial preservation requires a staging-contract redesign — deferred to a separate PR.

**ARCH-LOW-2** ([`AutotuneRecommend.swift:1432`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L1432)): retries are silent (no stderr log). UX enhancement deferred to a separate PR to keep this scoped to correctness.

## No behavior change for happy-path installs

Users whose HF downloads complete on the first attempt see zero difference. Only users hitting a transient `-1005 / -1001 / -1009 / -1004 / -1006 / -1008` during a multi-GB shard transfer benefit from the retry. This is the exact failure mode operator's M5 hit twice on 2026-07-02.

## Test plan

- [x] `swift build --product macprovider-cli` clean at v1.7.4
- [x] `swift test --filter AutotuneRecommendTests`: **50/50 pass** (41 pre-existing + 9 new)
- [x] Full `swift test` suite green
- [x] 3-lane codex audit R1 CONVERGED at 0/0/0 across CODE/SECURITY/ARCHITECT
- [x] Verification B empirically confirmed URLSession.download(resumeFrom:) + HF CDN 206 Partial Content flow
- [ ] Post-merge: `gh workflow run release.yml -f version=v1.7.4`
- [ ] Post-release: `curl get.streamvc.live/install.sh | bash` on M5 survives HF transient drops during multi-GB shard downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
