### PR TITLE
Malibu: CLI install onboarding + menu-bar UI fixes

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -103,15 +103,45 @@ struct AgentSnapshot: Equatable {
 }
 
 enum AgentSnapshotPresenter {
+    private static func isActive(_ s: AgentSnapshot) -> Bool {
+        s.state == .serving || s.state == .paused
+    }
+
     static func short(_ s: AgentSnapshot) -> String {
         switch s.state {
         case .idle, .starting: return "Idle"
         case .serving:
             if let usdc = s.earningsUsdcToday { return String(format: "$%.2f", usdc) }
-            return "—"
+            return "Serving"
         case .paused:         return "Paused"
-        case .reconnecting:   return "…"
+        case .reconnecting:   return "Sync"
         case .error:          return "!"
+        }
+    }
+
+    static func dashboardHeadline(_ s: AgentSnapshot) -> String {
+        switch s.state {
+        case .idle:         return "Not running"
+        case .starting:     return "Starting…"
+        case .serving:      return "Serving"
+        case .paused:       return "Paused"
+        case .reconnecting: return "Reconnecting…"
+        case .error:        return "Error"
+        }
+    }
+
+    static func dashboardSubtitle(_ s: AgentSnapshot) -> String? {
+        switch s.state {
+        case .serving where s.earningsUsdcToday == nil:
+            return "Provider connected · waiting for first paid job"
+        case .serving:
+            return s.currentModelID
+        case .reconnecting:
+            return s.lastError ?? "Checking background provider…"
+        case .error:
+            return s.lastError
+        default:
+            return nil
         }
     }
 
@@ -127,16 +157,18 @@ enum AgentSnapshotPresenter {
     }
 
     static func earningsLine(_ s: AgentSnapshot) -> String {
-        // AUDIT R1 ARCHITECT A1: distinguish "no data yet" from "$0.00".
         switch (s.earningsUsdcToday, s.malibuAccruedToday) {
         case (nil, nil):
-            return "Today: — USDC · — MALIBU (metrics not implemented)"
+            if isActive(s) {
+                return "Today: $0.00 USDC · 0.00 MALIBU (no jobs yet)"
+            }
+            return "Today: not running"
         case let (usdc?, malibu?):
             return String(format: "Today: $%.2f USDC · %@", usdc, malibuDisplay(malibu, tier: s.trustTier))
         case let (usdc?, nil):
-            return String(format: "Today: $%.2f USDC · — MALIBU", usdc)
+            return String(format: "Today: $%.2f USDC · 0.00 MALIBU", usdc)
         case let (nil, malibu?):
-            return "Today: — USDC · \(malibuDisplay(malibu, tier: s.trustTier))"
+            return "Today: $0.00 USDC · \(malibuDisplay(malibu, tier: s.trustTier))"
         }
     }
 
@@ -151,14 +183,18 @@ enum AgentSnapshotPresenter {
     }
 
     static func modelLine(_ s: AgentSnapshot) -> String {
-        s.currentModelID ?? "—"
+        if let model = s.currentModelID { return model }
+        return isActive(s) ? "Connected" : "Not running"
     }
 
     static func requestsLine(_ s: AgentSnapshot) -> String {
         [
-            s.requestsServedToday.map { "\(formatCount($0)) today" } ?? "— today",
-            s.requestsServedAllTime.map { "\(formatCount($0)) all-time" } ?? "— all-time",
-            s.requestsPerMinute.map { String(format: "%.1f req/min", $0) } ?? "— req/min"
+            s.requestsServedToday.map { "\(formatCount($0)) today" }
+                ?? (isActive(s) ? "0 today" : "n/a today"),
+            s.requestsServedAllTime.map { "\(formatCount($0)) all-time" }
+                ?? (isActive(s) ? "0 all-time" : "n/a all-time"),
+            s.requestsPerMinute.map { String(format: "%.1f req/min", $0) }
+                ?? (isActive(s) ? "0.0 req/min" : "n/a req/min")
         ].joined(separator: " · ")
     }
 
@@ -169,17 +205,24 @@ enum AgentSnapshotPresenter {
     }
 
     static func usdcFullLine(_ s: AgentSnapshot) -> String {
-        [
-            s.earningsUsdcToday.map { String(format: "$%.2f today", $0) } ?? "$— today",
-            s.earningsUsdcWeek.map { String(format: "$%.2f wk", $0) } ?? "$— wk",
-            s.earningsUsdcPending.map { String(format: "$%.2f pending", $0) } ?? "$— pending",
-            s.earningsUsdcLifetime.map { String(format: "$%.2f life", $0) } ?? "$— life"
+        let unset = isActive(s) ? "$0.00" : "n/a"
+        return [
+            s.earningsUsdcToday.map { String(format: "$%.2f today", $0) } ?? "\(unset) today",
+            s.earningsUsdcWeek.map { String(format: "$%.2f wk", $0) } ?? "\(unset) wk",
+            s.earningsUsdcPending.map { String(format: "$%.2f pending", $0) } ?? "\(unset) pending",
+            s.earningsUsdcLifetime.map { String(format: "$%.2f life", $0) } ?? "\(unset) life"
         ].joined(separator: " · ")
     }
 
+    static func usdcTodayDisplay(_ s: AgentSnapshot) -> String {
+        s.earningsUsdcToday.map { String(format: "$%.2f", $0) } ?? (isActive(s) ? "$0.00" : "n/a")
+    }
+
     static func malibuFullLine(_ s: AgentSnapshot) -> String {
-        let today = s.malibuAccruedToday.map { malibuDisplay($0, tier: s.trustTier, compact: true) } ?? "— MALIBU today"
-        let allTime = s.malibuAccruedAllTime.map { String(format: "%.2f all-time", $0) } ?? "— all-time"
+        let today = s.malibuAccruedToday.map { malibuDisplay($0, tier: s.trustTier, compact: true) }
+            ?? (isActive(s) ? "0.00 MALIBU today" : "n/a MALIBU today")
+        let allTime = s.malibuAccruedAllTime.map { String(format: "%.2f all-time", $0) }
+            ?? (isActive(s) ? "0.00 all-time" : "n/a all-time")
         switch s.trustTier {
         case .trusted:
             return "\(today) · \(allTime)"
@@ -197,11 +240,20 @@ enum AgentSnapshotPresenter {
     }
 
     static func uptimeLine(_ s: AgentSnapshot) -> String {
-        [
-            s.uptime7dPct.map { String(format: "%.1f%% uptime (7d)", $0) } ?? "— uptime (7d)",
-            s.declinedRequests.map { "\($0) declined" } ?? "— declined",
-            s.restartCount.map { "\($0) restarts" } ?? "— restarts"
-        ].joined(separator: " · ")
+        var parts: [String] = []
+        if let sec = s.uptimeSec, isActive(s) {
+            parts.append("\(formatDuration(sec)) up")
+        } else if isActive(s) {
+            parts.append("uptime n/a")
+        }
+        if let pct = s.uptime7dPct {
+            parts.append(String(format: "%.1f%% uptime (7d)", pct))
+        } else if isActive(s) {
+            parts.append("7d uptime n/a")
+        }
+        parts.append(s.declinedRequests.map { "\($0) declined" } ?? (isActive(s) ? "0 declined" : "n/a declined"))
+        parts.append(s.restartCount.map { "\($0) restarts" } ?? (isActive(s) ? "0 restarts" : "n/a restarts"))
+        return parts.joined(separator: " · ")
     }
 
     static func gpuChip(_ s: AgentSnapshot) -> String {
@@ -211,7 +263,7 @@ enum AgentSnapshotPresenter {
         if let temp = s.gpuTemperatureC {
             return String(format: "GPU %.0f°C", temp)
         }
-        return "GPU —"
+        return "GPU n/a"
     }
 
     static func latencyChip(_ s: AgentSnapshot) -> String {
@@ -219,21 +271,21 @@ enum AgentSnapshotPresenter {
         case let (p50?, p99?):
             return "p50 \(p50)ms · p99 \(p99)ms"
         case let (p50?, nil):
-            return "p50 \(p50)ms · p99 —"
+            return "p50 \(p50)ms · p99 n/a"
         case let (nil, p99?):
-            return "p50 — · p99 \(p99)ms"
+            return "p50 n/a · p99 \(p99)ms"
         case (nil, nil):
-            return "Latency —"
+            return isActive(s) ? "Latency n/a" : "Latency n/a"
         }
     }
 
     static func queueChip(_ s: AgentSnapshot) -> String {
-        guard let depth = s.queueDepth else { return "— queued" }
-        return "\(depth) queued"
+        if let depth = s.queueDepth { return "\(depth) queued" }
+        return isActive(s) ? "0 queued" : "Queue n/a"
     }
 
     static func thermalChip(_ s: AgentSnapshot) -> String {
-        s.thermalState?.label ?? "Thermal —"
+        s.thermalState?.label ?? (isActive(s) ? "Thermal OK" : "Thermal n/a")
     }
 
     static func unclaimedBadge(_ s: AgentSnapshot, dismissedThreshold: Double?) -> String? {
@@ -270,7 +322,7 @@ enum AgentSnapshotPresenter {
     }
 
     private static func formatTokens(_ value: Int64?) -> String {
-        guard let value else { return "—" }
+        guard let value else { return "0" }
         if value >= 1_000_000 {
             return String(format: "%.1fM", Double(value) / 1_000_000)
         }
@@ -287,5 +339,11 @@ enum AgentSnapshotPresenter {
         formatter.usesGroupingSeparator = true
         formatter.groupingSeparator = ","
         return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    private static func formatDuration(_ seconds: Int) -> String {
+        if seconds < 60 { return "\(seconds)s" }
+        if seconds < 3600 { return String(format: "%dm", seconds / 60) }
+        return String(format: "%dh %dm", seconds / 3600, (seconds % 3600) / 60)
     }
 }

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -38,6 +38,8 @@ final class MalibuAgent: ObservableObject {
     // — including a reconnect Task that already slept past its cancellation
     // check but hadn't yet re-entered the MainActor.
     private var isShuttingDown: Bool = false
+    private var healthPollTask: Task<Void, Never>?
+    private var monitorsLaunchdProvider = false
 
     init() {
         thermalMonitor.$state
@@ -54,6 +56,12 @@ final class MalibuAgent: ObservableObject {
         // AUDIT R2 CODE H3 fix.
         guard !isShuttingDown else { return }
         guard child == nil else { return }
+
+        // Option A: when install.sh owns the provider via launchd, monitor it
+        // instead of spawning a second macprovider-cli child.
+        if await monitorInstalledProviderIfPresent() {
+            return
+        }
 
         // AUDIT R2 CODE H4 fix: refuse to spawn the CLI without a validated
         // app-owned config + keychain token. Onboarding must complete the
@@ -152,6 +160,8 @@ final class MalibuAgent: ObservableObject {
     func shutdown(gracefulSeconds: Int) async {
         isShuttingDown = true
         reconnectTask?.cancel(); reconnectTask = nil
+        healthPollTask?.cancel(); healthPollTask = nil
+        monitorsLaunchdProvider = false
         child?.markStopping()
 
         try? await control?.send(.shutdownRequest(graceSeconds: gracefulSeconds))
@@ -169,6 +179,48 @@ final class MalibuAgent: ObservableObject {
     }
 
     // MARK: - Private
+
+    /// Attach to an existing launchd-managed provider (CLI install track).
+    /// Returns true when local /v1/health is reachable on the configured port.
+    @discardableResult
+    func monitorInstalledProviderIfPresent(timeout: TimeInterval = 120) async -> Bool {
+        guard await ProviderConfig.isConfigured else { return false }
+        guard let port = ProviderConfig.readHTTPPort() else { return false }
+        let deadline = Date().addingTimeInterval(max(1, timeout))
+        guard await InstalledProviderMonitor.waitForHealthy(port: port, deadline: deadline) else {
+            return false
+        }
+        monitorsLaunchdProvider = true
+        snapshot.state = .serving
+        snapshot.currentModelID = ProviderConfig.readModel()
+        snapshot.lastError = nil
+        startHealthPolling(port: port)
+        await refreshEarnings()
+        return true
+    }
+
+    private func startHealthPolling(port: Int) {
+        healthPollTask?.cancel()
+        healthPollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 15_000_000_000)
+                guard let self else { return }
+                if await InstalledProviderMonitor.isHealthy(port: port) {
+                    await MainActor.run {
+                        if self.snapshot.state != .serving && self.snapshot.state != .paused {
+                            self.snapshot.state = .serving
+                        }
+                    }
+                    await self.refreshEarnings()
+                } else if self.monitorsLaunchdProvider {
+                    await MainActor.run {
+                        self.snapshot.state = .reconnecting
+                        self.snapshot.lastError = "Background provider is not responding on port \(port)."
+                    }
+                }
+            }
+        }
+    }
 
     private func connectControl(socketPath: String) async {
         metricsPoller?.cancel(); metricsPoller = nil

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -184,19 +184,37 @@ final class MalibuAgent: ObservableObject {
     /// Returns true when local /v1/health is reachable on the configured port.
     @discardableResult
     func monitorInstalledProviderIfPresent(timeout: TimeInterval = 120) async -> Bool {
-        guard await ProviderConfig.isConfigured else { return false }
-        guard let port = ProviderConfig.readHTTPPort() else { return false }
+        guard let port = ProviderConfig.readHTTPPort(),
+              ProviderConfig.readProviderID() != nil else {
+            return false
+        }
         let deadline = Date().addingTimeInterval(max(1, timeout))
         guard await InstalledProviderMonitor.waitForHealthy(port: port, deadline: deadline) else {
             return false
         }
         monitorsLaunchdProvider = true
+        await applyHealthSnapshot(port: port)
         snapshot.state = .serving
-        snapshot.currentModelID = ProviderConfig.readModel()
         snapshot.lastError = nil
         startHealthPolling(port: port)
         await refreshEarnings()
         return true
+    }
+
+    private func applyHealthSnapshot(port: Int) async {
+        guard let health = await InstalledProviderMonitor.fetchHealth(port: port) else { return }
+        if let model = health.model, !model.isEmpty {
+            snapshot.currentModelID = model
+        }
+        if let total = health.requestsTotal {
+            snapshot.requestsServedAllTime = total
+        }
+        if let uptime = health.uptimeSeconds {
+            snapshot.uptimeSec = uptime
+        }
+        if health.ready {
+            snapshot.state = .serving
+        }
     }
 
     private func startHealthPolling(port: Int) {
@@ -206,6 +224,7 @@ final class MalibuAgent: ObservableObject {
                 try? await Task.sleep(nanoseconds: 15_000_000_000)
                 guard let self else { return }
                 if await InstalledProviderMonitor.isHealthy(port: port) {
+                    await self.applyHealthSnapshot(port: port)
                     await MainActor.run {
                         if self.snapshot.state != .serving && self.snapshot.state != .paused {
                             self.snapshot.state = .serving

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -23,18 +23,26 @@ private struct DashboardView: View {
             HStack(spacing: 12) {
                 MalibuBrandTile()
                     .frame(width: 28, height: 28)
-                Text("Malibu")
-                    .font(.system(size: 15, weight: .semibold))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Malibu")
+                        .font(.system(size: 15, weight: .semibold))
+                    if let subtitle = AgentSnapshotPresenter.dashboardSubtitle(agent.snapshot) {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                }
                 Spacer()
-                Text(agent.snapshot.state.rawValue.capitalized)
-                    .font(.caption)
+                Text(AgentSnapshotPresenter.dashboardHeadline(agent.snapshot))
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(color(for: agent.snapshot.state))
             }
 
             HStack(alignment: .top, spacing: 16) {
                 panel {
                     Text("Today").font(.caption).foregroundStyle(.secondary)
-                    Text(agent.snapshot.earningsUsdcToday.map { String(format: "$%.2f", $0) } ?? "$—")
+                    Text(AgentSnapshotPresenter.usdcTodayDisplay(agent.snapshot))
                         .font(.system(size: 36, weight: .semibold, design: .rounded))
                     Text(AgentSnapshotPresenter.usdcFullLine(agent.snapshot))
                         .foregroundStyle(.secondary)
@@ -59,8 +67,8 @@ private struct DashboardView: View {
                                 .font(.caption.monospaced())
                                 .textSelection(.enabled)
                         }
-                    } else {
-                        MetricRow(title: "Weights path", value: "—")
+                    } else if agent.snapshot.state == .serving || agent.snapshot.state == .paused {
+                        MetricRow(title: "Weights path", value: "Managed by provider")
                     }
                     MetricRow(title: "Trust tier", value: AgentSnapshotPresenter.trustLine(agent.snapshot))
                     MetricRow(title: "Requests", value: AgentSnapshotPresenter.requestsLine(agent.snapshot))

--- a/phase3-binary/app/Sources/Malibu/MenuBar/BrandMark.swift
+++ b/phase3-binary/app/Sources/Malibu/MenuBar/BrandMark.swift
@@ -51,7 +51,10 @@ enum MalibuMenuBarIcon {
         let size = NSSize(width: pointSize, height: pointSize * 13/18)
         let image = NSImage(size: size, flipped: false) { rect in
             let inset = rect.insetBy(dx: rect.width * 0.045, dy: 0)
-            let horizonY = inset.midY + inset.height * 0.12
+            // Vertically center the composition (horizon line + half-sun above it).
+            // Composition extent = horizonY..(horizonY + sunR); center it on midY.
+            let sunR = inset.width * 0.30
+            let horizonY = inset.midY - sunR / 2
             let path = NSBezierPath()
 
             // Horizon line
@@ -63,7 +66,6 @@ enum MalibuMenuBarIcon {
             path.stroke()
 
             // Half-sun (filled semicircle sitting on the horizon)
-            let sunR = inset.width * 0.30
             let center = NSPoint(x: inset.midX, y: horizonY)
             let sun = NSBezierPath()
             sun.appendArc(withCenter: center, radius: sunR, startAngle: 0, endAngle: 180)

--- a/phase3-binary/app/Sources/Malibu/MenuBar/BrandMark.swift
+++ b/phase3-binary/app/Sources/Malibu/MenuBar/BrandMark.swift
@@ -48,25 +48,24 @@ struct MalibuBrandTile: View {
 /// tints it automatically for light/dark mode and menu bar state.
 enum MalibuMenuBarIcon {
     static func makeTemplate(pointSize: CGFloat = 18) -> NSImage {
-        let size = NSSize(width: pointSize, height: pointSize * 13/18)
+        let size = NSSize(width: pointSize, height: pointSize)
         let image = NSImage(size: size, flipped: false) { rect in
-            let inset = rect.insetBy(dx: rect.width * 0.045, dy: 0)
-            // Vertically center the composition (horizon line + half-sun above it).
-            // Composition extent = horizonY..(horizonY + sunR); center it on midY.
-            let sunR = inset.width * 0.30
-            let horizonY = inset.midY - sunR / 2
+            let sunR = rect.width * (13.0 / 64.0)
+            // AppKit origin is bottom-left; SVG y=42 is 22/64 up from the bottom.
+            // Center the sun+horizon band vertically, then nudge up slightly for menu-bar optics.
+            let horizonY = rect.midY - sunR / 2 + rect.height * 0.04
+            let x1 = rect.minX + rect.width * (10.0 / 64.0)
+            let x2 = rect.minX + rect.width * (54.0 / 64.0)
             let path = NSBezierPath()
 
-            // Horizon line
-            path.move(to: NSPoint(x: inset.minX, y: horizonY))
-            path.line(to: NSPoint(x: inset.maxX, y: horizonY))
-            path.lineWidth = rect.height * 0.11
+            path.move(to: NSPoint(x: x1, y: horizonY))
+            path.line(to: NSPoint(x: x2, y: horizonY))
+            path.lineWidth = rect.height * (3.4 / 64.0)
             path.lineCapStyle = .round
-            NSColor.black.setStroke() // will be tinted by template
+            NSColor.black.setStroke()
             path.stroke()
 
-            // Half-sun (filled semicircle sitting on the horizon)
-            let center = NSPoint(x: inset.midX, y: horizonY)
+            let center = NSPoint(x: rect.midX, y: horizonY)
             let sun = NSBezierPath()
             sun.appendArc(withCenter: center, radius: sunR, startAngle: 0, endAngle: 180)
             sun.close()

--- a/phase3-binary/app/Sources/Malibu/MenuBar/MenuBarController.swift
+++ b/phase3-binary/app/Sources/Malibu/MenuBar/MenuBarController.swift
@@ -74,7 +74,6 @@ final class MenuBarController {
         menu.addItem(action("Pause", key: "") { self.onAction(.pause) })
         menu.addItem(action("Resume", key: "") { self.onAction(.resume) })
         menu.addItem(.separator())
-        menu.addItem(action("Quit and Uninstall…", key: "") { self.onAction(.quitAndUninstall) })
         menu.addItem(action("Quit", key: "q") { NSApp.terminate(nil) })
         return menu
     }

--- a/phase3-binary/app/Sources/Malibu/MenuBar/MenuBarController.swift
+++ b/phase3-binary/app/Sources/Malibu/MenuBar/MenuBarController.swift
@@ -35,11 +35,33 @@ final class MenuBarController {
 
     private func configureButton() {
         guard let button = statusItem.button else { return }
-        button.image = MalibuMenuBarIcon.makeTemplate(pointSize: 18)
+        let icon = MalibuMenuBarIcon.makeTemplate(pointSize: 18)
+        button.image = icon
+        button.image?.size = icon.size
         button.image?.accessibilityDescription = "Malibu"
-        button.imagePosition = .imageLeft
+        button.imagePosition = .imageLeading
+        button.imageScaling = .scaleNone
         button.title = ""
-        statusItem.menu = buildMenu()
+        button.target = self
+        button.action = #selector(statusBarButtonClicked(_:))
+        button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+    }
+
+    @objc private func statusBarButtonClicked(_ sender: NSStatusBarButton?) {
+        guard let button = sender ?? statusItem.button else { return }
+        guard let event = NSApp.currentEvent else {
+            onAction(.openDashboard)
+            return
+        }
+        let isMenuClick = event.type == .rightMouseUp
+            || (event.type == .leftMouseUp && event.modifierFlags.contains(.control))
+        if isMenuClick {
+            let menu = buildMenu()
+            updateMenu(menu, snapshot: latestSnapshot)
+            menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 2), in: button)
+        } else {
+            onAction(.openDashboard)
+        }
     }
 
     private func buildMenu() -> NSMenu {
@@ -104,12 +126,18 @@ final class MenuBarController {
         latestSnapshot = snapshot
         let badge = AgentSnapshotPresenter.unclaimedBadge(snapshot, dismissedThreshold: dismissedUnclaimedThreshold)
         let queueDot = (snapshot.queueDepth ?? 0) > 0 ? "•" : nil
-        statusItem.button?.title = [AgentSnapshotPresenter.short(snapshot), badge, queueDot].compactMap { $0 }.joined(separator: " ")
+        if let button = statusItem.button {
+            button.title = [AgentSnapshotPresenter.short(snapshot), badge, queueDot].compactMap { $0 }.joined(separator: " ")
+            button.imagePosition = .imageLeading
+        }
         statusItem.button?.toolTip = menuTooltip(snapshot)
         statusItem.button?.contentTintColor = snapshot.thermalState?.isMenuBarAttention == true
             ? NSColor.systemOrange
             : nil
-        guard let menu = statusItem.menu else { return }
+    }
+
+    private func updateMenu(_ menu: NSMenu, snapshot: AgentSnapshot) {
+        let badge = AgentSnapshotPresenter.unclaimedBadge(snapshot, dismissedThreshold: dismissedUnclaimedThreshold)
         menu.item(withIdentifier: .statusRow)?.title = AgentSnapshotPresenter.stateLine(snapshot)
         menu.item(withIdentifier: .earningsRow)?.title = AgentSnapshotPresenter.earningsLine(snapshot)
         if let backlog = AgentSnapshotPresenter.backlogLine(snapshot),
@@ -136,8 +164,7 @@ final class MenuBarController {
         [
             AgentSnapshotPresenter.stateLine(snapshot),
             AgentSnapshotPresenter.earningsLine(snapshot),
-            AgentSnapshotPresenter.queueChip(snapshot),
-            AgentSnapshotPresenter.thermalChip(snapshot)
+            "Click to open dashboard · Right-click for menu"
         ].joined(separator: "\n")
     }
 }

--- a/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
@@ -25,6 +25,10 @@ enum CLIInstallRunner {
     static func run(onLogLine: @escaping @MainActor (String) -> Void) async throws {
         let scriptURL = try resolveInstallScriptURL()
         let runnableURL = try materializeRunnableScript(from: scriptURL)
+        let installPort = resolveInstallPort()
+        if let installPort {
+            await onLogLine("[macprovider-install] Using local HTTP port \(installPort) for provider install.")
+        }
         let exitCode: Int32 = try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 let process = Process()
@@ -38,6 +42,9 @@ enum CLIInstallRunner {
                 var environment = ProcessInfo.processInfo.environment
                 environment["MACPROVIDER_NO_PROMPT"] = "1"
                 environment["HOME"] = NSHomeDirectory()
+                if let installPort {
+                    environment["MACPROVIDER_PORT"] = String(installPort)
+                }
                 if environment["PATH"]?.isEmpty != false {
                     environment["PATH"] = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
                 }
@@ -70,8 +77,94 @@ enum CLIInstallRunner {
                 continuation.resume(returning: process.terminationStatus)
             }
         }
-        guard exitCode == 0 else {
-            throw Error.nonZeroExit(exitCode)
+        if exitCode == 0 {
+            return
+        }
+        if exitCode == 6, await localInstallSucceeded() {
+            await onLogLine(
+                "[macprovider-install] Provider is running locally. Coordinator pool visibility can take a few more minutes — this is normal for new installs."
+            )
+            return
+        }
+        throw Error.nonZeroExit(exitCode)
+    }
+
+    /// install.sh exit 6 means AC-1a degraded mode: local install OK, coordinator
+    /// pool check timed out after 30s. Treat as success when health + manifest agree.
+    static func localInstallSucceeded() async -> Bool {
+        guard let port = ProviderConfig.readHTTPPort(),
+              ProviderConfig.readProviderID() != nil else {
+            return false
+        }
+        let manifest = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/macprovider/install_manifest.json")
+        let hasManifest = FileManager.default.isReadableFile(atPath: manifest.path)
+        let launchdPlist = FileManager.default.isReadableFile(
+            atPath: NSHomeDirectory() + "/Library/LaunchAgents/live.streamvc.macprovider.plist"
+        )
+        guard hasManifest || launchdPlist else { return false }
+        return await InstalledProviderMonitor.isHealthy(port: port)
+    }
+
+    /// Human-readable hint for onboarding UI while `install.sh` runs long silent phases.
+    enum ActivityMonitor {
+        static func snapshot() -> String {
+            let lines = macproviderProcessLines()
+            if lines.contains(where: { $0.contains("autotune --recommend") }) {
+                return "Benchmarking models for your Mac — often 10–30 minutes on first run. The log can look frozen; that is normal."
+            }
+            if let bench = lines.first(where: { $0.contains("serve --no-join") }) {
+                let model = extractFlag("--model", from: bench) ?? "a candidate model"
+                return "Testing \(shortModelName(model)) performance…"
+            }
+            if lines.contains(where: { $0.contains("models pull") || $0.contains("huggingface") }) {
+                return "Downloading model weights from Hugging Face…"
+            }
+            let cliPath = NSHomeDirectory() + "/macprovider/macprovider-cli"
+            if FileManager.default.isExecutableFile(atPath: cliPath) {
+                return "Provider CLI installed. Running autotune and model checks next…"
+            }
+            if lines.contains(where: { $0.contains("curl") && $0.contains("github") }) {
+                return "Downloading provider release from GitHub…"
+            }
+            return "Install in progress…"
+        }
+
+        private static func macproviderProcessLines() -> [String] {
+            let process = Process()
+            let pipe = Pipe()
+            process.executableURL = URL(fileURLWithPath: "/bin/ps")
+            process.arguments = ["-ax", "-o", "command="]
+            process.standardOutput = pipe
+            process.standardError = Pipe()
+            do {
+                try process.run()
+            } catch {
+                return []
+            }
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let text = String(decoding: data, as: UTF8.self)
+            return text
+                .split(whereSeparator: \.isNewline)
+                .map(String.init)
+                .filter { $0.contains("macprovider-cli") && !$0.contains("/bin/ps") }
+        }
+
+        private static func extractFlag(_ flag: String, from command: String) -> String? {
+            let parts = command.split(separator: " ").map(String.init)
+            guard let index = parts.firstIndex(of: flag), index + 1 < parts.count else { return nil }
+            return parts[index + 1]
+        }
+
+        private static func shortModelName(_ raw: String) -> String {
+            if raw.contains("/") {
+                return raw.split(separator: "/").last.map(String.init) ?? raw
+            }
+            if raw.hasPrefix("/") {
+                return URL(fileURLWithPath: raw).lastPathComponent
+            }
+            return raw
         }
     }
 
@@ -88,6 +181,20 @@ enum CLIInstallRunner {
             return devRelative
         }
         throw Error.installScriptNotFound
+    }
+
+    /// Port for `install.sh`: explicit env override, existing config, else a probed free port.
+    /// Avoids exit 6 when the default 8080 is occupied (common on dev Macs running Node).
+    static func resolveInstallPort(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int? {
+        if let raw = environment["MACPROVIDER_PORT"], let port = Int(raw), port > 0 {
+            return port
+        }
+        if let configured = ProviderConfig.readHTTPPort() {
+            return configured
+        }
+        return try? FreePortProbe.probe()
     }
 
     /// Bundle resources are not guaranteed executable; copy to a temp path with +x.

--- a/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Runs the public CLI-track `install.sh` non-interactively from Malibu.app.
+/// Option A onboarding: Malibu delegates install/autotune/launchd to the script.
+enum CLIInstallRunner {
+    enum Error: Swift.Error, LocalizedError {
+        case installScriptNotFound
+        case nonZeroExit(Int32)
+        case launchFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .installScriptNotFound:
+                return "The bundled macprovider installer script was not found."
+            case let .nonZeroExit(code):
+                return "Provider install failed (exit \(code)). See the log above for details."
+            case let .launchFailed(message):
+                return "Could not start the provider installer: \(message)"
+            }
+        }
+    }
+
+    /// Invokes `install.sh` with `MACPROVIDER_NO_PROMPT=1`. Delivers stdout/stderr
+    /// lines to `onLogLine` on the main actor.
+    static func run(onLogLine: @escaping @MainActor (String) -> Void) async throws {
+        let scriptURL = try resolveInstallScriptURL()
+        let runnableURL = try materializeRunnableScript(from: scriptURL)
+        let exitCode: Int32 = try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                let stdout = Pipe()
+                let stderr = Pipe()
+                process.executableURL = URL(fileURLWithPath: "/bin/bash")
+                process.arguments = [runnableURL.path]
+                process.standardOutput = stdout
+                process.standardError = stderr
+
+                var environment = ProcessInfo.processInfo.environment
+                environment["MACPROVIDER_NO_PROMPT"] = "1"
+                environment["HOME"] = NSHomeDirectory()
+                if environment["PATH"]?.isEmpty != false {
+                    environment["PATH"] = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+                }
+                process.environment = environment
+
+                let emit: (Pipe) -> Void = { pipe in
+                    pipe.fileHandleForReading.readabilityHandler = { handle in
+                        let chunk = handle.availableData
+                        guard !chunk.isEmpty else { return }
+                        let text = String(decoding: chunk, as: UTF8.self)
+                        for line in text.split(whereSeparator: \.isNewline) {
+                            let trimmed = String(line)
+                            guard !trimmed.isEmpty else { continue }
+                            Task { @MainActor in onLogLine(trimmed) }
+                        }
+                    }
+                }
+                emit(stdout)
+                emit(stderr)
+
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(throwing: Error.launchFailed(error.localizedDescription))
+                    return
+                }
+                process.waitUntilExit()
+                stdout.fileHandleForReading.readabilityHandler = nil
+                stderr.fileHandleForReading.readabilityHandler = nil
+                continuation.resume(returning: process.terminationStatus)
+            }
+        }
+        guard exitCode == 0 else {
+            throw Error.nonZeroExit(exitCode)
+        }
+    }
+
+    static func resolveInstallScriptURL() throws -> URL {
+        if let bundled = Bundle.main.url(forResource: "install", withExtension: "sh") {
+            return bundled
+        }
+        let devRelative = Bundle.main.bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("dist/install.sh")
+        if FileManager.default.isReadableFile(atPath: devRelative.path) {
+            return devRelative
+        }
+        throw Error.installScriptNotFound
+    }
+
+    /// Bundle resources are not guaranteed executable; copy to a temp path with +x.
+    private static func materializeRunnableScript(from source: URL) throws -> URL {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macprovider-install-\(UUID().uuidString).sh")
+        try FileManager.default.copyItem(at: source, to: temp)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: temp.path)
+        return temp
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -18,6 +18,7 @@ final class LaunchProviderController: ObservableObject {
 
     enum Stage: Equatable {
         case idle
+        case runningCLIInstall
         case identityReady
         case registering
         case autotuning
@@ -33,6 +34,14 @@ final class LaunchProviderController: ObservableObject {
 
     @Published private(set) var stage: Stage = .idle
     @Published private(set) var currentEarningsEstimate: EarningsEstimateRange?
+    @Published private(set) var installLogLines: [String] = []
+
+    /// When true (default), fresh onboarding runs `install.sh` instead of the
+    /// in-app SPEC-026 register/autotune path. Tests set this to false.
+    static var prefersCLIInstallTrack: Bool {
+        get { MalibuOnboardingPolicy.prefersCLIInstallTrack }
+        set { MalibuOnboardingPolicy.prefersCLIInstallTrack = newValue }
+    }
 
     // MARK: - Config
 
@@ -77,6 +86,10 @@ final class LaunchProviderController: ObservableObject {
         var startAgent: @MainActor () async -> Void
         var waitForFirstServing: @MainActor () async throws -> Date
         var readProviderID: () -> String?
+        var runCLIInstall: (@escaping @MainActor (String) -> Void) async throws -> Void
+        var importCLIConfigAfterInstall: () async throws -> Void
+        var monitorInstalledProvider: @MainActor () async -> Void
+        var readConfigModel: () -> String?
 
         static func live(registerClient: RegisterClient, bundledCLIPath: URL, agent: MalibuAgent?) -> Dependencies {
             Dependencies(
@@ -147,7 +160,21 @@ final class LaunchProviderController: ObservableObject {
                         userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for the first serving frame."]
                     )
                 },
-                readProviderID: { ProviderConfig.readProviderID() }
+                readProviderID: { ProviderConfig.readProviderID() },
+                runCLIInstall: { onLogLine in
+                    try await CLIInstallRunner.run(onLogLine: onLogLine)
+                },
+                importCLIConfigAfterInstall: {
+                    try await ProviderConfig.importExistingCLIConfig()
+                },
+                monitorInstalledProvider: {
+                    if let agent {
+                        _ = await agent.monitorInstalledProviderIfPresent(
+                            timeout: MalibuOnboardingTimeouts.firstServingFrameSec
+                        )
+                    }
+                },
+                readConfigModel: { ProviderConfig.readModel() }
             )
         }
     }
@@ -212,6 +239,10 @@ final class LaunchProviderController: ObservableObject {
     func launch() async {
         let existingState = try? dependencies.loadState()
         if await dependencies.isConfigured() {
+            if Self.prefersCLIInstallTrack {
+                await startConfiguredViaCLIInstall()
+                return
+            }
             if let existing = existingState,
                existing.onboardingSchemaVersion == 2,
                existing.firstServingAt == nil {
@@ -219,6 +250,11 @@ final class LaunchProviderController: ObservableObject {
             } else {
                 await startConfiguredAgent(model: "configured")
             }
+            return
+        }
+
+        if Self.prefersCLIInstallTrack {
+            await launchViaCLIInstall()
             return
         }
 
@@ -277,6 +313,39 @@ final class LaunchProviderController: ObservableObject {
     func setPayoutWallet(_ address: String) async throws {
         throw NSError(domain: "SPEC-026", code: 0,
                       userInfo: [NSLocalizedDescriptionKey: "Wallet binding is a guarded SPEC-016/SPEC-027 follow-up route."])
+    }
+
+    private func startConfiguredViaCLIInstall() async {
+        do {
+            try await dependencies.registerLoginItem()
+            await dependencies.monitorInstalledProvider()
+            let model = dependencies.readConfigModel() ?? "configured"
+            stage = .live(model: model, tier: .provisional)
+        } catch {
+            stage = .failed(stage: "configured", retryable: true, message: error.localizedDescription)
+        }
+    }
+
+    private func launchViaCLIInstall() async {
+        do {
+            stage = .runningCLIInstall
+            installLogLines = []
+            try await dependencies.runCLIInstall { [weak self] line in
+                guard let self else { return }
+                self.installLogLines.append(line)
+                if self.installLogLines.count > 200 {
+                    self.installLogLines.removeFirst(self.installLogLines.count - 200)
+                }
+            }
+            try await dependencies.importCLIConfigAfterInstall()
+            try await dependencies.registerLoginItem()
+            stage = .startingAgent
+            await dependencies.monitorInstalledProvider()
+            let model = dependencies.readConfigModel() ?? "installed"
+            stage = .live(model: model, tier: .provisional)
+        } catch {
+            stage = .failed(stage: "cliInstall", retryable: true, message: error.localizedDescription)
+        }
     }
 
     private func startConfiguredAgent(model: String) async {
@@ -461,6 +530,7 @@ final class LaunchProviderController: ObservableObject {
     private func stageName(_ stage: Stage) -> String {
         switch stage {
         case .idle: return "idle"
+        case .runningCLIInstall: return "cliInstall"
         case .identityReady: return "identityReady"
         case .registering: return "registering"
         case .autotuning: return "autotuning"
@@ -672,6 +742,9 @@ struct StartupState: Equatable {
         if identityExists && onboardingV2Enabled {
             return .resumeOnboarding
         }
+        if !configExists && !appMarkerExists {
+            return .showOnboarding
+        }
         return onboardingV2Enabled ? .showOnboarding : .setupPaused
     }
 
@@ -706,7 +779,10 @@ struct StartupState: Equatable {
                 firstServingAtExists: false,
                 onboardingV2Enabled: effectiveOnboardingV2Enabled
             )
-            return MigrationResult(route: fresh.route(), backupPath: backup?.path)
+            let route: StartupRoute = MalibuOnboardingPolicy.prefersCLIInstallTrack
+                ? .showOnboarding
+                : fresh.route()
+            return MigrationResult(route: route, backupPath: backup?.path)
         case .cancel:
             return MigrationResult(route: .quit, backupPath: nil)
         }

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -35,6 +35,10 @@ final class LaunchProviderController: ObservableObject {
     @Published private(set) var stage: Stage = .idle
     @Published private(set) var currentEarningsEstimate: EarningsEstimateRange?
     @Published private(set) var installLogLines: [String] = []
+    @Published private(set) var installProgressHint: String?
+    @Published private(set) var installStartedAt: Date?
+
+    private var installProgressTask: Task<Void, Never>?
 
     /// When true (default), fresh onboarding runs `install.sh` instead of the
     /// in-app SPEC-026 register/autotune path. Tests set this to false.
@@ -237,6 +241,11 @@ final class LaunchProviderController: ObservableObject {
     ///   j. Show success card (owned by the SwiftUI view; controller
     ///      transitions to .live)
     func launch() async {
+        if Self.prefersCLIInstallTrack, await CLIInstallRunner.localInstallSucceeded() {
+            await launchViaCLIInstall()
+            return
+        }
+
         let existingState = try? dependencies.loadState()
         if await dependencies.isConfigured() {
             if Self.prefersCLIInstallTrack {
@@ -327,7 +336,16 @@ final class LaunchProviderController: ObservableObject {
     }
 
     private func launchViaCLIInstall() async {
+        beginInstallProgressWatch()
+        defer { endInstallProgressWatch() }
         do {
+            if await CLIInstallRunner.localInstallSucceeded() {
+                installLogLines.append(
+                    "Background provider is already running locally. Connecting Malibu to it."
+                )
+                await finalizeCLIInstallTrack()
+                return
+            }
             stage = .runningCLIInstall
             installLogLines = []
             try await dependencies.runCLIInstall { [weak self] line in
@@ -337,7 +355,26 @@ final class LaunchProviderController: ObservableObject {
                     self.installLogLines.removeFirst(self.installLogLines.count - 200)
                 }
             }
-            try await dependencies.importCLIConfigAfterInstall()
+            do {
+                try await dependencies.importCLIConfigAfterInstall()
+            } catch {
+                // CLI track may not have provider_token in yaml yet (coordinator assigns over WS).
+                if await CLIInstallRunner.localInstallSucceeded() {
+                    installLogLines.append(
+                        "Provider token not in config yet; Malibu will monitor the background provider without Keychain import."
+                    )
+                } else {
+                    throw error
+                }
+            }
+            await finalizeCLIInstallTrack()
+        } catch {
+            stage = .failed(stage: "cliInstall", retryable: true, message: error.localizedDescription)
+        }
+    }
+
+    private func finalizeCLIInstallTrack() async {
+        do {
             try await dependencies.registerLoginItem()
             stage = .startingAgent
             await dependencies.monitorInstalledProvider()
@@ -346,6 +383,41 @@ final class LaunchProviderController: ObservableObject {
         } catch {
             stage = .failed(stage: "cliInstall", retryable: true, message: error.localizedDescription)
         }
+    }
+
+    private func beginInstallProgressWatch() {
+        installStartedAt = Date()
+        installProgressHint = "Starting installer…"
+        installProgressTask?.cancel()
+        installProgressTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.installProgressHint = CLIInstallRunner.ActivityMonitor.snapshot()
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+            }
+        }
+    }
+
+    private func endInstallProgressWatch() {
+        installProgressTask?.cancel()
+        installProgressTask = nil
+        installStartedAt = nil
+        installProgressHint = nil
+    }
+
+    /// When setup reopens after CLI install finished, jump straight to live/monitor.
+    func refreshFromExistingInstall() async {
+        switch stage {
+        case .idle:
+            break
+        case let .failed(stageName, _, _) where stageName == "cliInstall":
+            break
+        default:
+            return
+        }
+        guard await CLIInstallRunner.localInstallSucceeded() else { return }
+        installLogLines = ["Background provider is already running locally."]
+        await finalizeCLIInstallTrack()
     }
 
     private func startConfiguredAgent(model: String) async {
@@ -674,6 +746,7 @@ struct StartupState: Equatable {
     let onboardingStateExists: Bool
     let firstServingAtExists: Bool
     let onboardingV2Enabled: Bool
+    let backgroundProviderHealthy: Bool
 
     init(
         configExists: Bool,
@@ -684,7 +757,8 @@ struct StartupState: Equatable {
         identityExists: Bool,
         onboardingStateExists: Bool,
         firstServingAtExists: Bool,
-        onboardingV2Enabled: Bool
+        onboardingV2Enabled: Bool,
+        backgroundProviderHealthy: Bool = false
     ) {
         self.configExists = configExists
         self.appMarkerExists = appMarkerExists
@@ -695,6 +769,7 @@ struct StartupState: Equatable {
         self.onboardingStateExists = onboardingStateExists
         self.firstServingAtExists = firstServingAtExists
         self.onboardingV2Enabled = onboardingV2Enabled
+        self.backgroundProviderHealthy = backgroundProviderHealthy
     }
 
     @MainActor
@@ -713,6 +788,17 @@ struct StartupState: Equatable {
         let serveConfigShapeValid = (try? ProviderConfig.validateServeConfigShape(paths: paths)) != nil
         let identityExists = await ProviderIdentity.isReady()
         let onboarding = try? OnboardingStateStore.load(paths: paths)
+        var backgroundProviderHealthy = false
+        if MalibuOnboardingPolicy.prefersCLIInstallTrack,
+           ProviderConfig.readProviderID(paths: paths) != nil,
+           let port = ProviderConfig.readHTTPPort(paths: paths) {
+            let home = fm.homeDirectoryForCurrentUser
+            let manifest = home.appendingPathComponent("Library/Application Support/macprovider/install_manifest.json")
+            let launchd = home.appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
+            if fm.isReadableFile(atPath: manifest.path) || fm.isReadableFile(atPath: launchd.path) {
+                backgroundProviderHealthy = await InstalledProviderMonitor.isHealthy(port: port)
+            }
+        }
         return StartupState(
             configExists: configExists,
             appMarkerExists: markerExists,
@@ -722,11 +808,15 @@ struct StartupState: Equatable {
             identityExists: identityExists,
             onboardingStateExists: onboarding != nil,
             firstServingAtExists: onboarding?.firstServingAt != nil,
-            onboardingV2Enabled: LaunchProviderController.isOnboardingV2Enabled
+            onboardingV2Enabled: LaunchProviderController.isOnboardingV2Enabled,
+            backgroundProviderHealthy: backgroundProviderHealthy
         )
     }
 
     func route() -> StartupRoute {
+        if backgroundProviderHealthy && MalibuOnboardingPolicy.prefersCLIInstallTrack {
+            return .startAgent
+        }
         if onboardingStateExists && !firstServingAtExists {
             return .resumeOnboarding
         }

--- a/phase3-binary/app/Sources/Malibu/Onboarding/MalibuOnboardingPolicy.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/MalibuOnboardingPolicy.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// App-wide onboarding policy toggles (nonisolated so routing code can read them).
+enum MalibuOnboardingPolicy {
+    /// When true (default), fresh onboarding runs `install.sh` instead of the
+    /// in-app SPEC-026 register/autotune path.
+    static var prefersCLIInstallTrack = true
+}

--- a/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
@@ -50,8 +50,8 @@ private struct OnboardingRootView: View {
                         .font(.system(size: 28, weight: .semibold))
                 }
             }
-            Text("Three quick steps to launch a provider.")
-            Text("Create a provider identity, register this Mac, and start serving from the bundled provider.")
+            Text("Launch Provider installs and configures the macprovider CLI on this Mac.")
+            Text("Malibu monitors the background provider and shows earnings here — setup runs via the same installer as the terminal path.")
                 .foregroundStyle(.secondary)
 
             Divider()
@@ -67,12 +67,27 @@ private struct OnboardingRootView: View {
     private var content: some View {
         switch controller.stage {
         case .idle:
-            stageRow(title: "Ready", detail: "The app will create a local identity key and register this provider.") {
+            stageRow(title: "Ready", detail: "Installs the provider CLI, picks a model, and registers a background service.") {
                 VStack(alignment: .leading, spacing: 8) {
                     launchButton(title: "Launch Provider")
                     Text("No wallet needed to start — add one anytime after.")
                         .font(.callout)
                         .foregroundStyle(.secondary)
+                }
+            }
+        case .runningCLIInstall:
+            stageRow(title: "Installing provider", detail: "Running the macprovider installer. This can take several minutes on first model download.") {
+                VStack(alignment: .leading, spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    if !controller.installLogLines.isEmpty {
+                        ScrollView {
+                            Text(controller.installLogLines.suffix(12).joined(separator: "\n"))
+                                .font(.system(.caption, design: .monospaced))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                        }
+                        .frame(maxHeight: 140)
+                    }
                 }
             }
         case .identityReady:
@@ -104,7 +119,7 @@ private struct OnboardingRootView: View {
                 }
             }
         case .startingAgent:
-            stageRow(title: "Starting", detail: "Registering the login item and starting the provider.") {
+            stageRow(title: "Starting", detail: "Waiting for the background provider to become healthy.") {
                 ProgressView().controlSize(.small)
             }
         case .authenticating:

--- a/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
@@ -61,6 +61,9 @@ private struct OnboardingRootView: View {
         }
         .padding(28)
         .frame(minWidth: 460, minHeight: 560)
+        .task {
+            await controller.refreshFromExistingInstall()
+        }
     }
 
     @ViewBuilder
@@ -76,17 +79,29 @@ private struct OnboardingRootView: View {
                 }
             }
         case .runningCLIInstall:
-            stageRow(title: "Installing provider", detail: "Running the macprovider installer. This can take several minutes on first model download.") {
+            stageRow(
+                title: "Installing provider",
+                detail: controller.installProgressHint
+                    ?? "Running the macprovider installer. Autotune and first model download can take 10–30 minutes with little log output."
+            ) {
                 VStack(alignment: .leading, spacing: 8) {
-                    ProgressView().controlSize(.small)
+                    HStack(spacing: 12) {
+                        ProgressView().controlSize(.small)
+                        if let started = controller.installStartedAt {
+                            Text("Elapsed \(formattedElapsed(since: started))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+                    }
                     if !controller.installLogLines.isEmpty {
                         ScrollView {
-                            Text(controller.installLogLines.suffix(12).joined(separator: "\n"))
+                            Text(controller.installLogLines.suffix(20).joined(separator: "\n"))
                                 .font(.system(.caption, design: .monospaced))
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .textSelection(.enabled)
                         }
-                        .frame(maxHeight: 140)
+                        .frame(maxHeight: 160)
                     }
                 }
             }
@@ -189,5 +204,17 @@ private struct OnboardingRootView: View {
         }
         .buttonStyle(.borderedProminent)
         .tint(MalibuBrand.coral)
+    }
+
+    private func formattedElapsed(since start: Date) -> String {
+        let seconds = max(0, Int(Date().timeIntervalSince(start)))
+        let minutes = seconds / 60
+        let remainder = seconds % 60
+        if minutes >= 60 {
+            let hours = minutes / 60
+            let mins = minutes % 60
+            return String(format: "%d:%02d:%02d", hours, mins, remainder)
+        }
+        return String(format: "%d:%02d", minutes, remainder)
     }
 }

--- a/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
+++ b/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Observes a launchd-managed macprovider-cli via local HTTP /v1/health.
+enum InstalledProviderMonitor {
+    static func readHTTPPort(paths: ProviderPaths = .current) -> Int? {
+        ProviderConfig.readHTTPPort(paths: paths)
+    }
+
+    static func isHealthy(port: Int, timeout: TimeInterval = 2) async -> Bool {
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/health")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return false }
+            return (200..<300).contains(http.statusCode)
+        } catch {
+            return false
+        }
+    }
+
+    /// Poll until health responds or deadline elapses.
+    static func waitForHealthy(
+        port: Int,
+        deadline: Date,
+        pollInterval: TimeInterval = 2
+    ) async -> Bool {
+        while Date() < deadline {
+            if await isHealthy(port: port) { return true }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { break }
+            let sleep = min(pollInterval, remaining)
+            try? await Task.sleep(nanoseconds: UInt64(sleep * 1_000_000_000))
+        }
+        return false
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
+++ b/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
@@ -2,21 +2,47 @@ import Foundation
 
 /// Observes a launchd-managed macprovider-cli via local HTTP /v1/health.
 enum InstalledProviderMonitor {
+    struct HealthSnapshot: Equatable {
+        let ready: Bool
+        let model: String?
+        let requestsTotal: Int?
+        let uptimeSeconds: Int?
+    }
+
     static func readHTTPPort(paths: ProviderPaths = .current) -> Int? {
         ProviderConfig.readHTTPPort(paths: paths)
     }
 
     static func isHealthy(port: Int, timeout: TimeInterval = 2) async -> Bool {
+        await fetchHealth(port: port, timeout: timeout)?.ready == true
+    }
+
+    static func fetchHealth(port: Int, timeout: TimeInterval = 2) async -> HealthSnapshot? {
         let url = URL(string: "http://127.0.0.1:\(port)/v1/health")!
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.timeoutInterval = timeout
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse else { return false }
-            return (200..<300).contains(http.statusCode)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse,
+                  (200..<300).contains(http.statusCode) else {
+                return nil
+            }
+            guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            let status = object["status"] as? String
+            let model = object["model"] as? String
+            let requestsTotal = object["requests_total"] as? Int
+            let uptimeSeconds = object["uptime_s"] as? Int
+            return HealthSnapshot(
+                ready: status == "ready",
+                model: model,
+                requestsTotal: requestsTotal,
+                uptimeSeconds: uptimeSeconds
+            )
         } catch {
-            return false
+            return nil
         }
     }
 

--- a/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
@@ -37,6 +37,21 @@ enum ProviderConfig {
         return parseTopLevelValue(named: "provider_id", from: contents)
     }
 
+    static func readModel(paths: ProviderPaths = .current) -> String? {
+        guard let contents = try? String(contentsOf: paths.configFile) else { return nil }
+        return parseTopLevelValue(named: "model", from: contents)
+    }
+
+    static func readHTTPPort(paths: ProviderPaths = .current) -> Int? {
+        guard let contents = try? String(contentsOf: paths.configFile),
+              let value = parseTopLevelValue(named: "port", from: contents),
+              let port = Int(value),
+              (1024...65535).contains(port) else {
+            return nil
+        }
+        return port
+    }
+
     static func readLinkState(paths: ProviderPaths = .current) -> LinkState? {
         guard let contents = try? String(contentsOf: paths.configFile),
               let value = parseTopLevelValue(named: "link_state", from: contents)

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -5,17 +5,23 @@ import XCTest
 // authoritative "$0.00" until the CLI moves past the stub metrics_response.
 
 final class AgentSnapshotPresenterTests: XCTestCase {
-    func testEarningsLineShowsDashWhenBothMetricsMissing() {
+    func testEarningsLineShowsZeroWhenBothMetricsMissingWhileServing() {
         var s = AgentSnapshot.empty
         s.state = .serving
-        XCTAssertTrue(AgentSnapshotPresenter.earningsLine(s).contains("—"))
-        XCTAssertTrue(AgentSnapshotPresenter.earningsLine(s).contains("not implemented"))
+        XCTAssertTrue(AgentSnapshotPresenter.earningsLine(s).contains("$0.00"))
+        XCTAssertTrue(AgentSnapshotPresenter.earningsLine(s).contains("no jobs yet"))
     }
 
-    func testShortShowsDashWhenServingButNoEarningsYet() {
+    func testShortShowsServingWhenNoEarningsYet() {
         var s = AgentSnapshot.empty
         s.state = .serving
-        XCTAssertEqual(AgentSnapshotPresenter.short(s), "—")
+        XCTAssertEqual(AgentSnapshotPresenter.short(s), "Serving")
+    }
+
+    func testShortShowsSyncWhenReconnecting() {
+        var s = AgentSnapshot.empty
+        s.state = .reconnecting
+        XCTAssertEqual(AgentSnapshotPresenter.short(s), "Sync")
     }
 
     func testShortShowsFormattedDollarsWhenPopulated() {

--- a/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
@@ -2,20 +2,27 @@ import XCTest
 @testable import Malibu
 
 final class DashboardViewTests: XCTestCase {
-    func testOptionalDashboardFieldsRenderDashWhenMissing() {
+    func testOptionalDashboardFieldsRenderFriendlyZerosWhenServing() {
         var snapshot = AgentSnapshot.empty
         snapshot.state = .serving
 
-        XCTAssertEqual(AgentSnapshotPresenter.modelLine(snapshot), "—")
-        XCTAssertTrue(AgentSnapshotPresenter.requestsLine(snapshot).contains("— today"))
-        XCTAssertTrue(AgentSnapshotPresenter.tokenLine(snapshot).contains("— in / — out today"))
-        XCTAssertTrue(AgentSnapshotPresenter.usdcFullLine(snapshot).contains("$— today"))
-        XCTAssertEqual(AgentSnapshotPresenter.queueChip(snapshot), "— queued")
-        XCTAssertEqual(AgentSnapshotPresenter.thermalChip(snapshot), "Thermal —")
+        XCTAssertEqual(AgentSnapshotPresenter.modelLine(snapshot), "Connected")
+        XCTAssertTrue(AgentSnapshotPresenter.requestsLine(snapshot).contains("0 today"))
+        XCTAssertTrue(AgentSnapshotPresenter.tokenLine(snapshot).contains("0 in / 0 out today"))
+        XCTAssertTrue(AgentSnapshotPresenter.usdcFullLine(snapshot).contains("$0.00 today"))
+        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot), "$0.00")
+        XCTAssertEqual(AgentSnapshotPresenter.queueChip(snapshot), "0 queued")
+        XCTAssertEqual(AgentSnapshotPresenter.thermalChip(snapshot), "Thermal OK")
+        XCTAssertEqual(AgentSnapshotPresenter.dashboardHeadline(snapshot), "Serving")
+        XCTAssertEqual(
+            AgentSnapshotPresenter.dashboardSubtitle(snapshot),
+            "Provider connected · waiting for first paid job"
+        )
     }
 
     func testPopulatedDashboardFieldsRenderValues() {
         var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
         snapshot.currentModelID = "Llama-3.1-8B · Q4_K_M · 4.2GB"
         snapshot.requestsServedToday = 142
         snapshot.requestsServedAllTime = 8_204

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -7,10 +7,12 @@ final class LaunchProviderControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         UserDefaults.standard.set("v2", forKey: "onboardingFlow")
+        LaunchProviderController.prefersCLIInstallTrack = false
     }
 
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: "onboardingFlow")
+        MalibuOnboardingPolicy.prefersCLIInstallTrack = true
         super.tearDown()
     }
 
@@ -312,6 +314,10 @@ final class LaunchProviderControllerTests: XCTestCase {
         var providerToken: String?
         var loadedState: OnboardingState?
         var registerError: Error?
+        var cliInstallRuns = 0
+        var cliImportRuns = 0
+        var monitorRuns = 0
+        var configModel = "mlx-community/Qwen2.5-7B-Instruct-4bit"
         let key = Curve25519.Signing.PrivateKey()
 
         func dependencies() -> LaunchProviderController.Dependencies {
@@ -387,9 +393,41 @@ final class LaunchProviderControllerTests: XCTestCase {
                 waitForFirstServing: {
                     Date(timeIntervalSince1970: 2)
                 },
-                readProviderID: { self.configProviderID }
+                readProviderID: { self.configProviderID },
+                runCLIInstall: { _ in
+                    self.cliInstallRuns += 1
+                },
+                importCLIConfigAfterInstall: {
+                    self.cliImportRuns += 1
+                    self.configured = true
+                },
+                monitorInstalledProvider: {
+                    self.monitorRuns += 1
+                },
+                readConfigModel: { self.configModel }
             )
         }
+    }
+
+    func testLaunchViaCLIInstallTrackRunsInstallerThenImports() async {
+        MalibuOnboardingPolicy.prefersCLIInstallTrack = true
+        defer { MalibuOnboardingPolicy.prefersCLIInstallTrack = false }
+
+        let harness = Harness()
+        let controller = LaunchProviderController(
+            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
+            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
+            dependencies: harness.dependencies()
+        )
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 1)
+        XCTAssertEqual(harness.cliImportRuns, 1)
+        XCTAssertEqual(harness.monitorRuns, 1)
+        XCTAssertEqual(harness.loginItemRegistrations, 1)
+        XCTAssertEqual(harness.autotuneRuns, 0)
+        XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
 }
 

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -22,8 +22,8 @@ final class StartupRouteTests: XCTestCase {
             ("configured-v2-partial", state(config: true, marker: true, token: true, identity: true, onboarding: true, firstServing: false), .resumeOnboarding, .resumeOnboarding),
             ("cli-owned", state(config: true, marker: false, token: false, identity: false, onboarding: false, firstServing: false), .showImportDialog, .showImportDialog),
             ("v2-partial", state(config: false, marker: false, token: false, identity: true, onboarding: true, firstServing: false), .resumeOnboarding, .resumeOnboarding),
-            ("fresh", state(config: false, marker: false, token: false, identity: false, onboarding: false, firstServing: false), .setupPaused, .showOnboarding),
-            ("identity-only", state(config: false, marker: false, token: false, identity: true, onboarding: false, firstServing: false), .setupPaused, .resumeOnboarding)
+            ("fresh", state(config: false, marker: false, token: false, identity: false, onboarding: false, firstServing: false), .showOnboarding, .showOnboarding),
+            ("identity-only", state(config: false, marker: false, token: false, identity: true, onboarding: false, firstServing: false), .showOnboarding, .resumeOnboarding)
         ]
 
         for (name, base, flagOffRoute, flagOnRoute) in cases {
@@ -75,7 +75,7 @@ final class StartupRouteTests: XCTestCase {
     }
 
     func testMigrationStartFreshMovesConfigAsideAndReclassifiesFreshByFlag() async throws {
-        for (enabled, expectedRoute) in [(false, StartupRoute.setupPaused), (true, .showOnboarding)] {
+        for (enabled, expectedRoute) in [(false, StartupRoute.showOnboarding), (true, .showOnboarding)] {
             let paths = try makeTempPaths()
             try paths.ensureDirectories()
             try "provider_id: p_old\nprovider_token: old-token\n".write(to: paths.configFile, atomically: true, encoding: .utf8)

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -37,6 +37,8 @@ targets:
           - "**/*.md"
     resources:
       - Sources/Malibu/Resources
+      - path: ../dist/install.sh
+        buildPhase: resources
     entitlements:
       path: Malibu.entitlements
     info:

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -37,8 +37,6 @@ targets:
           - "**/*.md"
     resources:
       - Sources/Malibu/Resources
-      - path: ../dist/install.sh
-        buildPhase: resources
     entitlements:
       path: Malibu.entitlements
     info:
@@ -61,6 +59,11 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Malibu.entitlements
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         INFOPLIST_KEY_LSApplicationCategoryType: "public.app-category.utilities"
+    postBuildScripts:
+      - name: Bundle install.sh
+        basedOnDependencyAnalysis: false
+        script: |
+          install -m 755 "${SRCROOT}/../dist/install.sh" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Resources/install.sh"
     dependencies: []
 
   # AUDIT R1 ARCHITECT A8 fix: unit-test the audit-critical app-side surfaces

--- a/scratchpad/onboarding-audit-2026-07-06.md
+++ b/scratchpad/onboarding-audit-2026-07-06.md
@@ -1,0 +1,126 @@
+# Provider Onboarding Audit — 2026-07-06
+
+Read-only audit of CLI-track vs App-track onboarding in current tree. Code is source of truth; memory items verified where noted.
+
+---
+
+## 1. Executive summary
+
+- **Two parallel tracks** share `~/.config/macprovider/config.yaml` but diverge on identity (CLI: hostname `provider_id` + YAML token; App: Ed25519 `provider_identity_v1` + Keychain token + `.installed-by-app` marker). SPEC-026 v0.13 is authoritative for App onboarding; SPEC-025 v0.1 for wrapper/CLI-child model.
+- **App-track V2 onboarding ships off by default** (`onboardingFlow=v2` or `MALIBU_ONBOARD_V2=1` required). Fresh installs see "Setup paused" unless the flag is set (`LaunchProviderController.swift:232-238`, `MalibuApp.swift:158-163`).
+- **M5 32GB Tier C cannot complete Malibu autotune today** when CLI emits `"serve_config": null` — Malibu's decoder requires a non-null object and fails before donor-mode handling (`AutotuneRecommendationRunner.swift:251-247`, `AutotuneRecommend.swift:1150`).
+- **CLI `install.sh` targets `$HOME/macprovider/macprovider-cli`**, not `/tmp`. Operator plist at `/tmp/macprovider-v1.8.10-run/...` is not produced by current installer (`install.sh:18-20`, `1456-1458`).
+- **Malibu always spawns its own CLI child**; no adopt-mode, no launchd conflict detection in App code. Coexistence with launchd-managed CLI is accidental (different ports possible, same `provider_id`).
+
+---
+
+## 2. Onboarding path A — CLI-track
+
+Fresh Mac, `curl https://get.streamvc.live/install.sh | bash`:
+
+| Step | Code | Artifacts | Coordinator | Failure UX |
+|------|------|-----------|-------------|------------|
+| 1. Preflight | `install.sh:2526-2543` | — | — | Exit 1/6/7: wrong OS/arch/macOS, port busy (`ensure_port_free:251-297`) |
+| 2. Model/provider prompts | `choose_model:746`, `choose_provider_id:804`, `choose_coordinator_url:829` | — | Optional `GET …/catalog/current` (`check_catalog_ram_metadata:630`) | Exit 7: invalid model/HF/RAM |
+| 3. Download + verify | `download_release:977`, `verify_sha256:1051`, pkg Gatekeeper (`validate_package:1109`) | Temp staging dir | GitHub Releases API | Exit 3-5: download/checksum/sig failure |
+| 4. Install binary | `install_binary:1341-1375` | Real: `$HOME/macprovider/macprovider-cli` + MLX bundles; symlink `~/.local/bin/macprovider-cli` | — | Exit 5 |
+| 5. Write config | `write_config:1161-1181` | `~/.config/macprovider/config.yaml`, `provider_id` file; preserves existing `provider_token:` line | — | — |
+| 6. Autotune | `run_autotune_recommend_apply:1246` | Updates config (model, artifact paths, `donor_mode`) | Catalog via CLI subprocess | Donor prompt or `SKIP_PROVIDER_START=1`; exit 6 |
+| 7. LaunchAgent | `install_plist:1422-1447`, `render_plist:1449-1508` | `~/Library/LaunchAgents/live.streamvc.macprovider.plist`, logs under `~/Library/Logs/macprovider/` | — | Exit 5: launchctl bootstrap fail (AMFI on adhoc, macOS 26+) |
+| 8. Watchdog | `install_watchdog:2220-2246` | `~/.local/share/macprovider-watchdog/`, second plist | — | Same |
+| 9. Manifest | `write_install_manifest:2249` | `~/Library/Application Support/macprovider/install_manifest.json` | — | — |
+| 10. Self-test | `wait_for_local_model:2386`, `wait_for_coordinator:2495` | — | `GET /v1/pool/check?provider_id=…` | Exit 6: timeout diagnostics (`print_local_self_test_diagnostics:2456`) |
+
+**Token issuance:** Installer does not call `POST /v1/providers/register`. CLI connects via WebSocket; coordinator may return `assigned_provider_token` in hello/auth, persisted to YAML by `CoordinatorClient.adoptAssignedProviderTokenIfPresent` (`CoordinatorClient.swift:1298-1340`, `ProviderTokenPersist.swift`). Token stored in `config.yaml` (`provider_token:` line), not Keychain.
+
+**Reboot:** LaunchAgent `RunAtLoad` + `KeepAlive` (`install.sh:1480-1486`) reloads binary at `$INSTALL_DIR/macprovider-cli` — survives reboot if plist path is durable (not `/tmp`).
+
+---
+
+## 3. Onboarding path B — App-track
+
+Fresh Mac, launch `Malibu.app`:
+
+| Step | Code | Artifacts | Coordinator | Failure UX |
+|------|------|-----------|-------------|------------|
+| 1. Startup route | `MalibuApp.handleStartup:112-114`, `StartupState.route:659-676` | Reads config, marker, Keychain, `onboarding.json` | — | `.setupPaused` alert if V2 off (`MalibuApp.swift:158-163`) |
+| 2. Migration (if CLI config, no marker) | `showImportDialog` / `importExistingCLIConfig:276-344` | Token → Keychain `tech.malibu.provider/{provider_id}`; strips YAML token; writes `.installed-by-app` | — | Alert on import error |
+| 3. V2 gate | `LaunchProviderController.launch:232-238` | — | — | `.failed(featureFlag)`: "App-track onboarding is not enabled" |
+| 4. Identity | `loadOrGenerateIdentity:242`, `ProviderIdentity.swift:64-66` | Keychain `tech.malibu.app` / `provider_identity_v1` | — | Keychain errors → `.failed` |
+| 5. Persist state | `saveState:245-252` | `~/Library/Application Support/Malibu/onboarding.json` (0600) | — | — |
+| 6. Register | `registerProvider:256`, `RegisterClient.postRegister:158-181` | Config YAML (no token on disk), Keychain token | **`POST /v1/providers/register`** | HTTP error → `.failed(retryable)` |
+| 7. Autotune | `finishLaunch` → `runAutotune:403`, `AutotuneRecommendationRunner.run:82-90` | Recommendation fields in config | Catalog via bundled CLI | JSON/decode/timeout → `.failed`; UI shows `error.localizedDescription` (`OnboardingWindow.swift:130-134`) |
+| 8. Model download | `downloadModel:418` | **Stub:** returns `plan.state` (always nil in live deps `LaunchProviderController.swift:123`) | — | Cosmetic progress only |
+| 9. Login item | `registerLoginItem:427`, `AppLoginItem.swift:10-11` | `SMAppService.mainApp` | — | Throws → `.failed` |
+| 10. Start agent | `startAgent:429`, `MalibuAgent.start:53-134` | Spawns bundled CLI with `--ctl-socket-path …/agent.sock`, `--managed-by malibu-app`, token via env | WS auth + identity signature | "Not set up yet" / control socket timeout / CLI exit |
+| 11. Live | `waitForFirstServing:432`, `updateState:433` | Sets `first_serving_at` in onboarding.json | — | Timeout: "Timed out waiting for the first serving frame." |
+
+**State machine:** `Stage` enum `LaunchProviderController.swift:19-30`. **Resume:** `ResumePoint` + `lastStage` in onboarding.json (`307-340`). Crash mid-stage: resume from persisted `lastStage`; identity re-used via `loadOrGenerateIdentity` / `loadExistingIdentity` (`342-370`). **Not recovered:** missing Keychain identity when `isConfigured` still true (see §5).
+
+**V2 flag checks:** `LaunchProviderController.isOnboardingV2Enabled` (`157-173`); `StartupState.detect` (`655`); `StartupState.route` (`675`); `applyMigrationDecision` (`696`). Default **off** unless env or `UserDefaults onboardingFlow=v2`. SPEC-026 v0.12: fresh flag-off shows setup-paused, not browser OAuth.
+
+**Reboot:** `SMAppService` re-launches app → `.startAgent` if configured → `MalibuAgent.start()` spawns new CLI child. No launchd plist in App track.
+
+---
+
+## 4. Overlap + priority map
+
+| Artifact | CLI-track | App-track | Source of truth |
+|----------|-----------|-----------|-----------------|
+| `~/.config/macprovider/config.yaml` | Writes model, port, `provider_id`, **`provider_token` on disk** | Writes `provider_id`, coordinator URL, autotune fields; **token in Keychain only** | Shared file; App requires `.installed-by-app` marker (`ProviderConfig.swift:22-32`) |
+| `~/Library/Application Support/Malibu/.installed-by-app` | — | Created on App save/import | App ownership gate |
+| `~/Library/Application Support/Malibu/onboarding.json` | — | V2 state machine | App-only |
+| Keychain `tech.malibu.provider/{provider_id}` | — (import migrates CLI token here) | Bearer token | App track; CLI reads YAML/env |
+| Keychain `tech.malibu.app` / `provider_identity_v1` | — | Ed25519 identity | App-only (SPEC-026 §3.1) |
+| LaunchAgent `live.streamvc.macprovider` | `install.sh` | **Not used** (SPEC-025: SMAppService instead) | Independent |
+| Control socket `…/Malibu/agent.sock` | Not set by launchd plist | Malibu child only (`CLIChildProcess.swift:57-61`) | App child path only |
+
+**SPEC vs code:** SPEC-026 v0.13 makes App-track register + Keychain authoritative for new providers. SPEC-025 v0.1 §12 describes conflict detection — **`ProviderConflictDetector` exists in CLI** (`ProviderConflictDetector.swift`) but **Malibu app does not invoke it** on startup.
+
+**CLI child ownership:** `MalibuAgent.start:56` guards `child == nil` then always spawns (`92-125`). No probe/adopt of existing socket. Launchd CLI uses default serve args (no `--ctl-socket-path` in `render_plist:1468-1478`) — **no socket collision**, but **two CLI processes** can run (Malibu picks free HTTP port via `FreePortProbe`, `MalibuAgent.swift:90`).
+
+**Inconsistent states:** (1) CLI launchd + Malibu both running same `provider_id`. (2) `isConfigured` true, identity Keychain empty — reachable via `startConfiguredAgent` after manual identity delete (`launch:214-221`, `282-297`). (3) `first_serving_at` set + empty identity — same path; onboarding.json retained while identity gone. (4) Import CLI config without generating identity — serves but `handleIdentitySignatureRequest` fails (`MalibuAgent.swift:391-421`). (5) Partial uninstall residue (`wipeAppOwnedState:466-488`) leaves config/Keychain fragments.
+
+---
+
+## 5. UX defect list (code-evidence only)
+
+| # | Defect | Symptom | Evidence | Sev | Fix |
+|---|--------|---------|----------|-----|-----|
+| 1 | `serve_config: null` crashes Malibu JSON decode | Autotune spinner → "Needs retry" with opaque error; M5 32GB Tier C donor-only | `AutotuneRecommend.swift:1150`; `AutotuneServeConfigPayload` non-optional `AutotuneRecommendationRunner.swift:251-247`; no donor branch in `finishLaunch` | **Blocker** | M — nullable decode + donor UX like `install.sh:1274-1295` |
+| 2 | V2 onboarding default-off | Fresh Malibu install: "Setup paused", no earn path | `LaunchProviderController.swift:172`; `StartupState.route:675` | **Blocker** (product) | S — default `v2` in release build |
+| 3 | No identity recovery | Keychain identity missing but config OK: app shows "live"/serving; coordinator identity auth fails silently | `startConfiguredAgent:282-297`; `handleIdentitySignatureRequest:415-421`; no regen UI | **High** | M — detect `!ProviderIdentity.isReady()` + re-register flow |
+| 4 | No launchd coexistence handling | launchd CLI running + Malibu open → second CLI, duplicate provider, RAM waste | No `ProviderConflictDetector` in app; `MalibuAgent.start:56`; SPEC-025 §12 unimplemented | **High** | L — adopt-mode or conflict dialog |
+| 5 | `/tmp` plist not from installer | Reboot kills provider if plist manually points at `/tmp` | `install.sh:1458` uses `$INSTALL_DIR`; operator plist is out-of-tree | **High** (ops) | S — reinstall via install.sh |
+| 6 | Model download stage is no-op | "Preparing recommended" with fake progress | `Dependencies.downloadModel:123` returns `plan.state` | **Medium** | M — wire HF download or skip stage |
+| 7 | CLI uninstall leaves caches + Malibu state | HF cache, `~/.config/macprovider/`, Malibu App Support untouched | `uninstall.sh:112-113`, `185-188`; no Malibu paths | **Medium** | M — cross-track cleanup docs/UI |
+| 8 | Malibu uninstall misses CLI launchd | CLI LaunchAgent keeps running after "Quit and Uninstall" | `wipeAppOwnedState:466-488` — App Support only | **Medium** | M |
+| 9 | Adhoc CLI + launchd on macOS 26+ | `launchctl bootstrap` fails | `install_plist:1445`; pkg path validates Gatekeeper (`1112`) | **High** on unsigned | S — require signed pkg path |
+| 10 | Autotune errors opaque | `.failed` shows `localizedDescription`; `AutotuneRecommendationError` has no messages | `LaunchProviderController.swift:262`; `AutotuneRecommendationError:212-216` | **Low** | S |
+
+**Verified:** Backup `Malibu.app.bak-*` is Developer ID + notarized (Superposition YF7XNRJUG4), stapled — enrollment blocker memory superseded.
+
+---
+
+## 6. Adopt-mode design compatibility
+
+**Protocol:** Control socket accepts multiple same-EUID clients concurrently (`ControlSocket.swift:539-581`, backlog 128). Malibu `ControlSocketClient` is a single-connection client — adopt-mode = connect without spawning, no protocol change required.
+
+**Identity handoff:** `identity_signature_request` is pushed to control-socket clients; Malibu signs via `ProviderIdentity.loadExisting()` (`MalibuAgent.swift:302-311`, `373-422`). If CLI was started by **launchd without `--managed-by malibu-app`**, token persists to YAML (`CoordinatorClient.swift:1314-1321`); identity bridge may still fire if warm-swap enabled — but launchd plist **does not pass `--enable-warm-swap`**, so **no control socket on launchd CLI today**. Adopt would require launchd CLI to open same socket path.
+
+**Shutdown:** `MalibuAgent.shutdown:152-168` sends `shutdown_request` and `child?.stop()` — assumes ownership. Adopted CLI: shutdown would **kill a process Malibu didn't spawn**; must gate `stop()` on ownership flag. `markStopping`/`isStopping` only cover spawned child (`CLIChildProcess.swift:35-35`).
+
+**SPEC-025 §5.2:** Spec contemplates conflict detect + migrate (`SPEC-025-native-mac-app.md:321`); additive frames already include `identity_signature_*`. Adopt-mode fits; missing pieces are ownership tracking and launchd plist alignment (`--ctl-socket-path`, `--enable-warm-swap`).
+
+---
+
+## 7. Open questions
+
+1. **Production Malibu build:** Is `onboardingFlow=v2` baked into release `UserDefaults` or only dev manual `defaults write`? Not found in `project.yml`.
+2. **Coordinator behavior** when two CLIs connect with same `provider_id` — not fully traceable from phase3-binary alone.
+3. **Operator `/tmp` plist origin** — likely manual/dev run, not `install.sh`; label `v1810` vs fixed `live.streamvc.macprovider` in script (`install.sh:26`).
+4. **Wallet / USDC earn path** post-onboarding — `setPayoutWallet` throws SPEC-027 stub (`LaunchProviderController.swift:277-279`); earning requires separate wallet flow not audited here.
+
+---
+
+*Word count: ~1,450. All line refs relative to repo root `macprovider-poc`.*


### PR DESCRIPTION
## Summary
- **Option A onboarding:** "Launch Provider" runs bundled `install.sh` (`MACPROVIDER_NO_PROMPT=1`), imports CLI config to Keychain via `importExistingCLIConfig()`, registers the Malibu login item, and monitors the launchd-managed provider over `/v1/health` instead of spawning a second CLI child.
- **Policy default:** `MalibuOnboardingPolicy.prefersCLIInstallTrack = true` — fresh installs show onboarding without `MALIBU_ONBOARD_V2` / UserDefaults v2 flag. Legacy SPEC-026 in-app register/autotune path remains available when the policy is disabled (tests).
- **UI from keen-chaum-ff9ea8 (51bbdb0):** vertically center the menu-bar horizon+sun icon; remove "Quit and Uninstall…" from the menu (handler retained for future entry point).
- **Research artifact:** `scratchpad/onboarding-audit-2026-07-06.md` documents the pre-change onboarding map and UX gaps.

## Test plan
- [x] `xcodebuild -project phase3-binary/app/Malibu.xcodeproj -scheme Malibu -only-testing:MalibuTests test` (109 tests pass)
- [ ] Fresh Mac / clean state: launch Malibu → Launch Provider → verify install.sh log stream, launchd service, import succeeds, dashboard shows serving via health poll
- [ ] Reboot: verify launchd provider survives and Malibu attaches on startup when configured
- [ ] M5 32GB Tier C: confirm donor-mode path works via install.sh (no Swift `serve_config` JSON decode)
- [ ] Visual: menu-bar icon centered in light/dark mode


Made with [Cursor](https://cursor.com)