### PR TITLE
fix(spec-023): soft-signal TPS + TTFT eligibility gates (Option B) + bump v1.7.9

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -46,6 +46,18 @@ enum AutotuneRecommendWarning: String, CaseIterable {
     /// should be aware that heavy real-world context loads may push
     /// this Mac into swap.
     case swapObservedUnderLoad = "swap_observed_under_load"
+    /// v1.7.9 Track A5 (Option B): the recommended candidate's measured
+    /// sustained TPS was below the catalog's `min_sustained_tps` gate
+    /// for its row. The gate is now a soft signal — the ACTUAL gate is
+    /// `expected_net_usd_per_hour >= $0.005/hr`, since a provider with
+    /// slower-than-nominal TPS still earns at the reduced measured rate.
+    /// Buyers routing to this provider get slower inference than the
+    /// catalog gate implied.
+    case tpsBelowGate = "tps_below_gate"
+    /// v1.7.9 Track A5 (Option B): the recommended candidate's measured
+    /// 4K TTFT was above the catalog's `max_4k_ttft_ms` ceiling. Same
+    /// soft-signal reasoning as `tpsBelowGate`.
+    case ttftAboveGate = "ttft_above_gate"
 }
 
 enum BandwidthTier: String, Codable, CaseIterable, Comparable {
@@ -991,6 +1003,18 @@ struct AutotuneRecommendEngine {
             if request.benchmarks[target.catalogKey]?.swapDetected == true {
                 warnings.insert(.swapObservedUnderLoad)
             }
+            // v1.7.9 Track A5: catalog TPS/TTFT gates are soft signals.
+            // Surface the gap when the recommended candidate misses either
+            // gate so the operator sees the QoS delta vs catalog expectation.
+            if let benchmark = request.benchmarks[target.catalogKey],
+               let candidateRow = request.candidateCatalog.rows[target.catalogKey] {
+                if benchmark.sustainedTPS < Double(candidateRow.benchGate.minSustainedTPS) {
+                    warnings.insert(.tpsBelowGate)
+                }
+                if benchmark.ttftMS > candidateRow.benchGate.max4KTTFTMS {
+                    warnings.insert(.ttftAboveGate)
+                }
+            }
         }
 
         let resultCandidates = eligible.isEmpty ? Array(scored.prefix(5)) : Array(eligible.prefix(5))
@@ -1035,22 +1059,20 @@ struct AutotuneRecommendEngine {
         guard candidate.minRAMGB <= request.hardware.memoryGB - Self.safetyMarginGB else { return false }
         guard request.hardware.bandwidthTier.satisfies(minimum: candidate.minBandwidthTier) else { return false }
         guard let benchmark else { return false }
-        // v1.7.6 Track A2a: swapDetected relaxed from hard-block to
-        // soft-signal. Probe hit swap under a 4000-token prefill on this
-        // Mac, but the candidate still cleared its TPS/TTFT bench gates.
-        // Real production demand often runs shorter than 4K context, so
-        // blocking the model would strand a capable provider. The engine
-        // now inserts a `swapObservedUnderLoad` warning at scoring time
-        // (see recommend() loop) to surface the risk to the operator.
+        // v1.7.6 Track A2a: swapDetected relaxed to soft-signal.
+        // v1.7.9 Track A5 (Option B): sustainedTPS < min_sustained_tps
+        // and ttftMS > max_4k_ttft_ms both relaxed to soft-signals too.
+        // These catalog gates express warm-service QoS targets — a
+        // provider that misses them still EARNS at the rate implied by
+        // its measured TPS via `expected_net_usd_per_hour`. The real
+        // financial gate that decides "paid vs donor" is
+        // `expected_net_usd_per_hour >= $0.005/hr` (paidThreshold),
+        // applied later in recommend().
         // thermalThrottleDetected stays a hard-block because throttled
-        // TPS measurements are unreliable (they may be optimistic).
-        guard benchmark.sustainedTPS >= candidate.benchGate.minSustainedTPS,
-              benchmark.ttftMS <= candidate.benchGate.max4KTTFTMS,
-              !benchmark.thermalThrottleDetected
-        else {
-            return false
-        }
-        return Self.cachedBenchmarkAdmitted(benchmark, request: request, modelKey: modelKey)
+        // TPS measurements are unreliable (may be optimistically low
+        // and rebound in production, but also may mask real degradation).
+        return !benchmark.thermalThrottleDetected
+            && Self.cachedBenchmarkAdmitted(benchmark, request: request, modelKey: modelKey)
     }
 
     static func donorModeAdmitted(
@@ -1066,9 +1088,8 @@ struct AutotuneRecommendEngine {
         candidate: CandidateCatalog.Row?,
         request: AutotuneRecommendRequest
     ) -> Bool {
-        // v1.7.6 Track A2a: donor mode inherits the paid-tier swap
-        // relaxation (see isEligible above). Thermal throttle stays
-        // a hard-block for both tiers.
+        // v1.7.6 Track A2a + v1.7.9 Track A5: donor mode inherits the
+        // paid-tier relaxations. Only thermal throttle stays a hard-block.
         guard let candidate,
               ["candidate", "listed", "recommendable"].contains(candidate.runtimeStatus),
               candidate.modelRevision != nil,
@@ -1076,8 +1097,6 @@ struct AutotuneRecommendEngine {
               candidate.minRAMGB <= request.hardware.memoryGB - safetyMarginGB,
               request.hardware.bandwidthTier.satisfies(minimum: candidate.minBandwidthTier),
               let benchmark = request.benchmarks[modelKey],
-              benchmark.sustainedTPS >= candidate.benchGate.minSustainedTPS,
-              benchmark.ttftMS <= candidate.benchGate.max4KTTFTMS,
               !benchmark.thermalThrottleDetected
         else {
             return false

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.7.8"
+    static let binaryVersion = "1.7.9"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -1209,6 +1209,64 @@ final class AutotuneRecommendTests: XCTestCase {
         ))
     }
 
+    // MARK: - v1.7.9 Track A5 (Option B) — soft TPS + TTFT gates
+
+    func testTPSBelowGateNoLongerBlocksEligibilityButEmitsWarning() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        var benchmark = try XCTUnwrap(request.benchmarks[modelKey])
+        // Force TPS below the catalog gate (25 tok/s for qwen3-coder).
+        // Keep it high enough that expected_net_usd_per_hour still
+        // clears the $0.005/hr paid threshold.
+        benchmark.sustainedTPS = 20
+        request.benchmarks[modelKey] = benchmark
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(result.recommendedModel, modelKey,
+            "v1.7.9 Option B: TPS below catalog gate must not veto eligibility")
+        XCTAssertTrue(result.warnings.contains(.tpsBelowGate))
+        XCTAssertFalse(result.warnings.contains(.noEligiblePaidModel))
+    }
+
+    func testTTFTAboveGateNoLongerBlocksEligibilityButEmitsWarning() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        var benchmark = try XCTUnwrap(request.benchmarks[modelKey])
+        // Force TTFT above the catalog ceiling (3000ms for qwen3-coder).
+        benchmark.ttftMS = 6_000
+        request.benchmarks[modelKey] = benchmark
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(result.recommendedModel, modelKey,
+            "v1.7.9 Option B: TTFT above catalog ceiling must not veto eligibility")
+        XCTAssertTrue(result.warnings.contains(.ttftAboveGate))
+    }
+
+    func testNoTPSWarningWhenBenchmarkClearsGate() throws {
+        let result = AutotuneRecommendEngine().recommend(try makeRequest())
+        XCTAssertFalse(result.warnings.contains(.tpsBelowGate))
+        XCTAssertFalse(result.warnings.contains(.ttftAboveGate))
+    }
+
+    func testDonorModeInheritsTPSAndTTFTRelaxation() throws {
+        var request = try makeRequest(modelKey: "qwen3-32b")
+        request.donorMode = true
+        request.hardware.bandwidthTier = .a
+        var benchmark = try XCTUnwrap(request.benchmarks["qwen3-32b"])
+        // Below TPS gate + above TTFT ceiling for qwen3-32b.
+        benchmark.sustainedTPS = 1
+        benchmark.ttftMS = 100_000
+        request.benchmarks["qwen3-32b"] = benchmark
+
+        XCTAssertTrue(AutotuneRecommendEngine.donorModeAdmitted(
+            modelKey: "qwen3-32b",
+            candidate: request.candidateCatalog.rows["qwen3-32b"],
+            request: request
+        ))
+    }
+
     // MARK: - Stage1 probe timeout + BenchmarkOutcomes diagnostics (v1.7.5)
 
     func testStage1ProberDefaultIdleTimeoutIsSafeForLargePrefill() {

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1481,10 +1481,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.8")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.8")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.7.8")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.7.8")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.9")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.9")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.7.9")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.7.9")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/specs/AUDIT_SPEC_023_V179_SOFT_GATES_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_V179_SOFT_GATES_ARCHITECT_PROMPT.md
@@ -1,0 +1,103 @@
+---
+role: architect-audit
+version: 1.0
+date: 2026-07-03
+target_pr: v1.7.9 soft-signal TPS + TTFT eligibility gates (Track A5)
+lens: ARCHITECTURE
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# ARCHITECT audit — v1.7.9 soft TPS + TTFT gates
+
+## Context
+
+v1.7.9 relaxes TPS + TTFT catalog gates from hard-block to soft-signal.
+Follows the v1.7.6 A2a pattern for swap. The financial gate
+(`expected_net_usd_per_hour >= $0.005/hr paidThreshold`) is
+unchanged.
+
+Motivation: on M5 32GB Tier C, v1.7.8 measured qwen3-coder-30b-a3b at
+23.4 TPS (vs 25 gate) — the candidate earns $0.0178/hr net (above
+threshold) but was blocked by a catalog gate calibrated for larger
+hardware. The user's directive: "we cannot accept situations where
+32gb mac is not eligible."
+
+Alternative was to lower the catalog `min_sustained_tps` values, but
+the autotune-static-v2 private key isn't in the repo, so a catalog
+re-sign wasn't possible this session. Ships now, defers a proper
+catalog re-sign (with lower gates) to a follow-up.
+
+## What to audit
+
+### 1. Consistency with the A2a/A1 relaxation pattern
+
+Now four eligibility gates are soft-signals: swap, rate-card-default,
+tps, ttft. Only thermal + hard structural gates (RAM, tier,
+runtime_status, demand.recommendable, signed benchmark admission)
+remain hard. Is this the right split? What's the general principle?
+
+Principle claim: soft = "provider-quality trade-off surfaced to
+operator"; hard = "either catalog admission or physical
+impossibility." Confirm this frames the split correctly.
+
+### 2. What does `min_sustained_tps` mean now?
+
+Semantically, `catalog.rows.<key>.bench_gate.min_sustained_tps` was
+originally "required warm-service TPS floor". Post-v1.7.9 it's
+"advisory — below this you get a warning." Should:
+- SPEC-023 update the field description to soft-signal semantics?
+- The field name change from `min_sustained_tps` to
+  `target_sustained_tps`? (Semantic drift makes it easy to
+  misinterpret later.)
+- Add a companion field like `hard_min_sustained_tps` if the network
+  ever wants a hard floor again?
+
+### 3. Buyer QoS contract implications
+
+Buyers may assume "if the network recommends a provider for model X,
+they meet catalog QoS gates." That's no longer true. Consider:
+- Is any buyer-side documentation making this assumption?
+- Does the gateway (buyer-facing) need to expose TPS warnings?
+- Rate-card-in-use identifies the tier the buyer pays for — soft-TPS
+  gate silently degrades that tier's actual delivery.
+
+### 4. Follow-up: catalog re-sign
+
+The user explicitly asked for the private key to end up in the repo.
+Task #39 tracks that. Once re-signed with lower gates, `.tpsBelowGate`
+and `.ttftAboveGate` warnings should rarely fire. But they'll be
+kept as safety nets. Confirm this evolution path makes sense.
+
+### 5. Test extremes
+
+`testDonorModeInheritsTPSAndTTFTRelaxation` uses TPS=1, TTFT=100_000ms.
+A realistic donor should still probably be filtered by some sanity
+gate (e.g. TPS < 0.5 = probably a broken provider). Is this test's
+extreme case actually the right behavior, or does it argue for a
+minimum-viable-TPS floor even in soft-signal mode?
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+- `specs/SPEC-023-installer-autotune-recommend.md`
+- `phase3-binary/dist/static/autotune-candidates.json`
+
+## Reply format
+
+```
+## ARCHITECT audit — v1.7.9
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```

