### PR TITLE
Protect gateway from runaway buyer bursts (#375)

### DIFF
--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -353,7 +353,8 @@ final class AutoUpdateTests: XCTestCase {
                     tokenValidated: true,
                     bearerlessDuplicate: false,
                     connected: true,
-                    stableReason: "tier_demoted"
+                    stableReason: "tier_demoted",
+                    acceptProvisional: false
                 )
             },
             drain: { _ in true },
@@ -416,7 +417,8 @@ final class AutoUpdateTests: XCTestCase {
                     tokenValidated: true,
                     bearerlessDuplicate: false,
                     connected: true,
-                    stableReason: "tier_demoted"
+                    stableReason: "tier_demoted",
+                    acceptProvisional: false
                 )
             },
             drain: { _ in true },

--- a/phase5-gateway/dist/deploy-pearl-vps.md
+++ b/phase5-gateway/dist/deploy-pearl-vps.md
@@ -32,8 +32,25 @@ the change-log / rollback runbook the script's comments cross-reference.
   - `GITHUB_OAUTH_CLIENT_SECRET`
 - `/opt/macprovider/gateway.yaml` — `coordinator.buyer_url: http://127.0.0.1:8443`,
   `quotas.reaper_interval_hours: 1`, `quotas.reservation_max_age_hours: 24`,
+  `quotas.account_concurrency: 4`,
+  `quotas.account_request_rate_per_second: 30`, and
   `quotas.demo_concurrency: 2` (M1-8). `deploy-pearl-vps.sh` does NOT
   overwrite this file.
+
+For upgrades from older gateway configs, edit `/opt/macprovider/gateway.yaml`
+before deploy and set:
+
+```yaml
+quotas:
+  account_concurrency: 4
+  account_request_rate_per_second: 30
+```
+
+Then validate the effective config and restart via the deploy script:
+
+```bash
+/opt/macprovider/gateway --config /opt/macprovider/gateway.yaml --check
+```
 
 ## Smoke checks after deploy
 

--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -61,7 +61,8 @@ quotas:
   account_daily_tokens: 100000
   demo_daily_tokens_per_ip: 1000
   demo_sessions_per_ip_per_hour: 10
