### PR TITLE
Fix gateway settlement for blocked stream frames

### DIFF
--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -343,6 +343,12 @@ final class AutoUpdateTests: XCTestCase {
             providerStatus: status,
             markerStore: store,
             trustProvider: {
+                // Provider config opts out of provisional autoupdate
+                // (`auto_update_accept_provisional: false`), so provisional
+                // trust is "notify only" — the scenario the test name
+                // promises. Without this override, v1.8.16's default
+                // `acceptProvisional=true` treats provisional as eligible
+                // and autoupdate state DOES get created.
                 AutoUpdateTrustState(
                     v2Accepted: true,
                     tier: "provisional",
@@ -353,7 +359,8 @@ final class AutoUpdateTests: XCTestCase {
                     tokenValidated: true,
                     bearerlessDuplicate: false,
                     connected: true,
-                    stableReason: "tier_demoted"
+                    stableReason: "tier_demoted",
+                    acceptProvisional: false
                 )
             },
             drain: { _ in true },
@@ -406,6 +413,13 @@ final class AutoUpdateTests: XCTestCase {
                         connected: true
                     )
                 }
+                // Provider config opts out of provisional autoupdate
+                // (`auto_update_accept_provisional: false`), so the tier
+                // demotion between auth and swap DOES disqualify the
+                // update — the scenario the test name promises. Without
+                // this override, v1.8.16's default `acceptProvisional=true`
+                // treats provisional as eligible and execution falls
+                // through to the release API.
                 return AutoUpdateTrustState(
                     v2Accepted: true,
                     tier: "provisional",
@@ -416,7 +430,8 @@ final class AutoUpdateTests: XCTestCase {
                     tokenValidated: true,
                     bearerlessDuplicate: false,
                     connected: true,
-                    stableReason: "tier_demoted"
+                    stableReason: "tier_demoted",
+                    acceptProvisional: false
                 )
             },
             drain: { _ in true },

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -877,7 +877,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 							flusher.Flush()
 						}
 						cancelCoordinator()
-						s.settleStreamingAfterCommitWithCoordinatorFinality(r, subject, promptEstimate, maxCompletion, maxUsageTokens, "gateway_estimated", "stream_output_exceeded", reservationWindow, resp)
+						s.settleStreamingAfterCommitWithCoordinatorFinality(r, subject, promptEstimate, gatewayContentEstimatedCompletion(), maxUsageTokens, "gateway_estimated", "stream_output_exceeded", reservationWindow, resp)
 						return false
 					}
 					if projectedSerializedBytes-projectedContentBytes > maxStreamingFallbackMetadataBytes {
@@ -887,7 +887,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 							flusher.Flush()
 						}
 						cancelCoordinator()
-						s.settleStreamingAfterCommitWithCoordinatorFinality(r, subject, promptEstimate, maxCompletion, maxUsageTokens, "gateway_estimated", "stream_output_exceeded", reservationWindow, resp)
+						s.settleStreamingAfterCommitWithCoordinatorFinality(r, subject, promptEstimate, gatewayContentEstimatedCompletion(), maxUsageTokens, "gateway_estimated", "stream_output_exceeded", reservationWindow, resp)
 						return false
 					}
 					emitted = projectedContentBytes
@@ -1022,6 +1022,7 @@ func (s *Server) passThroughNoProviderCoordinatorError(w http.ResponseWriter, r 
 		return
 	}
 	copyCleanHeaders(w.Header(), resp.Header)
+	w.Header().Set("X-Request-ID", requestID(r))
 	w.Header().Set("Content-Type", contentTypeOrJSON(resp.Header))
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(body)

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -3138,6 +3138,57 @@ func TestChatForwardsMiddlewareMintedRequestIDWhenBuyerOmits(t *testing.T) {
 	}
 }
 
