### PR TITLE
chore(pearl): TCP kernel tuning for streaming SSE (BBR + no-idle-reset + 16MB bufs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ test-dist:
 	bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh
 	bash phase4-coordinator/dist/test/check_nginx_stats_test.sh
 	bash phase4-coordinator/dist/test/check_pearl_tls_test.sh
+	bash phase4-coordinator/dist/test/check_pearl_tcp_test.sh
 	SPEC015_NGINX_LIVE_OPTIONAL=$${SPEC015_NGINX_LIVE_OPTIONAL:-1} bash phase4-coordinator/dist/test/check_nginx_receipt_header_live_test.sh
 	bash scripts/test-install-config-token-preserve.sh
 	bash scripts/test-install-launchd-enable.sh

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -28,6 +28,7 @@
 #   STRICT_PROVENANCE default: 0  fail if /healthz lacks `version` field
 #   SKIP_C2_CHECK    default: 0   skip C2 cross-check (development only)
 #   ALLOW_CONFIG_DRIFT default: 0 push local coordinator.yaml over live one
+#   SKIP_TCP_TUNING default: 0    skip Pearl TCP sysctl install/apply step
 #
 # Note: DOMAIN and STATS_DOMAIN are validated up-front (step 0) against
 # DNS-name regex AND against the baked-in vhost-template hostnames. The
@@ -125,6 +126,8 @@ CLI_BINARY="$DIST_DIR/coordinator-cli-linux-amd64"
 CONFIG="$DIST_DIR/coordinator.yaml"
 SERVICE="$DIST_DIR/macprovider-coordinator.service"
 NGINX_SITE="$DIST_DIR/nginx-coordinator.streamvc.live.conf"
+TCP_SYSCTL="$DIST_DIR/sysctl.d/99-macprovider-tcp.conf"
+TCP_BBR_MODULES_LOAD="$DIST_DIR/modules-load.d/tcp_bbr.conf"
 # SPEC-017 v0.1.8 Step 4.B — additional nginx artifacts the
 # coordinator vhost depends on:
 #   - stats-shared.conf is the http-context snippet declaring the
@@ -492,6 +495,135 @@ $SSH 'set -e
     echo "  /etc/macprovider/coordinator.env not yet present; operator must drop it with mode 0640 (root:macprovider)"
   fi
 '
+
+log "step 3b/9: install TCP sysctl overrides"
+if [ "${SKIP_TCP_TUNING:-0}" = "1" ]; then
+  log "  SKIP_TCP_TUNING=1 set — skipping TCP sysctl overrides"
+else
+  [ -f "$TCP_SYSCTL" ] || { echo "missing required file: $TCP_SYSCTL" >&2; exit 1; }
+  [ -f "$TCP_BBR_MODULES_LOAD" ] || { echo "missing required file: $TCP_BBR_MODULES_LOAD" >&2; exit 1; }
+  TCP_SYSCTL_UNEXPECTED=$($SSH 'for path in /etc/sysctl.d/*macprovider*; do
+    [ -e "$path" ] || continue
+    [ "$(basename "$path")" = "99-macprovider-tcp.conf" ] && continue
+    printf "%s\n" "$path"
+  done
+  exit 0')
+  if [ -n "$TCP_SYSCTL_UNEXPECTED" ]; then
+    log "  WARN: found unexpected macprovider sysctl artifacts on Pearl:"
+    while IFS= read -r unexpected_sysctl; do
+      [ -n "$unexpected_sysctl" ] || continue
+      log "    $unexpected_sysctl"
+    done <<EOF
+$TCP_SYSCTL_UNEXPECTED
+EOF
+    log "  These are not managed by this deploy; consider removing after verifying they are stale."
+  fi
+  TCP_SYSCTL_TMP=$($SSH 'umask 077 && mktemp -d -t macprovider-tcp.XXXXXXXX') || {
+    echo "failed to create remote TCP sysctl staging directory" >&2; exit 1;
+  }
+  case "$TCP_SYSCTL_TMP" in
+    /tmp/macprovider-tcp.*) ;;
+    *)
+      echo "aborting deploy: TCP sysctl mktemp produced unexpected path: '$TCP_SYSCTL_TMP'" >&2
+      exit 1
+      ;;
+  esac
+  if ! $SCP "$TCP_SYSCTL" "$VPS_USER@$VPS_HOST:$TCP_SYSCTL_TMP/macprovider-tcp.conf"; then
+    $SSH "rm -rf $TCP_SYSCTL_TMP" 2>/dev/null || true
+    exit 1
+  fi
+  if ! $SCP "$TCP_BBR_MODULES_LOAD" "$VPS_USER@$VPS_HOST:$TCP_SYSCTL_TMP/tcp_bbr.conf"; then
+    $SSH "rm -rf $TCP_SYSCTL_TMP" 2>/dev/null || true
+    exit 1
+  fi
+  TCP_SYSCTL_RESULT=$($SSH "bash -s -- '$TCP_SYSCTL_TMP'" <<'REMOTE_TCP_SYSCTL'
+    set -e
+    tmp_dir="$1"
+    tmp_conf="$tmp_dir/macprovider-tcp.conf"
+    tmp_modules_load="$tmp_dir/tcp_bbr.conf"
+    dst="/etc/sysctl.d/99-macprovider-tcp.conf"
+    modules_load_dst="/etc/modules-load.d/tcp_bbr.conf"
+    trap 'rm -rf "$tmp_dir"' EXIT
+
+    fail_tcp_tuning_partial_apply() {
+      echo "ABORT:   step 3b/9 failure — kernel TCP state may be partially mutated." >&2
+      echo "         Rollback: sudo rm /etc/sysctl.d/99-macprovider-tcp.conf /etc/modules-load.d/tcp_bbr.conf && sudo sysctl --system" >&2
+      echo "         Then investigate the failure above before re-running the deploy." >&2
+      exit 10
+    }
+
+    kernel="$(uname -r)"
+    if ! modprobe -n -v tcp_bbr >/dev/null 2>&1; then
+      echo "ABORT: tcp_bbr kernel module is not available on $(hostname) (kernel $kernel)." >&2
+      echo "       Install linux-modules-extra-$kernel or upgrade the kernel before deploying TCP tuning." >&2
+      exit 10
+    fi
+    if ! modprobe tcp_bbr >/dev/null 2>&1; then
+      echo "ABORT: tcp_bbr kernel module exists but failed to load on $(hostname) (kernel $kernel)." >&2
+      exit 10
+    fi
+
+    expect_sysctl() {
+      key="$1"
+      expected="$2"
+      actual="$(sysctl -n "$key" 2>/dev/null || true)"
+      if [ "$actual" != "$expected" ]; then
+        echo "ABORT: sysctl $key mismatch: expected $expected, got ${actual:-<unset>}" >&2
+        return 1
+      fi
+      return 0
+    }
+
+    all_tcp_sysctls_applied() {
+      while IFS='=' read -r key expected; do
+        key="$(printf '%s' "$key" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+        expected="$(printf '%s' "$expected" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+        [ -n "$key" ] || continue
+        [ "${key:0:1}" = "#" ] && continue
+        expect_sysctl "$key" "$expected" || return 1
+      done < "$tmp_conf"
+      return 0
+    }
+
+    if [ -f /etc/sysctl.d/99-macprovider-tcp.conf ] &&
+       [ -f /etc/modules-load.d/tcp_bbr.conf ] &&
+       cmp -s "$tmp_conf" /etc/sysctl.d/99-macprovider-tcp.conf &&
+       cmp -s "$tmp_modules_load" /etc/modules-load.d/tcp_bbr.conf &&
+       all_tcp_sysctls_applied >/dev/null 2>&1; then
+      echo "already"
+      exit 0
+    fi
+
+    install -m 0644 -o root -g root "$tmp_conf" "$dst"
+    # modules-load.d ensures tcp_bbr is loaded before systemd-sysctl at boot.
+    install -m 0644 -o root -g root "$tmp_modules_load" "$modules_load_dst"
+    if ! sysctl -p "$dst" >/dev/null; then
+      echo "ABORT: failed to apply $dst" >&2
+      fail_tcp_tuning_partial_apply
+    fi
+
+    if ! all_tcp_sysctls_applied; then
+      fail_tcp_tuning_partial_apply
+    fi
+    if ! expect_sysctl net.ipv4.tcp_congestion_control bbr; then
+      fail_tcp_tuning_partial_apply
+    fi
+    echo "applied"
+REMOTE_TCP_SYSCTL
+  )
+  case "$TCP_SYSCTL_RESULT" in
+    already)
+      log "  TCP sysctl overrides — already applied"
+      ;;
+    applied)
+      log "  TCP sysctl overrides applied: bbr + slow_start_after_idle=0 + 16MB buffers"
+      ;;
+    *)
+      echo "unexpected TCP sysctl deploy result: $TCP_SYSCTL_RESULT" >&2
+      exit 10
+      ;;
+  esac
+fi
 
 log "step 4/9: upload binary + config + nginx site (with rollback snapshot)"
 # Backup the live binary BEFORE the install so a rollback is one mv away.

