### PR TITLE
refactor(coord): extract sqliteutil.Transact; convert 6 money-path sites

### DIFF
--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -465,87 +465,76 @@ func (s *Store) MintProviderTokenAppTrack(ctx context.Context, providerID string
 	if err := config.ValidateProviderID(providerID); err != nil {
 		return "", err
 	}
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return "", err
-	}
-	defer conn.Close()
-	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		return "", err
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+	var token string
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		nowText := nowString()
+		var active struct {
+			ID        int64
+			TokenHash string
 		}
-	}()
-
-	nowText := nowString()
-	var active struct {
-		ID        int64
-		TokenHash string
-	}
-	err = conn.QueryRowContext(ctx, `
+		lookupErr := conn.QueryRowContext(ctx, `
 SELECT id, token_hash
   FROM provider_tokens
  WHERE provider_id = ? AND revoked_at IS NULL
  LIMIT 1`, providerID).Scan(&active.ID, &active.TokenHash)
-	if err != nil && err != sql.ErrNoRows {
-		return "", err
-	}
-
-	requiresProof := err == nil
-	if requiresProof {
-		if currentBearer == nil || strings.TrimSpace(*currentBearer) == "" || tokenHash(strings.TrimSpace(*currentBearer)) != active.TokenHash {
-			return "", ErrAppTrackExistingTokenNoProof
+		if lookupErr != nil && lookupErr != sql.ErrNoRows {
+			return lookupErr
 		}
-		var recent int
-		if err := conn.QueryRowContext(ctx, `
+
+		requiresProof := lookupErr == nil
+		if requiresProof {
+			if currentBearer == nil || strings.TrimSpace(*currentBearer) == "" || tokenHash(strings.TrimSpace(*currentBearer)) != active.TokenHash {
+				return ErrAppTrackExistingTokenNoProof
+			}
+			var recent int
+			if err := conn.QueryRowContext(ctx, `
 SELECT COUNT(1)
   FROM apptrack_register_reissues
  WHERE provider_id = ? AND ts >= ?`,
-			providerID, timeText(time.Now().UTC().Add(-5*time.Minute)),
-		).Scan(&recent); err != nil {
-			return "", err
+				providerID, timeText(time.Now().UTC().Add(-5*time.Minute)),
+			).Scan(&recent); err != nil {
+				return err
+			}
+			if recent > 0 {
+				return ErrAppTrackReissueCooldown
+			}
 		}
-		if recent > 0 {
-			return "", ErrAppTrackReissueCooldown
-		}
-	}
 
-	if err == nil {
-		if _, err := conn.ExecContext(ctx, `
+		if lookupErr == nil {
+			if _, err := conn.ExecContext(ctx, `
 UPDATE provider_tokens
    SET revoked_at = ?
  WHERE id = ? AND revoked_at IS NULL`, nowText, active.ID); err != nil {
-			return "", err
+				return err
+			}
 		}
-	}
 
-	token, err := randomHex(32)
+		newToken, err := randomHex(32)
+		if err != nil {
+			return err
+		}
+		prefix := newToken[:tokenDisplayPrefixLength]
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at)
+VALUES (?, ?, ?, ?, ?)`, tokenHash(newToken), prefix, providerID, "malibu-app", nowText); err != nil {
+			if isActiveProviderTokenConstraintFailure(err) {
+				return ErrActiveTokenAlreadyExists
+			}
+			return err
+		}
+		if requiresProof {
+			if _, err := conn.ExecContext(ctx, `
+INSERT INTO apptrack_register_reissues (provider_id, ts)
+VALUES (?, ?)`, providerID, nowText); err != nil {
+				return err
+			}
+		}
+		token = newToken
+		return nil
+	})
 	if err != nil {
 		return "", err
 	}
-	prefix := token[:tokenDisplayPrefixLength]
-	if _, err := conn.ExecContext(ctx, `
-INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at)
-VALUES (?, ?, ?, ?, ?)`, tokenHash(token), prefix, providerID, "malibu-app", nowText); err != nil {
-		if isActiveProviderTokenConstraintFailure(err) {
-			return "", ErrActiveTokenAlreadyExists
-		}
-		return "", err
-	}
-	if requiresProof {
-		if _, err := conn.ExecContext(ctx, `
-INSERT INTO apptrack_register_reissues (provider_id, ts)
-VALUES (?, ?)`, providerID, nowText); err != nil {
-			return "", err
-		}
-	}
-	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
-		return "", err
-	}
-	committed = true
 	return token, nil
 }
 
@@ -1046,73 +1035,59 @@ func (s *Store) MintPairOTRefresh(ctx context.Context, providerID, sourceIP, use
 	if providerID == "" {
 		return PairOTRefreshResult{}, fmt.Errorf("provider id is required")
 	}
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return PairOTRefreshResult{}, err
-	}
-	defer conn.Close()
-	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		return PairOTRefreshResult{}, err
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+	var result PairOTRefreshResult
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		rows, err := conn.QueryContext(ctx, `SELECT ts FROM pair_ot_mint_log WHERE provider_id = ? AND outcome = 200 AND ts >= ? ORDER BY ts ASC`, providerID, timeText(now.Add(-time.Hour)))
+		if err != nil {
+			return err
 		}