+func TestNoProvider503EchoesOnlyGatewayRequestID(t *testing.T) {
+	cases := []struct {
+		name      string
+		coordBody string
+	}{
+		{
+			name:      "coordinator_body",
+			coordBody: `{"error":{"code":"no_provider_available","message":"No provider available","param":null,"type":"service_unavailable"}}`,
+		},
+		{
+			name:      "empty_body",
+			coordBody: "",
+		},
+	}
+	for _, tc := range cases {
+		for _, stream := range []bool{false, true} {
+			name := tc.name + "_non_stream"
+			if stream {
+				name = tc.name + "_stream"
+			}
+			t.Run(name, func(t *testing.T) {
+				client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					return responseWithBody(http.StatusServiceUnavailable, http.Header{
+						"Content-Type": []string{"application/json"},
+						"X-Request-ID": []string{"99999999-9999-4999-8999-999999999999"},
+					}, tc.coordBody), nil
+				})}
+				h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+					cfg.Coordinator.BuyerURL = "http://coordinator.test"
+				}, WithHTTPClient(client))
+				fullKey := createAccountAndKey(t, store, cfg, "acct_no_provider_request_id_"+name)
+
+				requestID := "88888888-8888-4888-8888-888888888888"
+				body := `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+				if stream {
+					body = `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+				}
+				resp := postChat(t, h, fullKey, body, map[string]string{"X-Request-ID": requestID})
+
+				if resp.Code != http.StatusServiceUnavailable {
+					t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+				}
+				values := resp.Header().Values("X-Request-ID")
+				if len(values) != 1 || values[0] != requestID {
+					t.Fatalf("response X-Request-ID values=%q, want only gateway request id %q", values, requestID)
+				}
+			})
+		}
+	}
+}
+
 func TestStickyConversationDerivesInternalHeaderAndStripsInjection(t *testing.T) {
 	var captured http.Header
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -4467,7 +4518,7 @@ func TestStreamingGatewayEstimateStopsOverMaxOutput(t *testing.T) {
 	}
 	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
 	quota := readQuota(t, usageResp)
-	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	wantUsed := float64(estimatePromptTokens([]byte(body)))
 	if quota["daily_tokens_used"].(float64) != wantUsed {
 		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
 	}
@@ -4509,7 +4560,7 @@ func TestStreamingGatewayEstimateCountsDataWithoutSpace(t *testing.T) {
 	}
 	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
 	quota := readQuota(t, usageResp)
-	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	wantUsed := float64(estimatePromptTokens([]byte(body)))
 	if quota["daily_tokens_used"].(float64) != wantUsed {
 		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
 	}
@@ -4573,7 +4624,7 @@ func TestStreamingGatewayEstimateCountsGeneratedDeltaStrings(t *testing.T) {
 			}
 			usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
 			quota := readQuota(t, usageResp)
-			wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+			wantUsed := float64(estimatePromptTokens([]byte(body)))
 			if quota["daily_tokens_used"].(float64) != wantUsed {
 				t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
 			}
@@ -4698,7 +4749,7 @@ func TestStreamingGatewayEstimateStopsOverMaxToolCallArguments(t *testing.T) {
 	}
 	usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
 	quota := readQuota(t, usageResp)
-	wantUsed := float64(estimatePromptTokens([]byte(body)) + 1)
+	wantUsed := float64(estimatePromptTokens([]byte(body)))
 	if quota["daily_tokens_used"].(float64) != wantUsed {
 		t.Fatalf("daily_tokens_used=%v want %v", quota["daily_tokens_used"], wantUsed)
 	}
@@ -5206,7 +5257,7 @@ func TestSettleFromUsage_TruncatedOverMaxWithoutObservedOutput_FallsBackToByteCa
 	})
 }
 
-func TestSettleFromUsage_RunawayByteStream_HardCap(t *testing.T) {
+func TestSettleFromUsage_RunawayByteStream_HardCapChargesOnlyForwardedPrefix(t *testing.T) {
 	runStreamingUsageSettlementCase(t, streamingUsageSettlementCase{
 		accountID:      "acct_usage_runaway_hard_cap",
 		model:          "llama",
@@ -5215,7 +5266,7 @@ func TestSettleFromUsage_RunawayByteStream_HardCap(t *testing.T) {
 		maxTokens:      128,
 		wantOutcome:    "stream_output_exceeded",
 		wantSource:     "gateway_estimated",
-		wantCompletion: 128,
+		wantCompletion: 0,
 	})
 }
 


### PR DESCRIPTION
## Summary
- settle gateway-triggered stream_output_exceeded failures using only the already-forwarded streaming prefix instead of the max_tokens cap
- force no-provider 503 passthrough responses back to the gateway-visible X-Request-ID after copying coordinator headers
- add regressions for stream/non-stream no-provider 503 request ids, empty 503 bodies, and blocked runaway stream settlement

Closes #432

## Validation
- go test ./internal/router -run 'TestNoProvider503EchoesOnlyGatewayRequestID|TestStreamingGatewayEstimate(StopsOverMaxOutput|CountsDataWithoutSpace|CountsGeneratedDeltaStrings|StopsOverMaxToolCallArguments)|TestSettleFromUsage_RunawayByteStream_HardCapChargesOnlyForwardedPrefix' -count=1\n- go test ./internal/router -count=1\n- go test ./... -count=1\n- go vet ./internal/router\n- git diff --check\n\n## Audits\n- code correctness lane: 0 C/H/M/L findings\n- security/money-path lane: 0 C/H/M/L findings\n- architecture/invariant lane: 0 C/H/M findings; one low coverage suggestion addressed by adding empty-body 503 cases\n\n## Not tested\n- live harness replay against qwen3-coder single-slot provider