### PR TITLE
Enable Malibu stats behind deploy guards

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -207,7 +207,6 @@ func main() {
 			Enabled:             cfg.Stats.Enabled,
 			ReaderDSN:           cfg.Stats.ReaderDSN,
 			RollupDSN:           cfg.Stats.RollupDSN,
-			ProviderPortalDSN:   cfg.Stats.ProviderPortalDSN,
 			PartnerKeys:         stats.PartnerKeysConfig{LastUsedAtUpdatesEnabled: cfg.Stats.PartnerKeys.LastUsedAtUpdatesEnabled, WriterDSN: cfg.Stats.PartnerKeys.WriterDSN},
 			PartnerKeysAdminDSN: cfg.Stats.PartnerKeysAdminDSN,
 			Rollup: stats.RollupConfig{
@@ -244,7 +243,7 @@ func main() {
 		// `coordinator stats migrate --admin-dsn=...`
 		// subcommand. The integration test harness applies
 		// migrations through its own admin DSN.
-		logger.Info().Msg("SPEC-017 stats pools opened (reader, rollup, provider_portal); migrations are operator-applied; /v1/stats/* will be mounted by Step 3")
+		logger.Info().Msg("SPEC-017 stats pools opened (reader, rollup); migrations are operator-applied; /v1/stats/* will be mounted by Step 3")
 	} else {
 		logger.Info().Msg("SPEC-017 stats DISABLED via config (default); /v1/stats/* not registered")
 	}

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -91,6 +91,37 @@ explorer:
   settlements_default_window_hours: 720
   requests_per_minute_cap: 60
 
+# SPEC-017 Network Stats API — public surface consumed by
+# https://www.malibu.tech/network/. These DSNs are resolved from
+# /etc/macprovider/coordinator.env by systemd; never inline them in YAML.
+stats:
+  enabled: true
+  reader_dsn: env:STATS_READER_DSN
+  rollup_dsn: env:STATS_ROLLUP_DSN
+  partner_keys:
+    # Optional last_used_at writes remain disabled for public Malibu stats.
+    # If this is flipped to true, add stats.partner_keys.writer_dsn and
+    # provision STATS_PARTNER_KEYS_WRITER_DSN in coordinator.env first.
+    last_used_at_updates_enabled: false
+    production_signoff_path: "/opt/macprovider/spec017-signoff.txt"
+  rollup:
+    # Full backfill avoids guessing a partial cutover timestamp and lets
+    # Malibu render all-time totals once the SPEC-017 tables are migrated.
+    backfill_mode: "full"
+    late_events_retention_days: 90
+    usd_per_million_credits: 1.0
+    drift_threshold_ratio: 0.005
+    nightly_rebuild_hour_utc: 9
+    late_events_lookback_hours: 48
+  cors:
+    access_control_max_age_seconds: 60
+    partner_origin_allowlist:
+      - "https://www.malibu.tech"
+      - "https://malibu.tech"
+  trusted_proxies:
+    - "127.0.0.0/8"
+    - "::1/128"
+
 onboarding:
   app_track_register_enabled: true
   postgres_dsn: env:ONBOARDING_POSTGRES_DSN

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -218,6 +218,41 @@ tier2:
   # When empty, /poolz falls back to scheme + request Host. For Pearl:
   public_catalog_base_url: "https://coordinator.streamvc.live"
 
+# SPEC-017 Network Stats API.
+#
+# Production `dist/coordinator.yaml` enables this block for
+# https://www.malibu.tech/network/. Keep this example disabled unless you
+# have applied the SPEC-017 migrations and provisioned role-specific Postgres
+# DSNs in /etc/macprovider/coordinator.env.
+stats:
+  enabled: false
+  # Required when enabled=true:
+  # reader_dsn: env:STATS_READER_DSN
+  # rollup_dsn: env:STATS_ROLLUP_DSN
+  partner_keys:
+    last_used_at_updates_enabled: false
+    # Production deploys should set this to
+    # /opt/macprovider/spec017-signoff.txt before issuing partner keys.
+    # Leave unset in staging fixtures.
+    # production_signoff_path: "/opt/macprovider/spec017-signoff.txt"
+    # Required only when last_used_at_updates_enabled=true:
+    # writer_dsn: env:STATS_PARTNER_KEYS_WRITER_DSN
+  rollup:
+    backfill_mode: "full"
+    late_events_retention_days: 90
+    usd_per_million_credits: 1.0
+    drift_threshold_ratio: 0.005
+    nightly_rebuild_hour_utc: 9
+    late_events_lookback_hours: 48
+  cors:
+    access_control_max_age_seconds: 60
+    partner_origin_allowlist:
+      - "https://www.malibu.tech"
+      - "https://malibu.tech"
+  trusted_proxies:
+    - "127.0.0.0/8"
+    - "::1/128"
+
 # Auto-update recommendation surface. The coordinator forwards
 # `latest_binary_version` to every connected provider in its
 # `auth_response` / `state_update` frame as `recommended_binary_version`.

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -496,6 +496,49 @@ $SSH 'set -e
   fi
 '
 
+log "step 3a/9: stats env preflight"
+STATS_ENABLED_LOCAL="$(yaml_block_value stats enabled)"
+if [ "$STATS_ENABLED_LOCAL" = "true" ]; then
+  # stats.enabled=true makes the coordinator fail closed during config load if
+  # any required stats DSN is missing. Check the remote EnvironmentFile before
+  # uploading/restarting so a stats cutover cannot brick the daemon late in
+  # the deploy after artifacts have already been installed.
+  $SSH 'set -e
+    env_file=/etc/macprovider/coordinator.env
+    if [ ! -r "$env_file" ]; then
+      echo "aborting deploy: stats.enabled=true but $env_file is missing or unreadable" >&2
+      exit 12
+    fi
+    missing=""
+    for name in STATS_READER_DSN STATS_ROLLUP_DSN; do
+      if ! awk -v name="$name" '"'"'
+        function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+        /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+        {
+          line=$0
+          sub(/^[[:space:]]*/, "", line)
+          if (line ~ "^" name "[[:space:]]*=") {
+            found=1
+            sub("^[^=]*=", "", line)
+            line=trim(line)
+            if (line == "" || line == "\"\"" || line == "'\'''\''") exit 2
+          }
+        }
+        END { if (!found) exit 1 }
+      '"'"' "$env_file"; then
+        missing="$missing $name"
+      fi
+    done
+    if [ -n "$missing" ]; then
+      echo "aborting deploy: stats.enabled=true but coordinator.env is missing required non-empty var(s):$missing" >&2
+      exit 12
+    fi
+    echo "  ok: required stats DSN env vars are present in coordinator.env"
+  '
+else
+  echo "  stats.enabled is not true in $CONFIG — skipping stats env preflight"
+fi
+
 log "step 3b/9: install TCP sysctl overrides"
 if [ "${SKIP_TCP_TUNING:-0}" = "1" ]; then
   log "  SKIP_TCP_TUNING=1 set — skipping TCP sysctl overrides"
@@ -1129,26 +1172,55 @@ echo "  SPEC-023 static feeds OK"
 # just deployed; gate the smoke check on it.
 STATS_ENABLED_LOCAL="$(yaml_block_value stats enabled)"
 if [ "$STATS_ENABLED_LOCAL" = "true" ]; then
-  echo "  GET https://$STATS_DOMAIN/v1/stats/health -> expect 200"
+  STATS_SMOKE_NONCE="${BACKUP_TS:-$(date -u +%Y%m%dT%H%M%SZ)}-$$"
+  echo "  GET https://$STATS_DOMAIN/v1/stats/health?deploy_smoke=<nonce> -> expect 200"
   # R4 CODE/SEC convergent HIGH — DON'T use `STATS=$(curl ... || echo 000)`:
   # curl prints `000` to stdout AND exits non-zero on TLS/DNS failure, so
   # the `|| echo 000` appends another `000` producing `STATS=000000` and
   # silently passing the `[ "$STATS" = "000" ]` failure branch.
-  if ! STATS_STATUS=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "https://$STATS_DOMAIN/v1/stats/health" 2>/dev/null); then
+  if ! STATS_STATUS=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "https://$STATS_DOMAIN/v1/stats/health?deploy_smoke=$STATS_SMOKE_NONCE" 2>/dev/null); then
     STATS_STATUS="000"
   fi
   if [ "$STATS_STATUS" != "200" ]; then
     if [ "$STATS_STATUS" = "000" ]; then
