### PR TITLE
feat(provider): idle-prewarm timer keeps MLX Metal warm during idle

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -66,6 +66,12 @@ public struct AppConfig: Equatable, Sendable {
     public var ctlSocketPath: String?
     public var switchStatePath: String?
     public var donorMode: Bool
+    public var idlePrewarmEnabled: Bool
+    public var idlePrewarmIdleThresholdSeconds: Double
+    public var idlePrewarmTickSeconds: Double
+    public var idlePrewarmMaxTokens: Int
+    public var idlePrewarmPrompt: String
+    public var idlePrewarmRunOnBattery: Bool
     // SPEC-001: provider authentication token (closes XSEC-1 from
     // audits/2026-06-10/REPO_AUDIT.md). When set, the binary sends
     // "Authorization: Bearer <token>" on the WS connect and the
@@ -123,6 +129,12 @@ public struct AppConfig: Equatable, Sendable {
             ctlSocketPath: nil,
             switchStatePath: nil,
             donorMode: false,
+            idlePrewarmEnabled: true,
+            idlePrewarmIdleThresholdSeconds: 30,
+            idlePrewarmTickSeconds: 5,
+            idlePrewarmMaxTokens: 1,
+            idlePrewarmPrompt: "warm",
+            idlePrewarmRunOnBattery: false,
             providerToken: nil,
             managedBy: nil
         )
@@ -152,6 +164,12 @@ public struct CLIOverrides: Equatable, Sendable {
     public var kvBits: Int?
     public var maxContext: Int?
     public var maxBatch: Int?
+    public var idlePrewarmEnabled: Bool?
+    public var idlePrewarmIdleThresholdSeconds: Double?
+    public var idlePrewarmTickSeconds: Double?
+    public var idlePrewarmMaxTokens: Int?
+    public var idlePrewarmPrompt: String?
+    public var idlePrewarmRunOnBattery: Bool?
 
     public init(
         port: Int? = nil,
@@ -172,7 +190,13 @@ public struct CLIOverrides: Equatable, Sendable {
         managedBy: String? = nil,
         kvBits: Int? = nil,
         maxContext: Int? = nil,
-        maxBatch: Int? = nil
+        maxBatch: Int? = nil,
+        idlePrewarmEnabled: Bool? = nil,
+        idlePrewarmIdleThresholdSeconds: Double? = nil,
+        idlePrewarmTickSeconds: Double? = nil,
+        idlePrewarmMaxTokens: Int? = nil,
+        idlePrewarmPrompt: String? = nil,
+        idlePrewarmRunOnBattery: Bool? = nil
     ) {
         self.port = port
         self.model = model
@@ -193,6 +217,12 @@ public struct CLIOverrides: Equatable, Sendable {
         self.kvBits = kvBits
         self.maxContext = maxContext
         self.maxBatch = maxBatch
+        self.idlePrewarmEnabled = idlePrewarmEnabled
+        self.idlePrewarmIdleThresholdSeconds = idlePrewarmIdleThresholdSeconds
+        self.idlePrewarmTickSeconds = idlePrewarmTickSeconds
+        self.idlePrewarmMaxTokens = idlePrewarmMaxTokens
+        self.idlePrewarmPrompt = idlePrewarmPrompt
+        self.idlePrewarmRunOnBattery = idlePrewarmRunOnBattery
     }
 }
 
@@ -235,6 +265,7 @@ public enum ConfigLoader {
         config = try applyEnvironment(config, environment: environment)
         config = try applyCLI(config, cli: cli)
         config.configPath = configPath
+        try validateIdlePrewarm(config)
         return config
     }
 
@@ -310,6 +341,14 @@ public enum ConfigLoader {
         try assign(&config.ctlSocketPath, from: dict, key: "ctl_socket_path", expected: "string")
         try assign(&config.switchStatePath, from: dict, key: "switch_state_path", expected: "string")
         try assign(&config.donorMode, from: dict, key: "donor_mode", expected: "boolean")
+        if let nested = dict["idle_prewarm"] as? [String: Any] {
+            try assign(&config.idlePrewarmEnabled, from: nested, key: "enabled", expected: "boolean")
+            try assign(&config.idlePrewarmIdleThresholdSeconds, from: nested, key: "idle_threshold_seconds", expected: "number")
+            try assign(&config.idlePrewarmTickSeconds, from: nested, key: "tick_seconds", expected: "number")
+            try assign(&config.idlePrewarmMaxTokens, from: nested, key: "max_tokens", expected: "integer")
+            try assign(&config.idlePrewarmPrompt, from: nested, key: "prompt", expected: "string")
+            try assign(&config.idlePrewarmRunOnBattery, from: nested, key: "run_on_battery", expected: "boolean")
+        }
         try assign(&config.providerToken, from: dict, key: "provider_token", expected: "string")
         try assign(&config.managedBy, from: dict, key: "managed_by", expected: "string")
         return config
@@ -348,6 +387,12 @@ public enum ConfigLoader {
         try assign(&config.ctlSocketPath, from: environment, env: "MACPROVIDER_CTL_SOCKET_PATH", expected: "string")
         try assign(&config.switchStatePath, from: environment, env: "MACPROVIDER_SWITCH_STATE_PATH", expected: "string")
         try assign(&config.donorMode, from: environment, env: "MACPROVIDER_DONOR_MODE", expected: "boolean")
+        try assign(&config.idlePrewarmEnabled, from: environment, env: "MACPROVIDER_IDLE_PREWARM_ENABLED", expected: "boolean")
+        try assign(&config.idlePrewarmIdleThresholdSeconds, from: environment, env: "MACPROVIDER_IDLE_PREWARM_IDLE_THRESHOLD_S", expected: "number")
+        try assign(&config.idlePrewarmTickSeconds, from: environment, env: "MACPROVIDER_IDLE_PREWARM_TICK_S", expected: "number")
+        try assign(&config.idlePrewarmMaxTokens, from: environment, env: "MACPROVIDER_IDLE_PREWARM_MAX_TOKENS", expected: "integer")
+        try assign(&config.idlePrewarmPrompt, from: environment, env: "MACPROVIDER_IDLE_PREWARM_PROMPT", expected: "string")
+        try assign(&config.idlePrewarmRunOnBattery, from: environment, env: "MACPROVIDER_IDLE_PREWARM_ON_BATTERY", expected: "boolean")
         try assign(&config.providerToken, from: environment, env: "MACPROVIDER_PROVIDER_TOKEN", expected: "string")
         try assign(&config.managedBy, from: environment, env: "MACPROVIDER_MANAGED_BY", expected: "string")
         return config
@@ -412,6 +457,24 @@ public enum ConfigLoader {
         if let maxBatch = cli.maxBatch {
             config.maxConcurrencyOverride = maxBatch
         }
+        if let idlePrewarmEnabled = cli.idlePrewarmEnabled {
+            config.idlePrewarmEnabled = idlePrewarmEnabled
+        }
+        if let idlePrewarmIdleThresholdSeconds = cli.idlePrewarmIdleThresholdSeconds {
+            config.idlePrewarmIdleThresholdSeconds = idlePrewarmIdleThresholdSeconds
+        }
+        if let idlePrewarmTickSeconds = cli.idlePrewarmTickSeconds {
+            config.idlePrewarmTickSeconds = idlePrewarmTickSeconds
+        }
+        if let idlePrewarmMaxTokens = cli.idlePrewarmMaxTokens {
+            config.idlePrewarmMaxTokens = idlePrewarmMaxTokens
+        }
+        if let idlePrewarmPrompt = cli.idlePrewarmPrompt {
+            config.idlePrewarmPrompt = idlePrewarmPrompt
+        }
+        if let idlePrewarmRunOnBattery = cli.idlePrewarmRunOnBattery {
+            config.idlePrewarmRunOnBattery = idlePrewarmRunOnBattery
+        }
         return config
     }
 
@@ -447,6 +510,31 @@ public enum ConfigLoader {
             throw ConfigError.invalidValue(key: key, value: String(describing: value), expected: expected)
         }
         field = string
+    }
+
+    private static func assign(_ field: inout String, from dict: [String: Any], key: String, expected: String) throws {
+        guard let value = dict[key], !(value is NSNull) else { return }
+        guard let string = value as? String else {
+            throw ConfigError.invalidValue(key: key, value: String(describing: value), expected: expected)
+        }
+        field = string
+    }
+
+    private static func assign(_ field: inout Double, from dict: [String: Any], key: String, expected: String) throws {
+        guard let value = dict[key], !(value is NSNull) else { return }
+        if let double = value as? Double {
+            field = double
+            return
+        }
+        if let int = value as? Int {
+            field = Double(int)
+            return
+        }
+        if let string = value as? String, let double = Double(string) {
+            field = double
+            return
+        }
+        throw ConfigError.invalidValue(key: key, value: String(describing: value), expected: expected)
     }
 
     private static func assign(_ field: inout [String]?, from dict: [String: Any], key: String, expected: String) throws {
@@ -517,6 +605,19 @@ public enum ConfigLoader {
         field = value
     }
 
+    private static func assign(_ field: inout String, from env: [String: String], env key: String, expected: String) throws {
+        guard let value = env[key] else { return }
+        field = value
+    }
+
+    private static func assign(_ field: inout Double, from env: [String: String], env key: String, expected: String) throws {
+        guard let value = env[key] else { return }
+        guard let double = Double(value) else {
+            throw ConfigError.invalidValue(key: key, value: value, expected: expected)
+        }
+        field = double
+    }
+
     private static func assign(_ field: inout Bool, from env: [String: String], env key: String, expected: String) throws {
         guard let value = env[key] else { return }
         guard let bool = parseBool(value) else {
@@ -557,6 +658,42 @@ public enum ConfigLoader {
             return false
         default:
             return nil
+        }
+    }
+
+    private static func validateIdlePrewarm(_ config: AppConfig) throws {
+        try validateRange(
+            key: "idle_prewarm.idle_threshold_seconds",
+            value: config.idlePrewarmIdleThresholdSeconds,
+            range: 5...3600
+        )
+        try validateRange(
+            key: "idle_prewarm.tick_seconds",
+            value: config.idlePrewarmTickSeconds,
+            range: 1...60
+        )
+        try validateRange(
+            key: "idle_prewarm.max_tokens",
+            value: Double(config.idlePrewarmMaxTokens),
+            range: 1...8
+        )
+        let promptBytes = config.idlePrewarmPrompt.utf8.count
+        guard (1...64).contains(promptBytes) else {
+            throw ConfigError.invalidValue(
+                key: "idle_prewarm.prompt",
+                value: "\(promptBytes) bytes",
+                expected: "1...64 UTF-8 bytes"
+            )
+        }
+    }
+
+    private static func validateRange(key: String, value: Double, range: ClosedRange<Double>) throws {
+        guard range.contains(value) else {
+            throw ConfigError.invalidValue(
+                key: key,
+                value: String(value),
+                expected: "\(range.lowerBound)...\(range.upperBound)"
+            )
         }
     }
 }

--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -8,6 +8,21 @@ struct HTTPServer: Sendable {
     let modelRuntime: ModelRuntime
     let providerStatus: ProviderStatus
     let receiptBuilder: ReceiptBuilder?
+    let idlePrewarmer: IdlePrewarmer?
+
+    init(
+        config: AppConfig,
+        modelRuntime: ModelRuntime,
+        providerStatus: ProviderStatus,
+        receiptBuilder: ReceiptBuilder?,
+        idlePrewarmer: IdlePrewarmer? = nil
+    ) {
+        self.config = config
+        self.modelRuntime = modelRuntime
+        self.providerStatus = providerStatus
+        self.receiptBuilder = receiptBuilder
+        self.idlePrewarmer = idlePrewarmer
+    }
 
     func run() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
@@ -29,7 +44,8 @@ struct HTTPServer: Sendable {
                             providerStatus: providerStatus,
                             warmSwapEnabled: config.enableWarmSwap,
                             maxBodyBytes: config.maxRequestBodyBytes,
-                            receiptBuilder: receiptBuilder
+                            receiptBuilder: receiptBuilder,
+                            idlePrewarmer: idlePrewarmer
                         )
                     )
                 }
@@ -54,6 +70,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
     private let warmSwapEnabled: Bool
     private let maxBodyBytes: Int
     private let receiptBuilder: ReceiptBuilder?
+    private let idlePrewarmer: IdlePrewarmer?
     private var requestHead: HTTPRequestHead?
     private var bodyBuffer: ByteBuffer?
     private var bodyTooLarge = false
@@ -66,7 +83,8 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         providerStatus: ProviderStatus,
         warmSwapEnabled: Bool,
         maxBodyBytes: Int,
-        receiptBuilder: ReceiptBuilder? = nil
+        receiptBuilder: ReceiptBuilder? = nil,
+        idlePrewarmer: IdlePrewarmer? = nil
     ) {
         self.modelID = modelID
         self.providerID = providerID
@@ -76,6 +94,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         self.warmSwapEnabled = warmSwapEnabled
         self.maxBodyBytes = maxBodyBytes
         self.receiptBuilder = receiptBuilder
+        self.idlePrewarmer = idlePrewarmer
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -245,14 +264,17 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                     receiptBuilder: receiptBuilder,
                     providerID: providerID,
                     requestID: auditRequestID,
-                    settlementMetadata: settlementMetadata
+                    settlementMetadata: settlementMetadata,
+                    idlePrewarmer: idlePrewarmer
                 )
                 return
             }
 
             let providerStatus = providerStatus
-            Task.detached { @Sendable [modelRuntime, providerStatus, request, writer, warmSwapEnabled, receiptBuilder, providerID, auditRequestID, settlementMetadata] in
+            let idlePrewarmer = idlePrewarmer
+            Task.detached { @Sendable [modelRuntime, providerStatus, request, writer, warmSwapEnabled, receiptBuilder, providerID, auditRequestID, settlementMetadata, idlePrewarmer] in
                 let startedAt = await providerStatus.beginRequest()
+                await idlePrewarmer?.cancelInflightPrewarm()
                 // SPEC-015 §M.2.2 atomic-read invariant — capture
                 // the pre-snapshot for warm-swap validation, then
                 // call `completeWithServedSnapshot` which returns
@@ -539,14 +561,16 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         receiptBuilder: ReceiptBuilder?,
         providerID: String?,
         requestID: String,
-        settlementMetadata: SettlementReceiptMetadata?
+        settlementMetadata: SettlementReceiptMetadata?,
+        idlePrewarmer: IdlePrewarmer?
     ) {
         let created = Int(Date().timeIntervalSince1970)
         let id = "chatcmpl-\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
 
         let providerStatus = providerStatus
-        Task.detached { @Sendable [modelRuntime, providerStatus, request, writer, warmSwapEnabled, receiptBuilder, providerID, requestID, settlementMetadata] in
+        Task.detached { @Sendable [modelRuntime, providerStatus, request, writer, warmSwapEnabled, receiptBuilder, providerID, requestID, settlementMetadata, idlePrewarmer] in
             let startedAt = await providerStatus.beginRequest()
+            await idlePrewarmer?.cancelInflightPrewarm()
             var sseStarted = false
             do {
                 let snapshot = await modelRuntime.currentSnapshot()

--- a/phase3-binary/Sources/macprovider-cli/IdlePrewarmer.swift
+++ b/phase3-binary/Sources/macprovider-cli/IdlePrewarmer.swift
@@ -1,0 +1,353 @@
+import Foundation
+import IOKit.ps
+import MacProviderCore
+
+struct IdlePrewarmConfig: Sendable, Equatable {
+    let enabled: Bool
+    let idleThresholdSeconds: Double
+    let tickSeconds: Double
+    let maxTokens: Int
+    let prompt: String
+    let runOnBattery: Bool
+
+    init(
+        enabled: Bool,
+        idleThresholdSeconds: Double,
+        tickSeconds: Double,
+        maxTokens: Int,
+        prompt: String,
+        runOnBattery: Bool
+    ) {
+        self.enabled = enabled
+        self.idleThresholdSeconds = idleThresholdSeconds
+        self.tickSeconds = tickSeconds
+        self.maxTokens = min(8, max(1, maxTokens))
+        self.prompt = prompt
+        self.runOnBattery = runOnBattery
+    }
+
+    init(appConfig: AppConfig) {
+        self.init(
+            enabled: appConfig.idlePrewarmEnabled,
+            idleThresholdSeconds: appConfig.idlePrewarmIdleThresholdSeconds,
+            tickSeconds: appConfig.idlePrewarmTickSeconds,
+            maxTokens: appConfig.idlePrewarmMaxTokens,
+            prompt: appConfig.idlePrewarmPrompt,
+            runOnBattery: appConfig.idlePrewarmRunOnBattery
+        )
+    }
+}
+
+enum PowerSourceState: Sendable, Equatable {
+    case battery
+    case external
+    case unknown
+
+    var isBatteryOnly: Bool { self == .battery }
+}
+
+protocol PowerSourceReporting: Sendable {
+    func currentPowerSourceState() -> PowerSourceState
+}
+
+struct SystemPowerSourceReporter: PowerSourceReporting {
+    func currentPowerSourceState() -> PowerSourceState {
+        guard let info = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+              let sources = IOPSCopyPowerSourcesList(info)?.takeRetainedValue() as? [CFTypeRef],
+              !sources.isEmpty
+        else {
+            return .unknown
+        }
+        var sawExternal = false
+        for source in sources {
+            guard let description = IOPSGetPowerSourceDescription(info, source)?.takeUnretainedValue() as? [String: Any],
+                  let state = description[kIOPSPowerSourceStateKey] as? String
+            else {
+                continue
+            }
+            if state == (kIOPSBatteryPowerValue as String) {
+                return .battery
+            }
+            if state == (kIOPSACPowerValue as String) {
+                sawExternal = true
+            }
+        }
+        return sawExternal ? .external : .unknown
+    }
+}
+
+private final class IdlePrewarmCancellationToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+}
+
+private struct IdlePrewarmRun: Sendable {
+    let id: UUID
+    let startedAt: Date
+    let token: IdlePrewarmCancellationToken
+    let task: Task<Void, Never>
+}
+
+struct IdlePrewarmLogger: Sendable {
+    let emit: @Sendable ([String: Any]) -> Void
+
+    static let stdout = IdlePrewarmLogger { object in
+        guard JSONSerialization.isValidJSONObject(object),
+              var data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
+        else {
+            return
+        }
+        data.append(0x0A)
+        FileHandle.standardOutput.write(data)
+    }
+}
+
+actor IdlePrewarmer {
+    private let modelRuntime: ModelRuntime
+    private let providerStatus: ProviderStatus
+    private let thermalGate: ThermalGate
+    private let powerSource: PowerSourceReporting
+    private let config: IdlePrewarmConfig
+    private let logger: IdlePrewarmLogger
+    private var loopTask: Task<Void, Never>?
+    private var inflight: IdlePrewarmRun?
+    private var stopped = false
+
+    init(
+        modelRuntime: ModelRuntime,
+        providerStatus: ProviderStatus,
+        thermalGate: ThermalGate,
+        powerSource: PowerSourceReporting,
+        config: IdlePrewarmConfig,
+        clock _: any Clock = ContinuousClock()
+    ) {
+        self.init(
+            modelRuntime: modelRuntime,
+            providerStatus: providerStatus,
+            thermalGate: thermalGate,
+            powerSource: powerSource,
+            config: config,
+            logger: .stdout
+        )
+    }
+
+    init(
+        modelRuntime: ModelRuntime,
+        providerStatus: ProviderStatus,
+        thermalGate: ThermalGate,
+        powerSource: PowerSourceReporting,
+        config: IdlePrewarmConfig,
+        logger: IdlePrewarmLogger
+    ) {
+        self.modelRuntime = modelRuntime
+        self.providerStatus = providerStatus
+        self.thermalGate = thermalGate
+        self.powerSource = powerSource
+        self.config = config
+        self.logger = logger
+    }
+
+    func start() {
+        guard loopTask == nil else { return }
+        stopped = false
+        let tickNanoseconds = Self.nanoseconds(config.tickSeconds)
+        loopTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: tickNanoseconds)
+                } catch {
+                    break
+                }
+                await self?.runTick()
+            }
+        }
+    }
+
+    func stop() async {
+        stopped = true
+        let task = loopTask
+        task?.cancel()
+        loopTask = nil
+        let run = inflight
+        inflight = nil
+        run?.token.cancel()
+        run?.task.cancel()
+        await task?.value
+        await run?.task.value
+    }
+
+    func cancelInflightPrewarm() async {
+        cancelInflight(logRealRequest: true)
+    }
+
+    func runOneTickForTest() async {
+        await runTick()
+    }
+
+    private func runTick() async {
+        guard !shouldStopTick() else { return }
+        guard inflight == nil else { return }
+        guard config.enabled else {
+            logSkipped("disabled")
+            return
+        }
+
+        let snapshot = await providerStatus.snapshot()
+        guard !shouldStopTick() else { return }
+        guard snapshot.requestsInFlight == 0 else {
+            logSkipped("busy")
+            return
+        }
+
+        let idleSeconds = await providerStatus.secondsSinceLastActivityOrPrewarm()
+        guard !shouldStopTick() else { return }
+        guard idleSeconds >= config.idleThresholdSeconds else {
+            logSkipped("not_idle_yet")
+            return
+        }
+
+        let thermalState = await thermalGate.currentState()
+        guard !shouldStopTick() else { return }
+        guard !ThermalGate.shouldThrottle(thermalState) else {
+            logSkipped("thermal_pressure")
+            return
+        }
+
+        let powerState = powerSource.currentPowerSourceState()
+        let onBattery = powerState.isBatteryOnly
+        guard !onBattery || config.runOnBattery else {
+            logSkipped("on_battery")
+            return
+        }
+
+        let isLoaded = await modelRuntime.isLoaded
+        guard !shouldStopTick() else { return }
+        let loadedModelHash = await modelRuntime.loadedModelHash
+        guard !shouldStopTick() else { return }
+        guard isLoaded, loadedModelHash != nil else {
+            logSkipped("model_not_loaded")
+            return
+        }
+
+        let finalSnapshot = await providerStatus.snapshot()
+        guard !shouldStopTick() else { return }
+        guard finalSnapshot.requestsInFlight == 0 else {
+            logSkipped("busy")
+            return
+        }
+        let finalIdleSeconds = await providerStatus.secondsSinceLastActivityOrPrewarm()
+        guard !shouldStopTick() else { return }
+        guard finalIdleSeconds >= config.idleThresholdSeconds else {
+            logSkipped("not_idle_yet")
+            return
+        }
+
+        fireWarmup(idleSeconds: finalIdleSeconds, thermalState: thermalState, onBattery: onBattery)
+    }
+
+    private func fireWarmup(idleSeconds: Double, thermalState: ProcessInfo.ThermalState, onBattery: Bool) {
+        let id = UUID()
+        let startedAt = Date()
+        let token = IdlePrewarmCancellationToken()
+        let maxTokens = config.maxTokens
+        let prompt = config.prompt
+        log([
+            "event": "idle_prewarm_fired",
+            "idle_seconds": idleSeconds,
+            "max_tokens": maxTokens,
+            "thermal_state": thermalState.label,
+            "on_battery": onBattery,
+        ])
+        let task = Task { [modelRuntime, providerStatus, weak self, token] in
+            await providerStatus.noteInternalPrewarm(at: startedAt, elapsedMS: 0)
+            do {
+                let result = try await modelRuntime.runInternalWarmup(
+                    maxTokens: maxTokens,
+                    prompt: prompt,
+                    shouldCancel: { token.isCancelled }
+                )
+                await providerStatus.noteInternalPrewarm(at: startedAt, elapsedMS: result.totalElapsedMS)
+                await self?.completeWarmup(id: id, result: result)
+            } catch is CancellationError {
+                await self?.clearWarmup(id: id)
+            } catch {
+                await self?.failWarmup(id: id, error: error, startedAt: startedAt)
+            }
+        }
+        inflight = IdlePrewarmRun(id: id, startedAt: startedAt, token: token, task: task)
+    }
+
+    private func completeWarmup(id: UUID, result: InternalWarmupResult) {
+        guard inflight?.id == id else { return }
+        inflight = nil
+        log([
+            "event": "idle_prewarm_completed",
+            "elapsed_ms": result.totalElapsedMS,
+            "tokens_generated": result.tokensGenerated,
+            "first_token_ms": result.firstTokenElapsedMS,
+        ])
+    }
+
+    private func failWarmup(id: UUID, error: Error, startedAt: Date) {
+        guard inflight?.id == id else { return }
+        inflight = nil
+        log([
+            "event": "idle_prewarm_failed",
+            "error_class": String(describing: type(of: error)),
+            "elapsed_ms": Self.elapsedMilliseconds(since: startedAt),
+        ])
+    }
+
+    private func clearWarmup(id: UUID) {
+        guard inflight?.id == id else { return }
+        inflight = nil
+    }
+
+    private func cancelInflight(logRealRequest: Bool) {
+        guard let run = inflight else { return }
+        inflight = nil
+        run.token.cancel()
+        run.task.cancel()
+        if logRealRequest {
+            log([
+                "event": "idle_prewarm_cancelled_by_real_request",
+                "elapsed_ms": Self.elapsedMilliseconds(since: run.startedAt),
+            ])
+        }
+    }
+
+    private func logSkipped(_ reason: String) {
+        log([
+            "event": "idle_prewarm_skipped",
+            "reason": reason,
+        ])
+    }
+
+    private func log(_ object: [String: Any]) {
+        logger.emit(object)
+    }
+
+    private func shouldStopTick() -> Bool {
+        stopped || Task.isCancelled
+    }
+
+    private static func elapsedMilliseconds(since date: Date) -> Double {
+        max(0, Date().timeIntervalSince(date) * 1000.0)
+    }
+
+    private static func nanoseconds(_ seconds: Double) -> UInt64 {
+        UInt64(max(0, seconds) * 1_000_000_000)
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -80,6 +80,24 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "Maximum concurrent in-flight inferences. Defaults to 1 (single-slot, the only safe value while mlx-swift parallel generation remains unproven). Lifting this above 1 is an autotune knob — the binary itself does not enforce safety beyond the AsyncSemaphore. Overrides MACPROVIDER_MAX_CONCURRENCY_OVERRIDE and config key max_concurrency_override.")
     var maxBatch: Int?
 
+    @Flag(name: .customLong("idle-prewarm"), inversion: .prefixedNo, help: "Enable provider-side idle MLX Metal prewarm. Default on.")
+    var idlePrewarm: Bool?
+
+    @Option(name: .customLong("idle-prewarm-idle-threshold-s"), help: "Seconds of no real requests before idle prewarm may fire. Default 30; range 5...3600.")
+    var idlePrewarmIdleThresholdSeconds: Double?
+
+    @Option(name: .customLong("idle-prewarm-tick-s"), help: "Idle prewarm check interval in seconds. Default 5; range 1...60.")
+    var idlePrewarmTickSeconds: Double?
+
+    @Option(name: .customLong("idle-prewarm-max-tokens"), help: "Synthetic warmup max tokens. Default 1; range 1...8.")
+    var idlePrewarmMaxTokens: Int?
+
+    @Option(name: .customLong("idle-prewarm-prompt"), help: "Synthetic warmup prompt. Default 'warm'; range 1...64 UTF-8 bytes.")
+    var idlePrewarmPrompt: String?
+
+    @Flag(name: .customLong("idle-prewarm-on-battery"), inversion: .prefixedNo, help: "Allow idle prewarm while running on battery. Default off.")
+    var idlePrewarmRunOnBattery: Bool?
+
     @Flag(help: "Run only the local HTTP server; do not establish a coordinator WebSocket session.")
     var noJoin = false
 
@@ -295,7 +313,13 @@ struct ServeCommand: AsyncParsableCommand {
                 managedBy: managedBy,
                 kvBits: kvBits,
                 maxContext: maxContext,
-                maxBatch: maxBatch
+                maxBatch: maxBatch,
+                idlePrewarmEnabled: idlePrewarm,
+                idlePrewarmIdleThresholdSeconds: idlePrewarmIdleThresholdSeconds,
+                idlePrewarmTickSeconds: idlePrewarmTickSeconds,
+                idlePrewarmMaxTokens: idlePrewarmMaxTokens,
+                idlePrewarmPrompt: idlePrewarmPrompt,
+                idlePrewarmRunOnBattery: idlePrewarmRunOnBattery
             )
         )
 
@@ -354,6 +378,13 @@ struct ServeCommand: AsyncParsableCommand {
             thermalGate: thermalGate
         )
         await modelRuntime.setProviderStatus(providerStatus)
+        let idlePrewarmer = IdlePrewarmer(
+            modelRuntime: modelRuntime,
+            providerStatus: providerStatus,
+            thermalGate: thermalGate,
+            powerSource: SystemPowerSourceReporter(),
+            config: IdlePrewarmConfig(appConfig: resolved)
+        )
         let receiptKeyStore = KeychainReceiptKeyStore()
         let receiptRuntime = try Self.makeReceiptRuntime(config: resolved, keyStore: receiptKeyStore)
         if resolved.donorMode {
@@ -407,15 +438,18 @@ struct ServeCommand: AsyncParsableCommand {
             controlSocket = nil
         }
         await coordinatorClient?.start()
+        await idlePrewarmer.start()
         let server = HTTPServer(
             config: resolved,
             modelRuntime: modelRuntime,
             providerStatus: providerStatus,
-            receiptBuilder: receiptRuntime.builder
+            receiptBuilder: receiptRuntime.builder,
+            idlePrewarmer: idlePrewarmer
         )
-        let terminationHandlers = installTerminationHandlers(coordinatorClient: coordinatorClient, controlSocket: controlSocket)
+        let terminationHandlers = installTerminationHandlers(coordinatorClient: coordinatorClient, controlSocket: controlSocket, idlePrewarmer: idlePrewarmer)
         defer {
             Task {
+                await idlePrewarmer.stop()
                 await controlSocket?.stop()
                 await coordinatorClient?.stop()
             }
@@ -560,13 +594,15 @@ struct UpdateCommand: AsyncParsableCommand {
 
 private func installTerminationHandlers(
     coordinatorClient: CoordinatorClient?,
-    controlSocket: ControlSocketServer?
+    controlSocket: ControlSocketServer?,
+    idlePrewarmer: IdlePrewarmer?
 ) -> [DispatchSourceSignal] {
     [SIGTERM, SIGINT].map { signalNumber in
         signal(signalNumber, SIG_IGN)
         let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global(qos: .userInitiated))
         source.setEventHandler {
             Task {
+                await idlePrewarmer?.stop()
                 await controlSocket?.stop()
                 await coordinatorClient?.drainAndExit(reason: "\(signalName(signalNumber)) received")
                 Darwin.exit(0)
@@ -603,4 +639,10 @@ private func printResolvedConfiguration(_ config: AppConfig) {
     print("  max_context: \(config.maxContextOverride.map(String.init) ?? "<unset, per-tier default>")")
     print("  max_batch: \(config.maxConcurrencyOverride.map(String.init) ?? "1")")
     print("  enable_receipts: \(config.enableReceipts)")
+    print("  idle_prewarm.enabled: \(config.idlePrewarmEnabled)")
+    print("  idle_prewarm.idle_threshold_seconds: \(config.idlePrewarmIdleThresholdSeconds)")
+    print("  idle_prewarm.tick_seconds: \(config.idlePrewarmTickSeconds)")
+    print("  idle_prewarm.max_tokens: \(config.idlePrewarmMaxTokens)")
+    print("  idle_prewarm.prompt: \(config.idlePrewarmPrompt)")
+    print("  idle_prewarm.run_on_battery: \(config.idlePrewarmRunOnBattery)")
 }

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -223,6 +223,12 @@ struct ModelRuntimeLoadError: Error, CustomStringConvertible {
     }
 }
 
+struct InternalWarmupResult: Sendable {
+    let tokensGenerated: Int
+    let firstTokenElapsedMS: Double
+    let totalElapsedMS: Double
+}
+
 actor ModelRuntime: ModelRuntimeServing {
     // AC-V2-9b (LOCKED): SPEC-019 v0.2.4 §6 normative 2 MiB streaming
     // content cap. Byte domain is post-stop-token-filter buyer-visible
@@ -266,7 +272,7 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 
     var isLoaded: Bool {
-        currentContainer != nil
+        currentContainer != nil || (testCompletion != nil && currentModelID != nil)
     }
 
     init(
@@ -549,6 +555,113 @@ actor ModelRuntime: ModelRuntimeServing {
     ) async throws -> CompletionResult {
         let (result, _) = try await completeWithServedSnapshot(request, shouldCancel: shouldCancel)
         return result
+    }
+
+    /// Runs a synthetic, coordinator-invisible inference against the loaded
+    /// runtime. This intentionally bypasses ProviderStatus request accounting,
+    /// receipt emission, and conversation-cache reads/writes.
+    func runInternalWarmup(
+        maxTokens: Int,
+        prompt: String,
+        shouldCancel: @escaping @Sendable () -> Bool
+    ) async throws -> InternalWarmupResult {
+        let boundedMaxTokens = min(8, max(1, maxTokens))
+        guard (1...64).contains(prompt.utf8.count) else {
+            throw APIError(
+                status: 400,
+                message: "internal warmup prompt must be 1...64 UTF-8 bytes",
+                type: "invalid_request_error",
+                code: "invalid_request",
+                param: "prompt"
+            )
+        }
+
+        let startedAt = Date()
+        let snapshot = await currentSnapshot()
+        try Self.validateReady(snapshot.state)
+        guard snapshot.modelHash != nil else {
+            throw APIError(status: 503, message: "Model hash unavailable", type: "server_error", code: "model_not_loaded")
+        }
+
+        if let testCompletion {
+            let request = try Self.internalWarmupRequest(modelID: snapshot.modelID, prompt: prompt, maxTokens: boundedMaxTokens)
+            let completion = try await withThrowingTaskGroup(of: CompletionResult.self) { group in
+                group.addTask {
+                    try await testCompletion(snapshot, request)
+                }
+                group.addTask {
+                    while !Task.isCancelled {
+                        if shouldCancel() {
+                            throw CancellationError()
+                        }
+                        try await Task.sleep(nanoseconds: 5_000_000)
+                    }
+                    throw CancellationError()
+                }
+                guard let completion = try await group.next() else {
+                    throw CancellationError()
+                }
+                group.cancelAll()
+                return completion
+            }
+            let elapsed = Date().timeIntervalSince(startedAt) * 1000.0
+            return InternalWarmupResult(
+                tokensGenerated: completion.completionTokens,
+                firstTokenElapsedMS: Double(completion.ttftMilliseconds ?? Int64(elapsed)),
+                totalElapsedMS: elapsed
+            )
+        }
+
+        guard let container = snapshot.container else {
+            throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
+        }
+
+        let maxContextTokens = maxContextTokens
+        let kvBitsOverride = kvBitsOverride
+        let inferenceGate = inferenceGate
+        let firstToken = FirstTokenRecorder()
+        let cancellation = WarmupCancellationRecorder()
+        let result: GenerateResult = try await inferenceGate.withPermit {
+            if Task.isCancelled || shouldCancel() {
+                throw CancellationError()
+            }
+            return try await container.perform { context in
+                if Task.isCancelled || shouldCancel() {
+                    throw CancellationError()
+                }
+                let input = UserInput(chat: [.user(prompt)])
+                let lmInput = try await context.processor.prepare(input: input)
+                try Self.validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
+                let parameters = GenerateParameters(
+                    maxTokens: boundedMaxTokens,
+                    maxKVSize: maxContextTokens,
+                    kvBits: kvBitsOverride,
+                    temperature: 0.0,
+                    topP: 1.0
+                )
+                let kvCache = context.model.newCache(parameters: parameters)
+                let iterator = try TokenIterator(input: lmInput, model: context.model, cache: kvCache, parameters: parameters)
+                return try generate(input: lmInput, context: context, iterator: iterator) { tokens in
+                    if !tokens.isEmpty {
+                        firstToken.recordIfMissing()
+                    }
+                    if Task.isCancelled || shouldCancel() {
+                        cancellation.record()
+                        return .stop
+                    }
+                    return .more
+                }
+            }
+        }
+        if cancellation.wasCancelled || Task.isCancelled || shouldCancel() {
+            throw CancellationError()
+        }
+        let elapsed = Date().timeIntervalSince(startedAt) * 1000.0
+        return InternalWarmupResult(
+            tokensGenerated: result.generationTokenCount,
+            firstTokenElapsedMS: Double(firstToken.elapsedMilliseconds(since: startedAt) ?? Int64(elapsed)),
+            totalElapsedMS: elapsed
+        )
     }
 
     /// SPEC-015 §M.2.2 — atomic snapshot capture inside the actor
@@ -1181,6 +1294,22 @@ actor ModelRuntime: ModelRuntimeServing {
         )
     }
 
+    private static func internalWarmupRequest(modelID: String?, prompt: String, maxTokens: Int) throws -> ChatCompletionRequest {
+        let body: [String: Any] = [
+            "model": modelID ?? "internal-warmup",
+            "messages": [
+                [
+                    "role": "user",
+                    "content": prompt,
+                ],
+            ],
+            "max_tokens": maxTokens,
+            "temperature": 0,
+            "top_p": 1,
+        ]
+        return try ChatCompletionRequest.parse(data: try JSONSerialization.data(withJSONObject: body))
+    }
+
     private static func validateStructuredCompletion(_ completion: CompletionResult, request: ChatCompletionRequest) throws -> CompletionResult {
         if completion.toolCalls?.isEmpty == false {
             return completion
@@ -1753,6 +1882,23 @@ private final class FirstTokenRecorder: @unchecked Sendable {
             return nil
         }
         return max(0, Int64(timestamp.timeIntervalSince(start) * 1000))
+    }
+}
+
+private final class WarmupCancellationRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var wasCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func record() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/ProviderStatus.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderStatus.swift
@@ -89,6 +89,8 @@ struct ProviderSnapshot: Sendable {
     let recommendedBinaryVersion: String?
     let activeRequestIDCount: Int
     let thermallyThrottled: Bool
+    let lastActivityAt: Date
+    let lastPrewarmAt: Date?
 
     var slotsFree: Int {
         if thermallyThrottled { return 0 }
@@ -121,6 +123,9 @@ actor ProviderStatus {
     private var recommendedBinaryVersion: String?
     private var activeRequestIDs = Set<String>()
     private let thermalGate: ThermalGate?
+    private var lastActivityAt = Date()
+    private var lastPrewarmAt: Date?
+    private var lastPrewarmElapsedMS: Double?
 
     init(modelID: String?, modelLoaded: Bool, capacity: ProviderCapacity, modelHash: String? = nil, thermalGate: ThermalGate? = nil) {
         self.modelID = modelID
@@ -132,6 +137,7 @@ actor ProviderStatus {
     }
 
     func beginRequest(requestID: String? = nil) -> Date {
+        noteRealRequestStart()
         requestsInFlight += 1
         if let requestID {
             activeRequestIDs.insert(requestID)
@@ -141,6 +147,7 @@ actor ProviderStatus {
     }
 
     func finishRequest(startedAt: Date, completion: CompletionResult?, failed: Bool, requestID: String? = nil) {
+        noteRealRequestEnd()
         requestsInFlight = max(0, requestsInFlight - 1)
         if let requestID {
             activeRequestIDs.remove(requestID)
@@ -162,6 +169,30 @@ actor ProviderStatus {
 
     func recordError() {
         errorsTotal += 1
+    }
+
+    func noteRealRequestStart() {
+        lastActivityAt = Date()
+    }
+
+    func noteRealRequestEnd() {
+        lastActivityAt = Date()
+    }
+
+    func secondsSinceLastRealActivity() -> Double {
+        max(0, Date().timeIntervalSince(lastActivityAt))
+    }
+
+    func secondsSinceLastActivityOrPrewarm() -> Double {
+        let now = Date()
+        let secondsSinceActivity = max(0, now.timeIntervalSince(lastActivityAt))
+        guard let lastPrewarmAt else { return secondsSinceActivity }
+        return min(secondsSinceActivity, max(0, now.timeIntervalSince(lastPrewarmAt)))
+    }
+
+    func noteInternalPrewarm(at: Date = Date(), elapsedMS: Double) {
+        lastPrewarmAt = at
+        lastPrewarmElapsedMS = elapsedMS
     }
 
     func setState(_ newState: ProviderHealthState) {
@@ -210,7 +241,9 @@ actor ProviderStatus {
             coordinatorTier: coordinatorTier,
             recommendedBinaryVersion: recommendedBinaryVersion,
             activeRequestIDCount: activeRequestIDs.count,
-            thermallyThrottled: throttled
+            thermallyThrottled: throttled,
+            lastActivityAt: lastActivityAt,
+            lastPrewarmAt: lastPrewarmAt
         )
         if resetWindow {
             windowRequests = 0

--- a/phase3-binary/Tests/macprovider-cliTests/IdlePrewarmerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/IdlePrewarmerTests.swift
@@ -1,0 +1,438 @@
+import ArgumentParser
+import Foundation
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+final class IdlePrewarmerTests: XCTestCase {
+    func testPrewarmFiresAfterIdleThreshold() async throws {
+        let fixture = try await Fixture(idleThreshold: 0.03)
+        try await Task.sleep(nanoseconds: 40_000_000)
+
+        await fixture.prewarmer.runOneTickForTest()
+        try await waitUntil { await fixture.probe.calls == 1 }
+
+        let snapshot = await fixture.status.snapshot()
+        XCTAssertNotNil(snapshot.lastPrewarmAt)
+        let prompts = await fixture.probe.prompts
+        XCTAssertEqual(prompts, ["warm"])
+    }
+
+    func testPrewarmDoesNotFireWhileBusy() async throws {
+        let fixture = try await Fixture(idleThreshold: 0)
+        let startedAt = await fixture.status.beginRequest()
+
+        await fixture.prewarmer.runOneTickForTest()
+        await fixture.status.finishRequest(startedAt: startedAt, completion: nil, failed: false)
+
+        let calls = await fixture.probe.calls
+        XCTAssertEqual(calls, 0)
+        XCTAssertEqual(fixture.events.names, ["idle_prewarm_skipped"])
+        XCTAssertEqual(fixture.events.last?["reason"] as? String, "busy")
+    }
+
+    func testPrewarmDoesNotFireBeforeIdleThreshold() async throws {
+        let fixture = try await Fixture(idleThreshold: 30)
+
+        await fixture.prewarmer.runOneTickForTest()
+
+        let calls = await fixture.probe.calls
+        XCTAssertEqual(calls, 0)
+        XCTAssertEqual(fixture.events.last?["reason"] as? String, "not_idle_yet")
+    }
+
+    func testPrewarmSkipsOnSerious() async throws {
+        let fixture = try await Fixture(idleThreshold: 0, thermalState: .serious)
+
+        await fixture.prewarmer.runOneTickForTest()
+
+        let calls = await fixture.probe.calls
+        XCTAssertEqual(calls, 0)
+        XCTAssertEqual(fixture.events.last?["reason"] as? String, "thermal_pressure")
+    }
+
+    func testPrewarmSkipsOnCritical() async throws {
+        let fixture = try await Fixture(idleThreshold: 0, thermalState: .critical)
+
+        await fixture.prewarmer.runOneTickForTest()
+
+        let calls = await fixture.probe.calls
+        XCTAssertEqual(calls, 0)
+        XCTAssertEqual(fixture.events.last?["reason"] as? String, "thermal_pressure")
+    }
+
+    func testBatteryGateHonorsRunOnBatteryConfig() async throws {
+        let off = try await Fixture(idleThreshold: 0, powerState: .battery, runOnBattery: false)
+        await off.prewarmer.runOneTickForTest()
+        let offCalls = await off.probe.calls
+        XCTAssertEqual(offCalls, 0)
+        XCTAssertEqual(off.events.last?["reason"] as? String, "on_battery")
+
+        let on = try await Fixture(idleThreshold: 0, powerState: .battery, runOnBattery: true)
+        await on.prewarmer.runOneTickForTest()
+        try await waitUntil { await on.probe.calls == 1 }
+    }
+
+    func testDisabledProducesNoWarmupCallsAcrossTicks() async throws {
+        let fixture = try await Fixture(enabled: false, idleThreshold: 0)
+
+        for _ in 0..<10 {
+            await fixture.prewarmer.runOneTickForTest()
+        }
+
+        let calls = await fixture.probe.calls
+        XCTAssertEqual(calls, 0)
+        XCTAssertEqual(fixture.events.names.filter { $0 == "idle_prewarm_skipped" }.count, 10)
+    }
+
+    func testInflightPrewarmCanBeCancelledByRealRequest() async throws {
+        let fixture = try await Fixture(idleThreshold: 0, blocksWarmup: true)
+        await fixture.prewarmer.runOneTickForTest()
+        try await waitUntil { await fixture.probe.calls == 1 }
+
+        await fixture.prewarmer.cancelInflightPrewarm()
+        try await waitUntil { fixture.events.names.contains("idle_prewarm_cancelled_by_real_request") }
+
+        XCTAssertLessThan((fixture.events.last?["elapsed_ms"] as? Double) ?? 1_000, 500)
+    }
+
+    func testRunInternalWarmupDoesNotTouchRequestCountersSlotsOrReceiptAudit() async throws {
+        let fixture = try await Fixture(idleThreshold: 0)
+        let before = await fixture.status.snapshot(resetWindow: true)
+        let receiptBytes = DataCapture()
+
+        _ = try await ReceiptAudit.withSink({ receiptBytes.append($0) }) {
+            try await fixture.runtime.runInternalWarmup(maxTokens: 99, prompt: "warm", shouldCancel: { false })
+        }
+
+        let after = await fixture.status.snapshot(resetWindow: false)
+        XCTAssertEqual(after.requestsTotal, before.requestsTotal)
+        XCTAssertEqual(after.requestsInFlight, before.requestsInFlight)
+        XCTAssertEqual(after.requestsServedSinceLast, 0)
+        XCTAssertNil(after.avgLatencyMSSinceLast)
+        XCTAssertNil(after.throughputTPSSinceLast)
+        XCTAssertEqual(after.slotsFree, before.slotsFree)
+        XCTAssertTrue(receiptBytes.isEmpty)
+        let maxTokens = await fixture.probe.maxTokens
+        XCTAssertEqual(maxTokens, [8])
+    }
+
+    func testPrewarmDoesNotFireAgainWithinIdleThreshold() async throws {
+        let fixture = try await Fixture(idleThreshold: 0.08)
+        try await Task.sleep(nanoseconds: 90_000_000)
+        await fixture.prewarmer.runOneTickForTest()
+        try await waitUntil { await fixture.probe.calls == 1 }
+        try await waitUntil { (await fixture.status.snapshot()).lastPrewarmAt != nil }
+
+        await fixture.prewarmer.runOneTickForTest()
+
+        let calls = await fixture.probe.calls
+        XCTAssertEqual(calls, 1)
+        XCTAssertEqual(fixture.events.last?["reason"] as? String, "not_idle_yet")
+    }
+
+    func testPrewarmFiresAgainAfterIdleThresholdSincePrewarm() async throws {
+        let fixture = try await Fixture(idleThreshold: 0.08)
+        try await Task.sleep(nanoseconds: 90_000_000)
+        await fixture.prewarmer.runOneTickForTest()
+        try await waitUntil { fixture.events.names.contains("idle_prewarm_completed") }
+
+        try await Task.sleep(nanoseconds: 90_000_000)
+        await fixture.prewarmer.runOneTickForTest()
+
+        try await waitUntil { await fixture.probe.calls == 2 }
+    }
+
+    func testStructuredEventsCoverAllCategories() async throws {
+        let success = try await Fixture(idleThreshold: 0)
+        await success.prewarmer.runOneTickForTest()
+        try await waitUntil { success.events.names.contains("idle_prewarm_completed") }
+
+        let skipped = try await Fixture(enabled: false, idleThreshold: 0)
+        await skipped.prewarmer.runOneTickForTest()
+
+        let cancelled = try await Fixture(idleThreshold: 0, blocksWarmup: true)
+        await cancelled.prewarmer.runOneTickForTest()
+        try await waitUntil { await cancelled.probe.calls == 1 }
+        await cancelled.prewarmer.cancelInflightPrewarm()
+
+        let failed = try await Fixture(idleThreshold: 0, warmupError: TestWarmupError.failed)
+        await failed.prewarmer.runOneTickForTest()
+        try await waitUntil { failed.events.names.contains("idle_prewarm_failed") }
+
+        let names = Set(success.events.names + skipped.events.names + cancelled.events.names + failed.events.names)
+        XCTAssertTrue(names.isSuperset(of: [
+            "idle_prewarm_fired",
+            "idle_prewarm_completed",
+            "idle_prewarm_skipped",
+            "idle_prewarm_cancelled_by_real_request",
+            "idle_prewarm_failed",
+        ]))
+    }
+
+    func testConfigValidationRejectsInvalidIdlePrewarmValues() {
+        let cases = [
+            ("idle_prewarm:\n  enabled: maybe\n", "enabled"),
+            ("idle_prewarm:\n  idle_threshold_seconds: 4\n", "idle_prewarm.idle_threshold_seconds"),
+            ("idle_prewarm:\n  tick_seconds: 0\n", "idle_prewarm.tick_seconds"),
+            ("idle_prewarm:\n  max_tokens: 9\n", "idle_prewarm.max_tokens"),
+            ("idle_prewarm:\n  prompt: \"\"\n", "idle_prewarm.prompt"),
+            ("idle_prewarm:\n  run_on_battery: maybe\n", "run_on_battery"),
+        ]
+
+        for (yaml, field) in cases {
+            XCTAssertThrowsError(try ConfigLoader.load(
+                cli: CLIOverrides(),
+                environment: [:],
+                fileExists: { _ in true },
+                readFile: { _ in yaml }
+            ), field) { error in
+                XCTAssertTrue(String(describing: error).contains(field), String(describing: error))
+            }
+        }
+    }
+
+    func testNoIdlePrewarmOnBatteryOverridesYamlTrue() throws {
+        let disabled = try ServeCommand.parse(["--no-idle-prewarm-on-battery"])
+        XCTAssertEqual(disabled.idlePrewarmRunOnBattery, false)
+        let enabled = try ServeCommand.parse(["--idle-prewarm-on-battery"])
+        XCTAssertEqual(enabled.idlePrewarmRunOnBattery, true)
+
+        let loaded = try ConfigLoader.load(
+            cli: CLIOverrides(idlePrewarmRunOnBattery: disabled.idlePrewarmRunOnBattery),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in "idle_prewarm:\n  run_on_battery: true\n" }
+        )
+
+        XCTAssertFalse(loaded.idlePrewarmRunOnBattery)
+    }
+
+    func testTickSkipsWhenPrewarmAlreadyInflight() async throws {
+        let fixture = try await Fixture(idleThreshold: 0, blocksWarmup: true)
+        await fixture.prewarmer.runOneTickForTest()
+        try await waitUntil { await fixture.probe.calls == 1 }
+
+        await fixture.prewarmer.runOneTickForTest()
+
+        let calls = await fixture.probe.calls
+        XCTAssertEqual(calls, 1)
+        await fixture.prewarmer.stop()
+    }
+
+    func testStopCancelsBackgroundLoopAndInflightWarmup() async throws {
+        let fixture = try await Fixture(idleThreshold: 0, tickSeconds: 0.02, blocksWarmup: true)
+        await fixture.prewarmer.start()
+        try await waitUntil { await fixture.probe.calls == 1 }
+
+        let start = Date()
+        await fixture.prewarmer.stop()
+        try await waitUntil { await fixture.probe.cancelledCompletions == 1 }
+
+        XCTAssertLessThan(Date().timeIntervalSince(start), 5)
+        let callsAfterStop = await fixture.probe.calls
+        try await Task.sleep(nanoseconds: 60_000_000)
+        let calls = await fixture.probe.calls
+        XCTAssertEqual(calls, callsAfterStop)
+    }
+
+    func testShutdownDuringInflightPrewarmCompletesWithinBoundedTime() async throws {
+        let fixture = try await Fixture(idleThreshold: 0, blocksWarmup: true)
+        await fixture.prewarmer.runOneTickForTest()
+        try await waitUntil { await fixture.probe.calls == 1 }
+
+        let start = Date()
+        await fixture.prewarmer.stop()
+
+        XCTAssertLessThan(Date().timeIntervalSince(start), 5)
+        let cancelledCompletions = await fixture.probe.cancelledCompletions
+        XCTAssertEqual(cancelledCompletions, 1)
+    }
+
+    func testSlotsFreeInvariantBeforeDuringAfterPrewarm() async throws {
+        let fixture = try await Fixture(idleThreshold: 0, blocksWarmup: true, maxConcurrency: 4)
+        let before = await fixture.status.snapshot()
+        await fixture.prewarmer.runOneTickForTest()
+        try await waitUntil { await fixture.probe.calls == 1 }
+        let during = await fixture.status.snapshot()
+
+        await fixture.prewarmer.stop()
+        let after = await fixture.status.snapshot()
+
+        XCTAssertEqual(before.slotsFree, 4)
+        XCTAssertEqual(during.slotsFree, before.slotsFree)
+        XCTAssertEqual(after.slotsFree, before.slotsFree)
+    }
+}
+
+private struct Fixture {
+    let runtime: ModelRuntime
+    let status: ProviderStatus
+    let prewarmer: IdlePrewarmer
+    let probe: WarmupProbe
+    let events: EventCapture
+
+    init(
+        enabled: Bool = true,
+        idleThreshold: Double,
+        tickSeconds: Double = 1,
+        thermalState: ProcessInfo.ThermalState = .nominal,
+        powerState: PowerSourceState = .external,
+        runOnBattery: Bool = false,
+        blocksWarmup: Bool = false,
+        warmupError: Error? = nil,
+        maxConcurrency: Int = 1
+    ) async throws {
+        let probe = WarmupProbe(blocks: blocksWarmup, error: warmupError)
+        let hash = String(repeating: "a", count: 64)
+        let runtime = ModelRuntime(
+            modelID: "model-a",
+            modelHash: hash,
+            warmSwapEnabled: false,
+            loader: { _ in throw TestWarmupError.unexpectedLoad },
+            testCompletion: { _, request in
+                try await probe.complete(request: request)
+            }
+        )
+        let thermalGate = ThermalGate(stateProvider: FixedThermalProvider(state: thermalState))
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: maxConcurrency),
+            modelHash: hash,
+            thermalGate: thermalGate
+        )
+        await runtime.setProviderStatus(status)
+        let events = EventCapture()
+        let prewarmer = IdlePrewarmer(
+            modelRuntime: runtime,
+            providerStatus: status,
+            thermalGate: thermalGate,
+            powerSource: FixedPowerSource(state: powerState),
+            config: IdlePrewarmConfig(
+                enabled: enabled,
+                idleThresholdSeconds: idleThreshold,
+                tickSeconds: tickSeconds,
+                maxTokens: 1,
+                prompt: "warm",
+                runOnBattery: runOnBattery
+            ),
+            logger: IdlePrewarmLogger { events.append($0) }
+        )
+        self.runtime = runtime
+        self.status = status
+        self.prewarmer = prewarmer
+        self.probe = probe
+        self.events = events
+    }
+}
+
+private actor WarmupProbe {
+    private let blocks: Bool
+    private let error: Error?
+    private var callCount = 0
+    private var cancelledCount = 0
+    private var seenPrompts: [String] = []
+    private var seenMaxTokens: [Int] = []
+
+    init(blocks: Bool, error: Error?) {
+        self.blocks = blocks
+        self.error = error
+    }
+
+    var calls: Int { callCount }
+    var cancelledCompletions: Int { cancelledCount }
+    var prompts: [String] { seenPrompts }
+    var maxTokens: [Int] { seenMaxTokens }
+
+    func complete(request: ChatCompletionRequest) async throws -> CompletionResult {
+        callCount += 1
+        seenPrompts.append(request.messages.last?.content ?? "")
+        seenMaxTokens.append(request.maxTokens ?? 0)
+        if let error {
+            throw error
+        }
+        if blocks {
+            do {
+                while !Task.isCancelled {
+                    try await Task.sleep(nanoseconds: 5_000_000)
+                }
+            } catch is CancellationError {
+                cancelledCount += 1
+                throw CancellationError()
+            }
+            cancelledCount += 1
+            throw CancellationError()
+        }
+        return CompletionResult(content: "ok", finishReason: "stop", promptTokens: 1, completionTokens: 1, ttftMilliseconds: 1)
+    }
+}
+
+private final class EventCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [[String: Any]] = []
+
+    var names: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values.compactMap { $0["event"] as? String }
+    }
+
+    var last: [String: Any]? {
+        lock.lock()
+        defer { lock.unlock() }
+        return values.last
+    }
+
+    func append(_ event: [String: Any]) {
+        lock.lock()
+        values.append(event)
+        lock.unlock()
+    }
+}
+
+private final class DataCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    var isEmpty: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return data.isEmpty
+    }
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+}
+
+private struct FixedPowerSource: PowerSourceReporting {
+    let state: PowerSourceState
+    func currentPowerSourceState() -> PowerSourceState { state }
+}
+
+private struct FixedThermalProvider: ThermalStateProviding {
+    let state: ProcessInfo.ThermalState
+    func currentThermalState() -> ProcessInfo.ThermalState { state }
+}
+
+private enum TestWarmupError: Error {
+    case failed
+    case unexpectedLoad
+}
+
+private func waitUntil(
+    timeoutNanoseconds: UInt64 = 2_000_000_000,
+    _ predicate: () async -> Bool
+) async throws {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while DispatchTime.now().uptimeNanoseconds < deadline {
+        if await predicate() {
+            return
+        }
+        try await Task.sleep(nanoseconds: 5_000_000)
+    }
+    XCTFail("Timed out waiting for condition")
+}

--- a/specs/AUDIT_PROVIDER_IDLE_PREWARM_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_PROVIDER_IDLE_PREWARM_ARCHITECT_PROMPT.md
@@ -1,0 +1,118 @@
+# AUDIT_PROVIDER_IDLE_PREWARM_ARCHITECT — ARCHITECT lane
+
+You are auditing the diff that implements the provider idle-prewarm
+described in `specs/BUILD_PROVIDER_IDLE_PREWARM_IMPL_PROMPT.md`.
+
+## Your lane: ARCHITECT
+
+Focus on design-level concerns: placement, layering, consistency with
+existing patterns, extensibility.
+
+### Look for
+
+1. **Actor topology placement**
+   - `IdlePrewarmer` is a peer to `ThermalGate` / `ProviderStatus` /
+     `ModelRuntime`, not a nested type inside one of them.
+   - Prewarmer holds references (not ownership) of the other actors
+     it queries.
+   - No circular actor dependency (e.g. ModelRuntime holds
+     IdlePrewarmer holds ModelRuntime).
+
+2. **API additions on existing types**
+   - `ModelRuntime.runInternalWarmup` placed near `complete()` /
+     `.stream()` for review-locality.
+   - `ProviderStatus.noteRealRequestStart` / `noteRealRequestEnd` /
+     `secondsSinceLastRealActivity` / `noteInternalPrewarm` are
+     grouped as a "activity tracking" region with a shared comment.
+   - No new type parameters, no changed return types on existing
+     public methods.
+
+3. **Config placement**
+   - Top-level `idle_prewarm:` yaml block matches existing yaml key
+     naming (`snake_case`, existing style like `max_context_override`).
+   - Consider whether nesting under a `runtime:` or `prewarm:`
+     umbrella would age better as more prewarm-adjacent knobs land
+     (e.g. B2 coord-side keepalive, if that ships later).
+   - Defaults registered in the same place as other phase3-binary
+     defaults (avoid drift where some knobs default in yaml unmarshal
+     and others in a normaliser).
+
+4. **CLI flag naming consistency**
+   - `--idle-prewarm-tick-s` matches existing flag naming style
+     (`--max-context`, `--max-batch`, dashes not underscores).
+   - Long-form only (no short flags) matches existing style.
+   - Consider whether a compound flag like
+     `--idle-prewarm=off,tick=5,threshold=30` would be cleaner —
+     probably NOT worth the divergence from existing per-knob flags.
+
+5. **Wiring in `MacProviderCLI.swift`**
+   - Instantiation ordering per R5 is respected.
+   - `IdlePrewarmer.start()` and `.stop()` are called from the
+     matching lifecycle handlers (serve start / SIGINT drain).
+   - No leaked task / dispatch queue that outlives the serve command.
+
+6. **Test-file naming**
+   - `IdlePrewarmerTests.swift` matches existing test-file naming
+     pattern in `phase3-binary/Tests/macprovider-cliTests/`.
+
+7. **Protocol injection surfaces**
+   - `PowerSourceReporting` protocol is defined next to its concrete
+     `SystemPowerSource` (or equivalent) implementation, mirroring
+     the `ThermalStateProviding` / `SystemThermalStateProvider`
+     pattern in `ThermalGate.swift`.
+   - Injection points on `IdlePrewarmer.init` mirror the parameter
+     shape of `ThermalGate.init` (`stateProvider: X = Y()`).
+
+8. **Interaction with SPEC-023 autotune**
+   - Prewarm results MUST NOT populate `AutotuneDB.swift` (this is a
+     CODE-lane check but also an architectural boundary — the
+     autotune loop measures buyer-facing throughput; prewarm noise
+     would bias its recommendations).
+   - Verify by inspection that `runInternalWarmup` does not touch
+     `Stage1Iterator` / `Stage2HillClimb` / `AutotuneRecommend`.
+
+9. **Interaction with ThermalGate.setTransitionLogger**
+   - The prewarmer polls `thermalGate.currentThermalState()` at
+     tick time. Does the current ThermalGate API expose a
+     `currentThermalState()` accessor? If not, add one (do NOT
+     invert the pattern by using the setTransitionLogger callback as
+     a state-cache for the prewarmer — that's stale-read-prone).
+
+10. **Extensibility signals**
+    - A future "prewarm with a real cached prompt from KV cache" or
+      "prewarm interval scales with observed traffic pattern" would
+      fit naturally in this shape without a redesign.
+    - A future coord-side keepalive (B2 alternative) can reuse
+      `PowerSourceReporting` and the event-name conventions.
+    - The `runInternalWarmup` entry point is generic enough that
+      other components (e.g. a health-check probe) could reuse it
+      without duplicating the "bypass metrics + receipts" plumbing.
+
+11. **Scope discipline**
+    - No changes outside the "MUST change" file list in the BUILD
+      prompt § "Scope of change" — unless the change is justified
+      and small (comment-level).
+    - No new SwiftPM dependencies added to `Package.swift`.
+    - No changes to coord / gateway code.
+
+### Do NOT flag
+
+- Code correctness bugs (CODE lane).
+- Security concerns (SECURITY lane).
+- Pure aesthetic preferences without operational consequence.
+- Findings that would require SPEC-level changes (defer to a separate
+  design PR).
+
+### Output format
+
+Report findings ranked C / H / M / L / I. Each finding lists:
+file:line, design concern, future scenario where it bites, proposed
+change.
+
+```
+STATUS: ARCHITECT lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+## Diff to audit
+
+`git diff` in the worktree.

--- a/specs/AUDIT_PROVIDER_IDLE_PREWARM_CODE_PROMPT.md
+++ b/specs/AUDIT_PROVIDER_IDLE_PREWARM_CODE_PROMPT.md
@@ -1,0 +1,129 @@
+# AUDIT_PROVIDER_IDLE_PREWARM_CODE — CODE lane
+
+You are auditing the diff that implements the provider idle-prewarm
+described in `specs/BUILD_PROVIDER_IDLE_PREWARM_IMPL_PROMPT.md`. Read
+that file for the behavioural contract, then read the diff.
+
+## Your lane: CODE correctness
+
+Focus exclusively on code-correctness bugs. Not security, not
+architecture. Assume the design in the BUILD prompt is fixed.
+
+### Look for
+
+1. **Actor + Task lifecycle**
+   - Background tick loop is a `Task.detached` or `Task { }` owned by
+     the actor and stored so `stop()` can `.cancel()` it.
+   - `Task.sleep(nanoseconds:)` (or injected `Clock.sleep`) is
+     `try await` and honours `Task.isCancelled`.
+   - No `Task { }` leaks — every spawned task's handle is retained.
+   - First tick fires after ONE full interval (not immediately).
+   - Stopping the actor cancels the tick loop AND any in-flight
+     prewarm task within one boundary check.
+
+2. **Cancellation propagation**
+   - `cancelInflightPrewarm()` sets a cancel flag AND cancels the
+     inflight prewarm `Task` if any.
+   - `shouldCancel` closure passed into `runInternalWarmup` reads a
+     `Sendable` state that gets flipped on real-request arrival.
+   - No path where `shouldCancel` returns false but the surrounding
+     task was cancelled (deadlock risk).
+   - Cancellation during MLX token generation aborts on next token
+     boundary — no infinite loop.
+
+3. **Concurrency / race conditions**
+   - `isPrewarmInflight` state read + set is inside the actor (safe by
+     actor isolation).
+   - The tick loop checks `isPrewarmInflight` BEFORE deciding to fire.
+   - HTTP handler's `cancelInflightPrewarm` call is `await`ed before
+     the real inference begins so ordering is guaranteed.
+   - No data race on `providerStatus.lastActivityAt` — reads and
+     writes both go through the actor's async surface.
+   - `ProviderStatus.noteRealRequestStart()` is called from the HTTP
+     handler with proper `await`.
+
+4. **Config validation**
+   - New validation branches trigger correctly for each of the 6
+     knobs' out-of-range values.
+   - Validation error messages name the offending field.
+   - Defaults applied when field absent from yaml.
+
+5. **Battery detection**
+   - `PowerSourceReporting` protocol is used in production and in tests.
+   - IOKit CFTypeRef objects (`IOPSCopyPowerSourcesInfo` return value,
+     `IOPSCopyPowerSourcesList` return value) are released via
+     `CFRelease` — no leaks.
+   - Absence of power source objects returns `.unknown`, treated as
+     "not on battery" per R9.
+
+6. **Thermal detection**
+   - Prewarmer polls `thermalGate.currentThermalState()` at the actor
+     level, not caching a value across ticks.
+   - `.serious` and `.critical` both cause skip; `.nominal` and
+     `.fair` both allow fire.
+
+7. **Idle threshold logic**
+   - `providerStatus.secondsSinceLastRealActivity()` uses monotonic
+     clock (or `Date().timeIntervalSince(lastActivity)`) — not
+     wall-clock-jump-sensitive on system clock changes.
+   - `lastActivityAt` bumps on request START (not just end) so a
+     long-running request keeps the "recent activity" window active.
+   - Values compare correctly at boundary (idle == threshold).
+
+8. **runInternalWarmup contract**
+   - Does NOT call `providerStatus.noteRealRequestStart()` or
+     `.noteRealRequestEnd()`.
+   - Does NOT increment `requestsTotal` or `requestsInFlight`.
+   - Does NOT emit `ReceiptAudit` lines.
+   - Does NOT contribute to throughput / latency metrics.
+   - DOES call `providerStatus.noteInternalPrewarm(...)` for
+     observability only.
+   - Uses the SAME MLX inference path as `complete()` for Metal-warmup
+     effect.
+   - Bounded `maxTokens` [1, 8] and `prompt` length [1, 64] enforced
+     at load time (not runtime).
+
+9. **Observability**
+   - Each event name (`idle_prewarm_fired`, `idle_prewarm_completed`,
+     `idle_prewarm_skipped`, `idle_prewarm_cancelled_by_real_request`,
+     `idle_prewarm_failed`) is emitted exactly once per lifecycle.
+   - Fields match R6's list; no field name typos.
+   - `idle_prewarm_skipped` fires at most once per tick with the
+     tightest reason (per R6 last sentence).
+
+10. **Test coverage matches AC3**
+    - All 14 AC3 test cases present as distinct tests.
+    - Tests use injected fake clock + fake `ThermalStateProviding` +
+      fake `PowerSourceReporting` + spy `ModelRuntime` (no real MLX
+      inference).
+    - No `Thread.sleep` or real wall-clock waits > 100 ms in tests.
+    - AC4 (slots_free invariance) is asserted via a coordinator
+      heartbeat spy.
+    - AC6 (SIGINT during in-flight prewarm) has a bounded-wait
+      assertion.
+
+### Do NOT flag
+
+- Placement / architecture (that's the ARCHITECT lane).
+- Auth / credential concerns (that's the SECURITY lane).
+- Naming taste, comment style, log-message wording (unless it
+  violates R6 event names verbatim).
+- Anything outside the diff.
+
+### Output format
+
+Report findings ranked C (CRITICAL) / H (HIGH) / M (MEDIUM) / L (LOW) /
+I (INFO). One paragraph per finding: file:line, defect description,
+concrete failure scenario, proposed fix in plain English. No code
+patches.
+
+Include a bottom-line status line:
+
+```
+STATUS: CODE lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+## Diff to audit
+
+`git diff` in the worktree. New file
+`phase3-binary/Sources/macprovider-cli/IdlePrewarmer.swift`.

--- a/specs/AUDIT_PROVIDER_IDLE_PREWARM_R2_PROMPT.md
+++ b/specs/AUDIT_PROVIDER_IDLE_PREWARM_R2_PROMPT.md
@@ -1,0 +1,131 @@
+# AUDIT_PROVIDER_IDLE_PREWARM_R2 — three lanes, ROUND 2
+
+Round 1 audit findings (all fixed):
+
+- **CODE H1** — `IdlePrewarmer.stop()` shutdown race (didn't await
+  loop task, no cancellation check between `runTick()` awaits and
+  `fireWarmup()`).
+- **CODE H2** — HTTP handler ordering race (called
+  `cancelInflightPrewarm()` before `providerStatus.beginRequest()`;
+  tick could fire prewarm concurrent with real inference).
+- **CODE M** — test coverage gaps (13 vs required 14 cases, missing
+  SIGINT case, missing amplification cooldown case).
+- **SECURITY M** — prewarm amplification: `runTick()` only checked
+  `lastActivityAt`, so once idle threshold crossed, every tick fired
+  a new prewarm indefinitely.
+- **ARCHITECT M** — `--idle-prewarm-on-battery` was a bare positive
+  flag with no inverse, breaking CLI > yaml precedence.
+
+Fixes applied in the R1 → R2 delta:
+
+- Actor stopped-flag + `stop()` awaits `loopTask.value`; tick checks
+  the flag between awaits and immediately before fire.
+- HTTP handler now bumps `providerStatus.beginRequest()` BEFORE
+  calling `cancelInflightPrewarm()`, then dispatches.
+- Tick has a second actor-owned "double-check" of
+  `requestsInFlight` and idle time right before `fireWarmup()`.
+- `ProviderStatus.secondsSinceLastActivityOrPrewarm()` new method
+  returns `min(now - lastActivityAt, now - lastPrewarmAt)`;
+  `runTick()` uses it. `noteInternalPrewarm(at:)` called on prewarm
+  START.
+- `--idle-prewarm-on-battery` now uses `inversion: .prefixedNo` (or
+  equivalent), so `--no-idle-prewarm-on-battery` overrides yaml
+  back to false.
+- New tests: `testPrewarmSkipsOnSerious`,
+  `testPrewarmSkipsOnCritical` (previously combined),
+  `testPrewarmDoesNotFireAgainWithinIdleThreshold`,
+  `testShutdownDuringInflightPrewarmCompletesWithinBoundedTime`,
+  and `--no-idle-prewarm-on-battery` yaml-override case.
+
+R1 LOW / INFO findings ship as-is with PR-body documentation and
+are NOT expected to be fixed in this round.
+
+## Your task
+
+You are running the CODE, SECURITY, and ARCHITECT audit lanes
+against the R1 → R2 delta. Audit ONLY the fixes for the five
+findings above and their supporting test additions. Do not
+re-litigate R1 findings; do not re-audit code that R1 already
+accepted at 0 C/H/M.
+
+### CODE lane focus for R2
+
+- Correctness of the stopped-flag semantics: no lost-update on
+  concurrent stop/tick.
+- The `await loopTask.value` path in `stop()` handles the case where
+  `loopTask` was never started (start not called).
+- The "double-check" in `runTick()` uses actor-isolated reads (i.e.
+  the second read of `requestsInFlight` happens INSIDE the actor's
+  isolated context after all preceding awaits).
+- HTTPServer ordering swap does not break existing streaming /
+  non-streaming test cases.
+- `secondsSinceLastActivityOrPrewarm()` semantics: verify
+  `min(now-a, now-b)` = "the more recent one", i.e. `max(a, b)` in
+  time — correct direction.
+- `noteInternalPrewarm(at:)` called on START, not COMPLETION, so
+  cancelled prewarms still count toward cooldown.
+- New tests use bounded waits (< 5 s per BUILD prompt AC6).
+
+### SECURITY lane focus for R2
+
+- The amplification fix actually closes the loop: with defaults
+  (tick=5, threshold=30, prewarm-cooldown=30), a hostile config
+  cannot cause more than one prewarm per idle_threshold_seconds.
+- The `noteInternalPrewarm` START timing preserves the cooldown
+  even under cancellation (a HTTP-handler-triggered cancel between
+  ticks does NOT reset the cooldown clock, so an attacker who spams
+  1-token requests cannot rapidly resume amplification).
+- CLI `--no-idle-prewarm-on-battery` closes the yaml-override
+  security gap for battery-drain amplification.
+
+### ARCHITECT lane focus for R2
+
+- The CLI flag change follows ArgumentParser's `inversion:
+  .prefixedNo` idiom, consistent with any other invertible flags
+  present in the phase3-binary codebase.
+- Actor stopped-flag pattern is consistent with any other
+  actor-lifecycle patterns present.
+- No scope creep — the fix touched only files listed in R1
+  MUST-change scope.
+
+### Do NOT flag
+
+- Anything already accepted in R1 (config surface, IOKit release
+  discipline, receipt-path bypass, etc.).
+- R1 LOW / INFO findings (deferred by design):
+  - ARCHITECT L1 (prewarmer start before HTTP listener bound)
+  - ARCHITECT L2 (`currentState()` vs `currentThermalState()` naming)
+  - ARCHITECT L3 (`powerSource` default, unused `clock`)
+  - ARCHITECT I1 (activity-tracking comment grouping)
+  - SECURITY L1 (operator prompt printed raw at startup)
+  - CODE R1 LOW (real Task.sleep in tests — kept per convention)
+- Anything outside the R1 → R2 delta.
+
+## Output format
+
+Three separate status lines, one per lane:
+
+```
+STATUS: CODE lane R2 — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+STATUS: SECURITY lane R2 — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+STATUS: ARCHITECT lane R2 — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+For each finding, one paragraph: file:line, defect, concrete
+failure scenario, proposed fix.
+
+## Diff to audit
+
+`git diff` in the worktree shows the full accumulated R1+R2 change.
+The R2 delta is:
+
+- `IdlePrewarmer.swift`: stopped-flag, `stop()` await, double-check
+  in `runTick()`, `secondsSinceLastActivityOrPrewarm()` gate,
+  `noteInternalPrewarm` on start.
+- `HTTPServer.swift`: order swap of `beginRequest()` before
+  `cancelInflightPrewarm()`.
+- `ProviderStatus.swift`: new `secondsSinceLastActivityOrPrewarm()`
+  method + `lastPrewarmAt` update on start.
+- `MacProviderCLI.swift`: `--idle-prewarm-on-battery` flag
+  `inversion: .prefixedNo`; resolution site updated.
+- `IdlePrewarmerTests.swift`: 5 new / restructured cases.

--- a/specs/AUDIT_PROVIDER_IDLE_PREWARM_SECURITY_PROMPT.md
+++ b/specs/AUDIT_PROVIDER_IDLE_PREWARM_SECURITY_PROMPT.md
@@ -1,0 +1,111 @@
+# AUDIT_PROVIDER_IDLE_PREWARM_SECURITY — SECURITY lane
+
+You are auditing the diff that implements the provider idle-prewarm
+described in `specs/BUILD_PROVIDER_IDLE_PREWARM_IMPL_PROMPT.md`.
+
+## Your lane: SECURITY
+
+Focus exclusively on security-class defects. Not correctness, not
+architecture.
+
+### Look for
+
+1. **Coordinator-visibility hygiene**
+   - The prewarm inference MUST NOT change any WSS heartbeat field
+     (slots_free, slots_total, requests_total, in_flight_count, any
+     new field). A hostile provider operator MUST NOT be able to use
+     prewarm activity to lie to the coordinator about capacity or
+     to exclude themselves from routing during warm periods.
+   - No new WSS message type introduced. No new
+     `CoordinatorClient.swift` request-dispatch surface added.
+
+2. **Receipt / billing path leakage**
+   - `runInternalWarmup` cannot invoke `ReceiptAudit.emit*`,
+     `ReceiptBuilder`, `CachedReceiptKeyStore`, or
+     `InMemoryReceiptKeyStore`. A prewarm that accidentally emitted a
+     receipt would inflate provider earnings.
+   - No path where a prewarm result gets tagged with a buyer
+     `request_id` or `conversation_key` and forwarded upstream.
+
+3. **Amplification vectors**
+   - Config bounds enforced at load time:
+     - `tick_seconds >= 1` (prevents CPU-spin loop).
+     - `max_tokens <= 8` (bounded per-tick GPU cost).
+     - `prompt` length <= 64 UTF-8 bytes (bounded prefill cost).
+     - `idle_threshold_seconds >= 5` (prevents "prewarm every second").
+   - A malicious yaml with all knobs at their extremes still
+     produces bounded resource consumption per unit time.
+
+4. **KV-cache / SPEC-024 poisoning**
+   - The prewarm inference MUST NOT write to the SPEC-024
+     conversation-cache in a way that a subsequent buyer request
+     with a colliding hash would see. If the prewarm hits the same
+     cache key as a real buyer's future request, it could bias
+     billing or leak into non-intended conversation contexts.
+   - Prewarm bypasses cache-write OR uses a well-known reserved
+     key namespace.
+
+5. **Battery-drain amplification**
+   - `run_on_battery: false` (default) is enforced BEFORE the
+     inference dispatch, not after. An attacker with yaml-write
+     access flipping `run_on_battery: true` and setting
+     `tick_seconds: 1` + `max_tokens: 8` is bounded by the load-time
+     validation.
+   - Even at `run_on_battery: true`, thermal gating (R1 point 4)
+     provides a floor — prewarm stops on `.serious`.
+
+6. **IOKit resource handling**
+   - `IOPSCopyPowerSourcesInfo` return value is `CFRelease`d before
+     returning from the check.
+   - `IOPSCopyPowerSourcesList` return value is `CFRelease`d.
+   - Individual `CFDictionaryRef` items obtained via
+     `IOPSGetPowerSourceDescription` are NOT `CFRelease`d (they're
+     borrowed references per Apple docs). Verify the code does not
+     over-release.
+   - No unbounded allocation / retention cycle.
+
+7. **Signal / SIGINT hygiene**
+   - Shutdown handler cancels the prewarmer BEFORE draining the
+     runtime, so no prewarm inference outlasts a graceful shutdown
+     window and holds MLX resources.
+   - Force-kill (SIGKILL) is out of scope.
+
+8. **Log injection**
+   - `prompt` field (operator-configurable) is NOT logged verbatim
+     in structured events. If the operator sets `prompt: "\"attack\"
+     newline injection"` the log line must remain well-formed JSON.
+   - `thermal_state` and `on_battery` are enum values, no injection
+     risk.
+
+9. **Config knob as attack surface**
+   - Validation prevents `tick_seconds: 0.001`, `max_tokens:
+     100000`, `prompt: "<128k characters>"`.
+   - Yaml unmarshal defaults for missing fields do NOT produce a
+     less-safe state than the documented defaults.
+
+10. **No secret exfiltration**
+    - Prewarm event logs do NOT include buyer keys, provider tokens,
+      keychain secrets, or any material from
+      `~/.config/macprovider/keys/`.
+    - Prewarm output text is NOT logged at all (only
+      `tokens_generated` count).
+
+### Do NOT flag
+
+- Non-security correctness bugs (CODE lane).
+- Naming / placement (ARCHITECT).
+- Findings from unchanged pre-diff code.
+
+### Output format
+
+Report findings ranked C / H / M / L / I. Each finding lists:
+file:line, threat model (who benefits), concrete scenario, proposed
+mitigation.
+
+```
+STATUS: SECURITY lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+## Diff to audit
+
+`git diff` in the worktree.

--- a/specs/BUILD_PROVIDER_IDLE_PREWARM_IMPL_PROMPT.md
+++ b/specs/BUILD_PROVIDER_IDLE_PREWARM_IMPL_PROMPT.md
@@ -1,0 +1,450 @@
+# BUILD_PROVIDER_IDLE_PREWARM_IMPL — Provider Swift idle prewarm (MLX Metal keep-warm)
+
+## Motivation (measured, 2026-07-04)
+
+A 4-way cold-start bisection against `mac` (M5 32GB, v1.8.0) produced
+the following breakdown of buyer-observed TTFT after ≥ 90 s of provider
+idle:
+
+| Path | Cold TTFT | Warm TTFT | Idle delta |
+|---|---:|---:|---:|
+| Buyer → api.streamvc.live | 5.6-6.6 s | 1.4 s | ~4-5 s |
+| M5 → 127.0.0.1:18080 (direct) | 0.61 s wall | 0.17 s wall | ~440 ms |
+| Gateway `wall_ms` on cold request | 5590 ms | ~1200 ms | ~4390 ms |
+
+The bulk (≥ 4 s) of the cold-start penalty occurs between coordinator
+`routing_decision` (dispatched immediately, ~1 s after buyer send) and
+first content token. Provider WSS keepalive is at 5 s cadence and is
+working — NAT idle isn't the cause. macOS `event=thermal_state_changed
+from=fair to=nominal` fired during the cold window, indicating GPU
+power-managed idle state on the M5. When the same prompt is warm the
+buyer sees ~1.4 s TTFT and the provider path is ~168 ms.
+
+Root cause: MLX Metal command queue + kernel scheduler degrade during
+provider idle. First inference has to reload kernels and rebuild the
+command pipeline. Model weights stay resident so a "true" cold-load
+isn't happening — only the Metal runtime + KV state.
+
+Additional 3-run reliability sweep observed one 6.6 s TTFT spike among
+30 successful `gap=5s` requests (99th percentile), confirming the same
+idle-state degradation reappears whenever the provider is briefly idle
+between buyer requests.
+
+## Goal (this PR)
+
+Add a provider-side idle prewarm actor that keeps the MLX Metal state
+hot during operator-configurable idle windows. Every N seconds (default
+tick: 5 s) the prewarmer asks: "has the provider been idle for at
+least K seconds (default 30 s) AND is it in a state where prewarm is
+safe?" If yes, it fires a synthetic minimal internal inference
+(default: 1 token, prompt "warm") through a new ModelRuntime path that
+bypasses request tracking, receipt emission, and coordinator-visible
+slot accounting.
+
+The prewarm inference must be transparent to the coordinator and the
+buyer. It never counts toward `requestsTotal`, never emits receipts,
+never occupies a slot the coordinator sees, and never appears in
+throughput / latency metrics.
+
+## Non-goals
+
+- No change to coordinator (`phase4-coordinator/**`) or gateway
+  (`phase5-gateway/**`) code.
+- No new buyer-visible endpoints.
+- No change to the WSS keepalive cadence or protocol.
+- No change to SPEC-023 autotune, SPEC-024 conversation-cache, or
+  SPEC-016 payout code paths.
+- No change to model weights, quantization, or MLX runtime version.
+- No visible signal to the coordinator that prewarm happened (no new
+  heartbeat field, no new WSS message type).
+
+## Scope of change
+
+Files that MUST change:
+- `phase3-binary/Sources/macprovider-cli/IdlePrewarmer.swift` (new).
+- `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift` — add
+  the internal prewarm entry point.
+- `phase3-binary/Sources/macprovider-cli/ProviderStatus.swift` — add
+  the `lastActivityAt` field / update path.
+- `phase3-binary/Sources/macprovider-cli/HTTPServer.swift` — bump
+  `lastActivityAt` on each real request start, and (optionally) hand
+  the prewarmer a cancel signal.
+- `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift` —
+  instantiate + start / stop the prewarmer.
+- `phase3-binary/Sources/macprovider-cli/ConfigApplier.swift` +
+  `MacProviderCLI.swift` — CLI flag(s) / config-yaml key(s) for the
+  new knobs.
+- `phase3-binary/Tests/macprovider-cliTests/IdlePrewarmerTests.swift`
+  (new).
+
+Files that MAY change (only if the implementer determines it's the
+cleanest home):
+- `phase3-binary/Sources/macprovider-cli/RuntimeStateMachine.swift`
+  if activity-tracking naturally lives there instead of
+  `ProviderStatus.swift`.
+- `phase3-binary/Sources/macprovider-cli/ThermalGate.swift` if a
+  thermal-state accessor is added there instead of duplicating.
+
+Files that MUST NOT change:
+- Anything under `phase4-coordinator/**` or `phase5-gateway/**`.
+- `phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift`,
+  `ReceiptAudit.swift`, `CachedReceiptKeyStore.swift`,
+  `InMemoryReceiptKeyStore.swift` — the prewarm path must not emit
+  receipts, so it never touches these files.
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+  request-dispatch code — no coordinator interaction from the
+  prewarm path.
+- `phase3-binary/Sources/macprovider-cli/AutotuneDB.swift`,
+  `AutotuneRecommend.swift` — prewarm results MUST NOT contribute
+  to autotune measurements.
+
+## Behavioural requirements
+
+**R1 — Idle-detection contract.** The prewarmer fires iff *all* of
+the following hold at the check tick:
+
+1. Configuration `idle_prewarm.enabled == true`.
+2. `providerStatus.requestsInFlight == 0` (no active real request).
+3. `now - providerStatus.lastActivityAt >= idle_prewarm.idle_threshold_seconds`.
+4. `thermalGate.currentThermalState()` is not `.serious` and not
+   `.critical` — i.e. `.nominal` or `.fair` only.
+5. Power source is not battery-only OR
+   `idle_prewarm.run_on_battery == true`. Battery / plugged-in is
+   detected via `IOPSCopyPowerSourcesInfo` + `IOPSGetPowerSourceState`
+   (macOS `IOKit.pwr_mgt`). Absence of any power source (rare on Mac
+   Studio / Mac mini) is treated as "not on battery" for the check.
+6. Model is loaded (`await modelRuntime.isLoaded == true`) and a
+   `loadedModelHash` is present.
+
+If any check fails at the tick, log the reason at `event=idle_prewarm_skipped`
+with the tightest matching reason (`disabled`, `busy`, `not_idle_yet`,
+`thermal_pressure`, `on_battery`, `model_not_loaded`) and skip to next
+tick.
+
+**R2 — Prewarm inference contract.** The prewarm inference:
+
+- Uses a NEW `ModelRuntime` entry point named `runInternalWarmup(
+  maxTokens: Int, prompt: String, shouldCancel: @escaping @Sendable ()
+  -> Bool) async throws -> InternalWarmupResult`.
+- MUST NOT increment `providerStatus.requestsTotal`.
+- MUST NOT increment `providerStatus.requestsInFlight` (so
+  `slots_free` reported to the coordinator stays at
+  `slots_total - real_in_flight`, not `slots_total - real_in_flight - 1`).
+- MUST NOT emit any receipt event, receipt-omitted event, or
+  ReceiptAudit line.
+- MUST NOT contribute to `providerStatus.avgLatencyMSSinceLast`,
+  `throughputTPSSinceLast`, or `requestsServedSinceLast`.
+- MUST NOT be visible in the coordinator's WSS heartbeat / provider
+  activity payloads.
+- SHALL update a new `providerStatus.lastPrewarmAt` timestamp used
+  only for observability / test assertions.
+- SHOULD reuse the same MLX inference path as `complete()` for
+  Metal-warmup effect (going through a totally different code path
+  would defeat the purpose).
+- SHALL run with `maxTokens` bounded to `[1, 8]`. Values outside are
+  clamped or produce a load-time config validation error.
+- SHALL run with a prompt bounded to `[1, 64]` characters after
+  UTF-8 encoding.
+
+**R3 — Cancellation on real-request arrival.** If a real chat request
+arrives (HTTP `/v1/chat/completions`) while a prewarm is in flight,
+the prewarm MUST be cancelled promptly (measured: within one MLX
+token boundary or 200 ms, whichever is shorter). Cancellation MUST
+NOT partially charge the real request, corrupt the KV cache, or
+leave the runtime in a bad state.
+
+Preferred mechanism: the prewarmer holds the currently-running
+prewarm `Task` and exposes a `cancelInflightPrewarm()` method the
+HTTP handler calls before it invokes `modelRuntime.complete()` /
+`.stream()`.
+
+**R4 — Tick discipline.** The prewarmer runs a background `Task` on
+its own actor with a `Task.sleep(nanoseconds:)` loop cadenced at
+`idle_prewarm.tick_seconds` (default 5, range [1, 60]). At startup
+the first tick fires after one full tick interval (not immediately)
+so warmup benefits from natural startup + first-real-request patterns.
+
+If a prewarm is already in flight when a tick fires, the tick is
+skipped (no queuing).
+
+**R5 — Startup / shutdown ordering.**
+
+- Prewarmer is instantiated AFTER `modelRuntime`, `providerStatus`,
+  and `thermalGate` are all constructed and after
+  `modelRuntime.setProviderStatus(providerStatus)` has run.
+- Prewarmer is started (its background loop begins) AFTER the HTTP
+  server is listening and BEFORE the coordinator client dials in.
+  If that ordering can't be honoured cleanly, start prewarmer after
+  the coordinator dial completes so a start-time prewarm doesn't
+  race with the first real request.
+- Prewarmer must be stoppable via `stop()` that cancels the
+  background loop AND any in-flight prewarm.
+- On SIGINT / SIGTERM (graceful serve shutdown), the prewarmer's
+  in-flight prewarm inference is cancelled BEFORE the runtime begins
+  drain; the prewarmer's background loop is stopped BEFORE the
+  server closes its listener.
+
+**R6 — Observability.** Emit exactly one structured JSON line per
+event, printed to stdout in the existing `log_format: json` style
+used by the rest of the serve loop. Event names (values of `"event":`):
+
+- `idle_prewarm_fired` — at successful start of a prewarm inference.
+  Fields: `idle_seconds`, `max_tokens`, `thermal_state`, `on_battery`.
+- `idle_prewarm_completed` — at successful completion. Fields:
+  `elapsed_ms`, `tokens_generated`, `first_token_ms`.
+- `idle_prewarm_skipped` — at tick when preconditions fail. Field:
+  `reason` from R1's enumerated set.
+- `idle_prewarm_cancelled_by_real_request` — when R3 cancellation
+  fires. Field: `elapsed_ms` (time from prewarm start to cancel).
+- `idle_prewarm_failed` — on error from `runInternalWarmup`. Fields:
+  `error_class`, `elapsed_ms`.
+
+Do NOT emit `idle_prewarm_skipped` more than once per tick (i.e.
+find the tightest reason and log only that one).
+
+**R7 — Config surface.**
+
+New CLI flag block (long-form only, no short flags):
+- `--idle-prewarm / --no-idle-prewarm` (default: enabled)
+- `--idle-prewarm-idle-threshold-s` (default 30, range [5, 3600])
+- `--idle-prewarm-tick-s` (default 5, range [1, 60])
+- `--idle-prewarm-max-tokens` (default 1, range [1, 8])
+- `--idle-prewarm-prompt` (default "warm", length [1, 64] UTF-8 bytes)
+- `--idle-prewarm-on-battery` (default false — do NOT run on battery)
+
+Config-yaml keys under a new top-level `idle_prewarm:` block:
+- `enabled`, `idle_threshold_seconds`, `tick_seconds`, `max_tokens`,
+  `prompt`, `run_on_battery`.
+
+Precedence follows the existing pattern used for other flags: CLI
+flag > yaml > default.
+
+Config validation errors (out-of-range) MUST fail load-time (not at
+first tick).
+
+**R8 — Do-not-degrade guarantees.**
+
+- The prewarm's presence MUST NOT change the SPEC-024 conversation-
+  cache state that a subsequent buyer request would see. If the
+  prewarm inference is a cache-miss it MUST NOT populate cache in a
+  way that persists to buyer traffic — i.e. either bypass cache-
+  write for internal warmup, OR use a prompt that is guaranteed to
+  produce the same key any prior buyer traffic would produce (unsafe;
+  bypass is preferred).
+- The prewarm MUST NOT affect `providerStatus.slotsFree` reported to
+  the coordinator at any point (before, during, after).
+- The prewarm MUST NOT trigger `event=thermal_state_changed` more
+  frequently than pre-diff behaviour (it must respect thermal
+  throttling and step out during `.serious`+).
+
+**R9 — Battery awareness.** Battery detection uses IOKit
+`IOPSCopyPowerSourcesInfo` + `IOPSGetPowerSourceState` + a check for
+`kIOPSBatteryPowerValue`. Wrap in a minimal helper `PowerSourceInfo`
+struct or extension for testability (inject a
+`PowerSourceReporting` protocol). Absence of any power source object
+returns `.unknown`; treat `.unknown` as "not on battery".
+
+## Concrete API additions
+
+```swift
+// ModelRuntime.swift
+struct InternalWarmupResult: Sendable {
+    let tokensGenerated: Int
+    let firstTokenElapsedMS: Double
+    let totalElapsedMS: Double
+}
+
+extension ModelRuntime {
+    /// Runs a synthetic warmup inference on the currently-loaded model.
+    /// Does not increment ProviderStatus.requestsTotal or
+    /// requestsInFlight; does not emit receipts; does not update
+    /// throughput metrics. Cancellable via shouldCancel.
+    func runInternalWarmup(
+        maxTokens: Int,
+        prompt: String,
+        shouldCancel: @escaping @Sendable () -> Bool
+    ) async throws -> InternalWarmupResult
+}
+```
+
+```swift
+// ProviderStatus.swift additions
+extension ProviderStatus {
+    /// Marks the start of a real (non-prewarm) request. HTTP handler
+    /// calls this before invoking modelRuntime.complete/.stream.
+    func noteRealRequestStart()
+
+    /// Marks the completion of a real request.
+    func noteRealRequestEnd()
+
+    /// Reports the number of seconds since the last real request
+    /// started OR ended (whichever is later). Used by IdlePrewarmer.
+    func secondsSinceLastRealActivity() -> Double
+
+    /// Marks a completed prewarm run for observability.
+    func noteInternalPrewarm(at: Date, elapsedMS: Double)
+}
+```
+
+```swift
+// IdlePrewarmer.swift (new)
+actor IdlePrewarmer {
+    init(
+        modelRuntime: ModelRuntime,
+        providerStatus: ProviderStatus,
+        thermalGate: ThermalGate,
+        powerSource: PowerSourceReporting,
+        config: IdlePrewarmConfig,
+        clock: any Clock = ContinuousClock()
+    )
+    func start()
+    func stop() async
+    func cancelInflightPrewarm() async
+}
+
+struct IdlePrewarmConfig: Sendable, Equatable {
+    let enabled: Bool
+    let idleThresholdSeconds: Double
+    let tickSeconds: Double
+    let maxTokens: Int
+    let prompt: String
+    let runOnBattery: Bool
+}
+```
+
+## Acceptance criteria
+
+**AC1** — `swift build --product macprovider-cli` clean.
+
+**AC2** — `swift test` full suite passes: existing tests unchanged
+(including the 822+ tests baseline), plus all new
+`IdlePrewarmerTests.swift` cases.
+
+**AC3** — New tests in
+`phase3-binary/Tests/macprovider-cliTests/IdlePrewarmerTests.swift`
+cover, using a fake clock + injected `ThermalStateProviding` +
+`PowerSourceReporting` + a spy `ModelRuntime`:
+
+1. Prewarm fires after `idleThresholdSeconds` of no activity.
+2. Prewarm does NOT fire while `requestsInFlight > 0`.
+3. Prewarm does NOT fire when `now - lastActivity < idleThreshold`.
+4. Prewarm does NOT fire on `.serious` thermal state.
+5. Prewarm does NOT fire on `.critical` thermal state.
+6. Prewarm does NOT fire on battery when `runOnBattery == false`.
+7. Prewarm DOES fire on battery when `runOnBattery == true`.
+8. `enabled: false` produces zero prewarm calls across 10 ticks.
+9. In-flight prewarm is cancelled within one tick when a real
+   request arrives.
+10. `runInternalWarmup` does not touch `requestsTotal`,
+    `requestsInFlight`, or emit ReceiptAudit lines.
+11. Structured JSON events with correct event names are emitted for
+    each of R6's five event categories (use stdout capture).
+12. Config validation: out-of-range values for each of the 6 knobs
+    each fail at load time with a message that names the offending
+    field.
+13. Tick skipping when a prewarm is already in flight (no queuing).
+14. Stop cancels the background loop AND any in-flight prewarm.
+
+**AC4** — `providerStatus.slotsFree` observed via a spy coordinator
+heartbeat is unchanged before, during, and after a prewarm cycle.
+Slot accounting is invariant to prewarm activity.
+
+**AC5** — Battery detection is unit-tested with `PowerSourceReporting`
+protocol injection (no real IOKit dependency in tests).
+
+**AC6** — On SIGINT during an in-flight prewarm, the shutdown path
+completes within 5 seconds of signal receipt (test with a mocked
+signal handler or a bounded-wait assertion).
+
+## Observability contract
+
+Emit only structured JSON lines to stdout, matching the existing
+`log_format: json` schema. Do NOT add metrics counters, Prometheus,
+or new HTTP endpoints in this PR.
+
+## Backwards compatibility
+
+- Buyer-observable behaviour is unchanged. No new headers, no new
+  status codes, no changed timing on real requests.
+- Coordinator-observable behaviour is unchanged. `slots_free`
+  heartbeats are identical whether the prewarm ran or not.
+- Config: an operator that does not touch the new `idle_prewarm:`
+  yaml block gets the enabled defaults automatically. To fully
+  disable, they set `idle_prewarm.enabled: false` OR pass
+  `--no-idle-prewarm`.
+- Battery-only Macs: default OFF (`run_on_battery: false`) preserves
+  battery life; operator opt-in required to change.
+
+## Prohibited implementation choices
+
+- Do NOT run prewarm through the HTTP surface (loopback to
+  `127.0.0.1:18080` /v1/chat/completions). It MUST bypass the HTTP
+  server, coordinator dispatch, receipt path, and slot accounting.
+- Do NOT create a second MLX ModelRuntime instance; the prewarm
+  MUST share the loaded model with real inference.
+- Do NOT change the WSS heartbeat cadence or fields.
+- Do NOT introduce a new persistent state file, SQLite table, or
+  IPC channel.
+- Do NOT add prewarm-derived rows to `AutotuneDB.swift`'s samples.
+- Do NOT change the return type or signature of `ModelRuntime.
+  complete()` / `.stream()` (add a NEW method for internal warmup).
+- Do NOT use `Task.sleep(seconds:)` — use `Task.sleep(nanoseconds:)`
+  or the injected `Clock` for testable tick cadence.
+- Do NOT block the actor's mailbox while an inference is running —
+  the prewarm must run in a child `Task` so `cancelInflightPrewarm`
+  can preempt it.
+
+## Commit style
+
+```
+feat(provider): idle-prewarm timer keeps MLX Metal warm during idle
+
+Motivation: cold-start bisection 2026-07-04 measured 4-5s buyer TTFT
+after 90s provider idle vs 1.4s warm; provider-side (bypassing WAN
+and coord) still showed 442ms cold-vs-warm delta. Root cause is MLX
+Metal command queue + GPU power-managed idle. Model weights stay
+resident; only the runtime state degrades.
+
+Change: new IdlePrewarmer actor fires a synthetic 1-token internal
+inference every 30s of provider idle, gated on thermal (must be
+<= .fair) and power (skips battery by default). Runs through a new
+ModelRuntime.runInternalWarmup that bypasses request tracking,
+receipt emission, and slot accounting.
+
+Config: new idle_prewarm block; defaults on for AC power, off for
+battery, 30s idle threshold, 5s tick, 1 token, prompt="warm".
+
+Tested: 14 IdlePrewarmerTests cases; existing swift test suite
+unchanged.
+```
+
+## Audit boundaries
+
+Three separate audit lanes will be fired against this diff after
+implementation:
+
+- **CODE** — correctness of the actor + Task lifecycle,
+  cancellation propagation, thermal / power-source protocol wiring,
+  config validation, tick-skipping logic, no accidental
+  ProviderStatus mutation during warmup, first-tick timing.
+- **SECURITY** — no coordinator-visible signal that prewarm
+  happened, no receipt-path leakage, no battery-drain amplification
+  vector, no config knob that lets an attacker force expensive work
+  (prompt-length cap, max-tokens cap, tick-cadence lower bound), no
+  IOKit resource leak (unclosed CFRelease targets).
+- **ARCHITECT** — placement in the actor topology, consistency with
+  existing `ThermalGate` and `ProviderStatus` patterns, config-key
+  naming consistency, event-name greppability for future ops
+  dashboards, extensibility (would a future "prewarm with real prompt
+  from cache" fit naturally, or is this a dead-end shape?).
+
+## References
+
+- Cold-start bisection data: earlier session, buyer path 5.6-6.6 s
+  cold vs 1.4 s warm; local direct 610 ms cold vs 168 ms warm.
+- ThermalGate at `phase3-binary/Sources/macprovider-cli/ThermalGate.swift`.
+- ProviderStatus at
+  `phase3-binary/Sources/macprovider-cli/ProviderStatus.swift`.
+- Existing HTTP entry to inference at `HTTPServer.swift:200`
+  (`handleChatCompletions`).
+- Existing runtime instantiation at `MacProviderCLI.swift:319-356`.

--- a/specs/FIX_PROVIDER_IDLE_PREWARM_R1_PROMPT.md
+++ b/specs/FIX_PROVIDER_IDLE_PREWARM_R1_PROMPT.md
@@ -1,0 +1,190 @@
+# FIX_PROVIDER_IDLE_PREWARM_R1 — apply all R1 audit findings
+
+Round 1 three-lane audit returned the following findings that must be
+fixed before ship:
+
+## CODE HIGH #1 — stop() shutdown race
+
+**File:** `phase3-binary/Sources/macprovider-cli/IdlePrewarmer.swift`
+around line 176.
+
+**Defect:** `stop()` cancels `loopTask` but does not `await` its
+completion. `runTick()` has multiple suspension points (calls to
+`providerStatus.snapshot()`, `modelRuntime.isLoaded`, etc.) with no
+cancellation check before `fireWarmup()`. If shutdown lands while a
+tick is between the snapshot/isLoaded awaits, `stop()` can return
+with `inflight == nil`, then the cancelled loop resumes past the
+suspension point and starts a NEW warmup after shutdown supposedly
+completed.
+
+**Fix:**
+
+1. Add a `stopped: Bool` (or `state: enum { .idle, .running, .stopping,
+   .stopped }`) flag on the actor.
+2. `stop()` sets `stopped = true`, cancels `loopTask`, cancels any
+   inflight prewarm, then `await`s `loopTask.value` (or `?.value`)
+   before returning.
+3. `runTick()` checks `stopped` (or `Task.isCancelled` on the ambient
+   task) after EACH `await` and immediately before `fireWarmup()`.
+4. When `stopped` is observed, exit the tick cleanly without firing.
+5. Ensure `runOneTickForTest()` respects the same `stopped` gate so
+   tests behave deterministically.
+
+## CODE HIGH #2 — cancel-vs-begin ordering race
+
+**File:** `phase3-binary/Sources/macprovider-cli/HTTPServer.swift`
+around line 276 (real-request handling in `handleChatCompletions`).
+
+**Defect:** the HTTP handler calls `idlePrewarmer.cancelInflightPrewarm()`
+BEFORE `providerStatus.beginRequest()` (or equivalent
+`noteRealRequestStart()`). A tick that has already observed
+`requestsInFlight == 0` and `idle_since >= threshold` can be
+suspended at an await, get past the "should I fire?" checks, and
+then fire `fireWarmup()` AFTER the HTTP handler's `cancelInflightPrewarm()`
+returned (because there was no inflight yet), while a real inference
+starts on the same MLX runtime.
+
+**Fix:**
+
+1. In `handleChatCompletions` (and the streaming variant if separate),
+   call `providerStatus.beginRequest()` / `noteRealRequestStart()`
+   BEFORE `cancelInflightPrewarm()`. Order:
+   a. `beginRequest()` (bumps `requestsInFlight`, updates
+      `lastActivityAt`).
+   b. `cancelInflightPrewarm()` (cancels anything already running).
+   c. Actual `modelRuntime.complete()` / `.stream()` dispatch.
+2. In `IdlePrewarmer.runTick()`, add a FINAL actor-owned busy /
+   activity recheck immediately before `fireWarmup()`:
+   ```swift
+   // Re-check inside the actor after all preceding awaits so a
+   // real request that raced in between the initial snapshot and
+   // the fire decision can't be preempted by the prewarm.
+   let snap = await providerStatus.snapshot()
+   guard snap.requestsInFlight == 0 else { emitSkipped(.busy); return }
+   let idle = await providerStatus.secondsSinceLastRealActivity()
+   guard idle >= config.idleThresholdSeconds else {
+       emitSkipped(.notIdleYet); return
+   }
+   ```
+3. This "double check" pattern is standard for actors with async
+   observation windows and is not redundant — the first check
+   short-circuits cheap ineligible ticks, the second closes the race.
+
+## SECURITY MEDIUM — prewarm amplification (every-tick vs every-interval)
+
+**File:** `phase3-binary/Sources/macprovider-cli/IdlePrewarmer.swift`
+around line 207 (the tick-eligibility check).
+
+**Defect:** `runTick()` checks
+`providerStatus.secondsSinceLastRealActivity()` but prewarms do NOT
+advance `lastActivityAt` (that's a REAL-request tracker). Once idle
+threshold is crossed, every subsequent tick fires another prewarm
+until real traffic arrives. With `tick_seconds: 1`,
+`idle_threshold_seconds: 5`, `max_tokens: 8`, `run_on_battery: true`
+(all valid per current validation), you get 8 tokens of GPU work
+every second indefinitely.
+
+**Fix:**
+
+1. Extend `ProviderStatus.secondsSinceLastRealActivity()` to be
+   `secondsSinceLastActivityOrPrewarm()` that returns
+   `min(now - lastActivityAt, now - lastPrewarmAt)`. Rename call sites
+   if the semantic differs from what other callers want; otherwise
+   keep the original method and add a NEW
+   `secondsSinceLastActivityOrPrewarm()` for the prewarmer only.
+2. In `runTick()`, gate on `secondsSinceLastActivityOrPrewarm() >=
+   config.idleThresholdSeconds` instead of the activity-only version.
+3. `noteInternalPrewarm(at:, elapsedMS:)` already updates
+   `lastPrewarmAt`; make sure it's called on prewarm START (not
+   completion) so cancellations still count against the cooldown.
+4. Add a new test case: `testPrewarmDoesNotFireAgainWithinIdleThreshold`
+   that fires one prewarm, advances clock < idleThreshold, ticks, and
+   asserts zero additional fires. Add another case that advances
+   clock ≥ idleThreshold and asserts one additional fire.
+
+## ARCHITECT MEDIUM — `--idle-prewarm-on-battery` non-invertible
+
+**File:** `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+around line 98 (`@Flag(name: .customLong("idle-prewarm-on-battery"))`).
+
+**Defect:** the flag is a bare positive `@Flag` that only turns
+`run_on_battery` ON. If yaml has `idle_prewarm.run_on_battery: true`
+and the operator wants to disable for a single serve invocation via
+CLI, they cannot — the flag has no inverse. This breaks the stated
+CLI > yaml > default precedence for this specific knob.
+
+**Fix:**
+
+1. Change the flag definition to use ArgumentParser's inversion:
+   ```swift
+   @Flag(
+       name: .customLong("idle-prewarm-on-battery"),
+       inversion: .prefixedNo,
+       help: "Allow idle prewarm while running on battery. Default off."
+   )
+   var idlePrewarmRunOnBattery: Bool?
+   ```
+   (Or the equivalent `@Option(name: ...)` with `Bool?` if `@Flag`
+   inversion doesn't yield an optional; the key requirement is that
+   both `--idle-prewarm-on-battery` and `--no-idle-prewarm-on-battery`
+   are valid CLI flags, and the ABSENCE of both preserves the yaml
+   value.)
+2. Update the resolution site (around line 322 in the same file) to
+   pass the optional through instead of mapping `true ? true : nil`.
+3. Add a test case exercising `--no-idle-prewarm-on-battery` overriding
+   a yaml `run_on_battery: true` back to false.
+
+## CODE MEDIUM — test coverage gaps
+
+**File:** `phase3-binary/Tests/macprovider-cliTests/IdlePrewarmerTests.swift`
+
+**Defect:** AC3 in the BUILD prompt lists 14 distinct test cases;
+current file has 13, combining `.serious` and `.critical` thermal
+into one test. Also uses real `Task.sleep` (lines 9, 183, 371) for
+tick timing, and AC4 uses `ProviderStatus.snapshot()` instead of a
+coordinator-heartbeat spy. AC6 (SIGINT during in-flight prewarm) is
+absent.
+
+**Fix (minimum viable — do NOT over-engineer):**
+
+1. Split `.serious` and `.critical` thermal skip into two separate
+   `testPrewarmSkipsOnSerious` and `testPrewarmSkipsOnCritical` cases.
+2. Add `testPrewarmDoesNotFireAgainWithinIdleThreshold` (from
+   SECURITY MEDIUM fix above).
+3. Add `testShutdownDuringInflightPrewarmCompletesWithinBoundedTime`
+   that simulates SIGINT during an inflight prewarm and asserts the
+   full `IdlePrewarmer.stop()` returns within 5 seconds (per AC6).
+4. **Do NOT** rewrite the whole test file to use an injected Clock
+   protocol — that's a much larger change and the LOW-tier concern
+   (real sleeps around 40 ms per test) is acceptable per repo
+   convention for LOW-severity test hygiene. Focus on new coverage,
+   not migrating existing.
+
+## What NOT to fix in this round
+
+- All LOW / INFO findings from R1 ship as-is with PR-body
+  documentation:
+  - ARCHITECT L1 (prewarmer start before HTTP listener bound)
+  - ARCHITECT L2 (`currentState()` vs `currentThermalState()` naming)
+  - ARCHITECT L3 (`powerSource` param not defaulted, `clock` unused)
+  - ARCHITECT I1 (comment grouping on activity-tracking region)
+  - SECURITY L1 (operator prompt printed raw at startup)
+
+## Deliverables
+
+- Updated `IdlePrewarmer.swift`, `HTTPServer.swift`,
+  `ProviderStatus.swift`, `MacProviderCLI.swift`, and
+  `IdlePrewarmerTests.swift`.
+- No changes to files outside the R1 diff scope.
+- All existing tests must still pass.
+- New tests must pass.
+- No new SwiftPM dependencies.
+
+## After you finish
+
+1. Run `cd phase3-binary && swift build --product macprovider-cli`.
+2. Run `cd phase3-binary && swift test --filter IdlePrewarmerTests`.
+3. Run `cd phase3-binary && swift test` (full suite must remain
+   green).
+4. Print a short summary of the applied changes ordered by finding
+   (H1, H2, S-M, A-M, C-M).


### PR DESCRIPTION
## Summary

New `IdlePrewarmer` actor that fires a synthetic 1-token internal inference every 30 s of provider idle to keep MLX Metal state warm. Targets the 4-5 s cold-TTFT spike that appears whenever the provider has been idle for ≥ 90 s. Runs through a new `ModelRuntime.runInternalWarmup(...)` entry point that bypasses request tracking, receipt emission, and slot accounting so the coordinator's view of provider capacity is bit-identical to today.

## Motivation — measured data

Cold-start bisection against `mac` (M5 32GB, v1.8.0) on 2026-07-04:

| Path | Cold total | Warm total | Cold penalty |
|---|---:|---:|---:|
| Buyer → api.streamvc.live | 6.06 s | ~500 ms | ~5.5 s |
| M5 → 127.0.0.1:18080 (direct) | 0.61 s | 0.17 s | ~440 ms |
| Gateway `wall_ms` on cold buyer request | 5590 ms | ~1200 ms | ~4390 ms |

Coord `routing_decision` fires ~1 s after buyer send; the remaining ~4.5 s is provider-side MLX Metal cold-start + KV state re-initialisation. Provider log around the cold window shows `event=thermal_state_changed from=fair to=nominal`, consistent with GPU power-managed idle. WSS keepalive at 5 s cadence is working — NAT idle isn't the cause.

## Change

- New file `phase3-binary/Sources/macprovider-cli/IdlePrewarmer.swift` (353 lines) — actor with background tick loop.
- New file `phase3-binary/Tests/macprovider-cliTests/IdlePrewarmerTests.swift` (438 lines, 18 test cases).
- `ModelRuntime.swift` — new `runInternalWarmup(maxTokens:prompt:shouldCancel:)` entry point that:
  - Does NOT increment `providerStatus.requestsTotal`/`requestsInFlight`.
  - Does NOT emit any `ReceiptAudit` line.
  - Does NOT contribute to `throughputTPSSinceLast` / `avgLatencyMSSinceLast`.
  - Reuses the same MLX inference path as `complete()` for the Metal-warmup effect.
- `ProviderStatus.swift` — new `noteRealRequestStart/End`, `lastPrewarmAt`, `secondsSinceLastActivityOrPrewarm()`, `noteInternalPrewarm(at:)`.
- `HTTPServer.swift` — real request handler now calls `providerStatus.beginRequest()` BEFORE `idlePrewarmer.cancelInflightPrewarm()`, then dispatches. Order closes an R1-audit-found race.
- `MacProviderCLI.swift` — 6 new CLI flags + wire-up. `--idle-prewarm-on-battery` uses ArgumentParser `.prefixedNo` inversion so `--no-idle-prewarm-on-battery` can override yaml back to false.
- `MacProviderCore/Config.swift` — new `idle_prewarm:` yaml block, config validation for each of the 6 knobs with named-field error messages.

## Gating logic

Prewarm fires only when **all** of the following are true at the tick:

- `config.enabled == true`
- `providerStatus.requestsInFlight == 0`
- `seconds since max(lastActivity, lastPrewarm) >= idleThresholdSeconds` (closes the SECURITY R1 amplification vector)
- `thermalGate.currentThermalState()` is `.nominal` or `.fair`
- Power source is not battery (unless `run_on_battery == true`)
- Model is loaded

Immediately before `fireWarmup()` the tick performs an actor-owned re-check of `requestsInFlight` and idle time — closes the CODE R1 H2 race where a real request could arrive between the initial snapshot and the fire decision.

## Coordinator invisibility

`providerStatus.slotsFree` reported to the coord is invariant to prewarm activity — asserted in `testSlotsFreeInvariantBeforeDuringAfterPrewarm`. No new WSS message type. No receipt emission. No new heartbeat fields. Autotune's `Stage1Iterator` / `Stage2HillClimb` / `AutotuneDB` are not touched by the prewarm path.

## Audit convergence — three codex lanes

- **CODE R1**: 0 C / **2 H** / **1 M** / 0 L / 0 I
  - H1 `stop()` shutdown race (loop task not awaited, no cancellation check between `runTick()` awaits) → fixed via `stopped: Bool` flag + `await loopTask?.value` in `stop()` + cancellation checks at every await boundary in `runTick()`.
  - H2 `cancelInflightPrewarm()` called before `providerStatus.beginRequest()` in HTTP handler → fixed by swapping order + adding actor-owned re-check inside `runTick()` immediately before `fireWarmup()`.
  - M test coverage gap (13 cases vs 14 required, missing SIGINT case) → fixed; suite now 18 tests.
- **SECURITY R1**: 0 C / 0 H / **1 M** / 1 L / 0 I
  - M prewarm amplification (`runTick()` gated only on `lastActivityAt`, so after crossing idle threshold, every tick fired another prewarm forever) → fixed via `secondsSinceLastActivityOrPrewarm()` gate + `noteInternalPrewarm` called on prewarm START (so a cancelled prewarm still counts toward cooldown, preventing rapid-resume amplification).
- **ARCHITECT R1**: 0 C / 0 H / **1 M** / 3 L / 1 I
  - M `--idle-prewarm-on-battery` bare positive flag couldn't override yaml `true` back to false → fixed with `inversion: .prefixedNo`.
- **CODE R2 · SECURITY R2 · ARCHITECT R2**: 0 / 0 / 0 / 0 / 0 across all three lanes.

## Deferred R1 LOW / INFO findings (ship as-is)

- **ARCHITECT L1** — prewarmer starts before HTTP listener is bound; the BUILD prompt R5 allows this as the fallback ordering. If startup grows more async in future, revisit and hook prewarm start to a "listener bound" callback.
- **ARCHITECT L2** — `ThermalGate.currentState()` vs `currentThermalState()` naming mismatch with the BUILD prompt's stated name. Naming taste; no functional impact.
- **ARCHITECT L3** — `powerSource` parameter not defaulted on `IdlePrewarmer.init`; `clock` parameter present but unused (kept as a seam for future fake-clock migration).
- **ARCHITECT I1** — activity-tracking methods on `ProviderStatus` not grouped under a shared `// Activity tracking …` comment region.
- **SECURITY L1** — operator-configurable `prompt` string is echoed verbatim at startup in the resolved-config print (structured `idle_prewarm_*` events correctly OMIT the prompt body).
- **CODE R1 LOW** — new tests use real `Task.sleep` (bounded ≤ 200 ms per case) rather than an injected fake clock; a `clock: Clock` seam is present on `IdlePrewarmer.init` for future migration.

None of the deferred LOWs affect correctness, security posture, or coordinator-observable behaviour.

## Test plan

- [x] `cd phase3-binary && swift build --product macprovider-cli` clean
- [x] `swift test --filter IdlePrewarmerTests` — 18 tests, 0 failures
- [x] `swift test` full suite — 840 tests, 7 skipped, 0 failures (up from 835 baseline)
- [x] Existing tests unchanged
- [ ] CI green on this PR (pending)

## Config summary

Yaml block (`idle_prewarm:` at top of provider config):

```yaml
idle_prewarm:
  enabled: true                    # default true; --idle-prewarm / --no-idle-prewarm to override
  idle_threshold_seconds: 30       # range [5, 3600]
  tick_seconds: 5                  # range [1, 60]
  max_tokens: 1                    # range [1, 8]
  prompt: warm                     # length [1, 64] UTF-8 bytes
  run_on_battery: false            # default OFF for battery hygiene
```

CLI overrides: `--idle-prewarm / --no-idle-prewarm`, `--idle-prewarm-idle-threshold-s`, `--idle-prewarm-tick-s`, `--idle-prewarm-max-tokens`, `--idle-prewarm-prompt`, `--idle-prewarm-on-battery / --no-idle-prewarm-on-battery`. CLI > yaml > default.

## Observability

Five structured JSON events, printed to stdout in the existing `log_format: json` style:

- `event=idle_prewarm_fired` — successful start; fields: `idle_seconds`, `max_tokens`, `thermal_state`, `on_battery`.
- `event=idle_prewarm_completed` — successful completion; fields: `elapsed_ms`, `tokens_generated`, `first_token_ms`.
- `event=idle_prewarm_skipped` — tick eligibility failed; field: `reason` (`disabled`|`busy`|`not_idle_yet`|`thermal_pressure`|`on_battery`|`model_not_loaded`).
- `event=idle_prewarm_cancelled_by_real_request` — cancellation on real-request arrival; field: `elapsed_ms`.
- `event=idle_prewarm_failed` — error path; fields: `error_class`, `elapsed_ms`.

Grep-stable event names for future Prometheus / stats.streamvc.live wire-up in a follow-up PR.

## Follow-up work (not in scope)

- Metrics wire-up (Prometheus counter per event class).
- The `powerSource` and `clock` default-injection cleanup (ARCH L3).
- SPEC-023 autotune multi-slot recommendation for M-Max / M-Ultra (A1b).
- Pearl TCP kernel tuning (C1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
