### PR TITLE
Serve SPEC-023 autotune feeds on buyer mux (P2b)

### DIFF
--- a/beta/MALIBU_WORKSTREAM.md
+++ b/beta/MALIBU_WORKSTREAM.md
@@ -21,7 +21,7 @@ repo.
 
 | ID | Scope | Exit criterion | Notes |
 |---|---|---|---|
-| **P2a** | **Harden autotune `--apply`** | `recommend` does not fail entirely when an unrelated catalog row has a bad HF cache; `--candidate-models` scopes recommend probes | PR in progress |
+| **P2b** | **Consolidate static feeds into buyer API** | Live autotune catalog + demand-rank served from coordinator buyer mux (`/v1/demand-rank`, `/v1/autotune-candidates` + `.sig`); Pearl deploy installs `/opt/macprovider/autotune/`; CLI fetches `/v1/*`; drop nginx `/static/` | PR in progress |
 
 ---
 
@@ -29,7 +29,6 @@ repo.
 
 | ID | Scope | Exit criterion | Area |
 |---|---|---|---|
-| **P2b** | **Consolidate static feeds into buyer API** *(future)* | Live autotune catalog + demand-rank served from coordinator buyer mux (like `/v1/rate-card`); drop Pearl nginx `/opt/macprovider/static/` copy step; keep Ed25519 signatures + baked fallback | Coordinator / ops |
 | **P3** | Dashboard log tail wiring (SPEC-026 Step 3 Item 6) | `LogTailView` shows live provider stderr/out tail on dashboard when lines exist (hidden when empty as of v1.8.18) | Malibu UI |
 
 ---
@@ -38,8 +37,9 @@ repo.
 
 | ID | Shipped | PR / release | Notes |
 |---|---|---|---|
