### PR TITLE
fix(autotune): drop keychain path, use file-only (no more "login keychain password" prompt after auto-update)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -200,22 +200,35 @@ struct AutotuneHMACSecretStore {
     var randomBytes: (Int) throws -> Data = Self.secureRandomBytes
 
     func loadOrCreate() throws -> Data {
-        if usesDefaultPath {
-            if let keychainSecret = try? Self.loadKeychainSecret(), keychainSecret.count == 32 {
-                return keychainSecret
-            }
-        }
+        // Keychain path removed 2026-07-03: macOS binds the keychain-item ACL
+        // to the specific creating binary's code-signature hash. Auto-update
+        // replaces the binary with a new hash → ACL check fails → macOS
+        // prompts every operator for the "login" keychain password on the
+        // next interactive autotune run after each release. Under launchd
+        // (non-interactive) the API returns errSecInteractionRequired and
+        // the code silently falls through to file — so the keychain path
+        // was already dead weight for the auto-updated background flow,
+        // and pure UX drag for the interactive foreground flow.
+        //
+        // The file at ~/.config/macprovider/autotune-hmac-secret is created
+        // at 0600 under a 0700 parent (see writeNewFileSecret + ensurePrivate
+        // ParentDirectory). HMAC of autotune log integrity does not need
+        // keychain-level protection — the threat model (someone with code
+        // execution on this Mac forging autotune logs on the same Mac) is
+        // already outside what keychain protects against.
+        //
+        // Existing operators: any legacy `live.streamvc.macprovider.autotune`
+        // keychain item is now orphaned but harmless — it is never read.
+        // They can remove it with:
+        //   security delete-generic-password -s "live.streamvc.macprovider.autotune"
+        // No automatic delete is attempted; SecItemDelete would also trip
+        // the ACL prompt for the exact reason this fix exists.
         if FileManager.default.fileExists(atPath: path.path) {
             do {
                 return try loadExistingFileSecret()
             } catch {
                 return try rotateRecoverableFileSecret()
             }
-        }
-        if usesDefaultPath,
-           let created = try? Self.createKeychainSecret(randomBytes: randomBytes),
-           created.count == 32 {
-            return created
         }
         return try createFileSecret()
     }
@@ -328,43 +341,6 @@ struct AutotuneHMACSecretStore {
         }
         return true
     }
-
-    private static func loadKeychainSecret() throws -> Data {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: keychainService,
-            kSecAttrAccount as String: keychainAccount,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var result: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let data = result as? Data, data.count == 32 else {
-            throw AutotuneRecommendError.noHMACSecret
-        }
-        return data
-    }
-
-    private static func createKeychainSecret(randomBytes: (Int) throws -> Data) throws -> Data {
-        let secret = try randomBytes(32)
-        guard secret.count == 32 else { throw AutotuneRecommendError.noHMACSecret }
-        let attributes: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: keychainService,
-            kSecAttrAccount as String: keychainAccount,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
-            kSecValueData as String: secret,
-        ]
-        let status = SecItemAdd(attributes as CFDictionary, nil)
-        if status == errSecDuplicateItem {
-            return try loadKeychainSecret()
-        }
-        guard status == errSecSuccess else { throw AutotuneRecommendError.noHMACSecret }
-        return secret
-    }
-
-    private static let keychainService = "live.streamvc.macprovider.autotune"
-    private static let keychainAccount = "hmac-secret-v1"
 
     private static func secureRandomBytes(count: Int) throws -> Data {
         var data = Data(count: count)

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -776,6 +776,34 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertEqual(st.st_mode & 0o777, 0o600)
     }
 
