### PR TITLE
Draft SPEC-029 losslessness probe

### DIFF
--- a/.omc/logs/losslessness-probe-open-questions-2026-07.md
+++ b/.omc/logs/losslessness-probe-open-questions-2026-07.md
@@ -1,0 +1,14 @@
+# SPEC-029 Open Questions
+
+**Date:** 2026-07-09
+**Branch:** `feat/losslessness-probe`
+
+These are the human-blocking items before SPEC-029 can move toward LOCK:
+
+1. **Threshold and K approval:** Approve or revise the draft TV thresholds and decide whether v0.1 accepts default `K=64` with `K=256` retry, or requires `K=256` for all stochastic probes.
+2. **Prompt corpus owner:** Assign an owner for the normative probe corpus and decide how corpus changes are versioned.
+3. **Telemetry surface:** Confirm that out-of-band `losslessness_probe_v1` telemetry is sufficient for v0.1 and that SPEC-015 v0.4 receipts remain unchanged.
+4. **Sanction scope:** Decide whether repeated losslessness failures affect only stochastic speculative-decoding eligibility or also general provider readiness.
+5. **Operational details:** Decide whether v0.1 needs an HTTP provider-control fallback, set retention/redaction rules for compact top-K evidence, and decide whether a future SPEC-015 v0.5 should bind a recent probe digest.
+
+Self-review result: no product-code changes proposed; SPEC-015 v0.4 receipt tuple and `usage` remain unchanged; SPEC-022 settlement semantics remain unchanged; buyer API remains unchanged; compute-integrity and covert canaries remain out of scope.

--- a/.omc/logs/losslessness-probe-open-questions-2026-07.md
+++ b/.omc/logs/losslessness-probe-open-questions-2026-07.md
@@ -3,12 +3,10 @@
 **Date:** 2026-07-09
 **Branch:** `feat/losslessness-probe`
 
-These are the human-blocking items before SPEC-029 can move toward LOCK:
+These are the remaining maintainer-input items before SPEC-029 can move toward LOCK:
 
-1. **Threshold and K approval:** Approve or revise the draft TV thresholds and decide whether v0.1 accepts default `K=64` with `K=256` retry, or requires `K=256` for all stochastic probes.
-2. **Prompt corpus owner:** Assign an owner for the normative probe corpus and decide how corpus changes are versioned.
-3. **Telemetry surface:** Confirm that out-of-band `losslessness_probe_v1` telemetry is sufficient for v0.1 and that SPEC-015 v0.4 receipts remain unchanged.
-4. **Sanction scope:** Decide whether repeated losslessness failures affect only stochastic speculative-decoding eligibility or also general provider readiness.
-5. **Operational details:** Decide whether v0.1 needs an HTTP provider-control fallback, set retention/redaction rules for compact top-K evidence, and decide whether a future SPEC-015 v0.5 should bind a recent probe digest.
+1. **Retention TTL:** Decide whether the default 30-day compact-evidence retention TTL should be shorter for public beta.
+2. **Future receipt binding:** Decide whether a future SPEC-015 v0.5 should bind a recent losslessness probe digest, without changing v0.4.
+3. **Maintainer approval:** MacProvider SPEC Maintainers must approve the v0.1 corpus, threshold table, calibration process, and SPEC-028 rollout consumer rule before LOCK.
 
 Self-review result: no product-code changes proposed; SPEC-015 v0.4 receipt tuple and `usage` remain unchanged; SPEC-022 settlement semantics remain unchanged; buyer API remains unchanged; compute-integrity and covert canaries remain out of scope.

--- a/docs/research/losslessness-probe-2026-07.md
+++ b/docs/research/losslessness-probe-2026-07.md
@@ -1,0 +1,295 @@
+# Losslessness Probe Research
+
+**Date:** 2026-07-09
+**Branch:** `feat/losslessness-probe`
+**Requested by:** `specs/RESEARCH_LOSSLESSNESS_PROBE_PROMPT.md`
+
+## Summary
+
+MacProvider should add an overt, coordinator-issued losslessness probe before any stochastic speculative-decoding rollout. The probe should not ride the buyer API, buyer receipts, or SPEC-015 v0.4 `usage` object. Those surfaces are intentionally strict: SPEC-028 keeps speculative-decoding telemetry out of receipts, and the coordinator plus external verifier reject any extra v0.4 tuple or usage keys.
+
+The safest v0.1 shape is:
+
+- Use the existing coordinator canary scheduler and sanction plumbing as the operational lane, but add a new `losslessness_probe_v1` profile instead of overloading nonce echo canaries.
+- Send probes out-of-band to providers through a dedicated WS/provider-control message, not as buyer-like `/v1/chat/completions` traffic.
+- Ask providers for compact per-position distributions for plain target decoding and speculative decoding. The provider returns top-K normalized probabilities plus residual tail mass; the coordinator recomputes total-variation distance.
+- Default to `K=64`, retry at `K=256` when tail mass or threshold proximity makes the result inconclusive, and do not rely on repeated sampled-token counts as the quarantine-grade mechanism.
+- Rotate temperature settings across `{0.2, 0.5, 0.7, 1.0}` with `top_p=1.0`; keep `temperature=0.0` as a control for token-exact greedy equality.
+- Publish probe results as out-of-band coordinator telemetry keyed by provider, model hash, draft model id, sampling profile, and probe id. Future SPEC-015 receipt versions may optionally bind a digest, but this research does not recommend changing v0.4 receipts.
+
+This keeps the probe compatible with SPEC-028's buyer-invisible, provider-side optimization posture while giving the coordinator a quantitative gate for stochastic speculative decoding.
+
+## Sources Checked
+
+Local code/spec anchors:
+
+- SPEC-028 scope and invariants: `specs/SPEC-028-mlx-speculative-decoding.md:11`, `:38-47`, `:136-164`, `:166-181`, `:183-195`.
+- SPEC-015 receipt strictness: `specs/SPEC-015-receipts.md:1-4`, `:3804-3816`, `:4051-4062`, `:4742`.
+- Coordinator settlement verifier strict keys: `phase4-coordinator/internal/billing/settlement_verifier.go:35-49`, `:321-354`, `:365-403`.
+- External verifier strict keys: `phase7-verify/internal/verify/settlement.go:40-71`, `:417-445`.
+- Buyer request validation/routing: `phase4-coordinator/internal/buyer/server.go:1445-1514`, `:1602-1644`, `:4167-4202`, `:4750-4868`.
+- Existing coordinator canary config and loop: `phase4-coordinator/internal/config/config.go:255-265`; `phase4-coordinator/internal/ws/server.go:1827-1878`, `:1902-2100`.
+- Existing canary sanction state: `phase4-coordinator/internal/pool/provider.go:908-970`.
+- Provider request defaults and prompt hash fields: `phase3-binary/Sources/MacProviderCore/ChatCompletionRequest.swift:47-55`, `:205-239`; `phase3-binary/Sources/macprovider-cli/PromptCanonicalizer.swift:4-24`.
+- Provider generation path: `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:700-716`, `:850-866`, `:1297-1310`.
+- Provider model-snapshot/warm-swap receipt binding: `phase3-binary/Sources/macprovider-cli/HTTPServer.swift:238-321`, `:556-585`, `:743-755`, `:852-875`.
+
+External anchors:
+
+- Shard `specpipe.py`, distribution canary concept: <https://raw.githubusercontent.com/leyten/shard/master/phase0/specpipe.py>.
+- `mlx-swift-lm` 3.31.4 `Evaluate.swift`, sampler and speculative iterator shape: <https://raw.githubusercontent.com/ml-explore/mlx-swift-lm/3.31.4/Libraries/MLXLMCommon/Evaluate.swift>.
+- Leviathan, Kalman, and Matias, "Fast Inference from Transformers via Speculative Decoding": <https://arxiv.org/abs/2211.17192>.
+- Chen et al., "Accelerating Large Language Model Decoding with Speculative Sampling": <https://arxiv.org/abs/2302.01318>.
+- Wei and Dudley, "Two-sample Dvoretzky-Kiefer-Wolfowitz inequalities": <https://collaborate.princeton.edu/en/publications/two-sample-dvoretzky-kiefer-wolfowitz-inequalities>.
+
+## A. Canary Issuance Mechanism
+
+### Existing surface
+
+MacProvider already has a coordinator-side canary lane. Config exposes canary enablement, cadence, timeout, max tokens, failure threshold, and challenge templates. The WS server starts a canary loop when pool canaries are enabled, schedules jittered sweeps, dispatches probes, compares returned content against an expected string, and records pass/fail into the provider registry. After thresholded failures, provisional providers become unavailable and pinned providers degrade through canary recovery holds.
+
+That machinery is useful for scheduling, rate limiting, and state transitions. The current canary body, however, is an echo challenge: it builds a normal chat request with a nonce prompt and expects a fixed text response. Losslessness needs a different probe type because the coordinator must compare distributions, not exact challenge text.
+
+### Recommended v0.1 issuance
+
+Add a distinct `losslessness_probe_v1` canary profile under the existing coordinator canary subsystem:
+
+1. The coordinator selects ready providers with speculative decoding enabled and a known `(target_model_hash, draft_model_id)` pair.
+2. It sends one probe per selected `(provider_id, assigned_id, model_id, target_model_hash, draft_model_id, sampling_profile)` per cadence slot.
+3. It rotates sampling profiles over the day instead of issuing every temperature on every cadence.
+4. It writes a result event and only feeds provider sanctions when the result is a confirmed losslessness failure, not when the provider reports `inconclusive`.
+
+Default cadence should be light enough not to become synthetic load:
+
+| Scope | Default |
+|---|---:|
+| Provider/model probe interval | 60 minutes |
+| Temperature profiles per interval | 1 rotating profile |
+| Full grid coverage | Every 24 hours per provider/model/draft pair |
+| Probe max positions | 8 measured decode positions |
+| Probe max prompt corpus entries | 4 prompts per result event |
+| Per-provider concurrent probes | 1 |
+
+The cadence should reuse the current canary jitter pattern so probes do not synchronize across the fleet.
+
+### Temperature profile
+
+SPEC-028 currently permits speculative decoding only for deterministic greedy requests. The losslessness probe exists to decide whether stochastic speculative decoding can later be allowed. It therefore must cover non-zero temperatures even before product traffic does.
+
+Recommended grid:
+
+- Control: `temperature=0.0`, `top_p=1.0`, greedy token-id equality.
+- Stochastic: `temperature in {0.2, 0.5, 0.7, 1.0}`, `top_p=1.0`.
+- Later extension: `top_p in {0.9, 0.95}` after the top-p sampler path is instrumented.
+
+The provider request parser already defaults `temperature` and `top_p` to `1.0`, validates `temperature` in `[0.0, 2.0]`, and validates `top_p` in `[0.0, 1.0]`. The provider generation path forwards both values into `GenerateParameters`. The probe should therefore report results per `(temperature, top_p)` rather than collapsing all sampling modes into one pass/fail.
+
+## B. Output Representation
+
+### Why sampled output is not enough
+
+Shard's `specpipe.py` uses a useful research pattern: compare plain target, speculative target, and a second plain baseline at the same content position, then judge whether plain-versus-spec distance is near the plain-versus-plain Monte Carlo noise floor. That is valuable for a research harness and for detecting large stochastic drift. It is not ideal as the default quarantine-grade MacProvider mechanism because repeated sampled-token tests need many draws to distinguish small total-variation deltas with high confidence.
+
+For a finite K-bin categorical comparison, a conservative Hoeffding union bound over two empirical histograms is:
+
+```text
+P(max_i |p_hat_i - p_i| > delta) <= 2K exp(-2n delta^2)
+TV(p_hat, p) <= K * delta / 2
+```
+
+Solving this for small epsilon and moderate K produces expensive probes. For example, `K=64`, `epsilon=0.03`, and `alpha=0.01` require tens of thousands of draws per distribution under this loose bound. Even sharper two-sample DKW-style bounds do not make sampled-token probing cheap enough for frequent fleet health checks at small epsilon.
+
+### Recommended representation
+
+Use compact probability snapshots, not generated samples, as the normative v0.1 result:
+
+```json
+{
+  "probe_version": "losslessness_probe_v1",
+  "probe_id": "2026-07-09T12:00:00Z/provider-a/...",
+  "model_id": "mlx-community/...",
+  "target_model_hash": "sha256:...",
+  "draft_model_id": "mlx-community/...",
+  "temperature": 0.7,
+  "top_p": 1.0,
+  "positions": [
+    {
+      "index": 0,
+      "context_hash": "sha256:...",
+      "plain_topk": [{"token_id": 123, "p": 0.201}],
+      "plain_tail_mass": 0.006,
+      "spec_topk": [{"token_id": 123, "p": 0.199}],
+      "spec_tail_mass": 0.007,
+      "plain_plain_baseline_topk": [{"token_id": 123, "p": 0.202}],
+      "plain_plain_baseline_tail_mass": 0.006
+    }
+  ]
+}
+```
+
+The coordinator recomputes:
+
+```text
+support = union(topk_token_ids(plain), topk_token_ids(spec))
+TV_bound = 0.5 * (
+  sum_{token in support} |p_plain(token) - p_spec(token)|
+  + |plain_tail_mass - spec_tail_mass|
+)
+```
+
+This is a bound over the reported support plus residual tail mass. It avoids leaking raw logits and avoids treating provider-supplied scalar verdicts as authoritative. The provider may include a scalar for local debugging, but the coordinator's recomputation is canonical.
+
+### K/N choice
+
+Recommended K:
+
+- Start with `K=64`.
+- Require each side to report residual tail mass.
+- Mark a position `inconclusive:tail_mass_high` when either tail mass exceeds `0.01`.
+- Retry inconclusive or near-threshold probes with `K=256` and a stricter `0.005` tail target.
+- If `K=256` still has high tail mass, preserve the event as inconclusive and do not sanction.
+
+Recommended N:
+
+- `N=0` for the normative top-K probability path.
+- Optional `sample_n=2000` only for a research or calibration lane that uses a plain/spec/plain baseline. This can expose gross implementation drift but should not be the v0.1 quarantine source.
+
+The top-K path still needs numerical tolerance. `mlx-swift-lm` uses `ArgMaxSampler` when temperature is zero and otherwise applies sampling filters such as top-p/top-k/min-p before categorical sampling. The probe should capture probabilities after applying the same sampling profile that production stochastic decoding would use.
+
+## C. TV-Distance Computation And Thresholds
+
+### Computation ownership
+
+The coordinator should own verdict computation:
+
+- It knows the provider id, assigned id, state, current sanctions, and probe cadence.
+- It can enforce consistent thresholds across providers.
+- It can retry with larger K before sanctioning.
+- It can persist raw compact evidence for audit without trusting a provider-side scalar.
+
+The provider should own only the model-local measurement primitive: for each prompt position, run the plain target path and the speculative target path under the requested sampling profile and return compact distributions.
+
+### Status categories
+
+Use four categories:
+
+| Category | Meaning |
+|---|---|
+| `pass` | All measured positions are under the profile threshold with acceptable tail mass. |
+| `warn` | Drift exceeds warning threshold, but not enough to quarantine; or baseline is missing. |
+| `quarantine_candidate` | Drift exceeds the quarantine threshold after retry with larger K and stable model snapshot. |
+| `inconclusive` | Tail mass too high, provider swapped model mid-probe, timeout, unsupported sampler, missing telemetry, or transient probe failure. |
+
+### Threshold proposal
+
+Thresholds should be profile-specific and require a local reference baseline before they can trigger sanctions. Initial values:
+
+| Metric | Warning | Quarantine candidate |
+|---|---:|---:|
+| Median `TV_bound` across positions | `> 0.02` | `> 0.05` |
+| Any single high-entropy position `TV_bound` | `> 0.05` | `> 0.10` |
+| Tail mass after K=256 retry | `> 0.005` | inconclusive, not quarantine |
+
+High-entropy positions should be chosen because low-entropy positions can pass trivially. The prompt corpus should include short general chat, code completion, instruction following, and tool-call-like JSON contexts, then select measurement positions where the target distribution is not nearly deterministic.
+
+Sanction gating:
+
+1. A first `quarantine_candidate` emits a warning and schedules an immediate retry.
+2. A second consecutive `quarantine_candidate` for the same `(provider_id, assigned_id, target_model_hash, draft_model_id, sampling_profile)` may feed the existing canary failure counter.
+3. The existing thresholded canary sanction path can then degrade pinned providers or mark provisional providers unavailable.
+4. `inconclusive` does not increment the canary failure counter.
+
+This matches the current registry's thresholded failure model while preventing one noisy probe from removing a provider.
+
+## D. Publishing Surface
+
+### Do not modify SPEC-015 v0.4 receipts
+
+SPEC-015 v0.4 settlement receipts have a strict 23-field tuple and a strict five-key `usage` object. The coordinator billing verifier and external verifier both enforce exact key sets and reject extra usage fields with `usage_shape_invalid`. SPEC-028 also explicitly says speculative-decoding accepted/drafted tokens are telemetry, not billable usage, and that SPEC-028 must not add fields to the SPEC-015 v0.4 settlement `usage`.
+
+Therefore the losslessness probe must not add:
+
+- `losslessness_probe_status` to v0.4 receipts.
+- `spec_decode_losslessness_tv` to v0.4 `usage`.
+- Any extra buyer response field that a settlement verifier might later treat as receipt-bound usage evidence.
+
+### Recommended v0.1 surface
+
+Publish out-of-band coordinator telemetry:
+
+```json
+{
+  "event_type": "losslessness_probe_v1",
+  "probe_id": "uuid-or-jcs-hash",
+  "provider_id": "provider-a",
+  "assigned_id": "assignment-id",
+  "model_id": "mlx-community/...",
+  "target_model_hash": "sha256:...",
+  "draft_model_id": "mlx-community/...",
+  "sampling_profile": {"temperature": 0.7, "top_p": 1.0, "top_k": null},
+  "k": 64,
+  "status": "pass",
+  "median_tv_bound": 0.011,
+  "max_tv_bound": 0.018,
+  "max_tail_mass": 0.004,
+  "positions_measured": 8,
+  "created_at": "2026-07-09T12:00:00Z"
+}
+```
+
+Storage should be coordinator-owned, queryable by operations, and optionally surfaced in aggregate provider status. Buyers do not need per-request visibility while stochastic speculative decoding is still gated. If a future buyer-facing receipt must bind the result, create a future SPEC-015 v0.5 field such as `losslessness_probe_result_digest`; do not retrofit v0.4.
+
+## E. Temperature Handling
+
+Temperature is a first-class part of the probe key. Current provider code parses and validates it, prompt canonicalization preserves the original request fields, and generation passes it into `mlx-swift-lm`.
+
+The probe should define these rules:
+
+- `temperature=0.0` is a greedy control. The expected invariant is token-id equality between plain and speculative decoding for the measured positions.
+- `temperature>0.0` is measured by total-variation distance over the next-token categorical distribution after the requested sampler profile.
+- Results are never aggregated across temperatures for a pass/fail verdict.
+- The coordinator may display a provider-level aggregate, but sanctions must use the exact sampling profile.
+- `top_p=1.0` is the v0.1 default. Top-p values below one should be a v0.2 extension because the probe must capture probabilities after truncation, not before.
+
+This aligns with SPEC-028's current greedy-only production gate and gives maintainers evidence to decide whether a future `--allow-stochastic-spec-decode` flag is safe.
+
+## F. Warm-Swap Interaction
+
+Warm-swap and probe verdicts need explicit state handling. The provider HTTP path already captures model snapshots for serving and receipt binding, and SPEC-028 requires counters to reset on target-swap boundaries. A losslessness probe must be keyed to the same target model identity.
+
+Recommended rules:
+
+- A probe request includes the coordinator's expected `target_model_hash`.
+- The provider returns the actual snapshot hash used for every measured position.
+- If the provider swaps target model or draft model during the probe, the result is `inconclusive:model_swap`.
+- A model swap triggers an immediate probe for the new `(target_model_hash, draft_model_id)` pair after the provider reports ready and draft compatibility checked.
+- Old probe results do not carry forward across target-swap boundaries.
+- Draft-load failure after a target swap leaves the provider serving without stochastic spec decode and emits `inconclusive:draft_unavailable` or `warn:draft_disabled`, not a losslessness failure.
+
+Failing loudly as inconclusive is better than silently invalidating the result because operations need to see swap churn and because a stale pass must not authorize stochastic decoding for a new model snapshot.
+
+## G. Covert Canary Seam
+
+The v0.1 probe is overt: providers know they are being tested. That is acceptable for a first stochastic-losslessness gate because the main risk is an implementation bug or sampler mismatch, not a malicious provider optimizing only canary requests.
+
+A future covert canary would require a different seam:
+
+- Buyer-like traffic issued by coordinator-controlled accounts without a special provider-control message.
+- No canary-specific headers, probe ids, or obvious prompt corpus.
+- Private scoring after the response, using receipt/prompt hashes and a hidden challenge schedule.
+- Budget controls so covert probes do not distort buyer billing or provider payout.
+- A separate abuse model because malicious providers can still identify low-entropy or repeated prompt families.
+
+That design crosses into buyer API, billing, and settlement semantics. It should remain out of scope for losslessness probe v0.1 and be handled in a later spec.
+
+## Recommendation
+
+Draft SPEC-029 as a narrow, overt, out-of-band probe:
+
+- It extends coordinator canaries with a new probe profile and telemetry event.
+- It does not change SPEC-015 v0.4 receipts, SPEC-022 settlement, SPEC-028 receipt invariants, buyer API fields, or billable usage.
+- It uses coordinator-recomputed top-K plus tail TV bounds rather than provider-provided scalar verdicts.
+- It treats warm-swap, high tail mass, missing sampler support, and timeouts as inconclusive.
+- It requires repeated confirmed failures before feeding the current canary sanction path.
+
+The main remaining human decisions are threshold ownership, whether K=64/K=256 is acceptable for v0.1, whether out-of-band telemetry is sufficient for rollout governance, and which prompt corpus becomes normative.

--- a/docs/research/losslessness-probe-2026-07.md
+++ b/docs/research/losslessness-probe-2026-07.md
@@ -10,9 +10,9 @@ MacProvider should add an overt, coordinator-issued losslessness probe before an
 
 The safest v0.1 shape is:
 
-- Use the existing coordinator canary scheduler and sanction plumbing as the operational lane, but add a new `losslessness_probe_v1` profile instead of overloading nonce echo canaries.
+- Use the existing coordinator canary scheduler, jitter, retry, and persistence plumbing as the operational lane, but keep losslessness-specific eligibility and disablement state instead of overloading nonce echo canary sanctions.
 - Send probes out-of-band to providers through a dedicated WS/provider-control message, not as buyer-like `/v1/chat/completions` traffic.
-- Ask providers for compact per-position distributions for plain target decoding and speculative decoding. The provider returns top-K normalized probabilities plus residual tail mass; the coordinator recomputes total-variation distance.
+- Ask providers for compact per-position distributions for plain target decoding and speculative decoding. The provider returns full-distribution probabilities over shared support plus residual tail mass; the coordinator recomputes `tv_lower` and `tv_upper`.
 - Default to `K=64`, retry at `K=256` when tail mass or threshold proximity makes the result inconclusive, and do not rely on repeated sampled-token counts as the quarantine-grade mechanism.
 - Rotate temperature settings across `{0.2, 0.5, 0.7, 1.0}` with `top_p=1.0`; keep `temperature=0.0` as a control for token-exact greedy equality.
 - Publish probe results as out-of-band coordinator telemetry keyed by provider, model hash, draft model id, sampling profile, and probe id. Future SPEC-015 receipt versions may optionally bind a digest, but this research does not recommend changing v0.4 receipts.