-  account_concurrency: 2
+  account_concurrency: 4
+  account_request_rate_per_second: 30
   demo_concurrency: 2
   signup_accounts_per_ip_per_day: 3
   reaper_interval_hours: 1

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -95,14 +95,15 @@ type DemoConfig struct {
 }
 
 type QuotasConfig struct {
-	AccountDailyTokens        int64 `yaml:"account_daily_tokens"`
-	DemoDailyTokensPerIP      int64 `yaml:"demo_daily_tokens_per_ip"`
-	DemoSessionsPerIPPerHour  int   `yaml:"demo_sessions_per_ip_per_hour"`
-	AccountConcurrency        int   `yaml:"account_concurrency"`
-	DemoConcurrency           int   `yaml:"demo_concurrency"`
-	SignupAccountsPerIPPerDay int   `yaml:"signup_accounts_per_ip_per_day"`
-	ReaperIntervalHours       uint  `yaml:"reaper_interval_hours"`
-	ReservationMaxAgeHours    uint  `yaml:"reservation_max_age_hours"`
+	AccountDailyTokens          int64 `yaml:"account_daily_tokens"`
+	DemoDailyTokensPerIP        int64 `yaml:"demo_daily_tokens_per_ip"`
+	DemoSessionsPerIPPerHour    int   `yaml:"demo_sessions_per_ip_per_hour"`
+	AccountConcurrency          int   `yaml:"account_concurrency"`
+	AccountRequestRatePerSecond int   `yaml:"account_request_rate_per_second"`
+	DemoConcurrency             int   `yaml:"demo_concurrency"`
+	SignupAccountsPerIPPerDay   int   `yaml:"signup_accounts_per_ip_per_day"`
+	ReaperIntervalHours         uint  `yaml:"reaper_interval_hours"`
+	ReservationMaxAgeHours      uint  `yaml:"reservation_max_age_hours"`
 }
 
 type LimitsConfig struct {
@@ -185,23 +186,26 @@ func Default() Config {
 			AccountDailyTokens:       100000,
 			DemoDailyTokensPerIP:     1000,
 			DemoSessionsPerIPPerHour: 10,
-			// Issue #190: AccountConcurrency=3 matches phase-A
-			// network capacity (3 providers × 1 slot each) and the
-			// "user types follow-up while previous reply still
-			// streaming" UX pattern for paying buyers.
+			// Issue #375: AccountConcurrency=4 gives one runaway
+			// buyer enough headroom for normal multi-agent fan-out
+			// without letting a large local burst monopolize the
+			// provider pool. AccountRequestRatePerSecond is the
+			// gateway-edge steady request-start bucket for the same
+			// account_id.
 			// DemoConcurrency stays at 2 because M1-8 / PERF-6
 			// documented that 3+ parallel demo requests from one
 			// IP saturate the MLX-serialized provider pool for up
 			// to CoordinatorTimeout — an accidental DoS against
 			// paying buyers. Bumping the demo default to 3 would
 			// re-introduce that regression. Operators can override
-			// either via account_concurrency / demo_concurrency
-			// in gateway.yaml.
-			AccountConcurrency:        3,
-			DemoConcurrency:           2,
-			SignupAccountsPerIPPerDay: 3,
-			ReaperIntervalHours:       1,
-			ReservationMaxAgeHours:    24,
+			// account_concurrency, account_request_rate_per_second,
+			// or demo_concurrency in gateway.yaml.
+			AccountConcurrency:          4,
+			AccountRequestRatePerSecond: 30,
+			DemoConcurrency:             2,
+			SignupAccountsPerIPPerDay:   3,
+			ReaperIntervalHours:         1,
+			ReservationMaxAgeHours:      24,
 		},
 		Limits: LimitsConfig{
 			MaxTokensPerRequest:          4096,
@@ -388,6 +392,9 @@ func (c Config) Validate() error {
 	}
 	if c.Quotas.DemoSessionsPerIPPerHour <= 0 || c.Quotas.AccountConcurrency <= 0 || c.Quotas.SignupAccountsPerIPPerDay <= 0 {
 		return fmt.Errorf("quota counters must be positive")
+	}
+	if c.Quotas.AccountRequestRatePerSecond <= 0 {
+		return fmt.Errorf("quotas.account_request_rate_per_second must be positive")
 	}
 	if c.Quotas.DemoConcurrency <= 0 {
 		return fmt.Errorf("quotas.demo_concurrency must be positive")

--- a/phase5-gateway/internal/config/config_test.go
+++ b/phase5-gateway/internal/config/config_test.go
@@ -15,6 +15,16 @@ func TestQuotaReaperDefaults(t *testing.T) {
 	}
 }
 
+func TestAccountAdmissionDefaults(t *testing.T) {
+	cfg := Default()
+	if cfg.Quotas.AccountConcurrency != 4 {
+		t.Fatalf("AccountConcurrency=%d want 4", cfg.Quotas.AccountConcurrency)
+	}
+	if cfg.Quotas.AccountRequestRatePerSecond != 30 {
+		t.Fatalf("AccountRequestRatePerSecond=%d want 30", cfg.Quotas.AccountRequestRatePerSecond)
+	}
+}
+
 // Post-#92 (PR #167): header timeout must be >= the request budget so a
 // slow-but-valid streaming first-event (or non-streaming completion)
 // doesn't false-fail before the coordinator's own request_timeout_s
@@ -130,6 +140,15 @@ func TestQuotaReaperConfigValidation(t *testing.T) {
 				t.Fatalf("Validate error=%v want containing %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestAccountRequestRateConfigValidation(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.Quotas.AccountRequestRatePerSecond = 0
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "quotas.account_request_rate_per_second must be positive") {
+		t.Fatalf("Validate error=%v", err)
 	}
 }
 

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -154,6 +154,18 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		subject = usageSubject{AccountID: authn.Bearer.AccountID}
 	}
 	accountID = subject.AccountID
+	requestRate := s.chatStartLimits.allow(subject.AccountID, s.cfg.Quotas.AccountRequestRatePerSecond, s.now())
+	if !requestRate.Admitted {
+		slog.Warn("chat completion request rate limited",
+			"request_id", requestID(r),
+			"account_id", subject.AccountID,
+			"limit_rps", requestRate.Limit,
+			"retry_after_s", requestRate.RetryAfterSeconds,
+		)
+		setConcurrencyRateLimitHeaders(w, requestRate.Limit, requestRate.Remaining, requestRate.RetryAfterSeconds, s.now())
+		writeError(w, http.StatusTooManyRequests, "rate_limit_exceeded", "account_request_rate_exceeded", "Account request rate limit exceeded")
+		return
+	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, s.cfg.Limits.RequestBodyBytes+1))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_request_body", "Could not read request body")
@@ -264,6 +276,12 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	})
 	if errors.Is(concurrencyErr, storage.ErrQuotaExceeded) {
 		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+		slog.Warn("chat completion concurrency limited",
+			"request_id", requestID(r),
+			"account_id", subject.AccountID,
+			"limit", concurrencyLimit,
+			"retry_after_s", concurrencyRetryAfterSeconds,
+		)
 		// Issue #190: surface OpenAI-compatible concurrency
 		// rate-limit headers so client SDKs can self-pace
 		// instead of retrying blindly until 429.
@@ -359,7 +377,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 	structuredStreaming := chat.Stream && chat.hasStructuredOutput()
 	timing.markCoordinatorStart(s.now())
-	resp, err := s.doCoordinatorChatWithRetry(upCtx, r, buildUpReq)
+	resp, err := s.doCoordinatorChatWithRetry(upCtx, r, subject.AccountID, buildUpReq)
 	if err != nil {
 		if structuredStreaming && errors.Is(upCtx.Err(), context.DeadlineExceeded) {
 			if !s.settleBeforeResponse(w, r, subject, promptEstimate, 0, maxUsageTokens, "gateway_estimated", "provider_timeout") {
@@ -387,7 +405,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	s.forwardNonStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens)
 }
 
-func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Request, buildUpReq func() (*http.Request, error)) (*http.Response, error) {
+func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Request, accountID string, buildUpReq func() (*http.Request, error)) (*http.Response, error) {
 	maxAttempts := 1
 	if s.cfg.Retry503.Enabled {
 		maxAttempts = s.cfg.Retry503.MaxAttempts
@@ -453,19 +471,29 @@ func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Reque
 			return resp, nil
 		}
 		backoff := coord503RetryBackoff(attempt, s.cfg.Retry503)
-		slog.Info("gateway coord retry",
-			"request_id", requestID(r),
-			"attempt", attempt+1,
-			"backoff_ms", backoff.Milliseconds(),
-			"status", resp.StatusCode,
-			"body_code", openAIErrorCode(body),
-		)
 		select {
 		case <-time.After(backoff):
 			totalBackoffMS += backoff.Milliseconds()
 			if err := upCtx.Err(); err != nil {
 				return resp, nil
 			}
+			retryRate := s.chatStartLimits.allow(accountID, s.cfg.Quotas.AccountRequestRatePerSecond, s.now())
+			if !retryRate.Admitted {
+				slog.Warn("gateway coord retry request rate limited",
+					"request_id", requestID(r),
+					"account_id", accountID,
+					"limit_rps", retryRate.Limit,
+					"retry_after_s", retryRate.RetryAfterSeconds,
+				)
+				return resp, nil
+			}
+			slog.Info("gateway coord retry",
+				"request_id", requestID(r),
+				"attempt", attempt+1,
+				"backoff_ms", backoff.Milliseconds(),
+				"status", resp.StatusCode,
+				"body_code", openAIErrorCode(body),
+			)
 			_ = resp.Body.Close()
 		case <-upCtx.Done():
 			return resp, nil

--- a/phase5-gateway/internal/router/chat_proxy_retry_test.go
+++ b/phase5-gateway/internal/router/chat_proxy_retry_test.go
@@ -262,6 +262,28 @@ func TestGatewayCoord503RetryDisabledKeepsSingleDispatch(t *testing.T) {
 	assertRetryLogCounts(t, logs.String(), 0, 0, 0)
 }
 
+func TestGatewayCoord503RetryAttemptsRespectRequestRateLimit(t *testing.T) {
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, func(cfg *config.Config) {
+		cfg.Quotas.AccountRequestRatePerSecond = 1
+	})
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_rate_limited")
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "no_provider_available")
+	if calls != 1 {
+		t.Fatalf("coordinator calls=%d want 1; retry attempts must not multiply request-start rate", calls)
+	}
+}
+
 func TestGatewayCoord503RetryReplaysIdenticalRequestBodies(t *testing.T) {
 	var calls int
 	var seen [][]byte
@@ -401,6 +423,53 @@ func TestGatewayCoord503RetrySleepStopsOnBuyerCancel(t *testing.T) {
 	}
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("coordinator calls=%d want 1; retry sleep should be cancellable before second attempt", got)
+	}
+}
+
+func TestGatewayCoord503RetryCancelDoesNotConsumeRetryRateToken(t *testing.T) {
+	var calls atomic.Int32
+	firstAttemptReturned := make(chan struct{})
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			close(firstAttemptReturned)
+			return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, retryChatSuccessBody), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, func(cfg *config.Config) {
+		cfg.Quotas.AccountRequestRatePerSecond = 2
+		cfg.Retry503.BackoffBaseMs = 5000
+		cfg.Retry503.BackoffMaxMs = 5000
+	})
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_cancel_rate")
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(chatBody(false))).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+fullKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(resp, req)
+		close(done)
+	}()
+	select {
+	case <-firstAttemptReturned:
+	case <-time.After(time.Second):
+		t.Fatal("first coordinator attempt was not reached")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not return promptly after buyer cancel during retry sleep")
+	}
+
+	second := postChat(t, h, fullKey, chatBody(false), nil)
+	if second.Code != http.StatusOK {
+		t.Fatalf("second request status=%d body=%s; canceled retry sleep must not consume request-rate token", second.Code, second.Body.String())
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("coordinator calls=%d want 2; second request should reach upstream", got)
 	}
 }
 

