### PR TITLE
fix(spec-023): Stage1 probe TPS measurement + bump v1.7.8

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.7.7"
+    static let binaryVersion = "1.7.8"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift
+++ b/phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift
@@ -569,6 +569,12 @@ struct Stage1Prober: Stage1Probing {
         let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
         var generatedText = ""
         var firstTokenAt: Date?
+        // v1.7.8 Track A4: count SSE content deltas as a token-count proxy.
+        // MLX serve emits one delta per generated token, so this closely
+        // tracks the actual token count. Pre-v1.7.8 code counted
+        // whitespace-separated English words (English averages ~0.75
+        // words/token, under-counting by ~1.3x).
+        var deltaCount = 0
 
         for try await rawLine in bytes.lines {
             guard rawLine.hasPrefix("data:") else {
@@ -585,6 +591,7 @@ struct Stage1Prober: Stage1Probing {
                 firstTokenAt = clock()
             }
             generatedText += content
+            deltaCount += 1
         }
 
         guard let firstTokenAt else {
@@ -596,14 +603,23 @@ struct Stage1Prober: Stage1Probing {
             )
         }
 
+        // v1.7.8 Track A4: measure generation-only throughput.
+        // Pre-v1.7.8 the denominator was `ended - started`, which
+        // included TTFT (the full prefill wall-clock, 5-30s on M-Base
+        // even after v1.7.7's prewarm on a 3200-token prompt).
+        // That inflated the denominator by ~4-10x and drove reported
+        // TPS to 3-4 tok/s for candidates that actually stream 25-40
+        // tok/s in warm generation. Catalog `min_sustained_tps`
+        // (20-30 range) expresses warm-generation throughput, so this
+        // is the semantics the gate expects.
         let ended = clock()
-        let outputTokens = max(1, generatedText.split(whereSeparator: \.isWhitespace).count)
-        let elapsed = max(0.001, ended.timeIntervalSince(started))
+        let generationElapsed = max(0.001, ended.timeIntervalSince(firstTokenAt))
+        let outputTokens = max(1, deltaCount)
         return SingleProbeResult(
             statusCode: statusCode,
             ttftMS: max(0, firstTokenAt.timeIntervalSince(started) * 1_000),
             generatedText: generatedText,
-            throughputTPS: Double(outputTokens) / elapsed
+            throughputTPS: Double(outputTokens) / generationElapsed
         )
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1481,10 +1481,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.7")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.7")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.7.7")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.7.7")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.8")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.8")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.7.8")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.7.8")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/Stage1IteratorTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/Stage1IteratorTests.swift
@@ -296,6 +296,50 @@ final class Stage1IteratorTests: XCTestCase {
         XCTAssertTrue(reason.contains("prewarm") || reason.contains("exit"), reason)
     }
 
