### PR TITLE
Malibu: CLI-wrapper-only refactor (remove V2 spawn path)

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -53,105 +53,45 @@ final class MalibuAgent: ObservableObject {
     // MARK: - Lifecycle
 
     func start() async {
-        // AUDIT R2 CODE H3 fix.
         guard !isShuttingDown else { return }
 
-        // Option A: when install.sh owns the provider via launchd, monitor it
-        // instead of spawning a second macprovider-cli child. Run this before
-        // the spawned-child guard so a stale Malibu-owned CLI is released first.
+        // Release any Malibu-spawned CLI from older builds before attaching to launchd.
+        await releaseSpawnedChildForLaunchdMonitor()
+
+        snapshot.state = .starting
         if await monitorInstalledProviderIfPresent() {
             return
         }
 
-        guard child == nil else { return }
-
-        // AUDIT R2 CODE H4 fix: refuse to spawn the CLI without a validated
-        // app-owned config + keychain token. Onboarding must complete the
-        // deep-link callback first.
-        guard await ProviderConfig.isConfigured else {
+        guard ProviderConfig.readProviderID() != nil else {
             snapshot.state = .error
             snapshot.lastError = "Not set up yet. Click Launch Provider to activate."
             return
         }
-        // Re-check after the await, since we suspended.
         guard !isShuttingDown else { return }
 
-        snapshot.state = .starting
-
-        let paths = ProviderPaths.current
-        let cliURL: URL
-        do { cliURL = try Self.resolveCLIExecutable() } catch {
-            snapshot.state = .error; snapshot.lastError = "CLI binary not found"; return
-        }
-
-        var extraEnv: [String: String] = [:]
-        if let providerID = ProviderConfig.readProviderID(),
-           let token = await KeychainStore.readProviderToken(providerID: providerID) {
-            extraEnv["MACPROVIDER_PROVIDER_TOKEN"] = token
-        }
-        guard !isShuttingDown else { return }
-
-        // FreePortProbe: ask the kernel for a free 127.0.0.1 TCP port so the
-        // CLI's local HTTP inference endpoint doesn't collide with whatever
-        // else may be on port 8080 (Node dev server, Rails, jaeger). Falling
-        // back to nil lets the CLI use its default 8080; the CLI's own bind
-        // error surfaces the failure with the same context as before, so
-        // this cannot regress.
-        let probedPort = try? FreePortProbe.probe()
-
-        let launch = CLIChildProcess.Launch(
-            executable: cliURL,
-            configPath: paths.configFile,
-            controlSocketPath: paths.controlSocket,
-            httpPort: probedPort,
-            logFileURL: paths.cliLogFile,
-            extraEnvironment: extraEnv
-        )
-        let child = CLIChildProcess(launch: launch)
-        let startInstant = Date()
-        child.onUnexpectedExit = { [weak self] code in
-            Task { @MainActor in
-                guard let self else { return }
-                // AUDIT R1 CODE H1: nil the wrapper BEFORE scheduling reconnect
-                // so start()'s `guard child == nil` doesn't short-circuit.
-                self.child = nil
-                // AUDIT R1 ARCHITECT A7: fast-fail on flag/compat rejection.
-                let elapsed = Date().timeIntervalSince(startInstant)
-                if elapsed < 3 && code != 0 {
-                    self.snapshot.state = .error
-                    self.snapshot.lastError = "The bundled macprovider-cli is incompatible with this Malibu.app version (exit \(code) in \(String(format: "%.1f", elapsed))s). Please reinstall Malibu.app or file a bug."
-                    return
-                }
-                // AUDIT R2 CODE H3: do not schedule a reconnect during shutdown.
-                guard !self.isShuttingDown else { return }
-                self.snapshot.state = .reconnecting
-                self.snapshot.lastError = "CLI exited (\(code))"
-                await self.scheduleReconnect()
-            }
-        }
-        self.child = child
-
-        do {
-            try child.start()
-            startLogTail(fileURL: paths.cliLogFile)
-        } catch {
-            snapshot.state = .error; snapshot.lastError = "Failed to launch: \(error)"
-            self.child = nil
-            return
-        }
-
-        await connectControl(socketPath: paths.controlSocket.path)
+        snapshot.state = .reconnecting
+        snapshot.lastError = "Background provider is not responding. Open onboarding to reinstall or check ~/Library/Logs/macprovider/."
+        await scheduleReconnect()
     }
 
     // AUDIT R1 ARCHITECT A1: don't flip state until the CLI acks. If the CLI
     // returns accepted:false (current stub does), leave state where it was
     // and surface the reason in snapshot.lastError.
     func pause() async {
+        if monitorsLaunchdProvider {
+            snapshot.lastError = "Pause is not available while Malibu monitors the background provider."
+            return
+        }
         snapshot.pauseAcknowledged = false
         try? await control?.send(.pauseRequest)
     }
 
     func resume() async {
+        if monitorsLaunchdProvider {
+            snapshot.lastError = "Resume is not available while Malibu monitors the background provider."
+            return
+        }
         try? await control?.send(.resumeRequest)
     }
 

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -68,6 +68,16 @@ final class MalibuAgent: ObservableObject {
             snapshot.lastError = "Not set up yet. Click Launch Provider to activate."
             return
         }
+        guard StartupState.launchdInstallEvidenceExists() else {
+            snapshot.state = .error
+            snapshot.lastError = "Not set up yet. Click Launch Provider to run the installer."
+            return
+        }
+        guard await ProviderConfig.isConfigured || ProviderConfig.readHTTPPort() != nil else {
+            snapshot.state = .error
+            snapshot.lastError = "Not set up yet. Click Launch Provider to activate."
+            return
+        }
         guard !isShuttingDown else { return }
 
         snapshot.state = .reconnecting

--- a/phase3-binary/app/Sources/Malibu/MalibuApp.swift
+++ b/phase3-binary/app/Sources/Malibu/MalibuApp.swift
@@ -118,10 +118,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         switch route {
         case .startAgent:
             await agent.start()
-        case .showOnboarding, .resumeOnboarding:
+        case .showOnboarding:
             presentOnboarding()
-        case .setupPaused:
-            presentSetupPaused()
         case .quit:
             NSApp.terminate(nil)
         case .showImportDialog:
@@ -153,14 +151,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .alertSecondButtonReturn: return .startFresh
         default: return .cancel
         }
-    }
-
-    private func presentSetupPaused() {
-        let alert = NSAlert()
-        alert.messageText = "Setup paused"
-        alert.informativeText = "App-track onboarding is disabled for this build. Existing configured providers still start normally."
-        alert.alertStyle = .informational
-        alert.runModal()
     }
 
     private func presentStartFreshBackup(path: String) {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/AutotuneRecommendationRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/AutotuneRecommendationRunner.swift
@@ -215,8 +215,15 @@ enum AutotuneRecommendationError: Error {
     case timedOut
 }
 
+struct ModelDownloadPlan: Equatable {
+    let modelName: String
+    let earningsEstimate: EarningsEstimateRange?
+
+    static let recommended = ModelDownloadPlan(modelName: "recommended", earningsEstimate: nil)
+}
+
 struct AutotuneRecommendationResult: Equatable {
-    let plan: LaunchProviderController.ModelDownloadPlan
+    let plan: ModelDownloadPlan
     let serveConfig: ProviderConfig.AutotuneServeConfig
 
     static func fromAutotuneJSON(_ data: Data) throws -> Self {
@@ -225,7 +232,7 @@ struct AutotuneRecommendationResult: Equatable {
             throw AutotuneRecommendationError.invalidJSON
         }
         return AutotuneRecommendationResult(
-            plan: try LaunchProviderController.ModelDownloadPlan.fromAutotuneRoot(root),
+            plan: try ModelDownloadPlan.fromAutotuneRoot(root),
             serveConfig: try AutotuneServeConfigEnvelope.decode(from: data)
         )
     }
@@ -312,7 +319,7 @@ private struct AutotuneServeConfigPayload: Decodable {
     }
 }
 
-extension LaunchProviderController.ModelDownloadPlan {
+extension ModelDownloadPlan {
     static func fromAutotuneJSON(_ data: Data) throws -> Self {
         let rootObject = try JSONSerialization.jsonObject(with: data)
         guard let root = rootObject as? [String: Any] else {
@@ -324,7 +331,7 @@ extension LaunchProviderController.ModelDownloadPlan {
     static func fromAutotuneRoot(_ root: [String: Any]) throws -> Self {
         let modelName = recommendedModel(in: root) ?? Self.recommended.modelName
         let range = earningsEstimate(modelName: modelName, root: root)
-        return Self(modelName: modelName, state: nil, earningsEstimate: range)
+        return Self(modelName: modelName, earningsEstimate: range)
     }
 
     private static func recommendedModel(in root: [String: Any]) -> String? {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -1,13 +1,8 @@
 import Foundation
-import CryptoKit
 
-// SPEC-026 v0.11 §7.2 LaunchProviderController.
-//
-// Owns the click-and-earn state machine: identityReady → registering →
-// autotuning → downloadingModel → startingAgent → live. Sit behind the
-// MALIBU_ONBOARD_V2 flag (§8). See SPEC-026 §6.1 for the user-flow
-// walkthrough that the state machine implements.
-//
+// Malibu is a CLI wrapper: onboarding runs install.sh, then Malibu monitors
+// the launchd-managed macprovider-cli. No in-app register/autotune/spawn path.
+
 @MainActor
 final class LaunchProviderController: ObservableObject {
 
@@ -19,152 +14,31 @@ final class LaunchProviderController: ObservableObject {
     enum Stage: Equatable {
         case idle
         case runningCLIInstall
-        case identityReady
-        case registering
-        case autotuning
-        case downloadingCLI(progressPct: Double)     // no-op in v1: SPEC-025 bundles the CLI
-        case downloadingModel(name: String, progressPct: Double)
         case startingAgent
-        case authenticating
         case live(model: String, tier: TrustTier)
         case failed(stage: String, retryable: Bool, message: String)
     }
 
-    // MARK: - Published state (drives the SwiftUI onboarding view)
-
     @Published private(set) var stage: Stage = .idle
-    @Published private(set) var currentEarningsEstimate: EarningsEstimateRange?
     @Published private(set) var installLogLines: [String] = []
     @Published private(set) var installProgressHint: String?
     @Published private(set) var installStartedAt: Date?
 
     private var installProgressTask: Task<Void, Never>?
-
-    /// When true (default), fresh onboarding runs `install.sh` instead of the
-    /// in-app SPEC-026 register/autotune path. Tests set this to false.
-    static var prefersCLIInstallTrack: Bool {
-        get { MalibuOnboardingPolicy.prefersCLIInstallTrack }
-        set { MalibuOnboardingPolicy.prefersCLIInstallTrack = newValue }
-    }
-
-    // MARK: - Config
-
-    /// Coordinator base URL. Comes from build config — production is
-    /// `https://coordinator.streamvc.live` per SPEC-026 canonical domain.
-    let coordinatorBaseURL: URL
-
-    /// Path to `macprovider-cli` inside the App bundle (SPEC-025 bundles
-    /// it, so this is not a fresh download in v1 — see SPEC-026 §6.1
-    /// step 7e).
-    let bundledCLIPath: URL
-    private let registerClient: RegisterClient
     private let dependencies: Dependencies
 
-    struct ModelDownloadPlan: Equatable {
-        let modelName: String
-        let state: OnboardingState.ModelDownloadState?
-        let earningsEstimate: EarningsEstimateRange?
-
-        static let recommended = ModelDownloadPlan(modelName: "recommended", state: nil, earningsEstimate: nil)
-    }
-
     struct Dependencies {
-        var isConfigured: () async -> Bool
-        var loadState: () throws -> OnboardingState?
-        var loadOrGenerateIdentity: () async throws -> Curve25519.Signing.PrivateKey
-        var loadExistingIdentity: () async throws -> Curve25519.Signing.PrivateKey
-        var providerID: (Curve25519.Signing.PrivateKey) -> String
-        var currentProviderToken: (String) async -> String?
-        var registerProvider: (Curve25519.Signing.PrivateKey, String?) async throws -> RegisterResponse
-        var saveProviderIdentity: (String, String, URL) async throws -> Void
-        var repairMarkerlessAppConfig: (String) async throws -> Void
-        var saveState: (OnboardingState) throws -> Void
-        var updateState: (String, String, Date?, OnboardingState.ModelDownloadState?) throws -> Void
-        var markLinkState: (ProviderConfig.LinkState) throws -> Void
-        var runAutotune: (String) async throws -> AutotuneRecommendationResult
-        var persistAutotuneRecommendation: (ProviderConfig.AutotuneServeConfig) throws -> Void
-        var validateServeConfigShape: () throws -> Void
-        var ensureCLIReady: () throws -> Void
-        var downloadModel: (ModelDownloadPlan) async throws -> OnboardingState.ModelDownloadState?
+        var localInstallSucceeded: @MainActor () async -> Bool
         var registerLoginItem: @MainActor () async throws -> Void
-        var startAgent: @MainActor () async -> Void
-        var waitForFirstServing: @MainActor () async throws -> Date
-        var readProviderID: () -> String?
-        var runCLIInstall: (@escaping @MainActor (String) -> Void) async throws -> Void
-        var importCLIConfigAfterInstall: () async throws -> Void
+        var runCLIInstall: @MainActor (@escaping @MainActor (String) -> Void) async throws -> Void
+        var importCLIConfigAfterInstall: @MainActor () async throws -> Void
         var monitorInstalledProvider: @MainActor () async -> Bool
         var readConfigModel: () -> String?
 
-        static func live(registerClient: RegisterClient, bundledCLIPath: URL, agent: MalibuAgent?) -> Dependencies {
+        static func live(agent: MalibuAgent?) -> Dependencies {
             Dependencies(
-                isConfigured: { await ProviderConfig.isConfigured },
-                loadState: { try OnboardingStateStore.load() },
-                loadOrGenerateIdentity: { try await ProviderIdentity.loadOrGenerate() },
-                loadExistingIdentity: { try await ProviderIdentity.loadExisting() },
-                providerID: { ProviderIdentity.providerID(for: $0) },
-                currentProviderToken: { providerID in await KeychainStore.readProviderToken(providerID: providerID) },
-                registerProvider: { key, bearerProof in
-                    let request = try registerClient.makeSignedRequest(identityKey: key)
-                    return try await registerClient.postRegister(request, bearerProof: bearerProof)
-                },
-                saveProviderIdentity: { providerID, token, coordinatorWSURL in
-                    try await ProviderConfig.saveProviderIdentity(providerID: providerID, token: token, coordinatorWSURL: coordinatorWSURL)
-                },
-                repairMarkerlessAppConfig: { providerID in
-                    try await ProviderConfig.repairMarkerlessAppOwnedConfig(providerID: providerID)
-                },
-                saveState: { try OnboardingStateStore.save($0) },
-                updateState: { providerID, lastStage, firstServingAt, modelDownload in
-                    try OnboardingStateStore.update(
-                        providerID: providerID,
-                        lastStage: lastStage,
-                        firstServingAt: firstServingAt,
-                        modelDownload: modelDownload
-                    )
-                },
-                markLinkState: { state in try ProviderConfig.writeLinkState(state) },
-                runAutotune: { _ in
-                    try await AutotuneRecommendationRunner.run(cliURL: bundledCLIPath)
-                },
-                persistAutotuneRecommendation: { config in
-                    try ProviderConfig.persistAutotuneRecommendation(config)
-                },
-                validateServeConfigShape: {
-                    try ProviderConfig.validateServeConfigShape()
-                },
-                ensureCLIReady: {
-                    guard FileManager.default.isExecutableFile(atPath: bundledCLIPath.path) else {
-                        throw POSIXError(.ENOENT)
-                    }
-                },
-                downloadModel: { plan in plan.state },
+                localInstallSucceeded: { await CLIInstallRunner.localInstallSucceeded() },
                 registerLoginItem: { try AppLoginItem.register() },
-                startAgent: { await agent?.start() },
-                waitForFirstServing: {
-                    guard let agent else { return Date() }
-                    let deadline = Date().addingTimeInterval(MalibuOnboardingTimeouts.firstServingFrameSec)
-                    let pollNanos = UInt64(MalibuOnboardingTimeouts.firstServingPollIntervalSec * 1_000_000_000)
-                    while Date() < deadline {
-                        switch agent.snapshot.state {
-                        case .serving:
-                            return Date()
-                        case .error:
-                            throw NSError(
-                                domain: "Malibu.LaunchProviderController",
-                                code: 1,
-                                userInfo: [NSLocalizedDescriptionKey: agent.snapshot.lastError ?? "Provider failed to start."]
-                            )
-                        default:
-                            try await Task.sleep(nanoseconds: pollNanos)
-                        }
-                    }
-                    throw NSError(
-                        domain: "Malibu.LaunchProviderController",
-                        code: 2,
-                        userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for the first serving frame."]
-                    )
-                },
-                readProviderID: { ProviderConfig.readProviderID() },
                 runCLIInstall: { onLogLine in
                     try await CLIInstallRunner.run(onLogLine: onLogLine)
                 },
@@ -182,171 +56,48 @@ final class LaunchProviderController: ObservableObject {
         }
     }
 
-    /// Feature-flag guard from §8: env var MALIBU_ONBOARD_V2 wins over
-    /// UserDefaults `onboardingFlow == "v2"`.
-    static var isOnboardingV2Enabled: Bool {
-        isOnboardingV2Enabled(
-            environment: ProcessInfo.processInfo.environment,
-            userDefaults: .standard
-        )
+    init(agent: MalibuAgent? = nil, dependencies: Dependencies? = nil) {
+        self.dependencies = dependencies ?? .live(agent: agent)
     }
 
-    static func isOnboardingV2Enabled(
-        environment: [String: String],
-        userDefaults: UserDefaults
-    ) -> Bool {
-        if let value = environment["MALIBU_ONBOARD_V2"]?.lowercased() {
-            if ["1", "true", "yes", "on", "v2"].contains(value) { return true }
-            if ["0", "false", "no", "off", "v1"].contains(value) { return false }
-        }
-        return userDefaults.string(forKey: "onboardingFlow") == "v2"
-    }
-
-    // MARK: - Init
-
-    init(
-        coordinatorBaseURL: URL,
-        bundledCLIPath: URL,
-        agent: MalibuAgent? = nil,
-        dependencies: Dependencies? = nil
-    ) {
-        self.coordinatorBaseURL = coordinatorBaseURL
-        self.bundledCLIPath = bundledCLIPath
-        let registerClient = RegisterClient(coordinatorBaseURL: coordinatorBaseURL)
-        self.registerClient = registerClient
-        self.dependencies = dependencies ?? .live(
-            registerClient: registerClient,
-            bundledCLIPath: bundledCLIPath,
-            agent: agent
-        )
-    }
-
-    // MARK: - Public API
-
-    /// Fire the state machine. Safe to re-invoke; each call resumes from
-    /// the persisted `onboardingSchemaVersion == 2` state if present, else
-    /// starts from `.idle`.
-    ///
-    /// State transitions per SPEC-026 §6.1 step 7 sub-steps a-j:
-    ///   a. Generate Ed25519 identity keypair → Keychain
-    ///   b. POST /v1/providers/register → receive provider_token
-    ///   c. Run macprovider-cli autotune --recommend --json locally
-    ///   d. Persist provider_id + provider_token + onboardingSchemaVersion=2
-    ///   e. Download macprovider-cli if not bundled (no-op in v1)
-    ///   f. Download model weights per autotune output (resumable)
-    ///   g. Register SMAppService login item
-    ///   h. Start MalibuAgent (existing code) which spawns CLI child
-    ///   i. Wait for first .serving control-socket frame
-    ///   j. Show success card (owned by the SwiftUI view; controller
-    ///      transitions to .live)
     func launch() async {
-        if Self.prefersCLIInstallTrack, await CLIInstallRunner.localInstallSucceeded() {
-            await launchViaCLIInstall()
+        if await dependencies.localInstallSucceeded() {
+            installLogLines = ["Background provider is already running locally. Connecting Malibu to it."]
+            await finalizeInstall()
             return
         }
-
-        let existingState = try? dependencies.loadState()
-        if await dependencies.isConfigured() {
-            if Self.prefersCLIInstallTrack {
-                await startConfiguredViaCLIInstall()
-                return
-            }
-            if let existing = existingState,
-               existing.onboardingSchemaVersion == 2,
-               existing.firstServingAt == nil {
-                await resumePartialOnboarding(existing)
-            } else {
-                await startConfiguredAgent(model: "configured")
-            }
-            return
-        }
-
-        if Self.prefersCLIInstallTrack {
-            await launchViaCLIInstall()
-            return
-        }
-
-        if let existing = existingState,
-           existing.onboardingSchemaVersion == 2,
-           existing.firstServingAt == nil {
-            await resumePartialOnboarding(existing)
-            return
-        }
-
-        guard Self.isOnboardingV2Enabled else {
-            stage = .failed(
-                stage: "featureFlag",
-                retryable: false,
-                message: "App-track onboarding is not enabled in this build."
-            )
-            return
-        }
-
-        do {
-            let key = try await dependencies.loadOrGenerateIdentity()
-            let providerID = dependencies.providerID(key)
-            stage = .identityReady
-            try dependencies.saveState(OnboardingState(
-                onboardingSchemaVersion: 2,
-                providerID: providerID,
-                createdAt: Date(),
-                lastStage: "identityReady",
-                firstServingAt: nil,
-                modelDownload: nil
-            ))
-
-            stage = .registering
-            let bearerProof = await dependencies.currentProviderToken(providerID)
-            let response = try await dependencies.registerProvider(key, bearerProof)
-            try await dependencies.saveProviderIdentity(response.providerID, response.providerToken, response.coordinatorWebSocketURL)
-            try dependencies.updateState(response.providerID, "registered", nil, nil)
-
-            try await finishLaunch(providerID: response.providerID, from: .autotune, plan: nil)
-        } catch {
-            stage = .failed(stage: stageName(stage), retryable: true, message: error.localizedDescription)
-        }
+        await launchViaCLIInstall()
     }
 
-    /// Retries from the last-failed stage. Preserves partial-download
-    /// state and identity Keychain slot.
     func retry() async {
         guard case .failed(_, let retryable, _) = stage, retryable else { return }
         await launch()
     }
 
-    /// Sets a payout wallet POST-onboarding. Wraps the SPEC-016 §3
-    /// EIP-712 signing flow. §1.1 forbids opening this UI during the
-    /// onboarding launch window; success-card + dashboard "Add wallet"
-    /// affordance is the correct entry point.
     func setPayoutWallet(_ address: String) async throws {
-        throw NSError(domain: "SPEC-026", code: 0,
-                      userInfo: [NSLocalizedDescriptionKey: "Wallet binding is a guarded SPEC-016/SPEC-027 follow-up route."])
+        throw NSError(
+            domain: "SPEC-027",
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: "Wallet binding is a guarded SPEC-027 follow-up route."]
+        )
     }
 
-    private func startConfiguredViaCLIInstall() async {
-        do {
-            try await dependencies.registerLoginItem()
-            guard await dependencies.monitorInstalledProvider() else {
-                throw launchdMonitorUnavailableError()
-            }
-            let model = dependencies.readConfigModel() ?? "configured"
-            stage = .live(model: model, tier: .provisional)
-        } catch {
-            stage = .failed(stage: "configured", retryable: true, message: error.localizedDescription)
+    func refreshFromExistingInstall() async {
+        switch stage {
+        case .idle, .failed(stage: "cliInstall", _, _):
+            break
+        default:
+            return
         }
+        guard await dependencies.localInstallSucceeded() else { return }
+        installLogLines = ["Background provider is already running locally."]
+        await finalizeInstall()
     }
 
     private func launchViaCLIInstall() async {
         beginInstallProgressWatch()
         defer { endInstallProgressWatch() }
         do {
-            if await CLIInstallRunner.localInstallSucceeded() {
-                installLogLines.append(
-                    "Background provider is already running locally. Connecting Malibu to it."
-                )
-                await finalizeCLIInstallTrack()
-                return
-            }
             stage = .runningCLIInstall
             installLogLines = []
             try await dependencies.runCLIInstall { [weak self] line in
@@ -359,8 +110,7 @@ final class LaunchProviderController: ObservableObject {
             do {
                 try await dependencies.importCLIConfigAfterInstall()
             } catch {
-                // CLI track may not have provider_token in yaml yet (coordinator assigns over WS).
-                if await CLIInstallRunner.localInstallSucceeded() {
+                if await dependencies.localInstallSucceeded() {
                     installLogLines.append(
                         "Provider token not in config yet; Malibu will monitor the background provider without Keychain import."
                     )
@@ -368,13 +118,13 @@ final class LaunchProviderController: ObservableObject {
                     throw error
                 }
             }
-            await finalizeCLIInstallTrack()
+            await finalizeInstall()
         } catch {
             stage = .failed(stage: "cliInstall", retryable: true, message: error.localizedDescription)
         }
     }
 
-    private func finalizeCLIInstallTrack() async {
+    private func finalizeInstall() async {
         do {
             try await dependencies.registerLoginItem()
             stage = .startingAgent
@@ -418,324 +168,12 @@ final class LaunchProviderController: ObservableObject {
         installStartedAt = nil
         installProgressHint = nil
     }
-
-    /// When setup reopens after CLI install finished, jump straight to live/monitor.
-    func refreshFromExistingInstall() async {
-        switch stage {
-        case .idle:
-            break
-        case let .failed(stageName, _, _) where stageName == "cliInstall":
-            break
-        default:
-            return
-        }
-        guard await CLIInstallRunner.localInstallSucceeded() else { return }
-        installLogLines = ["Background provider is already running locally."]
-        await finalizeCLIInstallTrack()
-    }
-
-    private func startConfiguredAgent(model: String) async {
-        do {
-            try dependencies.validateServeConfigShape()
-            await dependencies.startAgent()
-            stage = .live(model: model, tier: .provisional)
-        } catch {
-            guard let providerID = dependencies.readProviderID() else {
-                stage = .failed(stage: "configured", retryable: true, message: error.localizedDescription)
-                return
-            }
-            do {
-                try await finishLaunch(providerID: providerID, from: .autotune, plan: nil)
-            } catch {
-                stage = .failed(stage: stageName(stage), retryable: true, message: error.localizedDescription)
-            }
-        }
-    }
-
-    private enum ResumePoint {
-        case autotune
-        case cliReady
-        case downloadingModel
-        case modelReady
-    }
-
-    private func resumePartialOnboarding(_ existing: OnboardingState) async {
-        do {
-            var point: ResumePoint
-            switch existing.lastStage {
-            case "identityReady", "registering":
-                try await resumeRegistration(existing)
-                return
-            case "registered", "autotuning":
-                point = .autotune
-            case "cliReady":
-                point = .cliReady
-            case "downloadingModel":
-                point = .downloadingModel
-            case "modelReady", "startingAgent":
-                point = .modelReady
-            default:
-                point = .autotune
-            }
-            let configurationReady = try await recoverResumeConfigurationIfNeeded(existing)
-            if !configurationReady {
-                try await resumeRegistration(existing)
-                return
-            }
-            if point != .autotune && !isServeConfigShapeValid() {
-                point = .autotune
-            }
-            let plan = existing.modelDownload.map {
-                ModelDownloadPlan(modelName: $0.modelID, state: $0, earningsEstimate: nil)
-            }
-            try await finishLaunch(providerID: existing.providerID, from: point, plan: plan)
-        } catch {
-            stage = .failed(stage: stageName(stage), retryable: true, message: error.localizedDescription)
-        }
-    }
-
-    private func recoverResumeConfigurationIfNeeded(_ existing: OnboardingState) async throws -> Bool {
-        if await dependencies.isConfigured() { return true }
-        guard let configProviderID = dependencies.readProviderID() else { return false }
-        guard configProviderID == existing.providerID else {
-            throw NSError(
-                domain: "SPEC-026",
-                code: 2,
-                userInfo: [NSLocalizedDescriptionKey: "Stored provider config does not match the onboarding state."]
-            )
-        }
-
-        let key = try await dependencies.loadExistingIdentity()
-        guard dependencies.providerID(key) == existing.providerID else {
-            throw NSError(
-                domain: "SPEC-026",
-                code: 3,
-                userInfo: [NSLocalizedDescriptionKey: "Stored provider identity does not match the onboarding state."]
-            )
-        }
-        guard await dependencies.currentProviderToken(existing.providerID) != nil else {
-            throw ProviderConfig.SaveError.missingProviderToken
-        }
-
-        try await dependencies.repairMarkerlessAppConfig(existing.providerID)
-        guard await dependencies.isConfigured() else {
-            throw ProviderConfig.SaveError.savedIdentityNotConfigured
-        }
-        return true
-    }
-
-    private func resumeRegistration(_ existing: OnboardingState) async throws {
-        let key = try await dependencies.loadOrGenerateIdentity()
-        let providerID = dependencies.providerID(key)
-        guard providerID == existing.providerID else {
-            throw NSError(
-                domain: "SPEC-026",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "Stored provider identity does not match the onboarding state."]
-            )
-        }
-
-        stage = .registering
-        let bearerProof = await dependencies.currentProviderToken(providerID)
-        let response = try await dependencies.registerProvider(key, bearerProof)
-        try await dependencies.saveProviderIdentity(response.providerID, response.providerToken, response.coordinatorWebSocketURL)
-        try dependencies.updateState(response.providerID, "registered", nil, nil)
-        try await finishLaunch(providerID: response.providerID, from: .autotune, plan: existing.modelDownload.map {
-            ModelDownloadPlan(modelName: $0.modelID, state: $0, earningsEstimate: nil)
-        })
-    }
-
-    private func finishLaunch(
-        providerID: String,
-        from resumePoint: ResumePoint,
-        plan resumePlan: ModelDownloadPlan?
-    ) async throws {
-        var plan = resumePlan ?? .recommended
-
-        if resumePoint == .autotune {
-            stage = .autotuning
-            try dependencies.updateState(providerID, "autotuning", nil, nil)
-            let recommendation = try await dependencies.runAutotune(providerID)
-            try dependencies.persistAutotuneRecommendation(recommendation.serveConfig)
-            try requireServeConfigShape()
-            plan = recommendation.plan
-
-            stage = .downloadingCLI(progressPct: 1)
-            try dependencies.ensureCLIReady()
-            try dependencies.updateState(providerID, "cliReady", nil, nil)
-        }
-
-        if resumePoint == .cliReady || resumePoint == .downloadingModel || resumePoint == .autotune {
-            let progress = plan.state.map { $0.partialBytes > 0 ? 0.5 : 0 } ?? 0
-            stage = .downloadingModel(name: plan.modelName, progressPct: progress)
-            currentEarningsEstimate = plan.earningsEstimate
-            try dependencies.updateState(providerID, "downloadingModel", nil, plan.state)
-            let completedDownload = try await dependencies.downloadModel(plan)
-            stage = .downloadingModel(name: plan.modelName, progressPct: 1)
-            try dependencies.updateState(providerID, "modelReady", nil, completedDownload)
-        }
-
-        try requireServeConfigShape()
-        stage = .startingAgent
-        try dependencies.updateState(providerID, "startingAgent", nil, nil)
-        try dependencies.markLinkState(.pendingLink)
-        try await dependencies.registerLoginItem()
-        try dependencies.markLinkState(.linked)
-        await dependencies.startAgent()
-
-        stage = .authenticating
-        let firstServingAt = try await dependencies.waitForFirstServing()
-        try dependencies.updateState(providerID, "live", firstServingAt, nil)
-        stage = .live(model: plan.modelName, tier: .provisional)
-    }
-
-    private func isServeConfigShapeValid() -> Bool {
-        do {
-            try dependencies.validateServeConfigShape()
-            return true
-        } catch {
-            return false
-        }
-    }
-
-    private func requireServeConfigShape() throws {
-        do {
-            try dependencies.validateServeConfigShape()
-        } catch {
-            throw NSError(
-                domain: "SPEC-026",
-                code: 4,
-                userInfo: [
-                    NSLocalizedDescriptionKey: "autotune completed but config is missing required serve config shape — file a bug",
-                    NSUnderlyingErrorKey: error,
-                ]
-            )
-        }
-    }
-
-    private func stageName(_ stage: Stage) -> String {
-        switch stage {
-        case .idle: return "idle"
-        case .runningCLIInstall: return "cliInstall"
-        case .identityReady: return "identityReady"
-        case .registering: return "registering"
-        case .autotuning: return "autotuning"
-        case .downloadingCLI: return "downloadingCLI"
-        case .downloadingModel: return "downloadingModel"
-        case .startingAgent: return "startingAgent"
-        case .authenticating: return "authenticating"
-        case .live: return "live"
-        case let .failed(stage, _, _): return stage
-        }
-    }
-}
-
-// MARK: - Persistent onboarding state (SPEC-026 §7.5)
-
-/// Persisted at `~/Library/Application Support/Malibu/onboarding.json`
-/// with file mode 0600. Never contains the private key or bearer token
-/// — those live in Keychain.
-struct OnboardingState: Codable {
-    /// SPEC-026 §7.5 + §8 migration disambiguator. Fresh v0.11 installs
-    /// write 2; v1 SPEC-025 installs have no such file.
-    let onboardingSchemaVersion: Int
-    let providerID: String
-    let createdAt: Date
-    let lastStage: String
-    let firstServingAt: Date?
-    let modelDownload: ModelDownloadState?
-
-    enum CodingKeys: String, CodingKey {
-        case onboardingSchemaVersion = "onboarding_schema_version"
-        case providerID = "provider_id"
-        case createdAt = "created_at"
-        case lastStage = "last_stage"
-        case firstServingAt = "first_serving_at"
-        case modelDownload = "model_download"
-    }
-
-    struct ModelDownloadState: Codable, Equatable {
-        let modelID: String
-        let targetURL: URL
-        let targetSHA256: String
-        let partialBytes: Int64
-
-        enum CodingKeys: String, CodingKey {
-            case modelID = "model_id"
-            case targetURL = "target_url"
-            case targetSHA256 = "target_sha256"
-            case partialBytes = "partial_bytes"
-        }
-    }
-}
-
-enum OnboardingStateStore {
-    static func load(paths: ProviderPaths = .current) throws -> OnboardingState? {
-        let url = paths.onboardingStateFile
-        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
-        let data = try Data(contentsOf: url)
-        return try decoder.decode(OnboardingState.self, from: data)
-    }
-
-    static func save(_ state: OnboardingState, paths: ProviderPaths = .current) throws {
-        try paths.ensureDirectories()
-        let data = try encoder.encode(state)
-        try data.write(to: paths.onboardingStateFile, options: [.atomic])
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: paths.onboardingStateFile.path
-        )
-    }
-
-    static func update(
-        providerID: String,
-        lastStage: String,
-        firstServingAt: Date? = nil,
-        modelDownload: OnboardingState.ModelDownloadState? = nil,
-        paths: ProviderPaths = .current
-    ) throws {
-        let existing = try load(paths: paths)
-        try save(OnboardingState(
-            onboardingSchemaVersion: 2,
-            providerID: providerID,
-            createdAt: existing?.createdAt ?? Date(),
-            lastStage: lastStage,
-            firstServingAt: firstServingAt ?? existing?.firstServingAt,
-            modelDownload: modelDownload ?? existing?.modelDownload
-        ), paths: paths)
-    }
-
-    static func delete(paths: ProviderPaths = .current) throws {
-        let url = paths.onboardingStateFile
-        do { try FileManager.default.removeItem(at: url) }
-        catch {
-            let ns = error as NSError
-            if !(ns.domain == NSCocoaErrorDomain && ns.code == NSFileNoSuchFileError) {
-                throw error
-            }
-        }
-    }
-
-    private static let encoder: JSONEncoder = {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        return encoder
-    }()
-
-    private static let decoder: JSONDecoder = {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        return decoder
-    }()
 }
 
 enum StartupRoute: Equatable {
     case startAgent
     case showOnboarding
     case showImportDialog
-    case setupPaused
-    case resumeOnboarding
     case quit
 }
 
@@ -753,38 +191,8 @@ struct MigrationResult: Equatable {
 struct StartupState: Equatable {
     let configExists: Bool
     let appMarkerExists: Bool
-    let providerTokenExists: Bool
-    let linkState: ProviderConfig.LinkState?
-    let serveConfigShapeValid: Bool
-    let identityExists: Bool
-    let onboardingStateExists: Bool
-    let firstServingAtExists: Bool
-    let onboardingV2Enabled: Bool
+    let launchdInstallEvidenceExists: Bool
     let backgroundProviderHealthy: Bool
-
-    init(
-        configExists: Bool,
-        appMarkerExists: Bool,
-        providerTokenExists: Bool,
-        linkState: ProviderConfig.LinkState?,
-        serveConfigShapeValid: Bool = true,
-        identityExists: Bool,
-        onboardingStateExists: Bool,
-        firstServingAtExists: Bool,
-        onboardingV2Enabled: Bool,
-        backgroundProviderHealthy: Bool = false
-    ) {
-        self.configExists = configExists
-        self.appMarkerExists = appMarkerExists
-        self.providerTokenExists = providerTokenExists
-        self.linkState = linkState
-        self.serveConfigShapeValid = serveConfigShapeValid
-        self.identityExists = identityExists
-        self.onboardingStateExists = onboardingStateExists
-        self.firstServingAtExists = firstServingAtExists
-        self.onboardingV2Enabled = onboardingV2Enabled
-        self.backgroundProviderHealthy = backgroundProviderHealthy
-    }
 
     @MainActor
     static func detect(paths: ProviderPaths = .current) async -> StartupState {
@@ -792,71 +200,44 @@ struct StartupState: Equatable {
         try? await ProviderConfig.recoverPendingImportIfNeeded(paths: paths)
         let configExists = fm.fileExists(atPath: paths.configFile.path)
         let markerExists = fm.fileExists(atPath: paths.appMarkerFile.path)
-        let providerID = ProviderConfig.readProviderID(paths: paths)
-        let tokenExists: Bool
-        if let providerID {
-            tokenExists = await KeychainStore.readProviderToken(providerID: providerID) != nil
-        } else {
-            tokenExists = false
-        }
-        let serveConfigShapeValid = (try? ProviderConfig.validateServeConfigShape(paths: paths)) != nil
-        let identityExists = await ProviderIdentity.isReady()
-        let onboarding = try? OnboardingStateStore.load(paths: paths)
+        let home = fm.homeDirectoryForCurrentUser
+        let manifest = home.appendingPathComponent("Library/Application Support/macprovider/install_manifest.json")
+        let launchd = home.appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
+        let launchdInstallEvidenceExists =
+            fm.isReadableFile(atPath: manifest.path) || fm.isReadableFile(atPath: launchd.path)
+
         var backgroundProviderHealthy = false
-        if MalibuOnboardingPolicy.prefersCLIInstallTrack,
-           ProviderConfig.readProviderID(paths: paths) != nil,
-           let port = ProviderConfig.readHTTPPort(paths: paths) {
-            let home = fm.homeDirectoryForCurrentUser
-            let manifest = home.appendingPathComponent("Library/Application Support/macprovider/install_manifest.json")
-            let launchd = home.appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
-            if fm.isReadableFile(atPath: manifest.path) || fm.isReadableFile(atPath: launchd.path) {
-                backgroundProviderHealthy = await InstalledProviderMonitor.isHealthy(port: port)
-            }
+        if ProviderConfig.readProviderID(paths: paths) != nil,
+           let port = ProviderConfig.readHTTPPort(paths: paths),
+           launchdInstallEvidenceExists {
+            backgroundProviderHealthy = await InstalledProviderMonitor.isHealthy(port: port)
         }
+
         return StartupState(
             configExists: configExists,
             appMarkerExists: markerExists,
-            providerTokenExists: tokenExists,
-            linkState: ProviderConfig.readLinkState(paths: paths),
-            serveConfigShapeValid: serveConfigShapeValid,
-            identityExists: identityExists,
-            onboardingStateExists: onboarding != nil,
-            firstServingAtExists: onboarding?.firstServingAt != nil,
-            onboardingV2Enabled: LaunchProviderController.isOnboardingV2Enabled,
+            launchdInstallEvidenceExists: launchdInstallEvidenceExists,
             backgroundProviderHealthy: backgroundProviderHealthy
         )
     }
 
     func route() -> StartupRoute {
-        if backgroundProviderHealthy && MalibuOnboardingPolicy.prefersCLIInstallTrack {
+        if backgroundProviderHealthy {
             return .startAgent
-        }
-        if onboardingStateExists && !firstServingAtExists {
-            return .resumeOnboarding
-        }
-        if configExists && appMarkerExists && providerTokenExists && linkState == .pendingLink {
-            return .resumeOnboarding
-        }
-        if configExists && appMarkerExists && providerTokenExists {
-            return serveConfigShapeValid ? .startAgent : .resumeOnboarding
         }
         if configExists && !appMarkerExists {
             return .showImportDialog
         }
-        if identityExists && onboardingV2Enabled {
-            return .resumeOnboarding
+        if configExists || launchdInstallEvidenceExists {
+            return .startAgent
         }
-        if !configExists && !appMarkerExists {
-            return .showOnboarding
-        }
-        return onboardingV2Enabled ? .showOnboarding : .setupPaused
+        return .showOnboarding
     }
 
     static func applyMigrationDecision(
         _ decision: MigrationDecision,
         paths: ProviderPaths = .current,
-        now: Date = Date(),
-        onboardingV2Enabled: Bool? = nil
+        now: Date = Date()
     ) async throws -> MigrationResult {
         switch decision {
         case .importExisting:
@@ -865,28 +246,7 @@ struct StartupState: Equatable {
             return MigrationResult(route: state.route(), backupPath: nil)
         case .startFresh:
             let backup = try ProviderConfig.startFreshMovingCLIConfigAside(now: now, paths: paths)
-            let effectiveOnboardingV2Enabled: Bool
-            if let onboardingV2Enabled {
-                effectiveOnboardingV2Enabled = onboardingV2Enabled
-            } else {
-                effectiveOnboardingV2Enabled = await MainActor.run {
-                    LaunchProviderController.isOnboardingV2Enabled
-                }
-            }
-            let fresh = StartupState(
-                configExists: false,
-                appMarkerExists: false,
-                providerTokenExists: false,
-                linkState: nil,
-                identityExists: false,
-                onboardingStateExists: false,
-                firstServingAtExists: false,
-                onboardingV2Enabled: effectiveOnboardingV2Enabled
-            )
-            let route: StartupRoute = MalibuOnboardingPolicy.prefersCLIInstallTrack
-                ? .showOnboarding
-                : fresh.route()
-            return MigrationResult(route: route, backupPath: backup?.path)
+            return MigrationResult(route: .showOnboarding, backupPath: backup?.path)
         case .cancel:
             return MigrationResult(route: .quit, backupPath: nil)
         }

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -200,11 +200,7 @@ struct StartupState: Equatable {
         try? await ProviderConfig.recoverPendingImportIfNeeded(paths: paths)
         let configExists = fm.fileExists(atPath: paths.configFile.path)
         let markerExists = fm.fileExists(atPath: paths.appMarkerFile.path)
-        let home = fm.homeDirectoryForCurrentUser
-        let manifest = home.appendingPathComponent("Library/Application Support/macprovider/install_manifest.json")
-        let launchd = home.appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
-        let launchdInstallEvidenceExists =
-            fm.isReadableFile(atPath: manifest.path) || fm.isReadableFile(atPath: launchd.path)
+        let launchdInstallEvidenceExists = Self.launchdInstallEvidenceExists(paths: paths)
 
         var backgroundProviderHealthy = false
         if ProviderConfig.readProviderID(paths: paths) != nil,
@@ -228,10 +224,24 @@ struct StartupState: Equatable {
         if configExists && !appMarkerExists {
             return .showImportDialog
         }
-        if configExists || launchdInstallEvidenceExists {
+        // Launchd + config but provider still starting: attach and poll health.
+        if launchdInstallEvidenceExists && configExists {
             return .startAgent
         }
+        // Legacy app-track config without launchd, or launchd plist without config:
+        // run install.sh via onboarding instead of a reconnect loop.
+        if configExists || launchdInstallEvidenceExists {
+            return .showOnboarding
+        }
         return .showOnboarding
+    }
+
+    static func launchdInstallEvidenceExists(paths: ProviderPaths = .current) -> Bool {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser
+        let manifest = home.appendingPathComponent("Library/Application Support/macprovider/install_manifest.json")
+        let launchd = home.appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
+        return fm.isReadableFile(atPath: manifest.path) || fm.isReadableFile(atPath: launchd.path)
     }
 
     static func applyMigrationDecision(

--- a/phase3-binary/app/Sources/Malibu/Onboarding/MalibuOnboardingPolicy.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/MalibuOnboardingPolicy.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-/// App-wide onboarding policy toggles (nonisolated so routing code can read them).
-enum MalibuOnboardingPolicy {
-    /// When true (default), fresh onboarding runs `install.sh` instead of the
-    /// in-app SPEC-026 register/autotune path.
-    static var prefersCLIInstallTrack = true
-}

--- a/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingState.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingState.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Legacy V2 onboarding state persisted in onboarding.json.
+/// Retained for decode tests; production onboarding no longer writes this file.
+struct OnboardingState: Codable {
+    let onboardingSchemaVersion: Int
+    let providerID: String
+    let createdAt: Date
+    let lastStage: String
+    let firstServingAt: Date?
+    let modelDownload: ModelDownloadState?
+
+    enum CodingKeys: String, CodingKey {
+        case onboardingSchemaVersion = "onboarding_schema_version"
+        case providerID = "provider_id"
+        case createdAt = "created_at"
+        case lastStage = "last_stage"
+        case firstServingAt = "first_serving_at"
+        case modelDownload = "model_download"
+    }
+
+    struct ModelDownloadState: Codable, Equatable {
+        let modelID: String
+        let targetURL: URL
+        let targetSHA256: String
+        let partialBytes: Int64
+
+        enum CodingKeys: String, CodingKey {
+            case modelID = "model_id"
+            case targetURL = "target_url"
+            case targetSHA256 = "target_sha256"
+            case partialBytes = "partial_bytes"
+        }
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
@@ -27,13 +27,7 @@ private struct OnboardingRootView: View {
     init(agent: MalibuAgent, onDone: @escaping () -> Void) {
         self.agent = agent
         self.onDone = onDone
-        let bundled = Bundle.main.bundleURL
-            .appendingPathComponent("Contents/MacOS/macprovider-cli")
-        _controller = StateObject(wrappedValue: LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: bundled,
-            agent: agent
-        ))
+        _controller = StateObject(wrappedValue: LaunchProviderController(agent: agent))
     }
 
     var body: some View {
@@ -105,40 +99,8 @@ private struct OnboardingRootView: View {
                     }
                 }
             }
-        case .identityReady:
-            stageRow(title: "Identity ready", detail: "Local provider identity created in Keychain.") {
-                ProgressView().controlSize(.small)
-            }
-        case .registering:
-            stageRow(title: "Registering", detail: "Requesting a provider token from the coordinator.") {
-                ProgressView().controlSize(.small)
-            }
-        case .autotuning:
-            stageRow(title: "Autotuning", detail: "Selecting the recommended local model.") {
-                ProgressView().controlSize(.small)
-            }
-        case let .downloadingCLI(progress):
-            stageRow(title: "Provider binary", detail: "Bundled provider binary is ready.") {
-                ProgressView(value: progress)
-            }
-        case let .downloadingModel(name, progress):
-            stageRow(title: "Model", detail: "Preparing \(name).") {
-                ProgressView(value: progress)
-                if let line = EarningsEstimateFormatter.line(
-                    modelName: name,
-                    range: controller.currentEarningsEstimate
-                ) {
-                    Text(line)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-            }
         case .startingAgent:
             stageRow(title: "Starting", detail: "Waiting for the background provider to become healthy.") {
-                ProgressView().controlSize(.small)
-            }
-        case .authenticating:
-            stageRow(title: "Authenticating", detail: "Completing provider authentication.") {
                 ProgressView().controlSize(.small)
             }
         case let .live(model, tier):
@@ -158,7 +120,7 @@ private struct OnboardingRootView: View {
                     .tint(MalibuBrand.coral)
             }
         case let .failed(_, retryable, message):
-            stageRow(title: retryable ? "Needs retry" : "Setup paused", detail: message) {
+            stageRow(title: retryable ? "Needs retry" : "Setup failed", detail: message) {
                 if retryable {
                     launchButton(title: "Retry")
                 }

--- a/phase3-binary/app/Tests/MalibuTests/EarningsEstimateFormatterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/EarningsEstimateFormatterTests.swift
@@ -35,7 +35,7 @@ final class EarningsEstimateFormatterTests: XCTestCase {
         }
         """.utf8)
 
-        let plan = try LaunchProviderController.ModelDownloadPlan.fromAutotuneJSON(data)
+        let plan = try ModelDownloadPlan.fromAutotuneJSON(data)
 
         XCTAssertEqual(plan.modelName, "meta-llama/llama-3.1-8b-instruct")
         XCTAssertEqual(plan.earningsEstimate, EarningsEstimateRange(lowDailyUSD: 6, highDailyUSD: 6))
@@ -50,7 +50,7 @@ final class EarningsEstimateFormatterTests: XCTestCase {
         }
         """.utf8)
 
-        let plan = try LaunchProviderController.ModelDownloadPlan.fromAutotuneJSON(data)
+        let plan = try ModelDownloadPlan.fromAutotuneJSON(data)
 
         XCTAssertEqual(plan.modelName, "meta-llama/llama-3.1-8b-instruct")
         XCTAssertNil(plan.earningsEstimate)

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -1,425 +1,12 @@
-import CryptoKit
 import XCTest
 @testable import Malibu
 
 @MainActor
 final class LaunchProviderControllerTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        UserDefaults.standard.set("v2", forKey: "onboardingFlow")
-        LaunchProviderController.prefersCLIInstallTrack = false
-    }
 
-    override func tearDown() {
-        UserDefaults.standard.removeObject(forKey: "onboardingFlow")
-        MalibuOnboardingPolicy.prefersCLIInstallTrack = true
-        super.tearDown()
-    }
-
-    func testLaunchHappyPathRunsOrderedStateMachine() async {
+    func testLaunchViaCLIInstallWhenNotAlreadyRunning() async {
         let harness = Harness()
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        XCTAssertEqual(harness.savedProviderID, "p_test")
-        XCTAssertEqual(harness.savedToken, "provider-token")
-        XCTAssertEqual(harness.loginItemRegistrations, 1)
-        XCTAssertEqual(harness.agentStarts, 1)
-        XCTAssertEqual(harness.autotuneRuns, 1)
-        XCTAssertEqual(harness.persistedServeConfigs.count, 1)
-        XCTAssertEqual(harness.validateServeConfigShapeCalls, 2)
-        XCTAssertEqual(harness.modelDownloads.map(\.modelName), ["recommended"])
-        XCTAssertEqual(harness.stageUpdates, ["registered", "autotuning", "cliReady", "downloadingModel", "modelReady", "startingAgent", "live"])
-        XCTAssertEqual(controller.stage, .live(model: "recommended", tier: .provisional))
-    }
-
-    func testLaunchRegisterFailureIsRetryableAtRegisteringStage() async {
-        let harness = Harness()
-        harness.registerError = NSError(domain: "tests", code: 1, userInfo: [NSLocalizedDescriptionKey: "register failed"])
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        if case let .failed(stage, retryable, message) = controller.stage {
-            XCTAssertEqual(stage, "registering")
-            XCTAssertTrue(retryable)
-            XCTAssertEqual(message, "register failed")
-        } else {
-            XCTFail("expected failed registering stage")
-        }
-        XCTAssertEqual(harness.loginItemRegistrations, 0)
-        XCTAssertEqual(harness.agentStarts, 0)
-    }
-
-    func testLaunchResumesConfiguredPartialModelDownloadWithoutReregistering() async {
-        let harness = Harness()
-        harness.configured = true
-        harness.loadedState = OnboardingState(
-            onboardingSchemaVersion: 2,
-            providerID: "p_test",
-            createdAt: Date(timeIntervalSince1970: 1),
-            lastStage: "downloadingModel",
-            firstServingAt: nil,
-            modelDownload: OnboardingState.ModelDownloadState(
-                modelID: "Qwen2.5-7B-Instruct",
-                targetURL: URL(string: "https://models.example/qwen")!,
-                targetSHA256: "abc123",
-                partialBytes: 4096
-            )
-        )
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        XCTAssertNil(harness.savedProviderID)
-        XCTAssertEqual(harness.autotuneRuns, 0)
-        XCTAssertEqual(harness.modelDownloads.map(\.modelName), ["Qwen2.5-7B-Instruct"])
-        XCTAssertEqual(harness.stageUpdates, ["downloadingModel", "modelReady", "startingAgent", "live"])
-        XCTAssertEqual(harness.agentStarts, 1)
-        XCTAssertEqual(controller.stage, .live(model: "Qwen2.5-7B-Instruct", tier: .provisional))
-    }
-
-    func testLaunchStartsConfiguredInstallWithoutSynthesizingFirstServingState() async {
-        let harness = Harness()
-        harness.configured = true
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        XCTAssertEqual(harness.agentStarts, 1)
-        XCTAssertEqual(harness.validateServeConfigShapeCalls, 1)
-        XCTAssertTrue(harness.stageUpdates.isEmpty)
-        XCTAssertEqual(controller.stage, .live(model: "configured", tier: .provisional))
-    }
-
-    func testConfiguredInstallMissingServeConfigRerunsAutotuneBeforeStart() async {
-        let harness = Harness()
-        harness.configured = true
-        harness.serveConfigShapeValid = false
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        XCTAssertEqual(harness.autotuneRuns, 1)
-        XCTAssertEqual(harness.persistedServeConfigs, [.valid])
-        XCTAssertEqual(harness.agentStarts, 1)
-        XCTAssertEqual(harness.stageUpdates, ["autotuning", "cliReady", "downloadingModel", "modelReady", "startingAgent", "live"])
-        XCTAssertEqual(controller.stage, .live(model: "recommended", tier: .provisional))
-    }
-
-    func testLaunchResumesIdentityReadyByRegisteringBeforeAutotune() async {
-        let harness = Harness()
-        harness.loadedState = OnboardingState(
-            onboardingSchemaVersion: 2,
-            providerID: "p_test",
-            createdAt: Date(timeIntervalSince1970: 1),
-            lastStage: "identityReady",
-            firstServingAt: nil,
-            modelDownload: nil
-        )
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        XCTAssertEqual(harness.savedProviderID, "p_test")
-        XCTAssertEqual(harness.savedToken, "provider-token")
-        XCTAssertEqual(harness.stageUpdates, ["registered", "autotuning", "cliReady", "downloadingModel", "modelReady", "startingAgent", "live"])
-        XCTAssertEqual(harness.autotuneRuns, 1)
-        XCTAssertEqual(harness.agentStarts, 1)
-        XCTAssertEqual(controller.stage, .live(model: "recommended", tier: .provisional))
-    }
-
-    func testLaunchRepairsMarkerlessRegisteredStateBeforeResume() async {
-        let harness = Harness()
-        harness.configured = false
-        harness.configProviderID = "p_test"
-        harness.providerToken = "provider-token"
-        harness.loadedState = OnboardingState(
-            onboardingSchemaVersion: 2,
-            providerID: "p_test",
-            createdAt: Date(timeIntervalSince1970: 1),
-            lastStage: "registered",
-            firstServingAt: nil,
-            modelDownload: nil
-        )
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        XCTAssertEqual(harness.markerRepairs, ["p_test"])
-        XCTAssertNil(harness.savedProviderID)
-        XCTAssertEqual(harness.autotuneRuns, 1)
-        XCTAssertEqual(harness.stageUpdates, ["autotuning", "cliReady", "downloadingModel", "modelReady", "startingAgent", "live"])
-        XCTAssertEqual(harness.agentStarts, 1)
-        XCTAssertEqual(controller.stage, .live(model: "recommended", tier: .provisional))
-    }
-
-    func testLaunchRepairsMarkerlessStartingAgentStateBeforeResume() async {
-        let harness = Harness()
-        harness.configured = false
-        harness.configProviderID = "p_test"
-        harness.providerToken = "provider-token"
-        harness.loadedState = OnboardingState(
-            onboardingSchemaVersion: 2,
-            providerID: "p_test",
-            createdAt: Date(timeIntervalSince1970: 1),
-            lastStage: "startingAgent",
-            firstServingAt: nil,
-            modelDownload: OnboardingState.ModelDownloadState(
-                modelID: "Qwen2.5-7B-Instruct",
-                targetURL: URL(string: "https://models.example/qwen")!,
-                targetSHA256: "abc123",
-                partialBytes: 0
-            )
-        )
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        XCTAssertEqual(harness.markerRepairs, ["p_test"])
-        XCTAssertNil(harness.savedProviderID)
-        XCTAssertEqual(harness.autotuneRuns, 0)
-        XCTAssertTrue(harness.modelDownloads.isEmpty)
-        XCTAssertEqual(harness.stageUpdates, ["startingAgent", "live"])
-        XCTAssertEqual(harness.agentStarts, 1)
-        XCTAssertEqual(controller.stage, .live(model: "Qwen2.5-7B-Instruct", tier: .provisional))
-    }
-
-    func testLaunchPersistsAndValidatesServeConfigBeforeDownloadingModel() async {
-        let harness = Harness()
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        XCTAssertEqual(harness.persistedServeConfigs, [.valid])
-        XCTAssertLessThan(
-            harness.events.firstIndex(of: "validateServeConfigShape") ?? Int.max,
-            harness.events.firstIndex(of: "downloadModel") ?? Int.max
-        )
-        XCTAssertEqual(controller.stage, .live(model: "recommended", tier: .provisional))
-    }
-
-    func testRetryRerunsAutotuneAfterServeConfigValidationFailure() async {
-        let harness = Harness()
-        harness.validateFailuresRemaining = 1
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        XCTAssertEqual(harness.agentStarts, 0)
-        XCTAssertEqual(harness.autotuneRuns, 1)
-        guard case .failed(_, true, let message) = controller.stage else {
-            XCTFail("expected retryable validation failure")
-            return
-        }
-        XCTAssertEqual(message, "autotune completed but config is missing required serve config shape — file a bug")
-
-        await controller.retry()
-
-        XCTAssertEqual(harness.autotuneRuns, 2)
-        XCTAssertEqual(harness.agentStarts, 1)
-        XCTAssertEqual(controller.stage, .live(model: "recommended", tier: .provisional))
-    }
-
-    func testResumeFromStartingAgentDemotesToAutotuneWhenServeConfigShapeMissing() async {
-        let harness = Harness()
-        harness.configured = true
-        harness.serveConfigShapeValid = false
-        harness.loadedState = OnboardingState(
-            onboardingSchemaVersion: 2,
-            providerID: "p_test",
-            createdAt: Date(timeIntervalSince1970: 1),
-            lastStage: "startingAgent",
-            firstServingAt: nil,
-            modelDownload: OnboardingState.ModelDownloadState(
-                modelID: "Qwen2.5-7B-Instruct",
-                targetURL: URL(string: "https://models.example/qwen")!,
-                targetSHA256: "abc123",
-                partialBytes: 0
-            )
-        )
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
-
-        await controller.launch()
-
-        XCTAssertEqual(harness.autotuneRuns, 1)
-        XCTAssertEqual(harness.persistedServeConfigs, [.valid])
-        XCTAssertEqual(harness.modelDownloads.map(\.modelName), ["recommended"])
-        XCTAssertEqual(harness.agentStarts, 1)
-        XCTAssertEqual(controller.stage, .live(model: "recommended", tier: .provisional))
-    }
-
-    private final class Harness {
-        var savedProviderID: String?
-        var savedToken: String?
-        var loginItemRegistrations = 0
-        var agentStarts = 0
-        var markerRepairs: [String] = []
-        var linkStates: [ProviderConfig.LinkState] = []
-        var stageUpdates: [String] = []
-        var modelDownloads: [LaunchProviderController.ModelDownloadPlan] = []
-        var persistedServeConfigs: [ProviderConfig.AutotuneServeConfig] = []
-        var validateServeConfigShapeCalls = 0
-        var validateFailuresRemaining = 0
-        var serveConfigShapeValid = true
-        var events: [String] = []
-        var autotuneRuns = 0
-        var configured = false
-        var configProviderID = "p_test"
-        var providerToken: String?
-        var loadedState: OnboardingState?
-        var registerError: Error?
-        var cliInstallRuns = 0
-        var cliImportRuns = 0
-        var monitorRuns = 0
-        var configModel = "mlx-community/Qwen2.5-7B-Instruct-4bit"
-        let key = Curve25519.Signing.PrivateKey()
-
-        func dependencies() -> LaunchProviderController.Dependencies {
-            LaunchProviderController.Dependencies(
-                isConfigured: { self.configured },
-                loadState: { self.loadedState },
-                loadOrGenerateIdentity: { self.key },
-                loadExistingIdentity: { self.key },
-                providerID: { _ in "p_test" },
-                currentProviderToken: { _ in self.providerToken },
-                registerProvider: { _, _ in
-                    if let error = self.registerError { throw error }
-                    return RegisterResponse(
-                        providerID: "p_test",
-                        providerToken: "provider-token",
-                        trustTier: "provisional",
-                        coordinatorWebSocketURL: URL(string: "wss://coordinator.streamvc.live/v2/provider")!
-                    )
-                },
-                saveProviderIdentity: { providerID, token, _ in
-                    self.savedProviderID = providerID
-                    self.savedToken = token
-                },
-                repairMarkerlessAppConfig: { providerID in
-                    self.markerRepairs.append(providerID)
-                    self.configured = true
-                },
-                saveState: { _ in },
-                updateState: { _, lastStage, _, _ in
-                    self.stageUpdates.append(lastStage)
-                },
-                markLinkState: { state in
-                    self.linkStates.append(state)
-                },
-                runAutotune: { _ in
-                    self.autotuneRuns += 1
-                    self.events.append("runAutotune")
-                    return AutotuneRecommendationResult(plan: .recommended, serveConfig: .valid)
-                },
-                persistAutotuneRecommendation: { config in
-                    self.events.append("persistAutotuneRecommendation")
-                    self.persistedServeConfigs.append(config)
-                    self.serveConfigShapeValid = true
-                },
-                validateServeConfigShape: {
-                    self.events.append("validateServeConfigShape")
-                    self.validateServeConfigShapeCalls += 1
-                    if self.validateFailuresRemaining > 0 {
-                        self.validateFailuresRemaining -= 1
-                        throw ProviderConfig.ServeConfigError.missingField("model_artifact_sha256")
-                    }
-                    if !self.serveConfigShapeValid {
-                        throw ProviderConfig.ServeConfigError.missingField("model_artifact_sha256")
-                    }
-                },
-                ensureCLIReady: {},
-                downloadModel: { plan in
-                    self.events.append("downloadModel")
-                    self.modelDownloads.append(plan)
-                    return plan.state ?? OnboardingState.ModelDownloadState(
-                        modelID: plan.modelName,
-                        targetURL: URL(string: "https://models.example/\(plan.modelName)")!,
-                        targetSHA256: "sha256",
-                        partialBytes: 0
-                    )
-                },
-                registerLoginItem: {
-                    self.loginItemRegistrations += 1
-                },
-                startAgent: {
-                    self.agentStarts += 1
-                },
-                waitForFirstServing: {
-                    Date(timeIntervalSince1970: 2)
-                },
-                readProviderID: { self.configProviderID },
-                runCLIInstall: { _ in
-                    self.cliInstallRuns += 1
-                },
-                importCLIConfigAfterInstall: {
-                    self.cliImportRuns += 1
-                    self.configured = true
-                },
-                monitorInstalledProvider: {
-                    self.monitorRuns += 1
-                    return true
-                },
-                readConfigModel: { self.configModel }
-            )
-        }
-    }
-
-    func testLaunchViaCLIInstallTrackRunsInstallerThenImports() async {
-        MalibuOnboardingPolicy.prefersCLIInstallTrack = true
-        defer { MalibuOnboardingPolicy.prefersCLIInstallTrack = false }
-
-        let harness = Harness()
-        let controller = LaunchProviderController(
-            coordinatorBaseURL: URL(string: "https://coordinator.streamvc.live")!,
-            bundledCLIPath: URL(fileURLWithPath: "/tmp/macprovider-cli"),
-            dependencies: harness.dependencies()
-        )
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
 
         await controller.launch()
 
@@ -427,25 +14,132 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(harness.cliImportRuns, 1)
         XCTAssertEqual(harness.monitorRuns, 1)
         XCTAssertEqual(harness.loginItemRegistrations, 1)
-        XCTAssertEqual(harness.autotuneRuns, 0)
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
-}
 
-private extension ProviderConfig.AutotuneServeConfig {
-    static let valid = ProviderConfig.AutotuneServeConfig(
-        model: "meta-llama/llama-3.1-8b-instruct",
-        modelArtifactPath: "/Users/test/.cache/huggingface/hub/models--mlx-community--Meta-Llama-3.1-8B-Instruct-4bit/snapshots/241a666dad6cb93c8ff213d39a7f34a36bf26db4",
-        modelArtifactSHA256: String(repeating: "a", count: 64),
-        modelCatalogKey: "meta-llama/llama-3.1-8b-instruct",
-        modelCatalogModelID: "mlx-community/Meta-Llama-3.1-8B-Instruct-4bit",
-        modelCatalogRevision: "241a666dad6cb93c8ff213d39a7f34a36bf26db4",
-        modelCatalogSHA256: String(repeating: "a", count: 64),
-        modelCatalogVersion: "baked-2026-07-03",
-        modelCatalogHash: String(repeating: "b", count: 64),
-        kvBits: nil,
-        maxContextOverride: 4000,
-        maxConcurrencyOverride: 1,
-        donorMode: false
-    )
+    func testLaunchSkipsInstallerWhenLocalProviderAlreadyHealthy() async {
+        let harness = Harness()
+        harness.localInstallSucceeded = true
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 0)
+        XCTAssertEqual(harness.cliImportRuns, 0)
+        XCTAssertEqual(harness.monitorRuns, 1)
+        XCTAssertEqual(harness.loginItemRegistrations, 1)
+        XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
+    }
+
+    func testLaunchInstallFailureIsRetryable() async {
+        let harness = Harness()
+        harness.cliInstallError = NSError(domain: "tests", code: 1, userInfo: [NSLocalizedDescriptionKey: "install failed"])
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+
+        if case let .failed(stage, retryable, message) = controller.stage {
+            XCTAssertEqual(stage, "cliInstall")
+            XCTAssertTrue(retryable)
+            XCTAssertEqual(message, "install failed")
+        } else {
+            XCTFail("expected failed cliInstall stage")
+        }
+        XCTAssertEqual(harness.loginItemRegistrations, 0)
+        XCTAssertEqual(harness.monitorRuns, 0)
+    }
+
+    func testLaunchMonitorFailureIsRetryable() async {
+        let harness = Harness()
+        harness.monitorHealthy = false
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+
+        if case let .failed(stage, retryable, _) = controller.stage {
+            XCTAssertEqual(stage, "cliInstall")
+            XCTAssertTrue(retryable)
+        } else {
+            XCTFail("expected failed cliInstall stage after monitor timeout")
+        }
+        XCTAssertEqual(harness.loginItemRegistrations, 1)
+    }
+
+    func testRetryRerunsInstallAfterFailure() async {
+        let harness = Harness()
+        harness.cliInstallError = NSError(domain: "tests", code: 1, userInfo: [NSLocalizedDescriptionKey: "install failed"])
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+        harness.cliInstallError = nil
+        await controller.retry()
+
+        XCTAssertEqual(harness.cliInstallRuns, 2)
+        XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
+    }
+
+    func testRefreshFromExistingInstallConnectsWithoutInstaller() async {
+        let harness = Harness()
+        harness.localInstallSucceeded = true
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.refreshFromExistingInstall()
+
+        XCTAssertEqual(harness.cliInstallRuns, 0)
+        XCTAssertEqual(harness.monitorRuns, 1)
+        XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
+    }
+
+    func testImportFailureToleratedWhenProviderAlreadyHealthy() async {
+        let harness = Harness()
+        harness.cliImportError = NSError(domain: "tests", code: 2, userInfo: [NSLocalizedDescriptionKey: "import failed"])
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 1)
+        XCTAssertEqual(harness.cliImportRuns, 1)
+        XCTAssertEqual(harness.monitorRuns, 1)
+        XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
+    }
+
+    private final class Harness {
+        var localInstallSucceeded = false
+        var localInstallSucceededAfterInstall = false
+        var cliInstallRuns = 0
+        var cliImportRuns = 0
+        var monitorRuns = 0
+        var loginItemRegistrations = 0
+        var monitorHealthy = true
+        var cliInstallError: Error?
+        var cliImportError: Error?
+        var configModel = "mlx-community/Qwen2.5-7B-Instruct-4bit"
+        var installLogLines: [String] = []
+
+        func dependencies() -> LaunchProviderController.Dependencies {
+            LaunchProviderController.Dependencies(
+                localInstallSucceeded: {
+                    self.localInstallSucceeded || self.localInstallSucceededAfterInstall
+                },
+                registerLoginItem: {
+                    self.loginItemRegistrations += 1
+                },
+                runCLIInstall: { onLogLine in
+                    self.cliInstallRuns += 1
+                    if let error = self.cliInstallError { throw error }
+                    self.localInstallSucceededAfterInstall = true
+                    onLogLine("install.sh finished")
+                },
+                importCLIConfigAfterInstall: {
+                    self.cliImportRuns += 1
+                    if let error = self.cliImportError { throw error }
+                },
+                monitorInstalledProvider: {
+                    self.monitorRuns += 1
+                    return self.monitorHealthy
+                },
+                readConfigModel: { self.configModel }
+            )
+        }
+    }
 }

--- a/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
@@ -86,7 +86,8 @@ final class ProviderConfigParserTests: XCTestCase {
 
         let state = await StartupState.detect(paths: paths)
 
-        XCTAssertEqual(state.route(), .startAgent)
+        let expectedRoute: StartupRoute = state.launchdInstallEvidenceExists ? .startAgent : .showOnboarding
+        XCTAssertEqual(state.route(), expectedRoute)
         XCTAssertFalse(FileManager.default.fileExists(atPath: ProviderConfig.importPendingMarker(paths: paths).path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))

--- a/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
@@ -86,7 +86,7 @@ final class ProviderConfigParserTests: XCTestCase {
 
         let state = await StartupState.detect(paths: paths)
 
-        XCTAssertEqual(state.route(), .resumeOnboarding)
+        XCTAssertEqual(state.route(), .startAgent)
         XCTAssertFalse(FileManager.default.fileExists(atPath: ProviderConfig.importPendingMarker(paths: paths).path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -6,9 +6,10 @@ final class StartupRouteTests: XCTestCase {
     func testStartupRouteInstallStates() {
         let cases: [(String, StartupState, StartupRoute)] = [
             ("healthy-launchd", state(config: true, marker: true, launchd: true, healthy: true), .startAgent),
-            ("configured-app", state(config: true, marker: true, launchd: false, healthy: false), .startAgent),
+            ("launchd-config-starting", state(config: true, marker: true, launchd: true, healthy: false), .startAgent),
+            ("legacy-app-config", state(config: true, marker: true, launchd: false, healthy: false), .showOnboarding),
             ("cli-owned", state(config: true, marker: false, launchd: false, healthy: false), .showImportDialog),
-            ("launchd-only", state(config: false, marker: false, launchd: true, healthy: false), .startAgent),
+            ("launchd-only", state(config: false, marker: false, launchd: true, healthy: false), .showOnboarding),
             ("fresh", state(config: false, marker: false, launchd: false, healthy: false), .showOnboarding)
         ]
 
@@ -17,7 +18,7 @@ final class StartupRouteTests: XCTestCase {
         }
     }
 
-    func testMigrationImportMovesTokenToKeychainAndRemovesBearerFromConfig() async throws {
+    func testMigrationImportWithoutLaunchdRoutesToOnboarding() async throws {
         let paths = try makeTempPaths()
         try paths.ensureDirectories()
         try "provider_id: p_import\nprovider_token: secret-token\nmodel: test\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
@@ -26,7 +27,9 @@ final class StartupRouteTests: XCTestCase {
         defer { Task { try? await KeychainStore.deleteProviderToken(providerID: "p_import") } }
 
         let result = try await StartupState.applyMigrationDecision(.importExisting, paths: paths)
-        XCTAssertEqual(result.route, .startAgent)
+        let state = await StartupState.detect(paths: paths)
+        let expectedRoute: StartupRoute = state.launchdInstallEvidenceExists ? .startAgent : .showOnboarding
+        XCTAssertEqual(result.route, expectedRoute)
         XCTAssertNil(result.backupPath)
         XCTAssertTrue(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
         let rewritten = try String(contentsOf: paths.configFile)

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -2,55 +2,18 @@ import XCTest
 @testable import Malibu
 
 final class StartupRouteTests: XCTestCase {
-    @MainActor
-    func testFeatureFlagEnvironmentOverridesUserDefaults() {
-        let defaults = UserDefaults(suiteName: "malibu-tests-\(UUID().uuidString)")!
-        defaults.set("v2", forKey: "onboardingFlow")
-        XCTAssertFalse(LaunchProviderController.isOnboardingV2Enabled(
-            environment: ["MALIBU_ONBOARD_V2": "0"],
-            userDefaults: defaults
-        ))
-        XCTAssertTrue(LaunchProviderController.isOnboardingV2Enabled(
-            environment: ["MALIBU_ONBOARD_V2": "1"],
-            userDefaults: defaults
-        ))
-    }
 
-    func testStartupRouteFiveInstallStatesByFlagPosition() {
-        let cases: [(String, StartupState, StartupRoute, StartupRoute)] = [
-            ("configured", state(config: true, marker: true, token: true, identity: true, onboarding: true, firstServing: true), .startAgent, .startAgent),
-            ("configured-v2-partial", state(config: true, marker: true, token: true, identity: true, onboarding: true, firstServing: false), .resumeOnboarding, .resumeOnboarding),
-            ("cli-owned", state(config: true, marker: false, token: false, identity: false, onboarding: false, firstServing: false), .showImportDialog, .showImportDialog),
-            ("v2-partial", state(config: false, marker: false, token: false, identity: true, onboarding: true, firstServing: false), .resumeOnboarding, .resumeOnboarding),
-            ("fresh", state(config: false, marker: false, token: false, identity: false, onboarding: false, firstServing: false), .showOnboarding, .showOnboarding),
-            ("identity-only", state(config: false, marker: false, token: false, identity: true, onboarding: false, firstServing: false), .showOnboarding, .resumeOnboarding)
+    func testStartupRouteInstallStates() {
+        let cases: [(String, StartupState, StartupRoute)] = [
+            ("healthy-launchd", state(config: true, marker: true, launchd: true, healthy: true), .startAgent),
+            ("configured-app", state(config: true, marker: true, launchd: false, healthy: false), .startAgent),
+            ("cli-owned", state(config: true, marker: false, launchd: false, healthy: false), .showImportDialog),
+            ("launchd-only", state(config: false, marker: false, launchd: true, healthy: false), .startAgent),
+            ("fresh", state(config: false, marker: false, launchd: false, healthy: false), .showOnboarding)
         ]
 
-        for (name, base, flagOffRoute, flagOnRoute) in cases {
-            var off = base
-            off = StartupState(
-                configExists: off.configExists,
-                appMarkerExists: off.appMarkerExists,
-                providerTokenExists: off.providerTokenExists,
-                linkState: off.linkState,
-                identityExists: off.identityExists,
-                onboardingStateExists: off.onboardingStateExists,
-                firstServingAtExists: off.firstServingAtExists,
-                onboardingV2Enabled: false
-            )
-            XCTAssertEqual(off.route(), flagOffRoute, name)
-
-            let on = StartupState(
-                configExists: base.configExists,
-                appMarkerExists: base.appMarkerExists,
-                providerTokenExists: base.providerTokenExists,
-                linkState: base.linkState,
-                identityExists: base.identityExists,
-                onboardingStateExists: base.onboardingStateExists,
-                firstServingAtExists: base.firstServingAtExists,
-                onboardingV2Enabled: true
-            )
-            XCTAssertEqual(on.route(), flagOnRoute, name)
+        for (name, base, expected) in cases {
+            XCTAssertEqual(base.route(), expected, name)
         }
     }
 
@@ -63,7 +26,7 @@ final class StartupRouteTests: XCTestCase {
         defer { Task { try? await KeychainStore.deleteProviderToken(providerID: "p_import") } }
 
         let result = try await StartupState.applyMigrationDecision(.importExisting, paths: paths)
-        XCTAssertEqual(result.route, .resumeOnboarding)
+        XCTAssertEqual(result.route, .startAgent)
         XCTAssertNil(result.backupPath)
         XCTAssertTrue(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
         let rewritten = try String(contentsOf: paths.configFile)
@@ -74,27 +37,24 @@ final class StartupRouteTests: XCTestCase {
         XCTAssertEqual(importedToken, "secret-token")
     }
 
-    func testMigrationStartFreshMovesConfigAsideAndReclassifiesFreshByFlag() async throws {
-        for (enabled, expectedRoute) in [(false, StartupRoute.showOnboarding), (true, .showOnboarding)] {
-            let paths = try makeTempPaths()
-            try paths.ensureDirectories()
-            try "provider_id: p_old\nprovider_token: old-token\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
-            defer { try? FileManager.default.removeItem(at: paths.appSupport.deletingLastPathComponent()) }
-            defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent()) }
+    func testMigrationStartFreshMovesConfigAsideAndShowsOnboarding() async throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        try "provider_id: p_old\nprovider_token: old-token\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: paths.appSupport.deletingLastPathComponent()) }
+        defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent()) }
 
-            let result = try await StartupState.applyMigrationDecision(
-                .startFresh,
-                paths: paths,
-                now: Date(timeIntervalSince1970: 1_783_082_460),
-                onboardingV2Enabled: enabled
-            )
-            XCTAssertEqual(result.route, expectedRoute)
-            XCTAssertNotNil(result.backupPath)
-            XCTAssertFalse(FileManager.default.fileExists(atPath: paths.configFile.path))
-            XCTAssertTrue(FileManager.default.fileExists(atPath: result.backupPath!))
-            let attrs = try FileManager.default.attributesOfItem(atPath: result.backupPath!)
-            XCTAssertEqual((attrs[.posixPermissions] as? NSNumber)?.intValue, 0o600)
-        }
+        let result = try await StartupState.applyMigrationDecision(
+            .startFresh,
+            paths: paths,
+            now: Date(timeIntervalSince1970: 1_783_082_460)
+        )
+        XCTAssertEqual(result.route, .showOnboarding)
+        XCTAssertNotNil(result.backupPath)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: paths.configFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.backupPath!))
+        let attrs = try FileManager.default.attributesOfItem(atPath: result.backupPath!)
+        XCTAssertEqual((attrs[.posixPermissions] as? NSNumber)?.intValue, 0o600)
     }
 
     func testMigrationCancelTouchesNoFiles() async throws {
@@ -114,54 +74,17 @@ final class StartupRouteTests: XCTestCase {
         XCTAssertNil(untouchedToken)
     }
 
-    func testConfiguredPendingLinkStateResumesOnboarding() {
-        let state = StartupState(
-            configExists: true,
-            appMarkerExists: true,
-            providerTokenExists: true,
-            linkState: .pendingLink,
-            identityExists: true,
-            onboardingStateExists: false,
-            firstServingAtExists: false,
-            onboardingV2Enabled: true
-        )
-
-        XCTAssertEqual(state.route(), .resumeOnboarding)
-    }
-
-    func testConfiguredInvalidServeConfigShapeResumesOnboarding() {
-        let state = StartupState(
-            configExists: true,
-            appMarkerExists: true,
-            providerTokenExists: true,
-            linkState: .linked,
-            serveConfigShapeValid: false,
-            identityExists: true,
-            onboardingStateExists: false,
-            firstServingAtExists: false,
-            onboardingV2Enabled: true
-        )
-
-        XCTAssertEqual(state.route(), .resumeOnboarding)
-    }
-
     private func state(
         config: Bool,
         marker: Bool,
-        token: Bool,
-        identity: Bool,
-        onboarding: Bool,
-        firstServing: Bool
+        launchd: Bool,
+        healthy: Bool
     ) -> StartupState {
         StartupState(
             configExists: config,
             appMarkerExists: marker,
-            providerTokenExists: token,
-            linkState: nil,
-            identityExists: identity,
-            onboardingStateExists: onboarding,
-            firstServingAtExists: firstServing,
-            onboardingV2Enabled: false
+            launchdInstallEvidenceExists: launchd,
+            backgroundProviderHealthy: healthy
         )
     }
 
@@ -180,5 +103,4 @@ final class StartupRouteTests: XCTestCase {
             downloadsDirectory: appSupport.appendingPathComponent("Downloads", isDirectory: true)
         )
     }
-
 }

--- a/scratchpad/onboarding-audit-2026-07-06.md
+++ b/scratchpad/onboarding-audit-2026-07-06.md
@@ -1,16 +1,19 @@
 # Provider Onboarding Audit — 2026-07-06
 
+> **Update 2026-07-06:** `feat/malibu-cli-wrapper-only` removes App-track V2 onboarding.
+> Malibu is now CLI-wrapper-only: `install.sh` for setup, launchd monitor for runtime.
+> Items marked **V2-removed** below are no longer production paths.
+
 Read-only audit of CLI-track vs App-track onboarding in current tree. Code is source of truth; memory items verified where noted.
 
 ---
 
 ## 1. Executive summary
 
-- **Two parallel tracks** share `~/.config/macprovider/config.yaml` but diverge on identity (CLI: hostname `provider_id` + YAML token; App: Ed25519 `provider_identity_v1` + Keychain token + `.installed-by-app` marker). SPEC-026 v0.13 is authoritative for App onboarding; SPEC-025 v0.1 for wrapper/CLI-child model.
-- **App-track V2 onboarding ships off by default** (`onboardingFlow=v2` or `MALIBU_ONBOARD_V2=1` required). Fresh installs see "Setup paused" unless the flag is set (`LaunchProviderController.swift:232-238`, `MalibuApp.swift:158-163`).
-- **M5 32GB Tier C cannot complete Malibu autotune today** when CLI emits `"serve_config": null` — Malibu's decoder requires a non-null object and fails before donor-mode handling (`AutotuneRecommendationRunner.swift:251-247`, `AutotuneRecommend.swift:1150`).
+- **Malibu is a CLI wrapper** (post-refactor): onboarding runs bundled `install.sh`; runtime monitors launchd-managed `macprovider-cli` via `/v1/health`. No in-app register/autotune/spawn-child path.
+- **CLI-track** remains the authoritative install path (`install.sh` → LaunchAgent → watchdog).
+- **V2 App-track removed** — former defects #1–3, #6, #10 are **V2-removed** (not production). See branch `feat/malibu-cli-wrapper-only`.
 - **CLI `install.sh` targets `$HOME/macprovider/macprovider-cli`**, not `/tmp`. Operator plist at `/tmp/macprovider-v1.8.10-run/...` is not produced by current installer (`install.sh:18-20`, `1456-1458`).
-- **Malibu always spawns its own CLI child**; no adopt-mode, no launchd conflict detection in App code. Coexistence with launchd-managed CLI is accidental (different ports possible, same `provider_id`).
 
 ---
 
@@ -37,33 +40,38 @@ Fresh Mac, `curl https://get.streamvc.live/install.sh | bash`:
 
 ---
 
-## 3. Onboarding path B — App-track
+## 3. Onboarding path B — Malibu wrapper (post-refactor)
 
 Fresh Mac, launch `Malibu.app`:
 
-| Step | Code | Artifacts | Coordinator | Failure UX |
-|------|------|-----------|-------------|------------|
-| 1. Startup route | `MalibuApp.handleStartup:112-114`, `StartupState.route:659-676` | Reads config, marker, Keychain, `onboarding.json` | — | `.setupPaused` alert if V2 off (`MalibuApp.swift:158-163`) |
-| 2. Migration (if CLI config, no marker) | `showImportDialog` / `importExistingCLIConfig:276-344` | Token → Keychain `tech.malibu.provider/{provider_id}`; strips YAML token; writes `.installed-by-app` | — | Alert on import error |
-| 3. V2 gate | `LaunchProviderController.launch:232-238` | — | — | `.failed(featureFlag)`: "App-track onboarding is not enabled" |
-| 4. Identity | `loadOrGenerateIdentity:242`, `ProviderIdentity.swift:64-66` | Keychain `tech.malibu.app` / `provider_identity_v1` | — | Keychain errors → `.failed` |
-| 5. Persist state | `saveState:245-252` | `~/Library/Application Support/Malibu/onboarding.json` (0600) | — | — |
-| 6. Register | `registerProvider:256`, `RegisterClient.postRegister:158-181` | Config YAML (no token on disk), Keychain token | **`POST /v1/providers/register`** | HTTP error → `.failed(retryable)` |
-| 7. Autotune | `finishLaunch` → `runAutotune:403`, `AutotuneRecommendationRunner.run:82-90` | Recommendation fields in config | Catalog via bundled CLI | JSON/decode/timeout → `.failed`; UI shows `error.localizedDescription` (`OnboardingWindow.swift:130-134`) |
-| 8. Model download | `downloadModel:418` | **Stub:** returns `plan.state` (always nil in live deps `LaunchProviderController.swift:123`) | — | Cosmetic progress only |
-| 9. Login item | `registerLoginItem:427`, `AppLoginItem.swift:10-11` | `SMAppService.mainApp` | — | Throws → `.failed` |
-| 10. Start agent | `startAgent:429`, `MalibuAgent.start:53-134` | Spawns bundled CLI with `--ctl-socket-path …/agent.sock`, `--managed-by malibu-app`, token via env | WS auth + identity signature | "Not set up yet" / control socket timeout / CLI exit |
-| 11. Live | `waitForFirstServing:432`, `updateState:433` | Sets `first_serving_at` in onboarding.json | — | Timeout: "Timed out waiting for the first serving frame." |
+| Step | Code | Artifacts | Notes |
+|------|------|-----------|-------|
+| 1. Startup route | `StartupState.route()` | config, marker, launchd manifest/plist | Healthy launchd → `.startAgent`; CLI config without marker → import dialog; else onboarding |
+| 2. Migration (if CLI config, no marker) | `importExistingCLIConfig` | Token → Keychain; `.installed-by-app` marker | Same as before |
+| 3. Onboarding | `LaunchProviderController.launchViaCLIInstall` | Runs bundled `install.sh` (`MACPROVIDER_NO_PROMPT=1`) | No V2 register/autotune UI |
+| 4. Finalize | `finalizeInstall` | Login item + `monitorInstalledProviderIfPresent` | Waits for `/v1/health` |
+| 5. Runtime | `MalibuAgent.start()` | Health poll only | **Does not spawn CLI child** |
 
-**State machine:** `Stage` enum `LaunchProviderController.swift:19-30`. **Resume:** `ResumePoint` + `lastStage` in onboarding.json (`307-340`). Crash mid-stage: resume from persisted `lastStage`; identity re-used via `loadOrGenerateIdentity` / `loadExistingIdentity` (`342-370`). **Not recovered:** missing Keychain identity when `isConfigured` still true (see §5).
-
-**V2 flag checks:** `LaunchProviderController.isOnboardingV2Enabled` (`157-173`); `StartupState.detect` (`655`); `StartupState.route` (`675`); `applyMigrationDecision` (`696`). Default **off** unless env or `UserDefaults onboardingFlow=v2`. SPEC-026 v0.12: fresh flag-off shows setup-paused, not browser OAuth.
-
-**Reboot:** `SMAppService` re-launches app → `.startAgent` if configured → `MalibuAgent.start()` spawns new CLI child. No launchd plist in App track.
+**Removed (V2-removed):** identity generation, `POST /v1/providers/register`, in-app autotune, model download stage, control-socket child spawn, `resumeOnboarding` / `setupPaused` routes.
 
 ---
 
-## 4. Overlap + priority map
+## 3b. Onboarding path B — App-track V2 (historical, removed)
+
+<details>
+<summary>Pre-refactor V2 path (reference only)</summary>
+
+| Step | Code | Status |
+|------|------|--------|
+| V2 gate / setup paused | `isOnboardingV2Enabled`, `setupPaused` | **V2-removed** |
+| Register / autotune / model download | `finishLaunch`, `resumePartialOnboarding` | **V2-removed** |
+| Spawn CLI child | `MalibuAgent.start()` spawn path | **V2-removed** |
+
+</details>
+
+---
+
+## 4. Overlap + priority map (post-refactor)
 
 | Artifact | CLI-track | App-track | Source of truth |
 |----------|-----------|-----------|-----------------|
@@ -85,18 +93,18 @@ Fresh Mac, launch `Malibu.app`:
 
 ## 5. UX defect list (code-evidence only)
 
-| # | Defect | Symptom | Evidence | Sev | Fix |
-|---|--------|---------|----------|-----|-----|
-| 1 | `serve_config: null` crashes Malibu JSON decode | Autotune spinner → "Needs retry" with opaque error; M5 32GB Tier C donor-only | `AutotuneRecommend.swift:1150`; `AutotuneServeConfigPayload` non-optional `AutotuneRecommendationRunner.swift:251-247`; no donor branch in `finishLaunch` | **Blocker** | M — nullable decode + donor UX like `install.sh:1274-1295` |
-| 2 | V2 onboarding default-off | Fresh Malibu install: "Setup paused", no earn path | `LaunchProviderController.swift:172`; `StartupState.route:675` | **Blocker** (product) | S — default `v2` in release build |
-| 3 | No identity recovery | Keychain identity missing but config OK: app shows "live"/serving; coordinator identity auth fails silently | `startConfiguredAgent:282-297`; `handleIdentitySignatureRequest:415-421`; no regen UI | **High** | M — detect `!ProviderIdentity.isReady()` + re-register flow |
-| 4 | No launchd coexistence handling | launchd CLI running + Malibu open → second CLI, duplicate provider, RAM waste | No `ProviderConflictDetector` in app; `MalibuAgent.start:56`; SPEC-025 §12 unimplemented | **High** | L — adopt-mode or conflict dialog |
-| 5 | `/tmp` plist not from installer | Reboot kills provider if plist manually points at `/tmp` | `install.sh:1458` uses `$INSTALL_DIR`; operator plist is out-of-tree | **High** (ops) | S — reinstall via install.sh |
-| 6 | Model download stage is no-op | "Preparing recommended" with fake progress | `Dependencies.downloadModel:123` returns `plan.state` | **Medium** | M — wire HF download or skip stage |
-| 7 | CLI uninstall leaves caches + Malibu state | HF cache, `~/.config/macprovider/`, Malibu App Support untouched | `uninstall.sh:112-113`, `185-188`; no Malibu paths | **Medium** | M — cross-track cleanup docs/UI |
-| 8 | Malibu uninstall misses CLI launchd | CLI LaunchAgent keeps running after "Quit and Uninstall" | `wipeAppOwnedState:466-488` — App Support only | **Medium** | M |
-| 9 | Adhoc CLI + launchd on macOS 26+ | `launchctl bootstrap` fails | `install_plist:1445`; pkg path validates Gatekeeper (`1112`) | **High** on unsigned | S — require signed pkg path |
-| 10 | Autotune errors opaque | `.failed` shows `localizedDescription`; `AutotuneRecommendationError` has no messages | `LaunchProviderController.swift:262`; `AutotuneRecommendationError:212-216` | **Low** | S |
+| # | Defect | Status |
+|---|--------|--------|
+| 1 | `serve_config: null` crashes Malibu JSON decode | **V2-removed** |
+| 2 | V2 onboarding default-off / setup paused | **Fixed** — CLI install is only path |
+| 3 | No identity recovery | **V2-removed** (identity path deferred to SPEC-026 P4) |
+| 4 | No launchd coexistence / dual CLI | **Fixed** — monitor-only, no spawn |
+| 5 | `/tmp` plist not from installer | Open (ops) |
+| 6 | Model download stage is no-op | **V2-removed** |
+| 7 | CLI uninstall leaves caches + Malibu state | Open |
+| 8 | Malibu uninstall misses CLI launchd | Open |
+| 9 | Adhoc CLI + launchd on macOS 26+ | Open |
+| 10 | Autotune errors opaque | **V2-removed** |
 
 **Verified:** Backup `Malibu.app.bak-*` is Developer ID + notarized (Superposition YF7XNRJUG4), stapled — enrollment blocker memory superseded.
 


### PR DESCRIPTION
## Summary

- Makes Malibu a thin CLI wrapper: onboarding runs bundled `install.sh`, runtime monitors launchd-managed `macprovider-cli` via `/v1/health` — no in-app register/autotune/spawn-child path.
- Removes V2 onboarding stages, `MalibuOnboardingPolicy`, `resumeOnboarding`/`setupPaused` routes, and ~1,300 lines of dead production code.
- Bugbot follow-up: legacy app-marker configs without launchd now route to onboarding (not an endless reconnect loop); `MalibuAgent` refuses to poll when launchd install evidence is missing.

## Test plan

- [x] `xcodebuild test -scheme Malibu -destination 'platform=macOS'` (all unit tests pass)
- [ ] Fresh Mac: install `Malibu-v1.8.12.dmg`, Launch Provider → verify `install.sh` completes and menu bar shows healthy provider
- [ ] Upgrade path: machine with legacy app-marker config but no launchd → app opens onboarding (not reconnect spinner)
- [ ] Existing launchd install: app attaches on launch without spawning second CLI


Made with [Cursor](https://cursor.com)