### PR TITLE
[codex] Detect dead provider sockets before routing buyer work

### DIFF
--- a/phase4-coordinator/internal/ws/relay.go
+++ b/phase4-coordinator/internal/ws/relay.go
@@ -1,6 +1,7 @@
 package ws
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -13,6 +14,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	"github.com/augstar/macprovider-coordinator/internal/tier2"
+	gobwas "github.com/gobwas/ws"
 	"github.com/gobwas/ws/wsutil"
 )
 
@@ -26,6 +28,7 @@ var (
 )
 
 const retiredRelayRequestTTL = 5 * time.Minute
+const providerDispatchWriteProbeTimeout = 500 * time.Millisecond
 
 var relayEndFrameAADMismatchTotal atomic.Uint64
 var relayBufferExceededTotal atomic.Uint64
@@ -136,20 +139,22 @@ type retiredRelayRequest struct {
 }
 
 type providerSession struct {
-	providerID string
-	assignedID string
-	conn       net.Conn
-	writeCh    chan providerFrame
-	writeLimit time.Duration
-	closeOnce  sync.Once
-	writeMu    sync.Mutex
-	closed     bool
-	activeMu   sync.Mutex
-	active     map[string]*relayActive
-	retired    map[string]retiredRelayRequest
-	httpOnly   bool
-	tier2Mu    sync.Mutex
-	tier2      *pool.Tier2Session
+	providerID     string
+	assignedID     string
+	conn           net.Conn
+	writeCh        chan providerFrame
+	writeLimit     time.Duration
+	probeWrites    bool
+	onWriteFailure func(*providerSession, error)
+	closeOnce      sync.Once
+	writeMu        sync.Mutex
+	closed         bool
+	activeMu       sync.Mutex
+	active         map[string]*relayActive
+	retired        map[string]retiredRelayRequest
+	httpOnly       bool
+	tier2Mu        sync.Mutex
+	tier2          *pool.Tier2Session
 }
 
 // providerFrame is the unit of work consumed by runWriter. Two kinds exist:
