### PR TITLE
fix(release): allow MLX package validation in CI

### DIFF
--- a/phase3-binary/dist/package.sh
+++ b/phase3-binary/dist/package.sh
@@ -27,6 +27,8 @@ xcodebuild -scheme macprovider-cli \
            -configuration Release \
            -destination 'platform=macOS,arch=arm64' \
            -derivedDataPath "$RELEASE_DIR" \
+           -skipPackagePluginValidation \
+           -skipMacroValidation \
            clean build 2>&1 | tail -20
 
 PRODUCTS="$RELEASE_DIR/Build/Products/Release"


### PR DESCRIPTION
## Summary
- allow noninteractive Xcode release packaging for the trusted MLX SwiftPM plugin and macro targets
- unblocks v1.8.0 prerelease canary publication after PR345

## Verification
- `phase3-binary/dist/package.sh v1.8.0`
- `PROVIDER_ARTIFACT=... PROVIDER_VERSION=1.8.0 scripts/check-tier2-provider-artifact.sh`
- `git diff --check`

## Risk
Narrow release tooling change. Package versions remain pinned in `Package.resolved`; this does not affect runtime code.