### PR TITLE
Fix SSE-error fallback overbill reconciliation

### DIFF
--- a/test/network-harness/internal/buyer/loadgen.go
+++ b/test/network-harness/internal/buyer/loadgen.go
@@ -579,7 +579,8 @@ type chunkPayload struct {
 //   - code: the non-empty `error.code` value if the dispatched event
 //     is a STANDALONE error envelope; "" otherwise.
 //   - isStandaloneError: true ONLY if the event has a non-empty
-//     `error.code` AND no `choices` AND no `usage` tokens.
+//     `error.code`, no `choices` key, no `usage` key, no duplicate
+//     top-level keys, and no duplicate immediate `error.*` keys.
 //
 // The caller in consumeSSE tracks whether the LAST DISPATCHED event
 // before `[DONE]`/EOF was a standalone error envelope; only that
@@ -593,23 +594,134 @@ func parseChunkTokens(payload []byte, res *Result) (code string, isStandaloneErr
 	if err := json.Unmarshal(payload, &c); err != nil {
 		return "", false
 	}
+	// Error-bearing frames are either strict standalone terminal envelopes or
+	// untrusted for both corroboration and token extraction. Otherwise a
+	// malformed `error` + `usage` frame could fail the envelope gate but still
+	// donate prompt tokens to the harness side and erase the overbill drift
+	// the gate is meant to preserve.
+	if topLevelJSONKeyPresent(payload, "error") {
+		if code, ok := standaloneSSEErrorCode(payload); ok {
+			return code, true
+		}
+		return "", false
+	}
 	if c.Usage.CompletionTokens > 0 {
 		res.CompletionTokensReceived = c.Usage.CompletionTokens
 	}
 	if c.Usage.PromptTokens > 0 {
 		res.PromptTokensReported = c.Usage.PromptTokens
 	}
-	// Standalone terminal-envelope shape: error.code present AND no
-	// choices AND no usage tokens. Both writeSSEError and
-	// writeStructuredOutputTimeoutSSE emit chunks of this exact shape
-	// — see phase5-gateway/internal/router/chat_proxy.go:1239 / :1256.
-	if c.Error != nil && c.Error.Code != "" &&
-		len(c.Choices) == 0 &&
-		c.Usage.CompletionTokens == 0 &&
-		c.Usage.PromptTokens == 0 {
-		return c.Error.Code, true
-	}
 	return "", false
+}
+
+func topLevelJSONKeyPresent(payload []byte, want string) bool {
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.UseNumber()
+
+	tok, err := dec.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != '{' {
+		return false
+	}
+
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return false
+		}
+		if key == want {
+			return true
+		}
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return false
+		}
+	}
+	return false
+}
+
+func standaloneSSEErrorCode(payload []byte) (string, bool) {
+	top, ok := strictJSONRawObject(payload)
+	if !ok {
+		return "", false
+	}
+	if _, hasChoices := top["choices"]; hasChoices {
+		return "", false
+	}
+	if _, hasUsage := top["usage"]; hasUsage {
+		return "", false
+	}
+	errorRaw, ok := top["error"]
+	if !ok {
+		return "", false
+	}
+	errorFields, ok := strictJSONRawObject(errorRaw)
+	if !ok {
+		return "", false
+	}
+	codeRaw, ok := errorFields["code"]
+	if !ok {
+		return "", false
+	}
+	var code string
+	if err := json.Unmarshal(codeRaw, &code); err != nil || code == "" {
+		return "", false
+	}
+	return code, true
+}
+
+func strictJSONRawObject(payload []byte) (map[string]json.RawMessage, bool) {
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.UseNumber()
+
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, false
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != '{' {
+		return nil, false
+	}
+
+	fields := make(map[string]json.RawMessage)
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, false
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, false
+		}
+		if _, exists := fields[key]; exists {
+			return nil, false
+		}
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return nil, false
+		}
+		fields[key] = raw
+	}
+
+	tok, err = dec.Token()
+	if err != nil {
+		return nil, false
+	}
+	delim, ok = tok.(json.Delim)
+	if !ok || delim != '}' {
+		return nil, false
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, false
+	}
+	return fields, true
 }
 
 // isDefaultEventName returns true when the SSE event name is empty or

