### PR TITLE
Deepsec P2 cleanup

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -5,11 +5,13 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"net"
 	"net/http"
 	"net/netip"
 	"os"
 	"os/signal"
 	"reflect"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -570,8 +572,8 @@ func main() {
 			return buyer.PreflightResult{Accepted: ack.Accepted, Reason: ack.Reason}, ok, err
 		}),
 	)
-	providerAddr := fmt.Sprintf("%s:%d", cfg.Listen.BindAddress, cfg.Listen.ProviderPort)
-	buyerAddr := fmt.Sprintf("%s:%d", cfg.Listen.BindAddress, cfg.Listen.BuyerPort)
+	providerAddr := listenAddress(cfg.Listen.BindAddress, cfg.Listen.ProviderPort)
+	buyerAddr := listenAddress(cfg.Listen.BindAddress, cfg.Listen.BuyerPort)
 	providerMux := http.NewServeMux()
 	providerMux.Handle("/", wsServer.Handler())
 	providerMux.Handle("/internal/", buyerServer.InternalHandler())
@@ -946,6 +948,10 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 		ReadTimeout:       310 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
+}
+
+func listenAddress(host string, port int) string {
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 func operatorMetricsHandler(operatorKey string, registry *prom.Registry) http.Handler {

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -40,6 +41,21 @@ func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
 	}
 	if server.IdleTimeout == 0 {
 		t.Fatal("IdleTimeout must be set")
+	}
+}
+
+func TestListenAddressParsesIPv4AndIPv6(t *testing.T) {
+	for _, host := range []string{"127.0.0.1", "::1", "::"} {
+		t.Run(host, func(t *testing.T) {
+			addr := listenAddress(host, 8080)
+			tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+			if err != nil {
+				t.Fatalf("ResolveTCPAddr(%q): %v", addr, err)
+			}
+			if tcpAddr.Port != 8080 {
+				t.Fatalf("port=%d want 8080 for %q", tcpAddr.Port, addr)
+			}
+		})
 	}
 }
 

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -189,6 +189,14 @@ type SettlementRelayFunc func(ctx context.Context, provider pool.Provider, reque
 
 type Option func(*Server)
 
+func applyTier2OutputGuard(guard *tier2.PillarDGuard, output []byte) ([]byte, string, error) {
+	filtered, err := guard.CheckNonStreamingBody(output)
+	if err != nil {
+		return nil, "tier2_output_encoding_invalid", err
+	}
+	return filtered, "", nil
+}
+
 type requestLogInserter interface {
 	Insert(context.Context, requestlog.Row) error
 	InsertForAccount(context.Context, requestlog.AuthenticatedAccount, requestlog.Row) error
@@ -2183,6 +2191,21 @@ func (s *Server) forwardHTTPSequence(
 					writeError(w, http.StatusBadGateway, "provider_failed", "Selected provider failed; buyer should retry")
 					return dispatchedAttempt{}, false
 				}
+				guard := tier2.NewPillarDGuard(s.tier2Config(), requestID, state.provider, s.log)
+				checkedBody, blockReason, guardErr := applyTier2OutputGuard(guard, respBody)
+				if guardErr != nil {
+					cancelAttempt()
+					s.handleProviderFailure(state.provider, http.StatusBadGateway)
+					output := settlementOutputUnavailableFor(billing.TerminalStateProviderError)
+					if err := rec.recordRow(state.provider.AssignedID, state.provider.ProviderID, http.StatusBadGateway, nil, nil, nil, "Provider returned invalid Tier2 output encoding", blockReason, state.explicitRetries, nil, billing.FaultBreakerQualifying, output); err != nil {
+						writeError(w, http.StatusInternalServerError, "request_log_failed", "Could not durably log request")
+						return dispatchedAttempt{}, false
+					}
+					writeError(w, http.StatusBadGateway, blockReason, "Provider returned invalid Tier2 output encoding")
+					return dispatchedAttempt{}, false
+				}
+				bodyMutatedByGuard := !bytes.Equal(checkedBody, respBody)
+				respBody = checkedBody
 				estimatedCompletion := s.observedCompletionTokensFromBytes(len(respBody))
 				promptTok, cachedPromptTok, completionTok := tokenPointersFromChatResponse(respBody)
 				effectiveCached := effectiveCachedPromptTokensForBuyer(cachedPromptTok, promptTok, state, rec.attemptN)
@@ -2197,6 +2220,9 @@ func (s *Server) forwardHTTPSequence(
 					respBody = chatResponseWithCachedPromptTokens(respBody, effectiveCached)
 				}
 				receiptValue := normalizeReceiptHeaderValue(resp.Header.Get("X-MacProvider-Receipt"))
+				if bodyMutatedByGuard {
+					receiptValue = ""
+				}
 				terminalTS := time.Now().UTC().UnixMilli()
 				if providerTS, ok := trustedProviderTerminalStateTS(resp.Header.Get(receiptTerminalStateTSHeaderName), startedAt, time.Now().UTC()); ok {
 					terminalTS = providerTS
@@ -2219,7 +2245,7 @@ func (s *Server) forwardHTTPSequence(
 				if hasReceiptState {
 					setInternalSettlementOutcomeHeaders(w.Header(), rec, receiptState)
 				}
-				copyReceiptHeaderForProvider(w.Header(), resp.Header, state.provider)
+				setReceiptHeaderForProvider(w.Header(), receiptValue, state.provider)
 				w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
 				if w.Header().Get("Content-Type") == "" {
 					w.Header().Set("Content-Type", "application/json")
@@ -2654,10 +2680,11 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 				faultFlag = billing.FaultBreakerQualifying
 			}
 			originalBody := body.Bytes()
-			checkedBody, err := guard.CheckNonStreamingBody(originalBody)
+			checkedBody, blockReason, err := applyTier2OutputGuard(guard, originalBody)
 			if err != nil {
-				writeError(w, http.StatusBadGateway, "tier2_output_encoding_invalid", "Provider returned invalid Tier2 output encoding")
-				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider returned invalid Tier2 output encoding"}
+				s.handleProviderFailure(provider, http.StatusBadGateway)
+				writeError(w, http.StatusBadGateway, blockReason, "Provider returned invalid Tier2 output encoding")
+				return wsForwardFailed, requestLogAttempt{Status: http.StatusBadGateway, Error: "Provider returned invalid Tier2 output encoding", ErrorCode: blockReason, FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
 			}
 			// Round-2 audit HIGH: PillarD enforceOutputCap may truncate the
 			// completion. The provider signed end.Receipt over the original

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -1375,6 +1375,40 @@ func TestHTTPForwardingPassesReceiptFromProviderWithPublishedReceiptKey(t *testi
 	}
 }
 
+func TestHTTPForwardingStripsReceiptWhenPillarDTruncatesBody(t *testing.T) {
+	const receipt = "originalbytes.http.signed.receipt"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-MacProvider-Receipt", receipt)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-test","object":"chat.completion","created":1716768000,"model":"model-a","choices":[{"index":0,"message":{"role":"assistant","content":"this content is longer than the cap and will get truncated"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":20,"total_tokens":24}}`))
+	}))
+	defer upstream.Close()
+
+	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: upstream.URL}})
+	registerWithEndpointReceiptPubkey(registry, "p1", "session-1", "model-a", pool.StateReady, 20000, 1, upstream.URL, 20, bytes.Repeat([]byte{0x61}, 32))
+	tier2Cfg := config.Default().Tier2
+	tier2Cfg.BehavioralSafetyEnabled = true
+	tier2Cfg.OutputSizeCapBytes = 8
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithTier2Config(tier2Cfg),
+	)
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}],"stream":false}`), nil)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	if bytes.Contains(rr.Body.Bytes(), []byte("truncated")) {
+		t.Fatalf("body was not truncated by PillarD: %s", rr.Body.String())
+	}
+	if got := rr.Header().Get("X-MacProvider-Receipt"); got != "" {
+		t.Fatalf("receipt header = %q, want stripped because PillarD mutated the body the provider signed", got)
+	}
+}
+
 func TestHTTPForwardingStripsV04SettlementReceiptFromBuyerResponse(t *testing.T) {
 	receipt := base64.StdEncoding.EncodeToString([]byte(`{"receipt_version":"4","terminal_state_ts_unix_ms":1782864001789}`)) + "." + base64.StdEncoding.EncodeToString([]byte("signature"))
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3663,11 +3697,17 @@ func TestChatCompletionsWSTunneledTier2RejectsInvalidNonStreamingOutput(t *testi
 	tier2Cfg := config.Default().Tier2
 	tier2Cfg.BehavioralSafetyEnabled = true
 	tier2Cfg.EncodingValidationEnabled = true
+	recoveryIDs := make(chan string, 1)
 	server := buyer.NewServer(
 		registry,
 		zerolog.Nop(),
 		time.Unix(1716768000, 0),
 		buyer.WithTier2Config(tier2Cfg),
+		buyer.WithRecoveryConfig(10*time.Millisecond, 1, true),
+		buyer.WithPreflight(func(provider pool.Provider, requestID string, estimatedTokens int, timeout time.Duration) (buyer.PreflightResult, bool, error) {
+			recoveryIDs <- requestID
+			return buyer.PreflightResult{Accepted: true}, true, nil
+		}),
 		buyer.WithRelay(func(ctx context.Context, provider pool.Provider, requestID string, body []byte, stream bool) (*providerws.RelayStream, error) {
 			chunks := make(chan providerws.InferenceResponseChunk, 1)
 			done := make(chan providerws.InferenceResponseEnd, 1)
@@ -3685,6 +3725,82 @@ func TestChatCompletionsWSTunneledTier2RejectsInvalidNonStreamingOutput(t *testi
 	}
 	if !bytes.Contains(rr.Body.Bytes(), []byte(`"code":"tier2_output_encoding_invalid"`)) {
 		t.Fatalf("body missing tier2 output error: %s", rr.Body.String())
+	}
+	select {
+	case requestID := <-recoveryIDs:
+		if !strings.HasPrefix(requestID, "recovery-probe-") {
+			t.Fatalf("requestID = %q", requestID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("recovery preflight did not run")
+	}
+}
+
+func TestChatCompletionsHTTPNonStreamingAppliesTier2OutputGuard(t *testing.T) {
+	reqLog, dbPath := openBuyerRequestLog(t)
+	defer reqLog.Close()
+	var upstreamCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"http","choices":[{"message":{"content":"bad\u0000"}}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`))
+	}))
+	defer upstream.Close()
+
+	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: upstream.URL}})
+	registerWithEndpoint(registry, "p1", "s1", "model-a", pool.StateReady, 20000, 1, upstream.URL, 20)
+	recoveryIDs := make(chan string, 1)
+	tier2Cfg := config.Default().Tier2
+	tier2Cfg.BehavioralSafetyEnabled = true
+	tier2Cfg.EncodingValidationEnabled = true
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithRequestLog(reqLog),
+		buyer.WithTier2Config(tier2Cfg),
+		buyer.WithRecoveryConfig(10*time.Millisecond, 1, true),
+		buyer.WithPreflight(func(provider pool.Provider, requestID string, estimatedTokens int, timeout time.Duration) (buyer.PreflightResult, bool, error) {
+			recoveryIDs <- requestID
+			return buyer.PreflightResult{Accepted: true}, true, nil
+		}),
+	)
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}]}`), nil)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if !bytes.Contains(rr.Body.Bytes(), []byte(`"code":"tier2_output_encoding_invalid"`)) {
+		t.Fatalf("body missing tier2 output error: %s", rr.Body.String())
+	}
+	if bytes.Contains(rr.Body.Bytes(), []byte(`bad`)) {
+		t.Fatalf("blocked provider output leaked to buyer: %s", rr.Body.String())
+	}
+	if upstreamCalls != 1 {
+		t.Fatalf("upstreamCalls=%d want 1", upstreamCalls)
+	}
+	rows := queryAllRequestLogRows(t, dbPath)
+	if len(rows) != 1 {
+		t.Fatalf("request_log rows=%d want 1: %#v", len(rows), rows)
+	}
+	if rows[0].Status != http.StatusBadGateway {
+		t.Fatalf("logged status=%d want 502", rows[0].Status)
+	}
+	if !rows[0].ErrorCode.Valid || rows[0].ErrorCode.String != "tier2_output_encoding_invalid" {
+		t.Fatalf("logged error_code=%v want tier2_output_encoding_invalid", rows[0].ErrorCode)
+	}
+	if rows[0].PromptTokens.Valid || rows[0].CompletionTokens.Valid {
+		t.Fatalf("blocked response logged billable tokens: prompt=%v completion=%v", rows[0].PromptTokens, rows[0].CompletionTokens)
+	}
+	select {
+	case requestID := <-recoveryIDs:
+		if !strings.HasPrefix(requestID, "recovery-probe-") {
+			t.Fatalf("requestID = %q", requestID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("recovery preflight did not run")
 	}
 }
 

--- a/phase5-gateway/internal/storage/interfaces.go
+++ b/phase5-gateway/internal/storage/interfaces.go
@@ -76,19 +76,22 @@ type UsageStore interface {
 	ListSettlementHeldReservations(ctx context.Context, limit int) ([]ActiveReservation, error)
 	InsertUsageEvent(ctx context.Context, event UsageEvent) error
 	// EnsureUsageEvent inserts a usage_events row idempotently. The
-	// behavior on a request_id PK conflict is the SPEC-006 § 17.7
-	// money-path contract for the failure-mode fallback in
-	// chat_proxy.settleAfterCommit (issue #187):
+	// idempotency key is the composite (account_id, request_id), matching
+	// the usage_events primary key. That is the SPEC-006 § 17.7 money-path
+	// contract for the failure-mode fallback in chat_proxy.settleAfterCommit
+	// (issue #187):
 	//
 	//   - Returns nil on a fresh insert.
-	//   - Returns nil when an existing row at the same request_id
-	//     matches the incoming event in EVERY billing-relevant field
-	//     (account_id, demo_identity, window_date, prompt_tokens,
+	//   - Returns nil when an existing row at the same account_id and
+	//     request_id matches the incoming event in EVERY billing-relevant
+	//     field (demo_identity, window_date, prompt_tokens,
 	//     completion_tokens, total_tokens, token_source, outcome).
-	//   - Returns ErrUsageEventConflict when an existing row at the
-	//     same request_id DIFFERS from the incoming event in any of
-	//     those fields — covers cross-account collisions (#196
-	//     pre-existing) and any same-account payload drift.
+	//   - Returns ErrUsageEventConflict when an existing row at the same
+	//     account_id and request_id DIFFERS from the incoming event in any
+	//     of those fields.
+	//   - Allows the same request_id under a different account_id to be
+	//     stored independently; cross-account ambiguity is handled by
+	//     lookup callers that accept request_id without account_id.
 	//
 	// The caller must treat ErrUsageEventConflict as a failure to
 	// settle (i.e., the audit trail is unrecoverable for THIS event)

--- a/specs/AUDIT_FIX_P2_CLEANUP_ARCHITECT_R1.md
+++ b/specs/AUDIT_FIX_P2_CLEANUP_ARCHITECT_R1.md
@@ -1,0 +1,28 @@
+# Audit Prompt: Fix P2 Cleanup Architect R1
+
+Review branch `fix/deepsec-p2-cleanup` against `origin/main`.
+
+Scope:
+- `phase4-coordinator/internal/buyer/server.go`
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase5-gateway/internal/storage/interfaces.go`
+- `test/network-harness/internal/buyer/loadgen.go`
+- `test/network-harness/internal/scenario/schema.go`
+- `test/network-harness/README.md`
+- `test/network-harness/scenarios/05_mid_stream_drop.yaml`
+- `test/network-harness/scenarios/06_cold_start_race.yaml`
+- `test/network-harness/scenarios/07_sustained_throughput.yaml`
+- `test/network-harness/scenarios/09_streaming_ttft_distribution.yaml`
+
+Architecture review goals:
+- Verify the Tier-2 guard integration reuses existing coordinator concepts instead of introducing a parallel policy path.
+- Verify request-log, billing, and fault-breaker side effects remain consistent with existing provider-error handling.
+- Verify the harness response parser is strict enough to prevent false success metrics but not so strict that it rejects valid supported chat-completion shapes.
+- Verify scenario validation remains centralized in the schema layer.
+- Verify docs changes match the current local/live harness boundary and do not broaden the operational model beyond this cleanup.
+
+Report format:
+- Findings first, ordered by severity.
+- Use `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or `INFO`.
+- Include exact file and line references.
+- End with counts by severity and a clear `ACCEPT` only if there are 0 `CRITICAL`, 0 `HIGH`, and 0 `MEDIUM`.

--- a/specs/AUDIT_FIX_P2_CLEANUP_CODE_R1.md
+++ b/specs/AUDIT_FIX_P2_CLEANUP_CODE_R1.md
@@ -1,0 +1,29 @@
+# Audit Prompt: Fix P2 Cleanup Code R1
+
+Review branch `fix/deepsec-p2-cleanup` against `origin/main`.
+
+Scope:
+- `phase4-coordinator/internal/buyer/server.go`
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase5-gateway/internal/storage/interfaces.go`
+- `test/network-harness/internal/buyer/loadgen.go`
+- `test/network-harness/internal/scenario/schema.go`
+- `test/network-harness/README.md`
+- `test/network-harness/scenarios/05_mid_stream_drop.yaml`
+- `test/network-harness/scenarios/06_cold_start_race.yaml`
+- `test/network-harness/scenarios/07_sustained_throughput.yaml`
+- `test/network-harness/scenarios/09_streaming_ttft_distribution.yaml`
+
+Audit objective:
+- Find correctness bugs, regression risks, missing tests, and behavior mismatches introduced by this cleanup.
+- Verify the coordinator non-streaming HTTP path applies the same Tier-2 non-streaming output encoding guard as the WS-tunneled path and does not leak blocked provider output.
+- Verify IPv4 and IPv6 coordinator bind addresses are formatted with `net.JoinHostPort`.
+- Verify harness invalid 2xx JSON/wrong-shape responses cannot count as success and are visible in metrics.
+- Verify scenario numeric validation rejects values that would be nonsensical or panic at runtime.
+- Verify the docs and scenario YAML edits describe current harness behavior.
+
+Report format:
+- Findings first, ordered by severity.
+- Use `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or `INFO`.
+- Include exact file and line references.
+- End with counts by severity and a clear `ACCEPT` only if there are 0 `CRITICAL`, 0 `HIGH`, and 0 `MEDIUM`.

--- a/specs/AUDIT_FIX_P2_CLEANUP_SECURITY_R1.md
+++ b/specs/AUDIT_FIX_P2_CLEANUP_SECURITY_R1.md
@@ -1,0 +1,28 @@
+# Audit Prompt: Fix P2 Cleanup Security R1
+
+Review branch `fix/deepsec-p2-cleanup` against `origin/main`.
+
+Scope:
+- `phase4-coordinator/internal/buyer/server.go`
+- `phase4-coordinator/cmd/coordinator/main.go`
+- `phase5-gateway/internal/storage/interfaces.go`
+- `test/network-harness/internal/buyer/loadgen.go`
+- `test/network-harness/internal/scenario/schema.go`
+- `test/network-harness/README.md`
+- `test/network-harness/scenarios/05_mid_stream_drop.yaml`
+- `test/network-harness/scenarios/06_cold_start_race.yaml`
+- `test/network-harness/scenarios/07_sustained_throughput.yaml`
+- `test/network-harness/scenarios/09_streaming_ttft_distribution.yaml`
+
+Security invariants:
+- Non-streaming HTTP forwarding is covered by the same output-safety encoding guard as the WS-tunneled non-streaming path.
+- Blocked Tier-2 output is not forwarded to the buyer and is not billed as a successful provider response.
+- Invalid 2xx provider responses cannot be masked as successful harness requests.
+- Scenario numeric config cannot survive validation with values that panic the harness or create unbounded/invalid behavior.
+- Documentation changes do not instruct operators to use obsolete remote SSH controls for local chaos scenarios.
+
+Report format:
+- Findings first, ordered by severity.
+- Use `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or `INFO`.
+- Include exact file and line references.
+- End with counts by severity and a clear `ACCEPT` only if there are 0 `CRITICAL`, 0 `HIGH`, 0 `MEDIUM`, and 0 `LOW`.

