### PR TITLE
Prepare v1.8.10 signed provider release

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.9"
+    static let binaryVersion = "1.8.10"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1603,10 +1603,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.9")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.9")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.9")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.9")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.10")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.10")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.10")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.10")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {


### PR DESCRIPTION
## Summary
- bump macprovider-cli binary version to 1.8.10
- update the single-source version handshake test

## Why
The live hardware-stats coordinator changes are merged, but v1.8.9 was released from the earlier tag before that code. GitHub Actions owns Apple signing/notarization, and release.yml validates the built CLI version against the tag, so the signed Malibu/provider rollout needs a fresh v1.8.10 release from merged main.

## Validation
- swift test --filter CoordinatorClientTests/testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames
- swift test --filter CoordinatorClientTests/testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames (actual XCTest selector)
- phase3-binary/dist/package.sh v1.8.10
- build-release/Build/Products/Release/macprovider-cli --version => 1.8.10

## Audits
- CODE lane: PASS, 0 C/H/M
- SECURITY lane: PASS, 0 C/H/M
- ARCHITECT lane: initial process blocker was not to dispatch before merge; release dispatch is held until this PR merges