### PR TITLE
[codex] Tune buyer-facing nginx keepalive settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,10 @@ test-integration:
 # false-failing the gate (the 2026-06-17 regression that forced SKIP_C2_CHECK=1).
 test-dist:
 	bash -n phase4-coordinator/dist/deploy-pearl-vps.sh
+	bash -n phase5-gateway/dist/deploy-pearl-vps.sh
 	bash phase4-coordinator/dist/test/check_deploy_config_test.sh
 	bash phase4-coordinator/dist/test/check_nginx_receipt_buffers_test.sh
+	bash phase4-coordinator/dist/test/check_nginx_api_perf_tuning_test.sh
 	bash phase4-coordinator/dist/test/check_nginx_catalog_routes_test.sh
 	bash phase4-coordinator/dist/test/check_nginx_stats_test.sh
 	bash phase4-coordinator/dist/test/check_stats_inventory_deploy_test.sh

--- a/phase4-coordinator/dist/test/check_nginx_api_perf_tuning_test.sh
+++ b/phase4-coordinator/dist/test/check_nginx_api_perf_tuning_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# check_nginx_api_perf_tuning_test.sh — assert #378 buyer-facing nginx
+# latency/connection tuning stays active in the gateway deploy surface.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+NGINX_CONF="$REPO_ROOT/phase5-gateway/dist/nginx-api.streamvc.live.conf"
+GATEWAY_DEPLOY="$REPO_ROOT/phase5-gateway/dist/deploy-pearl-vps.sh"
+
+FAIL=0
+fail() { echo "FAIL: $1" >&2; FAIL=1; }
+
+if [ ! -f "$NGINX_CONF" ]; then
+  fail "$NGINX_CONF: missing"
+  exit "$FAIL"
+fi
+if [ ! -f "$GATEWAY_DEPLOY" ]; then
+  fail "$GATEWAY_DEPLOY: missing"
+  exit "$FAIL"
+fi
+
+ACTIVE_CONF="$(sed 's/[[:space:]]*#.*$//' "$NGINX_CONF")"
+ACTIVE_DEPLOY="$(grep -vE '^[[:space:]]*#' "$GATEWAY_DEPLOY")"
+require_conf_directive() {
+  local directive="$1"
+  if ! grep -qF "$directive" <<<"$ACTIVE_CONF"; then
+    fail "$NGINX_CONF missing active directive: $directive"
+  fi
+}
+
+require_conf_directive "keepalive_timeout 300s;"
+require_conf_directive "keepalive_requests 1000;"
+require_conf_directive "client_body_timeout 300s;"
+require_conf_directive "send_timeout 300s;"
+
+# `worker_connections` is an nginx events-context directive, so the gateway
+# deploy script owns the idempotent global nginx.conf tuning before `nginx -t`.
+if ! grep -qE "grep[[:space:]].*worker_connections.*/etc/nginx/nginx.conf" <<<"$ACTIVE_DEPLOY"; then
+  fail "$GATEWAY_DEPLOY missing active worker_connections precheck"
+fi
+if ! grep -qE "sed[[:space:]].*worker_connections 4096;" <<<"$ACTIVE_DEPLOY"; then
+  fail "$GATEWAY_DEPLOY missing active worker_connections 4096 deploy tuning"
+fi
+if ! grep -qF "nginx.conf.bak.macprovider-c2" <<<"$ACTIVE_DEPLOY"; then
+  fail "$GATEWAY_DEPLOY missing nginx.conf backup naming for C2 rollback"
+fi
+if ! grep -qE "if[[:space:]]+\\[[[:space:]]+![[:space:]]+-f[[:space:]]+/etc/nginx/nginx.conf.bak.macprovider-c2[[:space:]]+\\]" <<<"$ACTIVE_DEPLOY"; then
+  fail "$GATEWAY_DEPLOY does not preserve the first C2 nginx.conf backup"
+fi
+if ! grep -qE "grep[[:space:]].*worker_connections.*4096.*/etc/nginx/nginx.conf" <<<"$ACTIVE_DEPLOY"; then
+  fail "$GATEWAY_DEPLOY missing active worker_connections 4096 postcondition"
+fi
+if ! grep -qF "/etc/nginx/nginx.conf" <<<"$ACTIVE_DEPLOY"; then
+  fail "$GATEWAY_DEPLOY does not apply worker_connections via /etc/nginx/nginx.conf"
+fi
+if ! grep -qF "nginx worker tuning rollback" "$GATEWAY_DEPLOY"; then
+  fail "$GATEWAY_DEPLOY missing C2 nginx rollback guidance"
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "ok: nginx API buyer-path performance tuning configured"
+fi
+exit "$FAIL"

