### PR TITLE
[codex] Preserve SPEC-028 benchmark evidence

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -11,7 +11,7 @@ struct MacProviderCLI: AsyncParsableCommand {
         commandName: "macprovider-cli",
         abstract: "OpenAI-compatible Mac Provider inference CLI.",
         version: CoordinatorClient.binaryVersion,
-        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, RotateKeyCommand.self, Spec028CanaryCommand.self, DecodeBenchCommand.self, EnrollCommand.self],
+        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, RotateKeyCommand.self, Spec028CanaryCommand.self, Spec028BenchmarkCommand.self, DecodeBenchCommand.self, EnrollCommand.self],
         defaultSubcommand: ServeCommand.self
     )
 }

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -2098,17 +2098,23 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 
     static func tokenizerArtifactFingerprint(in directory: URL) throws -> String? {
-        let tokenizerArtifactNames = [
-            "tokenizer.json",
-            "tokenizer_config.json",
-            "special_tokens_map.json",
-            "tokenizer.model",
-            "vocab.json",
-            "merges.txt",
-            "added_tokens.json",
-            "chat_template.jinja",
-        ]
         let fileManager = FileManager.default
+        let hasFastTokenizer = fileManager.fileExists(atPath: directory.appendingPathComponent("tokenizer.json").path)
+        let tokenizerArtifactNames = hasFastTokenizer
+            ? [
+                "tokenizer.json",
+                "tokenizer_config.json",
+                "special_tokens_map.json",
+                "added_tokens.json",
+            ]
+            : [
+                "tokenizer_config.json",
+                "special_tokens_map.json",
+                "tokenizer.model",
+                "vocab.json",
+                "merges.txt",
+                "added_tokens.json",
+            ]
         let files = try tokenizerArtifactNames.compactMap { name -> TokenizerArtifactManifestFile? in
             let url = directory.appendingPathComponent(name)
             var isDirectory = ObjCBool(false)
@@ -2118,12 +2124,11 @@ actor ModelRuntime: ModelRuntimeServing {
                 return nil
             }
             let contentURL = url.resolvingSymlinksInPath()
-            let attributes = try fileManager.attributesOfItem(atPath: contentURL.path)
-            let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+            let data = try tokenizerArtifactFingerprintData(for: contentURL, name: name)
             return TokenizerArtifactManifestFile(
                 name: name,
-                sha256: try sha256Hex(ofFileAt: contentURL),
-                size: size
+                sha256: hexString(SHA256.hash(data: data)),
+                size: UInt64(data.count)
             )
         }
 
@@ -2134,6 +2139,20 @@ actor ModelRuntime: ModelRuntimeServing {
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         let data = try encoder.encode(manifest)
         return hexString(SHA256.hash(data: data))
+    }
+
+    private static func tokenizerArtifactFingerprintData(for url: URL, name: String) throws -> Data {
+        let data = try Data(contentsOf: url)
+        guard name == "tokenizer_config.json",
+              var root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return data
+        }
+        // Chat-template default prompt text can differ across same-vocabulary
+        // draft/target repos. Runtime token probes plus the equivalence canary
+        // remain the authority for whether such a pair is actually compatible.
+        root.removeValue(forKey: "chat_template")
+        return try JSONSerialization.data(withJSONObject: root, options: [.sortedKeys, .withoutEscapingSlashes])
     }
 
     private static func sha256Hex(ofFileAt url: URL) throws -> String {

--- a/phase3-binary/Sources/macprovider-cli/Spec028BenchmarkCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/Spec028BenchmarkCommand.swift
@@ -1,0 +1,414 @@
+import ArgumentParser
+import Foundation
+import MacProviderCore
+
+struct Spec028BenchmarkCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "spec028-benchmark",
+        abstract: "Measure SPEC-028 speculative decoding impact against the baseline path."
+    )
+
+    @Option(name: .customLong("fixture"), help: "Fixture JSON path. May be repeated. Defaults to the AC-10 fixture.")
+    var fixturePaths: [String] = []
+
+    @Option(help: "Target model local snapshot path. Overrides each fixture target model load path.")
+    var target: String?
+
+    @Option(help: "Draft model local snapshot path. Overrides each fixture draft model load path.")
+    var draft: String?
+
+    @Option(help: "Speculative draft tokens per verification round.")
+    var numDraftTokens: Int = 3
+
+    @Option(help: "Maximum prompt context tokens.")
+    var maxContextTokens: Int = ProviderCapacity.draftContextCapForCurrentHost()
+
+    @Option(help: "Number of baseline samples per fixture.")
+    var baselineRuns: Int = 3
+
+    @Option(help: "Number of speculative samples per fixture.")
+    var specRuns: Int = 3
+
+    @Option(help: "Sustained speculative window in seconds. Use 0 to skip.")
+    var sustainedSeconds: Double = 0
+
+    @Option(help: "Trailing sustained window in seconds for sustained ratio reporting.")
+    var lastWindowSeconds: Double = 30
+
+    @Option(help: "Minimum median speculative/baseline TPS ratio for a positive recommendation.")
+    var recommendRatioFloor: Double = 1.15
+
+    @Option(help: "Maximum allowed p95 latency multiplier for a positive recommendation.")
+    var maxP95LatencyRatio: Double = 1.0
+
+    @Option(help: "Maximum allowed p95 TTFT multiplier for a positive recommendation.")
+    var maxP95TTFTRatio: Double = 1.0
+
+    @Option(help: "Minimum speculative accepted/drafted token rate for a positive recommendation.")
+    var recommendAcceptanceFloor: Double = 0.30
+
+    @Flag(help: "Emit one compact JSON object per fixture instead of a single pretty-printed report.")
+    var jsonl = false
+
+    mutating func validate() throws {
+        guard baselineRuns > 0 else {
+            throw ValidationError("--baseline-runs must be > 0")
+        }
+        guard specRuns > 0 else {
+            throw ValidationError("--spec-runs must be > 0")
+        }
+        guard sustainedSeconds >= 0 else {
+            throw ValidationError("--sustained-seconds must be >= 0")
+        }
+        guard lastWindowSeconds > 0 else {
+            throw ValidationError("--last-window-seconds must be > 0")
+        }
+        guard numDraftTokens >= 1 && numDraftTokens <= 16 else {
+            throw ValidationError("--num-draft-tokens must be in 1...16")
+        }
+        guard recommendRatioFloor > 0 else {
+            throw ValidationError("--recommend-ratio-floor must be > 0")
+        }
+        guard maxP95LatencyRatio > 0 else {
+            throw ValidationError("--max-p95-latency-ratio must be > 0")
+        }
+        guard maxP95TTFTRatio > 0 else {
+            throw ValidationError("--max-p95-ttft-ratio must be > 0")
+        }
+        guard recommendAcceptanceFloor >= 0 && recommendAcceptanceFloor <= 1 else {
+            throw ValidationError("--recommend-acceptance-floor must be in 0...1")
+        }
+    }
+
+    mutating func run() async throws {
+        let fixtures = try loadFixtures()
+        var results: [Spec028BenchmarkFixtureResult] = []
+        for fixture in fixtures {
+            results.append(try await benchmark(fixture: fixture))
+            if jsonl, let latest = results.last {
+                try Self.emit(latest, pretty: false)
+            }
+        }
+        guard !jsonl else { return }
+        try Self.emit(
+            Spec028BenchmarkReport(
+                benchmark: "SPEC-028",
+                generatedAtUnixSeconds: Date().timeIntervalSince1970,
+                host: HostEvidence.current(),
+                binaryVersion: CoordinatorClient.binaryVersion,
+                fixtures: results
+            ),
+            pretty: true
+        )
+    }
+
+    private func loadFixtures() throws -> [Spec028CanaryFixture] {
+        if fixturePaths.isEmpty {
+            return [try Spec028CanaryFixture.load(path: nil)]
+        }
+        return try fixturePaths.map { path in
+            try Spec028CanaryFixture.load(
+                path: path,
+                defaultResourceName: URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent,
+                defaultFixturePath: path,
+                label: "SPEC-028 benchmark"
+            )
+        }
+    }
+
+    private func benchmark(fixture: Spec028CanaryFixture) async throws -> Spec028BenchmarkFixtureResult {
+        let targetLoadPath = target ?? fixture.targetModel
+        let draftLoadPath = draft ?? fixture.draftModel
+        let runtime = try await ModelRuntime(
+            modelID: fixture.targetModel,
+            modelLoadPath: targetLoadPath,
+            draftModelID: fixture.draftModel,
+            draftModelLoadPath: draftLoadPath,
+            numDraftTokens: numDraftTokens,
+            maxContextTokensOverride: maxContextTokens,
+            maxBatch: 1,
+            warmSwapEnabled: false
+        )
+        let baselineRequest = try fixture.request(forceTokenIterator: true)
+        let specRequest = try fixture.request(forceTokenIterator: false)
+        var baselineSamples: [Spec028BenchmarkSample] = []
+        var specSamples: [Spec028BenchmarkSample] = []
+        var sustainedSamples: [Spec028BenchmarkSample] = []
+
+        for _ in 0..<baselineRuns {
+            baselineSamples.append(try await Self.measure(runtime: runtime, request: baselineRequest, phase: "baseline"))
+        }
+        for _ in 0..<specRuns {
+            specSamples.append(try await Self.measure(runtime: runtime, request: specRequest, phase: "spec"))
+        }
+
+        let sustainedStartedAt = Date()
+        let sustainedDeadline = sustainedStartedAt.addingTimeInterval(sustainedSeconds)
+        while Date() < sustainedDeadline {
+            sustainedSamples.append(try await Self.measure(runtime: runtime, request: specRequest, phase: "sustained"))
+        }
+        let sustainedEndedAt = Date()
+        let evaluation = try Spec028BenchmarkEvaluation.evaluate(
+            baselineSamples: baselineSamples,
+            specSamples: specSamples,
+            sustainedSamples: sustainedSamples,
+            sustainedEndedAt: sustainedEndedAt,
+            lastWindowSeconds: lastWindowSeconds,
+            recommendRatioFloor: recommendRatioFloor,
+            maxP95LatencyRatio: maxP95LatencyRatio,
+            maxP95TTFTRatio: maxP95TTFTRatio,
+            recommendAcceptanceFloor: recommendAcceptanceFloor
+        )
+        return Spec028BenchmarkFixtureResult(
+            fixtureID: fixture.fixtureID,
+            targetModel: fixture.targetModel,
+            draftModel: fixture.draftModel,
+            targetLoadPath: Self.evidenceModelRef(targetLoadPath),
+            draftLoadPath: Self.evidenceModelRef(draftLoadPath),
+            numDraftTokens: numDraftTokens,
+            maxContextTokens: maxContextTokens,
+            request: Spec028BenchmarkRequestSummary(
+                stream: specRequest.stream,
+                temperature: specRequest.temperature,
+                topP: specRequest.topP,
+                maxTokens: specRequest.maxTokens
+            ),
+            evaluation: evaluation,
+            baselineSamples: baselineSamples,
+            specSamples: specSamples,
+            sustainedSamples: sustainedSamples
+        )
+    }
+
+    private static func measure(
+        runtime: ModelRuntime,
+        request: ChatCompletionRequest,
+        phase: String
+    ) async throws -> Spec028BenchmarkSample {
+        let startedAt = Date()
+        let chunkCounter = Spec028BenchmarkLockedCounter()
+        let completion: CompletionResult
+        if request.stream {
+            let handle = try await runtime.acquireRequestHandle(request)
+            do {
+                try await runtime.preflight(request, with: handle)
+                completion = try await runtime.stream(request, with: handle) { chunk in
+                    switch chunk {
+                    case .content, .toolCallDelta:
+                        chunkCounter.increment()
+                    }
+                }
+                await runtime.unregisterInFlight(handle.registrationID)
+            } catch {
+                await runtime.unregisterInFlight(handle.registrationID)
+                throw error
+            }
+        } else {
+            completion = try await runtime.complete(request)
+        }
+        let endedAt = Date()
+        let elapsed = max(endedAt.timeIntervalSince(startedAt), 0.001)
+        return Spec028BenchmarkSample(
+            phase: phase,
+            promptTokens: completion.promptTokens,
+            completionTokens: completion.completionTokens,
+            elapsedSeconds: elapsed,
+            tokensPerSecond: Double(completion.completionTokens) / elapsed,
+            ttftMilliseconds: completion.ttftMilliseconds,
+            draftedTokens: completion.specDecodeDraftedTokens,
+            acceptedTokens: completion.specDecodeAcceptedTokens,
+            streamedChunks: chunkCounter.value,
+            endedAtUnixSeconds: endedAt.timeIntervalSince1970,
+            thermalState: ProcessInfo.processInfo.thermalState.label
+        )
+    }
+
+    private static func emit<T: Encodable>(_ value: T, pretty: Bool) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = pretty ? [.prettyPrinted, .sortedKeys] : [.sortedKeys]
+        let data = try encoder.encode(value)
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+    }
+
+    private static func evidenceModelRef(_ value: String) -> String {
+        ProviderStatus.publicSpecDecodeDraftModelID(value) ?? "unknown"
+    }
+}
+
+struct Spec028BenchmarkEvaluation: Encodable, Equatable {
+    let baselineMedianTPS: Double
+    let specMedianTPS: Double
+    let tpsRatio: Double
+    let baselineP95LatencyMS: Double
+    let specP95LatencyMS: Double
+    let p95LatencyRatio: Double
+    let baselineP95TTFTMS: Double?
+    let specP95TTFTMS: Double?
+    let ttftP95Ratio: Double?
+    let acceptanceRate: Double?
+    let sustainedMedianTPS: Double?
+    let sustainedRatio: Double?
+    let recommendEnable: Bool
+    let recommendationReasons: [String]
+
+    static func evaluate(
+        baselineSamples: [Spec028BenchmarkSample],
+        specSamples: [Spec028BenchmarkSample],
+        sustainedSamples: [Spec028BenchmarkSample],
+        sustainedEndedAt: Date,
+        lastWindowSeconds: Double,
+        recommendRatioFloor: Double,
+        maxP95LatencyRatio: Double,
+        maxP95TTFTRatio: Double,
+        recommendAcceptanceFloor: Double
+    ) throws -> Spec028BenchmarkEvaluation {
+        guard let baselineMedianTPS = median(baselineSamples.map(\.tokensPerSecond)), baselineMedianTPS > 0 else {
+            throw ValidationError("SPEC-028 benchmark baseline did not produce throughput samples")
+        }
+        guard let specMedianTPS = median(specSamples.map(\.tokensPerSecond)) else {
+            throw ValidationError("SPEC-028 benchmark speculative run did not produce throughput samples")
+        }
+        let baselineLatencyP95 = percentile95(baselineSamples.map { $0.elapsedSeconds * 1_000 })
+        let specLatencyP95 = percentile95(specSamples.map { $0.elapsedSeconds * 1_000 })
+        guard let baselineLatencyP95, baselineLatencyP95 > 0, let specLatencyP95 else {
+            throw ValidationError("SPEC-028 benchmark did not produce latency samples")
+        }
+
+        let baselineTTFTP95 = percentile95(baselineSamples.compactMap(\.ttftMilliseconds).map(Double.init))
+        let specTTFTP95 = percentile95(specSamples.compactMap(\.ttftMilliseconds).map(Double.init))
+        let ttftRatio = Self.ratio(numerator: specTTFTP95, denominator: baselineTTFTP95)
+        let drafted = specSamples.reduce(0) { $0 + $1.draftedTokens }
+        let accepted = specSamples.reduce(0) { $0 + $1.acceptedTokens }
+        let acceptanceRate = drafted > 0 ? Double(accepted) / Double(drafted) : nil
+        let lastWindowStart = sustainedEndedAt.timeIntervalSince1970 - lastWindowSeconds
+        let lastWindowSamples = sustainedSamples.filter { $0.endedAtUnixSeconds >= lastWindowStart }
+        let sustainedMedian = median(lastWindowSamples.map(\.tokensPerSecond))
+        let sustainedRatio = sustainedMedian.map { $0 / baselineMedianTPS }
+        let tpsRatio = specMedianTPS / baselineMedianTPS
+        let p95LatencyRatio = specLatencyP95 / baselineLatencyP95
+
+        var reasons: [String] = []
+        if tpsRatio < recommendRatioFloor {
+            reasons.append(String(format: "TPS ratio %.3f < %.3f", tpsRatio, recommendRatioFloor))
+        }
+        if p95LatencyRatio > maxP95LatencyRatio {
+            reasons.append(String(format: "p95 latency ratio %.3f > %.3f", p95LatencyRatio, maxP95LatencyRatio))
+        }
+        if let ttftRatio {
+            if ttftRatio > maxP95TTFTRatio {
+                reasons.append(String(format: "p95 TTFT ratio %.3f > %.3f", ttftRatio, maxP95TTFTRatio))
+            }
+        } else {
+            reasons.append("p95 TTFT ratio unavailable")
+        }
+        if acceptanceRate == nil || acceptanceRate! < recommendAcceptanceFloor {
+            reasons.append(String(format: "acceptance %.3f < %.3f", acceptanceRate ?? 0, recommendAcceptanceFloor))
+        }
+        if let sustainedRatio, sustainedRatio < recommendRatioFloor {
+            reasons.append(String(format: "sustained TPS ratio %.3f < %.3f", sustainedRatio, recommendRatioFloor))
+        }
+
+        return Spec028BenchmarkEvaluation(
+            baselineMedianTPS: baselineMedianTPS,
+            specMedianTPS: specMedianTPS,
+            tpsRatio: tpsRatio,
+            baselineP95LatencyMS: baselineLatencyP95,
+            specP95LatencyMS: specLatencyP95,
+            p95LatencyRatio: p95LatencyRatio,
+            baselineP95TTFTMS: baselineTTFTP95,
+            specP95TTFTMS: specTTFTP95,
+            ttftP95Ratio: ttftRatio,
+            acceptanceRate: acceptanceRate,
+            sustainedMedianTPS: sustainedMedian,
+            sustainedRatio: sustainedRatio,
+            recommendEnable: reasons.isEmpty,
+            recommendationReasons: reasons
+        )
+    }
+
+    private static func ratio(numerator: Double?, denominator: Double?) -> Double? {
+        guard let numerator, let denominator, denominator > 0 else {
+            return nil
+        }
+        return numerator / denominator
+    }
+
+    private static func median(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let sorted = values.sorted()
+        let mid = sorted.count / 2
+        if sorted.count % 2 == 0 {
+            return (sorted[mid - 1] + sorted[mid]) / 2.0
+        }
+        return sorted[mid]
+    }
+
+    private static func percentile95(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let sorted = values.sorted()
+        let rank = max(0, Int(ceil(Double(sorted.count) * 0.95)) - 1)
+        return sorted[min(rank, sorted.count - 1)]
+    }
+}
+
+struct Spec028BenchmarkSample: Encodable, Equatable {
+    let phase: String
+    let promptTokens: Int
+    let completionTokens: Int
+    let elapsedSeconds: Double
+    let tokensPerSecond: Double
+    let ttftMilliseconds: Int64?
+    let draftedTokens: Int
+    let acceptedTokens: Int
+    let streamedChunks: Int
+    let endedAtUnixSeconds: Double
+    let thermalState: String
+}
+
+private struct Spec028BenchmarkReport: Encodable {
+    let benchmark: String
+    let generatedAtUnixSeconds: Double
+    let host: HostEvidence
+    let binaryVersion: String
+    let fixtures: [Spec028BenchmarkFixtureResult]
+}
+
+private struct Spec028BenchmarkFixtureResult: Encodable {
+    let fixtureID: String
+    let targetModel: String
+    let draftModel: String
+    let targetLoadPath: String
+    let draftLoadPath: String
+    let numDraftTokens: Int
+    let maxContextTokens: Int
+    let request: Spec028BenchmarkRequestSummary
+    let evaluation: Spec028BenchmarkEvaluation
+    let baselineSamples: [Spec028BenchmarkSample]
+    let specSamples: [Spec028BenchmarkSample]
+    let sustainedSamples: [Spec028BenchmarkSample]
+}
+
+private struct Spec028BenchmarkRequestSummary: Encodable {
+    let stream: Bool
+    let temperature: Double
+    let topP: Double
+    let maxTokens: Int?
+}
+
+private final class Spec028BenchmarkLockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/Spec028PlumbingTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/Spec028PlumbingTests.swift
@@ -348,7 +348,29 @@ final class Spec028PlumbingTests: XCTestCase {
     func testTokenizerArtifactFingerprintBindsTokenizerFiles() throws {
         let first = try makeTokenizerSnapshot(tokenizerJSON: #"{"model":"same"}"#, configJSON: #"{"eos_token":"</s>"}"#)
         let matching = try makeTokenizerSnapshot(tokenizerJSON: #"{"model":"same"}"#, configJSON: #"{"eos_token":"</s>"}"#)
+        let matchingExceptChatTemplate = try makeTokenizerSnapshot(
+            tokenizerJSON: #"{"model":"same"}"#,
+            configJSON: #"{"eos_token":"</s>","chat_template":"different default assistant prompt"}"#
+        )
+        let matchingFastTokenizerWithRedundantMerges = try makeTokenizerSnapshot(
+            tokenizerJSON: #"{"model":"same"}"#,
+            configJSON: #"{"eos_token":"</s>"}"#,
+            mergesTXT: "redundant BPE sidecar ignored when tokenizer.json is present"
+        )
+        let divergentConfig = try makeTokenizerSnapshot(tokenizerJSON: #"{"model":"same"}"#, configJSON: #"{"eos_token":"<eos>"}"#)
         let divergent = try makeTokenizerSnapshot(tokenizerJSON: #"{"model":"different"}"#, configJSON: #"{"eos_token":"</s>"}"#)
+        let slowTokenizer = try makeTokenizerSnapshot(
+            tokenizerJSON: nil,
+            configJSON: #"{"eos_token":"</s>"}"#,
+            vocabJSON: #"{"hello":0}"#,
+            mergesTXT: "h e"
+        )
+        let divergentSlowTokenizer = try makeTokenizerSnapshot(
+            tokenizerJSON: nil,
+            configJSON: #"{"eos_token":"</s>"}"#,
+            vocabJSON: #"{"hello":0}"#,
+            mergesTXT: "x y"
+        )
         let empty = FileManager.default.temporaryDirectory
             .appendingPathComponent("spec028-empty-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
@@ -357,9 +379,25 @@ final class Spec028PlumbingTests: XCTestCase {
             try ModelRuntime.tokenizerArtifactFingerprint(in: first),
             try ModelRuntime.tokenizerArtifactFingerprint(in: matching)
         )
+        XCTAssertEqual(
+            try ModelRuntime.tokenizerArtifactFingerprint(in: first),
+            try ModelRuntime.tokenizerArtifactFingerprint(in: matchingExceptChatTemplate)
+        )
+        XCTAssertEqual(
+            try ModelRuntime.tokenizerArtifactFingerprint(in: first),
+            try ModelRuntime.tokenizerArtifactFingerprint(in: matchingFastTokenizerWithRedundantMerges)
+        )
+        XCTAssertNotEqual(
+            try ModelRuntime.tokenizerArtifactFingerprint(in: first),
+            try ModelRuntime.tokenizerArtifactFingerprint(in: divergentConfig)
+        )
         XCTAssertNotEqual(
             try ModelRuntime.tokenizerArtifactFingerprint(in: first),
             try ModelRuntime.tokenizerArtifactFingerprint(in: divergent)
+        )
+        XCTAssertNotEqual(
+            try ModelRuntime.tokenizerArtifactFingerprint(in: slowTokenizer),
+            try ModelRuntime.tokenizerArtifactFingerprint(in: divergentSlowTokenizer)
         )
         XCTAssertNil(try ModelRuntime.tokenizerArtifactFingerprint(in: empty))
     }
@@ -498,6 +536,51 @@ final class Spec028PlumbingTests: XCTestCase {
         XCTAssertEqual(spec.topP, baseline.topP)
         XCTAssertEqual(spec.maxTokens, baseline.maxTokens)
         XCTAssertEqual(spec.messages.map(\.content), baseline.messages.map(\.content))
+    }
+
+    func testSpec028BenchmarkEvaluationGatesTTFTRegression() throws {
+        let now = Date()
+        let evaluation = try Spec028BenchmarkEvaluation.evaluate(
+            baselineSamples: [
+                benchmarkSample(
+                    phase: "baseline",
+                    tokensPerSecond: 20,
+                    ttftMilliseconds: 100,
+                    endedAtUnixSeconds: now.timeIntervalSince1970 - 10
+                ),
+            ],
+            specSamples: [
+                benchmarkSample(
+                    phase: "spec",
+                    tokensPerSecond: 28,
+                    ttftMilliseconds: 130,
+                    draftedTokens: 100,
+                    acceptedTokens: 95,
+                    endedAtUnixSeconds: now.timeIntervalSince1970 - 5
+                ),
+            ],
+            sustainedSamples: [
+                benchmarkSample(
+                    phase: "sustained",
+                    tokensPerSecond: 27,
+                    ttftMilliseconds: 120,
+                    draftedTokens: 100,
+                    acceptedTokens: 95,
+                    endedAtUnixSeconds: now.timeIntervalSince1970
+                ),
+            ],
+            sustainedEndedAt: now,
+            lastWindowSeconds: 30,
+            recommendRatioFloor: 1.15,
+            maxP95LatencyRatio: 2.0,
+            maxP95TTFTRatio: 1.0,
+            recommendAcceptanceFloor: 0.30
+        )
+
+        XCTAssertEqual(evaluation.tpsRatio, 1.4, accuracy: 0.001)
+        XCTAssertEqual(evaluation.ttftP95Ratio ?? 0, 1.3, accuracy: 0.001)
+        XCTAssertFalse(evaluation.recommendEnable)
+        XCTAssertTrue(evaluation.recommendationReasons.contains("p95 TTFT ratio 1.300 > 1.000"))
     }
 
     func testAC10CanaryEvaluationRequiresRatioAcceptanceAndSustainedWindow() throws {
@@ -751,12 +834,25 @@ final class Spec028PlumbingTests: XCTestCase {
         return root
     }
 
-    private func makeTokenizerSnapshot(tokenizerJSON: String, configJSON: String) throws -> URL {
+    private func makeTokenizerSnapshot(
+        tokenizerJSON: String?,
+        configJSON: String,
+        vocabJSON: String? = nil,
+        mergesTXT: String? = nil
+    ) throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("spec028-tokenizer-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        try Data(tokenizerJSON.utf8).write(to: root.appendingPathComponent("tokenizer.json"))
+        if let tokenizerJSON {
+            try Data(tokenizerJSON.utf8).write(to: root.appendingPathComponent("tokenizer.json"))
+        }
         try Data(configJSON.utf8).write(to: root.appendingPathComponent("tokenizer_config.json"))
+        if let vocabJSON {
+            try Data(vocabJSON.utf8).write(to: root.appendingPathComponent("vocab.json"))
+        }
+        if let mergesTXT {
+            try Data(mergesTXT.utf8).write(to: root.appendingPathComponent("merges.txt"))
+        }
         return root
     }
 
@@ -798,6 +894,29 @@ final class Spec028PlumbingTests: XCTestCase {
             acceptedTokens: acceptedTokens,
             acceptanceRate: draftedTokens > 0 ? Double(acceptedTokens) / Double(draftedTokens) : nil,
             chunks: chunks,
+            thermalState: "nominal"
+        )
+    }
+
+    private func benchmarkSample(
+        phase: String,
+        tokensPerSecond: Double,
+        ttftMilliseconds: Int64,
+        draftedTokens: Int = 0,
+        acceptedTokens: Int = 0,
+        endedAtUnixSeconds: Double
+    ) -> Spec028BenchmarkSample {
+        Spec028BenchmarkSample(
+            phase: phase,
+            promptTokens: 10,
+            completionTokens: 20,
+            elapsedSeconds: 20 / tokensPerSecond,
+            tokensPerSecond: tokensPerSecond,
+            ttftMilliseconds: ttftMilliseconds,
+            draftedTokens: draftedTokens,
+            acceptedTokens: acceptedTokens,
+            streamedChunks: 20,
+            endedAtUnixSeconds: endedAtUnixSeconds,
             thermalState: "nominal"
         )
     }

--- a/specs/SPEC-028-BENCHMARK-HANDOFF.md
+++ b/specs/SPEC-028-BENCHMARK-HANDOFF.md
@@ -1,0 +1,196 @@
+# SPEC-028 benchmark handoff
+
+Date: 2026-07-05
+
+## Summary
+
+SPEC-028 speculative decoding is present in the macprovider binary but remains
+operator-gated by `draft_model`. Without a configured draft model, the runtime
+does not load a draft model and all chat completions continue through the
+target-only generation path.
+
+Local M5 / 32 GB testing found one real throughput-positive pair:
+Qwen2.5-Coder 7B target with Qwen2.5-Coder 1.5B draft. That pair improved
+median and sustained throughput, but first-token latency regressed enough that
+it should not be globally enabled yet.
+
+The Qwen2.5-Coder 32B / 7B pair needs a larger Apple Silicon host before it
+can be judged. On the 32 GB local host, it did not complete even a bounded
+16-token smoke run within the session window.
+
+## What changed in this handoff
+
+- Added `spec028-benchmark`, a local CLI benchmark harness that runs baseline
+  and speculative paths against SPEC-028 fixtures.
+- Added recommendation gates for:
+  - median speculative / baseline TPS ratio
+  - p95 total latency ratio
+  - p95 TTFT ratio
+  - speculative acceptance rate
+  - sustained TPS ratio when a sustained window is requested
+- Relaxed tokenizer artifact matching for same-vocabulary fast-tokenizer
+  snapshots:
+  - ignore top-level `chat_template` in `tokenizer_config.json`
+  - when `tokenizer.json` exists, do not treat redundant `vocab.json` /
+    `merges.txt` packaging differences as incompatibility
+  - when `tokenizer.json` is absent, keep `vocab.json` / `merges.txt` binding
+    for slow-tokenizer layouts
+
+## Local benchmark environment
+
+- Host: Apple Silicon M5
+- RAM: 32 GB unified memory
+- Binary: release build of `macprovider-cli`
+- Context cap used: 8192 tokens for the completed matrix
+- Logs: `/tmp/spec028-release-matrix-20260705214654`
+
+## Completed local matrix
+
+| Pair | Fixture | Baseline TPS | Spec TPS | TPS ratio | Sustained ratio | Acceptance | Recommendation |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| Llama 3.2 3B / 1B | `spec028-small-air-short-chat-v1` | 56.12 | 51.46 | 0.917x | 0.871x | 54.5% | Do not enable |
+| Llama 3.2 3B / 1B | `spec028-small-air-streaming-check-v1` | 52.15 | 44.84 | 0.860x | 0.832x | 54.1% | Do not enable |
+| Qwen2.5-Coder 7B / 1.5B | `spec028-code-iso8601-v1` | 24.74 | 31.42 | 1.270x | 1.322x | 96.5% | Throughput win, TTFT fail |
+
+Qwen2.5-Coder 7B / 1.5B details:
+
+- `tpsRatio`: 1.2698843002639708
+- `sustainedRatio`: 1.3220061447492875
+- `acceptanceRate`: 0.9645390070921985
+- `p95LatencyRatio`: 0.7948502457691152
+- `ttftP95Ratio`: 1.5052631578947369
+- `recommendEnable`: false
+- reason: `p95 TTFT ratio 1.505 > 1.000`
+
+## 32B / 7B findings
+
+Two blockers were found:
+
+1. The initial `draft_model_tokenizer_mismatch` was our policy being too
+   strict, not a real vocabulary mismatch. The 32B and 7B local snapshots had
+   identical `tokenizer.json`, `vocab.json`, `added_tokens.json`, and
+   `special_tokens_map.json`. The difference was a redundant `merges.txt` in
+   the 7B snapshot.
+2. After fixing that policy, the 32B / 7B run no longer failed immediately, but
+   it did not produce benchmark JSON on the 32 GB local host. A 16-token smoke
+   was also stopped after several minutes with an empty output file.
+
+Local model footprint:
+
+- Qwen2.5-Coder 32B 4-bit snapshot: about 17 GB
+- Qwen2.5-Coder 7B 4-bit snapshot: about 4.0 GB
+- Combined weights alone: about 21 GB before MLX runtime memory, KV cache,
+  Metal buffers, allocator overhead, and OS pressure
+
+Conclusion: 32B / 7B is not a measured loss. It is not locally benchmarkable on
+the 32 GB host without a narrower diagnostic run or larger Apple Silicon RAM.
+
+## Research and infrastructure plan
+
+Generic cloud or VPS is not sufficient for the main decision because this work
+tests MLX / Metal behavior on Apple Silicon. A Linux VPS or NVIDIA GPU box can
+only validate the algorithm in another stack; it cannot validate macprovider's
+real runtime path.
+
+Recommended rented infra:
+
+- Apple Silicon Mac Studio or Mac Pro
+- Minimum: 64 GB unified memory
+- Preferred: 128 GB unified memory
+- Ideal: 192 GB or 256 GB unified memory
+
+Candidate provider categories checked:
+
+- MacStadium dedicated Apple Silicon Mac cloud
+- MacWeb Mac Studio rental listings, including high-memory M2/M3 Ultra tiers
+- MacinCloud dedicated/on-demand Mac servers
+
+Run the same harness on rented Apple Silicon hardware, not on generic Linux
+VPS. The goal is to test the exact `mlx-swift` and Metal execution path that
+the product uses.
+
+## Proposed rented-host matrix
+
+Run release `macprovider-cli` with generated production resources.
+
+Required pairs:
+
+- Qwen2.5-Coder 7B target / 1.5B draft
+- Qwen2.5-Coder 32B target / 7B draft
+- Llama 3.2 3B target / 1B draft as a known negative control
+
+Optional pairs if local snapshots and canary pass:
+
+- Qwen3 32B / compatible smaller Qwen3 draft
+- Qwen3-Coder 30B-A3B / compatible Qwen draft
+
+Suggested command shape:
+
+```bash
+./macprovider-cli spec028-benchmark \
+  --fixture phase3-binary/Sources/macprovider-cli/Resources/spec028/spec028-code-iso8601-v1.json \
+  --target /path/to/target \
+  --draft /path/to/draft \
+  --max-context-tokens 8192 \
+  --baseline-runs 5 \
+  --spec-runs 5 \
+  --sustained-seconds 60 \
+  --last-window-seconds 30 \
+  --max-p95-ttft-ratio 1.0
+```
+
+For first 32B smoke on rented hardware:
+
+```bash
+jq '.request.max_tokens=16' \
+  phase3-binary/Sources/macprovider-cli/Resources/spec028/spec028-code-iso8601-v1.json \
+  > /tmp/spec028-code-iso8601-16tok.json
+
+./macprovider-cli spec028-benchmark \
+  --fixture /tmp/spec028-code-iso8601-16tok.json \
+  --target /path/to/Qwen2.5-Coder-32B-Instruct-4bit \
+  --draft /path/to/Qwen2.5-Coder-7B-Instruct-4bit \
+  --max-context-tokens 1024 \
+  --baseline-runs 1 \
+  --spec-runs 1 \
+  --sustained-seconds 0 \
+  --last-window-seconds 1
+```
+
+## Continuation plan
+
+1. Keep SPEC-028 disabled by default.
+2. Use this PR to preserve the benchmark harness, stricter recommendation
+   gates, tokenizer policy fix, and evidence.
+3. Rent or access a 128 GB+ Apple Silicon host.
+4. Run the matrix above and attach raw JSON outputs to the follow-up PR.
+5. If Qwen2.5-Coder 7B / 1.5B keeps its throughput win but TTFT still fails,
+   investigate first-token mitigation:
+   - warm draft and target prefill
+   - defer speculative decoding until after the first token
+   - cache/reuse prompt preparation where safe
+6. If Qwen2.5-Coder 32B / 7B works on 128 GB+ and beats baseline, gate
+   SPEC-028 by model pair and RAM tier instead of enabling globally.
+
+## Tests run
+
+```bash
+swift test --package-path phase3-binary \
+  --filter Spec028PlumbingTests/testTokenizerArtifactFingerprintBindsTokenizerFiles \
+  --filter Spec028PlumbingTests/testSpec028BenchmarkEvaluationGatesTTFTRegression
+```
+
+Result: passed.
+
+```bash
+swift build --package-path phase3-binary -c release --product macprovider-cli
+```
+
+Result: passed with existing Swift concurrency/deprecation warnings.
+
+## Current recommendation
+
+SPEC-028 was not oversold in principle: Qwen2.5-Coder 7B / 1.5B showed a real
+throughput improvement and high acceptance locally. The current implementation
+is not ready for default enablement because TTFT regressed and larger model
+pairs require Apple Silicon hardware with more unified memory.

--- a/specs/SPEC-028-BENCHMARK-HANDOFF.md
+++ b/specs/SPEC-028-BENCHMARK-HANDOFF.md
@@ -194,3 +194,20 @@ SPEC-028 was not oversold in principle: Qwen2.5-Coder 7B / 1.5B showed a real
 throughput improvement and high acceptance locally. The current implementation
 is not ready for default enablement because TTFT regressed and larger model
 pairs require Apple Silicon hardware with more unified memory.
+
+## 2026-07-09 re-verification (isolated worktree)
+
+- Branch rebased cleanly onto current `origin/main` (only conflict was
+  subcommand registration list in `MacProviderCLI.swift` from concurrent
+  additions of `DecodeBenchCommand` + `EnrollCommand`; resolved to include
+  `Spec028BenchmarkCommand.self`).
+- `swift test --package-path phase3-binary --filter 'Spec028PlumbingTests'`
+  → 30 tests executed (1 skipped), 0 failures.
+- Debug `swift build --package-path phase3-binary --product macprovider-cli`
+  succeeds.
+- This host: 32 GB unified memory (matches the "local" M5 env used for the
+  original matrix; reconfirms 32B/7B pair is not feasible here without
+  narrower diagnostics or more RAM).
+- All work performed in fresh sibling worktree per house rules
+  (`../macprovider-spec028-bench` on `codex/spec028-benchmark-handoff`).
+  Canonical checkout untouched.


### PR DESCRIPTION
## Summary

This is a handoff PR for SPEC-028 after local hardware testing showed that we need larger Apple Silicon infra before making an enablement call.

It intentionally does **not** enable speculative decoding by default. SPEC-028 remains operator-gated by `draft_model`; if no draft model is configured, `macprovider-cli` keeps using the existing target-only path.

## What changed

- Added `macprovider-cli spec028-benchmark` to measure baseline vs speculative decoding on the actual macprovider/MLX/Metal runtime path.
- Added benchmark recommendation gates for:
  - median speculative/baseline TPS ratio
  - p95 total latency ratio
  - p95 TTFT ratio
  - speculative acceptance rate
  - sustained TPS ratio when a sustained window is requested
- Relaxed tokenizer artifact matching for same-vocabulary fast-tokenizer snapshots:
  - ignore top-level `chat_template` in `tokenizer_config.json`
  - when `tokenizer.json` exists, ignore redundant `vocab.json` / `merges.txt` packaging differences
  - when `tokenizer.json` is absent, keep `vocab.json` / `merges.txt` binding for slow-tokenizer layouts
- Added `specs/SPEC-028-BENCHMARK-HANDOFF.md` with findings, commands, test evidence, and the rented Mac validation plan.

## Local findings

Local host: Apple Silicon M5, 32 GB unified memory, release `macprovider-cli`, context cap 8192 tokens.

Completed matrix:

| Pair | Fixture | Baseline TPS | Spec TPS | TPS ratio | Sustained ratio | Acceptance | Result |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| Llama 3.2 3B / 1B | `spec028-small-air-short-chat-v1` | 56.12 | 51.46 | 0.917x | 0.871x | 54.5% | Do not enable |
| Llama 3.2 3B / 1B | `spec028-small-air-streaming-check-v1` | 52.15 | 44.84 | 0.860x | 0.832x | 54.1% | Do not enable |
| Qwen2.5-Coder 7B / 1.5B | `spec028-code-iso8601-v1` | 24.74 | 31.42 | 1.270x | 1.322x | 96.5% | Throughput win, TTFT fail |

Qwen2.5-Coder 7B / 1.5B showed real throughput lift and high acceptance, but failed the first-token latency gate:

- `tpsRatio`: 1.2698843002639708
- `sustainedRatio`: 1.3220061447492875
- `acceptanceRate`: 0.9645390070921985
- `p95LatencyRatio`: 0.7948502457691152
- `ttftP95Ratio`: 1.5052631578947369
- `recommendEnable`: false
- reason: `p95 TTFT ratio 1.505 > 1.000`

## 32B / 7B findings

The original `draft_model_tokenizer_mismatch` on Qwen2.5-Coder 32B / 7B was our policy being too strict, not a real tokenizer vocabulary mismatch. The snapshots matched on `tokenizer.json`, `vocab.json`, `added_tokens.json`, and `special_tokens_map.json`; the difference was redundant `merges.txt` packaging in the 7B snapshot.

After the tokenizer policy fix, 32B / 7B no longer failed immediately, but it did not complete on the 32 GB local host. A 16-token smoke was also stopped after several minutes with an empty output file.

Observed local footprint:

- Qwen2.5-Coder 32B 4-bit snapshot: about 17 GB
- Qwen2.5-Coder 7B 4-bit snapshot: about 4 GB
- Combined weights: about 21 GB before MLX runtime memory, KV cache, Metal buffers, allocator overhead, and OS pressure

Conclusion: 32B / 7B is not a measured loss. It is not locally benchmarkable on this 32 GB host without narrower diagnostics or more unified memory.

## Rented infra plan

Generic VPS/Linux/NVIDIA cloud is not sufficient for the main product decision because this implementation is specifically `mlx-swift` + Metal on Apple Silicon. It can validate a different algorithmic stack, but not the live macprovider runtime path.

Use rented Apple Silicon instead:

- Minimum: 64 GB unified memory
- Preferred: 128 GB unified memory
- Ideal: 192 GB or 256 GB unified memory
- Candidate provider categories researched:
  - MacStadium dedicated Apple Silicon Mac cloud: https://macstadium.com/bare-metal-mac
  - MacWeb Mac Studio rental listings: https://macweb.com/macstudio
  - MacinCloud dedicated/on-demand Mac servers: https://www.macincloud.com/
  - Apple Mac Studio hardware tiers: https://www.apple.com/mac-studio/

Required rented-host matrix:

- Qwen2.5-Coder 7B target / 1.5B draft
- Qwen2.5-Coder 32B target / 7B draft
- Llama 3.2 3B target / 1B draft as known negative control

Suggested command shape is in `specs/SPEC-028-BENCHMARK-HANDOFF.md`.

## Tests run

```bash
swift test --package-path phase3-binary \
  --filter Spec028PlumbingTests/testTokenizerArtifactFingerprintBindsTokenizerFiles \
  --filter Spec028PlumbingTests/testSpec028BenchmarkEvaluationGatesTTFTRegression
```

Result: passed, 2 tests, 0 failures.

```bash
swift build --package-path phase3-binary -c release --product macprovider-cli
```

Result: passed. Existing Swift concurrency/deprecation warnings remain.

## Follow-up recommendation

Keep SPEC-028 disabled by default until rented Apple Silicon testing proves a positive matrix by model pair and RAM tier. If Qwen2.5-Coder 7B / 1.5B keeps the throughput win but TTFT still fails, test first-token mitigation next: warm draft/target prefill, defer speculative decoding until after token 1, and cache/reuse prompt preparation where safe.
