### PR TITLE
Keep stats billing rows mirrored out of band

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ default.profraw
 phase4-coordinator/dist/coordinator-linux-amd64
 phase4-coordinator/dist/coordinator-cli-linux-amd64
 phase4-coordinator/dist/stats-inventory-sync-linux-amd64
+phase4-coordinator/dist/stats-billing-mirror-linux-amd64
 phase4-coordinator/dist/*.bak
 
 # Phase 5 gateway build artifacts

--- a/phase4-coordinator/cmd/stats-billing-mirror/main.go
+++ b/phase4-coordinator/cmd/stats-billing-mirror/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/augstar/macprovider-coordinator/internal/stats/billingmirror"
+)
+
+func main() {
+	var opts billingmirror.Options
+	flag.StringVar(&opts.SQLitePath, "sqlite", "", "SQLite coordinator DB path; defaults to STATS_BILLING_MIRROR_SQLITE or /var/lib/macprovider/request-log.sqlite")
+	flag.StringVar(&opts.PostgresDSN, "dsn", "", "Postgres DSN; defaults to STATS_BILLING_MIRROR_DSN")
+	flag.IntVar(&opts.BatchSize, "batch-size", billingmirror.DefaultBatchSize, "maximum request-credit rows to fetch per batch")
+	flag.Int64Var(&opts.OverlapRows, "overlap-rows", billingmirror.DefaultOverlapRows, "number of recent SQLite row IDs to re-read every run")
+	flag.IntVar(&opts.SweepRows, "sweep-rows", 0, "historical primary-key sweep rows to refresh per run; defaults to batch-size")
+	flag.IntVar(&opts.MaxBatches, "max-batches", 5, "maximum new-row batches to process per run")
+	flag.BoolVar(&opts.EnsureSchema, "ensure-schema", true, "create/upgrade the narrow Postgres mirror schema before syncing")
+	flag.BoolVar(&opts.DryRun, "dry-run", false, "read SQLite and print counts without writing Postgres")
+	flag.Parse()
+	opts.Stdout = os.Stdout
+
+	if _, err := billingmirror.Run(context.Background(), opts); err != nil {
+		fmt.Fprintf(os.Stderr, "stats-billing-mirror: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -124,10 +124,13 @@ DIST_DIR="$_PEARL_TLS_SCRIPT_DIR"
 BINARY="$DIST_DIR/coordinator-linux-amd64"
 CLI_BINARY="$DIST_DIR/coordinator-cli-linux-amd64"
 STATS_INVENTORY_BINARY="$DIST_DIR/stats-inventory-sync-linux-amd64"
+STATS_BILLING_MIRROR_BINARY="$DIST_DIR/stats-billing-mirror-linux-amd64"
 CONFIG="$DIST_DIR/coordinator.yaml"
 SERVICE="$DIST_DIR/macprovider-coordinator.service"
 STATS_INVENTORY_SERVICE="$DIST_DIR/stats-inventory-sync.service"
 STATS_INVENTORY_TIMER="$DIST_DIR/stats-inventory-sync.timer"
+STATS_BILLING_MIRROR_SERVICE="$DIST_DIR/stats-billing-mirror.service"
+STATS_BILLING_MIRROR_TIMER="$DIST_DIR/stats-billing-mirror.timer"
 NGINX_SITE="$DIST_DIR/nginx-coordinator.streamvc.live.conf"
 TCP_SYSCTL="$DIST_DIR/sysctl.d/99-macprovider-tcp.conf"
 TCP_BBR_MODULES_LOAD="$DIST_DIR/modules-load.d/tcp_bbr.conf"
@@ -164,8 +167,9 @@ STATIC_AUTOTUNE_SIG="$STATIC_FEEDS_DIR/autotune-candidates.json.sig"
 # prune-tokens / list-tokens also belong on Pearl). If absent, the
 # operator forgot to run build-linux.sh after the M2 update that
 # extended it. Fail closed — do NOT silently deploy with a stale CLI.
-for f in "$BINARY" "$CLI_BINARY" "$STATS_INVENTORY_BINARY" \
-         "$CONFIG" "$SERVICE" "$STATS_INVENTORY_SERVICE" "$STATS_INVENTORY_TIMER" "$NGINX_SITE" \
+for f in "$BINARY" "$CLI_BINARY" "$STATS_INVENTORY_BINARY" "$STATS_BILLING_MIRROR_BINARY" \
+         "$CONFIG" "$SERVICE" "$STATS_INVENTORY_SERVICE" "$STATS_INVENTORY_TIMER" \
+         "$STATS_BILLING_MIRROR_SERVICE" "$STATS_BILLING_MIRROR_TIMER" "$NGINX_SITE" \
          "$NGINX_STATS_SHARED" "$NGINX_STATS_SECHEADERS" "$NGINX_STATS_SITE" \
          "$STATIC_DEMAND_JSON" "$STATIC_DEMAND_SIG" \
          "$STATIC_AUTOTUNE_JSON" "$STATIC_AUTOTUNE_SIG"; do
@@ -516,6 +520,13 @@ $SSH 'set -e
   else
     echo "  /etc/macprovider-stats/stats-inventory-sync.env not yet present; stats inventory timer remains opt-in"
   fi
+  if [ -f /etc/macprovider-stats/stats-billing-mirror.env ]; then
+    chown root:root /etc/macprovider-stats/stats-billing-mirror.env
+    chmod 0600 /etc/macprovider-stats/stats-billing-mirror.env
+    echo "  enforced stats billing mirror env perms: root:root 0600"
+  else
+    echo "  /etc/macprovider-stats/stats-billing-mirror.env not yet present; stats billing mirror timer remains opt-in"
+  fi
 '
 
 log "step 3a/9: stats env preflight"
@@ -728,10 +739,13 @@ log "  staging dir: $DEPLOY_TMP (root:root 0700)"
 $SCP "$BINARY"      "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator-linux-amd64"
 $SCP "$CLI_BINARY"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator-cli-linux-amd64"
 $SCP "$STATS_INVENTORY_BINARY"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-inventory-sync-linux-amd64"
+$SCP "$STATS_BILLING_MIRROR_BINARY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror-linux-amd64"
 $SCP "$CONFIG"      "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator.yaml"
 $SCP "$SERVICE"     "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/macprovider-coordinator.service"
 $SCP "$STATS_INVENTORY_SERVICE" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-inventory-sync.service"
 $SCP "$STATS_INVENTORY_TIMER"   "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-inventory-sync.timer"
+$SCP "$STATS_BILLING_MIRROR_SERVICE" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror.service"
+$SCP "$STATS_BILLING_MIRROR_TIMER"   "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror.timer"
 $SCP "$NGINX_SITE"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-coordinator-full.conf"
 # SPEC-017 v0.1.8 Step 4.B artifacts (snippet must land at
 # /etc/nginx/conf.d/ so the http-context declarations are visible
@@ -781,10 +795,24 @@ $SSH "set -e
   # It runs under its own Unix identity and only receives execute access
   # to this binary; its Postgres writer DSN lives under /etc/macprovider-stats.
   install -o root -g macprovider-stats -m 0750 $DEPLOY_TMP/stats-inventory-sync-linux-amd64 /opt/macprovider-stats/stats-inventory-sync
+  # stats-billing-mirror is an out-of-band stats sidecar. It runs as the
+  # dedicated macprovider-stats identity and gets read access only to the
+  # SQLite ledger files via file ACLs below.
+  install -o root -g macprovider-stats -m 0750 $DEPLOY_TMP/stats-billing-mirror-linux-amd64 /opt/macprovider-stats/stats-billing-mirror
   install -o root -g macprovider -m 0640 $DEPLOY_TMP/coordinator.yaml /opt/macprovider/coordinator.yaml
   install -o root -g root       -m 0644 $DEPLOY_TMP/macprovider-coordinator.service /etc/systemd/system/macprovider-coordinator.service
   install -o root -g root       -m 0644 $DEPLOY_TMP/stats-inventory-sync.service /etc/systemd/system/stats-inventory-sync.service
   install -o root -g root       -m 0644 $DEPLOY_TMP/stats-inventory-sync.timer /etc/systemd/system/stats-inventory-sync.timer
+  install -o root -g root       -m 0644 $DEPLOY_TMP/stats-billing-mirror.service /etc/systemd/system/stats-billing-mirror.service
+  install -o root -g root       -m 0644 $DEPLOY_TMP/stats-billing-mirror.timer /etc/systemd/system/stats-billing-mirror.timer
+  if command -v setfacl >/dev/null 2>&1 && [ -f /var/lib/macprovider/request-log.sqlite ]; then
+    setfacl -m u:macprovider-stats:--x /var/lib/macprovider
+    setfacl -m u:macprovider-stats:r-- /var/lib/macprovider/request-log.sqlite
+    [ -f /var/lib/macprovider/request-log.sqlite-wal ] && setfacl -m u:macprovider-stats:r-- /var/lib/macprovider/request-log.sqlite-wal
+    [ -f /var/lib/macprovider/request-log.sqlite-shm ] && setfacl -m u:macprovider-stats:r-- /var/lib/macprovider/request-log.sqlite-shm
+  elif [ -f /var/lib/macprovider/request-log.sqlite ]; then
+    echo "  warning: setfacl not available; stats billing mirror will remain disabled until macprovider-stats can read request-log.sqlite"
+  fi
   # SPEC-023 v1.7.3 signed static feeds — served by nginx as
   # coordinator.streamvc.live/static/*. Files are world-readable
   # (mode 0644) because they are public signed content; nginx runs as
@@ -1105,6 +1133,16 @@ $SSH 'set -e
     systemctl is-active stats-inventory-sync.timer
   else
     echo "stats inventory timer not enabled: missing /etc/macprovider-stats/stats-hardware-inventory.yaml or stats-inventory-sync.env"
+  fi
+  if [ -f /etc/macprovider-stats/stats-billing-mirror.env ] && [ -f /var/lib/macprovider/request-log.sqlite ] && su -s /bin/sh -c "test -r /var/lib/macprovider/request-log.sqlite" macprovider-stats; then
+    systemctl enable --now stats-billing-mirror.timer
+    if ! systemctl start stats-billing-mirror.service; then
+      echo "warning: stats-billing-mirror.service failed; leaving coordinator deploy running"
+      journalctl -u stats-billing-mirror.service -n 30 --no-pager || true
+    fi
+    systemctl is-active stats-billing-mirror.timer
+  else
+    echo "stats billing mirror timer not enabled: missing env/sqlite source or macprovider-stats read ACL"
   fi
   sleep 3
   systemctl is-active macprovider-coordinator

--- a/phase4-coordinator/dist/stats-billing-mirror-bootstrap.sql
+++ b/phase4-coordinator/dist/stats-billing-mirror-bootstrap.sql
@@ -1,0 +1,217 @@
+-- Bootstrap for the stats billing mirror sidecar.
+--
+-- Apply as the database owner/admin, then place a DSN for
+-- stats_billing_mirror_writer in:
+--   /etc/macprovider-stats/stats-billing-mirror.env
+--
+-- Create the login role with an operator-generated password before applying:
+--   CREATE ROLE stats_billing_mirror_writer LOGIN PASSWORD '<generated-password>';
+
+CREATE TABLE IF NOT EXISTS ledger_request_credits (
+    id BIGSERIAL PRIMARY KEY,
+    sqlite_lrc_id BIGINT,
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL CHECK (attempt_n >= 0),
+    provider_id TEXT NOT NULL,
+    ts_utc TIMESTAMPTZ NOT NULL,
+    created_at_utc TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at_utc TIMESTAMPTZ,
+    prompt_tokens BIGINT CHECK (prompt_tokens IS NULL OR prompt_tokens >= 0),
+    completion_tokens BIGINT CHECK (completion_tokens IS NULL OR completion_tokens >= 0),
+    estimated_completion_tokens BIGINT CHECK (estimated_completion_tokens IS NULL OR estimated_completion_tokens >= 0),
+    usage_source TEXT NOT NULL DEFAULT 'provider_reported' CHECK (usage_source IN ('provider_reported','byte_estimated','null_error')),
+    provider_credits BIGINT NOT NULL DEFAULT 0 CHECK (provider_credits >= 0),
+    fault_flag TEXT NOT NULL DEFAULT 'none' CHECK (fault_flag IN ('none','breaker_qualifying','null_usage_error')),
+    quarantined BOOLEAN NOT NULL DEFAULT FALSE
+);
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS sqlite_lrc_id BIGINT;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS request_id TEXT;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS attempt_n INTEGER;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS provider_id TEXT;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS ts_utc TIMESTAMPTZ;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ DEFAULT now();
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS prompt_tokens BIGINT;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS completion_tokens BIGINT;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS estimated_completion_tokens BIGINT;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS usage_source TEXT DEFAULT 'provider_reported';
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS provider_credits BIGINT DEFAULT 0;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS fault_flag TEXT DEFAULT 'none';
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS quarantined BOOLEAN DEFAULT FALSE;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_attempt_nonnegative') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_attempt_nonnegative CHECK (attempt_n >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_prompt_tokens_nonnegative') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_prompt_tokens_nonnegative CHECK (prompt_tokens IS NULL OR prompt_tokens >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_completion_tokens_nonnegative') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_completion_tokens_nonnegative CHECK (completion_tokens IS NULL OR completion_tokens >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_estimated_completion_tokens_nonnegative') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_estimated_completion_tokens_nonnegative CHECK (estimated_completion_tokens IS NULL OR estimated_completion_tokens >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_usage_source_enum') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_usage_source_enum CHECK (usage_source IN ('provider_reported','byte_estimated','null_error'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_provider_credits_nonnegative') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_provider_credits_nonnegative CHECK (provider_credits >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_fault_flag_enum') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_fault_flag_enum CHECK (fault_flag IN ('none','breaker_qualifying','null_usage_error'));
+    END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_lrc_mirror_unique_attempt ON ledger_request_credits(request_id, attempt_n, provider_id);
+CREATE INDEX IF NOT EXISTS idx_lrc_mirror_provider_ts ON ledger_request_credits(provider_id, ts_utc);
+
+CREATE TABLE IF NOT EXISTS provider_tokens (
+    id BIGSERIAL PRIMARY KEY,
+    token_hash TEXT NOT NULL UNIQUE,
+    token_prefix TEXT NOT NULL DEFAULT '',
+    provider_id TEXT NOT NULL DEFAULT '',
+    provider_name TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    revoked_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ
+);
+ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS token_prefix TEXT DEFAULT '';
+ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS provider_id TEXT DEFAULT '';
+ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS provider_name TEXT DEFAULT '';
+ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT now();
+ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMPTZ;
+ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMPTZ;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_provider_tokens_one_active_per_provider
+    ON provider_tokens(provider_id)
+    WHERE revoked_at IS NULL AND provider_id <> '';
+
+CREATE TABLE IF NOT EXISTS stats_billing_mirror_state (
+    source TEXT PRIMARY KEY,
+    last_request_credit_id BIGINT NOT NULL DEFAULT 0,
+    sweep_after_request_credit_id BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE stats_billing_mirror_state ADD COLUMN IF NOT EXISTS sweep_after_request_credit_id BIGINT NOT NULL DEFAULT 0;
+
+CREATE OR REPLACE FUNCTION stats_billing_mirror_load_state(p_source TEXT)
+RETURNS TABLE(last_request_credit_id BIGINT, sweep_after_request_credit_id BIGINT)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    INSERT INTO stats_billing_mirror_state (source, last_request_credit_id, sweep_after_request_credit_id)
+    VALUES (p_source, 0, 0)
+    ON CONFLICT (source) DO NOTHING;
+
+    SELECT s.last_request_credit_id, s.sweep_after_request_credit_id
+      FROM stats_billing_mirror_state s
+     WHERE s.source = p_source;
+$$;
+
+CREATE OR REPLACE FUNCTION stats_billing_mirror_save_state(p_source TEXT, p_last_request_credit_id BIGINT, p_sweep_after_request_credit_id BIGINT)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    INSERT INTO stats_billing_mirror_state (source, last_request_credit_id, sweep_after_request_credit_id, updated_at)
+    VALUES (p_source, p_last_request_credit_id, p_sweep_after_request_credit_id, now())
+    ON CONFLICT (source) DO UPDATE SET
+        last_request_credit_id = GREATEST(stats_billing_mirror_state.last_request_credit_id, EXCLUDED.last_request_credit_id),
+        sweep_after_request_credit_id = EXCLUDED.sweep_after_request_credit_id,
+        updated_at = EXCLUDED.updated_at;
+$$;
+
+CREATE OR REPLACE FUNCTION stats_billing_mirror_ensure_provider(
+    p_token_hash TEXT,
+    p_provider_id TEXT,
+    p_provider_name TEXT,
+    p_created_at TIMESTAMPTZ,
+    p_last_used_at TIMESTAMPTZ
+)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at, last_used_at)
+    SELECT p_token_hash, 'stats-mirror', p_provider_id, p_provider_name, p_created_at, p_last_used_at
+    WHERE NOT EXISTS (
+        SELECT 1 FROM provider_tokens WHERE provider_id = p_provider_id AND provider_id <> ''
+    )
+    ON CONFLICT (token_hash) DO UPDATE SET
+        provider_id = EXCLUDED.provider_id,
+        provider_name = EXCLUDED.provider_name,
+        last_used_at = EXCLUDED.last_used_at;
+$$;
+
+CREATE OR REPLACE FUNCTION stats_billing_mirror_upsert_request_credit(
+    p_sqlite_lrc_id BIGINT,
+    p_request_id TEXT,
+    p_attempt_n INTEGER,
+    p_provider_id TEXT,
+    p_ts_utc TIMESTAMPTZ,
+    p_created_at_utc TIMESTAMPTZ,
+    p_updated_at_utc TIMESTAMPTZ,
+    p_prompt_tokens BIGINT,
+    p_completion_tokens BIGINT,
+    p_estimated_completion_tokens BIGINT,
+    p_usage_source TEXT,
+    p_provider_credits BIGINT,
+    p_fault_flag TEXT,
+    p_quarantined BOOLEAN
+)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    INSERT INTO ledger_request_credits (
+        sqlite_lrc_id, request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
+        prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
+        provider_credits, fault_flag, quarantined
+    ) VALUES (
+        p_sqlite_lrc_id, p_request_id, p_attempt_n, p_provider_id, p_ts_utc, p_created_at_utc, p_updated_at_utc,
+        p_prompt_tokens, p_completion_tokens, p_estimated_completion_tokens, p_usage_source,
+        p_provider_credits, p_fault_flag, p_quarantined
+    )
+    ON CONFLICT (request_id, attempt_n, provider_id) DO UPDATE SET
+        sqlite_lrc_id = EXCLUDED.sqlite_lrc_id,
+        ts_utc = EXCLUDED.ts_utc,
+        created_at_utc = EXCLUDED.created_at_utc,
+        updated_at_utc = EXCLUDED.updated_at_utc,
+        prompt_tokens = EXCLUDED.prompt_tokens,
+        completion_tokens = EXCLUDED.completion_tokens,
+        estimated_completion_tokens = EXCLUDED.estimated_completion_tokens,
+        usage_source = EXCLUDED.usage_source,
+        provider_credits = EXCLUDED.provider_credits,
+        fault_flag = EXCLUDED.fault_flag,
+        quarantined = EXCLUDED.quarantined;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'stats_billing_mirror_writer') THEN
+        RAISE EXCEPTION 'create role stats_billing_mirror_writer with an operator-generated password before applying this bootstrap';
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'stats_rollup') THEN
+        GRANT SELECT ON ledger_request_credits TO stats_rollup;
+        GRANT SELECT ON provider_tokens TO stats_rollup;
+    END IF;
+END $$;
+
+GRANT USAGE ON SCHEMA public TO stats_billing_mirror_writer;
+REVOKE ALL ON ledger_request_credits FROM stats_billing_mirror_writer;
+REVOKE ALL ON provider_tokens FROM stats_billing_mirror_writer;
+REVOKE ALL ON stats_billing_mirror_state FROM stats_billing_mirror_writer;
+REVOKE ALL ON FUNCTION stats_billing_mirror_load_state(TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION stats_billing_mirror_save_state(TEXT, BIGINT, BIGINT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION stats_billing_mirror_ensure_provider(TEXT, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC;
+REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION stats_billing_mirror_load_state(TEXT) TO stats_billing_mirror_writer;
+GRANT EXECUTE ON FUNCTION stats_billing_mirror_save_state(TEXT, BIGINT, BIGINT) TO stats_billing_mirror_writer;
+GRANT EXECUTE ON FUNCTION stats_billing_mirror_ensure_provider(TEXT, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) TO stats_billing_mirror_writer;
+GRANT EXECUTE ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) TO stats_billing_mirror_writer;

--- a/phase4-coordinator/dist/stats-billing-mirror.env.example
+++ b/phase4-coordinator/dist/stats-billing-mirror.env.example
@@ -1,0 +1,17 @@
+# Environment for stats-billing-mirror.service.
+#
+# Use a dedicated Postgres role scoped to bootstrap-created functions:
+#   EXECUTE on stats_billing_mirror_load_state
+#   EXECUTE on stats_billing_mirror_save_state
+#   EXECUTE on stats_billing_mirror_ensure_provider
+#   EXECUTE on stats_billing_mirror_upsert_request_credit
+#
+# Apply stats-billing-mirror-bootstrap.sql as a database owner/admin before
+# enabling the timer; the systemd service runs with --ensure-schema=false so
+# this writer role does not need DDL or direct table DML privileges.
+#
+# The service reads the coordinator SQLite DB read-only and never runs in
+# coordinator request handling. Install this file as:
+#   /etc/macprovider-stats/stats-billing-mirror.env
+# with root:root 0600.
+STATS_BILLING_MIRROR_DSN=postgres://stats_billing_mirror_writer:REPLACE_ME@127.0.0.1:5432/macprovider?sslmode=disable

--- a/phase4-coordinator/dist/stats-billing-mirror.service
+++ b/phase4-coordinator/dist/stats-billing-mirror.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=MacProvider stats billing mirror
+Documentation=https://github.com/augstar/macprovider-poc
+Wants=network-online.target
+After=network-online.target
+ConditionPathExists=/etc/macprovider-stats/stats-billing-mirror.env
+ConditionPathExists=/var/lib/macprovider/request-log.sqlite
+
+[Service]
+Type=oneshot
+User=macprovider-stats
+Group=macprovider-stats
+EnvironmentFile=/etc/macprovider-stats/stats-billing-mirror.env
+ExecStart=/opt/macprovider-stats/stats-billing-mirror --sqlite /var/lib/macprovider/request-log.sqlite --ensure-schema=false
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadOnlyPaths=/var/lib/macprovider/request-log.sqlite
+ReadOnlyPaths=-/var/lib/macprovider/request-log.sqlite-wal
+ReadOnlyPaths=-/var/lib/macprovider/request-log.sqlite-shm
+InaccessiblePaths=/etc/macprovider
+InaccessiblePaths=-/opt/macprovider/coordinator.yaml
+InaccessiblePaths=-/var/lib/macprovider/coordinator.db

--- a/phase4-coordinator/dist/stats-billing-mirror.timer
+++ b/phase4-coordinator/dist/stats-billing-mirror.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run MacProvider stats billing mirror
+
+[Timer]
+OnBootSec=90s
+OnUnitActiveSec=60s
+AccuracySec=10s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh
+++ b/phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check_stats_billing_mirror_deploy_test.sh — offline validation for the
+# stats billing mirror sidecar deploy wiring.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_SH="$DIST_DIR/deploy-pearl-vps.sh"
+SERVICE="$DIST_DIR/stats-billing-mirror.service"
+TIMER="$DIST_DIR/stats-billing-mirror.timer"
+ENV_EXAMPLE="$DIST_DIR/stats-billing-mirror.env.example"
+BOOTSTRAP_SQL="$DIST_DIR/stats-billing-mirror-bootstrap.sql"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+for f in "$DEPLOY_SH" "$SERVICE" "$TIMER" "$ENV_EXAMPLE" "$BOOTSTRAP_SQL"; do
+  [ -f "$f" ] || fail "missing required file: $f"
+done
+
+grep -qF 'STATS_BILLING_MIRROR_BINARY="$DIST_DIR/stats-billing-mirror-linux-amd64"' "$DEPLOY_SH" ||
+  fail "deploy script missing billing mirror binary variable"
+grep -qF 'STATS_BILLING_MIRROR_SERVICE="$DIST_DIR/stats-billing-mirror.service"' "$DEPLOY_SH" ||
+  fail "deploy script missing billing mirror service variable"
+grep -qF 'STATS_BILLING_MIRROR_TIMER="$DIST_DIR/stats-billing-mirror.timer"' "$DEPLOY_SH" ||
+  fail "deploy script missing billing mirror timer variable"
+grep -qF '$SCP "$STATS_BILLING_MIRROR_BINARY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror-linux-amd64"' "$DEPLOY_SH" ||
+  fail "deploy script missing billing mirror binary upload"
+grep -qF 'for f in "$BINARY" "$CLI_BINARY" "$STATS_INVENTORY_BINARY" "$STATS_BILLING_MIRROR_BINARY"' "$DEPLOY_SH" ||
+  fail "deploy preflight must require billing mirror binary"
+grep -qF '"$STATS_BILLING_MIRROR_SERVICE" "$STATS_BILLING_MIRROR_TIMER" "$NGINX_SITE"' "$DEPLOY_SH" ||
+  fail "deploy preflight must require billing mirror unit files"
+grep -qF '$SCP "$STATS_BILLING_MIRROR_SERVICE" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror.service"' "$DEPLOY_SH" ||
+  fail "deploy script missing billing mirror service upload"
+grep -qF '$SCP "$STATS_BILLING_MIRROR_TIMER"   "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror.timer"' "$DEPLOY_SH" ||
+  fail "deploy script missing billing mirror timer upload"
+grep -qF 'install -o root -g macprovider-stats -m 0750 $DEPLOY_TMP/stats-billing-mirror-linux-amd64 /opt/macprovider-stats/stats-billing-mirror' "$DEPLOY_SH" ||
+  fail "deploy script missing billing mirror binary install"
+grep -qF 'setfacl -m u:macprovider-stats:r-- /var/lib/macprovider/request-log.sqlite' "$DEPLOY_SH" ||
+  fail "deploy script must grant narrow SQLite file ACL"
+grep -qF 'su -s /bin/sh -c "test -r /var/lib/macprovider/request-log.sqlite" macprovider-stats' "$DEPLOY_SH" ||
+  fail "deploy script must only enable mirror when stats user can read sqlite source"
+grep -qF 'install -o root -g root       -m 0644 $DEPLOY_TMP/stats-billing-mirror.service /etc/systemd/system/stats-billing-mirror.service' "$DEPLOY_SH" ||
+  fail "deploy script missing billing mirror service install"
+grep -qF 'install -o root -g root       -m 0644 $DEPLOY_TMP/stats-billing-mirror.timer /etc/systemd/system/stats-billing-mirror.timer' "$DEPLOY_SH" ||
+  fail "deploy script missing billing mirror timer install"
+grep -qF '[ -f /etc/macprovider-stats/stats-billing-mirror.env ] && [ -f /var/lib/macprovider/request-log.sqlite ]' "$DEPLOY_SH" ||
+  fail "deploy script must only enable timer when env and SQLite source exist"
+grep -qF 'warning: stats-billing-mirror.service failed; leaving coordinator deploy running' "$DEPLOY_SH" ||
+  fail "deploy script must not fail coordinator deploy on mirror run failure"
+
+grep -qxF 'User=macprovider-stats' "$SERVICE" ||
+  fail "billing mirror must run as dedicated stats user"
+grep -qxF 'Group=macprovider-stats' "$SERVICE" ||
+  fail "billing mirror must run with dedicated stats group"
+grep -qxF 'ConditionPathExists=/etc/macprovider-stats/stats-billing-mirror.env' "$SERVICE" ||
+  fail "billing mirror service must be opt-in on env file"
+grep -qxF 'ConditionPathExists=/var/lib/macprovider/request-log.sqlite' "$SERVICE" ||
+  fail "billing mirror service must require the SQLite source"
+grep -qxF 'EnvironmentFile=/etc/macprovider-stats/stats-billing-mirror.env' "$SERVICE" ||
+  fail "billing mirror service must read isolated env file"
+grep -qxF 'ExecStart=/opt/macprovider-stats/stats-billing-mirror --sqlite /var/lib/macprovider/request-log.sqlite --ensure-schema=false' "$SERVICE" ||
+  fail "billing mirror service must execute from deploy path"
+grep -qxF 'ReadOnlyPaths=/var/lib/macprovider/request-log.sqlite' "$SERVICE" ||
+  fail "billing mirror service must read only the SQLite source"
+grep -qxF 'InaccessiblePaths=/etc/macprovider' "$SERVICE" ||
+  fail "billing mirror service must not access coordinator secrets"
+grep -qxF 'OnUnitActiveSec=60s' "$TIMER" ||
+  fail "billing mirror timer must run frequently enough for public stats"
+grep -qF 'stats_billing_mirror_writer' "$ENV_EXAMPLE" ||
+  fail "env example must document dedicated writer role"
+grep -qF 'STATS_BILLING_MIRROR_DSN=' "$ENV_EXAMPLE" ||
+  fail "env example must define the expected DSN variable"
+grep -qF 'runs with --ensure-schema=false' "$ENV_EXAMPLE" ||
+  fail "env example must document bootstrap-before-service contract"
+grep -qF 'CREATE TABLE IF NOT EXISTS ledger_request_credits' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must create ledger_request_credits"
+if grep -qF "PASSWORD 'REPLACE_ME'" "$BOOTSTRAP_SQL"; then
+  fail "bootstrap SQL must not create a known default password"
+fi
+grep -qF 'RAISE EXCEPTION' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must fail if writer role is missing"
+grep -qF 'CREATE TABLE IF NOT EXISTS provider_tokens' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must create provider_tokens"
+grep -qF 'GRANT SELECT ON ledger_request_credits TO stats_rollup' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must grant rollup read access"
+grep -qF 'REVOKE ALL ON ledger_request_credits FROM stats_billing_mirror_writer' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must revoke direct writer table DML"
+grep -qF 'REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must revoke public function execute"
+grep -qF 'GRANT EXECUTE ON FUNCTION stats_billing_mirror_upsert_request_credit' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must grant constrained upsert function"
+grep -qF 'CHECK (usage_source IN' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must carry source billing enum constraints"
+
+if LC_ALL=C grep -q $'\r' "$SERVICE" "$TIMER" "$ENV_EXAMPLE" "$BOOTSTRAP_SQL"; then
+  fail "billing mirror deploy artifacts contain CRLF line endings"
+fi
+if awk '/[^[:space:]]/ && /[[:blank:]]$/ { print FILENAME ":" FNR ":" $0; bad=1 } END { exit bad }' "$SERVICE" "$TIMER" "$ENV_EXAMPLE" "$BOOTSTRAP_SQL" >&2; then
+  :
+else
+  fail "billing mirror deploy artifacts contain trailing whitespace"
+fi
+
+echo "ok: stats billing mirror deploy wiring"

--- a/phase4-coordinator/internal/stats/billingmirror/mirror.go
+++ b/phase4-coordinator/internal/stats/billingmirror/mirror.go
@@ -1,0 +1,764 @@
+package billingmirror
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+	_ "github.com/lib/pq"
+	_ "modernc.org/sqlite"
+)
+
+const (
+	DefaultSQLitePath  = "/var/lib/macprovider/request-log.sqlite"
+	DefaultBatchSize   = 5000
+	DefaultOverlapRows = 1000
+	DefaultRunTimeout  = 25 * time.Second
+
+	StateSource = "sqlite-ledger-request-credits"
+)
+
+type Options struct {
+	SQLitePath   string
+	PostgresDSN  string
+	BatchSize    int
+	OverlapRows  int64
+	SweepRows    int
+	MaxBatches   int
+	EnsureSchema bool
+	DryRun       bool
+	Stdout       io.Writer
+}
+
+type Result struct {
+	RequestRowsRead     int
+	RequestRowsUpserted int
+	ProviderRowsRead    int
+	ProviderRowsEnsured int
+	LastRequestID       int64
+	SweepAfterID        int64
+	SourceMaxID         int64
+	PendingRequestRows  int64
+	DryRun              bool
+}
+
+type RequestCredit struct {
+	SQLiteID                  int64
+	RequestID                 string
+	AttemptN                  int
+	ProviderID                string
+	TSUTC                     time.Time
+	CreatedAtUTC              time.Time
+	UpdatedAtUTC              sql.NullTime
+	PromptTokens              sql.NullInt64
+	CompletionTokens          sql.NullInt64
+	EstimatedCompletionTokens sql.NullInt64
+	UsageSource               string
+	ProviderCredits           int64
+	FaultFlag                 string
+	Quarantined               bool
+}
+
+type ProviderIdentity struct {
+	ProviderID   string
+	ProviderName string
+	CreatedAt    time.Time
+	LastUsedAt   sql.NullTime
+}
+
+type State struct {
+	LastRequestID int64
+	SweepAfterID  int64
+}
+
+func Run(parent context.Context, opts Options) (Result, error) {
+	opts = normalizeOptions(opts)
+	out := opts.Stdout
+	if out == nil {
+		out = io.Discard
+	}
+	if opts.SQLitePath == "" {
+		return Result{}, errors.New("sqlite path is required")
+	}
+	if opts.PostgresDSN == "" && !opts.DryRun {
+		return Result{}, errors.New("postgres dsn is required")
+	}
+
+	ctx, cancel := context.WithTimeout(parent, DefaultRunTimeout)
+	defer cancel()
+
+	source, err := OpenSQLite(opts.SQLitePath)
+	if err != nil {
+		return Result{}, err
+	}
+	defer source.Close()
+
+	var pg *sql.DB
+	var state State
+	if !opts.DryRun {
+		pg, err = OpenPostgres(opts.PostgresDSN)
+		if err != nil {
+			return Result{}, err
+		}
+		defer pg.Close()
+		if opts.EnsureSchema {
+			if err := EnsureSchema(ctx, pg); err != nil {
+				return Result{}, err
+			}
+		}
+		state, err = LoadState(ctx, pg)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+
+	maxSourceID, err := FetchMaxRequestCreditID(ctx, source)
+	if err != nil {
+		return Result{}, err
+	}
+	newRows := make([]RequestCredit, 0, opts.BatchSize)
+	newCursor := state.LastRequestID
+	for batch := 0; batch < opts.MaxBatches; batch++ {
+		batchRows, err := FetchRequestCredits(ctx, source, newCursor, opts.BatchSize)
+		if err != nil {
+			return Result{}, err
+		}
+		if len(batchRows) == 0 {
+			break
+		}
+		newRows = append(newRows, batchRows...)
+		newCursor = maxSQLiteID(batchRows, newCursor)
+		if len(batchRows) < opts.BatchSize {
+			break
+		}
+	}
+	nextLastRequestID := maxSQLiteID(newRows, state.LastRequestID)
+	rows := newRows
+	if state.LastRequestID > 0 && opts.OverlapRows > 0 {
+		startID := state.LastRequestID - opts.OverlapRows
+		if startID < 0 {
+			startID = 0
+		}
+		overlapRows, err := FetchRequestCreditsThrough(ctx, source, startID, state.LastRequestID, minInt(opts.BatchSize, int(opts.OverlapRows)))
+		if err != nil {
+			return Result{}, err
+		}
+		rows = mergeRequestCredits(overlapRows, rows)
+	}
+	nextSweepAfterID := state.SweepAfterID
+	if opts.SweepRows > 0 && maxSourceID > 0 {
+		sweepStart := state.SweepAfterID
+		if sweepStart >= maxSourceID {
+			sweepStart = 0
+		}
+		sweepRows, err := FetchRequestCreditsThrough(ctx, source, sweepStart, maxSourceID, opts.SweepRows)
+		if err != nil {
+			return Result{}, err
+		}
+		rows = mergeRequestCredits(rows, sweepRows)
+		nextSweepAfterID = maxSQLiteID(sweepRows, sweepStart)
+		if nextSweepAfterID >= maxSourceID {
+			nextSweepAfterID = 0
+		}
+	}
+	providers, err := FetchProviderIdentities(ctx, source)
+	if err != nil {
+		return Result{}, err
+	}
+	result := Result{
+		RequestRowsRead:  len(rows),
+		ProviderRowsRead: len(providers),
+		DryRun:           opts.DryRun,
+		LastRequestID:    nextLastRequestID,
+		SweepAfterID:     nextSweepAfterID,
+		SourceMaxID:      maxSourceID,
+	}
+	if maxSourceID > result.LastRequestID {
+		result.PendingRequestRows = maxSourceID - result.LastRequestID
+	}
+	if opts.DryRun {
+		fmt.Fprintf(out, "would upsert %d request credit rows and ensure %d provider identities (last_request_id=%d source_max_id=%d pending_request_rows=%d sweep_after_id=%d)\n", result.RequestRowsRead, result.ProviderRowsRead, result.LastRequestID, result.SourceMaxID, result.PendingRequestRows, result.SweepAfterID)
+		return result, nil
+	}
+
+	if err := Apply(ctx, pg, rows, providers, State{LastRequestID: result.LastRequestID, SweepAfterID: result.SweepAfterID}); err != nil {
+		return Result{}, err
+	}
+	result.RequestRowsUpserted = len(rows)
+	result.ProviderRowsEnsured = len(providers)
+	fmt.Fprintf(out, "upserted %d request credit rows and ensured %d provider identities (last_request_id=%d source_max_id=%d pending_request_rows=%d sweep_after_id=%d)\n", result.RequestRowsUpserted, result.ProviderRowsEnsured, result.LastRequestID, result.SourceMaxID, result.PendingRequestRows, result.SweepAfterID)
+	return result, nil
+}
+
+func normalizeOptions(opts Options) Options {
+	opts.SQLitePath = strings.TrimSpace(opts.SQLitePath)
+	if opts.SQLitePath == "" {
+		opts.SQLitePath = strings.TrimSpace(os.Getenv("STATS_BILLING_MIRROR_SQLITE"))
+	}
+	if opts.SQLitePath == "" {
+		opts.SQLitePath = DefaultSQLitePath
+	}
+	opts.PostgresDSN = strings.TrimSpace(opts.PostgresDSN)
+	if opts.PostgresDSN == "" {
+		opts.PostgresDSN = strings.TrimSpace(os.Getenv("STATS_BILLING_MIRROR_DSN"))
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = DefaultBatchSize
+	}
+	if opts.BatchSize > 50000 {
+		opts.BatchSize = 50000
+	}
+	if opts.MaxBatches <= 0 {
+		opts.MaxBatches = 5
+	}
+	if opts.MaxBatches > 20 {
+		opts.MaxBatches = 20
+	}
+	if opts.OverlapRows < 0 {
+		opts.OverlapRows = 0
+	}
+	if opts.OverlapRows == 0 {
+		opts.OverlapRows = DefaultOverlapRows
+	}
+	if opts.OverlapRows > int64(opts.BatchSize) {
+		opts.OverlapRows = int64(opts.BatchSize)
+	}
+	if opts.SweepRows < 0 {
+		opts.SweepRows = 0
+	}
+	if opts.SweepRows == 0 {
+		opts.SweepRows = opts.BatchSize
+	}
+	if opts.SweepRows > opts.BatchSize {
+		opts.SweepRows = opts.BatchSize
+	}
+	return opts
+}
+
+func OpenSQLite(path string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite", sqliteutil.ReadOnlyDSN(path))
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	return db, nil
+}
+
+func OpenPostgres(dsn string) (*sql.DB, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open postgres: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(5 * time.Minute)
+	db.SetConnMaxIdleTime(time.Minute)
+	return db, nil
+}
+
+func FetchRequestCredits(ctx context.Context, db *sql.DB, startID int64, limit int) ([]RequestCredit, error) {
+	const q = `
+SELECT id, request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
+       prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
+       provider_credits, fault_flag, quarantined
+  FROM ledger_request_credits
+ WHERE id > ?
+ ORDER BY id
+ LIMIT ?`
+	return scanRequestCredits(ctx, db, q, startID, limit)
+}
+
+func FetchMaxRequestCreditID(ctx context.Context, db *sql.DB) (int64, error) {
+	var maxID sql.NullInt64
+	if err := db.QueryRowContext(ctx, `SELECT MAX(id) FROM ledger_request_credits`).Scan(&maxID); err != nil {
+		return 0, fmt.Errorf("select max ledger_request_credits id: %w", err)
+	}
+	if !maxID.Valid {
+		return 0, nil
+	}
+	return maxID.Int64, nil
+}
+
+func FetchRequestCreditsThrough(ctx context.Context, db *sql.DB, startID, endID int64, limit int) ([]RequestCredit, error) {
+	const q = `
+SELECT id, request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
+       prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
+       provider_credits, fault_flag, quarantined
+  FROM ledger_request_credits
+ WHERE id > ?
+   AND id <= ?
+ ORDER BY id
+ LIMIT ?`
+	return scanRequestCredits(ctx, db, q, startID, endID, limit)
+}
+
+func scanRequestCredits(ctx context.Context, db *sql.DB, q string, args ...any) ([]RequestCredit, error) {
+	cur, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("select ledger_request_credits: %w", err)
+	}
+	defer cur.Close()
+	var out []RequestCredit
+	for cur.Next() {
+		var row RequestCredit
+		var ts, created sql.NullString
+		var updated sql.NullString
+		var quarantined int
+		if err := cur.Scan(
+			&row.SQLiteID, &row.RequestID, &row.AttemptN, &row.ProviderID,
+			&ts, &created, &updated,
+			&row.PromptTokens, &row.CompletionTokens, &row.EstimatedCompletionTokens,
+			&row.UsageSource, &row.ProviderCredits, &row.FaultFlag, &quarantined,
+		); err != nil {
+			return nil, fmt.Errorf("scan ledger_request_credits: %w", err)
+		}
+		row.TSUTC, err = parseRequiredTime(ts, "ts_utc")
+		if err != nil {
+			return nil, err
+		}
+		row.CreatedAtUTC, err = parseRequiredTime(created, "created_at_utc")
+		if err != nil {
+			return nil, err
+		}
+		row.UpdatedAtUTC, err = parseOptionalTime(updated)
+		if err != nil {
+			return nil, fmt.Errorf("updated_at_utc: %w", err)
+		}
+		row.Quarantined = quarantined != 0
+		out = append(out, row)
+	}
+	if err := cur.Err(); err != nil {
+		return nil, fmt.Errorf("iterate ledger_request_credits: %w", err)
+	}
+	return out, nil
+}
+
+func FetchProviderIdentities(ctx context.Context, db *sql.DB) ([]ProviderIdentity, error) {
+	const q = `
+SELECT provider_id,
+       COALESCE(MAX(NULLIF(provider_name, '')), provider_id) AS provider_name,
+       COALESCE(MIN(created_at), strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) AS created_at,
+       MAX(last_used_at) AS last_used_at
+  FROM provider_tokens
+ WHERE provider_id <> ''
+ GROUP BY provider_id
+ ORDER BY provider_id`
+	cur, err := db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("select provider_tokens: %w", err)
+	}
+	defer cur.Close()
+	var out []ProviderIdentity
+	for cur.Next() {
+		var p ProviderIdentity
+		var created sql.NullString
+		var lastUsed sql.NullString
+		if err := cur.Scan(&p.ProviderID, &p.ProviderName, &created, &lastUsed); err != nil {
+			return nil, fmt.Errorf("scan provider_tokens: %w", err)
+		}
+		createdAt, err := parseRequiredTime(created, "provider_tokens.created_at")
+		if err != nil {
+			return nil, err
+		}
+		p.CreatedAt = createdAt
+		p.LastUsedAt, err = parseOptionalTime(lastUsed)
+		if err != nil {
+			return nil, fmt.Errorf("provider_tokens.last_used_at: %w", err)
+		}
+		out = append(out, p)
+	}
+	if err := cur.Err(); err != nil {
+		return nil, fmt.Errorf("iterate provider_tokens: %w", err)
+	}
+	return out, nil
+}
+
+func Apply(ctx context.Context, db *sql.DB, rows []RequestCredit, providers []ProviderIdentity, state State) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin mirror transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	var locked bool
+	if err := tx.QueryRowContext(ctx, `SELECT pg_try_advisory_xact_lock(47017, 1711)`).Scan(&locked); err != nil {
+		return fmt.Errorf("acquire mirror advisory lock: %w", err)
+	}
+	if !locked {
+		return errors.New("another stats billing mirror run is active")
+	}
+	for _, p := range providers {
+		if err := ensureProvider(ctx, tx, p); err != nil {
+			return err
+		}
+	}
+	for _, row := range rows {
+		if err := upsertRequestCredit(ctx, tx, row); err != nil {
+			return err
+		}
+	}
+	if err := SaveState(ctx, tx, state); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit mirror transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func EnsureSchema(ctx context.Context, db *sql.DB) error {
+	for _, stmt := range schemaStatements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("ensure stats billing mirror schema: %w", err)
+		}
+	}
+	return nil
+}
+
+func LoadState(ctx context.Context, db *sql.DB) (State, error) {
+	var state State
+	if err := db.QueryRowContext(ctx, `SELECT last_request_credit_id, sweep_after_request_credit_id FROM stats_billing_mirror_load_state($1)`, StateSource).Scan(&state.LastRequestID, &state.SweepAfterID); err != nil {
+		return State{}, fmt.Errorf("load mirror state: %w", err)
+	}
+	return state, nil
+}
+
+func SaveState(ctx context.Context, tx *sql.Tx, state State) error {
+	if _, err := tx.ExecContext(ctx, `SELECT stats_billing_mirror_save_state($1, $2, $3)`,
+		StateSource, state.LastRequestID, state.SweepAfterID); err != nil {
+		return fmt.Errorf("save mirror state: %w", err)
+	}
+	return nil
+}
+
+func ensureProvider(ctx context.Context, tx *sql.Tx, p ProviderIdentity) error {
+	tokenHash := syntheticTokenHash(p.ProviderID)
+	if _, err := tx.ExecContext(ctx, `SELECT stats_billing_mirror_ensure_provider($1, $2, $3, $4, $5)`,
+		tokenHash, p.ProviderID, p.ProviderName, p.CreatedAt, nullTimeArg(p.LastUsedAt)); err != nil {
+		return fmt.Errorf("ensure provider %q: %w", p.ProviderID, err)
+	}
+	return nil
+}
+
+func upsertRequestCredit(ctx context.Context, tx *sql.Tx, row RequestCredit) error {
+	if _, err := tx.ExecContext(ctx, `SELECT stats_billing_mirror_upsert_request_credit(
+    $1, $2, $3, $4, $5, $6, $7,
+    $8, $9, $10, $11,
+    $12, $13, $14
+)`,
+		row.SQLiteID, row.RequestID, row.AttemptN, row.ProviderID, row.TSUTC, row.CreatedAtUTC, nullTimeArg(row.UpdatedAtUTC),
+		nullInt64Arg(row.PromptTokens), nullInt64Arg(row.CompletionTokens), nullInt64Arg(row.EstimatedCompletionTokens),
+		row.UsageSource, row.ProviderCredits, row.FaultFlag, row.Quarantined); err != nil {
+		return fmt.Errorf("upsert request credit %q/%d/%q: %w", row.RequestID, row.AttemptN, row.ProviderID, err)
+	}
+	return nil
+}
+
+func mergeRequestCredits(a, b []RequestCredit) []RequestCredit {
+	if len(b) == 0 {
+		return a
+	}
+	byKey := make(map[string]RequestCredit, len(a)+len(b))
+	for _, row := range a {
+		byKey[requestCreditKey(row)] = row
+	}
+	for _, row := range b {
+		byKey[requestCreditKey(row)] = row
+	}
+	out := make([]RequestCredit, 0, len(byKey))
+	for _, row := range byKey {
+		out = append(out, row)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].SQLiteID == out[j].SQLiteID {
+			return requestCreditKey(out[i]) < requestCreditKey(out[j])
+		}
+		return out[i].SQLiteID < out[j].SQLiteID
+	})
+	return out
+}
+
+func requestCreditKey(row RequestCredit) string {
+	return row.RequestID + "\x00" + fmt.Sprint(row.AttemptN) + "\x00" + row.ProviderID
+}
+
+func maxSQLiteID(rows []RequestCredit, floor int64) int64 {
+	out := floor
+	for _, row := range rows {
+		if row.SQLiteID > out {
+			out = row.SQLiteID
+		}
+	}
+	return out
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func syntheticTokenHash(providerID string) string {
+	sum := sha256.Sum256([]byte("stats-billing-mirror\x00" + providerID))
+	return "stats-mirror-sha256:" + hex.EncodeToString(sum[:])
+}
+
+func parseRequiredTime(v sql.NullString, field string) (time.Time, error) {
+	if !v.Valid || strings.TrimSpace(v.String) == "" {
+		return time.Time{}, fmt.Errorf("%s is required", field)
+	}
+	t, err := parseTimeText(v.String)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%s: %w", field, err)
+	}
+	return t, nil
+}
+
+func parseOptionalTime(v sql.NullString) (sql.NullTime, error) {
+	if !v.Valid || strings.TrimSpace(v.String) == "" {
+		return sql.NullTime{}, nil
+	}
+	t, err := parseTimeText(v.String)
+	if err != nil {
+		return sql.NullTime{}, err
+	}
+	return sql.NullTime{Time: t, Valid: true}, nil
+}
+
+func parseTimeText(raw string) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05.999999999Z07:00", "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid timestamp %q", raw)
+}
+
+func nullTimeArg(v sql.NullTime) any {
+	if !v.Valid {
+		return nil
+	}
+	return v.Time.UTC()
+}
+
+func nullInt64Arg(v sql.NullInt64) any {
+	if !v.Valid {
+		return nil
+	}
+	return v.Int64
+}
+
+var schemaStatements = []string{
+	`CREATE TABLE IF NOT EXISTS ledger_request_credits (
+    id BIGSERIAL PRIMARY KEY,
+    sqlite_lrc_id BIGINT,
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL CHECK (attempt_n >= 0),
+    provider_id TEXT NOT NULL,
+    ts_utc TIMESTAMPTZ NOT NULL,
+    created_at_utc TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at_utc TIMESTAMPTZ,
+    prompt_tokens BIGINT CHECK (prompt_tokens IS NULL OR prompt_tokens >= 0),
+    completion_tokens BIGINT CHECK (completion_tokens IS NULL OR completion_tokens >= 0),
+    estimated_completion_tokens BIGINT CHECK (estimated_completion_tokens IS NULL OR estimated_completion_tokens >= 0),
+    usage_source TEXT NOT NULL DEFAULT 'provider_reported' CHECK (usage_source IN ('provider_reported','byte_estimated','null_error')),
+    provider_credits BIGINT NOT NULL DEFAULT 0 CHECK (provider_credits >= 0),
+    fault_flag TEXT NOT NULL DEFAULT 'none' CHECK (fault_flag IN ('none','breaker_qualifying','null_usage_error')),
+    quarantined BOOLEAN NOT NULL DEFAULT FALSE
+)`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS sqlite_lrc_id BIGINT`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS request_id TEXT`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS attempt_n INTEGER`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS provider_id TEXT`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS ts_utc TIMESTAMPTZ`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ DEFAULT now()`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS prompt_tokens BIGINT`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS completion_tokens BIGINT`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS estimated_completion_tokens BIGINT`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS usage_source TEXT DEFAULT 'provider_reported'`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS provider_credits BIGINT DEFAULT 0`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS fault_flag TEXT DEFAULT 'none'`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS quarantined BOOLEAN DEFAULT FALSE`,
+	`DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_attempt_nonnegative') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_attempt_nonnegative CHECK (attempt_n >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_prompt_tokens_nonnegative') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_prompt_tokens_nonnegative CHECK (prompt_tokens IS NULL OR prompt_tokens >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_completion_tokens_nonnegative') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_completion_tokens_nonnegative CHECK (completion_tokens IS NULL OR completion_tokens >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_estimated_completion_tokens_nonnegative') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_estimated_completion_tokens_nonnegative CHECK (estimated_completion_tokens IS NULL OR estimated_completion_tokens >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_usage_source_enum') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_usage_source_enum CHECK (usage_source IN ('provider_reported','byte_estimated','null_error'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_provider_credits_nonnegative') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_provider_credits_nonnegative CHECK (provider_credits >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_fault_flag_enum') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_fault_flag_enum CHECK (fault_flag IN ('none','breaker_qualifying','null_usage_error'));
+    END IF;
+END $$`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS idx_lrc_mirror_unique_attempt ON ledger_request_credits(request_id, attempt_n, provider_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_lrc_mirror_provider_ts ON ledger_request_credits(provider_id, ts_utc)`,
+	`CREATE TABLE IF NOT EXISTS provider_tokens (
+    id BIGSERIAL PRIMARY KEY,
+    token_hash TEXT NOT NULL UNIQUE,
+    token_prefix TEXT NOT NULL DEFAULT '',
+    provider_id TEXT NOT NULL DEFAULT '',
+    provider_name TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    revoked_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ
+)`,
+	`ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS token_prefix TEXT DEFAULT ''`,
+	`ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS provider_id TEXT DEFAULT ''`,
+	`ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS provider_name TEXT DEFAULT ''`,
+	`ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT now()`,
+	`ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMPTZ`,
+	`ALTER TABLE provider_tokens ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMPTZ`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS idx_provider_tokens_one_active_per_provider
+    ON provider_tokens(provider_id)
+    WHERE revoked_at IS NULL AND provider_id <> ''`,
+	`CREATE TABLE IF NOT EXISTS stats_billing_mirror_state (
+    source TEXT PRIMARY KEY,
+    last_request_credit_id BIGINT NOT NULL DEFAULT 0,
+    sweep_after_request_credit_id BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)`,
+	`ALTER TABLE stats_billing_mirror_state ADD COLUMN IF NOT EXISTS sweep_after_request_credit_id BIGINT NOT NULL DEFAULT 0`,
+	`CREATE OR REPLACE FUNCTION stats_billing_mirror_load_state(p_source TEXT)
+RETURNS TABLE(last_request_credit_id BIGINT, sweep_after_request_credit_id BIGINT)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    INSERT INTO stats_billing_mirror_state (source, last_request_credit_id, sweep_after_request_credit_id)
+    VALUES (p_source, 0, 0)
+    ON CONFLICT (source) DO NOTHING;
+
+    SELECT s.last_request_credit_id, s.sweep_after_request_credit_id
+      FROM stats_billing_mirror_state s
+     WHERE s.source = p_source;
+$$`,
+	`CREATE OR REPLACE FUNCTION stats_billing_mirror_save_state(p_source TEXT, p_last_request_credit_id BIGINT, p_sweep_after_request_credit_id BIGINT)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    INSERT INTO stats_billing_mirror_state (source, last_request_credit_id, sweep_after_request_credit_id, updated_at)
+    VALUES (p_source, p_last_request_credit_id, p_sweep_after_request_credit_id, now())
+    ON CONFLICT (source) DO UPDATE SET
+        last_request_credit_id = GREATEST(stats_billing_mirror_state.last_request_credit_id, EXCLUDED.last_request_credit_id),
+        sweep_after_request_credit_id = EXCLUDED.sweep_after_request_credit_id,
+        updated_at = EXCLUDED.updated_at;
+$$`,
+	`CREATE OR REPLACE FUNCTION stats_billing_mirror_ensure_provider(
+    p_token_hash TEXT,
+    p_provider_id TEXT,
+    p_provider_name TEXT,
+    p_created_at TIMESTAMPTZ,
+    p_last_used_at TIMESTAMPTZ
+)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at, last_used_at)
+    SELECT p_token_hash, 'stats-mirror', p_provider_id, p_provider_name, p_created_at, p_last_used_at
+    WHERE NOT EXISTS (
+        SELECT 1 FROM provider_tokens WHERE provider_id = p_provider_id AND provider_id <> ''
+    )
+    ON CONFLICT (token_hash) DO UPDATE SET
+        provider_id = EXCLUDED.provider_id,
+        provider_name = EXCLUDED.provider_name,
+        last_used_at = EXCLUDED.last_used_at;
+$$`,
+	`CREATE OR REPLACE FUNCTION stats_billing_mirror_upsert_request_credit(
+    p_sqlite_lrc_id BIGINT,
+    p_request_id TEXT,
+    p_attempt_n INTEGER,
+    p_provider_id TEXT,
+    p_ts_utc TIMESTAMPTZ,
+    p_created_at_utc TIMESTAMPTZ,
+    p_updated_at_utc TIMESTAMPTZ,
+    p_prompt_tokens BIGINT,
+    p_completion_tokens BIGINT,
+    p_estimated_completion_tokens BIGINT,
+    p_usage_source TEXT,
+    p_provider_credits BIGINT,
+    p_fault_flag TEXT,
+    p_quarantined BOOLEAN
+)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    INSERT INTO ledger_request_credits (
+        sqlite_lrc_id, request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
+        prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
+        provider_credits, fault_flag, quarantined
+    ) VALUES (
+        p_sqlite_lrc_id, p_request_id, p_attempt_n, p_provider_id, p_ts_utc, p_created_at_utc, p_updated_at_utc,
+        p_prompt_tokens, p_completion_tokens, p_estimated_completion_tokens, p_usage_source,
+        p_provider_credits, p_fault_flag, p_quarantined
+    )
+    ON CONFLICT (request_id, attempt_n, provider_id) DO UPDATE SET
+        sqlite_lrc_id = EXCLUDED.sqlite_lrc_id,
+        ts_utc = EXCLUDED.ts_utc,
+        created_at_utc = EXCLUDED.created_at_utc,
+        updated_at_utc = EXCLUDED.updated_at_utc,
+        prompt_tokens = EXCLUDED.prompt_tokens,
+        completion_tokens = EXCLUDED.completion_tokens,
+        estimated_completion_tokens = EXCLUDED.estimated_completion_tokens,
+        usage_source = EXCLUDED.usage_source,
+        provider_credits = EXCLUDED.provider_credits,
+        fault_flag = EXCLUDED.fault_flag,
+        quarantined = EXCLUDED.quarantined;
+$$`,
+	`DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'stats_rollup') THEN
+        GRANT SELECT ON ledger_request_credits TO stats_rollup;
+        GRANT SELECT ON provider_tokens TO stats_rollup;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'stats_billing_mirror_writer') THEN
+        REVOKE ALL ON ledger_request_credits FROM stats_billing_mirror_writer;
+        REVOKE ALL ON provider_tokens FROM stats_billing_mirror_writer;
+        REVOKE ALL ON stats_billing_mirror_state FROM stats_billing_mirror_writer;
+        REVOKE ALL ON FUNCTION stats_billing_mirror_load_state(TEXT) FROM PUBLIC;
+        REVOKE ALL ON FUNCTION stats_billing_mirror_save_state(TEXT, BIGINT, BIGINT) FROM PUBLIC;
+        REVOKE ALL ON FUNCTION stats_billing_mirror_ensure_provider(TEXT, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC;
+        REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) FROM PUBLIC;
+        GRANT EXECUTE ON FUNCTION stats_billing_mirror_load_state(TEXT) TO stats_billing_mirror_writer;
+        GRANT EXECUTE ON FUNCTION stats_billing_mirror_save_state(TEXT, BIGINT, BIGINT) TO stats_billing_mirror_writer;
+        GRANT EXECUTE ON FUNCTION stats_billing_mirror_ensure_provider(TEXT, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) TO stats_billing_mirror_writer;
+        GRANT EXECUTE ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) TO stats_billing_mirror_writer;
+    END IF;
+END $$`,
+}

--- a/phase4-coordinator/internal/stats/billingmirror/mirror_test.go
+++ b/phase4-coordinator/internal/stats/billingmirror/mirror_test.go
@@ -1,0 +1,268 @@
+package billingmirror
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestRunDryRunReadsSQLiteWithoutPostgresDSN(t *testing.T) {
+	dbPath := seedSQLite(t)
+	var out bytes.Buffer
+	res, err := Run(context.Background(), Options{
+		SQLitePath:  dbPath,
+		DryRun:      true,
+		BatchSize:   10,
+		OverlapRows: 1,
+		SweepRows:   1,
+		Stdout:      &out,
+	})
+	if err != nil {
+		t.Fatalf("Run(dry-run) error = %v", err)
+	}
+	if res.RequestRowsRead != 2 {
+		t.Fatalf("RequestRowsRead = %d, want 2", res.RequestRowsRead)
+	}
+	if res.ProviderRowsRead != 1 {
+		t.Fatalf("ProviderRowsRead = %d, want 1", res.ProviderRowsRead)
+	}
+	if res.LastRequestID != 2 {
+		t.Fatalf("LastRequestID = %d, want 2", res.LastRequestID)
+	}
+	if got := out.String(); !strings.Contains(got, "would upsert 2 request credit rows and ensure 1 provider identities") {
+		t.Fatalf("dry-run output = %q", got)
+	}
+}
+
+func TestFetchRequestCreditsParsesEffectiveStatsColumns(t *testing.T) {
+	dbPath := seedSQLite(t)
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	defer db.Close()
+
+	rows, err := FetchRequestCredits(context.Background(), db, 0, 10)
+	if err != nil {
+		t.Fatalf("FetchRequestCredits() error = %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2", len(rows))
+	}
+	first := rows[0]
+	if first.RequestID != "req-1" || first.AttemptN != 0 || first.ProviderID != "provider-a" {
+		t.Fatalf("first identity = %#v", first)
+	}
+	if !first.PromptTokens.Valid || first.PromptTokens.Int64 != 100 {
+		t.Fatalf("prompt tokens = %#v, want 100", first.PromptTokens)
+	}
+	if !first.CompletionTokens.Valid || first.CompletionTokens.Int64 != 200 {
+		t.Fatalf("completion tokens = %#v, want 200", first.CompletionTokens)
+	}
+	if first.Quarantined {
+		t.Fatal("first.Quarantined = true, want false")
+	}
+	second := rows[1]
+	if second.UsageSource != "byte_estimated" {
+		t.Fatalf("second usage source = %q, want byte_estimated", second.UsageSource)
+	}
+	if second.CompletionTokens.Valid {
+		t.Fatalf("second completion tokens = %#v, want NULL", second.CompletionTokens)
+	}
+	if !second.EstimatedCompletionTokens.Valid || second.EstimatedCompletionTokens.Int64 != 44 {
+		t.Fatalf("second estimated completion = %#v, want 44", second.EstimatedCompletionTokens)
+	}
+	if !second.Quarantined {
+		t.Fatal("second.Quarantined = false, want true")
+	}
+}
+
+func TestFetchMaxRequestCreditID(t *testing.T) {
+	dbPath := seedSQLite(t)
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	defer db.Close()
+
+	maxID, err := FetchMaxRequestCreditID(context.Background(), db)
+	if err != nil {
+		t.Fatalf("FetchMaxRequestCreditID() error = %v", err)
+	}
+	if maxID != 2 {
+		t.Fatalf("maxID = %d, want 2", maxID)
+	}
+}
+
+func TestFetchRequestCreditsThroughReplaysOnlyBoundedOverlap(t *testing.T) {
+	dbPath := seedSQLite(t)
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	defer db.Close()
+
+	rows, err := FetchRequestCreditsThrough(context.Background(), db, 0, 1, 10)
+	if err != nil {
+		t.Fatalf("FetchRequestCreditsThrough() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if rows[0].SQLiteID != 1 {
+		t.Fatalf("SQLiteID = %d, want 1", rows[0].SQLiteID)
+	}
+}
+
+func TestMaxSQLiteIDOnlyUsesSequentialNewRows(t *testing.T) {
+	newRows := []RequestCredit{{SQLiteID: 11}, {SQLiteID: 12}}
+	recentReplay := []RequestCredit{{SQLiteID: 99}}
+	next := maxSQLiteID(newRows, 10)
+	if next != 12 {
+		t.Fatalf("next = %d, want 12", next)
+	}
+	if got := maxSQLiteID(recentReplay, next); got != 99 {
+		t.Fatalf("sanity max = %d, want 99", got)
+	}
+	// Run intentionally calls maxSQLiteID before merging recentReplay so a
+	// recently updated high-ID row cannot skip unfetched IDs 13..98.
+}
+
+func TestFetchProviderIdentitiesDoesNotRequireTokenHashes(t *testing.T) {
+	dbPath := seedSQLite(t)
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	defer db.Close()
+
+	providers, err := FetchProviderIdentities(context.Background(), db)
+	if err != nil {
+		t.Fatalf("FetchProviderIdentities() error = %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("len(providers) = %d, want 1", len(providers))
+	}
+	if providers[0].ProviderID != "provider-a" {
+		t.Fatalf("provider id = %q, want provider-a", providers[0].ProviderID)
+	}
+	if providers[0].ProviderName != "Provider A" {
+		t.Fatalf("provider name = %q, want Provider A", providers[0].ProviderName)
+	}
+	if !providers[0].LastUsedAt.Valid {
+		t.Fatal("LastUsedAt.Valid = false, want true")
+	}
+}
+
+func TestFetchProviderIdentitiesFailsWhenTrustSourceMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "request-log.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE ledger_request_credits (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("seed sqlite: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
+	}
+	source, err := OpenSQLite(path)
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	defer source.Close()
+	_, err = FetchProviderIdentities(context.Background(), source)
+	if err == nil || !strings.Contains(err.Error(), "provider_tokens") {
+		t.Fatalf("FetchProviderIdentities() error = %v, want provider_tokens failure", err)
+	}
+}
+
+func TestMergeRequestCreditsDeduplicatesNaturalKey(t *testing.T) {
+	old := RequestCredit{SQLiteID: 10, RequestID: "req", AttemptN: 0, ProviderID: "p", ProviderCredits: 1}
+	updated := old
+	updated.ProviderCredits = 2
+	rows := mergeRequestCredits([]RequestCredit{old}, []RequestCredit{updated})
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if rows[0].ProviderCredits != 2 {
+		t.Fatalf("ProviderCredits = %d, want updated value 2", rows[0].ProviderCredits)
+	}
+}
+
+func TestSyntheticTokenHashDoesNotExposeProviderID(t *testing.T) {
+	got := syntheticTokenHash("provider-secret")
+	if !strings.HasPrefix(got, "stats-mirror-sha256:") {
+		t.Fatalf("hash = %q, want stats mirror prefix", got)
+	}
+	if strings.Contains(got, "provider-secret") {
+		t.Fatalf("hash exposes provider id: %q", got)
+	}
+	if got != syntheticTokenHash("provider-secret") {
+		t.Fatal("syntheticTokenHash is not deterministic")
+	}
+}
+
+func seedSQLite(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "request-log.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite seed db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`
+CREATE TABLE ledger_request_credits (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL,
+    provider_id TEXT NOT NULL,
+    ts_utc TEXT NOT NULL,
+    created_at_utc TEXT NOT NULL,
+    updated_at_utc TEXT NULL,
+    prompt_tokens INTEGER NULL,
+    completion_tokens INTEGER NULL,
+    estimated_completion_tokens INTEGER NULL,
+    usage_source TEXT NOT NULL,
+    provider_credits INTEGER NOT NULL,
+    fault_flag TEXT NOT NULL,
+    quarantined INTEGER NOT NULL
+);
+CREATE TABLE provider_tokens (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    token_hash TEXT NOT NULL UNIQUE,
+    token_prefix TEXT NOT NULL,
+    provider_id TEXT NOT NULL DEFAULT '',
+    provider_name TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    revoked_at TEXT DEFAULT NULL,
+    last_used_at TEXT DEFAULT NULL
+);
+INSERT INTO ledger_request_credits (
+    request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
+    prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
+    provider_credits, fault_flag, quarantined
+) VALUES
+    ('req-1', 0, 'provider-a', '2026-07-05T08:59:00Z', '2026-07-05T08:59:01Z', NULL,
+     100, 200, NULL, 'provider_reported', 300, 'none', 0),
+    ('req-2', 0, 'provider-a', '2026-07-05T09:01:00Z', '2026-07-05T09:01:01Z', '2026-07-05T09:02:00Z',
+     33, NULL, 44, 'byte_estimated', 0, 'none', 1);
+INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at, last_used_at)
+VALUES ('hash-a', 'hash-a', 'provider-a', 'Provider A', '2026-07-05T08:00:00Z', '2026-07-05T09:00:00Z');
+`); err != nil {
+		t.Fatalf("seed sqlite: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sqlite seed db: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat seed sqlite: %v", err)
+	}
+	return path
+}

--- a/phase4-coordinator/scripts/build-linux.sh
+++ b/phase4-coordinator/scripts/build-linux.sh
@@ -6,6 +6,8 @@
 #                                         prune-tokens / revoke-and-kick)
 #   dist/stats-inventory-sync-linux-amd64
 #                                      — operator hardware inventory sync
+#   dist/stats-billing-mirror-linux-amd64
+#                                      — SQLite→Postgres stats billing mirror
 #
 # Refuses to build with uncommitted changes by default; set FORCE_DIRTY=1
 # to override (the resulting binary's version string will end in "-dirty"
@@ -62,3 +64,7 @@ echo "built $CLI_OUT @ ${VERSION}"
 INVENTORY_OUT="dist/stats-inventory-sync-linux-amd64"
 GOOS=linux GOARCH=amd64 go build -o "$INVENTORY_OUT" ./cmd/stats-inventory-sync
 echo "built $INVENTORY_OUT @ ${VERSION}"
+
+BILLING_MIRROR_OUT="dist/stats-billing-mirror-linux-amd64"
+GOOS=linux GOARCH=amd64 go build -o "$BILLING_MIRROR_OUT" ./cmd/stats-billing-mirror
+echo "built $BILLING_MIRROR_OUT @ ${VERSION}"


### PR DESCRIPTION
## Summary
- Add `stats-billing-mirror`, a oneshot/timer sidecar that mirrors SQLite `ledger_request_credits` into the Postgres source tables consumed by SPEC-017 stats rollups.
- Keep coordinator request paths untouched: the mirror reads SQLite read-only, batches new rows, replays a bounded tail overlap, and sweeps historical primary-key ranges so late row changes are eventually repaired without unindexed source scans.
- Add bootstrap SQL, systemd units, deploy wiring, build wiring, and offline deploy tests. Runtime writes go through constrained security-definer functions; the deployed service runs as `macprovider-stats` with narrow SQLite file ACLs.

## Validation
- `go test ./...`
- `go vet ./cmd/stats-billing-mirror ./internal/stats/billingmirror`
- `dist/test/check_stats_billing_mirror_deploy_test.sh`
- `bash dist/test/check_stats_inventory_deploy_test.sh`
- `bash -n dist/deploy-pearl-vps.sh scripts/build-linux.sh`
- `git diff --check`
- `GOOS=linux GOARCH=amd64 go build -o /tmp/stats-billing-mirror-linux-amd64 ./cmd/stats-billing-mirror`
- Three audit lanes rerun to 0 C/H/M: code correctness, security, architecture/performance.

## Operational Notes
- Before enabling the timer, create `stats_billing_mirror_writer` with an operator-generated password, apply `dist/stats-billing-mirror-bootstrap.sql`, then install `/etc/macprovider-stats/stats-billing-mirror.env` as `root:root 0600`.
- The deploy script installs the sidecar automatically but enables the timer only if the env file exists and `macprovider-stats` can read `/var/lib/macprovider/request-log.sqlite`.