-      echo "  WARN: $STATS_DOMAIN /v1/stats/health unreachable (TLS handshake or DNS failed)" >&2
+      echo "  ABORT: $STATS_DOMAIN /v1/stats/health unreachable (TLS handshake or DNS failed)" >&2
     else
-      echo "  WARN: $STATS_DOMAIN /v1/stats/health returned status=$STATS_STATUS (expected 200)" >&2
+      echo "  ABORT: $STATS_DOMAIN /v1/stats/health returned status=$STATS_STATUS (expected 200)" >&2
     fi
-    if [ "${STATS_REQUIRED:-0}" = "1" ]; then
-      echo "  STATS_REQUIRED=1 set — aborting." >&2
-      exit 9
-    fi
+    echo "  stats.enabled=true in $CONFIG — public stats smoke is mandatory." >&2
+    exit 9
+  fi
+  echo "  ok: $STATS_DOMAIN /v1/stats/health responded 200"
+
+  echo "  GET https://$STATS_DOMAIN/v1/stats/overview?deploy_smoke=<nonce> with Malibu Origin -> expect 200 + CORS"
+  STATS_HEADERS="$(mktemp -t macprovider-stats-headers.XXXXXX)"
+  if ! STATS_OVERVIEW_STATUS=$(curl -sS -D "$STATS_HEADERS" -o /dev/null -w '%{http_code}' --max-time 10 -H "Origin: https://www.malibu.tech" "https://$STATS_DOMAIN/v1/stats/overview?deploy_smoke=$STATS_SMOKE_NONCE" 2>/dev/null); then
+    STATS_OVERVIEW_STATUS="000"
+  fi
+  if [ "$STATS_OVERVIEW_STATUS" != "200" ]; then
+    echo "  ABORT: $STATS_DOMAIN /v1/stats/overview returned status=$STATS_OVERVIEW_STATUS (expected 200)" >&2
+    rm -f "$STATS_HEADERS"
+    exit 9
+  fi
+  if ! tr -d '\r' < "$STATS_HEADERS" | grep -Eiq '^access-control-allow-origin:[[:space:]]*(\*|https://www\.malibu\.tech)[[:space:]]*$'; then
+    echo "  ABORT: $STATS_DOMAIN /v1/stats/overview did not return a Malibu-compatible Access-Control-Allow-Origin header" >&2
+    sed 's/^/    /' "$STATS_HEADERS" >&2
+    rm -f "$STATS_HEADERS"
+    exit 9
+  fi
+  rm -f "$STATS_HEADERS"
+  echo "  ok: $STATS_DOMAIN /v1/stats/overview responded 200 with Malibu-compatible CORS"
+
+  echo "  GET https://$STATS_DOMAIN/v1/stats/leaderboard?deploy_smoke=<nonce> -> expect 200"
+  if ! STATS_LEADERBOARD_STATUS=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "https://$STATS_DOMAIN/v1/stats/leaderboard?deploy_smoke=$STATS_SMOKE_NONCE" 2>/dev/null); then
+    STATS_LEADERBOARD_STATUS="000"
+  fi
+  if [ "$STATS_LEADERBOARD_STATUS" != "200" ]; then
+    echo "  ABORT: $STATS_DOMAIN /v1/stats/leaderboard returned status=$STATS_LEADERBOARD_STATUS (expected 200)" >&2
+    echo "  stats.enabled=true in $CONFIG — Malibu stats population smoke is mandatory." >&2
+    exit 9
   else
