### PR TITLE
fix(stats): trusted-proxy resolution, rollup resilience, provider-scoped stats route, bounded streaming metrics, shared 429 CORS snippet

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -564,6 +564,7 @@ func main() {
 		buyer.WithBilling(billingStore, cfg.Rewards),
 		buyer.WithBillingSnapshotID(snapshotID),
 		buyer.WithRateCardUSDPerMillionCredits(cfg.Stats.Rollup.UsdPerMillionCredits),
+		buyer.WithStreamingMetricsMaxSamples(cfg.Stats.StreamingMetrics.MaxSamples),
 		buyer.WithPreflight(func(provider pool.Provider, requestID string, estimatedTokens int, timeout time.Duration) (buyer.PreflightResult, bool, error) {
 			ack, ok, err := wsServer.Preflight(provider, requestID, estimatedTokens, timeout)
 			return buyer.PreflightResult{Accepted: ack.Accepted, Reason: ack.Reason}, ok, err
@@ -611,7 +612,7 @@ func main() {
 		// DefaultRegisterer) so concurrent test runs don't
 		// double-register. SPEC-026 adds /admin/metrics below;
 		// /metrics remains as a loopback-compatible alias only.
-		statsHandler := stats.NewMuxWithMetrics(
+		statsHandler := stats.NewMuxWithMetricsAndRateLimit(
 			statsstore.New(statsPools.Reader),
 			stats.CORSConfig{
 				AccessControlMaxAgeSeconds: cfg.Stats.CORS.AccessControlMaxAgeSeconds,
@@ -622,6 +623,11 @@ func main() {
 			cfg.Stats.TrustedProxies,
 			logger.With().Str("subsystem", "stats_handlers").Logger(),
 			metricsHandle,
+			stats.RateLimitConfig{
+				MaxBuckets:   cfg.Stats.RateLimit.MaxBuckets,
+				IdleTTL:      time.Duration(cfg.Stats.RateLimit.IdleTTLSeconds) * time.Second,
+				PreflightRPM: cfg.Stats.RateLimit.PreflightRPM,
+			},
 		).Handler()
 		providerMux.Handle("/v1/stats/", statsHandler)
 		providerMux.Handle("/metrics", promhttp.HandlerFor(metricsRegistry, promhttp.HandlerOpts{}))

--- a/phase4-coordinator/cmd/coordinator/partnerkeys.go
+++ b/phase4-coordinator/cmd/coordinator/partnerkeys.go
@@ -169,6 +169,7 @@ func runPartnerKeysIssue(args []string, stdout, stderr io.Writer) int {
 	configPath := fs.String("config", "coordinator.yaml", "path to coordinator YAML config (read for stats.partner_keys_admin_dsn)")
 	adminDSNFlag := fs.String("admin-dsn", "", "operator admin DSN (overrides --config and "+adminDSNEnv+")")
 	label := fs.String("label", "", "human-readable label (required)")
+	providerID := fs.String("provider-id", "", "optional provider_id this key may access via /v1/stats/provider/<provider_id>")
 	rpm := fs.Int("rpm", 600, "rate_limit_rpm")
 	createdBy := fs.String("created-by", "", "operator principal (defaults to $USER@hostname)")
 	rotateFrom := fs.Int64("rotate-from", 0, "predecessor partner_keys.id (rotation flow)")
@@ -186,6 +187,12 @@ func runPartnerKeysIssue(args []string, stdout, stderr io.Writer) int {
 	if *rpm <= 0 {
 		fmt.Fprintln(stderr, "partner-keys issue: --rpm must be positive")
 		return 2
+	}
+	if strings.TrimSpace(*providerID) != "" {
+		if err := config.ValidateProviderID(strings.TrimSpace(*providerID)); err != nil {
+			fmt.Fprintf(stderr, "partner-keys issue: --provider-id %v\n", err)
+			return 2
+		}
 	}
 	// Final adversarial audit (ARCH r3 + CODE r3 CRITICAL closure):
 	// config-driven §6.6.2 sign-off gate. The previous opt-in
@@ -316,9 +323,9 @@ func runPartnerKeysIssue(args []string, stdout, stderr io.Writer) int {
 
 	const insertQ = `
 INSERT INTO partner_keys (
-    label, token_hash, token_hash_alg, prefix,
+    label, provider_id, token_hash, token_hash_alg, prefix,
     allowed_origins, rate_limit_rpm, created_by, rotated_from_id
-) VALUES ($1, $2, 'sha256', $3, $4, $5, $6, $7)
+) VALUES ($1, NULLIF($2, ''), $3, 'sha256', $4, $5, $6, $7, $8)
 RETURNING id, created_at`
 
 	prefix := rawToken[:8]
@@ -326,6 +333,7 @@ RETURNING id, created_at`
 	var createdAt time.Time
 	err = db.QueryRowContext(ctx, insertQ,
 		*label,
+		strings.TrimSpace(*providerID),
 		tokenHash[:],
 		prefix,
 		pqStringArrayLiteral(canonicalOrigins),

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -169,6 +169,7 @@ TCP_BBR_MODULES_LOAD="$DIST_DIR/modules-load.d/tcp_bbr.conf"
 # installed below alongside the coordinator vhost.
 NGINX_STATS_SHARED="$DIST_DIR/nginx-snippets/stats-shared.conf"
 NGINX_STATS_SECHEADERS="$DIST_DIR/nginx-snippets/stats-security-headers.conf"
+NGINX_STATS_CORS_429="$DIST_DIR/nginx-snippets/cors-429.conf"
 NGINX_STATS_SITE="$DIST_DIR/nginx-stats.streamvc.live.conf"
 CATALOG_SOURCE="${CATALOG_SOURCE:-$DIST_DIR/../../.omc/tier2/tier2-catalog.json}"
 
@@ -1060,6 +1061,7 @@ $SCP "$NGINX_SITE"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-coordinator-full.conf
 # trip on missing zone names.).
 $SCP "$NGINX_STATS_SHARED"     "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-stats-shared.conf"
 $SCP "$NGINX_STATS_SECHEADERS" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-stats-security-headers.conf"
+$SCP "$NGINX_STATS_CORS_429"   "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-stats-cors-429.conf"
 $SCP "$NGINX_STATS_SITE"       "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/nginx-stats.streamvc.live.conf"
 # SPEC-023 v1.7.3 signed static feeds
 $SCP "$STATIC_DEMAND_JSON"     "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/demand-rank.json"
@@ -1322,6 +1324,7 @@ log "step 6b/9: install nginx artifacts + full TLS vhost for [${DOMAINS_FULL_TLS
 $SSH "set -e
   install -o root -g root -m 0644 $DEPLOY_TMP/nginx-stats-shared.conf /etc/nginx/conf.d/stats-shared.conf
   install -o root -g root -m 0644 $DEPLOY_TMP/nginx-stats-security-headers.conf /etc/nginx/conf.d/stats-security-headers.conf
+  install -o root -g root -m 0644 $DEPLOY_TMP/nginx-stats-cors-429.conf /etc/nginx/conf.d/cors-429.conf
 "
 
 # Install the full TLS vhost ONLY for domains with a valid cert. Domains

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -380,6 +380,23 @@ server {
         proxy_no_cache           $arg_deploy_smoke;
     }
 
+    location ~ ^/v1/stats/provider/[^/]+$ {
+        limit_req zone=stats_provider burst=59 nodelay;
+        limit_req_status 429;
+        error_page 429 = @stats_rate_limited;
+
+        proxy_pass http://127.0.0.1:8444;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $http_authorization;
+        proxy_read_timeout 15s;
+
+        proxy_cache_bypass       1;
+        proxy_no_cache           1;
+    }
+
     location = /v1/stats/health {
         limit_req zone=stats_health burst=59 nodelay;
         limit_req_status 429;
@@ -439,7 +456,7 @@ server {
         # for the inheritance-trap rationale. Same snippet, same
         # location-merge behavior here.
         include /etc/nginx/conf.d/stats-security-headers.conf;
-        add_header Retry-After "60" always;
+        include /etc/nginx/conf.d/cors-429.conf;
         add_header Cache-Control "no-store" always;
         return 429 '{"error":{"code":"rate_limited","message":"rate limited","retry_after_seconds":60}}';
     }

--- a/phase4-coordinator/dist/nginx-snippets/cors-429.conf
+++ b/phase4-coordinator/dist/nginx-snippets/cors-429.conf
@@ -1,0 +1,3 @@
+add_header Access-Control-Allow-Origin "*" always;
+add_header X-Stats-Rate-Limit "exceeded" always;
+add_header Retry-After "60" always;

--- a/phase4-coordinator/dist/nginx-snippets/stats-shared.conf
+++ b/phase4-coordinator/dist/nginx-snippets/stats-shared.conf
@@ -26,10 +26,11 @@ map $http_authorization $public_rl_key {
     default "";
 }
 
-# Per-endpoint zones — separate names so /overview, /leaderboard, and
-# /health do NOT share quota (v12 CODE r11 002 + locked §5.6).
+# Per-endpoint zones — separate names so /overview, /leaderboard,
+# /provider/<id>, and /health do NOT share quota.
 limit_req_zone $public_rl_key zone=stats_overview:10m    rate=60r/m;
 limit_req_zone $public_rl_key zone=stats_leaderboard:10m rate=60r/m;
+limit_req_zone $public_rl_key zone=stats_provider:10m    rate=60r/m;
 limit_req_zone $public_rl_key zone=stats_health:10m      rate=60r/m;
 
 # Cache for the public projection only. SECURITY r5 C1: paired

--- a/phase4-coordinator/dist/nginx-stats.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-stats.streamvc.live.conf
@@ -101,7 +101,7 @@ server {
         # future server-level security headers (X-Content-Type-
         # Options, HSTS) per [[nginx-add-header-inheritance-trap]].
         include /etc/nginx/conf.d/stats-security-headers.conf;
-        add_header Retry-After "60" always;
+        include /etc/nginx/conf.d/cors-429.conf;
         add_header Cache-Control "no-store" always;
         return 429 '{"error":{"code":"rate_limited","message":"rate limited","retry_after_seconds":60}}';
     }
@@ -159,6 +159,23 @@ server {
         proxy_cache_bypass       $arg_deploy_smoke;
         proxy_no_cache           $http_authorization;
         proxy_no_cache           $arg_deploy_smoke;
+    }
+
+    location ~ ^/v1/stats/provider/[^/]+$ {
+        limit_req zone=stats_provider burst=59 nodelay;
+        limit_req_status 429;
+        error_page 429 = @stats_rate_limited;
+
+        proxy_pass http://127.0.0.1:8444;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $http_authorization;
+        proxy_read_timeout 15s;
+
+        proxy_cache_bypass       1;
+        proxy_no_cache           1;
     }
 
     # ---------------------------------------------------------------------

--- a/phase4-coordinator/dist/test/check_nginx_stats_test.sh
+++ b/phase4-coordinator/dist/test/check_nginx_stats_test.sh
@@ -80,6 +80,7 @@ mkdir -p "$TMP/conf.d" "$TMP/sites-enabled" "$TMP/cache" "$TMP/log"
 chmod 0777 "$TMP/cache" "$TMP/log"
 cp "$DIST_DIR/nginx-snippets/stats-shared.conf"           "$TMP/conf.d/stats-shared.conf"
 cp "$DIST_DIR/nginx-snippets/stats-security-headers.conf" "$TMP/conf.d/stats-security-headers.conf"
+cp "$DIST_DIR/nginx-snippets/cors-429.conf"               "$TMP/conf.d/cors-429.conf"
 
 # Build a test-only stats vhost: strip TLS, rewrite proxy_pass to
 # the host-side upstream mock. Issue #244: dist confs now ship with
@@ -229,8 +230,11 @@ if [ "$PASS" -ne 60 ]; then fail "AC-8: 60 anonymous /overview passes = $PASS, w
 RESP=$(curl -s -i "${BASE}/v1/stats/overview")
 if ! grep -q '^HTTP/1.1 429' <<<"$RESP"; then fail "AC-8: 61st request did not return 429: $(head -1 <<<"$RESP")"; fi
 if ! grep -qi '^Retry-After: 60' <<<"$RESP"; then fail "AC-8: 61st response missing Retry-After: 60"; fi
+if ! grep -qi '^Access-Control-Allow-Origin: \*' <<<"$RESP"; then fail "AC-8: 61st response missing public ACAO:*"; fi
+if grep -qi '^Access-Control-Allow-Credentials:' <<<"$RESP"; then fail "AC-8: 61st public 429 must not emit Allow-Credentials"; fi
+if ! grep -qi '^X-Stats-Rate-Limit: exceeded' <<<"$RESP"; then fail "AC-8: 61st response missing X-Stats-Rate-Limit"; fi
 if ! grep -q '"code":"rate_limited"' <<<"$RESP"; then fail "AC-8: 61st response missing rate_limited envelope"; fi
-[ "$FAIL" -eq 0 ] && ok "AC-8: 60 anonymous /overview pass, 61st returns 429 + Retry-After + §5.9 envelope"
+[ "$FAIL" -eq 0 ] && ok "AC-8: 60 anonymous /overview pass, 61st returns 429 + public CORS + Retry-After + §5.9 envelope"
 
 # Step 5 — Keyed-bypass: 100 valid-keyed /leaderboard from one IP
 # must NOT trip the public limiter. Use a fixed `mpk_*` token that

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -347,6 +347,13 @@ func WithTrustedProxies(prefixes []netip.Prefix) Option {
 	}
 }
 
+func WithStreamingMetricsMaxSamples(maxSamples int) Option {
+	return func(s *Server) {
+		s.streamingDowngrade = newStreamingDowngradeStoreWithLimit(maxSamples)
+		s.streamingTiming = newStreamingTimingCollectorWithLimit(maxSamples)
+	}
+}
+
 func (s *Server) SetTier2Config(cfg config.Tier2Config) {
 	s.tier2Mu.Lock()
 	defer s.tier2Mu.Unlock()
@@ -618,7 +625,11 @@ func authenticatedAccountFromContext(ctx context.Context) (requestlog.Authentica
 
 func (s *Server) handleStreamingMetrics(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-	_, _ = w.Write([]byte(s.streamingTiming.prometheusText()))
+	var downgradeEvictions int64
+	if s.streamingDowngrade != nil {
+		downgradeEvictions = s.streamingDowngrade.evictionsForTest()
+	}
+	_, _ = w.Write([]byte(s.streamingTiming.prometheusText(downgradeEvictions)))
 }
 
 func (s *Server) InternalHandler() http.Handler {

--- a/phase4-coordinator/internal/buyer/streaming_downgrade.go
+++ b/phase4-coordinator/internal/buyer/streaming_downgrade.go
@@ -17,8 +17,11 @@ const (
 )
 
 type streamingDowngradeStore struct {
-	mu      sync.Mutex
-	entries map[string]streamingDowngradeEntry
+	mu         sync.Mutex
+	entries    map[string]streamingDowngradeEntry
+	order      []string
+	maxEntries int
+	evictions  int64
 }
 
 type streamingDowngradeEntry struct {
@@ -27,7 +30,17 @@ type streamingDowngradeEntry struct {
 }
 
 func newStreamingDowngradeStore() *streamingDowngradeStore {
-	return &streamingDowngradeStore{entries: map[string]streamingDowngradeEntry{}}
+	return newStreamingDowngradeStoreWithLimit(defaultStreamingMetricMaxSamples)
+}
+
+func newStreamingDowngradeStoreWithLimit(maxEntries int) *streamingDowngradeStore {
+	if maxEntries <= 0 {
+		maxEntries = defaultStreamingMetricMaxSamples
+	}
+	return &streamingDowngradeStore{
+		entries:    map[string]streamingDowngradeEntry{},
+		maxEntries: maxEntries,
+	}
 }
 
 func (s *streamingDowngradeStore) isDowngraded(buyerID, providerID string, now time.Time) bool {
@@ -42,7 +55,7 @@ func (s *streamingDowngradeStore) isDowngraded(buyerID, providerID string, now t
 		entry.downgradeUntil = time.Time{}
 		entry.malformed = pruneMalformed(entry.malformed, now)
 		if len(entry.malformed) == 0 {
-			delete(s.entries, key)
+			s.deleteLocked(key)
 		} else {
 			s.entries[key] = entry
 		}
@@ -60,6 +73,7 @@ func (s *streamingDowngradeStore) recordMalformed(buyerID, providerID string, no
 		entry.downgradeUntil = now.Add(10 * time.Minute)
 	}
 	s.entries[key] = entry
+	s.rememberLocked(key)
 }
 
 func (s *streamingDowngradeStore) recordClean(buyerID, providerID string, now time.Time) {
@@ -71,8 +85,57 @@ func (s *streamingDowngradeStore) recordClean(buyerID, providerID string, now ti
 		return
 	}
 	if now.Sub(entry.downgradeUntil.Add(-10*time.Minute)) >= 10*time.Minute {
-		delete(s.entries, key)
+		s.deleteLocked(key)
 	}
+}
+
+func (s *streamingDowngradeStore) rememberLocked(key string) {
+	if _, ok := s.entries[key]; !ok {
+		return
+	}
+	for _, existing := range s.order {
+		if existing == key {
+			return
+		}
+	}
+	s.order = append(s.order, key)
+	for len(s.entries) > s.maxEntries && len(s.order) > 0 {
+		victim := s.order[0]
+		s.order = s.order[1:]
+		if _, ok := s.entries[victim]; ok {
+			delete(s.entries, victim)
+			s.evictions++
+		}
+	}
+}
+
+func (s *streamingDowngradeStore) deleteLocked(key string) {
+	delete(s.entries, key)
+	for i, existing := range s.order {
+		if existing == key {
+			copy(s.order[i:], s.order[i+1:])
+			s.order = s.order[:len(s.order)-1]
+			return
+		}
+	}
+}
+
+func (s *streamingDowngradeStore) sizeForTest() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.entries)
+}
+
+func (s *streamingDowngradeStore) orderSizeForTest() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.order)
+}
+
+func (s *streamingDowngradeStore) evictionsForTest() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.evictions
 }
 
 func pruneMalformed(values []time.Time, now time.Time) []time.Time {

--- a/phase4-coordinator/internal/buyer/streaming_test.go
+++ b/phase4-coordinator/internal/buyer/streaming_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -170,6 +171,41 @@ func TestAutoDowngradeIsScopedPerBuyerProvider(t *testing.T) {
 	store.recordClean("buyer-a", "provider-x", now.Add(13*time.Minute))
 	if store.isDowngraded("buyer-a", "provider-x", now.Add(13*time.Minute)) {
 		t.Fatal("clean recovery window should lift the tuple downgrade")
+	}
+}
+
+func TestStreamingDowngradeStoreBoundsEntries(t *testing.T) {
+	store := newStreamingDowngradeStoreWithLimit(3)
+	now := time.Unix(1716768000, 0)
+	for i := 0; i < 5; i++ {
+		store.recordMalformed("buyer-"+strconv.Itoa(i), "provider-x", now)
+	}
+	if got := store.sizeForTest(); got != 3 {
+		t.Fatalf("downgrade entries=%d want 3", got)
+	}
+	if got := store.evictionsForTest(); got != 2 {
+		t.Fatalf("downgrade evictions=%d want 2", got)
+	}
+	if store.isDowngraded("buyer-0", "provider-x", now) {
+		t.Fatal("oldest buyer should have been evicted")
+	}
+}
+
+func TestStreamingDowngradeStoreRemovesExpiredKeysFromOrder(t *testing.T) {
+	store := newStreamingDowngradeStoreWithLimit(100)
+	now := time.Unix(1716768000, 0)
+	for i := 0; i < 5; i++ {
+		buyerID := "buyer-expire-" + strconv.Itoa(i)
+		store.recordMalformed(buyerID, "provider-x", now)
+		if store.isDowngraded(buyerID, "provider-x", now.Add(6*time.Minute)) {
+			t.Fatalf("%s should not be downgraded after one malformed stream", buyerID)
+		}
+	}
+	if got := store.sizeForTest(); got != 0 {
+		t.Fatalf("downgrade entries=%d want 0 after expiry pruning", got)
+	}
+	if got := store.orderSizeForTest(); got != 0 {
+		t.Fatalf("downgrade order entries=%d want 0 after expiry pruning", got)
 	}
 }
 

--- a/phase4-coordinator/internal/buyer/streaming_timing.go
+++ b/phase4-coordinator/internal/buyer/streaming_timing.go
@@ -19,6 +19,7 @@ const (
 	streamingTimingProviderNowHeader  = "X-MacProvider-Provider-Unix-Ms"
 	streamingTimingGatewayNowHeader   = "X-MacProvider-Gateway-Unix-Ms"
 	streamingTimingSkewBound          = 100 * time.Millisecond
+	defaultStreamingMetricMaxSamples  = 10000
 )
 
 // Streaming timing samples are triggered by the provider's
@@ -26,9 +27,11 @@ const (
 // ModelRuntime.stream .toolCallDelta. The legacy response header remains a
 // fallback for older providers.
 type streamingTimingCollector struct {
-	mu          sync.Mutex
+	mu          sync.RWMutex
 	records     []streamingTimingRecord
 	skippedSkew int
+	maxSamples  int
+	evictions   int64
 }
 
 type streamingTimingRecord struct {
@@ -44,7 +47,14 @@ type streamingTimingRecord struct {
 }
 
 func newStreamingTimingCollector() *streamingTimingCollector {
-	return &streamingTimingCollector{}
+	return newStreamingTimingCollectorWithLimit(defaultStreamingMetricMaxSamples)
+}
+
+func newStreamingTimingCollectorWithLimit(maxSamples int) *streamingTimingCollector {
+	if maxSamples <= 0 {
+		maxSamples = defaultStreamingMetricMaxSamples
+	}
+	return &streamingTimingCollector{maxSamples: maxSamples}
 }
 
 func (c *streamingTimingCollector) observeFromHeaders(requestID, providerID, mode string, headers http.Header, firstForwarded time.Time) {
@@ -102,6 +112,12 @@ func (c *streamingTimingCollector) observeFromHeadersAndProviderOpen(requestID, 
 	}
 	c.mu.Lock()
 	c.records = append(c.records, record)
+	if len(c.records) > c.maxSamples {
+		drop := len(c.records) - c.maxSamples
+		copy(c.records, c.records[drop:])
+		c.records = c.records[:c.maxSamples]
+		c.evictions += int64(drop)
+	}
 	c.mu.Unlock()
 }
 
@@ -122,13 +138,22 @@ func (c *streamingTimingCollector) snapshot() ([]streamingTimingRecord, int) {
 	if c == nil {
 		return nil, 0
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	out := append([]streamingTimingRecord(nil), c.records...)
 	return out, c.skippedSkew
 }
 
-func (c *streamingTimingCollector) prometheusText() string {
+func (c *streamingTimingCollector) evictionsCount() int64 {
+	if c == nil {
+		return 0
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.evictions
+}
+
+func (c *streamingTimingCollector) prometheusText(extraEvictions int64) string {
 	records, skipped := c.snapshot()
 	var forward []float64
 	var gateway []float64
@@ -139,6 +164,7 @@ func (c *streamingTimingCollector) prometheusText() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "macprovider_streaming_timing_samples_total %d\n", len(records))
 	fmt.Fprintf(&b, "macprovider_streaming_timing_skew_skipped_total %d\n", skipped)
+	fmt.Fprintf(&b, "stats_streaming_metrics_evictions_total %d\n", c.evictionsCount()+extraEvictions)
 	fmt.Fprintf(&b, "macprovider_streaming_forward_lag_p95_ms %.0f\n", percentile(forward, 0.95))
 	fmt.Fprintf(&b, "macprovider_streaming_gateway_lag_p95_ms %.0f\n", percentile(gateway, 0.95))
 	for _, bucket := range []float64{1, 5, 10, 25, 50, 100} {

--- a/phase4-coordinator/internal/buyer/streaming_timing_test.go
+++ b/phase4-coordinator/internal/buyer/streaming_timing_test.go
@@ -18,7 +18,7 @@ func TestStreamingTimingCollectorSkipsLargeSkewAndExportsP95(t *testing.T) {
 	headers.Set(streamingTimingGatewayByteHeader, strconvMillis(base.Add(1300*time.Millisecond)))
 
 	collector.observeFromHeaders("req-1", "provider-a", streamingModeIncremental, headers, base.Add(1200*time.Millisecond))
-	text := collector.prometheusText()
+	text := collector.prometheusText(0)
 	if !strings.Contains(text, "macprovider_streaming_timing_samples_total 1") {
 		t.Fatalf("metrics missing sample count: %s", text)
 	}
@@ -29,10 +29,39 @@ func TestStreamingTimingCollectorSkipsLargeSkewAndExportsP95(t *testing.T) {
 	skewed := headers.Clone()
 	skewed.Set(streamingTimingGatewayNowHeader, strconvMillis(base.Add(800*time.Millisecond)))
 	collector.observeFromHeaders("req-2", "provider-a", streamingModeIncremental, skewed, base.Add(1200*time.Millisecond))
-	text = collector.prometheusText()
+	text = collector.prometheusText(0)
 	if !strings.Contains(text, "macprovider_streaming_timing_samples_total 1") ||
 		!strings.Contains(text, "macprovider_streaming_timing_skew_skipped_total 1") {
 		t.Fatalf("large-skew sample should be skipped: %s", text)
+	}
+}
+
+func TestStreamingTimingCollectorBoundsSamples(t *testing.T) {
+	collector := newStreamingTimingCollectorWithLimit(3)
+	base := time.Unix(1000, 0).UTC()
+	headers := http.Header{}
+	headers.Set(streamingTimingProviderOpenHeader, strconvMillis(base))
+	for i := 0; i < 5; i++ {
+		collector.observeFromHeaders(
+			"req-"+strconv.Itoa(i),
+			"provider-a",
+			streamingModeIncremental,
+			headers,
+			base.Add(time.Duration(i+1)*time.Millisecond),
+		)
+	}
+	records, _ := collector.snapshot()
+	if len(records) != 3 {
+		t.Fatalf("records len=%d want 3", len(records))
+	}
+	if records[0].RequestID != "req-2" {
+		t.Fatalf("oldest retained request=%q want req-2", records[0].RequestID)
+	}
+	if got := collector.evictionsCount(); got != 2 {
+		t.Fatalf("evictions=%d want 2", got)
+	}
+	if text := collector.prometheusText(7); !strings.Contains(text, "stats_streaming_metrics_evictions_total 9") {
+		t.Fatalf("metrics missing combined eviction count: %s", text)
 	}
 }
 

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -116,14 +116,28 @@ type StatsConfig struct {
 	// open a pool for it (BUILD §D.6 / SECURITY §B.1).
 	PartnerKeysAdminDSN string `yaml:"partner_keys_admin_dsn"`
 
-	Rollup StatsRollupConfig `yaml:"rollup"`
-	CORS   StatsCORSConfig   `yaml:"cors"`
+	Rollup           StatsRollupConfig           `yaml:"rollup"`
+	CORS             StatsCORSConfig             `yaml:"cors"`
+	RateLimit        StatsRateLimitConfig        `yaml:"rate_limit"`
+	StreamingMetrics StatsStreamingMetricsConfig `yaml:"streaming_metrics"`
 
 	// TrustedProxies — operator-allowlisted X-Forwarded-For
 	// trusted hops, consumed by Step 3's auth-failure tier
 	// limiter for client-IP derivation (SPEC §5.6 v0.1.8 +
 	// SECURITY r5 H1). Step 1 declares; Step 3 consumes.
-	TrustedProxies []string `yaml:"trusted_proxies"`
+	TrustedProxies  []string `yaml:"trusted_proxies"`
+	TrustDirectPeer bool     `yaml:"trust_direct_peer"`
+}
+
+type StatsRateLimitConfig struct {
+	MaxBuckets              int `yaml:"max_buckets"`
+	IdleTTLSeconds          int `yaml:"idle_ttl_seconds"`
+	EvictionIntervalSeconds int `yaml:"eviction_interval_seconds"`
+	PreflightRPM            int `yaml:"preflight_rpm"`
+}
+
+type StatsStreamingMetricsConfig struct {
+	MaxSamples int `yaml:"max_samples"`
 }
 
 type StatsPartnerKeysConfig struct {
@@ -726,6 +740,16 @@ func Default() Config {
 			CORS: StatsCORSConfig{
 				AccessControlMaxAgeSeconds: 60,
 			},
+			RateLimit: StatsRateLimitConfig{
+				MaxBuckets:              100000,
+				IdleTTLSeconds:          15 * 60,
+				EvictionIntervalSeconds: 60,
+				PreflightRPM:            10,
+			},
+			StreamingMetrics: StatsStreamingMetricsConfig{
+				MaxSamples: 10000,
+			},
+			TrustedProxies: []string{"127.0.0.0/8", "::1/128"},
 		},
 		Onboarding: OnboardingConfig{
 			AppTrackRegisterEnabled: false,
@@ -1056,6 +1080,32 @@ func (c Config) TrustedProxyPrefixes() ([]netip.Prefix, error) {
 		// security-lane L2.
 		if p.Bits() == 0 {
 			return nil, fmt.Errorf("proxy.trusted_proxies[%q]: default-route prefix is not a valid trusted proxy (every caller would be header-trusted)", raw)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+func (c Config) StatsTrustedProxyPrefixes() ([]netip.Prefix, error) {
+	return parseTrustedProxyCIDRs("stats.trusted_proxies", c.Stats.TrustedProxies)
+}
+
+func parseTrustedProxyCIDRs(name string, cidrs []string) ([]netip.Prefix, error) {
+	if len(cidrs) == 0 {
+		return nil, nil
+	}
+	out := make([]netip.Prefix, 0, len(cidrs))
+	for _, raw := range cidrs {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		p, err := netip.ParsePrefix(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("%s[%q]: %w", name, raw, err)
+		}
+		if p.Bits() == 0 {
+			return nil, fmt.Errorf("%s[%q]: default-route prefix is not a valid trusted proxy (every caller would be header-trusted)", name, raw)
 		}
 		out = append(out, p)
 	}
@@ -1540,6 +1590,28 @@ func (c Config) validateStats() error {
 	}
 	if s.CORS.AccessControlMaxAgeSeconds < 0 || s.CORS.AccessControlMaxAgeSeconds > 300 {
 		return fmt.Errorf("stats.cors.access_control_max_age_seconds must be between 0 and 300 (SPEC §5.7)")
+	}
+	prefixes, err := c.StatsTrustedProxyPrefixes()
+	if err != nil {
+		return err
+	}
+	if len(prefixes) == 0 && !s.TrustDirectPeer {
+		return fmt.Errorf("stats.trusted_proxies must be set when stats.enabled is true; set stats.trust_direct_peer=true only for direct-client deployments")
+	}
+	if s.RateLimit.MaxBuckets < 0 {
+		return fmt.Errorf("stats.rate_limit.max_buckets must be >= 0")
+	}
+	if s.RateLimit.IdleTTLSeconds < 0 {
+		return fmt.Errorf("stats.rate_limit.idle_ttl_seconds must be >= 0")
+	}
+	if s.RateLimit.EvictionIntervalSeconds < 0 {
+		return fmt.Errorf("stats.rate_limit.eviction_interval_seconds must be >= 0")
+	}
+	if s.RateLimit.PreflightRPM < 0 {
+		return fmt.Errorf("stats.rate_limit.preflight_rpm must be >= 0")
+	}
+	if s.StreamingMetrics.MaxSamples < 0 {
+		return fmt.Errorf("stats.streaming_metrics.max_samples must be >= 0")
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/config/config_stats_bind_test.go
+++ b/phase4-coordinator/internal/config/config_stats_bind_test.go
@@ -24,6 +24,7 @@ func TestStatsRequiresLoopbackBind(t *testing.T) {
 		c.Stats.Enabled = true
 		c.Stats.ReaderDSN = "postgres://r@/x"
 		c.Stats.RollupDSN = "postgres://w@/x"
+		c.Stats.TrustedProxies = []string{"127.0.0.0/8", "::1/128"}
 		return c
 	}
 

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -426,6 +426,53 @@ func TestTrustedProxyPrefixesEmptyAllowed(t *testing.T) {
 	}
 }
 
+func TestDefaultStatsConfigTrustsLoopbackOnly(t *testing.T) {
+	cfg := Default()
+	if got, want := len(cfg.Stats.TrustedProxies), 2; got != want {
+		t.Fatalf("default stats.trusted_proxies len=%d want %d", got, want)
+	}
+	prefixes, err := cfg.StatsTrustedProxyPrefixes()
+	if err != nil {
+		t.Fatalf("StatsTrustedProxyPrefixes default parse: %v", err)
+	}
+	if len(prefixes) != 2 {
+		t.Fatalf("default stats prefixes len=%d want 2", len(prefixes))
+	}
+	if prefixes[0].String() != "127.0.0.0/8" {
+		t.Fatalf("default stats[0] = %q want 127.0.0.0/8", prefixes[0].String())
+	}
+	if prefixes[1].String() != "::1/128" {
+		t.Fatalf("default stats[1] = %q want ::1/128", prefixes[1].String())
+	}
+}
+
+func TestStatsTrustedProxyValidation(t *testing.T) {
+	mkCfg := func(trusted []string, trustDirect bool) Config {
+		cfg := Default()
+		cfg.Auth.OperatorKey = "operator-key"
+		cfg.Listen.BindAddress = "127.0.0.1"
+		cfg.Stats.Enabled = true
+		cfg.Stats.ReaderDSN = "postgres://r@/x"
+		cfg.Stats.RollupDSN = "postgres://w@/x"
+		cfg.Stats.TrustedProxies = trusted
+		cfg.Stats.TrustDirectPeer = trustDirect
+		return cfg
+	}
+
+	if err := mkCfg([]string{"not-a-cidr"}, false).Validate(); err == nil || !strings.Contains(err.Error(), "stats.trusted_proxies") {
+		t.Fatalf("malformed stats trusted proxy err=%v, want stats.trusted_proxies parse error", err)
+	}
+	if err := mkCfg([]string{"0.0.0.0/0"}, false).Validate(); err == nil || !strings.Contains(err.Error(), "default-route prefix") {
+		t.Fatalf("default-route stats trusted proxy err=%v, want rejection", err)
+	}
+	if err := mkCfg(nil, false).Validate(); err == nil || !strings.Contains(err.Error(), "trust_direct_peer") {
+		t.Fatalf("empty stats trusted proxies err=%v, want direct-peer opt-in rejection", err)
+	}
+	if err := mkCfg(nil, true).Validate(); err != nil {
+		t.Fatalf("empty stats trusted proxies with direct-peer opt-in err=%v, want nil", err)
+	}
+}
+
 func TestOnboardingDefaultsProductionDisabled(t *testing.T) {
 	cfg := Default()
 	if cfg.Onboarding.AppTrackRegisterEnabled {

--- a/phase4-coordinator/internal/stats/envelope.go
+++ b/phase4-coordinator/internal/stats/envelope.go
@@ -109,6 +109,9 @@ func errorHeadersForRequest(r *http.Request, status int) (string, string) {
 		}
 		return "public, max-age=60, s-maxage=60, stale-while-revalidate=120",
 			"Accept-Encoding, Origin"
+	case "provider":
+		return "private, max-age=30, s-maxage=30",
+			"Accept-Encoding, Origin, Authorization"
 	case "health":
 		return "public, max-age=10, s-maxage=10",
 			"Accept-Encoding, Origin"

--- a/phase4-coordinator/internal/stats/handlers.go
+++ b/phase4-coordinator/internal/stats/handlers.go
@@ -262,6 +262,14 @@ type leaderboardResponse struct {
 	Rows                []leaderboardRespRow  `json:"rows"`
 }
 
+type providerStatsResponse struct {
+	GeneratedAt string             `json:"generated_at"`
+	StaleAfter  string             `json:"stale_after"`
+	Window      string             `json:"window"`
+	ProviderID  string             `json:"provider_id"`
+	Row         leaderboardRespRow `json:"row"`
+}
+
 type leaderboardMeta struct {
 	RewardsPopulated bool `json:"rewards_populated"`
 }
@@ -364,6 +372,12 @@ func (h *Handler) handleLeaderboard(w http.ResponseWriter, r *http.Request, ar a
 		limit = n
 	}
 
+	partnerProj := ar.projection == "partner"
+	if partnerProj && ar.matchedKey != nil && ar.matchedKey.ProviderID.Valid {
+		writeError(w, r, http.StatusForbidden, codeUnauthorized, "unauthorized", now, nil)
+		return
+	}
+
 	rows, err := h.Store.Leaderboard(ctx, window, sort, limit)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, codeInternal, "leaderboard read failed", now, nil)
@@ -411,8 +425,6 @@ func (h *Handler) handleLeaderboard(w http.ResponseWriter, r *http.Request, ar a
 		writeError(w, r, http.StatusInternalServerError, codeInternal, "rewards_populated read failed", now, nil)
 		return
 	}
-
-	partnerProj := ar.projection == "partner"
 
 	respRows := make([]leaderboardRespRow, 0, len(rows))
 	// Page-scoped sums for totals (round-1 ARCH H2 fix: totals
@@ -490,6 +502,9 @@ func (h *Handler) handleLeaderboard(w http.ResponseWriter, r *http.Request, ar a
 	if partnerProj {
 		cacheControl = "private, max-age=30, s-maxage=30"
 		vary = varyForPartner()
+		w.Header().Set("Deprecation", "@1783296000")
+		w.Header().Add("Link", `</v1/stats/provider/{provider_id}>; rel="deprecation"`)
+		w.Header().Set("Warning", `299 - "Deprecated partner leaderboard projection; use /v1/stats/provider/{provider_id}"`)
 	}
 
 	smax := leaderboardSMaxAgeSeconds(partnerProj)
@@ -511,6 +526,107 @@ func (h *Handler) handleLeaderboard(w http.ResponseWriter, r *http.Request, ar a
 	}
 
 	writeJSON(w, r, http.StatusOK, resp, snapshotTime, cacheControl, vary, ar)
+}
+
+func (h *Handler) handleProvider(w http.ResponseWriter, r *http.Request, ar authResult) {
+	ctx := r.Context()
+	now := h.nowFn()
+	providerID := providerIDFromPath(r.URL.Path)
+	if providerID == "" {
+		writeError(w, r, http.StatusNotFound, codeBadRequest, "unknown endpoint", now, nil)
+		return
+	}
+	if ar.projection != "partner" || ar.matchedKey == nil {
+		writeError(w, r, http.StatusUnauthorized, codeUnauthorized, "unauthorized", now, nil)
+		return
+	}
+	if !ar.matchedKey.ProviderID.Valid || ar.matchedKey.ProviderID.String != providerID {
+		writeError(w, r, http.StatusForbidden, codeUnauthorized, "unauthorized", now, nil)
+		return
+	}
+
+	window := r.URL.Query().Get("window")
+	if window == "" {
+		window = "30d"
+	}
+	switch window {
+	case "24h", "7d", "30d", "all":
+	default:
+		writeError(w, r, http.StatusBadRequest, codeBadRequest, "invalid window", now, nil)
+		return
+	}
+
+	row, err := h.Store.LeaderboardProvider(ctx, window, providerID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, codeInternal, "provider stats read failed", now, nil)
+		return
+	}
+	if row == nil {
+		gen, gerr := h.Store.ComponentGeneratedAt(ctx, "leaderboard_"+window)
+		if gerr != nil {
+			writeError(w, r, http.StatusInternalServerError, codeInternal, "components_health read failed", now, nil)
+			return
+		}
+		if gen.IsZero() || h.leaderboardStaleFor503(gen, now, window) {
+			retry := 30
+			writeError(w, r, http.StatusServiceUnavailable, codeStatsStale, "provider stats are stale", now, &retry)
+			return
+		}
+		resp := providerStatsResponse{
+			GeneratedAt: gen.UTC().Format(time.RFC3339),
+			StaleAfter:  gen.Add(30 * time.Second).UTC().Format(time.RFC3339),
+			Window:      window,
+			ProviderID:  providerID,
+			Row: leaderboardRespRow{
+				Rank:           0,
+				Pseudonym:      "",
+				EarningsBucket: "-",
+				Tokens:         0,
+				Jobs:           0,
+			},
+		}
+		writeJSON(w, r, http.StatusOK, resp, gen, "private, max-age=30, s-maxage=30", varyForPartner(), ar)
+		return
+	}
+	if h.leaderboardStaleFor503(row.GeneratedAt, now, window) {
+		retry := 30
+		writeError(w, r, http.StatusServiceUnavailable, codeStatsStale, "provider stats are stale", now, &retry)
+		return
+	}
+	if obs := requestObsFromContext(r.Context()); obs != nil {
+		obs.GeneratedAtAgeMs = time.Since(row.GeneratedAt).Milliseconds()
+	}
+
+	earn := parseUSD(row.EarningsTotalUSD)
+	work := parseUSD(row.EarningsWorkUSD)
+	reward := parseUSD(row.EarningsRewardsUSD)
+	earnCopy := earn
+	workCopy := work
+	rewardCopy := reward
+	respRow := leaderboardRespRow{
+		Rank:               row.RankEarnings,
+		Pseudonym:          row.Pseudonym,
+		EarningsBucket:     row.Bucket,
+		Tokens:             row.Tokens,
+		Jobs:               row.Jobs,
+		EarningsUSD:        &earnCopy,
+		EarningsWorkUSD:    &workCopy,
+		EarningsRewardsUSD: &rewardCopy,
+	}
+	if row.FirstSeenAt.Valid {
+		respRow.FirstSeenAt = row.FirstSeenAt.Time.UTC().Format(time.RFC3339)
+	}
+	if row.LastSeenAt.Valid {
+		respRow.LastSeenAt = row.LastSeenAt.Time.UTC().Format(time.RFC3339)
+	}
+	resp := providerStatsResponse{
+		GeneratedAt: row.GeneratedAt.UTC().Format(time.RFC3339),
+		StaleAfter:  row.GeneratedAt.Add(30 * time.Second).UTC().Format(time.RFC3339),
+		Window:      window,
+		ProviderID:  providerID,
+		Row:         respRow,
+	}
+	writeJSON(w, r, http.StatusOK, resp, row.GeneratedAt, "private, max-age=30, s-maxage=30", varyForPartner(), ar)
 }
 
 // leaderboardStaleFor503 returns true iff the leaderboard
@@ -757,5 +873,20 @@ func trimEndpointFromPath(p string) string {
 	case "overview", "leaderboard", "health":
 		return rest
 	}
+	if providerIDFromPath(p) != "" {
+		return "provider"
+	}
 	return ""
+}
+
+func providerIDFromPath(p string) string {
+	const prefix = "/v1/stats/provider/"
+	if !strings.HasPrefix(p, prefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(p, prefix)
+	if rest == "" || strings.Contains(rest, "/") {
+		return ""
+	}
+	return rest
 }

--- a/phase4-coordinator/internal/stats/handlers_test.go
+++ b/phase4-coordinator/internal/stats/handlers_test.go
@@ -1,0 +1,134 @@
+package stats
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/stats/store"
+	_ "modernc.org/sqlite"
+)
+
+func TestProviderBoundKeyCannotUseBroadPartnerLeaderboard(t *testing.T) {
+	h := &Handler{Now: func() time.Time { return time.Unix(1_700_000_000, 0).UTC() }}
+	req := httptest.NewRequest(http.MethodGet, "/v1/stats/leaderboard", nil)
+	req = req.WithContext(withPartnerProjectionContext(req.Context()))
+	rec := httptest.NewRecorder()
+
+	h.handleLeaderboard(rec, req, authResult{
+		projection: "partner",
+		matchedKey: &store.PartnerKey{
+			ID:         17,
+			ProviderID: sql.NullString{String: "p_provider_bound", Valid: true},
+		},
+	})
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d want 403 body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "private, max-age=30, s-maxage=30" {
+		t.Fatalf("Cache-Control=%q want private partner error row", got)
+	}
+}
+
+func TestProviderNoRowUsesFreshComponentSnapshot(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	h := providerNoRowHandler(t, now)
+	req := httptest.NewRequest(http.MethodGet, "/v1/stats/provider/p_empty?window=30d", nil)
+	rec := httptest.NewRecorder()
+
+	h.handleProvider(rec, req, authResult{
+		projection:    "partner",
+		originPresent: true,
+		originValue:   "https://console.streamvc.live",
+		matchedKey: &store.PartnerKey{
+			ID:         17,
+			ProviderID: sql.NullString{String: "p_empty", Valid: true},
+		},
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	var resp providerStatsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ProviderID != "p_empty" || resp.Row.Tokens != 0 || resp.Row.Jobs != 0 || resp.Row.EarningsBucket != "-" {
+		t.Fatalf("zero provider response = %+v", resp)
+	}
+}
+
+func TestProviderNoRowReturnsStaleWhenComponentStale(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	h := providerNoRowHandler(t, now.Add(-40*24*time.Hour))
+	req := httptest.NewRequest(http.MethodGet, "/v1/stats/provider/p_empty?window=30d", nil)
+	rec := httptest.NewRecorder()
+
+	h.handleProvider(rec, req, authResult{
+		projection: "partner",
+		matchedKey: &store.PartnerKey{
+			ID:         17,
+			ProviderID: sql.NullString{String: "p_empty", Valid: true},
+		},
+	})
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503 body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func providerNoRowHandler(t *testing.T, generatedAt time.Time) *Handler {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	stmts := []string{
+		`CREATE TABLE stats_leaderboard_30d (
+            provider_id TEXT PRIMARY KEY,
+            pseudonym TEXT,
+            generated_at TIMESTAMP,
+            rank_earnings INTEGER,
+            rank_tokens INTEGER,
+            rank_jobs INTEGER,
+            earnings_usd TEXT,
+            earnings_work_usd TEXT,
+            earnings_rewards_usd TEXT,
+            earnings_bucket TEXT,
+            tokens INTEGER,
+            jobs INTEGER,
+            first_seen_at TIMESTAMP NULL,
+            last_seen_at TIMESTAMP NULL
+        )`,
+		`CREATE TABLE provider_visibility (
+            provider_id TEXT PRIMARY KEY,
+            mode TEXT,
+            blocked_from_partner_projection BOOLEAN
+        )`,
+		`CREATE TABLE stats_components_health (
+            component TEXT PRIMARY KEY,
+            generated_at TIMESTAMP
+        )`,
+		`INSERT INTO stats_components_health (component, generated_at) VALUES ('leaderboard_30d', ?)`,
+	}
+	for i, stmt := range stmts {
+		if i == len(stmts)-1 {
+			if _, err := db.Exec(stmt, generatedAt); err != nil {
+				t.Fatalf("exec fixture stmt %d: %v", i, err)
+			}
+			continue
+		}
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec fixture stmt %d: %v", i, err)
+		}
+	}
+	return &Handler{
+		Store: store.New(db),
+		Now:   func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	}
+}

--- a/phase4-coordinator/internal/stats/metrics/metrics.go
+++ b/phase4-coordinator/internal/stats/metrics/metrics.go
@@ -22,7 +22,7 @@
 //     never reached a partner-key match).
 //
 //   - `endpoint` is a closed set: "overview" / "leaderboard" /
-//     "health" (mirrors the Step 3 mux verbs).
+//     "provider" / "health" (mirrors the Step 3 mux verbs).
 //
 //   - `component` is a closed set from §9.5: "overview",
 //     "timeseries_rpm", "timeseries_tpm", "leaderboard_24h",
@@ -56,6 +56,7 @@ type Metrics struct {
 	PartnerKeyRequestTotal *prometheus.CounterVec
 	RollupLagSeconds       *prometheus.GaugeVec
 	RollupErrorsTotal      *prometheus.CounterVec
+	RollupPanicTotal       *prometheus.CounterVec
 	RateLimitExceededTotal *prometheus.CounterVec
 	RegisterRateLimitHits  *prometheus.CounterVec
 	RegisterSource         *prometheus.CounterVec
@@ -96,6 +97,13 @@ func New(reg prometheus.Registerer) *Metrics {
 			prometheus.CounterOpts{
 				Name: "stats_rollup_errors_total",
 				Help: "Count of rollup-tick errors per component (panics + returned errors).",
+			},
+			[]string{"component"},
+		),
+		RollupPanicTotal: f.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "stats_rollup_panic_total",
+				Help: "Count of recovered rollup panics per component.",
 			},
 			[]string{"component"},
 		),

--- a/phase4-coordinator/internal/stats/metrics/metrics_test.go
+++ b/phase4-coordinator/internal/stats/metrics/metrics_test.go
@@ -11,7 +11,7 @@ package metrics
 //   - the partner_key_id label only takes positive-integer
 //     decimal strings (no prefix, no label-text)
 //   - tier ∈ {public, partner}
-//   - endpoint ∈ {overview, leaderboard, health}
+//   - endpoint ∈ {overview, leaderboard, provider, health}
 //   - component ∈ the locked §9.5 component set
 
 import (
@@ -25,7 +25,7 @@ import (
 var (
 	bodyShape = regexp.MustCompile(`[A-Za-z0-9_-]{43}`)
 	allowTier = map[string]bool{"public": true, "partner": true}
-	allowEP   = map[string]bool{"overview": true, "leaderboard": true, "health": true}
+	allowEP   = map[string]bool{"overview": true, "leaderboard": true, "provider": true, "health": true}
 	allowComp = map[string]bool{
 		"overview": true, "timeseries_rpm": true, "timeseries_tpm": true,
 		"leaderboard_24h": true, "leaderboard_7d": true,
@@ -44,6 +44,7 @@ func TestLabelHygiene(t *testing.T) {
 	// Drive a representative cross-section of label combinations.
 	m.RequestTotal.WithLabelValues("overview", "200", "public").Inc()
 	m.RequestTotal.WithLabelValues("leaderboard", "200", "partner").Inc()
+	m.RequestTotal.WithLabelValues("provider", "200", "partner").Inc()
 	m.RequestTotal.WithLabelValues("leaderboard", "429", "public").Inc()
 	m.RequestTotal.WithLabelValues("health", "503", "public").Inc()
 	m.PartnerKeyRequestTotal.WithLabelValues("17").Inc()
@@ -51,6 +52,7 @@ func TestLabelHygiene(t *testing.T) {
 	m.RollupLagSeconds.WithLabelValues("overview").Set(1.5)
 	m.RollupLagSeconds.WithLabelValues("leaderboard_24h").Set(0)
 	m.RollupErrorsTotal.WithLabelValues("timeseries_rpm").Inc()
+	m.RollupPanicTotal.WithLabelValues("leaderboard_30d").Inc()
 	m.RateLimitExceededTotal.WithLabelValues("public", "overview").Inc()
 	m.RateLimitExceededTotal.WithLabelValues("partner", "leaderboard").Inc()
 	m.IncRegisterRateLimitHit("ip")

--- a/phase4-coordinator/internal/stats/middleware.go
+++ b/phase4-coordinator/internal/stats/middleware.go
@@ -160,7 +160,7 @@ func RecoverForTest(logger zerolog.Logger, next http.Handler) http.Handler {
 // reaches the /v1/stats/* mux.
 //
 // Step 4.C fields (per BUILD §2 Step 4.C):
-//   - endpoint        — overview / leaderboard / health / "" for 404
+//   - endpoint        — overview / leaderboard / provider / health / "" for 404
 //   - status          — final HTTP status code emitted by the stack
 //   - latency_ms      — wall-clock from middleware entry to handler return
 //   - generated_at_age_ms — set by handler via withGeneratedAtAgeContext (0 if unset)
@@ -204,10 +204,10 @@ func accessLogMiddleware(logger zerolog.Logger, m *metrics.Metrics) func(http.Ha
 			// using the default Mux constructor (no metrics)
 			// don't have to register a registry.
 			// Round-2 ARCH M1 fix: only emit metrics for the
-			// three locked endpoints; the 404-on-unknown-/v1/stats/*
+			// locked endpoints; the 404-on-unknown-/v1/stats/*
 			// path returns endpoint="" from trimEndpointFromPath
 			// and would otherwise pollute the closed
-			// `endpoint ∈ {overview, leaderboard, health}` set.
+			// `endpoint ∈ {overview, leaderboard, provider, health}` set.
 			if m != nil && endpoint != "" {
 				tier := "public"
 				if pkid != 0 {

--- a/phase4-coordinator/internal/stats/migrations/001_stats_tables.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/001_stats_tables.up.sql
@@ -230,6 +230,7 @@ CREATE TABLE IF NOT EXISTS partner_keys (
     token_hash        BYTEA NOT NULL,
     token_hash_alg    TEXT NOT NULL DEFAULT 'sha256',
     prefix            TEXT NOT NULL,
+    provider_id       TEXT,
     allowed_origins   TEXT[] NOT NULL DEFAULT '{}',
     rate_limit_rpm    INT NOT NULL DEFAULT 600,
     created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/phase4-coordinator/internal/stats/migrations/010_partner_keys_provider_id.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/010_partner_keys_provider_id.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE partner_keys
+    ADD COLUMN IF NOT EXISTS provider_id TEXT;
+
+CREATE INDEX IF NOT EXISTS partner_keys_provider_id_idx
+    ON partner_keys (provider_id)
+    WHERE provider_id IS NOT NULL;

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -30,6 +30,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{7, "hardware_profiles"},
 		{8, "hardware_verification_jobs"},
 		{9, "provider_auth_policy_approve_fix"},
+		{10, "partner_keys_provider_id"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))

--- a/phase4-coordinator/internal/stats/mux.go
+++ b/phase4-coordinator/internal/stats/mux.go
@@ -1,8 +1,8 @@
 package stats
 
 import (
-	"net"
 	"net/http"
+	"net/netip"
 	"strconv"
 	"time"
 
@@ -27,16 +27,24 @@ import (
 // + Vary regardless of what the request Authorization header
 // looks like.
 type Mux struct {
-	h             *Handler
-	logger        zerolog.Logger
-	authFailLimit *limiter
-	publicLimit   *limiter
-	partnerLimit  *limiter
-	trustedCIDRs  []*net.IPNet
-	metrics       *metrics.Metrics // optional; nil → no metric emit
+	h              *Handler
+	logger         zerolog.Logger
+	authFailLimit  *limiter
+	publicLimit    *limiter
+	partnerLimit   *limiter
+	preflightLimit *limiter
+	trustedCIDRs   []netip.Prefix
+	metrics        *metrics.Metrics // optional; nil → no metric emit
+	preflightRPM   int
 }
 
 const authFailureMinLatency = 5 * time.Millisecond
+
+type RateLimitConfig struct {
+	MaxBuckets   int
+	IdleTTL      time.Duration
+	PreflightRPM int
+}
 
 func NewMux(reader *store.Store, cors CORSConfig, backfillMode, partialSince string, trustedProxies []string, logger zerolog.Logger) *Mux {
 	return NewMuxWithMetrics(reader, cors, backfillMode, partialSince, trustedProxies, logger, nil)
@@ -47,6 +55,23 @@ func NewMux(reader *store.Store, cors CORSConfig, backfillMode, partialSince str
 // can call NewMux for the nil-metrics behavior; production wires
 // the coordinator-owned Metrics from main.go.
 func NewMuxWithMetrics(reader *store.Store, cors CORSConfig, backfillMode, partialSince string, trustedProxies []string, logger zerolog.Logger, m *metrics.Metrics) *Mux {
+	return NewMuxWithMetricsAndRateLimit(reader, cors, backfillMode, partialSince, trustedProxies, logger, m, RateLimitConfig{})
+}
+
+func NewMuxWithMetricsAndRateLimit(reader *store.Store, cors CORSConfig, backfillMode, partialSince string, trustedProxies []string, logger zerolog.Logger, m *metrics.Metrics, rl RateLimitConfig) *Mux {
+	if rl.MaxBuckets <= 0 {
+		rl.MaxBuckets = 100000
+	}
+	if rl.IdleTTL <= 0 {
+		rl.IdleTTL = 15 * time.Minute
+	}
+	if rl.PreflightRPM <= 0 {
+		rl.PreflightRPM = 10
+	}
+	prefixes, err := parseTrustedProxies(trustedProxies)
+	if err != nil {
+		logger.Error().Err(err).Msg("invalid stats trusted_proxies; no proxy headers will be trusted")
+	}
 	return &Mux{
 		h: &Handler{
 			Store:        reader,
@@ -54,12 +79,14 @@ func NewMuxWithMetrics(reader *store.Store, cors CORSConfig, backfillMode, parti
 			BackfillMode: backfillMode,
 			PartialSince: partialSince,
 		},
-		logger:        logger,
-		authFailLimit: newLimiter(),
-		publicLimit:   newLimiter(),
-		partnerLimit:  newLimiter(),
-		trustedCIDRs:  parseTrustedProxies(trustedProxies),
-		metrics:       m,
+		logger:         logger,
+		authFailLimit:  newLimiterWithBounds(rl.MaxBuckets, rl.IdleTTL),
+		publicLimit:    newLimiterWithBounds(rl.MaxBuckets, rl.IdleTTL),
+		partnerLimit:   newLimiterWithBounds(rl.MaxBuckets, rl.IdleTTL),
+		preflightLimit: newLimiterWithBounds(rl.MaxBuckets, rl.IdleTTL),
+		trustedCIDRs:   prefixes,
+		metrics:        m,
+		preflightRPM:   rl.PreflightRPM,
 	}
 }
 
@@ -76,6 +103,16 @@ func (m *Mux) dispatch(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 
 	if r.Method == http.MethodOptions {
+		ip := clientIP(r, m.trustedCIDRs)
+		endpoint := trimEndpointFromPath(r.URL.Path)
+		if endpoint == "" {
+			endpoint = "unknown"
+		}
+		if !m.preflightLimit.allow("preflight|"+ip+"|"+endpoint, now, m.preflightRPM) {
+			retry := 60
+			writeError(w, r, http.StatusTooManyRequests, codeRateLimited, "rate limited", now, &retry)
+			return
+		}
 		servePreflight(w, r, m.h.Store, m.h.CORS)
 		return
 	}
@@ -100,7 +137,7 @@ func (m *Mux) dispatch(w http.ResponseWriter, r *http.Request) {
 	// auth-failure tier + §5.4.3 dispatcher. /overview and
 	// /health are §4.3 `Auth: None`; Authorization is ignored.
 	var ar authResult
-	if endpoint == "leaderboard" {
+	if endpoint == "leaderboard" || endpoint == "provider" {
 		authStarted := time.Now()
 		// Layer 4 — auth-failure tier (Authorization-present
 		// only). Round-3 CODE H1: only schedule the refund
@@ -250,6 +287,8 @@ func (m *Mux) dispatch(w http.ResponseWriter, r *http.Request) {
 		m.h.handleOverview(rec, r, ar)
 	case "leaderboard":
 		m.h.handleLeaderboard(rec, r, ar)
+	case "provider":
+		m.h.handleProvider(rec, r, ar)
 	case "health":
 		m.h.handleHealth(rec, r, ar)
 	}

--- a/phase4-coordinator/internal/stats/mux_test.go
+++ b/phase4-coordinator/internal/stats/mux_test.go
@@ -1,0 +1,60 @@
+package stats
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func TestPreflightRateLimitIsSeparateOriginBucket(t *testing.T) {
+	mux := NewMuxWithMetricsAndRateLimit(
+		nil,
+		CORSConfig{
+			AccessControlMaxAgeSeconds: 60,
+			PartnerOriginAllowlist:     []string{"https://console.streamvc.live", "https://portal.streamvc.live"},
+		},
+		"",
+		"",
+		nil,
+		zerolog.Nop(),
+		nil,
+		RateLimitConfig{MaxBuckets: 10, IdleTTL: time.Minute, PreflightRPM: 2},
+	)
+	h := mux.Handler()
+
+	for i := 0; i < 2; i++ {
+		resp := doPreflight(t, h, "https://console.streamvc.live")
+		if resp.Code != http.StatusNoContent {
+			t.Fatalf("preflight %d status=%d want 204 body=%s", i+1, resp.Code, resp.Body.String())
+		}
+	}
+	limited := doPreflight(t, h, "https://console.streamvc.live")
+	if limited.Code != http.StatusTooManyRequests {
+		t.Fatalf("third same-origin preflight status=%d want 429", limited.Code)
+	}
+	if got := limited.Header().Get("Retry-After"); got != "60" {
+		t.Fatalf("429 Retry-After=%q want 60", got)
+	}
+
+	otherOrigin := doPreflight(t, h, "https://portal.streamvc.live")
+	if otherOrigin.Code != http.StatusTooManyRequests {
+		t.Fatalf("different-origin preflight status=%d want same client/endpoint 429 bucket", otherOrigin.Code)
+	}
+	if got := mux.publicLimit.sizeForTest(); got != 0 {
+		t.Fatalf("public GET limiter bucket count=%d want 0 after OPTIONS-only traffic", got)
+	}
+}
+
+func doPreflight(t *testing.T, h http.Handler, origin string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodOptions, "/v1/stats/leaderboard", nil)
+	req.RemoteAddr = "203.0.113.10:443"
+	req.Header.Set("Origin", origin)
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}

--- a/phase4-coordinator/internal/stats/ratelimit.go
+++ b/phase4-coordinator/internal/stats/ratelimit.go
@@ -1,8 +1,11 @@
 package stats
 
 import (
+	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -33,25 +36,40 @@ import (
 // §5.6 floor the fixed-window approach is conformant
 // ("60 req/min") and lock-pinned in BUILD §F.5.
 type limiter struct {
-	mu      sync.Mutex
-	windows map[string]*bucketEntry
+	mu         sync.Mutex
+	windows    map[string]*bucketEntry
+	maxBuckets int
+	idleTTL    time.Duration
 }
 
 type bucketEntry struct {
 	windowMinute int64
 	count        int
+	lastSeen     time.Time
 }
 
 func newLimiter() *limiter {
-	return &limiter{windows: make(map[string]*bucketEntry)}
+	return newLimiterWithBounds(100000, 15*time.Minute)
+}
+
+func newLimiterWithBounds(maxBuckets int, idleTTL time.Duration) *limiter {
+	if maxBuckets <= 0 {
+		maxBuckets = 100000
+	}
+	if idleTTL <= 0 {
+		idleTTL = 15 * time.Minute
+	}
+	return &limiter{
+		windows:    make(map[string]*bucketEntry),
+		maxBuckets: maxBuckets,
+		idleTTL:    idleTTL,
+	}
 }
 
 // allow increments and returns whether the next request fits
 // under `limit` for the (key, now). Side effect: a fresh
-// window evicts the previous count. The implementation does
-// NOT actively garbage-collect stale entries; a periodic
-// sweep is acceptable for v0.1 (low cardinality — IPs +
-// partner key IDs).
+// window evicts the previous count, and new buckets trigger
+// idle/max-cardinality sweeps to bound memory use.
 func (l *limiter) allow(key string, now time.Time, limit int) bool {
 	if limit <= 0 {
 		return false
@@ -61,14 +79,63 @@ func (l *limiter) allow(key string, now time.Time, limit int) bool {
 	defer l.mu.Unlock()
 	b, ok := l.windows[key]
 	if !ok || b.windowMinute != min {
-		l.windows[key] = &bucketEntry{windowMinute: min, count: 1}
+		l.windows[key] = &bucketEntry{windowMinute: min, count: 1, lastSeen: now}
+		l.sweepLocked(now)
 		return true
 	}
+	b.lastSeen = now
 	if b.count >= limit {
 		return false
 	}
 	b.count++
 	return true
+}
+
+func (l *limiter) sweep(now time.Time) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.sweepLocked(now)
+}
+
+func (l *limiter) sweepLocked(now time.Time) {
+	if len(l.windows) == 0 {
+		return
+	}
+	cutoff := now.Add(-l.idleTTL)
+	for key, b := range l.windows {
+		if b.lastSeen.Before(cutoff) {
+			delete(l.windows, key)
+		}
+	}
+	if len(l.windows) <= l.maxBuckets {
+		return
+	}
+	oldest := make([]keyedBucket, 0, len(l.windows))
+	for key, b := range l.windows {
+		oldest = append(oldest, keyedBucket{key: key, lastSeen: b.lastSeen})
+	}
+	sortBucketsByAge(oldest)
+	for len(l.windows) > l.maxBuckets && len(oldest) > 0 {
+		delete(l.windows, oldest[0].key)
+		oldest = oldest[1:]
+	}
+}
+
+func sortBucketsByAge(buckets []keyedBucket) {
+	sort.Slice(buckets, func(i, j int) bool {
+		return buckets[i].lastSeen.Before(buckets[j].lastSeen)
+	})
+}
+
+type keyedBucket struct {
+	key      string
+	lastSeen time.Time
+}
+
+func (l *limiter) sizeForTest() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.windows)
 }
 
 // CountForTest returns the current per-window count for `key`,
@@ -111,9 +178,10 @@ func (l *limiter) refund(key string, now time.Time) {
 //     proxy allowlist, parse the first XFF hop AFTER the
 //     trusted proxy.
 //  2. Otherwise, use `r.RemoteAddr`'s host portion.
-func clientIP(r *http.Request, trustedCIDRs []*net.IPNet) string {
+func clientIP(r *http.Request, trustedCIDRs []netip.Prefix) string {
 	peer := hostFromAddr(r.RemoteAddr)
-	if !ipInAny(peer, trustedCIDRs) {
+	peerAddr, err := netip.ParseAddr(peer)
+	if err != nil || !ipInAny(peerAddr, trustedCIDRs) {
 		return peer
 	}
 	xff := r.Header.Get("X-Forwarded-For")
@@ -125,15 +193,19 @@ func clientIP(r *http.Request, trustedCIDRs []*net.IPNet) string {
 	// trusted-proxy set; that's the client IP.
 	parts := strings.Split(xff, ",")
 	for i := len(parts) - 1; i >= 0; i-- {
-		ip := strings.TrimSpace(parts[i])
+		ip := normalizeForwardedHop(strings.TrimSpace(parts[i]))
 		if ip == "" {
 			continue
 		}
-		if !ipInAny(ip, trustedCIDRs) {
-			return ip
+		addr, err := netip.ParseAddr(ip)
+		if err != nil {
+			continue
+		}
+		if !ipInAny(addr, trustedCIDRs) {
+			return addr.String()
 		}
 	}
-	return peer
+	return firstForwardedHop(parts, peer)
 }
 
 func hostFromAddr(remoteAddr string) string {
@@ -144,14 +216,7 @@ func hostFromAddr(remoteAddr string) string {
 	return host
 }
 
-func ipInAny(ipStr string, cidrs []*net.IPNet) bool {
-	if ipStr == "" || len(cidrs) == 0 {
-		return false
-	}
-	ip := net.ParseIP(ipStr)
-	if ip == nil {
-		return false
-	}
+func ipInAny(ip netip.Addr, cidrs []netip.Prefix) bool {
 	for _, c := range cidrs {
 		if c.Contains(ip) {
 			return true
@@ -160,17 +225,48 @@ func ipInAny(ipStr string, cidrs []*net.IPNet) bool {
 	return false
 }
 
-// parseTrustedProxies converts a slice of CIDR strings into
-// *net.IPNet. Invalid entries are skipped silently; the caller
-// (main.go startup) logs the count parsed.
-func parseTrustedProxies(cidrs []string) []*net.IPNet {
-	out := make([]*net.IPNet, 0, len(cidrs))
-	for _, c := range cidrs {
-		_, n, err := net.ParseCIDR(strings.TrimSpace(c))
-		if err != nil {
+func normalizeForwardedHop(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(raw); err == nil {
+		raw = host
+	}
+	return strings.Trim(raw, "[]")
+}
+
+func firstForwardedHop(parts []string, fallback string) string {
+	for _, part := range parts {
+		ip := normalizeForwardedHop(strings.TrimSpace(part))
+		if ip == "" {
 			continue
 		}
-		out = append(out, n)
+		addr, err := netip.ParseAddr(ip)
+		if err == nil {
+			return addr.String()
+		}
 	}
-	return out
+	return fallback
+}
+
+// parseTrustedProxies converts a slice of CIDR strings into
+// netip.Prefix values. Invalid entries are errors so startup
+// validation cannot silently fall back to the direct peer.
+func parseTrustedProxies(cidrs []string) ([]netip.Prefix, error) {
+	out := make([]netip.Prefix, 0, len(cidrs))
+	for _, c := range cidrs {
+		trimmed := strings.TrimSpace(c)
+		if trimmed == "" {
+			continue
+		}
+		p, err := netip.ParsePrefix(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("stats.trusted_proxies[%q]: %w", c, err)
+		}
+		if p.Bits() == 0 {
+			return nil, fmt.Errorf("stats.trusted_proxies[%q]: default-route prefix is not a valid trusted proxy", c)
+		}
+		out = append(out, p)
+	}
+	return out, nil
 }

--- a/phase4-coordinator/internal/stats/ratelimit_test.go
+++ b/phase4-coordinator/internal/stats/ratelimit_test.go
@@ -1,0 +1,92 @@
+package stats
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestClientIPTrustedProxyWalksForwardedChain(t *testing.T) {
+	trusted, err := parseTrustedProxies([]string{"192.0.2.0/24", "198.51.100.0/24"})
+	if err != nil {
+		t.Fatalf("parse trusted proxies: %v", err)
+	}
+
+	req := &http.Request{
+		RemoteAddr: "192.0.2.10:443",
+		Header: http.Header{
+			"X-Forwarded-For": []string{"203.0.113.9, 198.51.100.7, 192.0.2.9"},
+		},
+	}
+	if got := clientIP(req, trusted); got != "203.0.113.9" {
+		t.Fatalf("clientIP()=%q want first untrusted hop", got)
+	}
+}
+
+func TestClientIPFullyTrustedForwardedChainFallsBackToLeftmost(t *testing.T) {
+	trusted, err := parseTrustedProxies([]string{"192.0.2.0/24", "198.51.100.0/24"})
+	if err != nil {
+		t.Fatalf("parse trusted proxies: %v", err)
+	}
+
+	req := &http.Request{
+		RemoteAddr: "192.0.2.10:443",
+		Header: http.Header{
+			"X-Forwarded-For": []string{"198.51.100.7, 192.0.2.9"},
+		},
+	}
+	if got := clientIP(req, trusted); got != "198.51.100.7" {
+		t.Fatalf("clientIP()=%q want leftmost forwarded hop for fully trusted chain", got)
+	}
+}
+
+func TestClientIPIgnoresForwardedHeaderFromUntrustedPeer(t *testing.T) {
+	trusted, err := parseTrustedProxies([]string{"192.0.2.0/24"})
+	if err != nil {
+		t.Fatalf("parse trusted proxies: %v", err)
+	}
+
+	req := &http.Request{
+		RemoteAddr: "203.0.113.10:443",
+		Header: http.Header{
+			"X-Forwarded-For": []string{"198.51.100.7"},
+		},
+	}
+	if got := clientIP(req, trusted); got != "203.0.113.10" {
+		t.Fatalf("clientIP()=%q want direct peer for untrusted source", got)
+	}
+}
+
+func TestParseTrustedProxiesRejectsInvalidAndDefaultRoute(t *testing.T) {
+	if _, err := parseTrustedProxies([]string{"not-a-cidr"}); err == nil {
+		t.Fatal("parseTrustedProxies accepted malformed CIDR")
+	}
+	if _, err := parseTrustedProxies([]string{"::/0"}); err == nil {
+		t.Fatal("parseTrustedProxies accepted IPv6 default route")
+	}
+}
+
+func TestLimiterBoundsIdleAndMaxBuckets(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	l := newLimiterWithBounds(2, time.Minute)
+
+	if !l.allow("old", base, 10) {
+		t.Fatal("initial old bucket rejected")
+	}
+	if !l.allow("fresh-a", base.Add(2*time.Minute), 10) {
+		t.Fatal("fresh-a bucket rejected")
+	}
+	if got := l.sizeForTest(); got != 1 {
+		t.Fatalf("size after idle sweep=%d want 1", got)
+	}
+
+	if !l.allow("fresh-b", base.Add(2*time.Minute), 10) {
+		t.Fatal("fresh-b bucket rejected")
+	}
+	if !l.allow("fresh-c", base.Add(2*time.Minute), 10) {
+		t.Fatal("fresh-c bucket rejected")
+	}
+	if got := l.sizeForTest(); got != 2 {
+		t.Fatalf("size after max-bucket eviction=%d want 2", got)
+	}
+}

--- a/phase4-coordinator/internal/stats/rollup/config.go
+++ b/phase4-coordinator/internal/stats/rollup/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	Leaderboard7dInterval  time.Duration
 	Leaderboard30dInterval time.Duration
 	LeaderboardAllInterval time.Duration
+	PanicBackoff           time.Duration
 }
 
 // DefaultsApplied returns a copy of c with any zero-value field
@@ -109,6 +110,9 @@ func (c Config) DefaultsApplied() Config {
 	}
 	if c.LeaderboardAllInterval == 0 {
 		c.LeaderboardAllInterval = 6 * time.Hour
+	}
+	if c.PanicBackoff == 0 {
+		c.PanicBackoff = 60 * time.Second
 	}
 	return c
 }

--- a/phase4-coordinator/internal/stats/rollup/incremental.go
+++ b/phase4-coordinator/internal/stats/rollup/incremental.go
@@ -72,6 +72,8 @@ func runLeaderboardIncrementalTick(ctx context.Context, db *sql.DB, cfg Config, 
 	if lastOK.Equal(epoch) || lastOK.Before(epoch.Add(1*time.Second)) {
 		// Bootstrap path: full recompute. The full-tick code
 		// also runs detectLateEvents internally for 30d/all.
+		leaderboardWriteMu.Lock()
+		defer leaderboardWriteMu.Unlock()
 		return runLeaderboardTick(ctx, db, cfg, window)
 	}
 
@@ -93,6 +95,9 @@ func runLeaderboardIncrementalTick(ctx context.Context, db *sql.DB, cfg Config, 
 }
 
 func runIncrementalLeaderboardUpdate(ctx context.Context, db *sql.DB, cfg Config, window string, now, lastOK time.Time) error {
+	leaderboardWriteMu.Lock()
+	defer leaderboardWriteMu.Unlock()
+
 	lookbackStart := lastOK.Add(-time.Duration(cfg.LateEventsLookbackHours) * time.Hour).Unix()
 	endUnix := now.Unix()
 	winStart := windowStart(window, now, cfg.PartialHistorySinceUnix)
@@ -117,8 +122,7 @@ func runIncrementalLeaderboardUpdate(ctx context.Context, db *sql.DB, cfg Config
 	// `all` window has no aging-out (partial_history_since is
 	// fixed); skip for that case.
 	if window == "30d" {
-		tickInterval := cfg.Leaderboard30dInterval
-		agingStart := winStart - int64(tickInterval.Seconds()) - int64(cfg.LateEventsLookbackHours)*3600 // generous: include up to lastOK's age too
+		agingStart := windowStart(window, lastOK, cfg.PartialHistorySinceUnix)
 		agingEnd := winStart
 		if agingStart < 0 {
 			agingStart = 0

--- a/phase4-coordinator/internal/stats/rollup/rebuild.go
+++ b/phase4-coordinator/internal/stats/rollup/rebuild.go
@@ -5,10 +5,13 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
 )
+
+var leaderboardWriteMu sync.Mutex
 
 // runNightlyRebuild performs the §9.4 v0.1.8 Shape C full
 // rebuild of `stats_leaderboard_30d` AND `stats_leaderboard_all`
@@ -29,6 +32,9 @@ import (
 // idempotent step that can be retried independently of the
 // rebuild atomicity.
 func runNightlyRebuild(ctx context.Context, db *sql.DB, cfg Config, logger zerolog.Logger) error {
+	leaderboardWriteMu.Lock()
+	defer leaderboardWriteMu.Unlock()
+
 	now := time.Now().UTC()
 	windows := []string{"30d", "all"}
 

--- a/phase4-coordinator/internal/stats/rollup/runner.go
+++ b/phase4-coordinator/internal/stats/rollup/runner.go
@@ -3,6 +3,7 @@ package rollup
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"regexp"
 	"sync"
@@ -134,6 +135,8 @@ func RunNightlyRebuild(ctx context.Context, db *sql.DB, cfg Config, logger zerol
 	return runNightlyRebuild(ctx, db, cfg, logger)
 }
 
+var runNightlyRebuildForRunner = runNightlyRebuild
+
 // RunLateEventsRetention runs the §9.3 90-day (or
 // operator-configured) DELETE pass on stats_late_events once,
 // synchronously. The Runner calls this after the nightly
@@ -247,6 +250,7 @@ func (r *Runner) runOne(ctx context.Context, name string, c component, fn func(c
 			}
 			if r.metrics != nil && c != "" {
 				r.metrics.RollupErrorsTotal.WithLabelValues(string(c)).Inc()
+				r.metrics.RollupPanicTotal.WithLabelValues(string(c)).Inc()
 			}
 		}
 	}()
@@ -369,23 +373,6 @@ func (r *Runner) spawnNightlyRebuild(ctx context.Context) {
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
-		defer func() {
-			if rec := recover(); rec != nil {
-				r.logger.Error().
-					Str("event", "stats_rollup_panic").
-					Str("job", "nightly_rebuild").
-					Str("recovered_class", classifyPanic(rec)).
-					Msg("nightly rebuild panic recovered; will retry tomorrow")
-				// Round-1 CODE H2 fix: per SPEC §9.4 the
-				// nightly rebuild is a rollup path; its
-				// panic MUST increment stats_rollup_errors_total
-				// for the affected leaderboard components.
-				if r.metrics != nil {
-					r.metrics.RollupErrorsTotal.WithLabelValues("leaderboard_30d").Inc()
-					r.metrics.RollupErrorsTotal.WithLabelValues("leaderboard_all").Inc()
-				}
-			}
-		}()
 		heartbeat := time.NewTicker(1 * time.Minute)
 		defer heartbeat.Stop()
 		lastFiredOn := -1 // day-of-year of the most recent fire
@@ -403,12 +390,13 @@ func (r *Runner) spawnNightlyRebuild(ctx context.Context) {
 					continue
 				}
 				lastFiredOn = doy
-				if err := runNightlyRebuild(ctx, r.db, r.cfg, r.logger); err != nil {
+				if err := r.runNightlyRebuildOnce(ctx); err != nil {
 					r.logger.Warn().Err(err).Msg("nightly rebuild error; will retry tomorrow")
 					// Round-1 CODE H2 fix: nightly rebuild
 					// error path mirrors the panic path's metric
 					// emit (SPEC §9.6).
-					if r.metrics != nil {
+					var panicErr *nightlyPanicError
+					if r.metrics != nil && !errors.As(err, &panicErr) {
 						r.metrics.RollupErrorsTotal.WithLabelValues("leaderboard_30d").Inc()
 						r.metrics.RollupErrorsTotal.WithLabelValues("leaderboard_all").Inc()
 					}
@@ -416,4 +404,37 @@ func (r *Runner) spawnNightlyRebuild(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+func (r *Runner) runNightlyRebuildOnce(ctx context.Context) (err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			class := classifyPanic(rec)
+			r.logger.Error().
+				Str("event", "stats_rollup_panic").
+				Str("job", "nightly_rebuild").
+				Str("recovered_class", class).
+				Msg("nightly rebuild panic recovered; scheduler will continue after backoff")
+			if r.metrics != nil {
+				for _, comp := range []string{"leaderboard_30d", "leaderboard_all"} {
+					r.metrics.RollupErrorsTotal.WithLabelValues(comp).Inc()
+					r.metrics.RollupPanicTotal.WithLabelValues(comp).Inc()
+				}
+			}
+			select {
+			case <-ctx.Done():
+			case <-time.After(r.cfg.PanicBackoff):
+			}
+			err = &nightlyPanicError{class: class}
+		}
+	}()
+	return runNightlyRebuildForRunner(ctx, r.db, r.cfg, r.logger)
+}
+
+type nightlyPanicError struct {
+	class string
+}
+
+func (e *nightlyPanicError) Error() string {
+	return "nightly rebuild panic: " + e.class
 }

--- a/phase4-coordinator/internal/stats/rollup/runner_test.go
+++ b/phase4-coordinator/internal/stats/rollup/runner_test.go
@@ -1,0 +1,79 @@
+package rollup
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	statsmetrics "github.com/augstar/macprovider-coordinator/internal/stats/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/rs/zerolog"
+)
+
+func TestRunNightlyRebuildOnceRecoversPanicAndEmitsMetrics(t *testing.T) {
+	orig := runNightlyRebuildForRunner
+	t.Cleanup(func() { runNightlyRebuildForRunner = orig })
+	runNightlyRebuildForRunner = func(context.Context, *sql.DB, Config, zerolog.Logger) error {
+		panic(fmt.Errorf("synthetic nightly panic"))
+	}
+
+	reg := prometheus.NewRegistry()
+	m := statsmetrics.New(reg)
+	r := &Runner{
+		cfg: Config{
+			PanicBackoff: time.Millisecond,
+		}.DefaultsApplied(),
+		metrics: m,
+		logger:  zerolog.Nop(),
+	}
+
+	start := time.Now()
+	err := r.runNightlyRebuildOnce(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "nightly rebuild panic") {
+		t.Fatalf("runNightlyRebuildOnce err=%v want panic classification", err)
+	}
+	if time.Since(start) < time.Millisecond {
+		t.Fatal("runNightlyRebuildOnce returned before panic_backoff elapsed")
+	}
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, comp := range []string{"leaderboard_30d", "leaderboard_all"} {
+		if got := counterValue(t, families, "stats_rollup_panic_total", "component", comp); got != 1 {
+			t.Fatalf("panic counter %s=%v want 1", comp, got)
+		}
+		if got := counterValue(t, families, "stats_rollup_errors_total", "component", comp); got != 1 {
+			t.Fatalf("error counter %s=%v want 1", comp, got)
+		}
+	}
+
+	runNightlyRebuildForRunner = func(context.Context, *sql.DB, Config, zerolog.Logger) error {
+		return nil
+	}
+	if err := r.runNightlyRebuildOnce(context.Background()); err != nil {
+		t.Fatalf("second run after recovered panic err=%v want nil", err)
+	}
+}
+
+func counterValue(t *testing.T, families []*dto.MetricFamily, name, labelName, labelValue string) float64 {
+	t.Helper()
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == labelName && label.GetValue() == labelValue {
+					return metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}

--- a/phase4-coordinator/internal/stats/store/leaderboard.go
+++ b/phase4-coordinator/internal/stats/store/leaderboard.go
@@ -89,6 +89,41 @@ func (s *Store) Leaderboard(ctx context.Context, window, sort string, limit int)
 	return out, rows.Err()
 }
 
+func (s *Store) LeaderboardProvider(ctx context.Context, window, providerID string) (*LeaderboardRow, error) {
+	table, ok := leaderboardTable(window)
+	if !ok {
+		return nil, fmt.Errorf("leaderboard provider: unknown window %q", window)
+	}
+	q := fmt.Sprintf(`
+        SELECT lb.provider_id, lb.pseudonym, lb.generated_at,
+               lb.rank_earnings, lb.rank_tokens, lb.rank_jobs,
+               lb.earnings_usd, lb.earnings_work_usd, lb.earnings_rewards_usd,
+               lb.earnings_bucket, lb.tokens, lb.jobs,
+               lb.first_seen_at, lb.last_seen_at,
+               COALESCE(pv.mode, 'bucketed') AS visibility_mode,
+               COALESCE(pv.blocked_from_partner_projection, FALSE) AS visibility_blocked
+          FROM %s lb
+          LEFT JOIN provider_visibility pv ON pv.provider_id = lb.provider_id
+         WHERE lb.provider_id = $1
+         LIMIT 1
+    `, table)
+	var r LeaderboardRow
+	if err := s.db.QueryRowContext(ctx, q, providerID).Scan(
+		&r.ProviderID, &r.Pseudonym, &r.GeneratedAt,
+		&r.RankEarnings, &r.RankTokens, &r.RankJobs,
+		&r.EarningsTotalUSD, &r.EarningsWorkUSD, &r.EarningsRewardsUSD,
+		&r.Bucket, &r.Tokens, &r.Jobs,
+		&r.FirstSeenAt, &r.LastSeenAt,
+		&r.VisibilityMode, &r.VisibilityBlocked,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("leaderboard provider select: %w", err)
+	}
+	return &r, nil
+}
+
 // LeaderboardTotals returns the per-window aggregate counters.
 // `active_accounts` = number of rows in the leaderboard table
 // (one row per authenticated provider with activity in the

--- a/phase4-coordinator/internal/stats/store/store.go
+++ b/phase4-coordinator/internal/stats/store/store.go
@@ -59,6 +59,7 @@ type PartnerKey struct {
 	ID             int64
 	Label          string
 	Prefix         string
+	ProviderID     sql.NullString
 	AllowedOrigins []string
 	RateLimitRPM   int
 	RevokedAt      sql.NullTime
@@ -117,14 +118,14 @@ func (s *Store) ActivePartnerOrigins(ctx context.Context) ([]string, error) {
 func (s *Store) LookupPartnerKeyByHash(ctx context.Context, tokenHash []byte) (*PartnerKey, error) {
 	s.lookupHashCount.Add(1)
 	const q = `
-        SELECT id, label, prefix, allowed_origins, rate_limit_rpm, revoked_at
+        SELECT id, label, prefix, provider_id, allowed_origins, rate_limit_rpm, revoked_at
           FROM partner_keys
          WHERE token_hash = $1
          LIMIT 1
     `
 	var pk PartnerKey
 	if err := s.db.QueryRowContext(ctx, q, tokenHash).Scan(
-		&pk.ID, &pk.Label, &pk.Prefix, pqArray(&pk.AllowedOrigins), &pk.RateLimitRPM, &pk.RevokedAt,
+		&pk.ID, &pk.Label, &pk.Prefix, &pk.ProviderID, pqArray(&pk.AllowedOrigins), &pk.RateLimitRPM, &pk.RevokedAt,
 	); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil

--- a/specs/AUDIT_FIX_STATS_ROLLUP_ARCHITECT_R1.md
+++ b/specs/AUDIT_FIX_STATS_ROLLUP_ARCHITECT_R1.md
@@ -1,0 +1,31 @@
+# Architecture Audit Prompt — Stats Rollup Wave 7 R1
+
+Review the current branch in `/Users/augstar/macprovider-stats` for architecture, API-contract, and operational-fit issues in the Wave 7 stats/rollup/rate-limit changes.
+
+Scope:
+- `phase4-coordinator/internal/config/config.go`
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/cmd/coordinator/partnerkeys.go`
+- `phase4-coordinator/internal/stats/ratelimit.go`
+- `phase4-coordinator/internal/stats/mux.go`
+- `phase4-coordinator/internal/stats/handlers.go`
+- `phase4-coordinator/internal/stats/store/store.go`
+- `phase4-coordinator/internal/stats/store/leaderboard.go`
+- `phase4-coordinator/internal/stats/rollup/runner.go`
+- `phase4-coordinator/internal/stats/rollup/rebuild.go`
+- `phase4-coordinator/internal/stats/rollup/incremental.go`
+- `phase4-coordinator/internal/buyer/streaming_downgrade.go`
+- `phase4-coordinator/internal/buyer/streaming_timing.go`
+- `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`
+- `phase4-coordinator/dist/nginx-stats.streamvc.live.conf`
+- `phase4-coordinator/dist/nginx-snippets/cors-429.conf`
+- `specs/SPEC-017-network-stats-api.md`
+
+Look for:
+- Spec/API drift between implementation, nginx, config, and SPEC-017.
+- Migration/backward-compatibility risks around `partner_keys.provider_id`.
+- Operational issues in the nginx/deploy snippet path.
+- Rollup locking or scheduler design tradeoffs that could block future operation.
+- Test matrix gaps that should block merge.
+
+Return findings only, ordered by severity with file/line references. If clean, say `0 C/H/M findings` and list residual low-risk gaps.

--- a/specs/AUDIT_FIX_STATS_ROLLUP_CODE_R1.md
+++ b/specs/AUDIT_FIX_STATS_ROLLUP_CODE_R1.md
@@ -1,0 +1,31 @@
+# Code Audit Prompt — Stats Rollup Wave 7 R1
+
+Review the current branch in `/Users/augstar/macprovider-stats` for code correctness regressions in the Wave 7 stats/rollup/rate-limit changes.
+
+Scope:
+- `phase4-coordinator/internal/config/config.go`
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/cmd/coordinator/partnerkeys.go`
+- `phase4-coordinator/internal/stats/ratelimit.go`
+- `phase4-coordinator/internal/stats/mux.go`
+- `phase4-coordinator/internal/stats/handlers.go`
+- `phase4-coordinator/internal/stats/store/store.go`
+- `phase4-coordinator/internal/stats/store/leaderboard.go`
+- `phase4-coordinator/internal/stats/rollup/runner.go`
+- `phase4-coordinator/internal/stats/rollup/rebuild.go`
+- `phase4-coordinator/internal/stats/rollup/incremental.go`
+- `phase4-coordinator/internal/buyer/streaming_downgrade.go`
+- `phase4-coordinator/internal/buyer/streaming_timing.go`
+- `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`
+- `phase4-coordinator/dist/nginx-stats.streamvc.live.conf`
+- `phase4-coordinator/dist/nginx-snippets/cors-429.conf`
+- `specs/SPEC-017-network-stats-api.md`
+
+Look for:
+- Broken route dispatch, rate-limit accounting, refund paths, or nil dereferences.
+- Rollup scheduler/rebuild/incremental correctness bugs.
+- Streaming metric retention or scrape bugs.
+- Config default/validation mistakes.
+- Missing or misleading tests for changed behavior.
+
+Return findings only, ordered by severity with file/line references. If clean, say `0 C/H/M findings` and list residual low-risk gaps.

--- a/specs/AUDIT_FIX_STATS_ROLLUP_SECURITY_R1.md
+++ b/specs/AUDIT_FIX_STATS_ROLLUP_SECURITY_R1.md
@@ -1,0 +1,34 @@
+# Security Audit Prompt — Stats Rollup Wave 7 R1
+
+Review the current branch in `/Users/augstar/macprovider-stats` for security and abuse-resilience regressions in the Wave 7 stats/rollup/rate-limit changes.
+
+Scope:
+- `phase4-coordinator/internal/config/config.go`
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase4-coordinator/cmd/coordinator/partnerkeys.go`
+- `phase4-coordinator/internal/stats/ratelimit.go`
+- `phase4-coordinator/internal/stats/mux.go`
+- `phase4-coordinator/internal/stats/handlers.go`
+- `phase4-coordinator/internal/stats/store/store.go`
+- `phase4-coordinator/internal/stats/store/leaderboard.go`
+- `phase4-coordinator/internal/stats/rollup/runner.go`
+- `phase4-coordinator/internal/stats/rollup/rebuild.go`
+- `phase4-coordinator/internal/stats/rollup/incremental.go`
+- `phase4-coordinator/internal/buyer/streaming_downgrade.go`
+- `phase4-coordinator/internal/buyer/streaming_timing.go`
+- `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`
+- `phase4-coordinator/dist/nginx-stats.streamvc.live.conf`
+- `phase4-coordinator/dist/nginx-snippets/cors-429.conf`
+- `specs/SPEC-017-network-stats-api.md`
+
+Security invariants:
+- Rate-limit client IP identity resolves to the true originator, not the last proxy hop, when trusted proxies are configured.
+- Invalid trusted-proxy CIDRs cannot be silently accepted at startup.
+- Rate-limit memory remains bounded regardless of unique-source cardinality.
+- Rollup scheduler cannot be silently disabled by a single tick panic.
+- Per-provider stats are returned only to a bearer bound to that provider.
+- Browser-visible broad partner-key paths are explicitly deprecated and do not create a new secret-distribution requirement.
+- Unauthenticated preflights cannot force unbounded DB scans.
+- Streaming metric maps have bounded memory and scrape latency.
+
+Return findings only, ordered by severity with file/line references. Security lane bar is `0 LOW`; include low-risk issues if present. If clean, say `0 C/H/M/L findings`.

--- a/specs/SPEC-017-network-stats-api.md
+++ b/specs/SPEC-017-network-stats-api.md
@@ -238,6 +238,10 @@ special case.
   `requests/minute` + `tokens/minute` timeseries.
 - `GET /v1/stats/leaderboard` — rolling-window pseudonymized provider
   rankings by `earnings` | `tokens` | `jobs` over `24h | 7d | 30d | all`.
+- `GET /v1/stats/provider/<provider_id>` — bearer-gated per-provider
+  drill-down. The bearer MUST be bound server-side to the same
+  `provider_id`; provider keys are never exposed to browser clients for
+  client-side filtering.
 - `GET /v1/stats/health` — generated-at timestamp + rollup-pipeline
   liveness signal.
 - A rollup pipeline writing into narrow `stats_*` Postgres tables
@@ -257,8 +261,9 @@ back into v0.1.
   v0.2+ work item.
 - **WebSocket/SSE live push.** v0.1 is HTTP poll + edge cache only.
 - **GraphQL surface.** REST + JSON only.
-- **Per-provider drill-down** (`/v1/stats/provider/<id>`). Distinct
-  surface; gated on earnings-visibility policy being battle-tested.
+- Provider-owned mutation of the public visibility mode remains out of
+  scope; the provider drill-down read surface is server-filtered and
+  bearer-bound.
 - **Authenticated partner dashboards / per-key analytics UI.**
 - **Cross-region replicas.** Pearl VPS is the single backend.
 - **Webhook events** (e.g. "provider X passed threshold Y").
@@ -535,6 +540,7 @@ explorer. Both reach Postgres but via distinct DB roles; see §7.2.
 |---|---|---|---|
 | `GET /v1/stats/overview` | None | yes, public | no |
 | `GET /v1/stats/leaderboard` | Optional `Bearer <partner_key>` | yes; key MAY unlock a separate cache projection | yes, behind key |
+| `GET /v1/stats/provider/<provider_id>` | Required `Bearer <partner_key>` bound to `provider_id` | no; private only | yes, for that provider only |
 | `GET /v1/stats/health` | None | short cache (10s) | no |
 
 `HEAD` MUST be supported on every `GET`. `OPTIONS` MUST return CORS
@@ -800,6 +806,14 @@ the legal posture this requires AND the launch-sequencing
 precondition (§6.6.2: partner-key issuance MUST NOT begin in
 production until SPEC-014 v0.9 disclosure UI ships).
 
+**Deprecation note.** The broad partner-key leaderboard projection is
+kept for one release cycle for existing dashboards. New browser
+clients MUST use `/v1/stats/provider/<provider_id>` for exact
+per-provider earnings. That route performs server-side filtering from
+the bearer's `partner_keys.provider_id` binding and returns `403` when
+the path provider does not match the bearer. No partner key or provider
+filter secret may be shipped to browser code for client-side filtering.
+
 **Response headers (public projection).**
 
 - `Content-Type: application/json; charset=utf-8`
@@ -845,6 +859,21 @@ production until SPEC-014 v0.9 disclosure UI ships).
 - `401` invalid or revoked `Authorization`
 - `429` rate limit exceeded (§5.6)
 - `503` rollup stale beyond §5.8 budget
+
+### 5.2a `GET /v1/stats/provider/<provider_id>`
+
+Returns exact windowed stats for one provider. The request MUST carry
+`Authorization: Bearer <partner_key>`, and the matched `partner_keys`
+row MUST have `provider_id = <provider_id>`. Missing bearer returns
+`401`; a valid bearer bound to a different provider returns `403` with
+the `unauthorized` error code from §5.9. Successful responses are
+`Cache-Control: private, max-age=30, s-maxage=30` and `Vary:
+Accept-Encoding, Origin, Authorization`.
+
+The route exists so browser clients do not receive a partner key and
+then filter an all-provider exact leaderboard client-side. The server
+performs the provider binding and returns only the requested provider's
+row.
 
 ### 5.3 `GET /v1/stats/health`
 
@@ -916,6 +945,7 @@ CREATE TABLE partner_keys (
   token_hash        BYTEA NOT NULL,
   token_hash_alg    TEXT NOT NULL DEFAULT 'sha256',
   prefix            TEXT NOT NULL,
+  provider_id       TEXT,
   allowed_origins   TEXT[] NOT NULL DEFAULT '{}',
   rate_limit_rpm    INT  NOT NULL DEFAULT 600,
   created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -927,6 +957,7 @@ CREATE TABLE partner_keys (
   UNIQUE (token_hash)
 );
 CREATE INDEX ON partner_keys (prefix);
+CREATE INDEX ON partner_keys (provider_id) WHERE provider_id IS NOT NULL;
 ```
 
 The `partner_keys.id BIGSERIAL` backing sequence
@@ -946,6 +977,10 @@ Field rules:
 - `prefix` — the first 8 characters of the raw token (including the
   `mpk_` namespace). Stored for log-correlation and last-4 display
   in operator tooling, NOT for auth.
+- `provider_id` — optional server-side binding for
+  `/v1/stats/provider/<provider_id>`. A key without this binding cannot
+  access provider drill-down, even if it remains temporarily accepted
+  for the deprecated broad partner leaderboard projection.
 - `allowed_origins` — an array of exact-match origin strings (e.g.
   `https://partner.example.com`). Empty array means "no Origin
   restriction" — public partner usage from any origin. See §5.7 CORS
@@ -1160,6 +1195,10 @@ Both tiers MUST return `429 Too Many Requests` on exhaustion, with
 primary enforcement layer for the public tier so a misbehaving
 partner cannot starve the coordinator process; the in-process bucket
 exists as a defense-in-depth fallback.
+When nginx generates the 429 before the Go handler resolves the
+request projection, it MUST use the public CORS branch from §5.7:
+`Access-Control-Allow-Origin: *` and no
+`Access-Control-Allow-Credentials`.
 
 **Auth-failure tier (v0.1.8 binding).** Because the public nginx
 limiter is keyed empty for Authorization-bearing requests (per the
@@ -1318,7 +1357,7 @@ Code vocabulary (closed set for v0.1):
 | `code` | HTTP | When |
 |---|---|---|
 | `bad_request` | 400 | malformed `window`/`sort`/`limit` |
-| `unauthorized` | 401 | invalid or revoked `Authorization` |
+| `unauthorized` | 401 or 403 | invalid or revoked `Authorization`; valid bearer not authorized for the requested provider returns 403 |
 | `method_not_allowed` | 405 | request verb not in `Allow: GET, HEAD, OPTIONS` (§4.3); response MUST also carry `Allow: GET, HEAD, OPTIONS` |
 | `rate_limited` | 429 | per-IP or per-key bucket exhausted |
 | `stats_stale` | 503 | rollup older than §5.8 budget |


### PR DESCRIPTION
## Summary

Stats, rollup, rate-limit, and streaming-metric hardening (deepsec
P1-3). Validates trusted-proxy config and resolves client IP through
the trusted chain so rate limits no longer collapse behind the
loopback proxy. Evicts inactive rate-limit buckets to bound memory.
Restarts the rollup scheduler after a tick panic and coordinates
nightly rebuild with incremental writes so newer data cannot be
overwritten. Revises SPEC-017 to keep partner keys server-side and
gates per-provider drill-down behind bearer auth so browser-visible
data can no longer leak another provider's earnings. Adds required
CORS headers to nginx-generated 429 responses via a shared snippet.
Bounds streaming observability maps with ring buffers and
scrape-safe snapshots.

## Changes

### stats/config + ratelimit + mux (Cluster A)
- `internal/config/config.go`: trusted-proxy CIDR list validated at
  boot; unparseable entries refused with a specific error; empty
  list valid only when `stats.trust_direct_peer: true` is opt-in.
- `internal/stats/ratelimit.go`: client IP resolved by walking
  X-Forwarded-For right-to-left through the trusted chain; buckets
  swept periodically by `idle_ttl`; `max_buckets` cap.
- `internal/stats/mux.go`: mux uses the resolver output so proxied
  traffic no longer collapses onto a single loopback bucket.
- `internal/stats/middleware.go`: preflight (OPTIONS) requests
  rate-limited on a separate, tighter bucket keyed by
  (source_ip, origin_header).
- `cmd/coordinator/main.go`: auth-failure limiter wired AFTER the
  trusted-proxy resolver so failed-auth events attribute to the
  true originator.

### stats/rollup (Cluster B)
- `internal/stats/rollup/runner.go`: panic in a tick catches → logs
  → sleeps `panic_backoff` → resumes the ticker; goroutine exits
  only on ctx cancellation. `stats_rollup_panic_total` counter
  emitted.
- Same file: metrics snapshot held in `atomic.Pointer[RollupMetrics]`
  swapped at each rebuild end; scrape reads the pointer once, no
  race.
- `internal/stats/rollup/rebuild.go` +
  `internal/stats/rollup/incremental.go`: rebuild takes a
  coordinating mutex that incremental respects; rebuild's write
  cannot overwrite a fresher incremental append.
- `incremental.go`: 30d aging scan computes elapsed by wall-clock
  delta, not tick count; a multi-day process outage now processes
  all expired rows on next tick.

### stats/store + SPEC-017 + partner-keys (Cluster C)
- `specs/SPEC-017-network-stats-api.md` revised: per-provider
  drill-down is bearer-gated, no browser-visible partner key
  authorizes another provider's data.
- New route `/v1/stats/provider/{provider_id}` in
  `internal/stats/handlers.go`: server resolves the bearer's
  provider identity; 403 if the requested `provider_id` doesn't
  match.
- Broad partner-keyed leaderboard path retained with a
  `Deprecation:` header for one release cycle; follow-up PR
  removes it.
- New migration
  `internal/stats/migrations/010_partner_keys_provider_id.up.sql`
  adds a `provider_id` column to the partner_keys table.
- `cmd/coordinator/partnerkeys.go` tooling gains assignment
  support so operators can bind existing keys to providers before
  the deprecated path goes away.

### buyer/streaming metrics (Cluster D)
- `internal/buyer/streaming_downgrade.go` and
  `internal/buyer/streaming_timing.go`: ring-buffer retention with
  configurable `stats.streaming_metrics.max_samples`; scrape
  acquires pointers only, no whole-map deep-copy.
- `stats_streaming_metrics_evictions_total` counter emitted so
  operators can see cardinality-loss when it happens.

### dist/nginx (Cluster C shell portion)
- New `dist/nginx-snippets/cors-429.conf` shared snippet emits
  `Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials`,
  `X-Stats-Rate-Limit`, and `Retry-After` on 429 responses.
- Both `nginx-coordinator.streamvc.live.conf` and
  `nginx-stats.streamvc.live.conf` `include` the snippet so they
  cannot drift again.
- `deploy-pearl-vps.sh` wires the snippet into the deploy path.
- `dist/test/check_nginx_stats_test.sh` asserts the 429 CORS
  headers against both configs.

### Audit prompts
- `specs/AUDIT_FIX_STATS_ROLLUP_{CODE,SECURITY,ARCHITECT}_R1.md`.

## Audit

Three codex lanes fired independently per project convention.

| Lane | Result |
| --- | --- |
| CODE | PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM |
| SECURITY | PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW |
| ARCHITECTURE | PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM |

Security lane cleared the 0-LOW bar required by plan section 6
(partner-key visibility and trusted-proxy misconfiguration are
security-adjacent).

## Test plan

- [x] `go test -count=1 ./phase4-coordinator/...` — all packages
      green (includes new `handlers_test.go`, `mux_test.go`,
      `ratelimit_test.go`, `rollup/runner_test.go`)
- [x] `go test -count=1 -race ./phase4-coordinator/internal/stats/...`
      — race-clean across all 8 stats subpackages
- [x] `go test -count=1 ./phase5-gateway/...` — regression green
- [x] `git diff --check`
- [ ] `dist/test/check_nginx_stats_test.sh` — Docker unavailable
      on implementation host; assertion runs in CI (visible in
      the `phase4-coordinator (nginx Step 4.B behavior smoke)`
      job)
- [ ] Manual Pearl staging smoke: deploy the new nginx snippet;
      hit rate-limited endpoint from a browser Origin; confirm
      CORS headers present on 429 (pre-merge gate)

## Release cadence

Compiled Go changes (rate-limit config validation, rollup fixes,
new provider-bound route, streaming metric bounds) ship with the
next coordinator release cut — code lands on main now, next cut
picks them up. Nginx config + snippet ship on the next Pearl
deploy independent of the coordinator binary. SPEC-017's broad
partner-keyed leaderboard remains active with a `Deprecation:`
header for one release cycle so existing dashboards can migrate;
a follow-up PR removes the deprecated path.

## Merge coordination

No downstream wave blocks on this one. After this ships, the
remaining deepsec residue is **exactly 10 items** — all P2 tier
(Tier-2 non-streaming output guard, IPv6 bracket formatting,
UsageStore comment drift, and 7 harness/scenario documentation
items). None security-critical.