@@ -166,8 +171,10 @@ type providerSession struct {
 // The single runWriter goroutine has exclusive ownership of all post-handshake
 // conn writes; every other caller MUST go through send / enqueueRaw.
 type providerFrame struct {
-	raw     bool
-	payload []byte
+	raw        bool
+	payload    []byte
+	writeLimit time.Duration
+	result     chan error
 }
 
 type encryptedInferenceRequest struct {
@@ -220,7 +227,11 @@ func newProviderSession(providerID, assignedID string, conn net.Conn, bufferSize
 
 func (ps *providerSession) runWriter() {
 	for f := range ps.writeCh {
-		_ = ps.conn.SetWriteDeadline(time.Now().Add(ps.writeLimit))
+		writeLimit := ps.writeLimit
+		if f.writeLimit > 0 && (writeLimit <= 0 || f.writeLimit < writeLimit) {
+			writeLimit = f.writeLimit
+		}
+		_ = ps.conn.SetWriteDeadline(time.Now().Add(writeLimit))
 		var err error
 		if f.raw {
 			// Single Write of an already-framed control reply. The header and
@@ -230,11 +241,26 @@ func (ps *providerSession) runWriter() {
 		} else {
 			err = wsutil.WriteServerText(ps.conn, f.payload)
 		}
+		ps.completeFrame(f, err)
 		if err != nil {
 			ps.failAll(ErrRelayClosed)
 			_ = ps.conn.Close()
+			ps.close()
+			if ps.onWriteFailure != nil {
+				ps.onWriteFailure(ps, err)
+			}
 			return
 		}
+	}
+}
+
+func (ps *providerSession) completeFrame(f providerFrame, err error) {
+	if f.result == nil {
+		return
+	}
+	select {
+	case f.result <- err:
+	default:
 	}
 }
 
@@ -250,6 +276,48 @@ func (ps *providerSession) close() {
 
 func (ps *providerSession) send(payload []byte) error {
 	return ps.enqueueFrame(providerFrame{payload: payload})
+}
+
+func (ps *providerSession) sendProbe(payload []byte, timeout time.Duration) error {
+	if timeout <= 0 || !ps.probeWrites {
+		return ps.send(payload)
+	}
+	frame, err := providerWriteProbeFrame()
+	if err != nil {
+		return err
+	}
+	if err := ps.writeProbe(frame, timeout); err != nil {
+		return err
+	}
+	return ps.send(payload)
+}
+
+func (ps *providerSession) writeProbe(rawFrame []byte, timeout time.Duration) error {
+	result := make(chan error, 1)
+	if err := ps.enqueueFrame(providerFrame{raw: true, payload: rawFrame, writeLimit: timeout, result: result}); err != nil {
+		return err
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-result:
+		if err != nil {
+			return ErrRelayClosed
+		}
+		return nil
+	case <-timer.C:
+		_ = ps.conn.Close()
+		ps.close()
+		return ErrRelayClosed
+	}
+}
+
+func providerWriteProbeFrame() ([]byte, error) {
+	var buf bytes.Buffer
+	if err := gobwas.WriteFrame(&buf, gobwas.NewPingFrame([]byte("probe"))); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // enqueueRaw queues a pre-baked WS frame (header + body, already assembled by
@@ -658,8 +726,11 @@ func (s *Server) dispatchInference(ctx context.Context, provider pool.Provider, 
 		session.removeActive(requestID)
 		return nil, err
 	}
-	if err := session.send(payload); err != nil {
+	if err := session.sendProbe(payload, providerDispatchWriteProbeTimeout); err != nil {
 		session.removeActive(requestID)
+		if errors.Is(err, ErrRelayClosed) {
+			s.handleProviderWriteFailure(session, err)
+		}
 		return nil, err
 	}
 	if provider.EncryptedLeg {

--- a/phase4-coordinator/internal/ws/relay_test.go
+++ b/phase4-coordinator/internal/ws/relay_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +19,98 @@ import (
 	"github.com/gobwas/ws/wsutil"
 	"github.com/rs/zerolog"
 )
+
+type blockingWriteConn struct {
+	mu            sync.Mutex
+	writeDeadline time.Time
+	closed        chan struct{}
+	closeOnce     sync.Once
+}
+
+func newBlockingWriteConn() *blockingWriteConn {
+	return &blockingWriteConn{closed: make(chan struct{})}
+}
+
+func (c *blockingWriteConn) Read(_ []byte) (int, error) {
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *blockingWriteConn) Write(_ []byte) (int, error) {
+	for {
+		c.mu.Lock()
+		deadline := c.writeDeadline
+		c.mu.Unlock()
+		if deadline.IsZero() {
+			select {
+			case <-c.closed:
+				return 0, net.ErrClosed
+			case <-time.After(10 * time.Millisecond):
+				continue
+			}
+		}
+		wait := time.Until(deadline)
+		if wait <= 0 {
+			return 0, os.ErrDeadlineExceeded
+		}
+		select {
+		case <-c.closed:
+			return 0, net.ErrClosed
+		case <-time.After(wait):
+			return 0, os.ErrDeadlineExceeded
+		}
+	}
+}
+
+func (c *blockingWriteConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return nil
+}
+
+func (c *blockingWriteConn) LocalAddr() net.Addr  { return testAddr("local") }
+func (c *blockingWriteConn) RemoteAddr() net.Addr { return testAddr("remote") }
+
+func (c *blockingWriteConn) SetDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.writeDeadline = t
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *blockingWriteConn) SetReadDeadline(time.Time) error { return nil }
+
+func (c *blockingWriteConn) SetWriteDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.writeDeadline = t
+	c.mu.Unlock()
+	return nil
+}
+
+type testAddr string
+
+func (a testAddr) Network() string { return "test" }
+func (a testAddr) String() string  { return string(a) }
+
+type firstWriteSucceedsConn struct {
+	*blockingWriteConn
+	mu     sync.Mutex
+	writes int
+}
+
+func newFirstWriteSucceedsConn() *firstWriteSucceedsConn {
+	return &firstWriteSucceedsConn{blockingWriteConn: newBlockingWriteConn()}
+}
+
+func (c *firstWriteSucceedsConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	if c.writes == 0 {
+		c.writes++
+		c.mu.Unlock()
+		return len(p), nil
+	}
+	c.mu.Unlock()
+	return c.blockingWriteConn.Write(p)
+}
 
 func TestRelayDispatchRoutesChunkAndEndByRequestID(t *testing.T) {
 	serverConn, providerConn := net.Pipe()
@@ -121,6 +215,299 @@ func TestRelayDispatchCarriesConversationKeyFromContext(t *testing.T) {
 	}
 	if req.ConversationKey != "conv:relay-cache" {
 		t.Fatalf("conversation_key=%q want conv:relay-cache", req.ConversationKey)
+	}
+}
+
+func TestRelayWriteFailureMarksProviderUnavailable(t *testing.T) {
+	serverConn, providerConn := net.Pipe()
+	defer serverConn.Close()
+
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	}
+	registry.Register(provider, serverConn)
+	s := NewServer(config.Default(), registry, zerolog.Nop())
+	session := newProviderSession("p1", "s1", serverConn, 4)
+	session.onWriteFailure = s.handleProviderWriteFailure
+	s.sessions.Store(sessionKey("p1", "s1"), session)
+	go session.runWriter()
+
+	if err := providerConn.Close(); err != nil {
+		t.Fatalf("close provider side: %v", err)
+	}
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-dead", []byte(`{"model":"model-a"}`), false)
+	if err != nil && !errors.Is(err, ErrRelayClosed) {
+		t.Fatalf("dispatch = %v, want nil or ErrRelayClosed", err)
+	}
+	if relay != nil {
+		select {
+		case relayErr := <-relay.Errors:
+			if !errors.Is(relayErr, ErrRelayClosed) {
+				t.Fatalf("relay error = %v, want ErrRelayClosed", relayErr)
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("timed out waiting for relay close after write failure")
+		}
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		got, ok := s.pool.Resolve("p1", "s1")
+		if ok && got.State == pool.StateUnavailable {
+			break
+		}
+		if time.Now().After(deadline) {
+			if !ok {
+				t.Fatal("timed out waiting for provider to remain registered as unavailable")
+			}
+			t.Fatalf("timed out waiting for unavailable state; state=%s", got.State)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, ok := s.storedSessionFor("p1", "s1"); ok {
+		t.Fatal("session still routable after websocket write failure")
+	}
+}
+
+func TestRelayWriteProbeTimesOutBlockingProviderWrite(t *testing.T) {
+	conn := newBlockingWriteConn()
+	defer conn.Close()
+
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	}
+	registry.Register(provider, conn)
+	s := NewServer(config.Default(), registry, zerolog.Nop())
+	session := newProviderSession("p1", "s1", conn, 4, 10*time.Second)
+	session.probeWrites = true
+	session.onWriteFailure = s.handleProviderWriteFailure
+	s.sessions.Store(sessionKey("p1", "s1"), session)
+	go session.runWriter()
+
+	start := time.Now()
+	_, err := s.DispatchInference(context.Background(), *provider, "req-blocked", []byte(`{"model":"model-a"}`), false)
+	elapsed := time.Since(start)
+	if !errors.Is(err, ErrRelayClosed) {
+		t.Fatalf("dispatch = %v, want ErrRelayClosed", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("dispatch took %v, want below 1s probe bound", elapsed)
+	}
+	got, ok := s.pool.Resolve("p1", "s1")
+	if !ok {
+		t.Fatal("provider missing")
+	}
+	if got.State != pool.StateUnavailable {
+		t.Fatalf("state = %s, want unavailable", got.State)
+	}
+	if _, ok := s.storedSessionFor("p1", "s1"); ok {
+		t.Fatal("session still routable after blocked write probe failure")
+	}
+}
+
+func TestPreflightWriteProbeTimesOutBlockingProviderWrite(t *testing.T) {
+	conn := newBlockingWriteConn()
+	defer conn.Close()
+
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	}
+	registry.Register(provider, conn)
+	s := NewServer(config.Default(), registry, zerolog.Nop())
+	session := newProviderSession("p1", "s1", conn, 4, 10*time.Second)
+	session.probeWrites = true
+	session.onWriteFailure = s.handleProviderWriteFailure
+	s.sessions.Store(sessionKey("p1", "s1"), session)
+	go session.runWriter()
+
+	start := time.Now()
+	_, _, err := s.Preflight(*provider, "req-preflight-blocked", 1024, 5*time.Second)
+	elapsed := time.Since(start)
+	if !errors.Is(err, ErrRelayClosed) {
+		t.Fatalf("preflight = %v, want ErrRelayClosed", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("preflight took %v, want below 1s probe bound", elapsed)
+	}
+	got, ok := s.pool.Resolve("p1", "s1")
+	if !ok {
+		t.Fatal("provider missing")
+	}
+	if got.State != pool.StateUnavailable {
+		t.Fatalf("state = %s, want unavailable", got.State)
+	}
+	if _, ok := s.storedSessionFor("p1", "s1"); ok {
+		t.Fatal("session still routable after blocked preflight write probe failure")
+	}
+}
+
+func TestRelayWriteProbeDoesNotEvictSlowRequestPayloadWrite(t *testing.T) {
+	conn := newFirstWriteSucceedsConn()
+	defer conn.Close()
+
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	}
+	registry.Register(provider, conn)
+	s := NewServer(config.Default(), registry, zerolog.Nop())
+	session := newProviderSession("p1", "s1", conn, 4, 10*time.Second)
+	session.probeWrites = true
+	session.onWriteFailure = s.handleProviderWriteFailure
+	s.sessions.Store(sessionKey("p1", "s1"), session)
+	go session.runWriter()
+
+	start := time.Now()
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-slow-payload", []byte(`{"model":"model-a"}`), false)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("dispatch = %v, want probe success before slow payload write", err)
+	}
+	if relay == nil {
+		t.Fatal("relay is nil after successful probe")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("dispatch took %v, want below 1s after probe success", elapsed)
+	}
+	got, ok := s.pool.Resolve("p1", "s1")
+	if !ok {
+		t.Fatal("provider missing")
+	}
+	if got.State == pool.StateUnavailable {
+		t.Fatal("provider marked unavailable even though small write probe succeeded")
+	}
+	if _, ok := s.storedSessionFor("p1", "s1"); !ok {
+		t.Fatal("session removed even though small write probe succeeded")
+	}
+	relay.Cancel("test_cleanup")
+}
+
+func TestRegisteredProviderSessionEnablesWriteProbes(t *testing.T) {
+	serverConn, providerConn := net.Pipe()
+	defer providerConn.Close()
+	defer serverConn.Close()
+
+	s := NewServer(config.Default(), pool.NewRegistry(nil), zerolog.Nop())
+	session, refusal := s.registerProviderSession(serverConn, &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	})
+	if refusal != pool.RegisterRefusalNone || session == nil {
+		t.Fatalf("registerProviderSession refusal=%q session=%v", refusal, session)
+	}
+	if !session.probeWrites {
+		t.Fatal("production-registered provider session did not enable write probes")
+	}
+	session.close()
+}
+
+func TestRelayClosedSendMarksProviderUnavailable(t *testing.T) {
+	serverConn, providerConn := net.Pipe()
+	defer providerConn.Close()
+	defer serverConn.Close()
+
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:     "p1",
+		AssignedID:     "s1",
+		ModelID:        "model-a",
+		Tier:           pool.TierProvisional,
+		InferencePath:  pool.InferencePathWSTunneled,
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+	}
+	registry.Register(provider, serverConn)
+	s := NewServer(config.Default(), registry, zerolog.Nop())
+	session := newProviderSession("p1", "s1", serverConn, 4)
+	session.onWriteFailure = s.handleProviderWriteFailure
+	s.sessions.Store(sessionKey("p1", "s1"), session)
+	session.close()
+
+	if _, err := s.DispatchInference(context.Background(), *provider, "req-closed", []byte(`{"model":"model-a"}`), false); !errors.Is(err, ErrRelayClosed) {
+		t.Fatalf("dispatch = %v, want ErrRelayClosed", err)
+	}
+	got, ok := s.pool.Resolve("p1", "s1")
+	if !ok {
+		t.Fatal("provider missing")
+	}
+	if got.State != pool.StateUnavailable {
+		t.Fatalf("state = %s, want unavailable", got.State)
+	}
+	if _, ok := s.storedSessionFor("p1", "s1"); ok {
+		t.Fatal("session still routable after closed send")
+	}
+}
+
+func TestProviderLivenessThresholdCapsB1ProvidersAtSixtySeconds(t *testing.T) {
+	cfg := config.Default()
+	cfg.Pool.HeartbeatMissThresholdS = 90
+	s := NewServer(cfg, pool.NewRegistry(nil), zerolog.Nop())
+
+	legacy := s.providerLivenessThreshold(pool.Provider{BinaryVersion: "1.8.0"})
+	if legacy != 90*time.Second {
+		t.Fatalf("legacy threshold = %v, want 90s", legacy)
+	}
+	b1 := s.providerLivenessThreshold(pool.Provider{BinaryVersion: "1.8.1"})
+	if b1 != 60*time.Second {
+		t.Fatalf("b1 threshold = %v, want 60s", b1)
+	}
+	next := s.providerLivenessThreshold(pool.Provider{BinaryVersion: "1.8.2"})
+	if next != 60*time.Second {
+		t.Fatalf("next release threshold = %v, want 60s", next)
+	}
+	malformed := s.providerLivenessThreshold(pool.Provider{BinaryVersion: "1.8.2-dev"})
+	if malformed != 90*time.Second {
+		t.Fatalf("malformed threshold = %v, want 90s", malformed)
+	}
+
+	cfg.Pool.HeartbeatMissThresholdS = 10
+	s = NewServer(cfg, pool.NewRegistry(nil), zerolog.Nop())
+	tight := s.providerLivenessThreshold(pool.Provider{BinaryVersion: "1.8.1"})
+	if tight != 10*time.Second {
+		t.Fatalf("tight configured threshold = %v, want 10s", tight)
 	}
 }
 

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -1259,6 +1259,8 @@ func (s *Server) registerProviderSession(conn net.Conn, entry *pool.Provider) (*
 	}
 	session := newProviderSession(entry.ProviderID, entry.AssignedID, conn, s.cfg.WS.WriteBufferSize, s.cfg.ProviderWSWriteTimeout())
 	session.useTier2Session(entry.Tier2Session)
+	session.probeWrites = true
+	session.onWriteFailure = s.handleProviderWriteFailure
 	s.sessions.Store(sessionKey(entry.ProviderID, entry.AssignedID), session)
 	go session.runWriter()
 	go s.monitorHeartbeat(entry.ProviderID, entry.AssignedID, conn)
@@ -1680,7 +1682,10 @@ func (s *Server) Preflight(provider pool.Provider, requestID string, estimatedTo
 	if err != nil {
 		return PreflightAck{}, false, err
 	}
-	if err := session.send(payload); err != nil {
+	if err := session.sendProbe(payload, providerDispatchWriteProbeTimeout); err != nil {
+		if errors.Is(err, ErrRelayClosed) {
+			s.handleProviderWriteFailure(session, err)
+		}
 		return PreflightAck{}, false, err
 	}
 	timer := time.NewTimer(timeout)
@@ -2538,6 +2543,23 @@ func (s *Server) handleDisconnect(providerID, assignedID string) {
 	})
 }
 
+func (s *Server) handleProviderWriteFailure(session *providerSession, err error) {
+	if session == nil {
+		return
+	}
+	s.clearWarmupGate(session.providerID, session.assignedID)
+	_ = session.conn.Close()
+	session.close()
+	s.sessions.Delete(sessionKey(session.providerID, session.assignedID))
+	if s.pool.MarkState(session.providerID, session.assignedID, pool.StateUnavailable) {
+		s.log.Warn().
+			Err(err).
+			Str("provider_id", session.providerID).
+			Str("assigned_id", session.assignedID).
+			Msg("provider websocket write failed; marked unavailable")
+	}
+}
+
 func (s *Server) monitorHeartbeat(providerID, assignedID string, conn net.Conn) {
 	tick := s.cfg.FailoverTimeout() / 2
 	if tick <= 0 {
@@ -2548,7 +2570,6 @@ func (s *Server) monitorHeartbeat(providerID, assignedID string, conn net.Conn) 
 	}
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
-	threshold := s.cfg.HeartbeatMissThreshold()
 	for range ticker.C {
 		provider, ok := s.pool.Resolve(providerID, assignedID)
 		if !ok {
@@ -2563,6 +2584,7 @@ func (s *Server) monitorHeartbeat(providerID, assignedID string, conn net.Conn) 
 		if last.IsZero() {
 			last = provider.LastHeartbeatAt
 		}
+		threshold := s.providerLivenessThreshold(provider)
 		if s.now().Sub(last) <= threshold {
 			continue
 		}
@@ -2574,6 +2596,21 @@ func (s *Server) monitorHeartbeat(providerID, assignedID string, conn net.Conn) 
 		_ = conn.Close()
 		return
 	}
+}
+
+func (s *Server) providerLivenessThreshold(provider pool.Provider) time.Duration {
+	threshold := s.cfg.HeartbeatMissThreshold()
+	if providerSupportsInternalActivityLiveness(provider.BinaryVersion) {
+		if internalActivityThreshold := 60 * time.Second; threshold > internalActivityThreshold {
+			threshold = internalActivityThreshold
+		}
+	}
+	return threshold
+}
+
+func providerSupportsInternalActivityLiveness(binaryVersion string) bool {
+	cmp, ok := compareSemver(binaryVersion, "1.8.1")
+	return ok && cmp >= 0
 }
 
 func validState(state pool.State) bool {


### PR DESCRIPTION
## Summary
- add a 500ms server-side websocket Ping probe before dispatching inference/preflight payloads to provider sessions
- mark exact provider sessions unavailable and remove them from routing when route-time probe/write failure proves the socket is dead
- cap B1-capable provider liveness windows at 60s while preserving stricter configured thresholds
- add regressions for blocked route-time probes, preflight probes, slow full-payload writes, closed sends, production probe registration, and B1 liveness threshold behavior

## Audit lanes
- Code lane: 0 critical/high/medium findings
- Security lane: 0 critical/high/medium findings; low follow-up noted for malformed/suffixed binary versions bypassing the B1 liveness cap
- Architecture lane: 0 critical/high/medium findings; low follow-up noted for write-failure cleanup not mirroring normal disconnect drain/grace cleanup

## Validation
- go test ./internal/ws -count=1
- go test ./... -count=1 in phase4-coordinator
- go test -race ./internal/ws -run 'TestRegisteredProviderSessionEnablesWriteProbes|TestRelayWriteProbeTimesOutBlockingProviderWrite|TestPreflightWriteProbeTimesOutBlockingProviderWrite|TestRelayWriteProbeDoesNotEvictSlowRequestPayloadWrite|TestRelayWriteFailureMarksProviderUnavailable|TestRelayClosedSendMarksProviderUnavailable|TestProviderLivenessThresholdCapsB1ProvidersAtSixtySeconds' -count=1\n- git diff --check\n\n## Not tested\n- live Pearl provider SIGKILL/tunnel-partition drill\n\nFixes #380