### PR TITLE
Emit phase timing on gateway completion logs

### DIFF
--- a/phase4-coordinator/internal/buyer/forward_loop_test.go
+++ b/phase4-coordinator/internal/buyer/forward_loop_test.go
@@ -40,6 +40,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -50,10 +51,45 @@ import (
 	"github.com/rs/zerolog"
 )
 
+func assertTimingHeaderPresent(t *testing.T, h http.Header, name string) int64 {
+	t.Helper()
+	raw := h.Get(name)
+	if raw == "" {
+		t.Fatalf("%s missing", name)
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("%s = %q, want integer milliseconds", name, raw)
+	}
+	if value < 0 {
+		t.Fatalf("%s = %d, want non-negative milliseconds", name, value)
+	}
+	return value
+}
+
+func assertTimingHeaderBelow(t *testing.T, h http.Header, name string, maxExclusive int64) {
+	t.Helper()
+	if value := assertTimingHeaderPresent(t, h, name); value >= maxExclusive {
+		t.Fatalf("%s = %d, want below %d to prove final-attempt timing did not include the failed first attempt", name, value, maxExclusive)
+	}
+}
+
+func assertTimingHeaderAtLeast(t *testing.T, h http.Header, name string, minInclusive int64) {
+	t.Helper()
+	if value := assertTimingHeaderPresent(t, h, name); value < minInclusive {
+		t.Fatalf("%s = %d, want at least %d", name, value, minInclusive)
+	}
+}
+
 // Scenario 1: HTTP success on first attempt. One row, retried=0.
 func TestM2_1C_RowSequence_HTTPSuccessFirstAttempt(t *testing.T) {
 	const requestID = "aaaaaaaa-1111-4111-8111-111111111111"
 	okUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(120 * time.Millisecond)
 		_, _ = w.Write([]byte(`{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`))
 	}))
 	defer okUpstream.Close()
@@ -79,6 +115,7 @@ func TestM2_1C_RowSequence_HTTPSuccessFirstAttempt(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
 	}
+	assertTimingHeaderAtLeast(t, rr.Header(), "X-MacProvider-Timing-Provider-Prefill-Ms", 80)
 	rows := queryAllRequestLogRows(t, dbPath)
 	if len(rows) != 1 {
 		t.Fatalf("request_log rows = %d, want 1: %#v", len(rows), rows)
@@ -100,10 +137,12 @@ func TestM2_1C_RowSequence_HTTPSuccessFirstAttempt(t *testing.T) {
 func TestM2_1C_RowSequence_HTTPRetryToSuccess(t *testing.T) {
 	const requestID = "bbbbbbbb-2222-4222-8222-222222222222"
 	failUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 	}))
 	defer failUpstream.Close()
 	okUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Millisecond)
 		_, _ = w.Write([]byte(`{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`))
 	}))
 	defer okUpstream.Close()
@@ -133,6 +172,7 @@ func TestM2_1C_RowSequence_HTTPRetryToSuccess(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
 	}
+	assertTimingHeaderBelow(t, rr.Header(), "X-MacProvider-Timing-Provider-Dispatch-Ms", 150)
 	rows := queryAllRequestLogRows(t, dbPath)
 	if len(rows) != 2 {
 		t.Fatalf("request_log rows = %d, want 2: %#v", len(rows), rows)
@@ -257,16 +297,20 @@ func TestM2_1C_RowSequence_WSNonStreamingFailoverDoesNotBumpRetried(t *testing.T
 			StickyMaxEntries: 10000,
 		}),
 		buyer.WithRelay(func(ctx context.Context, provider pool.Provider, reqID string, body []byte, stream bool) (*providerws.RelayStream, error) {
-			chunks := make(chan providerws.InferenceResponseChunk, 1)
+			chunks := make(chan providerws.InferenceResponseChunk, 2)
 			done := make(chan providerws.InferenceResponseEnd, 1)
 			errs := make(chan error, 1)
 			if provider.ProviderID == "p1" {
 				// Drive into wsForwardProviderDisconnected — pre-commit.
-				errs <- providerws.ErrRelayClosed
-				return &providerws.RelayStream{RequestID: reqID, Chunks: chunks, Done: done, Errors: errs}, nil
+				time.Sleep(200 * time.Millisecond)
+				return nil, providerws.ErrRelayClosed
 			}
-			chunks <- providerws.InferenceResponseChunk{Type: "inference_response_chunk", RequestID: reqID, Seq: 0, Data: `{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`}
-			done <- providerws.InferenceResponseEnd{Type: "inference_response_end", RequestID: reqID, Status: "complete", ChunksSent: 1}
+			go func() {
+				chunks <- providerws.InferenceResponseChunk{Type: "inference_response_chunk", RequestID: reqID, Seq: 0, Data: ""}
+				time.Sleep(120 * time.Millisecond)
+				chunks <- providerws.InferenceResponseChunk{Type: "inference_response_chunk", RequestID: reqID, Seq: 1, Data: `{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`}
+				done <- providerws.InferenceResponseEnd{Type: "inference_response_end", RequestID: reqID, Status: "complete", ChunksSent: 2}
+			}()
 			return &providerws.RelayStream{RequestID: reqID, Chunks: chunks, Done: done, Errors: errs}, nil
 		}, time.Second),
 	)
