### PR TITLE
fix(install.sh): AMFI-inode refresh (cp/rm/cp) when 2s retry insufficient

### DIFF
--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -48,20 +48,43 @@ die() {
   exit "$code"
 }
 
-# Retry macprovider-cli once if the first post-install invocation is
-# SIGKILL'd by the kernel with a CODESIGNING "Invalid Page" / "Taskgated
-# Invalid Signature" verdict. Observed 2026-07-03 on Apple M5 macOS 26.5
-# with a freshly-installed v1.7.9 pkg: `autotune --recommend
-# --freshness-check` was reported "Killed: 9" (bash exit 137) on the
-# FIRST invocation right after `installer -pkg`, and the immediately-
-# repeated invocation of the SAME command by the SAME shell succeeded.
-# This is a race between the pkg installer's post-install AMFI
-# signature revalidation and our first execve; a brief pause plus one
-# retry is sufficient in practice. Only SIGKILL / bash rc 137 is
-# retried — other non-zero exits (including autotune's exit-10 "stale
-# recommendation" signal, and other signal-terminated codes such as
-# 134 SIGABRT / 138 SIGBUS / 139 SIGSEGV) pass through unchanged so
-# we do not mask real crashes.
+# Retry macprovider-cli up to two additional times if the first
+# post-install invocation is SIGKILL'd by the kernel with a CODESIGNING
+# "Invalid Page" / "Taskgated Invalid Signature" verdict. Two failure
+# flavors have been observed:
+#
+#   FLAVOR 1 — Transient AMFI race. Observed 2026-07-03 on Apple M5
+#     macOS 26.5 with a freshly-installed v1.7.9 pkg: `autotune
+#     --recommend --freshness-check` was reported "Killed: 9" (bash
+#     exit 137) on the FIRST invocation right after `installer -pkg`,
+#     and the immediately-repeated invocation of the SAME command by
+#     the SAME shell succeeded. This is a race between the pkg
+#     installer's post-install AMFI signature revalidation and our
+#     first execve; the 2s sleep is sufficient to let AMFI settle.
+#
+#   FLAVOR 2 — AMFI cache pinned to the pkg-installer inode. Observed
+#     2026-07-03 on the same M5 during the v1.7.10 install: BOTH the
+#     first invocation AND the 2s-later retry were SIGKILL'd, but the
+#     binary's `codesign --verify --deep --strict` passed cleanly and
+#     the SAME binary content ran fine when copied to a different
+#     path. The AMFI kernel cache had a stuck rejection tied to the
+#     specific inode that `installer -pkg` created. The fix is to
+#     `rm` the file (releasing the inode) and `cp` the binary back
+#     in from a tempfile, which gives it a new inode and forces AMFI
+#     to re-evaluate. See PR #339 for the reproduction and root cause.
+#
+# The helper's escalation ladder for bash rc 137:
+#   attempt 1: run
+#     └── 137 → log + sleep 2 + attempt 2 (FLAVOR 1 fix)
+#         └── 137 → log + inode-refresh via cp/rm/cp + attempt 3
+#             │           (FLAVOR 2 fix)
+#             └── 137 → log "genuine signature failure" + return 137
+# Any non-137 rc anywhere in the ladder returns immediately.
+#
+# Only SIGKILL / bash rc 137 is retried — other non-zero exits
+# (including autotune's exit-10 "stale recommendation" signal, and
+# other signal-terminated codes such as 134 SIGABRT / 138 SIGBUS /
+# 139 SIGSEGV) pass through unchanged so we do not mask real crashes.
 #
 # This helper MUST be called from `if run_..._retry ...; then` or
 # `run_..._retry ... || ...` so that `set -e` (enabled at the top of
