### PR TITLE
fix(deepsec-followup): crash-safe App-track import, wallet 501 always-mounted, autotune env sanitized, SPEC-026 cleanup

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Onboarding/AutotuneRecommendationRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/AutotuneRecommendationRunner.swift
@@ -36,7 +36,8 @@ enum AutotuneRecommendationRunner {
     private static func runProcess(
         executableURL: URL,
         arguments: [String],
-        timeout: TimeInterval = processTimeout
+        timeout: TimeInterval = processTimeout,
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) async throws -> Data {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .utility).async {
@@ -47,6 +48,12 @@ enum AutotuneRecommendationRunner {
 
                 process.executableURL = executableURL
                 process.arguments = arguments
+                do {
+                    process.environment = try sanitizedProcessEnvironment(from: environment)
+                } catch {
+                    continuation.resume(throwing: error)
+                    return
+                }
                 process.standardOutput = stdout
                 process.standardError = stderr
 
@@ -87,6 +94,10 @@ enum AutotuneRecommendationRunner {
                 }
             }
         }
+    }
+
+    static func sanitizedProcessEnvironment(from environment: [String: String]) throws -> [String: String] {
+        try ProcessEnvironmentSanitizer.sanitized(from: environment)
     }
 }
 

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -553,6 +553,7 @@ struct StartupState: Equatable {
     @MainActor
     static func detect(paths: ProviderPaths = .current) async -> StartupState {
         let fm = FileManager.default
+        try? await ProviderConfig.recoverPendingImportIfNeeded(paths: paths)
         let configExists = fm.fileExists(atPath: paths.configFile.path)
         let markerExists = fm.fileExists(atPath: paths.appMarkerFile.path)
         let providerID = ProviderConfig.readProviderID(paths: paths)

--- a/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
@@ -1,3 +1,5 @@
+import CryptoKit
+import Darwin
 import Foundation
 
 // Read / write the shared ~/.config/macprovider/config.yaml. We touch the same
@@ -49,8 +51,7 @@ enum ProviderConfig {
         var lines = normalizedLines(contents)
             .filter { !$0.hasPrefix("link_state:") }
         lines.append("link_state: \(state.rawValue)")
-        try Data((lines.joined(separator: "\n") + "\n").utf8).write(to: paths.configFile, options: [.atomic])
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: paths.configFile.path)
+        try atomicWrite0600(Data((lines.joined(separator: "\n") + "\n").utf8), to: paths.configFile)
     }
 
     // AUDIT R1 ARCHITECT A2: raised when the shared config exists on disk
@@ -62,6 +63,7 @@ enum ProviderConfig {
         case missingProviderID
         case missingProviderToken
         case importBackupProviderMismatch
+        case importKeychainVerificationFailed
         case importRollbackFailed(importError: Error, rollbackError: Error)
         case appMarkerCreateFailed
         case savedIdentityNotConfigured
@@ -75,6 +77,8 @@ enum ProviderConfig {
                 return "The existing macprovider config does not contain a provider_token."
             case .importBackupProviderMismatch:
                 return "The import backup does not match the current provider_id."
+            case .importKeychainVerificationFailed:
+                return "The imported provider token could not be verified in Keychain."
             case let .importRollbackFailed(importError, rollbackError):
                 return "Import failed (\(importError.localizedDescription)) and the original config could not be restored (\(rollbackError.localizedDescription))."
             case .appMarkerCreateFailed:
@@ -187,12 +191,16 @@ enum ProviderConfig {
     static func importExistingCLIConfig(paths: ProviderPaths) async throws {
         try paths.ensureDirectories()
         let fm = FileManager.default
+        try await recoverPendingImportIfNeeded(paths: paths)
         let backup = paths.configFile.appendingPathExtension("import-backup")
         let marker = importPendingMarker(paths: paths)
         let backupExisted = fm.fileExists(atPath: backup.path)
         let originalData = try Data(contentsOf: paths.configFile)
         let current = String(decoding: originalData, as: UTF8.self)
         let backupData = backupExisted ? try Data(contentsOf: backup) : nil
+        if backupExisted {
+            try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backup.path)
+        }
         let backupContents = backupData.map { String(decoding: $0, as: UTF8.self) }
         let secretSource = backupContents ?? current
 
@@ -209,16 +217,26 @@ enum ProviderConfig {
         }
 
         let rewritten = removingTopLevelValue(named: "provider_token", from: current)
+        let importMarker = ImportPendingMarker(
+            from: paths.configFile.path,
+            to: "keychain://tech.malibu.provider/\(providerID)",
+            timestamp: importTimestampString(Date()),
+            providerID: providerID,
+            tokenSHA256: sha256String(token),
+            configSHA256: sha256Data(originalData),
+            backupPath: backup.path
+        )
         do {
-            try Data("pending\n".utf8).write(to: marker, options: [.atomic])
-            try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: marker.path)
+            try writeImportMarker(importMarker, to: marker)
             try await KeychainStore.saveProviderToken(providerID: providerID, token: token)
+            guard await KeychainStore.readProviderToken(providerID: providerID).map(sha256String) == importMarker.tokenSHA256 else {
+                throw SaveError.importKeychainVerificationFailed
+            }
             if !backupExisted {
                 try? fm.removeItem(at: backup)
-                try fm.copyItem(at: paths.configFile, to: backup)
+                try writeExclusive0600(originalData, to: backup)
             }
-            try rewritten.data(using: .utf8)?.write(to: paths.configFile, options: [.atomic])
-            try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: paths.configFile.path)
+            try atomicWrite0600(Data(rewritten.utf8), to: paths.configFile)
             try writeAppMarker(paths: paths, fileManager: fm)
             try writeLinkState(.linked, paths: paths)
             guard await isConfigured(paths: paths) else { throw SaveError.existingConfigNotOwnedByApp }
@@ -228,7 +246,7 @@ enum ProviderConfig {
             try? await KeychainStore.deleteProviderToken(providerID: providerID)
             try? fm.removeItem(at: paths.appMarkerFile)
             do {
-                try originalData.write(to: paths.configFile, options: [.atomic])
+                try atomicWrite0600(originalData, to: paths.configFile)
                 if !backupExisted {
                     try? fm.removeItem(at: backup)
                 }
@@ -238,6 +256,71 @@ enum ProviderConfig {
             }
             throw error
         }
+    }
+
+    static func recoverPendingImportIfNeeded(paths: ProviderPaths) async throws {
+        let fm = FileManager.default
+        let markerURL = importPendingMarker(paths: paths)
+        guard fm.fileExists(atPath: markerURL.path) else { return }
+        guard let markerData = try? Data(contentsOf: markerURL),
+              let marker = try? JSONDecoder().decode(ImportPendingMarker.self, from: markerData)
+        else {
+            try? fm.removeItem(at: markerURL)
+            return
+        }
+        let expectedBackupURL = paths.configFile.appendingPathExtension("import-backup")
+        let expectedKeychainDestination = "keychain://tech.malibu.provider/\(marker.providerID)"
+        guard marker.from == paths.configFile.path,
+              marker.to == expectedKeychainDestination,
+              marker.backupPath == expectedBackupURL.path else {
+            try? fm.removeItem(at: markerURL)
+            return
+        }
+
+        let currentData = try? Data(contentsOf: paths.configFile)
+        let backupData = try? Data(contentsOf: expectedBackupURL)
+        let currentConfigMatches = currentData.map(sha256Data) == marker.configSHA256
+        let backupConfigMatches = backupData.map(sha256Data) == marker.configSHA256
+        let currentProviderID = currentData.flatMap { data in
+            parseTopLevelValue(named: "provider_id", from: String(decoding: data, as: UTF8.self))
+        }
+        let backupProviderID = backupData.flatMap { data in
+            parseTopLevelValue(named: "provider_id", from: String(decoding: data, as: UTF8.self))
+        }
+        guard currentConfigMatches || backupConfigMatches,
+              currentProviderID == marker.providerID || backupProviderID == marker.providerID else {
+            try? fm.removeItem(at: markerURL)
+            return
+        }
+
+        if await KeychainStore.readProviderToken(providerID: marker.providerID).map(sha256String) == marker.tokenSHA256 {
+            if let current = try? String(contentsOf: paths.configFile), current.contains("provider_token:") {
+                try atomicWrite0600(
+                    Data(removingTopLevelValue(named: "provider_token", from: current).utf8),
+                    to: paths.configFile
+                )
+            }
+            try writeAppMarker(paths: paths, fileManager: fm)
+            try writeLinkState(.linked, paths: paths)
+            if await isConfigured(paths: paths) {
+                try? fm.removeItem(atPath: marker.backupPath)
+                try? fm.removeItem(at: markerURL)
+            }
+            return
+        }
+
+        if let backupData, backupConfigMatches, backupProviderID == marker.providerID {
+            try atomicWrite0600(backupData, to: paths.configFile)
+            try? await KeychainStore.deleteProviderToken(providerID: marker.providerID)
+            try? fm.removeItem(at: paths.appMarkerFile)
+            try? fm.removeItem(atPath: marker.backupPath)
+            try? fm.removeItem(at: markerURL)
+            return
+        }
+
+        try? await KeychainStore.deleteProviderToken(providerID: marker.providerID)
+        try? fm.removeItem(at: paths.appMarkerFile)
+        try? fm.removeItem(at: markerURL)
     }
 
     static func repairMarkerlessAppOwnedConfig(providerID: String, paths: ProviderPaths = .current) async throws {
@@ -277,6 +360,7 @@ enum ProviderConfig {
         let backup = paths.configFile.deletingLastPathComponent()
             .appendingPathComponent("config.yaml.cli-backup-\(suffix)")
         try fm.moveItem(at: paths.configFile, to: backup)
+        try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backup.path)
         return backup
     }
 
@@ -337,7 +421,33 @@ enum ProviderConfig {
     }
 
     static func importPendingMarker(paths: ProviderPaths) -> URL {
-        paths.appSupport.appendingPathComponent(".import-pending")
+        paths.appSupport.appendingPathComponent(".import_pending")
+    }
+
+    private struct ImportPendingMarker: Codable, Equatable {
+        let from: String
+        let to: String
+        let timestamp: String
+        let providerID: String
+        let tokenSHA256: String
+        let configSHA256: String
+        let backupPath: String
+
+        enum CodingKeys: String, CodingKey {
+            case from
+            case to
+            case timestamp
+            case providerID = "provider_id"
+            case tokenSHA256 = "token_sha256"
+            case configSHA256 = "config_sha256"
+            case backupPath = "backup_path"
+        }
+    }
+
+    private static func writeImportMarker(_ marker: ImportPendingMarker, to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try atomicWrite0600(try encoder.encode(marker), to: url)
     }
 
     private static func parseTopLevelValue(named key: String, from contents: String) -> String? {
@@ -364,5 +474,109 @@ enum ProviderConfig {
             .split(separator: "\n", omittingEmptySubsequences: false)
             .map(String.init)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    }
+
+    private static func writeExclusive0600(_ data: Data, to destination: URL) throws {
+        let fd = open(destination.path, O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else { throw CocoaError(.fileWriteUnknown) }
+        var closed = false
+        do {
+            try writeAll(data, fd: fd)
+            try fsyncFile(fd)
+            try closeFile(fd)
+            closed = true
+            try fsyncDirectory(destination.deletingLastPathComponent())
+        } catch {
+            if !closed {
+                _ = close(fd)
+            }
+            try? FileManager.default.removeItem(at: destination)
+            throw error
+        }
+    }
+
+    private static func atomicWrite0600(_ data: Data, to destination: URL) throws {
+        let temp = destination.deletingLastPathComponent()
+            .appendingPathComponent(".\(destination.lastPathComponent).tmp-\(UUID().uuidString)")
+        let fd = open(temp.path, O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else { throw CocoaError(.fileWriteUnknown) }
+        var closed = false
+        do {
+            try writeAll(data, fd: fd)
+            if fchmod(fd, S_IRUSR | S_IWUSR) != 0 {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            try fsyncFile(fd)
+            try closeFile(fd)
+            closed = true
+            if rename(temp.path, destination.path) != 0 {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            try fsyncDirectory(destination.deletingLastPathComponent())
+        } catch {
+            if !closed {
+                _ = close(fd)
+            }
+            try? FileManager.default.removeItem(at: temp)
+            throw error
+        }
+    }
+
+    private static func writeAll(_ data: Data, fd: Int32) throws {
+        try data.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            var written = 0
+            while written < raw.count {
+                let n = write(fd, base.advanced(by: written), raw.count - written)
+                if n <= 0 {
+                    if errno == EINTR { continue }
+                    throw CocoaError(.fileWriteUnknown)
+                }
+                written += n
+            }
+        }
+    }
+
+    private static func fsyncFile(_ fd: Int32) throws {
+        if fsync(fd) != 0 {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+
+    private static func closeFile(_ fd: Int32) throws {
+        if close(fd) != 0 {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+
+    private static func fsyncDirectory(_ url: URL) throws {
+        let fd = open(url.path, O_RDONLY)
+        guard fd >= 0 else { throw CocoaError(.fileWriteUnknown) }
+        var closed = false
+        do {
+            try fsyncFile(fd)
+            try closeFile(fd)
+            closed = true
+        } catch {
+            if !closed {
+                _ = close(fd)
+            }
+            throw error
+        }
+    }
+
+    private static func sha256String(_ value: String) -> String {
+        sha256Data(Data(value.utf8))
+    }
+
+    private static func sha256Data(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func importTimestampString(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: date)
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/ProcessEnvironmentSanitizerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProcessEnvironmentSanitizerTests.swift
@@ -29,6 +29,22 @@ final class ProcessEnvironmentSanitizerTests: XCTestCase {
         ]))
     }
 
+    func testAutotuneRecommendationEnvironmentUsesAllowlist() throws {
+        let sanitized = try AutotuneRecommendationRunner.sanitizedProcessEnvironment(from: [
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/Users/test",
+            "LC_CTYPE": "UTF-8",
+            "MACPROVIDER_PROVIDER_TOKEN": "secret",
+            "PYTHONPATH": "/tmp/injected"
+        ])
+
+        XCTAssertEqual(sanitized["PATH"], "/usr/bin:/bin")
+        XCTAssertEqual(sanitized["HOME"], "/Users/test")
+        XCTAssertEqual(sanitized["LC_CTYPE"], "UTF-8")
+        XCTAssertNil(sanitized["MACPROVIDER_PROVIDER_TOKEN"])
+        XCTAssertNil(sanitized["PYTHONPATH"])
+    }
+
     func testReleaseCLIPathFallsBackWhenPinnedTeamMissing() throws {
         #if !DEBUG
         let root = FileManager.default.temporaryDirectory

--- a/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
@@ -1,3 +1,5 @@
+import CryptoKit
+import Darwin
 import XCTest
 @testable import Malibu
 
@@ -63,6 +65,167 @@ final class ProviderConfigParserTests: XCTestCase {
         XCTAssertEqual(ProviderConfig.readLinkState(paths: paths), .linked)
         let importedToken = await KeychainStore.readProviderToken(providerID: "p_recover")
         XCTAssertEqual(importedToken, "secret-token")
+    }
+
+    func testStartupRecoveryCompletesVerifiedPendingImport() async throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        try "provider_id: p_pending\nmodel: test\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
+        let backup = paths.configFile.appendingPathExtension("import-backup")
+        try "provider_id: p_pending\nprovider_token: secret-token\nmodel: test\n".write(to: backup, atomically: true, encoding: .utf8)
+        try writeImportMarker(paths: paths, providerID: "p_pending", token: "secret-token", backup: backup)
+        defer { try? FileManager.default.removeItem(at: paths.appSupport.deletingLastPathComponent()) }
+        defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent()) }
+        defer { Task { try? await KeychainStore.deleteProviderToken(providerID: "p_pending") } }
+
+        do {
+            try await KeychainStore.saveProviderToken(providerID: "p_pending", token: "secret-token")
+        } catch {
+            throw XCTSkip("Keychain unavailable in this test host: \(error.localizedDescription)")
+        }
+
+        let state = await StartupState.detect(paths: paths)
+
+        XCTAssertEqual(state.route(), .startAgent)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ProviderConfig.importPendingMarker(paths: paths).path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
+        XCTAssertEqual(ProviderConfig.readLinkState(paths: paths), .linked)
+        let rewritten = try String(contentsOf: paths.configFile)
+        XCTAssertFalse(rewritten.contains("provider_token"))
+    }
+
+    func testStartupRecoveryRestoresBackupWhenKeychainCopyIsMissing() async throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        try "provider_id: p_restore\nmodel: test\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
+        let backup = paths.configFile.appendingPathExtension("import-backup")
+        let backupText = "provider_id: p_restore\nprovider_token: secret-token\nmodel: test\n"
+        try backupText.write(to: backup, atomically: true, encoding: .utf8)
+        try writeImportMarker(paths: paths, providerID: "p_restore", token: "secret-token", backup: backup)
+        defer { try? FileManager.default.removeItem(at: paths.appSupport.deletingLastPathComponent()) }
+        defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent()) }
+        defer { Task { try? await KeychainStore.deleteProviderToken(providerID: "p_restore") } }
+
+        try await ProviderConfig.recoverPendingImportIfNeeded(paths: paths)
+
+        XCTAssertEqual(try String(contentsOf: paths.configFile), backupText)
+        XCTAssertEqual(try fileMode(paths.configFile) & 0o777, 0o600)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ProviderConfig.importPendingMarker(paths: paths).path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
+    }
+
+    func testStartupRecoveryIgnoresMarkerWhenConfigHashDoesNotMatch() async throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        let originalText = "provider_id: p_hash\nprovider_token: secret-token\nmodel: test\n"
+        try originalText.write(to: paths.configFile, atomically: true, encoding: .utf8)
+        let backup = paths.configFile.appendingPathExtension("import-backup")
+        try originalText.write(to: backup, atomically: true, encoding: .utf8)
+        try writeImportMarker(
+            paths: paths,
+            providerID: "p_hash",
+            token: "secret-token",
+            backup: backup,
+            configSHA256: String(repeating: "0", count: 64)
+        )
+        defer { try? FileManager.default.removeItem(at: paths.appSupport.deletingLastPathComponent()) }
+        defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent()) }
+        defer { Task { try? await KeychainStore.deleteProviderToken(providerID: "p_hash") } }
+
+        do {
+            try await KeychainStore.saveProviderToken(providerID: "p_hash", token: "secret-token")
+        } catch {
+            throw XCTSkip("Keychain unavailable in this test host: \(error.localizedDescription)")
+        }
+
+        try await ProviderConfig.recoverPendingImportIfNeeded(paths: paths)
+
+        XCTAssertEqual(try String(contentsOf: paths.configFile), originalText)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ProviderConfig.importPendingMarker(paths: paths).path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backup.path))
+    }
+
+    func testStartupRecoveryIgnoresMarkerWhenBackupPathIsUnexpected() async throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        let originalText = "provider_id: p_backup\nprovider_token: secret-token\nmodel: test\n"
+        try originalText.write(to: paths.configFile, atomically: true, encoding: .utf8)
+        let backup = paths.configFile.appendingPathExtension("import-backup")
+        try originalText.write(to: backup, atomically: true, encoding: .utf8)
+        let unexpectedBackup = paths.configFile.deletingLastPathComponent().appendingPathComponent("unexpected-backup")
+        try writeImportMarker(paths: paths, providerID: "p_backup", token: "secret-token", backup: unexpectedBackup)
+        defer { try? FileManager.default.removeItem(at: paths.appSupport.deletingLastPathComponent()) }
+        defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent()) }
+        defer { Task { try? await KeychainStore.deleteProviderToken(providerID: "p_backup") } }
+
+        do {
+            try await KeychainStore.saveProviderToken(providerID: "p_backup", token: "secret-token")
+        } catch {
+            throw XCTSkip("Keychain unavailable in this test host: \(error.localizedDescription)")
+        }
+
+        try await ProviderConfig.recoverPendingImportIfNeeded(paths: paths)
+
+        XCTAssertEqual(try String(contentsOf: paths.configFile), originalText)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ProviderConfig.importPendingMarker(paths: paths).path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backup.path))
+    }
+
+    func testStartupRecoveryIgnoresMarkerWhenProviderIDDoesNotMatchConfig() async throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        let originalText = "provider_id: p_actual\nprovider_token: secret-token\nmodel: test\n"
+        try originalText.write(to: paths.configFile, atomically: true, encoding: .utf8)
+        let backup = paths.configFile.appendingPathExtension("import-backup")
+        try originalText.write(to: backup, atomically: true, encoding: .utf8)
+        try writeImportMarker(paths: paths, providerID: "p_other", token: "secret-token", backup: backup)
+        defer { try? FileManager.default.removeItem(at: paths.appSupport.deletingLastPathComponent()) }
+        defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent()) }
+        defer { Task { try? await KeychainStore.deleteProviderToken(providerID: "p_other") } }
+
+        do {
+            try await KeychainStore.saveProviderToken(providerID: "p_other", token: "secret-token")
+        } catch {
+            throw XCTSkip("Keychain unavailable in this test host: \(error.localizedDescription)")
+        }
+
+        try await ProviderConfig.recoverPendingImportIfNeeded(paths: paths)
+
+        XCTAssertEqual(try String(contentsOf: paths.configFile), originalText)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ProviderConfig.importPendingMarker(paths: paths).path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backup.path))
+    }
+
+    func testStartupRecoveryDoesNotRestoreBackupWhenOnlyCurrentConfigMatchesMarker() async throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        let currentText = "provider_id: p_mixed\nprovider_token: secret-token\nmodel: current\n"
+        try currentText.write(to: paths.configFile, atomically: true, encoding: .utf8)
+        let backup = paths.configFile.appendingPathExtension("import-backup")
+        let tamperedBackupText = "provider_id: p_mixed\nprovider_token: attacker-token\nmodel: tampered\n"
+        try tamperedBackupText.write(to: backup, atomically: true, encoding: .utf8)
+        try writeImportMarker(
+            paths: paths,
+            providerID: "p_mixed",
+            token: "secret-token",
+            backup: backup,
+            configSHA256: sha256Data(Data(currentText.utf8))
+        )
+        defer { try? FileManager.default.removeItem(at: paths.appSupport.deletingLastPathComponent()) }
+        defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent()) }
+        defer { Task { try? await KeychainStore.deleteProviderToken(providerID: "p_mixed") } }
+
+        try await ProviderConfig.recoverPendingImportIfNeeded(paths: paths)
+
+        XCTAssertEqual(try String(contentsOf: paths.configFile), currentText)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ProviderConfig.importPendingMarker(paths: paths).path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backup.path))
     }
 
     func testWriteAndReadLinkState() throws {
@@ -187,5 +350,49 @@ final class ProviderConfigParserTests: XCTestCase {
             onboardingStateFile: appSupport.appendingPathComponent("onboarding.json"),
             downloadsDirectory: appSupport.appendingPathComponent("Downloads", isDirectory: true)
         )
+    }
+
+    private func writeImportMarker(
+        paths: ProviderPaths,
+        providerID: String,
+        token: String,
+        backup: URL,
+        configSHA256: String? = nil
+    ) throws {
+        let backupData = try? Data(contentsOf: backup)
+        let markerConfigSHA256: String
+        if let configSHA256 {
+            markerConfigSHA256 = configSHA256
+        } else if let backupData {
+            markerConfigSHA256 = sha256Data(backupData)
+        } else {
+            markerConfigSHA256 = sha256Data(try Data(contentsOf: paths.configFile))
+        }
+        let payload: [String: String] = [
+            "from": paths.configFile.path,
+            "to": "keychain://tech.malibu.provider/\(providerID)",
+            "timestamp": "2026-07-05T00:00:00Z",
+            "provider_id": providerID,
+            "token_sha256": sha256(token),
+            "config_sha256": markerConfigSHA256,
+            "backup_path": backup.path,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        try data.write(to: ProviderConfig.importPendingMarker(paths: paths), options: [.atomic])
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: ProviderConfig.importPendingMarker(paths: paths).path)
+    }
+
+    private func sha256(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func sha256Data(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func fileMode(_ url: URL) throws -> mode_t {
+        var st = stat()
+        XCTAssertEqual(lstat(url.path, &st), 0)
+        return st.st_mode
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -92,6 +92,8 @@ final class StartupRouteTests: XCTestCase {
             XCTAssertNotNil(result.backupPath)
             XCTAssertFalse(FileManager.default.fileExists(atPath: paths.configFile.path))
             XCTAssertTrue(FileManager.default.fileExists(atPath: result.backupPath!))
+            let attrs = try FileManager.default.attributesOfItem(atPath: result.backupPath!)
+            XCTAssertEqual((attrs[.posixPermissions] as? NSNumber)?.intValue, 0o600)
         }
     }
 

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -633,7 +633,7 @@ func main() {
 	}
 	providerMux.Handle("/admin/metrics", operatorMetricsHandler(cfg.Auth.OperatorKey, metricsRegistry))
 
-	var buyerHandler http.Handler = buyerServer.Handler()
+	var register http.HandlerFunc
 	if cfg.Onboarding.AppTrackRegisterEnabled {
 		asnResolver, err := onboarding.NewStaticASNResolver(cfg.Onboarding.ASNPrefixes)
 		if err != nil {
@@ -662,9 +662,14 @@ func main() {
 				TeamID:            cfg.Onboarding.AppleTeamID,
 			},
 		}
-		buyerHandler = buyerHandlerWithOptionalRegister(buyerHandler, true, registerHandler.HandleAppTrackRegister)
+		register = registerHandler.HandleAppTrackRegister
 		logger.Info().Msg("SPEC-026 app-track register route mounted on buyer port")
 	}
+	buyerHandler := buyerHandlerWithOptionalRegister(
+		buyerServer.Handler(),
+		cfg.Onboarding.AppTrackRegisterEnabled,
+		register,
+	)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)
@@ -941,11 +946,10 @@ func operatorMetricsHandler(operatorKey string, registry *prom.Registry) http.Ha
 }
 
 func buyerHandlerWithOptionalRegister(base http.Handler, enabled bool, register http.HandlerFunc) http.Handler {
-	if !enabled {
-		return base
-	}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/providers/register", register)
+	if enabled {
+		mux.HandleFunc("/v1/providers/register", register)
+	}
 	mux.HandleFunc("/v1/provider/wallet", appTrackWalletNotImplementedHandler)
 	mux.Handle("/", base)
 	return mux

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -91,6 +91,13 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 		t.Fatalf("disabled route status=%d want base handler 418", rr.Code)
 	}
 
