### PR TITLE
[codex] SPEC-028 PR-A speculative decoding plumbing

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -21,6 +21,10 @@ public struct AppConfig: Equatable, Sendable {
     public var model: String?
     public var modelArtifactPath: String?
     public var modelArtifactSHA256: String?
+    public var draftModel: String?
+    public var draftModelArtifactSHA256: String?
+    public var numDraftTokens: Int
+    public var publishesSpecDecodeTelemetry: Bool
     public var modelCatalogKey: String?
     public var modelCatalogModelID: String?
     public var modelCatalogRevision: String?
@@ -97,6 +101,10 @@ public struct AppConfig: Equatable, Sendable {
             model: nil,
             modelArtifactPath: nil,
             modelArtifactSHA256: nil,
+            draftModel: nil,
+            draftModelArtifactSHA256: nil,
+            numDraftTokens: 3,
+            publishesSpecDecodeTelemetry: false,
             modelCatalogKey: nil,
             modelCatalogModelID: nil,
             modelCatalogRevision: nil,
@@ -144,6 +152,10 @@ public struct AppConfig: Equatable, Sendable {
 public struct CLIOverrides: Equatable, Sendable {
     public var port: Int?
     public var model: String?
+    public var draftModel: String?
+    public var draftModelArtifactSHA256: String?
+    public var numDraftTokens: Int?
+    public var publishesSpecDecodeTelemetry: Bool?
     public var coordinatorURL: String?
     public var providerID: String?
     public var endpointURL: String?
@@ -175,6 +187,10 @@ public struct CLIOverrides: Equatable, Sendable {
     public init(
         port: Int? = nil,
         model: String? = nil,
+        draftModel: String? = nil,
+        draftModelArtifactSHA256: String? = nil,
+        numDraftTokens: Int? = nil,
+        publishesSpecDecodeTelemetry: Bool? = nil,
         coordinatorURL: String? = nil,
         providerID: String? = nil,
         endpointURL: String? = nil,
@@ -202,6 +218,10 @@ public struct CLIOverrides: Equatable, Sendable {
     ) {
         self.port = port
         self.model = model
+        self.draftModel = draftModel
+        self.draftModelArtifactSHA256 = draftModelArtifactSHA256
+        self.numDraftTokens = numDraftTokens
+        self.publishesSpecDecodeTelemetry = publishesSpecDecodeTelemetry
         self.coordinatorURL = coordinatorURL
         self.providerID = providerID
         self.endpointURL = endpointURL
@@ -311,6 +331,10 @@ public enum ConfigLoader {
         try assign(&config.model, from: dict, key: "model", expected: "string")
         try assign(&config.modelArtifactPath, from: dict, key: "model_artifact_path", expected: "string")
         try assign(&config.modelArtifactSHA256, from: dict, key: "model_artifact_sha256", expected: "string")
+        try assign(&config.draftModel, from: dict, key: "draft_model", expected: "string")
+        try assign(&config.draftModelArtifactSHA256, from: dict, key: "draft_model_artifact_sha256", expected: "string")
+        try assign(&config.numDraftTokens, from: dict, key: "num_draft_tokens", expected: "integer")
+        try assign(&config.publishesSpecDecodeTelemetry, from: dict, key: "publishes_spec_decode_telemetry", expected: "boolean")
         try assign(&config.modelCatalogKey, from: dict, key: "model_catalog_key", expected: "string")
         try assign(&config.modelCatalogModelID, from: dict, key: "model_catalog_model_id", expected: "string")
         try assign(&config.modelCatalogRevision, from: dict, key: "model_catalog_revision", expected: "string")
@@ -365,6 +389,10 @@ public enum ConfigLoader {
         try assign(&config.port, from: environment, env: "MACPROVIDER_PORT", expected: "integer")
         try assign(&config.model, from: environment, env: "MACPROVIDER_MODEL", expected: "string")
         try assign(&config.modelArtifactSHA256, from: environment, env: "MACPROVIDER_MODEL_ARTIFACT_SHA256", expected: "string")
+        try assign(&config.draftModel, from: environment, env: "MACPROVIDER_DRAFT_MODEL", expected: "string")
+        try assign(&config.draftModelArtifactSHA256, from: environment, env: "MACPROVIDER_DRAFT_MODEL_ARTIFACT_SHA256", expected: "string")
+        try assign(&config.numDraftTokens, from: environment, env: "MACPROVIDER_NUM_DRAFT_TOKENS", expected: "integer")
+        try assign(&config.publishesSpecDecodeTelemetry, from: environment, env: "MACPROVIDER_PUBLISHES_SPEC_DECODE_TELEMETRY", expected: "boolean")
         try assign(&config.coordinatorURL, from: environment, env: "MACPROVIDER_COORDINATOR_URL", expected: "string")
         try assign(&config.providerID, from: environment, env: "MACPROVIDER_PROVIDER_ID", expected: "string")
         try assign(&config.endpointURL, from: environment, env: "MACPROVIDER_ENDPOINT_URL", expected: "string")
@@ -408,6 +436,18 @@ public enum ConfigLoader {
         }
         if let model = cli.model {
             config.model = model
+        }
+        if let draftModel = cli.draftModel {
+            config.draftModel = draftModel
+        }
+        if let draftModelArtifactSHA256 = cli.draftModelArtifactSHA256 {
+            config.draftModelArtifactSHA256 = draftModelArtifactSHA256
+        }
+        if let numDraftTokens = cli.numDraftTokens {
+            config.numDraftTokens = numDraftTokens
+        }
+        if let publishesSpecDecodeTelemetry = cli.publishesSpecDecodeTelemetry {
+            config.publishesSpecDecodeTelemetry = publishesSpecDecodeTelemetry
         }
         if let coordinatorURL = cli.coordinatorURL {
             config.coordinatorURL = coordinatorURL

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -28,6 +28,18 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "HuggingFace model identifier or local model path. Overrides MACPROVIDER_MODEL and config file model.")
     var model: String?
 
+    @Option(help: "Optional speculative decoding draft model identifier or local path. Overrides MACPROVIDER_DRAFT_MODEL and config key draft_model.")
+    var draftModel: String?
+
+    @Option(help: "Lowercase SHA-256 artifact hash for the draft model snapshot. Overrides MACPROVIDER_DRAFT_MODEL_ARTIFACT_SHA256 and config key draft_model_artifact_sha256.")
+    var draftModelArtifactSha256: String?
+
+    @Option(help: "Speculative decoding draft tokens per verification round. Default 3 when --draft-model is set; valid range 1...16.")
+    var numDraftTokens: Int?
+
+    @Flag(name: .customLong("publish-spec-decode-telemetry"), inversion: .prefixedNo, help: "Opt into publishing SPEC-028 speculative decoding telemetry on coordinator heartbeats after compatibility is verified. Default off.")
+    var publishSpecDecodeTelemetry: Bool?
+
     @Option(help: "Coordinator WebSocket URL. Overrides MACPROVIDER_COORDINATOR_URL and config file coordinator_url.")
     var coordinator: String?
 
@@ -148,6 +160,81 @@ struct ServeCommand: AsyncParsableCommand {
             FileHandle.standardError.write(Data((
                 "--max-batch \(maxBatch) must be >= 1\n"
             ).utf8))
+            throw ExitCode(2)
+        }
+        if !(1...16).contains(resolved.numDraftTokens) {
+            FileHandle.standardError.write(Data((
+                "--num-draft-tokens \(resolved.numDraftTokens) out of range 1...16\n"
+            ).utf8))
+            throw ExitCode(2)
+        }
+        if let draftModel = resolved.draftModel,
+           draftModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            FileHandle.standardError.write(Data("--draft-model must be non-empty\n".utf8))
+            throw ExitCode(2)
+        }
+        if let hash = resolved.draftModelArtifactSHA256,
+           hash.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) == nil {
+            FileHandle.standardError.write(Data("draft_model_artifact_sha256 must be 64 lowercase hex characters\n".utf8))
+            throw ExitCode(2)
+        }
+        if resolved.publishesSpecDecodeTelemetry {
+            FileHandle.standardError.write(Data("spec_decode_heartbeat_incompatible: SPEC-028 heartbeat telemetry is implemented in PR-B\n".utf8))
+            throw ExitCode(2)
+        }
+    }
+
+    static func runSpecDecodeCapacityPreflight(_ resolved: inout AppConfig) throws {
+        guard resolved.draftModel?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+            return
+        }
+        let defaultContext = ProviderCapacity.defaultContextTokensForCurrentHost()
+        let requestedContext = resolved.maxContextOverride ?? defaultContext
+        let draftCap = ProviderCapacity.draftContextCapForCurrentHost()
+        let effectiveContext = min(requestedContext, draftCap)
+        if let explicit = resolved.maxContextOverride, explicit > effectiveContext {
+            FileHandle.standardError.write(Data("draft_model_capacity_shortfall: --max-context \(explicit) exceeds draft-enabled cap \(effectiveContext)\n".utf8))
+            throw ExitCode(2)
+        }
+        if let explicit = resolved.maxConcurrencyOverride, explicit > 1 {
+            FileHandle.standardError.write(Data("draft_model_capacity_shortfall: --max-batch \(explicit) exceeds draft-enabled cap 1\n".utf8))
+            throw ExitCode(2)
+        }
+        resolved.maxContextOverride = effectiveContext
+        resolved.maxConcurrencyOverride = 1
+    }
+
+    static func runDraftModelArtifactPreflight(
+        _ resolved: AppConfig,
+        joiningCoordinator: Bool = true
+    ) throws -> String? {
+        guard let draftModel = resolved.draftModel?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !draftModel.isEmpty else {
+            return nil
+        }
+        guard let expected = resolved.draftModelArtifactSHA256 else {
+            if joiningCoordinator || resolved.enableReceipts {
+                FileHandle.standardError.write(Data("draft_model_unverified_artifact: coordinator or receipt-capable serve requires draft_model_artifact_sha256\n".utf8))
+                throw ExitCode(2)
+            }
+            return draftModel
+        }
+        guard expected.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil else {
+            FileHandle.standardError.write(Data("draft_model_artifact_sha256 must be 64 lowercase hex characters\n".utf8))
+            throw ExitCode(2)
+        }
+        do {
+            let directory = try ModelRuntime.localModelDirectory(for: draftModel)
+            let actual = try ModelArtifactVerifier.canonicalArtifactHash(directory: directory)
+            guard actual == expected else {
+                FileHandle.standardError.write(Data("draft_model_unverified_artifact: draft model artifact hash mismatch for \(directory.path)\n".utf8))
+                throw ExitCode(2)
+            }
+            return directory.standardizedFileURL.path
+        } catch let exit as ExitCode {
+            throw exit
+        } catch {
+            FileHandle.standardError.write(Data("draft_model_unverified_artifact: draft model artifact verification failed for \(draftModel): \(error)\n".utf8))
             throw ExitCode(2)
         }
     }
@@ -300,6 +387,10 @@ struct ServeCommand: AsyncParsableCommand {
             cli: CLIOverrides(
                 port: port,
                 model: model,
+                draftModel: draftModel,
+                draftModelArtifactSHA256: draftModelArtifactSha256,
+                numDraftTokens: numDraftTokens,
+                publishesSpecDecodeTelemetry: publishSpecDecodeTelemetry,
                 coordinatorURL: coordinator,
                 providerID: providerID,
                 endpointURL: endpointURL,
@@ -340,13 +431,18 @@ struct ServeCommand: AsyncParsableCommand {
         try Self.runSupportedModelsPreflight(&resolved)
         try Self.runDrainTimeoutPreflight(resolved)
         try Self.runServingKnobsPreflight(resolved)
+        try Self.runSpecDecodeCapacityPreflight(&resolved)
         try await Self.runModelArtifactPreflight(resolved, joiningCoordinator: !noJoin)
+        let verifiedDraftModelLoadPath = try Self.runDraftModelArtifactPreflight(resolved, joiningCoordinator: !noJoin)
 
         printResolvedConfiguration(resolved)
 
         let modelRuntime = try await ModelRuntime(
             modelID: resolved.model,
             modelLoadPath: resolved.modelArtifactPath,
+            draftModelID: resolved.draftModel,
+            draftModelLoadPath: verifiedDraftModelLoadPath,
+            numDraftTokens: resolved.numDraftTokens,
             maxContextTokensOverride: resolved.maxContextOverride,
             kvBitsOverride: resolved.kvBitsOverride,
             maxBatch: resolved.maxConcurrencyOverride ?? 1,
@@ -632,6 +728,9 @@ private func printResolvedConfiguration(_ config: AppConfig) {
     print("macprovider-cli config")
     print("  port: \(config.port)")
     print("  model: \(config.model ?? "<unset>")")
+    print("  draft_model: \(config.draftModel ?? "<unset>")")
+    print("  num_draft_tokens: \(config.numDraftTokens)")
+    print("  publishes_spec_decode_telemetry: \(config.publishesSpecDecodeTelemetry)")
     print("  coordinator_url: \(config.coordinatorURL ?? "<unset>")")
     print("  provider_id: \(config.providerID ?? "<unset, will use per-instance UUID>")")
     print("  endpoint_url: \(config.endpointURL ?? "<unset, WS-tunneled>")")

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -199,6 +199,27 @@ public struct RuntimeSnapshot: @unchecked Sendable {
     public let container: ModelContainer?
     public let modelID: String?
     public let modelHash: String?
+    public let draftModelID: String?
+    public let draftContainer: ModelContainer?
+    public let numDraftTokens: Int?
+
+    init(
+        state: SwapState,
+        container: ModelContainer?,
+        modelID: String?,
+        modelHash: String?,
+        draftModelID: String? = nil,
+        draftContainer: ModelContainer? = nil,
+        numDraftTokens: Int? = nil
+    ) {
+        self.state = state
+        self.container = container
+        self.modelID = modelID
+        self.modelHash = modelHash
+        self.draftModelID = draftModelID
+        self.draftContainer = draftContainer
+        self.numDraftTokens = numDraftTokens
+    }
 }
 
 public struct RequestHandle: @unchecked Sendable {
@@ -223,6 +244,32 @@ struct ModelRuntimeLoadError: Error, CustomStringConvertible {
     }
 }
 
+enum SpecDecodeStartupError: Error, CustomStringConvertible, Equatable {
+    case targetRequired
+    case tokenizerMismatch
+    case probeFailed(String)
+    case fixtureMissing
+    case fixtureInvalid(String)
+    case equivalenceFailed(plain: [Int], speculative: [Int])
+
+    var description: String {
+        switch self {
+        case .targetRequired:
+            return "draft_model_target_required"
+        case .tokenizerMismatch:
+            return "draft_model_tokenizer_mismatch"
+        case .probeFailed(let reason):
+            return "draft_model_probe_failed: \(reason)"
+        case .fixtureMissing:
+            return "draft_model_equivalence_failed: spec028 equivalence fixture missing"
+        case .fixtureInvalid(let reason):
+            return "draft_model_equivalence_failed: spec028 equivalence fixture invalid: \(reason)"
+        case .equivalenceFailed:
+            return "draft_model_equivalence_failed"
+        }
+    }
+}
+
 struct InternalWarmupResult: Sendable {
     let tokensGenerated: Int
     let firstTokenElapsedMS: Double
@@ -243,6 +290,9 @@ actor ModelRuntime: ModelRuntimeServing {
     private var targetModelID: String?
     private var currentModelID: String?
     private var currentContainer: ModelContainer?
+    private var currentDraftModelID: String?
+    private var currentDraftContainer: ModelContainer?
+    private let numDraftTokens: Int
     private let stopTokenFilter: StopTokenFilter
     private var currentModelHash: String?
     private let maxContextTokens: Int
@@ -278,6 +328,9 @@ actor ModelRuntime: ModelRuntimeServing {
     init(
         modelID: String?,
         modelLoadPath: String? = nil,
+        draftModelID: String? = nil,
+        draftModelLoadPath: String? = nil,
+        numDraftTokens: Int = 3,
         maxContextTokensOverride: Int? = nil,
         kvBitsOverride: Int? = nil,
         maxBatch: Int = 1,
@@ -285,6 +338,9 @@ actor ModelRuntime: ModelRuntimeServing {
         swapDrainTimeoutSeconds: Int = 30
     ) async throws {
         self.currentModelID = modelID
+        self.currentDraftModelID = nil
+        self.currentDraftContainer = nil
+        self.numDraftTokens = numDraftTokens
         self.maxContextTokens = maxContextTokensOverride ?? Self.defaultMaxContextTokens()
         self.kvBitsOverride = kvBitsOverride
         self.conversationCache = ConversationCache()
@@ -304,6 +360,9 @@ actor ModelRuntime: ModelRuntimeServing {
             self.currentContainer = nil
             self.stopTokenFilter = StopTokenFilter(tokens: [])
             self.currentModelHash = nil
+            if draftModelID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                throw SpecDecodeStartupError.targetRequired
+            }
             return
         }
 
@@ -317,11 +376,41 @@ actor ModelRuntime: ModelRuntimeServing {
             self.stopTokenFilter = StopTokenFilter(tokens: [])
         }
         self.currentModelHash = try? Self.modelWeightArtifactManifestHash(in: directory)
+
+        if let draftModelID = draftModelID?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !draftModelID.isEmpty {
+            let (draftContainer, draftDirectory) = try await Self.loadLocalContainer(from: draftModelLoadPath ?? draftModelID)
+            try await Self.validateTokenizerCompatibility(
+                target: container,
+                targetDirectory: directory,
+                draft: draftContainer,
+                draftDirectory: draftDirectory
+            )
+            try await Self.runSpeculativeStartupProbe(
+                target: container,
+                draft: draftContainer,
+                numDraftTokens: 1,
+                maxContextTokens: self.maxContextTokens,
+                kvBitsOverride: self.kvBitsOverride
+            )
+            try await Self.runSpeculativeEquivalenceCanary(
+                target: container,
+                draft: draftContainer,
+                targetModelID: modelID,
+                numDraftTokens: numDraftTokens,
+                maxContextTokens: self.maxContextTokens,
+                kvBitsOverride: self.kvBitsOverride
+            )
+            self.currentDraftModelID = draftModelID
+            self.currentDraftContainer = draftContainer
+        }
     }
 
     init(
         modelID: String?,
         modelHash: String? = nil,
+        draftModelID: String? = nil,
+        numDraftTokens: Int = 3,
         maxContextTokensOverride: Int? = nil,
         kvBitsOverride: Int? = nil,
         maxBatch: Int = 1,
@@ -334,6 +423,9 @@ actor ModelRuntime: ModelRuntimeServing {
     ) {
         self.currentModelID = modelID
         self.currentContainer = nil
+        self.currentDraftModelID = draftModelID
+        self.currentDraftContainer = nil
+        self.numDraftTokens = numDraftTokens
         self.currentModelHash = modelHash
         self.stopTokenFilter = StopTokenFilter(tokens: [])
         self.maxContextTokens = maxContextTokensOverride ?? Self.defaultMaxContextTokens()
@@ -358,7 +450,10 @@ actor ModelRuntime: ModelRuntimeServing {
             state: state,
             container: currentContainer,
             modelID: currentModelID,
-            modelHash: currentModelHash
+            modelHash: currentModelHash,
+            draftModelID: currentDraftModelID,
+            draftContainer: currentDraftContainer,
+            numDraftTokens: currentDraftModelID == nil ? nil : numDraftTokens
         )
     }
 
@@ -426,6 +521,14 @@ actor ModelRuntime: ModelRuntimeServing {
         maxContextTokens
     }
 
+    func draftModelIDForTest() -> String? {
+        currentDraftModelID
+    }
+
+    func numDraftTokensForTest() -> Int {
+        numDraftTokens
+    }
+
     private func transitionToLoading(target: String) throws {
         guard state == .ready else {
             throw RuntimeStateMachineError.notReady(current: state)
@@ -467,6 +570,8 @@ actor ModelRuntime: ModelRuntimeServing {
         currentContainer = container
         currentModelID = modelID
         currentModelHash = modelHash
+        currentDraftModelID = nil
+        currentDraftContainer = nil
         state = .ready
         targetModelID = nil
         signal(SwapSignal(targetModelID: target, outcome: .completed(newModelID: modelID, newModelHash: modelHash)))
@@ -517,7 +622,10 @@ actor ModelRuntime: ModelRuntimeServing {
             state: state,
             container: currentContainer,
             modelID: currentModelID,
-            modelHash: currentModelHash
+            modelHash: currentModelHash,
+            draftModelID: currentDraftModelID,
+            draftContainer: currentDraftContainer,
+            numDraftTokens: currentDraftModelID == nil ? nil : numDraftTokens
         )
         try Self.validateReady(snapshot.state)
         try request.validateModelMatches(snapshot.modelID)
@@ -1027,6 +1135,190 @@ actor ModelRuntime: ModelRuntimeServing {
         }
     }
 
+    private static func validateTokenizerCompatibility(
+        target: ModelContainer,
+        targetDirectory: URL,
+        draft: ModelContainer,
+        draftDirectory: URL
+    ) async throws {
+        guard let targetFingerprint = try tokenizerArtifactFingerprint(in: targetDirectory),
+              let draftFingerprint = try tokenizerArtifactFingerprint(in: draftDirectory),
+              targetFingerprint == draftFingerprint
+        else {
+            throw SpecDecodeStartupError.tokenizerMismatch
+        }
+        let targetTokenizer = await target.tokenizer
+        let draftTokenizer = await draft.tokenizer
+        guard tokenizersAreCompatible(targetTokenizer: targetTokenizer, draftTokenizer: draftTokenizer) else {
+            throw SpecDecodeStartupError.tokenizerMismatch
+        }
+    }
+
+    static func tokenizersAreCompatible(
+        targetTokenizer: MLXLMCommon.Tokenizer,
+        draftTokenizer: MLXLMCommon.Tokenizer
+    ) -> Bool {
+        let probes = [
+            "",
+            "hello",
+            "Write a Swift function named iso8601DayPrefix.",
+            "<|endoftext|>",
+            "JSON {\"role\":\"user\",\"content\":\"test\"}",
+        ]
+        guard targetTokenizer.eosToken == draftTokenizer.eosToken,
+              targetTokenizer.unknownToken == draftTokenizer.unknownToken
+        else {
+            return false
+        }
+        for probe in probes {
+            guard targetTokenizer.encode(text: probe, addSpecialTokens: true) == draftTokenizer.encode(text: probe, addSpecialTokens: true),
+                  targetTokenizer.encode(text: probe, addSpecialTokens: false) == draftTokenizer.encode(text: probe, addSpecialTokens: false)
+            else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func runSpeculativeStartupProbe(
+        target: ModelContainer,
+        draft: ModelContainer,
+        numDraftTokens: Int,
+        maxContextTokens: Int,
+        kvBitsOverride: Int?
+    ) async throws {
+        do {
+            _ = try await target.perform { targetContext in
+                let input = UserInput(prompt: "spec028 startup probe")
+                let lmInput = try await targetContext.processor.prepare(input: input)
+                try validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
+                let parameters = GenerateParameters(
+                    maxTokens: 1,
+                    maxKVSize: maxContextTokens,
+                    kvBits: kvBitsOverride,
+                    temperature: 0.0,
+                    topP: 1.0
+                )
+                return try await speculativeTokenIDs(
+                    input: lmInput,
+                    parameters: parameters,
+                    targetContext: targetContext,
+                    draft: draft,
+                    numDraftTokens: numDraftTokens
+                )
+            }
+        } catch let error as SpecDecodeStartupError {
+            throw error
+        } catch {
+            throw SpecDecodeStartupError.probeFailed(String(describing: error))
+        }
+    }
+
+    private static func runSpeculativeEquivalenceCanary(
+        target: ModelContainer,
+        draft: ModelContainer,
+        targetModelID: String,
+        numDraftTokens: Int,
+        maxContextTokens: Int,
+        kvBitsOverride: Int?
+    ) async throws {
+        let request = try spec028EquivalenceRequest(targetModelID: targetModelID)
+        let tokenPair = try await target.perform { targetContext in
+            let input = try userInput(for: request)
+            let lmInput = try await targetContext.processor.prepare(input: input)
+            try validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
+            let parameters = GenerateParameters(
+                maxTokens: request.maxTokens,
+                maxKVSize: maxContextTokens,
+                kvBits: kvBitsOverride,
+                temperature: 0.0,
+                topP: 1.0
+            )
+            let plain = try plainTokenIDs(input: lmInput, parameters: parameters, context: targetContext)
+            let speculative = try await speculativeTokenIDs(
+                input: lmInput,
+                parameters: parameters,
+                targetContext: targetContext,
+                draft: draft,
+                numDraftTokens: numDraftTokens
+            )
+            return (plain, speculative)
+        }
+        try validateSpeculativeEquivalence(plain: tokenPair.0, speculative: tokenPair.1)
+    }
+
+    static func validateSpeculativeEquivalence(plain: [Int], speculative: [Int]) throws {
+        guard plain == speculative else {
+            throw SpecDecodeStartupError.equivalenceFailed(plain: plain, speculative: speculative)
+        }
+    }
+
+    private static func plainTokenIDs(
+        input: LMInput,
+        parameters: GenerateParameters,
+        context: ModelContext
+    ) throws -> [Int] {
+        let cache = context.model.newCache(parameters: parameters)
+        let iterator = try TokenIterator(input: input, model: context.model, cache: cache, parameters: parameters)
+        return generate(input: input, context: context, iterator: iterator) { _ in
+            .more
+        }.tokenIds
+    }
+
+    private static func speculativeTokenIDs(
+        input: LMInput,
+        parameters: GenerateParameters,
+        targetContext: ModelContext,
+        draft: ModelContainer,
+        numDraftTokens: Int
+    ) async throws -> [Int] {
+        try await draft.perform(nonSendable: (input, targetContext)) { draftContext, values in
+            let (input, targetContext) = values
+            let draftCache = draftContext.model.newCache(parameters: parameters)
+            var tokenIDs: [Int] = []
+            for await generation in try generateTokens(
+                input: input,
+                parameters: parameters,
+                context: targetContext,
+                draftModel: draftContext.model,
+                draftCache: draftCache,
+                numDraftTokens: numDraftTokens
+            ) {
+                if let token = generation.token {
+                    tokenIDs.append(token)
+                }
+            }
+            return tokenIDs
+        }
+    }
+
+    private static func spec028EquivalenceRequest(targetModelID: String) throws -> ChatCompletionRequest {
+        let data = try spec028EquivalenceFixtureBytes()
+        guard var object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw SpecDecodeStartupError.fixtureInvalid("root is not an object")
+        }
+        object["model"] = targetModelID
+        let requestData = try JSONSerialization.data(withJSONObject: object)
+        return try ChatCompletionRequest.parse(data: requestData)
+    }
+
+    private static func spec028EquivalenceFixtureBytes() throws -> Data {
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let candidates = [
+            cwd.appendingPathComponent("Tests/Fixtures/spec028/equivalence-smoke-v1.json"),
+            cwd.appendingPathComponent("phase3-binary/Tests/Fixtures/spec028/equivalence-smoke-v1.json"),
+            URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Tests/Fixtures/spec028/equivalence-smoke-v1.json"),
+        ].compactMap { $0 }
+        for url in candidates where FileManager.default.fileExists(atPath: url.path) {
+            return try Data(contentsOf: url)
+        }
+        throw SpecDecodeStartupError.fixtureMissing
+    }
+
     private static func loadLocalContainer(from target: String) async throws -> (ModelContainer, URL) {
         let directory = try localModelDirectory(for: target)
         // mlx-swift-lm 3.x requires an explicit tokenizer loader. The provider
@@ -1039,7 +1331,7 @@ actor ModelRuntime: ModelRuntimeServing {
         return (container, directory)
     }
 
-    private static func localModelDirectory(for target: String) throws -> URL {
+    static func localModelDirectory(for target: String) throws -> URL {
         let expanded = (target as NSString).expandingTildeInPath
         if expanded.hasPrefix("/") || FileManager.default.fileExists(atPath: expanded) {
             let url = URL(fileURLWithPath: expanded)
@@ -1108,7 +1400,7 @@ actor ModelRuntime: ModelRuntimeServing {
         ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil).maxContextTokens
     }
 
-    private static func localHuggingFaceSnapshot(for modelID: String) -> URL? {
+    static func localHuggingFaceSnapshot(for modelID: String) -> URL? {
         let parts = modelID.split(separator: "/", maxSplits: 1).map(String.init)
         guard parts.count == 2 else { return nil }
 
@@ -1157,6 +1449,45 @@ actor ModelRuntime: ModelRuntimeServing {
             )
         }
         let manifest = ModelWeightManifest(files: files)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(manifest)
+        return hexString(SHA256.hash(data: data))
+    }
+
+    static func tokenizerArtifactFingerprint(in directory: URL) throws -> String? {
+        let tokenizerArtifactNames = [
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "special_tokens_map.json",
+            "tokenizer.model",
+            "vocab.json",
+            "merges.txt",
+            "added_tokens.json",
+            "chat_template.jinja",
+        ]
+        let fileManager = FileManager.default
+        let files = try tokenizerArtifactNames.compactMap { name -> TokenizerArtifactManifestFile? in
+            let url = directory.appendingPathComponent(name)
+            var isDirectory = ObjCBool(false)
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+                  !isDirectory.boolValue
+            else {
+                return nil
+            }
+            let contentURL = url.resolvingSymlinksInPath()
+            let attributes = try fileManager.attributesOfItem(atPath: contentURL.path)
+            let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+            return TokenizerArtifactManifestFile(
+                name: name,
+                sha256: try sha256Hex(ofFileAt: contentURL),
+                size: size
+            )
+        }
+
+        guard !files.isEmpty else { return nil }
+
+        let manifest = TokenizerArtifactManifest(files: files)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         let data = try encoder.encode(manifest)
@@ -1813,6 +2144,16 @@ private struct ModelWeightManifest: Encodable {
 }
 
 private struct ModelWeightManifestFile: Encodable {
+    let name: String
+    let sha256: String
+    let size: UInt64
+}
+
+private struct TokenizerArtifactManifest: Encodable {
+    let files: [TokenizerArtifactManifestFile]
+}
+
+private struct TokenizerArtifactManifestFile: Encodable {
     let name: String
     let sha256: String
     let size: UInt64

--- a/phase3-binary/Sources/macprovider-cli/ProviderStatus.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderStatus.swift
@@ -20,17 +20,7 @@ struct ProviderCapacity: Sendable {
         let physicalMemoryGB = Self.systemMemoryGB()
         self.ramGB = physicalMemoryGB
 
-        let defaults: (tier: String, context: Int, concurrency: Int)
-        switch physicalMemoryGB {
-        case ...12:
-            defaults = ("8GB", 20_000, 1)
-        case ...24:
-            defaults = ("16GB", 50_000, 2)
-        case ...48:
-            defaults = ("32GB", 120_000, 4)
-        default:
-            defaults = ("64GB+", 200_000, 8)
-        }
+        let defaults = Self.defaults(forPhysicalMemoryGB: physicalMemoryGB)
 
         self.ramTier = defaults.tier
         self.maxContextTokens = maxContextOverride ?? defaults.context
@@ -65,6 +55,44 @@ struct ProviderCapacity: Sendable {
             return max(1, Int((memsize + 1_073_741_823) / 1_073_741_824))
         }
         return max(1, Int((ProcessInfo.processInfo.physicalMemory + 1_073_741_823) / 1_073_741_824))
+    }
+
+    static func defaults(forPhysicalMemoryGB physicalMemoryGB: Int) -> (tier: String, context: Int, concurrency: Int) {
+        switch physicalMemoryGB {
+        case ...12:
+            return ("8GB", 20_000, 1)
+        case ...24:
+            return ("16GB", 50_000, 2)
+        case ...48:
+            return ("32GB", 120_000, 4)
+        default:
+            return ("64GB+", 200_000, 8)
+        }
+    }
+
+    static func defaultContextTokens(forPhysicalMemoryGB physicalMemoryGB: Int) -> Int {
+        defaults(forPhysicalMemoryGB: physicalMemoryGB).context
+    }
+
+    static func draftContextCap(forPhysicalMemoryGB physicalMemoryGB: Int) -> Int {
+        switch physicalMemoryGB {
+        case ...12:
+            return 8_192
+        case ...24:
+            return 20_000
+        case ...48:
+            return 50_000
+        default:
+            return 120_000
+        }
+    }
+
+    static func defaultContextTokensForCurrentHost() -> Int {
+        defaultContextTokens(forPhysicalMemoryGB: systemMemoryGB())
+    }
+
+    static func draftContextCapForCurrentHost() -> Int {
+        draftContextCap(forPhysicalMemoryGB: systemMemoryGB())
     }
 }
 

--- a/phase3-binary/Tests/Fixtures/spec028/equivalence-smoke-v1.json
+++ b/phase3-binary/Tests/Fixtures/spec028/equivalence-smoke-v1.json
@@ -1,0 +1,18 @@
+{
+  "fixture_id": "spec028-equivalence-smoke-v1",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a deterministic coding assistant. Answer with concise plain text only."
+    },
+    {
+      "role": "user",
+      "content": "Write a Swift function named iso8601DayPrefix that returns the first 10 characters of an ISO-8601 timestamp if present, otherwise returns nil."
+    }
+  ],
+  "temperature": 0,
+  "top_p": 1.0,
+  "max_tokens": 64,
+  "stream": false,
+  "response_format": { "type": "text" }
+}

--- a/phase3-binary/Tests/Fixtures/spec028/small-air-short-chat.json
+++ b/phase3-binary/Tests/Fixtures/spec028/small-air-short-chat.json
@@ -1,0 +1,22 @@
+{
+  "fixture_id": "spec028-small-air-short-chat-v1",
+  "target_model": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+  "draft_model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+  "request": {
+    "messages": [
+      {
+        "role": "system",
+        "content": "Answer in one short paragraph."
+      },
+      {
+        "role": "user",
+        "content": "Explain what a provider heartbeat reports in MacProvider."
+      }
+    ],
+    "temperature": 0,
+    "top_p": 1.0,
+    "max_tokens": 48,
+    "stream": false,
+    "response_format": { "type": "text" }
+  }
+}

--- a/phase3-binary/Tests/Fixtures/spec028/small-air-streaming-check.json
+++ b/phase3-binary/Tests/Fixtures/spec028/small-air-streaming-check.json
@@ -1,0 +1,22 @@
+{
+  "fixture_id": "spec028-small-air-streaming-check-v1",
+  "target_model": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+  "draft_model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+  "request": {
+    "messages": [
+      {
+        "role": "system",
+        "content": "Return concise plain text only."
+      },
+      {
+        "role": "user",
+        "content": "List three safe startup checks for speculative decoding."
+      }
+    ],
+    "temperature": 0,
+    "top_p": 1.0,
+    "max_tokens": 64,
+    "stream": true,
+    "response_format": { "type": "text" }
+  }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ReceiptBuilderTests.swift
@@ -284,6 +284,9 @@ final class ReceiptBuilderTests: XCTestCase {
             Set(usage.keys),
             ["billable_input_tokens", "billable_output_tokens", "delivered_output_bytes", "observed_input_tokens", "observed_output_tokens"]
         )
+        XCTAssertFalse(usage.keys.contains { $0.hasPrefix("spec_decode") })
+        XCTAssertNil(usage["drafted_tokens"])
+        XCTAssertNil(usage["accepted_tokens"])
         XCTAssertEqual(usage["billable_input_tokens"] as? Int, 8)
         XCTAssertEqual(usage["billable_output_tokens"] as? Int, 3)
     }

--- a/phase3-binary/Tests/macprovider-cliTests/Spec028PlumbingTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/Spec028PlumbingTests.swift
@@ -1,0 +1,441 @@
+import ArgumentParser
+import Foundation
+import MLXLMCommon
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+final class Spec028PlumbingTests: XCTestCase {
+    func testDraftConfigDefaultsAreDisabledAndInert() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [:],
+            fileExists: { _ in false },
+            readFile: { _ in "" }
+        )
+
+        XCTAssertNil(config.draftModel)
+        XCTAssertNil(config.draftModelArtifactSHA256)
+        XCTAssertEqual(config.numDraftTokens, 3)
+        XCTAssertFalse(config.publishesSpecDecodeTelemetry)
+    }
+
+    func testDraftConfigCLIOverridesEnvironmentOverridesYAML() throws {
+        let cliHash = String(repeating: "a", count: 64)
+        let envHash = String(repeating: "b", count: 64)
+        let yamlHash = String(repeating: "c", count: 64)
+
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(
+                draftModel: "/models/cli-draft",
+                draftModelArtifactSHA256: cliHash,
+                numDraftTokens: 7,
+                publishesSpecDecodeTelemetry: false
+            ),
+            environment: [
+                "MACPROVIDER_DRAFT_MODEL": "/models/env-draft",
+                "MACPROVIDER_DRAFT_MODEL_ARTIFACT_SHA256": envHash,
+                "MACPROVIDER_NUM_DRAFT_TOKENS": "5",
+                "MACPROVIDER_PUBLISHES_SPEC_DECODE_TELEMETRY": "true",
+            ],
+            fileExists: { _ in true },
+            readFile: { _ in
+                """
+                draft_model: /models/yaml-draft
+                draft_model_artifact_sha256: \(yamlHash)
+                num_draft_tokens: 3
+                publishes_spec_decode_telemetry: true
+                """
+            }
+        )
+
+        XCTAssertEqual(config.draftModel, "/models/cli-draft")
+        XCTAssertEqual(config.draftModelArtifactSHA256, cliHash)
+        XCTAssertEqual(config.numDraftTokens, 7)
+        XCTAssertFalse(config.publishesSpecDecodeTelemetry)
+    }
+
+    func testDraftConfigEnvironmentOverridesYAML() throws {
+        let envHash = String(repeating: "d", count: 64)
+        let yamlHash = String(repeating: "e", count: 64)
+
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [
+                "MACPROVIDER_DRAFT_MODEL": "/models/env-draft",
+                "MACPROVIDER_DRAFT_MODEL_ARTIFACT_SHA256": envHash,
+                "MACPROVIDER_NUM_DRAFT_TOKENS": "4",
+                "MACPROVIDER_PUBLISHES_SPEC_DECODE_TELEMETRY": "true",
+            ],
+            fileExists: { _ in true },
+            readFile: { _ in
+                """
+                draft_model: /models/yaml-draft
+                draft_model_artifact_sha256: \(yamlHash)
+                num_draft_tokens: 2
+                publishes_spec_decode_telemetry: false
+                """
+            }
+        )
+
+        XCTAssertEqual(config.draftModel, "/models/env-draft")
+        XCTAssertEqual(config.draftModelArtifactSHA256, envHash)
+        XCTAssertEqual(config.numDraftTokens, 4)
+        XCTAssertTrue(config.publishesSpecDecodeTelemetry)
+    }
+
+    func testServeDraftFlagsParse() throws {
+        let hash = String(repeating: "f", count: 64)
+        let command = try ServeCommand.parse([
+            "--draft-model", "/models/draft",
+            "--draft-model-artifact-sha256", hash,
+            "--num-draft-tokens", "6",
+            "--publish-spec-decode-telemetry",
+            "--model", "target",
+        ])
+
+        XCTAssertEqual(command.draftModel, "/models/draft")
+        XCTAssertEqual(command.draftModelArtifactSha256, hash)
+        XCTAssertEqual(command.numDraftTokens, 6)
+        XCTAssertEqual(command.publishSpecDecodeTelemetry, true)
+    }
+
+    func testNumDraftTokensPreflightRejectsOutOfRangeValues() throws {
+        for value in [0, -1, 17] {
+            var config = AppConfig.defaults()
+            config.numDraftTokens = value
+            XCTAssertThrowsError(try ServeCommand.runServingKnobsPreflight(config), "value=\(value)")
+        }
+    }
+
+    func testTelemetryPublishFlagFailsLoudUntilHeartbeatPR() throws {
+        var config = AppConfig.defaults()
+        config.publishesSpecDecodeTelemetry = true
+
+        XCTAssertThrowsError(try ServeCommand.runServingKnobsPreflight(config))
+    }
+
+    func testDraftCapacityHelpersMatchSpec028Tiers() {
+        XCTAssertEqual(ProviderCapacity.defaultContextTokens(forPhysicalMemoryGB: 8), 20_000)
+        XCTAssertEqual(ProviderCapacity.defaultContextTokens(forPhysicalMemoryGB: 16), 50_000)
+        XCTAssertEqual(ProviderCapacity.defaultContextTokens(forPhysicalMemoryGB: 32), 120_000)
+        XCTAssertEqual(ProviderCapacity.defaultContextTokens(forPhysicalMemoryGB: 64), 200_000)
+
+        XCTAssertEqual(ProviderCapacity.draftContextCap(forPhysicalMemoryGB: 8), 8_192)
+        XCTAssertEqual(ProviderCapacity.draftContextCap(forPhysicalMemoryGB: 16), 20_000)
+        XCTAssertEqual(ProviderCapacity.draftContextCap(forPhysicalMemoryGB: 32), 50_000)
+        XCTAssertEqual(ProviderCapacity.draftContextCap(forPhysicalMemoryGB: 64), 120_000)
+    }
+
+    func testDraftCapacityPreflightRejectsExplicitConcurrentBatchAboveOne() throws {
+        var config = AppConfig.defaults()
+        config.draftModel = "/models/draft"
+        config.maxConcurrencyOverride = 2
+
+        XCTAssertThrowsError(try ServeCommand.runSpecDecodeCapacityPreflight(&config))
+    }
+
+    func testDraftCapacityPreflightDownshiftsImplicitContextAndBatch() throws {
+        var config = AppConfig.defaults()
+        config.draftModel = "/models/draft"
+
+        XCTAssertNoThrow(try ServeCommand.runSpecDecodeCapacityPreflight(&config))
+        XCTAssertEqual(config.maxContextOverride, ProviderCapacity.draftContextCapForCurrentHost())
+        XCTAssertEqual(config.maxConcurrencyOverride, 1)
+    }
+
+    func testDraftCapacityPreflightLeavesDisabledConfigUnchanged() throws {
+        var config = AppConfig.defaults()
+        config.maxContextOverride = nil
+        config.maxConcurrencyOverride = nil
+
+        XCTAssertNoThrow(try ServeCommand.runSpecDecodeCapacityPreflight(&config))
+        XCTAssertNil(config.maxContextOverride)
+        XCTAssertNil(config.maxConcurrencyOverride)
+    }
+
+    func testDraftArtifactPreflightRequiresHashForCoordinatorJoin() throws {
+        var config = AppConfig.defaults()
+        config.draftModel = "/models/draft"
+
+        XCTAssertThrowsError(try ServeCommand.runDraftModelArtifactPreflight(config, joiningCoordinator: true))
+    }
+
+    func testDraftArtifactPreflightAcceptsVerifiedLocalSnapshotForNoJoinSmoke() throws {
+        let snapshot = try makeSnapshot()
+        var config = AppConfig.defaults()
+        config.draftModel = snapshot.path
+        config.draftModelArtifactSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+
+        let verifiedPath = try ServeCommand.runDraftModelArtifactPreflight(config, joiningCoordinator: false)
+        XCTAssertEqual(verifiedPath, snapshot.standardizedFileURL.path)
+    }
+
+    func testDraftArtifactPreflightReturnsUnverifiedPathOnlyForLocalSmoke() throws {
+        var config = AppConfig.defaults()
+        config.draftModel = "/models/local-smoke"
+
+        let loadPath = try ServeCommand.runDraftModelArtifactPreflight(config, joiningCoordinator: false)
+        XCTAssertEqual(loadPath, "/models/local-smoke")
+    }
+
+    func testTokenizerArtifactFingerprintBindsTokenizerFiles() throws {
+        let first = try makeTokenizerSnapshot(tokenizerJSON: #"{"model":"same"}"#, configJSON: #"{"eos_token":"</s>"}"#)
+        let matching = try makeTokenizerSnapshot(tokenizerJSON: #"{"model":"same"}"#, configJSON: #"{"eos_token":"</s>"}"#)
+        let divergent = try makeTokenizerSnapshot(tokenizerJSON: #"{"model":"different"}"#, configJSON: #"{"eos_token":"</s>"}"#)
+        let empty = FileManager.default.temporaryDirectory
+            .appendingPathComponent("spec028-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
+
+        XCTAssertEqual(
+            try ModelRuntime.tokenizerArtifactFingerprint(in: first),
+            try ModelRuntime.tokenizerArtifactFingerprint(in: matching)
+        )
+        XCTAssertNotEqual(
+            try ModelRuntime.tokenizerArtifactFingerprint(in: first),
+            try ModelRuntime.tokenizerArtifactFingerprint(in: divergent)
+        )
+        XCTAssertNil(try ModelRuntime.tokenizerArtifactFingerprint(in: empty))
+    }
+
+    func testTokenizerCompatibilityDetectsMismatchedDraftTokenizer() {
+        let target = FixedTokenizer(eosToken: "<eos>", unknownToken: "<unk>")
+        let matching = FixedTokenizer(eosToken: "<eos>", unknownToken: "<unk>")
+        let mismatchedSpecial = FixedTokenizer(eosToken: "</s>", unknownToken: "<unk>")
+        let mismatchedEncoding = FixedTokenizer(
+            eosToken: "<eos>",
+            unknownToken: "<unk>",
+            overrides: ["hello|true": [42]]
+        )
+
+        XCTAssertTrue(ModelRuntime.tokenizersAreCompatible(targetTokenizer: target, draftTokenizer: matching))
+        XCTAssertFalse(ModelRuntime.tokenizersAreCompatible(targetTokenizer: target, draftTokenizer: mismatchedSpecial))
+        XCTAssertFalse(ModelRuntime.tokenizersAreCompatible(targetTokenizer: target, draftTokenizer: mismatchedEncoding))
+    }
+
+    func testSpeculativeEquivalenceRequiresExactTokenIDs() throws {
+        XCTAssertNoThrow(try ModelRuntime.validateSpeculativeEquivalence(plain: [1, 2, 3], speculative: [1, 2, 3]))
+        XCTAssertThrowsError(try ModelRuntime.validateSpeculativeEquivalence(plain: [1, 2, 3], speculative: [1, 9, 3])) { error in
+            XCTAssertEqual(String(describing: error), "draft_model_equivalence_failed")
+        }
+    }
+
+    func testDraftRuntimeTestInitializerStoresOnlyConfiguredDraftModel() async {
+        let disabled = ModelRuntime(
+            modelID: "target",
+            warmSwapEnabled: false,
+            loader: { _ in throw ModelRuntimeLoadError(target: "unused") }
+        )
+        let disabledDraftModelID = await disabled.draftModelIDForTest()
+        let disabledNumDraftTokens = await disabled.numDraftTokensForTest()
+        XCTAssertNil(disabledDraftModelID)
+        XCTAssertEqual(disabledNumDraftTokens, 3)
+
+        let enabled = ModelRuntime(
+            modelID: "target",
+            draftModelID: "draft",
+            numDraftTokens: 5,
+            warmSwapEnabled: false,
+            loader: { _ in throw ModelRuntimeLoadError(target: "unused") }
+        )
+        let enabledDraftModelID = await enabled.draftModelIDForTest()
+        let enabledNumDraftTokens = await enabled.numDraftTokensForTest()
+        let enabledSnapshot = await enabled.currentSnapshot()
+        XCTAssertEqual(enabledDraftModelID, "draft")
+        XCTAssertEqual(enabledNumDraftTokens, 5)
+        XCTAssertEqual(enabledSnapshot.draftModelID, "draft")
+        XCTAssertNil(enabledSnapshot.draftContainer)
+        XCTAssertEqual(enabledSnapshot.numDraftTokens, 5)
+    }
+
+    func testSupportedModelsDoesNotIncludeDraftModel() async throws {
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = "target-model"
+        config.draftModel = "draft-model"
+        config.supportedModels = nil
+        config.publishesSupportedModels = false
+        let status = ProviderStatus(
+            modelID: "target-model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            sleepAssertionFactory: { nil }
+        ))
+
+        let auth = await client.authInitialMessage(attempt: Tier2AuthAttempt())
+        let supported = try XCTUnwrap(auth["supported_models"] as? [String])
+        XCTAssertEqual(supported, ["target-model"])
+        XCTAssertFalse(supported.contains("draft-model"))
+    }
+
+    func testSpec028FixturesArePinnedAndParse() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/spec028")
+
+        let equivalence = try jsonObject(root.appendingPathComponent("equivalence-smoke-v1.json"))
+        XCTAssertEqual(equivalence["fixture_id"] as? String, "spec028-equivalence-smoke-v1")
+        XCTAssertNotNil(equivalence["messages"] as? [[String: Any]])
+        XCTAssertEqual(equivalence["temperature"] as? Int, 0)
+        XCTAssertEqual(equivalence["stream"] as? Bool, false)
+
+        let shortChat = try jsonObject(root.appendingPathComponent("small-air-short-chat.json"))
+        XCTAssertEqual(shortChat["target_model"] as? String, "mlx-community/Llama-3.2-3B-Instruct-4bit")
+        XCTAssertEqual(shortChat["draft_model"] as? String, "mlx-community/Llama-3.2-1B-Instruct-4bit")
+
+        let streaming = try jsonObject(root.appendingPathComponent("small-air-streaming-check.json"))
+        let request = try XCTUnwrap(streaming["request"] as? [String: Any])
+        XCTAssertEqual(request["stream"] as? Bool, true)
+    }
+
+    func testSmallAirLlama32CanaryWhenExplicitlyEnabled() async throws {
+        guard ProcessInfo.processInfo.environment["SPEC028_RUN_SMALL_AIR_CANARY"] == "1" else {
+            throw XCTSkip("Set SPEC028_RUN_SMALL_AIR_CANARY=1 on an M1 8 GB host with local Llama 3.2 3B/1B snapshots to run AC-11.")
+        }
+        let memoryGB = Int((ProcessInfo.processInfo.physicalMemory + 1_073_741_823) / 1_073_741_824)
+        guard memoryGB <= 12 else {
+            throw XCTSkip("AC-11 is scoped to M1 8 GB; host reports \(memoryGB) GB.")
+        }
+
+        let target = ProcessInfo.processInfo.environment["SPEC028_SMALL_AIR_TARGET_PATH"] ?? "mlx-community/Llama-3.2-3B-Instruct-4bit"
+        let draft = ProcessInfo.processInfo.environment["SPEC028_SMALL_AIR_DRAFT_PATH"] ?? "mlx-community/Llama-3.2-1B-Instruct-4bit"
+        let runtime = try await ModelRuntime(
+            modelID: "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            modelLoadPath: target,
+            draftModelID: "mlx-community/Llama-3.2-1B-Instruct-4bit",
+            draftModelLoadPath: draft,
+            numDraftTokens: 3,
+            maxContextTokensOverride: 8_192,
+            maxBatch: 1,
+            warmSwapEnabled: false
+        )
+
+        let shortChat = try requestFixture("small-air-short-chat.json", model: "mlx-community/Llama-3.2-3B-Instruct-4bit")
+        let completion = try await runtime.complete(shortChat)
+        XCTAssertGreaterThan(completion.completionTokens, 0)
+
+        let streaming = try requestFixture("small-air-streaming-check.json", model: "mlx-community/Llama-3.2-3B-Instruct-4bit")
+        let handle = try await runtime.acquireRequestHandle(streaming)
+        let chunkCounter = LockedCounter()
+        do {
+            let streamCompletion = try await runtime.stream(streaming, with: handle, onChunk: { _ in
+                chunkCounter.increment()
+            })
+            await runtime.unregisterInFlight(handle.registrationID)
+            XCTAssertGreaterThan(streamCompletion.completionTokens, 0)
+        } catch {
+            await runtime.unregisterInFlight(handle.registrationID)
+            throw error
+        }
+        XCTAssertGreaterThan(chunkCounter.value, 0)
+    }
+
+    private struct FixedTokenizer: MLXLMCommon.Tokenizer {
+        let bosToken: String? = "<bos>"
+        let eosToken: String?
+        let unknownToken: String?
+        let overrides: [String: [Int]]
+
+        init(eosToken: String?, unknownToken: String?, overrides: [String: [Int]] = [:]) {
+            self.eosToken = eosToken
+            self.unknownToken = unknownToken
+            self.overrides = overrides
+        }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            if let override = overrides["\(text)|\(addSpecialTokens)"] {
+                return override
+            }
+            let base = text.utf8.map(Int.init)
+            return addSpecialTokens ? [1] + base + [2] : base
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map(String.init).joined(separator: ",")
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            if token == bosToken { return 1 }
+            if token == eosToken { return 2 }
+            if token == unknownToken { return 0 }
+            return nil
+        }
+
+        func convertIdToToken(_ id: Int) -> String? {
+            switch id {
+            case 1: bosToken
+            case 2: eosToken
+            case 0: unknownToken
+            default: String(id)
+            }
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            encode(text: "\(messages)", addSpecialTokens: true)
+        }
+    }
+
+    private final class LockedCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        var value: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return count
+        }
+
+        func increment() {
+            lock.lock()
+            count += 1
+            lock.unlock()
+        }
+    }
+
+    private func makeSnapshot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("spec028-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: root.appendingPathComponent("model.safetensors"))
+        try Data("{}".utf8).write(to: root.appendingPathComponent("config.json"))
+        return root
+    }
+
+    private func makeTokenizerSnapshot(tokenizerJSON: String, configJSON: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("spec028-tokenizer-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data(tokenizerJSON.utf8).write(to: root.appendingPathComponent("tokenizer.json"))
+        try Data(configJSON.utf8).write(to: root.appendingPathComponent("tokenizer_config.json"))
+        return root
+    }
+
+    private func jsonObject(_ url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func requestFixture(_ name: String, model: String) throws -> ChatCompletionRequest {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/spec028")
+        let wrapper = try jsonObject(root.appendingPathComponent(name))
+        var request = try XCTUnwrap(wrapper["request"] as? [String: Any])
+        request["model"] = model
+        let data = try JSONSerialization.data(withJSONObject: request)
+        return try ChatCompletionRequest.parse(data: data)
+    }
+}


### PR DESCRIPTION
## Summary

Implements SPEC-028 PR-A plumbing for speculative decoding in the phase3 binary:

- Adds YAML/env/CLI config for `draft_model`, `draft_model_artifact_sha256`, `num_draft_tokens`, and the PR-B-gated telemetry publish flag.
- Loads target and draft containers at startup when draft mode is configured, verifies the draft artifact before runtime handoff, checks tokenizer artifact/behavior compatibility, runs a speculative startup probe, and runs a pinned plain-vs-spec token-ID equivalence canary.
- Refreshes draft-mode provider capacity headroom by downshifting implicit context/batch caps and rejecting explicit over-cap settings.
- Keeps request-path generation byte-identical when draft mode is disabled; speculative `generateTokens(... draftModel ...)` is confined to startup probe/canary in PR-A.
- Preserves receipt usage invariants and keeps `supported_models[]` target-only.
- Adds pinned SPEC-028 fixtures and an env-gated M1 8 GB Llama-3.2-3B+1B canary.

## Validation

- `git diff --check`
- `swift test --filter Spec028PlumbingTests`
- `swift test --filter ReceiptBuilderTests/testBuildSettlementSignsStrictV04Tuple`
- `swift test --filter ServingKnobsConfigTests`
- `swift test --filter CoordinatorClientTests/testAuthInitialDefaultsToSingleEntryCatalog`
- `swift test` after rebasing onto current `origin/main`: 871 tests, 8 skipped, 0 failures

## BUILD audit

Three-lane Codex BUILD audit loop completed after fixes:

- CODE C/H/M: 0/0/0
- SECURITY C/H/M: 0/0/0
- ARCH C/H/M: 0/0/0

## Known validation gap

The AC-11 live canary is checked in and pinned, but was not executed locally because this host is Apple M5 with 32 GB RAM, not an M1 8 GB machine with local Llama-3.2-3B+1B snapshots. It runs only with `SPEC028_RUN_SMALL_AIR_CANARY=1` on the target hardware.