-    echo "  ok: $STATS_DOMAIN /v1/stats/health responded 200"
+    echo "  ok: $STATS_DOMAIN /v1/stats/leaderboard responded 200"
   fi
 else
   # Stats disabled in deployed config. If STATS_REQUIRED=1, the operator

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -331,7 +331,9 @@ server {
         proxy_cache_valid 200    30s;
         proxy_cache_use_stale    error timeout updating;
         proxy_cache_bypass       $http_authorization;
+        proxy_cache_bypass       $arg_deploy_smoke;
         proxy_no_cache           $http_authorization;
+        proxy_no_cache           $arg_deploy_smoke;
     }
 
     location = /v1/stats/leaderboard {
@@ -351,7 +353,9 @@ server {
         proxy_cache_valid 200    30s;
         proxy_cache_use_stale    error timeout updating;
         proxy_cache_bypass       $http_authorization;
+        proxy_cache_bypass       $arg_deploy_smoke;
         proxy_no_cache           $http_authorization;
+        proxy_no_cache           $arg_deploy_smoke;
     }
 
     location = /v1/stats/health {
@@ -371,7 +375,9 @@ server {
         proxy_cache_valid 200    30s;
         proxy_cache_use_stale    error timeout updating;
         proxy_cache_bypass       $http_authorization;
+        proxy_cache_bypass       $arg_deploy_smoke;
         proxy_no_cache           $http_authorization;
+        proxy_no_cache           $arg_deploy_smoke;
     }
 
     # ---------------------------------------------------------------------

--- a/phase4-coordinator/dist/nginx-stats.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-stats.streamvc.live.conf
@@ -130,7 +130,9 @@ server {
         # present; the second SUPPRESSES cache writes for the same
         # responses. proxy_cache_bypass alone would still WRITE.
         proxy_cache_bypass       $http_authorization;
+        proxy_cache_bypass       $arg_deploy_smoke;
         proxy_no_cache           $http_authorization;
+        proxy_no_cache           $arg_deploy_smoke;
     }
 
     # ---------------------------------------------------------------------
@@ -154,7 +156,9 @@ server {
         proxy_cache_valid 200    30s;
         proxy_cache_use_stale    error timeout updating;
         proxy_cache_bypass       $http_authorization;
+        proxy_cache_bypass       $arg_deploy_smoke;
         proxy_no_cache           $http_authorization;
+        proxy_no_cache           $arg_deploy_smoke;
     }
 
     # ---------------------------------------------------------------------
@@ -177,7 +181,9 @@ server {
         proxy_cache_valid 200    30s;
         proxy_cache_use_stale    error timeout updating;
         proxy_cache_bypass       $http_authorization;
+        proxy_cache_bypass       $arg_deploy_smoke;
         proxy_no_cache           $http_authorization;
+        proxy_no_cache           $arg_deploy_smoke;
     }
 
     # Anything else under /v1/stats/* → 404 from nginx so the

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -94,8 +94,10 @@ type OnboardingConfig struct {
 type StatsConfig struct {
 	Enabled bool `yaml:"enabled"`
 
-	// DSNs per active runtime role. When Enabled = true, the
-	// three always-required DSNs MUST be non-empty.
+	// DSNs per active daemon role. When Enabled = true, the
+	// reader and rollup DSNs MUST be non-empty. ProviderPortalDSN
+	// is retained for portal/operator tooling compatibility but
+	// is not opened by the public stats daemon.
 	ReaderDSN         string `yaml:"reader_dsn"`
 	RollupDSN         string `yaml:"rollup_dsn"`
 	ProviderPortalDSN string `yaml:"provider_portal_dsn"`
@@ -1393,8 +1395,8 @@ func (c Config) validateExplorer() error {
 // below; an operator that has not flipped the gate cannot brick
 // startup by leaving Stats fields empty.
 //
-// When Stats.Enabled=true the three required runtime DSNs MUST
-// be set (fail-closed per BUILD §C.3). PartnerKeys.WriterDSN is
+// When Stats.Enabled=true the required daemon DSNs MUST be set
+// (fail-closed per BUILD §C.3). PartnerKeys.WriterDSN is
 // only required when last_used_at_updates_enabled=true. The CLI
 // admin DSN is OPTIONAL even when stats is enabled (BUILD §B.2).
 //
@@ -1430,9 +1432,6 @@ func (c Config) validateStats() error {
 	}
 	if strings.TrimSpace(s.RollupDSN) == "" {
 		return fmt.Errorf("stats.rollup_dsn must be set when stats.enabled is true")
-	}
-	if strings.TrimSpace(s.ProviderPortalDSN) == "" {
-		return fmt.Errorf("stats.provider_portal_dsn must be set when stats.enabled is true")
 	}
 	if s.PartnerKeys.LastUsedAtUpdatesEnabled && strings.TrimSpace(s.PartnerKeys.WriterDSN) == "" {
 		return fmt.Errorf("stats.partner_keys.writer_dsn must be set when stats.partner_keys.last_used_at_updates_enabled is true")

--- a/phase4-coordinator/internal/config/config_env_test.go
+++ b/phase4-coordinator/internal/config/config_env_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -57,6 +58,96 @@ auth:
 	}
 	if cfg.Auth.GatewayServiceToken != "gateway-secret" {
 		t.Fatalf("GatewayServiceToken=%q", cfg.Auth.GatewayServiceToken)
+	}
+}
+
+// TestLoadResolvesEnvStatsDSNs locks the SPEC-017 deployment path:
+// stats runtime DSNs may be env-indirected and resolve before
+// stats.enabled validation runs.
+func TestLoadResolvesEnvStatsDSNs(t *testing.T) {
+	t.Setenv("M3_2_TEST_OPERATOR_KEY", "operator-secret")
+	t.Setenv("TEST_STATS_READER_DSN", "postgres://reader@localhost/macprovider")
+	t.Setenv("TEST_STATS_ROLLUP_DSN", "postgres://rollup@localhost/macprovider")
+
+	cfg := writeMinimalConfig(t, `
+listen:
+  bind_address: "127.0.0.1"
+auth:
+  operator_key: env:M3_2_TEST_OPERATOR_KEY
+stats:
+  enabled: true
+  reader_dsn: env:TEST_STATS_READER_DSN
+  rollup_dsn: env:TEST_STATS_ROLLUP_DSN
+  rollup:
+    backfill_mode: "full"
+`)
+	if cfg.Stats.ReaderDSN != "postgres://reader@localhost/macprovider" {
+		t.Fatalf("Stats.ReaderDSN=%q", cfg.Stats.ReaderDSN)
+	}
+	if cfg.Stats.RollupDSN != "postgres://rollup@localhost/macprovider" {
+		t.Fatalf("Stats.RollupDSN=%q", cfg.Stats.RollupDSN)
+	}
+}
+
+// TestLoadFailsClosedOnMissingStatsEnvDSN ensures stats cutovers fail
+// before boot when a required env-indirected DSN is absent.
+func TestLoadFailsClosedOnMissingStatsEnvDSN(t *testing.T) {
+	t.Setenv("M3_2_TEST_OPERATOR_KEY", "operator-secret")
+	os.Unsetenv("TEST_STATS_MISSING_READER_DSN")
+
+	_, err := loadConfigFromYAML(t, `
+listen:
+  bind_address: "127.0.0.1"
+auth:
+  operator_key: env:M3_2_TEST_OPERATOR_KEY
+stats:
+  enabled: true
+  reader_dsn: env:TEST_STATS_MISSING_READER_DSN
+  rollup_dsn: postgres://rollup@localhost/macprovider
+`)
+	if err == nil {
+		t.Fatal("expected missing stats env DSN error")
+	}
+	if !strings.Contains(err.Error(), "stats.reader_dsn") || !strings.Contains(err.Error(), "TEST_STATS_MISSING_READER_DSN") {
+		t.Fatalf("error should name stats.reader_dsn and env var, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "unset or empty") {
+		t.Fatalf("error should mention unset/empty, got %v", err)
+	}
+}
+
+// TestDeployCoordinatorYAMLLoadsWithStatsEnv is the production-config
+// regression for the Malibu stats rollout. It proves dist/coordinator.yaml
+// can pass config load with stats enabled when Pearl's env file provides
+// the required values, and that Malibu's browser origin is allowlisted.
+func TestDeployCoordinatorYAMLLoadsWithStatsEnv(t *testing.T) {
+	t.Setenv("OPERATOR_KEY", "operator-secret")
+	t.Setenv("GATEWAY_SERVICE_TOKEN", "gateway-secret")
+	t.Setenv("OPERATOR_AUTH_POLICY_A", "operator-a")
+	t.Setenv("OPERATOR_AUTH_POLICY_B", "operator-b")
+	t.Setenv("STATS_READER_DSN", "postgres://reader@localhost/macprovider")
+	t.Setenv("STATS_ROLLUP_DSN", "postgres://rollup@localhost/macprovider")
+	t.Setenv("ONBOARDING_POSTGRES_DSN", "postgres://onboarding@localhost/macprovider")
+	t.Setenv("APPLE_TEAM_ID", "TEAMID1234")
+
+	cfg, err := Load(filepath.Join("..", "..", "dist", "coordinator.yaml"))
+	if err != nil {
+		t.Fatalf("Load dist/coordinator.yaml: %v", err)
+	}
+	if !cfg.Stats.Enabled {
+		t.Fatal("Stats.Enabled=false, want true")
+	}
+	if cfg.Stats.ReaderDSN != "postgres://reader@localhost/macprovider" {
+		t.Fatalf("Stats.ReaderDSN=%q", cfg.Stats.ReaderDSN)
+	}
+	if cfg.Stats.RollupDSN != "postgres://rollup@localhost/macprovider" {
+		t.Fatalf("Stats.RollupDSN=%q", cfg.Stats.RollupDSN)
+	}
+	if !slices.Contains(cfg.Stats.CORS.PartnerOriginAllowlist, "https://www.malibu.tech") {
+		t.Fatalf("Malibu origin missing from stats CORS allowlist: %#v", cfg.Stats.CORS.PartnerOriginAllowlist)
+	}
+	if got, want := cfg.Stats.PartnerKeys.ProductionSignoffPath, "/opt/macprovider/spec017-signoff.txt"; got != want {
+		t.Fatalf("ProductionSignoffPath=%q want %q", got, want)
 	}
 }
 

--- a/phase4-coordinator/internal/config/config_stats_bind_test.go
+++ b/phase4-coordinator/internal/config/config_stats_bind_test.go
@@ -24,7 +24,6 @@ func TestStatsRequiresLoopbackBind(t *testing.T) {
 		c.Stats.Enabled = true
 		c.Stats.ReaderDSN = "postgres://r@/x"
 		c.Stats.RollupDSN = "postgres://w@/x"
-		c.Stats.ProviderPortalDSN = "postgres://p@/x"
 		return c
 	}
 

--- a/phase4-coordinator/internal/stats/handlers_integration_test.go
+++ b/phase4-coordinator/internal/stats/handlers_integration_test.go
@@ -492,6 +492,8 @@ var _ = strings.HasPrefix
 // bucket.
 // ===========================================================================
 func TestAC22_AuthFailureLimiter(t *testing.T) {
+	waitForRateLimitWindowHeadroom(t, 10*time.Second)
+
 	// Round-7 CODE M closure: build the mux against a store
 	// we hold a reference to so we can query
 	// LookupHashCountForTest after the flood to prove the
@@ -533,6 +535,22 @@ func TestAC22_AuthFailureLimiter(t *testing.T) {
 	// (the 50 429s short-circuited BEFORE the auth dispatcher).
 	if got := st.LookupHashCountForTest(); got > 300 {
 		t.Errorf("partner_keys SELECT count = %d, want ≤300 (auth-failure limiter must cap pre-SELECT DB load)", got)
+	}
+}
+
+func waitForRateLimitWindowHeadroom(t *testing.T, minRemaining time.Duration) {
+	t.Helper()
+	if minRemaining <= 0 || minRemaining >= time.Minute {
+		t.Fatalf("invalid rate-limit window headroom %s", minRemaining)
+	}
+	for {
+		now := time.Now()
+		elapsed := time.Duration(now.Second())*time.Second + time.Duration(now.Nanosecond())
+		remaining := time.Minute - elapsed
+		if remaining >= minRemaining {
+			return
+		}
+		time.Sleep(remaining + 20*time.Millisecond)
 	}
 }
 

--- a/phase4-coordinator/internal/stats/stats.go
+++ b/phase4-coordinator/internal/stats/stats.go
@@ -33,11 +33,12 @@ import (
 type Config struct {
 	Enabled bool
 
-	// DSN per active runtime role. When Enabled = true, the three
-	// always-required DSNs MUST be non-empty.
-	ReaderDSN         string
-	RollupDSN         string
-	ProviderPortalDSN string
+	// DSN per active daemon role. When Enabled = true, reader and
+	// rollup DSNs MUST be non-empty. The provider_portal role is
+	// intentionally not opened by the public stats daemon; it belongs
+	// to provider-authenticated portal/operator flows.
+	ReaderDSN string
+	RollupDSN string
 
 	// PartnerKeys gates the optional `partner_keys_writer` pool.
 	// v0.1 default is LastUsedAtUpdatesEnabled = false; the
@@ -113,17 +114,15 @@ type CORSConfig struct {
 	PartnerOriginAllowlist []string
 }
 
-// Pools holds one *sql.DB per active runtime role. Per SPEC §7.2.5,
+// Pools holds one *sql.DB per active daemon role. Per SPEC §7.2.5,
 // no two roles MAY share a pool.
 //
-// Reader, Rollup, ProviderPortal are non-nil whenever Open returns
-// nil. PartnerKeysWriter is nil unless
-// Config.PartnerKeys.LastUsedAtUpdatesEnabled was true at Open
-// time (BUILD §C.2 + §D.5).
+// Reader and Rollup are non-nil whenever Open returns nil.
+// PartnerKeysWriter is nil unless Config.PartnerKeys.LastUsedAtUpdatesEnabled
+// was true at Open time (BUILD §C.2 + §D.5).
 type Pools struct {
 	Reader            *sql.DB
 	Rollup            *sql.DB
-	ProviderPortal    *sql.DB
 	PartnerKeysWriter *sql.DB
 }
 
@@ -138,7 +137,7 @@ func (p *Pools) Close() error {
 		return nil
 	}
 	var firstErr error
-	for _, db := range []*sql.DB{p.Reader, p.Rollup, p.ProviderPortal, p.PartnerKeysWriter} {
+	for _, db := range []*sql.DB{p.Reader, p.Rollup, p.PartnerKeysWriter} {
 		if db == nil {
 			continue
 		}
@@ -203,13 +202,6 @@ func Open(ctx context.Context, cfg Config) (*Pools, error) {
 	}
 	pools.Rollup = rollup
 
-	portal, err := openPool(cfg.ProviderPortalDSN, poolTuneWrite())
-	if err != nil {
-		_ = pools.Close()
-		return nil, fmt.Errorf("provider_portal: %w", err)
-	}
-	pools.ProviderPortal = portal
-
 	if cfg.PartnerKeys.LastUsedAtUpdatesEnabled {
 		writer, err := openPool(cfg.PartnerKeys.WriterDSN, poolTuneWrite())
 		if err != nil {
@@ -233,9 +225,6 @@ func validateRequiredDSNs(cfg Config) error {
 	}
 	if strTrim(cfg.RollupDSN) == "" {
 		return errors.New("stats_rollup_dsn is required when stats.enabled = true")
-	}
-	if strTrim(cfg.ProviderPortalDSN) == "" {
-		return errors.New("provider_portal_dsn is required when stats.enabled = true")
 	}
 	if cfg.PartnerKeys.LastUsedAtUpdatesEnabled && strTrim(cfg.PartnerKeys.WriterDSN) == "" {
 		return errors.New(
@@ -296,7 +285,7 @@ func openPool(dsn string, tune poolTune) (*sql.DB, error) {
 //
 //  1. SELECT current_user equals the expected role for each
 //     pool (catches miswired DSN).
-//  2. The three required roles are distinct (catches all
+//  2. The required roles are distinct (catches all
 //     pools sharing one role).
 //  3. A positive probe — each role can read a table the
 //     locked SPEC §7.2 says it should be able to read.
@@ -332,13 +321,6 @@ func smoke(ctx context.Context, p *Pools) error {
 			positiveSQL: `SELECT 1 FROM stats_components_health LIMIT 1`,
 			// partner_keys is on the §7.2.2 deny list.
 			denySQL: `SELECT 1 FROM partner_keys LIMIT 1`,
-		},
-		{
-			role:        "provider_portal",
-			db:          p.ProviderPortal,
-			positiveSQL: `SELECT 1`, // no SELECT grants on any SPEC-017 table; trivial probe.
-			// stats_overview_current is on the §7.2.3 deny list.
-			denySQL: `SELECT 1 FROM stats_overview_current LIMIT 1`,
 		},
 	}
 	if p.PartnerKeysWriter != nil {

--- a/phase4-coordinator/internal/stats/stats_test.go
+++ b/phase4-coordinator/internal/stats/stats_test.go
@@ -28,40 +28,27 @@ func TestOpenMissingDSNFailClosed(t *testing.T) {
 		{
 			name: "missing reader",
 			cfg: Config{
-				Enabled:           true,
-				ReaderDSN:         "",
-				RollupDSN:         "x",
-				ProviderPortalDSN: "x",
+				Enabled:   true,
+				ReaderDSN: "",
+				RollupDSN: "x",
 			},
 			wantField: "stats_reader",
 		},
 		{
 			name: "missing rollup",
 			cfg: Config{
-				Enabled:           true,
-				ReaderDSN:         "x",
-				RollupDSN:         "",
-				ProviderPortalDSN: "x",
+				Enabled:   true,
+				ReaderDSN: "x",
+				RollupDSN: "",
 			},
 			wantField: "stats_rollup",
 		},
 		{
-			name: "missing portal",
-			cfg: Config{
-				Enabled:           true,
-				ReaderDSN:         "x",
-				RollupDSN:         "x",
-				ProviderPortalDSN: "",
-			},
-			wantField: "provider_portal",
-		},
-		{
 			name: "writer enabled but DSN missing",
 			cfg: Config{
-				Enabled:           true,
-				ReaderDSN:         "x",
-				RollupDSN:         "x",
-				ProviderPortalDSN: "x",
+				Enabled:   true,
+				ReaderDSN: "x",
+				RollupDSN: "x",
 				PartnerKeys: PartnerKeysConfig{
 					LastUsedAtUpdatesEnabled: true,
 					WriterDSN:                "",


### PR DESCRIPTION
## Summary

Enables SPEC-017 Network Stats for the Malibu network page while keeping the production rollout fail-closed.

## What changed

- Enables `stats:` in the Pearl coordinator config with env-backed reader/rollup DSNs, Malibu CORS origins, full rollup, and production signoff path.
- Adds a deploy preflight that aborts before artifact install/restart if required stats DSNs are missing from `/etc/macprovider/coordinator.env`.
- Makes public stats smoke mandatory when `stats.enabled=true`, including health, overview with Malibu CORS, and leaderboard.
- Adds cache-bypassed deploy smoke via `deploy_smoke` and nginx `proxy_cache_bypass` / `proxy_no_cache` handling on both stats vhosts.
- Removes the unused public `provider_portal` stats pool from coordinator runtime wiring.
- Adds config regression tests for stats env resolution and production dist config loading.

## Root cause

`malibu.tech/network` was rendering the offline banner because the backend SPEC-017 stats surface was not enabled/routed in production. The frontend was already correctly polling the configured stats URL and handling the unavailable state.

## Validation

- `bash -n phase4-coordinator/dist/deploy-pearl-vps.sh`
- `bash phase4-coordinator/dist/check-deploy-config.sh phase4-coordinator/dist/coordinator.yaml phase5-gateway/dist/gateway.yaml`
- `cd phase4-coordinator && go test ./internal/config ./internal/stats ./cmd/coordinator`
- `git diff --check --cached`
- Three audit lanes returned `0 C/H/M findings` after the final cache-bypass patch.

## Not tested

- Live Pearl deploy
- Live `malibu.tech/network` rendering after deployment
