### PR TITLE
Malibu: tail provider logs and surface stale-catalog startup failures

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -149,6 +149,8 @@ enum AgentSnapshotPresenter {
             return s.currentModelID
         case .reconnecting:
             return s.lastError ?? "Checking background provider…"
+        case .starting:
+            return s.lastError ?? "Waiting for the background provider to respond…"
         case .error:
             return s.lastError
         default:

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -22,18 +22,19 @@ import Foundation
 final class MalibuAgent: ObservableObject {
     @Published private(set) var snapshot: AgentSnapshot = .empty
     @Published private(set) var logLines: [String] = []
+    @Published private(set) var providerStartFailure: String?
 
     private var child: CLIChildProcess?
     private var control: ControlSocketClient?
     private var metricsPoller: Task<Void, Never>?
     private var eventStreamTask: Task<Void, Never>?
     private var reconnectTask: Task<Void, Never>?
-    private var logTailReader: LogTailReader?
+    private var providerLogTail: ProviderLogTail?
+    private var providerLogTailCancellable: AnyCancellable?
     private var reconnect = ReconnectPolicy()
     private let earningsClient = EarningsClient()
     private let thermalMonitor = ThermalMonitor()
     private var cancellables: Set<AnyCancellable> = []
-    private var logTailCancellable: AnyCancellable?
     // AUDIT R2 CODE H3 fix: once shutdown begins, refuse any subsequent start()
     // — including a reconnect Task that already slept past its cancellation
     // check but hadn't yet re-entered the MainActor.
@@ -63,7 +64,14 @@ final class MalibuAgent: ObservableObject {
         await releaseSpawnedChildForLaunchdMonitor()
 
         snapshot.state = .starting
+        startProviderLogTail()
         if await monitorInstalledProviderIfPresent() {
+            return
+        }
+
+        if let failure = providerStartFailure {
+            snapshot.state = .error
+            snapshot.lastError = failure
             return
         }
 
@@ -84,8 +92,17 @@ final class MalibuAgent: ObservableObject {
         }
         guard !isShuttingDown else { return }
 
+        if let failure = diagnosedProviderFailure() {
+            providerStartFailure = failure
+            snapshot.state = .error
+            snapshot.lastError = failure
+            return
+        }
+
         snapshot.state = .reconnecting
-        snapshot.lastError = "Background provider is not responding. Open onboarding to reinstall or check ~/Library/Logs/macprovider/."
+        snapshot.lastError = ProviderLogDiagnostics.timeoutMessage(
+            logHint: ProviderLogDiagnostics.logHint()
+        )
         await scheduleReconnect()
     }
 
@@ -155,8 +172,7 @@ final class MalibuAgent: ObservableObject {
         await control?.close()
         metricsPoller?.cancel(); metricsPoller = nil
         eventStreamTask?.cancel(); eventStreamTask = nil
-        logTailCancellable?.cancel(); logTailCancellable = nil
-        logTailReader?.stop(); logTailReader = nil
+        stopProviderLogTail()
         logLines = []
         child = nil
         control = nil
@@ -176,18 +192,39 @@ final class MalibuAgent: ObservableObject {
               ProviderConfig.readProviderID() != nil else {
             return false
         }
+        providerStartFailure = nil
         await releaseSpawnedChildForLaunchdMonitor()
+        startProviderLogTail()
         let deadline = Date().addingTimeInterval(max(1, timeout))
-        guard await InstalledProviderMonitor.waitForHealthy(port: port, deadline: deadline) else {
-            return false
+        let pollInterval: TimeInterval = 2
+        while Date() < deadline {
+            if await InstalledProviderMonitor.isHealthy(port: port) {
+                monitorsLaunchdProvider = true
+                providerStartFailure = nil
+                await applyProviderSnapshot(port: port)
+                snapshot.state = .serving
+                snapshot.lastError = nil
+                startHealthPolling(port: port)
+                await refreshEarnings()
+                return true
+            }
+            if let failure = diagnosedProviderFailure() {
+                providerStartFailure = failure
+                snapshot.state = .error
+                snapshot.lastError = failure
+                return false
+            }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { break }
+            let sleep = min(pollInterval, remaining)
+            try? await Task.sleep(nanoseconds: UInt64(sleep * 1_000_000_000))
         }
-        monitorsLaunchdProvider = true
-        await applyProviderSnapshot(port: port)
-        snapshot.state = .serving
-        snapshot.lastError = nil
-        startHealthPolling(port: port)
-        await refreshEarnings()
-        return true
+        let failure = diagnosedProviderFailure()
+            ?? ProviderLogDiagnostics.timeoutMessage(logHint: ProviderLogDiagnostics.logHint())
+        providerStartFailure = failure
+        snapshot.state = .error
+        snapshot.lastError = failure
+        return false
     }
 
     /// Stop a Malibu-spawned CLI child before attaching to launchd. Without
@@ -204,10 +241,6 @@ final class MalibuAgent: ObservableObject {
         metricsPoller = nil
         eventStreamTask?.cancel()
         eventStreamTask = nil
-        logTailCancellable?.cancel()
-        logTailCancellable = nil
-        logTailReader?.stop()
-        logTailReader = nil
         await control?.close()
         child = nil
         control = nil
@@ -302,8 +335,16 @@ final class MalibuAgent: ObservableObject {
                     await self.refreshEarnings()
                 } else if self.monitorsLaunchdProvider {
                     await MainActor.run {
-                        self.snapshot.state = .reconnecting
-                        self.snapshot.lastError = "Background provider is not responding on port \(port)."
+                        if let failure = self.diagnosedProviderFailure() {
+                            self.providerStartFailure = failure
+                            self.snapshot.state = .error
+                            self.snapshot.lastError = failure
+                        } else {
+                            self.snapshot.state = .reconnecting
+                            self.snapshot.lastError = ProviderLogDiagnostics.timeoutMessage(
+                                logHint: ProviderLogDiagnostics.logHint()
+                            )
+                        }
                     }
                 }
             }
@@ -498,16 +539,27 @@ final class MalibuAgent: ObservableObject {
         }
     }
 
-    private func startLogTail(fileURL: URL) {
-        logTailCancellable?.cancel()
-        logTailReader?.stop()
-        let reader = LogTailReader(fileURL: fileURL)
-        logTailCancellable = reader.$lines
+    private func startProviderLogTail(paths: ProviderPaths = .current) {
+        providerLogTailCancellable?.cancel()
+        providerLogTail?.stop()
+        let tail = ProviderLogTail()
+        providerLogTailCancellable = tail.$lines
             .sink { [weak self] lines in
                 self?.logLines = lines
             }
-        logTailReader = reader
-        reader.start()
+        providerLogTail = tail
+        tail.start(paths: paths)
+    }
+
+    private func stopProviderLogTail() {
+        providerLogTailCancellable?.cancel()
+        providerLogTailCancellable = nil
+        providerLogTail?.stop()
+        providerLogTail = nil
+    }
+
+    private func diagnosedProviderFailure() -> String? {
+        ProviderLogDiagnostics.diagnose(lines: logLines)?.userMessage
     }
 
     private func handleIdentitySignatureRequest(

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -34,6 +34,7 @@ final class LaunchProviderController: ObservableObject {
         var importCLIConfigAfterInstall: @MainActor () async throws -> Void
         var monitorInstalledProvider: @MainActor () async -> Bool
         var readConfigModel: () -> String?
+        var providerStartFailure: @MainActor () -> String?
 
         static func live(agent: MalibuAgent?) -> Dependencies {
             Dependencies(
@@ -51,7 +52,8 @@ final class LaunchProviderController: ObservableObject {
                         timeout: MalibuOnboardingTimeouts.firstServingFrameSec
                     )
                 },
-                readConfigModel: { ProviderConfig.readModel() }
+                readConfigModel: { ProviderConfig.readModel() },
+                providerStartFailure: { agent?.providerStartFailure }
             )
         }
     }
@@ -129,7 +131,9 @@ final class LaunchProviderController: ObservableObject {
             try await dependencies.registerLoginItem()
             stage = .startingAgent
             guard await dependencies.monitorInstalledProvider() else {
-                throw launchdMonitorUnavailableError()
+                let message = dependencies.providerStartFailure()
+                    ?? ProviderLogDiagnostics.timeoutMessage(logHint: ProviderLogDiagnostics.logHint())
+                throw launchdMonitorUnavailableError(message: message)
             }
             let model = dependencies.readConfigModel() ?? "installed"
             stage = .live(model: model, tier: .provisional)
@@ -138,14 +142,11 @@ final class LaunchProviderController: ObservableObject {
         }
     }
 
-    private func launchdMonitorUnavailableError() -> NSError {
+    private func launchdMonitorUnavailableError(message: String) -> NSError {
         NSError(
             domain: "Malibu.LaunchProviderController",
             code: 3,
-            userInfo: [
-                NSLocalizedDescriptionKey:
-                    "Background provider did not become healthy in time. Check ~/Library/Logs/macprovider/ and try again."
-            ]
+            userInfo: [NSLocalizedDescriptionKey: message]
         )
     }
 

--- a/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
@@ -100,8 +100,24 @@ private struct OnboardingRootView: View {
                 }
             }
         case .startingAgent:
-            stageRow(title: "Starting", detail: "Waiting for the background provider to become healthy.") {
-                ProgressView().controlSize(.small)
+            stageRow(
+                title: "Starting",
+                detail: agent.providerStartFailure
+                    ?? agent.snapshot.lastError
+                    ?? "Waiting for the background provider to become healthy."
+            ) {
+                VStack(alignment: .leading, spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    if !agent.logLines.isEmpty {
+                        ScrollView {
+                            Text(agent.logLines.suffix(20).joined(separator: "\n"))
+                                .font(.system(.caption, design: .monospaced))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                        }
+                        .frame(maxHeight: 160)
+                    }
+                }
             }
         case let .live(model, tier):
             VStack(alignment: .leading, spacing: 16) {

--- a/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Maps macprovider-cli stderr lines (launchd or Malibu-spawned) to operator-facing text.
+enum ProviderLogDiagnostics {
+    struct Finding: Equatable {
+        let id: String
+        let userMessage: String
+        let matchedLine: String
+    }
+
+    private struct Rule {
+        let id: String
+        let needle: String
+        let userMessage: String
+    }
+
+    private static let rules: [Rule] = [
+        Rule(
+            id: "stale_model_catalog",
+            needle: "model catalog provenance is stale",
+            userMessage:
+                "Model catalog is out of date for this Mac. Update Malibu to the latest release, "
+                + "or run: macprovider-cli autotune --recommend --apply"
+        ),
+        Rule(
+            id: "catalog_admission",
+            needle: "model artifact is not admitted by the signed candidate catalog",
+            userMessage:
+                "The configured model is not allowed by the signed catalog. "
+                + "Run: macprovider-cli autotune --recommend --apply"
+        ),
+        Rule(
+            id: "rate_card_admission",
+            needle: "model artifact is not admitted by the signed rate card",
+            userMessage:
+                "The configured model is not on the signed rate card. "
+                + "Run: macprovider-cli autotune --recommend --apply"
+        ),
+        Rule(
+            id: "catalog_key_mismatch",
+            needle: "model must match model_catalog_key",
+            userMessage:
+                "Config model does not match the catalog entry from autotune. "
+                + "Run: macprovider-cli autotune --recommend --apply"
+        ),
+        Rule(
+            id: "artifact_hash_mismatch",
+            needle: "model artifact hash mismatch",
+            userMessage:
+                "Downloaded model weights do not match the catalog hash. "
+                + "Re-download the model or rerun autotune --recommend --apply."
+        ),
+        Rule(
+            id: "artifact_verification_failed",
+            needle: "model artifact verification failed",
+            userMessage:
+                "Local model weights failed verification. Re-download the model or rerun autotune."
+        ),
+        Rule(
+            id: "missing_catalog_provenance",
+            needle: "model_artifact_sha256 requires model_catalog_* provenance",
+            userMessage:
+                "Serve config is missing catalog provenance from autotune. "
+                + "Run: macprovider-cli autotune --recommend --apply"
+        ),
+        Rule(
+            id: "missing_artifact_sha",
+            needle: "coordinator join requires model_artifact_sha256",
+            userMessage:
+                "Serve config is missing a verified model artifact hash. "
+                + "Run: macprovider-cli autotune --recommend --apply"
+        ),
+        Rule(
+            id: "snapshot_path_mismatch",
+            needle: "model must be the catalog-pinned hugging face snapshot path",
+            userMessage:
+                "Config points at the wrong on-disk model path. "
+                + "Run: macprovider-cli autotune --recommend --apply"
+        ),
+    ]
+
+    static func diagnose(lines: [String]) -> Finding? {
+        for line in lines.reversed() {
+            let normalized = line.lowercased()
+            for rule in rules {
+                if normalized.contains(rule.needle) {
+                    return Finding(id: rule.id, userMessage: rule.userMessage, matchedLine: line)
+                }
+            }
+        }
+        return nil
+    }
+
+    static func timeoutMessage(logHint: String) -> String {
+        "Background provider did not become healthy in time. \(logHint)"
+    }
+
+    static func logHint(paths: ProviderPaths = .current) -> String {
+        "Check \(paths.launchdStderrLog.path) and \(paths.launchdStdoutLog.path)."
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/System/ProviderLogTail.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderLogTail.swift
@@ -1,0 +1,58 @@
+import Combine
+import Foundation
+
+/// Tails launchd provider stdout/stderr logs into one redacted line buffer for UI + diagnostics.
+@MainActor
+final class ProviderLogTail: ObservableObject {
+    @Published private(set) var lines: [String] = []
+
+    private let capacity: Int
+    private var stderrReader: LogTailReader?
+    private var stdoutReader: LogTailReader?
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(capacity: Int = 200) {
+        self.capacity = capacity
+    }
+
+    func start(paths: ProviderPaths = .current) {
+        stop()
+        stderrReader = attachReader(fileURL: paths.launchdStderrLog)
+        stdoutReader = attachReader(fileURL: paths.launchdStdoutLog)
+        Task { @MainActor [weak self] in
+            await self?.stderrReader?.readAvailable()
+            await self?.stdoutReader?.readAvailable()
+            self?.mergePublishedLines()
+        }
+    }
+
+    func stop() {
+        cancellables.removeAll()
+        stderrReader?.stop()
+        stdoutReader?.stop()
+        stderrReader = nil
+        stdoutReader = nil
+    }
+
+    @discardableResult
+    private func attachReader(fileURL: URL) -> LogTailReader {
+        let reader = LogTailReader(fileURL: fileURL, capacity: capacity)
+        reader.start()
+        reader.$lines
+            .sink { [weak self] _ in
+                self?.mergePublishedLines()
+            }
+            .store(in: &cancellables)
+        return reader
+    }
+
+    private func mergePublishedLines() {
+        var merged: [String] = []
+        merged.append(contentsOf: stderrReader?.lines ?? [])
+        merged.append(contentsOf: stdoutReader?.lines ?? [])
+        if merged.count > capacity {
+            merged.removeFirst(merged.count - capacity)
+        }
+        lines = merged
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/System/ProviderPaths.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderPaths.swift
@@ -9,6 +9,8 @@ struct ProviderPaths {
     let configFile: URL          // ~/.config/macprovider/config.yaml (shared with CLI track)
     let controlSocket: URL       // ~/Library/Application Support/Malibu/agent.sock
     let cliLogFile: URL          // ~/Library/Logs/malibu/malibu-cli.log
+    let launchdStdoutLog: URL    // ~/Library/Logs/macprovider/macprovider.out.log
+    let launchdStderrLog: URL    // ~/Library/Logs/macprovider/macprovider.err.log
     let appSupport: URL          // ~/Library/Application Support/Malibu
     let appMarkerFile: URL       // ~/Library/Application Support/Malibu/.installed-by-app
     let onboardingStateFile: URL // ~/Library/Application Support/Malibu/onboarding.json
@@ -22,6 +24,8 @@ struct ProviderPaths {
             configFile: home.appendingPathComponent(".config/macprovider/config.yaml"),
             controlSocket: appSupport.appendingPathComponent("agent.sock"),
             cliLogFile: home.appendingPathComponent("Library/Logs/malibu/malibu-cli.log"),
+            launchdStdoutLog: home.appendingPathComponent("Library/Logs/macprovider/macprovider.out.log"),
+            launchdStderrLog: home.appendingPathComponent("Library/Logs/macprovider/macprovider.err.log"),
             appSupport: appSupport,
             appMarkerFile: appSupport.appendingPathComponent(".installed-by-app"),
             onboardingStateFile: appSupport.appendingPathComponent("onboarding.json"),

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -103,6 +103,25 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
 
+    func testLaunchMonitorFailureSurfacesProviderStartFailure() async {
+        let harness = Harness()
+        harness.monitorHealthy = false
+        harness.providerStartFailureMessage =
+            "Model catalog is out of date for this Mac. Update Malibu to the latest release, "
+            + "or run: macprovider-cli autotune --recommend --apply"
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+
+        if case let .failed(stage, retryable, message) = controller.stage {
+            XCTAssertEqual(stage, "cliInstall")
+            XCTAssertTrue(retryable)
+            XCTAssertEqual(message, harness.providerStartFailureMessage)
+        } else {
+            XCTFail("expected failed cliInstall stage with provider start failure")
+        }
+    }
+
     private final class Harness {
         var localInstallSucceeded = false
         var localInstallSucceededAfterInstall = false
@@ -111,6 +130,7 @@ final class LaunchProviderControllerTests: XCTestCase {
         var monitorRuns = 0
         var loginItemRegistrations = 0
         var monitorHealthy = true
+        var providerStartFailureMessage: String?
         var cliInstallError: Error?
         var cliImportError: Error?
         var configModel = "mlx-community/Qwen2.5-7B-Instruct-4bit"
@@ -138,7 +158,8 @@ final class LaunchProviderControllerTests: XCTestCase {
                     self.monitorRuns += 1
                     return self.monitorHealthy
                 },
-                readConfigModel: { self.configModel }
+                readConfigModel: { self.configModel },
+                providerStartFailure: { self.providerStartFailureMessage }
             )
         }
     }

--- a/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
@@ -533,6 +533,8 @@ final class ProviderConfigParserTests: XCTestCase {
             configFile: configRoot.appendingPathComponent("config.yaml"),
             controlSocket: appSupport.appendingPathComponent("agent.sock"),
             cliLogFile: root.appendingPathComponent("logs/malibu-cli.log"),
+            launchdStdoutLog: root.appendingPathComponent("logs/macprovider.out.log"),
+            launchdStderrLog: root.appendingPathComponent("logs/macprovider.err.log"),
             appSupport: appSupport,
             appMarkerFile: appSupport.appendingPathComponent(".installed-by-app"),
             onboardingStateFile: appSupport.appendingPathComponent("onboarding.json"),

--- a/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Malibu
+
+final class ProviderLogDiagnosticsTests: XCTestCase {
+    func testDiagnoseStaleCatalogProvenance() {
+        let finding = ProviderLogDiagnostics.diagnose(lines: [
+            "loading config",
+            "model catalog provenance is stale; rerun autotune --recommend --apply",
+        ])
+
+        XCTAssertEqual(finding?.id, "stale_model_catalog")
+        XCTAssertTrue(finding?.userMessage.contains("autotune --recommend --apply") == true)
+    }
+
+    func testDiagnosePrefersMostRecentMatchingLine() {
+        let finding = ProviderLogDiagnostics.diagnose(lines: [
+            "model artifact hash mismatch for /tmp/old",
+            "model catalog provenance is stale; rerun autotune --recommend --apply",
+        ])
+
+        XCTAssertEqual(finding?.id, "stale_model_catalog")
+    }
+
+    func testDiagnoseReturnsNilForUnrecognizedLines() {
+        XCTAssertNil(ProviderLogDiagnostics.diagnose(lines: ["serve starting", "connected to coordinator"]))
+    }
+
+    func testTimeoutMessageIncludesLogPaths() {
+        let message = ProviderLogDiagnostics.timeoutMessage(
+            logHint: ProviderLogDiagnostics.logHint(
+                paths: ProviderPaths(
+                    configFile: URL(fileURLWithPath: "/tmp/config.yaml"),
+                    controlSocket: URL(fileURLWithPath: "/tmp/agent.sock"),
+                    cliLogFile: URL(fileURLWithPath: "/tmp/malibu-cli.log"),
+                    launchdStdoutLog: URL(fileURLWithPath: "/tmp/macprovider.out.log"),
+                    launchdStderrLog: URL(fileURLWithPath: "/tmp/macprovider.err.log"),
+                    appSupport: URL(fileURLWithPath: "/tmp/Malibu"),
+                    appMarkerFile: URL(fileURLWithPath: "/tmp/.installed-by-app"),
+                    onboardingStateFile: URL(fileURLWithPath: "/tmp/onboarding.json"),
+                    downloadsDirectory: URL(fileURLWithPath: "/tmp/Downloads")
+                )
+            )
+        )
+
+        XCTAssertTrue(message.contains("/tmp/macprovider.err.log"))
+        XCTAssertTrue(message.contains("/tmp/macprovider.out.log"))
+    }
+}

--- a/phase3-binary/app/Tests/MalibuTests/ProviderLogTailTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderLogTailTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Malibu
+
+@MainActor
+final class ProviderLogTailTests: XCTestCase {
+    func testMergedTailIncludesStderrAndStdout() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let stderr = root.appendingPathComponent("macprovider.err.log")
+        let stdout = root.appendingPathComponent("macprovider.out.log")
+        try "stderr-line\n".data(using: .utf8)?.write(to: stderr)
+        try "stdout-line\n".data(using: .utf8)?.write(to: stdout)
+
+        let paths = ProviderPaths(
+            configFile: root.appendingPathComponent("config.yaml"),
+            controlSocket: root.appendingPathComponent("agent.sock"),
+            cliLogFile: root.appendingPathComponent("malibu-cli.log"),
+            launchdStdoutLog: stdout,
+            launchdStderrLog: stderr,
+            appSupport: root.appendingPathComponent("Malibu"),
+            appMarkerFile: root.appendingPathComponent(".installed-by-app"),
+            onboardingStateFile: root.appendingPathComponent("onboarding.json"),
+            downloadsDirectory: root.appendingPathComponent("Downloads")
+        )
+
+        let tail = ProviderLogTail(capacity: 20)
+        tail.start(paths: paths)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertTrue(tail.lines.contains("stderr-line"))
+        XCTAssertTrue(tail.lines.contains("stdout-line"))
+    }
+}

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -100,6 +100,8 @@ final class StartupRouteTests: XCTestCase {
             configFile: configRoot.appendingPathComponent("config.yaml"),
             controlSocket: appSupport.appendingPathComponent("agent.sock"),
             cliLogFile: root.appendingPathComponent("logs/malibu-cli.log"),
+            launchdStdoutLog: root.appendingPathComponent("logs/macprovider.out.log"),
+            launchdStderrLog: root.appendingPathComponent("logs/macprovider.err.log"),
             appSupport: appSupport,
             appMarkerFile: appSupport.appendingPathComponent(".installed-by-app"),
             onboardingStateFile: appSupport.appendingPathComponent("onboarding.json"),


### PR DESCRIPTION
## Summary

- Tail launchd provider stdout/stderr into Malibu during startup and steady-state monitoring so the dashboard log panel is live.
- Scan tailed lines for known CLI serve-preflight failures (stale catalog provenance, artifact hash mismatch, missing autotune pins) and fail fast with actionable copy instead of an infinite Starting spinner.
- Show redacted log tail plus diagnosis in onboarding and propagate providerStartFailure into launch failures.

Fixes the Malibu reboot incident class where launchd restart-looped on stale catalog provenance while the UI showed no explanation.

## Test plan

- [x] xcodebuild MalibuTests (116 tests, 0 failures)
- [ ] CI phase3-binary swift test green
- [ ] Manual: stale-catalog line in macprovider.err.log surfaces in onboarding


Made with [Cursor](https://cursor.com)