### PR TITLE
Expose gateway retry metrics for coordinator 503s

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,26 @@ repository (Claude, Codex, Cursor, etc.), not just Claude. Read
 
 The most important rules, in priority order:
 
-## 1. PR workflow — never develop on local `main`
+## 1. Worktree isolation — never edit the canonical checkout
+
+For any implementation, audit, release, or other write-heavy task in
+`/Users/augstar/macprovider-poc`, first create a fresh sibling worktree
+from the intended base, usually `origin/main`:
+
+```bash
+git status -sb
+git worktree list
+git fetch origin
+git worktree add ../macprovider-<topic> -b fix/<topic> origin/main
+cd ../macprovider-<topic>
+```
+
+Do all edits, tests, commits, pushes, PR work, and merge follow-up from
+that task worktree unless the user explicitly says to use the current
+checkout. Do not reuse or mutate another active session's branch/worktree
+silently.
+
+## 2. PR workflow — never develop on local `main`
 
 Money-path and security-sensitive changes (billing, payouts, gateway,
 coordinator auth) go through PRs. GitHub squash-merge produces a new
@@ -20,7 +39,7 @@ Always work on a feature branch. After your PR squash-merges, run
 PR-branch commits. See `CLAUDE.md` § *PR workflow* for the full
 sequence and recovery steps for inheriting a divergent local main.
 
-## 2. Git identity — pushes route to `Augustas11` automatically
+## 3. Git identity — pushes route to `Augustas11` automatically
 
 A per-repo credential helper in `.git/config` calls `gh auth token
 -u Augustas11` at push time, regardless of which `gh` account is
@@ -29,7 +48,7 @@ manually switch accounts; do **not** embed tokens in URLs. See
 `CLAUDE.md` § *Git identity* for restore steps if the helper is ever
 missing (e.g. after a fresh clone).
 
-## 3. Sensitive paths require PR
+## 4. Sensitive paths require PR
 
 These directories carry money or auth logic and any change to them
 must go through a PR with review:
@@ -41,13 +60,13 @@ must go through a PR with review:
 - `phase5-gateway/internal/router/`
 - `phase5-gateway/internal/auth/`
 
