### PR TITLE
Accept text-only structured content arrays

### DIFF
--- a/docs/using-macprovider-with-openai-sdk.md
+++ b/docs/using-macprovider-with-openai-sdk.md
@@ -40,6 +40,11 @@ print(resp.choices[0].message.content)
 
 Any MLX chat model in the pool works. Available models: `client.models.list()` or `curl https://api.streamvc.live/v1/models`.
 
+Text-only structured message content is accepted too. Frameworks that emit
+`content=[{"type":"text","text":"Hello"}]` are normalized to plain text before
+provider dispatch. Multimodal parts such as `image_url` are not supported in
+v1 and return `unsupported_content_shape`.
+
 ## Streaming
 
 ```python

--- a/docs/using-macprovider-with-openai-sdk.md
+++ b/docs/using-macprovider-with-openai-sdk.md
@@ -40,10 +40,10 @@ print(resp.choices[0].message.content)
 
 Any MLX chat model in the pool works. Available models: `client.models.list()` or `curl https://api.streamvc.live/v1/models`.
 
-Text-only structured message content is accepted too. Frameworks that emit
-`content=[{"type":"text","text":"Hello"}]` are normalized to plain text before
-provider dispatch. Multimodal parts such as `image_url` are not supported in
-v1 and return `unsupported_content_shape`.
+Text-only structured content is accepted for `system` and `user` messages too.
+Frameworks that emit `content=[{"type":"text","text":"Hello"}]` for those roles
+are normalized to plain text before provider dispatch. Multimodal parts such as
+`image_url` are not supported in v1 and return `unsupported_content_shape`.
 
 ## Streaming
 

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1477,6 +1477,11 @@ type chatMessage struct {
 	ToolCalls  json.RawMessage `json:"tool_calls"`
 }
 
