### PR TITLE
Fix status/routing mismatch and auto-reconnect after token mint

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -431,6 +431,15 @@ actor CoordinatorClient {
                 try? await Task.sleep(nanoseconds: reconnectGraceNanoseconds)
                 backoffSeconds = 1
                 failedAttempts = 0
+            } catch is CoordinatorAuthUpgradeReconnect {
+                // FR-C9.3: tokenless bootstrap minted a bearer; reconnect immediately
+                // so the coordinator registers auth_state=bearer_validated and the
+                // session becomes buyer-routable.
+                await cleanupConnection()
+                print("coordinator reconnect scheduled after provisional token adoption")
+                try? await Task.sleep(nanoseconds: reconnectGraceNanoseconds)
+                backoffSeconds = 1
+                failedAttempts = 0
             } catch {
                 await cleanupConnection()
                 failedAttempts += 1
@@ -825,6 +834,12 @@ actor CoordinatorClient {
             await cleanupConnection()
             runTask = nil
             print("coordinator reconnect attempt 1 scheduled after drain")
+            try? await Task.sleep(nanoseconds: reconnectGraceNanoseconds)
+            startReconnectTask()
+        } catch is CoordinatorAuthUpgradeReconnect {
+            await cleanupConnection()
+            runTask = nil
+            print("coordinator reconnect scheduled after provisional token adoption")
             try? await Task.sleep(nanoseconds: reconnectGraceNanoseconds)
             startReconnectTask()
         } catch {
@@ -1371,6 +1386,11 @@ actor CoordinatorClient {
         // Awaited so that persist-before-adopt holds: see
         // adoptAssignedProviderTokenIfPresent doc-comment.
         let assignedProviderTokenAdopted = await adoptAssignedProviderTokenIfPresent(payload)
+        if assignedProviderTokenAdopted {
+            // The current tokenless WS session stays auth_state=self_minted and is
+            // not buyer-routable until we reconnect with Authorization: Bearer.
+            throw CoordinatorAuthUpgradeReconnect()
+        }
         do {
             try pairingController.handlePairingMaterial(
                 pairOT: payload["pair_ot"] as? String,
@@ -2437,6 +2457,10 @@ extension CoordinatorClient: ReceiptKeyRotatingCoordinatorClient {}
 /// Signals "coordinator asked us to drain, handle complete, reconnect later
 /// after a grace period." Caught by runReconnectLoop.
 struct CoordinatorDrainComplete: Error {}
+
+/// FR-C9.3 — coordinator minted a provisional bearer on a tokenless connect;
+/// reconnect with Authorization so auth_state becomes bearer_validated.
+struct CoordinatorAuthUpgradeReconnect: Error {}
 
 enum CoordinatorAuthError: Error, Equatable, CustomStringConvertible {
     case invalidMessage(String)

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -353,6 +353,47 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertFalse(authJSON.contains("request_pair_ot"), authJSON)
     }
 
+    func testHelloAckAssignedProviderTokenTriggersAuthUpgradeReconnect() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let dir = try Self.makeTemporaryDirectory(prefix: "coordinator-token-reconnect-")
+        let configPath = dir.appendingPathComponent("config.yaml").path
+        try "provider_id: provider-test\nmodel: model-a\n".write(
+            toFile: configPath,
+            atomically: true,
+            encoding: .utf8
+        )
+        var config = AppConfig.defaults(configPath: configPath)
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = "model-a"
+        config.wsTunneledMode = false
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            webSocketFactory: { _ in FakeProviderWebSocketTask(receiveResults: []) },
+            sleepAssertionFactory: { nil }
+        ))
+
+        do {
+            try await client.handleCoordinatorPayloadForTest([
+                "type": "hello_ack",
+                "assigned_id": "assigned-a",
+                "heartbeat_interval_s": 30,
+                "assigned_provider_token": "minted-provisional-token",
+            ])
+            XCTFail("expected CoordinatorAuthUpgradeReconnect")
+        } catch is CoordinatorAuthUpgradeReconnect {
+            // FR-C9.3: tokenless bootstrap must reconnect with Bearer before serving buyers.
+        }
+    }
+
     func testHelloAckPairingMaterial_WritesClaimURLBeforeFailedOpen() async throws {
         let recorder = CoordinatorFrameRecorder()
         let status = ProviderStatus(

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -2788,6 +2788,7 @@ func (s *Server) handlePoolz(w http.ResponseWriter, r *http.Request) {
 	}
 	type poolzProvider struct {
 		pool.Provider
+		RoutingEligible   bool                    `json:"routing_eligible"`
 		CanaryFailCount   int                     `json:"canary_fail_count"`
 		ReceiptPubkey     *string                 `json:"receipt_pubkey"`
 		ReceiptPubkeyPrev *poolzReceiptPubkeyPrev `json:"receipt_pubkey_prev"`
@@ -2810,6 +2811,7 @@ func (s *Server) handlePoolz(w http.ResponseWriter, r *http.Request) {
 		}
 		poolz = append(poolz, poolzProvider{
 			Provider:          provider,
+			RoutingEligible:   provider.RoutingEligible(),
 			CanaryFailCount:   provider.CanaryFailCount,
 			ReceiptPubkey:     receiptPubkey,
 			ReceiptPubkeyPrev: receiptPubkeyPrev,

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -541,8 +541,7 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body)
 			return
 		}
-		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
-		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "no_provider_available", "No provider available")
+		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body)
 		return
 	}
 	if resp.StatusCode == http.StatusGatewayTimeout {
@@ -642,8 +641,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body)
 			return
 		}
-		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
-		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "no_provider_available", "No provider available")
+		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body)
 		return
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -1006,6 +1004,10 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 
 func (s *Server) passThroughNoProviderCoordinatorError(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, body []byte) {
 	_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+	if len(bytes.TrimSpace(body)) == 0 && resp.StatusCode == http.StatusServiceUnavailable {
+		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "no_provider_available", "No provider available")
+		return
+	}
 	copyCleanHeaders(w.Header(), resp.Header)
 	w.Header().Set("Content-Type", contentTypeOrJSON(resp.Header))
 	w.WriteHeader(resp.StatusCode)

