### PR TITLE
feat(gateway): OAuth return_to handoff for Malibu console sign-in

### DIFF
--- a/phase5-gateway/cmd/gateway/main.go
+++ b/phase5-gateway/cmd/gateway/main.go
@@ -196,18 +196,29 @@ type reservationReaper interface {
 
 type oauthStatePruner interface {
 	PruneExpiredOAuthState(context.Context, time.Time) (int64, error)
+	PruneExpiredOAuthHandoffs(context.Context, time.Time) (int64, error)
 }
 
+// runOAuthStatePruner deletes expired oauth_states AND expired oauth_handoffs
+// rows on a fixed cadence. Both tables are populated by /auth/github/*
+// traffic and grow unbounded without this loop; handoffs additionally hold
+// the recently-minted API key until consumed, so timely cleanup limits how
+// long an unclaimed key sits in the DB after its 5-minute validity window.
 func runOAuthStatePruner(ctx context.Context, store oauthStatePruner, interval time.Duration) {
 	if interval <= 0 {
 		interval = time.Minute
 	}
 	prune := func() {
-		deleted, err := store.PruneExpiredOAuthState(ctx, time.Now().UTC())
-		if err != nil {
+		now := time.Now().UTC()
+		if deleted, err := store.PruneExpiredOAuthState(ctx, now); err != nil {
 			slog.Warn("oauth state prune failed", "error", err)
 		} else if deleted > 0 {
 			slog.Info("expired oauth states pruned", "count", deleted)
+		}
+		if deleted, err := store.PruneExpiredOAuthHandoffs(ctx, now); err != nil {
+			slog.Warn("oauth handoff prune failed", "error", err)
+		} else if deleted > 0 {
+			slog.Info("expired oauth handoffs pruned", "count", deleted)
 		}
 	}
 	prune()

--- a/phase5-gateway/cmd/gateway/main_test.go
+++ b/phase5-gateway/cmd/gateway/main_test.go
@@ -36,21 +36,31 @@ func (f *fakeSettlementReconciler) ReconcileSettlementHolds(ctx context.Context,
 }
 
 type fakeOAuthPruner struct {
-	calls chan time.Time
+	stateCalls   chan time.Time
+	handoffCalls chan time.Time
 }
 
 func (f *fakeOAuthPruner) PruneExpiredOAuthState(ctx context.Context, now time.Time) (int64, error) {
 	select {
 	case <-ctx.Done():
 		return 0, ctx.Err()
-	case f.calls <- now:
+	case f.stateCalls <- now:
+		return 1, nil
+	}
+}
+
+func (f *fakeOAuthPruner) PruneExpiredOAuthHandoffs(ctx context.Context, now time.Time) (int64, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case f.handoffCalls <- now:
 		return 1, nil
 	}
 }
 
 func TestRunOAuthStatePrunerRunsAndStops(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	fake := &fakeOAuthPruner{calls: make(chan time.Time, 2)}
+	fake := &fakeOAuthPruner{stateCalls: make(chan time.Time, 2), handoffCalls: make(chan time.Time, 2)}
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -58,9 +68,14 @@ func TestRunOAuthStatePrunerRunsAndStops(t *testing.T) {
 	}()
 
 	select {
-	case <-fake.calls:
+	case <-fake.stateCalls:
 	case <-time.After(time.Second):
 		t.Fatal("oauth state pruner did not run immediately")
+	}
+	select {
+	case <-fake.handoffCalls:
+	case <-time.After(time.Second):
+		t.Fatal("oauth handoff pruner did not run immediately")
 	}
 
 	cancel()

--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -43,6 +43,11 @@ auth:
     callback_allowlist:
       - https://api.streamvc.live/auth/github/callback
       - http://localhost:9443/auth/github/callback
+    return_to_allowlist:
+      - https://malibu.tech/console/auth/callback.html
+      - https://www.malibu.tech/console/auth/callback.html
+      - http://127.0.0.1:5173/console/auth/callback.html
+      - http://localhost:5173/console/auth/callback.html
     github:
       client_id: env:GITHUB_OAUTH_CLIENT_ID
       client_secret: env:GITHUB_OAUTH_CLIENT_SECRET
@@ -122,3 +127,7 @@ cors:
   allowed_origins:
     - https://console.streamvc.live
     - https://streamvc.live
+    - https://malibu.tech
+    - https://www.malibu.tech
+    - http://127.0.0.1:5173
+    - http://localhost:5173

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -77,6 +77,7 @@ type AuthConfig struct {
 
 type OAuthConfig struct {
 	CallbackAllowlist []string          `yaml:"callback_allowlist"`
+	ReturnToAllowlist []string          `yaml:"return_to_allowlist"`
 	StateMaxPerIP     int               `yaml:"state_max_per_ip"`
 	GitHub            GitHubOAuthConfig `yaml:"github"`
 }
@@ -357,6 +358,11 @@ func (c Config) Validate() error {
 	}
 	for i, callback := range c.Auth.OAuth.CallbackAllowlist {
 		if err := requireURL(fmt.Sprintf("auth.oauth.callback_allowlist[%d]", i), callback); err != nil {
+			return err
+		}
+	}
+	for i, returnTo := range c.Auth.OAuth.ReturnToAllowlist {
+		if err := requireURL(fmt.Sprintf("auth.oauth.return_to_allowlist[%d]", i), returnTo); err != nil {
 			return err
 		}
 	}

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -451,6 +451,7 @@ func (c Config) Validate() error {
 	if c.Retry503.BackoffMaxMs < c.Retry503.BackoffBaseMs {
 		return fmt.Errorf("retry_503.backoff_max_ms must be >= retry_503.backoff_base_ms")
 	}
+	corsOrigins := make(map[string]struct{}, len(c.CORS.AllowedOrigins))
 	for i, origin := range c.CORS.AllowedOrigins {
 		if origin == "*" || origin == "null" {
 			return fmt.Errorf("cors.allowed_origins[%d] must not be wildcard or null", i)
@@ -458,6 +459,22 @@ func (c Config) Validate() error {
 		u, err := url.Parse(origin)
 		if err != nil || u.Scheme == "" || u.Host == "" || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
 			return fmt.Errorf("cors.allowed_origins[%d] must be an exact origin", i)
+		}
+		corsOrigins[strings.ToLower(u.Scheme)+"://"+strings.ToLower(u.Host)] = struct{}{}
+	}
+	// Every return_to allowlist entry must have a matching CORS origin,
+	// otherwise the browser-side POST /auth/handoff/exchange call from the
+	// return-to page's origin fails CORS after the OAuth redirect succeeds,
+	// leaving the user on the return-to page with no API key and no
+	// operator-visible signal beyond a browser console error.
+	for i, returnTo := range c.Auth.OAuth.ReturnToAllowlist {
+		u, err := url.Parse(returnTo)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			continue // requireURL above already covered this.
+		}
+		origin := strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host)
+		if _, ok := corsOrigins[origin]; !ok {
+			return fmt.Errorf("auth.oauth.return_to_allowlist[%d] origin %q missing matching cors.allowed_origins entry", i, origin)
 		}
 	}
 	return nil

--- a/phase5-gateway/internal/router/oauth.go
+++ b/phase5-gateway/internal/router/oauth.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -42,6 +43,11 @@ func (s *Server) handleGitHubStart(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "oauth_action_unknown", "Unknown OAuth action")
 		return
 	}
+	returnTo := strings.TrimSpace(r.URL.Query().Get("return_to"))
+	if returnTo != "" && !s.returnToAllowed(returnTo) {
+		writeError(w, http.StatusBadRequest, "invalid_request_error", "oauth_return_to_not_allowed", "OAuth return URL is not allowed")
+		return
+	}
 	state, err := auth.StateToken()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "state_generation_failed", "Could not start OAuth flow")
@@ -55,7 +61,7 @@ func (s *Server) handleGitHubStart(w http.ResponseWriter, r *http.Request) {
 	now := s.now()
 	if err := s.store.StoreOAuthStateWithCap(r.Context(), storage.OAuthState{
 		StateHash: auth.StateHash(state), SessionID: sessionID, RedirectURI: redirectURI,
-		ClientIP: s.clientIP(r), Action: action, CreatedAt: now, ExpiresAt: auth.OAuthStateExpiry(now),
+		ReturnTo: returnTo, ClientIP: s.clientIP(r), Action: action, CreatedAt: now, ExpiresAt: auth.OAuthStateExpiry(now),
 	}, s.cfg.Auth.OAuth.StateMaxPerIP, now); err != nil {
 		if errors.Is(err, storage.ErrOAuthStateCap) {
 			writeError(w, http.StatusTooManyRequests, "rate_limit_exceeded", "oauth_state_rate_limited", "OAuth start limit exceeded")
@@ -91,7 +97,7 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 	// returns the action bound to it at /auth/github/start time. Action lives
 	// in the state row exactly so it is single-use and impossible to leak
 	// across browser tabs, stale cookies, or early callback failures.
-	redirectURI, action, err := s.store.ConsumeOAuthState(r.Context(), auth.StateHash(state), cookie.Value, s.now())
+	redirectURI, action, returnTo, err := s.store.ConsumeOAuthState(r.Context(), auth.StateHash(state), cookie.Value, s.now())
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "oauth_state_invalid", "OAuth state is invalid")
 		return
@@ -114,18 +120,18 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var fullKey string
 	account, err := s.store.LookupAccountByIdentity(r.Context(), "github", identity.ProviderUserID)
 	if errors.Is(err, storage.ErrNotFound) {
 		account, err = s.createSignupAccount(w, r.Context(), r, identity)
 		if err != nil {
 			return
 		}
-		fullKey, _, err := s.keyMgr.Issue(r.Context(), s.store, account.AccountID)
+		fullKey, _, err = s.keyMgr.Issue(r.Context(), s.store, account.AccountID)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "server_error", "api_key_issuance_failed", "Could not issue API key")
 			return
 		}
-		http.SetCookie(w, &http.Cookie{Name: "mp_new_api_key", Value: fullKey, Path: "/account", HttpOnly: true, Secure: s.secureCookies(), SameSite: http.SameSiteLaxMode, MaxAge: 300})
 	} else if err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "account_lookup_failed", "Could not load account")
 		return
@@ -136,15 +142,12 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 		// can revoke older keys via POST /auth/api-keys/{key_id}/revoke once
 		// they have a working bearer. Re-issuing (not rotating) preserves
 		// any other still-in-use keys the operator has elsewhere.
-		fullKey, summary, err := s.keyMgr.Issue(r.Context(), s.store, account.AccountID)
+		var summary storage.APIKey
+		fullKey, summary, err = s.keyMgr.Issue(r.Context(), s.store, account.AccountID)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "server_error", "api_key_issuance_failed", "Could not issue API key")
 			return
 		}
-		http.SetCookie(w, &http.Cookie{
-			Name: "mp_new_api_key", Value: fullKey, Path: "/account", HttpOnly: true,
-			Secure: s.secureCookies(), SameSite: http.SameSiteLaxMode, MaxAge: 300,
-		})
 		// Audit payload includes key_id and key_prefix so the lifecycle of
 		// each minted key is traceable end-to-end alongside the revoke/rotate
 		// events in api_key_events. account_id is in Actor; the action label
@@ -157,7 +160,49 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 			CreatedAt: s.now(),
 		})
 	}
+	if returnTo != "" {
+		if fullKey == "" {
+			s.redirectOAuthReturn(w, r, returnTo, "no_key")
+			return
+		}
+		if err := s.redirectOAuthHandoff(r.Context(), w, r, returnTo, fullKey); err != nil {
+			s.redirectOAuthReturn(w, r, returnTo, "handoff_failed")
+		}
+		return
+	}
+	if fullKey != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name: "mp_new_api_key", Value: fullKey, Path: "/account", HttpOnly: true,
+			Secure: s.secureCookies(), SameSite: http.SameSiteLaxMode, MaxAge: 300,
+		})
+	}
 	http.Redirect(w, r, s.cfg.Public.AccountPath, http.StatusFound)
