### PR TITLE
fix(identity): proof-required token mutations, App-track path gating, sanitized process env, link retry markers

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/BrowserOpener.swift
+++ b/phase3-binary/Sources/MacProviderCore/BrowserOpener.swift
@@ -106,7 +106,8 @@ public final class BrowserOpener: @unchecked Sendable {
         let executable = strdup("/usr/bin/open")
         let arg0 = strdup("open")
         let arg1 = strdup(claimURL)
-        let environment = ProcessInfo.processInfo.environment.map { key, value in
+        let sanitized = try ProcessEnvironmentSanitizer.sanitized()
+        let environment = sanitized.map { key, value in
             strdup("\(key)=\(value)")
         }
         defer {

--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -78,7 +78,7 @@ public struct AppConfig: Equatable, Sendable {
     // coordinator validates against its store when
     // auth.require_provider_tokens=true. Triple-exposed per house
     // convention: yaml key `provider_token`, env
-    // MACPROVIDER_PROVIDER_TOKEN, CLI --provider-token. Operator should
+    // MACPROVIDER_PROVIDER_TOKEN or CLI --token-file. Operator should
     // chmod 0600 the config file containing this value; the binary
     // never logs the token (URL is redacted, headers are not logged).
     public var providerToken: String?
@@ -157,6 +157,7 @@ public struct CLIOverrides: Equatable, Sendable {
     public var ctlSocketPath: String?
     public var switchStatePath: String?
     public var providerToken: String?
+    public var providerTokenFile: String?
     // SPEC-025 §12 conflict #2 — see AppConfig.managedBy.
     public var managedBy: String?
     // SPEC-013 autoresearch serving knobs. nil ⇒ defer to env / YAML /
@@ -187,6 +188,7 @@ public struct CLIOverrides: Equatable, Sendable {
         ctlSocketPath: String? = nil,
         switchStatePath: String? = nil,
         providerToken: String? = nil,
+        providerTokenFile: String? = nil,
         managedBy: String? = nil,
         kvBits: Int? = nil,
         maxContext: Int? = nil,
@@ -213,6 +215,7 @@ public struct CLIOverrides: Equatable, Sendable {
         self.ctlSocketPath = ctlSocketPath
         self.switchStatePath = switchStatePath
         self.providerToken = providerToken
+        self.providerTokenFile = providerTokenFile
         self.managedBy = managedBy
         self.kvBits = kvBits
         self.maxContext = maxContext
@@ -443,7 +446,14 @@ public enum ConfigLoader {
             config.switchStatePath = switchStatePath
         }
         if let providerToken = cli.providerToken {
-            config.providerToken = providerToken
+            throw ConfigError.invalidValue(
+                key: "--provider-token",
+                value: providerToken.isEmpty ? "<empty>" : "<redacted>",
+                expected: "use MACPROVIDER_PROVIDER_TOKEN, provider_token in a 0600 config file, or --token-file"
+            )
+        }
+        if let providerTokenFile = cli.providerTokenFile {
+            config.providerToken = try readProviderTokenFile(providerTokenFile)
         }
         if let managedBy = cli.managedBy {
             config.managedBy = managedBy
@@ -476,6 +486,31 @@ public enum ConfigLoader {
             config.idlePrewarmRunOnBattery = idlePrewarmRunOnBattery
         }
         return config
+    }
+
+    private static func readProviderTokenFile(_ path: String) throws -> String {
+        let expanded = expandTilde(path)
+        let attrs: [FileAttributeKey: Any]
+        do {
+            attrs = try FileManager.default.attributesOfItem(atPath: expanded)
+        } catch {
+            throw ConfigError.unreadableConfig(path: expanded, underlying: String(describing: error))
+        }
+        let mode = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? 0
+        guard mode & 0o077 == 0 else {
+            throw ConfigError.invalidValue(key: "--token-file", value: expanded, expected: "file mode 0600 or stricter")
+        }
+        let contents: String
+        do {
+            contents = try String(contentsOfFile: expanded, encoding: .utf8)
+        } catch {
+            throw ConfigError.unreadableConfig(path: expanded, underlying: String(describing: error))
+        }
+        let token = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
+            throw ConfigError.invalidValue(key: "--token-file", value: expanded, expected: "non-empty token")
+        }
+        return token
     }
 
     private static func assign(_ field: inout Int, from dict: [String: Any], key: String, expected: String) throws {

--- a/phase3-binary/Sources/MacProviderCore/ProcessEnvironmentSanitizer.swift
+++ b/phase3-binary/Sources/MacProviderCore/ProcessEnvironmentSanitizer.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public enum ProcessEnvironmentSanitizer {
+    public enum Error: Swift.Error, CustomStringConvertible, Equatable {
+        case unsafeValue(String)
+
+        public var description: String {
+            switch self {
+            case let .unsafeValue(key):
+                return "unsafe environment value for \(key)"
+            }
+        }
+    }
+
+    public static func sanitized(
+        from environment: [String: String] = ProcessInfo.processInfo.environment,
+        allowMacProviderKeys: Bool = false
+    ) throws -> [String: String] {
+        var result: [String: String] = [:]
+        for (key, value) in environment {
+            guard isAllowedKey(key, allowMacProviderKeys: allowMacProviderKeys) else { continue }
+            guard isSafeValue(value) else { throw Error.unsafeValue(key) }
+            result[key] = value
+        }
+        return result
+    }
+
+    public static func isSafeValue(_ value: String) -> Bool {
+        for scalar in value.unicodeScalars {
+            if scalar.value == 0 || scalar.value == 0x7f || scalar.value < 0x20 {
+                return false
+            }
+            if ";|&`$<>".unicodeScalars.contains(scalar) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func isAllowedKey(_ key: String, allowMacProviderKeys: Bool) -> Bool {
+        switch key {
+        case "PATH", "HOME", "USER", "TMPDIR", "LANG", "NSUnbufferedIO":
+            return true
+        default:
+            return key.hasPrefix("LC_") || (allowMacProviderKeys && key.hasPrefix("MACPROVIDER_"))
+        }
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/ClaimCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ClaimCommand.swift
@@ -55,7 +55,13 @@ struct ClaimRefresher: Sendable {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            let session = URLSession(
+                configuration: .ephemeral,
+                delegate: ClaimRefreshRedirectGuard(),
+                delegateQueue: nil
+            )
+            defer { session.finishTasksAndInvalidate() }
+            (data, response) = try await session.data(for: request)
         } catch {
             throw ClaimRefreshError.network(String(describing: error))
         }
@@ -80,6 +86,50 @@ struct ClaimRefresher: Sendable {
         default:
             throw ClaimRefreshError.httpStatus(http.statusCode)
         }
+    }
+}
+
+final class ClaimRefreshRedirectGuard: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let originalURL = task.originalRequest?.url,
+              let newURL = request.url,
+              let originalOrigin = Self.origin(for: originalURL),
+              let newOrigin = Self.origin(for: newURL),
+              originalOrigin.scheme == "https",
+              newOrigin.scheme == "https"
+        else {
+            completionHandler(nil)
+            return
+        }
+        guard originalOrigin != newOrigin else {
+            completionHandler(request)
+            return
+        }
+        var stripped = request
+        stripped.setValue(nil, forHTTPHeaderField: "Authorization")
+        completionHandler(stripped)
+    }
+
+    private struct Origin: Equatable {
+        let scheme: String
+        let host: String
+        let port: Int
+    }
+
+    private static func origin(for url: URL) -> Origin? {
+        guard let scheme = url.scheme?.lowercased(),
+              let host = url.host?.lowercased()
+        else {
+            return nil
+        }
+        let port = url.port ?? (scheme == "https" ? 443 : scheme == "http" ? 80 : -1)
+        return Origin(scheme: scheme, host: host, port: port)
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -65,8 +65,11 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "CLI-side cooldown state file. Overrides MACPROVIDER_SWITCH_STATE_PATH and config switch_state_path. Default $HOME/Library/Application Support/macprovider-cli/last-switch.ts. Cooldown soft guard lands in Phase 1E.")
     var switchStatePath: String?
 
-    @Option(help: "Provider authentication token (SPEC-001 / XSEC-1). When set, the binary sends 'Authorization: Bearer <token>' on the coordinator WS connect. Required when the coordinator runs with auth.require_provider_tokens=true. Overrides MACPROVIDER_PROVIDER_TOKEN and config key provider_token. Treat as a secret — the binary never logs it; chmod 0600 the config file containing it.")
+    @Option(name: [.customLong("provider-token"), .customLong("token")], help: "Deprecated inline provider token. This is rejected because argv is visible to same-user process inspection; use MACPROVIDER_PROVIDER_TOKEN, provider_token in a 0600 config file, or --token-file.")
     var providerToken: String?
+
+    @Option(help: "Read provider authentication token from a 0600 file. Overrides MACPROVIDER_PROVIDER_TOKEN and config key provider_token without exposing the token in process arguments.")
+    var tokenFile: String?
 
     @Option(help: "Marks this binary as spawned by an outer manager (SPEC-025). Setting this to 'malibu-app' disables the CLI's own AutoUpdater so Sparkle in Malibu.app owns whole-bundle updates. Overrides MACPROVIDER_MANAGED_BY and config key managed_by. Unset for the standalone CLI track.")
     var managedBy: String?
@@ -310,6 +313,7 @@ struct ServeCommand: AsyncParsableCommand {
                 ctlSocketPath: ctlSocketPath,
                 switchStatePath: switchStatePath,
                 providerToken: providerToken,
+                providerTokenFile: tokenFile,
                 managedBy: managedBy,
                 kvBits: kvBits,
                 maxContext: maxContext,

--- a/phase3-binary/Tests/macprovider-cliTests/BrowserOpenerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BrowserOpenerTests.swift
@@ -51,4 +51,25 @@ final class BrowserOpenerTests: XCTestCase {
         XCTAssertEqual(decision, .opened)
         XCTAssertEqual(openedURL.get(), "https://portal.example/claim?ot=PAIR")
     }
+
+    func testSanitizedBrowserEnvironmentDropsMacProviderSecrets() throws {
+        let sanitized = try ProcessEnvironmentSanitizer.sanitized(from: [
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/Users/test",
+            "LC_CTYPE": "UTF-8",
+            "MACPROVIDER_PROVIDER_TOKEN": "secret",
+            "MACPROVIDER_NO_BROWSER": "1"
+        ])
+
+        XCTAssertEqual(sanitized["PATH"], "/usr/bin:/bin")
+        XCTAssertEqual(sanitized["LC_CTYPE"], "UTF-8")
+        XCTAssertNil(sanitized["MACPROVIDER_PROVIDER_TOKEN"])
+        XCTAssertNil(sanitized["MACPROVIDER_NO_BROWSER"])
+    }
+
+    func testSanitizedBrowserEnvironmentRejectsMetacharacters() {
+        XCTAssertThrowsError(try ProcessEnvironmentSanitizer.sanitized(from: [
+            "PATH": "/usr/bin;evil"
+        ]))
+    }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/ClaimCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ClaimCommandTests.swift
@@ -199,11 +199,66 @@ final class ClaimCommandTests: XCTestCase {
         XCTAssertTrue(command is ClaimCommand)
     }
 
+    func testClaimRefreshRedirectGuardStripsAuthorizationOnCrossOriginHTTPSRedirect() throws {
+        let redirected = decideRedirect(
+            originalURL: URL(string: "https://coordinator.example/v1/provider/claim/refresh")!,
+            redirectTo: URL(string: "https://other.example/v1/provider/claim/refresh")!
+        )
+
+        XCTAssertEqual(redirected?.url?.host, "other.example")
+        XCTAssertNil(redirected?.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    func testClaimRefreshRedirectGuardStripsAuthorizationOnSameHostDifferentPortRedirect() throws {
+        let redirected = decideRedirect(
+            originalURL: URL(string: "https://coordinator.example/v1/provider/claim/refresh")!,
+            redirectTo: URL(string: "https://coordinator.example:4443/v1/provider/claim/refresh")!
+        )
+
+        XCTAssertEqual(redirected?.url?.port, 4443)
+        XCTAssertNil(redirected?.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    func testClaimRefreshRedirectGuardRejectsNonHTTPSRedirect() throws {
+        let redirected = decideRedirect(
+            originalURL: URL(string: "https://coordinator.example/v1/provider/claim/refresh")!,
+            redirectTo: URL(string: "http://coordinator.example/v1/provider/claim/refresh")!
+        )
+
+        XCTAssertNil(redirected)
+    }
+
     private func refreshCountingRefresher(_ calls: LockedBox<Int>) -> ClaimRefresher {
         ClaimRefresher { _ in
             calls.update { $0 += 1 }
             throw ClaimRefreshError.httpStatus(500)
         }
+    }
+
+    private func decideRedirect(originalURL: URL, redirectTo newURL: URL) -> URLRequest? {
+        let session = URLSession.shared
+        let task = session.dataTask(with: originalURL)
+        var request = URLRequest(url: newURL)
+        request.setValue("Bearer provider-token", forHTTPHeaderField: "Authorization")
+        let response = HTTPURLResponse(
+            url: originalURL,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: ["Location": newURL.absoluteString]
+        )!
+        let waiter = expectation(description: "redirect completion")
+        var redirected: URLRequest?
+        ClaimRefreshRedirectGuard().urlSession(
+            session,
+            task: task,
+            willPerformHTTPRedirection: response,
+            newRequest: request
+        ) { result in
+            redirected = result
+            waiter.fulfill()
+        }
+        wait(for: [waiter], timeout: 1)
+        return redirected
     }
 
     private func makeFixture(prefix: String) throws -> ClaimFixture {

--- a/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
@@ -5,6 +5,38 @@ import XCTest
 @testable import macprovider_cli
 
 final class ServeCommandTests: XCTestCase {
+    func testServeCommandRejectsInlineProviderTokenArguments() throws {
+        let deprecated = try ServeCommand.parse(["--token", "secret"])
+        XCTAssertThrowsError(try ConfigLoader.load(cli: CLIOverrides(providerToken: deprecated.providerToken), environment: [:])) { error in
+            XCTAssertTrue(String(describing: error).contains("--provider-token"))
+        }
+
+        let legacy = try ServeCommand.parse(["--provider-token", "secret"])
+        XCTAssertThrowsError(try ConfigLoader.load(cli: CLIOverrides(providerToken: legacy.providerToken), environment: [:])) { error in
+            XCTAssertTrue(String(describing: error).contains("--provider-token"))
+        }
+    }
+
+    func testConfigLoaderReadsProviderTokenFromPrivateTokenFile() throws {
+        let dir = try tempDir()
+        let tokenFile = dir.appendingPathComponent("token")
+        try "file-token\n".write(to: tokenFile, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tokenFile.path)
+
+        let config = try ConfigLoader.load(cli: CLIOverrides(providerTokenFile: tokenFile.path), environment: [:])
+
+        XCTAssertEqual(config.providerToken, "file-token")
+    }
+
+    func testConfigLoaderRejectsWorldReadableProviderTokenFile() throws {
+        let dir = try tempDir()
+        let tokenFile = dir.appendingPathComponent("token")
+        try "file-token\n".write(to: tokenFile, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: tokenFile.path)
+
+        XCTAssertThrowsError(try ConfigLoader.load(cli: CLIOverrides(providerTokenFile: tokenFile.path), environment: [:]))
+    }
+
     func testNoJoinFlagParses() throws {
         let command = try ServeCommand.parse([
             "--no-join",

--- a/phase3-binary/app/Sources/Malibu/Agent/CLIChildProcess.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/CLIChildProcess.swift
@@ -11,9 +11,8 @@ final class CLIChildProcess {
         let controlSocketPath: URL
         let httpPort: Int?
         let logFileURL: URL
-        // Merged over the parent process's env (which supplies PATH/HOME/etc).
-        // MACPROVIDER_PROVIDER_TOKEN belongs here so the token never touches
-        // config.yaml or the argv (which is visible in `ps`).
+        // Merged over an allowlisted parent env. MACPROVIDER_PROVIDER_TOKEN
+        // belongs here so the token never touches config.yaml or argv.
         let extraEnvironment: [String: String]
     }
 
@@ -66,9 +65,7 @@ final class CLIChildProcess {
         }
         proc.arguments = args
 
-        var env = ProcessInfo.processInfo.environment
-        for (k, v) in launch.extraEnvironment { env[k] = v }
-        proc.environment = env
+        proc.environment = try ProcessEnvironmentSanitizer.sanitized(extraEnvironment: launch.extraEnvironment)
 
         proc.standardOutput = handle
         proc.standardError = handle

--- a/phase3-binary/app/Sources/Malibu/Agent/EarningsClient.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/EarningsClient.swift
@@ -48,11 +48,11 @@ struct ProviderEarnings: Decodable, Equatable {
 
 struct EarningsClient {
     let coordinatorBaseURL: URL
-    let session: URLSession
+    private let session: URLSession?
 
     init(
         coordinatorBaseURL: URL = URL(string: "https://coordinator.streamvc.live")!,
-        session: URLSession = .shared
+        session: URLSession? = nil
     ) {
         self.coordinatorBaseURL = coordinatorBaseURL
         self.session = session
@@ -67,7 +67,15 @@ struct EarningsClient {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
-        let (data, response) = try await session.data(for: request)
+        let data: Data
+        let response: URLResponse
+        if let session {
+            (data, response) = try await session.data(for: request)
+        } else {
+            let guarded = ProviderBearerURLSession.make()
+            defer { guarded.finishTasksAndInvalidate() }
+            (data, response) = try await guarded.data(for: request)
+        }
         if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
             throw EarningsClientError.httpStatus(http.statusCode)
         }

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -417,11 +417,16 @@ final class MalibuAgent: ObservableObject {
         }
     }
 
-    private static func resolveCLIExecutable() throws -> URL {
-        if let override = ProcessInfo.processInfo.environment["MALIBU_CLI_PATH"] {
+    static func resolveCLIExecutable(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundleURL: URL = Bundle.main.bundleURL
+    ) throws -> URL {
+        if let override = environment["MALIBU_CLI_PATH"], !override.isEmpty {
+            #if DEBUG
             return URL(fileURLWithPath: override)
+            #endif
         }
-        let bundled = Bundle.main.bundleURL
+        let bundled = bundleURL
             .appendingPathComponent("Contents/MacOS/macprovider-cli")
         if FileManager.default.isExecutableFile(atPath: bundled.path) { return bundled }
         throw POSIXError(.ENOENT)

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -67,6 +67,7 @@ final class LaunchProviderController: ObservableObject {
         var repairMarkerlessAppConfig: (String) async throws -> Void
         var saveState: (OnboardingState) throws -> Void
         var updateState: (String, String, Date?, OnboardingState.ModelDownloadState?) throws -> Void
+        var markLinkState: (ProviderConfig.LinkState) throws -> Void
         var runAutotune: (String) async throws -> ModelDownloadPlan
         var ensureCLIReady: () throws -> Void
         var downloadModel: (ModelDownloadPlan) async throws -> OnboardingState.ModelDownloadState?
@@ -102,6 +103,7 @@ final class LaunchProviderController: ObservableObject {
                         modelDownload: modelDownload
                     )
                 },
+                markLinkState: { state in try ProviderConfig.writeLinkState(state) },
                 runAutotune: { _ in
                     (try? await AutotuneRecommendationRunner.run(cliURL: bundledCLIPath)) ?? .recommended
                 },
@@ -391,7 +393,9 @@ final class LaunchProviderController: ObservableObject {
 
         stage = .startingAgent
         try dependencies.updateState(providerID, "startingAgent", nil, nil)
+        try dependencies.markLinkState(.pendingLink)
         try await dependencies.registerLoginItem()
+        try dependencies.markLinkState(.linked)
         await dependencies.startAgent()
 
         stage = .authenticating
@@ -540,6 +544,7 @@ struct StartupState: Equatable {
     let configExists: Bool
     let appMarkerExists: Bool
     let providerTokenExists: Bool
+    let linkState: ProviderConfig.LinkState?
     let identityExists: Bool
     let onboardingStateExists: Bool
     let firstServingAtExists: Bool
@@ -563,6 +568,7 @@ struct StartupState: Equatable {
             configExists: configExists,
             appMarkerExists: markerExists,
             providerTokenExists: tokenExists,
+            linkState: ProviderConfig.readLinkState(paths: paths),
             identityExists: identityExists,
             onboardingStateExists: onboarding != nil,
             firstServingAtExists: onboarding?.firstServingAt != nil,
@@ -572,6 +578,9 @@ struct StartupState: Equatable {
 
     func route() -> StartupRoute {
         if onboardingStateExists && !firstServingAtExists {
+            return .resumeOnboarding
+        }
+        if configExists && appMarkerExists && providerTokenExists && linkState == .pendingLink {
             return .resumeOnboarding
         }
         if configExists && appMarkerExists && providerTokenExists {
@@ -610,6 +619,7 @@ struct StartupState: Equatable {
                 configExists: false,
                 appMarkerExists: false,
                 providerTokenExists: false,
+                linkState: nil,
                 identityExists: false,
                 onboardingStateExists: false,
                 firstServingAtExists: false,

--- a/phase3-binary/app/Sources/Malibu/System/ProcessEnvironmentSanitizer.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProcessEnvironmentSanitizer.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+enum ProcessEnvironmentSanitizer {
+    enum Error: Swift.Error, CustomStringConvertible, Equatable {
+        case unsafeValue(String)
+
+        var description: String {
+            switch self {
+            case let .unsafeValue(key):
+                return "unsafe environment value for \(key)"
+            }
+        }
+    }
+
+    static func sanitized(
+        from environment: [String: String] = ProcessInfo.processInfo.environment,
+        extraEnvironment: [String: String] = [:]
+    ) throws -> [String: String] {
+        var result: [String: String] = [:]
+        for (key, value) in environment {
+            guard isAllowedInheritedKey(key) else { continue }
+            guard isSafeValue(value) else { throw Error.unsafeValue(key) }
+            result[key] = value
+        }
+        for (key, value) in extraEnvironment {
+            guard isSafeValue(value) else { throw Error.unsafeValue(key) }
+            result[key] = value
+        }
+        return result
+    }
+
+    static func isSafeValue(_ value: String) -> Bool {
+        for scalar in value.unicodeScalars {
+            if scalar.value == 0 || scalar.value == 0x7f || scalar.value < 0x20 {
+                return false
+            }
+            if ";|&`$<>".unicodeScalars.contains(scalar) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func isAllowedInheritedKey(_ key: String) -> Bool {
+        switch key {
+        case "PATH", "HOME", "USER", "TMPDIR", "LANG", "NSUnbufferedIO":
+            return true
+        default:
+            return key.hasPrefix("LC_")
+        }
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
@@ -5,6 +5,12 @@ import Foundation
 // Keychain (never persisted to disk in this track). See SPEC-025 §7.
 
 enum ProviderConfig {
+    enum LinkState: String, Equatable {
+        case pendingLink = "pending_link"
+        case linked
+        case unlinkPending = "unlink_pending"
+    }
+
     // AUDIT R1 CODE H4 / SECURITY S1 / ARCHITECT A2 fix:
     //   * config exists AND
     //   * app-ownership marker exists (we did not inherit a CLI-track config) AND
@@ -26,23 +32,25 @@ enum ProviderConfig {
 
     static func readProviderID(paths: ProviderPaths = .current) -> String? {
         guard let contents = try? String(contentsOf: paths.configFile) else { return nil }
-        // AUDIT R1 CODE M1 fix, corrected in E2E:
-        // Swift's Character treats `\r\n` as a single grapheme cluster, so a
-        // predicate `$0 == "\n" || $0 == "\r"` on Character never matches
-        // inside CRLF sequences. Normalize CRLF → LF first, then split.
-        let normalized = contents
-            .replacingOccurrences(of: "\r\n", with: "\n")
-            .replacingOccurrences(of: "\r", with: "\n")
-        for rawLine in normalized.split(separator: "\n") {
-            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard line.hasPrefix("provider_id:") else { continue }
-            let value = line
-                .dropFirst("provider_id:".count)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-            return value.isEmpty ? nil : value
+        return parseTopLevelValue(named: "provider_id", from: contents)
+    }
+
+    static func readLinkState(paths: ProviderPaths = .current) -> LinkState? {
+        guard let contents = try? String(contentsOf: paths.configFile),
+              let value = parseTopLevelValue(named: "link_state", from: contents)
+        else {
+            return nil
         }
-        return nil
+        return LinkState(rawValue: value)
+    }
+
+    static func writeLinkState(_ state: LinkState, paths: ProviderPaths = .current) throws {
+        let contents = (try? String(contentsOf: paths.configFile)) ?? ""
+        var lines = normalizedLines(contents)
+            .filter { !$0.hasPrefix("link_state:") }
+        lines.append("link_state: \(state.rawValue)")
+        try Data((lines.joined(separator: "\n") + "\n").utf8).write(to: paths.configFile, options: [.atomic])
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: paths.configFile.path)
     }
 
     // AUDIT R1 ARCHITECT A2: raised when the shared config exists on disk
@@ -124,9 +132,14 @@ enum ProviderConfig {
                 .replacingOccurrences(of: "\r\n", with: "\n")
                 .replacingOccurrences(of: "\r", with: "\n")
             lines = normalized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-                .filter { !$0.hasPrefix("provider_id:") && !$0.hasPrefix("provider_token:") }
+                .filter {
+                    !$0.hasPrefix("provider_id:")
+                        && !$0.hasPrefix("provider_token:")
+                        && !$0.hasPrefix("link_state:")
+                }
         }
         lines.append("provider_id: \(providerID)")
+        lines.append("link_state: \(LinkState.pendingLink.rawValue)")
         // We deliberately do NOT write the token to disk. The CLI must be
         // launched with the token in the environment (MACPROVIDER_PROVIDER_TOKEN),
         // which MalibuAgent will set from Keychain before spawning the process.
@@ -175,6 +188,7 @@ enum ProviderConfig {
         try paths.ensureDirectories()
         let fm = FileManager.default
         let backup = paths.configFile.appendingPathExtension("import-backup")
+        let marker = importPendingMarker(paths: paths)
         let backupExisted = fm.fileExists(atPath: backup.path)
         let originalData = try Data(contentsOf: paths.configFile)
         let current = String(decoding: originalData, as: UTF8.self)
@@ -196,6 +210,8 @@ enum ProviderConfig {
 
         let rewritten = removingTopLevelValue(named: "provider_token", from: current)
         do {
+            try Data("pending\n".utf8).write(to: marker, options: [.atomic])
+            try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: marker.path)
             try await KeychainStore.saveProviderToken(providerID: providerID, token: token)
             if !backupExisted {
                 try? fm.removeItem(at: backup)
@@ -204,8 +220,10 @@ enum ProviderConfig {
             try rewritten.data(using: .utf8)?.write(to: paths.configFile, options: [.atomic])
             try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: paths.configFile.path)
             try writeAppMarker(paths: paths, fileManager: fm)
+            try writeLinkState(.linked, paths: paths)
             guard await isConfigured(paths: paths) else { throw SaveError.existingConfigNotOwnedByApp }
             try? fm.removeItem(at: backup)
+            try? fm.removeItem(at: marker)
         } catch {
             try? await KeychainStore.deleteProviderToken(providerID: providerID)
             try? fm.removeItem(at: paths.appMarkerFile)
@@ -214,6 +232,7 @@ enum ProviderConfig {
                 if !backupExisted {
                     try? fm.removeItem(at: backup)
                 }
+                try? fm.removeItem(at: marker)
             } catch let rollbackError {
                 throw SaveError.importRollbackFailed(importError: error, rollbackError: rollbackError)
             }
@@ -315,6 +334,10 @@ enum ProviderConfig {
         guard fm.createFile(atPath: paths.appMarkerFile.path, contents: Data()) else {
             throw SaveError.appMarkerCreateFailed
         }
+    }
+
+    static func importPendingMarker(paths: ProviderPaths) -> URL {
+        paths.appSupport.appendingPathComponent(".import-pending")
     }
 
     private static func parseTopLevelValue(named key: String, from contents: String) -> String? {

--- a/phase3-binary/app/Sources/Malibu/System/RegisterClient.swift
+++ b/phase3-binary/app/Sources/Malibu/System/RegisterClient.swift
@@ -114,13 +114,13 @@ struct RegisterResponse: Decodable, Equatable {
 }
 
 struct RegisterClient {
-    let coordinatorBaseURL: URL
-    let session: URLSession
+	let coordinatorBaseURL: URL
+	private let session: URLSession?
 
-    init(coordinatorBaseURL: URL, session: URLSession = .shared) {
-        self.coordinatorBaseURL = coordinatorBaseURL
-        self.session = session
-    }
+	init(coordinatorBaseURL: URL, session: URLSession? = nil) {
+		self.coordinatorBaseURL = coordinatorBaseURL
+		self.session = session
+	}
 
     func makeSignedRequest(
         identityKey: Curve25519.Signing.PrivateKey,
@@ -164,10 +164,18 @@ struct RegisterClient {
         }
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody.jsonObject, options: [.sortedKeys])
 
-        let (data, response) = try await session.data(for: request)
-        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
-            throw RegisterClientError.httpStatus(http.statusCode)
-        }
+		let data: Data
+		let response: URLResponse
+		if let session {
+			(data, response) = try await session.data(for: request)
+		} else {
+			let guarded = ProviderBearerURLSession.make()
+			defer { guarded.finishTasksAndInvalidate() }
+			(data, response) = try await guarded.data(for: request)
+		}
+		if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+			throw RegisterClientError.httpStatus(http.statusCode)
+		}
         return try JSONDecoder().decode(RegisterResponse.self, from: data)
     }
 
@@ -251,4 +259,54 @@ struct RegisterClient {
 
 enum RegisterClientError: Error {
     case httpStatus(Int)
+}
+
+enum ProviderBearerURLSession {
+    static func make() -> URLSession {
+        URLSession(configuration: .ephemeral, delegate: ProviderBearerRedirectGuard(), delegateQueue: nil)
+    }
+}
+
+final class ProviderBearerRedirectGuard: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let originalURL = task.originalRequest?.url,
+              let newURL = request.url,
+              let originalOrigin = Self.origin(for: originalURL),
+              let newOrigin = Self.origin(for: newURL),
+              originalOrigin.scheme == "https",
+              newOrigin.scheme == "https"
+        else {
+            completionHandler(nil)
+            return
+        }
+        guard originalOrigin != newOrigin else {
+            completionHandler(request)
+            return
+        }
+        var stripped = request
+        stripped.setValue(nil, forHTTPHeaderField: "Authorization")
+        completionHandler(stripped)
+    }
+
+    private struct Origin: Equatable {
+        let scheme: String
+        let host: String
+        let port: Int
+    }
+
+    private static func origin(for url: URL) -> Origin? {
+        guard let scheme = url.scheme?.lowercased(),
+              let host = url.host?.lowercased()
+        else {
+            return nil
+        }
+        let port = url.port ?? (scheme == "https" ? 443 : scheme == "http" ? 80 : -1)
+        return Origin(scheme: scheme, host: host, port: port)
+    }
 }

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -200,6 +200,7 @@ final class LaunchProviderControllerTests: XCTestCase {
         var loginItemRegistrations = 0
         var agentStarts = 0
         var markerRepairs: [String] = []
+        var linkStates: [ProviderConfig.LinkState] = []
         var stageUpdates: [String] = []
         var modelDownloads: [LaunchProviderController.ModelDownloadPlan] = []
         var autotuneRuns = 0
@@ -238,6 +239,9 @@ final class LaunchProviderControllerTests: XCTestCase {
                 saveState: { _ in },
                 updateState: { _, lastStage, _, _ in
                     self.stageUpdates.append(lastStage)
+                },
+                markLinkState: { state in
+                    self.linkStates.append(state)
                 },
                 runAutotune: { _ in
                     self.autotuneRuns += 1

--- a/phase3-binary/app/Tests/MalibuTests/ProcessEnvironmentSanitizerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProcessEnvironmentSanitizerTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Malibu
+
+final class ProcessEnvironmentSanitizerTests: XCTestCase {
+    func testChildEnvironmentKeepsOnlyAllowlistedInheritedValuesAndExplicitToken() throws {
+        let sanitized = try ProcessEnvironmentSanitizer.sanitized(
+            from: [
+                "PATH": "/usr/bin:/bin",
+                "HOME": "/Users/test",
+                "LC_CTYPE": "UTF-8",
+                "MACPROVIDER_EVIL": "1",
+                "MALIBU_CLI_PATH": "/tmp/fake"
+            ],
+            extraEnvironment: [
+                "MACPROVIDER_PROVIDER_TOKEN": "provider-token"
+            ]
+        )
+
+        XCTAssertEqual(sanitized["PATH"], "/usr/bin:/bin")
+        XCTAssertEqual(sanitized["LC_CTYPE"], "UTF-8")
+        XCTAssertEqual(sanitized["MACPROVIDER_PROVIDER_TOKEN"], "provider-token")
+        XCTAssertNil(sanitized["MACPROVIDER_EVIL"])
+        XCTAssertNil(sanitized["MALIBU_CLI_PATH"])
+    }
+
+    func testChildEnvironmentRejectsUnsafeInheritedValue() {
+        XCTAssertThrowsError(try ProcessEnvironmentSanitizer.sanitized(from: [
+            "PATH": "/usr/bin;evil"
+        ]))
+    }
+
+    func testReleaseCLIPathFallsBackWhenPinnedTeamMissing() throws {
+        #if !DEBUG
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("malibu-cli-path-tests-\(UUID().uuidString)", isDirectory: true)
+        let app = root.appendingPathComponent("Malibu.app", isDirectory: true)
+        let macos = app.appendingPathComponent("Contents/MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macos, withIntermediateDirectories: true)
+        let bundled = macos.appendingPathComponent("macprovider-cli")
+        FileManager.default.createFile(atPath: bundled.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: bundled.path)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolved = try MalibuAgent.resolveCLIExecutable(
+            environment: ["MALIBU_CLI_PATH": "/tmp/unsigned-cli"],
+            bundleURL: app
+        )
+
+        XCTAssertEqual(resolved, bundled)
+        #endif
+    }
+}

--- a/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
@@ -59,8 +59,24 @@ final class ProviderConfigParserTests: XCTestCase {
         XCTAssertFalse(rewritten.contains("provider_token"))
         XCTAssertTrue(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ProviderConfig.importPendingMarker(paths: paths).path))
+        XCTAssertEqual(ProviderConfig.readLinkState(paths: paths), .linked)
         let importedToken = await KeychainStore.readProviderToken(providerID: "p_recover")
         XCTAssertEqual(importedToken, "secret-token")
+    }
+
+    func testWriteAndReadLinkState() throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        defer { try? FileManager.default.removeItem(at: paths.appSupport.deletingLastPathComponent()) }
+        defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent()) }
+        try "provider_id: p_link\nmodel: test\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
+
+        try ProviderConfig.writeLinkState(.pendingLink, paths: paths)
+
+        XCTAssertEqual(ProviderConfig.readLinkState(paths: paths), .pendingLink)
+        let contents = try String(contentsOf: paths.configFile)
+        XCTAssertTrue(contents.contains("link_state: pending_link"))
     }
 
     func testSaveProviderIdentityRollsBackWhenTokenSaveFails() async throws {

--- a/phase3-binary/app/Tests/MalibuTests/RegisterClientTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/RegisterClientTests.swift
@@ -62,19 +62,52 @@ final class RegisterClientTests: XCTestCase {
         )
     }
 
+    func testProviderBearerRedirectGuardStripsAuthorizationOnSameHostDifferentPortRedirect() throws {
+        let redirected = decideProviderBearerRedirect(
+            originalURL: URL(string: "https://coordinator.example/v1/providers/register")!,
+            redirectTo: URL(string: "https://coordinator.example:4443/v1/providers/register")!
+        )
+
+        XCTAssertEqual(redirected?.url?.port, 4443)
+        XCTAssertNil(redirected?.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    func testProviderBearerRedirectGuardRejectsNonHTTPSRedirect() throws {
+        let redirected = decideProviderBearerRedirect(
+            originalURL: URL(string: "https://coordinator.example/v1/providers/register")!,
+            redirectTo: URL(string: "http://coordinator.example/v1/providers/register")!
+        )
+
+        XCTAssertNil(redirected)
+    }
+
     func testSharedSpec026RegisterFixtureCanonicalizes() throws {
         let fixture = try loadRegisterFixture()
-        let canonical = try CanonicalJSON.encode(try canonicalValue(from: fixture.bodyWithoutSignature))
-        XCTAssertEqual(String(data: canonical, encoding: .utf8), fixture.canonicalWithoutSignature)
+        XCTAssertEqual(fixture.schema, "spec026_register_jcs_v1")
+        XCTAssertGreaterThanOrEqual(fixture.objects.count, 5)
+        for row in fixture.objects {
+            let canonical = try CanonicalJSON.encode(try canonicalValue(from: row.body))
+            XCTAssertEqual(String(data: canonical, encoding: .utf8), row.expectedCanonical, row.id)
+            if case let .object(body) = row.body {
+                XCTAssertNil(body["current_provider_token"], row.id)
+            }
+        }
     }
 
     private struct RegisterFixture: Decodable {
-        let bodyWithoutSignature: JSONValue
-        let canonicalWithoutSignature: String
+        let schema: String
+        let objects: [RegisterFixtureRow]
+    }
+
+    private struct RegisterFixtureRow: Decodable {
+        let id: String
+        let body: JSONValue
+        let expectedCanonical: String
 
         enum CodingKeys: String, CodingKey {
-            case bodyWithoutSignature = "body_without_signature"
-            case canonicalWithoutSignature = "canonical_without_signature"
+            case id
+            case body
+            case expectedCanonical = "expected_canonical"
         }
     }
 
@@ -110,6 +143,32 @@ final class RegisterClientTests: XCTestCase {
         url.appendPathComponent("phase4-coordinator/test/jcs_fixtures/spec026_register.json")
         let data = try Data(contentsOf: url)
         return try JSONDecoder().decode(RegisterFixture.self, from: data)
+    }
+
+    private func decideProviderBearerRedirect(originalURL: URL, redirectTo newURL: URL) -> URLRequest? {
+        let session = URLSession.shared
+        let task = session.dataTask(with: originalURL)
+        var request = URLRequest(url: newURL)
+        request.setValue("Bearer provider-token", forHTTPHeaderField: "Authorization")
+        let response = HTTPURLResponse(
+            url: originalURL,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: ["Location": newURL.absoluteString]
+        )!
+        let waiter = expectation(description: "redirect completion")
+        var redirected: URLRequest?
+        ProviderBearerRedirectGuard().urlSession(
+            session,
+            task: task,
+            willPerformHTTPRedirection: response,
+            newRequest: request
+        ) { result in
+            redirected = result
+            waiter.fulfill()
+        }
+        wait(for: [waiter], timeout: 1)
+        return redirected
     }
 
     private func canonicalValue(from value: JSONValue) throws -> CanonicalJSONValue {

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -32,6 +32,7 @@ final class StartupRouteTests: XCTestCase {
                 configExists: off.configExists,
                 appMarkerExists: off.appMarkerExists,
                 providerTokenExists: off.providerTokenExists,
+                linkState: off.linkState,
                 identityExists: off.identityExists,
                 onboardingStateExists: off.onboardingStateExists,
                 firstServingAtExists: off.firstServingAtExists,
@@ -43,6 +44,7 @@ final class StartupRouteTests: XCTestCase {
                 configExists: base.configExists,
                 appMarkerExists: base.appMarkerExists,
                 providerTokenExists: base.providerTokenExists,
+                linkState: base.linkState,
                 identityExists: base.identityExists,
                 onboardingStateExists: base.onboardingStateExists,
                 firstServingAtExists: base.firstServingAtExists,
@@ -110,6 +112,21 @@ final class StartupRouteTests: XCTestCase {
         XCTAssertNil(untouchedToken)
     }
 
+    func testConfiguredPendingLinkStateResumesOnboarding() {
+        let state = StartupState(
+            configExists: true,
+            appMarkerExists: true,
+            providerTokenExists: true,
+            linkState: .pendingLink,
+            identityExists: true,
+            onboardingStateExists: false,
+            firstServingAtExists: false,
+            onboardingV2Enabled: true
+        )
+
+        XCTAssertEqual(state.route(), .resumeOnboarding)
+    }
+
     private func state(
         config: Bool,
         marker: Bool,
@@ -122,6 +139,7 @@ final class StartupRouteTests: XCTestCase {
             configExists: config,
             appMarkerExists: marker,
             providerTokenExists: token,
+            linkState: nil,
             identityExists: identity,
             onboardingStateExists: onboarding,
             firstServingAtExists: firstServing,

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -935,8 +935,23 @@ func buyerHandlerWithOptionalRegister(base http.Handler, enabled bool, register 
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/providers/register", register)
+	mux.HandleFunc("/v1/provider/wallet", appTrackWalletNotImplementedHandler)
 	mux.Handle("/", base)
 	return mux
+}
+
+func appTrackWalletNotImplementedHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		_, _ = w.Write([]byte(`{"error":"method_not_allowed"}` + "\n"))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusNotImplemented)
+	_, _ = w.Write([]byte(`{"error":"wallet_change_requires_spec_027"}` + "\n"))
 }
 
 func reloadTier2Config(configPath string, startupTier2 config.Tier2Config, logger zerolog.Logger, wsServer *providerws.Server, buyerServer *buyer.Server, billingStores ...*billing.Store) {

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -97,6 +97,13 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("enabled route status=%d want 204", rr.Code)
 	}
+
+	walletReq := httptest.NewRequest(http.MethodPost, "/v1/provider/wallet", nil)
+	rr = httptest.NewRecorder()
+	enabled.ServeHTTP(rr, walletReq)
+	if rr.Code != http.StatusNotImplemented || !strings.Contains(rr.Body.String(), "wallet_change_requires_spec_027") {
+		t.Fatalf("wallet route status=%d body=%s, want 501 wallet_change_requires_spec_027", rr.Code, rr.Body.String())
+	}
 }
 
 func TestNginxRegisterRouteBeforeV1CatchAll(t *testing.T) {
@@ -123,6 +130,34 @@ func TestNginxRegisterRouteBeforeV1CatchAll(t *testing.T) {
 	} {
 		if !strings.Contains(cfg[route:catchAll], needle) {
 			t.Fatalf("register route missing %q", needle)
+		}
+	}
+}
+
+func TestNginxWalletRouteBeforeV1CatchAll(t *testing.T) {
+	body, err := os.ReadFile("../../dist/nginx-coordinator.streamvc.live.conf")
+	if err != nil {
+		t.Fatalf("read nginx config: %v", err)
+	}
+	cfg := string(body)
+	route := strings.Index(cfg, "location = /v1/provider/wallet")
+	catchAll := strings.Index(cfg, "location /v1/ {\n        return 404;")
+	if route < 0 {
+		t.Fatal("missing exact /v1/provider/wallet route")
+	}
+	if catchAll < 0 {
+		t.Fatal("missing /v1/ catch-all route")
+	}
+	if route > catchAll {
+		t.Fatal("/v1/provider/wallet route must appear before /v1/ catch-all")
+	}
+	for _, needle := range []string{
+		"proxy_pass http://127.0.0.1:8443/v1/provider/wallet;",
+		"proxy_set_header Authorization $http_authorization;",
+		"add_header Cache-Control \"no-store\" always;",
+	} {
+		if !strings.Contains(cfg[route:catchAll], needle) {
+			t.Fatalf("wallet route missing %q", needle)
 		}
 	}
 }

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -278,6 +278,26 @@ server {
     }
 
     # ---------------------------------------------------------------------
+    # /v1/provider/wallet — App-track wallet changes are intentionally
+    # blocked until SPEC-027 defines non-bearer proof of ownership.
+    # Proxies to the buyer mux so the coordinator returns the explicit
+    # 501 wallet_change_requires_spec_027 body instead of the generic
+    # /v1/ catch-all.
+    # ---------------------------------------------------------------------
+    location = /v1/provider/wallet {
+        proxy_pass http://127.0.0.1:8443/v1/provider/wallet;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $http_authorization;
+        proxy_read_timeout 10s;
+        proxy_no_cache 1;
+        proxy_cache_bypass 1;
+        add_header Cache-Control "no-store" always;
+    }
+
+    # ---------------------------------------------------------------------
     # SPEC-017 v0.1.8 Step 4.B — /v1/stats/* allow-through. Public
     # Network Stats API endpoints, mounted on the coordinator's
     # provider port (8444) per main.go:525. The dedicated vhost

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -41,7 +41,7 @@ var ErrPairOTInvalid = errors.New("pair_ot invalid")
 var ErrPairOTAlreadyOwned = errors.New("pair_ot provider already owned by another account")
 var ErrSessionInvalid = errors.New("mp_session invalid")
 var ErrPendingPairOTMissing = errors.New("pending pair_ot missing")
-var ErrAppTrackExistingTokenNoProof = errors.New("existing active token requires current_provider_token proof")
+var ErrAppTrackExistingTokenNoProof = errors.New("existing active token requires current bearer proof")
 var ErrAppTrackReissueCooldown = errors.New("app-track provider token reissue cooldown active")
 
 type Store struct {
@@ -482,20 +482,19 @@ func (s *Store) MintProviderTokenAppTrack(ctx context.Context, providerID string
 
 	nowText := nowString()
 	var active struct {
-		ID         int64
-		TokenHash  string
-		LastUsedAt sql.NullString
+		ID        int64
+		TokenHash string
 	}
 	err = conn.QueryRowContext(ctx, `
-SELECT id, token_hash, last_used_at
+SELECT id, token_hash
   FROM provider_tokens
  WHERE provider_id = ? AND revoked_at IS NULL
- LIMIT 1`, providerID).Scan(&active.ID, &active.TokenHash, &active.LastUsedAt)
+ LIMIT 1`, providerID).Scan(&active.ID, &active.TokenHash)
 	if err != nil && err != sql.ErrNoRows {
 		return "", err
 	}
 
-	requiresProof := err == nil && active.LastUsedAt.Valid
+	requiresProof := err == nil
 	if requiresProof {
 		if currentBearer == nil || strings.TrimSpace(*currentBearer) == "" || tokenHash(strings.TrimSpace(*currentBearer)) != active.TokenHash {
 			return "", ErrAppTrackExistingTokenNoProof
@@ -550,24 +549,9 @@ VALUES (?, ?)`, providerID, nowText); err != nil {
 	return token, nil
 }
 
-// HasActiveTokenForProvider returns true when at least one unrevoked
-// token row exists for `providerID`. Exposed on both the concrete Store
-// AND the `internal/ws.TokenIssuer` interface (v0.8.4 composition, PR #69
-// merge with PR #78) so `resolveProvisionalToken` can disambiguate
-// "no row at all (mint OK)" from "active row with last_used_at IS NOT
-// NULL (strict TOFU reject)" after `RevokeUnusedTokenForProvider`
-// returned (false, nil).
-//
-// Under v0.8.4 the TOCTOU concern the v0.8.2 codex security re-audit
-// (PR #44 MAJOR-1) flagged is no longer applicable: the partial unique
-// index `idx_provider_tokens_one_active_per_provider` remains the atomic
-// mint-or-collide invariant. This method is purely a read-only
-// disambiguation step that runs AFTER the self-heal write; the
-// subsequent `IssueToken` INSERT is what actually commits the
-// at-most-one-bearer rule. A concurrent reconnect that races between
-// our HasActive check and our INSERT is caught by the unique index
-// (returns `ErrActiveTokenAlreadyExists` → race-loss admit-quarantined
-// path).
+// HasActiveTokenForProvider returns true when at least one unrevoked token row
+// exists for providerID. The Wave 2 custody gate treats every active row as
+// proof-required; last_used_at is not a recovery signal.
 //
 // Also used for operator tooling — e.g. `coordinator-cli list-tokens`
 // presence checks and pre-flag-flip audit scripts.

--- a/phase4-coordinator/internal/auth/tokens_test.go
+++ b/phase4-coordinator/internal/auth/tokens_test.go
@@ -195,7 +195,7 @@ func TestTokenIssueValidateRevokeAndList(t *testing.T) {
 	}
 }
 
-func TestMintProviderTokenAppTrackRotatesUnusedAndRequiresProofForUsed(t *testing.T) {
+func TestMintProviderTokenAppTrackRequiresProofForAnyActiveToken(t *testing.T) {
 	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -212,39 +212,28 @@ func TestMintProviderTokenAppTrackRotatesUnusedAndRequiresProofForUsed(t *testin
 		t.Fatalf("first token len=%d want 64", len(first))
 	}
 
-	second, err := store.MintProviderTokenAppTrack(ctx, providerID, nil)
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
+		t.Fatalf("unused active without proof err=%v want ErrAppTrackExistingTokenNoProof", err)
+	}
+	if provider, ok, err := store.ValidateToken(ctx, first); err != nil || !ok || provider != providerID {
+		t.Fatalf("first token should remain active provider=%q ok=%v err=%v", provider, ok, err)
+	}
+	wrong := "wrong-token"
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &wrong); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
+		t.Fatalf("active token with wrong proof err=%v want ErrAppTrackExistingTokenNoProof", err)
+	}
+
+	second, err := store.MintProviderTokenAppTrack(ctx, providerID, &first)
 	if err != nil {
-		t.Fatalf("unused duplicate should rotate without proof: %v", err)
+		t.Fatalf("active token with current proof should reissue: %v", err)
 	}
 	if second == first {
-		t.Fatal("rotated token matched first token")
-	}
-	if provider, ok, err := store.ValidateToken(ctx, first); err != nil || ok || provider != "" {
-		t.Fatalf("first token should be revoked provider=%q ok=%v err=%v", provider, ok, err)
+		t.Fatal("proof reissue returned same token")
 	}
 	if err := store.MarkTokenUsed(ctx, second); err != nil {
 		t.Fatalf("mark second used: %v", err)
 	}
-
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
-		t.Fatalf("used active without proof err=%v want ErrAppTrackExistingTokenNoProof", err)
-	}
-	wrong := "wrong-token"
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &wrong); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
-		t.Fatalf("used active with wrong proof err=%v want ErrAppTrackExistingTokenNoProof", err)
-	}
-
-	third, err := store.MintProviderTokenAppTrack(ctx, providerID, &second)
-	if err != nil {
-		t.Fatalf("used active with current proof should reissue: %v", err)
-	}
-	if third == second {
-		t.Fatal("proof reissue returned same token")
-	}
-	if err := store.MarkTokenUsed(ctx, third); err != nil {
-		t.Fatalf("mark third used: %v", err)
-	}
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &third); !errors.Is(err, auth.ErrAppTrackReissueCooldown) {
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &second); !errors.Is(err, auth.ErrAppTrackReissueCooldown) {
 		t.Fatalf("cooldown reissue err=%v want ErrAppTrackReissueCooldown", err)
 	}
 }

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -824,7 +824,7 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 	for _, p := range providers {
 		switch p.State {
 		case pool.StateReady:
-			if p.AuthState != pool.AuthBearerlessDuplicate && len(p.PendingReceiptPubkey) == 0 {
+			if p.CapacityEligible() {
 				resp.PoolReady++
 			}
 		case pool.StateDegraded, pool.StateBusy:
@@ -1281,7 +1281,7 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		if pillarAActive && !p.RoutingEligible() {
 			continue
 		}
-		if !pillarAActive && (p.State != pool.StateReady || p.AuthState == pool.AuthBearerlessDuplicate || len(p.PendingReceiptPubkey) > 0) {
+		if !pillarAActive && (p.State != pool.StateReady || !p.CapacityEligible()) {
 			continue
 		}
 		excluded := tier2Active && s.tier2ProviderExcludedForConfig(p, cfg)
@@ -5520,7 +5520,7 @@ func validatePinnedProvider(p pool.Provider, model string, estimatedTokens int, 
 // For routing decisions, use pool.Provider.RoutingEligible() — that is the
 // single authority on whether a provider may receive traffic.
 func hasAvailableSlot(p pool.Provider) bool {
-	if p.AuthState == pool.AuthBearerlessDuplicate {
+	if !p.CapacityEligible() {
 		return false
 	}
 	return p.State == pool.StateReady && p.SlotsFree > 0

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -1097,6 +1097,23 @@ func TestHealthzExcludesPendingReceiptCandidateFromReadyCapacity(t *testing.T) {
 	}
 }
 
+func TestHealthzExcludesAuthSelfMintedFromReadyCapacity(t *testing.T) {
+	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: "https://p1.example"}})
+	registerAuthState(registry, "p1", "session-1", "model-a", "https://p1.example", pool.AuthSelfMinted)
+	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0))
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rr := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	if !bytes.Contains(rr.Body.Bytes(), []byte(`"pool_size":1`)) || !bytes.Contains(rr.Body.Bytes(), []byte(`"pool_ready":0`)) {
+		t.Fatalf("self-minted provider must remain visible but not ready capacity; body=%s", rr.Body.String())
+	}
+}
+
 func TestHealthzReportsInjectedVersion(t *testing.T) {
 	registry := pool.NewRegistry(nil)
 	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0), buyer.WithVersion("v1.3.0-7-gabcdef0"))
@@ -6314,6 +6331,10 @@ func TestSPEC004DefaultConfigRegression_ContextTooSmall(t *testing.T) {
 // pool.Provider.RoutingEligible(). Mirrors the v1.2.5 bearer-less reconnect case
 // that v0.8.3 admits and quarantines.
 func registerBearerlessDuplicate(registry *pool.Registry, providerID, assignedID, modelID, endpointURL string) {
+	registerAuthState(registry, providerID, assignedID, modelID, endpointURL, pool.AuthBearerlessDuplicate)
+}
+
+func registerAuthState(registry *pool.Registry, providerID, assignedID, modelID, endpointURL string, authState pool.AuthState) {
 	now := time.Now().UTC()
 	registry.Register(&pool.Provider{
 		ProviderID:            providerID,
@@ -6335,7 +6356,7 @@ func registerBearerlessDuplicate(registry *pool.Registry, providerID, assignedID
 		LastActivityAt:        now,
 		ConnectedAt:           now,
 		BinaryVersion:         "0.1.0",
-		AuthState:             pool.AuthBearerlessDuplicate,
+		AuthState:             authState,
 	}, nil)
 }
 
@@ -6455,6 +6476,46 @@ func TestModelsExcludesAuthBearerlessDuplicateFromCapacity(t *testing.T) {
 	if modelA.TotalSlots != 1 {
 		t.Fatalf("total_slots = %d, want 1 (good only)", modelA.TotalSlots)
 	}
+}
+
+func TestModelsExcludesAuthSelfMintedFromCapacity(t *testing.T) {
+	registry := pool.NewRegistry([]config.ProviderConfig{
+		{ProviderID: "good", EndpointURL: "https://good.example"},
+		{ProviderID: "bad", EndpointURL: "https://bad.example"},
+	})
+	register(registry, "good", "session-good", "model-a", pool.StateReady, 20000, 1)
+	registerAuthState(registry, "bad", "session-bad", "model-a", "https://bad.example", pool.AuthSelfMinted)
+
+	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0))
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rr := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Data []struct {
+			ID            string `json:"id"`
+			ProviderCount int    `json:"provider_count"`
+			TotalSlots    int    `json:"total_slots"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	for _, m := range resp.Data {
+		if m.ID == "model-a" {
+			if m.ProviderCount != 1 {
+				t.Fatalf("provider_count = %d, want 1 (good only; self-minted excluded)", m.ProviderCount)
+			}
+			if m.TotalSlots != 1 {
+				t.Fatalf("total_slots = %d, want 1 (good only; self-minted excluded)", m.TotalSlots)
+			}
+			return
+		}
+	}
+	t.Fatalf("model-a not in response; body=%s", rr.Body.String())
 }
 
 func TestModelsExcludesPendingReceiptCandidateFromCapacity(t *testing.T) {

--- a/phase4-coordinator/internal/onboarding/apptrack.go
+++ b/phase4-coordinator/internal/onboarding/apptrack.go
@@ -1,10 +1,7 @@
-// Package onboarding implements SPEC-026 v0.11 App-track provider onboarding.
+// Package onboarding implements SPEC-026 App-track provider onboarding.
 //
 // The primary entry point is HandleAppTrackRegister (SPEC-026 §4.1). The
-// full contract is documented in the spec + BUILD prompt at
-// specs/BUILD_SPEC_026_IMPL_STEP_1_COORD_REGISTER_PROMPT.md — the
-// implementation body of the handler is intentionally left as a
-// stub in this scaffold PR; codex fills it in via the audit-loop pass.
+// full contract is documented in specs/SPEC-026-browserless-provider-onboarding.md.
 package onboarding
 
 import (
@@ -31,15 +28,14 @@ import (
 // RegisterRequest is the JSON body of POST /v1/providers/register.
 // SPEC-026 §4.1. All fields required except AppAttestObject / AppAttestKeyID.
 type RegisterRequest struct {
-	ProviderID           string          `json:"provider_id"`
-	IdentityPubkey       string          `json:"identity_pubkey"` // base64 32-byte Ed25519
-	HardwareSummary      HardwareSummary `json:"hardware_summary"`
-	AppAttestObject      *string         `json:"app_attest_object,omitempty"` // base64 CBOR
-	AppAttestKeyID       *string         `json:"app_attest_key_id,omitempty"` // base64 32-byte
-	Nonce                string          `json:"nonce"`                       // 64-hex = 32 random bytes
-	TSUTC                string          `json:"ts_utc"`                      // RFC3339
-	CurrentProviderToken *string         `json:"current_provider_token,omitempty"`
-	Signature            string          `json:"signature"` // base64 64-byte Ed25519 over JCS(body\signature)
+	ProviderID      string          `json:"provider_id"`
+	IdentityPubkey  string          `json:"identity_pubkey"` // base64 32-byte Ed25519
+	HardwareSummary HardwareSummary `json:"hardware_summary"`
+	AppAttestObject *string         `json:"app_attest_object,omitempty"` // base64 CBOR
+	AppAttestKeyID  *string         `json:"app_attest_key_id,omitempty"` // base64 32-byte
+	Nonce           string          `json:"nonce"`                       // 64-hex = 32 random bytes
+	TSUTC           string          `json:"ts_utc"`                      // RFC3339
+	Signature       string          `json:"signature"`                   // base64 64-byte Ed25519 over JCS(body\signature)
 }
 
 type HardwareSummary struct {
@@ -116,14 +112,9 @@ type StatsDB interface {
 // AuthTokenStore is the SQLite-side dependency (existing
 // phase4-coordinator/internal/auth/tokens.go).
 type AuthTokenStore interface {
-	// MintProviderTokenAppTrack mints per SPEC-026 §4.1 step 7 semantics:
-	// same-identity_pubkey duplicate register rotates the token; different
-	// identity_pubkey rejects with ErrProviderIDPubkeyMismatch.
-	//
-	// The `current_provider_token` bearer-proof path is enforced against
-	// last_used_at IS NOT NULL rows: caller must pass the raw cleartext
-	// so this store can SHA-256 hash and compare against token_hash.
-	//
+	// MintProviderTokenAppTrack mints per SPEC-026 §4.1 step 7 semantics.
+	// Duplicate registration with any active token requires bearer proof from
+	// the Authorization header; request bodies must never carry bearer material.
 	// provider_name is the tenant literal "malibu-app" for App-track.
 	MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (cleartext string, err error)
 }
@@ -195,6 +186,10 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	var raw map[string]any
 	if err := json.Unmarshal(body, &raw); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "invalid json body")
+		return
+	}
+	if _, ok := raw["current_provider_token"]; ok {
+		writeJSONError(w, http.StatusBadRequest, "bearer_proof_in_body", "current_provider_token is not allowed in request body")
 		return
 	}
 	var req RegisterRequest
@@ -315,6 +310,10 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			writeJSONError(w, http.StatusBadRequest, "app_attest_unverified", "app attest verifier unavailable")
 			return
 		}
+		if strings.TrimSpace(h.AppAttestConfig.TeamID) == "" || strings.TrimSpace(h.AppAttestConfig.BundleID) == "" {
+			writeJSONError(w, http.StatusServiceUnavailable, "app_attest_pin_unconfigured", "app attest team and bundle pins are required")
+			return
+		}
 		verifyCtx, cancelVerify := context.WithTimeout(r.Context(), 2*time.Second)
 		ok, err := h.AppAttestVerifier.Verify(verifyCtx, AppAttestEvidence{
 			Object:         obj,
@@ -347,9 +346,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	currentBearer := bearerFromRequest(r)
-	if currentBearer == nil {
-		currentBearer = req.CurrentProviderToken
-	}
 	token, err := h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer)
 	if err != nil {
 		switch {

--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -177,6 +177,25 @@ func TestHandleAppTrackRegisterAppAttestPresentRequiresVerifier(t *testing.T) {
 	}
 }
 
+func TestHandleAppTrackRegisterAppAttestRequiresPinnedTeamAndBundle(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(m map[string]any) {
+		m["app_attest_object"] = base64.StdEncoding.EncodeToString([]byte{0xa0})
+		m["app_attest_key_id"] = base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{1}, 32))
+	})
+	handler := testRegisterHandler(&fakeStatsDB{}, &fakeAuthStore{token: "provider-token"}, nil)
+	handler.AppAttestVerifier = &fakeAppAttestVerifier{ok: true}
+	handler.AppAttestConfig = AppAttestConfig{}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	req.RemoteAddr = "198.51.100.10:4444"
+	rr := httptest.NewRecorder()
+	handler.HandleAppTrackRegister(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable || !strings.Contains(rr.Body.String(), "app_attest_pin_unconfigured") {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestHandleAppTrackRegisterAcceptsVerifiedAppAttest(t *testing.T) {
 	keyID := bytes.Repeat([]byte{1}, 32)
 	body, _ := signedRegisterBody(t, func(m map[string]any) {
@@ -311,16 +330,14 @@ func TestHandleAppTrackRegisterDuplicateBearerProofPaths(t *testing.T) {
 			wantBody:   "existing_active_token_no_proof",
 		},
 		{
-			name:       "body proof",
+			name:       "body proof rejected",
 			bodyToken:  &current,
-			wantStatus: http.StatusOK,
-			wantBearer: &current,
-			wantBody:   "provider-token",
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "bearer_proof_in_body",
 		},
 		{
-			name:       "authorization header takes precedence",
+			name:       "authorization header proof",
 			header:     "Bearer header-token",
-			bodyToken:  &current,
 			wantStatus: http.StatusOK,
 			wantBearer: stringPtr("header-token"),
 			wantBody:   "provider-token",
@@ -463,7 +480,11 @@ func testRegisterHandler(stats *fakeStatsDB, authStore *fakeAuthStore, metrics *
 		CoordinatorWSURL:  "wss://coordinator.streamvc.live/v2/provider",
 		IPRateLimiter:     limiter,
 		ASNRateLimiter:    allowLimiter{},
-		Metrics:           metrics,
+		AppAttestConfig: AppAttestConfig{
+			BundleID: "live.streamvc.Malibu",
+			TeamID:   "MALIBU1234",
+		},
+		Metrics: metrics,
 		Now: func() time.Time {
 			return time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
 		},

--- a/phase4-coordinator/internal/onboarding/jcs_fixture_test.go
+++ b/phase4-coordinator/internal/onboarding/jcs_fixture_test.go
@@ -59,7 +59,7 @@ func TestSpec026RegisterJCSFixtureParity(t *testing.T) {
 		"app_attest_present_valid_shape",
 		"unicode_hardware_chip",
 		"jcs_only_nested_object_variant",
-		"signature_stripped_current_token_variant",
+		"signature_stripped_register_body_variant",
 	} {
 		if !seen[id] {
 			t.Fatalf("missing required fixture row %q", id)

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -20,17 +20,11 @@ type RecoveryReason string
 type HashStatus string
 type AttestationStatus string
 
-// AuthState records HOW a provider session was admitted. Added in
-// SPEC-003 v0.8.3 fix-pass-3 (codex security audit on PR #69 MAJOR-1)
-// so the post-PR-#69 admit-tokenless-on-duplicate behavior can be
-// distinguished from a legitimate self-mint or Bearer-validated
-// session for routing, billing, and operator audit purposes. The zero
-// value (empty string) is intentionally "no special marking" so
-// pre-FR-C9 providers and pinned-tier admissions don't need to set it
-// explicitly; the registry, routing, and billing all treat empty +
-// AuthBearerValidated + AuthSelfMinted as routable. Only
-// AuthBearerlessDuplicate triggers the eviction-defense + non-routable
-// gates.
+// AuthState records HOW a provider session was admitted. The zero value
+// (empty string) is intentionally "no special marking" so pre-FR-C9 providers
+// and pinned-tier admissions don't need to set it explicitly. Bearer-validated
+// sessions are trusted for routing. Self-minted sessions remain visible but are
+// not money-path eligible until they return with a credential proof.
 type AuthState string
 
 const (
@@ -67,11 +61,16 @@ const (
 	// auth.Store.ValidateToken matched. Post-flag-flip this is the
 	// only admitted state.
 	AuthBearerValidated AuthState = "bearer_validated"
-	// AuthSelfMinted — connect arrived tokenless and the coordinator
-	// minted a fresh provider_tokens row + returned the cleartext in
-	// the ack frame (FR-C9.1). Provider can persist it and reconnect
-	// authenticated next time.
+	// AuthSelfMinted — connect arrived tokenless and the coordinator minted a
+	// fresh provider_tokens row + returned the cleartext in the ack frame.
+	// Provider can persist it and reconnect authenticated next time. The
+	// current tokenless session is not routing or payout eligible.
 	AuthSelfMinted AuthState = "self_minted"
+	// AuthSelfMintedVerified is reserved for explicit proof-of-ownership
+	// challenge completion. Today, the production path reaches equivalent
+	// trust by reconnecting with the minted Bearer and becoming
+	// AuthBearerValidated.
+	AuthSelfMintedVerified AuthState = "self_minted_verified"
 	// AuthBearerlessDuplicate — connect arrived tokenless for a
 	// provider_id that already has an unrevoked token row in
 	// provider_tokens (FR-C9.4 v0.8.3). The connection is admitted
@@ -215,13 +214,27 @@ type ReceiptPubkeyPrevious struct {
 // health surfaces separately exclude pending receipt-key publication while
 // preserving ready providers that are temporarily out of free slots.
 func (p Provider) RoutingEligible() bool {
-	if p.AuthState == AuthBearerlessDuplicate {
+	if p.AuthState == AuthBearerlessDuplicate || p.AuthState == AuthSelfMinted {
 		return false
 	}
 	if len(p.PendingReceiptPubkey) > 0 {
 		return false
 	}
 	return p.State == StateReady && p.SlotsFree > 0
+}
+
+// CapacityEligible reports whether a provider may be counted on serving and
+// capacity surfaces. It deliberately omits SlotsFree so busy providers still
+// count as online capacity while tokenless, duplicate, and receipt-key-rotation
+// sessions stay visible but not advertised as usable serving capacity.
+func (p Provider) CapacityEligible() bool {
+	if p.AuthState == AuthBearerlessDuplicate || p.AuthState == AuthSelfMinted {
+		return false
+	}
+	if len(p.PendingReceiptPubkey) > 0 {
+		return false
+	}
+	return p.State == StateReady || p.State == StateBusy
 }
 
 func (p Provider) IsWSTunneled() bool {
@@ -464,10 +477,9 @@ func (r *Registry) Endpoint(providerID string) (config.ProviderConfig, bool) {
 //     non-Bearer-validated session (AuthSelfMinted / AuthMintFailed /
 //     empty) is refused whenever the existing session is a routing-
 //     eligible AuthBearerValidated session. Without this rule, a
-//     concurrent tokenless self-heal during a victim's first-mint
-//     window could mint a fresh bearer and then register as
+//     tokenless admission racing a proven session could register as
 //     AuthSelfMinted, last-writer-wins evicting the victim's
-//     validated session (security audit, PR #69 fix-pass-5 MAJOR-2).
+//     validated session.
 //     Bearer-validated incoming connects always succeed because
 //     their proof-of-bearer is independently strong.
 //
@@ -509,11 +521,9 @@ func (r *Registry) RegisterAtDetailed(p *Provider, conn net.Conn, now time.Time)
 		if p.AuthState == AuthBearerlessDuplicate {
 			return nil, false, RegisterRefusalBearerlessDuplicate
 		}
-		// SPEC-003 v0.8.4 FR-C9.4 (fix-pass-5) — protect proven
-		// (Bearer-validated, routing-eligible) sessions from non-
-		// Bearer-validated replacement. Under composition, a tokenless
-		// connect that hits self-heal becomes AuthSelfMinted; without
-		// this check, the attacker could last-writer-wins evict the
+		// Protect proven (Bearer-validated, routing-eligible) sessions
+		// from non-Bearer-validated replacement. Without this check, a
+		// tokenless admission could last-writer-wins evict the
 		// legitimate Bearer-validated session. A legitimate provider
 		// reconnect with a valid Bearer always wins because their
 		// AuthState is AuthBearerValidated.

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -230,10 +230,26 @@ func TestRoutingEligibleIgnoresHashStatus(t *testing.T) {
 	if bearerless.RoutingEligible() {
 		t.Fatal("AuthBearerlessDuplicate MUST be excluded — SPEC-003 v0.8.3 FR-C9.4 credential trust gate")
 	}
+	selfMinted := base
+	selfMinted.AuthState = AuthSelfMinted
+	if selfMinted.RoutingEligible() {
+		t.Fatal("AuthSelfMinted MUST be excluded until the provider proves custody of the minted bearer")
+	}
+	if selfMinted.CapacityEligible() {
+		t.Fatal("AuthSelfMinted MUST be excluded from published serving capacity")
+	}
+	selfMintedVerified := base
+	selfMintedVerified.AuthState = AuthSelfMintedVerified
+	if !selfMintedVerified.RoutingEligible() {
+		t.Fatal("AuthSelfMintedVerified should be route eligible once proof-of-custody has completed")
+	}
 	pendingReceiptKey := base
 	pendingReceiptKey.PendingReceiptPubkey = []byte("pending")
 	if pendingReceiptKey.RoutingEligible() {
 		t.Fatal("pending receipt pubkey sessions must be excluded from routing until state_update publishes the key")
+	}
+	if pendingReceiptKey.CapacityEligible() {
+		t.Fatal("pending receipt pubkey sessions must be excluded from published serving capacity")
 	}
 }
 

--- a/phase4-coordinator/internal/stats/poolsnapshot/poolsnapshot.go
+++ b/phase4-coordinator/internal/stats/poolsnapshot/poolsnapshot.go
@@ -76,16 +76,9 @@ func (p *Provider) OverviewSnapshot() statsrollup.OverviewSnapshot {
 	return snap
 }
 
-// onlineForStats mirrors "genuinely serving traffic" for the public
-// stats surface: ready or busy (a busy provider is online, just out
-// of free slots), and not one of the excluded auth states or key-
-// rotation-pending states that RoutingEligible filters out.
+// onlineForStats mirrors "genuinely serving traffic" for the public stats
+// surface: ready or busy (a busy provider is online, just out of free slots),
+// while reusing the pool-level capacity trust predicate.
 func onlineForStats(p pool.Provider) bool {
-	if p.AuthState == pool.AuthBearerlessDuplicate {
-		return false
-	}
-	if len(p.PendingReceiptPubkey) > 0 {
-		return false
-	}
-	return p.State == pool.StateReady || p.State == pool.StateBusy
+	return p.CapacityEligible()
 }

--- a/phase4-coordinator/internal/stats/poolsnapshot/poolsnapshot_test.go
+++ b/phase4-coordinator/internal/stats/poolsnapshot/poolsnapshot_test.go
@@ -72,6 +72,23 @@ func TestExcludesBearerlessDuplicate(t *testing.T) {
 	}
 }
 
+func TestExcludesSelfMintedFromPublicCapacity(t *testing.T) {
+	src := fakeSrc{
+		{ProviderID: "a", State: pool.StateReady, RAMGB: 16, ModelID: "m1"},
+		{ProviderID: "b", State: pool.StateReady, RAMGB: 32, ModelID: "m2", AuthState: pool.AuthSelfMinted},
+	}
+	got := newFixed(src).OverviewSnapshot()
+	if got.NodesOnline != 1 {
+		t.Fatalf("NodesOnline=%d want 1 (self-minted excluded)", got.NodesOnline)
+	}
+	if got.UnifiedRAMGBTotal != 16 {
+		t.Fatalf("UnifiedRAMGBTotal=%d want 16", got.UnifiedRAMGBTotal)
+	}
+	if got.ModelsServing != 1 {
+		t.Fatalf("ModelsServing=%d want 1", got.ModelsServing)
+	}
+}
+
 func TestExcludesPendingReceiptPubkey(t *testing.T) {
 	src := fakeSrc{
 		{ProviderID: "a", State: pool.StateReady, RAMGB: 16, ModelID: "m1", PendingReceiptPubkey: []byte{1, 2, 3}},

--- a/phase4-coordinator/internal/ws/provider_token_self_serve_test.go
+++ b/phase4-coordinator/internal/ws/provider_token_self_serve_test.go
@@ -403,29 +403,15 @@ func TestSelfServeProvisionalTokenMintFailureFailsClosed(t *testing.T) {
 	}
 }
 
-// SPEC-003 v0.8.4 FR-C9.4 unused-token self-heal — when an active row
-// exists for a provider_id but its last_used_at IS NULL (never
-// authenticated), the coordinator MUST revoke that row and mint a
-// fresh token for the incoming tokenless connect instead of
-// rejecting. Closes the deploy-gap lockout class that hit `air5` on
-// the 2026-06-12 production deploy: a provider minted a token under
-// the new coordinator but reconnected before consuming the ack
-// frame, and v0.8.2's blanket TOFU policy locked them out
-// indefinitely. The codex MAJOR-1 credential-capture vector that
-// v0.8.1 closed requires the attacker to have authenticated at
-// least once (which sets last_used_at) — an unused row carries no
-// live credential, so self-heal does not weaken the security model.
-// Pre-v0.8.3 this test asserted strict rejection; the new contract
-// is in DECISION_CRITERIA Entry 67.
-func TestSelfServeProvisionalTokenSelfHealsWhenExistingTokenUnused(t *testing.T) {
+// Wave 2 token custody: a tokenless reconnect must not revoke or replace any
+// active provider token row, even one that has never authenticated. Mutation
+// requires proof of the existing bearer or an operator recovery path.
+func TestSelfServeProvisionalTokenRejectsWhenExistingTokenUnused(t *testing.T) {
 	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
 	defer store.Close()
-	// Seed: a legitimate provider self-minted on a prior connect but
-	// never used the token (the deploy-gap pattern: minted, persisted
-	// or not, but ack-frame not consumed by the old binary in flight).
 	seedRecord, seedCleartext, err := store.IssueToken(context.Background(), "claimed-provider", "claimed-provider hostname")
 	if err != nil {
 		t.Fatalf("seed unused token: %v", err)
@@ -436,9 +422,6 @@ func TestSelfServeProvisionalTokenSelfHealsWhenExistingTokenUnused(t *testing.T)
 	h := selfServeHarness(t, store)
 	defer h.HTTP.Close()
 
-	// The same provider_id reconnects tokenless (binary lost the
-	// ack-frame's assigned_provider_token across a coordinator
-	// restart, or never persisted it). Self-heal should kick in.
 	conn, _, _, err := gobwas.Dial(context.Background(), wsURL(h.HTTP.URL))
 	if err != nil {
 		t.Fatalf("dial tokenless reconnect: %v", err)
@@ -448,78 +431,31 @@ func TestSelfServeProvisionalTokenSelfHealsWhenExistingTokenUnused(t *testing.T)
 		t.Fatalf("write hello: %v", err)
 	}
 
-	// Self-heal path: the ack frame should arrive normally with a NEW
-	// assigned_provider_token, not a close frame.
-	payload, op, err := wsutil.ReadServerData(conn)
+	frame, err := gobwas.ReadFrame(conn)
 	if err != nil {
-		t.Fatalf("read self-heal ack: %v", err)
+		t.Fatalf("read tokenless existing-token close: %v", err)
 	}
-	if op != gobwas.OpText {
-		t.Fatalf("op = %v, want text (self-heal ack), not close (legacy strict reject)", op)
+	if frame.Header.OpCode != gobwas.OpClose {
+		t.Fatalf("op = %v, want close", frame.Header.OpCode)
 	}
-	var ack providerws.HelloAck
-	if err := json.Unmarshal(payload, &ack); err != nil {
-		t.Fatalf("ack json: %v", err)
-	}
-	if ack.Type != "hello_ack" {
-		t.Fatalf("ack type = %q, want hello_ack", ack.Type)
-	}
-	if ack.AssignedProviderToken == "" {
-		t.Fatalf("assigned_provider_token empty in self-heal hello_ack: %#v", ack)
-	}
-	if ack.AssignedProviderToken == seedCleartext {
-		t.Fatalf("self-heal ack returned the SAME cleartext as the seed; expected a freshly minted token")
+	code, reason := gobwas.ParseCloseFrameData(frame.Payload)
+	if code != providerws.CloseInvalidToken || reason != "invalid_token" {
+		t.Fatalf("close = %d %q, want %d invalid_token", code, reason, providerws.CloseInvalidToken)
 	}
 
-	// DB invariant: the seed row is revoked, exactly one active row
-	// remains (the fresh mint), and the fresh row resolves to the
-	// declared provider_id.
 	records, err := store.ListTokens(context.Background())
 	if err != nil {
 		t.Fatalf("list tokens: %v", err)
 	}
-	if len(records) != 2 {
-		t.Fatalf("token rows after self-heal = %d, want 2 (revoked seed + fresh mint): %#v", len(records), records)
+	if len(records) != 1 {
+		t.Fatalf("token rows after reject = %d, want original only: %#v", len(records), records)
 	}
-	var seedRow, freshRow *auth.TokenRecord
-	for i := range records {
-		r := records[i]
-		if r.ID == seedRecord.ID {
-			cp := r
-			seedRow = &cp
-		} else {
-			cp := r
-			freshRow = &cp
-		}
+	if records[0].ID != seedRecord.ID || records[0].RevokedAt.Valid {
+		t.Fatalf("seed row mutated after reject: %#v", records[0])
 	}
-	if seedRow == nil || freshRow == nil {
-		t.Fatalf("could not classify rows: seed=%v fresh=%v records=%#v", seedRow, freshRow, records)
-	}
-	if !seedRow.RevokedAt.Valid {
-		t.Fatalf("seed row should be revoked after self-heal; revoked_at=%v", seedRow.RevokedAt)
-	}
-	if freshRow.RevokedAt.Valid {
-		t.Fatalf("fresh row should be active after self-heal; revoked_at=%v", freshRow.RevokedAt)
-	}
-	if freshRow.ProviderID != "claimed-provider" {
-		t.Fatalf("fresh row provider_id = %q, want claimed-provider", freshRow.ProviderID)
-	}
-	providerID, ok, err := store.ValidateToken(context.Background(), ack.AssignedProviderToken)
+	providerID, ok, err := store.ValidateToken(context.Background(), seedCleartext)
 	if err != nil || !ok || providerID != "claimed-provider" {
-		t.Fatalf("self-heal token validation: id=%q ok=%v err=%v (want claimed-provider true nil)", providerID, ok, err)
-	}
-
-	// Composition with PR #69 (v0.8.4 fix-pass): the self-healed
-	// session is admitted with a freshly-minted token, so its
-	// AuthState MUST be AuthSelfMinted — fully routable, no
-	// quarantine. The bearer-less duplicate path is for the
-	// IssueToken race-loss case, not the self-heal path.
-	provider, ok := h.Registry.Resolve("claimed-provider", ack.AssignedID)
-	if !ok {
-		t.Fatalf("registry has no entry for assigned_id %q after self-heal", ack.AssignedID)
-	}
-	if provider.AuthState != pool.AuthSelfMinted {
-		t.Fatalf("self-heal auth_state = %q, want %q (self-mint must mark routable, not quarantined)", provider.AuthState, pool.AuthSelfMinted)
+		t.Fatalf("original token validation after reject: id=%q ok=%v err=%v", providerID, ok, err)
 	}
 }
 
@@ -926,14 +862,9 @@ func TestProviderTokenBootstrapRejectsTokenlessUsedTokenOnAuthResponseV2(t *test
 	}
 }
 
-// SPEC-003 v0.8.4 — v2 mirror of TestSelfServeProvisionalTokenSelfHealsWhenExistingTokenUnused.
-// The composed self-heal contract MUST hold across the v2 ECDH path
-// too: a tokenless v2 connect declaring a provider_id whose active row
-// has last_used_at IS NULL self-heals (revoke + remint), and the
-// auth_response carries the fresh token. Also forces retainSpec010=true
-// via SPEC-010 catalog fields so the R-7.9.7 defer's terminal-path
-// release is exercised — AuthAttemptCount MUST return to 0.
-func TestSelfServeProvisionalTokenSelfHealsOnAuthResponseV2WithRetentionCleanup(t *testing.T) {
+// V2 mirrors the Wave 2 custody rule and still releases retained auth-attempt
+// state on the fail-closed terminal path.
+func TestSelfServeProvisionalTokenRejectsExistingUnusedTokenOnAuthResponseV2WithRetentionCleanup(t *testing.T) {
 	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -961,8 +892,8 @@ func TestSelfServeProvisionalTokenSelfHealsOnAuthResponseV2WithRetentionCleanup(
 	}
 	providerPublic := base64.RawURLEncoding.EncodeToString(providerPublicRaw)
 	// SPEC-010 catalog fields force retainSpec010=true so the auth-attempt
-	// retention store reserves an entry. ANY terminal path (including
-	// successful self-heal mint) must release it via the R-7.9.7 defer.
+	// retention store reserves an entry. ANY terminal path must release it via
+	// the R-7.9.7 defer.
 	initial := validAuthInitial("v2-selfheal", providerPublic)
 	initial["supported_models"] = []string{
 		"mlx-community/Qwen2.5-7B-Instruct-4bit",
@@ -974,49 +905,34 @@ func TestSelfServeProvisionalTokenSelfHealsOnAuthResponseV2WithRetentionCleanup(
 	}
 	challenge := readAuthChallenge(t, conn)
 	writeAuthProof(t, conn, challenge, "v2-selfheal", nil)
-	response := readAuthResponse(t, conn)
 
-	if response.Status != "accepted" {
-		t.Fatalf("v2 auth_response.status = %q, want accepted (self-heal mints fresh token): %+v", response.Status, response)
+	frame, err := gobwas.ReadFrame(conn)
+	if err != nil {
+		t.Fatalf("read v2 tokenless existing-token close: %v", err)
 	}
-	if response.AssignedProviderToken == "" {
-		t.Fatalf("v2 assigned_provider_token empty; want freshly-minted token from self-heal: %+v", response)
+	if frame.Header.OpCode != gobwas.OpClose {
+		t.Fatalf("op = %v, want close", frame.Header.OpCode)
 	}
-	if response.AssignedProviderToken == seedCleartext {
-		t.Fatalf("v2 self-heal returned the SAME cleartext as the seed; expected a freshly minted token")
+	code, reason := gobwas.ParseCloseFrameData(frame.Payload)
+	if code != providerws.CloseInvalidToken || reason != "invalid_token" {
+		t.Fatalf("close = %d %q, want %d invalid_token", code, reason, providerws.CloseInvalidToken)
 	}
 
-	// DB invariant: seed row revoked, fresh row active.
 	records, err := store.ListTokens(context.Background())
 	if err != nil {
 		t.Fatalf("list tokens: %v", err)
 	}
-	if len(records) != 2 {
-		t.Fatalf("token rows after v2 self-heal = %d, want 2: %#v", len(records), records)
+	if len(records) != 1 || records[0].ID != seedRecord.ID || records[0].RevokedAt.Valid {
+		t.Fatalf("token rows after v2 reject = %#v, want original active row only", records)
 	}
-	for _, r := range records {
-		if r.ID == seedRecord.ID && !r.RevokedAt.Valid {
-			t.Fatalf("v2 seed row should be revoked after self-heal: %#v", r)
-		}
-		if r.ID != seedRecord.ID && r.RevokedAt.Valid {
-			t.Fatalf("v2 fresh row should be active after self-heal: %#v", r)
-		}
-	}
-
-	provider, ok := h.Registry.Resolve("v2-selfheal", response.AssignedID)
-	if !ok {
-		t.Fatalf("registry has no entry for assigned_id %q after v2 self-heal", response.AssignedID)
-	}
-	if provider.AuthState != pool.AuthSelfMinted {
-		t.Fatalf("v2 self-heal auth_state = %q, want %q (self-mint is routable)", provider.AuthState, pool.AuthSelfMinted)
+	providerID, ok, err := store.ValidateToken(context.Background(), seedCleartext)
+	if err != nil || !ok || providerID != "v2-selfheal" {
+		t.Fatalf("original v2 token validation after reject: id=%q ok=%v err=%v", providerID, ok, err)
 	}
 
 	// The R-7.9.7 defer MUST release the retention entry on EVERY
-	// terminal path — including successful self-heal. Without the
-	// release, AuthAttemptCount stays at 1 and (with enough connects)
-	// reaches the 1024 bound and locks out legitimate provisional
-	// connects.
+	// terminal path.
 	if got := h.Provider.AuthAttemptCount(); got != 0 {
-		t.Fatalf("auth-attempt retention count = %d, want 0 (self-heal terminal path must release the entry — R-7.9.7 defer)", got)
+		t.Fatalf("auth-attempt retention count = %d, want 0", got)
 	}
 }

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -95,12 +95,10 @@ type Server struct {
 // so test seams can mock validation independently.
 //
 // SPEC-003 v0.8.4 (fix-pass-5) added `ValidateAndMarkTokenUsed` to close
-// the TOCTOU window between `ValidateToken` and `MarkTokenUsed`: a
-// concurrent tokenless self-heal between the two could revoke the
-// legitimate provider's still-NULL row and mint a fresh bearer. The
+// the TOCTOU window between `ValidateToken` and `MarkTokenUsed`. The
 // atomic operation stamps `last_used_at` in the same DB statement that
-// validates the token, so `RevokeUnusedTokenForProvider` will never see
-// a NULL row for a bearer that has just validated.
+// validates the token, so bearer validation and token-use marking cannot
+// diverge under concurrent reconnects.
 //
 // `ValidateToken` is retained as a separate method for read-only
 // validations that don't need to record use (operator tooling, status).
@@ -127,28 +125,11 @@ type TokenIssuer interface {
 	// resolveProvisionalToken in this package and SPEC-003 v0.8.4
 	// FR-C9.4 (composed self-heal + race-loss quarantine).
 	IssueToken(ctx context.Context, providerID, providerName string) (auth.TokenRecord, string, error)
-	// HasActiveTokenForProvider implements the FR-C9.4 strict-reject
-	// path: when true AND the active row's `last_used_at IS NOT NULL`
-	// (verified separately via RevokeUnusedTokenForProvider returning
-	// false), the server MUST refuse to mint a second token for the
-	// same provider_id and MUST close the tokenless connection. Closes
-	// the credential-capture attack flagged by the codex security
-	// audit on PR #44 — an attacker who declares a victim's
-	// provider_id on a tokenless connect cannot harvest a parallel
-	// bearer once the victim has authenticated once.
+	// HasActiveTokenForProvider implements the Wave 2 custody gate:
+	// when true, the server MUST refuse tokenless mutation for this
+	// provider_id and close the connection. Changing an active token now
+	// requires proof of the existing token or an operator recovery path.
 	HasActiveTokenForProvider(ctx context.Context, providerID string) (bool, error)
-	// RevokeUnusedTokenForProvider implements SPEC-003 v0.8.3 FR-C9.4
-	// unused-token self-heal: atomically revokes the active row for
-	// `providerID` if its `last_used_at IS NULL`, returning true when
-	// a row was revoked. Called BEFORE HasActiveTokenForProvider in
-	// resolveProvisionalToken so a deploy-gap reconnect with an
-	// unused (never-authenticated) row self-heals into a clean
-	// re-mint instead of triggering the strict-reject path. A used
-	// token (last_used_at NOT NULL) is NOT touched — that case still
-	// follows the v0.8.1 strict-reject contract because the codex
-	// MAJOR-1 credential-capture vector requires an attacker to have
-	// authenticated at least once.
-	RevokeUnusedTokenForProvider(ctx context.Context, providerID string) (bool, error)
 }
 
 type providerAuth struct {
@@ -501,14 +482,10 @@ func (s *Server) validateProviderToken(r *http.Request) (providerAuth, bool) {
 		return providerAuth{}, false
 	}
 	token := strings.TrimSpace(strings.TrimPrefix(authz, prefix))
-	// SPEC-003 v0.8.4 (fix-pass-5) — validate-and-mark in one atomic
-	// DB operation. Pre-fix this was ValidateToken at upgrade + a
-	// separate MarkTokenUsed inside prepareProviderAdmission, leaving a
-	// TOCTOU window where a concurrent tokenless self-heal could revoke
-	// the still-NULL row and mint a fresh bearer for an attacker. The
-	// atomic UPDATE-RETURNING closes the window: once we have a non-
-	// empty providerID, the row's last_used_at IS NOT NULL, so any
-	// concurrent RevokeUnusedTokenForProvider skips it.
+	// Validate-and-mark in one atomic DB operation. Pre-fix this was
+	// ValidateToken at upgrade plus a later MarkTokenUsed inside
+	// prepareProviderAdmission, so bearer validation and token-use
+	// marking could diverge under concurrent reconnects.
 	providerID, ok, err := s.tokens.ValidateAndMarkTokenUsed(r.Context(), token)
 	if err != nil {
 		s.log.Warn().Err(err).Msg("provider token validation failed")
@@ -591,14 +568,14 @@ const (
 	// provisionalTokenRejectTOFU — caller MUST close the connection with
 	// CloseInvalidToken / "invalid_token". Triggers: last_used_at IS NOT NULL
 	// on the existing row (strict TOFU credential-capture closure), or the
-	// self-heal / HasActive DB lookups returned an error (fail closed).
+	// active-token lookup returned an error (fail closed).
 	provisionalTokenRejectTOFU
 )
 
 // resolveProvisionalToken implements SPEC-003 v0.8.4 FR-C9.1 (mint),
-// FR-C9.4 unused-token self-heal (PR #78), FR-C9.4 strict TOFU
-// (refuse second mint for a USED identity), and the v0.8.3 race-loss
-// admit-tokenless quarantine (PR #69, AuthBearerlessDuplicate). It is
+// Wave 2 token-custody strict TOFU (refuse tokenless mutation for any
+// identity with an active token), and race-loss admit-tokenless
+// quarantine (PR #69, AuthBearerlessDuplicate). It is
 // the single decision point the v1 hello_ack and v2 auth_response
 // paths both call before constructing their ack frame.
 //
@@ -609,21 +586,18 @@ const (
 //     drives registry eviction defense, buyer routing
 //     exclusion, and billing exclusion.
 //
-// Algorithm (v0.8.4 composed):
+// Algorithm:
 //  1. If the issuer is not wired: return Skip + empty authState (legacy
 //     pre-FR-C9 mode; provider is routable as before).
 //  2. If the connect arrived with a validated Bearer: return Skip +
 //     authState=BearerValidated (no mint needed).
-//  3. Call RevokeUnusedTokenForProvider:
-//     - (true, nil): self-heal fired — proceed to mint.
-//     - (false, nil): call HasActiveTokenForProvider; if true a USED
-//     row exists → return RejectTOFU (preserves v0.8.1 closure of
-//     codex MAJOR-1 credential-capture vector).
-//     - (_, err): fail closed, return RejectTOFU.
+//  3. Call HasActiveTokenForProvider; if true, an active row already exists
+//     and any tokenless replacement would mutate credential custody without
+//     proof of the existing token. Return RejectTOFU.
 //  4. Mint via IssueToken:
 //     - success: return Minted + cleartext + authState=SelfMinted.
 //     - ErrActiveTokenAlreadyExists: a concurrent connect won the race
-//     between our revoke and our INSERT. Return Skip + authState=
+//     between our active-token check and our INSERT. Return Skip + authState=
 //     BearerlessDuplicate. The connection is admitted bearer-less,
 //     but pool.Registry.Register refuses to evict an existing
 //     routable session, and buyer routing + billing exclude this
@@ -631,7 +605,7 @@ const (
 //     - other DB error: return Skip + empty authState (transient infra
 //     failure; binary retries next reconnect).
 //
-// Settling-window posture (FR-C9.4):
+// Settling-window posture:
 // validateProviderToken rejects all tokenless connects at the WS
 // upgrade gate when RequireProviderTokens=true, so this function is
 // only reached for tokenless admissions during the settling window
@@ -648,23 +622,14 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 		return provisionalTokenSkip, "", "", "", pool.AuthBearerValidated
 	}
 	ctx := context.Background()
-	selfHealed, err := s.issuer.RevokeUnusedTokenForProvider(ctx, providerID)
+	hasActive, err := s.issuer.HasActiveTokenForProvider(ctx, providerID)
 	if err != nil {
-		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("FR-C9.4 unused-token self-heal evaluation failed; closing tokenless connect (fail closed)")
+		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("FR-C9.4 TOFU gate evaluation failed; closing tokenless connect (fail closed)")
 		return provisionalTokenRejectTOFU, "", "", "", ""
 	}
-	if selfHealed {
-		s.log.Info().Str("provider_id", providerID).Str("event", "fr_c9_4_self_heal").Msg("FR-C9.4 self-heal: revoked existing unused token for this provider_id; proceeding to mint a fresh one (SPEC-003 v0.8.4 deploy-gap recovery path)")
-	} else {
-		hasActive, err := s.issuer.HasActiveTokenForProvider(ctx, providerID)
-		if err != nil {
-			s.log.Warn().Err(err).Str("provider_id", providerID).Msg("FR-C9.4 TOFU gate evaluation failed; closing tokenless connect (fail closed)")
-			return provisionalTokenRejectTOFU, "", "", "", ""
-		}
-		if hasActive {
-			s.log.Info().Str("provider_id", providerID).Str("event", "fr_c9_4_tofu_reject").Msg("FR-C9.4 TOFU: tokenless connect refused; an active USED token already exists for this provider_id (operator can revoke + retry if this is the legitimate provider after a used-token persist failure)")
-			return provisionalTokenRejectTOFU, "", "", "", ""
-		}
+	if hasActive {
+		s.log.Info().Str("provider_id", providerID).Str("event", "fr_c9_4_tofu_reject").Msg("FR-C9.4 TOFU: tokenless connect refused; an active token already exists for this provider_id and mutation requires existing-token proof or operator recovery")
+		return provisionalTokenRejectTOFU, "", "", "", ""
 	}
 	if s.cfg.Auth.GitHubOAuth.Enabled && s.authStore != nil {
 		mint, err := s.authStore.MintAdmissionTokenAndPairOT(ctx, providerID, providerName, s.now())
@@ -686,8 +651,8 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 	if err != nil {
 		if errors.Is(err, auth.ErrActiveTokenAlreadyExists) {
 			// SPEC-003 v0.8.4 race-loss path: a concurrent tokenless
-			// connect won the IssueToken race after our self-heal /
-			// strict-reject gates passed. Admit bearer-less-duplicate;
+			// connect won the IssueToken race after our active-token
+			// custody gate passed. Admit bearer-less-duplicate;
 			// the registry eviction defense + routing/billing
 			// exclusion neutralize impact.
 			s.log.Info().Str("provider_id", providerID).Str("event", "fr_c9_4_race_loss_admit_quarantined").Msg("FR-C9.4 race-loss: concurrent connect won IssueToken; admitting bearer-less-duplicate (non-routable; operator MUST revoke before legitimate provider can reconnect cleanly)")
@@ -731,9 +696,10 @@ func (s *Server) handleV1Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	if !ok {
 		return "", ""
 	}
-	// SPEC-003 v0.8.4 FR-C9.1/FR-C9.2/FR-C9.4 — composed flow:
-	// self-heal-on-NULL (PR #78) + strict-reject-on-USED (PR #78) +
-	// race-loss admit-quarantined (PR #69). On RejectTOFU close;
+	// SPEC-003 FR-C9.1/FR-C9.2 plus Wave 2 token custody:
+	// reject any tokenless connect for a provider_id that already has
+	// an active token; keep the race-loss quarantine for concurrent
+	// first-token mints. On RejectTOFU close;
 	// on Minted embed the token in hello_ack; on Skip admit with
 	// the provided AuthState (BearerValidated / BearerlessDuplicate /
 	// empty) and let the registry eviction defense + RoutingEligible
@@ -1103,12 +1069,10 @@ func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hell
 			s.close(conn, CloseInvalidToken, "invalid_token")
 			return nil, false
 		}
-		// SPEC-003 v0.8.4 (fix-pass-5) — `last_used_at` is now stamped
-		// atomically by validateProviderToken's ValidateAndMarkTokenUsed
-		// call at WS upgrade. The previously-here MarkTokenUsed
-		// invocation was removed because it ran AFTER admission, leaving
-		// a TOCTOU window where a concurrent tokenless self-heal could
-		// revoke the row before the mark.
+		// `last_used_at` is now stamped atomically by
+		// validateProviderToken's ValidateAndMarkTokenUsed call at WS
+		// upgrade. The previously-here MarkTokenUsed invocation was
+		// removed because it ran after admission.
 	}
 	tier, closeCode, closeReason := s.checkOrRecordAdmission(hello, pinned, recordAdmission)
 	if closeCode != 0 {
@@ -2866,7 +2830,7 @@ func (s *Server) handlePoolz(w http.ResponseWriter, r *http.Request) {
 }
 
 func providerPublishedReady(p pool.Provider) bool {
-	return p.State == pool.StateReady && p.AuthState != pool.AuthBearerlessDuplicate && len(p.PendingReceiptPubkey) == 0
+	return p.State == pool.StateReady && p.CapacityEligible()
 }
 
 func (s *Server) providerTier2PolicyEligible(p pool.Provider, cfg config.Tier2Config) bool {

--- a/phase4-coordinator/internal/ws/server_test.go
+++ b/phase4-coordinator/internal/ws/server_test.go
@@ -2690,6 +2690,38 @@ func TestProviderHealthzDefaultVersion(t *testing.T) {
 	}
 }
 
+func TestProviderHealthzAndPoolzExcludeSelfMintedFromPublishedCapacity(t *testing.T) {
+	harness := newProviderHarness(t)
+	defer harness.HTTP.Close()
+	now := time.Now().UTC()
+	harness.Registry.Register(&pool.Provider{
+		ProviderID:       "m4-anon",
+		AssignedID:       "self-minted-session",
+		Hostname:         "self-minted.local",
+		ModelID:          "model-a",
+		MaxContextTokens: 20000,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		EndpointURL:      "https://m4.streamvc.live",
+		Tier:             pool.TierPinned,
+		State:            pool.StateReady,
+		LastHeartbeatAt:  now,
+		LastActivityAt:   now,
+		ConnectedAt:      now,
+		BinaryVersion:    "0.1.0",
+		AuthState:        pool.AuthSelfMinted,
+	}, nil)
+
+	healthz := fetchProviderHealthz(t, harness.HTTP.URL)
+	if healthz.PoolSize != 1 || healthz.PoolReady != 0 || healthz.PoolPolicyReady != 0 {
+		t.Fatalf("self-minted healthz = %+v, want visible but not ready/policy-ready", healthz)
+	}
+	poolz := fetchPoolz(t, harness.HTTP.URL)
+	if poolz.Summary.TotalProviders != 1 || poolz.Summary.Ready != 0 || poolz.Summary.FreeSlots != 0 {
+		t.Fatalf("self-minted poolz summary = %+v, want visible but not ready/free capacity", poolz.Summary)
+	}
+}
+
 func TestOperatorEndpointsBlacklistTwoPhaseDrain(t *testing.T) {
 	ts := newProviderServer(t)
 	defer ts.Close()

--- a/phase4-coordinator/test/jcs_fixtures/spec026_register.json
+++ b/phase4-coordinator/test/jcs_fixtures/spec026_register.json
@@ -64,11 +64,10 @@
       "expected_canonical": "{\"a\":{\"a\":\"first\",\"b\":[3,\"two\",true]},\"m\":null,\"z\":\"last\"}"
     },
     {
-      "id": "signature_stripped_current_token_variant",
+      "id": "signature_stripped_register_body_variant",
       "body": {
         "provider_id": "p_abcdefghijklmnopqrstuvwxyz234567abcdefghijklm",
         "identity_pubkey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        "current_provider_token": "existing-token-proof",
         "hardware_summary": {
           "chip": "M4",
           "unified_memory_gb": 24,
@@ -78,7 +77,7 @@
         "nonce": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
         "ts_utc": "2026-07-03T12:00:03Z"
       },
-      "expected_canonical": "{\"current_provider_token\":\"existing-token-proof\",\"hardware_summary\":{\"app_version\":\"1.0.0\",\"chip\":\"M4\",\"macos_version\":\"15.5\",\"unified_memory_gb\":24},\"identity_pubkey\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"nonce\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"provider_id\":\"p_abcdefghijklmnopqrstuvwxyz234567abcdefghijklm\",\"ts_utc\":\"2026-07-03T12:00:03Z\"}"
+      "expected_canonical": "{\"hardware_summary\":{\"app_version\":\"1.0.0\",\"chip\":\"M4\",\"macos_version\":\"15.5\",\"unified_memory_gb\":24},\"identity_pubkey\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"nonce\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"provider_id\":\"p_abcdefghijklmnopqrstuvwxyz234567abcdefghijklm\",\"ts_utc\":\"2026-07-03T12:00:03Z\"}"
     }
   ]
 }

--- a/specs/AUDIT_FIX_IDENTITY_CUSTODY_ARCHITECT_R1.md
+++ b/specs/AUDIT_FIX_IDENTITY_CUSTODY_ARCHITECT_R1.md
@@ -1,0 +1,40 @@
+# Audit Prompt — Identity Custody Architect R1
+
+You are architecture-auditing branch `fix/deepsec-provider-identity-token-custody`.
+Return findings only, grouped by severity: CRITICAL, HIGH, MEDIUM, LOW.
+The pass condition is 0 CRITICAL / 0 HIGH / 0 MEDIUM; LOW is allowed.
+
+Review whether the implementation boundaries and specifications are coherent
+across coordinator auth, App-track onboarding, Swift token custody, and local
+crash consistency.
+
+Files:
+
+- `phase4-coordinator/internal/pool/provider.go`
+- `phase4-coordinator/internal/ws/server.go`
+- `phase4-coordinator/internal/onboarding/apptrack.go`
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`
+- `phase3-binary/Sources/MacProviderCore/ProcessEnvironmentSanitizer.swift`
+- `phase3-binary/Sources/MacProviderCore/BrowserOpener.swift`
+- `phase3-binary/Sources/MacProviderCore/Config.swift`
+- `phase3-binary/Sources/macprovider-cli/ClaimCommand.swift`
+- `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+- `phase3-binary/app/Sources/Malibu/Agent/CLIChildProcess.swift`
+- `phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift`
+- `phase3-binary/app/Sources/Malibu/System/ProcessEnvironmentSanitizer.swift`
+- `phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift`
+- `phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift`
+- `specs/SPEC-016-payout-pipeline.md`
+- `specs/SPEC-026-browserless-provider-onboarding.md`
+- `specs/SPEC-027-provider-proof-of-ownership.md`
+
+Architecture questions:
+
+- Is trust-state ownership centralized enough to prevent caller-by-caller drift?
+- Do the spec gates and handler behavior line up, including nginx routing?
+- Are Swift environment/path/token-file policies reusable without creating conflicting allowlists?
+- Does App-track import/link recovery have a clear state machine and idempotent retry behavior?
+- Are deferred SPEC-027 proof mechanisms isolated without leaving accidental live paths?
+
+Do not require implementation of the full SPEC-027 proof protocol. Report concrete boundary or contract risks with file/line references.

--- a/specs/AUDIT_FIX_IDENTITY_CUSTODY_CODE_R1.md
+++ b/specs/AUDIT_FIX_IDENTITY_CUSTODY_CODE_R1.md
@@ -1,0 +1,51 @@
+# Audit Prompt — Identity Custody Code R1
+
+You are auditing branch `fix/deepsec-provider-identity-token-custody`.
+Return findings only, grouped by severity: CRITICAL, HIGH, MEDIUM, LOW.
+The pass condition is 0 CRITICAL / 0 HIGH / 0 MEDIUM; LOW is allowed.
+
+Review for correctness, test adequacy, edge cases, and maintainability in:
+
+- `phase4-coordinator/internal/pool/provider.go`
+- `phase4-coordinator/internal/pool/provider_test.go`
+- `phase4-coordinator/internal/ws/server.go`
+- `phase4-coordinator/internal/ws/provider_token_self_serve_test.go`
+- `phase4-coordinator/internal/onboarding/apptrack.go`
+- `phase4-coordinator/internal/onboarding/apptrack_test.go`
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/cmd/coordinator/main_test.go`
+- `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`
+- `phase3-binary/Sources/MacProviderCore/ProcessEnvironmentSanitizer.swift`
+- `phase3-binary/Sources/MacProviderCore/BrowserOpener.swift`
+- `phase3-binary/Sources/MacProviderCore/Config.swift`
+- `phase3-binary/Sources/macprovider-cli/ClaimCommand.swift`
+- `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+- `phase3-binary/Tests/macprovider-cliTests/BrowserOpenerTests.swift`
+- `phase3-binary/Tests/macprovider-cliTests/ClaimCommandTests.swift`
+- `phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift`
+- `phase3-binary/app/Sources/Malibu/Agent/CLIChildProcess.swift`
+- `phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift`
+- `phase3-binary/app/Sources/Malibu/System/ProcessEnvironmentSanitizer.swift`
+- `phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift`
+- `phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift`
+- `phase3-binary/app/Tests/MalibuTests/ProcessEnvironmentSanitizerTests.swift`
+- `phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift`
+- `phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift`
+- `phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift`
+- `specs/SPEC-016-payout-pipeline.md`
+- `specs/SPEC-026-browserless-provider-onboarding.md`
+- `specs/SPEC-027-provider-proof-of-ownership.md`
+
+Expected intent:
+
+- Tokenless provider reconnect must not revoke or replace an active provider token.
+- `self_minted` provider sessions are not routing/payout eligible until explicitly verified.
+- App-track wallet binding is gated with a 501 until proof-of-ownership is specified.
+- App Attest verification refuses unpinned Team ID / Bundle ID configuration.
+- Malibu child/browser processes inherit only allowlisted environment variables.
+- CLI path override is release-gated by signing-team validation.
+- Claim refresh strips Authorization on cross-origin HTTPS redirects and rejects non-HTTPS redirects.
+- Inline token argv input is rejected; `--token-file` requires a private file.
+- App config import/linking has durable pending-state markers.
+
+Do not suggest unrelated refactors. Include exact file/line references and a minimal reproducer or failing test idea for each issue.

--- a/specs/AUDIT_FIX_IDENTITY_CUSTODY_SECURITY_R1.md
+++ b/specs/AUDIT_FIX_IDENTITY_CUSTODY_SECURITY_R1.md
@@ -1,0 +1,39 @@
+# Audit Prompt — Identity Custody Security R1
+
+You are security-auditing branch `fix/deepsec-provider-identity-token-custody`.
+Return findings only, grouped by severity: CRITICAL, HIGH, MEDIUM, LOW.
+The pass condition is 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW.
+
+Focus exclusively on bearer-token custody, identity trust, redirect leakage,
+environment leakage, App Attest pinning, and crash/retry states in:
+
+- `phase4-coordinator/internal/pool/provider.go`
+- `phase4-coordinator/internal/ws/server.go`
+- `phase4-coordinator/internal/ws/provider_token_self_serve_test.go`
+- `phase4-coordinator/internal/onboarding/apptrack.go`
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`
+- `phase3-binary/Sources/MacProviderCore/ProcessEnvironmentSanitizer.swift`
+- `phase3-binary/Sources/MacProviderCore/BrowserOpener.swift`
+- `phase3-binary/Sources/MacProviderCore/Config.swift`
+- `phase3-binary/Sources/macprovider-cli/ClaimCommand.swift`
+- `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+- `phase3-binary/app/Sources/Malibu/Agent/CLIChildProcess.swift`
+- `phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift`
+- `phase3-binary/app/Sources/Malibu/System/ProcessEnvironmentSanitizer.swift`
+- `phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift`
+- `phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift`
+- `specs/SPEC-016-payout-pipeline.md`
+- `specs/SPEC-026-browserless-provider-onboarding.md`
+- `specs/SPEC-027-provider-proof-of-ownership.md`
+
+Security invariants to verify:
+
+- No unauthenticated/tokenless flow can rotate, revoke, replace, or capture an existing provider bearer.
+- Unverified self-minted provider state cannot route buyer work or qualify for payout.
+- No bearer token is placed in process arguments, browser child environment, URL scheme parameters, logs, or cross-origin redirect headers.
+- App-track App Attest validation fails closed when Team ID / Bundle ID pins are unset.
+- Release builds do not send Keychain-provided bearer tokens to arbitrary `MALIBU_CLI_PATH` binaries.
+- Token import/link retry markers do not create a rollback, duplicate-token, or stale-state bypass.
+
+For each finding, include attacker preconditions, exploit path, affected file/line, and a concrete fix.

--- a/specs/SPEC-016-payout-pipeline.md
+++ b/specs/SPEC-016-payout-pipeline.md
@@ -1,6 +1,6 @@
 # SPEC-016 — Provider payout pipeline (USDC on Base)
 
-**Version:** 0.1.19 (2026-06-25, draft — audit-narrative split. Splits the inlined codex round-9..19 audit findings out of this SPEC body into per-round `specs/SPEC-016-rN-audit.md` files per the established repo convention ([[feedback-spec-audit-file-convention]] / cf. SPEC-005-r1-audit.md, SPEC-005-r2-audit.md). NO normative changes — only reorganization of audit-narrative artifacts. The body shrinks from ~5,860 lines back to its normative core. Round-by-round audit detail now lives in `specs/SPEC-016-r9-audit.md` through `specs/SPEC-016-r19-audit.md`. Round-19 codex declared CONVERGED at 0/0/0 against v0.1.17; v0.1.18 swept 4 deferred LOWs; v0.1.19 is hygiene-only.)
+**Version:** 0.1.20 (2026-07-04, draft — Wave 2 provider-token custody. Payout attempts require provider-token trust: pinned/operator-issued, bearer-validated, or explicit self_minted_verified proof. Tokenless self-minted sessions are not payout eligible.)
 **Status:** Draft (design-only — no IMPL until operator funds hot
 wallet and discharges the eight §9 prerequisites).
 **Depends on:** SPEC-005 v0.3 (§5.1 unit definition; §10.1 WAL
@@ -28,6 +28,12 @@ live in this SPEC body.
 inlined codex round-9..19 audit findings out of this SPEC body into
 per-round `specs/SPEC-016-rN-audit.md` files. NO normative changes.
 Body shrinks from ~5,860 lines to its normative core.
+
+**v0.1.20 (2026-07-04, draft — Wave 2 provider-token custody):**
+Payout attempts require provider-token trust: pinned/operator-issued,
+bearer-validated, or explicit `self_minted_verified` proof. A
+tokenless `self_minted` provider session remains visible but MUST NOT
+enter payout selection.
 
 **v0.1.18 (2026-06-25, draft — post-convergence LOW sweep, no
 audit fix pass):** Swept the 4 LOWs deferred since round-11
@@ -753,8 +759,13 @@ could fall back to (first-ever registration during
 cooling-off), OR with `registered_against_hot_wallet !=
 payout.security.hot_wallet_address` (row registered against
 a prior hot wallet pre-§6.4 rotation, awaiting
-re-registration per §6.4 step 5), MUST NOT have any payout
-attempt initiated on their behalf. Their
+re-registration per §6.4 step 5), OR whose provider-token
+trust state is only tokenless `self_minted` / unverified,
+MUST NOT have any payout attempt initiated on their behalf.
+Eligible trust states are pinned/operator-issued provider
+configuration, a WebSocket session admitted with
+`bearer_validated`, or an explicit `self_minted_verified`
+proof-of-custody state. Their
 `ledger_payout_ready` rows remain in `status='ready'`.
 
 If a rotation is `pending_until_utc > now()` AND

--- a/specs/SPEC-026-browserless-provider-onboarding.md
+++ b/specs/SPEC-026-browserless-provider-onboarding.md
@@ -1,8 +1,34 @@
 # SPEC-026 — Browserless Provider Onboarding (one-click Launch Provider)
 
-Status: DRAFT v0.12 · Owner: augstar · Target: 2026 Q3
+Status: DRAFT v0.13 · Owner: augstar · Target: 2026 Q3
 
 ## Change log
+
+**v0.13 (2026-07-04, Wave 2 token-custody hardening).** Wave 2
+keeps App-track wallet and non-bearer proof surfaces fail-closed
+until SPEC-027 exists:
+
+- **App-track wallet changes are blocked pending SPEC-027.**
+  `POST /v1/provider/wallet` MUST return
+  `501 {"error":"wallet_change_requires_spec_027"}` for App-track
+  providers until SPEC-027 defines the required non-bearer proof and
+  cancellation semantics.
+- **CLI-track receipt-key rotation proof is old-key signed.**
+  Rotation requests MUST prove control of the currently-published
+  receipt key. A signature that verifies only against the proposed
+  replacement key is self-declared proof and MUST be rejected.
+- **WebSocket `identity_signature` challenge excludes the signature
+  field.** The coordinator challenge is the pre-auth
+  `auth_challenge`; the response signature covers the retained initial
+  transcript plus the coordinator challenge and MUST NOT include the
+  signature value itself in its own signed input.
+- **App Attest pins are required when App Attest evidence is present.**
+  The coordinator MUST reject App Attest verification when the Malibu
+  team ID or bundle ID pin is unset; production pins are loaded from
+  deployment config and must match the Malibu app identity.
+- **Provider-token custody is fail-closed.** Tokenless reconnects MUST
+  NOT revoke or replace an existing `provider_tokens` row. Mutation
+  requires proof of the existing token or an operator recovery action.
 
 **v0.12 (2026-07-03, Step-2 build-prompt audit closure).** The Step-2
 implementation prompt audit found that v0.11 still promised

--- a/specs/SPEC-027-provider-proof-of-ownership.md
+++ b/specs/SPEC-027-provider-proof-of-ownership.md
@@ -1,0 +1,41 @@
+# SPEC-027 — Provider Proof of Ownership for App-Track Wallet Changes
+
+Status: SKELETON v0.1 · Owner: augstar · Target: follow-up to SPEC-026 Wave 2
+
+## 1. Purpose
+
+SPEC-027 will define the non-bearer proof mechanisms required before App-track
+providers can change payout wallets, cancel pending wallet swaps, or rotate
+proof roots without weakening token custody.
+
+This Wave 2 skeleton exists so SPEC-026 and coordinator handlers can fail
+closed with a named dependency instead of inventing partial proof semantics.
+
+## 2. Blocking Requirements
+
+- App-track wallet changes MUST remain unavailable until this spec defines a
+  provider proof that does not rely only on the bearer token.
+- Receipt-key rotation MUST prove possession of the currently-published receipt
+  key. A request signed only by the proposed replacement key is not proof.
+- Provider-token mutation MUST require proof of the existing token or an
+  operator recovery action. Tokenless reconnects MUST NOT revoke or replace
+  active token rows.
+- Any user-visible wallet-swap cancel affordance MUST have coordinator-side
+  state-machine semantics before it ships.
+
+## 3. Non-Goals for the Skeleton
+
+- No endpoint shapes are locked here.
+- No EIP-712 domain is locked here.
+- No email, deep-link, or push-notification channel is locked here.
+- No recovery SLA or operator approval quorum is locked here.
+
+## 4. Interim Coordinator Behavior
+
+Until this spec is complete, `POST /v1/provider/wallet` returns:
+
+```json
+{"error":"wallet_change_requires_spec_027"}
+```
+
+with HTTP `501 Not Implemented`.


### PR DESCRIPTION
## Summary

Provider identity, wallet, receipt-key, and local token-custody correctness.
Establishes the trust anchor that Wave 3 (gateway auth) and Wave 4
(coordinator perimeter) build on top of.

- Requires proof-of-existing-token for any provider token mutation; no
  unauthenticated takeover path.
- Splits provider status into pinned / self-minted-verified /
  self-minted-unverified; only verified statuses reach payout.
- Gates App-track wallet-change behind SPEC-027 with a dedicated 501
  handler.
- Enforces receipt-key rotation semantics via a 7-day previous-key grace
  window, refusing concurrent rotations.
- Pins App Attest team and bundle identity via required config (fails
  closed if unset).
- Redesigns the WebSocket identity_signature challenge/response so the
  signed payload is producible.
- Restricts MALIBU_CLI_PATH to DEBUG builds; release builds ignore the
  override and use the bundled CLI.
- Adds a process-environment sanitizer used by CLIChildProcess and the
  browser spawn path so children inherit only an allowlisted env plus
  the explicit token.
- Strips Authorization on cross-origin redirects during claim refresh.
- Deprecates inline --token in favor of MACPROVIDER_PROVIDER_TOKEN or a
  --token-file.
- Adds link_state to ProviderConfig with a retry-on-startup path so a
  failed link no longer strands the app in an unretryable state.
- SPEC-027 skeleton lands as the placeholder for the non-bearer proof
  mechanism that unlocks App-track wallet and receipt-key rotation flows.

## Changes

### coordinator
- internal/auth/tokens.go, internal/ws/server.go,
  internal/ws/provider_token_self_serve_test.go: proof-required token
  mutations; unauthenticated rotation rejected.
- internal/pool/provider.go, internal/stats/poolsnapshot/:
  verified/unverified/pinned provider status distinction; only verified
  statuses count for payout and pool health.
- internal/onboarding/apptrack.go: producible identity_signature
  handshake; App Attest team + bundle pin.
- cmd/coordinator/main.go: wallet 501 handler; App Attest pin config
  required at startup.
- internal/buyer/server.go: buyer entry hardening.
- dist/nginx-coordinator.streamvc.live.conf: edge headers for App
  Attest surface.

### macOS app + CLI
- Sources/MacProviderCore/ProcessEnvironmentSanitizer.swift +
  app/Sources/Malibu/System/ProcessEnvironmentSanitizer.swift:
  allowlist-based env for child processes.
- Sources/MacProviderCore/BrowserOpener.swift: browser child gets
  sanitized env, no MACPROVIDER_PROVIDER_TOKEN leak.
- app/Sources/Malibu/Agent/CLIChildProcess.swift: child env comes from
  sanitizer + explicit token append.
- app/Sources/Malibu/Agent/MalibuAgent.swift: MALIBU_CLI_PATH override
  restricted to DEBUG builds.
- Sources/macprovider-cli/ClaimCommand.swift: URLSession delegate
  strips Authorization on cross-origin redirect; refuses non-HTTPS
  redirect targets.
- Sources/macprovider-cli/MacProviderCLI.swift: inline --token
  deprecated; MACPROVIDER_PROVIDER_TOKEN or --token-file required.
- app/Sources/Malibu/System/ProviderConfig.swift +
  LaunchProviderController.swift: link_state field + startup retry
  path.
- app/Sources/Malibu/Agent/EarningsClient.swift,
  app/Sources/Malibu/System/RegisterClient.swift: aligned with the
  sanitizer + identity signature changes.

### specs
- SPEC-016-payout-pipeline.md: payout eligibility distinguishes
  verified vs unverified self-mint.
- SPEC-026-browserless-provider-onboarding.md: wallet /
  receipt-key-rotation / identity_signature / App Attest pin sections
  revised; wallet + receipt-key paths gated pending SPEC-027.
- SPEC-027-provider-proof-of-ownership.md: skeleton for non-bearer
  proof mechanism (full text is next).

### audit prompts
- AUDIT_FIX_IDENTITY_CUSTODY_{CODE,SECURITY,ARCHITECT}_R1.md.

## Audit

Three codex lanes fired independently per project convention.

| Lane | Result |
| --- | --- |
| CODE | PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM |
| SECURITY | PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM |
| ARCHITECTURE | WATCH, 0 CRITICAL / 0 HIGH / 0 MEDIUM |

Remaining items are LOW-only. See "Deferred" below.

## Test plan

- [x] go test -count=1 ./internal/auth ./internal/onboarding ./internal/pool ./internal/ws ./internal/buyer ./internal/stats/poolsnapshot ./cmd/coordinator (coordinator)
- [x] go test -count=1 ./internal/router (gateway smoke)
- [x] swift test --filter 'ClaimCommandTests|BrowserOpenerTests|ServeCommandTests' (CLI)
- [x] xcodebuild build-for-testing -project Malibu.xcodeproj -scheme Malibu -destination 'platform=macOS' (Malibu app compile/link)
- [x] git diff --check
- [ ] Malibu Xcode test runner: currently hangs before executing tests due to Xcode target-runner / CoreSimulator tooling noise. Compile+link via build-for-testing passes; unit-level ProcessEnvironmentSanitizer paths are covered by Swift Package tests.
- [ ] Manual: fresh Malibu install → App-track handshake → payout eligibility gate observable (pre-merge staging smoke)

## Deferred

Bundled into a follow-up branch fix/deepsec-crash-consistency-followups
(local plan: .deepsec-local/FIX_PLAN_WAVE2_FOLLOWUP.md), targeted after
Wave 3 lands:

- **AutoUpdateMarker crash-safe import.** Three-phase migration with
  marker file to eliminate a torn-state window during token import.
  Deferred because it is a one-time-per-user path, recoverable by user
  inspection, and not remotely exploitable. Wave 2 audits closed cleanly
  without it; adding a new module now triggers full re-audit for a
  lower-severity item.
- **Wallet route always-mounted 501** (auditor LOW). Currently gated on
  App-track enable flag; recommend unconditional mount so App-track-off
  coordinators fail-closed rather than 404.
- **Backup chmod hardening** (auditor LOW). ProviderConfig backup files
  should chmod 0600 explicitly rather than rely on default umask.
- **Autotune env sanitization** (auditor LOW). Route the autotune child
  through the same ProcessEnvironmentSanitizer.allowlist.
- **Stale SPEC-026 paragraph** (auditor LOW). Spec-only cleanup, one
  paragraph still references pre-SPEC-027 wallet flow.

## Merge coordination

Wave 3 (fix/deepsec-gateway-auth-abuse) branches from origin/main after
this PR merges. Wave 3 touches the same OAuth surface as this wave's App
Attest handlers, so it needs this identity trust anchor in place first.