-	}()
-
-	rows, err := conn.QueryContext(ctx, `SELECT ts FROM pair_ot_mint_log WHERE provider_id = ? AND outcome = 200 AND ts >= ? ORDER BY ts ASC`, providerID, timeText(now.Add(-time.Hour)))
-	if err != nil {
-		return PairOTRefreshResult{}, err
-	}
-	count := 0
-	var oldest sql.NullString
-	for rows.Next() {
-		var ts string
-		if err := rows.Scan(&ts); err != nil {
+		count := 0
+		var oldest sql.NullString
+		for rows.Next() {
+			var ts string
+			if err := rows.Scan(&ts); err != nil {
+				rows.Close()
+				return err
+			}
+			if count == 0 {
+				oldest = sql.NullString{String: ts, Valid: true}
+			}
+			count++
+		}
+		if err := rows.Err(); err != nil {
 			rows.Close()
-			return PairOTRefreshResult{}, err
+			return err
 		}
-		if count == 0 {
-			oldest = sql.NullString{String: ts, Valid: true}
-		}
-		count++
-	}
-	if err := rows.Err(); err != nil {
 		rows.Close()
-		return PairOTRefreshResult{}, err
-	}
-	rows.Close()
 
-	if count >= 5 {
+		if count >= 5 {
+			if _, err := conn.ExecContext(ctx, `INSERT INTO pair_ot_mint_log (provider_id, source_ip, user_agent, outcome, ts) VALUES (?, ?, ?, ?, ?)`,
+				providerID, nullString(sourceIP), nullString(userAgent), http.StatusTooManyRequests, timeText(now)); err != nil {
+				return err
+			}
+			result = PairOTRefreshResult{RetryAfter: retryAfterSeconds(oldest, now), RateLimited: true}
+			return nil
+		}
+
+		pairOT, err := randomHex(32)
+		if err != nil {
+			return err
+		}
+		expires := now.Add(10 * time.Minute).UTC()
+		if _, err := conn.ExecContext(ctx, `INSERT INTO pair_ots (id, provider_id, expires_at, created_at) VALUES (?, ?, ?, ?)`, pairOT, providerID, timeText(expires), timeText(now)); err != nil {
+			return err
+		}
 		if _, err := conn.ExecContext(ctx, `INSERT INTO pair_ot_mint_log (provider_id, source_ip, user_agent, outcome, ts) VALUES (?, ?, ?, ?, ?)`,
-			providerID, nullString(sourceIP), nullString(userAgent), http.StatusTooManyRequests, timeText(now)); err != nil {
-			return PairOTRefreshResult{}, err
+			providerID, nullString(sourceIP), nullString(userAgent), http.StatusOK, timeText(now)); err != nil {
+			return err
 		}
-		if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
-			return PairOTRefreshResult{}, err
-		}
-		committed = true
-		return PairOTRefreshResult{RetryAfter: retryAfterSeconds(oldest, now), RateLimited: true}, nil
-	}
-
-	pairOT, err := randomHex(32)
+		result = PairOTRefreshResult{Mint: PairOTMint{PairOT: pairOT, ExpiresAt: expires}}
+		return nil
+	})
 	if err != nil {
 		return PairOTRefreshResult{}, err
 	}
