### PR TITLE
Malibu P1/P2 polish + v1.8.13 release prep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -678,10 +678,11 @@ jobs:
           if [ -f "phase3-binary/app/dist/Malibu-${tag}.dmg" ]; then
             cat >> release-notes.md <<EOF
 
-          **Malibu.app (App-track provider onboarding)** — this release ships a
-          Developer ID-signed, notarized, and stapled \`Malibu-${tag}.dmg\`.
-          Open the disk image, drag Malibu.app to Applications, and launch.
-          First run drives install.sh onboarding with no terminal setup.
+          **Malibu.app (CLI wrapper)** — this release ships a Developer ID-signed,
+          notarized, and stapled \`Malibu-${tag}.dmg\`. Open the disk image, drag
+          Malibu.app to Applications, and launch. First run drives install.sh
+          onboarding with no terminal setup; Malibu monitors the launchd provider.
+          Publish \`latest.dmg\` with \`scripts/publish-malibu-latest-dmg.sh ${tag}\`.
           EOF
           elif [ -f "phase3-binary/app/dist/Malibu-${tag}.pkg" ]; then
             cat >> release-notes.md <<EOF
@@ -718,6 +719,18 @@ jobs:
             --title "macprovider-cli $tag" \
             --notes-file release-notes.md \
             "${release_flags[@]}"
+
+      - name: Publish Malibu latest.dmg
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MALIBU_DOWNLOAD_BUCKET: ${{ secrets.MALIBU_DOWNLOAD_BUCKET }}
+          MALIBU_DOWNLOAD_ENDPOINT: ${{ secrets.MALIBU_DOWNLOAD_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.MALIBU_DOWNLOAD_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MALIBU_DOWNLOAD_AWS_SECRET_ACCESS_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/publish-malibu-latest-dmg.sh "${{ steps.version.outputs.tag }}"
 
       - name: Verify published Tier-2 Release assets
         shell: bash

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.12"
+    static let binaryVersion = "1.8.13"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1644,10 +1644,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.12")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.12")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.12")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.12")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.13")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.13")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.13")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.13")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/app/README.md
+++ b/phase3-binary/app/README.md
@@ -71,4 +71,26 @@ open build/Release/Malibu.app
 2. **CLI-side handler semantics.** Frames + wire format are wired end-to-end (`feat(control-socket): add metrics/pause/resume/shutdown frames`), but the server-side handlers are stubs — `pause_ack`/`resume_ack` return `accepted:false, reason:"not_implemented"` and `metrics_response` returns zeros. Real earnings / uptime source + pause gating land in P1.
 3. **CLI-track config migration dialog.** If `~/.config/macprovider/config.yaml` exists without the App-track marker, the App routes to the SPEC-026 migration surface instead of overwriting it silently.
 5. **Sparkle** not wired up yet — separate P3 pass.
-6. **Signed release pipeline** — `release.yml` ships stapled `Malibu-{tag}.dmg` (primary) and optional `Malibu-{tag}.pkg`. Validate downloads with `scripts/verify-malibu-release-artifacts.sh`.
+6. **Signed release pipeline** — `release.yml` ships stapled `Malibu-{tag}.dmg` (primary) and optional `Malibu-{tag}.pkg`. Validate downloads with `scripts/verify-malibu-release-artifacts.sh`. Publish `latest.dmg` with `scripts/publish-malibu-latest-dmg.sh` after tagging.
+
+## Uninstall (Malibu + CLI)
+
+Malibu **Quit and Uninstall** runs, in order:
+
+1. `macprovider-cli uninstall --yes` (stops launchd, removes CLI binary/plists/manifest)
+2. Malibu login item unregister
+3. App Keychain slots + App Support wipe
+
+CLI-only uninstall remains:
+
+```bash
+bash <(curl -fsSL https://get.streamvc.live/uninstall.sh)
+# or
+macprovider-cli uninstall --yes
+```
+
+CLI uninstall does **not** remove `~/Library/Application Support/Malibu` or Malibu Keychain tokens — use Malibu uninstall or delete App Support manually.
+
+Malibu uninstall does **not** remove Hugging Face model caches (`~/.cache/huggingface/`) — same as CLI uninstall.
+
+Fresh-Mac validation checklist: `scratchpad/fresh-mac-smoke-v1.8.13.md`.

--- a/phase3-binary/app/Sources/Malibu/MalibuApp.swift
+++ b/phase3-binary/app/Sources/Malibu/MalibuApp.swift
@@ -184,11 +184,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // request termination ourselves.
     private func performUninstall() async {
         await agent.shutdown(gracefulSeconds: 30)
+        let cliTeardown = await CLIInstallTeardown.uninstallBackgroundProvider()
         let unregisterFailure = await AppLoginItem.unregisterReturningError()
         // SPEC-026 §6.5: also wipe the Ed25519 identity Keychain slot.
         do { try await ProviderIdentity.deleteFromKeychain() }
         catch { NSLog("[malibu] provider identity delete failed: %@", error.localizedDescription) }
-        let residue = await ProviderConfig.wipeAppOwnedState()
+        var residue = await ProviderConfig.wipeAppOwnedState()
+        residue.cliUninstallWarnings = cliTeardown.warnings
 
         if !residue.clean || unregisterFailure != nil {
             self.presentUninstallResidue(residue, loginItem: unregisterFailure)
@@ -210,6 +212,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let e = residue.appSupportRemoveFailed { bullets.append("App Support: \(e.localizedDescription)") }
         if let e = residue.keychainDeleteFailed { bullets.append("Keychain: \(e.localizedDescription)") }
         if let e = loginItem { bullets.append("Login item: \(e.localizedDescription)") }
+        for warning in residue.cliUninstallWarnings {
+            bullets.append("Background provider: \(warning)")
+        }
         let alert = NSAlert()
         alert.messageText = "Uninstall finished with residue"
         alert.informativeText = bullets.isEmpty

--- a/phase3-binary/app/Sources/Malibu/System/CLIInstallTeardown.swift
+++ b/phase3-binary/app/Sources/Malibu/System/CLIInstallTeardown.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Stops the launchd-managed CLI install that Malibu onboarding created via install.sh.
+enum CLIInstallTeardown {
+    struct Result: Equatable {
+        var warnings: [String]
+        var succeeded: Bool { warnings.isEmpty }
+    }
+
+    @MainActor
+    static func uninstallBackgroundProvider(
+        perform: (@MainActor () async throws -> Void)? = nil
+    ) async -> Result {
+        do {
+            if let perform {
+                try await perform()
+            } else {
+                let cliURL = try MalibuAgent.resolveCLIExecutable()
+                try await runBundledUninstall(cliURL: cliURL)
+            }
+            return Result(warnings: [])
+        } catch {
+            return Result(warnings: ["CLI uninstall failed: \(error.localizedDescription)"])
+        }
+    }
+
+    @MainActor
+    private static func runBundledUninstall(cliURL: URL) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: .utility).async {
+                let process = Process()
+                let stderr = Pipe()
+                process.executableURL = cliURL
+                process.arguments = ["uninstall", "--yes"]
+                process.environment = try? ProcessEnvironmentSanitizer.sanitized(
+                    from: ProcessInfo.processInfo.environment
+                )
+                process.standardOutput = FileHandle.nullDevice
+                process.standardError = stderr
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    if process.terminationStatus == 0 {
+                        continuation.resume()
+                        return
+                    }
+                    let errData = stderr.fileHandleForReading.readDataToEndOfFile()
+                    let message = String(data: errData, encoding: .utf8)?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    continuation.resume(
+                        throwing: NSError(
+                            domain: "Malibu.CLIInstallTeardown",
+                            code: Int(process.terminationStatus),
+                            userInfo: [
+                                NSLocalizedDescriptionKey: message?.isEmpty == false
+                                    ? message!
+                                    : "macprovider-cli uninstall exited \(process.terminationStatus)"
+                            ]
+                        )
+                    )
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
@@ -473,8 +473,12 @@ enum ProviderConfig {
         var configRemoveFailed: Error?
         var appSupportRemoveFailed: Error?
         var keychainDeleteFailed: Error?
+        var cliUninstallWarnings: [String] = []
         var clean: Bool {
-            configRemoveFailed == nil && appSupportRemoveFailed == nil && keychainDeleteFailed == nil
+            configRemoveFailed == nil
+                && appSupportRemoveFailed == nil
+                && keychainDeleteFailed == nil
+                && cliUninstallWarnings.isEmpty
         }
     }
 

--- a/phase3-binary/app/Tests/MalibuTests/CLIInstallTeardownTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/CLIInstallTeardownTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import Malibu
+
+@MainActor
+final class CLIInstallTeardownTests: XCTestCase {
+    func testUninstallReturnsWarningWhenRunnerFails() async {
+        let result = await CLIInstallTeardown.uninstallBackgroundProvider {
+            throw NSError(domain: "tests", code: 1, userInfo: [NSLocalizedDescriptionKey: "boom"])
+        }
+        XCTAssertFalse(result.succeeded)
+        XCTAssertEqual(result.warnings, ["CLI uninstall failed: boom"])
+    }
+
+    func testUninstallSucceedsWhenRunnerCompletes() async {
+        let result = await CLIInstallTeardown.uninstallBackgroundProvider {}
+        XCTAssertTrue(result.succeeded)
+        XCTAssertTrue(result.warnings.isEmpty)
+    }
+}

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -22,8 +22,8 @@ settings:
     SWIFT_VERSION: "5.9"
     ENABLE_HARDENED_RUNTIME: YES
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "0.1.0"
-    CURRENT_PROJECT_VERSION: "1"
+    MARKETING_VERSION: "1.8.13"
+    CURRENT_PROJECT_VERSION: "13"
     OTHER_SWIFT_FLAGS: "-strict-concurrency=complete"
 
 targets:

--- a/scratchpad/fresh-mac-smoke-v1.8.13.md
+++ b/scratchpad/fresh-mac-smoke-v1.8.13.md
@@ -1,0 +1,40 @@
+# Fresh-Mac smoke — Malibu v1.8.13
+
+Run on a Mac that has **never** had macprovider or Malibu installed. Check each box before calling P1 exit.
+
+## Download
+
+- [ ] Open `https://download.malibu.tech/latest.dmg` (or GitHub Release `Malibu-v1.8.13.dmg` if redirect not wired yet)
+- [ ] Verify SHA-256 sidecar if published (`Malibu-v1.8.13.dmg.sha256`)
+- [ ] Gatekeeper: double-click DMG, drag to Applications — no “damaged” / AMFI block
+- [ ] `bash scripts/verify-malibu-release-artifacts.sh Malibu-v1.8.13.dmg` passes on a dev Mac with stapler
+
+## First launch
+
+- [ ] Launch Malibu from Applications — menu bar icon appears (no Dock icon)
+- [ ] Onboarding window opens automatically on fresh Mac
+- [ ] Click **Launch Provider** — install log streams (autotune can take 10–30 min)
+- [ ] On success: “Provider live” + **Open Dashboard**
+- [ ] Menu bar shows serving state (not Idle / reconnect loop)
+
+## Background provider
+
+- [ ] `launchctl list | rg macprovider` shows `live.streamvc.macprovider` with PID
+- [ ] `curl -s http://127.0.0.1:$(grep '^port:' ~/.config/macprovider/config.yaml | awk '{print $2}')/v1/health` → `"status":"ready"` (after model load)
+- [ ] `curl -s "https://coordinator.streamvc.live/v1/pool/check?provider_id=$(cat ~/.config/macprovider/provider_id)"` → `"state":"ready"`
+
+## Reboot
+
+- [ ] Reboot Mac — provider comes back without opening Malibu
+- [ ] Re-open Malibu — attaches to launchd provider (no second CLI process)
+
+## Uninstall (cross-track)
+
+- [ ] Menu bar → **Quit and Uninstall**
+- [ ] `launchctl list | rg macprovider` empty
+- [ ] `~/macprovider/macprovider-cli` removed (or manifest gone)
+- [ ] `~/Library/Application Support/Malibu` removed
+
+## Notes
+
+Record Mac model, RAM, macOS version, wall-clock install time, and any failure screenshots in the friend-test thread.

--- a/scripts/publish-malibu-latest-dmg.sh
+++ b/scripts/publish-malibu-latest-dmg.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Publish Malibu-{tag}.dmg to the download.malibu.tech bucket and refresh latest.dmg.
+#
+# Requires operator credentials for the object store backing download.malibu.tech.
+# Example (Cloudflare R2 via awscli-compatible endpoint):
+#
+#   export MALIBU_DOWNLOAD_ENDPOINT="https://<account>.r2.cloudflarestorage.com"
+#   export MALIBU_DOWNLOAD_BUCKET="malibu-download"
+#   export AWS_ACCESS_KEY_ID=...
+#   export AWS_SECRET_ACCESS_KEY=...
+#   bash scripts/publish-malibu-latest-dmg.sh v1.8.13
+#
+# Without object-store credentials this script prints the GitHub Release URL to
+# wire manually in Cloudflare (redirect latest.dmg → versioned asset).
+
+set -euo pipefail
+
+die() {
+  printf '[publish-malibu-latest-dmg] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+tag="${1:-}"
+[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "usage: $0 vX.Y.Z"
+
+repo="${GITHUB_REPOSITORY:-Augustas11/macprovider}"
+dmg_name="Malibu-${tag}.dmg"
+versioned_key="Malibu-${tag}.dmg"
+latest_key="latest.dmg"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/malibu-publish.XXXXXX")"
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+gh release download "$tag" \
+  --repo "$repo" \
+  --pattern "$dmg_name" \
+  --dir "$work" \
+  --clobber
+
+asset="$work/$dmg_name"
+[[ -f "$asset" ]] || die "release asset missing: $dmg_name"
+
+sha256="$(shasum -a 256 "$asset" | awk '{print $1}')"
+printf '%s  %s\n' "$sha256" "$dmg_name" > "$work/${dmg_name}.sha256"
+
+if [[ -z "${MALIBU_DOWNLOAD_BUCKET:-}" ]]; then
+  cat <<EOF
+[publish-malibu-latest-dmg] No MALIBU_DOWNLOAD_BUCKET set — manual step required.
+
+1. Upload $dmg_name to download.malibu.tech as:
+     $versioned_key
+     SHA-256: $sha256
+2. Point https://download.malibu.tech/latest.dmg at that object (redirect or copy).
+3. GitHub Release asset (fallback):
+     https://github.com/$repo/releases/download/$tag/$dmg_name
+EOF
+  exit 0
+fi
+
+command -v aws >/dev/null 2>&1 || die "aws CLI required when MALIBU_DOWNLOAD_BUCKET is set"
+
+aws_args=()
+if [[ -n "${MALIBU_DOWNLOAD_ENDPOINT:-}" ]]; then
+  aws_args+=(--endpoint-url "$MALIBU_DOWNLOAD_ENDPOINT")
+fi
+
+aws s3 cp "$asset" "s3://${MALIBU_DOWNLOAD_BUCKET}/${versioned_key}" "${aws_args[@]}"
+aws s3 cp "$asset" "s3://${MALIBU_DOWNLOAD_BUCKET}/${latest_key}" "${aws_args[@]}"
+aws s3 cp "$work/${dmg_name}.sha256" "s3://${MALIBU_DOWNLOAD_BUCKET}/${dmg_name}.sha256" "${aws_args[@]}"
+
+printf '[publish-malibu-latest-dmg] ok: s3://%s/%s and latest.dmg (sha256=%s)\n' \
+  "$MALIBU_DOWNLOAD_BUCKET" "$versioned_key" "$sha256"


### PR DESCRIPTION
## Summary

- **Uninstall stops launchd**: Quit-and-Uninstall runs macprovider-cli uninstall --yes before wiping Malibu App Support/Keychain (fixes audit item #8).
- **Version bump**: binaryVersion and Malibu MARKETING_VERSION to 1.8.13 (no v1.8.13 tag exists yet; latest release is v1.8.12).
- **download.malibu.tech/latest.dmg**: adds scripts/publish-malibu-latest-dmg.sh plus release workflow step (uploads when MALIBU_DOWNLOAD_* secrets are set; otherwise prints manual operator steps).
- **Docs**: cross-track uninstall notes in phase3-binary/app/README.md; fresh-Mac smoke checklist at scratchpad/fresh-mac-smoke-v1.8.13.md.

## After merge — cut release

    git checkout main && git pull
    git tag v1.8.13 && git push origin v1.8.13

GHA release.yml will build/sign Malibu-v1.8.13.dmg and CLI artifacts.

## Test plan

- [x] xcodebuild test -scheme Malibu
- [x] swift test --filter CoordinatorClientTests
- [ ] Fresh-Mac smoke on second machine (scratchpad/fresh-mac-smoke-v1.8.13.md) — operator
- [ ] Friend group install test — operator (DM sent)