--- a/specs/AUDIT_SPEC_023_V179_SOFT_GATES_CODE_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_V179_SOFT_GATES_CODE_PROMPT.md
@@ -1,0 +1,148 @@
+---
+role: code-audit
+version: 1.0
+date: 2026-07-03
+target_pr: v1.7.9 soft-signal TPS + TTFT eligibility gates (Track A5 Option B)
+lens: CODE — correctness, edge cases, coding errors
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# CODE audit — SPEC-023 v1.7.9 soft TPS + TTFT gates
+
+Audit for correctness bugs on the current diff. Report CRITICAL/HIGH/
+MEDIUM/LOW/INFO with file:line and concrete defect scenarios.
+
+## Context
+
+v1.7.8 M5 32GB Tier C install produced:
+- qwen3-coder-30b-a3b: TPS=23.4 (vs 25 gate), net=$0.0178/hr, `eligible=false`
+- gpt-oss-20b: TPS=16.7 (vs 30 gate), net=$0.0054/hr, `eligible=false`
+- llama-3.1-8b: TPS=23.4 (vs 20 gate ✓), net=$0.0020/hr (below $0.005 threshold)
+
+Every candidate had positive net income projections but was blocked by
+the CATALOG TPS/TTFT gate at
+`AutotuneRecommendEngine.isEligible` — a warm-service QoS target
+calibrated for M-Pro/M-Max hardware. M-Base Tier C sustains below-
+gate TPS, so all install-time recommendations get vetoed → donor mode
+→ drop-out cliff.
+
+Pattern precedent: v1.7.6 A2a relaxed `swapDetected` from hard-block
+to soft-signal + `.swapObservedUnderLoad` warning. Same principle
+here: TPS/TTFT are QoS aspirations, `expected_net_usd_per_hour >=
+paidThreshold` is the real financial gate.
+
+## The change
+
+At `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`:
+
+1. Two new warnings: `.tpsBelowGate = "tps_below_gate"` and
+   `.ttftAboveGate = "ttft_above_gate"`.
+
+2. `isEligible`:
+   ```swift
+   // Pre-v1.7.9:
+   guard benchmark.sustainedTPS >= candidate.benchGate.minSustainedTPS,
+         benchmark.ttftMS <= candidate.benchGate.max4KTTFTMS,
+         !benchmark.thermalThrottleDetected
+   else { return false }
+   // Post-v1.7.9:
+   return !benchmark.thermalThrottleDetected
+       && Self.cachedBenchmarkAdmitted(...)
+   ```
+
+3. `donorModeCompatible`: same relaxations, inheriting paid-tier
+   behavior.
+
+4. In `recommend()` post-selection warning-insertion loop (which
+   already fires warnings only for the actually-recommended
+   candidate per codex CODE-LOW-1 from v1.7.6), added:
+   ```swift
+   if let benchmark = request.benchmarks[target.catalogKey],
+      let candidateRow = request.candidateCatalog.rows[target.catalogKey] {
+       if benchmark.sustainedTPS < Double(candidateRow.benchGate.minSustainedTPS) {
+           warnings.insert(.tpsBelowGate)
+       }
+       if benchmark.ttftMS > candidateRow.benchGate.max4KTTFTMS {
+           warnings.insert(.ttftAboveGate)
+       }
+   }
+   ```
+
+Version bump: 1.7.8 → 1.7.9.
+
+## Tests added
+
+- `testTPSBelowGateNoLongerBlocksEligibilityButEmitsWarning`
+- `testTTFTAboveGateNoLongerBlocksEligibilityButEmitsWarning`
+- `testNoTPSWarningWhenBenchmarkClearsGate`
+- `testDonorModeInheritsTPSAndTTFTRelaxation`
+
+Full suite: **806/806 pass** (was 802, +4).
+
+## What to audit
+
+1. **Type coercion in warning comparison** — `benchmark.sustainedTPS`
+   is `Double`, `benchGate.minSustainedTPS` is `Int`. The cast
+   `Double(candidateRow.benchGate.minSustainedTPS)` should preserve
+   value. Any way an integer > 2^53 loses precision here? (Unlikely
+   for TPS gates < 100 but confirm.)
+
+2. **Warning scope correctness** — the tps/ttft warnings are inside
+   the same `attachTargets` loop that fires `.swapObservedUnderLoad`.
+   Confirm they only fire for the ACTUALLY-recommended candidate
+   (or donor fallback), not any lower-ranked scored candidate.
+
+3. **Interaction with `expected_net_usd_per_hour < paidThreshold`
+   filter** — recommended is nulled if net < $0.005/hr. In that case,
+   `recommended = nil`, so `attachTargets` becomes
+   `donorFallback.map(...)`. Do the tps/ttft warnings fire correctly
+   for the donor fallback too? Verify with the fallback path.
+
+4. **Edge case: benchmark absent** — `request.benchmarks[target.catalogKey]`
+   could be nil (e.g., if benchmarker returned .infeasible). Then no
+   tps/ttft warning fires. Correct — no benchmark = no measurement
+   to compare against.
+
+5. **Thermal throttle interaction** — thermal throttle is a hard-block
+   in `isEligible`. But the warning check runs after selection, and
+   selection excludes thermal-throttled candidates. So tps/ttft
+   warnings can't co-exist with thermal-throttle at scoring time.
+   Confirm this is the desired ordering.
+
+6. **Donor-mode fallback path** — `donorModeCompatible` no longer
+   checks TPS or TTFT. Is there ANY code path where a candidate would
+   have been rejected by TPS/TTFT in donor mode but is now admitted?
+   Confirm that's intentional (matches paid-tier philosophy).
+
+7. **Test `testDonorModeInheritsTPSAndTTFTRelaxation`** uses
+   extreme values (TPS=1, TTFT=100_000ms). Verify these still pass
+   the OTHER admission checks (RAM, tier, thermal, cached
+   benchmark). Otherwise the test asserts the wrong thing.
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+  (esp. `AutotuneRecommendWarning`, `isEligible`,
+  `donorModeCompatible`, warning-attach loop in `recommend()`)
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+- `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift`
+
+## Reply format
+
+```
+## CODE audit — v1.7.9
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```

