### PR TITLE
Research prompt: sweep-by-workload-class stratification

### DIFF
--- a/.omc/logs/sweep-workload-class-open-questions-2026-07.md
+++ b/.omc/logs/sweep-workload-class-open-questions-2026-07.md
@@ -3,22 +3,14 @@
 **Date:** 2026-07-09
 **Scope:** Maintainer decisions needed before implementing SPEC-029.
 
-1. Should the static catalog field be named `workload_profiles`, `per_class`, or another canonical term?
-
-   Recommendation: use `workload_profiles` because v0.1 keys are beta harness workload names, not a general request taxonomy.
-
-2. What traffic-weighting policy should choose a single legacy/default winner if consumers cannot yet use per-workload profiles?
+1. What traffic-weighting policy should choose a single legacy/default winner if consumers cannot yet use per-workload profiles?
 
    Recommendation: use observed buyer traffic mix from `runs.sqlite` when available, and require an explicit report note when falling back to equal weights.
 
-3. What numeric TTFT gates should apply to `long_context` and `streaming_check`?
-
-   Recommendation: keep short/medium/code/agent gates strict, define a separate long-context prefill/TTFT gate, and treat streaming TTFT as a probe gate rather than a winner axis.
-
-4. Should SPEC-028 speculative acceptance rate be a hard winner gate or an advisory metric in v0.1?
-
-   Recommendation: record acceptance rate per workload and target/draft pair first; promote to a hard gate only after enough local sweep data exists.
-
-5. Which follow-up SPEC owns runtime workload classification and class-routed serving?
+2. Which follow-up SPEC owns runtime workload classification and class-routed serving?
 
    Recommendation: create a separate coordinator/provider routing SPEC. SPEC-029 should stop at per-workload winners as signed recommendation data.
+
+3. Should a later client SPEC consume `workload_profiles` directly in installer recommendation, or should it first remain a report-only/feed-only artifact?
+
+   Recommendation: keep v0.1 report/feed-only for current clients, then add client consumption in a separate SPEC with explicit backward-compat tests.

--- a/.omc/logs/sweep-workload-class-open-questions-2026-07.md
+++ b/.omc/logs/sweep-workload-class-open-questions-2026-07.md
@@ -1,0 +1,24 @@
+# Sweep Workload-Class Open Questions
+
+**Date:** 2026-07-09
+**Scope:** Maintainer decisions needed before implementing SPEC-029.
+
+1. Should the static catalog field be named `workload_profiles`, `per_class`, or another canonical term?
+
+   Recommendation: use `workload_profiles` because v0.1 keys are beta harness workload names, not a general request taxonomy.
+
+2. What traffic-weighting policy should choose a single legacy/default winner if consumers cannot yet use per-workload profiles?
+
+   Recommendation: use observed buyer traffic mix from `runs.sqlite` when available, and require an explicit report note when falling back to equal weights.
+
+3. What numeric TTFT gates should apply to `long_context` and `streaming_check`?
+
+   Recommendation: keep short/medium/code/agent gates strict, define a separate long-context prefill/TTFT gate, and treat streaming TTFT as a probe gate rather than a winner axis.
+
+4. Should SPEC-028 speculative acceptance rate be a hard winner gate or an advisory metric in v0.1?
+
+   Recommendation: record acceptance rate per workload and target/draft pair first; promote to a hard gate only after enough local sweep data exists.
+
+5. Which follow-up SPEC owns runtime workload classification and class-routed serving?
+
+   Recommendation: create a separate coordinator/provider routing SPEC. SPEC-029 should stop at per-workload winners as signed recommendation data.

--- a/beta/config.yaml
+++ b/beta/config.yaml
@@ -18,6 +18,13 @@ model: "mlx-community/Llama-3.2-3B-Instruct-4bit"
 #   - {id: "mlx-community/Llama-3.2-3B-Instruct-4bit", tier: "8gb"}
 # model_select: "rotate"    # "rotate" | "first" | "day_of_week"
 
+# SPEC-029 sweep metadata. Because this harness can run buyer-side against a
+# remote provider, fill one of these from the provider/sweep host before running
+# `python harness.py --batch spec029`.
+# provider_host_ram_bytes: 17179869184
+# provider_ram_gib: 16
+# provider_ram_tier: "16gb"  # report-only; real SPEC-029 sweeps require bytes/GiB
+
 # Per-request HTTP timeout (seconds). Long-context workloads on 8GB Macs can
 # easily eat 60s of prefill; 180s gives headroom without hanging forever on a
 # dead tunnel.
@@ -44,6 +51,25 @@ batch_adversarial:
   - malformed_tool_call
   # long_context_oom_probe is heavy (~30K tokens) — opt in deliberately:
   # - long_context_oom_probe
+
+# SPEC-029 workload-class sweep. `--batch spec029` forces streaming for included
+# workloads so TTFT can be measured, expands every workload x cell x sample, and
+# requires explicit provider RAM metadata above.
+# spec029_sweep:
+#   samples_per_cell: 20
+#   # Exactly one cell execution mechanism is required for real sweeps:
+#   # cell_control_url: "http://127.0.0.1:8091/spec029/apply-cell"
+#   # cell_apply_command: ["./scripts/apply-spec029-cell.sh"]
+#   workloads:
+#     - short_chat
+#     - medium_with_system
+#     - long_context
+#     - code_completion
+#     - agent_style
+#     - streaming_check
+#   cells:
+#     - {kv_bits: 8, max_context_override: 8192, max_concurrency_override: 1}
+#     - {kv_bits: 4, max_context_override: 20000, max_concurrency_override: 1}
 
 # Where to write the SQLite database. Relative paths resolve against beta/.
 db_path: "runs.sqlite"

--- a/beta/harness.py
+++ b/beta/harness.py
@@ -25,7 +25,9 @@ import argparse
 import json
 import os
 import re
+import shlex
 import sqlite3
+import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -38,6 +40,7 @@ import yaml
 import workloads
 import workloads_adversarial
 import stop_tokens
+import spec029
 
 BETA_DIR = Path(__file__).resolve().parent
 DEFAULT_CONFIG = BETA_DIR / "config.yaml"
