### PR TITLE
[codex] Gate hardware stats behind verifier trust

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -68,6 +68,9 @@ struct AutotuneCommand: AsyncParsableCommand {
     @Flag(help: "Recommend the best paid-yield model for this Mac from the signed/static market inputs.")
     var recommend = false
 
+    @Flag(name: .customLong("submit-hardware-evidence"), inversion: .prefixedNo, help: "With --recommend, submit local autotune hardware evidence for stats verification when provider credentials are configured.")
+    var submitHardwareEvidence = true
+
     @Flag(help: "With --recommend, check whether the stored recommendation is fresh without benchmarking.")
     var freshnessCheck = false
 
@@ -742,6 +745,20 @@ struct AutotuneCommand: AsyncParsableCommand {
         var result = AutotuneRecommendEngine().recommend(request)
         result.probeDiagnostics = outcomes.diagnostics
         try RecommendationStateStore.write(result)
+        if submitHardwareEvidence {
+            let submission = await AutotuneHardwareEvidenceSubmitter(config: resolvedConfig).submit(
+                result: result,
+                benchmarks: request.benchmarks
+            )
+            switch submission {
+            case .submitted:
+                FileHandle.standardError.write(Data("hardware evidence submitted for stats verification\n".utf8))
+            case .skipped:
+                break
+            case .failed(let reason):
+                FileHandle.standardError.write(Data("[warn] hardware evidence submission failed: \(reason)\n".utf8))
+            }
+        }
         let paidSelected = result.recommendedModel.flatMap { recommendedModel in
             result.selectedCandidate.flatMap { $0.model == recommendedModel ? $0 : nil }
         }

--- a/phase3-binary/Sources/macprovider-cli/AutotuneHardwareEvidence.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneHardwareEvidence.swift
@@ -1,0 +1,180 @@
+import Foundation
+import MacProviderCore
+
+enum AutotuneHardwareEvidenceSubmission: Equatable {
+    case submitted
+    case skipped(String)
+    case failed(String)
+}
+
+struct AutotuneHardwareEvidenceSubmitter {
+    static let endpointPath = "/v1/providers/hardware-evidence"
+
+    var config: AppConfig?
+    var session: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 10
+        configuration.timeoutIntervalForResource = 20
+        return URLSession(configuration: configuration, delegate: NoRedirectURLSessionDelegate(), delegateQueue: nil)
+    }()
+
+    func submit(result: AutotuneRecommendResult, benchmarks: [String: CandidateBenchmark]) async -> AutotuneHardwareEvidenceSubmission {
+        guard let config else { return .skipped("config unavailable") }
+        guard let providerID = trimmedNonEmpty(config.providerID) else { return .skipped("provider_id missing") }
+        guard let providerToken = trimmedNonEmpty(config.providerToken) else { return .skipped("provider_token missing") }
+        guard let coordinatorURL = trimmedNonEmpty(config.coordinatorURL),
+              let endpoint = Self.hardwareEvidenceEndpoint(from: coordinatorURL)
+        else {
+            return .skipped("coordinator_url missing")
+        }
+        do {
+            let payload = try Self.payloadData(providerID: providerID, result: result, benchmarks: benchmarks)
+            var request = URLRequest(url: endpoint)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.setValue("Bearer \(providerToken)", forHTTPHeaderField: "Authorization")
+            request.httpBody = payload
+            let (_, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return .failed("non-HTTP response")
+            }
+            if (200..<300).contains(http.statusCode) {
+                return .submitted
+            }
+            return .failed("HTTP \(http.statusCode)")
+        } catch {
+            return .failed("\(error)")
+        }
+    }
+
+    static func hardwareEvidenceEndpoint(from raw: String) -> URL? {
+        guard var components = URLComponents(string: raw) else { return nil }
+        switch components.scheme?.lowercased() {
+        case "wss":
+            components.scheme = "https"
+        case "https":
+            break
+        default:
+            return nil
+        }
+        components.path = endpointPath
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
+    static func payloadData(providerID: String, result: AutotuneRecommendResult, benchmarks: [String: CandidateBenchmark]) throws -> Data {
+        let payload = HardwareEvidencePayload(
+            schemaVersion: "hardware_evidence.autotune.v1",
+            providerID: providerID,
+            generatedAt: ISO8601DateFormatter.autotuneInternet.string(from: result.generatedAt),
+            hardware: HardwarePayload(
+                chip: result.hardware.chip,
+                memoryGB: result.hardware.memoryGB,
+                bandwidthTier: result.hardware.bandwidthTier.rawValue,
+                detected: result.hardware.detected,
+                osVersion: result.hardware.osVersion,
+                binaryVersion: result.hardware.binaryVersion,
+                hardwareIdentityHash: result.hardware.hardwareIdentityHash
+            ),
+            candidateCatalogSHA256: result.candidateCatalogSHA256,
+            recommendedModel: result.recommendedModel,
+            benchmarks: benchmarks.keys.sorted().map { key in
+                let benchmark = benchmarks[key]!
+                return BenchmarkPayload(
+                    modelKey: benchmark.modelKey,
+                    modelID: benchmark.modelID,
+                    sustainedTPS: benchmark.sustainedTPS,
+                    ttftMS: benchmark.ttftMS,
+                    swapDetected: benchmark.swapDetected,
+                    thermalThrottleDetected: benchmark.thermalThrottleDetected,
+                    artifactSHA256: benchmark.artifactSHA256,
+                    candidateCatalogSHA256: benchmark.candidateCatalogSHA256,
+                    benchmarkID: benchmark.benchmarkID,
+                    generatedAt: ISO8601DateFormatter.autotuneInternet.string(from: benchmark.generatedAt),
+                    binaryVersion: benchmark.binaryVersion,
+                    hardwareIdentityHash: benchmark.hardwareIdentityHash
+                )
+            }
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(payload)
+    }
+
+    private func trimmedNonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+}
+
+private struct HardwareEvidencePayload: Encodable {
+    var schemaVersion: String
+    var providerID: String
+    var generatedAt: String
+    var hardware: HardwarePayload
+    var candidateCatalogSHA256: String
+    var recommendedModel: String?
+    var benchmarks: [BenchmarkPayload]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case providerID = "provider_id"
+        case generatedAt = "generated_at"
+        case hardware
+        case candidateCatalogSHA256 = "candidate_catalog_sha256"
+        case recommendedModel = "recommended_model"
+        case benchmarks
+    }
+}
+
+private struct HardwarePayload: Encodable {
+    var chip: String
+    var memoryGB: Int
+    var bandwidthTier: String
+    var detected: Bool
+    var osVersion: String
+    var binaryVersion: String
+    var hardwareIdentityHash: String
+
+    enum CodingKeys: String, CodingKey {
+        case chip
+        case memoryGB = "memory_gb"
+        case bandwidthTier = "bandwidth_tier"
+        case detected
+        case osVersion = "os_version"
+        case binaryVersion = "binary_version"
+        case hardwareIdentityHash = "hardware_identity_hash"
+    }
+}
+
+private struct BenchmarkPayload: Encodable {
+    var modelKey: String
+    var modelID: String
+    var sustainedTPS: Double
+    var ttftMS: Int
+    var swapDetected: Bool
+    var thermalThrottleDetected: Bool
+    var artifactSHA256: String
+    var candidateCatalogSHA256: String
+    var benchmarkID: String?
+    var generatedAt: String
+    var binaryVersion: String
+    var hardwareIdentityHash: String
+
+    enum CodingKeys: String, CodingKey {
+        case modelKey = "model_key"
+        case modelID = "model_id"
+        case sustainedTPS = "sustained_tps"
+        case ttftMS = "ttft_ms"
+        case swapDetected = "swap_detected"
+        case thermalThrottleDetected = "thermal_throttle_detected"
+        case artifactSHA256 = "artifact_sha256"
+        case candidateCatalogSHA256 = "candidate_catalog_sha256"
+        case benchmarkID = "benchmark_id"
+        case generatedAt = "generated_at"
+        case binaryVersion = "binary_version"
+        case hardwareIdentityHash = "hardware_identity_hash"
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneHardwareEvidenceTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneHardwareEvidenceTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+@testable import macprovider_cli
+import XCTest
+
+final class AutotuneHardwareEvidenceTests: XCTestCase {
+    func testEndpointConvertsCoordinatorWebSocketURL() {
+        let url = AutotuneHardwareEvidenceSubmitter.hardwareEvidenceEndpoint(
+            from: "wss://coordinator.streamvc.live/v2/provider?x=1"
+        )
+        XCTAssertEqual(url?.absoluteString, "https://coordinator.streamvc.live/v1/providers/hardware-evidence")
+    }
+
+    func testEndpointRejectsCleartextCoordinatorURL() {
+        XCTAssertNil(AutotuneHardwareEvidenceSubmitter.hardwareEvidenceEndpoint(from: "http://coordinator.streamvc.live/v2/provider"))
+        XCTAssertNil(AutotuneHardwareEvidenceSubmitter.hardwareEvidenceEndpoint(from: "ws://coordinator.streamvc.live/v2/provider"))
+    }
+
+    func testPayloadIncludesHardwareAndBenchmarks() throws {
+        let generatedAt = Date(timeIntervalSince1970: 1_788_000_000)
+        let result = AutotuneRecommendResult(
+            generatedAt: generatedAt,
+            hardware: AutotuneRecommendHardware(
+                machine: nil,
+                chip: "Apple M5",
+                memoryGB: 32,
+                bandwidthTier: .c,
+                osVersion: "15.5",
+                binaryVersion: "1.7.9",
+                diversificationID: "div",
+                hardwareIdentityHash: "hash"
+            ),
+            rateCardVersion: "rates.v1",
+            demandRankVersion: "demand.v1",
+            candidateCatalogVersion: "catalog.v1",
+            candidateCatalogSHA256: String(repeating: "a", count: 64),
+            benchmarkID: nil,
+            benchmarkGeneratedAt: nil,
+            recommendedModel: "model-a",
+            selectedCandidate: nil,
+            candidates: [],
+            defaultModel: nil,
+            donorFallbackModel: nil,
+            donorFallbackCandidate: nil,
+            donorFallbackNetUSDPerHour: nil,
+            recommendedDeltaUSDPerHour: 0,
+            recommendedDeltaPercent: 0,
+            warnings: [],
+            assumedUtilization: 1,
+            availabilityHoursPerDay: 24,
+            electricityUSDPerKWH: nil
+        )
+        let benchmark = CandidateBenchmark(
+            modelKey: "model-a",
+            sustainedTPS: 42.5,
+            ttftMS: 1200,
+            swapDetected: false,
+            thermalThrottleDetected: false,
+            artifactSHA256: String(repeating: "b", count: 64),
+            modelArtifactPath: "/tmp/model",
+            benchmarkID: "bench-1",
+            generatedAt: generatedAt,
+            candidateCatalogSHA256: String(repeating: "a", count: 64),
+            binaryVersion: "1.7.9",
+            modelID: "mlx-community/model-a",
+            hardwareIdentityHash: "hash"
+        )
+
+        let data = try AutotuneHardwareEvidenceSubmitter.payloadData(
+            providerID: "mac",
+            result: result,
+            benchmarks: ["model-a": benchmark]
+        )
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(object?["schema_version"] as? String, "hardware_evidence.autotune.v1")
+        XCTAssertEqual(object?["provider_id"] as? String, "mac")
+        let hardware = object?["hardware"] as? [String: Any]
+        XCTAssertEqual(hardware?["chip"] as? String, "Apple M5")
+        XCTAssertEqual(hardware?["memory_gb"] as? Int, 32)
+        let benchmarks = object?["benchmarks"] as? [[String: Any]]
+        XCTAssertEqual(benchmarks?.first?["model_key"] as? String, "model-a")
+        XCTAssertEqual(benchmarks?.first?["sustained_tps"] as? Double, 42.5)
+    }
+}

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -634,20 +634,23 @@ func main() {
 	providerMux.Handle("/admin/metrics", operatorMetricsHandler(cfg.Auth.OperatorKey, metricsRegistry))
 
 	var register http.HandlerFunc
+	var hardwareEvidence http.HandlerFunc
 	if cfg.Onboarding.AppTrackRegisterEnabled {
 		asnResolver, err := onboarding.NewStaticASNResolver(cfg.Onboarding.ASNPrefixes)
 		if err != nil {
 			logger.Fatal().Err(err).Msg("onboarding ASN resolver config invalid")
 		}
 		registerHandler := &onboarding.Handler{
-			StatsDB:           onboardingStore,
-			AuthTokenStore:    tokenStore,
-			CoordinatorDomain: cfg.Onboarding.CoordinatorDomain,
-			CoordinatorWSURL:  "wss://" + cfg.Onboarding.CoordinatorDomain + "/v2/provider",
-			TrustedProxies:    mustParseTrustedProxies(cfg, logger),
-			IPRateLimiter:     onboarding.NewMemoryRateLimiter(5, time.Minute),
-			ASNRateLimiter:    onboarding.NewMemoryRateLimiter(30, time.Minute),
-			ASNResolver:       asnResolver,
+			StatsDB:                             onboardingStore,
+			AuthTokenStore:                      tokenStore,
+			CoordinatorDomain:                   cfg.Onboarding.CoordinatorDomain,
+			CoordinatorWSURL:                    "wss://" + cfg.Onboarding.CoordinatorDomain + "/v2/provider",
+			TrustedProxies:                      mustParseTrustedProxies(cfg, logger),
+			IPRateLimiter:                       onboarding.NewMemoryRateLimiter(5, time.Minute),
+			ASNRateLimiter:                      onboarding.NewMemoryRateLimiter(30, time.Minute),
+			ASNResolver:                         asnResolver,
+			HardwareEvidenceIPRateLimiter:       onboarding.NewMemoryRateLimiter(10, time.Minute),
+			HardwareEvidenceProviderRateLimiter: onboarding.NewMemoryRateLimiter(1, 10*time.Minute),
 			AppAttestVerifier: onboarding.AppleAppAttestVerifier{
 				Config: onboarding.AppAttestConfig{
 					CoordinatorDomain: cfg.Onboarding.CoordinatorDomain,
@@ -663,12 +666,14 @@ func main() {
 			},
 		}
 		register = registerHandler.HandleAppTrackRegister
+		hardwareEvidence = registerHandler.HandleHardwareEvidence
 		logger.Info().Msg("SPEC-026 app-track register route mounted on buyer port")
 	}
-	buyerHandler := buyerHandlerWithOptionalRegister(
+	buyerHandler := buyerHandlerWithOptionalProviderEndpoints(
 		buyerServer.Handler(),
 		cfg.Onboarding.AppTrackRegisterEnabled,
 		register,
+		hardwareEvidence,
 	)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
@@ -945,10 +950,11 @@ func operatorMetricsHandler(operatorKey string, registry *prom.Registry) http.Ha
 	})
 }
 
-func buyerHandlerWithOptionalRegister(base http.Handler, enabled bool, register http.HandlerFunc) http.Handler {
+func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, register, hardwareEvidence http.HandlerFunc) http.Handler {
 	mux := http.NewServeMux()
 	if enabled {
 		mux.HandleFunc("/v1/providers/register", register)
+		mux.HandleFunc("/v1/providers/hardware-evidence", hardwareEvidence)
 	}
 	mux.HandleFunc("/v1/provider/wallet", appTrackWalletNotImplementedHandler)
 	mux.Handle("/", base)

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -82,13 +82,22 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 	register := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})
+	hardwareEvidence := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	})
 
-	disabled := buyerHandlerWithOptionalRegister(base, false, register)
+	disabled := buyerHandlerWithOptionalProviderEndpoints(base, false, register, hardwareEvidence)
 	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", nil)
 	rr := httptest.NewRecorder()
 	disabled.ServeHTTP(rr, req)
 	if rr.Code != http.StatusTeapot {
 		t.Fatalf("disabled route status=%d want base handler 418", rr.Code)
+	}
+	evidenceReq := httptest.NewRequest(http.MethodPost, "/v1/providers/hardware-evidence", nil)
+	rr = httptest.NewRecorder()
+	disabled.ServeHTTP(rr, evidenceReq)
+	if rr.Code != http.StatusTeapot {
+		t.Fatalf("disabled evidence route status=%d want base handler 418", rr.Code)
 	}
 
 	walletReq := httptest.NewRequest(http.MethodPost, "/v1/provider/wallet", nil)
@@ -98,11 +107,16 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 		t.Fatalf("disabled wallet route status=%d body=%s, want 501 wallet_change_requires_spec_027", rr.Code, rr.Body.String())
 	}
 
-	enabled := buyerHandlerWithOptionalRegister(base, true, register)
+	enabled := buyerHandlerWithOptionalProviderEndpoints(base, true, register, hardwareEvidence)
 	rr = httptest.NewRecorder()
 	enabled.ServeHTTP(rr, req)
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("enabled route status=%d want 204", rr.Code)
+	}
+	rr = httptest.NewRecorder()
+	enabled.ServeHTTP(rr, evidenceReq)
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("enabled evidence route status=%d want 202", rr.Code)
 	}
 
 	rr = httptest.NewRecorder()
