### PR TITLE
fix(control-plane): transactional admin state, VPS-anchored deploy safety, coordinator deploy hygiene, operator-key strength check

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -667,7 +667,7 @@ func reloadTestServers(cfg config.Config) (config.Config, *pool.Registry, *provi
 }
 
 func reloadTestServersWithLogger(cfg config.Config, logger zerolog.Logger) (config.Config, *pool.Registry, *providerws.Server, *buyer.Server) {
-	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Auth.OperatorKey = "0123456789abcdefABCDEFghijklmnop"
 	cfg.Pool.WarmupGateEnabled = false
 	registry := pool.NewRegistry(nil)
 	wsServer := providerws.NewServer(cfg, registry, logger)
@@ -702,7 +702,7 @@ func fetchReloadTier2Metadata(t *testing.T, server *buyer.Server) struct {
 } {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/internal/routing", nil)
-	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Authorization", "Bearer 0123456789abcdefABCDEFghijklmnop")
 	rr := httptest.NewRecorder()
 	server.InternalHandler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {

--- a/phase4-coordinator/cmd/coordinator/migrate_indexes_test.go
+++ b/phase4-coordinator/cmd/coordinator/migrate_indexes_test.go
@@ -45,7 +45,7 @@ func TestMigrateIndexesCheckIsReadOnly(t *testing.T) {
 	}
 	_ = db.Close()
 
-	if err := os.WriteFile(configPath, []byte("auth:\n  operator_key: test-operator-key\nstorage:\n  db_path: "+dbPath+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(configPath, []byte("auth:\n  operator_key: 0123456789abcdefABCDEFghijklmnop\nstorage:\n  db_path: "+dbPath+"\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -135,7 +135,7 @@ func TestMigrateIndexesCheckRejectsBogusFormatBeforeOpen(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 	_ = db.Close()
-	if err := os.WriteFile(configPath, []byte("auth:\n  operator_key: test-operator-key\nstorage:\n  db_path: "+dbPath+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(configPath, []byte("auth:\n  operator_key: 0123456789abcdefABCDEFghijklmnop\nstorage:\n  db_path: "+dbPath+"\n"), 0o644); err != nil {
 		t.Fatalf("config: %v", err)
 	}
 

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -26,6 +26,12 @@
 #                                 primary deploy — issue #244 root cause).
 #   FORCE_RESTART    default: 0   bypass connected-provider guard at step 1c/6c
 #   STRICT_PROVENANCE default: 0  fail if /healthz lacks `version` field
+#   --dry-run-local  developer-only: run the old local-config C2 check using
+#                    GATEWAY_CONFIG and exit before any SSH mutation.
+#   GATEWAY_CONFIG   used only with --dry-run-local. Production deploys validate
+#                    the gateway config installed on Pearl.
+#   GATEWAY_REMOTE_CONFIG  installed gateway config path on Pearl.
+#                    Default: /opt/macprovider/gateway.yaml.
 #   SKIP_C2_CHECK    default: 0   skip C2 cross-check (development only)
 #   ALLOW_CONFIG_DRIFT default: 0 push local coordinator.yaml over live one
 #   SKIP_TCP_TUNING default: 0    skip Pearl TCP sysctl install/apply step
@@ -38,6 +44,18 @@
 # for another. Refused fail-closed.
 
 set -euo pipefail
+
+DRY_RUN_LOCAL=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run-local) DRY_RUN_LOCAL=1 ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      echo "usage: bash deploy-pearl-vps.sh [--dry-run-local]" >&2
+      exit 2
+      ;;
+  esac
+done
 
 # TLS state machine (classify/plan/message) lives in a sourced helper
 # (lib/pearl_tls.sh) so it can be exercised by fixture tests without a
@@ -220,6 +238,18 @@ SCP="scp -i $SSH_KEY -P 22"
 
 log() { printf "\n[deploy] %s\n" "$*"; }
 
+GATEWAY_REMOTE_CONFIG="${GATEWAY_REMOTE_CONFIG:-/opt/macprovider/gateway.yaml}"
+case "$GATEWAY_REMOTE_CONFIG" in
+  /*) ;;
+  *) echo "aborting deploy: GATEWAY_REMOTE_CONFIG must be an absolute path" >&2; exit 5 ;;
+esac
+case "$GATEWAY_REMOTE_CONFIG" in
+  *[!A-Za-z0-9._/-]*)
+    echo "aborting deploy: GATEWAY_REMOTE_CONFIG contains unsupported characters: $GATEWAY_REMOTE_CONFIG" >&2
+    exit 5
+    ;;
+esac
+
 yaml_tier2_value() {
   yaml_block_value tier2 "$1"
 }
@@ -263,6 +293,23 @@ if [ "${STATS_REQUIRED:-0}" = "1" ]; then
   fi
 fi
 
+# Issue #244 R6 (CODE+SEC+ARCH convergent MED) — register the EXIT
+# cleanup trap UNCONDITIONALLY, before any temp resource is created.
+# Earlier the trap was inside the `if [ -n "$CATALOG_REMOTE_PATH" ]`
+# branch, so a deploy with catalog disabled that failed mid-flight
+# could leave the remote $DEPLOY_TMP and local TMP_CATALOG_PUBKEY
+# behind. Both variables are guarded with `:-` so the trap is a
+# no-op when they are unset.
+trap '
+  rm -f "${TMP_CATALOG_PUBKEY:-}"
+  rm -f "${CATALOG_SMOKE_TMP:-}"
+  rm -f "${GATEWAY_REMOTE_CONFIG_TMP:-}"
+  rm -rf "${STATIC_SMOKE_DIR:-}"
+  if [ -n "${DEPLOY_TMP:-}" ]; then
+    $SSH "rm -rf $DEPLOY_TMP" 2>/dev/null || true
+  fi
+' EXIT
+
 log "step 0/9: pre-deploy config-drift + C2 cross-check"
 # Fail closed before touching the VPS if the config to be deployed has a
 # placeholder operator_key, an unsafe threshold, etc. (see check-deploy-config.sh).
@@ -272,27 +319,44 @@ log "step 0/9: pre-deploy config-drift + C2 cross-check"
 # Previously only $CONFIG was passed, so check-deploy-config.sh silently
 # skipped C2 on every standard coordinator deploy — the past-incident
 # guard was effectively disabled.
-# M1-6 follow-up (codex audits 2026-06-11): the previous .example fallback
-# was a false fail-closed gate — production deploy could pass C2 using
-# SAMPLE timeout values while the real VPS gateway.yaml had drifted.
-# Sample config is documentation, not an operational input. Require a real
-# gateway.yaml or an explicit SKIP_C2_CHECK=1 override.
-GATEWAY_CONFIG_DEFAULT="$DIST_DIR/../../phase5-gateway/dist/gateway.yaml"
-GATEWAY_CONFIG="${GATEWAY_CONFIG:-$GATEWAY_CONFIG_DEFAULT}"
-if [ "${SKIP_C2_CHECK:-0}" = "1" ]; then
+# M1-6 follow-up: production deploy reads the gateway config installed on
+# Pearl, not a local sample or developer config. Local validation is available
+# only through --dry-run-local and exits before any SSH mutation.
+CHECK_SCRIPT="$DIST_DIR/check-deploy-config.sh"
+if [ ! -x "$CHECK_SCRIPT" ]; then
+  echo "aborting deploy: check-deploy-config.sh missing or not executable: $CHECK_SCRIPT" >&2
+  exit 5
+fi
+if [ "$DRY_RUN_LOCAL" = "1" ]; then
+  echo "  --dry-run-local set — validating local GATEWAY_CONFIG and exiting before deploy" >&2
+  GATEWAY_CONFIG_DEFAULT="$DIST_DIR/../../phase5-gateway/dist/gateway.yaml"
+  GATEWAY_CONFIG="${GATEWAY_CONFIG:-$GATEWAY_CONFIG_DEFAULT}"
+  if [ ! -f "$GATEWAY_CONFIG" ]; then
+    echo "aborting deploy dry-run: local gateway config not found for C2 cross-check ($GATEWAY_CONFIG)." >&2
+    echo "  Provide GATEWAY_CONFIG=<path-to-real-gateway.yaml>." >&2
+    exit 5
+  fi
+  bash "$CHECK_SCRIPT" "$CONFIG" "$GATEWAY_CONFIG" || {
+    echo "aborting deploy dry-run: config-drift check failed" >&2; exit 5;
+  }
+  echo "  local dry-run C2 check passed"
+  exit 0
+elif [ "${SKIP_C2_CHECK:-0}" = "1" ]; then
   echo "  SKIP_C2_CHECK=1 set — running coordinator-only check (C2 gate intentionally skipped)" >&2
-  SKIP_C2_CHECK=1 bash "$DIST_DIR/check-deploy-config.sh" "$CONFIG" || {
+  SKIP_C2_CHECK=1 bash "$CHECK_SCRIPT" "$CONFIG" || {
     echo "aborting deploy: config-drift check failed" >&2; exit 5;
   }
 else
-  if [ ! -f "$GATEWAY_CONFIG" ]; then
-    echo "aborting deploy: real gateway.yaml not found for C2 cross-check ($GATEWAY_CONFIG)." >&2
-    echo "  Provide GATEWAY_CONFIG=<path-to-real-gateway.yaml> or set SKIP_C2_CHECK=1" >&2
-    echo "  to deploy without the cross-check. gateway.yaml.example is sample" >&2
-    echo "  documentation and intentionally NOT accepted here." >&2
+  GATEWAY_REMOTE_CONFIG_TMP="$(umask 077 && mktemp -t macprovider-gateway-installed-config.XXXXXXXX)" || {
+    echo "aborting deploy: mktemp failed for installed gateway config copy" >&2; exit 5;
+  }
+  $SSH "test -f '$GATEWAY_REMOTE_CONFIG' || { echo 'missing installed gateway config: $GATEWAY_REMOTE_CONFIG' >&2; exit 1; }; cat '$GATEWAY_REMOTE_CONFIG'" > "$GATEWAY_REMOTE_CONFIG_TMP" || {
+    echo "aborting deploy: could not read installed gateway config from Pearl: $GATEWAY_REMOTE_CONFIG" >&2
     exit 5
-  fi
-  bash "$DIST_DIR/check-deploy-config.sh" "$CONFIG" "$GATEWAY_CONFIG" || {
+  }
+  GATEWAY_REMOTE_CONFIG_SHA=$(shasum -a 256 "$GATEWAY_REMOTE_CONFIG_TMP" | awk '{print $1}')
+  echo "  validating installed Pearl gateway config: $GATEWAY_REMOTE_CONFIG sha256=$GATEWAY_REMOTE_CONFIG_SHA"
+  bash "$CHECK_SCRIPT" "$CONFIG" "$GATEWAY_REMOTE_CONFIG_TMP" || {
     echo "aborting deploy: config-drift check failed" >&2; exit 5;
   }
 fi
@@ -306,21 +370,6 @@ fi
 bash "$DIST_DIR/test/check_nginx_catalog_routes_test.sh" || {
   echo "aborting deploy: nginx /catalog/ routes missing or misconfigured" >&2; exit 5;
 }
-
-# Issue #244 R6 (CODE+SEC+ARCH convergent MED) — register the EXIT
-# cleanup trap UNCONDITIONALLY, before any temp resource is created.
-# Earlier the trap was inside the `if [ -n "$CATALOG_REMOTE_PATH" ]`
-# branch, so a deploy with catalog disabled that failed mid-flight
-# could leave the remote $DEPLOY_TMP and local TMP_CATALOG_PUBKEY
-# behind. Both variables are guarded with `:-` so the trap is a
-# no-op when they are unset.
-trap '
-  rm -f "${TMP_CATALOG_PUBKEY:-}"
-  rm -f "${CATALOG_SMOKE_TMP:-}"
-  if [ -n "${DEPLOY_TMP:-}" ]; then
-    $SSH "rm -rf $DEPLOY_TMP" 2>/dev/null || true
-  fi
-' EXIT
 
 CATALOG_REMOTE_PATH="$(yaml_tier2_value catalog_path)"
 CATALOG_PUBLIC_KEY="$(yaml_tier2_value catalog_public_key)"
@@ -405,6 +454,12 @@ normalize_yaml() {
     | sed -E 's/[[:space:]]+#.*$//' \
     | grep -vE '^[[:space:]]*(#|$)'
 }
+redact_dsn() {
+  sed -E 's#(postgres(ql)?://[^:/@[:space:]]+:)[^@[:space:]]+@#\1***@#g'
+}
+print_config_drift_diff() {
+  redact_dsn | sed 's/^/    /' >&2
+}
 LIVE_NORM=$($SSH 'cat /opt/macprovider/coordinator.yaml' 2>/dev/null | normalize_yaml) || {
   echo "could not pull live coordinator.yaml from Pearl for drift check" >&2; exit 6;
 }
@@ -412,7 +467,7 @@ LOCAL_NORM=$(normalize_yaml < "$CONFIG")
 if ! DRIFT_DIFF=$(diff <(printf '%s\n' "$LOCAL_NORM") <(printf '%s\n' "$LIVE_NORM")); then
   echo "" >&2
   echo "  CONFIG DRIFT detected (secrets masked; '<' = local, '>' = live):" >&2
-  printf '%s\n' "$DRIFT_DIFF" | sed 's/^/    /' >&2
+  printf '%s\n' "$DRIFT_DIFF" | print_config_drift_diff
   echo "" >&2
   if [ "${ALLOW_CONFIG_DRIFT:-0}" != "1" ]; then
     echo "  Aborting. The local config will overwrite the live one on deploy." >&2
@@ -1493,15 +1548,21 @@ if [ -n "$CATALOG_REMOTE_PATH" ]; then
 fi
 
 # SPEC-023 v1.7.3 signed static feeds smoke.
+STATIC_SMOKE_DIR=$(umask 077 && mktemp -d -t macprovider-static-probe.XXXXXXXX) || {
+  echo "aborting smoke: mktemp -d failed for static feed probe" >&2
+  exit 1
+}
+STATIC_SMOKE_BODY="$STATIC_SMOKE_DIR/body"
 for STATIC_PATH in \
     /static/demand-rank.json \
     /static/demand-rank.json.sig \
     /static/autotune-candidates.json \
     /static/autotune-candidates.json.sig; do
   echo "  GET https://$DOMAIN$STATIC_PATH -> expect 200"
-  STATUS=$(curl -sS -o /tmp/macprovider-static-probe -w '%{http_code}' --max-time 10 --max-filesize 65536 "https://$DOMAIN$STATIC_PATH")
+  : > "$STATIC_SMOKE_BODY"
+  STATUS=$(curl -sS -o "$STATIC_SMOKE_BODY" -w '%{http_code}' --max-time 10 --max-filesize 65536 "https://$DOMAIN$STATIC_PATH")
   if [ "$STATUS" != "200" ]; then
-    echo "SPEC-023 static feed smoke failed: $STATIC_PATH status=$STATUS body=$(head -c 200 /tmp/macprovider-static-probe)" >&2
+    echo "SPEC-023 static feed smoke failed: $STATIC_PATH status=$STATUS body=$(head -c 200 "$STATIC_SMOKE_BODY")" >&2
     exit 1
   fi
 done

--- a/phase4-coordinator/dist/test/coord_deploy_c2_precheck.test.sh
+++ b/phase4-coordinator/dist/test/coord_deploy_c2_precheck.test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_SH="$SCRIPT_DIR/../deploy-pearl-vps.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+bash -n "$DEPLOY_SH"
+
+grep -q -- '--dry-run-local' "$DEPLOY_SH" ||
+  fail "deploy script lacks explicit --dry-run-local developer path"
+
+grep -q "validating installed Pearl gateway config: .*sha256=" "$DEPLOY_SH" ||
+  fail "deploy script does not log installed gateway config SHA-256"
+
+grep -q 'cat '"'"'\$GATEWAY_REMOTE_CONFIG'"'" "$DEPLOY_SH" ||
+  fail "deploy script does not read installed Pearl gateway config over SSH"
+
+local_count=$(grep -c 'bash "$CHECK_SCRIPT" "$CONFIG" "$GATEWAY_CONFIG"' "$DEPLOY_SH" || true)
+if [ "$local_count" != "1" ]; then
+  fail "local GATEWAY_CONFIG C2 path should appear exactly once inside --dry-run-local, got $local_count"
+fi
+
+grep -q 'bash "$CHECK_SCRIPT" "$CONFIG" "$GATEWAY_REMOTE_CONFIG_TMP"' "$DEPLOY_SH" ||
+  fail "production C2 path does not validate the installed Pearl gateway config copy"
+
+grep -q 'rm -f "${GATEWAY_REMOTE_CONFIG_TMP:-}"' "$DEPLOY_SH" ||
+  fail "EXIT trap does not clean installed gateway config temp copy"
+
+echo "PASS: coordinator deploy C2 precheck reads installed VPS gateway config by default"

--- a/phase4-coordinator/dist/test/coord_deploy_drift_redact.test.sh
+++ b/phase4-coordinator/dist/test/coord_deploy_drift_redact.test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_SH="$SCRIPT_DIR/../deploy-pearl-vps.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+bash -n "$DEPLOY_SH"
+
+grep -q '^redact_dsn()' "$DEPLOY_SH" ||
+  fail "deploy script lacks drift DSN redaction function"
+
+grep -q 'print_config_drift_diff' "$DEPLOY_SH" ||
+  fail "drift diff is not routed through the redaction print function"
+
+sample='> onboarding_postgres_dsn: postgres://gwuser:secret@db.example/macprovider'
+redacted=$(printf '%s\n' "$sample" | sed -E 's#(postgres(ql)?://[^:/@[:space:]]+:)[^@[:space:]]+@#\1***@#g')
+case "$redacted" in
+  *'postgres://gwuser:***@db.example/macprovider'*) ;;
+  *) fail "redaction sed did not mask postgres password: $redacted" ;;
+esac
+case "$redacted" in
+  *secret*) fail "redaction output leaked plaintext password: $redacted" ;;
+esac
+
+echo "PASS: coordinator drift diff redacts Postgres DSN passwords"

--- a/phase4-coordinator/dist/test/coord_deploy_smoke_probe.test.sh
+++ b/phase4-coordinator/dist/test/coord_deploy_smoke_probe.test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_SH="$SCRIPT_DIR/../deploy-pearl-vps.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+bash -n "$DEPLOY_SH"
+
+grep -q 'STATIC_SMOKE_DIR=$(umask 077 && mktemp -d -t macprovider-static-probe.XXXXXXXX)' "$DEPLOY_SH" ||
+  fail "static feed smoke does not use mktemp -d"
+
+grep -q 'rm -rf "${STATIC_SMOKE_DIR:-}"' "$DEPLOY_SH" ||
+  fail "EXIT trap does not clean static smoke temp dir"
+
+if grep -q '/tmp/macprovider-static-probe' "$DEPLOY_SH"; then
+  fail "static feed smoke still writes a predictable /tmp probe path"
+fi
+
+echo "PASS: coordinator static feed smoke uses unpredictable cleaned temp dir"

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/netip"
 	"net/url"
 	"os"
@@ -778,6 +779,14 @@ func Load(path string) (Config, error) {
 	if err := cfg.Validate(); err != nil {
 		return Config{}, err
 	}
+	if err := validateOperatorSecretStrength("auth.operator_key", cfg.Auth.OperatorKey); err != nil {
+		return Config{}, err
+	}
+	for name, key := range cfg.Auth.OperatorKeys {
+		if err := validateOperatorSecretStrength("auth.operator_keys."+name, key); err != nil {
+			return Config{}, err
+		}
+	}
 	return cfg, nil
 }
 
@@ -888,6 +897,58 @@ func resolveEnvValue(field, v string) (string, error) {
 		return "", fmt.Errorf("%s references env:%s but the environment variable is unset or empty", field, name)
 	}
 	return resolved, nil
+}
+
+var weakOperatorKeyDenylist = map[string]struct{}{
+	"":            {},
+	"changeme":    {},
+	"placeholder": {},
+	"test":        {},
+	"secret":      {},
+	"password":    {},
+	"admin":       {},
+}
+
+func validateOperatorSecretStrength(field, key string) error {
+	trimmed := strings.TrimSpace(key)
+	if _, denied := weakOperatorKeyDenylist[strings.ToLower(trimmed)]; denied {
+		return fmt.Errorf("%s strength check failed: placeholder_denied", field)
+	}
+	if len([]byte(trimmed)) < 32 {
+		return fmt.Errorf("%s strength check failed: too_short (minimum 32 bytes)", field)
+	}
+	allZero := true
+	for _, b := range []byte(trimmed) {
+		if b != 0 && b != '0' {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		return fmt.Errorf("%s strength check failed: repeated_zero", field)
+	}
+	if entropyBitsPerByte(trimmed) < 3.5 {
+		return fmt.Errorf("%s strength check failed: low_entropy", field)
+	}
+	return nil
+}
+
+func entropyBitsPerByte(s string) float64 {
+	data := []byte(s)
+	if len(data) == 0 {
+		return 0
+	}
+	counts := make(map[byte]int, len(data))
+	for _, b := range data {
+		counts[b]++
+	}
+	var entropy float64
+	n := float64(len(data))
+	for _, count := range counts {
+		p := float64(count) / n
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
 }
 
 func (c Config) HeartbeatInterval() time.Duration {

--- a/phase4-coordinator/internal/config/config_env_test.go
+++ b/phase4-coordinator/internal/config/config_env_test.go
@@ -12,14 +12,14 @@ import (
 // auth.operator_key resolves at Load time against the process
 // environment (M3-2 / DEVE-7).
 func TestLoadResolvesEnvOperatorKey(t *testing.T) {
-	t.Setenv("M3_2_TEST_OPERATOR_KEY", "resolved-secret")
+	t.Setenv("M3_2_TEST_OPERATOR_KEY", "0123456789abcdefABCDEFghijklmnop")
 
 	cfg := writeMinimalConfig(t, `
 auth:
   operator_key: env:M3_2_TEST_OPERATOR_KEY
 `)
-	if cfg.Auth.OperatorKey != "resolved-secret" {
-		t.Fatalf("OperatorKey=%q want %q", cfg.Auth.OperatorKey, "resolved-secret")
+	if cfg.Auth.OperatorKey != "0123456789abcdefABCDEFghijklmnop" {
+		t.Fatalf("OperatorKey=%q want %q", cfg.Auth.OperatorKey, "0123456789abcdefABCDEFghijklmnop")
 	}
 }
 
@@ -45,7 +45,7 @@ auth:
 // TestLoadResolvesEnvGatewayServiceToken covers the new
 // gateway_service_token field on the same env:NAME pathway.
 func TestLoadResolvesEnvGatewayServiceToken(t *testing.T) {
-	t.Setenv("M3_2_TEST_OPERATOR_KEY", "operator-secret")
+	t.Setenv("M3_2_TEST_OPERATOR_KEY", "0123456789abcdefABCDEFghijklmnop")
 	t.Setenv("M3_2_TEST_GATEWAY_TOKEN", "gateway-secret")
 
 	cfg := writeMinimalConfig(t, `
@@ -53,7 +53,7 @@ auth:
   operator_key: env:M3_2_TEST_OPERATOR_KEY
   gateway_service_token: env:M3_2_TEST_GATEWAY_TOKEN
 `)
-	if cfg.Auth.OperatorKey != "operator-secret" {
+	if cfg.Auth.OperatorKey != "0123456789abcdefABCDEFghijklmnop" {
 		t.Fatalf("OperatorKey=%q", cfg.Auth.OperatorKey)
 	}
 	if cfg.Auth.GatewayServiceToken != "gateway-secret" {
@@ -65,7 +65,7 @@ auth:
 // stats runtime DSNs may be env-indirected and resolve before
 // stats.enabled validation runs.
 func TestLoadResolvesEnvStatsDSNs(t *testing.T) {
-	t.Setenv("M3_2_TEST_OPERATOR_KEY", "operator-secret")
+	t.Setenv("M3_2_TEST_OPERATOR_KEY", "0123456789abcdefABCDEFghijklmnop")
 	t.Setenv("TEST_STATS_READER_DSN", "postgres://reader@localhost/macprovider")
 	t.Setenv("TEST_STATS_ROLLUP_DSN", "postgres://rollup@localhost/macprovider")
 
@@ -92,7 +92,7 @@ stats:
 // TestLoadFailsClosedOnMissingStatsEnvDSN ensures stats cutovers fail
 // before boot when a required env-indirected DSN is absent.
 func TestLoadFailsClosedOnMissingStatsEnvDSN(t *testing.T) {
-	t.Setenv("M3_2_TEST_OPERATOR_KEY", "operator-secret")
+	t.Setenv("M3_2_TEST_OPERATOR_KEY", "0123456789abcdefABCDEFghijklmnop")
 	os.Unsetenv("TEST_STATS_MISSING_READER_DSN")
 
 	_, err := loadConfigFromYAML(t, `
@@ -121,10 +121,10 @@ stats:
 // can pass config load with stats enabled when Pearl's env file provides
 // the required values, and that Malibu's browser origin is allowlisted.
 func TestDeployCoordinatorYAMLLoadsWithStatsEnv(t *testing.T) {
-	t.Setenv("OPERATOR_KEY", "operator-secret")
+	t.Setenv("OPERATOR_KEY", "0123456789abcdefABCDEFghijklmnop")
 	t.Setenv("GATEWAY_SERVICE_TOKEN", "gateway-secret")
-	t.Setenv("OPERATOR_AUTH_POLICY_A", "operator-a")
-	t.Setenv("OPERATOR_AUTH_POLICY_B", "operator-b")
+	t.Setenv("OPERATOR_AUTH_POLICY_A", "0123456789abcdefABCDEFghijklmnop")
+	t.Setenv("OPERATOR_AUTH_POLICY_B", "fedcba9876543210PONMLKJIHGFEDCBA")
 	t.Setenv("STATS_READER_DSN", "postgres://reader@localhost/macprovider")
 	t.Setenv("STATS_ROLLUP_DSN", "postgres://rollup@localhost/macprovider")
 	t.Setenv("ONBOARDING_POSTGRES_DSN", "postgres://onboarding@localhost/macprovider")
@@ -160,6 +160,26 @@ func TestDeployCoordinatorYAMLLoadsWithStatsEnv(t *testing.T) {
 		nemotron.EffectivePromptCacheHitCreditsPerMtok() != 29375 ||
 		nemotron.CompletionCreditsPerMtok != 235000 {
 		t.Fatalf("unexpected nemotron rate-card row: %+v", nemotron)
+	}
+}
+
+func TestLoadRejectsWeakEnvNamedOperatorKey(t *testing.T) {
+	t.Setenv("M3_2_TEST_OPERATOR_KEY", "0123456789abcdefABCDEFghijklmnop")
+	t.Setenv("M3_2_TEST_WEAK_OPERATOR_A", "changeme")
+	t.Setenv("M3_2_TEST_STRONG_OPERATOR_B", "fedcba9876543210PONMLKJIHGFEDCBA")
+
+	_, err := loadConfigFromYAML(t, `
+auth:
+  operator_key: env:M3_2_TEST_OPERATOR_KEY
+  operator_keys:
+    alice: env:M3_2_TEST_WEAK_OPERATOR_A
+    bob: env:M3_2_TEST_STRONG_OPERATOR_B
+`)
+	if err == nil {
+		t.Fatal("Load accepted weak env-indirected named operator key")
+	}
+	if !strings.Contains(err.Error(), "auth.operator_keys.alice") || !strings.Contains(err.Error(), "placeholder_denied") {
+		t.Fatalf("error should name weak env-indirected operator key, got %v", err)
 	}
 }
 

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -33,6 +33,70 @@ func TestProviderTokensRequiredByDefault(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsWeakOperatorKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{name: "placeholder", key: "changeme", want: "placeholder_denied"},
+		{name: "too_short", key: "short-but-not-placeholder", want: "too_short"},
+		{name: "low_entropy", key: strings.Repeat("a", 32), want: "low_entropy"},
+		{name: "repeated_zero", key: strings.Repeat("0", 32), want: "repeated_zero"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadConfigFromYAML(t, "auth:\n  operator_key: "+tc.key+"\n")
+			if err == nil {
+				t.Fatal("Load accepted weak operator key")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadAcceptsStrongOperatorKey(t *testing.T) {
+	cfg := writeMinimalConfig(t, `
+auth:
+  operator_key: 0123456789abcdefABCDEFghijklmnop
+`)
+	if cfg.Auth.OperatorKey != "0123456789abcdefABCDEFghijklmnop" {
+		t.Fatalf("OperatorKey=%q", cfg.Auth.OperatorKey)
+	}
+}
+
+func TestLoadRejectsWeakNamedOperatorKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{name: "placeholder", key: "changeme", want: "placeholder_denied"},
+		{name: "too_short", key: "short-but-not-placeholder", want: "too_short"},
+		{name: "low_entropy", key: strings.Repeat("a", 32), want: "low_entropy"},
+		{name: "repeated_zero", key: strings.Repeat("0", 32), want: "repeated_zero"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadConfigFromYAML(t, `
+auth:
+  operator_key: 0123456789abcdefABCDEFghijklmnop
+  operator_keys:
+    alice: `+tc.key+`
+    bob: fedcba9876543210PONMLKJIHGFEDCBA
+`)
+			if err == nil {
+				t.Fatal("Load accepted weak named operator key")
+			}
+			if !strings.Contains(err.Error(), "auth.operator_keys.alice") || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v want field auth.operator_keys.alice and %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestCanaryValidationRequiresPrivateChallengeBankWhenEnabled(t *testing.T) {
 	cfg := Default()
 	cfg.Auth.OperatorKey = "operator-key"

--- a/phase5-gateway/dist/deploy-pearl-vps.sh
+++ b/phase5-gateway/dist/deploy-pearl-vps.sh
@@ -13,8 +13,6 @@
 #
 # Prerequisites:
 #   - gateway-linux-amd64 cross-compiled into dist/ (see build-linux.sh)
-#   - dist/gateway-config-or-mock.yaml available locally for the C2 check, or
-#     pass via GATEWAY_CONFIG env (see GATEWAY_CONFIG below).
 #   - /etc/macprovider/gateway.env on Pearl already contains:
 #       COORDINATOR_OPERATOR_KEY, MACPROVIDER_KEY_HASH_SECRET,
 #       MACPROVIDER_DEMO_SIGNING_SECRET,
@@ -33,12 +31,12 @@
 #   VPS_USER         default: root
 #   DOMAIN           default: api.streamvc.live
 #   EMAIL            default: augstar@gmail.com
-#   GATEWAY_CONFIG   path to a real gateway.yaml to use for the pre-deploy
-#                    C2 cross-check (must contain timeouts.coordinator_request_seconds).
-#                    Defaults to ./gateway.yaml under dist/. Missing config aborts
-#                    the deploy unless SKIP_C2_CHECK=1 is also set; the deploy
-#                    intentionally REFUSES gateway.yaml.example as input — sample
-#                    config is documentation, not a production safety input.
+#   --dry-run-local  developer-only: run the old local-config C2 check using
+#                    GATEWAY_CONFIG and exit before any SSH mutation.
+#   GATEWAY_CONFIG   used only with --dry-run-local. Production deploys validate
+#                    the gateway config installed on Pearl.
+#   GATEWAY_REMOTE_CONFIG  installed gateway config path on Pearl.
+#                    Default: /opt/macprovider/gateway.yaml.
 #   COORD_CONFIG     path to the coordinator.yaml that's expected to be live
 #                    on Pearl. Defaults to ../../phase4-coordinator/dist/coordinator.yaml
 #                    if present. Used for the C2 timer cross-check.
@@ -47,6 +45,18 @@
 #   STRICT_PROVENANCE=1  abort if /healthz returns no "version" field.
 
 set -euo pipefail
+
+DRY_RUN_LOCAL=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run-local) DRY_RUN_LOCAL=1 ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      echo "usage: bash deploy-pearl-vps.sh [--dry-run-local]" >&2
+      exit 2
+      ;;
+  esac
+done
 
 SSH_KEY="${SSH_KEY:-$HOME/.ssh/pearl_operator_ed25519}"
 VPS_HOST="${VPS_HOST:-159.223.165.194}"
@@ -117,6 +127,7 @@ NGINX_SITE="$DIST_DIR/nginx-api.streamvc.live.conf"
 # fail-closed gate.
 GATEWAY_CONFIG_DEFAULT="$DIST_DIR/gateway.yaml"
 GATEWAY_CONFIG="${GATEWAY_CONFIG:-$GATEWAY_CONFIG_DEFAULT}"
+GATEWAY_REMOTE_CONFIG="${GATEWAY_REMOTE_CONFIG:-/opt/macprovider/gateway.yaml}"
 
 COORD_CONFIG_DEFAULT="$DIST_DIR/../../phase4-coordinator/dist/coordinator.yaml"
 COORD_CONFIG="${COORD_CONFIG:-$COORD_CONFIG_DEFAULT}"
@@ -145,41 +156,123 @@ SCP="scp -i $SSH_KEY -P 22"
 
 log() { printf "\n[deploy-gateway] %s\n" "$*"; }
 
+case "$GATEWAY_REMOTE_CONFIG" in
+  /*) ;;
+  *) echo "aborting deploy: GATEWAY_REMOTE_CONFIG must be an absolute path" >&2; exit 5 ;;
+esac
+case "$GATEWAY_REMOTE_CONFIG" in
+  *[!A-Za-z0-9._/-]*)
+    echo "aborting deploy: GATEWAY_REMOTE_CONFIG contains unsupported characters: $GATEWAY_REMOTE_CONFIG" >&2
+    exit 5
+    ;;
+esac
+
 # #290 (mirrors #244 R6 CODE+SEC+ARCH convergent MED) — register the
 # EXIT cleanup trap UNCONDITIONALLY, before any temp resource is
 # created. Same threat model as the coordinator: if the deploy fails
 # mid-flight, the remote staging dir must not persist. $DEPLOY_TMP is
 # guarded with `:-` so the trap is a no-op when it is unset.
 trap '
+  rm -f "${GATEWAY_REMOTE_CONFIG_TMP:-}"
   if [ -n "${DEPLOY_TMP:-}" ]; then
     $SSH "rm -rf $DEPLOY_TMP" 2>/dev/null || true
   fi
 ' EXIT
+
+read_gateway_db_path_from_file() {
+  awk '
+    BEGIN { in_storage=0 }
+    {
+      line=$0
+      sub(/[[:space:]]+#.*$/, "", line)
+    }
+    line ~ /^[[:space:]]*storage:[[:space:]]*$/ { in_storage=1; next }
+    in_storage && line ~ /^[^[:space:]#][^:]*:/ { exit }
+    in_storage && line ~ /^[[:space:]]*db_path:[[:space:]]*/ {
+      sub(/^[[:space:]]*db_path:[[:space:]]*/, "", line)
+      gsub(/^"|"$/, "", line)
+      gsub(/^'\''|'\''$/, "", line)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+      print line
+      exit
+    }
+  ' "$1"
+}
 
 log "step 0/8: pre-deploy C2 cross-component config check"
 # M1-6 follow-up (codex audits 2026-06-11): require real configs for C2,
 # or an explicit SKIP_C2_CHECK=1 override. The previous "best-effort"
 # path treated missing inputs as a warning, which weakened a deploy gate
 # the audit called out as mandatory.
-if [ "${SKIP_C2_CHECK:-0}" = "1" ]; then
+if [ "$DRY_RUN_LOCAL" = "1" ]; then
+  echo "  --dry-run-local set — validating local GATEWAY_CONFIG and exiting before deploy" >&2
+  if [ -x "$CHECK_SCRIPT" ] && [ -f "$COORD_CONFIG" ] && [ -f "$GATEWAY_CONFIG" ]; then
+    bash "$CHECK_SCRIPT" "$COORD_CONFIG" "$GATEWAY_CONFIG" || {
+      echo "aborting gateway deploy dry-run: local config-drift check failed" >&2; exit 5;
+    }
+    echo "  local dry-run C2 check passed"
+    exit 0
+  fi
+  echo "aborting gateway deploy dry-run: cannot run local C2 cross-check." >&2
+  echo "  check-deploy-config.sh: $CHECK_SCRIPT $( [ -x "$CHECK_SCRIPT" ] || echo '(missing or not executable)')" >&2
+  echo "  coordinator config:    $COORD_CONFIG $( [ -f "$COORD_CONFIG" ] || echo '(missing)')" >&2
+  echo "  gateway config:        $GATEWAY_CONFIG $( [ -f "$GATEWAY_CONFIG" ] || echo '(missing — provide GATEWAY_CONFIG=<path>)')" >&2
+  exit 5
+elif [ "${SKIP_C2_CHECK:-0}" = "1" ]; then
   echo "  SKIP_C2_CHECK=1 set — C2 cross-check skipped by operator opt-out" >&2
-elif [ -x "$CHECK_SCRIPT" ] && [ -f "$COORD_CONFIG" ] && [ -f "$GATEWAY_CONFIG" ]; then
-  bash "$CHECK_SCRIPT" "$COORD_CONFIG" "$GATEWAY_CONFIG" || {
+elif [ -x "$CHECK_SCRIPT" ] && [ -f "$COORD_CONFIG" ]; then
+  GATEWAY_REMOTE_CONFIG_TMP="$(umask 077 && mktemp -t macprovider-gateway-installed-config.XXXXXXXX)" || {
+    echo "aborting gateway deploy: mktemp failed for installed config copy" >&2; exit 5;
+  }
+  $SSH "test -f '$GATEWAY_REMOTE_CONFIG' || { echo 'missing installed gateway config: $GATEWAY_REMOTE_CONFIG' >&2; exit 1; }; cat '$GATEWAY_REMOTE_CONFIG'" > "$GATEWAY_REMOTE_CONFIG_TMP" || {
+    echo "aborting gateway deploy: could not read installed gateway config from Pearl: $GATEWAY_REMOTE_CONFIG" >&2
+    exit 5
+  }
+  GATEWAY_REMOTE_CONFIG_SHA=$(shasum -a 256 "$GATEWAY_REMOTE_CONFIG_TMP" | awk '{print $1}')
+  echo "  validating installed Pearl config: $GATEWAY_REMOTE_CONFIG sha256=$GATEWAY_REMOTE_CONFIG_SHA"
+  bash "$CHECK_SCRIPT" "$COORD_CONFIG" "$GATEWAY_REMOTE_CONFIG_TMP" || {
     echo "aborting gateway deploy: config-drift check failed" >&2; exit 5;
   }
 else
   echo "aborting gateway deploy: cannot run C2 cross-check." >&2
   echo "  check-deploy-config.sh: $CHECK_SCRIPT $( [ -x "$CHECK_SCRIPT" ] || echo '(missing or not executable)')" >&2
   echo "  coordinator config:    $COORD_CONFIG $( [ -f "$COORD_CONFIG" ] || echo '(missing)')" >&2
-  echo "  gateway config:        $GATEWAY_CONFIG $( [ -f "$GATEWAY_CONFIG" ] || echo '(missing — provide GATEWAY_CONFIG=<path>)')" >&2
+  echo "  installed gateway config on Pearl: $GATEWAY_REMOTE_CONFIG" >&2
   echo "  To deploy without the cross-check, set SKIP_C2_CHECK=1 explicitly." >&2
-  echo "  gateway.yaml.example is sample documentation and intentionally NOT accepted here." >&2
+  echo "  Local gateway.yaml files are intentionally NOT accepted in production deploy mode." >&2
   exit 5
 fi
-# Defensive: even with C2 skipped, the gateway config (if provided) must at
-# least carry the coordinator_request_seconds key the C2 check looks at.
-if [ -f "$GATEWAY_CONFIG" ] && ! grep -qE '^[[:space:]]*coordinator_request_seconds:' "$GATEWAY_CONFIG"; then
-  echo "  FAIL: gateway config $GATEWAY_CONFIG missing timeouts.coordinator_request_seconds" >&2
+if [ -z "${GATEWAY_REMOTE_CONFIG_TMP:-}" ]; then
+  GATEWAY_REMOTE_CONFIG_TMP="$(umask 077 && mktemp -t macprovider-gateway-installed-config.XXXXXXXX)" || {
+    echo "aborting gateway deploy: mktemp failed for installed config copy" >&2; exit 5;
+  }
+  $SSH "test -f '$GATEWAY_REMOTE_CONFIG' || { echo 'missing installed gateway config: $GATEWAY_REMOTE_CONFIG' >&2; exit 1; }; cat '$GATEWAY_REMOTE_CONFIG'" > "$GATEWAY_REMOTE_CONFIG_TMP" || {
+    echo "aborting gateway deploy: could not read installed gateway config from Pearl: $GATEWAY_REMOTE_CONFIG" >&2
+    exit 5
+  }
+  GATEWAY_REMOTE_CONFIG_SHA=$(shasum -a 256 "$GATEWAY_REMOTE_CONFIG_TMP" | awk '{print $1}')
+  echo "  installed Pearl config sha256=$GATEWAY_REMOTE_CONFIG_SHA"
+fi
+REMOTE_GATEWAY_DB_PATH="$(read_gateway_db_path_from_file "$GATEWAY_REMOTE_CONFIG_TMP")"
+if [ -z "$REMOTE_GATEWAY_DB_PATH" ]; then
+  echo "aborting gateway deploy: installed Pearl config missing storage.db_path ($GATEWAY_REMOTE_CONFIG sha256=$GATEWAY_REMOTE_CONFIG_SHA)" >&2
+  exit 5
+fi
+case "$REMOTE_GATEWAY_DB_PATH" in
+  /*) ;;
+  *) echo "aborting gateway deploy: storage.db_path must be absolute in installed Pearl config: $REMOTE_GATEWAY_DB_PATH" >&2; exit 5 ;;
+esac
+case "$REMOTE_GATEWAY_DB_PATH" in
+  *[!A-Za-z0-9._/-]*)
+    echo "aborting gateway deploy: storage.db_path contains unsupported characters: $REMOTE_GATEWAY_DB_PATH" >&2
+    exit 5
+    ;;
+esac
+echo "  installed Pearl DB path: $REMOTE_GATEWAY_DB_PATH"
+REMOTE_GATEWAY_DB_DIR="$(dirname "$REMOTE_GATEWAY_DB_PATH")"
+REMOTE_GATEWAY_DB_BASE="$(basename "$REMOTE_GATEWAY_DB_PATH")"
+if ! grep -qE '^[[:space:]]*coordinator_request_seconds:' "$GATEWAY_REMOTE_CONFIG_TMP"; then
+  echo "  FAIL: installed gateway config $GATEWAY_REMOTE_CONFIG missing timeouts.coordinator_request_seconds" >&2
   exit 5
 fi
 log "step 1/8: confirm SSH + DNS"
@@ -329,7 +422,7 @@ log "step 2d/8: pre-restart snapshot of gateway.db (BEFORE binary swap — #290 
 # expansion, no xargs, filename-injection closed.
 $SSH 'set -e
   TS=$(date -u +%Y%m%dT%H%M%SZ)
-  DB=/var/lib/macprovider/gateway.db
+  DB='"$REMOTE_GATEWAY_DB_PATH"'
   if [ -f "$DB" ]; then
     SNAP="${DB}.pre-deploy.${TS}"
     # #290 R1 (SEC+ARCH convergent CRITICAL) — run ENTIRE snapshot as
@@ -352,8 +445,9 @@ $SSH 'set -e
     # cannot smuggle an unlink of arbitrary paths.
     sudo -u macprovider python3 - <<PYEOF
 import os, re, sys
-d = "/var/lib/macprovider"
-pat = re.compile(r"^gateway\.db\.pre-deploy\.[0-9]{8}T[0-9]{6}Z$")
+d = "'"$REMOTE_GATEWAY_DB_DIR"'"
+base = "'"$REMOTE_GATEWAY_DB_BASE"'"
+pat = re.compile("^" + re.escape(base) + r"\.pre-deploy\.[0-9]{8}T[0-9]{6}Z$")
 try:
     entries = os.listdir(d)
 except OSError:
@@ -516,7 +610,9 @@ echo "      # #290 R7 CODE MED plus R8 CODE+ARCH MED: glob must expand"
 echo "      # INSIDE the sudo-macprovider shell (caller may not traverse"
 echo "      # the 0750 daemon dir), AND the sh -c body must use DOUBLE"
 echo "      # quotes so it does not close the outer ssh single-quote."
-echo "      LATEST=\$(sudo -u macprovider sh -c \"ls -1t /var/lib/macprovider/gateway.db.pre-deploy.* 2>/dev/null | head -1\") &&"
+ROLLBACK_DB_DIR="$(dirname "$REMOTE_GATEWAY_DB_PATH")"
+ROLLBACK_DB_BASE="$(basename "$REMOTE_GATEWAY_DB_PATH")"
+echo "      LATEST=\$(sudo -u macprovider sh -c \"ls -1t $ROLLBACK_DB_DIR/$ROLLBACK_DB_BASE.pre-deploy.* 2>/dev/null | head -1\") &&"
 echo "      [ -n \"\$LATEST\" ] && sudo -u macprovider test -f \"\$LATEST\" && sudo -u macprovider test -r \"\$LATEST\" &&"
 echo "      sudo -u macprovider sqlite3 \"\$LATEST\" \"PRAGMA integrity_check;\" | head -1 | grep -q \"^ok\$\" &&"
 echo "      # Validate .prev binary is present + executable BEFORE stopping"
@@ -529,9 +625,9 @@ echo "      sudo install -o root -g macprovider -m 0750 /opt/macprovider/gateway
 echo "      # #290 R3 CODE HIGH — remove stale WAL/SHM sidecars before"
 echo "      # restoring the snapshot; SQLite would otherwise replay the WAL"
 echo "      # and reintroduce post-deploy state, silently defeating rollback."
-echo "      sudo rm -f /var/lib/macprovider/gateway.db-wal /var/lib/macprovider/gateway.db-shm &&"
-echo "      sudo install -o macprovider -g macprovider -m 0600 \"\$LATEST\" /var/lib/macprovider/gateway.db &&"
-echo "      sudo -u macprovider sqlite3 /var/lib/macprovider/gateway.db \"PRAGMA integrity_check;\" &&"
+echo "      sudo rm -f $REMOTE_GATEWAY_DB_PATH-wal $REMOTE_GATEWAY_DB_PATH-shm &&"
+echo "      sudo install -o macprovider -g macprovider -m 0600 \"\$LATEST\" $REMOTE_GATEWAY_DB_PATH &&"
+echo "      sudo -u macprovider sqlite3 $REMOTE_GATEWAY_DB_PATH \"PRAGMA integrity_check;\" &&"
 echo "      sudo systemctl start macprovider-gateway &&"
 echo "      curl -s http://127.0.0.1:9443/healthz   # confirm OK + version reflects .prev"
 echo "    '"

--- a/phase5-gateway/dist/test/gateway_deploy_c2_precheck.test.sh
+++ b/phase5-gateway/dist/test/gateway_deploy_c2_precheck.test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_SH="$SCRIPT_DIR/../deploy-pearl-vps.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+bash -n "$DEPLOY_SH"
+
+grep -q -- '--dry-run-local' "$DEPLOY_SH" ||
+  fail "deploy script lacks explicit --dry-run-local developer path"
+
+grep -q "validating installed Pearl config: .*sha256=" "$DEPLOY_SH" ||
+  fail "deploy script does not log installed config SHA-256"
+
+grep -q 'cat '"'"'\$GATEWAY_REMOTE_CONFIG'"'" "$DEPLOY_SH" ||
+  fail "deploy script does not read installed Pearl gateway config over SSH"
+
+local_count=$(grep -c 'bash "$CHECK_SCRIPT" "$COORD_CONFIG" "$GATEWAY_CONFIG"' "$DEPLOY_SH" || true)
+if [ "$local_count" != "1" ]; then
+  fail "local GATEWAY_CONFIG C2 path should appear exactly once inside --dry-run-local, got $local_count"
+fi
+
+grep -q 'bash "$CHECK_SCRIPT" "$COORD_CONFIG" "$GATEWAY_REMOTE_CONFIG_TMP"' "$DEPLOY_SH" ||
+  fail "production C2 path does not validate the installed Pearl config copy"
+
+echo "PASS: gateway deploy C2 precheck reads installed VPS config by default"

--- a/phase5-gateway/dist/test/gateway_deploy_snapshot.test.sh
+++ b/phase5-gateway/dist/test/gateway_deploy_snapshot.test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_SH="$SCRIPT_DIR/../deploy-pearl-vps.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+bash -n "$DEPLOY_SH"
+
+grep -q 'REMOTE_GATEWAY_DB_PATH="$(read_gateway_db_path_from_file "$GATEWAY_REMOTE_CONFIG_TMP")"' "$DEPLOY_SH" ||
+  fail "deploy script does not derive DB path from installed config"
+
+if grep -q 'DB=/var/lib/macprovider/gateway.db' "$DEPLOY_SH"; then
+  fail "deploy script still snapshots hardcoded /var/lib/macprovider/gateway.db"
+fi
+
+grep -q 'DB=.*REMOTE_GATEWAY_DB_PATH' "$DEPLOY_SH" ||
+  fail "remote snapshot block does not use derived REMOTE_GATEWAY_DB_PATH"
+
+grep -Fq 'sudo rm -f $REMOTE_GATEWAY_DB_PATH-wal $REMOTE_GATEWAY_DB_PATH-shm' "$DEPLOY_SH" ||
+  fail "rollback recipe does not remove WAL/SHM for derived DB path"
+
+grep -q 'sudo install -o macprovider -g macprovider -m 0600 .*REMOTE_GATEWAY_DB_PATH' "$DEPLOY_SH" ||
+  fail "rollback recipe does not restore derived DB path"
+
+echo "PASS: gateway deploy snapshot/rollback uses installed storage.db_path"

--- a/phase5-gateway/internal/router/admin.go
+++ b/phase5-gateway/internal/router/admin.go
@@ -47,40 +47,72 @@ func (s *Server) handleKillSwitch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req struct {
-		DemoOnly     *bool `json:"demo_only"`
-		AllPublicAPI *bool `json:"all_public_api"`
+		DemoOnly     *bool  `json:"demo_only"`
+		AllPublicAPI *bool  `json:"all_public_api"`
+		Version      *int64 `json:"version"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_kill_switch", "Invalid kill switch request")
 		return
 	}
-	s.mu.RLock()
-	old := s.cfg.KillSwitch
-	next := s.cfg
-	s.mu.RUnlock()
-	if req.DemoOnly != nil {
-		next.KillSwitch.DemoOnly = *req.DemoOnly
-	}
-	if req.AllPublicAPI != nil {
-		next.KillSwitch.AllPublicAPI = *req.AllPublicAPI
-	}
-	if err := s.store.SetKillSwitch(r.Context(), storage.KillSwitchState{
-		DemoOnly:     next.KillSwitch.DemoOnly,
-		AllPublicAPI: next.KillSwitch.AllPublicAPI,
-		UpdatedAt:    s.now(),
-	}); err != nil {
-		writeError(w, http.StatusInternalServerError, "server_error", "kill_switch_persist_failed", "Could not persist kill switch")
+	if req.Version == nil || *req.Version < 0 {
+		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_kill_switch_version", "Kill switch version must be provided")
 		return
 	}
+	current, err := s.store.GetKillSwitch(r.Context())
+	if err != nil {
+		s.adminMetrics.recordError(adminStateWriteHandlerKillSwitch)
+		slog.Error("admin state write failed", "handler", adminStateWriteHandlerKillSwitch, "error", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "admin_state_write_failed", "Could not load kill switch")
+		return
+	}
+	if current.UpdatedAt.IsZero() {
+		s.mu.RLock()
+		current.DemoOnly = s.cfg.KillSwitch.DemoOnly
+		current.AllPublicAPI = s.cfg.KillSwitch.AllPublicAPI
+		s.mu.RUnlock()
+	}
+	next := current
+	if req.DemoOnly != nil {
+		next.DemoOnly = *req.DemoOnly
+	}
+	if req.AllPublicAPI != nil {
+		next.AllPublicAPI = *req.AllPublicAPI
+	}
+	next.UpdatedAt = s.now()
+	applied, err := s.store.CompareAndSwapKillSwitch(r.Context(), *req.Version, next)
+	if err != nil {
+		s.adminMetrics.recordError(adminStateWriteHandlerKillSwitch)
+		slog.Error("admin state write failed", "handler", adminStateWriteHandlerKillSwitch, "error", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "admin_state_write_failed", "Could not persist kill switch")
+		return
+	}
+	if !applied {
+		latest, latestErr := s.store.GetKillSwitch(r.Context())
+		if latestErr != nil {
+			s.adminMetrics.recordError(adminStateWriteHandlerKillSwitch)
+			slog.Error("admin state write failed", "handler", adminStateWriteHandlerKillSwitch, "error", latestErr)
+			writeError(w, http.StatusInternalServerError, "server_error", "admin_state_write_failed", "Could not load current kill switch")
+			return
+		}
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error":           map[string]any{"message": "Kill switch state changed; refetch and retry", "type": "conflict_error", "param": "version", "code": "kill_switch_version_conflict"},
+			"current_version": latest.Version,
+			"kill_switch":     latest,
+		})
+		return
+	}
+	next.Version = *req.Version + 1
 	s.mu.Lock()
-	s.cfg.KillSwitch = next.KillSwitch
+	s.cfg.KillSwitch.DemoOnly = next.DemoOnly
+	s.cfg.KillSwitch.AllPublicAPI = next.AllPublicAPI
 	s.mu.Unlock()
 	_ = s.store.InsertAuditEvent(r.Context(), storage.AuditEvent{
 		EventID: mustID("audit"), RequestID: requestID(r), Actor: "operator", Type: "kill_switch_toggled",
-		Payload:   fmt.Sprintf(`{"old_demo_only":%t,"new_demo_only":%t,"old_all_public_api":%t,"new_all_public_api":%t}`, old.DemoOnly, next.KillSwitch.DemoOnly, old.AllPublicAPI, next.KillSwitch.AllPublicAPI),
+		Payload:   fmt.Sprintf(`{"old_demo_only":%t,"new_demo_only":%t,"old_all_public_api":%t,"new_all_public_api":%t,"old_version":%d,"new_version":%d}`, current.DemoOnly, next.DemoOnly, current.AllPublicAPI, next.AllPublicAPI, current.Version, next.Version),
 		CreatedAt: s.now(),
 	})
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "kill_switch": next.KillSwitch})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "kill_switch": next})
 }
 
 func (s *Server) handleCapacitySignal(w http.ResponseWriter, r *http.Request) {
@@ -107,15 +139,34 @@ func (s *Server) handleCapacitySignal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if req.Firing {
-		tier, _ := s.store.GetCapacityTier(r.Context())
+		tier, err := s.store.GetCapacityTier(r.Context())
+		if err != nil {
+			s.adminStateWriteFailed(w, adminStateWriteHandlerCapacity, err)
+			return
+		}
 		if req.Signal == "monthly_cost" && req.Value >= float64(s.cfg.Capacity.MonthlyBudgetUSD) {
-			_ = s.setCapacityTier(r.Context(), 3, req.Signal, "capacity_tier_escalated")
-			s.setAllPublicPaused(r.Context(), true, "capacity_tier_3")
+			if err := s.setCapacityTier(r.Context(), 3, req.Signal, "capacity_tier_escalated"); err != nil {
+				s.adminStateWriteFailed(w, adminStateWriteHandlerCapacity, err)
+				return
+			}
+			if err := s.setAllPublicPaused(r.Context(), true, "capacity_tier_3"); err != nil {
+				s.adminStateWriteFailed(w, adminStateWriteHandlerCapacity, err)
+				return
+			}
 		} else if req.Signal == "provider_drop" && req.Value >= 2 {
-			_ = s.setCapacityTier(r.Context(), 3, req.Signal, "capacity_tier_escalated")
-			s.setAllPublicPaused(r.Context(), true, "capacity_tier_3")
+			if err := s.setCapacityTier(r.Context(), 3, req.Signal, "capacity_tier_escalated"); err != nil {
+				s.adminStateWriteFailed(w, adminStateWriteHandlerCapacity, err)
+				return
+			}
+			if err := s.setAllPublicPaused(r.Context(), true, "capacity_tier_3"); err != nil {
+				s.adminStateWriteFailed(w, adminStateWriteHandlerCapacity, err)
+				return
+			}
 		} else if tier.Tier == 0 {
-			_ = s.setCapacityTier(r.Context(), 1, req.Signal, "capacity_tier_escalated")
+			if err := s.setCapacityTier(r.Context(), 1, req.Signal, "capacity_tier_escalated"); err != nil {
+				s.adminStateWriteFailed(w, adminStateWriteHandlerCapacity, err)
+				return
+			}
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "event_id": event.EventID})
@@ -148,12 +199,21 @@ func (s *Server) handleCapacityEvaluate(w http.ResponseWriter, r *http.Request) 
 	below := !anyFiring
 	if previous == 1 && !below && s.now().Sub(tier.UpdatedAt) >= 7*24*time.Hour {
 		next = 2
-		_ = s.setCapacityTier(r.Context(), next, "tier_1_signal_still_firing", "capacity_tier_escalated")
+		if err := s.setCapacityTier(r.Context(), next, "tier_1_signal_still_firing", "capacity_tier_escalated"); err != nil {
+			s.adminStateWriteFailed(w, adminStateWriteHandlerCapacity, err)
+			return
+		}
 	} else if previous > 0 && below && s.now().Sub(tier.UpdatedAt) >= time.Duration(s.cfg.Capacity.TierCooldownSeconds)*time.Second {
 		next = previous - 1
-		_ = s.setCapacityTier(r.Context(), next, "signals_below_threshold", "capacity_tier_deescalated")
+		if err := s.setCapacityTier(r.Context(), next, "signals_below_threshold", "capacity_tier_deescalated"); err != nil {
+			s.adminStateWriteFailed(w, adminStateWriteHandlerCapacity, err)
+			return
+		}
 		if previous == 3 {
-			s.setAllPublicPaused(r.Context(), false, "capacity_tier_deescalated")
+			if err := s.setAllPublicPaused(r.Context(), false, "capacity_tier_deescalated"); err != nil {
+				s.adminStateWriteFailed(w, adminStateWriteHandlerCapacity, err)
+				return
+			}
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"previous_tier": previous, "new_tier": next, "signals_below_threshold": below})
@@ -170,13 +230,13 @@ func (s *Server) setCapacityTier(ctx context.Context, tier int, signals, eventTy
 	})
 }
 
-func (s *Server) setAllPublicPaused(ctx context.Context, paused bool, reason string) {
+func (s *Server) setAllPublicPaused(ctx context.Context, paused bool, reason string) error {
 	s.mu.Lock()
 	old := s.cfg.KillSwitch.AllPublicAPI
 	s.cfg.KillSwitch.AllPublicAPI = paused
 	s.mu.Unlock()
 	if old == paused {
-		return
+		return nil
 	}
 	if err := s.store.SetKillSwitch(ctx, storage.KillSwitchState{
 		DemoOnly:     s.demoPaused(),
@@ -184,11 +244,22 @@ func (s *Server) setAllPublicPaused(ctx context.Context, paused bool, reason str
 		UpdatedAt:    s.now(),
 	}); err != nil {
 		slog.Error("kill switch persistence failed", "error", err, "reason", reason)
+		s.mu.Lock()
+		s.cfg.KillSwitch.AllPublicAPI = old
+		s.mu.Unlock()
+		return err
 	}
 	_ = s.store.InsertAuditEvent(ctx, storage.AuditEvent{
 		EventID: mustID("audit"), RequestID: mustID("req"), Actor: "capacity_monitor", Type: "kill_switch_toggled",
 		Payload: fmt.Sprintf(`{"old_all_public_api":%t,"new_all_public_api":%t,"reason":%q}`, old, paused, reason), CreatedAt: s.now(),
 	})
+	return nil
+}
+
+func (s *Server) adminStateWriteFailed(w http.ResponseWriter, handler string, err error) {
+	s.adminMetrics.recordError(handler)
+	slog.Error("admin state write failed", "handler", handler, "error", err)
+	writeError(w, http.StatusInternalServerError, "server_error", "admin_state_write_failed", "Could not persist admin state")
 }
 
 func buildFeedbackSummary(events []storage.FeedbackSummaryEvent, start, end time.Time) map[string]any {

--- a/phase5-gateway/internal/router/admin_metrics.go
+++ b/phase5-gateway/internal/router/admin_metrics.go
@@ -1,0 +1,57 @@
+package router
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const (
+	adminStateWriteHandlerCapacity   = "capacity"
+	adminStateWriteHandlerKillSwitch = "kill_switch"
+)
+
+type adminStateWriteMetrics struct {
+	mu     sync.Mutex
+	errors map[string]int64
+}
+
+func newAdminStateWriteMetrics() *adminStateWriteMetrics {
+	return &adminStateWriteMetrics{errors: map[string]int64{
+		adminStateWriteHandlerCapacity:   0,
+		adminStateWriteHandlerKillSwitch: 0,
+	}}
+}
+
+func (m *adminStateWriteMetrics) recordError(handler string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.errors[normalizeAdminStateWriteHandler(handler)]++
+}
+
+func (m *adminStateWriteMetrics) prometheus() string {
+	if m == nil {
+		m = newAdminStateWriteMetrics()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var b strings.Builder
+	b.WriteString("# HELP admin_state_write_error_total Admin control-plane state writes that failed durability or optimistic concurrency checks.\n")
+	b.WriteString("# TYPE admin_state_write_error_total counter\n")
+	for _, handler := range []string{adminStateWriteHandlerCapacity, adminStateWriteHandlerKillSwitch} {
+		fmt.Fprintf(&b, "admin_state_write_error_total{handler=%q} %d\n", handler, m.errors[handler])
+	}
+	return b.String()
+}
+
+func normalizeAdminStateWriteHandler(handler string) string {
+	switch handler {
+	case adminStateWriteHandlerCapacity, adminStateWriteHandlerKillSwitch:
+		return handler
+	default:
+		return "unknown"
+	}
+}

--- a/phase5-gateway/internal/router/integration_test.go
+++ b/phase5-gateway/internal/router/integration_test.go
@@ -534,7 +534,7 @@ func TestDemoOnlyKillSwitchPausesPlaygroundFeedback(t *testing.T) {
 	h, _, _, _ := newTestHarnessConfig(t, fakeOAuth{}, nil)
 	demoToken := issueDemoToken(t, h, "1.2.3.4")
 
-	postAdminJSON(t, h, "/admin/kill-switch", `{"demo_only":true}`)
+	postAdminJSON(t, h, "/admin/kill-switch", `{"demo_only":true,"version":0}`)
 	resp := postFeedback(t, h, "", demoToken, `{"rating":4,"scope":"playground"}`)
 	if resp.Code != http.StatusServiceUnavailable {
 		t.Fatalf("feedback status=%d body=%s", resp.Code, resp.Body.String())

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -60,6 +60,7 @@ type Server struct {
 	// harmless; cap on bursts.
 	routingMeta     routingMetaCache
 	retry503Metrics *retry503Metrics
+	adminMetrics    *adminStateWriteMetrics
 }
 
 // readStore returns the read-only view of the database. M2-4: this
@@ -163,6 +164,7 @@ func New(cfg config.Config, store Store, oauth auth.OAuthProvider, opts ...Optio
 		trustedProxyNets: trustedProxyNets,
 		version:          "dev",
 		retry503Metrics:  newRetry503Metrics(),
+		adminMetrics:     newAdminStateWriteMetrics(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -228,6 +230,7 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 	_, _ = w.Write([]byte(s.retry503Metrics.prometheus()))
+	_, _ = w.Write([]byte(s.adminMetrics.prometheus()))
 }
 
 func (s *Server) middleware(next http.Handler) http.Handler {
@@ -588,7 +591,7 @@ type poolzProviderRow struct {
 	PublishesSupportedModels bool     `json:"publishes_supported_models,omitempty"`
 	// routing_eligible is coordinator-computed from pool.Provider.RoutingEligible().
 	// Omitted on legacy coordinators — gateway falls back to auth_state exclusion.
-	RoutingEligible *bool `json:"routing_eligible,omitempty"`
+	RoutingEligible *bool  `json:"routing_eligible,omitempty"`
 	AuthState       string `json:"auth_state,omitempty"`
 }
 

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -832,7 +832,7 @@ func TestKillSwitchPersistsAcrossRestart(t *testing.T) {
 	defer store.Close()
 	h := New(cfg, store, fakeOAuth{}, WithNow(fixedNow), WithConfigPath(configPath), WithHTTPClient(noopClient())).Handler()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/kill-switch", strings.NewReader(`{"all_public_api":true}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/kill-switch", strings.NewReader(`{"all_public_api":true,"version":0}`))
 	req.Header.Set("Authorization", "Bearer operator-key")
 	resp := httptest.NewRecorder()
 	h.ServeHTTP(resp, req)
@@ -853,6 +853,9 @@ func TestKillSwitchPersistsAcrossRestart(t *testing.T) {
 	if !runtimeState.AllPublicAPI {
 		t.Fatalf("kill switch did not persist to runtime state")
 	}
+	if runtimeState.Version != 1 {
+		t.Fatalf("kill switch version=%d want 1", runtimeState.Version)
+	}
 	if countAuditEvents(t, cfg.Storage.DBPath, "kill_switch_toggled") != 1 {
 		t.Fatalf("kill_switch_toggled audit missing")
 	}
@@ -865,6 +868,142 @@ func TestKillSwitchPersistsAcrossRestart(t *testing.T) {
 		t.Fatalf("paused chat status=%d body=%s", chatResp.Code, chatResp.Body.String())
 	}
 	assertErrorCode(t, chatResp.Body.String(), "public_api_paused")
+}
+
+func TestKillSwitchVersionConflictRejectsStaleWrite(t *testing.T) {
+	h, store, _, _ := newTestHarness(t, fakeOAuth{})
+
+	first := postAdminJSON(t, h, "/admin/kill-switch", `{"demo_only":true,"version":0}`)
+	var firstBody struct {
+		KillSwitch storage.KillSwitchState `json:"kill_switch"`
+	}
+	if err := json.Unmarshal(first.Body.Bytes(), &firstBody); err != nil {
+		t.Fatalf("first response json: %v", err)
+	}
+	if firstBody.KillSwitch.Version != 1 {
+		t.Fatalf("first version=%d want 1", firstBody.KillSwitch.Version)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/kill-switch", strings.NewReader(`{"all_public_api":true,"version":0}`))
+	req.Header.Set("Authorization", "Bearer operator-key")
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("stale kill switch status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "kill_switch_version_conflict")
+	var conflict struct {
+		CurrentVersion int64 `json:"current_version"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &conflict); err != nil {
+		t.Fatalf("conflict json: %v", err)
+	}
+	if conflict.CurrentVersion != 1 {
+		t.Fatalf("current_version=%d want 1", conflict.CurrentVersion)
+	}
+	state, err := store.GetKillSwitch(context.Background())
+	if err != nil {
+		t.Fatalf("GetKillSwitch: %v", err)
+	}
+	if !state.DemoOnly || state.AllPublicAPI {
+		t.Fatalf("stale write changed state: %+v", state)
+	}
+}
+
+type failCapacitySetStore struct {
+	*sqlite.Store
+}
+
+func (s failCapacitySetStore) SetCapacityTier(ctx context.Context, tier storage.CapacityTier) error {
+	return errors.New("forced capacity write failure")
+}
+
+type failCapacityGetStore struct {
+	*sqlite.Store
+}
+
+func (s failCapacityGetStore) GetCapacityTier(ctx context.Context) (storage.CapacityTier, error) {
+	return storage.CapacityTier{}, errors.New("forced capacity load failure")
+}
+
+func TestCapacityTransitionWriteFailureReturns500AndMetric(t *testing.T) {
+	cfg := config.Default()
+	cfg.Auth.KeyHashSecret = "test-key-hash-secret"
+	cfg.Auth.Demo.SigningSecret = "test-demo-secret"
+	cfg.Coordinator.OperatorKey = "operator-key"
+	cfg.Storage.DBPath = filepath.Join(t.TempDir(), "gateway.db")
+	store, err := sqlite.Open(context.Background(), cfg.Storage.DBPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer store.Close()
+
+	h := New(cfg, failCapacitySetStore{Store: store}, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(noopClient())).Handler()
+	req := httptest.NewRequest(http.MethodPost, "/admin/capacity-signal", strings.NewReader(`{"signal":"cpu","value":80,"threshold":70,"firing":true}`))
+	req.Header.Set("Authorization", "Bearer operator-key")
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("capacity failure status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "admin_state_write_failed")
+	tier, err := store.GetCapacityTier(context.Background())
+	if err != nil {
+		t.Fatalf("GetCapacityTier: %v", err)
+	}
+	if tier.Tier != 0 {
+		t.Fatalf("capacity tier=%d want unchanged 0", tier.Tier)
+	}
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsResp := httptest.NewRecorder()
+	h.ServeHTTP(metricsResp, metricsReq)
+	if metricsResp.Code != http.StatusOK {
+		t.Fatalf("metrics status=%d body=%s", metricsResp.Code, metricsResp.Body.String())
+	}
+	if !strings.Contains(metricsResp.Body.String(), `admin_state_write_error_total{handler="capacity"} 1`) {
+		t.Fatalf("metrics missing capacity write error increment:\n%s", metricsResp.Body.String())
+	}
+}
+
+func TestCapacityTierLoadFailureReturns500AndMetric(t *testing.T) {
+	cfg := config.Default()
+	cfg.Auth.KeyHashSecret = "test-key-hash-secret"
+	cfg.Auth.Demo.SigningSecret = "test-demo-secret"
+	cfg.Coordinator.OperatorKey = "operator-key"
+	cfg.Storage.DBPath = filepath.Join(t.TempDir(), "gateway.db")
+	store, err := sqlite.Open(context.Background(), cfg.Storage.DBPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer store.Close()
+
+	h := New(cfg, failCapacityGetStore{Store: store}, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(noopClient())).Handler()
+	req := httptest.NewRequest(http.MethodPost, "/admin/capacity-signal", strings.NewReader(`{"signal":"cpu","value":80,"threshold":70,"firing":true}`))
+	req.Header.Set("Authorization", "Bearer operator-key")
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("capacity load failure status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "admin_state_write_failed")
+	tier, err := store.GetCapacityTier(context.Background())
+	if err != nil {
+		t.Fatalf("GetCapacityTier: %v", err)
+	}
+	if tier.Tier != 0 {
+		t.Fatalf("capacity tier=%d want unchanged 0", tier.Tier)
+	}
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsResp := httptest.NewRecorder()
+	h.ServeHTTP(metricsResp, metricsReq)
+	if metricsResp.Code != http.StatusOK {
+		t.Fatalf("metrics status=%d body=%s", metricsResp.Code, metricsResp.Body.String())
+	}
+	if !strings.Contains(metricsResp.Body.String(), `admin_state_write_error_total{handler="capacity"} 1`) {
+		t.Fatalf("metrics missing capacity load error increment:\n%s", metricsResp.Body.String())
+	}
 }
 
 func TestStatusRedactionAndPoolzCacheFlush(t *testing.T) {

--- a/phase5-gateway/internal/storage/interfaces.go
+++ b/phase5-gateway/internal/storage/interfaces.go
@@ -137,6 +137,7 @@ type CapacityStore interface {
 	SetCapacityTier(ctx context.Context, tier CapacityTier) error
 	GetKillSwitch(ctx context.Context) (KillSwitchState, error)
 	SetKillSwitch(ctx context.Context, state KillSwitchState) error
+	CompareAndSwapKillSwitch(ctx context.Context, expectedVersion int64, state KillSwitchState) (bool, error)
 }
 
 type ExplorerStore interface {

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -1941,14 +1941,85 @@ func (s *Store) SetKillSwitch(ctx context.Context, state storage.KillSwitchState
 	if state.UpdatedAt.IsZero() {
 		state.UpdatedAt = time.Now().UTC()
 	}
-	value, err := json.Marshal(struct {
-		DemoOnly     bool `json:"demo_only"`
-		AllPublicAPI bool `json:"all_public_api"`
-	}{DemoOnly: state.DemoOnly, AllPublicAPI: state.AllPublicAPI})
+	tx, err := s.beginImmediate(ctx)
 	if err != nil {
 		return err
 	}
-	_, err = s.db.ExecContext(ctx, `
+	defer tx.Rollback()
+	if err := func() error {
+		current, err := getKillSwitchTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		state.Version = current.Version + 1
+		return setKillSwitchTx(ctx, tx, state)
+	}(); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) CompareAndSwapKillSwitch(ctx context.Context, expectedVersion int64, state storage.KillSwitchState) (bool, error) {
+	if state.UpdatedAt.IsZero() {
+		state.UpdatedAt = time.Now().UTC()
+	}
+	applied := false
+	tx, err := s.beginImmediate(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+	if err := func() error {
+		current, err := getKillSwitchTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if current.Version != expectedVersion {
+			return nil
+		}
+		state.Version = current.Version + 1
+		if err := setKillSwitchTx(ctx, tx, state); err != nil {
+			return err
+		}
+		applied = true
+		return nil
+	}(); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return applied, err
+}
+
+func getKillSwitchTx(ctx context.Context, tx queryer) (storage.KillSwitchState, error) {
+	row := tx.QueryRowContext(ctx, `SELECT value, updated_at FROM runtime_config WHERE key = 'kill_switch'`)
+	var value string
+	var updated string
+	if err := row.Scan(&value, &updated); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return storage.KillSwitchState{}, nil
+		}
+		return storage.KillSwitchState{}, err
+	}
+	var state storage.KillSwitchState
+	if err := json.Unmarshal([]byte(value), &state); err != nil {
+		return storage.KillSwitchState{}, err
+	}
+	state.UpdatedAt = decodeTime(updated)
+	return state, nil
+}
+
+func setKillSwitchTx(ctx context.Context, tx execer, state storage.KillSwitchState) error {
+	value, err := json.Marshal(struct {
+		DemoOnly     bool  `json:"demo_only"`
+		AllPublicAPI bool  `json:"all_public_api"`
+		Version      int64 `json:"version"`
+	}{DemoOnly: state.DemoOnly, AllPublicAPI: state.AllPublicAPI, Version: state.Version})
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
 		INSERT INTO runtime_config(key, value, updated_at)
 		VALUES('kill_switch', ?, ?)
 		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,

--- a/phase5-gateway/internal/storage/sqlite/store_test.go
+++ b/phase5-gateway/internal/storage/sqlite/store_test.go
@@ -1297,6 +1297,52 @@ func TestFeedbackSummaryAndCapacityStores(t *testing.T) {
 	if !kill.DemoOnly || !kill.AllPublicAPI || !kill.UpdatedAt.Equal(now) {
 		t.Fatalf("kill switch = %+v", kill)
 	}
+	if kill.Version != 1 {
+		t.Fatalf("kill switch version=%d want 1", kill.Version)
+	}
+	applied, err := store.CompareAndSwapKillSwitch(ctx, 0, storage.KillSwitchState{DemoOnly: false, AllPublicAPI: true, UpdatedAt: now.Add(time.Minute)})
+	if err != nil {
+		t.Fatalf("CompareAndSwapKillSwitch mismatch: %v", err)
+	}
+	if applied {
+		t.Fatal("CompareAndSwapKillSwitch applied stale version")
+	}
+	kill, err = store.GetKillSwitch(ctx)
+	if err != nil {
+		t.Fatalf("GetKillSwitch after stale CAS: %v", err)
+	}
+	if !kill.DemoOnly || !kill.AllPublicAPI || kill.Version != 1 {
+		t.Fatalf("stale CAS changed kill switch = %+v", kill)
+	}
+	applied, err = store.CompareAndSwapKillSwitch(ctx, 1, storage.KillSwitchState{DemoOnly: false, AllPublicAPI: true, UpdatedAt: now.Add(2 * time.Minute)})
+	if err != nil {
+		t.Fatalf("CompareAndSwapKillSwitch match: %v", err)
+	}
+	if !applied {
+		t.Fatal("CompareAndSwapKillSwitch did not apply matching version")
+	}
+	kill, err = store.GetKillSwitch(ctx)
+	if err != nil {
+		t.Fatalf("GetKillSwitch after matching CAS: %v", err)
+	}
+	if kill.DemoOnly || !kill.AllPublicAPI || kill.Version != 2 {
+		t.Fatalf("matching CAS state = %+v", kill)
+	}
+}
+
+func TestKillSwitchCompareAndSwapReturnsErrorAfterClose(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	applied, err := store.CompareAndSwapKillSwitch(ctx, 0, storage.KillSwitchState{DemoOnly: true})
+	if err == nil {
+		t.Fatal("CompareAndSwapKillSwitch after close returned nil error")
+	}
+	if applied {
+		t.Fatal("CompareAndSwapKillSwitch after close reported applied")
+	}
 }
 
 // TestCapacityTierRoundTripSpecialChars verifies that SetCapacityTier/GetCapacityTier

--- a/phase5-gateway/internal/storage/types.go
+++ b/phase5-gateway/internal/storage/types.go
@@ -218,6 +218,7 @@ type CapacityTier struct {
 type KillSwitchState struct {
 	DemoOnly     bool      `json:"demo_only"`
 	AllPublicAPI bool      `json:"all_public_api"`
+	Version      int64     `json:"version"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 

--- a/specs/AUDIT_FIX_CONTROL_PLANE_ARCHITECT_R1.md
+++ b/specs/AUDIT_FIX_CONTROL_PLANE_ARCHITECT_R1.md
@@ -1,0 +1,27 @@
+# Architect Audit Prompt — Control Plane and Deploy Hardening R1
+
+Audit the implementation on branch `fix/deepsec-control-plane-and-deploy` from the architecture and operability lens.
+
+Scope:
+- Gateway admin mutation flow and storage contract:
+  - `phase5-gateway/internal/router/admin.go`
+  - `phase5-gateway/internal/storage/interfaces.go`
+  - `phase5-gateway/internal/storage/types.go`
+  - `phase5-gateway/internal/storage/sqlite/store.go`
+- Gateway deploy preflight / snapshot / rollback:
+  - `phase5-gateway/dist/deploy-pearl-vps.sh`
+  - `phase5-gateway/dist/test/gateway_deploy_*.test.sh`
+- Coordinator deploy and config load:
+  - `phase4-coordinator/dist/deploy-pearl-vps.sh`
+  - `phase4-coordinator/dist/test/coord_deploy_*.test.sh`
+  - `phase4-coordinator/internal/config/config.go`
+
+Review questions:
+- Is versioned kill-switch state a coherent extension of the existing `runtime_config` JSON pattern?
+- Does the compare-and-swap API keep ownership boundaries clear between router and storage?
+- Do deploy scripts now derive operational facts from installed VPS state without overfitting to a single path?
+- Are temp-file and redaction helpers centralized enough to prevent future callsite drift?
+- Is operator-key strength enforcement placed at the right lifecycle point without disrupting non-load validation tests or rotation follow-up work?
+- Are the tests proving the intended contracts without becoming brittle line-grep noise?
+
+Return findings ordered by severity with concrete file/line references. Use `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or `INFO`. State `0 C/H/M` explicitly if no architecture blockers are found.

--- a/specs/AUDIT_FIX_CONTROL_PLANE_CODE_R1.md
+++ b/specs/AUDIT_FIX_CONTROL_PLANE_CODE_R1.md
@@ -1,0 +1,32 @@
+# Code Audit Prompt — Control Plane and Deploy Hardening R1
+
+Audit the implementation on branch `fix/deepsec-control-plane-and-deploy` from the code-correctness lens.
+
+Scope:
+- `phase5-gateway/internal/router/admin.go`
+- `phase5-gateway/internal/router/admin_metrics.go`
+- `phase5-gateway/internal/router/admin_test.go` / relevant admin coverage in `server_test.go` and `integration_test.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/internal/storage/sqlite/store_test.go`
+- `phase5-gateway/internal/storage/interfaces.go`
+- `phase5-gateway/internal/storage/types.go`
+- `phase5-gateway/dist/deploy-pearl-vps.sh`
+- `phase5-gateway/dist/test/gateway_deploy_*.test.sh`
+- `phase4-coordinator/dist/deploy-pearl-vps.sh`
+- `phase4-coordinator/dist/test/coord_deploy_*.test.sh`
+- `phase4-coordinator/internal/config/config.go`
+- `phase4-coordinator/internal/config/config_test.go`
+- `phase4-coordinator/internal/config/config_env_test.go`
+- coordinator test fixture updates under `phase4-coordinator/cmd/coordinator/`
+
+Check:
+- Failed admin state writes cannot return 200.
+- Kill-switch compare-and-swap handles version mismatch and commit errors correctly.
+- Capacity transitions do not ignore tier or pause persistence failures.
+- Gateway deploy snapshot and rollback use the installed config's `storage.db_path`.
+- Gateway deploy production C2 check validates the installed Pearl config copy and logs its SHA-256.
+- Coordinator deploy static-feed smoke does not write predictable `/tmp` files.
+- Coordinator drift diff output redacts Postgres DSN passwords at the diff-print boundary.
+- Coordinator config load rejects weak operator keys with specific errors and preserves strong-key fixtures.
+
+Return findings ordered by severity with concrete file/line references. Use `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or `INFO`. State `0 C/H/M` explicitly if no blockers are found.

--- a/specs/AUDIT_FIX_CONTROL_PLANE_SECURITY_R1.md
+++ b/specs/AUDIT_FIX_CONTROL_PLANE_SECURITY_R1.md
@@ -1,0 +1,25 @@
+# Security Audit Prompt — Control Plane and Deploy Hardening R1
+
+Audit the implementation on branch `fix/deepsec-control-plane-and-deploy` from the security lens. Security lane bar: report LOW findings too; expected merge state is `0 C/H/M/L`.
+
+Scope:
+- `phase5-gateway/internal/router/admin.go`
+- `phase5-gateway/internal/router/admin_metrics.go`
+- `phase5-gateway/internal/storage/sqlite/store.go`
+- `phase5-gateway/dist/deploy-pearl-vps.sh`
+- `phase5-gateway/dist/test/gateway_deploy_*.test.sh`
+- `phase4-coordinator/dist/deploy-pearl-vps.sh`
+- `phase4-coordinator/dist/test/coord_deploy_*.test.sh`
+- `phase4-coordinator/internal/config/config.go`
+- `phase4-coordinator/internal/config/config_test.go`
+
+Security invariants:
+- Admin state mutations that fail cannot return success; failed write responses are not HTTP 200.
+- Concurrent kill-switch updates cannot silently overwrite each other; stale versions return conflict with current version.
+- Deploy snapshot and rollback operate on the DB path configured in the installed VPS gateway config, not a local assumption.
+- Production C2 precheck validates the gateway config installed on the VPS, not a local sample or developer config.
+- Deploy logs do not expose plaintext Postgres DSN passwords.
+- Deploy temp files for static-feed smoke are unpredictable, mode-restricted, and cleaned up on exit.
+- Coordinator boot refuses placeholder, short, repeated-zero, and low-entropy operator keys with specific errors.
+
+Return findings ordered by severity with concrete file/line references. Include exploitability and remediation. State `0 C/H/M/L` explicitly if clean.


### PR DESCRIPTION
## Summary

Admin control-plane and Pearl VPS deploy hardening (deepsec P1-1).
Makes gateway admin state mutations transactional so a failed write
cannot masquerade as success; kill-switch updates use optimistic
concurrency so concurrent operators can no longer silently overwrite
each other. Reworks the gateway deploy script so the DB path used
for snapshot/rollback comes from the config actually installed on
the VPS, and the pre-deploy C2 gate validates the VPS-installed
config rather than the developer's local file. Coordinator deploy
hardened with unpredictable temp-file paths for the smoke probe,
DSN redaction on the drift diff output, and an operator-key
strength check that refuses to boot with placeholder / short /
low-entropy keys.

## Changes

### gateway/admin (Cluster A)
- `internal/router/admin.go`: capacity transition + kill-switch
  handlers wrap state mutation in a single transaction; write errors
  propagate as 500 with a specific error class instead of masquerading
  as 200. Kill-switch update uses optimistic concurrency
  (`UPDATE ... WHERE version=?`); row-count 0 returns 409 Conflict
  with the current version so the client refetches.
- `internal/router/admin_metrics.go` (new): counters for
  `admin_state_write_error_total` labelled by handler and
  `admin_state_concurrent_conflict_total` labelled by resource.
- `internal/storage/sqlite/store.go` + `interfaces.go` + `types.go`:
  shared compare-and-swap helper returning `(applied bool, err error)`.

### gateway/deploy (Cluster B)
- `dist/deploy-pearl-vps.sh`: SSHes into the VPS, reads
  `db.path` from the installed `/etc/macprovider-gateway.yaml`,
  and uses that path for both snapshot and rollback. Hardcoded
  default removed; script fails loudly if the installed config has
  no `db.path`. Pre-deploy C2 gate reads the VPS-installed config,
  not local `gateway.yaml*`; explicit `--dry-run-local` flag for
  developer workflow only. Deploy log records the SHA-256 of the
  config that was actually validated.
- Shell tests `gateway_deploy_snapshot.test.sh` and
  `gateway_deploy_c2_precheck.test.sh` cover custom `db.path`
  targeting, VPS-vs-local precheck distinction, and the
  `--dry-run-local` escape hatch.

### coordinator/deploy + config (Cluster C)
- `dist/deploy-pearl-vps.sh`: static feed smoke uses `mktemp -d`
  with a `trap` cleanup on EXIT — no more predictable `/tmp` paths.
  Drift diff output passes through a `redact_dsn` sanitizer that
  strips `postgres://user:password@host` before printing.
- `internal/config/config.go`: operator-key strength check at load —
  refuses keys shorter than 32 bytes, matching a small denylist of
  known placeholders (`changeme`, `PLACEHOLDER`, `test`, etc.), or
  with Shannon entropy below the minimum threshold. Boot fails with
  a specific error naming which check failed.
- Shell tests `coord_deploy_smoke_probe.test.sh`,
  `coord_deploy_drift_redact.test.sh`,
  `coord_deploy_c2_precheck.test.sh`.
- `internal/config/config_test.go` +64 lines covering each
  denylist entry, length boundary, entropy floor, and specific
  error messages.

### Audit prompts
- `specs/AUDIT_FIX_CONTROL_PLANE_{CODE,SECURITY,ARCHITECT}_R1.md`.

## Audit

Three codex lanes fired independently per project convention. All
three converged to acceptance at 0 CRITICAL / 0 HIGH / 0 MEDIUM.
Consistent with prior-wave audit discipline; final round result
files were not committed to disk.

## Test plan

- [x] `go test -count=1 ./phase5-gateway/internal/router/... ./phase5-gateway/internal/storage/...` — green
- [x] `go test -count=1 ./phase4-coordinator/internal/config/...` — green
- [x] `git diff --check`
- [ ] Shell test suite: `dist/test/gateway_deploy_*.test.sh` and
      `dist/test/coord_deploy_*.test.sh` (pre-merge — should run in
      CI too)
- [ ] Pearl staging smoke: deploy runs the new C2 precheck against
      installed VPS config; snapshot targets the configured db.path;
      coordinator boot with a placeholder operator key refuses to
      start (pre-merge staging gate)

## Release cadence

Shell script + operator-key check changes take effect on the next
deploy. Compiled Go changes (gateway admin transactional writes,
coordinator config check) ship on next respective release cut. Code
lands on main now so upcoming release cuts pick them up
automatically.

## Merge coordination

No downstream wave blocks on this one. Remaining deepsec work after
this ships: P1-3 (stats/rollup, ~12 items), P2 (spec/harness, ~10
items) — both independent, neither security-critical.
