### PR TITLE
Prepare provider release v1.8.13

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.12"
+    static let binaryVersion = "1.8.13"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1644,10 +1644,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.12")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.12")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.12")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.12")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.13")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.13")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.13")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.13")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {


### PR DESCRIPTION
## Summary
- Bump binaryVersion to 1.8.13 for release of health-endpoint token counters (PR #420).

## Test plan
- [ ] CI green
- [ ] Trigger Release macprovider-cli workflow with tag v1.8.13 after merge

Made with [Cursor](https://cursor.com)