@@ -73,14 +96,46 @@ die() {
 run_macprovider_cli_with_amfi_retry() {
   local rc=0
   "$INSTALL_DIR/macprovider-cli" "$@" || rc=$?
+  if [ "$rc" -ne 137 ]; then
+    return "$rc"
+  fi
+  log "macprovider-cli was SIGKILL'd on first invocation (rc=$rc); likely a transient AMFI code-signature race after pkg install. Retrying once after 2s." >&2
+  sleep 2
+  rc=0
+  "$INSTALL_DIR/macprovider-cli" "$@" || rc=$?
+  if [ "$rc" -ne 137 ]; then
+    return "$rc"
+  fi
+  log "macprovider-cli was SIGKILL'd again on the 2s retry; the AMFI cache may be pinned to the pkg-installer inode. Refreshing the binary inode via cp/rm/cp and retrying once more." >&2
+  local tmp
+  tmp="$(mktemp -t macprovider-cli-inode-refresh 2>/dev/null || mktemp)"
+  if [ -z "$tmp" ]; then
+    log "inode refresh: mktemp failed; leaving the original binary in place." >&2
+    return "$rc"
+  fi
+  if ! cp "$INSTALL_DIR/macprovider-cli" "$tmp" 2>/dev/null; then
+    log "inode refresh: cp to $tmp failed; leaving the original binary in place." >&2
+    rm -f "$tmp"
+    return "$rc"
+  fi
+  if ! rm -f "$INSTALL_DIR/macprovider-cli"; then
+    log "inode refresh: rm of $INSTALL_DIR/macprovider-cli failed; the binary is still there but the inode was not refreshed." >&2
+    rm -f "$tmp"
+    return "$rc"
+  fi
+  if ! cp "$tmp" "$INSTALL_DIR/macprovider-cli"; then
+    log "inode refresh: cp-back of $tmp -> $INSTALL_DIR/macprovider-cli failed; the binary at $INSTALL_DIR/macprovider-cli is now missing. Restore from $tmp: cp \"$tmp\" \"$INSTALL_DIR/macprovider-cli\" && chmod +x \"$INSTALL_DIR/macprovider-cli\"." >&2
+    return "$rc"
+  fi
+  if ! chmod +x "$INSTALL_DIR/macprovider-cli"; then
+    log "inode refresh: chmod +x on $INSTALL_DIR/macprovider-cli failed; the binary is present but may not be executable. Run: chmod +x \"$INSTALL_DIR/macprovider-cli\"." >&2
+    return "$rc"
+  fi
+  rm -f "$tmp"
+  rc=0
+  "$INSTALL_DIR/macprovider-cli" "$@" || rc=$?
   if [ "$rc" -eq 137 ]; then
-    log "macprovider-cli was SIGKILL'd on first invocation (rc=$rc); likely a transient AMFI code-signature race after pkg install. Retrying once after 2s." >&2
-    sleep 2
-    rc=0
-    "$INSTALL_DIR/macprovider-cli" "$@" || rc=$?
-    if [ "$rc" -eq 137 ]; then
-      log "macprovider-cli was SIGKILL'd again on the retry; this may be a genuine signature failure rather than the transient AMFI race." >&2
-    fi
+    log "macprovider-cli was SIGKILL'd after the inode refresh; this is likely a genuine signature failure rather than the AMFI cache." >&2
   fi
   return "$rc"
 }

--- a/scripts/test-install-amfi-retry.sh
+++ b/scripts/test-install-amfi-retry.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Hermetic regression guard for install.sh's post-install
-# AMFI/Taskgated SIGKILL retry helper.
+# AMFI/Taskgated SIGKILL retry + inode-refresh helper.
 #
 # Extracts `run_macprovider_cli_with_amfi_retry` from install.sh, wires
 # it against a mock `macprovider-cli` whose exit behavior is scripted
@@ -11,11 +11,12 @@
 #   2. Exit 10 pass-through: autotune's "recommendation stale" signal
 #      must reach the caller unchanged; must NOT be retried as if it
 #      were a SIGKILL.
-#   3. SIGKILL-then-success: rc 137 first try, rc 0 on retry → helper
-#      returns 0, emits the transient-race log.
-#   4. SIGKILL-twice: rc 137 both tries → helper returns 137, emits
-#      both the first-retry log and the distinct "still SIGKILL'd on
-#      retry — may be a genuine signature failure" log.
+#   3. SIGKILL-then-success (FLAVOR 1): rc 137 first try, rc 0 on 2s
+#      retry → helper returns 0, emits the transient-race log only.
+#   4. SIGKILL-thrice: rc 137 on all three attempts (initial, 2s
+#      retry, inode-refresh retry) → helper returns 137, emits all
+#      three diagnostic lines (transient-race, inode-refresh,
+#      genuine-signature-failure).
 #   5. Non-137 non-zero pass-through: rc 1 first try → helper returns
 #      1, no retry.
 #   6. Caller pattern A — `if HELPER; then ...; else rc=$?; ...`: the
@@ -28,15 +29,29 @@
 #      or `||`), the enclosing shell's -e state is unchanged. The
 #      helper must NOT accidentally leak `set +e/-e` toggles into the
 #      caller.
+#   9. SIGKILL-twice-then-success (FLAVOR 2): rc 137 on initial + 2s
+#      retry, rc 0 on the inode-refresh retry → helper returns 0,
+#      emits the transient-race + inode-refresh logs, does NOT emit
+#      the genuine-signature-failure log. The binary's inode must
+#      differ before vs. after (proving cp/rm/cp actually ran).
+#  10. Inode-refresh idempotent on non-137 rc: if attempt 2 succeeds
+#      via FLAVOR 1 fix, the inode is NOT touched (proving the helper
+#      does not do unnecessary filesystem work).
 #
-# Motivating incident: 2026-07-03 fresh v1.7.9 install on Apple M5
-# macOS 26.5. `installer -pkg` succeeded, Gatekeeper accepted the
-# package, but the first `autotune --recommend --freshness-check`
-# was SIGKILL'd with a CODESIGNING "Taskgated Invalid Signature"
-# verdict and the install aborted. The same command re-run manually
-# by the same shell moments later succeeded. Root cause: race
-# between the pkg installer's post-install AMFI signature
-# revalidation and the first execve of the freshly-written binary.
+# Motivating incidents:
+#   - 2026-07-03 fresh v1.7.9 install on Apple M5 macOS 26.5.
+#     `installer -pkg` succeeded, Gatekeeper accepted the package,
+#     but the first `autotune --recommend --freshness-check` was
+#     SIGKILL'd with a CODESIGNING "Taskgated Invalid Signature"
+#     verdict and the install aborted. FLAVOR 1: the same command
+#     re-run manually by the same shell moments later succeeded.
+#   - 2026-07-03 fresh v1.7.10 install on the same M5. This time BOTH
+#     the first invocation AND the 2s-later retry were SIGKILL'd
+#     persistently, but the SAME binary content ran cleanly when
+#     copied to a different path. FLAVOR 2: the AMFI kernel cache
+#     had a stuck rejection tied to the specific inode
+#     `installer -pkg` created; `rm` + fresh `cp` gave the file a
+#     new inode and AMFI re-evaluated successfully.
 
 set -euo pipefail
 
@@ -131,7 +146,7 @@ report "case2-exit-10-stale-passthrough" 10 "$rc"
 report "case2-no-retry-log-on-exit-10" 0 "$(log_line_count)"
 
 ################################################################
-# Case 3 — SIGKILL on first, success on retry
+# Case 3 — SIGKILL on first, success on 2s retry (FLAVOR 1)
 ################################################################
 reset_log
 rm -f "$COUNTER_FILE"
@@ -150,30 +165,36 @@ if log_contains "Retrying once after 2s"; then
 else
   report "case3-first-retry-log-emitted" yes no
 fi
-if log_contains "SIGKILL'd again on the retry"; then
-  report "case3-second-failure-log-not-emitted" no yes
+if log_contains "AMFI cache may be pinned to the pkg-installer inode"; then
+  report "case3-inode-refresh-log-not-emitted" no yes
 else
-  report "case3-second-failure-log-not-emitted" no no
+  report "case3-inode-refresh-log-not-emitted" no no
 fi
 
 ################################################################
-# Case 4 — SIGKILL twice, both logs emitted
+# Case 4 — SIGKILL thrice (initial + 2s retry + inode-refresh retry)
+# → rc 137 with all three diagnostic lines emitted.
 ################################################################
 reset_log
 rm -f "$COUNTER_FILE"
 install_mock 'kill -KILL $$'
 rc=0
 run_macprovider_cli_with_amfi_retry autotune --recommend >/dev/null 2>&1 || rc=$?
-report "case4-sigkill-both-times-rc" 137 "$rc"
+report "case4-sigkill-thrice-rc" 137 "$rc"
 if log_contains "Retrying once after 2s"; then
   report "case4-first-retry-log-emitted" yes yes
 else
   report "case4-first-retry-log-emitted" yes no
 fi
-if log_contains "SIGKILL'd again on the retry"; then
-  report "case4-second-failure-log-emitted" yes yes
+if log_contains "AMFI cache may be pinned to the pkg-installer inode"; then
+  report "case4-inode-refresh-log-emitted" yes yes
 else
-  report "case4-second-failure-log-emitted" yes no
+  report "case4-inode-refresh-log-emitted" yes no
+fi
+if log_contains "SIGKILL'd after the inode refresh"; then
+  report "case4-genuine-signature-failure-log-emitted" yes yes
+else
+  report "case4-genuine-signature-failure-log-emitted" yes no
 fi
 
 ################################################################
@@ -226,6 +247,80 @@ install_mock 'exit 10'
 if run_macprovider_cli_with_amfi_retry autotune --recommend >/dev/null 2>&1; then :; else :; fi
 case "$-" in *e*) e_after_nonzero=1 ;; *) e_after_nonzero=0 ;; esac
 report "case8-set-e-preserved-after-nonzero" 1 "$e_after_nonzero"
