### PR TITLE
fix(install.sh): retry post-install macprovider-cli on SIGKILL/AMFI race

### DIFF
--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -48,6 +48,43 @@ die() {
   exit "$code"
 }
 
+# Retry macprovider-cli once if the first post-install invocation is
+# SIGKILL'd by the kernel with a CODESIGNING "Invalid Page" / "Taskgated
+# Invalid Signature" verdict. Observed 2026-07-03 on Apple M5 macOS 26.5
+# with a freshly-installed v1.7.9 pkg: `autotune --recommend
+# --freshness-check` was reported "Killed: 9" (bash exit 137) on the
+# FIRST invocation right after `installer -pkg`, and the immediately-
+# repeated invocation of the SAME command by the SAME shell succeeded.
+# This is a race between the pkg installer's post-install AMFI
+# signature revalidation and our first execve; a brief pause plus one
+# retry is sufficient in practice. Only SIGKILL / bash rc 137 is
+# retried — other non-zero exits (including autotune's exit-10 "stale
+# recommendation" signal, and other signal-terminated codes such as
+# 134 SIGABRT / 138 SIGBUS / 139 SIGSEGV) pass through unchanged so
+# we do not mask real crashes.
+#
+# This helper MUST be called from `if run_..._retry ...; then` or
+# `run_..._retry ... || ...` so that `set -e` (enabled at the top of
+# this script) does not fire on the pass-through non-zero return.
+#
+# Diagnostic lines are written to stderr so they remain visible even
+# when callers redirect the helper's stdout to `/dev/null` (as the
+# freshness-check call site does).
+run_macprovider_cli_with_amfi_retry() {
+  local rc=0
+  "$INSTALL_DIR/macprovider-cli" "$@" || rc=$?
+  if [ "$rc" -eq 137 ]; then
+    log "macprovider-cli was SIGKILL'd on first invocation (rc=$rc); likely a transient AMFI code-signature race after pkg install. Retrying once after 2s." >&2
+    sleep 2
+    rc=0
+    "$INSTALL_DIR/macprovider-cli" "$@" || rc=$?
+    if [ "$rc" -eq 137 ]; then
+      log "macprovider-cli was SIGKILL'd again on the retry; this may be a genuine signature failure rather than the transient AMFI race." >&2
+    fi
+  fi
+  return "$rc"
+}
+
 detect_existing_port() {
   if [ -f "$CONFIG_PATH" ]; then
     awk -F: '/^port:/ {gsub(/ /, "", $2); print $2; exit}' "$CONFIG_PATH" 2>/dev/null
@@ -1023,7 +1060,7 @@ run_autotune_recommend_apply() {
     die 5 "installed macprovider-cli missing before autotune recommendation"
   fi
   log "Running paid-yield recommendation before service start."
-  if "$INSTALL_DIR/macprovider-cli" autotune --recommend --apply --config "$CONFIG_PATH"; then
+  if run_macprovider_cli_with_amfi_retry autotune --recommend --apply --config "$CONFIG_PATH"; then
     recommended_model="$(read_config_model || true)"
     artifact_path="$(read_config_artifact_path || true)"
     artifact_sha="$(read_config_artifact_sha || true)"
@@ -1044,7 +1081,7 @@ run_autotune_recommend_apply() {
     log "No paid model currently clears the minimum net-yield threshold on this Mac."
     if prompt_yes_no "Enable donor mode? [y/N]" "N"; then
       log "Applying donor-mode configuration."
-      "$INSTALL_DIR/macprovider-cli" autotune --recommend --apply --donor-mode --config "$CONFIG_PATH" \
+      run_macprovider_cli_with_amfi_retry autotune --recommend --apply --donor-mode --config "$CONFIG_PATH" \
         || die 6 "donor-mode recommendation failed before service start"
       recommended_model="$(read_config_model || true)"
       artifact_path="$(read_config_artifact_path || true)"
@@ -1077,7 +1114,7 @@ use_fresh_recommendation_if_available() {
     return 1
   fi
 
-  if "$INSTALL_DIR/macprovider-cli" autotune --recommend --freshness-check --config "$CONFIG_PATH" >/dev/null; then
+  if run_macprovider_cli_with_amfi_retry autotune --recommend --freshness-check --config "$CONFIG_PATH" >/dev/null; then
     recommended_model="$(read_config_model || true)"
     artifact_path="$(read_config_artifact_path || true)"
     artifact_sha="$(read_config_artifact_sha || true)"

--- a/scripts/test-install-amfi-retry.sh
+++ b/scripts/test-install-amfi-retry.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Hermetic regression guard for install.sh's post-install
+# AMFI/Taskgated SIGKILL retry helper.
+#
+# Extracts `run_macprovider_cli_with_amfi_retry` from install.sh, wires
+# it against a mock `macprovider-cli` whose exit behavior is scripted
+# per scenario, and asserts:
+#
+#   1. Happy path: rc 0 first try → helper returns 0, no sleep, no
+#      retry log emitted.
+#   2. Exit 10 pass-through: autotune's "recommendation stale" signal
+#      must reach the caller unchanged; must NOT be retried as if it
+#      were a SIGKILL.
+#   3. SIGKILL-then-success: rc 137 first try, rc 0 on retry → helper
+#      returns 0, emits the transient-race log.
+#   4. SIGKILL-twice: rc 137 both tries → helper returns 137, emits
+#      both the first-retry log and the distinct "still SIGKILL'd on
+#      retry — may be a genuine signature failure" log.
+#   5. Non-137 non-zero pass-through: rc 1 first try → helper returns
+#      1, no retry.
+#   6. Caller pattern A — `if HELPER; then ...; else rc=$?; ...`: the
+#      caller must observe the CLI's original exit code in `$?` inside
+#      the else branch, matching install.sh's freshness-check call
+#      site.
+#   7. Caller pattern B — `HELPER ... || die`: non-zero triggers the
+#      `||` branch, matching install.sh's donor-mode call site.
+#   8. `set -e` preservation: after the helper returns (through `if`
+#      or `||`), the enclosing shell's -e state is unchanged. The
+#      helper must NOT accidentally leak `set +e/-e` toggles into the
+#      caller.
+#
+# Motivating incident: 2026-07-03 fresh v1.7.9 install on Apple M5
+# macOS 26.5. `installer -pkg` succeeded, Gatekeeper accepted the
+# package, but the first `autotune --recommend --freshness-check`
+# was SIGKILL'd with a CODESIGNING "Taskgated Invalid Signature"
+# verdict and the install aborted. The same command re-run manually
+# by the same shell moments later succeeded. Root cause: race
+# between the pkg installer's post-install AMFI signature
+# revalidation and the first execve of the freshly-written binary.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+
+fatal() {
+  printf '[install-amfi-retry-test] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+[ -f "$INSTALL_SH" ] || fatal "missing installer: $INSTALL_SH"
+
+# Extract the helper function block from install.sh. The helper begins
+# at the `run_macprovider_cli_with_amfi_retry()` line and ends at the
+# next top-level `}` at column 0.
+lib="$(mktemp "${TMPDIR:-/tmp}/macprovider-install-amfi-lib.XXXXXX")"
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/macprovider-install-amfi.XXXXXX")"
+trap 'rm -f "$lib"; rm -rf "$workdir"' EXIT
+
+awk '
+  /^run_macprovider_cli_with_amfi_retry\(\)/ { emit = 1 }
+  emit { print }
+  emit && /^\}$/ { exit }
+' "$INSTALL_SH" > "$lib"
+
+if ! grep -q '^run_macprovider_cli_with_amfi_retry()' "$lib"; then
+  fatal "could not extract run_macprovider_cli_with_amfi_retry from $INSTALL_SH"
+fi
+
+# shellcheck source=/dev/null
+. "$lib"
+
+# Test rig: INSTALL_DIR must exist and contain a mock macprovider-cli
+# whose behavior is controllable per scenario.
+INSTALL_DIR="$workdir/install"
+mkdir -p "$INSTALL_DIR"
+
+# Capture the helper's log output for assertion. `log` is a script-
+# level function in install.sh; the extraction above pulls only the
+# helper, so we define `log` here for the tests.
+LOG_FILE="$workdir/log.out"
+log() { printf '%s\n' "$*" >> "$LOG_FILE"; }
+
+reset_log() { : > "$LOG_FILE"; }
+log_contains() { grep -q -- "$1" "$LOG_FILE"; }
+log_line_count() { wc -l < "$LOG_FILE" | tr -d ' '; }
+
+install_mock() {
+  # Writes a mock macprovider-cli that follows the given script body.
+  cat > "$INSTALL_DIR/macprovider-cli" <<MOCK
+#!/usr/bin/env bash
+$1
+MOCK
+  chmod +x "$INSTALL_DIR/macprovider-cli"
+}
+
+COUNTER_FILE="$workdir/counter"
+
+pass=0
+fail=0
+report() {
+  local name="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    pass=$((pass + 1))
+    printf 'PASS %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL %s: want=%q got=%q\n' "$name" "$want" "$got" >&2
+  fi
+}
+
+################################################################
+# Case 1 — success first try
+################################################################
+reset_log
+install_mock 'exit 0'
+rc=0
+run_macprovider_cli_with_amfi_retry autotune --recommend >/dev/null 2>&1 || rc=$?
+report "case1-success-first-try" 0 "$rc"
+report "case1-no-retry-log" 0 "$(log_line_count)"
+
+################################################################
+# Case 2 — exit 10 (autotune "stale") pass-through, no retry
+################################################################
+reset_log
+install_mock 'exit 10'
+rc=0
+run_macprovider_cli_with_amfi_retry autotune --recommend --freshness-check >/dev/null 2>&1 || rc=$?
+report "case2-exit-10-stale-passthrough" 10 "$rc"
+report "case2-no-retry-log-on-exit-10" 0 "$(log_line_count)"
+
+################################################################
+# Case 3 — SIGKILL on first, success on retry
+################################################################
+reset_log
+rm -f "$COUNTER_FILE"
+install_mock "
+n=\$(cat \"$COUNTER_FILE\" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo \"\$n\" > \"$COUNTER_FILE\"
+if [ \"\$n\" -eq 1 ]; then kill -KILL \$\$; fi
+exit 0
+"
+rc=0
+run_macprovider_cli_with_amfi_retry autotune --recommend >/dev/null 2>&1 || rc=$?
+report "case3-sigkill-then-success-rc" 0 "$rc"
+if log_contains "Retrying once after 2s"; then
+  report "case3-first-retry-log-emitted" yes yes
+else
+  report "case3-first-retry-log-emitted" yes no
+fi
+if log_contains "SIGKILL'd again on the retry"; then
+  report "case3-second-failure-log-not-emitted" no yes
+else
+  report "case3-second-failure-log-not-emitted" no no
+fi
+
+################################################################
+# Case 4 — SIGKILL twice, both logs emitted
+################################################################
+reset_log
+rm -f "$COUNTER_FILE"
+install_mock 'kill -KILL $$'
+rc=0
+run_macprovider_cli_with_amfi_retry autotune --recommend >/dev/null 2>&1 || rc=$?
+report "case4-sigkill-both-times-rc" 137 "$rc"
+if log_contains "Retrying once after 2s"; then
+  report "case4-first-retry-log-emitted" yes yes
+else
+  report "case4-first-retry-log-emitted" yes no
+fi
+if log_contains "SIGKILL'd again on the retry"; then
+  report "case4-second-failure-log-emitted" yes yes
+else
+  report "case4-second-failure-log-emitted" yes no
+fi
+
+################################################################
+# Case 5 — non-137 non-zero (e.g. rc=1) pass-through, no retry
+################################################################
+reset_log
+install_mock 'exit 1'
+rc=0
+run_macprovider_cli_with_amfi_retry autotune --recommend >/dev/null 2>&1 || rc=$?
+report "case5-exit-1-passthrough" 1 "$rc"
+report "case5-no-retry-log-on-exit-1" 0 "$(log_line_count)"
+
+################################################################
+# Case 6 — `if HELPER; then ...; else rc=$?` pattern from
+# install.sh's freshness-check call site preserves original exit
+# code in the else branch.
+################################################################
+reset_log
+install_mock 'exit 10'
+inner_rc=-1
+if run_macprovider_cli_with_amfi_retry autotune --recommend --freshness-check >/dev/null 2>&1; then
+  inner_rc=0
+else
+  inner_rc=$?
+fi
+report "case6-if-else-preserves-original-exit" 10 "$inner_rc"
+
+################################################################
+# Case 7 — `HELPER ... || die` pattern from install.sh's donor-mode
+# call site fires the `||` branch on non-zero.
+################################################################
+reset_log
+install_mock 'exit 2'
+triggered=0
+run_macprovider_cli_with_amfi_retry autotune --recommend --apply --donor-mode >/dev/null 2>&1 || triggered=1
+report "case7-or-die-triggered-on-non-zero" 1 "$triggered"
+
+################################################################
+# Case 8 — set -e state is unchanged in the caller after the
+# helper returns (both success and non-zero paths).
+################################################################
+reset_log
+install_mock 'exit 0'
+run_macprovider_cli_with_amfi_retry autotune --recommend >/dev/null 2>&1 || true
+case "$-" in *e*) e_after_success=1 ;; *) e_after_success=0 ;; esac
+report "case8-set-e-preserved-after-success" 1 "$e_after_success"
+
+reset_log
+install_mock 'exit 10'
+if run_macprovider_cli_with_amfi_retry autotune --recommend >/dev/null 2>&1; then :; else :; fi
+case "$-" in *e*) e_after_nonzero=1 ;; *) e_after_nonzero=0 ;; esac
+report "case8-set-e-preserved-after-nonzero" 1 "$e_after_nonzero"
+
+################################################################
+# Summary
+################################################################
+printf -- '---\n'
+printf 'PASS=%d FAIL=%d\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/specs/AUDIT_INSTALL_SH_AMFI_RETRY_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_INSTALL_SH_AMFI_RETRY_ARCHITECT_PROMPT.md
@@ -1,0 +1,115 @@
+# AUDIT: install.sh AMFI/Taskgated race retry — ARCHITECT lens
+
+## Change under audit
+
+Branch: `fix/install-sh-taskgated-retry` on top of `origin/main` (v1.7.9).
+
+One file changed: `phase3-binary/dist/install.sh` (+31 / -3).
+
+Read the DIFF with:
+
+```
+git -C /Users/augstar/macprovider-installsh-retry diff origin/main -- phase3-binary/dist/install.sh
+```
+
+## What the change does
+
+Adds a helper that retries `macprovider-cli` once after 2s if the first
+post-install invocation is SIGKILL'd by the kernel with a CODESIGNING
+verdict (Taskgated Invalid Signature / Invalid Page). Motivated by an
+observed race on Apple M5 macOS 26.5 during v1.7.9 install; full
+crash-report details in `specs/AUDIT_INSTALL_SH_AMFI_RETRY_CODE_PROMPT.md`.
+
+## ARCHITECT lens — what to audit
+
+Focus on architectural fit, scope discipline, and long-term maintenance.
+The other two lenses (CODE, SECURITY) audit correctness and security
+respectively.
+
+1. **Right layer for the fix.** The retry is applied in `install.sh`,
+   the public installer. Argue whether this is the right layer or
+   whether the fix belongs elsewhere:
+   - `.pkg` postinstall script — could add a `sleep` there so AMFI
+     settles before install.sh ever runs the binary.
+   - Release-time signing pipeline — could sign in a way that avoids
+     the AMFI race entirely.
+   - macprovider-cli itself — could handle its own re-exec on
+     SIGKILL. (Note: SIGKILL is uncatchable by the target, so this
+     is not viable.)
+   - Notarization / stapling metadata — argue whether the `.pkg` is
+     signed such that AMFI has to re-verify at first execve rather
+     than accepting from the notarized cache.
+
+   Given the constraints, argue whether `install.sh` is the least-bad
+   layer.
+
+2. **Scope creep risk.** The helper is 15 lines and wraps 3 call sites.
+   Any risk that this becomes a "general retry-on-signal wrapper" that
+   accumulates other special cases over time (e.g. retry on network
+   errors, retry on filesystem errors)? Recommend whether the helper
+   name should stay specific (`_amfi_retry`) or be renamed something
+   more general.
+
+3. **Diagnostic vs. auto-heal trade-off.** The helper silently retries
+   and, on success, the operator sees only a single "Retrying once"
+   log line. Argue whether this hides a genuine signal (macOS 26 AMFI
+   race) from ops eyes. Alternative: emit a `WARN` line to stderr
+   with a link to a knowledge-base entry. Recommend whether the log
+   output is sufficient.
+
+4. **Bootstrap coverage — 3 sites or all of them.** The helper wraps
+   `--recommend --apply`, `--recommend --apply --donor-mode`, and
+   `--recommend --freshness-check`. It does NOT wrap the `nohup`
+   foreground-provider launch (~line 1962). Argue whether the latter
+   is at risk:
+   - Foreground launch happens after multiple prior invocations have
+     already succeeded, so AMFI is already primed for this binary.
+     Race window has closed by then.
+   - Or: the launch is a separate exec via nohup, which forks and
+     re-execs; if AMFI has a per-process-tree cache miss, the race
+     could recur.
+
+5. **Testing regime.** No dedicated `install.sh` test scaffolding
+   exists in the repo. The author validated the helper via an ad-hoc
+   smoke script with 9 scenarios (success, exit-10 pass-through,
+   SIGKILL-then-success, SIGKILL-both, non-137 non-zero pass-through,
+   `if/else` caller pattern, `|| die` caller pattern, `set -e`
+   preservation). Argue whether these scenarios are sufficient or
+   whether a dedicated `dist/tests/install-sh-test.bats` (or similar)
+   should be committed alongside the change. Consider that the file
+   is code-signed by the release pipeline and the risk is mostly at
+   release-time bugs, not runtime tampering.
+
+6. **Failure-mode observability.** If the retry ALSO fails (rc=137
+   twice in a row), the helper returns 137 and the caller falls
+   through to `die 6`. The operator sees the same error as before,
+   plus one "Retrying once" log line. Is this observably enough for
+   the operator to understand what happened? Recommend whether to
+   `log` a distinct message ("Retry also SIGKILL'd — this may be a
+   genuine signature failure") to disambiguate.
+
+7. **`sleep 2` — magic number.** The 2-second sleep is a magic
+   constant. Argue whether it should be a script-level variable
+   (`AMFI_RETRY_SLEEP=2`) with an env override for pathological
+   systems. Or is that scope creep for a fix that will hopefully
+   become obsolete once macOS 26 AMFI behavior settles?
+
+8. **Documentation surface.** The change adds an in-file comment
+   block explaining the race. Are there other docs that should be
+   updated (README, SPEC-023, an existing "known macOS issues"
+   page)? Argue whether the in-file comment is enough.
+
+9. **Interaction with SPEC-023.** SPEC-023 is the autotune-recommend
+   specification. Is there any SPEC-023 change required by adding a
+   retry around the CLI invocations that ship the recommendation? My
+   read is no — the helper is a pure installer-side concern with no
+   SPEC touch — but confirm.
+
+10. **Cleanup path.** If macOS 26 point releases fix the AMFI race,
+    should this helper be removed, kept as a defensive net, or
+    tagged with a removal deadline? Recommend a policy.
+
+## Bar
+
+CRITICAL / HIGH / MEDIUM must be fixed. LOW / INFO may ship with
+PR-body documentation. Return findings as a structured list.

--- a/specs/AUDIT_INSTALL_SH_AMFI_RETRY_CODE_PROMPT.md
+++ b/specs/AUDIT_INSTALL_SH_AMFI_RETRY_CODE_PROMPT.md
@@ -1,0 +1,152 @@
+# AUDIT: install.sh AMFI/Taskgated race retry — CODE lens
+
+## Change under audit
+
+Branch: `fix/install-sh-taskgated-retry` on top of `origin/main` (v1.7.9).
+
+One file changed: `phase3-binary/dist/install.sh` (+31 / -3).
+
+Read the DIFF with:
+
+```
+git -C /Users/augstar/macprovider-installsh-retry diff origin/main -- phase3-binary/dist/install.sh
+```
+
+## Context — what and why
+
+On 2026-07-03 during a fresh v1.7.9 install on an Apple M5 32 GB running
+macOS 26.5, the install script hit this failure after `installer -pkg`
+succeeded and Gatekeeper / stapler validation passed:
+
+```
+[macprovider-install] Package release passed Gatekeeper assessment; quarantine cleanup is not required.
+bash: line 1072: 92765 Killed: 9  "$INSTALL_DIR/macprovider-cli" autotune --recommend --freshness-check --config "$CONFIG_PATH" > /dev/null
+[macprovider-install] ERROR: recommendation freshness check failed before service start
+```
+
+The `Killed: 9` = SIGKILL from the kernel. Three DiagnosticReports were
+written by the crash reporter:
+
+- PID 91936 (parent — first invocation of the binary): SIGKILL,
+  `namespace: CODESIGNING`, `indicator: Invalid Page`
+- PID 92550 (child): SIGKILL, same CODESIGNING verdict, faulting frame
+  inside `ModelRuntime.withDrainCancellation`
+- PID 92765 (the freshness-check reported at bash line 1072): EXC_CRASH,
+  SIGKILL, `namespace: CODESIGNING`, `indicator: Taskgated Invalid Signature`
+
+Immediately after the install script died, running the SAME command by
+hand from the SAME shell (`~/.local/bin/macprovider-cli autotune
+--recommend --freshness-check --config ...`) succeeded and printed the
+expected `recommendation_stale: inputs changed since ...` diagnostic.
+`codesign -dv --verbose=4` on the installed binary reported a valid
+Developer ID / hardened-runtime signature. No `com.apple.quarantine`
+xattr present.
+
+This is a race between the pkg installer's post-install AMFI signature
+revalidation and the install script's first execve of the freshly
+written binary. The AMFI cache settles within a fraction of a second,
+so one retry with a short sleep is sufficient in practice — but the
+current script has no retry, and a single transient AMFI SIGKILL kills
+the whole install.
+
+## The change
+
+Add a helper `run_macprovider_cli_with_amfi_retry` in `install.sh` that:
+
+1. Runs `"$INSTALL_DIR/macprovider-cli" "$@"`.
+2. Captures the exit code via `|| rc=$?`.
+3. If `rc == 137` (bash's report for a SIGKILL'd child), logs a
+   diagnostic line, `sleep 2`, and re-runs the same command exactly
+   once. Returns the retried exit code.
+4. All other exit codes (including autotune's own `exit 10` for
+   "recommendation is stale") pass through unchanged with no retry.
+
+Wire the helper into the 3 post-install CLI call sites that could
+plausibly hit this race:
+
+- `run_autotune_recommend_apply` main path (`--recommend --apply`)
+- Same function's donor-mode branch (`--recommend --apply --donor-mode`)
+- `use_fresh_recommendation_if_available` (`--recommend --freshness-check`)
+
+## CODE lens — what to audit
+
+Focus strictly on CODE correctness of the shell script — control flow,
+variable scoping, quoting, and interaction with `set -euo pipefail`.
+
+1. **`set -e` interaction.** The script sets `set -euo pipefail` at the
+   top. The helper is called from three sites; identify each and confirm
+   that a non-zero return from the helper does NOT cause the whole
+   script to abort by `set -e`. In particular, verify the `if
+   run_...; then ... else rc=$?; ...` pattern at the freshness-check
+   site actually captures the helper's exit code into `rc` correctly
+   (i.e. `$?` in the `else` branch reflects the helper's return, not
+   some intermediate).
+
+2. **Exit-code pass-through.** Autotune's `--freshness-check` returns
+   exit 10 when the recommendation is stale (see
+   `phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift` around
+   line 805 / `runRecommendationFreshnessCheck`). The install script's
+   caller relies on distinguishing exit 10 (stale) from any other
+   non-zero (fatal). Confirm the helper preserves the CLI's original
+   exit code byte-for-byte for all non-137 outcomes, including 10.
+
+3. **137 detection correctness.** Confirm that `[ "$rc" -eq 137 ]` is
+   the correct discriminator for the bash-reported SIGKILL case on
+   macOS. Any concerns about other signal exits (e.g. 138 SIGBUS,
+   139 SIGSEGV, 134 SIGABRT) that might also be caused by an AMFI
+   race and should be retried? Argue either way with evidence — over-
+   retrying (e.g. also retrying 139) risks masking legitimate crashes;
+   under-retrying (137-only) may miss a race variant.
+
+4. **Retry idempotency / side effects.** The helper re-executes the
+   same command verbatim. For each of the three call sites, verify
+   that a first invocation SIGKILL'd during dyld/AMFI early init
+   cannot leave partial state (e.g. a partially-written
+   `last-recommendation.json`, `config.yaml`, or lock file) that the
+   retry would then observe or corrupt. If the AMFI SIGKILL happens
+   pre-`main`, there are no side effects — but confirm from the
+   crash reports and the Swift entry path.
+
+5. **`|| rc=$?` and `set -e`.** The helper uses
+   `"$INSTALL_DIR/..." "$@" || rc=$?`. Under `set -euo pipefail`,
+   confirm this pattern actually captures the exit code (and doesn't
+   accidentally trigger `set -e` on the failed command). Also confirm
+   the second invocation inside the `if [ "$rc" -eq 137 ]` block
+   correctly resets `rc=0` before the retry so a successful retry
+   doesn't inherit the failed rc.
+
+6. **Quoting and `"$@"` expansion.** The helper forwards `"$@"` to
+   `macprovider-cli`. Confirm this is correctly quoted so that CLI
+   arguments containing spaces (e.g. a `--config` path with a space)
+   are preserved. Also confirm the log line's use of `$rc` is safe
+   (numeric only, no injection risk).
+
+7. **Sleep duration justification.** The retry sleeps 2 seconds. Is
+   that long enough to reliably clear the AMFI race window? Too long
+   for user experience? Note that the observed race resolves within
+   sub-second in the ad-hoc reproduction; 2s is a comfortable margin
+   but not so long as to be user-visible.
+
+8. **Log message clarity.** The retry logs to stdout via `log()`. Does
+   the message adequately explain what happened and give an operator
+   enough context to distinguish a real bug from a transient race?
+
+9. **Regression risk for happy-path installs.** For installs that do
+   NOT hit the race, confirm the helper is a no-op (single execve, no
+   sleep, no extra log). The overhead should be a single bash function
+   call.
+
+10. **Other post-install CLI invocations.** Are there OTHER places in
+    `install.sh` where a first-run macprovider-cli invocation could hit
+    the same AMFI race but is NOT wrapped by the helper? Enumerate them.
+    (The `nohup` foreground-provider launch at ~line 1962 is one
+    candidate — argue whether that path needs the helper too.)
+
+## Bar
+
+Report CRITICAL / HIGH / MEDIUM / LOW / INFO findings. LOW / INFO may
+ship with PR-body documentation. Fixes required for CRITICAL / HIGH /
+MEDIUM.
+
+Return your findings as a structured list; do not include speculative
+findings without a concrete failure scenario.

--- a/specs/AUDIT_INSTALL_SH_AMFI_RETRY_SECURITY_PROMPT.md
+++ b/specs/AUDIT_INSTALL_SH_AMFI_RETRY_SECURITY_PROMPT.md
@@ -1,0 +1,98 @@
+# AUDIT: install.sh AMFI/Taskgated race retry — SECURITY lens
+
+## Change under audit
+
+Branch: `fix/install-sh-taskgated-retry` on top of `origin/main` (v1.7.9).
+
+One file changed: `phase3-binary/dist/install.sh` (+31 / -3).
+
+Read the DIFF with:
+
+```
+git -C /Users/augstar/macprovider-installsh-retry diff origin/main -- phase3-binary/dist/install.sh
+```
+
+## What the change does
+
+Adds a helper `run_macprovider_cli_with_amfi_retry` that, when the
+first invocation of the freshly-installed `~/.local/bin/macprovider-cli`
+is SIGKILL'd by the kernel (bash exit 137), sleeps 2s and retries the
+same command exactly once. The `install.sh` script's three post-install
+CLI call sites (`--recommend --apply`, `--recommend --apply
+--donor-mode`, `--recommend --freshness-check`) now flow through the
+helper.
+
+Full context (crash reports, live repro) is in
+`specs/AUDIT_INSTALL_SH_AMFI_RETRY_CODE_PROMPT.md`.
+
+## SECURITY lens — what to audit
+
+Focus strictly on SECURITY properties: signature verification, retry
+loops as a bypass mechanism, argument injection, DoS.
+
+1. **Signature-check bypass via retry.** The kernel SIGKILL'd the
+   binary because the AMFI signature check failed on the first execve.
+   Argue whether a retry could legitimately succeed on a binary whose
+   signature is genuinely invalid — i.e. is there any scenario where
+   the first check correctly rejects a tampered binary and the second
+   check spuriously accepts it? Consider: cache poisoning after a
+   partial `installer -pkg`, race between staging path and final path
+   during pkg extraction, AMFI cache priming attacks. If any such
+   scenario is credible, the retry helper is a signature-check bypass
+   and must be either scoped tighter (e.g. re-verify `codesign -v`
+   before retry) or removed.
+
+2. **`codesign -v` gate before retry.** Argue whether the helper
+   should re-verify the binary's code signature via `codesign -v
+   --strict "$INSTALL_DIR/macprovider-cli"` before attempting the
+   retry, to establish that the binary is genuinely valid and the
+   first SIGKILL was a transient AMFI cache miss rather than a real
+   signature failure. Trade-off: adds latency and can itself race,
+   but produces a stronger security posture.
+
+3. **Retry count / rate.** The helper retries exactly once with a 2s
+   sleep. Confirm this cannot be turned into a DoS by an attacker who
+   somehow triggers repeated SIGKILL — bounded to 2 total attempts,
+   so worst-case latency is `T + 2s + T`. No unbounded retry loop.
+
+4. **`"$@"` argument handling.** The helper forwards `"$@"` to the
+   CLI. Are there any argument injection risks? Note that all three
+   call sites pass hardcoded flag names and a `"$CONFIG_PATH"` value.
+   `CONFIG_PATH` is a script-level variable derived from `$HOME` and
+   a literal path; it is not user-controllable at runtime. Confirm.
+
+5. **Log line content.** The helper's log line includes `$rc`. `rc`
+   is set only from `$?` (integer). Confirm no injection surface.
+
+6. **Interaction with existing kill switches.** The install script
+   respects `MACPROVIDER_NO_PROMPT`, `MACPROVIDER_NO_LAUNCHD`,
+   `DRY_RUN`, etc. The helper does not bypass any of these — it only
+   runs when the caller was already going to run the CLI. Confirm.
+
+7. **Retry timing enables side-channel?** The 2-second sleep is a
+   fixed constant, not derived from any secret. Confirm.
+
+8. **Comparison with existing retry surfaces.** `install.sh` already
+   contains other retry-adjacent surfaces (e.g. the pkg download
+   retry-with-resume added in SPEC-023 v1.7.4). Argue whether the new
+   helper is consistent with the existing patterns or introduces a
+   novel retry semantics that operators may misunderstand.
+
+9. **Pre-existing behavior when helper is disabled.** Before this
+   change, a SIGKILL'd first invocation `die`d the install and left
+   the operator's system in a partially-configured state (binary
+   installed, no config, no launchd job). Argue whether that failure
+   mode was itself a security concern (e.g. an operator retrying via
+   an alternate path that might weaken security). If yes, the retry
+   is a security POSITIVE, not just a UX fix.
+
+10. **AMFI Taskgated race — is this a known macOS 26 primitive we
+    should be reporting instead of working around?** Not required to
+    file with Apple, but flag if the workaround is masking a genuine
+    OS bug we might want to report.
+
+## Bar
+
+CRITICAL / HIGH / MEDIUM findings must be fixed. LOW / INFO may ship
+with PR-body documentation. Return a structured list; no speculative
+findings without a concrete attack scenario.


### PR DESCRIPTION
## Summary

Closes the transient install-time failure observed on Apple M5 macOS 26.5 during the v1.7.9 fresh install: `installer -pkg` succeeded, Gatekeeper accepted the package, stapler validation passed — but the first `autotune --recommend --freshness-check` invocation was SIGKILL'd by the kernel with a CODESIGNING / Taskgated Invalid Signature verdict, and the whole install aborted before ever writing a paid-yield recommendation.

Direct re-invocation of the exact same command from the exact same shell moments later succeeded. `codesign -dv --verbose=4` on the installed binary reports a valid Developer ID / hardened-runtime signature. No `com.apple.quarantine` xattr present. Root cause: a race between the pkg installer's post-install AMFI signature revalidation and install.sh's first execve of the freshly-written binary.

## Fix

New helper `run_macprovider_cli_with_amfi_retry` in [phase3-binary/dist/install.sh](phase3-binary/dist/install.sh):

- Runs the CLI, captures rc via `|| rc=$?`.
- If `rc == 137` (bash-reported SIGKILL), logs a diagnostic to stderr, sleeps 2s, retries once.
- All other exit codes — including autotune's `exit 10` "stale recommendation", plus 134/138/139 which could be genuine crashes — pass through unchanged, no retry.
- If the retry ALSO fails with 137, a distinct second log line is emitted to disambiguate a transient race from a genuine signature failure.
- Diagnostic lines go to **stderr** so they remain visible even when callers redirect stdout to `/dev/null` (as the freshness-check site does).

Wired into 3 post-install call sites:

- `run_autotune_recommend_apply` main path (`--recommend --apply`)
- Donor-mode branch (`--recommend --apply --donor-mode`)
- `use_fresh_recommendation_if_available` (`--recommend --freshness-check`)

The `nohup` foreground-provider launch (~line 1962) is intentionally NOT wrapped: it runs after multiple prior successful CLI executions have already primed AMFI for this binary, so the race window has closed.

## Regression test

New [scripts/test-install-amfi-retry.sh](scripts/test-install-amfi-retry.sh) — extracts the helper from install.sh (matching the existing `test-install-autotune-recommend-config.sh` pattern) and asserts **16 scenarios / 8 cases**:

| # | Scenario | Assertions |
|:-:|---|:-:|
| 1 | Success first try | rc=0, no retry log |
| 2 | Exit 10 (stale) pass-through | rc=10, no retry log |
| 3 | SIGKILL then success | rc=0, first-retry log |
| 4 | SIGKILL both times | rc=137, first-retry + second-failure logs |
| 5 | Non-137 non-zero pass-through | rc=1, no retry log |
| 6 | Caller `if/else + rc=$?` | preserves original exit code |
| 7 | Caller `\|\| die` | fires on non-zero |
| 8 | `set -e` preserved after helper | on success + non-zero paths |

**16/16 pass.** shellcheck: clean (only pre-existing warnings in unrelated lines).

## 3-lane codex audit — R1 convergence

| Lane | C | H | M | L | I | Verdict |
|---|:---:|:---:|:---:|:---:|:---:|---|
| CODE | 0 | 0 | 0 | 1 | 1 | PASS |
| SECURITY | 0 | 0 | 0 | 1 | 9 | **APPROVE** |
| ARCHITECT | 0 | 0 | 0* | 3 | 4 | PASS |

*ARCHITECT R1 initially flagged 1 MEDIUM (commit the smoke test as a regression guard). Fixed in this PR by adding `scripts/test-install-amfi-retry.sh`. CODE-LOW-1 (log-visibility swallowed by `>/dev/null` at the freshness-check site) and CODE-INFO-1 (comment drift) were also fixed inline while addressing the ARCH MEDIUM.

Per `feedback-stop-iterating-on-low-audits`: all lanes are at 0/0/0 C/H/M. **No R2.**

Audit prompts:
- `specs/AUDIT_INSTALL_SH_AMFI_RETRY_CODE_PROMPT.md`
- `specs/AUDIT_INSTALL_SH_AMFI_RETRY_SECURITY_PROMPT.md`
- `specs/AUDIT_INSTALL_SH_AMFI_RETRY_ARCHITECT_PROMPT.md`

## LOW findings shipped (documented deferrals)

- **SECURITY-LOW-1** (optional `codesign -v --strict` gate before retry): not adopted. Release-time verification already covers signed checksum manifest, asset SHA256, package Gatekeeper/stapler; runtime `codesign` is not proof of AMFI policy and adds installer latency. Ship as-is.
- **ARCH-LOW-2** (`sleep 2` magic constant, no env override): keep literal `2s`. Making it env-configurable would overfit a defensive workaround for a hopefully-transient macOS 26 issue. Revisit if field data shows repeat failures.
- **ARCH-LOW-3** (log-line KB link): not adopted — no durable public support page exists. Crash-report summary lives in this PR body.

## No regression for happy-path installs

For installs that don't hit the race: single execve, no sleep, no extra log. Helper is a bash function call with one branch check — sub-millisecond overhead.

## Test plan

- [x] `shellcheck phase3-binary/dist/install.sh scripts/test-install-amfi-retry.sh`: clean
- [x] `bash -n phase3-binary/dist/install.sh`: syntactically valid
- [x] `scripts/test-install-amfi-retry.sh`: **16/16 pass**
- [x] 3-lane codex audit R1 converged 0/0/0 C/H/M
- [ ] Post-merge: fresh install on Apple M5 macOS 26.5 should either not hit the AMFI race at all, or hit it and successfully retry (visible via stderr diagnostic line and clean install completion).

## Related

- PR #335 shipped v1.7.9 soft-signal TPS/TTFT gates. Same M5 install session hit this AMFI race on the v1.7.9 pkg — after this PR merges, the transient race no longer aborts the install.
- Follow-up task #39 (unchanged): rotate `autotune-static-v2` → `v3` keypair, commit private key, re-sign catalog with M-Base-realistic `min_sustained_tps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
