### PR TITLE
Add network harness settlement regression scenarios (#303)

### DIFF
--- a/specs/NETWORK_HARNESS_BASELINE_V0_6_ISS303.md
+++ b/specs/NETWORK_HARNESS_BASELINE_V0_6_ISS303.md
@@ -1,0 +1,67 @@
+# Network harness v0.6 baseline - issue #303 settlement regressions
+
+Internal. Created 2026-07-06 for issue #303. This baseline adds
+network-harness coverage for the three streaming settlement paths that
+PR #288 already closed in production.
+
+## Scope
+
+The v0.6 scenario set adds:
+
+| Scenario | Path | Required live model rows | Expected closed signal |
+|---|---|---|---|
+| `12_moe_mid_stream_projection.yaml` | A - MoE mid-stream byte projection | `mlx-community/gpt-oss-20b-MXFP4-Q8`, `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | I1 requires `gateway_outcome=ok` and `gateway_token_source=provider_reported` on matched successes |
+| `13_dense_token_count_regression.yaml` | B - dense content downclamp | `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | buyer and gateway completion-token counts agree within 2 tokens; gateway and coordinator still agree exactly |
+| `14_sparse_provider_reported_tokens.yaml` | C - sparse English byte-estimate override | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` or issue-approved English-heavy Llama fallback | I1 requires `gateway_token_source=provider_reported`; `gateway_estimated` is a regression signal |
+
+Scenario number 11 is already committed as
+`11_sku_earn_viability.yaml`, so the issue #303 scenarios start at 12
+per the issue's "or per convention" acceptance clause.
+
+## Local validation baseline
+
+As of this baseline note, the scenarios have been validated for harness
+shape and schema compatibility, but not yet run as a live Pearl
+acceptance baseline.
+
+| Check | Result |
+|---|---|
+| `go test ./... -count=1` from `test/network-harness` | PASS |
+| dry-run `12_moe_mid_stream_projection.yaml` | PASS - scenario valid |
+| dry-run `13_dense_token_count_regression.yaml` | PASS - scenario valid |
+| dry-run `14_sparse_provider_reported_tokens.yaml` | PASS - scenario valid |
+
+## Live v0.6 baseline status
+
+Live v0.6 execution is pending fleet availability. Issue #303 requires
+the MoE, Qwen2.5-Coder-32B, and Llama sparse-English model classes to be
+actively serving on Pearl before the acceptance run is meaningful.
+
+When those model rows are available, run scenarios 12-14 against Pearl
+and record:
+
+| Scenario | I1 | I2 | I3 | I4 | Path closure evidence |
+|---|---|---|---|---|---|
+| 12 | PENDING | PENDING | PENDING | PENDING | record `gateway_outcome` and `gateway_token_source` from `ledger_reconcile.json` |
+| 13 | PENDING | PENDING | PENDING | PENDING | record max buyer/gateway/coordinator completion-token delta |
+| 14 | PENDING | PENDING | PENDING | PENDING | record `gateway_token_source` from `ledger_reconcile.json` |
+
+## Comparison against v0.5
+
+The repository has v0.1 and v0.2 benchmark baseline documents, but no
+committed v0.5 network-harness baseline file at the time this note was
+created. The v0.6 comparison therefore cannot quantify live deltas yet.
+
+Expected comparison once v0.5/v0.6 live artifacts are available:
+
+- Path A remains closed when no successful buyer stream maps to
+  `gateway_outcome=stream_output_exceeded`.
+- Path B remains closed when the largest successful buyer/gateway
+  completion-token delta is <= 2 tokens and gateway/coordinator settlement
+  still agrees exactly.
+- Path C remains closed when every successful matched pair reports
+  `gateway_token_source=provider_reported`.
+
+This document is intentionally not a substitute for the live acceptance
+run. It records the committed coverage surface and the evidence still
+needed to lock the live v0.6 baseline.

--- a/test/network-harness/README.md
+++ b/test/network-harness/README.md
@@ -172,11 +172,12 @@ to bring the provider back up.
 ## Cost discipline
 
 Scenarios target the live network and consume real provider time. The
-committed scenarios use conservative `max_tokens` (16–32) and small
-buyer fleets — a full pass of all 4 scenarios costs cents, not dollars.
-Before scaling a scenario up (e.g., 100 buyers, longer outputs), think
-about the bill. Pearl logs every settled request; don't run 10× the
-same scenario without reading the artifact bundle first.
+committed smoke and routing-discovery scenarios use conservative
+`max_tokens` (16-32) and small buyer fleets, while benchmark and
+settlement-regression scenarios intentionally use longer outputs. Before
+scaling a scenario up (e.g., 100 buyers, longer outputs), think about the
+bill. Pearl logs every settled request; don't run 10x the same scenario
+without reading the artifact bundle first.
 
 ## Artifact bundle
 
@@ -261,6 +262,14 @@ triage reads them as a set.
 | [`scenarios/04_wrong_model.yaml`](scenarios/04_wrong_model.yaml) | 3 buyers, nonexistent model | Negative-path error code + no-charge guarantee | BUYER_TOKEN, `pearl` SSH alias |
 | [`scenarios/05_mid_stream_drop.yaml`](scenarios/05_mid_stream_drop.yaml) | 1 streaming buyer + local launchd chaos at t=5s | Gateway behavior on mid-stream provider loss; billing of partial tokens | BUYER_TOKEN, `pearl` SSH alias, local launchd label |
 | [`scenarios/06_cold_start_race.yaml`](scenarios/06_cold_start_race.yaml) | Restart provider, buyer waits 2s, then fires before model loads | Cold-start window: queue / error / reroute / hang | BUYER_TOKEN, `pearl` SSH alias, local launchd label |
+| [`scenarios/07_sustained_throughput.yaml`](scenarios/07_sustained_throughput.yaml) | 2 buyers, paced streaming load | Benchmark TTFT, TPS, tail ratio, error rate, and slot utilization | BUYER_TOKEN, `pearl` SSH alias |
+| [`scenarios/08_cold_warm_compare.yaml`](scenarios/08_cold_warm_compare.yaml) | 10 cold/warm request pairs | Benchmark cold-start TTFT penalty | BUYER_TOKEN, `pearl` SSH alias |
+| [`scenarios/09_streaming_ttft_distribution.yaml`](scenarios/09_streaming_ttft_distribution.yaml) | 100 paced short streams | Benchmark TTFT histogram and tail ratio | BUYER_TOKEN, `pearl` SSH alias |
+| [`scenarios/10_provider_session_economics.yaml`](scenarios/10_provider_session_economics.yaml) | 10-minute low-load session | Benchmark provider slot utilization and earnings/hr | BUYER_TOKEN, `pearl` SSH alias |
+| [`scenarios/11_sku_earn_viability.yaml`](scenarios/11_sku_earn_viability.yaml) | Hardware matrix simulation | SKU-economics gate against live rate card | Packaged CLI, public coordinator |
+| [`scenarios/12_moe_mid_stream_projection.yaml`](scenarios/12_moe_mid_stream_projection.yaml) | MoE streaming regression | #303 Path A: premature `stream_output_exceeded` before provider usage | BUYER_TOKEN, `pearl` SSH alias, required MoE model rows |
+| [`scenarios/13_dense_token_count_regression.yaml`](scenarios/13_dense_token_count_regression.yaml) | Dense coding streams | #303 Path B: dense-content token downclamp drift | BUYER_TOKEN, `pearl` SSH alias, Qwen2.5-Coder-32B row |
+| [`scenarios/14_sparse_provider_reported_tokens.yaml`](scenarios/14_sparse_provider_reported_tokens.yaml) | Sparse English streams | #303 Path C: provider-reported tokens must beat byte estimates | BUYER_TOKEN, `pearl` SSH alias, Llama 3.1 8B row |
 
 See [`internal/scenario/schema.go`](internal/scenario/schema.go) for the
 authoritative field reference.

--- a/test/network-harness/internal/invariants/hard.go
+++ b/test/network-harness/internal/invariants/hard.go
@@ -118,9 +118,18 @@ func checkI1(sc *scenario.Scenario, ledger *reconcile.Result) Check {
 	gwOverbillVsHarness := ledger.GatewayOverbillVsHarnessTokens
 	absGwCoordMismatch := ledger.AbsGatewayCoordinatorMismatchTokens
 	tolerance := int64(0)
+	maxCompletionDelta := int64(0)
+	requiredGatewayOutcome := ""
+	requiredGatewayTokenSource := ""
 	if sc != nil {
 		tolerance = sc.ChargedDeliveredToleranceTokens
+		maxCompletionDelta = sc.MaxCompletionTokenDelta
+		requiredGatewayOutcome = sc.RequiredGatewayOutcome
+		requiredGatewayTokenSource = sc.RequiredGatewayTokenSource
 	}
+	completionDeltaPairs := completionTokenDeltaViolations(ledger, maxCompletionDelta)
+	gatewayOutcomePairs := gatewayOutcomeViolations(ledger, requiredGatewayOutcome)
+	gatewayTokenSourcePairs := gatewayTokenSourceViolations(ledger, requiredGatewayTokenSource)
 	unmatched := len(ledger.UnmatchedSuccesses)
 	unmatchedGwOK := len(ledger.UnmatchedGatewayOKRows)
 	unmatchedCoord2xx := len(ledger.UnmatchedCoordinator2xxRows)
@@ -145,6 +154,15 @@ func checkI1(sc *scenario.Scenario, ledger *reconcile.Result) Check {
 		driftSignals++
 	}
 	if gwOverbillVsHarness > tolerance {
+		driftSignals++
+	}
+	if len(completionDeltaPairs) > 0 {
+		driftSignals++
+	}
+	if len(gatewayOutcomePairs) > 0 {
+		driftSignals++
+	}
+	if len(gatewayTokenSourcePairs) > 0 {
 		driftSignals++
 	}
 	if absGwCoordMismatch > 0 {
@@ -182,6 +200,15 @@ func checkI1(sc *scenario.Scenario, ledger *reconcile.Result) Check {
 	if gwOverbillVsHarness > tolerance {
 		parts = append(parts, fmt.Sprintf("gateway over-billed by %d vs harness above tolerance %d across %d pair(s)", gwOverbillVsHarness, tolerance, len(ledger.OverbilledPairs)))
 	}
+	if len(completionDeltaPairs) > 0 {
+		parts = append(parts, fmt.Sprintf("%d buyer/gateway completion-token pair(s) exceeded max delta %d", len(completionDeltaPairs), maxCompletionDelta))
+	}
+	if len(gatewayOutcomePairs) > 0 {
+		parts = append(parts, fmt.Sprintf("%d matched pair(s) did not have required gateway outcome %q", len(gatewayOutcomePairs), requiredGatewayOutcome))
+	}
+	if len(gatewayTokenSourcePairs) > 0 {
+		parts = append(parts, fmt.Sprintf("%d matched pair(s) did not have required gateway token source %q", len(gatewayTokenSourcePairs), requiredGatewayTokenSource))
+	}
 	if absGwCoordMismatch > 0 {
 		parts = append(parts, fmt.Sprintf("gateway-coord ledger mismatch %d tokens across %d pair(s)", absGwCoordMismatch, len(ledger.GatewayCoordMismatchedPairs)))
 	}
@@ -196,11 +223,57 @@ func checkI1(sc *scenario.Scenario, ledger *reconcile.Result) Check {
 	c.OffendingIDs = append(c.OffendingIDs, ledger.UnmatchedGatewayOKRows...)
 	c.OffendingIDs = append(c.OffendingIDs, ledger.UnmatchedCoordinator2xxRows...)
 	c.OffendingIDs = append(c.OffendingIDs, ledger.OverbilledPairs...)
+	c.OffendingIDs = append(c.OffendingIDs, completionDeltaPairs...)
+	c.OffendingIDs = append(c.OffendingIDs, gatewayOutcomePairs...)
+	c.OffendingIDs = append(c.OffendingIDs, gatewayTokenSourcePairs...)
 	c.OffendingIDs = append(c.OffendingIDs, ledger.MatchedCoordMissing...)
 	c.OffendingIDs = append(c.OffendingIDs, ledger.GatewayCoordMismatchedPairs...)
 	c.OffendingIDs = append(c.OffendingIDs, ledger.AmbiguousExactGatewayIDs...)
 	c.OffendingIDs = append(c.OffendingIDs, ledger.AmbiguousExactCoordIDs...)
 	return c
+}
+
+func completionTokenDeltaViolations(ledger *reconcile.Result, maxDelta int64) []string {
+	if ledger == nil || maxDelta <= 0 {
+		return nil
+	}
+	var out []string
+	for _, p := range ledger.MatchedSuccesses {
+		delta := p.GatewayCompletionTokens - p.HarnessCompletionTokens
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta > maxDelta {
+			out = append(out, p.HarnessRequestID)
+		}
+	}
+	return out
+}
+
+func gatewayOutcomeViolations(ledger *reconcile.Result, required string) []string {
+	if ledger == nil || required == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range ledger.MatchedSuccesses {
+		if p.GatewayOutcome != required {
+			out = append(out, p.HarnessRequestID)
+		}
+	}
+	return out
+}
+
+func gatewayTokenSourceViolations(ledger *reconcile.Result, required string) []string {
+	if ledger == nil || required == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range ledger.MatchedSuccesses {
+		if p.GatewayTokenSource != required {
+			out = append(out, p.HarnessRequestID)
+		}
+	}
+	return out
 }
 
 // I2 — no 5xx response without a billing settlement entry on the

--- a/test/network-harness/internal/invariants/hard_test.go
+++ b/test/network-harness/internal/invariants/hard_test.go
@@ -158,6 +158,70 @@ func TestCheckI1_HarnessUnderbillAlone_Passes(t *testing.T) {
 	}
 }
 
+func TestCheckI1_MaxCompletionTokenDeltaFailsEitherDirection(t *testing.T) {
+	sc := &scenario.Scenario{MaxCompletionTokenDelta: 2}
+	ledger := &reconcile.Result{
+		MatchedSuccesses: []reconcile.MatchedPair{
+			{HarnessRequestID: "under", HarnessCompletionTokens: 20, GatewayCompletionTokens: 17},
+			{HarnessRequestID: "over", HarnessCompletionTokens: 20, GatewayCompletionTokens: 23},
+			{HarnessRequestID: "inside", HarnessCompletionTokens: 20, GatewayCompletionTokens: 18},
+		},
+	}
+	c := checkI1(sc, ledger)
+	if c.Passed {
+		t.Fatal("I1 should fail when configured completion-token delta is exceeded")
+	}
+	if !contains(c.OffendingIDs, "under") || !contains(c.OffendingIDs, "over") {
+		t.Fatalf("offending ids should include both over-limit deltas, got %v", c.OffendingIDs)
+	}
+	if contains(c.OffendingIDs, "inside") {
+		t.Fatalf("delta at tolerance should not be offending, got %v", c.OffendingIDs)
+	}
+	if !strings.Contains(c.Detail, "completion-token") {
+		t.Fatalf("detail should call out completion-token delta: %s", c.Detail)
+	}
+}
+
+func TestCheckI1_RequiredGatewayOutcomeFailsMismatches(t *testing.T) {
+	sc := &scenario.Scenario{RequiredGatewayOutcome: "ok"}
+	ledger := &reconcile.Result{
+		MatchedSuccesses: []reconcile.MatchedPair{
+			{HarnessRequestID: "ok", GatewayOutcome: "ok"},
+			{HarnessRequestID: "fallback", GatewayOutcome: "stream_output_exceeded"},
+		},
+	}
+	c := checkI1(sc, ledger)
+	if c.Passed {
+		t.Fatal("I1 should fail when a matched pair has the wrong gateway outcome")
+	}
+	if !contains(c.OffendingIDs, "fallback") || contains(c.OffendingIDs, "ok") {
+		t.Fatalf("offending ids should contain only the mismatched outcome pair, got %v", c.OffendingIDs)
+	}
+	if !strings.Contains(c.Detail, "required gateway outcome") {
+		t.Fatalf("detail should call out required gateway outcome: %s", c.Detail)
+	}
+}
+
+func TestCheckI1_RequiredGatewayTokenSourceFailsMismatches(t *testing.T) {
+	sc := &scenario.Scenario{RequiredGatewayTokenSource: "provider_reported"}
+	ledger := &reconcile.Result{
+		MatchedSuccesses: []reconcile.MatchedPair{
+			{HarnessRequestID: "reported", GatewayTokenSource: "provider_reported"},
+			{HarnessRequestID: "estimated", GatewayTokenSource: "gateway_estimated"},
+		},
+	}
+	c := checkI1(sc, ledger)
+	if c.Passed {
+		t.Fatal("I1 should fail when a matched pair has the wrong gateway token source")
+	}
+	if !contains(c.OffendingIDs, "estimated") || contains(c.OffendingIDs, "reported") {
+		t.Fatalf("offending ids should contain only the mismatched token-source pair, got %v", c.OffendingIDs)
+	}
+	if !strings.Contains(c.Detail, "required gateway token source") {
+		t.Fatalf("detail should call out required gateway token source: %s", c.Detail)
+	}
+}
+
 // Net-zero with hidden overbill: +10 in one pair, -10 in another → Net
 // = 0 but positive-overbill = 10. Must fail. This is the CRITICAL the
 // R1 audit caught.

--- a/test/network-harness/internal/reconcile/ledger.go
+++ b/test/network-harness/internal/reconcile/ledger.go
@@ -240,6 +240,7 @@ type MatchedPair struct {
 	HarnessTotalTokens          int64  `json:"harness_total_tokens"`
 	GatewayTotalTokens          int64  `json:"gateway_total_tokens"`
 	GatewayCompletionTokens     int64  `json:"gateway_completion_tokens"`
+	GatewayTokenSource          string `json:"gateway_token_source,omitempty"`
 	GatewayOutcome              string `json:"gateway_outcome"`                // "ok" or SPEC-006 §17.7 fallback name; distinguishes coord-missing severity
 	GatewayMatchMethod          string `json:"gateway_match_method,omitempty"` // "exact_id" | "fuzzy_token_ts"
 	CoordinatorRequestID        string `json:"coordinator_request_id,omitempty"`
@@ -829,6 +830,7 @@ func matchExactPass(r *Result, ordered []buyer.Result, gwPool *[]gwRow, coordPoo
 			GatewayAccountID:        g.AccountID,
 			GatewayCompletionTokens: g.CompletionTokens,
 			GatewayTotalTokens:      gatewayTotalTokens(g),
+			GatewayTokenSource:      g.TokenSource,
 			GatewayOutcome:          g.Outcome,
 			GatewayLagMs:            g.CreatedAt.Sub(h.StartUTC).Milliseconds(),
 		}
@@ -871,6 +873,7 @@ func matchFuzzyPass(r *Result, deferred []buyer.Result, gwPool *[]gwRow, coordPo
 			GatewayAccountID:        g.AccountID,
 			GatewayCompletionTokens: g.CompletionTokens,
 			GatewayTotalTokens:      gatewayTotalTokens(g),
+			GatewayTokenSource:      g.TokenSource,
 			GatewayOutcome:          g.Outcome,
 			GatewayLagMs:            g.CreatedAt.Sub(h.StartUTC).Milliseconds(),
 		}
@@ -1193,6 +1196,7 @@ type gwRow struct {
 	PromptTokens     int64
 	CompletionTokens int64
 	TotalTokens      int64
+	TokenSource      string
 	Outcome          string
 	CreatedAt        time.Time
 }
@@ -1466,14 +1470,22 @@ func queryGateway(path string, start, end time.Time) ([]gwRow, bool, error) {
 	if hasAcct {
 		acctExpr = "COALESCE(account_id, '')"
 	}
+	hasTokenSource, err := columnExists(db, "usage_events", "token_source")
+	if err != nil {
+		return nil, false, fmt.Errorf("probe usage_events.token_source: %w", err)
+	}
+	tokenSourceExpr := "''"
+	if hasTokenSource {
+		tokenSourceExpr = "COALESCE(token_source, '')"
+	}
 	promptExpr, completionExpr, totalExpr, err := gatewayTokenExprs(db)
 	if err != nil {
 		return nil, false, err
 	}
 	rows, err := db.Query(fmt.Sprintf(`
-				SELECT request_id, %s, %s, %s, %s, outcome, created_at
+				SELECT request_id, %s, %s, %s, %s, %s, outcome, created_at
 				FROM usage_events
-			`, acctExpr, promptExpr, completionExpr, totalExpr))
+			`, acctExpr, promptExpr, completionExpr, totalExpr, tokenSourceExpr))
 	if err != nil {
 		return nil, false, err
 	}
