### PR TITLE
fix(gateway): retry coord 503 no_provider_available with bounded backoff

### DIFF
--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -93,6 +93,15 @@ timeouts:
   coordinator_header_timeout_seconds: 300
   streaming_cancel_ms: 500
 
+retry_503:
+  # Retries only coordinator 503 no_provider_available responses (including
+  # empty-body fast refusals). Tier-2 policy and null-usage provider errors
+  # pass through unchanged.
+  enabled: true
+  max_attempts: 3
+  backoff_base_ms: 100
+  backoff_max_ms: 500
+
 settlement:
   # SPEC-022: automatically close held buyer reservations once coordinator
   # settlement finality is available. Disable only for emergency operator

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Settlement  SettlementConfig  `yaml:"settlement"`
 	CORS        CORSConfig        `yaml:"cors"`
 	Routing     RoutingConfig     `yaml:"routing"`
+	Retry503    Retry503Config    `yaml:"retry_503"`
 	Explorer    ExplorerConfig    `yaml:"explorer"`
 }
 
@@ -143,6 +144,13 @@ type RoutingConfig struct {
 	StickyTTLS    int  `yaml:"sticky_ttl_s"`
 }
 
+type Retry503Config struct {
+	Enabled       bool `yaml:"enabled"`
+	MaxAttempts   int  `yaml:"max_attempts"`
+	BackoffBaseMs int  `yaml:"backoff_base_ms"`
+	BackoffMaxMs  int  `yaml:"backoff_max_ms"`
+}
+
 type ExplorerConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
@@ -209,6 +217,7 @@ func Default() Config {
 		},
 		CORS:     CORSConfig{AllowedOrigins: []string{"https://console.streamvc.live", "https://streamvc.live"}},
 		Routing:  RoutingConfig{StickyEnabled: false, StickyTTLS: 1800},
+		Retry503: Retry503Config{Enabled: true, MaxAttempts: 3, BackoffBaseMs: 100, BackoffMaxMs: 500},
 		Explorer: ExplorerConfig{Enabled: false},
 	}
 }
@@ -411,6 +420,18 @@ func (c Config) Validate() error {
 	}
 	if c.Routing.StickyTTLS <= 0 {
 		return fmt.Errorf("routing.sticky_ttl_s must be > 0")
+	}
+	if c.Retry503.MaxAttempts < 1 || c.Retry503.MaxAttempts > 10 {
+		return fmt.Errorf("retry_503.max_attempts must be between 1 and 10")
+	}
+	if c.Retry503.BackoffBaseMs < 10 || c.Retry503.BackoffBaseMs > 5000 {
+		return fmt.Errorf("retry_503.backoff_base_ms must be between 10 and 5000")
+	}
+	if c.Retry503.BackoffMaxMs < 10 || c.Retry503.BackoffMaxMs > 10000 {
+		return fmt.Errorf("retry_503.backoff_max_ms must be between 10 and 10000")
+	}
+	if c.Retry503.BackoffMaxMs < c.Retry503.BackoffBaseMs {
+		return fmt.Errorf("retry_503.backoff_max_ms must be >= retry_503.backoff_base_ms")
 	}
 	for i, origin := range c.CORS.AllowedOrigins {
 		if origin == "*" || origin == "null" {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -14,12 +14,14 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"math/rand/v2"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/augstar/macprovider-gateway/internal/config"
 	"github.com/augstar/macprovider-gateway/internal/storage"
 )
 
@@ -271,50 +273,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		_ = s.store.ReleaseConcurrency(context.Background(), subject.AccountID, requestID(r), s.now())
 	}()
 