--- a/phase4-coordinator/dist/modules-load.d/tcp_bbr.conf
+++ b/phase4-coordinator/dist/modules-load.d/tcp_bbr.conf
@@ -1,0 +1,4 @@
+# tcp_bbr.conf — load TCP BBR before systemd-sysctl applies Pearl tuning.
+# Managed by phase4-coordinator/dist/deploy-pearl-vps.sh; do not
+# edit by hand.
+tcp_bbr

--- a/phase4-coordinator/dist/sysctl.d/99-macprovider-tcp.conf
+++ b/phase4-coordinator/dist/sysctl.d/99-macprovider-tcp.conf
@@ -1,0 +1,23 @@
+# 99-macprovider-tcp.conf — Pearl VPS TCP tuning for streaming SSE.
+# Managed by phase4-coordinator/dist/deploy-pearl-vps.sh; do not
+# edit by hand.
+#
+# Applies to all outbound sockets on this host: nginx → buyer,
+# gateway → coord, coord → provider WSS. See PR #<PR> and the
+# 2026-07-04 inter-token latency bisection for the measurement
+# that motivated each knob.
+
+# BBR handles jitter / bufferbloat better than cubic. Requires the
+# tcp_bbr kernel module; deploy-pearl-vps.sh verifies availability.
+net.ipv4.tcp_congestion_control=bbr
+
+# Do NOT reset the congestion window after an idle period. WSS
+# provider tunnels spend tens of seconds idle between token bursts;
+# without this each burst restarts slow-start and eats several RTTs.
+net.ipv4.tcp_slow_start_after_idle=0
+
+# Raise socket send/receive buffer ceilings from the Ubuntu default
+# (~416 KB) to 16 MB. Removes a soft cap on streaming responses on
+# high-BDP paths. Actual per-socket allocation grows only under load.
+net.core.rmem_max=16777216
+net.core.wmem_max=16777216

