### PR TITLE
Harden provider WS reconnect and retry transient 502s at gateway

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -493,7 +493,7 @@ actor CoordinatorClient {
         }
         await cleanupConnection()
 
-        let socket = openWebSocket()
+        let socket = try await openWebSocket()
         do {
             try await authenticateRotatedSocket(socket, newKey: newKey, commitKey: commitKey)
         } catch let error as CoordinatorReceiptRotationCommittedRecoveryFailed {
@@ -722,7 +722,7 @@ actor CoordinatorClient {
 
     private func restoreReceiptRotationSessionWithTimeout() async throws {
         let timeoutNanoseconds = receiptKeyRotationTimeoutNanoseconds
-        let socket = openWebSocket()
+        let socket = try await openWebSocket()
         let completion = ReceiptRotationVoidCompletion()
         let restoreTask = Task {
             do {
@@ -851,14 +851,15 @@ actor CoordinatorClient {
     }
 
     private func connectAndRun() async throws {
+        let socket = try await openWebSocket()
         if wsTunneledMode {
-            try await connectAndRunTier2(socket: openWebSocket())
+            try await connectAndRunTier2(socket: socket)
         } else {
-            try await connectAndRunLegacy(socket: openWebSocket())
+            try await connectAndRunLegacy(socket: socket)
         }
     }
 
-    private func openWebSocket() -> ProviderWebSocketTask {
+    private func openWebSocket() async throws -> ProviderWebSocketTask {
         var request = URLRequest(url: coordinatorURL)
         // M1-1 / XSEC-1: attach Authorization: Bearer when the operator has
         // issued this provider a token. Coordinator validates the header in
@@ -873,7 +874,36 @@ actor CoordinatorClient {
         webSocket = socket
         socket.resume()
         Self.keepaliveDebug("ws_resume url=\(Self.redactedURL(coordinatorURL)) token=\(providerToken == nil ? "absent" : "present")")
+        try await Self.waitForWebSocketReady(socket)
         return socket
+    }
+
+    /// URLSessionWebSocketTask.send() fails with NSPOSIXErrorDomain Code=57
+    /// ("Socket is not connected") when called immediately after resume(), before
+    /// the TCP/TLS/WS handshake completes. Reconnect loops then spam WARN lines
+    /// and leave the provider absent from the pool during the backoff window.
+    private static func waitForWebSocketReady(_ socket: ProviderWebSocketTask, timeoutSeconds: Double = 15) async throws {
+        guard let urlTask = socket as? URLSessionWebSocketTask else { return }
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        var lastError: Error?
+        while Date() < deadline {
+            if Task.isCancelled { throw CancellationError() }
+            switch urlTask.state {
+            case .completed, .canceling:
+                throw lastError ?? CoordinatorAuthError.invalidMessage("WebSocket closed before ready")
+            case .running:
+                do {
+                    try await urlTask.sendPing()
+                    return
+                } catch {
+                    lastError = error
+                }
+            default:
+                break
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        throw lastError ?? CoordinatorAuthError.invalidMessage("WebSocket timed out waiting for ready")
     }
 
     private func connectAndRunTier2(socket: ProviderWebSocketTask) async throws {

--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -102,9 +102,10 @@ timeouts:
   streaming_cancel_ms: 500
 
 retry_503:
-  # Retries only coordinator 503 no_provider_available responses (including
-  # empty-body fast refusals). Tier-2 policy and null-usage provider errors
-  # pass through unchanged.
+  # Retries coordinator 503 no_provider_available AND transient 502 provider
+  # transport failures (provider_disconnected / provider_error / provider_failed).
+  # Does NOT retry null-usage provider errors, tier-2 policy rejects, or
+  # post-inference structured-output 502s (malformed_json_response, etc.).
   enabled: true
   max_attempts: 3
   backoff_base_ms: 100

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -403,10 +403,13 @@ func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Reque
 		if err != nil {
 			return nil, err
 		}
-		if !s.cfg.Retry503.Enabled || maxAttempts == 1 || resp.StatusCode != http.StatusServiceUnavailable {
+		if !s.cfg.Retry503.Enabled || maxAttempts == 1 {
+			return resp, nil
+		}
+		if resp.StatusCode != http.StatusServiceUnavailable && resp.StatusCode != http.StatusBadGateway {
 			if attempt > 1 && resp.StatusCode == http.StatusOK {
 				s.retry503Metrics.recordRecovered(requestIDClass(r), totalBackoffMS)
-				slog.Info("gateway coord 503 retry recovered",
+				slog.Info("gateway coord retry recovered",
 					"request_id", requestID(r),
 					"attempt", attempt,
 					"total_backoff_ms", totalBackoffMS,
@@ -428,15 +431,16 @@ func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Reque
 			resp.Body = io.NopCloser(bytes.NewReader(body))
 		}
 		resp.ContentLength = int64(len(body))
-		if readErr != nil || !isCoordNoProviderAvailable503(resp.StatusCode, body) {
+		if readErr != nil || !isCoordinatorChatRetryEligible(resp.StatusCode, body) {
 			return resp, nil
 		}
 		if attempt == maxAttempts {
 			s.retry503Metrics.recordExhausted(totalBackoffMS)
-			slog.Warn("gateway coord 503 retry exhausted",
+			slog.Warn("gateway coord retry exhausted",
 				"request_id", requestID(r),
 				"attempts", maxAttempts,
 				"total_backoff_ms", totalBackoffMS,
+				"status", resp.StatusCode,
 			)
 			return resp, nil
 		}
@@ -444,10 +448,11 @@ func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Reque
 			return resp, nil
 		}
 		backoff := coord503RetryBackoff(attempt, s.cfg.Retry503)
-		slog.Info("gateway coord 503 retry",
+		slog.Info("gateway coord retry",
 			"request_id", requestID(r),
 			"attempt", attempt+1,
 			"backoff_ms", backoff.Milliseconds(),
+			"status", resp.StatusCode,
 			"body_code", openAIErrorCode(body),
 		)
 		select {
@@ -1135,6 +1140,41 @@ func coordinatorTier2PolicyError(status int, body []byte) bool {
 		return status == http.StatusServiceUnavailable
 	case "tier2_hard_pin_predicate_failed":
 		return status == http.StatusBadRequest
+	default:
+		return false
+	}
+}
+
+// isCoordinatorChatRetryEligible returns true when the coordinator response
+// indicates the request MAY succeed on a retry — momentarily unavailable pool
+// (503) or transient provider transport failure (502). It intentionally does
+// NOT retry null-usage provider errors, tier2 policy errors, or post-inference
+// structured-output failures that already ran billing.
+func isCoordinatorChatRetryEligible(status int, body []byte) bool {
+	if isCoordNoProviderAvailable503(status, body) {
+		return true
+	}
+	return isCoordTransientProvider502(status, body)
+}
+
+// isCoordTransientProvider502 returns true for coordinator 502 responses that
+// signal provider disconnect / relay failure rather than billable inference
+// faults. Mirrors the buyer-visible codes written on ErrRelayClosed and
+// wsForwardProviderDisconnected paths in phase4-coordinator buyer/server.go.
+func isCoordTransientProvider502(status int, body []byte) bool {
+	if status != http.StatusBadGateway {
+		return false
+	}
+	if isNullUsageProviderError(body) {
+		return false
+	}
+	if coordinatorTier2PolicyError(status, body) {
+		return false
+	}
+	code := openAIErrorCode(body)
+	switch code {
+	case "provider_error", "provider_failed", "provider_disconnected", "":
+		return true
 	default:
 		return false
 	}

--- a/phase5-gateway/internal/router/chat_proxy_retry_test.go
+++ b/phase5-gateway/internal/router/chat_proxy_retry_test.go
@@ -146,6 +146,55 @@ func TestGatewayCoord503RetrySkipsTier2PolicyError(t *testing.T) {
 	assertRetryLogCounts(t, logs.String(), 0, 0, 0)
 }
 
+func TestGatewayCoord502RetryRecoversAfterTransientProviderError(t *testing.T) {
+	logs := captureRetryLogs(t)
+	var calls int
+	body := `{"error":{"code":"provider_disconnected","message":"Selected provider disconnected; buyer should retry","param":null,"type":"api_error"}}`
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if calls <= 2 {
+			return responseWithBody(http.StatusBadGateway, http.Header{"Content-Type": []string{"application/json"}}, body), nil
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, retryChatSuccessBody), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_502_recovered")
+
+	resp := postChat(t, h, fullKey, chatBody(false), map[string]string{
+		"X-Request-ID": "22222222-2222-4222-8222-222222222222",
+	})
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 3 {
+		t.Fatalf("coordinator calls=%d want 3", calls)
+	}
+	assertRetryLogCounts(t, logs.String(), 2, 1, 0)
+}
+
+func TestGatewayCoord502RetrySkipsStructuredOutputProviderError(t *testing.T) {
+	logs := captureRetryLogs(t)
+	var calls int
+	body := `{"error":{"code":"malformed_json_response","message":"bad json","param":null,"type":"upstream_provider_error","inference_ran":true,"settlement_ran":true}}`
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return responseWithBody(http.StatusBadGateway, http.Header{"Content-Type": []string{"application/json"}}, body), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_502_structured")
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("coordinator calls=%d want 1", calls)
+	}
+	assertRetryLogCounts(t, logs.String(), 0, 0, 0)
+}
+
 func TestGatewayCoord503RetrySkipsNullUsageProviderError(t *testing.T) {
 	logs := captureRetryLogs(t)
 	var calls int
@@ -400,13 +449,13 @@ func captureRetryLogs(t *testing.T) *bytes.Buffer {
 
 func assertRetryLogCounts(t *testing.T, logs string, retry, recovered, exhausted int) {
 	t.Helper()
-	if got := strings.Count(logs, `msg="gateway coord 503 retry"`); got != retry {
+	if got := strings.Count(logs, `msg="gateway coord retry"`); got != retry {
 		t.Fatalf("retry log count=%d want %d logs:\n%s", got, retry, logs)
 	}
-	if got := strings.Count(logs, `msg="gateway coord 503 retry recovered"`); got != recovered {
+	if got := strings.Count(logs, `msg="gateway coord retry recovered"`); got != recovered {
 		t.Fatalf("recovered log count=%d want %d logs:\n%s", got, recovered, logs)
 	}
-	if got := strings.Count(logs, `msg="gateway coord 503 retry exhausted"`); got != exhausted {
+	if got := strings.Count(logs, `msg="gateway coord retry exhausted"`); got != exhausted {
 		t.Fatalf("exhausted log count=%d want %d logs:\n%s", got, exhausted, logs)
 	}
 }

--- a/test/e2e/malibu-console/README.md
+++ b/test/e2e/malibu-console/README.md
@@ -1,0 +1,31 @@
+# Malibu Console E2E smoke
+
+Mirrors the buyer paths used by `malibu.tech/console` (`console/api.js`):
+
+- `GET /v1/status` — pool dot / model availability
+- `POST /v1/chat/completions` — streaming chat with sticky `X-MacProvider-Conversation`
+
+## Run against production API
+
+```bash
+export MALIBU_API_KEY=mp_your_key
+export MALIBU_MODEL=qwen3-coder-30b-a3b-instruct   # optional
+node test/e2e/malibu-console/smoke.mjs
+```
+
+Demo quota (no key):
+
+```bash
+MALIBU_ALLOW_DEMO=1 node test/e2e/malibu-console/smoke.mjs
+```
+
+## What to watch
+
+| Signal | Healthy | Investigate |
+|--------|---------|-------------|
+| turn1 latency | usually < 10s | > 30s with small prompt |
+| turn2 `cached_prompt_tokens` | > 0 when sticky works | 0 on multi-turn |
+| turn2 502 | should not happen after gateway retry | provider WS flap / single-node pool |
+| Malibu app "Sync" | brief during reconnect | stuck > 60s |
+
+Provider-side: `~/Library/Logs/macprovider/macprovider.out.log` for `coordinator reconnect failed`.

--- a/test/e2e/malibu-console/smoke.mjs
+++ b/test/e2e/malibu-console/smoke.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Malibu Console smoke — mirrors console/api.js buyer paths.
+ *
+ * Usage:
+ *   MALIBU_API_KEY=mp_... node test/e2e/malibu-console/smoke.mjs
+ *   MALIBU_BASE=https://api.streamvc.live  (default)
+ *
+ * Exercises:
+ *   GET  /v1/status          (sidebar pool dot)
+ *   POST /v1/chat/completions turn 1 + turn 2 with sticky conversation header
+ */
+
+const BASE = (process.env.MALIBU_BASE || 'https://api.streamvc.live').replace(/\/$/, '');
+const API_KEY = process.env.MALIBU_API_KEY || '';
+const DEMO_TOKEN = process.env.MALIBU_DEMO_TOKEN || '';
+const MODEL = process.env.MALIBU_MODEL || 'qwen3-coder-30b-a3b-instruct';
+
+function authHeaders(extra = {}) {
+  const headers = { ...extra };
+  if (API_KEY) {
+    headers.Authorization = `Bearer ${API_KEY}`;
+    return headers;
+  }
+  if (DEMO_TOKEN) {
+    headers['X-Demo-Token'] = DEMO_TOKEN;
+  }
+  return headers;
+}
+
+async function ensureDemoToken() {
+  if (API_KEY || DEMO_TOKEN) return DEMO_TOKEN;
+  if (!process.env.MALIBU_ALLOW_DEMO) return '';
+  const r = await fetch(`${BASE}/auth/demo-session`, { method: 'POST' });
+  const text = await r.text();
+  if (!r.ok) fail(`demo-session HTTP ${r.status}: ${text.slice(0, 200)}`);
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    fail('demo-session response is not JSON');
+  }
+  const token = body.demo_token || body.token || '';
+  if (!token) fail('demo-session missing demo_token');
+  return token;
+}
+
+function fail(msg) {
+  console.error('FAIL:', msg);
+  process.exit(1);
+}
+
+function ok(msg) {
+  console.log('OK:', msg);
+}
+
+async function getStatus(demoToken) {
+  const headers = authHeaders({ Accept: 'application/json' });
+  if (demoToken) headers['X-Demo-Token'] = demoToken;
+  const r = await fetch(`${BASE}/v1/status`, { headers });
+  const text = await r.text();
+  if (!r.ok) fail(`status HTTP ${r.status}: ${text.slice(0, 200)}`);
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    fail('status response is not JSON');
+  }
+  return body;
+}
+
+async function chatStream({ model, messages, conversationId, maxTokens = 256, demoToken }) {
+  const headers = authHeaders({
+    'Content-Type': 'application/json',
+    Accept: 'text/event-stream',
+  });
+  if (demoToken) headers['X-Demo-Token'] = demoToken;
+  if (conversationId) headers['X-MacProvider-Conversation'] = conversationId;
+
+  const r = await fetch(`${BASE}/v1/chat/completions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ model, messages, stream: true, max_tokens: maxTokens }),
+  });
+
+  const provider = r.headers.get('X-Provider-Id') || r.headers.get('X-MacProvider-Provider') || '';
+  if (!r.ok) {
+    const text = await r.text().catch(() => '');
+    return { ok: false, status: r.status, text: text.slice(0, 400), provider };
+  }
+
+  const reader = r.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  let content = '';
+  let usage = null;
+  const started = Date.now();
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf('\n\n')) !== -1) {
+      const frame = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      for (const line of frame.split('\n')) {
+        if (!line.startsWith('data:')) continue;
+        const payload = line.slice(5).trim();
+        if (!payload || payload === '[DONE]') continue;
+        try {
+          const obj = JSON.parse(payload);
+          const delta = obj?.choices?.[0]?.delta?.content;
+          if (delta) content += delta;
+          if (obj?.usage) usage = obj.usage;
+        } catch {
+          /* ignore partial frames */
+        }
+      }
+    }
+  }
+
+  return {
+    ok: true,
+    content,
+    usage,
+    provider,
+    latencyMs: Date.now() - started,
+  };
+}
+
+async function main() {
+  if (!API_KEY && !DEMO_TOKEN && !process.env.MALIBU_ALLOW_DEMO) {
+    fail('Set MALIBU_API_KEY, MALIBU_DEMO_TOKEN, or MALIBU_ALLOW_DEMO=1');
+  }
+
+  const demoToken = await ensureDemoToken();
+
+  const status = await getStatus(demoToken);
+  ok(`pool status=${status.status} ready=${status.pool?.ready ?? '?'} models=${status.models?.length ?? 0}`);
+  const modelEntry = (status.models || []).find((m) => m.id === MODEL);
+  if (!modelEntry) {
+    console.warn(`WARN: model ${MODEL} not in status.models (continuing anyway)`);
+  } else if (modelEntry.available === false) {
+    fail(`model ${MODEL} marked unavailable: ${modelEntry.availability || 'unknown'}`);
+  } else {
+    ok(`model ${MODEL} available slots_free=${modelEntry.slots_free}`);
+  }
+
+  const threadId = crypto.randomUUID();
+  const turn1 = await chatStream({
+    model: MODEL,
+    conversationId: threadId,
+    demoToken,
+    messages: [{ role: 'user', content: 'Reply with exactly: pong' }],
+    maxTokens: 16,
+  });
+  if (!turn1.ok) fail(`turn1 chat ${turn1.status}: ${turn1.text}`);
+  if (!turn1.content.toLowerCase().includes('pong')) {
+    console.warn(`WARN: turn1 content unexpected: ${JSON.stringify(turn1.content.slice(0, 80))}`);
+  }
+  ok(`turn1 ${turn1.latencyMs}ms provider=${turn1.provider || 'n/a'} tokens=${turn1.usage?.total_tokens ?? '?'}`);
+
+  const turn2 = await chatStream({
+    model: MODEL,
+    conversationId: threadId,
+    demoToken,
+    messages: [
+      { role: 'user', content: 'Reply with exactly: pong' },
+      { role: 'assistant', content: turn1.content },
+      { role: 'user', content: 'Reply with exactly: pong again' },
+    ],
+    maxTokens: 16,
+  });
+  if (!turn2.ok) fail(`turn2 sticky chat ${turn2.status}: ${turn2.text}`);
+  ok(
+    `turn2 sticky ${turn2.latencyMs}ms cached=${turn2.usage?.cached_prompt_tokens ?? 0} provider=${turn2.provider || 'n/a'}`
+  );
+
+  console.log('\nAll Malibu console smoke checks passed.');
+}
+
+main().catch((e) => fail(e.message || String(e)));


### PR DESCRIPTION
## Summary
- Wait for the coordinator WebSocket to reach `.running` and pass a ping before Tier-2 auth, fixing ENOTCONN reconnect spam that left locally healthy providers unroutable.
- Extend the existing `retry_503` coordinator chat loop to also retry transient provider transport 502s (`provider_disconnected`, `provider_failed`, `provider_error`) so sticky multi-turn chats survive brief WS flaps on single-node pools.
- Add Malibu Console E2E smoke (`test/e2e/malibu-console/smoke.mjs`) covering `/v1/status` and sticky two-turn chat.

## Test plan
- [x] `go test ./internal/router/ -run 'TestGatewayCoord502|TestGatewayCoord503Retry'`
- [x] `swift test --filter CoordinatorClientTests`
- [x] `MALIBU_ALLOW_DEMO=1 node test/e2e/malibu-console/smoke.mjs`


Made with [Cursor](https://cursor.com)