### PR TITLE
fix(gateway): enforce OAuth flag, atomic issuance ceilings, oauth_state TTL/prune, audit-after-auth + feedback bounds

### DIFF
--- a/phase5-gateway/cmd/gateway/main.go
+++ b/phase5-gateway/cmd/gateway/main.go
@@ -72,11 +72,13 @@ func main() {
 	}()
 
 	slog.Info("gateway initialized", "address", cfg.Address(), "db_path", cfg.Storage.DBPath)
+	slog.Info("gateway oauth", "github_oauth", cfg.Auth.GitHubOAuthEnabled)
 	if *checkOnly {
 		return
 	}
 
 	go runReservationReaper(ctx, store, time.Duration(cfg.Quotas.ReaperIntervalHours)*time.Hour)
+	go runOAuthStatePruner(ctx, store, time.Minute)
 
 	// coordinatorTransport clones the default transport and adds
 	// ResponseHeaderTimeout so buyers get a bounded failure if the coordinator
@@ -190,6 +192,35 @@ const terminalReservationRetention = 7 * 24 * time.Hour
 type reservationReaper interface {
 	ReapExpiredReservations(context.Context, time.Time) (int64, error)
 	DeleteTerminalQuotaReservations(context.Context, time.Time) (int64, error)
+}
+
+type oauthStatePruner interface {
+	PruneExpiredOAuthState(context.Context, time.Time) (int64, error)
+}
+
+func runOAuthStatePruner(ctx context.Context, store oauthStatePruner, interval time.Duration) {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	prune := func() {
+		deleted, err := store.PruneExpiredOAuthState(ctx, time.Now().UTC())
+		if err != nil {
+			slog.Warn("oauth state prune failed", "error", err)
+		} else if deleted > 0 {
+			slog.Info("expired oauth states pruned", "count", deleted)
+		}
+	}
+	prune()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			prune()
+		}
+	}
 }
 
 func runReservationReaper(ctx context.Context, store reservationReaper, interval time.Duration) {

--- a/phase5-gateway/cmd/gateway/main_test.go
+++ b/phase5-gateway/cmd/gateway/main_test.go
@@ -35,6 +35,42 @@ func (f *fakeSettlementReconciler) ReconcileSettlementHolds(ctx context.Context,
 	}
 }
 