--- a/phase4-coordinator/dist/test/check_pearl_tcp_test.sh
+++ b/phase4-coordinator/dist/test/check_pearl_tcp_test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# check_pearl_tcp_test.sh — offline validation for the Pearl TCP sysctl
+# artifact and deploy-pearl-vps.sh step 3b/9.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SYSCTL_FILE="$DIST_DIR/sysctl.d/99-macprovider-tcp.conf"
+MODULES_LOAD_FILE="$DIST_DIR/modules-load.d/tcp_bbr.conf"
+DEPLOY_SH="$DIST_DIR/deploy-pearl-vps.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[ -f "$SYSCTL_FILE" ] || fail "missing sysctl file: $SYSCTL_FILE"
+[ -f "$MODULES_LOAD_FILE" ] || fail "missing modules-load file: $MODULES_LOAD_FILE"
+[ -f "$DEPLOY_SH" ] || fail "missing deploy script: $DEPLOY_SH"
+
+EXPECTED="$(mktemp -t pearl-tcp-expected.XXXXXX)"
+trap 'rm -f "$EXPECTED"' EXIT
+cat > "$EXPECTED" <<'EOF'
+# 99-macprovider-tcp.conf — Pearl VPS TCP tuning for streaming SSE.
+# Managed by phase4-coordinator/dist/deploy-pearl-vps.sh; do not
+# edit by hand.
+#
+# Applies to all outbound sockets on this host: nginx → buyer,
+# gateway → coord, coord → provider WSS. See PR #<PR> and the
+# 2026-07-04 inter-token latency bisection for the measurement
+# that motivated each knob.
+
+# BBR handles jitter / bufferbloat better than cubic. Requires the
+# tcp_bbr kernel module; deploy-pearl-vps.sh verifies availability.
+net.ipv4.tcp_congestion_control=bbr
+
+# Do NOT reset the congestion window after an idle period. WSS
+# provider tunnels spend tens of seconds idle between token bursts;
+# without this each burst restarts slow-start and eats several RTTs.
+net.ipv4.tcp_slow_start_after_idle=0
+
+# Raise socket send/receive buffer ceilings from the Ubuntu default
+# (~416 KB) to 16 MB. Removes a soft cap on streaming responses on
+# high-BDP paths. Actual per-socket allocation grows only under load.
+net.core.rmem_max=16777216
+net.core.wmem_max=16777216
+EOF
+
+if ! cmp -s "$EXPECTED" "$SYSCTL_FILE"; then
+  diff -u "$EXPECTED" "$SYSCTL_FILE" >&2 || true
+  fail "sysctl file does not match expected contents byte-for-byte"
+fi
+
+for line in \
+  "net.ipv4.tcp_congestion_control=bbr" \
+  "net.ipv4.tcp_slow_start_after_idle=0" \
+  "net.core.rmem_max=16777216" \
+  "net.core.wmem_max=16777216"; do
+  grep -qxF "$line" "$SYSCTL_FILE" || fail "missing expected sysctl: $line"
+done
+
+key_count="$(grep -Ec '^[a-z0-9_.]+=' "$SYSCTL_FILE")"
+[ "$key_count" = "4" ] || fail "expected exactly 4 sysctl keys, found $key_count"
+while IFS= read -r line; do
+  case "$line" in
+    net.ipv4.tcp_congestion_control=bbr|\
+    net.ipv4.tcp_slow_start_after_idle=0|\
+    net.core.rmem_max=16777216|\
+    net.core.wmem_max=16777216)
+      ;;
+    *)
+      fail "unexpected sysctl key line: $line"
+      ;;
+  esac
+done < <(grep -E '^[a-z0-9_.]+=' "$SYSCTL_FILE")
+
+if LC_ALL=C grep -q $'\r' "$SYSCTL_FILE"; then
+  fail "sysctl file contains CRLF line endings"
+fi
+if awk '/[^[:space:]]/ && /[[:blank:]]$/ { print; bad=1 } END { exit bad }' "$SYSCTL_FILE" >&2; then
+  :
+else
+  fail "sysctl file contains trailing whitespace on non-blank lines"
+fi
+last_byte="$(tail -c 1 "$SYSCTL_FILE" | od -An -t x1 | tr -d ' \n')"
+[ "$last_byte" = "0a" ] || fail "sysctl file does not end with a newline"
+if [ "$(tail -c 2 "$SYSCTL_FILE" | od -An -t x1 | tr -s ' ' | sed 's/^ //;s/ $//')" = "0a 0a" ]; then
+  fail "sysctl file ends with more than one newline"
+fi
+
+modules_non_comment="$(sed -E '/^[[:space:]]*($|#)/d; s/^[[:space:]]+|[[:space:]]+$//g' "$MODULES_LOAD_FILE")"
+[ "$modules_non_comment" = "tcp_bbr" ] ||
+  fail "modules-load file must contain exactly tcp_bbr as non-comment content"
+if LC_ALL=C grep -q $'\r' "$MODULES_LOAD_FILE"; then
+  fail "modules-load file contains CRLF line endings"
+fi
+if awk '/[^[:space:]]/ && /[[:blank:]]$/ { print; bad=1 } END { exit bad }' "$MODULES_LOAD_FILE" >&2; then
+  :
+else
+  fail "modules-load file contains trailing whitespace on non-blank lines"
+fi
+modules_last_byte="$(tail -c 1 "$MODULES_LOAD_FILE" | od -An -t x1 | tr -d ' \n')"
+[ "$modules_last_byte" = "0a" ] || fail "modules-load file does not end with a newline"
+
+grep -qF "log \"step 3b/9: install TCP sysctl overrides\"" "$DEPLOY_SH" ||
+  fail "deploy script missing step 3b/9 log line"
+grep -qF "SKIP_TCP_TUNING" "$DEPLOY_SH" ||
+  fail "deploy script missing SKIP_TCP_TUNING escape hatch"
+grep -qF '[ -f "$TCP_SYSCTL" ] || { echo "missing required file: $TCP_SYSCTL" >&2; exit 1; }' "$DEPLOY_SH" ||
+  fail "deploy script must require TCP sysctl artifact only inside the non-skip branch"
+grep -qF '[ -f "$TCP_BBR_MODULES_LOAD" ] || { echo "missing required file: $TCP_BBR_MODULES_LOAD" >&2; exit 1; }' "$DEPLOY_SH" ||
+  fail "deploy script must require TCP BBR modules-load artifact only inside the non-skip branch"
+grep -qF "mktemp -d -t macprovider-tcp.XXXXXXXX" "$DEPLOY_SH" ||
+  fail "deploy script missing private remote staging directory for TCP sysctl file"
+grep -qF '$SCP "$TCP_SYSCTL" "$VPS_USER@$VPS_HOST:$TCP_SYSCTL_TMP/macprovider-tcp.conf"' "$DEPLOY_SH" ||
+  fail "deploy script missing scp of TCP sysctl file to private staging path"
+grep -qF '$SCP "$TCP_BBR_MODULES_LOAD" "$VPS_USER@$VPS_HOST:$TCP_SYSCTL_TMP/tcp_bbr.conf"' "$DEPLOY_SH" ||
+  fail "deploy script missing scp of TCP BBR modules-load file to private staging path"
+grep -qF "modprobe -n -v tcp_bbr" "$DEPLOY_SH" ||
+  fail "deploy script missing tcp_bbr dry-run presence check"
+grep -qF "modprobe tcp_bbr" "$DEPLOY_SH" ||
+  fail "deploy script missing tcp_bbr load step"
+grep -qF 'kernel="$(uname -r)"' "$DEPLOY_SH" ||
+  fail "deploy script missing uname -r capture for tcp_bbr failure message"
+grep -qF 'linux-modules-extra-$kernel' "$DEPLOY_SH" ||
+  fail "deploy script missing targeted linux-modules-extra remediation message"
+grep -qF 'dst="/etc/sysctl.d/99-macprovider-tcp.conf"' "$DEPLOY_SH" ||
+  fail "deploy script missing sysctl destination path"
+grep -qF 'modules_load_dst="/etc/modules-load.d/tcp_bbr.conf"' "$DEPLOY_SH" ||
+  fail "deploy script missing tcp_bbr modules-load destination path"
+grep -qF 'install -m 0644 -o root -g root "$tmp_conf" "$dst"' "$DEPLOY_SH" ||
+  fail "deploy script missing root:root 0644 sysctl install"
+grep -qF 'install -m 0644 -o root -g root "$tmp_modules_load" "$modules_load_dst"' "$DEPLOY_SH" ||
+  fail "deploy script missing root:root 0644 modules-load install"
+grep -qF 'sysctl -p "$dst"' "$DEPLOY_SH" ||
+  fail "deploy script missing file-scoped sysctl apply"
+grep -qF "expect_sysctl net.ipv4.tcp_congestion_control bbr" "$DEPLOY_SH" ||
+  fail "deploy script missing post-apply BBR active congestion-control verification"
+grep -qF 'cmp -s "$tmp_conf" /etc/sysctl.d/99-macprovider-tcp.conf' "$DEPLOY_SH" ||
+  fail "deploy script missing idempotency cmp against installed sysctl file"
+grep -qF 'cmp -s "$tmp_modules_load" /etc/modules-load.d/tcp_bbr.conf' "$DEPLOY_SH" ||
+  fail "deploy script missing idempotency cmp against installed modules-load file"
+grep -qF 'echo "already"' "$DEPLOY_SH" ||
+  fail "deploy script missing already-applied idempotency result"
+grep -qF 'while IFS='\''='\'' read -r key expected' "$DEPLOY_SH" ||
+  fail "deploy script must parse expected sysctl keys from the staged conf"
+if grep -qF "expect_sysctl net.ipv4.tcp_slow_start_after_idle 0" "$DEPLOY_SH" ||
+   grep -qF "expect_sysctl net.core.rmem_max 16777216" "$DEPLOY_SH" ||
+   grep -qF "expect_sysctl net.core.wmem_max 16777216" "$DEPLOY_SH"; then
+  fail "deploy script hardcodes non-BBR sysctl verification keys instead of parsing the conf"
+fi
+grep -qF 'log "  WARN: found unexpected macprovider sysctl artifacts on Pearl:"' "$DEPLOY_SH" ||
+  fail "deploy script missing unexpected macprovider sysctl artifact warning"
+grep -qF 'These are not managed by this deploy; consider removing after verifying they are stale.' "$DEPLOY_SH" ||
+  fail "deploy script missing unexpected macprovider sysctl cleanup guidance"
+grep -qF 'step 3b/9 failure — kernel TCP state may be partially mutated.' "$DEPLOY_SH" ||
+  fail "deploy script missing partial-apply rollback warning"
+grep -qF 'Rollback: sudo rm /etc/sysctl.d/99-macprovider-tcp.conf /etc/modules-load.d/tcp_bbr.conf && sudo sysctl --system' "$DEPLOY_SH" ||
+  fail "deploy script missing rollback command"
+if grep -qF "/tmp/macprovider-tcp.conf" "$DEPLOY_SH"; then
+  fail "deploy script uses predictable /tmp TCP sysctl staging path"
+fi
+if grep -qE 'sysctl[[:space:]]+-w|/etc/sysctl\.conf' "$DEPLOY_SH"; then
+  fail "deploy script uses a prohibited sysctl apply path"
+fi
+
+echo "PASS: Pearl TCP sysctl artifact and deploy hook validated"

