### PR TITLE
Audit SPEC-028 speculative decoding v0.2

### DIFF
--- a/.omc/logs/spec-decode-open-questions-2026-07.md
+++ b/.omc/logs/spec-decode-open-questions-2026-07.md
@@ -1,0 +1,14 @@
+# SPEC-028 Open Questions
+
+**Date:** 2026-07-05
+**Branch:** `research/spec-decode-serve`
+
+These are the human-blocking items before SPEC-028 can move toward LOCK:
+
+1. **gpt-oss draft candidate:** Confirm whether a smaller same-tokenizer, license-clean draft exists for `mlx-community/gpt-oss-20b-MXFP4-Q8`, or waive gpt-oss from v0.1 compatibility requirements.
+2. **Greedy-only gate:** Decide whether v0.1 may restrict spec decode to `temperature=0.0`, with stochastic requests falling back to the existing path.
+3. **SPEC-011 amendment boundary:** Decide whether draft model hash must appear in heartbeat, or whether `spec_decode_draft_model_id` plus acceptance counters is sufficient.
+4. **Model-card approval:** Confirm Qwen and Llama draft-target candidate pairs are acceptable for the static catalog under their respective licenses.
+5. **LOCK canary threshold:** Approve the first canary threshold: Qwen2.5-Coder 7B + 1.5B draft on air5, `code_completion`, median generation throughput >= 24 tok/s and acceptance rate >= 0.35.
+
+Self-review result: no code changes proposed; SPEC-015 usage remains unchanged; buyer API remains unchanged; coordinator routing remains unchanged. Main unresolved risk is compatibility evidence for gpt-oss and Qwen3 behavior under current upstream MLX-LM reports.