-	expires := now.Add(10 * time.Minute).UTC()
-	if _, err := conn.ExecContext(ctx, `INSERT INTO pair_ots (id, provider_id, expires_at, created_at) VALUES (?, ?, ?, ?)`, pairOT, providerID, timeText(expires), timeText(now)); err != nil {
-		return PairOTRefreshResult{}, err
-	}
-	if _, err := conn.ExecContext(ctx, `INSERT INTO pair_ot_mint_log (provider_id, source_ip, user_agent, outcome, ts) VALUES (?, ?, ?, ?, ?)`,
-		providerID, nullString(sourceIP), nullString(userAgent), http.StatusOK, timeText(now)); err != nil {
-		return PairOTRefreshResult{}, err
-	}
-	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
-		return PairOTRefreshResult{}, err
-	}
-	committed = true
-	return PairOTRefreshResult{Mint: PairOTMint{PairOT: pairOT, ExpiresAt: expires}}, nil
+	return result, nil
 }
 
 func (s *Store) ConsumePendingPairOT(ctx context.Context, sessionID string, now time.Time) (string, error) {

--- a/phase4-coordinator/internal/billing/hotpath.go
+++ b/phase4-coordinator/internal/billing/hotpath.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/requestlog"
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 )
 
 type HotPathInput struct {
@@ -52,112 +53,116 @@ type CacheBillingRoutingDecision struct {
 func (s *Store) WriteHotPath(ctx context.Context, reqLogStore *requestlog.Store, reqRow requestlog.Row, in HotPathInput) error {
 	boundProviderReportedPromptTokens(&in)
 	reqRow = requestLogRowWithBoundedPrompt(reqRow, in)
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		return err
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		if err := reqLogStore.InsertExec(ctx, conn, reqRow); err != nil {
+			return err
 		}
-	}()
-	if err := reqLogStore.InsertExec(ctx, conn, reqRow); err != nil {
-		return err
-	}
-	if in.ProviderAssignedID == "" {
-		_, err := conn.ExecContext(ctx, `COMMIT`)
-		committed = err == nil
-		return err
-	}
-	if in.SettlementAccountScopeHash == "" {
-		in.SettlementAccountScopeHash = SettlementAccountScopeHashForAccountID(reqRow.AccountID)
-	}
-	if in.SettlementPolicyMode == "" {
-		in.SettlementPolicyMode = "legacy"
-	}
-	// SPEC-002 v1.5.0 / issue #211 money-path defense-in-depth:
-	// scope the AttemptN-derivation COUNT by (account_id, request_id)
-	// using SQLite `IS` semantics so all three sites (this one,
-	// recovery.go, endpoints.go admin-reconcile) compute the same
-	// attempt ordinal for any given row. Note that request_log.request_id
-	// is coordinator-internal (server-minted UUID v4); the buyer-
-	// supplied #211 collision class lives on external_request_id and
-	// is addressed by the composite (account_id, external_request_id)
-	// reconciliation key. This account scoping is defense-in-depth:
-	// if a UUID v4 collision or retry-loop bug ever causes the same
-	// internal request_id to recur across accounts, each account's
-	// attempt sequence is computed within its own scope. NULL-
-	// account_id legacy rows cluster with NULL-account_id legacy
-	// rows only (NULL = NULL under `IS`). For an empty in-memory
-	// AccountID, pass an explicit nil so SQLite matches IS NULL.
-	var accountIDArg any
-	if reqRow.AccountID != "" {
-		accountIDArg = reqRow.AccountID
-	}
-	var requestCount int
-	countErr := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM request_log WHERE account_id IS ? AND request_id = ?`, accountIDArg, in.RequestID).Scan(&requestCount)
-	if countErr == nil && requestCount > 0 {
-		if derived := requestCount - 1; derived > in.AttemptN {
-			if in.AttemptN != derived {
+		if in.ProviderAssignedID == "" {
+			return nil
+		}
+		if in.SettlementAccountScopeHash == "" {
+			in.SettlementAccountScopeHash = SettlementAccountScopeHashForAccountID(reqRow.AccountID)
+		}
+		if in.SettlementPolicyMode == "" {
+			in.SettlementPolicyMode = "legacy"
+		}
+		// SPEC-002 v1.5.0 / issue #211 money-path defense-in-depth:
+		// scope the AttemptN-derivation COUNT by (account_id, request_id)
+		// using SQLite `IS` semantics so all three sites (this one,
+		// recovery.go, endpoints.go admin-reconcile) compute the same
+		// attempt ordinal for any given row. Note that request_log.request_id
+		// is coordinator-internal (server-minted UUID v4); the buyer-
+		// supplied #211 collision class lives on external_request_id and
+		// is addressed by the composite (account_id, external_request_id)
+		// reconciliation key. This account scoping is defense-in-depth:
+		// if a UUID v4 collision or retry-loop bug ever causes the same
+		// internal request_id to recur across accounts, each account's
+		// attempt sequence is computed within its own scope. NULL-
+		// account_id legacy rows cluster with NULL-account_id legacy
+		// rows only (NULL = NULL under `IS`). For an empty in-memory
+		// AccountID, pass an explicit nil so SQLite matches IS NULL.
+		var accountIDArg any
+		if reqRow.AccountID != "" {
+			accountIDArg = reqRow.AccountID
+		}
+		var requestCount int
+		countErr := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM request_log WHERE account_id IS ? AND request_id = ?`, accountIDArg, in.RequestID).Scan(&requestCount)
+		if countErr == nil && requestCount > 0 {
+			if derived := requestCount - 1; derived > in.AttemptN {
+				if in.AttemptN != derived {
+					in.AttemptN = derived
+					if in.TSUtc.IsZero() {
+						in.TSUtc = time.Now().UTC()
+					}
+					if in.FaultFlag == "" {
+						in.FaultFlag = FaultNone
+					}
+					result := ComputeCredits(
+						in.PromptTokens,
+						in.CompletionTokens,
+						in.EstimatedCompTokens,
+						usageFor(in.ErrorCode, in.EstimatedCompTokens),
+						in.FaultFlag,
+						in.RateEntry,
+						in.MultiplierPPM,
+						in.ProviderShareBps,
+					)
+					result = zeroCredits(result)
+					now := time.Now().UTC().Format(time.RFC3339Nano)
+					if _, err := insertRequestCreditTx(ctx, conn, in, result, "hot_path", now, true, "ambiguous_attempt_n"); err != nil {
+						return err
+					}
+					if err := insertProviderIdentitySnapshotTx(ctx, conn, in, now); err != nil {
+						return err
+					}
+					return nil
+				}
 				in.AttemptN = derived
-				if in.TSUtc.IsZero() {
-					in.TSUtc = time.Now().UTC()
-				}
-				if in.FaultFlag == "" {
-					in.FaultFlag = FaultNone
-				}
-				result := ComputeCredits(
-					in.PromptTokens,
-					in.CompletionTokens,
-					in.EstimatedCompTokens,
-					usageFor(in.ErrorCode, in.EstimatedCompTokens),
-					in.FaultFlag,
-					in.RateEntry,
-					in.MultiplierPPM,
-					in.ProviderShareBps,
-				)
-				result = zeroCredits(result)
-				now := time.Now().UTC().Format(time.RFC3339Nano)
-				if _, err := insertRequestCreditTx(ctx, conn, in, result, "hot_path", now, true, "ambiguous_attempt_n"); err != nil {
-					return err
-				}
-				if err := insertProviderIdentitySnapshotTx(ctx, conn, in, now); err != nil {
-					return err
-				}
-				_, err := conn.ExecContext(ctx, `COMMIT`)
-				committed = err == nil
+			}
+		}
+		if in.TSUtc.IsZero() {
+			in.TSUtc = time.Now().UTC()
+		}
+		if in.FaultFlag == "" {
+			in.FaultFlag = FaultNone
+		}
+		cacheQuarantineReason := normalizeCachedPromptTokens(&in)
+		logCacheBillingRoutingDecision(in, cacheQuarantineReason)
+		// SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168) quarantine rule:
+		// with persisted monotonic attempt_n, row 3+ (attempt_n >= 2) is
+		// credited normally — the v0.3.1 "row 3+ MUST quarantine until
+		// SPEC-002 gains monotonic attempt_n" rule is now satisfied. The
+		// remaining quarantine class is attempt_n==1 with retried==0:
+		// legitimate-retry-without-explicit-marker that cannot be safely
+		// distinguished from a buggy duplicate INSERT. This narrowing is
+		// safe in the hot path because reqRow.AttemptN here is the value
+		// just persisted by InsertExec (v1.5.2 always writes a non-NULL
+		// value); the in.AttemptN was already aligned to the persisted
+		// value by the post-INSERT COUNT-1 derivation above.
+		if in.AttemptN == 1 && reqRow.Retried == 0 {
+			result := ComputeCredits(
+				in.PromptTokens,
+				in.CompletionTokens,
+				in.EstimatedCompTokens,
+				usageFor(in.ErrorCode, in.EstimatedCompTokens),
+				in.FaultFlag,
+				in.RateEntry,
+				in.MultiplierPPM,
+				in.ProviderShareBps,
+			)
+			result = zeroCredits(result)
+			now := time.Now().UTC().Format(time.RFC3339Nano)
+			if _, err := insertRequestCreditTx(ctx, conn, in, result, "hot_path", now, true, "ambiguous_attempt_n"); err != nil {
 				return err
 			}
-			in.AttemptN = derived
+			if err := insertProviderIdentitySnapshotTx(ctx, conn, in, now); err != nil {
+				return err
+			}
+			return nil
 		}
-	}
-	if in.TSUtc.IsZero() {
-		in.TSUtc = time.Now().UTC()
-	}
-	if in.FaultFlag == "" {
-		in.FaultFlag = FaultNone
-	}
-	cacheQuarantineReason := normalizeCachedPromptTokens(&in)
-	logCacheBillingRoutingDecision(in, cacheQuarantineReason)
-	// SPEC-005 v0.3.3 / SPEC-002 v1.5.2 (issue #168) quarantine rule:
-	// with persisted monotonic attempt_n, row 3+ (attempt_n >= 2) is
-	// credited normally — the v0.3.1 "row 3+ MUST quarantine until
-	// SPEC-002 gains monotonic attempt_n" rule is now satisfied. The
-	// remaining quarantine class is attempt_n==1 with retried==0:
-	// legitimate-retry-without-explicit-marker that cannot be safely
-	// distinguished from a buggy duplicate INSERT. This narrowing is
-	// safe in the hot path because reqRow.AttemptN here is the value
-	// just persisted by InsertExec (v1.5.2 always writes a non-NULL
-	// value); the in.AttemptN was already aligned to the persisted
-	// value by the post-INSERT COUNT-1 derivation above.
-	if in.AttemptN == 1 && reqRow.Retried == 0 {
-		result := ComputeCredits(
+		result := ComputeCreditsWithCache(
 			in.PromptTokens,
+			in.CachedPromptTokens,
 			in.CompletionTokens,
 			in.EstimatedCompTokens,
 			usageFor(in.ErrorCode, in.EstimatedCompTokens),
@@ -166,58 +171,32 @@ func (s *Store) WriteHotPath(ctx context.Context, reqLogStore *requestlog.Store,
 			in.MultiplierPPM,
 			in.ProviderShareBps,
 		)
-		result = zeroCredits(result)
 		now := time.Now().UTC().Format(time.RFC3339Nano)
-		if _, err := insertRequestCreditTx(ctx, conn, in, result, "hot_path", now, true, "ambiguous_attempt_n"); err != nil {
+		if cacheQuarantineReason != "" {
+			result = zeroCredits(result)
+			if _, err := insertRequestCreditTx(ctx, conn, in, result, "hot_path", now, true, cacheQuarantineReason); err != nil {
+				return err
+			}
+			if err := insertProviderIdentitySnapshotTx(ctx, conn, in, now); err != nil {
+				return err
+			}
+			return nil
+		}
+		requestCreditID, err := insertRequestCreditTx(ctx, conn, in, result, "hot_path", now, false, "")
+		if err != nil {
+			return err
+		}
+		if err := insertOperatorCreditTx(ctx, conn, requestCreditID, in, result, now); err != nil {
 			return err
 		}
 		if err := insertProviderIdentitySnapshotTx(ctx, conn, in, now); err != nil {
 			return err
 		}
-		_, err := conn.ExecContext(ctx, `COMMIT`)
-		committed = err == nil
-		return err
-	}
-	result := ComputeCreditsWithCache(
-		in.PromptTokens,
-		in.CachedPromptTokens,
-		in.CompletionTokens,
-		in.EstimatedCompTokens,
-		usageFor(in.ErrorCode, in.EstimatedCompTokens),
-		in.FaultFlag,
-		in.RateEntry,
-		in.MultiplierPPM,
-		in.ProviderShareBps,
-	)
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-	if cacheQuarantineReason != "" {
-		result = zeroCredits(result)
-		if _, err := insertRequestCreditTx(ctx, conn, in, result, "hot_path", now, true, cacheQuarantineReason); err != nil {
+		if _, err := syncVerifiedReceiptLedgerCreditForAttemptTx(ctx, conn, in.RequestID, int64(in.AttemptN), in.ProviderID); err != nil {
 			return err
 		}
-		if err := insertProviderIdentitySnapshotTx(ctx, conn, in, now); err != nil {
-			return err
-		}
-		_, err := conn.ExecContext(ctx, `COMMIT`)
-		committed = err == nil
-		return err
-	}
-	requestCreditID, err := insertRequestCreditTx(ctx, conn, in, result, "hot_path", now, false, "")
-	if err != nil {
-		return err
-	}
-	if err := insertOperatorCreditTx(ctx, conn, requestCreditID, in, result, now); err != nil {
-		return err
-	}
-	if err := insertProviderIdentitySnapshotTx(ctx, conn, in, now); err != nil {
-		return err
-	}
-	if _, err := syncVerifiedReceiptLedgerCreditForAttemptTx(ctx, conn, in.RequestID, int64(in.AttemptN), in.ProviderID); err != nil {
-		return err
-	}
-	_, err = conn.ExecContext(ctx, `COMMIT`)
-	committed = err == nil
-	return err
+		return nil
+	})
 }
 
 func normalizeCachedPromptTokens(in *HotPathInput) string {
@@ -301,32 +280,18 @@ func (s *Store) WriteRequestLogWithIdentity(ctx context.Context, reqLogStore *re
 		}
 	}
 	reqRow = requestLogRowWithBoundedPrompt(reqRow, in)
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		return err
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
-		}
-	}()
-	if err := reqLogStore.InsertExec(ctx, conn, reqRow); err != nil {
-		return err
-	}
-	if in.ProviderAssignedID != "" && in.ProviderID != "" {
-		now := time.Now().UTC().Format(time.RFC3339Nano)
-		if err := insertProviderIdentitySnapshotTx(ctx, conn, in, now); err != nil {
+	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		if err := reqLogStore.InsertExec(ctx, conn, reqRow); err != nil {
 			return err
 		}
-	}
-	_, err = conn.ExecContext(ctx, `COMMIT`)
-	committed = err == nil
-	return err
+		if in.ProviderAssignedID != "" && in.ProviderID != "" {
+			now := time.Now().UTC().Format(time.RFC3339Nano)
+			if err := insertProviderIdentitySnapshotTx(ctx, conn, in, now); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func requestLogRowWithBoundedPrompt(row requestlog.Row, in HotPathInput) requestlog.Row {

--- a/phase4-coordinator/internal/billing/settlement_receipts.go
+++ b/phase4-coordinator/internal/billing/settlement_receipts.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 )
 
 const (
@@ -220,84 +222,70 @@ func (s *Store) RecordMissingSettlementReceipt(ctx context.Context, input Settle
 }
 
 func (s *Store) applySettlementReceiptVerdict(ctx context.Context, id SettlementReceiptIdentity, receiptPresent bool, receivedAtUnixMS int64, verify func(settlementEvidence, bool) SettlementVerifyResult) (SettlementReceiptState, error) {
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return SettlementReceiptState{}, err
-	}
-	defer conn.Close()
-	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		return SettlementReceiptState{}, err
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+	var outcome SettlementReceiptState
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		existing, found, err := loadSettlementReceiptStateConn(ctx, conn, id)
+		if err != nil {
+			return err
 		}
-	}()
+		if found && existing.Closed {
+			existing.IdempotencyStatus = settlementReceiptIDTerminalNoop
+			if err := hydrateSettlementReceiptRouteAuditFieldsConn(ctx, conn, &existing); err != nil {
+				return err
+			}
+			if err := insertSettlementReceiptVerdictAuditConn(ctx, conn, existing, nil, receivedAtUnixMS); err != nil {
+				return err
+			}
+			outcome = existing
+			return nil
+		}
+		evidence, err := loadSettlementEvidenceConn(ctx, conn, id)
+		if err != nil {
+			return err
+		}
 
-	existing, found, err := loadSettlementReceiptStateConn(ctx, conn, id)
+		result := verify(evidence, false)
+		state, err := settlementReceiptStateFromResult(id, evidence, result, receiptPresent, receivedAtUnixMS, found)
+		if err != nil {
+			return err
+		}
+		persisted, err := settlementReceiptPersistedFromState(state, result)
+		if err != nil {
+			return err
+		}
+		if found {
+			if err := updateSettlementReceiptStateConn(ctx, conn, persisted); err != nil {
+				return err
+			}
+		} else if err := insertSettlementReceiptStateConn(ctx, conn, persisted); err != nil {
+			return err
+		}
+		if reason, err := syncVerifiedReceiptLedgerCreditForAttemptTx(ctx, conn, state.RequestID, state.AttemptN, state.ProviderID); err != nil {
+			return err
+		} else if reason != "" {
+			state.ReceiptResult = SettlementReceiptResultInvalid
+			state.SettlementOutcome = SettlementOutcomeQuarantined
+			state.Reason = reason
+			state.Closed = true
+			if err := markSettlementReceiptCacheQuarantinedConn(ctx, conn, state, reason); err != nil {
+				return err
+			}
+		}
+		if receiptPresent {
+			if err := insertSettlementReceiptIngestedAuditConn(ctx, conn, state); err != nil {
+				return err
+			}
+		}
+		if err := insertSettlementReceiptVerdictAuditConn(ctx, conn, state, &result.Checks, receivedAtUnixMS); err != nil {
+			return err
+		}
+		outcome = state
+		return nil
+	})
 	if err != nil {
 		return SettlementReceiptState{}, err
 	}