--- a/specs/AUDIT_SPEC_023_V179_SOFT_GATES_SECURITY_PROMPT.md
+++ b/specs/AUDIT_SPEC_023_V179_SOFT_GATES_SECURITY_PROMPT.md
@@ -1,0 +1,99 @@
+---
+role: security-audit
+version: 1.0
+date: 2026-07-03
+target_pr: v1.7.9 soft-signal TPS + TTFT eligibility gates (Track A5)
+lens: SECURITY
+audit_bar: 0 CRITICAL, 0 HIGH, 0 MEDIUM. LOW/INFO acceptable if documented.
+---
+
+# SECURITY audit — v1.7.9 soft TPS + TTFT gates
+
+Audit for security-relevant defects on the current diff.
+
+## Context
+
+v1.7.9 relaxes two eligibility gates in
+`AutotuneRecommendEngine.isEligible` and
+`donorModeCompatible`:
+- `benchmark.sustainedTPS >= min_sustained_tps` → soft signal
+- `benchmark.ttftMS <= max_4k_ttft_ms` → soft signal
+
+Thermal throttle remains a hard block. The real financial gate
+(`expected_net_usd_per_hour >= $0.005/hr`) is unchanged; it's
+applied post-selection in `recommend()`.
+
+This is a CLIENT-side install-time recommendation change. Runtime
+billing is unchanged; coord's `RateFor` still authoritatively prices
+each session.
+
+## Security-relevant surfaces
+
+### 1. Economic exploitation via inflated eligibility
+
+Provider could try to serve under-nominal-quality inference and
+still get recommended. Consider:
+- Buyers get slower-than-catalog TPS from the provider. Is there
+  a channel by which the buyer OR the coord penalizes this at
+  billing time? (Coord bills per-token, not per-second, so provider
+  earns proportionally less — no financial harm to network.)
+- Reputation impact — do buyers observe "this provider is slow"
+  and gradient away? Depends on demand-rank feedback.
+- Does the `tps_below_gate` warning surface to any billing/routing
+  system that would reprice? (No — warning is client-side only.)
+
+### 2. Thermal-throttle asymmetry
+
+Thermal throttle stays hard-block, TPS/TTFT go soft. Is this the
+right split? Argument for:
+- Thermal-throttled TPS is unreliable — could rebound in production
+  and confuse routing.
+- TPS/TTFT below gate is a REAL, stable measurement — routing can
+  trust it and price accordingly.
+
+Confirm this reasoning holds under adversarial scenarios (e.g. a
+provider that oscillates in and out of thermal throttle to game
+the eligibility window).
+
+### 3. donor mode inheritance
+
+`donorModeCompatible` also drops TPS/TTFT checks. Any candidate
+that would have been rejected for donor mode is now admitted. Is
+there any adversarial case where a rogue provider abuses donor
+mode with grossly under-spec hardware? Donor mode pays no credits,
+so no financial exploit.
+
+### 4. Warning as trust signal
+
+`tps_below_gate` / `ttft_above_gate` warnings surface via
+`.warnings` array and stderr output. Not persisted to
+`last-recommendation.json` (that carries `probe_diagnostics`
+separately). Could an attacker suppress these warnings by
+tampering with the catalog SHA (already checked upstream via
+signature verify)?
+
+## Files to read
+
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`
+  (esp. `AutotuneRecommendWarning`, `isEligible`,
+  `donorModeCompatible`, warning-attach loop in `recommend()`)
+
+## Reply format
+
+```
+## SECURITY audit — v1.7.9
+
+CRITICAL: <count>
+HIGH: <count>
+MEDIUM: <count>
+LOW: <count>
+INFO: <count>
+
+### CRITICAL
+[if none: "None."]
+### HIGH
+### MEDIUM
+### LOW
+### INFO
+### Verdict
+```


### PR DESCRIPTION
## Summary

Closes the **fifth** drop-out mode on M5 32GB Tier C — the "catalog gate calibrated for larger hardware" cliff. Operator directive: *"we cannot accept situations where 32gb mac is not eligible."*

## Root cause

v1.7.8 install measured on M5 (with correct TPS math from PR #333):

| Candidate | Measured TPS | Catalog gate | Net USD/hr | Eligible |
|---|:---:|:---:|:---:|:---:|
| qwen3-coder-30b-a3b | 23.4 | ≥ 25 | $0.0178 | ❌ TPS |
| gpt-oss-20b | 16.7 | ≥ 30 | $0.0054 | ❌ TPS |
| llama-3.1-8b | 23.4 | ≥ 20 ✓ | $0.0020 | ❌ net |

Every candidate had positive net income but was hard-blocked by [`AutotuneRecommendEngine.isEligible`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L1023) — the catalog's TPS/TTFT gates are warm-service QoS targets calibrated for M-Pro/M-Max hardware. M-Base Tier C sits below these gates.

## The "right" fix requires a catalog re-sign

The clean fix is to lower `min_sustained_tps` values in the Ed25519-signed catalog. But the `streamvc-autotune-static-v2` private key isn't in the repo, so the re-sign path isn't available this session. Task #39 tracks the follow-up: rotate the keypair, commit the private key to the repo (per operator's directive), re-sign the catalog with M-Base-realistic gates.

## The client-side fix that ships this session (Option B)

Same pattern as v1.7.6 A2a (swap tolerance): **treat TPS and TTFT as soft signals**. The real financial gate — `expected_net_usd_per_hour >= $0.005/hr` — is unchanged. It naturally filters out truly-unprofitable candidates.

Changes at [`AutotuneRecommend.swift`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift):

- Two new warnings: [`.tpsBelowGate`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L50), [`.ttftAboveGate`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L56)
- [`isEligible`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L1023): drop TPS + TTFT guards. Keep `thermalThrottleDetected` as hard-block.
- [`donorModeCompatible`](phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift#L1064): same relaxation.
- Warning-attach loop: insert `tpsBelowGate` / `ttftAboveGate` for the actually-recommended candidate (matches v1.7.6 CODE-LOW-1 scope discipline).

## Expected M5 outcome

- **qwen3-coder-30b-a3b**: recommended paid, net $0.0178/hr, `tps_below_gate` warning (23.4 vs 25)
- gpt-oss-20b: eligible backup, net $0.0054/hr, `tps_below_gate` warning (16.7 vs 30)
- llama-3.1-8b: eligible on TPS, nulled by `.recommendationBelowThreshold` ($0.0020 < $0.005)

## 3-lane codex audit — R1 convergence

| Lane | CRITICAL | HIGH | MEDIUM | LOW | INFO | Verdict |
|---|:---:|:---:|:---:|:---:|:---:|---|
| CODE | 0 | 0 | 0 | 0 | 5 | ✅ **fully clean** |
| SECURITY | 0 | 0 | 0 | 0 | 4 | ✅ **fully clean** |
| ARCHITECT | 0 | 0 | 0 | 2 | 4 | ✅ PASS |

Per `feedback-stop-iterating-on-low-audits`: R1 converged. **No R2.**

Audit prompts:
- [`specs/AUDIT_SPEC_023_V179_SOFT_GATES_CODE_PROMPT.md`](specs/AUDIT_SPEC_023_V179_SOFT_GATES_CODE_PROMPT.md)
- [`specs/AUDIT_SPEC_023_V179_SOFT_GATES_SECURITY_PROMPT.md`](specs/AUDIT_SPEC_023_V179_SOFT_GATES_SECURITY_PROMPT.md)
- [`specs/AUDIT_SPEC_023_V179_SOFT_GATES_ARCHITECT_PROMPT.md`](specs/AUDIT_SPEC_023_V179_SOFT_GATES_ARCHITECT_PROMPT.md)

### LOW deferrals shipped

- **ARCH-LOW-1**: SPEC-023 v0.1 still describes TPS/TTFT/swap as hard gates. Update to advisory-QoS terminology deferred to a SPEC-023 v0.2 PR.
- **ARCH-LOW-2**: `min_sustained_tps` naming carries semantic drift (now advisory, not a hard minimum). Rename would break signed catalog compatibility; SPEC should call out semantics. Future hard-floor policy should use a distinct field name (`hard_min_sustained_tps`).

## Tests

- `testTPSBelowGateNoLongerBlocksEligibilityButEmitsWarning`
- `testTTFTAboveGateNoLongerBlocksEligibilityButEmitsWarning`
- `testNoTPSWarningWhenBenchmarkClearsGate`
- `testDonorModeInheritsTPSAndTTFTRelaxation`

Full suite: **806/806 pass** (was 802, +4).

## No regression for hardware already clearing gates

Any provider whose measured TPS/TTFT already passed under v1.7.8 still passes under v1.7.9 (no soft-signal warning fires). Warnings only surface for candidates that miss their catalog gate.

## Test plan

- [x] `swift build --product macprovider-cli` clean at v1.7.9
- [x] `swift test --filter AutotuneRecommendTests`: **71/71 pass**
- [x] Full suite: **806/806 pass** (7 skipped, pre-existing)
- [x] 3-lane codex audit R1 converged at 0/0/0
- [ ] Post-merge: `gh workflow run release.yml -f version=v1.7.9`
- [ ] Post-release: `curl get.streamvc.live/install.sh | bash` on M5 32GB produces **paid recommendation** for qwen3-coder-30b-a3b or gpt-oss-20b with `tps_below_gate` warning surfaced.

## Follow-up (Task #39, separate PR)

Rotate `autotune-static-v2` → `v3` keypair. Commit the v3 private key to the repo. Re-sign the catalog with lower `min_sustained_tps` values reflecting actual M-Base measurements. Once landed, `.tps_below_gate` becomes a rare safety-net warning rather than the common case for M-Base providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
