### PR TITLE
Malibu P2: signed .dmg release, stable provider_id, watchdog UX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -397,19 +397,36 @@ jobs:
 
           tag="${{ steps.version.outputs.tag }}"
           mkdir -p "phase3-binary/app/dist"
+          DIST_DMG="phase3-binary/app/dist/Malibu-${tag}.dmg"
 
-          # Wrap the signed+notarized+stapled Malibu.app in a user-installable
-          # .pkg (matches CLI pattern; delivers double-click install to
-          # /Applications instead of manual drag from a .zip). Requires the
-          # Developer ID Installer cert — if absent, fail loud rather than
-          # silently ship a .zip (mismatches the CLI convention and gives
-          # beta providers no double-click install path).
+          # SPEC-025 P2: primary consumer download is a stapled .dmg with an
+          # Applications symlink (Application cert only; no Installer cert).
+          DMG_STAGE="$RUNNER_TEMP/malibu-dmg-stage"
+          mkdir -p "$DMG_STAGE"
+          cp -R "$APP" "$DMG_STAGE/"
+          ln -sf /Applications "$DMG_STAGE/Applications"
+          hdiutil create \
+            -volname "Malibu" \
+            -srcfolder "$DMG_STAGE" \
+            -ov \
+            -format UDZO \
+            "$GITHUB_WORKSPACE/$DIST_DMG"
+          rm -rf "$DMG_STAGE"
+
+          codesign --sign "$SIGNING_ID" --timestamp "$GITHUB_WORKSPACE/$DIST_DMG"
+          xcrun notarytool submit "$GITHUB_WORKSPACE/$DIST_DMG" \
+            --apple-id "$APPLE_NOTARY_APPLE_ID" \
+            --password "$APPLE_NOTARY_PASSWORD" \
+            --team-id "$APPLE_NOTARY_TEAM_ID" \
+            --wait
+          xcrun stapler staple "$GITHUB_WORKSPACE/$DIST_DMG"
+          xcrun stapler validate "$GITHUB_WORKSPACE/$DIST_DMG"
+
+          # Optional .pkg for operators who prefer a double-click installer.
           if [ -z "$APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64" ]; then