+}
+
+func (s *Server) handleHandoffExchange(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method_not_allowed", "Method not allowed")
+		return
+	}
+	var req struct {
+		Handoff string `json:"handoff"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_handoff", "Handoff token is invalid")
+		return
+	}
+	req.Handoff = strings.TrimSpace(req.Handoff)
+	if req.Handoff == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_handoff", "Handoff token is invalid")
+		return
+	}
+	apiKey, err := s.store.ConsumeOAuthHandoff(r.Context(), auth.StateHash(req.Handoff), s.now())
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_handoff", "Handoff token is invalid")
+		return
+	}
+	setNoStoreHeaders(w.Header())
+	writeJSON(w, http.StatusOK, map[string]any{"api_key": apiKey})
 }
 
 func (s *Server) createSignupAccount(w http.ResponseWriter, ctx context.Context, r *http.Request, identity auth.OAuthIdentity) (storage.Account, error) {
@@ -289,6 +334,64 @@ func (s *Server) callbackAllowed(callback string) bool {
 	for _, allowed := range s.cfg.Auth.OAuth.CallbackAllowlist {
 		if callback == allowed {
 			return true
+		}
+	}
+	return false
+}
+
+func (s *Server) redirectOAuthHandoff(ctx context.Context, w http.ResponseWriter, r *http.Request, returnTo, apiKey string) error {
+	token, err := auth.StateToken()
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	if err := s.store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
+		TokenHash: auth.StateHash(token),
+		APIKey:    apiKey,
+		CreatedAt: now,
+		ExpiresAt: now.Add(5 * time.Minute),
+	}); err != nil {
+		return err
+	}
+	target, err := url.Parse(returnTo)
+	if err != nil {
+		return err
+	}
+	values := target.Query()
+	values.Set("handoff", token)
+	target.RawQuery = values.Encode()
+	http.Redirect(w, r, target.String(), http.StatusFound)
+	return nil
+}
+
+func (s *Server) redirectOAuthReturn(w http.ResponseWriter, r *http.Request, returnTo, errCode string) {
+	target, err := url.Parse(returnTo)
+	if err != nil {
+		http.Redirect(w, r, s.cfg.Public.AccountPath, http.StatusFound)
+		return
+	}
+	if errCode != "" {
+		values := target.Query()
+		values.Set("error", errCode)
+		target.RawQuery = values.Encode()
+	}
+	http.Redirect(w, r, target.String(), http.StatusFound)
+}
+
+func (s *Server) returnToAllowed(returnTo string) bool {
+	target, err := url.Parse(returnTo)
+	if err != nil || target.Scheme == "" || target.Host == "" {
+		return false
+	}
+	for _, allowed := range s.cfg.Auth.OAuth.ReturnToAllowlist {
+		u, err := url.Parse(allowed)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			continue
+		}
+		if strings.EqualFold(target.Scheme, u.Scheme) && strings.EqualFold(target.Host, u.Host) {
+			if u.Path == "" || u.Path == "/" || strings.HasPrefix(target.Path, u.Path) {
+				return true
+			}
 		}
 	}
 	return false

--- a/phase5-gateway/internal/router/oauth.go
+++ b/phase5-gateway/internal/router/oauth.go
@@ -160,21 +160,34 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 			CreatedAt: s.now(),
 		})
 	}
+	// The mp_new_api_key cookie is scoped to the gateway origin's /account
+	// path, so it is not readable by any Malibu return_to page. Setting it
+	// on every fullKey!="" path (not just the legacy /account redirect)
+	// keeps the fallback: if the handoff persistence fails after we have
+	// already consumed the OAuth state and issued the key, the user can
+	// still recover the key by visiting api.streamvc.live/account.
+	if fullKey != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name: "mp_new_api_key", Value: fullKey, Path: "/account", HttpOnly: true,
+			Secure: s.secureCookies(), SameSite: http.SameSiteLaxMode, MaxAge: 300,
+		})
+	}
 	if returnTo != "" {
 		if fullKey == "" {
 			s.redirectOAuthReturn(w, r, returnTo, "no_key")
 			return
 		}
 		if err := s.redirectOAuthHandoff(r.Context(), w, r, returnTo, fullKey); err != nil {
-			s.redirectOAuthReturn(w, r, returnTo, "handoff_failed")
+			// Handoff-token persistence failed AFTER the OAuth state was
+			// consumed and a fresh API key was minted. The Malibu handoff
+			// contract can no longer complete (there is no token to
+			// exchange), so we anchor the recovery UX in the gateway itself:
+			// redirect to /account, which reads the mp_new_api_key cookie
+			// set above and shows the key. This keeps the recovery path
+			// stable regardless of what the paired client does on error.
+			http.Redirect(w, r, s.cfg.Public.AccountPath, http.StatusFound)
 		}
 		return
-	}
-	if fullKey != "" {
-		http.SetCookie(w, &http.Cookie{
-			Name: "mp_new_api_key", Value: fullKey, Path: "/account", HttpOnly: true,
-			Secure: s.secureCookies(), SameSite: http.SameSiteLaxMode, MaxAge: 300,
-		})
 	}
 	http.Redirect(w, r, s.cfg.Public.AccountPath, http.StatusFound)
 }
@@ -360,6 +373,13 @@ func (s *Server) redirectOAuthHandoff(ctx context.Context, w http.ResponseWriter
 	values := target.Query()
 	values.Set("handoff", token)
 	target.RawQuery = values.Encode()
+	// The raw handoff token rides in the redirect URL as a query param, so it
+	// lands in nginx access logs and browser history. Suppress the outbound
+	// referrer from the Malibu callback page so the token does not leak to
+	// third parties Malibu subsequently fetches, and mark the redirect
+	// response as no-store so intermediary proxies do not cache the URL.
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	setNoStoreHeaders(w.Header())
 	http.Redirect(w, r, target.String(), http.StatusFound)
 	return nil
 }
@@ -378,9 +398,25 @@ func (s *Server) redirectOAuthReturn(w http.ResponseWriter, r *http.Request, ret
 	http.Redirect(w, r, target.String(), http.StatusFound)
 }
 
+// returnToAllowed matches a caller-supplied return_to URL against the
+// allowlist. Scheme and Host match case-insensitively. Path semantics:
+//
+//   - Reject any target whose Path contains a "." or ".." segment (before
+//     or after URL-decoding), so `/console/auth/callback.html/../admin`
+//     cannot smuggle a token onto an unintended route on the same host.
+//   - Allowlist path "" or "/" matches any target path on that host.
+//   - Allowlist path with a trailing "/" is an explicit directory prefix
+//     match; the target path must have the allowlist path as a prefix.
+//   - Any other allowlist path requires an exact match — so
+//     `/console/auth/callback.html` does NOT accept
+//     `/console/auth/callback.htmlx` or
+//     `/console/auth/callback.html/other`.
 func (s *Server) returnToAllowed(returnTo string) bool {
 	target, err := url.Parse(returnTo)
 	if err != nil || target.Scheme == "" || target.Host == "" {
+		return false
+	}
+	if hasDotSegment(target.Path) || hasDotSegment(target.EscapedPath()) {
 		return false
 	}
 	for _, allowed := range s.cfg.Auth.OAuth.ReturnToAllowlist {
@@ -388,10 +424,33 @@ func (s *Server) returnToAllowed(returnTo string) bool {
 		if err != nil || u.Scheme == "" || u.Host == "" {
 			continue
 		}
-		if strings.EqualFold(target.Scheme, u.Scheme) && strings.EqualFold(target.Host, u.Host) {
-			if u.Path == "" || u.Path == "/" || strings.HasPrefix(target.Path, u.Path) {
+		if !strings.EqualFold(target.Scheme, u.Scheme) || !strings.EqualFold(target.Host, u.Host) {
+			continue
+		}
+		switch {
+		case u.Path == "" || u.Path == "/":
+			return true
+		case strings.HasSuffix(u.Path, "/"):
+			if strings.HasPrefix(target.Path, u.Path) {
 				return true
 			}
+		default:
+			if target.Path == u.Path {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasDotSegment(p string) bool {
+	for _, seg := range strings.Split(p, "/") {
+		if seg == "." || seg == ".." {
+			return true
+		}
+		lowered := strings.ToLower(seg)
+		if lowered == "%2e" || lowered == "%2e%2e" {
+			return true
 		}
 	}
 	return false

--- a/phase5-gateway/internal/router/oauth_handoff_test.go
+++ b/phase5-gateway/internal/router/oauth_handoff_test.go
@@ -1,0 +1,288 @@
+package router
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-gateway/internal/auth"
+	"github.com/augstar/macprovider-gateway/internal/config"
+	"github.com/augstar/macprovider-gateway/internal/storage"
+	"github.com/augstar/macprovider-gateway/internal/storage/sqlite"
+)
+
+// failingHandoffStore wraps a Store and forces StoreOAuthHandoff to fail.
+// The wrapper is used to pin the recovery UX when handoff persistence
+// breaks after the OAuth state has been consumed and the API key issued —
+// the callback must redirect to the gateway /account page (which reads the
+// mp_new_api_key cookie) so the user can retrieve the newly minted key
+// without depending on the paired client's error-handling behavior.
+type failingHandoffStore struct {
+	Store
+}
+
+func (f *failingHandoffStore) StoreOAuthHandoff(ctx context.Context, handoff storage.OAuthHandoff) error {
+	return errors.New("induced handoff persistence failure")
+}
+
+// withMalibuReturnTo wires the return_to allowlist + CORS entries used by the
+// Malibu handoff tests so the tests exercise the same shape as production.
+func withMalibuReturnTo(cfg *config.Config) {
+	cfg.Auth.OAuth.ReturnToAllowlist = []string{
+		"https://malibu.tech/console/auth/callback.html",
+	}
+	cfg.CORS.AllowedOrigins = append(cfg.CORS.AllowedOrigins, "https://malibu.tech")
+}
+
+func TestReturnToAllowedRejectsPrefixAndTraversal(t *testing.T) {
+	h, _, _, _ := newTestHarnessConfig(t, fakeOAuth{}, withMalibuReturnTo)
+	cases := []struct {
+		name    string
+		target  string
+		allowed bool
+	}{
+		{"exact", "https://malibu.tech/console/auth/callback.html", true},
+		{"case_insensitive_host", "https://MALIBU.TECH/console/auth/callback.html", true},
+		{"scheme_mismatch", "http://malibu.tech/console/auth/callback.html", false},
+		{"host_mismatch", "https://malibu.tech.attacker.example/console/auth/callback.html", false},
+		{"path_extended", "https://malibu.tech/console/auth/callback.html/extra", false},
+		{"path_suffix_pun", "https://malibu.tech/console/auth/callback.htmlx", false},
+		{"path_traversal_literal", "https://malibu.tech/console/auth/callback.html/../admin", false},
+		{"path_traversal_encoded", "https://malibu.tech/console/auth/callback.html/%2E%2E/admin", false},
+		{"empty_scheme", "//malibu.tech/console/auth/callback.html", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/auth/github/start?return_to="+url.QueryEscape(tc.target)+"&redirect_uri="+url.QueryEscape("https://api.streamvc.live/auth/github/callback"), nil)
+			resp := httptest.NewRecorder()
+			h.ServeHTTP(resp, req)
+			if tc.allowed {
+				if resp.Code != http.StatusFound {
+					t.Fatalf("expected 302 for allowed %s, got %d body=%s", tc.target, resp.Code, resp.Body.String())
+				}
+			} else {
+				if resp.Code == http.StatusFound {
+					t.Fatalf("expected rejection for %s, got 302 with Location=%s", tc.target, resp.Header().Get("Location"))
+				}
+				if !strings.Contains(resp.Body.String(), "oauth_return_to_not_allowed") {
+					t.Fatalf("expected oauth_return_to_not_allowed for %s, got body=%s", tc.target, resp.Body.String())
+				}
+			}
+		})
+	}
+}
+
+func TestOAuthHandoffFlowRoundTrip(t *testing.T) {
+	identity := auth.OAuthIdentity{ProviderUserID: "handoff-user", Scopes: []string{"read:user"}}
+	h, _, _, _ := newTestHarnessConfig(t, fakeOAuth{identity: identity}, withMalibuReturnTo)
+	returnTo := "https://malibu.tech/console/auth/callback.html"
+
+	startPath := "/auth/github/start?redirect_uri=" + url.QueryEscape("https://api.streamvc.live/auth/github/callback") + "&return_to=" + url.QueryEscape(returnTo)
+	startReq := httptest.NewRequest(http.MethodGet, startPath, nil)
+	startResp := httptest.NewRecorder()
+	h.ServeHTTP(startResp, startReq)
+	if startResp.Code != http.StatusFound {
+		t.Fatalf("start status=%d body=%s", startResp.Code, startResp.Body.String())
+	}
+	location, err := url.Parse(startResp.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse start location: %v", err)
+	}
+	state := location.Query().Get("state")
+	if state == "" {
+		t.Fatal("state missing from start redirect")
+	}
+
+	callbackReq := httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=ok&state="+url.QueryEscape(state), nil)
+	for _, c := range startResp.Result().Cookies() {
+		callbackReq.AddCookie(c)
+	}
+	callbackResp := httptest.NewRecorder()
+	h.ServeHTTP(callbackResp, callbackReq)
+	if callbackResp.Code != http.StatusFound {
+		t.Fatalf("callback status=%d body=%s", callbackResp.Code, callbackResp.Body.String())
+	}
+	callbackLoc, err := url.Parse(callbackResp.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse callback location: %v", err)
+	}
+	if !strings.EqualFold(callbackLoc.Host, "malibu.tech") || callbackLoc.Path != "/console/auth/callback.html" {
+		t.Fatalf("callback did not redirect to Malibu return_to, got %s", callbackLoc.String())
+	}
+	handoff := callbackLoc.Query().Get("handoff")
+	if handoff == "" {
+		t.Fatalf("callback did not include handoff query, location=%s", callbackLoc.String())
+	}
+	if got := callbackResp.Header().Get("Referrer-Policy"); got != "no-referrer" {
+		t.Fatalf("Referrer-Policy=%q want no-referrer (token leaks via referrer chain otherwise)", got)
+	}
+	if got := callbackResp.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control=%q want no-store", got)
+	}
+	// Fallback cookie is set so /account still works if Malibu is unreachable.
+	if findCookie(callbackResp, "mp_new_api_key") == "" {
+		t.Fatal("mp_new_api_key fallback cookie missing on handoff callback")
+	}
+
+	body, _ := json.Marshal(map[string]string{"handoff": handoff})
+	exchangeReq := httptest.NewRequest(http.MethodPost, "/auth/handoff/exchange", bytes.NewReader(body))
+	exchangeReq.Header.Set("Content-Type", "application/json")
+	exchangeResp := httptest.NewRecorder()
+	h.ServeHTTP(exchangeResp, exchangeReq)
+	if exchangeResp.Code != http.StatusOK {
+		t.Fatalf("exchange status=%d body=%s", exchangeResp.Code, exchangeResp.Body.String())
+	}
+	if got := exchangeResp.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("exchange Cache-Control=%q want no-store", got)
+	}
+	var reply struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal(exchangeResp.Body.Bytes(), &reply); err != nil {
+		t.Fatalf("decode exchange body: %v", err)
+	}
+	if !strings.HasPrefix(reply.APIKey, "mp_") {
+		t.Fatalf("api_key=%q must start with mp_", reply.APIKey)
+	}
+
+	// Replay must fail with the same generic error surface.
+	replayReq := httptest.NewRequest(http.MethodPost, "/auth/handoff/exchange", bytes.NewReader(body))
+	replayReq.Header.Set("Content-Type", "application/json")
+	replayResp := httptest.NewRecorder()
+	h.ServeHTTP(replayResp, replayReq)
+	if replayResp.Code != http.StatusBadRequest {
+		t.Fatalf("replay status=%d want 400 body=%s", replayResp.Code, replayResp.Body.String())
+	}
+	if !strings.Contains(replayResp.Body.String(), "invalid_handoff") {
+		t.Fatalf("replay body=%q want invalid_handoff", replayResp.Body.String())
+	}
+}
+
+// TestOAuthHandoffPersistenceFailureRedirectsToAccount pins the recovery
+// contract when StoreOAuthHandoff fails after the OAuth state is consumed
+// and the API key is minted. The callback must NOT redirect back to
+// Malibu (there is no handoff token to exchange) — it must anchor the
+// recovery UX inside the gateway by redirecting to Public.AccountPath so
+// the pre-set mp_new_api_key cookie can hand the user their key.
+func TestOAuthHandoffPersistenceFailureRedirectsToAccount(t *testing.T) {
+	identity := auth.OAuthIdentity{ProviderUserID: "handoff-fail-user", Scopes: []string{"read:user"}}
+	cfg := config.Default()
+	cfg.Auth.KeyHashSecret = "test-key-hash-secret"
+	cfg.Auth.Demo.SigningSecret = "test-demo-secret"
+	cfg.Auth.OAuth.GitHub.ClientID = "client-id"
+	cfg.Auth.OAuth.GitHub.ClientSecret = "client-secret"
+	cfg.Coordinator.OperatorKey = "operator-key"
+	cfg.Auth.OAuth.CallbackAllowlist = []string{"https://api.streamvc.live/auth/github/callback"}
+	cfg.Storage.DBPath = filepath.Join(t.TempDir(), "gateway.db")
+	withMalibuReturnTo(&cfg)
+
+	realStore, err := sqlite.Open(context.Background(), cfg.Storage.DBPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = realStore.Close() })
+	wrapped := &failingHandoffStore{Store: realStore}
+	h := New(cfg, wrapped, fakeOAuth{identity: identity}, WithNow(fixedNow)).Handler()
+
+	returnTo := "https://malibu.tech/console/auth/callback.html"
+	startPath := "/auth/github/start?redirect_uri=" + url.QueryEscape("https://api.streamvc.live/auth/github/callback") + "&return_to=" + url.QueryEscape(returnTo)
+	startReq := httptest.NewRequest(http.MethodGet, startPath, nil)
+	startResp := httptest.NewRecorder()
+	h.ServeHTTP(startResp, startReq)
+	if startResp.Code != http.StatusFound {
+		t.Fatalf("start status=%d body=%s", startResp.Code, startResp.Body.String())
+	}
+	location, err := url.Parse(startResp.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse start location: %v", err)
+	}
+	state := location.Query().Get("state")
+
+	callbackReq := httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=ok&state="+url.QueryEscape(state), nil)
+	for _, c := range startResp.Result().Cookies() {
+		callbackReq.AddCookie(c)
+	}
+	callbackResp := httptest.NewRecorder()
+	h.ServeHTTP(callbackResp, callbackReq)
+	if callbackResp.Code != http.StatusFound {
+		t.Fatalf("callback status=%d body=%s", callbackResp.Code, callbackResp.Body.String())
+	}
+	if got := callbackResp.Header().Get("Location"); got != cfg.Public.AccountPath {
+		t.Fatalf("failure redirect Location=%q want %q — recovery must anchor to gateway /account, not Malibu", got, cfg.Public.AccountPath)
+	}
+	if findCookie(callbackResp, "mp_new_api_key") == "" {
+		t.Fatal("mp_new_api_key cookie missing on handoff-failure redirect — /account cannot deliver the key without it")
+	}
+}
+
+func TestHandoffExchangeErrorSurface(t *testing.T) {
+	h, _, _, _ := newTestHarnessConfig(t, fakeOAuth{}, withMalibuReturnTo)
+
+	// Wrong method: 405.
+	getReq := httptest.NewRequest(http.MethodGet, "/auth/handoff/exchange", nil)
+	getResp := httptest.NewRecorder()
+	h.ServeHTTP(getResp, getReq)
+	if getResp.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET status=%d want 405", getResp.Code)
+	}
+
+	// Empty body: 400 invalid_handoff.
+	emptyReq := httptest.NewRequest(http.MethodPost, "/auth/handoff/exchange", strings.NewReader(""))
+	emptyResp := httptest.NewRecorder()
+	h.ServeHTTP(emptyResp, emptyReq)
+	if emptyResp.Code != http.StatusBadRequest || !strings.Contains(emptyResp.Body.String(), "invalid_handoff") {
+		t.Fatalf("empty body status=%d body=%s", emptyResp.Code, emptyResp.Body.String())
+	}
+
+	// Unknown token: same error code (no distinguisher).
+	unknownBody, _ := json.Marshal(map[string]string{"handoff": "notatoken"})
+	unknownReq := httptest.NewRequest(http.MethodPost, "/auth/handoff/exchange", bytes.NewReader(unknownBody))
+	unknownReq.Header.Set("Content-Type", "application/json")
+	unknownResp := httptest.NewRecorder()
+	h.ServeHTTP(unknownResp, unknownReq)
+	if unknownResp.Code != http.StatusBadRequest || !strings.Contains(unknownResp.Body.String(), "invalid_handoff") {
+		t.Fatalf("unknown token status=%d body=%s", unknownResp.Code, unknownResp.Body.String())
+	}
+}
+
+// TestReturnToConfigRequiresMatchingCORSOrigin locks in the config-time
+// cross-check between auth.oauth.return_to_allowlist and cors.allowed_origins.
+// Without this, an operator can add a Malibu return-to entry, ship it, and
+// see the OAuth flow silently break on the browser-side exchange.
+func TestReturnToConfigRequiresMatchingCORSOrigin(t *testing.T) {
+	cfg := baselineValidConfig(t)
+	cfg.Auth.OAuth.ReturnToAllowlist = []string{"https://malibu.tech/console/auth/callback.html"}
+	// Deliberately DO NOT add malibu.tech to CORS.AllowedOrigins.
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate must reject a return_to entry without matching CORS origin")
+	}
+	if !strings.Contains(err.Error(), "missing matching cors.allowed_origins") {
+		t.Fatalf("error=%v want missing-cors-origins message", err)
+	}
+
+	cfg.CORS.AllowedOrigins = append(cfg.CORS.AllowedOrigins, "https://malibu.tech")
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate with matching CORS origin failed: %v", err)
+	}
+}
+
+func baselineValidConfig(t *testing.T) config.Config {
+	t.Helper()
+	cfg := config.Default()
+	cfg.Auth.KeyHashSecret = "test-key-hash-secret"
+	cfg.Auth.Demo.SigningSecret = "test-demo-secret"
+	cfg.Auth.OAuth.GitHub.ClientID = "client-id"
+	cfg.Auth.OAuth.GitHub.ClientSecret = "client-secret"
+	cfg.Coordinator.OperatorKey = "operator-key"
+	cfg.Auth.OAuth.CallbackAllowlist = []string{"https://api.streamvc.live/auth/github/callback"}
+	return cfg
+}
+

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -188,6 +188,7 @@ func (s *Server) Handler() http.Handler {
 		mux.HandleFunc("/auth/github/start", s.handleGitHubStart)
 		mux.HandleFunc("/auth/github/callback", s.handleGitHubCallback)
 	}
+	mux.Handle("/auth/handoff/exchange", s.withCORS(http.MethodPost, http.HandlerFunc(s.handleHandoffExchange)))
 	mux.Handle("/auth/demo-session", s.withCORS(http.MethodPost, http.HandlerFunc(s.handleDemoSession)))
 	mux.HandleFunc("/auth/api-keys", s.handleAPIKeys)
 	mux.HandleFunc("/auth/api-keys/", s.handleAPIKeyAction)

--- a/phase5-gateway/internal/storage/interfaces.go
+++ b/phase5-gateway/internal/storage/interfaces.go
@@ -18,7 +18,10 @@ type AuthStore interface {
 	RotateAPIKey(ctx context.Context, oldKeyID, accountID string, newKey APIKey, actor, requestID string) error
 	StoreOAuthState(ctx context.Context, state OAuthState) error
 	StoreOAuthStateWithCap(ctx context.Context, state OAuthState, maxPerIP int, now time.Time) error
-	ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (redirectURI, action string, err error)
+	ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (redirectURI, action, returnTo string, err error)
+	StoreOAuthHandoff(ctx context.Context, handoff OAuthHandoff) error
+	ConsumeOAuthHandoff(ctx context.Context, tokenHash []byte, now time.Time) (apiKey string, err error)
+	PruneExpiredOAuthHandoffs(ctx context.Context, now time.Time) (int64, error)
 	PruneExpiredOAuthState(ctx context.Context, now time.Time) (int64, error)
 	ReservePublicIssuance(ctx context.Context, reservation PublicIssuanceReservation) error
 	RecordSignupEvent(ctx context.Context, event SignupEvent) error
@@ -49,7 +52,10 @@ type KeyStore interface {
 type OAuthStateStore interface {
 	StoreOAuthState(ctx context.Context, state OAuthState) error
 	StoreOAuthStateWithCap(ctx context.Context, state OAuthState, maxPerIP int, now time.Time) error
-	ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (redirectURI, action string, err error)
+	ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (redirectURI, action, returnTo string, err error)
+	StoreOAuthHandoff(ctx context.Context, handoff OAuthHandoff) error
+	ConsumeOAuthHandoff(ctx context.Context, tokenHash []byte, now time.Time) (apiKey string, err error)
+	PruneExpiredOAuthHandoffs(ctx context.Context, now time.Time) (int64, error)
 	PruneExpiredOAuthState(ctx context.Context, now time.Time) (int64, error)
 }
 

--- a/phase5-gateway/internal/storage/sqlite/migrate.go
+++ b/phase5-gateway/internal/storage/sqlite/migrate.go
@@ -136,12 +136,23 @@ CREATE TABLE IF NOT EXISTS oauth_states (
 	state_hash BLOB PRIMARY KEY,
 	session_id TEXT NOT NULL,
 	redirect_uri TEXT NOT NULL,
+	return_to TEXT NOT NULL DEFAULT '',
 	client_ip TEXT NOT NULL,
 	created_at TEXT NOT NULL,
 	expires_at TEXT NOT NULL,
 	consumed_at TEXT NOT NULL DEFAULT '',
 	action TEXT NOT NULL DEFAULT ''
 );
+
+CREATE TABLE IF NOT EXISTS oauth_handoffs (
+	token_hash BLOB PRIMARY KEY,
+	api_key TEXT NOT NULL,
+	created_at TEXT NOT NULL,
+	expires_at TEXT NOT NULL,
+	consumed_at TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_handoffs_expires ON oauth_handoffs(expires_at);
 
 CREATE TABLE IF NOT EXISTS public_issuance_events (
 	event_id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -102,6 +102,7 @@ func (s *Store) Ping(ctx context.Context) error {
 //	     for coordinator-missing ambiguity that must release active quota.
 //	v8 — public issuance reservation events for atomic per-IP signup/demo/
 //	     feedback ceilings.
+//	v9 — oauth return_to + oauth_handoffs support.
 //
 // At Open time the store reads the current applied version; if it
 // exceeds this constant the binary is older than the DB and refuses
@@ -112,7 +113,7 @@ func (s *Store) Ping(ctx context.Context) error {
 // Operators rolling back the gateway binary on a DB at a higher
 // version must restore /var/lib/macprovider/gateway.db from the
 // pre-deploy snapshot (deploy-pearl-vps.sh step 5b writes one).
-const maxKnownSchemaVersion = 8
+const maxKnownSchemaVersion = 9
 
 func (s *Store) Migrate(ctx context.Context) error {
 	if err := s.checkSchemaVersionGate(ctx); err != nil {
@@ -148,6 +149,12 @@ func (s *Store) Migrate(ctx context.Context) error {
 		return err
 	}
 	if err := s.ensureOAuthStateActionColumn(ctx); err != nil {
+		return err
+	}
+	if err := s.ensureOAuthStateReturnToColumn(ctx); err != nil {
+		return err
+	}
+	if err := s.ensureOAuthHandoffsTable(ctx); err != nil {
 		return err
 	}
 	if err := s.ensureUsageEventsCompositePK(ctx); err != nil {
@@ -198,6 +205,9 @@ func (s *Store) Migrate(ctx context.Context) error {
 		return err
 	}
 	if _, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(8, ?)", now); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(9, ?)", now); err != nil {
 		return err
 	}
 	return nil
@@ -302,6 +312,50 @@ func (s *Store) ensureOAuthStateActionColumn(ctx context.Context) error {
 		return nil
 	}
 	_, err = s.db.ExecContext(ctx, `ALTER TABLE oauth_states ADD COLUMN action TEXT NOT NULL DEFAULT ''`)
+	return err
+}
+
+func (s *Store) ensureOAuthStateReturnToColumn(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, `PRAGMA table_info(oauth_states)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	hasReturnTo := false
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		if name == "return_to" {
+			hasReturnTo = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if hasReturnTo {
+		return nil
+	}
+	_, err = s.db.ExecContext(ctx, `ALTER TABLE oauth_states ADD COLUMN return_to TEXT NOT NULL DEFAULT ''`)
+	return err
+}
+
+func (s *Store) ensureOAuthHandoffsTable(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS oauth_handoffs (
+			token_hash BLOB PRIMARY KEY,
+			api_key TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			expires_at TEXT NOT NULL,
+			consumed_at TEXT NOT NULL DEFAULT ''
+		);
+		CREATE INDEX IF NOT EXISTS idx_oauth_handoffs_expires ON oauth_handoffs(expires_at);
+	`)
 	return err
 }
 
@@ -893,44 +947,102 @@ func (s *Store) StoreOAuthStateWithCap(ctx context.Context, state storage.OAuthS
 		}
 	}
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO oauth_states(state_hash, session_id, redirect_uri, client_ip, created_at, expires_at, action)
-		VALUES(?, ?, ?, ?, ?, ?, ?)`,
-		state.StateHash, state.SessionID, state.RedirectURI, state.ClientIP,
-		encodeTime(state.CreatedAt), encodeTime(state.ExpiresAt), state.Action)
+		INSERT INTO oauth_states(state_hash, session_id, redirect_uri, return_to, client_ip, created_at, expires_at, action)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?)`,
+		state.StateHash, state.SessionID, state.RedirectURI, state.ReturnTo,
+		state.ClientIP, encodeTime(state.CreatedAt), encodeTime(state.ExpiresAt), state.Action)
 	if err != nil {
 		return err
 	}
 	return tx.Commit()
 }
 
-func (s *Store) ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (string, string, error) {
+func (s *Store) ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (string, string, string, error) {
 	tx, err := s.beginImmediate(ctx)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	defer tx.Rollback()
 	var redirectURI string
+	var returnTo string
 	var expiresAt string
 	var consumedAt string
 	var action string
 	if err := tx.QueryRowContext(ctx, `