--- a/test/network-harness/internal/buyer/loadgen_iss232_test.go
+++ b/test/network-harness/internal/buyer/loadgen_iss232_test.go
@@ -74,6 +74,78 @@ data: [DONE]
 	}
 }
 
+// TestConsumeSSE_MalformedStandaloneErrorEnvelopeRejected_449:
+// SPEC-006 §17.7.1 requires a literal standalone terminal envelope:
+// no top-level `choices` key, no top-level `usage` key, unique top-level
+// keys, unique immediate `error.*` keys, and no trailing bytes after the
+// JSON object. These cases look terminal to a loose json.Unmarshal-based
+// parser, but they are not buyer-side corroboration and must not suppress
+// downstream reconciler overbill signals.
+func TestConsumeSSE_MalformedStandaloneErrorEnvelopeRejected_449(t *testing.T) {
+	cases := []struct {
+		name           string
+		payload        string
+		wantPromptZero bool
+	}{
+		{
+			name:    "usage empty object",
+			payload: `{"error":{"code":"stream_truncated","type":"api_error","message":"forged"},"usage":{}}`,
+		},
+		{
+			name:    "usage null",
+			payload: `{"error":{"code":"stream_truncated","type":"api_error","message":"forged"},"usage":null}`,
+		},
+		{
+			name:    "usage zero tokens",
+			payload: `{"error":{"code":"stream_truncated","type":"api_error","message":"forged"},"usage":{"prompt_tokens":0,"completion_tokens":0}}`,
+		},
+		{
+			name:           "usage prompt tokens",
+			payload:        `{"error":{"code":"stream_output_exceeded","type":"api_error","message":"forged"},"usage":{"prompt_tokens":64,"completion_tokens":0}}`,
+			wantPromptZero: true,
+		},
+		{
+			name:    "choices empty array",
+			payload: `{"error":{"code":"stream_truncated","type":"api_error","message":"forged"},"choices":[]}`,
+		},
+		{
+			name:    "duplicate top-level error",
+			payload: `{"error":{"code":"stream_truncated","type":"api_error","message":"forged"},"error":{"code":"stream_truncated","type":"api_error","message":"forged"}}`,
+		},
+		{
+			name:    "duplicate top-level usage",
+			payload: `{"error":{"code":"stream_truncated","type":"api_error","message":"forged"},"usage":null,"usage":{}}`,
+		},
+		{
+			name:    "duplicate error code",
+			payload: `{"error":{"code":"stream_truncated","code":"stream_truncated","type":"api_error","message":"forged"}}`,
+		},
+		{
+			name:    "trailing garbage",
+			payload: `{"error":{"code":"stream_truncated","type":"api_error","message":"forged"}} true`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := bytes.NewBufferString("data: " + tc.payload + "\n\ndata: [DONE]\n\n")
+			r := &Result{}
+			consumeSSE(body, r)
+			if r.SawSSEErrorEvent {
+				t.Errorf("malformed standalone envelope %q MUST NOT corroborate — got SawSSEErrorEvent=true", tc.name)
+			}
+			if r.SSEErrorCode != "" {
+				t.Errorf("SSEErrorCode must stay empty for malformed envelope %q, got %q", tc.name, r.SSEErrorCode)
+			}
+			if !r.SawTerminator {
+				t.Errorf("trailing [DONE] should still flip SawTerminator for malformed envelope %q", tc.name)
+			}
+			if tc.wantPromptZero && r.PromptTokensReported != 0 {
+				t.Errorf("malformed envelope %q must not import usage.prompt_tokens, got %d", tc.name, r.PromptTokensReported)
+			}
+		})
+	}
+}
+
 // TestConsumeSSE_AttackerEmitsStandaloneErrorMidStreamThenContinues_232_R2_HIGH:
 // the second SEC R2 HIGH-1 attack vector. Gateway emits a real-looking
 // standalone error envelope mid-stream, then continues to emit content