-            echo "::error::APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64 required for Malibu.app.pkg;" >&2
-            echo "::error::the same secret is used for the CLI .pkg — populate it." >&2
-            exit 1
-          fi
-
+            echo "::warning::APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64 not set;"
+            echo "::warning::skipping Malibu.app.pkg (Malibu-${tag}.dmg is the primary artifact)."
+          else
           INSTALLER_ID=$(security find-identity -v build.keychain \
                         | awk -F'"' '/Developer ID Installer/ {print $2; exit}')
           [ -n "$INSTALLER_ID" ] || {
@@ -453,14 +470,20 @@ jobs:
           spctl -a -vvv -t install "$GITHUB_WORKSPACE/$DIST_PKG"
 
           rm -rf "$APP_PKG_ROOT" "$UNSIGNED_PKG"
+          fi
 
           echo "  Malibu.app signed by: $SIGNING_ID"
           echo "  Malibu.app notarization: accepted"
           echo "  Malibu.app stapling: validated"
-          echo "  Malibu.app.pkg signed by: $INSTALLER_ID"
-          echo "  Malibu.app.pkg notarization: accepted"
-          echo "  Malibu.app.pkg stapling: validated"
-          echo "  Malibu.app.pkg: $DIST_PKG"
+          echo "  Malibu-${tag}.dmg notarization: accepted"
+          echo "  Malibu-${tag}.dmg stapling: validated"
+          echo "  Malibu-${tag}.dmg: $DIST_DMG"
+          if [ -f "$GITHUB_WORKSPACE/phase3-binary/app/dist/Malibu-${tag}.pkg" ]; then
+            echo "  Malibu.app.pkg signed by: $INSTALLER_ID"
+            echo "  Malibu.app.pkg notarization: accepted"
+            echo "  Malibu.app.pkg stapling: validated"
+            echo "  Malibu.app.pkg: phase3-binary/app/dist/Malibu-${tag}.pkg"
+          fi
 
       - name: Clean signing material
         if: always()
@@ -595,9 +618,11 @@ jobs:
           src="phase3-binary/dist/phase3-binary-m4-${tag}.tar.gz"
           pkg_src="phase3-binary/dist/phase3-binary-m4-${tag}.pkg"
           app_src="phase3-binary/app/dist/Malibu-${tag}.pkg"
+          app_dmg_src="phase3-binary/app/dist/Malibu-${tag}.dmg"
           tar_asset="macprovider-cli-${tag}-darwin-arm64.tar.gz"
           pkg_asset="macprovider-cli-${tag}-darwin-arm64.pkg"
           app_asset="Malibu-${tag}.pkg"
+          app_dmg_asset="Malibu-${tag}.dmg"
           test -f "$src"
           if [ -z "$MACPROVIDER_RELEASE_SIGNING_KEY_PEM" ]; then
             echo "MACPROVIDER_RELEASE_SIGNING_KEY_PEM secret is required" >&2
@@ -613,6 +638,10 @@ jobs:
           if [ -f "$pkg_src" ]; then
             cp "$pkg_src" "$pkg_asset"
             release_assets+=("$pkg_asset")
+          fi
+          if [ -f "$app_dmg_src" ]; then
+            cp "$app_dmg_src" "$app_dmg_asset"
+            release_assets+=("$app_dmg_asset")
           fi
           if [ -f "$app_src" ]; then
             cp "$app_src" "$app_asset"
@@ -646,7 +675,15 @@ jobs:
           a stapled .pkg asset in addition to the compatibility tarball.
           EOF
           fi
-          if [ -f "phase3-binary/app/dist/Malibu-${tag}.pkg" ]; then
+          if [ -f "phase3-binary/app/dist/Malibu-${tag}.dmg" ]; then
+            cat >> release-notes.md <<EOF
+
+          **Malibu.app (App-track provider onboarding)** — this release ships a
+          Developer ID-signed, notarized, and stapled \`Malibu-${tag}.dmg\`.
+          Open the disk image, drag Malibu.app to Applications, and launch.
+          First run drives install.sh onboarding with no terminal setup.
+          EOF
+          elif [ -f "phase3-binary/app/dist/Malibu-${tag}.pkg" ]; then
             cat >> release-notes.md <<EOF
 
           **Malibu.app (App-track provider onboarding)** - this release also

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ test-dist:
 	bash phase4-coordinator/dist/test/check_pearl_tcp_test.sh
 	SPEC015_NGINX_LIVE_OPTIONAL=$${SPEC015_NGINX_LIVE_OPTIONAL:-1} bash phase4-coordinator/dist/test/check_nginx_receipt_header_live_test.sh
 	bash scripts/test-install-config-token-preserve.sh
+	bash scripts/test-install-provider-id-preserve.sh
 	bash scripts/test-install-launchd-enable.sh
 	bash scripts/test-watchdog-inline-drift.sh
 

--- a/ops/macprovider-watchdog/README.md
+++ b/ops/macprovider-watchdog/README.md
@@ -23,7 +23,7 @@ operator without any hardcoded provider id.
 
 | File | Purpose |
 |---|---|
-| `watchdog.sh` | The poll script. Idempotent; safe to invoke repeatedly. |
+| `watchdog.sh` | The poll script source (installed as `macprovider-health-monitor`). Idempotent; safe to invoke repeatedly. |
 | `live.streamvc.macprovider-watchdog.template.plist` | LaunchAgent template; substituted by `install.sh`. |
 | `install.sh` | Idempotent installer. Invoked by both the main `get.streamvc.live/install.sh` flow and by an operator running this directory by hand. |
 | `uninstall.sh` | Removes the LaunchAgent and the `~/.local/share/macprovider-watchdog` directory. |

--- a/ops/macprovider-watchdog/install.sh
+++ b/ops/macprovider-watchdog/install.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 WATCHDOG_DIR_DEFAULT="$HOME/.local/share/macprovider-watchdog"
 WATCHDOG_DIR="${MACPROVIDER_WATCHDOG_DIR:-$WATCHDOG_DIR_DEFAULT}"
-WATCHDOG_PATH="$WATCHDOG_DIR/watchdog.sh"
+WATCHDOG_PATH="$WATCHDOG_DIR/macprovider-health-monitor"
 PLIST_TEMPLATE_PATH="${MACPROVIDER_WATCHDOG_TEMPLATE:-$(cd "$(dirname "$0")" && pwd)/live.streamvc.macprovider-watchdog.template.plist}"
 SOURCE_WATCHDOG="$(cd "$(dirname "$0")" && pwd)/watchdog.sh"
 PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
@@ -65,6 +65,10 @@ log "Installing watchdog to $WATCHDOG_DIR"
 run mkdir -p "$WATCHDOG_DIR" "$LOG_DIR" "$(dirname "$PLIST_PATH")"
 
 if [ "$DRY_RUN" -eq 0 ]; then
+  legacy_watchdog="$WATCHDOG_DIR/watchdog.sh"
+  if [ -f "$legacy_watchdog" ] && [ "$legacy_watchdog" != "$WATCHDOG_PATH" ]; then
+    rm -f "$legacy_watchdog"
+  fi
   install -m 0755 "$SOURCE_WATCHDOG" "$WATCHDOG_PATH"
 else
   log "[dry-run] install -m 0755 $SOURCE_WATCHDOG $WATCHDOG_PATH"

--- a/phase3-binary/app/README.md
+++ b/phase3-binary/app/README.md
@@ -71,4 +71,4 @@ open build/Release/Malibu.app
 2. **CLI-side handler semantics.** Frames + wire format are wired end-to-end (`feat(control-socket): add metrics/pause/resume/shutdown frames`), but the server-side handlers are stubs — `pause_ack`/`resume_ack` return `accepted:false, reason:"not_implemented"` and `metrics_response` returns zeros. Real earnings / uptime source + pause gating land in P1.
 3. **CLI-track config migration dialog.** If `~/.config/macprovider/config.yaml` exists without the App-track marker, the App routes to the SPEC-026 migration surface instead of overwriting it silently.
 5. **Sparkle** not wired up yet — separate P3 pass.
-6. **Signed release pipeline** — extends `.github/workflows/release.yml` per SPEC-025 §6.2. Not part of this skeleton.
+6. **Signed release pipeline** — `release.yml` ships stapled `Malibu-{tag}.dmg` (primary) and optional `Malibu-{tag}.pkg`. Validate downloads with `scripts/verify-malibu-release-artifacts.sh`.

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -31,7 +31,9 @@ LOG_DIR="$HOME/Library/Logs/macprovider"
 # the scripts here so the public installer remains a single curl-able
 # artifact.
 WATCHDOG_DIR="$HOME/.local/share/macprovider-watchdog"
-WATCHDOG_PATH="$WATCHDOG_DIR/watchdog.sh"
+# Installed without a .sh suffix so macOS Login Items shows a readable
+# background-item name instead of "watchdog.sh".
+WATCHDOG_PATH="$WATCHDOG_DIR/macprovider-health-monitor"
 WATCHDOG_PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
 WATCHDOG_LABEL="live.streamvc.macprovider-watchdog"
 NO_WATCHDOG="${MACPROVIDER_NO_WATCHDOG:-0}"
@@ -810,6 +812,12 @@ choose_provider_id() {
     fi
   fi
 
+  existing="$(read_config_provider_id || true)"
+  if [ -n "$existing" ]; then
+    printf "%s" "$existing"
+    return
+  fi
+
   default_handle="$(sanitize_handle "$(hostname -s 2>/dev/null || hostname)")"
   [ -n "$default_handle" ] || default_handle="macprovider"
   if [ "$NO_PROMPT" = "1" ]; then
@@ -1197,6 +1205,19 @@ read_config_model() {
     /^model:/ {
       value=$0
       sub(/^model:[[:space:]]*/, "", value)
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "$CONFIG_PATH"
+}
+
+read_config_provider_id() {
+  [ -f "$CONFIG_PATH" ] || return 1
+  awk -F: '
+    /^provider_id:/ {
+      value=$0
+      sub(/^provider_id:[[:space:]]*/, "", value)
       gsub(/^"|"$/, "", value)
       print value
       exit
@@ -2233,6 +2254,10 @@ install_watchdog() {
   fi
   log "Installing watchdog LaunchAgent (operator-visibility safety net for iss-189-class wedges)."
   mkdir -p "$WATCHDOG_DIR" "$LOG_DIR" "$(dirname "$WATCHDOG_PLIST_PATH")"
+  legacy_watchdog="$WATCHDOG_DIR/watchdog.sh"
+  if [ -f "$legacy_watchdog" ] && [ "$legacy_watchdog" != "$WATCHDOG_PATH" ]; then
+    rm -f "$legacy_watchdog"
+  fi
   write_watchdog_script
   render_watchdog_plist "$coordinator_url" > "$WATCHDOG_PLIST_PATH"
   plutil -lint "$WATCHDOG_PLIST_PATH" >/dev/null \

--- a/phase3-binary/dist/release-signing-runbook.md
+++ b/phase3-binary/dist/release-signing-runbook.md
@@ -180,6 +180,26 @@ Common follow-up issues:
 - ~5 minutes added to each release build (notarization wait)
 - No per-release fee
 
+## Malibu.app release artifacts (SPEC-025 P2)
+
+When `APPLE_DEVELOPER_ID_CERT_P12_BASE64` is populated, the same release
+tag also publishes:
+
+- **`Malibu-{tag}.dmg`** — primary consumer download. Drag `Malibu.app`
+  to `/Applications`. Notarized and stapled; validate with:
+  `bash scripts/verify-malibu-release-artifacts.sh Malibu-{tag}.dmg`
+- **`Malibu-{tag}.pkg`** — optional double-click installer when
+  `APPLE_DEVELOPER_ID_INSTALLER_CERT_P12_BASE64` is also present.
+
+Fresh-mac acceptance check after each tagged release:
+
+```bash
+bash scripts/verify-malibu-release-artifacts.sh Malibu-vX.Y.Z.dmg
+```
+
+Expect `codesign --verify`, `stapler validate`, and `spctl` to pass
+without `xattr -d`.
+
 ## Related
 
 - Memory: `macprovider-launchd-amfi-blocker-macos-26` — full

--- a/scripts/test-install-provider-id-preserve.sh
+++ b/scripts/test-install-provider-id-preserve.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Hermetic guard for install.sh preserving provider_id across reinstall.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+
+die() {
+  printf '[install-provider-id-test] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+[ -f "$INSTALL_SH" ] || die "missing installer: $INSTALL_SH"
+
+lib="$(mktemp "${TMPDIR:-/tmp}/macprovider-install-provider-id-lib.XXXXXX")"
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/macprovider-install-provider-id.XXXXXX")"
+trap 'rm -f "$lib"; rm -rf "$workdir"' EXIT
+
+{
+  awk '/^sanitize_handle\(\)/, /^}/' "$INSTALL_SH"
+  awk '/^read_config_provider_id\(\)/, /^}/' "$INSTALL_SH"
+  awk '/^choose_provider_id\(\)/, /^}/' "$INSTALL_SH"
+} > "$lib"
+
+# shellcheck source=/dev/null
+. "$lib"
+
+CONFIG_DIR="$workdir/config"
+CONFIG_PATH="$CONFIG_DIR/config.yaml"
+PROVIDER_ID_PATH="$CONFIG_DIR/provider_id"
+NO_PROMPT=1
+
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_PATH" <<'EOF_CONFIG'
+model: "old/model"
+coordinator_url: "wss://old.example/ws/provider"
+provider_id: "p_upiv4dug6kmmcpavsyqjmt35andgfpbf4ztrrnhlqdjqirhprcxq"
+port: 18080
+EOF_CONFIG
+
+chosen="$(choose_provider_id)"
+[ "$chosen" = "p_upiv4dug6kmmcpavsyqjmt35andgfpbf4ztrrnhlqdjqirhprcxq" ] \
+  || die "expected config.yaml provider_id, got: $chosen"
+
+rm -f "$PROVIDER_ID_PATH"
+printf "mac\n" > "$PROVIDER_ID_PATH"
+chosen="$(choose_provider_id)"
+[ "$chosen" = "mac" ] || die "expected provider_id file to win, got: $chosen"
+
+rm -f "$PROVIDER_ID_PATH"
+chosen="$(choose_provider_id)"
+[ "$chosen" = "p_upiv4dug6kmmcpavsyqjmt35andgfpbf4ztrrnhlqdjqirhprcxq" ] \
+  || die "expected config.yaml fallback after empty provider_id file, got: $chosen"
+
+printf '[install-provider-id-test] installer preserves provider_id across reinstall ok\n'

--- a/scripts/verify-malibu-release-artifacts.sh
+++ b/scripts/verify-malibu-release-artifacts.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Post-release Gatekeeper checks for signed Malibu artifacts (SPEC-025 P2).
+#
+# Usage:
+#   bash scripts/verify-malibu-release-artifacts.sh Malibu-v1.8.11.dmg
+#   bash scripts/verify-malibu-release-artifacts.sh /Applications/Malibu.app
+#
+# Validates codesign, stapler, and spctl on a locally downloaded release asset.
+
+set -euo pipefail
+
+die() {
+  printf '[verify-malibu-release] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+[ $# -eq 1 ] || die "usage: $0 <Malibu.app path or Malibu-*.dmg>"
+
+target="$1"
+[ -e "$target" ] || die "missing: $target"
+
+case "$target" in
+  *.dmg)
+    mount_dir="$(mktemp -d "${TMPDIR:-/tmp}/malibu-dmg.XXXXXX")"
+    cleanup() {
+      hdiutil detach "$mount_dir" -quiet >/dev/null 2>&1 || true
+      rm -rf "$mount_dir"
+    }
+    trap cleanup EXIT
+    hdiutil attach -nobrowse -mountpoint "$mount_dir" "$target" >/dev/null
+    app_path="$mount_dir/Malibu.app"
+    [ -d "$app_path" ] || die "Malibu.app not found inside $target"
+    codesign --verify --strict --deep --verbose=2 "$app_path"
+    xcrun stapler validate "$target"
+    spctl -a -vvv -t open "$target" || spctl -a -vvv -t exec "$app_path"
+    ;;
+  *.app)
+    codesign --verify --strict --deep --verbose=2 "$target"
+    xcrun stapler validate "$target"
+    spctl -a -vvv -t exec "$target"
+    ;;
+  *)
+    die "expected .app bundle or .dmg, got: $target"
+    ;;
+esac
+
+printf '[verify-malibu-release] ok: %s\n' "$target"


### PR DESCRIPTION
## Summary
- **PR #415 merged** — launchd monitor races fixed on `main` (`fed1318`).
- **P2 release pipeline** — `release.yml` now ships stapled `Malibu-{tag}.dmg` as the primary consumer artifact (Application cert only); `.pkg` remains optional when the Installer cert is present.
- **Reinstall stability** — `install.sh` preserves `provider_id` from existing `config.yaml` when the sidecar file is missing.
- **Watchdog UX** — background helper installs as `macprovider-health-monitor` (not `watchdog.sh`) for readable Login Items; legacy path removed on upgrade.
- **Verification** — `scripts/verify-malibu-release-artifacts.sh` + runbook section for fresh-mac Gatekeeper checks.

## Test plan
- [x] `bash scripts/test-install-provider-id-preserve.sh`
- [x] `bash scripts/test-watchdog-inline-drift.sh`
- [x] Malibu `xcodebuild build` succeeds
- [ ] Tag a release with signing secrets → confirm `Malibu-{tag}.dmg` attaches to GitHub Release
- [ ] `bash scripts/verify-malibu-release-artifacts.sh Malibu-{tag}.dmg` on a clean Mac
