### PR TITLE
chore(release): bump binaryVersion to 1.8.4

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.3"
+    static let binaryVersion = "1.8.4"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1481,10 +1481,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.3")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.3")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.3")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.3")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.4")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.4")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.4")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.4")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {


### PR DESCRIPTION
## Summary

- Bump `CoordinatorClient.binaryVersion` 1.8.3 → 1.8.4
- Update `CoordinatorClientTests.swift` fixtures to match

Cadence bump for smoke re-run of #396 (autotune process timeout 30s → 7260s / 2h1m). v1.8.4 prerelease is the first `.pkg` containing the timeout fix.

## Deferred to follow-up

`phase4-coordinator/dist/coordinator.yaml` `latest_binary_version` stays at 1.8.3 until v1.8.4 prerelease validation confirms `.live` on fresh install.

## Test plan

- [ ] CI passes
- [ ] Post-merge: dispatch v1.8.4 prerelease
- [ ] Post-merge: clean-slate install v1.8.4 on this Mac, verify Malibu.app reaches `.live` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)