--- a/specs/AUDIT_PEARL_TCP_TUNING_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_PEARL_TCP_TUNING_ARCHITECT_PROMPT.md
@@ -1,0 +1,93 @@
+# AUDIT_PEARL_TCP_TUNING_ARCHITECT — ARCHITECT lane
+
+Audit the diff that implements
+`specs/BUILD_PEARL_TCP_TUNING_IMPL_PROMPT.md`.
+
+## Your lane: ARCHITECT
+
+### Look for
+
+1. **Placement in deploy script**
+   - Sub-step "3b/9" is inserted between existing "3/9" and "4/9"
+     WITHOUT renumbering. Existing step 4-9 numbers stay stable.
+   - Sub-step lands AFTER user + dirs setup (so `root:root` owner
+     is available) and BEFORE nginx install (so kernel-level
+     changes are settled before any long-running proxying starts).
+
+2. **Idempotency in the pipeline shape**
+   - Matches the pattern of other idempotent steps in the same
+     script (e.g. certbot renew, systemd unit reload).
+   - Detection method (cmp on file / value comparison) matches the
+     drift-detection approach used by the existing step 1b.
+
+3. **File organisation**
+   - New directory `phase4-coordinator/dist/sysctl.d/` matches the
+     naming style of `phase4-coordinator/dist/nginx-snippets/` and
+     `phase4-coordinator/dist/monitor/`.
+   - Test file lives under `phase4-coordinator/dist/test/` matching
+     the existing shell-test convention.
+   - Test naming (`check_pearl_tcp_test.sh`) matches
+     `check_pearl_tls_test.sh` etc.
+
+4. **Sysctl file precedence**
+   - `99-` prefix reserves the highest position in `/etc/sysctl.d/`
+     load order. Confirm no other deploy artifact wants that
+     precedence.
+   - No overlap with `/etc/sysctl.d/*macprovider*` from any past
+     deploy. If historical files exist, deploy should log that fact
+     and either upgrade or refuse fail-loud.
+
+5. **Extensibility**
+   - Would adding a fifth sysctl key later require re-writing the
+     step? Verify by inspection that the step handles the file as a
+     whole (install + apply + verify each key) rather than
+     enumerating keys inline in the shell.
+   - The verification loop reads each expected key from a data
+     structure (associative array or here-doc) so adding a fifth
+     value only touches the sysctl.conf file, not the script.
+
+6. **`SKIP_TCP_TUNING` naming consistency**
+   - Env var name matches existing skips (`FORCE_RESTART`,
+     `SKIP_C2_CHECK`, `STRICT_PROVENANCE`, etc.) — same case, same
+     0/1 semantics.
+   - Documented at top of script alongside the other env vars.
+
+7. **BBR module handling — deploy-time vs boot-time**
+   - `modprobe tcp_bbr` at deploy time loads the module now, but
+     the sysctl file at `/etc/sysctl.d/` alone does NOT ensure the
+     module is loaded across reboots. Standard idiom is to also
+     drop a `/etc/modules-load.d/tcp_bbr.conf` file OR use
+     `modprobe --first-time` in the sysctl config.
+   - Verify one of these is done, OR document explicitly why it's
+     acceptable to rely on `tcp_bbr` being loaded on-demand at
+     first BBR socket creation (which the kernel does automatically
+     when `net.ipv4.tcp_congestion_control=bbr` is applied via
+     sysctl.d).
+
+8. **Scope discipline**
+   - Diff touches only:
+     - `phase4-coordinator/dist/sysctl.d/99-macprovider-tcp.conf`
+       (new)
+     - `phase4-coordinator/dist/deploy-pearl-vps.sh` (modified)
+     - `phase4-coordinator/dist/test/check_pearl_tcp_test.sh` (new)
+     - `specs/BUILD_PEARL_TCP_TUNING_IMPL_PROMPT.md` (new)
+   - No changes to nginx configs, gateway configs, coord Go code,
+     provider Swift code, systemd unit files, or CI workflows.
+
+### Do NOT flag
+
+- Shell correctness (CODE lane).
+- Threat model (SECURITY lane).
+- Findings outside the diff.
+
+### Output
+
+```
+STATUS: ARCHITECT lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+Each finding: file:line, design concern, future scenario, fix.
+
+## Diff to audit
+
+`git diff` in the worktree.

--- a/specs/AUDIT_PEARL_TCP_TUNING_CODE_PROMPT.md
+++ b/specs/AUDIT_PEARL_TCP_TUNING_CODE_PROMPT.md
@@ -1,0 +1,81 @@
+# AUDIT_PEARL_TCP_TUNING_CODE — CODE lane
+
+Audit the diff that implements
+`specs/BUILD_PEARL_TCP_TUNING_IMPL_PROMPT.md`. Read the BUILD prompt
+for the behavioural contract, then read the diff.
+
+## Your lane: CODE (shell / deploy-script correctness)
+
+### Look for
+
+1. **Shell correctness in the new deploy step**
+   - `set -euo pipefail` inheritance (script-wide already set).
+   - No unquoted variable expansions in paths / commands
+     (`"$VPS_HOST"`, `"$SSH_KEY"`, etc.).
+   - No word-splitting on `install -m 0644 -o root -g root ...` args.
+   - Error paths use `die` / `fail` helper if one exists in the
+     script (grep for existing pattern).
+   - `scp` invocation matches existing scp calls in the same script
+     for `-i "$SSH_KEY"` and `-P` port options (if used elsewhere).
+
+2. **Sysctl file content**
+   - Exact 4-key match with BUILD § "Sysctl file contents".
+   - No trailing whitespace on non-blank lines.
+   - Single trailing newline (not zero, not two).
+   - Comment lines match verbatim.
+   - No CRLF line endings.
+
+3. **Verification steps**
+   - `modprobe -n -v tcp_bbr` availability check runs BEFORE the
+     `install`.
+   - `modprobe tcp_bbr` load runs BEFORE `sysctl -p`.
+   - Post-apply verification reads `net.ipv4.tcp_congestion_control`
+     and matches `bbr` exactly (not `contains "bbr"`, not
+     `startswith "bbr"`).
+   - Each of the 4 sysctl keys is re-read and asserted against its
+     expected value.
+   - On any mismatch, the script fails-loud with a message that
+     names the offending key AND the actual value observed.
+
+4. **Idempotency**
+   - Re-run detection is correct: `cmp -s` (or equivalent) against
+     the on-disk copy before re-installing.
+   - Second run produces "already applied" and exits 0 with no
+     mutation.
+   - No false-positive "already applied" when a previous partial
+     deploy left the file but not the runtime state.
+
+5. **Escape hatch**
+   - `SKIP_TCP_TUNING=1` gate is checked at the top of step 3b/9.
+   - Skip path logs a clear message ("SKIP_TCP_TUNING=1: bypassing
+     TCP kernel tuning").
+   - Skip does NOT count as failure (deploy continues).
+
+6. **Test script correctness**
+   - `check_pearl_tcp_test.sh` uses `set -euo pipefail`.
+   - Assertions produce actionable failure messages (name the
+     expected value, name the actual value).
+   - Runs offline (no ssh, no sudo, no root, no /etc access).
+   - Executable bit set (`chmod 0755`).
+
+### Do NOT flag
+
+- Placement / step-numbering (ARCHITECT lane).
+- Threat model / privilege concerns (SECURITY lane).
+- Anything outside the diff.
+
+### Output format
+
+```
+STATUS: CODE lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+Each finding: file:line, defect, concrete failure scenario, fix.
+
+## Diff to audit
+
+`git diff` in the worktree. New files:
+`phase4-coordinator/dist/sysctl.d/99-macprovider-tcp.conf`,
+`phase4-coordinator/dist/test/check_pearl_tcp_test.sh`,
+`specs/BUILD_PEARL_TCP_TUNING_IMPL_PROMPT.md`. Modified:
+`phase4-coordinator/dist/deploy-pearl-vps.sh`.

