### PR TITLE
fix(release): accept MLX metallib in published verifier

### DIFF
--- a/scripts/verify-tier2-provider-release.sh
+++ b/scripts/verify-tier2-provider-release.sh
@@ -138,6 +138,8 @@ validate_payload_entries() {
       macprovider-cli)
         has_binary=1
         ;;
+      mlx.metallib)
+        ;;
       THIRD-PARTY-NOTICES.txt)
         ;;
       *.bundle|*.bundle/*)


### PR DESCRIPTION
## Summary
- allow `mlx.metallib` in the published release package verifier payload allowlist
- aligns the verifier with release packaging and artifact preflight for v1.8.0

## Verification
- `DOWNLOAD_ATTEMPTS=3 DOWNLOAD_RETRY_SLEEP=2 scripts/verify-tier2-provider-release.sh --tag v1.8.0`
- `git diff --check`

## Risk
Narrow verifier-only change; no runtime behavior changes.