--- a/phase5-gateway/internal/router/integration_test.go
+++ b/phase5-gateway/internal/router/integration_test.go
@@ -383,6 +383,22 @@ func TestDemoConcurrencyCap(t *testing.T) {
 	}
 }
 
+func TestCoordinator503PassthroughPreservesPreflightRejected(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		body := `{"error":{"code":"preflight_rejected","message":"Provider rejected preflight","param":null,"type":"service_unavailable"}}`
+		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, body), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, "acct_preflight_passthrough")
+	resp := postChat(t, h, fullKey, `{"model":"llama","max_tokens":80,"messages":[{"role":"user","content":"hi"}]}`, nil)
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "preflight_rejected")
+}
+
 func TestProviderUnavailableReturns503AndRefunds(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		return responseWithBody(http.StatusServiceUnavailable, nil, ""), nil

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -564,31 +564,36 @@ type statusModel struct {
 // normative contract — if these ever drift, fix SPEC-002 first.
 const authStateBearerlessDuplicate = "bearerless_duplicate"
 
+// Non-routable auth_state values mirrored from pool.Provider.RoutingEligible().
+// Used when /poolz rows omit routing_eligible (pre-upgrade coordinators).
+const (
+	authStateSelfMinted = "self_minted"
+	authStateMintFailed = "mint_failed"
+)
+
+type poolzProviderRow struct {
+	ProviderID               string   `json:"provider_id"`
+	AssignedID               string   `json:"assigned_id"`
+	EndpointURL              string   `json:"endpoint_url"`
+	Hostname                 string   `json:"hostname"`
+	ModelID                  string   `json:"model_id"`
+	State                    string   `json:"state"`
+	SlotsFree                int      `json:"slots_free"`
+	SlotsTotal               int      `json:"slots_total"`
+	MaxContextTokens         int      `json:"max_context_tokens"`
+	MemoryBytes              int64    `json:"memory_bytes"`
+	CPUCount                 int      `json:"cpu_count"`
+	OperatorIdentity         string   `json:"operator_identity"`
+	SupportedModels          []string `json:"supported_models,omitempty"`
+	PublishesSupportedModels bool     `json:"publishes_supported_models,omitempty"`
+	// routing_eligible is coordinator-computed from pool.Provider.RoutingEligible().
+	// Omitted on legacy coordinators — gateway falls back to auth_state exclusion.
+	RoutingEligible *bool `json:"routing_eligible,omitempty"`
+	AuthState       string `json:"auth_state,omitempty"`
+}
+
 type poolzResponse struct {
-	Pool []struct {
-		ProviderID               string   `json:"provider_id"`
-		AssignedID               string   `json:"assigned_id"`
-		EndpointURL              string   `json:"endpoint_url"`
-		Hostname                 string   `json:"hostname"`
-		ModelID                  string   `json:"model_id"`
-		State                    string   `json:"state"`
-		SlotsFree                int      `json:"slots_free"`
-		SlotsTotal               int      `json:"slots_total"`
-		MaxContextTokens         int      `json:"max_context_tokens"`
-		MemoryBytes              int64    `json:"memory_bytes"`
-		CPUCount                 int      `json:"cpu_count"`
-		OperatorIdentity         string   `json:"operator_identity"`
-		SupportedModels          []string `json:"supported_models,omitempty"`
-		PublishesSupportedModels bool     `json:"publishes_supported_models,omitempty"`
-		// SPEC-003 v0.8.3 FR-C9.4 auth_state — empty / bearer_validated /
-		// self_minted are routable; bearerless_duplicate is non-routable
-		// (admitted for /poolz visibility, excluded from buyer traffic +
-		// billing). The gateway mirrors pool.Provider.RoutingEligible() by
-		// dropping bearerless_duplicate entries from /v1/status capacity
-		// aggregation so the buyer-visible status doesn't promise capacity
-		// the coordinator will refuse to route.
-		AuthState string `json:"auth_state,omitempty"`
-	} `json:"pool"`
+	Pool    []poolzProviderRow `json:"pool"`
 	Summary struct {
 		TotalProviders int `json:"total_providers"`
 		Ready          int `json:"ready"`
@@ -656,14 +661,11 @@ func aggregateStatus(poolz poolzResponse, readyThreshold int, now time.Time) sta
 		Coordinator: coordinatorStatus{Status: "up", CheckedAt: now.Format(time.RFC3339)},
 	}
 	for _, p := range poolz.Pool {
-		// SPEC-003 v0.8.3 FR-C9.4 — bearerless duplicates are admitted to
-		// /poolz for operator visibility but are non-routable (excluded by
-		// pool.Provider.RoutingEligible). They MUST NOT contribute to the
-		// gateway's buyer-facing capacity counts: counting them would
-		// over-promise capacity that the coordinator will refuse to route,
-		// and would taint per-model availability (a model whose only
-		// "ready" entry is a bearerless duplicate would appear available).
-		if p.AuthState == authStateBearerlessDuplicate {
+		// SPEC-003 v0.8.3 FR-C9.4 + pool.Provider.RoutingEligible() — sessions
+		// admitted to /poolz for operator visibility but excluded from buyer
+		// routing (self_minted, bearerless_duplicate, pending receipt rotation,
+		// etc.) MUST NOT contribute to buyer-facing capacity counts.
+		if !poolzProviderCountsTowardBuyerCapacity(p) {
 			continue
 		}
 		out.Pool.TotalProviders++
@@ -715,7 +717,7 @@ func aggregateStatus(poolz poolzResponse, readyThreshold int, now time.Time) sta
 	// SPEC-002 v1.4.1 — the summary fallback only fires when the coordinator
 	// omitted the detailed `pool` array entirely (e.g. a redacted/summary-only
 	// response). It MUST NOT fire when `pool` rows ARE present but all have
-	// been excluded by the bearerless-duplicate gate above; otherwise the
+	// been excluded by the non-routable aggregation gate above; otherwise the
 	// coordinator's summary (which includes bearerless rows in
 	// `total_providers`) would reintroduce excluded capacity on the buyer-
 	// facing surface. The condition is on `len(poolz.Pool)`, not on
@@ -747,6 +749,20 @@ func aggregateStatus(poolz poolzResponse, readyThreshold int, now time.Time) sta
 	}
 	sort.Slice(out.Models, func(i, j int) bool { return out.Models[i].ID < out.Models[j].ID })
 	return out
+}
+
+// poolzProviderCountsTowardBuyerCapacity mirrors pool.Provider.RoutingEligible()
+// for buyer-facing /v1/status aggregation.
+func poolzProviderCountsTowardBuyerCapacity(p poolzProviderRow) bool {
+	if p.RoutingEligible != nil {
+		return *p.RoutingEligible
+	}
+	switch p.AuthState {
+	case authStateBearerlessDuplicate, authStateSelfMinted, authStateMintFailed:
+		return false
+	default:
+		return true
+	}
 }
 
 type poolzModelStats struct {

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1114,27 +1114,27 @@ func TestAggregateStatusExcludesBearerlessDuplicatesFromCapacity(t *testing.T) {
 		"summary":{"total_providers":4,"ready":3,"total_slots":5,"free_slots":5}
 	}`), 1, fixedNow())
 
-	if out.Pool.TotalProviders != 3 {
-		t.Fatalf("TotalProviders=%d, want 3 (bearerless duplicate excluded)", out.Pool.TotalProviders)
+	if out.Pool.TotalProviders != 2 {
+		t.Fatalf("TotalProviders=%d, want 2 (bearerless duplicate and self_minted excluded)", out.Pool.TotalProviders)
 	}
-	if out.Pool.Ready != 3 {
-		t.Fatalf("Pool.Ready=%d, want 3 (bearerless duplicate excluded)", out.Pool.Ready)
+	if out.Pool.Ready != 2 {
+		t.Fatalf("Pool.Ready=%d, want 2 (bearerless duplicate and self_minted excluded)", out.Pool.Ready)
 	}
 	if len(out.Models) != 1 {
 		t.Fatalf("models=%+v, want one model entry", out.Models)
 	}
 	m := out.Models[0]
-	if m.ProviderCount != 3 {
-		t.Fatalf("model.ProviderCount=%d, want 3 (bearerless duplicate excluded)", m.ProviderCount)
+	if m.ProviderCount != 2 {
+		t.Fatalf("model.ProviderCount=%d, want 2 (bearerless duplicate and self_minted excluded)", m.ProviderCount)
 	}
-	if m.ReadyProviderCount != 3 {
-		t.Fatalf("model.ReadyProviderCount=%d, want 3 (bearerless duplicate excluded)", m.ReadyProviderCount)
+	if m.ReadyProviderCount != 2 {
+		t.Fatalf("model.ReadyProviderCount=%d, want 2 (bearerless duplicate and self_minted excluded)", m.ReadyProviderCount)
 	}
-	if m.TotalSlots != 4 {
-		t.Fatalf("model.TotalSlots=%d, want 4 (1 from bearerless duplicate excluded)", m.TotalSlots)
+	if m.TotalSlots != 3 {
+		t.Fatalf("model.TotalSlots=%d, want 3 (2 excluded slots omitted)", m.TotalSlots)
 	}
-	if m.SlotsFree != 4 {
-		t.Fatalf("model.SlotsFree=%d, want 4 (1 from bearerless duplicate excluded)", m.SlotsFree)
+	if m.SlotsFree != 3 {
+		t.Fatalf("model.SlotsFree=%d, want 3 (2 excluded slots omitted)", m.SlotsFree)
 	}
 	if !m.Available || m.Availability != "available" {
 		t.Fatalf("model availability=%+v, want available", m)
@@ -1211,11 +1211,9 @@ func TestAggregateStatusSummaryFallbackFiresOnlyWhenPoolIsEmpty(t *testing.T) {
 }
 
 // SPEC-003 v0.8.3 enum coverage — pins per-value routability so future
-// changes (issue #82 item 2 will flip `mint_failed` semantics) MUST update
-// this test and SPEC-002 v1.4.1's aggregation rule together. Only
-// `bearerless_duplicate` is excluded today; everything else — including
-// empty (pre-v0.8.3 coordinator), `bearer_validated`, `self_minted`,
-// `mint_failed`, and unknown future values — aggregates normally.
+// changes MUST update this test and SPEC-002 v1.4.1's aggregation rule together.
+// Non-routable auth_state values (bearerless_duplicate, self_minted, mint_failed)
+// are excluded from buyer-facing /v1/status capacity.
 func TestAggregateStatusAuthStateRoutabilityCoverage(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -1224,10 +1222,10 @@ func TestAggregateStatusAuthStateRoutabilityCoverage(t *testing.T) {
 	}{
 		{name: "empty (pre-v0.8.3 coordinator)", authState: "", wantReady: 1},
 		{name: "bearer_validated", authState: "bearer_validated", wantReady: 1},
-		{name: "self_minted", authState: "self_minted", wantReady: 1},
-		{name: "mint_failed (currently routable; flips in #82 item 2)", authState: "mint_failed", wantReady: 1},
+		{name: "self_minted", authState: "self_minted", wantReady: 0},
+		{name: "mint_failed", authState: "mint_failed", wantReady: 0},
 		{name: "unknown future value (defensive default = aggregate)", authState: "future_value_xyz", wantReady: 1},
-		{name: "bearerless_duplicate (the only excluded value)", authState: "bearerless_duplicate", wantReady: 0},
+		{name: "bearerless_duplicate", authState: "bearerless_duplicate", wantReady: 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1253,6 +1251,48 @@ func TestAuthStateBearerlessDuplicateConstantMatchesSpec(t *testing.T) {
 	const want = "bearerless_duplicate"
 	if authStateBearerlessDuplicate != want {
 		t.Fatalf("authStateBearerlessDuplicate = %q, want %q (SPEC-002 v1.4.1 FR-O2 aggregation rule)", authStateBearerlessDuplicate, want)
+	}
+}
+
+func TestPoolzProviderCountsTowardBuyerCapacity(t *testing.T) {
+	falseVal := false
+	trueVal := true
+	cases := []struct {
+		name string
+		row  poolzProviderRow
+		want bool
+	}{
+		{name: "routing_eligible true", row: poolzProviderRow{RoutingEligible: &trueVal}, want: true},
+		{name: "routing_eligible false", row: poolzProviderRow{RoutingEligible: &falseVal, AuthState: "bearer_validated"}, want: false},
+		{name: "legacy bearer_validated", row: poolzProviderRow{AuthState: "bearer_validated"}, want: true},
+		{name: "legacy self_minted", row: poolzProviderRow{AuthState: "self_minted"}, want: false},
+		{name: "legacy bearerless_duplicate", row: poolzProviderRow{AuthState: "bearerless_duplicate"}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := poolzProviderCountsTowardBuyerCapacity(tc.row); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAggregateStatusAllSelfMintedPoolReportsNoCapacity(t *testing.T) {
+	out := aggregateStatus(decodePoolz(t, `{
+		"pool":[
+			{"model_id":"llama","state":"ready","slots_free":1,"slots_total":1,"max_context_tokens":4096,"auth_state":"self_minted","routing_eligible":false}
+		],
+		"summary":{"total_providers":1,"ready":0,"total_slots":1,"free_slots":0}
+	}`), 1, fixedNow())
+
+	if out.Pool.Ready != 0 {
+		t.Fatalf("Pool.Ready=%d, want 0", out.Pool.Ready)
+	}
+	if out.Status != "idle" {
+		t.Fatalf("status=%q, want idle", out.Status)
+	}
+	if len(out.Models) != 0 {
+		t.Fatalf("models=%+v, want no model entries", out.Models)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Fix A:** `/poolz` now emits `routing_eligible`; gateway `/v1/status` excludes non-routable sessions (`self_minted`, `mint_failed`, `bearerless_duplicate`, pending receipt rotation) so buyers no longer see green capacity when chat returns 503.
- **Fix B:** MacProvider reconnects immediately after FR-C9.3 provisional token adoption so the next WS session is `bearer_validated` and buyer-routable.
- **Fix C:** Gateway passes through coordinator 503 error bodies (`preflight_rejected`, etc.) instead of rewriting everything to generic `no_provider_available` (empty-body 503 still maps to the generic envelope).

## Test plan
- [x] `go test ./phase5-gateway/internal/router/...`
- [x] `go test ./phase4-coordinator/internal/ws/... -run Poolz`
- [x] New tests: status aggregation for `self_minted`, `routing_eligible` pointer, 503 passthrough, Swift auth-upgrade reconnect


Made with [Cursor](https://cursor.com)