+type chatContentPart struct {
+	Type string          `json:"type"`
+	Text json.RawMessage `json:"text"`
+}
+
 type requestToolCall struct {
 	ID        string
 	Name      string
@@ -4372,6 +4377,10 @@ func validateChatRequest(body []byte) (chatRequest, int, string, string) {
 	if err := json.Unmarshal(messagesRaw, &req.Messages); err != nil || len(req.Messages) == 0 {
 		return req, http.StatusBadRequest, "invalid_request", "Invalid messages"
 	}
+	var rawMessages []map[string]json.RawMessage
+	if err := json.Unmarshal(messagesRaw, &rawMessages); err != nil || len(rawMessages) != len(req.Messages) {
+		return req, http.StatusBadRequest, "invalid_request", "Invalid messages"
+	}
 	if v, ok := raw["stream"]; ok {
 		if err := json.Unmarshal(v, &req.Stream); err != nil {
 			return req, http.StatusBadRequest, "invalid_request", "Invalid stream"
@@ -4380,8 +4389,19 @@ func validateChatRequest(body []byte) (chatRequest, int, string, string) {
 	if status, code, msg := validateOptionalFields(raw, req.Stream); status != 0 {
 		return req, status, code, msg
 	}
-	if status, code, msg := validateMessages(req.Messages); status != 0 {
+	if normalized, status, code, msg := validateMessages(req.Messages, rawMessages); status != 0 {
 		return req, status, code, msg
+	} else if normalized {
+		normalizedMessages, err := json.Marshal(rawMessages)
+		if err != nil {
+			return req, http.StatusBadRequest, "invalid_request", "Invalid messages"
+		}
+		raw["messages"] = normalizedMessages
+		normalizedBody, err := json.Marshal(raw)
+		if err != nil {
+			return req, http.StatusBadRequest, "invalid_request", "Invalid request"
+		}
+		req.raw = normalizedBody
 	}
 	if status, code, msg := validateTools(raw, req.Messages); status != 0 {
 		return req, status, code, msg
@@ -4747,9 +4767,9 @@ func jsonSchemaNumberOperand(node map[string]json.RawMessage, keyword string) (f
 	return number, true, ""
 }
 
-func validateMessages(messages []chatMessage) (int, string, string) {
+func validateMessages(messages []chatMessage, rawMessages []map[string]json.RawMessage) (bool, int, string, string) {
 	if len(messages) > maxChatMessages {
-		return http.StatusBadRequest, "messages_too_long", "messages may contain at most 256 entries"
+		return false, http.StatusBadRequest, "messages_too_long", "messages may contain at most 256 entries"
 	}
 
 	allIDs := map[string]int{}
@@ -4757,34 +4777,41 @@ func validateMessages(messages []chatMessage) (int, string, string) {
 	totalToolCalls := 0
 	totalArgumentBytes := 0
 	duplicateAssistantID := false
+	normalizedContent := false
 
 	for i, m := range messages {
 		switch m.Role {
 		case "system", "user":
-			if !rawStringNonEmpty(m.Content) {
-				return http.StatusBadRequest, "invalid_request", "Invalid message content"
+			normalized, changed, status, code, msg := normalizeSystemUserContent(m.Content)
+			if status != 0 {
+				return false, status, code, msg
+			}
+			if changed {
+				messages[i].Content = normalized
+				rawMessages[i]["content"] = normalized
+				normalizedContent = true
 			}
 		case "assistant":
 			hasContent := string(m.Content) != "" && string(m.Content) != "null"
 			hasTools := len(m.ToolCalls) > 0 && string(m.ToolCalls) != "null"
 			if hasContent && !rawString(m.Content) {
-				return http.StatusBadRequest, "invalid_request", "Invalid assistant content"
+				return false, http.StatusBadRequest, "invalid_request", "Invalid assistant content"
 			}
 			if !hasContent && !hasTools {
-				return http.StatusBadRequest, "invalid_request", "Assistant message requires content or tool_calls"
+				return false, http.StatusBadRequest, "invalid_request", "Assistant message requires content or tool_calls"
 			}
 			if hasTools {
 				calls, status, code, msg := parseRequestToolCalls(m.ToolCalls, i)
 				if status != 0 {
-					return status, code, msg
+					return false, status, code, msg
 				}
 				totalToolCalls += len(calls)
 				if totalToolCalls > maxAssistantToolCalls {
-					return http.StatusBadRequest, "too_many_tool_calls", "assistant tool_calls may contain at most 128 entries"
+					return false, http.StatusBadRequest, "too_many_tool_calls", "assistant tool_calls may contain at most 128 entries"
 				}
 				for _, call := range calls {
 					if !validRequestToolCallID(call.ID) {
-						return http.StatusBadRequest, "invalid_tool_call_id", "Invalid tool_call id"
+						return false, http.StatusBadRequest, "invalid_tool_call_id", "Invalid tool_call id"
 					}
 					if _, exists := allIDs[call.ID]; exists {
 						duplicateAssistantID = true
@@ -4793,24 +4820,24 @@ func validateMessages(messages []chatMessage) (int, string, string) {
 					}
 					totalArgumentBytes += len([]byte(call.Arguments))
 					if totalArgumentBytes > maxToolCallArgumentsResponseBytes {
-						return http.StatusRequestEntityTooLarge, "tool_call_arguments_aggregate_too_large", "assistant-history tool_call arguments exceed aggregate cap"
+						return false, http.StatusRequestEntityTooLarge, "tool_call_arguments_aggregate_too_large", "assistant-history tool_call arguments exceed aggregate cap"
 					}
 				}
 				parsedByMessage[i] = calls
 			}
 		case "tool":
 			if m.ToolCallID == "" || !validRequestToolCallID(m.ToolCallID) {
-				return http.StatusBadRequest, "invalid_tool_call_id", "Invalid tool_call_id"
+				return false, http.StatusBadRequest, "invalid_tool_call_id", "Invalid tool_call_id"
 			}
 			if string(m.Content) == "null" || !rawString(m.Content) {
-				return http.StatusBadRequest, "invalid_request", "Invalid tool message content"
+				return false, http.StatusBadRequest, "invalid_request", "Invalid tool message content"
 			}
 		default:
-			return http.StatusBadRequest, "invalid_request", "Invalid message role"
+			return false, http.StatusBadRequest, "invalid_request", "Invalid message role"
 		}
 	}
 	if duplicateAssistantID {
-		return http.StatusBadRequest, "duplicate_tool_call_id", "Duplicate assistant tool_call id"
+		return false, http.StatusBadRequest, "duplicate_tool_call_id", "Duplicate assistant tool_call id"
 	}
 
 	seenAssistantIDs := map[string]struct{}{}
@@ -4824,27 +4851,69 @@ func validateMessages(messages []chatMessage) (int, string, string) {
 			continue
 		}
 		if _, ok := allIDs[m.ToolCallID]; !ok {
-			return http.StatusBadRequest, "tool_call_id_not_found", "tool_call_id does not reference an earlier assistant tool_call"
+			return false, http.StatusBadRequest, "tool_call_id_not_found", "tool_call_id does not reference an earlier assistant tool_call"
 		}
 		if _, ok := seenAssistantIDs[m.ToolCallID]; !ok {
-			return http.StatusBadRequest, "tool_call_result_out_of_order", "tool result appears before matching assistant tool_call"
+			return false, http.StatusBadRequest, "tool_call_result_out_of_order", "tool result appears before matching assistant tool_call"
 		}
 		if _, exists := fulfilledToolIDs[m.ToolCallID]; exists {
-			return http.StatusBadRequest, "duplicate_tool_call_id", "Duplicate tool result for tool_call_id"
+			return false, http.StatusBadRequest, "duplicate_tool_call_id", "Duplicate tool result for tool_call_id"
 		}
 		fulfilledToolIDs[m.ToolCallID] = struct{}{}
 		var content string
 		_ = json.Unmarshal(m.Content, &content)
 		contentBytes := len([]byte(content))
 		if contentBytes > maxToolResultBytes {
-			return http.StatusRequestEntityTooLarge, "tool_result_too_large", "tool message content exceeds 256 KiB"
+			return false, http.StatusRequestEntityTooLarge, "tool_result_too_large", "tool message content exceeds 256 KiB"
 		}
 		totalToolResultBytes += contentBytes
 		if totalToolResultBytes > maxToolResultsAggregateBytes {
-			return http.StatusRequestEntityTooLarge, "tool_results_aggregate_too_large", "tool message content exceeds aggregate cap"
+			return false, http.StatusRequestEntityTooLarge, "tool_results_aggregate_too_large", "tool message content exceeds aggregate cap"
 		}
 	}
-	return 0, "", ""
+	return normalizedContent, 0, "", ""
+}
+
+func normalizeSystemUserContent(raw json.RawMessage) (json.RawMessage, bool, int, string, string) {
+	if rawStringNonEmpty(raw) {
+		return raw, false, 0, "", ""
+	}
+
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, http.StatusBadRequest, "invalid_request", "content must be a non-empty string"
+	}
+	if trimmed[0] != '[' {
+		return nil, false, http.StatusBadRequest, "unsupported_content_shape", "content must be a non-empty string or a text-only structured content array in v1"
+	}
+
+	var parts []chatContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return nil, false, http.StatusBadRequest, "unsupported_content_shape", "structured content arrays must contain text parts in v1"
+	}
+	if len(parts) == 0 {
+		return nil, false, http.StatusBadRequest, "invalid_request", "content must contain non-empty text"
+	}
+
+	var b strings.Builder
+	for _, part := range parts {
+		if part.Type != "text" {
+			return nil, false, http.StatusBadRequest, "unsupported_content_shape", "multimodal content arrays are not supported in v1; use text parts only"
+		}
+		var text string
+		if err := json.Unmarshal(part.Text, &text); err != nil {
+			return nil, false, http.StatusBadRequest, "unsupported_content_shape", "structured content text parts must contain string text"
+		}
+		b.WriteString(text)
+	}
+	if b.Len() == 0 {
+		return nil, false, http.StatusBadRequest, "invalid_request", "content must contain non-empty text"
+	}
+	normalized, err := json.Marshal(b.String())
+	if err != nil {
+		return nil, false, http.StatusBadRequest, "invalid_request", "Invalid message content"
+	}
+	return json.RawMessage(normalized), true, 0, "", ""
 }
 
 func validateTools(raw map[string]json.RawMessage, messages []chatMessage) (int, string, string) {

--- a/phase4-coordinator/internal/buyer/server_internal_test.go
+++ b/phase4-coordinator/internal/buyer/server_internal_test.go
@@ -313,6 +313,69 @@ func TestRequestSidePassThrough_ToolCalls_ByteEquivalent(t *testing.T) {
 	}
 }
 
+func TestStructuredTextContentArrayNormalizesForProvider(t *testing.T) {
+	body := []byte(`{
+		"model":"model-a",
+		"messages":[
+			{"role":"system","content":[{"type":"text","text":"Be "},{"type":"text","text":"brief."}]},
+			{"role":"user","content":[{"type":"text","text":"Hello"}]}
+		],
+		"user":"sdk-user"
+	}`)
+	req, status, code, msg := validateChatRequest(body)
+	if status != 0 {
+		t.Fatalf("validateChatRequest status=%d code=%s msg=%s", status, code, msg)
+	}
+	for _, providerModelID := range []string{"model-a", "provider-model-b"} {
+		t.Run(providerModelID, func(t *testing.T) {
+			outbound, err := dispatchBodyForProvider(req, pool.Provider{ModelID: providerModelID})
+			if err != nil {
+				t.Fatalf("dispatchBodyForProvider: %v", err)
+			}
+			if bytes.Contains(outbound, []byte(`"tool_calls"`)) || bytes.Contains(outbound, []byte(`"tool_call_id"`)) {
+				t.Fatalf("normalized simple messages gained tool fields: %s", string(outbound))
+			}
+
+			var got struct {
+				Model    string `json:"model"`
+				Messages []struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				} `json:"messages"`
+			}
+			if err := json.Unmarshal(outbound, &got); err != nil {
+				t.Fatalf("unmarshal outbound: %v; body=%s", err, string(outbound))
+			}
+			if got.Model != providerModelID {
+				t.Fatalf("model = %q, want %q; body=%s", got.Model, providerModelID, string(outbound))
+			}
+			if len(got.Messages) != 2 {
+				t.Fatalf("messages len = %d, want 2; body=%s", len(got.Messages), string(outbound))
+			}
+			if got.Messages[0].Content != "Be brief." || got.Messages[1].Content != "Hello" {
+				t.Fatalf("normalized content = %#v; body=%s", got.Messages, string(outbound))
+			}
+		})
+	}
+}
+
+func TestStructuredContentArrayRejectsMultimodalPart(t *testing.T) {
+	body := []byte(`{
+		"model":"model-a",
+		"messages":[{"role":"user","content":[
+			{"type":"text","text":"describe this"},
+			{"type":"image_url","image_url":{"url":"https://example.test/image.png"}}
+		]}]
+	}`)
+	_, status, code, msg := validateChatRequest(body)
+	if status != 400 || code != "unsupported_content_shape" {
+		t.Fatalf("validateChatRequest status=%d code=%s msg=%s, want 400 unsupported_content_shape", status, code, msg)
+	}
+	if !strings.Contains(msg, "multimodal content arrays are not supported") {
+		t.Fatalf("message not actionable: %q", msg)
+	}
+}
+
 func requestSideToolFields(t *testing.T, body []byte) (json.RawMessage, []json.RawMessage) {
 	t.Helper()
 	var parsed struct {

--- a/phase4-coordinator/internal/buyer/server_internal_test.go
+++ b/phase4-coordinator/internal/buyer/server_internal_test.go
@@ -359,6 +359,69 @@ func TestStructuredTextContentArrayNormalizesForProvider(t *testing.T) {
 	}
 }
 
+func TestStructuredTextContentArrayPreservesToolHistory(t *testing.T) {
+	body := []byte(`{
+		"model":"model-a",
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"plan"}]},
+			{"role":"assistant","content":null,"tool_calls":[
+				{"id":"call_alpha12345678901","type":"function","function":{"name":"lookup","arguments":"{\"q\":\"content array\",\"n\":1}"}}
+			]},
+			{"role":"tool","tool_call_id":"call_alpha12345678901","content":"{\"ok\":true}"}
+		]
+	}`)
+	req, status, code, msg := validateChatRequest(body)
+	if status != 0 {
+		t.Fatalf("validateChatRequest status=%d code=%s msg=%s", status, code, msg)
+	}
+
+	originalToolCalls, originalToolIDs := requestSideToolFields(t, body)
+	for _, providerModelID := range []string{"model-a", "provider-model-b"} {
+		t.Run(providerModelID, func(t *testing.T) {
+			outbound, err := dispatchBodyForProvider(req, pool.Provider{ModelID: providerModelID})
+			if err != nil {
+				t.Fatalf("dispatchBodyForProvider: %v", err)
+			}
+			var got struct {
+				Messages []struct {
+					Role    string          `json:"role"`
+					Content json.RawMessage `json:"content"`
+				} `json:"messages"`
+			}
+			if err := json.Unmarshal(outbound, &got); err != nil {
+				t.Fatalf("unmarshal outbound: %v; body=%s", err, string(outbound))
+			}
+			if len(got.Messages) != 3 {
+				t.Fatalf("messages len = %d, want 3; body=%s", len(got.Messages), string(outbound))
+			}
+			if got.Messages[0].Role != "user" || !bytes.Equal(got.Messages[0].Content, mustJSONString(t, "plan")) {
+				t.Fatalf("user content not normalized to string: %#v; body=%s", got.Messages[0], string(outbound))
+			}
+			forwardedToolCalls, forwardedToolIDs := requestSideToolFields(t, outbound)
+			if !bytes.Equal(compactJSONRaw(t, originalToolCalls), compactJSONRaw(t, forwardedToolCalls)) {
+				t.Fatalf("tool_calls semantics mutated:\noriginal=%s\nforwarded=%s", originalToolCalls, forwardedToolCalls)
+			}
+			if len(originalToolIDs) != len(forwardedToolIDs) {
+				t.Fatalf("tool_call_id count = %d, want %d", len(forwardedToolIDs), len(originalToolIDs))
+			}
+			for i := range originalToolIDs {
+				if !bytes.Equal(originalToolIDs[i], forwardedToolIDs[i]) {
+					t.Fatalf("tool_call_id[%d] bytes = %s, want %s", i, forwardedToolIDs[i], originalToolIDs[i])
+				}
+			}
+		})
+	}
+}
+
+func compactJSONRaw(t *testing.T, raw json.RawMessage) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		t.Fatalf("compact JSON %s: %v", raw, err)
+	}
+	return buf.Bytes()
+}
+
 func TestStructuredContentArrayRejectsMultimodalPart(t *testing.T) {
 	body := []byte(`{
 		"model":"model-a",

--- a/phase5-gateway/internal/router/templates/docs.md
+++ b/phase5-gateway/internal/router/templates/docs.md
@@ -93,6 +93,11 @@ Primary buyer endpoints:
 
 `POST /v1/chat/completions` accepts OpenAI-compatible chat completion requests. Set `stream:true` for server-sent events or omit it for a single JSON response.
 
+Text-only structured `messages[].content` arrays such as
+`[{"type":"text","text":"Say hello"}]` are accepted and normalized to plain
+text before provider dispatch. Multimodal parts such as `image_url` are not
+supported in v1 and return `unsupported_content_shape`.
+
 Covered paid settlement claims are limited to `POST /v1/chat/completions`. Buyer cancel, gateway timeout, provider error, or upstream disconnect can create a partial charge only when a settlement-capable receipt binds the delivered output prefix and partial usage.
 
 Excluded legacy/direct paths are outside this SPEC-022 gateway settlement claim unless separately disabled or migrated behind the gateway paid ledger: `coordinator.streamvc.live`, `m4.streamvc.live`, and `m1.streamvc.live`.
@@ -178,5 +183,6 @@ Common codes:
 | `missing_bearer_token` | Add `Authorization: Bearer mp_...` |
 | `invalid_demo_token` | Refresh the browser demo session |
 | `quota_exhausted` | Daily or request quota is exhausted |
+| `unsupported_content_shape` | Use string content or text-only structured content arrays; multimodal parts are not supported in v1 |
 | `coordinator_unavailable` | The provider pool is temporarily unavailable |
 | `not_found` | The requested route does not exist |

--- a/phase5-gateway/internal/router/templates/docs.md
+++ b/phase5-gateway/internal/router/templates/docs.md
@@ -93,10 +93,10 @@ Primary buyer endpoints:
 
 `POST /v1/chat/completions` accepts OpenAI-compatible chat completion requests. Set `stream:true` for server-sent events or omit it for a single JSON response.
 
-Text-only structured `messages[].content` arrays such as
-`[{"type":"text","text":"Say hello"}]` are accepted and normalized to plain
-text before provider dispatch. Multimodal parts such as `image_url` are not
-supported in v1 and return `unsupported_content_shape`.
+Text-only structured `messages[].content` arrays are accepted for `system` and
+`user` messages and normalized to plain text before provider dispatch.
+Multimodal parts such as `image_url` are not supported in v1 and return
+`unsupported_content_shape`.
 
 Covered paid settlement claims are limited to `POST /v1/chat/completions`. Buyer cancel, gateway timeout, provider error, or upstream disconnect can create a partial charge only when a settlement-capable receipt binds the delivered output prefix and partial usage.
 
@@ -183,6 +183,6 @@ Common codes:
 | `missing_bearer_token` | Add `Authorization: Bearer mp_...` |
 | `invalid_demo_token` | Refresh the browser demo session |
 | `quota_exhausted` | Daily or request quota is exhausted |
-| `unsupported_content_shape` | Use string content or text-only structured content arrays; multimodal parts are not supported in v1 |
+| `unsupported_content_shape` | Use string content; `system` and `user` messages may also use text-only structured content arrays. Multimodal parts are not supported in v1 |
 | `coordinator_unavailable` | The provider pool is temporarily unavailable |
 | `not_found` | The requested route does not exist |

--- a/specs/SPEC-006-buyer-api.md
+++ b/specs/SPEC-006-buyer-api.md
@@ -917,9 +917,9 @@ Known v1 divergences include:
 - No tool execution.
 - Tool fields may be syntactically accepted but are not executed.
 - Strict schema-enforced structured outputs are not guaranteed.
-- Multimodal `messages[].content` parts are not supported in v1. Text-only
-  structured content arrays are accepted and normalized to a single string;
-  non-text parts such as `image_url` return
+- Multimodal `messages[].content` parts are not supported in v1. For `system`
+  and `user` messages, text-only structured content arrays are accepted and
+  normalized to a single string; non-text parts such as `image_url` return
   `unsupported_content_shape`.
 - Provider availability can yield 503 immediately.
 - Model lineup is live-pool dependent.

--- a/specs/SPEC-006-buyer-api.md
+++ b/specs/SPEC-006-buyer-api.md
@@ -917,6 +917,10 @@ Known v1 divergences include:
 - No tool execution.
 - Tool fields may be syntactically accepted but are not executed.
 - Strict schema-enforced structured outputs are not guaranteed.
+- Multimodal `messages[].content` parts are not supported in v1. Text-only
+  structured content arrays are accepted and normalized to a single string;
+  non-text parts such as `image_url` return
+  `unsupported_content_shape`.
 - Provider availability can yield 503 immediately.
 - Model lineup is live-pool dependent.
 - Usage accounting may be gateway-estimated when provider token fields are absent.
@@ -1201,6 +1205,13 @@ Supported request fields:
 `user` is accepted as opaque diagnostics, stored in usage events, and MUST NOT be exposed in buyer-visible responses.
 
 `logprobs` is accepted syntactically and forwarded to the provider as part of the request body. SPEC-001 v1.2.2 § 6.4 specifies unknown-field tolerance, so the provider MAY ignore unknown OpenAI-compatible fields including `logprobs`. Behavior is model-dependent; the gateway MUST NOT enforce `logprobs`-specific semantics.
+
+For `system` and `user` messages, `content` MAY be a non-empty JSON string
+or a text-only structured content array such as
+`[{"type":"text","text":"hello"}]`. The buyer boundary MUST normalize
+text-only arrays into a single string before provider dispatch. Multimodal or
+otherwise non-text content parts MUST be rejected with HTTP 400,
+`type: "invalid_request_error"`, and `code: "unsupported_content_shape"`.
 
 Gateway request caps:
 


### PR DESCRIPTION
## Summary
- Accept text-only structured `messages[].content` arrays for `system` and `user` messages and normalize them to string content before provider dispatch.
- Reject multimodal/non-text content parts with `unsupported_content_shape` and an actionable message.
- Document the v1 multimodal divergence in SPEC-006, the SDK cookbook, and the public gateway docs template.

Closes #445.

## Validation
- `cd phase4-coordinator && go test ./internal/buyer -count=1`
- `cd phase4-coordinator && go test ./... -count=1`
- `cd phase5-gateway && go test ./... -count=1`

## Notes
- Unchanged string-content requests keep the existing raw pass-through behavior.
- Normalized requests are reserialized only when a supported text-only content array is present.
