### PR TITLE
Wire Sparkle in-app updates for Malibu.app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,6 +485,24 @@ jobs:
             echo "  Malibu.app.pkg: phase3-binary/app/dist/Malibu-${tag}.pkg"
           fi
 
+      - name: Generate Sparkle appcast for Malibu.app
+        shell: bash
+        env:
+          SPARKLE_EDDSA_PRIVATE_KEY: ${{ secrets.SPARKLE_EDDSA_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          dmg="phase3-binary/app/dist/Malibu-${tag}.dmg"
+          if [ ! -f "$dmg" ]; then
+            echo "No Malibu dmg at $dmg; skipping appcast generation."
+            exit 0
+          fi
+          if [ -z "${SPARKLE_EDDSA_PRIVATE_KEY:-}" ]; then
+            echo "::warning::SPARKLE_EDDSA_PRIVATE_KEY not set; skipping Sparkle appcast generation."
+            exit 0
+          fi
+          bash scripts/generate-malibu-appcast.sh "$tag"
+
       - name: Clean signing material
         if: always()
         shell: bash
@@ -619,10 +637,12 @@ jobs:
           pkg_src="phase3-binary/dist/phase3-binary-m4-${tag}.pkg"
           app_src="phase3-binary/app/dist/Malibu-${tag}.pkg"
           app_dmg_src="phase3-binary/app/dist/Malibu-${tag}.dmg"
+          appcast_src="phase3-binary/app/dist/appcast.xml"
           tar_asset="macprovider-cli-${tag}-darwin-arm64.tar.gz"
           pkg_asset="macprovider-cli-${tag}-darwin-arm64.pkg"
           app_asset="Malibu-${tag}.pkg"
           app_dmg_asset="Malibu-${tag}.dmg"
+          appcast_asset="appcast.xml"
           test -f "$src"
           if [ -z "$MACPROVIDER_RELEASE_SIGNING_KEY_PEM" ]; then
             echo "MACPROVIDER_RELEASE_SIGNING_KEY_PEM secret is required" >&2
@@ -642,6 +662,10 @@ jobs:
           if [ -f "$app_dmg_src" ]; then
             cp "$app_dmg_src" "$app_dmg_asset"
             release_assets+=("$app_dmg_asset")
+          fi
+          if [ -f "$appcast_src" ]; then
+            cp "$appcast_src" "$appcast_asset"
+            release_assets+=("$appcast_asset")
           fi
           if [ -f "$app_src" ]; then
             cp "$app_src" "$app_asset"
@@ -682,7 +706,8 @@ jobs:
           notarized, and stapled \`Malibu-${tag}.dmg\`. Open the disk image, drag
           Malibu.app to Applications, and launch. First run drives install.sh
           onboarding with no terminal setup; Malibu monitors the launchd provider.
-          Publish \`latest.dmg\` with \`scripts/publish-malibu-latest-dmg.sh ${tag}\`.
+          Publish \`latest.dmg\` and \`appcast.xml\` with \`scripts/publish-malibu-latest-dmg.sh ${tag}\`.
+          Malibu checks \`https://download.malibu.tech/appcast.xml\` for in-app updates via Sparkle.
           EOF
           elif [ -f "phase3-binary/app/dist/Malibu-${tag}.pkg" ]; then
             cat >> release-notes.md <<EOF

--- a/phase3-binary/app/Malibu.entitlements
+++ b/phase3-binary/app/Malibu.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
 </plist>

--- a/phase3-binary/app/README.md
+++ b/phase3-binary/app/README.md
@@ -35,6 +35,8 @@ app/
         ├── KeychainStore.swift    # provider_token in Keychain, service tech.malibu.provider
         ├── ProviderIdentity.swift # App-track Ed25519 identity in Keychain
         └── AppLoginItem.swift     # SMAppService.mainApp wrapper
+        ├── MalibuUpdateConfiguration.swift  # Sparkle feed URL + Ed25519 public key
+        └── SparkleUpdaterController.swift     # SPUStandardUpdaterController wrapper
 ```
 
 ## Build
@@ -70,8 +72,8 @@ open build/Release/Malibu.app
 1. **`ControlFrame` is duplicated**, not shared. Extract the wire-format frames from `phase3-binary/Sources/macprovider-cli/ControlSocket.swift` into a new `MacProviderControl` library target so both CLI and app import one source of truth.
 2. **CLI-side handler semantics.** Frames + wire format are wired end-to-end (`feat(control-socket): add metrics/pause/resume/shutdown frames`), but the server-side handlers are stubs — `pause_ack`/`resume_ack` return `accepted:false, reason:"not_implemented"` and `metrics_response` returns zeros. Real earnings / uptime source + pause gating land in P1.
 3. **CLI-track config migration dialog.** If `~/.config/macprovider/config.yaml` exists without the App-track marker, the App routes to the SPEC-026 migration surface instead of overwriting it silently.
-5. **Sparkle** not wired up yet — separate P3 pass.
-6. **Signed release pipeline** — `release.yml` ships stapled `Malibu-{tag}.dmg` (primary) and optional `Malibu-{tag}.pkg`. Validate downloads with `scripts/verify-malibu-release-artifacts.sh`. Publish `latest.dmg` with `scripts/publish-malibu-latest-dmg.sh` after tagging.
+5. **Sparkle in-app updates** — wired via `SparkleUpdaterController` + `https://download.malibu.tech/appcast.xml`. Release CI signs appcast entries with `SPARKLE_EDDSA_PRIVATE_KEY`; publish with `scripts/publish-malibu-latest-dmg.sh` uploads `appcast.xml` beside `latest.dmg`. CLI self-update stays disabled under `--managed-by malibu-app`.
+6. **Signed release pipeline** — `release.yml` ships stapled `Malibu-{tag}.dmg` (primary) and optional `Malibu-{tag}.pkg`. Validate downloads with `scripts/verify-malibu-release-artifacts.sh`. Publish `latest.dmg` + `appcast.xml` with `scripts/publish-malibu-latest-dmg.sh` after tagging.
 
 ## Uninstall (Malibu + CLI)
 

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 @MainActor
 enum DashboardWindow {
-    static func make(agent: MalibuAgent) -> NSWindow {
-        let hosting = NSHostingController(rootView: DashboardView(agent: agent))
+    static func make(agent: MalibuAgent, sparkleUpdater: SparkleUpdaterController) -> NSWindow {
+        let hosting = NSHostingController(rootView: DashboardView(agent: agent, sparkleUpdater: sparkleUpdater))
         let window = NSWindow(contentViewController: hosting)
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.title = "Malibu"
@@ -17,6 +17,7 @@ enum DashboardWindow {
 
 private struct DashboardView: View {
     @ObservedObject var agent: MalibuAgent
+    @ObservedObject var sparkleUpdater: SparkleUpdaterController
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -77,12 +78,10 @@ private struct DashboardView: View {
                             .font(.caption)
                             .foregroundStyle(agent.snapshot.cliUpdateLastError == nil ? Color.secondary : Color.red)
                     }
-                    if AgentSnapshotPresenter.updateAvailable(agent.snapshot) {
-                        Button(agent.snapshot.cliUpdateInProgress ? "Updating…" : updateButtonTitle) {
-                            Task { await agent.updateCLINow() }
-                        }
-                        .disabled(agent.snapshot.cliUpdateInProgress)
+                    Button(sparkleUpdater.updateAvailable ? "Check for Updates… (available)" : "Check for Updates…") {
+                        sparkleUpdater.checkForUpdates(nil)
                     }
+                    .disabled(!sparkleUpdater.canCheckForUpdates)
                     MetricRow(title: "Requests", value: AgentSnapshotPresenter.requestsLine(agent.snapshot))
                     MetricRow(title: "Tokens", value: AgentSnapshotPresenter.tokenLine(agent.snapshot))
                     MetricRow(title: "Uptime", value: AgentSnapshotPresenter.uptimeLine(agent.snapshot))
@@ -121,13 +120,6 @@ private struct DashboardView: View {
 
     private var queueTone: MetricChip.Tone {
         (agent.snapshot.queueDepth ?? 0) > 0 ? .attention : .neutral
-    }
-
-    private var updateButtonTitle: String {
-        if let target = AgentSnapshotPresenter.updateTargetVersion(agent.snapshot) {
-            return "Update to v\(target)"
-        }
-        return "Update CLI"
     }
 
     private var thermalTone: MetricChip.Tone {

--- a/phase3-binary/app/Sources/Malibu/Info.plist
+++ b/phase3-binary/app/Sources/Malibu/Info.plist
@@ -31,5 +31,11 @@
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2026 Malibu AI, Inc.</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>https://download.malibu.tech/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>JkTDWnRJfOI3YIlpfJKvasWkxb0O1j/7ObGYiIA7big=</string>
 </dict>
 </plist>

--- a/phase3-binary/app/Sources/Malibu/MalibuApp.swift
+++ b/phase3-binary/app/Sources/Malibu/MalibuApp.swift
@@ -13,6 +13,7 @@ struct MalibuApp: App {
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private let agent = MalibuAgent()
+    private lazy var sparkleUpdater = SparkleUpdaterController { [unowned self] in self.agent }
     private var menuBar: MenuBarController!
     private var onboardingWindow: NSWindow?
     private var dashboardWindow: NSWindow?
@@ -22,7 +23,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // support can tell a Sparkle-only update from a get.streamvc.live-only one.
         logStartupProvenance()
 
-        menuBar = MenuBarController(agent: agent) { [weak self] action in
+        menuBar = MenuBarController(agent: agent, sparkleUpdater: sparkleUpdater) { [weak self] action in
             self?.handle(action)
         }
 
@@ -85,7 +86,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .openOnboarding: presentOnboarding()
         case .pause: Task { await agent.pause() }
         case .resume: Task { await agent.resume() }
-        case .updateCLI: Task { await agent.updateCLINow() }
+        case .checkForUpdates: sparkleUpdater.checkForUpdates(nil)
+        case .updateCLI: sparkleUpdater.checkForUpdates(nil)
         case .quitAndUninstall:
             guard uninstallTask == nil else { return }
             uninstallTask = Task { @MainActor [weak self] in
@@ -172,7 +174,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func presentDashboard() {
         if dashboardWindow == nil {
-            dashboardWindow = DashboardWindow.make(agent: agent)
+            dashboardWindow = DashboardWindow.make(agent: agent, sparkleUpdater: sparkleUpdater)
         }
         dashboardWindow?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/phase3-binary/app/Sources/Malibu/MenuBar/MenuBarController.swift
+++ b/phase3-binary/app/Sources/Malibu/MenuBar/MenuBarController.swift
@@ -8,12 +8,14 @@ final class MenuBarController {
         case openOnboarding
         case pause
         case resume
+        case checkForUpdates
         case updateCLI
         case quitAndUninstall
     }
 
     private let statusItem: NSStatusItem
     private let agent: MalibuAgent
+    private let sparkleUpdater: SparkleUpdaterController
     private let onAction: (Action) -> Void
     private var dismissalStore: UnclaimedBadgeDismissalStore
     private var cancellables: Set<AnyCancellable> = []
@@ -22,16 +24,19 @@ final class MenuBarController {
 
     init(
         agent: MalibuAgent,
+        sparkleUpdater: SparkleUpdaterController,
         dismissalStore: UnclaimedBadgeDismissalStore = UnclaimedBadgeDismissalStore(),
         onAction: @escaping (Action) -> Void
     ) {
         self.agent = agent
+        self.sparkleUpdater = sparkleUpdater
         self.dismissalStore = dismissalStore
         self.dismissedUnclaimedThreshold = dismissalStore.dismissedThreshold
         self.onAction = onAction
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         configureButton()
         subscribeToState()
+        subscribeToSparkle()
     }
 
     private func configureButton() {
@@ -85,10 +90,9 @@ final class MenuBarController {
         cliVersionItem.isHidden = true
         menu.addItem(cliVersionItem)
 
-        let updateCLIItem = action("Update CLI…", key: "") { self.onAction(.updateCLI) }
-        updateCLIItem.identifier = .updateCLIAction
-        updateCLIItem.isHidden = true
-        menu.addItem(updateCLIItem)
+        let updateItem = action("Check for Updates…", key: "") { self.onAction(.checkForUpdates) }
+        updateItem.identifier = .updateAction
+        menu.addItem(updateItem)
 
         let backlogItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
         backlogItem.identifier = .backlogRow
@@ -123,6 +127,16 @@ final class MenuBarController {
         (sender.representedObject as? () -> Void)?()
     }
 
+    private func subscribeToSparkle() {
+        sparkleUpdater.$updateAvailable
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.render(self.latestSnapshot)
+            }
+            .store(in: &cancellables)
+    }
+
     private func subscribeToState() {
         agent.$snapshot
             .receive(on: RunLoop.main)
@@ -137,7 +151,7 @@ final class MenuBarController {
         // snapshot data type. This lets locale/currency work touch one place.
         latestSnapshot = snapshot
         let badge = AgentSnapshotPresenter.unclaimedBadge(snapshot, dismissedThreshold: dismissedUnclaimedThreshold)
-        let updateBadge = AgentSnapshotPresenter.updateBadge(snapshot)
+        let updateBadge = sparkleUpdater.updateAvailable ? "↑" : nil
         let queueDot = (snapshot.queueDepth ?? 0) > 0 ? "•" : nil
         if let button = statusItem.button {
             button.title = [AgentSnapshotPresenter.short(snapshot), badge, updateBadge, queueDot].compactMap { $0 }.joined(separator: " ")
@@ -160,13 +174,13 @@ final class MenuBarController {
         } else {
             menu.item(withIdentifier: .cliVersionRow)?.isHidden = true
         }
-        if let updateItem = menu.item(withIdentifier: .updateCLIAction) {
-            let showUpdate = AgentSnapshotPresenter.updateAvailable(snapshot) && !snapshot.cliUpdateInProgress
-            updateItem.isHidden = !showUpdate
-            if let target = AgentSnapshotPresenter.updateTargetVersion(snapshot) {
-                updateItem.title = "Update CLI to v\(target)…"
+        if let updateItem = menu.item(withIdentifier: .updateAction) {
+            updateItem.isHidden = false
+            updateItem.isEnabled = sparkleUpdater.canCheckForUpdates
+            if sparkleUpdater.updateAvailable {
+                updateItem.title = "Check for Updates… (available)"
             } else {
-                updateItem.title = "Update CLI…"
+                updateItem.title = "Check for Updates…"
             }
         }
         if let backlog = AgentSnapshotPresenter.backlogLine(snapshot),
@@ -206,7 +220,7 @@ private extension NSUserInterfaceItemIdentifier {
     static let statusRow = NSUserInterfaceItemIdentifier("malibu.menubar.status")
     static let earningsRow = NSUserInterfaceItemIdentifier("malibu.menubar.earnings")
     static let cliVersionRow = NSUserInterfaceItemIdentifier("malibu.menubar.cliVersion")
-    static let updateCLIAction = NSUserInterfaceItemIdentifier("malibu.menubar.updateCLI")
+    static let updateAction = NSUserInterfaceItemIdentifier("malibu.menubar.update")
     static let backlogRow = NSUserInterfaceItemIdentifier("malibu.menubar.backlog")
     static let dismissBacklogBadge = NSUserInterfaceItemIdentifier("malibu.menubar.dismissBacklogBadge")
 }

--- a/phase3-binary/app/Sources/Malibu/System/MalibuUpdateConfiguration.swift
+++ b/phase3-binary/app/Sources/Malibu/System/MalibuUpdateConfiguration.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Sparkle feed + Ed25519 public key for Malibu.app whole-bundle updates (SPEC-025 §3.3).
+enum MalibuUpdateConfiguration {
+    /// Immutable versioned DMG on the download bucket; `latest.dmg` redirects here for humans.
+    static let versionedDownloadBaseURL = URL(string: "https://download.malibu.tech")!
+
+    /// Sparkle appcast served beside `latest.dmg` on the same bucket.
+    static let appcastURL = versionedDownloadBaseURL.appendingPathComponent("appcast.xml")
+
+    /// Base64-encoded Ed25519 public key (32 bytes) for `SUPublicEDKey`.
+    /// Private key lives in GitHub Actions secret `SPARKLE_EDDSA_PRIVATE_KEY` (base64 seed).
+    /// Regenerate with `scripts/generate-sparkle-signing-key.sh` and rotate both together.
+    static let publicEdKeyBase64 = "JkTDWnRJfOI3YIlpfJKvasWkxb0O1j/7ObGYiIA7big="
+
+    static func releaseDownloadURL(tag: String) -> URL {
+        versionedDownloadBaseURL.appendingPathComponent("Malibu-\(tag).dmg")
+    }
+
+    static func releaseNotesURL(tag: String, repository: String = "Augustas11/macprovider") -> URL {
+        URL(string: "https://github.com/\(repository)/releases/tag/\(tag)")!
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/System/SparkleUpdaterController.swift
+++ b/phase3-binary/app/Sources/Malibu/System/SparkleUpdaterController.swift
@@ -1,0 +1,71 @@
+import AppKit
+import Combine
+import Sparkle
+
+/// Owns Sparkle whole-bundle updates for Malibu.app (SPEC-025 §3.3, §12).
+@MainActor
+final class SparkleUpdaterController: NSObject, ObservableObject {
+    @Published private(set) var updateAvailable = false
+
+    private let agentProvider: () -> MalibuAgent?
+    private lazy var standardController: SPUStandardUpdaterController = {
+        let controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: self,
+            userDriverDelegate: nil
+        )
+        controller.updater.automaticallyChecksForUpdates = true
+        controller.updater.updateCheckInterval = 86_400
+        return controller
+    }()
+
+    init(agentProvider: @escaping () -> MalibuAgent?) {
+        self.agentProvider = agentProvider
+        super.init()
+        _ = standardController
+    }
+
+    var canCheckForUpdates: Bool {
+        standardController.updater.canCheckForUpdates
+    }
+
+    func checkForUpdates(_ sender: Any?) {
+        standardController.checkForUpdates(sender)
+    }
+
+    private func shutdownProviderBeforeUpdate() async {
+        await agentProvider()?.shutdown(gracefulSeconds: 15)
+    }
+}
+
+extension SparkleUpdaterController: SPUUpdaterDelegate {
+    nonisolated func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        Task { @MainActor in
+            self.updateAvailable = true
+        }
+    }
+
+    nonisolated func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+        Task { @MainActor in
+            self.updateAvailable = false
+        }
+    }
+
+    nonisolated func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+        Task { @MainActor in
+            await self.shutdownProviderBeforeUpdate()
+        }
+    }
+
+    nonisolated func updater(
+        _ updater: SPUUpdater,
+        willInstallUpdateOnQuit item: SUAppcastItem,
+        immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
+    ) -> Bool {
+        Task { @MainActor in
+            await self.shutdownProviderBeforeUpdate()
+            immediateInstallHandler()
+        }
+        return true
+    }
+}

--- a/phase3-binary/app/Tests/MalibuTests/MalibuUpdateConfigurationTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/MalibuUpdateConfigurationTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Malibu
+
+final class MalibuUpdateConfigurationTests: XCTestCase {
+    func testAppcastURLMatchesInfoPlistFeed() {
+        XCTAssertEqual(
+            MalibuUpdateConfiguration.appcastURL.absoluteString,
+            "https://download.malibu.tech/appcast.xml"
+        )
+    }
+
+    func testPublicEdKeyMatchesInfoPlist() {
+        XCTAssertEqual(
+            MalibuUpdateConfiguration.publicEdKeyBase64,
+            "JkTDWnRJfOI3YIlpfJKvasWkxb0O1j/7ObGYiIA7big="
+        )
+        XCTAssertFalse(MalibuUpdateConfiguration.publicEdKeyBase64.isEmpty)
+    }
+
+    func testVersionedDownloadURLUsesTagSuffix() {
+        let url = MalibuUpdateConfiguration.releaseDownloadURL(tag: "v1.8.18")
+        XCTAssertEqual(url.absoluteString, "https://download.malibu.tech/Malibu-v1.8.18.dmg")
+    }
+
+    func testReleaseNotesURLPointsAtGitHubTag() {
+        let url = MalibuUpdateConfiguration.releaseNotesURL(tag: "v1.8.18")
+        XCTAssertEqual(
+            url.absoluteString,
+            "https://github.com/Augustas11/macprovider/releases/tag/v1.8.18"
+        )
+    }
+}

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -17,6 +17,11 @@ options:
   developmentLanguage: en
   createIntermediateGroups: true
 
+packages:
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    from: 2.6.4
+
 settings:
   base:
     SWIFT_VERSION: "5.9"
@@ -52,6 +57,9 @@ targets:
         NSHumanReadableCopyright: "Copyright © 2026 Malibu AI, Inc."
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
+        SUFeedURL: https://download.malibu.tech/appcast.xml
+        SUPublicEDKey: JkTDWnRJfOI3YIlpfJKvasWkxb0O1j/7ObGYiIA7big=
+        SUEnableAutomaticChecks: true
     settings:
       base:
         PRODUCT_NAME: Malibu
@@ -64,7 +72,9 @@ targets:
         basedOnDependencyAnalysis: false
         script: |
           install -m 755 "${SRCROOT}/../dist/install.sh" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Resources/install.sh"
-    dependencies: []
+    dependencies:
+      - package: Sparkle
+        product: Sparkle
 
   # AUDIT R1 ARCHITECT A8 fix: unit-test the audit-critical app-side surfaces
   # (codec parity vs CLI, URL-scheme nonce validation, snapshot presenter,

--- a/scripts/generate-malibu-appcast.sh
+++ b/scripts/generate-malibu-appcast.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Build Sparkle appcast.xml for a signed Malibu-{tag}.dmg release asset.
+#
+# Requires:
+#   - Malibu-{tag}.dmg at phase3-binary/app/dist/ (or pass DMG=...)
+#   - SPARKLE_EDDSA_PRIVATE_KEY (base64 Ed25519 seed) or SPARKLE_PRIVATE_KEY_FILE
+#   - curl + tar (Sparkle release tools downloaded on demand)
+#
+# Usage:
+#   SPARKLE_EDDSA_PRIVATE_KEY=... bash scripts/generate-malibu-appcast.sh v1.8.18
+#   DMG=path/to/Malibu-v1.8.18.dmg bash scripts/generate-malibu-appcast.sh v1.8.18
+
+set -euo pipefail
+
+tag="${1:-}"
+[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "usage: $0 vX.Y.Z" >&2
+  exit 2
+}
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+dmg="${DMG:-$repo_root/phase3-binary/app/dist/Malibu-${tag}.dmg}"
+[[ -f "$dmg" ]] || {
+  echo "missing dmg: $dmg" >&2
+  exit 1
+}
+
+sparkle_version="${SPARKLE_VERSION:-2.6.4}"
+tools_dir="${SPARKLE_TOOLS_DIR:-$repo_root/.cache/sparkle-${sparkle_version}}"
+if [[ ! -x "$tools_dir/bin/generate_appcast" ]]; then
+  mkdir -p "$(dirname "$tools_dir")"
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/sparkle-tools.XXXXXX")"
+  curl -fsSL -o "$tmp/sparkle.tar.xz" \
+    "https://github.com/sparkle-project/Sparkle/releases/download/${sparkle_version}/Sparkle-${sparkle_version}.tar.xz"
+  rm -rf "$tools_dir"
+  mkdir -p "$tools_dir"
+  tar -xJf "$tmp/sparkle.tar.xz" -C "$tools_dir" --strip-components=0
+  rm -rf "$tmp"
+fi
+
+key_file=""
+cleanup_key() {
+  [[ -n "$key_file" && -f "$key_file" ]] && rm -f "$key_file"
+}
+trap cleanup_key EXIT
+
+if [[ -n "${SPARKLE_PRIVATE_KEY_FILE:-}" ]]; then
+  key_file="$SPARKLE_PRIVATE_KEY_FILE"
+elif [[ -n "${SPARKLE_EDDSA_PRIVATE_KEY:-}" ]]; then
+  key_file="$(mktemp "${TMPDIR:-/tmp}/sparkle-ed-key.XXXXXX")"
+  printf '%s' "$SPARKLE_EDDSA_PRIVATE_KEY" > "$key_file"
+else
+  echo "SPARKLE_EDDSA_PRIVATE_KEY or SPARKLE_PRIVATE_KEY_FILE is required" >&2
+  exit 1
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/malibu-appcast.XXXXXX")"
+cleanup_work() { rm -rf "$work"; }
+trap cleanup_work EXIT
+trap cleanup_key EXIT
+
+cp "$dmg" "$work/Malibu-${tag}.dmg"
+release_notes="$work/release-notes.html"
+cat > "$release_notes" <<EOF
+<html><body><p>Malibu ${tag} — see the GitHub release for notes.</p></body></html>
+EOF
+
+"$tools_dir/bin/generate_appcast" \
+  --ed-key-file "$key_file" \
+  --download-url-prefix "https://download.malibu.tech/" \
+  "$work"
+
+out="$repo_root/phase3-binary/app/dist/appcast.xml"
+cp "$work/appcast.xml" "$out"
+echo "wrote $out"

--- a/scripts/generate-sparkle-signing-key.sh
+++ b/scripts/generate-sparkle-signing-key.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Generate a Sparkle Ed25519 signing keypair for Malibu.app appcast signing.
+#
+# Commits only the public key into MalibuUpdateConfiguration.swift (operator
+# action). Store the printed PRIVATE_B64 in GitHub secret SPARKLE_EDDSA_PRIVATE_KEY.
+#
+# Usage:
+#   bash scripts/generate-sparkle-signing-key.sh
+
+set -euo pipefail
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/malibu-sparkle-key.XXXXXX")"
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+openssl genpkey -algorithm ED25519 -out "$work/private.pem"
+openssl pkey -in "$work/private.pem" -pubout -outform DER -out "$work/public.der"
+
+read -r PUBLIC_B64 PRIVATE_B64 <<EOF
+$(python3 - "$work/private.pem" "$work/public.der" <<'PY'
+import base64, pathlib, re, sys
+priv_pem = pathlib.Path(sys.argv[1]).read_text()
+pub_der = pathlib.Path(sys.argv[2]).read_bytes()
+priv_raw = base64.b64decode(''.join(re.findall(
+    r'-----BEGIN PRIVATE KEY-----(.*?)-----END PRIVATE KEY-----',
+    priv_pem,
+    re.S,
+)[0].split()))
+seed = priv_raw[-32:]
+public = pub_der[-32:]
+print(base64.b64encode(public).decode())
+print(base64.b64encode(seed).decode())
+PY
+)
+EOF
+
+cat <<EOF
+Sparkle signing keypair generated.
+
+1. Update phase3-binary/app/Sources/Malibu/System/MalibuUpdateConfiguration.swift:
+     publicEdKeyBase64 = "$PUBLIC_B64"
+
+2. Set GitHub Actions secret SPARKLE_EDDSA_PRIVATE_KEY to:
+     $PRIVATE_B64
+
+3. Re-sign appcast entries after rotation with scripts/generate-malibu-appcast.sh
+
+Never commit the private key to git.
+EOF

--- a/scripts/publish-malibu-latest-dmg.sh
+++ b/scripts/publish-malibu-latest-dmg.sh
@@ -35,6 +35,7 @@ trap cleanup EXIT
 gh release download "$tag" \
   --repo "$repo" \
   --pattern "$dmg_name" \
+  --pattern "appcast.xml" \
   --dir "$work" \
   --clobber
 
@@ -68,6 +69,14 @@ fi
 aws s3 cp "$asset" "s3://${MALIBU_DOWNLOAD_BUCKET}/${versioned_key}" "${aws_args[@]}"
 aws s3 cp "$asset" "s3://${MALIBU_DOWNLOAD_BUCKET}/${latest_key}" "${aws_args[@]}"
 aws s3 cp "$work/${dmg_name}.sha256" "s3://${MALIBU_DOWNLOAD_BUCKET}/${dmg_name}.sha256" "${aws_args[@]}"
+
+appcast="$work/appcast.xml"
+if [[ -f "$appcast" ]]; then
+  aws s3 cp "$appcast" "s3://${MALIBU_DOWNLOAD_BUCKET}/appcast.xml" "${aws_args[@]}"
+  printf '[publish-malibu-latest-dmg] ok: appcast.xml published\n'
+else
+  printf '[publish-malibu-latest-dmg] WARN: appcast.xml missing from release %s — Sparkle feed unchanged\n' "$tag" >&2
+fi
 
 printf '[publish-malibu-latest-dmg] ok: s3://%s/%s and latest.dmg (sha256=%s)\n' \
   "$MALIBU_DOWNLOAD_BUCKET" "$versioned_key" "$sha256"


### PR DESCRIPTION
## Summary
- Integrate Sparkle 2.6.4 for whole-bundle Malibu.app updates via `https://download.malibu.tech/appcast.xml`.
- Replace CLI self-update UI with Sparkle "Check for Updates…" in the menu bar and dashboard; shut down the launchd provider before install.
- Add release tooling: Ed25519 key helper, appcast generator, CI appcast signing (`SPARKLE_EDDSA_PRIVATE_KEY`), and publish script uploads `appcast.xml` beside `latest.dmg`.

## Test plan
- [x] `xcodegen generate && xcodebuild test -project Malibu.xcodeproj -scheme Malibu` (120 tests)
- [ ] Merge PR, tag **v1.8.18**, confirm release workflow attaches signed `appcast.xml`
- [ ] Run `scripts/publish-malibu-latest-dmg.sh v1.8.18` to publish `latest.dmg` + `appcast.xml`
- [ ] On a Mac with Malibu installed, use **Check for Updates…** and confirm Sparkle finds the feed


Made with [Cursor](https://cursor.com)