### PR TITLE
Release v1.8.15: SPEC-023 v0.5 payout-first scoring

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.14"
+    static let binaryVersion = "1.8.15"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1644,10 +1644,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.14")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.14")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.14")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.14")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.15")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.15")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.15")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.15")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -22,8 +22,8 @@ settings:
     SWIFT_VERSION: "5.9"
     ENABLE_HARDENED_RUNTIME: YES
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "1.8.14"
-    CURRENT_PROJECT_VERSION: "14"
+    MARKETING_VERSION: "1.8.15"
+    CURRENT_PROJECT_VERSION: "15"
     OTHER_SWIFT_FLAGS: "-strict-concurrency=complete"
 
 targets:


### PR DESCRIPTION
## Summary
- Bump CLI and Malibu marketing version to **1.8.15** for the merged SPEC-023 v0.5 payout-first autotune engine.

## Test plan
- [ ] CI green
- [ ] Tag `v1.8.15` and publish release after merge


Made with [Cursor](https://cursor.com)