### PR TITLE
Harden autotune recommend against unrelated artifact failures (P2a)

### DIFF
--- a/beta/MALIBU_WORKSTREAM.md
+++ b/beta/MALIBU_WORKSTREAM.md
@@ -21,7 +21,7 @@ repo.
 
 | ID | Scope | Exit criterion | Notes |
 |---|---|---|---|
-| **R1** | **Cut v1.8.18** — Sparkle live + dashboard layout fix | Tag ships signed `Malibu-v1.8.18.dmg` + `appcast.xml`; `publish-malibu-latest-dmg.sh` pushes both | PR in progress |
+| **P2a** | **Harden autotune `--apply`** | `recommend` does not fail entirely when an unrelated catalog row has a bad HF cache; `--candidate-models` scopes recommend probes | PR in progress |
 
 ---
 
@@ -29,7 +29,6 @@ repo.
 
 | ID | Scope | Exit criterion | Area |
 |---|---|---|---|
-| **P2a** | **Harden autotune `--apply`** | `recommend` does not fail entirely when an unrelated catalog row has a bad HF cache (e.g. Llama hash mismatch); scope benchmarks to `--candidate-models` or skip rows that fail artifact verification before Stage 1 | CLI / autotune |
 | **P2b** | **Consolidate static feeds into buyer API** *(future)* | Live autotune catalog + demand-rank served from coordinator buyer mux (like `/v1/rate-card`); drop Pearl nginx `/opt/macprovider/static/` copy step; keep Ed25519 signatures + baked fallback | Coordinator / ops |
 | **P3** | Dashboard log tail wiring (SPEC-026 Step 3 Item 6) | `LogTailView` shows live provider stderr/out tail on dashboard when lines exist (hidden when empty as of v1.8.18) | Malibu UI |
 
@@ -39,39 +38,28 @@ repo.
 
 | ID | Shipped | PR / release | Notes |
 |---|---|---|---|