+type fakeOAuthPruner struct {
+	calls chan time.Time
+}
+
+func (f *fakeOAuthPruner) PruneExpiredOAuthState(ctx context.Context, now time.Time) (int64, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case f.calls <- now:
+		return 1, nil
+	}
+}
+
+func TestRunOAuthStatePrunerRunsAndStops(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &fakeOAuthPruner{calls: make(chan time.Time, 2)}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runOAuthStatePruner(ctx, fake, time.Hour)
+	}()
+
+	select {
+	case <-fake.calls:
+	case <-time.After(time.Second):
+		t.Fatal("oauth state pruner did not run immediately")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("oauth state pruner did not stop after context cancellation")
+	}
+}
+
 func TestRunSettlementReconcilerRunsImmediately(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	fake := &fakeSettlementReconciler{calls: make(chan int, 2)}

--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -39,6 +39,7 @@ auth:
   github_oauth_enabled: true
   email_magic_link_enabled: false
   oauth:
+    state_max_per_ip: 20
     callback_allowlist:
       - https://api.streamvc.live/auth/github/callback
       - http://localhost:9443/auth/github/callback
@@ -65,6 +66,8 @@ limits:
   max_tokens_per_request: 4096
   demo_max_tokens_per_request: 512
   max_feedback_comment_bytes: 2000
+  max_feedback_body_bytes: 16384
+  feedback_requests_per_ip_per_hour: 10
   request_body_bytes: 1048576
 
 kill_switch:

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -77,6 +77,7 @@ type AuthConfig struct {
 
 type OAuthConfig struct {
 	CallbackAllowlist []string          `yaml:"callback_allowlist"`
+	StateMaxPerIP     int               `yaml:"state_max_per_ip"`
 	GitHub            GitHubOAuthConfig `yaml:"github"`
 }
 
@@ -104,10 +105,12 @@ type QuotasConfig struct {
 }
 
 type LimitsConfig struct {
-	MaxTokensPerRequest     int64 `yaml:"max_tokens_per_request"`
-	DemoMaxTokensPerRequest int64 `yaml:"demo_max_tokens_per_request"`
-	MaxFeedbackCommentBytes int   `yaml:"max_feedback_comment_bytes"`
-	RequestBodyBytes        int64 `yaml:"request_body_bytes"`
+	MaxTokensPerRequest          int64 `yaml:"max_tokens_per_request"`
+	DemoMaxTokensPerRequest      int64 `yaml:"demo_max_tokens_per_request"`
+	MaxFeedbackCommentBytes      int   `yaml:"max_feedback_comment_bytes"`
+	MaxFeedbackBodyBytes         int64 `yaml:"max_feedback_body_bytes"`
+	FeedbackRequestsPerIPPerHour int   `yaml:"feedback_requests_per_ip_per_hour"`
+	RequestBodyBytes             int64 `yaml:"request_body_bytes"`
 }
 
 type KillSwitchConfig struct {
@@ -169,7 +172,7 @@ func Default() Config {
 			KeyHash:               "hmac_sha256",
 			GitHubOAuthEnabled:    true,
 			EmailMagicLinkEnabled: false,
-			OAuth: OAuthConfig{CallbackAllowlist: []string{
+			OAuth: OAuthConfig{StateMaxPerIP: 20, CallbackAllowlist: []string{
 				"https://api.streamvc.live/auth/github/callback",
 			}, GitHub: GitHubOAuthConfig{
 				AuthorizeURL: "https://github.com/login/oauth/authorize",
@@ -200,10 +203,12 @@ func Default() Config {
 			ReservationMaxAgeHours:    24,
 		},
 		Limits: LimitsConfig{
-			MaxTokensPerRequest:     4096,
-			DemoMaxTokensPerRequest: 512,
-			MaxFeedbackCommentBytes: 2000,
-			RequestBodyBytes:        1048576,
+			MaxTokensPerRequest:          4096,
+			DemoMaxTokensPerRequest:      512,
+			MaxFeedbackCommentBytes:      2000,
+			MaxFeedbackBodyBytes:         16 * 1024,
+			FeedbackRequestsPerIPPerHour: 10,
+			RequestBodyBytes:             1048576,
 		},
 		Capacity: CapacityConfig{
 			MonthlyBudgetUSD: 500, ReadyProviderDegradedThreshold: 1, ProjectedCostTier1Percent: 80, TierCooldownSeconds: 3600,
@@ -369,6 +374,9 @@ func (c Config) Validate() error {
 			return err
 		}
 	}
+	if c.Auth.OAuth.StateMaxPerIP <= 0 {
+		return fmt.Errorf("auth.oauth.state_max_per_ip must be > 0")
+	}
 	if c.Quotas.AccountDailyTokens <= 0 || c.Quotas.DemoDailyTokensPerIP <= 0 {
 		return fmt.Errorf("quotas must be positive")
 	}
@@ -387,8 +395,11 @@ func (c Config) Validate() error {
 	if c.Limits.MaxTokensPerRequest <= 0 || c.Limits.DemoMaxTokensPerRequest <= 0 || c.Limits.RequestBodyBytes <= 0 {
 		return fmt.Errorf("limits must be positive")
 	}
-	if c.Limits.MaxFeedbackCommentBytes <= 0 {
-		return fmt.Errorf("limits.max_feedback_comment_bytes must be > 0")
+	if c.Limits.MaxFeedbackCommentBytes <= 0 || c.Limits.MaxFeedbackBodyBytes <= 0 || c.Limits.FeedbackRequestsPerIPPerHour <= 0 {
+		return fmt.Errorf("feedback limits must be positive")
+	}
+	if int64(c.Limits.MaxFeedbackCommentBytes) > c.Limits.MaxFeedbackBodyBytes {
+		return fmt.Errorf("limits.max_feedback_comment_bytes must be <= limits.max_feedback_body_bytes")
 	}
 	if c.Capacity.MonthlyBudgetUSD <= 0 || c.Capacity.ReadyProviderDegradedThreshold <= 0 || c.Capacity.ProjectedCostTier1Percent <= 0 || c.Capacity.TierCooldownSeconds <= 0 {
 		return fmt.Errorf("capacity thresholds must be positive")

--- a/phase5-gateway/internal/router/admin.go
+++ b/phase5-gateway/internal/router/admin.go
@@ -30,7 +30,7 @@ func (s *Server) handleFeedbackSummary(w http.ResponseWriter, r *http.Request) {
 	}
 	end := s.now()
 	start := end.AddDate(0, 0, -days)
-	events, err := s.store.ListFeedbackEventsSince(r.Context(), start)
+	events, err := s.store.ListFeedbackEventsSinceLimit(r.Context(), start, 1000)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "feedback_summary_failed", "Could not summarize feedback")
 		return
@@ -198,7 +198,9 @@ func buildFeedbackSummary(events []storage.FeedbackSummaryEvent, start, end time
 		if event.RequestID != "" {
 			key = event.AccountID + "\x00" + event.RequestID
 		}
-		latest[key] = event
+		if existing, ok := latest[key]; !ok || event.CreatedAt.After(existing.CreatedAt) {
+			latest[key] = event
+		}
 	}
 	distribution := map[string]int{"1": 0, "2": 0, "3": 0, "4": 0}
 	type scopeAgg struct {

--- a/phase5-gateway/internal/router/auth_helpers.go
+++ b/phase5-gateway/internal/router/auth_helpers.go
@@ -23,10 +23,19 @@ func (s *Server) operatorAuthorized(w http.ResponseWriter, r *http.Request) bool
 }
 
 func (s *Server) shouldPersistInternalHeaderAudit(r *http.Request) bool {
-	if strings.HasPrefix(r.URL.Path, "/admin/explorer/") || r.URL.Path == "/admin/explorer" {
+	if strings.HasPrefix(r.URL.Path, "/admin/") {
 		return operatorBearerAuthorized(r.Header, s.cfg.Coordinator.OperatorKey)
 	}
-	return true
+	if token := r.Header.Get("X-Demo-Token"); token != "" {
+		_, err := s.demoMgr.Validate(token, s.clientIP(r), s.now())
+		return err == nil
+	}
+	header := r.Header.Get("Authorization")
+	if !strings.HasPrefix(header, "Bearer ") {
+		return false
+	}
+	_, err := s.keyMgr.Validate(r.Context(), s.store, strings.TrimSpace(strings.TrimPrefix(header, "Bearer ")))
+	return err == nil
 }
 
 func operatorBearerAuthorized(headers http.Header, expected string) bool {

--- a/phase5-gateway/internal/router/oauth.go
+++ b/phase5-gateway/internal/router/oauth.go
@@ -14,6 +14,10 @@ import (
 )
 
 func (s *Server) handleGitHubStart(w http.ResponseWriter, r *http.Request) {
+	if !s.cfg.Auth.GitHubOAuthEnabled {
+		http.Error(w, "oauth_disabled", http.StatusServiceUnavailable)
+		return
+	}
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method_not_allowed", "Method not allowed")
 		return
@@ -49,10 +53,14 @@ func (s *Server) handleGitHubStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := s.now()
-	if err := s.store.StoreOAuthState(r.Context(), storage.OAuthState{
+	if err := s.store.StoreOAuthStateWithCap(r.Context(), storage.OAuthState{
 		StateHash: auth.StateHash(state), SessionID: sessionID, RedirectURI: redirectURI,
 		ClientIP: s.clientIP(r), Action: action, CreatedAt: now, ExpiresAt: auth.OAuthStateExpiry(now),
-	}); err != nil {
+	}, s.cfg.Auth.OAuth.StateMaxPerIP, now); err != nil {
+		if errors.Is(err, storage.ErrOAuthStateCap) {
+			writeError(w, http.StatusTooManyRequests, "rate_limit_exceeded", "oauth_state_rate_limited", "OAuth start limit exceeded")
+			return
+		}
 		writeError(w, http.StatusInternalServerError, "server_error", "oauth_state_store_failed", "Could not start OAuth flow")
 		return
 	}
@@ -64,6 +72,10 @@ func (s *Server) handleGitHubStart(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
+	if !s.cfg.Auth.GitHubOAuthEnabled {
+		http.Error(w, "oauth_disabled", http.StatusServiceUnavailable)
+		return
+	}
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method_not_allowed", "Method not allowed")
 		return
@@ -159,29 +171,31 @@ func (s *Server) createSignupAccount(w http.ResponseWriter, ctx context.Context,
 		return storage.Account{}, storage.ErrQuotaExceeded
 	}
 	ip := s.clientIP(r)
-	count, err := s.store.CountSignupEventsSince(ctx, ip, s.now().Add(-24*time.Hour))
-	if err != nil {
+	now := s.now()
+	if err := s.store.ReservePublicIssuance(ctx, storage.PublicIssuanceReservation{
+		Surface: "signup", ClientIP: ip, WindowStart: now.Add(-24 * time.Hour), Limit: s.cfg.Quotas.SignupAccountsPerIPPerDay, CreatedAt: now,
+	}); err != nil {
+		if errors.Is(err, storage.ErrRateLimit) {
+			writeError(w, http.StatusTooManyRequests, "rate_limit_exceeded", "signup_rate_limited", "Signup limit exceeded")
+			return storage.Account{}, err
+		}
 		writeError(w, http.StatusInternalServerError, "server_error", "signup_limit_check_failed", "Could not check signup limit")
 		return storage.Account{}, err
 	}
-	if count >= s.cfg.Quotas.SignupAccountsPerIPPerDay {
-		writeError(w, http.StatusTooManyRequests, "rate_limit_exceeded", "signup_rate_limited", "Signup limit exceeded")
-		return storage.Account{}, storage.ErrQuotaExceeded
-	}
 	accountID := mustID("acct")
-	account := storage.Account{AccountID: accountID, Status: "active", QuotaClass: "default", ConcurrencyClass: "default", CreatedAt: s.now()}
+	account := storage.Account{AccountID: accountID, Status: "active", QuotaClass: "default", ConcurrencyClass: "default", CreatedAt: now}
 	if err := s.store.CreateAccount(ctx, account); err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "account_create_failed", "Could not create account")
 		return storage.Account{}, err
 	}
 	if err := s.store.AddAccountIdentity(ctx, storage.AccountIdentity{
-		AccountID: accountID, Provider: "github", ProviderUserID: identity.ProviderUserID, Email: identity.Email, CreatedAt: s.now(),
+		AccountID: accountID, Provider: "github", ProviderUserID: identity.ProviderUserID, Email: identity.Email, CreatedAt: now,
 	}); err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "identity_create_failed", "Could not create identity")
 		return storage.Account{}, err
 	}
 	if err := s.store.RecordSignupEvent(ctx, storage.SignupEvent{
-		EventID: mustID("signup"), AccountID: accountID, ClientIP: ip, Provider: "github", CreatedAt: s.now(),
+		EventID: mustID("signup"), AccountID: accountID, ClientIP: ip, Provider: "github", CreatedAt: now,
 	}); err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "signup_event_failed", "Could not record signup")
 		return storage.Account{}, err
@@ -199,21 +213,23 @@ func (s *Server) handleDemoSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ip := s.clientIP(r)
-	count, err := s.store.CountDemoSessionEventsSince(r.Context(), ip, s.now().Add(-time.Hour))
-	if err != nil {
+	now := s.now()
+	if err := s.store.ReservePublicIssuance(r.Context(), storage.PublicIssuanceReservation{
+		Surface: "demo_session", ClientIP: ip, WindowStart: now.Add(-time.Hour), Limit: s.cfg.Quotas.DemoSessionsPerIPPerHour, CreatedAt: now,
+	}); err != nil {
+		if errors.Is(err, storage.ErrRateLimit) {
+			writeError(w, http.StatusTooManyRequests, "rate_limit_exceeded", "demo_session_rate_limited", "Demo session limit exceeded")
+			return
+		}
 		writeError(w, http.StatusInternalServerError, "server_error", "demo_session_check_failed", "Could not check demo session limit")
 		return
 	}
-	if count >= s.cfg.Quotas.DemoSessionsPerIPPerHour {
-		writeError(w, http.StatusTooManyRequests, "rate_limit_exceeded", "demo_session_rate_limited", "Demo session limit exceeded")
-		return
-	}
-	token, expires, err := s.demoMgr.Issue(ip, s.now(), 24*time.Hour)
+	token, expires, err := s.demoMgr.Issue(ip, now, 24*time.Hour)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "demo_token_issuance_failed", "Could not issue demo token")
 		return
 	}
-	if err := s.store.RecordDemoSessionEvent(r.Context(), storage.DemoSessionEvent{EventID: mustID("demo"), ClientIP: ip, CreatedAt: s.now()}); err != nil {
+	if err := s.store.RecordDemoSessionEvent(r.Context(), storage.DemoSessionEvent{EventID: mustID("demo"), ClientIP: ip, CreatedAt: now}); err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "demo_session_record_failed", "Could not record demo session")
 		return
 	}

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"expvar"
 	"fmt"
 	"log/slog"
 	"net"
@@ -21,6 +23,8 @@ import (
 	"github.com/augstar/macprovider-gateway/internal/config"
 	"github.com/augstar/macprovider-gateway/internal/storage"
 )
+
+var unauthenticatedInternalProbes = expvar.NewInt("unauthenticated_internal_probes_total")
 
 type Server struct {
 	cfg     config.Config
@@ -180,8 +184,10 @@ func (s *Server) loadRuntimeKillSwitch(ctx context.Context) {
 
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/auth/github/start", s.handleGitHubStart)
-	mux.HandleFunc("/auth/github/callback", s.handleGitHubCallback)
+	if s.cfg.Auth.GitHubOAuthEnabled {
+		mux.HandleFunc("/auth/github/start", s.handleGitHubStart)
+		mux.HandleFunc("/auth/github/callback", s.handleGitHubCallback)
+	}
 	mux.Handle("/auth/demo-session", s.withCORS(http.MethodPost, http.HandlerFunc(s.handleDemoSession)))
 	mux.HandleFunc("/auth/api-keys", s.handleAPIKeys)
 	mux.HandleFunc("/auth/api-keys/", s.handleAPIKeyAction)
@@ -224,6 +230,8 @@ func (s *Server) middleware(next http.Handler) http.Handler {
 					EventID: mustID("audit"), RequestID: requestID, Actor: "public_ingress", Type: "internal_header_injection_stripped",
 					Payload: fmt.Sprintf(`{"headers":%q}`, strings.Join(stripped, ",")), CreatedAt: s.now(),
 				})
+			} else {
+				unauthenticatedInternalProbes.Add(1)
 			}
 		}
 		w.Header().Set("X-Request-ID", requestID)
@@ -411,13 +419,19 @@ func (s *Server) handleFeedback(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method_not_allowed", "Method not allowed")
 		return
 	}
+	if !validFeedbackSource(r.Header.Get("X-Feedback-Source")) {
+		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_feedback_source", "feedback source is required")
+		return
+	}
+	ip := s.clientIP(r)
+	now := s.now()
 	var req struct {
 		Rating    int    `json:"rating"`
 		Comment   string `json:"comment"`
 		RequestID string `json:"request_id"`
 		Scope     string `json:"scope"`
 	}
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, int64(s.cfg.Limits.MaxFeedbackCommentBytes)+4096)).Decode(&req); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, s.cfg.Limits.MaxFeedbackBodyBytes)).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_feedback", "Invalid feedback")
 		return
 	}
@@ -464,7 +478,16 @@ func (s *Server) handleFeedback(w http.ResponseWriter, r *http.Request) {
 		}
 		accountID = validation.AccountID
 	}
-	now := s.now()
+	if err := s.store.ReservePublicIssuance(r.Context(), storage.PublicIssuanceReservation{
+		Surface: "feedback", ClientIP: ip, WindowStart: now.Add(-time.Hour), Limit: s.cfg.Limits.FeedbackRequestsPerIPPerHour, CreatedAt: now,
+	}); err != nil {
+		if errors.Is(err, storage.ErrRateLimit) {
+			writeError(w, http.StatusTooManyRequests, "rate_limit_exceeded", "feedback_rate_limited", "Feedback rate limit exceeded")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "server_error", "feedback_limit_check_failed", "Could not check feedback limit")
+		return
+	}
 	event := storage.FeedbackEvent{
 		EventID: mustID("fb"), RequestID: req.RequestID, AccountID: accountID, Scope: req.Scope,
 		Rating: req.Rating, Comment: req.Comment, CreatedAt: now,
@@ -755,6 +778,20 @@ func sortedKeys(set map[string]struct{}) []string {
 
 func validFeedbackScope(scope string) bool {
 	return scope == "request" || scope == "session" || scope == "account" || scope == "playground"
+}
+
+func validFeedbackSource(source string) bool {
+	source = strings.TrimSpace(source)
+	if source == "" || len(source) > 64 {
+		return false
+	}
+	for _, r := range source {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func safeID(v string) bool {

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -86,6 +86,44 @@ func TestOAuthStateCSRF(t *testing.T) {
 	}
 }
 
+func TestGitHubOAuthDisabledRoutesAreUnmounted(t *testing.T) {
+	h, _, _, _ := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Auth.GitHubOAuthEnabled = false
+		cfg.Auth.OAuth.GitHub.ClientID = ""
+		cfg.Auth.OAuth.GitHub.ClientSecret = ""
+	})
+
+	for _, path := range []string{"/auth/github/start", "/auth/github/callback"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		resp := httptest.NewRecorder()
+		h.ServeHTTP(resp, req)
+		if resp.Code != http.StatusNotFound {
+			t.Fatalf("%s status=%d want 404 body=%s", path, resp.Code, resp.Body.String())
+		}
+	}
+}
+
+func TestGitHubOAuthHandlersFailClosedWhenDisabled(t *testing.T) {
+	cfg := config.Default()
+	cfg.Auth.GitHubOAuthEnabled = false
+	s := &Server{cfg: cfg}
+
+	for name, handler := range map[string]http.HandlerFunc{
+		"start":    s.handleGitHubStart,
+		"callback": s.handleGitHubCallback,
+	} {
+		req := httptest.NewRequest(http.MethodGet, "/auth/github/"+name, nil)
+		resp := httptest.NewRecorder()
+		handler(resp, req)
+		if resp.Code != http.StatusServiceUnavailable {
+			t.Fatalf("%s status=%d want 503 body=%s", name, resp.Code, resp.Body.String())
+		}
+		if !strings.Contains(resp.Body.String(), "oauth_disabled") {
+			t.Fatalf("%s body=%q want oauth_disabled", name, resp.Body.String())
+		}
+	}
+}
+
 func TestOAuthScopeMinimization(t *testing.T) {
 	h, _, _, _ := newTestHarness(t, fakeOAuth{identity: auth.OAuthIdentity{ProviderUserID: "44", Scopes: []string{"read:user"}}})
 	state, cookie := startOAuth(t, h, "https://api.streamvc.live/auth/github/callback")
@@ -1299,6 +1337,77 @@ func TestFeedbackSummaryAggregation(t *testing.T) {
 	}
 	if countRows(t, dbPath, "feedback_events") != 5 {
 		t.Fatalf("feedback append-only event count mismatch")
+	}
+}
+
+func TestFeedbackRequiresSourceAndBoundsWrites(t *testing.T) {
+	h, store, _, cfg := newTestHarness(t, fakeOAuth{})
+	fullKey := createAccountAndKey(t, store, cfg, "acct_feedback_bounds")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/feedback", strings.NewReader(`{"rating":4,"comment":"ok","scope":"account"}`))
+	req.Header.Set("Authorization", "Bearer "+fullKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("missing source status=%d want 400 body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "invalid_feedback_source")
+
+	tooLargeBody := `{"rating":4,"comment":"` + strings.Repeat("x", int(cfg.Limits.MaxFeedbackBodyBytes)) + `","scope":"account"}`
+	resp = postFeedback(t, h, fullKey, "", tooLargeBody)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("oversize body status=%d want 400 body=%s", resp.Code, resp.Body.String())
+	}
+
+	tooLongComment := `{"rating":4,"comment":"` + strings.Repeat("x", cfg.Limits.MaxFeedbackCommentBytes+1) + `","scope":"account"}`
+	resp = postFeedback(t, h, fullKey, "", tooLongComment)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("long comment status=%d want 400 body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "comment_too_long")
+}
+
+func TestFeedbackRateLimitPerIP(t *testing.T) {
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Limits.FeedbackRequestsPerIPPerHour = 10
+	})
+	fullKey := createAccountAndKey(t, store, cfg, "acct_feedback_rate")
+	for i := 0; i < 10; i++ {
+		submitFeedback(t, h, fullKey, "", fmt.Sprintf(`{"rating":4,"comment":"ok %d","scope":"account"}`, i))
+	}
+	resp := postFeedback(t, h, fullKey, "", `{"rating":4,"comment":"blocked","scope":"account"}`)
+	if resp.Code != http.StatusTooManyRequests {
+		t.Fatalf("11th feedback status=%d want 429 body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "feedback_rate_limited")
+}
+
+func TestFeedbackSummaryLimitsRawScan(t *testing.T) {
+	h, store, _, cfg := newTestHarness(t, fakeOAuth{})
+	for i := 0; i < 1100; i++ {
+		if err := store.InsertFeedbackEvent(context.Background(), storage.FeedbackEvent{
+			EventID: fmt.Sprintf("fb_limit_%04d", i), RequestID: "", AccountID: "acct_summary_limit",
+			Scope: "account", Rating: 4, Comment: "", CreatedAt: fixedNow().Add(time.Duration(i) * time.Second),
+		}); err != nil {
+			t.Fatalf("InsertFeedbackEvent %d: %v", i, err)
+		}
+	}
+	req := httptest.NewRequest(http.MethodGet, "/admin/feedback-summary", nil)
+	req.Header.Set("Authorization", "Bearer "+cfg.Coordinator.OperatorKey)
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("summary status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		RatingCount int `json:"rating_count"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("summary json: %v body=%s", err, resp.Body.String())
+	}
+	if body.RatingCount != 1000 {
+		t.Fatalf("rating_count=%d want 1000 limited raw scan", body.RatingCount)
 	}
 }
 
@@ -5414,6 +5523,7 @@ func postFeedback(t *testing.T, h http.Handler, bearer, demoToken, body string) 
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/v1/feedback", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Feedback-Source", "test")
 	req.Header.Set("X-Real-IP", "1.2.3.4")
 	if bearer != "" {
 		req.Header.Set("Authorization", "Bearer "+bearer)
@@ -6097,14 +6207,7 @@ func TestStickyDeleteIsAccountScopedRegardlessOfQueryParam(t *testing.T) {
 	}
 }
 
-// TestInternalHeaderStripAndAuditEventOnUnauthenticatedRequest pins that
-// the strip-before-auth middleware fires AND audit-logs a buyer-supplied
-// X-MacProvider-Internal-Conv even when the request is unauthenticated
-// (no bearer at all). The strip MUST run before auth so a 401-returning
-// path is still audited; otherwise an attacker can probe the gateway with
-// throwaway tokens or no tokens and the injection attempt goes unlogged.
-// Regression-locks the code-review MAJOR (strip-on-unauthenticated path).
-func TestInternalHeaderStripAndAuditEventOnUnauthenticatedRequest(t *testing.T) {
+func TestInternalHeaderStripDoesNotAuditUnauthenticatedRequest(t *testing.T) {
 	h, _, dbPath, _ := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
 		cfg.Coordinator.BuyerURL = "http://coordinator.test"
 		cfg.Coordinator.OperatorURL = "http://operator.test"
@@ -6122,9 +6225,29 @@ func TestInternalHeaderStripAndAuditEventOnUnauthenticatedRequest(t *testing.T) 
 	if resp.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 for missing bearer, got %d body=%s", resp.Code, resp.Body.String())
 	}
-	// Strip-before-auth must STILL have fired and audited; otherwise an
-	// attacker can probe injection without ever appearing in audit logs.
+	if got := countAuditEvents(t, dbPath, "internal_header_injection_stripped"); got != 0 {
+		t.Fatalf("audit event count = %d, want 0 for unauthenticated probe", got)
+	}
+}
+
+func TestInternalHeaderStripAuditsAuthenticatedRequest(t *testing.T) {
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Coordinator.OperatorURL = "http://operator.test"
+		cfg.Routing.StickyEnabled = true
+	}, WithHTTPClient(modelsOKClient()))
+	fullKey := createAccountAndKey(t, store, cfg, "acct_internal_header_auth")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer "+fullKey)
+	req.Header.Set("X-MacProvider-Internal-Conv", "conv:attacker")
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200 for authenticated models request, got %d body=%s", resp.Code, resp.Body.String())
+	}
 	if got := countAuditEvents(t, dbPath, "internal_header_injection_stripped"); got != 1 {
-		t.Fatalf("audit event count = %d, want 1 (strip MUST run before auth and emit audit on 401 path)", got)
+		t.Fatalf("audit event count = %d, want 1 for authenticated probe", got)
 	}
 }

--- a/phase5-gateway/internal/storage/errors.go
+++ b/phase5-gateway/internal/storage/errors.go
@@ -9,6 +9,8 @@ var (
 	ErrReservationExists   = errors.New("quota reservation exists")
 	ErrReservationNotFound = errors.New("quota reservation not found")
 	ErrReservationTerminal = errors.New("quota reservation is terminal")
+	ErrRateLimit           = errors.New("rate limit exceeded")
+	ErrOAuthStateCap       = errors.New("oauth state cap exceeded")
 	// ErrUsageEventConflict is returned by EnsureUsageEvent when the
 	// request_id PK already has a row whose identity fields
 	// (account_id, demo_identity, token_source, outcome) DISAGREE

--- a/phase5-gateway/internal/storage/interfaces.go
+++ b/phase5-gateway/internal/storage/interfaces.go
@@ -17,7 +17,10 @@ type AuthStore interface {
 	RevokeAPIKeyForAccount(ctx context.Context, accountID, keyID, actor, requestID string) error
 	RotateAPIKey(ctx context.Context, oldKeyID, accountID string, newKey APIKey, actor, requestID string) error
 	StoreOAuthState(ctx context.Context, state OAuthState) error
+	StoreOAuthStateWithCap(ctx context.Context, state OAuthState, maxPerIP int, now time.Time) error
 	ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (redirectURI, action string, err error)
+	PruneExpiredOAuthState(ctx context.Context, now time.Time) (int64, error)
+	ReservePublicIssuance(ctx context.Context, reservation PublicIssuanceReservation) error
 	RecordSignupEvent(ctx context.Context, event SignupEvent) error
 	CountSignupEventsSince(ctx context.Context, clientIP string, since time.Time) (int, error)
 	RecordDemoSessionEvent(ctx context.Context, event DemoSessionEvent) error
@@ -31,6 +34,7 @@ type AccountStore interface {
 	LookupAccount(ctx context.Context, accountID string) (Account, error)
 	RecordSignupEvent(ctx context.Context, event SignupEvent) error
 	CountSignupEventsSince(ctx context.Context, clientIP string, since time.Time) (int, error)
+	ReservePublicIssuance(ctx context.Context, reservation PublicIssuanceReservation) error
 }
 
 type KeyStore interface {
@@ -44,7 +48,9 @@ type KeyStore interface {
 
 type OAuthStateStore interface {
 	StoreOAuthState(ctx context.Context, state OAuthState) error
+	StoreOAuthStateWithCap(ctx context.Context, state OAuthState, maxPerIP int, now time.Time) error
 	ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (redirectURI, action string, err error)
+	PruneExpiredOAuthState(ctx context.Context, now time.Time) (int64, error)
 }
 
 type DemoSessionStore interface {
@@ -111,6 +117,7 @@ type HealthStore interface {
 type FeedbackStore interface {
 	InsertFeedbackEvent(ctx context.Context, event FeedbackEvent) error
 	ListFeedbackEventsSince(ctx context.Context, since time.Time) ([]FeedbackSummaryEvent, error)
+	ListFeedbackEventsSinceLimit(ctx context.Context, since time.Time, limit int) ([]FeedbackSummaryEvent, error)
 }
 
 type AuditStore interface {

--- a/phase5-gateway/internal/storage/sqlite/migrate.go
+++ b/phase5-gateway/internal/storage/sqlite/migrate.go
@@ -143,7 +143,14 @@ CREATE TABLE IF NOT EXISTS oauth_states (
 	action TEXT NOT NULL DEFAULT ''
 );
 
-CREATE INDEX IF NOT EXISTS idx_oauth_states_session ON oauth_states(session_id, expires_at);
+CREATE TABLE IF NOT EXISTS public_issuance_events (
+	event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	surface TEXT NOT NULL,
+	client_ip TEXT NOT NULL,
+	created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_public_issuance_surface_ip_created ON public_issuance_events(surface, client_ip, created_at);
 
 CREATE TABLE IF NOT EXISTS api_keys (
 	key_id TEXT PRIMARY KEY,

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -100,6 +100,8 @@ func (s *Store) Ping(ctx context.Context) error {
 //	     admin reconciliation does not scan ordinary in-flight reservations.
 //	v7 — SPEC-022 D13: quota_reservations accepts stale_held terminal holds
 //	     for coordinator-missing ambiguity that must release active quota.
+//	v8 — public issuance reservation events for atomic per-IP signup/demo/
+//	     feedback ceilings.
 //
 // At Open time the store reads the current applied version; if it
 // exceeds this constant the binary is older than the DB and refuses
@@ -110,7 +112,7 @@ func (s *Store) Ping(ctx context.Context) error {
 // Operators rolling back the gateway binary on a DB at a higher
 // version must restore /var/lib/macprovider/gateway.db from the
 // pre-deploy snapshot (deploy-pearl-vps.sh step 5b writes one).
-const maxKnownSchemaVersion = 7
+const maxKnownSchemaVersion = 8
 
 func (s *Store) Migrate(ctx context.Context) error {
 	if err := s.checkSchemaVersionGate(ctx); err != nil {
@@ -140,6 +142,9 @@ func (s *Store) Migrate(ctx context.Context) error {
 		return err
 	}
 	if _, err := s.db.ExecContext(ctx, demoUsageEventsAuxiliaryDDL); err != nil {
+		return err
+	}
+	if err := s.ensureOAuthStateExpiresAtColumn(ctx); err != nil {
 		return err
 	}
 	if err := s.ensureOAuthStateActionColumn(ctx); err != nil {
@@ -192,7 +197,48 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(7, ?)", now); err != nil {
 		return err
 	}
+	if _, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(8, ?)", now); err != nil {
+		return err
+	}
 	return nil
+}
+
+func (s *Store) ensureOAuthStateExpiresAtColumn(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, `PRAGMA table_info(oauth_states)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	hasExpiresAt := false
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		if name == "expires_at" {
+			hasExpiresAt = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if !hasExpiresAt {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE oauth_states ADD COLUMN expires_at TEXT NOT NULL DEFAULT ''`); err != nil {
+			return err
+		}
+		if _, err := s.db.ExecContext(ctx, `UPDATE oauth_states SET expires_at = strftime('%Y-%m-%dT%H:%M:%SZ', created_at, '+10 minutes') WHERE expires_at = ''`); err != nil {
+			return err
+		}
+	}
+	_, err = s.db.ExecContext(ctx, `
+		CREATE INDEX IF NOT EXISTS idx_oauth_states_session ON oauth_states(session_id, expires_at);
+		CREATE INDEX IF NOT EXISTS idx_oauth_states_client_ip_expires ON oauth_states(client_ip, expires_at);
+	`)
+	return err
 }
 
 // checkSchemaVersionGate refuses to run Migrate when the DB carries
@@ -816,18 +862,45 @@ func (s *Store) RotateAPIKey(ctx context.Context, oldKeyID, accountID string, ne
 }
 
 func (s *Store) StoreOAuthState(ctx context.Context, state storage.OAuthState) error {
+	return s.StoreOAuthStateWithCap(ctx, state, 0, time.Now().UTC())
+}
+
+func (s *Store) StoreOAuthStateWithCap(ctx context.Context, state storage.OAuthState, maxPerIP int, now time.Time) error {
 	if state.CreatedAt.IsZero() {
-		state.CreatedAt = time.Now().UTC()
+		if now.IsZero() {
+			now = time.Now().UTC()
+		}
+		state.CreatedAt = now.UTC()
 	}
 	if state.ExpiresAt.IsZero() {
 		state.ExpiresAt = state.CreatedAt.Add(10 * time.Minute)
 	}
-	_, err := s.db.ExecContext(ctx, `
+	tx, err := s.beginImmediate(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if maxPerIP > 0 && state.ClientIP != "" {
+		var count int
+		if err := tx.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM oauth_states
+			WHERE client_ip = ? AND consumed_at = '' AND expires_at > ?`,
+			state.ClientIP, encodeTime(now.UTC())).Scan(&count); err != nil {
+			return err
+		}
+		if count >= maxPerIP {
+			return storage.ErrOAuthStateCap
+		}
+	}
+	_, err = tx.ExecContext(ctx, `
 		INSERT INTO oauth_states(state_hash, session_id, redirect_uri, client_ip, created_at, expires_at, action)
 		VALUES(?, ?, ?, ?, ?, ?, ?)`,
 		state.StateHash, state.SessionID, state.RedirectURI, state.ClientIP,
 		encodeTime(state.CreatedAt), encodeTime(state.ExpiresAt), state.Action)
-	return err
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (string, string, error) {
@@ -858,6 +931,97 @@ func (s *Store) ConsumeOAuthState(ctx context.Context, stateHash []byte, session
 		return "", "", err
 	}
 	return redirectURI, action, tx.Commit()
+}
+
+func (s *Store) PruneExpiredOAuthState(ctx context.Context, now time.Time) (int64, error) {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	res, err := s.db.ExecContext(ctx, `
+		DELETE FROM oauth_states
+		WHERE expires_at <= ?`, encodeTime(now.UTC()))
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func (s *Store) ReservePublicIssuance(ctx context.Context, reservation storage.PublicIssuanceReservation) error {
+	if reservation.Limit <= 0 {
+		return storage.ErrRateLimit
+	}
+	if reservation.CreatedAt.IsZero() {
+		reservation.CreatedAt = time.Now().UTC()
+	}
+	tx, err := s.beginImmediate(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	windowStart := encodeTime(reservation.WindowStart.UTC())
+	createdAt := encodeTime(reservation.CreatedAt.UTC())
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM public_issuance_events
+		WHERE surface = ? AND created_at < ?`, reservation.Surface, windowStart); err != nil {
+		return err
+	}
+
+	var count int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM public_issuance_events
+		WHERE surface = ? AND client_ip = ? AND created_at >= ?`,
+		reservation.Surface, reservation.ClientIP, windowStart).Scan(&count); err != nil {
+		return err
+	}
+
+	legacyCount, err := s.legacyPublicIssuanceCountTx(ctx, tx, reservation.Surface, reservation.ClientIP, windowStart)
+	if err != nil {
+		return err
+	}
+	count += legacyCount
+	if count >= reservation.Limit {
+		return storage.ErrRateLimit
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO public_issuance_events(surface, client_ip, created_at)
+		VALUES(?, ?, ?)`, reservation.Surface, reservation.ClientIP, createdAt)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) legacyPublicIssuanceCountTx(ctx context.Context, tx *immediateTx, surface, clientIP, windowStart string) (int, error) {
+	var firstReservation sql.NullString
+	if err := tx.QueryRowContext(ctx, `
+		SELECT MIN(created_at) FROM public_issuance_events
+		WHERE surface = ? AND client_ip = ?`, surface, clientIP).Scan(&firstReservation); err != nil {
+		return 0, err
+	}
+	legacyUpperBound := ""
+	if firstReservation.Valid {
+		legacyUpperBound = firstReservation.String
+	}
+	var query string
+	switch surface {
+	case "signup":
+		query = `SELECT COUNT(*) FROM signup_events WHERE client_ip = ? AND created_at >= ?`
+	case "demo_session":
+		query = `SELECT COUNT(*) FROM demo_session_events WHERE client_ip = ? AND created_at >= ?`
+	default:
+		return 0, nil
+	}
+	args := []any{clientIP, windowStart}
+	if legacyUpperBound != "" {
+		query += ` AND created_at < ?`
+		args = append(args, legacyUpperBound)
+	}
+	var count int
+	if err := tx.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func (s *Store) RecordSignupEvent(ctx context.Context, event storage.SignupEvent) error {
@@ -1519,11 +1683,21 @@ func (s *Store) InsertFeedbackEvent(ctx context.Context, event storage.FeedbackE
 }
 
 func (s *Store) ListFeedbackEventsSince(ctx context.Context, since time.Time) ([]storage.FeedbackSummaryEvent, error) {
+	return s.ListFeedbackEventsSinceLimit(ctx, since, 0)
+}
+
+func (s *Store) ListFeedbackEventsSinceLimit(ctx context.Context, since time.Time, limit int) ([]storage.FeedbackSummaryEvent, error) {
+	limitClause := ""
+	args := []any{encodeTime(since)}
+	if limit > 0 {
+		limitClause = " LIMIT ?"
+		args = append(args, limit)
+	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT event_id, request_id, account_id, scope, rating, comment, created_at
 		FROM feedback_events
 		WHERE created_at >= ?
-		ORDER BY created_at ASC`, encodeTime(since))
+		ORDER BY created_at DESC`+limitClause, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/phase5-gateway/internal/storage/sqlite/store_test.go
+++ b/phase5-gateway/internal/storage/sqlite/store_test.go
@@ -304,6 +304,103 @@ func TestOAuthStateAndRateLimitStores(t *testing.T) {
 	assertSQLFails(t, store, `DELETE FROM demo_session_events WHERE event_id = 'demo_1'`)
 }
 
+func TestOAuthStateCapAndPrune(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	now := fixedTime()
+	for i := 0; i < 20; i++ {
+		hash := keyHash(fmt.Sprintf("state-%02d", i))
+		if err := store.StoreOAuthStateWithCap(ctx, storage.OAuthState{
+			StateHash: hash[:], SessionID: fmt.Sprintf("session_%02d", i), RedirectURI: "https://api.streamvc.live/auth/github/callback",
+			ClientIP: "1.2.3.4", CreatedAt: now, ExpiresAt: now.Add(10 * time.Minute),
+		}, 20, now); err != nil {
+			t.Fatalf("StoreOAuthStateWithCap %d: %v", i, err)
+		}
+	}
+	overflow := keyHash("state-overflow")
+	if err := store.StoreOAuthStateWithCap(ctx, storage.OAuthState{
+		StateHash: overflow[:], SessionID: "session_overflow", RedirectURI: "https://api.streamvc.live/auth/github/callback",
+		ClientIP: "1.2.3.4", CreatedAt: now, ExpiresAt: now.Add(10 * time.Minute),
+	}, 20, now); !errors.Is(err, storage.ErrOAuthStateCap) {
+		t.Fatalf("overflow err=%v want ErrOAuthStateCap", err)
+	}
+	deleted, err := store.PruneExpiredOAuthState(ctx, now.Add(11*time.Minute))
+	if err != nil {
+		t.Fatalf("PruneExpiredOAuthState: %v", err)
+	}
+	if deleted != 20 {
+		t.Fatalf("deleted=%d want 20", deleted)
+	}
+}
+
+func TestReservePublicIssuanceConcurrentCeiling(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	now := fixedTime()
+	const limit = 1
+	const attempts = 16
+	var admitted atomic.Int64
+	var limited atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := store.ReservePublicIssuance(ctx, storage.PublicIssuanceReservation{
+				Surface: "signup", ClientIP: "1.2.3.4", WindowStart: now.Add(-24 * time.Hour), Limit: limit, CreatedAt: now,
+			})
+			if err == nil {
+				admitted.Add(1)
+				return
+			}
+			if errors.Is(err, storage.ErrRateLimit) {
+				limited.Add(1)
+				return
+			}
+			t.Errorf("ReservePublicIssuance unexpected err: %v", err)
+		}()
+	}
+	wg.Wait()
+	if admitted.Load() != limit {
+		t.Fatalf("admitted=%d want %d", admitted.Load(), limit)
+	}
+	if limited.Load() != attempts-limit {
+		t.Fatalf("limited=%d want %d", limited.Load(), attempts-limit)
+	}
+}
+
+func TestReservePublicIssuanceCountsLegacyWindowWithoutDoubleCountingNewEvents(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	now := fixedTime()
+	if err := store.RecordSignupEvent(ctx, storage.SignupEvent{
+		EventID: "signup_legacy_1", AccountID: "acct_legacy_1", ClientIP: "1.2.3.4", Provider: "github", CreatedAt: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("RecordSignupEvent legacy 1: %v", err)
+	}
+	if err := store.RecordSignupEvent(ctx, storage.SignupEvent{
+		EventID: "signup_legacy_2", AccountID: "acct_legacy_2", ClientIP: "1.2.3.4", Provider: "github", CreatedAt: now.Add(-30 * time.Minute),
+	}); err != nil {
+		t.Fatalf("RecordSignupEvent legacy 2: %v", err)
+	}
+	if err := store.ReservePublicIssuance(ctx, storage.PublicIssuanceReservation{
+		Surface: "signup", ClientIP: "1.2.3.4", WindowStart: now.Add(-24 * time.Hour), Limit: 3, CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("ReservePublicIssuance with legacy room: %v", err)
+	}
+	if err := store.RecordSignupEvent(ctx, storage.SignupEvent{
+		EventID: "signup_new_1", AccountID: "acct_new_1", ClientIP: "1.2.3.4", Provider: "github", CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("RecordSignupEvent new: %v", err)
+	}
+	err := store.ReservePublicIssuance(ctx, storage.PublicIssuanceReservation{
+		Surface: "signup", ClientIP: "1.2.3.4", WindowStart: now.Add(-24 * time.Hour), Limit: 3, CreatedAt: now.Add(time.Minute),
+	})
+	if !errors.Is(err, storage.ErrRateLimit) {
+		t.Fatalf("second reservation err=%v want ErrRateLimit", err)
+	}
+}
+
 func TestQuotaReservationLedgerSemantics(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)

--- a/phase5-gateway/internal/storage/types.go
+++ b/phase5-gateway/internal/storage/types.go
@@ -77,6 +77,14 @@ type DemoSessionEvent struct {
 	CreatedAt time.Time
 }
 
+type PublicIssuanceReservation struct {
+	Surface     string
+	ClientIP    string
+	WindowStart time.Time
+	Limit       int
+	CreatedAt   time.Time
+}
+
 type DemoUsageEvent struct {
 	RequestID     string
 	ClientIP      string

--- a/specs/AUDIT_FIX_GATEWAY_AUTH_ABUSE_ARCHITECT_R1.md
+++ b/specs/AUDIT_FIX_GATEWAY_AUTH_ABUSE_ARCHITECT_R1.md
@@ -1,0 +1,22 @@
+# Architecture Audit: Gateway Public Auth Perimeter R1
+
+Review the implementation on branch `fix/deepsec-gateway-auth-abuse`.
+
+Scope:
+- `phase5-gateway/internal/config/config.go`
+- `phase5-gateway/cmd/gateway/main.go`
+- `phase5-gateway/internal/router/server.go`
+- `phase5-gateway/internal/router/oauth.go`
+- `phase5-gateway/internal/router/admin.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/internal/storage/sqlite/migrate.go`
+
+Assess whether the implementation uses the right ownership boundaries:
+configuration owns tunables, router owns request policy and status mapping,
+storage owns atomicity and migration compatibility, and main owns lifecycle
+goroutines. Check whether the design is maintainable without broad refactors,
+new dependencies, or hidden coupling between public endpoints.
+
+Report findings by severity: CRITICAL, HIGH, MEDIUM, LOW, INFO. Include file
+and line references. The pass condition is 0 CRITICAL, 0 HIGH, and 0 MEDIUM
+findings.

--- a/specs/AUDIT_FIX_GATEWAY_AUTH_ABUSE_CODE_R1.md
+++ b/specs/AUDIT_FIX_GATEWAY_AUTH_ABUSE_CODE_R1.md
@@ -1,0 +1,22 @@
+# Code Audit: Gateway Public Auth Perimeter R1
+
+Review the implementation on branch `fix/deepsec-gateway-auth-abuse`.
+
+Scope:
+- `phase5-gateway/internal/config/config.go`
+- `phase5-gateway/cmd/gateway/main.go`
+- `phase5-gateway/internal/router/server.go`
+- `phase5-gateway/internal/router/oauth.go`
+- `phase5-gateway/internal/router/admin.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/internal/storage/sqlite/migrate.go`
+
+Check for correctness, test adequacy, migration safety, interface drift, and
+regressions against existing gateway behavior. Pay particular attention to
+OAuth feature flag enforcement, atomic public issuance reservations, OAuth state
+TTL/cap/pruning, authenticated-only internal-header audit writes, and bounded
+feedback write/read paths.
+
+Report findings by severity: CRITICAL, HIGH, MEDIUM, LOW, INFO. Include file
+and line references. The pass condition is 0 CRITICAL, 0 HIGH, and 0 MEDIUM
+findings.

--- a/specs/AUDIT_FIX_GATEWAY_AUTH_ABUSE_SECURITY_R1.md
+++ b/specs/AUDIT_FIX_GATEWAY_AUTH_ABUSE_SECURITY_R1.md
@@ -1,0 +1,26 @@
+# Security Audit: Gateway Public Auth Perimeter R1
+
+Review the implementation on branch `fix/deepsec-gateway-auth-abuse`.
+
+Scope:
+- `phase5-gateway/internal/config/config.go`
+- `phase5-gateway/cmd/gateway/main.go`
+- `phase5-gateway/internal/router/server.go`
+- `phase5-gateway/internal/router/oauth.go`
+- `phase5-gateway/internal/router/admin.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/internal/storage/sqlite/migrate.go`
+
+Security invariants to verify:
+- OAuth handlers do not execute when `GitHubOAuthEnabled=false`, including
+  direct handler invocation or accidental registration.
+- Unauthenticated callers cannot force persistent database writes on gateway
+  public endpoints.
+- Per-IP public issuance ceilings are enforced under concurrent load without
+  check-then-insert races.
+- OAuth state rows cannot grow unbounded and cannot outlive the expected TTL.
+- Feedback is bounded on both write and read paths.
+
+Report findings by severity: CRITICAL, HIGH, MEDIUM, LOW, INFO. Include file
+and line references. The pass condition is 0 CRITICAL, 0 HIGH, 0 MEDIUM, and
+0 LOW findings because this is an externally reachable path.

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -714,6 +714,7 @@ func (s *scenario) writeGatewayYAML(gwPort int, stickyEnabled bool, serviceToken
 			"github_oauth_enabled":     false,
 			"email_magic_link_enabled": false,
 			"oauth": map[string]any{
+				"state_max_per_ip": 20,
 				"callback_allowlist": []string{
 					fmt.Sprintf("http://127.0.0.1:%d/auth/github/callback", gwPort),
 				},
@@ -733,10 +734,12 @@ func (s *scenario) writeGatewayYAML(gwPort int, stickyEnabled bool, serviceToken
 			"reservation_max_age_hours":      24,
 		},
 		"limits": map[string]any{
-			"max_tokens_per_request":      4096,
-			"demo_max_tokens_per_request": 512,
-			"max_feedback_comment_bytes":  2000,
-			"request_body_bytes":          1048576,
+			"max_tokens_per_request":            4096,
+			"demo_max_tokens_per_request":       512,
+			"max_feedback_comment_bytes":        2000,
+			"max_feedback_body_bytes":           16384,
+			"feedback_requests_per_ip_per_hour": 10,
+			"request_body_bytes":                1048576,
 		},
 		"capacity": map[string]any{
 			"monthly_budget_usd":                500,

--- a/test/integration/scenarios_test.go
+++ b/test/integration/scenarios_test.go
@@ -84,6 +84,20 @@ func TestHappyPathChatCompletion(t *testing.T) {
 	}
 }
 
+func TestGatewayGitHubOAuthDisabledRoutesReturn404(t *testing.T) {
+	s := newScenario(t, scenarioOpts{seedAccount: false})
+	for _, path := range []string{"/auth/github/start", "/auth/github/callback"} {
+		resp, err := http.Get(s.gatewayBaseURL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("GET %s status=%d want 404", path, resp.StatusCode)
+		}
+	}
+}
+
 // TestInternalBearerWrongTokenRejected pins the auth boundary directly
 // at the SERVICE-TO-SERVICE endpoint the gateway calls (/internal/routing
 // on the provider port, mounted by InternalHandler at buyer/server.go:388-393).


### PR DESCRIPTION
## Summary

Gateway public-auth perimeter hardening. Enforces the GitHub OAuth feature
flag at route-mount and handler entry, replaces check-then-insert races on
per-IP issuance ceilings with atomic rolling-window reservations, adds TTL
+ per-source cap + background pruning to the OAuth state table, and
bounds the feedback endpoint on both write and read paths. Reorders
internal-header probe middleware so unauthenticated probes can no longer
force persistent audit-DB writes.

## Changes

### gateway/config + boot
- `GitHubOAuthEnabled` propagated to route-mount and handler-entry gates
  (belt-and-suspenders: routes unmounted when disabled, handlers still
  refuse if reached via another path).
- Boot log reflects effective OAuth state.
- New `gateway.yaml.example` fields for OAuth state pruner and issuance
  ceilings.

### gateway/router
- Atomic per-IP ceilings for oauth / signup / demo issuance (rolling
  window, preserves legacy signup/demo semantics).
- Audit-write reordered after auth-check so unauthenticated internal-
  header probes can no longer force persistent DB writes.
- Feedback endpoint bounded on writes: per-IP rate limit, body/comment
  size caps, source-header requirement.
- Admin feedback summary bounded on reads: LIMIT + aggregate over
  returned rows, not full table.

### gateway/storage
- `oauth_state` migration: `expires_at` column, per-IP write cap,
  `PruneExpiredOAuthState` called from main lifecycle pruner.
- New atomic reservation types for oauth/signup/demo issuance.
- Storage error surface adds bounded rate-limit + cap error classes.

### specs
- `AUDIT_FIX_GATEWAY_AUTH_ABUSE_{CODE,SECURITY,ARCHITECT}_R1.md`.

## Audit

Three codex lanes fired independently per project convention.

| Lane | R2 result |
| --- | --- |
| SECURITY | PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW |
| CODE | PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM (1 LOW carried) |
| ARCHITECTURE | PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM (1 LOW carried) |

Security lane cleared the higher 0-LOW bar required for externally
reachable auth paths. Both carried LOWs are non-blocking; see "Deferred"
below.

## Test plan

- [x] `go test -count=1 ./phase5-gateway/...`
- [x] `go vet ./phase5-gateway/...`
- [x] `go test -count=1 ./phase4-coordinator/...` (regression guard)
- [x] `go test -count=1 ./test/network-harness/...`
- [x] `go test -count=1 -timeout 5m ./test/integration/...`
- [x] `git diff --check`
- [ ] Staging smoke on Pearl: gateway with `github_oauth_enabled: false`
      boots; `/oauth/github/authorize` returns 404; feedback endpoint
      429s on the 11th same-IP request within an hour (pre-merge gate)

## Deferred

Two LOW items carried per project convention (bar for LOW is
documentation, not iteration):

- **Missing explicit demo legacy-window regression test** (code lane).
  Rolling-window reservation covers demo issuance; a dedicated
  regression test for the pre-existing legacy demo window would tighten
  coverage. Existing atomic-issuance tests exercise the reservation
  code path.
- **Raw string issuance surface names** (architecture lane). Issuance
  surface identifiers (`oauth`, `signup`, `demo`) are passed as raw
  strings rather than a typed enum. Cosmetic; typing them would
  broaden the surface refactor beyond this wave's scope.

## Merge coordination

No hold on this PR. Wave 4 (`fix/deepsec-coordinator-perimeter`) works
on the coordinator-side authorization surface, orthogonal to this
wave's public gateway perimeter. Wave 2 followup
(`fix/deepsec-crash-consistency-followups`) still slots in after this
wave lands so the auditor-LOW bundle can amortize a single audit round.