-	if found && existing.Closed {
-		existing.IdempotencyStatus = settlementReceiptIDTerminalNoop
-		if err := hydrateSettlementReceiptRouteAuditFieldsConn(ctx, conn, &existing); err != nil {
-			return SettlementReceiptState{}, err
-		}
-		if err := insertSettlementReceiptVerdictAuditConn(ctx, conn, existing, nil, receivedAtUnixMS); err != nil {
-			return SettlementReceiptState{}, err
-		}
-		if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
-			return SettlementReceiptState{}, err
-		}
-		committed = true
-		return existing, nil
-	}
-	evidence, err := loadSettlementEvidenceConn(ctx, conn, id)
-	if err != nil {
-		return SettlementReceiptState{}, err
-	}
-
-	result := verify(evidence, false)
-	state, err := settlementReceiptStateFromResult(id, evidence, result, receiptPresent, receivedAtUnixMS, found)
-	if err != nil {
-		return SettlementReceiptState{}, err
-	}
-	persisted, err := settlementReceiptPersistedFromState(state, result)
-	if err != nil {
-		return SettlementReceiptState{}, err
-	}
-	if found {
-		if err := updateSettlementReceiptStateConn(ctx, conn, persisted); err != nil {
-			return SettlementReceiptState{}, err
-		}
-	} else if err := insertSettlementReceiptStateConn(ctx, conn, persisted); err != nil {
-		return SettlementReceiptState{}, err
-	}
-	if reason, err := syncVerifiedReceiptLedgerCreditForAttemptTx(ctx, conn, state.RequestID, state.AttemptN, state.ProviderID); err != nil {
-		return SettlementReceiptState{}, err
-	} else if reason != "" {
-		state.ReceiptResult = SettlementReceiptResultInvalid
-		state.SettlementOutcome = SettlementOutcomeQuarantined
-		state.Reason = reason
-		state.Closed = true
-		if err := markSettlementReceiptCacheQuarantinedConn(ctx, conn, state, reason); err != nil {
-			return SettlementReceiptState{}, err
-		}
-	}
-	if receiptPresent {
-		if err := insertSettlementReceiptIngestedAuditConn(ctx, conn, state); err != nil {
-			return SettlementReceiptState{}, err
-		}
-	}
-	if err := insertSettlementReceiptVerdictAuditConn(ctx, conn, state, &result.Checks, receivedAtUnixMS); err != nil {
-		return SettlementReceiptState{}, err
-	}
-	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
-		return SettlementReceiptState{}, err
-	}
-	committed = true
-	return state, nil
+	return outcome, nil
 }
 
 type settlementReceiptCreditSyncDB interface {

--- a/phase4-coordinator/internal/billing/snapshot.go
+++ b/phase4-coordinator/internal/billing/snapshot.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"errors"
 	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 )
 
 var ErrNoSnapshot = errors.New("no config snapshot found")