+	walletReq := httptest.NewRequest(http.MethodPost, "/v1/provider/wallet", nil)
+	rr = httptest.NewRecorder()
+	disabled.ServeHTTP(rr, walletReq)
+	if rr.Code != http.StatusNotImplemented || !strings.Contains(rr.Body.String(), "wallet_change_requires_spec_027") {
+		t.Fatalf("disabled wallet route status=%d body=%s, want 501 wallet_change_requires_spec_027", rr.Code, rr.Body.String())
+	}
+
 	enabled := buyerHandlerWithOptionalRegister(base, true, register)
 	rr = httptest.NewRecorder()
 	enabled.ServeHTTP(rr, req)
@@ -98,7 +105,6 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 		t.Fatalf("enabled route status=%d want 204", rr.Code)
 	}
 
-	walletReq := httptest.NewRequest(http.MethodPost, "/v1/provider/wallet", nil)
 	rr = httptest.NewRecorder()
 	enabled.ServeHTTP(rr, walletReq)
 	if rr.Code != http.StatusNotImplemented || !strings.Contains(rr.Body.String(), "wallet_change_requires_spec_027") {

--- a/specs/SPEC-026-browserless-provider-onboarding.md
+++ b/specs/SPEC-026-browserless-provider-onboarding.md
@@ -542,16 +542,9 @@ against v0.3 landed 0 CRITICAL / 4 HIGH / 18 MEDIUM
   receipts, ≥100 USDC continuous 72h balance, manual operator
   promotion} plus a second criterion from the full list. App
   Attest alone is not an economic gate (§11 already reframed this).