--- a/test/network-harness/README.md
+++ b/test/network-harness/README.md
@@ -75,19 +75,22 @@ in phase B.
 ```
 go build -o harness ./cmd/harness
 
-# Required for all scenarios:
-export BUYER_TOKEN="..."         # live buyer bearer (committed YAML uses ${BUYER_TOKEN})
-export PEARL_SSH="root@..."      # ssh target for Pearl VPS (coordinator + gateway SQLite)
-
-# Required for chaos scenarios (05, 06):
-export PROVIDER_SSH="ops@..."    # ssh target of the Mac to chaos-kill
+# Required for buyer-fleet scenarios:
+export BUYER_TOKEN="..."         # committed YAML uses ${BUYER_TOKEN}
 
 ./harness run scenarios/smoke.yaml --out artifacts/smoke-run-1
+
+# Convenience wrapper: builds the binary, resolves scenario mode safely,
+# reads BUYER_TOKEN from .env.harness or ~/.config/macprovider/buyer-api-key,
+# and writes a timestamped artifacts/<scenario>-<utc>/ bundle.
+./run-scenario.sh smoke.yaml
 ```
 
 Scenario YAML supports `${VAR}` expansion at load time. Unset vars expand to empty
 and `Validate()` rejects empty required fields. SSH targets are passed through