--- a/docs/research/spec-decode-integration-2026-07.md
+++ b/docs/research/spec-decode-integration-2026-07.md
@@ -1,0 +1,260 @@
+# MLX Speculative Decoding Integration Research
+
+**Date:** 2026-07-05
+**Branch:** `research/spec-decode-serve`
+**Requested by:** `specs/RESEARCH_SPEC_DECODE_PROMPT.md` from `/Users/augstar/macprovider-poc-spec-decode-prompt`
+
+## Summary
+
+MacProvider's current provider runtime calls `mlx-swift-lm` directly from Swift. It does not shell out to `mlx_lm.server` or `mlx_lm.generate`. The integration point is therefore the Swift `ModelRuntime` generation path, not the Python server. The pinned Swift dependency is `mlx-swift-lm` 3.31.4 (`phase3-binary/Package.swift:20-23`, `phase3-binary/Package.resolved:13-19`), and that package already exposes `generate(... draftModel:draftCache:numDraftTokens: ...)` plus `SpeculativeTokenIterator` telemetry.
+
+The safe v0.1 shape is provider-side, opt-in, and buyer-invisible:
+
+- Add `macprovider-cli serve --draft-model <id-or-path>` and `--num-draft-tokens <N>`.
+- Thread both through the flat config/env/CLI pattern used by `kv_bits`, `max_context_override`, and `max_concurrency_override`.
+- Load the draft model beside the target runtime container, fail loudly on tokenizer/cache incompatibility, and fall back only when the operator explicitly disables spec decode.
+- Report acceptance rate as aggregate provider telemetry on `/v1/status` and coordinator heartbeat, not in SPEC-015 v0.4 settlement receipts.
+- Keep default behavior byte-identical: no draft model means the existing `TokenIterator` path remains active.
+
+## Sources Checked
+
+Local code/spec anchors:
+
+- CLI entry and serve flags: `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:19-84`, `:131-153`.
+- Config layering: `phase3-binary/Sources/MacProviderCore/Config.swift:19-74`, `:94-140`, `:309-357`, `:365-401`, `:427-469`.
+- Runtime call site: `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:1-8`, `:232-320`, `:667-790`, `:804-930`.
+- Request temperature/top-p parse: `phase3-binary/Sources/MacProviderCore/ChatCompletionRequest.swift:42-55`.
+- Provider capacity/status: `phase3-binary/Sources/macprovider-cli/ProviderStatus.swift:12-39`, `:71-102`, `:149-168`.
+- Heartbeat payload: `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:2059-2088`.
+- Receipt/verifier strict usage schema: `phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift:279-285`, `phase4-coordinator/internal/billing/settlement_verifier.go:35-49`, `:273-319`, `:348-354`, `:375-380`, `:511-519`.
+- SPEC constraints: SPEC-001 `:167-193`, `:443-456`, `:1069-1096`, `:1316-1336`, `:1760-1820`, `:1933-1937`; SPEC-010 `:300-303`, `:333-369`, `:490-513`, `:861-879`; SPEC-011 `:110-125`, `:227-239`; SPEC-013 `:252-260`, `:927-929`; SPEC-015 `:1-5`, `:20-45`.
+- Current static candidate catalog: `phase3-binary/dist/static/autotune-candidates.json:1`.
+- Beta workload and Air configs: `beta/workloads.py:26-34`, `:88-240`; `beta/config-m1.yaml:7-23`; `beta/config-m4.yaml:7-21`; `beta/DECISION_CRITERIA.md:54-76`, `:254-264`.
+
+External upstream anchors:
+
+- Python server request fields: <https://raw.githubusercontent.com/ml-explore/mlx-lm/main/mlx_lm/SERVER.md> documents `draft_model` and `num_draft_tokens`.
+- Python generator flags and algorithm: <https://raw.githubusercontent.com/ml-explore/mlx-lm/main/mlx_lm/generate.py>.
+- Swift pinned implementation: <https://raw.githubusercontent.com/ml-explore/mlx-swift-lm/3.31.4/Libraries/MLXLMCommon/Evaluate.swift>.
+- Current upstream risk reports: <https://github.com/ml-explore/mlx-lm/issues/846>, <https://github.com/ml-explore/mlx-lm/issues/1423>, <https://github.com/ml-explore/mlx-lm/issues/1446>.
+
+## A. Serve-Path Integration
+
+### Current Call Graph
+
+```text
+macprovider-cli serve
+  -> ServeCommand options
+     phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:19-84
+  -> AppConfig resolution
+     phase3-binary/Sources/MacProviderCore/Config.swift:309-357
+     phase3-binary/Sources/MacProviderCore/Config.swift:365-401
+     phase3-binary/Sources/MacProviderCore/Config.swift:427-469
+  -> HTTPServer starts local OpenAI-compatible API
+     phase3-binary/Sources/macprovider-cli/HTTPServer.swift:27-57
+  -> POST /v1/chat/completions
+     phase3-binary/Sources/macprovider-cli/HTTPServer.swift:144-160
+  -> ModelRuntime.completeWithServedSnapshot or stream
+     phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:667-790
+     phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:804-930
+  -> mlx-swift-lm TokenIterator + generate
+     phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:737-738
+     phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:891-893
+```
+
+The provider imports `MLX`, `MLXLLM`, `MLXHuggingFace`, and `MLXLMCommon` directly (`ModelRuntime.swift:1-8`). It creates `GenerateParameters` in Swift (`ModelRuntime.swift:710-716`, `:860-866`), then instantiates `TokenIterator` and calls `generate` (`:737-738`, `:891-893`). That means the SPEC should target `mlx-swift-lm`, not the Python `mlx_lm.server` surface.
+
+### Upstream Primitive Shape
+
+The Python server now exposes request fields `draft_model` and `num_draft_tokens` in OpenAI-style requests. The Python CLI also exposes `--draft-model` and `--num-draft-tokens`; the generator has `speculative_generate_step(prompt, model, draft_model, num_draft_tokens=2, ...)` and rejects non-trimmable prompt caches.
+
+The pinned Swift API has the native shape MacProvider needs:
+
+- `SpeculativeTokenIterator(input:mainModel:draftModel:mainCache:draftCache:parameters:numDraftTokens:...)`.
+- `generate(input:cache:parameters:context:draftModel:draftCache:numDraftTokens:...)`.
+- `GenerateInfo.speculativeDecodingTelemetry`, including accepted/drafted counts.
+
+The v0.1 implementation should use the Swift primitive because the repo is pinned to `mlx-swift-lm` 3.31.4 (`Package.swift:20-23`) and the runtime is already a Swift wrapper.
+
+### Minimal Thread-Through
+
+The new config should mirror existing serving knobs:
+
+| Surface | Existing pattern | Spec-decode addition |
+|---|---|---|
+| CLI | `--kv-bits`, `--max-context`, `--max-batch` in `MacProviderCLI.swift:77-84` | `--draft-model <id-or-path>`, `--num-draft-tokens <N>` |
+| YAML | flat keys parsed in `Config.swift:332-341` | `draft_model`, `num_draft_tokens` |
+| Env | `MACPROVIDER_KV_BITS`, `MACPROVIDER_MAX_CONTEXT_OVERRIDE` in `Config.swift:378-380` | `MACPROVIDER_DRAFT_MODEL`, `MACPROVIDER_NUM_DRAFT_TOKENS` |
+| Runtime | `GenerateParameters(... kvBits: kvBitsOverride ...)` at `ModelRuntime.swift:710-716` | Load draft container, pass `draftModel`, `draftCache`, `numDraftTokens` to Swift speculative generate |
+| Telemetry | `ProviderStatus.finishRequest` rolls request/tps windows at `ProviderStatus.swift:149-168` | Add accepted/drafted target-verified counters to the same provider aggregate window |
+
+Preflight should follow the serve-knob fail-loud style in `MacProviderCLI.swift:131-153`: reject `num_draft_tokens < 1`, reject draft-model equal to empty string, and reject configured draft model if it cannot be loaded with a compatible tokenizer/cache.
+
+## B. Draft Model Compatibility
+
+### Current Supported Targets
+
+The current static autotune catalog contains:
+
+- `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit`, min RAM 28 GB.
+- `mlx-community/gpt-oss-20b-MXFP4-Q8`, min RAM 24 GB.
+- `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit`, min RAM 16 GB.
+- `mlx-community/Qwen3-32B-4bit`, min RAM 48 GB.
+- `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit`, min RAM 48 GB.
+
+The beta Air providers add real deployed targets:
+
+- M1 8 GB: `mlx-community/Llama-3.2-3B-Instruct-4bit` (`beta/config-m1.yaml:7-13`).
+- M4 16 GB: `mlx-community/Qwen2.5-7B-Instruct-4bit` (`beta/config-m4.yaml:7-8`).
+
+### Compatibility Matrix
+
+Memory estimates are intentionally coarse. They use 4-bit weight-size heuristics plus KV/cache/headroom; the implementing PR must measure resident memory and Metal working-set pressure.
+
+| Family | Target | Draft candidate | Air fit estimate | License posture | Risk |
+|---|---|---|---|---|---|
+| Qwen2.5 Instruct | `mlx-community/Qwen2.5-7B-Instruct-4bit` | `mlx-community/Qwen2.5-1.5B-Instruct-4bit` | M4 16 GB likely fits; M1 8 GB not recommended | Qwen license family; maintainer must confirm model card | Good first canary |
+| Qwen2.5 Instruct | `mlx-community/Qwen2.5-7B-Instruct-4bit` | `mlx-community/Qwen2.5-0.5B-Instruct-4bit` | M4 16 GB fits; M1 8 GB possibly fits but target 7B is not the M1 baseline | Same as above | Lower acceptance but lower memory |
+| Qwen2.5 Coder | `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit` | 48 GB+ only | Qwen license family; maintainer must confirm | Strong code workload candidate |
+| Qwen2.5 Coder | `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | `mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit` | 48 GB+ likely fits with more headroom | Same as above | May under-draft complex code |
+| Qwen3 | `mlx-community/Qwen3-32B-4bit` | `mlx-community/Qwen3-1.7B-4bit` | 48 GB+ only | Qwen3 model-card confirmation required | Public MLX-LM issues report Qwen spec-decode divergence |
+| Qwen3 | `mlx-community/Qwen3-32B-4bit` | `mlx-community/Qwen3-0.6B-4bit` | 48 GB+ only | Same as above | Lower memory, lower likely acceptance |
+| Qwen3 Coder | `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | `mlx-community/Qwen3-1.7B-4bit` | 32 GB may be tight; catalog min RAM is 28 GB before draft | Same as above | Tokenizer compatibility must be proven |
+| Qwen3 Coder | `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | `mlx-community/Qwen3-0.6B-4bit` | 32 GB likely safer than 1.7B; M4 16 GB not recommended | Same as above | Acceptance unknown |
+| Llama | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` | `mlx-community/Llama-3.2-3B-Instruct-4bit` | M4 16 GB likely fits; M1 8 GB tight | Meta Llama license family; maintainer must confirm | Good general-chat canary |
+| Llama | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` | `mlx-community/Llama-3.2-1B-Instruct-4bit` | M4 16 GB fits; may fit 8 GB with smaller context | Same as above | Lower acceptance |
+| Llama | `mlx-community/Llama-3.2-3B-Instruct-4bit` | `mlx-community/Llama-3.2-1B-Instruct-4bit` | M1 8 GB best small-Air canary | Same as above | Lower absolute speedup because target is already small |
+| gpt-oss | `mlx-community/gpt-oss-20b-MXFP4-Q8` | none confirmed | Catalog min RAM 24 GB before draft | OpenAI model license terms must be reviewed | Human-blocking open question |
+
+The Qwen and Llama rows satisfy the "two viable pairs per family" research bar. gpt-oss does not: no smaller same-family draft candidate was confirmed from local catalog evidence or upstream MLX naming. That must block LOCK or be explicitly waived.
+
+### Air Variant Fit
+
+The M1 8 GB provider uses a 3B 4-bit Llama target (`beta/config-m1.yaml:7-13`). It should only test `Llama-3.2-3B` plus a 1B draft at modest context. The first failure mode is unified-memory pressure and KV growth, not raw weight size; `ProviderCapacity` gives 8 GB machines a 20k default context (`ProviderStatus.swift:23-37`), which may be too optimistic once a second model is resident.
+
+The M4 16 GB provider uses Qwen2.5 7B (`beta/config-m4.yaml:7-8`). It is the best first proving target: Qwen2.5 7B + 0.5B/1.5B draft should fit with enough memory to run the existing short, medium, code, agent, and streaming workloads (`beta/workloads.py:88-240`). Thermal pressure is still a real risk because accepted drafts increase generated-token throughput, so sustained high acceptance can heat-soak faster than baseline.
+
+The 32B/30B catalog rows are not Air-class v0.1 canaries. They belong on 48 GB+ hosts because the static catalog already sets 28-48 GB floors before adding a draft (`autotune-candidates.json:1`).
+
+### Tokenizer Compatibility
+
+Python MLX-LM explicitly checks draft tokenizer vocabulary size and raises when it differs; the Swift API documents that the draft model must share a tokenizer. The MacProvider SPEC should require an implementation-side load check before accepting traffic:
+
+- Load target tokenizer and draft tokenizer.
+- Compare vocabulary size and canonical tokenizer identity if exposed by `swift-transformers`.
+- Run a deterministic prompt through both processors and assert identical token IDs.
+- If any check fails, `serve` exits nonzero with `draft_model_tokenizer_mismatch`.
+
+This belongs at startup, not first buyer request, because `ServeCommand.runServingKnobsPreflight` already validates operator knobs at startup (`MacProviderCLI.swift:131-153`).
+
+## C. Losslessness Posture
+
+MLX speculative decoding verifies drafted tokens with the target model and accepts only matching target tokens in the implementation. Swift also uses `ArgMaxSampler` when `temperature == 0` in `GenerateParameters.sampler()`. In theory, that makes greedy speculative decoding token-exact compared with normal greedy decoding.
+
+MacProvider exposes buyer-controlled `temperature` and `top_p`: parse defaults and ranges are in `ChatCompletionRequest.swift:47-55`, and generation forwards them into `GenerateParameters` in both non-streaming and streaming paths (`ModelRuntime.swift:710-716`, `:860-866`). Because buyer temperature defaults to `1.0`, speculative decoding must not silently alter non-greedy output in v0.1.
+
+Recommended v0.1 gate:
+
+- Enable spec decode only when `request.temperature == 0.0` unless an operator sets an explicit future `--allow-stochastic-spec-decode` flag.
+- Keep stochastic requests on the existing non-spec `TokenIterator` path.
+- Add a coordinator-issued or local canary follow-up: run paired plain/spec requests at `temperature=0`, compare token IDs, and separately run a sampling-distance test before any stochastic enablement.
+
+The canary should be a follow-up, not a v0.1 core requirement. Current upstream MLX-LM issues report Qwen skipped-token behavior, greedy divergence, and non-trimmable prompt-cache failures. Those are enough to keep the first SPEC conservative even if the pinned Swift API is cleaner than Python server behavior.
+
+## D. Acceptance-Rate Visibility
+
+SPEC-015 v0.4 settlement receipts are a bad home for acceptance counters. The settlement verifier requires a strict usage object with exactly:
+
+- `billable_input_tokens`
+- `billable_output_tokens`
+- `delivered_output_bytes`
+- `observed_input_tokens`
+- `observed_output_tokens`
+
+The strict key set appears in `settlement_verifier.go:45-49`, unknown keys cause `usage_shape_invalid` at `:378-380`, and the receipt builder emits only those five fields (`ReceiptBuilder.swift:279-285`). Adding `speculative_accepted_tokens` to settlement `usage` would break v0.4 verification.
+
+Concrete field proposal:
+
+| Field | Type | Semantics | Surface |
+|---|---|---|---|
+| `spec_decode_acceptance_rate` | JSON number in `[0,1]` or `null` | Rolling aggregate `accepted_draft_tokens / drafted_tokens` for completed provider requests in the current metrics window; `null` when disabled or no draft tokens were attempted | `/v1/status` and coordinator heartbeat |
+| `spec_decode_drafted_tokens_since_last` | integer | Draft tokens proposed during the current heartbeat/status window | `/v1/status` and coordinator heartbeat |
+| `spec_decode_accepted_tokens_since_last` | integer | Draft tokens accepted by target verification during the current heartbeat/status window | `/v1/status` and coordinator heartbeat |
+| `spec_decode_enabled` | boolean | Runtime has a loaded draft model and is eligible to spec-decode greedy requests | `/v1/status` and coordinator heartbeat |
+| `spec_decode_draft_model_id` | string or null | Configured draft model identifier; null when disabled | `/v1/status` and coordinator heartbeat |
+
+The buyer should not see these fields per request. The existing OpenAI `usage` response shape in `HTTPServer.swift:1125-1132` should stay token/accounting focused. Operator/provider aggregates match the current heartbeat metrics style in `CoordinatorClient.swift:2059-2088`.
+
+## E. Warm-Swap Interaction
+
+Current warm-swap keeps one active target model and one current container in `ModelRuntime` (`ModelRuntime.swift:242-248`). It captures a request snapshot before inference (`:515-531`) and uses that snapshot for receipt binding (`:667-689`). Warm swap is opt-in and dormant by default per SPEC-011's lock-preserving gate (`SPEC-011:110-125`), and coordinator observation is heartbeat-based (`SPEC-011:227-239`).
+
+Safe v0.1 behavior:
+
+- Draft model is coupled to the target model.
+- When target swap begins, new requests should run non-spec until the matching draft for the new target is loaded and compatibility-checked.
+- The old target + old draft pair remains pinned for in-flight requests that already captured the old target snapshot.
+- Failed draft load must not fail the target swap; it should leave the new target serving without spec decode and report `spec_decode_enabled=false` plus a draft-load error in local/operator logs.
+
+If the coordinator needs both target and draft hashes, SPEC-011 is impacted. v0.1 should avoid requiring `draft_model_hash` for routing or settlement and should report only draft model ID + acceptance metrics. Model-hash settlement remains tied to the target container that served the request, as required by SPEC-015.
+
+## F. Autotune Interaction
+
+Speculative decoding is two decisions, not one flat axis:
+
+1. Outer loop: choose a target/draft pair that is compatible and fits memory.
+2. Inner loop: tune `num_draft_tokens` and existing serving knobs for that pair.
+
+SPEC-013 already scopes autotune around a chosen target model and existing axes (`--kv-bits`, `--max-batch`, optional `--max-context`) (`SPEC-013:252-260`). Its output maps recommended knobs to config keys (`SPEC-013:927-929`). Spec decode should extend that model:
+
+- Add optional candidate metadata to `autotune-candidates.json`: `draft_candidates[]` with `model_id`, `min_extra_ram_gb`, `default_num_draft_tokens`, and `workload_bias`.
+- Treat draft choice as an outer filter over candidates, not as a full multiplication of every context/concurrency cell.
+- For the chosen pair, evaluate a small `num_draft_tokens` axis, e.g. `{2,3,4,6}`, and stop early if acceptance falls below threshold or TPS regresses.
+
+This avoids multiplying a 28-cell context/concurrency grid by every draft model and token count. Runtime cost is high because every draft candidate has a load/fetch/prewarm cost and doubles resident model memory. The static JSON should advertise draft-tuned candidates because the current file already carries model IDs, min RAM, benchmark gates, and notes in one operator-curated row (`autotune-candidates.json:1`).
+
+## G. Coordinator Routing
+
+Spec decode should not surface to the buyer API in v0.1. It is a provider-side throughput optimization, like KV-cache quantization and serving knob autotune. Buyer-visible output, token usage, receipts, and error envelopes should be unchanged.
+
+The coordinator should learn about it through heartbeat/status telemetry, not buyer API fields:
+
+- `spec_decode_enabled`
+- `spec_decode_draft_model_id`
+- `spec_decode_acceptance_rate`
+- `spec_decode_drafted_tokens_since_last`
+- `spec_decode_accepted_tokens_since_last`
+
+Routing should not change in v0.1. A future coordinator SPEC could prefer spec-decoding providers for workload classes known to have high acceptance, especially `code_completion`, `agent_style`, and repeated long-context flows. The current workload taxonomy is already explicit in `beta/workloads.py:26-34`; the v0.1 SPEC should only define enough telemetry for later routing analysis.
+
+## Risk Register
+
+| Risk | Why it matters | Mitigation in SPEC-028 |
+|---|---|---|
+| 8 GB Air memory ceiling | M1 8 GB target+draft+KV may exceed unified-memory headroom before model weights alone fail | Require canary on Llama 3.2 3B + 1B only; require measured resident memory and fail-closed load |
+| Tokenizer mismatch | Spec decode correctness requires target/draft token IDs to match | Startup compatibility check; fail before serving |
+| Non-trimmable cache | Upstream speculative decode can reject caches that cannot rewind after rejected tokens | AC requires fallback/non-spec path and explicit load/probe failure |
+| Qwen divergence | Public MLX-LM issues report Qwen skipped tokens and greedy divergence | v0.1 gates to `temperature=0` and requires plain-vs-spec token canary before LOCK |
+| Warm-swap race | Draft may not match target after swap | Couple draft lifecycle to target snapshot; disable spec during load |
+| Receipt schema break | SPEC-015 v0.4 usage schema is strict | Keep spec-decode counters out of receipt `usage` |
+| Thermal pressure | High acceptance increases sustained token throughput and heat | Report aggregate acceptance/TPS; autotune must measure under workload windows, not one short run |
+
+## Recommended SPEC-028 v0.1 Shape
+
+1. Operator opt-in only; no default behavior change.
+2. New flat config keys: `draft_model`, `num_draft_tokens`.
+3. New env vars: `MACPROVIDER_DRAFT_MODEL`, `MACPROVIDER_NUM_DRAFT_TOKENS`.
+4. New CLI flags: `--draft-model`, `--num-draft-tokens`.
+5. Greedy-only v0.1 enablement unless a later canary validates stochastic equivalence.
+6. Provider aggregate telemetry on `/v1/status` and heartbeat.
+7. No SPEC-015 v0.4 receipt tuple change.
+8. No buyer API or coordinator routing behavior change.
+
+## Self-Review
+
+- Wire-shape break: avoided for buyer API and SPEC-015 receipts; proposed fields are heartbeat/status additions only.
+- Ambiguous FR risk: SPEC draft must define config precedence, validation ranges, and disabled-mode behavior explicitly.
+- Undocumented dependencies: SPEC draft must cite SPEC-001, SPEC-010, SPEC-011, SPEC-013, SPEC-015, and pinned `mlx-swift-lm` 3.31.4.
+- Warm-swap state: draft lifecycle must be coupled to target lifecycle; no persistent stale draft across target swaps.
+- Acceptance-rate field: aggregate-only, not request usage; strict types and null behavior required.
+- Open questions: gpt-oss draft candidate, stochastic gating policy, SPEC-011 amendment boundary, license confirmation, benchmark threshold.

--- a/specs/AUDIT_SPEC_028_R2_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_SPEC_028_R2_ARCHITECT_PROMPT.md
@@ -1,0 +1,59 @@
+# AUDIT_SPEC_028_R2_ARCHITECT_PROMPT
+
+You are auditing `specs/SPEC-028-mlx-speculative-decoding.md` from the ARCHITECT lane.
+
+Audit target: SPEC-028 v0.2-draft only. Treat the current branch as a
+research/spec branch: do not propose executable code, and do not audit unrelated
+repository changes.
+
+Controlling context:
+
+- `specs/SPEC-028-mlx-speculative-decoding.md`
+- `docs/research/spec-decode-integration-2026-07.md`
+- `specs/SPEC-001-phase3-binary.md`
+- `specs/SPEC-010-model-catalog.md`
+- `specs/SPEC-011-operator-pushed-warm-swap.md`
+- `specs/SPEC-013-cli-autotune.md`
+- `specs/SPEC-015-receipts.md`
+- `phase3-binary/dist/static/autotune-candidates.json`
+- `beta/workloads.py`
+- `beta/config-m1.yaml`
+- `beta/config-m4.yaml`
+- `beta/DECISION_CRITERIA.md`
+
+Lock bar: 0 critical, 0 high, 0 medium.
+
+Focus:
+
+- Is SPEC-028 scoped to the correct layer: provider-side throughput, no buyer
+  API change, no settlement schema change, no coordinator routing behavior
+  change?
+- Are SPEC-001, SPEC-010, SPEC-011, SPEC-013, and SPEC-015 interactions assigned
+  to the right owners?
+- Does v0.2 close the major research risks from v0.1 without over-scoping the
+  first implementation round?
+- Is the gpt-oss waiver architecturally acceptable for v0.1, or does it
+  undermine the compatibility matrix and lock bar?
+- Does the PR-A/PR-B/PR-C implementation sequencing keep state-machine,
+  telemetry, and runtime-loading risks isolated?
+- Does the autotune extension stay a future SPEC-013 amendment rather than
+  accidentally becoming a dependency of SPEC-028?
+- Are AC-10 and AC-11 good acceptance gates for a provider fleet made of mixed
+  8 GB, 16 GB, and 48 GB+ Apple Silicon machines?
+
+Output format:
+
+Start with exactly one summary line:
+
+`VERDICT: READY | COUNTS: C=0 H=0 M=0 L=<n>`
+
+or:
+
+`VERDICT: NEEDS REVISION | COUNTS: C=<n> H=<n> M=<n> L=<n>`
+
+Then list ID-prefixed findings, ordered by severity:
+
+- `ARCH-C-1`, `ARCH-H-1`, `ARCH-M-1`, `ARCH-L-1`, etc.
+- Each finding must cite the SPEC section and concrete repo/spec evidence.
+- Do not include Critical/High/Medium findings unless they should block LOCK.
+- Low findings may be left for later; the stop bar is 0 C/H/M.

--- a/specs/AUDIT_SPEC_028_R2_CODE_PROMPT.md
+++ b/specs/AUDIT_SPEC_028_R2_CODE_PROMPT.md
@@ -1,0 +1,57 @@
+# AUDIT_SPEC_028_R2_CODE_PROMPT
+
+You are auditing `specs/SPEC-028-mlx-speculative-decoding.md` from the CODE lane.
+
+Audit target: SPEC-028 v0.2-draft only. Treat the current branch as a
+research/spec branch: do not propose executable code, and do not audit unrelated
+repository changes.
+
+Controlling context:
+
+- `specs/SPEC-028-mlx-speculative-decoding.md`
+- `docs/research/spec-decode-integration-2026-07.md`
+- `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+- `phase3-binary/Sources/MacProviderCore/Config.swift`
+- `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+- `phase3-binary/Sources/macprovider-cli/ProviderStatus.swift`
+- `phase3-binary/Sources/macprovider-cli/HTTPServer.swift`
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+- `phase3-binary/Package.swift`
+- `phase3-binary/Package.resolved`
+
+Lock bar: 0 critical, 0 high, 0 medium.
+
+Focus:
+
+- Is every FR implementable against the current Swift runtime and config
+  layering?
+- Do `--draft-model`, `--num-draft-tokens`, YAML, and env precedence match
+  existing serve-knob patterns?
+- Is FR-4's capacity/headroom refresh concrete enough to implement and test?
+- Does FR-5's greedy-only gate avoid accidental speculative decoding for
+  stochastic buyer requests?
+- Are FR-8 telemetry fields and AC-7/AC-8 precise enough for unit/integration
+  tests?
+- Are warm-swap snapshot and counter-reset requirements implementable without
+  races?
+- Are AC-10 and AC-11 runnable in a future implementation PR, including the
+  baseline/spec ratio measurement?
+- Does the SPEC leave any code path ambiguous enough that two reasonable
+  implementers would produce incompatible behavior?
+
+Output format:
+
+Start with exactly one summary line:
+
+`VERDICT: READY | COUNTS: C=0 H=0 M=0 L=<n>`
+
+or:
+
+`VERDICT: NEEDS REVISION | COUNTS: C=<n> H=<n> M=<n> L=<n>`
+
+Then list ID-prefixed findings, ordered by severity:
+
+- `CODE-C-1`, `CODE-H-1`, `CODE-M-1`, `CODE-L-1`, etc.
+- Each finding must cite the SPEC section and concrete repo/spec evidence.
+- Do not include Critical/High/Medium findings unless they should block LOCK.
+- Low findings may be left for later; the stop bar is 0 C/H/M.

--- a/specs/AUDIT_SPEC_028_R2_SECURITY_PROMPT.md
+++ b/specs/AUDIT_SPEC_028_R2_SECURITY_PROMPT.md
@@ -1,0 +1,57 @@
+# AUDIT_SPEC_028_R2_SECURITY_PROMPT
+
+You are auditing `specs/SPEC-028-mlx-speculative-decoding.md` from the SECURITY lane.
+
+Audit target: SPEC-028 v0.2-draft only. Treat the current branch as a
+research/spec branch: do not propose executable code, and do not audit unrelated
+repository changes.
+
+Controlling context:
+
+- `specs/SPEC-028-mlx-speculative-decoding.md`
+- `docs/research/spec-decode-integration-2026-07.md`
+- `specs/SPEC-001-phase3-binary.md`
+- `specs/SPEC-010-model-catalog.md`
+- `specs/SPEC-011-operator-pushed-warm-swap.md`
+- `specs/SPEC-013-cli-autotune.md`
+- `specs/SPEC-015-receipts.md`
+- `phase4-coordinator/internal/billing/settlement_verifier.go`
+- `phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift`
+- `phase3-binary/Sources/MacProviderCore/ChatCompletionRequest.swift`
+
+Lock bar: 0 critical, 0 high, 0 medium.
+
+Focus:
+
+- Does SPEC-028 preserve SPEC-015 v0.4 settlement receipt usage strictness and
+  avoid new money/accounting ambiguity?
+- Does provider telemetry avoid leaking buyer prompts, output content,
+  account identity, request IDs, or receipt-sensitive state?
+- Does the draft model configuration create a supply-chain or remote-code risk
+  beyond the current target model loading posture, and if so does the SPEC name
+  the required guard?
+- Are tokenizer mismatch, prompt-cache rewind failure, Qwen divergence, and
+  stochastic-output risks handled fail-closed enough for buyer correctness?
+- Does warm-swap behavior avoid stale draft/target pairing that could create
+  unverifiable target model claims?
+- Does heartbeat/status telemetry create a coordinator trust or routing hazard
+  before a coordinator-side SPEC consumes it?
+- Are disabled-mode and fallback semantics precise enough that failures cannot
+  silently alter buyer-visible outputs or receipts?
+
+Output format:
+
+Start with exactly one summary line:
+
+`VERDICT: READY | COUNTS: C=0 H=0 M=0 L=<n>`
+
+or:
+
+`VERDICT: NEEDS REVISION | COUNTS: C=<n> H=<n> M=<n> L=<n>`
+
+Then list ID-prefixed findings, ordered by severity:
+
+- `SEC-C-1`, `SEC-H-1`, `SEC-M-1`, `SEC-L-1`, etc.
+- Each finding must cite the SPEC section and concrete repo/spec evidence.
+- Do not include Critical/High/Medium findings unless they should block LOCK.
+- Low findings may be left for later; the stop bar is 0 C/H/M.

--- a/specs/SPEC-028-mlx-speculative-decoding.md
+++ b/specs/SPEC-028-mlx-speculative-decoding.md
@@ -1,8 +1,11 @@
 # SPEC-028 — MLX Speculative Decoding for Provider Serve
 
-**Version:** 0.1-draft
+**Version:** 0.2-draft
 **Status:** Draft (research round; not locked; implementation MUST NOT begin before human review)
 **Date drafted:** 2026-07-05
+**Revision history:**
+- v0.1 (2026-07-05): initial research-round draft.
+- v0.2 (2026-07-05): greedy-only gate confirmed for v0.1; draft-model hash explicitly out of scope (no SPEC-011 amendment); gpt-oss waived from v0.1 compatibility; AC-10 reframed as ratio over measured baseline plus a sustained-thermal window; FR-4 gains a `ProviderCapacity` headroom refresh; FR-9 gains a counter-reset on warm-swap boundary.
 **Depends on:** SPEC-001 v1.6 (`macprovider-cli serve`, OpenAI-compatible HTTP, heartbeat/status), SPEC-010 v1.5 (`supported_models[]` semantics), SPEC-011 v0.5 (warm-swap state machine and target `model_hash` heartbeat), SPEC-013 v0.3 (`autotune` serving knobs and static candidate catalog), SPEC-015 v0.4.2 (locked settlement receipt usage schema), `mlx-swift-lm` 3.31.4.
 
 SPEC-028 is provider-side only. With no draft model configured, provider behavior MUST be byte-identical to the existing non-speculative serve path. SPEC-028 MUST NOT change the buyer API, the SPEC-015 v0.4 receipt tuple, settlement verifier behavior, or coordinator routing policy.
@@ -38,7 +41,8 @@ Non-normative motivation: the 2026-07-03 leyten/shard technical report measured 
 - No coordinator routing preference change.
 - No tree-verification or shard-style multi-branch algorithm.
 - No stochastic speculative decoding until a later SPEC defines canary/equivalence policy.
-- No gpt-oss draft-model claim until a maintainer confirms a smaller same-tokenizer draft candidate.
+- No gpt-oss draft-model support in v0.1. `mlx-community/gpt-oss-20b-MXFP4-Q8` continues to serve non-speculatively. A same-tokenizer, license-clean smaller draft candidate is a follow-up SPEC concern and MUST NOT block v0.1 LOCK.
+- No `draft_model_hash` field in heartbeat or receipts in v0.1. Draft-model *ID* plus acceptance counters (FR-8) is sufficient; adding a hash would require a SPEC-011 amendment and is deferred until a future coordinator routing SPEC needs it.
 
 ---
 
@@ -85,6 +89,7 @@ When `draft_model` is configured, serve startup MUST:
 3. Verify tokenizer compatibility before accepting buyer traffic.
 4. Run a minimal speculative-generation probe at `temperature=0`, `max_tokens=1`, and `num_draft_tokens=1`.
 5. Fail startup if the draft model cannot load, tokenizer compatibility cannot be proven, or the speculative probe fails.
+6. Refresh `ProviderCapacity` effective headroom (max context, batch, working-set) to reflect the second resident model. The current default context — 20k on 8 GB machines — is set without knowledge of a second resident model (`ProviderStatus.swift:23-37`), so leaving it unchanged over-admits traffic. If the resulting refresh drops effective `max_context` below the SPEC-013 candidate row's minimum, serve preflight MUST fail with a `draft_model_capacity_shortfall` (or equivalent stable code).
 
 The failure MUST be loud and local: nonzero process exit, structured error log, and no partial admission to the coordinator as spec-decode enabled.
 
@@ -137,7 +142,8 @@ When warm swap is enabled:
 2. While a new target is loading, new requests MUST run non-speculative unless a compatible draft for that target is already loaded and verified.
 3. In-flight requests MUST keep using the target/draft pair associated with their captured runtime snapshot.
 4. A draft-load failure during target swap MUST NOT roll back a successful target swap. The provider MUST continue serving the target non-speculatively and set `spec_decode_enabled=false`.
-5. SPEC-011 target `model_hash` semantics remain unchanged. Draft model hash is not required by SPEC-028 v0.1.
+5. On every target-swap boundary the `spec_decode_drafted_tokens_since_last` and `spec_decode_accepted_tokens_since_last` counters MUST reset to zero, so `spec_decode_acceptance_rate` never blends pre-swap and post-swap draft populations. The heartbeat window immediately following a swap MAY report `spec_decode_acceptance_rate=null` if no draft tokens were attempted post-swap.
+6. SPEC-011 target `model_hash` semantics remain unchanged. Draft model hash is not required by SPEC-028 v0.1.
 
 ### FR-10. Supported models and catalog posture
 
@@ -203,7 +209,13 @@ The current gpt-oss catalog row has no confirmed smaller same-family draft candi
 
 **AC-9. Warm-swap target coupling.** During a warm swap, requests started before the swap finish on their captured target/draft pair; requests accepted while the new draft is not ready run non-speculatively.
 
-**AC-10. First performance canary.** On air5 or equivalent 16 GB Apple Silicon, with target `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit`, draft `mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit`, workload `code_completion`, seed prompt `spec028-code-iso8601-v1`, `temperature=0`, `max_tokens=240`, and `num_draft_tokens=3`, median generation throughput over 5 warm runs MUST be at least 24 tok/s and `spec_decode_acceptance_rate` MUST be non-null and at least 0.35. If target model availability blocks this exact canary, the implementing PR MUST record the substituted Qwen2.5 Coder 7B-compatible target/draft pair and keep the same threshold unless a maintainer approves a change.
+**AC-10. First performance canary (ratio + thermal window).** On air5 or equivalent 16 GB Apple Silicon, with target `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit`, draft `mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit`, workload `code_completion`, seed prompt `spec028-code-iso8601-v1`, `temperature=0`, `max_tokens=240`, `num_draft_tokens=3`:
+
+1. **Ratio floor (not absolute tok/s).** Immediately before the spec-decode run, capture the median non-spec generation throughput over 5 warm runs at the same target/prompt/params (`baseline_tps`). Median spec-decode throughput over 5 warm runs MUST be at least `1.4 * baseline_tps`. This replaces v0.1's absolute 24 tok/s floor, which drifts across mlx-swift-lm releases and macOS updates.
+2. **Acceptance floor.** `spec_decode_acceptance_rate` MUST be non-null and at least 0.30 over the same 5 runs.
+3. **Sustained thermal window.** After the paired 5-run comparison, run the spec-decode configuration back-to-back for at least 5 minutes of continuous generation. Median throughput measured over the *last minute* of that window MUST remain at least `1.2 * baseline_tps`. This guards against acceptance-driven token throughput heat-soaking the device into thermal throttle — a failure mode the short warm-run measurement will not surface.
+
+If target model availability blocks this exact canary, the implementing PR MUST record the substituted Qwen2.5 Coder 7B-compatible target/draft pair and keep the same ratios and window unless a maintainer approves a change.
 
 **AC-11. Small-Air canary.** On M1 8 GB, target `mlx-community/Llama-3.2-3B-Instruct-4bit` plus draft `mlx-community/Llama-3.2-1B-Instruct-4bit` MUST complete `short_chat` and `streaming_check` at `temperature=0` without Metal OOM or process crash.
 
@@ -211,11 +223,17 @@ The current gpt-oss catalog row has no confirmed smaller same-family draft candi
 
 ## 6. Open Questions
 
-1. Which smaller gpt-oss draft, if any, is license-clean and tokenizer-compatible with `mlx-community/gpt-oss-20b-MXFP4-Q8`?
-2. Is greedy-only v0.1 acceptable, or does product require stochastic speculative decoding behind an explicit risk flag?
-3. Should heartbeat carry draft model hash in a SPEC-011 amendment, or is draft model ID plus acceptance metrics enough for v0.1?
-4. Which model-card license approvals are required before publishing Qwen/Llama draft recommendations in the static catalog?
-5. Should the first LOCK gate use a stricter plain-vs-spec token-equivalence canary for Qwen3, given current upstream issue reports?
+### Resolved in v0.2
+
+- **~~gpt-oss draft candidate~~** — waived from v0.1 (see §2 Non-goals). Follow-up SPEC only.
+- **~~Greedy-only v0.1 gate~~** — confirmed: FR-5 restricts spec decode to `temperature == 0.0`. Stochastic support belongs to a later SPEC with its own equivalence canary.
+- **~~SPEC-011 draft-hash amendment~~** — confirmed not required for v0.1: heartbeat/status carry `spec_decode_draft_model_id` plus counters (FR-8); no `draft_model_hash` field is added.
+- **~~AC-10 absolute-tok/s threshold~~** — replaced by the ratio-plus-thermal-window formulation now written into AC-10.
+
+### Still open (do not block LOCK on these unless flagged)
+
+1. Which model-card license approvals are required before publishing Qwen/Llama draft recommendations in the static catalog? (Blocks SPEC-013 `draft_candidates[]` publication, not SPEC-028 LOCK.)
+2. Should the first LOCK gate add a stricter plain-vs-spec token-equivalence canary for Qwen3, given current upstream MLX-LM divergence issues? Default posture: keep Qwen3 out of the AC-10 canary until upstream issues 846/1423/1446 resolve or a MacProvider-side equivalence test lands.
 
 ---
 
@@ -232,3 +250,18 @@ Implementation will likely touch:
 - tests for config precedence, runtime gating, status/heartbeat telemetry, receipts, and warm-swap lifecycle.
 
 Those edits are out of scope for this research branch.
+
+## 8. Implementation Sequencing (recommended, non-normative)
+
+Implementation is proposed as three bundled PRs to keep the three-lane codex audit surface tight per PR. A single-PR implementation is acceptable if audit lanes stay green.
+
+**PR-A — Plumbing (FR-1..FR-4, FR-6, FR-7, FR-10; AC-1..AC-4, AC-6, AC-11).**
+CLI/env/YAML config, target+draft load, tokenizer compatibility check, `ProviderCapacity` headroom refresh (FR-4.6), Swift primitive wiring, disabled-mode byte-identity, receipt invariant, `supported_models[]` non-overload. Small-Air load canary (AC-11). Audit focus: precedence, load-failure loudness, disabled-mode identity, receipt schema.
+
+**PR-B — Telemetry and greedy gate (FR-5, FR-8; AC-5, AC-7, AC-8, AC-10).**
+`temperature==0` gate, `/v1/status` fields, aggregate counters. Heartbeat fields SHOULD ship behind an operator opt-in flag until a coordinator-side SPEC accepts them, to avoid a schema-compat drift on `CoordinatorClient` heartbeat. AC-10 ratio-plus-thermal-window canary lives here. Audit focus: counter arithmetic under mixed greedy/stochastic traffic, `null` semantics, buyer-response non-mutation.
+
+**PR-C — Warm-swap lifecycle (FR-9; AC-9).**
+Draft lifecycle coupled to target snapshot, in-flight pair pinning, counter reset on swap boundary. Highest state-machine risk. Audit focus: swap-boundary races, in-flight-request affinity, `spec_decode_enabled` transitions.
+
+FR-11 (autotune `draft_candidates[]`) is a separate SPEC-013 amendment, not part of this SPEC's implementation.

--- a/specs/SPEC-028-mlx-speculative-decoding.md
+++ b/specs/SPEC-028-mlx-speculative-decoding.md
@@ -1,0 +1,234 @@
+# SPEC-028 — MLX Speculative Decoding for Provider Serve
+
+**Version:** 0.1-draft
+**Status:** Draft (research round; not locked; implementation MUST NOT begin before human review)
+**Date drafted:** 2026-07-05
+**Depends on:** SPEC-001 v1.6 (`macprovider-cli serve`, OpenAI-compatible HTTP, heartbeat/status), SPEC-010 v1.5 (`supported_models[]` semantics), SPEC-011 v0.5 (warm-swap state machine and target `model_hash` heartbeat), SPEC-013 v0.3 (`autotune` serving knobs and static candidate catalog), SPEC-015 v0.4.2 (locked settlement receipt usage schema), `mlx-swift-lm` 3.31.4.
+
+SPEC-028 is provider-side only. With no draft model configured, provider behavior MUST be byte-identical to the existing non-speculative serve path. SPEC-028 MUST NOT change the buyer API, the SPEC-015 v0.4 receipt tuple, settlement verifier behavior, or coordinator routing policy.
+
+---
+
+## 1. Mission
+
+MacProvider serves MLX models from Apple Silicon contributors. The current Phase 3 binary calls `mlx-swift-lm` directly from Swift and generates tokens through `TokenIterator` plus `generate` in `ModelRuntime.swift`. The pinned Swift dependency already exposes speculative decoding, where a smaller compatible draft model proposes tokens and the target model verifies them.
+
+SPEC-028 defines the first locked surface for wiring that primitive into `macprovider-cli serve` as an opt-in operator performance feature.
+
+Non-normative motivation: the 2026-07-03 leyten/shard technical report measured a large draftable-text throughput gap on consumer hardware. That result is not the same mechanism as MLX linear speculative decoding, but it is enough evidence to justify a MacProvider-native research and benchmark track.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- New provider `serve` config for target/draft speculative decoding.
+- Draft model compatibility validation.
+- Greedy-only v0.1 request gating.
+- Provider aggregate acceptance-rate telemetry.
+- Warm-swap lifecycle rules for draft models.
+- Autotune/candidate-catalog extension points.
+
+### Non-goals
+
+- No buyer API field, flag, or routing parameter.
+- No SPEC-015 v0.4 receipt tuple change.
+- No settlement verifier schema change.
+- No coordinator routing preference change.
+- No tree-verification or shard-style multi-branch algorithm.
+- No stochastic speculative decoding until a later SPEC defines canary/equivalence policy.
+- No gpt-oss draft-model claim until a maintainer confirms a smaller same-tokenizer draft candidate.
+
+---
+
+## 3. Normative Requirements
+
+### FR-1. Disabled-mode baseline
+
+When `draft_model` is unset after config resolution, the provider MUST keep using the existing non-speculative generation path:
+
+- Non-streaming: `TokenIterator(input:model:cache:parameters:)` followed by `generate`.
+- Streaming: the same non-speculative iterator/generate path.
+- No spec-decode telemetry fields are emitted except where this SPEC explicitly requires a nullable/false disabled value on `/v1/status` or heartbeat after the feature is implemented.
+
+No buyer-visible JSON response, SSE frame, token count, receipt tuple, or error envelope may change in this disabled mode.
+
+### FR-2. CLI flags
+
+`macprovider-cli serve` MUST add:
+
+| Flag | Type | Default | Validation |
+|---|---|---|---|
+| `--draft-model <id-or-path>` | string | unset | Non-empty when present. May be HuggingFace ID or local path, matching `--model` resolution style. |
+| `--num-draft-tokens <N>` | integer | `3` when `draft_model` is set | `1 <= N <= 16`; invalid values fail serve preflight with exit code 2. |
+
+These flags MUST follow the existing serve-knob override style used by `--kv-bits`, `--max-context`, and `--max-batch`.
+
+### FR-3. Config and environment schema
+
+The provider's flat config schema MUST add:
+
+| YAML key | Env var | CLI override |
+|---|---|---|
+| `draft_model` | `MACPROVIDER_DRAFT_MODEL` | `--draft-model` |
+| `num_draft_tokens` | `MACPROVIDER_NUM_DRAFT_TOKENS` | `--num-draft-tokens` |
+
+Precedence MUST remain CLI over environment over YAML over default. `num_draft_tokens` without `draft_model` is accepted but inert; implementations SHOULD log one operator-facing warning at startup.
+
+### FR-4. Runtime load and compatibility check
+
+When `draft_model` is configured, serve startup MUST:
+
+1. Load the target model exactly as today.
+2. Load the draft model into a separate container/cache context.
+3. Verify tokenizer compatibility before accepting buyer traffic.
+4. Run a minimal speculative-generation probe at `temperature=0`, `max_tokens=1`, and `num_draft_tokens=1`.
+5. Fail startup if the draft model cannot load, tokenizer compatibility cannot be proven, or the speculative probe fails.
+
+The failure MUST be loud and local: nonzero process exit, structured error log, and no partial admission to the coordinator as spec-decode enabled.
+
+### FR-5. Request gating
+
+In v0.1, speculative decoding MUST run only when all conditions hold:
+
+- `draft_model` is configured and compatibility-checked.
+- The request's parsed `temperature` is exactly `0.0`.
+- The request is not using a runtime feature the implementation cannot prove compatible with Swift speculative generation.
+
+Requests with `temperature > 0.0` MUST use the existing non-speculative path. This is required because the buyer controls `temperature`, MacProvider currently defaults it to `1.0`, and v0.1 does not define stochastic equivalence.
+
+### FR-6. Swift primitive
+
+The implementation MUST use the pinned `mlx-swift-lm` speculative decoding API, not shell out to Python `mlx_lm.server` or `mlx_lm.generate`.
+
+The implementation SHOULD use `generate(input:cache:parameters:context:draftModel:draftCache:numDraftTokens:)` or the equivalent `SpeculativeTokenIterator` pathway exposed by `mlx-swift-lm` 3.31.4.
+
+### FR-7. Usage and receipt invariants
+
+SPEC-028 MUST NOT add any field to SPEC-015 v0.4 settlement `usage`. The receipt tuple and verifier strict key sets remain owned by SPEC-015.
+
+Spec decode accepted/drafted tokens are implementation telemetry, not billable usage. Billable and observed token counts continue to mean target input/output tokens only.
+
+### FR-8. Provider aggregate telemetry
+
+The provider runtime MUST aggregate speculative-decoding counters over the same provider metrics window used for request/tps heartbeat fields.
+
+Required fields:
+
+| Field | Type | Semantics |
+|---|---|---|
+| `spec_decode_enabled` | boolean | True when a compatible draft model is loaded and eligible for greedy requests. |
+| `spec_decode_draft_model_id` | string or null | Configured draft model ID/path after resolution, or null when disabled. |
+| `spec_decode_num_draft_tokens` | integer or null | Active draft-token count, or null when disabled. |
+| `spec_decode_drafted_tokens_since_last` | integer | Draft tokens proposed in the current metrics window. |
+| `spec_decode_accepted_tokens_since_last` | integer | Draft tokens accepted by target verification in the current metrics window. |
+| `spec_decode_acceptance_rate` | number or null | `accepted / drafted` for the current metrics window; null when no draft tokens were attempted. |
+
+These fields MUST appear on `/v1/status`. They MAY appear on heartbeat in the same implementation round; if heartbeat fields are included, they MUST use the exact names above.
+
+### FR-9. Warm-swap lifecycle
+
+When warm swap is disabled, the draft model lifecycle is bound to process startup and shutdown.
+
+When warm swap is enabled:
+
+1. Draft compatibility is bound to the target model.
+2. While a new target is loading, new requests MUST run non-speculative unless a compatible draft for that target is already loaded and verified.
+3. In-flight requests MUST keep using the target/draft pair associated with their captured runtime snapshot.
+4. A draft-load failure during target swap MUST NOT roll back a successful target swap. The provider MUST continue serving the target non-speculatively and set `spec_decode_enabled=false`.
+5. SPEC-011 target `model_hash` semantics remain unchanged. Draft model hash is not required by SPEC-028 v0.1.
+
+### FR-10. Supported models and catalog posture
+
+`supported_models[]` continues to describe target models the provider is willing to serve. It MUST NOT be overloaded to include draft model IDs.
+
+If a future coordinator or UI needs draft capability discovery, it must read the explicit SPEC-028 telemetry fields, not infer from `supported_models[]`.
+
+### FR-11. Autotune extension
+
+SPEC-013 autotune MAY gain an outer-loop draft-pair selection step. It MUST NOT blindly multiply every existing context/concurrency/kv cell by every draft candidate.
+
+Static candidate rows MAY add:
+
+```json
+"draft_candidates": [
+  {
+    "model_id": "mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit",
+    "default_num_draft_tokens": 3,
+    "min_extra_ram_gb": 2,
+    "workload_bias": ["code_completion", "agent_style"]
+  }
+]
+```
+
+The serving implementation does not depend on autotune shipping first.
+
+---
+
+## 4. Compatibility Matrix
+
+The following candidate pairs are approved for benchmark exploration, not LOCKED production defaults:
+
+| Family | Target | Drafts |
+|---|---|---|
+| Qwen2.5 Instruct | `mlx-community/Qwen2.5-7B-Instruct-4bit` | `mlx-community/Qwen2.5-1.5B-Instruct-4bit`, `mlx-community/Qwen2.5-0.5B-Instruct-4bit` |
+| Qwen2.5 Coder | `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit`, `mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit` |
+| Qwen3 | `mlx-community/Qwen3-32B-4bit` | `mlx-community/Qwen3-1.7B-4bit`, `mlx-community/Qwen3-0.6B-4bit` |
+| Qwen3 Coder | `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | `mlx-community/Qwen3-1.7B-4bit`, `mlx-community/Qwen3-0.6B-4bit` |
+| Llama | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` | `mlx-community/Llama-3.2-3B-Instruct-4bit`, `mlx-community/Llama-3.2-1B-Instruct-4bit` |
+| Llama small-Air | `mlx-community/Llama-3.2-3B-Instruct-4bit` | `mlx-community/Llama-3.2-1B-Instruct-4bit` |
+
+The current gpt-oss catalog row has no confirmed smaller same-family draft candidate. SPEC-028 remains draft until that is either resolved or explicitly waived.
+
+---
+
+## 5. Acceptance Criteria
+
+**AC-1. Disabled baseline.** Start `serve` without `--draft-model`; a representative non-streaming and streaming request produces byte-identical response shape and usage fields compared with pre-SPEC-028.
+
+**AC-2. Config precedence.** YAML `draft_model`, env `MACPROVIDER_DRAFT_MODEL`, and CLI `--draft-model` resolve in the standard CLI > env > YAML order. Same for `num_draft_tokens`.
+
+**AC-3. Validation.** `--num-draft-tokens 0`, `--num-draft-tokens -1`, and `--num-draft-tokens 17` fail at serve preflight with exit code 2.
+
+**AC-4. Tokenizer mismatch.** A known-incompatible target/draft pair fails before coordinator admission with `draft_model_tokenizer_mismatch` or an equivalent stable error code.
+
+**AC-5. Greedy gate.** With a compatible draft configured, a request with `"temperature": 0` uses speculative generation and updates accepted/drafted telemetry. The same request with `"temperature": 0.7` completes through the non-speculative path and does not increment draft counters.
+
+**AC-6. Receipt invariant.** With SPEC-015 receipts enabled, the settlement receipt `usage` object contains exactly the v0.4 five fields and no speculative counters.
+
+**AC-7. Status telemetry.** `/v1/status` includes all FR-8 fields with correct disabled, enabled/no-window, and enabled/after-request values.
+
+**AC-8. Heartbeat telemetry.** If the implementation emits FR-8 fields on heartbeat, a mock coordinator accepts them without changing routing behavior.
+
+**AC-9. Warm-swap target coupling.** During a warm swap, requests started before the swap finish on their captured target/draft pair; requests accepted while the new draft is not ready run non-speculatively.
+
+**AC-10. First performance canary.** On air5 or equivalent 16 GB Apple Silicon, with target `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit`, draft `mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit`, workload `code_completion`, seed prompt `spec028-code-iso8601-v1`, `temperature=0`, `max_tokens=240`, and `num_draft_tokens=3`, median generation throughput over 5 warm runs MUST be at least 24 tok/s and `spec_decode_acceptance_rate` MUST be non-null and at least 0.35. If target model availability blocks this exact canary, the implementing PR MUST record the substituted Qwen2.5 Coder 7B-compatible target/draft pair and keep the same threshold unless a maintainer approves a change.
+
+**AC-11. Small-Air canary.** On M1 8 GB, target `mlx-community/Llama-3.2-3B-Instruct-4bit` plus draft `mlx-community/Llama-3.2-1B-Instruct-4bit` MUST complete `short_chat` and `streaming_check` at `temperature=0` without Metal OOM or process crash.
+
+---
+
+## 6. Open Questions
+
+1. Which smaller gpt-oss draft, if any, is license-clean and tokenizer-compatible with `mlx-community/gpt-oss-20b-MXFP4-Q8`?
+2. Is greedy-only v0.1 acceptable, or does product require stochastic speculative decoding behind an explicit risk flag?
+3. Should heartbeat carry draft model hash in a SPEC-011 amendment, or is draft model ID plus acceptance metrics enough for v0.1?
+4. Which model-card license approvals are required before publishing Qwen/Llama draft recommendations in the static catalog?
+5. Should the first LOCK gate use a stricter plain-vs-spec token-equivalence canary for Qwen3, given current upstream issue reports?
+
+---
+
+## 7. Implementation Notes for Future Build Prompt
+
+Implementation will likely touch:
+
+- `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift`
+- `phase3-binary/Sources/MacProviderCore/Config.swift`
+- `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+- `phase3-binary/Sources/macprovider-cli/ProviderStatus.swift`
+- `phase3-binary/Sources/macprovider-cli/HTTPServer.swift`
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+- tests for config precedence, runtime gating, status/heartbeat telemetry, receipts, and warm-swap lifecycle.
+
+Those edits are out of scope for this research branch.