+| **R1** | 2026-07-07 | v1.8.18 (#457) | Sparkle live + dashboard stats clipping fix |
 | Pearl static feeds | 2026-07-07 | #454 | Baked catalog sync + nginx EACCES hardening |
 | Malibu P1 diagnostics | 2026-07-07 | #455 | Provider log tail + stale-catalog UX on onboarding |
-| Sparkle in-app updates | 2026-07-07 | #456 → `main` `47d838d` | Sparkle code on main; goes live with R1 |
-| CLI update UI in dashboard | 2026-07-06 | v1.8.16 (`c73d4fe`) | Added CLI version + update rows; overflow fixed in v1.8.18 |
-
----
-
-## Release checklist (R1 — v1.8.18)
-
-1. [x] Fix dashboard right-panel overflow (scroll + hide empty log tail).
-2. [x] Bump `MARKETING_VERSION` / `CoordinatorClient.binaryVersion` → `1.8.18`.
-3. [ ] Tag `v1.8.18`; confirm CI release attaches `appcast.xml` (`SPARKLE_EDDSA_PRIVATE_KEY` set ✓).
-4. [ ] `bash scripts/publish-malibu-latest-dmg.sh v1.8.18` → `latest.dmg` + `appcast.xml` on `download.malibu.tech`.
-5. [ ] Smoke: **Check for Updates…** on a test Mac finds feed.
+| Sparkle in-app updates | 2026-07-07 | #456 | Sparkle in Malibu.app |
+| CLI update UI in dashboard | 2026-07-06 | v1.8.16 | Overflow fixed in v1.8.18 |
 
 ---
 
 ## FAQ
 
-### Can I update Malibu before v1.8.18 ships?
+### Update paths (post v1.8.18)
 
-| Path | Works today? | What it updates |
-|---|---|---|
-| **CLI update button** (`Update to v1.8.16`) | Yes on builds ≤ v1.8.16 that still ship the old dashboard | Bundled `macprovider-cli` via catalog/`install.sh` — **not** the `.app` shell |
-| **Sparkle** (`Check for Updates…`) | After R1 | Whole `Malibu.app` bundle via `appcast.xml` |
-
-After v1.8.18: Sparkle owns app updates; CLI self-update stays off under `--managed-by malibu-app`.
+| Path | What it updates |
+|---|---|
+| **Sparkle** (`Check for Updates…`) | Whole `Malibu.app` bundle via `appcast.xml` |
+| **CLI self-update** | Disabled under `--managed-by malibu-app` |
 
 ### SPEC-025 phases vs this file
 
 | SPEC-025 §11 | Status |
 |---|---|
-| P2 signing / `.dmg` | Done (release pipeline) |
-| P3 Sparkle | Live after R1 |
+| P2 signing / `.dmg` | Done |
+| P3 Sparkle | Live (v1.8.18) |
 | P4 landing page | Not started |
 | P5+ WalletConnect, Homebrew | Backlog |

--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -510,6 +510,17 @@ struct AutotuneCommand: AsyncParsableCommand {
         return AutotunePlan(candidates: filtered.map(\.modelID), source: .defaultList, warning: nil)
     }
 
+    /// When `--candidate-models` is set, `--recommend` probes only catalog rows
+    /// whose HuggingFace `model_id` appears in the operator list.
+    private func recommendCandidateModelFilter() throws -> Set<String>? {
+        guard let candidateModels,
+              !candidateModels.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+        return Set(try Self.parseCSVStrict(candidateModels, flag: "--candidate-models"))
+    }
+
     static let specVersion = "SPEC-013 v0.3"
 
     static func candidatesBySize(for plan: AutotunePlan) -> [String]? {
@@ -709,6 +720,7 @@ struct AutotuneCommand: AsyncParsableCommand {
         let identity = HMACIdentity.derive(secret: secret, fingerprint: fingerprint, providerID: resolvedConfig?.providerID)
         let hardware = AutotuneRecommendHardware(fingerprint: fingerprint, hmacIdentity: identity)
         let catalogSHA = AutotuneStaticInputs.candidateCatalogSHA256(bytes: catalog.selectedBytes)
+        let candidateModelFilter = try recommendCandidateModelFilter()
         let now = Date()
         var warnings = Set<AutotuneRecommendWarning>()
         warnings.formUnion(demand.warnings)
@@ -732,7 +744,8 @@ struct AutotuneCommand: AsyncParsableCommand {
             gateTTFTMS: gateTTFTMS,
             replicates: stage1Replicates,
             port: port,
-            interruptFlag: interruptFlag
+            interruptFlag: interruptFlag,
+            candidateModelIDs: candidateModelFilter
         )
         if interruptFlag.isSet() {
             FileHandle.standardError.write(Data("autotune --recommend interrupted; exiting after subtree cleanup\n".utf8))

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -1705,7 +1705,8 @@ struct CachedModelArtifactResolver {
 ///
 /// `benchmarks` contains only feasible probes (rows admitted into eligibility);
 /// `diagnostics` contains a modelKey -> reason string for every candidate that
-/// returned .infeasible OR was skipped by runtime-status/RAM/tier gates. This is
+/// returned .infeasible OR was skipped by runtime-status/RAM/tier gates OR failed
+/// artifact verification before Stage 1. This is
 /// what the SPEC-023 caller emits to stderr + persists into
 /// last-recommendation.json so the user can see WHY no eligible paid model was
 /// found. Prior to v1.7.5 the .infeasible(reason:nErr:) string was silently
@@ -1731,7 +1732,8 @@ struct AutotuneRecommendationBenchmarker {
         gateTTFTMS: Int,
         replicates: Int,
         port: Int,
-        interruptFlag: AutotuneInterruptFlag? = nil
+        interruptFlag: AutotuneInterruptFlag? = nil,
+        candidateModelIDs: Set<String>? = nil
     ) async throws -> BenchmarkOutcomes {
         var results: [String: CandidateBenchmark] = [:]
         var diagnostics: [String: String] = [:]
@@ -1745,6 +1747,9 @@ struct AutotuneRecommendationBenchmarker {
                 break
             }
             guard let row = request.candidateCatalog.rows[modelKey] else {
+                continue
+            }
+            if let candidateModelIDs, !candidateModelIDs.contains(row.modelID) {
                 continue
             }
             if row.runtimeStatus == "blocked" {
@@ -1800,7 +1805,11 @@ struct AutotuneRecommendationBenchmarker {
                 case .infeasible(let reason, let nErr):
                     diagnostics[modelKey] = "\(reason) (n_err=\(nErr))"
                 }
-            } catch {
+            } catch let error as AutotuneRecommendError {
+                if case .invalidArtifact(let message) = error {
+                    diagnostics[modelKey] = message
+                    continue
+                }
                 throw error
             }
         }

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -1175,7 +1175,7 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertThrowsError(try CachedModelArtifactResolver(hubRoot: hub).verifiedExistingArtifact(for: mismatch))
     }
 
-    func testBenchmarkingFailsClosedOnArtifactHashMismatch() async throws {
+    func testBenchmarksDiagnosesRowsSkippedByArtifactHashMismatch() async throws {
         var request = try makeRequest()
         let modelKey = "qwen3-coder-30b-a3b-instruct"
         let row = try XCTUnwrap(request.candidateCatalog.rows[modelKey])
@@ -1193,18 +1193,133 @@ final class AutotuneRecommendTests: XCTestCase {
             runnerFactory: { throw AutotuneRecommendError.invalidStaticJSON("runner should not start") }
         )
 
-        do {
-            _ = try await benchmarker.benchmarks(
-                request: request,
-                targetContext: 4_000,
-                gateTTFTMS: 3_000,
-                replicates: 1,
-                port: 18080
-            )
-            XCTFail("artifact mismatch must fail closed")
-        } catch AutotuneRecommendError.invalidArtifact {
-            // expected
-        }
+        let outcomes = try await benchmarker.benchmarks(
+            request: request,
+            targetContext: 4_000,
+            gateTTFTMS: 3_000,
+            replicates: 1,
+            port: 18080
+        )
+
+        XCTAssertNil(outcomes.benchmarks[modelKey])
+        let diagnostic = try XCTUnwrap(outcomes.diagnostics[modelKey])
+        XCTAssertTrue(diagnostic.contains("hash mismatch"))
+    }
+
+    func testBenchmarkRecommendContinuesWhenUnrelatedRowHasArtifactMismatch() async throws {
+        let badKey = "meta-llama/llama-3.1-8b-instruct"
+        let goodKey = "qwen3-coder-30b-a3b-instruct"
+        var request = try makeRequest(modelKey: goodKey)
+        let badRow = try XCTUnwrap(
+            try AutotuneStaticInputs.decodeCandidateCatalog(
+                Data(AutotuneStaticInputs.bakedCandidateCatalogJSON.utf8)
+            ).rows[badKey]
+        )
+        request.candidateCatalog.rows[badKey] = badRow
+        request.demandRank.rows[badKey] = try XCTUnwrap(
+            try AutotuneStaticInputs.decodeDemandRank(
+                Data(AutotuneStaticInputs.bakedDemandRankJSON.utf8)
+            ).rows[badKey]
+        )
+        request.rateCard.rows[badKey] = try XCTUnwrap(
+            try AutotuneStaticInputs.decodeRateCard(
+                Data(AutotuneStaticInputs.bakedRateCardJSON.utf8)
+            ).rows[badKey]
+        )
+        request.benchmarks = [:]
+
+        let hub = try tempDir()
+        let badRevision = try XCTUnwrap(badRow.modelRevision)
+        let badSnapshot = hub
+            .appendingPathComponent("models--mlx-community--Meta-Llama-3.1-8B-Instruct-4bit", isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(badRevision, isDirectory: true)
+        try FileManager.default.createDirectory(at: badSnapshot, withIntermediateDirectories: true)
+        try Data("stale-llama".utf8).write(to: badSnapshot.appendingPathComponent("weights.bin"))
+
+        let goodRow = try XCTUnwrap(request.candidateCatalog.rows[goodKey])
+        let goodRevision = try XCTUnwrap(goodRow.modelRevision)
+        let goodSnapshot = hub
+            .appendingPathComponent("models--mlx-community--Qwen3-Coder-30B-A3B-Instruct-4bit", isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(goodRevision, isDirectory: true)
+        try FileManager.default.createDirectory(at: goodSnapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: goodSnapshot.appendingPathComponent("weights.bin"))
+        request.candidateCatalog.rows[goodKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: goodSnapshot)
+        let goodArtifactPath = goodSnapshot.path
+
+        let prober = RecordingStage1Prober(results: [
+            goodArtifactPath: .feasible(medianTPS: 88, p95TTFTMS: 900)
+        ])
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: CachedModelArtifactResolver(hubRoot: hub),
+            runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
+            prober: prober,
+            safetySampler: StaticProbeSafetySampler(),
+            clock: { Self.date("2026-07-02T00:00:00Z") }
+        )
+
+        let outcomes = try await benchmarker.benchmarks(
+            request: request,
+            targetContext: 4_000,
+            gateTTFTMS: 3_000,
+            replicates: 1,
+            port: 18080
+        )
+
+        XCTAssertNil(outcomes.benchmarks[badKey])
+        XCTAssertTrue(try XCTUnwrap(outcomes.diagnostics[badKey]).contains("hash mismatch"))
+        XCTAssertNotNil(outcomes.benchmarks[goodKey])
+        XCTAssertEqual(prober.probedModels, [goodArtifactPath])
+    }
+
+    func testBenchmarksScopesToCandidateModelsWhenFilterProvided() async throws {
+        let goodKey = "qwen3-coder-30b-a3b-instruct"
+        let skippedKey = "meta-llama/llama-3.1-8b-instruct"
+        var request = try makeRequest(modelKey: goodKey)
+        let skippedRow = try XCTUnwrap(
+            try AutotuneStaticInputs.decodeCandidateCatalog(
+                Data(AutotuneStaticInputs.bakedCandidateCatalogJSON.utf8)
+            ).rows[skippedKey]
+        )
+        request.candidateCatalog.rows[skippedKey] = skippedRow
+        request.benchmarks = [:]
+
+        let goodRow = try XCTUnwrap(request.candidateCatalog.rows[goodKey])
+        let revision = try XCTUnwrap(goodRow.modelRevision)
+        let hub = try tempDir()
+        let snapshot = hub
+            .appendingPathComponent("models--mlx-community--Qwen3-Coder-30B-A3B-Instruct-4bit", isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(revision, isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
+        request.candidateCatalog.rows[goodKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        let artifactPath = snapshot.path
+
+        let prober = RecordingStage1Prober(results: [
+            artifactPath: .feasible(medianTPS: 88, p95TTFTMS: 900)
+        ])
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: CachedModelArtifactResolver(hubRoot: hub),
+            runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
+            prober: prober,
+            safetySampler: StaticProbeSafetySampler()
+        )
+
+        let outcomes = try await benchmarker.benchmarks(
+            request: request,
+            targetContext: 4_000,
+            gateTTFTMS: 3_000,
+            replicates: 1,
+            port: 18080,
+            candidateModelIDs: Set([goodRow.modelID])
+        )
+
+        XCTAssertNotNil(outcomes.benchmarks[goodKey])
+        XCTAssertNil(outcomes.benchmarks[skippedKey])
+        XCTAssertNil(outcomes.diagnostics[skippedKey])
+        XCTAssertEqual(prober.probedModels, [artifactPath])
     }
 
     func testBenchmarkingRethrowsUnexpectedRunnerFailures() async throws {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/AutotuneRecommendationRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/AutotuneRecommendationRunner.swift
@@ -4,7 +4,10 @@ enum AutotuneRecommendationRunner {
     /// Wall-clock budget for `macprovider-cli autotune --recommend --json`.
     ///
     /// Autotune runs Stage-1 probes against every non-blocked, RAM-eligible
-    /// row in the catalog. Each probe spawns a subprocess of
+    /// row in the catalog. Rows that fail artifact verification (e.g. stale
+    /// HuggingFace cache hash mismatch on an unrelated model) are skipped with
+    /// a diagnostic instead of aborting the whole run. Optional
+    /// `--candidate-models` scopes probes to matching catalog `model_id`s. Each probe spawns a subprocess of
     /// `macprovider-cli serve`, waits for MLX to load the model, then does a
     /// prewarm HTTP call followed by measured TTFT + tokens/sec replicates.
     ///


### PR DESCRIPTION
## Summary
- `autotune --recommend` no longer aborts when an unrelated catalog row has a bad HuggingFace cache (hash mismatch, missing pin, etc.); the row is skipped with a `probe_diagnostics` entry like RAM/bandwidth gates.
- `--candidate-models` now scopes recommend Stage 1 probes to catalog rows whose `model_id` is in the operator list (previously parsed but ignored on the recommend path).
- SPEC-013 `Stage1Iterator` integrity abort behavior is unchanged.

## Test plan
- [x] `swift test --filter AutotuneRecommendTests.testBenchmarksDiagnosesRowsSkippedByArtifactHashMismatch`
- [x] `swift test --filter AutotuneRecommendTests.testBenchmarkRecommendContinuesWhenUnrelatedRowHasArtifactMismatch`
- [x] `swift test --filter AutotuneRecommendTests.testBenchmarksScopesToCandidateModelsWhenFilterProvided`
- [x] `swift test --filter AutotuneRecommendTests.testBenchmarkingRethrowsUnexpectedRunnerFailures`
- [ ] CI green
- [ ] Smoke: `macprovider-cli autotune --recommend --apply` on a Mac with one stale unrelated HF cache row


Made with [Cursor](https://cursor.com)