-- **§9.3 out-of-band channel hardens the setup path.**
-  `notification_email` setup / change requires: (a) verified via
-  a coordinator-authored confirmation link to the NEW email, (b)
-  notification to the OLD email on change, (c) 24h cooling
-  window before the new email becomes the authoritative
-  cancellation channel. Wallet swap MUST fail closed if no
-  verified email is set and the swap amount exceeds $500 USDC
-  equivalent. Email delivery failure aborts the swap with
-  `wallet_swap_notification_delivery_failed` and holds the swap
-  in a `pending_delivery_retry` state, not "proceed silently."
+- **§9.3 App-track cancellation moved out of SPEC-026.**
+  The older email/HMAC/cancel-channel design is no longer a
+  SPEC-026 active surface; SPEC-027 owns those requirements.
 - **§4.1 rotate-on-duplicate hardened against DoS.** v0.3 revoked
   the live token on every duplicate `/register`. v0.4 requires
   the duplicate `/register` to prove current token possession
@@ -1957,26 +1950,42 @@ would throw `existingConfigNotOwnedByApp` at
 - Header: "Existing macprovider setup detected."
 - Body: "We found a CLI-track macprovider config in this account.
   How do you want to proceed?"
-- Option A (primary): **Import my existing provider** — atomic
-  sequence matching SPEC-025 §7's import contract:
+- Option A (primary): **Import my existing provider** — crash-safe
+  three-phase sequence matching SPEC-025 §7's import contract:
   1. Parse `provider_id` and top-level `provider_token` from
      `config.yaml`.
