### PR TITLE
chore(release): bump binaryVersion to 1.7.11

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.7.10"
+    static let binaryVersion = "1.7.11"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1481,10 +1481,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.10")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.10")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.7.10")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.7.10")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.7.11")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.7.11")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.7.11")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.7.11")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {


### PR DESCRIPTION
## Summary

Release-cycle bump for provider CLI binaryVersion 1.7.10 → 1.7.11. Ships to the release channel what's already on `main`:

- **#341** provisional-tier auto-update opt-in (`auto_update_accept_provisional`) + `coordinator_advertised_version` template block
- **#340** install.sh AMFI-inode refresh (cp/rm/cp)
- **#338** KV-cache: forward conversation_key on sticky miss too (prod-verified as 45% prefill reuse on `mac`)

## Rollout after merge

1. Tag `origin/main` HEAD with `v1.7.11` → GitHub release workflow builds + publishes darwin-arm64 binary automatically.
2. Bump Pearl's `coordinator_advertised_version.latest_binary_version: "1.7.11"` so providers upgrading to the new binary can then flip `auto_update_accept_provisional: true` and receive further fixes.

## Tested

Bump is a single-line change to a Swift constant; CI covers compile + regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)