+    // MARK: - v1.7.8 Track A4 — token-count + generation-only elapsed
+
+    /// Pre-v1.7.8 code counted whitespace-separated words and divided by
+    /// TOTAL elapsed (including TTFT). This test uses a mock that emits
+    /// 10 single-token deltas fast (each ~1ms apart) after a deliberately
+    /// long 0.4s TTFT. Post-v1.7.8 TPS = 10 / (~10ms) = 1000+ tok/s.
+    /// Pre-v1.7.8 TPS would have been ~25 tok/s (10 words / 0.4s) —
+    /// well under the asserted 40 tok/s floor.
+    ///
+    /// Real-world win: pre-v1.7.8, M-Base measured 3-4 TPS on 30B MoE
+    /// candidates that actually stream 25-40 tok/s in warm generation.
+    /// The measurement bug drove every candidate under the catalog's
+    /// `min_sustained_tps` gate and caused install drop-out.
+    func testStage1ProberTPSCountsDeltasAndDividesByGenerationTime() async throws {
+        let port = try unusedPort()
+        let runner = try CandidateProviderRunner(
+            providerBinaryPath: try slowTTFTFastDeltasScript(ttftSeconds: 0.4, deltaCount: 10).path,
+            logDirectory: try temporaryDirectory(name: "stage1-tps-math-logs")
+        )
+
+        let result = try await Stage1Prober(readyTimeoutSec: 10, stopGraceSeconds: 1).probe(
+            model: "model-a",
+            port: port,
+            runner: runner,
+            targetContext: 64,
+            gateTTFTMS: 60_000,
+            replicates: 1
+        )
+
+        guard case .feasible(let medianTPS, let p95TTFTMS) = result else {
+            return XCTFail("expected feasible, got \(result)")
+        }
+        // Generation elapsed for 10 fast-emitted deltas is ~10ms
+        // (Python for-loop + socket sendall). Expected TPS ≈ 10 /
+        // 0.010 = 1000. Even under CI jitter → 100ms elapsed → TPS =
+        // 100. Assert > 40 to rule out the pre-v1.7.8 total-elapsed
+        // math which would produce ~25 TPS (10 deltas / 0.4s).
+        XCTAssertGreaterThan(medianTPS, 40,
+            "post-v1.7.8 TPS must exclude TTFT from elapsed; got \(medianTPS)")
+        // TTFT measurement itself should reflect the ~400ms wait
+        // (v1.7.5 contract, unaffected by A4).
+        XCTAssertGreaterThan(p95TTFTMS, 200)
+    }
+
     func testStage1ProberDetectsTTFTGateMiss() async throws {
         let port = try unusedPort()
         let runner = try CandidateProviderRunner(
@@ -626,6 +670,75 @@ final class Stage1IteratorTests: XCTestCase {
             maxBatch: intOrNil(15),
             replicatesN: intOrNil(16)
         )
+    }
+
+    /// v1.7.8 Track A4 test helper: emits `deltaCount` SSE deltas fast after
+    /// a deliberate `ttftSeconds` delay. Used to verify that the prober
+    /// measures generation-only elapsed and counts deltas (not words).
+    private func slowTTFTFastDeltasScript(ttftSeconds: Double, deltaCount: Int) throws -> URL {
+        let directory = try temporaryDirectory(name: "stage1-slow-ttft-provider")
+        let scriptURL = directory.appendingPathComponent("slow-ttft-provider")
+        let script = """
+        #!/usr/bin/env python3
+        import json, socket, sys, time
+
+        args = sys.argv[1:]
+        if "serve" not in args or "--no-join" not in args:
+            sys.stderr.write("expected serve --no-join\\n")
+            sys.exit(2)
+        port = int(args[args.index("--port") + 1])
+
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("127.0.0.1", port))
+        server.listen(16)
+        print("stage1 slow-ttft provider ready", flush=True)
+
+        ttft = \(ttftSeconds)
+        delta_count = \(deltaCount)
+        while True:
+            client, _ = server.accept()
+            request = client.recv(65536).decode("utf-8", "ignore")
+            if "GET /v1/models " in request:
+                body = '{"object":"list","data":[{"id":"stub","object":"model"}]}'
+                client.sendall((
+                    "HTTP/1.1 200 OK\\r\\n"
+                    "Content-Type: application/json\\r\\n"
+                    f"Content-Length: {len(body)}\\r\\n"
+                    "Connection: close\\r\\n"
+                    "\\r\\n"
+                    f"{body}"
+                ).encode())
+                client.close()
+                continue
+            if "POST /v1/chat/completions " in request:
+                client.sendall((
+                    "HTTP/1.1 200 OK\\r\\n"
+                    "Content-Type: text/event-stream\\r\\n"
+                    "Cache-Control: no-cache\\r\\n"
+                    "Connection: close\\r\\n"
+                    "\\r\\n"
+                ).encode())
+                time.sleep(ttft)
+                for i in range(delta_count):
+                    chunk = json.dumps({"choices":[{"delta":{"content":"tok"}}]})
+                    client.sendall(f"data: {chunk}\\n\\n".encode())
+                client.sendall(b"data: [DONE]\\n\\n")
+                client.close()
+                continue
+            body = "not found"
+            client.sendall((
+                "HTTP/1.1 404 Not Found\\r\\n"
+                f"Content-Length: {len(body)}\\r\\n"
+                "Connection: close\\r\\n"
+                "\\r\\n"
+                f"{body}"
+            ).encode())
+            client.close()
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        return scriptURL
     }
 
     /// v1.7.7 Track A3 test helper: first POST returns HTTP 500 (simulates

--- a/specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_ARCHITECT_PROMPT.md
@@ -1,0 +1,95 @@
+---
+role: architect-audit
+version: 1.0
+date: 2026-07-03
+target_pr: v1.7.8 fix TPS measurement (Track A4)
+lens: ARCHITECTURE
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# ARCHITECT audit — v1.7.8 TPS measurement fix
+
+Audit for structural issues on the current diff.
+
+## Context
+
+`Stage1Prober.probeOnce` now returns `throughputTPS` computed as:
+- `outputTokens = max(1, deltaCount)` — counts SSE content deltas
+- `generationElapsed = max(0.001, ended.timeIntervalSince(firstTokenAt))`
+- `throughputTPS = Double(outputTokens) / generationElapsed`
+
+Pre-v1.7.8 used whitespace-word count and total elapsed (including
+TTFT).
+
+## What to audit
+
+### 1. Measurement contract change
+
+Catalog `min_sustained_tps` values (20-30 for various models) now
+gate against warm-generation throughput semantics. Consider:
+- Is this contract documented anywhere (SPEC-023, catalog schema, ADR)?
+- If a future implementation reverts to total-elapsed, catalog gates
+  would silently over-block again. Add a normative SPEC note?
+
+### 2. SSE-delta-count assumption
+
+The fix relies on "MLX serve emits one delta per token." Consider:
+- Is this a stable contract of MLX serve? Any risk of a future MLX
+  version batching tokens per chunk (e.g. 4 tokens per delta)?
+- If MLX starts emitting multi-token deltas, TPS reports would drop
+  by 4×. Silent under-report — provider would fail eligibility for
+  no fault of theirs.
+- Would a tokenizer-based measurement be more stable? (Tradeoff:
+  need to embed a tokenizer.)
+
+### 3. Interaction with prewarm (v1.7.7)
+
+Prewarm calls `probeOnce` too — its result is discarded via `try?`.
+Confirm the deltaCount local scoping is per-invocation. Any risk that
+Swift async retains state that leaks between the prewarm's probeOnce
+call and the real replicates loop's probeOnce calls?
+
+### 4. Edge cases in the eligibility path
+
+With correct TPS measurement, more candidates now clear the TPS gate.
+Downstream `expectedNetUSDPerHour < paidThreshold` may become the new
+bottleneck instead of TPS. Consider:
+- Are there candidates that will now pass TPS but fail net-yield?
+  (Yes: llama-3.1-8B at $0.027/M rate.)
+- Is that behavior correct? (Yes — it means the catalog is honest
+  about which models earn enough.)
+- Should the `.recommendationBelowThreshold` warning surface differently
+  now that it will fire more often?
+
+### 5. Data-shape stability
+
+`SingleProbeResult.throughputTPS` type/units unchanged (Double,
+tokens/second). Downstream consumers (`benchmarks()` → `.feasible`
+switch) don't care about the internal math change. Confirm no
+serialization/persistence issue.
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift`
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+- `specs/SPEC-023-installer-autotune-recommend.md`
+
+## Reply format
+
+```
+## ARCHITECT audit — v1.7.8
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```

--- a/specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_CODE_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_CODE_PROMPT.md
@@ -1,0 +1,139 @@
+---
+role: code-audit
+version: 1.0
+date: 2026-07-03
+target_pr: v1.7.8 fix TPS measurement in Stage1 probe (Track A4)
+lens: CODE — correctness, edge cases, coding errors
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# CODE audit — SPEC-023 v1.7.8 TPS measurement fix
+
+Audit for correctness bugs on the current diff. Report CRITICAL/HIGH/
+MEDIUM/LOW/INFO with file:line and concrete defect scenarios. No
+speculative findings.
+
+## Context
+
+v1.7.7 M5 install analysis via `macprovider-cli autotune --recommend
+--json` showed:
+
+- qwen3-coder-30b-a3b: measured 3.7 TPS vs 25 TPS gate → not eligible
+- gpt-oss-20b: measured 3.6 TPS vs 30 TPS gate → not eligible
+
+MLX warm-generation throughput on M-Base is 25-40 tok/s for these
+models. The measured 3-4 TPS is a 10× under-report driven by two
+compounding bugs in `Stage1Prober.probeOnce`:
+
+**Bug 1** (line 580 pre-v1.7.8):
+`outputTokens = generatedText.split(\.isWhitespace).count`
+This counts **whitespace-separated English words**, not tokens.
+English averages ~0.75 words per token, so under-counts by ~1.3×.
+
+**Bug 2** (line 581 pre-v1.7.8):
+`elapsed = ended.timeIntervalSince(started)`
+`started` is the time of the HTTP POST, before the request is even
+sent. So `elapsed` includes TTFT — the full prefill wall-clock. For
+a 3200-token prompt on M-Base, prefill can dominate (5-30s even
+after v1.7.7's prewarm). Generation of 64 tokens takes 1-2s. The
+denominator is 3-15× too large.
+
+## The fix
+
+At `phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift`
+`probeOnce`:
+
+1. Add `deltaCount` counter incremented once per SSE content delta
+   received. MLX serve emits one delta per generated token, so this
+   is a much closer proxy to true token count than word count.
+
+2. Replace `elapsed = ended.timeIntervalSince(started)` with
+   `generationElapsed = ended.timeIntervalSince(firstTokenAt)` —
+   only measures time from first token to last, excluding TTFT.
+
+3. `throughputTPS = Double(outputTokens) / generationElapsed` where
+   `outputTokens = max(1, deltaCount)`.
+
+`ttftMS` calculation unchanged (still `firstTokenAt - started`).
+
+Version bump: 1.7.7 → 1.7.8.
+
+## Tests added
+
+- `testStage1ProberTPSCountsDeltasAndDividesByGenerationTime` — new
+  mock (`slowTTFTFastDeltasScript`) emits 20 SSE deltas fast after a
+  deliberate 1.5s TTFT delay. Post-v1.7.8 TPS ≈ 20 / 0.02 = 1000+ tok/s.
+  Pre-v1.7.8 total-elapsed math would produce ~13 TPS (20 deltas /
+  1.5s). Asserts `medianTPS > 50` — impossible to hit with pre-v1.7.8
+  math but easy to hit post-v1.7.8. Also asserts `p95TTFTMS > 1000`
+  (TTFT contract unaffected by A4).
+
+Full suite: **802/802 pass** (was 801, +1 new).
+
+## What to audit
+
+1. **Division by zero** — `generationElapsed = max(0.001, ...)` matches
+   the pre-v1.7.8 pattern for `elapsed`. Confirm no path can reach
+   division by zero even if `firstTokenAt == ended` (both same clock
+   sample would give elapsed = 0, but `max(0.001, ...)` prevents that).
+
+2. **Delta counting when `content.isEmpty`** — SSE loop skips empty
+   content via `guard ... content.isEmpty else { continue }`. Confirm
+   deltas ONLY count when content is non-empty (matches
+   `generatedText += content` semantics).
+
+3. **First delta counted correctly** — the `firstTokenAt = clock()`
+   assignment and `deltaCount += 1` both happen inside the same guard
+   scope, after the empty check. Are they in the correct order? Any
+   race where deltaCount = 0 but firstTokenAt is set?
+
+4. **`.infinity` TTFT path** — when no first token arrives, the early
+   return at line 590-596 returns `throughputTPS: 0` and doesn't use
+   the deltaCount. Correct — but confirm deltaCount could genuinely be
+   nonzero in this path (empty-content-only deltas would count against
+   deltaCount but firstTokenAt would remain nil).
+
+   Wait — re-examine: the code path `guard let content =
+   contentDelta..., !content.isEmpty else { continue }` skips empty
+   content BEFORE the `firstTokenAt` assignment AND the deltaCount
+   increment. So deltaCount only increments on non-empty content. If
+   all deltas are empty, `firstTokenAt` stays nil and the early
+   return fires. Correct.
+
+5. **Realistic TPS bounds** — the new mock test asserts `medianTPS >
+   50`. Is that too tight for CI runners with slow OS timing?
+   Alternative would be to relax to `> 30` to accommodate loaded
+   runners. Consider stability.
+
+6. **Interaction with the pre-existing prewarm at line ~465** — prewarm
+   throws away its result. But it DOES call `probeOnce` which now counts
+   deltas locally. Is there any state that persists between prewarm
+   and the real probe that could inflate deltaCount for the real probe?
+   (Answer should be no: `deltaCount` is a `var` inside `probeOnce`,
+   scoped to each invocation. Confirm.)
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift`
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+- `phase3-binary/Tests/macprovider-cliTests/Stage1IteratorTests.swift`
+
+## Reply format
+
+```
+## CODE audit — v1.7.8
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```

--- a/specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_SECURITY_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_SECURITY_PROMPT.md
@@ -1,0 +1,91 @@
+---
+role: security-audit
+version: 1.0
+date: 2026-07-03
+target_pr: v1.7.8 fix TPS measurement (Track A4)
+lens: SECURITY
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# SECURITY audit — v1.7.8 TPS measurement fix
+
+Audit for security-relevant defects on the current diff.
+
+## Context
+
+`Stage1Prober.probeOnce` in
+`phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift`
+now counts SSE content deltas as a token-count proxy and measures
+generation-only elapsed (from first token to last). Pre-v1.7.8
+counted words and included TTFT in elapsed.
+
+Result affects install-time recommendation math ONLY. Coord-side
+billing math is unchanged (coord bills based on runtime usage, not
+install-time benchmark).
+
+## Security-relevant surfaces
+
+### 1. TPS inflation as an eligibility bypass
+
+Provider could try to inflate reported TPS to unlock a recommendation
+they shouldn't get. Consider:
+- Local subprocess trust: the MLX server is CLI-spawned. Attacker
+  would need to compromise local machine to substitute a bogus SSE
+  emitter that spams empty-content deltas fast.
+- Empty content is filtered by the pre-existing `guard !content.isEmpty`
+  check, so deltas require actual content bytes.
+- A bogus emitter could send many single-char delta chunks fast to
+  inflate deltaCount. This affects install-time recommendation
+  identity ONLY. Runtime billing is based on coord-side rate-card,
+  not the install-time TPS.
+
+Confirm the inflation surface is limited to install-time
+recommendation identity, not runtime credit inflation.
+
+### 2. Rate-card decision downstream
+
+An inflated TPS causes a HIGHER-expected-net-USD-per-hour candidate
+to be recommended. Recommended candidate must still clear
+$0.005/hr paid threshold. If the provider serves inference at
+sub-threshold real-world TPS, they'll earn less than the install-
+time projection. No financial harm to the network — they just earn
+less than expected.
+
+### 3. Amplification in denominator
+
+`generationElapsed = max(0.001, ...)` gives a lower bound of 1ms.
+Fastest possible TPS = `outputTokens / 0.001` = 1000 * outputTokens.
+Consider whether this ceiling is exploitable. For `maxTokens = 64`,
+max reported TPS = 64000. Is that observable/loggable in any way
+that could confuse operators or downstream systems?
+
+## Non-goals
+
+- MLX server internal security (unchanged).
+- Rate-card signing (unchanged).
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift`
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+  (for reference to how TPS feeds into recommendation math)
+
+## Reply format
+
+```
+## SECURITY audit — v1.7.8
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```


### PR DESCRIPTION
## Summary

Closes the **fourth** drop-out mode on the v1.7.7 M5 32GB Tier C install. Fixes a 10× under-report of measured TPS that drove every catalog candidate under its `min_sustained_tps` gate → `no_eligible_paid_model` → donor mode → drop-out.

## Root cause (from `autotune --recommend --json`)

| Candidate | Measured TPS (pre-v1.7.8) | Catalog gate | Verdict |
|---|:---:|:---:|:---:|
| qwen3-coder-30b-a3b | 3.7 | ≥ 25 | fails ❌ |
| gpt-oss-20b | 3.6 | ≥ 30 | fails ❌ |
| llama-3.1-8b | ~4 | ≥ 20 | fails ❌ |

MLX warm-generation on M-Base is 25-40 tok/s for these models. Two compounding bugs in [`Stage1Prober.probeOnce`](phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift):

**Bug 1 — word count**:
```swift
let outputTokens = max(1, generatedText.split(whereSeparator: \.isWhitespace).count)
```
Counts English **words**, not tokens. English averages ~0.75 words per token → 1.3× under-count.

**Bug 2 — total elapsed includes TTFT**:
```swift
let elapsed = max(0.001, ended.timeIntervalSince(started))
```
`started` is HTTP-POST time, so elapsed includes TTFT (prefill wall-clock, 5-30s on M-Base even after v1.7.7's prewarm). Generation of 64 tokens is 1-2s. Denominator 3-15× too large.

Combined: ~10× under-report.

## Fix

- Add `deltaCount` incremented per non-empty SSE content delta (MLX emits one delta per token — closest proxy to true token count without embedding a tokenizer)
- Replace `elapsed = ended - started` with `generationElapsed = ended - firstTokenAt` (generation only, excludes TTFT)
- `throughputTPS = outputTokens / generationElapsed`

`ttftMS` calculation unchanged. Division-by-zero guard retained.

## Expected M5 outcome

| Candidate | Post-fix TPS | Net USD/hr @ threshold | Verdict |
|---|:---:|:---:|:---:|
| gpt-oss-20b | ~30 | $0.0097 | ✅ clears $0.005 |
| qwen3-coder-30b-a3b | ~30 | $0.0228 | ✅ clears |
| llama-3.1-8b | ~30 | $0.0026 | ❌ rate too low (catalog honest — no bug) |

Provider stays online with gpt-oss-20b or qwen3-coder-30b-a3b.

## Tests added

- `testStage1ProberTPSCountsDeltasAndDividesByGenerationTime` — new mock (`slowTTFTFastDeltasScript`) emits 10 fast deltas after a 0.4s TTFT. Post-v1.7.8 TPS ≈ 1000 (10 / ~0.01s). Pre-v1.7.8 total-elapsed math would give ~25 TPS (10 / 0.4s). Asserts TPS > 40 rules out pre-v1.7.8 math. Runtime 1.9s.

## 3-lane codex audit — R1 → R2 convergence

| Round | Lane | C | H | M | L | I | Verdict |
|:---:|---|:---:|:---:|:---:|:---:|:---:|---|
| R1 | CODE | 0 | 0 | **1** | 0 | 0 | MED: test hung in codex env (timings too long) |
| R1 | SECURITY | 0 | 0 | 0 | 0 | 1 | ✅ PASS — skipped R2 |
| R1 | ARCHITECT | 0 | 0 | 0 | 1 | 5 | ✅ PASS — skipped R2 |
| R2 | CODE | 0 | 0 | 0 | 1 | 0 | ✅ PASS — LOW: stale comment fixed |

R1 CODE MEDIUM was test timing (mock hung under codex's 45s bound), not a production correctness issue. Fix: `ttftSeconds 1.5→0.4`, `deltaCount 20→10`, `readyTimeoutSec 5→10`. Single-test runtime 1.9s local.

Audit prompts:
- [`specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_CODE_PROMPT.md`](specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_CODE_PROMPT.md)
- [`specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_SECURITY_PROMPT.md`](specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_SECURITY_PROMPT.md)
- [`specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_ARCHITECT_PROMPT.md`](specs/AUDIT_SPEC_023_V178_TPS_MEASUREMENT_ARCHITECT_PROMPT.md)

Per `feedback-stop-iterating-on-low-audits`: R2 converged. **No R3.**

### LOW deferrals shipped

- **ARCH-LOW-1**: SPEC-023 v0.1 doesn't yet make warm-generation TPS semantics normative. Recommended for v0.2 note. Deferred to a SPEC-023 v0.2 PR.

## No behavior change for hardware already measuring warm

Any candidate that already passed the TPS gate under pre-v1.7.8 math will still pass under post-v1.7.8 math (numerator up ~1.3×, denominator down 5-15×). No previously-eligible candidate becomes ineligible.

## Test plan

- [x] `swift build --product macprovider-cli` clean at v1.7.8
- [x] `swift test --filter Stage1IteratorTests`: **14/14 pass**
- [x] Full suite: **802/802 pass** (7 skipped, pre-existing)
- [x] 3-lane codex audit converged R2 CODE + R1 SECURITY + R1 ARCHITECT
- [ ] Post-merge: `gh workflow run release.yml -f version=v1.7.8`
- [ ] Post-release: `curl get.streamvc.live/install.sh | bash` on M5 32GB produces a **paid recommendation** for gpt-oss-20b or qwen3-coder-30b-a3b (was: donor mode only in v1.7.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