+| **P2a** | 2026-07-07 | #458 | Autotune `--recommend`/`--apply` hardening |
 | **R1** | 2026-07-07 | v1.8.18 (#457) | Sparkle live + dashboard stats clipping fix |
-| Pearl static feeds | 2026-07-07 | #454 | Baked catalog sync + nginx EACCES hardening |
+| Pearl static feeds | 2026-07-07 | #454 | Baked catalog sync + nginx EACCES hardening (superseded by P2b buyer mux) |
 | Malibu P1 diagnostics | 2026-07-07 | #455 | Provider log tail + stale-catalog UX on onboarding |
 | Sparkle in-app updates | 2026-07-07 | #456 | Sparkle in Malibu.app |
 | CLI update UI in dashboard | 2026-07-06 | v1.8.16 | Overflow fixed in v1.8.18 |

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -746,8 +746,8 @@ struct AutotuneStaticInputs {
         let bakedValue = (try? decode(bakedBytes))!
         let bakedGeneratedAt = generatedAt(in: bakedBytes) ?? .distantFuture
         do {
-            let jsonURL = URL(string: "https://coordinator.streamvc.live/static/\(name).json")!
-            let sigURL = URL(string: "https://coordinator.streamvc.live/static/\(name).json.sig")!
+            let jsonURL = URL(string: "https://coordinator.streamvc.live/v1/\(name)")!
+            let sigURL = URL(string: "https://coordinator.streamvc.live/v1/\(name).sig")!
             let jsonBytes = try await fetch(jsonURL)
             let sigBytes = try await fetch(sigURL)
             guard sidecarIsValid(sigBytes), verifySignature(jsonBytes, sigBytes) else {

--- a/phase3-binary/dist/static/keys/README.md
+++ b/phase3-binary/dist/static/keys/README.md
@@ -35,7 +35,9 @@ The runtime verification model relies on:
 
 1. **Provider clients** ship the baked v4 public key in
    `AutotuneRecommend.swift`. They fetch the signed feed from
-   `https://coordinator.streamvc.live/static/*` (URL hardcoded in
+   `https://coordinator.streamvc.live/v1/demand-rank` and
+   `https://coordinator.streamvc.live/v1/autotune-candidates` (URL
+   hardcoded in
    [`AutotuneRecommend.swift`](../../../Sources/macprovider-cli/AutotuneRecommend.swift))
    and verify each `.sig` sidecar against the baked pubkey.
 2. **The private key** is held only by the operator running
@@ -43,8 +45,8 @@ The runtime verification model relies on:
    git, CI logs, or `coordinator.streamvc.live`.
 3. **Deployment** copies the freshly-signed `autotune-candidates.json`
    / `demand-rank.json` and their `.sig` sidecars to Pearl VPS via
-   `phase4-coordinator/dist/deploy-pearl-vps.sh`; nginx serves them
-   under `/static/`.
+   `phase4-coordinator/dist/deploy-pearl-vps.sh`; the coordinator buyer
+   mux serves them under `/v1/demand-rank` and `/v1/autotune-candidates`.
 
 Additional defenses in depth:
 

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -120,6 +120,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "config: %v\n", err)
 		os.Exit(1)
 	}
+	autotuneFeeds, err := buyer.LoadAutotuneFeeds(cfg.AutotuneFeeds)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "autotune feeds: %v\n", err)
+		os.Exit(1)
+	}
 	providerhttp.Init(cfg.ProviderHTTP.TimeoutS)
 
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
@@ -571,6 +576,7 @@ func main() {
 		buyer.WithBilling(billingStore, cfg.Rewards),
 		buyer.WithBillingSnapshotID(snapshotID),
 		buyer.WithRateCardUSDPerMillionCredits(cfg.Stats.Rollup.UsdPerMillionCredits),
+		buyer.WithAutotuneFeeds(autotuneFeeds),
 		buyer.WithStreamingMetricsMaxSamples(cfg.Stats.StreamingMetrics.MaxSamples),
 		buyer.WithPreflight(func(provider pool.Provider, requestID string, estimatedTokens int, timeout time.Duration) (buyer.PreflightResult, bool, error) {
 			ack, ok, err := wsServer.Preflight(provider, requestID, estimatedTokens, timeout)

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -144,6 +144,15 @@ logging:
   level: "info"
   format: "json"
 
+# SPEC-023 signed recommendation feeds — buyer mux /v1/demand-rank and
+# /v1/autotune-candidates (+ .sig sidecars). Deploy refreshes from
+# phase3-binary/dist/static/ on each Pearl run.
+autotune:
+  demand_rank_path: "/opt/macprovider/autotune/demand-rank.json"
+  demand_rank_sig_path: "/opt/macprovider/autotune/demand-rank.json.sig"
+  autotune_candidates_path: "/opt/macprovider/autotune/autotune-candidates.json"
+  autotune_candidates_sig_path: "/opt/macprovider/autotune/autotune-candidates.json.sig"
+
 # Wave 1 subset — Entry 92 v2 rate-card rows for canary rollout (2026-07-01).
 # Units: credits_per_mtok; stats_rollup.usd_per_million_credits=1.0 → 1M credits = $1.00.
 # Keys must match Wave 0b normalizeModelKey() output (phase4-coordinator/internal/billing/formula.go).

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -131,6 +131,17 @@ logging:
   level: "info"
   format: "json"
 
+# SPEC-023 signed recommendation feeds served on the buyer mux at
+# /v1/demand-rank(+ .sig) and /v1/autotune-candidates(+ .sig).
+# Paths point at literal signed bytes on disk (not computed like
+# /v1/rate-card). Empty paths disable that feed (404). Deploy installs
+# fresh files from phase3-binary/dist/static/ into /opt/macprovider/autotune/.
+autotune:
+  demand_rank_path: "/opt/macprovider/autotune/demand-rank.json"
+  demand_rank_sig_path: "/opt/macprovider/autotune/demand-rank.json.sig"
+  autotune_candidates_path: "/opt/macprovider/autotune/autotune-candidates.json"
+  autotune_candidates_sig_path: "/opt/macprovider/autotune/autotune-candidates.json.sig"
+
 # Rewards / rate-card configuration (Entry 92 v2 pricing thesis; Wave 1 hot-reload surface).
 #
 # Sample below documents the Wave 1 2-row canary pattern that shipped 2026-07-01

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -175,10 +175,10 @@ NGINX_STATS_PROXY_PARTNER="$DIST_DIR/nginx-snippets/stats-proxy-partner.conf"
 NGINX_STATS_SITE="$DIST_DIR/nginx-stats.streamvc.live.conf"
 CATALOG_SOURCE="${CATALOG_SOURCE:-$DIST_DIR/../../.omc/tier2/tier2-catalog.json}"
 
-# SPEC-023 v1.7.3 — signed static feeds (demand-rank + autotune-candidates)
-# served by nginx from /opt/macprovider/static/ under the /static/ prefix.
+# SPEC-023 signed recommendation feeds served on the buyer mux at
+# /v1/demand-rank and /v1/autotune-candidates (+ .sig sidecars).
 # Files live in phase3-binary/dist/static/ in the repo. Deploy installs
-# them alongside the coordinator config.
+# them into /opt/macprovider/autotune/ for coordinator startup load.
 STATIC_FEEDS_DIR="$DIST_DIR/../../phase3-binary/dist/static"
 STATIC_DEMAND_JSON="$STATIC_FEEDS_DIR/demand-rank.json"
 STATIC_DEMAND_SIG="$STATIC_FEEDS_DIR/demand-rank.json.sig"
@@ -555,13 +555,6 @@ $SSH 'set -e
   # config, catalog) are still installed mode-set to macprovider so
   # the daemon can read them.
   install -d -o root -g macprovider -m 0750 /opt/macprovider
-  # SPEC-023: nginx (www-data) must traverse /opt/macprovider to reach
-  # /opt/macprovider/static/*. o+x on the parent is path-traversal only;
-  # sibling files keep 0750/0640. Re-applied immediately after install -d
-  # because install -d resets mode to exactly 0750 and wipes a prior o+x
-  # when step 6 is skipped or a partial rerun only refreshes dirs — caught
-  # 2026-07-07 P0 static-feed outage (nginx stat() EACCES → public 404).
-  chmod o+x /opt/macprovider
   install -d -o root -g macprovider-stats -m 0750 /opt/macprovider-stats
   install -d -o macprovider -g macprovider -m 0750 /var/lib/macprovider
   install -d -o macprovider -g macprovider -m 0750 /var/log/macprovider
@@ -1136,27 +1129,14 @@ $SSH "set -e
   elif [ -f /var/lib/macprovider/request-log.sqlite ]; then
     echo '  warning: setfacl not available; stats billing mirror will remain disabled until macprovider-stats can read request-log.sqlite'
   fi
-  # SPEC-023 v1.7.3 signed static feeds — served by nginx as
-  # coordinator.streamvc.live/static/*. Files are world-readable
-  # (mode 0644) because they are public signed content; nginx runs as
-  # www-data. Directory itself is world-executable so www-data can enter.
-  #
-  # /opt/macprovider/ is provisioned as root:macprovider 0750, which
-  # blocks www-data (not in the macprovider group) from traversing INTO
-  # any subdir including /static/. Add +x for others so nginx can walk
-  # the path; contents of siblings (coordinator, coordinator-cli,
-  # coordinator.yaml, coordinator.env) stay unreadable — their own modes
-  # 0750/0640 unchanged, +x on the parent only adds path-traversal, not
-  # listing or reading. Caught 2026-07-02 v1.7.3 first deploy: smoke
-  # returned 404 until the parent chmod was applied.
-  chmod o+x /opt/macprovider
-  mkdir -p /opt/macprovider/static
-  chown root:root /opt/macprovider/static
-  chmod 0755      /opt/macprovider/static
-  install -o root -g root -m 0644 $DEPLOY_TMP/demand-rank.json          /opt/macprovider/static/demand-rank.json
-  install -o root -g root -m 0644 $DEPLOY_TMP/demand-rank.json.sig      /opt/macprovider/static/demand-rank.json.sig
-  install -o root -g root -m 0644 $DEPLOY_TMP/autotune-candidates.json  /opt/macprovider/static/autotune-candidates.json
-  install -o root -g root -m 0644 $DEPLOY_TMP/autotune-candidates.json.sig /opt/macprovider/static/autotune-candidates.json.sig
+  # SPEC-023 signed recommendation feeds — loaded by coordinator at startup
+  # and served on the buyer mux (/v1/demand-rank, /v1/autotune-candidates).
+  # root:macprovider 0640 so the macprovider daemon can read them.
+  install -d -o root -g macprovider -m 0750 /opt/macprovider/autotune
+  install -o root -g macprovider -m 0640 $DEPLOY_TMP/demand-rank.json            /opt/macprovider/autotune/demand-rank.json
+  install -o root -g macprovider -m 0640 $DEPLOY_TMP/demand-rank.json.sig        /opt/macprovider/autotune/demand-rank.json.sig
+  install -o root -g macprovider -m 0640 $DEPLOY_TMP/autotune-candidates.json   /opt/macprovider/autotune/autotune-candidates.json
+  install -o root -g macprovider -m 0640 $DEPLOY_TMP/autotune-candidates.json.sig /opt/macprovider/autotune/autotune-candidates.json.sig
 "
 if [ -n "$CATALOG_REMOTE_PATH" ]; then
   # R4: no more `install -d` on a dynamic dirname. /opt/macprovider is
@@ -1563,35 +1543,34 @@ if [ -n "$CATALOG_REMOTE_PATH" ]; then
   echo "  catalog OK: $CATALOG_SUMMARY"
 fi
 
-# SPEC-023 v1.7.3 signed static feeds smoke.
-log "  verifying nginx can read static feeds as www-data"
+# SPEC-023 signed recommendation feeds smoke (buyer mux via nginx).
+log "  verifying coordinator can read autotune feeds as macprovider"
 $SSH "set -e
-  chmod o+x /opt/macprovider
-  sudo -u www-data test -r /opt/macprovider/static/autotune-candidates.json
-  sudo -u www-data test -r /opt/macprovider/static/demand-rank.json
+  sudo -u macprovider test -r /opt/macprovider/autotune/autotune-candidates.json
+  sudo -u macprovider test -r /opt/macprovider/autotune/demand-rank.json
 " || {
-  echo "aborting smoke: www-data cannot read /opt/macprovider/static/* (check chmod o+x /opt/macprovider)" >&2
+  echo "aborting smoke: macprovider cannot read /opt/macprovider/autotune/*" >&2
   exit 1
 }
-STATIC_SMOKE_DIR=$(umask 077 && mktemp -d -t macprovider-static-probe.XXXXXXXX) || {
-  echo "aborting smoke: mktemp -d failed for static feed probe" >&2
+STATIC_SMOKE_DIR=$(umask 077 && mktemp -d -t macprovider-autotune-probe.XXXXXXXX) || {
+  echo "aborting smoke: mktemp -d failed for autotune feed probe" >&2
   exit 1
 }
 STATIC_SMOKE_BODY="$STATIC_SMOKE_DIR/body"
 for STATIC_PATH in \
-    /static/demand-rank.json \
-    /static/demand-rank.json.sig \
-    /static/autotune-candidates.json \
-    /static/autotune-candidates.json.sig; do
+    /v1/demand-rank \
+    /v1/demand-rank.sig \
+    /v1/autotune-candidates \
+    /v1/autotune-candidates.sig; do
   echo "  GET https://$DOMAIN$STATIC_PATH -> expect 200"
   : > "$STATIC_SMOKE_BODY"
   STATUS=$(curl -sS -o "$STATIC_SMOKE_BODY" -w '%{http_code}' --max-time 10 --max-filesize 65536 "https://$DOMAIN$STATIC_PATH")
   if [ "$STATUS" != "200" ]; then
-    echo "SPEC-023 static feed smoke failed: $STATIC_PATH status=$STATUS body=$(head -c 200 "$STATIC_SMOKE_BODY")" >&2
+    echo "SPEC-023 autotune feed smoke failed: $STATIC_PATH status=$STATUS body=$(head -c 200 "$STATIC_SMOKE_BODY")" >&2
     exit 1
   fi
 done
-echo "  SPEC-023 static feeds OK"
+echo "  SPEC-023 autotune feeds OK"
 
 # R3+R4+R5 stats smoke check on STATS_DOMAIN.
 #

--- a/phase4-coordinator/dist/monitor/README.md
+++ b/phase4-coordinator/dist/monitor/README.md
@@ -37,7 +37,7 @@ runs journal-only.
 
 ## What it alerts on (transition-based)
 - pool `ready == 0` (idle / no buyer capacity) — CRITICAL
-- SPEC-023 static feeds (`/static/autotune-candidates.json`, `.sig`, `/static/demand-rank.json`, `.sig`) unreachable from Pearl — CRITICAL
+- SPEC-023 autotune feeds (`/v1/autotune-candidates`, `.sig`, `/v1/demand-rank`, `.sig`) unreachable from Pearl — CRITICAL
 - a provider → `unavailable` (breaker re-trip / `warmup_failed` / removed) — WARN
 - a provider → `degraded` (breaker trip / warm-up hold) — WARN
 - a provider dropped from the pool — WARN

--- a/phase4-coordinator/dist/monitor/macprovider-monitor.py
+++ b/phase4-coordinator/dist/monitor/macprovider-monitor.py
@@ -33,10 +33,10 @@ HEALTHZ = "http://127.0.0.1:8444/healthz"
 POOLZ = "http://127.0.0.1:8444/poolz"
 GW_STATUS = "http://127.0.0.1:9443/v1/status"
 STATIC_FEEDS = (
-    "https://coordinator.streamvc.live/static/autotune-candidates.json",
-    "https://coordinator.streamvc.live/static/autotune-candidates.json.sig",
-    "https://coordinator.streamvc.live/static/demand-rank.json",
-    "https://coordinator.streamvc.live/static/demand-rank.json.sig",
+    "https://coordinator.streamvc.live/v1/autotune-candidates",
+    "https://coordinator.streamvc.live/v1/autotune-candidates.sig",
+    "https://coordinator.streamvc.live/v1/demand-rank",
+    "https://coordinator.streamvc.live/v1/demand-rank.sig",
 )
 TIMEOUT = 8
 HOST = socket.gethostname()

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -236,24 +236,45 @@ server {
     }
 
     # ---------------------------------------------------------------------
-    # /static/{demand-rank,autotune-candidates}.{json,json.sig} — SPEC-023
-    # signed static feeds. Introduced in v1.7.3 to move feed hosting off
-    # get.streamvc.live (Cloudflare Pages) onto Pearl so feed updates ship
-    # via `git commit + deploy-pearl-vps.sh` instead of Cloudflare dashboard
-    # config. Ed25519-signed with key `streamvc-autotune-static-v4` whose
-    # public key is baked into macprovider-cli at
-    # AutotuneRecommend.swift. Files live in /opt/macprovider/static/,
-    # installed by deploy-pearl-vps.sh step 6b from
-    # phase3-binary/dist/static/.
-    #
-    # Cache-Control: 5 min max-age matches the /v1/rate-card cadence.
+    # /v1/demand-rank and /v1/autotune-candidates (+ .sig) — SPEC-023
+    # signed recommendation feeds on the buyer mux (8443). Replaces the
+    # former nginx /static/ alias to /opt/macprovider/static/. Deploy
+    # installs literal signed bytes into /opt/macprovider/autotune/ and
+    # the coordinator loads them at startup. Cache-Control: 5 min max-age
+    # matches /v1/rate-card cadence.
+    # MUST be declared BEFORE the catch-all `location /v1/ { return 404; }`.
     # ---------------------------------------------------------------------
-    location /static/ {
-        alias /opt/macprovider/static/;
-        add_header Cache-Control "public, max-age=300" always;
-        try_files $uri =404;
-        types { application/json json; application/octet-stream sig; }
-        default_type application/json;
+    location = /v1/demand-rank {
+        proxy_pass http://127.0.0.1:8443/v1/demand-rank$is_args$args;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 10s;
+    }
+    location = /v1/demand-rank.sig {
+        proxy_pass http://127.0.0.1:8443/v1/demand-rank.sig$is_args$args;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 10s;
+    }
+    location = /v1/autotune-candidates {
+        proxy_pass http://127.0.0.1:8443/v1/autotune-candidates$is_args$args;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 10s;
+    }
+    location = /v1/autotune-candidates.sig {
+        proxy_pass http://127.0.0.1:8443/v1/autotune-candidates.sig$is_args$args;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 10s;
     }
 
     # ---------------------------------------------------------------------

--- a/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
+++ b/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
@@ -11,20 +11,16 @@ fail() {
 
 bash -n "$DEPLOY_SH"
 
-grep -q 'chmod o+x /opt/macprovider' "$DEPLOY_SH" ||
-  fail "deploy must chmod o+x /opt/macprovider for nginx static feed traversal"
+grep -q 'install -d -o root -g macprovider -m 0750 /opt/macprovider/autotune' "$DEPLOY_SH" ||
+  fail "deploy must install autotune feed directory under /opt/macprovider/autotune"
 
-# Step 3 must re-apply o+x immediately after install -d resets mode to 0750.
-awk '
-  /install -d -o root -g macprovider -m 0750 \/opt\/macprovider/ {
-    if (!getline nxt || nxt !~ /chmod o\+x \/opt\/macprovider/) {
-      exit 1
-    }
-  }
-  END { exit 0 }
-' "$DEPLOY_SH" || fail "step 3 must chmod o+x immediately after install -d /opt/macprovider"
+grep -q 'sudo -u macprovider test -r /opt/macprovider/autotune/autotune-candidates.json' "$DEPLOY_SH" ||
+  fail "deploy smoke must verify macprovider can read autotune feeds"
 
-grep -q 'sudo -u www-data test -r /opt/macprovider/static/autotune-candidates.json' "$DEPLOY_SH" ||
-  fail "deploy smoke must verify www-data can read static feeds"
+grep -q '/v1/demand-rank' "$DEPLOY_SH" ||
+  fail "deploy smoke must probe /v1/demand-rank"
 
-echo "PASS: deploy static feed nginx access guards present"
+grep -q 'chmod o+x /opt/macprovider' "$DEPLOY_SH" &&
+  fail "deploy must not chmod o+x /opt/macprovider for legacy nginx static feeds"
+
+echo "PASS: deploy autotune feed access guards present"

--- a/phase4-coordinator/internal/buyer/autotune_feeds.go
+++ b/phase4-coordinator/internal/buyer/autotune_feeds.go
@@ -1,0 +1,132 @@
+package buyer
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+)
+
+// AutotuneFeeds holds the literal signed bytes for SPEC-023 recommendation
+// inputs. Served on the buyer mux at /v1/demand-rank(+ .sig) and
+// /v1/autotune-candidates(+ .sig), replacing nginx /static/* hosting.
+type AutotuneFeeds struct {
+	DemandRankJSON         []byte
+	DemandRankSig          []byte
+	AutotuneCandidatesJSON []byte
+	AutotuneCandidatesSig  []byte
+}
+
+func (f AutotuneFeeds) demandRankEnabled() bool {
+	return len(f.DemandRankJSON) > 0 && len(f.DemandRankSig) > 0
+}
+
+func (f AutotuneFeeds) autotuneCandidatesEnabled() bool {
+	return len(f.AutotuneCandidatesJSON) > 0 && len(f.AutotuneCandidatesSig) > 0
+}
+
+// LoadAutotuneFeeds reads signed feed files from cfg paths. Empty paths
+// disable that feed (handler returns 404). When a JSON path is set, its
+// matching .sig path must also be set and both files must exist.
+func LoadAutotuneFeeds(cfg config.AutotuneFeedsConfig) (AutotuneFeeds, error) {
+	var out AutotuneFeeds
+	var err error
+	if out.DemandRankJSON, out.DemandRankSig, err = loadAutotuneFeedPair(
+		cfg.DemandRankPath, cfg.DemandRankSigPath, "demand_rank",
+	); err != nil {
+		return AutotuneFeeds{}, err
+	}
+	if out.AutotuneCandidatesJSON, out.AutotuneCandidatesSig, err = loadAutotuneFeedPair(
+		cfg.AutotuneCandidatesPath, cfg.AutotuneCandidatesSigPath, "autotune_candidates",
+	); err != nil {
+		return AutotuneFeeds{}, err
+	}
+	return out, nil
+}
+
+func loadAutotuneFeedPair(jsonPath, sigPath, label string) ([]byte, []byte, error) {
+	jsonPath = strings.TrimSpace(jsonPath)
+	sigPath = strings.TrimSpace(sigPath)
+	if jsonPath == "" && sigPath == "" {
+		return nil, nil, nil
+	}
+	if jsonPath == "" || sigPath == "" {
+		return nil, nil, configPairError(label)
+	}
+	jsonBytes, err := os.ReadFile(jsonPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	sigBytes, err := os.ReadFile(sigPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(jsonBytes) == 0 || len(sigBytes) == 0 {
+		return nil, nil, configEmptyFeedError(label)
+	}
+	return jsonBytes, sigBytes, nil
+}
+
+type configFeedError string
+
+func (e configFeedError) Error() string { return string(e) }
+
+func configPairError(label string) error {
+	return configFeedError("autotune." + label + "_path and autotune." + label + "_sig_path must both be set")
+}
+
+func configEmptyFeedError(label string) error {
+	return configFeedError("autotune." + label + " feed file is empty")
+}
+
+func WithAutotuneFeeds(feeds AutotuneFeeds) Option {
+	return func(s *Server) {
+		s.autotuneFeedsMu.Lock()
+		defer s.autotuneFeedsMu.Unlock()
+		s.autotuneFeeds = feeds
+	}
+}
+
+func (s *Server) autotuneFeedsSnapshot() AutotuneFeeds {
+	s.autotuneFeedsMu.RLock()
+	defer s.autotuneFeedsMu.RUnlock()
+	return s.autotuneFeeds
+}
+
+func (s *Server) handleDemandRank(w http.ResponseWriter, r *http.Request) {
+	feeds := s.autotuneFeedsSnapshot()
+	s.serveAutotuneFeedBytes(w, r, feeds.DemandRankJSON, feeds.demandRankEnabled())
+}
+
+func (s *Server) handleDemandRankSig(w http.ResponseWriter, r *http.Request) {
+	feeds := s.autotuneFeedsSnapshot()
+	s.serveAutotuneFeedBytes(w, r, feeds.DemandRankSig, feeds.demandRankEnabled())
+}
+
+func (s *Server) handleAutotuneCandidates(w http.ResponseWriter, r *http.Request) {
+	feeds := s.autotuneFeedsSnapshot()
+	s.serveAutotuneFeedBytes(w, r, feeds.AutotuneCandidatesJSON, feeds.autotuneCandidatesEnabled())
+}
+
+func (s *Server) handleAutotuneCandidatesSig(w http.ResponseWriter, r *http.Request) {
+	feeds := s.autotuneFeedsSnapshot()
+	s.serveAutotuneFeedBytes(w, r, feeds.AutotuneCandidatesSig, feeds.autotuneCandidatesEnabled())
+}
+
+func (s *Server) serveAutotuneFeedBytes(w http.ResponseWriter, r *http.Request, body []byte, enabled bool) {
+	if !s.allowReceiptKeys(r) {
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "Autotune feed endpoint rate limit exceeded")
+		return
+	}
+	if !enabled {
+		writeError(w, http.StatusNotFound, "autotune_feed_not_found", "Autotune feed not found")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	if _, err := w.Write(body); err != nil {
+		s.log.Warn().Err(err).Msg("write autotune feed response failed")
+	}
+}

--- a/phase4-coordinator/internal/buyer/autotune_feeds_test.go
+++ b/phase4-coordinator/internal/buyer/autotune_feeds_test.go
@@ -1,0 +1,131 @@
+package buyer_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/buyer"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/rs/zerolog"
+)
+
+func TestAutotuneFeedsServeLiteralSignedBytes(t *testing.T) {
+	t.Parallel()
+	staticDir := filepath.Join("..", "..", "..", "phase3-binary", "dist", "static")
+	demandJSON, err := os.ReadFile(filepath.Join(staticDir, "demand-rank.json"))
+	if err != nil {
+		t.Fatalf("read demand-rank.json: %v", err)
+	}
+	demandSig, err := os.ReadFile(filepath.Join(staticDir, "demand-rank.json.sig"))
+	if err != nil {
+		t.Fatalf("read demand-rank.json.sig: %v", err)
+	}
+	candidatesJSON, err := os.ReadFile(filepath.Join(staticDir, "autotune-candidates.json"))
+	if err != nil {
+		t.Fatalf("read autotune-candidates.json: %v", err)
+	}
+	candidatesSig, err := os.ReadFile(filepath.Join(staticDir, "autotune-candidates.json.sig"))
+	if err != nil {
+		t.Fatalf("read autotune-candidates.json.sig: %v", err)
+	}
+
+	feeds, err := buyer.LoadAutotuneFeeds(config.AutotuneFeedsConfig{
+		DemandRankPath:            filepath.Join(staticDir, "demand-rank.json"),
+		DemandRankSigPath:         filepath.Join(staticDir, "demand-rank.json.sig"),
+		AutotuneCandidatesPath:    filepath.Join(staticDir, "autotune-candidates.json"),
+		AutotuneCandidatesSigPath: filepath.Join(staticDir, "autotune-candidates.json.sig"),
+	})
+	if err != nil {
+		t.Fatalf("LoadAutotuneFeeds: %v", err)
+	}
+
+	server := buyer.NewServer(
+		pool.NewRegistry(nil),
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithAutotuneFeeds(feeds),
+	)
+	handler := server.Handler()
+
+	cases := []struct {
+		path string
+		want []byte
+	}{
+		{"/v1/demand-rank", demandJSON},
+		{"/v1/demand-rank.sig", demandSig},
+		{"/v1/autotune-candidates", candidatesJSON},
+		{"/v1/autotune-candidates.sig", candidatesSig},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+			}
+			if got := rr.Body.Bytes(); string(got) != string(tc.want) {
+				t.Fatalf("body mismatch: got %d bytes want %d bytes", len(got), len(tc.want))
+			}
+			if cc := rr.Header().Get("Cache-Control"); cc != "public, max-age=300" {
+				t.Fatalf("Cache-Control=%q", cc)
+			}
+		})
+	}
+}
+
+func TestAutotuneFeedsDisabledWhenUnset(t *testing.T) {
+	t.Parallel()
+	server := buyer.NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Unix(1716768000, 0))
+	handler := server.Handler()
+
+	for _, path := range []string{
+		"/v1/demand-rank",
+		"/v1/demand-rank.sig",
+		"/v1/autotune-candidates",
+		"/v1/autotune-candidates.sig",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("%s status=%d want 404", path, rr.Code)
+		}
+	}
+}
+
+func TestNginxAutotuneFeedsAllowThroughBeforeV1CatchAll(t *testing.T) {
+	t.Parallel()
+	b, err := os.ReadFile(filepath.Join("..", "..", "dist", "nginx-coordinator.streamvc.live.conf"))
+	if err != nil {
+		t.Fatalf("read nginx config: %v", err)
+	}
+	cfg := string(b)
+	catchAll := strings.Index(cfg, "location /v1/ {\n        return 404;")
+	if catchAll < 0 {
+		t.Fatalf("/v1/ 404 catch-all missing")
+	}
+	beforeCatchAll := cfg[:catchAll]
+	for _, location := range []string{
+		"location = /v1/rate-card",
+		"location = /v1/demand-rank",
+		"location = /v1/demand-rank.sig",
+		"location = /v1/autotune-candidates",
+		"location = /v1/autotune-candidates.sig",
+	} {
+		if !strings.Contains(beforeCatchAll, location) {
+			t.Fatalf("%s missing before /v1/ catch-all", location)
+		}
+	}
+	if strings.Contains(beforeCatchAll, "location /static/") {
+		t.Fatalf("legacy /static/ nginx alias should be removed")
+	}
+}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -169,6 +169,8 @@ type Server struct {
 	billingCfg        config.RewardsConfig
 	billingSnapshotID int64
 	rateCardUSDPerM   float64
+	autotuneFeedsMu   sync.RWMutex
+	autotuneFeeds     AutotuneFeeds
 	now               func() time.Time
 	version           string
 }
@@ -588,6 +590,10 @@ func (s *Server) Handler() http.Handler {
 	r.Get("/healthz", s.handleHealthz)
 	r.Get("/v1/models", s.handleModels)
 	r.Get("/v1/rate-card", s.handleRateCard)
+	r.Get("/v1/demand-rank", s.handleDemandRank)
+	r.Get("/v1/demand-rank.sig", s.handleDemandRankSig)
+	r.Get("/v1/autotune-candidates", s.handleAutotuneCandidates)
+	r.Get("/v1/autotune-candidates.sig", s.handleAutotuneCandidatesSig)
 	r.Get("/v1/pool/check", s.handlePoolCheck)
 	r.Get("/v1/receipt-keys/{provider_id}", s.handleReceiptKeys)
 	// SPEC-015 §M.4 — SPEC-002 v1.6 candidate annotations.

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	Explorer                     ExplorerConfig               `yaml:"explorer"`
 	Stats                        StatsConfig                  `yaml:"stats"`
 	Onboarding                   OnboardingConfig             `yaml:"onboarding"`
+	AutotuneFeeds                AutotuneFeedsConfig          `yaml:"autotune"`
 	Proxy                        ProxyConfig                  `yaml:"proxy"`
 	Providers                    []ProviderConfig             `yaml:"providers"`
 }
@@ -79,6 +80,16 @@ type OnboardingConfig struct {
 	AppleTeamID             string            `yaml:"apple_team_id"`
 	CoordinatorDomain       string            `yaml:"coordinator_domain"`
 	ASNPrefixes             map[string]string `yaml:"asn_prefixes"`
+}
+
+// AutotuneFeedsConfig points at the signed SPEC-023 recommendation feeds
+// served on the buyer mux (/v1/demand-rank, /v1/autotune-candidates, and
+// their .sig sidecars). Empty paths disable that feed (404).
+type AutotuneFeedsConfig struct {
+	DemandRankPath            string `yaml:"demand_rank_path"`
+	DemandRankSigPath         string `yaml:"demand_rank_sig_path"`
+	AutotuneCandidatesPath    string `yaml:"autotune_candidates_path"`
+	AutotuneCandidatesSigPath string `yaml:"autotune_candidates_sig_path"`
 }
 
 // StatsConfig is the SPEC-017 Network Stats API config block.
@@ -1326,6 +1337,9 @@ func (c Config) Validate() error {
 	if err := c.validateOnboarding(); err != nil {
 		return err
 	}
+	if err := c.validateAutotuneFeeds(); err != nil {
+		return err
+	}
 	if _, ok := c.Rewards.RateCard["default"]; !ok {
 		return fmt.Errorf("rewards.rate_card must contain default")
 	}
@@ -1351,6 +1365,29 @@ func (c Config) Validate() error {
 			if err := ValidateEndpointURL(p.EndpointURL); err != nil {
 				return fmt.Errorf("provider %q endpoint_url must be a valid https URL (http allowed only for 127.0.0.1/localhost)", p.ProviderID)
 			}
+		}
+	}
+	return nil
+}
+
+func (c Config) validateAutotuneFeeds() error {
+	a := c.AutotuneFeeds
+	pairs := []struct {
+		label    string
+		jsonPath string
+		sigPath  string
+	}{
+		{"demand_rank", a.DemandRankPath, a.DemandRankSigPath},
+		{"autotune_candidates", a.AutotuneCandidatesPath, a.AutotuneCandidatesSigPath},
+	}
+	for _, p := range pairs {
+		jsonPath := strings.TrimSpace(p.jsonPath)
+		sigPath := strings.TrimSpace(p.sigPath)
+		if jsonPath == "" && sigPath == "" {
+			continue
+		}
+		if jsonPath == "" || sigPath == "" {
+			return fmt.Errorf("autotune.%s_path and autotune.%s_sig_path must both be set", p.label, p.label)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Serve `demand-rank` and `autotune-candidates` (+ `.sig` sidecars) from the coordinator buyer mux at `/v1/demand-rank` and `/v1/autotune-candidates`, loading literal signed bytes at startup like tier-2 catalog file serve (not computed like `/v1/rate-card`).
- Update Pearl deploy to install feeds under `/opt/macprovider/autotune/`, proxy the four endpoints in nginx before the `/v1/` catch-all, and drop the legacy `/static/` alias plus `chmod o+x /opt/macprovider` workaround.
- Point `AutotuneRecommend.swift` and production monitor URLs at the new `/v1/*` paths.

## Test plan
- [x] `go test ./...` in `phase4-coordinator`
- [x] `swift test --filter AutotuneRecommend` in `phase3-binary`
- [x] `phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh`
- [ ] After merge: coordinated Pearl deploy + v1.8.19 client release (existing v1.8.18 clients still fetch `/static/*`)


Made with [Cursor](https://cursor.com)