-verbatim to `ssh` and `scp` — your `~/.ssh/config` and agent forwarding apply.
+verbatim to `ssh` and `scp` when remote DB reconciliation is configured.
+Committed live scenarios use the `pearl:` SSH alias; configure that in
+`~/.ssh/config` rather than exporting a separate SSH target variable.
 
 Exit codes:
 
@@ -100,13 +103,16 @@ Exit codes:
 
 ## Pointing at different stacks
 
-The harness does **not** spawn coordinator/gateway. Caller is responsible.
+The harness does **not** deploy production services. The buyer fleet runs
+in-process inside the harness binary against the configured
+`target.gateway_url`. Caller is responsible for pointing that URL at a
+live stack or at test binaries booted by `test/integration` helpers.
 
 **Default for phase A is the live network** at `https://api.streamvc.live`
-with the user's own M-series providers attached. All committed scenarios
-target this. **I1 runs against live** by SCP'ing a WAL-consistent SQLite
-snapshot (via `sqlite3 'VACUUM INTO'` over SSH) before reconciliation —
-`target.coordinator_db_ssh` and `target.gateway_db_ssh` configure where.
+with the user's own M-series providers attached. All committed buyer-fleet
+scenarios target this. **I1 runs only when DB sources are configured**:
+local file paths use `target.coordinator_db_path` / `target.gateway_db_path`;
+live runs use `target.coordinator_db_ssh` / `target.gateway_db_ssh`.
 
 Other targets supported by editing `target.gateway_url` / `target.coordinator_url`:
 
@@ -116,7 +122,7 @@ Other targets supported by editing `target.gateway_url` / `target.coordinator_ur
 - **Local stack (synthetic provider)** — via `test/integration` helpers.
   Best for harness self-validation, but won't catch real-model quirks.
 
-## DB snapshot mechanics (live runs)
+## DB snapshot mechanics
 
 When `target.coordinator_db_ssh` / `target.gateway_db_ssh` are set, the
 reconciler runs three SSH operations per DB:
@@ -132,6 +138,10 @@ live writers. The local temp file is deleted after reconciliation. If
 the SSH target requires a non-default key, set it in your `~/.ssh/config`
 under the matching host alias; the harness inherits.
 
+When `target.coordinator_db_path` / `target.gateway_db_path` are set,
+the reconciler opens those local SQLite files directly. This is the
+preferred path for in-process local stacks booted by integration helpers.
+
 ## Chaos events
 
 A scenario can include a `chaos_events` timeline:
@@ -140,10 +150,10 @@ A scenario can include a `chaos_events` timeline:
 chaos_events:
   - at: 5s
     description: "Kill provider mid-stream"
-    command: ssh ${PROVIDER_SSH} pkill -SIGKILL macprovider-cli || true
+    command: launchctl kickstart -k gui/$(id -u)/live.streamvc.macprovider
   - at: 30s
     description: "Restart provider"
-    command: ssh ${PROVIDER_SSH} 'launchctl kickstart -k gui/$(id -u)/live.streamvc.macprovider'
+    command: launchctl kickstart gui/$(id -u)/live.streamvc.macprovider
 ```
 
 Each entry runs via `/bin/sh -c` at the specified offset from scenario
@@ -156,8 +166,8 @@ with what buyers observed.
 Edit the launchd label / pkill pattern in scenarios 05 and 06 to match
 your provider's actual start mechanism before running them. The
 trailing restart events in those scenarios are best-effort — if they
-fail, you may need to SSH into the affected Mac afterward to bring the
-provider back up.
+fail, run the same launchd recovery command locally on the affected Mac
+to bring the provider back up.
 
 ## Cost discipline
 
@@ -176,7 +186,7 @@ After a run, `--out` contains:
 scenario.yaml             # verbatim copy of the input
 run_meta.json             # scenario name, UTC window, git sha
 per_request.jsonl         # one row per request — the raw evidence
-metrics_summary.json      # aggregated histograms + route distribution
+metrics_summary.json      # aggregated histograms, route distribution, invalid-2xx count
 ledger_reconcile.json     # three-way drift report (omitted when skipped)
 invariants.json           # the 4 hard verdicts
 benchmark_summary.json    # B-invariants source data (only when benchmark.enabled)
@@ -244,13 +254,13 @@ triage reads them as a set.
 
 | File | Shape | What it surfaces | Env needed |
 |---|---|---|---|