--- a/test/network-harness/internal/buyer/result.go
+++ b/test/network-harness/internal/buyer/result.go
@@ -62,7 +62,7 @@ type Result struct {
 	// SawSSEErrorEvent is true when the SSE stream's last DISPATCHED SSE
 	// event before `[DONE]` (or EOF) was a STANDALONE terminal error
 	// envelope — `{"error": {"code": "...", ...}}` with no `choices`
-	// and no `usage` tokens. This shape matches the gateway's
+	// key and no `usage` key. This shape matches the gateway's
 	// writeSSEError and writeStructuredOutputTimeoutSSE helpers in
 	// chat_proxy.go.
 	//

--- a/test/network-harness/internal/invariants/hard.go
+++ b/test/network-harness/internal/invariants/hard.go
@@ -364,13 +364,10 @@ func checkI2(results []buyer.Result, ledger *reconcile.Result) Check {
 	return c
 }
 
-// I3 — no charged-tokens > delivered-tokens. The harness's own SSE
-// parser produced CompletionTokensReceived; the gateway's usage block
-// produced PromptTokensReported / CompletionTokensReceived (when the
-// usage field was inlined). For successful requests we compare:
-// reported_completion <= harness_observed_completion. Strict greater-
-// than is a fail; equal or less is fine (provider may report fewer if
-// usage is gateway-estimated).
+// I3 — no charged-tokens > delivered-tokens. This consumes the
+// reconciler's actionable GatewayOverbillVsHarnessTokens field rather
+// than raw net drift, so corroborated SPEC-006 fallback prompt-token
+// drift remains diagnostic while uncorroborated overbill still fails.
 //
 // Phase A limitation: when the usage block is provider-reported and
 // differs from the SSE-content count, we may flag false positives.

--- a/test/network-harness/internal/reconcile/ledger.go
+++ b/test/network-harness/internal/reconcile/ledger.go
@@ -27,7 +27,8 @@
 //     bypass or settlement gap
 //   - "row count or token-sum mismatch between gateway and coord in
 //     the window" — money-path drift
-//   - "harness saw N tokens but gateway billed M (M > N)" — overcharge
+//   - "gateway has actionable positive drift vs harness after fallback
+//     corroboration suppression" — overcharge
 package reconcile
 
 import (
@@ -158,14 +159,16 @@ type Result struct {
 	NetGatewayMinusCoordinatorTokens int64 `json:"net_gateway_minus_coordinator_tokens"`
 	NetGatewayMinusHarnessTokens     int64 `json:"net_gateway_minus_harness_tokens"`
 
-	// Gateway-vs-Harness positive overbill: I1 headline signal for this
-	// axis. Sums per-pair (gateway − harness) where gateway > harness.
-	// Underbill alone is allowed because gateway-side streaming rounding
-	// can legitimately undercount vs the harness's SSE byte timeline.
-	// Positive-only means a +N overbill is not hidden behind a −N
-	// underbill (#229 R1 CRITICAL).
+	// Gateway-vs-Harness actionable overbill: I1/I3 headline signal for
+	// this axis. Sums per-pair (gateway − harness) where gateway > harness,
+	// excluding SPEC-006 fallback outcomes corroborated by the buyer's
+	// terminal SSE error envelope. Raw signed drift remains visible in
+	// NetGatewayMinusHarnessTokens. Underbill alone is allowed because
+	// gateway-side streaming rounding can legitimately undercount vs the
+	// harness's SSE byte timeline. Positive-only means a +N overbill is not
+	// hidden behind a −N underbill (#229 R1 CRITICAL).
 	GatewayOverbillVsHarnessTokens int64    `json:"gateway_overbill_vs_harness_tokens"`
-	OverbilledPairs                []string `json:"overbilled_pairs,omitempty"` // harness request_ids of overbilled pairs
+	OverbilledPairs                []string `json:"overbilled_pairs,omitempty"` // harness request_ids of actionable overbill pairs
 
 	// Gateway-vs-Coordinator positive overbill: REFERENCE ONLY for triage.
 	// Both gateway and coord are settlement systems and MUST agree on
@@ -253,7 +256,7 @@ type MatchedPair struct {
 	// HarnessSawSSEErrorEvent carries through buyer.Result.SawSSEErrorEvent:
 	// true when the last DISPATCHED SSE event in the buyer's stream before
 	// `[DONE]` or EOF was a STANDALONE OpenAI-style terminal `error`
-	// envelope (no `choices`, no `usage` tokens) — the shape SPEC-006
+	// envelope (no `choices` key, no `usage` key) — the shape SPEC-006
 	// §17.7.1 pins for every in-scope fallback path. "Dispatched" is
 	// precise per the HTML5/SSE model: only a blank-line-terminated
 	// event counts (#232 R8 SEC HIGH — closes the leading-`[DONE]`
@@ -285,10 +288,10 @@ type MatchedPair struct {
 	// HarnessSSEErrorCode carries the `error.code` value from the
 	// terminal SSE error envelope, when one was observed. Empty when
 	// HarnessSawSSEErrorEvent is false. Triage uses this to cross-check
-	// the buyer-visible code against the gateway's `outcome` column —
-	// a mismatch (e.g. buyer saw `provider_disconnected` but gateway
-	// settled `stream_truncated`) is not currently an I1 signal but is
-	// useful evidence in `ledger_reconcile.json`. (#232 R2 ARCH LOW.)
+	// the buyer-visible code against the gateway's `outcome` column. A
+	// mismatch without a named SPEC-006 mapping exception prevents fallback
+	// overbill suppression, so positive drift remains actionable in I1/I3.
+	// (#232 R2 ARCH LOW.)
 	HarnessSSEErrorCode string `json:"harness_sse_error_code,omitempty"`
 }
 
@@ -457,14 +460,16 @@ func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Ti
 //	             field is for triage reference, NOT the I1 pass/fail
 //	             input (3-lane codex audit CRITICAL on PR #229 R1).
 //
-//	GatewayOverbill*-: sum of POSITIVE-only per-pair deltas; an overbilled
-//	                  pair contributes its overbill amount, an underbilled
-//	                  pair contributes 0. This is the headline overbill
-//	                  signal — does NOT cancel against other pairs.
+//	GatewayOverbill*-: positive-only per-pair deltas retained for triage.
+//	                  On the harness axis, corroborated fallback pairs are
+//	                  suppressed before contributing to the I1/I3 headline
+//	                  signal; on the coord axis, I1 gates on
+//	                  AbsGatewayCoordinatorMismatchTokens instead. This
+//	                  positive-only view does NOT cancel against underbills.
 //
-// Also populates OverbilledPairs with harness request IDs of any pair
-// where the gateway billed more than the harness observed, so triage
-// can drill into the offending requests.
+// Also populates OverbilledPairs with harness request IDs of actionable
+// gateway-vs-harness overbill pairs after fallback corroboration suppression,
+// so triage can drill into the offending requests.
 //
 // MatchedCoordMissing is populated for pairs whose gateway outcome is
 // "ok" but no coord row matched — fallback outcomes legitimately lack
@@ -476,12 +481,14 @@ func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Ti
 func computePerPairDrift(r *Result) {
 	for _, p := range r.MatchedSuccesses {
 		// Gateway vs Harness — fold every positive buyer-visible delta into
-		// the headline overbill signal. Fallback/SSE-error corroboration can
-		// explain why a stream ended, but it must not hide a gateway row that
-		// charged more completion tokens than the harness observed.
+		// the headline overbill signal unless a SPEC-006 fallback outcome is
+		// corroborated by the buyer-visible terminal SSE error envelope. Raw
+		// signed drift still lands in NetGatewayMinusHarnessTokens for triage,
+		// but I1/I3 should not fail on prompt tokens consumed before a
+		// corroborated error-terminated stream.
 		dh := pairGatewayTokens(p) - pairHarnessTokens(p)
 		r.NetGatewayMinusHarnessTokens += dh
-		if dh > 0 {
+		if dh > 0 && !fallbackOverbillSuppressed(p) {
 			r.GatewayOverbillVsHarnessTokens += dh
 			r.OverbilledPairs = append(r.OverbilledPairs, p.HarnessRequestID)
 		}
@@ -493,12 +500,13 @@ func computePerPairDrift(r *Result) {
 		// surface. AbsGatewayCoordinatorMismatchTokens uses |delta| to
 		// avoid signed-cancel across pairs (#229 R2 HIGH).
 		//
-		// Fallback pairs keep contributing to the signed net for triage,
-		// but are excluded from overbill/mismatch signals for the same
-		// fallback-unit asymmetry described on the gateway-vs-harness axis
-		// above: gateway counts emitted bytes before truncation, while coord
-		// can record the provider's full reported usage. Counting that as
-		// drift false-fails I1 in the #285 reproduction.
+		// Fallback pairs keep contributing to the signed net and positive
+		// gw-coord overbill fields for triage, but are excluded from I1's
+		// absolute mismatch signal for the same fallback-unit asymmetry
+		// described on the gateway-vs-harness axis above: gateway counts
+		// emitted bytes before truncation, while coord can record the
+		// provider's full reported usage. Counting that as drift false-fails
+		// I1 in the #285 reproduction.
 		//
 		// #232: same buyer-corroboration check applies here. The coord
 		// axis uses the buyer's view as the trust anchor — if the buyer

--- a/test/network-harness/internal/reconcile/ledger_test.go
+++ b/test/network-harness/internal/reconcile/ledger_test.go
@@ -221,7 +221,7 @@ func TestCollectUnmatchedGatewayOK_NoLeftovers(t *testing.T) {
 	}
 }
 
-func TestComputePerPairDrift_FallbackPairsCountBuyerVisibleOverbill(t *testing.T) {
+func TestComputePerPairDrift_FallbackPairsWithSSEErrorSuppressHarnessOverbill(t *testing.T) {
 	r := &Result{
 		MatchedSuccesses: []MatchedPair{
 			{HarnessRequestID: "fallback_undercount", HarnessCompletionTokens: 8, GatewayCompletionTokens: 64,
@@ -231,11 +231,79 @@ func TestComputePerPairDrift_FallbackPairsCountBuyerVisibleOverbill(t *testing.T
 		},
 	}
 	computePerPairDrift(r)
-	if r.GatewayOverbillVsHarnessTokens != 56 {
-		t.Errorf("fallback pair must count buyer-visible overbill 56, got %d", r.GatewayOverbillVsHarnessTokens)
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("corroborated fallback pair must suppress harness-axis overbill, got %d", r.GatewayOverbillVsHarnessTokens)
 	}
-	if len(r.OverbilledPairs) != 1 || r.OverbilledPairs[0] != "fallback_undercount" {
-		t.Errorf("fallback pair must appear in OverbilledPairs: %v", r.OverbilledPairs)
+	if len(r.OverbilledPairs) != 0 {
+		t.Errorf("corroborated fallback pair must not appear in OverbilledPairs: %v", r.OverbilledPairs)
+	}
+}
+
+func TestComputePerPairDrift_StreamOutputExceededSSEErrorPromptOnlySuppressesHarnessOverbill_449(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			{
+				HarnessRequestID:            "scenario15_prompt_only",
+				HarnessTotalTokens:          0,
+				HarnessCompletionTokens:     0,
+				GatewayTotalTokens:          64,
+				GatewayCompletionTokens:     0,
+				CoordinatorRequestID:        "coord_scenario15_prompt_only",
+				CoordinatorTotalTokens:      63,
+				CoordinatorCompletionTokens: 0,
+				GatewayOutcome:              "stream_output_exceeded",
+				HarnessSawSSEErrorEvent:     true,
+				HarnessSSEErrorCode:         "stream_output_exceeded",
+			},
+		},
+	}
+
+	computePerPairDrift(r)
+
+	if r.NetGatewayMinusHarnessTokens != 64 {
+		t.Errorf("raw net harness drift should remain visible for triage: want 64, got %d", r.NetGatewayMinusHarnessTokens)
+	}
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("corroborated stream_output_exceeded fallback must suppress harness-axis prompt-token overbill, got %d", r.GatewayOverbillVsHarnessTokens)
+	}
+	if len(r.OverbilledPairs) != 0 {
+		t.Errorf("corroborated stream_output_exceeded fallback must not appear in OverbilledPairs: %v", r.OverbilledPairs)
+	}
+	if r.NetGatewayMinusCoordinatorTokens != 1 || r.GatewayOverbillVsCoordinatorTokens != 1 {
+		t.Errorf("raw gw-coord tokenizer drift should remain diagnostic, got net=%d overbill=%d",
+			r.NetGatewayMinusCoordinatorTokens, r.GatewayOverbillVsCoordinatorTokens)
+	}
+	if r.AbsGatewayCoordinatorMismatchTokens != 0 || len(r.GatewayCoordMismatchedPairs) != 0 {
+		t.Errorf("corroborated fallback must suppress gw-coord mismatch signal, got abs=%d pairs=%v",
+			r.AbsGatewayCoordinatorMismatchTokens, r.GatewayCoordMismatchedPairs)
+	}
+}
+
+func TestComputePerPairDrift_StreamOutputExceededMalformedEnvelopeDoesNotSuppressOverbill_449(t *testing.T) {
+	r := &Result{
+		MatchedSuccesses: []MatchedPair{
+			{
+				HarnessRequestID:        "scenario15_malformed_envelope",
+				HarnessTotalTokens:      0,
+				HarnessCompletionTokens: 0,
+				GatewayTotalTokens:      64,
+				GatewayCompletionTokens: 0,
+				GatewayOutcome:          "stream_output_exceeded",
+				// The buyer parser leaves this false for malformed terminal
+				// envelopes that contain choices/usage keys or duplicate keys.
+				HarnessSawSSEErrorEvent: false,
+				HarnessSSEErrorCode:     "",
+			},
+		},
+	}
+
+	computePerPairDrift(r)
+
+	if r.GatewayOverbillVsHarnessTokens != 64 {
+		t.Errorf("malformed-envelope fallback must not suppress harness-axis prompt-token overbill, got %d", r.GatewayOverbillVsHarnessTokens)
+	}
+	if len(r.OverbilledPairs) != 1 || r.OverbilledPairs[0] != "scenario15_malformed_envelope" {
+		t.Errorf("malformed-envelope fallback must surface in OverbilledPairs, got %v", r.OverbilledPairs)
 	}
 }
 
@@ -308,8 +376,8 @@ func TestComputePerPairDrift_FallbackUnlistedCodeMismatch_232_R6_HIGH(t *testing
 // the SPEC-006 §17.7.1 named-mapping exception path. Buyer-visible
 // `error.code=provider_disconnected` while gateway outcome is
 // `stream_truncated` is an EXPLICITLY allowed divergence (matches
-// gateway writeProviderDisconnectedSSE behavior). The mapping may suppress
-// coord-mismatch noise, but it must not suppress buyer-visible overbill.
+// gateway writeProviderDisconnectedSSE behavior). The mapping suppresses both
+// coord-mismatch noise and harness-axis overbill noise.
 func TestComputePerPairDrift_FallbackNamedMappingException_232_R6(t *testing.T) {
 	r := &Result{
 		MatchedSuccesses: []MatchedPair{
@@ -320,11 +388,11 @@ func TestComputePerPairDrift_FallbackNamedMappingException_232_R6(t *testing.T) 
 		},
 	}
 	computePerPairDrift(r)
-	if r.GatewayOverbillVsHarnessTokens != 56 {
-		t.Errorf("provider_disconnected↔stream_truncated named mapping must still count overbill 56, got %d", r.GatewayOverbillVsHarnessTokens)
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("provider_disconnected↔stream_truncated named mapping must suppress harness-axis overbill, got %d", r.GatewayOverbillVsHarnessTokens)
 	}
-	if len(r.OverbilledPairs) != 1 || r.OverbilledPairs[0] != "named_exception" {
-		t.Errorf("named-mapping exception must surface buyer-visible overbill, got %v", r.OverbilledPairs)
+	if len(r.OverbilledPairs) != 0 {
+		t.Errorf("named-mapping exception must not surface harness-axis overbill, got %v", r.OverbilledPairs)
 	}
 }
 
@@ -358,9 +426,9 @@ func TestSseErrorCorroboratesOutcome_232_R6(t *testing.T) {
 
 // TestComputePerPairDrift_FallbackPairSuppressedWithSSEErrorEvent_232:
 // the legitimate fallback case: gateway labeled the pair as a fallback AND
-// the buyer received the matching terminal SSE error envelope. This can
-// suppress coord mismatch noise, but not buyer-visible overbill.
-func TestComputePerPairDrift_FallbackPairCountsHarnessOverbillWithSSEErrorEvent_232(t *testing.T) {
+// the buyer received the matching terminal SSE error envelope. This suppresses
+// both coord mismatch noise and harness-axis overbill noise.
+func TestComputePerPairDrift_FallbackPairSuppressesHarnessOverbillWithSSEErrorEvent_232(t *testing.T) {
 	r := &Result{
 		MatchedSuccesses: []MatchedPair{
 			{HarnessRequestID: "legit_truncation", HarnessCompletionTokens: 8, GatewayCompletionTokens: 64,
@@ -370,17 +438,17 @@ func TestComputePerPairDrift_FallbackPairCountsHarnessOverbillWithSSEErrorEvent_
 	}
 	computePerPairDrift(r)
 
-	if r.GatewayOverbillVsHarnessTokens != 56 {
-		t.Errorf("legit truncation must count harness-axis overbill 56, got %d", r.GatewayOverbillVsHarnessTokens)
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("legit truncation must suppress harness-axis overbill, got %d", r.GatewayOverbillVsHarnessTokens)
 	}
 	if r.GatewayOverbillVsCoordinatorTokens != 0 {
-		t.Errorf("legit truncation must keep coord-axis suppression, got %d", r.GatewayOverbillVsCoordinatorTokens)
+		t.Errorf("legit truncation fixture has gateway under coord, so positive coord-axis overbill must stay 0, got %d", r.GatewayOverbillVsCoordinatorTokens)
 	}
 	if r.AbsGatewayCoordinatorMismatchTokens != 0 {
 		t.Errorf("legit truncation must keep coord-mismatch suppression, got %d", r.AbsGatewayCoordinatorMismatchTokens)
 	}
-	if len(r.OverbilledPairs) != 1 || r.OverbilledPairs[0] != "legit_truncation" || len(r.GatewayCoordMismatchedPairs) != 0 {
-		t.Errorf("legit truncation must surface overbill only, got %v / %v",
+	if len(r.OverbilledPairs) != 0 || len(r.GatewayCoordMismatchedPairs) != 0 {
+		t.Errorf("legit truncation must suppress overbill and coord mismatch, got %v / %v",
 			r.OverbilledPairs, r.GatewayCoordMismatchedPairs)
 	}
 }
@@ -998,7 +1066,7 @@ func TestMatchPairs_MixedExactAndFuzzyPool(t *testing.T) {
 
 // TestMatchPairs_FallbackExactMatchEndToEnd is the R1 code-lane LOW:
 // a harness OK whose exact gateway match is a fallback outcome must
-// (a) match by exact id, (b) count buyer-visible gateway overbill,
+// (a) match by exact id, (b) suppress corroborated fallback overbill,
 // (c) NOT trigger MatchedCoordMissing, (d) NOT leak into
 // UnmatchedGatewayOKRows.
 func TestMatchPairs_FallbackExactMatchEndToEnd(t *testing.T) {
@@ -1025,11 +1093,11 @@ func TestMatchPairs_FallbackExactMatchEndToEnd(t *testing.T) {
 	if r.MatchedSuccesses[0].GatewayMatchMethod != "exact_id" {
 		t.Errorf("want exact_id match on fallback row, got %q", r.MatchedSuccesses[0].GatewayMatchMethod)
 	}
-	if r.GatewayOverbillVsHarnessTokens != 56 {
-		t.Errorf("fallback exact-match must count buyer-visible overbill 56, got %d", r.GatewayOverbillVsHarnessTokens)
+	if r.GatewayOverbillVsHarnessTokens != 0 {
+		t.Errorf("fallback exact-match must suppress corroborated harness-axis overbill, got %d", r.GatewayOverbillVsHarnessTokens)
 	}
-	if len(r.OverbilledPairs) != 1 || r.OverbilledPairs[0] != "h1" {
-		t.Errorf("fallback exact-match must surface in OverbilledPairs, got %v", r.OverbilledPairs)
+	if len(r.OverbilledPairs) != 0 {
+		t.Errorf("fallback exact-match must not surface in OverbilledPairs, got %v", r.OverbilledPairs)
 	}
 	if len(r.MatchedCoordMissing) != 0 {
 		t.Errorf("fallback pair must not trigger coord-missing, got %v", r.MatchedCoordMissing)


### PR DESCRIPTION
## Summary
- suppress actionable harness-axis overbill only for fallback outcomes corroborated by strict buyer-visible terminal SSE error envelopes
- keep raw drift diagnostics visible while preserving no-SSE, malformed-envelope, and code/outcome mismatch trust-gap failures
- harden the buyer SSE parser so malformed top-level error frames cannot import usage tokens or satisfy fallback corroboration

## Validation
- go test ./... in test/network-harness
- go vet ./... in test/network-harness
- 3-lane audit loop: code/security/architecture all 0 Critical, 0 High, 0 Medium

## Not tested
- live Pearl scenario 15 chaos harness rerun

Closes #449