--- a/phase5-gateway/dist/deploy-pearl-vps.sh
+++ b/phase5-gateway/dist/deploy-pearl-vps.sh
@@ -436,6 +436,20 @@ $SSH "set -e
   # deploy — mitigated by switching to a binary-only swap at the time).
   sed -i 's|# ssl_certificate /etc/letsencrypt|ssl_certificate /etc/letsencrypt|g' /etc/nginx/sites-available/$DOMAIN
   sed -i 's|# ssl_certificate_key /etc/letsencrypt|ssl_certificate_key /etc/letsencrypt|g' /etc/nginx/sites-available/$DOMAIN
+  # C2 nginx tuning: worker_connections is an events-context directive,
+  # so it must be applied in the global nginx.conf rather than the vhost.
+  if ! grep -qE '^[[:space:]]*worker_connections[[:space:]]+' /etc/nginx/nginx.conf; then
+    echo 'aborting deploy: /etc/nginx/nginx.conf has no active worker_connections directive to tune' >&2
+    exit 5
+  fi
+  if [ ! -f /etc/nginx/nginx.conf.bak.macprovider-c2 ]; then
+    install -o root -g root -m 0644 /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak.macprovider-c2
+  fi
+  sed -i -E 's#^([[:space:]]*)worker_connections[[:space:]]+[0-9]+;#\1worker_connections 4096;#' /etc/nginx/nginx.conf
+  grep -qE '^[[:space:]]*worker_connections[[:space:]]+4096;' /etc/nginx/nginx.conf || {
+    echo 'aborting deploy: failed to set worker_connections 4096 in /etc/nginx/nginx.conf' >&2
+    exit 5
+  }
   nginx -t
   systemctl reload nginx
 "
@@ -524,3 +538,10 @@ echo "    '"
 echo
 echo "  Binary-only rollback (gateway.prev only) is SAFE only if no schema"
 echo "  bump happened between the two deploys."
+echo
+echo "  C2 nginx worker tuning rollback, if needed:"
+echo "    ssh $VPS_USER@$VPS_HOST '"
+echo "      sudo test -f /etc/nginx/nginx.conf.bak.macprovider-c2 &&"
+echo "      sudo install -o root -g root -m 0644 /etc/nginx/nginx.conf.bak.macprovider-c2 /etc/nginx/nginx.conf &&"
+echo "      sudo nginx -t && sudo systemctl reload nginx"
+echo "    '"

--- a/phase5-gateway/dist/nginx-api.streamvc.live.conf
+++ b/phase5-gateway/dist/nginx-api.streamvc.live.conf
@@ -48,7 +48,12 @@ server {
     large_client_header_buffers 4 8k;
     proxy_buffer_size 8k;
     proxy_buffers 4 8k;
-    keepalive_timeout 360s;
+    # C2 buyer-path tuning: preserve reused TLS connections for streaming
+    # clients while mirroring the gateway/coordinator request timeout budget.
+    keepalive_timeout 300s;
+    keepalive_requests 1000;
+    client_body_timeout 300s;
+    send_timeout 300s;
 
     location = /v1/pool/check {
         default_type application/json;


### PR DESCRIPTION
## Summary

Closes #378.

- Tune the buyer-facing api.streamvc.live nginx vhost for reused streaming client connections:
  - `keepalive_timeout 300s`
  - `keepalive_requests 1000`
  - `client_body_timeout 300s`
  - `send_timeout 300s`
- Apply `worker_connections 4096` in the gateway deploy script against `/etc/nginx/nginx.conf`, because it is an nginx `events`-context directive and cannot live in the site vhost.
- Preserve the first `/etc/nginx/nginx.conf.bak.macprovider-c2` backup and add rollback guidance for restoring it.
- Add a static deploy-tooling test that pins the vhost directives and the deploy-script precheck/backup/postcondition/rollback hooks.

## Audit loop

Three-lane audit loop completed at 0 blocking findings:

- CODE lane: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW
- SECURITY lane: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW
- ARCHITECTURE lane: CLEAR, 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW

## Tests

- [x] `bash -n phase5-gateway/dist/deploy-pearl-vps.sh`
- [x] `bash -n phase4-coordinator/dist/test/check_nginx_api_perf_tuning_test.sh`
- [x] `bash phase4-coordinator/dist/test/check_nginx_api_perf_tuning_test.sh`
- [x] `git diff --cached --check`
- [x] `make test-dist`

Notes:

- Local `make test-dist` passed. Existing Docker-backed `check_nginx_stats_test.sh` skipped locally because Docker daemon is not reachable; CI runs that path.
- Production `nginx -t` and the live 30-request TLS-handshake sweep remain deploy-time validation, not local validation.