-| [`scenarios/smoke.yaml`](scenarios/smoke.yaml) | 1 buyer × 3 prompts | Harness pipeline + basic reachability | BUYER_TOKEN, PEARL_SSH |
-| [`scenarios/01_happy_path_concurrent.yaml`](scenarios/01_happy_path_concurrent.yaml) | 5 buyers × 2 requests | Routing distribution under modest concurrency, two-model parity | BUYER_TOKEN, PEARL_SSH |
-| [`scenarios/02_capacity_contention.yaml`](scenarios/02_capacity_contention.yaml) | 10 buyers, burst at t=0 | Capacity-exhaustion behavior (queue / fail-fast / preflight reject) | BUYER_TOKEN, PEARL_SSH |
-| [`scenarios/03_sticky_multi_turn.yaml`](scenarios/03_sticky_multi_turn.yaml) | 3 buyers × 5 sequential | Whether sticky affinity is active in production | BUYER_TOKEN, PEARL_SSH |
-| [`scenarios/04_wrong_model.yaml`](scenarios/04_wrong_model.yaml) | 3 buyers, nonexistent model | Negative-path error code + no-charge guarantee | BUYER_TOKEN, PEARL_SSH |
-| [`scenarios/05_mid_stream_drop.yaml`](scenarios/05_mid_stream_drop.yaml) | 1 streaming buyer + chaos kill at t=5s | Gateway behavior on mid-stream provider loss; billing of partial tokens | BUYER_TOKEN, PEARL_SSH, PROVIDER_SSH |
-| [`scenarios/06_cold_start_race.yaml`](scenarios/06_cold_start_race.yaml) | Restart provider, buyer fires before model loads | Cold-start window: queue / error / reroute / hang | BUYER_TOKEN, PEARL_SSH, PROVIDER_SSH |
+| [`scenarios/smoke.yaml`](scenarios/smoke.yaml) | 1 buyer × 3 prompts | Harness pipeline + basic reachability | BUYER_TOKEN, `pearl` SSH alias |
+| [`scenarios/01_happy_path_concurrent.yaml`](scenarios/01_happy_path_concurrent.yaml) | 5 buyers × 2 requests | Routing distribution under modest concurrency, two-model parity | BUYER_TOKEN, `pearl` SSH alias |
+| [`scenarios/02_capacity_contention.yaml`](scenarios/02_capacity_contention.yaml) | 10 buyers, burst at t=0 | Capacity-exhaustion behavior (queue / fail-fast / preflight reject) | BUYER_TOKEN, `pearl` SSH alias |
+| [`scenarios/03_sticky_multi_turn.yaml`](scenarios/03_sticky_multi_turn.yaml) | 3 buyers × 5 sequential | Whether sticky affinity is active in production | BUYER_TOKEN, `pearl` SSH alias |
+| [`scenarios/04_wrong_model.yaml`](scenarios/04_wrong_model.yaml) | 3 buyers, nonexistent model | Negative-path error code + no-charge guarantee | BUYER_TOKEN, `pearl` SSH alias |
+| [`scenarios/05_mid_stream_drop.yaml`](scenarios/05_mid_stream_drop.yaml) | 1 streaming buyer + local launchd chaos at t=5s | Gateway behavior on mid-stream provider loss; billing of partial tokens | BUYER_TOKEN, `pearl` SSH alias, local launchd label |
+| [`scenarios/06_cold_start_race.yaml`](scenarios/06_cold_start_race.yaml) | Restart provider, buyer waits 2s, then fires before model loads | Cold-start window: queue / error / reroute / hang | BUYER_TOKEN, `pearl` SSH alias, local launchd label |
 
 See [`internal/scenario/schema.go`](internal/scenario/schema.go) for the
 authoritative field reference.
@@ -260,7 +270,9 @@ Key fields:
 - `target.gateway_url` — required
 - `target.buyer_token` OR `target.demo_identity` — required
 - `target.coordinator_db_path` + `target.gateway_db_path` — required for I1
-- `buyers.count`, `buyers.pattern` (`constant` | `interval` | `ramp` | `burst`)
+- `target.coordinator_db_ssh` + `target.gateway_db_ssh` — remote snapshot alternative for I1
+- `buyers.count`, `buyers.pattern` (`constant` | `interval` | `ramp` | `burst` | `cold_warm_pairs`)
+- `buyers.initial_delay` — optional fleet-wide delay before first request
 - `prompts[]` — rotated round-robin across the buyer fleet
 - `expected_shape` — free-text "what we're looking to learn" (phase A: recorded only)
 