--- a/phase5-gateway/internal/router/integration_test.go
+++ b/phase5-gateway/internal/router/integration_test.go
@@ -276,6 +276,102 @@ func TestAccountConcurrencyCap(t *testing.T) {
 	}
 }
 
+func TestAccountRequestRateLimitRejectsBurstBeforeUpstream(t *testing.T) {
+	now := fixedNow()
+	upstreamHits := make(chan struct{}, 4)
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		upstreamHits <- struct{}{}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_request_rate",
+			"object":"chat.completion",
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2},
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Quotas.AccountConcurrency = 10
+		cfg.Quotas.AccountRequestRatePerSecond = 2
+	}, WithNow(func() time.Time { return now }), WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_request_rate_burst")
+	body := `{"model":"llama","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}`
+
+	for i := 0; i < 2; i++ {
+		resp := postChat(t, h, key, body, nil)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("admitted request %d status=%d body=%s", i, resp.Code, resp.Body.String())
+		}
+	}
+	beforeReject := gatewaySettlementSnapshot(t, dbPath, "acct_request_rate_burst")
+	third := postChat(t, h, key, body, nil)
+	if third.Code != http.StatusTooManyRequests {
+		t.Fatalf("third request status=%d body=%s, want 429", third.Code, third.Body.String())
+	}
+	assertErrorCode(t, third.Body.String(), "account_request_rate_exceeded")
+	assertConcurrencyRejectHeaders(t, third, 2)
+	if got := len(upstreamHits); got != 2 {
+		t.Fatalf("upstream hits after rate rejection=%d want 2", got)
+	}
+	afterReject := gatewaySettlementSnapshot(t, dbPath, "acct_request_rate_burst")
+	if afterReject != beforeReject {
+		t.Fatalf("rate rejection changed settlement state: before=%+v after=%+v", beforeReject, afterReject)
+	}
+
+	now = now.Add(time.Second)
+	fourth := postChat(t, h, key, body, nil)
+	if fourth.Code != http.StatusOK {
+		t.Fatalf("request after refill status=%d body=%s", fourth.Code, fourth.Body.String())
+	}
+	if got := len(upstreamHits); got != 3 {
+		t.Fatalf("upstream hits after refill=%d want 3", got)
+	}
+}
+
+func TestRunawayBuyerBurstGetsQuick429sAtGateway(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		entered <- struct{}{}
+		<-release
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_runaway",
+			"object":"chat.completion",
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2},
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Quotas.AccountConcurrency = 1
+		cfg.Quotas.AccountRequestRatePerSecond = 100
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_runaway_burst")
+	body := `{"model":"llama","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}`
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() { done <- postChat(t, h, key, body, nil) }()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first upstream request")
+	}
+
+	for i := 0; i < 19; i++ {
+		resp := postChat(t, h, key, body, nil)
+		if resp.Code != http.StatusTooManyRequests {
+			t.Fatalf("burst request %d status=%d body=%s, want 429", i+2, resp.Code, resp.Body.String())
+		}
+		assertErrorCode(t, resp.Body.String(), "account_concurrency_exceeded")
+		assertConcurrencyRejectHeaders(t, resp, 1)
+	}
+
+	close(release)
+	first := <-done
+	if first.Code != http.StatusOK {
+		t.Fatalf("first in-flight response status=%d body=%s", first.Code, first.Body.String())
+	}
+}
+
 // Issue #190 R1 security HIGH helper: confirm chat responses are
 // non-cacheable so per-tenant headers cannot leak via a shared
 // CDN/proxy cache.