@@ -70,6 +73,25 @@ CREATE TABLE IF NOT EXISTS runs (
     prompt_tokens INTEGER,
     completion_tokens INTEGER,
     throughput_tps REAL,
+    host_ram_bytes INTEGER,
+    ram_tier_key TEXT,
+    provider_ram_source TEXT,
+    cell_execution_source TEXT,
+    non_runnable_reason TEXT,
+    corpus_class TEXT,
+    max_context_override INTEGER,
+    max_concurrency_override INTEGER,
+    kv_bits INTEGER,
+    metric_unavailable_reason TEXT,
+    draft_model TEXT,
+    draft_model_artifact_sha256 TEXT,
+    num_draft_tokens INTEGER,
+    drafted_tokens INTEGER,
+    accepted_tokens INTEGER,
+    spec_decode_acceptance_rate REAL,
+    candidate_source TEXT,
+    winner_status TEXT,
+    no_winner_reason TEXT,
     stop_token_leak INTEGER NOT NULL DEFAULT 0,
     error TEXT,
     response_preview TEXT
@@ -106,6 +128,32 @@ CREATE TABLE IF NOT EXISTS full_responses (
     full_content TEXT
 );
 """
+
+RUNS_SPEC029_COLUMNS = {
+    "host_ram_bytes": "INTEGER",
+    "ram_tier_key": "TEXT",
+    "provider_ram_source": "TEXT",
+    "cell_execution_source": "TEXT",
+    "non_runnable_reason": "TEXT",
+    "corpus_class": "TEXT",
+    "max_context_override": "INTEGER",
+    "max_concurrency_override": "INTEGER",
+    "kv_bits": "INTEGER",
+    "metric_unavailable_reason": "TEXT",
+    "draft_model": "TEXT",
+    "draft_model_artifact_sha256": "TEXT",
+    "num_draft_tokens": "INTEGER",
+    "drafted_tokens": "INTEGER",
+    "accepted_tokens": "INTEGER",
+    "spec_decode_acceptance_rate": "REAL",
+    "candidate_source": "TEXT",
+    "winner_status": "TEXT",
+    "no_winner_reason": "TEXT",
+}
+
+
+class Spec029CellApplyError(RuntimeError):
+    """A configured SPEC-029 cell was attempted but could not be made runnable."""
 
 
 def load_config(path: Path) -> dict:
@@ -164,14 +212,24 @@ def resolve_model(cfg: dict, verbose: bool = False) -> str:
 
     # Set cfg["model"] so downstream code just uses cfg["model"]
     cfg["model"] = model_id
+    cfg["_selected_model_entry"] = entry if isinstance(entry, dict) else {"id": model_id}
     return model_id
 
 
 def open_db(db_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path)
     conn.executescript(SCHEMA)
+    ensure_runs_spec029_columns(conn)
     conn.commit()
     return conn
+
+
+def ensure_runs_spec029_columns(conn: sqlite3.Connection) -> None:
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(runs)")}
+    for name, type_name in RUNS_SPEC029_COLUMNS.items():
+        if name not in existing:
+            conn.execute(f"ALTER TABLE runs ADD COLUMN {name} {type_name}")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_runs_spec029_partition ON runs(workload, ram_tier_key)")
 
 
 def detect_leak(text: str) -> bool:
@@ -192,6 +250,34 @@ def strip_leaks_model(text: str, model_id: str) -> str:
     """Per-model stop-token stripping."""
     regex = stop_tokens.get_leak_regex(model_id)
     return regex.sub("", text or "")
+
+
+def extract_spec_decode_metrics(data: dict[str, Any], usage: dict[str, Any] | None = None) -> dict[str, Any]:
+    usage = usage or {}
+    spec_decode = data.get("spec_decode") if isinstance(data.get("spec_decode"), dict) else {}
+
+    def first(*keys):
+        for source in (data, usage, spec_decode):
+            for key in keys:
+                value = source.get(key)
+                if value is not None:
+                    return value
+        return None
+
+    drafted = first("drafted_tokens", "spec_decode_drafted_tokens", "spec_decode_drafted_tokens_since_last")
+    accepted = first("accepted_tokens", "spec_decode_accepted_tokens", "spec_decode_accepted_tokens_since_last")
+    acceptance_rate = first("spec_decode_acceptance_rate", "acceptance_rate")
+    if acceptance_rate is None and drafted not in (None, 0) and accepted is not None:
+        acceptance_rate = accepted / drafted
+
+    out: dict[str, Any] = {}
+    if drafted is not None:
+        out["drafted_tokens"] = drafted
+    if accepted is not None:
+        out["accepted_tokens"] = accepted
+    if acceptance_rate is not None:
+        out["spec_decode_acceptance_rate"] = acceptance_rate
+    return out
 
 
 def fire_nonstream(url: str, model: str, body: dict, timeout: float) -> dict:
@@ -224,6 +310,7 @@ def fire_nonstream(url: str, model: str, body: dict, timeout: float) -> dict:
     usage = data.get("usage") or {}
     out["prompt_tokens"] = usage.get("prompt_tokens")
     out["completion_tokens"] = usage.get("completion_tokens")
+    out.update(extract_spec_decode_metrics(data, usage))
     if out["completion_tokens"] and total_ms > 0:
         out["throughput_tps"] = out["completion_tokens"] / (total_ms / 1000.0)
 
@@ -233,6 +320,65 @@ def fire_nonstream(url: str, model: str, body: dict, timeout: float) -> dict:
     return out
 
 
+def apply_spec029_cell(cfg: dict, cell: dict[str, Any], dry_run: bool, verbose: bool = False) -> str:
+    """Apply or prove the configured SPEC-029 cell before collecting samples."""
+    normalized = spec029.normalize_sweep_cell(cell, cfg)
+    spec_cfg = cfg.get("spec029_sweep") or {}
+    if dry_run:
+        return "dry_run"
+
+    control_url = spec_cfg.get("cell_control_url") or cfg.get("spec029_cell_control_url")
+    if control_url:
+        payload = {"model": cfg["model"], "cell": normalized}
+        try:
+            response = requests.post(control_url, json=payload, timeout=cfg.get("timeout_s", 180))
+        except requests.RequestException as exc:
+            raise Spec029CellApplyError(f"SPEC-029 cell control request failed: {exc}") from exc
+        if response.status_code < 200 or response.status_code >= 300:
+            raise Spec029CellApplyError(f"SPEC-029 cell control failed HTTP {response.status_code}: {response.text[:200]}")
+        return "cell_control_url"
+
+    command = spec_cfg.get("cell_apply_command") or cfg.get("spec029_cell_apply_command")
+    if command:
+        env = os.environ.copy()
+        env.update({
+            "SPEC029_MODEL": str(cfg["model"]),
+            "SPEC029_KV_BITS": str(normalized["kv_bits"]),
+            "SPEC029_MAX_CONTEXT_OVERRIDE": str(normalized["max_context_override"]),
+            "SPEC029_MAX_CONCURRENCY_OVERRIDE": str(normalized["max_concurrency_override"]),
+            "SPEC029_DRAFT_MODEL": str(normalized.get("draft_model") or ""),
+            "SPEC029_DRAFT_MODEL_ARTIFACT_SHA256": str(normalized.get("draft_model_artifact_sha256") or ""),
+            "SPEC029_NUM_DRAFT_TOKENS": str(normalized.get("num_draft_tokens") or ""),
+        })
+        args = command if isinstance(command, list) else shlex.split(str(command))
+        try:
+            subprocess.run(args, check=True, timeout=spec_cfg.get("cell_apply_timeout_s", 180), env=env)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+            raise Spec029CellApplyError(f"SPEC-029 cell apply command failed: {exc}") from exc
+        return "cell_apply_command"
+
+    raise RuntimeError(
+        "SPEC-029 sweep requires spec029_sweep.cell_control_url, "
+        "or spec029_sweep.cell_apply_command"
+    )
+
+
+def validate_spec029_cell_execution_config(cfg: dict, dry_run: bool) -> None:
+    if dry_run:
+        return
+    spec_cfg = cfg.get("spec029_sweep") or {}
+    mechanisms = [
+        bool(spec_cfg.get("cell_control_url") or cfg.get("spec029_cell_control_url")),
+        bool(spec_cfg.get("cell_apply_command") or cfg.get("spec029_cell_apply_command")),
+    ]
+    count = sum(1 for enabled in mechanisms if enabled)
+    if count != 1:
+        raise RuntimeError(
+            "SPEC-029 sweep requires exactly one cell execution mechanism: "
+            "cell_control_url or cell_apply_command"
+        )
+
+
 def fire_stream(url: str, model: str, body: dict, timeout: float) -> dict:
     """POST a streaming request, parse SSE. Returns a metrics dict with TTFT."""
     payload = {"model": model, **body, "stream": True}
@@ -240,6 +386,7 @@ def fire_stream(url: str, model: str, body: dict, timeout: float) -> dict:
     ttft_ms: float | None = None
     pieces: list[str] = []
     usage: dict[str, Any] = {}
+    last_chunk: dict[str, Any] = {}
     http_status: int | None = None
     error: str | None = None
 
@@ -278,6 +425,7 @@ def fire_stream(url: str, model: str, body: dict, timeout: float) -> dict:
                         pieces.append(piece)
                 if chunk.get("usage"):
                     usage = chunk["usage"]
+                last_chunk = chunk
     except requests.RequestException as e:
         error = f"{type(e).__name__}: {e}"
 
@@ -292,6 +440,7 @@ def fire_stream(url: str, model: str, body: dict, timeout: float) -> dict:
         "stop_token_leak": detect_leak_model(content, model),
         "response_preview": strip_leaks_model(content, model)[:300],
     }
+    out.update(extract_spec_decode_metrics(last_chunk, usage))
     out["_full_content"] = content
     if error:
         out["error"] = error
@@ -300,11 +449,25 @@ def fire_stream(url: str, model: str, body: dict, timeout: float) -> dict:
     return out
 
 
-def run_one(cfg: dict, name: str, conn: sqlite3.Connection, verbose: bool, dry_run: bool) -> dict:
+def run_one(
+    cfg: dict,
+    name: str,
+    conn: sqlite3.Connection,
+    verbose: bool,
+    dry_run: bool,
+    cell: dict[str, Any] | None = None,
+    force_stream: bool = False,
+    provider_ram: spec029.ProviderRAM | None = None,
+    cell_execution_source: str | None = None,
+    metrics_override: dict[str, Any] | None = None,
+) -> dict:
     builder = workloads.REGISTRY.get(name)
     if builder is None:
         raise SystemExit(f"unknown workload: {name} (try --list)")
     body = builder()
+    normalized_cell = spec029.normalize_sweep_cell(cell, cfg) if cell is not None else None
+    if force_stream:
+        body["stream"] = True
     streamed = bool(body.get("stream"))
     url = cfg["tunnel_url"].rstrip("/") + "/v1/chat/completions"
 
@@ -313,11 +476,15 @@ def run_one(cfg: dict, name: str, conn: sqlite3.Connection, verbose: bool, dry_r
             print(f"[dry-run] {name} stream={streamed} max_tokens={body.get('max_tokens')}")
         return {}
 
-    if streamed:
+    if metrics_override is not None:
+        metrics = metrics_override
+    elif streamed:
         metrics = fire_stream(url, cfg["model"], body, cfg.get("timeout_s", 180))
     else:
         metrics = fire_nonstream(url, cfg["model"], body, cfg.get("timeout_s", 180))
 
+    provider_ram = provider_ram or spec029.resolve_provider_ram(cfg)
+    cell = normalized_cell if normalized_cell is not None else spec029.sweep_cell_from_config(cfg)
     row = {
         "ts_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "workload": name,
@@ -330,6 +497,29 @@ def run_one(cfg: dict, name: str, conn: sqlite3.Connection, verbose: bool, dry_r
         "prompt_tokens": metrics.get("prompt_tokens"),
         "completion_tokens": metrics.get("completion_tokens"),
         "throughput_tps": metrics.get("throughput_tps"),
+        "host_ram_bytes": provider_ram.host_ram_bytes,
+        "ram_tier_key": provider_ram.ram_tier_key,
+        "provider_ram_source": provider_ram.source,
+        "cell_execution_source": cell_execution_source,
+        "non_runnable_reason": metrics.get("non_runnable_reason"),
+        "corpus_class": spec029.corpus_class_for_workload(name),
+        "max_context_override": cell.get("max_context_override"),
+        "max_concurrency_override": cell.get("max_concurrency_override"),
+        "kv_bits": cell.get("kv_bits"),
+        "metric_unavailable_reason": spec029.metric_unavailable_reason(
+            metrics.get("prompt_tokens"),
+            metrics.get("completion_tokens"),
+            metrics.get("throughput_tps"),
+        ),
+        "draft_model": cell.get("draft_model"),
+        "draft_model_artifact_sha256": cell.get("draft_model_artifact_sha256"),
+        "num_draft_tokens": cell.get("num_draft_tokens"),
+        "drafted_tokens": metrics.get("drafted_tokens"),
+        "accepted_tokens": metrics.get("accepted_tokens"),
+        "spec_decode_acceptance_rate": metrics.get("spec_decode_acceptance_rate"),
+        "candidate_source": cell.get("candidate_source"),
+        "winner_status": None,
+        "no_winner_reason": None,
         "stop_token_leak": int(bool(metrics.get("stop_token_leak"))),
         "error": metrics.get("error"),
         "response_preview": metrics.get("response_preview"),
@@ -337,11 +527,27 @@ def run_one(cfg: dict, name: str, conn: sqlite3.Connection, verbose: bool, dry_r
     cur = conn.execute(
         """INSERT INTO runs (ts_utc, workload, model, tunnel_url, streamed,
                               http_status, ttft_ms, total_ms, prompt_tokens,
-                              completion_tokens, throughput_tps, stop_token_leak,
+                              completion_tokens, throughput_tps, host_ram_bytes,
+                              ram_tier_key, provider_ram_source, cell_execution_source,
+                              non_runnable_reason, corpus_class, max_context_override,
+                              max_concurrency_override, kv_bits,
+                              metric_unavailable_reason, draft_model,
+                              draft_model_artifact_sha256, num_draft_tokens,
+                              drafted_tokens, accepted_tokens,
+                              spec_decode_acceptance_rate, candidate_source,
+                              winner_status, no_winner_reason, stop_token_leak,
                               error, response_preview)
            VALUES (:ts_utc, :workload, :model, :tunnel_url, :streamed,
                    :http_status, :ttft_ms, :total_ms, :prompt_tokens,
-                   :completion_tokens, :throughput_tps, :stop_token_leak,
+                   :completion_tokens, :throughput_tps, :host_ram_bytes,
+                   :ram_tier_key, :provider_ram_source, :cell_execution_source,
+                   :non_runnable_reason, :corpus_class, :max_context_override,
+                   :max_concurrency_override, :kv_bits,
+                   :metric_unavailable_reason, :draft_model,
+                   :draft_model_artifact_sha256, :num_draft_tokens,
+                   :drafted_tokens, :accepted_tokens,
+                   :spec_decode_acceptance_rate, :candidate_source,
+                   :winner_status, :no_winner_reason, :stop_token_leak,
                    :error, :response_preview)""",
         row,
     )
@@ -374,6 +580,64 @@ def run_one(cfg: dict, name: str, conn: sqlite3.Connection, verbose: bool, dry_r
                 f"leak={row['stop_token_leak']}"
             )
     return row
+
+
+def run_spec029_sweep(cfg: dict, conn: sqlite3.Connection, verbose: bool, dry_run: bool) -> list[dict]:
+    provider_ram = spec029.resolve_provider_ram(cfg, require=True)
+    if provider_ram.host_ram_bytes is None:
+        raise RuntimeError("SPEC-029 sweep requires provider_host_ram_bytes or provider_ram_gib")
+    targets = spec029.spec029_workloads_from_config(cfg)
+    cells = spec029.sweep_cells_from_config(cfg, require_grid=True)
+    samples_per_cell = spec029.spec029_samples_per_cell(cfg)
+    validate_spec029_cell_execution_config(cfg, dry_run)
+    rows: list[dict] = []
+
+    if verbose:
+        print(
+            "harness: SPEC-029 sweep "
+            f"model={cfg['model']} provider_ram_tier={provider_ram.ram_tier_key} "
+            f"cells={len(cells)} workloads={len(targets)} samples_per_cell={samples_per_cell}"
+        )
+
+    for name in targets:
+        for cell in cells:
+            try:
+                cell_execution_source = apply_spec029_cell(cfg, cell, dry_run, verbose=verbose)
+            except Spec029CellApplyError as exc:
+                rows.append(
+                    run_one(
+                        cfg,
+                        name,
+                        conn,
+                        verbose,
+                        dry_run,
+                        cell=cell,
+                        force_stream=True,
+                        provider_ram=provider_ram,
+                        cell_execution_source="cell_apply_failed",
+                        metrics_override={
+                            "error": str(exc),
+                            "non_runnable_reason": "cell_apply_failed",
+                            "response_preview": str(exc)[:300],
+                        },
+                    )
+                )
+                continue
+            for _ in range(samples_per_cell):
+                rows.append(
+                    run_one(
+                        cfg,
+                        name,
+                        conn,
+                        verbose,
+                        dry_run,
+                        cell=cell,
+                        force_stream=True,
+                        provider_ram=provider_ram,
+                        cell_execution_source=cell_execution_source,
+                    )
+                )
+    return rows
 
 
 def run_one_adversarial(cfg: dict, name: str, conn: sqlite3.Connection, verbose: bool, dry_run: bool) -> dict:
@@ -438,7 +702,7 @@ def main() -> int:
         const="cooperative",
         default=None,
         metavar="PROFILE",
-        help="fire a batch list from config. PROFILE is 'cooperative' (default) or 'adversarial'.",
+        help="fire a batch list from config. PROFILE is 'cooperative' (default), 'adversarial', or 'spec029'.",
     )
     ap.add_argument("--list", action="store_true", help="list registered workloads and exit")
     ap.add_argument("--dry-run", action="store_true", help="build prompts but skip HTTP")
@@ -461,7 +725,7 @@ def main() -> int:
 
     try:
         # Resolve targets + which runner to use based on profile.
-        profile = args.batch  # None | "cooperative" | "adversarial"
+        profile = args.batch  # None | "cooperative" | "adversarial" | "spec029"
         targets: list[str]
         if args.once:
             # --once falls back to cooperative registry unless the name is in
@@ -473,6 +737,15 @@ def main() -> int:
             if not targets:
                 sys.exit("config: batch_adversarial is empty; add workloads or use --once")
             is_adversarial = True
+        elif profile == "spec029":
+            rows = run_spec029_sweep(cfg, conn, args.verbose, args.dry_run)
+            failures = sum(
+                1 for row in rows
+                if row.get("error") or (row.get("http_status") and row["http_status"] != 200)
+            )
+            if args.verbose:
+                print(f"harness: done, {failures} failure(s)")
+            return 0 if failures == 0 else 1
         elif profile == "cooperative":
             targets = list(cfg.get("batch") or [])
             if not targets:

--- a/beta/report.py
+++ b/beta/report.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import html
+import json
 import re
 import sqlite3
 import statistics
@@ -24,6 +25,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import yaml
+
+import spec029
 
 BETA_DIR = Path(__file__).resolve().parent
 DEFAULT_CONFIG = BETA_DIR / "config.yaml"
@@ -38,7 +41,7 @@ def fetch_rows(conn: sqlite3.Connection, date_iso: str) -> list[sqlite3.Row]:
     cur = conn.cursor()
     cur.row_factory = sqlite3.Row
     cur.execute(
-        "SELECT * FROM runs WHERE substr(ts_utc, 1, 10) = ? ORDER BY ts_utc",
+        "SELECT * FROM runs WHERE substr(ts_utc, 1, 10) = ? ORDER BY ts_utc, id",
         (date_iso,),
     )
     return cur.fetchall()
@@ -56,6 +59,10 @@ def median_or_none(xs: list[float]) -> float | None:
     return statistics.median(xs) if xs else None
 
 
+def row_get(row: sqlite3.Row, key: str, default=None):
+    return row[key] if key in row.keys() else default
+
+
 def summarize_per_workload(rows: list[sqlite3.Row]) -> list[dict]:
     by_name: dict[str, list[sqlite3.Row]] = {}
     for r in rows:
@@ -67,8 +74,12 @@ def summarize_per_workload(rows: list[sqlite3.Row]) -> list[dict]:
         totals = [r["total_ms"] for r in oks if r["total_ms"] is not None]
         tps = [r["throughput_tps"] for r in oks if r["throughput_tps"] is not None]
         leaks = sum(1 for r in group if r["stop_token_leak"])
+        corpus_classes = sorted({row_get(r, "corpus_class") for r in group if row_get(r, "corpus_class")})
+        ram_tiers = sorted({row_get(r, "ram_tier_key") for r in group if row_get(r, "ram_tier_key")})
         out.append({
             "name": name,
+            "corpus_class": ",".join(corpus_classes) if corpus_classes else None,
+            "ram_tiers": ",".join(ram_tiers) if ram_tiers else None,
             "n": len(group),
             "ok": len(oks),
             "fail": len(group) - len(oks),
@@ -116,6 +127,8 @@ def render(date_iso: str, rows: list[sqlite3.Row]) -> str:
     tunnel_url = rows[0]["tunnel_url"] if rows else "—"
     model = rows[0]["model"] if rows else "—"
     per_wl = summarize_per_workload(rows)
+    spec029_cells = spec029.cells_from_rows(rows)
+    spec029_summary = spec029.class_aware_report(spec029_cells, f"beta-report-{date_iso}") if spec029_cells else None
 
     parts: list[str] = []
     parts.append(f"<!doctype html><html><head><meta charset=utf-8><title>Phase 2 — {date_iso}</title><style>{CSS}</style></head><body>")
@@ -134,6 +147,7 @@ def render(date_iso: str, rows: list[sqlite3.Row]) -> str:
     parts.append("<h2>Per-workload medians</h2>")
     parts.append("<table><thead><tr>"
                  "<th>Workload</th>"
+                 "<th>Corpus</th><th>RAM tier</th>"
                  "<th class=num>N</th><th class=num>OK</th><th class=num>Fail</th>"
                  "<th class=num>Median TTFT</th><th class=num>Median total</th>"
                  "<th class=num>Median tok/s</th><th class=num>Leaks</th>"
@@ -141,6 +155,8 @@ def render(date_iso: str, rows: list[sqlite3.Row]) -> str:
     for w in per_wl:
         parts.append("<tr>")
         parts.append(f"<td>{html.escape(w['name'])}</td>")
+        parts.append(f"<td>{html.escape(w['corpus_class'] or '—')}</td>")
+        parts.append(f"<td>{html.escape(w['ram_tiers'] or '—')}</td>")
         parts.append(f"<td class=num>{w['n']}</td>")
         parts.append(f"<td class=num>{w['ok']}</td>")
         fail_cls = "num bad" if w['fail'] else "num"
@@ -153,9 +169,94 @@ def render(date_iso: str, rows: list[sqlite3.Row]) -> str:
         parts.append("</tr>")
     parts.append("</tbody></table>")
 
+    if spec029_summary:
+        parts.append("<h2>SPEC-029 class-aware sweep</h2>")
+        parts.append("<table><thead><tr>"
+                     "<th>Model</th><th>Workload</th><th>Corpus</th><th>RAM tier</th>"
+                     "<th>Status</th><th>No-winner reason</th>"
+                     "<th class=num>Samples</th><th class=num>Cells</th>"
+                     "<th>Metrics</th><th>Gate</th><th>Winner tuple</th><th>Tie-breaker reason</th><th>Tie-breakers</th><th>Candidate source</th><th>Source</th>"
+                     "</tr></thead><tbody>")
+        for p in spec029_summary["partitions"] + spec029_summary["streaming_probes"]:
+            gate = p["gate_policy"]
+            metrics = p.get("profile_metrics") or {}
+            gate_text = (
+                f"n>={gate['min_samples']}, "
+                f"p95 TTFT<={gate['max_p95_ttft_ms']}ms, "
+                f"leak<={gate['max_stop_token_leak_rate']}"
+            )
+            metrics_text = (
+                f"median_tps={fmt(metrics.get('median_tps'), '', 1)}, "
+                f"p95_ttft={fmt(metrics.get('p95_ttft_ms'), 'ms', 0)}, "
+                f"leak={fmt(metrics.get('stop_token_leak_rate'), '', 3)}, "
+                f"spec_accept={fmt(metrics.get('spec_decode_acceptance_rate'), '', 3)}"
+            )
+            winner = p["winner_tuple"]
+            winner_text = html.escape(str(winner)) if winner else "—"
+            tie_text = ", ".join(p.get("tie_breaker_order") or [])
+            parts.append("<tr>")
+            parts.append(f"<td>{html.escape(p.get('model') or '—')}</td>")
+            parts.append(f"<td>{html.escape(p['workload'])}</td>")
+            parts.append(f"<td>{html.escape(p.get('corpus_class') or '—')}</td>")
+            parts.append(f"<td>{html.escape(p['ram_tier_key'])}</td>")
+            parts.append(f"<td>{html.escape(p['status'])}</td>")
+            parts.append(f"<td>{html.escape(p.get('no_winner_reason') or '—')}</td>")
+            parts.append(f"<td class=num>{metrics.get('sample_count', '—')}</td>")
+            parts.append(f"<td class=num>{p.get('evaluated_cell_count', '—')}</td>")
+            parts.append(f"<td>{html.escape(metrics_text)}</td>")
+            parts.append(f"<td>{html.escape(gate_text)}</td>")
+            parts.append(f"<td><code>{winner_text}</code></td>")
+            parts.append(f"<td>{html.escape(p.get('tie_breaker_reason') or '—')}</td>")
+            parts.append(f"<td>{html.escape(tie_text or '—')}</td>")
+            parts.append(f"<td>{html.escape(p.get('candidate_source') or '—')}</td>")
+            parts.append(f"<td>{html.escape(p.get('source') or '—')}</td>")
+            parts.append("</tr>")
+        parts.append("</tbody></table>")
+
+        parts.append("<h2>SPEC-029 evaluated cells</h2>")
+        parts.append("<table><thead><tr>"
+                     "<th>Model</th><th>Workload</th><th>RAM tier</th><th>Cell</th>"
+                     "<th class=num>Samples</th><th class=num>Failures</th>"
+                     "<th>Metrics</th><th>Draft</th><th>Source</th>"
+                     "</tr></thead><tbody>")
+        for cell in spec029_summary["evaluated_cells"]:
+            cell_text = (
+                f"kv_bits={cell['kv_bits']}, "
+                f"context={cell['max_context_override']}, "
+                f"concurrency={cell['max_concurrency_override']}"
+            )
+            metrics_text = (
+                f"p95_ttft={fmt(cell['p95_ttft_ms'], 'ms', 0)}, "
+                f"median_tps={fmt(cell['median_tps'], '', 1)}, "
+                f"leak={fmt(cell['stop_token_leak_rate'], '', 3)}, "
+                f"spec_accept={fmt(cell['spec_decode_acceptance_rate'], '', 3)}"
+            )
+            draft_text = "—"
+            if cell.get("draft_model") or cell.get("draft_model_artifact_sha256") or cell.get("num_draft_tokens"):
+                draft_text = (
+                    f"model={cell.get('draft_model') or '—'}, "
+                    f"sha256={cell.get('draft_model_artifact_sha256') or '—'}, "
+                    f"tokens={cell.get('num_draft_tokens') or '—'}"
+                )
+                if cell.get("draft_validation_error"):
+                    draft_text += f", validation={cell['draft_validation_error']}"
+            parts.append("<tr>")
+            parts.append(f"<td>{html.escape(cell.get('model') or '—')}</td>")
+            parts.append(f"<td>{html.escape(cell['workload'])}</td>")
+            parts.append(f"<td>{html.escape(cell['ram_tier_key'])}</td>")
+            parts.append(f"<td>{html.escape(cell_text)}</td>")
+            parts.append(f"<td class=num>{cell['successful_sample_count']}</td>")
+            parts.append(f"<td class=num>{cell['hard_failure_count']}</td>")
+            parts.append(f"<td>{html.escape(metrics_text)}</td>")
+            parts.append(f"<td>{html.escape(draft_text)}</td>")
+            parts.append(f"<td>{html.escape(cell.get('candidate_source') or '—')}</td>")
+            parts.append("</tr>")
+        parts.append("</tbody></table>")
+
     parts.append("<h2>All runs</h2>")
     parts.append("<table><thead><tr>"
                  "<th>Time (UTC)</th><th>Workload</th>"
+                 "<th>Corpus</th><th>RAM tier</th><th>RAM source</th><th>Cell source</th><th>Host RAM</th><th>Cell</th>"
                  "<th class=num>Status</th><th class=num>TTFT</th><th class=num>Total</th>"
                  "<th class=num>In</th><th class=num>Out</th><th class=num>tok/s</th>"
                  "<th>Notes</th>"
@@ -169,12 +270,38 @@ def render(date_iso: str, rows: list[sqlite3.Row]) -> str:
             notes_bits.append(f"<span class=bad>{html.escape(r['error'][:120])}</span>")
         if r["stop_token_leak"]:
             notes_bits.append("<span class=bad>stop-token leak</span>")
+        metric_reason = row_get(r, "metric_unavailable_reason")
+        if metric_reason:
+            notes_bits.append(f"<span class=muted>{html.escape(metric_reason)}</span>")
+        non_runnable_reason = row_get(r, "non_runnable_reason")
+        if non_runnable_reason:
+            notes_bits.append(f"<span class=bad>{html.escape(non_runnable_reason)}</span>")
         if r["response_preview"] and not r["error"]:
             notes_bits.append(f"<span class=preview>{html.escape(r['response_preview'][:120])}</span>")
         notes = " · ".join(notes_bits) if notes_bits else "<span class=muted>—</span>"
         parts.append(f"<tr{row_cls}>")
         parts.append(f"<td>{time_only}</td>")
         parts.append(f"<td>{html.escape(r['workload'])}</td>")
+        parts.append(f"<td>{html.escape(row_get(r, 'corpus_class', '—') or '—')}</td>")
+        parts.append(f"<td>{html.escape(row_get(r, 'ram_tier_key', '—') or '—')}</td>")
+        parts.append(f"<td>{html.escape(row_get(r, 'provider_ram_source', '—') or '—')}</td>")
+        parts.append(f"<td>{html.escape(row_get(r, 'cell_execution_source', '—') or '—')}</td>")
+        host_ram = row_get(r, "host_ram_bytes")
+        parts.append(f"<td>{html.escape(fmt(host_ram))}</td>")
+        cell_bits = []
+        if row_get(r, "kv_bits") is not None:
+            cell_bits.append(f"kv_bits={row_get(r, 'kv_bits')}")
+        if row_get(r, "max_context_override") is not None:
+            cell_bits.append(f"context={row_get(r, 'max_context_override')}")
+        if row_get(r, "max_concurrency_override") is not None:
+            cell_bits.append(f"concurrency={row_get(r, 'max_concurrency_override')}")
+        if row_get(r, "draft_model"):
+            cell_bits.append(f"draft={row_get(r, 'draft_model')}")
+        if row_get(r, "num_draft_tokens") is not None:
+            cell_bits.append(f"draft_tokens={row_get(r, 'num_draft_tokens')}")
+        if row_get(r, "candidate_source"):
+            cell_bits.append(f"source={row_get(r, 'candidate_source')}")
+        parts.append(f"<td>{html.escape(', '.join(cell_bits) if cell_bits else '—')}</td>")
         parts.append(f"<td class=num>{r['http_status'] if r['http_status'] is not None else '—'}</td>")
         parts.append(f"<td class=num>{fmt(r['ttft_ms'], ' ms', 0)}</td>")
         parts.append(f"<td class=num>{fmt(r['total_ms'], ' ms', 0)}</td>")
@@ -185,7 +312,7 @@ def render(date_iso: str, rows: list[sqlite3.Row]) -> str:
         parts.append("</tr>")
     parts.append("</tbody></table>")
 
-    parts.append(f"<p class=muted>Generated {datetime.now(timezone.utc).isoformat(timespec='seconds')}</p>")
+    parts.append(f"<p class=muted>Generated for UTC date {html.escape(date_iso)}</p>")
     parts.append("</body></html>")
     return "".join(parts)
 
@@ -195,6 +322,12 @@ def write_report(date_iso: str, conn: sqlite3.Connection, out_dir: Path) -> Path
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / f"{date_iso}.html"
     out_path.write_text(render(date_iso, rows))
+    spec029_cells = spec029.cells_from_rows(rows)
+    if spec029_cells:
+        json_path = out_dir / f"{date_iso}.spec029.json"
+        summary = spec029.class_aware_report(spec029_cells, f"beta-report-{date_iso}")
+        summary["raw_trials"] = [spec029.trial_row_json(row) for row in rows]
+        json_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
     return out_path
 
 

--- a/beta/spec029.py
+++ b/beta/spec029.py
@@ -1,0 +1,838 @@
+"""
+SPEC-029 workload-class sweep helpers.
+
+This module is deliberately pure: the harness records raw rows, then the
+selector turns evaluated search cells into partition-local winner/no-winner
+profiles for reports or future static-catalog publication.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+from dataclasses import dataclass
+from typing import Any, NamedTuple
+
+try:
+    import workloads
+except ImportError:  # pragma: no cover - package-relative test imports
+    from . import workloads  # type: ignore
+
+
+INCLUDED_WORKLOADS = frozenset({
+    "short_chat",
+    "medium_with_system",
+    "long_context",
+    "code_completion",
+    "agent_style",
+})
+PROBE_ONLY_WORKLOADS = frozenset({"streaming_check"})
+ALL_SPEC029_WORKLOADS = INCLUDED_WORKLOADS | PROBE_ONLY_WORKLOADS
+RAM_TIER_KEYS = frozenset({"8gb", "16gb", "32gb", "64gb_plus"})
+NO_WINNER_REASONS = frozenset({
+    "insufficient_samples",
+    "gate_unmet",
+    "hard_failure",
+    "no_cells_evaluated",
+})
+RUNNABLE_CELL_EXECUTION_SOURCES = frozenset({
+    "cell_control_url",
+    "cell_apply_command",
+})
+NON_RUNNABLE_CELL_EXECUTION_SOURCES = frozenset({"cell_apply_failed"})
+EVALUATED_CELL_EXECUTION_SOURCES = RUNNABLE_CELL_EXECUTION_SOURCES | NON_RUNNABLE_CELL_EXECUTION_SOURCES
+
+SPEC028_DRAFT_CONTEXT_CAPS = {
+    "8gb": 8_192,
+    "16gb": 20_000,
+    "32gb": 50_000,
+    "64gb_plus": 120_000,
+}
+
+APPROVED_DRAFT_SOURCE_PREFIXES = (
+    "static_draft_candidates:",
+    "research_fixture:",
+    "local_operator_override:",
+)
+
+DEFAULT_SWEEP_CELLS = (
+    {
+        "kv_bits": 8,
+        "max_context_override": 8_192,
+        "max_concurrency_override": 1,
+    },
+    {
+        "kv_bits": 4,
+        "max_context_override": 20_000,
+        "max_concurrency_override": 1,
+    },
+)
+
+
+class ProviderRAM(NamedTuple):
+    host_ram_bytes: int | None
+    ram_tier_key: str | None
+    source: str
+
+
+@dataclass(frozen=True)
+class GatePolicy:
+    min_samples: int
+    max_p95_ttft_ms: int
+    max_stop_token_leak_rate: float = 0.0
+    min_median_tps: float | None = None
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "min_samples": self.min_samples,
+            "max_p95_ttft_ms": self.max_p95_ttft_ms,
+            "max_stop_token_leak_rate": self.max_stop_token_leak_rate,
+            "min_median_tps": self.min_median_tps,
+        }
+
+
+GATE_POLICIES = {
+    "short_chat": GatePolicy(20, 8_000),
+    "medium_with_system": GatePolicy(20, 12_000),
+    "long_context": GatePolicy(20, 60_000),
+    "code_completion": GatePolicy(20, 12_000),
+    "agent_style": GatePolicy(20, 20_000),
+    "streaming_check": GatePolicy(20, 2_000),
+}
+
+
+@dataclass(frozen=True)
+class SearchCellResult:
+    workload_name: str
+    ram_tier_key: str
+    kv_bits: int
+    max_context_override: int
+    max_concurrency_override: int
+    successful_sample_count: int
+    p95_ttft_ms: float | None
+    median_tps: float | None
+    stop_token_leak_rate: float
+    hard_failure_count: int = 0
+    non_runnable_reason: str | None = None
+    draft_model: str | None = None
+    draft_model_artifact_sha256: str | None = None
+    num_draft_tokens: int | None = None
+    spec_decode_acceptance_rate: float | None = None
+    candidate_source: str | None = None
+    model: str | None = None
+
+    @property
+    def draft_validation_error(self) -> str | None:
+        if not self.draft_model:
+            if self.draft_model_artifact_sha256 is not None or self.num_draft_tokens is not None:
+                return "partial_speculative_tuple"
+            return None
+        if not self.candidate_source:
+            return "missing_candidate_source"
+        if not self.candidate_source.startswith(APPROVED_DRAFT_SOURCE_PREFIXES):
+            return "unapproved_candidate_source"
+        if not self.draft_model_artifact_sha256 or not _is_lower_hex(self.draft_model_artifact_sha256, 64):
+            return "invalid_draft_model_artifact_sha256"
+        if self.num_draft_tokens is None or not 1 <= self.num_draft_tokens <= 16:
+            return "invalid_num_draft_tokens"
+        if self.max_concurrency_override > 1:
+            return "draft_concurrency_cap_exceeded"
+        cap = SPEC028_DRAFT_CONTEXT_CAPS[self.ram_tier_key]
+        if self.max_context_override > cap:
+            return "draft_context_cap_exceeded"
+        return None
+
+    @property
+    def runnable(self) -> bool:
+        return self.non_runnable_reason is None and self.draft_validation_error is None
+
+    @property
+    def produced_successful_sample(self) -> bool:
+        return self.successful_sample_count > 0 and self.runnable
+
+    @property
+    def hard_failed(self) -> bool:
+        return not self.runnable or self.successful_sample_count == 0
+
+    def reached_min_samples(self, policy: GatePolicy) -> bool:
+        return self.produced_successful_sample and self.successful_sample_count >= policy.min_samples
+
+    def passes_hard_gates(self, policy: GatePolicy) -> bool:
+        return (
+            self.reached_min_samples(policy)
+            and self.p95_ttft_ms is not None
+            and self.p95_ttft_ms <= policy.max_p95_ttft_ms
+            and self.stop_token_leak_rate <= policy.max_stop_token_leak_rate
+            and self.runnable
+        )
+
+    def recommended_json(self) -> dict[str, Any]:
+        if self.draft_validation_error is not None:
+            raise ValueError(f"invalid SPEC-029 speculative tuple: {self.draft_validation_error}")
+        out: dict[str, Any] = {
+            "kv_bits": self.kv_bits,
+            "max_context_override": self.max_context_override,
+            "max_concurrency_override": self.max_concurrency_override,
+        }
+        if self.draft_model:
+            out["draft_model"] = self.draft_model
+            out["draft_model_artifact_sha256"] = self.draft_model_artifact_sha256
+            out["num_draft_tokens"] = self.num_draft_tokens
+        return out
+
+
+@dataclass(frozen=True)
+class SelectionResult:
+    workload_name: str
+    ram_tier_key: str
+    gate_policy: GatePolicy
+    winner: SearchCellResult | None
+    no_winner_reason: str | None
+    evaluated_cell_count: int
+    highest_successful_sample_count: int
+    tie_breaker_reason: str | None
+
+    @property
+    def status(self) -> str:
+        return "winner" if self.winner is not None else "no_winner"
+
+
+def host_ram_bytes() -> int | None:
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        if pages > 0 and page_size > 0:
+            return int(pages * page_size)
+    except (OSError, ValueError, AttributeError):
+        return None
+    return None
+
+
+def ram_tier_key_for_gib(physical_memory_gib: int | float) -> str:
+    if physical_memory_gib <= 12:
+        return "8gb"
+    if physical_memory_gib <= 24:
+        return "16gb"
+    if physical_memory_gib <= 48:
+        return "32gb"
+    return "64gb_plus"
+
+
+def ram_tier_key_for_bytes(physical_memory_bytes: int) -> str:
+    gib = physical_memory_bytes / (1024 ** 3)
+    return ram_tier_key_for_gib(gib)
+
+
+def normalize_provider_ram_tier(raw: str) -> str:
+    normalized = raw.strip().lower()
+    if normalized in {"8gb", "16gb", "32gb"}:
+        return normalized
+    if normalized == "64gb+":
+        return "64gb_plus"
+    raise ValueError(f"invalid SPEC-029 RAM-tier string: {raw!r}")
+
+
+def resolve_provider_ram(cfg: dict[str, Any], require: bool = False) -> ProviderRAM:
+    """Resolve the measured provider/sweep-host RAM from config.
+
+    The beta harness often runs buyer-side against a remote provider, so SPEC-029
+    sweep artifacts must prefer explicit provider metadata over local machine RAM.
+    """
+    explicit = _provider_ram_from_mapping(cfg, "config")
+    if explicit.ram_tier_key:
+        return explicit
+
+    selected = cfg.get("_selected_model_entry")
+    if isinstance(selected, dict):
+        entry = _provider_ram_from_mapping(selected, "selected_model")
+        if entry.ram_tier_key:
+            return entry
+
+    if require:
+        raise ValueError(
+            "SPEC-029 sweep requires provider_host_ram_bytes, provider_ram_gib, "
+            "or provider_ram_tier in config or selected model entry"
+        )
+
+    local = host_ram_bytes()
+    return ProviderRAM(
+        local,
+        ram_tier_key_for_bytes(local) if local else None,
+        "local_harness_fallback",
+    )
+
+
+def _provider_ram_from_mapping(mapping: dict[str, Any], source: str) -> ProviderRAM:
+    raw_bytes = mapping.get("provider_host_ram_bytes") or mapping.get("host_ram_bytes")
+    if raw_bytes is not None:
+        host_ram = int(raw_bytes)
+        if host_ram <= 0:
+            raise ValueError(f"{source}: provider host RAM bytes must be positive")
+        return ProviderRAM(host_ram, ram_tier_key_for_bytes(host_ram), source)
+
+    raw_gib = mapping.get("provider_ram_gib") or mapping.get("ram_gib")
+    if raw_gib is not None:
+        gib = float(raw_gib)
+        if gib <= 0:
+            raise ValueError(f"{source}: provider RAM GiB must be positive")
+        return ProviderRAM(int(gib * 1024 ** 3), ram_tier_key_for_gib(gib), source)
+
+    raw_tier = mapping.get("provider_ram_tier") or mapping.get("ram_tier")
+    if raw_tier:
+        return ProviderRAM(None, normalize_provider_ram_tier(str(raw_tier)), source)
+
+    return ProviderRAM(None, None, source)
+
+
+def _is_lower_hex(value: str, count: int) -> bool:
+    return len(value) == count and all(ch in "0123456789abcdef" for ch in value)
+
+
+def corpus_class_for_workload(workload_name: str) -> str | None:
+    return workloads._WORKLOAD_CORPUS_MAP.get(workload_name)
+
+
+def gate_policy_for_workload(workload_name: str) -> GatePolicy:
+    try:
+        return GATE_POLICIES[workload_name]
+    except KeyError as exc:
+        raise ValueError(f"unknown SPEC-029 workload: {workload_name}") from exc
+
+
+def is_publishable_workload(workload_name: str) -> bool:
+    return workload_name in INCLUDED_WORKLOADS
+
+
+def metric_unavailable_reason(
+    prompt_tokens: int | None,
+    completion_tokens: int | None,
+    throughput_tps: float | None,
+) -> str | None:
+    missing: list[str] = []
+    if prompt_tokens is None:
+        missing.append("missing_prompt_tokens")
+    if completion_tokens is None:
+        missing.append("missing_completion_tokens")
+    if throughput_tps is None:
+        missing.append("missing_throughput_tps")
+    return ",".join(missing) if missing else None
+
+
+def sweep_cell_from_config(cfg: dict[str, Any]) -> dict[str, Any]:
+    cell = dict(cfg.get("sweep_cell") or {})
+    for key in [
+        "max_context_override",
+        "max_concurrency_override",
+        "kv_bits",
+        "draft_model",
+        "draft_model_artifact_sha256",
+        "num_draft_tokens",
+        "candidate_source",
+    ]:
+        if key in cfg and key not in cell:
+            cell[key] = cfg[key]
+    return cell
+
+
+def sweep_cells_from_config(cfg: dict[str, Any], require_grid: bool = False) -> list[dict[str, Any]]:
+    spec_cfg = cfg.get("spec029_sweep") or {}
+    raw_cells = spec_cfg.get("cells") or cfg.get("sweep_cells")
+    if raw_cells is None:
+        raw_grid = spec_cfg.get("grid") or cfg.get("sweep_grid")
+        raw_cells = expand_sweep_grid(raw_grid) if raw_grid else None
+
+    if raw_cells is None:
+        if require_grid:
+            raise ValueError("SPEC-029 sweep requires explicit spec029_sweep.cells or spec029_sweep.grid")
+        else:
+            raw_cells = [sweep_cell_from_config(cfg)]
+
+    cells = [normalize_sweep_cell(cell, cfg) for cell in raw_cells]
+    if require_grid and not cells:
+        raise ValueError("SPEC-029 sweep requires at least one configured search cell")
+    return cells
+
+
+def expand_sweep_grid(raw_grid: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(raw_grid, dict):
+        raise ValueError("SPEC-029 sweep grid must be a mapping")
+    kv_values = raw_grid.get("kv_bits", [4])
+    context_values = raw_grid.get("max_context_override", [20_000])
+    concurrency_values = raw_grid.get("max_concurrency_override", [1])
+    draft_entries = raw_grid.get("draft_candidates") or [None]
+    cells: list[dict[str, Any]] = []
+    for kv_bits in _as_list(kv_values):
+        for context in _as_list(context_values):
+            for concurrency in _as_list(concurrency_values):
+                for draft in _as_list(draft_entries):
+                    cell = {
+                        "kv_bits": kv_bits,
+                        "max_context_override": context,
+                        "max_concurrency_override": concurrency,
+                    }
+                    if draft:
+                        if not isinstance(draft, dict):
+                            raise ValueError("SPEC-029 draft grid entries must be mappings")
+                        cell.update(draft)
+                    cells.append(cell)
+    return cells
+
+
+def normalize_sweep_cell(cell: dict[str, Any], cfg: dict[str, Any] | None = None) -> dict[str, Any]:
+    if not isinstance(cell, dict):
+        raise ValueError("SPEC-029 sweep cell must be a mapping")
+    cfg = cfg or {}
+    merged = dict(cell)
+    for key in [
+        "max_context_override",
+        "max_concurrency_override",
+        "kv_bits",
+        "draft_model",
+        "draft_model_artifact_sha256",
+        "num_draft_tokens",
+        "candidate_source",
+    ]:
+        if key in cfg and key not in merged:
+            merged[key] = cfg[key]
+    for key in ["kv_bits", "max_context_override", "max_concurrency_override"]:
+        if key not in merged:
+            raise ValueError(f"SPEC-029 sweep cell missing {key}")
+        merged[key] = int(merged[key])
+    if "num_draft_tokens" in merged and merged["num_draft_tokens"] is not None:
+        merged["num_draft_tokens"] = int(merged["num_draft_tokens"])
+    return merged
+
+
+def spec029_workloads_from_config(cfg: dict[str, Any]) -> list[str]:
+    spec_cfg = cfg.get("spec029_sweep") or {}
+    workloads_list = list(spec_cfg.get("workloads") or cfg.get("spec029_batch") or sorted(INCLUDED_WORKLOADS) + sorted(PROBE_ONLY_WORKLOADS))
+    invalid = [name for name in workloads_list if name not in ALL_SPEC029_WORKLOADS]
+    if invalid:
+        raise ValueError(f"SPEC-029 sweep cannot run workload(s): {', '.join(invalid)}")
+    return workloads_list
+
+
+def spec029_samples_per_cell(cfg: dict[str, Any]) -> int:
+    spec_cfg = cfg.get("spec029_sweep") or {}
+    samples = int(spec_cfg.get("samples_per_cell") or cfg.get("spec029_samples_per_cell") or 1)
+    if samples <= 0:
+        raise ValueError("SPEC-029 samples_per_cell must be positive")
+    return samples
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else [value]
+
+
+def choose_partition(
+    cells: list[SearchCellResult],
+    workload_name: str,
+    ram_tier_key: str,
+    model: str | None = None,
+) -> SelectionResult:
+    if workload_name in PROBE_ONLY_WORKLOADS:
+        raise ValueError(f"{workload_name} is probe-only and cannot publish a winner")
+    if workload_name not in INCLUDED_WORKLOADS:
+        raise ValueError(f"{workload_name} is not included in SPEC-029 v0.1")
+    if ram_tier_key not in RAM_TIER_KEYS:
+        raise ValueError(f"invalid RAM-tier key: {ram_tier_key}")
+
+    partition = [
+        cell for cell in cells
+        if cell.workload_name == workload_name and cell.ram_tier_key == ram_tier_key
+        and (model is None or cell.model == model)
+    ]
+    policy = gate_policy_for_workload(workload_name)
+    if not partition:
+        return SelectionResult(workload_name, ram_tier_key, policy, None, "no_cells_evaluated", 0, 0, None)
+    if model is None and len({cell.model for cell in partition}) > 1:
+        raise ValueError(f"{workload_name}/{ram_tier_key} partition contains multiple target models")
+
+    highest_success = max(
+        (
+            cell.successful_sample_count for cell in partition
+            if cell.produced_successful_sample
+        ),
+        default=0,
+    )
+    winners = [cell for cell in partition if cell.passes_hard_gates(policy)]
+    if winners:
+        winner = sorted(winners, key=_winner_sort_key)[0]
+        return SelectionResult(
+            workload_name,
+            ram_tier_key,
+            policy,
+            winner,
+            None,
+            len(partition),
+            highest_success,
+            _tie_breaker_reason(winners),
+        )
+
+    reason = no_winner_reason_for_cells(partition, policy)
+    return SelectionResult(workload_name, ram_tier_key, policy, None, reason, len(partition), highest_success, None)
+
+
+def no_winner_reason_for_cells(cells: list[SearchCellResult], policy: GatePolicy) -> str:
+    if not cells:
+        return "no_cells_evaluated"
+    if all(cell.hard_failed for cell in cells):
+        return "hard_failure"
+    if any(cell.produced_successful_sample for cell in cells) and not any(
+        cell.reached_min_samples(policy) for cell in cells
+    ):
+        return "insufficient_samples"
+    if any(cell.reached_min_samples(policy) for cell in cells):
+        return "gate_unmet"
+    return "hard_failure"
+
+
+def _winner_sort_key(cell: SearchCellResult) -> tuple[Any, ...]:
+    serialized_tuple = json.dumps(cell.recommended_json(), sort_keys=True, separators=(",", ":"))
+    return (
+        0 if cell.hard_failure_count == 0 and cell.stop_token_leak_rate == 0 else 1,
+        -(cell.median_tps if cell.median_tps is not None else -1.0),
+        cell.p95_ttft_ms if cell.p95_ttft_ms is not None else float("inf"),
+        cell.max_context_override,
+        cell.max_concurrency_override,
+        serialized_tuple,
+    )
+
+
+def _tie_breaker_reason(winners: list[SearchCellResult]) -> str:
+    ordered = sorted(winners, key=_winner_sort_key)
+    if len(ordered) == 1:
+        return "only_gate_passing_cell"
+
+    winner_key = _winner_sort_key(ordered[0])
+    runner_key = _winner_sort_key(ordered[1])
+    labels = [
+        "zero_hard_failures_and_leaks",
+        "higher_median_tps",
+        "lower_ttft",
+        "lower_context_memory_risk",
+        "lower_concurrency_memory_risk",
+        "lexical_tuple",
+    ]
+    for label, winner_value, runner_value in zip(labels, winner_key, runner_key, strict=True):
+        if winner_value != runner_value:
+            return label
+    return "deterministic_tie"
+
+
+def workload_profile(result: SelectionResult, source: str) -> dict[str, Any]:
+    policy_json = result.gate_policy.as_json()
+    if result.winner is not None:
+        winner = result.winner
+        profile = {
+            "status": "winner",
+            "recommended": winner.recommended_json(),
+            "candidate_source": winner.candidate_source,
+            "tie_breaker_reason": result.tie_breaker_reason,
+            "gate_policy": policy_json,
+            "profile_metrics": {
+                "median_tps": winner.median_tps,
+                "p95_ttft_ms": winner.p95_ttft_ms,
+                "stop_token_leak_rate": winner.stop_token_leak_rate,
+                "spec_decode_acceptance_rate": winner.spec_decode_acceptance_rate,
+                "sample_count": winner.successful_sample_count,
+            },
+            "source": source,
+        }
+        return profile
+
+    return {
+        "status": "no_winner",
+        "no_winner_reason": result.no_winner_reason,
+        "gate_policy": policy_json,
+        "profile_metrics": {
+            "median_tps": None,
+            "p95_ttft_ms": None,
+            "stop_token_leak_rate": None,
+            "spec_decode_acceptance_rate": None,
+            "sample_count": result.highest_successful_sample_count,
+        },
+        "source": source,
+    }
+
+
+def no_winner_profile(result: SelectionResult, cells: list[SearchCellResult], source: str) -> dict[str, Any]:
+    return workload_profile(result, source)
+
+
+def class_aware_report(
+    cells: list[SearchCellResult],
+    source: str,
+    ram_tier_keys: list[str] | None = None,
+) -> dict[str, Any]:
+    tiers = ram_tier_keys or sorted({cell.ram_tier_key for cell in cells if cell.ram_tier_key in RAM_TIER_KEYS})
+    models = sorted({cell.model for cell in cells}, key=lambda value: value or "")
+    partitions: list[dict[str, Any]] = []
+    for model in models:
+        model_cells = [cell for cell in cells if cell.model == model]
+        for workload_name in sorted(INCLUDED_WORKLOADS):
+            for ram_tier_key in tiers:
+                result = choose_partition(model_cells, workload_name, ram_tier_key)
+                profile = workload_profile(result, source)
+                partitions.append({
+                    "model": model,
+                    "workload": workload_name,
+                    "corpus_class": corpus_class_for_workload(workload_name),
+                    "ram_tier_key": ram_tier_key,
+                    "status": result.status,
+                    "no_winner_reason": result.no_winner_reason,
+                    "gate_policy": result.gate_policy.as_json(),
+                    "evaluated_cell_count": result.evaluated_cell_count,
+                    "profile_metrics": profile["profile_metrics"],
+                    "source": profile["source"],
+                    "candidate_source": profile.get("candidate_source"),
+                    "tie_breaker_reason": result.tie_breaker_reason,
+                    "tie_breaker_order": [
+                        "zero_hard_failures_and_leaks",
+                        "ttft_gate",
+                        "higher_median_tps",
+                        "lower_ttft",
+                        "lower_memory_risk",
+                        "lexical_tuple",
+                    ],
+                    "winner_tuple": result.winner.recommended_json() if result.winner else None,
+                    "profile": profile,
+                })
+
+    streaming = [
+        cell for cell in cells
+        if cell.workload_name in PROBE_ONLY_WORKLOADS and cell.ram_tier_key in RAM_TIER_KEYS
+    ]
+    probe_partitions = []
+    for model in sorted({cell.model for cell in streaming}, key=lambda value: value or ""):
+        for ram_tier_key in sorted({cell.ram_tier_key for cell in streaming if cell.model == model}):
+            policy = gate_policy_for_workload("streaming_check")
+            group = [
+                cell for cell in streaming
+                if cell.model == model and cell.ram_tier_key == ram_tier_key
+            ]
+            highest_success = max(
+                (
+                    cell.successful_sample_count for cell in group
+                    if cell.produced_successful_sample
+                ),
+                default=0,
+            )
+            passing_cells = [cell for cell in group if cell.passes_hard_gates(policy)]
+            passed = bool(passing_cells)
+            representative = sorted(passing_cells, key=_winner_sort_key)[0] if passing_cells else None
+            probe_partitions.append({
+                "model": model,
+                "workload": "streaming_check",
+                "corpus_class": corpus_class_for_workload("streaming_check"),
+                "ram_tier_key": ram_tier_key,
+                "status": "probe_pass" if passed else "probe_no_winner",
+                "no_winner_reason": None if passed else no_winner_reason_for_cells(group, policy),
+                "gate_policy": policy.as_json(),
+                "evaluated_cell_count": len(group),
+                "profile_metrics": {
+                    "median_tps": representative.median_tps if representative else None,
+                    "p95_ttft_ms": representative.p95_ttft_ms if representative else None,
+                    "stop_token_leak_rate": representative.stop_token_leak_rate if representative else None,
+                    "spec_decode_acceptance_rate": representative.spec_decode_acceptance_rate if representative else None,
+                    "sample_count": representative.successful_sample_count if representative else highest_success,
+                },
+                "source": source,
+                "winner_tuple": None,
+            })
+
+    return {
+        "source": source,
+        "evaluated_cells": [
+            search_cell_json(cell) for cell in sorted(cells, key=_cell_identity_sort_key)
+        ],
+        "partitions": partitions,
+        "streaming_probes": probe_partitions,
+    }
+
+
+def search_cell_json(cell: SearchCellResult) -> dict[str, Any]:
+    return {
+        "workload": cell.workload_name,
+        "model": cell.model,
+        "ram_tier_key": cell.ram_tier_key,
+        "kv_bits": cell.kv_bits,
+        "max_context_override": cell.max_context_override,
+        "max_concurrency_override": cell.max_concurrency_override,
+        "draft_model": cell.draft_model,
+        "draft_model_artifact_sha256": cell.draft_model_artifact_sha256,
+        "num_draft_tokens": cell.num_draft_tokens,
+        "candidate_source": cell.candidate_source,
+        "successful_sample_count": cell.successful_sample_count,
+        "p95_ttft_ms": cell.p95_ttft_ms,
+        "median_tps": cell.median_tps,
+        "stop_token_leak_rate": cell.stop_token_leak_rate,
+        "hard_failure_count": cell.hard_failure_count,
+        "spec_decode_acceptance_rate": cell.spec_decode_acceptance_rate,
+        "draft_validation_error": cell.draft_validation_error,
+    }
+
+
+def trial_row_json(row: Any) -> dict[str, Any]:
+    return {
+        "ts_utc": _row_get(row, "ts_utc"),
+        "workload": _row_get(row, "workload"),
+        "model": _row_get(row, "model"),
+        "streamed": _row_get(row, "streamed"),
+        "http_status": _row_get(row, "http_status"),
+        "error": _row_get(row, "error"),
+        "ttft_ms": _row_get(row, "ttft_ms"),
+        "total_ms": _row_get(row, "total_ms"),
+        "prompt_tokens": _row_get(row, "prompt_tokens"),
+        "completion_tokens": _row_get(row, "completion_tokens"),
+        "throughput_tps": _row_get(row, "throughput_tps"),
+        "host_ram_bytes": _row_get(row, "host_ram_bytes"),
+        "ram_tier_key": _row_get(row, "ram_tier_key"),
+        "provider_ram_source": _row_get(row, "provider_ram_source"),
+        "cell_execution_source": _row_get(row, "cell_execution_source"),
+        "non_runnable_reason": _row_get(row, "non_runnable_reason"),
+        "corpus_class": _row_get(row, "corpus_class"),
+        "max_context_override": _row_get(row, "max_context_override"),
+        "max_concurrency_override": _row_get(row, "max_concurrency_override"),
+        "kv_bits": _row_get(row, "kv_bits"),
+        "metric_unavailable_reason": _row_get(row, "metric_unavailable_reason"),
+        "draft_model": _row_get(row, "draft_model"),
+        "draft_model_artifact_sha256": _row_get(row, "draft_model_artifact_sha256"),
+        "num_draft_tokens": _row_get(row, "num_draft_tokens"),
+        "drafted_tokens": _row_get(row, "drafted_tokens"),
+        "accepted_tokens": _row_get(row, "accepted_tokens"),
+        "spec_decode_acceptance_rate": _row_get(row, "spec_decode_acceptance_rate"),
+        "candidate_source": _row_get(row, "candidate_source"),
+        "winner_status": _row_get(row, "winner_status"),
+        "no_winner_reason": _row_get(row, "no_winner_reason"),
+        "stop_token_leak": _row_get(row, "stop_token_leak"),
+    }
+
+
+def _cell_identity_sort_key(cell: SearchCellResult) -> tuple[Any, ...]:
+    return (
+        cell.workload_name,
+        cell.model or "",
+        cell.ram_tier_key,
+        cell.kv_bits,
+        cell.max_context_override,
+        cell.max_concurrency_override,
+        cell.draft_model or "",
+        cell.draft_model_artifact_sha256 or "",
+        cell.num_draft_tokens if cell.num_draft_tokens is not None else -1,
+        cell.candidate_source or "",
+    )
+
+
+def cells_from_rows(rows: list[Any]) -> list[SearchCellResult]:
+    grouped: dict[tuple[Any, ...], list[Any]] = {}
+    for row in rows:
+        cell_execution_source = _row_get(row, "cell_execution_source")
+        if cell_execution_source not in EVALUATED_CELL_EXECUTION_SOURCES:
+            continue
+        if cell_execution_source in NON_RUNNABLE_CELL_EXECUTION_SOURCES and not _row_get(row, "non_runnable_reason"):
+            continue
+        workload_name = _row_get(row, "workload")
+        ram_tier_key = _row_get(row, "ram_tier_key")
+        kv_bits = _row_get(row, "kv_bits")
+        context = _row_get(row, "max_context_override")
+        concurrency = _row_get(row, "max_concurrency_override")
+        if not workload_name or not ram_tier_key or kv_bits is None or context is None or concurrency is None:
+            continue
+        key = (
+            workload_name,
+            _row_get(row, "model"),
+            ram_tier_key,
+            int(kv_bits),
+            int(context),
+            int(concurrency),
+            _row_get(row, "draft_model"),
+            _row_get(row, "draft_model_artifact_sha256"),
+            _row_get(row, "num_draft_tokens"),
+            _row_get(row, "candidate_source"),
+        )
+        grouped.setdefault(key, []).append(row)
+
+    out: list[SearchCellResult] = []
+    for key, group in grouped.items():
+        (
+            workload_name,
+            model,
+            ram_tier_key,
+            kv_bits,
+            context,
+            concurrency,
+            draft_model,
+            draft_hash,
+            num_draft_tokens,
+            candidate_source,
+        ) = key
+        non_runnable_reason = next(
+            (
+                _row_get(row, "non_runnable_reason")
+                for row in group
+                if _row_get(row, "non_runnable_reason")
+            ),
+            None,
+        )
+        successful_rows = [row for row in group if _row_ok(row)]
+        successful_sample_count = len(successful_rows)
+        ttft_values = [
+            float(_row_get(row, "ttft_ms"))
+            for row in successful_rows
+            if _row_get(row, "ttft_ms") is not None
+        ]
+        tps_values = [
+            float(_row_get(row, "throughput_tps"))
+            for row in successful_rows
+            if _row_get(row, "throughput_tps") is not None
+        ]
+        acceptance_values = [
+            float(_row_get(row, "spec_decode_acceptance_rate"))
+            for row in successful_rows
+            if _row_get(row, "spec_decode_acceptance_rate") is not None
+        ]
+        leak_count = sum(1 for row in successful_rows if _row_get(row, "stop_token_leak"))
+        leak_rate = (leak_count / successful_sample_count) if successful_sample_count else 0.0
+        hard_failure_count = len(group) - successful_sample_count
+        out.append(SearchCellResult(
+            workload_name=workload_name,
+            model=model,
+            ram_tier_key=ram_tier_key,
+            kv_bits=kv_bits,
+            max_context_override=context,
+            max_concurrency_override=concurrency,
+            successful_sample_count=successful_sample_count,
+            p95_ttft_ms=p95(ttft_values),
+            median_tps=statistics.median(tps_values) if tps_values else None,
+            stop_token_leak_rate=leak_rate,
+            hard_failure_count=hard_failure_count,
+            non_runnable_reason=non_runnable_reason,
+            draft_model=draft_model,
+            draft_model_artifact_sha256=draft_hash,
+            num_draft_tokens=num_draft_tokens,
+            spec_decode_acceptance_rate=statistics.median(acceptance_values) if acceptance_values else None,
+            candidate_source=candidate_source,
+        ))
+    return out
+
+
+def _row_ok(row: Any) -> bool:
+    return _row_get(row, "http_status") == 200 and not _row_get(row, "error")
+
+
+def _row_get(row: Any, key: str, default=None):
+    if hasattr(row, "keys") and key in row.keys():
+        return row[key]
+    if isinstance(row, dict):
+        return row.get(key, default)
+    return getattr(row, key, default)
+
+
+def p95(values: list[float]) -> float | None:
+    if not values:
+        return None
+    if len(values) == 1:
+        return values[0]
+    return statistics.quantiles(values, n=100, method="inclusive")[94]

--- a/beta/test_spec029.py
+++ b/beta/test_spec029.py
@@ -1,0 +1,1039 @@
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import harness
+import report
+import spec029
+
+
+class Spec029HelpersTests(unittest.TestCase):
+    def test_ram_tier_boundaries(self):
+        cases = [
+            (12, "8gb"),
+            (13, "16gb"),
+            (24, "16gb"),
+            (25, "32gb"),
+            (48, "32gb"),
+            (49, "64gb_plus"),
+        ]
+        for gib, expected in cases:
+            with self.subTest(gib=gib):
+                self.assertEqual(spec029.ram_tier_key_for_gib(gib), expected)
+
+    def test_provider_tier_normalization(self):
+        self.assertEqual(spec029.normalize_provider_ram_tier("8GB"), "8gb")
+        self.assertEqual(spec029.normalize_provider_ram_tier("16GB"), "16gb")
+        self.assertEqual(spec029.normalize_provider_ram_tier("32GB"), "32gb")
+        self.assertEqual(spec029.normalize_provider_ram_tier("64gb+"), "64gb_plus")
+        self.assertEqual(spec029.normalize_provider_ram_tier("64GB+"), "64gb_plus")
+        with self.assertRaises(ValueError):
+            spec029.normalize_provider_ram_tier("24GB")
+
+    def test_provider_ram_prefers_explicit_provider_config_over_local_host(self):
+        with mock.patch.object(spec029, "host_ram_bytes", return_value=64 * 1024 ** 3):
+            resolved = spec029.resolve_provider_ram({"provider_ram_gib": 16}, require=True)
+
+        self.assertEqual(resolved.host_ram_bytes, 16 * 1024 ** 3)
+        self.assertEqual(resolved.ram_tier_key, "16gb")
+        self.assertEqual(resolved.source, "config")
+
+    def test_provider_ram_requires_explicit_metadata_for_spec029_sweep(self):
+        with self.assertRaises(ValueError):
+            spec029.resolve_provider_ram({}, require=True)
+
+    def test_sweep_grid_expands_to_search_cells(self):
+        cfg = {
+            "spec029_sweep": {
+                "grid": {
+                    "kv_bits": [4, 8],
+                    "max_context_override": [8192],
+                    "max_concurrency_override": [1, 2],
+                }
+            }
+        }
+
+        cells = spec029.sweep_cells_from_config(cfg, require_grid=True)
+
+        self.assertEqual(len(cells), 4)
+        self.assertIn(
+            {"kv_bits": 4, "max_context_override": 8192, "max_concurrency_override": 2},
+            cells,
+        )
+
+    def test_streaming_check_is_probe_only(self):
+        self.assertFalse(spec029.is_publishable_workload("streaming_check"))
+        self.assertIn("streaming_check", spec029.spec029_workloads_from_config({"spec029_sweep": {"workloads": ["streaming_check"]}}))
+        with self.assertRaises(ValueError):
+            spec029.choose_partition([], "streaming_check", "16gb")
+
+    def test_metric_unavailable_reason(self):
+        self.assertIsNone(spec029.metric_unavailable_reason(10, 20, 3.5))
+        self.assertEqual(
+            spec029.metric_unavailable_reason(10, None, None),
+            "missing_completion_tokens,missing_throughput_tps",
+        )
+
+
+class Spec029SelectionTests(unittest.TestCase):
+    def test_partition_local_winner_and_winning_cell_sample_count(self):
+        cells = [
+            self.cell("short_chat", "16gb", kv_bits=8, samples=20, p95=600, tps=12),
+            self.cell("short_chat", "16gb", kv_bits=4, samples=20, p95=700, tps=20),
+            self.cell("code_completion", "16gb", kv_bits=2, samples=20, p95=700, tps=40),
+        ]
+
+        result = spec029.choose_partition(cells, "short_chat", "16gb")
+        profile = spec029.workload_profile(result, "test-source")
+
+        self.assertEqual(result.winner.kv_bits, 4)
+        self.assertEqual(profile["profile_metrics"]["sample_count"], 20)
+        self.assertEqual(profile["recommended"]["kv_bits"], 4)
+
+    def test_tie_breaker_uses_memory_risk_then_lexical_tuple(self):
+        cells = [
+            self.cell("agent_style", "32gb", kv_bits=8, context=50_000, concurrency=2, samples=20, p95=1000, tps=10),
+            self.cell("agent_style", "32gb", kv_bits=4, context=20_000, concurrency=1, samples=20, p95=1000, tps=10),
+        ]
+
+        result = spec029.choose_partition(cells, "agent_style", "32gb")
+
+        self.assertEqual(result.winner.kv_bits, 4)
+        self.assertEqual(result.winner.max_context_override, 20_000)
+        self.assertEqual(result.tie_breaker_reason, "lower_context_memory_risk")
+
+    def test_no_winner_reason_precedence(self):
+        self.assertEqual(
+            spec029.choose_partition([], "short_chat", "16gb").no_winner_reason,
+            "no_cells_evaluated",
+        )
+
+        hard = [self.cell("short_chat", "16gb", samples=0, p95=None, tps=None)]
+        self.assertEqual(
+            spec029.choose_partition(hard, "short_chat", "16gb").no_winner_reason,
+            "hard_failure",
+        )
+
+        insufficient = [self.cell("short_chat", "16gb", samples=19, p95=100, tps=10)]
+        self.assertEqual(
+            spec029.choose_partition(insufficient, "short_chat", "16gb").no_winner_reason,
+            "insufficient_samples",
+        )
+
+        gate_unmet = [self.cell("short_chat", "16gb", samples=20, p95=9_000, tps=10)]
+        self.assertEqual(
+            spec029.choose_partition(gate_unmet, "short_chat", "16gb").no_winner_reason,
+            "gate_unmet",
+        )
+
+    def test_non_runnable_spec_cell_is_evaluated_but_not_recommended(self):
+        cells = [
+            self.cell(
+                "code_completion",
+                "16gb",
+                samples=0,
+                p95=None,
+                tps=None,
+                non_runnable_reason="draft_model_unverified_artifact",
+                draft_model="mlx-community/example-draft",
+            )
+        ]
+
+        result = spec029.choose_partition(cells, "code_completion", "16gb")
+
+        self.assertEqual(result.evaluated_cell_count, 1)
+        self.assertIsNone(result.winner)
+        self.assertEqual(result.no_winner_reason, "hard_failure")
+
+    def test_no_winner_profile_carries_highest_success_count_and_null_metrics(self):
+        cells = [
+            self.cell("long_context", "16gb", samples=4, p95=10_000, tps=2),
+            self.cell("long_context", "16gb", samples=7, p95=12_000, tps=3),
+        ]
+        result = spec029.choose_partition(cells, "long_context", "16gb")
+        profile = spec029.no_winner_profile(result, cells, "test-source")
+
+        self.assertEqual(profile["status"], "no_winner")
+        self.assertEqual(profile["profile_metrics"]["sample_count"], 7)
+        self.assertIsNone(profile["profile_metrics"]["median_tps"])
+        self.assertNotIn("recommended", profile)
+
+    def test_class_aware_report_emits_one_partition_per_included_workload(self):
+        cells = [self.cell("short_chat", "16gb", samples=20, p95=500, tps=10)]
+
+        summary = spec029.class_aware_report(cells, "test-source", ram_tier_keys=["16gb"])
+
+        self.assertEqual(len(summary["partitions"]), 5)
+        statuses = {p["workload"]: p["status"] for p in summary["partitions"]}
+        self.assertEqual(statuses["short_chat"], "winner")
+        self.assertEqual(statuses["long_context"], "no_winner")
+        long_context = next(p for p in summary["partitions"] if p["workload"] == "long_context")
+        self.assertEqual(long_context["no_winner_reason"], "no_cells_evaluated")
+        self.assertEqual(long_context["gate_policy"]["max_p95_ttft_ms"], 60_000)
+        self.assertIn("higher_median_tps", long_context["tie_breaker_order"])
+
+    def test_class_aware_report_keeps_per_workload_draft_token_choice(self):
+        draft_hash = "0" * 64
+        cells = [
+            self.cell(
+                "code_completion",
+                "16gb",
+                samples=20,
+                p95=500,
+                tps=10,
+                draft_model="mlx-community/Fixture-Draft-4bit",
+                draft_hash=draft_hash,
+                draft_tokens=4,
+            ),
+            self.cell(
+                "agent_style",
+                "16gb",
+                samples=20,
+                p95=500,
+                tps=10,
+                draft_model="mlx-community/Fixture-Draft-4bit",
+                draft_hash=draft_hash,
+                draft_tokens=8,
+            ),
+        ]
+
+        summary = spec029.class_aware_report(cells, "test-source", ram_tier_keys=["16gb"])
+        tuples = {p["workload"]: p["winner_tuple"] for p in summary["partitions"] if p["winner_tuple"]}
+
+        self.assertEqual(tuples["code_completion"]["num_draft_tokens"], 4)
+        self.assertEqual(tuples["agent_style"]["num_draft_tokens"], 8)
+        code = next(p for p in summary["partitions"] if p["workload"] == "code_completion")
+        self.assertEqual(code["candidate_source"], "research_fixture:spec029-test")
+        self.assertEqual(code["profile"]["candidate_source"], "research_fixture:spec029-test")
+
+    def test_invalid_draft_tuples_cannot_become_python_winners(self):
+        invalid_cases = [
+            {"candidate_source": ""},
+            {"candidate_source": "fixture"},
+            {"draft_hash": "ABC"},
+            {"draft_tokens": 0},
+            {"draft_tokens": 17},
+            {"concurrency": 2},
+            {"context": 20_001},
+        ]
+        for overrides in invalid_cases:
+            with self.subTest(overrides=overrides):
+                cells = [
+                    self.cell(
+                        "code_completion",
+                        "16gb",
+                        samples=20,
+                        p95=500,
+                        tps=10,
+                        draft_model="mlx-community/Fixture-Draft-4bit",
+                        **overrides,
+                    )
+                ]
+
+                result = spec029.choose_partition(cells, "code_completion", "16gb")
+
+                self.assertIsNone(result.winner)
+                self.assertEqual(result.no_winner_reason, "hard_failure")
+                with self.assertRaises(ValueError):
+                    cells[0].recommended_json()
+
+        partial = self.cell(
+            "code_completion",
+            "16gb",
+            samples=20,
+            p95=500,
+            tps=10,
+            draft_model=None,
+            draft_hash="0" * 64,
+        )
+        self.assertEqual(partial.draft_validation_error, "partial_speculative_tuple")
+
+    def test_non_runnable_success_rows_do_not_inflate_no_winner_sample_count(self):
+        cells = [
+            self.cell(
+                "code_completion",
+                "16gb",
+                samples=25,
+                p95=500,
+                tps=10,
+                draft_model="mlx-community/Fixture-Draft-4bit",
+                draft_hash="ABC",
+            )
+        ]
+
+        result = spec029.choose_partition(cells, "code_completion", "16gb")
+        profile = spec029.workload_profile(result, "test-source")
+
+        self.assertEqual(result.no_winner_reason, "hard_failure")
+        self.assertEqual(profile["profile_metrics"]["sample_count"], 0)
+
+    def test_winner_prefers_zero_failures_and_rejects_leaks(self):
+        clean = self.cell("short_chat", "16gb", kv_bits=8, samples=20, p95=500, tps=5, hard_failure_count=0)
+        partial_failure = self.cell("short_chat", "16gb", kv_bits=4, samples=20, p95=500, tps=50, hard_failure_count=1)
+
+        result = spec029.choose_partition([partial_failure, clean], "short_chat", "16gb")
+
+        self.assertEqual(result.winner.kv_bits, 8)
+
+        leaky = self.cell("short_chat", "16gb", samples=20, p95=500, tps=50, leak_rate=0.01)
+        leaky_result = spec029.choose_partition([leaky], "short_chat", "16gb")
+        self.assertIsNone(leaky_result.winner)
+        self.assertEqual(leaky_result.no_winner_reason, "gate_unmet")
+
+    def cell(
+        self,
+        workload,
+        ram_tier,
+        kv_bits=4,
+        context=20_000,
+        concurrency=1,
+        samples=20,
+        p95=1_000,
+        tps=10.0,
+        non_runnable_reason=None,
+        draft_model=None,
+        draft_hash=None,
+        draft_tokens=4,
+        hard_failure_count=0,
+        leak_rate=0,
+        candidate_source=None,
+    ):
+        return spec029.SearchCellResult(
+            workload_name=workload,
+            ram_tier_key=ram_tier,
+            kv_bits=kv_bits,
+            max_context_override=context,
+            max_concurrency_override=concurrency,
+            successful_sample_count=samples,
+            p95_ttft_ms=p95,
+            median_tps=tps,
+            stop_token_leak_rate=leak_rate,
+            hard_failure_count=hard_failure_count,
+            non_runnable_reason=non_runnable_reason,
+            draft_model=draft_model,
+            draft_model_artifact_sha256=draft_hash if draft_hash is not None else ("0" * 64 if draft_model else None),
+            num_draft_tokens=draft_tokens if draft_model else None,
+            candidate_source=candidate_source if candidate_source is not None else ("research_fixture:spec029-test" if draft_model else None),
+        )
+
+
+class Spec029HarnessReportTests(unittest.TestCase):
+    def test_cells_from_rows_aggregate_real_repeated_rows_into_winner_cell(self):
+        rows = [
+            self.row(
+                "short_chat",
+                "16gb",
+                ttft_ms=400 + i,
+                throughput_tps=10 + (i % 3),
+            )
+            for i in range(20)
+        ]
+
+        cells = spec029.cells_from_rows(rows)
+        result = spec029.choose_partition(cells, "short_chat", "16gb")
+
+        self.assertEqual(len(cells), 1)
+        self.assertEqual(cells[0].successful_sample_count, 20)
+        self.assertEqual(result.status, "winner")
+        self.assertEqual(result.winner.successful_sample_count, 20)
+
+    def test_cells_from_rows_ignore_unproven_execution_sources(self):
+        rows = [
+            self.row(
+                "code_completion",
+                "16gb",
+                cell_execution_source="request_overrides",
+            )
+            for _ in range(20)
+        ] + [
+            self.row(
+                "code_completion",
+                "16gb",
+                cell_execution_source=None,
+            )
+            for _ in range(20)
+        ]
+
+        cells = spec029.cells_from_rows(rows)
+        result = spec029.choose_partition(cells, "code_completion", "16gb")
+
+        self.assertEqual(cells, [])
+        self.assertEqual(result.status, "no_winner")
+        self.assertEqual(result.no_winner_reason, "no_cells_evaluated")
+
+    def test_cells_from_rows_do_not_mix_target_models(self):
+        rows = [
+            self.row("short_chat", "16gb", model="model-a")
+            for _ in range(10)
+        ] + [
+            self.row("short_chat", "16gb", model="model-b")
+            for _ in range(10)
+        ]
+
+        cells = spec029.cells_from_rows(rows)
+        summary = spec029.class_aware_report(cells, "test-source", ram_tier_keys=["16gb"])
+        short_chat = [
+            partition for partition in summary["partitions"]
+            if partition["workload"] == "short_chat"
+        ]
+
+        self.assertEqual(len(cells), 2)
+        self.assertEqual(sorted(cell.successful_sample_count for cell in cells), [10, 10])
+        self.assertEqual({partition["model"] for partition in short_chat}, {"model-a", "model-b"})
+        self.assertTrue(all(partition["status"] == "no_winner" for partition in short_chat))
+        with self.assertRaises(ValueError):
+            spec029.choose_partition(cells, "short_chat", "16gb")
+
+    def test_streaming_rows_aggregate_to_probe_pass(self):
+        rows = [
+            self.row(
+                "streaming_check",
+                "8gb",
+                kv_bits=8,
+                context=8192,
+                ttft_ms=1_500,
+                throughput_tps=None,
+                prompt_tokens=None,
+                completion_tokens=None,
+            )
+            for _ in range(20)
+        ]
+
+        summary = spec029.class_aware_report(
+            spec029.cells_from_rows(rows),
+            "test-source",
+            ram_tier_keys=["8gb"],
+        )
+        probe = summary["streaming_probes"][0]
+
+        self.assertEqual(probe["status"], "probe_pass")
+        self.assertIsNone(probe["winner_tuple"])
+        self.assertEqual(probe["profile_metrics"]["sample_count"], 20)
+
+    def test_streaming_probe_hard_failures_use_hard_failure_reason(self):
+        rows = [
+            self.row(
+                "streaming_check",
+                "8gb",
+                kv_bits=8,
+                context=8192,
+                error="HTTP 500",
+                prompt_tokens=None,
+                completion_tokens=None,
+                throughput_tps=None,
+            )
+            for _ in range(20)
+        ]
+
+        summary = spec029.class_aware_report(
+            spec029.cells_from_rows(rows),
+            "test-source",
+            ram_tier_keys=["8gb"],
+        )
+        probe = summary["streaming_probes"][0]
+
+        self.assertEqual(probe["status"], "probe_no_winner")
+        self.assertEqual(probe["no_winner_reason"], "hard_failure")
+        self.assertEqual(probe["profile_metrics"]["sample_count"], 0)
+
+    def test_open_db_migrates_legacy_runs_table(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "runs.sqlite"
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                "CREATE TABLE runs (id INTEGER PRIMARY KEY AUTOINCREMENT, ts_utc TEXT NOT NULL, "
+                "workload TEXT NOT NULL, model TEXT, tunnel_url TEXT, streamed INTEGER NOT NULL, "
+                "http_status INTEGER, ttft_ms REAL, total_ms REAL, prompt_tokens INTEGER, "
+                "completion_tokens INTEGER, throughput_tps REAL, stop_token_leak INTEGER NOT NULL DEFAULT 0, "
+                "error TEXT, response_preview TEXT)"
+            )
+            conn.commit()
+            conn.close()
+
+            migrated = harness.open_db(db_path)
+            try:
+                columns = {row[1] for row in migrated.execute("PRAGMA table_info(runs)")}
+            finally:
+                migrated.close()
+
+        self.assertIn("ram_tier_key", columns)
+        self.assertIn("provider_ram_source", columns)
+        self.assertIn("cell_execution_source", columns)
+        self.assertIn("non_runnable_reason", columns)
+        self.assertIn("metric_unavailable_reason", columns)
+        self.assertIn("draft_model_artifact_sha256", columns)
+
+    def test_report_renders_legacy_rows_without_spec029_columns(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            "CREATE TABLE runs (id INTEGER PRIMARY KEY AUTOINCREMENT, ts_utc TEXT NOT NULL, "
+            "workload TEXT NOT NULL, model TEXT, tunnel_url TEXT, streamed INTEGER NOT NULL, "
+            "http_status INTEGER, ttft_ms REAL, total_ms REAL, prompt_tokens INTEGER, "
+            "completion_tokens INTEGER, throughput_tps REAL, stop_token_leak INTEGER NOT NULL DEFAULT 0, "
+            "error TEXT, response_preview TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO runs (ts_utc, workload, model, tunnel_url, streamed, http_status, "
+            "ttft_ms, total_ms, prompt_tokens, completion_tokens, throughput_tps, stop_token_leak, "
+            "error, response_preview) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("2026-07-09T00:00:00Z", "short_chat", "model", "http://localhost", 0, 200, None, 100, 10, 20, 3.0, 0, None, "ok"),
+        )
+        rows = conn.execute("SELECT * FROM runs").fetchall()
+
+        html = report.render("2026-07-09", rows)
+        conn.close()
+
+        self.assertIn("short_chat", html)
+        self.assertIn("RAM tier", html)
+
+    def test_run_one_persists_spec029_trial_identity_and_speculative_metrics(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            conn.row_factory = sqlite3.Row
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "provider_ram_gib": 16,
+                "sweep_cell": {
+                    "max_context_override": 20_000,
+                    "max_concurrency_override": 1,
+                    "kv_bits": 4,
+                    "draft_model": "mlx-community/Fixture-Draft-4bit",
+                    "draft_model_artifact_sha256": "0" * 64,
+                    "num_draft_tokens": 4,
+                    "candidate_source": "research_fixture:spec029-test",
+                },
+            }
+            metrics = {
+                "http_status": 200,
+                "ttft_ms": 500,
+                "total_ms": 2000,
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "throughput_tps": 10,
+                "stop_token_leak": False,
+                "response_preview": "ok",
+                "drafted_tokens": 8,
+                "accepted_tokens": 4,
+                "spec_decode_acceptance_rate": 0.5,
+            }
+
+            with mock.patch.object(harness, "fire_nonstream", return_value=metrics), \
+                 mock.patch.object(spec029, "host_ram_bytes", return_value=64 * 1024 ** 3):
+                harness.run_one(cfg, "code_completion", conn, verbose=False, dry_run=False)
+
+            row = conn.execute("SELECT * FROM runs").fetchone()
+            conn.close()
+
+        self.assertEqual(row["ram_tier_key"], "16gb")
+        self.assertEqual(row["provider_ram_source"], "config")
+        self.assertEqual(row["corpus_class"], "code")
+        self.assertEqual(row["metric_unavailable_reason"], None)
+        self.assertEqual(row["draft_model"], "mlx-community/Fixture-Draft-4bit")
+        self.assertEqual(row["drafted_tokens"], 8)
+        self.assertEqual(row["accepted_tokens"], 4)
+        self.assertEqual(row["spec_decode_acceptance_rate"], 0.5)
+
+    def test_spec029_sweep_uses_provider_ram_grid_and_streaming_ttft(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            conn.row_factory = sqlite3.Row
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "provider_ram_gib": 16,
+                "spec029_sweep": {
+                    "cell_control_url": "http://127.0.0.1:8091/spec029/apply-cell",
+                    "workloads": ["short_chat"],
+                    "samples_per_cell": 2,
+                    "cells": [
+                        {"max_context_override": 8192, "max_concurrency_override": 1, "kv_bits": 8},
+                        {
+                            "max_context_override": 20_000,
+                            "max_concurrency_override": 1,
+                            "kv_bits": 4,
+                            "draft_model": "mlx-community/Fixture-Draft-4bit",
+                            "draft_model_artifact_sha256": "0" * 64,
+                            "num_draft_tokens": 4,
+                            "candidate_source": "research_fixture:spec029-test",
+                        },
+                    ],
+                },
+            }
+            metrics = {
+                "http_status": 200,
+                "ttft_ms": 500,
+                "total_ms": 2000,
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "throughput_tps": 10,
+                "stop_token_leak": False,
+                "response_preview": "ok",
+            }
+
+            class ApplyResponse:
+                status_code = 204
+                text = ""
+
+            with mock.patch.object(harness.requests, "post", return_value=ApplyResponse()) as post, \
+                 mock.patch.object(harness, "fire_stream", return_value=metrics) as fire_stream, \
+                 mock.patch.object(harness, "fire_nonstream", side_effect=AssertionError("SPEC-029 sweep must stream")):
+                rows = harness.run_spec029_sweep(cfg, conn, verbose=False, dry_run=False)
+
+            db_rows = conn.execute("SELECT * FROM runs ORDER BY id").fetchall()
+            conn.close()
+
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(post.call_count, 2)
+        applied_cells = [call.kwargs["json"]["cell"] for call in post.call_args_list]
+        self.assertEqual({cell["kv_bits"] for cell in applied_cells}, {4, 8})
+        self.assertEqual(fire_stream.call_count, 4)
+        request_bodies = [call.args[2] for call in fire_stream.call_args_list]
+        self.assertTrue(all("macprovider_kv_bits" not in body for body in request_bodies))
+        self.assertTrue(all("macprovider_draft_model" not in body for body in request_bodies))
+        self.assertTrue(all(body["stream"] is True for body in request_bodies))
+        self.assertEqual({row["streamed"] for row in db_rows}, {1})
+        self.assertEqual({row["ram_tier_key"] for row in db_rows}, {"16gb"})
+        self.assertEqual({row["provider_ram_source"] for row in db_rows}, {"config"})
+        self.assertEqual({row["cell_execution_source"] for row in db_rows}, {"cell_control_url"})
+        self.assertEqual({row["host_ram_bytes"] for row in db_rows}, {16 * 1024 ** 3})
+        self.assertEqual({row["kv_bits"] for row in db_rows}, {4, 8})
+        self.assertTrue(all(row["ttft_ms"] == 500 for row in db_rows))
+
+    def test_spec029_sweep_schedules_streaming_probe_without_publication_profile(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            conn.row_factory = sqlite3.Row
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "provider_ram_gib": 8,
+                "spec029_sweep": {
+                    "cell_control_url": "http://127.0.0.1:8091/spec029/apply-cell",
+                    "workloads": ["streaming_check"],
+                    "samples_per_cell": 1,
+                    "cells": [
+                        {"max_context_override": 8192, "max_concurrency_override": 1, "kv_bits": 8},
+                    ],
+                },
+            }
+            metrics = {
+                "http_status": 200,
+                "ttft_ms": 100,
+                "total_ms": 500,
+                "prompt_tokens": None,
+                "completion_tokens": None,
+                "throughput_tps": None,
+                "stop_token_leak": False,
+                "response_preview": "ok",
+            }
+
+            class ApplyResponse:
+                status_code = 204
+                text = ""
+
+            with mock.patch.object(harness.requests, "post", return_value=ApplyResponse()), \
+                 mock.patch.object(harness, "fire_stream", return_value=metrics):
+                harness.run_spec029_sweep(cfg, conn, verbose=False, dry_run=False)
+            rows = conn.execute("SELECT * FROM runs ORDER BY id").fetchall()
+            summary = spec029.class_aware_report(spec029.cells_from_rows(rows), "test-source", ram_tier_keys=["8gb"])
+            conn.close()
+
+        self.assertEqual(rows[0]["workload"], "streaming_check")
+        self.assertEqual(rows[0]["ram_tier_key"], "8gb")
+        self.assertEqual(len(summary["streaming_probes"]), 1)
+        self.assertTrue(all(partition["workload"] != "streaming_check" for partition in summary["partitions"]))
+
+    def test_spec029_sweep_fails_closed_without_cell_execution_mechanism(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "provider_ram_gib": 8,
+                "spec029_sweep": {
+                    "workloads": ["short_chat"],
+                    "cells": [
+                        {"max_context_override": 8192, "max_concurrency_override": 1, "kv_bits": 8},
+                    ],
+                },
+            }
+
+            with self.assertRaises(RuntimeError):
+                harness.run_spec029_sweep(cfg, conn, verbose=False, dry_run=False)
+            conn.close()
+
+    def test_spec029_sweep_records_cell_apply_failure_as_non_runnable_cell(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            conn.row_factory = sqlite3.Row
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "provider_ram_gib": 16,
+                "spec029_sweep": {
+                    "cell_control_url": "http://127.0.0.1:8091/spec029/apply-cell",
+                    "workloads": ["code_completion"],
+                    "cells": [
+                        {"max_context_override": 20_000, "max_concurrency_override": 1, "kv_bits": 4},
+                    ],
+                },
+            }
+
+            class ApplyResponse:
+                status_code = 503
+                text = "capacity preflight failed"
+
+            with mock.patch.object(harness.requests, "post", return_value=ApplyResponse()), \
+                 mock.patch.object(harness, "fire_stream", side_effect=AssertionError("non-runnable cell should not sample")):
+                rows = harness.run_spec029_sweep(cfg, conn, verbose=False, dry_run=False)
+            db_rows = conn.execute("SELECT * FROM runs ORDER BY id").fetchall()
+            cells = spec029.cells_from_rows(db_rows)
+            result = spec029.choose_partition(cells, "code_completion", "16gb")
+            conn.close()
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(db_rows[0]["cell_execution_source"], "cell_apply_failed")
+        self.assertEqual(db_rows[0]["non_runnable_reason"], "cell_apply_failed")
+        self.assertEqual(cells[0].non_runnable_reason, "cell_apply_failed")
+        self.assertEqual(result.no_winner_reason, "hard_failure")
+
+    def test_spec029_sweep_records_cell_control_transport_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            conn.row_factory = sqlite3.Row
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "provider_ram_gib": 16,
+                "spec029_sweep": {
+                    "cell_control_url": "http://127.0.0.1:8091/spec029/apply-cell",
+                    "workloads": ["code_completion"],
+                    "cells": [
+                        {"max_context_override": 20_000, "max_concurrency_override": 1, "kv_bits": 4},
+                    ],
+                },
+            }
+
+            with mock.patch.object(harness.requests, "post", side_effect=harness.requests.Timeout("timed out")), \
+                 mock.patch.object(harness, "fire_stream", side_effect=AssertionError("non-runnable cell should not sample")):
+                rows = harness.run_spec029_sweep(cfg, conn, verbose=False, dry_run=False)
+            db_rows = conn.execute("SELECT * FROM runs ORDER BY id").fetchall()
+            cells = spec029.cells_from_rows(db_rows)
+            result = spec029.choose_partition(cells, "code_completion", "16gb")
+            conn.close()
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(db_rows[0]["cell_execution_source"], "cell_apply_failed")
+        self.assertEqual(db_rows[0]["non_runnable_reason"], "cell_apply_failed")
+        self.assertIn("cell control request failed", db_rows[0]["error"])
+        self.assertEqual(result.no_winner_reason, "hard_failure")
+
+    def test_spec029_sweep_records_cell_apply_command_launch_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            conn.row_factory = sqlite3.Row
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "provider_ram_gib": 16,
+                "spec029_sweep": {
+                    "cell_apply_command": "/definitely/missing/spec029-apply-cell",
+                    "workloads": ["code_completion"],
+                    "cells": [
+                        {"max_context_override": 20_000, "max_concurrency_override": 1, "kv_bits": 4},
+                    ],
+                },
+            }
+
+            with mock.patch.object(harness, "fire_stream", side_effect=AssertionError("non-runnable cell should not sample")):
+                rows = harness.run_spec029_sweep(cfg, conn, verbose=False, dry_run=False)
+            db_rows = conn.execute("SELECT * FROM runs ORDER BY id").fetchall()
+            cells = spec029.cells_from_rows(db_rows)
+            result = spec029.choose_partition(cells, "code_completion", "16gb")
+            conn.close()
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(db_rows[0]["cell_execution_source"], "cell_apply_failed")
+        self.assertEqual(db_rows[0]["non_runnable_reason"], "cell_apply_failed")
+        self.assertIn("cell apply command failed", db_rows[0]["error"])
+        self.assertEqual(result.no_winner_reason, "hard_failure")
+
+    def test_spec029_sweep_rejects_tier_only_provider_ram(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "provider_ram_tier": "16gb",
+                "spec029_sweep": {
+                    "cell_control_url": "http://127.0.0.1:8091/spec029/apply-cell",
+                    "workloads": ["short_chat"],
+                    "cells": [
+                        {"max_context_override": 8192, "max_concurrency_override": 1, "kv_bits": 8},
+                    ],
+                },
+            }
+
+            with self.assertRaises(RuntimeError):
+                harness.run_spec029_sweep(cfg, conn, verbose=False, dry_run=False)
+            conn.close()
+
+    def test_spec029_sweep_rejects_multiple_cell_execution_mechanisms(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "provider_ram_gib": 16,
+                "spec029_sweep": {
+                    "cell_control_url": "http://127.0.0.1:8091/spec029/apply-cell",
+                    "cell_apply_command": ["true"],
+                    "workloads": ["short_chat"],
+                    "cells": [
+                        {"max_context_override": 8192, "max_concurrency_override": 1, "kv_bits": 8},
+                    ],
+                },
+            }
+
+            with self.assertRaises(RuntimeError):
+                harness.run_spec029_sweep(cfg, conn, verbose=False, dry_run=False)
+            conn.close()
+
+    def test_spec029_sweep_rejects_missing_explicit_grid(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "provider_ram_gib": 16,
+                "spec029_sweep": {
+                    "cell_control_url": "http://127.0.0.1:8091/spec029/apply-cell",
+                    "workloads": ["short_chat"],
+                },
+            }
+
+            with self.assertRaises(ValueError):
+                harness.run_spec029_sweep(cfg, conn, verbose=False, dry_run=False)
+            conn.close()
+
+    def test_fire_nonstream_extracts_spec_decode_response_metrics(self):
+        class Response:
+            status_code = 200
+
+            def json(self):
+                return {
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 20,
+                        "spec_decode_drafted_tokens": 12,
+                        "spec_decode_accepted_tokens": 9,
+                    },
+                }
+
+        with mock.patch.object(harness.requests, "post", return_value=Response()), \
+             mock.patch.object(harness, "detect_leak_model", return_value=False), \
+             mock.patch.object(harness, "strip_leaks_model", side_effect=lambda content, model: content):
+            metrics = harness.fire_nonstream("http://localhost/v1/chat/completions", "model", {}, 1)
+
+        self.assertEqual(metrics["drafted_tokens"], 12)
+        self.assertEqual(metrics["accepted_tokens"], 9)
+        self.assertEqual(metrics["spec_decode_acceptance_rate"], 0.75)
+
+    def test_streaming_probe_and_class_aware_report_render_gates_and_decisions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            conn.row_factory = sqlite3.Row
+            cfg = {
+                "tunnel_url": "http://127.0.0.1:8090",
+                "model": "mlx-community/Fixture-Model-4bit",
+                "sweep_cell": {
+                    "max_context_override": 8192,
+                    "max_concurrency_override": 1,
+                    "kv_bits": 8,
+                },
+            }
+            metrics = {
+                "http_status": 200,
+                "ttft_ms": 1500,
+                "total_ms": 2000,
+                "prompt_tokens": None,
+                "completion_tokens": None,
+                "throughput_tps": None,
+                "stop_token_leak": False,
+                "response_preview": "ok",
+            }
+            with mock.patch.object(harness, "fire_stream", return_value=metrics), \
+                 mock.patch.object(spec029, "host_ram_bytes", return_value=8 * 1024 ** 3):
+                harness.run_one(
+                    cfg,
+                    "streaming_check",
+                    conn,
+                    verbose=False,
+                    dry_run=False,
+                    cell_execution_source="cell_control_url",
+                )
+            with mock.patch.object(harness, "fire_nonstream", return_value={**metrics, "prompt_tokens": 10, "completion_tokens": 20, "throughput_tps": 10}), \
+                 mock.patch.object(spec029, "host_ram_bytes", return_value=8 * 1024 ** 3):
+                harness.run_one(
+                    cfg,
+                    "short_chat",
+                    conn,
+                    verbose=False,
+                    dry_run=False,
+                    cell_execution_source="cell_control_url",
+                )
+
+            rows = conn.execute("SELECT * FROM runs ORDER BY id").fetchall()
+            html = report.render("2026-07-09", rows)
+            conn.close()
+
+        self.assertEqual(rows[0]["metric_unavailable_reason"], "missing_prompt_tokens,missing_completion_tokens,missing_throughput_tps")
+        self.assertIn("SPEC-029 class-aware sweep", html)
+        self.assertIn("n&gt;=20", html)
+        self.assertIn("insufficient_samples", html)
+        self.assertIn("streaming_check", html)
+        self.assertIn("probe_no_winner", html)
+
+    def test_write_report_emits_reproducible_spec029_json_and_html_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = harness.open_db(Path(tmp) / "runs.sqlite")
+            conn.row_factory = sqlite3.Row
+            for idx in range(20):
+                conn.execute(
+                    """INSERT INTO runs (ts_utc, workload, model, tunnel_url, streamed,
+                                          http_status, ttft_ms, total_ms, prompt_tokens,
+                                          completion_tokens, throughput_tps, host_ram_bytes,
+                                          ram_tier_key, provider_ram_source, cell_execution_source,
+                                          non_runnable_reason, corpus_class, max_context_override,
+                                          max_concurrency_override, kv_bits,
+                                          metric_unavailable_reason, draft_model,
+                                          draft_model_artifact_sha256, num_draft_tokens,
+                                          drafted_tokens, accepted_tokens,
+                                          spec_decode_acceptance_rate, candidate_source,
+                                          winner_status, no_winner_reason, stop_token_leak,
+                                          error, response_preview)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        f"2026-07-09T00:00:{idx:02d}Z",
+                        "code_completion",
+                        "model",
+                        "http://localhost",
+                        0,
+                        200,
+                        500 + idx,
+                        2000,
+                        10,
+                        20,
+                        10 + idx / 100,
+                        16 * 1024 ** 3,
+                        "16gb",
+                        "config",
+                        "cell_control_url",
+                        None,
+                        "code",
+                        20_000,
+                        1,
+                        4,
+                        None,
+                        "mlx-community/Fixture-Draft-4bit",
+                        "0" * 64,
+                        4,
+                        8,
+                        4,
+                        0.5,
+                        "research_fixture:spec029-test",
+                        None,
+                        None,
+                        0,
+                        None,
+                        "ok",
+                    ),
+                )
+            conn.commit()
+
+            html_path = report.write_report("2026-07-09", conn, Path(tmp) / "reports")
+            html = html_path.read_text()
+            rerendered_html = report.render("2026-07-09", report.fetch_rows(conn, "2026-07-09"))
+            json_path = html_path.with_suffix(".spec029.json")
+            payload = json_path.read_text()
+            parsed = json.loads(payload)
+            conn.close()
+
+        self.assertEqual(html, rerendered_html)
+        self.assertIn("SPEC-029 evaluated cells", html)
+        self.assertIn("kv_bits=4", html)
+        self.assertIn("source=research_fixture:spec029-test", html)
+        self.assertIn(str(16 * 1024 ** 3), html)
+        self.assertIn('"evaluated_cells"', payload)
+        self.assertEqual(parsed["evaluated_cells"][0]["model"], "model")
+        self.assertEqual(parsed["raw_trials"][0]["host_ram_bytes"], 16 * 1024 ** 3)
+        self.assertEqual(parsed["raw_trials"][0]["provider_ram_source"], "config")
+        self.assertEqual(parsed["raw_trials"][0]["cell_execution_source"], "cell_control_url")
+        self.assertIsNone(parsed["raw_trials"][0]["non_runnable_reason"])
+        self.assertEqual(parsed["raw_trials"][0]["drafted_tokens"], 8)
+        self.assertEqual(parsed["raw_trials"][0]["accepted_tokens"], 4)
+        code_partition = next(
+            partition for partition in parsed["partitions"]
+            if partition["workload"] == "code_completion"
+        )
+        self.assertEqual(code_partition["candidate_source"], "research_fixture:spec029-test")
+        self.assertEqual(code_partition["tie_breaker_reason"], "only_gate_passing_cell")
+        self.assertIn('"status": "winner"', payload)
+        self.assertIn('"successful_sample_count": 20', payload)
+
+    def row(
+        self,
+        workload,
+        ram_tier,
+        kv_bits=4,
+        context=20_000,
+        concurrency=1,
+        ttft_ms=500,
+        throughput_tps=10,
+        prompt_tokens=10,
+        completion_tokens=20,
+        stop_token_leak=0,
+        error=None,
+        draft_model=None,
+        draft_hash=None,
+        num_draft_tokens=None,
+        candidate_source="research_fixture:spec029-test",
+        model="model",
+        cell_execution_source="cell_control_url",
+        non_runnable_reason=None,
+    ):
+        return {
+            "model": model,
+            "workload": workload,
+            "cell_execution_source": cell_execution_source,
+            "non_runnable_reason": non_runnable_reason,
+            "ram_tier_key": ram_tier,
+            "kv_bits": kv_bits,
+            "max_context_override": context,
+            "max_concurrency_override": concurrency,
+            "http_status": 200,
+            "error": error,
+            "ttft_ms": ttft_ms,
+            "throughput_tps": throughput_tps,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "stop_token_leak": stop_token_leak,
+            "draft_model": draft_model,
+            "draft_model_artifact_sha256": draft_hash,
+            "num_draft_tokens": num_draft_tokens,
+            "spec_decode_acceptance_rate": None,
+            "candidate_source": candidate_source,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/research/sweep-workload-class-2026-07.md
+++ b/docs/research/sweep-workload-class-2026-07.md
@@ -1,0 +1,122 @@
+# Sweep Workload-Class Stratification Research Memo
+
+**Date:** 2026-07-09
+**Status:** Research memo for SPEC-029 v0.1-draft
+**Scope:** Research and SPEC drafting only. No sweep, harness, autotune, runtime, or static-catalog implementation changes.
+
+## Summary
+
+MacProvider already measures buyer-harness behavior by workload name, but the autotune and static-candidate surfaces are still class-blind. The right v0.1 shape is to keep the existing context/concurrency/kv sweep shape and run it as parallel workload-class partitions, producing per-class winners as data. Runtime request classification and class-routed serving should stay out of scope until a later SPEC defines the trust, latency, and API boundary.
+
+The current beta workload library exposes six workload names and maps them to five corpus classes: `short_chat -> short`, `medium_with_system -> medium`, `long_context -> long`, `code_completion -> code`, `agent_style -> agent`, and `streaming_check -> short` (`beta/workloads.py:26`). The report path already groups rows by workload and publishes per-workload medians (`beta/report.py:59`, `beta/report.py:118`). Decision criteria also ask for per-workload median throughput, streaming TTFT, and stop-token leak checks (`beta/DECISION_CRITERIA.md:54`, `beta/DECISION_CRITERIA.md:85`).
+
+Two prompt references were unavailable in the current repository state: `.omc/logs/context-throughput-sweep-impl-notes.md` does not exist, and `origin/spike/context-throughput-sweep` is not a valid ref. Those absences should be treated as research constraints, not inferred evidence.
+
+## A. Search-Space Shape
+
+Use workload class as a partition/filter over the existing grid, not as one global 28 x K optimization with a single winner.
+
+This is operationally equivalent to measuring K copies of the grid, but it keeps the semantics clean:
+
+- Each partition has one winner for one traffic shape.
+- Storage can add `workload_class` or `workload_name` to trial/report rows without changing the meaning of existing `runs.workload`.
+- Failure gates and tie-breakers can be class-local.
+- The implementation can reuse the existing per-workload report posture rather than invent a global compromise winner.
+
+The existing harness schema records `workload`, token counts, TTFT, total latency, throughput, and leak flags, with an index on workload (`beta/harness.py:59`, `beta/harness.py:77`). That is enough evidence that workload is already a first-class reporting dimension. The missing surface is the sweep winner and catalog recommendation layer, not the buyer-harness measurement layer.
+
+The v0.1 sweep should include these content-shape workload names:
+
+- `short_chat`
+- `medium_with_system`
+- `long_context`
+- `code_completion`
+- `agent_style`
+
+`streaming_check` should remain a probe/gate workload in v0.1, not a separate serve-knob winner. It maps to the `short` corpus category (`beta/workloads.py:26`) but has `stream=True` and is used to measure streaming TTFT behavior, not a distinct prompt/content family (`beta/workloads.py:231`). It should contribute streaming TTFT gates and report rows, and a later SPEC can promote a TTFT-only serving profile if there is a concrete runtime use for it.
+
+## B. Winner-Picking Under SPEC-028
+
+With speculative decoding, a winner is no longer only a serve-capacity tuple. The candidate profile can include:
+
+```text
+(kv_bits, max_context, max_batch, draft_model, num_draft_tokens)
+```
+
+`num_draft_tokens` should be per workload class for a given target/draft pair. SPEC-028 makes `num_draft_tokens` a provider serve knob (`specs/SPEC-028-mlx-speculative-decoding.md:63`) and explicitly identifies autotune/candidate-catalog extension points (`specs/SPEC-028-mlx-speculative-decoding.md:31`). It also warns that autotune must not blindly multiply every context/concurrency/kv cell by every draft candidate and shows `draft_candidates[]` with `workload_bias` as an additive static-row extension (`specs/SPEC-028-mlx-speculative-decoding.md:202`). That points to a staged shape: choose eligible target/draft candidates first, then tune per class.
+
+Acceptance rate is expected to vary by content shape. A shared `num_draft_tokens` would reintroduce the compromise this SPEC is trying to avoid. The safer v0.1 policy is:
+
+- Pick winners independently per class.
+- Do not let one class dominate another class's winner.
+- If a single legacy default must be exported, derive it from an explicit buyer-traffic weighting policy, not from hidden precedence.
+
+There is no current request-time class classifier in the provider/coordinator path. Therefore v0.1 should publish per-class winners as data and keep runtime serving on the existing single chosen config until a follow-up routing SPEC decides how a buyer request gets a trusted class label.
+
+## C. Static Candidate Shape
+
+Extend the existing `autotune-candidates.json` row shape additively with a per-class profile map. Do not ship a sibling file in v0.1 unless catalog size or consumer separation proves it is needed.
+
+The current static catalog is a signed object with top-level metadata and `rows`; each row carries model identity, RAM/bandwidth eligibility, advisory benchmark gates, runtime status, and notes. The Swift decoder uses a typed `Row` with coding keys for those known fields (`phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:439`). Swift `Decodable` ignores unknown JSON keys by default when decoding keyed containers, so adding an unknown field to each row is backward-compatible for current consumers.
+
+Recommended additive shape:
+
+```json
+{
+  "model_id": "example/target",
+  "workload_profiles": {
+    "code_completion": {
+      "recommended": {
+        "kv_bits": 4,
+        "max_context_override": 20000,
+        "max_concurrency_override": 1,
+        "draft_model": "example/draft",
+        "num_draft_tokens": 4
+      },
+      "bench_gate": {
+        "min_sustained_tps": 8.5,
+        "max_ttft_ms": 8000,
+        "max_stop_token_leak_rate": 0
+      },
+      "source": "sweep-workload-class-2026-07"
+    }
+  }
+}
+```
+
+Use `workload_profiles` rather than `per_class` in the normative SPEC because the keys are harness workload names in v0.1, not a general traffic taxonomy. `per_class` can remain an acceptable alias only if maintainers prefer that spelling.
+
+The same static feed trust domain should sign the additive catalog. The current public key is baked into the installer recommendation code with key ID `streamvc-autotune-static-v4` (`phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:684`), and the static-key README describes the single feed trust model and re-signing process (`phase3-binary/dist/static/keys/README.md:32`). A new key would imply a new trust domain; class profiles are still operator-curated candidate recommendations, so reusing the current static key is correct.
+
+## D. Runtime Routing
+
+This SPEC should not introduce runtime request classification.
+
+The workload definitions live in the beta buyer harness (`beta/workloads.py:26`). They are corpus/sample labels, not request-time metadata. SPEC-028 is also explicit that v0.1 does not change buyer API, receipts, settlement, or coordinator routing (`specs/SPEC-028-mlx-speculative-decoding.md:11`, `specs/SPEC-028-mlx-speculative-decoding.md:38`). Introducing a classifier here would cross those boundaries.
+
+If a later SPEC routes by class, the coordinator should own the canonical classification decision or pass a coordinator-derived class label through the request path. Provider-only classification is lower latency but inconsistent and easier to game. A coordinator-side label is more auditable and can be tied to routing policy, but it must be designed without adding a new buyer-visible field unless the API SPEC explicitly allows it.
+
+For v0.1, the output is data:
+
+- Per-workload benchmark rows.
+- Per-workload winner recommendations.
+- Open routing/classification questions for a follow-up SPEC.
+
+## E. Sweep Artifacts and Gates
+
+Existing sweep reports can stay as-is. Add class-aware reports alongside them.
+
+The beta report already summarizes by workload (`beta/report.py:59`) and renders a per-workload median table (`beta/report.py:134`). That means class-aware report generation can be an additive report mode. Historical class-blind HTML should not be regenerated unless a specific release artifact requires it.
+
+Gates should become class-parameterized where the metric is shape-sensitive:
+
+- `long_context` should have explicit prefill/TTFT tolerance, because long prompt length changes the expected latency envelope.
+- `streaming_check` should own streaming TTFT gates and should not choose a separate non-stream serve config in v0.1.
+- `code_completion` and `agent_style` should track speculative acceptance rate and output correctness/leak checks more closely, because draft-token benefit depends on structured continuation shape.
+- Stop-token leak gates should remain per workload because decision criteria already ask for stop-token leak rate per workload (`beta/DECISION_CRITERIA.md:85`).
+
+SPEC-023 made static-catalog TPS and TTFT fields advisory rather than hard eligibility gates (`specs/SPEC-023-installer-autotune-recommend.md:35`). The class profile should preserve that posture: record class-specific measured gates and let recommendation logic consume them explicitly after an implementation SPEC updates the consumer.
+
+## Recommended Next Step
+
+Adopt SPEC-029 v0.1-draft as a research/specification artifact. Do not implement code until maintainers answer the routing/default-profile open questions and confirm whether the static row field should be named `workload_profiles` or `per_class`.

--- a/docs/research/sweep-workload-class-2026-07.md
+++ b/docs/research/sweep-workload-class-2026-07.md
@@ -8,7 +8,7 @@
 
 MacProvider already measures buyer-harness behavior by workload name, but the autotune and static-candidate surfaces are still class-blind. The right v0.1 shape is to keep the existing context/concurrency/kv sweep shape and run it as parallel workload-class partitions, producing per-class winners as data. Runtime request classification and class-routed serving should stay out of scope until a later SPEC defines the trust, latency, and API boundary.
 
-The current beta workload library exposes six workload names and maps them to five corpus classes: `short_chat -> short`, `medium_with_system -> medium`, `long_context -> long`, `code_completion -> code`, `agent_style -> agent`, and `streaming_check -> short` (`beta/workloads.py:26`). The report path already groups rows by workload and publishes per-workload medians (`beta/report.py:59`, `beta/report.py:118`). Decision criteria also ask for per-workload median throughput, streaming TTFT, and stop-token leak checks (`beta/DECISION_CRITERIA.md:54`, `beta/DECISION_CRITERIA.md:85`).
+The current beta workload library exposes six workload names and maps them to five corpus classes: `short_chat -> short`, `medium_with_system -> medium`, `long_context -> long`, `code_completion -> code`, `agent_style -> agent`, and `streaming_check -> short` (`beta/workloads.py:26`). The report path already groups rows by workload and publishes per-workload medians (`beta/report.py:59`, `beta/report.py:118`). Decision criteria also ask for per-workload median throughput, streaming TTFT, and stop-token leak checks (`beta/DECISION_CRITERIA.md:57`, `beta/DECISION_CRITERIA.md:89`).
 
 Two prompt references were unavailable in the current repository state: `.omc/logs/context-throughput-sweep-impl-notes.md` does not exist, and `origin/spike/context-throughput-sweep` is not a valid ref. Those absences should be treated as research constraints, not inferred evidence.
 
@@ -43,7 +43,7 @@ With speculative decoding, a winner is no longer only a serve-capacity tuple. Th
 (kv_bits, max_context, max_batch, draft_model, num_draft_tokens)
 ```
 
-`num_draft_tokens` should be per workload class for a given target/draft pair. SPEC-028 makes `num_draft_tokens` a provider serve knob (`specs/SPEC-028-mlx-speculative-decoding.md:63`) and explicitly identifies autotune/candidate-catalog extension points (`specs/SPEC-028-mlx-speculative-decoding.md:31`). It also warns that autotune must not blindly multiply every context/concurrency/kv cell by every draft candidate and shows `draft_candidates[]` with `workload_bias` as an additive static-row extension (`specs/SPEC-028-mlx-speculative-decoding.md:202`). That points to a staged shape: choose eligible target/draft candidates first, then tune per class.
+`num_draft_tokens` should be per workload class for a given target/draft pair. SPEC-028 makes `num_draft_tokens` a provider serve knob (`specs/SPEC-028-mlx-speculative-decoding.md:63`) and explicitly identifies autotune/candidate-catalog extension points (`specs/SPEC-028-mlx-speculative-decoding.md:31`). It also warns that autotune must not blindly multiply every context/concurrency/kv cell by every draft candidate and shows `draft_candidates[]` with `workload_bias` as an additive static-row extension (`specs/SPEC-028-mlx-speculative-decoding.md:202`, `specs/SPEC-028-mlx-speculative-decoding.md:206`). That points to a staged shape: choose eligible target/draft candidates first, then tune per class.
 
 Acceptance rate is expected to vary by content shape. A shared `num_draft_tokens` would reintroduce the compromise this SPEC is trying to avoid. The safer v0.1 policy is:
 
@@ -71,12 +71,20 @@ Recommended additive shape:
         "max_context_override": 20000,
         "max_concurrency_override": 1,
         "draft_model": "example/draft",
+        "draft_model_artifact_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         "num_draft_tokens": 4
       },
-      "bench_gate": {
-        "min_sustained_tps": 8.5,
-        "max_ttft_ms": 8000,
-        "max_stop_token_leak_rate": 0
+      "gate_policy": {
+        "max_p95_ttft_ms": 12000,
+        "max_stop_token_leak_rate": 0,
+        "min_sustained_tps": null
+      },
+      "profile_metrics": {
+        "median_tps": 8.5,
+        "p95_ttft_ms": 2400,
+        "stop_token_leak_rate": 0,
+        "spec_decode_acceptance_rate": 0.42,
+        "sample_count": 5
       },
       "source": "sweep-workload-class-2026-07"
     }
@@ -84,7 +92,7 @@ Recommended additive shape:
 }
 ```
 
-Use `workload_profiles` rather than `per_class` in the normative SPEC because the keys are harness workload names in v0.1, not a general traffic taxonomy. `per_class` can remain an acceptable alias only if maintainers prefer that spelling.
+Use `workload_profiles` rather than `per_class` in the normative SPEC because the keys are harness workload names in v0.1, not a general traffic taxonomy. The nested object should avoid the existing top-level `bench_gate` key so SPEC-023's advisory catalog gates are not confused with workload-specific gate policy and measured profile metrics.
 
 The same static feed trust domain should sign the additive catalog. The current public key is baked into the installer recommendation code with key ID `streamvc-autotune-static-v4` (`phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:684`), and the static-key README describes the single feed trust model and re-signing process (`phase3-binary/dist/static/keys/README.md:32`). A new key would imply a new trust domain; class profiles are still operator-curated candidate recommendations, so reusing the current static key is correct.
 
@@ -113,10 +121,10 @@ Gates should become class-parameterized where the metric is shape-sensitive:
 - `long_context` should have explicit prefill/TTFT tolerance, because long prompt length changes the expected latency envelope.
 - `streaming_check` should own streaming TTFT gates and should not choose a separate non-stream serve config in v0.1.
 - `code_completion` and `agent_style` should track speculative acceptance rate and output correctness/leak checks more closely, because draft-token benefit depends on structured continuation shape.
-- Stop-token leak gates should remain per workload because decision criteria already ask for stop-token leak rate per workload (`beta/DECISION_CRITERIA.md:85`).
+- Stop-token leak gates should remain per workload because decision criteria already ask for stop-token leak rate per workload (`beta/DECISION_CRITERIA.md:89`).
 
-SPEC-023 made static-catalog TPS and TTFT fields advisory rather than hard eligibility gates (`specs/SPEC-023-installer-autotune-recommend.md:35`). The class profile should preserve that posture: record class-specific measured gates and let recommendation logic consume them explicitly after an implementation SPEC updates the consumer.
+SPEC-023 made static-catalog TPS and TTFT fields advisory rather than hard eligibility gates (`specs/SPEC-023-installer-autotune-recommend.md:35`). The class profile should preserve that posture for measured throughput and SPEC-023 top-level `bench_gate` fields, while SPEC-029 should separately serialize the workload-specific hard TTFT/leak gate policy used to choose a sweep winner.
 
 ## Recommended Next Step
 
-Adopt SPEC-029 v0.1-draft as a research/specification artifact. Do not implement code until maintainers answer the routing/default-profile open questions and confirm whether the static row field should be named `workload_profiles` or `per_class`.
+Adopt SPEC-029 v0.1-draft as a research/specification artifact. Do not implement runtime class-routed serving until maintainers answer the routing/default-profile open questions.

--- a/docs/research/sweep-workload-class-2026-07.md
+++ b/docs/research/sweep-workload-class-2026-07.md
@@ -19,7 +19,7 @@ Use workload class as a partition/filter over the existing grid, not as one glob
 This is operationally equivalent to measuring K copies of the grid, but it keeps the semantics clean:
 
 - Each partition has one winner for one traffic shape.
-- Storage can add `workload_class` or `workload_name` to trial/report rows without changing the meaning of existing `runs.workload`.
+- Storage can add `corpus_class` to trial/report rows without changing the meaning of existing `runs.workload`.
 - Failure gates and tie-breakers can be class-local.
 - The implementation can reuse the existing per-workload report posture rather than invent a global compromise winner.
 
@@ -49,7 +49,7 @@ Acceptance rate is expected to vary by content shape. A shared `num_draft_tokens
 
 - Pick winners independently per class.
 - Do not let one class dominate another class's winner.
-- If a single legacy default must be exported, derive it from an explicit buyer-traffic weighting policy, not from hidden precedence.
+- If a single legacy default is ever exported, derive it from an explicit buyer-traffic weighting policy, not from hidden precedence; SPEC-029 v0.1 blocks that export until the policy is defined.
 
 There is no current request-time class classifier in the provider/coordinator path. Therefore v0.1 should publish per-class winners as data and keep runtime serving on the existing single chosen config until a follow-up routing SPEC decides how a buyer request gets a trusted class label.
 
@@ -66,33 +66,36 @@ Recommended additive shape:
   "model_id": "example/target",
   "workload_profiles": {
     "code_completion": {
-      "recommended": {
-        "kv_bits": 4,
-        "max_context_override": 20000,
-        "max_concurrency_override": 1,
-        "draft_model": "example/draft",
-        "draft_model_artifact_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-        "num_draft_tokens": 4
-      },
-      "gate_policy": {
-        "max_p95_ttft_ms": 12000,
-        "max_stop_token_leak_rate": 0,
-        "min_sustained_tps": null
-      },
-      "profile_metrics": {
-        "median_tps": 8.5,
-        "p95_ttft_ms": 2400,
-        "stop_token_leak_rate": 0,
-        "spec_decode_acceptance_rate": 0.42,
-        "sample_count": 5
-      },
-      "source": "sweep-workload-class-2026-07"
+      "16gb": {
+        "recommended": {
+          "kv_bits": 4,
+          "max_context_override": 20000,
+          "max_concurrency_override": 1,
+          "draft_model": "example/draft",
+          "draft_model_artifact_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          "num_draft_tokens": 4
+        },
+        "gate_policy": {
+          "min_samples": 20,
+          "max_p95_ttft_ms": 12000,
+          "max_stop_token_leak_rate": 0,
+          "min_median_tps": null
+        },
+        "profile_metrics": {
+          "median_tps": 8.5,
+          "p95_ttft_ms": 2400,
+          "stop_token_leak_rate": 0,
+          "spec_decode_acceptance_rate": 0.42,
+          "sample_count": 20
+        },
+        "source": "sweep-workload-class-2026-07"
+      }
     }
   }
 }
 ```
 
-Use `workload_profiles` rather than `per_class` in the normative SPEC because the keys are harness workload names in v0.1, not a general traffic taxonomy. The nested object should avoid the existing top-level `bench_gate` key so SPEC-023's advisory catalog gates are not confused with workload-specific gate policy and measured profile metrics.
+Use `workload_profiles` rather than `per_class` in the normative SPEC because the first-level keys are harness workload names in v0.1, not a general request taxonomy. Nesting by RAM tier is required because SPEC-028 draft context caps are tier-specific. The nested object should avoid the existing top-level `bench_gate` key so SPEC-023's advisory catalog gates are not confused with workload-specific gate policy and measured profile metrics.
 
 The same static feed trust domain should sign the additive catalog. The current public key is baked into the installer recommendation code with key ID `streamvc-autotune-static-v4` (`phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:684`), and the static-key README describes the single feed trust model and re-signing process (`phase3-binary/dist/static/keys/README.md:32`). A new key would imply a new trust domain; class profiles are still operator-curated candidate recommendations, so reusing the current static key is correct.
 

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -447,6 +447,111 @@ struct CandidateCatalog: Decodable, Equatable {
         }
     }
 
+    struct WorkloadRecommended: Decodable, Equatable {
+        var kvBits: Int
+        var maxContextOverride: Int
+        var maxConcurrencyOverride: Int
+        var draftModel: String?
+        var draftModelArtifactSHA256: String?
+        var numDraftTokens: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case kvBits = "kv_bits"
+            case maxContextOverride = "max_context_override"
+            case maxConcurrencyOverride = "max_concurrency_override"
+            case draftModel = "draft_model"
+            case draftModelArtifactSHA256 = "draft_model_artifact_sha256"
+            case numDraftTokens = "num_draft_tokens"
+        }
+    }
+
+    struct WorkloadGatePolicy: Decodable, Equatable {
+        var minSamples: Int
+        var maxP95TTFTMS: Int
+        var maxStopTokenLeakRate: Double
+        var minMedianTPS: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case minSamples = "min_samples"
+            case maxP95TTFTMS = "max_p95_ttft_ms"
+            case maxStopTokenLeakRate = "max_stop_token_leak_rate"
+            case minMedianTPS = "min_median_tps"
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            for key in [CodingKeys.minSamples, .maxP95TTFTMS, .maxStopTokenLeakRate, .minMedianTPS] {
+                guard c.contains(key) else {
+                    throw AutotuneRecommendError.invalidStaticJSON("workload gate_policy \(key.stringValue)")
+                }
+            }
+            minSamples = try c.decode(Int.self, forKey: .minSamples)
+            maxP95TTFTMS = try c.decode(Int.self, forKey: .maxP95TTFTMS)
+            maxStopTokenLeakRate = try c.decode(Double.self, forKey: .maxStopTokenLeakRate)
+            minMedianTPS = try c.decodeIfPresent(Double.self, forKey: .minMedianTPS)
+        }
+    }
+
+    struct WorkloadProfileMetrics: Decodable, Equatable {
+        var medianTPS: Double?
+        var p95TTFTMS: Double?
+        var stopTokenLeakRate: Double?
+        var specDecodeAcceptanceRate: Double?
+        var sampleCount: Int
+
+        enum CodingKeys: String, CodingKey {
+            case medianTPS = "median_tps"
+            case p95TTFTMS = "p95_ttft_ms"
+            case stopTokenLeakRate = "stop_token_leak_rate"
+            case specDecodeAcceptanceRate = "spec_decode_acceptance_rate"
+            case sampleCount = "sample_count"
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            for key in [CodingKeys.medianTPS, .p95TTFTMS, .stopTokenLeakRate, .specDecodeAcceptanceRate, .sampleCount] {
+                guard c.contains(key) else {
+                    throw AutotuneRecommendError.invalidStaticJSON("workload profile metric \(key.stringValue)")
+                }
+            }
+            medianTPS = try c.decodeIfPresent(Double.self, forKey: .medianTPS)
+            p95TTFTMS = try c.decodeIfPresent(Double.self, forKey: .p95TTFTMS)
+            stopTokenLeakRate = try c.decodeIfPresent(Double.self, forKey: .stopTokenLeakRate)
+            specDecodeAcceptanceRate = try c.decodeIfPresent(Double.self, forKey: .specDecodeAcceptanceRate)
+            sampleCount = try c.decode(Int.self, forKey: .sampleCount)
+        }
+    }
+
+    struct WorkloadProfile: Decodable, Equatable {
+        var status: String?
+        var noWinnerReason: String?
+        var recommended: WorkloadRecommended?
+        var gatePolicy: WorkloadGatePolicy
+        var profileMetrics: WorkloadProfileMetrics
+        var source: String
+        var candidateSource: String?
+
+        enum CodingKeys: String, CodingKey {
+            case status
+            case noWinnerReason = "no_winner_reason"
+            case recommended
+            case gatePolicy = "gate_policy"
+            case profileMetrics = "profile_metrics"
+            case source
+            case candidateSource = "candidate_source"
+        }
+    }
+
+    struct DraftCandidate: Decodable, Equatable {
+        var draftModel: String
+        var draftModelArtifactSHA256: String
+
+        enum CodingKeys: String, CodingKey {
+            case draftModel = "draft_model"
+            case draftModelArtifactSHA256 = "draft_model_artifact_sha256"
+        }
+    }
+
     struct Row: Decodable, Equatable {
         var modelID: String
         var modelRevision: String?
@@ -456,6 +561,8 @@ struct CandidateCatalog: Decodable, Equatable {
         var benchGate: BenchGate
         var runtimeStatus: String
         var notes: String?
+        var draftCandidates: [DraftCandidate]?
+        var workloadProfiles: [String: [String: WorkloadProfile]]?
 
         enum CodingKeys: String, CodingKey {
             case modelID = "model_id"
@@ -466,6 +573,50 @@ struct CandidateCatalog: Decodable, Equatable {
             case benchGate = "bench_gate"
             case runtimeStatus = "runtime_status"
             case notes
+            case draftCandidates = "draft_candidates"
+            case workloadProfiles = "workload_profiles"
+            case perClass = "per_class"
+        }
+
+        init(
+            modelID: String,
+            modelRevision: String?,
+            modelSHA256: String?,
+            minRAMGB: Int,
+            minBandwidthTier: BandwidthTier,
+            benchGate: BenchGate,
+            runtimeStatus: String,
+            notes: String?,
+            draftCandidates: [DraftCandidate]? = nil,
+            workloadProfiles: [String: [String: WorkloadProfile]]? = nil
+        ) {
+            self.modelID = modelID
+            self.modelRevision = modelRevision
+            self.modelSHA256 = modelSHA256
+            self.minRAMGB = minRAMGB
+            self.minBandwidthTier = minBandwidthTier
+            self.benchGate = benchGate
+            self.runtimeStatus = runtimeStatus
+            self.notes = notes
+            self.draftCandidates = draftCandidates
+            self.workloadProfiles = workloadProfiles
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            if c.contains(.perClass) {
+                throw AutotuneRecommendError.invalidStaticJSON("per_class alias is forbidden")
+            }
+            modelID = try c.decode(String.self, forKey: .modelID)
+            modelRevision = try c.decodeIfPresent(String.self, forKey: .modelRevision)
+            modelSHA256 = try c.decodeIfPresent(String.self, forKey: .modelSHA256)
+            minRAMGB = try c.decode(Int.self, forKey: .minRAMGB)
+            minBandwidthTier = try c.decode(BandwidthTier.self, forKey: .minBandwidthTier)
+            benchGate = try c.decode(BenchGate.self, forKey: .benchGate)
+            runtimeStatus = try c.decode(String.self, forKey: .runtimeStatus)
+            notes = try c.decodeIfPresent(String.self, forKey: .notes)
+            draftCandidates = try c.decodeIfPresent([DraftCandidate].self, forKey: .draftCandidates)
+            workloadProfiles = try c.decodeIfPresent([String: [String: WorkloadProfile]].self, forKey: .workloadProfiles)
         }
     }
 
@@ -517,13 +668,189 @@ struct CandidateCatalog: Decodable, Equatable {
                     throw AutotuneRecommendError.invalidStaticJSON("model_sha256 for \(key)")
                 }
             }
+            try Self.validateWorkloadProfiles(row.workloadProfiles, rowKey: key, draftCandidates: row.draftCandidates)
         }
         return self
+    }
+
+    private static func validateWorkloadProfiles(
+        _ workloadProfiles: [String: [String: WorkloadProfile]]?,
+        rowKey: String,
+        draftCandidates: [DraftCandidate]?
+    ) throws {
+        guard let workloadProfiles else { return }
+        let allowedWorkloads = Set(["short_chat", "medium_with_system", "long_context", "code_completion", "agent_style"])
+        let allowedTiers = Set(["8gb", "16gb", "32gb", "64gb_plus"])
+        let allowedNoWinnerReasons = Set(["insufficient_samples", "gate_unmet", "hard_failure", "no_cells_evaluated"])
+        let draftContextCaps = ["8gb": 8_192, "16gb": 20_000, "32gb": 50_000, "64gb_plus": 120_000]
+
+        for (workload, tiers) in workloadProfiles {
+            guard allowedWorkloads.contains(workload) else {
+                throw AutotuneRecommendError.invalidStaticJSON("workload_profiles workload for \(rowKey)")
+            }
+            guard !tiers.isEmpty else {
+                throw AutotuneRecommendError.invalidStaticJSON("workload_profiles tiers for \(rowKey)")
+            }
+            for (tier, profile) in tiers {
+                guard allowedTiers.contains(tier) else {
+                    throw AutotuneRecommendError.invalidStaticJSON("workload_profiles tier for \(rowKey)")
+                }
+                try validateWorkloadProfile(
+                    profile,
+                    workload: workload,
+                    tier: tier,
+                    rowKey: rowKey,
+                    allowedNoWinnerReasons: allowedNoWinnerReasons,
+                    draftContextCaps: draftContextCaps,
+                    draftCandidates: draftCandidates
+                )
+            }
+        }
+    }
+
+    private static func validateWorkloadProfile(
+        _ profile: WorkloadProfile,
+        workload: String,
+        tier: String,
+        rowKey: String,
+        allowedNoWinnerReasons: Set<String>,
+        draftContextCaps: [String: Int],
+        draftCandidates: [DraftCandidate]?
+    ) throws {
+        guard !profile.source.isEmpty else {
+            throw AutotuneRecommendError.invalidStaticJSON("workload profile source for \(rowKey)")
+        }
+        guard let expectedTTFT = spec029DefaultMaxP95TTFTMS[workload],
+              profile.gatePolicy.minSamples == 20,
+              profile.gatePolicy.maxP95TTFTMS == expectedTTFT,
+              profile.gatePolicy.maxStopTokenLeakRate == 0,
+              profile.gatePolicy.minMedianTPS == nil
+        else {
+            throw AutotuneRecommendError.invalidStaticJSON("workload gate_policy for \(rowKey)")
+        }
+        if let median = profile.profileMetrics.medianTPS, (!median.isFinite || median < 0) {
+            throw AutotuneRecommendError.invalidStaticJSON("workload median_tps for \(rowKey)")
+        }
+        if let ttft = profile.profileMetrics.p95TTFTMS, (!ttft.isFinite || ttft < 0) {
+            throw AutotuneRecommendError.invalidStaticJSON("workload p95_ttft_ms for \(rowKey)")
+        }
+        if let leak = profile.profileMetrics.stopTokenLeakRate, (!leak.isFinite || leak < 0 || leak > 1) {
+            throw AutotuneRecommendError.invalidStaticJSON("workload stop_token_leak_rate for \(rowKey)")
+        }
+        if let acceptance = profile.profileMetrics.specDecodeAcceptanceRate, (!acceptance.isFinite || acceptance < 0 || acceptance > 1) {
+            throw AutotuneRecommendError.invalidStaticJSON("workload spec_decode_acceptance_rate for \(rowKey)")
+        }
+        guard profile.profileMetrics.sampleCount >= 0 else {
+            throw AutotuneRecommendError.invalidStaticJSON("workload sample_count for \(rowKey)")
+        }
+
+        if profile.status == "no_winner" {
+            guard let reason = profile.noWinnerReason, allowedNoWinnerReasons.contains(reason) else {
+                throw AutotuneRecommendError.invalidStaticJSON("workload no_winner_reason for \(rowKey)")
+            }
+            guard profile.recommended == nil,
+                  profile.profileMetrics.medianTPS == nil,
+                  profile.profileMetrics.p95TTFTMS == nil,
+                  profile.profileMetrics.stopTokenLeakRate == nil,
+                  profile.profileMetrics.specDecodeAcceptanceRate == nil
+            else {
+                throw AutotuneRecommendError.invalidStaticJSON("workload no_winner profile_metrics for \(rowKey)")
+            }
+            switch reason {
+            case "no_cells_evaluated", "hard_failure":
+                guard profile.profileMetrics.sampleCount == 0 else {
+                    throw AutotuneRecommendError.invalidStaticJSON("workload no_winner sample_count for \(rowKey)")
+                }
+            case "insufficient_samples":
+                guard profile.profileMetrics.sampleCount > 0,
+                      profile.profileMetrics.sampleCount < profile.gatePolicy.minSamples
+                else {
+                    throw AutotuneRecommendError.invalidStaticJSON("workload no_winner sample_count for \(rowKey)")
+                }
+            case "gate_unmet":
+                guard profile.profileMetrics.sampleCount >= profile.gatePolicy.minSamples else {
+                    throw AutotuneRecommendError.invalidStaticJSON("workload no_winner sample_count for \(rowKey)")
+                }
+            default:
+                throw AutotuneRecommendError.invalidStaticJSON("workload no_winner_reason for \(rowKey)")
+            }
+            return
+        }
+
+        guard profile.status == nil || profile.status == "winner" else {
+            throw AutotuneRecommendError.invalidStaticJSON("workload status for \(rowKey)")
+        }
+        guard profile.noWinnerReason == nil, let recommended = profile.recommended else {
+            throw AutotuneRecommendError.invalidStaticJSON("workload winner recommended for \(rowKey)")
+        }
+        guard recommended.kvBits >= 0,
+              recommended.maxContextOverride > 0,
+              recommended.maxConcurrencyOverride > 0,
+              let p95TTFTMS = profile.profileMetrics.p95TTFTMS,
+              p95TTFTMS <= Double(profile.gatePolicy.maxP95TTFTMS),
+              let stopTokenLeakRate = profile.profileMetrics.stopTokenLeakRate,
+              stopTokenLeakRate <= profile.gatePolicy.maxStopTokenLeakRate,
+              profile.profileMetrics.sampleCount >= profile.gatePolicy.minSamples
+        else {
+            throw AutotuneRecommendError.invalidStaticJSON("workload winner metrics for \(rowKey)")
+        }
+
+        let hasAnyDraftField = recommended.draftModel != nil || recommended.draftModelArtifactSHA256 != nil || recommended.numDraftTokens != nil
+        guard hasAnyDraftField else { return }
+        guard recommended.draftModel != nil,
+              let draftSHA = recommended.draftModelArtifactSHA256,
+              isHex(draftSHA, count: 64),
+              let numDraftTokens = recommended.numDraftTokens,
+              (1 ... 16).contains(numDraftTokens),
+              recommended.maxConcurrencyOverride <= 1,
+              let cap = draftContextCaps[tier],
+              recommended.maxContextOverride <= cap,
+              let candidateSource = profile.candidateSource,
+              isApprovedSpec029DraftSource(candidateSource),
+              staticDraftCandidateBindingIsValid(
+                  source: candidateSource,
+                  recommended: recommended,
+                  draftCandidates: draftCandidates
+              )
+        else {
+            throw AutotuneRecommendError.invalidStaticJSON("workload speculative recommended for \(rowKey)")
+        }
+    }
+
+    private static func staticDraftCandidateBindingIsValid(
+        source: String,
+        recommended: WorkloadRecommended,
+        draftCandidates: [DraftCandidate]?
+    ) -> Bool {
+        guard source.hasPrefix("static_draft_candidates:") else { return true }
+        guard let draftModel = recommended.draftModel,
+              let draftSHA = recommended.draftModelArtifactSHA256,
+              let draftCandidates
+        else {
+            return false
+        }
+        return draftCandidates.contains {
+            $0.draftModel == draftModel && $0.draftModelArtifactSHA256 == draftSHA
+        }
+    }
+
+    private static func isApprovedSpec029DraftSource(_ source: String) -> Bool {
+        source.hasPrefix("static_draft_candidates:")
+            || source.hasPrefix("research_fixture:")
+            || source.hasPrefix("local_operator_override:")
     }
 
     private static func isHex(_ value: String, count: Int) -> Bool {
         value.count == count && value.allSatisfy { ("0"..."9").contains($0) || ("a"..."f").contains($0) }
     }
+
+    private static let spec029DefaultMaxP95TTFTMS = [
+        "short_chat": 8_000,
+        "medium_with_system": 12_000,
+        "long_context": 60_000,
+        "code_completion": 12_000,
+        "agent_style": 20_000,
+    ]
 }
 
 struct RateCardProjection: Decodable, Equatable {

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -80,6 +80,104 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertEqual(catalogRow.minBandwidthTier, .c)
     }
 
+    func testCandidateCatalogDecodesSpec029WorkloadProfiles() throws {
+        let catalog = try AutotuneStaticInputs.decodeCandidateCatalog(
+            Data(Self.spec029CatalogJSON(workloadProfilesJSON: Self.validSpec029ProfilesJSON).utf8)
+        )
+        let row = try XCTUnwrap(catalog.rows["fixture-model"])
+        let profiles = try XCTUnwrap(row.workloadProfiles)
+
+        let code = try XCTUnwrap(profiles["code_completion"]?["16gb"])
+        XCTAssertEqual(code.status, "winner")
+        XCTAssertEqual(code.recommended?.kvBits, 4)
+        XCTAssertEqual(code.recommended?.draftModelArtifactSHA256, String(repeating: "0", count: 64))
+        XCTAssertEqual(code.recommended?.numDraftTokens, 4)
+        XCTAssertEqual(code.profileMetrics.sampleCount, 20)
+        XCTAssertEqual(code.source, "spec029-report-fixture")
+        XCTAssertEqual(code.candidateSource, "research_fixture:spec029-test")
+
+        let short = try XCTUnwrap(profiles["short_chat"]?["8gb"])
+        XCTAssertEqual(short.recommended?.kvBits, 8)
+        XCTAssertNil(short.recommended?.draftModel)
+
+        let long = try XCTUnwrap(profiles["long_context"]?["16gb"])
+        XCTAssertEqual(long.status, "no_winner")
+        XCTAssertEqual(long.noWinnerReason, "insufficient_samples")
+        XCTAssertNil(long.recommended)
+        XCTAssertNil(long.profileMetrics.medianTPS)
+        XCTAssertEqual(long.profileMetrics.sampleCount, 7)
+
+        let staticProfiles = #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(candidateSource: "static_draft_candidates:fixture"))}}"#
+        let staticCatalog = try AutotuneStaticInputs.decodeCandidateCatalog(
+            Data(Self.spec029CatalogJSON(workloadProfilesJSON: staticProfiles, draftCandidatesJSON: Self.spec029DraftCandidatesJSON).utf8)
+        )
+        let staticProfile = try XCTUnwrap(staticCatalog.rows["fixture-model"]?.workloadProfiles?["code_completion"]?["16gb"])
+        XCTAssertEqual(staticProfile.candidateSource, "static_draft_candidates:fixture")
+    }
+
+    func testCandidateCatalogRejectsInvalidSpec029WorkloadProfiles() throws {
+        let invalidProfiles: [(String, String)] = [
+            ("invalid tier", #"{"code_completion":{"24gb":\#(Self.spec029WinnerProfileJSON())}}"#),
+            ("unknown workload", #"{"unknown_workload":{"16gb":\#(Self.spec029WinnerProfileJSON())}}"#),
+            ("streaming probe published", #"{"streaming_check":{"16gb":\#(Self.spec029WinnerProfileJSON())}}"#),
+            ("empty source", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(source: ""))}}"#),
+            ("generic draft candidate source", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(candidateSource: "fixture"))}}"#),
+            ("missing draft candidate source", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(candidateSource: nil))}}"#),
+            ("static draft missing catalog binding", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(candidateSource: "static_draft_candidates:fixture"))}}"#),
+            ("unknown no-winner reason", #"{"long_context":{"16gb":\#(Self.spec029NoWinnerProfileJSON(reason: "unknown"))}}"#),
+            ("missing no-winner reason", #"{"long_context":{"16gb":{"status":"no_winner","gate_policy":{"min_samples":20,"max_p95_ttft_ms":60000,"max_stop_token_leak_rate":0,"min_median_tps":null},"profile_metrics":{"median_tps":null,"p95_ttft_ms":null,"stop_token_leak_rate":null,"spec_decode_acceptance_rate":null,"sample_count":7},"source":"fixture"}}}"#),
+            ("no cells with sample count", #"{"long_context":{"16gb":\#(Self.spec029NoWinnerProfileJSON(reason: "no_cells_evaluated", sampleCount: 1))}}"#),
+            ("insufficient samples with zero count", #"{"long_context":{"16gb":\#(Self.spec029NoWinnerProfileJSON(reason: "insufficient_samples", sampleCount: 0))}}"#),
+            ("gate unmet below min samples", #"{"long_context":{"16gb":\#(Self.spec029NoWinnerProfileJSON(reason: "gate_unmet", sampleCount: 19))}}"#),
+            ("no-winner with recommended", #"{"long_context":{"16gb":{"status":"no_winner","no_winner_reason":"insufficient_samples","recommended":{"kv_bits":4,"max_context_override":20000,"max_concurrency_override":1},"gate_policy":{"min_samples":20,"max_p95_ttft_ms":60000,"max_stop_token_leak_rate":0,"min_median_tps":null},"profile_metrics":{"median_tps":null,"p95_ttft_ms":null,"stop_token_leak_rate":null,"spec_decode_acceptance_rate":null,"sample_count":7},"source":"fixture"}}}"#),
+            ("winner missing required metrics", #"{"code_completion":{"16gb":{"status":"winner","recommended":{"kv_bits":4,"max_context_override":20000,"max_concurrency_override":1},"gate_policy":{"min_samples":20,"max_p95_ttft_ms":12000,"max_stop_token_leak_rate":0,"min_median_tps":null},"profile_metrics":{"median_tps":8.5,"p95_ttft_ms":null,"stop_token_leak_rate":0,"spec_decode_acceptance_rate":null,"sample_count":20},"source":"fixture"}}}"#),
+            ("winner p95 fails gate", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(p95TTFTMS: 12_001))}}"#),
+            ("winner leak fails gate", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(stopTokenLeakRate: 0.01))}}"#),
+            ("partial draft tuple", #"{"code_completion":{"16gb":{"status":"winner","recommended":{"kv_bits":4,"max_context_override":20000,"max_concurrency_override":1,"draft_model":"mlx-community/Fixture-Draft-4bit"},"gate_policy":{"min_samples":20,"max_p95_ttft_ms":12000,"max_stop_token_leak_rate":0,"min_median_tps":null},"profile_metrics":{"median_tps":8.5,"p95_ttft_ms":2400,"stop_token_leak_rate":0,"spec_decode_acceptance_rate":null,"sample_count":20},"source":"fixture","candidate_source":"research_fixture:spec029-test"}}}"#),
+            ("invalid draft hash", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(draftHash: "ABC"))}}"#),
+            ("uppercase draft hash", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(draftHash: String(repeating: "A", count: 64)))}}"#),
+            ("invalid draft tokens", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(numDraftTokens: 17))}}"#),
+            ("draft context over cap", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(maxContext: 50_000))}}"#),
+            ("draft concurrency over cap", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(maxConcurrency: 2))}}"#),
+            ("non-default gate", #"{"code_completion":{"16gb":\#(Self.spec029WinnerProfileJSON(maxP95TTFTMS: 999_999))}}"#),
+            ("omitted gate null", #"{"code_completion":{"16gb":{"status":"winner","recommended":{"kv_bits":4,"max_context_override":20000,"max_concurrency_override":1},"gate_policy":{"min_samples":20,"max_p95_ttft_ms":12000,"max_stop_token_leak_rate":0},"profile_metrics":{"median_tps":8.5,"p95_ttft_ms":2400,"stop_token_leak_rate":0,"spec_decode_acceptance_rate":null,"sample_count":20},"source":"fixture"}}}"#),
+            ("omitted nullable metric", #"{"code_completion":{"16gb":{"status":"winner","recommended":{"kv_bits":4,"max_context_override":20000,"max_concurrency_override":1},"gate_policy":{"min_samples":20,"max_p95_ttft_ms":12000,"max_stop_token_leak_rate":0,"min_median_tps":null},"profile_metrics":{"p95_ttft_ms":2400,"stop_token_leak_rate":0,"spec_decode_acceptance_rate":null,"sample_count":20},"source":"fixture"}}}"#),
+        ]
+
+        for (label, profiles) in invalidProfiles {
+            XCTAssertThrowsError(
+                try AutotuneStaticInputs.decodeCandidateCatalog(Data(Self.spec029CatalogJSON(workloadProfilesJSON: profiles).utf8)),
+                label
+            )
+        }
+
+        XCTAssertThrowsError(
+            try AutotuneStaticInputs.decodeCandidateCatalog(
+                Data(Self.spec029CatalogJSON(workloadProfilesJSON: Self.validSpec029ProfilesJSON, rowExtraJSON: #""per_class":{}"#).utf8)
+            ),
+            "forbidden per_class alias"
+        )
+    }
+
+    func testSpec029WorkloadProfilesDoNotChangeRecommendationSelection() throws {
+        let baseline = try makeRequest()
+        var profiled = baseline
+        let fixture = try AutotuneStaticInputs.decodeCandidateCatalog(
+            Data(Self.spec029CatalogJSON(workloadProfilesJSON: Self.validSpec029ProfilesJSON).utf8)
+        )
+        profiled.candidateCatalog.rows["qwen3-coder-30b-a3b-instruct"]?.workloadProfiles =
+            fixture.rows["fixture-model"]?.workloadProfiles
+
+        let engine = AutotuneRecommendEngine()
+        let baselineResult = engine.recommend(baseline)
+        let profiledResult = engine.recommend(profiled)
+
+        XCTAssertEqual(profiled.candidateCatalog.rows["qwen3-coder-30b-a3b-instruct"]?.workloadProfiles?.isEmpty, false)
+        XCTAssertEqual(profiledResult.recommendedModel, baselineResult.recommendedModel)
+        XCTAssertEqual(profiledResult.candidates, baselineResult.candidates)
+        XCTAssertEqual(profiledResult.warnings, baselineResult.warnings)
+    }
+
     func testRecommendationJSONIncludesApplyReadyServeConfigWhenProvided() throws {
         let request = try makeRequest()
         let result = AutotuneRecommendEngine().recommend(request)
@@ -1948,6 +2046,145 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertTrue(transcript.contains("per million completion tokens"), transcript)
         XCTAssertFalse(transcript.contains("/hr"), transcript)
         XCTAssertFalse(transcript.contains("starter"), transcript)
+    }
+
+    private static let validSpec029ProfilesJSON = """
+    {
+      "code_completion": {
+        "16gb": \(spec029WinnerProfileJSON())
+      },
+      "short_chat": {
+        "8gb": {
+          "status": "winner",
+          "recommended": {
+            "kv_bits": 8,
+            "max_context_override": 8192,
+            "max_concurrency_override": 1
+          },
+          "gate_policy": {
+            "min_samples": 20,
+            "max_p95_ttft_ms": 8000,
+            "max_stop_token_leak_rate": 0,
+            "min_median_tps": null
+          },
+          "profile_metrics": {
+            "median_tps": null,
+            "p95_ttft_ms": 700,
+            "stop_token_leak_rate": 0,
+            "spec_decode_acceptance_rate": null,
+            "sample_count": 20
+          },
+          "source": "fixture"
+        }
+      },
+      "long_context": {
+        "16gb": \(spec029NoWinnerProfileJSON())
+      }
+    }
+    """
+
+    private static let spec029DraftCandidatesJSON = """
+    [
+      {
+        "draft_model": "mlx-community/Fixture-Draft-4bit",
+        "draft_model_artifact_sha256": "\(String(repeating: "0", count: 64))"
+      }
+    ]
+    """
+
+    private static func spec029CatalogJSON(
+        workloadProfilesJSON: String,
+        draftCandidatesJSON: String? = nil,
+        rowExtraJSON: String? = nil
+    ) -> String {
+        let draftCandidatesLine = draftCandidatesJSON.map { ",\n              \"draft_candidates\": \($0)" } ?? ""
+        let rowExtraLine = rowExtraJSON.map { ",\n              \($0)" } ?? ""
+        return """
+        {
+          "version": "fixture-spec029",
+          "generated_at": "2026-07-09T00:00:00Z",
+          "source": "operator_curated_autotune_candidate_catalog",
+          "rows": {
+            "fixture-model": {
+              "model_id": "mlx-community/Fixture-Model-4bit",
+              "model_revision": "\(String(repeating: "a", count: 40))",
+              "model_sha256": "\(String(repeating: "b", count: 64))",
+              "min_ram_gb": 12,
+              "min_bandwidth_tier": "C",
+              "bench_gate": {
+                "min_sustained_tps": 1,
+                "max_4k_ttft_ms": 1000
+              },
+              "runtime_status": "recommendable"\(draftCandidatesLine),
+              "workload_profiles": \(workloadProfilesJSON)\(rowExtraLine)
+            }
+          }
+        }
+        """
+    }
+
+    private static func spec029WinnerProfileJSON(
+        draftHash: String = String(repeating: "0", count: 64),
+        numDraftTokens: Int = 4,
+        maxContext: Int = 20_000,
+        maxConcurrency: Int = 1,
+        maxP95TTFTMS: Int = 12_000,
+        p95TTFTMS: Int = 2_400,
+        stopTokenLeakRate: Double = 0,
+        source: String = "spec029-report-fixture",
+        candidateSource: String? = "research_fixture:spec029-test"
+    ) -> String {
+        let candidateSourceLine = candidateSource.map { ",\n          \"candidate_source\": \"\($0)\"" } ?? ""
+        return """
+        {
+          "status": "winner",
+          "recommended": {
+            "kv_bits": 4,
+            "max_context_override": \(maxContext),
+            "max_concurrency_override": \(maxConcurrency),
+            "draft_model": "mlx-community/Fixture-Draft-4bit",
+            "draft_model_artifact_sha256": "\(draftHash)",
+            "num_draft_tokens": \(numDraftTokens)
+          },
+          "gate_policy": {
+            "min_samples": 20,
+            "max_p95_ttft_ms": \(maxP95TTFTMS),
+            "max_stop_token_leak_rate": 0,
+            "min_median_tps": null
+          },
+          "profile_metrics": {
+            "median_tps": 8.5,
+            "p95_ttft_ms": \(p95TTFTMS),
+            "stop_token_leak_rate": \(stopTokenLeakRate),
+            "spec_decode_acceptance_rate": 0.42,
+            "sample_count": 20
+          },
+          "source": "\(source)"\(candidateSourceLine)
+        }
+        """
+    }
+
+    private static func spec029NoWinnerProfileJSON(reason: String = "insufficient_samples", sampleCount: Int = 7) -> String {
+        """
+        {
+          "status": "no_winner",
+          "no_winner_reason": "\(reason)",
+          "gate_policy": {
+            "min_samples": 20,
+            "max_p95_ttft_ms": 60000,
+            "max_stop_token_leak_rate": 0,
+            "min_median_tps": null
+          },
+          "profile_metrics": {
+            "median_tps": null,
+            "p95_ttft_ms": null,
+            "stop_token_leak_rate": null,
+            "spec_decode_acceptance_rate": null,
+            "sample_count": \(sampleCount)
+          },
+          "source": "fixture"
+        }
+        """
     }
 
     private func makeRequest(modelKey: String = "qwen3-coder-30b-a3b-instruct") throws -> AutotuneRecommendRequest {

--- a/specs/BUILD_SPEC_029_IMPL_PROMPT.md
+++ b/specs/BUILD_SPEC_029_IMPL_PROMPT.md
@@ -26,13 +26,13 @@ Controlling contract:
 - `.omc/logs/sweep-workload-class-open-questions-2026-07.md`.
 - Repo rules in `AGENTS.md` and `CLAUDE.md`.
 
-SPEC-029 currently says: "Draft, research round. Implementation MUST NOT begin
-before maintainer review." If that status is still present and the user has
-not explicitly authorized implementing draft SPEC-029, STOP after reporting
-that maintainer authorization is required. If maintainer authorization has
-been given, implement the SPEC exactly; do not re-litigate the product
-decisions. If code reveals a true SPEC ambiguity, stop and surface it as a
-SPEC follow-up instead of silently changing the contract in code.
+If SPEC-029 status still says "Draft, research round. Implementation MUST NOT
+begin before maintainer review" and the user has not explicitly authorized
+implementing draft SPEC-029, STOP after reporting that maintainer authorization
+is required. If maintainer authorization has been given, implement the SPEC
+exactly; do not re-litigate the product decisions. If code reveals a true SPEC
+ambiguity, stop and surface it as a SPEC follow-up instead of silently changing
+the contract in code.
 
 Clean-room boundary: do not inspect Darkbloom / layr-labs `d-inference`
 source.

--- a/specs/BUILD_SPEC_029_IMPL_PROMPT.md
+++ b/specs/BUILD_SPEC_029_IMPL_PROMPT.md
@@ -1,0 +1,382 @@
+# BUILD_SPEC_029_IMPL_PROMPT - Sweep Workload-Class Stratification
+
+You are starting a fresh implementation session in the macprovider repo. You
+have no memory of prior conversations. Read this prompt end-to-end before
+writing code.
+
+## 0. Workspace And Authority
+
+Before editing anything, verify:
+
+```bash
+pwd
+git status -sb
+git worktree list
+git fetch origin
+ls AGENTS.md CLAUDE.md specs/SPEC-029-sweep-workload-class-stratification.md
+```
+
+Work in a fresh isolated worktree/feature branch, never local `main`, and read
+`AGENTS.md` plus `CLAUDE.md` before writing or pushing code.
+
+Controlling contract:
+
+- `specs/SPEC-029-sweep-workload-class-stratification.md`.
+- `docs/research/sweep-workload-class-2026-07.md`.
+- `.omc/logs/sweep-workload-class-open-questions-2026-07.md`.
+- Repo rules in `AGENTS.md` and `CLAUDE.md`.
+
+SPEC-029 currently says: "Draft, research round. Implementation MUST NOT begin
+before maintainer review." If that status is still present and the user has
+not explicitly authorized implementing draft SPEC-029, STOP after reporting
+that maintainer authorization is required. If maintainer authorization has
+been given, implement the SPEC exactly; do not re-litigate the product
+decisions. If code reveals a true SPEC ambiguity, stop and surface it as a
+SPEC follow-up instead of silently changing the contract in code.
+
+Clean-room boundary: do not inspect Darkbloom / layr-labs `d-inference`
+source.
+
+## 1. Scope Summary
+
+Implement SPEC-029 v0.1 as a research/data-plane extension:
+
+- Class-aware sweep partitions keyed by `(workload name, RAM-tier key)`.
+- Per-workload/per-RAM-tier winner or explicit no-winner result.
+- Workload-specific gates, deterministic tie-breakers, and report rows.
+- Speculative decoding search-cell metadata when SPEC-028 fields are present.
+- Additive static-catalog `workload_profiles` schema and validation.
+- Backward-compatible current-client behavior when `workload_profiles` exists.
+
+Out of scope:
+
+- No buyer API change.
+- No coordinator routing-policy change.
+- No provider request-time classifier.
+- No runtime class-routed serving.
+- No settlement, receipt, request-log, ledger, billing, or payout schema change.
+- No modification to SPEC-013 or SPEC-028.
+- No single legacy/default export derived from workload winners unless a later
+  SPEC or maintainer-approved run manifest defines the weighting policy.
+- No regeneration of old class-blind sweep reports unless needed for fixtures.
+
+## 2. Existing Surfaces To Inspect First
+
+Start by mapping the current code; do not assume file names beyond this list:
+
+- Beta harness/report: `beta/harness.py`, `beta/report.py`,
+  `beta/workloads.py`, `beta/workloads_adversarial.py`, `beta/config*.yaml`.
+- Static catalog and recommendation parsing:
+  `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift`,
+  `phase3-binary/Sources/macprovider-cli/AutotuneRecommendSimulateCommand.swift`,
+  `phase3-binary/dist/static/autotune-candidates.json`.
+- Provider capacity / RAM tier behavior:
+  `phase3-binary/Sources/macprovider-cli/ProviderStatus.swift`.
+- SPEC-028 plumbing and tests:
+  `phase3-binary/Tests/macprovider-cliTests/Spec028PlumbingTests.swift`.
+- Candidate-catalog tests:
+  `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift`,
+  `phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendSimulateTests.swift`.
+- Signing/key material:
+  `phase3-binary/dist/static/keys/README.md`,
+  `scripts/resign-autotune-static.sh`.
+
+Preserve existing class-blind modes and existing static catalog behavior unless
+SPEC-029 explicitly adds a field or test.
+
+## 3. Mandatory Implementation Slices
+
+Implement in the order below. Each slice must include targeted tests before
+moving on.
+
+### Slice A - SPEC-029 Data Model And RAM-Tier Helpers
+
+Add a small, explicit model layer for class-aware sweep artifacts instead of
+scattering dictionaries across the harness/report code.
+
+Requirements:
+
+1. Define the included workload set exactly:
+   `short_chat`, `medium_with_system`, `long_context`, `code_completion`,
+   `agent_style`.
+2. Treat `streaming_check` as a TTFT probe only. It may be measured and gated,
+   but it must not emit a serve-knob winner or static `workload_profiles`
+   profile.
+3. Preserve workload/corpus mapping from `beta/workloads.py`
+   `_WORKLOAD_CORPUS_MAP`; add `corpus_class` only where both workload name
+   and corpus class must be represented.
+4. Add RAM-tier normalization matching `ProviderCapacity` thresholds:
+   - physical RAM <= 12 GiB -> `8gb`
+   - > 12 and <= 24 GiB -> `16gb`
+   - > 24 and <= 48 GiB -> `32gb`
+   - > 48 GiB -> `64gb_plus`
+   - existing provider tier strings map `8GB`, `16GB`, `32GB` to lower-case
+     keys and `64GB+` case-insensitively to `64gb_plus`
+   - any other provider tier string is invalid for SPEC-029 publication.
+5. Define a closed no-winner enum:
+   `insufficient_samples`, `gate_unmet`, `hard_failure`,
+   `no_cells_evaluated`.
+6. Define workload gate defaults exactly as SPEC-029 FR-6:
+   - `short_chat`: min samples 20, max p95 TTFT 8000 ms
+   - `medium_with_system`: min samples 20, max p95 TTFT 12000 ms
+   - `long_context`: min samples 20, max p95 TTFT 60000 ms
+   - `code_completion`: min samples 20, max p95 TTFT 12000 ms
+   - `agent_style`: min samples 20, max p95 TTFT 20000 ms
+   - `streaming_check`: min samples 20, max p95 TTFT 2000 ms, probe only
+   - every workload has hard stop-token leak rate 0 and advisory
+     `min_median_tps = null`.
+
+Tests:
+
+- RAM-tier boundary tests at 12/13/24/25/48/49 GiB.
+- Provider-tier string normalization tests for `8GB`, `16GB`, `32GB`,
+  case variants of `64GB+`, and invalid strings.
+- Included/probe workload tests proving `streaming_check` cannot be published
+  as a winner profile.
+
+### Slice B - Class-Aware Trial Capture And Report Rows
+
+Extend the beta harness/report path to record the SPEC-029 identity fields
+without breaking existing runs or daily reports.
+
+Requirements:
+
+1. Class-aware artifacts must record at least:
+   - target model identifier
+   - host RAM bytes
+   - RAM-tier key
+   - workload name
+   - corpus class when known
+   - context limit cell
+   - concurrency cell
+   - kv-bit cell
+   - measured TTFT, total latency, error/status state, and stop-token leak
+   - prompt/completion token counts and throughput when emitted
+   - `metric_unavailable_reason` when token counts or throughput are
+     unavailable
+   - winner/no-winner decision and reason.
+2. For speculative search cells, also record:
+   - `draft_model`
+   - `draft_model_artifact_sha256` when `draft_model` is present
+   - `num_draft_tokens`
+   - drafted token count, accepted token count, and acceptance rate when
+     speculative decoding was attempted
+   - candidate source: static `draft_candidates[]`, local operator override,
+     or research fixture.
+3. Keep existing class-blind run/report mode working. Add opt-in flags or a
+   new output artifact for class-aware sweep reports rather than making old
+   scripts require new columns unconditionally.
+4. If existing SQLite rows lack new fields, migration/default handling must let
+   old reports render without failure.
+
+Tests:
+
+- Fixture rows with token counts present and missing.
+- `metric_unavailable_reason` emitted when throughput cannot be computed.
+- Old/class-blind report path still renders from a legacy-shaped fixture.
+- Speculative metadata is preserved when present and omitted/null-safe when
+  absent.
+
+### Slice C - Winner Selection Engine
+
+Build a deterministic selector over `(workload name, RAM-tier key)` partitions.
+
+Requirements:
+
+1. A non-speculative winner tuple is exactly:
+   `(kv_bits, max_context_override, max_concurrency_override)`.
+2. A speculative winner tuple may additionally include:
+   `(draft_model, draft_model_artifact_sha256, num_draft_tokens)`.
+3. `num_draft_tokens` is selected per workload. Do not export a single shared
+   value unless a later SPEC or maintainer-approved run manifest defines the
+   weighting policy.
+4. A winner requires the winning cell's successful sample count to be at least
+   `gate_policy.min_samples`; do not aggregate samples across cells to qualify
+   a winner.
+5. Tie-breaking is partition-local and deterministic:
+   - zero hard failures and zero stop-token leaks
+   - satisfies workload-specific TTFT gate
+   - higher median throughput
+   - lower TTFT
+   - lower memory-risk posture, such as lower context or lower concurrency,
+     when throughput is materially tied
+   - lexical serialized tuple fallback.
+6. Non-runnable speculative candidate cells count as evaluated but must not
+   produce `recommended`.
+7. No-winner reason precedence is exactly:
+   `no_cells_evaluated` -> `hard_failure` -> `insufficient_samples` ->
+   `gate_unmet`.
+8. For no-winner profiles, `profile_metrics.sample_count` is the highest
+   successful sample count among cells, or 0 when no cells were evaluated.
+   Other profile metrics are null in the static no-winner sentinel.
+
+Tests:
+
+- One partition cannot affect another partition's winner.
+- Winner sample count is from the winning cell, not the aggregate.
+- Deterministic tie-breaker fallback is stable.
+- `hard_failure` wins when every evaluated cell hard-failed or was
+  non-runnable.
+- `insufficient_samples` wins when at least one cell produced successful
+  samples but none reached min samples.
+- `gate_unmet` wins when at least one cell reached min samples but none passed
+  hard gates.
+- `no_cells_evaluated` wins when zero cells were evaluated.
+- Non-runnable speculative cells are evaluated, excluded from sample-count
+  conditions, and never produce `recommended`.
+
+### Slice D - Static Catalog `workload_profiles`
+
+Extend candidate-catalog parsing/validation additively. Do not require current
+recommendation or serving code to consume `workload_profiles` for routing.
+
+Requirements:
+
+1. Add optional row field `workload_profiles`.
+2. Shape is:
+
+```text
+workload_profiles.<workload_name>.<ram_tier_key> -> tier-scoped workload profile
+```
+
+3. Tier key must be one of `8gb`, `16gb`, `32gb`, `64gb_plus`.
+4. Winner profile:
+   - may omit `status` or use `"winner"`
+   - includes `recommended`, `gate_policy`, `profile_metrics`, and `source`.
+5. No-winner profile:
+   - has `status: "no_winner"`
+   - has closed-vocabulary `no_winner_reason`
+   - omits `recommended`
+   - includes `gate_policy`, `profile_metrics`, and `source`
+   - only `profile_metrics.sample_count` is populated; all other
+     `profile_metrics` fields are JSON null.
+6. Use the exact recommended field names from SPEC-013/SPEC-028:
+   `kv_bits`, `max_context_override`, `max_concurrency_override`,
+   optional `draft_model`, optional `draft_model_artifact_sha256`, optional
+   `num_draft_tokens`.
+7. If `recommended.draft_model` is present:
+   - `draft_model_artifact_sha256` must be present and lowercase 64-hex
+   - `1 <= num_draft_tokens <= 16`
+   - `max_concurrency_override <= 1`
+   - `max_context_override` must not exceed SPEC-028 draft caps:
+     `8gb=8192`, `16gb=20000`, `32gb=50000`, `64gb_plus=120000`.
+8. `gate_policy.min_median_tps` is JSON null unless a maintainer-approved run
+   manifest defines a throughput floor.
+9. `profile_metrics` units:
+   - `p95_ttft_ms` in milliseconds
+   - `median_tps` in tokens/sec
+   - rates as 0.0-1.0 fractions
+   - nullable attempted metrics encoded as JSON null, not omitted.
+10. `streaming_check` must not be published in `workload_profiles`.
+11. Preserve current consumers: existing recommendation paths must ignore this
+    additive field unless this implementation explicitly adds a read-only
+    inspection/simulation command.
+
+Tests:
+
+- Decode a current catalog with no `workload_profiles`.
+- Decode a catalog with winner and no-winner workload profiles.
+- Reject invalid tier key, invalid workload name, `streaming_check` profile,
+  unknown no-winner reason, missing no-winner reason, no-winner with
+  `recommended`, winner without required metrics, invalid draft hash, invalid
+  `num_draft_tokens`, speculative context over tier cap, and speculative
+  concurrency > 1.
+- Prove existing recommendation selection output is unchanged when an otherwise
+  identical catalog adds valid `workload_profiles`.
+- Prove static signing still uses the existing SPEC-023 v4 key material and no
+  new key ID is introduced.
+
+### Slice E - Publication/Fixture Artifacts
+
+Do not publish production workload winners unless real sweep data exists and
+maintainers have approved the run manifest. Use fixtures for schema and tests.
+
+Requirements:
+
+1. Add minimal fixture JSON that exercises:
+   - one winner profile
+   - one no-winner profile
+   - one non-speculative tuple
+   - one SPEC-028 speculative tuple
+   - nullable throughput/token metrics.
+2. If `phase3-binary/dist/static/autotune-candidates.json` is updated in this
+   PR, keep the change additive and re-sign with the existing SPEC-023 v4 key
+   only. Do not rotate keys for SPEC-029.
+3. If production static artifacts are not updated, add tests that validate a
+   fixture catalog and leave production catalog bytes untouched.
+4. Append to `beta/DECISION_CRITERIA.md` only if this implementation makes a
+   new maintainer decision not already captured by SPEC-029.
+
+Tests:
+
+- Fixture round-trip validation.
+- `scripts/resign-autotune-static.sh` or existing static sync checks still pass
+  if static artifacts changed.
+
+## 4. Acceptance Criteria Coverage
+
+Map tests or explicit verification notes to every SPEC-029 acceptance criterion:
+
+- AC-1: class-aware sweep groups by workload and RAM-tier.
+- AC-2: `streaming_check` is probe-only.
+- AC-3: partition-local deterministic winner.
+- AC-4: speculative `num_draft_tokens` selected per workload.
+- AC-5: additive `workload_profiles` schema.
+- AC-6: existing SPEC-023 signing/key identity preserved.
+- AC-7: no runtime classifier or routing policy added.
+- AC-8: reports include workload, corpus, RAM-tier, gates, metrics, and reason.
+- AC-9: current clients ignore additive field / unchanged recommendation.
+- AC-10: nullable metrics encoded as JSON null.
+- AC-11: FR-3 trial/report identity fields present.
+- AC-12: `min_samples` semantics use winning-cell count.
+- AC-13: SPEC-028 RAM-tier caps enforced.
+- AC-14: closed no-winner reasons and precedence implemented.
+
+## 5. Audit-Loop Discipline
+
+Before opening or updating the PR as ready:
+
+1. Run targeted tests after each slice.
+2. Run the repo-appropriate aggregate checks, at minimum:
+
+```bash
+git diff --check
+cd phase3-binary && swift test --filter AutotuneRecommendTests
+cd phase3-binary && swift test --filter Spec028PlumbingTests
+```
+
+3. If Python beta tests are added, run the exact test command for them and
+   include it in the PR.
+4. Run 3 independent native audit lanes and 2 external Claude subscription
+   review lanes against the implementation and SPEC-029. In this repo, Claude
+   subscription CLI can be invoked without the stale API-key setting by using:
+
+```bash
+claude -p --setting-sources project,local "<review prompt>"
+```
+
+5. Loop on all Critical/High/Medium findings until there are 0 C/H/M findings
+   remaining. Low findings may be accepted only with a written rationale in
+   the PR or audit note.
+6. Include an audit summary in the PR with:
+   - lanes run
+   - commands/tests run
+   - remaining accepted Low findings, if any
+   - explicit statement that C/H/M findings are 0.
+
+## 6. PR Checklist
+
+The PR is not complete until all of the following are true:
+
+- Implementation is in an isolated feature worktree/branch.
+- SPEC-029 draft-status authorization is documented or SPEC status has been
+  updated by maintainers before implementation began.
+- Existing class-blind behavior still works.
+- `streaming_check` is probe-only.
+- No buyer API, coordinator routing, provider runtime classifier, billing,
+  settlement, request-log, or payout paths were changed.
+- Static catalog compatibility is proven by tests.
+- Signing remains SPEC-023 v4.
+- Tests and `git diff --check` pass.
+- Audit loop is converged to 0 C/H/M findings.
+- Commit message follows the Lore Commit Protocol in `AGENTS.md`.

--- a/specs/RESEARCH_SWEEP_WORKLOAD_CLASS_PROMPT.md
+++ b/specs/RESEARCH_SWEEP_WORKLOAD_CLASS_PROMPT.md
@@ -1,0 +1,90 @@
+# RESEARCH_SWEEP_WORKLOAD_CLASS_PROMPT
+
+**Purpose:** research + SPEC-drafting prompt for extending the context×concurrency
+sweep search space to a third axis — **workload class** — so autotune produces
+per-class winners rather than one compromise config across all traffic shapes.
+
+**Status:** research-round, pre-SPEC.
+
+**Author:** drafted 2026-07-05 by Claude Opus 4.7 session (opus-4-7).
+
+**Why it matters now.** SPEC-028 (speculative decoding, v0.2 audited on `origin/main`
+at `a1be007`) is landing chain speculative on the provider serve path. Draft-token
+acceptance rate is workload-dependent: shard's 2026-07-03 report shows +49% on
+reasoning cells vs. chain-wins on code/RAG/long-ctx. Without a class-aware sweep,
+SPEC-028 ships with a single `--num-draft-tokens N` chosen as a compromise across
+workloads — leaving materially throughput on the table on the classes it under-fits.
+**This SPEC is the multiplier that makes SPEC-028 land at full strength.**
+
+**Verified state (2026-07-05).**
+- `beta/workloads.py` has 6 named classes (`short_chat, medium_with_system, long_context, code_completion, agent_style, streaming_check`) with a `_WORKLOAD_CORPUS_MAP` category mapping.
+- `beta/report.py::summarize_per_workload` groups results per class.
+- `beta/DECISION_CRITERIA.md` §B/§C explicitly requires per-workload metrics ("Median tok/s per workload", "Stop-token leak rate per workload").
+- **But the sweep grid** (per `.omc/logs/context-throughput-sweep-impl-notes.md`) **is 7 contexts × 4 concurrency = 28 cells — shape-only, class-blind.** Buyer-harness stratifies output; knob-search doesn't.
+
+---
+
+# Codex session: research + SPEC workload-class sweep for macprovider-poc
+
+## Context
+
+The buyer harness reports per-workload; the sweep search space does not. This SPEC extends the sweep to `(context × concurrency × workload_class)` (or a class-filter over the existing grid — decide which) so autotune produces per-class knob winners publishable to `phase3-binary/dist/static/autotune-candidates.json` (or a class-partitioned sibling).
+
+## Scope — hard limits
+
+- **Read-only research + SPEC drafting.** No code changes to sweep, harness, autotune, or `autotune-candidates.json`. No PRs against `origin/main`.
+- Do **not** modify SPEC-013 (CLI autotune, LOCK candidate) or SPEC-028 (speculative decoding) — this SPEC is a companion, not a modification.
+
+## Read first
+
+1. `CLAUDE.md`, `AGENTS.md`, `HANDOFF.md`.
+2. `beta/workloads.py`, `beta/report.py::summarize_per_workload`, `beta/DECISION_CRITERIA.md`.
+3. `.omc/logs/context-throughput-sweep-impl-notes.md` (28-cell grid rationale).
+4. `beta/sweep.py` on branch `spike/context-throughput-sweep`.
+5. `specs/SPEC-013-*` (CLI autotune) — where the new axis surfaces to operators.
+6. `specs/SPEC-028-*` (speculative decoding) — the drafter's `num_draft_tokens` axis interacts with class; sweep must accommodate both.
+7. `phase3-binary/dist/static/autotune-candidates.json` — the ship surface.
+
+## Questions to answer (cite files:lines)
+
+### A. Search-space shape
+- Class as a third grid dimension (28 × K cells) vs. class as a filter over the existing grid (K parallel 28-cell sweeps): which is correct? Cite runtime cost, storage impact on `runs.sqlite`.
+- Which of the 6 workload classes belongs in the sweep? Are any (e.g., `streaming_check`) infrastructure-shape rather than content-shape and should be excluded?
+
+### B. Winner-picking under SPEC-028
+- With chain spec-decode, a knob winner is a tuple `(kv_bits, max_context, max_batch, num_draft_tokens)`. Is `num_draft_tokens` per-class or shared across classes? Cite tradeoff.
+- How does per-class tie-breaking work when two classes want conflicting knobs? Which class dominates? (Suggested: buyer-weighted, per the observed traffic mix in `runs.sqlite`.)
+
+### C. Autotune-candidates.json shape
+- Extend the existing schema with a `per_class` map, or ship a sibling file (`autotune-candidates-per-class.json`) with the class dimension? Backward-compat with existing autotune-recommend consumers?
+- Static-sign implications (`phase3-binary/dist/static/keys/autotune-static-v3.public.base64`): does the class-partitioned candidate set need a new key, or can it reuse v3?
+
+### D. Runtime routing
+- When a buyer request lands, how does the provider (or coordinator) classify it into a workload class at request-time? The classes exist in `workloads.py` for corpus sampling; is there a request-time classifier, or would this SPEC introduce one?
+- If a classifier is needed: does it live in the provider (fast, potentially gameable) or the coordinator (adds RTT)? Which is right?
+- If class routing turns out to require a new classifier component: **that is out of scope for this SPEC** — restrict this SPEC to producing per-class winners as data. A follow-up SPEC handles serving them.
+
+### E. Interaction with existing sweep artifacts
+- `.omc/logs/context-throughput-sweep-impl-notes.md` documents 28-cell design decisions (feasible gate at `n_err == 0`, `ttft_p95_ms <= 8000`, no `stop_token_leak`). Do these gates need to be class-parameterized? (e.g., long-context class may need a higher TTFT gate.)
+- Do the existing sweep reports (`beta/reports/sweep-*.html`) need re-generation with class stratification, or can they stay as-is with new class-aware reports alongside?
+
+## Deliverables
+
+Branch `research/sweep-workload-class` off `origin/main`, three artifacts:
+
+1. **`docs/research/sweep-workload-class-2026-07.md`** — research memo answering §A–E with citations.
+2. **`specs/SPEC-XXX-sweep-workload-class-stratification.md`** v0.1-draft — normative FRs, non-goals, open questions, acceptance criteria.
+3. **`.omc/logs/sweep-workload-class-open-questions-2026-07.md`** — maintainer-input list.
+
+## Definition of done (this research session)
+
+- Every §A–E question answered with a code citation.
+- SPEC draft passes self-review round.
+- Open questions list ≤5 items, all genuinely blocked on human decision.
+- No code changes. No PR beyond this branch.
+
+## Do NOT
+
+- Modify sweep code, harness, autotune, or `autotune-candidates.json`.
+- Introduce a request-time workload classifier in this SPEC — call the seam, defer.
+- Modify SPEC-013 or SPEC-028.

--- a/specs/SPEC-029-sweep-workload-class-stratification.md
+++ b/specs/SPEC-029-sweep-workload-class-stratification.md
@@ -1,0 +1,211 @@
+# SPEC-029 - Sweep Workload-Class Stratification
+
+**Version:** 0.1-draft
+**Status:** Draft, research round. Implementation MUST NOT begin before maintainer review.
+**Date drafted:** 2026-07-09
+**Depends on:** SPEC-013, SPEC-023, SPEC-028, beta buyer harness workload/report schema.
+
+SPEC-029 defines a class-aware sweep and candidate-publication shape for MacProvider autotune research. It produces per-workload winners as data. It does not introduce runtime request classification or class-routed serving.
+
+## 1. Mission
+
+MacProvider's beta harness already measures performance per workload, but serve-knob selection and static candidate recommendation are class-blind. SPEC-029 makes workload shape a first-class partition in sweep outputs so autotune can publish per-workload recommendations instead of one compromise config across short chat, medium chat, long context, code, and agent-style traffic.
+
+This SPEC is a companion to SPEC-028. Speculative decoding adds draft-model and `num_draft_tokens` choices whose value depends on prompt/content shape. SPEC-029 defines how those choices are measured and published by workload without changing SPEC-028's provider runtime contract.
+
+## 2. Scope
+
+### In scope
+
+- Workload-stratified sweep runs over the existing context/concurrency/kv search shape.
+- Per-workload winner selection.
+- Class-specific report rows and gates.
+- Additive static-catalog schema for per-workload recommendation profiles.
+- Open questions for future runtime routing/classification.
+
+### Non-goals
+
+- No buyer API change.
+- No coordinator routing-policy change.
+- No provider request-time classifier.
+- No settlement, receipt, or billing schema change.
+- No modification to SPEC-013 or SPEC-028.
+- No requirement to regenerate old class-blind sweep reports.
+- No implementation changes in this draft PR.
+
+## 3. Terms
+
+- **Workload name:** The beta harness registry key, such as `short_chat` or `code_completion`.
+- **Corpus class:** The sampling category in `_WORKLOAD_CORPUS_MAP`, such as `short`, `medium`, or `code`.
+- **Workload profile:** A static-catalog profile keyed by workload name containing measured gates and recommended knobs.
+- **Winner:** The selected serve-knob tuple for one workload name and one target model candidate.
+
+## 4. Normative Requirements
+
+### FR-1. Sweep partitioning
+
+The sweep implementation MUST treat workload name as a partition/filter over the existing sweep grid, not as a single global optimization that emits one winner across all classes.
+
+For every included workload name, the sweep MUST evaluate the configured context/concurrency/kv search cells and emit one class-local winner or one explicit no-winner result.
+
+The sweep MUST preserve the existing class-blind run/report mode unless a later implementation SPEC explicitly removes it.
+
+### FR-2. Included workloads
+
+The v0.1 class-aware winner set MUST include these workload names:
+
+- `short_chat`
+- `medium_with_system`
+- `long_context`
+- `code_completion`
+- `agent_style`
+
+`streaming_check` MUST be treated as a streaming TTFT probe/gate in v0.1. It MUST NOT emit a separate serve-knob winner unless a future SPEC defines a runtime profile that can use it.
+
+### FR-3. Trial and report identity
+
+Class-aware sweep artifacts MUST record at least:
+
+- target model identifier
+- workload name
+- corpus class, when known
+- context limit cell
+- concurrency cell
+- kv-bit cell
+- measured TTFT, total latency, throughput, token counts, error count, and stop-token leak state
+- winner/no-winner decision and reason
+
+Implementations SHOULD keep the existing `workload` field name when operating on beta harness rows and add a separate `workload_class` or `corpus_class` field only when both names must be represented.
+
+### FR-4. Winner tuple
+
+For non-speculative rows, a winner tuple MUST include:
+
+```text
+(kv_bits, max_context_override, max_concurrency_override)
+```
+
+For SPEC-028 speculative rows, a winner tuple MAY additionally include:
+
+```text
+(draft_model, draft_model_artifact_sha256, num_draft_tokens)
+```
+
+When speculative decoding is enabled, `num_draft_tokens` MUST be selected per workload name. A single shared `num_draft_tokens` MAY be exported only as a legacy/default profile and MUST be derived from an explicit weighting policy.
+
+### FR-5. Tie-breaking
+
+Tie-breaking MUST be class-local. No workload name may silently dominate another workload name's winner.
+
+Within one workload name, the implementation MUST define deterministic tie-breakers. The recommended order for v0.1 is:
+
+1. Zero hard failures and zero stop-token leaks.
+2. Satisfies workload-specific TTFT gate.
+3. Higher sustained throughput.
+4. Lower TTFT.
+5. Lower memory-risk posture, such as lower context or lower concurrency, when throughput is materially tied.
+6. Stable lexical order of serialized tuple as a final deterministic fallback.
+
+If a single legacy default is required, the default MUST be chosen from the per-workload winners using an explicit traffic-weighting policy documented in the report.
+
+### FR-6. Gates
+
+Sweep gates MUST be parameterizable by workload name.
+
+At minimum:
+
+- `long_context` MUST have an explicit TTFT/prefill gate separate from short chat.
+- `streaming_check` MUST gate streaming TTFT.
+- stop-token leak checks MUST be reportable per workload name.
+- speculative acceptance metrics, when present, MUST be reported per workload name and target/draft pair.
+
+### FR-7. Static catalog extension
+
+The static `autotune-candidates.json` schema SHOULD be extended additively inside each existing row with a workload profile map.
+
+Recommended field name:
+
+```json
+{
+  "workload_profiles": {
+    "code_completion": {
+      "recommended": {
+        "kv_bits": 4,
+        "max_context_override": 20000,
+        "max_concurrency_override": 1,
+        "draft_model": "example/draft",
+        "draft_model_artifact_sha256": "lowercase-hex-sha256",
+        "num_draft_tokens": 4
+      },
+      "bench_gate": {
+        "min_sustained_tps": 8.5,
+        "max_ttft_ms": 8000,
+        "max_stop_token_leak_rate": 0
+      },
+      "source": "sweep-workload-class-2026-07"
+    }
+  }
+}
+```
+
+The field MAY be named `per_class` only if maintainers choose that naming before implementation.
+
+Current consumers MUST be able to ignore the additive field. Implementations MUST NOT require current installer recommendation clients to understand workload profiles until the client SPEC is updated.
+
+### FR-8. Static signing
+
+Workload-profile catalog data MUST use the existing static autotune-catalog signing domain unless maintainers explicitly create a new trust domain.
+
+Publishing any changed static catalog bytes MUST include a fresh signature sidecar using the current accepted static key process. SPEC-029 does not require a new public key.
+
+### FR-9. Runtime classification boundary
+
+SPEC-029 MUST NOT introduce a provider or coordinator request-time classifier.
+
+Generated workload profiles are data for future consumers. A later SPEC MUST decide:
+
+- whether buyer requests receive a workload label,
+- whether classification occurs at the coordinator, provider, buyer, or offline recommendation layer,
+- how a label affects routing, serve config, receipts, and auditability.
+
+Until that SPEC exists, implementations MUST NOT silently switch serve knobs per request based on inferred workload class.
+
+### FR-10. Report compatibility
+
+Existing class-blind sweep reports MAY remain unchanged. Implementations SHOULD write class-aware reports alongside existing reports, not overwrite historical artifacts.
+
+Reports MUST include enough metadata to reproduce winner selection, including search cells, workload name, gates, measured metrics, and tie-breaker reason.
+
+## 5. Acceptance Criteria
+
+- AC-1: A class-aware sweep can run every included workload name over the configured grid and emit one winner/no-winner result per workload.
+- AC-2: `streaming_check` contributes TTFT gate/report data but does not emit a serve-knob winner.
+- AC-3: Winner selection is deterministic and class-local.
+- AC-4: SPEC-028 speculative rows can select `num_draft_tokens` per workload name.
+- AC-5: Static catalog extension is additive and ignored by existing clients that do not know the new field.
+- AC-6: Changed static catalog bytes are re-signed with the existing static signing process.
+- AC-7: No runtime request classifier or class-routed serving behavior is implemented under this SPEC.
+- AC-8: Reports cite workload-specific gates and tie-breaker outcomes.
+
+## 6. Open Questions
+
+1. Should the static field be named `workload_profiles`, `per_class`, or another maintainer-preferred term?
+2. If a single legacy default must be exported, what traffic-weighting policy is authoritative?
+3. What numeric TTFT gates should apply to `long_context` and `streaming_check`?
+4. Should speculative acceptance-rate thresholds become hard gates or advisory report fields in v0.1?
+5. Which follow-up SPEC owns runtime classification and class-routed serving?
+
+## 7. Evidence
+
+- `beta/workloads.py:26` defines the workload-to-corpus mapping.
+- `beta/report.py:59` summarizes rows per workload.
+- `beta/harness.py:59` records workload, latency, throughput, token, and leak fields.
+- `beta/DECISION_CRITERIA.md:54` and `beta/DECISION_CRITERIA.md:85` require per-workload decision metrics.
+- `specs/SPEC-028-mlx-speculative-decoding.md:63` defines `--num-draft-tokens`.
+- `specs/SPEC-028-mlx-speculative-decoding.md:202` allows autotune/static-catalog draft candidate extension points and rejects blind grid multiplication.
+- `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:439` decodes the current static catalog row shape.
+- `phase3-binary/dist/static/keys/README.md:32` describes the current static feed trust model.
+
+## 8. Research Constraints
+
+The prompt referenced `.omc/logs/context-throughput-sweep-impl-notes.md` and `origin/spike/context-throughput-sweep`. Neither was available in the current repository state during drafting. This SPEC therefore avoids relying on undocumented 28-cell implementation details beyond the research prompt's own description.

--- a/specs/SPEC-029-sweep-workload-class-stratification.md
+++ b/specs/SPEC-029-sweep-workload-class-stratification.md
@@ -37,7 +37,7 @@ This SPEC is a companion to SPEC-028. Speculative decoding adds draft-model and 
 
 - **Workload name:** The beta harness registry key, such as `short_chat` or `code_completion`.
 - **Corpus class:** The sampling category in `_WORKLOAD_CORPUS_MAP`, such as `short`, `medium`, or `code`.
-- **Workload profile:** A static-catalog profile keyed by workload name containing measured gates and recommended knobs.
+- **Workload profile:** A static-catalog profile keyed by workload name containing measured profile metrics, the gate policy used to choose the winner, and recommended knobs.
 - **Winner:** The selected serve-knob tuple for one workload name and one target model candidate.
 
 ## 4. Normative Requirements
@@ -72,10 +72,20 @@ Class-aware sweep artifacts MUST record at least:
 - context limit cell
 - concurrency cell
 - kv-bit cell
-- measured TTFT, total latency, throughput, token counts, error count, and stop-token leak state
+- measured TTFT, total latency, error count, and stop-token leak state
+- token counts and throughput when emitted by the response path
+- `metric_unavailable_reason` when token counts or throughput are unavailable
 - winner/no-winner decision and reason
 
 Implementations SHOULD keep the existing `workload` field name when operating on beta harness rows and add a separate `workload_class` or `corpus_class` field only when both names must be represented.
+
+For speculative search cells, artifacts MUST also record:
+
+- draft model identifier
+- draft model artifact SHA-256, when the candidate is runnable
+- `num_draft_tokens`
+- drafted token count, accepted token count, and acceptance rate when speculative decoding was attempted
+- candidate source, such as a static `draft_candidates[]` row, local operator override, or research fixture
 
 ### FR-4. Winner tuple
 
@@ -92,6 +102,15 @@ For SPEC-028 speculative rows, a winner tuple MAY additionally include:
 ```
 
 When speculative decoding is enabled, `num_draft_tokens` MUST be selected per workload name. A single shared `num_draft_tokens` MAY be exported only as a legacy/default profile and MUST be derived from an explicit weighting policy.
+
+Any workload profile whose `recommended` object contains `draft_model` MUST satisfy all of the following:
+
+- The target/draft pair came from a sweep or fixture that satisfied SPEC-028 FR-4 compatibility and provenance checks, or the profile is explicitly marked with `non_runnable_reason`.
+- `draft_model_artifact_sha256` is present for runnable profiles and is lowercase 64-hex.
+- `num_draft_tokens` is an integer in the SPEC-028 range `1 <= N <= 16`.
+- `max_concurrency_override` is not greater than `1` for runnable SPEC-028 v0.1 profiles.
+- `max_context_override` does not exceed SPEC-028's effective draft-enabled context cap for the target RAM tier unless the profile is explicitly marked with `non_runnable_reason`.
+- The profile SHOULD reference the row's SPEC-028 `draft_candidates[]` entry when the candidate was selected from the static catalog.
 
 ### FR-5. Tie-breaking
 
@@ -112,6 +131,19 @@ If a single legacy default is required, the default MUST be chosen from the per-
 
 Sweep gates MUST be parameterizable by workload name.
 
+The v0.1 default hard gate policy is:
+
+| Workload name | Hard max p95 TTFT | Hard stop-token leak rate | Notes |
+|---|---:|---:|---|
+| `short_chat` | 8000 ms | 0 | Uses the existing class-blind 8s TTFT posture. |
+| `medium_with_system` | 12000 ms | 0 | Allows additional prefill over short chat. |
+| `long_context` | 60000 ms | 0 | Allows long-context prefill; still fails pathological stalls. |
+| `code_completion` | 12000 ms | 0 | Keeps code continuation close to medium-chat latency. |
+| `agent_style` | 20000 ms | 0 | Allows larger system/tool-catalog prompt shape. |
+| `streaming_check` | 2000 ms | 0 | TTFT probe only; no serve-knob winner. |
+
+Implementations MUST use these defaults unless a later SPEC or a maintainer-approved run manifest defines a replacement policy. Replacement policies MUST be serialized into the sweep report and static workload profile that used them.
+
 At minimum:
 
 - `long_context` MUST have an explicit TTFT/prefill gate separate from short chat.
@@ -119,11 +151,13 @@ At minimum:
 - stop-token leak checks MUST be reportable per workload name.
 - speculative acceptance metrics, when present, MUST be reported per workload name and target/draft pair.
 
+Speculative acceptance rate is advisory in v0.1. It MUST be recorded when available, but it MUST NOT be a hard winner gate until a later SPEC defines a numeric threshold.
+
 ### FR-7. Static catalog extension
 
-The static `autotune-candidates.json` schema SHOULD be extended additively inside each existing row with a workload profile map.
+The static `autotune-candidates.json` schema MUST be extended additively inside each existing row with a `workload_profiles` map when SPEC-029 workload-specific recommendations are published.
 
-Recommended field name:
+The v0.1 field name is `workload_profiles`. Implementations MUST NOT publish the same data under `per_class` in v0.1.
 
 ```json
 {
@@ -134,13 +168,20 @@ Recommended field name:
         "max_context_override": 20000,
         "max_concurrency_override": 1,
         "draft_model": "example/draft",
-        "draft_model_artifact_sha256": "lowercase-hex-sha256",
+        "draft_model_artifact_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         "num_draft_tokens": 4
       },
-      "bench_gate": {
-        "min_sustained_tps": 8.5,
-        "max_ttft_ms": 8000,
-        "max_stop_token_leak_rate": 0
+      "gate_policy": {
+        "max_p95_ttft_ms": 12000,
+        "max_stop_token_leak_rate": 0,
+        "min_sustained_tps": null
+      },
+      "profile_metrics": {
+        "median_tps": 8.5,
+        "p95_ttft_ms": 2400,
+        "stop_token_leak_rate": 0,
+        "spec_decode_acceptance_rate": 0.42,
+        "sample_count": 5
       },
       "source": "sweep-workload-class-2026-07"
     }
@@ -148,7 +189,9 @@ Recommended field name:
 }
 ```
 
-The field MAY be named `per_class` only if maintainers choose that naming before implementation.
+`gate_policy` records the hard policy used for winner selection. `profile_metrics` records measured/advisory metrics. The nested workload profile MUST NOT reuse the top-level SPEC-023 `bench_gate` key; SPEC-023 `bench_gate.min_sustained_tps` and `bench_gate.max_4k_ttft_ms` remain advisory QoS signals for the existing recommendation engine.
+
+`workload_profiles.<workload>.recommended` MUST use the same serve-knob names as SPEC-013/SPEC-028 config outputs. `profile_metrics` values MUST use milliseconds for TTFT, tokens per second for throughput, and a 0.0-1.0 fraction for rates. Nullable metrics MUST be encoded as JSON `null`, not omitted, when the sweep attempted the metric but the response path did not emit enough data.
 
 Current consumers MUST be able to ignore the additive field. Implementations MUST NOT require current installer recommendation clients to understand workload profiles until the client SPEC is updated.
 
@@ -156,7 +199,7 @@ Current consumers MUST be able to ignore the additive field. Implementations MUS
 
 Workload-profile catalog data MUST use the existing static autotune-catalog signing domain unless maintainers explicitly create a new trust domain.
 
-Publishing any changed static catalog bytes MUST include a fresh signature sidecar using the current accepted static key process. SPEC-029 does not require a new public key.
+Publishing any changed static catalog bytes MUST include a fresh signature sidecar using the SPEC-023 v4 static key process. SPEC-029 does not require a new public key.
 
 ### FR-9. Runtime classification boundary
 
@@ -182,29 +225,33 @@ Reports MUST include enough metadata to reproduce winner selection, including se
 - AC-2: `streaming_check` contributes TTFT gate/report data but does not emit a serve-knob winner.
 - AC-3: Winner selection is deterministic and class-local.
 - AC-4: SPEC-028 speculative rows can select `num_draft_tokens` per workload name.
-- AC-5: Static catalog extension is additive and ignored by existing clients that do not know the new field.
-- AC-6: Changed static catalog bytes are re-signed with the existing static signing process.
+- AC-5: Static catalog extension is additive, uses `workload_profiles`, and is ignored by existing clients that do not know the new field.
+- AC-6: Changed static catalog bytes are re-signed with the SPEC-023 v4 static signing process.
 - AC-7: No runtime request classifier or class-routed serving behavior is implemented under this SPEC.
 - AC-8: Reports cite workload-specific gates and tie-breaker outcomes.
+- AC-9: A decode/recommendation regression test proves current clients still accept a catalog row containing `workload_profiles`.
+- AC-10: `streaming_check` reports TTFT, status/error, leak state, and gate outcome even when token counts and throughput are `null` because SSE usage was absent.
 
 ## 6. Open Questions
 
-1. Should the static field be named `workload_profiles`, `per_class`, or another maintainer-preferred term?
-2. If a single legacy default must be exported, what traffic-weighting policy is authoritative?
-3. What numeric TTFT gates should apply to `long_context` and `streaming_check`?
-4. Should speculative acceptance-rate thresholds become hard gates or advisory report fields in v0.1?
-5. Which follow-up SPEC owns runtime classification and class-routed serving?
+1. If a single legacy default must be exported, what traffic-weighting policy is authoritative?
+2. Which follow-up SPEC owns runtime classification and class-routed serving?
+3. Should a later client SPEC consume `workload_profiles` directly in installer recommendation, or should it first remain a report-only/feed-only artifact?
 
 ## 7. Evidence
 
 - `beta/workloads.py:26` defines the workload-to-corpus mapping.
 - `beta/report.py:59` summarizes rows per workload.
 - `beta/harness.py:59` records workload, latency, throughput, token, and leak fields.
-- `beta/DECISION_CRITERIA.md:54` and `beta/DECISION_CRITERIA.md:85` require per-workload decision metrics.
+- `beta/DECISION_CRITERIA.md:57` through `beta/DECISION_CRITERIA.md:62` and `beta/DECISION_CRITERIA.md:89` through `beta/DECISION_CRITERIA.md:92` require per-workload decision metrics.
 - `specs/SPEC-028-mlx-speculative-decoding.md:63` defines `--num-draft-tokens`.
-- `specs/SPEC-028-mlx-speculative-decoding.md:202` allows autotune/static-catalog draft candidate extension points and rejects blind grid multiplication.
+- `specs/SPEC-028-mlx-speculative-decoding.md:202` through `specs/SPEC-028-mlx-speculative-decoding.md:215` allow autotune/static-catalog draft candidate extension points and reject blind grid multiplication.
 - `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:439` decodes the current static catalog row shape.
+- `specs/SPEC-023-installer-autotune-recommend.md:320` through `specs/SPEC-023-installer-autotune-recommend.md:342` define the v4 static signing process.
 - `phase3-binary/dist/static/keys/README.md:32` describes the current static feed trust model.
+- `scripts/resign-autotune-static.sh:1` through `scripts/resign-autotune-static.sh:3` describe the v4 static feed signing helper.
+- `scripts/resign-autotune-static.sh:26` through `scripts/resign-autotune-static.sh:30` define byte-for-byte signing and sidecar shape.
+- `scripts/resign-autotune-static.sh:42` pins the current static signing key ID used by the signing helper.
 
 ## 8. Research Constraints
 

--- a/specs/SPEC-029-sweep-workload-class-stratification.md
+++ b/specs/SPEC-029-sweep-workload-class-stratification.md
@@ -1,7 +1,7 @@
 # SPEC-029 - Sweep Workload-Class Stratification
 
 **Version:** 0.1-draft
-**Status:** Draft, research round. Implementation MUST NOT begin before maintainer review.
+**Status:** Draft, implementation authorized by maintainer request on 2026-07-09 for PR #387.
 **Date drafted:** 2026-07-09
 **Depends on:** SPEC-013, SPEC-023, SPEC-028, beta buyer harness workload/report schema.
 
@@ -31,7 +31,6 @@ This SPEC is a companion to SPEC-028. Speculative decoding adds draft-model and 
 - No settlement, receipt, or billing schema change.
 - No modification to SPEC-013 or SPEC-028.
 - No requirement to regenerate old class-blind sweep reports.
-- No implementation changes in this draft PR.
 
 ## 3. Terms
 

--- a/specs/SPEC-029-sweep-workload-class-stratification.md
+++ b/specs/SPEC-029-sweep-workload-class-stratification.md
@@ -37,6 +37,8 @@ This SPEC is a companion to SPEC-028. Speculative decoding adds draft-model and 
 
 - **Workload name:** The beta harness registry key, such as `short_chat` or `code_completion`.
 - **Corpus class:** The sampling category in `_WORKLOAD_CORPUS_MAP`, such as `short`, `medium`, or `code`.
+- **RAM-tier key:** One of `8gb`, `16gb`, `32gb`, or `64gb_plus`, derived from the sweep host's resolved provider RAM tier using the same ceil-rounded GiB thresholds as `ProviderCapacity`: at most 12 GiB maps to `8gb`; greater than 12 GiB and at most 24 GiB maps to `16gb`; greater than 24 GiB and at most 48 GiB maps to `32gb`; greater than 48 GiB maps to `64gb_plus`. When normalizing an existing provider tier string, map raw `64GB+` case-insensitively to `64gb_plus`; lowercase `8GB`, `16GB`, and `32GB` to `8gb`, `16gb`, and `32gb`. Any other provider tier string is invalid for SPEC-029 publication.
+- **Evaluated candidate cell:** A configured search cell that the sweep attempted to classify, including a cell rejected at preflight as non-runnable. `no_cells_evaluated` applies only when the sweep enumerated zero cells for the workload/RAM-tier pair.
 - **Workload profile:** A static-catalog profile keyed by workload name containing measured profile metrics, the gate policy used to choose the winner, and recommended knobs.
 - **Winner:** The selected serve-knob tuple for one workload name and one target model candidate.
 
@@ -44,9 +46,9 @@ This SPEC is a companion to SPEC-028. Speculative decoding adds draft-model and 
 
 ### FR-1. Sweep partitioning
 
-The sweep implementation MUST treat workload name as a partition/filter over the existing sweep grid, not as a single global optimization that emits one winner across all classes.
+The sweep implementation MUST treat `(workload name, RAM-tier key)` as the partition/filter over the existing sweep grid, not as a single global optimization that emits one winner across all classes or hardware tiers.
 
-For every included workload name, the sweep MUST evaluate the configured context/concurrency/kv search cells and emit one class-local winner or one explicit no-winner result.
+For every included workload name and measured RAM-tier key, the sweep MUST evaluate the configured context/concurrency/kv search cells and emit one partition-local winner or one explicit no-winner result.
 
 The sweep MUST preserve the existing class-blind run/report mode unless a later implementation SPEC explicitly removes it.
 
@@ -62,27 +64,31 @@ The v0.1 class-aware winner set MUST include these workload names:
 
 `streaming_check` MUST be treated as a streaming TTFT probe/gate in v0.1. It MUST NOT emit a separate serve-knob winner unless a future SPEC defines a runtime profile that can use it.
 
+New workload names added to the beta harness registry after this SPEC is locked are out of scope until a later SPEC revision explicitly adds them to the included workload set or marks them probe-only.
+
 ### FR-3. Trial and report identity
 
 Class-aware sweep artifacts MUST record at least:
 
 - target model identifier
+- host RAM in bytes
+- RAM-tier key
 - workload name
 - corpus class, when known
 - context limit cell
 - concurrency cell
 - kv-bit cell
-- measured TTFT, total latency, error count, and stop-token leak state
+- measured TTFT, total latency, error/status state, and stop-token leak state
 - token counts and throughput when emitted by the response path
 - `metric_unavailable_reason` when token counts or throughput are unavailable
 - winner/no-winner decision and reason
 
-Implementations SHOULD keep the existing `workload` field name when operating on beta harness rows and add a separate `workload_class` or `corpus_class` field only when both names must be represented.
+Implementations SHOULD keep the existing `workload` field name when operating on beta harness rows and add a separate `corpus_class` field only when both workload name and corpus class must be represented.
 
 For speculative search cells, artifacts MUST also record:
 
 - draft model identifier
-- draft model artifact SHA-256, when the candidate is runnable
+- draft model artifact SHA-256 whenever the candidate cell includes `draft_model`
 - `num_draft_tokens`
 - drafted token count, accepted token count, and acceptance rate when speculative decoding was attempted
 - candidate source, such as a static `draft_candidates[]` row, local operator override, or research fixture
@@ -101,31 +107,42 @@ For SPEC-028 speculative rows, a winner tuple MAY additionally include:
 (draft_model, draft_model_artifact_sha256, num_draft_tokens)
 ```
 
-When speculative decoding is enabled, `num_draft_tokens` MUST be selected per workload name. A single shared `num_draft_tokens` MAY be exported only as a legacy/default profile and MUST be derived from an explicit weighting policy.
+When speculative decoding is enabled, `num_draft_tokens` MUST be selected per workload name. A single shared `num_draft_tokens` MUST NOT be exported in v0.1 unless the report names the weighting policy and that policy is defined by a later SPEC revision or maintainer-approved run manifest.
 
-Any workload profile whose `recommended` object contains `draft_model` MUST satisfy all of the following:
+Candidate cells that cannot satisfy artifact/provenance, tokenizer, probe, or capacity preconditions are not runnable. Non-runnable speculative candidate cells MUST NOT produce a `recommended` object. A non-runnable candidate cell counts as evaluated for no-winner-reason selection and MUST be classified through the FR-6 reason precedence.
 
-- The target/draft pair came from a sweep or fixture that satisfied SPEC-028 FR-4 compatibility and provenance checks, or the profile is explicitly marked with `non_runnable_reason`.
-- `draft_model_artifact_sha256` is present for runnable profiles and is lowercase 64-hex.
+Any tier-scoped workload profile whose `recommended` object contains `draft_model` MUST satisfy all of the following:
+
+- The target/draft pair came from a sweep or fixture that satisfied SPEC-028 FR-4 compatibility and provenance checks.
+- `draft_model_artifact_sha256` is present and is lowercase 64-hex.
 - `num_draft_tokens` is an integer in the SPEC-028 range `1 <= N <= 16`.
 - `max_concurrency_override` is not greater than `1` for runnable SPEC-028 v0.1 profiles.
-- `max_context_override` does not exceed SPEC-028's effective draft-enabled context cap for the target RAM tier unless the profile is explicitly marked with `non_runnable_reason`.
+- `max_context_override` does not exceed SPEC-028's effective draft-enabled context cap for the profile's RAM-tier key.
 - The profile SHOULD reference the row's SPEC-028 `draft_candidates[]` entry when the candidate was selected from the static catalog.
+
+SPEC-029 RAM-tier keys map to SPEC-028 draft context caps as follows:
+
+| RAM-tier key | SPEC-028 draft context cap |
+|---|---:|
+| `8gb` | 8192 |
+| `16gb` | 20000 |
+| `32gb` | 50000 |
+| `64gb_plus` | 120000 |
 
 ### FR-5. Tie-breaking
 
-Tie-breaking MUST be class-local. No workload name may silently dominate another workload name's winner.
+Tie-breaking MUST be partition-local. No workload name or RAM-tier key may silently dominate another partition's winner.
 
-Within one workload name, the implementation MUST define deterministic tie-breakers. The recommended order for v0.1 is:
+Within one workload/RAM-tier pair, the implementation MUST define deterministic tie-breakers. The recommended order for v0.1 is:
 
 1. Zero hard failures and zero stop-token leaks.
 2. Satisfies workload-specific TTFT gate.
-3. Higher sustained throughput.
+3. Higher median throughput.
 4. Lower TTFT.
 5. Lower memory-risk posture, such as lower context or lower concurrency, when throughput is materially tied.
 6. Stable lexical order of serialized tuple as a final deterministic fallback.
 
-If a single legacy default is required, the default MUST be chosen from the per-workload winners using an explicit traffic-weighting policy documented in the report.
+Single legacy/default export is blocked in v0.1 until the authoritative traffic-weighting policy is resolved. Implementations MUST NOT export a single default derived from per-workload winners unless the report names the weighting policy and that policy is defined by a later SPEC revision or maintainer-approved run manifest.
 
 ### FR-6. Gates
 
@@ -133,16 +150,36 @@ Sweep gates MUST be parameterizable by workload name.
 
 The v0.1 default hard gate policy is:
 
-| Workload name | Hard max p95 TTFT | Hard stop-token leak rate | Notes |
-|---|---:|---:|---|
-| `short_chat` | 8000 ms | 0 | Uses the existing class-blind 8s TTFT posture. |
-| `medium_with_system` | 12000 ms | 0 | Allows additional prefill over short chat. |
-| `long_context` | 60000 ms | 0 | Allows long-context prefill; still fails pathological stalls. |
-| `code_completion` | 12000 ms | 0 | Keeps code continuation close to medium-chat latency. |
-| `agent_style` | 20000 ms | 0 | Allows larger system/tool-catalog prompt shape. |
-| `streaming_check` | 2000 ms | 0 | TTFT probe only; no serve-knob winner. |
+| Workload name | Min samples | Hard max p95 TTFT | Hard stop-token leak rate | Advisory min median TPS | Notes |
+|---|---:|---:|---:|---:|---|
+| `short_chat` | 20 | 8000 ms | 0 | none | Uses the existing class-blind 8s TTFT posture. |
+| `medium_with_system` | 20 | 12000 ms | 0 | none | Allows additional prefill over short chat. |
+| `long_context` | 20 | 60000 ms | 0 | none | Allows long-context prefill; still fails pathological stalls. |
+| `code_completion` | 20 | 12000 ms | 0 | none | Keeps code continuation close to medium-chat latency. |
+| `agent_style` | 20 | 20000 ms | 0 | none | Allows larger system/tool-catalog prompt shape. |
+| `streaming_check` | 20 | 2000 ms | 0 | none | TTFT probe only; no serve-knob winner. |
 
 Implementations MUST use these defaults unless a later SPEC or a maintainer-approved run manifest defines a replacement policy. Replacement policies MUST be serialized into the sweep report and static workload profile that used them.
+
+A workload/RAM-tier pair MUST NOT emit a winner unless the winning cell's successful sample count is at least the gate policy's `min_samples`. `profile_metrics.sample_count` on a winner profile MUST be the winning cell's successful sample count, not the aggregate count across every cell for that workload. When no winner is emitted, implementations MUST choose `no_winner_reason` by the precedence table below. On any no-winner profile, `profile_metrics.sample_count` MUST be the highest successful sample count observed for any candidate cell in that workload/RAM-tier pair, or `0` when no cell was evaluated. A maintainer-approved run manifest MAY replace p95 with observed maximum for a small exploratory run, but that run MUST NOT publish static-catalog workload recommendations.
+
+No-winner reasons are a closed vocabulary in v0.1:
+
+| Reason | Meaning |
+|---|---|
+| `insufficient_samples` | At least one candidate cell produced one or more successful samples, but no sampled cell reached `gate_policy.min_samples`. |
+| `gate_unmet` | At least one candidate cell reached `gate_policy.min_samples`, but none of the cells that reached `min_samples` passed all hard TTFT and stop-token leak gates. |
+| `hard_failure` | At least one candidate cell was evaluated, and every evaluated cell hard-failed: either non-runnable at preflight or hard-failed at runtime/request execution, so no cell produced a gate-eligible sample set. |
+| `no_cells_evaluated` | Zero candidate cells were evaluated for the workload/RAM-tier pair. |
+
+Non-runnable cells count as evaluated, but they are excluded from the `insufficient_samples` and `gate_unmet` sample-count conditions. In this table, "produced samples" means produced at least one successful, gate-eligible sample. A runtime-hard-failed cell is a cell that ran with zero successful samples. Such cells only determine `hard_failure` when every evaluated cell is non-runnable or otherwise hard-failing.
+
+When more than one no-winner reason could apply, implementations MUST use the first matching reason in this precedence order:
+
+1. `no_cells_evaluated`
+2. `hard_failure`
+3. `insufficient_samples`
+4. `gate_unmet`
 
 At minimum:
 
@@ -159,31 +196,42 @@ The static `autotune-candidates.json` schema MUST be extended additively inside 
 
 The v0.1 field name is `workload_profiles`. Implementations MUST NOT publish the same data under `per_class` in v0.1.
 
+`workload_profiles` is a two-level map keyed first by workload name and then by RAM-tier key:
+
+```text
+workload_profiles.<workload_name>.<ram_tier_key> -> tier-scoped workload profile
+```
+
+The tier key MUST be one of `8gb`, `16gb`, `32gb`, or `64gb_plus`. Winner and no-winner status is scoped to one workload/RAM-tier pair. Publishing a second tier for the same workload MUST add a sibling tier key, not overwrite the existing tier profile.
+
 ```json
 {
   "workload_profiles": {
     "code_completion": {
-      "recommended": {
-        "kv_bits": 4,
-        "max_context_override": 20000,
-        "max_concurrency_override": 1,
-        "draft_model": "example/draft",
-        "draft_model_artifact_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-        "num_draft_tokens": 4
-      },
-      "gate_policy": {
-        "max_p95_ttft_ms": 12000,
-        "max_stop_token_leak_rate": 0,
-        "min_sustained_tps": null
-      },
-      "profile_metrics": {
-        "median_tps": 8.5,
-        "p95_ttft_ms": 2400,
-        "stop_token_leak_rate": 0,
-        "spec_decode_acceptance_rate": 0.42,
-        "sample_count": 5
-      },
-      "source": "sweep-workload-class-2026-07"
+      "16gb": {
+        "recommended": {
+          "kv_bits": 4,
+          "max_context_override": 20000,
+          "max_concurrency_override": 1,
+          "draft_model": "example/draft",
+          "draft_model_artifact_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          "num_draft_tokens": 4
+        },
+        "gate_policy": {
+          "min_samples": 20,
+          "max_p95_ttft_ms": 12000,
+          "max_stop_token_leak_rate": 0,
+          "min_median_tps": null
+        },
+        "profile_metrics": {
+          "median_tps": 8.5,
+          "p95_ttft_ms": 2400,
+          "stop_token_leak_rate": 0,
+          "spec_decode_acceptance_rate": 0.42,
+          "sample_count": 20
+        },
+        "source": "sweep-workload-class-2026-07"
+      }
     }
   }
 }
@@ -191,7 +239,41 @@ The v0.1 field name is `workload_profiles`. Implementations MUST NOT publish the
 
 `gate_policy` records the hard policy used for winner selection. `profile_metrics` records measured/advisory metrics. The nested workload profile MUST NOT reuse the top-level SPEC-023 `bench_gate` key; SPEC-023 `bench_gate.min_sustained_tps` and `bench_gate.max_4k_ttft_ms` remain advisory QoS signals for the existing recommendation engine.
 
-`workload_profiles.<workload>.recommended` MUST use the same serve-knob names as SPEC-013/SPEC-028 config outputs. `profile_metrics` values MUST use milliseconds for TTFT, tokens per second for throughput, and a 0.0-1.0 fraction for rates. Nullable metrics MUST be encoded as JSON `null`, not omitted, when the sweep attempted the metric but the response path did not emit enough data.
+`workload_profiles.<workload>.<ram_tier>.recommended` MUST use the same serve-knob names as SPEC-013/SPEC-028 config outputs. `gate_policy.min_median_tps` is an optional/advisory floor over `profile_metrics.median_tps` and MUST be JSON `null` when no throughput floor was used for winner selection. `profile_metrics` values MUST use milliseconds for TTFT, tokens per second for throughput, and a 0.0-1.0 fraction for rates. Nullable metrics MUST be encoded as JSON `null`, not omitted, when the sweep attempted the metric but the response path did not emit enough data.
+
+No-winner workloads MUST be represented in `workload_profiles` with a sentinel object instead of being silently omitted:
+
+```json
+{
+  "workload_profiles": {
+    "long_context": {
+      "16gb": {
+        "status": "no_winner",
+        "no_winner_reason": "insufficient_samples",
+        "gate_policy": {
+          "min_samples": 20,
+          "max_p95_ttft_ms": 60000,
+          "max_stop_token_leak_rate": 0,
+          "min_median_tps": null
+        },
+        "profile_metrics": {
+          "median_tps": null,
+          "p95_ttft_ms": null,
+          "stop_token_leak_rate": null,
+          "spec_decode_acceptance_rate": null,
+          "sample_count": 3
+        },
+        "source": "sweep-workload-class-2026-07"
+      }
+    }
+  }
+}
+```
+
+Winner objects MUST either omit `status` or set `status` to `winner`. No-winner objects MUST omit `recommended`.
+On no-winner profiles, `profile_metrics.sample_count` MUST be populated as defined in FR-6, and all other `profile_metrics` fields MUST be JSON `null`; measured values from rejected cells remain in the sweep report rather than the signed static catalog sentinel.
+
+`streaming_check` is a probe/gate workload and is not part of the v0.1 `workload_profiles` winner/no-winner publication set.
 
 Current consumers MUST be able to ignore the additive field. Implementations MUST NOT require current installer recommendation clients to understand workload profiles until the client SPEC is updated.
 
@@ -217,11 +299,11 @@ Until that SPEC exists, implementations MUST NOT silently switch serve knobs per
 
 Existing class-blind sweep reports MAY remain unchanged. Implementations SHOULD write class-aware reports alongside existing reports, not overwrite historical artifacts.
 
-Reports MUST include enough metadata to reproduce winner selection, including search cells, workload name, gates, measured metrics, and tie-breaker reason.
+Reports MUST include enough metadata to reproduce winner selection, including search cells, workload name, host RAM bytes, RAM-tier key, gates, measured metrics, and tie-breaker reason.
 
 ## 5. Acceptance Criteria
 
-- AC-1: A class-aware sweep can run every included workload name over the configured grid and emit one winner/no-winner result per workload.
+- AC-1: A class-aware sweep can run every included workload name over the configured grid for an evaluated RAM-tier key and emit one winner/no-winner result per workload/RAM-tier pair, with `streaming_check` remaining probe-only.
 - AC-2: `streaming_check` contributes TTFT gate/report data but does not emit a serve-knob winner.
 - AC-3: Winner selection is deterministic and class-local.
 - AC-4: SPEC-028 speculative rows can select `num_draft_tokens` per workload name.
@@ -231,6 +313,10 @@ Reports MUST include enough metadata to reproduce winner selection, including se
 - AC-8: Reports cite workload-specific gates and tie-breaker outcomes.
 - AC-9: A decode/recommendation regression test proves current clients still accept a catalog row containing `workload_profiles`.
 - AC-10: `streaming_check` reports TTFT, status/error, leak state, and gate outcome even when token counts and throughput are `null` because SSE usage was absent.
+- AC-11: Class-aware artifacts record the complete FR-3 field set, including `metric_unavailable_reason` when applicable and speculative drafted/accepted/acceptance metrics when speculative decoding was attempted.
+- AC-12: No workload/RAM-tier pair emits a winner below `min_samples`; below-threshold pairs emit a `no_winner_reason`.
+- AC-13: Draft-bearing workload profiles are keyed by RAM tier and satisfy the SPEC-028 draft context cap for that tier.
+- AC-14: `no_winner_reason` is one of the closed v0.1 reason codes.
 
 ## 6. Open Questions
 
@@ -244,7 +330,7 @@ Reports MUST include enough metadata to reproduce winner selection, including se
 - `beta/report.py:59` summarizes rows per workload.
 - `beta/harness.py:59` records workload, latency, throughput, token, and leak fields.
 - `beta/DECISION_CRITERIA.md:57` through `beta/DECISION_CRITERIA.md:62` and `beta/DECISION_CRITERIA.md:89` through `beta/DECISION_CRITERIA.md:92` require per-workload decision metrics.
-- `specs/SPEC-028-mlx-speculative-decoding.md:63` defines `--num-draft-tokens`.
+- `specs/SPEC-028-mlx-speculative-decoding.md:71` defines `--num-draft-tokens`.
 - `specs/SPEC-028-mlx-speculative-decoding.md:202` through `specs/SPEC-028-mlx-speculative-decoding.md:215` allow autotune/static-catalog draft candidate extension points and reject blind grid multiplication.
 - `phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:439` decodes the current static catalog row shape.
 - `specs/SPEC-023-installer-autotune-recommend.md:320` through `specs/SPEC-023-installer-autotune-recommend.md:342` define the v4 static signing process.


### PR DESCRIPTION
## Status

**DRAFT — RESEARCH PROMPT ONLY, NO IMPLEMENTATION.** This PR contains only a Codex session prompt (`specs/RESEARCH_SWEEP_WORKLOAD_CLASS_PROMPT.md`) that stages the research + SPEC-drafting work. No code changes.

## Why this exists

`beta/workloads.py` has 6 named workload classes; `beta/report.py::summarize_per_workload` and `beta/DECISION_CRITERIA.md` already require per-workload metrics. **But the sweep grid is class-blind** — 7 contexts × 4 concurrency = 28 cells, no class axis. Autotune winners today are one compromise config across all workload shapes.

Critical timing: SPEC-028 (chain speculative decoding, v0.2 audited on `main`) is landing now. Draft-token acceptance rate is workload-dependent — reasoning cells gain +49% while code/RAG/long-ctx prefer chain. Without class-aware sweep, SPEC-028 ships with a single `--num-draft-tokens N` chosen as compromise. **Per-class sweep is the multiplier that makes SPEC-028 land at full strength.**

## What has to achieve to be considered implemented

Ordered gates from research through ship:

1. **Research session** runs the prompt in this PR and produces:
   - `docs/research/sweep-workload-class-2026-07.md` — research memo answering questions §A–E with code citations.
   - `specs/SPEC-XXX-sweep-workload-class-stratification.md` v0.1-draft — normative FRs (search-space shape, winner-picking under SPEC-028, autotune-candidates.json extension, class-parameterized gates), non-goals, open questions, measurable acceptance criteria.
   - `.omc/logs/sweep-workload-class-open-questions-2026-07.md` — ≤5 items blocked on human decision.

2. **SPEC audit** — SPEC v0.1-draft passes CODE + SECURITY + ARCHITECT audit lanes at 0-CRITICAL / 0-HIGH (mirrors the SPEC-015 v0.4 lock protocol).

3. **Implementation** (separate PR, gated on locked SPEC):
   - Sweep search space extended with workload_class dimension (grid-multiplication OR class-filter — SPEC decides).
   - Per-class winners published to `phase3-binary/dist/static/autotune-candidates.json` (or class-partitioned sibling) with matching signature under the current or new static key.
   - `beta/report.py` surfaces per-class winner metadata alongside existing aggregate.

4. **Measurable acceptance** (in the impl PR's tests):
   - Given a prompt from workload class W, provider is served with class-W-tuned knobs (routing mechanism deferred to a follow-up SPEC; this SPEC ships the DATA).
   - Sweep re-run on `air5` produces per-class winners that outperform the baseline single-config winner on tok/s or TTFT-p95 for at least 3 of the 6 workload classes.
   - No regression on the classes where the baseline single-config already wins.

## Do NOT (until gates 1+2 close)

- Modify sweep code, harness, autotune runtime, or `autotune-candidates.json`.
- Introduce a request-time workload classifier (called out as follow-up SPEC in the prompt).
- Modify SPEC-013 (CLI autotune) or SPEC-028 (speculative decoding) — this is a companion.

## Related

- Companion to SPEC-028 (speculative decoding, merged v0.2 at `a1be007`).
- Depends on: none.
- Blocked by: none.
- Blocks: none (this multiplier makes SPEC-028 stronger; not required for SPEC-028 to ship).
