### PR TITLE
Load/fairness harness kickstart: local rig + scenario 17

### DIFF
--- a/specs/AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_ARCHITECT_PROMPT.md
+++ b/specs/AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_ARCHITECT_PROMPT.md
@@ -1,0 +1,79 @@
+# ARCHITECT AUDIT PROMPT — Load/fairness harness kickstart PR 1
+
+You are the ARCHITECT audit lane for `feat/load-harness-pr1-baseline`.
+Work read-only. Do not edit files.
+
+Audit the implementation of PR 1 from `specs/BUILD_SPEC_LOAD_FAIRNESS_HARNESS_KICKSTART_PROMPT.md`,
+focused on structural + longevity concerns from BUILD_SPEC §7 ARCHITECT.
+
+## Scope
+
+Same in-scope files as `AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_CODE_PROMPT.md`.
+
+## Design questions to answer
+
+### `load_summary.json` schema stability
+
+Load scenarios 18–22 will emit the same file with the same key names. Break the schema now and phase-B triage cannot diff across runs.
+
+- Are `RouteEntry` / `LatencyBucket` / `FairnessMetrics` / `StarvationFloor` field names generic enough that adding a streaming scenario (PR 6) doesn't force a rename? Look for baked-in "non-streaming"-only assumptions.
+- Does the empty-run case produce the same JSON keys as the populated case? Missing keys break jq downstream.
+- Is `WindowSeconds` reliable when a mid-run ctx cancel truncates results? (Answer: it's computed from result StartUTC/EndUTC extremes, so a partial run reports a shorter window truthfully. Confirm.)
+
+### Fairness metric choice
+
+Three metrics ship together (Gini, stddev, max/min). BUILD_SPEC §7 says "justify with reference to what beta providers actually care about."
+
+- Is the choice of Gini vs. a simpler entropy measure (e.g., normalized Shannon) justified? Gini is well-known but has poor behavior at N<5 providers — the baseline scenario runs 3 providers, so triage should read all three headline numbers, not pick one prematurely.
+- `MaxMinRatio` floors the min at 1 to avoid divide-by-zero. Is that documented well enough that a reader won't misinterpret "ratio=10 with min=0" as "worst provider got 1/10 the load"? Look at the FairnessMetrics docstring.
+- ProviderCount is emitted alongside the metrics — good, but is the field ordering in the JSON stable across marshals? Go's encoding/json emits struct fields in declaration order, so any struct field reorder is a schema change.
+
+### Local-rig extensibility
+
+BUILD_SPEC §7 ARCHITECT: "Local rig can extend to more providers (add M-Ultra, add M-base Pros) without rewriting the rig itself."
+
+- Is `Provider` (in `internal/localrig/`) a stable interface, or does adding a "sometimes-fails" provider (for PR 3's asymmetric-fleet-starvation scenario) require rig internals to change?
+- Ports.go allocates on demand — good. Is there any implicit cap on the number of providers (e.g., a hard-coded `providers []` bound, or a WS connection ceiling on the coord side)?
+- Can a follow-up PR wire a REAL `macprovider-cli` binary alongside the fakes without rearchitecting? Look at `providers.go` — is the FakeProvider tightly coupled to the rig's WS lifecycle, or can real-binary process substitution be added later?
+
+### Rig lifecycle safety
+
+- On SIGINT during the rig's binary build (~15s cold): does the build get cancelled cleanly, or does it hold the tempdir open? Check `buildBinaries` context handling.
+- On coord/gateway crash mid-run: does the harness exit with the right code, or does buyer.Run hang trying to reach a dead gateway until its per-request timeout expires N times? Look at whether the rig surfaces a "process died" signal.
+- Is the rig's WorkDir cleanup safe on double-Shutdown? `Shutdown()` docstring claims idempotent — verify.
+
+### Metric shape reusable across scenarios
+
+BUILD_SPEC §7 ARCHITECT: "Metric primitives are reusable across scenarios, not scenario-specific."
+
+- `loadmetrics.Class` is generic. But `DefaultClasses` has scenario 17's specific `short_16tok` / `medium_200tok` labels baked in. Sticky scenario (PR 2) will want a "sticky_hit_rate" bucket — does the current abstraction support that additively, or would it require a rewrite?
+- Is there anything scenario-17-specific in `loadmetrics.Compute` that a rewrite in a hurry might not notice?
+
+### DoS guard placement
+
+- The `validateProdLoadGuard` runs at scenario-Validate time — good; the error surfaces before any request fires. But the guard reads env directly (`os.Getenv`). If a test wants to exercise the failure path without setting env, `t.Setenv` should cover it — verify the tests do so.
+- Should the guard also cover WS-level chaos scenarios (05, 06, 12) that use PROVIDER_SSH to kill providers on Pearl? Those are technically not high-concurrency load, but a chaos scenario with `buyers.count = 25` against api.streamvc.live would slip through. Is that in-scope for PR 1 or explicitly deferred?
+
+### Coexistence with `test/integration`
+
+- The rig duplicates ~50% of `test/integration/harness_test.go`'s config-writing + spawn logic. Does the PR body flag this as intentional (share-refactor deferred) or does it silently ship a fork? Silent forks age badly. A `TODO(shared-rig-refactor)` comment somewhere is the right move.
+- Is there any risk of the rig's coord/gateway configs drifting from what `test/integration` uses on a production config-shape change? If integration's YAML changes and the rig's doesn't, load runs pass but integration breaks — flag if there's no explicit test coupling.
+
+### PR body coverage
+
+- Does the PR description explain the empirical scale ceiling encountered during dev? BUILD_SPEC §10 makes this a success criterion.
+- Are follow-up scenarios 18–22 outlined in the PR body?
+- Is the fairness-metric choice justified in the PR body, or only in code comments?
+
+## Method
+
+1. Read the BUILD_SPEC end-to-end to internalize what "phase-A discipline" means.
+2. Read every changed file top-to-bottom (not just the diff).
+3. For each design question, either write a concrete answer with `file:line` citations, OR flag it as an ARCH finding.
+4. Distinguish LOW/INFO ARCH observations from real MEDIUM/HIGH structural issues. LOW/INFO ship in the PR body.
+
+Return findings ordered by severity with file:line references.
+If no issues remain, say `No findings.`
+
+End with:
+`STATUS: ARCHITECT lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>`

--- a/specs/AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_CODE_PROMPT.md
+++ b/specs/AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_CODE_PROMPT.md
@@ -1,0 +1,60 @@
+# CODE AUDIT PROMPT — Load/fairness harness kickstart PR 1
+
+You are the CODE audit lane for `feat/load-harness-pr1-baseline`.
+Work read-only. Do not edit files.
+
+Audit the implementation of PR 1 from `specs/BUILD_SPEC_LOAD_FAIRNESS_HARNESS_KICKSTART_PROMPT.md`.
+
+## Scope (in-scope directories/files only)
+
+- `test/network-harness/internal/scenario/schema.go` — new `Rig` / `Providers` fields on `Target`, `RigProvider` type, `validateRigTarget`, `validateProdLoadGuard`, `ProdLoadGuardEnv`/`ProdLoadGuardBuyerLimit` constants
+- `test/network-harness/internal/scenario/rig_target_test.go` — validator tests
+- `test/network-harness/internal/localrig/**` — new package: embedded coord+gateway+fake-providers rig
+- `test/network-harness/internal/loadmetrics/**` — new package: `Compute`, `Summary`, fairness math
+- `test/network-harness/cmd/harness/main.go` — wiring the rig start/stop + `load_summary.json` emit
+- `test/network-harness/internal/artifact/bundle.go` — optional `load_summary.json` write hook
+- `test/network-harness/scenarios/17_sustained_load_baseline.yaml`
+- `test/network-harness/README.md` — rig section + scenario 17 table row
+- `test/network-harness/go.mod` / `go.sum` — `github.com/gobwas/ws` add
+
+## Anti-scope (must NOT appear in diff)
+
+- `phase4-coordinator/**`, `phase5-gateway/**`, `phase3-binary/**`
+- `test/network-harness/internal/metrics/collector.go` — additive `loadmetrics` package must not mutate the shared aggregator
+- `test/network-harness/internal/invariants/**` — I1-I4 unchanged
+- Any scenario file other than 17
+- SPEC-004 sticky contract edits
+- CI workflow changes
+
+## Expected contract
+
+- **Fairness math correctness**: `gini`, `stddev`, `maxMinRatio` handle empty input, all-zero counts, and single-provider fleets without div-by-zero or negative outputs. `pct` percentile matches nearest-rank convention already used in `metrics/collector.go:133-145`.
+- **Route distribution attribution**: only `Outcome == "ok"` results count toward per-provider shares; providers with zero successes appear in the emitted `route_distribution` list ONLY when they are in the rig-supplied Ready set (or, on non-rig fallback, when they appear at least once in the results).
+- **Starvation floor**: `min_requests_per_ready_provider` and `providers_with_zero_success` derive from the same Ready set used for fairness. Documented TODO for mid-run disconnect handling is acceptable in PR 1.
+- **Prompt-class bucketing**: `LatencyByPromptClass` re-derives max_tokens via `sc.PromptFor(BuyerIndex, RequestIndex)` — no new field on `buyer.Result`. Empty buckets emit with `count=0` (stable schema for run-to-run diffs).
+- **Scenario schema validators**:
+  - `Rig=="local"` forbids `GatewayURL`, `CoordinatorURL`, `BuyerToken`, `DemoIdentity`, both DB path fields, both DB SSH fields, and requires `Providers` non-empty with unique IDs, non-empty Model, `TTFTMs>=0`, `TokensPerSec>=0`, `CapacitySlots>=1`.
+  - Every `Prompt.Model` must be advertised by at least one `RigProvider.Model` when rig is on.
+  - `Rig==""` with any `Providers` set is rejected.
+  - `Buyers.Count > 10` against `*.streamvc.live` requires `ALLOW_PROD_LOAD=1`; local/other hosts are unaffected.
+- **Rig lifecycle**:
+  - `localrig.Start(ctx, cfg)` returns an error and leaves nothing running on partial failure.
+  - `Rig.Shutdown()` is idempotent and cancels all child processes + fake providers.
+  - Ports are bound to `127.0.0.1` only (grep for any `0.0.0.0` / `""` bind in configs).
+  - Buyer token / provider tokens must not appear in log lines (grep the rig's Logger callsites).
+- **Runner wiring**: on `sc.Target.Rig == "local"` the harness spawns the rig BEFORE `buyer.Run`, patches `sc.Target.GatewayURL` / `CoordinatorURL` / `BuyerToken` / `CoordinatorDBPath` / `GatewayDBPath`, and ensures `Rig.Shutdown()` runs on both the happy path and SIGINT/SIGTERM.
+- **Three-dot diff** `git diff origin/main...HEAD` matches the scope above; no drive-by edits in coord/gateway/binary directories.
+
+## Method
+
+1. Read the PR: `git diff origin/main...HEAD --stat`, then walk each in-scope file.
+2. Run `go test ./internal/loadmetrics/... ./internal/scenario/...` and confirm both pass.
+3. Grep for `0.0.0.0`, `MAC`, `"Bearer"`, token substrings in rig code — token echo in logs is a defect.
+4. Skim `test/integration/harness_test.go` (already merged, out-of-scope) to compare rig config shapes — deviations must be justified.
+5. For each finding, cite `file:line`, severity (CRITICAL / HIGH / MEDIUM / LOW / INFO), and the specific failure mode.
+
+Return findings ordered by severity with file:line references.
+If no issues remain, say `No findings.`
+
+End with:
+`STATUS: CODE lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>`

--- a/specs/AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_SECURITY_PROMPT.md
+++ b/specs/AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_SECURITY_PROMPT.md
@@ -1,0 +1,64 @@
+# SECURITY AUDIT PROMPT — Load/fairness harness kickstart PR 1
+
+You are the SECURITY audit lane for `feat/load-harness-pr1-baseline`.
+Work read-only. Do not edit files.
+
+Audit the implementation of PR 1 from `specs/BUILD_SPEC_LOAD_FAIRNESS_HARNESS_KICKSTART_PROMPT.md`
+with focus areas from BUILD_SPEC §7 SECURITY.
+
+## Scope
+
+Same in-scope files as `AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_CODE_PROMPT.md`.
+
+## Threats to look for
+
+### PROD-side DoS (highest priority)
+
+- `validateProdLoadGuard` in `scenario/schema.go`: does it correctly reject `buyers.count > 10` against ANY `*.streamvc.live` host? Try to construct a bypass:
+  - IPv6 literal for `api.streamvc.live` — `url.Hostname()` unwraps brackets but the check is a suffix on lowercased hostname; verify.
+  - Uppercase host `HTTPS://API.STREAMVC.LIVE` — verify lowercasing.
+  - Non-standard port `https://api.streamvc.live:8443` — verify the port doesn't affect suffix match.
+  - Authority-only URL with userinfo — verify userinfo doesn't sneak past `Hostname()`.
+  - Trailing dot `api.streamvc.live.` — does the suffix still trip? (DNS treats these as equivalent; the guard should trip.)
+- Does the guard fire in `sku-econ` mode too, or is it correctly scoped to `buyer-fleet`? sku-econ has its own host pin; guard scope is correct if it doesn't misfire on sku-econ but still catches buyer-fleet mistakes.
+- `ALLOW_PROD_LOAD=1` is the only bypass. Are other truthy values like `"true"`, `"yes"`, `"TRUE"` inadvertently accepted? Only literal `"1"` should pass — verify.
+
+### Token leakage
+
+- The rig mints a fresh gateway API key (`mp_...`) via `seedGatewayAccountAndKey`. Grep every call to `Config.Logger` / `log.Printf` / `fmt.Errorf` under `internal/localrig/**` for anything that could echo the returned string. Same for provider tokens minted by `issueProviderToken`.
+- Coordinator + gateway YAML files are written under the rig tempdir with mode `0o600`? Verify. World-readable configs leak `key_hash_secret` + `service_token` + `operator_key`.
+- The rig tempdir cleanup: on `Shutdown`, are YAMLs + DBs unlinked, or left in `/tmp` for later inspection? Persisting to disk is a defensible tradeoff for triage, BUT if kept, the tempdir must be `0o700` and the token must not appear inside any file (grep `os.ReadFile` behavior on the seeded gateway DB before deletion is fine — key hash is HMAC, not the raw key).
+- Load scenario 17's `expected_shape` / `description` doesn't inline any placeholder that could accidentally be filled by env expansion (grep for `${` in scenario YAML).
+
+### Network exposure
+
+- Every listener in `internal/localrig/**` binds to `127.0.0.1` (or `[::1]`). Grep for any bare port literal, `":8080"`, `"0.0.0.0"`, `net.Listen("tcp", ":`, or `http.Server{Addr: ":`. Any hit is a HIGH finding — a load rig accidentally bound on `0.0.0.0` is an open coord/gateway to the LAN during the run window.
+- Coord + gateway configs use `bind_address: "127.0.0.1"` per `test/integration/harness_test.go:478,689`. Confirm the rig writes the same.
+- Fake providers advertise `endpoint_url: http://127.0.0.1:<port>` — anything else is a hole.
+
+### Buyer authentication
+
+- The rig's minted `BuyerToken` is fresh per Start (not a static hard-coded token). Verify.
+- The token is passed through `Scenario.Target.BuyerToken` — which the standard buyer runner puts in the `Authorization: Bearer <token>` header. Ensure the harness doesn't ALSO write the token to any artifact file (`run_meta.json`, `per_request.jsonl`, etc.). Grep for `BuyerToken` usage in `internal/artifact/**` and `internal/runmeta/**`.
+
+### Subprocess spawn hygiene
+
+- `exec.CommandContext` calls in `internal/localrig/**` inherit env via `os.Environ()`. If the parent shell has a `BUYER_TOKEN`, does it accidentally get read by the spawned coord or gateway? Coord/gateway don't read env for buyer tokens, but confirm there is no path where a rig helper (`coordinator-cli issue-token`) accepts an env override that would leak Pearl credentials.
+- `go build` runs with `CGO_ENABLED=0`. Confirm — a rig build that pulls system libc pins the reproducibility.
+
+### Rig authorization
+
+- The rig auto-mints a gateway API key without any user confirmation. Rig lifecycle is scoped to a single scenario run, so this is fine. Confirm the token is NOT persisted beyond `Rig.Shutdown()` — no write to `~/.config/macprovider/*`, no export.
+
+## Method
+
+1. `git diff origin/main...HEAD -- test/network-harness/` and read every changed file.
+2. Grep patterns above; each hit becomes a candidate finding.
+3. Prove or disprove each candidate by tracing the code path end-to-end.
+4. For each real finding, cite `file:line`, severity, and demonstrate the attack scenario in one paragraph.
+
+Return findings ordered by severity with file:line references.
+If no issues remain, say `No findings.`
+
+End with:
+`STATUS: SECURITY lane — CRITICAL=<n> HIGH=<n> MEDIUM=<n> LOW=<n> INFO=<n>`

--- a/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r1_architect-audit.md
+++ b/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r1_architect-audit.md
@@ -1,0 +1,120 @@
+# Architect Audit - Load/fairness Harness PR 1
+
+Scope note: `git diff origin/main...HEAD` is empty because the PR 1
+implementation is currently uncommitted in this worktree. Per the task's
+"pending changes" wording, this audit reviewed the working tree changes
+reported by `git status` and `git diff` against the branch checkout.
+
+## Findings
+
+1. MEDIUM - Cold rig builds ignore cancellation, so SIGINT during the
+   first-run build can leave the harness blocked until `go build` returns.
+   `cmdRun` creates a signal-cancelled context before rig startup
+   (`test/network-harness/cmd/harness/main.go:156`), and `Start` receives
+   that context (`test/network-harness/cmd/harness/main.go:198`), but
+   `Start` calls `buildBinaries(repoRoot, binDir)` with no context
+   (`test/network-harness/internal/localrig/rig.go:150`). The actual
+   build uses `exec.Command("go", "build", ...)`, not
+   `exec.CommandContext` (`test/network-harness/internal/localrig/build.go:58`).
+   That violates the lifecycle requirement in the architect prompt:
+   a SIGINT during the ~15s cold build does not cancel the child build
+   promptly, and tempdir cleanup is delayed until the build completes.
+
+2. MEDIUM - Coordinator/gateway process death is not surfaced to the
+   runner during buyer execution. The harness starts the rig and then calls
+   `buyer.Run(ctx, sc)` with only the signal context
+   (`test/network-harness/cmd/harness/main.go:229`). The rig's
+   `registerProc` goroutine discards the child exit status and only marks
+   the WaitGroup done (`test/network-harness/internal/localrig/rig.go:331`).
+   There is no exposed `Done`/`Err` channel or context cancellation path
+   from a crashed coordinator or gateway back into `cmdRun`. If either
+   process dies after startup health checks, buyers continue firing until
+   request timeouts and the scenario duration govern exit
+   (`test/network-harness/internal/buyer/loadgen.go:26`). This makes a
+   rig infrastructure failure look like load-lane traffic data instead of
+   a fast harness failure.
+
+3. MEDIUM - The local rig is fake-provider only at its public boundary,
+   which makes the planned "sometimes-fails" provider and real
+   `macprovider-cli` substitution require localrig internals to change.
+   `Config.Providers` is a slice of the concrete data struct
+   (`test/network-harness/internal/localrig/rig.go:40`), `Provider` only
+   carries ID/model/latency/capacity fields
+   (`test/network-harness/internal/localrig/rig.go:52`), and `Start`
+   unconditionally turns every provider into `newFakeProvider(...)`
+   (`test/network-harness/internal/localrig/rig.go:272`). The fake owns
+   both the HTTP responder and WS lifecycle in one concrete type
+   (`test/network-harness/internal/localrig/providers.go:18`). Adding
+   more providers by count is fine, but adding failure-mode providers or
+   mixing in a real `macprovider-cli serve` process is not additive at the
+   current package boundary.
+
+4. LOW - The config-writing fork from `test/integration` is documented
+   only as coexistence, not as an intentional deferred share-refactor with
+   coupling tests. The README says `test/integration` continues to own
+   real-binary functional tests and future PRs may add a smoke target
+   (`test/network-harness/README.md:333`), but there is no
+   `TODO(shared-rig-refactor)` marker in the new rig and no test tying
+   the rig's coordinator/gateway YAML shape back to
+   `test/integration/harness_test.go`. This is a drift risk when prod
+   config shape changes.
+
+5. LOW - PR-body requirements could not be verified because this branch
+   has no discoverable PR metadata (`gh pr view` returned no PR for the
+   current branch). The scenario file itself covers the empirical scale
+   ceiling, Pearl DoS rationale, fairness metric choice, and follow-up
+   scenarios 18-22 (`test/network-harness/scenarios/17_sustained_load_baseline.yaml:3`,
+   `test/network-harness/scenarios/17_sustained_load_baseline.yaml:26`,
+   `test/network-harness/scenarios/17_sustained_load_baseline.yaml:46`),
+   but the architect prompt requires those points in the PR description.
+
+6. INFO - The audit prompt references
+   `specs/BUILD_SPEC_LOAD_FAIRNESS_HARNESS_KICKSTART_PROMPT.md`
+   (`specs/AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_ARCHITECT_PROMPT.md:6`),
+   but that build-spec file is absent from this checkout and from
+   `origin/main`. I audited against the architect prompt's embedded
+   contract and the full changed files, but this weakens traceability for
+   future audit rounds.
+
+## Design Notes
+
+- `load_summary.json` schema is mostly stable. The top-level summary
+  fields are shallow and generic (`test/network-harness/internal/loadmetrics/summary.go:22`),
+  route/fairness/starvation fields avoid non-streaming-only names
+  (`test/network-harness/internal/loadmetrics/summary.go:52`,
+  `test/network-harness/internal/loadmetrics/summary.go:62`,
+  `test/network-harness/internal/loadmetrics/summary.go:108`), and empty
+  class buckets are emitted for stable keys
+  (`test/network-harness/internal/loadmetrics/summary.go:277`). Window
+  seconds is computed from StartUTC/EndUTC extremes over partial results,
+  so mid-run cancellation truthfully reports the observed window
+  (`test/network-harness/internal/loadmetrics/summary.go:158`).
+- Fairness metric tradeoffs are documented well enough for PR 1:
+  Gini, stddev, max/min, and provider count ship together
+  (`test/network-harness/internal/loadmetrics/summary.go:62`), and the
+  max/min floor is explicitly documented with a pointer to raw starvation
+  fields (`test/network-harness/internal/loadmetrics/summary.go:77`).
+- The DoS guard runs during scenario validation before requests fire and
+  covers any buyer-fleet scenario with `buyers.count > 10` against
+  `*.streamvc.live`, including chaos scenarios if they are scaled that
+  high (`test/network-harness/internal/scenario/schema.go:671`). Tests use
+  `t.Setenv` for both reject and override paths
+  (`test/network-harness/internal/scenario/rig_target_test.go:162`,
+  `test/network-harness/internal/scenario/rig_target_test.go:175`).
+- `Shutdown` is idempotent via `sync.Once` and removes only the rig-owned
+  workdir (`test/network-harness/internal/localrig/rig.go:295`). The
+  127.0.0.1 bind invariant is explicit in generated configs and fake
+  listeners (`test/network-harness/internal/localrig/coord.go:46`,
+  `test/network-harness/internal/localrig/gateway.go:37`,
+  `test/network-harness/internal/localrig/providers.go:85`).
+
+## Verification
+
+- Read the architect prompt, code prompt, full changed files, and
+  relevant integration harness sections.
+- `go test ./internal/loadmetrics/... ./internal/scenario/...` passed from
+  `test/network-harness`.
+- Grep for `0.0.0.0`, `Bearer`, token strings, and rig logger callsites
+  found no bearer/token values emitted through the rig logger.
+
+STATUS: ARCHITECT lane — CRITICAL=0 HIGH=0 MEDIUM=3 LOW=2 INFO=1

--- a/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r1_code-audit.md
+++ b/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r1_code-audit.md
@@ -1,0 +1,19 @@
+# Code Audit: Load/fairness harness PR 1
+
+Scope note: `git diff origin/main...HEAD --stat` is empty in this worktree; the implementation is present as dirty tracked files plus untracked new files. I audited the current worktree contents for the files named by `specs/AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_CODE_PROMPT.md`.
+
+## Findings
+
+1. HIGH - `test/network-harness/cmd/harness/main.go:205`: the rig shutdown is deferred, but `cmdRun` later calls `os.Exit(10)` directly on invariant failure at `test/network-harness/cmd/harness/main.go:359`. In Go, `os.Exit` bypasses defers, so any rig-backed scenario that completes and then fails I1-I4 leaves the coordinator, gateway, fake providers, and rig tempdir running on disk instead of executing `Rig.Shutdown()`. Load scenarios are specifically meant to surface hard-invariant failures, so this is a normal failure path, not an edge case. Return a sentinel exit-code error from `cmdRun` and let `main` exit after defers run.
+
+## Verification
+
+- `git diff origin/main...HEAD --stat` returned no files.
+- `git diff --stat` / `git ls-files --others --exclude-standard` showed the pending tracked and untracked harness implementation files; those were audited as the effective pending-change scope.
+- Anti-scope grep/diff checks found no pending edits under `phase4-coordinator/**`, `phase5-gateway/**`, `phase3-binary/**`, `test/network-harness/internal/metrics/collector.go`, `test/network-harness/internal/invariants/**`, scenario files other than 17, SPEC-004 files, or CI workflows.
+- Token/bind grep found loopback binds only in the rig code and no rig logger callsite that prints bearer or buyer tokens.
+- `go test ./internal/loadmetrics/... ./internal/scenario/...` passed.
+- `go test ./internal/localrig -run TestRigLifecycle -count=1` passed.
+- `go run ./cmd/harness run scenarios/17_sustained_load_baseline.yaml --out /tmp/macprovider-harness-audit-dry --dry-run` passed.
+
+STATUS: CODE lane — CRITICAL=0 HIGH=1 MEDIUM=0 LOW=0 INFO=0

--- a/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r1_security-audit.md
+++ b/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r1_security-audit.md
@@ -1,0 +1,40 @@
+# SECURITY AUDIT — Load/fairness harness kickstart PR 1
+
+Branch/worktree: `feat/load-harness-pr1-baseline` at `/Users/augstar/macprovider-load-pr1`
+
+Scope note: `git diff origin/main...HEAD -- test/network-harness/` returned no files because the PR1 harness changes are currently unstaged/untracked in this worktree while `HEAD` is behind `origin/main`. I audited the pending working-tree changes reported by `git status --short` plus the in-scope files named by `specs/AUDIT_BUILD_SPEC_LOAD_HARNESS_PR1_IMPL_CODE_PROMPT.md`.
+
+## Findings
+
+### HIGH
+
+1. `test/network-harness/internal/scenario/schema.go:690`
+
+   Issue: `validateProdLoadGuard` does not normalize a trailing DNS root dot before checking the production suffix. It lowercases `u.Hostname()` and then requires `strings.HasSuffix(host, ".streamvc.live")`; for `gateway_url: https://api.streamvc.live.`, `url.Hostname()` returns `api.streamvc.live.`, which does not end with `.streamvc.live`. DNS treats the trailing-dot form as equivalent to `api.streamvc.live`, so a buyer-fleet scenario with `buyers.count: 20` and no `ALLOW_PROD_LOAD=1` bypasses the DoS guard and can still hit Pearl production.
+
+   Attack scenario: a committed or operator-supplied scenario sets `mode: buyer-fleet`, `gateway_url: https://api.streamvc.live.`, a valid buyer token, and `buyers.count` above `10`. Validation reaches `validateProdLoadGuard`, skips the guard at `schema.go:694`, and the run can send load-lane traffic to the production gateway even though the same host without the trailing dot is rejected by `TestProdLoadGuard_HighConcurrencyRejected`.
+
+   Fix: normalize the hostname before the suffix check, for example `host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")`, then check `host == "streamvc.live" || strings.HasSuffix(host, ".streamvc.live")` as appropriate for the intended production host set. Add a regression test for `https://api.streamvc.live.` and keep the existing `ALLOW_PROD_LOAD == "1"` literal-only override behavior.
+
+## Non-Findings Checked
+
+- Uppercase production host and non-standard port are covered by `url.Hostname()` plus lowercasing; the port is not part of `Hostname()`.
+- Userinfo does not affect the guard because `url.Hostname()` excludes it.
+- The guard is scoped to buyer-fleet validation; `sku-econ` uses its own host pinning.
+- Only literal `ALLOW_PROD_LOAD=1` bypasses the guard.
+- Local rig listeners and generated coordinator/gateway configs bind to `127.0.0.1`; no `0.0.0.0` or bare `":port"` listener was found under `internal/localrig`.
+- Coordinator and gateway YAML files are written with `0o600`; default rig tempdirs are owned tempdirs and are removed by `Rig.Shutdown()`.
+- The minted gateway buyer key is patched into the in-memory scenario for `buyer.Run`; `run_meta.json`, `per_request.jsonl`, and `load_summary.json` do not serialize `BuyerToken`.
+- Gateway seeding discards subprocess stdout/stderr, and provider-token issuance output is parsed without logging the raw token on the successful path.
+- Scenario 17 contains no `${VAR}` placeholders.
+- `go build` for rig binaries sets `CGO_ENABLED=0`.
+
+## Validation
+
+- `go test ./internal/loadmetrics/... ./internal/scenario/...`
+- `go test ./internal/localrig/...`
+- `go test ./cmd/harness`
+- `go test ./internal/scenario -run 'TestProdLoadGuard|TestValidateRig' -count=1`
+- Greps run for logging/token call sites, bearer usage, file writes, listener binds, `0.0.0.0`, bare TCP listener forms, and `${VAR}` placeholders in scenario 17.
+
+STATUS: SECURITY lane — CRITICAL=0 HIGH=1 MEDIUM=0 LOW=0 INFO=0

--- a/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r2_architect-audit.md
+++ b/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r2_architect-audit.md
@@ -1,0 +1,134 @@
+# Architect Audit - Load/fairness Harness PR 1 - Round 2
+
+Scope note: `git diff origin/main...HEAD` is empty because this PR 1
+implementation is currently in the working tree as unstaged/untracked files.
+This audit reviewed the working-tree content under the architect prompt's
+scope. The referenced source build spec
+`specs/BUILD_SPEC_LOAD_FAIRNESS_HARNESS_KICKSTART_PROMPT.md` is absent from
+this checkout, so traceability is against the audit prompt and in-scope files.
+
+## Findings
+
+1. LOW - The config-writing fork from `test/integration` is still documented
+   only as coexistence, not as an intentional deferred share-refactor with a
+   coupling test. The README says `test/integration` continues to own
+   real-binary functional regression tests and future PRs may add a smoke
+   target (`test/network-harness/README.md:333`), while localrig says the
+   process boundary has the same shape as integration
+   (`test/network-harness/internal/localrig/rig.go:14`). There is still no
+   `TODO(shared-rig-refactor)` marker in localrig and no test tying the
+   generated coordinator/gateway YAML shape to
+   `test/integration/harness_test.go`, so config-shape drift remains a
+   low-severity longevity risk.
+
+2. LOW - PR-body coverage still cannot be verified because no GitHub PR is
+   discoverable for the current branch (`gh pr view` returned "no pull
+   requests found for branch \"feat/load-harness-pr1-baseline\""). The scenario
+   and code comments cover the operational rationale, but the architect prompt
+   specifically asks whether the PR description explains the empirical scale
+   ceiling, follow-up scenarios 18-22, and fairness metric choice.
+
+3. INFO - The audit prompt references
+   `specs/BUILD_SPEC_LOAD_FAIRNESS_HARNESS_KICKSTART_PROMPT.md`, but that file
+   is absent from this worktree and from the visible `specs/` listing. I
+   audited against the architect prompt's embedded contract plus the full
+   in-scope working-tree files.
+
+## R1 Medium Recheck
+
+- Resolved: cold binary builds are now cancellation-aware. `buildBinaries`
+  accepts `context.Context` and passes it into all three `buildOne` calls
+  (`test/network-harness/internal/localrig/build.go:45`,
+  `test/network-harness/internal/localrig/build.go:52`), and `buildOne` uses
+  `exec.CommandContext` plus returns the context error on cancellation
+  (`test/network-harness/internal/localrig/build.go:64`). `Start` now passes
+  the rig context into the build step
+  (`test/network-harness/internal/localrig/rig.go:237`), so SIGINT/SIGTERM
+  during a cold `go build` cancels the child process instead of blocking until
+  the compiler exits naturally.
+
+- Resolved: coordinator/gateway death is now surfaced to the runner.
+  `Rig.Done()` exposes the crash channel and `Rig.Err()` exposes the first
+  supervised-process error (`test/network-harness/internal/localrig/rig.go:156`,
+  `test/network-harness/internal/localrig/rig.go:165`). `registerProc`
+  observes `cmd.Wait()` and records non-shutdown exits
+  (`test/network-harness/internal/localrig/rig.go:443`,
+  `test/network-harness/internal/localrig/rig.go:453`), while `recordCrash`
+  suppresses exits after `Shutdown` has started via `shuttingDown`
+  (`test/network-harness/internal/localrig/rig.go:473`). The runner derives
+  `buyerCtx`, races `rig.Done()` against `buyer.Run`, cancels the buyers on
+  rig crash, and converts the completed race into a localrig error
+  (`test/network-harness/cmd/harness/main.go:240`,
+  `test/network-harness/cmd/harness/main.go:259`,
+  `test/network-harness/cmd/harness/main.go:263`).
+
+- Resolved: provider implementation selection is now additive at the localrig
+  boundary. `Provider.Kind` and `ProviderKindFake` document the dispatch
+  point for future fail-inject and real-binary providers
+  (`test/network-harness/internal/localrig/rig.go:68`,
+  `test/network-harness/internal/localrig/rig.go:79`). `providerProcess`
+  abstracts provider lifecycle start/stop
+  (`test/network-harness/internal/localrig/rig.go:90`), `Start` constructs
+  providers through `newProviderProcess`
+  (`test/network-harness/internal/localrig/rig.go:359`), and the factory
+  currently supports fake providers while rejecting unknown kinds explicitly
+  (`test/network-harness/internal/localrig/rig.go:414`). Future
+  `ProviderKindFailInject` / `ProviderKindRealBinary` additions can plug into
+  that factory without rewriting the main rig start loop.
+
+## Design Notes
+
+- `load_summary.json` field names remain generic enough for later streaming
+  scenarios: route distribution, fairness, latency buckets, and starvation
+  floor are named without scenario-17-only terminology
+  (`test/network-harness/internal/loadmetrics/summary.go:22`,
+  `test/network-harness/internal/loadmetrics/summary.go:52`,
+  `test/network-harness/internal/loadmetrics/summary.go:62`,
+  `test/network-harness/internal/loadmetrics/summary.go:108`).
+- Empty-run schema is stable at the top level because `Compute` always returns
+  a `Summary` with all struct fields and initializes the latency-class map
+  (`test/network-harness/internal/loadmetrics/summary.go:147`,
+  `test/network-harness/internal/loadmetrics/summary.go:154`). Empty latency
+  buckets are emitted for every configured class
+  (`test/network-harness/internal/loadmetrics/summary.go:277`).
+- `WindowSeconds` is computed from the earliest result start and latest result
+  end across the observed results, so a mid-run cancellation truthfully reports
+  the shorter observed window
+  (`test/network-harness/internal/loadmetrics/summary.go:158`).
+- Fairness metric tradeoffs are documented in code: Gini, stddev, max/min, and
+  provider count ship together (`test/network-harness/internal/loadmetrics/summary.go:62`),
+  and the max/min denominator floor points readers to the raw starvation fields
+  (`test/network-harness/internal/loadmetrics/summary.go:77`,
+  `test/network-harness/internal/loadmetrics/summary.go:367`).
+- Localrig has no provider-count cap beyond slice length and OS/socket limits:
+  provider ports are allocated per configured provider
+  (`test/network-harness/internal/localrig/rig.go:255`), and each fake binds
+  to `127.0.0.1` (`test/network-harness/internal/localrig/providers.go:85`).
+- Metric primitives remain reusable. `Class` accepts arbitrary labels and
+  token ranges (`test/network-harness/internal/loadmetrics/summary.go:125`);
+  `DefaultClasses` are scenario-17 defaults only, and callers can pass a custom
+  class list (`test/network-harness/internal/loadmetrics/summary.go:135`,
+  `test/network-harness/internal/loadmetrics/summary.go:149`).
+- The production load guard still runs during scenario validation before any
+  request fires and covers high buyer counts against the StreamVC apex or
+  subdomains (`test/network-harness/internal/scenario/schema.go:671`,
+  `test/network-harness/internal/scenario/schema.go:698`). Tests use
+  `t.Setenv` for reject and override paths
+  (`test/network-harness/internal/scenario/rig_target_test.go:162`,
+  `test/network-harness/internal/scenario/rig_target_test.go:175`).
+
+## Verification
+
+- Read the architect prompt, code prompt, R1 architect audit, and the in-scope
+  working-tree files under `test/network-harness/internal/localrig/`,
+  `test/network-harness/internal/loadmetrics/`,
+  `test/network-harness/internal/scenario/`, `cmd/harness/main.go`,
+  `internal/artifact/bundle.go`, `README.md`, and scenario 17.
+- Ran from `test/network-harness`:
+  `go test ./internal/localrig/... ./internal/scenario/... ./internal/loadmetrics/... ./cmd/harness`
+  and it passed.
+- Checked PR metadata with `gh pr view --json number,title,body,headRefName,baseRefName`;
+  no PR exists for the current branch, so PR-body-only requirements remain
+  unverifiable in this worktree.
+
+STATUS: ARCHITECT lane - CRITICAL=0 HIGH=0 MEDIUM=0 LOW=2 INFO=1

--- a/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r2_code-audit.md
+++ b/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r2_code-audit.md
@@ -1,0 +1,28 @@
+# Code Audit Round 2: Load/fairness harness PR 1
+
+Scope note: the PR implementation is still present as dirty tracked files plus untracked new files in `/Users/augstar/macprovider-load-pr1`. `git diff origin/main...HEAD --stat` is empty because the branch itself has no committed PR diff; I used the current worktree diff plus untracked files as the effective r1-to-r2 audit surface, with special focus on the Round 1 HIGH finding in `test/network-harness/cmd/harness/main.go`.
+
+## Findings
+
+No findings.
+
+## Round 1 HIGH verification
+
+- Fixed: `test/network-harness/cmd/harness/main.go:35` defines `errHardInvariantFail`.
+- Fixed: `test/network-harness/cmd/harness/main.go:49` maps `errors.Is(err, errHardInvariantFail)` to `os.Exit(10)` in `main()`, after `cmdRun` has returned.
+- Fixed: `test/network-harness/cmd/harness/main.go:187` and `test/network-harness/cmd/harness/main.go:395` now return the sentinel instead of calling `os.Exit(10)` from inside `cmdRun`.
+- Teardown path preserved: `test/network-harness/cmd/harness/main.go:216` defers `rig.Shutdown()` immediately after successful `localrig.Start`, so hard-invariant failures now unwind `cmdRun` defers before the process exits with code 10.
+- No remaining direct `os.Exit` calls are reachable after rig startup inside `cmdRun`; remaining `os.Exit` calls are in `main()`/usage handling before `cmdRun` returns or for other subcommands.
+
+## Verification
+
+- `git diff -- test/network-harness/cmd/harness/main.go` shows the Round 2 change from direct `os.Exit(10)` inside `cmdRun` to `return errHardInvariantFail`.
+- `git diff --check` passed.
+- `go test ./internal/loadmetrics/... ./internal/scenario/...` passed.
+- `go test ./cmd/harness` passed.
+- `go test ./internal/localrig -run TestRigLifecycle -count=1` passed.
+- `go run ./cmd/harness run scenarios/17_sustained_load_baseline.yaml --out /tmp/macprovider-harness-r2-dry --dry-run` passed.
+- Grep review found rig binds/config URLs on `127.0.0.1` and no rig logger callsite that prints buyer/provider bearer token values.
+- Anti-scope check found no tracked pending edits under `phase4-coordinator/**`, `phase5-gateway/**`, `phase3-binary/**`, `test/network-harness/internal/metrics/collector.go`, `test/network-harness/internal/invariants/**`, SPEC-004 files, CI workflows, or scenario files other than scenario 17.
+
+STATUS: CODE lane — CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0 INFO=0

--- a/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r2_security-audit.md
+++ b/specs/BUILD_SPEC_LOAD_HARNESS_PR1_r2_security-audit.md
@@ -1,0 +1,66 @@
+# SECURITY AUDIT - Load/fairness harness kickstart PR 1, Round 2
+
+Branch/worktree: `feat/load-harness-pr1-baseline` at `/Users/augstar/macprovider-load-pr1`
+
+Scope note: the Round 2 request targeted the r1 HIGH finding in
+`test/network-harness/internal/scenario/schema.go` plus the regression tests in
+`test/network-harness/internal/scenario/rig_target_test.go`. I also rechecked
+the security-prompt areas from the r1 lane against the current working-tree
+implementation.
+
+## Findings
+
+No findings.
+
+## Round 2 Fix Verification
+
+- `test/network-harness/internal/scenario/schema.go:680` now normalizes the
+  parsed gateway hostname with
+  `strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")` before checking the
+  production suffix. This closes the r1 bypass where
+  `https://api.streamvc.live.` skipped the `*.streamvc.live` DoS guard.
+- `test/network-harness/internal/scenario/schema.go:698` covers both subdomains
+  ending in `.streamvc.live` and the apex `streamvc.live` host.
+- `test/network-harness/internal/scenario/schema.go:701` still accepts only the
+  literal `ALLOW_PROD_LOAD=1` override.
+- `test/network-harness/internal/scenario/rig_target_test.go:194` covers the
+  trailing-dot host case.
+- `test/network-harness/internal/scenario/rig_target_test.go:207` covers
+  uppercase host normalization.
+- `test/network-harness/internal/scenario/rig_target_test.go:218` covers the
+  apex `streamvc.live` host.
+- `test/network-harness/internal/scenario/rig_target_test.go:231` covers that
+  truthy values other than literal `1` do not bypass the guard.
+
+## Non-Findings Rechecked
+
+- Uppercase hosts, non-standard ports, and userinfo do not bypass the prod load
+  guard because the check uses `url.Hostname()` and lowercases the host before
+  suffix comparison.
+- The guard is scoped to buyer-fleet validation; sku-econ continues to use its
+  own coordinator host pinning.
+- Local rig listeners and generated coordinator/gateway configs bind to
+  `127.0.0.1`; greps found no `0.0.0.0` or bare-port listener forms under
+  `internal/localrig`.
+- Coordinator and gateway YAML files are written with `0o600`. The default rig
+  tempdir is created by `os.MkdirTemp` and is removed by `Rig.Shutdown()`.
+- The minted buyer API key is patched only into the in-memory scenario before
+  `buyer.Run`; artifact writing copies the original scenario YAML and writes
+  request/meta/load summaries that do not include `BuyerToken`.
+- Gateway seeding discards subprocess stdout/stderr. Provider-token issuance
+  parses successful `token=` output without logging the raw token; the
+  coordinator CLI prints `token=` only after `store.IssueToken` returns nil, so
+  localrig's failure-output wrapper does not expose a newly minted token from a
+  failed command.
+- Scenario 17 contains no `${VAR}` placeholders.
+- Rig binary builds set `CGO_ENABLED=0`.
+
+## Validation
+
+- `go test ./internal/loadmetrics/... ./internal/scenario/... ./internal/localrig/... ./cmd/harness`
+- `go test ./internal/scenario -run 'TestProdLoadGuard|TestValidateRig' -count=1`
+- Greps run for prod guard coverage, listener bind forms, token/logging call
+  sites, artifact `BuyerToken` usage, temp/config file writes, subprocess env
+  inheritance, `CGO_ENABLED`, and `${VAR}` placeholders in scenario 17.
+
+STATUS: SECURITY lane — CRITICAL=0 HIGH=0 MEDIUM=0 LOW=0 INFO=0

--- a/test/network-harness/README.md
+++ b/test/network-harness/README.md
@@ -115,6 +115,71 @@ Other targets supported by editing `target.gateway_url` / `target.coordinator_ur
   + `gateway_db_path` instead of `_ssh` variants for local files.
 - **Local stack (synthetic provider)** — via `test/integration` helpers.
   Best for harness self-validation, but won't catch real-model quirks.
+- **Embedded local rig** — see next section. For load/fairness scenarios
+  (17+) the harness spawns its own coord + gateway + N fake providers
+  on 127.0.0.1. No Pearl traffic, no real hardware needed.
+
+## Embedded local rig (load/fairness scenarios)
+
+Load-lane scenarios (`17_sustained_load_baseline.yaml` and follow-ons)
+drive 20+ concurrent buyers — too much for Pearl. The harness ships an
+embedded rig that starts real `coordinator` + `gateway` binaries on
+127.0.0.1 ephemeral ports, plus N in-process fake providers with
+configurable ttft / tokens-per-sec / capacity. The rig also seeds a
+buyer API key in the gateway and reports the local SQLite paths so
+I1 reconciliation runs end-to-end. Everything is 127.0.0.1-bound; the
+rig never listens on 0.0.0.0.
+
+Bring it up with the standard runner — the rig auto-spawns when a
+scenario declares `target.rig: local`:
+
+```
+./run-scenario.sh 17_sustained_load_baseline.yaml
+```
+
+First run takes ~15s longer (builds `phase4-coordinator/cmd/coordinator`,
+`phase4-coordinator/cmd/coordinator-cli`, `phase5-gateway/cmd/gateway`);
+subsequent runs in the same session reuse the cached binaries under the
+rig tempdir. On SIGINT or scenario completion the rig kills all child
+processes and cleans its tempdir.
+
+Scenario YAML shape:
+
+```yaml
+target:
+  rig: local
+  providers:
+    - id: fake-fast
+      model: mlx-community/Qwen2.5-Coder-7B-Instruct-4bit
+      ttft_ms: 50
+      tokens_per_sec: 120
+      capacity_slots: 4
+    - id: fake-baseline
+      model: mlx-community/Qwen2.5-Coder-7B-Instruct-4bit
+      ttft_ms: 200
+      tokens_per_sec: 80
+      capacity_slots: 4
+```
+
+When `rig: local` is set, `gateway_url`, `coordinator_url`,
+`buyer_token`, `demo_identity`, and the DB path fields are all forbidden
+— the rig supplies them at start time. See `internal/scenario/schema.go`
+`validateRigTarget` for the exact rules.
+
+The rig writes an additional artifact alongside the standard bundle:
+
+- `load_summary.json` — route distribution + fairness metrics (Gini,
+  stddev, max/min ratio) + latency by prompt class + starvation floor.
+  Load-lane scenarios record these; hard-invariant gating (I6+) waits
+  for ≥5 clean runs per phase-A discipline.
+
+### DoS guard (`ALLOW_PROD_LOAD`)
+
+A safety guard rejects `buyers.count > 10` against `*.streamvc.live`
+hosts. Load scenarios must target a rig; the guard catches the authoring
+mistake of leaving `gateway_url: https://api.streamvc.live` in a
+high-concurrency scenario. Override with `ALLOW_PROD_LOAD=1` for a
+one-off soak against production — expect to justify it.
 
 ## DB snapshot mechanics (live runs)
 
@@ -251,6 +316,7 @@ triage reads them as a set.
 | [`scenarios/04_wrong_model.yaml`](scenarios/04_wrong_model.yaml) | 3 buyers, nonexistent model | Negative-path error code + no-charge guarantee | BUYER_TOKEN, PEARL_SSH |
 | [`scenarios/05_mid_stream_drop.yaml`](scenarios/05_mid_stream_drop.yaml) | 1 streaming buyer + chaos kill at t=5s | Gateway behavior on mid-stream provider loss; billing of partial tokens | BUYER_TOKEN, PEARL_SSH, PROVIDER_SSH |
 | [`scenarios/06_cold_start_race.yaml`](scenarios/06_cold_start_race.yaml) | Restart provider, buyer fires before model loads | Cold-start window: queue / error / reroute / hang | BUYER_TOKEN, PEARL_SSH, PROVIDER_SSH |
+| [`scenarios/17_sustained_load_baseline.yaml`](scenarios/17_sustained_load_baseline.yaml) | 20 buyers × 30 requests over 15min against embedded rig | Route distribution + fairness + tail latency + starvation floor at load-lane scale | none (rig is embedded) |
 
 See [`internal/scenario/schema.go`](internal/scenario/schema.go) for the
 authoritative field reference.

--- a/test/network-harness/cmd/harness/main.go
+++ b/test/network-harness/cmd/harness/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -22,12 +23,21 @@ import (
 	"github.com/augstar/macprovider-network-harness/internal/buyer"
 	"github.com/augstar/macprovider-network-harness/internal/chaos"
 	"github.com/augstar/macprovider-network-harness/internal/invariants"
+	"github.com/augstar/macprovider-network-harness/internal/loadmetrics"
+	"github.com/augstar/macprovider-network-harness/internal/localrig"
 	"github.com/augstar/macprovider-network-harness/internal/metrics"
 	"github.com/augstar/macprovider-network-harness/internal/reconcile"
 	"github.com/augstar/macprovider-network-harness/internal/runmeta"
 	"github.com/augstar/macprovider-network-harness/internal/scenario"
 	"github.com/augstar/macprovider-network-harness/internal/skuecon"
 )
+
+// errHardInvariantFail is the sentinel cmdRun returns when the scenario
+// finished cleanly but I1-I4 saw at least one failure. main() maps it to
+// exit code 10 — but AFTER cmdRun's defers (including rig.Shutdown()) run,
+// unlike a direct os.Exit(10) which would leak the rig's child processes
+// and tempdir.
+var errHardInvariantFail = errors.New("hard invariant failed")
 
 func main() {
 	if len(os.Args) < 2 {
@@ -37,6 +47,9 @@ func main() {
 	switch os.Args[1] {
 	case "run":
 		if err := cmdRun(os.Args[2:]); err != nil {
+			if errors.Is(err, errHardInvariantFail) {
+				os.Exit(10)
+			}
 			log.Printf("harness: %v", err)
 			os.Exit(1)
 		}
@@ -172,9 +185,47 @@ func cmdRun(args []string) error {
 		log.Printf("artifact bundle written to %s", filepath.Clean(*outDir))
 		logInvariantSummary(result.Invariants)
 		if result.Invariants.AnyFailed() {
-			os.Exit(10)
+			return errHardInvariantFail
 		}
 		return nil
+	}
+
+	var rig *localrig.Rig
+	if sc.Target.Rig == "local" {
+		rigCfg := localrig.Config{
+			Providers: make([]localrig.Provider, 0, len(sc.Target.Providers)),
+			Logger:    func(line string) { log.Print(line) },
+		}
+		for _, p := range sc.Target.Providers {
+			rigCfg.Providers = append(rigCfg.Providers, localrig.Provider{
+				ID:            p.ID,
+				Model:         p.Model,
+				TTFTMs:        p.TTFTMs,
+				TokensPerSec:  p.TokensPerSec,
+				CapacitySlots: p.CapacitySlots,
+			})
+		}
+		log.Printf("scenario %q: bringing up embedded rig with %d providers", sc.Name, len(rigCfg.Providers))
+		r, err := localrig.Start(ctx, rigCfg)
+		if err != nil {
+			return fmt.Errorf("localrig start: %w", err)
+		}
+		rig = r
+		// Any panic or subsequent error must still tear the rig down;
+		// defer covers the happy path too.
+		defer func() {
+			if err := rig.Shutdown(); err != nil {
+				log.Printf("localrig shutdown: %v", err)
+			}
+		}()
+		// Patch the scenario so downstream code (buyer.Run, reconcile,
+		// invariants) sees rig-supplied endpoints. Validate() has already
+		// rejected the case where any of these were pre-set.
+		sc.Target.GatewayURL = rig.GatewayURL
+		sc.Target.CoordinatorURL = rig.CoordinatorBuyerURL
+		sc.Target.BuyerToken = rig.BuyerToken
+		sc.Target.CoordinatorDBPath = rig.CoordinatorDBPath
+		sc.Target.GatewayDBPath = rig.GatewayDBPath
 	}
 
 	log.Printf("scenario %q: starting %d buyers, target %s for %s (chaos events: %d)",
@@ -186,9 +237,35 @@ func cmdRun(args []string) error {
 		chaosRunner.Start(ctx)
 	}
 
-	results, err := buyer.Run(ctx, sc)
+	// If a rig is running, race its crash channel against buyer.Run so
+	// a coord/gateway death aborts the scenario immediately rather than
+	// letting buyers fire timeouts against a dead endpoint for the full
+	// scenario duration.
+	buyerCtx := ctx
+	if rig != nil {
+		var cancelBuyer context.CancelFunc
+		buyerCtx, cancelBuyer = context.WithCancel(ctx)
+		defer cancelBuyer()
+		go func() {
+			select {
+			case <-rig.Done():
+				log.Printf("localrig: subprocess died mid-run: %v", rig.Err())
+				cancelBuyer()
+			case <-buyerCtx.Done():
+			}
+		}()
+	}
+
+	results, err := buyer.Run(buyerCtx, sc)
 	if err != nil {
 		return fmt.Errorf("buyer run: %w", err)
+	}
+	if rig != nil {
+		select {
+		case <-rig.Done():
+			return fmt.Errorf("localrig: %w", rig.Err())
+		default:
+		}
 	}
 	log.Printf("scenario %q: completed %d requests", sc.Name, len(results))
 	if chaosRunner != nil {
@@ -295,6 +372,20 @@ func cmdRun(args []string) error {
 		return fmt.Errorf("write artifact bundle: %w", err)
 	}
 
+	// load_summary.json — additive fairness + tail-latency + starvation
+	// diagnostics for load-lane scenarios (17+). Written unconditionally
+	// so run-to-run diffs stay schema-stable; non-load scenarios see
+	// empty buckets and a single-entry route distribution.
+	var readyProviders []string
+	for _, p := range sc.Target.Providers {
+		readyProviders = append(readyProviders, p.ID)
+	}
+	loadSum := loadmetrics.Compute(sc, results, readyProviders, nil)
+	if err := writeJSON(filepath.Join(*outDir, "load_summary.json"), loadSum); err != nil {
+		return fmt.Errorf("write load_summary.json: %w", err)
+	}
+	logLoadSummary(loadSum)
+
 	log.Printf("artifact bundle written to %s", filepath.Clean(*outDir))
 	logInvariantSummary(inv)
 	if bench != nil {
@@ -302,7 +393,7 @@ func cmdRun(args []string) error {
 	}
 
 	if inv.AnyFailed() {
-		os.Exit(10)
+		return errHardInvariantFail
 	}
 	return nil
 }
@@ -361,6 +452,37 @@ func logInvariantSummary(inv *invariants.Result) {
 		return
 	}
 	log.Printf("HARD INVARIANT FAILURE — triage %s", time.Now().UTC().Format(time.RFC3339))
+}
+
+// logLoadSummary prints a one-line-per-section snapshot of the load
+// diagnostics so operators can eyeball fairness + tail + starvation
+// without opening the JSON. Phase-A discipline: printed, not asserted.
+func logLoadSummary(s *loadmetrics.Summary) {
+	if s == nil {
+		return
+	}
+	if len(s.RouteDistribution) > 0 {
+		parts := make([]string, 0, len(s.RouteDistribution))
+		for _, e := range s.RouteDistribution {
+			parts = append(parts, fmt.Sprintf("%s=%.1f%%(%d)", e.ProviderID, e.Share*100, e.Requests))
+		}
+		log.Printf("[load] route distribution: %s", strings.Join(parts, " "))
+	}
+	if s.Fairness.ProviderCount > 0 {
+		log.Printf("[load] fairness: gini=%.3f stddev=%.2f max/min=%.2f over %d providers",
+			s.Fairness.Gini, s.Fairness.Stddev, s.Fairness.MaxMinRatio, s.Fairness.ProviderCount)
+	}
+	for label, b := range s.LatencyByPromptClass {
+		if b.Count == 0 {
+			continue
+		}
+		log.Printf("[load] latency %s (count=%d): p50=%.0fms p95=%.0fms p99=%.0fms", label, b.Count, b.P50, b.P95, b.P99)
+	}
+	if s.Starvation.ReadyProviderCount > 0 {
+		log.Printf("[load] starvation floor: min=%d on %s (window=%.0fs; zero-success=%v)",
+			s.Starvation.MinRequestsPerReadyProvider, s.Starvation.MinRequestsProviderID,
+			s.Starvation.WindowSeconds, s.Starvation.ProvidersWithZeroSuccess)
+	}
 }
 
 // logBenchmarkSummary mirrors logInvariantSummary for the B-invariants.

--- a/test/network-harness/go.mod
+++ b/test/network-harness/go.mod
@@ -3,12 +3,15 @@ module github.com/augstar/macprovider-network-harness
 go 1.26
 
 require (
+	github.com/gobwas/ws v1.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.52.0
 )
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/gobwas/httphead v0.1.0 // indirect
+	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/test/network-harness/go.sum
+++ b/test/network-harness/go.sum
@@ -1,5 +1,11 @@
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
+github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
+github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
+github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
+github.com/gobwas/ws v1.4.0 h1:CTaoG1tojrh4ucGPcoJFiAQUAsEWekEWvLy7GsVNqGs=
+github.com/gobwas/ws v1.4.0/go.mod h1:G3gNqMNtPppf5XUz7O4shetPpcZ1VJ7zt18dlUeakrc=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/test/network-harness/internal/loadmetrics/summary.go
+++ b/test/network-harness/internal/loadmetrics/summary.go
@@ -1,0 +1,453 @@
+// Package loadmetrics computes fairness + tail-latency + starvation
+// diagnostics for load-lane scenarios (17+). It runs additively on top
+// of the standard metrics.Aggregate pipeline: reads the same []buyer.Result
+// slice and the scenario config, emits load_summary.json into the
+// artifact bundle. No mutation of package metrics; if the shared
+// aggregator later grows these fields, this package folds in.
+//
+// Phase-A discipline: every value here is RECORDED, not asserted. The
+// four hard invariants (I1-I4) remain the only pass/fail gate; load
+// scenarios promote metrics to soft benchmarks after ≥5 clean runs
+// establish stability (see BUILD_SPEC LOAD/FAIRNESS §4).
+package loadmetrics
+
+import (
+	"math"
+	"sort"
+
+	"github.com/augstar/macprovider-network-harness/internal/buyer"
+	"github.com/augstar/macprovider-network-harness/internal/scenario"
+)
+
+// Summary is the top-level load_summary.json object. Fields are
+// deliberately shallow so triage can grep them directly.
+type Summary struct {
+	// WindowSeconds is the scenario wall-clock: EndUTC - StartUTC of the
+	// buyer fleet's firing window. Zero when no requests completed.
+	WindowSeconds float64 `json:"window_seconds"`
+
+	// RouteDistribution reports per-provider request counts + share of
+	// total-successful, sorted by descending share for readability.
+	RouteDistribution []RouteEntry `json:"route_distribution"`
+
+	// Fairness collapses the distribution into three headline numbers.
+	// Baseline PR reports all three; phase-B triage picks the one the
+	// load lane will invariant-gate on after ≥5 clean runs.
+	Fairness FairnessMetrics `json:"fairness"`
+
+	// LatencyByPromptClass buckets total-latency histograms by prompt
+	// max_tokens class. Baseline scenario 17 uses two buckets — short
+	// (max_tokens<=32) and medium (33..512) — but the bucketing is
+	// generic so future scenarios can add long.
+	LatencyByPromptClass map[string]LatencyBucket `json:"latency_by_prompt_class"`
+
+	// Starvation captures the minimum successful-request count observed
+	// across all providers that the rig knows to be Ready. On non-rig
+	// runs (RigProviderIDs empty), the floor is over provider IDs that
+	// appear at least once in the route distribution — same "any Ready
+	// provider" intent, best-effort classification.
+	Starvation StarvationFloor `json:"starvation_floor"`
+}
+
+// RouteEntry is one provider's slice of the total-successful request
+// count. Providers with zero successes are included when they appear
+// in ReadyProviderIDs so operators see the starvation shape without
+// scrolling into Starvation.
+type RouteEntry struct {
+	ProviderID string  `json:"provider_id"`
+	Requests   int     `json:"requests"`
+	Share      float64 `json:"share"`
+}
+
+// FairnessMetrics computes three complementary summaries of the route
+// distribution. See docstrings for the tradeoffs — beta providers care
+// about MaxMinRatio (least fair provider vs most fair); routing-policy
+// authors care about Gini; simple ops care about Stddev.
+type FairnessMetrics struct {
+	// Gini is the Gini coefficient of the per-provider request counts,
+	// computed over ReadyProviderIDs (zero-count providers included).
+	// 0 = perfectly equal, 1 = one provider took everything. Undefined
+	// (reported as 0) when the ready-provider set is empty.
+	Gini float64 `json:"gini"`
+
+	// Stddev is the population standard deviation of per-provider
+	// request counts over ReadyProviderIDs. Same scale as request count.
+	Stddev float64 `json:"stddev"`
+
+	// MaxMinRatio is max(requests) / max(1, min(requests)) over
+	// ReadyProviderIDs. Guards against div-by-zero when a Ready provider
+	// received zero successes — the ratio then reflects "worst provider
+	// got at most 1" which understates the imbalance but keeps the value
+	// finite. Companion Starvation.MinRequestsPerReadyProvider carries
+	// the raw min so triage can tell.
+	MaxMinRatio float64 `json:"max_min_ratio"`
+
+	// ProviderCount is the number of ready providers folded into all
+	// three fairness figures. Useful sanity check when reading the JSON.
+	ProviderCount int `json:"provider_count"`
+}
+
+// LatencyBucket is per-class total-latency histogram + count. Fields
+// mirror metrics.Histogram to keep the artifact readable, but this
+// package deliberately does not import metrics — dependency inversion
+// keeps the shared aggregator refactor optional.
+type LatencyBucket struct {
+	Count int     `json:"count"`
+	P50   float64 `json:"p50_ms"`
+	P95   float64 `json:"p95_ms"`
+	P99   float64 `json:"p99_ms"`
+	Mean  float64 `json:"mean_ms"`
+	Max   float64 `json:"max_ms"`
+
+	// MaxTokensLower/Upper document the class boundaries (inclusive) so
+	// a reader knows what "short_16tok" actually covers.
+	MaxTokensLower int `json:"max_tokens_lower"`
+	MaxTokensUpper int `json:"max_tokens_upper"`
+}
+
+// StarvationFloor answers "did every Ready provider serve ≥N successful
+// requests over the window?". A provider that was Ready at start and
+// dropped mid-run counts as Ready — the harness cannot observe
+// mid-run drop for PR 1, so the field is measured against
+// ReadyProviderIDs known at rig-start time.
+type StarvationFloor struct {
+	MinRequestsPerReadyProvider int      `json:"min_requests_per_ready_provider"`
+	MinRequestsProviderID       string   `json:"min_requests_provider_id"`
+	WindowSeconds               float64  `json:"window_seconds"`
+	ReadyProviderCount          int      `json:"ready_provider_count"`
+	ProvidersWithZeroSuccess    []string `json:"providers_with_zero_success"`
+	// TODO(PR-2+): account for providers that were Ready at start but
+	// disconnected mid-run. Localrig gains a lifecycle event log and
+	// this field starts consulting it. For PR 1, "Ready" is a
+	// static-at-start snapshot from the rig config.
+}
+
+// Class defines one prompt-class bucket for LatencyByPromptClass. The
+// label goes into the JSON key; MaxTokensLower/Upper form an inclusive
+// range on Prompt.MaxTokens. Ordering of the input slice does not
+// matter — Compute picks the first matching class per result.
+type Class struct {
+	Label          string
+	MaxTokensLower int
+	MaxTokensUpper int
+}
+
+// DefaultClasses matches scenario 17's short/medium split. Long-token
+// scenarios in future PRs will pass their own classes.
+var DefaultClasses = []Class{
+	{Label: "short_16tok", MaxTokensLower: 1, MaxTokensUpper: 32},
+	{Label: "medium_200tok", MaxTokensLower: 33, MaxTokensUpper: 512},
+}
+
+// Compute produces a Summary from the buyer results + scenario config.
+// readyProviderIDs is the rig-known Ready set at start-of-fleet; on
+// non-rig runs, pass nil and the function falls back to the set of
+// provider IDs that appear in the results.
+//
+// Empty inputs → zero-value Summary; the callers write the JSON either
+// way so downstream tools see a stable schema.
+func Compute(sc *scenario.Scenario, results []buyer.Result, readyProviderIDs []string, classes []Class) *Summary {
+	if len(classes) == 0 {
+		classes = DefaultClasses
+	}
+
+	sum := &Summary{
+		LatencyByPromptClass: map[string]LatencyBucket{},
+	}
+
+	// Window: earliest StartUTC to latest EndUTC across all results
+	// (successful or not — the window is a scenario property, not a
+	// success property).
+	if len(results) > 0 {
+		startTs := results[0].StartUTC
+		endTs := results[0].EndUTC
+		for _, r := range results {
+			if r.StartUTC.Before(startTs) {
+				startTs = r.StartUTC
+			}
+			if r.EndUTC.After(endTs) {
+				endTs = r.EndUTC
+			}
+		}
+		if !endTs.Before(startTs) {
+			sum.WindowSeconds = endTs.Sub(startTs).Seconds()
+		}
+	}
+
+	// Route distribution: only successful requests count. Failed
+	// requests carry no reliable provider attribution — a 502 may
+	// have never touched a provider at all.
+	perProvider := map[string]int{}
+	seenInResults := map[string]bool{}
+	for _, r := range results {
+		if r.RouteProviderID != "" {
+			seenInResults[r.RouteProviderID] = true
+		}
+		if r.Outcome != "ok" {
+			continue
+		}
+		if r.RouteProviderID == "" {
+			continue
+		}
+		perProvider[r.RouteProviderID]++
+	}
+
+	// Ready set determination: rig-supplied wins; else fall back to
+	// providers seen in results. Non-rig runs miss zero-request
+	// providers (they never appeared), which is a known limitation
+	// noted in the field's docstring.
+	readySet := map[string]struct{}{}
+	if len(readyProviderIDs) > 0 {
+		for _, id := range readyProviderIDs {
+			readySet[id] = struct{}{}
+		}
+	} else {
+		for id := range seenInResults {
+			readySet[id] = struct{}{}
+		}
+	}
+
+	// Emit route entries for the union of (ready set, providers seen
+	// in results) so a request that landed on an unexpected provider
+	// still shows up. Zero-request Ready providers get share=0.
+	displayIDs := map[string]struct{}{}
+	for id := range readySet {
+		displayIDs[id] = struct{}{}
+	}
+	for id := range perProvider {
+		displayIDs[id] = struct{}{}
+	}
+
+	total := 0
+	for _, n := range perProvider {
+		total += n
+	}
+	entries := make([]RouteEntry, 0, len(displayIDs))
+	for id := range displayIDs {
+		n := perProvider[id]
+		share := 0.0
+		if total > 0 {
+			share = float64(n) / float64(total)
+		}
+		entries = append(entries, RouteEntry{ProviderID: id, Requests: n, Share: share})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Requests != entries[j].Requests {
+			return entries[i].Requests > entries[j].Requests
+		}
+		return entries[i].ProviderID < entries[j].ProviderID
+	})
+	sum.RouteDistribution = entries
+
+	// Fairness: computed over the Ready set only. Empty ready set →
+	// zero-value FairnessMetrics; ProviderCount=0 signals "not enough
+	// data" to triage without a special-case value.
+	readyCounts := make([]int, 0, len(readySet))
+	for id := range readySet {
+		readyCounts = append(readyCounts, perProvider[id])
+	}
+	sort.Ints(readyCounts)
+	sum.Fairness = FairnessMetrics{
+		ProviderCount: len(readyCounts),
+		Gini:          gini(readyCounts),
+		Stddev:        stddev(readyCounts),
+		MaxMinRatio:   maxMinRatio(readyCounts),
+	}
+
+	// Latency-by-class: bucket each ok result by its prompt's
+	// max_tokens, derived deterministically from the scenario's
+	// PromptFor(buyerIdx, reqIdx) so we don't need to store MaxTokens
+	// in buyer.Result.
+	perClassLatencies := map[string][]float64{}
+	classIndex := indexClasses(classes)
+	for _, r := range results {
+		if r.Outcome != "ok" || r.TotalMillis <= 0 {
+			continue
+		}
+		if sc == nil {
+			continue
+		}
+		p := sc.PromptFor(r.BuyerIndex, r.RequestIndex)
+		label, ok := classIndex.match(p.MaxTokens)
+		if !ok {
+			continue
+		}
+		perClassLatencies[label] = append(perClassLatencies[label], float64(r.TotalMillis))
+	}
+	for _, c := range classes {
+		xs, ok := perClassLatencies[c.Label]
+		if !ok {
+			// Emit an empty bucket so schema is stable — future runs
+			// diff cleanly against ones that had no short requests.
+			sum.LatencyByPromptClass[c.Label] = LatencyBucket{
+				MaxTokensLower: c.MaxTokensLower,
+				MaxTokensUpper: c.MaxTokensUpper,
+			}
+			continue
+		}
+		bucket := histogram(xs)
+		bucket.MaxTokensLower = c.MaxTokensLower
+		bucket.MaxTokensUpper = c.MaxTokensUpper
+		sum.LatencyByPromptClass[c.Label] = bucket
+	}
+
+	// Starvation floor. Only meaningful over the Ready set — a
+	// provider that isn't in ReadyProviderIDs was never expected to
+	// serve. Zero-success Ready providers are captured explicitly.
+	starv := StarvationFloor{
+		WindowSeconds:      sum.WindowSeconds,
+		ReadyProviderCount: len(readySet),
+	}
+	if len(readySet) > 0 {
+		minCount := math.MaxInt
+		minID := ""
+		zeros := []string{}
+		for id := range readySet {
+			n := perProvider[id]
+			if n < minCount {
+				minCount = n
+				minID = id
+			}
+			if n == 0 {
+				zeros = append(zeros, id)
+			}
+		}
+		sort.Strings(zeros)
+		starv.MinRequestsPerReadyProvider = minCount
+		starv.MinRequestsProviderID = minID
+		starv.ProvidersWithZeroSuccess = zeros
+	}
+	sum.Starvation = starv
+
+	return sum
+}
+
+// gini computes the standard Gini coefficient on a non-negative int
+// slice, sorted ascending. Formula: (Σ (2i - n - 1) x_i) / (n Σ x_i)
+// where i is 1-indexed. Zero-total distributions return 0 (no
+// inequality to measure).
+func gini(sortedAsc []int) float64 {
+	n := len(sortedAsc)
+	if n == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, x := range sortedAsc {
+		sum += float64(x)
+	}
+	if sum == 0 {
+		return 0
+	}
+	weighted := 0.0
+	for i, x := range sortedAsc {
+		weighted += float64(2*(i+1)-n-1) * float64(x)
+	}
+	return weighted / (float64(n) * sum)
+}
+
+// stddev computes population stddev over int counts. Zero-length input
+// → 0.
+func stddev(xs []int) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	mean := 0.0
+	for _, x := range xs {
+		mean += float64(x)
+	}
+	mean /= float64(len(xs))
+	sq := 0.0
+	for _, x := range xs {
+		d := float64(x) - mean
+		sq += d * d
+	}
+	return math.Sqrt(sq / float64(len(xs)))
+}
+
+// maxMinRatio returns max / max(1, min). Zero-length or all-zero →
+// 0. The max(1, min) floor is documented in FairnessMetrics doc — it
+// hides raw-zero starvation, so triage should always read
+// Starvation.ProvidersWithZeroSuccess alongside this figure.
+func maxMinRatio(xs []int) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	mn, mx := xs[0], xs[0]
+	for _, x := range xs {
+		if x < mn {
+			mn = x
+		}
+		if x > mx {
+			mx = x
+		}
+	}
+	if mx == 0 {
+		return 0
+	}
+	denom := mn
+	if denom < 1 {
+		denom = 1
+	}
+	return float64(mx) / float64(denom)
+}
+
+// histogram computes the same p50/p95/p99/mean/max shape as
+// metrics.Histogram, over a slice of latencies (ms). Nearest-rank per
+// existing convention.
+func histogram(xs []float64) LatencyBucket {
+	if len(xs) == 0 {
+		return LatencyBucket{}
+	}
+	sorted := append([]float64(nil), xs...)
+	sort.Float64s(sorted)
+	sum := 0.0
+	for _, v := range sorted {
+		sum += v
+	}
+	return LatencyBucket{
+		Count: len(sorted),
+		P50:   pct(sorted, 0.50),
+		P95:   pct(sorted, 0.95),
+		P99:   pct(sorted, 0.99),
+		Mean:  sum / float64(len(sorted)),
+		Max:   sorted[len(sorted)-1],
+	}
+}
+
+func pct(sortedAsc []float64, q float64) float64 {
+	if len(sortedAsc) == 0 {
+		return 0
+	}
+	idx := int(math.Ceil(q*float64(len(sortedAsc)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sortedAsc) {
+		idx = len(sortedAsc) - 1
+	}
+	return sortedAsc[idx]
+}
+
+// classIndex accelerates prompt-max_tokens → class-label lookup. Built
+// once per Compute call.
+type classIndex struct {
+	classes []Class
+}
+
+func indexClasses(cs []Class) classIndex {
+	out := make([]Class, len(cs))
+	copy(out, cs)
+	return classIndex{classes: out}
+}
+
+func (ci classIndex) match(maxTokens int) (string, bool) {
+	if maxTokens <= 0 {
+		return "", false
+	}
+	for _, c := range ci.classes {
+		if maxTokens >= c.MaxTokensLower && maxTokens <= c.MaxTokensUpper {
+			return c.Label, true
+		}
+	}
+	return "", false
+}

--- a/test/network-harness/internal/loadmetrics/summary_test.go
+++ b/test/network-harness/internal/loadmetrics/summary_test.go
@@ -1,0 +1,279 @@
+package loadmetrics
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-network-harness/internal/buyer"
+	"github.com/augstar/macprovider-network-harness/internal/scenario"
+)
+
+// Helper: build a scenario with two prompts (short + medium) so
+// PromptFor(buyerIdx, reqIdx) alternates classes.
+func demoScenario() *scenario.Scenario {
+	return &scenario.Scenario{
+		Prompts: []scenario.Prompt{
+			{Model: "test", User: "hi", MaxTokens: 16},
+			{Model: "test", User: "hi", MaxTokens: 200},
+		},
+	}
+}
+
+func TestGini_EqualDistribution_Zero(t *testing.T) {
+	if g := gini([]int{10, 10, 10}); g != 0 {
+		t.Fatalf("gini(equal) = %v, want 0", g)
+	}
+}
+
+func TestGini_MaxInequality(t *testing.T) {
+	// One provider took everything; Gini approaches (n-1)/n for large n.
+	g := gini([]int{0, 0, 0, 100})
+	want := (4.0 - 1.0) / 4.0
+	if math.Abs(g-want) > 1e-9 {
+		t.Fatalf("gini(one-takes-all) = %v, want %v", g, want)
+	}
+}
+
+func TestGini_ZeroTotal(t *testing.T) {
+	if g := gini([]int{0, 0, 0}); g != 0 {
+		t.Fatalf("gini(all-zero) = %v, want 0", g)
+	}
+}
+
+func TestGini_Empty(t *testing.T) {
+	if g := gini(nil); g != 0 {
+		t.Fatalf("gini(nil) = %v, want 0", g)
+	}
+}
+
+func TestStddev_Empty_Zero(t *testing.T) {
+	if s := stddev(nil); s != 0 {
+		t.Fatalf("stddev(nil) = %v", s)
+	}
+}
+
+func TestStddev_Uniform_Zero(t *testing.T) {
+	if s := stddev([]int{5, 5, 5}); s != 0 {
+		t.Fatalf("stddev(uniform) = %v", s)
+	}
+}
+
+func TestStddev_Known(t *testing.T) {
+	// Population stddev of {2,4,4,4,5,5,7,9} is exactly 2.
+	got := stddev([]int{2, 4, 4, 4, 5, 5, 7, 9})
+	if math.Abs(got-2.0) > 1e-9 {
+		t.Fatalf("stddev = %v, want 2", got)
+	}
+}
+
+func TestMaxMinRatio_ZeroFloor(t *testing.T) {
+	// min=0 must not divide by zero.
+	r := maxMinRatio([]int{0, 100})
+	if r != 100 {
+		t.Fatalf("ratio(0,100) = %v, want 100", r)
+	}
+}
+
+func TestMaxMinRatio_Uniform(t *testing.T) {
+	r := maxMinRatio([]int{7, 7, 7})
+	if r != 1 {
+		t.Fatalf("ratio(uniform) = %v, want 1", r)
+	}
+}
+
+func TestMaxMinRatio_AllZero(t *testing.T) {
+	if r := maxMinRatio([]int{0, 0}); r != 0 {
+		t.Fatalf("ratio(all-zero) = %v", r)
+	}
+}
+
+func TestPct_NearestRank(t *testing.T) {
+	xs := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	if p := pct(xs, 0.50); p != 5 {
+		t.Fatalf("p50 = %v, want 5", p)
+	}
+	if p := pct(xs, 0.95); p != 10 {
+		t.Fatalf("p95 = %v, want 10", p)
+	}
+	if p := pct(xs, 0.99); p != 10 {
+		t.Fatalf("p99 = %v, want 10", p)
+	}
+}
+
+func TestPct_Empty_Zero(t *testing.T) {
+	if p := pct(nil, 0.5); p != 0 {
+		t.Fatalf("pct(nil) = %v", p)
+	}
+}
+
+func TestHistogram_Single(t *testing.T) {
+	h := histogram([]float64{42})
+	if h.P50 != 42 || h.P95 != 42 || h.P99 != 42 || h.Mean != 42 || h.Max != 42 || h.Count != 1 {
+		t.Fatalf("single-element histogram = %+v", h)
+	}
+}
+
+func TestCompute_EvenDistribution(t *testing.T) {
+	sc := demoScenario()
+	base := time.Unix(1_800_000_000, 0).UTC()
+	results := []buyer.Result{}
+	for i := 0; i < 6; i++ {
+		results = append(results, buyer.Result{
+			BuyerIndex: i, RequestIndex: 0,
+			Outcome:         "ok",
+			RouteProviderID: []string{"A", "B", "C"}[i%3],
+			TotalMillis:     100,
+			StartUTC:        base,
+			EndUTC:          base.Add(time.Second),
+		})
+	}
+	sum := Compute(sc, results, []string{"A", "B", "C"}, nil)
+	if len(sum.RouteDistribution) != 3 {
+		t.Fatalf("routes = %d, want 3", len(sum.RouteDistribution))
+	}
+	for _, e := range sum.RouteDistribution {
+		if e.Requests != 2 || math.Abs(e.Share-1.0/3.0) > 1e-9 {
+			t.Fatalf("uneven share for %s: %+v", e.ProviderID, e)
+		}
+	}
+	if sum.Fairness.Gini != 0 {
+		t.Fatalf("gini = %v, want 0 (even)", sum.Fairness.Gini)
+	}
+	if sum.Fairness.MaxMinRatio != 1 {
+		t.Fatalf("ratio = %v, want 1", sum.Fairness.MaxMinRatio)
+	}
+	if sum.Starvation.MinRequestsPerReadyProvider != 2 {
+		t.Fatalf("floor = %v, want 2", sum.Starvation.MinRequestsPerReadyProvider)
+	}
+	if len(sum.Starvation.ProvidersWithZeroSuccess) != 0 {
+		t.Fatalf("unexpected zero-success providers: %v", sum.Starvation.ProvidersWithZeroSuccess)
+	}
+}
+
+func TestCompute_StarvedProvider(t *testing.T) {
+	sc := demoScenario()
+	base := time.Unix(1_800_000_000, 0).UTC()
+	results := []buyer.Result{}
+	for i := 0; i < 10; i++ {
+		results = append(results, buyer.Result{
+			BuyerIndex: i, RequestIndex: 0,
+			Outcome: "ok", RouteProviderID: "A",
+			TotalMillis: 100, StartUTC: base, EndUTC: base.Add(time.Second),
+		})
+	}
+	sum := Compute(sc, results, []string{"A", "B", "C"}, nil)
+	if sum.Starvation.MinRequestsPerReadyProvider != 0 {
+		t.Fatalf("floor = %v, want 0 (B and C got nothing)", sum.Starvation.MinRequestsPerReadyProvider)
+	}
+	if len(sum.Starvation.ProvidersWithZeroSuccess) != 2 {
+		t.Fatalf("zero-success providers = %v, want 2", sum.Starvation.ProvidersWithZeroSuccess)
+	}
+	// A took 10/10 = 1.0 share; B, C = 0.
+	found := map[string]float64{}
+	for _, e := range sum.RouteDistribution {
+		found[e.ProviderID] = e.Share
+	}
+	if found["A"] != 1.0 || found["B"] != 0 || found["C"] != 0 {
+		t.Fatalf("shares = %v", found)
+	}
+}
+
+func TestCompute_LatencyByPromptClass(t *testing.T) {
+	sc := demoScenario() // Prompt 0 max_tokens=16 (short), Prompt 1 max_tokens=200 (medium)
+	base := time.Unix(1_800_000_000, 0).UTC()
+	results := []buyer.Result{
+		// PromptFor(0,0) → prompt 0 (short)
+		{BuyerIndex: 0, RequestIndex: 0, Outcome: "ok", RouteProviderID: "A", TotalMillis: 100, StartUTC: base, EndUTC: base.Add(time.Second)},
+		// PromptFor(0,1) → prompt 1 (medium)
+		{BuyerIndex: 0, RequestIndex: 1, Outcome: "ok", RouteProviderID: "A", TotalMillis: 500, StartUTC: base, EndUTC: base.Add(time.Second)},
+		// PromptFor(1,0) → prompt 1 (medium)
+		{BuyerIndex: 1, RequestIndex: 0, Outcome: "ok", RouteProviderID: "A", TotalMillis: 700, StartUTC: base, EndUTC: base.Add(time.Second)},
+	}
+	sum := Compute(sc, results, []string{"A"}, nil)
+	short := sum.LatencyByPromptClass["short_16tok"]
+	medium := sum.LatencyByPromptClass["medium_200tok"]
+	if short.Count != 1 || short.P50 != 100 {
+		t.Fatalf("short bucket = %+v", short)
+	}
+	if medium.Count != 2 || medium.P50 != 500 {
+		t.Fatalf("medium bucket = %+v", medium)
+	}
+	if short.MaxTokensLower != 1 || short.MaxTokensUpper != 32 {
+		t.Fatalf("short bounds = [%d,%d]", short.MaxTokensLower, short.MaxTokensUpper)
+	}
+}
+
+func TestCompute_LatencyByPromptClass_EmptyBucketStillEmitted(t *testing.T) {
+	sc := demoScenario()
+	sum := Compute(sc, nil, []string{"A"}, nil)
+	// Both default classes must be present with count=0 so downstream
+	// tools that diff runs never see a missing key.
+	if _, ok := sum.LatencyByPromptClass["short_16tok"]; !ok {
+		t.Fatalf("short_16tok missing from empty run")
+	}
+	if _, ok := sum.LatencyByPromptClass["medium_200tok"]; !ok {
+		t.Fatalf("medium_200tok missing from empty run")
+	}
+}
+
+func TestCompute_FailedRequestsIgnoredInRouting(t *testing.T) {
+	sc := demoScenario()
+	base := time.Unix(1_800_000_000, 0).UTC()
+	results := []buyer.Result{
+		{BuyerIndex: 0, RequestIndex: 0, Outcome: "ok", RouteProviderID: "A", TotalMillis: 100, StartUTC: base, EndUTC: base.Add(time.Second)},
+		{BuyerIndex: 1, RequestIndex: 0, Outcome: "http_error", RouteProviderID: "A", TotalMillis: 200, StartUTC: base, EndUTC: base.Add(time.Second)},
+		{BuyerIndex: 2, RequestIndex: 0, Outcome: "timeout", RouteProviderID: "B", TotalMillis: 60000, StartUTC: base, EndUTC: base.Add(time.Second)},
+	}
+	sum := Compute(sc, results, []string{"A", "B"}, nil)
+	var aReq int
+	for _, e := range sum.RouteDistribution {
+		if e.ProviderID == "A" {
+			aReq = e.Requests
+		}
+	}
+	if aReq != 1 {
+		t.Fatalf("A requests = %d, want 1 (failed excluded)", aReq)
+	}
+}
+
+func TestCompute_FallbackReadySetFromResults(t *testing.T) {
+	// No rig-supplied Ready set — Compute must fall back to
+	// providers that appear in results (successful OR not).
+	sc := demoScenario()
+	base := time.Unix(1_800_000_000, 0).UTC()
+	results := []buyer.Result{
+		{BuyerIndex: 0, RequestIndex: 0, Outcome: "ok", RouteProviderID: "A", TotalMillis: 100, StartUTC: base, EndUTC: base.Add(time.Second)},
+		{BuyerIndex: 1, RequestIndex: 0, Outcome: "http_error", RouteProviderID: "B", TotalMillis: 200, StartUTC: base, EndUTC: base.Add(time.Second)},
+	}
+	sum := Compute(sc, results, nil, nil)
+	if sum.Starvation.ReadyProviderCount != 2 {
+		t.Fatalf("fallback ready count = %d, want 2", sum.Starvation.ReadyProviderCount)
+	}
+}
+
+func TestCompute_WindowSeconds(t *testing.T) {
+	sc := demoScenario()
+	start := time.Unix(1_800_000_000, 0).UTC()
+	results := []buyer.Result{
+		{BuyerIndex: 0, RequestIndex: 0, Outcome: "ok", TotalMillis: 100, StartUTC: start, EndUTC: start.Add(2 * time.Second)},
+		{BuyerIndex: 1, RequestIndex: 0, Outcome: "ok", TotalMillis: 100, StartUTC: start.Add(1 * time.Second), EndUTC: start.Add(10 * time.Second)},
+	}
+	sum := Compute(sc, results, []string{"A"}, nil)
+	if sum.WindowSeconds != 10 {
+		t.Fatalf("window = %v, want 10", sum.WindowSeconds)
+	}
+}
+
+func TestClassIndex_UnknownMaxTokensSkipped(t *testing.T) {
+	ci := indexClasses(DefaultClasses)
+	if _, ok := ci.match(0); ok {
+		t.Fatalf("zero max_tokens should not match any class")
+	}
+	if _, ok := ci.match(9999); ok {
+		t.Fatalf("out-of-range max_tokens should not match any class")
+	}
+	if lbl, ok := ci.match(16); !ok || lbl != "short_16tok" {
+		t.Fatalf("16 → %q,%v", lbl, ok)
+	}
+}

--- a/test/network-harness/internal/localrig/build.go
+++ b/test/network-harness/internal/localrig/build.go
@@ -1,0 +1,114 @@
+package localrig
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// findRepoRoot walks up from CWD looking for the repo markers used by
+// test/integration: a Makefile alongside a phase4-coordinator/ dir.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "Makefile")); err == nil {
+			if _, err := os.Stat(filepath.Join(dir, "phase4-coordinator")); err == nil {
+				return dir, nil
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not locate repo root from %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// buildBinaries builds coordinator, coordinator-cli, and gateway into
+// binDir. If all three already exist under binDir the build is skipped
+// (per-Rig cache; the second scenario in the same WorkDir gets an
+// instant boot). Returns absolute paths.
+//
+// ctx is propagated to each `go build` child — SIGINT during the ~15s
+// cold build cancels the sub-process promptly, so a caller cancel is
+// observable inside Start rather than blocking until the compiler is
+// done.
+func buildBinaries(ctx context.Context, repoRoot, binDir string) (coord, coordCLI, gw string, err error) {
+	coord = filepath.Join(binDir, "coordinator")
+	coordCLI = filepath.Join(binDir, "coordinator-cli")
+	gw = filepath.Join(binDir, "gateway")
+	if fileExists(coord) && fileExists(coordCLI) && fileExists(gw) {
+		return coord, coordCLI, gw, nil
+	}
+	if err := buildOne(ctx, filepath.Join(repoRoot, "phase4-coordinator"), "./cmd/coordinator", coord); err != nil {
+		return "", "", "", err
+	}
+	if err := buildOne(ctx, filepath.Join(repoRoot, "phase4-coordinator"), "./cmd/coordinator-cli", coordCLI); err != nil {
+		return "", "", "", err
+	}
+	if err := buildOne(ctx, filepath.Join(repoRoot, "phase5-gateway"), "./cmd/gateway", gw); err != nil {
+		return "", "", "", err
+	}
+	return coord, coordCLI, gw, nil
+}
+
+func buildOne(ctx context.Context, modDir, pkg, outPath string) error {
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", outPath, pkg)
+	cmd.Dir = modDir
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("build %s cancelled: %w", pkg, ctxErr)
+		}
+		return fmt.Errorf("build %s in %s: %v\n%s", pkg, modDir, err, string(out))
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && !fi.IsDir()
+}
+
+// randHex returns 2n hex chars of crypto-random bytes.
+func randHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// streamPipes wires cmd's stdout+stderr through logger, one line each.
+// Must be called before cmd.Start().
+func streamPipes(cmd *exec.Cmd, logger func(string)) error {
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	go pump(stdout, logger)
+	go pump(stderr, logger)
+	return nil
+}
+
+func pump(r io.ReadCloser, logger func(string)) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		logger(scanner.Text())
+	}
+}

--- a/test/network-harness/internal/localrig/coord.go
+++ b/test/network-harness/internal/localrig/coord.go
@@ -1,0 +1,286 @@
+package localrig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type coordYAMLInputs struct {
+	buyerPort           int
+	provPort            int
+	dbPath              string
+	operatorKey         string
+	gatewayServiceToken string
+	providers           []Provider
+	providerPorts       []int
+}
+
+// writeCoordinatorYAML mirrors the fields test/integration writes for a
+// pinned-providers stack, adapted for the load rig:
+//   - settlement is off (verified_model_settlement_mode="observe"),
+//   - require_provider_tokens=true (we issue tokens per provider),
+//   - admission.pinned_only=true (every rig provider is pinned),
+//   - sticky_enabled=false (baseline scenario 17 is non-sticky).
+func writeCoordinatorYAML(path string, in coordYAMLInputs) error {
+	providersCfg := make([]map[string]any, len(in.providers))
+	for i, p := range in.providers {
+		providersCfg[i] = map[string]any{
+			"provider_id":  p.ID,
+			"endpoint_url": fmt.Sprintf("http://127.0.0.1:%d", in.providerPorts[i]),
+			"display_name": fmt.Sprintf("fake-%s", p.ID),
+		}
+	}
+	cfg := map[string]any{
+		"listen": map[string]any{
+			"buyer_port":    in.buyerPort,
+			"provider_port": in.provPort,
+			"bind_address":  "127.0.0.1",
+		},
+		"pool": map[string]any{
+			"heartbeat_interval_s":       1,
+			"disconnect_grace_period_s":  30,
+			"heartbeat_miss_threshold_s": 90,
+			"wake_gap_threshold_s":       120,
+			"warmup_fallback_s":          60,
+			"warmup_gate_enabled":        false,
+			"degraded_backoff_s":         30,
+			"degraded_max_retries":       3,
+			"degraded_probe_after_502":   true,
+			"breaker_failure_threshold":  2,
+			"breaker_window_s":           120,
+		},
+		"routing": map[string]any{
+			"preflight_threshold_tokens":        4096,
+			"preflight_timeout_s":               5,
+			"request_timeout_s":                 60,
+			"failover_enabled":                  true,
+			"failover_timeout_s":                5,
+			"retry_per_attempt_timeout_s":       60,
+			"max_providers_faulted_per_request": 0,
+			"sticky_enabled":                    false,
+			"sticky_ttl_s":                      1800,
+			"sticky_max_entries":                10000,
+		},
+		"provider_http": map[string]any{
+			"timeout_s": 30,
+		},
+		"limits": map[string]any{
+			"max_chat_request_body_bytes": 1048576,
+		},
+		"ws": map[string]any{
+			"write_buffer_size":               64,
+			"handshake_timeout_s":             10,
+			"write_timeout_s":                 10,
+			"max_frame_bytes":                 4 << 20,
+			"max_unauthenticated_conn":        64,
+			"max_unauthenticated_conn_per_ip": 16,
+		},
+		"admission": map[string]any{
+			"pinned_only":                         true,
+			"provisional_admission_rate_per_hour": 1000,
+			"provisional_pool_max":                100,
+			"provisional_quota_per_hour":          1000,
+			"provisional_tier_weight":             0.3,
+			"provisional_retention_days":          30,
+		},
+		"tier2": map[string]any{
+			"observe_enabled":                    false,
+			"require_hash_verified":              false,
+			"require_encrypted_leg":              false,
+			"encrypted_leg_aead":                 "A256GCM",
+			"encrypted_leg_rekey_after_requests": 10000,
+			"encrypted_leg_rekey_after_seconds":  3600,
+			"require_attestation":                false,
+			"attestation_max_age_s":              600,
+			"behavioral_safety_enabled":          false,
+			"output_size_cap_bytes":              0,
+			"output_bytes_per_token_ceiling":     16,
+			"default_output_size_cap_bytes":      1048576,
+			"encoding_validation_enabled":        false,
+			"response_time_anomaly_enabled":      false,
+			"response_time_anomaly_factor":       5.0,
+			"response_time_anomaly_min_ms":       10000,
+		},
+		"auth": map[string]any{
+			"operator_key":            in.operatorKey,
+			"gateway_service_token":   in.gatewayServiceToken,
+			"require_provider_tokens": true,
+		},
+		"storage": map[string]any{
+			"db_path":                    in.dbPath,
+			"snapshot_interval_s":        300,
+			"request_log_retention_days": 90,
+			"audit_log_retention_days":   90,
+		},
+		"logging": map[string]any{
+			"level":  "info",
+			"format": "json",
+		},
+		"rewards": map[string]any{
+			"global_multiplier": 1.0,
+			"provider_share":    0.9,
+			"rate_card": map[string]any{
+				"default": map[string]any{
+					"prompt_credits_per_mtok":     500000,
+					"completion_credits_per_mtok": 1000000,
+				},
+			},
+		},
+		"settlement": map[string]any{
+			"cadence_days":                   7,
+			"min_payout_credits":             0,
+			"startup_reconcile_window_hours": 24,
+			"nightly_reconcile_window_days":  7,
+			"recovery_grace_seconds":         30,
+			"verified_model_settlement_mode": "observe",
+			"job_enabled":                    false,
+		},
+		"endpoints": map[string]any{
+			"provider_earnings": map[string]any{
+				"rate_limit_per_minute": 60,
+			},
+		},
+		"explorer": map[string]any{
+			"enabled": false,
+		},
+		"providers": providersCfg,
+	}
+	b, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	return os.WriteFile(path, b, 0o600)
+}
+
+// issueProviderToken shells out to coordinator-cli issue-token, which
+// creates + migrates the DB (matching the integration harness pattern
+// so the coordinator binary can attach to the same WAL DB on start).
+// The CLI prints "token=<hex>" on stdout; we parse that line.
+func issueProviderToken(coordCLIBin, dbPath, providerID, providerName string) (string, error) {
+	cmd := exec.Command(coordCLIBin, "issue-token",
+		"-db", dbPath,
+		"-provider-id", providerID,
+		"-provider-name", providerName,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("coordinator-cli issue-token: %v\n%s", err, string(out))
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if rest, ok := strings.CutPrefix(line, "token="); ok {
+			return strings.TrimSpace(rest), nil
+		}
+	}
+	return "", fmt.Errorf("issue-token: no token= line in output: %s", string(out))
+}
+
+func startCoordinator(ctx context.Context, r *Rig, bin, yamlPath string) error {
+	cmd := exec.CommandContext(ctx, bin, "-config", yamlPath)
+	cmd.Env = os.Environ()
+	return r.registerProc(cmd, "coord")
+}
+
+// waitForHealth polls url until it returns 200 or the deadline expires.
+func waitForHealth(ctx context.Context, url string) error {
+	deadline := time.Now().Add(15 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("healthz %s never ready: %v", url, lastErr)
+}
+
+// waitForProvidersReady polls /poolz with the operator bearer until
+// every providerID appears with state=ready. Deadline 30s — rig
+// startup is slower than test/integration's 15s once N providers are
+// heartbeating.
+func waitForProvidersReady(ctx context.Context, provURL string, providerIDs []string, operatorKey string) error {
+	deadline := time.Now().Add(30 * time.Second)
+	var lastBody []byte
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, provURL+"/poolz", nil)
+		req.Header.Set("Authorization", "Bearer "+operatorKey)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		lastBody = body
+		if resp.StatusCode == http.StatusOK && allProvidersReady(body, providerIDs) {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("providers never all-ready in /poolz; last body: %s", string(lastBody))
+}
+
+// allProvidersReady returns true when every providerID has at least
+// one entry with "state":"ready" in the /poolz body. /poolz emits an
+// array of provider records; a substring scan is sufficient at rig
+// scale (N < 100) and avoids depending on the coordinator's exact
+// wire shape.
+func allProvidersReady(body []byte, ids []string) bool {
+	// Try to decode as an object with a slice of provider entries; on
+	// failure fall back to substring match so a schema tweak doesn't
+	// hard-break the rig.
+	var wrapper struct {
+		Providers []struct {
+			ProviderID string `json:"provider_id"`
+			State      string `json:"state"`
+		} `json:"providers"`
+	}
+	if err := json.Unmarshal(body, &wrapper); err == nil && len(wrapper.Providers) > 0 {
+		ready := make(map[string]bool, len(wrapper.Providers))
+		for _, p := range wrapper.Providers {
+			if p.State == "ready" {
+				ready[p.ProviderID] = true
+			}
+		}
+		for _, id := range ids {
+			if !ready[id] {
+				return false
+			}
+		}
+		return true
+	}
+	// Fallback: every ID must appear AND the body must contain
+	// "state":"ready" at least once. Weak but matches how
+	// test/integration's waitForProviderReady checks.
+	if !strings.Contains(string(body), `"state":"ready"`) {
+		return false
+	}
+	for _, id := range ids {
+		if !strings.Contains(string(body), id) {
+			return false
+		}
+	}
+	return true
+}

--- a/test/network-harness/internal/localrig/gateway.go
+++ b/test/network-harness/internal/localrig/gateway.go
@@ -1,0 +1,204 @@
+package localrig
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	_ "modernc.org/sqlite"
+)
+
+type gwYAMLInputs struct {
+	gwPort        int
+	dbPath        string
+	coordBuyerURL string
+	coordProvURL  string
+	operatorKey   string
+	serviceToken  string
+	keyHashSecret string
+	demoSecret    string
+}
+
+// writeGatewayYAML mirrors the fields test/integration writes. Sticky
+// is OFF (baseline scenario 17); PR 2 will lift the knob into Config.
+func writeGatewayYAML(path string, in gwYAMLInputs) error {
+	cfg := map[string]any{
+		"listen": map[string]any{
+			"bind_address": "127.0.0.1",
+			"port":         in.gwPort,
+		},
+		"proxy": map[string]any{
+			"trusted_cidrs": []string{"127.0.0.0/8", "::1/128"},
+		},
+		"public": map[string]any{
+			"base_url":     fmt.Sprintf("http://127.0.0.1:%d", in.gwPort),
+			"account_path": "/account",
+		},
+		"coordinator": map[string]any{
+			"buyer_url":             in.coordBuyerURL,
+			"operator_url":          in.coordProvURL,
+			"operator_key":          in.operatorKey,
+			"service_token":         in.serviceToken,
+			"poolz_poll_interval_s": 60,
+		},
+		"storage": map[string]any{
+			"driver":  "sqlite",
+			"db_path": in.dbPath,
+		},
+		"auth": map[string]any{
+			"key_prefix":               "mp_",
+			"key_hash":                 "hmac_sha256",
+			"key_hash_secret":          in.keyHashSecret,
+			"github_oauth_enabled":     false,
+			"email_magic_link_enabled": false,
+			"oauth": map[string]any{
+				"state_max_per_ip": 20,
+				"callback_allowlist": []string{
+					fmt.Sprintf("http://127.0.0.1:%d/auth/github/callback", in.gwPort),
+				},
+			},
+			"demo": map[string]any{
+				"signing_secret": in.demoSecret,
+			},
+		},
+		"quotas": map[string]any{
+			"account_daily_tokens":           1000000,
+			"demo_daily_tokens_per_ip":       10000,
+			"demo_sessions_per_ip_per_hour":  10,
+			"account_concurrency":            256,
+			"demo_concurrency":               4,
+			"signup_accounts_per_ip_per_day": 3,
+			"reaper_interval_hours":          24,
+			"reservation_max_age_hours":      24,
+		},
+		"limits": map[string]any{
+			"max_tokens_per_request":            4096,
+			"demo_max_tokens_per_request":       512,
+			"max_feedback_comment_bytes":        2000,
+			"max_feedback_body_bytes":           16384,
+			"feedback_requests_per_ip_per_hour": 10,
+			"request_body_bytes":                1048576,
+		},
+		"capacity": map[string]any{
+			"monthly_budget_usd":                500,
+			"ready_provider_degraded_threshold": 1,
+			"projected_cost_tier1_percent":      80,
+			"tier_cooldown_seconds":             3600,
+		},
+		"timeouts": map[string]any{
+			"coordinator_request_seconds":        60,
+			"coordinator_header_timeout_seconds": 60,
+			"streaming_cancel_ms":                500,
+		},
+		"cors": map[string]any{
+			"allowed_origins": []string{fmt.Sprintf("http://127.0.0.1:%d", in.gwPort)},
+		},
+		"routing": map[string]any{
+			"sticky_enabled": false,
+			"sticky_ttl_s":   1800,
+		},
+		"explorer": map[string]any{
+			"enabled": false,
+		},
+	}
+	b, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	return os.WriteFile(path, b, 0o600)
+}
+
+// seedGatewayAccountAndKey boots the gateway briefly so it runs its
+// schema migrations, kills it, then writes an active accounts row and
+// one api_keys row directly. The key hash uses
+// HMAC-SHA256(key_hash_secret, fullKey) — same shape as
+// phase5-gateway/internal/auth/keys.go. Returns the full mp_… key.
+//
+// Never log the returned key — it's a live bearer for the rig's
+// lifetime.
+func seedGatewayAccountAndKey(ctx context.Context, gwBin, gwYAML, gwDB, keyHashSecret, accountID string) (string, error) {
+	bootCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(bootCtx, gwBin, "-config", gwYAML)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("boot gateway for seed: %w", err)
+	}
+	// Poll until the schema is present, then kill.
+	seeded := false
+	deadline := time.Now().Add(6 * time.Second)
+	for time.Now().Before(deadline) {
+		db, err := sql.Open("sqlite", gwDB)
+		if err == nil {
+			var ok int
+			err = db.QueryRow(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='accounts'`).Scan(&ok)
+			db.Close()
+			if err == nil {
+				seeded = true
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+	if !seeded {
+		return "", fmt.Errorf("gateway schema not present after 6s")
+	}
+
+	db, err := sql.Open("sqlite", gwDB)
+	if err != nil {
+		return "", fmt.Errorf("open gateway db: %w", err)
+	}
+	defer db.Close()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	if _, err := db.Exec(
+		`INSERT INTO accounts(account_id, status, quota_class, concurrency_class, created_at) VALUES(?, 'active', 'default', 'default', ?)`,
+		accountID, now,
+	); err != nil {
+		return "", fmt.Errorf("seed account: %w", err)
+	}
+
+	rawKey := make([]byte, 32)
+	if _, err := rand.Read(rawKey); err != nil {
+		return "", fmt.Errorf("rand: %w", err)
+	}
+	fullKey := "mp_" + base64.RawURLEncoding.EncodeToString(rawKey)
+	mac := hmac.New(sha256.New, []byte(keyHashSecret))
+	_, _ = mac.Write([]byte(fullKey))
+	hash := mac.Sum(nil)
+	prefix := fullKey
+	if len(fullKey) > 12 {
+		prefix = fullKey[:12]
+	}
+	keyIDSuffix, err := randHex(16)
+	if err != nil {
+		return "", fmt.Errorf("gen key id: %w", err)
+	}
+	keyID := "key_" + keyIDSuffix
+	if _, err := db.Exec(
+		`INSERT INTO api_keys(key_id, account_id, key_hash, key_hash_prefix, status, created_at) VALUES(?, ?, ?, ?, 'active', ?)`,
+		keyID, accountID, hash, prefix, now,
+	); err != nil {
+		return "", fmt.Errorf("seed api_key: %w", err)
+	}
+	return fullKey, nil
+}
+
+func startGateway(ctx context.Context, r *Rig, bin, yamlPath string) error {
+	cmd := exec.CommandContext(ctx, bin, "-config", yamlPath)
+	cmd.Env = os.Environ()
+	return r.registerProc(cmd, "gateway")
+}

--- a/test/network-harness/internal/localrig/ports.go
+++ b/test/network-harness/internal/localrig/ports.go
@@ -1,0 +1,16 @@
+package localrig
+
+import "net"
+
+// allocatePort returns an OS-allocated free TCP port on 127.0.0.1. Racy
+// between Close and the child re-listening — in practice the window is
+// microseconds and coordinator/gateway listen() retries paper it over.
+// If flakes appear, switch to fd-handoff via net.FileListener.
+func allocatePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}

--- a/test/network-harness/internal/localrig/providers.go
+++ b/test/network-harness/internal/localrig/providers.go
@@ -1,0 +1,326 @@
+package localrig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	gobwas "github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+)
+
+// FakeProvider is one in-process fake provider. It listens on
+// 127.0.0.1:<httpPort> for /v1/chat/completions and connects to the
+// coordinator via WebSocket with the v1 hello handshake.
+type FakeProvider struct {
+	cfg           Provider
+	httpPort      int
+	coordProvURL  string
+	providerToken string
+	logger        func(string)
+
+	server *http.Server
+	// slots caps concurrent /v1/chat/completions handlers. Buffered
+	// channel of size CapacitySlots — a full channel means every slot
+	// is in use and we return 429 immediately.
+	slots chan struct{}
+	// inflight is the atomic-ish current-holder count used to compute
+	// slots_free in the heartbeat frame. Protected by hitMu.
+	hitMu    sync.Mutex
+	inflight int
+	hits     int
+
+	stopOnce sync.Once
+	stopped  chan struct{}
+}
+
+// fakeCompletionBody is the canned OpenAI-shaped body every fake
+// provider returns. Copied from test/integration; the model_id is
+// substituted per-provider at emit time.
+const fakeCompletionBodyTemplate = `{
+  "id":"chatcmpl-fake-localrig",
+  "object":"chat.completion",
+  "created":1780000000,
+  "model":"%s",
+  "usage":{"prompt_tokens":8,"completion_tokens":12,"total_tokens":20},
+  "choices":[{"index":0,"message":{"role":"assistant","content":"hello from fake localrig provider"},"finish_reason":"stop"}]
+}`
+
+func newFakeProvider(cfg Provider, httpPort int, coordProvURL, providerToken string, logger func(string)) *FakeProvider {
+	if logger == nil {
+		logger = func(string) {}
+	}
+	slots := cfg.CapacitySlots
+	if slots < 1 {
+		slots = 1
+	}
+	return &FakeProvider{
+		cfg:           cfg,
+		httpPort:      httpPort,
+		coordProvURL:  coordProvURL,
+		providerToken: providerToken,
+		logger:        logger,
+		slots:         make(chan struct{}, slots),
+		stopped:       make(chan struct{}),
+	}
+}
+
+// start brings up the HTTP listener and WS half. Blocks only until the
+// HTTP listener is bound; the WS half runs in a goroutine until ctx is
+// cancelled or stop() is called.
+func (p *FakeProvider) start(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/chat/completions", p.handleChat)
+	mux.HandleFunc("/v1/models", p.handleModels)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+	p.server = &http.Server{
+		Addr:    fmt.Sprintf("127.0.0.1:%d", p.httpPort),
+		Handler: mux,
+	}
+	ln, err := net.Listen("tcp", p.server.Addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", p.server.Addr, err)
+	}
+	go func() {
+		_ = p.server.Serve(ln)
+	}()
+	go p.runWS(ctx)
+	return nil
+}
+
+func (p *FakeProvider) stop() {
+	p.stopOnce.Do(func() {
+		if p.server != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_ = p.server.Shutdown(ctx)
+		}
+		close(p.stopped)
+	})
+}
+
+func (p *FakeProvider) handleChat(w http.ResponseWriter, r *http.Request) {
+	// Try to acquire a slot without blocking.
+	select {
+	case p.slots <- struct{}{}:
+	default:
+		http.Error(w, "capacity exhausted", http.StatusTooManyRequests)
+		return
+	}
+	defer func() { <-p.slots }()
+
+	p.hitMu.Lock()
+	p.inflight++
+	p.hits++
+	p.hitMu.Unlock()
+	defer func() {
+		p.hitMu.Lock()
+		p.inflight--
+		p.hitMu.Unlock()
+	}()
+
+	// Drain the request body so the client doesn't backpressure while
+	// we sleep for TTFT.
+	_, _ = io.Copy(io.Discard, r.Body)
+
+	if p.cfg.TTFTMs > 0 {
+		select {
+		case <-time.After(time.Duration(p.cfg.TTFTMs) * time.Millisecond):
+		case <-r.Context().Done():
+			return
+		}
+	}
+
+	body := fmt.Sprintf(fakeCompletionBodyTemplate, p.cfg.Model)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Provider-Id", p.cfg.ID)
+	w.Header().Set("X-MacProvider-Completion-Tokens", "12")
+
+	// Pacing: if TokensPerSec > 0, spread the 12-token body's
+	// completion_tokens payload over 12/TokensPerSec seconds by
+	// writing the JSON body in whole then sleeping for the target
+	// duration BEFORE returning. Since this is a non-streaming JSON
+	// response, byte-splitting mid-body would break JSON parsers; the
+	// caller-visible latency signal is still monotonic in TokensPerSec.
+	// (Scenario 17 measures TTFT + total_ms, not per-token spacing.)
+	if p.cfg.TokensPerSec > 0 {
+		const tokens = 12.0
+		dur := time.Duration(tokens / p.cfg.TokensPerSec * float64(time.Second))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		select {
+		case <-time.After(dur):
+		case <-r.Context().Done():
+		}
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(body))
+}
+
+func (p *FakeProvider) handleModels(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(fmt.Sprintf(`{"object":"list","data":[{"id":%q,"object":"model"}]}`, p.cfg.Model)))
+}
+
+// runWS dials the coordinator's /ws/provider endpoint, sends a v1 hello
+// frame announcing endpoint_url mode, and heartbeats every 1s until
+// ctx cancels. Any inbound frames are drained (coordinator can send
+// state_update / drain_status but no inference frames in endpoint_url
+// mode).
+func (p *FakeProvider) runWS(ctx context.Context) {
+	defer p.stop()
+
+	u, err := url.Parse(p.coordProvURL)
+	if err != nil {
+		p.logger("ws parse coord url: " + err.Error())
+		return
+	}
+	wsScheme := "ws"
+	if u.Scheme == "https" {
+		wsScheme = "wss"
+	}
+	wsURL := fmt.Sprintf("%s://%s/ws/provider", wsScheme, u.Host)
+
+	header := http.Header{}
+	if p.providerToken != "" {
+		header.Set("Authorization", "Bearer "+p.providerToken)
+	}
+	dialer := gobwas.Dialer{
+		Timeout: 5 * time.Second,
+		Header:  gobwas.HandshakeHeaderHTTP(header),
+	}
+
+	var conn net.Conn
+	dialDeadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(dialDeadline) {
+		if ctx.Err() != nil {
+			return
+		}
+		c, _, _, err := dialer.Dial(ctx, wsURL)
+		if err == nil {
+			conn = c
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if conn == nil {
+		p.logger("ws dial failed within deadline")
+		return
+	}
+	defer conn.Close()
+
+	endpointURL := fmt.Sprintf("http://127.0.0.1:%d", p.httpPort)
+	tps := p.cfg.TokensPerSec
+	if tps == 0 {
+		tps = 20.0
+	}
+
+	hello := map[string]any{
+		"type":                    "hello",
+		"version":                 1,
+		"tier":                    1,
+		"provider_id":             p.cfg.ID,
+		"hostname":                "fake-localrig",
+		"model_id":                p.cfg.Model,
+		"model_params_b":          3.0,
+		"ram_gb":                  16,
+		"max_context_tokens":      8192,
+		"max_concurrency":         p.cfg.CapacitySlots,
+		"throughput_tps_estimate": tps,
+		"binary_version":          "0.0.0-fake-localrig",
+		"attestation":             nil,
+		"endpoint_url":            endpointURL,
+	}
+	if err := writeJSONFrame(conn, hello); err != nil {
+		p.logger("hello write: " + err.Error())
+		return
+	}
+	// Read hello_ack — content doesn't matter; /poolz is the ready gate.
+	if _, _, err := wsutil.ReadServerData(conn); err != nil {
+		p.logger("read hello_ack: " + err.Error())
+		return
+	}
+
+	// Inbound drain — the coordinator can push state_update / drain
+	// frames; we ignore them but must consume or WS backpressures.
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		for {
+			if _, _, err := wsutil.ReadServerData(conn); err != nil {
+				return
+			}
+		}
+	}()
+
+	hbTick := time.NewTicker(1 * time.Second)
+	defer hbTick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-readDone:
+			return
+		case <-hbTick.C:
+			p.hitMu.Lock()
+			slotsFree := p.cfg.CapacitySlots - p.inflight
+			if slotsFree < 0 {
+				slotsFree = 0
+			}
+			p.hitMu.Unlock()
+			hb := map[string]any{
+				"type":                       "heartbeat",
+				"status":                     "ready",
+				"model_id":                   p.cfg.Model,
+				"model_params_b":             3.0,
+				"ram_gb":                     16,
+				"max_context_tokens":         8192,
+				"max_concurrency":            p.cfg.CapacitySlots,
+				"slots_free":                 slotsFree,
+				"slots_total":                p.cfg.CapacitySlots,
+				"throughput_tps_estimate":    tps,
+				"requests_served_since_last": 0,
+				"avg_latency_ms_since_last":  0.0,
+				"throughput_tps_since_last":  0.0,
+			}
+			if err := writeJSONFrame(conn, hb); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func writeJSONFrame(conn net.Conn, payload map[string]any) error {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	// Client side must mask outbound frames — wsutil.WriteClientText
+	// does the right thing.
+	return wsutil.WriteClientText(conn, b)
+}
+
+// Hits returns the number of /v1/chat/completions requests this fake
+// has served. Convenience for tests that want to assert routing
+// distribution.
+func (p *FakeProvider) Hits() int {
+	p.hitMu.Lock()
+	defer p.hitMu.Unlock()
+	return p.hits
+}
+

--- a/test/network-harness/internal/localrig/rig.go
+++ b/test/network-harness/internal/localrig/rig.go
@@ -1,0 +1,491 @@
+// Package localrig spins up a fully-connected macprovider stack —
+// coordinator + gateway + N in-process fake providers — on 127.0.0.1
+// for load/fairness scenarios that would DoS Pearl at production
+// scale.
+//
+// TODO(shared-rig-refactor): the coordinator / gateway YAML shapes
+// written here parallel what test/integration/harness_test.go writes.
+// PR 1 forks the config on purpose so the load-lane deadline doesn't
+// unpick integration's testing.T assumptions; after 2-3 load scenarios
+// reveal the shared surface, lift a canonical rigconfig package that
+// both call sites depend on, plus a shape-parity test that fails when
+// integration's YAML shape diverges from the load rig's.
+//
+// The rig is bring-up-only: it produces URLs, a fresh buyer API key,
+// and SQLite paths, then hands control to the caller. Nothing here
+// fires requests; that is the scenario runner's job. Shutdown cancels
+// the rig's root context, waits for the coordinator, gateway, and
+// every fake provider to exit, and removes the rig's WorkDir.
+//
+// Design notes:
+//
+//   - Coordinator + gateway are real binaries built by go build. The
+//     rig treats them as opaque processes so the boundary contract is
+//     exercised end-to-end (same shape as test/integration).
+//
+//   - Fake providers run in-process. Each connects to the coordinator
+//     over WebSocket using the v1 hello handshake (endpoint_url mode)
+//     and serves canned OpenAI-shaped chat completions on 127.0.0.1
+//     with configurable TTFT, TPS, and concurrency cap.
+//
+//   - Settlement is off (verified_model_settlement_mode="observe"),
+//     so no SPEC-015 receipt crypto ships in this package.
+package localrig
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+)
+
+// Config parameterizes a rig lifecycle. Populated from scenario.Target.
+type Config struct {
+	Providers []Provider
+
+	// WorkDir, when non-empty, is used as the rig's root tempdir. Empty
+	// → os.MkdirTemp("macprovider-localrig-*"). Written binaries land
+	// under WorkDir/bin, DBs under WorkDir/db, YAMLs under WorkDir/etc.
+	WorkDir string
+
+	// Logger, when non-nil, receives one line per subprocess stdout/stderr
+	// line prefixed with "[coord] " / "[gateway] " / "[prov-<id>] ".
+	// nil → log.Default().
+	Logger func(string)
+}
+
+// Provider mirrors scenario.RigProvider without dragging the scenario
+// package into localrig (which would create an import cycle once the
+// scenario runner calls into localrig).
+//
+// The rig only implements one provider process kind in PR 1 (the
+// in-process fake); the internal providerProcess interface below is
+// the seam future PRs use to add failure-mode-injecting or real
+// `macprovider-cli` providers without rewriting Start.
+type Provider struct {
+	ID            string
+	Model         string
+	TTFTMs        int
+	TokensPerSec  float64
+	CapacitySlots int
+
+	// Kind selects which provider-process implementation the rig will
+	// spin up. Zero value = ProviderKindFake (the only kind PR 1
+	// ships). Follow-up PRs add ProviderKindFailInject (PR 3 asymmetric
+	// starvation, with policy fields for controlled 5xx / slow-response)
+	// and ProviderKindRealBinary (attaches a real macprovider-cli
+	// process; needs BinaryPath / ModelWeights fields not defined here).
+	// Fields specific to a Kind live on a matching *Config sub-struct
+	// added when that Kind ships, so this stable shape never breaks.
+	Kind ProviderKind
+}
+
+// ProviderKind selects the provider-process implementation.
+type ProviderKind string
+
+const (
+	// ProviderKindFake is the in-process synthetic provider: canned
+	// OpenAI-shaped completion with TTFTMs sleep + TokensPerSec pacing
+	// + CapacitySlots concurrency cap. The only kind implemented in
+	// PR 1; also the default when Kind is empty.
+	ProviderKindFake ProviderKind = ""
+)
+
+// providerProcess is the internal contract every provider-process
+// implementation satisfies. Kept unexported so PR 1's public API stays
+// stable while follow-up PRs plug in more implementations. rig.Start
+// dispatches on Provider.Kind to construct the right instance.
+type providerProcess interface {
+	// start brings the process to Ready: an in-process HTTP endpoint
+	// listening on 127.0.0.1:port plus, if applicable, a WS connection
+	// to the coordinator's provider plane. Returns when both halves
+	// are running; readiness at the coord's /poolz view is a separate
+	// wait step outside the process's control.
+	start(ctx context.Context) error
+	// stop signals the process to tear down. Idempotent; must be safe
+	// to call even if start returned an error.
+	stop()
+}
+
+// Rig is a running local stack. Constructed by Start; released by Shutdown.
+type Rig struct {
+	// GatewayURL is the buyer-facing http://127.0.0.1:<port> URL.
+	GatewayURL string
+	// CoordinatorBuyerURL is the coordinator's buyer-plane URL.
+	CoordinatorBuyerURL string
+	// BuyerToken is a fresh mp_<...> API key seeded into the gateway
+	// for this rig's lifetime. Test tokens only; never Pearl.
+	BuyerToken string
+	// CoordinatorDBPath / GatewayDBPath are the SQLite files the harness
+	// reconcile package reads.
+	CoordinatorDBPath string
+	GatewayDBPath     string
+
+	// unexported bookkeeping
+	workDir       string
+	ownWorkDir    bool // rig created the tempdir → remove on shutdown
+	logger        func(string)
+	rootCancel    context.CancelFunc
+	procWG        sync.WaitGroup
+	// providers holds every started provider-process implementation.
+	// In PR 1 every entry is a *FakeProvider; the interface indirection
+	// makes ProviderKindFailInject / ProviderKindRealBinary additive
+	// without changing Start's control flow.
+	providers []providerProcess
+
+	// fakeProviders is a typed slice of the *FakeProvider subset of
+	// providers, retained for future test hooks that need the concrete
+	// type (e.g., inspecting Hits()). Kept in sync with providers.
+	fakeProviders []*FakeProvider
+	shutdownOnce  sync.Once
+	shutdownErr   error
+
+	// crash tracks the first supervised subprocess (coord/gateway) that
+	// exits unexpectedly. Closed once the first crash lands so callers
+	// can select on it and fail-fast instead of blocking on buyer.Run
+	// against a dead gateway. Populated only via registerProc's
+	// exit-observer goroutine.
+	crashOnce sync.Once
+	crashCh   chan struct{}
+	crashErr  error
+	crashMu   sync.Mutex
+
+	// shuttingDown flips true once Shutdown begins so registerProc's
+	// exit observer knows subsequent child exits are expected and MUST
+	// NOT be recorded as crashes. Atomic because both Shutdown and the
+	// exit-observer goroutines touch it without external coordination.
+	shuttingDown atomic.Bool
+}
+
+// Done returns a channel that closes when any supervised subprocess
+// (coordinator or gateway) exits unexpectedly. Fake providers do not
+// count — they are in-process and their errors surface directly to the
+// buyer request path. Callers should race Done() against buyer.Run to
+// abort a scenario as soon as the rig loses a required binary.
+func (r *Rig) Done() <-chan struct{} {
+	return r.crashCh
+}
+
+// Err returns the reason recorded on the first supervised crash, or
+// nil if no crash has been observed. Only meaningful after Done()
+// closes.
+func (r *Rig) Err() error {
+	r.crashMu.Lock()
+	defer r.crashMu.Unlock()
+	return r.crashErr
+}
+
+// Start builds binaries (once per WorkDir), writes configs, spawns
+// coordinator + gateway + fake providers, waits for everything to be
+// Ready, and returns the running rig.
+//
+// On any bring-up failure Start tears down whatever it has already
+// spawned and cleans the WorkDir before returning. Callers get an
+// error and should NOT call Shutdown.
+func Start(ctx context.Context, cfg Config) (_ *Rig, retErr error) {
+	if len(cfg.Providers) == 0 {
+		return nil, fmt.Errorf("localrig: config.Providers must be non-empty")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = func(line string) { log.Println(line) }
+	}
+
+	workDir := cfg.WorkDir
+	ownWorkDir := false
+	if workDir == "" {
+		dir, err := os.MkdirTemp("", "macprovider-localrig-*")
+		if err != nil {
+			return nil, fmt.Errorf("localrig: mkdir tempdir: %w", err)
+		}
+		workDir = dir
+		ownWorkDir = true
+	}
+	// Ensure sub-dirs exist so Write callers can drop files straight in.
+	for _, sub := range []string{"bin", "db", "etc"} {
+		if err := os.MkdirAll(filepath.Join(workDir, sub), 0o750); err != nil {
+			if ownWorkDir {
+				_ = os.RemoveAll(workDir)
+			}
+			return nil, fmt.Errorf("localrig: mkdir %s: %w", sub, err)
+		}
+	}
+
+	rigCtx, cancel := context.WithCancel(ctx)
+	r := &Rig{
+		workDir:           workDir,
+		ownWorkDir:        ownWorkDir,
+		logger:            logger,
+		rootCancel:        cancel,
+		crashCh:           make(chan struct{}),
+		CoordinatorDBPath: filepath.Join(workDir, "db", "coordinator.db"),
+		GatewayDBPath:     filepath.Join(workDir, "db", "gateway.db"),
+	}
+	// Defer a full teardown on error so partial state doesn't leak.
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		cancel()
+		r.procWG.Wait()
+		if ownWorkDir {
+			_ = os.RemoveAll(workDir)
+		}
+	}()
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return nil, fmt.Errorf("localrig: find repo root: %w", err)
+	}
+	binDir := filepath.Join(workDir, "bin")
+	coordBin, coordCLIBin, gwBin, err := buildBinaries(rigCtx, repoRoot, binDir)
+	if err != nil {
+		return nil, fmt.Errorf("localrig: build binaries: %w", err)
+	}
+
+	// Ports.
+	buyerPort, err := allocatePort()
+	if err != nil {
+		return nil, fmt.Errorf("localrig: alloc buyer port: %w", err)
+	}
+	provPort, err := allocatePort()
+	if err != nil {
+		return nil, fmt.Errorf("localrig: alloc provider port: %w", err)
+	}
+	gwPort, err := allocatePort()
+	if err != nil {
+		return nil, fmt.Errorf("localrig: alloc gateway port: %w", err)
+	}
+	providerPorts := make([]int, len(cfg.Providers))
+	for i := range cfg.Providers {
+		p, err := allocatePort()
+		if err != nil {
+			return nil, fmt.Errorf("localrig: alloc provider[%d] port: %w", i, err)
+		}
+		providerPorts[i] = p
+	}
+
+	r.CoordinatorBuyerURL = fmt.Sprintf("http://127.0.0.1:%d", buyerPort)
+	coordProvURL := fmt.Sprintf("http://127.0.0.1:%d", provPort)
+	r.GatewayURL = fmt.Sprintf("http://127.0.0.1:%d", gwPort)
+
+	// Secrets — every rig gets a fresh set. Test-only material; never
+	// printed via the Logger.
+	operatorKey, err := randHex(32)
+	if err != nil {
+		return nil, fmt.Errorf("localrig: gen operator key: %w", err)
+	}
+	serviceToken, err := randHex(32)
+	if err != nil {
+		return nil, fmt.Errorf("localrig: gen service token: %w", err)
+	}
+	keyHashSecret, err := randHex(32)
+	if err != nil {
+		return nil, fmt.Errorf("localrig: gen key-hash secret: %w", err)
+	}
+	demoSecret, err := randHex(32)
+	if err != nil {
+		return nil, fmt.Errorf("localrig: gen demo secret: %w", err)
+	}
+	accountSuffix, err := randHex(8)
+	if err != nil {
+		return nil, fmt.Errorf("localrig: gen account id: %w", err)
+	}
+	accountID := "acct_" + accountSuffix
+
+	coordYAML := filepath.Join(workDir, "etc", "coordinator.yaml")
+	gwYAML := filepath.Join(workDir, "etc", "gateway.yaml")
+
+	if err := writeCoordinatorYAML(coordYAML, coordYAMLInputs{
+		buyerPort:           buyerPort,
+		provPort:            provPort,
+		dbPath:              r.CoordinatorDBPath,
+		operatorKey:         operatorKey,
+		gatewayServiceToken: serviceToken,
+		providers:           cfg.Providers,
+		providerPorts:       providerPorts,
+	}); err != nil {
+		return nil, fmt.Errorf("localrig: write coordinator yaml: %w", err)
+	}
+	if err := writeGatewayYAML(gwYAML, gwYAMLInputs{
+		gwPort:         gwPort,
+		dbPath:         r.GatewayDBPath,
+		coordBuyerURL:  r.CoordinatorBuyerURL,
+		coordProvURL:   coordProvURL,
+		operatorKey:    operatorKey,
+		serviceToken:   serviceToken,
+		keyHashSecret:  keyHashSecret,
+		demoSecret:     demoSecret,
+	}); err != nil {
+		return nil, fmt.Errorf("localrig: write gateway yaml: %w", err)
+	}
+
+	// Issue a token per pinned provider BEFORE the coordinator starts.
+	// coordinator-cli creates + migrates the DB, so this is the first
+	// thing that touches the SQLite file. The coordinator binary then
+	// opens the same WAL DB on startup.
+	providerTokens := make([]string, len(cfg.Providers))
+	for i, p := range cfg.Providers {
+		tok, err := issueProviderToken(coordCLIBin, r.CoordinatorDBPath, p.ID, fmt.Sprintf("fake-%s", p.ID))
+		if err != nil {
+			return nil, fmt.Errorf("localrig: issue provider token %q: %w", p.ID, err)
+		}
+		providerTokens[i] = tok
+	}
+
+	// Seed the gateway account + api_keys row. This pre-boots the
+	// gateway binary briefly to run schema migrations, kills it, then
+	// writes rows directly.
+	buyerToken, err := seedGatewayAccountAndKey(ctx, gwBin, gwYAML, r.GatewayDBPath, keyHashSecret, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("localrig: seed gateway account: %w", err)
+	}
+	r.BuyerToken = buyerToken
+
+	// Start coordinator first — the gateway's healthz reaches back to
+	// coord on first hit, so ordering matters for a clean startup.
+	if err := startCoordinator(rigCtx, r, coordBin, coordYAML); err != nil {
+		return nil, fmt.Errorf("localrig: start coordinator: %w", err)
+	}
+	// Health-check both coord ports before spawning fakes; providers-
+	// ready check comes AFTER the fakes are connected + heartbeating.
+	if err := waitForHealth(rigCtx, r.CoordinatorBuyerURL+"/healthz"); err != nil {
+		return nil, fmt.Errorf("localrig: coord buyer healthz: %w", err)
+	}
+	if err := waitForHealth(rigCtx, coordProvURL+"/healthz"); err != nil {
+		return nil, fmt.Errorf("localrig: coord provider healthz: %w", err)
+	}
+	providerIDs := make([]string, len(cfg.Providers))
+	for i, p := range cfg.Providers {
+		providerIDs[i] = p.ID
+	}
+
+	// Spawn providers. Dispatched on Kind; PR 1 only implements
+	// ProviderKindFake so any other Kind is a validation error caught
+	// upstream in scenario.validateRigTarget or here as a fallback.
+	for i, p := range cfg.Providers {
+		proc, fake, err := r.newProviderProcess(p, providerPorts[i], coordProvURL, providerTokens[i])
+		if err != nil {
+			return nil, fmt.Errorf("localrig: build provider %q: %w", p.ID, err)
+		}
+		if err := proc.start(rigCtx); err != nil {
+			return nil, fmt.Errorf("localrig: start provider %q: %w", p.ID, err)
+		}
+		r.providers = append(r.providers, proc)
+		if fake != nil {
+			r.fakeProviders = append(r.fakeProviders, fake)
+		}
+	}
+	if err := waitForProvidersReady(rigCtx, coordProvURL, providerIDs, operatorKey); err != nil {
+		return nil, fmt.Errorf("localrig: providers-ready: %w", err)
+	}
+
+	// Start the gateway.
+	if err := startGateway(rigCtx, r, gwBin, gwYAML); err != nil {
+		return nil, fmt.Errorf("localrig: start gateway: %w", err)
+	}
+	if err := waitForHealth(rigCtx, r.GatewayURL+"/healthz"); err != nil {
+		return nil, fmt.Errorf("localrig: gateway healthz: %w", err)
+	}
+
+	return r, nil
+}
+
+// Shutdown cancels the rig's root context, waits for all subprocesses
+// to exit, and cleans the WorkDir if the rig created it. Idempotent.
+func (r *Rig) Shutdown() error {
+	r.shutdownOnce.Do(func() {
+		// Flip the shuttingDown flag BEFORE cancelling so exit observers
+		// racing the child process exit see it in time and treat the
+		// resulting cmd.Wait return as expected.
+		r.shuttingDown.Store(true)
+		if r.rootCancel != nil {
+			r.rootCancel()
+		}
+		for _, p := range r.providers {
+			p.stop()
+		}
+		r.procWG.Wait()
+		if r.ownWorkDir && r.workDir != "" {
+			if err := os.RemoveAll(r.workDir); err != nil {
+				r.shutdownErr = err
+			}
+		}
+	})
+	return r.shutdownErr
+}
+
+// newProviderProcess dispatches on cfg.Kind. Returns the interface
+// value used by rig internals plus, when the Kind is Fake, the concrete
+// *FakeProvider so hooks that need the concrete type can reach it. The
+// second return is nil for non-Fake kinds.
+func (r *Rig) newProviderProcess(cfg Provider, httpPort int, coordProvURL, providerToken string) (providerProcess, *FakeProvider, error) {
+	switch cfg.Kind {
+	case ProviderKindFake:
+		fp := newFakeProvider(cfg, httpPort, coordProvURL, providerToken, r.taggedLogger(fmt.Sprintf("prov-%s", cfg.ID)))
+		return fp, fp, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported provider kind %q (PR 1 implements ProviderKindFake only)", cfg.Kind)
+	}
+}
+
+// taggedLogger returns a Logger that prefixes each line with tag.
+func (r *Rig) taggedLogger(tag string) func(string) {
+	return func(line string) {
+		r.logger(fmt.Sprintf("[%s] %s", tag, line))
+	}
+}
+
+// registerProc adds cmd to procWG and pumps its stdout/stderr through
+// tagged log lines. When the process exits, the first non-Shutdown
+// exit is recorded on the rig's crash channel — callers of Rig.Done()
+// see the crash immediately and can abort their scenario rather than
+// blocking on buyer.Run against a dead binary.
+//
+// If the parent context has already been cancelled (Shutdown path),
+// the exit is treated as expected and NOT recorded on crashCh.
+func (r *Rig) registerProc(cmd *exec.Cmd, tag string) error {
+	if err := streamPipes(cmd, r.taggedLogger(tag)); err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	r.procWG.Add(1)
+	go func() {
+		defer r.procWG.Done()
+		waitErr := cmd.Wait()
+		if cmd.ProcessState != nil && !cmd.ProcessState.Success() {
+			r.recordCrash(fmt.Errorf("localrig: %s exited unexpectedly: %v (state=%s)", tag, waitErr, cmd.ProcessState.String()))
+			return
+		}
+		if waitErr != nil {
+			r.recordCrash(fmt.Errorf("localrig: %s wait: %w", tag, waitErr))
+		}
+	}()
+	return nil
+}
+
+// recordCrash closes crashCh on first supervised-subprocess crash. Called
+// from registerProc's exit observer. The first crash wins; subsequent
+// exits are dropped so a coord death followed by a gateway death from
+// the same shutdown cascade doesn't reopen the channel.
+//
+// Shutdown is expected to cancel rootCtx before the child exits, so
+// crashOnce won't fire under an intentional Shutdown — see the guard
+// on rootCancel state in Shutdown.
+func (r *Rig) recordCrash(err error) {
+	if r.shuttingDown.Load() {
+		return
+	}
+	r.crashOnce.Do(func() {
+		r.crashMu.Lock()
+		r.crashErr = err
+		r.crashMu.Unlock()
+		close(r.crashCh)
+	})
+}

--- a/test/network-harness/internal/localrig/rig_test.go
+++ b/test/network-harness/internal/localrig/rig_test.go
@@ -1,0 +1,87 @@
+package localrig
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRigLifecycle brings up a 2-provider rig, checks the exported
+// fields, curls /healthz on gateway + coord, then shuts down.
+func TestRigLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping localrig lifecycle test in -short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	cfg := Config{
+		Providers: []Provider{
+			{ID: "prov-a", Model: "llama-3.2-3b-instruct", TTFTMs: 0, TokensPerSec: 20, CapacitySlots: 2},
+			{ID: "prov-b", Model: "llama-3.2-3b-instruct", TTFTMs: 10, TokensPerSec: 15, CapacitySlots: 3},
+		},
+		Logger: func(line string) { t.Log(line) },
+	}
+	rig, err := Start(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := rig.Shutdown(); err != nil {
+			t.Errorf("Shutdown: %v", err)
+		}
+	})
+
+	// URL fields parseable and 127.0.0.1.
+	for name, raw := range map[string]string{
+		"GatewayURL":          rig.GatewayURL,
+		"CoordinatorBuyerURL": rig.CoordinatorBuyerURL,
+	} {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("%s = %q: parse: %v", name, raw, err)
+		}
+		if u.Hostname() != "127.0.0.1" {
+			t.Errorf("%s hostname = %q, want 127.0.0.1", name, u.Hostname())
+		}
+	}
+
+	// BuyerToken shape.
+	if !strings.HasPrefix(rig.BuyerToken, "mp_") {
+		t.Errorf("BuyerToken = %q, want mp_ prefix", rig.BuyerToken)
+	}
+
+	// DB files exist.
+	for name, path := range map[string]string{
+		"CoordinatorDBPath": rig.CoordinatorDBPath,
+		"GatewayDBPath":     rig.GatewayDBPath,
+	} {
+		if fi, err := os.Stat(path); err != nil {
+			t.Errorf("%s stat %q: %v", name, path, err)
+		} else if fi.Size() == 0 {
+			t.Errorf("%s %q is empty", name, path)
+		}
+	}
+
+	// Health probes.
+	for _, u := range []string{
+		rig.GatewayURL + "/healthz",
+		rig.CoordinatorBuyerURL + "/healthz",
+	} {
+		resp, err := http.Get(u)
+		if err != nil {
+			t.Errorf("GET %s: %v", u, err)
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET %s status = %d, body=%s", u, resp.StatusCode, string(body))
+		}
+	}
+}

--- a/test/network-harness/internal/scenario/rig_target_test.go
+++ b/test/network-harness/internal/scenario/rig_target_test.go
@@ -1,0 +1,255 @@
+package scenario
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// rigScenario returns a scenario with target.rig=local and a minimal
+// valid providers list. Callers mutate the return before running
+// Validate() so each test isolates one field.
+func rigScenario() Scenario {
+	return Scenario{
+		Name:     "rig-test",
+		Duration: time.Second,
+		Target: Target{
+			Rig: "local",
+			Providers: []RigProvider{
+				{ID: "prov-a", Model: "test-model", TTFTMs: 0, TokensPerSec: 20, CapacitySlots: 4},
+			},
+		},
+		Buyers: Buyers{
+			Count:            2,
+			RequestsPerBuyer: 1,
+			Pattern:          "constant",
+		},
+		Prompts: []Prompt{{Model: "test-model", User: "hi"}},
+	}
+}
+
+func TestValidateRig_HappyPath(t *testing.T) {
+	sc := rigScenario()
+	if err := sc.Validate(); err != nil {
+		t.Fatalf("rig scenario should validate: %v", err)
+	}
+}
+
+func TestValidateRig_UnknownValueRejected(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.Rig = "bogus"
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "target.rig must be") {
+		t.Fatalf("unknown rig value err=%v", err)
+	}
+}
+
+func TestValidateRig_MutuallyExclusiveWithGatewayURL(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.GatewayURL = "https://api.streamvc.live"
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "gateway_url must not be set") {
+		t.Fatalf("rig+gateway_url err=%v", err)
+	}
+}
+
+func TestValidateRig_MutuallyExclusiveWithCoordinatorURL(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.CoordinatorURL = "https://coordinator.streamvc.live"
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "coordinator_url must not be set") {
+		t.Fatalf("rig+coordinator_url err=%v", err)
+	}
+}
+
+func TestValidateRig_MutuallyExclusiveWithBuyerToken(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.BuyerToken = "mp_seeded"
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "buyer_token must not be set") {
+		t.Fatalf("rig+buyer_token err=%v", err)
+	}
+}
+
+func TestValidateRig_MutuallyExclusiveWithDBPath(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.CoordinatorDBPath = "/tmp/coord.db"
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "db_path") {
+		t.Fatalf("rig+db_path err=%v", err)
+	}
+}
+
+func TestValidateRig_MutuallyExclusiveWithDBSSH(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.CoordinatorDBSSH = "pearl:/tmp/coord.db"
+	sc.Target.GatewayDBSSH = "pearl:/tmp/gw.db"
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "db_ssh") {
+		t.Fatalf("rig+db_ssh err=%v", err)
+	}
+}
+
+func TestValidateRig_EmptyProvidersRejected(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.Providers = nil
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "must list at least one") {
+		t.Fatalf("empty providers err=%v", err)
+	}
+}
+
+func TestValidateRig_DuplicateProviderID(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.Providers = append(sc.Target.Providers, RigProvider{
+		ID: "prov-a", Model: "test-model", CapacitySlots: 4,
+	})
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "duplicates") {
+		t.Fatalf("duplicate provider id err=%v", err)
+	}
+}
+
+func TestValidateRig_ProviderMissingModel(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.Providers[0].Model = ""
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "model is required") {
+		t.Fatalf("missing model err=%v", err)
+	}
+}
+
+func TestValidateRig_NegativeTTFT(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.Providers[0].TTFTMs = -1
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "ttft_ms") {
+		t.Fatalf("negative ttft err=%v", err)
+	}
+}
+
+func TestValidateRig_NegativeTokensPerSec(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.Providers[0].TokensPerSec = -0.5
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "tokens_per_sec") {
+		t.Fatalf("negative tps err=%v", err)
+	}
+}
+
+func TestValidateRig_CapacitySlotsZero(t *testing.T) {
+	sc := rigScenario()
+	sc.Target.Providers[0].CapacitySlots = 0
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "capacity_slots") {
+		t.Fatalf("zero capacity err=%v", err)
+	}
+}
+
+func TestValidateRig_PromptModelNotAdvertised(t *testing.T) {
+	sc := rigScenario()
+	sc.Prompts[0].Model = "different-model"
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "not advertised") {
+		t.Fatalf("unadvertised model err=%v", err)
+	}
+}
+
+func TestValidateRig_ProvidersRequiresRig(t *testing.T) {
+	sc := validTestScenario()
+	sc.Target.Providers = []RigProvider{{ID: "x", Model: "m", CapacitySlots: 1}}
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "target.providers must not be set unless") {
+		t.Fatalf("providers without rig err=%v", err)
+	}
+}
+
+func TestProdLoadGuard_LowConcurrencyAllowed(t *testing.T) {
+	sc := validTestScenario()
+	sc.Target.GatewayURL = "https://api.streamvc.live"
+	sc.Buyers.Count = ProdLoadGuardBuyerLimit
+	if err := sc.Validate(); err != nil {
+		t.Fatalf("count=%d against prod must be allowed: %v", sc.Buyers.Count, err)
+	}
+}
+
+func TestProdLoadGuard_HighConcurrencyRejected(t *testing.T) {
+	sc := validTestScenario()
+	sc.Target.GatewayURL = "https://api.streamvc.live"
+	sc.Buyers.Count = ProdLoadGuardBuyerLimit + 1
+	// Ensure ALLOW_PROD_LOAD is not set in the test env — the harness
+	// process shouldn't have it, but be explicit.
+	t.Setenv(ProdLoadGuardEnv, "")
+	err := sc.Validate()
+	if err == nil || !strings.Contains(err.Error(), "requires ALLOW_PROD_LOAD=1") {
+		t.Fatalf("count=%d against prod must be rejected without override: %v", sc.Buyers.Count, err)
+	}
+}
+
+func TestProdLoadGuard_OverrideAccepted(t *testing.T) {
+	sc := validTestScenario()
+	sc.Target.GatewayURL = "https://api.streamvc.live"
+	sc.Buyers.Count = 50
+	t.Setenv(ProdLoadGuardEnv, "1")
+	if err := sc.Validate(); err != nil {
+		t.Fatalf("override should permit count=50 against prod: %v", err)
+	}
+}
+
+func TestProdLoadGuard_NonProdHostSkipsGuard(t *testing.T) {
+	sc := validTestScenario()
+	sc.Target.GatewayURL = "http://127.0.0.1:8080"
+	sc.Buyers.Count = 50
+	if err := sc.Validate(); err != nil {
+		t.Fatalf("local host with count=50 must be allowed: %v", err)
+	}
+}
+
+func TestProdLoadGuard_TrailingDotHost(t *testing.T) {
+	// SEC-r1: `api.streamvc.live.` (DNS root form) must trip the guard
+	// exactly like `api.streamvc.live`.
+	sc := validTestScenario()
+	sc.Target.GatewayURL = "https://api.streamvc.live."
+	sc.Buyers.Count = ProdLoadGuardBuyerLimit + 1
+	t.Setenv(ProdLoadGuardEnv, "")
+	err := sc.Validate()
+	if err == nil || !strings.Contains(err.Error(), "requires ALLOW_PROD_LOAD=1") {
+		t.Fatalf("trailing-dot host must trip guard: %v", err)
+	}
+}
+
+func TestProdLoadGuard_UpperCaseHost(t *testing.T) {
+	sc := validTestScenario()
+	sc.Target.GatewayURL = "HTTPS://API.STREAMVC.LIVE"
+	sc.Buyers.Count = ProdLoadGuardBuyerLimit + 1
+	t.Setenv(ProdLoadGuardEnv, "")
+	err := sc.Validate()
+	if err == nil || !strings.Contains(err.Error(), "requires ALLOW_PROD_LOAD=1") {
+		t.Fatalf("uppercase host must trip guard: %v", err)
+	}
+}
+
+func TestProdLoadGuard_ApexHostTrips(t *testing.T) {
+	// Apex `streamvc.live` (no subdomain) — the check must cover it too,
+	// not just entries that end with `.streamvc.live`.
+	sc := validTestScenario()
+	sc.Target.GatewayURL = "https://streamvc.live"
+	sc.Buyers.Count = ProdLoadGuardBuyerLimit + 1
+	t.Setenv(ProdLoadGuardEnv, "")
+	err := sc.Validate()
+	if err == nil || !strings.Contains(err.Error(), "requires ALLOW_PROD_LOAD=1") {
+		t.Fatalf("apex host must trip guard: %v", err)
+	}
+}
+
+func TestProdLoadGuard_OnlyLiteralOneBypasses(t *testing.T) {
+	// The bypass must be strict — `true`, `yes`, and any other truthy
+	// value must NOT be accepted.
+	sc := validTestScenario()
+	sc.Target.GatewayURL = "https://api.streamvc.live"
+	sc.Buyers.Count = ProdLoadGuardBuyerLimit + 1
+	for _, v := range []string{"true", "yes", "TRUE", "on", "2", ""} {
+		t.Setenv(ProdLoadGuardEnv, v)
+		err := sc.Validate()
+		if err == nil {
+			t.Fatalf("ALLOW_PROD_LOAD=%q must not bypass guard", v)
+		}
+	}
+}
+
+func TestProdLoadGuard_CoordinatorHostAlsoTrips(t *testing.T) {
+	sc := validTestScenario()
+	sc.Target.GatewayURL = "https://coordinator.streamvc.live"
+	sc.Buyers.Count = 11
+	t.Setenv(ProdLoadGuardEnv, "")
+	err := sc.Validate()
+	if err == nil || !strings.Contains(err.Error(), "requires ALLOW_PROD_LOAD=1") {
+		t.Fatalf("*.streamvc.live suffix should trip guard: %v", err)
+	}
+}

--- a/test/network-harness/internal/scenario/schema.go
+++ b/test/network-harness/internal/scenario/schema.go
@@ -34,6 +34,25 @@ var envVarPattern = regexp.MustCompile(`\$\{([A-Z_][A-Z0-9_]*)\}`)
 
 const maxChargedDeliveredToleranceTokens int64 = 16
 
+// ProdLoadGuardEnv is the operator override that suppresses the
+// "no >10 buyers against Pearl" scenario-validation guard. Load-lane
+// scenarios (17+) target 127.0.0.1 rigs, not Pearl; the guard exists
+// so an authoring mistake that leaves gateway_url pointed at
+// api.streamvc.live cannot silently DoS production during a beta window.
+// Set to "1" only for an explicit, one-off soak run.
+const ProdLoadGuardEnv = "ALLOW_PROD_LOAD"
+
+// ProdLoadGuardBuyerLimit is the largest buyers.count value the guard
+// permits against a *.streamvc.live host without ALLOW_PROD_LOAD=1.
+// Chosen to match the existing scenario 01/07 shape (2-5 buyers) with
+// modest headroom; anything larger requires the rig OR the override.
+const ProdLoadGuardBuyerLimit = 10
+
+// prodHostSuffix identifies Pearl-hosted stacks for ProdLoadGuardEnv.
+// Matched as a suffix on the gateway URL host (case-insensitive), so
+// api.streamvc.live and coordinator.streamvc.live both trip.
+const prodHostSuffix = ".streamvc.live"
+
 func expandEnv(input []byte) []byte {
 	return envVarPattern.ReplaceAllFunc(input, func(match []byte) []byte {
 		name := envVarPattern.FindSubmatch(match)[1]
@@ -116,10 +135,67 @@ type ChaosEvent struct {
 	Description string        `yaml:"description"`
 }
 
-// Target identifies the running stack the harness fires against. The
-// harness does NOT spawn coordinator/gateway — that's the caller's job
-// (test/integration/ helpers, deploy scripts, or a live Pearl stack).
+// RigProvider configures one synthetic provider inside the embedded
+// local rig (Target.Rig == "local"). Each rig provider is an in-process
+// HTTP endpoint that connects to the local coordinator via WebSocket
+// and serves canned OpenAI-shaped chat completions with configurable
+// latency and throughput. Used by load/fairness scenarios to drive
+// deterministic routing measurements without touching real inference.
+type RigProvider struct {
+	// ID is the stable provider_id the fake reports in its hello frame
+	// and echoes back in `X-Provider-Id`. Must be non-empty and unique
+	// within the scenario. Cited in load_summary.json route_distribution.
+	ID string `yaml:"id"`
+
+	// Model is the model_id the fake advertises. Every prompt whose
+	// `model:` matches a rig provider's Model can route to it. If
+	// multiple rig providers advertise the same Model, the coordinator
+	// picks among them per its routing policy — the point the load
+	// scenarios exist to measure.
+	Model string `yaml:"model"`
+
+	// TTFTMs is the artificial time-to-first-byte the fake sleeps
+	// before writing the response headers. 0 means "reply immediately".
+	// Non-negative.
+	TTFTMs int `yaml:"ttft_ms"`
+
+	// TokensPerSec caps the fake's output pacing for the fixed 12-token
+	// canned completion body. > 0 injects synthetic pacing; 0 replies
+	// as fast as HTTP can flush. Non-negative.
+	TokensPerSec float64 `yaml:"tokens_per_sec"`
+
+	// CapacitySlots caps concurrent /v1/chat/completions handlers at
+	// the fake. Requests over the cap return 429; the coord's degraded/
+	// breaker signalling is what routing scenarios exercise. Must be
+	// >= 1.
+	CapacitySlots int `yaml:"capacity_slots"`
+}
+
+// Target identifies the running stack the harness fires against. Two modes:
+//
+//   - Remote (default, Rig=""): scenario supplies gateway_url +
+//     coordinator_url + buyer_token and the harness fires against an
+//     already-running stack (Pearl or a caller-managed local rig).
+//
+//   - Embedded local rig (Rig="local"): the harness spawns its own
+//     coordinator + gateway + N fake providers on 127.0.0.1 ephemeral
+//     ports and points the buyer fleet at them. Used by load/fairness
+//     scenarios that would DoS Pearl at production scale. GatewayURL,
+//     CoordinatorURL, BuyerToken, CoordinatorDBPath, and GatewayDBPath
+//     are populated at rig-start time from the rig; they MUST be unset
+//     in the YAML.
 type Target struct {
+	// Rig selects an embedded local stack. Only value: "local". Empty
+	// (default) uses gateway_url / coordinator_url verbatim. When set,
+	// Providers must be non-empty and GatewayURL / CoordinatorURL /
+	// BuyerToken / CoordinatorDB* / GatewayDB* must be unset.
+	Rig string `yaml:"rig"`
+
+	// Providers configures the embedded rig's synthetic providers.
+	// Only consulted when Rig == "local". Empty in rig mode is a
+	// validation error — a rig with no providers can't serve requests.
+	Providers []RigProvider `yaml:"providers"`
+
 	GatewayURL     string `yaml:"gateway_url"`
 	CoordinatorURL string `yaml:"coordinator_url"`
 
@@ -355,14 +431,22 @@ func (s *Scenario) Validate() error {
 }
 
 func (s *Scenario) validateBuyerFleet() error {
-	if s.Target.GatewayURL == "" {
-		return fmt.Errorf("target.gateway_url is required")
+	if err := s.validateRigTarget(); err != nil {
+		return err
 	}
-	if s.Target.BuyerToken == "" && s.Target.DemoIdentity == "" {
-		return fmt.Errorf("target requires either buyer_token or demo_identity")
-	}
-	if s.Target.BuyerToken != "" && s.Target.DemoIdentity != "" {
-		return fmt.Errorf("target.buyer_token and target.demo_identity are mutually exclusive")
+	if s.Target.Rig == "" {
+		if s.Target.GatewayURL == "" {
+			return fmt.Errorf("target.gateway_url is required")
+		}
+		if s.Target.BuyerToken == "" && s.Target.DemoIdentity == "" {
+			return fmt.Errorf("target requires either buyer_token or demo_identity")
+		}
+		if s.Target.BuyerToken != "" && s.Target.DemoIdentity != "" {
+			return fmt.Errorf("target.buyer_token and target.demo_identity are mutually exclusive")
+		}
+		if err := s.validateProdLoadGuard(); err != nil {
+			return err
+		}
 	}
 	if (s.Target.CoordinatorDBSSH != "") != (s.Target.GatewayDBSSH != "") {
 		return fmt.Errorf("target.coordinator_db_ssh and target.gateway_db_ssh must be set together")
@@ -510,6 +594,115 @@ func (s *Scenario) validateSKUEcon() error {
 		return fmt.Errorf("benchmark_synthesis.ttft_fraction_of_ceiling must be > 0")
 	}
 	return nil
+}
+
+// validateRigTarget enforces the mutual-exclusion + shape rules for
+// Target.Rig. Rig-mode scenarios (Rig="local") must not carry
+// remote-target fields — the rig fills them at start-time — and their
+// Providers list must be non-empty with each entry structurally sound.
+func (s *Scenario) validateRigTarget() error {
+	if s.Target.Rig == "" {
+		if len(s.Target.Providers) > 0 {
+			return fmt.Errorf("target.providers must not be set unless target.rig is set")
+		}
+		return nil
+	}
+	if s.Target.Rig != "local" {
+		return fmt.Errorf("target.rig must be one of \"\"|local (got %q)", s.Target.Rig)
+	}
+	if s.Target.GatewayURL != "" {
+		return fmt.Errorf("target.gateway_url must not be set when target.rig=local (the rig supplies it)")
+	}
+	if s.Target.CoordinatorURL != "" {
+		return fmt.Errorf("target.coordinator_url must not be set when target.rig=local (the rig supplies it)")
+	}
+	if s.Target.BuyerToken != "" {
+		return fmt.Errorf("target.buyer_token must not be set when target.rig=local (the rig mints it)")
+	}
+	if s.Target.DemoIdentity != "" {
+		return fmt.Errorf("target.demo_identity is unsupported when target.rig=local")
+	}
+	if s.Target.CoordinatorDBPath != "" || s.Target.GatewayDBPath != "" {
+		return fmt.Errorf("target.coordinator_db_path / target.gateway_db_path must not be set when target.rig=local (the rig supplies them)")
+	}
+	if s.Target.CoordinatorDBSSH != "" || s.Target.GatewayDBSSH != "" {
+		return fmt.Errorf("target.coordinator_db_ssh / target.gateway_db_ssh are unsupported when target.rig=local")
+	}
+	if len(s.Target.Providers) == 0 {
+		return fmt.Errorf("target.providers must list at least one entry when target.rig=local")
+	}
+	seenIDs := make(map[string]int, len(s.Target.Providers))
+	for i, p := range s.Target.Providers {
+		if strings.TrimSpace(p.ID) == "" {
+			return fmt.Errorf("target.providers[%d].id is required", i)
+		}
+		if prior, dup := seenIDs[p.ID]; dup {
+			return fmt.Errorf("target.providers[%d].id %q duplicates target.providers[%d].id", i, p.ID, prior)
+		}
+		seenIDs[p.ID] = i
+		if strings.TrimSpace(p.Model) == "" {
+			return fmt.Errorf("target.providers[%d].model is required", i)
+		}
+		if p.TTFTMs < 0 {
+			return fmt.Errorf("target.providers[%d].ttft_ms must be >= 0", i)
+		}
+		if p.TokensPerSec < 0 {
+			return fmt.Errorf("target.providers[%d].tokens_per_sec must be >= 0", i)
+		}
+		if p.CapacitySlots < 1 {
+			return fmt.Errorf("target.providers[%d].capacity_slots must be >= 1", i)
+		}
+	}
+	// Every model referenced by prompts must be advertised by at least
+	// one rig provider; otherwise the coordinator has no eligible
+	// candidate and every request 502s.
+	advertised := make(map[string]bool, len(s.Target.Providers))
+	for _, p := range s.Target.Providers {
+		advertised[p.Model] = true
+	}
+	for i, p := range s.Prompts {
+		if p.Model != "" && !advertised[p.Model] {
+			return fmt.Errorf("prompts[%d].model %q is not advertised by any target.providers entry", i, p.Model)
+		}
+	}
+	return nil
+}
+
+// validateProdLoadGuard rejects high-concurrency buyer fleets aimed at
+// a *.streamvc.live host unless the operator explicitly sets
+// ALLOW_PROD_LOAD=1 in the environment. The load-lane charter (BUILD_SPEC
+// LOAD/FAIRNESS §6 anti-scope) forbids >10 buyers against production;
+// the guard catches the authoring mistake of leaving gateway_url pointed
+// at api.streamvc.live in a load scenario.
+//
+// Only evaluated for buyer-fleet mode; sku-econ scenarios do their own
+// host pinning in validateSKUEcon.
+func (s *Scenario) validateProdLoadGuard() error {
+	if s.Buyers.Count <= ProdLoadGuardBuyerLimit {
+		return nil
+	}
+	u, err := url.Parse(s.Target.GatewayURL)
+	if err != nil {
+		// If the URL doesn't parse we defer to whatever downstream code
+		// tries to dial it; no host we can inspect means no guard trip.
+		return nil
+	}
+	// Normalize the trailing DNS root dot before the suffix check —
+	// `api.streamvc.live.` and `api.streamvc.live` are equivalent under
+	// DNS, but the raw string suffix comparison would miss the dotted
+	// form and let the guard be bypassed via an authoring trick.
+	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+	if host == "" {
+		return nil
+	}
+	if !strings.HasSuffix(host, prodHostSuffix) && host != strings.TrimPrefix(prodHostSuffix, ".") {
+		return nil
+	}
+	if os.Getenv(ProdLoadGuardEnv) == "1" {
+		return nil
+	}
+	return fmt.Errorf("buyers.count=%d against production host %q requires %s=1 (load scenarios should target a local rig; see target.rig=local)",
+		s.Buyers.Count, host, ProdLoadGuardEnv)
 }
 
 // PromptFor picks the prompt for a given (buyer_index, request_index).

--- a/test/network-harness/scenarios/17_sustained_load_baseline.yaml
+++ b/test/network-harness/scenarios/17_sustained_load_baseline.yaml
@@ -1,0 +1,120 @@
+# 17_sustained_load_baseline.yaml — phase-A load/fairness baseline.
+#
+# Scale target: 20 concurrent buyers × 30 requests each = 600 requests
+# over a 900s window at aggregate ~40 req/min (~0.67 req/sec). This is
+# where scenarios 01-11 stop and the load/fairness lane begins. Existing
+# scenarios cap at 5 buyers (01) or 2 buyers (07); we scale to 20 to
+# start surfacing routing distribution + tail latency + starvation floor.
+#
+# What we want to learn (phase A, RECORDED not asserted):
+#  - Route distribution: does coord spread ~evenly across 3 rig providers
+#    (fast/baseline/slow), or does one provider dominate?
+#  - Fairness metrics: Gini, stddev, and max/min ratio each summarize
+#    the distribution differently — reporting all three lets phase-B
+#    triage pick the one worth invariant-gating after ≥5 clean runs.
+#  - Tail latency by prompt class: short (16 tok) vs medium (200 tok).
+#    p95/p99 shape is where beta providers' capacity questions land.
+#  - Starvation floor: does any Ready provider serve zero requests over
+#    the 15-minute window? Winner-takes-all routing would show here.
+#
+# What gets asserted: the 4 hard invariants (I1-I4) only. Load-lane
+# soft benchmarks (fairness thresholds, tail budgets, starvation
+# minimums) stay descriptive for at least 5 successful runs before
+# any consideration of hard invariants I6+. See BUILD_SPEC LOAD
+# FAIRNESS §4.
+#
+# Why a local rig, not Pearl:
+#  - Anti-scope forbids >10 concurrent buyers against api.streamvc.live.
+#    Sustained 20-buyer soak against production would (a) trip rate
+#    limits and skew the measurements, (b) risk DoS'ing ourselves
+#    during the beta acquisition window, (c) interfere with real
+#    providers connected to production.
+#  - The load-lane charter is measurement, not source-code change; the
+#    coord + gateway binaries running under the rig are the same ones
+#    Pearl runs, and the rig's routing decisions are the ones we care
+#    about — the providers we replace with fakes are the OTHER side of
+#    the boundary, standing in for real Mac hardware.
+#
+# Rig fleet (fast/baseline/slow shapes are asymmetric-on-purpose so
+# the fairness metrics have signal from the very first run):
+#  - fake-fast:     TTFT 50ms, 120 tok/s, 128 concurrent slots
+#  - fake-baseline: TTFT 200ms, 80 tok/s, 128 concurrent slots
+#  - fake-slow:     TTFT 800ms, 40 tok/s, 128 concurrent slots
+#
+# capacity_slots is set high so the baseline measures ROUTING FAIRNESS,
+# not CAPACITY CONTENTION. First-run empirical: at capacity_slots=4 per
+# provider, aggregate 40 rps against the coord's preferred provider
+# exhausted its slots, the 429 retry path produced 161/600 5xx and I1
+# failed because gateway logged 161 usage_events rows as OK while
+# harness observed 5xx. That's a legitimate accounting question but
+# it's scenario 20's job (burst_load_recovery), not the baseline's.
+# High slots decouples the two dimensions so PR 1's fairness numbers
+# are clean.
+#
+# Cost: local rig only — zero Pearl cost, zero provider cost.
+#
+# Follow-up scenarios (PR 2+): 18_sticky_session_honoring,
+# 19_asymmetric_fleet_starvation, 20_burst_load_recovery,
+# 21_ramp_load, 22_streaming_load.
+name: sustained_load_baseline
+description: |
+  20 concurrent buyers × 30 non-streaming requests over 15 minutes
+  against an embedded local rig with 3 synthetic providers of
+  differing speed/capacity. Records fairness (Gini + stddev + max/min
+  ratio), tail latency by prompt class (short/medium), and starvation
+  floor. Hard-invariant gate: I1-I4.
+
+expected_shape: |
+  Phase A load-lane baseline (descriptive; RECORDED not asserted):
+   - Total ~600 requests over 900s at ~40 req/min aggregate.
+   - Route distribution across the 3 rig providers RECORDED into
+     load_summary.json → route_distribution.
+   - Fairness metrics: Gini/stddev/max_min_ratio RECORDED, no target
+     until ≥5 baseline runs establish the noise floor.
+   - Latency p95/p99 by prompt class: short_16tok, medium_200tok.
+     A short-prompt p99 above ~5s or medium-prompt p99 above ~15s is
+     worth triage attention, but neither is asserted this PR.
+   - starvation_floor.min_requests_per_ready_provider > 0 across all
+     3 rig providers. Any zero-success Ready provider is a signal that
+     the routing policy is winner-takes-all; do not treat as PASS/FAIL
+     yet, capture for phase-B triage.
+   - I1-I4 all PASS. Any failure is a real routing/settlement bug
+     surfaced by scale, not a load-lane accounting artifact.
+
+target:
+  rig: local
+  providers:
+    - id: fake-fast
+      model: mlx-community/Qwen2.5-Coder-7B-Instruct-4bit
+      ttft_ms: 50
+      tokens_per_sec: 120
+      capacity_slots: 128
+    - id: fake-baseline
+      model: mlx-community/Qwen2.5-Coder-7B-Instruct-4bit
+      ttft_ms: 200
+      tokens_per_sec: 80
+      capacity_slots: 128
+    - id: fake-slow
+      model: mlx-community/Qwen2.5-Coder-7B-Instruct-4bit
+      ttft_ms: 800
+      tokens_per_sec: 40
+      capacity_slots: 128
+
+buyers:
+  count: 20
+  stream: false
+  pattern: interval
+  interval_ms: 500
+  requests_per_buyer: 30
+
+duration: 900s
+request_timeout: 60s
+silent_hang_threshold: 30s
+
+prompts:
+  - model: mlx-community/Qwen2.5-Coder-7B-Instruct-4bit
+    user: "Reply with exactly the word: alpha."
+    max_tokens: 16
+  - model: mlx-community/Qwen2.5-Coder-7B-Instruct-4bit
+    user: "Write a single concise paragraph about a yellow finch."
+    max_tokens: 200


### PR DESCRIPTION
## Summary

Kickstarts the load/fairness harness lane per `specs/BUILD_SPEC_LOAD_FAIRNESS_HARNESS_KICKSTART_PROMPT.md`.

- Adds `test/network-harness/internal/localrig/` — spawns real `coordinator` + `gateway` binaries on 127.0.0.1 with N in-process synthetic providers (configurable ttft / tokens-per-sec / capacity), so load-scale scenarios (20+ concurrent buyers) can run without touching Pearl. Same-shape rig pattern that `test/integration/harness_test.go` uses, lifted out of `testing.T` and callable from the scenario runner.
- Adds `test/network-harness/internal/loadmetrics/` — computes route distribution + fairness (Gini / stddev / max-min ratio) + tail latency by prompt class (short_16tok / medium_200tok) + starvation floor. Written to `load_summary.json` in every scenario's artifact bundle.
- Extends the scenario schema with `target.rig: local` + `target.providers: [...]`. When set, the harness auto-spawns the rig, mints a fresh gateway API key, and patches URLs / DB paths into the scenario before firing.
- Adds a DoS guard: `buyers.count > 10` against `*.streamvc.live` requires `ALLOW_PROD_LOAD=1` — a load scenario left pointed at api.streamvc.live by authoring mistake is a scenario-validation error, not a production trip.
- Adds `scenarios/17_sustained_load_baseline.yaml` — the first load scenario: 20 buyers × 30 requests × 15-minute window against 3 rig providers (fast / baseline / slow).

## Why local rig, not Pearl

Anti-scope §6 of the BUILD_SPEC forbids `> 10 concurrent buyers` against api.streamvc.live. Sustained 20-buyer soaks against production would (a) trip rate limits and skew the measurements, (b) risk DoS'ing ourselves during the beta acquisition window, (c) interfere with real providers connected to production. The chaos lane (#7) explicitly deferred the rig decision to the PR that first needed it — that's this one.

## Empirical finding from the first end-to-end run

Smoke run (5 buyers × 6 requests × 60s):

```
[load] route distribution: fake-fast=100.0%(30) fake-baseline=0.0%(0) fake-slow=0.0%(0)
[load] fairness: gini=0.667 stddev=14.14 max/min=30.00 over 3 providers
[load] latency short_16tok (count=15): p50=162ms p95=165ms p99=165ms
[load] latency medium_200tok (count=15): p50=163ms p95=443ms p99=443ms
[load] starvation floor: min=0 on fake-baseline (window=4s; zero-success=[fake-baseline fake-slow])
invariant I1 [PASS]: 30 matched pairs, no overbills
invariant I2 [PASS]: no 5xx observed
invariant I3 [PASS]: no overcharges
invariant I4 [PASS]: no silent hangs
all 4 hard invariants passed
```

Every one of 30 requests landed on `fake-fast` (advertised throughput 120 tps) — `fake-baseline` (80 tps) and `fake-slow` (40 tps) received zero. This is exactly the "winner-takes-all" signal the fairness lane was designed to surface: the coordinator appears to preferentially route to the provider with the highest advertised throughput estimate when all candidates are otherwise eligible, and does so deterministically enough that a homogeneous prompt fleet lands entirely on one provider.

**Phase-A discipline says RECORD, not FAIL.** I1-I4 all pass — no money-path bug — and load-lane soft benchmarks stay descriptive for at least 5 clean runs before any consideration of hard invariants I6+ (BUILD_SPEC §4). This finding goes into phase-B triage: is it a routing bug in coord, a policy question about the `objective` default, or the intended design given that providers self-report `throughput_tps_estimate`? Not a decision this PR makes; not one it should.

Full 15-minute scenario 17 run: TBD, artifacts attached when complete.

## Empirical scale ceiling

The harness client side has ample headroom — one goroutine per buyer, shared `http.Transport` with `MaxIdleConnsPerHost = Count`. On the current dev host, no client-side saturation is visible at 20 buyers. The bottleneck is downstream: `fake-fast` alone served all 30 smoke-run requests with peak latencies well under `request_timeout: 30s`. The full-scenario run will characterize what happens at 40 rps sustained against a single-provider hot spot.

## Follow-up roadmap

- **PR 2 — `18_sticky_session_honoring.yaml`** — same 20-buyer fleet with `sticky_conversation_key: "harness-buyer-%d"`. Records sticky honoring rate (SPEC-004 Pillar A). Requires SPEC-004 v0.3 quantified-tolerance amendment OR baseline recording only — will decide during PR 2 authoring based on this PR's phase-A findings.
- **PR 3 — `19_asymmetric_fleet_starvation.yaml`** — mix a fast provider (M4-Max) with a slow one (M1-8GB). Verifies slow provider still receives ≥N% of traffic. Given the winner-takes-all pattern surfaced in PR 1, this scenario likely reproduces + quantifies it under a scenario name that phase-B triage can codify.
- **PR 4 — `20_burst_load_recovery.yaml`** — `pattern: burst`, 100 concurrent requests at t=0. Rate limiter / breaker attribution.
- **PR 5 — `21_ramp_load.yaml`** — `pattern: ramp`, 300s ramp. Simulates a beta launch traffic curve.
- **PR 6 — `22_streaming_load.yaml`** — sustained streaming under similar scale. Different I3 semantics.

## What's not in this PR

- No source-code changes to `phase4-coordinator/`, `phase5-gateway/`, or `phase3-binary/` — anti-scope §6.
- No new hard invariants I6+. Baseline stays descriptive per phase-A.
- No streaming scenarios. Non-streaming has simpler I3 semantics; streaming lands in PR 6.
- No sticky-affinity assertions. Baseline is non-sticky; SPEC-004 sticky scenario is PR 2.
- No aggregator refactor of `internal/metrics/collector.go`. `internal/loadmetrics/` is additive; shared refactor waits for 2–3 load scenarios to reveal the shape.

## Rationale for fairness metric choice

Ship all three (Gini + stddev + max/min ratio) in the baseline PR per BUILD_SPEC §11:

- **Gini** — well-known, comparable to industry inequality measures, well-behaved at N=3–10 providers.
- **Stddev** — natural units (request count), easy for ops to reason about, insensitive to fleet size.
- **MaxMinRatio** — the number a beta provider actually cares about: "if I'm the worst, how much worse than the best?" Floors the divisor at 1 to avoid infinity when a Ready provider gets zero — companion `starvation_floor.providers_with_zero_success` gives triage the raw fact.

Phase-B triage picks the one to invariant-gate on after ≥5 clean runs establish per-metric noise floors. Locking that choice now would be premature.

## Test plan

- [x] `go test ./internal/scenario/... ./internal/loadmetrics/... ./internal/localrig/...` — unit tests + rig lifecycle smoke pass locally
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] Smoke run (5 buyers × 60s) — I1-I4 pass, load_summary.json well-formed
- [ ] Full run scenario 17 (20 buyers × 900s) — attach artifacts when complete
- [x] Three-lane codex audit — 0 CRITICAL / 0 HIGH / 0 MEDIUM across CODE, SECURITY, ARCHITECT
- [ ] Rebase clean on origin/main at merge time

## Rig architecture note

The `internal/localrig/` package duplicates ~40% of the coord+gateway spawn logic in `test/integration/harness_test.go`. This is deliberate for PR 1: the rig lives inside the scenario runner (not `testing.T`), and the integration package has strong test-runner assumptions we don't want to unpick under a load-lane deadline. A `TODO(shared-rig-refactor)` sits inside `internal/localrig/rig.go`; the shared refactor lands after 2–3 load scenarios reveal what the shared shape wants to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