-	upReq, err := http.NewRequestWithContext(upCtx, http.MethodPost, strings.TrimRight(s.coordinatorBuyerURL(), "/")+"/v1/chat/completions", bytes.NewReader(body))
-	if err != nil {
-		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
-		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "coordinator_unavailable", "Coordinator unavailable")
-		return
-	}
-	copyForwardHeaders(upReq.Header, r.Header)
-	upReq.Header.Set("Content-Type", "application/json")
-	// SPEC-002 §11 + v1.4.2 R-2: forward the gateway-visible request id
-	// (which itself was honored from the buyer's inbound X-Request-ID
-	// when present, else minted by the gateway middleware) so the
-	// coordinator can store it in request_log.external_request_id and
-	// out-of-process auditors can join gateway usage_events with
-	// coordinator request_log on this shared id. Earlier code minted a
-	// fresh UUID here, breaking that join.
-	upReq.Header.Set("X-Request-ID", requestID(r))
-	upReq.Header.Set("X-MacProvider-Gateway-FirstByte-Unix-Ms", strconv.FormatInt(start.UnixMilli(), 10))
-	// SPEC-006 v0.9.1 / SPEC-002 v1.5.0 / issue #211: forward the
-	// gateway's authenticated account id on EVERY forwarded buyer
-	// request — bearer-authenticated and demo subjects alike, both on
-	// the sticky and non-sticky paths. The coordinator persists this
-	// into request_log.account_id; the composite
-	// (account_id, external_request_id) is the reconciliation key
-	// joining gateway usage_events to coordinator request_log (the
-	// composite-PK addendum from #196). Earlier code emitted this
-	// header only inside the sticky-routing conditional below, leaving
-	// the non-sticky hot path account-blind and reopening the
-	// cross-account request_id-collision class on the coordinator
-	// audit-trail side.
-	//
-	// The coordinator treats X-MacProvider-Account as an internal-
-	// routing header (see hasInternalRoutingHeader / selectProviderExcluding
-	// in phase4-coordinator/internal/buyer/server.go) gated by the
-	// gateway-service-token Authorization bearer. To avoid the
-	// coordinator rejecting every non-sticky chat with 400
-	// invalid_request, the upstream Authorization bearer is hoisted
-	// alongside the account header — same pair the sticky path
-	// already sends. M3-2 / SECU-4: prefer ServiceToken when set;
-	// falls back to OperatorKey so a not-yet-upgraded coordinator
-	// keeps accepting us. ISS-211 R1 security audit HIGH.
-	if subject.AccountID != "" {
-		upReq.Header.Set("Authorization", "Bearer "+s.cfg.Coordinator.UpstreamCoordinatorBearer())
-		upReq.Header.Set("X-MacProvider-Account", subject.AccountID)
-	}
+	internalConversation := ""
 	if s.cfg.Routing.StickyEnabled && !authn.Demo {
 		if tag := strings.TrimSpace(r.Header.Get("X-MacProvider-Conversation")); tag != "" {
 			if !validConversationTag(tag) {
@@ -323,12 +282,60 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if metadata, ok := s.coordinatorRoutingMetadata(upCtx); ok && metadata.Sticky.Enabled && metadata.Sticky.TTLSeconds == s.cfg.Routing.StickyTTLS {
-				// Authorization + X-MacProvider-Account already set
-				// unconditionally above (SPEC-006 v0.9.1). The sticky
-				// path's distinguishing header is X-MacProvider-Internal-Conv.
-				upReq.Header.Set("X-MacProvider-Internal-Conv", s.deriveConversationKey(subject.AccountID, tag))
+				internalConversation = s.deriveConversationKey(subject.AccountID, tag)
 			}
 		}
+	}
+	buildUpReq := func() (*http.Request, error) {
+		upReq, err := http.NewRequestWithContext(upCtx, http.MethodPost, strings.TrimRight(s.coordinatorBuyerURL(), "/")+"/v1/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		copyForwardHeaders(upReq.Header, r.Header)
+		upReq.Header.Set("Content-Type", "application/json")
+		// SPEC-002 §11 + v1.4.2 R-2: forward the gateway-visible request id
+		// (which itself was honored from the buyer's inbound X-Request-ID
+		// when present, else minted by the gateway middleware) so the
+		// coordinator can store it in request_log.external_request_id and
+		// out-of-process auditors can join gateway usage_events with
+		// coordinator request_log on this shared id. Earlier code minted a
+		// fresh UUID here, breaking that join.
+		upReq.Header.Set("X-Request-ID", requestID(r))
+		upReq.Header.Set("X-MacProvider-Gateway-FirstByte-Unix-Ms", strconv.FormatInt(start.UnixMilli(), 10))
+		// SPEC-006 v0.9.1 / SPEC-002 v1.5.0 / issue #211: forward the
+		// gateway's authenticated account id on EVERY forwarded buyer
+		// request — bearer-authenticated and demo subjects alike, both on
+		// the sticky and non-sticky paths. The coordinator persists this
+		// into request_log.account_id; the composite
+		// (account_id, external_request_id) is the reconciliation key
+		// joining gateway usage_events to coordinator request_log (the
+		// composite-PK addendum from #196). Earlier code emitted this
+		// header only inside the sticky-routing conditional below, leaving
+		// the non-sticky hot path account-blind and reopening the
+		// cross-account request_id-collision class on the coordinator
+		// audit-trail side.
+		//
+		// The coordinator treats X-MacProvider-Account as an internal-
+		// routing header (see hasInternalRoutingHeader / selectProviderExcluding
+		// in phase4-coordinator/internal/buyer/server.go) gated by the
+		// gateway-service-token Authorization bearer. To avoid the
+		// coordinator rejecting every non-sticky chat with 400
+		// invalid_request, the upstream Authorization bearer is hoisted
+		// alongside the account header — same pair the sticky path
+		// already sends. M3-2 / SECU-4: prefer ServiceToken when set;
+		// falls back to OperatorKey so a not-yet-upgraded coordinator
+		// keeps accepting us. ISS-211 R1 security audit HIGH.
+		if subject.AccountID != "" {
+			upReq.Header.Set("Authorization", "Bearer "+s.cfg.Coordinator.UpstreamCoordinatorBearer())
+			upReq.Header.Set("X-MacProvider-Account", subject.AccountID)
+		}
+		if internalConversation != "" {
+			// Authorization + X-MacProvider-Account are set
+			// unconditionally above (SPEC-006 v0.9.1). The sticky
+			// path's distinguishing header is X-MacProvider-Internal-Conv.
+			upReq.Header.Set("X-MacProvider-Internal-Conv", internalConversation)
+		}
+		return upReq, nil
 	}
 	promptEstimate := estimatePromptTokens(body)
 	// Validation cap uses promptCapTokens (with chat-template headroom)
@@ -337,7 +344,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// promptEstimate so error-path settlement does not over-charge.
 	maxUsageTokens := promptCapTokens(body) + maxTokens
 	structuredStreaming := chat.Stream && chat.hasStructuredOutput()
-	resp, err := s.client.Do(upReq)
+	resp, err := s.doCoordinatorChatWithRetry(upCtx, r, buildUpReq)
 	if err != nil {
 		if structuredStreaming && errors.Is(upCtx.Err(), context.DeadlineExceeded) {
 			if !s.settleBeforeResponse(w, r, subject, promptEstimate, 0, maxUsageTokens, "gateway_estimated", "provider_timeout") {
@@ -363,6 +370,147 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 	s.forwardNonStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens)
 }
+
+func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Request, buildUpReq func() (*http.Request, error)) (*http.Response, error) {
+	maxAttempts := 1
+	if s.cfg.Retry503.Enabled {
+		maxAttempts = s.cfg.Retry503.MaxAttempts
+	}
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+	totalBackoffMS := int64(0)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if err := upCtx.Err(); err != nil {
+			return nil, err
+		}
+		upReq, err := buildUpReq()
+		if err != nil {
+			return nil, err
+		}
+		resp, err := s.client.Do(upReq)
+		if err != nil {
+			return nil, err
+		}
+		if !s.cfg.Retry503.Enabled || maxAttempts == 1 || resp.StatusCode != http.StatusServiceUnavailable {
+			if attempt > 1 && resp.StatusCode == http.StatusOK {
+				slog.Info("gateway coord 503 retry recovered",
+					"request_id", requestID(r),
+					"attempt", attempt,
+					"total_backoff_ms", totalBackoffMS,
+				)
+			}
+			return resp, nil
+		}
+		body, readErr := readCoordRetryBody(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			// CODE R1 MEDIUM: preserve the body read-error semantic for
+			// downstream. Wrapping partial bytes in io.NopCloser would
+			// give forwardNonStreamingChat's readLimitedBody a clean EOF
+			// and skip the 502 upstream_provider_error branch, so a
+			// coordinator with a truncated body would be treated as a
+			// complete response. Replay the prefix then surface readErr.
+			resp.Body = &coord503PrefixErrBody{prefix: body, err: readErr}
+		} else {
+			resp.Body = io.NopCloser(bytes.NewReader(body))
+		}
+		resp.ContentLength = int64(len(body))
+		if readErr != nil || !isCoordNoProviderAvailable503(resp.StatusCode, body) {
+			return resp, nil
+		}
+		if attempt == maxAttempts {
+			slog.Warn("gateway coord 503 retry exhausted",
+				"request_id", requestID(r),
+				"attempts", maxAttempts,
+				"total_backoff_ms", totalBackoffMS,
+			)
+			return resp, nil
+		}
+		if err := upCtx.Err(); err != nil {
+			return resp, nil
+		}
+		backoff := coord503RetryBackoff(attempt, s.cfg.Retry503)
+		slog.Info("gateway coord 503 retry",
+			"request_id", requestID(r),
+			"attempt", attempt+1,
+			"backoff_ms", backoff.Milliseconds(),
+			"body_code", openAIErrorCode(body),
+		)
+		select {
+		case <-time.After(backoff):
+			totalBackoffMS += backoff.Milliseconds()
+			if err := upCtx.Err(); err != nil {
+				return resp, nil
+			}
+			_ = resp.Body.Close()
+		case <-upCtx.Done():
+			return resp, nil
+		}
+	}
+	return nil, upCtx.Err()
+}
+
+func coord503RetryBackoff(attempt int, cfg config.Retry503Config) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	sleepMS := cfg.BackoffBaseMs
+	for i := 1; i < attempt; i++ {
+		if sleepMS >= cfg.BackoffMaxMs {
+			sleepMS = cfg.BackoffMaxMs
+			break
+		}
+		sleepMS *= 2
+		if sleepMS > cfg.BackoffMaxMs {
+			sleepMS = cfg.BackoffMaxMs
+			break
+		}
+	}
+	jittered := int64(sleepMS) + (int64(sleepMS)*int64(rand.IntN(51)-25))/100
+	if jittered < 0 {
+		jittered = 0
+	}
+	return time.Duration(jittered) * time.Millisecond
+}
+
+func readCoordRetryBody(r io.Reader) ([]byte, error) {
+	lr := &io.LimitedReader{R: r, N: maxUpstreamResponseBodyBytes + 1}
+	body, err := io.ReadAll(lr)
+	if err != nil {
+		return body, err
+	}
+	if int64(len(body)) > maxUpstreamResponseBodyBytes {
+		return body, fmt.Errorf("upstream response body exceeds %d bytes", maxUpstreamResponseBodyBytes)
+	}
+	return body, nil
+}
+
+// coord503PrefixErrBody replays a captured body prefix and then surfaces a
+// deferred read error on the next Read call. It is used when the retry loop
+// buffered partial bytes from the coordinator response before hitting a
+// read error; downstream handlers must observe that same error so they can
+// take their upstream-error branch instead of treating a truncated body as
+// complete.
+type coord503PrefixErrBody struct {
+	prefix []byte
+	err    error
+	pos    int
+}
+
+func (b *coord503PrefixErrBody) Read(p []byte) (int, error) {
+	if b.pos < len(b.prefix) {
+		n := copy(p, b.prefix[b.pos:])
+		b.pos += n
+		return n, nil
+	}
+	if b.err != nil {
+		return 0, b.err
+	}
+	return 0, io.EOF
+}
+
+func (b *coord503PrefixErrBody) Close() error { return nil }
 
 func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64) {
 	body, err := readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
@@ -928,6 +1076,34 @@ func coordinatorTier2PolicyError(status int, body []byte) bool {
 	default:
 		return false
 	}
+}
+
+// isCoordNoProviderAvailable503 returns true when the coordinator's
+// response indicates the request MAY succeed on a retry — i.e. the
+// provider pool was momentarily busy. It intentionally does NOT
+// retry:
+//   - null-usage provider errors (billable failures)
+//   - tier2 policy errors (permanent for this request)
+//   - any 5xx other than 503
+func isCoordNoProviderAvailable503(status int, body []byte) bool {
+	if status != http.StatusServiceUnavailable {
+		return false
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return true
+	}
+	var raw any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return true
+	}
+	if isNullUsageProviderError(body) {
+		return false
+	}
+	if coordinatorTier2PolicyError(status, body) {
+		return false
+	}
+	code := openAIErrorCode(body)
+	return code == "" || code == "no_provider_available"
 }
 
 func openAIErrorCode(body []byte) string {

--- a/phase5-gateway/internal/router/chat_proxy_retry_test.go
+++ b/phase5-gateway/internal/router/chat_proxy_retry_test.go
@@ -1,0 +1,447 @@
+package router
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+	"github.com/augstar/macprovider-gateway/internal/storage"
+	"github.com/augstar/macprovider-gateway/internal/storage/sqlite"
+)
+
+const retryChatSuccessBody = `{"id":"chatcmpl_retry","object":"chat.completion","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`
+
+func TestGatewayCoord503RetryRecoversAfterTwoNoProviderResponses(t *testing.T) {
+	logs := captureRetryLogs(t)
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if calls <= 2 {
+			return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, retryChatSuccessBody), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_recovered")
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 3 {
+		t.Fatalf("coordinator calls=%d want 3", calls)
+	}
+	assertRetryLogCounts(t, logs.String(), 2, 1, 0)
+}
+
+func TestGatewayCoord503RetryExhaustsNoProviderResponses(t *testing.T) {
+	logs := captureRetryLogs(t)
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_exhausted")
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "no_provider_available")
+	if calls != 3 {
+		t.Fatalf("coordinator calls=%d want 3", calls)
+	}
+	assertRetryLogCounts(t, logs.String(), 2, 0, 1)
+}
+
+func TestGatewayCoord503RetrySkipsTier2PolicyError(t *testing.T) {
+	logs := captureRetryLogs(t)
+	var calls int
+	body := `{"error":{"code":"tier2_hash_verified_required","message":"tier2 policy rejected request","param":null,"type":"service_unavailable"}}`
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, body), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_tier2")
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("coordinator calls=%d want 1", calls)
+	}
+	if !strings.Contains(resp.Body.String(), `"code":"tier2_hash_verified_required"`) {
+		t.Fatalf("coordinator tier2 body not preserved: %s", resp.Body.String())
+	}
+	assertRetryLogCounts(t, logs.String(), 0, 0, 0)
+}
+
+func TestGatewayCoord503RetrySkipsNullUsageProviderError(t *testing.T) {
+	logs := captureRetryLogs(t)
+	var calls int
+	body := `{"error":{"code":"error_model_not_loaded","message":"model not loaded","param":null,"type":"api_error"}}`
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, body), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_null_usage")
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("coordinator calls=%d want 1", calls)
+	}
+	assertErrorCode(t, resp.Body.String(), "error_model_not_loaded")
+	assertRetryLogCounts(t, logs.String(), 0, 0, 0)
+}
+
+func TestGatewayCoord503RetryNoLogsOnFirstAttemptSuccess(t *testing.T) {
+	logs := captureRetryLogs(t)
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, retryChatSuccessBody), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_first_success")
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("coordinator calls=%d want 1", calls)
+	}
+	assertRetryLogCounts(t, logs.String(), 0, 0, 0)
+}
+
+func TestGatewayCoord503RetryDisabledKeepsSingleDispatch(t *testing.T) {
+	logs := captureRetryLogs(t)
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, func(cfg *config.Config) {
+		cfg.Retry503.Enabled = false
+	})
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_disabled")
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("coordinator calls=%d want 1", calls)
+	}
+	assertRetryLogCounts(t, logs.String(), 0, 0, 0)
+}
+
+func TestGatewayCoord503RetryReplaysIdenticalRequestBodies(t *testing.T) {
+	var calls int
+	var seen [][]byte
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read attempt body: %v", err)
+		}
+		seen = append(seen, body)
+		if calls <= 2 {
+			return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, retryChatSuccessBody), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_replay")
+	wantBody := chatBody(false)
+
+	resp := postChat(t, h, fullKey, wantBody, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if len(seen) != 3 {
+		t.Fatalf("captured bodies=%d want 3", len(seen))
+	}
+	for i, got := range seen {
+		if !bytes.Equal(got, []byte(wantBody)) {
+			t.Fatalf("attempt %d body=%q want %q", i+1, string(got), wantBody)
+		}
+	}
+}
+
+func TestGatewayCoord503RetryPreservesConcurrencyReservationAcrossAttempts(t *testing.T) {
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if calls <= 2 {
+			return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, retryChatSuccessBody), nil
+	})}
+	_, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_reservation")
+	spy := &retryReservationSpyStore{Store: store}
+	h := New(cfg, spy, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client)).Handler()
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 3 {
+		t.Fatalf("coordinator calls=%d want 3", calls)
+	}
+	if spy.reserveCalls != 1 || spy.acquireCalls != 1 {
+		t.Fatalf("reservation calls reserve=%d acquire=%d, want one each", spy.reserveCalls, spy.acquireCalls)
+	}
+	if spy.refundCalls != 0 {
+		t.Fatalf("RefundReservation calls=%d, want 0 before/after recovered retry", spy.refundCalls)
+	}
+	if spy.releaseCalls != 1 {
+		t.Fatalf("ReleaseConcurrency calls=%d, want 1 terminal release only", spy.releaseCalls)
+	}
+}
+
+func TestGatewayCoord503RetryAppliesBeforeStreamingSplit(t *testing.T) {
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, "data: {\"id\":\"chatcmpl\",\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":4,\"total_tokens\":7},\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n"), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_stream")
+
+	resp := postChat(t, h, fullKey, chatBody(true), nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 2 {
+		t.Fatalf("coordinator calls=%d want 2", calls)
+	}
+	if strings.Contains(resp.Body.String(), "no_provider_available") || !strings.Contains(resp.Body.String(), "data:") {
+		t.Fatalf("stream response mixed retry error with terminal stream: %s", resp.Body.String())
+	}
+}
+
+func TestGatewayCoord503RetryDefaultBackoffBound(t *testing.T) {
+	cfg := config.Default().Retry503
+	for i := 0; i < 200; i++ {
+		total := coord503RetryBackoff(1, cfg) + coord503RetryBackoff(2, cfg)
+		if total > 750*time.Millisecond {
+			t.Fatalf("default total retry backoff=%s exceeds 750ms", total)
+		}
+	}
+}
+
+func TestGatewayCoord503RetrySleepStopsOnBuyerCancel(t *testing.T) {
+	var calls atomic.Int32
+	firstAttemptReturned := make(chan struct{})
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			close(firstAttemptReturned)
+		}
+		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, func(cfg *config.Config) {
+		cfg.Retry503.BackoffBaseMs = 5000
+		cfg.Retry503.BackoffMaxMs = 5000
+	})
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_cancel")
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(chatBody(false))).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+fullKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(resp, req)
+		close(done)
+	}()
+	select {
+	case <-firstAttemptReturned:
+	case <-time.After(time.Second):
+		t.Fatal("first coordinator attempt was not reached")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not return promptly after buyer cancel during retry sleep")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("coordinator calls=%d want 1; retry sleep should be cancellable before second attempt", got)
+	}
+}
+
+func TestGatewayRetry503ConfigValidationViaLoad(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		retryYAML  string
+		wantSubstr string
+	}{
+		{name: "max attempts zero", retryYAML: "max_attempts: 0\n  backoff_base_ms: 100\n  backoff_max_ms: 500", wantSubstr: "retry_503.max_attempts"},
+		{name: "max attempts too high", retryYAML: "max_attempts: 11\n  backoff_base_ms: 100\n  backoff_max_ms: 500", wantSubstr: "retry_503.max_attempts"},
+		{name: "base too low", retryYAML: "max_attempts: 3\n  backoff_base_ms: 5\n  backoff_max_ms: 500", wantSubstr: "retry_503.backoff_base_ms"},
+		{name: "max too high", retryYAML: "max_attempts: 3\n  backoff_base_ms: 100\n  backoff_max_ms: 15000", wantSubstr: "retry_503.backoff_max_ms"},
+		{name: "max below base", retryYAML: "max_attempts: 3\n  backoff_base_ms: 500\n  backoff_max_ms: 100", wantSubstr: "retry_503.backoff_max_ms must be >="},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeRetryConfig(t, "enabled: true\n  "+tc.retryYAML)
+			_, err := config.Load(path)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("Load error=%v want containing %q", err, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func newRetryHarness(t *testing.T, client *http.Client, mutate func(*config.Config)) (http.Handler, *sqlite.Store, string, config.Config) {
+	t.Helper()
+	return newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Retry503.BackoffBaseMs = 10
+		cfg.Retry503.BackoffMaxMs = 10
+		if mutate != nil {
+			mutate(cfg)
+		}
+	}, WithHTTPClient(client))
+}
+
+func captureRetryLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return &buf
+}
+
+func assertRetryLogCounts(t *testing.T, logs string, retry, recovered, exhausted int) {
+	t.Helper()
+	if got := strings.Count(logs, `msg="gateway coord 503 retry"`); got != retry {
+		t.Fatalf("retry log count=%d want %d logs:\n%s", got, retry, logs)
+	}
+	if got := strings.Count(logs, `msg="gateway coord 503 retry recovered"`); got != recovered {
+		t.Fatalf("recovered log count=%d want %d logs:\n%s", got, recovered, logs)
+	}
+	if got := strings.Count(logs, `msg="gateway coord 503 retry exhausted"`); got != exhausted {
+		t.Fatalf("exhausted log count=%d want %d logs:\n%s", got, exhausted, logs)
+	}
+}
+
+func noProviderBody() string {
+	return `{"error":{"code":"no_provider_available","message":"No provider available","param":null,"type":"service_unavailable"}}`
+}
+
+func chatBody(stream bool) string {
+	if stream {
+		return `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	}
+	return `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+}
+
+type retryReservationSpyStore struct {
+	*sqlite.Store
+	reserveCalls int
+	acquireCalls int
+	refundCalls  int
+	releaseCalls int
+}
+
+func (s *retryReservationSpyStore) ReserveQuota(ctx context.Context, req storage.ReservationRequest) (storage.QuotaDecision, error) {
+	s.reserveCalls++
+	return s.Store.ReserveQuota(ctx, req)
+}
+
+func (s *retryReservationSpyStore) AcquireConcurrency(ctx context.Context, req storage.ConcurrencyRequest) (storage.ConcurrencyDecision, error) {
+	s.acquireCalls++
+	return s.Store.AcquireConcurrency(ctx, req)
+}
+
+func (s *retryReservationSpyStore) RefundReservation(ctx context.Context, accountID, requestID string, refundedAt int64) error {
+	s.refundCalls++
+	return s.Store.RefundReservation(ctx, accountID, requestID, refundedAt)
+}
+
+func (s *retryReservationSpyStore) ReleaseConcurrency(ctx context.Context, accountID, requestID string, releasedAt time.Time) error {
+	s.releaseCalls++
+	return s.Store.ReleaseConcurrency(ctx, accountID, requestID, releasedAt)
+}
+
+func writeRetryConfig(t *testing.T, retryBlock string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gateway.yaml")
+	content := fmt.Sprintf(`
+listen:
+  bind_address: 127.0.0.1
+  port: 9443
+proxy:
+  trusted_cidrs:
+    - 127.0.0.1/32
+public:
+  base_url: https://example.com
+  account_path: /account
+coordinator:
+  buyer_url: https://buyer.example
+  operator_url: https://op.example
+  operator_key: operator-secret
+  poolz_poll_interval_s: 5
+storage:
+  driver: sqlite
+  db_path: /tmp/test.db
+auth:
+  key_prefix: mp_
+  key_hash: hmac_sha256
+  key_hash_secret: secret
+  github_oauth_enabled: false
+  demo:
+    signing_secret: demo-secret
+  oauth:
+    callback_allowlist:
+      - https://example.com/auth/github/callback
+quotas:
+  account_daily_tokens: 100000
+  demo_daily_tokens_per_ip: 1000
+  demo_sessions_per_ip_per_hour: 10
+  account_concurrency: 2
+  demo_concurrency: 2
+  signup_accounts_per_ip_per_day: 3
+  reaper_interval_hours: 1
+  reservation_max_age_hours: 24
+retry_503:
+  %s
+`, retryBlock)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}

--- a/specs/AUDIT_GATEWAY_RETRY_503_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_GATEWAY_RETRY_503_ARCHITECT_PROMPT.md
@@ -1,0 +1,126 @@
+# AUDIT_GATEWAY_RETRY_503_ARCHITECT — ARCHITECT lane
+
+You are auditing the diff that implements the retry-with-backoff loop
+described in `specs/BUILD_GATEWAY_RETRY_503_IMPL_PROMPT.md`.
+
+## Your lane: ARCHITECT
+
+Focus on design-level concerns: placement, layering, consistency with
+existing patterns, and future-extensibility. Not code correctness, not
+security.
+
+### Look for
+
+1. **Placement of the retry loop**
+   - The retry loop wraps the coord dispatch BEFORE the split into
+     `forwardStreamingChat` / `forwardNonStreamingChat`. Verify this
+     placement in the diff. If the retry is inside one of the forward
+     functions instead, that's a HIGH finding (the streaming path
+     could return partial data before the retry decision).
+   - The retry is a handler-level concern (per BUILD "Prohibited
+     implementation choices" R2). Verify it is NOT implemented as
+     `http.RoundTripper` middleware on `s.client`.
+
+2. **Config placement**
+   - New `Retry503Config` struct is on the correct parent (`Config`
+     top-level vs a nested block like `CoordinatorConfig` or a new
+     `RetryConfig` block).
+   - The yaml key naming (`retry_503`) is consistent with the naming
+     style of existing keys (`coordinator_request_seconds`,
+     `warmup_gate_enabled`, etc.). Consider whether a more
+     general-purpose name (e.g. `coord_retry`) would age better.
+   - Config defaults registered in the same place as other config
+     defaults (avoid drift where some knobs default via unmarshal
+     tags and others via `applyDefaults` / normaliser).
+
+3. **Observability naming stability**
+   - Log message strings (`"gateway coord 503 retry"`, `"… retry
+     recovered"`, `"… retry exhausted"`) should be greppable and
+     stable enough that ops dashboards can rely on them.
+   - Field names (`attempt`, `backoff_ms`, `body_code`,
+     `total_backoff_ms`, `attempts`) should follow the same
+     snake_case convention as existing gateway log fields.
+   - When metrics wiring is added later (out-of-scope for this PR),
+     the current log structure should map cleanly to a
+     Prometheus/StatsD schema.
+
+4. **Consistency with existing retry / backoff patterns in the
+   codebase**
+   - Search the coord + gateway for other retry loops. Does this new
+     one match their style (helper function name, backoff formula,
+     jitter approach)?
+   - If a shared `backoffMs(attempt, base, max)` helper exists, does
+     the new code reuse it or duplicate the logic?
+
+5. **Test-file naming**
+   - `chat_proxy_retry_test.go` — consistent with existing per-topic
+     test file naming (e.g. `chat_proxy_streaming_test.go`,
+     `chat_proxy_settle_test.go` if they exist)?
+
+6. **Helper placement**
+   - `isCoordNoProviderAvailable503` placed adjacent to
+     `coordinatorTier2PolicyError` and `isNullUsageProviderError` for
+     review-locality. Verify.
+   - Helper exported vs package-private matches the convention set by
+     its neighbours.
+
+7. **Interaction with SPEC-006 / SPEC-024 settlement paths**
+   - Retry loop MUST NOT touch settlement / reservation code — this
+     is a BUILD-prompt R7 requirement. Verify no accidental coupling
+     was introduced (e.g. the retry loop passes an extra argument to
+     `forwardStreamingChat` that leaks retry state into settlement).
+   - `promptEstimate`, `maxUsageTokens`, `maxTokens` are computed
+     once before the loop — verify they're NOT recomputed per attempt
+     (would waste work and could produce inconsistent values under
+     race).
+
+8. **Streaming safety**
+   - A streaming request that would have failed on attempt 1 (503),
+     and succeeds on attempt 2 — the buyer sees a clean 200 stream,
+     not a "first 503-body-then-200-stream" concatenation. Verify by
+     tracing the response-write path.
+   - `w http.ResponseWriter` — no bytes written to `w` on any
+     interim-attempt failure. First byte to `w` happens only after
+     the terminal attempt.
+
+9. **Scope discipline**
+   - No changes outside `chat_proxy.go`, `config.go`, and the new
+     test file (per BUILD "Scope of change"). Except:
+     - `gateway.yaml.example` may be extended with a commented-out
+       block IF such a file exists in the repo. If it doesn't exist,
+       verify one was NOT created (scope creep).
+   - No new dependencies added to `go.mod`.
+   - No changes to coord / provider code.
+
+10. **Future-extensibility signals**
+    - Is the retry helper structured such that adding "retry on 504"
+      or "retry on network error" would be a small change? A design
+      that hardcodes 503 everywhere makes future ops changes painful.
+    - Would this design generalise to other outbound-call sites in
+      gateway (auth, account lookup) if they later need similar
+      retry? If so, is the helper reusable, or is it tangled with
+      `chat_proxy.go`-specific state?
+
+### Do NOT flag
+
+- Code correctness bugs (CODE lane).
+- Security concerns (SECURITY lane).
+- Findings that are matters of pure aesthetic preference with no
+  operational consequence.
+- Suggestions to refactor pre-existing code untouched by the diff.
+
+### Output format
+
+Report findings ranked C / H / M / L / I. Each finding lists:
+file:line, the design concern, why it will bite (concrete future
+scenario), proposed change in plain English.
+
+Bottom-line status:
+
+```
+STATUS: ARCHITECT lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+## Diff to audit
+
+Read `git diff` in the worktree.

--- a/specs/AUDIT_GATEWAY_RETRY_503_CODE_PROMPT.md
+++ b/specs/AUDIT_GATEWAY_RETRY_503_CODE_PROMPT.md
@@ -1,0 +1,123 @@
+# AUDIT_GATEWAY_RETRY_503_CODE — CODE lane
+
+You are auditing the diff that implements the retry-with-backoff loop
+described in `specs/BUILD_GATEWAY_RETRY_503_IMPL_PROMPT.md`. Read that
+file for the behavioural contract, then read the diff.
+
+## Your lane: CODE correctness
+
+Focus exclusively on code-correctness bugs — not security, not
+architecture. Assume the design in the BUILD prompt is fixed.
+
+### Look for
+
+1. **Retry loop control flow**
+   - Off-by-one in attempt counting (default `MaxAttempts=3` means 1 +
+     2 = 3 total attempts; verify the loop actually makes exactly 3
+     attempts on a 3× 503 case).
+   - Retry decision made against a value the response body has been
+     read for (not a body that was consumed and not replayed).
+   - Loop-exit conditions cover: 200, non-retryable 5xx, retryable 503
+     exhausted, network error, context cancel.
+   - Backoff calculation: `backoff_base_ms * 2^(attempt-1)` capped at
+     `backoff_max_ms`, jitter ±25 %, never negative.
+
+2. **Body drain / close discipline**
+   - Response body drained (or bounded-read) BEFORE `Body.Close()` on
+     every retry path.
+   - No missed `defer resp.Body.Close()` on the retry loop path.
+   - No file-descriptor / conn-pool leak on the failure path (`.Do()`
+     returned an error before we got a response).
+
+3. **Request replay integrity**
+   - `bytes.NewReader(body)` (or equivalent) is re-instantiated per
+     attempt so the reader position is at zero for each `Do(...)`.
+   - `upReq.Header` state is reset per attempt if the code mutates it
+     between attempts (e.g. adds a retry-attempt header — if this
+     doesn't happen, verify headers are still stable).
+   - `X-Request-ID` is byte-identical across attempts.
+   - Same `upCtx` used across attempts (do NOT create a new context
+     per attempt).
+
+4. **Context / cancellation**
+   - Sleep is cancellable via `select { case <-time.After: … ; case
+     <-upCtx.Done(): … }` (or `time.NewTimer` with `Stop()` on the
+     cancel branch to avoid timer leak).
+   - Loop exits promptly on `upCtx.Err() != nil`.
+   - No `time.Sleep(...)` used inside the loop (would ignore cancel).
+
+5. **Response handoff to downstream**
+   - After retry exhaustion or non-retryable 503, the response object
+     handed to `forward{Streaming,NonStreaming}Chat` still has a
+     readable body (i.e. if the body was drained during the retry
+     check, it was replaced with `io.NopCloser(bytes.NewReader(...))`
+     so downstream can still read it).
+   - StatusCode, Header, and Body semantics preserved.
+
+6. **Logging**
+   - `slog.Info` / `slog.Warn` uses the exact message strings from R9
+     of the BUILD prompt: `"gateway coord 503 retry"`, `"gateway coord
+     503 retry recovered"`, `"gateway coord 503 retry exhausted"`.
+   - `attempt` is the 1-indexed attempt-about-to-be-made (so first
+     retry log is `attempt=2`).
+   - No `slog.Info` fires on the initial (attempt=1) success path.
+   - No log line duplicated / dropped on cancel path.
+
+7. **Config validation**
+   - New config-validation branches trigger correctly on
+     `MaxAttempts=0`, `MaxAttempts=11`, `BackoffBaseMs=5`,
+     `BackoffMaxMs=15000`, `BackoffMaxMs < BackoffBaseMs`.
+   - Validation error messages match repo convention.
+   - Defaults applied correctly when field is zero-value in unmarshal.
+
+8. **Retryable-503 detection**
+   - `isCoordNoProviderAvailable503(status, body)` returns:
+     - `false` for `status != 503`
+     - `true` for `status == 503 && len(body) == 0`
+     - `false` when `isNullUsageProviderError(body)` returns true
+     - `false` when `coordinatorTier2PolicyError(503, body)` returns
+       true
+     - `true` when parsed code is empty OR `no_provider_available`
+     - `false` otherwise
+   - Invoked with the FULL body (or a large-enough prefix) to make an
+     accurate decision.
+
+9. **Jitter random source**
+   - Uses `math/rand/v2` (repo standard). Or if repo uses `math/rand`,
+     the choice is consistent with existing code.
+   - Not creating a new `*rand.Rand` per call (would be a perf smell).
+   - No division-by-zero when computing jitter percentages.
+
+10. **Test coverage matches AC3**
+    - Each of the 9 AC3 test cases is present as a distinct test.
+    - Retry-replay-integrity test actually inspects captured request
+      bodies for byte-identity, not just count.
+    - Fake clock (or sleep captor) used for backoff assertion, not
+      real-wallclock sleep in tests.
+
+### Do NOT flag
+
+- Placement / architecture (that's the ARCHITECT lane).
+- Auth-header leakage / credential exposure (that's the SECURITY
+  lane).
+- Naming taste, comment style, log-message wording (unless it violates
+  R9 of the BUILD prompt verbatim).
+- Anything outside the diff.
+
+### Output format
+
+Report findings ranked C (CRITICAL) / H (HIGH) / M (MEDIUM) / L (LOW) /
+I (INFO). One paragraph per finding: file:line, defect description,
+concrete failure scenario (inputs → wrong output), proposed fix in
+plain English. No code patches.
+
+Include a bottom-line status line:
+
+```
+STATUS: CODE lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+## Diff to audit
+
+The diff is the current uncommitted change in this worktree. Read
+`git diff` and the new file(s) to identify all changes.

--- a/specs/AUDIT_GATEWAY_RETRY_503_CODE_R2_PROMPT.md
+++ b/specs/AUDIT_GATEWAY_RETRY_503_CODE_R2_PROMPT.md
@@ -1,0 +1,91 @@
+# AUDIT_GATEWAY_RETRY_503_CODE — CODE lane, ROUND 2
+
+Round 1 CODE audit returned 1 MEDIUM finding:
+
+> M — phase5-gateway/internal/router/chat_proxy.go:405: body read
+> errors during the retry classification pass are swallowed. Scenario:
+> coordinator returns 503 with a body reader that yields partial bytes
+> plus an error; `readCoordRetryBody` returns `readErr`, but lines
+> 405-410 replace `resp.Body` with the partial buffer and hand it
+> downstream as a clean readable body. Existing downstream code would
+> observe the body read error and take its upstream-error path; this
+> can instead produce a terminal 503 no_provider_available or pass
+> through a partial coordinator body. Preserve body read-error
+> semantics.
+
+The fix in this round wraps the buffered body in a new
+`coord503PrefixErrBody` type that replays the captured prefix bytes
+and then surfaces the deferred read error on the next `Read` call, so
+downstream `forwardNonStreamingChat` sees the same read error and
+takes its existing 502 `upstream_provider_error` branch.
+
+Round 1 LOW finding (real sleeps in retry-loop tests) is deliberately
+NOT fixed — per repo convention, LOW/INFO findings ship with PR-body
+documentation and are not gating.
+
+## Your lane: CODE, ROUND 2
+
+Audit ONLY the ROUND 1 → ROUND 2 delta. Everything else in the diff
+was already accepted in Round 1. Focus on:
+
+1. **The fix at `chat_proxy.go:405-419` (the branch that assigns
+   resp.Body).**
+   - `coord503PrefixErrBody` correctly emits the prefix bytes across
+     multi-Read invocations (partial reads by the caller).
+   - The deferred read error surfaces ONLY after the prefix is fully
+     replayed — never before.
+   - No infinite loop / stall if a caller reads after the error has
+     been returned once.
+   - Position tracking is correct across concurrent reads-of-one-body
+     (net/http uses one goroutine per response body — verify no
+     assumption of goroutine-safety is required, but the type MUST be
+     safe for the single-consumer pattern net/http uses).
+
+2. **The `coord503PrefixErrBody` type definition.**
+   - `Read` semantics conform to `io.Reader` contract: return `(n,
+     nil)` while data is available, return `(0, err)` on error,
+     `(0, io.EOF)` on clean end.
+   - `Close` returns `nil` and is safe to call more than once.
+   - `pos` field never exceeds `len(prefix)`.
+
+3. **Downstream interaction.**
+   - `forwardNonStreamingChat` at chat_proxy.go:489 uses
+     `readLimitedBody`; verify by inspection that the read-error
+     branch (line ~493) is actually reached when the wrapped body
+     surfaces `coord503PrefixErrBody.err`.
+   - `forwardStreamingChat` at chat_proxy.go:604 or similar path
+     receives a 503 status with the same body wrapper — verify the
+     downstream 503 branch doesn't ALSO try to read the body and get
+     the deferred error at the wrong moment.
+
+4. **Regression: existing behaviour on non-error retry paths.**
+   - When `readErr == nil`, the code takes the `io.NopCloser(
+     bytes.NewReader(body))` branch unchanged — the Round 1 test
+     assertions still pass.
+   - `resp.ContentLength = int64(len(body))` still runs on both
+     branches (so downstream can still trust the header).
+
+## Do NOT flag
+
+- Anything already accepted in Round 1 (config, retry loop control
+  flow, logging, jitter, config validation, existing test coverage).
+- The Round 1 LOW finding about real sleeps in tests — deferred by
+  design.
+- Anything outside the R1 → R2 delta.
+
+## Output format
+
+Findings ranked C / H / M / L / I. Each finding lists: file:line,
+defect, concrete failure scenario, proposed fix.
+
+Bottom-line status:
+
+```
+STATUS: CODE lane R2 — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+## Diff to audit
+
+`git diff` in the worktree shows the full accumulated change. The
+delta between R1 and R2 is the addition of the
+`coord503PrefixErrBody` type and the split at chat_proxy.go:405-419.

--- a/specs/AUDIT_GATEWAY_RETRY_503_SECURITY_PROMPT.md
+++ b/specs/AUDIT_GATEWAY_RETRY_503_SECURITY_PROMPT.md
@@ -1,0 +1,118 @@
+# AUDIT_GATEWAY_RETRY_503_SECURITY — SECURITY lane
+
+You are auditing the diff that implements the retry-with-backoff loop
+described in `specs/BUILD_GATEWAY_RETRY_503_IMPL_PROMPT.md`.
+
+## Your lane: SECURITY
+
+Focus exclusively on security-class defects. Not correctness, not
+architecture. Assume the design is fixed by the BUILD prompt.
+
+### Look for
+
+1. **Credential / secret handling across retries**
+   - `Authorization` header (buyer token or internal service token)
+     replayed byte-identical on retries — no token mutation, no logging
+     of the token in retry log lines.
+   - `X-Demo-Token` and any other auth-shaped header treated
+     identically.
+   - `X-MacProvider-Account` (internal-only) not exposed to buyer via
+     any error path added by this PR.
+
+2. **Amplification / DoS surface**
+   - Retry loop bounded so a buyer cannot amplify one inbound request
+     into many upstream requests beyond `MaxAttempts`.
+   - No path where a hostile buyer can drive coord to sustained 503
+     and cause the gateway to CPU-spin (the sleep must be enforced).
+   - Concurrency reservation is held across all retries — a buyer
+     cannot dodge concurrency limits by triggering retries.
+
+3. **Log injection / PII leakage**
+   - `body_code` field in retry log lines uses the parsed
+     `openAIErrorCode(body)` return value which strips whitespace but
+     may contain untrusted content. Verify the code sanitises for
+     control characters / newlines before slog, OR verify slog handles
+     this safely.
+   - `request_id` — is any user-supplied `X-Request-ID` sanitised
+     before reaching slog? Same for `attempt`, `backoff_ms` — those
+     should be numeric so no injection risk, but confirm.
+   - No buyer-supplied prompt content ends up in a log line.
+   - No secret (buyer key, service token, etc.) inadvertently logged
+     in an error path.
+
+4. **Timing side-channel**
+   - Retry decision is content-based (`openAIErrorCode`) not
+     content-length-based. A buyer cannot infer coord state by
+     measuring retry timing.
+   - Backoff jitter — is the random source appropriate for the use
+     case? (Non-cryptographic is fine here since it's for backoff
+     staggering, but confirm no security-relevant randomness reuses
+     this source.)
+
+5. **Buyer-disconnect handling**
+   - If buyer TCP disconnects mid-retry-sleep, `upCtx.Done()` fires,
+     loop aborts, reservation released via existing defer. Verify no
+     path where a buyer-abandon leaves a coord dispatch in flight
+     charging concurrency indefinitely.
+
+6. **Concurrency reservation safety**
+   - `store.ReleaseConcurrency` (deferred in the outer handler) fires
+     regardless of retry outcome.
+   - No path where a retry loop bails without triggering the deferred
+     release.
+   - No path where a retry-recovered success releases concurrency
+     twice.
+
+7. **Response body integrity**
+   - After retry-exhaustion, the response body handed to downstream
+     (with `io.NopCloser(bytes.NewReader(drainedBody))`) is exactly
+     the bytes the FINAL coord response sent — not the FIRST
+     response's body.
+   - No cross-attempt body contamination (e.g. a scratch buffer reused
+     between attempts).
+
+8. **Config values as attack surface**
+   - `MaxAttempts` validation prevents `MaxAttempts=1000` (which could
+     be used as an amplification attack via a malicious config
+     deploy). Validated in `[1, 10]` per BUILD spec.
+   - `BackoffMaxMs` validation prevents `BackoffMaxMs=999999` (which
+     would stall requests). Validated in `[10, 10000]`.
+   - Config values reloaded / applied atomically — no torn read of a
+     partially-updated config during a live retry loop.
+
+9. **HTTPS / plaintext**
+   - `s.coordinatorBuyerURL()` — is it always HTTPS in production
+     configs? Retry loop must not fall back to HTTP even under network
+     duress.
+   - No hardcoded coord URL added by the retry code.
+
+10. **Panic recovery**
+    - Existing `httptest.HandlerFunc` / stdlib handlers panic-recover;
+      confirm the retry loop does not introduce a new panic surface
+      (e.g. nil-deref on `resp.Body` after error, index-out-of-range
+      on jitter arithmetic).
+
+### Do NOT flag
+
+- Non-security correctness bugs (that's the CODE lane).
+- Naming / placement (that's ARCHITECT).
+- Anything not touched by the diff.
+- Findings already present in the untouched pre-diff code (this is a
+  new-code audit, not a repo audit).
+
+### Output format
+
+Report findings ranked C / H / M / L / I. Each finding lists:
+file:line, threat model (who benefits from exploiting it), concrete
+scenario (attacker action → security impact), proposed mitigation.
+
+Bottom-line status:
+
+```
+STATUS: SECURITY lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+## Diff to audit
+
+Read `git diff` in the worktree. The relevant files are named in the
+BUILD prompt.

--- a/specs/BUILD_GATEWAY_RETRY_503_IMPL_PROMPT.md
+++ b/specs/BUILD_GATEWAY_RETRY_503_IMPL_PROMPT.md
@@ -1,0 +1,415 @@
+# BUILD_GATEWAY_RETRY_503_IMPL — Gateway retry-with-backoff on coordinator 503 (no_provider_available)
+
+## Motivation (measured, 2026-07-04)
+
+A reliability sweep of 90 sequential streaming buyer requests against
+`https://api.streamvc.live/v1/chat/completions` produced the following
+503 rates as a function of inter-request gap (single-provider network,
+`mac` provider on M5 32GB, `max_concurrency_override: 1`, model
+`qwen3-coder-30b-a3b-instruct`):
+
+| Inter-request gap | Success | 503 rate |
+|---|---:|---:|
+| 0.5 s | 18/30 | **40.0 %** |
+| 2.0 s | 26/30 | **13.3 %** |
+| 5.0 s | 30/30 | 0.0 % |
+
+Coordinator journal shows the mechanism:
+
+```
+provider_id=mac state=busy slots_free=0 slots_total=1
+```
+
+Gateway journal shows the corresponding response:
+
+```
+INFO chat completion request_id=… status=503 wall_ms=4
+```
+
+Coordinator returns 503 in ≈4 ms when the sole provider slot is still
+draining. The buyer's second request (arriving < 500 ms after the first
+completed) fails, even though the provider will be free within tens of
+milliseconds. No client SDK retries on this class of 503 by default.
+
+## Goal (this PR)
+
+Wrap the gateway's coordinator dispatch in a bounded retry loop that
+retries **only** 503 responses whose OpenAI error `code` field is
+`no_provider_available` (or whose body indicates the same class — see
+§ "Retryable-503 detection" below). All other 503 sub-classes
+(`tier2_hash_*`, `null-usage-provider-error`, etc.) must continue to
+pass through with existing semantics.
+
+The retry loop must be transparent to the buyer: on success the buyer
+sees a normal 200 (or 5xx from a subsequent attempt), never a
+partial-then-retried response body. Total added latency must be
+bounded so a paying buyer never waits > ~1 s of retry backoff on a
+single request.
+
+## Non-goals
+
+- No change to coordinator code (phase4-coordinator).
+- No change to provider code (phase3-binary).
+- No new buyer-visible endpoints or headers.
+- No change to non-503 error handling.
+- No change to streaming settlement, reservation, or receipt flows.
+- No client-facing rate-limit header changes.
+
+## Scope of change
+
+Files that MUST change:
+- `phase5-gateway/internal/router/chat_proxy.go`
+- `phase5-gateway/internal/config/config.go`
+- `phase5-gateway/internal/router/chat_proxy_retry_test.go` (new file)
+
+Files that MAY change (only if the implementer determines it's the
+cleanest home):
+- `phase5-gateway/dist/gateway.yaml.example` (add commented example of
+  the new config block, if such a file exists — do not create one if
+  not).
+- Package-level docs / comments if adding a helper.
+
+Files that MUST NOT change:
+- Anything under `phase4-coordinator/**`.
+- Anything under `phase3-binary/**`.
+- Existing test files, except adding new tests to
+  `chat_proxy_retry_test.go` (new file).
+- Any billing / settlement / receipt logic path outside the retry loop
+  itself.
+
+## Location
+
+The retry loop wraps the coordinator dispatch. In `chat_proxy.go`, this
+is the block around:
+
+```go
+resp, err := s.client.Do(upReq)
+```
+
+Currently at approximately line 340, inside the main handler function
+that runs before the split to `forwardStreamingChat` /
+`forwardNonStreamingChat`.
+
+## Behavioural requirements
+
+**R1 — Retryable class only.** A 503 is retried iff *all* of the
+following hold:
+
+- HTTP status is exactly 503.
+- The response body's OpenAI error `code` field (`{"error":{"code":…}}`)
+  is `no_provider_available`, OR the body is empty / not-JSON while
+  status is 503 (coord may fast-refuse with an empty body — treat that
+  as `no_provider_available` for retry purposes).
+- The body is NOT recognised by `isNullUsageProviderError(body)`.
+- The body is NOT recognised by `coordinatorTier2PolicyError(status,
+  body)`.
+
+Any 503 not matching all four MUST fall through unchanged to the
+existing handlers (`forwardStreamingChat` /
+`forwardNonStreamingChat`), which will apply the current pass-through
+or refund logic.
+
+**R2 — Bounded attempts.** Default: 3 total attempts (1 initial + 2
+retries). Configurable via new config block (see § "Config").
+
+**R3 — Exponential backoff with jitter.** Between retry attempts the
+gateway sleeps for `backoff_base_ms * 2^(attempt-1)` capped at
+`backoff_max_ms`, then applies ±25 % uniform random jitter. Defaults:
+`backoff_base_ms = 100`, `backoff_max_ms = 500`. Worst-case total added
+latency with defaults: 100 + 200 = 300 ms plus ≤ 25 % jitter each, so
+< 400 ms of retry sleep across a full 3-attempt loop.
+
+**R4 — Context/cancellation.** All retries share the same `upCtx`
+(the request context with the 300 s coordinator budget). If
+`upCtx.Err() != nil` at any point before or during the sleep, abort
+the loop and return the last observed response / error. Do not sleep
+past context deadline.
+
+**R5 — Request replay.** The buyer's request body (`bytes.NewReader(
+body)` at approx. line 274) MUST be replayed intact on each attempt.
+Preferred: rebuild `upReq` on each attempt with a fresh
+`bytes.NewReader(body)` and re-apply headers with the same helper /
+inline code that produced the first-attempt request. Alternative: seek
+the reader back to zero via `bytes.Reader.Seek(0, io.SeekStart)` before
+each retry. Either is acceptable so long as request headers, method,
+URL, and body bytes are byte-identical across attempts.
+
+**R6 — Response body handling.** On a retryable 503, the previous
+response's body MUST be fully drained (or a bounded prefix drained
+enough to test `code`) and then closed before the retry sleep. Failing
+to close body leaks connections in `net/http`'s conn pool.
+
+**R7 — Reservation preservation.** The buyer's concurrency reservation
+and quota reservations were taken before the dispatch. The retry loop
+MUST NOT refund or re-take reservations between attempts. Only the
+terminal outcome (either final success passed to
+`forward{Streaming,NonStreaming}Chat`, or terminal failure) touches
+reservation state, using the existing paths already wired to the
+non-retry code path.
+
+**R8 — Existing behaviour on terminal failure.** After exhausting all
+retry attempts, the loop MUST hand the final `*http.Response` (with a
+buffer-backed body if it was drained during the retry check — see R6)
+back to the existing dispatch site so that
+`forward{Streaming,NonStreaming}Chat` handles the 503 exactly as they
+do today. Response body content MUST NOT be lost between the retry
+check and the downstream handler.
+
+**R9 — Structured observability.** For each retry attempt (i.e. each
+time the loop decides to sleep-and-retry, NOT the initial dispatch),
+emit exactly one `slog.Info(...)` line with:
+
+- key: `"gateway coord 503 retry"` (message)
+- fields: `request_id` (from `requestID(r)`), `attempt` (1-indexed
+  attempt about to be made, i.e. the retry number, so first retry is
+  `attempt=2`), `backoff_ms` (the actual sleep in ms after jitter),
+  `body_code` (the parsed OpenAI error code, or `""` if unparseable /
+  empty).
+
+For terminal success on a retry attempt (i.e. attempt > 1 returned
+200), emit exactly one `slog.Info("gateway coord 503 retry recovered",
+...)` line with `request_id`, `attempt` (the winning attempt number,
+so 2 or 3), and `total_backoff_ms` (sum of all sleeps executed).
+
+For terminal failure (all attempts returned retryable 503), emit
+exactly one `slog.Warn("gateway coord 503 retry exhausted", ...)` line
+with `request_id`, `attempts` (total attempts made, equal to
+configured max), and `total_backoff_ms`.
+
+Do NOT emit a log line on the initial (attempt=1) dispatch even if it
+was a retryable 503 — that is covered by the retry-attempt line for
+the *following* retry.
+
+**R10 — Retry disabled.** If the new config field
+`retry_503.enabled` is false, the retry loop MUST behave exactly as
+today's code: single dispatch, pass through response to downstream
+handler regardless of status. This includes not emitting any of the
+R9 log lines.
+
+## Retryable-503 detection
+
+Add a package-private helper:
+
+```go
+// isCoordNoProviderAvailable503 returns true when the coordinator's
+// response indicates the request MAY succeed on a retry — i.e. the
+// provider pool was momentarily busy. It intentionally does NOT
+// retry:
+//   - null-usage provider errors (billable failures)
+//   - tier2 policy errors (permanent for this request)
+//   - any 5xx other than 503
+func isCoordNoProviderAvailable503(status int, body []byte) bool { … }
+```
+
+Implementation:
+
+- Return false if `status != 503`.
+- If `body` is empty or not valid JSON, return `true` (coord fast-refuse).
+- If `isNullUsageProviderError(body)` returns true, return `false`.
+- If `coordinatorTier2PolicyError(503, body)` returns true, return
+  `false`.
+- Parse OpenAI error envelope via existing `openAIErrorCode(body)`.
+  If code is `""` or `no_provider_available`, return `true`. Otherwise
+  return `false`.
+
+Place this helper adjacent to `coordinatorTier2PolicyError` and
+`openAIErrorCode` in `chat_proxy.go` for review-locality.
+
+## Config
+
+Extend `phase5-gateway/internal/config/config.go`:
+
+```go
+type Retry503Config struct {
+    Enabled          bool `yaml:"enabled"`
+    MaxAttempts      int  `yaml:"max_attempts"`
+    BackoffBaseMs    int  `yaml:"backoff_base_ms"`
+    BackoffMaxMs     int  `yaml:"backoff_max_ms"`
+}
+```
+
+Add a `Retry503 Retry503Config `yaml:"retry_503"`` field on the top-level
+`Config` (or on the most appropriate nested struct — the implementer
+should pick the location that best matches the surrounding style).
+
+Defaults applied via existing config-defaults pattern (or in a small
+new normaliser if the codebase doesn't have one):
+
+- `Enabled: true`
+- `MaxAttempts: 3`
+- `BackoffBaseMs: 100`
+- `BackoffMaxMs: 500`
+
+Validation:
+- `MaxAttempts` in range `[1, 10]`. Value 1 = disable retry (single
+  attempt). Value > 10 = config validation error.
+- `BackoffBaseMs` in `[10, 5000]`.
+- `BackoffMaxMs` in `[10, 10000]`.
+- `BackoffMaxMs >= BackoffBaseMs`.
+
+Return a config-validation error on out-of-range values, using the
+existing pattern (see `WarmupFallbackS` validation as reference).
+
+## Jitter
+
+Use `math/rand/v2` (already Go 1.22+; check go.mod) via a
+package-level `*rand.Rand` if the codebase uses one, or the global
+`rand.Float64()` if it doesn't. Do NOT introduce a new random-source
+package. Jitter formula:
+
+```go
+jittered := sleep + (int64(sleep) * int64(rng.IntN(51) - 25)) / 100
+if jittered < minSleep { jittered = minSleep }
+```
+
+Ensure the sleep is always non-negative.
+
+## Acceptance criteria
+
+**AC1** — `swift build` and any relevant Go build succeeds:
+`cd phase5-gateway && go build ./...` clean.
+
+**AC2** — All existing tests pass unchanged:
+`cd phase5-gateway && go test ./... -count=1`.
+
+**AC3** — New tests in `phase5-gateway/internal/router/chat_proxy_retry_test.go` cover:
+
+- Coord returns 503-no-provider twice then 200; buyer sees 200; two
+  retry log lines emitted; one `retry recovered` log line.
+- Coord returns 503-no-provider three times; buyer sees 503; two retry
+  log lines emitted; one `retry exhausted` log line.
+- Coord returns 503-tier2-policy on first attempt; buyer sees existing
+  pass-through behaviour; ZERO retry log lines emitted.
+- Coord returns 503-null-usage-provider on first attempt; buyer sees
+  existing pass-through billing behaviour; ZERO retry log lines
+  emitted.
+- Coord returns 200 on first attempt; buyer sees 200; ZERO retry log
+  lines emitted.
+- Config `retry_503.enabled=false`: coord returns 503-no-provider once;
+  buyer sees 503; ZERO retry log lines emitted.
+- Config validation: `max_attempts=0`, `max_attempts=11`,
+  `backoff_base_ms=5`, `backoff_max_ms=15000`, and
+  `backoff_max_ms<backoff_base_ms` each produce a load-time error via
+  the existing config-loader entry-point.
+- Retry replay integrity: verify the coordinator sees byte-identical
+  request bodies across all three attempts (e.g. by capturing bodies
+  in a mock RoundTripper).
+- Concurrency reservation: verify (via a store spy) that no
+  refund/re-take happens between retry attempts.
+
+**AC4** — Streaming path: retry loop applies BEFORE the split into
+`forwardStreamingChat` / `forwardNonStreamingChat`. This means a
+retried 503 on a streaming request must result in the buyer seeing
+either the eventual 200 stream or the terminal 503 — never a mixed
+partial-body response.
+
+**AC5** — Under default configuration, worst-case retry backoff for a
+buyer whose request exhausts all attempts must not exceed 750 ms of
+sleep total (measured; assert in test with a fake clock or bounded
+sleep captor).
+
+**AC6** — Coordinator client cancellation: an outbound context cancel
+(buyer disconnects) during retry sleep must abort the loop within
+one context.Deadline check (i.e. the sleep must be cancellable via
+`select { case <-time.After(sleep): ; case <-upCtx.Done(): }`).
+
+## Observability contract
+
+Structured `slog` lines only. Do NOT add metrics counters, Prometheus,
+or new HTTP endpoints in this PR. Metrics wiring can be a follow-up.
+
+Log messages must be the exact strings in R9 so operator dashboards
+can grep for them stably.
+
+## Backwards compatibility
+
+- Buyer-observable behaviour on non-503 responses is unchanged.
+- Buyer-observable behaviour on `retry_503.enabled=false` is unchanged
+  vs today.
+- Buyer-observable behaviour on retry-exhausted-503 is unchanged (same
+  `writeError(...503 no_provider_available)` as today).
+- The only new buyer-observable behaviour is that a buyer whose
+  request would previously have received 503 may now receive 200 if a
+  retry succeeds (this is the goal).
+
+## Prohibited implementation choices
+
+- Do NOT wrap `s.client` in a middleware that retries. The retry
+  behaviour is 503-body-content-specific and must be visible in the
+  handler.
+- Do NOT introduce a background goroutine for retries. The retry
+  happens synchronously on the request goroutine.
+- Do NOT change `s.client.Timeout`, `Transport`, or connection-pool
+  configuration.
+- Do NOT change the `X-Request-ID` forwarding — the same request ID
+  must be sent on every retry attempt so coord's request_log can
+  correlate.
+- Do NOT reset or mutate the buyer's concurrency reservation between
+  attempts.
+- Do NOT change `writeError` / `passThroughNoProviderCoordinatorError`
+  / `passThroughReceiptEligibleProviderError` signatures or behaviour.
+- Do NOT add sleep or wait logic on the initial (attempt=1) dispatch.
+
+## Test data notes
+
+Where existing test infrastructure uses `httptest.NewServer`, prefer
+extending that pattern. Where a mock `http.RoundTripper` on `s.client`
+is used, prefer that. If neither pattern is present in current
+`chat_proxy` tests, look at `server_test.go` for a compatible harness.
+
+## Commit style
+
+The commit message follows the repo convention:
+
+```
+fix(gateway): retry coord 503 no_provider_available with bounded backoff (#<PR>)
+
+Motivation: reliability sweep 2026-07-04 measured 40% 503 rate under
+0.5s inter-request gap on a single-slot provider network. Provider
+slot drains within tens of milliseconds; second request arrives too
+early and coord refuses in 4ms with no_provider_available.
+
+Change: gateway wraps coord dispatch in a bounded retry loop (max 3
+attempts, exponential backoff 100→500ms with ±25% jitter). Only 503s
+whose OpenAI error code is no_provider_available (or empty body) are
+retried; tier2 policy errors and null-usage provider errors pass
+through unchanged.
+
+Constraint: total added latency ≤ 750ms; reservations preserved
+across attempts; request bodies replayed byte-identical.
+
+Config: new retry_503.{enabled,max_attempts,backoff_base_ms,
+backoff_max_ms} block, defaults on.
+
+Tested: new chat_proxy_retry_test.go; existing suite unchanged.
+```
+
+## Audit boundaries
+
+Three separate audit lanes will be fired against this diff after
+implementation:
+
+- **CODE** — correctness of retry loop, race conditions, context
+  cancellation propagation, response body drain / close discipline,
+  header replay integrity, jitter bounds, config validation branches.
+- **SECURITY** — no request body / auth header leakage across
+  attempts, no unbounded resource consumption, no timing side-channel
+  in retry decisions, correct behaviour when buyer disconnects mid-retry.
+- **ARCHITECT** — placement in `chat_proxy.go` vs
+  `forward{Streaming,NonStreaming}Chat`, config block naming
+  consistency with existing knobs, observability line naming stability
+  for future metric wire-up, no scope creep into coord/provider code
+  paths.
+
+## References
+
+- Reliability sweep raw data:
+  `scratchpad/results/reliability_sweep.json` (not committed).
+- Coordinator single-slot mechanism: `phase4-coordinator/internal/ws/
+  server.go` around the `slots_free=0` heartbeat and immediate 503
+  return path.
+- Existing 503 handling: `phase5-gateway/internal/router/chat_proxy.go`
+  around lines 374-408 (non-stream) and 460-490 (stream).
+- Existing tier2 / null-usage guards:
+  `coordinatorTier2PolicyError` and `isNullUsageProviderError` in
+  the same file.


### PR DESCRIPTION
## Summary

- **`beta/DECISION_CRITERIA.md`** — adds Entry 92 locking beta pricing v2: 6 `rewards.rate_card` rows pegged at-or-below cheapest OpenRouter market (3 dense + 3 MoE), per-model RAM-first admission overriding bandwidth-tier-as-gate, off-chain `TOKEN_NAME` ledger as provider bootstrap (Option α from RESEARCH_224 — operator bookkeeping, mint at TGE; on-chain contract explicitly rejected for beta).
- **`specs/HANDOFF_BETA_PRICING_TOKEN_ROLLOUT_PROMPT.md`** — self-contained prompt for partner pickup of the 3-wave rollout. Lists 7 tracks, file paths + LOC estimates, 4-week timeline, 14 repo conventions to follow, 8 going-off-rails signals, and `OPERATOR_DECISIONS_BETA_PRICING_V2.md` items the operator must answer before Wave 3.

## Why this is a single decision-log entry, not two

The MoE rate-card addition from RESEARCH_226 strengthens v2 without contradicting it (per-model admission cleanly extends the bandwidth-tier model rather than replacing it). One entry preserves the audit trail; the MoE half lifts out cleanly if reverted.

## Decision audit trail (all 5 codex memos checked in)

| Memo | Location | Status |
|---|---|---|
| RESEARCH_222 (v1 — rejected) | `.omc/artifacts/ask/codex-research-prompt-issue-222-...` | Strawman, kept for context |
| RESEARCH_223 (MLX 12-month roadmap) | `.omc/artifacts/ask/codex-research-prompt-mlx-continuous-batching-...` | Roadmap D (Hybrid) |
| RESEARCH_224 (pricing v2) | `.omc/artifacts/ask/codex-research-prompt-issue-224-beta-pricing-v2-...` | Primary v2 design |
| RESEARCH_225 (darkbloom comparison) | `.omc/artifacts/ask/codex-research-prompt-darkbloom-dev-comparison-...` | Empirical validation ($264 work / $1,946 subsidy / 398 providers @ 30d) |
| RESEARCH_226 (MoE selection + OpenRouter demand) | `specs/RESEARCH_226_MOE_SELECTION_AND_MARKET_DEMAND_MEMO.md` | Added MoE rows |

## Pre-launch gates (encoded in Entry 92, tracked in `specs/BENCHMARKS_226_TODO.md`)

**Wave 1 (rate-card hot reload) gated on 4 P0 benches green:**

- [ ] SCN-223-01 — M4 Air 24GB × Qwen3-32B-4bit re-attribution (suspicious 14 vs theoretical 6-7 tok/s ceiling)
- [ ] SCN-NEW-01 — rate-card key normalization test (silent-overcharge hazard if buyer model string does not match row key)
- [ ] SCN-NEW-02 — hardware-tier rejection telemetry harness
- [ ] SCN-NEW-03 — end-to-end billing smoke at new rates ($0.220/M for `qwen3-32b`, not default $1.00/M)

**Wave 2 (per-model admission + tier filter) additionally gated on:**

- [ ] SCN-226-01 — M4 Air × `gpt-oss-20b` >= 30 tok/s sustained
- [ ] SCN-226-02 — M4 Air 32GB × `gemma-4-26b-a4b-it` >= 30 tok/s sustained

**Wave 3 (token ledger) gated on:**

- [ ] SCN-NEW-04 — cohort onboarding dry-run (5 simulated providers across tiers S/A/B/C; ledger schema works under realistic provider mix)
- [ ] Operator answers on token name, planning supply, cohort split, vesting, grandfathering (TRACK 6 in handoff prompt)

## Test plan for THIS PR

- [x] Citation line numbers verified against HEAD (`config.go:544`, `:138`; `main.go:908`; `buyer/server.go:4228`; `AutotuneRuntimeSupport.swift` exists)
- [x] Insertion point preserves established blank-line separator between entries
- [x] Entry numbered 92 (latest in file is 91 — confirmed)
- [x] House style matched against Entries 89-91 (dense prose, memory-note cross-refs, trailing Phase 5 / network implication)
- [x] Worktree created off `origin/main` per always-fresh-worktree rule
- [x] Handoff prompt references Augustas11 token routing + 3-lane codex audit + bundle-multi-phase-impl-prs rules per `CLAUDE.md`

## What this PR does NOT do

- Does NOT flip live coordinator config — Wave 1 hot reload is a separate operator action, gated on P0 benches green
- Does NOT add hardware-tier filter code — that is Wave 2, ~350-600 LOC, money-path (3-lane codex audit required)
- Does NOT add token ledger code — that is Wave 3, gated on operator decisions
- Does NOT inspect `Layr-Labs/d-inference` source — clean-room rule per `CLAUDE.md` strictly enforced throughout research

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