@@ -116,9 +116,12 @@ Use compact probability snapshots, not generated samples, as the normative v0.1 
     {
       "index": 0,
       "context_hash": "sha256:...",
-      "plain_topk": [{"token_id": 123, "p": 0.201}],
+      "plain_top_k_token_ids": [123],
+      "spec_top_k_token_ids": [123],
+      "support_token_ids": [123],
+      "plain_support": [{"token_id": 123, "p": 0.201}],
       "plain_tail_mass": 0.006,
-      "spec_topk": [{"token_id": 123, "p": 0.199}],
+      "spec_support": [{"token_id": 123, "p": 0.199}],
       "spec_tail_mass": 0.007,
       "plain_plain_baseline_topk": [{"token_id": 123, "p": 0.202}],
       "plain_plain_baseline_tail_mass": 0.006
@@ -131,13 +134,19 @@ The coordinator recomputes:
 
 ```text
 support = union(topk_token_ids(plain), topk_token_ids(spec))
-TV_bound = 0.5 * (
-  sum_{token in support} |p_plain(token) - p_spec(token)|
+support_diff = sum_{token in support} |p_plain(token) - p_spec(token)|
+tv_lower = 0.5 * (
+  support_diff
   + |plain_tail_mass - spec_tail_mass|
+)
+tv_upper = 0.5 * (
+  support_diff
+  + plain_tail_mass
+  + spec_tail_mass
 )
 ```
 
-This is a bound over the reported support plus residual tail mass. It avoids leaking raw logits and avoids treating provider-supplied scalar verdicts as authoritative. The provider may include a scalar for local debugging, but the coordinator's recomputation is canonical.
+`tv_lower` is the minimum total-variation distance consistent with shared-support probabilities plus aggregate tail masses, and `tv_upper` is the conservative upper bound. Pass decisions use `tv_upper`; quarantine decisions use `tv_lower`. This avoids leaking raw logits and avoids treating provider-supplied scalar verdicts as authoritative. The provider may include a scalar for local debugging, but the coordinator's recomputation is canonical.
 
 ### K/N choice
 
@@ -186,8 +195,8 @@ Thresholds should be profile-specific and require a local reference baseline bef
 
 | Metric | Warning | Quarantine candidate |
 |---|---:|---:|
-| Median `TV_bound` across positions | `> 0.02` | `> 0.05` |
-| Any single high-entropy position `TV_bound` | `> 0.05` | `> 0.10` |
+| Median `tv_upper` / `tv_lower` across positions | warn when `tv_upper > 0.01` | quarantine when `tv_lower > 0.05` |
+| Any single high-entropy position `tv_upper` / `tv_lower` | warn when `tv_upper > 0.02` | quarantine when `tv_lower > 0.10` |
 | Tail mass after K=256 retry | `> 0.005` | inconclusive, not quarantine |
 
 High-entropy positions should be chosen because low-entropy positions can pass trivially. The prompt corpus should include short general chat, code completion, instruction following, and tool-call-like JSON contexts, then select measurement positions where the target distribution is not nearly deterministic.
@@ -195,11 +204,11 @@ High-entropy positions should be chosen because low-entropy positions can pass t
 Sanction gating:
 
 1. A first `quarantine_candidate` emits a warning and schedules an immediate retry.
-2. A second consecutive `quarantine_candidate` for the same `(provider_id, assigned_id, target_model_hash, draft_model_id, sampling_profile)` may feed the existing canary failure counter.
-3. The existing thresholded canary sanction path can then degrade pinned providers or mark provisional providers unavailable.
-4. `inconclusive` does not increment the canary failure counter.
+2. A second consecutive `quarantine_candidate` for the same `(provider_id, assigned_id, target_model_hash, draft_model_id, draft_artifact_binding, draft_generation, sampling_profile, corpus_version, threshold_version)` disables only stochastic speculative decoding for that exact key.
+3. Losslessness failures remain isolated from echo-canary/general provider-readiness counters and from non-speculative provider availability.
+4. `inconclusive` uses losslessness-specific retry/block handling and does not increment the echo-canary/general provider-readiness counter.
 
-This matches the current registry's thresholded failure model while preventing one noisy probe from removing a provider.
+This can reuse canary scheduler, jitter, retry, and persistence plumbing, but the eligibility state and counters remain losslessness-specific so a noisy or failing probe cannot remove a provider from non-speculative traffic.
 
 ## D. Publishing Surface
 
@@ -229,8 +238,10 @@ Publish out-of-band coordinator telemetry:
   "sampling_profile": {"temperature": 0.7, "top_p": 1.0, "top_k": null},
   "k": 64,
   "status": "pass",
-  "median_tv_bound": 0.011,
-  "max_tv_bound": 0.018,
+  "median_tv_lower": 0.006,
+  "max_tv_lower": 0.009,
+  "median_tv_upper": 0.011,
+  "max_tv_upper": 0.018,
   "max_tail_mass": 0.004,
   "positions_measured": 8,
   "created_at": "2026-07-09T12:00:00Z"
@@ -264,7 +275,7 @@ Recommended rules:
 - If the provider swaps target model or draft model during the probe, the result is `inconclusive:model_swap`.
 - A model swap triggers an immediate probe for the new `(target_model_hash, draft_model_id)` pair after the provider reports ready and draft compatibility checked.
 - Old probe results do not carry forward across target-swap boundaries.
-- Draft-load failure after a target swap leaves the provider serving without stochastic spec decode and emits `inconclusive:draft_unavailable` or `warn:draft_disabled`, not a losslessness failure.
+- Draft-load failure after a target swap leaves the provider serving without stochastic spec decode and emits `inconclusive:draft_unavailable` or `inconclusive:draft_identity_unbound`, not a losslessness failure.
 
 Failing loudly as inconclusive is better than silently invalidating the result because operations need to see swap churn and because a stale pass must not authorize stochastic decoding for a new model snapshot.
 
@@ -288,8 +299,8 @@ Draft SPEC-029 as a narrow, overt, out-of-band probe:
 
 - It extends coordinator canaries with a new probe profile and telemetry event.
 - It does not change SPEC-015 v0.4 receipts, SPEC-022 settlement, SPEC-028 receipt invariants, buyer API fields, or billable usage.
-- It uses coordinator-recomputed top-K plus tail TV bounds rather than provider-provided scalar verdicts.
+- It uses coordinator-recomputed shared-support plus tail TV lower/upper bounds rather than provider-provided scalar verdicts.
 - It treats warm-swap, high tail mass, missing sampler support, and timeouts as inconclusive.
-- It requires repeated confirmed failures before feeding the current canary sanction path.
+- It requires repeated confirmed failures before disabling only the exact losslessness profile key; it never feeds the echo-canary sanction counter or general provider-readiness path.
 
 The main remaining human decisions are threshold ownership, whether K=64/K=256 is acceptable for v0.1, whether out-of-band telemetry is sufficient for rollout governance, and which prompt corpus becomes normative.

--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -60,6 +60,7 @@ public struct AppConfig: Equatable, Sendable {
     public var kvBitsOverride: Int?
     public var drainTimeoutSeconds: Int
     public var warmupEnabled: Bool
+    public var losslessnessProbeEnabled: Bool
     public var maxRequestBodyBytes: Int
     public var tier2MDAArtifactPath: String?
     public var supportedModels: [String]?
@@ -139,6 +140,7 @@ public struct AppConfig: Equatable, Sendable {
             kvBitsOverride: nil,
             drainTimeoutSeconds: 30,
             warmupEnabled: true,
+            losslessnessProbeEnabled: false,
             maxRequestBodyBytes: 10 * 1024 * 1024,
             tier2MDAArtifactPath: nil,
             supportedModels: nil,
@@ -378,6 +380,7 @@ public enum ConfigLoader {
         try assign(&config.kvBitsOverride, from: dict, key: "kv_bits", expected: "integer (4 or 8)")
         try assign(&config.drainTimeoutSeconds, from: dict, key: "drain_timeout_s", expected: "integer")
         try assign(&config.warmupEnabled, from: dict, key: "warmup_enabled", expected: "boolean")
+        try assign(&config.losslessnessProbeEnabled, from: dict, key: "losslessness_probe_enabled", expected: "boolean")
         try assign(&config.maxRequestBodyBytes, from: dict, key: "max_request_body_bytes", expected: "integer")
         try assign(&config.tier2MDAArtifactPath, from: dict, key: "tier2_mda_artifact_path", expected: "string")
         try assign(&config.supportedModels, from: dict, key: "supported_models", expected: "array of strings or comma-separated string")
@@ -430,6 +433,7 @@ public enum ConfigLoader {
         try assign(&config.kvBitsOverride, from: environment, env: "MACPROVIDER_KV_BITS", expected: "integer (4 or 8)")
         try assign(&config.drainTimeoutSeconds, from: environment, env: "MACPROVIDER_DRAIN_TIMEOUT_S", expected: "integer")
         try assign(&config.warmupEnabled, from: environment, env: "MACPROVIDER_WARMUP_ENABLED", expected: "boolean")
+        try assign(&config.losslessnessProbeEnabled, from: environment, env: "MACPROVIDER_LOSSLESSNESS_PROBE_ENABLED", expected: "boolean")
         try assign(&config.maxRequestBodyBytes, from: environment, env: "MACPROVIDER_MAX_REQUEST_BODY_BYTES", expected: "integer")
         try assign(&config.tier2MDAArtifactPath, from: environment, env: "MACPROVIDER_TIER2_MDA_ARTIFACT_PATH", expected: "string")
         config.supportedModels = SupportedModels.parseCSV(environment["MACPROVIDER_SUPPORTED_MODELS"]) ?? config.supportedModels

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -1130,6 +1130,8 @@ actor CoordinatorClient {
                 return
             }
             try await inferenceRelay.handleInferenceRequest(dict)
+        case LosslessnessProbeProtocol.requestType, LosslessnessProbeProtocol.encryptedRequestType:
+            try await handleLosslessnessProbeRequest(dict)
         case "cancel_request":
             guard wsTunneledMode, let inferenceRelay else {
                 try await sendNAK(
@@ -1158,6 +1160,84 @@ actor CoordinatorClient {
                 code: "unknown_message_type",
                 message: "Unrecognized message type: '\(type)'"
             )
+        }
+    }
+
+    private func handleLosslessnessProbeRequest(_ message: [String: Any]) async throws {
+        guard appConfig.losslessnessProbeEnabled else {
+            try await sendNAK(
+                inReplyTo: message["type"] as? String ?? LosslessnessProbeProtocol.requestType,
+                code: "losslessness_probe_disabled",
+                message: "losslessness_probe_v1 is disabled by provider config"
+            )
+            return
+        }
+
+        do {
+            try await handleEnabledLosslessnessProbeRequest(message)
+        } catch is LosslessnessProbeError {
+            try await sendNAK(
+                inReplyTo: message["type"] as? String ?? LosslessnessProbeProtocol.requestType,
+                code: "invalid_message",
+                message: "invalid losslessness_probe_v1 request"
+            )
+        } catch is Tier2ProviderError {
+            try await sendNAK(
+                inReplyTo: message["type"] as? String ?? LosslessnessProbeProtocol.requestType,
+                code: "invalid_message",
+                message: "invalid losslessness_probe_v1 encrypted request"
+            )
+        }
+    }
+
+    private func handleEnabledLosslessnessProbeRequest(_ message: [String: Any]) async throws {
+        let encrypted = message["type"] as? String == LosslessnessProbeProtocol.encryptedRequestType
+        let outer: [String: Any]
+        var encryptedRequestID: String?
+        if encrypted {
+            guard let tier2Session,
+                  let requestID = message["request_id"] as? String, !requestID.isEmpty
+            else {
+                try await sendNAK(inReplyTo: LosslessnessProbeProtocol.encryptedRequestType, code: "invalid_message", message: "losslessness encrypted request requires Tier-2 session and request_id")
+                return
+            }
+            encryptedRequestID = requestID
+            outer = try tier2Session.openLosslessnessProbeRequestPayload(message: message, requestID: requestID).outerEnvelope
+        } else {
+            if tier2Session != nil {
+                try await sendNAK(inReplyTo: LosslessnessProbeProtocol.requestType, code: "invalid_message", message: "losslessness plaintext request rejected for active Tier-2 session")
+                return
+            }
+            outer = message
+        }
+
+        let requestEnvelope = try LosslessnessProbeProtocol.decodeEnvelope(outer, expectedType: LosslessnessProbeProtocol.requestType)
+        let requestPayload = try LosslessnessProbeProtocol.decodeRequestPayload(requestEnvelope.payload)
+        if let encryptedRequestID, encryptedRequestID != requestEnvelope.probeID {
+            try await sendNAK(inReplyTo: LosslessnessProbeProtocol.encryptedRequestType, code: "invalid_message", message: "losslessness encrypted request_id must match probe_id")
+            return
+        }
+        let inconclusive = LosslessnessProbeRuntime.providerInconclusiveForUnavailableSampler(
+            probeID: requestEnvelope.probeID,
+            probeNonce: requestPayload.probeNonce,
+            requestDigest: requestEnvelope.probeRequestDigest
+        )
+        let resultDigest = try LosslessnessProbeProtocol.digest(payload: inconclusive)
+        let resultOuter: [String: Any] = [
+            "type": LosslessnessProbeProtocol.resultType,
+            "probe_id": requestEnvelope.probeID,
+            "probe_request_digest": requestEnvelope.probeRequestDigest,
+            "probe_result_digest": resultDigest,
+            "payload": inconclusive,
+        ]
+
+        if encrypted {
+            guard let tier2Session else {
+                throw LosslessnessProbeError.invalidEnvelope
+            }
+            try await send(tier2Session.sealLosslessnessProbeResult(requestID: encryptedRequestID ?? requestEnvelope.probeID, outerEnvelope: resultOuter))
+        } else {
+            try await send(resultOuter)
         }
     }
 

--- a/phase3-binary/Sources/macprovider-cli/LosslessnessProbeProtocol.swift
+++ b/phase3-binary/Sources/macprovider-cli/LosslessnessProbeProtocol.swift
@@ -1,0 +1,272 @@
+import CryptoKit
+import Foundation
+
+enum LosslessnessProbeProtocol {
+    static let version = "losslessness_probe_v1"
+    static let requestType = "losslessness_probe_v1.request"
+    static let resultType = "losslessness_probe_v1.result"
+    static let encryptedRequestType = "losslessness_probe_v1.encrypted_request"
+    static let encryptedResultType = "losslessness_probe_v1.encrypted_result"
+    static let requestPlaintextType = "losslessness_probe_v1.request_plaintext"
+    static let resultPlaintextType = "losslessness_probe_v1.result_plaintext"
+    static let supportSelection = "support_selection_v1"
+    static let normalizationBasis = "full_distribution"
+    static let samplerStage = "post_processors_post_sampling_profile_next_emitted_token"
+
+    static let allowedProviderInconclusiveReasons: Set<String> = [
+        "inconclusive:model_swap",
+        "inconclusive:unsupported_sampler",
+        "inconclusive:draft_unavailable",
+        "inconclusive:position_mismatch",
+        "inconclusive:missing_distribution",
+        "inconclusive:timeout",
+    ]
+
+    struct Envelope {
+        let type: String
+        let probeID: String
+        let probeRequestDigest: String
+        let probeResultDigest: String?
+        let payload: [String: Any]
+    }
+
+    struct ProviderInconclusive {
+        let probeID: String
+        let probeNonce: String
+        let probeRequestDigest: String
+        let reasonCode: String
+        let identityUnavailableReason: String?
+    }
+
+    struct RequestPayload {
+        let probeID: String
+        let probeNonce: String
+    }
+
+    static func digest(payload: [String: Any]) throws -> String {
+        let value = try jcsValue(from: payload)
+        let canonical = try RFC8785JCS.canonicalStringRawStrings(value)
+        let digest = SHA256.hash(data: Data(canonical.utf8))
+        return "sha256:" + digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func decodeEnvelope(_ raw: [String: Any], expectedType: String) throws -> Envelope {
+        guard raw["type"] as? String == expectedType,
+              let probeID = raw["probe_id"] as? String, !probeID.isEmpty,
+              let probeRequestDigest = raw["probe_request_digest"] as? String,
+              let payload = raw["payload"] as? [String: Any]
+        else {
+            throw LosslessnessProbeError.invalidEnvelope
+        }
+        let probeResultDigest = raw["probe_result_digest"] as? String
+        let computed = try digest(payload: payload)
+        if expectedType == requestType, computed != probeRequestDigest {
+            throw LosslessnessProbeError.digestMismatch
+        }
+        if expectedType == resultType, computed != probeResultDigest {
+            throw LosslessnessProbeError.digestMismatch
+        }
+        guard payload["probe_id"] as? String == probeID else {
+            throw LosslessnessProbeError.invalidEnvelope
+        }
+        if expectedType == resultType, payload["probe_request_digest"] as? String != probeRequestDigest {
+            throw LosslessnessProbeError.invalidEnvelope
+        }
+        return Envelope(
+            type: expectedType,
+            probeID: probeID,
+            probeRequestDigest: probeRequestDigest,
+            probeResultDigest: probeResultDigest,
+            payload: payload
+        )
+    }
+
+    static func decodeProviderInconclusive(_ payload: [String: Any]) throws -> ProviderInconclusive {
+        guard payload["result_kind"] as? String == "provider_inconclusive",
+              let probeID = payload["probe_id"] as? String, !probeID.isEmpty,
+              let probeNonce = payload["probe_nonce"] as? String, !probeNonce.isEmpty,
+              let requestDigest = payload["probe_request_digest"] as? String,
+              let reason = payload["provider_reason_code"] as? String
+        else {
+            throw LosslessnessProbeError.invalidPayload
+        }
+        guard allowedProviderInconclusiveReasons.contains(reason) else {
+            throw LosslessnessProbeError.unsupportedProviderReason(reason)
+        }
+        guard payload.keys.contains("target_model_hash"),
+              payload.keys.contains("target_generation"),
+              payload.keys.contains("draft_artifact_binding"),
+              payload.keys.contains("draft_generation") else {
+            throw LosslessnessProbeError.invalidPayload
+        }
+        let identityKnown = payload["target_model_hash"] as? String != nil &&
+            intValue(payload["target_generation"]).map { $0 > 0 } == true &&
+            payload["draft_artifact_binding"] as? [String: Any] != nil &&
+            intValue(payload["draft_generation"]).map { $0 > 0 } == true
+        let identityUnavailable = payload["target_model_hash"] is NSNull &&
+            payload["target_generation"] is NSNull &&
+            payload["draft_artifact_binding"] is NSNull &&
+            payload["draft_generation"] is NSNull &&
+            (payload["identity_unavailable_reason"] as? String)?.isEmpty == false
+        if !identityKnown && !identityUnavailable {
+            throw LosslessnessProbeError.invalidPayload
+        }
+        return ProviderInconclusive(
+            probeID: probeID,
+            probeNonce: probeNonce,
+            probeRequestDigest: requestDigest,
+            reasonCode: reason,
+            identityUnavailableReason: payload["identity_unavailable_reason"] as? String
+        )
+    }
+
+    static func decodeRequestPayload(_ payload: [String: Any]) throws -> RequestPayload {
+        guard payload["probe_version"] as? String == version,
+              let probeID = payload["probe_id"] as? String, !probeID.isEmpty,
+              let nonce = payload["probe_nonce"] as? String, !nonce.isEmpty,
+              let expiresAt = payload["expires_at"] as? String, ISO8601DateFormatter().date(from: expiresAt) != nil,
+              let modelID = payload["model_id"] as? String, !modelID.isEmpty,
+              let targetHash = payload["target_model_hash"] as? String, !targetHash.isEmpty,
+              let targetGeneration = intValue(payload["target_generation"]), targetGeneration > 0,
+              let draftModelID = payload["draft_model_id"] as? String, !draftModelID.isEmpty,
+              let draftBinding = payload["draft_artifact_binding"] as? [String: Any],
+              let draftBindingModelID = draftBinding["draft_model_id"] as? String, !draftBindingModelID.isEmpty,
+              let draftSHA = draftBinding["draft_artifact_sha256"] as? String, !draftSHA.isEmpty,
+              let bindingTokenizer = draftBinding["tokenizer_identity"] as? String, !bindingTokenizer.isEmpty,
+              let compatibility = draftBinding["compatibility_check_digest"] as? String, !compatibility.isEmpty,
+              let draftGeneration = intValue(payload["draft_generation"]), draftGeneration > 0,
+              let tokenizer = payload["tokenizer_identity"] as? String, !tokenizer.isEmpty,
+              let samplingProfile = payload["sampling_profile"] as? [String: Any],
+              numberPresent(samplingProfile["temperature"]),
+              numberPresent(samplingProfile["top_p"]),
+              let corpusVersion = payload["corpus_version"] as? String, !corpusVersion.isEmpty,
+              let thresholdVersion = payload["threshold_version"] as? String, !thresholdVersion.isEmpty,
+              let prompts = payload["prompts"] as? [[String: Any]], !prompts.isEmpty, prompts.count <= 4,
+              let positions = payload["measurement_positions"] as? [Any], !positions.isEmpty, positions.count <= 8,
+              let requestedK = intValue(payload["requested_k"]), requestedK == 64 || requestedK == 256,
+              payload["support_selection"] as? String == supportSelection,
+              let maxPrompts = intValue(payload["max_prompts"]), maxPrompts > 0, maxPrompts <= 4, prompts.count <= maxPrompts,
+              let maxPositions = intValue(payload["max_stochastic_positions"]), maxPositions > 0, maxPositions <= 8, positions.count <= maxPositions,
+              intValue(payload["timeout_ms"]) == 60_000 else {
+            throw LosslessnessProbeError.invalidPayload
+        }
+        for prompt in prompts {
+            guard prompt["prompt_id"] as? String != nil,
+                  prompt["prompt"] as? String != nil,
+                  prompt["coordinator_owned"] as? Bool == true,
+                  prompt["buyer_origin"] as? Bool == false else {
+                throw LosslessnessProbeError.invalidPayload
+            }
+        }
+        for position in positions {
+            guard let number = intValue(position), number >= 0 else {
+                throw LosslessnessProbeError.invalidPayload
+            }
+        }
+        return RequestPayload(probeID: probeID, probeNonce: nonce)
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if isJSONBool(value) {
+            return nil
+        }
+        if let int = value as? Int {
+            return int
+        }
+        if let number = value as? NSNumber {
+            let double = number.doubleValue
+            guard double.isFinite, double.rounded(.towardZero) == double else {
+                return nil
+            }
+            return number.intValue
+        }
+        return nil
+    }
+
+    private static func numberPresent(_ value: Any?) -> Bool {
+        if isJSONBool(value) {
+            return false
+        }
+        if value is NSNumber {
+            return true
+        }
+        return value is Double || value is Int
+    }
+
+    private static func isJSONBool(_ value: Any?) -> Bool {
+        if let number = value as? NSNumber {
+            return CFGetTypeID(number) == CFBooleanGetTypeID() || String(cString: number.objCType) == "c"
+        }
+        return value is Bool
+    }
+
+    static func validateMeasurementPosition(_ position: [String: Any]) throws {
+        guard position["support_selection"] as? String == supportSelection,
+              position["normalization_basis"] as? String == normalizationBasis,
+              position["sampler_stage"] as? String == samplerStage
+        else {
+            throw LosslessnessProbeError.malformedDistribution
+        }
+    }
+
+    static func jcsValue(from input: Any) throws -> RFC8785JCS.Value {
+        if let object = input as? [String: Any] {
+            var members: [String: RFC8785JCS.Value] = [:]
+            for (key, value) in object {
+                members[key] = try jcsValue(from: value)
+            }
+            return .object(members)
+        }
+        if let array = input as? [Any] {
+            return .array(try array.map { try jcsValue(from: $0) })
+        }
+        if let string = input as? String {
+            return .string(string)
+        }
+        if input is NSNull {
+            return .null
+        }
+        if let number = input as? NSNumber {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return .bool(number.boolValue)
+            }
+            let type = String(cString: number.objCType)
+            if type == "d" || type == "f" {
+                return .double(number.doubleValue)
+            }
+            guard let int = Int(exactly: number.int64Value) else {
+                throw LosslessnessProbeError.invalidPayload
+            }
+            return .int(int)
+        }
+        throw LosslessnessProbeError.invalidPayload
+    }
+}
+
+enum LosslessnessProbeError: Error, Equatable {
+    case digestMismatch
+    case invalidEnvelope
+    case invalidPayload
+    case malformedDistribution
+    case unsupportedProviderReason(String)
+    case samplerHookUnavailable
+}
+
+enum LosslessnessProbeRuntime {
+    static let samplerStage = LosslessnessProbeProtocol.samplerStage
+
+    static func providerInconclusiveForUnavailableSampler(probeID: String, probeNonce: String, requestDigest: String) -> [String: Any] {
+        [
+            "probe_id": probeID,
+            "probe_nonce": probeNonce,
+            "probe_request_digest": requestDigest,
+            "result_kind": "provider_inconclusive",
+            "provider_reason_code": "inconclusive:unsupported_sampler",
+            "target_model_hash": NSNull(),
+            "target_generation": NSNull(),
+            "draft_artifact_binding": NSNull(),
+            "draft_generation": NSNull(),
+            "identity_unavailable_reason": "full-distribution MLX sampler hook is not available in the current runtime",
+        ]
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/RFC8785JCS.swift
+++ b/phase3-binary/Sources/macprovider-cli/RFC8785JCS.swift
@@ -15,6 +15,14 @@ enum RFC8785JCS {
     }
 
     static func canonicalString(_ value: Value) throws -> String {
+        try canonicalString(value, normalizeStrings: true)
+    }
+
+    static func canonicalStringRawStrings(_ value: Value) throws -> String {
+        try canonicalString(value, normalizeStrings: false)
+    }
+
+    private static func canonicalString(_ value: Value, normalizeStrings: Bool) throws -> String {
         switch value {
         case .object(let object):
             let keys = object.keys.sorted(by: utf16LexicographicLess)
@@ -22,13 +30,13 @@ enum RFC8785JCS {
                 guard let member = object[key] else {
                     throw Error.missingObjectMember(key)
                 }
-                return "\(escapeString(key, normalizeNFC: false)):\(try canonicalString(member))"
+                return "\(escapeString(key, normalizeNFC: false)):\(try canonicalString(member, normalizeStrings: normalizeStrings))"
             }
             return "{\(members.joined(separator: ","))}"
         case .array(let array):
-            return try "[\(array.map { try canonicalString($0) }.joined(separator: ","))]"
+            return try "[\(array.map { try canonicalString($0, normalizeStrings: normalizeStrings) }.joined(separator: ","))]"
         case .string(let string):
-            return escapeString(string, normalizeNFC: true)
+            return escapeString(string, normalizeNFC: normalizeStrings)
         case .rawString(let string):
             return escapeString(string, normalizeNFC: false)
         case .int(let int):

--- a/phase3-binary/Sources/macprovider-cli/Tier2ProviderSession.swift
+++ b/phase3-binary/Sources/macprovider-cli/Tier2ProviderSession.swift
@@ -21,6 +21,10 @@ final class Tier2ProviderSession: @unchecked Sendable {
         let conversationKey: String?
     }
 
+    struct LosslessnessProbePayload {
+        let outerEnvelope: [String: Any]
+    }
+
     let providerID: String
     let assignedID: String
     let selectedAEAD: String
@@ -153,6 +157,74 @@ final class Tier2ProviderSession: @unchecked Sendable {
         )
     }
 
+    func openLosslessnessProbeRequestPayload(message: [String: Any], requestID: String) throws -> LosslessnessProbePayload {
+        guard message["type"] as? String == LosslessnessProbeProtocol.encryptedRequestType,
+              message["encrypted"] as? Bool == true,
+              message["stream"] as? Bool == false,
+              let enc = message["enc"] as? [String: Any]
+        else {
+            throw Tier2ProviderError.invalidEnvelope
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        let seq = c2pCounter
+        let aad = Tier2FrameAAD(
+            type: LosslessnessProbeProtocol.encryptedRequestType,
+            direction: "c2p",
+            requestID: requestID,
+            stream: false,
+            providerID: providerID,
+            assignedID: assignedID,
+            seq: seq
+        )
+        let plaintext = try Self.openEnvelope(enc, key: c2pKey, nonceBase: c2pNonceBase, keyID: keyID, expectedAAD: aad, expectedSeq: seq)
+        c2pCounter += 1
+        guard let envelope = try? JSONSerialization.jsonObject(with: plaintext) as? [String: Any],
+              envelope["type"] as? String == LosslessnessProbeProtocol.requestPlaintextType,
+              let payload = envelope["payload"] as? [String: Any] else {
+            throw Tier2ProviderError.invalidPlaintext
+        }
+        return LosslessnessProbePayload(outerEnvelope: payload)
+    }
+
+    func sealLosslessnessProbeResult(requestID: String, outerEnvelope: [String: Any]) throws -> [String: Any] {
+        let plaintext = try JSONSerialization.data(
+            withJSONObject: [
+                "type": LosslessnessProbeProtocol.resultPlaintextType,
+                "payload": outerEnvelope,
+            ],
+            options: [.sortedKeys]
+        )
+        lock.lock()
+        defer { lock.unlock() }
+        let seq = p2cCounter
+        let aad = Tier2FrameAAD(
+            type: LosslessnessProbeProtocol.encryptedResultType,
+            direction: "p2c",
+            requestID: requestID,
+            stream: false,
+            providerID: providerID,
+            assignedID: assignedID,
+            seq: seq
+        )
+        let enc = try Self.sealEnvelope(
+            plaintext,
+            key: p2cKey,
+            nonceBase: p2cNonceBase,
+            keyID: keyID,
+            aad: aad,
+            seq: seq
+        )
+        p2cCounter += 1
+        return [
+            "type": LosslessnessProbeProtocol.encryptedResultType,
+            "request_id": requestID,
+            "stream": false,
+            "encrypted": true,
+            "enc": enc,
+        ]
+    }
+
     func sealResponseChunk(requestID: String, stream: Bool, seq: Int, plaintext: String) throws -> [String: Any] {
         lock.lock()
         defer { lock.unlock() }
@@ -258,6 +330,63 @@ final class Tier2ProviderSession: @unchecked Sendable {
             "encrypted": true,
             "enc": enc,
         ]
+    }
+
+    static func sealLosslessnessRequestForTest(session: Tier2ProviderSession, requestID: String, outerEnvelope: [String: Any], seq: UInt64 = 0) throws -> [String: Any] {
+        let aad = Tier2FrameAAD(
+            type: LosslessnessProbeProtocol.encryptedRequestType,
+            direction: "c2p",
+            requestID: requestID,
+            stream: false,
+            providerID: session.providerID,
+            assignedID: session.assignedID,
+            seq: seq
+        )
+        let plaintextEnvelope: [String: Any] = [
+            "type": LosslessnessProbeProtocol.requestPlaintextType,
+            "payload": outerEnvelope,
+        ]
+        let plaintextData = try JSONSerialization.data(withJSONObject: plaintextEnvelope, options: [.sortedKeys])
+        let enc = try sealEnvelope(
+            plaintextData,
+            key: session.c2pKey,
+            nonceBase: session.c2pNonceBase,
+            keyID: session.keyID,
+            aad: aad,
+            seq: seq
+        )
+        return [
+            "type": LosslessnessProbeProtocol.encryptedRequestType,
+            "request_id": requestID,
+            "stream": false,
+            "encrypted": true,
+            "enc": enc,
+        ]
+    }
+
+    static func openLosslessnessResultForTest(session: Tier2ProviderSession, frame: [String: Any], requestID: String, seq: UInt64 = 0) throws -> [String: Any] {
+        guard frame["type"] as? String == LosslessnessProbeProtocol.encryptedResultType,
+              frame["encrypted"] as? Bool == true,
+              frame["stream"] as? Bool == false,
+              let enc = frame["enc"] as? [String: Any] else {
+            throw Tier2ProviderError.invalidEnvelope
+        }
+        let aad = Tier2FrameAAD(
+            type: LosslessnessProbeProtocol.encryptedResultType,
+            direction: "p2c",
+            requestID: requestID,
+            stream: false,
+            providerID: session.providerID,
+            assignedID: session.assignedID,
+            seq: seq
+        )
+        let plaintext = try openEnvelope(enc, key: session.p2cKey, nonceBase: session.p2cNonceBase, keyID: session.keyID, expectedAAD: aad, expectedSeq: seq)
+        guard let envelope = try JSONSerialization.jsonObject(with: plaintext) as? [String: Any],
+              envelope["type"] as? String == LosslessnessProbeProtocol.resultPlaintextType,
+              let payload = envelope["payload"] as? [String: Any] else {
+            throw Tier2ProviderError.invalidPlaintext
+        }
+        return payload
     }
 
     static func openResponseChunkForTest(session: Tier2ProviderSession, frame: [String: Any], requestID: String, stream: Bool, seq: UInt64 = 0) throws -> String {

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -85,6 +85,100 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertEqual(frames[0]["estimated_wait_ms"] as? Int, 0)
     }
 
+    func testEncryptedLosslessnessProbeRejectsCarrierRequestIDMismatch() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: recorder, losslessnessProbeEnabled: true)
+        let session = try Tier2ProviderSession(
+            providerID: "provider-test",
+            assignedID: "assigned-v2",
+            selectedAEAD: Tier2ProviderSession.aeadSuite,
+            keyID: "kid-test",
+            c2pKey: Data(repeating: 0x11, count: 32),
+            p2cKey: Data(repeating: 0x22, count: 32),
+            c2pNonceBase: Data(repeating: 0x33, count: 4),
+            p2cNonceBase: Data(repeating: 0x44, count: 4)
+        )
+        try await client.acceptAuthResponseForTest([
+            "type": "auth_response",
+            "version": 2,
+            "status": "accepted",
+            "assigned_id": "assigned-v2",
+            "heartbeat_interval_s": 30,
+            "tier2_session": [
+                "encrypted_leg": [
+                    "enabled": true,
+                    "alg": Tier2ProviderSession.aeadSuite,
+                    "kid": "kid-test",
+                ],
+            ],
+        ], session: session)
+
+        let payload: [String: Any] = [
+            "probe_version": LosslessnessProbeProtocol.version,
+            "probe_id": "payload-probe",
+            "probe_nonce": "00112233445566778899aabbccddeeff",
+            "expires_at": "2026-07-09T12:01:00Z",
+            "model_id": "model-a",
+            "target_model_hash": "sha256:target",
+            "target_generation": 1,
+            "draft_model_id": "draft-a",
+            "draft_artifact_binding": [
+                "draft_model_id": "draft-a",
+                "draft_artifact_sha256": "sha256:draft",
+                "tokenizer_identity": "tok-v1",
+                "compatibility_check_digest": "sha256:compat",
+            ],
+            "draft_generation": 1,
+            "tokenizer_identity": "tok-v1",
+            "sampling_profile": [
+                "temperature": 0.7,
+                "top_p": 1.0,
+            ],
+            "corpus_version": "corpus-v1",
+            "threshold_version": "threshold-v1",
+            "prompts": [
+                [
+                    "prompt_id": "synthetic-1",
+                    "prompt": "Synthetic coordinator-owned prompt.",
+                    "coordinator_owned": true,
+                    "buyer_origin": false,
+                ],
+            ],
+            "measurement_positions": [4],
+            "requested_k": 64,
+            "support_selection": LosslessnessProbeProtocol.supportSelection,
+            "max_prompts": 4,
+            "max_stochastic_positions": 8,
+            "timeout_ms": 60_000,
+        ]
+        let digest = try LosslessnessProbeProtocol.digest(payload: payload)
+        let outer: [String: Any] = [
+            "type": LosslessnessProbeProtocol.requestType,
+            "probe_id": "payload-probe",
+            "probe_request_digest": digest,
+            "payload": payload,
+        ]
+        let encrypted = try Tier2ProviderSession.sealLosslessnessRequestForTest(
+            session: session,
+            requestID: "carrier-probe",
+            outerEnvelope: outer
+        )
+
+        try await client.handleCoordinatorPayloadForTest(encrypted)
+
+        let frames = await recorder.frames
+        let nak = try XCTUnwrap(frames.last)
+        XCTAssertEqual(nak["type"] as? String, "nak")
+        XCTAssertEqual(nak["in_reply_to"] as? String, LosslessnessProbeProtocol.encryptedRequestType)
+        let error = try XCTUnwrap(nak["error"] as? [String: Any])
+        XCTAssertEqual(error["code"] as? String, "invalid_message")
+    }
+
     func testDrainWithNoInflightSendsCompleteAndResetsReady() async throws {
         let recorder = CoordinatorFrameRecorder()
         let status = ProviderStatus(
@@ -2240,7 +2334,8 @@ final class CoordinatorClientTests: XCTestCase {
         sendOverride: CoordinatorClient.SendOverride? = nil,
         watchdogExitHook: (@Sendable (String) -> Void)? = nil,
         publishesSpecDecodeTelemetry: Bool = false,
-        modelCatalogModelID: String? = nil
+        modelCatalogModelID: String? = nil,
+        losslessnessProbeEnabled: Bool = false
     ) async throws -> CoordinatorClient {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
         config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
@@ -2250,6 +2345,7 @@ final class CoordinatorClientTests: XCTestCase {
         config.drainTimeoutSeconds = drainTimeoutSeconds
         config.enableWarmSwap = enableWarmSwap
         config.publishesSpecDecodeTelemetry = publishesSpecDecodeTelemetry
+        config.losslessnessProbeEnabled = losslessnessProbeEnabled
         let runtime: ModelRuntime
         if let modelRuntime {
             runtime = modelRuntime

--- a/phase3-binary/Tests/macprovider-cliTests/LosslessnessProbeProtocolTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/LosslessnessProbeProtocolTests.swift
@@ -1,0 +1,261 @@
+import Foundation
+import XCTest
+import MacProviderCore
+@testable import macprovider_cli
+
+final class LosslessnessProbeProtocolTests: XCTestCase {
+    func testDigestFixturesMatchSwiftJCS() throws {
+        for fixture in try Self.loadFixtures() {
+            let digest = try LosslessnessProbeProtocol.digest(payload: fixture.payload)
+            XCTAssertEqual(digest, fixture.expectedSHA256, fixture.id)
+        }
+    }
+
+    func testEnvelopeDigestUsesInnerPayloadOnly() throws {
+        let request = try XCTUnwrap(try Self.loadFixtures().first { $0.id == "request_payload" })
+        let outer: [String: Any] = [
+            "type": LosslessnessProbeProtocol.requestType,
+            "probe_id": "probe-fixture-001",
+            "probe_request_digest": request.expectedSHA256,
+            "payload": request.payload,
+            "outer_debug_field": "not part of digest",
+        ]
+        let decoded = try LosslessnessProbeProtocol.decodeEnvelope(outer, expectedType: LosslessnessProbeProtocol.requestType)
+        XCTAssertEqual(decoded.probeID, "probe-fixture-001")
+        XCTAssertNotEqual(try LosslessnessProbeProtocol.digest(payload: outer), request.expectedSHA256)
+
+        var mismatchedOuter = outer
+        mismatchedOuter["probe_id"] = "outer-mismatch"
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeEnvelope(mismatchedOuter, expectedType: LosslessnessProbeProtocol.requestType)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .invalidEnvelope)
+        }
+    }
+
+    func testRejectsProviderInconclusiveUnknownReason() throws {
+        var payload = try XCTUnwrap(try Self.loadFixtures().first { $0.id == "provider_inconclusive_payload" }).payload
+        XCTAssertEqual(try LosslessnessProbeProtocol.decodeProviderInconclusive(payload).reasonCode, "inconclusive:unsupported_sampler")
+        payload["provider_reason_code"] = "inconclusive:invented_prose"
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeProviderInconclusive(payload)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .unsupportedProviderReason("inconclusive:invented_prose"))
+        }
+        payload["provider_reason_code"] = "inconclusive:identity_mismatch"
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeProviderInconclusive(payload)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .unsupportedProviderReason("inconclusive:identity_mismatch"))
+        }
+        payload["provider_reason_code"] = "inconclusive:unsupported_sampler"
+        payload.removeValue(forKey: "target_model_hash")
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeProviderInconclusive(payload)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .invalidPayload)
+        }
+        payload["target_model_hash"] = NSNull()
+        payload["target_generation"] = 1
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeProviderInconclusive(payload)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .invalidPayload)
+        }
+        payload["provider_reason_code"] = "inconclusive:unsupported_sampler"
+        payload["target_model_hash"] = "sha256:target"
+        payload["target_generation"] = 1
+        payload["draft_artifact_binding"] = [
+            "draft_model_id": "draft-a",
+            "draft_artifact_sha256": "sha256:draft",
+            "tokenizer_identity": "tok-v1",
+            "compatibility_check_digest": "sha256:compat",
+        ]
+        payload["draft_generation"] = 1
+        payload.removeValue(forKey: "identity_unavailable_reason")
+        XCTAssertNoThrow(try LosslessnessProbeProtocol.decodeProviderInconclusive(payload))
+    }
+
+    func testRequestPayloadRequiresSpec029Shape() throws {
+        let request = try XCTUnwrap(try Self.loadFixtures().first { $0.id == "request_payload" }).payload
+        XCTAssertNoThrow(try LosslessnessProbeProtocol.decodeRequestPayload(request))
+        var missingExpiry = request
+        missingExpiry.removeValue(forKey: "expires_at")
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeRequestPayload(missingExpiry)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .invalidPayload)
+        }
+        var buyerPrompt = request
+        var prompts = try XCTUnwrap(buyerPrompt["prompts"] as? [[String: Any]])
+        prompts[0]["buyer_origin"] = true
+        buyerPrompt["prompts"] = prompts
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeRequestPayload(buyerPrompt)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .invalidPayload)
+        }
+        var booleanGeneration = request
+        booleanGeneration["target_generation"] = true
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeRequestPayload(booleanGeneration)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .invalidPayload)
+        }
+        var fractionalGeneration = request
+        fractionalGeneration["target_generation"] = 1.5
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeRequestPayload(fractionalGeneration)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .invalidPayload)
+        }
+        var fractionalPosition = request
+        fractionalPosition["measurement_positions"] = [1.5]
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeRequestPayload(fractionalPosition)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .invalidPayload)
+        }
+        var booleanSamplingProfile = request
+        var samplingProfile = try XCTUnwrap(booleanSamplingProfile["sampling_profile"] as? [String: Any])
+        samplingProfile["temperature"] = true
+        booleanSamplingProfile["sampling_profile"] = samplingProfile
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeRequestPayload(booleanSamplingProfile)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .invalidPayload)
+        }
+        var tooManyForDeclaredMax = request
+        tooManyForDeclaredMax["max_prompts"] = 1
+        tooManyForDeclaredMax["prompts"] = [
+            ["prompt_id": "p1", "prompt": "one", "coordinator_owned": true, "buyer_origin": false],
+            ["prompt_id": "p2", "prompt": "two", "coordinator_owned": true, "buyer_origin": false],
+        ]
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.decodeRequestPayload(tooManyForDeclaredMax)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .invalidPayload)
+        }
+    }
+
+    func testMeasurementPositionRequiresNormativeSamplerStage() throws {
+        let valid: [String: Any] = [
+            "support_selection": LosslessnessProbeProtocol.supportSelection,
+            "normalization_basis": LosslessnessProbeProtocol.normalizationBasis,
+            "sampler_stage": LosslessnessProbeProtocol.samplerStage,
+        ]
+        XCTAssertNoThrow(try LosslessnessProbeProtocol.validateMeasurementPosition(valid))
+        var invalid = valid
+        invalid["sampler_stage"] = "sampled_token_histogram"
+        XCTAssertThrowsError(try LosslessnessProbeProtocol.validateMeasurementPosition(invalid)) { error in
+            XCTAssertEqual(error as? LosslessnessProbeError, .malformedDistribution)
+        }
+    }
+
+    func testTier2CarrierUsesDedicatedLosslessnessTypes() throws {
+        let session = try Tier2ProviderSession(
+            providerID: "provider-test",
+            assignedID: "assigned-test",
+            selectedAEAD: Tier2ProviderSession.aeadSuite,
+            keyID: "kid-test",
+            c2pKey: Data(repeating: 0x31, count: 32),
+            p2cKey: Data(repeating: 0x42, count: 32),
+            c2pNonceBase: Data([0x01, 0x02, 0x03, 0x04]),
+            p2cNonceBase: Data([0x05, 0x06, 0x07, 0x08])
+        )
+        let request = try XCTUnwrap(try Self.loadFixtures().first { $0.id == "request_payload" })
+        let outer: [String: Any] = [
+            "type": LosslessnessProbeProtocol.requestType,
+            "probe_id": "probe-fixture-001",
+            "probe_request_digest": request.expectedSHA256,
+            "payload": request.payload,
+        ]
+        let encrypted = try Tier2ProviderSession.sealLosslessnessRequestForTest(
+            session: session,
+            requestID: "probe-fixture-001",
+            outerEnvelope: outer
+        )
+        XCTAssertEqual(encrypted["type"] as? String, LosslessnessProbeProtocol.encryptedRequestType)
+        XCTAssertEqual(encrypted["stream"] as? Bool, false)
+        XCTAssertEqual(try session.openLosslessnessProbeRequestPayload(message: encrypted, requestID: "probe-fixture-001").outerEnvelope["type"] as? String, LosslessnessProbeProtocol.requestType)
+
+        let resultOuter: [String: Any] = [
+            "type": LosslessnessProbeProtocol.resultType,
+            "probe_id": "probe-fixture-001",
+            "probe_request_digest": request.expectedSHA256,
+            "probe_result_digest": "sha256:result",
+            "payload": ["probe_id": "probe-fixture-001"],
+        ]
+        let sealedResult = try session.sealLosslessnessProbeResult(requestID: "probe-fixture-001", outerEnvelope: resultOuter)
+        XCTAssertEqual(sealedResult["type"] as? String, LosslessnessProbeProtocol.encryptedResultType)
+        let openedResult = try Tier2ProviderSession.openLosslessnessResultForTest(
+            session: session,
+            frame: sealedResult,
+            requestID: "probe-fixture-001"
+        )
+        XCTAssertEqual(openedResult["type"] as? String, LosslessnessProbeProtocol.resultType)
+    }
+
+    func testTier2ProbeRejectsInferenceRequestCarrier() throws {
+        let session = try Tier2ProviderSession(
+            providerID: "provider-test",
+            assignedID: "assigned-test",
+            selectedAEAD: Tier2ProviderSession.aeadSuite,
+            keyID: "kid-test",
+            c2pKey: Data(repeating: 0x31, count: 32),
+            p2cKey: Data(repeating: 0x42, count: 32),
+            c2pNonceBase: Data([0x01, 0x02, 0x03, 0x04]),
+            p2cNonceBase: Data([0x05, 0x06, 0x07, 0x08])
+        )
+        let inferenceCarrier = try Tier2ProviderSession.sealRequestForTest(
+            session: session,
+            requestID: "probe-fixture-001",
+            stream: false,
+            plaintext: #"{"type":"losslessness_probe_v1.request"}"#
+        )
+        XCTAssertThrowsError(try session.openLosslessnessProbeRequestPayload(message: inferenceCarrier, requestID: "probe-fixture-001"))
+    }
+
+    func testConfigLoaderDefaultsProbeCapabilityOffAndReadsYAMLEnv() throws {
+        XCTAssertFalse(AppConfig.defaults().losslessnessProbeEnabled)
+
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let configURL = dir.appendingPathComponent("config.yaml")
+        try "losslessness_probe_enabled: true\n".write(to: configURL, atomically: true, encoding: .utf8)
+        let fromYAML = try ConfigLoader.load(cli: CLIOverrides(configPath: configURL.path), environment: [:])
+        XCTAssertTrue(fromYAML.losslessnessProbeEnabled)
+
+        let fromEnv = try ConfigLoader.load(
+            cli: CLIOverrides(configPath: configURL.path),
+            environment: ["MACPROVIDER_LOSSLESSNESS_PROBE_ENABLED": "true"]
+        )
+        XCTAssertTrue(fromEnv.losslessnessProbeEnabled)
+    }
+
+    func testUnavailableSamplerBuildsProviderInconclusiveWithoutReceiptFields() throws {
+        let payload = LosslessnessProbeRuntime.providerInconclusiveForUnavailableSampler(
+            probeID: "probe-no-hook",
+            probeNonce: "00112233445566778899aabbccddeeff",
+            requestDigest: "sha256:req"
+        )
+        XCTAssertEqual(payload["result_kind"] as? String, "provider_inconclusive")
+        XCTAssertEqual(payload["probe_nonce"] as? String, "00112233445566778899aabbccddeeff")
+        XCTAssertEqual(payload["provider_reason_code"] as? String, "inconclusive:unsupported_sampler")
+        XCTAssertTrue(payload["target_model_hash"] is NSNull)
+        XCTAssertTrue(payload["draft_artifact_binding"] is NSNull)
+        XCTAssertNil(payload["usage"])
+        XCTAssertNil(payload["receipt"])
+        XCTAssertNil(payload["choices"])
+        XCTAssertNoThrow(try LosslessnessProbeProtocol.decodeProviderInconclusive(payload))
+    }
+
+    private struct Fixture {
+        let id: String
+        let expectedSHA256: String
+        let payload: [String: Any]
+    }
+
+    private static func loadFixtures() throws -> [Fixture] {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let url = repoRoot
+            .appendingPathComponent("phase4-coordinator")
+            .appendingPathComponent("test")
+            .appendingPathComponent("jcs_fixtures")
+            .appendingPathComponent("spec029")
+            .appendingPathComponent("losslessness_probe_v1.json")
+        let raw = try Data(contentsOf: url)
+        guard let entries = try JSONSerialization.jsonObject(with: raw) as? [[String: Any]] else {
+            throw LosslessnessProbeError.invalidPayload
+        }
+        return try entries.map { entry in
+            guard let id = entry["id"] as? String,
+                  let expected = entry["expected_sha256"] as? String,
+                  let payload = entry["payload"] as? [String: Any] else {
+                throw LosslessnessProbeError.invalidPayload
+            }
+            return Fixture(id: id, expectedSHA256: expected, payload: payload)
+        }
+    }
+}