+    // Locks the 2026-07-03 fix that removed the keychain code path from
+    // AutotuneHMACSecretStore.loadOrCreate. Any future refactor that
+    // reintroduces `SecItemCopyMatching` / `SecItemAdd` calls against the
+    // legacy `live.streamvc.macprovider.autotune` service in this file
+    // will fail this test. Keychain access is what caused every
+    // auto-updated provider to see a "login keychain password" prompt on
+    // interactive autotune runs after a version bump, because the ACL of
+    // the keychain item is bound to the specific creating binary's
+    // code-signature hash and auto-update replaces the binary.
+    func testHMACSecretStoreDoesNotCallKeychainAPIs() {
+        // Reflect the file bytes for any lingering keychain-service or
+        // account literal so this test tracks the *source*, not just the
+        // runtime behaviour. Fixed-string check keeps the invariant tight.
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/macprovider-cli/AutotuneRecommend.swift")
+        let source = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        XCTAssertFalse(source.contains("SecItemCopyMatching"), "AutotuneRecommend.swift must not call SecItemCopyMatching — see 2026-07-03 keychain-prompt fix")
+        XCTAssertFalse(source.contains("SecItemAdd"), "AutotuneRecommend.swift must not call SecItemAdd — see 2026-07-03 keychain-prompt fix")
+        // Note: the legacy service literal `live.streamvc.macprovider.autotune`
+        // is intentionally allowed in comments (so operators can grep the
+        // source for the name they need to delete via `security` CLI).
+        // Only the runtime `kSecAttrService:` binding must not reappear.
+        XCTAssertFalse(source.contains("kSecAttrService"), "AutotuneRecommend.swift must not bind kSecAttrService — see 2026-07-03 keychain-prompt fix")
+    }
+
     func testHMACSecretFileRotatesRecoverableRegularFileFailuresAndRejectsSymlink() throws {
         let worldDir = try tempDir()
         let worldURL = worldDir.appendingPathComponent("secret")


### PR DESCRIPTION
## Summary

Every auto-updated provider will see a `login` keychain password prompt the first time an operator interactively runs `macprovider-cli autotune --recommend --apply` after a version bump. macOS binds the keychain-item ACL to the *specific creating binary's code-signature hash*; auto-update replaces the binary with a new hash — same Developer ID team (`YF7XNRJUG4`), same identifier (`macprovider-cli`), different per-binary hash — and macOS treats the new binary as an unknown requester.

This PR drops the keychain code path entirely. The file at `~/.config/macprovider/autotune-hmac-secret` (mode `0600` under `0700` parent) becomes the sole storage.

## Observed today (2026-07-03)

`mac` provider (Augustas Air) after auto-updating from v1.7.10 to v1.7.11:

<img src="https://i.imgur.com/placeholder.png" alt="keychain prompt" width="400"/>

Prompt fired the moment autotune tried to load the HMAC secret.

## Why keychain wasn't giving us anything

- **Under launchd** (background, no UI): keychain API returns `errSecInteractionRequired` without prompting; existing `try?` in `loadOrCreate` swallowed it and fell through to file. Keychain path was already dead weight there.
- **Under interactive operator runs**: prompt → user friction on every version bump.
- **Threat model for HMAC autotune log integrity**: assumes attacker with code execution on the same Mac. Keychain doesn't defend against that. File at `0600` under `0700` parent is comparable protection for the actual threat.

## Alternative I considered

`SecAccessCreate` with the designated requirement (`identifier "macprovider-cli" and anchor apple generic and ... [subject.OU] = YF7XNRJUG4`) — would trust any future release-signed binary silently. But: existing operators still hit a one-time prompt during migration (their existing keychain item is still bound to the old ACL), and the added complexity earns no security benefit over the file path.

## Migration for existing operators

Existing operators have a now-orphaned keychain item that is never read. They can leave it or delete it:

```bash
security delete-generic-password -s "live.streamvc.macprovider.autotune" -a "hmac-secret-v1"
```

No automatic delete is attempted — `SecItemDelete` would also trip the ACL prompt for the exact reason this fix exists. The inline comment in `AutotuneRecommend.swift` calls this out for operators grepping the source.

## Tests

- **`testHMACSecretStoreDoesNotCallKeychainAPIs`** (new) — locks the invariant by grepping the source file for `SecItemCopyMatching`, `SecItemAdd`, and `kSecAttrService`. Any future refactor that reintroduces keychain calls fails this test. Comment mentions of the legacy service literal are intentionally allowed (so operators can grep source for the name they need to delete via `security` CLI).
- Existing `testHMACIdentityUsesSeparateDomainsAndSecretFileIs0600` and `testHMACSecretFileRotatesRecoverableRegularFileFailuresAndRejectsSymlink` unchanged and still green.

```
swift test --filter AutotuneRecommendTests  # all green
swift build -c release                       # green
```

## Not tested in this PR

No integration test for the launchd non-interactive flow (was already relying on `try?` swallowing `errSecInteractionRequired`). The keychain-removal is behaviour-preserving under launchd; the change is only observable in the interactive path.

## Related

- PR #341 provisional-tier auto-update opt-in — surfaces this bug for the first time at scale because it enables auto-update for the beta-scale (provisional-tier) provider population, which will then repeatedly hit this prompt on every version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