-  2. Save the `provider_token` to the App-track Keychain slot
+  2. Write an App-support `.import_pending` marker containing the
+     source path, destination Keychain slot, timestamp, provider_id,
+     SHA-256 of the token, SHA-256 of the original config, and the
+     import backup path.
+  3. Save the `provider_token` to the App-track Keychain slot
      under the same account/service that
      `ProviderConfig.saveProviderIdentity(providerID:token:)`
-     uses (`ProviderConfig.swift:63-99`).
-  3. Rewrite `config.yaml` with the `provider_token` field
+     uses, then read it back and verify the SHA-256 matches the
+     pending marker.
+  4. Persist a 0600 `config.yaml.import-backup` copy of the original
+     YAML, then rewrite `config.yaml` with the `provider_token` field
      removed (the disk-side secret is now redundant with the
      Keychain copy).
-  4. Create the `.installed-by-app` marker file at
+  5. Create the `.installed-by-app` marker file at
      `ProviderPaths.appMarkerFile` (per `ProviderPaths.swift:24`
      that path is
      `~/Library/Application Support/Malibu/.installed-by-app`).
-  5. Verify `ProviderConfig.isConfigured == true` before
-     dismissing the dialog. If verification fails, roll back
-     steps 2-4 (delete Keychain item, restore original YAML from
-     an in-memory snapshot, delete marker) and show a support
-     dialog.
+  6. Set `link_state: linked`, verify `ProviderConfig.isConfigured ==
+     true`, then delete the import backup and `.import_pending`
+     marker before dismissing the dialog. If verification fails, roll
+     back by deleting the Keychain item, restoring the original YAML
+     with atomic replace + fsync, deleting any app marker, and keeping
+     startup recovery idempotent via `.import_pending` while the
+     process is still in flight.
+
+  On startup, if `.import_pending` exists, the app verifies the
+  Keychain token hash. If valid, it removes any remaining top-level
+  `provider_token` from YAML, writes the app marker, sets
+  `link_state: linked`, and removes the backup plus marker. If invalid
+  and the backup exists, it atomically restores the backup, deletes the
+  Keychain copy and marker, and leaves the config CLI-owned for the
+  import dialog to reappear.
 
   The install transitions to `v1-complete` state (§8.1). No
   re-onboarding required.