--- a/phase4-coordinator/internal/billing/jcs.go
+++ b/phase4-coordinator/internal/billing/jcs.go
@@ -19,8 +19,16 @@ import (
 type RawJSONString string
 
 func CanonicalJSON(v any) ([]byte, error) {
+	return canonicalJSON(v, true)
+}
+
+func CanonicalJSONRawStrings(v any) ([]byte, error) {
+	return canonicalJSON(v, false)
+}
+
+func canonicalJSON(v any, normalizeStrings bool) ([]byte, error) {
 	var b bytes.Buffer
-	if err := writeJCS(&b, v); err != nil {
+	if err := writeJCS(&b, v, normalizeStrings); err != nil {
 		return nil, err
 	}
 	return b.Bytes(), nil
@@ -35,12 +43,15 @@ func CanonicalSHA256Hex(v any) (string, []byte, error) {
 	return hex.EncodeToString(sum[:]), canonical, nil
 }
 
-func writeJCS(b *bytes.Buffer, v any) error {
+func writeJCS(b *bytes.Buffer, v any, normalizeStrings bool) error {
 	switch x := v.(type) {
 	case nil:
 		b.WriteString("null")
 	case string:
-		b.WriteString(escapeJCSString(norm.NFC.String(x)))
+		if normalizeStrings {
+			x = norm.NFC.String(x)
+		}
+		b.WriteString(escapeJCSString(x))
 	case RawJSONString:
 		b.WriteString(escapeJCSString(string(x)))
 	case bool:
@@ -71,7 +82,7 @@ func writeJCS(b *bytes.Buffer, v any) error {
 			if i > 0 {
 				b.WriteByte(',')
 			}
-			if err := writeJCS(b, item); err != nil {
+			if err := writeJCS(b, item, normalizeStrings); err != nil {
 				return err
 			}
 		}
@@ -91,7 +102,7 @@ func writeJCS(b *bytes.Buffer, v any) error {
 			}
 			b.WriteString(escapeJCSString(key))
 			b.WriteByte(':')
-			if err := writeJCS(b, x[key]); err != nil {
+			if err := writeJCS(b, x[key], normalizeStrings); err != nil {
 				return err
 			}
 		}

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -312,21 +312,21 @@ type PoolConfig struct {
 	WakeGapThresholdS       int `yaml:"wake_gap_threshold_s"`
 	// WakeGapThresholdMs, when > 0, overrides WakeGapThresholdS for
 	// millisecond-precision test scenarios. Not for production use.
-	WakeGapThresholdMs      int                                `yaml:"wake_gap_threshold_ms"`
-	WarmupFallbackS         int                                `yaml:"warmup_fallback_s"`
-	WarmupGateEnabled       bool                               `yaml:"warmup_gate_enabled"`
-	WarmupGateTimeoutS      int                                `yaml:"warmup_gate_timeout_s"`
-	WarmupGateMaxTokens     int                                `yaml:"warmup_gate_max_tokens"`
-	DegradedBackoffS        int                                `yaml:"degraded_backoff_s"`
-	DegradedMaxRetries      int                                `yaml:"degraded_max_retries"`
-	DegradedProbeAfter502   bool                               `yaml:"degraded_probe_after_502"`
-	BreakerFailureThreshold int                                `yaml:"breaker_failure_threshold"`
-	BreakerWindowS          int                                `yaml:"breaker_window_s"`
-	CanaryEnabled           bool                               `yaml:"canary_enabled"`
-	CanaryIntervalS         int                                `yaml:"canary_interval_s"`
-	CanaryTimeoutS          int                                `yaml:"canary_timeout_s"`
-	CanaryMaxTokens         int                                `yaml:"canary_max_tokens"`
-	CanaryFailureThreshold  int                                `yaml:"canary_failure_threshold"`
+	WakeGapThresholdMs      int  `yaml:"wake_gap_threshold_ms"`
+	WarmupFallbackS         int  `yaml:"warmup_fallback_s"`
+	WarmupGateEnabled       bool `yaml:"warmup_gate_enabled"`
+	WarmupGateTimeoutS      int  `yaml:"warmup_gate_timeout_s"`
+	WarmupGateMaxTokens     int  `yaml:"warmup_gate_max_tokens"`
+	DegradedBackoffS        int  `yaml:"degraded_backoff_s"`
+	DegradedMaxRetries      int  `yaml:"degraded_max_retries"`
+	DegradedProbeAfter502   bool `yaml:"degraded_probe_after_502"`
+	BreakerFailureThreshold int  `yaml:"breaker_failure_threshold"`
+	BreakerWindowS          int  `yaml:"breaker_window_s"`
+	CanaryEnabled           bool `yaml:"canary_enabled"`
+	CanaryIntervalS         int  `yaml:"canary_interval_s"`
+	CanaryTimeoutS          int  `yaml:"canary_timeout_s"`
+	CanaryMaxTokens         int  `yaml:"canary_max_tokens"`
+	CanaryFailureThreshold  int  `yaml:"canary_failure_threshold"`
 	// CanaryColdStartGraceS relaxes the WALL-TIME latency gates (max_ttft_ms and
 	// min_sustained_tps) for the first grace-window seconds after a provider
 	// connects. Canary probes are non-streaming, so both metrics are measured
@@ -337,9 +337,10 @@ type PoolConfig struct {
 	// probe to be enforced — so this cannot be used to evade sanctions. Size it
 	// to cover a cold large-model load (observed ~8s TTFT for a cold 30B; a full
 	// load can take tens of seconds).
-	CanaryColdStartGraceS   int                                `yaml:"canary_cold_start_grace_s"`
-	CanaryChallenges        []CanaryChallengeConfig            `yaml:"canary_challenges"`
-	ModelClassChallenges    map[string][]CanaryChallengeConfig `yaml:"model_class_challenges"`
+	CanaryColdStartGraceS int                                `yaml:"canary_cold_start_grace_s"`
+	CanaryChallenges      []CanaryChallengeConfig            `yaml:"canary_challenges"`
+	ModelClassChallenges  map[string][]CanaryChallengeConfig `yaml:"model_class_challenges"`
+	LosslessnessProbe     LosslessnessProbeConfig            `yaml:"losslessness_probe"`
 }
 
 type CanaryChallengeConfig struct {
@@ -381,6 +382,18 @@ func (p PoolConfig) CanaryChallengesForModel(modelID string) ([]CanaryChallengeC
 		}
 	}
 	return p.CanaryChallenges, false
+}
+
+type LosslessnessProbeConfig struct {
+	Enabled                  bool `yaml:"enabled"`
+	IntervalS                int  `yaml:"interval_s"`
+	TimeoutS                 int  `yaml:"timeout_s"`
+	MaxConcurrentPerProvider int  `yaml:"max_concurrent_per_provider"`
+	MaxPromptsPerProbe       int  `yaml:"max_prompts_per_probe"`
+	MaxStochasticPositions   int  `yaml:"max_stochastic_positions"`
+	ProfileFreshnessTTLHours int  `yaml:"profile_freshness_ttl_hours"`
+	EvidenceRetentionDays    int  `yaml:"evidence_retention_days"`
+	BackoffMaxS              int  `yaml:"backoff_max_s"`
 }
 
 type RoutingConfig struct {
@@ -775,6 +788,17 @@ func Default() Config {
 			CanaryTimeoutS:          30,
 			CanaryMaxTokens:         8,
 			CanaryFailureThreshold:  3,
+			LosslessnessProbe: LosslessnessProbeConfig{
+				Enabled:                  false,
+				IntervalS:                3600,
+				TimeoutS:                 60,
+				MaxConcurrentPerProvider: 1,
+				MaxPromptsPerProbe:       4,
+				MaxStochasticPositions:   8,
+				ProfileFreshnessTTLHours: 24,
+				EvidenceRetentionDays:    30,
+				BackoffMaxS:              21600,
+			},
 		},
 		Routing: RoutingConfig{
 			PreflightThresholdTokens:      4096,
@@ -1425,6 +1449,16 @@ func (c Config) Validate() error {
 			if err := validateCanaryChallengeList("pool.model_class_challenges."+modelID, challenges); err != nil {
 				return err
 			}
+		}
+	}
+	if c.Pool.LosslessnessProbe.Enabled {
+		lp := c.Pool.LosslessnessProbe
+		if lp.IntervalS != 3600 || lp.TimeoutS != 60 || lp.MaxConcurrentPerProvider != 1 ||
+			lp.MaxPromptsPerProbe <= 0 || lp.MaxPromptsPerProbe > 4 ||
+			lp.MaxStochasticPositions <= 0 || lp.MaxStochasticPositions > 8 ||
+			lp.ProfileFreshnessTTLHours != 24 || lp.EvidenceRetentionDays != 30 ||
+			lp.BackoffMaxS <= 0 || lp.BackoffMaxS > 21600 {
+			return fmt.Errorf("pool.losslessness_probe settings violate SPEC-029 v0.1-draft prototype bounds")
 		}
 	}
 	if c.Admission.ProvisionalAdmissionRatePerHour <= 0 {

--- a/phase4-coordinator/internal/spec015contract/spec029_no_mutation_test.go
+++ b/phase4-coordinator/internal/spec015contract/spec029_no_mutation_test.go
@@ -1,0 +1,62 @@
+package spec015contract
+
+import "testing"
+
+func TestSPEC029DoesNotExtendSPEC015ReceiptOrUsageKeys(t *testing.T) {
+	fixtures := loadV04Fixtures(t)
+	if len(fixtures.ReceiptTuples) == 0 {
+		t.Fatal("missing v0.4 receipt tuple fixtures")
+	}
+
+	tuple := fixtures.ReceiptTuples[0]
+	receipt := copyMap(tuple.Value)
+	usage, ok := receipt["usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s usage = %#v, want object", tuple.ID, receipt["usage"])
+	}
+	usage = copyMap(usage)
+
+	assertOnlyKeys(t, tuple.ID, receipt, receiptTupleKeys)
+	assertOnlyKeys(t, tuple.ID+".usage", usage, usageKeys)
+
+	receipt["losslessness_profile_state"] = "candidate"
+	if hasOnlyKeys(receipt, receiptTupleKeys) {
+		t.Fatal("SPEC-015 receipt tuple unexpectedly allows SPEC-029 probe metadata")
+	}
+
+	usage["probe_request_digest"] = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	if hasOnlyKeys(usage, usageKeys) {
+		t.Fatal("SPEC-015 usage object unexpectedly allows SPEC-029 probe metadata")
+	}
+}
+
+func copyMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func assertOnlyKeys(t *testing.T, id string, value map[string]any, want []string) {
+	t.Helper()
+	if !hasOnlyKeys(value, want) {
+		t.Fatalf("%s keys are not strict before SPEC-029 mutation probe", id)
+	}
+}
+
+func hasOnlyKeys(value map[string]any, want []string) bool {
+	if len(value) != len(want) {
+		return false
+	}
+	allowed := make(map[string]struct{}, len(want))
+	for _, key := range want {
+		allowed[key] = struct{}{}
+	}
+	for key := range value {
+		if _, ok := allowed[key]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/phase4-coordinator/internal/ws/losslessness.go
+++ b/phase4-coordinator/internal/ws/losslessness.go
@@ -1,0 +1,1502 @@
+package ws
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/billing"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/tier2"
+)
+
+const (
+	LosslessnessProbeVersion = "losslessness_probe_v1"
+
+	losslessnessRequestType                      = "losslessness_probe_v1.request"
+	losslessnessResultType                       = "losslessness_probe_v1.result"
+	losslessnessEncryptedRequestType             = "losslessness_probe_v1.encrypted_request"
+	losslessnessEncryptedResultType              = "losslessness_probe_v1.encrypted_result"
+	losslessnessRequestPlaintextType             = "losslessness_probe_v1.request_plaintext"
+	losslessnessResultPlaintextType              = "losslessness_probe_v1.result_plaintext"
+	losslessnessSamplerStage                     = "post_processors_post_sampling_profile_next_emitted_token"
+	losslessnessNormalizationBasis               = "full_distribution"
+	losslessnessSupportSelection                 = "support_selection_v1"
+	defaultLosslessnessEvidenceTTL               = 30 * 24 * time.Hour
+	defaultLosslessnessFreshnessTTL              = 24 * time.Hour
+	losslessnessWarnTVUpperThreshold             = 0.02
+	losslessnessWarnMedianTVUpperThreshold       = 0.01
+	losslessnessQuarantineAnyTVLowerThreshold    = 0.10
+	losslessnessQuarantineMedianTVLowerThreshold = 0.05
+)
+
+type LosslessnessSamplingProfile struct {
+	Temperature float64 `json:"temperature"`
+	TopP        float64 `json:"top_p"`
+}
+
+type LosslessnessDraftArtifactBinding struct {
+	DraftModelID             string `json:"draft_model_id"`
+	DraftArtifactSHA256      string `json:"draft_artifact_sha256"`
+	TokenizerIdentity        string `json:"tokenizer_identity"`
+	CompatibilityCheckDigest string `json:"compatibility_check_digest"`
+}
+
+type LosslessnessProfileKey struct {
+	ProviderID           string                           `json:"provider_id"`
+	AssignedID           string                           `json:"assigned_id"`
+	ModelID              string                           `json:"model_id"`
+	TargetModelHash      string                           `json:"target_model_hash"`
+	TargetGeneration     int                              `json:"target_generation"`
+	DraftModelID         string                           `json:"draft_model_id"`
+	DraftArtifactBinding LosslessnessDraftArtifactBinding `json:"draft_artifact_binding"`
+	DraftGeneration      int                              `json:"draft_generation"`
+	SamplingProfile      LosslessnessSamplingProfile      `json:"sampling_profile"`
+	CorpusVersion        string                           `json:"corpus_version"`
+	ThresholdVersion     string                           `json:"threshold_version"`
+}
+
+type LosslessnessGridKey struct {
+	ProviderID           string                           `json:"provider_id"`
+	AssignedID           string                           `json:"assigned_id"`
+	ModelID              string                           `json:"model_id"`
+	TargetModelHash      string                           `json:"target_model_hash"`
+	TargetGeneration     int                              `json:"target_generation"`
+	DraftModelID         string                           `json:"draft_model_id"`
+	DraftArtifactBinding LosslessnessDraftArtifactBinding `json:"draft_artifact_binding"`
+	DraftGeneration      int                              `json:"draft_generation"`
+	CorpusVersion        string                           `json:"corpus_version"`
+	ThresholdVersion     string                           `json:"threshold_version"`
+}
+
+func (k LosslessnessProfileKey) GridKey() LosslessnessGridKey {
+	return LosslessnessGridKey{
+		ProviderID:           k.ProviderID,
+		AssignedID:           k.AssignedID,
+		ModelID:              k.ModelID,
+		TargetModelHash:      k.TargetModelHash,
+		TargetGeneration:     k.TargetGeneration,
+		DraftModelID:         k.DraftModelID,
+		DraftArtifactBinding: k.DraftArtifactBinding,
+		DraftGeneration:      k.DraftGeneration,
+		CorpusVersion:        k.CorpusVersion,
+		ThresholdVersion:     k.ThresholdVersion,
+	}
+}
+
+type LosslessnessProbeOuterEnvelope struct {
+	Type               string          `json:"type"`
+	ProbeID            string          `json:"probe_id"`
+	ProbeRequestDigest string          `json:"probe_request_digest"`
+	ProbeResultDigest  string          `json:"probe_result_digest,omitempty"`
+	Payload            json.RawMessage `json:"payload"`
+}
+
+type LosslessnessProbeRequestPayload struct {
+	ProbeVersion           string                                 `json:"probe_version"`
+	ProbeID                string                                 `json:"probe_id"`
+	ProbeNonce             string                                 `json:"probe_nonce"`
+	ExpiresAt              string                                 `json:"expires_at"`
+	ModelID                string                                 `json:"model_id"`
+	TargetModelHash        string                                 `json:"target_model_hash"`
+	TargetGeneration       int                                    `json:"target_generation"`
+	DraftModelID           string                                 `json:"draft_model_id"`
+	DraftArtifactBinding   LosslessnessDraftArtifactBinding       `json:"draft_artifact_binding"`
+	DraftGeneration        int                                    `json:"draft_generation"`
+	TokenizerIdentity      string                                 `json:"tokenizer_identity"`
+	SamplingProfile        LosslessnessSamplingProfile            `json:"sampling_profile"`
+	CorpusVersion          string                                 `json:"corpus_version"`
+	ThresholdVersion       string                                 `json:"threshold_version"`
+	Prompts                []LosslessnessPromptPayload            `json:"prompts"`
+	MeasurementPositions   []int                                  `json:"measurement_positions"`
+	RequestedK             int                                    `json:"requested_k"`
+	SupportSelection       string                                 `json:"support_selection"`
+	MaxPrompts             int                                    `json:"max_prompts"`
+	MaxStochasticPositions int                                    `json:"max_stochastic_positions"`
+	TimeoutMS              int                                    `json:"timeout_ms"`
+	VocabSize              int                                    `json:"-"`
+	PositionContextHashes  map[int]string                         `json:"-"`
+	HighEntropyPositions   map[int]bool                           `json:"-"`
+	OfflinePlainSupport    map[int][]LosslessnessTokenProbability `json:"-"`
+}
+
+type LosslessnessPromptPayload struct {
+	PromptID              string          `json:"prompt_id"`
+	Prompt                string          `json:"prompt"`
+	CoordinatorOwned      bool            `json:"coordinator_owned"`
+	BuyerOrigin           bool            `json:"buyer_origin"`
+	OfflinePositionRecord map[int]float64 `json:"-"`
+}
+
+type LosslessnessProbeResultPayload struct {
+	ProbeID              string                             `json:"probe_id"`
+	ProbeNonce           string                             `json:"probe_nonce"`
+	ProbeRequestDigest   string                             `json:"probe_request_digest"`
+	ResultKind           string                             `json:"result_kind"`
+	TargetModelHash      string                             `json:"target_model_hash,omitempty"`
+	TargetGeneration     int                                `json:"target_generation,omitempty"`
+	DraftArtifactBinding *LosslessnessDraftArtifactBinding  `json:"draft_artifact_binding,omitempty"`
+	DraftGeneration      int                                `json:"draft_generation,omitempty"`
+	TokenizerIdentity    string                             `json:"tokenizer_identity,omitempty"`
+	Positions            []LosslessnessPositionDistribution `json:"positions,omitempty"`
+	ProviderReasonCode   string                             `json:"provider_reason_code,omitempty"`
+	IdentityUnavailable  string                             `json:"identity_unavailable_reason,omitempty"`
+}
+
+type LosslessnessPositionDistribution struct {
+	PositionIndex        int                              `json:"position_index"`
+	ContextHash          string                           `json:"context_hash"`
+	SupportSelection     string                           `json:"support_selection"`
+	PlainTopKTokenIDs    []int                            `json:"plain_top_k_token_ids"`
+	SpecTopKTokenIDs     []int                            `json:"spec_top_k_token_ids"`
+	SupportTokenIDs      []int                            `json:"support_token_ids"`
+	PlainSupport         []LosslessnessTokenProbability   `json:"plain_support"`
+	PlainTailMass        float64                          `json:"plain_tail_mass"`
+	SpecSupport          []LosslessnessTokenProbability   `json:"spec_support"`
+	SpecTailMass         float64                          `json:"spec_tail_mass"`
+	TargetModelHash      string                           `json:"target_model_hash"`
+	TargetGeneration     int                              `json:"target_generation"`
+	DraftArtifactBinding LosslessnessDraftArtifactBinding `json:"draft_artifact_binding"`
+	DraftGeneration      int                              `json:"draft_generation"`
+	TokenizerIdentity    string                           `json:"tokenizer_identity"`
+	NormalizationBasis   string                           `json:"normalization_basis"`
+	SamplerStage         string                           `json:"sampler_stage"`
+	HighEntropy          bool                             `json:"high_entropy"`
+	OfflinePlainSupport  []LosslessnessTokenProbability   `json:"-"`
+}
+
+type LosslessnessTokenProbability struct {
+	TokenID int     `json:"token_id"`
+	P       float64 `json:"p"`
+}
+
+type LosslessnessTVInterval struct {
+	Lower float64
+	Upper float64
+}
+
+type LosslessnessValidationResult struct {
+	ReasonCode string
+	Retryable  bool
+}
+
+type LosslessnessExpectedPositionIdentity struct {
+	TargetModelHash      string
+	TargetGeneration     int
+	DraftArtifactBinding LosslessnessDraftArtifactBinding
+	DraftGeneration      int
+}
+
+var errLosslessnessMalformed = errors.New("inconclusive:malformed_distribution")
+
+type losslessnessPendingProbe struct {
+	ProviderID          string
+	AssignedID          string
+	ProbeID             string
+	ProbeNonce          string
+	ProbeRequestDigest  string
+	ExpiresAt           time.Time
+	ProfileKey          LosslessnessProfileKey
+	RequestedK          int
+	VocabSize           int
+	TokenizerIdentity   string
+	ExpectedIdentity    LosslessnessExpectedPositionIdentity
+	RequestedPositions  map[int]struct{}
+	ExpectedContextHash map[int]string
+	HighEntropyPosition map[int]bool
+	OfflinePlainSupport map[int][]LosslessnessTokenProbability
+}
+
+type losslessnessDraftAdmissionKey struct {
+	ProviderID string
+	AssignedID string
+	ModelID    string
+}
+
+type LosslessnessDraftAdmissionRecord struct {
+	ProviderID           string
+	AssignedID           string
+	ModelID              string
+	TargetModelHash      string
+	TargetGeneration     int
+	DraftModelID         string
+	DraftArtifactBinding LosslessnessDraftArtifactBinding
+	DraftGeneration      int
+	TokenizerIdentity    string
+	ExpiresAt            time.Time
+}
+
+type LosslessnessTelemetryEvent struct {
+	EventSubtype   string
+	ProviderID     string
+	AssignedID     string
+	ProbeID        string
+	ResultKind     string
+	ReasonCode     string
+	ProfileState   LosslessnessStatus
+	OperatorAction LosslessnessOperatorAction
+	MeasuredAt     time.Time
+}
+
+func LosslessnessDigest(rawPayload json.RawMessage) (string, error) {
+	canonical, err := canonicalizeJSON(rawPayload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func ValidateLosslessnessEnvelope(raw []byte, wantType string) (LosslessnessProbeOuterEnvelope, error) {
+	var env LosslessnessProbeOuterEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return env, err
+	}
+	if env.Type != wantType {
+		return env, fmt.Errorf("losslessness envelope type %q, want %q", env.Type, wantType)
+	}
+	if strings.TrimSpace(env.ProbeID) == "" || len(env.Payload) == 0 {
+		return env, errors.New("losslessness envelope requires probe_id and payload")
+	}
+	digest, err := LosslessnessDigest(env.Payload)
+	if err != nil {
+		return env, err
+	}
+	switch wantType {
+	case losslessnessRequestType:
+		if env.ProbeRequestDigest != digest {
+			return env, fmt.Errorf("probe_request_digest mismatch")
+		}
+		if err := validateLosslessnessPayloadBinding(env, false); err != nil {
+			return env, err
+		}
+	case losslessnessResultType:
+		if env.ProbeRequestDigest == "" {
+			return env, fmt.Errorf("probe_request_digest required")
+		}
+		if env.ProbeResultDigest != digest {
+			return env, fmt.Errorf("probe_result_digest mismatch")
+		}
+		if err := validateLosslessnessPayloadBinding(env, true); err != nil {
+			return env, err
+		}
+	}
+	return env, nil
+}
+
+func ValidateLosslessnessResultPayload(raw json.RawMessage) (LosslessnessProbeResultPayload, error) {
+	var result LosslessnessProbeResultPayload
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return result, err
+	}
+	if result.ProbeID == "" || result.ProbeNonce == "" || result.ProbeRequestDigest == "" {
+		return result, errors.New("losslessness result missing replay fields")
+	}
+	switch result.ResultKind {
+	case "measurement":
+		if result.TargetModelHash == "" || result.TargetGeneration <= 0 ||
+			result.DraftArtifactBinding == nil || result.DraftGeneration <= 0 ||
+			result.TokenizerIdentity == "" || len(result.Positions) == 0 {
+			return result, errors.New("losslessness measurement result missing identity or positions")
+		}
+	case "provider_inconclusive":
+		if !losslessnessProviderReasonAllowed(result.ProviderReasonCode) {
+			return result, errors.New("losslessness provider_inconclusive missing allowed reason or identity_unavailable_reason")
+		}
+		if len(result.Positions) > 0 {
+			return result, errors.New("losslessness provider_inconclusive must not carry measurement positions")
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			return result, err
+		}
+		identityKnown := result.TargetModelHash != "" && result.TargetGeneration > 0 &&
+			result.DraftArtifactBinding != nil && result.DraftGeneration > 0
+		identityUnavailable := result.IdentityUnavailable != "" &&
+			jsonFieldIsNull(fields, "target_model_hash") &&
+			jsonFieldIsNull(fields, "target_generation") &&
+			jsonFieldIsNull(fields, "draft_artifact_binding") &&
+			jsonFieldIsNull(fields, "draft_generation")
+		if !identityKnown && !identityUnavailable {
+			return result, errors.New("losslessness provider_inconclusive requires known identity or explicit null identity fields with identity_unavailable_reason")
+		}
+	default:
+		return result, fmt.Errorf("unsupported losslessness result_kind %q", result.ResultKind)
+	}
+	return result, nil
+}
+
+func jsonFieldIsNull(fields map[string]json.RawMessage, key string) bool {
+	value, ok := fields[key]
+	return ok && bytes.Equal(bytes.TrimSpace(value), []byte("null"))
+}
+
+func losslessnessProviderReasonAllowed(reason string) bool {
+	switch reason {
+	case "inconclusive:model_swap",
+		"inconclusive:unsupported_sampler",
+		"inconclusive:draft_unavailable",
+		"inconclusive:position_mismatch",
+		"inconclusive:missing_distribution",
+		"inconclusive:timeout":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateLosslessnessPayloadBinding(env LosslessnessProbeOuterEnvelope, result bool) error {
+	var payload struct {
+		ProbeID            string `json:"probe_id"`
+		ProbeRequestDigest string `json:"probe_request_digest"`
+	}
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		return err
+	}
+	if payload.ProbeID == "" || payload.ProbeID != env.ProbeID {
+		return fmt.Errorf("losslessness payload probe_id mismatch")
+	}
+	if result && payload.ProbeRequestDigest != env.ProbeRequestDigest {
+		return fmt.Errorf("losslessness payload probe_request_digest mismatch")
+	}
+	return nil
+}
+
+func ComputeTVInterval(pos LosslessnessPositionDistribution) (LosslessnessTVInterval, error) {
+	plain, err := probabilityMap(pos.PlainSupport)
+	if err != nil {
+		return LosslessnessTVInterval{}, err
+	}
+	spec, err := probabilityMap(pos.SpecSupport)
+	if err != nil {
+		return LosslessnessTVInterval{}, err
+	}
+	var diff float64
+	for _, id := range pos.SupportTokenIDs {
+		pPlain, ok := plain[id]
+		if !ok {
+			return LosslessnessTVInterval{}, fmt.Errorf("%w: missing plain support token %d", errLosslessnessMalformed, id)
+		}
+		pSpec, ok := spec[id]
+		if !ok {
+			return LosslessnessTVInterval{}, fmt.Errorf("%w: missing spec support token %d", errLosslessnessMalformed, id)
+		}
+		diff += math.Abs(pPlain - pSpec)
+	}
+	return LosslessnessTVInterval{
+		Lower: 0.5 * (diff + math.Abs(pos.PlainTailMass-pos.SpecTailMass)),
+		Upper: 0.5 * (diff + pos.PlainTailMass + pos.SpecTailMass),
+	}, nil
+}
+
+func ValidateLosslessnessDistribution(pos LosslessnessPositionDistribution, k, vocabSize int, expectedTokenizer, expectedContextHash string, expectedIdentity *LosslessnessExpectedPositionIdentity, expectedHighEntropy bool, offlinePlainSupport []LosslessnessTokenProbability) LosslessnessValidationResult {
+	if k != 64 && k != 256 {
+		return malformedResult()
+	}
+	if pos.SupportSelection != losslessnessSupportSelection ||
+		pos.NormalizationBasis != losslessnessNormalizationBasis ||
+		pos.SamplerStage != losslessnessSamplerStage {
+		return malformedResult()
+	}
+	if expectedTokenizer != "" && pos.TokenizerIdentity != expectedTokenizer {
+		return malformedResult()
+	}
+	if expectedContextHash != "" && pos.ContextHash != expectedContextHash {
+		return malformedResult()
+	}
+	if expectedIdentity != nil && !losslessnessIdentityMatches(pos, *expectedIdentity) {
+		return LosslessnessValidationResult{ReasonCode: "inconclusive:identity_mismatch", Retryable: false}
+	}
+	if !validMass(pos.PlainTailMass) || !validMass(pos.SpecTailMass) {
+		return malformedResult()
+	}
+	if !topKSorted(pos.PlainTopKTokenIDs, pos.PlainSupport, k, vocabSize) ||
+		!topKSorted(pos.SpecTopKTokenIDs, pos.SpecSupport, k, vocabSize) {
+		return malformedResult()
+	}
+	union := numericUnion(pos.PlainTopKTokenIDs, pos.SpecTopKTokenIDs)
+	if !sameInts(union, pos.SupportTokenIDs) {
+		return malformedResult()
+	}
+	minSupport := k
+	if vocabSize > 0 && vocabSize < k {
+		minSupport = vocabSize
+	}
+	if len(pos.SupportTokenIDs) < minSupport || len(pos.SupportTokenIDs) > 2*k {
+		return malformedResult()
+	}
+	plain, err := probabilityMap(pos.PlainSupport)
+	if err != nil {
+		return malformedResult()
+	}
+	spec, err := probabilityMap(pos.SpecSupport)
+	if err != nil {
+		return malformedResult()
+	}
+	if len(plain) != len(pos.SupportTokenIDs) || len(spec) != len(pos.SupportTokenIDs) {
+		return malformedResult()
+	}
+	var plainSum, specSum float64
+	seen := map[int]struct{}{}
+	for _, id := range pos.SupportTokenIDs {
+		if id < 0 || (vocabSize > 0 && id >= vocabSize) {
+			return malformedResult()
+		}
+		if _, ok := seen[id]; ok {
+			return malformedResult()
+		}
+		seen[id] = struct{}{}
+		p, ok := plain[id]
+		if !ok {
+			return malformedResult()
+		}
+		plainSum += p
+		p, ok = spec[id]
+		if !ok {
+			return malformedResult()
+		}
+		specSum += p
+	}
+	if math.Abs(plainSum+pos.PlainTailMass-1.0) > 1e-5 || math.Abs(specSum+pos.SpecTailMass-1.0) > 1e-5 {
+		return malformedResult()
+	}
+	if k == 256 && (pos.PlainTailMass > 0.005 || pos.SpecTailMass > 0.005) {
+		return LosslessnessValidationResult{ReasonCode: "inconclusive:tail_mass_high", Retryable: true}
+	}
+	if expectedHighEntropy && vocabSize > 0 && len(pos.SupportTokenIDs) < vocabSize {
+		if len(offlinePlainSupport) == 0 {
+			return malformedResult()
+		}
+		offline, err := probabilityMap(offlinePlainSupport)
+		if err != nil {
+			return malformedResult()
+		}
+		var offlineSupport float64
+		for _, id := range pos.SupportTokenIDs {
+			offlineSupport += offline[id]
+		}
+		if pos.PlainTailMass < 1-offlineSupport-1e-5 {
+			return malformedResult()
+		}
+	}
+	return LosslessnessValidationResult{ReasonCode: "valid", Retryable: false}
+}
+
+func losslessnessIdentityMatches(pos LosslessnessPositionDistribution, expected LosslessnessExpectedPositionIdentity) bool {
+	return pos.TargetModelHash == expected.TargetModelHash &&
+		pos.TargetGeneration == expected.TargetGeneration &&
+		pos.DraftArtifactBinding == expected.DraftArtifactBinding &&
+		pos.DraftGeneration == expected.DraftGeneration
+}
+
+func LosslessnessRequiresK256Retry(k int, plainTailMass, specTailMass, tvLower, tvUpper, warnThreshold, quarantineThreshold float64) bool {
+	if k != 64 {
+		return false
+	}
+	if plainTailMass > 0.01 || specTailMass > 0.01 {
+		return true
+	}
+	if tvUpper >= warnThreshold {
+		return true
+	}
+	return math.Abs(tvLower-quarantineThreshold) <= 0.005
+}
+
+func malformedResult() LosslessnessValidationResult {
+	return LosslessnessValidationResult{ReasonCode: "inconclusive:malformed_distribution", Retryable: false}
+}
+
+type LosslessnessStatus string
+
+const (
+	LosslessnessStatusPassFresh             LosslessnessStatus = "pass_fresh"
+	LosslessnessStatusWarn                  LosslessnessStatus = "warn"
+	LosslessnessStatusInconclusiveRetryable LosslessnessStatus = "inconclusive_retryable"
+	LosslessnessStatusBlocked               LosslessnessStatus = "blocked"
+	LosslessnessStatusDisabled              LosslessnessStatus = "disabled"
+	LosslessnessStatusExpired               LosslessnessStatus = "expired"
+	LosslessnessStatusUnknown               LosslessnessStatus = "unknown"
+)
+
+type LosslessnessOperatorAction string
+
+const (
+	LosslessnessActionNone                       LosslessnessOperatorAction = "none"
+	LosslessnessActionInspectThresholdTrend      LosslessnessOperatorAction = "inspect_threshold_trend"
+	LosslessnessActionInspectProviderDraft       LosslessnessOperatorAction = "inspect_provider_draft"
+	LosslessnessActionApproveCalibrationBaseline LosslessnessOperatorAction = "approve_calibration_baseline"
+	LosslessnessActionDisableSpecDecodeKey       LosslessnessOperatorAction = "disable_spec_decode_key"
+	LosslessnessActionRetryProbeWithBackoff      LosslessnessOperatorAction = "retry_probe_with_backoff"
+	LosslessnessActionInspectProviderLoad        LosslessnessOperatorAction = "inspect_provider_load"
+	LosslessnessActionDisableSamplerProfile      LosslessnessOperatorAction = "disable_sampler_profile"
+	LosslessnessActionWaitReadySnapshotReprobe   LosslessnessOperatorAction = "wait_ready_snapshot_reprobe"
+	LosslessnessActionReloadOrDisableDraft       LosslessnessOperatorAction = "reload_or_disable_draft"
+	LosslessnessActionCreateDraftAdmissionRecord LosslessnessOperatorAction = "create_draft_admission_record"
+	LosslessnessActionInspectGenerationMismatch  LosslessnessOperatorAction = "inspect_generation_mismatch"
+	LosslessnessActionInspectControlReplay       LosslessnessOperatorAction = "inspect_control_channel_replay"
+	LosslessnessActionFixProviderSerializer      LosslessnessOperatorAction = "fix_provider_serializer"
+	LosslessnessActionFixPositionHandling        LosslessnessOperatorAction = "fix_position_handling"
+	LosslessnessActionFixResultCompleteness      LosslessnessOperatorAction = "fix_result_completeness"
+	LosslessnessActionRequestSpec028Approval     LosslessnessOperatorAction = "request_spec028_rollout_approval"
+	LosslessnessActionDisableStochasticSpec      LosslessnessOperatorAction = "disable_stochastic_spec_decode"
+)
+
+type LosslessnessReasonRule struct {
+	ReasonCode     string
+	Status         string
+	Retryable      bool
+	NextState      LosslessnessStatus
+	OperatorAction LosslessnessOperatorAction
+	Abusive        bool
+}
+
+var losslessnessReasonRules = map[string]LosslessnessReasonRule{
+	"pass:fresh":                             {"pass:fresh", "pass", false, LosslessnessStatusPassFresh, LosslessnessActionNone, false},
+	"warn:threshold_exceeded":                {"warn:threshold_exceeded", "warn", true, LosslessnessStatusWarn, LosslessnessActionInspectThresholdTrend, false},
+	"quarantine_candidate:tv_lower_exceeded": {"quarantine_candidate:tv_lower_exceeded", "quarantine_candidate", true, LosslessnessStatusWarn, LosslessnessActionInspectProviderDraft, false},
+	"blocked:calibration_missing":            {"blocked:calibration_missing", "blocked", false, LosslessnessStatusBlocked, LosslessnessActionApproveCalibrationBaseline, false},
+	"blocked:greedy_control_failed":          {"blocked:greedy_control_failed", "blocked", false, LosslessnessStatusBlocked, LosslessnessActionDisableSpecDecodeKey, false},
+	"inconclusive:tail_mass_high":            {"inconclusive:tail_mass_high", "inconclusive", true, LosslessnessStatusInconclusiveRetryable, LosslessnessActionRetryProbeWithBackoff, false},
+	"inconclusive:k_retry_failed":            {"inconclusive:k_retry_failed", "inconclusive", true, LosslessnessStatusInconclusiveRetryable, LosslessnessActionInspectProviderLoad, true},
+	"inconclusive:timeout":                   {"inconclusive:timeout", "inconclusive", true, LosslessnessStatusInconclusiveRetryable, LosslessnessActionInspectProviderLoad, true},
+	"inconclusive:unsupported_sampler":       {"inconclusive:unsupported_sampler", "inconclusive", false, LosslessnessStatusBlocked, LosslessnessActionDisableSamplerProfile, true},
+	"inconclusive:model_swap":                {"inconclusive:model_swap", "inconclusive", true, LosslessnessStatusExpired, LosslessnessActionWaitReadySnapshotReprobe, false},
+	"inconclusive:draft_unavailable":         {"inconclusive:draft_unavailable", "inconclusive", true, LosslessnessStatusInconclusiveRetryable, LosslessnessActionReloadOrDisableDraft, true},
+	"inconclusive:draft_identity_unbound":    {"inconclusive:draft_identity_unbound", "inconclusive", false, LosslessnessStatusBlocked, LosslessnessActionCreateDraftAdmissionRecord, true},
+	"inconclusive:identity_mismatch":         {"inconclusive:identity_mismatch", "inconclusive", false, LosslessnessStatusBlocked, LosslessnessActionInspectGenerationMismatch, true},
+	"inconclusive:replay_or_expired":         {"inconclusive:replay_or_expired", "inconclusive", false, LosslessnessStatusBlocked, LosslessnessActionInspectControlReplay, true},
+	"inconclusive:malformed_distribution":    {"inconclusive:malformed_distribution", "inconclusive", false, LosslessnessStatusBlocked, LosslessnessActionFixProviderSerializer, true},
+	"inconclusive:position_mismatch":         {"inconclusive:position_mismatch", "inconclusive", false, LosslessnessStatusBlocked, LosslessnessActionFixPositionHandling, true},
+	"inconclusive:missing_distribution":      {"inconclusive:missing_distribution", "inconclusive", false, LosslessnessStatusBlocked, LosslessnessActionFixResultCompleteness, true},
+}
+
+type LosslessnessProfileRecord struct {
+	Key                         LosslessnessProfileKey
+	State                       LosslessnessStatus
+	ReasonCode                  string
+	Retryable                   bool
+	OperatorAction              LosslessnessOperatorAction
+	MeasuredAt                  time.Time
+	StaleAfter                  time.Time
+	VerdictEngineReady          bool
+	CalibrationAccepted         bool
+	ConsecutiveQuarantine       int
+	AbusiveInconclusiveEvents   []time.Time
+	RetryableInconclusiveEvents []LosslessnessReasonEvent
+	GreedyControlFailureCount   int
+}
+
+type LosslessnessReasonEvent struct {
+	ReasonCode string
+	MeasuredAt time.Time
+}
+
+func ApplyLosslessnessReason(record LosslessnessProfileRecord, reasonCode string, measuredAt time.Time) (LosslessnessProfileRecord, error) {
+	rule, ok := losslessnessReasonRules[reasonCode]
+	if !ok {
+		return record, fmt.Errorf("unknown losslessness reason_code %q", reasonCode)
+	}
+	record.ReasonCode = reasonCode
+	record.Retryable = rule.Retryable
+	record.OperatorAction = rule.OperatorAction
+	record.MeasuredAt = measuredAt.UTC()
+	record.StaleAfter = record.MeasuredAt.Add(defaultLosslessnessFreshnessTTL)
+	switch reasonCode {
+	case "pass:fresh":
+		if !record.VerdictEngineReady || !record.CalibrationAccepted {
+			return record, errors.New("losslessness pass requires verdict engine and accepted calibration baseline")
+		}
+		record.ConsecutiveQuarantine = 0
+		record.AbusiveInconclusiveEvents = pruneAbuseEvents(record.AbusiveInconclusiveEvents, measuredAt)
+		if len(record.AbusiveInconclusiveEvents) >= 3 {
+			record.State = LosslessnessStatusBlocked
+			record.OperatorAction = LosslessnessActionDisableSamplerProfile
+		} else {
+			record.State = LosslessnessStatusPassFresh
+		}
+	case "warn:threshold_exceeded":
+		record.State = LosslessnessStatusWarn
+	case "quarantine_candidate:tv_lower_exceeded":
+		if !record.CalibrationAccepted {
+			record.ReasonCode = "blocked:calibration_missing"
+			record.Retryable = false
+			record.State = LosslessnessStatusBlocked
+			record.OperatorAction = LosslessnessActionApproveCalibrationBaseline
+			return record, nil
+		}
+		record.ConsecutiveQuarantine++
+		if record.ConsecutiveQuarantine >= 2 {
+			record.State = LosslessnessStatusDisabled
+			record.OperatorAction = LosslessnessActionDisableSpecDecodeKey
+		} else {
+			record.State = LosslessnessStatusWarn
+		}
+	case "blocked:greedy_control_failed":
+		record.GreedyControlFailureCount++
+		record.State = LosslessnessStatusBlocked
+	default:
+		repeatedAbusive := repeatedRetryableInconclusiveIsAbusive(record, reasonCode, measuredAt)
+		if reasonCode == "inconclusive:tail_mass_high" || reasonCode == "inconclusive:model_swap" {
+			record.RetryableInconclusiveEvents = appendRetryableInconclusiveEvent(record.RetryableInconclusiveEvents, reasonCode, measuredAt)
+		}
+		if rule.Abusive || repeatedAbusive {
+			record.AbusiveInconclusiveEvents = appendAbuseEvent(record.AbusiveInconclusiveEvents, measuredAt)
+			if len(record.AbusiveInconclusiveEvents) >= 3 {
+				record.State = LosslessnessStatusBlocked
+				break
+			}
+		}
+		record.State = rule.NextState
+	}
+	return record, nil
+}
+
+func repeatedRetryableInconclusiveIsAbusive(record LosslessnessProfileRecord, reasonCode string, measuredAt time.Time) bool {
+	if reasonCode != "inconclusive:tail_mass_high" && reasonCode != "inconclusive:model_swap" {
+		return false
+	}
+	cutoff := measuredAt.Add(-24 * time.Hour)
+	count := 1
+	for _, event := range record.RetryableInconclusiveEvents {
+		if event.ReasonCode == reasonCode && !event.MeasuredAt.Before(cutoff) {
+			count++
+		}
+	}
+	return count > 3
+}
+
+func appendRetryableInconclusiveEvent(events []LosslessnessReasonEvent, reasonCode string, measuredAt time.Time) []LosslessnessReasonEvent {
+	cutoff := measuredAt.Add(-24 * time.Hour)
+	out := events[:0]
+	for _, event := range events {
+		if !event.MeasuredAt.Before(cutoff) {
+			out = append(out, event)
+		}
+	}
+	return append(out, LosslessnessReasonEvent{ReasonCode: reasonCode, MeasuredAt: measuredAt.UTC()})
+}
+
+func appendAbuseEvent(events []time.Time, measuredAt time.Time) []time.Time {
+	return append(pruneAbuseEvents(events, measuredAt), measuredAt.UTC())
+}
+
+func pruneAbuseEvents(events []time.Time, measuredAt time.Time) []time.Time {
+	cutoff := measuredAt.Add(-24 * time.Hour)
+	out := events[:0]
+	for _, event := range events {
+		if !event.Before(cutoff) {
+			out = append(out, event)
+		}
+	}
+	return out
+}
+
+func LosslessnessGridState(records []LosslessnessProfileRecord, grid LosslessnessGridKey, required []LosslessnessSamplingProfile, now time.Time) string {
+	fresh := map[LosslessnessSamplingProfile]bool{}
+	for _, record := range records {
+		if record.Key.GridKey() == grid &&
+			record.State == LosslessnessStatusPassFresh &&
+			record.VerdictEngineReady &&
+			record.CalibrationAccepted &&
+			now.Before(record.StaleAfter) {
+			fresh[record.Key.SamplingProfile] = true
+		}
+	}
+	for _, profile := range required {
+		if !fresh[profile] {
+			return "not_ready"
+		}
+	}
+	return "all_profiles_fresh"
+}
+
+func LosslessnessDefaultProfiles() []LosslessnessSamplingProfile {
+	return []LosslessnessSamplingProfile{
+		{Temperature: 0.2, TopP: 1.0},
+		{Temperature: 0.5, TopP: 1.0},
+		{Temperature: 0.7, TopP: 1.0},
+		{Temperature: 1.0, TopP: 1.0},
+		{Temperature: 0.0, TopP: 1.0},
+	}
+}
+
+func ValidateLosslessnessCorpusPrompt(prompt LosslessnessPromptPayload) error {
+	if strings.TrimSpace(prompt.PromptID) == "" {
+		return errors.New("prompt_id required")
+	}
+	if !prompt.CoordinatorOwned || prompt.BuyerOrigin {
+		return errors.New("losslessness corpus prompts must be synthetic coordinator-owned material")
+	}
+	if strings.TrimSpace(prompt.Prompt) == "" {
+		return errors.New("prompt must not be empty")
+	}
+	return nil
+}
+
+func losslessnessProbeStoreKey(providerID, assignedID, probeID string) string {
+	return providerID + "\x00" + assignedID + "\x00" + probeID
+}
+
+func (s *Server) recordLosslessnessPendingProbe(providerID, assignedID string, payload LosslessnessProbeRequestPayload, requestDigest string, now time.Time) (losslessnessPendingProbe, error) {
+	expiresAt, err := time.Parse(time.RFC3339Nano, payload.ExpiresAt)
+	if err != nil {
+		return losslessnessPendingProbe{}, err
+	}
+	pending := losslessnessPendingProbe{
+		ProviderID:         providerID,
+		AssignedID:         assignedID,
+		ProbeID:            payload.ProbeID,
+		ProbeNonce:         payload.ProbeNonce,
+		ProbeRequestDigest: requestDigest,
+		ExpiresAt:          expiresAt.UTC(),
+		ProfileKey: LosslessnessProfileKey{
+			ProviderID:           providerID,
+			AssignedID:           assignedID,
+			ModelID:              payload.ModelID,
+			TargetModelHash:      payload.TargetModelHash,
+			TargetGeneration:     payload.TargetGeneration,
+			DraftModelID:         payload.DraftModelID,
+			DraftArtifactBinding: payload.DraftArtifactBinding,
+			DraftGeneration:      payload.DraftGeneration,
+			SamplingProfile:      payload.SamplingProfile,
+			CorpusVersion:        payload.CorpusVersion,
+			ThresholdVersion:     payload.ThresholdVersion,
+		},
+		RequestedK:        payload.RequestedK,
+		VocabSize:         payload.VocabSize,
+		TokenizerIdentity: payload.TokenizerIdentity,
+		ExpectedIdentity: LosslessnessExpectedPositionIdentity{
+			TargetModelHash:      payload.TargetModelHash,
+			TargetGeneration:     payload.TargetGeneration,
+			DraftArtifactBinding: payload.DraftArtifactBinding,
+			DraftGeneration:      payload.DraftGeneration,
+		},
+		RequestedPositions:  map[int]struct{}{},
+		ExpectedContextHash: map[int]string{},
+		HighEntropyPosition: map[int]bool{},
+		OfflinePlainSupport: map[int][]LosslessnessTokenProbability{},
+	}
+	for _, position := range payload.MeasurementPositions {
+		pending.RequestedPositions[position] = struct{}{}
+	}
+	for position, hash := range payload.PositionContextHashes {
+		pending.ExpectedContextHash[position] = hash
+	}
+	for position, highEntropy := range payload.HighEntropyPositions {
+		pending.HighEntropyPosition[position] = highEntropy
+	}
+	for position, support := range payload.OfflinePlainSupport {
+		pending.OfflinePlainSupport[position] = append([]LosslessnessTokenProbability(nil), support...)
+		if pending.VocabSize == 0 {
+			for _, token := range support {
+				if token.TokenID >= pending.VocabSize {
+					pending.VocabSize = token.TokenID + 1
+				}
+			}
+		}
+	}
+	storeKey := losslessnessProbeStoreKey(providerID, assignedID, payload.ProbeID)
+	if _, loaded := s.losslessnessPending.LoadOrStore(storeKey, pending); loaded {
+		return losslessnessPendingProbe{}, errors.New("duplicate losslessness probe_id")
+	}
+	nonceKey := losslessnessProbeStoreKey(providerID, assignedID, payload.ProbeNonce)
+	if _, loaded := s.losslessnessNonceIndex.LoadOrStore(nonceKey, storeKey); loaded {
+		s.losslessnessPending.Delete(storeKey)
+		return losslessnessPendingProbe{}, errors.New("duplicate losslessness probe nonce")
+	}
+	digestKey := losslessnessProbeStoreKey(providerID, assignedID, requestDigest)
+	if _, loaded := s.losslessnessDigestIndex.LoadOrStore(digestKey, storeKey); loaded {
+		s.losslessnessPending.Delete(storeKey)
+		s.losslessnessNonceIndex.Delete(nonceKey)
+		return losslessnessPendingProbe{}, errors.New("duplicate losslessness probe request digest")
+	}
+	return pending, nil
+}
+
+func (s *Server) deleteLosslessnessPendingIndexes(pending losslessnessPendingProbe) {
+	s.losslessnessNonceIndex.Delete(losslessnessProbeStoreKey(pending.ProviderID, pending.AssignedID, pending.ProbeNonce))
+	s.losslessnessDigestIndex.Delete(losslessnessProbeStoreKey(pending.ProviderID, pending.AssignedID, pending.ProbeRequestDigest))
+}
+
+func (s *Server) consumeLosslessnessPendingProbe(providerID, assignedID string, result LosslessnessProbeResultPayload, now time.Time) (losslessnessPendingProbe, error) {
+	key := losslessnessProbeStoreKey(providerID, assignedID, result.ProbeID)
+	value, ok := s.losslessnessPending.LoadAndDelete(key)
+	if !ok {
+		return losslessnessPendingProbe{}, errors.New("losslessness result has no pending probe")
+	}
+	pending, ok := value.(losslessnessPendingProbe)
+	if !ok {
+		return losslessnessPendingProbe{}, errors.New("losslessness pending probe has invalid store type")
+	}
+	if now.After(pending.ExpiresAt) {
+		s.deleteLosslessnessPendingIndexes(pending)
+		return pending, errors.New("losslessness result probe expired")
+	}
+	if result.ProbeNonce != pending.ProbeNonce || result.ProbeRequestDigest != pending.ProbeRequestDigest {
+		s.deleteLosslessnessPendingIndexes(pending)
+		return pending, errors.New("losslessness result replay fields mismatch")
+	}
+	s.deleteLosslessnessPendingIndexes(pending)
+	return pending, nil
+}
+
+func (s *Server) applyLosslessnessProfileReason(key LosslessnessProfileKey, reasonCode string, measuredAt time.Time) (LosslessnessProfileRecord, error) {
+	s.losslessnessProfilesMu.Lock()
+	defer s.losslessnessProfilesMu.Unlock()
+	record := s.losslessnessProfiles[key]
+	record.Key = key
+	next, err := ApplyLosslessnessReason(record, reasonCode, measuredAt)
+	if err != nil {
+		return next, err
+	}
+	s.losslessnessProfiles[key] = next
+	return next, nil
+}
+
+func (s *Server) losslessnessProfileSnapshot(key LosslessnessProfileKey) (LosslessnessProfileRecord, bool) {
+	s.losslessnessProfilesMu.Lock()
+	defer s.losslessnessProfilesMu.Unlock()
+	record, ok := s.losslessnessProfiles[key]
+	return record, ok
+}
+
+func losslessnessReasonForMeasurement(result LosslessnessProbeResultPayload, pending losslessnessPendingProbe) string {
+	if result.TargetModelHash != pending.ExpectedIdentity.TargetModelHash ||
+		result.TargetGeneration != pending.ExpectedIdentity.TargetGeneration ||
+		result.DraftArtifactBinding == nil ||
+		*result.DraftArtifactBinding != pending.ExpectedIdentity.DraftArtifactBinding ||
+		result.DraftGeneration != pending.ExpectedIdentity.DraftGeneration ||
+		result.TokenizerIdentity != pending.TokenizerIdentity {
+		return "inconclusive:identity_mismatch"
+	}
+	if len(result.Positions) == 0 {
+		return "inconclusive:missing_distribution"
+	}
+	if len(pending.RequestedPositions) == 0 || len(result.Positions) != len(pending.RequestedPositions) {
+		return "inconclusive:position_mismatch"
+	}
+	if pending.VocabSize <= 0 {
+		return "inconclusive:malformed_distribution"
+	}
+	var tvLowerValues []float64
+	var tvUpperValues []float64
+	anyUpperWarn := false
+	anyLowerQuarantine := false
+	seenPositions := map[int]struct{}{}
+	for _, pos := range result.Positions {
+		if _, ok := pending.RequestedPositions[pos.PositionIndex]; !ok {
+			return "inconclusive:position_mismatch"
+		}
+		if _, ok := seenPositions[pos.PositionIndex]; ok {
+			return "inconclusive:position_mismatch"
+		}
+		seenPositions[pos.PositionIndex] = struct{}{}
+		expectedContextHash, ok := pending.ExpectedContextHash[pos.PositionIndex]
+		if !ok || expectedContextHash == "" {
+			return "inconclusive:malformed_distribution"
+		}
+		offlinePlainSupport := pending.OfflinePlainSupport[pos.PositionIndex]
+		if len(offlinePlainSupport) == 0 {
+			return "inconclusive:malformed_distribution"
+		}
+		validation := ValidateLosslessnessDistribution(
+			pos,
+			pending.RequestedK,
+			pending.VocabSize,
+			pending.TokenizerIdentity,
+			expectedContextHash,
+			&pending.ExpectedIdentity,
+			pending.HighEntropyPosition[pos.PositionIndex],
+			offlinePlainSupport,
+		)
+		if validation.ReasonCode != "valid" {
+			return validation.ReasonCode
+		}
+		tv, err := ComputeTVInterval(pos)
+		if err != nil {
+			return "inconclusive:malformed_distribution"
+		}
+		if LosslessnessRequiresK256Retry(
+			pending.RequestedK,
+			pos.PlainTailMass,
+			pos.SpecTailMass,
+			tv.Lower,
+			tv.Upper,
+			losslessnessWarnTVUpperThreshold,
+			losslessnessQuarantineMedianTVLowerThreshold,
+		) {
+			return "inconclusive:tail_mass_high"
+		}
+		tvLowerValues = append(tvLowerValues, tv.Lower)
+		tvUpperValues = append(tvUpperValues, tv.Upper)
+		if tv.Lower > losslessnessQuarantineAnyTVLowerThreshold {
+			anyLowerQuarantine = true
+		}
+		if tv.Upper > losslessnessWarnTVUpperThreshold {
+			anyUpperWarn = true
+		}
+	}
+	if medianLower := losslessnessCanonicalMedian(tvLowerValues); anyLowerQuarantine || medianLower > losslessnessQuarantineMedianTVLowerThreshold {
+		return "quarantine_candidate:tv_lower_exceeded"
+	}
+	if medianUpper := losslessnessCanonicalMedian(tvUpperValues); anyUpperWarn || medianUpper > losslessnessWarnMedianTVUpperThreshold {
+		return "warn:threshold_exceeded"
+	}
+	return "pass:fresh"
+}
+
+func losslessnessCanonicalMedian(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	return sorted[(len(sorted)-1)/2]
+}
+
+func (s *Server) runLosslessnessProbeLoop() {
+	interval := time.Duration(s.cfg.Pool.LosslessnessProbe.IntervalS) * time.Second
+	if interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.dispatchLosslessnessProbeRound()
+	}
+}
+
+func (s *Server) dispatchLosslessnessProbeRound() {
+	if s.pool == nil || !s.cfg.Pool.LosslessnessProbe.Enabled {
+		return
+	}
+	for _, provider := range s.pool.Snapshot() {
+		if !providerPublishedReady(provider) || s.losslessnessProviderHasPending(provider.ProviderID, provider.AssignedID) {
+			continue
+		}
+		if err := s.issueLosslessnessProbeRequest(provider, s.nextLosslessnessProfile(provider)); err != nil {
+			s.log.Warn().Err(err).Str("provider_id", provider.ProviderID).Msg("losslessness probe dispatch failed")
+		}
+	}
+}
+
+func (s *Server) nextLosslessnessProfile(provider pool.Provider) LosslessnessSamplingProfile {
+	profiles := LosslessnessDefaultProfiles()
+	key := provider.ProviderID + "\x00" + provider.AssignedID + "\x00" + provider.ModelID
+	s.losslessnessStateMu.Lock()
+	defer s.losslessnessStateMu.Unlock()
+	idx := s.losslessnessProfileCursor[key]
+	s.losslessnessProfileCursor[key] = (idx + 1) % len(profiles)
+	return profiles[idx%len(profiles)]
+}
+
+func (s *Server) losslessnessProviderHasPending(providerID, assignedID string) bool {
+	prefix := losslessnessProbeStoreKey(providerID, assignedID, "")
+	found := false
+	s.losslessnessPending.Range(func(key, _ any) bool {
+		if strings.HasPrefix(key.(string), prefix) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func (s *Server) issueLosslessnessProbeRequest(provider pool.Provider, profile LosslessnessSamplingProfile) error {
+	session, ok := s.sessionFor(provider.ProviderID, provider.AssignedID)
+	if !ok {
+		return errors.New("losslessness probe dispatch requires active provider session")
+	}
+	now := s.now()
+	payload, err := s.buildLosslessnessProbeRequest(provider, profile, now)
+	if err != nil {
+		s.recordLosslessnessTelemetry(LosslessnessTelemetryEvent{
+			EventSubtype: "admission_blocked",
+			ProviderID:   provider.ProviderID,
+			AssignedID:   provider.AssignedID,
+			ResultKind:   "admission_blocked",
+			ReasonCode:   "inconclusive:draft_identity_unbound",
+			MeasuredAt:   now,
+		})
+		return err
+	}
+	payloadRaw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	requestDigest, err := LosslessnessDigest(payloadRaw)
+	if err != nil {
+		return err
+	}
+	outer := LosslessnessProbeOuterEnvelope{
+		Type:               losslessnessRequestType,
+		ProbeID:            payload.ProbeID,
+		ProbeRequestDigest: requestDigest,
+		Payload:            payloadRaw,
+	}
+	cleartext, err := json.Marshal(outer)
+	if err != nil {
+		return err
+	}
+	if _, err := ValidateLosslessnessEnvelope(cleartext, losslessnessRequestType); err != nil {
+		return err
+	}
+	pending, err := s.recordLosslessnessPendingProbe(provider.ProviderID, provider.AssignedID, payload, requestDigest, now)
+	if err != nil {
+		return err
+	}
+	frame, err := session.sealLosslessnessProbeRequest(provider, payload.ProbeID, cleartext)
+	if err != nil {
+		s.losslessnessPending.Delete(losslessnessProbeStoreKey(provider.ProviderID, provider.AssignedID, payload.ProbeID))
+		s.deleteLosslessnessPendingIndexes(pending)
+		return err
+	}
+	if err := session.send(frame); err != nil {
+		s.losslessnessPending.Delete(losslessnessProbeStoreKey(provider.ProviderID, provider.AssignedID, payload.ProbeID))
+		s.deleteLosslessnessPendingIndexes(pending)
+		return err
+	}
+	return nil
+}
+
+func (s *Server) buildLosslessnessProbeRequest(provider pool.Provider, profile LosslessnessSamplingProfile, now time.Time) (LosslessnessProbeRequestPayload, error) {
+	admission, ok := s.losslessnessDraftAdmission(provider.ProviderID, provider.AssignedID, provider.ModelID, now)
+	if !ok {
+		return LosslessnessProbeRequestPayload{}, errors.New("losslessness probe requires current draft_admission_v1")
+	}
+	cfg := s.cfg.Pool.LosslessnessProbe
+	maxPrompts := cfg.MaxPromptsPerProbe
+	if maxPrompts <= 0 || maxPrompts > 4 {
+		maxPrompts = 4
+	}
+	maxPositions := cfg.MaxStochasticPositions
+	if maxPositions <= 0 || maxPositions > 8 {
+		maxPositions = 8
+	}
+	probeID, err := losslessnessRandomID("losslessness-", 16)
+	if err != nil {
+		return LosslessnessProbeRequestPayload{}, err
+	}
+	nonce, err := losslessnessRandomID("", 16)
+	if err != nil {
+		return LosslessnessProbeRequestPayload{}, err
+	}
+	positions := make([]int, maxPositions)
+	contextHashes := make(map[int]string, maxPositions)
+	highEntropy := make(map[int]bool, maxPositions)
+	offline := make(map[int][]LosslessnessTokenProbability, maxPositions)
+	for i := range positions {
+		positions[i] = i
+		contextHashes[i] = losslessnessSyntheticHash(probeID, fmt.Sprintf("position:%d", i))
+		highEntropy[i] = i < 4
+		offline[i] = losslessnessSyntheticOfflineSupport(70)
+	}
+	prompts := make([]LosslessnessPromptPayload, 0, maxPrompts)
+	for i := 0; i < maxPrompts; i++ {
+		prompts = append(prompts, LosslessnessPromptPayload{
+			PromptID:         fmt.Sprintf("spec029-synthetic-%02d", i+1),
+			Prompt:           fmt.Sprintf("SPEC-029 synthetic losslessness probe prompt %02d.", i+1),
+			CoordinatorOwned: true,
+			BuyerOrigin:      false,
+		})
+	}
+	timeoutMS := cfg.TimeoutS * 1000
+	if timeoutMS <= 0 {
+		timeoutMS = 60000
+	}
+	return LosslessnessProbeRequestPayload{
+		ProbeVersion:           LosslessnessProbeVersion,
+		ProbeID:                probeID,
+		ProbeNonce:             nonce,
+		ExpiresAt:              now.Add(time.Duration(cfg.TimeoutS) * time.Second).UTC().Format(time.RFC3339Nano),
+		ModelID:                admission.ModelID,
+		TargetModelHash:        admission.TargetModelHash,
+		TargetGeneration:       admission.TargetGeneration,
+		DraftModelID:           admission.DraftModelID,
+		DraftArtifactBinding:   admission.DraftArtifactBinding,
+		DraftGeneration:        admission.DraftGeneration,
+		TokenizerIdentity:      admission.TokenizerIdentity,
+		SamplingProfile:        profile,
+		CorpusVersion:          "spec029-prototype-corpus-v1",
+		ThresholdVersion:       "spec029-v0.1-draft-thresholds",
+		Prompts:                prompts,
+		MeasurementPositions:   positions,
+		RequestedK:             64,
+		SupportSelection:       losslessnessSupportSelection,
+		MaxPrompts:             maxPrompts,
+		MaxStochasticPositions: maxPositions,
+		TimeoutMS:              timeoutMS,
+		VocabSize:              70,
+		PositionContextHashes:  contextHashes,
+		HighEntropyPositions:   highEntropy,
+		OfflinePlainSupport:    offline,
+	}, nil
+}
+
+func (s *Server) recordLosslessnessDraftAdmission(record LosslessnessDraftAdmissionRecord) {
+	s.losslessnessStateMu.Lock()
+	defer s.losslessnessStateMu.Unlock()
+	key := losslessnessDraftAdmissionKey{ProviderID: record.ProviderID, AssignedID: record.AssignedID, ModelID: record.ModelID}
+	s.losslessnessDraftAdmissions[key] = record
+	s.losslessnessTargetGenerations[key.ProviderID+"\x00"+key.AssignedID+"\x00"+key.ModelID] = record.TargetGeneration
+}
+
+func (s *Server) losslessnessDraftAdmission(providerID, assignedID, modelID string, now time.Time) (LosslessnessDraftAdmissionRecord, bool) {
+	s.losslessnessStateMu.Lock()
+	defer s.losslessnessStateMu.Unlock()
+	record, ok := s.losslessnessDraftAdmissions[losslessnessDraftAdmissionKey{ProviderID: providerID, AssignedID: assignedID, ModelID: modelID}]
+	if !ok || (!record.ExpiresAt.IsZero() && !now.Before(record.ExpiresAt)) {
+		return LosslessnessDraftAdmissionRecord{}, false
+	}
+	return record, true
+}
+
+func (s *Server) recordLosslessnessTelemetry(event LosslessnessTelemetryEvent) {
+	s.losslessnessStateMu.Lock()
+	defer s.losslessnessStateMu.Unlock()
+	s.losslessnessTelemetry = append(s.losslessnessTelemetry, event)
+}
+
+func (s *Server) losslessnessTelemetrySnapshot() []LosslessnessTelemetryEvent {
+	s.losslessnessStateMu.Lock()
+	defer s.losslessnessStateMu.Unlock()
+	return append([]LosslessnessTelemetryEvent(nil), s.losslessnessTelemetry...)
+}
+
+func losslessnessRandomID(prefix string, n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return prefix + hex.EncodeToString(buf), nil
+}
+
+func losslessnessSyntheticHash(parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func losslessnessSyntheticOfflineSupport(vocabSize int) []LosslessnessTokenProbability {
+	if vocabSize <= 0 {
+		return nil
+	}
+	out := make([]LosslessnessTokenProbability, vocabSize)
+	p := 1.0 / float64(vocabSize)
+	for i := range out {
+		out[i] = LosslessnessTokenProbability{TokenID: i, P: p}
+	}
+	return out
+}
+
+type encryptedLosslessnessRequest struct {
+	Type      string                 `json:"type"`
+	RequestID string                 `json:"request_id"`
+	Stream    bool                   `json:"stream"`
+	Encrypted bool                   `json:"encrypted"`
+	Enc       tier2.AEADEnvelopeBody `json:"enc"`
+}
+
+type encryptedLosslessnessResult struct {
+	Type      string                 `json:"type"`
+	RequestID string                 `json:"request_id"`
+	Stream    bool                   `json:"stream"`
+	Encrypted bool                   `json:"encrypted"`
+	Enc       tier2.AEADEnvelopeBody `json:"enc"`
+}
+
+type encryptedLosslessnessPlaintext struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+func (ps *providerSession) sealLosslessnessProbeRequest(provider pool.Provider, probeID string, cleartextOuterEnvelope []byte) ([]byte, error) {
+	ps.tier2Mu.Lock()
+	session := ps.tier2
+	if session == nil {
+		ps.tier2Mu.Unlock()
+		return cleartextOuterEnvelope, nil
+	}
+	defer ps.tier2Mu.Unlock()
+	if session.C2PCounter == ^uint64(0) {
+		return nil, errors.New("tier2 c2p frame counter exhausted")
+	}
+	seq := session.C2PCounter
+	aad := tier2.AEADFrameAAD{
+		Type:       losslessnessEncryptedRequestType,
+		Direction:  "c2p",
+		RequestID:  probeID,
+		Stream:     false,
+		ProviderID: provider.ProviderID,
+		AssignedID: provider.AssignedID,
+		Seq:        seq,
+	}
+	plaintext, err := json.Marshal(encryptedLosslessnessPlaintext{
+		Type:    losslessnessRequestPlaintextType,
+		Payload: cleartextOuterEnvelope,
+	})
+	if err != nil {
+		return nil, err
+	}
+	envelope, err := tier2.SealPillarBFrame(session.C2PKey, session.C2PNonceBase, session.KeyID, seq, aad, plaintext)
+	if err != nil {
+		return nil, err
+	}
+	session.C2PCounter++
+	return json.Marshal(encryptedLosslessnessRequest{
+		Type:      losslessnessEncryptedRequestType,
+		RequestID: probeID,
+		Stream:    false,
+		Encrypted: true,
+		Enc:       envelope.Enc,
+	})
+}
+
+func (ps *providerSession) openLosslessnessProbeResult(provider pool.Provider, probeID string, envelope tier2.AEADEnvelope) ([]byte, error) {
+	ps.tier2Mu.Lock()
+	defer ps.tier2Mu.Unlock()
+	if ps.tier2 == nil {
+		return nil, errors.New("encrypted losslessness result for provider without tier2 session")
+	}
+	if ps.tier2.P2CCounter == ^uint64(0) {
+		return nil, errors.New("tier2 p2c frame counter exhausted")
+	}
+	seq := ps.tier2.P2CCounter
+	aad := tier2.AEADFrameAAD{
+		Type:       losslessnessEncryptedResultType,
+		Direction:  "p2c",
+		RequestID:  probeID,
+		Stream:     false,
+		ProviderID: provider.ProviderID,
+		AssignedID: provider.AssignedID,
+		Seq:        seq,
+	}
+	plaintext, err := tier2.OpenPillarBFrame(ps.tier2.P2CKey, ps.tier2.P2CNonceBase, ps.tier2.KeyID, seq, aad, envelope)
+	if err != nil {
+		return nil, err
+	}
+	var carrier encryptedLosslessnessPlaintext
+	if err := json.Unmarshal(plaintext, &carrier); err != nil {
+		return nil, err
+	}
+	if carrier.Type != losslessnessResultPlaintextType || len(carrier.Payload) == 0 {
+		return nil, errors.New("invalid losslessness result plaintext envelope")
+	}
+	ps.tier2.P2CCounter++
+	return carrier.Payload, nil
+}
+
+func (s *Server) handleLosslessnessProbeResult(providerID, assignedID string, payload []byte) {
+	if !s.cfg.Pool.LosslessnessProbe.Enabled {
+		s.log.Warn().Str("provider_id", providerID).Msg("losslessness result ignored while probe feature disabled")
+		return
+	}
+
+	var envelope struct {
+		Type      string                 `json:"type"`
+		RequestID string                 `json:"request_id"`
+		Stream    bool                   `json:"stream"`
+		Encrypted bool                   `json:"encrypted"`
+		Enc       tier2.AEADEnvelopeBody `json:"enc"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("invalid losslessness result json")
+		return
+	}
+
+	cleartext := payload
+	if envelope.Type == losslessnessEncryptedResultType {
+		if !envelope.Encrypted || envelope.Stream || envelope.RequestID == "" {
+			s.log.Warn().Str("provider_id", providerID).Msg("invalid encrypted losslessness result carrier")
+			return
+		}
+		provider, ok := s.pool.Resolve(providerID, assignedID)
+		if !ok {
+			s.log.Warn().Str("provider_id", providerID).Msg("losslessness result from unresolved provider")
+			return
+		}
+		session, ok := s.sessionFor(providerID, assignedID)
+		if !ok {
+			s.log.Warn().Str("provider_id", providerID).Msg("encrypted losslessness result without active session")
+			return
+		}
+		opened, err := session.openLosslessnessProbeResult(provider, envelope.RequestID, tier2.AEADEnvelope{Encrypted: true, Enc: envelope.Enc})
+		if err != nil {
+			s.log.Warn().Err(err).Str("provider_id", providerID).Msg("invalid encrypted losslessness result")
+			return
+		}
+		cleartext = opened
+	} else if envelope.Type == losslessnessResultType {
+		if session, ok := s.sessionFor(providerID, assignedID); ok && session.hasTier2Session() {
+			s.log.Warn().Str("provider_id", providerID).Msg("plaintext losslessness result rejected for active tier2 session")
+			return
+		}
+	}
+
+	outer, err := ValidateLosslessnessEnvelope(cleartext, losslessnessResultType)
+	if err != nil {
+		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("invalid losslessness result envelope")
+		return
+	}
+	if envelope.Type == losslessnessEncryptedResultType && outer.ProbeID != envelope.RequestID {
+		s.log.Warn().Str("provider_id", providerID).Msg("losslessness encrypted result request_id/probe_id mismatch")
+		return
+	}
+	result, err := ValidateLosslessnessResultPayload(outer.Payload)
+	if err != nil {
+		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("invalid losslessness result payload")
+		return
+	}
+	pending, err := s.consumeLosslessnessPendingProbe(providerID, assignedID, result, s.now())
+	if err != nil {
+		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("losslessness result rejected without pending probe")
+		return
+	}
+	reasonCode := "pass:fresh"
+	if result.ResultKind == "provider_inconclusive" {
+		reasonCode = result.ProviderReasonCode
+	} else {
+		reasonCode = losslessnessReasonForMeasurement(result, pending)
+	}
+	record, err := s.applyLosslessnessProfileReason(pending.ProfileKey, reasonCode, s.now())
+	if err != nil {
+		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("losslessness result has unmapped reason")
+		return
+	}
+	s.recordLosslessnessTelemetry(LosslessnessTelemetryEvent{
+		EventSubtype:   "probe_result",
+		ProviderID:     providerID,
+		AssignedID:     assignedID,
+		ProbeID:        result.ProbeID,
+		ResultKind:     result.ResultKind,
+		ReasonCode:     reasonCode,
+		ProfileState:   record.State,
+		OperatorAction: record.OperatorAction,
+		MeasuredAt:     record.MeasuredAt,
+	})
+	s.log.Info().
+		Str("provider_id", providerID).
+		Str("probe_id", result.ProbeID).
+		Str("result_kind", result.ResultKind).
+		Str("reason_code", reasonCode).
+		Str("profile_state", string(record.State)).
+		Str("operator_action", string(record.OperatorAction)).
+		Str("evidence_strength", "cooperative_prototype_not_settlement_evidence").
+		Str("spec_status", "SPEC-029 v0.1-draft prototype").
+		Msg("validated losslessness probe result and derived prototype operator state")
+}
+
+func probabilityMap(values []LosslessnessTokenProbability) (map[int]float64, error) {
+	out := make(map[int]float64, len(values))
+	for _, value := range values {
+		if value.TokenID < 0 || !validMass(value.P) {
+			return nil, errLosslessnessMalformed
+		}
+		if _, exists := out[value.TokenID]; exists {
+			return nil, errLosslessnessMalformed
+		}
+		out[value.TokenID] = value.P
+	}
+	return out, nil
+}
+
+func validMass(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0) && v >= 0 && v <= 1
+}
+
+func topKSorted(ids []int, support []LosslessnessTokenProbability, k, vocabSize int) bool {
+	wantLen := k
+	if vocabSize > 0 && vocabSize < k {
+		wantLen = vocabSize
+	}
+	if len(ids) != wantLen {
+		return false
+	}
+	probs, err := probabilityMap(support)
+	if err != nil {
+		return false
+	}
+	seen := map[int]struct{}{}
+	for i, id := range ids {
+		if id < 0 || (vocabSize > 0 && id >= vocabSize) {
+			return false
+		}
+		if _, ok := seen[id]; ok {
+			return false
+		}
+		seen[id] = struct{}{}
+		if _, ok := probs[id]; !ok {
+			return false
+		}
+		if i == 0 {
+			continue
+		}
+		prev := ids[i-1]
+		if probs[prev] < probs[id] {
+			return false
+		}
+		if probs[prev] == probs[id] && prev > id {
+			return false
+		}
+	}
+	lastID := ids[len(ids)-1]
+	lastP := probs[lastID]
+	for _, candidate := range support {
+		if _, ok := seen[candidate.TokenID]; ok {
+			continue
+		}
+		if candidate.P > lastP {
+			return false
+		}
+		if candidate.P == lastP && candidate.TokenID < lastID {
+			return false
+		}
+	}
+	return true
+}
+
+func numericUnion(a, b []int) []int {
+	set := map[int]struct{}{}
+	for _, id := range a {
+		set[id] = struct{}{}
+	}
+	for _, id := range b {
+		set[id] = struct{}{}
+	}
+	out := make([]int, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func sameInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func canonicalizeJSON(raw []byte) ([]byte, error) {
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	return billing.CanonicalJSONRawStrings(value)
+}

--- a/phase4-coordinator/internal/ws/losslessness_test.go
+++ b/phase4-coordinator/internal/ws/losslessness_test.go
@@ -1,0 +1,999 @@
+package ws
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/tier2"
+	gobwas "github.com/gobwas/ws"
+	"github.com/rs/zerolog"
+)
+
+func TestLosslessnessDigestFixturesHashInnerPayloadOnly(t *testing.T) {
+	fixtures := loadLosslessnessFixtures(t)
+	for _, fixture := range fixtures {
+		payload := mustMarshal(t, fixture.Payload)
+		got, err := LosslessnessDigest(payload)
+		if err != nil {
+			t.Fatalf("%s digest: %v", fixture.ID, err)
+		}
+		if got != fixture.ExpectedSHA256 {
+			t.Fatalf("%s digest = %q, want %q", fixture.ID, got, fixture.ExpectedSHA256)
+		}
+	}
+
+	requestPayload := mustMarshal(t, fixtures[0].Payload)
+	requestDigest, err := LosslessnessDigest(requestPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outer := mustMarshal(t, map[string]any{
+		"type":                  losslessnessRequestType,
+		"probe_id":              "probe-fixture-001",
+		"probe_request_digest":  requestDigest,
+		"payload":               fixtures[0].Payload,
+		"transport_debug_field": "outer fields are not digest input",
+	})
+	if _, err := ValidateLosslessnessEnvelope(outer, losslessnessRequestType); err != nil {
+		t.Fatalf("valid request outer envelope rejected: %v", err)
+	}
+	outerDigest, err := LosslessnessDigest(outer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outerDigest == requestDigest {
+		t.Fatal("outer envelope digest unexpectedly matched inner payload digest")
+	}
+}
+
+func TestLosslessnessEnvelopeRejectsMissingPayloadAndDigestMismatch(t *testing.T) {
+	_, err := ValidateLosslessnessEnvelope([]byte(`{"type":"losslessness_probe_v1.request","probe_id":"probe-1","probe_request_digest":"sha256:00"}`), losslessnessRequestType)
+	if err == nil {
+		t.Fatal("missing payload accepted")
+	}
+
+	_, err = ValidateLosslessnessEnvelope([]byte(`{"type":"losslessness_probe_v1.request","probe_id":"probe-1","probe_request_digest":"sha256:00","payload":{"probe_id":"probe-1"}}`), losslessnessRequestType)
+	if err == nil {
+		t.Fatal("digest mismatch accepted")
+	}
+
+	payload := mustMarshal(t, map[string]any{"probe_id": "inner-probe"})
+	digest, err := LosslessnessDigest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outer := mustMarshal(t, map[string]any{
+		"type":                 losslessnessRequestType,
+		"probe_id":             "outer-probe",
+		"probe_request_digest": digest,
+		"payload":              map[string]any{"probe_id": "inner-probe"},
+	})
+	if _, err := ValidateLosslessnessEnvelope(outer, losslessnessRequestType); err == nil {
+		t.Fatal("inner/outer probe_id mismatch accepted")
+	}
+
+	resultPayload := mustMarshal(t, map[string]any{
+		"probe_id":               "probe-result",
+		"probe_nonce":            "nonce",
+		"probe_request_digest":   "",
+		"result_kind":            "provider_inconclusive",
+		"provider_reason_code":   "inconclusive:unsupported_sampler",
+		"target_model_hash":      nil,
+		"target_generation":      nil,
+		"draft_artifact_binding": nil,
+		"draft_generation":       nil,
+	})
+	resultDigest, err := LosslessnessDigest(resultPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultOuter := mustMarshal(t, map[string]any{
+		"type":                losslessnessResultType,
+		"probe_id":            "probe-result",
+		"probe_result_digest": resultDigest,
+		"payload":             json.RawMessage(resultPayload),
+	})
+	if _, err := ValidateLosslessnessEnvelope(resultOuter, losslessnessResultType); err == nil {
+		t.Fatal("result envelope without probe_request_digest accepted")
+	}
+}
+
+func TestLosslessnessProviderInconclusiveRequiresExplicitIdentityNulls(t *testing.T) {
+	base := map[string]any{
+		"probe_id":                    "probe-result",
+		"probe_nonce":                 "nonce",
+		"probe_request_digest":        "sha256:req",
+		"result_kind":                 "provider_inconclusive",
+		"provider_reason_code":        "inconclusive:unsupported_sampler",
+		"identity_unavailable_reason": "sampler hook unavailable",
+	}
+	if _, err := ValidateLosslessnessResultPayload(mustMarshal(t, base)); err == nil {
+		t.Fatal("provider_inconclusive omitted identity fields accepted")
+	}
+
+	base["target_model_hash"] = nil
+	base["target_generation"] = nil
+	base["draft_artifact_binding"] = nil
+	base["draft_generation"] = nil
+	if _, err := ValidateLosslessnessResultPayload(mustMarshal(t, base)); err != nil {
+		t.Fatalf("provider_inconclusive explicit null identity rejected: %v", err)
+	}
+
+	base["target_model_hash"] = "sha256:target"
+	if _, err := ValidateLosslessnessResultPayload(mustMarshal(t, base)); err == nil {
+		t.Fatal("provider_inconclusive partial null identity accepted")
+	}
+
+	base["target_model_hash"] = nil
+	base["positions"] = []map[string]any{{"position_index": 0}}
+	if _, err := ValidateLosslessnessResultPayload(mustMarshal(t, base)); err == nil {
+		t.Fatal("provider_inconclusive with measurement positions accepted")
+	}
+}
+
+func TestLosslessnessDistributionValidationAndTV(t *testing.T) {
+	pos := validLosslessnessPosition()
+	result := ValidateLosslessnessDistribution(pos, 64, 70, "tok-v1", "sha256:ctx", expectedLosslessnessIdentity(), true, pos.OfflinePlainSupport)
+	if result.ReasonCode != "valid" {
+		t.Fatalf("valid distribution reason = %q", result.ReasonCode)
+	}
+	pos.TargetGeneration = 2
+	result = ValidateLosslessnessDistribution(pos, 64, 70, "tok-v1", "sha256:ctx", expectedLosslessnessIdentity(), true, pos.OfflinePlainSupport)
+	if result.ReasonCode != "inconclusive:identity_mismatch" {
+		t.Fatalf("identity mismatch reason = %q", result.ReasonCode)
+	}
+	if !LosslessnessRequiresK256Retry(64, 0.001, 0.001, 0.095, 0.095, 0.1, 0.099) {
+		t.Fatal("K=64 near-quarantine threshold did not require K=256 retry")
+	}
+
+	tv, err := ComputeTVInterval(LosslessnessPositionDistribution{
+		SupportTokenIDs: []int{1, 2},
+		PlainSupport: []LosslessnessTokenProbability{
+			{TokenID: 1, P: 0.4},
+			{TokenID: 2, P: 0.1},
+		},
+		PlainTailMass: 0.5,
+		SpecSupport: []LosslessnessTokenProbability{
+			{TokenID: 1, P: 0.3},
+			{TokenID: 2, P: 0.2},
+		},
+		SpecTailMass: 0.5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if math.Abs(tv.Lower-0.1) > 1e-12 || math.Abs(tv.Upper-0.6) > 1e-12 {
+		t.Fatalf("tv = %+v, want lower=0.1 upper=0.6", tv)
+	}
+}
+
+func TestLosslessnessDistributionRejectsMalformedEvidence(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*LosslessnessPositionDistribution)
+	}{
+		{name: "duplicate support", mut: func(p *LosslessnessPositionDistribution) { p.SupportTokenIDs[1] = p.SupportTokenIDs[0] }},
+		{name: "negative probability", mut: func(p *LosslessnessPositionDistribution) { p.PlainSupport[0].P = -0.1 }},
+		{name: "wrong normalization", mut: func(p *LosslessnessPositionDistribution) { p.NormalizationBasis = "top_k_renormalized" }},
+		{name: "wrong sampler stage", mut: func(p *LosslessnessPositionDistribution) { p.SamplerStage = "sampled_token_histogram" }},
+		{name: "missing support probability", mut: func(p *LosslessnessPositionDistribution) { p.SpecSupport = p.SpecSupport[:len(p.SpecSupport)-1] }},
+		{name: "extra support probability", mut: func(p *LosslessnessPositionDistribution) {
+			p.PlainSupport = append(p.PlainSupport, LosslessnessTokenProbability{TokenID: 69, P: 0.001})
+			p.PlainSupport[0].P -= 0.001
+		}},
+		{name: "top-k omits higher support token", mut: func(p *LosslessnessPositionDistribution) {
+			for i := range p.PlainSupport {
+				switch p.PlainSupport[i].TokenID {
+				case 0:
+					p.PlainSupport[i].P -= 0.0002
+				case 64:
+					p.PlainSupport[i].P += 0.0002
+				}
+			}
+		}},
+		{name: "inconsistent tail", mut: func(p *LosslessnessPositionDistribution) { p.PlainTailMass = 0.001 }},
+		{name: "below offline tail floor", mut: func(p *LosslessnessPositionDistribution) {
+			p.HighEntropy = true
+			p.PlainTailMass = 0.001
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pos := validLosslessnessPosition()
+			tc.mut(&pos)
+			result := ValidateLosslessnessDistribution(pos, 64, 70, "tok-v1", "sha256:ctx", expectedLosslessnessIdentity(), true, pos.OfflinePlainSupport)
+			if result.ReasonCode != "inconclusive:malformed_distribution" {
+				t.Fatalf("reason = %q", result.ReasonCode)
+			}
+		})
+	}
+
+	pos := validLosslessnessPositionK256TailHigh()
+	result := ValidateLosslessnessDistribution(pos, 256, 300, "tok-v1", "sha256:ctx", expectedLosslessnessIdentity(), true, pos.OfflinePlainSupport)
+	if result.ReasonCode != "inconclusive:tail_mass_high" || !result.Retryable {
+		t.Fatalf("K=256 tail reason = %+v", result)
+	}
+}
+
+func TestLosslessnessStateTransitionsAndGridReadiness(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	record := LosslessnessProfileRecord{Key: losslessnessProfile(0.7), CalibrationAccepted: true}
+	var err error
+	record, err = ApplyLosslessnessReason(record, "quarantine_candidate:tv_lower_exceeded", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err = ApplyLosslessnessReason(record, "warn:threshold_exceeded", now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State != LosslessnessStatusWarn || record.ConsecutiveQuarantine != 1 {
+		t.Fatalf("after Q,W = %+v", record)
+	}
+	record, err = ApplyLosslessnessReason(record, "quarantine_candidate:tv_lower_exceeded", now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State != LosslessnessStatusDisabled {
+		t.Fatalf("Q,W,Q state = %q, want disabled", record.State)
+	}
+	qThenQ := LosslessnessProfileRecord{Key: losslessnessProfile(0.7), CalibrationAccepted: true}
+	qThenQ, err = ApplyLosslessnessReason(qThenQ, "quarantine_candidate:tv_lower_exceeded", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	qThenQ, err = ApplyLosslessnessReason(qThenQ, "quarantine_candidate:tv_lower_exceeded", now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if qThenQ.State != LosslessnessStatusDisabled {
+		t.Fatalf("Q,Q state = %q, want disabled", qThenQ.State)
+	}
+	qThenInconclusiveThenQ := LosslessnessProfileRecord{Key: losslessnessProfile(0.7), CalibrationAccepted: true}
+	for _, reason := range []string{
+		"quarantine_candidate:tv_lower_exceeded",
+		"inconclusive:tail_mass_high",
+		"quarantine_candidate:tv_lower_exceeded",
+	} {
+		qThenInconclusiveThenQ, err = ApplyLosslessnessReason(qThenInconclusiveThenQ, reason, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if qThenInconclusiveThenQ.State != LosslessnessStatusDisabled {
+		t.Fatalf("Q,inconclusive,Q state = %q, want disabled", qThenInconclusiveThenQ.State)
+	}
+	qThenPassThenQ := LosslessnessProfileRecord{Key: losslessnessProfile(0.7), VerdictEngineReady: true, CalibrationAccepted: true}
+	for _, reason := range []string{
+		"quarantine_candidate:tv_lower_exceeded",
+		"pass:fresh",
+		"quarantine_candidate:tv_lower_exceeded",
+	} {
+		qThenPassThenQ, err = ApplyLosslessnessReason(qThenPassThenQ, reason, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if qThenPassThenQ.State != LosslessnessStatusWarn {
+		t.Fatalf("Q,pass,Q state = %q, want warn", qThenPassThenQ.State)
+	}
+
+	missingCalibration := LosslessnessProfileRecord{Key: losslessnessProfile(0.7)}
+	missingCalibration, err = ApplyLosslessnessReason(missingCalibration, "quarantine_candidate:tv_lower_exceeded", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missingCalibration.ReasonCode != "blocked:calibration_missing" || missingCalibration.State != LosslessnessStatusBlocked {
+		t.Fatalf("missing calibration state = %+v", missingCalibration)
+	}
+	noVerdictPass := LosslessnessProfileRecord{Key: losslessnessProfile(0.7), CalibrationAccepted: true}
+	if _, err := ApplyLosslessnessReason(noVerdictPass, "pass:fresh", now); err == nil {
+		t.Fatal("pass:fresh accepted without verdict engine")
+	}
+
+	abuse := LosslessnessProfileRecord{Key: losslessnessProfile(0.5), VerdictEngineReady: true, CalibrationAccepted: true}
+	for i := 0; i < 3; i++ {
+		abuse, err = ApplyLosslessnessReason(abuse, "inconclusive:timeout", now.Add(time.Duration(i)*time.Hour))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if abuse.State != LosslessnessStatusBlocked {
+		t.Fatalf("abuse state = %q, want blocked", abuse.State)
+	}
+	abuse, err = ApplyLosslessnessReason(abuse, "pass:fresh", now.Add(4*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(abuse.AbusiveInconclusiveEvents) != 3 {
+		t.Fatalf("pass erased abuse events: %+v", abuse.AbusiveInconclusiveEvents)
+	}
+	if abuse.State != LosslessnessStatusBlocked {
+		t.Fatalf("pass re-enabled abusive profile: %q", abuse.State)
+	}
+
+	repeated := LosslessnessProfileRecord{Key: losslessnessProfile(0.2)}
+	for i := 0; i < 6; i++ {
+		repeated, err = ApplyLosslessnessReason(repeated, "inconclusive:tail_mass_high", now.Add(time.Duration(i)*time.Hour))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if repeated.State != LosslessnessStatusBlocked || len(repeated.AbusiveInconclusiveEvents) != 3 {
+		t.Fatalf("repeated tail_mass_high state/events = %q/%d", repeated.State, len(repeated.AbusiveInconclusiveEvents))
+	}
+
+	greedy := LosslessnessProfileRecord{Key: losslessnessProfile(0)}
+	greedy, err = ApplyLosslessnessReason(greedy, "blocked:greedy_control_failed", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if greedy.GreedyControlFailureCount != 1 || len(greedy.AbusiveInconclusiveEvents) != 0 {
+		t.Fatalf("greedy counters = %+v", greedy)
+	}
+
+	required := LosslessnessDefaultProfiles()
+	var records []LosslessnessProfileRecord
+	for _, profile := range required {
+		rec := LosslessnessProfileRecord{Key: losslessnessProfile(profile.Temperature), VerdictEngineReady: true, CalibrationAccepted: true}
+		rec.Key.SamplingProfile = profile
+		rec, err = ApplyLosslessnessReason(rec, "pass:fresh", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		records = append(records, rec)
+	}
+	grid := records[0].Key.GridKey()
+	if got := LosslessnessGridState(records, grid, required, now.Add(time.Hour)); got != "all_profiles_fresh" {
+		t.Fatalf("grid state = %q", got)
+	}
+	records[1].VerdictEngineReady = false
+	if got := LosslessnessGridState(records, grid, required, now.Add(time.Hour)); got != "not_ready" {
+		t.Fatalf("uncalibrated grid state = %q", got)
+	}
+	records[1].VerdictEngineReady = true
+	records[0].Key.TargetGeneration = 99
+	if got := LosslessnessGridState(records, grid, required, now.Add(time.Hour)); got != "not_ready" {
+		t.Fatalf("mixed grid state = %q", got)
+	}
+	records[0].Key.TargetGeneration = 1
+	records[2].StaleAfter = now.Add(-time.Second)
+	if got := LosslessnessGridState(records, grid, required, now); got != "not_ready" {
+		t.Fatalf("stale grid state = %q", got)
+	}
+}
+
+func TestLosslessnessConfigDefaultsDisabledAndValidateBounds(t *testing.T) {
+	cfg := config.Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	if cfg.Pool.LosslessnessProbe.Enabled {
+		t.Fatal("losslessness probe must default disabled")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("default config validates: %v", err)
+	}
+	cfg.Pool.LosslessnessProbe.Enabled = true
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("enabled bounded config validates: %v", err)
+	}
+	cfg.Pool.LosslessnessProbe.IntervalS = 3599
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("non-SPEC losslessness interval accepted")
+	}
+	cfg.Pool.LosslessnessProbe.IntervalS = 3600
+	cfg.Pool.LosslessnessProbe.TimeoutS = 61
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("non-SPEC losslessness timeout accepted")
+	}
+	cfg.Pool.LosslessnessProbe.TimeoutS = 60
+	cfg.Pool.LosslessnessProbe.MaxConcurrentPerProvider = 2
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("unsafe losslessness concurrency accepted")
+	}
+}
+
+func TestLosslessnessTier2UsesDedicatedCarrier(t *testing.T) {
+	s, provider, _ := newEncryptedRelayHarness(t)
+	session, ok := s.sessionFor(provider.ProviderID, provider.AssignedID)
+	if !ok {
+		t.Fatal("missing session")
+	}
+	payload := []byte(`{"type":"losslessness_probe_v1.request","probe_id":"probe-1","probe_request_digest":"sha256:test","payload":{"probe_id":"probe-1"}}`)
+	inferenceFrame, err := session.sealInferenceRequest(*provider, "probe-1", payload, false, nil, "")
+	if err != nil {
+		t.Fatalf("baseline inference seal: %v", err)
+	}
+	if bytes.Contains(inferenceFrame, []byte(losslessnessEncryptedRequestType)) {
+		t.Fatal("inference_request carrier accidentally used losslessness type")
+	}
+
+	sealed, err := session.sealLosslessnessProbeRequest(*provider, "probe-2", payload)
+	if err != nil {
+		t.Fatalf("seal losslessness request: %v", err)
+	}
+	var frame encryptedLosslessnessRequest
+	if err := json.Unmarshal(sealed, &frame); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if frame.Type != losslessnessEncryptedRequestType || frame.RequestID != "probe-2" || frame.Stream || !frame.Encrypted {
+		t.Fatalf("frame = %+v", frame)
+	}
+	aad := tier2.AEADFrameAAD{
+		Type:       losslessnessEncryptedRequestType,
+		Direction:  "c2p",
+		RequestID:  "probe-2",
+		Stream:     false,
+		ProviderID: provider.ProviderID,
+		AssignedID: provider.AssignedID,
+		Seq:        1,
+	}
+	opened, err := tier2.OpenPillarBFrame(provider.Tier2Session.C2PKey, provider.Tier2Session.C2PNonceBase, provider.Tier2Session.KeyID, 1, aad, tier2.AEADEnvelope{Encrypted: true, Enc: frame.Enc})
+	if err != nil {
+		t.Fatalf("open losslessness request: %v", err)
+	}
+	var plaintext encryptedLosslessnessPlaintext
+	if err := json.Unmarshal(opened, &plaintext); err != nil {
+		t.Fatal(err)
+	}
+	if plaintext.Type != losslessnessRequestPlaintextType || !bytes.Equal(plaintext.Payload, payload) {
+		t.Fatalf("plaintext = %+v", plaintext)
+	}
+}
+
+func TestLosslessnessCorpusRejectsBuyerOriginPrompts(t *testing.T) {
+	err := ValidateLosslessnessCorpusPrompt(LosslessnessPromptPayload{
+		PromptID:         "buyer-derived",
+		Prompt:           "secret buyer prompt",
+		CoordinatorOwned: true,
+		BuyerOrigin:      true,
+	})
+	if err == nil {
+		t.Fatal("buyer-origin corpus prompt accepted")
+	}
+}
+
+func TestLosslessnessPendingProbeBindsNonceDigestExpiryAndSingleUse(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	cfg := config.Default()
+	cfg.Pool.LosslessnessProbe.Enabled = true
+	s := NewServer(cfg, pool.NewRegistry(nil), zerolog.Nop(), WithNow(func() time.Time { return now }))
+	request := losslessnessTestRequestPayload(now.Add(time.Minute))
+	pending, err := s.recordLosslessnessPendingProbe("provider-a", "assigned-a", request, "sha256:req", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := LosslessnessProbeResultPayload{
+		ProbeID:            request.ProbeID,
+		ProbeNonce:         "wrong",
+		ProbeRequestDigest: "sha256:req",
+	}
+	if _, err := s.consumeLosslessnessPendingProbe("provider-a", "assigned-a", result, now); err == nil {
+		t.Fatal("nonce mismatch accepted")
+	}
+	s.losslessnessPending.Store(losslessnessProbeStoreKey("provider-a", "assigned-a", request.ProbeID), pending)
+	result.ProbeNonce = request.ProbeNonce
+	result.ProbeRequestDigest = "sha256:wrong"
+	if _, err := s.consumeLosslessnessPendingProbe("provider-a", "assigned-a", result, now); err == nil {
+		t.Fatal("digest mismatch accepted")
+	}
+	s.losslessnessPending.Store(losslessnessProbeStoreKey("provider-a", "assigned-a", request.ProbeID), pending)
+	result.ProbeRequestDigest = "sha256:req"
+	if _, err := s.consumeLosslessnessPendingProbe("provider-a", "assigned-a", result, now.Add(2*time.Minute)); err == nil {
+		t.Fatal("expired result accepted")
+	}
+	s.losslessnessPending.Store(losslessnessProbeStoreKey("provider-a", "assigned-a", request.ProbeID), pending)
+	if _, err := s.consumeLosslessnessPendingProbe("provider-a", "assigned-a", result, now); err != nil {
+		t.Fatalf("valid result rejected: %v", err)
+	}
+	if _, err := s.consumeLosslessnessPendingProbe("provider-a", "assigned-a", result, now); err == nil {
+		t.Fatal("replayed result accepted")
+	}
+}
+
+func TestLosslessnessPendingProbeRejectsDuplicateIndexes(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	cfg := config.Default()
+	cfg.Pool.LosslessnessProbe.Enabled = true
+	s := NewServer(cfg, pool.NewRegistry(nil), zerolog.Nop(), WithNow(func() time.Time { return now }))
+	request := losslessnessTestRequestPayload(now.Add(time.Minute))
+	if _, err := s.recordLosslessnessPendingProbe("provider-a", "assigned-a", request, "sha256:req", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.recordLosslessnessPendingProbe("provider-a", "assigned-a", request, "sha256:req-2", now); err == nil {
+		t.Fatal("duplicate probe_id accepted")
+	}
+	duplicateNonce := request
+	duplicateNonce.ProbeID = "probe-b"
+	if _, err := s.recordLosslessnessPendingProbe("provider-a", "assigned-a", duplicateNonce, "sha256:req-b", now); err == nil {
+		t.Fatal("duplicate nonce accepted")
+	}
+	duplicateDigest := request
+	duplicateDigest.ProbeID = "probe-c"
+	duplicateDigest.ProbeNonce = "nonce-c"
+	if _, err := s.recordLosslessnessPendingProbe("provider-a", "assigned-a", duplicateDigest, "sha256:req", now); err == nil {
+		t.Fatal("duplicate request digest accepted")
+	}
+}
+
+func TestLosslessnessHandlerRequiresPendingProbeAndPersistsProfileState(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	cfg := config.Default()
+	cfg.Pool.LosslessnessProbe.Enabled = true
+	s := NewServer(cfg, pool.NewRegistry(nil), zerolog.Nop(), WithNow(func() time.Time { return now }))
+	request := losslessnessTestRequestPayload(now.Add(time.Minute))
+	result := losslessnessProviderInconclusivePayload(request.ProbeID, request.ProbeNonce, "sha256:req")
+	cleartext := losslessnessResultOuter(t, result, "sha256:req")
+	s.handleLosslessnessProbeResult("provider-a", "assigned-a", cleartext)
+	if _, ok := s.losslessnessProfileSnapshot(losslessnessProfile(0.7)); ok {
+		t.Fatal("result without pending probe created profile state")
+	}
+	if _, err := s.recordLosslessnessPendingProbe("provider-a", "assigned-a", request, "sha256:req", now); err != nil {
+		t.Fatal(err)
+	}
+	s.handleLosslessnessProbeResult("provider-a", "assigned-a", cleartext)
+	record, ok := s.losslessnessProfileSnapshot(losslessnessProfile(0.7))
+	if !ok {
+		t.Fatal("pending result did not create profile state")
+	}
+	if record.State != LosslessnessStatusBlocked || record.ReasonCode != "inconclusive:unsupported_sampler" {
+		t.Fatalf("record = %+v, want blocked unsupported_sampler", record)
+	}
+	s.handleLosslessnessProbeResult("provider-a", "assigned-a", cleartext)
+	recordAfterReplay, _ := s.losslessnessProfileSnapshot(losslessnessProfile(0.7))
+	if len(recordAfterReplay.AbusiveInconclusiveEvents) != len(record.AbusiveInconclusiveEvents) {
+		t.Fatalf("replay mutated profile events: before=%d after=%d", len(record.AbusiveInconclusiveEvents), len(recordAfterReplay.AbusiveInconclusiveEvents))
+	}
+}
+
+func TestLosslessnessHandlerRejectsPlaintextResultForTier2Session(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	cfg := config.Default()
+	cfg.Pool.LosslessnessProbe.Enabled = true
+	s, provider, _ := newEncryptedRelayHarnessWithConfig(t, cfg, zerolog.Nop(), now)
+	s.now = func() time.Time { return now }
+	request := losslessnessTestRequestPayload(now.Add(time.Minute))
+	if _, err := s.recordLosslessnessPendingProbe(provider.ProviderID, provider.AssignedID, request, "sha256:req", now); err != nil {
+		t.Fatal(err)
+	}
+	result := losslessnessProviderInconclusivePayload(request.ProbeID, request.ProbeNonce, "sha256:req")
+	s.handleLosslessnessProbeResult(provider.ProviderID, provider.AssignedID, losslessnessResultOuter(t, result, "sha256:req"))
+	if _, ok := s.losslessnessProfileSnapshot(losslessnessProfile(0.7)); ok {
+		t.Fatal("plaintext result for active tier2 session created profile state")
+	}
+	if _, ok := s.losslessnessPending.Load(losslessnessProbeStoreKey(provider.ProviderID, provider.AssignedID, request.ProbeID)); !ok {
+		t.Fatal("plaintext tier2 rejection consumed pending probe")
+	}
+}
+
+func TestLosslessnessIssueProbeSeedsPendingAndUsesDedicatedCarrier(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	cfg := config.Default()
+	cfg.Pool.LosslessnessProbe.Enabled = true
+	s, provider, providerConn := newEncryptedRelayHarnessWithConfig(t, cfg, zerolog.Nop(), now)
+	s.now = func() time.Time { return now }
+	seedLosslessnessDraftAdmission(t, s, provider, now.Add(time.Hour))
+	if err := s.issueLosslessnessProbeRequest(*provider, LosslessnessSamplingProfile{Temperature: 0.7, TopP: 1}); err != nil {
+		t.Fatalf("issue probe: %v", err)
+	}
+	if err := providerConn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	frame, err := gobwas.ReadFrame(providerConn)
+	if err != nil {
+		t.Fatalf("read probe frame: %v", err)
+	}
+	var carrier encryptedLosslessnessRequest
+	if err := json.Unmarshal(frame.Payload, &carrier); err != nil {
+		t.Fatal(err)
+	}
+	if carrier.Type != losslessnessEncryptedRequestType || carrier.RequestID == "" || !carrier.Encrypted || carrier.Stream {
+		t.Fatalf("carrier = %+v", carrier)
+	}
+	value, ok := s.losslessnessPending.Load(losslessnessProbeStoreKey(provider.ProviderID, provider.AssignedID, carrier.RequestID))
+	if !ok {
+		t.Fatal("issued probe did not seed pending store")
+	}
+	pending := value.(losslessnessPendingProbe)
+	if pending.VocabSize <= 0 || pending.ExpectedContextHash[0] == "" || len(pending.OfflinePlainSupport[0]) == 0 {
+		t.Fatalf("pending missing safety metadata: %+v", pending)
+	}
+	if len(pending.RequestedPositions) != 8 || !pending.HighEntropyPosition[0] {
+		t.Fatalf("pending missing requested/high-entropy metadata: %+v", pending)
+	}
+}
+
+func TestLosslessnessIssueProbeBlocksWithoutDraftAdmission(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	cfg := config.Default()
+	cfg.Pool.LosslessnessProbe.Enabled = true
+	s, provider, _ := newEncryptedRelayHarnessWithConfig(t, cfg, zerolog.Nop(), now)
+	s.now = func() time.Time { return now }
+	if err := s.issueLosslessnessProbeRequest(*provider, LosslessnessSamplingProfile{Temperature: 0.7, TopP: 1}); err == nil {
+		t.Fatal("probe issued without draft admission")
+	}
+	events := s.losslessnessTelemetrySnapshot()
+	if len(events) != 1 || events[0].EventSubtype != "admission_blocked" || events[0].ReasonCode != "inconclusive:draft_identity_unbound" {
+		t.Fatalf("admission-blocked telemetry = %+v", events)
+	}
+}
+
+func TestLosslessnessSchedulerRotatesDefaultProfiles(t *testing.T) {
+	cfg := config.Default()
+	cfg.Pool.LosslessnessProbe.Enabled = true
+	s := NewServer(cfg, pool.NewRegistry(nil), zerolog.Nop())
+	provider := pool.Provider{ProviderID: "provider-a", AssignedID: "assigned-a", ModelID: "model-a"}
+	want := LosslessnessDefaultProfiles()
+	for i, expected := range append(want, want[0]) {
+		got := s.nextLosslessnessProfile(provider)
+		if got != expected {
+			t.Fatalf("profile[%d] = %+v, want %+v", i, got, expected)
+		}
+	}
+}
+
+func TestLosslessnessMeasurementVerdictFailsClosedWithoutSafetyMetadataAndRequiresK256Retry(t *testing.T) {
+	pos := validLosslessnessPosition()
+	expected := expectedLosslessnessIdentity()
+	result := LosslessnessProbeResultPayload{
+		ProbeID:              "probe-a",
+		ProbeNonce:           "nonce-a",
+		ProbeRequestDigest:   "sha256:req",
+		ResultKind:           "measurement",
+		TargetModelHash:      "sha256:target",
+		TargetGeneration:     1,
+		DraftArtifactBinding: &expected.DraftArtifactBinding,
+		DraftGeneration:      1,
+		TokenizerIdentity:    "tok-v1",
+		Positions:            []LosslessnessPositionDistribution{pos},
+	}
+	pending := losslessnessPendingProbe{
+		RequestedK:        64,
+		TokenizerIdentity: "tok-v1",
+		ExpectedIdentity:  *expected,
+	}
+	if got := losslessnessReasonForMeasurement(result, pending); got != "inconclusive:position_mismatch" {
+		t.Fatalf("missing metadata reason = %q", got)
+	}
+	pending.VocabSize = 70
+	pending.RequestedPositions = map[int]struct{}{pos.PositionIndex: struct{}{}}
+	pending.ExpectedContextHash = map[int]string{pos.PositionIndex: pos.ContextHash}
+	pending.HighEntropyPosition = map[int]bool{pos.PositionIndex: true}
+	pending.OfflinePlainSupport = map[int][]LosslessnessTokenProbability{pos.PositionIndex: pos.OfflinePlainSupport}
+	pos.HighEntropy = false
+	result.Positions = []LosslessnessPositionDistribution{pos}
+	if got := losslessnessReasonForMeasurement(result, pending); got != "inconclusive:tail_mass_high" {
+		t.Fatalf("K=64 retry reason = %q", got)
+	}
+	extraPos := pos
+	extraPos.PositionIndex = 99
+	result.Positions = []LosslessnessPositionDistribution{pos, extraPos}
+	if got := losslessnessReasonForMeasurement(result, pending); got != "inconclusive:position_mismatch" {
+		t.Fatalf("extra position reason = %q", got)
+	}
+	if losslessnessCanonicalMedian([]float64{0.03, 0.01, 0.02, 0.04}) != 0.02 {
+		t.Fatal("canonical median did not use lower-middle index")
+	}
+}
+
+func BenchmarkLosslessnessDispatchDisabledDefault(b *testing.B) {
+	cfg := config.Default()
+	registry := losslessnessBenchmarkRegistry(100, pool.StateReady)
+	s := NewServer(cfg, registry, zerolog.Nop())
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		s.dispatchLosslessnessProbeRound()
+	}
+}
+
+func BenchmarkLosslessnessDispatchEnabledUnavailableProviders(b *testing.B) {
+	cfg := config.Default()
+	cfg.Pool.LosslessnessProbe.Enabled = true
+	cfg.Pool.LosslessnessProbe.IntervalS = 0
+	registry := losslessnessBenchmarkRegistry(100, pool.StateUnavailable)
+	s := NewServer(cfg, registry, zerolog.Nop())
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		s.dispatchLosslessnessProbeRound()
+	}
+}
+
+func BenchmarkLosslessnessValidateDistributionK64(b *testing.B) {
+	pos := validLosslessnessPosition()
+	expected := expectedLosslessnessIdentity()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result := ValidateLosslessnessDistribution(pos, 64, 70, "tok-v1", "sha256:ctx", expected, true, pos.OfflinePlainSupport)
+		if result.ReasonCode != "valid" {
+			b.Fatalf("reason = %q", result.ReasonCode)
+		}
+	}
+}
+
+type losslessnessFixture struct {
+	ID             string         `json:"id"`
+	ExpectedSHA256 string         `json:"expected_sha256"`
+	Payload        map[string]any `json:"payload"`
+}
+
+func loadLosslessnessFixtures(t *testing.T) []losslessnessFixture {
+	t.Helper()
+	path := filepath.Join("..", "..", "test", "jcs_fixtures", "spec029", "losslessness_probe_v1.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixtures []losslessnessFixture
+	if err := json.Unmarshal(raw, &fixtures); err != nil {
+		t.Fatal(err)
+	}
+	return fixtures
+}
+
+func losslessnessBenchmarkRegistry(n int, state pool.State) *pool.Registry {
+	registry := pool.NewRegistry(nil)
+	for i := 0; i < n; i++ {
+		suffix := strconv.Itoa(i)
+		registry.Register(&pool.Provider{
+			ProviderID:     "bench-provider-" + suffix,
+			AssignedID:     "bench-session-" + suffix,
+			ModelID:        "bench-model",
+			State:          state,
+			SlotsFree:      1,
+			SlotsTotal:     1,
+			MaxConcurrency: 1,
+			Tier:           pool.TierProvisional,
+			InferencePath:  pool.InferencePathWSTunneled,
+			EncryptedLeg:   true,
+		}, nil)
+	}
+	return registry
+}
+
+func validLosslessnessPosition() LosslessnessPositionDistribution {
+	plainTop := make([]int, 64)
+	specTop := make([]int, 64)
+	for i := 0; i < 64; i++ {
+		plainTop[i] = i
+		specTop[i] = i
+	}
+	support := numericUnion(plainTop, specTop)
+	plainSupport, plainTail := descendingSupport(support, 0)
+	specSupport, specTail := descendingSupport(support, 1)
+	return LosslessnessPositionDistribution{
+		PositionIndex:     4,
+		ContextHash:       "sha256:ctx",
+		SupportSelection:  losslessnessSupportSelection,
+		PlainTopKTokenIDs: plainTop,
+		SpecTopKTokenIDs:  specTop,
+		SupportTokenIDs:   support,
+		PlainSupport:      plainSupport,
+		PlainTailMass:     plainTail,
+		SpecSupport:       specSupport,
+		SpecTailMass:      specTail,
+		TargetModelHash:   "sha256:target",
+		TargetGeneration:  1,
+		DraftArtifactBinding: LosslessnessDraftArtifactBinding{
+			DraftModelID:             "draft-a",
+			DraftArtifactSHA256:      "sha256:draft",
+			TokenizerIdentity:        "tok-v1",
+			CompatibilityCheckDigest: "sha256:compat",
+		},
+		DraftGeneration:     1,
+		TokenizerIdentity:   "tok-v1",
+		NormalizationBasis:  losslessnessNormalizationBasis,
+		SamplerStage:        losslessnessSamplerStage,
+		HighEntropy:         true,
+		OfflinePlainSupport: plainSupport,
+	}
+}
+
+func expectedLosslessnessIdentity() *LosslessnessExpectedPositionIdentity {
+	return &LosslessnessExpectedPositionIdentity{
+		TargetModelHash:  "sha256:target",
+		TargetGeneration: 1,
+		DraftArtifactBinding: LosslessnessDraftArtifactBinding{
+			DraftModelID:             "draft-a",
+			DraftArtifactSHA256:      "sha256:draft",
+			TokenizerIdentity:        "tok-v1",
+			CompatibilityCheckDigest: "sha256:compat",
+		},
+		DraftGeneration: 1,
+	}
+}
+
+func validLosslessnessPositionK256TailHigh() LosslessnessPositionDistribution {
+	top := make([]int, 256)
+	probs := make([]LosslessnessTokenProbability, 256)
+	for i := 0; i < 256; i++ {
+		top[i] = i
+		probs[i] = LosslessnessTokenProbability{TokenID: i, P: 0.994 / 256.0}
+	}
+	pos := validLosslessnessPosition()
+	pos.PlainTopKTokenIDs = top
+	pos.SpecTopKTokenIDs = top
+	pos.SupportTokenIDs = append([]int(nil), top...)
+	pos.PlainSupport = probs
+	pos.SpecSupport = probs
+	pos.PlainTailMass = 0.006
+	pos.SpecTailMass = 0.006
+	pos.OfflinePlainSupport = probs
+	return pos
+}
+
+func descendingSupport(ids []int, offset int) ([]LosslessnessTokenProbability, float64) {
+	out := make([]LosslessnessTokenProbability, 0, len(ids))
+	var sum float64
+	for _, id := range ids {
+		p := float64(80-id-offset) / 10000.0
+		if p < 0.0001 {
+			p = 0.0001
+		}
+		out = append(out, LosslessnessTokenProbability{TokenID: id, P: p})
+		sum += p
+	}
+	return out, 1 - sum
+}
+
+func losslessnessProfile(temp float64) LosslessnessProfileKey {
+	return LosslessnessProfileKey{
+		ProviderID:       "provider-a",
+		AssignedID:       "assigned-a",
+		ModelID:          "model-a",
+		TargetModelHash:  "sha256:target",
+		TargetGeneration: 1,
+		DraftModelID:     "draft-a",
+		DraftArtifactBinding: LosslessnessDraftArtifactBinding{
+			DraftModelID:             "draft-a",
+			DraftArtifactSHA256:      "sha256:draft",
+			TokenizerIdentity:        "tok-v1",
+			CompatibilityCheckDigest: "sha256:compat",
+		},
+		DraftGeneration:  1,
+		SamplingProfile:  LosslessnessSamplingProfile{Temperature: temp, TopP: 1},
+		CorpusVersion:    "corpus-v1",
+		ThresholdVersion: "threshold-v1",
+	}
+}
+
+func losslessnessTestRequestPayload(expiresAt time.Time) LosslessnessProbeRequestPayload {
+	pos := validLosslessnessPosition()
+	return LosslessnessProbeRequestPayload{
+		ProbeVersion:     LosslessnessProbeVersion,
+		ProbeID:          "probe-a",
+		ProbeNonce:       "nonce-a",
+		ExpiresAt:        expiresAt.UTC().Format(time.RFC3339Nano),
+		ModelID:          "model-a",
+		TargetModelHash:  "sha256:target",
+		TargetGeneration: 1,
+		DraftModelID:     "draft-a",
+		DraftArtifactBinding: LosslessnessDraftArtifactBinding{
+			DraftModelID:             "draft-a",
+			DraftArtifactSHA256:      "sha256:draft",
+			TokenizerIdentity:        "tok-v1",
+			CompatibilityCheckDigest: "sha256:compat",
+		},
+		DraftGeneration:        1,
+		TokenizerIdentity:      "tok-v1",
+		SamplingProfile:        LosslessnessSamplingProfile{Temperature: 0.7, TopP: 1},
+		CorpusVersion:          "corpus-v1",
+		ThresholdVersion:       "threshold-v1",
+		MeasurementPositions:   []int{pos.PositionIndex},
+		RequestedK:             64,
+		SupportSelection:       losslessnessSupportSelection,
+		MaxPrompts:             4,
+		MaxStochasticPositions: 8,
+		TimeoutMS:              60000,
+		VocabSize:              70,
+		PositionContextHashes:  map[int]string{pos.PositionIndex: pos.ContextHash},
+		HighEntropyPositions:   map[int]bool{pos.PositionIndex: true},
+		OfflinePlainSupport:    map[int][]LosslessnessTokenProbability{pos.PositionIndex: pos.OfflinePlainSupport},
+	}
+}
+
+func seedLosslessnessDraftAdmission(t *testing.T, s *Server, provider *pool.Provider, expiresAt time.Time) {
+	t.Helper()
+	s.recordLosslessnessDraftAdmission(LosslessnessDraftAdmissionRecord{
+		ProviderID:       provider.ProviderID,
+		AssignedID:       provider.AssignedID,
+		ModelID:          provider.ModelID,
+		TargetModelHash:  "sha256:target",
+		TargetGeneration: 1,
+		DraftModelID:     "draft-a",
+		DraftArtifactBinding: LosslessnessDraftArtifactBinding{
+			DraftModelID:             "draft-a",
+			DraftArtifactSHA256:      "sha256:draft",
+			TokenizerIdentity:        "tok-v1",
+			CompatibilityCheckDigest: "sha256:compat",
+		},
+		DraftGeneration:   1,
+		TokenizerIdentity: "tok-v1",
+		ExpiresAt:         expiresAt,
+	})
+}
+
+func losslessnessProviderInconclusivePayload(probeID, nonce, requestDigest string) map[string]any {
+	return map[string]any{
+		"probe_id":                    probeID,
+		"probe_nonce":                 nonce,
+		"probe_request_digest":        requestDigest,
+		"result_kind":                 "provider_inconclusive",
+		"provider_reason_code":        "inconclusive:unsupported_sampler",
+		"identity_unavailable_reason": "sampler hook unavailable",
+		"target_model_hash":           nil,
+		"target_generation":           nil,
+		"draft_artifact_binding":      nil,
+		"draft_generation":            nil,
+	}
+}
+
+func losslessnessResultOuter(t *testing.T, payload map[string]any, requestDigest string) []byte {
+	t.Helper()
+	payloadRaw := mustMarshal(t, payload)
+	resultDigest, err := LosslessnessDigest(payloadRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mustMarshal(t, map[string]any{
+		"type":                 losslessnessResultType,
+		"probe_id":             payload["probe_id"],
+		"probe_request_digest": requestDigest,
+		"probe_result_digest":  resultDigest,
+		"payload":              json.RawMessage(payloadRaw),
+	})
+}
+
+func mustMarshal(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestLosslessnessPlaintextTier2ResultOpensDedicatedCarrier(t *testing.T) {
+	_, provider, _ := newEncryptedRelayHarness(t)
+	serverConn, providerConn := net.Pipe()
+	defer serverConn.Close()
+	defer providerConn.Close()
+	session := newProviderSession(provider.ProviderID, provider.AssignedID, serverConn, 4)
+	session.useTier2Session(provider.Tier2Session)
+
+	cleartext := []byte(`{"type":"losslessness_probe_v1.result","probe_id":"probe-result","probe_request_digest":"sha256:req","probe_result_digest":"sha256:res","payload":{"probe_id":"probe-result"}}`)
+	plaintext, err := json.Marshal(encryptedLosslessnessPlaintext{Type: losslessnessResultPlaintextType, Payload: cleartext})
+	if err != nil {
+		t.Fatal(err)
+	}
+	aad := tier2.AEADFrameAAD{
+		Type:       losslessnessEncryptedResultType,
+		Direction:  "p2c",
+		RequestID:  "probe-result",
+		Stream:     false,
+		ProviderID: provider.ProviderID,
+		AssignedID: provider.AssignedID,
+		Seq:        0,
+	}
+	envelope, err := tier2.SealPillarBFrame(provider.Tier2Session.P2CKey, provider.Tier2Session.P2CNonceBase, provider.Tier2Session.KeyID, 0, aad, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opened, err := session.openLosslessnessProbeResult(*provider, "probe-result", envelope)
+	if err != nil {
+		t.Fatalf("open result: %v", err)
+	}
+	if !bytes.Equal(opened, cleartext) {
+		t.Fatalf("opened = %s", opened)
+	}
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -47,27 +47,37 @@ const (
 )
 
 type Server struct {
-	cfg             config.Config
-	tier2Mu         sync.RWMutex
-	tier2           config.Tier2Config
-	pool            *pool.Registry
-	log             zerolog.Logger
-	now             func() time.Time
-	newUUID         func() string
-	timers          sync.Map
-	pending         sync.Map
-	warmups         sync.Map
-	canaries        sync.Map
-	canaryDue       sync.Map
+	cfg       config.Config
+	tier2Mu   sync.RWMutex
+	tier2     config.Tier2Config
+	pool      *pool.Registry
+	log       zerolog.Logger
+	now       func() time.Time
+	newUUID   func() string
+	timers    sync.Map
+	pending   sync.Map
+	warmups   sync.Map
+	canaries  sync.Map
+	canaryDue sync.Map
 	// enforceNextCanary marks provider IDs (presence = true) whose NEXT canary
 	// probe must be enforced (no cold-start grace). Set after a graced-neutral
 	// probe and cleared after any recorded (enforced) probe, so a graced probe
 	// is always followed by an enforced one — a provider cannot arrange (via
 	// reconnect / due-timing churn) to only ever be probed under grace and evade
 	// the TTFT sanction. Keyed by PROVIDER ID so it survives reconnects.
-	enforceNextCanary sync.Map
-	canarySanctions CanarySanctionStore
-	tokens          TokenValidator
+	enforceNextCanary             sync.Map
+	losslessnessPending           sync.Map
+	losslessnessNonceIndex        sync.Map
+	losslessnessDigestIndex       sync.Map
+	losslessnessProfilesMu        sync.Mutex
+	losslessnessProfiles          map[LosslessnessProfileKey]LosslessnessProfileRecord
+	losslessnessStateMu           sync.Mutex
+	losslessnessDraftAdmissions   map[losslessnessDraftAdmissionKey]LosslessnessDraftAdmissionRecord
+	losslessnessTargetGenerations map[string]int
+	losslessnessProfileCursor     map[string]int
+	losslessnessTelemetry         []LosslessnessTelemetryEvent
+	canarySanctions               CanarySanctionStore
+	tokens                        TokenValidator
 	// SPEC-003 v0.8 FR-C9.1 — separate issuer field so validator and
 	// issuer roles can be wired independently. Production wires the same
 	// concrete *auth.Store to both (see main.go), but tests can override
@@ -384,16 +394,20 @@ type pendingPreflight struct {
 
 func NewServer(cfg config.Config, registry *pool.Registry, logger zerolog.Logger, opts ...Option) *Server {
 	s := &Server{
-		cfg:         cfg,
-		tier2:       cfg.Tier2,
-		pool:        registry,
-		log:         logger,
-		now:         func() time.Time { return time.Now().UTC() },
-		newUUID:     func() string { return uuid.NewString() },
-		started:     time.Now().UTC(),
-		unauth:      make(chan struct{}, cfg.ProviderWSMaxUnauthenticatedConn()),
-		unauthPerIP: map[string]int{},
-		version:     "dev",
+		cfg:                           cfg,
+		tier2:                         cfg.Tier2,
+		pool:                          registry,
+		log:                           logger,
+		now:                           func() time.Time { return time.Now().UTC() },
+		newUUID:                       func() string { return uuid.NewString() },
+		started:                       time.Now().UTC(),
+		unauth:                        make(chan struct{}, cfg.ProviderWSMaxUnauthenticatedConn()),
+		unauthPerIP:                   map[string]int{},
+		losslessnessProfiles:          map[LosslessnessProfileKey]LosslessnessProfileRecord{},
+		losslessnessDraftAdmissions:   map[losslessnessDraftAdmissionKey]LosslessnessDraftAdmissionRecord{},
+		losslessnessTargetGenerations: map[string]int{},
+		losslessnessProfileCursor:     map[string]int{},
+		version:                       "dev",
 	}
 	s.authAttempts = newAuthAttemptStore(1024)
 	s.admission = NewAdmissionManager(cfg.Admission, s.now)
@@ -418,6 +432,9 @@ func NewServer(cfg config.Config, registry *pool.Registry, logger zerolog.Logger
 	}
 	if registry != nil {
 		go s.runSELivenessLoop()
+	}
+	if cfg.Pool.LosslessnessProbe.Enabled && registry != nil {
+		go s.runLosslessnessProbeLoop()
 	}
 	return s
 }
@@ -1830,6 +1847,8 @@ func (s *Server) handleMessage(conn net.Conn, providerID, assignedID string, pay
 		s.handleDrainStatus(conn, providerID, assignedID, payload)
 	case "se_liveness_response":
 		s.handleSELivenessResponse(providerID, assignedID, payload)
+	case losslessnessResultType, losslessnessEncryptedResultType:
+		s.handleLosslessnessProbeResult(providerID, assignedID, payload)
 	default:
 		// SPEC-002 v1.5.1 R-2 / issue #197 R5 security: envelope.Type
 		// is provider-controlled and reaches structured logs only on

--- a/phase4-coordinator/test/jcs_fixtures/spec029/losslessness_probe_v1.json
+++ b/phase4-coordinator/test/jcs_fixtures/spec029/losslessness_probe_v1.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "request_payload",
+    "expected_sha256": "sha256:20cff86ed6f6fd472ddf7ff8b7ed3e7c3a634e84ed423bd65b3ba0433acd0cea",
+    "payload": {
+      "probe_version": "losslessness_probe_v1",
+      "probe_id": "probe-fixture-001",
+      "probe_nonce": "00112233445566778899aabbccddeeff",
+      "expires_at": "2026-07-09T12:01:00Z",
+      "model_id": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+      "target_model_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_generation": 1,
+      "draft_model_id": "mlx-community/Qwen2.5-1.5B-Instruct-4bit",
+      "draft_artifact_binding": {
+        "draft_model_id": "mlx-community/Qwen2.5-1.5B-Instruct-4bit",
+        "draft_artifact_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "tokenizer_identity": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "compatibility_check_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      },
+      "draft_generation": 2,
+      "tokenizer_identity": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "sampling_profile": {
+        "temperature": 0.7,
+        "top_p": 1
+      },
+      "corpus_version": "spec029-corpus-v1",
+      "threshold_version": "spec029-threshold-v1",
+      "prompts": [
+        {
+          "prompt_id": "synthetic-code-001",
+          "prompt": "Return the next token distribution for this synthetic coordinator prompt.",
+          "coordinator_owned": true,
+          "buyer_origin": false
+        }
+      ],
+      "measurement_positions": [
+        4,
+        8
+      ],
+      "requested_k": 64,
+      "support_selection": "support_selection_v1",
+      "max_prompts": 4,
+      "max_stochastic_positions": 8,
+      "timeout_ms": 60000
+    }
+  },
+  {
+    "id": "measurement_result_payload",
+    "expected_sha256": "sha256:ef24c3561e210e5eb889adf90886a9317114e06006bcf0f7a699d2b93dcbc21e",
+    "payload": {
+      "probe_id": "probe-fixture-001",
+      "probe_nonce": "00112233445566778899aabbccddeeff",
+      "probe_request_digest": "sha256:20cff86ed6f6fd472ddf7ff8b7ed3e7c3a634e84ed423bd65b3ba0433acd0cea",
+      "result_kind": "measurement",
+      "target_model_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_generation": 1,
+      "draft_artifact_binding": {
+        "draft_model_id": "mlx-community/Qwen2.5-1.5B-Instruct-4bit",
+        "draft_artifact_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "tokenizer_identity": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "compatibility_check_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      },
+      "draft_generation": 2,
+      "tokenizer_identity": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "positions": []
+    }
+  },
+  {
+    "id": "provider_inconclusive_payload",
+    "expected_sha256": "sha256:5076a7383c9b5d87d809ce97669ae18f1268525378cf0c813a24db15a6632963",
+    "payload": {
+      "probe_id": "probe-fixture-001",
+      "probe_nonce": "00112233445566778899aabbccddeeff",
+      "probe_request_digest": "sha256:20cff86ed6f6fd472ddf7ff8b7ed3e7c3a634e84ed423bd65b3ba0433acd0cea",
+      "result_kind": "provider_inconclusive",
+      "provider_reason_code": "inconclusive:unsupported_sampler",
+      "target_model_hash": null,
+      "target_generation": null,
+      "draft_artifact_binding": null,
+      "draft_generation": null,
+      "identity_unavailable_reason": "sampler hook unavailable"
+    }
+  },
+  {
+    "id": "raw_rfc8785_string_payload",
+    "expected_sha256": "sha256:09d6bff957ca9f04e3e0949343e522bcd217f02830d6b4607e97a564b207f8cb",
+    "payload": {
+      "probe_id": "unicode-probe",
+      "prompt": "Café",
+      "top_p": 1.0
+    }
+  }
+]

--- a/specs/BUILD_SPEC_029_v0_1_IMPL_PROMPT.md
+++ b/specs/BUILD_SPEC_029_v0_1_IMPL_PROMPT.md
@@ -1,0 +1,563 @@
+# BUILD_SPEC_029_v0_1_IMPL_PROMPT - Losslessness Probe
+
+You are starting a fresh implementation session in the MacProvider repo. You
+have no memory of prior conversations. Read this prompt end-to-end before
+writing code.
+
+## 0. Workspace And Authority
+
+Before editing anything, verify:
+
+```bash
+pwd
+git status -sb
+git fetch origin
+sed -n '1,80p' CLAUDE.md
+sed -n '1,40p' specs/SPEC-029-losslessness-probe.md
+```
+
+Work on a feature branch or isolated implementation worktree, never local
+`main`:
+
+```bash
+git worktree add ../macprovider-impl-spec-029-losslessness -b impl/spec-029-losslessness-probe origin/main
+cd ../macprovider-impl-spec-029-losslessness
+```
+
+If `specs/SPEC-029-losslessness-probe.md` is not present at the implementation
+base, STOP and rebase onto the branch that contains SPEC-029.
+
+SPEC-029 is allowed to drive implementation only after one of these is true:
+
+1. `specs/SPEC-029-losslessness-probe.md` is marked `v0.1 LOCKED`; or
+2. the user explicitly asks for a draft/prototype implementation from the
+   current SPEC-029 draft.
+
+If neither is true, STOP after preflight and report that SPEC-029 is still
+draft. Do not silently implement a draft protocol as production behavior.
+
+Controlling contract:
+
+- `specs/SPEC-029-losslessness-probe.md`.
+- `docs/research/losslessness-probe-2026-07.md` as non-normative background
+  only.
+- `specs/SPEC-028-mlx-speculative-decoding.md`.
+- `specs/SPEC-015-receipts.md` v0.4.2 receipt invariants.
+- `specs/SPEC-022-verified-model-settlement.md`.
+- Repo rules: `AGENTS.md` and `CLAUDE.md`.
+
+Clean-room boundary: do not inspect Darkbloom / layr-labs `d-inference`
+source. SPEC-029 references public papers and public upstream MLX surfaces only.
+
+## 1. Objective
+
+Implement SPEC-029 v0.1 losslessness probes end-to-end:
+
+- Coordinator-owned `losslessness_probe_v1` scheduling, request construction,
+  replay/auth/load bounds, validation, TV interval computation, state machine,
+  telemetry, and operator dashboard state.
+- Provider-side draft admission, target/draft identity echo, cleartext and
+  Tier-2 probe carrier handling, compact shared-support distribution output,
+  provider-inconclusive result variants, and warm-swap handling.
+- Corpus, calibration, threshold, privacy, and rollout-consumer gates required
+  to make `all_profiles_fresh` usable as SPEC-028 evidence.
+
+This is a probe/evidence surface only. It MUST NOT:
+
+- change SPEC-015 v0.4 receipt tuple or `usage`;
+- change SPEC-022 settlement semantics;
+- add buyer-visible `/v1/chat/completions` request/response fields;
+- route losslessness failures into echo-canary/general provider readiness;
+- enable stochastic speculative decoding without the separate SPEC-028 rollout
+  approval gate.
+
+## 2. Required Reading
+
+Read before coding:
+
+1. `CLAUDE.md`.
+2. `specs/SPEC-029-losslessness-probe.md` end-to-end.
+3. `docs/research/losslessness-probe-2026-07.md` for context only; the SPEC is
+   normative when they differ.
+4. `specs/SPEC-028-mlx-speculative-decoding.md`, especially the provider
+   target/draft lifecycle, telemetry, request gating, and warm-swap sections.
+5. `specs/SPEC-015-receipts.md` v0.4 strict receipt/usage sections.
+6. `specs/SPEC-022-verified-model-settlement.md` for money-path boundaries.
+7. Coordinator WS/canary code:
+   - `phase4-coordinator/internal/ws/server.go`
+   - `phase4-coordinator/internal/ws/messages.go`
+   - `phase4-coordinator/internal/ws/canary_store.go`
+   - `phase4-coordinator/internal/ws/canary_test.go`
+8. Coordinator config/stats/operator surfaces:
+   - `phase4-coordinator/internal/config/config.go`
+   - `phase4-coordinator/internal/stats/`
+   - `phase4-coordinator/internal/ws/admin_endpoints.go`
+9. Provider WS/Tier-2/runtime code:
+   - `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+   - `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift`
+   - `phase3-binary/Sources/macprovider-cli/Tier2ProviderSession.swift`
+   - `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+   - `phase3-binary/Sources/macprovider-cli/HTTPServer.swift`
+   - `phase3-binary/Sources/MacProviderCore/ChatCompletionRequest.swift`
+10. Receipt and prompt-hash code to prove no SPEC-015 mutation:
+    - `phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift`
+    - `phase3-binary/Sources/macprovider-cli/PromptCanonicalizer.swift`
+    - coordinator/gateway/verifier receipt tests.
+
+## 3. Hard Gates
+
+1. Feature gate all runtime behavior behind a disabled-by-default coordinator
+   flag such as `losslessness_probe.enabled` and a provider capability flag.
+   Fixtures, parsers, validators, and tests may land unconditionally.
+2. Do not reuse echo-canary pass/fail counters for losslessness verdicts.
+   Reuse only scheduling, jitter, persistence, and sweep plumbing where it
+   stays behaviorally separate.
+3. Do not use `inference_request` Tier-2 carrier frames for probes. SPEC-029
+   requires dedicated encrypted request/result carriers.
+4. Do not emit SPEC-015 receipts for probe traffic. Provider work is
+   non-billable.
+5. Do not add `draft_artifact_binding`, losslessness status, probe digest, or
+   spec-decode counters to SPEC-015 v0.4 receipts or `usage`.
+6. Do not make model-authenticity or malicious-provider honesty claims. v0.1 is
+   self-attested cooperative implementation-health evidence.
+7. Do not display raw prompt text by default. Corpus prompts must be synthetic
+   coordinator-owned material; buyer-origin material is prohibited.
+8. Stochastic speculative decoding remains disabled unless a SPEC-028 rollout
+   PR or decision-log entry approved by MacProvider SPEC Maintainers names the
+   grid key, feature flag, allowed profiles, and rollback condition.
+
+## 4. Implementation Slices
+
+Implement slices in order. Each slice must include focused tests before moving
+on.
+
+### Slice 0 - Preflight, Fixtures, And Version Gates
+
+What lands:
+
+1. Implementation notes file, for example
+   `specs/SPEC-029-IMPL-NOTES.md`, recording:
+   - SPEC-029 status and commit hash used as source of truth;
+   - whether implementation is locked or explicitly draft-authorized;
+   - baseline test command results;
+   - any intentionally deferred operator/deploy work.
+2. Golden protocol fixtures under a stable path such as
+   `phase4-coordinator/test/jcs_fixtures/spec029/`:
+   - cleartext request outer envelope;
+   - cleartext result outer envelope;
+   - measurement payload;
+   - provider-inconclusive payload;
+   - Tier-2 encrypted carrier metadata fixture with deterministic test keys;
+   - admission-blocked telemetry fixture;
+   - grid-state telemetry fixture.
+3. Cross-language JCS parity tests for request/result payload digests:
+   Swift provider code and Go coordinator code must compute the same
+   `probe_request_digest` and `probe_result_digest`.
+4. A no-receipt/no-usage fixture proving losslessness fields are rejected from
+   or absent in SPEC-015 v0.4 receipt and `usage` strict shapes.
+
+Tests:
+
+- Go and Swift digest parity.
+- Fixture decode/encode round trip.
+- SPEC-015 strict receipt/usage no-extra-field tests.
+- Baseline:
+
+```bash
+cd phase4-coordinator && go test ./...
+cd ../phase3-binary && swift test
+cd ../phase5-gateway && go test ./...
+cd ../phase7-verify && go test ./...
+```
+
+### Slice 1 - Coordinator State, Corpus, Calibration, And Math
+
+Likely files:
+
+- `phase4-coordinator/internal/ws/losslessness*.go` new files.
+- `phase4-coordinator/internal/ws/server.go`
+- `phase4-coordinator/internal/ws/messages.go`
+- `phase4-coordinator/internal/config/config.go`
+- `phase4-coordinator/internal/stats/migrations/` if durable storage is needed.
+- `phase4-coordinator/internal/stats/` or admin surfaces for dashboard data.
+
+Requirements:
+
+1. Define typed structs/enums for:
+   - `draft_admission_v1`;
+   - profile key and grid key;
+   - sampling profile;
+   - corpus version and threshold version;
+   - measurement positions and offline position-selection records;
+   - calibration records;
+   - probe request/result envelopes;
+   - reason codes, statuses, operator action enum, profile/grid states;
+   - telemetry events and evidence retention references.
+2. Implement coordinator-owned `target_generation`:
+   - monotonic per `(provider_id, assigned_id, model_id)`;
+   - starts at `1`;
+   - increments on target hash change, completed warm-swap, runtime reload,
+     same-hash reload, or reconnect where continuity cannot be proven;
+   - invalidates stale profile/grid state across generation boundaries.
+3. Implement profile/grid state machines exactly:
+   - profile states: `unknown`, `pending`, `pass_fresh`, `warn`,
+     `inconclusive_retryable`, `blocked`, `disabled`, `expired`;
+   - grid states: `all_profiles_fresh`, `not_ready`;
+   - profile freshness TTL is 24h;
+   - no cross-temperature aggregation.
+4. Implement the closed `operator_action` enum and optional label. Tests must
+   fail if new reason codes use prose strings instead of enum values.
+5. Implement canonical median: lower middle after ascending sort, index
+   `(n - 1) / 2` with integer division.
+6. Implement distribution validation:
+   - finite probabilities/tail in `[0,1]`;
+   - tokenizer-valid non-negative token IDs;
+   - `support_selection_v1`;
+   - `normalization_basis = "full_distribution"`;
+   - `sampler_stage = "post_processors_post_sampling_profile_next_emitted_token"`;
+   - plain/spec top-K sorted by probability desc, token-id asc tie;
+   - shared support equals numeric-ascending union;
+   - support probabilities exactly cover support IDs;
+   - sum plus tail equals `1.0` within `1e-5`;
+   - support length `K..2K` unless vocab smaller;
+   - high-entropy plain-tail floor computed from offline plain probabilities
+     over actual returned `support_token_ids`, not a K-only floor.
+7. Implement TV interval math:
+
+```text
+support_diff = sum_{token in support_token_ids} |p_plain(token) - p_spec(token)|
+tv_lower = 0.5 * (support_diff + |plain_tail_mass - spec_tail_mass|)
+tv_upper = 0.5 * (support_diff + plain_tail_mass + spec_tail_mass)
+```
+
+   Pass decisions use `tv_upper`; quarantine decisions use `tv_lower`.
+8. Implement K retry and tail handling:
+   - default `K=64`;
+   - retry at `K=256` when tail high, warning threshold hit, or within
+     `0.005` of quarantine threshold;
+   - failed required retry => `inconclusive:k_retry_failed`;
+   - `K=256` tail > `0.005` => `inconclusive:tail_mass_high`.
+9. Implement calibration gating:
+   - no confirmed quarantine counter without accepted calibration for
+     `(target_model_hash, draft_artifact_binding, sampling_profile,
+     corpus_version, threshold_version)`;
+   - baseline max/median `tv_upper` rules from SPEC-029;
+   - missing/failing calibration maps to `blocked:calibration_missing`.
+10. Implement counters exactly:
+    - confirmed quarantine counter;
+    - rolling 24h abusive-inconclusive event log;
+    - greedy-control failure counter separate from abusive-inconclusive count;
+    - `pass` clears only consecutive quarantine candidates, not rolling abuse.
+
+Tests:
+
+- AC-5 through AC-15 coordinator unit/state-machine tests.
+- Boundary tests for `Q,Q`, `Q,W,Q`, `Q,inconclusive,Q`, `Q,pass,Q`.
+- Valid shared-support case where support length > K and plain tail is below
+  plain top-K-only tail but equals expected tail outside returned union.
+- Missing calibration and failing calibration tests.
+- Same-hash reload/reconnect/target-generation tests.
+
+### Slice 2 - Coordinator Scheduling, Transport, Replay, And Telemetry
+
+Likely files:
+
+- `phase4-coordinator/internal/ws/server.go`
+- `phase4-coordinator/internal/ws/relay.go`
+- `phase4-coordinator/internal/ws/messages.go`
+- `phase4-coordinator/internal/ws/losslessness*.go`
+- `phase4-coordinator/internal/stats/` or admin/dashboard packages.
+
+Requirements:
+
+1. Add feature-gated `losslessness_probe_v1` scheduler:
+   - 60-minute cadence per provider/model/draft key;
+   - rotate one stochastic profile per slot;
+   - full default stochastic grid plus greedy control within 24h for eligible
+     ready keys;
+   - one concurrent losslessness probe per provider;
+   - 60s execution timeout;
+   - exponential backoff for retryable inconclusive results, capped at 6h.
+2. Issue only authenticated provider-control probes on accepted provider WS
+   sessions. Reject duplicate `probe_id`, nonce, and request digest.
+3. Build cleartext request/result envelopes with `type` discriminator and
+   required `payload`.
+4. Add Tier-2 dedicated carriers:
+   - `losslessness_probe_v1.encrypted_request`;
+   - `losslessness_probe_v1.request_plaintext`;
+   - `losslessness_probe_v1.encrypted_result`;
+   - `losslessness_probe_v1.result_plaintext`.
+   Do not tunnel through `inference_request`.
+5. Enforce bounds:
+   - nonce >= 128 bits;
+   - `expires_at` <= 120s after issuance;
+   - `K` only 64 or 256;
+   - <= 4 prompts;
+   - <= 8 stochastic measurement positions;
+   - request/result digest binding;
+   - audit logging of request digest, result digest, auth principal, issuance
+     time, result time, final reason.
+6. Implement telemetry:
+   - `probe_result`;
+   - `admission_blocked`;
+   - `grid_state`;
+   - `result_kind` / `metric_kind` nullability rules;
+   - TV metrics required only for stochastic measurement outcomes;
+   - greedy fields required only for greedy controls;
+   - timeout/no-result outcomes do not fake result digests or TV metrics;
+   - retained evidence digest/ref fields and 30-day default TTL.
+7. Implement operator/dashboard state:
+   - profile matrix fields;
+   - grid row fields;
+   - `not_ready_profiles`;
+   - SPEC-028 rollout approval status/ref/feature flag/allowed profiles/
+     rollback condition.
+
+Tests:
+
+- AC-1 protocol fixture including cleartext + Tier-2 carriers.
+- Replay rejection for duplicate IDs/nonces/digests.
+- Timeout/no-result telemetry nullability.
+- Provider-inconclusive telemetry nullability.
+- Greedy-control telemetry.
+- Grid-state event/dashboard snapshot tests.
+- Proof that losslessness counters do not mutate echo-canary readiness or
+  sanctions.
+
+### Slice 3 - Provider Draft Admission And Probe Carrier Handling
+
+Likely files:
+
+- `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift`
+- `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift`
+- `phase3-binary/Sources/macprovider-cli/Tier2ProviderSession.swift`
+- `phase3-binary/Sources/macprovider-cli/ConfigApplier.swift`
+- `phase3-binary/Sources/MacProviderCore/Config.swift`
+
+Requirements:
+
+1. Add provider-side config/capability for losslessness probes. Default off
+   unless the coordinator feature gate and provider config allow it.
+2. Create and send `draft_admission_v1` through authenticated provider-control
+   channel:
+   - provider/assigned/model/target identity;
+   - target generation as issued by coordinator;
+   - draft model ID;
+   - draft artifact SHA-256;
+   - tokenizer identity;
+   - compatibility check digest;
+   - draft generation;
+   - created/expiry.
+3. Increment `draft_generation` whenever draft artifact, tokenizer identity,
+   compatibility check output, or restart-without-continuity changes.
+4. Echo coordinator-issued target generation and actual target/draft identity
+   per measured position.
+5. Implement cleartext and Tier-2 dedicated carrier handlers for probe request
+   and result. Reject unknown/malformed carriers without affecting active buyer
+   inference.
+6. Implement result variants:
+   - `measurement`;
+   - `provider_inconclusive` with allowed reason codes only.
+7. Do not emit SPEC-015 receipts for probe traffic. Do not attach probe fields
+   to buyer responses, heartbeat, or receipt material unless SPEC-029
+   explicitly permits the field.
+8. Warm-swap handling:
+   - explicit in-flight target/draft generation change =>
+     `inconclusive:model_swap`;
+   - identity mismatch without declared swap =>
+     `inconclusive:identity_mismatch`;
+   - draft-load failure after target swap =>
+     `inconclusive:draft_unavailable` or
+     `inconclusive:draft_identity_unbound`.
+
+Tests:
+
+- Draft admission fixture and generation increment tests.
+- Cleartext carrier decode/encode tests.
+- Tier-2 carrier AAD/plaintext tests with deterministic keys.
+- Provider-inconclusive result variant tests.
+- No receipt/no heartbeat/no buyer-response pollution tests.
+- Warm-swap and identity mismatch tests.
+
+### Slice 4 - Provider Measurement Hook And Compact Distribution Output
+
+Likely files:
+
+- `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+- new provider files such as `LosslessnessProbeRuntime.swift`.
+- Swift tests under `phase3-binary/Tests/macprovider-cliTests/`.
+
+Requirements:
+
+1. Identify and document the exact Swift generation/sampler hook that
+   represents:
+
+```text
+post_processors_post_sampling_profile_next_emitted_token
+```
+
+   This is AC-3 and must be in code comments or implementation notes.
+2. Add a provider measurement path that is separate from buyer inference:
+   - synthetic coordinator prompts only;
+   - teacher-forced exact measurement positions;
+   - no billing/receipt side effects;
+   - no buyer-visible output.
+3. For every stochastic position:
+   - compute plain full next-token distribution at capture point;
+   - compute spec full next-token distribution at capture point;
+   - select plain/spec top-K by probability desc, token-ID asc;
+   - compute numeric-ascending shared support union;
+   - report full-distribution probabilities over shared support for both paths;
+   - report tail masses outside shared support;
+   - include tokenizer identity, context hash, target/draft identity,
+     `normalization_basis`, `sampler_stage`, and optional trace counters.
+4. For greedy control:
+   - compare token IDs for every requested position;
+   - return greedy metric fields, not TV fields.
+5. Implement position mismatch detection: dropped, substituted, or extra
+   positions => `inconclusive:position_mismatch`.
+6. If upstream MLX APIs do not expose the required full-distribution capture
+   point, STOP and surface a SPEC/implementation blocker. Do not fake compact
+   probabilities from sampled-token histograms.
+
+Tests:
+
+- Deterministic top-K ordering and tie-break tests.
+- Shared-support union and tail-mass tests.
+- Missing/wrong sampler-stage test.
+- Context-hash mismatch test.
+- Greedy control pass/fail tests.
+- Position mismatch tests.
+- Provider-inconclusive path when sampler hook is unavailable.
+
+### Slice 5 - SPEC-028 Rollout Consumer Gate And Privacy
+
+Likely files:
+
+- `phase4-coordinator/internal/ws/losslessness*.go`
+- `phase4-coordinator/internal/stats/` or dashboard/admin code.
+- SPEC-028 rollout config/feature flag code if already present.
+
+Requirements:
+
+1. Implement the SPEC-029 evidence side of the SPEC-028 rollout gate:
+   - `all_profiles_fresh` required before stochastic speculative decoding can
+     be enabled for a grid key;
+   - no approval => operator action `request_spec028_rollout_approval`;
+   - approved grid becomes `not_ready` => operator action
+     `disable_stochastic_spec_decode`;
+   - rollout consumer must disable stochastic spec decode for affected grid key.
+2. If SPEC-028 rollout feature flag plumbing does not exist yet, implement
+   only the losslessness evidence state and dashboard action; do not invent a
+   production stochastic rollout bypass.
+3. Retention/privacy:
+   - 30-day default compact evidence retention;
+   - encrypted-at-rest storage if evidence is retained;
+   - raw prompt text hidden by default;
+   - buyer-origin prompts rejected from corpus/admission.
+4. Operator/dashboard aggregate views may summarize provider health but must
+   not collapse sanctioning/eligibility across temperatures, target
+   generations, draft generations, corpus versions, or threshold versions.
+
+Tests:
+
+- AC-11, AC-17, AC-18, AC-19 where automatable.
+- Buyer-origin prompt rejection.
+- Raw prompt hidden by default.
+- No cross-temperature aggregation.
+- Rollout approval absent/present/superseded/revoked dashboard rows.
+
+## 5. Acceptance Criteria Mapping
+
+The implementation is not complete until every SPEC-029 AC is covered:
+
+- AC-1: protocol fixtures, auth/session binding, nonce, expiry, digests,
+  replay, timeout, bounded K, cleartext and Tier-2 carriers.
+- AC-2: draft admission fixture and no heartbeat/receipt boundary.
+- AC-3: provider sampler hook design and tests.
+- AC-4: no SPEC-015 receipt/usage mutation.
+- AC-5 through AC-9: distribution validation, TV interval, support-selection,
+  K retry, tail handling, calibration.
+- AC-10 through AC-15: profile/grid state, disablement, rolling abuse, reason
+  codes, operator actions, warm-swap/generation.
+- AC-16: corpus planning and exact-profile high-entropy quota.
+- AC-17: dashboard snapshot.
+- AC-18: privacy/corpus tests.
+- AC-19: maintainer approval artifact. If AC-19 is not available during
+  implementation, keep production feature gates disabled and record the gap in
+  implementation notes.
+
+## 6. Audit-Loop Discipline
+
+After each slice, write or update audit prompts under `specs/` using house
+names, for example:
+
+- `specs/AUDIT_SPEC_029_v0_1_IMPL_STEP_1_CODE_PROMPT.md`
+- `specs/AUDIT_SPEC_029_v0_1_IMPL_STEP_1_SECURITY_PROMPT.md`
+- `specs/AUDIT_SPEC_029_v0_1_IMPL_STEP_1_ARCHITECT_PROMPT.md`
+- `specs/AUDIT_SPEC_029_v0_1_IMPL_STEP_1_ADVERSARIAL_PROMPT.md`
+- `specs/AUDIT_SPEC_029_v0_1_IMPL_STEP_1_PRODUCT_PROMPT.md`
+
+Run the required lanes:
+
+1. Codex code lane.
+2. Codex security lane.
+3. Codex architect lane.
+4. Claude subscription CLI adversarial verification lane.
+5. Claude subscription CLI product design critic lane.
+
+If Claude CLI is unavailable, record the exact failure and use Codex fallback
+lanes for adversarial and product perspectives; do not pretend Claude ran.
+
+Loop until every lane reports 0 Critical / 0 High / 0 Medium findings. Skip a
+lane in a rerun once it has returned 0 C/H/M for that slice unless files or
+behavior it audited changed materially.
+
+Commit an audit rollup such as:
+
+- `specs/SPEC-029-IMPL-STEP_1-audit.md`
+- `specs/SPEC-029-IMPL-FULL-audit.md`
+
+## 7. Required Test Commands
+
+Run the narrowest relevant tests after each slice, then the full matrix before
+final:
+
+```bash
+cd phase4-coordinator && go test ./internal/ws ./internal/config ./internal/stats ./internal/buyer
+cd ../phase3-binary && swift test
+cd ../phase5-gateway && go test ./...
+cd ../phase7-verify && go test ./...
+```
+
+Before final:
+
+```bash
+git diff --check
+cd phase4-coordinator && go test ./...
+cd ../phase3-binary && swift test
+cd ../phase5-gateway && go test ./...
+cd ../phase7-verify && go test ./...
+```
+
+If a full test cannot run, document the blocker and run the next-best targeted
+suite. Do not claim completion without fresh validation evidence.
+
+## 8. Output Expectation
+
+Deliver a complete implementation branch with:
+
+- feature-gated coordinator and provider code;
+- protocol fixtures and cross-language digest parity tests;
+- durable or well-scoped in-memory state with explicit migration/config if
+  persistence is required;
+- operator/dashboard telemetry surfaces;
+- no SPEC-015/SPEC-022/buyer API mutation;
+- no production stochastic rollout without SPEC-028 approval;
+- slice audit records converged to 0 C/H/M;
+- final implementation notes listing commands run, known gaps, and AC mapping.
+
+No TODO stubs in production paths. If an item is intentionally deferred because
+SPEC-029 remains draft or AC-19 approvals are absent, keep the feature gate off,
+record the deferral in implementation notes, and add tests proving the unsafe
+path stays disabled.

--- a/specs/RESEARCH_LOSSLESSNESS_PROBE_PROMPT.md
+++ b/specs/RESEARCH_LOSSLESSNESS_PROBE_PROMPT.md
@@ -1,0 +1,106 @@
+# RESEARCH_LOSSLESSNESS_PROBE_PROMPT
+
+**Purpose:** research + SPEC-drafting prompt for a coordinator-issued
+losslessness probe — PLAIN vs. SPEC output comparison via TV distance,
+publishable as receipt metadata or telemetry. macprovider's version of shard's
+`phase0/specpipe.py --sample-test` on-swarm losslessness proof.
+
+**Status:** research-round, pre-SPEC. **Companion to SPEC-028 (speculative
+decoding, v0.2 on `origin/main` at `a1be007`).**
+
+**Author:** drafted 2026-07-05 by Claude Opus 4.7 session (opus-4-7).
+
+**Why it matters now.** SPEC-028's speculative decoding is provably token-exact
+only at temperature 0. At buyer-typical temperatures > 0 the guarantee weakens
+to distributional equivalence — a claim macprovider cannot back with receipts
+today. Adding the probe alongside SPEC-028 while its seam is open is
+timing-optimal; grafting it on later means reopening the same coordinator
+routing seam. The probe promotes macprovider's public losslessness claim from
+"lossless at greedy decoding" to **"empirically lossless within ε across
+buyer-typical temperatures, receipt-backed"**.
+
+Note: the probe primitive **also generalizes to non-spec-decode compute-integrity**
+checking (probe provider-A's PLAIN output vs. a reference distribution). That
+follow-on use is scoped in a separate SPEC (`RESEARCH_COMPUTE_INTEGRITY_RECEIPT_PROMPT.md`);
+this SPEC is scoped to the spec-decode losslessness case only, to keep v0.1
+tight.
+
+---
+
+# Codex session: research + SPEC losslessness probe for macprovider-poc
+
+## Context
+
+Coordinator issues explicit canary requests to a provider (not covert — overt-only in v0.1). Provider runs the same seed prompt through PLAIN and SPEC decode paths, returns both output distributions (top-K logits per position, or N sampled tokens per position). Coordinator computes empirical TV distance and publishes result as receipt metadata (SPEC-015 v0.4 extension) or telemetry.
+
+## Scope — hard limits
+
+- **Read-only research + SPEC drafting.** No code changes to coordinator, provider, verifier, or receipt schema. No PRs against `origin/main`.
+- Do NOT modify SPEC-015 v0.4 (LOCKED settlement receipts). If receipt-adjacent state is needed, propose a v0.5 draft note or an out-of-band telemetry channel — do NOT draft the v0.5 in this SPEC.
+- Do NOT re-scope SPEC-028. This is a companion.
+- **Overt-canary only** in v0.1. Covert-canary indistinguishability is a v0.2 problem — call the seam, defer.
+
+## Read first
+
+1. `CLAUDE.md`, `AGENTS.md`, `HANDOFF.md`.
+2. `specs/SPEC-028-*` — the speculative decoding SPEC this SPEC companions.
+3. `specs/SPEC-015-*` v0.4 — settlement receipt tuple and `usage` schema; also `phase4-coordinator/internal/billing/settlement_verifier.go` (23-field tuple keys, `expected_catalog_model_hash` pinning).
+4. `phase4-coordinator/` — where the coordinator issues requests to providers today; what routing seam a canary would use.
+5. Shard's `phase0/specpipe.py --sample-test` upstream (fetch via WebFetch from `github.com/leyten/shard`) — the reference mechanism; note macprovider is single-node, so the swarm-ring analog is per-provider not per-stage.
+6. `phase7-verify/` — the existing receipt verifier; may or may not consume this signal.
+
+## Questions to answer (cite files:lines)
+
+### A. Canary issuance mechanism
+- Which coordinator subsystem should issue canaries? Cite the file. Options: piggyback on existing scheduled probe path (heartbeat cycle), new dedicated canary scheduler, or on-demand only.
+- How does the provider know a request is a canary and should run BOTH paths? Options: new WS message kind, request header, dedicated endpoint. Which is minimally invasive?
+- Canary cadence: per hour? per model? per (provider, model) pair? Cite the tradeoff between coverage and cost.
+
+### B. Output representation
+- To compute empirical TV distance you need per-position distributions. Options: (i) top-K logits per position (cheap; requires provider to expose logits, MLX supports it); (ii) N iid sampled tokens per position (expensive but no logit exposure). Which is right for macprovider? Cite.
+- What K or N is required to bound TV-distance estimation error to ≤ ε₁? Statistical justification, not just a number.
+- Wire cost: how much extra bandwidth does a canary payload add? Cite request-per-second budget.
+
+### C. TV-distance computation
+- Where does the computation live — provider-side (returns single scalar; smaller wire), coordinator-side (returns raw distributions; auditable but expensive), or both (coordinator recomputes as verification)? Cite security tradeoff.
+- What ε threshold triggers a warning vs. a quarantine? Statistical justification.
+- How is the threshold model-dependent? (Different models have different intrinsic sampling variance.)
+
+### D. Publishing surface
+- SPEC-015 v0.4 `usage` schema extension: can a `losslessness_tv_distance` float fit as a JCS-canonical extension without breaking v0.4 verifiers? Cite `v04SettlementUsageKeys` and JCS rules.
+- If v0.4 backward-compat prevents extension: propose exact receipt v0.5 shape delta OR an out-of-band telemetry channel; say which. Justify.
+- Where does the per-provider aggregate live? (Buyer-facing dashboard? Public directory?)
+
+### E. Temperature range
+- SPEC-028 flag surface: how does the buyer set temperature? Cite. Does the canary probe iterate across a temperature grid (e.g., `{0.0, 0.2, 0.5, 0.7, 1.0}`) or only sample the buyer-typical value?
+- What's the receipt/telemetry shape when TV is reported per-temperature vs. aggregate?
+
+### F. Interaction with SPEC-011 warm-swap
+- If a provider warm-swaps model mid-probe, does the canary fail loudly or silently invalidate? Cite the safe semantic.
+- Should model swap trigger an immediate canary against the newly-loaded model? Cite trust tradeoff.
+
+### G. Covert-canary seam (out of scope for v0.1)
+- Sketch what would need to change for covert canaries to be indistinguishable from buyer traffic. Do NOT design it. Just name the seam.
+
+## Deliverables
+
+Branch `research/losslessness-probe` off `origin/main`, three artifacts:
+
+1. **`docs/research/losslessness-probe-2026-07.md`** — research memo answering §A–G with citations.
+2. **`specs/SPEC-XXX-losslessness-probe.md`** v0.1-draft — normative FRs (canary issuance, output shape, TV computation, publishing surface, threshold semantics), non-goals (covert canary, compute-integrity companion — those are separate SPECs), open questions, acceptance criteria.
+3. **`.omc/logs/losslessness-probe-open-questions-2026-07.md`** — maintainer-input list (ε threshold, temperature grid choice, publish surface decision).
+
+## Definition of done (this research session)
+
+- Every §A–G question answered.
+- Statistical justification for K/N and ε (not asserted values).
+- Publishing surface decision made — receipt v0.5 field name and type, OR out-of-band channel name.
+- SPEC draft passes self-review round.
+- No code changes.
+
+## Do NOT
+
+- Modify SPEC-015 v0.4, SPEC-022, or SPEC-028.
+- Design covert-canary indistinguishability in v0.1.
+- Scope compute-integrity-against-reference in this SPEC (separate SPEC handles it).
+- Introduce a dependency on shard's `phase0/specpipe.py` upstream — reuse the mechanism, do not reuse the code.

--- a/specs/SPEC-029-IMPL-NOTES.md
+++ b/specs/SPEC-029-IMPL-NOTES.md
@@ -1,0 +1,91 @@
+# SPEC-029 Implementation Notes
+
+Status: prototype implementation from `v0.1-draft`.
+
+Source-of-truth commit: `adef83ef16c039b5be1da310a5666bf200fc1708`
+(`Define the SPEC-029 implementation handoff`).
+
+Authorization: the user explicitly requested implementation of
+`BUILD_SPEC_029_v0_1_IMPL_PROMPT.md` while SPEC-029 remains a draft. Runtime
+behavior is therefore gated off by default and must not be treated as production
+rollout approval.
+
+## Implemented In This Slice
+
+- Coordinator disabled-by-default config gate: `pool.losslessness_probe`.
+- Coordinator protocol structs, shared RFC8785/JCS canonical payload digesting,
+  raw-string probe digesting, request/result envelope validation with
+  inner/outer probe binding, golden JCS fixtures including a non-NFC string
+  fixture, distribution validation, target/draft identity checks, K=256
+  terminal tail ceiling, TV interval math, reason-code/profile state
+  transitions, repeated retryable-inconclusive abuse promotion, target-grid
+  readiness, synthetic corpus prompt guard, explicit result-frame dispatch,
+  in-memory `draft_admission_v1` records, in-memory coordinator target
+  generation records, in-memory pending-probe binding, duplicate
+  probe-id/nonce/request-digest rejection, expiry/nonce/digest single-use
+  checks, in-memory profile-state persistence, typed telemetry snapshots for
+  probe results and admission-blocked cases, and dedicated Tier-2 carrier
+  helpers.
+- Coordinator prototype scheduler entry point gated by
+  `pool.losslessness_probe.enabled`: once per configured interval it dispatches
+  one synthetic coordinator-owned probe per ready provider when no probe is
+  already pending for that provider, rotating the default profile grid. Issuance
+  fails closed unless a current draft-admission record exists. The request seeds
+  requested-position membership, coordinator-owned high-entropy flags, context
+  hashes, vocabulary bounds, and offline baselines in pending state; these are
+  not sent on the wire.
+- Runtime measurement verdicts now fail closed if pending safety metadata is
+  absent, require the K=64-to-K=256 retry gate before pass/warn/quarantine
+  decisions, use canonical lower-middle median over TV intervals, and require
+  an accepted calibration/verdict-engine marker before `pass_fresh` or
+  quarantine disablement can count toward grid readiness.
+- Provider disabled-by-default config gate:
+  `MACPROVIDER_LOSSLESSNESS_PROBE_ENABLED` / `losslessness_probe_enabled`.
+- Provider cleartext and Tier-2 request handling for `losslessness_probe_v1`
+  carriers, including invalid-message NAKs for malformed enabled probe frames
+  and plaintext probe-request rejection after an active Tier-2 session exists.
+- Provider result generation for the current runtime state:
+  `provider_inconclusive` with
+  `inconclusive:unsupported_sampler`, because the current Swift/MLX runtime seam
+  does not expose the full post-processor distribution required by SPEC-029.
+  This result echoes `probe_nonce`, binds to `probe_request_digest`, and carries
+  null target/draft identity fields with `identity_unavailable_reason`.
+- SPEC-015 guard coverage showing probe metadata is not accepted in v0.4 receipt
+  tuples or `usage`.
+
+## Deliberately Deferred
+
+- Durable scheduler storage, durable replay/profile/telemetry persistence,
+  jitter/backoff persistence, retention sweeps, admin dashboard storage, and
+  operator telemetry export surfaces. In-memory typed snapshots exist for this
+  prototype; production enablement still requires a durable store.
+- Durable `draft_admission_v1` storage, durable coordinator-owned
+  `target_generation` persistence, and warm swap generation invalidation.
+- Full K=256 retry orchestration/redispatch, calibration baseline approval
+  workflow, threshold-version management, and dashboard nullability. This slice
+  contains the fail-closed verdict guards but not the operator workflow needed
+  to mark calibration/verdict prerequisites accepted in production.
+- Real MLX full-distribution sampler hook and measurement emission.
+- Deterministic Tier-2 encrypted golden fixture with static test keys.
+- Grid-state telemetry golden fixtures.
+- SPEC-028 stochastic speculative decoding enablement. This remains blocked on
+  a separate rollout approval naming grid key, feature flag, allowed profiles,
+  and rollback condition.
+
+## Verification Log
+
+- `cd phase4-coordinator && gofmt -w internal/config/config.go internal/ws/losslessness.go internal/ws/losslessness_test.go`
+- `cd phase4-coordinator && go test ./internal/config ./internal/ws`
+- `cd phase3-binary && swift test --filter LosslessnessProbeProtocolTests`
+- `cd phase4-coordinator && go test ./internal/config ./internal/ws ./internal/spec015contract`
+- `cd phase3-binary && swift test --filter 'LosslessnessProbeProtocolTests|CoordinatorClientTests/testEncryptedLosslessnessProbeRejectsCarrierRequestIDMismatch'`
+- `cd phase4-coordinator && go test ./internal/config ./internal/ws ./internal/spec015contract`
+- `cd phase3-binary && swift test --filter 'LosslessnessProbeProtocolTests|CoordinatorClientTests/testEncryptedLosslessnessProbeRejectsCarrierRequestIDMismatch'`
+- `cd phase4-coordinator && go test ./internal/config ./internal/ws ./internal/spec015contract`
+- `cd phase3-binary && swift test --filter 'LosslessnessProbeProtocolTests|CoordinatorClientTests/testEncryptedLosslessnessProbeRejectsCarrierRequestIDMismatch'`
+- `cd phase4-coordinator && go test ./internal/config ./internal/ws ./internal/spec015contract`
+- `cd phase4-coordinator && go test ./...`
+- `cd phase3-binary && swift test --filter 'LosslessnessProbeProtocolTests|CoordinatorClientTests/testEncryptedLosslessnessProbeRejectsCarrierRequestIDMismatch'`
+
+Additional verification should be appended before merge if this prototype is
+expanded to scheduler/dashboard/runtime measurement slices.

--- a/specs/SPEC-029-losslessness-probe.md
+++ b/specs/SPEC-029-losslessness-probe.md
@@ -1,0 +1,253 @@
+# SPEC-029 Losslessness Probe
+
+**Status:** v0.1-draft
+**Date:** 2026-07-09
+**Depends on:** SPEC-015 v0.4.2, SPEC-022, SPEC-028
+**Companion research:** `docs/research/losslessness-probe-2026-07.md`
+
+## 1. Purpose
+
+SPEC-029 defines an overt coordinator-issued probe that measures whether speculative decoding preserves the target model's next-token distribution under selected stochastic sampling profiles.
+
+The probe is a governance gate for any future stochastic speculative-decoding rollout. It is not a buyer API feature, not a settlement receipt field, and not a billable usage dimension.
+
+## 2. Scope
+
+In scope:
+
+- A coordinator-owned `losslessness_probe_v1` profile under the existing provider canary subsystem.
+- Provider-side measurement of plain target and speculative target next-token distributions.
+- Coordinator-side total-variation computation and verdict assignment.
+- Out-of-band probe telemetry and operator-visible aggregate status.
+- Warm-swap handling for target model and draft model changes.
+- Thresholded integration with the existing canary failure counter after repeated confirmed failures.
+
+Out of scope:
+
+- Any change to SPEC-015 v0.4 settlement receipt tuples or `usage` fields.
+- Any change to SPEC-022 settlement semantics.
+- Any buyer-visible `/v1/chat/completions` request or response field.
+- Covert canaries or indistinguishable buyer-like probes.
+- Compute-integrity attestation for model weights or executable code.
+- Stochastic speculative-decoding product enablement. This spec only defines a probe.
+
+## 3. Definitions
+
+**Plain path:** Target-model decoding without draft-model speculation.
+
+**Spec path:** Target-model decoding with a configured draft model and target verification.
+
+**Sampling profile:** The sampler parameters under test, at minimum `temperature` and `top_p`.
+
+**Measurement position:** A decode position selected from a probe prompt where the provider returns next-token distribution evidence.
+
+**TV distance:** Total-variation distance between two categorical distributions. For reported compact distributions, the coordinator computes `TV_bound` over the union of top-K token ids plus residual tail mass.
+
+**Tail mass:** The probability mass not included in the reported top-K token list.
+
+**Probe key:** `(provider_id, assigned_id, model_id, target_model_hash, draft_model_id, sampling_profile)`.
+
+## 4. Normative Requirements
+
+### FR-1 Probe profile
+
+The coordinator MUST define a distinct `losslessness_probe_v1` profile. It MUST NOT reuse nonce echo canary semantics for losslessness verdicts.
+
+The coordinator MAY implement this profile inside the existing canary scheduler, jitter, and sanction subsystem.
+
+### FR-2 Out-of-band transport
+
+The coordinator MUST issue v0.1 probes through an out-of-band provider-control path, such as a dedicated WS message type. It MUST NOT issue v0.1 probes as buyer-visible `/v1/chat/completions` traffic.
+
+The provider MUST treat probe traffic as non-billable and MUST NOT emit SPEC-015 settlement receipts for probe measurements.
+
+### FR-3 Probe identity
+
+Each probe request MUST include:
+
+- `probe_version = "losslessness_probe_v1"`.
+- `probe_id`.
+- `model_id`.
+- Expected `target_model_hash`.
+- `draft_model_id`.
+- Sampling profile.
+- Probe prompt or prompt corpus reference.
+- Requested `K`.
+- Measurement-position selection parameters.
+
+Each probe result MUST include the actual target snapshot identity used for every measured position.
+
+### FR-4 Sampling profiles
+
+The v0.1 default stochastic grid MUST include:
+
+- `temperature=0.2`, `top_p=1.0`.
+- `temperature=0.5`, `top_p=1.0`.
+- `temperature=0.7`, `top_p=1.0`.
+- `temperature=1.0`, `top_p=1.0`.
+
+The coordinator SHOULD also run a `temperature=0.0`, `top_p=1.0` greedy control. The greedy control verdict is token-id equality, not TV distance.
+
+Verdicts MUST be keyed by exact sampling profile. The coordinator MUST NOT aggregate different temperatures into one sanctioning verdict.
+
+### FR-5 Compact distribution output
+
+For each measured stochastic position, the provider MUST return:
+
+- `plain_topk`: top-K token ids and normalized probabilities for the plain path.
+- `plain_tail_mass`.
+- `spec_topk`: top-K token ids and normalized probabilities for the spec path.
+- `spec_tail_mass`.
+- `context_hash`.
+- Position index.
+
+The provider MAY return a plain/plain baseline distribution for calibration. The coordinator MUST NOT require sampled-token histograms for the normative v0.1 verdict.
+
+### FR-6 Coordinator TV computation
+
+The coordinator MUST compute the canonical verdict from provider-returned compact distributions. Provider-returned scalar verdicts MAY be logged but MUST NOT be authoritative.
+
+For stochastic positions, the coordinator MUST compute:
+
+```text
+support = union(token ids in plain_topk, token ids in spec_topk)
+TV_bound = 0.5 * (
+  sum_{token in support} |p_plain(token) - p_spec(token)|
+  + |plain_tail_mass - spec_tail_mass|
+)
+```
+
+Missing tokens in either side's top-K list MUST be treated as probability zero inside the reported support.
+
+### FR-7 K and tail handling
+
+The default requested K MUST be `64`.
+
+If either side's tail mass exceeds `0.01`, or if `TV_bound` is within `0.005` of a quarantine threshold, the coordinator SHOULD retry the probe at `K=256`.
+
+At `K=256`, if either side's tail mass exceeds `0.005`, the position MUST be marked inconclusive. High tail mass MUST NOT by itself increment the canary failure counter.
+
+### FR-8 Verdict categories
+
+The coordinator MUST assign one of:
+
+- `pass`.
+- `warn`.
+- `quarantine_candidate`.
+- `inconclusive`.
+
+Recommended initial thresholds:
+
+- `warn` when median `TV_bound > 0.02` or any high-entropy position `TV_bound > 0.05`.
+- `quarantine_candidate` when median `TV_bound > 0.05` or any high-entropy position `TV_bound > 0.10`, after any required K retry.
+- `inconclusive` for high tail mass after retry, timeout, unsupported sampler, model swap, draft unavailable, missing distributions, or malformed result.
+
+Thresholds are draft defaults. Locking this spec requires maintainer approval for the final threshold table and prompt corpus.
+
+### FR-9 Sanction gating
+
+A single `quarantine_candidate` MUST NOT immediately degrade or disable a provider.
+
+The coordinator MAY feed the existing canary failure counter only after two consecutive `quarantine_candidate` results for the same probe key. `pass` clears the consecutive losslessness failure count for that probe key. `warn` and `inconclusive` MUST NOT increment it.
+
+After the losslessness failure count is eligible for sanctioning, the existing canary threshold MAY degrade pinned providers or mark provisional providers unavailable.
+
+### FR-10 Telemetry surface
+
+The coordinator MUST publish probe results as out-of-band telemetry. The v0.1 event type is `losslessness_probe_v1`.
+
+The event MUST include:
+
+- `probe_id`.
+- `provider_id`.
+- `assigned_id`.
+- `model_id`.
+- `target_model_hash`.
+- `draft_model_id`.
+- Sampling profile.
+- K used for the final verdict.
+- Verdict status.
+- Median and max `TV_bound`.
+- Max tail mass.
+- Positions measured.
+- Timestamp.
+
+The event MAY include compact per-position evidence for audit retention.
+
+### FR-11 Receipt and usage invariants
+
+SPEC-029 MUST NOT add fields to SPEC-015 v0.4 receipts or v0.4 `usage`.
+
+SPEC-029 MUST NOT require a SPEC-022 settlement change.
+
+SPEC-029 MUST NOT alter buyer token accounting, payout accounting, receipt verification, or external verifier behavior.
+
+Future receipt versions MAY bind a digest of recent losslessness probe status, but that is outside v0.1.
+
+### FR-12 Warm-swap handling
+
+If the target model or draft model changes while a probe is running, the provider MUST return `inconclusive:model_swap` or equivalent structured error.
+
+Probe results MUST NOT carry across target-swap boundaries. After a new target snapshot becomes ready and draft compatibility is checked, the coordinator SHOULD schedule a fresh probe for the new probe key.
+
+Draft-load failure after a target swap MUST NOT fail the target-model swap. It MUST leave stochastic speculative decoding disabled for that model/draft pair and emit a warning or inconclusive probe result.
+
+### FR-13 Prompt corpus
+
+The v0.1 prompt corpus SHOULD include:
+
+- Short general instruction prompts.
+- Code-completion contexts.
+- Tool-call-like JSON contexts.
+- Multi-turn chat contexts.
+
+Measurement positions SHOULD prefer higher-entropy next-token distributions. Low-entropy positions MAY be included as controls but SHOULD NOT dominate the verdict.
+
+### FR-14 No covert canaries
+
+V0.1 probes are overt. The provider MAY know it is handling a losslessness probe.
+
+Covert probes MUST be specified separately because they interact with buyer traffic, billing, receipts, and abuse resistance.
+
+## 5. Non-Goals
+
+- Proving a malicious provider honestly loaded a claimed model.
+- Proving hardware, binary, or compute integrity.
+- Certifying every possible prompt or sampler configuration.
+- Replacing SPEC-028 acceptance-rate telemetry.
+- Replacing existing echo canaries.
+- Authorizing stochastic speculative decoding without a later rollout decision.
+
+## 6. Acceptance Criteria
+
+Before SPEC-029 can move toward LOCK:
+
+1. A coordinator design specifies the `losslessness_probe_v1` message, result event, storage table, and operator query path.
+2. A provider design identifies the exact Swift generation/sampler hook that emits top-K probabilities plus tail mass for plain and spec paths.
+3. A test fixture proves that extra losslessness fields are not added to SPEC-015 v0.4 receipts or `usage`.
+4. A unit test covers coordinator TV computation with non-overlapping top-K token sets and tail masses.
+5. A unit test covers `K=64` retry to `K=256` and the `inconclusive:tail_mass_high` path.
+6. A coordinator test covers two consecutive `quarantine_candidate` results feeding the existing canary failure counter, while `warn` and `inconclusive` do not.
+7. A warm-swap test covers `inconclusive:model_swap` and confirms old probe results do not authorize the new target snapshot.
+8. Maintainers approve the v0.1 prompt corpus and threshold table.
+
+## 7. Open Questions
+
+1. Should v0.1 require `K=256` for all `temperature=1.0` probes, or keep `K=64` with retry?
+2. What is the final normative prompt corpus and who owns updates to it?
+3. Should operator dashboards show per-position compact evidence or only aggregate verdicts?
+4. Should losslessness results become part of provider eligibility for stochastic spec decode only, or also affect general provider readiness?
+5. What retention period is required for compact per-position evidence?
+6. Does the provider-control WS path need an HTTP fallback in v0.1?
+7. Should a future SPEC-015 v0.5 bind a digest of recent losslessness probe status into settlement receipts?
+
+## 8. References
+
+- `docs/research/losslessness-probe-2026-07.md`.
+- `specs/SPEC-028-mlx-speculative-decoding.md`.
+- `specs/SPEC-015-receipts.md`.
+- `specs/SPEC-022-verified-model-settlement.md`.
+- Shard `specpipe.py`: <https://raw.githubusercontent.com/leyten/shard/master/phase0/specpipe.py>.
+- `mlx-swift-lm` 3.31.4 `Evaluate.swift`: <https://raw.githubusercontent.com/ml-explore/mlx-swift-lm/3.31.4/Libraries/MLXLMCommon/Evaluate.swift>.
+- Leviathan, Kalman, and Matias, "Fast Inference from Transformers via Speculative Decoding": <https://arxiv.org/abs/2211.17192>.
+- Chen et al., "Accelerating Large Language Model Decoding with Speculative Sampling": <https://arxiv.org/abs/2302.01318>.

--- a/specs/SPEC-029-losslessness-probe.md
+++ b/specs/SPEC-029-losslessness-probe.md
@@ -7,20 +7,23 @@
 
 ## 1. Purpose
 
-SPEC-029 defines an overt coordinator-issued probe that measures whether speculative decoding preserves the target model's next-token distribution under selected stochastic sampling profiles.
+SPEC-029 defines an overt, coordinator-issued probe that measures whether a provider's speculative decoding path preserves the target model's next-token distribution under selected stochastic sampling profiles.
 
-The probe is a governance gate for any future stochastic speculative-decoding rollout. It is not a buyer API feature, not a settlement receipt field, and not a billable usage dimension.
+The v0.1 probe is cooperative implementation-health evidence. It can gate stochastic speculative-decoding eligibility for the exact provider/model/draft/profile key under test, but it does not prove malicious-provider honesty, compute integrity, or model-weight integrity. Stronger claims require a later covert or independently verifiable probe spec.
+
+The probe is not a buyer API feature, not a settlement receipt field, and not a billable usage dimension.
 
 ## 2. Scope
 
 In scope:
 
-- A coordinator-owned `losslessness_probe_v1` profile under the existing provider canary subsystem.
-- Provider-side measurement of plain target and speculative target next-token distributions.
-- Coordinator-side total-variation computation and verdict assignment.
-- Out-of-band probe telemetry and operator-visible aggregate status.
+- A coordinator-owned `losslessness_probe_v1` profile under the provider canary subsystem.
+- A v0.1 WS provider-control request/result protocol.
+- Provider-side measurement of plain target and speculative target next-token distributions at a normative sampler hook.
+- Coordinator-side distribution validation, TV interval computation, verdict assignment, eligibility state, and operator dashboard state.
+- Probe-local target and draft artifact identity binding.
 - Warm-swap handling for target model and draft model changes.
-- Thresholded integration with the existing canary failure counter after repeated confirmed failures.
+- Key-scoped stochastic speculative-decoding disablement after repeated confirmed failures or repeated abusive inconclusive results.
 
 Out of scope:
 
@@ -28,56 +31,184 @@ Out of scope:
 - Any change to SPEC-022 settlement semantics.
 - Any buyer-visible `/v1/chat/completions` request or response field.
 - Covert canaries or indistinguishable buyer-like probes.
-- Compute-integrity attestation for model weights or executable code.
-- Stochastic speculative-decoding product enablement. This spec only defines a probe.
+- Compute-integrity attestation for model weights, runtime binaries, or hardware.
+- General provider-readiness sanctions from losslessness results alone.
+- Authorizing stochastic speculative decoding without the separate SPEC-028 rollout decision that consumes this probe state.
 
 ## 3. Definitions
 
 **Plain path:** Target-model decoding without draft-model speculation.
 
-**Spec path:** Target-model decoding with a configured draft model and target verification.
+**Spec path:** Target-model decoding with a configured draft model and target verification, using the same production sampler transforms and speculative accept/reject logic that stochastic speculative decoding would use.
 
 **Sampling profile:** The sampler parameters under test, at minimum `temperature` and `top_p`.
 
-**Measurement position:** A decode position selected from a probe prompt where the provider returns next-token distribution evidence.
+**Measurement position:** A coordinator-selected decode position in a versioned synthetic prompt corpus. The provider does not choose positions.
 
-**TV distance:** Total-variation distance between two categorical distributions. For reported compact distributions, the coordinator computes `TV_bound` over the union of top-K token ids plus residual tail mass.
+**Distribution capture point:** The categorical distribution over the next emitted token after production logit processors, temperature, top-p/top-k/min-p filters enabled by the sampling profile, and speculative accept/reject logic. The returned probabilities are full-distribution probability masses, not top-K-renormalized values.
 
-**Tail mass:** The probability mass not included in the reported top-K token list.
+**Shared support:** The ordered union of the plain path's top-K token ids and the spec path's top-K token ids for one measurement position. Both paths report probabilities for every token in this support. Tail mass is the probability mass outside the shared support.
 
-**Probe key:** `(provider_id, assigned_id, model_id, target_model_hash, draft_model_id, sampling_profile)`.
+**Tail mass:** The full-distribution probability mass outside the reported shared support.
 
-## 4. Normative Requirements
+**TV lower bound:** The minimum total-variation distance consistent with reported shared-support probabilities and aggregate tail masses outside that shared support.
+
+**TV upper bound:** The maximum total-variation distance consistent with reported shared-support probabilities and aggregate tail masses outside that shared support.
+
+**Draft artifact binding:** A probe-local immutable draft identity from the SPEC-029 draft admission record. It includes `draft_model_id`, `draft_artifact_sha256`, `tokenizer_identity`, and `compatibility_check_digest`. It is not added to SPEC-015 receipts or provider heartbeat.
+
+**Profile key:** `(provider_id, assigned_id, model_id, target_model_hash, target_generation, draft_model_id, draft_artifact_binding, draft_generation, sampling_profile, corpus_version, threshold_version)`.
+
+**Grid key:** The profile key without `sampling_profile`. It represents the full required stochastic profile grid plus greedy control for one provider/model/draft/corpus/threshold identity.
+
+**Target generation:** A coordinator-local monotonic integer for `(provider_id, assigned_id, model_id)` that identifies a continuous target-model runtime snapshot. It starts at `1` for the first ready target snapshot observed by the coordinator and increments on target model hash change, completed target warm-swap, target runtime reload, provider reconnect where continuity cannot be proven, or any same-hash target reload reported by the provider.
+
+**Probe request digest:** RFC8785/JCS SHA-256 over the inner coordinator probe request payload, excluding `probe_request_digest` and any outer transport envelope.
+
+**Probe result digest:** RFC8785/JCS SHA-256 over the inner provider probe result payload, excluding `probe_result_digest` and any outer transport envelope.
+
+## 4. Threat Model
+
+V0.1 probes are overt. A provider can know that it is handling `losslessness_probe_v1`.
+
+Therefore SPEC-029 MUST NOT be used to claim that a malicious provider honestly ran the requested model or honestly reported distributions. V0.1 detects cooperative implementation bugs, sampler drift, stale artifacts, and operational regressions. A provider that fabricates matching plain/spec shared-support distributions can defeat the v0.1 proof surface.
+
+The coordinator MUST present v0.1 results as self-attested implementation-health evidence. A fresh `pass_fresh` MAY allow stochastic speculative decoding only for the exact profile key after a separate rollout decision. It MUST NOT improve settlement trust, model authenticity trust, payout trust, or general provider readiness.
+
+The approval owner for v0.1 corpus, threshold, calibration, retention, and rollout-consumer decisions is the **MacProvider SPEC Maintainers** group: repository maintainers responsible for SPEC-028, SPEC-029, and coordinator/provider release gates. Approval MUST be recorded in the PR or decision log that changes the relevant corpus, threshold, calibration, retention, or rollout rule.
+
+## 5. Normative Requirements
 
 ### FR-1 Probe profile
 
 The coordinator MUST define a distinct `losslessness_probe_v1` profile. It MUST NOT reuse nonce echo canary semantics for losslessness verdicts.
 
-The coordinator MAY implement this profile inside the existing canary scheduler, jitter, and sanction subsystem.
+The coordinator MAY reuse the existing canary scheduler, jitter, and persistence infrastructure, but losslessness state MUST be stored separately from echo-canary pass/fail state.
 
-### FR-2 Out-of-band transport
+### FR-2 Draft admission record
 
-The coordinator MUST issue v0.1 probes through an out-of-band provider-control path, such as a dedicated WS message type. It MUST NOT issue v0.1 probes as buyer-visible `/v1/chat/completions` traffic.
+Before the coordinator can issue a losslessness probe for a draft model, it MUST have a coordinator-local `draft_admission_v1` record obtained through the authenticated provider-control channel.
 
-The provider MUST treat probe traffic as non-billable and MUST NOT emit SPEC-015 settlement receipts for probe measurements.
+`draft_admission_v1` MUST include:
 
-### FR-3 Probe identity
+- `provider_id`.
+- `assigned_id`.
+- `model_id`.
+- `target_model_hash`.
+- `target_generation`.
+- `draft_model_id`.
+- `draft_artifact_sha256`.
+- `tokenizer_identity`.
+- `compatibility_check_digest`.
+- `draft_generation`.
+- `created_at`.
+- `expires_at`.
 
-Each probe request MUST include:
+`compatibility_check_digest` MUST cover the provider's target/draft tokenizer equality check, draft-load compatibility check, and sampler-hook availability check. The coordinator MUST treat the record as provider self-attestation, not as model authenticity proof.
+
+`draft_generation` MUST increment whenever the provider reloads the draft artifact, changes tokenizer identity, changes compatibility check output, or restarts without proving continuity. If the coordinator lacks a current `draft_admission_v1` record, probe issuance MUST be blocked with `inconclusive:draft_identity_unbound`.
+
+This record is a provider-control/admission artifact only. It MUST NOT be added to SPEC-015 receipts, buyer responses, or provider heartbeat.
+
+The coordinator owns `target_generation`. Probe requests MUST carry the coordinator-issued expected `target_generation`, and providers MUST echo the actual target generation observed at each measured position. Results MUST NOT authorize stochastic speculative decoding across a target-generation boundary, including same-hash reloads and reconnects where runtime continuity cannot be proven.
+
+### FR-3 Transport, auth, and load bounds
+
+V0.1 probes MUST use the authenticated provider WS control channel. HTTP provider-control fallback is out of scope for v0.1.
+
+The coordinator MUST enforce:
+
+- Coordinator-origin authentication using the existing provider-control session binding.
+- A single-use unpredictable `probe_nonce` of at least 128 bits.
+- `expires_at` no more than 120 seconds after issuance.
+- Duplicate `probe_id`, duplicate nonce, or duplicate request digest rejection.
+- Provider-side result binding to `probe_request_digest`.
+- `K` limited to `64` or `256`.
+- At most 4 prompts and 8 stochastic measurement positions per probe result.
+- Per-provider concurrent losslessness probes limited to 1.
+- A 60-second provider execution timeout.
+- A default 60-minute cadence per provider/model/draft key, rotating one stochastic profile per slot.
+- Full default stochastic grid coverage within 24 hours for every key that remains eligible and ready.
+- Exponential backoff for repeated retryable inconclusive results, capped at 6 hours.
+- Audit logging of request digest, result digest, auth principal, issuance time, result time, and final reason code.
+
+Provider work for probes is non-billable and MUST NOT emit SPEC-015 settlement receipts.
+
+### FR-4 Probe identity and replay binding
+
+The wire protocol uses an outer envelope plus an inner JCS payload carried in a required `payload` field. The request digest is computed over RFC8785/JCS canonical JSON of the request `payload` before `probe_request_digest` is attached to the outer envelope. The result digest is computed over RFC8785/JCS canonical JSON of the result `payload` before `probe_result_digest` is attached to the outer envelope.
+
+For cleartext provider-control sessions, the WS frame is the outer envelope below. For encrypted Tier-2 provider-control sessions, SPEC-029 MUST use a dedicated provider-control carrier, not the existing `inference_request` carrier:
+
+- Request visible frame: `type = "losslessness_probe_v1.encrypted_request"`, `request_id = probe_id`, `stream = false`, `encrypted = true`, and `enc`.
+- Request AAD: visible frame type, direction `c2p`, `request_id`, `stream = false`, `provider_id`, `assigned_id`, and sequence number.
+- Request plaintext envelope: `type = "losslessness_probe_v1.request_plaintext"` and `payload` equal to the cleartext request outer envelope.
+- Result visible frame: `type = "losslessness_probe_v1.encrypted_result"`, `request_id = probe_id`, `stream = false`, `encrypted = true`, and `enc`.
+- Result AAD: visible frame type, direction `p2c`, `request_id`, `stream = false`, `provider_id`, `assigned_id`, and sequence number.
+- Result plaintext envelope: `type = "losslessness_probe_v1.result_plaintext"` and `payload` equal to the cleartext result outer envelope.
+
+The digest inputs remain the inner request/result payloads inside the cleartext outer envelope. Tier-2 encryption authenticates the carrier and plaintext envelope; it does not change the digest payload or tunnel probes through buyer inference frames.
+
+Each request outer envelope MUST use the existing provider WS `type` discriminator and include:
+
+- `type = "losslessness_probe_v1.request"`.
+- `probe_id`.
+- `probe_request_digest`.
+- `payload`.
+
+Each inner request payload MUST include:
 
 - `probe_version = "losslessness_probe_v1"`.
 - `probe_id`.
+- `probe_nonce`.
+- `expires_at`.
 - `model_id`.
 - Expected `target_model_hash`.
+- Expected `target_generation`.
 - `draft_model_id`.
+- Expected `draft_artifact_binding`.
+- Expected `draft_generation`.
+- Expected `tokenizer_identity`.
 - Sampling profile.
-- Probe prompt or prompt corpus reference.
+- `corpus_version`.
+- `threshold_version`.
+- Synthetic prompt payloads or allowlisted corpus references.
+- Coordinator-selected measurement positions.
 - Requested `K`.
-- Measurement-position selection parameters.
+- `support_selection = "support_selection_v1"`.
+- Request bounds: max prompts, max positions, timeout, and expiry.
 
-Each probe result MUST include the actual target snapshot identity used for every measured position.
+Each result outer envelope MUST use the existing provider WS `type` discriminator and include:
 
-### FR-4 Sampling profiles
+- `type = "losslessness_probe_v1.result"`.
+- `probe_id`.
+- `probe_request_digest`.
+- `probe_result_digest`.
+- `payload`.
+
+Each inner result payload MUST include:
+
+- `probe_id`.
+- `probe_nonce`.
+- `probe_request_digest`.
+- `result_kind = "measurement"` or `result_kind = "provider_inconclusive"`.
+
+For `result_kind = "measurement"`, the inner result payload MUST include:
+
+- Actual `target_model_hash` and `target_generation` for every measured position.
+- Actual `draft_artifact_binding` and `draft_generation` for every measured position.
+- Actual `tokenizer_identity`.
+- Returned distributions, support-selection metadata, and result metadata for every requested position.
+
+For `result_kind = "provider_inconclusive"`, the inner result payload MUST include:
+
+- `provider_reason_code`, limited to `inconclusive:model_swap`, `inconclusive:unsupported_sampler`, `inconclusive:draft_unavailable`, `inconclusive:position_mismatch`, `inconclusive:missing_distribution`, or `inconclusive:timeout`.
+- The actual target and draft identities known at failure time, or null with an explanatory `identity_unavailable_reason`.
+- No authoritative distributions. The coordinator MUST NOT compute TV or pass/warn/quarantine from this variant.
+
+The coordinator MUST mark the result `inconclusive:model_swap` when the provider explicitly reports that target or draft generation changed while the probe was running. The coordinator MUST mark the result `inconclusive:identity_mismatch` when actual target or draft identity differs from expected identity without a declared in-flight swap, when measured positions mix identities, or when draft identity is unavailable.
+
+### FR-5 Sampling profiles
 
 The v0.1 default stochastic grid MUST include:
 
@@ -86,95 +217,337 @@ The v0.1 default stochastic grid MUST include:
 - `temperature=0.7`, `top_p=1.0`.
 - `temperature=1.0`, `top_p=1.0`.
 
-The coordinator SHOULD also run a `temperature=0.0`, `top_p=1.0` greedy control. The greedy control verdict is token-id equality, not TV distance.
+The coordinator MUST also run a `temperature=0.0`, `top_p=1.0` greedy control at least once per full-grid coverage window. The greedy control verdict is token-id equality for every requested position, with the same identity and replay checks as stochastic probes.
 
-Verdicts MUST be keyed by exact sampling profile. The coordinator MUST NOT aggregate different temperatures into one sanctioning verdict.
+Verdicts MUST be keyed by exact sampling profile. The coordinator MUST NOT aggregate different temperatures into one sanctioning or eligibility verdict.
 
-### FR-5 Compact distribution output
+### FR-6 Prompt corpus and position selection
+
+The v0.1 corpus MUST be coordinator-owned, synthetic, and versioned. It MUST NOT contain buyer-origin prompts, buyer outputs, secrets, credentials, private code, or production conversation material.
+
+The corpus owner role is the SPEC-028/SPEC-029 maintainer group. Any corpus or threshold change MUST create a new `corpus_version` or `threshold_version`, and existing `pass_fresh` state for affected keys MUST become `expired`.
+
+The coordinator MUST send exact prompts and exact measurement-position indexes. The provider MUST measure every requested position without substitution. Dropped, substituted, or extra positions MUST produce `inconclusive:position_mismatch`.
+
+The versioned corpus metadata MUST include the offline position-selection record:
+
+- Prompt id.
+- Position index.
+- Sampling profile.
+- Token-prefix digest.
+- Baseline entropy.
+- Entropy profile key.
+- Offline per-token plain probabilities sufficient to compute expected tail mass for any returned `support_token_ids` union at `K=64` and `K=256`.
+- Whether the position is `high_entropy`.
+
+The offline position-selection record is keyed by `(prompt_id, position_index, sampling_profile, corpus_version)`. Baseline entropy is Shannon entropy of the full next-token distribution under the plain path after the exact sampling profile transforms, normalized by `log(vocab_size)`. A position is `high_entropy` for that sampling profile when normalized entropy is at least `0.35`. The offline per-token plain probabilities are coordinator-owned validation aids derived from the same full-distribution corpus build. They MUST be sufficient for the coordinator to compute `expected_plain_tail_after_returned_union = 1 - sum(offline_plain_p[token] for token in support_token_ids)` for any valid returned shared support; they are not provider-provided verdicts. Each stochastic probe MUST include at least 8 measured positions, and at least 4 MUST be `high_entropy` for the exact sampling profile under test.
+
+### FR-7 Compact distribution output
+
+For every measured stochastic position, the provider MUST construct support with `support_selection_v1`:
+
+1. Compute the plain path's full next-token distribution at the normative capture point.
+2. Compute the spec path's full next-token distribution at the normative capture point.
+3. Select `plain_top_k_token_ids`: the K highest-probability token ids in the plain distribution, descending by probability with ascending token id as tie-breaker.
+4. Select `spec_top_k_token_ids`: the K highest-probability token ids in the spec distribution, using the same ordering.
+5. Compute `support_token_ids`: the numeric-ascending union of `plain_top_k_token_ids` and `spec_top_k_token_ids`.
+6. Report full-distribution probabilities for every `support_token_ids` entry in both paths.
+7. Report tail mass as `1 - sum(probability over support_token_ids)` for each path.
+
+`K` is the per-path top-K count. `support_token_ids` length MUST be at least `K` and at most `2K`, unless vocabulary size is smaller.
 
 For each measured stochastic position, the provider MUST return:
 
-- `plain_topk`: top-K token ids and normalized probabilities for the plain path.
+- `position_index`.
+- `context_hash` over the exact teacher-forced token prefix.
+- `support_selection = "support_selection_v1"`.
+- `plain_top_k_token_ids`.
+- `spec_top_k_token_ids`.
+- `support_token_ids`.
+- `plain_support`: full-distribution probabilities for every token in `support_token_ids` for the plain path.
 - `plain_tail_mass`.
-- `spec_topk`: top-K token ids and normalized probabilities for the spec path.
+- `spec_support`: full-distribution probabilities for every token in `support_token_ids` for the spec path.
 - `spec_tail_mass`.
-- `context_hash`.
-- Position index.
+- `target_model_hash`, `target_generation`.
+- `draft_artifact_binding`, `draft_generation`.
+- `tokenizer_identity`.
+- `normalization_basis = "full_distribution"`.
+- `sampler_stage = "post_processors_post_sampling_profile_next_emitted_token"`.
+- Optional trace counters: drafted tokens, accepted tokens, rejected tokens, and fallback target tokens for the position.
 
 The provider MAY return a plain/plain baseline distribution for calibration. The coordinator MUST NOT require sampled-token histograms for the normative v0.1 verdict.
 
-### FR-6 Coordinator TV computation
+### FR-8 Distribution validation
+
+Before computing a verdict, the coordinator MUST validate every returned distribution:
+
+- Probabilities and tail masses are finite numbers in `[0,1]`.
+- Token ids are non-negative integers valid for the tokenizer/vocabulary bound to `target_model_hash`.
+- `support_selection` equals `support_selection_v1`.
+- `normalization_basis` equals `full_distribution`.
+- `sampler_stage` equals `post_processors_post_sampling_profile_next_emitted_token`.
+- `plain_top_k_token_ids` and `spec_top_k_token_ids` have no duplicates, are length K unless vocabulary size is smaller, and are sorted by probability descending with ascending token id ties.
+- `support_token_ids` equals the numeric-ascending union of `plain_top_k_token_ids` and `spec_top_k_token_ids`.
+- `plain_support` and `spec_support` have exactly one finite probability for every token in `support_token_ids`.
+- `abs(sum(plain_support.p) + plain_tail_mass - 1.0) <= 1e-5`.
+- `abs(sum(spec_support.p) + spec_tail_mass - 1.0) <= 1e-5`.
+- `support_token_ids` length is at least K and at most `2K`, unless vocabulary size is smaller.
+- For high-entropy v0.1 `top_p=1.0` positions with `support_token_ids.length < vocab_size`, the returned `plain_tail_mass` MUST be at least `expected_plain_tail_after_returned_union - 1e-5`, computed from the coordinator-owned offline plain probabilities over the actual returned `support_token_ids` union. Lower plain tail values MUST be rejected as malformed because they are inconsistent with the offline full-distribution baseline and are consistent with top-K-renormalized evidence. This floor is not applied to `spec_tail_mass`, and low-entropy positions are not rejected on tail size alone.
+- The returned `tokenizer_identity` equals the expected tokenizer identity from `draft_admission_v1`.
+- `context_hash` matches the coordinator's expected teacher-forced token prefix.
+
+Any validation failure MUST produce `inconclusive:malformed_distribution` and MUST increment the abusive-inconclusive counter defined in FR-14.
+
+### FR-9 Coordinator TV interval computation
 
 The coordinator MUST compute the canonical verdict from provider-returned compact distributions. Provider-returned scalar verdicts MAY be logged but MUST NOT be authoritative.
+
+For any non-empty ordered numeric set, the canonical median is the lower middle value after ascending sort: index `(n - 1) / 2` using integer division. This deliberately avoids averaging middle values, so boundary decisions are identical across integer, decimal, and binary floating-point implementations.
 
 For stochastic positions, the coordinator MUST compute:
 
 ```text
-support = union(token ids in plain_topk, token ids in spec_topk)
-TV_bound = 0.5 * (
-  sum_{token in support} |p_plain(token) - p_spec(token)|
-  + |plain_tail_mass - spec_tail_mass|
-)
+support_diff = sum_{token in support_token_ids} |p_plain(token) - p_spec(token)|
+tv_lower = 0.5 * (support_diff + |plain_tail_mass - spec_tail_mass|)
+tv_upper = 0.5 * (support_diff + plain_tail_mass + spec_tail_mass)
 ```
 
-Missing tokens in either side's top-K list MUST be treated as probability zero inside the reported support.
+Because both paths report probabilities for the same shared support and both tail masses are outside that support, `tv_lower` is the minimum TV consistent with the compact evidence and `tv_upper` is the conservative TV upper bound. A pass decision MUST use `tv_upper`. A quarantine decision MUST use `tv_lower`. Values between those decisions require retry or inconclusive handling.
 
-### FR-7 K and tail handling
+### FR-10 K and tail handling
 
 The default requested K MUST be `64`.
 
-If either side's tail mass exceeds `0.01`, or if `TV_bound` is within `0.005` of a quarantine threshold, the coordinator SHOULD retry the probe at `K=256`.
+If either side's tail mass exceeds `0.01`, if `tv_upper` is at or above a warning threshold, or if `tv_lower` is within `0.005` of a quarantine threshold, the coordinator MUST retry the probe at `K=256` before assigning `pass`, `warn`, or `quarantine_candidate`.
 
-At `K=256`, if either side's tail mass exceeds `0.005`, the position MUST be marked inconclusive. High tail mass MUST NOT by itself increment the canary failure counter.
+If the required `K=256` retry cannot complete, the result MUST be `inconclusive:k_retry_failed`. It MUST NOT increment the confirmed-failure counter, but it MUST follow the abusive-inconclusive handling in FR-14.
 
-### FR-8 Verdict categories
+At `K=256`, if either side's tail mass exceeds `0.005`, the position MUST be marked `inconclusive:tail_mass_high`. High tail mass MUST NOT by itself increment the abusive-inconclusive counter or the confirmed-failure counter.
 
-The coordinator MUST assign one of:
+### FR-11 Calibration
+
+Before any `quarantine_candidate` can count toward disablement, the coordinator MUST have an approved calibration baseline for `(target_model_hash, draft_artifact_binding, sampling_profile, corpus_version, threshold_version)`.
+
+The calibration record MUST include:
+
+- `calibration_id`.
+- `target_model_hash`.
+- `draft_artifact_binding`.
+- `sampling_profile`.
+- `corpus_version`.
+- `threshold_version`.
+- Baseline source: provider plain/plain hook or maintainer-approved local reference.
+- Baseline sample count or measurement count.
+- Baseline median and max `tv_lower`.
+- Baseline median and max `tv_upper`.
+- Approval timestamp and approver group.
+
+Calibration is acceptable only when baseline max `tv_upper <= 0.01` and baseline median `tv_upper <= 0.005`, or when maintainers explicitly approve a wider threshold version. The quarantine threshold for the active threshold version MUST exceed baseline max `tv_upper` by at least `0.05`.
+
+If calibration is missing or fails the acceptance rule, a result that would otherwise be `quarantine_candidate` MUST become `blocked:calibration_missing` and MUST NOT increment the confirmed-failure counter.
+
+### FR-12 Verdict categories and reason codes
+
+The coordinator MUST assign one status and one reason code:
 
 - `pass`.
 - `warn`.
 - `quarantine_candidate`.
 - `inconclusive`.
+- `blocked`.
+
+Required reason-code table:
+
+`operator_action` is a closed enum. Allowed values are: `none`, `inspect_threshold_trend`, `inspect_provider_draft`, `approve_calibration_baseline`, `disable_spec_decode_key`, `retry_probe_with_backoff`, `inspect_provider_load`, `disable_sampler_profile`, `wait_ready_snapshot_reprobe`, `reload_or_disable_draft`, `create_draft_admission_record`, `inspect_generation_mismatch`, `inspect_control_channel_replay`, `fix_provider_serializer`, `fix_position_handling`, `fix_result_completeness`, `request_spec028_rollout_approval`, and `disable_stochastic_spec_decode`. Telemetry and dashboards MAY include a separate `operator_action_label` for runbook prose, but filtering, alerting, and tests MUST use the enum.
+
+| Reason code | Status | Retryable | Counter effect | Next state | Operator action |
+|---|---|---:|---|---|---|
+| `pass:fresh` | `pass` | no | clear consecutive quarantine only | `pass_fresh` | none |
+| `warn:threshold_exceeded` | `warn` | yes | none | `warn` | `inspect_threshold_trend` |
+| `quarantine_candidate:tv_lower_exceeded` | `quarantine_candidate` | yes | increment confirmed-failure counter | `warn` until second consecutive candidate, then `disabled` | `inspect_provider_draft` |
+| `blocked:calibration_missing` | `blocked` | no | none | `blocked` | `approve_calibration_baseline` |
+| `blocked:greedy_control_failed` | `blocked` | no | increment greedy-control failure counter | `blocked` | `disable_spec_decode_key` |
+| `inconclusive:tail_mass_high` | `inconclusive` | yes | no abuse unless repeated >3 in 24h | `inconclusive_retryable` | `retry_probe_with_backoff` |
+| `inconclusive:k_retry_failed` | `inconclusive` | yes | abusive event | `inconclusive_retryable` or `blocked` at threshold | `inspect_provider_load` |
+| `inconclusive:timeout` | `inconclusive` | yes | abusive event | `inconclusive_retryable` or `blocked` at threshold | `inspect_provider_load` |
+| `inconclusive:unsupported_sampler` | `inconclusive` | no | abusive event | `blocked` | `disable_sampler_profile` |
+| `inconclusive:model_swap` | `inconclusive` | yes | no abuse unless repeated >3 in 24h | `expired` | `wait_ready_snapshot_reprobe` |
+| `inconclusive:draft_unavailable` | `inconclusive` | yes | abusive event | `inconclusive_retryable` or `blocked` at threshold | `reload_or_disable_draft` |
+| `inconclusive:draft_identity_unbound` | `inconclusive` | no | abusive event | `blocked` | `create_draft_admission_record` |
+| `inconclusive:identity_mismatch` | `inconclusive` | no | abusive event | `blocked` | `inspect_generation_mismatch` |
+| `inconclusive:replay_or_expired` | `inconclusive` | no | abusive event | `blocked` | `inspect_control_channel_replay` |
+| `inconclusive:malformed_distribution` | `inconclusive` | no | abusive event | `blocked` | `fix_provider_serializer` |
+| `inconclusive:position_mismatch` | `inconclusive` | no | abusive event | `blocked` | `fix_position_handling` |
+| `inconclusive:missing_distribution` | `inconclusive` | no | abusive event | `blocked` | `fix_result_completeness` |
+
+`blocked:greedy_control_failed` MUST be emitted when the greedy control token-id equality check fails for any requested position.
+
+The consecutive quarantine-candidate counter is keyed by profile key:
+
+- `quarantine_candidate:tv_lower_exceeded` increments the counter by one.
+- Any `pass` clears the counter.
+- `warn` preserves the counter but does not increment it.
+- `inconclusive` preserves the counter but does not increment it, while abusive inconclusive handling remains governed by FR-14.
+- `blocked`, `disabled`, `expired`, target-generation change, draft-generation change, corpus-version change, or threshold-version change clears the counter for the old key because later results apply to a different or no-longer-eligible key.
+
+Therefore `Q,Q` disables the profile key, `Q,W,Q` disables the profile key, `Q,inconclusive,Q` disables the profile key, and `Q,pass,Q` leaves the counter at one.
 
 Recommended initial thresholds:
 
-- `warn` when median `TV_bound > 0.02` or any high-entropy position `TV_bound > 0.05`.
-- `quarantine_candidate` when median `TV_bound > 0.05` or any high-entropy position `TV_bound > 0.10`, after any required K retry.
-- `inconclusive` for high tail mass after retry, timeout, unsupported sampler, model swap, draft unavailable, missing distributions, or malformed result.
+- `pass` requires all requested stochastic positions valid, all expected identities stable, no replay/expiry issue, no pending K retry, final per-position tail mass within the accepted ceiling, `tv_upper <= 0.02` for every position, and median `tv_upper <= 0.01`.
+- `warn:threshold_exceeded` when any position has `tv_upper > 0.02` or median `tv_upper > 0.01`, unless quarantine criteria are met.
+- `quarantine_candidate:tv_lower_exceeded` when any position has `tv_lower > 0.10` or median `tv_lower > 0.05`, after required K retry and with accepted calibration present.
+- `inconclusive` for any required validation, identity, transport, tail, sampler, timeout, or position failure.
 
 Thresholds are draft defaults. Locking this spec requires maintainer approval for the final threshold table and prompt corpus.
 
-### FR-9 Sanction gating
+### FR-13 Eligibility and failure state machine
 
-A single `quarantine_candidate` MUST NOT immediately degrade or disable a provider.
+The coordinator MUST maintain `losslessness_profile_state` separately from echo-canary state and keyed by the profile key.
 
-The coordinator MAY feed the existing canary failure counter only after two consecutive `quarantine_candidate` results for the same probe key. `pass` clears the consecutive losslessness failure count for that probe key. `warn` and `inconclusive` MUST NOT increment it.
+Allowed profile states:
 
-After the losslessness failure count is eligible for sanctioning, the existing canary threshold MAY degrade pinned providers or mark provisional providers unavailable.
+- `unknown`: no valid result for the profile key.
+- `pending`: probe issued and result not finalized.
+- `pass_fresh`: latest result for this profile key passes and has not expired.
+- `warn`: latest valid result is warning-class.
+- `inconclusive_retryable`: latest inconclusive is retryable and below abuse threshold.
+- `blocked`: repeated abusive inconclusive results, missing sampler support, missing calibration, or missing draft identity prevent stochastic spec decode for the profile key.
+- `disabled`: repeated confirmed quarantine candidates disable stochastic spec decode for the profile key.
+- `expired`: prior state exceeded freshness TTL or was invalidated by corpus/threshold/target/draft generation change.
 
-### FR-10 Telemetry surface
+Profile freshness TTL is 24 hours after the latest pass for the same profile key. `warn`, `inconclusive_retryable`, `blocked`, `disabled`, `unknown`, and `expired` MUST deny stochastic speculative-decoding eligibility for the profile key.
+
+The coordinator MUST also maintain `losslessness_grid_state` keyed by the grid key. It is `all_profiles_fresh` only when every required stochastic sampling profile and the greedy control have `pass_fresh` profile state for the same grid key. Any missing, stale, warning, blocked, disabled, inconclusive, or expired profile state MUST make the grid state `not_ready`.
+
+SPEC-029 only produces evidence for a SPEC-028 rollout decision. The rollout consumer rule is:
+
+1. `all_profiles_fresh` is required before stochastic speculative decoding can be enabled for a grid key.
+2. A SPEC-028 rollout PR or decision-log entry approved by MacProvider SPEC Maintainers MUST explicitly name the grid key, feature flag, allowed sampling profiles, and rollback condition.
+3. Until that SPEC-028 approval exists, the dashboard operator action for `all_profiles_fresh` is `request_spec028_rollout_approval`; stochastic speculative decoding remains disabled.
+4. If any profile state leaves `pass_fresh`, the grid state becomes `not_ready` and the SPEC-028 rollout consumer MUST disable stochastic speculative decoding for the affected grid key.
+
+### FR-14 Disablement and abusive-inconclusive handling
+
+A single `quarantine_candidate` MUST NOT degrade or disable general provider readiness.
+
+Two consecutive `quarantine_candidate` results for the same profile key MUST transition that key to `disabled`. This disablement applies only to stochastic speculative decoding for that key. Echo-canary failure counters and non-speculative provider availability MUST remain unchanged.
+
+Repeated abusive inconclusive results MUST fail closed for stochastic speculative decoding:
+
+- `k_retry_failed`, `timeout`, `unsupported_sampler`, `draft_unavailable`, `draft_identity_unbound`, `identity_mismatch`, `replay_or_expired`, `malformed_distribution`, `position_mismatch`, and `missing_distribution` increment an abusive-inconclusive event log.
+- `tail_mass_high` and `model_swap` do not increment the abusive-inconclusive counter unless they repeat more than 3 times in a 24-hour window for the same key.
+- Three abusive inconclusive results in a 24-hour window MUST transition the key to `blocked`.
+
+`blocked:greedy_control_failed` is an immediate deterministic-control block and increments only the greedy-control failure counter. It MUST NOT increment or be displayed inside the abusive-inconclusive count.
+
+`pass` clears only the consecutive quarantine-candidate counter for the key. It MUST NOT delete the rolling 24-hour abusive-inconclusive event log. Echo-canary pass/fail state MUST NOT clear losslessness counters.
+
+### FR-15 Telemetry event schema
 
 The coordinator MUST publish probe results as out-of-band telemetry. The v0.1 event type is `losslessness_probe_v1`.
 
-The event MUST include:
+Normal issued-probe events MUST include:
 
-- `probe_id`.
-- `provider_id`.
-- `assigned_id`.
-- `model_id`.
-- `target_model_hash`.
-- `draft_model_id`.
-- Sampling profile.
-- K used for the final verdict.
-- Verdict status.
-- Median and max `TV_bound`.
-- Max tail mass.
-- Positions measured.
-- Timestamp.
+| Field | Type |
+|---|---|
+| `event_type` | string, exactly `losslessness_probe_v1` |
+| `event_subtype` | string, exactly `probe_result` |
+| `probe_id` | string |
+| `probe_request_digest` | `sha256:<hex>` string |
+| `probe_result_digest` | `sha256:<hex>` string or null |
+| `provider_id` | string |
+| `assigned_id` | string |
+| `profile_key` | object containing the profile-key fields |
+| `grid_key` | object containing the grid-key fields |
+| `model_id` | string |
+| `target_model_hash` | string |
+| `target_generation` | integer |
+| `draft_model_id` | string |
+| `draft_artifact_binding` | object |
+| `draft_generation` | integer |
+| `tokenizer_identity` | string |
+| `sampling_profile` | object |
+| `corpus_version` | string |
+| `threshold_version` | string |
+| `result_kind` | string, `measurement`, `provider_inconclusive`, `coordinator_timeout`, or `admission_blocked` |
+| `metric_kind` | string, `tv`, `greedy_equality`, or `none` |
+| `final_k` | integer or null |
+| `position_k` | array of integers or null |
+| `status` | string |
+| `reason_code` | string |
+| `retryable` | boolean |
+| `operator_action` | operator-action enum string |
+| `operator_action_label` | string or null |
+| `median_tv_lower` | number or null |
+| `max_tv_lower` | number or null |
+| `median_tv_upper` | number or null |
+| `max_tv_upper` | number or null |
+| `max_tail_mass` | number or null |
+| `greedy_positions_matched` | integer or null |
+| `greedy_positions_failed` | integer or null |
+| `mismatched_position_count` | integer or null |
+| `position_count_requested` | integer |
+| `position_count_used` | integer |
+| `retry_attempts` | integer |
+| `measured_at` | RFC3339 UTC timestamp |
+| `stale_after` | RFC3339 UTC timestamp |
+| `evidence_mode` | string, `inline` or `retained_ref` |
+| `evidence_schema_version` | string |
+| `evidence_digest` | `sha256:<hex>` string |
+| `evidence_ref` | string or null |
+| `evidence_retained_until` | RFC3339 UTC timestamp |
 
-The event MAY include compact per-position evidence for audit retention.
+For pre-issuance blocked cases, such as missing `draft_admission_v1`, the coordinator MUST emit `event_subtype = "admission_blocked"`. In that event, `probe_request_digest`, `probe_result_digest`, `probe_id`, and result metrics follow the nullability rules below, but `provider_id`, `assigned_id`, `profile_key` or partial profile key, `grid_key` or partial grid key, `status`, `reason_code`, `retryable`, `operator_action`, `measured_at`, and `stale_after` MUST be present.
 
-### FR-11 Receipt and usage invariants
+For stochastic measurement outcomes, `result_kind = "measurement"` and `metric_kind = "tv"`; TV/tail metric fields are required and greedy fields MUST be null. For greedy control outcomes, `metric_kind = "greedy_equality"`; greedy fields are required and TV/tail fields MUST be null. For provider-inconclusive outcomes or coordinator timeout/no-result outcomes, `metric_kind = "none"`; TV/tail and greedy fields MUST be null. `probe_result_digest` is required when a provider result payload exists and MUST be null for coordinator timeout/no-result outcomes.
+
+The event MUST retain either inline compact per-position evidence or a digest plus retained object reference until `evidence_retained_until`.
+
+Grid-level rollout telemetry MUST be emitted whenever `losslessness_grid_state` changes or a SPEC-028 rollout approval reference is added, removed, or superseded. The grid event MUST include:
+
+| Field | Type |
+|---|---|
+| `event_type` | string, exactly `losslessness_probe_v1` |
+| `event_subtype` | string, exactly `grid_state` |
+| `grid_key` | object containing the grid-key fields |
+| `losslessness_grid_state` | string, `all_profiles_fresh` or `not_ready` |
+| `missing_profiles` | array of sampling-profile objects |
+| `stale_profiles` | array of sampling-profile objects |
+| `blocked_profiles` | array of sampling-profile objects |
+| `not_ready_profiles` | array of objects containing `sampling_profile`, `profile_state`, `reason_code`, `stale_after`, and `operator_action` |
+| `spec028_rollout_approval_status` | string, `absent`, `approved`, `superseded`, or `revoked` |
+| `spec028_rollout_approval_ref` | string or null |
+| `feature_flag` | string or null |
+| `allowed_sampling_profiles` | array of sampling-profile objects |
+| `rollback_condition` | string or null |
+| `operator_action` | operator-action enum string |
+| `operator_action_label` | string or null |
+| `measured_at` | RFC3339 UTC timestamp |
+| `stale_after` | RFC3339 UTC timestamp |
+
+### FR-16 Operator dashboard contract
+
+The operator dashboard MUST display a profile matrix by provider, model, target generation, draft artifact binding, draft generation, sampling profile, corpus version, and threshold version.
+
+For each cell it MUST show:
+
+- Eligibility state.
+- Latest status and reason code.
+- `measured_at` and `stale_after`.
+- Consecutive quarantine-candidate count.
+- Abusive-inconclusive count.
+- Greedy-control failure count.
+- Retryable flag.
+- Operator action.
+- Latest median/max `tv_lower` and `tv_upper`.
+- Latest max tail mass.
+
+The dashboard MUST also display a grid-level rollout row keyed by grid key. That row MUST show `losslessness_grid_state`, `not_ready_profiles` with each blocker profile state and reason code, SPEC-028 rollout approval status and reference, feature flag, allowed sampling profiles, rollback condition, and operator action. Its operator action MUST be `request_spec028_rollout_approval` when the grid is `all_profiles_fresh` but no current SPEC-028 approval exists, and `disable_stochastic_spec_decode` when any approved grid later becomes `not_ready`.
+
+Dashboard aggregates MAY summarize provider health, but aggregates MUST NOT collapse sanctioning or eligibility across temperatures, target generations, draft generations, corpus versions, or threshold versions.
+
+### FR-17 Receipt and usage invariants
 
 SPEC-029 MUST NOT add fields to SPEC-015 v0.4 receipts or v0.4 `usage`.
 
@@ -184,32 +557,29 @@ SPEC-029 MUST NOT alter buyer token accounting, payout accounting, receipt verif
 
 Future receipt versions MAY bind a digest of recent losslessness probe status, but that is outside v0.1.
 
-### FR-12 Warm-swap handling
+### FR-18 Warm-swap handling
 
-If the target model or draft model changes while a probe is running, the provider MUST return `inconclusive:model_swap` or equivalent structured error.
+If the target model or draft model changes while a probe is running, the result MUST be `inconclusive:model_swap`.
 
-Probe results MUST NOT carry across target-swap boundaries. After a new target snapshot becomes ready and draft compatibility is checked, the coordinator SHOULD schedule a fresh probe for the new probe key.
+Probe results MUST NOT carry across target or draft generation boundaries. After a new target snapshot becomes ready and draft compatibility is checked, the coordinator SHOULD schedule fresh probes for the affected profile keys.
 
-Draft-load failure after a target swap MUST NOT fail the target-model swap. It MUST leave stochastic speculative decoding disabled for that model/draft pair and emit a warning or inconclusive probe result.
+Draft-load failure after a target swap MUST NOT fail the target-model swap. It MUST leave stochastic speculative decoding disabled for that model/draft key and emit `inconclusive:draft_unavailable` or `inconclusive:draft_identity_unbound`.
 
-### FR-13 Prompt corpus
+### FR-19 Data retention and privacy
 
-The v0.1 prompt corpus SHOULD include:
+Probe prompts and retained evidence MUST be synthetic or explicitly redacted coordinator-owned material. Buyer-origin content is prohibited.
 
-- Short general instruction prompts.
-- Code-completion contexts.
-- Tool-call-like JSON contexts.
-- Multi-turn chat contexts.
+Compact per-position evidence MUST be retained for 30 days by default, encrypted at rest, and accessible only to coordinator operators with audit-log access. Retention longer than 30 days requires maintainer approval and a documented reason.
 
-Measurement positions SHOULD prefer higher-entropy next-token distributions. Low-entropy positions MAY be included as controls but SHOULD NOT dominate the verdict.
+Logs and dashboard views MUST NOT display raw prompt text by default. They MAY display prompt ids, corpus version, token-prefix digests, context hashes, and compact probability evidence.
 
-### FR-14 No covert canaries
+### FR-20 No covert canaries
 
 V0.1 probes are overt. The provider MAY know it is handling a losslessness probe.
 
 Covert probes MUST be specified separately because they interact with buyer traffic, billing, receipts, and abuse resistance.
 
-## 5. Non-Goals
+## 6. Non-Goals
 
 - Proving a malicious provider honestly loaded a claimed model.
 - Proving hardware, binary, or compute integrity.
@@ -217,31 +587,40 @@ Covert probes MUST be specified separately because they interact with buyer traf
 - Replacing SPEC-028 acceptance-rate telemetry.
 - Replacing existing echo canaries.
 - Authorizing stochastic speculative decoding without a later rollout decision.
+- Degrading general provider readiness from losslessness results alone.
 
-## 6. Acceptance Criteria
+## 7. Acceptance Criteria
 
 Before SPEC-029 can move toward LOCK:
 
-1. A coordinator design specifies the `losslessness_probe_v1` message, result event, storage table, and operator query path.
-2. A provider design identifies the exact Swift generation/sampler hook that emits top-K probabilities plus tail mass for plain and spec paths.
-3. A test fixture proves that extra losslessness fields are not added to SPEC-015 v0.4 receipts or `usage`.
-4. A unit test covers coordinator TV computation with non-overlapping top-K token sets and tail masses.
-5. A unit test covers `K=64` retry to `K=256` and the `inconclusive:tail_mass_high` path.
-6. A coordinator test covers two consecutive `quarantine_candidate` results feeding the existing canary failure counter, while `warn` and `inconclusive` do not.
-7. A warm-swap test covers `inconclusive:model_swap` and confirms old probe results do not authorize the new target snapshot.
-8. Maintainers approve the v0.1 prompt corpus and threshold table.
+1. A protocol fixture covers the WS request/result JSON schema, required `payload` envelope field, cleartext and Tier-2 encrypted probe carriers, measurement and provider-inconclusive result variants, auth/session binding, nonce, expiry, inner-payload request digest, inner-payload result digest, replay rejection, timeout, and bounded K.
+2. A draft-admission fixture covers `draft_admission_v1`, including draft artifact SHA-256, tokenizer identity, compatibility check digest, generation increment, expiry, and the no-heartbeat/no-receipt boundary.
+3. A provider design identifies the exact Swift generation/sampler hook that emits full-distribution shared-support probabilities plus tail mass at the normative capture point for plain and spec paths.
+4. A test fixture proves that extra losslessness fields are not added to SPEC-015 v0.4 receipts or `usage`.
+5. A coordinator unit test covers distribution validation failures: duplicate support token ids, NaN, negative probability, shared-support length mismatch, invalid `normalization_basis`, missing or wrong `sampler_stage`, below-baseline high-entropy tail with partial support, inconsistent tail mass, wrong tokenizer identity, wrong context hash, and wrong K. It also covers a valid case where `support_token_ids.length > K` and `plain_tail_mass` is below the plain top-K-only tail but equals the expected tail outside the returned shared-support union.
+6. A coordinator unit test covers `tv_lower` and `tv_upper` over shared support and equal-size disjoint tails outside the shared support.
+7. A coordinator test proves missing or invalid `support_selection_v1`, missing top-K lists, and top-K-only submissions that omit full shared-support probabilities are rejected as malformed.
+8. A coordinator unit test covers mandatory `K=64` retry to `K=256`, non-sanctioning retry failure, final tail ceilings for pass, and `inconclusive:tail_mass_high`.
+9. A coordinator test covers accepted calibration, missing calibration, calibration failing the baseline-noise rule, and quarantine threshold margin over baseline max `tv_upper`.
+10. A coordinator state-machine test covers profile-level `pass_fresh`, `warn`, `blocked`, `disabled`, and `expired`.
+11. A coordinator state-machine test covers grid-level `all_profiles_fresh` and `not_ready`, including the case where one sampling profile is stale.
+12. A coordinator test covers two consecutive `quarantine_candidate` results disabling stochastic spec decode only for the profile key while leaving echo-canary/general readiness unchanged.
+13. A coordinator test covers rolling 24-hour abusive inconclusive handling and proves a later `pass` does not erase abusive events inside the window.
+14. A coordinator test covers reason-code mapping for retryability, counter effect, next state, closed-enum operator action, and consecutive quarantine transitions for `Q,Q`, `Q,W,Q`, `Q,inconclusive,Q`, and `Q,pass,Q`, including `blocked:greedy_control_failed`.
+15. A warm-swap and generation test covers `target_generation` owner/increment rules, same-hash reload, reconnect without continuity proof, `inconclusive:model_swap`, target/draft generation mismatch, draft identity missing, and old results not authorizing a new target or draft generation.
+16. A corpus planning test rejects probe plans/results that do not meet exact position, exact-profile entropy, and high-entropy quota requirements.
+17. A dashboard snapshot test covers reason codes, retryable flag, closed-enum operator action plus label, profile/grid state, `not_ready_profiles`, counters, `metric_kind`, nullable metrics for non-TV outcomes, and no cross-temperature aggregation for eligibility.
+18. A privacy test or static fixture proves buyer-origin prompts are rejected from the corpus and raw prompt text is not displayed by default.
+19. MacProvider SPEC Maintainers approve the v0.1 prompt corpus, threshold table, retention TTL, calibration process, and SPEC-028 rollout consumer rule.
 
-## 7. Open Questions
+## 8. Open Questions
 
-1. Should v0.1 require `K=256` for all `temperature=1.0` probes, or keep `K=64` with retry?
-2. What is the final normative prompt corpus and who owns updates to it?
-3. Should operator dashboards show per-position compact evidence or only aggregate verdicts?
-4. Should losslessness results become part of provider eligibility for stochastic spec decode only, or also affect general provider readiness?
-5. What retention period is required for compact per-position evidence?
-6. Does the provider-control WS path need an HTTP fallback in v0.1?
-7. Should a future SPEC-015 v0.5 bind a digest of recent losslessness probe status into settlement receipts?
+These are not blockers to the v0.1 protocol shape but remain before LOCK:
 
-## 8. References
+1. Should the default 30-day evidence retention TTL be shorter for public beta?
+2. Should a future SPEC-015 v0.5 bind a recent losslessness probe digest into settlement receipts?
+
+## 9. References
 
 - `docs/research/losslessness-probe-2026-07.md`.
 - `specs/SPEC-028-mlx-speculative-decoding.md`.


### PR DESCRIPTION
## Status

**DRAFT — RESEARCH + SPEC ARTIFACTS ADDED, NO PRODUCT CODE.** This PR now contains the requested losslessness-probe research memo, SPEC-029 v0.1 draft, and maintainer open-question log. It intentionally does not modify runtime, coordinator, buyer, settlement, or verifier code.

## Why this exists

SPEC-028 is conservative for production traffic: greedy speculative decoding can be token-exact, while buyer-typical temperatures above 0 require a distributional-equivalence claim that MacProvider should not make without a measurable gate.

This PR defines that gate as an overt, out-of-band `losslessness_probe_v1` canary profile. The draft chooses coordinator-owned telemetry instead of changing SPEC-015 v0.4 receipts because the v0.4 tuple and `usage` schemas are strict and existing verifiers reject extra keys.

## Added artifacts

1. `docs/research/losslessness-probe-2026-07.md` answers §A–G with local and upstream citations: canary issuance, output representation, TV-distance computation, publishing surface, temperature range, warm-swap interaction, and covert-canary seam.
2. `specs/SPEC-029-losslessness-probe.md` defines v0.1 normative requirements, non-goals, acceptance criteria, and open questions.
3. `.omc/logs/losslessness-probe-open-questions-2026-07.md` records five maintainer-input items before LOCK.

## Key decisions in the draft

- Use an overt coordinator-issued probe profile, not buyer-visible traffic.
- Use compact top-K probability snapshots plus residual tail mass, with coordinator-recomputed TV bounds.
- Default to `K=64`, retry at `K=256` for high-tail or near-threshold cases, and keep sampled-token histograms as optional research calibration only.
- Keep SPEC-015 v0.4 receipts, SPEC-022 settlement semantics, and buyer API fields unchanged.
- Treat warm-swap, draft unavailability, high tail mass, unsupported sampler, and timeouts as inconclusive rather than sanctionable failures.

## Remaining gates

- Maintainer approval for thresholds, K policy, prompt corpus ownership, telemetry surface, sanction scope, and operational retention/fallback rules.
- CODE + SECURITY + ARCHITECT audit before LOCK.
- Implementation is a separate PR after the SPEC is accepted.

## Do NOT in this PR

- Modify SPEC-015 v0.4, SPEC-022, or SPEC-028.
- Implement coordinator/provider runtime changes.
- Design covert-canary indistinguishability in v0.1.
- Scope compute-integrity-against-reference; that remains a separate SPEC.
- Import or depend on shard code; the draft only cites the mechanism as research context.

## Related

- Companion to SPEC-028 speculative decoding.
- Blocks the compute-integrity receipt companion research, which depends on this probe primitive reaching v0.1 draft.