@@ -280,6 +324,9 @@ func TestM2_1C_RowSequence_WSNonStreamingFailoverDoesNotBumpRetried(t *testing.T
 	if rr.Header().Get("X-MacProvider-Provider") != "p2" {
 		t.Fatalf("provider = %q, want p2 (after failover)", rr.Header().Get("X-MacProvider-Provider"))
 	}
+	assertTimingHeaderBelow(t, rr.Header(), "X-MacProvider-Timing-Provider-Dispatch-Ms", 150)
+	assertTimingHeaderAtLeast(t, rr.Header(), "X-MacProvider-Timing-Provider-Prefill-Ms", 80)
+	assertTimingHeaderBelow(t, rr.Header(), "X-MacProvider-Timing-Provider-Decode-Ms", 150)
 	rows := queryAllRequestLogRows(t, dbPath)
 	if len(rows) != 2 {
 		t.Fatalf("request_log rows = %d, want 2 (failover-disconnect then success): %#v", len(rows), rows)

--- a/phase4-coordinator/internal/buyer/forward_state.go
+++ b/phase4-coordinator/internal/buyer/forward_state.go
@@ -48,6 +48,11 @@ type forwardState struct {
 	// remain non-billable.
 	queueWait time.Duration
 
+	// phaseTiming carries per-request spans that the gateway copies into
+	// its completion log. It is kept with forwardState because retries and
+	// failover already mutate the active route through this struct.
+	phaseTiming requestPhaseTiming
+
 	// queuedSlotProviderID is set when the slot queue reserves a
 	// recovered provider slot for this request. It is released when
 	// the request leaves that active route.

--- a/phase4-coordinator/internal/buyer/forward_with_failover.go
+++ b/phase4-coordinator/internal/buyer/forward_with_failover.go
@@ -149,6 +149,7 @@ func (s *Server) forwardWithFailover(
 					state.queueWait = nextQueueWait
 					state.queuedSlotProviderID = nextQueuedSlotProviderID
 					state.provider = next
+					state.phaseTiming.markCoordRoutingDone(phaseTimingNow(s))
 					if tx.afterFailoverHit != nil {
 						if fallThrough := tx.afterFailoverHit(state); fallThrough {
 							return true

--- a/phase4-coordinator/internal/buyer/phase_timing.go
+++ b/phase4-coordinator/internal/buyer/phase_timing.go
@@ -1,0 +1,190 @@
+package buyer
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	phaseTimingCoordRoutingHeader     = "X-MacProvider-Timing-Coord-Routing-Ms"
+	phaseTimingCoordAdmissionHeader   = "X-MacProvider-Timing-Coord-Admission-Ms"
+	phaseTimingProviderDispatchHeader = "X-MacProvider-Timing-Provider-Dispatch-Ms"
+	phaseTimingProviderPrefillHeader  = "X-MacProvider-Timing-Provider-Prefill-Ms"
+	phaseTimingProviderDecodeHeader   = "X-MacProvider-Timing-Provider-Decode-Ms"
+	phaseTimingCoordinatorTotalHeader = "X-MacProvider-Timing-Coordinator-Total-Ms"
+)
+
+type requestPhaseTiming struct {
+	mu sync.Mutex
+
+	requestStart          time.Time
+	coordRoutingDone      time.Time
+	providerDispatchStart time.Time
+	providerDispatchDone  time.Time
+	providerFirstByte     time.Time
+	providerDone          time.Time
+}
+
+func (t *requestPhaseTiming) init(start time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.requestStart = start
+}
+
+func (t *requestPhaseTiming) markCoordRoutingDone(at time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.coordRoutingDone = at
+}
+
+func (t *requestPhaseTiming) markProviderDispatchStart(at time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.providerDispatchStart = at
+	t.providerDispatchDone = time.Time{}
+	t.providerFirstByte = time.Time{}
+	t.providerDone = time.Time{}
+}
+
+func (t *requestPhaseTiming) markProviderDispatchDone(at time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.providerDispatchDone = at
+}
+
+func (t *requestPhaseTiming) markProviderFirstByte(at time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.providerFirstByte.IsZero() {
+		t.providerFirstByte = at
+	}
+}
+
+func (t *requestPhaseTiming) markProviderDone(at time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.providerDone.IsZero() {
+		t.providerDone = at
+	}
+}
+
+func (t *requestPhaseTiming) snapshot() requestPhaseTimingSnapshot {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return requestPhaseTimingSnapshot{
+		requestStart:          t.requestStart,
+		coordRoutingDone:      t.coordRoutingDone,
+		providerDispatchStart: t.providerDispatchStart,
+		providerDispatchDone:  t.providerDispatchDone,
+		providerFirstByte:     t.providerFirstByte,
+		providerDone:          t.providerDone,
+	}
+}
+
+type requestPhaseTimingSnapshot struct {
+	requestStart          time.Time
+	coordRoutingDone      time.Time
+	providerDispatchStart time.Time
+	providerDispatchDone  time.Time
+	providerFirstByte     time.Time
+	providerDone          time.Time
+}
+
+type phaseTimingResponseWriter struct {
+	http.ResponseWriter
+	state *forwardState
+	now   func() time.Time
+	once  sync.Once
+}
+
+func (w *phaseTimingResponseWriter) WriteHeader(code int) {
+	w.inject()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *phaseTimingResponseWriter) Write(b []byte) (int, error) {
+	w.inject()
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *phaseTimingResponseWriter) Flush() {
+	w.inject()
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (w *phaseTimingResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *phaseTimingResponseWriter) inject() {
+	w.once.Do(func() {
+		now := time.Now()
+		if w.now != nil {
+			now = w.now()
+		}
+		writePhaseTimingHeaders(w.Header(), w.state, now)
+	})
+}
+
+func writePhaseTimingHeaders(h http.Header, state *forwardState, now time.Time) {
+	if state == nil {
+		return
+	}
+	snap := state.phaseTiming.snapshot()
+	h.Set(phaseTimingCoordRoutingHeader, strconv.FormatInt(durationMillisBetween(snap.requestStart, snap.coordRoutingDone), 10))
+	h.Set(phaseTimingCoordAdmissionHeader, strconv.FormatInt(durationMillis(state.queueWait), 10))
+	h.Set(phaseTimingProviderDispatchHeader, strconv.FormatInt(durationMillisBetween(snap.providerDispatchStart, snap.providerDispatchDone), 10))
+	h.Set(phaseTimingProviderPrefillHeader, strconv.FormatInt(durationMillisBetween(snap.providerDispatchDone, snap.providerFirstByte), 10))
+	h.Set(phaseTimingProviderDecodeHeader, strconv.FormatInt(durationMillisBetween(snap.providerFirstByte, snap.providerDone), 10))
+	h.Set(phaseTimingCoordinatorTotalHeader, strconv.FormatInt(durationMillisBetween(snap.requestStart, now), 10))
+}
+
+func writePhaseTimingTrailers(h http.Header, state *forwardState, now time.Time) {
+	if state == nil {
+		return
+	}
+	snap := state.phaseTiming.snapshot()
+	h.Set(http.TrailerPrefix+phaseTimingProviderDecodeHeader, strconv.FormatInt(durationMillisBetween(snap.providerFirstByte, snap.providerDone), 10))
+	h.Set(http.TrailerPrefix+phaseTimingCoordinatorTotalHeader, strconv.FormatInt(durationMillisBetween(snap.requestStart, now), 10))
+}
+
+func durationMillisBetween(start, end time.Time) int64 {
+	if start.IsZero() || end.IsZero() || end.Before(start) {
+		return 0
+	}
+	return durationMillis(end.Sub(start))
+}
+
+func durationMillis(d time.Duration) int64 {
+	if d <= 0 {
+		return 0
+	}
+	return d.Milliseconds()
+}
+
+func phaseTimingNow(s *Server) time.Time {
+	if s != nil && s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+type firstByteTimingReader struct {
+	r      io.Reader
+	mark   func()
+	marked bool
+}
+
+func (r *firstByteTimingReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	if n > 0 && !r.marked {
+		r.marked = true
+		r.mark()
+	}
+	return n, err
+}

--- a/phase4-coordinator/internal/buyer/phase_timing_test.go
+++ b/phase4-coordinator/internal/buyer/phase_timing_test.go
@@ -1,0 +1,317 @@
+package buyer
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/rs/zerolog"
+)
+
+func TestPhaseTimingResponseWriterInjectsHeaders(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	state := &forwardState{queueWait: 25 * time.Millisecond}
+	state.phaseTiming.init(start)
+	state.phaseTiming.markCoordRoutingDone(start.Add(10 * time.Millisecond))
+	state.phaseTiming.markProviderDispatchStart(start.Add(20 * time.Millisecond))
+	state.phaseTiming.markProviderDispatchDone(start.Add(30 * time.Millisecond))
+	state.phaseTiming.markProviderFirstByte(start.Add(80 * time.Millisecond))
+	state.phaseTiming.markProviderDone(start.Add(140 * time.Millisecond))
+
+	rr := httptest.NewRecorder()
+	tw := &phaseTimingResponseWriter{
+		ResponseWriter: rr,
+		state:          state,
+		now: func() time.Time {
+			return start.Add(150 * time.Millisecond)
+		},
+	}
+
+	tw.WriteHeader(http.StatusOK)
+
+	assertHeader := func(name, want string) {
+		t.Helper()
+		if got := rr.Header().Get(name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+	assertHeader(phaseTimingCoordRoutingHeader, "10")
+	assertHeader(phaseTimingCoordAdmissionHeader, "25")
+	assertHeader(phaseTimingProviderDispatchHeader, "10")
+	assertHeader(phaseTimingProviderPrefillHeader, "50")
+	assertHeader(phaseTimingProviderDecodeHeader, "60")
+	assertHeader(phaseTimingCoordinatorTotalHeader, "150")
+}
+
+func TestPhaseTimingResponseWriterInjectsOnWriteAndFlush(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	state := &forwardState{}
+	state.phaseTiming.init(start)
+	state.phaseTiming.markCoordRoutingDone(start.Add(10 * time.Millisecond))
+
+	t.Run("write", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		tw := &phaseTimingResponseWriter{
+			ResponseWriter: rr,
+			state:          state,
+			now: func() time.Time {
+				return start.Add(30 * time.Millisecond)
+			},
+		}
+		if _, err := tw.Write([]byte("ok")); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := rr.Header().Get(phaseTimingCoordRoutingHeader), "10"; got != want {
+			t.Fatalf("coord routing header = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("flush", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		tw := &phaseTimingResponseWriter{
+			ResponseWriter: rr,
+			state:          state,
+			now: func() time.Time {
+				return start.Add(30 * time.Millisecond)
+			},
+		}
+		tw.Flush()
+		if got, want := rr.Header().Get(phaseTimingCoordRoutingHeader), "10"; got != want {
+			t.Fatalf("coord routing header = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestWritePhaseTimingTrailersInjectsTerminalFields(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	state := &forwardState{}
+	state.phaseTiming.init(start)
+	state.phaseTiming.markProviderDispatchDone(start.Add(30 * time.Millisecond))
+	state.phaseTiming.markProviderFirstByte(start.Add(80 * time.Millisecond))
+	state.phaseTiming.markProviderDone(start.Add(240 * time.Millisecond))
+
+	headers := http.Header{}
+	writePhaseTimingTrailers(headers, state, start.Add(250*time.Millisecond))
+
+	if got, want := headers.Get(http.TrailerPrefix+phaseTimingProviderDecodeHeader), "160"; got != want {
+		t.Fatalf("provider decode trailer = %q, want %q", got, want)
+	}
+	if got, want := headers.Get(http.TrailerPrefix+phaseTimingCoordinatorTotalHeader), "250"; got != want {
+		t.Fatalf("coordinator total trailer = %q, want %q", got, want)
+	}
+}
+
+func TestPhaseTimingStreamingTrailersSurviveHTTPResult(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	state := &forwardState{}
+	state.phaseTiming.init(start)
+	state.phaseTiming.markCoordRoutingDone(start.Add(10 * time.Millisecond))
+	state.phaseTiming.markProviderDispatchStart(start.Add(20 * time.Millisecond))
+	state.phaseTiming.markProviderDispatchDone(start.Add(30 * time.Millisecond))
+	state.phaseTiming.markProviderFirstByte(start.Add(40 * time.Millisecond))
+
+	rr := httptest.NewRecorder()
+	tw := &phaseTimingResponseWriter{
+		ResponseWriter: rr,
+		state:          state,
+		now: func() time.Time {
+			return start.Add(50 * time.Millisecond)
+		},
+	}
+
+	tw.WriteHeader(http.StatusOK)
+	state.phaseTiming.markProviderDone(start.Add(240 * time.Millisecond))
+	writePhaseTimingTrailers(tw.Header(), state, start.Add(260*time.Millisecond))
+	if _, err := tw.Write([]byte("data: {}\n\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	result := rr.Result()
+	defer result.Body.Close()
+	if got, want := result.Header.Get(phaseTimingProviderDecodeHeader), "0"; got != want {
+		t.Fatalf("initial decode header = %q, want %q", got, want)
+	}
+	if got, want := result.Trailer.Get(phaseTimingProviderDecodeHeader), "200"; got != want {
+		t.Fatalf("decode trailer = %q, want %q", got, want)
+	}
+	if got, want := result.Trailer.Get(phaseTimingCoordinatorTotalHeader), "260"; got != want {
+		t.Fatalf("coordinator total trailer = %q, want %q", got, want)
+	}
+}
+
+func TestForwardStreamingPublishesTerminalPhaseTimingTrailers(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl\",\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(20 * time.Millisecond)
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer upstream.Close()
+
+	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Now())
+	start := time.Now()
+	state := &forwardState{}
+	state.phaseTiming.init(start)
+	state.phaseTiming.markCoordRoutingDone(start.Add(time.Millisecond))
+	rr := httptest.NewRecorder()
+	tw := &phaseTimingResponseWriter{
+		ResponseWriter: rr,
+		state:          state,
+		now:            time.Now,
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	body := []byte(`{"model":"llama","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	provider := pool.Provider{
+		ProviderID:  "provider-1",
+		AssignedID:  "route-1",
+		EndpointURL: upstream.URL,
+	}
+
+	result, status, _ := server.forwardStreaming(tw, req, "req-1", body, provider, "llama", time.Second, nil, state, 0)
+
+	if result != wsForwardComplete {
+		t.Fatalf("result=%q, want %q", result, wsForwardComplete)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status=%d, want %d body=%s", status, http.StatusOK, rr.Body.String())
+	}
+	httpResult := rr.Result()
+	defer httpResult.Body.Close()
+	if got := httpResult.Trailer.Get(phaseTimingProviderDecodeHeader); got == "" || got == "0" {
+		t.Fatalf("provider decode trailer = %q, want non-zero", got)
+	}
+	if got := httpResult.Trailer.Get(phaseTimingCoordinatorTotalHeader); got == "" || got == "0" {
+		t.Fatalf("coordinator total trailer = %q, want non-zero", got)
+	}
+}
+
+func TestForwardStreamingNon200MarksFirstByteOnBodyRead(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(120 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"error":{"code":"provider_failed"}}`))
+	}))
+	defer upstream.Close()
+
+	server := NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Now())
+	start := time.Now()
+	state := &forwardState{}
+	state.phaseTiming.init(start)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	body := []byte(`{"model":"llama","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	provider := pool.Provider{
+		ProviderID:  "provider-1",
+		AssignedID:  "route-1",
+		EndpointURL: upstream.URL,
+	}
+
+	result, status, _ := server.forwardStreaming(rr, req, "req-1", body, provider, "llama", time.Second, nil, state, 0)
+
+	if result != wsForwardFailed {
+		t.Fatalf("result=%q, want %q", result, wsForwardFailed)
+	}
+	if status != http.StatusBadGateway {
+		t.Fatalf("status=%d, want %d", status, http.StatusBadGateway)
+	}
+	snap := state.phaseTiming.snapshot()
+	if got := durationMillisBetween(snap.providerDispatchDone, snap.providerFirstByte); got < 80 {
+		t.Fatalf("provider prefill = %d, want at least 80 to prove header arrival was not counted as first byte", got)
+	}
+}
+
+func TestPhaseTimingFinalAttemptSnapshotDoesNotMixPriorDispatch(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	state := &forwardState{queueWait: 7 * time.Millisecond}
+	state.phaseTiming.init(start)
+	state.phaseTiming.markCoordRoutingDone(start.Add(10 * time.Millisecond))
+	state.phaseTiming.markProviderDispatchStart(start.Add(20 * time.Millisecond))
+	state.phaseTiming.markProviderDispatchDone(start.Add(30 * time.Millisecond))
+	state.phaseTiming.markProviderFirstByte(start.Add(50 * time.Millisecond))
+	state.phaseTiming.markProviderDone(start.Add(60 * time.Millisecond))
+
+	state.phaseTiming.markCoordRoutingDone(start.Add(100 * time.Millisecond))
+	state.phaseTiming.markProviderDispatchStart(start.Add(110 * time.Millisecond))
+	state.phaseTiming.markProviderDispatchDone(start.Add(115 * time.Millisecond))
+	state.phaseTiming.markProviderFirstByte(start.Add(150 * time.Millisecond))
+	state.phaseTiming.markProviderDone(start.Add(210 * time.Millisecond))
+
+	headers := http.Header{}
+	writePhaseTimingHeaders(headers, state, start.Add(220*time.Millisecond))
+
+	assertHeader := func(name, want string) {
+		t.Helper()
+		if got := headers.Get(name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+	assertHeader(phaseTimingCoordRoutingHeader, "100")
+	assertHeader(phaseTimingProviderDispatchHeader, "5")
+	assertHeader(phaseTimingProviderPrefillHeader, "35")
+	assertHeader(phaseTimingProviderDecodeHeader, "60")
+}
+
+func TestPhaseTimingNowFallsBackWhenClockUnset(t *testing.T) {
+	before := time.Now()
+	got := phaseTimingNow(&Server{})
+	after := time.Now()
+	if got.Before(before) || got.After(after.Add(50*time.Millisecond)) {
+		t.Fatalf("fallback time %v outside expected range [%v, %v]", got, before, after)
+	}
+}
+
+func TestFirstByteTimingReaderMarksOnlyAfterBytes(t *testing.T) {
+	marks := 0
+	reader := &firstByteTimingReader{
+		r: bytes.NewBufferString("abc"),
+		mark: func() {
+			marks++
+		},
+	}
+
+	buf := make([]byte, 2)
+	n, err := reader.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 || marks != 1 {
+		t.Fatalf("first read n=%d marks=%d, want n=2 marks=1", n, marks)
+	}
+	n, err = reader.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 || marks != 1 {
+		t.Fatalf("second read n=%d marks=%d, want n=1 marks=1", n, marks)
+	}
+
+	empty := &firstByteTimingReader{
+		r: bytes.NewBufferString(""),
+		mark: func() {
+			marks++
+		},
+	}
+	n, err = empty.Read(buf)
+	if err != io.EOF {
+		t.Fatalf("empty read err=%v, want EOF", err)
+	}
+	if n != 0 || marks != 1 {
+		t.Fatalf("empty read n=%d marks=%d, want n=0 marks=1", n, marks)
+	}
+}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1502,6 +1502,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// estimatedTokens is populated below once the body is read +
 		// validated; retry-path PreflightResult derivation reads it.
 	}
+	state.phaseTiming.init(startedAt)
+	w = &phaseTimingResponseWriter{ResponseWriter: w, state: state, now: s.now}
 	// M3-10 (ARCH-6 close-out): the previously-inline logRowWithBilling
 	// closure now lives as *billingRecorder. setModel / setStream /
 	// setRequestID land before the first provider-bound recordRow call,
@@ -1631,11 +1633,13 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	provider, routeErr := s.selectProvider(r.Context(), routingRequestID, req, r.Header, state.dailyKey, state)
 	if routeErr != nil {
 		state.routingDone = s.now()
+		state.phaseTiming.markCoordRoutingDone(state.routingDone)
 		rec.logRow("", routeErr.status, nil, nil, routeErr.message, "", 0)
 		writeRouteError(w, routeErr)
 		return
 	}
 	state.routingDone = s.now()
+	state.phaseTiming.markCoordRoutingDone(state.routingDone)
 	state.provider = provider
 	defer s.releaseQueuedSlotReservation(state)
 	// M2-1c: the three transport loops (streaming, WS-non-streaming, HTTP)
@@ -2143,12 +2147,25 @@ func (s *Server) forwardHTTPSequence(
 			upReq.Header.Set("Content-Type", "application/json")
 			upReq.Header.Set("X-Request-ID", originalRequestID)
 			setSettlementMetadataHeader(upReq.Header, settlementMetadata)
+			state.phaseTiming.markProviderDispatchStart(phaseTimingNow(s))
 			resp, doErr := providerhttp.Client.Do(upReq)
+			dispatchDone := phaseTimingNow(s)
+			state.phaseTiming.markProviderDispatchDone(dispatchDone)
+			if doErr != nil || resp == nil {
+				state.phaseTiming.markProviderDone(dispatchDone)
+			}
 			// 200 success path: render body + receipt headers, log row,
 			// cancelAttempt on every exit.
 			if doErr == nil && resp != nil && resp.StatusCode == http.StatusOK {
-				respBody, readErr := readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
+				body := &firstByteTimingReader{
+					r: resp.Body,
+					mark: func() {
+						state.phaseTiming.markProviderFirstByte(phaseTimingNow(s))
+					},
+				}
+				respBody, readErr := readLimitedBody(body, maxUpstreamResponseBodyBytes)
 				_ = resp.Body.Close()
+				state.phaseTiming.markProviderDone(phaseTimingNow(s))
 				if readErr != nil {
 					cancelAttempt()
 					rec.logProviderRow(state.provider, http.StatusBadGateway, nil, nil, "Selected provider failed; buyer should retry", "", state.explicitRetries)
@@ -2213,8 +2230,15 @@ func (s *Server) forwardHTTPSequence(
 			var respBody []byte
 			if resp != nil {
 				status = resp.StatusCode
-				respBody, _ = readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
+				body := &firstByteTimingReader{
+					r: resp.Body,
+					mark: func() {
+						state.phaseTiming.markProviderFirstByte(phaseTimingNow(s))
+					},
+				}
+				respBody, _ = readLimitedBody(body, maxUpstreamResponseBodyBytes)
 				_ = resp.Body.Close()
+				state.phaseTiming.markProviderDone(phaseTimingNow(s))
 				attempt.ErrorCode = nullUsageProviderErrorCode(respBody)
 				receiptValue := normalizeReceiptHeaderValue(resp.Header.Get("X-MacProvider-Receipt"))
 				terminalState := terminalStateFromAttempt(status, http.StatusText(status), attempt.ErrorCode)
@@ -2421,11 +2445,13 @@ func (s *Server) advanceToNextProvider(
 	picked, routeErr := s.selectProviderExcluding(r.Context(), nextRouteID, req, r.Header, excluded, state.dailyKey, state)
 	if routeErr != nil {
 		state.routingDone = s.now()
+		state.phaseTiming.markCoordRoutingDone(state.routingDone)
 		rec.logRow("", routeErr.status, nil, nil, routeErr.message, "", state.explicitRetries)
 		writeRouteError(w, routeErr)
 		return "", false
 	}
 	state.routingDone = s.now()
+	state.phaseTiming.markCoordRoutingDone(state.routingDone)
 	state.explicitRetries++
 	state.faultedProviders++
 	state.provider = picked
@@ -2476,12 +2502,22 @@ func (s *Server) forwardWS(w http.ResponseWriter, r *http.Request, requestID str
 	}
 	var relay *providerws.RelayStream
 	var err error
+	if state != nil {
+		state.phaseTiming.markProviderDispatchStart(phaseTimingNow(s))
+	}
 	if settlementMetadata != nil && s.settlementRelay != nil {
 		relay, err = s.settlementRelay(ctx, provider, requestID, body, stream, settlementMetadata)
 	} else {
 		relay, err = s.relay(ctx, provider, requestID, body, stream)
 	}
+	dispatchDone := phaseTimingNow(s)
+	if state != nil {
+		state.phaseTiming.markProviderDispatchDone(dispatchDone)
+	}
 	if err != nil {
+		if state != nil {
+			state.phaseTiming.markProviderDone(dispatchDone)
+		}
 		if reserved {
 			s.admission.RefundRequest(provider)
 		}
@@ -2528,14 +2564,27 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 	started := time.Now()
 	ttftLogged := false
 	faultFlag := billing.FaultNone
+	markProviderDone := func() {
+		if state != nil {
+			now := phaseTimingNow(s)
+			state.phaseTiming.markProviderDone(now)
+			writePhaseTimingHeaders(w.Header(), state, now)
+		}
+	}
 	estimatedCompletion := func() *int64 {
 		return s.estimatedCompletionTokensFromBytes(body.Len())
 	}
-	observeTTFT := func() {
+	observeTTFT := func(data string) {
+		if data == "" {
+			return
+		}
 		if ttftLogged {
 			return
 		}
 		ttftLogged = true
+		if state != nil {
+			state.phaseTiming.markProviderFirstByte(phaseTimingNow(s))
+		}
 		guard.LogTTFT(time.Since(started))
 	}
 	chunks := relay.Chunks
@@ -2543,9 +2592,10 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 		select {
 		case chunk, ok := <-chunks:
 			if ok {
-				observeTTFT()
+				observeTTFT(chunk.Data)
 				if body.Len() > int(maxUpstreamResponseBodyBytes)-len(chunk.Data) {
 					relay.Cancel("response_body_too_large")
+					markProviderDone()
 					writeError(w, http.StatusBadGateway, "provider_response_too_large", "Provider response exceeded coordinator limit")
 					return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider response exceeded coordinator limit"}
 				}
@@ -2561,9 +2611,10 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 						chunks = nil
 						continue
 					}
-					observeTTFT()
+					observeTTFT(chunk.Data)
 					if body.Len() > int(maxUpstreamResponseBodyBytes)-len(chunk.Data) {
 						relay.Cancel("response_body_too_large")
+						markProviderDone()
 						writeError(w, http.StatusBadGateway, "provider_response_too_large", "Provider response exceeded coordinator limit")
 						return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider response exceeded coordinator limit"}
 					}
@@ -2575,8 +2626,10 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 			if end.Status != "complete" {
 				status := wsEndHTTPStatus(end.Status)
 				if end.Status == "error_queue_full" {
+					markProviderDone()
 					return wsForwardQueueFull, requestLogAttempt{Status: status, Error: endErrorMessage(end), ErrorCode: end.Status}
 				}
+				markProviderDone()
 				writeWSEndError(w, end)
 				attempt := requestLogAttempt{Status: status, Error: endErrorMessage(end), ErrorCode: spec001EndStatus(end.Status)}
 				if isSpec019ProviderDetailCode(attempt.ErrorCode) {
@@ -2584,6 +2637,7 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 				}
 				return wsForwardFailed, attempt
 			}
+			markProviderDone()
 			if s.zeroTokenFault(end, finishReasonFromChatResponse(body.Bytes())) {
 				s.recordBreakerFault(provider, breakerFaultZeroTokenCompletion, requestID)
 				faultFlag = billing.FaultBreakerQualifying
@@ -2641,10 +2695,12 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 			w.Header().Set("X-MacProvider-Provider", provider.ProviderID)
 			w.Header().Set("X-MacProvider-Route", provider.AssignedID)
 			setReceiptHeaderForProvider(w.Header(), receiptValue, provider)
+			markProviderDone()
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(checkedBody)
 			return wsForwardComplete, attempt
 		case err := <-relay.Errors:
+			markProviderDone()
 			s.log.Warn().Err(err).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("ws relay failed")
 			if errors.Is(err, providerws.ErrRelayTimeout) {
 				s.recordBreakerFault(provider, breakerFaultRelayTimeout, requestID)
@@ -2656,12 +2712,15 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 				s.recordBreakerFault(provider, breakerFaultDeadWS, requestID)
 				return wsForwardProviderDisconnected, requestLogAttempt{Status: http.StatusBadGateway, Error: "Selected provider disconnected; buyer should retry", EstimatedCompTokens: estimatedCompletion(), FaultFlag: billing.FaultBreakerQualifying}
 			} else if errors.Is(err, providerws.ErrRelayAEADFailed) {
+				markProviderDone()
 				writeError(w, http.StatusBadGateway, "tier2_aead_decrypt_failed", "Provider encrypted response failed authentication")
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider encrypted response failed authentication"}
 			} else if errors.Is(err, providerws.ErrRelayNAKFallback) {
+				markProviderDone()
 				writeError(w, http.StatusServiceUnavailable, "no_provider_available", "Selected provider is not reachable")
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusServiceUnavailable, Error: "Selected provider is not reachable"}
 			} else {
+				markProviderDone()
 				writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Selected provider failed; buyer should retry"}
 			}
@@ -2691,6 +2750,17 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 	}
 	streamFailureAttempt := requestLogAttempt{}
 	hasStreamFailureAttempt := false
+	markProviderDone := func() {
+		if state != nil {
+			now := phaseTimingNow(s)
+			state.phaseTiming.markProviderDone(now)
+			if committed {
+				writePhaseTimingTrailers(w.Header(), state, now)
+			} else {
+				writePhaseTimingHeaders(w.Header(), state, now)
+			}
+		}
+	}
 	setStreamFailureAttempt := func(status int, message string, code string) {
 		streamFailureAttempt = requestLogAttempt{Status: status, Error: message, ErrorCode: code, EstimatedCompTokens: s.estimatedCompletionTokensFromBytes(bytesEmitted), FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
 		hasStreamFailureAttempt = true
@@ -2712,13 +2782,17 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 		committed = true
 	}
 	writeChunk := func(data string) (bool, wsForwardResult) {
-		if !ttftLogged {
+		if data != "" && !ttftLogged {
 			ttftLogged = true
+			if state != nil {
+				state.phaseTiming.markProviderFirstByte(phaseTimingNow(s))
+			}
 			guard.LogTTFT(time.Since(started))
 		}
 		checked, stop, err := guard.CheckStreamingChunk(data)
 		if err != nil {
 			relay.Cancel("tier2_encoding_invalid")
+			markProviderDone()
 			if !committed {
 				setStreamFailureAttempt(http.StatusBadGateway, "Provider returned invalid Tier2 output encoding", "tier2_output_encoding_invalid")
 				writeError(w, http.StatusBadGateway, "tier2_output_encoding_invalid", "Provider returned invalid Tier2 output encoding")
@@ -2744,6 +2818,7 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 				s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
 			}
 			commit()
+			markProviderDone()
 			setStreamFailureAttempt(http.StatusOK, "Provider emitted malformed settlement stream", "malformed_settlement_stream")
 			writeSSEError(w, "Provider emitted malformed settlement stream", "malformed_settlement_stream")
 			if flusher != nil {
@@ -2757,6 +2832,7 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 				s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
 			}
 			commit()
+			markProviderDone()
 			setStreamFailureAttempt(http.StatusOK, "Provider emitted malformed tool-call stream", "malformed_tool_call")
 			writeSSEError(w, "Provider emitted malformed tool-call stream", "malformed_tool_call")
 			if flusher != nil {
@@ -2768,6 +2844,7 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 		if _, err := w.Write([]byte(checked)); err != nil {
 			relay.Cancel("buyer_disconnected")
 			s.log.Warn().Err(err).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("buyer ws stream write failed")
+			markProviderDone()
 			return true, wsForwardCancelled
 		}
 		bytesEmitted += len(checked)
@@ -2776,6 +2853,7 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 		}
 		if stop {
 			relay.Cancel("tier2_output_truncated")
+			markProviderDone()
 			return true, wsForwardComplete
 		}
 		return false, ""
@@ -2784,6 +2862,7 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 		select {
 		case <-r.Context().Done():
 			relay.Cancel("buyer_disconnected")
+			markProviderDone()
 			return wsForwardCancelled, progressAttempt("Buyer disconnected during streaming", billing.FaultNone)
 		case chunk, ok := <-chunks:
 			if !ok {
@@ -2826,10 +2905,13 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 			if !committed && end.Status != "complete" && end.Status != "cancelled" {
 				status := wsEndHTTPStatus(end.Status)
 				if end.Status == "error_queue_full" {
+					markProviderDone()
 					return wsForwardQueueFull, requestLogAttempt{Status: status, Error: endErrorMessage(end), ErrorCode: end.Status}
 				}
+				markProviderDone()
 				return wsForwardFailed, requestLogAttempt{Status: status, Error: endErrorMessage(end), ErrorCode: spec001EndStatus(end.Status)}
 			}
+			markProviderDone()
 			commit()
 			if end.Status == "complete" && s.zeroTokenFault(end, finishReason) {
 				s.recordBreakerFault(provider, breakerFaultZeroTokenCompletion, requestID)
@@ -2888,6 +2970,7 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 			}
 			return wsForwardComplete, attempt
 		case err := <-relay.Errors:
+			markProviderDone()
 			s.log.Warn().Err(err).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("ws streaming relay failed")
 			if errors.Is(err, providerws.ErrRelayClosed) {
 				if r.Context().Err() != nil {
@@ -2944,14 +3027,25 @@ func (s *Server) forwardWSStreamingBuffered(w http.ResponseWriter, r *http.Reque
 	var raw bytes.Buffer
 	var promptTok, cachedPromptTok, completionTok *int64
 	toolFinal := newStreamToolCallFinalValidator()
+	markProviderDone := func() {
+		if state != nil {
+			now := phaseTimingNow(s)
+			state.phaseTiming.markProviderDone(now)
+			writePhaseTimingTrailers(w.Header(), state, now)
+		}
+	}
 	for {
 		select {
 		case <-r.Context().Done():
 			relay.Cancel("buyer_disconnected")
+			markProviderDone()
 			return wsForwardCancelled, requestLogAttempt{Status: http.StatusOK, Error: "Buyer disconnected during buffered streaming", FaultFlag: billing.FaultNone}
 		case chunk, ok := <-relay.Chunks:
 			if !ok {
 				continue
+			}
+			if chunk.Data != "" && state != nil {
+				state.phaseTiming.markProviderFirstByte(phaseTimingNow(s))
 			}
 			if _, p, cached, c := sseBlockWithCachedPromptTokens([]byte(chunk.Data), state, billingAttemptN); p != nil || cached != nil || c != nil {
 				promptTok, cachedPromptTok, completionTok = mergeStreamUsagePointers(promptTok, cachedPromptTok, completionTok, p, cached, c)
@@ -2959,10 +3053,12 @@ func (s *Server) forwardWSStreamingBuffered(w http.ResponseWriter, r *http.Reque
 			checked, stop, err := guard.CheckStreamingChunk(chunk.Data)
 			if err != nil {
 				relay.Cancel("tier2_encoding_invalid")
+				markProviderDone()
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider returned invalid Tier2 output encoding", ErrorCode: "tier2_output_encoding_invalid", FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
 			}
 			if raw.Len() > int(maxUpstreamResponseBodyBytes)-len(checked) {
 				relay.Cancel("buffered_stream_too_large")
+				markProviderDone()
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider buffered stream exceeded cap", ErrorCode: "provider_stream_too_large", FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
 			}
 			if sanitized, p, cached, c := sseBlockWithCachedPromptTokens([]byte(checked), state, billingAttemptN); p != nil || cached != nil || c != nil {
@@ -2975,10 +3071,12 @@ func (s *Server) forwardWSStreamingBuffered(w http.ResponseWriter, r *http.Reque
 				if s.streamingDowngrade != nil {
 					s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
 				}
+				markProviderDone()
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider emitted malformed buffered tool-call stream", ErrorCode: "provider_stream_downgraded", FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
 			}
 			if stop {
 				relay.Cancel("tier2_output_truncated")
+				markProviderDone()
 				return wsForwardComplete, requestLogAttempt{Status: http.StatusOK, EstimatedCompTokens: s.estimatedCompletionTokensFromBytes(raw.Len())}
 			}
 		case end := <-relay.Done:
@@ -2986,12 +3084,14 @@ func (s *Server) forwardWSStreamingBuffered(w http.ResponseWriter, r *http.Reque
 				if toolFinal.toolOpened && s.streamingDowngrade != nil {
 					s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
 				}
+				markProviderDone()
 				return wsForwardFailed, requestLogAttempt{Status: wsEndHTTPStatus(end.Status), Error: endErrorMessage(end), ErrorCode: spec001EndStatus(end.Status), FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
 			}
 			if !toolFinal.finalCloseOK() {
 				if s.streamingDowngrade != nil {
 					s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
 				}
+				markProviderDone()
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider closed before tool-call stream completed", ErrorCode: "tool_call_final_close_failed", FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
 			}
 			out, err := consolidatedToolCallSSE(raw.Bytes())
@@ -2999,6 +3099,7 @@ func (s *Server) forwardWSStreamingBuffered(w http.ResponseWriter, r *http.Reque
 				if s.streamingDowngrade != nil {
 					s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
 				}
+				markProviderDone()
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider emitted malformed buffered tool-call stream", ErrorCode: "provider_stream_downgraded", FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
 			}
 			settlementTracker := newSettlementStreamOutputTracker()
@@ -3006,8 +3107,10 @@ func (s *Server) forwardWSStreamingBuffered(w http.ResponseWriter, r *http.Reque
 				if s.streamingDowngrade != nil {
 					s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
 				}
+				markProviderDone()
 				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider emitted malformed settlement stream", ErrorCode: "provider_stream_downgraded", FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
 			}
+			markProviderDone()
 			receiptValue := normalizeReceiptHeaderValue(end.Receipt)
 			terminalTS := int64(0)
 			if providerTS, ok := trustedProviderTerminalStateTSInt(end.TerminalStateTSUnixMS, started, time.Now().UTC()); ok {
@@ -3040,6 +3143,7 @@ func (s *Server) forwardWSStreamingBuffered(w http.ResponseWriter, r *http.Reque
 			}
 			return wsForwardComplete, attempt
 		case err := <-relay.Errors:
+			markProviderDone()
 			s.log.Warn().Err(err).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("ws buffered streaming relay failed")
 			if toolFinal.toolOpened && s.streamingDowngrade != nil {
 				s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
@@ -3065,8 +3169,25 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 	upReq.Header.Set("Content-Type", "application/json")
 	upReq.Header.Set("X-Request-ID", requestID)
 	setSettlementMetadataHeader(upReq.Header, settlementMetadata)
+	markProviderDone := func() {
+		if state != nil {
+			now := phaseTimingNow(s)
+			state.phaseTiming.markProviderDone(now)
+			writePhaseTimingTrailers(w.Header(), state, now)
+		}
+	}
+	if state != nil {
+		state.phaseTiming.markProviderDispatchStart(phaseTimingNow(s))
+	}
 	resp, err := providerhttp.Client.Do(upReq)
+	dispatchDone := phaseTimingNow(s)
+	if state != nil {
+		state.phaseTiming.markProviderDispatchDone(dispatchDone)
+	}
 	if err != nil {
+		if state != nil {
+			state.phaseTiming.markProviderDone(dispatchDone)
+		}
 		s.log.Warn().Err(err).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("streaming provider request failed")
 		if r.Context().Err() != nil {
 			return wsForwardCancelled, 0, requestLogAttempt{}
@@ -3087,7 +3208,17 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 	if resp.StatusCode != http.StatusOK {
 		s.log.Warn().Int("status", resp.StatusCode).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("streaming provider returned non-200")
 		s.handleProviderFailure(provider, resp.StatusCode)
-		respBody, _ := readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
+		body := io.Reader(resp.Body)
+		if state != nil {
+			body = &firstByteTimingReader{
+				r: resp.Body,
+				mark: func() {
+					state.phaseTiming.markProviderFirstByte(phaseTimingNow(s))
+				},
+			}
+		}
+		respBody, _ := readLimitedBody(body, maxUpstreamResponseBodyBytes)
+		markProviderDone()
 		attempt := requestLogAttempt{Status: resp.StatusCode, Error: http.StatusText(resp.StatusCode), ErrorCode: spec001StatusFromBody(respBody)}
 		if resp.StatusCode == http.StatusGatewayTimeout {
 			return wsForwardTimedOut, resp.StatusCode, attempt
@@ -3174,6 +3305,9 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 			if err != nil {
 				return err
 			}
+			if state != nil {
+				state.phaseTiming.markProviderFirstByte(phaseTimingNow(s))
+			}
 			if preCommit.Len()+lineBuf.Len() >= maxPreCommitStreamingBytes {
 				s.log.Warn().Int("bytes", preCommit.Len()+lineBuf.Len()).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("streaming provider exceeded pre-commit buffer cap")
 				return errPreCommitCapExceeded
@@ -3227,6 +3361,7 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 		}
 	}()
 	if preCommitErr != nil {
+		markProviderDone()
 		if errors.Is(preCommitErr, errPreCommitCapExceeded) {
 			s.handleProviderFailure(provider, http.StatusBadGateway)
 			return wsForwardProviderDisconnected, http.StatusBadGateway, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider exceeded pre-commit buffer without commit-worthy event", FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
@@ -3261,6 +3396,7 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 	firstForwardedAt := s.now()
 	if _, writeErr := w.Write(preCommit.Bytes()); writeErr != nil {
 		s.log.Warn().Err(writeErr).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("buyer pre-commit write failed")
+		markProviderDone()
 		return wsForwardCancelled, 0, progressAttempt("Buyer disconnected during streaming", billing.FaultNone)
 	}
 	if s.streamingTiming != nil {
@@ -3297,6 +3433,7 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 				if flusher != nil {
 					flusher.Flush()
 				}
+				markProviderDone()
 				return wsForwardProviderDisconnectedCommitted, http.StatusOK, progressUnavailableAttempt("Provider emitted malformed tool-call stream", "malformed_tool_call", billing.FaultBreakerQualifying)
 			}
 			if err := settlementTracker.observeLine(line); err != nil {
@@ -3308,10 +3445,12 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 				if flusher != nil {
 					flusher.Flush()
 				}
+				markProviderDone()
 				return wsForwardProviderDisconnectedCommitted, http.StatusOK, progressUnavailableAttempt("Provider emitted malformed settlement stream", "malformed_settlement_stream", billing.FaultBreakerQualifying)
 			}
 			if _, writeErr := w.Write(line); writeErr != nil {
 				s.log.Warn().Err(writeErr).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("buyer streaming write failed")
+				markProviderDone()
 				return wsForwardCancelled, 0, progressAttempt("Buyer disconnected during streaming", billing.FaultNone)
 			}
 			bytesEmitted += len(line)
@@ -3323,6 +3462,7 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 			continue
 		}
 		if err == io.EOF {
+			markProviderDone()
 			receiptValue := normalizeReceiptHeaderValue(resp.Trailer.Get("X-MacProvider-Receipt"))
 			if terminalSSEErrorCode != "" {
 				attempt := progressAttempt("Provider emitted terminal structured-output streaming error", billing.FaultBreakerQualifying)
@@ -3352,6 +3492,7 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 			return wsForwardComplete, http.StatusOK, requestLogAttempt{Status: http.StatusOK, PromptTokens: promptTok, CachedPromptTokens: cachedPromptTok, CompletionTokens: completionTok, EstimatedCompTokens: s.observedCompletionTokensFromBytes(bytesEmitted), SettlementOutput: settlementOutput, SettlementReceipt: receiptValue}
 		}
 		if r.Context().Err() != nil {
+			markProviderDone()
 			return wsForwardCancelled, 0, progressAttempt("Buyer disconnected during streaming", billing.FaultNone)
 		}
 		if isStreamingTimeoutErr(err, attemptCtx) {
@@ -3361,6 +3502,7 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 			if flusher != nil {
 				flusher.Flush()
 			}
+			markProviderDone()
 			return wsForwardProviderDisconnectedCommitted, http.StatusOK, progressAttemptWithTerminal("Provider timed out during streaming", billing.FaultBreakerQualifying, billing.TerminalStateGatewayTimeout)
 		} else {
 			s.log.Warn().Err(err).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("provider disconnected during streaming")
@@ -3370,18 +3512,37 @@ func (s *Server) forwardStreaming(w http.ResponseWriter, r *http.Request, reques
 		if flusher != nil {
 			flusher.Flush()
 		}
+		markProviderDone()
 		return wsForwardProviderDisconnectedCommitted, http.StatusOK, progressAttemptWithTerminal("Provider disconnected during streaming", billing.FaultBreakerQualifying, billing.TerminalStateUpstreamTransportDisconnect)
 	}
 }
 
 func (s *Server) forwardStreamingBuffered(w http.ResponseWriter, r *http.Request, requestID string, resp *http.Response, provider pool.Provider, modelScope, streamingMode, streamingBuyer string, state *forwardState, billingAttemptN int) (wsForwardResult, int, requestLogAttempt) {
 	started := time.Now()
-	raw, err := readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
+	markProviderDone := func() {
+		if state != nil {
+			now := phaseTimingNow(s)
+			state.phaseTiming.markProviderDone(now)
+			writePhaseTimingTrailers(w.Header(), state, now)
+		}
+	}
+	bodyReader := io.Reader(resp.Body)
+	if state != nil {
+		bodyReader = &firstByteTimingReader{
+			r: bodyReader,
+			mark: func() {
+				state.phaseTiming.markProviderFirstByte(phaseTimingNow(s))
+			},
+		}
+	}
+	raw, err := readLimitedBody(bodyReader, maxUpstreamResponseBodyBytes)
 	if err != nil {
+		markProviderDone()
 		s.log.Warn().Err(err).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("buffered streaming provider body read failed")
 		s.handleProviderFailure(provider, http.StatusBadGateway)
 		return wsForwardProviderDisconnected, http.StatusBadGateway, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider buffered stream failed", FaultFlag: billing.FaultBreakerQualifying}
 	}
+	markProviderDone()
 	receiptValue := normalizeReceiptHeaderValue(resp.Trailer.Get("X-MacProvider-Receipt"))
 	validator := newStreamToolCallFinalValidator()
 	if err := validator.observeBlock(string(raw)); err != nil || !validator.finalCloseOK() {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -95,6 +95,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// outcome, so the flaky-provider failure mode can be diagnosed without
 	// re-instrumenting the binary.
 	start := s.now()
+	timing := newGatewayPhaseTiming(start)
 	// AC-V2-9: gateway-side first-byte-of-request is the SPEC-019 v0.2
 	// wall-clock zero-point. The 300s budget (`coordinator_request_seconds`
 	// by convention) measures from this point to provider terminal SSE frame
@@ -118,14 +119,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	var accountID, model string
 	var streamMode bool
 	defer func() {
-		slog.Info("chat completion",
+		attrs := []any{
 			"request_id", requestID(r),
 			"account_id", accountID,
 			"model", model,
 			"stream", streamMode,
 			"wall_ms", s.now().Sub(start).Milliseconds(),
 			"status", sw.statusCode,
-		)
+		}
+		attrs = append(attrs, timing.attrs(s.now())...)
+		slog.Info("chat completion", attrs...)
 	}()
 
 	if r.Method != http.MethodPost {
@@ -355,6 +358,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return upReq, nil
 	}
 	structuredStreaming := chat.Stream && chat.hasStructuredOutput()
+	timing.markCoordinatorStart(s.now())
 	resp, err := s.doCoordinatorChatWithRetry(upCtx, r, buildUpReq)
 	if err != nil {
 		if structuredStreaming && errors.Is(upCtx.Err(), context.DeadlineExceeded) {
@@ -369,6 +373,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer resp.Body.Close()
+	timing.observeCoordinatorResponse(resp.Header, s.now())
 
 	if chat.Stream {
 		// ISS-187 R1 architect/code MAJOR: thread the reservation
@@ -376,7 +381,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// 17.7 fallback usage_events insert in settleAfterCommit
 		// uses the SAME window_date as the original reservation
 		// (avoids drift for streams that cross UTC midnight).
-		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, cancelUpstream, upCtx, structuredStreaming, window)
+		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, cancelUpstream, upCtx, structuredStreaming, window, timing)
 		return
 	}
 	s.forwardNonStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens)
@@ -639,7 +644,7 @@ func emitProviderAttribution(dst, src http.Header) {
 	}
 }
 
-func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64, cancelUpstream func(), upstreamCtx context.Context, structuredStreaming bool, reservationWindow string) {
+func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64, cancelUpstream func(), upstreamCtx context.Context, structuredStreaming bool, reservationWindow string, timing *gatewayPhaseTiming) {
 	if resp.StatusCode == http.StatusServiceUnavailable {
 		body, _ := io.ReadAll(resp.Body)
 		if coordinatorTier2PolicyError(resp.StatusCode, body) {
@@ -684,6 +689,9 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		}
 		writeError(w, http.StatusBadGateway, "api_error", "upstream_provider_error", "Upstream provider error")
 		return
+	}
+	if timing != nil {
+		defer timing.observeCoordinatorTrailers(resp.Trailer)
 	}
 	emitProviderAttribution(w.Header(), resp.Header)
 	copyCleanHeaders(w.Header(), resp.Header)

--- a/phase5-gateway/internal/router/phase_timing.go
+++ b/phase5-gateway/internal/router/phase_timing.go
@@ -1,0 +1,92 @@
+package router
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	phaseTimingCoordRoutingHeader     = "X-MacProvider-Timing-Coord-Routing-Ms"
+	phaseTimingCoordAdmissionHeader   = "X-MacProvider-Timing-Coord-Admission-Ms"
+	phaseTimingProviderDispatchHeader = "X-MacProvider-Timing-Provider-Dispatch-Ms"
+	phaseTimingProviderPrefillHeader  = "X-MacProvider-Timing-Provider-Prefill-Ms"
+	phaseTimingProviderDecodeHeader   = "X-MacProvider-Timing-Provider-Decode-Ms"
+	phaseTimingCoordinatorTotalHeader = "X-MacProvider-Timing-Coordinator-Total-Ms"
+)
+
+type gatewayPhaseTiming struct {
+	startedAt             time.Time
+	coordinatorStartAt    time.Time
+	coordinatorResponseAt time.Time
+
+	coordRoutingMS     int64
+	coordAdmissionMS   int64
+	providerDispatchMS int64
+	providerPrefillMS  int64
+	providerDecodeMS   int64
+	coordinatorTotalMS int64
+}
+
+func newGatewayPhaseTiming(start time.Time) *gatewayPhaseTiming {
+	return &gatewayPhaseTiming{startedAt: start}
+}
+
+func (t *gatewayPhaseTiming) markCoordinatorStart(at time.Time) {
+	t.coordinatorStartAt = at
+}
+
+func (t *gatewayPhaseTiming) observeCoordinatorResponse(h http.Header, at time.Time) {
+	t.coordinatorResponseAt = at
+	t.observeCoordinatorTimings(h)
+}
+
+func (t *gatewayPhaseTiming) observeCoordinatorTrailers(h http.Header) {
+	t.observeCoordinatorTimings(h)
+}
+
+func (t *gatewayPhaseTiming) observeCoordinatorTimings(h http.Header) {
+	setHeaderMillis(h, phaseTimingCoordRoutingHeader, &t.coordRoutingMS)
+	setHeaderMillis(h, phaseTimingCoordAdmissionHeader, &t.coordAdmissionMS)
+	setHeaderMillis(h, phaseTimingProviderDispatchHeader, &t.providerDispatchMS)
+	setHeaderMillis(h, phaseTimingProviderPrefillHeader, &t.providerPrefillMS)
+	setHeaderMillis(h, phaseTimingProviderDecodeHeader, &t.providerDecodeMS)
+	setHeaderMillis(h, phaseTimingCoordinatorTotalHeader, &t.coordinatorTotalMS)
+}
+
+func (t *gatewayPhaseTiming) attrs(now time.Time) []any {
+	return []any{
+		"timing_dns_ms", int64(0),
+		"timing_tls_ms", int64(0),
+		"timing_gateway_queue_ms", millisBetween(t.startedAt, t.coordinatorStartAt),
+		"timing_coord_admission_ms", t.coordAdmissionMS,
+		"timing_ws_send_ms", t.providerDispatchMS,
+		"timing_provider_prefill_ms", t.providerPrefillMS,
+		"timing_provider_decode_ms", t.providerDecodeMS,
+		"timing_flush_ms", millisBetween(t.coordinatorResponseAt, now),
+		"timing_coord_routing_ms", t.coordRoutingMS,
+		"timing_coord_total_ms", t.coordinatorTotalMS,
+	}
+}
+
+func headerMillis(h http.Header, name string) int64 {
+	value, err := strconv.ParseInt(h.Get(name), 10, 64)
+	if err != nil || value < 0 {
+		return 0
+	}
+	return value
+}
+
+func setHeaderMillis(h http.Header, name string, dst *int64) {
+	if h.Get(name) == "" {
+		return
+	}
+	*dst = headerMillis(h, name)
+}
+
+func millisBetween(start, end time.Time) int64 {
+	if start.IsZero() || end.IsZero() || end.Before(start) {
+		return 0
+	}
+	return end.Sub(start).Milliseconds()
+}

--- a/phase5-gateway/internal/router/phase_timing_test.go
+++ b/phase5-gateway/internal/router/phase_timing_test.go
@@ -1,0 +1,165 @@
+package router
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGatewayPhaseTimingAttrsIncludeCoordinatorHeaders(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	timing := newGatewayPhaseTiming(start)
+	timing.markCoordinatorStart(start.Add(15 * time.Millisecond))
+	headers := http.Header{}
+	headers.Set(phaseTimingCoordRoutingHeader, "10")
+	headers.Set(phaseTimingCoordAdmissionHeader, "25")
+	headers.Set(phaseTimingProviderDispatchHeader, "7")
+	headers.Set(phaseTimingProviderPrefillHeader, "100")
+	headers.Set(phaseTimingProviderDecodeHeader, "42")
+	headers.Set(phaseTimingCoordinatorTotalHeader, "190")
+	timing.observeCoordinatorResponse(headers, start.Add(150*time.Millisecond))
+
+	attrs := attrsMap(timing.attrs(start.Add(210 * time.Millisecond)))
+
+	assertAttr := func(name string, want int64) {
+		t.Helper()
+		if got := attrs[name]; got != want {
+			t.Fatalf("%s = %v, want %v", name, got, want)
+		}
+	}
+	assertAttr("timing_dns_ms", 0)
+	assertAttr("timing_tls_ms", 0)
+	assertAttr("timing_gateway_queue_ms", 15)
+	assertAttr("timing_coord_admission_ms", 25)
+	assertAttr("timing_ws_send_ms", 7)
+	assertAttr("timing_provider_prefill_ms", 100)
+	assertAttr("timing_provider_decode_ms", 42)
+	assertAttr("timing_flush_ms", 60)
+	assertAttr("timing_coord_routing_ms", 10)
+	assertAttr("timing_coord_total_ms", 190)
+}
+
+func TestGatewayPhaseTimingTrailersMergeTerminalFields(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	timing := newGatewayPhaseTiming(start)
+	timing.markCoordinatorStart(start.Add(15 * time.Millisecond))
+	headers := http.Header{}
+	headers.Set(phaseTimingCoordRoutingHeader, "10")
+	headers.Set(phaseTimingCoordAdmissionHeader, "25")
+	headers.Set(phaseTimingProviderDispatchHeader, "7")
+	headers.Set(phaseTimingProviderPrefillHeader, "100")
+	headers.Set(phaseTimingProviderDecodeHeader, "0")
+	headers.Set(phaseTimingCoordinatorTotalHeader, "150")
+	timing.observeCoordinatorResponse(headers, start.Add(150*time.Millisecond))
+
+	trailers := http.Header{}
+	trailers.Set(phaseTimingProviderDecodeHeader, "250")
+	trailers.Set(phaseTimingCoordinatorTotalHeader, "400")
+	timing.observeCoordinatorTrailers(trailers)
+
+	attrs := attrsMap(timing.attrs(start.Add(410 * time.Millisecond)))
+	if got, want := attrs["timing_coord_admission_ms"], int64(25); got != want {
+		t.Fatalf("coord admission after trailer merge = %v, want %v", got, want)
+	}
+	if got, want := attrs["timing_provider_decode_ms"], int64(250); got != want {
+		t.Fatalf("provider decode after trailer merge = %v, want %v", got, want)
+	}
+	if got, want := attrs["timing_coord_total_ms"], int64(400); got != want {
+		t.Fatalf("coord total after trailer merge = %v, want %v", got, want)
+	}
+}
+
+func TestGatewayStreamingCompletionLogConsumesTimingTrailers(t *testing.T) {
+	logs := captureRetryLogs(t)
+	headers := http.Header{}
+	headers.Set("Content-Type", "text/event-stream; charset=utf-8")
+	headers.Set(phaseTimingCoordAdmissionHeader, "9")
+	headers.Set(phaseTimingProviderDispatchHeader, "11")
+	headers.Set(phaseTimingProviderPrefillHeader, "13")
+	headers.Set(phaseTimingProviderDecodeHeader, "0")
+	headers.Set(phaseTimingCoordinatorTotalHeader, "40")
+	trailers := http.Header{}
+	trailers.Set(phaseTimingProviderDecodeHeader, "250")
+	trailers.Set(phaseTimingCoordinatorTotalHeader, "400")
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     headers.Clone(),
+			Body: io.NopCloser(strings.NewReader(
+				"data: {\"id\":\"chatcmpl\",\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":4,\"total_tokens\":7},\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n" +
+					"data: [DONE]\n\n",
+			)),
+			Trailer: trailers.Clone(),
+		}, nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, nil)
+	fullKey := createAccountAndKey(t, store, cfg, "acct_phase_timing_stream")
+
+	resp := postChat(t, h, fullKey, chatBody(true), nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	logText := logs.String()
+	if !strings.Contains(logText, `msg="chat completion"`) {
+		t.Fatalf("completion log missing:\n%s", logText)
+	}
+	for _, want := range []string{
+		"timing_coord_admission_ms=9",
+		"timing_ws_send_ms=11",
+		"timing_provider_prefill_ms=13",
+		"timing_provider_decode_ms=250",
+		"timing_coord_total_ms=400",
+	} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("completion log missing %q:\n%s", want, logText)
+		}
+	}
+}
+
+func TestGatewayPhaseTimingIgnoresMissingInvalidAndNegativeHeaders(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	timing := newGatewayPhaseTiming(start)
+	headers := http.Header{}
+	headers.Set(phaseTimingCoordAdmissionHeader, "25")
+	headers.Set(phaseTimingProviderDecodeHeader, "42")
+	timing.observeCoordinatorResponse(headers, start.Add(100*time.Millisecond))
+
+	updates := http.Header{}
+	updates.Set(phaseTimingCoordAdmissionHeader, "invalid")
+	updates.Set(phaseTimingProviderDecodeHeader, "-1")
+	updates.Set(phaseTimingCoordinatorTotalHeader, "400")
+	timing.observeCoordinatorTrailers(updates)
+
+	attrs := attrsMap(timing.attrs(start.Add(410 * time.Millisecond)))
+	if got, want := attrs["timing_coord_admission_ms"], int64(0); got != want {
+		t.Fatalf("invalid coord admission = %v, want %v", got, want)
+	}
+	if got, want := attrs["timing_provider_prefill_ms"], int64(0); got != want {
+		t.Fatalf("missing provider prefill = %v, want %v", got, want)
+	}
+	if got, want := attrs["timing_provider_decode_ms"], int64(0); got != want {
+		t.Fatalf("negative provider decode = %v, want %v", got, want)
+	}
+	if got, want := attrs["timing_coord_total_ms"], int64(400); got != want {
+		t.Fatalf("valid coord total = %v, want %v", got, want)
+	}
+}
+
+func attrsMap(attrs []any) map[string]int64 {
+	out := make(map[string]int64, len(attrs)/2)
+	for i := 0; i+1 < len(attrs); i += 2 {
+		key, ok := attrs[i].(string)
+		if !ok {
+			continue
+		}
+		value, ok := attrs[i+1].(int64)
+		if !ok {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- Add coordinator phase timing headers/trailers for routing, admission, provider dispatch, prefill, decode, and coordinator total.
- Add gateway completion-log timing_* attrs for issue #382, including required flat jq-friendly fields.
- Preserve body-byte first-byte semantics across HTTP/WS paths and merge streaming terminal values from trailers before logging.

## Audit
- Final code-review lane: 0 C/H/M, 0 material LOW.
- Final architecture lane: 0 C/H/M, 0 material LOW.
- Final test lane: 0 C/H/M coverage gaps.

## Validation
- phase4-coordinator: go test ./internal/buyer -count=1
- phase5-gateway: go test ./internal/router -count=1
- phase4-coordinator: go test ./...
- phase5-gateway: go test ./...
- git diff origin/main --check