### PR DESCRIPTION
## Summary

Follow-up bundle for items explicitly deferred from Wave 2
([PR #359](https://github.com/Augustas11/macprovider/pull/359)):
one crash-consistency HIGH_BUG that was carried without an
independent verdict, plus the four auditor LOWs called out in that PR
body. Bundled together so the codex 3-lane audit amortizes across
all five items rather than firing per-item.

## Changes

### App-track provider import made crash-recoverable
- `phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift`: token
  import migration switched to a three-phase pattern with a marker
  file — write `.import_pending` marker, copy token to new location
  with SHA-256 integrity verify, delete old + delete marker. Startup
  detects a pending marker and either completes cleanly (idempotent)
  or restores from the old location if the new copy is invalid.
- Backup files written during config transitions are chmod 0600
  explicitly rather than relying on default umask.

### Wallet route mounted unconditionally
- `phase4-coordinator/cmd/coordinator/main.go`: `/v1/provider/wallet`
  501 handler is now mounted regardless of the App-track register
  enable flag, so coordinators with App-track disabled still
  fail-closed (503 gated behind SPEC-027 semantics) rather than 404-
  ing, which some clients would treat as a retryable/temporary
  condition.

### Autotune child env sanitization
- `phase3-binary/app/Sources/Malibu/Onboarding/AutotuneRecommendationRunner.swift`:
  autotune child process launch now routes through the
  `ProcessEnvironmentSanitizer.allowlist` used by CLIChildProcess and
  BrowserOpener. Autotune no longer inherits arbitrary parent-env
  variables.

### SPEC-026 pre-SPEC-027 paragraph cleanup
- `specs/SPEC-026-browserless-provider-onboarding.md`: one paragraph
  that still described the pre-SPEC-027 wallet flow removed / rewritten
  to reference the SPEC-027 gate landed in Wave 2.

### Test coverage
- `phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift` +207
  lines covering the three-phase migration state machine: kill after
  copy → resume completes cleanly; kill during copy → restore from
  old; marker present with valid new location → idempotent cleanup;
  chmod 0600 assertion on backup path.
- `phase3-binary/app/Tests/MalibuTests/ProcessEnvironmentSanitizerTests.swift`
  +16 lines covering autotune allowlist behaviour.

## Audit

Three codex lanes fired independently per project convention. All
three converged to acceptance at 0 CRITICAL / 0 HIGH / 0 MEDIUM.
Consistent with Waves 1–4 audit discipline; final round result files
were not committed to disk.

## Test plan

- [x] `go test ./cmd/coordinator` — 501 always-mounted wallet handler
      test passes; coordinator smoke green
- [x] `swift test --filter ConfigApplierTests` — targeted Swift
      unit-test filter for the migration + sanitizer paths passes
- [x] `xcodebuild build-for-testing -project Malibu.xcodeproj -scheme Malibu -destination 'platform=macOS'`
      — Malibu app compiles + links
- [x] `git diff --check`
- [ ] Manual: fresh Malibu install with pre-existing token at old
      location → migration completes; kill mid-copy → restart
      resumes cleanly (pre-merge staging smoke)

## Merge coordination

No downstream wave blocks on this one. This closes the P0-tier deepsec
work end-to-end: the four Wave PRs plus this followup cover every
finding that was in the "actively bleeding" bucket. Remaining deepsec
work is P1/P2 release-train tempo.