-		SELECT redirect_uri, expires_at, consumed_at, action
+		SELECT redirect_uri, return_to, expires_at, consumed_at, action
 		FROM oauth_states
 		WHERE state_hash = ? AND session_id = ?`,
-		stateHash, sessionID).Scan(&redirectURI, &expiresAt, &consumedAt, &action); err != nil {
+		stateHash, sessionID).Scan(&redirectURI, &returnTo, &expiresAt, &consumedAt, &action); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", "", storage.ErrNotFound
+			return "", "", "", storage.ErrNotFound
 		}
-		return "", "", err
+		return "", "", "", err
 	}
 	if consumedAt != "" || !now.Before(decodeTime(expiresAt)) {
-		return "", "", storage.ErrNotFound
+		return "", "", "", storage.ErrNotFound
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE oauth_states SET consumed_at = ? WHERE state_hash = ?`, encodeTime(now.UTC()), stateHash)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
-	return redirectURI, action, tx.Commit()
+	return redirectURI, action, returnTo, tx.Commit()
+}
+
+func (s *Store) StoreOAuthHandoff(ctx context.Context, handoff storage.OAuthHandoff) error {
+	if handoff.CreatedAt.IsZero() {
+		handoff.CreatedAt = time.Now().UTC()
+	}
+	consumedAt := ""
+	if !handoff.ConsumedAt.IsZero() {
+		consumedAt = encodeTime(handoff.ConsumedAt)
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO oauth_handoffs(token_hash, api_key, created_at, expires_at, consumed_at)
+		VALUES(?, ?, ?, ?, ?)`,
+		handoff.TokenHash, handoff.APIKey, encodeTime(handoff.CreatedAt), encodeTime(handoff.ExpiresAt), consumedAt)
+	return err
+}
+
+func (s *Store) ConsumeOAuthHandoff(ctx context.Context, tokenHash []byte, now time.Time) (string, error) {
+	tx, err := s.beginImmediate(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer tx.Rollback()
+	var apiKey string
+	var expiresAt string
+	var consumedAt string
+	if err := tx.QueryRowContext(ctx, `
+		SELECT api_key, expires_at, consumed_at
+		FROM oauth_handoffs
+		WHERE token_hash = ?`,
+		tokenHash).Scan(&apiKey, &expiresAt, &consumedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", storage.ErrNotFound
+		}
+		return "", err
+	}
+	if consumedAt != "" || !now.Before(decodeTime(expiresAt)) {
+		return "", storage.ErrNotFound
+	}
+	_, err = tx.ExecContext(ctx, `UPDATE oauth_handoffs SET consumed_at = ? WHERE token_hash = ?`, encodeTime(now.UTC()), tokenHash)
+	if err != nil {
+		return "", err
+	}
+	return apiKey, tx.Commit()
+}
+
+func (s *Store) PruneExpiredOAuthHandoffs(ctx context.Context, now time.Time) (int64, error) {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	res, err := s.db.ExecContext(ctx, `
+		DELETE FROM oauth_handoffs
+		WHERE expires_at <= ?`, encodeTime(now.UTC()))
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
 }
 
 func (s *Store) PruneExpiredOAuthState(ctx context.Context, now time.Time) (int64, error) {

--- a/phase5-gateway/internal/storage/sqlite/store_test.go
+++ b/phase5-gateway/internal/storage/sqlite/store_test.go
@@ -234,7 +234,7 @@ func TestOAuthStateAndRateLimitStores(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("StoreOAuthState: %v", err)
 	}
-	redirectURI, action, err := store.ConsumeOAuthState(ctx, stateHash[:], "session_1", now.Add(time.Minute))
+	redirectURI, action, returnTo, err := store.ConsumeOAuthState(ctx, stateHash[:], "session_1", now.Add(time.Minute))
 	if err != nil {
 		t.Fatalf("ConsumeOAuthState: %v", err)
 	}
@@ -244,7 +244,10 @@ func TestOAuthStateAndRateLimitStores(t *testing.T) {
 	if action != "mint" {
 		t.Fatalf("action=%q, want %q", action, "mint")
 	}
-	if _, _, err := store.ConsumeOAuthState(ctx, stateHash[:], "session_1", now.Add(2*time.Minute)); !errors.Is(err, storage.ErrNotFound) {
+	if returnTo != "" {
+		t.Fatalf("returnTo=%q, want empty", returnTo)
+	}
+	if _, _, _, err := store.ConsumeOAuthState(ctx, stateHash[:], "session_1", now.Add(2*time.Minute)); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("ConsumeOAuthState replay err=%v, want ErrNotFound", err)
 	}
 
@@ -255,7 +258,7 @@ func TestOAuthStateAndRateLimitStores(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("StoreOAuthState expired: %v", err)
 	}
-	if _, _, err := store.ConsumeOAuthState(ctx, expiredHash[:], "session_2", now.Add(2*time.Minute)); !errors.Is(err, storage.ErrNotFound) {
+	if _, _, _, err := store.ConsumeOAuthState(ctx, expiredHash[:], "session_2", now.Add(2*time.Minute)); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("ConsumeOAuthState expired err=%v, want ErrNotFound", err)
 	}
 
@@ -267,7 +270,7 @@ func TestOAuthStateAndRateLimitStores(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("StoreOAuthState plain: %v", err)
 	}
-	_, action, err = store.ConsumeOAuthState(ctx, plainHash[:], "session_3", now.Add(time.Minute))
+	_, action, _, err = store.ConsumeOAuthState(ctx, plainHash[:], "session_3", now.Add(time.Minute))
 	if err != nil {
 		t.Fatalf("ConsumeOAuthState plain: %v", err)
 	}

--- a/phase5-gateway/internal/storage/sqlite/store_test.go
+++ b/phase5-gateway/internal/storage/sqlite/store_test.go
@@ -336,6 +336,93 @@ func TestOAuthStateCapAndPrune(t *testing.T) {
 	}
 }
 
+func TestOAuthStateReturnToRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	now := fixedTime()
+	stateHash := keyHash("oauth-state-returnto")
+	returnTo := "https://malibu.tech/console/auth/callback.html"
+	if err := store.StoreOAuthStateWithCap(ctx, storage.OAuthState{
+		StateHash: stateHash[:], SessionID: "sess_r", RedirectURI: "https://api.streamvc.live/auth/github/callback",
+		ReturnTo: returnTo, ClientIP: "1.2.3.4", CreatedAt: now, ExpiresAt: now.Add(10 * time.Minute),
+	}, 5, now); err != nil {
+		t.Fatalf("StoreOAuthStateWithCap: %v", err)
+	}
+	_, _, gotReturnTo, err := store.ConsumeOAuthState(ctx, stateHash[:], "sess_r", now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("ConsumeOAuthState: %v", err)
+	}
+	if gotReturnTo != returnTo {
+		t.Fatalf("returnTo=%q want %q", gotReturnTo, returnTo)
+	}
+}
+
+func TestOAuthHandoffStoreConsumeReplay(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	now := fixedTime()
+	tokenHash := keyHash("handoff-token")
+	if err := store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
+		TokenHash: tokenHash[:], APIKey: "mp_abc123", CreatedAt: now, ExpiresAt: now.Add(5 * time.Minute),
+	}); err != nil {
+		t.Fatalf("StoreOAuthHandoff: %v", err)
+	}
+	apiKey, err := store.ConsumeOAuthHandoff(ctx, tokenHash[:], now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("ConsumeOAuthHandoff: %v", err)
+	}
+	if apiKey != "mp_abc123" {
+		t.Fatalf("apiKey=%q want mp_abc123", apiKey)
+	}
+	if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash[:], now.Add(2*time.Minute)); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("replay err=%v want ErrNotFound", err)
+	}
+}
+
+func TestOAuthHandoffExpiredReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	now := fixedTime()
+	tokenHash := keyHash("handoff-expired")
+	if err := store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
+		TokenHash: tokenHash[:], APIKey: "mp_expired", CreatedAt: now, ExpiresAt: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("StoreOAuthHandoff: %v", err)
+	}
+	if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash[:], now.Add(2*time.Minute)); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expired err=%v want ErrNotFound", err)
+	}
+}
+
+func TestPruneExpiredOAuthHandoffs(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	now := fixedTime()
+	for i := 0; i < 3; i++ {
+		hash := keyHash(fmt.Sprintf("handoff-fresh-%d", i))
+		if err := store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
+			TokenHash: hash[:], APIKey: fmt.Sprintf("mp_fresh_%d", i), CreatedAt: now, ExpiresAt: now.Add(10 * time.Minute),
+		}); err != nil {
+			t.Fatalf("StoreOAuthHandoff fresh %d: %v", i, err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		hash := keyHash(fmt.Sprintf("handoff-stale-%d", i))
+		if err := store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
+			TokenHash: hash[:], APIKey: fmt.Sprintf("mp_stale_%d", i), CreatedAt: now, ExpiresAt: now.Add(time.Minute),
+		}); err != nil {
+			t.Fatalf("StoreOAuthHandoff stale %d: %v", i, err)
+		}
+	}
+	deleted, err := store.PruneExpiredOAuthHandoffs(ctx, now.Add(5*time.Minute))
+	if err != nil {
+		t.Fatalf("PruneExpiredOAuthHandoffs: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted=%d want 2 (fresh rows must survive)", deleted)
+	}
+}
+
 func TestReservePublicIssuanceConcurrentCeiling(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)

--- a/phase5-gateway/internal/storage/types.go
+++ b/phase5-gateway/internal/storage/types.go
@@ -51,6 +51,7 @@ type OAuthState struct {
 	StateHash   []byte
 	SessionID   string
 	RedirectURI string
+	ReturnTo    string
 	ClientIP    string
 	// Action is an optional operator-initiated intent threaded from the
 	// /auth/github/start query string to the /auth/github/callback handler.
@@ -58,6 +59,14 @@ type OAuthState struct {
 	// stale-cookie pollution, parallel-flow races, and uncleared cookies on
 	// early callback errors. Currently the only non-empty value is "mint".
 	Action     string
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	ConsumedAt time.Time
+}
+
+type OAuthHandoff struct {
+	TokenHash  []byte
+	APIKey     string
 	CreatedAt  time.Time
 	ExpiresAt  time.Time
 	ConsumedAt time.Time

--- a/specs/AUDIT_PR400_HANDOFF_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_PR400_HANDOFF_ARCHITECT_PROMPT.md
@@ -1,0 +1,184 @@
+# AUDIT PR400 ARCHITECT PROMPT — Malibu OAuth return_to handoff
+
+You are the **architect** lane of a three-lane audit (code / security /
+architect) of PR #400 (branch `feat/malibu-oauth-handoff`, commit
+`ca8f491`). Stay narrowly in your lane.
+
+Architect lane covers: lifecycle wiring, background pruners, migration
+compatibility across deploy directions, contract/schema drift, and
+whether the new abstractions cleanly compose with existing ones. Do
+not re-do the code lane's line-checking or the security lane's threat-
+modeling.
+
+## Diff surface
+
+- `phase5-gateway/internal/router/oauth.go`
+- `phase5-gateway/internal/router/server.go`
+- `phase5-gateway/internal/config/config.go`
+- `phase5-gateway/gateway.yaml.example`
+- `phase5-gateway/internal/storage/interfaces.go`
+- `phase5-gateway/internal/storage/types.go`
+- `phase5-gateway/internal/storage/sqlite/migrate.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/internal/storage/sqlite/store_test.go`
+- `phase5-gateway/cmd/gateway/main.go` (for background-pruner wiring
+  cross-reference — NOT modified by the PR)
+
+## Architect-lane checks (apply each; stay in lane)
+
+### ARCH-1. Background pruner wiring for `oauth_handoffs`
+The PR adds `PruneExpiredOAuthHandoffs` to both `AuthStore` and
+`OAuthStateStore` interfaces and implements it in the SQLite store.
+Look at `cmd/gateway/main.go` for background pruners:
+
+- `runOAuthStatePruner` (line ~201) currently calls only
+  `PruneExpiredOAuthState`. Is `PruneExpiredOAuthHandoffs` wired into
+  any background loop?
+- If NOT: the `oauth_handoffs` table grows unbounded over time
+  (consumed rows never deleted, expired-but-not-consumed rows never
+  deleted). On a production instance issuing N handoffs per day for
+  months, this leaks disk and slows the PK BLOB lookup on
+  `ConsumeOAuthHandoff`. Given the volume is small (bounded by
+  active-user signup rate), rate the finding by acuity:
+  - HIGH if the interface adds a method the caller never invokes AND
+    there is no other cleanup path (VACUUM, TTL, etc.).
+  - MEDIUM if there is another indirect cleanup (e.g. app-restart
+    truncation, which there isn't — SQLite persists).
+- Fix suggestion: extend the existing pruner to call both, or add a
+  parallel `runOAuthHandoffPruner`. The interface method already
+  exists — flag the missing invocation.
+
+### ARCH-2. Migration compatibility direction — deploy-then-rollback
+Schema v9 adds a column to `oauth_states` and creates
+`oauth_handoffs`. The migration file uses
+`CREATE TABLE IF NOT EXISTS oauth_states (... return_to TEXT NOT NULL DEFAULT '' ...)`
+AND runs `ensureOAuthStateReturnToColumn` (ALTER TABLE for existing
+v8 databases).
+
+Confirm the deploy directions:
+
+- **Fresh v9 install**: CREATE TABLE embeds the column; ensureColumn's
+  PRAGMA read finds it, no ALTER. Migration writes
+  `schema_migrations(9, ...)`. Clean.
+- **v8 → v9 upgrade**: pre-existing `oauth_states` lacks `return_to`;
+  ensureColumn ALTERs it in. Clean. `oauth_handoffs` created via
+  ensureOAuthHandoffsTable. Clean.
+- **v9 → v8 rollback (older binary on v9 db)**:
+  `maxKnownSchemaVersion = 8`, so `checkSchemaVersionGate` refuses
+  to start when the applied version (9) is greater. Deployment must
+  restore the v8 snapshot per `deploy-pearl-vps.sh 5b`. Confirm the
+  gate actually fires — is there a way the v8 binary can silently
+  start on a v9 db (e.g. the `INSERT OR IGNORE INTO schema_migrations`
+  never ran on some edge path)?
+- Is the pattern of BOTH embedding `return_to` in the CREATE TABLE
+  AND running `ensureOAuthStateReturnToColumn` intentional? Yes —
+  matches the existing `ensureOAuthStateActionColumn` pattern on v7
+  → v8. Confirm consistency; flag any drift from prior migration
+  style (`INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(N, ?)`
+  pattern is followed).
+
+### ARCH-3. Two allowlists must stay in sync
+The PR adds Malibu URLs to two configuration surfaces:
+
+- `auth.oauth.return_to_allowlist` in `phase5-gateway/gateway.yaml.example`
+- `cors.allowed_origins` in the same file
+
+For Malibu to complete the flow, BOTH must be updated in production.
+The PR body reminds the operator, but there is no configuration-time
+check that they stay consistent. Consider:
+
+- Is a Validate-time cross-check appropriate? (Every entry in
+  `return_to_allowlist` should have a `cors.allowed_origins` entry
+  matching scheme+host.) Missing check → MEDIUM if the failure mode
+  is silent (`return_to` works but the exchange call fails CORS,
+  leaving the user in a broken state on Malibu with no key). LOW if
+  the failure is obvious to the operator.
+- Alternative: derive one list from the other at boot. Not required
+  but worth calling out.
+
+### ARCH-4. Contract with the paired Malibu client
+The PR body cites Malibu commit `5a677d1` on branch
+`site-review-2026-07`. Contract points that must match:
+
+- Query param name: `handoff` (not `handoff_token`, not `code`).
+- Exchange endpoint path: `/auth/handoff/exchange`.
+- Exchange request body: `{ "handoff": "<token>" }`.
+- Exchange response body: `{ "api_key": "mp_..." }`.
+- Error surface on redirect: `?error=no_key` or `?error=handoff_failed`.
+
+Do NOT read the Malibu repo — that is out of scope. But flag any
+place where the gateway code uses a name inconsistent with the PR body
+(e.g. the redirect path or response body key drifts from what the PR
+body claims Malibu expects).
+
+### ARCH-5. `AuthStore` vs `OAuthStateStore` interface parity
+Both interfaces gained the same three new methods. Is one a superset
+of the other, or is the duplication intentional? Sweep the code for
+which interface is used at which call site and confirm this parity
+does not create two paths of divergence over time (one implementer
+staying behind on a signature change).
+
+Rate MEDIUM if the duplication is a real maintenance hazard (e.g.
+test doubles implement one but not the other and are used
+interchangeably); LOW/INFO if the split is a well-established
+project convention.
+
+### ARCH-6. `withCORS` vs plain mux consistency
+`/auth/handoff/exchange` is wrapped in `withCORS(POST, …)`.
+`/auth/github/start` and `/auth/github/callback` are NOT wrapped
+(they are user-navigation endpoints, not XHR). This asymmetry is
+correct but worth confirming the reasoning is preserved via a
+comment or route registration comment. Flag as LOW/INFO if the
+`/auth/handoff/exchange` line lacks any explanation of why it needs
+CORS while its siblings don't.
+
+### ARCH-7. Concurrency: two callbacks racing for one state
+`ConsumeOAuthState` uses `beginImmediate` and consumes the row
+atomically. `redirectOAuthHandoff` runs AFTER `ConsumeOAuthState` has
+already committed the "consumed" flag. Two race concerns:
+
+- If two identical callback requests race, only one wins
+  `ConsumeOAuthState`; the loser gets `ErrNotFound` → 400. Good.
+- If `StoreOAuthHandoff` fails (disk full, transient DB error), the
+  state row is ALREADY consumed. The user is redirected back with
+  `?error=handoff_failed` and has NO way to retry — they cannot
+  reuse the state, and the API key has been minted (in the mint or
+  signup branch). Is this an acceptable failure mode? On a mint
+  branch this leaves an orphan `mp_*` key that the user cannot
+  access. Rate as MEDIUM if this leaks credentials or leaves the
+  user with a broken account; LOW if the standard recovery is
+  "start OAuth again and re-mint".
+
+### ARCH-8. Cookie surface unchanged for legacy path
+The legacy `mp_new_api_key` cookie + `/account` redirect still fires
+when `returnTo == "" && fullKey != ""`. Confirm the console.streamvc.live
+provider portal flow (which does NOT pass `return_to`) is unchanged.
+Flag if any assumption in the console portal about the cookie's
+presence or path is broken by the refactor (e.g. Path=`/account`
+still matches; the SetCookie call site is unchanged in structure).
+
+## Output format
+
+Write a Markdown file at `specs/PR400_HANDOFF_r1_architect_audit.md`:
+
+```
+AUDIT_PR400_ARCHITECT: PASS   # 0 C / 0 H / 0 M
+# or
+AUDIT_PR400_ARCHITECT: FAIL
+
+CRITICAL: n
+HIGH: n
+MEDIUM: n
+LOW: n
+
+## Findings
+### H1 <title>
+- file: path:line (or "cross-cutting")
+- observation: <what the architecture does today>
+- risk: <what breaks over time or at scale>
+- fix: <concrete refactor / wiring change>
+```
+
+Report only architecture defects. Do not double-count with code or
+security lanes. LOWs are optional. End with
+`VERDICT: architect lane READY TO MERGE` iff 0 C/H/M.

--- a/specs/AUDIT_PR400_HANDOFF_ARCHITECT_R2_PROMPT.md
+++ b/specs/AUDIT_PR400_HANDOFF_ARCHITECT_R2_PROMPT.md
@@ -1,0 +1,75 @@
+# AUDIT PR400 ARCHITECT R2 PROMPT — Malibu OAuth return_to handoff
+
+Round 2 of the architect lane. Round 1 findings are in
+`specs/PR400_HANDOFF_r1_architect_audit.md`. Read
+`specs/AUDIT_PR400_HANDOFF_ARCHITECT_PROMPT.md` for the full checklist
+and diff surface.
+
+## Fixes applied since round 1
+
+### r1 ARCHITECT H1 — `PruneExpiredOAuthHandoffs` unwired
+Fixed in `phase5-gateway/cmd/gateway/main.go`.
+- The `oauthStatePruner` interface now requires both
+  `PruneExpiredOAuthState` and `PruneExpiredOAuthHandoffs`.
+- `runOAuthStatePruner` calls both on every tick (immediately + on
+  each ticker fire).
+- `cmd/gateway/main_test.go::TestRunOAuthStatePrunerRunsAndStops`
+  and its fake pruner now assert BOTH methods are invoked
+  immediately.
+
+Confirm:
+- No `store` object that implements `AuthStore` or
+  `OAuthStateStore` is now missing a `PruneExpiredOAuthHandoffs`
+  method (compile check — but re-verify by name search).
+- The pruner interface change does not silently drop callers or
+  break `cmd/gateway/main.go`'s call site `go runOAuthStatePruner(...)`.
+
+### r1 ARCHITECT M1 — return_to / CORS allowlist drift
+Fixed in `phase5-gateway/internal/config/config.go::Validate`.
+- Validate now builds a set of CORS origins (`scheme://host`,
+  lowercased) and requires every `auth.oauth.return_to_allowlist`
+  entry to have a matching CORS origin, else returns an error
+  naming the offending index and origin.
+- `TestReturnToConfigRequiresMatchingCORSOrigin` in
+  `phase5-gateway/internal/router/oauth_handoff_test.go` locks it in.
+
+Confirm:
+- The cross-check is order-independent (CORS entries validated first,
+  then return_to entries, both scoped to lowercase scheme+host).
+- The check does not spuriously fire when
+  `return_to_allowlist` is empty (default).
+- The error message names the offending origin so operators can
+  fix it without reading source.
+
+### r1 ARCHITECT M2 — Handoff-storage failure leaves orphan key
+Partially mitigated in
+`phase5-gateway/internal/router/oauth.go::handleGitHubCallback`.
+The `mp_new_api_key` cookie is now set on every `fullKey != ""`
+path, BEFORE the `returnTo` branch decides between handoff and
+legacy paths. If `StoreOAuthHandoff` fails, the user is redirected
+to Malibu with `?error=handoff_failed` AND the cookie survives on
+`api.streamvc.live`, so the user can retrieve the key by visiting
+`api.streamvc.live/account`.
+
+Rate this fix:
+- SUFFICIENT if the recovery path is a normal user-facing behavior
+  (visiting `/account` after the redirect) with a stable UX.
+- INSUFFICIENT if you see a case where the user cannot recover:
+  - Cookie MaxAge of 300s is too short if Malibu shows the error but
+    doesn't redirect back to gateway `/account`.
+  - Signup flow: does the audit trail record the newly-minted key on
+    the signup path? (Previously only the mint path emitted an
+    `api_key_minted_via_oauth` audit event; signup relied on the
+    `RecordSignupEvent`. Flag as MEDIUM if you can show the operator
+    cannot correlate the orphan key with the account.)
+
+Do NOT re-raise as HIGH/CRITICAL unless you can show a strict-loss
+scenario the fallback cookie doesn't cover.
+
+### r1 ARCHITECT L1 — CORS-only handoff route lacks explanation
+NOT fixed (LOW). Skip per project convention (LOWs ship in PR body).
+
+## Output format
+
+Write findings to `specs/PR400_HANDOFF_r2_architect_audit.md`. End
+with `VERDICT: architect lane READY TO MERGE` iff 0 C/H/M.

--- a/specs/AUDIT_PR400_HANDOFF_ARCHITECT_R3_PROMPT.md
+++ b/specs/AUDIT_PR400_HANDOFF_ARCHITECT_R3_PROMPT.md
@@ -1,0 +1,43 @@
+# AUDIT PR400 ARCHITECT R3 PROMPT — Malibu OAuth return_to handoff
+
+Round 3 of the architect lane. Round 2 findings are in
+`specs/PR400_HANDOFF_r2_architect_audit.md`. Read the round-2 prompt
+for the fixed-lane context; only ONE finding remained.
+
+## Fix applied since round 2
+
+### r2 ARCHITECT M1 — Handoff-store failure fallback was not a stable recovery contract
+Fixed in `phase5-gateway/internal/router/oauth.go::handleGitHubCallback`.
+- On `StoreOAuthHandoff` failure, the handler no longer redirects back to
+  Malibu with `?error=handoff_failed`. It redirects directly to
+  `s.cfg.Public.AccountPath` (the gateway `/account` page), which reads
+  the already-set `mp_new_api_key` cookie and shows the user their key.
+- The recovery UX is now anchored inside the gateway contract — no
+  dependency on Malibu client behavior for the failure path.
+- The cookie set BEFORE the returnTo branch (unchanged from round 2) is
+  the fallback: `Path=/account`, `HttpOnly`, `Secure`, `SameSite=Lax`,
+  `MaxAge=300`.
+
+Test pin added: `TestOAuthHandoffPersistenceFailureRedirectsToAccount`
+in `phase5-gateway/internal/router/oauth_handoff_test.go`. Uses a
+`failingHandoffStore` wrapper that induces `StoreOAuthHandoff` failure
+and asserts the redirect Location matches `cfg.Public.AccountPath` and
+the fallback cookie is set.
+
+## Confirm
+
+- The failure branch does NOT double-redirect: `redirectOAuthHandoff`
+  errors before it can call `http.Redirect`, so the subsequent
+  `http.Redirect(w, r, s.cfg.Public.AccountPath, ...)` is the only
+  Location write on that response.
+- The Malibu `?error=handoff_failed` code path (previously used for
+  persistence failure) is now dead. `redirectOAuthReturn` is still used
+  for the `no_key` case (existing account, no mint action) — that
+  remains a Malibu-side UX because there is no key to deliver.
+- No other C/H/M architecture defects surfaced (parity/lifecycle/migration
+  concerns from r1 remain closed).
+
+## Output format
+
+Write findings to `specs/PR400_HANDOFF_r3_architect_audit.md`. End with
+`VERDICT: architect lane READY TO MERGE` iff 0 C/H/M.

--- a/specs/AUDIT_PR400_HANDOFF_CODE_PROMPT.md
+++ b/specs/AUDIT_PR400_HANDOFF_CODE_PROMPT.md
@@ -1,0 +1,196 @@
+# AUDIT PR400 CODE PROMPT — Malibu OAuth return_to handoff
+
+You are the **code** lane of a three-lane audit (code / security / architect)
+of PR #400 (branch `feat/malibu-oauth-handoff`, commit `ca8f491`).
+
+Scope: correctness, control-flow, signature consistency, test adequacy.
+Security and architecture concerns are covered by the sibling lanes — stay
+in your lane.
+
+## Diff surface
+
+Files in scope (`git diff origin/main...HEAD` on the branch, or view the PR
+at https://github.com/Augustas11/macprovider/pull/400):
+
+- `phase5-gateway/internal/router/oauth.go`
+- `phase5-gateway/internal/router/server.go`
+- `phase5-gateway/internal/config/config.go`
+- `phase5-gateway/gateway.yaml.example`
+- `phase5-gateway/internal/storage/interfaces.go`
+- `phase5-gateway/internal/storage/types.go`
+- `phase5-gateway/internal/storage/sqlite/migrate.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/internal/storage/sqlite/store_test.go`
+
+## What the diff does
+
+1. Adds `return_to` query param on `GET /auth/github/start`, gated by a new
+   `auth.oauth.return_to_allowlist` config allowlist.
+2. Threads the value through `OAuthState` (new `ReturnTo` column, schema v9
+   migration + additive column on existing v8 tables).
+3. On `GET /auth/github/callback`, if `returnTo != ""`, mint a one-time
+   handoff token (`oauth_handoffs` table), redirect to
+   `<returnTo>?handoff=<token>`, and skip the usual `mp_new_api_key`
+   cookie + `/account` redirect.
+4. Adds `POST /auth/handoff/exchange` — Malibu exchanges the handoff for
+   the full `mp_*` key exactly once.
+5. Extends the CORS `allowed_origins` list to include Malibu.
+
+## Code-lane checks (apply each; stay in lane)
+
+### CODE-1. Signature change fanout — every caller updated?
+- `AuthStore.ConsumeOAuthState` grew a fourth return value (`returnTo`).
+  Every implementer and every caller must match. Sweep for stale 3-value
+  call sites (`_, _, err := ... .ConsumeOAuthState(`) and stale 3-value
+  method implementations. In-tree caller today is
+  `handleGitHubCallback`; test doubles in `store_test.go` and any router
+  test mocks must also be updated.
+- `OAuthStateStore` mirror interface has the same signature. Confirm.
+- `storage.OAuthState` gained `ReturnTo string`. Confirm nothing constructs
+  the struct positionally (would silently swap fields).
+
+### CODE-2. `fullKey` scoping across signup vs mint branches
+`handleGitHubCallback` now declares `var fullKey string` outside the
+signup / mint branches and uses `=` (not `:=`) inside each branch.
+
+- Confirm there is NO `:=` inside either branch that would shadow the
+  outer `fullKey` (which would silently leave `fullKey == ""` after
+  the branch and force the `no_key` return path for every user).
+- Confirm the third code path — existing account, `action != "mint"` —
+  correctly leaves `fullKey == ""` so that the `return_to` branch takes
+  the `no_key` early-return (that is the intended UX: existing users
+  who came without `action=mint` get redirected back with `?error=no_key`
+  rather than an empty key).
+- Confirm `err` reuse inside the branches does not mask an earlier
+  non-nil `err` that should have already returned.
+
+### CODE-3. `return_to` allowlist matching semantics
+`returnToAllowed` matches on `Scheme` + `Host` (case-insensitive) and a
+path-prefix check that accepts:
+- Empty or `/` allowlisted path → any target path on that host.
+- Non-empty allowlisted path → `strings.HasPrefix(target.Path, u.Path)`.
+
+- Is this the right shape given the configured allowlist entries in
+  `gateway.yaml.example` (each entry names a specific `.html` path)?
+- Does `HasPrefix` on the exact configured path
+  `/console/auth/callback.html` accept the target
+  `/console/auth/callback.html` (same string)? Yes — but does it also
+  accept `/console/auth/callback.html/extra` and
+  `/console/auth/callback.htmlish`? Flag if you find a semantic
+  mismatch between the config comment and the code.
+- Fragment / query on `returnTo` — is it preserved through
+  `redirectOAuthHandoff`'s `values := target.Query(); values.Set("handoff", …)`
+  round-trip? What if Malibu passes `?state=xyz` — is `xyz` kept?
+
+### CODE-4. `handleHandoffExchange` request body handling
+- `http.MaxBytesReader(w, r.Body, 1<<20)` caps body at 1 MiB. Reasonable
+  for a `{ "handoff": "..." }` payload.
+- On decode error, on empty handoff, and on store failure the handler
+  returns the SAME `oauth_handoff` / `invalid_handoff` error code. Is
+  the collapsed error surface intentional? (Not leaking whether the
+  token was valid-shape but wrong-value is deliberate; confirm the
+  handler never returns a distinguishable success on failure.)
+- Response: `writeJSON(w, http.StatusOK, map[string]any{"api_key": apiKey})`.
+  Contract must match what Malibu expects — PR body says
+  `{ "api_key": "mp_…" }`. Confirm exact key name.
+
+### CODE-5. Store: `StoreOAuthHandoff` / `ConsumeOAuthHandoff` correctness
+- `StoreOAuthHandoff` runs OUTSIDE a transaction (single `INSERT`).
+  Compare to `StoreOAuthStateWithCap` which uses `beginImmediate`
+  because it does a per-IP cap count first. There is no per-IP cap
+  here — is a bare `ExecContext` right, or should we mirror the
+  transactional pattern for consistency?
+- `ConsumeOAuthHandoff` uses `beginImmediate` + `SELECT` +
+  `UPDATE consumed_at`. Verify the consumed / expired guard mirrors
+  `ConsumeOAuthState` exactly — the two now diverge only in schema
+  (no session cookie binding here); flag any accidental divergence
+  in the freshness check.
+- `token_hash BLOB PRIMARY KEY` gives us idempotent replay protection
+  and O(1) lookup. Confirm the token generator (`auth.StateToken`) has
+  the same entropy as it does for `state`, and that
+  `auth.StateHash(token)` is used consistently (start vs consume).
+
+### CODE-6. Schema v9 migration
+- `ensureOAuthStateReturnToColumn` reads `PRAGMA table_info` and issues
+  an `ALTER TABLE ... ADD COLUMN return_to TEXT NOT NULL DEFAULT ''`
+  if missing. Confirm idempotence: running on a fresh v9 schema (from
+  `CREATE TABLE IF NOT EXISTS oauth_states (...)` already including
+  `return_to`) is a no-op, and running on an old v8 schema is
+  additive.
+- `ensureOAuthHandoffsTable` uses `CREATE TABLE IF NOT EXISTS` +
+  `CREATE INDEX IF NOT EXISTS`. Idempotent. Confirm.
+- Version bump: `maxKnownSchemaVersion` goes 8 → 9, and a new
+  `INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(9, ?)`
+  row is written. Confirm nothing else in the migration ladder was
+  missed (e.g. an intermediate v-string in comments that also needs
+  bumping).
+- What happens if an operator downgrades the binary back to a v8 build
+  after v9 has been applied? The binary compares
+  `current > maxKnownSchemaVersion` and refuses to start — confirm
+  this fail-loud path still fires. (The CLAUDE.md note references
+  `deploy-pearl-vps.sh step 5b` snapshot as the roll-back path.)
+
+### CODE-7. Test coverage adequacy (code lane view only — no security)
+- `TestOAuthStateAndRateLimitStores` was updated for the new 4-value
+  return and the `returnTo == ""` assertion. Good.
+- Is there ANY test for:
+  - a non-empty `ReturnTo` round-tripping through `StoreOAuthStateWithCap`
+    → `ConsumeOAuthState`?
+  - `StoreOAuthHandoff` + `ConsumeOAuthHandoff` happy path (returns
+    key, then replay returns `ErrNotFound`)?
+  - `ConsumeOAuthHandoff` on an expired row returns `ErrNotFound`?
+  - `PruneExpiredOAuthHandoffs` deletes only rows whose
+    `expires_at <= now`?
+  - `returnToAllowed` at the router level (mismatch host, mismatch
+    scheme, empty allowlist)?
+  - `handleHandoffExchange` HTTP behavior (405, empty body, unknown
+    token, valid token, replay)?
+- If any of these are absent, that is a CODE finding — call the
+  missing coverage out with an exact test name suggestion.
+
+### CODE-8. Config default + validation
+- `OAuthConfig.ReturnToAllowlist` has no default. If YAML omits it,
+  the slice is nil, `returnToAllowed` returns false for all inputs,
+  and the flow degrades to "no `return_to` allowed" — the existing
+  cookie+`/account` path. Confirm this default-off posture.
+- `Validate()` runs `requireURL` on each entry. Confirm empty entries
+  and duplicates behave the way you'd expect (either both accepted
+  or both rejected).
+
+### CODE-9. Route registration
+- `server.go` wires `/auth/handoff/exchange` via `s.withCORS(http.MethodPost, …)`
+  even though the `/auth/github/*` routes above it are wired plainly
+  with `mux.HandleFunc`. This is intentional (Malibu is a same-origin-
+  from-its-own-DNS cross-origin caller). Confirm the wrapper does not
+  double-set Access-Control-* headers via `setCORSHeaders` +
+  `setNoStoreHeaders` and does not conflict with `writeJSON`.
+
+## Output format
+
+Write a Markdown file at `specs/PR400_HANDOFF_r1_code_audit.md` with:
+
+```
+AUDIT_PR400_CODE: PASS   # if 0 CRITICAL / 0 HIGH / 0 MEDIUM
+# or
+AUDIT_PR400_CODE: FAIL
+
+CRITICAL: n
+HIGH: n
+MEDIUM: n
+LOW: n
+
+## Findings
+### C1 <title>
+- file: path:line
+- evidence: <exact snippet or claim>
+- impact: <what breaks in prod>
+- fix: <concrete one-paragraph change>
+### H1 …
+### M1 …
+### L1 …
+```
+
+Report ONLY defects. Do not propose scope expansion, feature refactors,
+or opinion-level stylistic changes. LOWs are optional and never block.
+
+End with a VERDICT line: `VERDICT: code lane READY TO MERGE` iff 0 C/H/M.

--- a/specs/AUDIT_PR400_HANDOFF_CODE_R2_PROMPT.md
+++ b/specs/AUDIT_PR400_HANDOFF_CODE_R2_PROMPT.md
@@ -1,0 +1,75 @@
+# AUDIT PR400 CODE R2 PROMPT — Malibu OAuth return_to handoff
+
+Round 2 of the code lane. Round 1 findings are in
+`specs/PR400_HANDOFF_r1_code_audit.md`. The following fixes have been
+applied on branch `feat/malibu-oauth-handoff`; verify they close the
+findings and did not introduce regressions.
+
+Scope stays as in round 1: correctness, control-flow, signature
+consistency, test adequacy. Read `specs/AUDIT_PR400_HANDOFF_CODE_PROMPT.md`
+for the full checklist and diff surface.
+
+## Fixes applied since round 1
+
+### r1 CODE M1 — `return_to` allowlist overmatch
+Fixed in `phase5-gateway/internal/router/oauth.go`. `returnToAllowed`
+now:
+- Requires exact path equality when the allowlist path does NOT end
+  in `/`.
+- Treats trailing-`/` allowlist paths as explicit directory prefixes.
+- Rejects any target path containing `.` or `..` segments (literal or
+  URL-encoded via `%2E`), by way of a new `hasDotSegment` helper.
+
+Confirm:
+- Exact allowlist entry `/console/auth/callback.html` accepts target
+  `/console/auth/callback.html`.
+- Same allowlist entry REJECTS `/console/auth/callback.htmlx`,
+  `/console/auth/callback.html/extra`, and
+  `/console/auth/callback.html/../admin`.
+- Path `/` and empty path still accept any target path on the host.
+
+### r1 CODE M2 — Missing regression coverage
+Added:
+- `TestOAuthStateReturnToRoundTrip` in
+  `phase5-gateway/internal/storage/sqlite/store_test.go`.
+- `TestOAuthHandoffStoreConsumeReplay` in same file.
+- `TestOAuthHandoffExpiredReturnsNotFound` in same file.
+- `TestPruneExpiredOAuthHandoffs` in same file.
+- `TestReturnToAllowedRejectsPrefixAndTraversal` in
+  `phase5-gateway/internal/router/oauth_handoff_test.go` (new file).
+- `TestOAuthHandoffFlowRoundTrip` in same new file — start → callback
+  → exchange → replay.
+- `TestHandoffExchangeErrorSurface` in same new file — 405, empty
+  body, unknown token.
+- `TestReturnToConfigRequiresMatchingCORSOrigin` in same new file
+  (this one is for the architect-lane config cross-check but also
+  serves as router-config regression).
+
+Confirm the new tests actually assert what they claim; flag any test
+that passes trivially (e.g. asserting an empty struct's zero value).
+
+## Cross-cutting changes to also re-check
+
+- `handleGitHubCallback` now sets the `mp_new_api_key` cookie for
+  every `fullKey != ""` case (not only the legacy `/account` path).
+  See the fallback-cookie comment above the `SetCookie` call. Confirm:
+  - The cookie is set BEFORE the returnTo branch runs (so a
+    handoff-storage failure still leaves the cookie for `/account`
+    recovery).
+  - The cookie's Path=/account keeps it scoped to the gateway origin
+    and NOT readable by Malibu.
+  - No behavior change for the pre-existing legacy flow
+    (`returnTo == "" && fullKey != ""` still writes cookie then
+    redirects to `s.cfg.Public.AccountPath`).
+
+- `redirectOAuthHandoff` now sets `Referrer-Policy: no-referrer` and
+  `Cache-Control: no-store` before the redirect. Confirm this does
+  not break integration tests that inspect response headers.
+
+## Output format
+
+Write findings to `specs/PR400_HANDOFF_r2_code_audit.md` in the same
+CRITICAL/HIGH/MEDIUM/LOW format the round-1 audit used. End with
+`VERDICT: code lane READY TO MERGE` iff 0 C/H/M.
+
+If the r1 findings are closed and no new C/H/M surfaced, PASS.

--- a/specs/AUDIT_PR400_HANDOFF_SECURITY_PROMPT.md
+++ b/specs/AUDIT_PR400_HANDOFF_SECURITY_PROMPT.md
@@ -1,0 +1,192 @@
+# AUDIT PR400 SECURITY PROMPT — Malibu OAuth return_to handoff
+
+You are the **security** lane of a three-lane audit (code / security /
+architect) of PR #400 (branch `feat/malibu-oauth-handoff`, commit
+`ca8f491`). Stay narrowly in your lane.
+
+## Why this diff is security-load-bearing
+
+The diff introduces two new attacker-reachable surfaces on the
+production gateway (`api.streamvc.live`):
+
+1. `GET /auth/github/start?return_to=<url>` — accepts an attacker-
+   controlled URL and, on successful OAuth callback, HTTP-redirects the
+   authenticated user's browser to that URL with a one-time handoff
+   token in the query string.
+2. `POST /auth/handoff/exchange` — anonymous endpoint that trades a
+   one-time token for a live `mp_*` API key.
+
+Anything short of full mediation between the token and the key is a
+credential-leak vector.
+
+## Diff surface
+
+- `phase5-gateway/internal/router/oauth.go`
+- `phase5-gateway/internal/router/server.go`
+- `phase5-gateway/internal/router/cors.go` (for context, unchanged)
+- `phase5-gateway/internal/storage/sqlite/store.go` (handoff table)
+- `phase5-gateway/internal/storage/sqlite/migrate.go`
+- `phase5-gateway/gateway.yaml.example`
+
+## Security-lane checks (apply each; stay in lane)
+
+### SEC-1. Open-redirect / phishing via `return_to`
+`returnToAllowed` (oauth.go ~L381) matches `Scheme` + `Host` (case-
+insensitive) and a path-prefix check. Verify the following attacker
+inputs are **rejected**:
+
+- Different scheme: `http://malibu.tech/console/auth/callback.html`
+  when allowlist has `https://…`.
+- Different host: `https://malibu.tech.attacker.example/console/auth/callback.html`
+  (subdomain of attacker containing allowed host as a substring).
+- Case-tricks: `https://MALIBU.TECH/console/auth/callback.html` —
+  intended to succeed; confirm it does succeed (or is documented as
+  intentional).
+- Userinfo injection: `https://malibu.tech@attacker.example/…`
+  (Go's `url.Parse` puts `attacker.example` in Host — confirm).
+- URL with credentials or unusual ports:
+  `https://malibu.tech:8443/console/auth/callback.html`.
+- Query / fragment injection where the fragment is
+  `#https://attacker.example` — not exploitable per se but confirm no
+  path uses the raw fragment.
+- Path prefix pun: allowlist path `/console/auth/callback.html`,
+  target path `/console/auth/callback.htmlx`. `strings.HasPrefix`
+  accepts this because there is no separator boundary check — is
+  this exploitable given the specific allowlisted paths? Any Malibu
+  route beginning with the prefix could receive the handoff token.
+  Rate as CRITICAL/HIGH only if there is a real path to attacker
+  landing; MEDIUM otherwise.
+- Path traversal: `/console/auth/callback.html/../../../admin` after
+  URL parse — does Go's `url.Parse` normalize `..` here, or does the
+  raw path survive to `HasPrefix`?
+
+### SEC-2. Handoff token — one-time, single-audience, short-lived
+- Confirm `oauth_handoffs.token_hash BLOB PRIMARY KEY` + the
+  `UPDATE ... SET consumed_at = ?` guarantees at-most-once claim
+  under concurrent exchange (uses `beginImmediate` — SQLite writer
+  serialization is fine, but confirm the SELECT reads current row).
+- TTL is 5 minutes (`now.Add(5 * time.Minute)` in
+  `redirectOAuthHandoff`). Reasonable for browser-to-server hop;
+  flag only if the code has an off-by-one where an expired row is
+  still consumable.
+- The token itself is `auth.StateToken()`. Is that the same 32-byte
+  cryptographic randomness used for OAuth state? Confirm no lower-
+  entropy generator was introduced.
+- Is the RAW token ever logged (server logs, access log, error
+  return)? Only the HASH is stored — but redirect emits the raw
+  token as a query param, so it will land in nginx access logs and
+  browser referrer chains. Is that acceptable given the 5-minute TTL
+  and one-shot consume? Call out only if the token appears in
+  additional log locations beyond the redirect URL itself.
+- Referrer leak: on Malibu's callback page, the browser's next
+  outbound request could include the referrer with the token in the
+  query string. Should the redirect set `Referrer-Policy: no-referrer`
+  header? Rate as MEDIUM if unmitigated.
+
+### SEC-3. Exchange endpoint attack surface
+- No authentication or rate limit on `POST /auth/handoff/exchange`.
+  An attacker who exfiltrates a token from any leak path (log line,
+  referrer, browser history sync) can trade it for a key from any
+  IP. Given at-most-once + 5-minute TTL + hash-only-in-DB, is the
+  residual risk acceptable? If any code path allows repeated attempts
+  to enumerate tokens (e.g. distinguishing "wrong hash" vs "expired"
+  vs "already consumed" via error code or timing), flag it. Confirm
+  `handleHandoffExchange` returns the SAME error for all failure
+  modes.
+- Body size cap is `1<<20` (1 MiB). Fine; not a DoS lever at this
+  volume.
+- Is there any CSRF exposure? The endpoint is POST-only, requires a
+  JSON body with the handoff token — CSRF only bites if the token
+  is available to the attacker. If token was already leaked, CSRF is
+  moot.
+
+### SEC-4. CORS envelope on the exchange endpoint
+- Route is wrapped with `s.withCORS(http.MethodPost, …)`.
+  `corsOriginAllowed` walks `cfg.CORS.AllowedOrigins`. The new YAML
+  adds `https://malibu.tech`, `https://www.malibu.tech`,
+  `http://127.0.0.1:5173`, `http://localhost:5173`. Confirm:
+  - `Access-Control-Allow-Credentials` is set to `false` in
+    `setCORSHeaders` (cors.go L46). Confirm the exchange handler does
+    NOT rely on cookies (it accepts the token via JSON body).
+  - The API key returned in the response body is NOT wrapped by
+    `Access-Control-Allow-Credentials: true` — if it were, a
+    cross-origin script from ANY allowed origin could read it. Since
+    Credentials is false, the response body is still readable by any
+    allowed origin's script (that's the whole point). Confirm this is
+    intentional and matches Malibu's fetch call shape.
+  - Any origin outside the allowlist gets no CORS headers and their
+    XHR/fetch is blocked. Confirm the request still succeeds
+    server-side (no auth) but the browser drops the response — which
+    means an attacker page from a bad origin still SEES the API key
+    if they can bypass CORS via a preflight bug. Look for
+    preflight-caching abuse (`Access-Control-Max-Age: 3600`
+    combined with wildcard origins).
+
+### SEC-5. Return-to redirect after failure
+On handoff DB failure, `redirectOAuthReturn(returnTo, "handoff_failed")`
+is called. This redirects the user's browser to the attacker-friendly
+`returnTo` URL with `?error=handoff_failed`. Two concerns:
+- Any secret in an error path? Confirm the error code is a stable
+  literal (`no_key`, `handoff_failed`) with no user-controlled data
+  interpolated.
+- If `s.redirectOAuthReturn` is called AFTER `redirectOAuthHandoff`
+  already wrote the redirect header, do we double-write? In the code
+  path `if err := s.redirectOAuthHandoff(...); err != nil { ... }` —
+  `redirectOAuthHandoff` calls `http.Redirect` unconditionally after
+  success. The error path returns before `http.Redirect` runs
+  (it errors before `target.String()`), so redirectOAuthReturn is
+  safe. Confirm this reasoning is right.
+
+### SEC-6. State row `return_to` — cannot be swapped mid-flow
+The `return_to` value is stored in the same `oauth_states` row as the
+state hash. `ConsumeOAuthState` atomically reads it out with the
+redirect_uri and action. Attacker cannot mutate it after start:
+- Confirm no code path allows updating an `oauth_states` row after
+  insert (search for `UPDATE oauth_states`; only the `SET consumed_at`
+  path exists).
+- Confirm `returnTo` is validated at `/auth/github/start` time and NOT
+  re-validated at callback — this is fine because it is bound to the
+  state row, but flag if the callback path could accept a query-param
+  `return_to` override.
+
+### SEC-7. Handoff cookie / cache surfaces
+- `handleHandoffExchange` calls `setNoStoreHeaders(w.Header())`.
+  Confirm this sets `Cache-Control: no-store` and `Pragma: no-cache`
+  (or the project's equivalent) so intermediary proxies do not cache
+  the response containing the API key.
+- The redirect to `returnTo?handoff=<token>` does NOT itself carry
+  the API key — only the token. Confirm.
+
+### SEC-8. Existing account, `action != "mint"` return-to path
+The callback code sets `fullKey == ""` for existing-account non-mint
+flows and takes the `no_key` early-return with `?error=no_key`. Is
+there a way for an attacker to trigger a signup with an attacker-
+controlled `return_to`, then use the resulting session/key for a
+different account? The callback binds identity via GitHub OAuth
+`ProviderUserID`, so no. Confirm the flow.
+
+## Output format
+
+Write a Markdown file at `specs/PR400_HANDOFF_r1_security_audit.md`:
+
+```
+AUDIT_PR400_SECURITY: PASS   # 0 C / 0 H / 0 M
+# or
+AUDIT_PR400_SECURITY: FAIL
+
+CRITICAL: n
+HIGH: n
+MEDIUM: n
+LOW: n
+
+## Findings
+### C1 <title>
+- file: path:line
+- attacker path: <who does what to trigger it>
+- impact: <what they get / what leaks>
+- fix: <concrete change>
+```
+
+Report ONLY defects. LOWs are optional. Do not propose scope
+expansion. End with `VERDICT: security lane READY TO MERGE` iff
+0 C/H/M.

--- a/specs/AUDIT_PR400_HANDOFF_SECURITY_R2_PROMPT.md
+++ b/specs/AUDIT_PR400_HANDOFF_SECURITY_R2_PROMPT.md
@@ -1,0 +1,72 @@
+# AUDIT PR400 SECURITY R2 PROMPT — Malibu OAuth return_to handoff
+
+Round 2 of the security lane. Round 1 findings are in
+`specs/PR400_HANDOFF_r1_security_audit.md`. Read
+`specs/AUDIT_PR400_HANDOFF_SECURITY_PROMPT.md` for the full checklist
+and diff surface.
+
+## Fixes applied since round 1
+
+### r1 SECURITY M1 — `return_to` path allowlist bypasses
+Fixed in `phase5-gateway/internal/router/oauth.go::returnToAllowed`.
+- Exact-path allowlist entries now match ONLY the exact target path.
+- Trailing-`/` allowlist paths are explicit directory prefixes.
+- Targets containing `.` or `..` segments (raw or percent-encoded
+  `%2E` / `%2E%2E`) are rejected outright via `hasDotSegment`.
+
+Confirm the following attacker inputs are rejected with 400
+`oauth_return_to_not_allowed`:
+- `https://malibu.tech/console/auth/callback.htmlx`
+- `https://malibu.tech/console/auth/callback.html/extra`
+- `https://malibu.tech/console/auth/callback.html/../admin`
+- `https://malibu.tech/console/auth/callback.html/%2E%2E/admin`
+- `https://malibu.tech.attacker.example/console/auth/callback.html`
+- `http://malibu.tech/console/auth/callback.html` (scheme mismatch)
+
+Verify by inspecting the code AND by reading the assertions in
+`phase5-gateway/internal/router/oauth_handoff_test.go`
+(`TestReturnToAllowedRejectsPrefixAndTraversal`).
+
+Flag any additional path-shape bypass you can construct (e.g.
+Unicode normalization tricks, path with backslashes on Windows-style
+parsing, whitespace in path). Only rate as HIGH/CRITICAL if you can
+demonstrate an actual attacker path to leak the handoff token.
+
+### r1 SECURITY M2 — Missing `Referrer-Policy`/`Cache-Control` on redirect
+Fixed in `phase5-gateway/internal/router/oauth.go::redirectOAuthHandoff`.
+`Referrer-Policy: no-referrer` and `Cache-Control: no-store` /
+`Pragma: no-cache` / `Expires: 0` are now set on the redirect
+response (via `setNoStoreHeaders`).
+
+Confirm:
+- The headers land on the 302 redirect that includes `?handoff=<token>`.
+- Assertions exist in `TestOAuthHandoffFlowRoundTrip` (the new test
+  in `oauth_handoff_test.go`).
+- The error redirect (`redirectOAuthReturn` on
+  `?error=handoff_failed`) does NOT include the token — that redirect
+  goes to a URL without the raw token, so it does not need the same
+  hardening, but flag if you see a case where a partial URL still
+  carries token material.
+
+## Cross-cutting: fallback cookie on failure
+`handleGitHubCallback` now sets the `mp_new_api_key` cookie for
+every `fullKey != ""` case, regardless of `returnTo`. The cookie is
+`Path=/account`, `HttpOnly`, `Secure` in prod, `SameSite=Lax`,
+`MaxAge=300`.
+
+Security concerns to check:
+- Cookie is scoped to the gateway origin (`api.streamvc.live`) and
+  path `/account`, so no Malibu page can read it — even a compromised
+  Malibu return_to page could not exfiltrate the fallback via
+  document.cookie.
+- Any XSS on `/account` could exfiltrate the cookie — is `/account`
+  already CSP-hardened? Look at `pages.go`. Flag only if the fallback
+  materially changes the risk (it doesn't change the pre-existing
+  cookie behavior — the same cookie was already set in the legacy
+  path — this fix just extends the case).
+
+## Output format
+
+Write findings to `specs/PR400_HANDOFF_r2_security_audit.md` in the
+same format the round-1 audit used. End with
+`VERDICT: security lane READY TO MERGE` iff 0 C/H/M.

--- a/specs/PR400_HANDOFF_r1_architect_audit.md
+++ b/specs/PR400_HANDOFF_r1_architect_audit.md
@@ -1,0 +1,32 @@
+AUDIT_PR400_ARCHITECT: FAIL
+
+CRITICAL: 0
+HIGH: 1
+MEDIUM: 2
+LOW: 1
+
+## Findings
+
+### H1 OAuth handoffs have a prune method but no lifecycle wiring
+- file: phase5-gateway/cmd/gateway/main.go:197
+- observation: `oauthStatePruner` exposes only `PruneExpiredOAuthState`, `runOAuthStatePruner` only calls that method, and `main` only launches that pruner. The SQLite store implements `PruneExpiredOAuthHandoffs`, but no background loop invokes it.
+- risk: `oauth_handoffs` persists every handoff row indefinitely. Consumed rows and expired unconsumed rows both remain after their 5-minute validity window, so a production instance accumulates stale API-key handoff material and grows the table/B-tree over months. There is no restart truncation, TTL, VACUUM cleanup, or alternate delete path.
+- fix: extend the existing OAuth pruner interface/loop to call both `PruneExpiredOAuthState` and `PruneExpiredOAuthHandoffs`, or add a sibling `runOAuthHandoffPruner` launched from `main` on the same cadence. Add a `cmd/gateway` test fake that fails unless both methods are invoked.
+
+### M1 Return-to and CORS allowlists can drift into a broken Malibu flow
+- file: phase5-gateway/internal/config/config.go:364
+- observation: `Validate` checks `auth.oauth.return_to_allowlist` entries only as absolute URLs and checks `cors.allowed_origins` entries only as exact origins, but it never verifies that every return-to scheme+host has a corresponding CORS origin. The example YAML updates both lists, but production config can update one without the other.
+- risk: OAuth can accept a Malibu `return_to`, redirect back with a valid `handoff`, and then the browser-side `POST /auth/handoff/exchange` fails CORS because `withCORS` only reflects origins present in `cors.allowed_origins`. That leaves the user back on Malibu without an API key even though the OAuth flow and handoff creation succeeded.
+- fix: in config validation, normalize each `return_to_allowlist` URL to `scheme://host` and require it in `cors.allowed_origins`, or derive the CORS origins for `/auth/handoff/exchange` from the return-to allowlist at boot. Cover the drift case in `config_test.go`.
+
+### M2 Handoff persistence failure consumes state after minting an inaccessible key
+- file: phase5-gateway/internal/router/oauth.go:100
+- observation: `handleGitHubCallback` consumes the OAuth state before exchanging the GitHub code, then may create an account and issue an API key, and only afterward calls `redirectOAuthHandoff`. If `StoreOAuthHandoff` fails, the handler redirects to `return_to?error=handoff_failed`; the state row is already consumed and the newly issued key is not delivered.
+- risk: on a transient DB error or disk-full condition after key issuance, the user receives no API key and cannot retry the same OAuth callback. In the signup branch this can leave an account plus active `mp_*` key that the user never saw; a later retry is now an existing-account flow and may return `no_key` unless the client also opts into minting.
+- fix: make the callback storage transition atomic at the abstraction boundary: consume state, persist the issued key, and persist the handoff in one store transaction, or add a compensating path that revokes/deletes the just-issued key and leaves a retryable state when handoff persistence fails. At minimum, document and test the retry contract for the Malibu start URL if the intended recovery is `action=mint`.
+
+### L1 CORS-only handoff route lacks a local route-level explanation
+- file: phase5-gateway/internal/router/server.go:191
+- observation: `/auth/handoff/exchange` is correctly registered with `withCORS(POST, ...)`, while `/auth/github/start` and `/auth/github/callback` remain plain navigation routes. The route table itself does not explain why this OAuth sibling needs CORS and the others do not.
+- risk: future route cleanup can treat the asymmetry as accidental and remove CORS from the only XHR leg of the Malibu handoff flow.
+- fix: add a short registration comment noting that the start/callback routes are browser navigations, but Malibu exchanges the handoff token from its origin via XHR/fetch.

--- a/specs/PR400_HANDOFF_r1_code_audit.md
+++ b/specs/PR400_HANDOFF_r1_code_audit.md
@@ -1,0 +1,21 @@
+AUDIT_PR400_CODE: FAIL
+
+CRITICAL: 0
+HIGH: 0
+MEDIUM: 2
+LOW: 0
+
+## Findings
+### M1 `return_to` path allowlist overmatches specific callback files
+- file: phase5-gateway/internal/router/oauth.go:392
+- evidence: `returnToAllowed` accepts any target path with `strings.HasPrefix(target.Path, u.Path)`, while `gateway.yaml.example` allowlists specific callback documents such as `https://malibu.tech/console/auth/callback.html`.
+- impact: A configured allowlist entry for `/console/auth/callback.html` also allows `/console/auth/callback.html/extra` and `/console/auth/callback.htmlish` on the same scheme/host. That does not match the example config shape, which names exact `.html` callback files, and can redirect the OAuth handoff to an unintended Malibu route instead of the callback page expected to exchange the token.
+- fix: Make non-empty allowlist paths exact by default, or use explicit directory-prefix semantics only for allowlist paths ending in `/`. For example, accept when `target.Path == u.Path`, or when `strings.HasSuffix(u.Path, "/") && strings.HasPrefix(target.Path, u.Path)`. Add a router-level `TestReturnToAllowedExactCallbackPath` covering exact match, `/extra`, and `.htmlish`.
+
+### M2 New `return_to` and handoff behavior lacks regression coverage
+- file: phase5-gateway/internal/storage/sqlite/store_test.go:247
+- evidence: `TestOAuthStateAndRateLimitStores` only asserts the new `returnTo` return value is empty; repository test search shows no `OAuthHandoff`, `StoreOAuthHandoff`, `ConsumeOAuthHandoff`, `PruneExpiredOAuthHandoffs`, `returnToAllowed`, or `/auth/handoff/exchange` test coverage.
+- impact: The new key-delivery path can regress while the current test suite still passes: a non-empty `ReturnTo` may fail to round-trip through `StoreOAuthStateWithCap` and `ConsumeOAuthState`, one-time handoff replay/expiry/prune behavior may break, or the HTTP exchange contract may drift from `{ "api_key": "mp_..." }` without a failing test.
+- fix: Add focused tests named `TestOAuthStateReturnToRoundTrip`, `TestOAuthHandoffStoreConsumeReplay`, `TestOAuthHandoffExpiredReturnsNotFound`, `TestPruneExpiredOAuthHandoffs`, `TestReturnToAllowed`, and `TestHandoffExchange`. Cover 405, empty body, unknown token, valid token, and replay for `/auth/handoff/exchange`.
+
+VERDICT: code lane NOT READY TO MERGE

--- a/specs/PR400_HANDOFF_r1_security_audit.md
+++ b/specs/PR400_HANDOFF_r1_security_audit.md
@@ -1,0 +1,19 @@
+AUDIT_PR400_SECURITY: FAIL
+
+CRITICAL: 0
+HIGH: 0
+MEDIUM: 2
+LOW: 0
+
+## Findings
+### M1 `return_to` path allowlist accepts prefix and dot-segment bypasses
+- file: phase5-gateway/internal/router/oauth.go:381
+- attacker path: An attacker starts OAuth with an allowlisted Malibu origin but a non-callback path that still has the allowlisted callback path as a raw prefix, such as `https://malibu.tech/console/auth/callback.htmlx` or `https://malibu.tech/console/auth/callback.html/../../../admin`. `returnToAllowed` compares `target.Path` with `strings.HasPrefix` and does not clean or boundary-check the path before accepting it.
+- impact: The gateway can redirect a fresh one-time handoff bearer token to a non-callback path on an allowlisted origin. If any accepted sibling/traversed path is attacker-controllable, open-redirecting, or emits the full URL via referrer/telemetry, the attacker can exchange the leaked handoff token for the live `mp_*` API key within the five-minute window.
+- fix: Parse and validate against canonical paths before storing `return_to`: reject any `.` or `..` path segment, reject encoded slash/dot traversal after unescaping, and require exact path equality for file allowlist entries such as `/console/auth/callback.html` unless the allowlist explicitly marks an entry as a directory prefix with a `/` boundary.
+
+### M2 Handoff token redirect lacks no-referrer/no-store protection
+- file: phase5-gateway/internal/router/oauth.go:360
+- attacker path: A victim completes OAuth through Malibu handoff. `redirectOAuthHandoff` adds `handoff=<raw token>` to the destination query string and immediately calls `http.Redirect` without setting `Referrer-Policy: no-referrer` or no-store headers on the redirect response.
+- impact: The one-time handoff token is a bearer credential for `/auth/handoff/exchange`. It is short-lived and single-use, but while valid it can leak through browser history, intermediary/access logs, and referrer chains from the callback URL before Malibu exchanges and clears it. Any party that obtains it first can trade it for the returned API key.
+- fix: Before the redirect, set `Referrer-Policy: no-referrer` and `Cache-Control: no-store`/`Pragma: no-cache` on the response. Prefer delivering the handoff in the URL fragment plus immediate `history.replaceState` on the Malibu callback page so it is not sent in HTTP request lines or server access logs.

--- a/specs/PR400_HANDOFF_r2_architect_audit.md
+++ b/specs/PR400_HANDOFF_r2_architect_audit.md
@@ -1,0 +1,33 @@
+AUDIT_PR400_ARCHITECT_R2: FAIL
+
+CRITICAL: 0
+HIGH: 0
+MEDIUM: 1
+LOW: 0
+
+## Findings
+
+### M1 Handoff-store failure fallback is not a stable recovery contract
+- file: phase5-gateway/internal/router/oauth.go:163
+- observation: `handleGitHubCallback` now sets the `mp_new_api_key` cookie before entering the `returnTo` handoff branch, so the key is not strictly lost if `StoreOAuthHandoff` fails. However, the actual failure redirect is still only `return_to?error=handoff_failed` (`phase5-gateway/internal/router/oauth.go:180`), while the recovery page is a different gateway-origin route (`/account`) that reads and clears the cookie (`phase5-gateway/internal/router/pages.go:79`). The cookie is scoped to `/account` and expires after 300 seconds (`phase5-gateway/internal/router/oauth.go:171`).
+- risk: this is an improvement over round 1, but it is not yet a normal, stable user-facing recovery path. If Malibu displays the error locally, waits for user action, or does not know to navigate to `https://api.streamvc.live/account` inside the 5-minute cookie window, the user still cannot retrieve the newly minted key. The gateway contract does not put the recovery URL in the redirect, extend the recovery window, or otherwise guarantee that the paired client will land the user on `/account` before the fallback cookie expires. This is not a HIGH/CRITICAL strict-loss scenario because the cookie fallback can recover the key, but the recovery depends on cross-client behavior outside the gateway contract.
+- fix: make the failure fallback explicit and durable at the gateway/client contract boundary. For example, redirect with a documented recovery URL parameter, redirect directly to the gateway `/account` page on `StoreOAuthHandoff` failure, or increase/replace the 300-second cookie fallback with a one-shot recovery token whose UX is explicitly exercised by a gateway test. Keep the existing pre-handoff cookie as defense in depth.
+
+## Confirmed Closed / Non-Blocking Checks
+
+- r1 H1 is closed: `oauthStatePruner` requires both `PruneExpiredOAuthState` and `PruneExpiredOAuthHandoffs` (`phase5-gateway/cmd/gateway/main.go:197`), `runOAuthStatePruner` invokes both immediately and on each tick (`phase5-gateway/cmd/gateway/main.go:213`, `phase5-gateway/cmd/gateway/main.go:218`), and `main` still launches that loop with the concrete store (`phase5-gateway/cmd/gateway/main.go:81`). Name search found no alternate `AuthStore` / `OAuthStateStore` implementation missing the handoff pruner; the SQLite store remains the concrete implementation.
+- r1 M1 is closed: config validation first validates return-to URLs, then builds a lowercase `scheme://host` set from exact CORS origins, then checks each return-to origin against that set (`phase5-gateway/internal/config/config.go:364`, `phase5-gateway/internal/config/config.go:454`). The check is order-independent, empty `return_to_allowlist` is a no-op loop, and the error includes both the offending index and normalized origin (`phase5-gateway/internal/config/config.go:477`).
+- Migration compatibility remains clean: v9 fresh schema embeds `oauth_states.return_to` and `oauth_handoffs`; upgrade helpers preserve existing DBs; schema version 9 is stamped with the existing `INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(9, ?)` pattern; rollback remains gated by `maxKnownSchemaVersion`.
+- Gateway/Malibu contract names match the prompt: redirect query parameter `handoff`, exchange endpoint `/auth/handoff/exchange`, request body field `handoff`, response field `api_key`, and error redirects `no_key` / `handoff_failed`.
+- `AuthStore` / `OAuthStateStore` method parity is compile-enforced by the concrete SQLite store and current call sites; no separate interchangeable test double was found that would create a divergence hazard.
+- Legacy no-`return_to` behavior is preserved: when `returnTo == ""`, the callback still redirects to `Public.AccountPath` after setting the `mp_new_api_key` cookie.
+- r1 L1 remains a LOW route-comment issue and is skipped per the round-2 prompt/project convention.
+
+## Verification
+
+- `rg -n "AuthStore|OAuthStateStore|oauthStatePruner|runOAuthStatePruner\\(" phase5-gateway --glob '*.go'`
+- `rg -n "PruneExpiredOAuthHandoffs|PruneExpiredOAuthState|StoreOAuthHandoff|ConsumeOAuthHandoff|return_to_allowlist|ReturnToAllowlist" phase5-gateway`
+- `go test -count=1 ./cmd/gateway ./internal/config ./internal/router ./internal/storage/sqlite`
+- `go test ./...` from `phase5-gateway`
+
+VERDICT: architect lane NOT READY TO MERGE

--- a/specs/PR400_HANDOFF_r2_code_audit.md
+++ b/specs/PR400_HANDOFF_r2_code_audit.md
@@ -1,0 +1,22 @@
+AUDIT_PR400_CODE: PASS
+
+CRITICAL: 0
+HIGH: 0
+MEDIUM: 0
+LOW: 0
+
+## Findings
+No code-lane defects found.
+
+## Verification
+- r1 CODE M1 is closed: `returnToAllowed` now requires exact path equality for non-directory allowlist paths, preserves explicit trailing-slash directory-prefix semantics, and rejects literal or `%2E`-encoded dot segments before matching. The exact `/console/auth/callback.html` case accepts, while `.htmlx`, `/extra`, and `/../admin` targets reject; empty and `/` allowlist paths still match any path on the same scheme/host.
+- r1 CODE M2 is closed: the added sqlite tests assert non-empty `ReturnTo` round-trip, handoff happy path, replay rejection, expiry rejection, and pruning counts. The added router tests assert return_to rejection cases, callback-to-handoff-to-exchange round-trip, replay failure, 405/empty/unknown-token error surfaces, fallback cookie presence, and response no-store/referrer headers.
+- Cross-cutting cookie check passed: `handleGitHubCallback` sets `mp_new_api_key` before the `returnTo` branch whenever `fullKey != ""`; the cookie remains `Path=/account`, `HttpOnly`, and same gateway-origin scoped, and the legacy `returnTo == "" && fullKey != ""` flow still writes the cookie before redirecting to `s.cfg.Public.AccountPath`.
+- Cross-cutting redirect-header check passed: `redirectOAuthHandoff` sets `Referrer-Policy: no-referrer` and `Cache-Control: no-store` before `http.Redirect`; router tests covering these headers pass.
+
+## Tests
+- `go test ./internal/storage/sqlite` from `phase5-gateway`
+- `go test ./internal/router` from `phase5-gateway`
+- `go test ./...` from `phase5-gateway`
+
+VERDICT: code lane READY TO MERGE

--- a/specs/PR400_HANDOFF_r2_security_audit.md
+++ b/specs/PR400_HANDOFF_r2_security_audit.md
@@ -1,0 +1,11 @@
+AUDIT_PR400_SECURITY: PASS
+
+CRITICAL: 0
+HIGH: 0
+MEDIUM: 0
+LOW: 0
+
+## Findings
+(none)
+
+VERDICT: security lane READY TO MERGE

--- a/specs/PR400_HANDOFF_r3_architect_audit.md
+++ b/specs/PR400_HANDOFF_r3_architect_audit.md
@@ -1,0 +1,51 @@
+AUDIT_PR400_ARCHITECT_R3: PASS
+
+CRITICAL: 0
+HIGH: 0
+MEDIUM: 0
+LOW: 0
+
+## Findings
+
+(none)
+
+## Confirmed Closed / Non-Blocking Checks
+
+- r2 ARCHITECT M1 is closed: `handleGitHubCallback` sets the
+  `mp_new_api_key` fallback cookie before entering the `returnTo` branch
+  (`phase5-gateway/internal/router/oauth.go:163`), and on
+  `StoreOAuthHandoff` failure it now redirects directly to
+  `s.cfg.Public.AccountPath` (`phase5-gateway/internal/router/oauth.go:180`).
+  That path is the gateway `/account` page, which reads and clears the cookie
+  (`phase5-gateway/internal/router/pages.go:79`).
+- The failure path does not double-redirect: `redirectOAuthHandoff` returns
+  before writing a redirect when token generation, storage, or URL parsing
+  fails (`phase5-gateway/internal/router/oauth.go:355`), and writes the Malibu
+  handoff redirect only after those steps succeed
+  (`phase5-gateway/internal/router/oauth.go:383`). Therefore the callback's
+  `/account` redirect is the only `Location` write on an induced
+  `StoreOAuthHandoff` failure.
+- The former Malibu `?error=handoff_failed` persistence-failure route is dead
+  in the gateway callback. Name search found no `handoff_failed` emission in
+  `phase5-gateway/internal/router`, while `redirectOAuthReturn` remains in use
+  for the existing-account/no-new-key `no_key` branch
+  (`phase5-gateway/internal/router/oauth.go:176`).
+- The recovery contract is pinned by
+  `TestOAuthHandoffPersistenceFailureRedirectsToAccount`, which forces
+  `StoreOAuthHandoff` to fail and asserts both the `/account` redirect and
+  the fallback `mp_new_api_key` cookie
+  (`phase5-gateway/internal/router/oauth_handoff_test.go:174`).
+- No new C/H/M architecture defect surfaced in the reviewed handoff failure
+  path. The parity, lifecycle, migration, and return-to/CORS concerns closed
+  in prior rounds remain closed for this lane.
+- r1 L1 remains a LOW route-comment issue and is skipped per the prompt /
+  project convention.
+
+## Verification
+
+- `rg -n "handoff_failed|StoreOAuthHandoff|redirectOAuthHandoff|redirectOAuthReturn|mp_new_api_key|AccountPath" phase5-gateway/internal/router phase5-gateway/internal/config phase5-gateway/cmd/gateway`
+- `rg -n "error=handoff_failed|handoff_failed" . --glob '!audits/**' --glob '!specs/PR400_HANDOFF_r2_architect_audit.md'`
+- `go test -count=1 ./internal/router` from `phase5-gateway`
+- `go test -count=1 ./...` from `phase5-gateway`
+
+VERDICT: architect lane READY TO MERGE


### PR DESCRIPTION
## Summary
- Add `return_to` query param on `GET /auth/github/start` with an allowlisted redirect target for Malibu console OAuth completion
- Issue one-time handoff tokens after signup/mint and redirect back to Malibu instead of the gateway `/account` page
- Add `POST /auth/handoff/exchange` so Malibu can exchange the handoff token for the full `mp_*` API key once

## Why
Malibu console now uses same-window GitHub sign-in and expects users to return authenticated with their API key saved automatically. The previous flow opened the Mac Provider account page and required manual copy/paste.

## Malibu side
Paired frontend change is in https://github.com/MalibuAI/malibu (branch `site-review-2026-07`, commit `5a677d1`).

## Production deploy notes
After merge, update Pearl `gateway.yaml`:
- `auth.oauth.return_to_allowlist`: add `https://malibu.tech/console/auth/callback.html` and `https://www.malibu.tech/console/auth/callback.html`
- `cors.allowed_origins`: add `https://malibu.tech` and `https://www.malibu.tech`

## Test plan
- [x] `go test ./...` in `phase5-gateway`
- [ ] `GET /auth/github/start?return_to=https://malibu.tech/console/auth/callback.html&action=mint` completes GitHub OAuth and redirects with `?handoff=…`
- [ ] `POST /auth/handoff/exchange` returns `{ "api_key": "mp_…" }` once, then rejects replay
- [ ] Malibu console sign-in returns as Connected without manual key paste


Made with [Cursor](https://cursor.com)