### PR TITLE
Preserve gateway request IDs on receipt-eligible 5xx passthroughs (closes #443)

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -1108,6 +1108,7 @@ func (s *Server) passThroughReceiptEligibleProviderError(w http.ResponseWriter, 
 	// no provider was selected on its callers' paths.
 	emitProviderAttribution(w.Header(), resp.Header)
 	copyReceiptEligibleHeaders(w.Header(), resp.Header)
+	w.Header().Set("X-Request-ID", requestID(r))
 	w.Header().Set("Content-Type", contentTypeOrJSON(resp.Header))
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(body)

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -910,6 +910,9 @@ func copyCleanHeadersWithReceipt(dst, src http.Header, allowReceipt bool) {
 		if isGatewayOwnedRateLimitHeader(key) {
 			continue
 		}
+		if isGatewayOwnedCorrelationHeader(key) {
+			continue
+		}
 		for _, value := range values {
 			dst.Add(key, value)
 		}
@@ -933,6 +936,10 @@ func isGatewayOwnedRateLimitHeader(key string) bool {
 		return true
 	}
 	return false
+}
+
+func isGatewayOwnedCorrelationHeader(key string) bool {
+	return strings.EqualFold(key, "X-Request-ID")
 }
 
 func isReceiptResponseHeader(key string) bool {

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -3189,6 +3189,42 @@ func TestNoProvider503EchoesOnlyGatewayRequestID(t *testing.T) {
 	}
 }
 
+func TestReceiptEligible5xxEchoesOnlyGatewayRequestID(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{name: "capacity_503", status: http.StatusServiceUnavailable},
+		{name: "upstream_502", status: http.StatusBadGateway},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"error":{"code":"error_model_not_loaded","message":"model not loaded","param":null,"type":"api_error"}}`
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return responseWithBody(tc.status, http.Header{
+					"Content-Type": []string{"application/json"},
+					"X-Request-ID": []string{"99999999-9999-4999-8999-999999999999"},
+				}, body), nil
+			})}
+			h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+				cfg.Coordinator.BuyerURL = "http://coordinator.test"
+			}, WithHTTPClient(client))
+			fullKey := createAccountAndKey(t, store, cfg, "acct_receipt_eligible_request_id_"+tc.name)
+
+			requestID := "77777777-7777-4777-8777-777777777777"
+			resp := postChat(t, h, fullKey, `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`, map[string]string{"X-Request-ID": requestID})
+
+			if resp.Code != tc.status {
+				t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+			}
+			values := resp.Header().Values("X-Request-ID")
+			if len(values) != 1 || values[0] != requestID {
+				t.Fatalf("response X-Request-ID values=%q, want only gateway request id %q", values, requestID)
+			}
+		})
+	}
+}
+
 func TestStickyConversationDerivesInternalHeaderAndStripsInjection(t *testing.T) {
 	var captured http.Header
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
Closes #443.

## Summary
- Force gateway-visible `X-Request-ID` on the receipt-eligible provider-error passthrough path in `chat_proxy.go`. This is the specific 5xx code path #443 identified as still orphan-shaped after #436 patched the no-provider-503 path.
- Mark `X-Request-ID` as a gateway-owned correlation header in `copyCleanHeadersWithReceipt`, so a coordinator/upstream ID never leaks into a buyer-visible response or duplicates against the gateway's own ID.
- Add regression tests: `TestReceiptEligible5xxEchoesOnlyGatewayRequestID` alongside the existing `TestNoProvider503EchoesOnlyGatewayRequestID`.

## Rationale

#443 filed today from the network-harness scenario 12 evidence (chaos-lane PR #431, blocked-by this): after #436 landed, the harness caught 5/6 requests still returning HTTP 503 with no request-id echo across three deterministic post-#436 baseline runs (buyer window 0-70s on a 1-slot provider, all under Pearl `v1.8.14-7-g213c8cc`). The failing responses came through the receipt-eligible provider-error passthrough helper — a sibling of the no-provider-503 helper #436 fixed — which was copying headers from upstream without asserting the gateway's own `X-Request-ID` on the way out.

The fix is the narrower of two options the audit lanes rejected: patching only the no-provider helper would leave the receipt-eligible path broken. Both helpers now go through the same "gateway owns `X-Request-ID`" contract.

## Validation
- `go test ./internal/router -run 'Test(NoProvider503EchoesOnlyGatewayRequestID|ReceiptEligible5xxEchoesOnlyGatewayRequestID)$' -count=1` — pass
- `go test ./... -count=1` in phase5-gateway — pass
- `go test -race ./internal/router -count=1` — pass
- `git diff --check` — clean
- Three-lane codex audit (code / security / architecture) — **0 C/H/M**

## Not tested
- Live network-harness replay on Pearl. That's what PR #431 (chaos scenario 12) will exercise once this lands: expected shape becomes 14/15 attempts get HTTP 503 with `X-Request-Id` echoed and 0-token settlement rows (I2 PASS), and the residual overbill from #444 remains the only outstanding money-path bug the scenario surfaces.

## Related
- #443 — this issue
- #436 — original fix (no-provider 503 + `stream_output_exceeded` fallback path)
- #444 — the other residual from post-#436 evidence (still open)
- #431 — chaos harness scenario 12 (still draft, blocked-by #444 after this lands)
- SPEC-006 §17.7.1 — the invariant this fix maintains

🤖 Generated with [Claude Code](https://claude.com/claude-code)