@@ -112,30 +126,48 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 	}
 }
 
-func TestNginxRegisterRouteBeforeV1CatchAll(t *testing.T) {
+func TestNginxProviderRoutesBeforeV1CatchAll(t *testing.T) {
 	body, err := os.ReadFile("../../dist/nginx-coordinator.streamvc.live.conf")
 	if err != nil {
 		t.Fatalf("read nginx config: %v", err)
 	}
 	cfg := string(body)
-	route := strings.Index(cfg, "location = /v1/providers/register")
+	registerRoute := strings.Index(cfg, "location = /v1/providers/register")
+	evidenceRoute := strings.Index(cfg, "location = /v1/providers/hardware-evidence")
 	catchAll := strings.Index(cfg, "location /v1/ {\n        return 404;")
-	if route < 0 {
+	if registerRoute < 0 {
 		t.Fatal("missing exact /v1/providers/register route")
+	}
+	if evidenceRoute < 0 {
+		t.Fatal("missing exact /v1/providers/hardware-evidence route")
 	}
 	if catchAll < 0 {
 		t.Fatal("missing /v1/ catch-all route")
 	}
-	if route > catchAll {
+	if registerRoute > catchAll {
 		t.Fatal("/v1/providers/register route must appear before /v1/ catch-all")
+	}
+	if evidenceRoute > catchAll {
+		t.Fatal("/v1/providers/hardware-evidence route must appear before /v1/ catch-all")
 	}
 	for _, needle := range []string{
 		"proxy_pass http://127.0.0.1:8443/v1/providers/register;",
 		"proxy_set_header Authorization $http_authorization;",
 		"add_header Cache-Control \"no-store\" always;",
 	} {
-		if !strings.Contains(cfg[route:catchAll], needle) {
+		if !strings.Contains(cfg[registerRoute:catchAll], needle) {
 			t.Fatalf("register route missing %q", needle)
+		}
+	}
+	for _, needle := range []string{
+		"proxy_pass http://127.0.0.1:8443/v1/providers/hardware-evidence;",
+		"limit_req zone=ws_provider_rate burst=5 nodelay;",
+		"proxy_set_header Authorization $http_authorization;",
+		"client_max_body_size 128k;",
+		"add_header Cache-Control \"no-store\" always;",
+	} {
+		if !strings.Contains(cfg[evidenceRoute:catchAll], needle) {
+			t.Fatalf("hardware evidence route missing %q", needle)
 		}
 	}
 }

--- a/phase4-coordinator/cmd/stats-hardware-verifier/main.go
+++ b/phase4-coordinator/cmd/stats-hardware-verifier/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/stats/hardwareverify"
+)
+
+func main() {
+	var dsn string
+	var limit int
+	var timeout time.Duration
+	flag.StringVar(&dsn, "dsn", envString("STATS_HARDWARE_VERIFIER_DSN", ""), "Postgres DSN for stats_hardware_verifier")
+	flag.IntVar(&limit, "limit", envInt("STATS_HARDWARE_VERIFIER_LIMIT", 100), "maximum pending jobs to process in one run")
+	flag.DurationVar(&timeout, "timeout", 30*time.Second, "maximum wall-clock time for one verification pass")
+	flag.Parse()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	store, err := hardwareverify.Open(dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "stats-hardware-verifier: %v\n", err)
+		os.Exit(2)
+	}
+	defer store.Close()
+	if err := store.Smoke(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "stats-hardware-verifier smoke failed: %v\n", err)
+		os.Exit(2)
+	}
+	processed, err := store.ProcessPending(ctx, limit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "stats-hardware-verifier process failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("stats-hardware-verifier: verified=%d rejected=%d waiting=%d\n", processed.Verified, processed.Rejected, processed.Waiting)
+}
+
+func envString(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func envInt(key string, fallback int) int {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -125,12 +125,15 @@ BINARY="$DIST_DIR/coordinator-linux-amd64"
 CLI_BINARY="$DIST_DIR/coordinator-cli-linux-amd64"
 STATS_INVENTORY_BINARY="$DIST_DIR/stats-inventory-sync-linux-amd64"
 STATS_BILLING_MIRROR_BINARY="$DIST_DIR/stats-billing-mirror-linux-amd64"
+STATS_HARDWARE_VERIFIER_BINARY="$DIST_DIR/stats-hardware-verifier-linux-amd64"
 CONFIG="$DIST_DIR/coordinator.yaml"
 SERVICE="$DIST_DIR/macprovider-coordinator.service"
 STATS_INVENTORY_SERVICE="$DIST_DIR/stats-inventory-sync.service"
 STATS_INVENTORY_TIMER="$DIST_DIR/stats-inventory-sync.timer"
 STATS_BILLING_MIRROR_SERVICE="$DIST_DIR/stats-billing-mirror.service"
 STATS_BILLING_MIRROR_TIMER="$DIST_DIR/stats-billing-mirror.timer"
+STATS_HARDWARE_VERIFIER_SERVICE="$DIST_DIR/stats-hardware-verifier.service"
+STATS_HARDWARE_VERIFIER_TIMER="$DIST_DIR/stats-hardware-verifier.timer"
 NGINX_SITE="$DIST_DIR/nginx-coordinator.streamvc.live.conf"
 TCP_SYSCTL="$DIST_DIR/sysctl.d/99-macprovider-tcp.conf"
 TCP_BBR_MODULES_LOAD="$DIST_DIR/modules-load.d/tcp_bbr.conf"
@@ -167,9 +170,10 @@ STATIC_AUTOTUNE_SIG="$STATIC_FEEDS_DIR/autotune-candidates.json.sig"
 # prune-tokens / list-tokens also belong on Pearl). If absent, the
 # operator forgot to run build-linux.sh after the M2 update that
 # extended it. Fail closed — do NOT silently deploy with a stale CLI.
-for f in "$BINARY" "$CLI_BINARY" "$STATS_INVENTORY_BINARY" "$STATS_BILLING_MIRROR_BINARY" \
+for f in "$BINARY" "$CLI_BINARY" "$STATS_INVENTORY_BINARY" "$STATS_BILLING_MIRROR_BINARY" "$STATS_HARDWARE_VERIFIER_BINARY" \
          "$CONFIG" "$SERVICE" "$STATS_INVENTORY_SERVICE" "$STATS_INVENTORY_TIMER" \
-         "$STATS_BILLING_MIRROR_SERVICE" "$STATS_BILLING_MIRROR_TIMER" "$NGINX_SITE" \
+         "$STATS_BILLING_MIRROR_SERVICE" "$STATS_BILLING_MIRROR_TIMER" \
+         "$STATS_HARDWARE_VERIFIER_SERVICE" "$STATS_HARDWARE_VERIFIER_TIMER" "$NGINX_SITE" \
          "$NGINX_STATS_SHARED" "$NGINX_STATS_SECHEADERS" "$NGINX_STATS_SITE" \
          "$STATIC_DEMAND_JSON" "$STATIC_DEMAND_SIG" \
          "$STATIC_AUTOTUNE_JSON" "$STATIC_AUTOTUNE_SIG"; do
@@ -527,10 +531,18 @@ $SSH 'set -e
   else
     echo "  /etc/macprovider-stats/stats-billing-mirror.env not yet present; stats billing mirror timer remains opt-in"
   fi
+  if [ -f /etc/macprovider-stats/stats-hardware-verifier.env ]; then
+    chown root:root /etc/macprovider-stats/stats-hardware-verifier.env
+    chmod 0600 /etc/macprovider-stats/stats-hardware-verifier.env
+    echo "  enforced stats hardware verifier env perms: root:root 0600"
+  else
+    echo "  /etc/macprovider-stats/stats-hardware-verifier.env not yet present; stats hardware verifier timer remains opt-in"
+  fi
 '
 
 log "step 3a/9: stats env preflight"
 STATS_ENABLED_LOCAL="$(yaml_block_value stats enabled)"
+ONBOARDING_ENABLED_LOCAL="$(yaml_block_value onboarding app_track_register_enabled)"
 if [ "$STATS_ENABLED_LOCAL" = "true" ]; then
   # stats.enabled=true makes the coordinator fail closed during config load if
   # any required stats DSN is missing. Check the remote EnvironmentFile before
@@ -570,6 +582,54 @@ if [ "$STATS_ENABLED_LOCAL" = "true" ]; then
   '
 else
   echo "  stats.enabled is not true in $CONFIG — skipping stats env preflight"
+fi
+
+if [ "$ONBOARDING_ENABLED_LOCAL" = "true" ]; then
+  $SSH 'set -e
+    env_file=/etc/macprovider/coordinator.env
+    if [ ! -r "$env_file" ]; then
+      echo "aborting deploy: onboarding enabled but $env_file is missing or unreadable" >&2
+      exit 12
+    fi
+    set -a
+    . "$env_file"
+    set +a
+    if [ -z "${ONBOARDING_POSTGRES_DSN:-}" ]; then
+      echo "aborting deploy: onboarding enabled but ONBOARDING_POSTGRES_DSN is missing in coordinator.env" >&2
+      exit 12
+    fi
+    if ! command -v psql >/dev/null 2>&1; then
+      echo "aborting deploy: psql is required for onboarding hardware evidence migration preflight" >&2
+      exit 12
+    fi
+    PGDATABASE="$ONBOARDING_POSTGRES_DSN" psql -v ON_ERROR_STOP=1 -qAt <<SQL >/dev/null
+SELECT 1 FROM hardware_verification_jobs LIMIT 1;
+SQL
+    echo "  ok: migration 008 hardware_verification_jobs is visible to provider_onboarding"
+    verifier_env=/etc/macprovider-stats/stats-hardware-verifier.env
+    if [ -f "$verifier_env" ]; then
+      if grep -Eq "REPLACE_ME|<generated-password>" "$verifier_env"; then
+        echo "aborting deploy: stats-hardware-verifier.env still contains placeholder secret material" >&2
+        exit 12
+      fi
+      set -a
+      . "$verifier_env"
+      set +a
+      if [ -z "${STATS_HARDWARE_VERIFIER_DSN:-}" ]; then
+        echo "aborting deploy: stats-hardware-verifier.env is present but STATS_HARDWARE_VERIFIER_DSN is empty" >&2
+        exit 12
+      fi
+      PGDATABASE="$STATS_HARDWARE_VERIFIER_DSN" psql -v ON_ERROR_STOP=1 -qAt <<SQL >/dev/null
+SELECT 1 FROM hardware_verification_jobs LIMIT 1;
+SELECT 1 FROM hardware_verification_trust LIMIT 1;
+SELECT 1 FROM chip_hardware_profiles LIMIT 1;
+SELECT 1 WHERE has_schema_privilege(current_user, '\''public'\'', '\''USAGE'\'');
+SQL
+      echo "  ok: stats_hardware_verifier role can read hardware jobs/trust/chip inventory"
+    fi
+  '
+else
+  echo "  onboarding.app_track_register_enabled is not true — skipping hardware evidence migration preflight"
 fi
 
 log "step 3b/9: install TCP sysctl overrides"
@@ -740,12 +800,15 @@ $SCP "$BINARY"      "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator-linux-amd64"
 $SCP "$CLI_BINARY"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator-cli-linux-amd64"
 $SCP "$STATS_INVENTORY_BINARY"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-inventory-sync-linux-amd64"
 $SCP "$STATS_BILLING_MIRROR_BINARY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror-linux-amd64"
+$SCP "$STATS_HARDWARE_VERIFIER_BINARY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-hardware-verifier-linux-amd64"
 $SCP "$CONFIG"      "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator.yaml"
 $SCP "$SERVICE"     "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/macprovider-coordinator.service"
 $SCP "$STATS_INVENTORY_SERVICE" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-inventory-sync.service"
 $SCP "$STATS_INVENTORY_TIMER"   "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-inventory-sync.timer"
 $SCP "$STATS_BILLING_MIRROR_SERVICE" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror.service"
 $SCP "$STATS_BILLING_MIRROR_TIMER"   "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror.timer"
+$SCP "$STATS_HARDWARE_VERIFIER_SERVICE" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-hardware-verifier.service"
+$SCP "$STATS_HARDWARE_VERIFIER_TIMER"   "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-hardware-verifier.timer"
 $SCP "$NGINX_SITE"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-coordinator-full.conf"
 # SPEC-017 v0.1.8 Step 4.B artifacts (snippet must land at
 # /etc/nginx/conf.d/ so the http-context declarations are visible
@@ -799,12 +862,17 @@ $SSH "set -e
   # dedicated macprovider-stats identity and gets read access only to the
   # SQLite ledger files via file ACLs below.
   install -o root -g macprovider-stats -m 0750 $DEPLOY_TMP/stats-billing-mirror-linux-amd64 /opt/macprovider-stats/stats-billing-mirror
+  # stats-hardware-verifier is an out-of-band stats sidecar. It promotes
+  # queued autotune evidence after conservative verification.
+  install -o root -g macprovider-stats -m 0750 $DEPLOY_TMP/stats-hardware-verifier-linux-amd64 /opt/macprovider-stats/stats-hardware-verifier
   install -o root -g macprovider -m 0640 $DEPLOY_TMP/coordinator.yaml /opt/macprovider/coordinator.yaml
   install -o root -g root       -m 0644 $DEPLOY_TMP/macprovider-coordinator.service /etc/systemd/system/macprovider-coordinator.service
   install -o root -g root       -m 0644 $DEPLOY_TMP/stats-inventory-sync.service /etc/systemd/system/stats-inventory-sync.service
   install -o root -g root       -m 0644 $DEPLOY_TMP/stats-inventory-sync.timer /etc/systemd/system/stats-inventory-sync.timer
   install -o root -g root       -m 0644 $DEPLOY_TMP/stats-billing-mirror.service /etc/systemd/system/stats-billing-mirror.service
   install -o root -g root       -m 0644 $DEPLOY_TMP/stats-billing-mirror.timer /etc/systemd/system/stats-billing-mirror.timer
+  install -o root -g root       -m 0644 $DEPLOY_TMP/stats-hardware-verifier.service /etc/systemd/system/stats-hardware-verifier.service
+  install -o root -g root       -m 0644 $DEPLOY_TMP/stats-hardware-verifier.timer /etc/systemd/system/stats-hardware-verifier.timer
   if command -v setfacl >/dev/null 2>&1 && [ -f /var/lib/macprovider/request-log.sqlite ]; then
     setfacl -m u:macprovider-stats:--x /var/lib/macprovider
     setfacl -m u:macprovider-stats:r-- /var/lib/macprovider/request-log.sqlite
@@ -1143,6 +1211,16 @@ $SSH 'set -e
     systemctl is-active stats-billing-mirror.timer
   else
     echo "stats billing mirror timer not enabled: missing env/sqlite source or macprovider-stats read ACL"
+  fi
+  if [ -f /etc/macprovider-stats/stats-hardware-verifier.env ]; then
+    systemctl enable --now stats-hardware-verifier.timer
+    if ! systemctl start stats-hardware-verifier.service; then
+      echo "warning: stats-hardware-verifier.service failed; leaving coordinator deploy running"
+      journalctl -u stats-hardware-verifier.service -n 30 --no-pager || true
+    fi
+    systemctl is-active stats-hardware-verifier.timer
+  else
+    echo "stats hardware verifier timer not enabled: missing /etc/macprovider-stats/stats-hardware-verifier.env"
   fi
   sleep 3
   systemctl is-active macprovider-coordinator

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -278,6 +278,28 @@ server {
     }
 
     # ---------------------------------------------------------------------
+    # /v1/providers/hardware-evidence — provider-token authenticated autotune
+    # hardware evidence queue. Lives on buyer_port (8443), not the provider
+    # mux. Declared before the /v1/ catch-all so configured CLIs can submit
+    # local evidence for out-of-band stats verification.
+    # ---------------------------------------------------------------------
+    location = /v1/providers/hardware-evidence {
+        limit_req zone=ws_provider_rate burst=5 nodelay;
+        limit_req_status 429;
+        proxy_pass http://127.0.0.1:8443/v1/providers/hardware-evidence;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $http_authorization;
+        proxy_read_timeout 10s;
+        proxy_no_cache 1;
+        proxy_cache_bypass 1;
+        client_max_body_size 128k;
+        add_header Cache-Control "no-store" always;
+    }
+
+    # ---------------------------------------------------------------------
     # /v1/provider/wallet — App-track wallet changes are intentionally
     # blocked until SPEC-027 defines non-bearer proof of ownership.
     # Proxies to the buyer mux so the coordinator returns the explicit

--- a/phase4-coordinator/dist/stats-hardware-verifier-bootstrap.sql
+++ b/phase4-coordinator/dist/stats-hardware-verifier-bootstrap.sql
@@ -1,0 +1,19 @@
+-- Bootstrap the hardware verifier login after migration 008 has created the
+-- NOLOGIN role and grants. Run with an admin/operator Postgres role:
+--
+--   export PGDATABASE="$ADMIN_DSN"
+--   export STATS_HARDWARE_VERIFIER_PASSWORD="$(openssl rand -base64 36)"
+--   psql -f stats-hardware-verifier-bootstrap.sql
+--   unset STATS_HARDWARE_VERIFIER_PASSWORD PGDATABASE
+--
+-- The password is intentionally supplied at execution time, not committed or
+-- passed through process arguments.
+
+\getenv verifier_password STATS_HARDWARE_VERIFIER_PASSWORD
+\if :{?verifier_password}
+\else
+  \echo 'missing required STATS_HARDWARE_VERIFIER_PASSWORD environment variable'
+  \quit 3
+\endif
+
+ALTER ROLE stats_hardware_verifier LOGIN PASSWORD :'verifier_password';

--- a/phase4-coordinator/dist/stats-hardware-verifier.env.example
+++ b/phase4-coordinator/dist/stats-hardware-verifier.env.example
@@ -1,0 +1,4 @@
+# Create the login with stats-hardware-verifier-bootstrap.sql and a generated
+# secret, then uncomment this DSN with that secret.
+# STATS_HARDWARE_VERIFIER_DSN=postgres://stats_hardware_verifier:<generated-password>@127.0.0.1:5432/macprovider_stats?sslmode=disable
+STATS_HARDWARE_VERIFIER_LIMIT=100

--- a/phase4-coordinator/dist/stats-hardware-verifier.service
+++ b/phase4-coordinator/dist/stats-hardware-verifier.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=MacProvider stats hardware evidence verifier
+Documentation=https://github.com/augstar/macprovider-poc
+After=network-online.target postgresql.service
+Wants=network-online.target
+ConditionPathExists=/etc/macprovider-stats/stats-hardware-verifier.env
+
+[Service]
+Type=oneshot
+User=macprovider-stats
+Group=macprovider-stats
+EnvironmentFile=/etc/macprovider-stats/stats-hardware-verifier.env
+ExecStart=/opt/macprovider-stats/stats-hardware-verifier
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/tmp
+InaccessiblePaths=/etc/macprovider
+InaccessiblePaths=-/opt/macprovider/coordinator.yaml
+InaccessiblePaths=-/var/lib/macprovider/coordinator.db
+
+[Install]
+WantedBy=multi-user.target

--- a/phase4-coordinator/dist/stats-hardware-verifier.timer
+++ b/phase4-coordinator/dist/stats-hardware-verifier.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run MacProvider stats hardware evidence verifier
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+AccuracySec=15s
+Unit=stats-hardware-verifier.service
+
+[Install]
+WantedBy=timers.target

--- a/phase4-coordinator/internal/onboarding/apptrack.go
+++ b/phase4-coordinator/internal/onboarding/apptrack.go
@@ -120,6 +120,11 @@ type Handler struct {
 	ASNRateLimiter ASNRateLimiter
 	ASNResolver    ASNResolver
 
+	// Hardware evidence has separate limits from app registration so autotune
+	// telemetry cannot consume the register budget or buyer DB capacity.
+	HardwareEvidenceIPRateLimiter       IPRateLimiter
+	HardwareEvidenceProviderRateLimiter IPRateLimiter
+
 	// App Attest verification seam. Production verifier validates the
 	// Apple attestation object; tests use a fake verifier for replay and
 	// outage behavior.
@@ -165,6 +170,11 @@ type AuthTokenStore interface {
 	// the Authorization header; request bodies must never carry bearer material.
 	// provider_name is the tenant literal "malibu-app" for App-track.
 	MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (cleartext string, err error)
+
+	// ValidateToken validates an existing provider bearer token and returns the
+	// bound provider_id. Evidence submission is read-only with respect to the
+	// SQLite token store, so it does not mark the token used.
+	ValidateToken(ctx context.Context, token string) (providerID string, ok bool, err error)
 }
 
 // IPRateLimiter and ASNRateLimiter both wrap the coordinator's existing

--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -61,6 +61,131 @@ func TestHandleAppTrackRegisterSuccess(t *testing.T) {
 	}
 }
 
+func TestHandleHardwareEvidenceQueuesAuthenticatedAutotuneEvidence(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	stats := &fakeStatsDB{}
+	handler := testRegisterHandler(stats, &fakeAuthStore{
+		validateOK:         true,
+		validateProviderID: "mac",
+	}, nil)
+	body := map[string]any{
+		"schema_version":           "hardware_evidence.autotune.v1",
+		"provider_id":              "mac",
+		"generated_at":             now.Format(time.RFC3339),
+		"candidate_catalog_sha256": strings.Repeat("b", 64),
+		"recommended_model":        "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
+		"hardware": map[string]any{
+			"chip":                   "Apple M5",
+			"memory_gb":              32,
+			"bandwidth_tier":         "C",
+			"detected":               true,
+			"os_version":             "15.5",
+			"binary_version":         "1.7.9",
+			"hardware_identity_hash": strings.Repeat("c", 64),
+		},
+		"benchmarks": []map[string]any{{
+			"model_key":                 "qwen-7b",
+			"model_id":                  "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
+			"sustained_tps":             42.5,
+			"ttft_ms":                   1200,
+			"swap_detected":             false,
+			"thermal_throttle_detected": false,
+			"artifact_sha256":           strings.Repeat("d", 64),
+			"candidate_catalog_sha256":  strings.Repeat("b", 64),
+			"generated_at":              now.Format(time.RFC3339),
+			"binary_version":            "1.7.9",
+			"hardware_identity_hash":    strings.Repeat("c", 64),
+		}},
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/hardware-evidence", bytes.NewReader(raw))
+	req.Header.Set("Authorization", "Bearer provider-token")
+	rr := httptest.NewRecorder()
+
+	handler.HandleHardwareEvidence(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if stats.evidenceProviderID != "mac" {
+		t.Fatalf("evidenceProviderID=%q want mac", stats.evidenceProviderID)
+	}
+	if stats.evidenceRequest.Hardware.Chip != "Apple M5" || stats.evidenceRequest.Hardware.MemoryGB != 32 {
+		t.Fatalf("unexpected evidence request: %+v", stats.evidenceRequest)
+	}
+	if !stats.evidenceGeneratedAt.Equal(now) {
+		t.Fatalf("generatedAt=%s want %s", stats.evidenceGeneratedAt, now)
+	}
+}
+
+func TestHandleHardwareEvidenceRejectsProviderMismatch(t *testing.T) {
+	handler := testRegisterHandler(&fakeStatsDB{}, &fakeAuthStore{
+		validateOK:         true,
+		validateProviderID: "mac",
+	}, nil)
+	body := []byte(`{"schema_version":"hardware_evidence.autotune.v1","provider_id":"other","generated_at":"2026-07-03T12:00:00Z","hardware":{"chip":"Apple M5","memory_gb":32,"bandwidth_tier":"C","detected":true,"os_version":"15.5","binary_version":"1.7.9","hardware_identity_hash":"abc"},"benchmarks":[]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/hardware-evidence", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer provider-token")
+	rr := httptest.NewRecorder()
+
+	handler.HandleHardwareEvidence(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleHardwareEvidenceRequiresBearer(t *testing.T) {
+	handler := testRegisterHandler(&fakeStatsDB{}, &fakeAuthStore{}, nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/hardware-evidence", strings.NewReader(`{}`))
+	rr := httptest.NewRecorder()
+
+	handler.HandleHardwareEvidence(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleHardwareEvidenceMapsRateLimitBeforeBodyRead(t *testing.T) {
+	handler := testRegisterHandler(&fakeStatsDB{}, &fakeAuthStore{
+		validateOK:         true,
+		validateProviderID: "mac",
+	}, nil)
+	handler.HardwareEvidenceIPRateLimiter = denyLimiter{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/hardware-evidence", strings.NewReader(`not-json`))
+	req.Header.Set("Authorization", "Bearer provider-token")
+	rr := httptest.NewRecorder()
+
+	handler.HandleHardwareEvidence(rr, req)
+
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleHardwareEvidenceMapsDBAdmissionCap(t *testing.T) {
+	stats := &fakeStatsDB{evidenceErr: ErrHardwareEvidenceRateLimited}
+	handler := testRegisterHandler(stats, &fakeAuthStore{
+		validateOK:         true,
+		validateProviderID: "mac",
+	}, nil)
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{"schema_version":"hardware_evidence.autotune.v1","provider_id":"mac","generated_at":"` + now.Format(time.RFC3339) + `","hardware":{"chip":"Apple M5","memory_gb":32,"bandwidth_tier":"C","detected":true,"os_version":"15.5","binary_version":"1.7.9","hardware_identity_hash":"abc"},"benchmarks":[]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/hardware-evidence", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer provider-token")
+	rr := httptest.NewRecorder()
+
+	handler.HandleHardwareEvidence(rr, req)
+
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestHandleAppTrackRegisterAcceptsSwiftHardwareSummaryShape(t *testing.T) {
 	body, providerID := signedRegisterBody(t, func(m map[string]any) {
 		m["hardware_summary"] = map[string]any{
@@ -679,6 +804,11 @@ type fakeStatsDB struct {
 	hardwareBlock        <-chan struct{}
 	hardwareStarted      chan struct{}
 	hardwareStartedOnce  sync.Once
+	evidenceProviderID   string
+	evidenceRequest      HardwareEvidenceRequest
+	evidenceGeneratedAt  time.Time
+	evidenceRecord       HardwareEvidenceJobRecord
+	evidenceErr          error
 }
 
 func (f *fakeStatsDB) UpsertProviderIdentity(ctx context.Context, providerID string, identityPubkey []byte, attested bool, appAttestKeyID []byte) error {
@@ -723,6 +853,19 @@ func (f *fakeStatsDB) CheckAppAttestKeyIDUnique(ctx context.Context, keyID []byt
 	return f.checkKeyErr
 }
 
+func (f *fakeStatsDB) InsertHardwareVerificationJob(ctx context.Context, providerID string, evidence HardwareEvidenceRequest, generatedAt time.Time) (HardwareEvidenceJobRecord, error) {
+	f.evidenceProviderID = providerID
+	f.evidenceRequest = evidence
+	f.evidenceGeneratedAt = generatedAt
+	if f.evidenceErr != nil {
+		return HardwareEvidenceJobRecord{}, f.evidenceErr
+	}
+	if f.evidenceRecord.JobID == 0 {
+		f.evidenceRecord = HardwareEvidenceJobRecord{JobID: 7, EvidenceSHA: strings.Repeat("a", 64)}
+	}
+	return f.evidenceRecord, nil
+}
+
 type fakeAppAttestVerifier struct {
 	ok       bool
 	err      error
@@ -744,10 +887,13 @@ func (waitForCancelAppAttestVerifier) Verify(ctx context.Context, evidence AppAt
 }
 
 type fakeAuthStore struct {
-	token      string
-	err        error
-	providerID string
-	bearer     *string
+	token              string
+	err                error
+	providerID         string
+	bearer             *string
+	validateProviderID string
+	validateOK         bool
+	validateErr        error
 }
 
 func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (string, error) {
@@ -757,6 +903,19 @@ func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerI
 		return "", f.err
 	}
 	return f.token, nil
+}
+
+func (f *fakeAuthStore) ValidateToken(ctx context.Context, token string) (string, bool, error) {
+	if f.validateErr != nil {
+		return "", false, f.validateErr
+	}
+	if !f.validateOK {
+		return "", false, nil
+	}
+	if f.validateProviderID != "" {
+		return f.validateProviderID, true, nil
+	}
+	return f.providerID, true, nil
 }
 
 type fakeMetrics struct {

--- a/phase4-coordinator/internal/onboarding/hardware_evidence.go
+++ b/phase4-coordinator/internal/onboarding/hardware_evidence.go
@@ -1,0 +1,325 @@
+package onboarding
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const hardwareEvidenceSchemaVersion = "hardware_evidence.autotune.v1"
+const hardwareEvidenceRecentWindow = 10 * time.Minute
+
+var ErrHardwareEvidenceRateLimited = errors.New("hardware evidence rate limited")
+
+// HardwareEvidenceRequest is provider-authenticated autotune evidence. The
+// coordinator queues it for the verifier sidecar; public stats only consume it
+// after the sidecar promotes a conservative trusted profile.
+type HardwareEvidenceRequest struct {
+	SchemaVersion          string                      `json:"schema_version"`
+	ProviderID             string                      `json:"provider_id"`
+	GeneratedAt            string                      `json:"generated_at"`
+	Hardware               HardwareEvidenceHardware    `json:"hardware"`
+	CandidateCatalogSHA256 string                      `json:"candidate_catalog_sha256"`
+	RecommendedModel       string                      `json:"recommended_model"`
+	Benchmarks             []HardwareEvidenceBenchmark `json:"benchmarks"`
+}
+
+type HardwareEvidenceHardware struct {
+	Chip                 string `json:"chip"`
+	MemoryGB             int    `json:"memory_gb"`
+	BandwidthTier        string `json:"bandwidth_tier"`
+	Detected             bool   `json:"detected"`
+	OSVersion            string `json:"os_version"`
+	BinaryVersion        string `json:"binary_version"`
+	HardwareIdentityHash string `json:"hardware_identity_hash"`
+}
+
+type HardwareEvidenceBenchmark struct {
+	ModelKey                string  `json:"model_key"`
+	ModelID                 string  `json:"model_id"`
+	SustainedTPS            float64 `json:"sustained_tps"`
+	TTFTMS                  int     `json:"ttft_ms"`
+	SwapDetected            bool    `json:"swap_detected"`
+	ThermalThrottleDetected bool    `json:"thermal_throttle_detected"`
+	ArtifactSHA256          string  `json:"artifact_sha256"`
+	CandidateCatalogSHA256  string  `json:"candidate_catalog_sha256"`
+	BenchmarkID             string  `json:"benchmark_id,omitempty"`
+	GeneratedAt             string  `json:"generated_at"`
+	BinaryVersion           string  `json:"binary_version"`
+	HardwareIdentityHash    string  `json:"hardware_identity_hash"`
+}
+
+type HardwareEvidenceJobRecord struct {
+	JobID       int64
+	EvidenceSHA string
+}
+
+// InsertHardwareVerificationJob queues provider-authenticated evidence for the
+// out-of-band verifier and may persist the untrusted provider hardware profile.
+func (s *PGStore) InsertHardwareVerificationJob(ctx context.Context, providerID string, evidence HardwareEvidenceRequest, generatedAt time.Time) (HardwareEvidenceJobRecord, error) {
+	if s == nil || s.db == nil {
+		return HardwareEvidenceJobRecord{}, errors.New("onboarding postgres store is nil")
+	}
+	raw, err := canonicalEvidenceJSON(evidence)
+	if err != nil {
+		return HardwareEvidenceJobRecord{}, err
+	}
+	sum := sha256.Sum256(raw)
+	evidenceSHA := hex.EncodeToString(sum[:])
+
+	chip := trimForStorage(evidence.Hardware.Chip, 120)
+	normalized := normalizeChip(chip)
+	macosVersion := trimForStorage(evidence.Hardware.OSVersion, 80)
+	appVersion := trimForStorage(evidence.Hardware.BinaryVersion, 80)
+	memoryGB := evidence.Hardware.MemoryGB
+	if memoryGB < 0 {
+		memoryGB = 0
+	}
+	if memoryGB > 4096 {
+		memoryGB = 4096
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return HardwareEvidenceJobRecord{}, err
+	}
+	defer tx.Rollback()
+
+	var recentJobs int
+	if err := tx.QueryRowContext(ctx, `
+SELECT COUNT(*)
+  FROM hardware_verification_jobs
+ WHERE provider_id = $1
+   AND (status IN ('pending', 'waiting_trust') OR submitted_at > now() - $2::interval)`,
+		providerID,
+		fmt.Sprintf("%d seconds", int(hardwareEvidenceRecentWindow.Seconds())),
+	).Scan(&recentJobs); err != nil {
+		return HardwareEvidenceJobRecord{}, err
+	}
+	if recentJobs > 0 {
+		return HardwareEvidenceJobRecord{}, ErrHardwareEvidenceRateLimited
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO provider_hardware_profiles (
+    provider_id, chip, chip_normalized, unified_memory_gb,
+    macos_version, app_version, source, last_reported_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, 'cli_hello', $7
+)
+ON CONFLICT (provider_id) DO UPDATE
+   SET chip = EXCLUDED.chip,
+       chip_normalized = EXCLUDED.chip_normalized,
+       unified_memory_gb = EXCLUDED.unified_memory_gb,
+       macos_version = EXCLUDED.macos_version,
+       app_version = EXCLUDED.app_version,
+       source = EXCLUDED.source,
+       last_reported_at = EXCLUDED.last_reported_at
+ WHERE provider_hardware_profiles.last_reported_at <= EXCLUDED.last_reported_at`,
+		providerID, chip, normalized, memoryGB, macosVersion, appVersion, generatedAt.UTC(),
+	); err != nil {
+		return HardwareEvidenceJobRecord{}, err
+	}
+
+	var jobID int64
+	err = tx.QueryRowContext(ctx, `
+WITH inserted AS (
+    INSERT INTO hardware_verification_jobs (
+        provider_id, source, status, chip, chip_normalized, unified_memory_gb,
+        bandwidth_tier, os_version, binary_version, benchmark_count,
+        max_sustained_tps, generated_at, evidence, evidence_sha256
+    ) VALUES (
+        $1, 'autotune', 'pending', $2, $3, $4,
+        $5, $6, $7, $8,
+        $9, $10, $11, $12
+    )
+    ON CONFLICT (evidence_sha256) DO NOTHING
+    RETURNING id
+)
+SELECT id FROM inserted
+UNION ALL
+SELECT id FROM hardware_verification_jobs WHERE evidence_sha256 = $12
+LIMIT 1`,
+		providerID,
+		chip,
+		normalized,
+		memoryGB,
+		trimForStorage(evidence.Hardware.BandwidthTier, 20),
+		macosVersion,
+		appVersion,
+		len(evidence.Benchmarks),
+		maxBenchmarkTPS(evidence.Benchmarks),
+		generatedAt.UTC(),
+		raw,
+		evidenceSHA,
+	).Scan(&jobID)
+	if err != nil {
+		return HardwareEvidenceJobRecord{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return HardwareEvidenceJobRecord{}, err
+	}
+	return HardwareEvidenceJobRecord{JobID: jobID, EvidenceSHA: evidenceSHA}, nil
+}
+
+func (h *Handler) HandleHardwareEvidence(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+	if h.StatsDB == nil || h.AuthTokenStore == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "onboarding dependencies unavailable")
+		return
+	}
+	token := bearerToken(r.Header)
+	providerID, ok, err := h.AuthTokenStore.ValidateToken(r.Context(), token)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "token validation unavailable")
+		return
+	}
+	if !ok {
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized", "provider bearer token required")
+		return
+	}
+	sourceIP := clientIP(r, h.TrustedProxies)
+	if h.HardwareEvidenceIPRateLimiter != nil && !h.HardwareEvidenceIPRateLimiter.Allow(sourceIP) {
+		w.Header().Set("Retry-After", "60")
+		writeJSONError(w, http.StatusTooManyRequests, "rate_limited", "hardware evidence ip rate limit exceeded")
+		return
+	}
+	if h.HardwareEvidenceProviderRateLimiter != nil && !h.HardwareEvidenceProviderRateLimiter.Allow(providerID) {
+		w.Header().Set("Retry-After", "600")
+		writeJSONError(w, http.StatusTooManyRequests, "rate_limited", "hardware evidence provider rate limit exceeded")
+		return
+	}
+	body, err := readBoundedBody(w, r, 128*1024)
+	if err != nil {
+		writeJSONError(w, http.StatusRequestEntityTooLarge, "request_too_large", "body exceeds 128 KiB")
+		return
+	}
+	var req HardwareEvidenceRequest
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_json", "request body is not valid hardware evidence JSON")
+		return
+	}
+	if dec.Decode(&struct{}{}) != io.EOF {
+		writeJSONError(w, http.StatusBadRequest, "invalid_json", "request body must contain exactly one JSON object")
+		return
+	}
+	generatedAt, err := h.validateHardwareEvidence(req, providerID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_evidence", err.Error())
+		return
+	}
+	store, ok := h.StatsDB.(interface {
+		InsertHardwareVerificationJob(context.Context, string, HardwareEvidenceRequest, time.Time) (HardwareEvidenceJobRecord, error)
+	})
+	if !ok {
+		writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "hardware evidence queue unavailable")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), hardwareProfilePersistTimeout)
+	defer cancel()
+	record, err := store.InsertHardwareVerificationJob(ctx, providerID, req, generatedAt)
+	if err != nil {
+		if errors.Is(err, ErrHardwareEvidenceRateLimited) {
+			w.Header().Set("Retry-After", "600")
+			writeJSONError(w, http.StatusTooManyRequests, "rate_limited", "hardware evidence queue already has a recent job")
+			return
+		}
+		writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "hardware evidence queue unavailable")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":       "queued",
+		"provider_id":  providerID,
+		"job_id":       record.JobID,
+		"evidence_sha": record.EvidenceSHA,
+	})
+}
+
+func (h *Handler) validateHardwareEvidence(req HardwareEvidenceRequest, tokenProviderID string) (time.Time, error) {
+	if req.SchemaVersion != hardwareEvidenceSchemaVersion {
+		return time.Time{}, errors.New("schema_version must be hardware_evidence.autotune.v1")
+	}
+	if strings.TrimSpace(req.ProviderID) == "" || len(req.ProviderID) > 128 {
+		return time.Time{}, errors.New("provider_id is required")
+	}
+	if req.ProviderID != tokenProviderID {
+		return time.Time{}, errors.New("provider_id must match bearer token")
+	}
+	generatedAt, err := time.Parse(time.RFC3339, req.GeneratedAt)
+	if err != nil {
+		return time.Time{}, errors.New("generated_at must be RFC3339")
+	}
+	now := time.Now().UTC()
+	if h.Now != nil {
+		now = h.Now().UTC()
+	}
+	if generatedAt.Before(now.Add(-48*time.Hour)) || generatedAt.After(now.Add(5*time.Minute)) {
+		return time.Time{}, errors.New("generated_at is outside the accepted window")
+	}
+	if strings.TrimSpace(req.Hardware.Chip) == "" || len(req.Hardware.Chip) > 120 {
+		return time.Time{}, errors.New("hardware.chip is required")
+	}
+	if req.Hardware.MemoryGB <= 0 || req.Hardware.MemoryGB > 4096 {
+		return time.Time{}, errors.New("hardware.memory_gb must be in 1...4096")
+	}
+	switch strings.ToUpper(strings.TrimSpace(req.Hardware.BandwidthTier)) {
+	case "C", "B", "A", "S", "UNKNOWN":
+	default:
+		return time.Time{}, errors.New("hardware.bandwidth_tier is invalid")
+	}
+	if len(req.Benchmarks) > 64 {
+		return time.Time{}, errors.New("benchmarks exceeds 64 entries")
+	}
+	for _, b := range req.Benchmarks {
+		if strings.TrimSpace(b.ModelKey) == "" || len(b.ModelKey) > 160 {
+			return time.Time{}, errors.New("benchmark.model_key is required")
+		}
+		if math.IsNaN(b.SustainedTPS) || math.IsInf(b.SustainedTPS, 0) || b.SustainedTPS < 0 || b.SustainedTPS > 1_000_000 {
+			return time.Time{}, errors.New("benchmark.sustained_tps is invalid")
+		}
+		if b.TTFTMS < 0 || b.TTFTMS > 3_600_000 {
+			return time.Time{}, errors.New("benchmark.ttft_ms is invalid")
+		}
+	}
+	return generatedAt.UTC(), nil
+}
+
+func canonicalEvidenceJSON(evidence HardwareEvidenceRequest) ([]byte, error) {
+	return json.Marshal(evidence)
+}
+
+func maxBenchmarkTPS(benchmarks []HardwareEvidenceBenchmark) float64 {
+	var max float64
+	for _, b := range benchmarks {
+		if b.SustainedTPS > max && !math.IsNaN(b.SustainedTPS) && !math.IsInf(b.SustainedTPS, 0) {
+			max = b.SustainedTPS
+		}
+	}
+	return max
+}
+
+func bearerToken(headers http.Header) string {
+	auth := strings.TrimSpace(headers.Get("Authorization"))
+	token, ok := strings.CutPrefix(auth, "Bearer ")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(token)
+}

