### PR TITLE
Release v1.8.19: autotune buyer mux client URLs

### DIFF
--- a/beta/MALIBU_WORKSTREAM.md
+++ b/beta/MALIBU_WORKSTREAM.md
@@ -21,7 +21,6 @@ repo.
 
 | ID | Scope | Exit criterion | Notes |
 |---|---|---|---|
-| **P2b** | **Consolidate static feeds into buyer API** | Live autotune catalog + demand-rank served from coordinator buyer mux (`/v1/demand-rank`, `/v1/autotune-candidates` + `.sig`); Pearl deploy installs `/opt/macprovider/autotune/`; CLI fetches `/v1/*`; drop nginx `/static/` | PR in progress |
 
 ---
 
@@ -37,6 +36,7 @@ repo.
 
 | ID | Shipped | PR / release | Notes |
 |---|---|---|---|
+| **P2b** | 2026-07-07 | v1.8.19 (#459 + release) | Autotune feeds on buyer mux `/v1/*`; Pearl deploy + Sparkle release |
 | **P2a** | 2026-07-07 | #458 | Autotune `--recommend`/`--apply` hardening |
 | **R1** | 2026-07-07 | v1.8.18 (#457) | Sparkle live + dashboard stats clipping fix |
 | Pearl static feeds | 2026-07-07 | #454 | Baked catalog sync + nginx EACCES hardening (superseded by P2b buyer mux) |
@@ -48,7 +48,7 @@ repo.
 
 ## FAQ
 
-### Update paths (post v1.8.18)
+### Update paths (post v1.8.19)
 
 | Path | What it updates |
 |---|---|
@@ -60,6 +60,6 @@ repo.
 | SPEC-025 §11 | Status |
 |---|---|
 | P2 signing / `.dmg` | Done |
-| P3 Sparkle | Live (v1.8.18) |
+| P3 Sparkle | Live (v1.8.19) |
 | P4 landing page | Not started |
 | P5+ WalletConnect, Homebrew | Backlog |

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.18"
+    static let binaryVersion = "1.8.19"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1644,10 +1644,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.18")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.18")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.18")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.18")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.19")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.19")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.19")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.19")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/app/Tests/MalibuTests/MalibuUpdateConfigurationTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/MalibuUpdateConfigurationTests.swift
@@ -18,15 +18,15 @@ final class MalibuUpdateConfigurationTests: XCTestCase {
     }
 
     func testVersionedDownloadURLUsesTagSuffix() {
-        let url = MalibuUpdateConfiguration.releaseDownloadURL(tag: "v1.8.18")
-        XCTAssertEqual(url.absoluteString, "https://download.malibu.tech/Malibu-v1.8.18.dmg")
+        let url = MalibuUpdateConfiguration.releaseDownloadURL(tag: "v1.8.19")
+        XCTAssertEqual(url.absoluteString, "https://download.malibu.tech/Malibu-v1.8.19.dmg")
     }
 
     func testReleaseNotesURLPointsAtGitHubTag() {
-        let url = MalibuUpdateConfiguration.releaseNotesURL(tag: "v1.8.18")
+        let url = MalibuUpdateConfiguration.releaseNotesURL(tag: "v1.8.19")
         XCTAssertEqual(
             url.absoluteString,
-            "https://github.com/Augustas11/macprovider/releases/tag/v1.8.18"
+            "https://github.com/Augustas11/macprovider/releases/tag/v1.8.19"
         )
     }
 }

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -27,7 +27,7 @@ settings:
     SWIFT_VERSION: "5.9"
     ENABLE_HARDENED_RUNTIME: YES
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "1.8.18"
+    MARKETING_VERSION: "1.8.19"
     CURRENT_PROJECT_VERSION: "18"
     OTHER_SWIFT_FLAGS: "-strict-concurrency=complete"
 

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -224,4 +224,4 @@ providers: []
 
 # Auto-update recommendation surface (2026-07-03 — added post-#332 to unblock air5 v1.7.0 -> v1.7.9)
 coordinator_advertised_version:
-  latest_binary_version: "1.8.3"
+  latest_binary_version: "1.8.19"


### PR DESCRIPTION
## Summary
- Bump CoordinatorClient.binaryVersion and Malibu MARKETING_VERSION to 1.8.19 so clients fetch autotune feeds from /v1/demand-rank and /v1/autotune-candidates (merged in #459).
- Set Pearl coordinator_advertised_version.latest_binary_version to 1.8.19 for coordinated deploy and Sparkle update path.
- Mark P2b done in beta/MALIBU_WORKSTREAM.md.

## Test plan
- [x] swift test --filter CoordinatorClientTests.testRegistrationHandshakeIncludesBinaryVersion
- [x] swift test --filter MalibuUpdateConfigurationTests
- [ ] After merge: Pearl deploy then tag v1.8.19 for release workflow

Made with [Cursor](https://cursor.com)