### PR TITLE
Parse Qwen3-Coder Nemotron XML tool calls for agent mode

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -2547,12 +2547,26 @@ private struct NativeToolCallStreamEmitter {
     }
 
     mutating func observe(_ text: String) -> [StreamChunk] {
-        guard !closed, let start = text.range(of: startDelimiter) else {
+        guard !closed else {
             return []
         }
-        let afterStart = start.upperBound
-        let bodyEnd = text.range(of: endDelimiter, range: afterStart..<text.endIndex)?.lowerBound ?? text.endIndex
-        let body = String(text[afterStart..<bodyEnd])
+        if let start = text.range(of: startDelimiter) {
+            let afterStart = start.upperBound
+            let bodyEnd = text.range(of: endDelimiter, range: afterStart..<text.endIndex)?.lowerBound ?? text.endIndex
+            let body = String(text[afterStart..<bodyEnd])
+            let isClosed = text.range(of: endDelimiter, range: afterStart..<text.endIndex) != nil
+            if body.contains("<function=") {
+                return observeNemotronXML(body: body, isClosed: isClosed)
+            }
+            return observeJSONToolCall(body: body, isClosed: isClosed)
+        }
+        if text.contains("<function=") {
+            return observeNemotronXML(body: text, isClosed: false)
+        }
+        return []
+    }
+
+    private mutating func observeJSONToolCall(body: String, isClosed: Bool) -> [StreamChunk] {
         guard let name = stringField("name", in: body),
               let arguments = argumentPrefix(in: body)
         else {
@@ -2569,7 +2583,30 @@ private struct NativeToolCallStreamEmitter {
             emittedArguments = arguments
             events.append(.toolCallDelta(StreamToolCallDelta(index: 0, id: nil, type: nil, functionName: nil, arguments: fragment)))
         }
-        if text.range(of: endDelimiter, range: afterStart..<text.endIndex) != nil {
+        if isClosed {
+            closed = true
+        }
+        return events
+    }
+
+    private mutating func observeNemotronXML(body: String, isClosed: Bool) -> [StreamChunk] {
+        guard let name = ToolCallParser.nemotronFunctionName(in: body),
+              let arguments = ToolCallParser.nemotronArgumentsJSON(in: body, includeIncomplete: isClosed)
+        else {
+            return []
+        }
+
+        var events: [StreamChunk] = []
+        if !opened {
+            opened = true
+            events.append(.toolCallDelta(StreamToolCallDelta(index: 0, id: callID, type: "function", functionName: name, arguments: "")))
+        }
+        let fragment = Self.delta(from: emittedArguments, to: arguments)
+        if !fragment.isEmpty {
+            emittedArguments = arguments
+            events.append(.toolCallDelta(StreamToolCallDelta(index: 0, id: nil, type: nil, functionName: nil, arguments: fragment)))
+        }
+        if isClosed {
             closed = true
         }
         return events

--- a/phase3-binary/Sources/macprovider-cli/ToolCallParser.swift
+++ b/phase3-binary/Sources/macprovider-cli/ToolCallParser.swift
@@ -20,11 +20,26 @@ enum ToolCallParser {
 
         do {
             let parsed = try parseDelimited(rawOutput, format: format)
-            if let allowedFunctionNames,
-               parsed.toolCalls.contains(where: { !allowedFunctionNames.contains($0.functionName) })
-            {
-                fputs("warning: tool-call output contains undeclared function for \(modelID)\n", stderr)
-                return (nilIfBlank(rawOutput), [])
+            if !parsed.toolCalls.isEmpty {
+                if let allowedFunctionNames,
+                   parsed.toolCalls.contains(where: { !allowedFunctionNames.contains($0.functionName) })
+                {
+                    fputs("warning: tool-call output contains undeclared function for \(modelID)\n", stderr)
+                    return (nilIfBlank(rawOutput), [])
+                }
+                return parsed
+            }
+            if rawOutput.contains("<function=") {
+                let bare = try parseBareNemotronCalls(rawOutput)
+                if !bare.toolCalls.isEmpty {
+                    if let allowedFunctionNames,
+                       bare.toolCalls.contains(where: { !allowedFunctionNames.contains($0.functionName) })
+                    {
+                        fputs("warning: tool-call output contains undeclared function for \(modelID)\n", stderr)
+                        return (nilIfBlank(rawOutput), [])
+                    }
+                    return bare
+                }
             }
             return parsed
         } catch {
@@ -66,11 +81,173 @@ enum ToolCallParser {
         return (nilIfBlank(cleaned), calls)
     }
 
+    private static func parseBareNemotronCalls(_ rawOutput: String) throws -> (cleanedContent: String?, toolCalls: [ToolCall]) {
+        var searchStart = rawOutput.startIndex
+        var cleaned = ""
+        var calls: [ToolCall] = []
+        var responseArgumentBytes = 0
+
+        while let open = rawOutput.range(of: "<function=", range: searchStart..<rawOutput.endIndex) {
+            cleaned += rawOutput[searchStart..<open.lowerBound]
+            let blockEnd = rawOutput.range(of: "</function>", range: open.lowerBound..<rawOutput.endIndex)?.upperBound ?? rawOutput.endIndex
+            let block = String(rawOutput[open.lowerBound..<blockEnd])
+            let call = try parseNemotronXMLCall(block)
+            let argumentBytes = call.arguments.utf8.count
+            guard argumentBytes <= SPEC018_ARGUMENTS_PER_CALL_BYTE_CAP else {
+                throw ParseError.byteCapExceeded
+            }
+            responseArgumentBytes += argumentBytes
+            guard responseArgumentBytes <= SPEC018_ARGUMENTS_PER_RESPONSE_BYTE_CAP else {
+                throw ParseError.responseByteCapExceeded
+            }
+            calls.append(call)
+            searchStart = blockEnd
+        }
+
+        cleaned += rawOutput[searchStart..<rawOutput.endIndex]
+        guard !calls.isEmpty else {
+            return (nilIfBlank(rawOutput), [])
+        }
+        return (nilIfBlank(cleaned), calls)
+    }
+
     private static func parseCall(_ rawCall: String, argumentKey: String) throws -> ToolCall {
-        if rawCall.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("{") {
+        let trimmed = rawCall.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("{") {
             return try parseJSONCall(rawCall, argumentKey: argumentKey)
         }
+        if trimmed.contains("<function=") {
+            return try parseNemotronXMLCall(rawCall)
+        }
         return try parsePythonStyleCall(rawCall)
+    }
+
+    private static func parseNemotronXMLCall(_ rawCall: String) throws -> ToolCall {
+        guard let functionName = nemotronFunctionName(in: rawCall) else {
+            throw ParseError.invalidShape
+        }
+        let argumentsObject = try nemotronParameterObject(in: rawCall, includeIncomplete: true)
+        guard JSONSerialization.isValidJSONObject(argumentsObject) else {
+            throw ParseError.invalidArguments
+        }
+        let data = try JSONSerialization.data(withJSONObject: argumentsObject, options: [.sortedKeys, .withoutEscapingSlashes])
+        let arguments = String(decoding: data, as: UTF8.self)
+        try validateNoDuplicateJSONKeys(arguments)
+        return ToolCall(
+            id: "call_\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())",
+            functionName: functionName,
+            arguments: arguments
+        )
+    }
+
+    static func nemotronFunctionName(in raw: String) -> String? {
+        guard let open = raw.range(of: "<function=") else {
+            return nil
+        }
+        let nameStart = open.upperBound
+        guard let close = raw.range(of: ">", range: nameStart..<raw.endIndex) else {
+            return nil
+        }
+        let name = String(raw[nameStart..<close.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isPythonIdentifier(name) else {
+            return nil
+        }
+        return name
+    }
+
+    static func nemotronArgumentsJSON(in raw: String, includeIncomplete: Bool) -> String? {
+        guard let object = try? nemotronParameterObject(in: raw, includeIncomplete: includeIncomplete),
+              JSONSerialization.isValidJSONObject(object)
+        else {
+            return nil
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes]) else {
+            return nil
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func nemotronParameterObject(in raw: String, includeIncomplete: Bool) throws -> [String: Any] {
+        var object: [String: Any] = [:]
+        var searchStart = raw.startIndex
+
+        while let paramOpen = raw.range(of: "<parameter=", range: searchStart..<raw.endIndex) {
+            let nameStart = paramOpen.upperBound
+            guard let nameEnd = raw.range(of: ">", range: nameStart..<raw.endIndex) else {
+                throw ParseError.invalidShape
+            }
+            let name = String(raw[nameStart..<nameEnd.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard isPythonIdentifier(name) else {
+                throw ParseError.invalidArguments
+            }
+            guard object[name] == nil else {
+                throw ParseError.invalidArguments
+            }
+
+            let valueStart = nameEnd.upperBound
+            let valueEnd = nemotronParameterValueEnd(in: raw, from: valueStart)
+            let hasClosingTag = raw[valueStart..<raw.endIndex].contains("</parameter>")
+                && raw.range(of: "</parameter>", range: valueStart..<valueEnd) != nil
+            let hasSuccessor = raw.range(of: "<parameter=", range: valueStart..<valueEnd) != nil
+                || raw.range(of: "</function>", range: valueStart..<valueEnd) != nil
+            guard includeIncomplete || hasClosingTag || hasSuccessor else {
+                break
+            }
+
+            let rawValue = String(raw[valueStart..<valueEnd])
+            object[name] = try nemotronParameterValue(rawValue)
+
+            if let closeTag = raw.range(of: "</parameter>", range: valueStart..<raw.endIndex),
+               closeTag.lowerBound == valueEnd
+            {
+                searchStart = closeTag.upperBound
+            } else if let nextParam = raw.range(of: "<parameter=", range: valueStart..<raw.endIndex),
+                      nextParam.lowerBound == valueEnd
+            {
+                searchStart = nextParam.lowerBound
+            } else if let closeFunction = raw.range(of: "</function>", range: valueStart..<raw.endIndex),
+                      closeFunction.lowerBound == valueEnd
+            {
+                searchStart = closeFunction.upperBound
+            } else {
+                searchStart = valueEnd
+                break
+            }
+        }
+
+        return object
+    }
+
+    private static func nemotronParameterValueEnd(in raw: String, from valueStart: String.Index) -> String.Index {
+        if let close = raw.range(of: "</parameter>", range: valueStart..<raw.endIndex) {
+            return close.lowerBound
+        }
+        if let next = raw.range(of: "<parameter=", range: valueStart..<raw.endIndex) {
+            return next.lowerBound
+        }
+        if let closeFunction = raw.range(of: "</function>", range: valueStart..<raw.endIndex) {
+            return closeFunction.lowerBound
+        }
+        return raw.endIndex
+    }
+
+    private static func nemotronParameterValue(_ rawValue: String) throws -> Any {
+        var trimmed = rawValue
+        if trimmed.hasPrefix("\n") {
+            trimmed.removeFirst()
+        }
+        if trimmed.hasSuffix("\n") {
+            trimmed.removeLast()
+        }
+        trimmed = trimmed.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return ""
+        }
+        do {
+            return try parsePythonLiteral(trimmed)
+        } catch {
+            return trimmed
+        }
     }
 
     private static func parseJSONCall(_ rawJSON: String, argumentKey: String) throws -> ToolCall {

--- a/phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift
@@ -402,6 +402,112 @@ final class ToolCallParserTests: XCTestCase {
         XCTAssertTrue(parsed.toolCalls.isEmpty)
     }
 
+    func testQwen3CoderNemotronXMLToolCall() throws {
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: #"""
+<tool_call>
+<function=json_validate>
+<parameter=text>
+{"valid":true}
+</parameter>
+</function>
+</tool_call>
+"""#,
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            allowedFunctionNames: ["json_validate"]
+        )
+
+        XCTAssertNil(parsed.cleanedContent)
+        let call = try XCTUnwrap(parsed.toolCalls.first)
+        XCTAssertEqual(call.functionName, "json_validate")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "text") as? String, "{\"valid\":true}")
+    }
+
+    func testQwen3CoderNemotronXMLInlineToolCall() throws {
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: #"<tool_call><function=json_validate><parameter=text>{"valid":true}</parameter></function></tool_call>"#,
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            allowedFunctionNames: ["json_validate"]
+        )
+
+        XCTAssertNil(parsed.cleanedContent)
+        let call = try XCTUnwrap(parsed.toolCalls.first)
+        XCTAssertEqual(call.functionName, "json_validate")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "text") as? String, "{\"valid\":true}")
+    }
+
+    func testQwen3CoderNemotronXMLMultilineParameter() throws {
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: #"""
+<tool_call>
+<function=execute_bash>
+<parameter=command>
+pwd && ls
+</parameter>
+</function>
+</tool_call>
+"""#,
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            allowedFunctionNames: ["execute_bash"]
+        )
+
+        let call = try XCTUnwrap(parsed.toolCalls.first)
+        XCTAssertEqual(call.functionName, "execute_bash")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "command") as? String, "pwd && ls")
+    }
+
+    func testQwen3CoderNemotronXMLMultipleParameters() throws {
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: #"""
+<tool_call>
+<function=search_products>
+<parameter=query>
+waterproof running shoes
+</parameter>
+<parameter=sort_by>
+price_low_to_high
+</parameter>
+</function>
+</tool_call>
+"""#,
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            allowedFunctionNames: ["search_products"]
+        )
+
+        let call = try XCTUnwrap(parsed.toolCalls.first)
+        XCTAssertEqual(call.functionName, "search_products")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "query") as? String, "waterproof running shoes")
+        XCTAssertEqual(try argumentValue(call.arguments, key: "sort_by") as? String, "price_low_to_high")
+    }
+
+    func testQwen3CoderNemotronXMLUndeclaredFunctionFailsClosed() {
+        let raw = #"<tool_call><function=delete_symbol><parameter=symbol>x</parameter></function></tool_call>"#
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: raw,
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            allowedFunctionNames: ["json_validate"]
+        )
+
+        XCTAssertEqual(parsed.cleanedContent, raw)
+        XCTAssertTrue(parsed.toolCalls.isEmpty)
+    }
+
+    func testQwen3CoderNemotronXMLBareFunctionWithoutToolCallWrapper() throws {
+        let parsed = ToolCallParser.parseToolCalls(
+            rawOutput: """
+I'll validate that.
+
+<function=json_validate><parameter=text>{"valid":true}</parameter></function>
+""",
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            allowedFunctionNames: ["json_validate"]
+        )
+
+        XCTAssertEqual(parsed.cleanedContent, "I'll validate that.")
+        let call = try XCTUnwrap(parsed.toolCalls.first)
+        XCTAssertEqual(call.functionName, "json_validate")
+    }
+
     func testTemplateToolsStripFieldsOutsideReceiptCanonicalSubset() {
         let tools: JSONValue = .array([
             .object([


### PR DESCRIPTION
## Summary
- Add Nemotron/Qwen3-Coder XML grammar parsing in `ToolCallParser` for `<function=name><parameter=key>value</parameter>` bodies inside `<tool_call>` blocks
- Extend `NativeToolCallStreamEmitter` to emit incremental `delta.tool_calls` for XML-format tool output
- Add fallback parsing for bare `<function=...>` blocks when models omit the outer `<tool_call>` wrapper
- Add regression tests with Qwen3-Coder fixtures

Fixes #426

## Test plan
- [x] `swift test --filter ToolCallParserTests` (40 tests pass)
- [ ] CI green
- [ ] Manual: Malibu Agent mode with `qwen3-coder-30b-a3b-instruct` emits `delta.tool_calls` instead of raw `<function=` markup


Made with [Cursor](https://cursor.com)