### PR TITLE
Release v1.8.14 — persisted provider stats

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.13"
+    static let binaryVersion = "1.8.14"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1644,10 +1644,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.13")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.13")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.13")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.13")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.14")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.14")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.14")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.14")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -22,8 +22,8 @@ settings:
     SWIFT_VERSION: "5.9"
     ENABLE_HARDENED_RUNTIME: YES
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "1.8.13"
-    CURRENT_PROJECT_VERSION: "13"
+    MARKETING_VERSION: "1.8.14"
+    CURRENT_PROJECT_VERSION: "14"
     OTHER_SWIFT_FLAGS: "-strict-concurrency=complete"
 
 targets:


### PR DESCRIPTION
## Summary

Version bump to **1.8.14** for release after #423 (provider-scoped stats persistence).

## Test plan

- [ ] Tag `v1.8.14` after merge → GHA release workflow
- [ ] `macprovider-cli update` on operator Mac