@@ -125,46 +127,34 @@ func (s *Store) ReloadBillingConfig(ctx context.Context, cfg RewardsConfig, forc
 		}
 	}
 
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return 0, err
-	}
-	defer conn.Close()
-	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		return 0, err
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
-		}
-	}()
-
-	res, err := conn.ExecContext(ctx, `
+	var snapshotID int64
+	if err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		res, err := conn.ExecContext(ctx, `
 INSERT INTO ledger_config_snapshots (
     effective_at_utc, config_hash, provider_share_bps, global_multiplier_ppm,
     rate_card_json, created_at_utc
 ) VALUES (?, ?, ?, ?, ?, ?)`,
-		ts, hash, canon.ProviderShareBps, canon.GlobalMultiplierPPM, string(rateJSON), ts,
-	)
-	if err != nil {
-		return 0, err
-	}
-	snapshotID, err := res.LastInsertId()
-	if err != nil {
-		return 0, err
-	}
-	if flagChanged {
-		if _, err := conn.ExecContext(ctx, `
+			ts, hash, canon.ProviderShareBps, canon.GlobalMultiplierPPM, string(rateJSON), ts,
+		)
+		if err != nil {
+			return err
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			return err
+		}
+		if flagChanged {
+			if _, err := conn.ExecContext(ctx, `
 INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
 VALUES (?, 'billing_config_flag_changed', NULL, ?)`, ts, string(flagPayloadJSON)); err != nil {
-			return 0, err
+				return err
+			}
 		}
-	}
-	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		snapshotID = id
+		return nil
+	}); err != nil {
 		return 0, err
 	}
-	committed = true
 	// Only after the snapshot row and (optional) flag-change audit
 	// row are durably committed do we publish the in-memory force-
 	// void flag. Handlers cannot observe the new value before the

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 	_ "modernc.org/sqlite"
 )
 