--- a/specs/AUDIT_PEARL_TCP_TUNING_R2_PROMPT.md
+++ b/specs/AUDIT_PEARL_TCP_TUNING_R2_PROMPT.md
@@ -1,0 +1,101 @@
+# AUDIT_PEARL_TCP_TUNING_R2 — three lanes, ROUND 2
+
+Round 1 audit findings that were fixed:
+
+- **ARCHITECT M1** — verification enumerated keys inline (spec
+  violation) → fixed by parsing `$tmp_conf` at deploy time and
+  looping over parsed pairs.
+- **ARCHITECT M2** — no BBR boot persistence → fixed by adding
+  `phase4-coordinator/dist/modules-load.d/tcp_bbr.conf` +
+  matching install / apply / verify steps.
+- **ARCHITECT M3** — no detection of historical `*macprovider*`
+  sysctl artifacts → fixed by WARN-level scan of `/etc/sysctl.d/`
+  before install.
+- **SECURITY M** — no rollback command in partial-apply failure
+  messages → fixed by adding explicit rollback text to each of
+  the three failure sites (sysctl -p failure, per-key mismatch,
+  BBR verification mismatch); NOT added to the SKIP path or BBR-
+  module-missing path (nothing was mutated in those).
+
+R1 LOW / INFO findings ship as-is with PR-body documentation and
+are NOT fixed in this round:
+
+- CODE R1 LOW — `SKIP_TCP_TUNING=1` log-message wording nit.
+- SECURITY R1 LOW — precedence collision check against later-
+  precedence sysctl files.
+- ARCHITECT R1 LOW — Makefile scope (intentional, wires test into
+  test-dist).
+
+## Your task
+
+Run the CODE, SECURITY, and ARCHITECT audit lanes against the
+R1 → R2 delta only. Do not re-litigate R1 findings; do not re-
+audit code that R1 already accepted.
+
+### CODE R2 focus
+
+- The `while IFS='=' read -r key expected_value` loop over
+  `$tmp_conf` correctly handles: blank lines, `#` comments,
+  leading/trailing whitespace, missing `=` sign, keys/values with
+  embedded spaces (there are none in this file but the code must
+  not corrupt if there were).
+- The BBR module load site invokes `modprobe tcp_bbr` on Pearl
+  (not on the operator's Mac).
+- The `install` invocation for `modules-load.d/tcp_bbr.conf`
+  uses the same `-m 0644 -o root -g root` shape as the sysctl
+  install.
+- The historical-file detection loop uses `find`, `ls`, or shell
+  glob without word-splitting bugs.
+- The rollback message contains the canonical shell command
+  string exactly as the operator would paste it — no shell
+  metacharacters that would corrupt the printed command.
+
+### SECURITY R2 focus
+
+- The new `find`/`ls` invocation for historical files does NOT
+  execute anything the found files contain (no `source`, no
+  `. `). It only lists and logs.
+- The rollback command text does NOT include a `sudo curl … | sh`
+  or any remote-fetch step. It must be a purely local rm + sysctl
+  --system.
+- Adding `/etc/modules-load.d/tcp_bbr.conf` on Pearl does not
+  expose any new listening service or open port.
+- The new artifact file mode is `0644` (world-readable is fine
+  for a kernel module load list).
+
+### ARCHITECT R2 focus
+
+- The file-as-source-of-truth pattern (M1 fix) is generic enough
+  that adding a fifth sysctl key to the `.conf` file would work
+  without touching the shell.
+- `modules-load.d/tcp_bbr.conf` naming and placement match the
+  existing `sysctl.d/` sibling.
+- The historical-file WARN message shape (M3 fix) matches the
+  existing `WARN:` conventions elsewhere in the same script.
+- Rollback message includes BOTH files (`sysctl.d/` and
+  `modules-load.d/`) so a partial-apply rollback covers both.
+
+### Do NOT flag
+
+- Anything already accepted in R1.
+- R1 LOW / INFO findings.
+- Anything outside the R1 → R2 delta.
+
+## Output
+
+Three status lines, one per lane:
+
+```
+STATUS: CODE lane R2 — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+STATUS: SECURITY lane R2 — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+STATUS: ARCHITECT lane R2 — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+## Diff to audit
+
+`git diff` in the worktree. R2 delta includes:
+- `phase4-coordinator/dist/deploy-pearl-vps.sh`: parse-loop, BBR
+  boot install, historical-file WARN scan, rollback message.
+- New `phase4-coordinator/dist/modules-load.d/tcp_bbr.conf`.
+- `phase4-coordinator/dist/test/check_pearl_tcp_test.sh`: new
+  assertions.

--- a/specs/AUDIT_PEARL_TCP_TUNING_SECURITY_PROMPT.md
+++ b/specs/AUDIT_PEARL_TCP_TUNING_SECURITY_PROMPT.md
@@ -1,0 +1,88 @@
+# AUDIT_PEARL_TCP_TUNING_SECURITY — SECURITY lane
+
+Audit the diff that implements
+`specs/BUILD_PEARL_TCP_TUNING_IMPL_PROMPT.md`.
+
+## Your lane: SECURITY
+
+### Look for
+
+1. **Privilege escalation surface**
+   - The `install`, `modprobe`, and `sysctl` calls are all run as
+     `root` (the deploy script runs as root on Pearl per its existing
+     invocation model). Verify no non-root path executes any of them.
+   - No path where a user-writable temp path (e.g. `/tmp/...`) is
+     re-read after upload with `install` — race between upload and
+     apply on shared `/tmp`. Prefer `/root/` or use `mktemp -d`.
+
+2. **Path injection**
+   - The fixed literal `/etc/sysctl.d/99-macprovider-tcp.conf`
+     matches the file naming convention (99- prefix) and does not
+     collide with any Ubuntu-shipped file.
+   - No interpolation of user-controlled variables into the target
+     path.
+
+3. **File integrity between upload and apply**
+   - After `scp`, before `install`, no attacker with write access
+     to `/tmp` can substitute the file.
+   - Preferred mitigation: upload to a root-owned dir (`/root/` or
+     `mktemp -d -p /root/`), NOT `/tmp/`.
+
+4. **sysctl.d precedence collisions**
+   - `99-` prefix: highest precedence in `/etc/sysctl.d/` load order.
+     Verify no `/etc/sysctl.d/99-*` file already ships with Ubuntu
+     or with a package the deploy might install later that would
+     conflict on the same 4 keys.
+   - If a conflict exists, deploy should log a warning.
+
+5. **BBR + module-load side effects**
+   - Loading `tcp_bbr` on a running server is safe — no in-flight
+     connection reset. Confirm no `sysctl` command that would
+     reset active TCP connections.
+   - Applying `tcp_congestion_control=bbr` to a live host does not
+     require a coord / gateway restart.
+
+6. **Escape hatch abuse**
+   - `SKIP_TCP_TUNING=1` bypass MUST log clearly (audit trail) so
+     an operator retrospectively knows the tuning was skipped.
+   - The bypass cannot be flipped mid-deploy such that the rest of
+     the deploy proceeds with mixed / inconsistent state.
+
+7. **No new listening service or open port**
+   - The sysctl changes affect kernel TCP behaviour only. No new
+     socket, no new listening port, no new privileged service.
+     Verify by inspection.
+
+8. **Log injection / secret exfil**
+   - Log lines do NOT include sensitive values (there aren't any
+     here, but verify the modprobe stderr isn't dumped to a
+     buyer-accessible log).
+   - `/etc/sysctl.d/99-macprovider-tcp.conf` is world-readable (mode
+     0644). Content is not sensitive; kernel tuning is public
+     information. Verify no accidental secret embedded.
+
+9. **Rollback safety**
+   - If step 3b/9 fails after `sysctl -p` succeeded but before
+     verification passed, the applied values persist on the box.
+     Deploy should surface this state clearly so the operator can
+     roll back manually with `rm /etc/sysctl.d/99-macprovider-tcp.conf
+     && sysctl --system`.
+   - Verify the failure message includes the rollback command.
+
+### Do NOT flag
+
+- Non-security correctness (CODE lane).
+- Naming / placement (ARCHITECT).
+- Findings outside the diff.
+
+### Output
+
+```
+STATUS: SECURITY lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>
+```
+
+Each finding: file:line, threat model, concrete scenario, mitigation.
+
+## Diff to audit
+
+`git diff` in the worktree.

--- a/specs/BUILD_PEARL_TCP_TUNING_IMPL_PROMPT.md
+++ b/specs/BUILD_PEARL_TCP_TUNING_IMPL_PROMPT.md
@@ -1,0 +1,272 @@
+# BUILD_PEARL_TCP_TUNING_IMPL — Pearl VPS TCP kernel tuning for streaming SSE
+
+## Motivation (measured, 2026-07-04)
+
+Cold-start / inter-token bisection against `mac` (M5 32GB, v1.8.0) via
+`api.streamvc.live` measured this inter-token latency distribution
+for a 500-token buyer stream:
+
+| Bench | median | p95 | p99 | max |
+|---|---:|---:|---:|---:|
+| M5 → api.streamvc.live (WAN + nginx + coord + provider) | 22.6 ms | 90.4 ms | 131.9 ms | **364.0 ms** |
+| Pearl → localhost:9443 gateway (no nginx, no TLS, no WAN) | 25.7 ms | 75.2 ms | 100.2 ms | **122.5 ms** |
+
+The tail delta (~50-240 ms extra on WAN) is TCP-level jitter on the
+M5 → Pearl link. Pearl is a 2vcpu 4GB DigitalOcean NYC1 droplet
+running Ubuntu. Two kernel-level defaults hurt streaming SSE
+specifically:
+
+1. **`net.ipv4.tcp_slow_start_after_idle=1`** (default). WSS
+   provider ↔ coord tunnel goes tens of seconds idle between token
+   bursts. Default kernel resets the congestion window every idle
+   period, so each new burst spends the first several RTTs in
+   slow-start. For a chat-completion stream, that's noticeable.
+2. **`net.ipv4.tcp_congestion_control=cubic`** (Ubuntu default).
+   BBR handles jitter under bufferbloat much better than cubic —
+   the classic "Google BBR paper" result. Every modern Ubuntu kernel
+   (5.15+) ships the `tcp_bbr` module; enabling BBR is a two-line
+   sysctl change and applies to all outbound sockets, including
+   WSS + gateway → buyer.
+
+Additionally, socket buffer defaults on 4GB VPS are conservative
+(~416 KB max). For streaming responses that fill the receive window
+during buffering, bumping `rmem_max` / `wmem_max` to 16 MB removes a
+soft cap without meaningfully changing memory usage at current load
+(current coord memory footprint is 22 MB).
+
+## Goal (this PR)
+
+Ship a sysctl.d file + a deploy step that:
+
+1. Installs `/etc/sysctl.d/99-macprovider-tcp.conf` on Pearl with
+   four kernel parameter overrides (see § "Sysctl file contents").
+2. Applies the file at deploy time.
+3. Verifies BBR is active as the actual congestion control.
+4. Fails the deploy if the kernel lacks the `tcp_bbr` module.
+
+The change is idempotent — re-running `deploy-pearl-vps.sh` produces
+no drift, no restart, no reload. The sysctl values are re-verified
+each run.
+
+## Non-goals
+
+- No change to nginx, gateway, or coord runtime code.
+- No new sysctl scope beyond the 4 knobs listed below. No fq /
+  fq_codel qdisc changes. No `tcp_notsent_lowat`. No IPv6 knobs.
+- No changes to firewall / ufw / iptables.
+- No kernel package upgrade (rely on the shipped `tcp_bbr` module).
+- No systemd-networkd changes.
+- Not deployed by this PR — merging just lands the artifact + deploy
+  hook. Actually applying on Pearl is a follow-up operator step.
+
+## Sysctl file contents
+
+Exactly this file, at
+`phase4-coordinator/dist/sysctl.d/99-macprovider-tcp.conf`:
+
+```
+# 99-macprovider-tcp.conf — Pearl VPS TCP tuning for streaming SSE.
+# Managed by phase4-coordinator/dist/deploy-pearl-vps.sh; do not
+# edit by hand.
+#
+# Applies to all outbound sockets on this host: nginx → buyer,
+# gateway → coord, coord → provider WSS. See PR #<PR> and the
+# 2026-07-04 inter-token latency bisection for the measurement
+# that motivated each knob.
+
+# BBR handles jitter / bufferbloat better than cubic. Requires the
+# tcp_bbr kernel module; deploy-pearl-vps.sh verifies availability.
+net.ipv4.tcp_congestion_control=bbr
+
+# Do NOT reset the congestion window after an idle period. WSS
+# provider tunnels spend tens of seconds idle between token bursts;
+# without this each burst restarts slow-start and eats several RTTs.
+net.ipv4.tcp_slow_start_after_idle=0
+
+# Raise socket send/receive buffer ceilings from the Ubuntu default
+# (~416 KB) to 16 MB. Removes a soft cap on streaming responses on
+# high-BDP paths. Actual per-socket allocation grows only under load.
+net.core.rmem_max=16777216
+net.core.wmem_max=16777216
+```
+
+Exact file contents — no additional keys, no blank lines beyond the
+ones shown, no trailing whitespace on non-blank lines. The file's
+permissions must be `0644 root:root` when installed on Pearl.
+
+## Deploy hook
+
+Add a new step to
+`phase4-coordinator/dist/deploy-pearl-vps.sh` immediately after the
+existing "step 3/9: create macprovider system user + dirs" block
+and before the existing nginx-install step. Numbering: promote it
+to a sub-step like "step 3b/9: install TCP sysctl overrides" so the
+existing 4-9 numbering stays stable (renumbering would break
+operator muscle memory).
+
+### Step 3b/9 behaviour
+
+1. `scp` the local
+   `phase4-coordinator/dist/sysctl.d/99-macprovider-tcp.conf` to a
+   temp path on Pearl (e.g. `/tmp/macprovider-tcp.conf`).
+2. Over SSH:
+   a. Detect BBR module availability: `modprobe -n -v tcp_bbr`
+      (dry-run resolution). If the module is not present in the
+      kernel image, **fail the deploy** with a clear message that
+      names the machine's `uname -r` and asks the operator to
+      either install `linux-modules-extra-$(uname -r)` or upgrade
+      the kernel.
+   b. Load the module: `modprobe tcp_bbr`. If load fails, fail the
+      deploy.
+   c. `install -m 0644 -o root -g root /tmp/macprovider-tcp.conf
+      /etc/sysctl.d/99-macprovider-tcp.conf`.
+   d. Apply: `sysctl -p /etc/sysctl.d/99-macprovider-tcp.conf`. On
+      failure, fail the deploy.
+   e. Verify: query each of the 4 sysctl keys and assert its value
+      is the expected one. On mismatch, print the actual value and
+      fail the deploy.
+   f. Verify BBR is the actual active congestion control globally:
+      `sysctl -n net.ipv4.tcp_congestion_control` must return `bbr`.
+   g. Clean up `/tmp/macprovider-tcp.conf`.
+3. Idempotency: re-running produces no output beyond "step 3b/9:
+   TCP sysctl overrides — already applied". Detect via
+   `cmp -s` against the on-disk copy before re-installing, or by
+   comparing the currently-applied sysctl values against expected.
+
+### Log line style
+
+Match existing steps' log style:
+```
+log "step 3b/9: install TCP sysctl overrides"
+```
+and
+```
+log "  TCP sysctl overrides applied: bbr + slow_start_after_idle=0 + 16MB buffers"
+```
+for the success line.
+
+## Test artifact
+
+New file
+`phase4-coordinator/dist/test/check_pearl_tcp_test.sh` that:
+
+1. Asserts the sysctl file exists at the expected repo path.
+2. Asserts each of the 4 expected keys is present with the exact
+   expected value.
+3. Asserts no additional sysctl keys are present in the file.
+4. Asserts the file has no trailing whitespace on non-blank lines,
+   no CRLF line endings, and ends with a single newline.
+5. Asserts the deploy script contains an install invocation for the
+   file at `/etc/sysctl.d/99-macprovider-tcp.conf` with mode `0644`
+   and owner `root:root`.
+6. Asserts the deploy script contains a `modprobe -n -v tcp_bbr`
+   presence check and a `modprobe tcp_bbr` load step.
+7. Asserts the deploy script contains a post-apply verification
+   step that reads `net.ipv4.tcp_congestion_control` and matches
+   against `bbr`.
+
+The test file must be executable, use `bash -euo pipefail`, and
+follow the shape of existing tests in the same directory (e.g.
+`check_deploy_config_test.sh`). Exit 0 on success, non-zero on any
+failure with a short description of what failed.
+
+Add the test to the existing test-runner if one exists (grep the
+`Makefile` or `.github/workflows/` for a test-invocation pattern);
+if the convention is per-test explicit invocation, follow that.
+
+## Acceptance criteria
+
+**AC1** — File
+`phase4-coordinator/dist/sysctl.d/99-macprovider-tcp.conf` exists
+and matches § "Sysctl file contents" byte-for-byte.
+
+**AC2** — `bash phase4-coordinator/dist/test/check_pearl_tcp_test.sh`
+exits 0 in a clean repo checkout.
+
+**AC3** — `deploy-pearl-vps.sh` executes step 3b/9 in a dry-run mode
+(if one exists) or with `set -x` shows the exact commands:
+`scp … tcp.conf`, `modprobe -n -v tcp_bbr`, `modprobe tcp_bbr`,
+`install -m 0644 …`, `sysctl -p …`, `sysctl -n
+net.ipv4.tcp_congestion_control`.
+
+**AC4** — Deploy script step 3b/9 fails-loud with a targeted message
+when the target kernel lacks the `tcp_bbr` module (simulated by
+mocking `modprobe -n -v tcp_bbr` to return non-zero).
+
+**AC5** — Idempotent re-run: second invocation produces
+"already applied" without re-installing or restarting anything.
+
+**AC6** — Existing test suite unchanged and passes:
+- `bash phase4-coordinator/dist/test/check_deploy_config_test.sh`
+- `bash phase4-coordinator/dist/test/check_pearl_tls_test.sh`
+- and all other files under `phase4-coordinator/dist/test/`.
+
+**AC7** — No changes to nginx configs, gateway configs, coord Go
+code, provider Swift code, or systemd unit files.
+
+## Prohibited implementation choices
+
+- Do NOT `sysctl -w` individual keys at deploy time — apply from
+  the file so persistence survives reboots.
+- Do NOT run `sysctl --system` (that re-applies every conf in
+  `/etc/sysctl.d/` and can perturb unrelated tuning). Only apply
+  the specific file.
+- Do NOT add new sysctl keys beyond the 4 listed. Extending scope
+  is a follow-up PR, not this one.
+- Do NOT touch `/etc/sysctl.conf` (deprecated in favour of
+  `/etc/sysctl.d/`).
+- Do NOT install the file if `SKIP_TCP_TUNING=1` env is set. This
+  is a documented escape hatch for operators who need to test
+  without the tuning. Log the skip clearly.
+- Do NOT change existing step numbering. Sub-step "3b/9" only.
+
+## Commit style
+
+```
+chore(pearl): TCP kernel tuning for streaming SSE (BBR + no-idle-reset + 16MB bufs)
+
+Motivation: 2026-07-04 inter-token latency bisection measured 240ms
+of tail latency on the M5→Pearl WAN path that's not present on
+localhost. Root cause is TCP-level jitter under bufferbloat + cwnd
+reset after WSS idle. Four sysctl overrides on Pearl close most of
+this without any code change.
+
+Change: new phase4-coordinator/dist/sysctl.d/99-macprovider-tcp.conf
++ deploy-pearl-vps.sh step 3b/9 that installs it, verifies
+tcp_bbr module availability, applies the file, and post-verifies
+active congestion control is bbr.
+
+Tested: new check_pearl_tcp_test.sh (offline validation); existing
+dist/test/ suite unchanged.
+
+Not deployed: merging this lands the artifact. Actually applying on
+Pearl is the next operator step (a single deploy-pearl-vps.sh run).
+```
+
+## Audit boundaries
+
+Three lanes will fire against the diff:
+
+- **CODE** — shell correctness: `set -euo pipefail`, no
+  word-splitting bugs, no injection surfaces on the `install -m ...`
+  args, `scp` uses `SSH_KEY` variable consistently with other scp
+  invocations in the same script, idempotency logic is correct.
+- **SECURITY** — no privilege escalation surface, no path
+  traversal (temp path is a fixed literal), no config-drift
+  bypass (SKIP_TCP_TUNING escape hatch clearly logs), no impact on
+  existing nginx / gateway / coord auth paths.
+- **ARCHITECT** — placement in deploy script, sub-step numbering
+  choice, file naming (99- prefix appropriate for sysctl.d
+  precedence), consistency with existing dist/ organisation, no
+  scope creep beyond the 4 sysctl keys.
+
+## References
+
+- Inter-token latency bisection data: 2026-07-04 session.
+- Deploy-script step-numbering convention:
+  `phase4-coordinator/dist/deploy-pearl-vps.sh` lines 251-460.
+- Existing test-file shape:
+  `phase4-coordinator/dist/test/check_deploy_config_test.sh`.
+- BBR module availability: Ubuntu 22.04+ kernels ship `tcp_bbr`
+  under `linux-modules-$(uname -r)`; deploy verification checks
+  this at run time rather than in this PR.

--- a/specs/FIX_PEARL_TCP_TUNING_R1_PROMPT.md
+++ b/specs/FIX_PEARL_TCP_TUNING_R1_PROMPT.md
@@ -1,0 +1,157 @@
+# FIX_PEARL_TCP_TUNING_R1 — apply R1 MEDIUM findings
+
+Round 1 audit MEDIUM findings that MUST be fixed before ship. All
+LOW / INFO findings ship as-is with PR-body documentation.
+
+## ARCHITECT MEDIUM #1 — verification enumerates keys inline
+
+**File:** `phase4-coordinator/dist/deploy-pearl-vps.sh` around
+line 546 (the per-key `sysctl -n` verification block).
+
+**Defect:** the verification loop hardcodes the four sysctl keys in
+the shell script. Adding a fifth key requires editing deploy logic,
+not just the `.conf` file, which contradicts the BUILD prompt § 5
+"Extensibility" requirement that the file should be the source of
+truth.
+
+**Fix:**
+
+1. Parse expected `key=value` pairs from `$tmp_conf` at deploy time.
+   Use a small awk/sed loop that skips blank lines and `#` comments.
+2. Iterate over the parsed pairs; for each, `sysctl -n "$key"` on
+   Pearl and compare against the expected value.
+3. On mismatch, emit the same fail-loud message shape as today
+   (name the key, name expected, name actual).
+4. The four current keys should produce byte-identical behaviour to
+   the pre-fix code. Verify by re-running
+   `bash phase4-coordinator/dist/test/check_pearl_tcp_test.sh`.
+
+Idiomatic shell for the parse (adjust to match repo style):
+
+```bash
+while IFS='=' read -r key expected_value; do
+    [ -z "$key" ] || [ "${key:0:1}" = "#" ] && continue
+    key="$(echo "$key" | sed -E 's/^ +| +$//g')"
+    expected_value="$(echo "$expected_value" | sed -E 's/^ +| +$//g')"
+    actual="$(sysctl -n "$key" 2>/dev/null || true)"
+    if [ "$actual" != "$expected_value" ]; then
+        die "sysctl mismatch: $key expected=$expected_value actual=$actual"
+    fi
+done < "$tmp_conf"
+```
+
+## ARCHITECT MEDIUM #2 — BBR boot persistence
+
+**File:** `phase4-coordinator/dist/deploy-pearl-vps.sh` around
+line 524 (the `modprobe tcp_bbr` load site).
+
+**Defect:** `modprobe tcp_bbr` loads the module NOW, but does not
+guarantee it is loaded on future reboots BEFORE `systemd-sysctl.service`
+applies `/etc/sysctl.d/99-macprovider-tcp.conf`. If BBR isn't loaded
+when the sysctl runs, the kernel may silently fall back to cubic or
+fail to apply.
+
+**Fix:**
+
+1. Add a companion `phase4-coordinator/dist/modules-load.d/tcp_bbr.conf`
+   file with a single line `tcp_bbr` and a top-of-file comment
+   explaining what it does (mirror the sysctl.conf's comment style).
+2. In step 3b/9, `scp` and `install -m 0644 -o root -g root` this
+   file to `/etc/modules-load.d/tcp_bbr.conf` alongside the sysctl
+   file.
+3. Extend the test file
+   `phase4-coordinator/dist/test/check_pearl_tcp_test.sh` to assert:
+   a. the new artifact exists at the expected repo path
+   b. it contains exactly `tcp_bbr` as its non-comment content
+   c. the deploy script installs it with the same install invocation
+      style as the sysctl file
+4. Idempotency: same `cmp -s` check as the sysctl file.
+5. Comment placement in the deploy script step: "modules-load.d
+   ensures tcp_bbr is loaded before systemd-sysctl at boot".
+
+## ARCHITECT MEDIUM #3 — historical macprovider sysctl detection
+
+**File:** `phase4-coordinator/dist/deploy-pearl-vps.sh` around
+line 521 (before the install step).
+
+**Defect:** the step installs
+`/etc/sysctl.d/99-macprovider-tcp.conf` but does not detect other
+`/etc/sysctl.d/*macprovider*` files that may exist from a previous
+deploy or a historical experiment. This creates ambiguous ownership.
+
+**Fix:**
+
+1. Before install, list any `/etc/sysctl.d/*macprovider*` files
+   whose basename is NOT `99-macprovider-tcp.conf`.
+2. If any are found, log a WARN line naming each one, and continue
+   the deploy (do not fail-loud — this is a hygiene concern, not
+   a correctness gate).
+3. WARN message shape:
+   `log "  WARN: found unexpected macprovider sysctl artifacts on Pearl:"`
+   followed by one indented line per file, then
+   `log "  These are not managed by this deploy; consider removing after verifying they are stale."`
+4. Extend the test file to assert the deploy script contains the
+   detection loop (grep for the `WARN` message shape).
+
+## SECURITY MEDIUM — rollback command on partial-apply failure
+
+**File:** `phase4-coordinator/dist/deploy-pearl-vps.sh` around
+line 561 (the failure branch after `sysctl -p "$dst"` or
+verification).
+
+**Defect:** the failure messages after step 3b/9 partial-apply do
+not tell the operator how to roll back. Kernel TCP state may have
+been mutated between `sysctl -p` succeeding and verification
+failing.
+
+**Fix:**
+
+1. Add a helper function OR inline the rollback text at every step
+   3b/9 failure site:
+   ```
+   die "  step 3b/9 failure — kernel TCP state may be partially mutated.
+     Rollback: sudo rm /etc/sysctl.d/99-macprovider-tcp.conf /etc/modules-load.d/tcp_bbr.conf && sudo sysctl --system
+     Then investigate the failure above before re-running the deploy."
+   ```
+2. The failure sites to cover:
+   a. `sysctl -p "$dst"` non-zero exit
+   b. Per-key verification mismatch
+   c. Post-apply `net.ipv4.tcp_congestion_control` != `bbr`
+3. The rollback message should NOT print on:
+   a. BBR module missing (nothing mutated yet)
+   b. `SKIP_TCP_TUNING=1` skip path
+   c. `install` failure (file wasn't in place yet)
+
+## What NOT to fix in this round
+
+Per repo convention (stop-iterating-on-LOWs), all R1 LOWs ship
+with PR-body documentation and are NOT fixed in this round:
+
+- CODE LOW — `SKIP_TCP_TUNING=1` log message wording mismatch
+  (current: `... set — skipping TCP sysctl overrides`; requested by
+  auditor: `... bypassing TCP kernel tuning`). Log-message taste.
+- SECURITY LOW — precedence collision check against
+  `/etc/sysctl.d/99-sysctl.conf` and later files. Reasonable
+  hygiene concern, deferred as follow-up.
+- ARCHITECT LOW — Makefile is out-of-scope for this lane but is
+  intentional (wires the new test into `test-dist`). No fix
+  required.
+
+## Deliverables
+
+- `phase4-coordinator/dist/deploy-pearl-vps.sh` updated with the
+  four fixes above.
+- New file `phase4-coordinator/dist/modules-load.d/tcp_bbr.conf`.
+- `phase4-coordinator/dist/test/check_pearl_tcp_test.sh` extended
+  with new assertions.
+- No changes outside R1 scope.
+
+## After finishing
+
+1. `bash phase4-coordinator/dist/test/check_pearl_tcp_test.sh` must
+   pass.
+2. `bash phase4-coordinator/dist/test/check_deploy_config_test.sh`
+   and all other existing dist/test/ files must still pass.
+3. `make test-dist` must complete without regression.
+4. Print a short summary of applied fixes ordered
+   (ARCH-M1, ARCH-M2, ARCH-M3, SEC-M).


### PR DESCRIPTION
## Summary

Two new dist artifacts (`sysctl.d/99-macprovider-tcp.conf` and `modules-load.d/tcp_bbr.conf`) plus a `deploy-pearl-vps.sh` step 3b/9 that installs, applies, and verifies them. Targets the ~240 ms tail latency added by the M5→Pearl WAN path in the 2026-07-04 inter-token bisection.

## Motivation — measured data

Inter-token latency for a 500-token buyer stream via `api.streamvc.live`:

| Path | median | p95 | p99 | max |
|---|---:|---:|---:|---:|
| M5 → api.streamvc.live (WAN + nginx + coord + provider) | 22.6 ms | 90.4 ms | 131.9 ms | **364 ms** |
| Pearl → localhost:9443 (no nginx, no TLS, no WAN) | 25.7 ms | 75.2 ms | 100.2 ms | **122 ms** |

Pearl-localhost caps at ~122 ms max stall; the WAN adds up to another ~240 ms. Root cause is TCP-level jitter under bufferbloat + congestion-window reset after WSS idle. Four sysctl overrides address this at the kernel level without touching any application code.

## Change

- **`phase4-coordinator/dist/sysctl.d/99-macprovider-tcp.conf`** (new) — 4 keys:
  ```
  net.ipv4.tcp_congestion_control=bbr
  net.ipv4.tcp_slow_start_after_idle=0
  net.core.rmem_max=16777216
  net.core.wmem_max=16777216
  ```
- **`phase4-coordinator/dist/modules-load.d/tcp_bbr.conf`** (new) — 1-line `tcp_bbr` so `systemd-modules-load.service` loads BBR before `systemd-sysctl.service` at boot.
- **`deploy-pearl-vps.sh` step 3b/9**:
  1. Scans `/etc/sysctl.d/*macprovider*` and WARN-logs stale historical files.
  2. `modprobe -n -v tcp_bbr` availability check; fail-loud if module missing (message names `uname -r` and points at `linux-modules-extra-$(uname -r)`).
  3. `modprobe tcp_bbr` load.
  4. `install -m 0644 -o root -g root` both artifacts.
  5. `sysctl -p /etc/sysctl.d/99-macprovider-tcp.conf`.
  6. Parse expected `key=value` pairs from the `.conf` at deploy time and verify each via `sysctl -n` (file-as-source-of-truth — adding a fifth key later needs no shell change).
  7. Post-verify `net.ipv4.tcp_congestion_control == bbr`.
  8. Idempotent: `cmp -s` against on-disk copy skips re-install cleanly.
- **`SKIP_TCP_TUNING=1`** env escape hatch that logs the skip clearly.
- **Failure paths** that occur after kernel state may have been mutated (sysctl -p failure, key mismatch, BBR-verification mismatch) print the explicit rollback command:
  ```
  sudo rm /etc/sysctl.d/99-macprovider-tcp.conf /etc/modules-load.d/tcp_bbr.conf && sudo sysctl --system
  ```
- **`check_pearl_tcp_test.sh`** (new, offline) — validates both artifact files' content byte-for-byte, then asserts the deploy script contains the expected install/apply/verify invocations and the WARN scan. Wired into `test-dist`.

## Audit convergence — three codex lanes

- **CODE R1**: 0 C/H/M / 1 LOW.
  - L: `SKIP_TCP_TUNING=1` log message wording nit ("skipping TCP sysctl overrides" vs "bypassing TCP kernel tuning"). Log-message taste; ship as-is.
- **SECURITY R1**: 0 C/H / **1 MEDIUM** / 1 LOW.
  - M: no rollback command in partial-apply failure messages → fixed via explicit rollback text at each failure site.
  - L: no precedence-collision detection against `/etc/sysctl.d/99-sysctl.conf` and later files. Reasonable follow-up hygiene; ship as-is.
- **ARCHITECT R1**: 0 C/H / **3 MEDIUM** / 1 LOW.
  - M1: verification enumerated keys inline (spec violation) → fixed via `while IFS='=' read -r key expected_value` loop over `$tmp_conf`.
  - M2: no BBR boot persistence → fixed via `modules-load.d/tcp_bbr.conf` + matching install / apply / verify steps.
  - M3: no detection of historical `*macprovider*` sysctl artifacts → fixed via WARN scan before install.
  - L: Makefile touched (out of pure ARCHITECT lane scope) — intentional, wires the new test into `test-dist`.
- **CODE R2 · SECURITY R2 · ARCHITECT R2**: 0/0/0/0/0 across all three lanes.

## Deferred R1 LOWs (shipped in PR body)

- CODE L1 — `SKIP_TCP_TUNING=1` log-message wording.
- SECURITY L1 — precedence collision check against later sysctl.d files. Follow-up if we ever observe drift.
- ARCHITECT L1 — Makefile scope (intentional).

## Test plan

- [x] `bash phase4-coordinator/dist/test/check_pearl_tcp_test.sh` green.
- [x] `make test-dist` full suite green (no regression on 53 pre-existing checks).
- [x] `bash -n phase4-coordinator/dist/deploy-pearl-vps.sh` clean.
- [x] `git diff --check` clean.
- [ ] CI green on this PR (pending).

## Non-goals + Not-in-scope

- No nginx / gateway / coord / provider code changes.
- No firewall / ufw / iptables changes.
- No IPv6 sysctl knobs, no qdisc changes (fq_codel etc.), no `tcp_notsent_lowat` — future PRs if measured need.
- **Not deployed by this PR.** Merging lands the artifacts. Actually applying on Pearl is a follow-up operator step: run `phase4-coordinator/dist/deploy-pearl-vps.sh`, which will apply step 3b/9 alongside the existing 4-9 steps. Plan is to batch with the A1a gateway deploy in a single Pearl session.

## Rollback

If step 3b/9 fails mid-apply, the operator sees the exact command in the failure message. Manual rollback also available:

```bash
ssh pearl
sudo rm /etc/sysctl.d/99-macprovider-tcp.conf /etc/modules-load.d/tcp_bbr.conf
sudo sysctl --system   # re-applies all remaining /etc/sysctl.d/*.conf; effectively restores kernel defaults for the 4 keys we set
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