--- a/test/network-harness/internal/buyer/loadgen.go
+++ b/test/network-harness/internal/buyer/loadgen.go
@@ -27,6 +27,18 @@ func Run(ctx context.Context, sc *scenario.Scenario) ([]Result, error) {
 	if sc.Buyers.Count < 1 {
 		return nil, fmt.Errorf("buyers.count must be >= 1")
 	}
+	if sc.Buyers.Count > scenario.MaxBuyerCount {
+		return nil, fmt.Errorf("buyers.count must be <= %d", scenario.MaxBuyerCount)
+	}
+	if sc.Buyers.RequestsPerBuyer < 1 {
+		return nil, fmt.Errorf("buyers.requests_per_buyer must be >= 1")
+	}
+	if sc.Buyers.RequestsPerBuyer > scenario.MaxRequestsPerBuyer {
+		return nil, fmt.Errorf("buyers.requests_per_buyer must be <= %d", scenario.MaxRequestsPerBuyer)
+	}
+	if sc.Buyers.Count > scenario.MaxTotalBuyerRequests/sc.Buyers.RequestsPerBuyer {
+		return nil, fmt.Errorf("buyers.count * buyers.requests_per_buyer must be <= %d", scenario.MaxTotalBuyerRequests)
+	}
 
 	deadline := time.Time{}
 	if sc.Duration > 0 {
@@ -53,9 +65,9 @@ func Run(ctx context.Context, sc *scenario.Scenario) ([]Result, error) {
 		buyerIdx := i
 
 		// Ramp pattern: stagger goroutine starts across RampDuration.
-		startAfter := time.Duration(0)
+		startAfter := sc.Buyers.InitialDelay
 		if sc.Buyers.Pattern == "ramp" && sc.Buyers.Count > 1 {
-			startAfter = sc.Buyers.RampDuration * time.Duration(buyerIdx) / time.Duration(sc.Buyers.Count-1)
+			startAfter += sc.Buyers.RampDuration * time.Duration(buyerIdx) / time.Duration(sc.Buyers.Count-1)
 		}
 
 		wg.Add(1)
@@ -63,9 +75,8 @@ func Run(ctx context.Context, sc *scenario.Scenario) ([]Result, error) {
 			defer wg.Done()
 
 			if startAfter > 0 {
-				select {
-				case <-time.After(startAfter):
-				case <-ctx.Done():
+				ok, interrupted := waitForDispatchDelay(ctx, startAfter, deadline)
+				if interrupted || !ok {
 					return
 				}
 			}
@@ -89,9 +100,8 @@ func Run(ctx context.Context, sc *scenario.Scenario) ([]Result, error) {
 				// cold (reqIdx=0) fires without a leading idle since the
 				// provider is in its natural state when the scenario starts.
 				if sc.Buyers.Pattern == "cold_warm_pairs" && reqIdx > 0 && reqIdx%2 == 0 {
-					select {
-					case <-time.After(time.Duration(sc.Buyers.InterPairIdleSeconds) * time.Second):
-					case <-ctx.Done():
+					ok, interrupted := waitForDispatchDelay(ctx, time.Duration(sc.Buyers.InterPairIdleSeconds)*time.Second, deadline)
+					if interrupted || !ok {
 						return
 					}
 				}
@@ -114,9 +124,8 @@ func Run(ctx context.Context, sc *scenario.Scenario) ([]Result, error) {
 					return
 				}
 				if sc.Buyers.Pattern == "interval" && sc.Buyers.IntervalMs > 0 {
-					select {
-					case <-time.After(time.Duration(sc.Buyers.IntervalMs) * time.Millisecond):
-					case <-ctx.Done():
+					ok, interrupted := waitForDispatchDelay(ctx, time.Duration(sc.Buyers.IntervalMs)*time.Millisecond, deadline)
+					if interrupted || !ok {
 						return
 					}
 				}
@@ -126,6 +135,32 @@ func Run(ctx context.Context, sc *scenario.Scenario) ([]Result, error) {
 
 	wg.Wait()
 	return results, nil
+}
+
+func waitForDispatchDelay(ctx context.Context, delay time.Duration, deadline time.Time) (ok bool, interrupted bool) {
+	if delay <= 0 {
+		return true, false
+	}
+	waitUntil := time.Now().Add(delay)
+	if !deadline.IsZero() && waitUntil.After(deadline) {
+		waitUntil = deadline
+	}
+	wait := time.Until(waitUntil)
+	if wait <= 0 {
+		return !deadlineExpired(deadline), false
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return deadlineExpired(deadline) == false, false
+	case <-ctx.Done():
+		return false, true
+	}
+}
+
+func deadlineExpired(deadline time.Time) bool {
+	return !deadline.IsZero() && !time.Now().Before(deadline)
 }
 
 func fireOnce(ctx context.Context, client *http.Client, sc *scenario.Scenario, p scenario.Prompt, buyerIdx, reqIdx int) Result {
@@ -602,14 +637,147 @@ func consumeJSON(body io.Reader, res *Result) {
 		res.ErrorMsg = err.Error()
 		return
 	}
-	var c chunkPayload
-	if err := json.Unmarshal(b, &c); err == nil {
+	c, err := parseNonStreamingChatCompletion(b)
+	if err != nil {
+		if res.HTTPStatus >= 200 && res.HTTPStatus < 300 {
+			res.Outcome = "invalid_response"
+			res.ErrorCode = "invalid_response"
+			res.ErrorMsg = err.Error()
+		}
+		return
+	}
+	if c.Usage != nil {
 		if c.Usage.CompletionTokens > 0 {
 			res.CompletionTokensReceived = c.Usage.CompletionTokens
 		}
 		if c.Usage.PromptTokens > 0 {
 			res.PromptTokensReported = c.Usage.PromptTokens
 		}
-		res.SawTerminator = true
 	}
+	res.SawTerminator = true
+}
+
+type nonStreamingChatCompletion struct {
+	Choices []struct {
+		Text    *string `json:"text"`
+		Message *struct {
+			Content      *string         `json:"content"`
+			Role         *string         `json:"role"`
+			Refusal      *string         `json:"refusal"`
+			Reasoning    *string         `json:"reasoning"`
+			ToolCalls    json.RawMessage `json:"tool_calls"`
+			FunctionCall json.RawMessage `json:"function_call"`
+		} `json:"message"`
+	} `json:"choices"`
+	Usage *struct {
+		PromptTokens     int64 `json:"prompt_tokens"`
+		CompletionTokens int64 `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+func parseNonStreamingChatCompletion(body []byte) (nonStreamingChatCompletion, error) {
+	var c nonStreamingChatCompletion
+	if err := json.Unmarshal(body, &c); err != nil {
+		return c, fmt.Errorf("invalid JSON response: %w", err)
+	}
+	if len(c.Choices) == 0 {
+		return c, fmt.Errorf("missing choices")
+	}
+	for i, choice := range c.Choices {
+		if nonEmptyString(choice.Text) {
+			continue
+		}
+		if choice.Message == nil {
+			return c, fmt.Errorf("choices[%d].message is required", i)
+		}
+		if len(choice.Message.ToolCalls) > 0 {
+			if ok, err := validToolCalls(choice.Message.ToolCalls); err != nil {
+				return c, fmt.Errorf("choices[%d].message.tool_calls: %w", i, err)
+			} else if ok {
+				continue
+			}
+		}
+		if len(choice.Message.FunctionCall) > 0 {
+			if ok, err := validFunctionCall(choice.Message.FunctionCall); err != nil {
+				return c, fmt.Errorf("choices[%d].message.function_call: %w", i, err)
+			} else if ok {
+				continue
+			}
+		}
+		if nonEmptyString(choice.Message.Content) ||
+			nonEmptyString(choice.Message.Refusal) ||
+			nonEmptyString(choice.Message.Reasoning) {
+			continue
+		}
+		return c, fmt.Errorf("choices[%d].message has no OpenAI-compatible signal", i)
+	}
+	return c, nil
+}
+
+func nonEmptyString(v *string) bool {
+	return v != nil && *v != ""
+}
+
+func validToolCalls(raw json.RawMessage) (bool, error) {
+	if len(raw) == 0 {
+		return false, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return false, fmt.Errorf("must not be null")
+	}
+	var calls []struct {
+		ID       string `json:"id"`
+		Type     string `json:"type"`
+		Function *struct {
+			Name      string  `json:"name"`
+			Arguments *string `json:"arguments"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(raw, &calls); err != nil {
+		return false, fmt.Errorf("must be an array: %w", err)
+	}
+	if len(calls) == 0 {
+		return false, fmt.Errorf("must not be empty")
+	}
+	for i, call := range calls {
+		if call.ID == "" {
+			return false, fmt.Errorf("[%d].id is required", i)
+		}
+		if call.Type != "function" {
+			return false, fmt.Errorf("[%d].type must be function", i)
+		}
+		if call.Function == nil {
+			return false, fmt.Errorf("[%d].function is required", i)
+		}
+		if call.Function.Name == "" {
+			return false, fmt.Errorf("[%d].function.name is required", i)
+		}
+		if call.Function.Arguments == nil {
+			return false, fmt.Errorf("[%d].function.arguments is required", i)
+		}
+	}
+	return true, nil
+}
+
+func validFunctionCall(raw json.RawMessage) (bool, error) {
+	if len(raw) == 0 {
+		return false, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return false, fmt.Errorf("must not be null")
+	}
+	var call struct {
+		Name      string  `json:"name"`
+		Arguments *string `json:"arguments"`
+	}
+	if err := json.Unmarshal(raw, &call); err != nil {
+		return false, fmt.Errorf("must be an object: %w", err)
+	}
+	if call.Name == "" {
+		return false, fmt.Errorf("name is required")
+	}
+	if call.Arguments == nil {
+		return false, fmt.Errorf("arguments is required")
+	}
+	return true, nil
 }

--- a/test/network-harness/internal/buyer/loadgen_invalid_response_test.go
+++ b/test/network-harness/internal/buyer/loadgen_invalid_response_test.go
@@ -1,0 +1,225 @@
+package buyer
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-network-harness/internal/scenario"
+)
+
+func TestFireOnceInvalid2xxMalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[`)
+	}))
+	defer srv.Close()
+
+	res := fireOnce(context.Background(), http.DefaultClient, validLoadgenScenario(srv.URL), scenario.Prompt{Model: "m", User: "hi"}, 0, 0)
+	if res.Outcome != "invalid_response" {
+		t.Fatalf("Outcome=%q want invalid_response: %+v", res.Outcome, res)
+	}
+	if res.ErrorCode != "invalid_response" {
+		t.Fatalf("ErrorCode=%q want invalid_response", res.ErrorCode)
+	}
+}
+
+func TestFireOnceInvalid2xxWrongShapeJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer srv.Close()
+
+	res := fireOnce(context.Background(), http.DefaultClient, validLoadgenScenario(srv.URL), scenario.Prompt{Model: "m", User: "hi"}, 0, 0)
+	if res.Outcome != "invalid_response" {
+		t.Fatalf("Outcome=%q want invalid_response: %+v", res.Outcome, res)
+	}
+	if res.SawTerminator {
+		t.Fatalf("wrong-shape JSON must not set SawTerminator")
+	}
+}
+
+func TestFireOnceInvalid2xxRejectsNullToolCalls(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"tool_calls":null}}]}`)
+	}))
+	defer srv.Close()
+
+	res := fireOnce(context.Background(), http.DefaultClient, validLoadgenScenario(srv.URL), scenario.Prompt{Model: "m", User: "hi"}, 0, 0)
+	if res.Outcome != "invalid_response" {
+		t.Fatalf("Outcome=%q want invalid_response: %+v", res.Outcome, res)
+	}
+}
+
+func TestFireOnceInvalid2xxRejectsEmptyToolCalls(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"tool_calls":[]}}]}`)
+	}))
+	defer srv.Close()
+
+	res := fireOnce(context.Background(), http.DefaultClient, validLoadgenScenario(srv.URL), scenario.Prompt{Model: "m", User: "hi"}, 0, 0)
+	if res.Outcome != "invalid_response" {
+		t.Fatalf("Outcome=%q want invalid_response: %+v", res.Outcome, res)
+	}
+}
+
+func TestFireOnceInvalid2xxRejectsMixedInvalidChoice(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok"}},{"message":{"tool_calls":[]}}]}`)
+	}))
+	defer srv.Close()
+
+	res := fireOnce(context.Background(), http.DefaultClient, validLoadgenScenario(srv.URL), scenario.Prompt{Model: "m", User: "hi"}, 0, 0)
+	if res.Outcome != "invalid_response" {
+		t.Fatalf("Outcome=%q want invalid_response: %+v", res.Outcome, res)
+	}
+}
+
+func TestFireOnceInvalid2xxRejectsMalformedToolCallsWithContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok","tool_calls":[]}}]}`)
+	}))
+	defer srv.Close()
+
+	res := fireOnce(context.Background(), http.DefaultClient, validLoadgenScenario(srv.URL), scenario.Prompt{Model: "m", User: "hi"}, 0, 0)
+	if res.Outcome != "invalid_response" {
+		t.Fatalf("Outcome=%q want invalid_response: %+v", res.Outcome, res)
+	}
+}
+
+func TestFireOnceAcceptsToolCallResponseShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{}"}}]}}]}`)
+	}))
+	defer srv.Close()
+
+	res := fireOnce(context.Background(), http.DefaultClient, validLoadgenScenario(srv.URL), scenario.Prompt{Model: "m", User: "hi"}, 0, 0)
+	if res.Outcome != "ok" {
+		t.Fatalf("Outcome=%q want ok: %+v", res.Outcome, res)
+	}
+	if !res.SawTerminator {
+		t.Fatalf("valid tool-call response should set SawTerminator")
+	}
+}
+
+func TestFireOnceAcceptsOpenAISignalResponseShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"refusal", `{"choices":[{"message":{"refusal":"cannot comply"}}]}`},
+		{"reasoning", `{"choices":[{"message":{"reasoning":"thinking"}}]}`},
+		{"function_call", `{"choices":[{"message":{"function_call":{"name":"lookup","arguments":"{}"}}}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer srv.Close()
+
+			res := fireOnce(context.Background(), http.DefaultClient, validLoadgenScenario(srv.URL), scenario.Prompt{Model: "m", User: "hi"}, 0, 0)
+			if res.Outcome != "ok" {
+				t.Fatalf("Outcome=%q want ok: %+v", res.Outcome, res)
+			}
+		})
+	}
+}
+
+func TestFireOnceInvalid2xxRejectsRoleOnlyMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"role":"assistant"}}]}`)
+	}))
+	defer srv.Close()
+
+	res := fireOnce(context.Background(), http.DefaultClient, validLoadgenScenario(srv.URL), scenario.Prompt{Model: "m", User: "hi"}, 0, 0)
+	if res.Outcome != "invalid_response" {
+		t.Fatalf("Outcome=%q want invalid_response: %+v", res.Outcome, res)
+	}
+}
+
+func TestFireOnceInvalid2xxRejectsEmptyStringSignals(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"","role":"","refusal":"","reasoning":""}}]}`)
+	}))
+	defer srv.Close()
+
+	res := fireOnce(context.Background(), http.DefaultClient, validLoadgenScenario(srv.URL), scenario.Prompt{Model: "m", User: "hi"}, 0, 0)
+	if res.Outcome != "invalid_response" {
+		t.Fatalf("Outcome=%q want invalid_response: %+v", res.Outcome, res)
+	}
+}
+
+func TestRunContextCancelStopsInitialDelay(t *testing.T) {
+	sc := validLoadgenScenario("http://127.0.0.1")
+	sc.Buyers.InitialDelay = time.Hour
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	results, err := Run(ctx, sc)
+	if err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("results len=%d want 0", len(results))
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("Run ignored context during initial delay; elapsed=%s", elapsed)
+	}
+}
+
+func TestRunDurationStopsInitialDelayWithoutParentCancel(t *testing.T) {
+	sc := validLoadgenScenario("http://127.0.0.1")
+	sc.Buyers.InitialDelay = time.Hour
+	sc.Duration = 10 * time.Millisecond
+
+	started := time.Now()
+	results, err := Run(context.Background(), sc)
+	if err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("results len=%d want 0", len(results))
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("Run ignored duration during initial delay; elapsed=%s", elapsed)
+	}
+}
+
+func validLoadgenScenario(url string) *scenario.Scenario {
+	return &scenario.Scenario{
+		Target: scenario.Target{
+			GatewayURL: url,
+			BuyerToken: "test-token",
+		},
+		Buyers: scenario.Buyers{
+			Count:            1,
+			RequestsPerBuyer: 1,
+		},
+		RequestTimeout:      5 * time.Second,
+		SilentHangThreshold: 30 * time.Second,
+	}
+}

--- a/test/network-harness/internal/buyer/result.go
+++ b/test/network-harness/internal/buyer/result.go
@@ -32,7 +32,7 @@ type Result struct {
 
 	// HTTP outcome.
 	HTTPStatus int    `json:"http_status"`
-	Outcome    string `json:"outcome"` // ok | http_error | transport_error | timeout | silent_hang | client_abort
+	Outcome    string `json:"outcome"` // ok | http_error | transport_error | timeout | silent_hang | client_abort | invalid_response
 
 	// Error detail (empty on Outcome=ok).
 	ErrorCode string `json:"error_code,omitempty"`

--- a/test/network-harness/internal/metrics/collector.go
+++ b/test/network-harness/internal/metrics/collector.go
@@ -20,11 +20,12 @@ type Summary struct {
 	TransportErrs int `json:"transport_errors"`
 	ClientAborts  int `json:"client_aborts"`
 	SilentHangs   int `json:"silent_hangs"`
+	Invalid2xx    int `json:"harness_invalid_2xx_total"`
 
 	SuccessRate float64 `json:"success_rate"`
 
-	TTFTMillis  Histogram `json:"ttft_ms"`
-	TotalMillis Histogram `json:"total_ms"`
+	TTFTMillis   Histogram `json:"ttft_ms"`
+	TotalMillis  Histogram `json:"total_ms"`
 	TokensPerSec Histogram `json:"tokens_per_sec"`
 
 	// RouteDistribution: provider_id -> request count. Empty when the
@@ -74,6 +75,8 @@ func Aggregate(results []buyer.Result) *Summary {
 			s.ClientAborts++
 		case "silent_hang":
 			s.SilentHangs++
+		case "invalid_response":
+			s.Invalid2xx++
 		}
 		if r.HTTPStatus > 0 {
 			s.HTTPStatusCounts[r.HTTPStatus]++

--- a/test/network-harness/internal/metrics/collector_test.go
+++ b/test/network-harness/internal/metrics/collector_test.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/augstar/macprovider-network-harness/internal/buyer"
+)
+
+func TestAggregateCountsInvalid2xx(t *testing.T) {
+	summary := Aggregate([]buyer.Result{{Outcome: "invalid_response", ErrorCode: "invalid_response", HTTPStatus: 200}})
+	if summary.SuccessCount != 0 {
+		t.Fatalf("SuccessCount=%d want 0", summary.SuccessCount)
+	}
+	if summary.Invalid2xx != 1 {
+		t.Fatalf("Invalid2xx=%d want 1", summary.Invalid2xx)
+	}
+	if summary.ErrorTaxonomy["invalid_response"] != 1 {
+		t.Fatalf("invalid_response taxonomy=%d want 1", summary.ErrorTaxonomy["invalid_response"])
+	}
+}

--- a/test/network-harness/internal/scenario/schema.go
+++ b/test/network-harness/internal/scenario/schema.go
@@ -32,7 +32,12 @@ const SKUEconCoordinatorHost = "coordinator.streamvc.live"
 // any required field that's empty.
 var envVarPattern = regexp.MustCompile(`\$\{([A-Z_][A-Z0-9_]*)\}`)
 
-const maxChargedDeliveredToleranceTokens int64 = 16
+const (
+	maxChargedDeliveredToleranceTokens int64 = 16
+	MaxBuyerCount                            = 1000
+	MaxRequestsPerBuyer                      = 10000
+	MaxTotalBuyerRequests                    = 100000
+)
 
 func expandEnv(input []byte) []byte {
 	return envVarPattern.ReplaceAllFunc(input, func(match []byte) []byte {
@@ -85,6 +90,8 @@ type Scenario struct {
 	Invariants         []string            `yaml:"invariants"`
 	BenchmarkSynthesis BenchmarkSynthesis  `yaml:"benchmark_synthesis"`
 	Artifacts          []string            `yaml:"artifacts"`
+
+	buyersRequestsPerBuyerSet bool
 }
 
 // Benchmark declares which B-invariants this scenario should evaluate
@@ -189,6 +196,7 @@ type Buyers struct {
 	//                         "cold" request, then immediately fires one "warm"
 	//                         request. RequestsPerBuyer MUST be even (= 2 × pairs).
 	Pattern          string        `yaml:"pattern"`
+	InitialDelay     time.Duration `yaml:"initial_delay"`
 	IntervalMs       int           `yaml:"interval_ms"`
 	RampDuration     time.Duration `yaml:"ramp_duration"`
 	RequestsPerBuyer int           `yaml:"requests_per_buyer"`
@@ -294,6 +302,7 @@ func load(path string, expand bool) (*Scenario, error) {
 	if err := yaml.Unmarshal(b, &sc); err != nil {
 		return nil, fmt.Errorf("yaml: %w", err)
 	}
+	sc.buyersRequestsPerBuyerSet = yamlMapPathHasKey(b, "buyers", "requests_per_buyer")
 	if !expand && sc.Mode == "sku-econ" && envVarPattern.Match(b) {
 		return nil, fmt.Errorf("sku-econ scenarios must not contain ${VAR} placeholders")
 	}
@@ -314,7 +323,7 @@ func (s *Scenario) applyDefaults() {
 	if s.Buyers.Pattern == "" {
 		s.Buyers.Pattern = "constant"
 	}
-	if s.Buyers.RequestsPerBuyer == 0 {
+	if s.Buyers.RequestsPerBuyer == 0 && !s.buyersRequestsPerBuyerSet {
 		s.Buyers.RequestsPerBuyer = 1
 	}
 	if s.Benchmark.Enabled && s.Benchmark.ProviderSlots == 0 {
@@ -331,6 +340,31 @@ func (s *Scenario) applyDefaults() {
 			s.BenchmarkSynthesis.TTFTFractionOfCeiling = 0.85
 		}
 	}
+}
+
+func yamlMapPathHasKey(b []byte, path ...string) bool {
+	var root yaml.Node
+	if err := yaml.Unmarshal(b, &root); err != nil || len(root.Content) == 0 {
+		return false
+	}
+	node := root.Content[0]
+	for _, key := range path {
+		if node.Kind != yaml.MappingNode {
+			return false
+		}
+		var next *yaml.Node
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == key {
+				next = node.Content[i+1]
+				break
+			}
+		}
+		if next == nil {
+			return false
+		}
+		node = next
+	}
+	return true
 }
 
 // Validate returns a non-nil error if the scenario is missing required
@@ -379,6 +413,15 @@ func (s *Scenario) validateBuyerFleet() error {
 	if s.Target.GatewayDBSSH != "" && s.Target.GatewayDBPath != "" {
 		return fmt.Errorf("target.gateway_db_ssh and target.gateway_db_path are mutually exclusive")
 	}
+	if s.RequestTimeout < 0 {
+		return fmt.Errorf("request_timeout must be >= 0")
+	}
+	if s.SilentHangThreshold < 0 {
+		return fmt.Errorf("silent_hang_threshold must be >= 0")
+	}
+	if s.Duration < 0 {
+		return fmt.Errorf("duration must be >= 0")
+	}
 	for i, c := range s.ChaosEvents {
 		if c.Command == "" {
 			return fmt.Errorf("chaos_events[%d].command is required", i)
@@ -390,6 +433,27 @@ func (s *Scenario) validateBuyerFleet() error {
 	if s.Buyers.Count < 1 {
 		return fmt.Errorf("buyers.count must be >= 1")
 	}
+	if s.Buyers.Count > MaxBuyerCount {
+		return fmt.Errorf("buyers.count must be <= %d", MaxBuyerCount)
+	}
+	if s.Buyers.RequestsPerBuyer < 1 {
+		return fmt.Errorf("scenario %s: requests_per_buyer must be >= 1, got %d", s.Name, s.Buyers.RequestsPerBuyer)
+	}
+	if s.Buyers.RequestsPerBuyer > MaxRequestsPerBuyer {
+		return fmt.Errorf("buyers.requests_per_buyer must be <= %d", MaxRequestsPerBuyer)
+	}
+	if s.Buyers.Count > MaxTotalBuyerRequests/s.Buyers.RequestsPerBuyer {
+		return fmt.Errorf("buyers.count * buyers.requests_per_buyer must be <= %d", MaxTotalBuyerRequests)
+	}
+	if s.Buyers.InitialDelay < 0 {
+		return fmt.Errorf("buyers.initial_delay must be >= 0")
+	}
+	if s.Buyers.IntervalMs < 0 {
+		return fmt.Errorf("buyers.interval_ms must be >= 0")
+	}
+	if s.Buyers.InterPairIdleSeconds < 0 {
+		return fmt.Errorf("buyers.inter_pair_idle_seconds must be >= 0")
+	}
 	if len(s.Prompts) == 0 {
 		return fmt.Errorf("at least one prompt is required")
 	}
@@ -399,6 +463,9 @@ func (s *Scenario) validateBuyerFleet() error {
 		}
 		if p.User == "" {
 			return fmt.Errorf("prompts[%d].user is required", i)
+		}
+		if p.MaxTokens < 0 {
+			return fmt.Errorf("prompts[%d].max_tokens must be >= 0", i)
 		}
 	}
 	switch s.Buyers.Pattern {
@@ -420,7 +487,7 @@ func (s *Scenario) validateBuyerFleet() error {
 			return fmt.Errorf("buyers.requests_per_buyer must be an even number ≥ 2 when pattern=cold_warm_pairs (got %d)", s.Buyers.RequestsPerBuyer)
 		}
 	}
-	if s.Duration <= 0 && s.Buyers.Pattern != "burst" {
+	if s.Duration == 0 && s.Buyers.Pattern != "burst" {
 		return fmt.Errorf("duration must be > 0 unless pattern=burst")
 	}
 	if s.Benchmark.Enabled {

--- a/test/network-harness/internal/scenario/schema_test.go
+++ b/test/network-harness/internal/scenario/schema_test.go
@@ -26,6 +26,182 @@ func TestValidateChargedDeliveredToleranceBounds(t *testing.T) {
 	}
 }
 
+func TestValidateRequestsPerBuyerBounds(t *testing.T) {
+	for _, value := range []int{-1, 0} {
+		sc := validTestScenario()
+		sc.Buyers.RequestsPerBuyer = value
+		err := sc.Validate()
+		if err == nil || !strings.Contains(err.Error(), "scenario test: requests_per_buyer must be >= 1, got") {
+			t.Fatalf("requests_per_buyer=%d err=%v, want >= 1 validation", value, err)
+		}
+	}
+
+	sc := validTestScenario()
+	sc.Buyers.RequestsPerBuyer = 1
+	if err := sc.Validate(); err != nil {
+		t.Fatalf("requests_per_buyer=1 should validate: %v", err)
+	}
+}
+
+func TestLoadRejectsExplicitZeroRequestsPerBuyer(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "zero.yaml")
+	yaml := `
+name: buyer
+target:
+  gateway_url: http://gateway.test
+  buyer_token: token
+buyers:
+  count: 1
+  requests_per_buyer: 0
+prompts:
+  - {model: m, user: hi}
+duration: 1s
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	sc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load err=%v", err)
+	}
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "requests_per_buyer must be >= 1") {
+		t.Fatalf("Validate err=%v, want requests_per_buyer rejection", err)
+	}
+}
+
+func TestLoadDefaultsOmittedRequestsPerBuyer(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "omitted.yaml")
+	yaml := `
+name: buyer
+target:
+  gateway_url: http://gateway.test
+  buyer_token: token
+buyers:
+  count: 1
+prompts:
+  - {model: m, user: hi}
+duration: 1s
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	sc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load err=%v", err)
+	}
+	if sc.Buyers.RequestsPerBuyer != 1 {
+		t.Fatalf("requests_per_buyer=%d want default 1", sc.Buyers.RequestsPerBuyer)
+	}
+	if err := sc.Validate(); err != nil {
+		t.Fatalf("Validate err=%v", err)
+	}
+}
+
+func TestValidateBuyerFleetUpperBounds(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Scenario)
+		wantIn string
+	}{
+		{"buyers.count", func(s *Scenario) { s.Buyers.Count = MaxBuyerCount + 1 }, "buyers.count must be <="},
+		{"buyers.requests_per_buyer", func(s *Scenario) { s.Buyers.RequestsPerBuyer = MaxRequestsPerBuyer + 1 }, "buyers.requests_per_buyer must be <="},
+		{"total requests", func(s *Scenario) {
+			s.Buyers.Count = MaxBuyerCount
+			s.Buyers.RequestsPerBuyer = MaxRequestsPerBuyer
+		}, "buyers.count * buyers.requests_per_buyer must be <="},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := validTestScenario()
+			tc.mutate(&sc)
+			err := sc.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.wantIn) {
+				t.Fatalf("err=%v want substring %q", err, tc.wantIn)
+			}
+		})
+	}
+
+	sc := validTestScenario()
+	sc.Buyers.Count = MaxBuyerCount
+	sc.Buyers.RequestsPerBuyer = MaxTotalBuyerRequests / MaxBuyerCount
+	if err := sc.Validate(); err != nil {
+		t.Fatalf("max bounded scenario should validate: %v", err)
+	}
+}
+
+func TestValidateRejectsInvalidTimingFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Scenario)
+		wantIn string
+	}{
+		{"request_timeout negative", func(s *Scenario) { s.RequestTimeout = -time.Second }, "request_timeout must be >= 0"},
+		{"silent_hang_threshold negative", func(s *Scenario) { s.SilentHangThreshold = -time.Second }, "silent_hang_threshold must be >= 0"},
+		{"duration negative", func(s *Scenario) { s.Duration = -time.Second }, "duration must be >= 0"},
+		{"burst duration negative", func(s *Scenario) {
+			s.Buyers.Pattern = "burst"
+			s.Duration = -time.Second
+		}, "duration must be >= 0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := validTestScenario()
+			tc.mutate(&sc)
+			err := sc.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.wantIn) {
+				t.Fatalf("err=%v want substring %q", err, tc.wantIn)
+			}
+		})
+	}
+}
+
+func TestValidateAllowsDefaultTimingFields(t *testing.T) {
+	sc := validTestScenario()
+	sc.RequestTimeout = 0
+	sc.SilentHangThreshold = 0
+	if err := sc.Validate(); err != nil {
+		t.Fatalf("zero timing fields should validate as defaults: %v", err)
+	}
+}
+
+func TestValidateRejectsNegativeNumericFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Scenario)
+		wantIn string
+	}{
+		{"buyers.count", func(s *Scenario) { s.Buyers.Count = -1 }, "buyers.count must be >= 1"},
+		{"buyers.requests_per_buyer", func(s *Scenario) { s.Buyers.RequestsPerBuyer = -1 }, "requests_per_buyer must be >= 1"},
+		{"buyers.initial_delay", func(s *Scenario) { s.Buyers.InitialDelay = -time.Second }, "buyers.initial_delay must be >= 0"},
+		{"buyers.interval_ms", func(s *Scenario) { s.Buyers.IntervalMs = -1 }, "buyers.interval_ms must be >= 0"},
+		{"buyers.inter_pair_idle_seconds", func(s *Scenario) { s.Buyers.InterPairIdleSeconds = -1 }, "buyers.inter_pair_idle_seconds must be >= 0"},
+		{"prompts.max_tokens", func(s *Scenario) { s.Prompts[0].MaxTokens = -1 }, "prompts[0].max_tokens must be >= 0"},
+		{"charged_delivered_tolerance_tokens", func(s *Scenario) { s.ChargedDeliveredToleranceTokens = -1 }, "charged_delivered_tolerance_tokens must be >= 0"},
+		{"benchmark.provider_slots", func(s *Scenario) {
+			s.Benchmark.Enabled = true
+			s.Benchmark.Invariants = []string{"B1"}
+			s.Benchmark.ProviderSlots = -1
+		}, "benchmark.provider_slots must be >= 1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := validTestScenario()
+			tc.mutate(&sc)
+			err := sc.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.wantIn) {
+				t.Fatalf("err=%v want substring %q", err, tc.wantIn)
+			}
+		})
+	}
+}
+
 func TestValidateSKUEconPinsCoordinatorURL(t *testing.T) {
 	tpl := Scenario{
 		Name: "sku",
@@ -214,8 +390,10 @@ duration: 1s
 
 func validTestScenario() Scenario {
 	return Scenario{
-		Name:     "test",
-		Duration: time.Second,
+		Name:                "test",
+		Duration:            time.Second,
+		RequestTimeout:      time.Second,
+		SilentHangThreshold: time.Second,
 		Target: Target{
 			GatewayURL:     "http://gateway.test",
 			BuyerToken:     "token",

--- a/test/network-harness/scenarios/05_mid_stream_drop.yaml
+++ b/test/network-harness/scenarios/05_mid_stream_drop.yaml
@@ -8,8 +8,9 @@
 #
 # What we want to learn (phase A, descriptive — recorded only):
 #  - Per chat_proxy.go:495, gateway DOES NOT failover mid-stream.
-#    Expectation: buyer sees `stream_truncated` SSE error event, billing
-#    settles for tokens already delivered, no reroute.
+#    Expectation: buyer sees a terminal SSE error envelope
+#    (stream_truncated) before the final [DONE] frame, billing settles
+#    for tokens already delivered, no reroute.
 #  - Does I4 (silent hang) fire? It SHOULD NOT — there should be a
 #    terminating error.
 #  - Does I1 reconcile show partial token count consistently across
@@ -33,8 +34,8 @@ expected_shape: |
   Phase A note (descriptive, not asserted):
    - Buyer should see Outcome != "ok" with SHORT completion_tokens_received > 0.
    - SawTerminator may be true (stream_truncated marker) or false.
-   - I4 (silent hang) should NOT fire — gateway should write an error event
-     before connection close.
+   - I4 (silent hang) should NOT fire — gateway should write a terminal
+     SSE error envelope before the final [DONE] frame.
    - I1 should show partial token agreement: coord.completion ==
      gw.completion == bytes-derived count.
    - PHASE B TRIAGE: confirm or refute "no mid-stream reroute" as contract.

--- a/test/network-harness/scenarios/06_cold_start_race.yaml
+++ b/test/network-harness/scenarios/06_cold_start_race.yaml
@@ -44,6 +44,7 @@ buyers:
   count: 1
   stream: false
   pattern: constant
+  initial_delay: 2s
   requests_per_buyer: 1
 
 duration: 120s
@@ -59,6 +60,6 @@ chaos_events:
   - at: 0s
     description: "Kill local provider to force a cold start"
     command: launchctl kickstart -k gui/$(id -u)/live.streamvc.macprovider
-  # Buyer fleet fires at t=0 (constant pattern, no ramp). The single
-  # buyer request happens before the 32B model has reloaded. The 90s
-  # request_timeout / 120s duration give the cold start ~110s of room.
+  # Buyer fleet waits initial_delay=2s, then fires while the 32B model
+  # is still expected to be reloading. The 90s request_timeout / 120s
+  # duration give the cold start ~110s of room.

--- a/test/network-harness/scenarios/07_sustained_throughput.yaml
+++ b/test/network-harness/scenarios/07_sustained_throughput.yaml
@@ -11,15 +11,20 @@
 #   The 2026-06-28 retune used wall_p50 → interval=5000ms → mean_active
 #   at p95 spiked to 4.7 → 42% non-2xx (issue #227 production trip).
 #
-# Use wall_p95 as the input so tail-spike concurrency stays under N_eff:
-#   interval ≥ B × wall_p95 / N_eff = 2 × 11791 / 2.5 = 9433ms
-#   Round up to 10000ms.
-#   mean_active at p95: 2 × 11.8 / 10 = 2.36 < N_eff ✓
-#   mean_active at p50: 2 × 5.6 / 10 = 1.12 (lots of headroom)
+# Harness interval semantics: each buyer sleeps interval_ms after a
+# request finishes. The interval is a floor between completions and the
+# next dispatch, not a fixed start-to-start cadence. Use wall_p95 as
+# the input so tail-spike concurrency stays under N_eff even before the
+# floor sleep applies:
+#   start-to-start floor ≈ wall_time + interval_ms
+#   p95 floor = 11.8s + 10s = 21.8s
+#   mean_active at p95 floor: 2 × 11.8 / 21.8 = 1.08 < N_eff ✓
+#   p50 floor = 5.6s + 10s = 15.6s
+#   mean_active at p50 floor: 2 × 5.6 / 15.6 = 0.72
 #
-# requests_per_buyer = 30 gives 30 × 10s = 300s firing window per buyer.
-# Bumping duration to 360s leaves a 60s tail buffer for last-request
-# completion under p95 wall.
+# requests_per_buyer = 30 gives roughly 30 × (wall_time + 10s) per
+# buyer; duration=360s is intentionally a cap, so the run records as
+# many floor-paced samples as fit instead of enforcing a fixed count.
 #
 # Not a chaos test — providers should stay up the whole window. Any
 # 5xx in the error_taxonomy is real signal worth investigating.

--- a/test/network-harness/scenarios/09_streaming_ttft_distribution.yaml
+++ b/test/network-harness/scenarios/09_streaming_ttft_distribution.yaml
@@ -18,7 +18,10 @@
 #
 #   interval ≥ B × wall_p95 / N_eff = 1 × 3000 / 2.5 = 1200ms (theory)
 #   Set 2000ms for belt + suspenders, mean_active at p95 = 1.5 (under N_eff).
-#   100 × 2s = 200s firing window, fits 240s duration.
+#   Harness interval_ms is a floor after each request completes, so the
+#   expected sample cost is roughly observed wall time + interval. With
+#   ~2.5s wall p50 plus 2s floor pacing, 100 samples need about 450s;
+#   duration=540s gives 20% headroom.
 #
 # Cost estimate (100 × 8 max_tokens): negligible.
 name: streaming_ttft_distribution
@@ -50,7 +53,7 @@ buyers:
   interval_ms: 2000
   requests_per_buyer: 100
 
-duration: 240s
+duration: 540s
 request_timeout: 30s
 silent_hang_threshold: 15s
 


### PR DESCRIPTION
## Summary
Deepsec P2 residue cleanup: wires the Tier-2 output-safety guard into the coordinator's HTTP non-streaming forwarding path so it matches WS non-streaming behavior, brackets IPv6 bind addresses via `net.JoinHostPort`, makes harness invalid-2xx responses explicit, adds scenario schema bounds/default validation, corrects the UsageStore composite-key comment, and refreshes harness README/scenario drift.

## Changes
- coordinator/buyer: shared Tier-2 non-streaming output guard for HTTP and WS paths, provider degradation/recovery side effects on invalid output, and receipt stripping when PillarD mutates body bytes
- coordinator/main: `net.JoinHostPort` for bind address formatting, with IPv4/IPv6 regression coverage
- harness/buyer/loadgen: strict 2xx response-shape validation and `invalid_response` classification
- harness/metrics: `harness_invalid_2xx_total` summary field
- harness/scenario: reject invalid numeric bounds, reject explicit `requests_per_buyer: 0`, preserve omitted default, and stop dispatch waits at duration without canceling in-flight requests
- gateway/storage: UsageStore comment now describes `(account_id, request_id)` composite idempotency
- harness docs/scenarios: current run/DB/local-chaos guidance, corrected SSE terminal wording, configured cold-start delay, pacing math, and TTFT duration
- audit: added the three requested audit prompt files under `specs/`

## Test plan
- [x] `go test -count=1 ./...` in `phase4-coordinator`
- [x] `go test -count=1 ./...` in `phase5-gateway`
- [x] `go test -count=1 ./...` in `test/network-harness`
- [x] `go test -count=1 -timeout 5m ./...` in `test/integration` (initial full runs intermittently failed with existing harness setup symptoms; clean rerun passed)
- [x] Three Codex audit lanes accepted: code 0 C/H/M, architecture 0 C/H/M, security 0 LOW

## Manual scenario runs
Not run. Scenarios 05/06 affect live/local provider processes and all four modified live scenarios require buyer credentials and operational side effects.
