### PR TITLE
Release v1.8.18: dashboard layout fix + Sparkle go-live

### DIFF
--- a/beta/MALIBU_WORKSTREAM.md
+++ b/beta/MALIBU_WORKSTREAM.md
@@ -1,0 +1,77 @@
+# Malibu + provider workstream runbook
+
+**Purpose:** Track *session* priority slices (P1, P2, …) without colliding with
+SPEC-025 rollout phases (P0–P6) or unrelated spec numbering elsewhere in the
+repo.
+
+**How to use**
+
+- Add rows under **Queued** with a one-line scope + exit criterion.
+- When work starts, move to **In flight** with PR link.
+- When merged/shipped, move to **Done** with release tag or commit.
+- Decisions that change product direction still go in `beta/DECISION_CRITERIA.md`;
+  this file is the *what's next* board only.
+
+**Naming:** `P1`, `P2` here mean *next/next-next session priorities*, not
+`specs/SPEC-025-native-mac-app.md` §11 phases.
+
+---
+
+## In flight
+
+| ID | Scope | Exit criterion | Notes |
+|---|---|---|---|
+| **R1** | **Cut v1.8.18** — Sparkle live + dashboard layout fix | Tag ships signed `Malibu-v1.8.18.dmg` + `appcast.xml`; `publish-malibu-latest-dmg.sh` pushes both | PR in progress |
+
+---
+
+## Queued (priority order)
+
+| ID | Scope | Exit criterion | Area |
+|---|---|---|---|
+| **P2a** | **Harden autotune `--apply`** | `recommend` does not fail entirely when an unrelated catalog row has a bad HF cache (e.g. Llama hash mismatch); scope benchmarks to `--candidate-models` or skip rows that fail artifact verification before Stage 1 | CLI / autotune |
+| **P2b** | **Consolidate static feeds into buyer API** *(future)* | Live autotune catalog + demand-rank served from coordinator buyer mux (like `/v1/rate-card`); drop Pearl nginx `/opt/macprovider/static/` copy step; keep Ed25519 signatures + baked fallback | Coordinator / ops |
+| **P3** | Dashboard log tail wiring (SPEC-026 Step 3 Item 6) | `LogTailView` shows live provider stderr/out tail on dashboard when lines exist (hidden when empty as of v1.8.18) | Malibu UI |
+
+---
+
+## Done
+
+| ID | Shipped | PR / release | Notes |
+|---|---|---|---|
+| Pearl static feeds | 2026-07-07 | #454 | Baked catalog sync + nginx EACCES hardening |
+| Malibu P1 diagnostics | 2026-07-07 | #455 | Provider log tail + stale-catalog UX on onboarding |
+| Sparkle in-app updates | 2026-07-07 | #456 → `main` `47d838d` | Sparkle code on main; goes live with R1 |
+| CLI update UI in dashboard | 2026-07-06 | v1.8.16 (`c73d4fe`) | Added CLI version + update rows; overflow fixed in v1.8.18 |
+
+---
+
+## Release checklist (R1 — v1.8.18)
+
+1. [x] Fix dashboard right-panel overflow (scroll + hide empty log tail).
+2. [x] Bump `MARKETING_VERSION` / `CoordinatorClient.binaryVersion` → `1.8.18`.
+3. [ ] Tag `v1.8.18`; confirm CI release attaches `appcast.xml` (`SPARKLE_EDDSA_PRIVATE_KEY` set ✓).
+4. [ ] `bash scripts/publish-malibu-latest-dmg.sh v1.8.18` → `latest.dmg` + `appcast.xml` on `download.malibu.tech`.
+5. [ ] Smoke: **Check for Updates…** on a test Mac finds feed.
+
+---
+
+## FAQ
+
+### Can I update Malibu before v1.8.18 ships?
+
+| Path | Works today? | What it updates |
+|---|---|---|
+| **CLI update button** (`Update to v1.8.16`) | Yes on builds ≤ v1.8.16 that still ship the old dashboard | Bundled `macprovider-cli` via catalog/`install.sh` — **not** the `.app` shell |
+| **Sparkle** (`Check for Updates…`) | After R1 | Whole `Malibu.app` bundle via `appcast.xml` |
+
+After v1.8.18: Sparkle owns app updates; CLI self-update stays off under `--managed-by malibu-app`.
+
+### SPEC-025 phases vs this file
+
+| SPEC-025 §11 | Status |
+|---|---|
+| P2 signing / `.dmg` | Done (release pipeline) |
+| P3 Sparkle | Live after R1 |
+| P4 landing page | Not started |
+| P5+ WalletConnect, Homebrew | Backlog |

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.16"
+    static let binaryVersion = "1.8.18"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1644,10 +1644,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.16")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.16")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.16")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.16")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.18")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.18")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.18")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.18")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -8,7 +8,7 @@ enum DashboardWindow {
         let window = NSWindow(contentViewController: hosting)
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.title = "Malibu"
-        window.setContentSize(NSSize(width: 780, height: 520))
+        window.setContentSize(NSSize(width: 780, height: 560))
         window.center()
         window.isReleasedWhenClosed = false
         return window
@@ -60,7 +60,7 @@ private struct DashboardView: View {
                         .disabled(true)
                 }
 
-                panel {
+                statsPanel {
                     MetricRow(title: "Running model", value: AgentSnapshotPresenter.modelLine(agent.snapshot))
                     if let path = agent.snapshot.weightsPath {
                         DisclosureGroup("Weights path") {
@@ -94,10 +94,12 @@ private struct DashboardView: View {
                     .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            .frame(minHeight: 260)
+            .frame(minHeight: 280)
 
-            LogTailView(lines: agent.logLines)
-                .frame(minHeight: 170)
+            if !agent.logLines.isEmpty {
+                LogTailView(lines: agent.logLines)
+                    .frame(minHeight: 120, maxHeight: 180)
+            }
             Spacer(minLength: 0)
         }
         .padding(20)
@@ -111,11 +113,29 @@ private struct DashboardView: View {
         }
         .frame(maxWidth: .infinity, minHeight: 250, alignment: .topLeading)
         .padding(16)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray.opacity(0.08)))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .strokeBorder(MalibuBrand.coral.opacity(0.25), lineWidth: 1)
-        )
+        .background(panelBackground)
+    }
+
+    @ViewBuilder
+    private func statsPanel<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                content()
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .frame(maxWidth: .infinity, minHeight: 280, alignment: .topLeading)
+        .padding(16)
+        .background(panelBackground)
+    }
+
+    private var panelBackground: some View {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(Color.gray.opacity(0.08))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(MalibuBrand.coral.opacity(0.25), lineWidth: 1)
+            )
     }
 
     private var queueTone: MetricChip.Tone {

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -27,8 +27,8 @@ settings:
     SWIFT_VERSION: "5.9"
     ENABLE_HARDENED_RUNTIME: YES
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "1.8.16"
-    CURRENT_PROJECT_VERSION: "16"
+    MARKETING_VERSION: "1.8.18"
+    CURRENT_PROJECT_VERSION: "18"
     OTHER_SWIFT_FLAGS: "-strict-concurrency=complete"
 
 targets:


### PR DESCRIPTION
## Summary
- Fix dashboard stats panel overflow: scroll the right column, hide empty `LogTailView` on steady-state dashboard, slightly taller default window.
- Bump `CoordinatorClient.binaryVersion` and Malibu `MARKETING_VERSION` to **1.8.18** for the Sparkle appcast release (#456).
- Add `beta/MALIBU_WORKSTREAM.md` session priority runbook.

## Test plan
- [x] `xcodebuild test -scheme Malibu` (120 tests)
- [ ] Merge → tag `v1.8.18` → release workflow ships DMG + `appcast.xml`
- [ ] `scripts/publish-malibu-latest-dmg.sh v1.8.18`
- [ ] Smoke **Check for Updates…** on test Mac


Made with [Cursor](https://cursor.com)