@@ -1482,7 +1494,7 @@ func queryGateway(path string, start, end time.Time) ([]gwRow, bool, error) {
 	for rows.Next() {
 		var g gwRow
 		var ts string
-		if err := rows.Scan(&g.RequestID, &g.AccountID, &g.PromptTokens, &g.CompletionTokens, &g.TotalTokens, &g.Outcome, &ts); err != nil {
+		if err := rows.Scan(&g.RequestID, &g.AccountID, &g.PromptTokens, &g.CompletionTokens, &g.TotalTokens, &g.TokenSource, &g.Outcome, &ts); err != nil {
 			return nil, false, err
 		}
 		g.CreatedAt, _ = time.Parse(time.RFC3339Nano, ts)
@@ -1534,16 +1546,24 @@ func queryGatewayByIDs(path string, ids []string) ([]gwRow, error) {
 	if hasAcct {
 		acctExpr = "COALESCE(account_id, '')"
 	}
+	hasTokenSource, err := columnExists(db, "usage_events", "token_source")
+	if err != nil {
+		return nil, fmt.Errorf("probe usage_events.token_source: %w", err)
+	}
+	tokenSourceExpr := "''"
+	if hasTokenSource {
+		tokenSourceExpr = "COALESCE(token_source, '')"
+	}
 	promptExpr, completionExpr, totalExpr, err := gatewayTokenExprs(db)
 	if err != nil {
 		return nil, err
 	}
 	placeholders, args := inClause(ids)
 	rows, err := db.Query(fmt.Sprintf(`
-				SELECT request_id, %s, %s, %s, %s, outcome, created_at
+				SELECT request_id, %s, %s, %s, %s, %s, outcome, created_at
 				FROM usage_events
 			WHERE request_id IN (%s)
-		`, acctExpr, promptExpr, completionExpr, totalExpr, placeholders), args...)
+		`, acctExpr, promptExpr, completionExpr, totalExpr, tokenSourceExpr, placeholders), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1552,7 +1572,7 @@ func queryGatewayByIDs(path string, ids []string) ([]gwRow, error) {
 	for rows.Next() {
 		var g gwRow
 		var ts string
-		if err := rows.Scan(&g.RequestID, &g.AccountID, &g.PromptTokens, &g.CompletionTokens, &g.TotalTokens, &g.Outcome, &ts); err != nil {
+		if err := rows.Scan(&g.RequestID, &g.AccountID, &g.PromptTokens, &g.CompletionTokens, &g.TotalTokens, &g.TokenSource, &g.Outcome, &ts); err != nil {
 			return nil, err
 		}
 		g.CreatedAt, _ = time.Parse(time.RFC3339Nano, ts)

--- a/test/network-harness/internal/reconcile/ledger_test.go
+++ b/test/network-harness/internal/reconcile/ledger_test.go
@@ -1293,6 +1293,59 @@ func insertGwRow(t *testing.T, path, requestID, accountID string, completionToke
 	}
 }
 
+func TestQueryGatewayCarriesTokenSourceWhenPresent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gateway.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open gateway db: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE usage_events (
+		request_id        TEXT NOT NULL,
+		account_id        TEXT NOT NULL DEFAULT '',
+		completion_tokens INTEGER NOT NULL DEFAULT 0,
+		token_source      TEXT NOT NULL,
+		outcome           TEXT NOT NULL,
+		created_at        TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("create usage_events: %v", err)
+	}
+	at := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	if _, err := db.Exec(
+		`INSERT INTO usage_events(request_id, account_id, completion_tokens, token_source, outcome, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"req_token_source", "acct", 12, "provider_reported", "ok", at.Format(time.RFC3339Nano),
+	); err != nil {
+		t.Fatalf("insert gw row: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	rows, hasAccountID, err := queryGateway(path, at.Add(-time.Second), at.Add(time.Second))
+	if err != nil {
+		t.Fatalf("queryGateway err: %v", err)
+	}
+	if !hasAccountID {
+		t.Fatal("hasAccountID=false, want true")
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d want 1", len(rows))
+	}
+	if rows[0].TokenSource != "provider_reported" {
+		t.Fatalf("TokenSource=%q want provider_reported", rows[0].TokenSource)
+	}
+
+	byIDRows, err := queryGatewayByIDs(path, []string{"req_token_source"})
+	if err != nil {
+		t.Fatalf("queryGatewayByIDs err: %v", err)
+	}
+	if len(byIDRows) != 1 {
+		t.Fatalf("byIDRows=%d want 1", len(byIDRows))
+	}
+	if byIDRows[0].TokenSource != "provider_reported" {
+		t.Fatalf("byIDRows[0].TokenSource=%q want provider_reported", byIDRows[0].TokenSource)
+	}
+}
+
 // newTestCoordDB creates an empty request_log table in a fresh temp
 // SQLite file and returns its path. Same read-side projection rule
 // as newTestGatewayDB.

--- a/test/network-harness/internal/scenario/schema.go
+++ b/test/network-harness/internal/scenario/schema.go
@@ -34,6 +34,7 @@ var envVarPattern = regexp.MustCompile(`\$\{([A-Z_][A-Z0-9_]*)\}`)
 
 const (
 	maxChargedDeliveredToleranceTokens int64 = 16
+	maxCompletionTokenDelta            int64 = 16
 	MaxBuyerCount                            = 1000
 	MaxRequestsPerBuyer                      = 10000
 	MaxTotalBuyerRequests                    = 100000
@@ -72,6 +73,23 @@ type Scenario struct {
 	// ChargedDeliveredToleranceTokens allows scenarios with known tokenizer
 	// drift to permit a small charged-vs-delivered delta. Default 0.
 	ChargedDeliveredToleranceTokens int64 `yaml:"charged_delivered_tolerance_tokens"`
+
+	// MaxCompletionTokenDelta, when >0, makes I1 fail if any matched
+	// buyer/gateway success pair differs by more than this many completion
+	// tokens in either direction. Default 0 preserves existing scenarios,
+	// where gateway underbilling alone is treated as triage evidence.
+	MaxCompletionTokenDelta int64 `yaml:"max_completion_token_delta"`
+
+	// RequiredGatewayOutcome, when non-empty, makes I1 fail if any matched
+	// buyer/gateway success pair has a different gateway outcome. Default
+	// empty preserves existing scenarios where outcome details are triage
+	// evidence only.
+	RequiredGatewayOutcome string `yaml:"required_gateway_outcome"`
+
+	// RequiredGatewayTokenSource, when non-empty, makes I1 fail if any
+	// matched buyer/gateway success pair has a different gateway token
+	// source. Default empty preserves old snapshots and legacy scenarios.
+	RequiredGatewayTokenSource string `yaml:"required_gateway_token_source"`
 
 	// RequestTimeout is a per-request hard cap. Default 120s if unset.
 	RequestTimeout time.Duration `yaml:"request_timeout"`
@@ -406,6 +424,18 @@ func (s *Scenario) validateBuyerFleet() error {
 	}
 	if s.ChargedDeliveredToleranceTokens > maxChargedDeliveredToleranceTokens {
 		return fmt.Errorf("charged_delivered_tolerance_tokens must be <= %d", maxChargedDeliveredToleranceTokens)
+	}
+	if s.MaxCompletionTokenDelta < 0 {
+		return fmt.Errorf("max_completion_token_delta must be >= 0")
+	}
+	if s.MaxCompletionTokenDelta > maxCompletionTokenDelta {
+		return fmt.Errorf("max_completion_token_delta must be <= %d", maxCompletionTokenDelta)
+	}
+	if s.RequiredGatewayOutcome != strings.TrimSpace(s.RequiredGatewayOutcome) {
+		return fmt.Errorf("required_gateway_outcome must not have leading or trailing whitespace")
+	}
+	if s.RequiredGatewayTokenSource != strings.TrimSpace(s.RequiredGatewayTokenSource) {
+		return fmt.Errorf("required_gateway_token_source must not have leading or trailing whitespace")
 	}
 	if s.Target.CoordinatorDBSSH != "" && s.Target.CoordinatorDBPath != "" {
 		return fmt.Errorf("target.coordinator_db_ssh and target.coordinator_db_path are mutually exclusive")

--- a/test/network-harness/internal/scenario/schema_test.go
+++ b/test/network-harness/internal/scenario/schema_test.go
@@ -3,6 +3,7 @@ package scenario
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +24,24 @@ func TestValidateChargedDeliveredToleranceBounds(t *testing.T) {
 	sc.ChargedDeliveredToleranceTokens = maxChargedDeliveredToleranceTokens + 1
 	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "must be <=") {
 		t.Fatalf("oversized tolerance err=%v, want max validation", err)
+	}
+}
+
+func TestValidateMaxCompletionTokenDeltaBounds(t *testing.T) {
+	sc := validTestScenario()
+	sc.MaxCompletionTokenDelta = maxCompletionTokenDelta
+	if err := sc.Validate(); err != nil {
+		t.Fatalf("max completion-token delta should validate: %v", err)
+	}
+
+	sc.MaxCompletionTokenDelta = -1
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "must be >= 0") {
+		t.Fatalf("negative max completion-token delta err=%v, want >= 0 validation", err)
+	}
+
+	sc.MaxCompletionTokenDelta = maxCompletionTokenDelta + 1
+	if err := sc.Validate(); err == nil || !strings.Contains(err.Error(), "must be <=") {
+		t.Fatalf("oversized max completion-token delta err=%v, want max validation", err)
 	}
 }
 
@@ -183,6 +202,9 @@ func TestValidateRejectsNegativeNumericFields(t *testing.T) {
 		{"buyers.inter_pair_idle_seconds", func(s *Scenario) { s.Buyers.InterPairIdleSeconds = -1 }, "buyers.inter_pair_idle_seconds must be >= 0"},
 		{"prompts.max_tokens", func(s *Scenario) { s.Prompts[0].MaxTokens = -1 }, "prompts[0].max_tokens must be >= 0"},
 		{"charged_delivered_tolerance_tokens", func(s *Scenario) { s.ChargedDeliveredToleranceTokens = -1 }, "charged_delivered_tolerance_tokens must be >= 0"},
+		{"max_completion_token_delta", func(s *Scenario) { s.MaxCompletionTokenDelta = -1 }, "max_completion_token_delta must be >= 0"},
+		{"required_gateway_outcome whitespace", func(s *Scenario) { s.RequiredGatewayOutcome = " ok" }, "required_gateway_outcome must not have leading or trailing whitespace"},
+		{"required_gateway_token_source whitespace", func(s *Scenario) { s.RequiredGatewayTokenSource = "provider_reported " }, "required_gateway_token_source must not have leading or trailing whitespace"},
 		{"benchmark.provider_slots", func(s *Scenario) {
 			s.Benchmark.Enabled = true
 			s.Benchmark.Invariants = []string{"B1"}
@@ -385,6 +407,40 @@ duration: 1s
 	}
 	if sc.Target.BuyerToken != "expanded-token" {
 		t.Fatalf("buyer token=%q, want expanded-token", sc.Target.BuyerToken)
+	}
+}
+
+func TestCommittedScenariosValidate(t *testing.T) {
+	t.Setenv("BUYER_TOKEN", "test-buyer-token")
+
+	paths, err := filepath.Glob(filepath.Join("..", "..", "scenarios", "*.yaml"))
+	if err != nil {
+		t.Fatalf("glob scenarios: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no committed scenario files found")
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			mode, err := ProbeMode(path)
+			if err != nil {
+				t.Fatalf("ProbeMode err=%v", err)
+			}
+			var sc *Scenario
+			if mode == "sku-econ" {
+				sc, err = LoadNoEnv(path)
+			} else {
+				sc, err = Load(path)
+			}
+			if err != nil {
+				t.Fatalf("Load err=%v", err)
+			}
+			if err := sc.Validate(); err != nil {
+				t.Fatalf("Validate err=%v", err)
+			}
+		})
 	}
 }
 

--- a/test/network-harness/scenarios/12_moe_mid_stream_projection.yaml
+++ b/test/network-harness/scenarios/12_moe_mid_stream_projection.yaml
@@ -1,0 +1,65 @@
+# 12_moe_mid_stream_projection.yaml — issue #303 Path A regression.
+#
+# PR #288 closed a MoE streaming settlement failure where gateway byte
+# projection could trip stream_output_exceeded before the provider's final
+# usage chunk arrived. This live scenario keeps that path covered with the
+# two MoE model rows documented in #303.
+#
+# What gets asserted by hard invariants:
+#   - I1 fails if gateway/coord token ledgers drift or if a gateway
+#     stream_output_exceeded fallback overbills a clean-looking buyer stream.
+#   - I2 fails if any 5xx response lacks a request id / settlement row.
+#   - I3 fails if charged tokens exceed buyer-delivered tokens.
+#   - I4 fails on silent stream hangs.
+#
+# Expected live shape when the required models are present:
+#   - All successful streams settle outcome=ok.
+#   - ledger_reconcile.matched_successes should show no
+#     gateway_outcome=stream_output_exceeded rows.
+#   - ledger_reconcile.matched_successes should show
+#     gateway_token_source=provider_reported for successful streams.
+name: moe_mid_stream_projection_regression
+description: |
+  Issue #303 Path A regression coverage. Two streaming buyer requests
+  exercise the MoE rows that previously triggered premature gateway byte
+  projection before provider usage arrived.
+
+expected_shape: |
+  Issue #303 Path A:
+   - 2 total streaming requests, one per MoE model row when both are
+     available in the live fleet.
+   - Successful requests should reconcile with gateway_outcome=ok.
+   - Any stream_output_exceeded row on a request where the buyer did not
+     observe the gateway terminal SSE error envelope is a regression signal.
+   - ledger_reconcile.json should show gateway_token_source=provider_reported
+     for successful streams; inspect DB rows only when triaging a mismatch.
+   - If a required model is absent, the scenario is not a valid #303
+     acceptance run; treat no_provider_available as fleet setup missing.
+
+target:
+  gateway_url: https://api.streamvc.live
+  coordinator_url: https://coordinator.streamvc.live
+  buyer_token: ${BUYER_TOKEN}
+  coordinator_db_ssh: pearl:/var/lib/macprovider/coordinator.db
+  gateway_db_ssh: pearl:/var/lib/macprovider/gateway.db
+  db_sudo_user: macprovider
+
+buyers:
+  count: 1
+  stream: true
+  pattern: constant
+  requests_per_buyer: 2
+
+duration: 300s
+request_timeout: 120s
+silent_hang_threshold: 45s
+required_gateway_outcome: ok
+required_gateway_token_source: provider_reported
+
+prompts:
+  - model: mlx-community/gpt-oss-20b-MXFP4-Q8
+    user: "Write a compact but complete implementation plan for a tiny append-only log, including record format, crash recovery, and three invariants."
+    max_tokens: 192
+  - model: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit
+    user: "Write a Python implementation of a red-black tree insert operation with rotations, type hints, and a short explanation after the code."
+    max_tokens: 192

--- a/test/network-harness/scenarios/13_dense_token_count_regression.yaml
+++ b/test/network-harness/scenarios/13_dense_token_count_regression.yaml
@@ -1,0 +1,55 @@
+# 13_dense_token_count_regression.yaml — issue #303 Path B regression.
+#
+# PR #288 closed an old downclamp path that under-settled dense coding
+# output from Qwen2.5-Coder-32B by roughly 12 tokens. This scenario keeps a
+# live dense-code generation shape in the harness.
+#
+# What gets asserted by hard invariants:
+#   - I1 fails on gateway/coord mismatch or positive gateway overbill vs
+#     the buyer. This scenario also opts into a 2-token absolute completion
+#     delta gate so the historical 12-token under-settlement fails I1.
+#   - I2/I3/I4 retain the standard orphan-5xx, overcharge, and silent-hang
+#     protections.
+name: dense_token_count_regression
+description: |
+  Issue #303 Path B regression coverage. Two streaming code-generation
+  requests against Qwen2.5-Coder-32B exercise the dense-content token
+  accounting path that PR #288 fixed.
+
+expected_shape: |
+  Issue #303 Path B:
+   - 2 total streaming requests against Qwen2.5-Coder-32B.
+   - Completion token counts in buyer, gateway, and coordinator artifacts
+     should agree within the configured 2-token tolerance.
+   - A 12-token gateway/coord or gateway/buyer delta reproduces the
+     historical downclamp class and should fail I1/I3.
+   - If the model is absent, the scenario is not a valid #303 acceptance
+     run; treat no_provider_available as fleet setup missing.
+
+target:
+  gateway_url: https://api.streamvc.live
+  coordinator_url: https://coordinator.streamvc.live
+  buyer_token: ${BUYER_TOKEN}
+  coordinator_db_ssh: pearl:/var/lib/macprovider/coordinator.db
+  gateway_db_ssh: pearl:/var/lib/macprovider/gateway.db
+  db_sudo_user: macprovider
+
+buyers:
+  count: 1
+  stream: true
+  pattern: constant
+  requests_per_buyer: 2
+
+duration: 360s
+request_timeout: 150s
+silent_hang_threshold: 60s
+charged_delivered_tolerance_tokens: 2
+max_completion_token_delta: 2
+
+prompts:
+  - model: mlx-community/Qwen2.5-Coder-32B-Instruct-4bit
+    user: "Write a Python function that parses a CSV stream into typed records, including error handling and one unit test."
+    max_tokens: 192
+  - model: mlx-community/Qwen2.5-Coder-32B-Instruct-4bit
+    user: "Write a SQL migration plus rollback for adding an idempotency key to a payments table, with comments explaining the constraints."
+    max_tokens: 192

--- a/test/network-harness/scenarios/14_sparse_provider_reported_tokens.yaml
+++ b/test/network-harness/scenarios/14_sparse_provider_reported_tokens.yaml
@@ -1,0 +1,60 @@
+# 14_sparse_provider_reported_tokens.yaml — issue #303 Path C regression.
+#
+# PR #288 closed a trust-byte-estimate path that over-settled sparse
+# English-heavy streams by overriding provider tokenizer counts. This
+# scenario exercises that sparse natural-language shape against the Llama
+# row documented in #303.
+#
+# What gets asserted by hard invariants:
+#   - I1/I3 fail if gateway byte estimation overcharges relative to the
+#     buyer-delivered stream or drifts from coordinator settlement.
+#   - I2/I4 retain the standard orphan-5xx and silent-hang protections.
+#
+# Expected live shape:
+#   - Successful streams use provider-reported token counts. If triaging,
+#     confirm ledger_reconcile.matched_successes has
+#     gateway_token_source=provider_reported for each matched success.
+name: sparse_provider_reported_tokens
+description: |
+  Issue #303 Path C regression coverage. Two sparse, English-heavy
+  streaming prompts against Llama-3.1-8B verify that provider-reported
+  tokenizer counts remain authoritative over gateway byte estimation.
+
+expected_shape: |
+  Issue #303 Path C:
+   - 2 total streaming requests against the Llama sparse-English row.
+   - Successful requests should reconcile with gateway_outcome=ok and
+     no positive gateway-vs-buyer overbill.
+   - ledger_reconcile.json should show gateway_token_source=provider_reported
+     for successful streams; gateway_estimated on a clean success is a
+     regression signal even if raw token drift is small.
+   - If this exact Llama row is absent, use the issue-approved fallback
+     English-heavy Llama variant and record that substitution in the
+     baseline artifact notes.
+
+target:
+  gateway_url: https://api.streamvc.live
+  coordinator_url: https://coordinator.streamvc.live
+  buyer_token: ${BUYER_TOKEN}
+  coordinator_db_ssh: pearl:/var/lib/macprovider/coordinator.db
+  gateway_db_ssh: pearl:/var/lib/macprovider/gateway.db
+  db_sudo_user: macprovider
+
+buyers:
+  count: 1
+  stream: true
+  pattern: constant
+  requests_per_buyer: 2
+
+duration: 240s
+request_timeout: 120s
+silent_hang_threshold: 45s
+required_gateway_token_source: provider_reported
+
+prompts:
+  - model: mlx-community/Meta-Llama-3.1-8B-Instruct-4bit
+    user: "Write four concise paragraphs describing how fog changes the soundscape of a harbor at dawn."
+    max_tokens: 192
+  - model: mlx-community/Meta-Llama-3.1-8B-Instruct-4bit
+    user: "Explain, in plain English, why careful accounting matters in a shared compute marketplace. Use no bullet points."
+    max_tokens: 192


### PR DESCRIPTION
## Summary
- Add #303 scenarios 12-14 for PR #288 Path A/B/C settlement regression coverage.
- Surface gateway token_source as gateway_token_source in ledger_reconcile matched pairs.
- Add an opt-in max_completion_token_delta I1 gate so dense under-settlement is actually machine-checked.
- Record the v0.6 #303 baseline surface with live Pearl acceptance explicitly pending model availability.

## Validation
- go test ./... -count=1 from test/network-harness
- dry-run scenarios 12, 13, and 14
- git diff --check
- local 3-lane audit: code/security/architecture at 0 C/H/M after fixes

## Live acceptance
- Not yet run against Pearl because #303 requires MoE, Qwen2.5-Coder-32B, and Llama sparse-English model rows to be actively serving.
- PR is draft until scenarios 12-14 PASS I1-I4 live and the v0.6 baseline table is filled.

Refs #303