--- a/specs/SPEC-028-mlx-speculative-decoding.md
+++ b/specs/SPEC-028-mlx-speculative-decoding.md
@@ -5,10 +5,12 @@
 **Date drafted:** 2026-07-05
 **Revision history:**
 - v0.1 (2026-07-05): initial research-round draft.
-- v0.2 (2026-07-05): greedy-only gate confirmed for v0.1; draft-model hash explicitly out of scope (no SPEC-011 amendment); gpt-oss waived from v0.1 compatibility; AC-10 reframed as ratio over measured baseline plus a sustained-thermal window; FR-4 gains a `ProviderCapacity` headroom refresh; FR-9 gains a counter-reset on warm-swap boundary.
+- v0.2 (2026-07-05): greedy-only gate confirmed for v0.1; draft-model hash explicitly out of scope (no SPEC-011 amendment); gpt-oss waived from v0.1 compatibility; AC-10 reframed as ratio over measured baseline plus a sustained-thermal window; FR-4 gains a concrete `ProviderCapacity` headroom refresh and fixed plain-vs-spec equivalence fixture; FR-5 gains a v0.1 request-feature allowlist; FR-8 gates heartbeat telemetry behind an operator opt-in until a coordinator SPEC consumes it; FR-9 gains a counter-reset on warm-swap boundary; FR-12 defines fail-closed runtime speculative error handling.
 **Depends on:** SPEC-001 v1.6 (`macprovider-cli serve`, OpenAI-compatible HTTP, heartbeat/status), SPEC-010 v1.5 (`supported_models[]` semantics), SPEC-011 v0.5 (warm-swap state machine and target `model_hash` heartbeat), SPEC-013 v0.3 (`autotune` serving knobs and static candidate catalog), SPEC-015 v0.4.2 (locked settlement receipt usage schema), `mlx-swift-lm` 3.31.4.
 
 SPEC-028 is provider-side only. With no draft model configured, provider behavior MUST be byte-identical to the existing non-speculative serve path. SPEC-028 MUST NOT change the buyer API, the SPEC-015 v0.4 receipt tuple, settlement verifier behavior, or coordinator routing policy.
