### PR TITLE
fix(spec-023): Stage1 probe idle timeout 64s -> 300s + persist infeasible-reason diagnostics + bump v1.7.5

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -727,14 +727,20 @@ struct AutotuneCommand: AsyncParsableCommand {
             availabilityHoursPerDay: 24,
             donorMode: donorMode
         )
-        request.benchmarks = try await AutotuneRecommendationBenchmarker().benchmarks(
+        let outcomes = try await AutotuneRecommendationBenchmarker().benchmarks(
             request: request,
             targetContext: Self.spec023RecommendationProbeContext,
             gateTTFTMS: gateTTFTMS,
             replicates: stage1Replicates,
             port: port
         )
-        let result = AutotuneRecommendEngine().recommend(request)
+        request.benchmarks = outcomes.benchmarks
+        for modelKey in outcomes.diagnostics.keys.sorted() {
+            let reason = outcomes.diagnostics[modelKey]!
+            FileHandle.standardError.write(Data("[warn] spec-023 probe: \(modelKey): \(reason)\n".utf8))
+        }
+        var result = AutotuneRecommendEngine().recommend(request)
+        result.probeDiagnostics = outcomes.diagnostics
         try RecommendationStateStore.write(result)
         let paidSelected = result.recommendedModel.flatMap { recommendedModel in
             result.selectedCandidate.flatMap { $0.model == recommendedModel ? $0 : nil }

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -833,6 +833,12 @@ struct AutotuneRecommendResult: Equatable {
     var assumedUtilization: Double
     var availabilityHoursPerDay: Int
     var electricityUSDPerKWH: Double?
+    /// modelKey -> reason string for each candidate that did not produce a
+    /// feasible probe. Populated by AutotuneRecommendationBenchmarker and
+    /// attached by the CLI caller after engine.recommend() returns. Persisted
+    /// into last-recommendation.json so post-hoc diagnosis explains WHY
+    /// benchmark_id is null / no eligible paid model was found.
+    var probeDiagnostics: [String: String] = [:]
 }
 
 struct AutotuneRecommendEngine {
@@ -1082,8 +1088,11 @@ extension AutotuneRecommendResult {
     }
 
     func storedStateJSON() -> String {
-        """
-        {"generated_at":\(ISO8601DateFormatter.autotuneInternet.string(from: generatedAt).jsonEscaped),"rate_card_version":\(rateCardVersion.jsonEscaped),"demand_rank_version":\(demandRankVersion.jsonEscaped),"candidate_catalog_version":\(candidateCatalogVersion.jsonEscaped),"candidate_catalog_sha256":\(candidateCatalogSHA256.jsonEscaped),"benchmark_id":\(benchmarkID?.jsonEscaped ?? "null"),"benchmark_generated_at":\(benchmarkGeneratedAt.map { ISO8601DateFormatter.autotuneInternet.string(from: $0).jsonEscaped } ?? "null"),"binary_version":\(hardware.binaryVersion.jsonEscaped),"hardware_identity_hash":\(hardware.hardwareIdentityHash.jsonEscaped),"recommended_model":\(recommendedModel?.jsonEscaped ?? "null")}
+        let diagnosticsJSON = probeDiagnostics.keys.sorted().map { key in
+            "\(key.jsonEscaped):\(probeDiagnostics[key]!.jsonEscaped)"
+        }.joined(separator: ",")
+        return """
+        {"generated_at":\(ISO8601DateFormatter.autotuneInternet.string(from: generatedAt).jsonEscaped),"rate_card_version":\(rateCardVersion.jsonEscaped),"demand_rank_version":\(demandRankVersion.jsonEscaped),"candidate_catalog_version":\(candidateCatalogVersion.jsonEscaped),"candidate_catalog_sha256":\(candidateCatalogSHA256.jsonEscaped),"benchmark_id":\(benchmarkID?.jsonEscaped ?? "null"),"benchmark_generated_at":\(benchmarkGeneratedAt.map { ISO8601DateFormatter.autotuneInternet.string(from: $0).jsonEscaped } ?? "null"),"binary_version":\(hardware.binaryVersion.jsonEscaped),"hardware_identity_hash":\(hardware.hardwareIdentityHash.jsonEscaped),"recommended_model":\(recommendedModel?.jsonEscaped ?? "null"),"probe_diagnostics":{\(diagnosticsJSON)}}
         """
     }
 
@@ -1135,6 +1144,7 @@ struct LastRecommendationState: Decodable, Equatable {
     var binaryVersion: String
     var hardwareIdentityHash: String
     var recommendedModel: String?
+    var probeDiagnostics: [String: String]
 
     enum CodingKeys: String, CodingKey {
         case generatedAt = "generated_at"
@@ -1147,6 +1157,7 @@ struct LastRecommendationState: Decodable, Equatable {
         case binaryVersion = "binary_version"
         case hardwareIdentityHash = "hardware_identity_hash"
         case recommendedModel = "recommended_model"
+        case probeDiagnostics = "probe_diagnostics"
     }
 
     init(
@@ -1159,7 +1170,8 @@ struct LastRecommendationState: Decodable, Equatable {
         benchmarkGeneratedAt: Date?,
         binaryVersion: String,
         hardwareIdentityHash: String,
-        recommendedModel: String?
+        recommendedModel: String?,
+        probeDiagnostics: [String: String] = [:]
     ) {
         self.generatedAt = generatedAt
         self.rateCardVersion = rateCardVersion
@@ -1171,6 +1183,7 @@ struct LastRecommendationState: Decodable, Equatable {
         self.binaryVersion = binaryVersion
         self.hardwareIdentityHash = hardwareIdentityHash
         self.recommendedModel = recommendedModel
+        self.probeDiagnostics = probeDiagnostics
     }
 
     init(from decoder: Decoder) throws {
@@ -1190,6 +1203,7 @@ struct LastRecommendationState: Decodable, Equatable {
         binaryVersion = try c.decode(String.self, forKey: .binaryVersion)
         hardwareIdentityHash = try c.decode(String.self, forKey: .hardwareIdentityHash)
         recommendedModel = try c.decodeIfPresent(String.self, forKey: .recommendedModel)
+        probeDiagnostics = try c.decodeIfPresent([String: String].self, forKey: .probeDiagnostics) ?? [:]
     }
 }
 
@@ -1627,6 +1641,23 @@ struct CachedModelArtifactResolver {
     }
 }
 
+/// Outcome of running Stage 1 probes across every eligible candidate row.
+///
+/// `benchmarks` contains only feasible probes (rows admitted into eligibility);
+/// `diagnostics` contains a modelKey -> reason string for every candidate that
+/// returned .infeasible OR was skipped by runtime-status/RAM/tier gates. This is
+/// what the SPEC-023 caller emits to stderr + persists into
+/// last-recommendation.json so the user can see WHY no eligible paid model was
+/// found. Prior to v1.7.5 the .infeasible(reason:nErr:) string was silently
+/// dropped, leaving users with `benchmark_id: null` and no root-cause path.
+struct BenchmarkOutcomes: Equatable {
+    var benchmarks: [String: CandidateBenchmark]
+    /// Ordered modelKey -> single-line diagnostic reason. Deterministic key
+    /// ordering (see `benchmarks(request:...)` iteration) so persisted JSON is
+    /// byte-stable across runs with identical inputs.
+    var diagnostics: [String: String]
+}
+
 struct AutotuneRecommendationBenchmarker {
     var artifactResolver: CachedModelArtifactResolver = CachedModelArtifactResolver()
     var runnerFactory: () throws -> CandidateProviderRunner = { try CandidateProviderRunner() }
@@ -1640,14 +1671,23 @@ struct AutotuneRecommendationBenchmarker {
         gateTTFTMS: Int,
         replicates: Int,
         port: Int
-    ) async throws -> [String: CandidateBenchmark] {
+    ) async throws -> BenchmarkOutcomes {
         var results: [String: CandidateBenchmark] = [:]
+        var diagnostics: [String: String] = [:]
         for modelKey in request.candidateCatalog.rows.keys.sorted() {
-            guard let row = request.candidateCatalog.rows[modelKey],
-                  row.runtimeStatus != "blocked",
-                  row.minRAMGB <= request.hardware.memoryGB - AutotuneRecommendEngine.safetyMarginGB,
-                  request.hardware.bandwidthTier.satisfies(minimum: row.minBandwidthTier)
-            else {
+            guard let row = request.candidateCatalog.rows[modelKey] else {
+                continue
+            }
+            if row.runtimeStatus == "blocked" {
+                diagnostics[modelKey] = "catalog row blocked by upstream"
+                continue
+            }
+            if row.minRAMGB > request.hardware.memoryGB - AutotuneRecommendEngine.safetyMarginGB {
+                diagnostics[modelKey] = "min_ram \(row.minRAMGB)GB exceeds \(request.hardware.memoryGB)GB - \(AutotuneRecommendEngine.safetyMarginGB)GB safety margin"
+                continue
+            }
+            if !request.hardware.bandwidthTier.satisfies(minimum: row.minBandwidthTier) {
+                diagnostics[modelKey] = "bandwidth tier \(request.hardware.bandwidthTier.rawValue) below minimum \(row.minBandwidthTier.rawValue)"
                 continue
             }
             do {
@@ -1664,7 +1704,8 @@ struct AutotuneRecommendationBenchmarker {
                 )
                 let after = safetySampler.sample()
                 let safety = ProbeSafetyAssessment.assess(before: before, after: after)
-                if case .feasible(let medianTPS, let p95TTFTMS) = probe {
+                switch probe {
+                case .feasible(let medianTPS, let p95TTFTMS):
                     let generatedAt = clock()
                     results[modelKey] = CandidateBenchmark(
                         modelKey: modelKey,
@@ -1681,12 +1722,20 @@ struct AutotuneRecommendationBenchmarker {
                         modelID: row.modelID,
                         hardwareIdentityHash: request.hardware.hardwareIdentityHash
                     )
+                    if safety.swapDetected || safety.thermalThrottleDetected {
+                        var flags: [String] = []
+                        if safety.swapDetected { flags.append("swap detected") }
+                        if safety.thermalThrottleDetected { flags.append("thermal throttle detected") }
+                        diagnostics[modelKey] = "feasible but " + flags.joined(separator: ", ")
+                    }
+                case .infeasible(let reason, let nErr):
+                    diagnostics[modelKey] = "\(reason) (n_err=\(nErr))"
                 }
             } catch {
                 throw error
             }
         }
-        return results
+        return BenchmarkOutcomes(benchmarks: results, diagnostics: diagnostics)
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.7.4"
+    static let binaryVersion = "1.7.5"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift
+++ b/phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift
@@ -378,22 +378,32 @@ private extension Stage1ProbeResult {
 
 struct Stage1Prober: Stage1Probing {
     static let maxTokens = 64
+    /// URL request idle-timeout (URLSession semantics: max seconds without any
+    /// bytes arriving from the server). Must cover prefill TTFT for the largest
+    /// supported candidate on the weakest supported hardware (30B MoE on M-Base
+    /// prefilling a ~3200-token probe can take 60-180s before first byte).
+    /// A value below 200s produced silent .infeasible timeouts on M-Base;
+    /// keeping headroom above measured maxima. See SPEC-023 v1.7.5.
+    static let defaultProbeIdleTimeoutSec: TimeInterval = 300
     private static let stopTokens = ["<|im_end|>", "<|endoftext|>", "<|eot_id|>"]
 
     private let session: URLSession
     private let readyTimeoutSec: TimeInterval
     private let stopGraceSeconds: Double
+    private let probeIdleTimeoutSec: TimeInterval
     private let clock: () -> Date
 
     init(
         session: URLSession = .shared,
         readyTimeoutSec: TimeInterval = 120,
         stopGraceSeconds: Double = 10,
+        probeIdleTimeoutSec: TimeInterval = Stage1Prober.defaultProbeIdleTimeoutSec,
         clock: @escaping () -> Date = Date.init
     ) {
         self.session = session
         self.readyTimeoutSec = readyTimeoutSec
         self.stopGraceSeconds = stopGraceSeconds
+        self.probeIdleTimeoutSec = max(1, probeIdleTimeoutSec)
         self.clock = clock
     }
 
@@ -519,7 +529,7 @@ struct Stage1Prober: Stage1Probing {
     private func probeOnce(model: String, port: Int, targetContext: Int) async throws -> SingleProbeResult {
         var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!)
         request.httpMethod = "POST"
-        request.timeoutInterval = max(1, TimeInterval(Stage1Prober.maxTokens))
+        request.timeoutInterval = probeIdleTimeoutSec
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: [
             "model": model,

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -941,7 +941,7 @@ final class AutotuneRecommendTests: XCTestCase {
             safetySampler: StaticProbeSafetySampler()
         )
 
-        let benchmarks = try await benchmarker.benchmarks(
+        let outcomes = try await benchmarker.benchmarks(
             request: request,
             targetContext: 4_000,
             gateTTFTMS: 3_000,
@@ -949,7 +949,7 @@ final class AutotuneRecommendTests: XCTestCase {
             port: 18080
         )
 
-        XCTAssertNotNil(benchmarks[modelKey])
+        XCTAssertNotNil(outcomes.benchmarks[modelKey])
         XCTAssertEqual(prober.probedModels, [snapshot.path])
     }
 
@@ -1096,6 +1096,157 @@ final class AutotuneRecommendTests: XCTestCase {
 
         XCTAssertNil(staleSince)
         XCTAssertEqual(staleWithDifferentProvider, Optional(Self.date("2026-07-02T00:00:00Z")))
+    }
+
+    // MARK: - Stage1 probe timeout + BenchmarkOutcomes diagnostics (v1.7.5)
+
+    func testStage1ProberDefaultIdleTimeoutIsSafeForLargePrefill() {
+        // Regression guard: v1.7.4 shipped with `TimeInterval(maxTokens)` = 64s,
+        // which idle-timed-out on M-Base 30B-MoE + 3200-token probes before the
+        // first byte arrived. Any value < 200s would re-introduce that bug.
+        XCTAssertGreaterThanOrEqual(Stage1Prober.defaultProbeIdleTimeoutSec, 200)
+    }
+
+    func testStage1ProberClampsSubSecondTimeoutToOne() {
+        // The `max(1, ...)` clamp guards the URLRequest contract (timeoutInterval
+        // must be > 0). Cover the boundary explicitly.
+        let clamped = Stage1Prober(probeIdleTimeoutSec: 0)
+        // Cannot inspect private storage; instead assert Mirror shows the clamp.
+        let mirror = Mirror(reflecting: clamped)
+        let stored = mirror.children.first(where: { $0.label == "probeIdleTimeoutSec" })?.value as? TimeInterval
+        XCTAssertEqual(stored, 1)
+    }
+
+    func testBenchmarksReturnsInfeasibleDiagnostics() async throws {
+        let modelKey = "qwen3-32b"
+        var request = try makeRequest(modelKey: modelKey)
+        request.hardware.bandwidthTier = .a
+        let row = try XCTUnwrap(request.candidateCatalog.rows[modelKey])
+        let revision = try XCTUnwrap(row.modelRevision)
+        let hub = try tempDir()
+        let resolver = CachedModelArtifactResolver(hubRoot: hub)
+        let snapshot = resolver.snapshotURL(modelID: row.modelID, revision: revision)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
+        request.candidateCatalog.rows[modelKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        request.benchmarks = [:]
+        let prober = RecordingStage1Prober(results: [
+            snapshot.path: .infeasible(reason: "probe request failed: The request timed out.", nErr: 3),
+        ])
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: resolver,
+            runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
+            prober: prober,
+            safetySampler: StaticProbeSafetySampler()
+        )
+
+        let outcomes = try await benchmarker.benchmarks(
+            request: request,
+            targetContext: 4_000,
+            gateTTFTMS: 3_000,
+            replicates: 3,
+            port: 18080
+        )
+
+        XCTAssertNil(outcomes.benchmarks[modelKey])
+        XCTAssertEqual(
+            outcomes.diagnostics[modelKey],
+            "probe request failed: The request timed out. (n_err=3)"
+        )
+    }
+
+    func testBenchmarksDiagnosesRowsSkippedByRAMGate() async throws {
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        var request = try makeRequest(modelKey: modelKey)
+        request.hardware.memoryGB = 8   // < row.minRAMGB + safetyMarginGB
+        request.benchmarks = [:]
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: CachedModelArtifactResolver(hubRoot: try tempDir()),
+            runnerFactory: { throw AutotuneRecommendError.invalidStaticJSON("must not spawn runner for skipped row") },
+            prober: RecordingStage1Prober(results: [:]),
+            safetySampler: StaticProbeSafetySampler()
+        )
+
+        let outcomes = try await benchmarker.benchmarks(
+            request: request,
+            targetContext: 4_000,
+            gateTTFTMS: 3_000,
+            replicates: 1,
+            port: 18080
+        )
+
+        XCTAssertNil(outcomes.benchmarks[modelKey])
+        let diagnostic = try XCTUnwrap(outcomes.diagnostics[modelKey])
+        XCTAssertTrue(diagnostic.contains("min_ram"))
+        XCTAssertTrue(diagnostic.contains("safety margin"))
+    }
+
+    func testBenchmarksDiagnosesRowsSkippedByBandwidthGate() async throws {
+        let modelKey = "qwen3-32b"
+        var request = try makeRequest(modelKey: modelKey)
+        request.hardware.bandwidthTier = .c  // qwen3-32b needs >= B
+        request.benchmarks = [:]
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: CachedModelArtifactResolver(hubRoot: try tempDir()),
+            runnerFactory: { throw AutotuneRecommendError.invalidStaticJSON("must not spawn runner") },
+            prober: RecordingStage1Prober(results: [:]),
+            safetySampler: StaticProbeSafetySampler()
+        )
+
+        let outcomes = try await benchmarker.benchmarks(
+            request: request,
+            targetContext: 4_000,
+            gateTTFTMS: 3_000,
+            replicates: 1,
+            port: 18080
+        )
+
+        XCTAssertNil(outcomes.benchmarks[modelKey])
+        let diagnostic = try XCTUnwrap(outcomes.diagnostics[modelKey])
+        XCTAssertTrue(diagnostic.contains("bandwidth tier"))
+        XCTAssertTrue(diagnostic.contains("below minimum"))
+    }
+
+    func testStoredStateJSONIncludesProbeDiagnostics() throws {
+        var result = AutotuneRecommendEngine().recommend(try makeRequest())
+        result.probeDiagnostics = [
+            "qwen3-32b": "bandwidth tier C below minimum B",
+            "gpt-oss-20b": "probe request failed: The request timed out. (n_err=1)",
+        ]
+        let stored = result.storedStateJSON()
+        XCTAssertTrue(stored.contains(#""probe_diagnostics":{"#))
+        XCTAssertTrue(stored.contains(#""gpt-oss-20b":"probe request failed: The request timed out. (n_err=1)""#))
+        XCTAssertTrue(stored.contains(#""qwen3-32b":"bandwidth tier C below minimum B""#))
+        // Deterministic ordering: keys sorted lexicographically.
+        let gptIdx = try XCTUnwrap(stored.range(of: #""gpt-oss-20b""#))
+        let qwenIdx = try XCTUnwrap(stored.range(of: #""qwen3-32b""#))
+        XCTAssertLessThan(gptIdx.lowerBound, qwenIdx.lowerBound)
+    }
+
+    func testStoredStateJSONEmitsEmptyDiagnosticsObjectWhenNone() throws {
+        let result = AutotuneRecommendEngine().recommend(try makeRequest())
+        // Default probeDiagnostics is [:] — JSON must still be valid.
+        let stored = result.storedStateJSON()
+        XCTAssertTrue(stored.contains(#""probe_diagnostics":{}"#))
+        let data = try XCTUnwrap(stored.data(using: .utf8))
+        _ = try JSONSerialization.jsonObject(with: data)  // round-trip parse must not throw
+    }
+
+    func testLastRecommendationStateDecodesProbeDiagnostics() throws {
+        let json = """
+        {"generated_at":"2026-07-02T18:00:00Z","rate_card_version":"v1","demand_rank_version":"v1","candidate_catalog_version":"v1","candidate_catalog_sha256":"abc","benchmark_id":null,"benchmark_generated_at":null,"binary_version":"1.7.5","hardware_identity_hash":"hw","recommended_model":null,"probe_diagnostics":{"qwen3-32b":"tier below minimum"}}
+        """
+        let decoded = try JSONDecoder().decode(LastRecommendationState.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.probeDiagnostics, ["qwen3-32b": "tier below minimum"])
+    }
+
+    func testLastRecommendationStateDecodesOldJSONWithoutProbeDiagnostics() throws {
+        // Backwards-compat: pre-v1.7.5 last-recommendation.json files must still decode.
+        let json = """
+        {"generated_at":"2026-07-02T18:00:00Z","rate_card_version":"v1","demand_rank_version":"v1","candidate_catalog_version":"v1","candidate_catalog_sha256":"abc","benchmark_id":null,"benchmark_generated_at":null,"binary_version":"1.7.4","hardware_identity_hash":"hw","recommended_model":null}
+        """
+        let decoded = try JSONDecoder().decode(LastRecommendationState.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.probeDiagnostics, [String: String]())
     }
 
     private func makeRequest(modelKey: String = "qwen3-coder-30b-a3b-instruct") throws -> AutotuneRecommendRequest {

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1481,10 +1481,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.4")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.4")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.7.4")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.7.4")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.5")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.5")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.7.5")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.7.5")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/specs/AUDIT_SPEC_023_PROBE_TIMEOUT_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_PROBE_TIMEOUT_ARCHITECT_PROMPT.md
@@ -1,0 +1,148 @@
+---
+role: architect-audit
+version: 1.0
+date: 2026-07-02
+target_pr: v1.7.5 Stage1 probe timeout + infeasible-reason persistence
+lens: ARCHITECTURE — layering, contracts, evolution, blast radius
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# ARCHITECT audit — SPEC-023 v1.7.5 probe timeout + diagnostics
+
+You are an architecture-review specialist. Independently audit this
+change through a **structural / evolution** lens — layer contracts,
+persistence-schema stability, protocol / SPEC alignment, coupling to
+external systems, and blast radius of future changes. Report only
+findings that block correctness or produce measurable long-term cost.
+
+## Context
+
+macprovider-cli v1.7.5 fixes a v1.7.4 install regression:
+- Fix A: `Stage1Prober` probe URLRequest was using a 64s idle timeout
+  (`TimeInterval(maxTokens)`), which under-provisioned prefill on
+  M-Base + 30B MoE. Now 300s default via constructor parameter.
+- Fix B: `.infeasible(reason:)` and pre-probe gate rejections now
+  surface to stderr and persist into `last-recommendation.json`
+  as a new `probe_diagnostics` map.
+
+`AutotuneRecommendationBenchmarker.benchmarks()` return type changed
+from `[String: CandidateBenchmark]` to `BenchmarkOutcomes` struct with
+`benchmarks` + `diagnostics` fields.
+
+`AutotuneRecommendResult` gained `probeDiagnostics: [String: String]`
+(defaulted `[:]` for source compat). `LastRecommendationState` gained
+the same field and `decodeIfPresent(...) ?? [:]` for wire compat.
+
+Binary version: 1.7.4 → 1.7.5.
+
+## What to audit
+
+### 1. `BenchmarkOutcomes` type shape
+
+The new struct wraps benchmarks + diagnostics. Is this the right
+representation?
+- Should it also carry per-model gate metadata (RAM headroom, tier
+  match) alongside diagnostics? Or is the current lean shape correct?
+- Any concern that adding fields later will break Equatable / test
+  fixtures?
+
+### 2. `probeDiagnostics` map schema stability
+
+Wire schema is `Map<String, String>` where the string value is
+free-form. Consider:
+- Is a flat map the right shape for future evolution? What if we later
+  want to record per-model TTFT-observed / TPS-observed even when
+  infeasible?
+- Should the value be a struct `{reason, nErr}` instead of pre-joined
+  `"reason (n_err=N)"`? Consumers may want to parse `nErr` separately.
+- Does the JSON schema-version bump warrant a discriminator field
+  (`schema_version` — but `last-recommendation.json` doesn't currently
+  carry one)?
+
+### 3. `last-recommendation.json` schema evolution
+
+Persistence file was previously implicit-schema. Adding
+`probe_diagnostics` maintains backward-compat via `decodeIfPresent`.
+- Do downstream consumers exist that parse this file and would ignore
+  unknown fields correctly? Check coordinator, portal, any dashboard.
+- Should the file have a `schema_version` field so future changes are
+  safer? Not necessarily this PR's job, but worth calling out.
+
+### 4. Probe timeout as a contract
+
+Extracting timeout from a hard-coded constant to an init parameter
+opens configuration surface. Consider:
+- Should this be surfaced as a CLI flag on `autotune --recommend` for
+  operators on unusually slow hardware? Or is 300s always sufficient?
+- Does the value belong on `Stage1Prober` or on the rate-card / catalog
+  (per-model expected TTFT)?
+- Where should the SPEC-023 v0.3 document be updated to record this
+  contract? (specs/ — check.)
+
+### 5. Stderr-warn coupling to caller
+
+`AutotuneCommand.runAutotuneRecommend` iterates `outcomes.diagnostics`
+and writes stderr. `benchmarks()` no longer emits directly. This is
+correct separation (benchmarker is pure), but:
+- Is there any risk that other callers of `benchmarks()` (existing or
+  future) will skip the stderr emission and users won't see the
+  warning?
+- Should the emission be inside `benchmarks()` or a helper on
+  `BenchmarkOutcomes`?
+
+### 6. `.blocked` runtime-status treated as diagnostic-worthy
+
+Prior code silently skipped `row.runtimeStatus == "blocked"`. New code
+writes `"catalog row blocked by upstream"`. Is that the right message?
+Should it distinguish "coordinator explicitly blocked" from "row
+missing from catalog"?
+
+### 7. Blast radius on Equatable / tests
+
+`AutotuneRecommendResult` gained a mutable field. All existing
+`Equatable` conformance-based tests still pass. Confirm no fixture is
+frozen against the old shape and would produce misleading test
+success/failure.
+
+### 8. SPEC document alignment
+
+SPEC-023 v0.3 documents Stage 1 probing. Should this PR also update
+that SPEC to record:
+- The 300s probe idle timeout as a normative contract
+- The `probe_diagnostics` field as a normative output of the
+  autotune-recommend flow
+- Or is this deferred to a follow-up SPEC-023 v0.4?
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift`
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+  (esp. `BenchmarkOutcomes`, `AutotuneRecommendResult`,
+  `LastRecommendationState`, `storedStateJSON`)
+- `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift`
+- `specs/SPEC-023-*.md` (any latest v0.x)
+- `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift`
+
+## Reply format
+
+```
+## ARCHITECT audit — v1.7.5
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```
+
+Findings must cite the specific file:line and describe the concrete
+future scenario that would surface the issue. Speculative
+"consider also X" without a concrete break-scenario ⇒ INFO or drop.

--- a/specs/AUDIT_SPEC_023_PROBE_TIMEOUT_CODE_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_PROBE_TIMEOUT_CODE_PROMPT.md
@@ -1,0 +1,143 @@
+---
+role: code-audit
+version: 1.0
+date: 2026-07-02
+target_pr: v1.7.5 Stage1 probe timeout + infeasible-reason persistence
+lens: CODE — correctness, edge cases, coding-error patterns
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# CODE audit — SPEC-023 v1.7.5 probe timeout + diagnostics
+
+You are a code-review specialist. Independently audit this change for
+**correctness bugs and coding errors**. Do not defer to earlier reviewer
+opinions. Report findings as CRITICAL / HIGH / MEDIUM / LOW / INFO with
+concrete file:line references and a defect-scenario sketch.
+
+## Context
+
+macprovider-cli v1.7.4 shipped SPEC-023 autotune-recommend, but the M5
+32GB Tier C operator install kept returning "donor mode only" after
+model downloads completed. Root cause: `Stage1Iterator.swift:522` set
+`URLRequest.timeoutInterval = max(1, TimeInterval(Stage1Prober.maxTokens))`
+= 64 seconds. `URLRequest.timeoutInterval` is an **idle timeout** — max
+seconds without any bytes arriving from the server. For an MLX 30B MoE
+prefilling a ~3200-token probe on M-Base hardware, TTFT can exceed 64s
+before the first byte, so the probe URLSession threw `.timedOut` before
+any measurement was possible. Every candidate returned
+`.infeasible(reason:nErr:)`. Worse, the `.infeasible(reason:)` string
+was silently discarded — the persisted `last-recommendation.json` had
+`benchmark_id: null` with no clue why.
+
+## The change under review (Fix A + Fix B)
+
+### Fix A — Realistic probe idle timeout
+- `Stage1Prober` now takes an optional `probeIdleTimeoutSec: TimeInterval`
+  init parameter, defaulting to `defaultProbeIdleTimeoutSec = 300`
+  seconds (5 minutes).
+- Value is clamped to `max(1, probeIdleTimeoutSec)` on stored assignment.
+- `probeOnce` now uses `request.timeoutInterval = probeIdleTimeoutSec`
+  instead of the buggy `TimeInterval(maxTokens)` expression.
+- File: `phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift`
+
+### Fix B — Persist `.infeasible` reasons + emit stderr warn lines
+- `AutotuneRecommendationBenchmarker.benchmarks(...)` return type
+  changed from `[String: CandidateBenchmark]` to a new
+  `BenchmarkOutcomes` struct carrying both `benchmarks` and a
+  `diagnostics: [String: String]` map.
+- `.infeasible(reason:nErr:)` results now write
+  `"\(reason) (n_err=\(nErr))"` into `diagnostics[modelKey]`.
+- Rows skipped by pre-probe RAM/tier/runtime-status gates ALSO write a
+  specific reason string. Prior code used `guard ... else { continue }`
+  and dropped the reason.
+- `AutotuneRecommendResult` gained a `probeDiagnostics: [String: String]`
+  field (defaulted `[:]` for source compat).
+- `storedStateJSON()` emits `"probe_diagnostics":{...}` with keys sorted
+  lexicographically for deterministic output.
+- `LastRecommendationState` decodes `probe_diagnostics` via
+  `decodeIfPresent(...) ?? [:]` so pre-v1.7.5 files still parse.
+- `AutotuneCommand.runAutotuneRecommend` now writes each diagnostic to
+  stderr as `[warn] spec-023 probe: <modelKey>: <reason>` before
+  invoking `engine.recommend()`, and attaches `outcomes.diagnostics` to
+  the result post-hoc.
+- Files:
+  - `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+  - `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift`
+
+### Version bump
+- `CoordinatorClient.binaryVersion`: `1.7.4` → `1.7.5`.
+
+## Tests added
+- `testStage1ProberDefaultIdleTimeoutIsSafeForLargePrefill`
+- `testStage1ProberClampsSubSecondTimeoutToOne`
+- `testBenchmarksReturnsInfeasibleDiagnostics`
+- `testBenchmarksDiagnosesRowsSkippedByRAMGate`
+- `testBenchmarksDiagnosesRowsSkippedByBandwidthGate`
+- `testStoredStateJSONIncludesProbeDiagnostics`
+- `testStoredStateJSONEmitsEmptyDiagnosticsObjectWhenNone`
+- `testLastRecommendationStateDecodesProbeDiagnostics`
+- `testLastRecommendationStateDecodesOldJSONWithoutProbeDiagnostics`
+- Result: `swift test` 781/781 pass (was 772 in v1.7.4).
+
+## What to audit
+
+Correctness bugs and coding errors. Non-exhaustive checklist:
+
+1. **Timeout value chosen (300s)** — does it correctly represent an
+   idle timeout in URLSession semantics? Any hardware/model combination
+   where 300s is still insufficient? Any concern that it masks
+   legitimately-broken servers (a server that hangs forever)?
+2. **Clamp `max(1, probeIdleTimeoutSec)`** — is this the right lower
+   bound? Any way a caller can bypass the clamp?
+3. **`BenchmarkOutcomes` return-type change** — could any caller silently
+   miss the diagnostics? Are all existing call sites updated?
+4. **Diagnostic key coverage** — does every code path that skips a
+   candidate write a diagnostic entry, or are there silent-drop paths?
+5. **Ordering / determinism** — `storedStateJSON()` sorts by key; is
+   that consistent with how `probeDiagnostics` is populated?
+6. **JSON emission safety** — is `jsonEscaped` on both keys and values?
+   Are quotes/backslashes/newlines in reason strings handled?
+7. **Backwards compatibility** — old `last-recommendation.json` files
+   without `probe_diagnostics`. Test covers happy path; are there weird
+   partial files that break?
+8. **stderr write blocking** — `FileHandle.standardError.write(...)`
+   can block on a full pipe. Is this concerning inside `benchmarks()`
+   caller or okay?
+9. **Concurrency / actor isolation** — `AutotuneRecommendationBenchmarker`
+   is a struct-with-vars. Any data-race concerns introduced by the
+   change to `BenchmarkOutcomes`?
+10. **`probeDiagnostics` on `AutotuneRecommendResult`** — is it always
+    populated where it should be, or does any code path emit a result
+    without diagnostics that a user would benefit from?
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift`
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+- `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift`
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+- `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift`
+
+## Reply format
+
+```
+## CODE audit — v1.7.5
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```
+
+Findings that do NOT reproduce as concrete bugs on the current diff
+must be omitted or downgraded to INFO. No speculative "consider
+adding X" nits at HIGH+ unless there's a real defect scenario.

--- a/specs/AUDIT_SPEC_023_PROBE_TIMEOUT_SECURITY_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_PROBE_TIMEOUT_SECURITY_PROMPT.md
@@ -1,0 +1,130 @@
+---
+role: security-audit
+version: 1.0
+date: 2026-07-02
+target_pr: v1.7.5 Stage1 probe timeout + infeasible-reason persistence
+lens: SECURITY — trust boundaries, data leakage, tampering, DoS
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# SECURITY audit — SPEC-023 v1.7.5 probe timeout + diagnostics
+
+You are a security-review specialist. Independently audit this change
+for **security-relevant defects**: trust-boundary crossings, data
+leakage, tampering opportunities, DoS surface expansion. Do NOT report
+generic hardening suggestions unless a concrete attack scenario exists.
+
+## Context
+
+macprovider-cli v1.7.5 fixes SPEC-023 install regression on M-Base +
+30B MoE (probe URLRequest timeout was 64s → prefill exceeded it → no
+paid model was ever admitted). Fix A extends the URL request idle
+timeout to 300s (configurable). Fix B persists per-candidate
+`.infeasible(reason:)` strings into `last-recommendation.json` and
+emits them to stderr as `[warn]` lines so users can diagnose "no
+eligible paid model" states.
+
+## Security-relevant surfaces to audit
+
+### 1. Diagnostic string source / injection
+
+`.infeasible(reason:nErr:)` strings originate from:
+- Local `Stage1Prober` — sources: probe HTTP status codes, "TTFT
+  exceeded gate", "provider readiness timeout: <lastError>", stop-token
+  leak messages. `<lastError>` is a Swift `Error.localizedDescription`
+  from the local mlx subprocess.
+- Local subprocess stderr tail on `.processExited` cases.
+- Local benchmarker's own gate rejections (RAM / tier / runtime-status).
+
+These strings are:
+- Written to stderr as `[warn] spec-023 probe: <modelKey>: <reason>`.
+- Written to `~/.config/macprovider/last-recommendation.json` inside
+  `probe_diagnostics` map.
+
+**Threat model to consider**:
+- Can a malicious model or CDN cause the probe to embed attacker-
+  controlled strings into these diagnostics? E.g. subprocess stderr tail
+  → does the coordinator later parse this file for anything?
+- If `last-recommendation.json` is ingested by another tool
+  (coordinator, portal, autotune-status), can a crafted reason string
+  cause parser trouble (JSON escaping bugs)?
+- Are terminal control sequences ever escaped when writing to stderr,
+  or does an ANSI-escape in a subprocess stderr tail get echoed to a
+  human terminal? See historical incident:
+  `c1-control-chars-terminal-sanitizer-bypass`.
+
+### 2. Model-key origin
+
+`benchmarks[modelKey]` and `probeDiagnostics[modelKey]` keys are drawn
+from `request.candidateCatalog.rows.keys`. The catalog is Ed25519-signed
+by streamvc autotune keys (SPEC-023 v0.3). Keys are attacker-controlled
+only if the signing key is compromised. Confirm audit assumes that.
+
+### 3. URLRequest timeout DoS surface
+
+New 300s idle timeout on `POST /v1/chat/completions` sent to
+`http://127.0.0.1:<port>`. Provider spawns a **local** mlx subprocess
+on that port (SPEC-023 v0.3 §Stage1Probe). Third parties cannot bind
+to that port during a probe (loopback only). Concerns:
+- Could a rogue subprocess be replaced during the 300s window (e.g.
+  via provider trust-of-local-tools compromise) to keep the connection
+  open, tying up the URLSession?
+- If yes, this only harms the calling user. Consider whether that's
+  in-scope.
+- Is 300s an acceptable ceiling given that `runner.stop(graceSeconds:
+  10)` is used in `defer`? What happens if the subprocess ignores
+  SIGTERM and the URLRequest is still pending?
+
+### 4. Configurability of `probeIdleTimeoutSec`
+
+Now injectable via `init` but no CLI flag or config file surface — so
+production always uses the 300s default. Consider whether this is
+correct posture (a malicious config could not override it).
+
+### 5. `probe_diagnostics` file persistence
+
+`last-recommendation.json` is written via `RecommendationStateStore.write`
+using `Data.write(to:options:.atomic)`. Consider:
+- Any file permissions concern?
+- Is this file readable by other users on multi-user Macs and would
+  the diagnostics leak information a threat model would care about
+  (installed model IDs and hardware constraints — probably not
+  sensitive, but confirm)?
+
+### 6. Non-goals to explicitly ignore
+
+- Cryptographic signing of `probe_diagnostics` — this is diagnostic
+  data, not authorization state. Not in scope.
+- Rate-limiting stderr emissions — same argument.
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift`
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+  (esp. `benchmarks()`, `storedStateJSON()`, `LastRecommendationState`)
+- `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift`
+  (esp. `runAutotuneRecommend()` stderr emission loop)
+
+## Reply format
+
+```
+## SECURITY audit — v1.7.5
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```
+
+Reject speculative "harden by also doing X" if there is no concrete
+attack. Report each finding with the attack scenario and the specific
+line(s) making it possible.


### PR DESCRIPTION
## Summary

Closes the **"v1.7.4 fresh install completes downloads but still recommends donor mode only"** gap caught during 2026-07-02 M5 32GB Tier C QA. After v1.7.4's HF-retry-with-resume shipped, install kept ending at `no_eligible_paid_model` with no user-facing reason. `~/.config/macprovider/last-recommendation.json` read `{"benchmark_id":null,"recommended_model":null}` with no diagnostic trail.

## Root cause chain (from source inspection + autotune-logs)

Every candidate probe subprocess in `~/.cache/macprovider/autotune-logs/` reached `Listening on http://127.0.0.1:18080` and then went silent — matching a URLSession idle-timeout followed by `defer runner.stop()`.

At [`Stage1Iterator.swift:522`](phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift#L522):

```swift
request.timeoutInterval = max(1, TimeInterval(Stage1Prober.maxTokens))  // = 64 seconds
```

`URLRequest.timeoutInterval` is an **idle timeout** — max seconds without any bytes arriving from the server. For an MLX 30B MoE prefilling a ~3200-token probe on M-Base hardware, TTFT can exceed 64s before the first byte, so `URLSession.bytes(for:)` threw `.timedOut` before any measurement was possible.

- Every candidate returned `.infeasible(reason:nErr:)`
- Engine gate 7 (`benchmark != nil`) failed for every eligible check
- `warnings.insert(.noEligiblePaidModel)` → donor mode
- `AutotuneRecommendationBenchmarker.benchmarks()` silently discarded the `.infeasible(reason:)` string, leaving `last-recommendation.json` with `benchmark_id: null` and zero root-cause path

Looks like a copy-paste bug — the author reused `maxTokens` (a token count) as a time-in-seconds value by accident.

## Fix A — realistic probe idle timeout

`Stage1Prober` now takes an injectable `probeIdleTimeoutSec: TimeInterval` init parameter defaulting to `defaultProbeIdleTimeoutSec = 300` seconds. Value clamped to `max(1, probeIdleTimeoutSec)` on store to preserve the URLRequest positive-timeout contract. `probeOnce` uses it as `request.timeoutInterval` instead of the buggy `TimeInterval(maxTokens)` expression.

300s covers observed 90-180s TTFT for 30B MoE + 3200-token prompts on M-Base while keeping enough headroom that a legitimately-broken server still fails within a bounded window.

## Fix B — persist `.infeasible` reasons + stderr WARN emission

- [`AutotuneRecommendationBenchmarker.benchmarks(...)`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L1650) now returns a new `BenchmarkOutcomes` struct `{benchmarks, diagnostics}` instead of just `[String: CandidateBenchmark]`.
- Diagnostics is a `modelKey -> single-line reason` map, populated for BOTH `.infeasible(reason:nErr:)` probe results AND pre-probe gate rejections (runtime-status `blocked`, min-RAM under safety margin, bandwidth tier under minimum). Pre-fix, those pre-probe gates used `guard ... else { continue }` and silently dropped the reason.
- [`AutotuneRecommendResult`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L836) gained a `probeDiagnostics: [String: String]` field (defaulted `[:]` for source compat; no test churn).
- [`storedStateJSON()`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L1093) emits `"probe_diagnostics":{...}` with keys sorted lexicographically for byte-stable output.
- [`LastRecommendationState`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L1145) decodes `probe_diagnostics` via `decodeIfPresent(...) ?? [:]` so pre-v1.7.5 files still parse.
- [`AutotuneCommand.runAutotuneRecommend`](phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift#L730) now writes each diagnostic to stderr as `[warn] spec-023 probe: <modelKey>: <reason>` before invoking `engine.recommend()`, then attaches `outcomes.diagnostics` to the result post-hoc.

Benchmarker stays pure — stderr emission is the caller's responsibility.

## 9 new unit tests

- `testStage1ProberDefaultIdleTimeoutIsSafeForLargePrefill` — regression guard, timeout ≥ 200s
- `testStage1ProberClampsSubSecondTimeoutToOne`
- `testBenchmarksReturnsInfeasibleDiagnostics` — `.infeasible(reason:nErr:)` becomes `"reason (n_err=N)"` in diagnostics
- `testBenchmarksDiagnosesRowsSkippedByRAMGate`
- `testBenchmarksDiagnosesRowsSkippedByBandwidthGate`
- `testStoredStateJSONIncludesProbeDiagnostics` — verifies lexicographic key ordering + string escape
- `testStoredStateJSONEmitsEmptyDiagnosticsObjectWhenNone`
- `testLastRecommendationStateDecodesProbeDiagnostics`
- `testLastRecommendationStateDecodesOldJSONWithoutProbeDiagnostics` — backwards-compat with pre-v1.7.5 files

## 3-lane codex audit — Round 1 convergence

Per `feedback-three-lane-codex-audits`: three independent codex invocations (code / security / architect). Per `feedback-audit-prompts-file-not-chat`: prompts committed to repo.

| Lane | CRITICAL | HIGH | MEDIUM | LOW | INFO | Verdict |
|---|:---:|:---:|:---:|:---:|:---:|---|
| CODE | 0 | 0 | 0 | 1 | 0 | ✅ PASS |
| SECURITY | 0 | 0 | 0 | 1 | 4 | ✅ PASS |
| ARCHITECT | 0 | 0 | 0 | 2 | 2 | ✅ PASS |

Per `feedback-stop-iterating-on-low-audits`: R1 CONVERGED at 0/0/0. **No R2 fixed-then-re-audit cycle** — LOWs shipped documented below.

Audit prompts at:
- [`specs/AUDIT_SPEC_023_PROBE_TIMEOUT_CODE_PROMPT.md`](specs/AUDIT_SPEC_023_PROBE_TIMEOUT_CODE_PROMPT.md)
- [`specs/AUDIT_SPEC_023_PROBE_TIMEOUT_SECURITY_PROMPT.md`](specs/AUDIT_SPEC_023_PROBE_TIMEOUT_SECURITY_PROMPT.md)
- [`specs/AUDIT_SPEC_023_PROBE_TIMEOUT_ARCHITECT_PROMPT.md`](specs/AUDIT_SPEC_023_PROBE_TIMEOUT_ARCHITECT_PROMPT.md)

### LOW findings shipped (documented deferrals)

**CODE-LOW-1** ([`AutotuneCommand.swift:740`](phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift#L740)): writes diagnostic reasons to stderr without normalizing embedded newlines. Reasons drawn from provider stderrTail can contain multiline output → continuation lines lack the `[warn] spec-023 probe:` prefix. JSON persistence remains safe via `jsonEscaped`. Log-format defect only, not a correctness bug. Deferred to a follow-up terminal-sanitizer PR.

**SEC-LOW-1** (same source as CODE-LOW-1, security lens): subprocess stderr can carry ANSI/C1 control sequences that echo to the user's terminal. Concrete sink: raw bytes captured in `CandidateProviderRunner.ProcessOutputTail` → embedded into `.infeasible(reason:)` → written to `standardError`. Related to prior `c1-control-chars-terminal-sanitizer-bypass` incident. Severity LOW because the input source is a **local admitted subprocess**, not a remote/unsigned input. Deferred to same follow-up.

**ARCH-LOW-1**: `probe_diagnostics` field wire schema is documented only by code (`Map<String, String>`). Future v1.8 might reshape values to `{reason, n_err}` — would break v1.7.5 downgrade paths. Recommendation is to keep this field permanently string-valued, or introduce a parallel `probe_diagnostics_v2` in the future.

**ARCH-LOW-2**: `SPEC-023-installer-autotune-recommend.md` is still locked at v0.1 while implementation carries a v1.7.5-specific timeout and diagnostics contract. A follow-up SPEC-023 v0.2 note would record the 300s probe idle timeout and `probe_diagnostics` field as normative outputs.

## No behavior change for happy-path installs

Users on M4/M4 Pro/M4 Max where the previous 64s timeout already sufficed see zero difference in recommend behavior — TTFT was below 64s so probes were feasible. The only observable change is:
- New `[warn] spec-023 probe: <modelKey>: <reason>` stderr line whenever a candidate is rejected
- New `probe_diagnostics` field in `~/.config/macprovider/last-recommendation.json`

For M-Base (M4/M5 32GB Tier C), 30B MoE probes now complete instead of timing out at 64s, restoring paid recommendations for hardware that clears the $0.005/hr threshold.

## Test plan

- [x] `swift build --product macprovider-cli` clean at v1.7.5
- [x] `swift test --filter AutotuneRecommendTests`: **59/59 pass** (50 pre-existing + 9 new)
- [x] Full `swift test` suite: **781/781 pass** (7 skipped, pre-existing)
- [x] 3-lane codex audit R1 CONVERGED at 0/0/0 across CODE/SECURITY/ARCHITECT
- [ ] Post-merge: `gh workflow run release.yml -f version=v1.7.5`
- [ ] Post-release: `curl get.streamvc.live/install.sh | bash` on M5 finishes with a paid-model recommendation (or if none clears, a clear per-candidate reason in `last-recommendation.json` instead of silent donor mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