-## 4. Clean-room boundary
+## 5. Clean-room boundary
 
 `d-inference` (https://github.com/layr-labs/d-inference) is licensed
 NOASSERTION and is strictly clean-room. Do **not** inspect their
 source under any circumstance.
 
-## 5. Spec and decision-log conventions
+## 6. Spec and decision-log conventions
 
 - Specs live under `specs/`. House style: `BUILD_SPEC_*`,
   `AUDIT_SPEC_*`, `FIX_SPEC_*_VX_Y` for prompts; `SPEC-NNN-*.md` for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,26 @@ it returns empty rather than the matching account's token). So pinning
 must explicitly call `gh auth token -u Augustas11` to bypass gh's
 active-account state.
 
+## Worktree isolation: don't edit the canonical checkout
+
+For any implementation, audit, release, or other write-heavy task in this
+repo, do not work directly in `/Users/augstar/macprovider-poc`. Start from a
+fresh sibling worktree off the intended base, usually `origin/main`, unless the
+user explicitly says to use the current checkout:
+
+```bash
+git status -sb
+git worktree list
+git fetch origin
+git worktree add ../macprovider-<topic> -b fix/<topic> origin/main
+cd ../macprovider-<topic>
+```
+
+Do all edits, tests, commits, pushes, PR work, and merge follow-up inside that
+task worktree. Do not reuse or mutate another active session's branch/worktree
+silently. For audits, start from `origin/main` and audit merged code unless the
+user names a different base.
+
 ## PR workflow: don't develop on local `main`
 
 Money-path and security-sensitive changes (billing, payouts, gateway,

--- a/phase5-gateway/internal/router/auth_helpers.go
+++ b/phase5-gateway/internal/router/auth_helpers.go
@@ -55,7 +55,7 @@ func operatorBearerAuthorized(headers http.Header, expected string) bool {
 }
 
 func (s *Server) publicPaused(path string) bool {
-	if strings.HasPrefix(path, "/admin/") || path == "/v1/status" || path == "/healthz" {
+	if strings.HasPrefix(path, "/admin/") || path == "/v1/status" || path == "/healthz" || path == "/metrics" {
 		return false
 	}
 	s.mu.RLock()

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -405,6 +405,7 @@ func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Reque
 		}
 		if !s.cfg.Retry503.Enabled || maxAttempts == 1 || resp.StatusCode != http.StatusServiceUnavailable {
 			if attempt > 1 && resp.StatusCode == http.StatusOK {
+				s.retry503Metrics.recordRecovered(requestIDClass(r), totalBackoffMS)
 				slog.Info("gateway coord 503 retry recovered",
 					"request_id", requestID(r),
 					"attempt", attempt,
@@ -431,6 +432,7 @@ func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Reque
 			return resp, nil
 		}
 		if attempt == maxAttempts {
+			s.retry503Metrics.recordExhausted(totalBackoffMS)
 			slog.Warn("gateway coord 503 retry exhausted",
 				"request_id", requestID(r),
 				"attempts", maxAttempts,

--- a/phase5-gateway/internal/router/chat_proxy_retry_test.go
+++ b/phase5-gateway/internal/router/chat_proxy_retry_test.go
@@ -35,7 +35,9 @@ func TestGatewayCoord503RetryRecoversAfterTwoNoProviderResponses(t *testing.T) {
 	h, store, _, cfg := newRetryHarness(t, client, nil)
 	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_recovered")
 
-	resp := postChat(t, h, fullKey, chatBody(false), nil)
+	resp := postChat(t, h, fullKey, chatBody(false), map[string]string{
+		"X-Request-ID": "11111111-1111-4111-8111-111111111111",
+	})
 
 	if resp.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
@@ -44,6 +46,13 @@ func TestGatewayCoord503RetryRecoversAfterTwoNoProviderResponses(t *testing.T) {
 		t.Fatalf("coordinator calls=%d want 3", calls)
 	}
 	assertRetryLogCounts(t, logs.String(), 2, 1, 0)
+	assertRetryMetricsContain(t, h,
+		`gateway_coord_503_retry_recovered_total{request_id_class="client_supplied"} 1`,
+		`gateway_coord_503_retry_recovered_total{request_id_class="gateway_generated"} 0`,
+		`gateway_coord_503_retry_exhausted_total 0`,
+		`gateway_coord_503_retry_backoff_ms_bucket{le="100"} 1`,
+		`gateway_coord_503_retry_backoff_ms_bucket{le="+Inf"} 1`,
+	)
 }
 
 func TestGatewayCoord503RetryExhaustsNoProviderResponses(t *testing.T) {
@@ -66,6 +75,50 @@ func TestGatewayCoord503RetryExhaustsNoProviderResponses(t *testing.T) {
 		t.Fatalf("coordinator calls=%d want 3", calls)
 	}
 	assertRetryLogCounts(t, logs.String(), 2, 0, 1)
+	assertRetryMetricsContain(t, h,
+		`gateway_coord_503_retry_recovered_total{request_id_class="client_supplied"} 0`,
+		`gateway_coord_503_retry_recovered_total{request_id_class="gateway_generated"} 0`,
+		`gateway_coord_503_retry_exhausted_total 1`,
+		`gateway_coord_503_retry_backoff_ms_bucket{le="100"} 1`,
+		`gateway_coord_503_retry_backoff_ms_bucket{le="+Inf"} 1`,
+	)
+}
+
+func TestGatewayCoord503RetryMetricsUsesGatewayGeneratedRequestIDClass(t *testing.T) {
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, retryChatSuccessBody), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_generated_id")
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	assertRetryMetricsContain(t, h,
+		`gateway_coord_503_retry_recovered_total{request_id_class="client_supplied"} 0`,
+		`gateway_coord_503_retry_recovered_total{request_id_class="gateway_generated"} 1`,
+		`gateway_coord_503_retry_backoff_ms_bucket{le="+Inf"} 1`,
+	)
+}
+
+func TestGatewayRetryMetricsBypassAllPublicKillSwitch(t *testing.T) {
+	h, _, _, _ := newRetryHarness(t, nil, func(cfg *config.Config) {
+		cfg.KillSwitch.AllPublicAPI = true
+	})
+
+	assertRetryMetricsContain(t, h,
+		`gateway_coord_503_retry_recovered_total{request_id_class="client_supplied"} 0`,
+		`gateway_coord_503_retry_recovered_total{request_id_class="gateway_generated"} 0`,
+		`gateway_coord_503_retry_exhausted_total 0`,
+		`gateway_coord_503_retry_backoff_ms_bucket{le="+Inf"} 0`,
+	)
 }
 
 func TestGatewayCoord503RetrySkipsTier2PolicyError(t *testing.T) {
@@ -355,6 +408,25 @@ func assertRetryLogCounts(t *testing.T, logs string, retry, recovered, exhausted
 	}
 	if got := strings.Count(logs, `msg="gateway coord 503 retry exhausted"`); got != exhausted {
 		t.Fatalf("exhausted log count=%d want %d logs:\n%s", got, exhausted, logs)
+	}
+}
+
+func assertRetryMetricsContain(t *testing.T, h http.Handler, wants ...string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("metrics status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if got := resp.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/plain; version=0.0.4") {
+		t.Fatalf("metrics content-type=%q", got)
+	}
+	body := resp.Body.String()
+	for _, want := range wants {
+		if !strings.Contains(body, "\n"+want+"\n") {
+			t.Fatalf("metrics missing %q in:\n%s", want, body)
+		}
 	}
 }
 

--- a/phase5-gateway/internal/router/retry_metrics.go
+++ b/phase5-gateway/internal/router/retry_metrics.go
@@ -1,0 +1,151 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	retry503RequestIDClassClientSupplied   = "client_supplied"
+	retry503RequestIDClassGatewayGenerated = "gateway_generated"
+)
+
+var retry503BackoffBucketsMS = []int64{100, 250, 500, 750, 1000}
+
+type retry503Metrics struct {
+	mu             sync.Mutex
+	recovered      map[string]int64
+	exhausted      int64
+	backoffBuckets map[string]int64
+	backoffCount   int64
+	backoffSumMS   int64
+}
+
+type retry503MetricsSnapshot struct {
+	recovered      map[string]int64
+	exhausted      int64
+	backoffBuckets map[string]int64
+	backoffCount   int64
+	backoffSumMS   int64
+}
+
+type requestIDClassKey struct{}
+
+func newRetry503Metrics() *retry503Metrics {
+	return &retry503Metrics{
+		recovered: map[string]int64{
+			retry503RequestIDClassClientSupplied:   0,
+			retry503RequestIDClassGatewayGenerated: 0,
+		},
+		backoffBuckets: newRetry503BackoffBucketMap(),
+	}
+}
+
+func newRetry503BackoffBucketMap() map[string]int64 {
+	buckets := make(map[string]int64, len(retry503BackoffBucketsMS)+1)
+	for _, le := range retry503BackoffBucketsMS {
+		buckets[strconv.FormatInt(le, 10)] = 0
+	}
+	buckets["+Inf"] = 0
+	return buckets
+}
+
+func requestIDClass(r *http.Request) string {
+	if v, ok := r.Context().Value(requestIDClassKey{}).(string); ok {
+		return normalizeRetry503RequestIDClass(v)
+	}
+	return retry503RequestIDClassGatewayGenerated
+}
+
+func normalizeRetry503RequestIDClass(class string) string {
+	switch class {
+	case retry503RequestIDClassClientSupplied, retry503RequestIDClassGatewayGenerated:
+		return class
+	default:
+		return retry503RequestIDClassGatewayGenerated
+	}
+}
+
+func (m *retry503Metrics) recordRecovered(requestIDClass string, totalBackoffMS int64) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.recovered[normalizeRetry503RequestIDClass(requestIDClass)]++
+	m.recordBackoffLocked(totalBackoffMS)
+}
+
+func (m *retry503Metrics) recordExhausted(totalBackoffMS int64) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.exhausted++
+	m.recordBackoffLocked(totalBackoffMS)
+}
+
+func (m *retry503Metrics) recordBackoffLocked(totalBackoffMS int64) {
+	if totalBackoffMS < 0 {
+		totalBackoffMS = 0
+	}
+	m.backoffCount++
+	m.backoffSumMS += totalBackoffMS
+	for _, le := range retry503BackoffBucketsMS {
+		if totalBackoffMS <= le {
+			m.backoffBuckets[strconv.FormatInt(le, 10)]++
+		}
+	}
+	m.backoffBuckets["+Inf"]++
+}
+
+func (m *retry503Metrics) snapshot() retry503MetricsSnapshot {
+	if m == nil {
+		m = newRetry503Metrics()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	recovered := make(map[string]int64, len(m.recovered))
+	for class, count := range m.recovered {
+		recovered[class] = count
+	}
+	backoffBuckets := newRetry503BackoffBucketMap()
+	for le, count := range m.backoffBuckets {
+		backoffBuckets[le] = count
+	}
+	return retry503MetricsSnapshot{
+		recovered:      recovered,
+		exhausted:      m.exhausted,
+		backoffBuckets: backoffBuckets,
+		backoffCount:   m.backoffCount,
+		backoffSumMS:   m.backoffSumMS,
+	}
+}
+
+func (m *retry503Metrics) prometheus() string {
+	snapshot := m.snapshot()
+	var b strings.Builder
+	b.WriteString("# HELP gateway_coord_503_retry_recovered_total Coordinator 503 no-provider retry requests recovered before exhaustion.\n")
+	b.WriteString("# TYPE gateway_coord_503_retry_recovered_total counter\n")
+	for _, class := range []string{retry503RequestIDClassClientSupplied, retry503RequestIDClassGatewayGenerated} {
+		fmt.Fprintf(&b, "gateway_coord_503_retry_recovered_total{request_id_class=%q} %d\n", class, snapshot.recovered[class])
+	}
+	b.WriteString("# HELP gateway_coord_503_retry_exhausted_total Coordinator 503 no-provider retry requests that exhausted all attempts.\n")
+	b.WriteString("# TYPE gateway_coord_503_retry_exhausted_total counter\n")
+	fmt.Fprintf(&b, "gateway_coord_503_retry_exhausted_total %d\n", snapshot.exhausted)
+	b.WriteString("# HELP gateway_coord_503_retry_backoff_ms Total retry backoff spent before recovered or exhausted terminal outcome.\n")
+	b.WriteString("# TYPE gateway_coord_503_retry_backoff_ms histogram\n")
+	for _, le := range retry503BackoffBucketsMS {
+		label := strconv.FormatInt(le, 10)
+		fmt.Fprintf(&b, "gateway_coord_503_retry_backoff_ms_bucket{le=%q} %d\n", label, snapshot.backoffBuckets[label])
+	}
+	fmt.Fprintf(&b, "gateway_coord_503_retry_backoff_ms_bucket{le=%q} %d\n", "+Inf", snapshot.backoffBuckets["+Inf"])
+	fmt.Fprintf(&b, "gateway_coord_503_retry_backoff_ms_sum %d\n", snapshot.backoffSumMS)
+	fmt.Fprintf(&b, "gateway_coord_503_retry_backoff_ms_count %d\n", snapshot.backoffCount)
+	return b.String()
+}

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -58,7 +58,8 @@ type Server struct {
 	// fires a coordinator roundtrip (the SPEC-004 audit's HIGH perf finding).
 	// 5s TTL — coordinator config only changes on reload, so staleness is
 	// harmless; cap on bursts.
-	routingMeta routingMetaCache
+	routingMeta     routingMetaCache
+	retry503Metrics *retry503Metrics
 }
 
 // readStore returns the read-only view of the database. M2-4: this
@@ -161,6 +162,7 @@ func New(cfg config.Config, store Store, oauth auth.OAuthProvider, opts ...Optio
 		client:           http.DefaultClient,
 		trustedProxyNets: trustedProxyNets,
 		version:          "dev",
+		retry503Metrics:  newRetry503Metrics(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -201,6 +203,7 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("/v1/status", s.withCORS(http.MethodGet, http.HandlerFunc(s.handleStatus)))
 	mux.HandleFunc("/v1/feedback", s.handleFeedback)
 	mux.HandleFunc("/healthz", s.handleHealthz)
+	mux.HandleFunc("/metrics", s.handleMetrics)
 	mux.HandleFunc("/admin/feedback-summary", s.handleFeedbackSummary)
 	mux.HandleFunc("/admin/kill-switch", s.handleKillSwitch)
 	mux.HandleFunc("/admin/capacity-signal", s.handleCapacitySignal)
@@ -218,11 +221,22 @@ func (s *Server) Handler() http.Handler {
 	return s.middleware(mux)
 }
 
+func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method_not_allowed", "Method not allowed")
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = w.Write([]byte(s.retry503Metrics.prometheus()))
+}
+
 func (s *Server) middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestID := r.Header.Get("X-Request-ID")
+		requestIDClass := retry503RequestIDClassClientSupplied
 		if !isUUIDLike(requestID) {
 			requestID = newUUID()
+			requestIDClass = retry503RequestIDClassGatewayGenerated
 		}
 		if stripped := stripInternalMacProviderHeaders(r.Header); len(stripped) > 0 {
 			slog.Warn("internal header injection stripped", "request_id", requestID, "headers", stripped)
@@ -241,6 +255,7 @@ func (s *Server) middleware(next http.Handler) http.Handler {
 			return
 		}
 		ctx := context.WithValue(r.Context(), requestIDKey{}, requestID)
+		ctx = context.WithValue(ctx, requestIDClassKey{}, requestIDClass)
 		defer func() {
 			if recovered := recover(); recovered != nil {
 				slog.Error("panic recovered", "panic", recovered, "request_id", requestID, "path", r.URL.Path, "stack", string(debug.Stack()))


### PR DESCRIPTION
## Summary
- add gateway retry telemetry for coordinator 503 no-provider recovered/exhausted terminal outcomes
- expose Prometheus text on `/metrics` with recovered labels, exhausted total, and backoff histogram buckets
- keep `/metrics` available during `AllPublicAPI` pause so incident scrape paths remain live

Fixes #383

## Validation
- 3-lane audit round 2: 0 C/H/M bugs
- `cd phase5-gateway && go test ./internal/router -run 'TestGatewayCoord503Retry|TestGatewayRetryMetricsBypassAllPublicKillSwitch|TestGatewayRetry503ConfigValidationViaLoad' -count=1`
- `cd phase5-gateway && go test ./...`
- `cd phase5-gateway && go vet ./...`
- `git diff --check`

## Notes
- Public nginx templates still do not proxy `/metrics`; this PR adds the gateway-local scrape surface requested by #383.
