### PR TITLE
[codex] Fix CI watchdog pipe and AC-18 timing flake

### DIFF
--- a/phase4-coordinator/internal/stats/mux.go
+++ b/phase4-coordinator/internal/stats/mux.go
@@ -36,6 +36,8 @@ type Mux struct {
 	metrics       *metrics.Metrics // optional; nil → no metric emit
 }
 
+const authFailureMinLatency = 5 * time.Millisecond
+
 func NewMux(reader *store.Store, cors CORSConfig, backfillMode, partialSince string, trustedProxies []string, logger zerolog.Logger) *Mux {
 	return NewMuxWithMetrics(reader, cors, backfillMode, partialSince, trustedProxies, logger, nil)
 }
@@ -99,6 +101,7 @@ func (m *Mux) dispatch(w http.ResponseWriter, r *http.Request) {
 	// /health are §4.3 `Auth: None`; Authorization is ignored.
 	var ar authResult
 	if endpoint == "leaderboard" {
+		authStarted := time.Now()
 		// Layer 4 — auth-failure tier (Authorization-present
 		// only). Round-3 CODE H1: only schedule the refund
 		// AFTER allow returns true.
@@ -135,6 +138,7 @@ func (m *Mux) dispatch(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if ar.statusCode == http.StatusUnauthorized {
+			padAuthFailureLatency(authStarted)
 			// Rejected keyed — omit ACAO per §5.7 rows 3/5/6/7.
 			w.Header().Set("Vary", varyForPublic())
 			writeError(w, r, http.StatusUnauthorized, codeUnauthorized, "unauthorized", now, nil)
@@ -248,6 +252,12 @@ func (m *Mux) dispatch(w http.ResponseWriter, r *http.Request) {
 		m.h.handleLeaderboard(rec, r, ar)
 	case "health":
 		m.h.handleHealth(rec, r, ar)
+	}
+}
+
+func padAuthFailureLatency(started time.Time) {
+	if remaining := authFailureMinLatency - time.Since(started); remaining > 0 {
+		time.Sleep(remaining)
 	}
 }
 

--- a/scripts/test-watchdog-inline-drift.sh
+++ b/scripts/test-watchdog-inline-drift.sh
@@ -58,7 +58,7 @@ normalize() {
 # (R2 architect MEDIUM).
 expected_shebang="#!/usr/bin/env bash"
 standalone_shebang="$(head -1 "$STANDALONE")"
-inline_shebang="$(printf "%s\n" "$extracted_inline" | head -1)"
+inline_shebang="${extracted_inline%%$'\n'*}"
 if [ "$standalone_shebang" != "$expected_shebang" ]; then
   echo "ERROR: $STANDALONE missing/wrong shebang: $standalone_shebang" >&2
   exit 1


### PR DESCRIPTION
## Summary

This standalone CI-fix PR bundles the two failures seen on the onboarding PR branch:

- avoids the `printf | head` broken-pipe failure in `scripts/test-watchdog-inline-drift.sh` under `set -euo pipefail`
- stabilizes SPEC-017 AC-18 row 5/6/7 timing equivalence by adding a 5 ms minimum latency floor only for keyed `/v1/stats/leaderboard` auth-failure 401 responses

## Root Cause

The watchdog drift script wrote the full extracted heredoc into a pipe where `head -1` can close early. On Ubuntu CI this surfaced as `printf: write error: Broken pipe` before the drift comparison ran.

The AC-18 failure was a sub-millisecond median spread across auth-failure rows 5/6/7 on a shared runner. The handler already performs the required shared SHA-256 and partner-key lookup work before branching; the new floor masks residual branch and runner jitter without affecting valid partner requests or public stats endpoints.

## Validation

- `cd phase4-coordinator && go test -tags=integration -run TestAC18_TimingEquivalenceRows5_6_7 -count=1 -v ./internal/stats`
- `make test-coordinator-integration`
- `make test-dist`
- `cd phase4-coordinator && go test ./internal/stats/...`

## Notes

The original onboarding branch was reset back to `340d5db` so this fix is isolated from the SPEC-026 docs PR.