--- a/phase4-coordinator/internal/onboarding/store_pg.go
+++ b/phase4-coordinator/internal/onboarding/store_pg.go
@@ -59,6 +59,9 @@ func (s *PGStore) Smoke(ctx context.Context) error {
 	if _, err := s.db.ExecContext(timeout, `SELECT provider_id, last_reported_at FROM provider_hardware_profiles LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_hardware_profiles read: %w", err)
 	}
+	if _, err := s.db.ExecContext(timeout, `SELECT id, evidence_sha256 FROM hardware_verification_jobs LIMIT 1`); err != nil {
+		return fmt.Errorf("provider_onboarding smoke hardware_verification_jobs read: %w", err)
+	}
 	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_register_nonces LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_register_nonces read: %w", err)
 	}

--- a/phase4-coordinator/internal/stats/hardwareverify/verify.go
+++ b/phase4-coordinator/internal/stats/hardwareverify/verify.go
@@ -1,0 +1,337 @@
+package hardwareverify
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+const verifierDecisionVersion = "hardware-verifier.v1"
+
+type Store struct {
+	db *sql.DB
+}
+
+type Processed struct {
+	Verified int
+	Rejected int
+	Waiting  int
+}
+
+type Job struct {
+	ID                 int64
+	ProviderID         string
+	Chip               string
+	ChipNormalized     string
+	MemoryGB           int
+	BandwidthTier      string
+	OSVersion          string
+	BinaryVersion      string
+	GeneratedAt        time.Time
+	Evidence           json.RawMessage
+	TrustMatched       bool
+	ChipProfileMatched bool
+}
+
+type Evidence struct {
+	SchemaVersion          string      `json:"schema_version"`
+	ProviderID             string      `json:"provider_id"`
+	GeneratedAt            string      `json:"generated_at"`
+	Hardware               Hardware    `json:"hardware"`
+	CandidateCatalogSHA256 string      `json:"candidate_catalog_sha256"`
+	RecommendedModel       string      `json:"recommended_model"`
+	Benchmarks             []Benchmark `json:"benchmarks"`
+}
+
+type Hardware struct {
+	Chip                 string `json:"chip"`
+	MemoryGB             int    `json:"memory_gb"`
+	BandwidthTier        string `json:"bandwidth_tier"`
+	Detected             bool   `json:"detected"`
+	OSVersion            string `json:"os_version"`
+	BinaryVersion        string `json:"binary_version"`
+	HardwareIdentityHash string `json:"hardware_identity_hash"`
+}
+
+type Benchmark struct {
+	ModelKey                string  `json:"model_key"`
+	ModelID                 string  `json:"model_id"`
+	SustainedTPS            float64 `json:"sustained_tps"`
+	TTFTMS                  int     `json:"ttft_ms"`
+	SwapDetected            bool    `json:"swap_detected"`
+	ThermalThrottleDetected bool    `json:"thermal_throttle_detected"`
+}
+
+type Decision struct {
+	Verified bool
+	Reason   string
+}
+
+func Open(dsn string) (*Store, error) {
+	dsn = strings.TrimSpace(dsn)
+	if dsn == "" {
+		return nil, errors.New("hardware verifier dsn is required")
+	}
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open hardware verifier postgres: %w", err)
+	}
+	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(30 * time.Minute)
+	db.SetConnMaxIdleTime(5 * time.Minute)
+	return &Store{db: db}, nil
+}
+
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func (s *Store) Smoke(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return errors.New("hardware verifier store is nil")
+	}
+	timeout, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	var currentUser string
+	if err := s.db.QueryRowContext(timeout, `SELECT current_user`).Scan(&currentUser); err != nil {
+		return fmt.Errorf("stats_hardware_verifier smoke current_user: %w", err)
+	}
+	if currentUser != "stats_hardware_verifier" {
+		return fmt.Errorf("stats_hardware_verifier smoke current_user = %q, want stats_hardware_verifier", currentUser)
+	}
+	if _, err := s.db.ExecContext(timeout, `SELECT id, status, evidence FROM hardware_verification_jobs LIMIT 1`); err != nil {
+		return fmt.Errorf("stats_hardware_verifier smoke hardware_verification_jobs read: %w", err)
+	}
+	if _, err := s.db.ExecContext(timeout, `SELECT provider_id, hardware_identity_hash FROM hardware_verification_trust LIMIT 1`); err != nil {
+		return fmt.Errorf("stats_hardware_verifier smoke hardware_verification_trust read: %w", err)
+	}
+	if _, err := s.db.ExecContext(timeout, `SELECT provider_id, verified FROM provider_hardware_profiles LIMIT 1`); err != nil {
+		return fmt.Errorf("stats_hardware_verifier smoke provider_hardware_profiles read: %w", err)
+	}
+	if _, err := s.db.ExecContext(timeout, `SELECT chip_normalized FROM chip_hardware_profiles LIMIT 1`); err != nil {
+		return fmt.Errorf("stats_hardware_verifier smoke chip_hardware_profiles read: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ProcessPending(ctx context.Context, limit int) (Processed, error) {
+	if s == nil || s.db == nil {
+		return Processed{}, errors.New("hardware verifier store is nil")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Processed{}, err
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx, `
+SELECT j.id, j.provider_id, j.chip, j.chip_normalized, j.unified_memory_gb,
+       j.bandwidth_tier, j.os_version, j.binary_version, j.generated_at, j.evidence,
+       EXISTS (
+           SELECT 1
+             FROM hardware_verification_trust t
+            WHERE t.provider_id = j.provider_id
+              AND t.hardware_identity_hash = j.evidence #>> '{hardware,hardware_identity_hash}'
+              AND t.chip_normalized = j.chip_normalized
+              AND t.unified_memory_gb = j.unified_memory_gb
+              AND (t.expires_at IS NULL OR t.expires_at > now())
+       ) AS trust_matched,
+       EXISTS (
+           SELECT 1
+             FROM chip_hardware_profiles ch
+            WHERE ch.chip_normalized = j.chip_normalized
+       ) AS chip_profile_matched
+  FROM hardware_verification_jobs j
+ WHERE j.status IN ('pending', 'waiting_trust')
+ ORDER BY j.id
+ LIMIT $1
+ FOR UPDATE SKIP LOCKED`, limit)
+	if err != nil {
+		return Processed{}, err
+	}
+	var jobs []Job
+	for rows.Next() {
+		var job Job
+		if err := rows.Scan(
+			&job.ID,
+			&job.ProviderID,
+			&job.Chip,
+			&job.ChipNormalized,
+			&job.MemoryGB,
+			&job.BandwidthTier,
+			&job.OSVersion,
+			&job.BinaryVersion,
+			&job.GeneratedAt,
+			&job.Evidence,
+			&job.TrustMatched,
+			&job.ChipProfileMatched,
+		); err != nil {
+			rows.Close()
+			return Processed{}, err
+		}
+		jobs = append(jobs, job)
+	}
+	if err := rows.Close(); err != nil {
+		return Processed{}, err
+	}
+	if err := rows.Err(); err != nil {
+		return Processed{}, err
+	}
+
+	var processed Processed
+	for _, job := range jobs {
+		decision := Evaluate(job)
+		if decision.Verified {
+			if err := promoteJob(ctx, tx, job, decision); err != nil {
+				return Processed{}, err
+			}
+			processed.Verified++
+			continue
+		}
+		if decision.Reason == "missing_trusted_hardware_identity" || decision.Reason == "missing_trusted_chip_profile" {
+			if err := waitTrustJob(ctx, tx, job.ID, decision.Reason); err != nil {
+				return Processed{}, err
+			}
+			processed.Waiting++
+			continue
+		}
+		if err := rejectJob(ctx, tx, job.ID, decision.Reason); err != nil {
+			return Processed{}, err
+		}
+		processed.Rejected++
+	}
+	if err := tx.Commit(); err != nil {
+		return Processed{}, err
+	}
+	return processed, nil
+}
+
+func Evaluate(job Job) Decision {
+	if strings.TrimSpace(job.ProviderID) == "" {
+		return reject("missing_provider_id")
+	}
+	if job.GeneratedAt.Before(time.Now().UTC().Add(-7 * 24 * time.Hour)) {
+		return reject("stale_job")
+	}
+	if job.MemoryGB < 8 || job.MemoryGB > 4096 {
+		return reject("memory_out_of_range")
+	}
+	if len(job.Evidence) == 0 {
+		return reject("missing_evidence")
+	}
+	var evidence Evidence
+	if err := json.Unmarshal(job.Evidence, &evidence); err != nil {
+		return reject("invalid_evidence_json")
+	}
+	if evidence.ProviderID != "" && evidence.ProviderID != job.ProviderID {
+		return reject("provider_id_mismatch")
+	}
+	if strings.TrimSpace(evidence.Hardware.HardwareIdentityHash) == "" {
+		return reject("missing_hardware_identity_hash")
+	}
+	if len(evidence.Benchmarks) == 0 {
+		return reject("missing_benchmarks")
+	}
+	if !hasPositiveBenchmark(evidence.Benchmarks) {
+		return reject("missing_positive_benchmark")
+	}
+	if strings.TrimSpace(job.ChipNormalized) == "" {
+		return reject("missing_chip_normalized")
+	}
+	if !job.TrustMatched {
+		return reject("missing_trusted_hardware_identity")
+	}
+	if !job.ChipProfileMatched {
+		return reject("missing_trusted_chip_profile")
+	}
+	return Decision{Verified: true, Reason: verifierDecisionVersion + ":verified_trusted_hardware"}
+}
+
+func promoteJob(ctx context.Context, tx *sql.Tx, job Job, decision Decision) error {
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO provider_hardware_profiles (
+    provider_id, chip, chip_normalized, unified_memory_gb,
+    macos_version, app_version, source, verified, last_reported_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, 'cli_hello', TRUE, $7
+)
+ON CONFLICT (provider_id) DO UPDATE
+   SET chip = EXCLUDED.chip,
+       chip_normalized = EXCLUDED.chip_normalized,
+       unified_memory_gb = EXCLUDED.unified_memory_gb,
+       macos_version = EXCLUDED.macos_version,
+       app_version = EXCLUDED.app_version,
+       source = EXCLUDED.source,
+       verified = TRUE,
+       last_reported_at = EXCLUDED.last_reported_at
+ WHERE provider_hardware_profiles.last_reported_at <= EXCLUDED.last_reported_at`,
+		job.ProviderID,
+		job.Chip,
+		job.ChipNormalized,
+		job.MemoryGB,
+		job.OSVersion,
+		job.BinaryVersion,
+		job.GeneratedAt.UTC(),
+	); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `
+UPDATE hardware_verification_jobs
+   SET status = 'verified',
+       processed_at = now(),
+       decision_reason = $2
+ WHERE id = $1 AND status IN ('pending', 'waiting_trust')`, job.ID, decision.Reason)
+	return err
+}
+
+func waitTrustJob(ctx context.Context, tx *sql.Tx, id int64, reason string) error {
+	_, err := tx.ExecContext(ctx, `
+UPDATE hardware_verification_jobs
+   SET status = 'waiting_trust',
+       processed_at = now(),
+       decision_reason = $2
+ WHERE id = $1 AND status IN ('pending', 'waiting_trust')`, id, verifierDecisionVersion+":"+reason)
+	return err
+}
+
+func rejectJob(ctx context.Context, tx *sql.Tx, id int64, reason string) error {
+	_, err := tx.ExecContext(ctx, `
+UPDATE hardware_verification_jobs
+   SET status = 'rejected',
+       processed_at = now(),
+       decision_reason = $2
+ WHERE id = $1 AND status IN ('pending', 'waiting_trust')`, id, verifierDecisionVersion+":"+reason)
+	return err
+}
+
+func reject(reason string) Decision {
+	return Decision{Verified: false, Reason: reason}
+}
+
+func hasPositiveBenchmark(benchmarks []Benchmark) bool {
+	for _, b := range benchmarks {
+		if b.SustainedTPS > 0 && !math.IsNaN(b.SustainedTPS) && !math.IsInf(b.SustainedTPS, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeChip(chip string) string {
+	chip = strings.ToLower(strings.TrimSpace(chip))
+	return strings.Join(strings.Fields(chip), " ")
+}

--- a/phase4-coordinator/internal/stats/hardwareverify/verify_test.go
+++ b/phase4-coordinator/internal/stats/hardwareverify/verify_test.go
@@ -1,0 +1,195 @@
+package hardwareverify
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestEvaluateVerifiesTrustedHardwareWithPositiveBenchmark(t *testing.T) {
+	evidence := Evidence{
+		ProviderID: "mac",
+		Hardware: Hardware{
+			HardwareIdentityHash: "hash",
+		},
+		Benchmarks: []Benchmark{{
+			ModelKey:     "qwen-7b",
+			SustainedTPS: 42.5,
+			TTFTMS:       1200,
+		}},
+	}
+	raw, err := json.Marshal(evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := Evaluate(Job{
+		ID:                 1,
+		ProviderID:         "mac",
+		Chip:               "Apple M5",
+		ChipNormalized:     "apple m5",
+		MemoryGB:           32,
+		BandwidthTier:      "C",
+		GeneratedAt:        time.Now().UTC(),
+		Evidence:           raw,
+		TrustMatched:       true,
+		ChipProfileMatched: true,
+	})
+	if !decision.Verified {
+		t.Fatalf("decision.Verified = false, reason=%s", decision.Reason)
+	}
+	if decision.Reason != "hardware-verifier.v1:verified_trusted_hardware" {
+		t.Fatalf("reason = %q, want trusted hardware verification", decision.Reason)
+	}
+}
+
+func TestEvaluateAllowsHigherTierChipsWhenOperatorInventoryMatches(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		chip string
+		tier string
+	}{
+		{name: "pro", chip: "Apple M4 Pro", tier: "B"},
+		{name: "max", chip: "Apple M4 Max", tier: "A"},
+		{name: "ultra", chip: "Apple M3 Ultra", tier: "S"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(Evidence{
+				ProviderID: "mac",
+				Hardware: Hardware{
+					HardwareIdentityHash: "hash",
+				},
+				Benchmarks: []Benchmark{{ModelKey: "x", SustainedTPS: 1}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			decision := Evaluate(Job{
+				ProviderID:         "mac",
+				Chip:               tc.chip,
+				ChipNormalized:     "apple m4 " + tc.name,
+				MemoryGB:           64,
+				BandwidthTier:      tc.tier,
+				GeneratedAt:        time.Now().UTC(),
+				Evidence:           raw,
+				TrustMatched:       true,
+				ChipProfileMatched: true,
+			})
+			if !decision.Verified {
+				t.Fatalf("decision.Verified = false for %s, reason=%s", tc.chip, decision.Reason)
+			}
+		})
+	}
+}
+
+func TestEvaluateRejectsProviderMismatch(t *testing.T) {
+	raw, err := json.Marshal(Evidence{
+		ProviderID: "other",
+		Hardware: Hardware{
+			HardwareIdentityHash: "hash",
+		},
+		Benchmarks: []Benchmark{{ModelKey: "x", SustainedTPS: 1}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := Evaluate(Job{
+		ProviderID:         "mac",
+		Chip:               "Apple M4",
+		ChipNormalized:     "apple m4",
+		MemoryGB:           32,
+		BandwidthTier:      "C",
+		GeneratedAt:        time.Now().UTC(),
+		Evidence:           raw,
+		TrustMatched:       true,
+		ChipProfileMatched: true,
+	})
+	if decision.Verified {
+		t.Fatal("decision.Verified = true, want false")
+	}
+	if decision.Reason != "provider_id_mismatch" {
+		t.Fatalf("reason = %q, want provider_id_mismatch", decision.Reason)
+	}
+}
+
+func TestEvaluateRejectsWithoutTrustMatch(t *testing.T) {
+	raw, err := json.Marshal(Evidence{
+		ProviderID: "mac",
+		Hardware: Hardware{
+			HardwareIdentityHash: "hash",
+		},
+		Benchmarks: []Benchmark{{ModelKey: "x", SustainedTPS: 1}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := Evaluate(Job{
+		ProviderID:         "mac",
+		Chip:               "Apple M5",
+		ChipNormalized:     "apple m5",
+		MemoryGB:           32,
+		BandwidthTier:      "C",
+		GeneratedAt:        time.Now().UTC(),
+		Evidence:           raw,
+		ChipProfileMatched: true,
+	})
+	if decision.Verified {
+		t.Fatal("decision.Verified = true, want false")
+	}
+	if decision.Reason != "missing_trusted_hardware_identity" {
+		t.Fatalf("reason = %q, want missing_trusted_hardware_identity", decision.Reason)
+	}
+}
+
+func TestEvaluateRejectsMalformedEvidenceBeforeWaitingForTrust(t *testing.T) {
+	raw, err := json.Marshal(Evidence{
+		ProviderID: "mac",
+		Benchmarks: []Benchmark{{ModelKey: "x", SustainedTPS: 1}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := Evaluate(Job{
+		ProviderID:     "mac",
+		Chip:           "Apple M5",
+		ChipNormalized: "apple m5",
+		MemoryGB:       32,
+		BandwidthTier:  "C",
+		GeneratedAt:    time.Now().UTC(),
+		Evidence:       raw,
+	})
+	if decision.Verified {
+		t.Fatal("decision.Verified = true, want false")
+	}
+	if decision.Reason != "missing_hardware_identity_hash" {
+		t.Fatalf("reason = %q, want missing_hardware_identity_hash", decision.Reason)
+	}
+}
+
+func TestEvaluateWaitsWithoutTrustedChipProfile(t *testing.T) {
+	raw, err := json.Marshal(Evidence{
+		ProviderID: "mac",
+		Hardware: Hardware{
+			HardwareIdentityHash: "hash",
+		},
+		Benchmarks: []Benchmark{{ModelKey: "x", SustainedTPS: 1}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := Evaluate(Job{
+		ProviderID:     "mac",
+		Chip:           "Apple M5",
+		ChipNormalized: "apple m5",
+		MemoryGB:       32,
+		BandwidthTier:  "C",
+		GeneratedAt:    time.Now().UTC(),
+		Evidence:       raw,
+		TrustMatched:   true,
+	})
+	if decision.Verified {
+		t.Fatal("decision.Verified = true, want false")
+	}
+	if decision.Reason != "missing_trusted_chip_profile" {
+		t.Fatalf("reason = %q, want missing_trusted_chip_profile", decision.Reason)
+	}
+}

--- a/phase4-coordinator/internal/stats/integration_test.go
+++ b/phase4-coordinator/internal/stats/integration_test.go
@@ -62,12 +62,13 @@ const (
 	// bumping the major version.
 	pgImage = "postgres:16.4-alpine3.20@sha256:5660c2cbfea50c7a9127d17dc4e48543eedd3d7a41a595a2dfa572471e37e64c"
 
-	roleStatsReader     = "stats_reader"
-	roleStatsRollup     = "stats_rollup"
-	roleProviderPortal  = "provider_portal"
-	roleProviderOnboard = "provider_onboarding"
-	roleAdminPassword   = "stepone-admin-password" // local only; container is ephemeral
-	roleRuntimePassword = "stepone-runtime-pw"
+	roleStatsReader      = "stats_reader"
+	roleStatsRollup      = "stats_rollup"
+	roleProviderPortal   = "provider_portal"
+	roleProviderOnboard  = "provider_onboarding"
+	roleHardwareVerifier = "stats_hardware_verifier"
+	roleAdminPassword    = "stepone-admin-password" // local only; container is ephemeral
+	roleRuntimePassword  = "stepone-runtime-pw"
 )
 
 // pgFixture wraps an ephemeral Postgres container + the four
@@ -184,7 +185,7 @@ func applyMigrationsAndStubOLTP(t *testing.T, fx *pgFixture) *sql.DB {
 	// production deploy automation rotates them via
 	// `ALTER ROLE ... WITH LOGIN PASSWORD '...'` from the
 	// secret store; the test harness does the same in-memory.
-	for _, role := range []string{roleStatsReader, roleStatsRollup, roleProviderPortal, roleProviderOnboard} {
+	for _, role := range []string{roleStatsReader, roleStatsRollup, roleProviderPortal, roleProviderOnboard, roleHardwareVerifier} {
 		if _, err := adminDB.ExecContext(ctx, fmt.Sprintf(
 			`ALTER ROLE %s WITH LOGIN PASSWORD '%s'`, role, roleRuntimePassword,
 		)); err != nil {
@@ -958,6 +959,118 @@ func TestHardwareProfileRoleGrantsAndVerificationGuard(t *testing.T) {
 	}
 	if verified {
 		t.Fatalf("changed-chip provider_onboarding update preserved verified; want cleared")
+	}
+}
+
+func TestHardwareVerifierPromotionGuard(t *testing.T) {
+	fx := startPostgres(t)
+	adminDB := applyMigrationsAndStubOLTP(t, fx)
+
+	verifierDB, err := sql.Open("postgres", fx.roleDSN(roleHardwareVerifier))
+	if err != nil {
+		t.Fatalf("open hardware verifier: %v", err)
+	}
+	defer verifierDB.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO chip_hardware_profiles
+            (chip_normalized, display_chip, memory_bandwidth_gb_per_s, network_power_kw, gpu_cores, cpu_cores)
+        VALUES ('apple m4 max', 'Apple M4 Max', 546, 0.12, 40, 16)
+    `); err != nil {
+		t.Fatalf("seed chip profile: %v", err)
+	}
+
+	staleGeneratedAt := time.Now().UTC().Add(-8 * 24 * time.Hour)
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO hardware_verification_jobs
+            (provider_id, source, status, chip, chip_normalized, unified_memory_gb,
+             bandwidth_tier, os_version, binary_version, benchmark_count, max_sustained_tps,
+             generated_at, evidence, evidence_sha256)
+        VALUES
+            ('p-stale', 'autotune', 'pending', 'Apple M4 Max', 'apple m4 max', 64,
+             'A', '15.0', '1.0.0', 1, 42,
+             $1, '{"provider_id":"p-stale","hardware":{"hardware_identity_hash":"hash-stale"},"benchmarks":[{"model_key":"x","sustained_tps":42}]}'::jsonb, 'sha-stale')
+    `, staleGeneratedAt); err != nil {
+		t.Fatalf("seed stale verification job: %v", err)
+	}
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO hardware_verification_trust
+            (provider_id, hardware_identity_hash, chip_normalized, unified_memory_gb, trusted_by)
+        VALUES ('p-stale', 'hash-stale', 'apple m4 max', 64, 'integration-test')
+    `); err != nil {
+		t.Fatalf("seed stale trust: %v", err)
+	}
+	_, err = verifierDB.ExecContext(ctx, `
+        INSERT INTO provider_hardware_profiles
+            (provider_id, chip, chip_normalized, unified_memory_gb,
+             macos_version, app_version, source, verified, last_reported_at)
+        VALUES ('p-stale', 'Apple M4 Max', 'apple m4 max', 64,
+                '15.0', '1.0.0', 'cli_hello', TRUE, $1)
+    `, staleGeneratedAt)
+	if err == nil {
+		t.Fatalf("stats_hardware_verifier promoted stale pending job")
+	}
+	if !contains(err.Error(), "matching trusted hardware evidence") {
+		t.Fatalf("stale promotion error = %q, want trusted evidence guard", err.Error())
+	}
+
+	freshGeneratedAt := time.Now().UTC()
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO hardware_verification_jobs
+            (provider_id, source, status, chip, chip_normalized, unified_memory_gb,
+             bandwidth_tier, os_version, binary_version, benchmark_count, max_sustained_tps,
+             generated_at, evidence, evidence_sha256)
+        VALUES
+            ('p-fresh', 'autotune', 'pending', 'Apple M4 Max', 'apple m4 max', 64,
+             'A', '15.0', '1.0.0', 1, 42,
+             $1, '{"provider_id":"p-fresh","hardware":{"hardware_identity_hash":"hash-fresh"},"benchmarks":[{"model_key":"x","sustained_tps":42}]}'::jsonb, 'sha-fresh')
+    `, freshGeneratedAt); err != nil {
+		t.Fatalf("seed fresh verification job: %v", err)
+	}
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO hardware_verification_trust
+            (provider_id, hardware_identity_hash, chip_normalized, unified_memory_gb, trusted_by)
+        VALUES ('p-fresh', 'hash-fresh', 'apple m4 max', 64, 'integration-test')
+    `); err != nil {
+		t.Fatalf("seed fresh trust: %v", err)
+	}
+	if _, err := verifierDB.ExecContext(ctx, `
+        INSERT INTO provider_hardware_profiles
+            (provider_id, chip, chip_normalized, unified_memory_gb,
+             macos_version, app_version, source, verified, last_reported_at)
+        VALUES ('p-fresh', 'Apple M4 Max', 'apple m4 max', 64,
+                '15.0', '1.0.0', 'cli_hello', TRUE, $1)
+    `, freshGeneratedAt); err != nil {
+		t.Fatalf("stats_hardware_verifier fresh trusted promotion: %v", err)
+	}
+
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO hardware_verification_jobs
+            (provider_id, source, status, chip, chip_normalized, unified_memory_gb,
+             bandwidth_tier, os_version, binary_version, benchmark_count, max_sustained_tps,
+             generated_at, evidence, evidence_sha256)
+        VALUES
+            ('p-final', 'autotune', 'verified', 'Apple M4 Max', 'apple m4 max', 64,
+             'A', '15.0', '1.0.0', 1, 42,
+             now(), '{"provider_id":"p-final","hardware":{"hardware_identity_hash":"hash-final"},"benchmarks":[{"model_key":"x","sustained_tps":42}]}'::jsonb, 'sha-final')
+    `); err != nil {
+		t.Fatalf("seed finalized verification job: %v", err)
+	}
+	_, err = verifierDB.ExecContext(ctx, `
+        UPDATE hardware_verification_jobs
+           SET status = 'waiting_trust',
+               processed_at = now(),
+               decision_reason = 'integration-reopen'
+         WHERE evidence_sha256 = 'sha-final'
+    `)
+	if err == nil {
+		t.Fatalf("stats_hardware_verifier reopened finalized job")
+	}
+	if !contains(err.Error(), "may not update finalized") {
+		t.Fatalf("finalized job update error = %q, want finalized guard", err.Error())
 	}
 }
 

--- a/phase4-coordinator/internal/stats/migrations/008_hardware_verification_jobs.down.sql
+++ b/phase4-coordinator/internal/stats/migrations/008_hardware_verification_jobs.down.sql
@@ -1,0 +1,19 @@
+-- Operator rollback artifact for autotune hardware evidence verification.
+-- The embedded migration runner intentionally applies only *.up.sql.
+
+REVOKE ALL ON hardware_verification_jobs FROM provider_onboarding;
+REVOKE ALL ON hardware_verification_trust FROM provider_onboarding;
+REVOKE ALL ON SEQUENCE hardware_verification_jobs_id_seq FROM provider_onboarding;
+REVOKE ALL ON hardware_verification_jobs FROM stats_hardware_verifier;
+REVOKE ALL ON hardware_verification_trust FROM stats_hardware_verifier;
+REVOKE ALL ON provider_hardware_profiles FROM stats_hardware_verifier;
+REVOKE ALL ON chip_hardware_profiles FROM stats_hardware_verifier;
+REVOKE USAGE ON SCHEMA public FROM stats_hardware_verifier;
+REVOKE ALL ON FUNCTION hardware_verification_jobs_guard_verifier_update() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS trg_hardware_verification_jobs_guard_verifier_update
+    ON hardware_verification_jobs;
+DROP FUNCTION IF EXISTS hardware_verification_jobs_guard_verifier_update();
+DROP TABLE IF EXISTS hardware_verification_trust;
+DROP TABLE IF EXISTS hardware_verification_jobs;
+DROP ROLE IF EXISTS stats_hardware_verifier;

--- a/phase4-coordinator/internal/stats/migrations/008_hardware_verification_jobs.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/008_hardware_verification_jobs.up.sql
@@ -1,0 +1,208 @@
+-- Autotune hardware evidence queue and minimized verifier role.
+--
+-- provider_onboarding can queue authenticated evidence and refresh the
+-- untrusted provider profile. stats_hardware_verifier can promote a row to
+-- verified=true only when operator-managed trust and chip inventory rows exist.
+
+CREATE TABLE IF NOT EXISTS hardware_verification_jobs (
+    id                         BIGSERIAL PRIMARY KEY,
+    provider_id                TEXT NOT NULL,
+    source                     TEXT NOT NULL CHECK (source IN ('autotune')),
+    status                     TEXT NOT NULL CHECK (status IN ('pending', 'waiting_trust', 'verified', 'rejected')) DEFAULT 'pending',
+    chip                       TEXT NOT NULL,
+    chip_normalized            TEXT NOT NULL,
+    unified_memory_gb          INT NOT NULL CHECK (unified_memory_gb >= 0 AND unified_memory_gb <= 4096),
+    bandwidth_tier             TEXT NOT NULL DEFAULT '',
+    os_version                 TEXT NOT NULL DEFAULT '',
+    binary_version             TEXT NOT NULL DEFAULT '',
+    benchmark_count            INT NOT NULL DEFAULT 0 CHECK (benchmark_count >= 0 AND benchmark_count <= 64),
+    max_sustained_tps          DOUBLE PRECISION NOT NULL DEFAULT 0 CHECK (max_sustained_tps >= 0),
+    generated_at               TIMESTAMPTZ NOT NULL,
+    submitted_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at               TIMESTAMPTZ NULL,
+    decision_reason            TEXT NOT NULL DEFAULT '',
+    evidence                   JSONB NOT NULL,
+    evidence_sha256            TEXT NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_hardware_verification_jobs_pending
+    ON hardware_verification_jobs(id)
+    WHERE status IN ('pending', 'waiting_trust');
+
+CREATE INDEX IF NOT EXISTS idx_hardware_verification_jobs_provider_submitted
+    ON hardware_verification_jobs(provider_id, submitted_at DESC);
+
+CREATE TABLE IF NOT EXISTS hardware_verification_trust (
+    provider_id                 TEXT NOT NULL,
+    hardware_identity_hash      TEXT NOT NULL,
+    chip_normalized             TEXT NOT NULL,
+    unified_memory_gb           INT NOT NULL CHECK (unified_memory_gb >= 0 AND unified_memory_gb <= 4096),
+    trusted_by                  TEXT NOT NULL,
+    trusted_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at                  TIMESTAMPTZ NULL,
+    notes                       TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (provider_id, hardware_identity_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_hardware_verification_trust_active
+    ON hardware_verification_trust(provider_id, hardware_identity_hash)
+    WHERE expires_at IS NULL;
+
+CREATE OR REPLACE FUNCTION provider_hardware_profiles_guard_verification()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF current_user = 'provider_onboarding' THEN
+        IF TG_OP = 'INSERT' THEN
+            NEW.verified := FALSE;
+        ELSIF NEW.chip_normalized IS DISTINCT FROM OLD.chip_normalized THEN
+            NEW.verified := FALSE;
+        ELSE
+            NEW.verified := OLD.verified;
+        END IF;
+
+        RETURN NEW;
+    END IF;
+
+    IF current_user = 'stats_hardware_verifier' THEN
+        IF TG_OP = 'UPDATE' AND NEW.last_reported_at < OLD.last_reported_at THEN
+            RAISE EXCEPTION 'stats_hardware_verifier may not move hardware profile timestamps backward';
+        END IF;
+
+        IF NEW.verified IS DISTINCT FROM TRUE THEN
+            RAISE EXCEPTION 'stats_hardware_verifier may only promote verified hardware profiles';
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1
+              FROM hardware_verification_jobs j
+              JOIN hardware_verification_trust t
+                ON t.provider_id = j.provider_id
+               AND t.hardware_identity_hash = j.evidence #>> '{hardware,hardware_identity_hash}'
+               AND t.chip_normalized = j.chip_normalized
+               AND t.unified_memory_gb = j.unified_memory_gb
+               AND (t.expires_at IS NULL OR t.expires_at > now())
+              JOIN chip_hardware_profiles ch
+                ON ch.chip_normalized = j.chip_normalized
+             WHERE j.provider_id = NEW.provider_id
+               AND j.chip_normalized = NEW.chip_normalized
+               AND j.unified_memory_gb = NEW.unified_memory_gb
+               AND j.os_version = NEW.macos_version
+               AND j.binary_version = NEW.app_version
+               AND j.generated_at = NEW.last_reported_at
+               AND j.generated_at >= now() - interval '7 days'
+               AND j.status IN ('pending', 'waiting_trust')
+               AND j.benchmark_count > 0
+               AND j.max_sustained_tps > 0
+               AND COALESCE(j.evidence #>> '{hardware,hardware_identity_hash}', '') <> ''
+        ) THEN
+            RAISE EXCEPTION 'stats_hardware_verifier promotion requires matching trusted hardware evidence';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION hardware_verification_jobs_guard_verifier_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF current_user = 'stats_hardware_verifier' THEN
+        IF OLD.status NOT IN ('pending', 'waiting_trust') THEN
+            RAISE EXCEPTION 'stats_hardware_verifier may not update finalized hardware verification jobs';
+        END IF;
+
+        IF NEW.status NOT IN ('waiting_trust', 'verified', 'rejected') THEN
+            RAISE EXCEPTION 'stats_hardware_verifier may only move jobs to waiting_trust, verified, or rejected';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_hardware_verification_jobs_guard_verifier_update
+    ON hardware_verification_jobs;
+
+CREATE TRIGGER trg_hardware_verification_jobs_guard_verifier_update
+BEFORE UPDATE ON hardware_verification_jobs
+FOR EACH ROW
+EXECUTE FUNCTION hardware_verification_jobs_guard_verifier_update();
+
+REVOKE ALL ON FUNCTION hardware_verification_jobs_guard_verifier_update() FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'stats_hardware_verifier') THEN
+        CREATE ROLE stats_hardware_verifier NOLOGIN;
+    ELSE
+        ALTER ROLE stats_hardware_verifier NOLOGIN;
+    END IF;
+END
+$$;
+
+GRANT USAGE ON SCHEMA public TO stats_hardware_verifier;
+
+REVOKE ALL ON
+    hardware_verification_jobs,
+    hardware_verification_trust
+FROM stats_reader, provider_portal, stats_rollup, provider_onboarding, stats_hardware_verifier;
+
+GRANT SELECT (
+    id,
+    provider_id,
+    status,
+    submitted_at,
+    evidence_sha256
+) ON hardware_verification_jobs TO provider_onboarding;
+GRANT INSERT (
+    provider_id,
+    source,
+    status,
+    chip,
+    chip_normalized,
+    unified_memory_gb,
+    bandwidth_tier,
+    os_version,
+    binary_version,
+    benchmark_count,
+    max_sustained_tps,
+    generated_at,
+    evidence,
+    evidence_sha256
+) ON hardware_verification_jobs TO provider_onboarding;
+GRANT USAGE, SELECT ON SEQUENCE hardware_verification_jobs_id_seq TO provider_onboarding;
+
+GRANT SELECT ON hardware_verification_jobs TO stats_hardware_verifier;
+GRANT UPDATE (
+    status,
+    processed_at,
+    decision_reason
+) ON hardware_verification_jobs TO stats_hardware_verifier;
+GRANT SELECT ON hardware_verification_trust TO stats_hardware_verifier;
+GRANT SELECT ON provider_hardware_profiles TO stats_hardware_verifier;
+GRANT INSERT (
+    provider_id,
+    chip,
+    chip_normalized,
+    unified_memory_gb,
+    macos_version,
+    app_version,
+    source,
+    verified,
+    last_reported_at
+) ON provider_hardware_profiles TO stats_hardware_verifier;
+GRANT UPDATE (
+    chip,
+    chip_normalized,
+    unified_memory_gb,
+    macos_version,
+    app_version,
+    source,
+    verified,
+    last_reported_at
+) ON provider_hardware_profiles TO stats_hardware_verifier;
+GRANT SELECT ON chip_hardware_profiles TO stats_hardware_verifier;

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -28,6 +28,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{5, "oltp_source_grants"},
 		{6, "spec_026_identity"},
 		{7, "hardware_profiles"},
+		{8, "hardware_verification_jobs"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))
@@ -64,7 +65,7 @@ func TestEmbeddedSchemaShapesCorrect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("All: %v", err)
 	}
-	var schema, bootstrap, spec026, hardware string
+	var schema, bootstrap, spec026, hardware, hardwareJobs string
 	for _, m := range all {
 		switch m.Name {
 		case "stats_tables":
@@ -75,6 +76,8 @@ func TestEmbeddedSchemaShapesCorrect(t *testing.T) {
 			spec026 = m.SQL
 		case "hardware_profiles":
 			hardware = m.SQL
+		case "hardware_verification_jobs":
+			hardwareJobs = m.SQL
 		}
 	}
 	if schema == "" {
@@ -224,6 +227,93 @@ func TestEmbeddedSchemaShapesCorrect(t *testing.T) {
 		"DROP TABLE IF EXISTS provider_hardware_profiles",
 	} {
 		mustContain(t, hardwareDownSQL, needle, "hardware rollback artifact")
+	}
+	if hardwareJobs == "" {
+		t.Fatal("hardware_verification_jobs migration body is empty")
+	}
+	hardwareJobsCode := stripSQLComments(hardwareJobs)
+	for _, needle := range []string{
+		"CREATE TABLE IF NOT EXISTS hardware_verification_jobs",
+		"CREATE TABLE IF NOT EXISTS hardware_verification_trust",
+		"status                     TEXT NOT NULL CHECK (status IN ('pending', 'waiting_trust', 'verified', 'rejected')) DEFAULT 'pending'",
+		"evidence                   JSONB NOT NULL",
+		"evidence_sha256            TEXT NOT NULL UNIQUE",
+		"CREATE ROLE stats_hardware_verifier NOLOGIN",
+		"ALTER ROLE stats_hardware_verifier NOLOGIN",
+		"GRANT USAGE ON SCHEMA public TO stats_hardware_verifier",
+		"GRANT SELECT (",
+		"submitted_at,\n    evidence_sha256\n) ON hardware_verification_jobs TO provider_onboarding",
+		"GRANT INSERT (",
+		"evidence_sha256\n) ON hardware_verification_jobs TO provider_onboarding",
+		"GRANT USAGE, SELECT ON SEQUENCE hardware_verification_jobs_id_seq TO provider_onboarding",
+		"current_user = 'stats_hardware_verifier'",
+		"stats_hardware_verifier promotion requires matching trusted hardware evidence",
+		"stats_hardware_verifier may not move hardware profile timestamps backward",
+		"j.generated_at >= now() - interval '7 days'",
+		"j.status IN ('pending', 'waiting_trust')",
+		"FROM hardware_verification_jobs j",
+		"JOIN hardware_verification_trust t",
+		"JOIN chip_hardware_profiles ch",
+		"CREATE OR REPLACE FUNCTION hardware_verification_jobs_guard_verifier_update()",
+		"stats_hardware_verifier may not update finalized hardware verification jobs",
+		"stats_hardware_verifier may only move jobs to waiting_trust, verified, or rejected",
+		"CREATE TRIGGER trg_hardware_verification_jobs_guard_verifier_update",
+		"REVOKE ALL ON FUNCTION hardware_verification_jobs_guard_verifier_update() FROM PUBLIC",
+		"GRANT SELECT ON hardware_verification_jobs TO stats_hardware_verifier",
+		"GRANT UPDATE (\n    status,\n    processed_at,\n    decision_reason\n) ON hardware_verification_jobs TO stats_hardware_verifier",
+		"GRANT SELECT ON hardware_verification_trust TO stats_hardware_verifier",
+		"GRANT SELECT ON provider_hardware_profiles TO stats_hardware_verifier",
+		"GRANT INSERT (",
+		"verified,\n    last_reported_at\n) ON provider_hardware_profiles TO stats_hardware_verifier",
+		"GRANT UPDATE (",
+		"verified,\n    last_reported_at\n) ON provider_hardware_profiles TO stats_hardware_verifier",
+		"GRANT SELECT ON chip_hardware_profiles TO stats_hardware_verifier",
+	} {
+		mustContain(t, hardwareJobs, needle, "hardware verification job schema/grant shape")
+	}
+	mustNotContain(t, hardwareJobsCode,
+		"PASSWORD 'REPLACE_ME'",
+		"embedded migrations must not create committed placeholder passwords")
+	mustNotContain(t, hardwareJobsCode,
+		"CREATE ROLE stats_hardware_verifier LOGIN",
+		"stats_hardware_verifier login must be enabled only by operator bootstrap with secret material")
+	mustNotContain(t, hardwareJobsCode,
+		"GRANT UPDATE ON hardware_verification_jobs TO provider_onboarding",
+		"provider_onboarding must not process hardware jobs")
+	mustNotContain(t, hardwareJobsCode,
+		"GRANT SELECT, INSERT, UPDATE ON chip_hardware_profiles TO stats_hardware_verifier",
+		"stats_hardware_verifier must not write operator-managed chip capacity inventory")
+	mustNotContain(t, hardwareJobsCode,
+		"GRANT SELECT, UPDATE ON hardware_verification_jobs TO stats_hardware_verifier",
+		"stats_hardware_verifier job writes must be column limited")
+	mustNotContain(t, hardwareJobsCode,
+		"GRANT SELECT, INSERT, UPDATE ON provider_hardware_profiles TO stats_hardware_verifier",
+		"stats_hardware_verifier profile writes must be column limited and trigger guarded")
+	mustNotContain(t, hardwareJobsCode,
+		"j.status IN ('pending', 'waiting_trust', 'verified')",
+		"stats_hardware_verifier must not replay finalized verification jobs")
+	hardwareJobsDown, err := os.ReadFile("008_hardware_verification_jobs.down.sql")
+	if err != nil {
+		t.Fatalf("read hardware verification rollback artifact: %v", err)
+	}
+	hardwareJobsDownSQL := string(hardwareJobsDown)
+	for _, needle := range []string{
+		"REVOKE ALL ON hardware_verification_jobs FROM provider_onboarding",
+		"REVOKE ALL ON hardware_verification_trust FROM provider_onboarding",
+		"REVOKE ALL ON SEQUENCE hardware_verification_jobs_id_seq FROM provider_onboarding",
+		"REVOKE ALL ON hardware_verification_jobs FROM stats_hardware_verifier",
+		"REVOKE ALL ON hardware_verification_trust FROM stats_hardware_verifier",
+		"REVOKE ALL ON provider_hardware_profiles FROM stats_hardware_verifier",
+		"REVOKE ALL ON chip_hardware_profiles FROM stats_hardware_verifier",
+		"REVOKE USAGE ON SCHEMA public FROM stats_hardware_verifier",
+		"REVOKE ALL ON FUNCTION hardware_verification_jobs_guard_verifier_update() FROM PUBLIC",
+		"DROP TRIGGER IF EXISTS trg_hardware_verification_jobs_guard_verifier_update",
+		"DROP FUNCTION IF EXISTS hardware_verification_jobs_guard_verifier_update()",
+		"DROP TABLE IF EXISTS hardware_verification_trust",
+		"DROP TABLE IF EXISTS hardware_verification_jobs",
+		"DROP ROLE IF EXISTS stats_hardware_verifier",
+	} {
+		mustContain(t, hardwareJobsDownSQL, needle, "hardware verification rollback artifact")
 	}
 }
 

--- a/phase4-coordinator/scripts/build-linux.sh
+++ b/phase4-coordinator/scripts/build-linux.sh
@@ -8,6 +8,8 @@
 #                                      — operator hardware inventory sync
 #   dist/stats-billing-mirror-linux-amd64
 #                                      — SQLite→Postgres stats billing mirror
+#   dist/stats-hardware-verifier-linux-amd64
+#                                      — autotune hardware evidence verifier
 #
 # Refuses to build with uncommitted changes by default; set FORCE_DIRTY=1
 # to override (the resulting binary's version string will end in "-dirty"
@@ -68,3 +70,7 @@ echo "built $INVENTORY_OUT @ ${VERSION}"
 BILLING_MIRROR_OUT="dist/stats-billing-mirror-linux-amd64"
 GOOS=linux GOARCH=amd64 go build -o "$BILLING_MIRROR_OUT" ./cmd/stats-billing-mirror
 echo "built $BILLING_MIRROR_OUT @ ${VERSION}"
+
+HARDWARE_VERIFIER_OUT="dist/stats-hardware-verifier-linux-amd64"
+GOOS=linux GOARCH=amd64 go build -o "$HARDWARE_VERIFIER_OUT" ./cmd/stats-hardware-verifier
+echo "built $HARDWARE_VERIFIER_OUT @ ${VERSION}"


### PR DESCRIPTION
## What changed
- Added autotune hardware evidence submission from macprovider-cli to /v1/providers/hardware-evidence.
- Added coordinator-side authenticated evidence intake with body caps, rate limits, and a durable hardware_verification_jobs queue.
- Added a minimized stats-hardware-verifier sidecar that promotes provider hardware profiles only when provider-specific trust and operator-managed chip inventory both match.
- Added migration 008 with verifier/trust tables, column-limited grants, and DB triggers that mirror the verifier trust policy.
- Wired nginx, Pearl deploy assets, systemd service/timer, and Linux build output for the new sidecar.

## Why
Malibu network stats need autotune to populate provider hardware evidence quickly, but public bandwidth/power/core totals must not trust provider self-reporting. This keeps coordinator request-path performance unchanged and moves promotion into a bounded sidecar.

## Validation
- go test ./... in phase4-coordinator
- go test -tags=integration -run 'TestHardwareVerifierPromotionGuard|TestHardwareProfileRoleGrantsAndVerificationGuard|TestHardwareVerification' -count=1 ./internal/stats
- swift test --filter AutotuneHardwareEvidenceTests
- bash -n phase4-coordinator/dist/deploy-pearl-vps.sh phase4-coordinator/scripts/build-linux.sh
- git diff --check
- FORCE_DIRTY=1 bash scripts/build-linux.sh
- 3 audit lanes rerun to 0 C/H/M findings

## Not tested
Live Pearl deploy and live Postgres migration were not executed from this PR branch.