### PR TITLE
Persist provider-scoped dashboard stats across CLI restarts

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -1082,6 +1082,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
             "model_loaded": snapshot.modelLoaded,
             "uptime_s": snapshot.uptimeSeconds,
             "requests_total": snapshot.requestsTotal,
+            "requests_today": snapshot.requestsToday,
             "input_tokens_today": snapshot.inputTokensToday,
             "output_tokens_today": snapshot.outputTokensToday,
             "input_tokens_all_time": snapshot.inputTokensAllTime,
@@ -1089,6 +1090,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
             "requests_in_flight": snapshot.requestsInFlight,
             "requests_queued": snapshot.requestsQueued,
             "errors_total": snapshot.errorsTotal,
+            "restart_count": snapshot.restartCount,
             "memory_rss_mb": snapshot.memoryRSSMB,
             "capacity": [
                 "ram_gb": snapshot.capacity.ramGB,
@@ -1173,6 +1175,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
             "model_loaded": effectiveModelLoaded,
             "uptime_s": snapshot.uptimeSeconds,
             "requests_total": snapshot.requestsTotal,
+            "requests_today": snapshot.requestsToday,
             "input_tokens_today": snapshot.inputTokensToday,
             "output_tokens_today": snapshot.outputTokensToday,
             "input_tokens_all_time": snapshot.inputTokensAllTime,
@@ -1180,6 +1183,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
             "requests_in_flight": snapshot.requestsInFlight,
             "active_request_id_count": snapshot.activeRequestIDCount,
             "errors_total": snapshot.errorsTotal,
+            "restart_count": snapshot.restartCount,
             "memory_rss_mb": snapshot.memoryRSSMB,
             "capacity": [
                 "ram_gb": snapshot.capacity.ramGB,

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -490,7 +490,8 @@ struct ServeCommand: AsyncParsableCommand {
             modelHash: await modelRuntime.loadedModelHash,
             thermalGate: thermalGate,
             specDecodeDraftModelID: resolved.draftModel,
-            specDecodeNumDraftTokens: resolved.numDraftTokens
+            specDecodeNumDraftTokens: resolved.numDraftTokens,
+            providerID: resolved.providerID
         )
         await modelRuntime.setProviderStatus(providerStatus)
         let idlePrewarmer = IdlePrewarmer(

--- a/phase3-binary/Sources/macprovider-cli/ProviderStatsStore.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderStatsStore.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Durable per-`provider_id` request/token counters for dashboard UX.
+/// Survives CLI restarts; lives under Application Support alongside install manifest.
+struct ProviderStatsRecord: Codable, Equatable {
+    static let currentVersion = 1
+
+    var version: Int
+    var providerID: String
+    var requestsTotal: Int
+    var requestsToday: Int
+    var requestsTodayDayStart: Date
+    var inputTokensToday: Int64
+    var outputTokensToday: Int64
+    var inputTokensAllTime: Int64
+    var outputTokensAllTime: Int64
+    var errorsTotal: Int
+    var restartCount: Int
+    var updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case providerID = "provider_id"
+        case requestsTotal = "requests_total"
+        case requestsToday = "requests_today"
+        case requestsTodayDayStart = "requests_today_day_start"
+        case inputTokensToday = "input_tokens_today"
+        case outputTokensToday = "output_tokens_today"
+        case inputTokensAllTime = "input_tokens_all_time"
+        case outputTokensAllTime = "output_tokens_all_time"
+        case errorsTotal = "errors_total"
+        case restartCount = "restart_count"
+        case updatedAt = "updated_at"
+    }
+
+    static func empty(providerID: String, now: Date = Date()) -> ProviderStatsRecord {
+        ProviderStatsRecord(
+            version: currentVersion,
+            providerID: providerID,
+            requestsTotal: 0,
+            requestsToday: 0,
+            requestsTodayDayStart: Calendar.current.startOfDay(for: now),
+            inputTokensToday: 0,
+            outputTokensToday: 0,
+            inputTokensAllTime: 0,
+            outputTokensAllTime: 0,
+            errorsTotal: 0,
+            restartCount: 0,
+            updatedAt: now
+        )
+    }
+}
+
+struct ProviderStatsStore: Sendable {
+    private let fileURL: URL
+    private let fileManager: FileManager
+
+    init(providerID: String, home: URL = FileManager.default.homeDirectoryForCurrentUser, fileManager: FileManager = .default) {
+        let safeID = Self.sanitizeProviderID(providerID)
+        let base = home
+            .appendingPathComponent("Library/Application Support/macprovider/stats", isDirectory: true)
+        self.fileURL = base.appendingPathComponent("\(safeID).json", isDirectory: false)
+        self.fileManager = fileManager
+    }
+
+    init(fileURL: URL, fileManager: FileManager = .default) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load(now: Date = Date()) -> ProviderStatsRecord? {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return nil }
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let record = try decoder.decode(ProviderStatsRecord.self, from: data)
+            guard record.version == ProviderStatsRecord.currentVersion else { return nil }
+            return record
+        } catch {
+            return nil
+        }
+    }
+
+    func save(_ record: ProviderStatsRecord) {
+        do {
+            let directory = fileURL.deletingLastPathComponent()
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(record)
+            let tempURL = fileURL.appendingPathExtension("tmp")
+            try data.write(to: tempURL, options: .atomic)
+            _ = try fileManager.replaceItemAt(fileURL, withItemAt: tempURL)
+        } catch {
+            // Stats persistence must never block serving.
+        }
+    }
+
+    static func sanitizeProviderID(_ providerID: String) -> String {
+        let trimmed = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "unknown" }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+        let scalars = trimmed.unicodeScalars.map { allowed.contains($0) ? Character($0) : "_" }
+        return String(scalars)
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/ProviderStatus.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderStatus.swift
@@ -104,6 +104,7 @@ struct ProviderSnapshot: Sendable {
     let modelLoaded: Bool
     let uptimeSeconds: Int
     let requestsTotal: Int
+    let requestsToday: Int
     let inputTokensToday: Int64
     let outputTokensToday: Int64
     let inputTokensAllTime: Int64
@@ -111,6 +112,7 @@ struct ProviderSnapshot: Sendable {
     let requestsInFlight: Int
     let requestsQueued: Int
     let errorsTotal: Int
+    let restartCount: Int
     let memoryRSSMB: Int
     let capacity: ProviderCapacity
     let requestsServedSinceLast: Int
@@ -150,7 +152,10 @@ actor ProviderStatus {
     private var capacity: ProviderCapacity
     private var status: ProviderHealthState
     private var requestsTotal = 0
+    private var requestsToday = 0
     private var tokensTodayDayStart = Calendar.current.startOfDay(for: Date())
+    private let statsStore: ProviderStatsStore?
+    private let persistedProviderID: String?
     private var inputTokensToday: Int64 = 0
     private var outputTokensToday: Int64 = 0
     private var inputTokensAllTime: Int64 = 0
@@ -158,6 +163,7 @@ actor ProviderStatus {
     private var requestsInFlight = 0
     private var requestsQueued = 0
     private var errorsTotal = 0
+    private var restartCount = 0
     private var windowRequests = 0
     private var windowLatencyMS = 0.0
     private var windowCompletionTokens = 0
@@ -185,7 +191,9 @@ actor ProviderStatus {
         modelHash: String? = nil,
         thermalGate: ThermalGate? = nil,
         specDecodeDraftModelID: String? = nil,
-        specDecodeNumDraftTokens: Int? = nil
+        specDecodeNumDraftTokens: Int? = nil,
+        providerID: String? = nil,
+        statsStore: ProviderStatsStore? = nil
     ) {
         self.modelID = modelID
         self.modelHash = modelHash
@@ -196,6 +204,15 @@ actor ProviderStatus {
         self.specDecodeEnabled = modelLoaded && specDecodeDraftModelID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         self.specDecodeDraftModelID = Self.publicSpecDecodeDraftModelID(specDecodeDraftModelID)
         self.specDecodeNumDraftTokens = self.specDecodeEnabled ? specDecodeNumDraftTokens : nil
+        let trimmedProviderID = providerID?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedProviderID, !trimmedProviderID.isEmpty {
+            persistedProviderID = trimmedProviderID
+            self.statsStore = statsStore ?? ProviderStatsStore(providerID: trimmedProviderID)
+            bootstrapPersistedStats()
+        } else {
+            persistedProviderID = nil
+            self.statsStore = nil
+        }
     }
 
     func beginRequest(requestID: String? = nil) -> Date {
@@ -214,7 +231,9 @@ actor ProviderStatus {
         if let requestID {
             activeRequestIDs.remove(requestID)
         }
+        rolloverDayCountersIfNeeded()
         requestsTotal += 1
+        requestsToday += 1
         if failed {
             errorsTotal += 1
         }
@@ -235,6 +254,7 @@ actor ProviderStatus {
             )
         }
         refreshAvailabilityState()
+        persistStats()
     }
 
     func currentSpecDecodeGeneration() -> Int {
@@ -273,6 +293,7 @@ actor ProviderStatus {
 
     func recordError() {
         errorsTotal += 1
+        persistStats()
     }
 
     func noteRealRequestStart() {
@@ -317,7 +338,7 @@ actor ProviderStatus {
     }
 
     func snapshot(resetWindow: Bool = false) async -> ProviderSnapshot {
-        rolloverTokensTodayIfNeeded()
+        rolloverDayCountersIfNeeded()
         // Resolve thermal state BEFORE reading any actor-isolated mutable
         // state. Actors are reentrant across `await`, so a `finishRequest`
         // running during the suspension could mutate `windowRequests` and
@@ -336,6 +357,7 @@ actor ProviderStatus {
             modelLoaded: modelLoaded,
             uptimeSeconds: Int(Date().timeIntervalSince(startedAt)),
             requestsTotal: requestsTotal,
+            requestsToday: requestsToday,
             inputTokensToday: inputTokensToday,
             outputTokensToday: outputTokensToday,
             inputTokensAllTime: inputTokensAllTime,
@@ -343,6 +365,7 @@ actor ProviderStatus {
             requestsInFlight: requestsInFlight,
             requestsQueued: requestsQueued,
             errorsTotal: errorsTotal,
+            restartCount: restartCount,
             memoryRSSMB: Self.memoryRSSMB(),
             capacity: capacity,
             requestsServedSinceLast: windowRequests,
@@ -393,16 +416,17 @@ actor ProviderStatus {
         status = requestsInFlight >= capacity.maxConcurrency ? .busy : .ready
     }
 
-    private func rolloverTokensTodayIfNeeded(now: Date = Date()) {
+    private func rolloverDayCountersIfNeeded(now: Date = Date()) {
         let dayStart = Calendar.current.startOfDay(for: now)
         guard dayStart > tokensTodayDayStart else { return }
         tokensTodayDayStart = dayStart
+        requestsToday = 0
         inputTokensToday = 0
         outputTokensToday = 0
     }
 
     private func recordTokenUsage(promptTokens: Int, completionTokens: Int) {
-        rolloverTokensTodayIfNeeded()
+        rolloverDayCountersIfNeeded()
         let input = Int64(max(0, promptTokens))
         let output = Int64(max(0, completionTokens))
         inputTokensToday += input
@@ -432,6 +456,50 @@ actor ProviderStatus {
         let digest = SHA256.hash(data: Data(canonical.utf8))
         let prefix = digest.map { String(format: "%02x", $0) }.joined().prefix(32)
         return "local:\(prefix)"
+    }
+
+    private func bootstrapPersistedStats() {
+        guard let statsStore, let persistedProviderID else { return }
+        if let record = statsStore.load(), record.providerID == persistedProviderID {
+            applyLoadedStats(record)
+            restartCount = record.restartCount + 1
+        } else {
+            restartCount = 0
+        }
+        persistStats()
+    }
+
+    private func applyLoadedStats(_ record: ProviderStatsRecord) {
+        requestsTotal = max(0, record.requestsTotal)
+        requestsToday = max(0, record.requestsToday)
+        tokensTodayDayStart = record.requestsTodayDayStart
+        inputTokensToday = max(0, record.inputTokensToday)
+        outputTokensToday = max(0, record.outputTokensToday)
+        inputTokensAllTime = max(0, record.inputTokensAllTime)
+        outputTokensAllTime = max(0, record.outputTokensAllTime)
+        errorsTotal = max(0, record.errorsTotal)
+        rolloverDayCountersIfNeeded()
+    }
+
+    private func persistStats(now: Date = Date()) {
+        guard let statsStore, let persistedProviderID else { return }
+        rolloverDayCountersIfNeeded(now: now)
+        statsStore.save(
+            ProviderStatsRecord(
+                version: ProviderStatsRecord.currentVersion,
+                providerID: persistedProviderID,
+                requestsTotal: requestsTotal,
+                requestsToday: requestsToday,
+                requestsTodayDayStart: tokensTodayDayStart,
+                inputTokensToday: inputTokensToday,
+                outputTokensToday: outputTokensToday,
+                inputTokensAllTime: inputTokensAllTime,
+                outputTokensAllTime: outputTokensAllTime,
+                errorsTotal: errorsTotal,
+                restartCount: restartCount,
+                updatedAt: now
+            )
+        )
     }
 
     private static func isPublicHuggingFaceModelID(_ value: String) -> Bool {

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderStatsStoreTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderStatsStoreTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class ProviderStatsStoreTests: XCTestCase {
+    func testSaveAndLoadRoundTrip() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let fileURL = directory.appendingPathComponent("mac.json")
+        let store = ProviderStatsStore(fileURL: fileURL)
+        let dayStart = Calendar.current.startOfDay(for: Date())
+        let record = ProviderStatsRecord(
+            version: ProviderStatsRecord.currentVersion,
+            providerID: "mac",
+            requestsTotal: 42,
+            requestsToday: 3,
+            requestsTodayDayStart: dayStart,
+            inputTokensToday: 100,
+            outputTokensToday: 200,
+            inputTokensAllTime: 1_000,
+            outputTokensAllTime: 2_000,
+            errorsTotal: 1,
+            restartCount: 2,
+            updatedAt: Date()
+        )
+
+        store.save(record)
+        let loaded = try XCTUnwrap(store.load())
+
+        XCTAssertEqual(loaded.version, record.version)
+        XCTAssertEqual(loaded.providerID, record.providerID)
+        XCTAssertEqual(loaded.requestsTotal, record.requestsTotal)
+        XCTAssertEqual(loaded.requestsToday, record.requestsToday)
+        XCTAssertEqual(loaded.requestsTodayDayStart, record.requestsTodayDayStart)
+        XCTAssertEqual(loaded.inputTokensToday, record.inputTokensToday)
+        XCTAssertEqual(loaded.outputTokensToday, record.outputTokensToday)
+        XCTAssertEqual(loaded.inputTokensAllTime, record.inputTokensAllTime)
+        XCTAssertEqual(loaded.outputTokensAllTime, record.outputTokensAllTime)
+        XCTAssertEqual(loaded.errorsTotal, record.errorsTotal)
+        XCTAssertEqual(loaded.restartCount, record.restartCount)
+    }
+
+    func testSanitizeProviderID() {
+        XCTAssertEqual(ProviderStatsStore.sanitizeProviderID("p_upiv4dug"), "p_upiv4dug")
+        XCTAssertEqual(ProviderStatsStore.sanitizeProviderID("bad/id"), "bad_id")
+        XCTAssertEqual(ProviderStatsStore.sanitizeProviderID("   "), "unknown")
+    }
+}
+
+final class ProviderStatsPersistenceTests: XCTestCase {
+    func testProviderStatusRestoresAndPersistsAcrossActorInstances() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let fileURL = directory.appendingPathComponent("mac.json")
+        let store = ProviderStatsStore(fileURL: fileURL)
+
+        let first = ProviderStatus(
+            modelID: "m",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 4_000, maxConcurrencyOverride: 1),
+            providerID: "mac",
+            statsStore: store
+        )
+        let startedAt = await first.beginRequest(requestID: "r-1")
+        await first.finishRequest(
+            startedAt: startedAt,
+            completion: CompletionResult(content: "ok", finishReason: "stop", promptTokens: 1, completionTokens: 2),
+            failed: false,
+            requestID: "r-1"
+        )
+
+        let reloaded = ProviderStatus(
+            modelID: "m",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 4_000, maxConcurrencyOverride: 1),
+            providerID: "mac",
+            statsStore: store
+        )
+        let snap = await reloaded.snapshot()
+        XCTAssertEqual(snap.requestsTotal, 1)
+        XCTAssertEqual(snap.requestsToday, 1)
+        XCTAssertEqual(snap.restartCount, 1)
+        XCTAssertEqual(snap.inputTokensAllTime, 1)
+        XCTAssertEqual(snap.outputTokensAllTime, 2)
+    }
+
+    func testProviderStatusIncrementsRestartCountOnEachServeStart() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let fileURL = directory.appendingPathComponent("mac.json")
+        let store = ProviderStatsStore(fileURL: fileURL)
+
+        _ = ProviderStatus(
+            modelID: "m",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 4_000, maxConcurrencyOverride: 1),
+            providerID: "mac",
+            statsStore: store
+        )
+        let second = ProviderStatus(
+            modelID: "m",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 4_000, maxConcurrencyOverride: 1),
+            providerID: "mac",
+            statsStore: store
+        )
+        let snap = await second.snapshot()
+        XCTAssertEqual(snap.restartCount, 1)
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -40,6 +40,7 @@ final class MalibuAgent: ObservableObject {
     private var isShuttingDown: Bool = false
     private var healthPollTask: Task<Void, Never>?
     private var monitorsLaunchdProvider = false
+    private var lastRequestsRateSample: (total: Int, date: Date)?
 
     init() {
         thermalMonitor.$state
@@ -114,6 +115,7 @@ final class MalibuAgent: ObservableObject {
         reconnectTask?.cancel(); reconnectTask = nil
         healthPollTask?.cancel(); healthPollTask = nil
         monitorsLaunchdProvider = false
+        lastRequestsRateSample = nil
         child?.markStopping()
 
         try? await control?.send(.shutdownRequest(graceSeconds: gracefulSeconds))
@@ -186,6 +188,10 @@ final class MalibuAgent: ObservableObject {
         }
         if let total = health.requestsTotal {
             snapshot.requestsServedAllTime = total
+            updateRequestsPerMinute(from: total)
+        }
+        if let today = health.requestsToday {
+            snapshot.requestsServedToday = today
         }
         if let inputToday = health.inputTokensToday {
             snapshot.inputTokensToday = inputToday
@@ -202,12 +208,28 @@ final class MalibuAgent: ObservableObject {
         if let uptime = health.uptimeSeconds {
             snapshot.uptimeSec = uptime
         }
+        if let restarts = health.restartCount {
+            snapshot.restartCount = restarts
+        }
         if health.ready {
             snapshot.state = .serving
         }
     }
 
+    private func updateRequestsPerMinute(from total: Int) {
+        let now = Date()
+        if let last = lastRequestsRateSample {
+            let elapsedMinutes = now.timeIntervalSince(last.date) / 60.0
+            if elapsedMinutes > 0 {
+                let delta = max(0, total - last.total)
+                snapshot.requestsPerMinute = Double(delta) / elapsedMinutes
+            }
+        }
+        lastRequestsRateSample = (total, now)
+    }
+
     private func startHealthPolling(port: Int) {
+        lastRequestsRateSample = nil
         healthPollTask?.cancel()
         healthPollTask = Task { [weak self] in
             while !Task.isCancelled {

--- a/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
+++ b/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
@@ -6,11 +6,13 @@ enum InstalledProviderMonitor {
         let ready: Bool
         let model: String?
         let requestsTotal: Int?
+        let requestsToday: Int?
         let inputTokensToday: Int64?
         let outputTokensToday: Int64?
         let inputTokensAllTime: Int64?
         let outputTokensAllTime: Int64?
         let uptimeSeconds: Int?
+        let restartCount: Int?
     }
 
     static func readHTTPPort(paths: ProviderPaths = .current) -> Int? {
@@ -38,20 +40,24 @@ enum InstalledProviderMonitor {
             let status = object["status"] as? String
             let model = object["model"] as? String
             let requestsTotal = object["requests_total"] as? Int
+            let requestsToday = object["requests_today"] as? Int
             let inputTokensToday = int64Value(object["input_tokens_today"])
             let outputTokensToday = int64Value(object["output_tokens_today"])
             let inputTokensAllTime = int64Value(object["input_tokens_all_time"])
             let outputTokensAllTime = int64Value(object["output_tokens_all_time"])
             let uptimeSeconds = object["uptime_s"] as? Int
+            let restartCount = object["restart_count"] as? Int
             return HealthSnapshot(
                 ready: status == "ready",
                 model: model,
                 requestsTotal: requestsTotal,
+                requestsToday: requestsToday,
                 inputTokensToday: inputTokensToday,
                 outputTokensToday: outputTokensToday,
                 inputTokensAllTime: inputTokensAllTime,
                 outputTokensAllTime: outputTokensAllTime,
-                uptimeSeconds: uptimeSeconds
+                uptimeSeconds: uptimeSeconds,
+                restartCount: restartCount
             )
         } catch {
             return nil

--- a/phase3-binary/app/Tests/MalibuTests/InstalledProviderMonitorTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/InstalledProviderMonitorTests.swift
@@ -8,11 +8,13 @@ final class InstalledProviderMonitorTests: XCTestCase {
           "status": "ready",
           "model": "qwen3-coder-30b-a3b-instruct",
           "requests_total": 4,
+          "requests_today": 2,
           "input_tokens_today": 766,
           "output_tokens_today": 1325,
           "input_tokens_all_time": 766,
           "output_tokens_all_time": 1325,
-          "uptime_s": 4713
+          "uptime_s": 4713,
+          "restart_count": 5
         }
         """.data(using: .utf8)!
         let object = try JSONSerialization.jsonObject(with: json) as! [String: Any]
@@ -20,25 +22,31 @@ final class InstalledProviderMonitorTests: XCTestCase {
         let status = object["status"] as? String
         let model = object["model"] as? String
         let requestsTotal = object["requests_total"] as? Int
+        let requestsToday = object["requests_today"] as? Int
         let inputTokensToday = Self.int64Value(object["input_tokens_today"])
         let outputTokensToday = Self.int64Value(object["output_tokens_today"])
         let inputTokensAllTime = Self.int64Value(object["input_tokens_all_time"])
         let outputTokensAllTime = Self.int64Value(object["output_tokens_all_time"])
         let uptimeSeconds = object["uptime_s"] as? Int
+        let restartCount = object["restart_count"] as? Int
 
         let snapshot = InstalledProviderMonitor.HealthSnapshot(
             ready: status == "ready",
             model: model,
             requestsTotal: requestsTotal,
+            requestsToday: requestsToday,
             inputTokensToday: inputTokensToday,
             outputTokensToday: outputTokensToday,
             inputTokensAllTime: inputTokensAllTime,
             outputTokensAllTime: outputTokensAllTime,
-            uptimeSeconds: uptimeSeconds
+            uptimeSeconds: uptimeSeconds,
+            restartCount: restartCount
         )
 
         XCTAssertTrue(snapshot.ready)
         XCTAssertEqual(snapshot.requestsTotal, 4)
+        XCTAssertEqual(snapshot.requestsToday, 2)
+        XCTAssertEqual(snapshot.restartCount, 5)
         XCTAssertEqual(snapshot.inputTokensToday, 766)
         XCTAssertEqual(snapshot.outputTokensToday, 1325)
         XCTAssertEqual(snapshot.inputTokensAllTime, 766)


### PR DESCRIPTION
## Summary

- Persist per-`provider_id` stats in `~/Library/Application Support/macprovider/stats/{id}.json`: requests (today/all-time), tokens (in/out today/all-time), errors, and restart count.
- CLI loads on `serve` start, saves after each completed request; `/v1/health` exposes `requests_today` and `restart_count`.
- Malibu launchd monitor reads persisted health fields and computes req/min from 15s poll deltas.

## Test plan

- [x] `swift test --filter ProviderStatsStoreTests`
- [x] `swift test --filter ProviderStatusTests`
- [ ] CI green
