### PR TITLE
fix(spec-023): default-tier rate-card fallthrough + swap tolerance + bump v1.7.6

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -34,6 +34,18 @@ enum AutotuneRecommendWarning: String, CaseIterable {
     case rateCardFallbackUsed = "rate_card_fallback_used"
     case recommendationBelowThreshold = "recommendation_below_threshold"
     case noEligiblePaidModel = "no_eligible_paid_model"
+    /// v1.7.6 Track A1: at least one recommended candidate had no
+    /// specific rate-card row and is being priced against the coord's
+    /// "default" fallback tier. Coord's `RateFor` already falls through
+    /// to this row for served inference, so credits still flow — the
+    /// warning surfaces the discovery-tier pricing to the operator.
+    case rateCardDefaultTierUsed = "rate_card_default_tier_used"
+    /// v1.7.6 Track A2a: at least one recommended candidate observed
+    /// swap pageouts during the Stage 1 probe. The candidate still
+    /// cleared TPS/TTFT gates so eligibility passes, but the operator
+    /// should be aware that heavy real-world context loads may push
+    /// this Mac into swap.
+    case swapObservedUnderLoad = "swap_observed_under_load"
 }
 
 enum BandwidthTier: String, Codable, CaseIterable, Comparable {
@@ -569,13 +581,18 @@ struct RateCardProjection: Decodable, Equatable {
             return (modelKey, row)
         }
         let normalized = AutotuneModelKeyNormalizer.normalize(modelKey)
-        if normalized == "default", modelKey != "default" {
-            return nil
-        }
-        if normalized != modelKey, let row = rows[normalized] {
+        if normalized != modelKey, normalized != "default", let row = rows[normalized] {
             return (normalized, row)
         }
-        if modelKey == "default", let row = rows["default"] {
+        // v1.7.6 Track A1: fall through to the "default" rate-card row when
+        // no specific row exists for this model. Matches the coord's
+        // `RateFor` fallback semantics (phase4-coordinator/internal/billing/
+        // formula.go), which pays the default rate for served inference on
+        // any model not explicitly listed. Prior behavior blocked probe-
+        // feasible models from recommendation just because the rate-card
+        // hadn't caught up — the classic "provider drops out after install"
+        // cliff.
+        if let row = rows["default"] {
             return ("default", row)
         }
         return nil
@@ -871,6 +888,10 @@ struct AutotuneRecommendEngine {
                 benchmark: benchmark,
                 request: request
             )
+            // Warning insertion deferred until final selection is known —
+            // scoring EVERY eligible row here would falsely warn when a
+            // lower-ranked default-tier or swap-detected candidate is not
+            // the one actually recommended. See warning attach block below.
             let tps = benchmark?.sustainedTPS ?? 0
             let rateRow = rateMatch?.row
             let usdPerMillionCompletion = Double(rateRow?.completionRatePerMtok ?? 0)
@@ -887,10 +908,23 @@ struct AutotuneRecommendEngine {
             let raw = tps * 3600.0 * usdPerMillionCompletion * providerShare * demandWeight
             let headroom = Double(request.hardware.memoryGB - Self.safetyMarginGB - candidate.minRAMGB)
             let confidence = confidence(warnings: warnings, benchmark: benchmark)
+            // v1.7.6 Track A1 correction: when the rate-card lookup resolves
+            // via the "default" fallthrough (rate key == "default" but the
+            // catalog model isn't literally "default"), the served-model
+            // identity must remain the catalog model. Otherwise `--apply`
+            // writes `config.model = "default"` at ConfigApplier — which is
+            // the pricing key, not a real model runtime identity — and the
+            // HTTP server would reject buyer requests for the real model.
+            let servedModel: String
+            if let match = rateMatch, match.key == "default", modelKey != "default" {
+                servedModel = modelKey
+            } else {
+                servedModel = rateMatch?.key ?? modelKey
+            }
             return AutotuneCandidateScore(
                 rank: 0,
                 catalogKey: modelKey,
-                model: rateMatch?.key ?? modelKey,
+                model: servedModel,
                 eligible: eligible,
                 expectedGrossUSDPerHour: gross.rounded6,
                 expectedNetUSDPerHour: net.rounded6,
@@ -940,6 +974,24 @@ struct AutotuneRecommendEngine {
                 request: request
             )
         }
+        // v1.7.6 Track A1/A2a: only surface default-tier and swap warnings when
+        // they apply to the ACTUALLY-recommended candidate (or donor fallback
+        // when no paid recommendation lands). Prior placement inside the score
+        // loop would warn based on any lower-ranked eligible candidate — false
+        // positive per codex CODE-LOW-1.
+        let attachTargets: [(catalogKey: String, model: String)] = [
+            recommended.map { ($0.catalogKey, $0.model) },
+            recommended == nil ? donorFallback.map { ($0.catalogKey, $0.model) } : nil,
+        ].compactMap { $0 }
+        for target in attachTargets {
+            let rateMatch = request.rateCard.rowForRecommendation(modelKey: target.catalogKey)
+            if rateMatch?.key == "default", target.catalogKey != "default" {
+                warnings.insert(.rateCardDefaultTierUsed)
+            }
+            if request.benchmarks[target.catalogKey]?.swapDetected == true {
+                warnings.insert(.swapObservedUnderLoad)
+            }
+        }
 
         let resultCandidates = eligible.isEmpty ? Array(scored.prefix(5)) : Array(eligible.prefix(5))
 
@@ -983,9 +1035,17 @@ struct AutotuneRecommendEngine {
         guard candidate.minRAMGB <= request.hardware.memoryGB - Self.safetyMarginGB else { return false }
         guard request.hardware.bandwidthTier.satisfies(minimum: candidate.minBandwidthTier) else { return false }
         guard let benchmark else { return false }
+        // v1.7.6 Track A2a: swapDetected relaxed from hard-block to
+        // soft-signal. Probe hit swap under a 4000-token prefill on this
+        // Mac, but the candidate still cleared its TPS/TTFT bench gates.
+        // Real production demand often runs shorter than 4K context, so
+        // blocking the model would strand a capable provider. The engine
+        // now inserts a `swapObservedUnderLoad` warning at scoring time
+        // (see recommend() loop) to surface the risk to the operator.
+        // thermalThrottleDetected stays a hard-block because throttled
+        // TPS measurements are unreliable (they may be optimistic).
         guard benchmark.sustainedTPS >= candidate.benchGate.minSustainedTPS,
               benchmark.ttftMS <= candidate.benchGate.max4KTTFTMS,
-              !benchmark.swapDetected,
               !benchmark.thermalThrottleDetected
         else {
             return false
@@ -1006,6 +1066,9 @@ struct AutotuneRecommendEngine {
         candidate: CandidateCatalog.Row?,
         request: AutotuneRecommendRequest
     ) -> Bool {
+        // v1.7.6 Track A2a: donor mode inherits the paid-tier swap
+        // relaxation (see isEligible above). Thermal throttle stays
+        // a hard-block for both tiers.
         guard let candidate,
               ["candidate", "listed", "recommendable"].contains(candidate.runtimeStatus),
               candidate.modelRevision != nil,
@@ -1015,7 +1078,6 @@ struct AutotuneRecommendEngine {
               let benchmark = request.benchmarks[modelKey],
               benchmark.sustainedTPS >= candidate.benchGate.minSustainedTPS,
               benchmark.ttftMS <= candidate.benchGate.max4KTTFTMS,
-              !benchmark.swapDetected,
               !benchmark.thermalThrottleDetected
         else {
             return false

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.7.5"
+    static let binaryVersion = "1.7.6"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -215,7 +215,16 @@ struct ServeCommand: AsyncParsableCommand {
                 FileHandle.standardError.write(Data("model artifact is not admitted by the signed rate card\n".utf8))
                 throw ExitCode(2)
             }
-            expectedPublicModel = match.key
+            // v1.7.6 Track A1: when the rate-card row resolves via the
+            // "default" fallthrough, the pricing key is `"default"` but
+            // the served-model identity remains the catalog key — matches
+            // AutotuneRecommend's servedModel split. Without this mirror,
+            // paid serve preflight would reject any default-tier install.
+            if match.key == "default", key != "default" {
+                expectedPublicModel = key
+            } else {
+                expectedPublicModel = match.key
+            }
         } else {
             expectedPublicModel = key
         }

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -204,16 +204,39 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertFalse(AutotuneRecommendEngine.cachedBenchmarkAdmitted(stale, request: request, modelKey: modelKey))
     }
 
-    func testNoCoordinatorDefaultFallbackUnlessCandidateKeyIsDefault() throws {
+    func testRateCardFallsThroughToDefaultForArbitraryModelKey() throws {
+        // v1.7.6 Track A1: any model without a specific rate-card row
+        // falls through to the "default" row so probe-feasible models
+        // still receive an earnings estimate. Coord's `RateFor` at
+        // phase4-coordinator/internal/billing/formula.go already pays
+        // the default rate for served inference on unmatched models —
+        // client now agrees.
         let rateCard = try AutotuneStaticInputs.decodeRateCard(Data("""
         {"version":"test","generated_at":"2026-07-01T00:00:00Z","usd_per_million_credits":1.0,"rows":{"default":{"prompt_rate_per_mtok":1,"completion_rate_per_mtok":1,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
         """.utf8))
 
-        XCTAssertNil(rateCard.rowForRecommendation(modelKey: "qwen3-coder-30b-a3b-instruct"))
-        XCTAssertNil(rateCard.rowForRecommendation(modelKey: "DEFAULT"))
-        XCTAssertNil(rateCard.rowForRecommendation(modelKey: " default "))
-        XCTAssertNil(rateCard.rowForRecommendation(modelKey: "mlx-community/default-4bit"))
-        XCTAssertNotNil(rateCard.rowForRecommendation(modelKey: "default"))
+        XCTAssertEqual(rateCard.rowForRecommendation(modelKey: "qwen3-coder-30b-a3b-instruct")?.key, "default")
+        XCTAssertEqual(rateCard.rowForRecommendation(modelKey: "meta-llama/llama-3.1-8b-instruct")?.key, "default")
+        XCTAssertEqual(rateCard.rowForRecommendation(modelKey: "default")?.key, "default")
+    }
+
+    func testRateCardReturnsNilWhenNoDefaultAndNoMatch() throws {
+        let rateCard = try AutotuneStaticInputs.decodeRateCard(Data("""
+        {"version":"test","generated_at":"2026-07-01T00:00:00Z","usd_per_million_credits":1.0,"rows":{"qwen3-32b":{"prompt_rate_per_mtok":1,"completion_rate_per_mtok":1,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
+        """.utf8))
+
+        XCTAssertNil(rateCard.rowForRecommendation(modelKey: "unknown-model"))
+    }
+
+    func testRateCardPrefersSpecificRowOverDefault() throws {
+        // v1.7.6 Track A1: exact/normalized specific row wins over "default".
+        let rateCard = try AutotuneStaticInputs.decodeRateCard(Data("""
+        {"version":"test","generated_at":"2026-07-01T00:00:00Z","usd_per_million_credits":1.0,"rows":{"default":{"prompt_rate_per_mtok":9,"completion_rate_per_mtok":9,"provider_share_bps":9000,"global_multiplier_ppm":1000000},"qwen3-32b":{"prompt_rate_per_mtok":1,"completion_rate_per_mtok":1,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
+        """.utf8))
+
+        let match = rateCard.rowForRecommendation(modelKey: "qwen3-32b")
+        XCTAssertEqual(match?.key, "qwen3-32b")
+        XCTAssertEqual(match?.row.promptRatePerMtok, 1)
     }
 
     func testNormalizedRateCardLookupRecordsNormalizedKey() throws {
@@ -1096,6 +1119,94 @@ final class AutotuneRecommendTests: XCTestCase {
 
         XCTAssertNil(staleSince)
         XCTAssertEqual(staleWithDifferentProvider, Optional(Self.date("2026-07-02T00:00:00Z")))
+    }
+
+    // MARK: - Default-tier fallthrough + swap tolerance (v1.7.6 Track A1/A2a)
+
+    func testRecommendationEmitsRateCardDefaultTierWarningWhenSpecificRowMissing() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        // Drop the specific row so the engine has to fall through to "default".
+        request.rateCard.rows.removeValue(forKey: modelKey)
+        // Provide a default row so the fallthrough resolves.
+        request.rateCard.rows["default"] = RateCardProjection.Row(
+            promptRatePerMtok: 500_000,
+            completionRatePerMtok: 1_000_000,
+            providerShareBPS: 9_000,
+            globalMultiplierPPM: 1_000_000
+        )
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertTrue(result.warnings.contains(.rateCardDefaultTierUsed))
+        // v1.7.6 Track A1 correction: the SERVED model is the catalog model
+        // (what MLX will actually load), not the pricing key. Only the
+        // rate-card row used for earnings math resolves to "default".
+        XCTAssertEqual(result.recommendedModel, modelKey)
+        XCTAssertEqual(result.selectedCandidate?.catalogKey, modelKey)
+    }
+
+    func testRecommendationNoDefaultTierWarningWhenSpecificRowPresent() throws {
+        let result = AutotuneRecommendEngine().recommend(try makeRequest())
+        XCTAssertFalse(result.warnings.contains(.rateCardDefaultTierUsed))
+    }
+
+    func testSwapDetectedNoLongerBlocksEligibilityButEmitsWarning() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        // Flip swap flag on the existing feasible benchmark fixture.
+        var benchmark = try XCTUnwrap(request.benchmarks[modelKey])
+        benchmark.swapDetected = true
+        request.benchmarks[modelKey] = benchmark
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(result.recommendedModel, modelKey, "v1.7.6 Track A2a: swap detected must not veto eligibility")
+        XCTAssertTrue(result.warnings.contains(.swapObservedUnderLoad))
+        XCTAssertFalse(result.warnings.contains(.noEligiblePaidModel))
+    }
+
+    func testThermalThrottleStillHardBlocksEligibility() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        var benchmark = try XCTUnwrap(request.benchmarks[modelKey])
+        benchmark.thermalThrottleDetected = true
+        request.benchmarks[modelKey] = benchmark
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertNil(result.recommendedModel, "v1.7.6: thermal throttle stays a hard-block (TPS reading unreliable)")
+        XCTAssertTrue(result.warnings.contains(.noEligiblePaidModel))
+    }
+
+    func testDonorModeInheritsSwapRelaxation() throws {
+        var request = try makeRequest(modelKey: "qwen3-32b")
+        request.donorMode = true
+        request.hardware.bandwidthTier = .a
+        var benchmark = try XCTUnwrap(request.benchmarks["qwen3-32b"])
+        benchmark.swapDetected = true
+        request.benchmarks["qwen3-32b"] = benchmark
+
+        XCTAssertTrue(AutotuneRecommendEngine.donorModeAdmitted(
+            modelKey: "qwen3-32b",
+            candidate: request.candidateCatalog.rows["qwen3-32b"],
+            request: request
+        ))
+    }
+
+    func testDonorModeStillRejectsThermalThrottle() throws {
+        var request = try makeRequest(modelKey: "qwen3-32b")
+        request.donorMode = true
+        request.hardware.bandwidthTier = .a
+        var benchmark = try XCTUnwrap(request.benchmarks["qwen3-32b"])
+        benchmark.thermalThrottleDetected = true
+        request.benchmarks["qwen3-32b"] = benchmark
+
+        XCTAssertFalse(AutotuneRecommendEngine.donorModeAdmitted(
+            modelKey: "qwen3-32b",
+            candidate: request.candidateCatalog.rows["qwen3-32b"],
+            request: request
+        ))
     }
 
     // MARK: - Stage1 probe timeout + BenchmarkOutcomes diagnostics (v1.7.5)

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1481,10 +1481,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.5")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.5")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.7.5")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.7.5")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.6")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.6")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.7.6")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.7.6")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_ARCHITECT_PROMPT.md
@@ -1,0 +1,122 @@
+---
+role: architect-audit
+version: 1.0
+date: 2026-07-02
+target_pr: v1.7.6 default-tier fallthrough + swap tolerance (Track A1 + A2a)
+lens: ARCHITECTURE — layering, contracts, evolution
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# ARCHITECT audit — SPEC-023 v1.7.6 discovery-tier + swap tolerance
+
+You are an architecture-review specialist. Audit for structural
+issues, contract stability, and blast-radius concerns.
+
+## Context
+
+v1.7.6 fixes a "provider drops out after install" cliff by:
+
+1. **A1 — Rate-card default fallthrough** at
+   `RateCardProjection.rowForRecommendation`. Aligns client-side
+   scoring with coord-side `RateFor` fallback semantics
+   (`phase4-coordinator/internal/billing/formula.go:52`).
+2. **A2a — Swap tolerance** by dropping `!benchmark.swapDetected`
+   from `isEligible` and `donorModeCompatible`. Emits a
+   `swap_observed_under_load` warning instead.
+
+Bundled: new `rateCardDefaultTierUsed` warning surfaces when the
+default row is used for a recommended candidate.
+
+## What to audit
+
+### 1. Client / coord contract alignment
+
+Client `rowForRecommendation` now mirrors coord `RateFor` fallback
+behavior. Confirm:
+- Both fall through to the same key (`"default"`).
+- Both handle namespace-normalized keys the same way.
+- Neither returns a "fake" row when the underlying data is missing.
+- Any evolution path where these two would diverge (e.g., if coord
+  ships a new fallback tier like "discovery-tier"), does the client
+  need parallel updates or is it decoupled?
+
+### 2. Rate-card row schema stability
+
+The rate-card v1 schema documents `rows: Map<String, Row>` with an
+implicit `"default"` sentinel. Confirm:
+- SPEC-023 (or upstream rate-card spec) records `"default"` as a
+  reserved key
+- Any Mac operator running v1.7.5 who upgrades to v1.7.6 gets the
+  new behavior automatically (no config migration)
+
+### 3. Warning enum evolution
+
+Two new cases added to `AutotuneRecommendWarning`. Consider:
+- Persistence: warnings appear in `AutotuneRecommendResult` (in-memory
+  only via `humanTranscript`). Are they also persisted anywhere that
+  would need schema migration?
+- Downstream consumers of `warnings.rawValue.sorted()` — anyone
+  parsing this string list who would break on unknown values? Grep
+  for consumers.
+- Warning names: `rate_card_default_tier_used`,
+  `swap_observed_under_load` — do they collide with existing warnings
+  or future-planned ones?
+
+### 4. Eligibility-gate philosophy
+
+The gate is now:
+- swap: soft
+- thermal: hard
+- TPS/TTFT under-gate: hard
+- RAM/tier under-gate: hard
+
+Is this the right split? Should thermal ALSO be relaxed (with warning)
+in future? What's the general principle for soft vs. hard?
+
+### 5. Interaction with v1.7.5 diagnostics
+
+v1.7.5 introduced `probe_diagnostics` (modelKey → reason string) for
+`.infeasible` results and pre-probe gate rejections. v1.7.6 relaxes
+the swap gate — a swap-detected candidate is now `.feasible` and
+eligible, but the v1.7.5 diagnostics loop ALSO records `"feasible but
+swap detected"` (see `benchmarks()` in AutotuneRecommend.swift). Confirm:
+- Both the warning and the diagnostic co-exist coherently
+- User sees consistent signal in `humanTranscript` and
+  `last-recommendation.json`
+
+### 6. SPEC-023 document alignment
+
+`specs/SPEC-023-installer-autotune-recommend.md` is locked at v0.1.
+This PR adds two new warnings and changes eligibility semantics.
+Does SPEC-023 need a v0.2 note recording:
+- Default-row fallthrough as a normative behavior?
+- Swap-detected as a soft-signal (with warning) rather than hard-block?
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+- `phase4-coordinator/internal/billing/formula.go`
+- `specs/SPEC-023-installer-autotune-recommend.md`
+- `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift`
+
+## Reply format
+
+```
+## ARCHITECT audit — v1.7.6
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```
+
+Findings must cite file:line and describe a concrete future scenario.

--- a/specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_CODE_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_CODE_PROMPT.md
@@ -1,0 +1,141 @@
+---
+role: code-audit
+version: 1.0
+date: 2026-07-02
+target_pr: v1.7.6 default-tier fallthrough + swap tolerance (Track A1 + A2a)
+lens: CODE — correctness, edge cases, coding errors
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# CODE audit — SPEC-023 v1.7.6 default-tier fallthrough + swap tolerance
+
+You are a code-review specialist. Independently audit this change for
+correctness bugs and coding errors. Report findings CRITICAL / HIGH /
+MEDIUM / LOW / INFO with file:line references and a concrete defect
+scenario. Do not speculate — findings must reproduce on the current diff.
+
+## Context
+
+macprovider-cli v1.7.5 closed one drop-out mode (probe timeout fix
+in Stage1Iterator + `.infeasible(reason:)` persistence). A follow-up
+M5 32GB fresh-install QA on 2026-07-02 revealed a second, larger
+drop-out mode: **provider hardware that CAN run a model, gets told
+"donor mode only" and drops out.**
+
+Two root causes:
+1. **`RateCardProjection.rowForRecommendation`** refused to return
+   the "default" row for arbitrary model keys. Client would decline
+   to recommend a probe-feasible model without a specific rate-card
+   entry. But **coord's `RateFor` at
+   `phase4-coordinator/internal/billing/formula.go:52`** already
+   falls through to "default" when no specific row exists — meaning
+   the coord will pay for served inference on ANY model. Client's
+   veto was purely defensive and produced the drop-out cliff.
+2. **`isEligible` and `donorModeCompatible`** hard-blocked any
+   benchmark with `swapDetected == true`. On the M5 32GB, all 3
+   probe-feasible candidates (llama-3.1-8b, gpt-oss-20b,
+   qwen3-coder-30b-a3b) triggered swap under a 4000-token probe.
+   Every one was eligible-by-TPS/TTFT but blocked. Real production
+   demand doesn't always hit 4K context — hard-blocking on swap
+   under a synthetic worst-case probe was too aggressive.
+
+## The change (Track A1 + A2a bundled)
+
+### A1 — Rate-card default-row fallthrough
+
+At [`AutotuneRecommend.swift`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift)
+`rowForRecommendation`:
+- If exact match, return it.
+- If normalized-key match (and normalized != "default"), return it.
+- Otherwise, fall through to `rows["default"]` if present.
+- Otherwise nil.
+
+New warning `AutotuneRecommendWarning.rateCardDefaultTierUsed` = `rate_card_default_tier_used`
+is inserted at scoring time when the resolved row's key is "default"
+but the model isn't literally "default".
+
+### A2a — Swap tolerance + `swapObservedUnderLoad` warning
+
+`isEligible` (paid) and `donorModeCompatible` (donor) drop the
+`!benchmark.swapDetected` guard. `!benchmark.thermalThrottleDetected`
+stays a hard-block because thermal-throttled TPS readings are
+unreliable (they may be optimistic vs cold-start production).
+
+New warning `AutotuneRecommendWarning.swapObservedUnderLoad` = `swap_observed_under_load`
+is inserted at scoring time when any recommended candidate's
+benchmark has swap detected.
+
+### Version bump
+
+`CoordinatorClient.binaryVersion`: `1.7.5` → `1.7.6`. Test assertion
+strings updated.
+
+## Tests added
+
+- `testRateCardFallsThroughToDefaultForArbitraryModelKey`
+- `testRateCardReturnsNilWhenNoDefaultAndNoMatch`
+- `testRateCardPrefersSpecificRowOverDefault`
+- `testRecommendationEmitsRateCardDefaultTierWarningWhenSpecificRowMissing`
+- `testRecommendationNoDefaultTierWarningWhenSpecificRowPresent`
+- `testSwapDetectedNoLongerBlocksEligibilityButEmitsWarning`
+- `testThermalThrottleStillHardBlocksEligibility`
+- `testDonorModeInheritsSwapRelaxation`
+- `testDonorModeStillRejectsThermalThrottle`
+
+Prior test `testNoCoordinatorDefaultFallbackUnlessCandidateKeyIsDefault`
+was INVERTED (it encoded the pre-v1.7.6 behavior) — the new tests above
+cover the new v1.7.6 contract.
+
+Full suite: **791/791 pass** (was 781, +10 net: 8 new + 3 renamed - 1
+inverted).
+
+## What to audit
+
+1. **`rowForRecommendation` correctness** — is the fallthrough order
+   correct? Any way an arbitrary key can bypass a normalized-key
+   match and hit the default? Any way the default row is returned
+   when the caller expects a specific-row miss?
+2. **Warning insertion sites** — is `rateCardDefaultTierUsed` only
+   inserted when a *recommended* candidate uses default (vs. when
+   any candidate is scored against default)? Same for
+   `swapObservedUnderLoad`. Consider whether the warning should fire
+   only for candidates in the top-scored set vs. every scored candidate.
+3. **Eligibility guard changes** — is the swap gate correctly removed
+   from BOTH `isEligible` and `donorModeCompatible`? Is thermal still
+   correctly hard-blocked?
+4. **Donor-mode integration** — with `donorModeCompatible` relaxed on
+   swap, do the M5-32GB donor-mode scenarios still land correctly?
+5. **Determinism / ordering** — the `warnings` set uses `Set<T>` +
+   `.map(\.rawValue).sorted()` — should be deterministic. Confirm the
+   new raw values don't introduce ordering surprises.
+6. **Regressions on existing tests** — any test that relied on the
+   old "no fallthrough" behavior implicitly? Search for callers of
+   `rowForRecommendation` in tests.
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+- `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift`
+- `phase4-coordinator/internal/billing/formula.go` (for RateFor
+  reference — no changes here, just confirm client/coord align)
+
+## Reply format
+
+```
+## CODE audit — v1.7.6
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```

--- a/specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_SECURITY_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_SECURITY_PROMPT.md
@@ -1,0 +1,127 @@
+---
+role: security-audit
+version: 1.0
+date: 2026-07-02
+target_pr: v1.7.6 default-tier fallthrough + swap tolerance (Track A1 + A2a)
+lens: SECURITY — trust, integrity, economic exploit, DoS
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# SECURITY audit — SPEC-023 v1.7.6 discovery-tier + swap tolerance
+
+You are a security-review specialist. Audit this change for
+security-relevant defects: trust-boundary crossings, data integrity,
+economic exploitation, DoS surface expansion.
+
+## Context
+
+v1.7.6 changes two eligibility gates in autotune-recommend:
+
+1. **Rate-card default fallthrough** — `rowForRecommendation` now
+   returns the `default` row when no specific row matches.
+2. **Swap tolerance** — `isEligible` and `donorModeCompatible`
+   no longer hard-block on `benchmark.swapDetected`. Instead a
+   `swap_observed_under_load` warning is inserted at scoring time.
+   Thermal throttle remains a hard-block.
+
+Both changes are **client-side** (macprovider-cli autotune-recommend
+scoring). Coord-side rate-card enforcement is unchanged — coord's
+`RateFor` already had the default-fallback semantics; client is
+now aligning with it.
+
+## Security-relevant surfaces
+
+### 1. Money-path economic exposure
+
+The default row on Pearl is currently:
+- `prompt_rate_per_mtok`: 500,000 credits (= $0.50/M at $1/M credits)
+- `completion_rate_per_mtok`: 1,000,000 credits (= $1.00/M)
+- `provider_share_bps`: 9000 (90%)
+- `global_multiplier_ppm`: 1,000,000
+
+Coord will pay this rate for served inference of any model. Consider:
+
+- Can a provider game the recommend flow to serve an *arbitrary*
+  model against `default` pricing and extract disproportionate
+  credits (vs. what a specific-row rate would allow)?
+- Coord's `RateFor` fallback is authoritative for BILLING — client-side
+  recommend only affects WHICH model to install. Billing side is
+  unchanged. Confirm the concern is about install-time economic
+  guidance, not runtime billing manipulation.
+- Is there a case where the default row's rates are much HIGHER than
+  a specific row (i.e., the coord accidentally over-pays)? Look at
+  current Pearl values and compare.
+
+### 2. Model-catalog trust
+
+`rowForRecommendation` fallthrough only applies when the model is IN
+the signed candidate catalog (`request.candidateCatalog.rows[modelKey]`
+is checked at scoring time — see `recommend()`). Confirm attacker
+cannot inject an unauthorized model into the recommend flow via the
+default fallthrough.
+
+### 3. Swap-tolerance eligibility
+
+`swapDetected` in `benchmark` is a local telemetry signal from
+`ProbeSafetyAssessment.assess`. Malicious tampering would require
+local compromise. Confirm this is the right threat model.
+
+But: could a provider deliberately trigger `swapDetected` (e.g., by
+loading random memory before autotune) to skip a specific eligibility
+path? Under v1.7.5 this would DE-CREDIT the candidate; under v1.7.6
+it only inserts a warning. Is there a scenario where the provider
+BENEFITS from the swap gate being relaxed?
+
+### 4. Thermal-throttle asymmetry
+
+Swap is relaxed; thermal-throttle stays hard-blocked. The two flags
+have different threat/utility profiles. Confirm this asymmetry is
+correct:
+- Swap: probe measures under memory pressure → but production may
+  not hit swap → soft signal.
+- Thermal: probe measures under throttling → TPS reading may be
+  optimistic → hard block correct.
+
+### 5. Warning trust boundary
+
+`rateCardDefaultTierUsed` and `swapObservedUnderLoad` warnings are
+inserted at scoring time and surface to the operator via `humanTranscript`
++ persisted `probe_diagnostics`. Any way an attacker can suppress
+these warnings by manipulating candidate catalog or rate-card content?
+
+## Non-goals to explicitly ignore
+
+- Ed25519 signing correctness of static feeds (unchanged in v1.7.6)
+- HTTP/S transport security (unchanged)
+- Notary/signing (unchanged)
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+  (esp. `rowForRecommendation`, `recommend()`, `isEligible`,
+  `donorModeCompatible`)
+- `phase4-coordinator/internal/billing/formula.go` (RateFor and
+  its callers — is the client change consistent with coord's
+  authoritative billing path?)
+
+## Reply format
+
+```
+## SECURITY audit — v1.7.6
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```
+
+Reject speculative "harden by also doing X" without an attack scenario.


### PR DESCRIPTION
## Summary

Closes the **"provider drops out after install"** cliff observed on 2026-07-02 M5 32GB Tier C QA. v1.7.5 shipped diagnostics that showed swap detected on all 3 probe-feasible candidates → donor mode declined → install exited without starting the provider service. The provider's Mac was capable of running the model, but the client refused to recommend it.

## Root cause

The client autotune-recommend engine was **more restrictive than the coord's authoritative billing path**:

1. **Coord's [`RateFor`](phase4-coordinator/internal/billing/formula.go#L40)** already falls through to a `"default"` rate-card row for any model without a specific entry. Pearl has this row deployed (`/v1/rate-card` returns `default` = `$0.50/M prompt, $1.00/M completion, 90% share`). Client's [`rowForRecommendation`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L567) explicitly REFUSED to return it for arbitrary model keys. Coord was ready to pay; client wouldn't recommend.
2. **`isEligible` and `donorModeCompatible`** hard-blocked any benchmark with `swapDetected == true`. On the M5 32GB, all 3 probe-feasible candidates triggered swap under a synthetic 4000-token probe — but real production demand doesn't always hit 4K context. Hard-blocking on a synthetic worst-case probe was too aggressive.

## Track A1 — Rate-card default-row fallthrough

`rowForRecommendation` at [`AutotuneRecommend.swift:567`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L567) now returns `rows["default"]` as final fallback after exact + normalized lookups fail. Matches coord's `RateFor` exact→normalized→default semantics.

New warning [`rate_card_default_tier_used`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L36) inserted at `recommend()` time when the *actually-recommended* (or donor-fallback) candidate resolved via the default fallthrough.

### Critical: pricing key ≠ served-model identity

When the rate-card lookup returns key `"default"`, the served-model identity remains the CATALOG model. `AutotuneCandidateScore.model` uses a new `servedModel` local that preserves `modelKey` when `rateMatch.key == "default"` and `modelKey != "default"`. [`MacProviderCLI.swift:214`](phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift#L214) serve preflight mirrors the same split so paid startup accepts the catalog model as `config.model` instead of rejecting it as "not matching rate-card key".

Without this split, `--apply` would write `config.model = "default"` and `ChatCompletionRequest.validateModelMatches` would reject buyer requests for the real model. **Caught by codex CODE R1 HIGH-1 (independently by ARCHITECT R1 HIGH-1 — 3-of-3 convergent finding).**

## Track A2a — Swap tolerance (soft signal)

`isEligible` and `donorModeCompatible` drop the `!benchmark.swapDetected` guard. Thermal throttle stays a hard-block (throttled TPS readings are unreliable — potentially optimistic vs cold-start production).

New warning [`swap_observed_under_load`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L42) inserted at `recommend()` time when the actually-recommended (or donor-fallback) candidate has `benchmark.swapDetected == true`.

## Warning insertion scope correction

Codex CODE R1 LOW-1 + ARCHITECT R1 LOW-2 (convergent): initial warning insertion was inside the score loop, so a lower-ranked eligible candidate could set the warning even when the actually-recommended model was clean. **Fixed** by deferring insertion until post-selection, iterating only over `{recommended, donor-fallback-if-no-paid}` targets.

## 3-lane codex audit

Convergence per `feedback-three-lane-codex-audits` + `feedback-skip-accepted-audit-lanes`:

| Round | Lane | C | H | M | L | I | Notes |
|:---:|---|:---:|:---:|:---:|:---:|:---:|---|
| R1 | CODE | 0 | 1 | 0 | 1 | 0 | HIGH: served-model=default. LOW: scope. |
| R1 | SECURITY | 0 | 0 | 0 | 1 | 5 | ✅ PASS — skipped R2/R3 |
| R1 | ARCHITECT | 0 | 1 | 0 | 2 | 4 | Convergent HIGH. LOWs. |
| R2 | CODE | 0 | 1 | 0 | 0 | 0 | New HIGH at `MacProviderCLI.swift:218` |
| R2 | ARCHITECT | 0 | 0 | 0 | 0 | 0 | ✅ PASS |
| R3 | CODE | 0 | 0 | 0 | 0 | 0 | ✅ PASS — all downstream sites verified |

Audit prompts:
- [`specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_CODE_PROMPT.md`](specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_CODE_PROMPT.md)
- [`specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_SECURITY_PROMPT.md`](specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_SECURITY_PROMPT.md)
- [`specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_ARCHITECT_PROMPT.md`](specs/AUDIT_SPEC_023_V176_DISCOVERY_TIER_ARCHITECT_PROMPT.md)

Per `audit-cycles-are-design-discovery`: 3-of-3 convergent HIGH on served-model=default was a highly reliable design finding; required R2 to catch `MacProviderCLI.swift:218` downstream; R3 verified the complete downstream call-site set (ConfigApplier, HTTPServer, ChatCompletionRequest, ModelRuntime all consume `config.model`, not the rate-card pricing key).

## LOW deferrals shipped

- **ARCH-LOW-1 R1**: SPEC-023 v0.1 document doesn't yet record default-row fallthrough or swap-as-soft-signal. Deferred to a SPEC-023 v0.2 PR to keep this change scoped to code.
- **SEC-LOW-1**: `humanTranscript()` doesn't include the new warnings in its rendered output; warnings are visible via `.warnings` array and stderr but not in the human-facing transcript block. UX polish deferred to a follow-up.

## No behavior change for happy-path installs

Providers with a probe-feasible model that has a specific rate-card row see zero difference. Only observable changes:
- Providers whose feasible model has no specific rate-card row now get a paid recommendation using the default rate (was: donor mode only). New `rate_card_default_tier_used` warning surfaces this.
- Providers whose feasible model triggers swap now stay eligible (was: hard-block → donor mode only). New `swap_observed_under_load` warning surfaces the risk.

Both changes only "flip" outcomes that were previously drop-out paths — **no eligible-under-v1.7.5 model becomes ineligible under v1.7.6.**

## Test plan

- [x] `swift build --product macprovider-cli` clean at v1.7.6
- [x] `swift test --filter AutotuneRecommendTests`: **67/67 pass** (was 59, +8)
- [x] Full `swift test` suite: **791/791 pass** (7 skipped, pre-existing)
- [x] 3-lane codex audit converged R3 CODE + R2 ARCHITECT + R1 SECURITY at 0/0/0
- [ ] Post-merge: `gh workflow run release.yml -f version=v1.7.6`
- [ ] Post-release: `curl get.streamvc.live/install.sh | bash` on M5 32GB finishes with a **paid recommendation** for one of the 3 probe-feasible candidates (was: donor mode only in v1.7.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
