### PR TITLE
fix(autoupdate): opt-in for provisional providers + land latest_binary_version in template

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -33,6 +33,15 @@ public struct AppConfig: Equatable, Sendable {
     public var wsTunneledMode: Bool?
     public var autoUpdateEnabled: Bool?
     public var autoupdateEnabled: Bool?
+    // Operator opt-in: when true, provisional-tier providers apply
+    // coordinator-recommended auto-updates. Default nil (== false) preserves
+    // the pinned-only trust posture. Landed to unblock the trust-orphan
+    // pattern where self-service (curl|bash) providers, which are always
+    // provisional at admission, would otherwise never receive fixes without
+    // manual operator SSH intervention. Flipping this to true is an explicit
+    // operator statement of trust in the connected coordinator's version
+    // recommendation surface.
+    public var autoUpdateAcceptProvisional: Bool?
     public var configPath: String
     public var logLevel: LogLevel
     public var logFormat: LogFormat
@@ -94,6 +103,7 @@ public struct AppConfig: Equatable, Sendable {
             wsTunneledMode: nil,
             autoUpdateEnabled: nil,
             autoupdateEnabled: nil,
+            autoUpdateAcceptProvisional: nil,
             configPath: configPath,
             logLevel: .info,
             logFormat: .json,
@@ -278,8 +288,10 @@ public enum ConfigLoader {
         try assign(&config.endpointURL, from: dict, key: "endpoint_url", expected: "string")
         try assign(&config.wsTunneledMode, from: dict, key: "ws_tunneled_mode", expected: "boolean")
         try assign(&config.autoUpdateEnabled, from: dict, key: "auto_update_enabled", expected: "boolean")
+        try assign(&config.autoUpdateAcceptProvisional, from: dict, key: "auto_update_accept_provisional", expected: "boolean")
         if let nested = dict["autoupdate"] as? [String: Any] {
             try assign(&config.autoupdateEnabled, from: nested, key: "enabled", expected: "boolean")
+            try assign(&config.autoUpdateAcceptProvisional, from: nested, key: "accept_provisional", expected: "boolean")
         }
         try assign(&config.logFormat, from: dict, key: "log_format", expected: "json or text")
         try assign(&config.logFile, from: dict, key: "log_file", expected: "string")
@@ -317,6 +329,7 @@ public enum ConfigLoader {
         try assign(&config.wsTunneledMode, from: environment, env: "MACPROVIDER_WS_TUNNELED_MODE", expected: "boolean")
         try assign(&config.autoUpdateEnabled, from: environment, env: "MACPROVIDER_AUTO_UPDATE_ENABLED", expected: "boolean")
         try assign(&config.autoupdateEnabled, from: environment, env: "MACPROVIDER_AUTOUPDATE", expected: "boolean")
+        try assign(&config.autoUpdateAcceptProvisional, from: environment, env: "MACPROVIDER_AUTO_UPDATE_ACCEPT_PROVISIONAL", expected: "boolean")
         try assign(&config.logLevel, from: environment, env: "MACPROVIDER_LOG_LEVEL", expected: "valid log level")
         try assign(&config.logFormat, from: environment, env: "MACPROVIDER_LOG_FORMAT", expected: "json or text")
         try assign(&config.logFile, from: environment, env: "MACPROVIDER_LOG_FILE", expected: "string")

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateTrustState.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateTrustState.swift
@@ -25,6 +25,15 @@ struct AutoUpdateTrustState: Sendable {
     let bearerlessDuplicate: Bool
     let connected: Bool
     let stableReason: String?
+    // Operator opt-in: accept auto-updates while the provider is in the
+    // provisional tier. Default false preserves the pre-existing
+    // pinned-only trust posture. Flipping this at the provider config layer
+    // is a deliberate operator choice — the semantic contract is "I trust
+    // the coordinator I chose to connect to enough to apply its version
+    // recommendations even before this provider is operator-promoted to
+    // pinned." This unblocks self-service (curl|bash) providers on the
+    // network from being trust-orphaned from fixes.
+    let acceptProvisional: Bool
 
     init(
         v2Accepted: Bool,
@@ -36,7 +45,8 @@ struct AutoUpdateTrustState: Sendable {
         tokenValidated: Bool,
         bearerlessDuplicate: Bool,
         connected: Bool,
-        stableReason: String? = nil
+        stableReason: String? = nil,
+        acceptProvisional: Bool = false
     ) {
         self.v2Accepted = v2Accepted
         self.tier = tier
@@ -48,13 +58,22 @@ struct AutoUpdateTrustState: Sendable {
         self.bearerlessDuplicate = bearerlessDuplicate
         self.connected = connected
         self.stableReason = stableReason
+        self.acceptProvisional = acceptProvisional
     }
 
     var verdict: AutoUpdateTrustVerdict {
         guard connected else { return .coordinatorDisconnected }
         guard v2Accepted else { return .legacyHelloAck }
         if bearerlessDuplicate { return .bearerlessDuplicate }
-        guard tier == "pinned" else { return .provisional }
+        // Tier gate: pinned providers always pass. Provisional providers
+        // pass only when the operator has explicitly opted the provider in
+        // via `auto_update_accept_provisional: true` in the local YAML
+        // config (or the MACPROVIDER_AUTO_UPDATE_ACCEPT_PROVISIONAL env
+        // var). Any other tier (empty / rejected) falls through to
+        // .provisional.
+        if tier != "pinned" {
+            guard tier == "provisional" && acceptProvisional else { return .provisional }
+        }
         guard encryptedLegValid else { return .encryptedLegFailed }
         guard !attestationRequired || attestationSatisfied else { return .attestationFailed }
         guard !tokenConfigured || tokenValidated else { return .tokenRejected }
@@ -74,7 +93,8 @@ struct AutoUpdateTrustState: Sendable {
         isV2: Bool,
         session: Tier2ProviderSession?,
         providerToken: String?,
-        assignedProviderTokenAdopted: Bool
+        assignedProviderTokenAdopted: Bool,
+        acceptProvisional: Bool = false
     ) -> AutoUpdateTrustState {
         let tier = payload["tier"] as? String
         let attestationStatus = (((payload["tier2_session"] as? [String: Any])?["attestation"] as? [String: Any])?["status"] as? String)
@@ -88,7 +108,8 @@ struct AutoUpdateTrustState: Sendable {
             tokenConfigured: tokenConfigured,
             tokenValidated: !tokenConfigured || providerToken?.isEmpty == false || assignedProviderTokenAdopted,
             bearerlessDuplicate: tokenConfigured && providerToken == nil && !assignedProviderTokenAdopted,
-            connected: true
+            connected: true,
+            acceptProvisional: acceptProvisional
         )
     }
 }

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -1309,7 +1309,8 @@ actor CoordinatorClient {
             isV2: isV2,
             session: tier2Session,
             providerToken: providerToken,
-            assignedProviderTokenAdopted: assignedProviderTokenAdopted
+            assignedProviderTokenAdopted: assignedProviderTokenAdopted,
+            acceptProvisional: appConfig.autoUpdateAcceptProvisional == true
         )
         autoupdateDrainExtensions = payload["autoupdate_drain_extensions"] as? Bool == true
         autoupdateAttemptedTargets.removeAll()
@@ -1919,7 +1920,8 @@ actor CoordinatorClient {
             isV2: autoupdateCoordinatorPayloadIsV2,
             session: tier2Session,
             providerToken: providerToken,
-            assignedProviderTokenAdopted: autoupdateAssignedProviderTokenAdopted
+            assignedProviderTokenAdopted: autoupdateAssignedProviderTokenAdopted,
+            acceptProvisional: appConfig.autoUpdateAcceptProvisional == true
         )
         if let reason = autoupdateDemotionReason {
             switch reason {
@@ -1934,7 +1936,8 @@ actor CoordinatorClient {
                     tokenValidated: state.tokenValidated,
                     bearerlessDuplicate: state.bearerlessDuplicate,
                     connected: state.connected,
-                    stableReason: reason
+                    stableReason: reason,
+                    acceptProvisional: state.acceptProvisional
                 )
             case "tier_demoted":
                 state = AutoUpdateTrustState(
@@ -1947,7 +1950,8 @@ actor CoordinatorClient {
                     tokenValidated: state.tokenValidated,
                     bearerlessDuplicate: state.bearerlessDuplicate,
                     connected: state.connected,
-                    stableReason: reason
+                    stableReason: reason,
+                    acceptProvisional: state.acceptProvisional
                 )
             case "token_revoked":
                 state = AutoUpdateTrustState(
@@ -1960,7 +1964,8 @@ actor CoordinatorClient {
                     tokenValidated: false,
                     bearerlessDuplicate: state.bearerlessDuplicate,
                     connected: state.connected,
-                    stableReason: reason
+                    stableReason: reason,
+                    acceptProvisional: state.acceptProvisional
                 )
             case "attestation_state_degraded":
                 state = AutoUpdateTrustState(
@@ -1973,7 +1978,8 @@ actor CoordinatorClient {
                     tokenValidated: state.tokenValidated,
                     bearerlessDuplicate: state.bearerlessDuplicate,
                     connected: state.connected,
-                    stableReason: reason
+                    stableReason: reason,
+                    acceptProvisional: state.acceptProvisional
                 )
             default:
                 state = AutoUpdateTrustState(
@@ -1986,7 +1992,8 @@ actor CoordinatorClient {
                     tokenValidated: state.tokenValidated,
                     bearerlessDuplicate: state.bearerlessDuplicate,
                     connected: false,
-                    stableReason: reason
+                    stableReason: reason,
+                    acceptProvisional: state.acceptProvisional
                 )
             }
         }

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -508,6 +508,220 @@ final class AutoUpdateTests: XCTestCase {
         try store.writePending(marker)
         return (marker, binary, backup)
     }
+
+    // MARK: — Provisional-tier auto-update graduation (2026-07-03)
+
+    // Before this fix: `guard tier == "pinned" else { return .provisional }`
+    // architecturally blocked every self-service (curl|bash-onboarded) provider
+    // from ever receiving auto-updates. After the fix, `acceptProvisional`
+    // (fed from `auto_update_accept_provisional` in the provider config or
+    // MACPROVIDER_AUTO_UPDATE_ACCEPT_PROVISIONAL env var) is an explicit
+    // operator opt-in that flips only the auto-update tier gate — pool cap,
+    // rate limit, routing-weight halving, and the other provisional-tier
+    // restrictions remain untouched (those live in the coordinator, not in
+    // this trust state).
+
+    func testTrustVerdictProvisionalWithoutAcceptFlagStaysIneligible() {
+        let state = AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "provisional",
+            encryptedLegValid: true,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: false,
+            tokenValidated: true,
+            bearerlessDuplicate: false,
+            connected: true
+            // acceptProvisional defaults to false
+        )
+        XCTAssertEqual(state.verdict, .provisional)
+        XCTAssertFalse(state.isEligible)
+    }
+
+    func testTrustVerdictProvisionalWithAcceptFlagBecomesEligible() {
+        let state = AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "provisional",
+            encryptedLegValid: true,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: false,
+            tokenValidated: true,
+            bearerlessDuplicate: false,
+            connected: true,
+            acceptProvisional: true
+        )
+        XCTAssertEqual(state.verdict, .eligible)
+        XCTAssertTrue(state.isEligible)
+    }
+
+    // Belt-and-suspenders: acceptProvisional must NOT loosen anything else.
+    // Even with acceptProvisional=true, encryptedLegFailed / attestationFailed
+    // / tokenRejected / bearerlessDuplicate must still block.
+    func testAcceptProvisionalDoesNotBypassEncryptedLegGate() {
+        let state = AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "provisional",
+            encryptedLegValid: false,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: false,
+            tokenValidated: true,
+            bearerlessDuplicate: false,
+            connected: true,
+            acceptProvisional: true
+        )
+        XCTAssertEqual(state.verdict, .encryptedLegFailed)
+    }
+
+    func testAcceptProvisionalDoesNotBypassBearerlessDuplicateGate() {
+        let state = AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "provisional",
+            encryptedLegValid: true,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: true,
+            tokenValidated: false,
+            bearerlessDuplicate: true,
+            connected: true,
+            acceptProvisional: true
+        )
+        XCTAssertEqual(state.verdict, .bearerlessDuplicate)
+    }
+
+    func testAcceptProvisionalDoesNotBypassTokenRejectionGate() {
+        let state = AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "provisional",
+            encryptedLegValid: true,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: true,
+            tokenValidated: false,
+            bearerlessDuplicate: false,
+            connected: true,
+            acceptProvisional: true
+        )
+        XCTAssertEqual(state.verdict, .tokenRejected)
+    }
+
+    // Rejected tier is a hard-refuse from the coordinator; acceptProvisional
+    // must not turn it into eligible. Only "pinned" and "provisional+opt-in"
+    // pass the gate.
+    func testAcceptProvisionalDoesNotEscalateRejectedTier() {
+        let state = AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "rejected",
+            encryptedLegValid: true,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: false,
+            tokenValidated: true,
+            bearerlessDuplicate: false,
+            connected: true,
+            acceptProvisional: true
+        )
+        XCTAssertEqual(state.verdict, .provisional)
+    }
+
+    // Pinned providers must remain eligible with or without the flag — flag
+    // affects only the provisional tier gate.
+    func testPinnedRemainsEligibleWhenAcceptProvisionalIsFalse() {
+        let state = AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "pinned",
+            encryptedLegValid: true,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: false,
+            tokenValidated: true,
+            bearerlessDuplicate: false,
+            connected: true,
+            acceptProvisional: false
+        )
+        XCTAssertEqual(state.verdict, .eligible)
+    }
+
+    // fromCoordinatorPayload must forward the flag intact. Prior version
+    // silently dropped it (missing param → default false), which was the
+    // shape of the trust-orphan bug the fix closes.
+    func testFromCoordinatorPayloadForwardsAcceptProvisional() throws {
+        let payload: [String: Any] = [
+            "type": "auth_response",
+            "status": "accepted",
+            "tier": "provisional",
+        ]
+        let session = try Tier2ProviderSession(
+            providerID: "provider-test",
+            assignedID: "assigned-test",
+            selectedAEAD: Tier2ProviderSession.aeadSuite,
+            keyID: "kid-test",
+            c2pKey: Data(repeating: 0x11, count: 32),
+            p2cKey: Data(repeating: 0x22, count: 32),
+            c2pNonceBase: Data([0x01, 0x02, 0x03, 0x04]),
+            p2cNonceBase: Data([0x05, 0x06, 0x07, 0x08])
+        )
+        let state = AutoUpdateTrustState.fromCoordinatorPayload(
+            payload,
+            isV2: true,
+            session: session,
+            providerToken: "test-token",
+            assignedProviderTokenAdopted: false,
+            acceptProvisional: true
+        )
+        XCTAssertEqual(state.tier, "provisional")
+        XCTAssertTrue(state.acceptProvisional)
+        XCTAssertEqual(state.verdict, .eligible)
+    }
+
+    // Config loader must accept the flag from both YAML flat key,
+    // YAML nested `autoupdate.accept_provisional`, and the env var.
+    func testConfigLoaderReadsAcceptProvisionalFromYAMLFlatAndNestedAndEnv() throws {
+        // 1. Flat YAML key.
+        let flatYAML = """
+        auto_update_accept_provisional: true
+        """
+        let fromFlat = try ConfigLoader.load(
+            cli: CLIOverrides(configPath: "/tmp/provider.yaml"),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in flatYAML }
+        )
+        XCTAssertEqual(fromFlat.autoUpdateAcceptProvisional, true)
+
+        // 2. Nested YAML block.
+        let nestedYAML = """
+        autoupdate:
+          accept_provisional: true
+        """
+        let fromNested = try ConfigLoader.load(
+            cli: CLIOverrides(configPath: "/tmp/provider.yaml"),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in nestedYAML }
+        )
+        XCTAssertEqual(fromNested.autoUpdateAcceptProvisional, true)
+
+        // 3. Env var overrides YAML (matches existing precedence).
+        let fromEnv = try ConfigLoader.load(
+            cli: CLIOverrides(configPath: "/tmp/provider.yaml"),
+            environment: ["MACPROVIDER_AUTO_UPDATE_ACCEPT_PROVISIONAL": "false"],
+            fileExists: { _ in true },
+            readFile: { _ in flatYAML }
+        )
+        XCTAssertEqual(fromEnv.autoUpdateAcceptProvisional, false)
+
+        // 4. Default is nil (unset), preserving the pinned-only trust
+        //    posture for existing deployments that haven't opted in.
+        let fromDefault = try ConfigLoader.load(
+            cli: CLIOverrides(configPath: "/tmp/provider.yaml"),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in "port: 8080" }
+        )
+        XCTAssertNil(fromDefault.autoUpdateAcceptProvisional)
+    }
 }
 
 private extension ISO8601DateFormatter {

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -197,6 +197,30 @@ tier2:
   # When empty, /poolz falls back to scheme + request Host. For Pearl:
   public_catalog_base_url: "https://coordinator.streamvc.live"
 
+# Auto-update recommendation surface. The coordinator forwards
+# `latest_binary_version` to every connected provider in its
+# `auth_response` / `state_update` frame as `recommended_binary_version`.
+# Provider CLIs whose auto-update trust-state gate accepts the coordinator
+# (pinned tier, OR provisional + operator opt-in via
+# `auto_update_accept_provisional: true` on the provider config — added
+# 2026-07-03 to unblock self-service providers from being trust-orphaned
+# from fixes) will then fetch + install the target release.
+#
+# WHEN THIS BLOCK IS UNSET the field is omitted from the wire frame and
+# providers receive no recommendation → auto-update never fires. This
+# block was silently missing from Pearl's `/opt/macprovider/coordinator.yaml`
+# at the 2026-07-03 KV-cache detection cutover: `air5` sat on v1.7.0 while
+# v1.7.9 was already released, because coord had nothing to advertise.
+# Landing it in the checked-in example prevents re-discovery on a fresh
+# clone deploy.
+#
+# `required_binary_version` (optional) hard-rejects providers below the
+# version, closing WS with CloseVersionTooOld. Use for security fixes
+# that must not be optional. Leave unset for advisory releases.
+coordinator_advertised_version:
+  latest_binary_version: "1.7.9"
+  # required_binary_version: "1.7.0"
+
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that
 # may connect MUST be listed here). Edit this list locally — DO NOT
 # add providers by SSHing to the VPS and appending to /opt/macprovider/


### PR DESCRIPTION
## Summary

Two related fixes surfaced by the 2026-07-03 KV-cache-detection cutover:

1. **Provisional-tier auto-update opt-in.** Adds `auto_update_accept_provisional` (triple-exposed: flat YAML key, nested `autoupdate.accept_provisional`, env `MACPROVIDER_AUTO_UPDATE_ACCEPT_PROVISIONAL`) so an operator can flip auto-update on for a provisional-tier provider. Default nil (== false) preserves the pre-existing pinned-only trust posture.
2. **Coord `coordinator_advertised_version` block landed in `dist/coordinator.yaml.example`** so Pearl's fix survives a fresh-clone deploy.

## Why (fix 1)

`AutoUpdateTrustState.verdict` had:

```swift
guard tier == "pinned" else { return .provisional }
```

Provisional providers — which is what every self-service (`curl|bash`-onboarded) provider becomes per SPEC-003 FR-C9 — silently returned `.provisional`, and `runAutoupdateIfEligible` recorded a skip event with `reason: "provisional"`. **100% of beta providers were trust-orphaned from receiving fixes** without manual `macprovider-cli update` via SSH per Mac.

Observed today on `air5` (self-mint, provisional) sitting at v1.7.0 while v1.7.9 was already published. Coord advertised the recommendation, provider received it, provider skipped:

```
{"target_version":"1.7.9","outcome":"skipped","reason":"provisional",...}
```

## Design choice (kept minimal)

I considered coord-side auto-promotion `provisional → pinned` after 24h clean soak. Rejected because it would ALSO lift:

- Pool cap (`provisional_pool_max`) — DoS defense
- Admission rate limit (`provisional_admission_rate_per_hour`) — DoS defense
- Routing-weight halving — trust proxy on the money path

Those are load-bearing tier restrictions. This PR loosens **only the auto-update gate**, leaves everything else exactly as-is. Provider-side opt-in matches the shape of the existing `auto_update_enabled` config toggle. Operator flips it per-Mac when they trust the coordinator's version recommendation surface.

## Why (fix 2)

Pearl's live `/opt/macprovider/coordinator.yaml` had no `coordinator_advertised_version` block at all — coord was sending `recommended_binary_version=""` (omitempty, field absent from JSON) to every connected provider, and auto-update never fired regardless of tier. The block was manually appended on Pearl earlier today (backup `coordinator.yaml.bak-20260703T081621Z`), but the checked-in template was silent. A re-deploy from a fresh clone would hit deploy step 1b's config-drift check and abort until the operator manually re-appended or clobbered Pearl with `ALLOW_CONFIG_DRIFT=1`.

Landing the block in `dist/coordinator.yaml.example` closes that gap. Also documents `required_binary_version` as the security-hard-fail counterpart (rejects providers below the version via `CloseVersionTooOld`).

## Defense-in-depth invariants preserved

Even with `acceptProvisional: true`, the trust-state verdict still returns:
- `.coordinatorDisconnected` when `!connected`
- `.legacyHelloAck` when `!v2Accepted`
- `.bearerlessDuplicate` when the auth-bearer duplicate marker is set
- `.provisional` when tier is anything other than `pinned` or `provisional`+opt-in (specifically: `rejected` or unknown)
- `.encryptedLegFailed` when tier2 session invalid
- `.attestationFailed` when attestation required but not satisfied
- `.tokenRejected` when token configured but validation failed

Six new tests explicitly lock these invariants (see `AutoUpdateTests.swift` diff).

## Tests

9 new tests, all green:

```
AutoUpdateTests
├── testTrustVerdictProvisionalWithoutAcceptFlagStaysIneligible
├── testTrustVerdictProvisionalWithAcceptFlagBecomesEligible
├── testAcceptProvisionalDoesNotBypassEncryptedLegGate
├── testAcceptProvisionalDoesNotBypassBearerlessDuplicateGate
├── testAcceptProvisionalDoesNotBypassTokenRejectionGate
├── testAcceptProvisionalDoesNotEscalateRejectedTier
├── testPinnedRemainsEligibleWhenAcceptProvisionalIsFalse
├── testFromCoordinatorPayloadForwardsAcceptProvisional
└── testConfigLoaderReadsAcceptProvisionalFromYAMLFlatAndNestedAndEnv
```

Full `swift test --filter AutoUpdateTests` green (existing + new). `swift build -c release` green.

## Rollout after merge

1. Land + cut a new provider binary release (v1.7.11).
2. On a provisional-tier Mac you want to auto-update, add to `~/.config/macprovider/config.yaml`:
   ```yaml
   auto_update_accept_provisional: true
   ```
3. Restart provider. Next `auth_response` from coord carrying `recommended_binary_version` will now be honored.
4. Redeploy coord to Pearl from this branch — `dist/coordinator.yaml.example` block replaces the manual append + backup preserved as history.

## Not tested in this PR

Live prod verify — needs a provider on the network running a binary that includes this fix AND whose operator has flipped the flag. Deferred to post-merge deploy sequence.

## Related

- PR #332 + #338 — the KV-cache work that surfaced why beta providers being trust-orphaned from fixes matters.
- SPEC-003 FR-C9 — provisional-tier semantics.
- SPEC-025 §12 conflict #2 — the malibu-app managed-by early-out still no-ops before this gate; unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