--- a/phase5-gateway/internal/router/request_rate_limiter.go
+++ b/phase5-gateway/internal/router/request_rate_limiter.go
@@ -1,0 +1,118 @@
+package router
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+const (
+	requestRateMaxBuckets    = 4096
+	requestRateBucketTTL     = 5 * time.Minute
+	requestRatePruneInterval = time.Minute
+)
+
+type requestRateDecision struct {
+	Admitted          bool
+	Limit             int
+	Remaining         int
+	RetryAfterSeconds int
+}
+
+type requestRateLimiter struct {
+	mu         sync.Mutex
+	buckets    map[string]*requestRateBucket
+	lastPruned time.Time
+}
+
+type requestRateBucket struct {
+	tokens   float64
+	last     time.Time
+	lastSeen time.Time
+}
+
+func newRequestRateLimiter() *requestRateLimiter {
+	return &requestRateLimiter{buckets: make(map[string]*requestRateBucket)}
+}
+
+func (l *requestRateLimiter) allow(key string, limit int, now time.Time) requestRateDecision {
+	if limit <= 0 || key == "" {
+		return requestRateDecision{Admitted: true, Limit: limit}
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	capacity := float64(limit)
+	bucket := l.buckets[key]
+	if bucket == nil {
+		l.pruneForInsertLocked(now)
+		bucket = &requestRateBucket{tokens: capacity, last: now}
+		l.buckets[key] = bucket
+	}
+	if elapsed := now.Sub(bucket.last).Seconds(); elapsed > 0 {
+		bucket.tokens = math.Min(capacity, bucket.tokens+elapsed*capacity)
+		bucket.last = now
+	}
+	bucket.lastSeen = now
+
+	if bucket.tokens >= 1 {
+		bucket.tokens--
+		return requestRateDecision{
+			Admitted:  true,
+			Limit:     limit,
+			Remaining: int(math.Floor(bucket.tokens)),
+		}
+	}
+
+	retryAfter := int(math.Ceil((1 - bucket.tokens) / capacity))
+	if retryAfter < 1 {
+		retryAfter = 1
+	}
+	return requestRateDecision{
+		Admitted:          false,
+		Limit:             limit,
+		Remaining:         0,
+		RetryAfterSeconds: retryAfter,
+	}
+}
+
+func (l *requestRateLimiter) pruneForInsertLocked(now time.Time) {
+	if len(l.buckets) < requestRateMaxBuckets {
+		if !l.lastPruned.IsZero() && now.Sub(l.lastPruned) < requestRatePruneInterval {
+			return
+		}
+		l.pruneExpiredLocked(now)
+		return
+	}
+	l.pruneExpiredLocked(now)
+	for len(l.buckets) >= requestRateMaxBuckets {
+		l.evictOldestLocked()
+	}
+}
+
+func (l *requestRateLimiter) pruneExpiredLocked(now time.Time) {
+	if !l.lastPruned.IsZero() && now.Sub(l.lastPruned) < requestRatePruneInterval && len(l.buckets) < requestRateMaxBuckets {
+		return
+	}
+	l.lastPruned = now
+	cutoff := now.Add(-requestRateBucketTTL)
+	for key, bucket := range l.buckets {
+		if bucket.lastSeen.Before(cutoff) {
+			delete(l.buckets, key)
+		}
+	}
+}
+
+func (l *requestRateLimiter) evictOldestLocked() {
+	var oldestKey string
+	var oldestSeen time.Time
+	for key, bucket := range l.buckets {
+		if oldestKey == "" || bucket.lastSeen.Before(oldestSeen) {
+			oldestKey = key
+			oldestSeen = bucket.lastSeen
+		}
+	}
+	if oldestKey != "" {
+		delete(l.buckets, oldestKey)
+	}
+}

--- a/phase5-gateway/internal/router/request_rate_limiter_test.go
+++ b/phase5-gateway/internal/router/request_rate_limiter_test.go
@@ -1,0 +1,46 @@
+package router
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestRequestRateLimiterCapsDistinctBuckets(t *testing.T) {
+	limiter := newRequestRateLimiter()
+	now := time.Unix(1_700_000_000, 0)
+
+	for i := 0; i < requestRateMaxBuckets+128; i++ {
+		decision := limiter.allow(fmt.Sprintf("acct-%04d", i), 1, now.Add(time.Duration(i)*time.Millisecond))
+		if !decision.Admitted {
+			t.Fatalf("new key %d rejected: %+v", i, decision)
+		}
+	}
+
+	if got := len(limiter.buckets); got != requestRateMaxBuckets {
+		t.Fatalf("bucket count=%d want hard cap %d", got, requestRateMaxBuckets)
+	}
+	if _, ok := limiter.buckets["acct-0000"]; ok {
+		t.Fatal("oldest bucket was not evicted at hard cap")
+	}
+	if _, ok := limiter.buckets[fmt.Sprintf("acct-%04d", requestRateMaxBuckets+127)]; !ok {
+		t.Fatal("newest bucket missing after cap eviction")
+	}
+}
+
+func TestRequestRateLimiterPrunesExpiredBeforeEvicting(t *testing.T) {
+	limiter := newRequestRateLimiter()
+	now := time.Unix(1_700_000_000, 0)
+
+	for i := 0; i < requestRateMaxBuckets; i++ {
+		limiter.allow(fmt.Sprintf("old-%04d", i), 1, now)
+	}
+	limiter.allow("fresh", 1, now.Add(requestRateBucketTTL+time.Second))
+
+	if got := len(limiter.buckets); got != 1 {
+		t.Fatalf("bucket count after stale prune=%d want 1", got)
+	}
+	if _, ok := limiter.buckets["fresh"]; !ok {
+		t.Fatal("fresh bucket missing after stale prune")
+	}
+}

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -61,6 +61,7 @@ type Server struct {
 	routingMeta     routingMetaCache
 	retry503Metrics *retry503Metrics
 	adminMetrics    *adminStateWriteMetrics
+	chatStartLimits *requestRateLimiter
 }
 
 // readStore returns the read-only view of the database. M2-4: this
@@ -165,6 +166,7 @@ func New(cfg config.Config, store Store, oauth auth.OAuthProvider, opts ...Optio
 		version:          "dev",
 		retry503Metrics:  newRetry503Metrics(),
 		adminMetrics:     newAdminStateWriteMetrics(),
+		chatStartLimits:  newRequestRateLimiter(),
 	}
 	for _, opt := range opts {
 		opt(s)

--- a/specs/SPEC-006-buyer-api.md
+++ b/specs/SPEC-006-buyer-api.md
@@ -1,7 +1,24 @@
 # SPEC-006 - Buyer API Gateway: Mac Provider's first public buyer surface
 
-**Version:** 0.9.6 (2026-07-06, bounded coordinator slot queue — issue #374)
+**Version:** 0.9.7 (2026-07-06, gateway per-account admission guard — issue #375)
 **Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.3, SPEC-003 v0.7, SPEC-004 v0.2
+
+**Change log v0.9.7 (2026-07-06, issue #375 — gateway per-account admission guard):**
+- Gateway enforces a per-account request-start token bucket before
+  forwarding `/v1/chat/completions` to the coordinator. Default steady
+  rate is `quotas.account_request_rate_per_second: 30` per gateway
+  instance; default
+  authenticated account concurrency is now `quotas.account_concurrency:
+  4`. Both remain operator-configurable in `gateway.yaml`.
+- The request-start token bucket is a non-authoritative abuse-shedding
+  guard. Persistent daily token quota and in-flight concurrency
+  reservations remain storage-backed and authoritative for money-path
+  accounting. Process restart may reset the request-start bucket; it
+  MUST NOT mint quota, bypass auth, or affect settlement.
+- Fast request-start rejection returns `429` with `Retry-After` and
+  OpenAI-compatible `X-RateLimit-*-Requests` headers; the gateway emits a
+  structured log line with `request_id`, `account_id`, `limit_rps`, and
+  `retry_after_s` for operator triage.
 
 **Change log v0.9.6 (2026-07-06, issue #374 — bounded coordinator slot queue):**
 - Non-pinned no-slot routing may use SPEC-002 v1.5.3's bounded
@@ -356,7 +373,7 @@ Buyer-facing responses MUST NOT include provider hostnames, internal coordinator
 
 The gateway MUST be horizontally scalable from day 1.
 
-The gateway MUST forbid in-process state for rate-limiting, quota, or session data.
+The gateway MUST forbid in-process authoritative quota, concurrency, billing, or session state. Non-authoritative process-local request-start buckets are allowed only for preflight abuse shedding as described in §4.6 and §7.3.
 
 The gateway MUST require data layer abstraction.
 
@@ -539,7 +556,7 @@ The metric MUST be reportable as a 7-day rolling distribution with median (p50) 
 No unbounded queueing.
 
 For non-pinned requests, the coordinator MAY wait in the bounded
-pre-dispatch slot queue described in section 7.7. If no slot becomes
+pre-dispatch slot queue described in section 7.8. If no slot becomes
 available before that deadline, return 503.
 
 Streaming cancellation: when client disconnects mid-SSE, gateway MUST cancel the upstream request to coordinator within 500ms.
@@ -778,7 +795,18 @@ Demo traffic MUST NOT bypass account signup issuance limits.
 
 Gateway request handlers MUST be stateless.
 
-The gateway MUST NOT keep in-process rate-limit counters.
+The gateway MUST NOT keep authoritative quota, concurrency, billing, or
+session state in-process.
+
+The gateway MAY keep a best-effort process-local request-start token
+bucket for abuse shedding before coordinator forwarding. That bucket is
+scoped to one gateway instance; multi-replica deployments multiply the
+effective aggregate request-start rate unless they add a shared
+admission layer. The bucket
+MUST be keyed by authenticated `account_id` or demo subject identity,
+MUST NOT be used for billing or settlement, and MUST NOT be the only
+guard for daily quota or in-flight concurrency. Daily quota and
+concurrency remain storage-backed authoritative controls.
 
 The gateway MUST NOT keep in-process quota state.
 
@@ -919,7 +947,7 @@ All authenticated API requests MUST accept:
 Authorization: Bearer mp_...
 ```
 
-All applicable responses MUST include:
+All applicable quota responses MUST include:
 
 ```text
 X-RateLimit-Limit
@@ -930,6 +958,14 @@ X-RateLimit-Reset
 When the request is authenticated, rate-limit headers describe the account daily token quota unless a more specific quota blocked the request.
 
 When the request is demo traffic, rate-limit headers describe the demo daily token quota.
+
+When request-start or concurrency admission blocks the request, the gateway MUST return `429`, SHOULD include `Retry-After`, and SHOULD include the OpenAI-compatible request-count headers:
+
+```text
+X-RateLimit-Limit-Requests
+X-RateLimit-Remaining-Requests
+X-RateLimit-Reset-Requests
+```
 
 The gateway MUST include:
 
@@ -1726,7 +1762,8 @@ Default quotas:
 
 - Account daily total tokens: 100,000.
 - Demo daily total tokens per IP: 1,000.
-- Per-account concurrent requests: 2.
+- Per-account concurrent requests: 4.
+- Per-account request-start rate: 30 requests per second per gateway instance.
 - Per-IP signup issuance per day: 3 accounts.
 - Authenticated max tokens per request: 4,096.
 - Demo max tokens per request: 512 unless configured otherwise.
@@ -1828,6 +1865,8 @@ The docs MUST explain reset behavior.
 
 Rate-limit headers MUST reflect post-decision quota state. For admitted requests this means after reservation; for rejected requests this means after the failed admission decision without subtracting rejected work.
 
+Request-start token buckets are preflight abuse-shedding controls, not quota ledgers. A request rejected by the request-start bucket MUST NOT create a quota reservation, usage event, coordinator request, buyer debit, or provider payout. In v1 the bucket is process-local, so the limit applies per gateway instance rather than globally across all replicas.
+
 ### 7.4 Quota enforcement order
 
 The gateway SHOULD enforce in this order:
@@ -1837,11 +1876,12 @@ The gateway SHOULD enforce in this order:
 3. request body size limit.
 4. auth or demo classification.
 5. account/key status.
-6. signup closed state for signup paths.
-7. per-request caps.
-8. quota availability.
-9. concurrency reservation.
-10. coordinator availability.
+6. request-start rate bucket for chat completions.
+7. signup closed state for signup paths.
+8. per-request caps.
+9. quota availability.
+10. concurrency reservation.
+11. coordinator availability.
 
 ### 7.5 Concurrency
 
@@ -1851,9 +1891,23 @@ The v1 implementation MAY use SQLite transactional reservations.
 
 A reservation MUST expire or be released on request completion, timeout, or cancellation.
 
-If the account has 2 active requests and the cap is 2, the third request MUST return 429.
+If the account has 4 active requests and the cap is 4, the fifth request MUST return 429 by default. Operators MAY tune the cap in `gateway.yaml`.
 
-### 7.6 Quota exhausted response
+### 7.6 Request-start rate exceeded response
+
+When the per-account request-start token bucket is exhausted before the first coordinator attempt, the gateway MUST return 429 before forwarding to the coordinator. If an already-admitted request exhausts the bucket while deciding whether to retry a transient coordinator response, the gateway MUST NOT make the extra retry attempt and MAY relay the current coordinator response.
+
+The error code SHOULD be:
+
+```text
+account_request_rate_exceeded
+```
+
+The response MUST include `Retry-After`.
+
+The gateway SHOULD emit a structured log line with at least `request_id`, `account_id`, `limit_rps`, and `retry_after_s`.
+
+### 7.7 Quota exhausted response
 
 When quota is exhausted, the gateway MUST return 429.
 
@@ -1865,7 +1919,7 @@ quota_exhausted
 
 The response MUST include `X-RateLimit-Reset`.
 
-### 7.7 Bounded slot queueing
+### 7.8 Bounded slot queueing
 
 The gateway MUST NOT queue requests indefinitely waiting for provider slots.
 
@@ -2563,7 +2617,8 @@ quotas:
   account_daily_tokens: 100000
   demo_daily_tokens_per_ip: 1000
   demo_sessions_per_ip_per_hour: 10
-  account_concurrency: 2
+  account_concurrency: 4
+  account_request_rate_per_second: 30
   signup_accounts_per_ip_per_day: 3
 
 limits:


### PR DESCRIPTION
## Summary
- Add a gateway-local per-account request-start token bucket for `/v1/chat/completions` before body read, quota reservation, and coordinator forwarding.
- Keep storage-backed quota and concurrency authoritative; request-start rejection returns 429 with OpenAI-compatible request-count headers and structured logs.
- Bound limiter bucket cardinality, debit retry attempts only when the retry will actually be made, and update SPEC-006 plus Pearl config migration docs.

Closes #375.

## Audit evidence
- Correctness/concurrency lane: 0 C/H/M.
- Security/money-path lane: 0 C/H/M.
- Architecture/spec lane: CLEAR, 0 C/H/M.

## Validation
- `go test ./... -count=1` in `phase5-gateway`
- `go vet ./...` in `phase5-gateway`
- `go test ./internal/router -run 'TestRequestRateLimiter|TestAccountRequestRateLimitRejectsBurstBeforeUpstream|TestRunawayBuyerBurstGetsQuick429sAtGateway|TestAccountConcurrencyCap|TestGatewayCoord503RetryAttemptsRespectRequestRateLimit|TestGatewayCoord503RetryCancelDoesNotConsumeRetryRateToken' -race -count=1` in `phase5-gateway`
- `go test ./... -count=1` in `phase4-coordinator`
- `go test ./... -count=1` in `test/integration`
- `git diff --check`
