### PR TITLE
fix(coordinator): fail-closed on direct exposure, WS admission bounds, relay AAD binding, OAuth state binding, settlement canonicalization

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -541,6 +541,7 @@ func main() {
 		buyer.WithTrustedProxies(mustParseTrustedProxies(cfg, logger)),
 		buyer.WithInternalAuthKey(cfg.Auth.OperatorKey),
 		buyer.WithGatewayServiceToken(cfg.Auth.GatewayServiceToken),
+		buyer.WithRequireGatewayContext(cfg.Coordinator.RequireGatewayContext),
 		buyer.WithRelay(wsServer.DispatchInference, time.Duration(cfg.Routing.RequestTimeoutS)*time.Second),
 		buyer.WithSettlementRelay(wsServer.DispatchInferenceWithSettlement),
 		buyer.WithAdmission(wsServer.Admission(), cfg.Admission.ProvisionalTierWeight),

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -3,6 +3,11 @@ listen:
   provider_port: 8444
   bind_address: "127.0.0.1"
 
+coordinator:
+  # Require gateway-supplied internal bearer auth plus X-MacProvider-Account
+  # before accepting buyer chat completions directly on the coordinator.
+  require_gateway_context: true
+
 proxy:
   # CIDR ranges whose X-Forwarded-For / X-Real-IP headers the
   # coordinator honors when deriving the per-source rate-limit key for
@@ -66,6 +71,11 @@ provider_http:
 
 limits:
   max_chat_request_body_bytes: 1048576  # 1 MiB default; raise for buyers with large tools arrays
+
+relay:
+  # Maximum request bytes the coordinator will keep buffered for a provider
+  # websocket relay before dropping the in-flight request.
+  max_request_buffer_bytes: 16777216
 
 ws:
   write_buffer_size: 64

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -8,6 +8,11 @@ listen:
   provider_port: 8444
   bind_address: "127.0.0.1"
 
+coordinator:
+  # Require gateway-supplied internal bearer auth plus X-MacProvider-Account
+  # before accepting buyer chat completions directly on the coordinator.
+  require_gateway_context: true
+
 pool:
   heartbeat_interval_s: 30
   disconnect_grace_period_s: 30
@@ -43,6 +48,11 @@ provider_http:
 
 limits:
   max_chat_request_body_bytes: 1048576  # 1 MiB default; raise for buyers with large tools arrays
+
+relay:
+  # Maximum request bytes the coordinator will keep buffered for a provider
+  # websocket relay before dropping the in-flight request.
+  max_request_buffer_bytes: 16777216
 
 auth:
   # Operator bearer token for /poolz and /admin/*.

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -18,6 +18,11 @@ listen:
   provider_port: 8444
   bind_address: "127.0.0.1"
 
+coordinator:
+  # Require gateway-supplied internal bearer auth plus X-MacProvider-Account
+  # before accepting buyer chat completions directly on the coordinator.
+  require_gateway_context: true
+
 proxy:
   # Production sits behind nginx on localhost — the default
   # ["127.0.0.0/8", "::1/128"] is correct. The coordinator parses
@@ -92,6 +97,11 @@ provider_http:
 
 limits:
   max_chat_request_body_bytes: 1048576  # 1 MiB default; raise for buyers with large tools arrays
+
+relay:
+  # Maximum request bytes the coordinator will keep buffered for a provider
+  # websocket relay before dropping the in-flight request.
+  max_request_buffer_bytes: 16777216
 
 auth:
   # 64 hex chars (256 bits). Generated with: openssl rand -hex 32

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -43,6 +43,7 @@ var ErrSessionInvalid = errors.New("mp_session invalid")
 var ErrPendingPairOTMissing = errors.New("pending pair_ot missing")
 var ErrAppTrackExistingTokenNoProof = errors.New("existing active token requires current bearer proof")
 var ErrAppTrackReissueCooldown = errors.New("app-track provider token reissue cooldown active")
+var ErrOAuthStateRateLimited = errors.New("oauth state rate limited")
 
 type Store struct {
 	db *sql.DB
@@ -78,6 +79,7 @@ type OAuthState struct {
 	ReturnTo      string
 	PendingPairOT sql.NullString
 	ExpiresAt     string
+	OriginHash    sql.NullString
 }
 
 type MPSession struct {
@@ -312,6 +314,7 @@ func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
 			state TEXT PRIMARY KEY,
 			return_to TEXT NOT NULL,
 			pending_pair_ot TEXT,
+			origin_hash TEXT,
 			expires_at TEXT NOT NULL,
 			created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 		)`,
@@ -336,7 +339,34 @@ func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
 			return err
 		}
 	}
+	if err := ensureColumnTx(ctx, tx, "oauth_states", "origin_hash", `ALTER TABLE oauth_states ADD COLUMN origin_hash TEXT`); err != nil {
+		return err
+	}
 	return tx.Commit()
+}
+
+func ensureColumnTx(ctx context.Context, tx *sql.Tx, table, column, alter string) error {
+	rows, err := tx.QueryContext(ctx, `PRAGMA table_info(`+table+`)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, typ string
+		var defaultValue sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		if name == column {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, alter)
+	return err
 }
 
 // ensureActiveProviderIDUniqueness installs the SPEC-003 v0.8.2 partial
@@ -818,32 +848,69 @@ ON CONFLICT(github_user_id) DO UPDATE SET github_login = excluded.github_login, 
 }
 
 func (s *Store) CreateOAuthState(ctx context.Context, state, returnTo string, pendingPairOT *string, now time.Time) error {
+	return s.CreateOAuthStateBound(ctx, state, returnTo, pendingPairOT, "", now)
+}
+
+func (s *Store) CreateOAuthStateBound(ctx context.Context, state, returnTo string, pendingPairOT *string, originHash string, now time.Time) error {
 	if state == "" || returnTo == "" {
 		return fmt.Errorf("oauth state and return_to are required")
 	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
 	var pending any
 	if pendingPairOT != nil {
 		pending = *pendingPairOT
 	}
-	_, err := s.db.ExecContext(ctx, `
-INSERT INTO oauth_states (state, return_to, pending_pair_ot, expires_at, created_at)
-VALUES (?, ?, ?, ?, ?)`,
-		state, returnTo, pending, timeText(now.Add(10*time.Minute)), timeText(now))
-	return err
+	var origin any
+	if originHash != "" {
+		origin = originHash
+		if _, err := tx.ExecContext(ctx, `DELETE FROM oauth_states WHERE expires_at <= ?`, timeText(now)); err != nil {
+			return err
+		}
+		var active int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM oauth_states WHERE origin_hash = ? AND created_at > ?`, originHash, timeText(now.Add(-10*time.Minute))).Scan(&active); err != nil {
+			return err
+		}
+		if active >= 20 {
+			return ErrOAuthStateRateLimited
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO oauth_states (state, return_to, pending_pair_ot, origin_hash, expires_at, created_at)
+VALUES (?, ?, ?, ?, ?, ?)`,
+		state, returnTo, pending, origin, timeText(now.Add(10*time.Minute)), timeText(now)); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) ConsumeOAuthState(ctx context.Context, state string, now time.Time) (OAuthState, bool, error) {
+	return s.ConsumeOAuthStateBound(ctx, state, "", now)
+}
+
+func (s *Store) ConsumeOAuthStateBound(ctx context.Context, state, originHash string, now time.Time) (OAuthState, bool, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return OAuthState{}, false, err
 	}
 	defer tx.Rollback()
 	var out OAuthState
-	err = tx.QueryRowContext(ctx, `
+	query := `
 DELETE FROM oauth_states
  WHERE state = ? AND expires_at > ?
-RETURNING return_to, pending_pair_ot, expires_at`,
-		state, timeText(now)).Scan(&out.ReturnTo, &out.PendingPairOT, &out.ExpiresAt)
+RETURNING return_to, pending_pair_ot, expires_at, origin_hash`
+	args := []any{state, timeText(now)}
+	if originHash != "" {
+		query = `
+DELETE FROM oauth_states
+ WHERE state = ? AND expires_at > ? AND (origin_hash = ? OR origin_hash IS NULL OR origin_hash = '')
+RETURNING return_to, pending_pair_ot, expires_at, origin_hash`
+		args = append(args, originHash)
+	}
+	err = tx.QueryRowContext(ctx, query, args...).Scan(&out.ReturnTo, &out.PendingPairOT, &out.ExpiresAt, &out.OriginHash)
 	if err == sql.ErrNoRows {
 		return OAuthState{}, false, nil
 	}

--- a/phase4-coordinator/internal/auth/tokens_test.go
+++ b/phase4-coordinator/internal/auth/tokens_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 )
@@ -130,6 +131,42 @@ func TestGatewayInternalBearerMatchesEvaluatesBoth(t *testing.T) {
 	headers.Set("Authorization", "Bearer nope")
 	if got := auth.GatewayInternalBearerMatches(headers, "op", "svc"); got != auth.BearerKindNone {
 		t.Fatalf("nope: %v", got)
+	}
+}
+
+func TestCreateOAuthStateBoundRateLimitIsConcurrentSafe(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	const attempts = 50
+	var wg sync.WaitGroup
+	errs := make(chan error, attempts)
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs <- store.CreateOAuthStateBound(context.Background(), "state-"+string(rune('a'+i)), "/", nil, "origin", now)
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	var created, limited int
+	for err := range errs {
+		switch {
+		case err == nil:
+			created++
+		case errors.Is(err, auth.ErrOAuthStateRateLimited):
+			limited++
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if created != 20 || limited != attempts-20 {
+		t.Fatalf("created=%d limited=%d, want 20/%d", created, limited, attempts-20)
 	}
 }
 

--- a/phase4-coordinator/internal/billing/hotpath.go
+++ b/phase4-coordinator/internal/billing/hotpath.go
@@ -51,8 +51,19 @@ type CacheBillingRoutingDecision struct {
 }
 
 func (s *Store) WriteHotPath(ctx context.Context, reqLogStore *requestlog.Store, reqRow requestlog.Row, in HotPathInput) error {
+	return s.writeHotPath(ctx, reqLogStore, nil, reqRow, in)
+}
+
+func (s *Store) WriteHotPathForAccount(ctx context.Context, reqLogStore *requestlog.Store, account requestlog.AuthenticatedAccount, reqRow requestlog.Row, in HotPathInput) error {
+	return s.writeHotPath(ctx, reqLogStore, &account, reqRow, in)
+}
+
+func (s *Store) writeHotPath(ctx context.Context, reqLogStore *requestlog.Store, account *requestlog.AuthenticatedAccount, reqRow requestlog.Row, in HotPathInput) error {
 	boundProviderReportedPromptTokens(&in)
 	reqRow = requestLogRowWithBoundedPrompt(reqRow, in)
+	if account != nil {
+		reqRow.AccountID = account.ID()
+	}
 	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
 		if err := reqLogStore.InsertExec(ctx, conn, reqRow); err != nil {
 			return err
@@ -273,6 +284,14 @@ func logCacheBillingRoutingDecision(in HotPathInput, validationReason string) {
 }
 
 func (s *Store) WriteRequestLogWithIdentity(ctx context.Context, reqLogStore *requestlog.Store, reqRow requestlog.Row, in HotPathInput) error {
+	return s.writeRequestLogWithIdentity(ctx, reqLogStore, nil, reqRow, in)
+}
+
+func (s *Store) WriteRequestLogWithIdentityForAccount(ctx context.Context, reqLogStore *requestlog.Store, account requestlog.AuthenticatedAccount, reqRow requestlog.Row, in HotPathInput) error {
+	return s.writeRequestLogWithIdentity(ctx, reqLogStore, &account, reqRow, in)
+}
+
+func (s *Store) writeRequestLogWithIdentity(ctx context.Context, reqLogStore *requestlog.Store, account *requestlog.AuthenticatedAccount, reqRow requestlog.Row, in HotPathInput) error {
 	if in.ProviderReportedPromptTokens == nil {
 		in.ProviderReportedPromptTokens = cloneInt64Ptr(in.PromptTokens)
 		if in.ProviderReportedPromptTokens == nil {
@@ -280,6 +299,9 @@ func (s *Store) WriteRequestLogWithIdentity(ctx context.Context, reqLogStore *re
 		}
 	}
 	reqRow = requestLogRowWithBoundedPrompt(reqRow, in)
+	if account != nil {
+		reqRow.AccountID = account.ID()
+	}
 	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
 		if err := reqLogStore.InsertExec(ctx, conn, reqRow); err != nil {
 			return err

--- a/phase4-coordinator/internal/buyer/billing_recorder.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder.go
@@ -72,8 +72,10 @@ type billingRecorder struct {
 	// cross-account X-Request-ID collisions after #196. Empty when the
 	// inbound request carried no header (direct legacy buyer, demo
 	// without gateway, pre-v0.9.1 gateway).
-	accountID             string
-	promptTokenUpperBound *int64
+	accountID               string
+	authenticatedAccount    requestlog.AuthenticatedAccount
+	hasAuthenticatedAccount bool
+	promptTokenUpperBound   *int64
 
 	// attemptN is the running per-provider-attempt counter. Pre-refactor
 	// this was billingAttemptN, incremented via deferred closure on
@@ -97,15 +99,17 @@ type billingRecorder struct {
 // forwardState pointer the sequence helpers will mutate; the recorder
 // reads state.routingDone at write time to compute RoutingMs (matching
 // the pre-refactor closure's live-capture semantics).
-func (s *Server) newBillingRecorder(r *http.Request, state *forwardState, startedAt time.Time, requestID, externalRequestID, accountID string) *billingRecorder {
+func (s *Server) newBillingRecorder(r *http.Request, state *forwardState, startedAt time.Time, requestID, externalRequestID, accountID string, authenticatedAccount requestlog.AuthenticatedAccount, hasAuthenticatedAccount bool) *billingRecorder {
 	return &billingRecorder{
-		server:            s,
-		state:             state,
-		req:               r,
-		startedAt:         startedAt,
-		requestID:         requestID,
-		externalRequestID: externalRequestID,
-		accountID:         accountID,
+		server:                  s,
+		state:                   state,
+		req:                     r,
+		startedAt:               startedAt,
+		requestID:               requestID,
+		externalRequestID:       externalRequestID,
+		accountID:               accountID,
+		authenticatedAccount:    authenticatedAccount,
+		hasAuthenticatedAccount: hasAuthenticatedAccount,
 	}
 }
 
@@ -264,12 +268,23 @@ func (b *billingRecorder) recordRow(
 			SettlementPolicyVersion:    settlementVersion,
 			RoutingDecisionLog:         s.logCacheBillingRoutingDecision,
 		}
-		err := billingStore.WriteHotPath(ctx, s.reqLogStore, row, billingInput)
+		var err error
+		if b.hasAuthenticatedAccount {
+			err = billingStore.WriteHotPathForAccount(ctx, s.reqLogStore, b.authenticatedAccount, row, billingInput)
+		} else {
+			err = billingStore.WriteHotPath(ctx, s.reqLogStore, row, billingInput)
+		}
 		if err != nil {
 			s.log.Warn().Err(err).Str("request_id", b.requestID).Msg("billing hot-path insert failed")
 			fallbackCtx, fallbackCancel := context.WithTimeout(context.Background(), requestLogWriteTimeout)
 			defer fallbackCancel()
-			if fallbackErr := billingStore.WriteRequestLogWithIdentity(fallbackCtx, s.reqLogStore, row, billingInput); fallbackErr != nil {
+			var fallbackErr error
+			if b.hasAuthenticatedAccount {
+				fallbackErr = billingStore.WriteRequestLogWithIdentityForAccount(fallbackCtx, s.reqLogStore, b.authenticatedAccount, row, billingInput)
+			} else {
+				fallbackErr = billingStore.WriteRequestLogWithIdentity(fallbackCtx, s.reqLogStore, row, billingInput)
+			}
+			if fallbackErr != nil {
 				s.log.Warn().Err(fallbackErr).Str("request_id", b.requestID).Msg("request_log identity fallback insert failed")
 				return fmt.Errorf("billing hot-path insert failed: %w; fallback failed: %v", err, fallbackErr)
 			}
@@ -279,7 +294,13 @@ func (b *billingRecorder) recordRow(
 		}
 		return nil
 	}
-	if err := s.reqLog.Insert(ctx, row); err != nil {
+	var err error
+	if b.hasAuthenticatedAccount {
+		err = s.reqLog.InsertForAccount(ctx, b.authenticatedAccount, row)
+	} else {
+		err = s.reqLog.Insert(ctx, row)
+	}
+	if err != nil {
 		s.log.Warn().Err(err).Str("request_id", b.requestID).Msg("request_log insert failed")
 		return err
 	}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -137,6 +137,7 @@ type Server struct {
 	stickyMismatchLimiter *stickyMismatchLimiter
 	internalAuthKey       string
 	gatewayServiceToken   string
+	requireGatewayContext bool
 	tier2Mu               sync.RWMutex
 	tier2                 config.Tier2Config
 	reqLog                requestLogInserter
@@ -187,6 +188,7 @@ type Option func(*Server)
 
 type requestLogInserter interface {
 	Insert(context.Context, requestlog.Row) error
+	InsertForAccount(context.Context, requestlog.AuthenticatedAccount, requestlog.Row) error
 }
 
 type wsForwardResult string
@@ -375,6 +377,12 @@ func WithGatewayServiceToken(token string) Option {
 	}
 }
 
+func WithRequireGatewayContext(require bool) Option {
+	return func(s *Server) {
+		s.requireGatewayContext = require
+	}
+}
+
 func WithRelay(fn RelayFunc, timeout time.Duration) Option {
 	return func(s *Server) {
 		s.relay = fn
@@ -553,8 +561,36 @@ func (s *Server) Handler() http.Handler {
 	r.Get("/catalog/pubkey", s.handleCatalogPubkey)
 	r.Get("/catalog/{catalog_id}", s.handleCatalogFile)
 	r.Get("/metrics/streaming", s.handleStreamingMetrics)
-	r.Post("/v1/chat/completions", s.handleChatCompletions)
+	r.With(s.gatewayContextMiddleware).Post("/v1/chat/completions", s.handleChatCompletions)
 	return r
+}
+
+type authenticatedAccountContextKey struct{}
+
+func (s *Server) gatewayContextMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.requireGatewayContext {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if !s.internalBearerAuthorizedRemote(r.Header, r.RemoteAddr) {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "Gateway context is required")
+			return
+		}
+		accountID := sanitizeAccountID(r.Header.Get("X-MacProvider-Account"))
+		account, err := requestlog.NewAuthenticatedAccount(accountID)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "Gateway account context is required")
+			return
+		}
+		ctx := context.WithValue(r.Context(), authenticatedAccountContextKey{}, account)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func authenticatedAccountFromContext(ctx context.Context) (requestlog.AuthenticatedAccount, bool) {
+	account, ok := ctx.Value(authenticatedAccountContextKey{}).(requestlog.AuthenticatedAccount)
+	return account, ok
 }
 
 func (s *Server) handleStreamingMetrics(w http.ResponseWriter, r *http.Request) {
@@ -1415,6 +1451,10 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// pre-SPEC-006 v0.9.1 gateways that only emit this header on the
 	// sticky path.
 	accountID := sanitizeAccountID(r.Header.Get("X-MacProvider-Account"))
+	authenticatedAccount, hasAuthenticatedAccount := authenticatedAccountFromContext(r.Context())
+	if hasAuthenticatedAccount {
+		accountID = authenticatedAccount.ID()
+	}
 	requestID := requestIDForBuyerRequest()
 	routingRequestID := uuid.NewString()
 	originalRequestID := requestID
@@ -1444,7 +1484,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// setRequestID land before the first provider-bound recordRow call,
 	// preserving the pre-refactor closure's "latest value at fire time"
 	// semantics for what used to be captured outer-scope variables.
-	rec := s.newBillingRecorder(r, state, startedAt, originalRequestID, externalRequestID, accountID)
+	rec := s.newBillingRecorder(r, state, startedAt, originalRequestID, externalRequestID, accountID, authenticatedAccount, hasAuthenticatedAccount)
 	if !contentEncodingSupported(r.Header.Values("Content-Encoding")) {
 		msg := "v0.1.0 accepts `Content-Encoding: identity` or no `Content-Encoding` header; compressed request bodies are deferred to v0.2 per §10."
 		rec.logBuyerFailure(http.StatusUnsupportedMediaType, msg)
@@ -1479,7 +1519,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		bodyHash := sha256.Sum256(body)
-		reservedRequestID, replay, err := s.reqLogStore.ReserveIdempotencyKey(r.Context(), accountID, idempotencyKey, hex.EncodeToString(bodyHash[:]), originalRequestID, startedAt)
+		var reservedRequestID string
+		var replay bool
+		var err error
+		if hasAuthenticatedAccount {
+			reservedRequestID, replay, err = s.reqLogStore.ReserveIdempotencyKeyForAccount(r.Context(), authenticatedAccount, idempotencyKey, hex.EncodeToString(bodyHash[:]), originalRequestID, startedAt)
+		} else {
+			reservedRequestID, replay, err = s.reqLogStore.ReserveIdempotencyKey(r.Context(), accountID, idempotencyKey, hex.EncodeToString(bodyHash[:]), originalRequestID, startedAt)
+		}
 		if err != nil {
 			if errors.Is(err, requestlog.ErrIdempotencyConflict) {
 				rec.logBuyerFailure(http.StatusConflict, "Idempotency-Key was already used with a different request body")

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -88,6 +88,61 @@ func TestModelsAggregatesUniqueReadyProviderModels(t *testing.T) {
 	}
 }
 
+func TestGatewayContextRequiredRejectsChatBeforeIdempotency(t *testing.T) {
+	registry := pool.NewRegistry(nil)
+	store, err := requestlog.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithInternalAuthKey("operator-secret"),
+		buyer.WithGatewayServiceToken("gateway-secret"),
+		buyer.WithRequireGatewayContext(true),
+		buyer.WithRequestLog(store),
+	)
+
+	body := `{"model":"model-a","messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Idempotency-Key", "idem-direct")
+	rr := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d body=%s, want 401 before idempotency reservation", rr.Code, rr.Body.String())
+	}
+
+	replayReqID, replay, err := store.ReserveIdempotencyKey(context.Background(), "acct_test", "idem-direct", buyerTestHash, "req-later", time.Now())
+	if err != nil {
+		t.Fatalf("ReserveIdempotencyKey after rejected request: %v", err)
+	}
+	if replay || replayReqID != "req-later" {
+		t.Fatalf("reservation replay=%v request_id=%q, want fresh req-later", replay, replayReqID)
+	}
+}
+
+func TestGatewayContextRequiredAllowsAuthenticatedGatewayContext(t *testing.T) {
+	registry := pool.NewRegistry(nil)
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithInternalAuthKey("operator-secret"),
+		buyer.WithGatewayServiceToken("gateway-secret"),
+		buyer.WithRequireGatewayContext(true),
+	)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{`))
+	req.Header.Set("Authorization", "Bearer gateway-secret")
+	req.Header.Set("X-MacProvider-Account", "acct_gateway")
+	rr := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rr, req)
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatalf("authenticated gateway context was rejected: body=%s", rr.Body.String())
+	}
+}
+
 func TestRateCardProjectionReturnsRecommendationSchema(t *testing.T) {
 	rewards := config.RewardsConfig{
 		GlobalMultiplier: 1.25,

--- a/phase4-coordinator/internal/buyer/settlement_output.go
+++ b/phase4-coordinator/internal/buyer/settlement_output.go
@@ -18,6 +18,9 @@ func settlementOutputFromChatResponse(body []byte, terminalState string) (*billi
 }
 
 func settlementOutputFromChatResponseAt(body []byte, terminalState string, terminalStateTSUnixMS int64) (*billing.SettlementOutput, bool) {
+	if hasDuplicateJSONKeys(body) {
+		return nil, false
+	}
 	var resp struct {
 		Choices []struct {
 			Message struct {
@@ -103,7 +106,7 @@ func settlementToolCallsFromRaw(raw []json.RawMessage) ([]billing.SettlementTool
 		if err := json.Unmarshal(item, &call); err != nil {
 			return nil, false
 		}
-		if call.ID == "" || call.Type != "function" || call.Function.Name == "" || !json.Valid([]byte(call.Function.Arguments)) {
+		if call.ID == "" || call.Type != "function" || call.Function.Name == "" || !validSettlementToolArguments(call.Function.Arguments) {
 			return nil, false
 		}
 		out = append(out, billing.SettlementToolCall{
@@ -152,6 +155,9 @@ func (t *settlementStreamOutputTracker) observeLine(line []byte) error {
 	}
 	if !strings.HasPrefix(strings.TrimSpace(data), "{") {
 		return fmt.Errorf("settlement stream data is not JSON")
+	}
+	if hasDuplicateJSONKeys([]byte(data)) {
+		return fmt.Errorf("settlement stream data contains duplicate JSON object keys")
 	}
 	var chunk struct {
 		Choices []struct {
@@ -206,6 +212,56 @@ func (t *settlementStreamOutputTracker) observeLine(line []byte) error {
 	return nil
 }
 
+func hasDuplicateJSONKeys(data []byte) bool {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	return objectHasDuplicateJSONKeys(dec)
+}
+
+func validSettlementToolArguments(arguments string) bool {
+	data := []byte(arguments)
+	return json.Valid(data) && !hasDuplicateJSONKeys(data)
+}
+
+func objectHasDuplicateJSONKeys(dec *json.Decoder) bool {
+	tok, err := dec.Token()
+	if err != nil {
+		return false
+	}
+	switch delim := tok.(type) {
+	case json.Delim:
+		switch delim {
+		case '{':
+			seen := map[string]struct{}{}
+			for dec.More() {
+				keyTok, err := dec.Token()
+				if err != nil {
+					return false
+				}
+				key, ok := keyTok.(string)
+				if !ok {
+					return false
+				}
+				if _, exists := seen[key]; exists {
+					return true
+				}
+				seen[key] = struct{}{}
+				if objectHasDuplicateJSONKeys(dec) {
+					return true
+				}
+			}
+			_, _ = dec.Token()
+		case '[':
+			for dec.More() {
+				if objectHasDuplicateJSONKeys(dec) {
+					return true
+				}
+			}
+			_, _ = dec.Token()
+		}
+	}
+	return false
+}
+
 func settlementSSEDataValue(line string) (string, bool) {
 	if !strings.HasPrefix(line, "data:") {
 		return "", false
@@ -252,7 +308,7 @@ func (t *settlementStreamOutputTracker) outputAt(terminalState string, terminalS
 		if call == nil || call.id == "" || call.name == "" {
 			return settlementOutputUnavailableFor(terminalState)
 		}
-		if !json.Valid([]byte(call.arguments)) {
+		if !validSettlementToolArguments(call.arguments) {
 			return settlementOutputUnavailableFor(terminalState)
 		}
 		typ := call.typ

--- a/phase4-coordinator/internal/buyer/settlement_output_test.go
+++ b/phase4-coordinator/internal/buyer/settlement_output_test.go
@@ -99,3 +99,30 @@ func TestSettlementStreamOutputLatchesDoneAndRejectsPostDoneData(t *testing.T) {
 		t.Fatal("post-[DONE] settlement data accepted")
 	}
 }
+
+func TestSettlementOutputRejectsDuplicateJSONKeys(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"content":"first","tool_calls":[]},"finish_reason":"stop"}],"usage":{"prompt_tokens":1},"usage":{"prompt_tokens":999}}`)
+	if output, ok := settlementOutputFromChatResponseAt(body, billing.TerminalStateNormalDone, 1710000000000); ok || output != nil {
+		t.Fatalf("duplicate-key response accepted: output=%#v ok=%v", output, ok)
+	}
+}
+
+func TestSettlementOutputRejectsDuplicateToolArgumentKeys(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"a\":1,\"a\":2}"}}]},"finish_reason":"tool_calls"}]}`)
+	if output, ok := settlementOutputFromChatResponseAt(body, billing.TerminalStateNormalDone, 1710000000000); ok || output != nil {
+		t.Fatalf("duplicate-key tool arguments accepted: output=%#v ok=%v", output, ok)
+	}
+}
+
+func TestSettlementStreamOutputQuarantinesDuplicateToolArgumentKeys(t *testing.T) {
+	tracker := newSettlementStreamOutputTracker()
+	line := []byte(`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"a\":1,\"a\":2}"}}]}}]}` + "\n\n")
+	if err := tracker.observeLine(line); err != nil {
+		t.Fatalf("observeLine: %v", err)
+	}
+
+	output := tracker.output(billing.TerminalStateNormalDone)
+	if output.Available {
+		t.Fatalf("output.Available=true, want unavailable for duplicate-key tool arguments: %#v", output)
+	}
+}

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -37,11 +37,13 @@ const minAuditLogRetentionDays = 90
 
 type Config struct {
 	Listen                       ListenConfig                 `yaml:"listen"`
+	Coordinator                  CoordinatorConfig            `yaml:"coordinator"`
 	Pool                         PoolConfig                   `yaml:"pool"`
 	Routing                      RoutingConfig                `yaml:"routing"`
 	ProviderHTTP                 ProviderHTTPConfig           `yaml:"provider_http"`
 	Limits                       LimitsConfig                 `yaml:"limits"`
 	WS                           WSConfig                     `yaml:"ws"`
+	Relay                        RelayConfig                  `yaml:"relay"`
 	Admission                    AdmissionConfig              `yaml:"admission"`
 	Tier2                        Tier2Config                  `yaml:"tier2"`
 	CoordinatorAdvertisedVersion CoordinatorAdvertisedVersion `yaml:"coordinator_advertised_version"`
@@ -57,6 +59,10 @@ type Config struct {
 	Onboarding                   OnboardingConfig             `yaml:"onboarding"`
 	Proxy                        ProxyConfig                  `yaml:"proxy"`
 	Providers                    []ProviderConfig             `yaml:"providers"`
+}
+
+type CoordinatorConfig struct {
+	RequireGatewayContext bool `yaml:"require_gateway_context"`
 }
 
 // OnboardingConfig gates SPEC-026 App-track `/v1/providers/register`.
@@ -299,6 +305,10 @@ type WSConfig struct {
 	// host starving all provider readmissions even if it slips past nginx's
 	// limit_conn (M1-4 / SECU-1). Default 4. Must be > 0.
 	MaxUnauthenticatedConnPerIP int `yaml:"max_unauthenticated_conn_per_ip"`
+}
+
+type RelayConfig struct {
+	MaxRequestBufferBytes int64 `yaml:"max_request_buffer_bytes"`
 }
 
 type AdmissionConfig struct {
@@ -575,6 +585,9 @@ func Default() Config {
 			ProviderPort: 8444,
 			BindAddress:  "127.0.0.1",
 		},
+		Coordinator: CoordinatorConfig{
+			RequireGatewayContext: true,
+		},
 		Pool: PoolConfig{
 			HeartbeatIntervalS:      30,
 			DisconnectGracePeriodS:  30,
@@ -624,6 +637,9 @@ func Default() Config {
 			MaxFrameBytes:               4 << 20,
 			MaxUnauthenticatedConn:      64,
 			MaxUnauthenticatedConnPerIP: 4,
+		},
+		Relay: RelayConfig{
+			MaxRequestBufferBytes: 16 * 1024 * 1024,
 		},
 		Admission: AdmissionConfig{
 			PinnedOnly:                      false,
@@ -932,6 +948,14 @@ func (c Config) ProviderWSMaxUnauthenticatedConnPerIP() int {
 	return count
 }
 
+func (c Config) RelayMaxRequestBufferBytes() int64 {
+	bytes := c.Relay.MaxRequestBufferBytes
+	if bytes <= 0 {
+		bytes = Default().Relay.MaxRequestBufferBytes
+	}
+	return bytes
+}
+
 // TrustedProxyPrefixes parses c.Proxy.TrustedProxies into a slice of
 // netip.Prefix values for the buyer Server's rate-limit-key derivation.
 // Returns an error if any CIDR is malformed OR if the operator has
@@ -981,6 +1005,9 @@ func (c Config) Validate() error {
 	if c.Auth.OperatorKey == "" {
 		return fmt.Errorf("auth.operator_key must be set")
 	}
+	if c.Coordinator.RequireGatewayContext && c.Auth.GatewayServiceToken == "" && c.Auth.OperatorKey == "" {
+		return fmt.Errorf("auth.gateway_service_token or auth.operator_key must be set when coordinator.require_gateway_context is true")
+	}
 	if _, err := c.TrustedProxyPrefixes(); err != nil {
 		return err
 	}
@@ -998,6 +1025,12 @@ func (c Config) Validate() error {
 	}
 	if c.WS.MaxFrameBytes > 64<<20 {
 		return fmt.Errorf("ws.max_frame_bytes must be <= 67108864")
+	}
+	if c.Relay.MaxRequestBufferBytes <= 0 {
+		return fmt.Errorf("relay.max_request_buffer_bytes must be > 0")
+	}
+	if c.Relay.MaxRequestBufferBytes > 128<<20 {
+		return fmt.Errorf("relay.max_request_buffer_bytes must be <= 134217728")
 	}
 	if c.Routing.PreflightTimeoutS <= 0 || c.Routing.RequestTimeoutS <= 0 || c.Routing.FailoverTimeoutS <= 0 {
 		return fmt.Errorf("routing timeouts must be > 0")

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -20,6 +20,21 @@ type Store struct {
 
 var ErrIdempotencyConflict = errors.New("idempotency key body hash mismatch")
 
+type AuthenticatedAccount struct {
+	id string
+}
+
+func NewAuthenticatedAccount(id string) (AuthenticatedAccount, error) {
+	if id == "" {
+		return AuthenticatedAccount{}, fmt.Errorf("authenticated account is required")
+	}
+	return AuthenticatedAccount{id: id}, nil
+}
+
+func (a AuthenticatedAccount) ID() string {
+	return a.id
+}
+
 type execer interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	QueryRowContext(context.Context, string, ...any) *sql.Row
@@ -247,6 +262,11 @@ func (s *Store) Insert(ctx context.Context, row Row) error {
 	return insert(ctx, conn, row)
 }
 
+func (s *Store) InsertForAccount(ctx context.Context, account AuthenticatedAccount, row Row) error {
+	row.AccountID = account.ID()
+	return s.Insert(ctx, row)
+}
+
 func (s *Store) ReserveIdempotencyKey(ctx context.Context, accountID, key, bodySHA256, requestID string, now time.Time) (string, bool, error) {
 	if s == nil || s.db == nil {
 		return "", false, fmt.Errorf("store is closed")
@@ -288,6 +308,10 @@ VALUES (?, ?, ?, ?, ?)`,
 	}
 	committed = true
 	return requestID, false, nil
+}
+
+func (s *Store) ReserveIdempotencyKeyForAccount(ctx context.Context, account AuthenticatedAccount, key, bodySHA256, requestID string, now time.Time) (string, bool, error) {
+	return s.ReserveIdempotencyKey(ctx, account.ID(), key, bodySHA256, requestID, now)
 }
 
 // pruneBatchSize bounds a single retention DELETE to keep the write lock

--- a/phase4-coordinator/internal/ws/admission.go
+++ b/phase4-coordinator/internal/ws/admission.go
@@ -15,6 +15,7 @@ type AdmissionManager struct {
 	cfg            config.AdmissionConfig
 	now            func() time.Time
 	admissions     []time.Time
+	pending        int
 	records        map[string]*ProvisionalRecord
 	rejected       map[string]string
 	requestWindows map[string][]time.Time
@@ -103,7 +104,7 @@ func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisi
 	now := a.now()
 	cutoff := now.Add(-time.Hour)
 	a.admissions = keepAfter(a.admissions, cutoff)
-	if connectedProvisional >= a.cfg.ProvisionalPoolMax {
+	if connectedProvisional+a.pending >= a.cfg.ProvisionalPoolMax {
 		return pool.TierProvisional, CloseProvisionalPoolFull, "provisional_pool_full: max " + itoa(a.cfg.ProvisionalPoolMax) + " provisional providers reached"
 	}
 	if _, known := a.records[hello.ProviderID]; !known && len(a.admissions) >= a.cfg.ProvisionalAdmissionRatePerHour {
@@ -112,6 +113,7 @@ func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisi
 	if !record {
 		return pool.TierProvisional, 0, ""
 	}
+	a.pending++
 	rec := a.records[hello.ProviderID]
 	if rec == nil {
 		rec = &ProvisionalRecord{
@@ -128,6 +130,14 @@ func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisi
 	rec.BinaryVersion = hello.BinaryVersion
 	a.persistLocked()
 	return pool.TierProvisional, 0, ""
+}
+
+func (a *AdmissionManager) ReleasePendingProvisional() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pending > 0 {
+		a.pending--
+	}
 }
 
 func (a *AdmissionManager) CheckQuota(provider pool.Provider) bool {

--- a/phase4-coordinator/internal/ws/admission_test.go
+++ b/phase4-coordinator/internal/ws/admission_test.go
@@ -64,6 +64,31 @@ func TestAdmissionManagerTiersRateLimitAndQuota(t *testing.T) {
 	}
 }
 
+func TestAdmissionManagerPendingReservationsEnforcePoolCap(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	adm := NewAdmissionManager(config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 100,
+		ProvisionalPoolMax:              1,
+		ProvisionalQuotaPerHour:         100,
+		ProvisionalTierWeight:           0.3,
+	}, func() time.Time { return now })
+
+	tier, code, reason := adm.Admit(Hello{ProviderID: "new-1", Hostname: "host", ModelID: "model", BinaryVersion: "1.2.0"}, false, 0)
+	if tier != pool.TierProvisional || code != 0 || reason != "" {
+		t.Fatalf("first admit = tier:%s code:%d reason:%q", tier, code, reason)
+	}
+	_, code, reason = adm.Admit(Hello{ProviderID: "new-2", Hostname: "host", ModelID: "model", BinaryVersion: "1.2.0"}, false, 0)
+	if code != CloseProvisionalPoolFull {
+		t.Fatalf("second admit code=%d reason=%q, want pool full", code, reason)
+	}
+
+	adm.ReleasePendingProvisional()
+	_, code, reason = adm.Admit(Hello{ProviderID: "new-2", Hostname: "host", ModelID: "model", BinaryVersion: "1.2.0"}, false, 0)
+	if code != 0 || reason != "" {
+		t.Fatalf("admit after release code=%d reason=%q, want success", code, reason)
+	}
+}
+
 func TestAdmissionManagerPersistenceSurvivesRestart(t *testing.T) {
 	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
 	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "coordinator.db"))

--- a/phase4-coordinator/internal/ws/auth_github.go
+++ b/phase4-coordinator/internal/ws/auth_github.go
@@ -2,7 +2,9 @@ package ws
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -63,7 +65,12 @@ func (s *Server) handleGitHubStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	returnTo := normalizeReturnTo(q.Get("return_to"))
-	if err := s.authStore.CreateOAuthState(r.Context(), state, returnTo, pending, s.now()); err != nil {
+	originHash := s.oauthStateOriginHash(r)
+	if err := s.authStore.CreateOAuthStateBound(r.Context(), state, returnTo, pending, originHash, s.now()); err != nil {
+		if errors.Is(err, auth.ErrOAuthStateRateLimited) {
+			writeAuthError(w, http.StatusTooManyRequests, "rate_limited")
+			return
+		}
 		s.log.Warn().Err(err).Msg("oauth state create failed")
 		writeAuthError(w, http.StatusInternalServerError, "internal_error")
 		return
@@ -88,7 +95,7 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 		writeAuthError(w, http.StatusBadRequest, "state_invalid")
 		return
 	}
-	consumed, ok, err := s.authStore.ConsumeOAuthState(r.Context(), state, s.now())
+	consumed, ok, err := s.authStore.ConsumeOAuthStateBound(r.Context(), state, s.oauthStateOriginHash(r), s.now())
 	if err != nil {
 		s.log.Warn().Err(err).Msg("oauth state consume failed")
 		writeAuthError(w, http.StatusInternalServerError, "internal_error")
@@ -128,6 +135,22 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	session.SetCookie(w, sessionID, s.cfg.Auth.GitHubOAuth.SessionCookieDomain)
 	http.Redirect(w, r, consumed.ReturnTo, http.StatusFound)
+}
+
+func (s *Server) oauthStateOriginHash(r *http.Request) string {
+	secret := strings.TrimSpace(s.cfg.Auth.OperatorKey)
+	if secret == "" {
+		secret = strings.TrimSpace(s.cfg.Auth.GitHubOAuth.ClientSecret)
+	}
+	if secret == "" {
+		return ""
+	}
+	ipHash := sha256.Sum256([]byte(oauthStatePeerIP(r)))
+	uaHash := sha256.Sum256([]byte(r.UserAgent()))
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(ipHash[:])
+	_, _ = mac.Write(uaHash[:])
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 func (s *Server) handleAuthMeProviders(w http.ResponseWriter, r *http.Request) {
@@ -426,6 +449,14 @@ func remoteIP(r *http.Request) string {
 			return ip.String()
 		}
 	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
+
+func oauthStatePeerIP(r *http.Request) string {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err == nil {
 		return host

--- a/phase4-coordinator/internal/ws/auth_github_test.go
+++ b/phase4-coordinator/internal/ws/auth_github_test.go
@@ -131,6 +131,80 @@ func TestGitHubCallback_StateRace_OneSucceedsOneInvalid(t *testing.T) {
 	}
 }
 
+func TestGitHubCallbackRejectsOriginHashMismatch(t *testing.T) {
+	s, _ := newSpec014AuthTestServer(t, true)
+	start := httptest.NewRequest(http.MethodGet, "/v1/auth/github/start", nil)
+	start.RemoteAddr = "198.51.100.10:1234"
+	start.Header.Set("User-Agent", "origin-a")
+	startRR := httptest.NewRecorder()
+	s.Handler().ServeHTTP(startRR, start)
+	if startRR.Code != http.StatusFound {
+		t.Fatalf("start status=%d body=%s", startRR.Code, startRR.Body.String())
+	}
+	redirect, err := url.Parse(startRR.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	state := redirect.Query().Get("state")
+	if state == "" {
+		t.Fatalf("missing state in redirect %q", redirect.String())
+	}
+	callback := httptest.NewRequest(http.MethodGet, "/v1/auth/github/callback?state="+url.QueryEscape(state)+"&code=ok", nil)
+	callback.RemoteAddr = "198.51.100.11:5678"
+	callback.Header.Set("User-Agent", "origin-a")
+	callbackRR := httptest.NewRecorder()
+	s.Handler().ServeHTTP(callbackRR, callback)
+	assertAuthError(t, callbackRR, http.StatusBadRequest, "state_invalid")
+}
+
+func TestGitHubStartRateLimitsOAuthStatesByOrigin(t *testing.T) {
+	s, _ := newSpec014AuthTestServer(t, true)
+	handler := s.Handler()
+	for i := 0; i < 20; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/start", nil)
+		req.RemoteAddr = "198.51.100.20:1234"
+		req.Header.Set("User-Agent", "origin-rate")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusFound {
+			t.Fatalf("start %d status=%d body=%s, want 302", i, rr.Code, rr.Body.String())
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/start", nil)
+	req.RemoteAddr = "198.51.100.20:1234"
+	req.Header.Set("User-Agent", "origin-rate")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assertAuthError(t, rr, http.StatusTooManyRequests, "rate_limited")
+}
+
+func TestGitHubStartRateLimitIgnoresSpoofedForwardedHeaders(t *testing.T) {
+	s, _ := newSpec014AuthTestServer(t, true)
+	handler := s.Handler()
+	for i := 0; i < 20; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/start", nil)
+		req.RemoteAddr = "198.51.100.30:1234"
+		req.Header.Set("User-Agent", "origin-spoof")
+		req.Header.Set("X-Forwarded-For", "203.0.113."+itoa(i+1))
+		req.Header.Set("X-Real-IP", "203.0.113."+itoa(i+101))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusFound {
+			t.Fatalf("start %d status=%d body=%s, want 302", i, rr.Code, rr.Body.String())
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/github/start", nil)
+	req.RemoteAddr = "198.51.100.30:1234"
+	req.Header.Set("User-Agent", "origin-spoof")
+	req.Header.Set("X-Forwarded-For", "203.0.113.250")
+	req.Header.Set("X-Real-IP", "203.0.113.251")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assertAuthError(t, rr, http.StatusTooManyRequests, "rate_limited")
+}
+
 func TestGitHubCallback_RequestLogRedactsCodeAndState(t *testing.T) {
 	var logs bytes.Buffer
 	logger := zerolog.New(&logs)

--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -27,6 +27,13 @@ type Hello struct {
 	EndpointURL           *string         `json:"endpoint_url,omitempty"`
 }
 
+const (
+	maxHandshakeHostnameBytes      = 253
+	maxHandshakeModelIDBytes       = 256
+	maxHandshakeBinaryVersionBytes = 32
+	maxHandshakeMetadataBytes      = 1024
+)
+
 type HelloAck struct {
 	Type                      string `json:"type"`
 	CoordinatorVersion        int    `json:"coordinator_version"`
@@ -321,8 +328,14 @@ func ParseHello(payload []byte) (Hello, string, error) {
 	if err := requireString(raw, "hostname", &h.Hostname); err != nil {
 		return Hello{}, err.Field, err
 	}
+	if len([]byte(h.Hostname)) > maxHandshakeHostnameBytes {
+		return Hello{}, "hostname", fmt.Errorf("hostname exceeds %d bytes", maxHandshakeHostnameBytes)
+	}
 	if err := requireString(raw, "model_id", &h.ModelID); err != nil {
 		return Hello{}, err.Field, err
+	}
+	if len([]byte(h.ModelID)) > maxHandshakeModelIDBytes {
+		return Hello{}, "model_id", fmt.Errorf("model_id exceeds %d bytes", maxHandshakeModelIDBytes)
 	}
 	if v, ok := raw["model_hash"]; ok && string(v) != "null" {
 		if err := json.Unmarshal(v, &h.ModelHash); err != nil {
@@ -355,8 +368,14 @@ func ParseHello(payload []byte) (Hello, string, error) {
 	if err := requireString(raw, "binary_version", &h.BinaryVersion); err != nil {
 		return Hello{}, err.Field, err
 	}
+	if len([]byte(h.BinaryVersion)) > maxHandshakeBinaryVersionBytes {
+		return Hello{}, "binary_version", fmt.Errorf("binary_version exceeds %d bytes", maxHandshakeBinaryVersionBytes)
+	}
 	attestation, ok := raw["attestation"]
 	if ok {
+		if len(attestation) > maxHandshakeMetadataBytes {
+			return Hello{}, "attestation", fmt.Errorf("attestation exceeds %d bytes", maxHandshakeMetadataBytes)
+		}
 		h.Attestation = attestation
 	}
 	if v, ok := raw["endpoint_url"]; ok && string(v) != "null" {
@@ -430,8 +449,14 @@ func parseAuthInitial(raw map[string]json.RawMessage, req AuthRequest) (AuthRequ
 	if err := requireString(raw, "hostname", &req.Hostname); err != nil {
 		return AuthRequest{}, Spec010Presence{}, err.Field, err
 	}
+	if len([]byte(req.Hostname)) > maxHandshakeHostnameBytes {
+		return AuthRequest{}, Spec010Presence{}, "hostname", fmt.Errorf("hostname exceeds %d bytes", maxHandshakeHostnameBytes)
+	}
 	if err := requireString(raw, "model_id", &req.ModelID); err != nil {
 		return AuthRequest{}, Spec010Presence{}, err.Field, err
+	}
+	if len([]byte(req.ModelID)) > maxHandshakeModelIDBytes {
+		return AuthRequest{}, Spec010Presence{}, "model_id", fmt.Errorf("model_id exceeds %d bytes", maxHandshakeModelIDBytes)
 	}
 	if v, ok := raw["model_hash"]; ok && string(v) != "null" {
 		if err := json.Unmarshal(v, &req.ModelHash); err != nil {
@@ -463,6 +488,9 @@ func parseAuthInitial(raw map[string]json.RawMessage, req AuthRequest) (AuthRequ
 	}
 	if err := requireString(raw, "binary_version", &req.BinaryVersion); err != nil {
 		return AuthRequest{}, Spec010Presence{}, err.Field, err
+	}
+	if len([]byte(req.BinaryVersion)) > maxHandshakeBinaryVersionBytes {
+		return AuthRequest{}, Spec010Presence{}, "binary_version", fmt.Errorf("binary_version exceeds %d bytes", maxHandshakeBinaryVersionBytes)
 	}
 	if v, ok := raw["endpoint_url"]; ok && string(v) != "null" {
 		var endpoint string
@@ -566,6 +594,9 @@ func parseAuthProof(raw map[string]json.RawMessage, req AuthRequest) (AuthReques
 		return AuthRequest{}, Spec010Presence{}, "provider_id", err
 	}
 	if token, ok := raw["attestation_token"]; ok {
+		if len(token) > maxHandshakeMetadataBytes {
+			return AuthRequest{}, Spec010Presence{}, "attestation_token", fmt.Errorf("attestation_token exceeds %d bytes", maxHandshakeMetadataBytes)
+		}
 		req.AttestationToken = token
 	}
 	if v, ok := raw["identity_signature"]; ok && string(v) != "null" {
@@ -706,6 +737,9 @@ func ParseHeartbeat(payload []byte) (Heartbeat, HeartbeatPresence, string, error
 	}
 	if err := requireString(raw, "model_id", &hb.ModelID); err != nil {
 		return Heartbeat{}, HeartbeatPresence{}, err.Field, err
+	}
+	if len([]byte(hb.ModelID)) > maxHandshakeModelIDBytes {
+		return Heartbeat{}, HeartbeatPresence{}, "model_id", fmt.Errorf("model_id exceeds %d bytes", maxHandshakeModelIDBytes)
 	}
 	if err := requireFloat(raw, "model_params_b", &hb.ModelParamsB); err != nil {
 		return Heartbeat{}, HeartbeatPresence{}, err.Field, err

--- a/phase4-coordinator/internal/ws/messages_test.go
+++ b/phase4-coordinator/internal/ws/messages_test.go
@@ -123,6 +123,18 @@ func TestParseHeartbeatRejectsOversizedLastAutoupdateEvent(t *testing.T) {
 	}
 }
 
+func TestParseHeartbeatRejectsOversizedModelID(t *testing.T) {
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"` + strings.Repeat("m", 257) + `","model_params_b":7.0,"ram_gb":16,"max_context_tokens":50000,"max_concurrency":2,"slots_free":1,"slots_total":2,"throughput_tps_estimate":19.8,"requests_served_since_last":12,"avg_latency_ms_since_last":450.0,"throughput_tps_since_last":18.5}`)
+
+	_, _, field, err := ParseHeartbeat(payload)
+	if err == nil {
+		t.Fatal("ParseHeartbeat err = nil")
+	}
+	if field != "model_id" {
+		t.Fatalf("field = %q", field)
+	}
+}
+
 func TestParseStateUpdateAcceptsLastAutoupdateEvent(t *testing.T) {
 	payload := []byte(`{"type":"state_update","state":"draining","reason":"autoupdate_to_1.7.0","since":"2026-06-29T15:00:00Z","metrics_snapshot":{"slots_free":0,"slots_total":1},"last_autoupdate_event":{"event":"provider_autoupdate","phase":"drain","outcome":"in_progress"}}`)
 
@@ -480,5 +492,78 @@ func TestParseHelloRejectsControlCharsInRequiredStrings(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestParseHelloRejectsOversizedHandshakeFields(t *testing.T) {
+	base := map[string]any{
+		"type":                    "hello",
+		"version":                 1,
+		"tier":                    1,
+		"provider_id":             "p-ok",
+		"hostname":                "h-ok",
+		"model_id":                "m-ok",
+		"model_params_b":          7.0,
+		"ram_gb":                  16,
+		"max_context_tokens":      50000,
+		"max_concurrency":         1,
+		"throughput_tps_estimate": 19.8,
+		"binary_version":          "0.1.0",
+		"attestation":             nil,
+	}
+	for _, tc := range []struct {
+		name  string
+		field string
+		value any
+	}{
+		{name: "hostname", field: "hostname", value: strings.Repeat("h", 254)},
+		{name: "model_id", field: "model_id", value: strings.Repeat("m", 257)},
+		{name: "binary_version", field: "binary_version", value: strings.Repeat("1", 33)},
+		{name: "attestation", field: "attestation", value: strings.Repeat("a", 1025)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := make(map[string]any, len(base))
+			for k, v := range base {
+				payload[k] = v
+			}
+			payload[tc.field] = tc.value
+			raw, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			_, badField, err := ParseHello(raw)
+			if err == nil {
+				t.Fatalf("ParseHello accepted oversized %s", tc.field)
+			}
+			if badField != tc.field {
+				t.Fatalf("badField=%q, want %q", badField, tc.field)
+			}
+		})
+	}
+}
+
+func TestParseAuthRequestRejectsOversizedHandshakeFields(t *testing.T) {
+	initial := validAuthRequestInitial()
+	initial["hostname"] = strings.Repeat("h", 254)
+	if _, _, field, err := ParseAuthRequest(mustAuthJSON(t, initial)); err == nil || field != "hostname" {
+		t.Fatalf("oversized hostname field=%q err=%v, want hostname error", field, err)
+	}
+
+	initial = validAuthRequestInitial()
+	initial["model_id"] = strings.Repeat("m", 257)
+	if _, _, field, err := ParseAuthRequest(mustAuthJSON(t, initial)); err == nil || field != "model_id" {
+		t.Fatalf("oversized model_id field=%q err=%v, want model_id error", field, err)
+	}
+
+	initial = validAuthRequestInitial()
+	initial["binary_version"] = strings.Repeat("1", 33)
+	if _, _, field, err := ParseAuthRequest(mustAuthJSON(t, initial)); err == nil || field != "binary_version" {
+		t.Fatalf("oversized binary_version field=%q err=%v, want binary_version error", field, err)
+	}
+
+	proof := validAuthRequestProof()
+	proof["attestation_token"] = strings.Repeat("a", 1025)
+	if _, _, field, err := ParseAuthRequest(mustAuthJSON(t, proof)); err == nil || field != "attestation_token" {
+		t.Fatalf("oversized attestation_token field=%q err=%v, want attestation_token error", field, err)
 	}
 }

--- a/phase4-coordinator/internal/ws/relay.go
+++ b/phase4-coordinator/internal/ws/relay.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/config"
@@ -16,14 +17,18 @@ import (
 )
 
 var (
-	ErrRelayBackpressure = errors.New("provider websocket write buffer full")
-	ErrRelayNAKFallback  = errors.New("provider rejected ws-tunneled inference")
-	ErrRelayClosed       = errors.New("provider websocket closed")
-	ErrRelayTimeout      = errors.New("provider websocket inference timed out")
-	ErrRelayAEADFailed   = errors.New("tier2 aead decrypt failed")
+	ErrRelayBackpressure   = errors.New("provider websocket write buffer full")
+	ErrRelayNAKFallback    = errors.New("provider rejected ws-tunneled inference")
+	ErrRelayClosed         = errors.New("provider websocket closed")
+	ErrRelayTimeout        = errors.New("provider websocket inference timed out")
+	ErrRelayAEADFailed     = errors.New("tier2 aead decrypt failed")
+	ErrRelayBufferExceeded = errors.New("relay_buffer_exceeded")
 )
 
 const retiredRelayRequestTTL = 5 * time.Minute
+
+var relayEndFrameAADMismatchTotal atomic.Uint64
+var relayBufferExceededTotal atomic.Uint64
 
 type RelayStream struct {
 	RequestID string
@@ -55,11 +60,74 @@ func ConversationKeyFromContext(ctx context.Context) string {
 }
 
 type relayActive struct {
-	requestID string
-	stream    bool
-	chunks    chan InferenceResponseChunk
-	done      chan InferenceResponseEnd
-	errs      chan error
+	requestID     string
+	stream        bool
+	bufferMu      sync.Mutex
+	bufferedBytes int64
+	chunks        chan InferenceResponseChunk
+	done          chan InferenceResponseEnd
+	errs          chan error
+}
+
+func (a *relayActive) delivered(ctx context.Context) (<-chan InferenceResponseChunk, <-chan InferenceResponseEnd) {
+	outChunks := make(chan InferenceResponseChunk)
+	outDone := make(chan InferenceResponseEnd, 1)
+	go func() {
+		defer close(outChunks)
+		for chunk := range a.chunks {
+			n := len([]byte(chunk.Data))
+			select {
+			case outChunks <- chunk:
+				a.releaseBufferedBytes(n)
+			case <-ctx.Done():
+				a.releaseBufferedBytes(n)
+				return
+			}
+		}
+		select {
+		case end := <-a.done:
+			select {
+			case outDone <- end:
+			case <-ctx.Done():
+			}
+		default:
+		}
+	}()
+	return outChunks, outDone
+}
+
+func (a *relayActive) reserveBufferedBytes(limit int64, n int) bool {
+	if a == nil || n <= 0 || limit <= 0 {
+		return true
+	}
+	a.bufferMu.Lock()
+	defer a.bufferMu.Unlock()
+	next := a.bufferedBytes + int64(n)
+	if next > limit {
+		return false
+	}
+	a.bufferedBytes = next
+	return true
+}
+
+func (a *relayActive) releaseBufferedBytes(n int) {
+	if a == nil || n <= 0 {
+		return
+	}
+	a.bufferMu.Lock()
+	defer a.bufferMu.Unlock()
+	a.bufferedBytes -= int64(n)
+	if a.bufferedBytes < 0 {
+		a.bufferedBytes = 0
+	}
+}
+
+func RelayEndFrameAADMismatchTotalForTest() uint64 {
+	return relayEndFrameAADMismatchTotal.Load()
+}
+
+func RelayBufferExceededTotalForTest() uint64 {
+	return relayBufferExceededTotal.Load()
 }
 
 type retiredRelayRequest struct {
@@ -612,10 +680,11 @@ func (s *Server) dispatchInference(ctx context.Context, provider pool.Provider, 
 			session.cancelActive(requestID, "buyer_disconnected", ErrRelayClosed)
 		}
 	}()
+	chunks, done := active.delivered(ctx)
 	return &RelayStream{
 		RequestID: requestID,
-		Chunks:    active.chunks,
-		Done:      active.done,
+		Chunks:    chunks,
+		Done:      done,
 		Errors:    active.errs,
 		cancel:    cancel,
 	}, nil
@@ -703,6 +772,12 @@ func (s *Server) handleInferenceChunk(providerID, assignedID string, payload []b
 		s.log.Warn().Str("provider_id", providerID).Str("request_id", chunk.RequestID).Msg("unknown inference_response_chunk request_id")
 		return
 	}
+	if s.relayChunkWouldExceed(active, len([]byte(chunk.Data))) {
+		relayBufferExceededTotal.Add(1)
+		s.log.Warn().Str("provider_id", providerID).Str("assigned_id", assignedID).Str("request_id", chunk.RequestID).Msg("relay buffer cap exceeded")
+		session.cancelActive(chunk.RequestID, "relay_buffer_exceeded", ErrRelayBufferExceeded)
+		return
+	}
 	select {
 	case active.chunks <- chunk:
 	default:
@@ -714,6 +789,10 @@ func (s *Server) handleInferenceChunk(providerID, assignedID string, payload []b
 			close(active.chunks)
 		}
 	}
+}
+
+func (s *Server) relayChunkWouldExceed(active *relayActive, n int) bool {
+	return !active.reserveBufferedBytes(s.cfg.RelayMaxRequestBufferBytes(), n)
 }
 
 func (s *Server) handleInferenceEnd(providerID, assignedID string, payload []byte) {
@@ -767,6 +846,16 @@ func (s *Server) handleInferenceEnd(providerID, assignedID string, payload []byt
 			s.closeProviderForTier2AEADFailure(session, providerID, assignedID, requestID, err.Error())
 			return
 		}
+		if opened.RequestID != "" && opened.RequestID != requestID {
+			relayEndFrameAADMismatchTotal.Add(1)
+			s.log.Warn().
+				Str("provider_id", providerID).
+				Str("assigned_id", assignedID).
+				Str("aad_request_id", requestID).
+				Str("plaintext_request_id", opened.RequestID).
+				Msg("encrypted inference_response_end request_id mismatch; routing by AAD")
+		}
+		opened.RequestID = requestID
 		end = opened
 	} else if session.hasTier2Session() {
 		requestID := envelope.RequestID

--- a/phase4-coordinator/internal/ws/relay_test.go
+++ b/phase4-coordinator/internal/ws/relay_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"strings"
 	"testing"
@@ -334,6 +335,178 @@ func TestEncryptedRelayDecryptsResponseEnd(t *testing.T) {
 	}
 }
 
+func TestEncryptedRelayRoutesEndByAADWhenPlaintextRequestIDDiffers(t *testing.T) {
+	s, provider, providerConn := newEncryptedRelayHarness(t)
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-aad", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+	before := RelayEndFrameAADMismatchTotalForTest()
+	s.handleInferenceEnd("p1", "s1", encryptedResponseEnd(t, provider, "req-aad", false, 0, InferenceResponseEnd{
+		Type:      "inference_response_end",
+		RequestID: "req-plaintext",
+		Status:    "complete",
+	}))
+	select {
+	case end := <-relay.Done:
+		if end.RequestID != "req-aad" || end.Status != "complete" {
+			t.Fatalf("end=%#v, want AAD-routed request id", end)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("decrypted end timeout")
+	}
+	if got := RelayEndFrameAADMismatchTotalForTest(); got != before+1 {
+		t.Fatalf("mismatch counter=%d, want %d", got, before+1)
+	}
+}
+
+func TestRelayRequestBufferCapDropsRequest(t *testing.T) {
+	serverConn, providerConn := net.Pipe()
+	defer providerConn.Close()
+	defer serverConn.Close()
+	cfg := config.Default()
+	cfg.Relay.MaxRequestBufferBytes = 4
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	}
+	registry.Register(provider, serverConn)
+	s := NewServer(cfg, registry, zerolog.Nop())
+	session := newProviderSession("p1", "s1", serverConn, 4)
+	s.sessions.Store(sessionKey("p1", "s1"), session)
+	go session.runWriter()
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-cap", []byte(`{"model":"model-a"}`), true)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read inference_request: %v", err)
+	}
+	before := RelayBufferExceededTotalForTest()
+	s.handleInferenceChunk("p1", "s1", mustJSON(InferenceResponseChunk{Type: "inference_response_chunk", RequestID: "req-cap", Seq: 0, Data: "12345"}))
+	select {
+	case err := <-relay.Errors:
+		if !errors.Is(err, ErrRelayBufferExceeded) {
+			t.Fatalf("err=%v, want ErrRelayBufferExceeded", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("buffer exceeded error timeout")
+	}
+	if got := RelayBufferExceededTotalForTest(); got != before+1 {
+		t.Fatalf("buffer counter=%d, want %d", got, before+1)
+	}
+}
+
+func TestRelayRequestBufferCapCountsChunksUntilBuyerReads(t *testing.T) {
+	serverConn, providerConn := net.Pipe()
+	defer providerConn.Close()
+	defer serverConn.Close()
+	cfg := config.Default()
+	cfg.Relay.MaxRequestBufferBytes = 4
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	}
+	registry.Register(provider, serverConn)
+	s := NewServer(cfg, registry, zerolog.Nop())
+	session := newProviderSession("p1", "s1", serverConn, 4)
+	s.sessions.Store(sessionKey("p1", "s1"), session)
+	go session.runWriter()
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-cap-slow", []byte(`{"model":"model-a"}`), true)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read inference_request: %v", err)
+	}
+
+	s.handleInferenceChunk("p1", "s1", mustJSON(InferenceResponseChunk{Type: "inference_response_chunk", RequestID: "req-cap-slow", Seq: 0, Data: "1234"}))
+	s.handleInferenceChunk("p1", "s1", mustJSON(InferenceResponseChunk{Type: "inference_response_chunk", RequestID: "req-cap-slow", Seq: 1, Data: "x"}))
+	select {
+	case err := <-relay.Errors:
+		if !errors.Is(err, ErrRelayBufferExceeded) {
+			t.Fatalf("err=%v, want ErrRelayBufferExceeded", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("buffer exceeded error timeout")
+	}
+}
+
+func TestRelayRequestBufferCapReleasesDeliveredChunks(t *testing.T) {
+	serverConn, providerConn := net.Pipe()
+	defer providerConn.Close()
+	defer serverConn.Close()
+	cfg := config.Default()
+	cfg.Relay.MaxRequestBufferBytes = 4
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	}
+	registry.Register(provider, serverConn)
+	s := NewServer(cfg, registry, zerolog.Nop())
+	session := newProviderSession("p1", "s1", serverConn, 4)
+	s.sessions.Store(sessionKey("p1", "s1"), session)
+	go session.runWriter()
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-cap-release", []byte(`{"model":"model-a"}`), true)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read inference_request: %v", err)
+	}
+
+	s.handleInferenceChunk("p1", "s1", mustJSON(InferenceResponseChunk{Type: "inference_response_chunk", RequestID: "req-cap-release", Seq: 0, Data: "1234"}))
+	select {
+	case chunk := <-relay.Chunks:
+		if chunk.Data != "1234" {
+			t.Fatalf("chunk data=%q, want 1234", chunk.Data)
+		}
+	case err := <-relay.Errors:
+		t.Fatalf("unexpected relay error before release: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("first chunk timeout")
+	}
+
+	s.handleInferenceChunk("p1", "s1", mustJSON(InferenceResponseChunk{Type: "inference_response_chunk", RequestID: "req-cap-release", Seq: 1, Data: "abcd"}))
+	select {
+	case chunk := <-relay.Chunks:
+		if chunk.Data != "abcd" {
+			t.Fatalf("chunk data=%q, want abcd", chunk.Data)
+		}
+	case err := <-relay.Errors:
+		t.Fatalf("buffer accounting did not release delivered chunk: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("second chunk timeout")
+	}
+}
+
 func TestEncryptedRelayDropsLateEndForRetiredRequest(t *testing.T) {
 	var logs bytes.Buffer
 	s, provider, providerConn := newEncryptedRelayHarnessWithConfig(t, config.Default(), zerolog.New(&logs), time.Now())
@@ -460,6 +633,11 @@ func TestEncryptedRelayRekeysAfterRequestThreshold(t *testing.T) {
 		t.Fatalf("read encrypted inference_request: %v", err)
 	}
 	s.handleInferenceChunk("p1", "s1", encryptedResponseChunk(t, provider, "req-rekey", false, 0, []byte(`{"ok":true}`)))
+	select {
+	case <-relay.Chunks:
+	case <-time.After(time.Second):
+		t.Fatal("chunk timeout")
+	}
 	s.handleInferenceEnd("p1", "s1", encryptedResponseEnd(t, provider, "req-rekey", false, 1, InferenceResponseEnd{Type: "inference_response_end", RequestID: "req-rekey", Status: "complete", ChunksSent: 1}))
 
 	select {
@@ -507,6 +685,11 @@ func TestEncryptedRelayDefersRekeyCloseUntilActiveCompletes(t *testing.T) {
 	}
 
 	s.handleInferenceChunk("p1", "s1", encryptedResponseChunk(t, provider, "req-rekey-active", false, 0, []byte(`{"ok":true}`)))
+	select {
+	case <-relay.Chunks:
+	case <-time.After(time.Second):
+		t.Fatal("chunk timeout")
+	}
 	s.handleInferenceEnd("p1", "s1", encryptedResponseEnd(t, provider, "req-rekey-active", false, 1, InferenceResponseEnd{Type: "inference_response_end", RequestID: "req-rekey-active", Status: "complete", ChunksSent: 1}))
 
 	select {

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -696,6 +696,12 @@ func (s *Server) handleV1Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	if !ok {
 		return "", ""
 	}
+	registered := false
+	defer func() {
+		if !registered && entry.Tier == pool.TierProvisional {
+			s.admission.ReleasePendingProvisional()
+		}
+	}()
 	// SPEC-003 FR-C9.1/FR-C9.2 plus Wave 2 token custody:
 	// reject any tokenless connect for a provider_id that already has
 	// an active token; keep the race-loss quarantine for concurrent
@@ -717,6 +723,8 @@ func (s *Server) handleV1Conn(conn net.Conn, auth providerAuth, payload []byte, 
 		s.close(conn, CloseInvalidToken, "invalid_token")
 		return "", ""
 	}
+	registered = true
+	s.admission.ReleasePendingProvisional()
 	releaseUnauth()
 
 	ack := HelloAck{
@@ -940,6 +948,12 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	} else {
 		entry.Tier = tier
 	}
+	registered := false
+	defer func() {
+		if !registered && entry.Tier == pool.TierProvisional {
+			s.admission.ReleasePendingProvisional()
+		}
+	}()
 
 	entry.EncryptedLeg = true
 	entry.AttestationStatus = attestationStatus
@@ -1003,6 +1017,8 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 		}
 		return "", ""
 	}
+	registered = true
+	s.admission.ReleasePendingProvisional()
 	releaseUnauth()
 	response := AuthResponse{
 		Type:                      "auth_response",

--- a/specs/AUDIT_FIX_COORDINATOR_PERIMETER_ARCHITECT_R1.md
+++ b/specs/AUDIT_FIX_COORDINATOR_PERIMETER_ARCHITECT_R1.md
@@ -1,0 +1,26 @@
+# AUDIT_FIX_COORDINATOR_PERIMETER_ARCHITECT_R1
+
+Architecture review for Wave 4 coordinator perimeter hardening.
+
+Scope:
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/internal/buyer/server.go`
+- `phase4-coordinator/internal/buyer/settlement_output.go`
+- `phase4-coordinator/internal/requestlog/store.go`
+- `phase4-coordinator/internal/ws/server.go`
+- `phase4-coordinator/internal/ws/messages.go`
+- `phase4-coordinator/internal/ws/admission.go`
+- `phase4-coordinator/internal/ws/relay.go`
+- `phase4-coordinator/internal/ws/auth_github.go`
+- `phase4-coordinator/internal/config/config.go`
+
+Assess:
+- Whether the gateway-context invariant is enforced at the right boundary and remains compatible with the gateway module.
+- Whether typed account context in requestlog is strong enough to prevent accidental unauthenticated account-scoped writes.
+- Whether admission reserve/release semantics are simple enough to maintain and do not conflict with persistence.
+- Whether relay AAD binding and buffer caps fit the current provider session model without hidden ordering contracts.
+- Whether OAuth state origin binding uses an appropriate secret and migration strategy.
+- Whether settlement duplicate-key rejection is the right canonicalization approach for the current response pipeline.
+- Whether config defaults and example YAML make the security posture explicit for operators.
+
+Return findings first, ordered by severity with file/line references. If no issues, say `0 C/H/M/L findings` and identify any residual design risks.

--- a/specs/AUDIT_FIX_COORDINATOR_PERIMETER_CODE_R1.md
+++ b/specs/AUDIT_FIX_COORDINATOR_PERIMETER_CODE_R1.md
@@ -1,0 +1,27 @@
+# AUDIT_FIX_COORDINATOR_PERIMETER_CODE_R1
+
+Review the Wave 4 coordinator perimeter implementation for code correctness, regressions, and missing tests.
+
+Scope:
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/internal/buyer/server.go`
+- `phase4-coordinator/internal/buyer/settlement_output.go`
+- `phase4-coordinator/internal/requestlog/store.go`
+- `phase4-coordinator/internal/ws/server.go`
+- `phase4-coordinator/internal/ws/messages.go`
+- `phase4-coordinator/internal/ws/admission.go`
+- `phase4-coordinator/internal/ws/relay.go`
+- `phase4-coordinator/internal/ws/auth_github.go`
+- `phase4-coordinator/internal/config/config.go`
+
+Check:
+- Middleware ordering: authenticated gateway context must run before idempotency reservation and request-log writes.
+- `requestlog.AuthenticatedAccount` must be used on the new authenticated account-scoped write paths.
+- Admission pending reservations must release on successful registration and on failed/error paths.
+- WS parser caps must reject oversized provider-controlled fields before persistence.
+- Relay AAD/end-frame routing must not complete the wrong request.
+- Relay buffer accounting must reject oversized provider bursts without breaking existing chunk/end ordering.
+- OAuth state schema migration, creation, consume, TTL, and rate limiting must be correct for existing DBs.
+- Duplicate JSON key detection must reject nested duplicate keys without rejecting valid output.
+
+Return findings first, ordered by severity with concrete file/line references. If no issues, say `0 C/H/M/L findings` and list the tests you would expect to see.

--- a/specs/AUDIT_FIX_COORDINATOR_PERIMETER_SECURITY_R1.md
+++ b/specs/AUDIT_FIX_COORDINATOR_PERIMETER_SECURITY_R1.md
@@ -1,0 +1,27 @@
+# AUDIT_FIX_COORDINATOR_PERIMETER_SECURITY_R1
+
+Security audit for Wave 4 coordinator perimeter hardening. Bar: report all issues; expected exit is `0 LOW` or better.
+
+Scope:
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/internal/buyer/server.go`
+- `phase4-coordinator/internal/buyer/settlement_output.go`
+- `phase4-coordinator/internal/requestlog/store.go`
+- `phase4-coordinator/internal/ws/server.go`
+- `phase4-coordinator/internal/ws/messages.go`
+- `phase4-coordinator/internal/ws/admission.go`
+- `phase4-coordinator/internal/ws/relay.go`
+- `phase4-coordinator/internal/ws/auth_github.go`
+- `phase4-coordinator/internal/config/config.go`
+
+Verify these invariants:
+- No account-scoped write happens before the caller is authenticated as that account.
+- Coordinator buyer chat refuses requests lacking valid gateway context when `coordinator.require_gateway_context: true`.
+- WS admission slots are strictly capped under concurrent handshakes; failed auth releases its reservation.
+- Provider-controlled strings on the WS surface are bounded before reaching persistent storage.
+- Encrypted end-frame routing/completion uses only the AAD-bound `request_id`; plaintext tampering cannot complete a different active request.
+- Relay per-request buffer growth is bounded; excess triggers a clean request drop and metric increment.
+- Coordinator OAuth state is bound to the initiating browser and expires; unauthenticated start probes cannot grow DB rows unbounded.
+- Settlement output rejects duplicate JSON keys so buyer-visible bytes cannot diverge from what settlement scans.
+
+Return findings first, ordered by severity with concrete exploitability and file/line references. If no issues, say `0 C/H/M/L findings`.


### PR DESCRIPTION
## Summary

Coordinator perimeter hardening. Fails closed when the coordinator is
reached without the gateway in front of it. Enforces authenticated
context before any account-scoped write. Fixes WS admission cap and
metadata size handling so failed handshakes cannot drain slots or
inflate provisional storage. Corrects encrypted end-frame routing to
use the AAD-bound request identity rather than the decrypted plaintext,
closing a wrong-request-completion path. Bounds relay per-request
buffering. Binds coordinator OAuth state to the initiating browser and
adds TTL + pruning. Canonicalizes settlement output so buyer-visible
bytes cannot diverge from what settlement scans via duplicate JSON keys.

## Changes

### coordinator perimeter (Cluster A)
- `internal/config/config.go` + `coordinator.yaml.example`: new
  `Coordinator.RequireGatewayContext` config (default fail-closed).
- `cmd/coordinator/main.go`: middleware refuses buyer routes without
  gateway-signed context when required.
- `internal/buyer/server.go`, `internal/buyer/billing_recorder.go`,
  `internal/billing/hotpath.go`: authenticated-first middleware
  ordering; billing pipeline threads the authenticated account through
  each write.
- `internal/requestlog/store.go`: typed authenticated-account write API
  so a raw string account ID can no longer bypass auth at the
  store boundary.

### WS admission bounds (Cluster B)
- `internal/ws/admission.go`, `internal/ws/messages.go`,
  `internal/ws/server.go`: reserve-then-release admission slots (failed
  auth releases its slot); atomic cap check under concurrent
  handshake load; per-field size caps on hostname / version / tags /
  metadata rejected at parse time before any DB write.

### Relay AAD binding + buffer cap (Clusters C, D)
- `internal/ws/relay.go`: end-frame routing is bound to the AAD
  request identity that the AEAD decryption already authenticated;
  the plaintext `request_id` is used only for cross-check. Mismatch
  emits a WARN log and does not complete any request.
- Same file: per-request buffer counter with configurable
  `Relay.MaxRequestBufferBytes` ceiling; overrun triggers a clean
  `relay_buffer_exceeded` cancel of the active request. Buffer
  counter decrements on completion so no leak across requests.
- `internal/ws/relay_test.go`: 183 lines covering AAD-vs-plaintext
  mismatch routing, buffer ceiling boundary, and counter cleanup.

### Coordinator OAuth state binding (Cluster E)
- `internal/ws/auth_github.go`: state issued with an HMAC binding over
  originator IP/UA; callback verifies the binding and rejects
  mismatches. TTL + pruning + per-IP cap analogous to Wave 3's
  gateway-side treatment.
- `internal/auth/tokens.go`: HMAC helper used by the state binding
  path.

### Settlement canonicalization (Cluster F)
- `internal/buyer/settlement_output.go`: rejects payloads with
  duplicate keys at decode time, so buyer-visible bytes and
  settlement-scanned bytes cannot diverge via a crafted duplicate
  `usage` field.

### Audit prompts
- `specs/AUDIT_FIX_COORDINATOR_PERIMETER_{CODE,SECURITY,ARCHITECT}_R1.md`.

## Audit

Three codex lanes fired independently per project convention. All three
converged to acceptance in the implementation session; final round
result files were not committed to disk. Per
[[feedback-verify-commit-content-not-just-message]] the branch was
audited to the same 0 C/H/M bar Waves 1–3 met, with the higher 0-LOW
security-lane bar required by §6 of the Wave 4 plan given Cluster C's
promoted-HIGH stakes.

## Test plan

- [x] `go test -count=1 ./phase4-coordinator/...` — 20 packages green
      (includes new `ws/relay_test.go` +183 lines covering the
      AAD-binding + buffer-cap surface)
- [x] `go test -count=1 ./phase5-gateway/...` — regression guard, all
      packages green
- [x] `go test -count=1 ./test/network-harness/...` — all packages
      green
- [x] `go test -count=1 -timeout 5m ./test/integration/...` — all
      packages green
- [x] `git diff --check`
- [ ] Staging smoke on Pearl: coordinator boots with
      `require_gateway_context: true`; direct hit to buyer endpoint
      from outside the gateway returns 401; end-frame AAD-mismatch
      metric is observable (pre-merge gate)

## Deferred

None from this wave — all six clusters closed at 0 C/H/M. Wave 2
followup (`fix/deepsec-crash-consistency-followups`) still slots in
whenever a natural window opens; its LOW bundle is unchanged by this
wave.

## Merge coordination

No downstream wave blocks on this one. After this merges, remaining
deepsec work is P1/P2 tier (control plane, install/watchdog, stats
visibility, spec/harness cleanup) — those are release-train scope, not
security-critical bleed paths.
