### PR TITLE
Fix Malibu launchd monitor races after CLI install onboarding

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -55,13 +55,15 @@ final class MalibuAgent: ObservableObject {
     func start() async {
         // AUDIT R2 CODE H3 fix.
         guard !isShuttingDown else { return }
-        guard child == nil else { return }
 
         // Option A: when install.sh owns the provider via launchd, monitor it
-        // instead of spawning a second macprovider-cli child.
+        // instead of spawning a second macprovider-cli child. Run this before
+        // the spawned-child guard so a stale Malibu-owned CLI is released first.
         if await monitorInstalledProviderIfPresent() {
             return
         }
+
+        guard child == nil else { return }
 
         // AUDIT R2 CODE H4 fix: refuse to spawn the CLI without a validated
         // app-owned config + keychain token. Onboarding must complete the
@@ -183,11 +185,14 @@ final class MalibuAgent: ObservableObject {
     /// Attach to an existing launchd-managed provider (CLI install track).
     /// Returns true when local /v1/health is reachable on the configured port.
     @discardableResult
-    func monitorInstalledProviderIfPresent(timeout: TimeInterval = 120) async -> Bool {
+    func monitorInstalledProviderIfPresent(
+        timeout: TimeInterval = MalibuOnboardingTimeouts.firstServingFrameSec
+    ) async -> Bool {
         guard let port = ProviderConfig.readHTTPPort(),
               ProviderConfig.readProviderID() != nil else {
             return false
         }
+        await releaseSpawnedChildForLaunchdMonitor()
         let deadline = Date().addingTimeInterval(max(1, timeout))
         guard await InstalledProviderMonitor.waitForHealthy(port: port, deadline: deadline) else {
             return false
@@ -199,6 +204,29 @@ final class MalibuAgent: ObservableObject {
         startHealthPolling(port: port)
         await refreshEarnings()
         return true
+    }
+
+    /// Stop a Malibu-spawned CLI child before attaching to launchd. Without
+    /// this, onboarding can leave two macprovider-cli processes (different
+    /// ports, same provider_id) running concurrently.
+    private func releaseSpawnedChildForLaunchdMonitor() async {
+        guard child != nil else { return }
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        child?.markStopping()
+        try? await control?.send(.shutdownRequest(graceSeconds: 5))
+        await child?.stop(gracePeriod: 5)
+        metricsPoller?.cancel()
+        metricsPoller = nil
+        eventStreamTask?.cancel()
+        eventStreamTask = nil
+        logTailCancellable?.cancel()
+        logTailCancellable = nil
+        logTailReader?.stop()
+        logTailReader = nil
+        await control?.close()
+        child = nil
+        control = nil
     }
 
     private func applyHealthSnapshot(port: Int) async {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -92,7 +92,7 @@ final class LaunchProviderController: ObservableObject {
         var readProviderID: () -> String?
         var runCLIInstall: (@escaping @MainActor (String) -> Void) async throws -> Void
         var importCLIConfigAfterInstall: () async throws -> Void
-        var monitorInstalledProvider: @MainActor () async -> Void
+        var monitorInstalledProvider: @MainActor () async -> Bool
         var readConfigModel: () -> String?
 
         static func live(registerClient: RegisterClient, bundledCLIPath: URL, agent: MalibuAgent?) -> Dependencies {
@@ -172,11 +172,10 @@ final class LaunchProviderController: ObservableObject {
                     try await ProviderConfig.importExistingCLIConfig()
                 },
                 monitorInstalledProvider: {
-                    if let agent {
-                        _ = await agent.monitorInstalledProviderIfPresent(
-                            timeout: MalibuOnboardingTimeouts.firstServingFrameSec
-                        )
-                    }
+                    guard let agent else { return false }
+                    return await agent.monitorInstalledProviderIfPresent(
+                        timeout: MalibuOnboardingTimeouts.firstServingFrameSec
+                    )
                 },
                 readConfigModel: { ProviderConfig.readModel() }
             )
@@ -327,7 +326,9 @@ final class LaunchProviderController: ObservableObject {
     private func startConfiguredViaCLIInstall() async {
         do {
             try await dependencies.registerLoginItem()
-            await dependencies.monitorInstalledProvider()
+            guard await dependencies.monitorInstalledProvider() else {
+                throw launchdMonitorUnavailableError()
+            }
             let model = dependencies.readConfigModel() ?? "configured"
             stage = .live(model: model, tier: .provisional)
         } catch {
@@ -377,12 +378,25 @@ final class LaunchProviderController: ObservableObject {
         do {
             try await dependencies.registerLoginItem()
             stage = .startingAgent
-            await dependencies.monitorInstalledProvider()
+            guard await dependencies.monitorInstalledProvider() else {
+                throw launchdMonitorUnavailableError()
+            }
             let model = dependencies.readConfigModel() ?? "installed"
             stage = .live(model: model, tier: .provisional)
         } catch {
             stage = .failed(stage: "cliInstall", retryable: true, message: error.localizedDescription)
         }
+    }
+
+    private func launchdMonitorUnavailableError() -> NSError {
+        NSError(
+            domain: "Malibu.LaunchProviderController",
+            code: 3,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Background provider did not become healthy in time. Check ~/Library/Logs/macprovider/ and try again."
+            ]
+        )
     }
 
     private func beginInstallProgressWatch() {

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -403,6 +403,7 @@ final class LaunchProviderControllerTests: XCTestCase {
                 },
                 monitorInstalledProvider: {
                     self.monitorRuns += 1
+                    return true
                 },
                 readConfigModel: { self.configModel }
             )


### PR DESCRIPTION
## Summary
- Use `MalibuOnboardingTimeouts.firstServingFrameSec` (600s) as the default health wait for launchd monitoring, matching onboarding's first-serving timeout.
- Release any Malibu-spawned CLI child before attaching to the launchd-managed provider, and try launchd monitoring before the spawned-child guard in `start()`.
- Propagate monitor success/failure through onboarding: `finalizeCLIInstallTrack()` and `startConfiguredViaCLIInstall()` now fail with a retryable error when the background provider never becomes healthy.

Fixes three Bugbot findings from PR #409 (duplicate CLI spawn, stale child race, false `.live` on monitor failure).

## Test plan
- [x] `xcodebuild -scheme Malibu build` succeeds
- [ ] Cold model load: onboarding waits up to 600s before failing (not 120s)
- [ ] Re-launch Malibu with existing launchd provider: no duplicate `macprovider-cli` processes
- [ ] Kill launchd provider during finalize: onboarding shows retryable failure instead of `.live`