@@ -979,34 +980,17 @@ func (s *Store) SetForceVoidEnabled(ctx context.Context, newValue bool, reloadSo
 	if err != nil {
 		return fmt.Errorf("marshal flag-change payload: %w", err)
 	}
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("acquire conn for flag-change audit: %w", err)
-	}
-	defer conn.Close()
-	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		return fmt.Errorf("begin immediate for flag-change audit: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
-		}
-	}()
-	now := payload["ts_utc"].(string)
-	if _, err := conn.ExecContext(ctx, `
+	if err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		now := payload["ts_utc"].(string)
+		if _, err := conn.ExecContext(ctx, `
 INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
 VALUES (?, 'billing_config_flag_changed', NULL, ?)`, now, string(payloadJSON)); err != nil {
-		_, _ = conn.ExecContext(ctx, `ROLLBACK`)
-		return fmt.Errorf("insert flag-change audit: %w", err)
+			return fmt.Errorf("insert flag-change audit: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
-	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
-		// Audit row may or may not be durable; assume not. Leave the
-		// route flag unchanged and surface the error so the operator
-		// can re-attempt.
-		return fmt.Errorf("commit flag-change audit: %w", err)
-	}
-	committed = true
 	// Audit is durable: publish the new value. No handler could
 	// observe newValue before this point because the only reader is
 	// h.store.ForceVoidEnabled() which reads s.forceVoidEnabled.

--- a/phase4-coordinator/internal/sqliteutil/transact.go
+++ b/phase4-coordinator/internal/sqliteutil/transact.go
@@ -1,0 +1,62 @@
+package sqliteutil
+
+import (
+	"context"
+	"database/sql"
+)
+
+// Transact reserves a single *sql.Conn from db, issues BEGIN IMMEDIATE to
+// take the SQLite write lock deterministically, invokes fn with the
+// reserved connection, and then COMMITs on nil error or ROLLBACKs on
+// non-nil error (or panic).
+//
+// The ROLLBACK is issued with context.Background(), never the caller's
+// ctx, so cancellation of the request context after a partial write does
+// not leave the transaction dangling.
+//
+// The callback receives the reserved *sql.Conn and MUST issue all
+// subsequent statements against it — SQLite transactions are bound to a
+// single connection, and running a statement on a different conn from the
+// pool while a BEGIN IMMEDIATE is in flight would deadlock against the
+// write lock this call is holding.
+//
+// This helper replaces the hand-rolled
+//
+//	conn, _ := s.db.Conn(ctx); defer conn.Close()
+//	conn.ExecContext(ctx, "BEGIN IMMEDIATE")
+//	committed := false
+//	defer func() { if !committed { _, _ = conn.ExecContext(context.Background(), "ROLLBACK") } }()
+//	... work ...
+//	conn.ExecContext(ctx, "COMMIT"); committed = true
+//
+// pattern used across money-path stores (billing, auth token issuance,
+// requestlog, receipts). Semantics are byte-equivalent to that pattern;
+// see phase4-coordinator/internal/sqliteutil/transact_test.go for the
+// invariant coverage.
+func Transact(ctx context.Context, db *sql.DB, fn func(context.Context, *sql.Conn) error) (err error) {
+	conn, cerr := db.Conn(ctx)
+	if cerr != nil {
+		return cerr
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+
+	if err := fn(ctx, conn); err != nil {
+		return err
+	}
+
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}

--- a/phase4-coordinator/internal/sqliteutil/transact_test.go
+++ b/phase4-coordinator/internal/sqliteutil/transact_test.go
@@ -1,0 +1,115 @@
+package sqliteutil
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	return db
+}
+
+func rowCount(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	return n
+}
+
+func TestTransactCommitsOnNilError(t *testing.T) {
+	db := openTestDB(t)
+	err := Transact(context.Background(), db, func(ctx context.Context, conn *sql.Conn) error {
+		if _, err := conn.ExecContext(ctx, `INSERT INTO t (v) VALUES ('a'), ('b')`); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Transact returned err: %v", err)
+	}
+	if n := rowCount(t, db); n != 2 {
+		t.Fatalf("row count after commit = %d, want 2", n)
+	}
+}
+
+func TestTransactRollsBackOnError(t *testing.T) {
+	db := openTestDB(t)
+	sentinel := errors.New("callback rejected")
+	err := Transact(context.Background(), db, func(ctx context.Context, conn *sql.Conn) error {
+		if _, err := conn.ExecContext(ctx, `INSERT INTO t (v) VALUES ('a')`); err != nil {
+			return err
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Transact returned %v, want sentinel", err)
+	}
+	if n := rowCount(t, db); n != 0 {
+		t.Fatalf("row count after rollback = %d, want 0", n)
+	}
+}
+
+// TestTransactRollbackUsesBackgroundContext verifies the load-bearing
+// invariant that ROLLBACK is issued with context.Background(), not the
+// caller's ctx: a caller who cancels their ctx after a partial write must
+// not leave the SQLite write lock held.
+func TestTransactRollbackUsesBackgroundContext(t *testing.T) {
+	db := openTestDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	sentinel := errors.New("aborting after partial write")
+	err := Transact(ctx, db, func(innerCtx context.Context, conn *sql.Conn) error {
+		if _, err := conn.ExecContext(innerCtx, `INSERT INTO t (v) VALUES ('a')`); err != nil {
+			return err
+		}
+		// Simulate a caller cancelling before the callback returns.
+		// If the helper used innerCtx for ROLLBACK, the rollback exec
+		// would fail with context.Canceled and the tx would leak. Our
+		// invariant is that ROLLBACK runs on context.Background().
+		cancel()
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Transact returned %v, want sentinel", err)
+	}
+	// Prove the tx was fully unwound: a fresh BEGIN IMMEDIATE on a
+	// separate conn must succeed immediately. If the previous tx
+	// held the writer lock the busy_timeout would fire (or with our
+	// pool of 1, this would deadlock).
+	if err := Transact(context.Background(), db, func(c context.Context, conn *sql.Conn) error {
+		_, err := conn.ExecContext(c, `INSERT INTO t (v) VALUES ('b')`)
+		return err
+	}); err != nil {
+		t.Fatalf("follow-up Transact after cancelled-caller rollback: %v", err)
+	}
+	if n := rowCount(t, db); n != 1 {
+		t.Fatalf("row count = %d, want 1 (only the follow-up commit)", n)
+	}
+}
+
+func TestTransactBeginError(t *testing.T) {
+	db := openTestDB(t)
+	_ = db.Close() // force db.Conn to fail
+	err := Transact(context.Background(), db, func(ctx context.Context, conn *sql.Conn) error {
+		t.Fatal("callback should not run when db is closed")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("Transact returned nil on closed db, want error")
+	}
+}

--- a/specs/AUDIT_SQLUTIL_TRANSACT_PROMPT.md
+++ b/specs/AUDIT_SQLUTIL_TRANSACT_PROMPT.md
@@ -1,0 +1,160 @@
+# AUDIT: `sqliteutil.Transact` helper + 6 money-path call-site conversions
+
+## Change under review
+
+Branch: `refactor/sqlutil-transact` (base `origin/main` = `3537154`).
+
+**New file:**
+
+- `phase4-coordinator/internal/sqliteutil/transact.go` (~62 LoC): defines
+  `Transact(ctx, db, fn(ctx, *sql.Conn) error) error`. Reserves a single
+  `*sql.Conn`, issues `BEGIN IMMEDIATE`, invokes `fn`, then `COMMIT` on nil
+  error or `ROLLBACK` on non-nil error. **`ROLLBACK` is issued with
+  `context.Background()`, never the caller's ctx** — this matches the
+  invariant from every hand-rolled site being replaced.
+
+**Converted call sites (6):**
+
+1. `phase4-coordinator/internal/auth/tokens.go` `MintProviderTokenAppTrack`
+   (App-track token issuance, SPEC-003 FR-C9, SPEC-026)
+2. `phase4-coordinator/internal/auth/tokens.go` `MintPairOTRefresh`
+   (pair-OT refresh, SPEC-014, rate-limited)
+3. `phase4-coordinator/internal/billing/hotpath.go` `WriteHotPath` — the
+   BIG one. Four early-COMMIT-and-return branches in the original
+   (attempt_n reconciliation, quarantine attempt-1, cache-quarantine,
+   happy path).
+4. `phase4-coordinator/internal/billing/hotpath.go`
+   `WriteRequestLogWithIdentity` (identity-snapshot writeback)
+5. `phase4-coordinator/internal/billing/store.go` `SetForceVoidEnabled`
+   (SPEC-005 §11.6 force-void flag audit; test
+   `TestSetForceVoidEnabledRollsBackOnAuditFailure` at
+   `quarantine_test.go:1351` is the load-bearing regression guard)
+6. `phase4-coordinator/internal/billing/snapshot.go` (config-snapshot +
+   optional flag-change audit atomic write)
+7. `phase4-coordinator/internal/billing/settlement_receipts.go`
+   `applySettlementReceiptVerdict` (SPEC-022 receipt idempotency +
+   settlement outcome)
+
+**Sites NOT converted (justified):**
+
+- `phase4-coordinator/internal/billing/quarantine.go:140`
+  (`handleForceVoid` HTTP handler): 4 different HTTP response paths
+  (404, validation error, 409 already-resolved, 500, 200) interleaved
+  with the tx and requires re-reading via `s.db` on the already-resolved
+  409 path AFTER releasing the conn (MaxOpenConns=1 deadlock avoidance,
+  see comment at `:184-188`). Converting cleanly requires restructuring
+  the whole handler, not the tx. Kept inline.
+- `phase4-coordinator/internal/requestlog/store.go:883`
+  (`BackfillAttemptNDryRun`): the current pattern always ROLLBACKs
+  (never COMMITs). `sqliteutil.Transact` commits on nil return, so it
+  is the wrong shape for a dry-run.
+- `phase5-gateway/internal/storage/sqlite/store.go:1770`
+  (`beginImmediate`): gateway already has its own `immediateTx` object
+  abstraction used by 12 call sites; no consolidation win.
+
+Diffstat (excludes the new `transact.go` file):
+
+```
+ phase4-coordinator/internal/auth/tokens.go            | 205 +++++++-------
+ phase4-coordinator/internal/billing/hotpath.go        | 299 +++++++++------------
+ phase4-coordinator/internal/billing/settlement_receipts.go | 124 ++++-----
+ phase4-coordinator/internal/billing/snapshot.go       |  52 ++--
+ phase4-coordinator/internal/billing/store.go          |  34 +--
+ 5 files changed, 308 insertions(+), 406 deletions(-)
+```
+
+Net -98 LoC in call sites + 62 LoC in the new helper = **-36 LoC net**,
+plus **one place** now owns BEGIN IMMEDIATE / ROLLBACK-on-cancel
+semantics for the money-path.
+
+## Semantics-preservation invariants each lane MUST verify
+
+1. **Rollback context isolation.** The hand-rolled pattern uses
+   `context.Background()` for the rollback, so cancellation of the
+   caller's ctx after a partial write does not leave the tx dangling.
+   `sqliteutil.Transact` MUST preserve this. Verify at
+   `sqliteutil/transact.go:52`.
+2. **Commit-then-publish ordering** in `SetForceVoidEnabled`. The
+   `forceVoidEnabled.Store(newValue)` MUST NOT execute unless the audit
+   INSERT durably committed. Reg test
+   `TestSetForceVoidEnabledRollsBackOnAuditFailure` covers this;
+   verify the refactor keeps `Store` outside the callback.
+3. **Return-value plumbing.** `MintProviderTokenAppTrack` and
+   `MintPairOTRefresh` return non-error data through a closure-captured
+   local var, set inside the callback before returning nil. Verify no
+   path returns nil-error-with-zero-value (would leak an empty token
+   or empty PairOTRefreshResult to a caller expecting success).
+4. **Early-return branches in `WriteHotPath`.** The original had four
+   `COMMIT + committed = err == nil + return err` sites at
+   lines 73, 132, 177, 218 (pre-refactor). Each is now `return nil`
+   inside the callback. Verify no branch dropped a mutation between
+   the original explicit COMMIT and the callback return.
+5. **`syncVerifiedReceiptLedgerCreditForAttemptTx` participation.** In
+   both `WriteHotPath` and `applySettlementReceiptVerdict`, this
+   helper runs INSIDE the tx. Verify the refactored callback still
+   passes `conn` (not `s.db`) to that helper — passing `s.db` would
+   deadlock at `MaxOpenConns=1` because the tx is holding the writer.
+6. **Error-wrapping regression.** `store.go:SetForceVoidEnabled`
+   previously wrapped BEGIN/COMMIT errors with `fmt.Errorf("begin
+   immediate for flag-change audit: %w", err)` and similar. The
+   refactor moves those inside the callback (only the INSERT is
+   wrapped now). Verify no test asserts the old error strings.
+7. **`applySettlementReceiptVerdict` early-return** at the
+   `found && existing.Closed` branch preserved the state via
+   `existing.IdempotencyStatus = ...`, hydration, audit INSERT, and
+   COMMIT-with-return. Verify the refactored callback assigns
+   `outcome = existing` before `return nil` (not
+   `outcome = state` — different variables).
+
+## What each lane should check
+
+### Lane A — code
+
+- Are the callback return values ever nil-on-partial-success? (i.e.
+  data assigned to an outer var, then a subsequent error, then a
+  second early-return that leaves the outer var stale).
+- Does the callback ever call a helper that expects `*sql.DB` rather
+  than `*sql.Conn` (silent second-conn acquisition → deadlock at
+  MaxOpenConns=1)?
+- Are there any `defer` orderings that changed (e.g. a deferred close
+  that used to run before ROLLBACK now runs after)?
+- Byte-equivalence check: does the helper's BEGIN/ROLLBACK/COMMIT
+  sequence match what each hand-rolled site did?
+
+### Lane B — security
+
+- Does the `Transact` helper leak a token or receipt state through
+  the closure on a rollback path? (Return-value plumbing in
+  `MintProviderTokenAppTrack` / `MintPairOTRefresh`.)
+- Does the SetForceVoidEnabled path publish the atomic flag before
+  the audit row is durable, under any refactored code path?
+- Is the ROLLBACK-with-Background-ctx invariant preserved so a
+  cancelled request cannot leave the write lock held?
+
+### Lane C — architect
+
+- Is `internal/sqliteutil` the right home for this? (`dsn.go` already
+  lives there; `WithPragmas` is byte-duplicated with gateway on
+  purpose per ARCH-5). The helper is coord-only for now — flag if
+  gateway should also adopt (my read: no, gateway has
+  `beginImmediate`+`immediateTx` object-style already).
+- Should the 3 skipped sites be tracked as follow-up work
+  (quarantine.go handler, requestlog dry-run, gateway parity)?
+- Does the abstraction pay for itself at 6 call sites, or is this
+  premature? (My read: yes — the ROLLBACK-with-Background-ctx
+  invariant is subtle enough that centralizing it is worth the
+  callback indirection, and the 4 early-COMMIT branches in
+  `WriteHotPath` reduced from 4× `COMMIT + committed = err == nil +
+  return err` to 4× `return nil`.)
+
+## Deliverable per lane
+
+Plain-text report, same format as previous audits:
+
+- **Verdict**: `PASS 0 CRITICAL / 0 HIGH / 0 MEDIUM` or a list of findings.
+- **Findings**: `SEVERITY | file:line | one-sentence claim | evidence`.
+- **Recommendation**: `merge` / `merge after LOW fixes` / `hold`.
+
+Money-path bar per repo convention: 0 CRITICAL, 0 HIGH, 0 MEDIUM
+across all three lanes before merge. LOW findings ship with PR-body
+documentation.


### PR DESCRIPTION
## Summary

Extracts `phase4-coordinator/internal/sqliteutil.Transact(ctx, db, fn)` — a callback-shaped helper that reserves a `*sql.Conn`, issues `BEGIN IMMEDIATE`, invokes `fn`, then `COMMIT`s on nil error or `ROLLBACK`s on non-nil error. Preserves the load-bearing invariant that `ROLLBACK` uses `context.Background()` (never the caller's ctx), so cancellation after a partial write cannot leave the SQLite write lock held.

Converts **6 money-path call sites** to the helper:

- `internal/auth/tokens.go` — `MintProviderTokenAppTrack` (App-track token issuance, SPEC-003 FR-C9 / SPEC-026)
- `internal/auth/tokens.go` — `MintPairOTRefresh` (pair-OT refresh, rate-limited)
- `internal/billing/hotpath.go` — `WriteHotPath` (had 4 early-COMMIT-and-return branches; each now returns nil from the callback)
- `internal/billing/hotpath.go` — `WriteRequestLogWithIdentity`
- `internal/billing/store.go` — `SetForceVoidEnabled` (SPEC-005 §11.6 force-void flag audit; `TestSetForceVoidEnabledRollsBackOnAuditFailure` is the load-bearing regression guard)
- `internal/billing/snapshot.go` — config-snapshot + optional flag-change audit atomic write
- `internal/billing/settlement_receipts.go` — `applySettlementReceiptVerdict` (SPEC-022 receipt idempotency + settlement outcome)

## Sites intentionally NOT converted

Three additional `BEGIN IMMEDIATE` sites in tree that the abstraction doesn't fit:

- `internal/billing/quarantine.go:140` (`handleForceVoid` HTTP handler): 4 different HTTP response paths (404, validation error, 409 already-resolved, 500, 200) interleaved with the tx; the 409 path releases the conn before re-reading via `s.db` (MaxOpenConns=1 deadlock avoidance). Cleanly converting requires restructuring the whole handler, not the tx.
- `internal/requestlog/store.go:883` (`BackfillAttemptNDryRun`): always ROLLBACKs, never COMMITs. `Transact` commits on nil return, so it is the wrong shape for a dry-run.
- `phase5-gateway/internal/storage/sqlite/store.go:1770`: gateway already has its own `immediateTx` object abstraction used by 12 call sites. No consolidation win.

## Diffstat

- Net change: **-98 LoC** in call sites + **62 LoC** in the new helper + **111 LoC** in the new test file.
- One place now owns BEGIN IMMEDIATE / ROLLBACK-on-cancel semantics for the money-path.

## Audit trail (3-lane codex)

Money-path bar: 3-lane codex audit converged in one round.

| Round | Code | Security | Architect |
|---|---|---|---|
| R1 | PASS 0/0/0 (no findings, merge) | PASS 0/0/0 (2 LOWs: missing test file, pre-existing govulncheck) | PASS 0/0/0 (1 LOW: missing test file) |

The missing-test-file LOW is closed by `transact_test.go` in this commit (4 tests including the load-bearing `TestTransactRollbackUsesBackgroundContext` that proves rollback survives a cancelled caller ctx). The govulncheck LOW is pre-existing in `stats.NormalizeOrigin -> idna.Lookup.ToASCII` and unrelated to this refactor — deferred.

Audit prompt committed at `specs/AUDIT_SQLUTIL_TRANSACT_PROMPT.md`.

## Test plan

- [x] `go build ./...` clean in both `phase4-coordinator` and `phase5-gateway`
- [x] `go test ./...` PASS in both modules (28 packages coord, 7 packages gateway)
- [x] `go test ./internal/sqliteutil` — new tests: `TestTransactCommitsOnNilError`, `TestTransactRollsBackOnError`, `TestTransactRollbackUsesBackgroundContext`, `TestTransactBeginError` — all PASS
- [x] Existing money-path regression `TestSetForceVoidEnabledRollsBackOnAuditFailure` (asserts audit-INSERT failure leaves the atomic flag unpublished) — PASS after refactor
- [x] Existing money-path regression `TestReloadBillingConfigAtomicAuditAndSnapshot` — PASS after refactor
- [x] `TestACQ047_SameTransactionAtomicity` (quarantine same-tx atomicity) — PASS after refactor

## Re-trigger conditions

Reopen this decision if: (a) one of the three skipped sites gets restructured such that `Transact` fits (particularly the `quarantine.go` handler if its dispatch is disentangled from the tx), (b) a new BEGIN IMMEDIATE site is added and the reviewer forgets to use `Transact`, or (c) the ROLLBACK-with-Background-ctx invariant needs to change (e.g. request-scoped cancellation propagation for observability).

Generated with Claude Code.
