### PR TITLE
chore(release): bump binaryVersion to 1.8.1

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.0"
+    static let binaryVersion = "1.8.1"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1481,10 +1481,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.0")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.0")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.0")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.0")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.1")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.1")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.1")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.1")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {


### PR DESCRIPTION
## Summary

- Bump `CoordinatorClient.binaryVersion` from `"1.8.0"` to `"1.8.1"`
- Update `CoordinatorClientTests` version assertions in lockstep (4 sites)

## Contents of the v1.8.1 canary

Everything on `main` between v1.8.0 and this bump:

- **#351 A1a** — gateway retry-with-backoff on coord `503 no_provider_available` (gateway-side; provider only sees fewer visible 503s)
- **#354** — money-path harness hardening (billing, streaming reconciliation)
- **#355 B1** — provider IdlePrewarmer keeps MLX Metal warm during idle. Landing this on the wire is the entire motivation for cutting v1.8.1 today.
- **#356 C1** — Pearl VPS TCP sysctl (kernel-side; already deployed to Pearl)
- **#357** — coordinator.yaml provenance

## Why prerelease

v1.8.0 is still the mlx-swift-lm migration canary. Marking v1.8.1 as prerelease keeps the canary channel open while B1 accumulates field data. Publish flow: land this bump → `gh workflow run release.yml -f version=v1.8.1 -f prerelease=true`.

## Test plan

- [x] Local Swift test suite verifies binaryVersion assertion updated
- [ ] CI green on this PR
- [ ] After merge: workflow_dispatch on release.yml with `version=v1.8.1 prerelease=true`
- [ ] Fresh install of published pkg on M5 — confirm `/healthz` reports 1.8.1
- [ ] After 60s of idle on the provider — confirm `idle_prewarm_fired` event in provider logs