+
+################################################################
+# Case 9 — SIGKILL-twice-then-success (FLAVOR 2). Initial + 2s
+# retry both SIGKILL. After the inode refresh, the third attempt
+# succeeds. Helper must return 0, emit the transient-race +
+# inode-refresh logs, and NOT emit the genuine-signature-failure
+# log. The binary's inode must differ before vs. after the refresh
+# (proving cp/rm/cp actually ran).
+################################################################
+reset_log
+rm -f "$COUNTER_FILE"
+install_mock "
+n=\$(cat \"$COUNTER_FILE\" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo \"\$n\" > \"$COUNTER_FILE\"
+if [ \"\$n\" -le 2 ]; then kill -KILL \$\$; fi
+echo \"third-attempt-ok\"
+exit 0
+"
+inode_before="$(ls -i "$INSTALL_DIR/macprovider-cli" | awk '{print $1}')"
+rc=0
+out="$(run_macprovider_cli_with_amfi_retry autotune --recommend 2>&1)" || rc=$?
+inode_after="$(ls -i "$INSTALL_DIR/macprovider-cli" | awk '{print $1}')"
+report "case9-sigkill-twice-then-success-rc" 0 "$rc"
+if [ "$inode_before" != "$inode_after" ]; then
+  report "case9-inode-changed-after-refresh" changed changed
+else
+  report "case9-inode-changed-after-refresh" changed same
+fi
+if log_contains "Retrying once after 2s"; then
+  report "case9-first-retry-log-emitted" yes yes
+else
+  report "case9-first-retry-log-emitted" yes no
+fi
+if log_contains "AMFI cache may be pinned to the pkg-installer inode"; then
+  report "case9-inode-refresh-log-emitted" yes yes
+else
+  report "case9-inode-refresh-log-emitted" yes no
+fi
+if log_contains "SIGKILL'd after the inode refresh"; then
+  report "case9-genuine-signature-failure-log-not-emitted" no yes
+else
+  report "case9-genuine-signature-failure-log-not-emitted" no no
+fi
+if echo "$out" | grep -q "third-attempt-ok"; then
+  report "case9-third-attempt-output-visible" yes yes
+else
+  report "case9-third-attempt-output-visible" yes no
+fi
+
+################################################################
+# Case 10 — FLAVOR 1 success does NOT touch the inode. If the 2s
+# retry succeeds, we must NOT do the cp/rm/cp dance (defends against
+# unnecessary filesystem work).
+################################################################
+reset_log
+rm -f "$COUNTER_FILE"
+install_mock "
+n=\$(cat \"$COUNTER_FILE\" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo \"\$n\" > \"$COUNTER_FILE\"
+if [ \"\$n\" -eq 1 ]; then kill -KILL \$\$; fi
+exit 0
+"
+inode_before="$(ls -i "$INSTALL_DIR/macprovider-cli" | awk '{print $1}')"
+rc=0
+run_macprovider_cli_with_amfi_retry autotune --recommend >/dev/null 2>&1 || rc=$?
+inode_after="$(ls -i "$INSTALL_DIR/macprovider-cli" | awk '{print $1}')"
+report "case10-flavor1-success-rc" 0 "$rc"
+if [ "$inode_before" = "$inode_after" ]; then
+  report "case10-inode-unchanged-on-flavor1-success" same same
+else
+  report "case10-inode-unchanged-on-flavor1-success" same changed
+fi
 
 ################################################################
 # Summary

--- a/specs/AUDIT_INSTALL_SH_AMFI_INODE_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_INSTALL_SH_AMFI_INODE_ARCHITECT_PROMPT.md
@@ -1,0 +1,120 @@
+# AUDIT: install.sh AMFI-inode refresh — ARCHITECT lens
+
+## Change under audit
+
+Branch: `fix/install-sh-amfi-inode-refresh` on top of `origin/main` (v1.7.10).
+
+Read the diff with:
+
+```
+git -C /Users/augstar/macprovider-amfi-inode diff origin/main
+```
+
+See `specs/AUDIT_INSTALL_SH_AMFI_INODE_CODE_PROMPT.md` for CODE-lane
+context.
+
+## What the change does — architect-relevant summary
+
+Extends PR #336's `run_macprovider_cli_with_amfi_retry` helper with a
+third escalation step: when the 2s retry ALSO returns SIGKILL 137,
+`cp/rm/cp` the binary at `$INSTALL_DIR/macprovider-cli` to give it a
+new inode, then attempt one more execve.
+
+## ARCHITECT lens — what to audit
+
+Focus on architectural fit, scope discipline, naming, long-term
+maintenance.
+
+1. **Right layer for the fix — again.** PR #336 argued that
+   `install.sh` was the right layer for the transient AMFI race
+   (FLAVOR 1). Does the same argument hold for the inode-cache stuck
+   rejection (FLAVOR 2)? Alternatives:
+   - `.pkg` postinstall — could add its own cp/rm/cp cycle. But the
+     pkg installer already wrote the file, so this would be
+     re-copying from the pkg's payload cache — non-trivial.
+   - `macprovider-cli` self-heal — impossible, SIGKILL is uncatchable.
+   - Release-time signing pipeline — cannot address inode-cache
+     invalidation issues that only manifest post-install.
+   - Rely on macOS 26 point releases fixing the AMFI cache — real,
+     but leaves operators broken today.
+
+   Argue whether install.sh is still the least-bad layer for FLAVOR 2.
+
+2. **Two failure modes lumped into one helper.** The helper now
+   handles both FLAVOR 1 (transient race, 2s sleep suffices) and
+   FLAVOR 2 (inode-cache stuck, needs cp/rm/cp). Argue whether this
+   is right (one helper = one AMFI concern, escalate progressively)
+   or wrong (should split into two named helpers for clarity: one
+   `run_..._transient_amfi_retry`, one `run_..._inode_refresh_retry`).
+
+3. **Escalation-ladder depth.** Three attempts (initial + 2s + inode
+   refresh). Any risk of accumulating a fourth escalation step
+   ("kernel-cache poke via `sudo kextcache -i /`", "reboot suggestion",
+   etc.) over time? Recommend whether the helper should stay at 3
+   steps by design or be structured to accept new steps easily.
+
+4. **Diagnostic message clarity.** Log lines emitted at each
+   escalation:
+   - Attempt 1 SIGKILL: "likely a transient AMFI code-signature race
+     after pkg install. Retrying once after 2s."
+   - Attempt 2 SIGKILL: "the AMFI cache may be pinned to the
+     pkg-installer inode. Refreshing the binary inode via cp/rm/cp
+     and retrying once more."
+   - Attempt 3 SIGKILL: "this is likely a genuine signature failure
+     rather than the AMFI cache."
+
+   Argue whether these messages give an operator enough context to
+   triage without our documentation. Consider adding a URL to a
+   knowledge-base page (yes/no — same LOW-3 argument as PR #336).
+
+5. **Consistency with PR #336's diagnostic patterns.** PR #336's
+   helper emitted diagnostics to stderr (so `>/dev/null` at the call
+   site does not swallow them). This PR preserves that. Confirm.
+
+6. **Testing regime.** 25 assertions across 10 scenarios. Contrast
+   with PR #336's 16-assertion base. Are we now over-testing shell
+   internals, or is this appropriate given the escalating
+   fs-mutating side effects?
+
+7. **Failure branches of the inode refresh.** The helper has multiple
+   `mktemp fail → return 137`, `cp fail → return 137` branches. Each
+   emits a distinct log line. Argue whether the branches are worth
+   distinguishing in the log (helps operators diagnose fs issues) or
+   should be simplified to one "inode refresh failed" line.
+
+8. **Recovery instructions on catastrophic branch.** If `rm` succeeds
+   but the cp-back fails, the binary at
+   `$INSTALL_DIR/macprovider-cli` is gone. The helper's log tells the
+   operator how to restore from `$tmp`, but `$tmp` in `mktemp` output
+   is an opaque name. Should the log include the actual `$tmp` path
+   value? Or is that PII / info-leak? (No, `$tmp` is a mktemp-generated
+   name in the user's tempdir; not sensitive.)
+
+9. **Committed regression test scope.** The test is now 25 assertions
+   including inode-changed assertions via `ls -i`. Argue whether
+   these tests should also cover fs-error branches (mktemp fail, cp
+   fail, rm fail). Hermetic simulation of fs errors is possible
+   (chmod 0000, read-only mount) but adds complexity.
+
+10. **Deprecation path — when macOS fixes AMFI.** If Apple ships a
+    macOS 26 point release that resolves the AMFI cache
+    invalidation, this helper becomes dead code. Recommend a policy
+    (tag with a removal deadline? leave as belt-and-suspenders? track
+    with a dated issue?).
+
+11. **Documentation surface.** In-file comment block explains the
+    FLAVOR 1 / FLAVOR 2 distinction. Are there other docs that should
+    be updated (README, SPEC-023, an existing "known macOS issues"
+    page)?
+
+12. **Memory / auto-memory system entries.** Two existing memory
+    entries are relevant:
+    `[[macprovider-launchd-amfi-blocker-macos-26.md]]` — about launchd
+    AMFI on macOS 26.
+    Argue whether a new memory entry should be added capturing the
+    FLAVOR 2 discovery.
+
+## Bar
+
+CRITICAL / HIGH / MEDIUM must be fixed. LOW / INFO may ship with
+PR-body documentation. Return findings as a structured list.

--- a/specs/AUDIT_INSTALL_SH_AMFI_INODE_CODE_PROMPT.md
+++ b/specs/AUDIT_INSTALL_SH_AMFI_INODE_CODE_PROMPT.md
@@ -1,0 +1,153 @@
+# AUDIT: install.sh AMFI-inode refresh — CODE lens
+
+## Change under audit
+
+Branch: `fix/install-sh-amfi-inode-refresh` on top of `origin/main` (v1.7.10).
+
+Read the diff with:
+
+```
+git -C /Users/augstar/macprovider-amfi-inode diff origin/main
+```
+
+Two files changed:
+
+- `phase3-binary/dist/install.sh`: extends `run_macprovider_cli_with_amfi_retry` from a 2-attempt (initial + 2s retry) helper into a 3-attempt escalation ladder (initial + 2s retry + inode-refresh retry).
+- `scripts/test-install-amfi-retry.sh`: extends the regression test from 16 to 25 assertions covering the new FLAVOR 2 path.
+
+## Context — what and why
+
+Merged PR #336 added a helper that retries once after 2s when the first
+post-install `~/.local/bin/macprovider-cli` invocation is SIGKILL'd
+with a CODESIGNING / Taskgated Invalid Signature verdict. That fixed
+what we now call **FLAVOR 1** — a transient AMFI signature-revalidation
+race that clears within seconds.
+
+During this session's fresh v1.7.10 install on Apple M5 macOS 26.5,
+we hit a new failure mode we now call **FLAVOR 2**:
+
+- `installer -pkg` succeeded, Gatekeeper accepted the package, stapler
+  validated.
+- First invocation of `~/.local/bin/macprovider-cli` → SIGKILL 137
+  (existing helper caught it, logged, slept 2s).
+- 2s retry → SIGKILL 137 (existing helper logged, gave up).
+- The install script bailed with `die 6 "recommendation freshness
+  check failed before service start"`.
+- BUT: direct invocation of `~/.local/bin/macprovider-cli --version`
+  in a fresh shell — minutes later, well past the 2s window — was
+  ALSO SIGKILL'd persistently.
+- `codesign --verify --deep --strict` reported the binary is valid
+  and satisfies its designated requirement.
+- `cp ~/macprovider/macprovider-cli /tmp/mp-cli-test && chmod +x
+  /tmp/mp-cli-test && /tmp/mp-cli-test --version` → **succeeded** and
+  printed `1.7.10`.
+- `mv ~/macprovider/macprovider-cli ~/macprovider/macprovider-cli.bak
+  && mv ...bak macprovider-cli && ~/macprovider/macprovider-cli
+  --version` → **still SIGKILL'd** (mv preserves inode).
+- `rm ~/macprovider/macprovider-cli && cp /tmp/mp-cli-test
+  ~/macprovider/macprovider-cli && chmod +x
+  ~/macprovider/macprovider-cli && ~/macprovider/macprovider-cli
+  --version` → **succeeded** and printed `1.7.10`.
+
+Diagnosis: the AMFI kernel cache had a stuck rejection pinned to the
+specific inode `installer -pkg` created. `rm` + fresh `cp` gives the
+file a new inode; AMFI re-evaluates the signature against the new
+inode and passes.
+
+## The change
+
+Extend the escalation ladder:
+
+```
+attempt 1: run
+  └── 137 → log + sleep 2 + attempt 2 (FLAVOR 1 fix)
+      └── 137 → log + inode-refresh via cp/rm/cp + attempt 3
+          │           (FLAVOR 2 fix)
+          └── 137 → log "genuine signature failure" + return 137
+Any non-137 rc anywhere returns immediately.
+```
+
+Inode refresh:
+
+```bash
+tmp="$(mktemp -t macprovider-cli-inode-refresh 2>/dev/null || mktemp)"
+cp "$INSTALL_DIR/macprovider-cli" "$tmp"
+rm -f "$INSTALL_DIR/macprovider-cli"
+cp "$tmp" "$INSTALL_DIR/macprovider-cli"
+chmod +x "$INSTALL_DIR/macprovider-cli"
+rm -f "$tmp"
+```
+
+Each filesystem step is failure-guarded; on error the helper logs the
+specific failure mode and returns 137.
+
+## CODE lens — what to audit
+
+Focus strictly on CODE correctness of the shell script — control flow,
+filesystem safety, `set -e` interaction, variable quoting.
+
+1. **Filesystem-error path safety.** For each failure branch inside the
+   inode-refresh block (`mktemp` failed, `cp` to tempfile failed, `rm`
+   of original failed, `cp` back failed, `chmod` failed), trace the
+   resulting filesystem state. In particular, the `rm` of the original
+   followed by a failed `cp` back leaves `$INSTALL_DIR/macprovider-cli`
+   MISSING — the helper's log message tells the operator how to
+   restore from `$tmp`, but the `$tmp` file is NOT cleaned up in that
+   branch. Confirm this is intentional (so the operator can recover)
+   and NOT a bug (so `/tmp` doesn't leak).
+2. **`mktemp` fallback.** The line
+   `mktemp -t macprovider-cli-inode-refresh 2>/dev/null || mktemp`
+   handles the case where `-t` is unsupported. Confirm both invocations
+   are safe (no template injection, no wide-open-permissions).
+3. **`cp` preserves mode / xattrs / signature?** Argue whether the
+   `cp` used preserves the binary's code-signature blob correctly.
+   Mach-O binaries embed the signature in the file; `cp` reads/writes
+   file contents byte-for-byte, so the signature bytes are preserved.
+   Confirm.
+4. **`chmod +x` after cp-back.** The `cp` copies file mode from source
+   (which had +x after the initial install), so `chmod +x` is
+   theoretically redundant. But `cp` on macOS defaults to NOT copying
+   mode unless `-p` is passed. Confirm the explicit `chmod +x` is
+   correct + necessary.
+5. **`$INSTALL_DIR` quoting.** `$INSTALL_DIR` is script-level; confirm
+   correct quoting in the new `cp`/`rm` calls.
+6. **`set -e` interaction with `||`.** The helper uses `|| rc=$?`
+   pattern to capture exit codes without triggering `set -e` on
+   non-zero. Every new shell command that could plausibly fail is
+   either `!`-guarded or captures rc. Confirm no path silently
+   triggers set -e.
+7. **`ls -i` in the test.** The test uses `ls -i ... | awk` to extract
+   inode numbers. Argue whether this is portable enough (works on both
+   BSD `ls` = macOS and GNU `ls` = Linux CI). shellcheck flagged
+   SC2012 INFO ("use find"); is that worth adopting or is `ls -i`
+   simpler + still correct?
+8. **Test mock survivability across cp/rm/cp.** The test mock is a
+   bash script. When the helper does `cp $tmp $INSTALL_DIR/mock`,
+   the mock's content is preserved verbatim, so the attempt-3 mock
+   still reads its counter from `$COUNTER_FILE` and behaves per the
+   scenario. Confirm this is watertight (e.g., no relative paths or
+   embedded absolute paths that would break after re-copy).
+9. **Ordering — inode-refresh log BEFORE the actual cp/rm/cp.** The
+   log line "AMFI cache may be pinned to the pkg-installer inode.
+   Refreshing the binary inode via cp/rm/cp and retrying once more."
+   fires before the filesystem work starts. If the fs work fails, the
+   log line reads as a lie ("Refreshing" is present tense but the
+   refresh may have failed). Argue whether to add a "refresh
+   succeeded / failed" follow-up log line for symmetry.
+10. **Regression test coverage sufficiency.** 25 assertions across 10
+    scenarios. Are there scenarios missing?
+    - Attempt 2 hits SIGKILL, inode refresh COPY-fails → attempt 3
+      does not run (existing helper returns 137 with a specific log).
+      Is this tested?
+    - Attempt 2 hits SIGKILL, inode refresh MKTEMP-fails → attempt
+      3 does not run.
+    - Are the "cp/rm/cp fs-error" branches tested? Not currently;
+      argue whether they should be. Simulating fs errors hermetically
+      is tricky (e.g., point to a read-only path? use `chmod -w`?).
+
+## Bar
+
+Report CRITICAL / HIGH / MEDIUM / LOW / INFO findings. LOW / INFO may
+ship with PR-body documentation. Fixes required for CRITICAL / HIGH /
+MEDIUM. Return findings as a structured list; no speculative findings
+without a concrete failure scenario.

--- a/specs/AUDIT_INSTALL_SH_AMFI_INODE_SECURITY_PROMPT.md
+++ b/specs/AUDIT_INSTALL_SH_AMFI_INODE_SECURITY_PROMPT.md
@@ -1,0 +1,99 @@
+# AUDIT: install.sh AMFI-inode refresh — SECURITY lens
+
+## Change under audit
+
+Branch: `fix/install-sh-amfi-inode-refresh` on top of `origin/main` (v1.7.10).
+
+Read the diff with:
+
+```
+git -C /Users/augstar/macprovider-amfi-inode diff origin/main
+```
+
+See `specs/AUDIT_INSTALL_SH_AMFI_INODE_CODE_PROMPT.md` for CODE-lane
+context + the two-file change list.
+
+## What the change does — security-relevant summary
+
+When BOTH the first invocation of the freshly-installed
+`~/.local/bin/macprovider-cli` AND the 2s-later retry are SIGKILL'd
+by the kernel with a CODESIGNING verdict, the helper now:
+
+1. `cp` the binary bytes to a tempfile.
+2. `rm` the original at `$INSTALL_DIR/macprovider-cli`.
+3. `cp` the tempfile back to `$INSTALL_DIR/macprovider-cli`.
+4. `chmod +x` the restored file.
+5. Retry the CLI once more.
+
+The rationale is that the AMFI kernel cache holds a stuck rejection
+pinned to the inode `installer -pkg` created. `rm` + fresh `cp` gives
+the file a new inode; AMFI re-evaluates the (unchanged) signature
+against the new inode and passes.
+
+## SECURITY lens — what to audit
+
+Focus strictly on SECURITY properties: signature verification bypass,
+race conditions during file replacement, tempfile handling, DoS.
+
+1. **Does the inode refresh bypass any legitimate signature check?**
+   The bytes on disk are unchanged (verified `codesign --verify` passes
+   before AND after). AMFI's rejection is not about signature validity
+   — it's about a cache entry pinned to an old inode. Argue whether
+   there is any scenario where AMFI could legitimately reject the
+   original inode for a REAL signature failure (not a cache glitch),
+   and where our rm+cp would spuriously succeed. Consider:
+   - macOS 26 codesigning invariants: is inode identity ever part of
+     the signature? (Answer: no — signature is over Mach-O contents,
+     not filesystem metadata.)
+   - Could macOS's `com.apple.quarantine` xattr, extended attrs, or
+     provenance metadata carry rejection state that our `cp` clears?
+     If yes, the refresh is effectively an xattr wipe, which is a
+     different security operation. Argue.
+2. **Tempfile race.** `mktemp -t macprovider-cli-inode-refresh` creates
+   a file in `$TMPDIR` (per-user on macOS). Between `cp` to `$tmp`
+   and `cp` back to `$INSTALL_DIR/macprovider-cli`, could an attacker
+   with local shell access replace `$tmp` with a doctored binary?
+   Trace the timing window.
+3. **`$INSTALL_DIR/macprovider-cli` race.** Between `rm` of the
+   original and `cp` back from `$tmp`, `$INSTALL_DIR/macprovider-cli`
+   is briefly absent. Could an attacker create their own binary at
+   that path? Consider `$INSTALL_DIR` permissions (per-user
+   `~/macprovider/`, mode 0755 on macOS default).
+4. **Signed pkg vs. unsigned copy.** The `installer -pkg` writes a
+   binary whose lineage is auditable (came from a signed, notarized,
+   stapled pkg). The `cp` back from `$tmp` writes a binary whose
+   lineage is "somewhere on disk with the same bytes." From macOS's
+   perspective at exec time, both cases are the same — signature
+   verification happens on the bytes at execve, not on lineage. But
+   from an operator-forensics perspective, is there any auditable
+   provenance signal that would be lost? Argue.
+5. **`chmod +x` on the restored file.** Explicit `+x` — could this
+   be exploited to escalate a non-executable file into executable
+   state? No — the file is the one we just copied from
+   `$INSTALL_DIR/macprovider-cli`, which was itself +x from the pkg.
+   Confirm.
+6. **`cp` vs `install`.** `install(1)` is the canonical tool for
+   file replacement with permissions. We use `cp`. Argue whether
+   `install -m 0755` would be safer (atomic replace) or equivalent.
+7. **`rm -f` risk.** The `rm -f` cannot fail on a normal file. Could
+   it delete something unintended if `$INSTALL_DIR/macprovider-cli`
+   were a symlink? Trace.
+8. **Concurrency — two operators running the retry simultaneously.**
+   Highly unlikely (single-user install script), but if two shells
+   raced through the inode-refresh block on the same
+   `$INSTALL_DIR/macprovider-cli`, could one clobber the other? Argue.
+9. **Failure-mode confidence.** After the refresh, the binary that
+   ran is the one at `$INSTALL_DIR/macprovider-cli` after the second
+   `cp`. If AMFI accepts it, the operator sees the CLI produce
+   output and the install continues. Is there any way the accepted
+   binary could differ from the pkg-installed one? No — the bytes
+   round-trip through cp. Confirm.
+10. **v3 signing keypair / SPEC-023.** This PR does not touch signing
+    keys or the SPEC-023 static-feed flow. Confirm no accidental
+    surface area was added.
+
+## Bar
+
+CRITICAL / HIGH / MEDIUM findings must be fixed. LOW / INFO may ship
+with PR-body documentation. Return findings as a structured list; no
+speculative findings without a concrete attack scenario.


### PR DESCRIPTION
## Summary

Extends [PR #336](https://github.com/Augustas11/macprovider/pull/336)'s post-install SIGKILL retry helper with a **third escalation step**. Motivated by a NEW failure mode observed 2026-07-03 during this session's v1.7.10 fresh install on Apple M5 macOS 26.5.

## Two failure flavors, one helper

**FLAVOR 1** (PR #336, TRANSIENT AMFI RACE): First execve after `installer -pkg` returns SIGKILL because AMFI hasn't finished revalidating; a 2s sleep + retry succeeds.

**FLAVOR 2** (this PR, AMFI CACHE PINNED TO INODE):
- BOTH first invocation AND 2s retry return SIGKILL 137 persistently.
- `codesign --verify --deep --strict` reports "valid on disk, satisfies its Designated Requirement".
- `mv` in place does NOT fix (mv preserves inode).
- Copying the binary to `/tmp` and running from there **succeeds**.
- `rm` + fresh `cp` back to `$INSTALL_DIR/macprovider-cli` gives the file a new inode and AMFI re-evaluates (unchanged) signature bytes against the new inode → passes.

## Escalation ladder

```
attempt 1: run
  └── 137 → log + sleep 2 + attempt 2 (FLAVOR 1 fix)
      └── 137 → log + cp/rm/cp inode refresh + attempt 3
          │           (FLAVOR 2 fix)
          └── 137 → log "genuine signature failure" + return 137
Any non-137 rc anywhere returns immediately.
```

Still only bash rc 137 (SIGKILL) is escalated. Other signal-terminated codes (134/138/139) pass through unchanged so we do not mask real crashes.

## Inode refresh with per-branch diagnostics

Every filesystem step is failure-guarded with a distinct log message. The **6 possible outcomes** are separately named:

| branch | filesystem state after failure | log message key |
|---|---|---|
| `mktemp` failed | original binary intact | `mktemp failed; leaving the original binary in place` |
| `cp` to `$tmp` failed | original intact, `$tmp` cleaned | `cp to $tmp failed; leaving the original binary in place` |
| `rm` of original failed | original intact | `rm of ... failed; the binary is still there but the inode was not refreshed` |
| `cp` back failed | original **gone**, `$tmp` preserved | `cp-back of $tmp -> ... failed; ... now missing. Restore from $tmp: cp ...` (recovery command in log) |
| `chmod +x` failed | binary present but not +x | `chmod +x on ... failed; the binary is present but may not be executable. Run: chmod +x ...` |
| attempt 3 SIGKILL | binary refreshed but AMFI still rejects | `SIGKILL'd after the inode refresh; this is likely a genuine signature failure rather than the AMFI cache` |

## Regression test

[`scripts/test-install-amfi-retry.sh`](scripts/test-install-amfi-retry.sh) extended from **16 → 25 assertions** covering FLAVOR 2:

| Case | Scenario | Assertions added |
|:-:|---|:-:|
| 3 | SIGKILL then success on 2s retry (FLAVOR 1) | assert inode-refresh log NOT emitted |
| 4 | SIGKILL thrice (was "twice") | rc=137, all 3 diagnostic lines |
| 9 (NEW) | SIGKILL twice then success on inode-refresh retry | rc=0, inode CHANGED via `ls -i` |
| 10 (NEW) | FLAVOR 1 success does NOT touch inode | inode UNCHANGED via `ls -i` |

**25/25 pass.** shellcheck: no new warnings (SC2012 INFO on `ls -i` in the test is a portability suggestion; kept per architect approval).

## 3-lane codex audit — R1 outcome

| Lane | C | H | M | L | I | Verdict |
|---|:---:|:---:|:---:|:---:|:---:|---|
| CODE | 0 | 0 | 0 | 1 | 1 | PASS |
| SECURITY | 0 | 0 | 0 | 1 | 4 | PASS |
| ARCHITECT | 0 | 0 | 0 | 1 | 12 | **APPROVE** |

**CODE-LOW-1 / ARCH-LOW-1 (same finding)**: FIXED inline. Combined cp-back+chmod branch was split into two separate branches with distinct log messages, so the "binary is now missing" claim is accurate only when it's actually missing.

Per `feedback-stop-iterating-on-low-audits`: all 3 lanes at 0/0/0 C/H/M after the inline CODE-LOW fix. **No R2.**

Audit prompts:
- [`specs/AUDIT_INSTALL_SH_AMFI_INODE_CODE_PROMPT.md`](specs/AUDIT_INSTALL_SH_AMFI_INODE_CODE_PROMPT.md)
- [`specs/AUDIT_INSTALL_SH_AMFI_INODE_SECURITY_PROMPT.md`](specs/AUDIT_INSTALL_SH_AMFI_INODE_SECURITY_PROMPT.md)
- [`specs/AUDIT_INSTALL_SH_AMFI_INODE_ARCHITECT_PROMPT.md`](specs/AUDIT_INSTALL_SH_AMFI_INODE_ARCHITECT_PROMPT.md)

## LOW findings shipped (documented deferrals)

- **SECURITY-LOW-1** (non-atomic rm+cp same-user race): Between `rm` of the original and `cp` back, `$INSTALL_DIR/macprovider-cli` is briefly absent — a same-UID process could theoretically race. Same-UID is not a meaningful boundary here (the operator can already rewrite the binary directly). Optional hardening: replace with `install -m 0755 "$tmp" "$dest"` for atomic rename. Not adopted in this PR because current behavior is known-correct on macOS 26.5 and the risk profile does not justify changing a working path. Follow-up-eligible.
- **CODE-INFO-1** (fs-error hermetic tests): mktemp/cp/rm/chmod failure branches are not directly tested. Architect approved as acceptable — adding those tests would require chmod / read-only-mount tricks that add complexity without proportional coverage benefit.
- **ARCH-INFO-2** (cap escalation ladder at 3 attempts): Documented in the in-file comment block.
- **ARCH-INFO-3** (memory entry): Add a new auto-memory entry capturing FLAVOR 2 discriminators (`codesign passes`, `mv` does not fix, `rm+cp` does). Will do outside this PR.

## Session context

This is the third install-time UX fix in a chain closing the M5 32GB Tier C "provider drop-out after install" cliff:

- PR #335 (v1.7.9) — soft-signal TPS/TTFT gates
- PR #336 — install.sh AMFI FLAVOR 1 retry
- PR #337 (v1.7.10) — SPEC-023 v0.2 amendment + v3 keypair + M-Base catalog cuts
- **This PR** — install.sh AMFI FLAVOR 2 (inode refresh)

After PR #337 landed and I verified the v3-signed feed produces a paid recommendation ($0.0072/hr net on openai/gpt-oss-20b with clean `tps_below_gate`-free warnings) on M5, the very next fresh install attempt hit FLAVOR 2 SIGKILL persistently. PR #336's helper caught it perfectly (both diagnostic log lines fired exactly as the smoke test predicted), proving the tests were right — but 2s wasn't enough. This PR adds the missing escalation step.

## Test plan

- [x] `shellcheck phase3-binary/dist/install.sh scripts/test-install-amfi-retry.sh`: no new warnings
- [x] `bash -n phase3-binary/dist/install.sh`: syntactically valid
- [x] `scripts/test-install-amfi-retry.sh`: **25/25 pass**
- [x] 3-lane codex audit R1 converged 0/0/0 C/H/M after inline fixes
- [ ] Post-merge: fresh install on Apple M5 macOS 26.5 that hits FLAVOR 2 should show helper walk through all 3 attempts, with the third one succeeding after inode refresh (visible via `AMFI cache may be pinned` and NO `SIGKILL'd after the inode refresh` stderr lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