+
+In this document, "v0.1" means the first implementation profile of SPEC-028, not the draft-document version number.
 
 ---
 
@@ -64,8 +66,10 @@ No buyer-visible JSON response, SSE frame, token count, receipt tuple, or error 
 
 | Flag | Type | Default | Validation |
 |---|---|---|---|
-| `--draft-model <id-or-path>` | string | unset | Non-empty when present. May be HuggingFace ID or local path, matching `--model` resolution style. |
+| `--draft-model <id-or-path>` | string | unset | Non-empty when present. May be HuggingFace ID or local path, matching `--model` resolution style, subject to the draft artifact provenance guard in FR-4 before coordinator admission. |
+| `--draft-model-artifact-sha256 <hex>` | string | unset | Optional for local-only non-coordinator smoke runs; required for coordinator-joining or settlement-capable serve unless an explicit signed/static draft-candidate allowlist supplies the same binding. Must be lowercase hex SHA-256 when present. |
 | `--num-draft-tokens <N>` | integer | `3` when `draft_model` is set | `1 <= N <= 16`; invalid values fail serve preflight with exit code 2. |
+| `--publish-spec-decode-telemetry` | boolean | `false` | When false, SPEC-028 fields remain local to `/v1/status` and MUST NOT appear on heartbeat. When true, heartbeat MUST include FR-8 fields after coordinator compatibility is verified. |
 
 These flags MUST follow the existing serve-knob override style used by `--kv-bits`, `--max-context`, and `--max-batch`.
 
@@ -76,7 +80,9 @@ The provider's flat config schema MUST add:
 | YAML key | Env var | CLI override |
 |---|---|---|
 | `draft_model` | `MACPROVIDER_DRAFT_MODEL` | `--draft-model` |
+| `draft_model_artifact_sha256` | `MACPROVIDER_DRAFT_MODEL_ARTIFACT_SHA256` | `--draft-model-artifact-sha256` |
 | `num_draft_tokens` | `MACPROVIDER_NUM_DRAFT_TOKENS` | `--num-draft-tokens` |
+| `publishes_spec_decode_telemetry` | `MACPROVIDER_PUBLISHES_SPEC_DECODE_TELEMETRY` | `--publish-spec-decode-telemetry` |
 
 Precedence MUST remain CLI over environment over YAML over default. `num_draft_tokens` without `draft_model` is accepted but inert; implementations SHOULD log one operator-facing warning at startup.
 
@@ -85,11 +91,43 @@ Precedence MUST remain CLI over environment over YAML over default. `num_draft_t
 When `draft_model` is configured, serve startup MUST:
 
 1. Load the target model exactly as today.
-2. Load the draft model into a separate container/cache context.
-3. Verify tokenizer compatibility before accepting buyer traffic.
-4. Run a minimal speculative-generation probe at `temperature=0`, `max_tokens=1`, and `num_draft_tokens=1`.
-5. Fail startup if the draft model cannot load, tokenizer compatibility cannot be proven, or the speculative probe fails.
-6. Refresh `ProviderCapacity` effective headroom (max context, batch, working-set) to reflect the second resident model. The current default context — 20k on 8 GB machines — is set without knowledge of a second resident model (`ProviderStatus.swift:23-37`), so leaving it unchanged over-admits traffic. If the resulting refresh drops effective `max_context` below the SPEC-013 candidate row's minimum, serve preflight MUST fail with a `draft_model_capacity_shortfall` (or equivalent stable code).
+2. Resolve and verify draft model artifact provenance before coordinator admission. When serve is running in a coordinator-joining or settlement-capable mode that requires target artifact verification, the draft model MUST be loaded from a verified local snapshot whose computed SHA-256 matches `draft_model_artifact_sha256`, or from an explicit signed/static draft-candidate allowlist tied to the target model that supplies the same artifact binding. If the current implementation has no signed draft-candidate allowlist, the only compliant v0.1 path is a verified local draft snapshot plus `draft_model_artifact_sha256`. Startup MUST fail with `draft_model_unverified_artifact` if the draft artifact provenance is unavailable or weaker than the target-model provenance required for the same serve mode. This guard is internal preflight state only; it does not add a `draft_model_hash` heartbeat or receipt field in SPEC-028 v0.1.
+3. Load the draft model into a separate container/cache context.
+4. Verify tokenizer compatibility before accepting buyer traffic.
+5. Run a minimal speculative-generation probe at `temperature=0`, `max_tokens=1`, and `num_draft_tokens=1`.
+6. Fail startup if the draft model cannot load, tokenizer compatibility cannot be proven, or the speculative probe fails.
+7. Refresh `ProviderCapacity` effective headroom (max context, batch, working-set) to reflect the second resident model. The current default context — 20k on 8 GB machines — is set without knowledge of a second resident model (`ProviderStatus.swift:23-37`), so leaving it unchanged over-admits traffic. The deterministic v0.1 rule is:
+   - `requested_context_tokens = resolved.max_context_override ?? ProviderCapacity.defaultForRamTier`. If the helper does not exist in code yet, the implementing PR MUST add it as a pure function returning the existing tier defaults from `ProviderCapacity.init` (8 GB -> 20000, 16 GB -> 50000, 32 GB -> 120000, 64 GB+ -> 200000).
+   - `draft_context_cap = 8192` on 8 GB tier, `20000` on 16 GB tier, `50000` on 32 GB tier, and `120000` on 64 GB+ tier.
+   - `effective_max_context_tokens = min(requested_context_tokens, draft_context_cap)`.
+   - `effective_max_batch = 1` for all draft-enabled v0.1 providers, regardless of any higher `max_concurrency_override`, because current production history already treats concurrent MLX inference as unsafe.
+   - `/v1/status`, heartbeat, coordinator auth admission, legacy coordinator hello admission, and local preflight MUST advertise/enforce the effective values, not the unrefreshed defaults.
+   - Serve preflight MUST fail with `draft_model_capacity_shortfall` when the operator explicitly requested `max_context_override` above the effective cap. v0.1 has no override for this downshift. This avoids silently advertising a larger context window than target+draft can safely host.
+   - Serve preflight MUST fail with `draft_model_capacity_shortfall` when the operator explicitly requested `max_concurrency_override > 1`. Default or unspecified concurrency still downshifts to `effective_max_batch = 1`.
+8. Run a plain-vs-spec token-equivalence canary for the configured target/draft pair before coordinator admission. The implementing PR MUST add the fixed fixture at `phase3-binary/Tests/Fixtures/spec028/equivalence-smoke-v1.json` with this exact request content:
+
+   ```json
+   {
+     "fixture_id": "spec028-equivalence-smoke-v1",
+     "messages": [
+       {
+         "role": "system",
+         "content": "You are a deterministic coding assistant. Answer with concise plain text only."
+       },
+       {
+         "role": "user",
+         "content": "Write a Swift function named iso8601DayPrefix that returns the first 10 characters of an ISO-8601 timestamp if present, otherwise returns nil."
+       }
+     ],
+     "temperature": 0,
+     "top_p": 1.0,
+     "max_tokens": 64,
+     "stream": false,
+     "response_format": { "type": "text" }
+   }
+   ```
+
+   The canary MUST load the fixture bytes rather than synthesize a prompt, MUST run with no conversation-cache reuse, no tools, no structured response format, and no streaming, and MUST compare generated token IDs, not decoded text. If the token ID sequence differs, serve startup MUST fail with `draft_model_equivalence_failed` and MUST NOT fall back silently to spec-decode-enabled serving.
 
 The failure MUST be loud and local: nonzero process exit, structured error log, and no partial admission to the coordinator as spec-decode enabled.
 
@@ -99,9 +137,19 @@ In v0.1, speculative decoding MUST run only when all conditions hold:
 
 - `draft_model` is configured and compatibility-checked.
 - The request's parsed `temperature` is exactly `0.0`.
-- The request is not using a runtime feature the implementation cannot prove compatible with Swift speculative generation.
+- The request is in the v0.1 allowlist:
+  - no top-level `tools` entries;
+  - no top-level `tool_choice` other than absent/null/default none; explicit `"auto"` is outside the v0.1 allowlist even when `tools` is absent;
+  - no prompt messages with role `tool`;
+  - no assistant prompt messages containing `tool_calls`;
+  - parsed `responseFormat` is plain text; absent `response_format` and explicit `{"type":"text"}` are allowed, JSON object/schema formats are not;
+  - no logprobs/top-logprobs output request; `logprobs` may be absent, null, or false, and `top_logprobs` must be absent or null;
+  - `logit_bias` is absent or null;
+  - no presence or frequency penalty other than `0.0`;
+  - `top_p == 1.0`;
+  - no conversation-cache reuse for the first implementation PR unless the implementation also adds a plain-vs-spec equivalence canary that exercises the cached path.
 
-Requests with `temperature > 0.0` MUST use the existing non-speculative path. This is required because the buyer controls `temperature`, MacProvider currently defaults it to `1.0`, and v0.1 does not define stochastic equivalence.
+Requests outside that allowlist MUST use the existing non-speculative path and MUST NOT increment spec-decode drafted/accepted counters. This is required because the buyer controls `temperature`, MacProvider currently defaults it to `1.0`, and v0.1 does not define stochastic equivalence.
 
 ### FR-6. Swift primitive
 
@@ -124,13 +172,13 @@ Required fields:
 | Field | Type | Semantics |
 |---|---|---|
 | `spec_decode_enabled` | boolean | True when a compatible draft model is loaded and eligible for greedy requests. |
-| `spec_decode_draft_model_id` | string or null | Configured draft model ID/path after resolution, or null when disabled. |
+| `spec_decode_draft_model_id` | string or null | Public HuggingFace model ID or a non-reversible redacted local alias for the configured draft model, or null when disabled. Raw local filesystem paths and basename-derived local aliases MUST NOT be emitted on `/v1/status` or heartbeat. Local aliases MUST use at least 128 bits of digest entropy, such as `local:<first-32-hex-of-sha256(canonical-path)>`, or a keyed/salted non-reversible equivalent. |
 | `spec_decode_num_draft_tokens` | integer or null | Active draft-token count, or null when disabled. |
 | `spec_decode_drafted_tokens_since_last` | integer | Draft tokens proposed in the current metrics window. |
 | `spec_decode_accepted_tokens_since_last` | integer | Draft tokens accepted by target verification in the current metrics window. |
 | `spec_decode_acceptance_rate` | number or null | `accepted / drafted` for the current metrics window; null when no draft tokens were attempted. |
 
-These fields MUST appear on `/v1/status`. They MAY appear on heartbeat in the same implementation round; if heartbeat fields are included, they MUST use the exact names above.
+These fields, and only these SPEC-028 fields, MUST appear on `/v1/status` as provider-status observability, not as a buyer API extension. SPEC-028 telemetry MUST NOT include buyer prompt/output content, account identifiers, request IDs, raw receipt material, receipt-sensitive state, or per-request rows. Heartbeat emission is opt-in in v0.1: the fields MUST NOT appear on heartbeat unless the operator enables `--publish-spec-decode-telemetry` / `publishes_spec_decode_telemetry` and a coordinator compatibility check has accepted the extra keys. When that flag is enabled and the compatibility check passes, heartbeat emission of all FR-8 fields is REQUIRED; if the compatibility check fails, serve preflight MUST fail with `spec_decode_heartbeat_incompatible` rather than silently run with the requested publish flag ignored. The v0.1 compatibility predicate is an implementation test against the current coordinator heartbeat decoder/state-update path if it is available in this repository; otherwise it MUST use a fixture generated from the current coordinator heartbeat JSON schema, not an invented parser. The test MUST decode a heartbeat containing the FR-8 fields as an unknown-key-tolerant JSON object, preserve the provider session, preserve existing heartbeat metrics, and make no routing/trust/settlement/admission transition from those fields. No runtime negotiation or coordinator ACK is required in SPEC-028. Until a future coordinator-side SPEC consumes these fields, the coordinator MUST NOT make routing, trust, settlement, or admission decisions from them; they are self-reported observability only.
 
 ### FR-9. Warm-swap lifecycle
 
@@ -142,7 +190,7 @@ When warm swap is enabled:
 2. While a new target is loading, new requests MUST run non-speculative unless a compatible draft for that target is already loaded and verified.
 3. In-flight requests MUST keep using the target/draft pair associated with their captured runtime snapshot.
 4. A draft-load failure during target swap MUST NOT roll back a successful target swap. The provider MUST continue serving the target non-speculatively and set `spec_decode_enabled=false`.
-5. On every target-swap boundary the `spec_decode_drafted_tokens_since_last` and `spec_decode_accepted_tokens_since_last` counters MUST reset to zero, so `spec_decode_acceptance_rate` never blends pre-swap and post-swap draft populations. The heartbeat window immediately following a swap MAY report `spec_decode_acceptance_rate=null` if no draft tokens were attempted post-swap.
+5. Spec-decode counters MUST be tagged internally by the target/draft generation captured at request start. On every target-swap boundary the current-window `spec_decode_drafted_tokens_since_last` and `spec_decode_accepted_tokens_since_last` counters MUST reset to zero, so `spec_decode_acceptance_rate` never blends pre-swap and post-swap draft populations. Late completions from the old generation MUST NOT increment the new current-window counters; they MAY be recorded in an internal closed-generation bucket that is not emitted on heartbeat/status. The heartbeat window immediately following a swap MAY report `spec_decode_acceptance_rate=null` if no draft tokens were attempted post-swap.
 6. SPEC-011 target `model_hash` semantics remain unchanged. Draft model hash is not required by SPEC-028 v0.1.
 
 ### FR-10. Supported models and catalog posture
@@ -170,6 +218,15 @@ Static candidate rows MAY add:
 
 The serving implementation does not depend on autotune shipping first.
 
+### FR-12. Runtime speculative error handling
+
+After startup admission, a speculative-generation error for an allowlisted request MUST fail closed:
+
+1. If the error occurs before any buyer-visible token, SSE frame, receipt state, or request-log terminal state is emitted, the provider MAY retry the request once on the existing non-speculative target path. That retry MUST use the same request snapshot target model/hash and MUST NOT carry over partial draft cache state.
+2. If the error occurs after any buyer-visible token or SSE frame is emitted, the provider MUST NOT retry or stitch output across speculative and non-speculative paths. It MUST terminate through the existing SPEC-001 error/streaming terminal path for inference errors.
+3. Spec-decode drafted/accepted counters MUST NOT be incremented for failed speculative attempts unless the target verification completed and the implementation can attribute counters without mixing failed/retried output. v0.1 implementations SHOULD count only successful final completions.
+4. SPEC-015 receipts, when enabled, MUST bind only the final target-generated output and the existing v0.4 five-field usage object. A request MUST NOT emit a settlement receipt for output assembled across a failed speculative attempt and a fallback retry.
+
 ---
 
 ## 4. Compatibility Matrix
@@ -179,13 +236,16 @@ The following candidate pairs are approved for benchmark exploration, not LOCKED
 | Family | Target | Drafts |
 |---|---|---|
 | Qwen2.5 Instruct | `mlx-community/Qwen2.5-7B-Instruct-4bit` | `mlx-community/Qwen2.5-1.5B-Instruct-4bit`, `mlx-community/Qwen2.5-0.5B-Instruct-4bit` |
+| Qwen2.5 Coder small-Air | `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit` | `mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit`, `mlx-community/Qwen2.5-Coder-0.5B-Instruct-4bit` |
 | Qwen2.5 Coder | `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit`, `mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit` |
 | Qwen3 | `mlx-community/Qwen3-32B-4bit` | `mlx-community/Qwen3-1.7B-4bit`, `mlx-community/Qwen3-0.6B-4bit` |
 | Qwen3 Coder | `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | `mlx-community/Qwen3-1.7B-4bit`, `mlx-community/Qwen3-0.6B-4bit` |
 | Llama | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` | `mlx-community/Llama-3.2-3B-Instruct-4bit`, `mlx-community/Llama-3.2-1B-Instruct-4bit` |
 | Llama small-Air | `mlx-community/Llama-3.2-3B-Instruct-4bit` | `mlx-community/Llama-3.2-1B-Instruct-4bit` |
 
-The current gpt-oss catalog row has no confirmed smaller same-family draft candidate. SPEC-028 remains draft until that is either resolved or explicitly waived.
+The current gpt-oss catalog row has no confirmed smaller same-family draft candidate. v0.2 explicitly waives gpt-oss from v0.1 spec-decode support; gpt-oss providers continue serving non-speculatively until a future SPEC names a compatible draft.
+
+48 GB+ target/draft acceptance canaries are deliberately deferred from SPEC-028 v0.1. The 30B/32B pairs above are benchmark-exploration candidates only until a later implementation or SPEC-013 amendment adds large-host acceptance evidence.
 
 ---
 
@@ -193,31 +253,45 @@ The current gpt-oss catalog row has no confirmed smaller same-family draft candi
 
 **AC-1. Disabled baseline.** Start `serve` without `--draft-model`; a representative non-streaming and streaming request produces byte-identical response shape and usage fields compared with pre-SPEC-028.
 
-**AC-2. Config precedence.** YAML `draft_model`, env `MACPROVIDER_DRAFT_MODEL`, and CLI `--draft-model` resolve in the standard CLI > env > YAML order. Same for `num_draft_tokens`.
+**AC-2. Config precedence.** YAML `draft_model`, env `MACPROVIDER_DRAFT_MODEL`, and CLI `--draft-model` resolve in the standard CLI > env > YAML order. Same for `draft_model_artifact_sha256`, `num_draft_tokens`, and `publishes_spec_decode_telemetry`.
 
 **AC-3. Validation.** `--num-draft-tokens 0`, `--num-draft-tokens -1`, and `--num-draft-tokens 17` fail at serve preflight with exit code 2.
 
-**AC-4. Tokenizer mismatch.** A known-incompatible target/draft pair fails before coordinator admission with `draft_model_tokenizer_mismatch` or an equivalent stable error code.
+**AC-4. Tokenizer/equivalence mismatch.** A known-incompatible target/draft pair fails before coordinator admission with `draft_model_tokenizer_mismatch` or an equivalent stable error code. A tokenizer-compatible pair whose `phase3-binary/Tests/Fixtures/spec028/equivalence-smoke-v1.json` token IDs diverge between plain and spec generation fails before coordinator admission with `draft_model_equivalence_failed`.
 
-**AC-5. Greedy gate.** With a compatible draft configured, a request with `"temperature": 0` uses speculative generation and updates accepted/drafted telemetry. The same request with `"temperature": 0.7` completes through the non-speculative path and does not increment draft counters.
+**AC-5. Greedy and feature gate.** With a compatible draft configured, a request with `"temperature": 0`, `top_p: 1.0`, no top-level tools/tool choice, no prompt `tool` role or assistant `tool_calls`, plain text response format, no logprobs/top-logprobs output request, no `logit_bias`, no penalties, and no conversation-cache reuse uses speculative generation and updates accepted/drafted telemetry. The same request with `"temperature": 0.7`, non-default `top_p`, tools/tool choice/tool-call history, explicit `tool_choice: "auto"` even without `tools`, JSON response format, `logprobs: true`, non-null `top_logprobs`, non-null `logit_bias`, penalties, or cache reuse completes through the non-speculative path and does not increment draft counters.
 
 **AC-6. Receipt invariant.** With SPEC-015 receipts enabled, the settlement receipt `usage` object contains exactly the v0.4 five fields and no speculative counters.
 
 **AC-7. Status telemetry.** `/v1/status` includes all FR-8 fields with correct disabled, enabled/no-window, and enabled/after-request values.
 
-**AC-8. Heartbeat telemetry.** If the implementation emits FR-8 fields on heartbeat, a mock coordinator accepts them without changing routing behavior.
+**AC-8. Heartbeat telemetry.** By default, heartbeat omits FR-8 fields. When the operator enables the SPEC-028 heartbeat telemetry flag, the current coordinator heartbeat decoder/state-update path, or a fixture generated from its current heartbeat JSON schema when that path is unavailable to the binary test target, accepts the extra fields without changing routing behavior, trust state, settlement state, or admission state. With the flag enabled and compatibility accepted, `CoordinatorClient.sendHeartbeat` or its test seam MUST emit all FR-8 fields; with the flag disabled, it MUST emit none of them.
 
 **AC-9. Warm-swap target coupling.** During a warm swap, requests started before the swap finish on their captured target/draft pair; requests accepted while the new draft is not ready run non-speculatively.
 
-**AC-10. First performance canary (ratio + thermal window).** On air5 or equivalent 16 GB Apple Silicon, with target `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit`, draft `mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit`, workload `code_completion`, seed prompt `spec028-code-iso8601-v1`, `temperature=0`, `max_tokens=240`, `num_draft_tokens=3`:
+**AC-9a. Runtime speculative failure.** A harness-injected speculative error before first output may retry once non-speculatively and must emit counters/receipt only for the final non-spec output. A harness-injected speculative error after the first streaming chunk must not retry or stitch output; it must terminate through the existing streaming error path and must not emit a settlement receipt for mixed output.
 
-1. **Ratio floor (not absolute tok/s).** Immediately before the spec-decode run, capture the median non-spec generation throughput over 5 warm runs at the same target/prompt/params (`baseline_tps`). Median spec-decode throughput over 5 warm runs MUST be at least `1.4 * baseline_tps`. This replaces v0.1's absolute 24 tok/s floor, which drifts across mlx-swift-lm releases and macOS updates.
-2. **Acceptance floor.** `spec_decode_acceptance_rate` MUST be non-null and at least 0.30 over the same 5 runs.
-3. **Sustained thermal window.** After the paired 5-run comparison, run the spec-decode configuration back-to-back for at least 5 minutes of continuous generation. Median throughput measured over the *last minute* of that window MUST remain at least `1.2 * baseline_tps`. This guards against acceptance-driven token throughput heat-soaking the device into thermal throttle — a failure mode the short warm-run measurement will not surface.
+**AC-10. First performance canary (ratio + thermal window).** On air5 or equivalent 16 GB Apple Silicon, intentionally using the Qwen2.5 Coder pair rather than the current generic Qwen2.5 beta config, with target `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit`, draft `mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit`, workload `code_completion`, seed prompt `spec028-code-iso8601-v1`, `temperature=0`, `max_tokens=240`, `num_draft_tokens=3`:
+
+1. **Fixture.** `spec028-code-iso8601-v1` is a checked-in workload fixture containing the ISO-8601 parser prompt currently used as the `code_completion` fallback in `beta/workloads.py`; the implementing PR MUST add the stable fixture before running this AC, and MUST NOT use the time-varying corpus sampler for this canary.
+2. **Ratio floor (not absolute tok/s).** Immediately before the spec-decode run, capture the median non-spec generation throughput over 5 warm runs at the same target/prompt/params (`baseline_tps`) in the same process shape used for the spec-decode run: target and draft are resident, but generation is forced down the non-speculative path for the baseline. Median spec-decode throughput over 5 warm runs MUST be at least `1.4 * baseline_tps`. This replaces v0.1's absolute 24 tok/s floor, which drifts across mlx-swift-lm releases and macOS updates.
+3. **Acceptance floor.** `spec_decode_acceptance_rate` MUST be non-null and at least 0.30 over the same 5 runs.
+4. **Sustained thermal window.** After the paired 5-run comparison, run the spec-decode configuration back-to-back for at least 5 minutes of continuous generation. Median throughput measured over the *last minute* of that window MUST remain at least `1.2 * baseline_tps`. This guards against acceptance-driven token throughput heat-soaking the device into thermal throttle — a failure mode the short warm-run measurement will not surface.
 
 If target model availability blocks this exact canary, the implementing PR MUST record the substituted Qwen2.5 Coder 7B-compatible target/draft pair and keep the same ratios and window unless a maintainer approves a change.
 
-**AC-11. Small-Air canary.** On M1 8 GB, target `mlx-community/Llama-3.2-3B-Instruct-4bit` plus draft `mlx-community/Llama-3.2-1B-Instruct-4bit` MUST complete `short_chat` and `streaming_check` at `temperature=0` without Metal OOM or process crash.
+AC-10 is a benchmark canary only. It does not require a SPEC-013 static catalog amendment or make Qwen2.5 Coder a production catalog dependency.
+
+**AC-11. Small-Air canary.** On M1 8 GB, target `mlx-community/Llama-3.2-3B-Instruct-4bit` plus draft `mlx-community/Llama-3.2-1B-Instruct-4bit` MUST complete stable checked-in `short_chat` and `streaming_check` fixtures at `temperature=0` without Metal OOM or process crash. The implementing PR MUST pin these fixtures rather than using the time-varying corpus sampler.
+
+**AC-12. Draft-enabled capacity canary.** Before a draft-enabled provider advertises a tier's FR-4 effective context cap through `/v1/status`, heartbeat, coordinator auth admission, legacy coordinator hello admission, or local preflight, the implementing PR MUST prove target+draft residency plus KV growth near that cap on representative hardware for that RAM tier. The canary MUST:
+
+1. Run with target and draft resident, `effective_max_batch = 1`, and the exact effective context cap advertised for the tier.
+2. Exercise a checked-in long-context fixture that reaches at least 90% of the advertised cap before generation, then generate at least 32 target-verified output tokens at `temperature=0`.
+3. Record peak resident memory, whether Metal OOM occurred, and the final advertised effective cap.
+4. Fail the implementation PR for that RAM tier if the run OOMs, crashes, or cannot generate the output tokens.
+
+For the first implementation profile, the 8 GB tier MUST use a pinned long-context fixture based on the existing `long_context` workload shape. The 16 GB tier MUST add a pinned fixture or synthetic checked-in generator that reaches at least 18k input tokens before advertising the 20k draft cap. If a tier cannot be tested in the implementation PR, that tier MUST either keep speculative decoding disabled or advertise the largest lower cap that has passed this AC on that hardware class.
 
 ---
 
@@ -229,6 +303,9 @@ If target model availability blocks this exact canary, the implementing PR MUST 
 - **~~Greedy-only v0.1 gate~~** — confirmed: FR-5 restricts spec decode to `temperature == 0.0`. Stochastic support belongs to a later SPEC with its own equivalence canary.
 - **~~SPEC-011 draft-hash amendment~~** — confirmed not required for v0.1: heartbeat/status carry `spec_decode_draft_model_id` plus counters (FR-8); no `draft_model_hash` field is added.
 - **~~AC-10 absolute-tok/s threshold~~** — replaced by the ratio-plus-thermal-window formulation now written into AC-10.
+- **~~FR-4 capacity threshold ambiguity~~** — replaced by deterministic v0.1 draft context caps and an explicit operator-request downshift rule.
+- **~~Plain-vs-spec equivalence guard~~** — added as a startup gate in FR-4 and AC-4 for every enabled target/draft pair.
+- **~~Runtime speculative failure semantics~~** — FR-12 and AC-9a define when pre-output fallback is allowed and when post-output failures must terminate without stitching outputs or receipts.
 
 ### Still open (do not block LOCK on these unless flagged)
 
@@ -255,11 +332,11 @@ Those edits are out of scope for this research branch.
 
 Implementation is proposed as three bundled PRs to keep the three-lane codex audit surface tight per PR. A single-PR implementation is acceptable if audit lanes stay green.
 
-**PR-A — Plumbing (FR-1..FR-4, FR-6, FR-7, FR-10; AC-1..AC-4, AC-6, AC-11).**
-CLI/env/YAML config, target+draft load, tokenizer compatibility check, `ProviderCapacity` headroom refresh (FR-4.6), Swift primitive wiring, disabled-mode byte-identity, receipt invariant, `supported_models[]` non-overload. Small-Air load canary (AC-11). Audit focus: precedence, load-failure loudness, disabled-mode identity, receipt schema.
+**PR-A — Plumbing (FR-1..FR-4, FR-6, FR-7, FR-10, FR-12 startup portions; AC-1..AC-4, AC-6, AC-11, AC-12).**
+CLI/env/YAML config, target+draft load, draft artifact provenance preflight, tokenizer compatibility check, `ProviderCapacity` headroom refresh (FR-4), Swift primitive wiring, disabled-mode byte-identity, receipt invariant, `supported_models[]` non-overload. Small-Air load canary (AC-11) is a load/minimal-generation proof with the draft resident; request-gating, acceptance-rate, and telemetry proof remain in PR-B. Draft-enabled capacity canary (AC-12) must pass before PR-A advertises the reduced effective caps for any RAM tier. Audit focus: precedence, load-failure loudness, disabled-mode identity, receipt schema, capacity-admission evidence.
 
-**PR-B — Telemetry and greedy gate (FR-5, FR-8; AC-5, AC-7, AC-8, AC-10).**
-`temperature==0` gate, `/v1/status` fields, aggregate counters. Heartbeat fields SHOULD ship behind an operator opt-in flag until a coordinator-side SPEC accepts them, to avoid a schema-compat drift on `CoordinatorClient` heartbeat. AC-10 ratio-plus-thermal-window canary lives here. Audit focus: counter arithmetic under mixed greedy/stochastic traffic, `null` semantics, buyer-response non-mutation.
+**PR-B — Telemetry, greedy gate, and runtime fallback (FR-5, FR-8, FR-12 request-path portions; AC-5, AC-7, AC-8, AC-9a, AC-10).**
+`temperature==0` gate, request-feature allowlist, `/v1/status` fields, aggregate counters, and fail-closed speculative runtime errors. Heartbeat fields SHOULD ship behind an operator opt-in flag until a coordinator-side SPEC accepts them, to avoid a schema-compat drift on `CoordinatorClient` heartbeat. AC-10 ratio-plus-thermal-window canary lives here. Audit focus: counter arithmetic under mixed greedy/stochastic traffic, `null` semantics, buyer-response non-mutation, no stitched outputs across fallback.
 
 **PR-C — Warm-swap lifecycle (FR-9; AC-9).**
 Draft lifecycle coupled to target snapshot, in-flight pair pinning, counter reset on swap boundary. Highest state-machine risk. Audit focus: swap-boundary races, in-flight-request affinity, `spec_decode_enabled` transitions.


### PR DESCRIPTION
## Summary
- revises SPEC-028 v0.2 after the requested R2 audit loop
- adds code/security/architect audit prompts under `specs/AUDIT_SPEC_028_R2_*_PROMPT.md`
- keeps this PR spec-only; implementation remains blocked pending human review

## Final audit pass
- Code: `VERDICT: READY | COUNTS: C=0 H=0 M=0 L=2`
- Security: `VERDICT: READY | COUNTS: C=0 H=0 M=0 L=1`
- Architect: `VERDICT: READY | COUNTS: C=0 H=0 M=0 L=2`

Final local omc artifacts:
- `.omc/artifacts/ask/codex-audit-spec-028-r2-code-prompt-you-are-auditing-specs-spec-02-2026-07-05T08-57-00-974Z.md`
- `.omc/artifacts/ask/codex-audit-spec-028-r2-security-prompt-you-are-auditing-specs-spe-2026-07-05T08-56-05-427Z.md`
- `.omc/artifacts/ask/codex-audit-spec-028-r2-architect-prompt-you-are-auditing-specs-sp-2026-07-05T08-57-00-808Z.md`

## Validation
- `git diff --cached --check`
- `omc ask codex` R2 code/security/architect loop until all lanes returned 0 C/H/M

## Notes
- `.omc` artifacts are ignored runtime outputs and are not committed.
- Existing unrelated untracked files were left untouched.