### PR TITLE
Add catalog expansion artifacts and close P1/G2 runbook tracker

### DIFF
--- a/beta/catalog-expansion/P0-01-moe-memory-parity.md
+++ b/beta/catalog-expansion/P0-01-moe-memory-parity.md
@@ -1,0 +1,130 @@
+# P0-01 — MLX MoE memory parity (Gemma-4 vs gpt-oss control)
+
+**Task:** P0-01 (Model Catalog Expansion Runbook)  
+**Date:** 2026-07-07  
+**Executor:** bench / measurement only (no catalog edits)  
+**MLX pin:** `mlx-swift-lm` 3.31.4, rev `bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57` (`phase3-binary/Package.resolved`)
+
+---
+
+## Hardware & environment
+
+| Field | Value |
+|-------|-------|
+| **Machine** | MacBook Air (Mac17,3) |
+| **Chip** | Apple M5 (10 cores: 4P + 6E) |
+| **Unified RAM** | 32 GB (`sysctl hw.memsize` = 34,359,738,368) |
+| **Bandwidth tier** | Tier-C (`BandwidthTier.derive` for base M5) |
+| **OS** | macOS 26.5 (25F71) |
+| **macprovider-cli** | 1.8.16 (release build from task worktree) |
+| **Load path** | `serve --no-join` → `LLMModelFactory.shared.loadContainer` + `#huggingFaceTokenizerLoader()` (same as `ModelRuntime.swift:1887–1890`) |
+| **Probe shape** | Stage1-equivalent: ~3,284 prompt tokens (`4096 × 0.8`) + 64 decode tokens, `temperature=0`, streaming |
+
+### Measurement notes
+
+- **Process RSS undercounts MLX resident memory** on Apple Silicon (typical ~50–90 MB RSS vs multi-GB unified allocations). Primary metric: **system used-memory delta** from pre-load baseline to idle-after-load, corroborated by on-disk weight size and provider `kv_cache_request_completed` logs.
+- Bench used `phase3-binary/.build/release/macprovider-cli` (debug build lacks bundled `default.metallib`).
+- A dev provider (`qwen3-coder-30b` on port 61919) was present but showed negligible RSS; Gemma run used a **clean 17 GB used baseline** (15 GB free). gpt-oss reruns after Gemma were **memory-contaminated** (baseline already ~32 GB used); gpt-oss control numbers below prefer the **first clean active-page delta** and on-disk weights.
+
+---
+
+## Per-model results
+
+| Role | MLX repo ID | Quant | On-disk weights | Idle resident Δ† | Post-gen resident Δ† | RSS (idle) ‡ | Swap during bench | Load | 4K probe gen | Decode TPS (rough) |
+|------|-------------|-------|-----------------|------------------|------------------------|--------------|-------------------|------|--------------|---------------------|
+| **Primary** | `mlx-community/gemma-4-26b-a4b-it-4bit` | 4-bit (+ 8-bit MLP/router slices per `config.json`) | **15 GB** | **+14.98 GB** | **+14.92 GB** | 0.09 GB | **No increase** (−9.9 GB swap vs baseline) | **PASS** | **PASS** (3284+64 tok) | **~7.7** |
+| **Control** | `mlx-community/gpt-oss-20b-MXFP4-Q8` | MXFP4-Q8 | **11 GB** | **+10.8 GB** § | n/a § | 0.08 GB § | Heavy swap when baseline full § | **PASS** | **PASS** (3284+64 tok) | **~9–11** § |
+
+† `resident Δ` = `used_gb_after − used_gb_before`, where `used_gb = 32 − free_pages×16 KiB`.  
+‡ RSS is not a reliable MLX footprint; included for completeness.  
+§ From first low-baseline gpt-oss run (active pages 3.35 → 14.13 GB) and rerun gen log; contaminated reruns hit swap but still completed inference.
+
+### Provider log evidence (4K probe)
+
+**Gemma-4** (`/tmp/p0-01-gemma4-primary.log.serve`):
+
+```json
+{"event":"kv_cache_request_completed","model_id":"mlx-community/gemma-4-26b-a4b-it-4bit","prompt_tokens":3284,"completion_tokens":64,"finish_reason":"length"}
+```
+
+**gpt-oss** (`/tmp/p0-01-gpt-oss-control-r2.log.serve`):
+
+```json
+{"event":"kv_cache_request_completed","model_id":"mlx-community/gpt-oss-20b-MXFP4-Q8","prompt_tokens":3284,"completion_tokens":64,"finish_reason":"length"}
+```
+
+---
+
+## Comparison to RESEARCH_226 & catalog
+
+| Model | RESEARCH_226 resident est. | Measured (this bench) | Catalog / baked `min_ram_gb` | Autotune gate (`memoryGB − 4`) on 32 GB |
+|-------|---------------------------|------------------------|------------------------------|----------------------------------------|
+| **Gemma-4 26B A4B** | 14.0–15.9 GB | **~15 GB** | Baked blocked row `google-gemma-4-26b-a4b-it`; RESEARCH_227 proposes **32 GB** | Requires `min_ram_gb ≤ 28` for eligibility |
+| **gpt-oss-20b** | 10.7–11.3 GB | **~11 GB** | Live `openai/gpt-oss-20b` **24 GB** | **24 ≤ 28** — passes gate |
+
+**Conclusion:** Pinned `mlx-swift-lm` 3.31.4 exhibits **MoE resident RAM in line with RESEARCH_226** for both models. No evidence of Darkbloom-scale fused gate+up bloat on these two MoE checkpoints; resident footprint tracks on-disk quantized weights.
+
+---
+
+## ModelFit cross-check (`ModelFit.swift`)
+
+Name-parsing treats parameter suffix as **dense total params**, not MoE active params:
+
+| Model ID | Parsed params | `inferBytesPerParam` | `estimateWeightSizeGB` | Measured resident | Discrepancy |
+|----------|---------------|----------------------|--------------------------|-------------------|-------------|
+| `gemma-4-26b-a4b-it-4bit` | 26B | 0.5 (4bit) | **13 GB** | **~15 GB** | **Underestimates ~2 GB** — MoE stores all experts resident; mixed 4/8-bit slices add overhead |
+| `gpt-oss-20b-MXFP4-Q8` | 20B | 1.0 (`-q8` match) | **20 GB** | **~11 GB** | **Overestimates ~9 GB** — `-q8` suffix is misleading for MXFP4; actual footprint matches MXFP4 MoE residency |
+
+`ModelFit` would mark both as `.fits` on 32 GB, but **admission heuristics derived only from name parsing will be wrong-direction for each MoE variant** (Gemma: false comfort; gpt-oss: false rejection). Catalog `min_ram_gb` should remain operator-curated, not `ModelFit`-derived, for MoE rows.
+
+---
+
+## Autotune 32 GB headroom check
+
+Gate (`AutotuneRecommend.swift:898`): `safetyMarginGB = 4` → eligible when `min_ram_gb ≤ memoryGB − 4` → **≤ 28 GB** on this machine.
+
+| Candidate | Measured resident | Implied RAM need (resident + 4 GB margin) | Fits 32 GB with ≥4 GB headroom? |
+|-----------|-------------------|-------------------------------------------|----------------------------------|
+| Gemma-4 | ~15 GB | ~19 GB | **Yes** — ~13 GB headroom after weights (OS + KV still tight under concurrent load) |
+| gpt-oss-20b | ~11 GB | ~15 GB | **Yes** — comfortable on 32 GB |
+
+---
+
+## Recommended `min_ram_gb` for Gemma-4 catalog row
+
+| Tier | Recommendation | Rationale |
+|------|----------------|-----------|
+| **Measured floor** | 24 GB | Weights ~15 GB + minimal OS/KV; matches MoE-small-active class |
+| **Recommended publish** | **28 GB** | Aligns with autotune gate on 32 GB Tier-C (`32 − 4`); leaves ~13 GB for OS + KV on observed 15 GB weights |
+| **Conservative (RESEARCH_227)** | 32 GB | Operator-safe for multi-app Macs and future KV growth |
+
+**Suggested catalog value:** **`min_ram_gb: 28`** for `google/gemma-4-26b-a4b-it` on 32 GB Tier-C fleet; keep **32 GB** if operator prefers RESEARCH_227 conservative posture.
+
+---
+
+## Verdict: **GREEN**
+
+| Criterion | Result |
+|-----------|--------|
+| Gemma-4 resident ≤ 18 GB | **PASS** (~15 GB) |
+| 32 GB load + 4K probe without swap (clean baseline) | **PASS** (swap decreased; gen completed) |
+| Pinned mlx-swift-lm 3.31.4 fits with ≥4 GB autotune headroom on 32 GB | **PASS** (~13 GB remaining after ~15 GB weights) |
+| OOM / hard load failure | **None observed** |
+
+---
+
+## One-line impact
+
+- **P1-01 / Gemma bench matrix:** **Unblocked** — memory parity confirmed on 32 GB M5.
+- **P0-04 (Gemma template probe):** **Unblocked** — prerequisite P0-01 is GREEN.
+
+---
+
+## Raw bench artifacts (local)
+
+| Artifact | Path |
+|----------|------|
+| Gemma JSON | `/tmp/p0-01-gemma4-primary.json` |
+| gpt-oss JSON (clean delta) | `/tmp/p0-01-gpt-oss-control.json` (first run) |
+| Bench script | `/tmp/p0-01-moe-bench.sh` |
+| Serve logs | `/tmp/p0-01-gemma4-primary.log.serve`, `/tmp/p0-01-gpt-oss-control-r2.log.serve` |

--- a/beta/catalog-expansion/P0-02-tier2-catalog-snapshot-rerun.md
+++ b/beta/catalog-expansion/P0-02-tier2-catalog-snapshot-rerun.md
@@ -1,0 +1,87 @@
+# P0-02 re-run — Production tier-2 vs autotune catalog diff
+
+**Task:** P0-02 re-run after P0-06 tier-2 republish  
+**Pull timestamp (UTC):** 2026-07-07T06:12:30Z  
+**Trigger:** P0-06 deploy of `macprovider-tier2-model-catalog-2026-07-07`  
+**Prior artifact:** `beta/catalog-expansion/P0-02-tier2-catalog-snapshot.md` (RED)
+
+---
+
+## Sources
+
+| Source | URL / path | Result |
+|--------|------------|--------|
+| Live autotune | `https://coordinator.streamvc.live/static/autotune-candidates.json` | HTTP 200 |
+| Live tier-2 | `https://coordinator.streamvc.live/catalog/current` | HTTP 200 |
+| Pearl on-disk | `/opt/macprovider/tier2-catalog.json` | Updated 2026-07-07T06:12:04Z (P0-06 deploy) |
+
+---
+
+## Live autotune catalog
+
+| Field | Value |
+|-------|-------|
+| **version** | `published-2026-07-06-mbase-lite` |
+| **generated_at** | `2026-07-06T11:45:00Z` |
+| **recommendable row count** | 7 |
+
+Unchanged from initial P0-02 pull.
+
+---
+
+## Production tier-2 catalog (`GET /catalog/current`)
+
+| Field | Value |
+|-------|-------|
+| **catalog_id** | `macprovider-tier2-model-catalog-2026-07-07` |
+| **issued_at** | `2026-07-07T00:00:00Z` |
+| **expires_at** | `2026-10-07T00:00:00Z` |
+| **model count** | 7 |
+| **signature** | Ed25519, `key_id=catalog-key-2026q2` (sig redacted) |
+
+### Tier-2 model entries
+
+| model_id | sha256 | min_ram_gb |
+|----------|--------|------------|
+| `mlx-community/gpt-oss-20b-MXFP4-Q8` | `f25592861e0b7f4eb8489d9103214f3f0dc4f798bb0e4e0cd817ff2f4191f1b1` | 24 |
+| `mlx-community/Llama-3.2-3B-Instruct-4bit` | `3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a` | 4 |
+| `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` | `67b26d6b1c50dc8836ab3705b06276a43c74c8f66247f9b112e232b58abbd99f` | 12 |
+| `mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit` | `1bc78f214f9a042eaeb290b1fa4cb29915df1028f79d8479266349166c40a71f` | 32 |
+| `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | `b7749cc57f37f7e9239d0f9b091bcffe6d7629e48af75e8cb84c1cdca1780973` | 48 |
+| `mlx-community/Qwen3-32B-4bit` | `69169cceb643f108755f96dba26d8647862e38a7f82cb1b5b25aff8f204967aa` | 48 |
+| `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | `10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0` | 28 |
+
+---
+
+## Diff summary (autotune recommendable ↔ tier-2 by `model_id`)
+
+| Metric | Count |
+|--------|-------|
+| Autotune recommendable | 7 |
+| Tier-2 models | 7 |
+| Full match (sha256 + min_ram_gb) | **7** |
+| Autotune-only (missing from tier-2) | **0** |
+| Tier-2-only orphans | **0** |
+| SHA or min_ram_gb mismatch | **0** |
+
+### Resolved from prior RED
+
+| Issue (P0-02 initial) | Re-run status |
+|-----------------------|---------------|
+| 6 autotune-only models absent from tier-2 | **Fixed** — all 7 present |
+| Llama-3.2-3B SHA mismatch (`3975387f…` vs `0baf1371…`) | **Fixed** — autotune hash served |
+| Orphan `Qwen2.5-7B-Instruct-4bit` | **Removed** (operator decision: retire) |
+| Orphan `Qwen2.5-Coder-7B-Instruct-4bit` | **Removed** (operator decision: retire) |
+
+---
+
+## Verdict: **GREEN**
+
+| Criterion | Assessment |
+|-----------|------------|
+| All 7 live recommendable keys listed with hashes | **Pass** |
+| No orphan tier-2-only rows without explanation | **Pass** |
+| No SHA mismatch on live models present in both catalogs | **Pass** |
+| Gemma-4 split-brain | **Pass** — not present in tier-2 |
+
+**P0-02 re-run: GREEN** — tier-2 aligned to live autotune; G2 block cleared.

--- a/beta/catalog-expansion/P0-02-tier2-catalog-snapshot.md
+++ b/beta/catalog-expansion/P0-02-tier2-catalog-snapshot.md
@@ -1,0 +1,149 @@
+# P0-02 — Production tier-2 vs autotune catalog diff
+
+**Task:** P0-02 (Model Catalog Expansion Runbook)  
+**Pull timestamp (UTC):** 2026-07-07T06:05:58Z  
+**Executor:** read-only fetch (no deploys, no secrets)
+
+---
+
+## Sources
+
+| Source | URL / path | Result |
+|--------|------------|--------|
+| Live autotune | `https://coordinator.streamvc.live/static/autotune-candidates.json` | HTTP 200 |
+| Live tier-2 (preferred API) | `https://coordinator.streamvc.live/catalog/current` | HTTP 200 — signed catalog served |
+| Tier-2 pubkey | `https://coordinator.streamvc.live/catalog/pubkey` | HTTP 200 — Ed25519 pubkey only (redacted below) |
+| Pearl VPS SSH | `/opt/macprovider/tier2-catalog.json` | Not attempted (no SSH in this session) |
+| Repo deploy hint | `phase4-coordinator/dist/coordinator.yaml:202` → `/opt/macprovider/tier2-catalog.json` | Confirms on-disk path; `/catalog/current` is the read-only equivalent |
+| Local autotune copy | `phase3-binary/dist/static/autotune-candidates.json` | Byte-identical to live fetch at pull time |
+
+---
+
+## Live autotune catalog
+
+| Field | Value |
+|-------|-------|
+| **version** | `published-2026-07-06-mbase-lite` |
+| **generated_at** | `2026-07-06T11:45:00Z` |
+| **recommendable row count** | 7 |
+
+### Recommendable rows (runtime_status = `"recommendable"`)
+
+| catalog_key | model_id | model_revision | model_sha256 | min_ram_gb |
+|-------------|----------|----------------|--------------|------------|
+| `qwen3-coder-30b-a3b-instruct` | `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | `6e302ea604ad9ab206367e2c501d1571023e7b6d` | `10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0` | 28 |
+| `openai/gpt-oss-20b` | `mlx-community/gpt-oss-20b-MXFP4-Q8` | `773a7da77e569019bb0fd17a554b263738d669a3` | `f25592861e0b7f4eb8489d9103214f3f0dc4f798bb0e4e0cd817ff2f4191f1b1` | 24 |
+| `meta-llama/llama-3.1-8b-instruct` | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` | `241a666dad6cb93c8ff213d39a7f34a36bf26db4` | `67b26d6b1c50dc8836ab3705b06276a43c74c8f66247f9b112e232b58abbd99f` | 12 |
+| `qwen3-32b` | `mlx-community/Qwen3-32B-4bit` | `bcaaf7f538adf166c1080a2befdb4f6019f66639` | `69169cceb643f108755f96dba26d8647862e38a7f82cb1b5b25aff8f204967aa` | 48 |
+| `qwen2.5-coder-32b-instruct` | `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | `d1e3b690c8e225d7795bccddf971ca6be68b2012` | `b7749cc57f37f7e9239d0f9b091bcffe6d7629e48af75e8cb84c1cdca1780973` | 48 |
+| `nvidia/nemotron-3-nano-30b-a3b` | `mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit` | `832f602eba5d22436c258c1462bdedc5afddb42b` | `1bc78f214f9a042eaeb290b1fa4cb29915df1028f79d8479266349166c40a71f` | 32 |
+| `meta-llama/llama-3.2-3b-instruct` | `mlx-community/Llama-3.2-3B-Instruct-4bit` | `7f0dc925e0d0afb0322d96f9255cfddf2ba5636e` | `3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a` | 4 |
+
+No non-`recommendable` rows in the live feed at pull time.
+
+---
+
+## Production tier-2 catalog (`GET /catalog/current`)
+
+| Field | Value |
+|-------|-------|
+| **catalog_id** | `macprovider-tier2-model-catalog-2026-05-31` |
+| **issued_at** | `2026-05-31T00:00:00Z` |
+| **expires_at** | `2026-08-31T00:00:00Z` |
+| **model count** | 3 |
+| **signature** | Ed25519, `key_id=catalog-key-2026q2` (sig redacted) |
+| **pubkey fingerprint** | Ed25519 pubkey served at `/catalog/pubkey` (not reproduced here) |
+
+### Tier-2 model entries
+
+| model_id | sha256 | min_ram_gb |
+|----------|--------|------------|
+| `mlx-community/Qwen2.5-7B-Instruct-4bit` | `c3b0ec86f9a59fb8416f2e037def2ed17ca012173461cd98d7b8b8da7d325e54` | 16 |
+| `mlx-community/Llama-3.2-3B-Instruct-4bit` | `0baf13715db1eeb56e6d0806b0d764aa1c44497aaaaf8d2ba90c21128d9fe2fe` | 8 |
+| `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit` | `1e1dbaad7ef9b5df4c4157ee1e13408a7d4386de57911f41deccb3171438e204` | 16 |
+
+All entries use `artifact_kind=mlx_weight_file`, `hash_scope=artifact_manifest`, `source=operator-curated`.
+
+---
+
+## Diff table (autotune recommendable ↔ tier-2 by `model_id`)
+
+Join key: `model_id` (tier-2 has no catalog_key field; see `phase4-coordinator/internal/tier2/catalog.go:32–40`).
+
+| catalog_key | model_id | autotune_sha256 | tier2_sha256 | match | min_ram_gb (autotune / tier2) | notes |
+|-------------|----------|-----------------|--------------|-------|-------------------------------|-------|
+| `qwen3-coder-30b-a3b-instruct` | `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | `10adb5da…ab9c0` | — | **N** | 28 / — | autotune-only; absent from tier-2 |
+| `openai/gpt-oss-20b` | `mlx-community/gpt-oss-20b-MXFP4-Q8` | `f2559286…1f1b1` | — | **N** | 24 / — | autotune-only; absent from tier-2 |
+| `meta-llama/llama-3.1-8b-instruct` | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` | `67b26d6b…bd99f` | — | **N** | 12 / — | autotune-only; absent from tier-2 |
+| `qwen3-32b` | `mlx-community/Qwen3-32B-4bit` | `69169cce…967aa` | — | **N** | 48 / — | autotune-only; absent from tier-2 |
+| `qwen2.5-coder-32b-instruct` | `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | `b7749cc5…80973` | — | **N** | 48 / — | autotune-only; absent from tier-2 |
+| `nvidia/nemotron-3-nano-30b-a3b` | `mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit` | `1bc78f21…0a71f` | — | **N** | 32 / — | autotune-only; absent from tier-2 |
+| `meta-llama/llama-3.2-3b-instruct` | `mlx-community/Llama-3.2-3B-Instruct-4bit` | `3975387f…7216a` | `0baf1371…fe2fe` | **N** | 4 / 8 | **SHA mismatch** on sole overlapping live model; autotune re-signed 2026-07-06 (rev `7f0dc925`), tier-2 still carries pre-expansion manifest |
+
+Full SHA-256 values (no truncation):
+
+| catalog_key | autotune_sha256 | tier2_sha256 |
+|-------------|-----------------|--------------|
+| `meta-llama/llama-3.2-3b-instruct` | `3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a` | `0baf13715db1eeb56e6d0806b0d764aa1c44497aaaaf8d2ba90c21128d9fe2fe` |
+
+---
+
+## Orphan / split-brain findings
+
+### In autotune only (6 of 7 live recommendable models)
+
+These models are **recommendable in the live autotune feed** but have **no tier-2 row**:
+
+- `qwen3-coder-30b-a3b-instruct`
+- `openai/gpt-oss-20b`
+- `meta-llama/llama-3.1-8b-instruct`
+- `qwen3-32b`
+- `qwen2.5-coder-32b-instruct`
+- `nvidia/nemotron-3-nano-30b-a3b`
+
+Providers following autotune can download and serve these; tier-2 hash verification / buyer pricing manifest does not cover them until tier-2 is republished.
+
+### In tier-2 only (orphan / legacy split-brain)
+
+These tier-2 rows have **no matching recommendable autotune catalog_key**:
+
+| model_id | tier2_sha256 | min_ram_gb | risk |
+|----------|--------------|------------|------|
+| `mlx-community/Qwen2.5-7B-Instruct-4bit` | `c3b0ec86f9a59fb8416f2e037def2ed17ca012173461cd98d7b8b8da7d325e54` | 16 | tier-2-only legacy row (May 2026 catalog) |
+| `mlx-community/Qwen2.5-Coder-7B-Instruct-4bit` | `1e1dbaad7ef9b5df4c4157ee1e13408a7d4386de57911f41deccb3171438e204` | 16 | tier-2-only legacy row (May 2026 catalog) |
+
+### Gemma-4 flag
+
+| Check | Result |
+|-------|--------|
+| `google-gemma-4-26b-a4b-it` in tier-2 | **No** |
+| Any `gemma-4*` / `gemma4` MLX ID in tier-2 | **No** |
+| Gemma in live autotune recommendable feed | **No** (not present in live rows) |
+
+No Gemma-4 split-brain at pull time. Gemma remains a future P1 target per runbook; not blocked by tier-2/autotune divergence today.
+
+---
+
+## Staleness summary
+
+| Dimension | Autotune | Tier-2 |
+|-----------|----------|--------|
+| Catalog age | 2026-07-06 (`published-2026-07-06-mbase-lite`) | 2026-05-31 (`macprovider-tier2-model-catalog-2026-05-31`) |
+| Model count | 7 recommendable | 3 signed entries |
+| Overlap | 1 model_id shared (`Llama-3.2-3B-Instruct-4bit`) | Same |
+| Hash agreement on overlap | **Fail** — different manifest SHA-256 and `min_ram_gb` (4 vs 8) |
+
+Tier-2 was **reachable** via `/catalog/current` (not YELLOW-waivable for unreachable tier-2). The failure mode is **content drift**, not availability.
+
+---
+
+## Verdict: **RED**
+
+| Criterion | Assessment |
+|-----------|------------|
+| All 7 live recommendable keys listed with hashes | **Pass** (documented above) |
+| No orphan tier-2-only rows without explanation | **Fail** — 2 legacy 7B rows unexplained relative to live autotune |
+| No SHA mismatch on live models present in both catalogs | **Fail** — `Llama-3.2-3B-Instruct-4bit` SHA mismatch |
+| Gemma-4 split-brain | **Pass** — not present in tier-2 |
+
+**Action before new catalog publishes (per runbook G2):** Re-sign and deploy an updated `tier2-catalog.json` aligned to the live autotune manifest hashes (all 7 recommendable `model_id` + SHA-256 + `min_ram_gb`), retire or explicitly document legacy 7B tier-2 rows, and re-run P0-02 for GREEN.

--- a/beta/catalog-expansion/P0-03-hf-weights-audit.md
+++ b/beta/catalog-expansion/P0-03-hf-weights-audit.md
@@ -1,0 +1,118 @@
+# P0-03 — HuggingFace MLX weight availability (flagship candidates)
+
+**Task:** P0-03 (Model Catalog Expansion Runbook)  
+**Date:** 2026-07-07  
+**Executor:** read-only HF API audit (no downloads, no catalog/code changes)
+
+---
+
+## Registry reference (mlx-swift-lm 3.31.4 pin)
+
+Expected `model_type` values per `LLMModelFactory.swift:26–87`:
+
+| Catalog target | Expected `model_type` | Registry line |
+|----------------|----------------------|---------------|
+| `gpt-oss-120b` | `gpt_oss` | 71 |
+| `gemma-4-31b-4bit` | `gemma4` / `gemma4_text` | 38–40 |
+| `qwen3-next-80b-a3b` | `qwen3_next` | 44 |
+
+---
+
+## Summary table
+
+| Target | Repo ID | Revision | Size (GB) | `model_type` | Registry Y/N | License | Verdict | Notes |
+|--------|---------|----------|-----------|--------------|--------------|---------|---------|-------|
+| `gpt-oss-120b` | [mlx-community/gpt-oss-120b-4bit](https://huggingface.co/mlx-community/gpt-oss-120b-4bit) | `08e7899579b5dd5e0364e4bcd32578134072e22d` | **65.77** | `gpt_oss` | **Y** | Apache-2.0 | **GREEN** | MoE 128 experts × 4 active/tok; est. resident **~66–70 GB** (+ KV). Alt: `gpt-oss-120b-MXFP4-Q4` (62.33 GB, rev `bce781be…`). |
+| `gemma-4-31b-4bit` | [mlx-community/gemma-4-31b-it-4bit](https://huggingface.co/mlx-community/gemma-4-31b-it-4bit) | `696d436c404745a59f30e4939a658162b0a9e57f` | **18.41** | `gemma4` (top); `text_config.model_type` = `gemma4_text` | **Y** | Apache-2.0 | **GREEN** | Dense text backbone (`enable_moe_block: false`); packaged as VLM (`Gemma4ForConditionalGeneration`). Est. resident **~17–20 GB** (31B×0.5 + vision tower). Base (non-IT) twin: `gemma-4-31b-4bit` same size/rev family. |
+| `qwen3-next-80b-a3b` | [mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit](https://huggingface.co/mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit) | `d8a069bfa8ae87d3d468412e1034acae19b5892b` | **44.84** | `qwen3_next` | **Y** | Apache-2.0 | **GREEN** | MoE 512 experts × 10 active/tok; full expert residency. Est. resident **~40–45 GB** (+ KV). Matches RESEARCH_226 range. |
+
+---
+
+## Per-target detail
+
+### 1. `gpt-oss-120b`
+
+**Search:** `mlx-community/*gpt-oss-120*` → 4 mlx-community repos (4bit, MXFP4-Q4/Q8, etc.).  
+**Fallback:** `lmstudio-community/gpt-oss-120b-MLX-8bit` (8-bit only; no 4bit lmstudio variant).
+
+**Primary candidate:** `mlx-community/gpt-oss-120b-4bit`
+
+| Field | Value |
+|-------|-------|
+| Revision | `08e7899579b5dd5e0364e4bcd32578134072e22d` |
+| Safetensors | 13 shards, **65.77 GB** total |
+| `config.json` → `model_type` | `gpt_oss` |
+| `architectures` | `["GptOssForCausalLM"]` |
+| MoE topology | 36 layers; `num_local_experts: 128`; `num_experts_per_tok: 4` |
+| Quantization | 4-bit affine, `group_size: 64` |
+| License | Apache-2.0 |
+| Registry | `gpt_oss` registered at `LLMModelFactory.swift:71` |
+
+**Resident estimate:** MoE loads all 128 experts → disk size ≈ resident weights (~66 GB) + KV/activations. Aligns with runbook P4-01 estimate 60–70 GB. Min machine: M4 Max 64 GB (tight) or M3 Ultra 96 GB.
+
+**Alternate:** `mlx-community/gpt-oss-120b-MXFP4-Q4` — 62.33 GB, `model_type: gpt_oss`, rev `bce781bef0f2fc85ed4e575af74054f5aad73ddd`.
+
+---
+
+### 2. `gemma-4-31b-4bit` (dense)
+
+**Search:** `mlx-community/*gemma-4-31b*` → 20+ repos (4/5/6/8bit, IT and base, QAT, MXFP4).  
+**Fallback:** `lmstudio-community/gemma-4-31B-it-MLX-4bit` exists (same arch family).
+
+**Primary candidate:** `mlx-community/gemma-4-31b-it-4bit` (highest downloads among 4bit variants)
+
+| Field | Value |
+|-------|-------|
+| Revision | `696d436c404745a59f30e4939a658162b0a9e57f` |
+| Safetensors | 4 shards, **18.41 GB** total |
+| `config.json` → `model_type` | `gemma4` (wrapper) |
+| `text_config.model_type` | `gemma4_text` |
+| `text_config.enable_moe_block` | `false` (dense) |
+| `text_config.num_hidden_layers` | 60; `hidden_size: 5376` |
+| `architectures` | `["Gemma4ForConditionalGeneration"]` |
+| Pipeline tag | `image-text-to-text` (VLM bundle includes vision encoder) |
+| Quantization | 4-bit affine, `group_size: 64` |
+| License | Apache-2.0 |
+| Registry | `gemma4`, `gemma4_text`, `gemma4_unified` at `LLMModelFactory.swift:38–40` |
+
+**Resident estimate:** Dense 31B at ~0.5 B/param ≈ **15.5 GB** text weights; total checkpoint 18.4 GB implies ~3 GB vision/multimodal overhead. Text-only serve path should use `gemma4_text` sub-config. Est. resident **~17–20 GB** on 48 GB tier (P4-03).
+
+**Note:** No separate text-only MLX repo found; all `gemma-4-31b*` mlx-community checkpoints use the VLM wrapper with dense text backbone. Acceptable for P4 bench — P0-04 must validate chat template on text path.
+
+---
+
+### 3. `qwen3-next-80b-a3b`
+
+**Search:** `mlx-community/*Qwen3-Next-80B*` → 4 repos (4/5/6/8bit).  
+**Fallback:** none required (mlx-community primary sufficient).
+
+**Primary candidate:** `mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit`
+
+| Field | Value |
+|-------|-------|
+| Revision | `d8a069bfa8ae87d3d468412e1034acae19b5892b` |
+| Safetensors | 9 shards, **44.84 GB** total |
+| `config.json` → `model_type` | `qwen3_next` |
+| `architectures` | `["Qwen3NextForCausalLM"]` |
+| MoE topology | 48 layers; `num_experts: 512`; `num_experts_per_tok: 10` |
+| Quantization | 4-bit affine (gate layers 8-bit per-layer overrides) |
+| License | Apache-2.0 |
+| Registry | `qwen3_next` registered at `LLMModelFactory.swift:44` |
+
+**Resident estimate:** Full 512-expert residency → **~40–45 GB** weights (+ KV). Matches RESEARCH_226 SCN-226-04 and runbook P4-02. Tier-A 64 GB minimum.
+
+---
+
+## Cross-check: weights without registry (none found)
+
+All three primary repos declare `model_type` values present in pinned `LLMTypeRegistry`. No case of weights-on-disk with missing/wrong type requiring arch work before P4 bench.
+
+---
+
+## Overall verdict
+
+### **GREEN**
+
+All three flagship candidates have ≥1 `mlx-community` repo with MLX safetensors, verified `config.json` `model_type`, and registry match. P4 bench (P4-01, P4-02, P4-03) is **unblocked on HF weight availability**; hardware tier and runtime validation remain gating.
+
+**Recommendation:** Proceed to P4 bench planning on documented repos above. Gemma-4 path should pair with P0-04 template probe before catalog publish.

--- a/beta/catalog-expansion/P0-04-gemma4-template-probe.md
+++ b/beta/catalog-expansion/P0-04-gemma4-template-probe.md
@@ -1,0 +1,198 @@
+# P0-04 — Gemma-4 chat template / OpenAI API compatibility
+
+**Task:** P0-04 (Model Catalog Expansion Runbook)  
+**Date:** 2026-07-07  
+**Executor:** runtime probe only (no catalog/code changes)  
+**MLX pin:** `mlx-swift-lm` 3.31.4, rev `bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57` (`phase3-binary/Package.resolved`)
+
+---
+
+## Hardware & binary
+
+| Field | Value |
+|-------|-------|
+| **Machine** | MacBook Air (Mac17,3) |
+| **Chip** | Apple M5 |
+| **Unified RAM** | 32 GB |
+| **OS** | macOS 26.5 (25F71) |
+| **macprovider-cli** | **1.8.16** (release build: `phase3-binary/.build/release/macprovider-cli`) |
+| **Model cache** | `~/Library/Caches/models/mlx-community/gemma-4-26b-a4b-it-4bit` (~15 GB on disk) |
+| **Load path** | `serve --no-join` → `LLMModelFactory.shared.loadContainer` + `#huggingFaceTokenizerLoader()` (`ModelRuntime.swift:1887–1890`) |
+
+### Serve command
+
+Port **8080** was occupied by a local `node` process; probe used **18080**.
+
+```bash
+cd phase3-binary
+./.build/release/macprovider-cli serve \
+  --no-join \
+  --model mlx-community/gemma-4-26b-a4b-it-4bit \
+  --port 18080 \
+  --log-level info
+```
+
+**Ready signal:** `GET http://127.0.0.1:18080/v1/models` returned the model list after ~2 min load + idle prewarm.
+
+**Serve log:** `/tmp/p0-04-gemma4-serve.log`
+
+---
+
+## Probe results
+
+### Probe A — single-turn arithmetic
+
+| Check | Result |
+|-------|--------|
+| **HTTP status** | **200** |
+| **Request (truncated)** | `{"role":"user","content":"What is 17 + 25? Reply with just the number."}` |
+| **Response content** | `42\n` |
+| **finish_reason** | `stop` |
+| **Template leakage** | **N** |
+| **Arithmetic** | **PASS** (42) |
+| **Stop behavior** | Natural stop at 3 completion tokens |
+
+Raw: `/tmp/p0-04-probe-a.json`
+
+---
+
+### Probe B — multi-turn system + user + assistant
+
+| Check | Result |
+|-------|--------|
+| **HTTP status** | **200** |
+| **Request (truncated)** | system → user (France capital) → assistant (Paris) → user ("And Germany?") |
+| **Response content** | `Berlin is the capital of Germany.` |
+| **finish_reason** | `stop` |
+| **Template leakage** | **N** |
+| **Multi-turn** | **PASS** (Berlin) |
+| **Stop behavior** | Natural stop at 7 completion tokens |
+
+Raw: `/tmp/p0-04-probe-b.json`
+
+---
+
+### Probe C — JSON-style smoke (no tools)
+
+| Check | Result |
+|-------|--------|
+| **HTTP status** | **200** |
+| **Request (truncated)** | `{"role":"user","content":"Return a JSON object with keys \"color\" and \"count\" for: three red apples."}` |
+| **Response content** | ` ```json\n{\n  "color": "red",\n  "count": 3\n}\n``` ` |
+| **finish_reason** | `stop` |
+| **Template leakage** | **N** |
+| **JSON shape** | Correct keys/values; wrapped in markdown fences (cosmetic only) |
+| **Stop behavior** | Natural stop at 20 completion tokens |
+
+Raw: `/tmp/p0-04-probe-c.json`
+
+---
+
+### Streaming — Probe A repeat
+
+| Check | Result |
+|-------|--------|
+| **HTTP status** | **200** (SSE) |
+| **SSE parse** | Valid `data:` chunks + `[DONE]` |
+| **Reassembled delta** | `42\n` (chunks: `4`, `2`, `\n`) |
+| **finish_reason** | `stop` on final chunk |
+| **Template leakage** | **N** |
+
+Raw: `/tmp/p0-04-probe-a-stream.txt`
+
+Provider log:
+
+```json
+{"event":"kv_cache_request_completed","model_id":"mlx-community/gemma-4-26b-a4b-it-4bit","prompt_tokens":24,"completion_tokens":3,"finish_reason":"stop","stream":true}
+```
+
+---
+
+## Evaluation checklist (rollup)
+
+| Check | A | B | C | Stream A |
+|-------|---|---|---|----------|
+| HTTP 200 | ✓ | ✓ | ✓ | ✓ |
+| Non-empty `choices[0].message.content` | ✓ | ✓ | ✓ | ✓ (deltas) |
+| No template leakage | ✓ | ✓ | ✓ | ✓ |
+| Natural stop / no repetition | ✓ | ✓ | ✓ | ✓ |
+| Task-specific correctness | 42 ✓ | Berlin ✓ | JSON ✓ | 42 ✓ |
+| Crash / OOM | None | None | None | None |
+
+**Leakage patterns checked:** `<start_of_turn>`, `<end_of_turn>`, `<bos>`, `<eos>`, `user\n`, `model\n`, `<|turn>`, `<turn|>`, tool-call tokens — **none present in any assistant output**.
+
+---
+
+## Tokenizer / stop-token findings
+
+### Local snapshot (`tokenizer_config.json`)
+
+| Token key | Value | Notes |
+|-----------|-------|-------|
+| `bos_token` | `<bos>` | Picked up by `StopTokenConfigExtractor` |
+| `eos_token` | `<eos>` | Picked up by `StopTokenConfigExtractor` |
+| `sot_token` | `<\|turn>` | Gemma-4 turn start (legacy Gemma used `<start_of_turn>`) |
+| `eot_token` | `<turn\|>` | Gemma-4 turn end (legacy Gemma used `<end_of_turn>`) |
+| `chat_template` | **absent** | Chat formatting delegated to mlx-swift-lm `Gemma4Processor` / factory |
+| `processor_class` | `Gemma4Processor` | Multimodal-capable processor schema present |
+
+### `config.json` EOS IDs
+
+```json
+"eos_token_id": [1, 106, 50]
+```
+
+Multiple EOS IDs (includes turn-end semantics). Generation stopped cleanly on all probes with `finish_reason: stop` — mlx-swift-lm handles stop IDs at decode time; MacProvider output filter (`StopTokenFilter` via `StopTokenConfigExtractor`, `ModelRuntime.swift:416–421`) strips `<bos>`/`<eos>` only and did not need `<turn|>` stripping in observed outputs.
+
+### `extraEOSTokens` in ModelConfiguration
+
+Not required for this probe. No garbled or runaway generations observed; no evidence that MacProvider must add Gemma-4-specific `extraEOSTokens` before P1.
+
+### Darkbloom behavioral compare
+
+**Not run** — no reachable reference API configured in this session.
+
+---
+
+## Verdict: **GREEN**
+
+| Criterion | Result |
+|-----------|--------|
+| Clean assistant text on 3 prompt shapes | **PASS** |
+| Stable stops (`finish_reason: stop`) | **PASS** |
+| No template / special-token leakage | **PASS** |
+| No crash on 32 GB M5 | **PASS** |
+| Streaming SSE path | **PASS** |
+
+**Minor note (non-blocking):** Probe C wraps JSON in markdown code fences — common model formatting, not a template bug. No workaround required for P1.
+
+---
+
+## Recommended fix (if YELLOW/RED)
+
+N/A — probe GREEN. No code changes indicated.
+
+---
+
+## One-line impact on P1
+
+- **P1-01 (Gemma bench matrix):** **Unblocked** — chat completions path validated; can proceed alongside catalog work.
+- **P1-03 (catalog rollout):** **Unblocked** — OpenAI-compatible `/v1/chat/completions` produces usable assistant text for Gemma-4 on pinned mlx-swift-lm 3.31.4.
+
+---
+
+## P0 rollup / G0
+
+With P0-04 **GREEN**, all six P0 tasks (P0-01, P0-02, P0-03, P0-04, P0-05, P0-06) have GREEN artifacts. **G0 can close** pending pinned-session verification and `P0_SUMMARY.md` rollup.
+
+---
+
+## Raw artifacts (local)
+
+| Artifact | Path |
+|----------|------|
+| Serve log | `/tmp/p0-04-gemma4-serve.log` |
+| Probe A | `/tmp/p0-04-probe-a.json` |
+| Probe B | `/tmp/p0-04-probe-b.json` |
+| Probe C | `/tmp/p0-04-probe-c.json` |
+| Stream A | `/tmp/p0-04-probe-a-stream.txt` |

--- a/beta/catalog-expansion/P0-05-nemotron-model-type.md
+++ b/beta/catalog-expansion/P0-05-nemotron-model-type.md
@@ -1,0 +1,89 @@
+# P0-05 — Nemotron-3-Nano `model_type` verification
+
+**Task:** P0-05 (Model Catalog Expansion Runbook)  
+**Date:** 2026-07-07  
+**Executor:** read-only investigation (no catalog/code changes)
+
+---
+
+## HuggingFace source
+
+| Field | Value |
+|-------|-------|
+| **Repo** | [mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit](https://huggingface.co/mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit) |
+| **Revision** | `832f602eba5d22436c258c1462bdedc5afddb42b` |
+| **config.json URL** | https://huggingface.co/mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit/raw/832f602eba5d22436c258c1462bdedc5afddb42b/config.json |
+
+Matches live catalog row `nvidia/nemotron-3-nano-30b-a3b` in `phase3-binary/dist/static/autotune-candidates.json`.
+
+---
+
+## `config.json` — architecture fields
+
+| Field | Value |
+|-------|-------|
+| **`model_type`** | **`nemotron_h`** |
+| `architectures` | `["NemotronHForCausalLM"]` |
+| `auto_map.AutoModelForCausalLM` | `modeling_nemotron_h.NemotronHForCausalLM` |
+| `hybrid_override_pattern` | `MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME` (Mamba + attention + MoE hybrid) |
+| `n_routed_experts` | 128 |
+| `num_experts_per_tok` | 6 |
+| `n_shared_experts` | 1 |
+| `moe_intermediate_size` | 1856 |
+| `moe_shared_expert_intermediate_size` | 3712 |
+| `num_hidden_layers` | 52 |
+| `hidden_size` | 2688 |
+| `quantization` | 4-bit affine, group_size 64 |
+
+**Not** `afmoe`, `qwen3_moe`, or `bailing_moe` — the HF config declares the dedicated hybrid type `nemotron_h`.
+
+---
+
+## Registry match (mlx-swift-lm 3.31.4)
+
+| Field | Value |
+|-------|-------|
+| **Pinned package** | `mlx-swift-lm` exact `3.31.4` (`Package.swift:21–22`) |
+| **Resolved revision** | `bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57` (`Package.resolved`) |
+| **Registry file** | `phase3-binary/.build/checkouts/mlx-swift-lm/Libraries/MLXLLM/LLMModelFactory.swift` |
+
+**Match: YES**
+
+```79:79:phase3-binary/.build/checkouts/mlx-swift-lm/Libraries/MLXLLM/LLMModelFactory.swift
+        "nemotron_h": create(NemotronHConfiguration.self, NemotronHModel.init),
+```
+
+Supporting implementation: `Libraries/MLXLLM/Models/NemotronH.swift` (hybrid Mamba/attention/MoE blocks); `NemotronHConfiguration.modelType` defaults to `"nemotron_h"` and maps JSON key `model_type` (`NemotronH.swift:799–835`). Unit tests present: `Tests/MLXLMTests/NemotronHTests.swift`.
+
+`LLMTypeRegistry` does **not** need fallback to `afmoe` or `qwen3_moe` for this checkpoint.
+
+---
+
+## Load test (optional)
+
+| Item | Result |
+|------|--------|
+| Local HF snapshot | **Not found** (`~/.cache/huggingface`, `~/Library/Caches/huggingface`) |
+| `LLMModelFactory.shared.loadContainer` | **Not run** — weights unavailable locally |
+
+---
+
+## Catalog cross-check
+
+Live row `nvidia/nemotron-3-nano-30b-a3b`:
+
+- `runtime_status`: **`recommendable`**
+- `notes`: *"published 2026-07-06: issue 411 Nemotron runtime validated; coordinator-side rollout active; SPEC-023 v0.3 gates are advisory QoS."*
+- Static key rotation v4 (2026-07-06) documents Nemotron feed update under issue 411 (`phase3-binary/dist/static/keys/README.md`).
+
+Catalog claim of runtime validation is **consistent** with registry support for `nemotron_h`; no evidence of a false `unsupportedModelType` path for this revision.
+
+---
+
+## Verdict
+
+### **GREEN**
+
+`model_type` is **`nemotron_h`** (verbatim from HF `config.json` at revision `832f602e…`), and it is registered in pinned `mlx-swift-lm` 3.31.4 `LLMTypeRegistry` at `LLMModelFactory.swift:79`. Local load was not executed; catalog “runtime validated” note aligns with registry coverage.
+
+**Recommendation:** No hotfix required — keep `nvidia/nemotron-3-nano-30b-a3b` as recommendable; P0-05 does not block G0 on model_type grounds.

--- a/beta/catalog-expansion/P0-06-tier2-republish.md
+++ b/beta/catalog-expansion/P0-06-tier2-republish.md
@@ -1,0 +1,120 @@
+# P0-06 — Tier-2 catalog republish
+
+**Task:** P0-06 (Model Catalog Expansion Runbook)  
+**Trigger:** P0-02 RED (`beta/catalog-expansion/P0-02-tier2-catalog-snapshot.md`)  
+**Executor timestamp (UTC):** 2026-07-07T06:12:04Z  
+**Verdict:** **GREEN**
+
+---
+
+## New catalog
+
+| Field | Value |
+|-------|-------|
+| **catalog_id** | `macprovider-tier2-model-catalog-2026-07-07` |
+| **issued_at** | `2026-07-07T00:00:00Z` |
+| **expires_at** | `2026-10-07T00:00:00Z` |
+| **model count** | 7 |
+| **signature key_id** | `catalog-key-2026q2` |
+| **signature alg** | Ed25519 (sig redacted) |
+
+### Model entries (sorted by `model_id`)
+
+| model_id | sha256 | min_ram_gb |
+|----------|--------|------------|
+| `mlx-community/gpt-oss-20b-MXFP4-Q8` | `f25592861e0b7f4eb8489d9103214f3f0dc4f798bb0e4e0cd817ff2f4191f1b1` | 24 |
+| `mlx-community/Llama-3.2-3B-Instruct-4bit` | `3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a` | 4 |
+| `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` | `67b26d6b1c50dc8836ab3705b06276a43c74c8f66247f9b112e232b58abbd99f` | 12 |
+| `mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit` | `1bc78f214f9a042eaeb290b1fa4cb29915df1028f79d8479266349166c40a71f` | 32 |
+| `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | `b7749cc57f37f7e9239d0f9b091bcffe6d7629e48af75e8cb84c1cdca1780973` | 48 |
+| `mlx-community/Qwen3-32B-4bit` | `69169cceb643f108755f96dba26d8647862e38a7f82cb1b5b25aff8f204967aa` | 48 |
+| `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | `10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0` | 28 |
+
+All entries use `artifact_kind=mlx_weight_file`, `hash_scope=artifact_manifest`, `source=operator-curated`.
+
+Hashes and `min_ram_gb` values sourced from live autotune feed `published-2026-07-06-mbase-lite` at build time.
+
+---
+
+## Build and sign
+
+| Step | Result |
+|------|--------|
+| Unsigned artifact | `.omc/tier2/tier2-catalog-2026-07-07.unsigned.json` (out-of-repo) |
+| Signed artifact | `.omc/tier2/tier2-catalog-2026-07-07.signed.json` (out-of-repo) |
+| Local verify (repo pubkey) | **PASS** — `model_count=7 key_id=catalog-key-2026q2` |
+| Local verify (prod pubkey fingerprint) | **PASS** — matches `coordinator.yaml:203` (`IVH2aAlT…0U9aFQ`) |
+
+Private signing key used from `.omc/tier2/catalog-signing-key.priv` (not reproduced).
+
+---
+
+## Deploy
+
+| Field | Value |
+|-------|-------|
+| **Method** | Option B — catalog-only SCP + install (minimal blast radius) |
+| **Deploy timestamp (UTC)** | `2026-07-07T06:12:04Z` |
+| **Target host** | Pearl VPS `159.223.165.194` (`ubuntu-s-2vcpu-4gb-120gb-intel-nyc1`) |
+| **Destination** | `/opt/macprovider/tier2-catalog.json` (root:macprovider, mode 0640) |
+| **Backup** | `/opt/macprovider/tier2-catalog.json.bak-p0-06-<timestamp>` |
+| **Reload** | `systemctl kill -s HUP macprovider-coordinator` |
+| **Journal evidence** | `tier2 config reloaded` at `2026-07-07T06:12:09Z` |
+
+Full `deploy-pearl-vps.sh` not run — only catalog file replaced.
+
+---
+
+## Post-deploy verification
+
+```json
+{
+  "catalog_id": "macprovider-tier2-model-catalog-2026-07-07",
+  "issued_at": "2026-07-07T00:00:00Z",
+  "expires_at": "2026-10-07T00:00:00Z",
+  "model_count": 7,
+  "key_id": "catalog-key-2026q2"
+}
+```
+
+`GET https://coordinator.streamvc.live/catalog/current` — HTTP 200, 7 models, all SHA-256 and `min_ram_gb` match live autotune table.
+
+Previous catalog `macprovider-tier2-model-catalog-2026-05-31` (3 models) no longer served.
+
+---
+
+## Operator decisions
+
+| Decision | Outcome |
+|----------|---------|
+| Legacy tier-2-only `Qwen2.5-7B-Instruct-4bit` | **Removed** — not in live autotune recommendable feed |
+| Legacy tier-2-only `Qwen2.5-Coder-7B-Instruct-4bit` | **Removed** — not in live autotune recommendable feed |
+| Gemma-4 rows | **Not added** — P1 scope per runbook |
+| Llama-3.2-3B hash | **Fixed** — autotune `3975387f…7216a` replaces old tier-2 `0baf1371…fe2fe`; `min_ram_gb` 4 (was 8) |
+
+---
+
+## P0-02 re-run
+
+**Verdict:** **GREEN**
+
+Full re-run artifact: `beta/catalog-expansion/P0-02-tier2-catalog-snapshot-rerun.md`
+
+| Check | Result |
+|-------|--------|
+| 7/7 autotune recommendable models in tier-2 | **Pass** |
+| SHA-256 match on all shared models | **Pass** (including Llama-3.2-3B) |
+| No orphan tier-2-only rows | **Pass** |
+| No orphan autotune-only rows | **Pass** |
+
+---
+
+## Pass / fail
+
+| Criterion | Assessment |
+|-----------|------------|
+| Sign + verify OK | **Pass** |
+| Deploy OK + `/catalog/current` serves new catalog | **Pass** |
+| P0-02 re-run GREEN | **Pass** |
+
+**P0-06: GREEN** — G2 tier-2 republish block cleared for pinned session.

--- a/beta/catalog-expansion/P0_SUMMARY.md
+++ b/beta/catalog-expansion/P0_SUMMARY.md
@@ -1,0 +1,51 @@
+# P0 rollup — Model catalog expansion verification
+
+**Date:** 2026-07-07  
+**Plan:** `specs/PLAN_MODEL_CATALOG_EXPANSION_RUNBOOK.md`  
+**Gate:** **G0 PROCEED**
+
+---
+
+## Task verdicts
+
+| Task ID | Verdict | Artifact |
+|---------|---------|----------|
+| P0-01 | **GREEN** | `P0-01-moe-memory-parity.md` |
+| P0-02 | **GREEN** (after P0-06) | `P0-02-tier2-catalog-snapshot-rerun.md` (initial: RED) |
+| P0-03 | **GREEN** | `P0-03-hf-weights-audit.md` |
+| P0-04 | **GREEN** | `P0-04-gemma4-template-probe.md` |
+| P0-05 | **GREEN** | `P0-05-nemotron-model-type.md` |
+| P0-06 | **GREEN** | `P0-06-tier2-republish.md` |
+
+No WAIVED tasks.
+
+---
+
+## Key findings (actionable for P1)
+
+| Topic | Finding |
+|-------|---------|
+| **Gemma-4 memory** | ~15 GB resident on 32 GB M5; recommend `min_ram_gb: 28` |
+| **Gemma-4 TPS (P0-01)** | ~7.7 tok/s — **low confidence**; do not use for catalog gates; re-bench in P1-01 |
+| **P1-01 prerequisite** | gpt-oss sanity on clean 32 GB Mac (target ≥12 tok/s median vs catalog 15 gate) |
+| **Gemma-4 template** | `/v1/chat/completions` clean; no `extraEOSTokens` fix needed |
+| **Tier-2** | Prod `macprovider-tier2-model-catalog-2026-07-07` — 7/7 autotune aligned |
+| **Flagship weights** | gpt-oss-120b, gemma-4-31b, qwen3-next-80b MLX repos confirmed (P4) |
+| **Nemotron** | `model_type=nemotron_h`; registry OK |
+| **ModelFit** | Unreliable for MoE — keep operator-curated `min_ram_gb` |
+
+---
+
+## G0 recommendation
+
+**PROCEED** to Phase P1 (Gemma-4 unblock).
+
+**G2 partial:** tier-2 hash layer cleared; full publish still needs P1-01 + P1-02 rate card.
+
+---
+
+## Next tasks (priority order)
+
+1. **P1-01** — Clean-machine bench + **gpt-oss sanity check** → then Gemma median TPS gates (supersedes P0-01 ~7.7)
+2. **P1-02** — Rate card row for `google-gemma-4-26b-a4b-it`
+3. **P1-03** — Catalog + tier-2 + autotune publish (add 8th model)

--- a/beta/catalog-expansion/P1-gemma4-bench-matrix.md
+++ b/beta/catalog-expansion/P1-gemma4-bench-matrix.md
@@ -1,0 +1,218 @@
+# P1-01 — Gemma-4 hardware bench matrix (clean machine protocol)
+
+**Task:** P1-01 (Model Catalog Expansion Runbook v0.1.7)  
+**Date:** 2026-07-07  
+**Executor:** bench + gate proposal only (no catalog publish)  
+**MLX pin:** `mlx-swift-lm` 3.31.4, rev `bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57`  
+**Binary:** `phase3-binary/.build/release/macprovider-cli` **1.8.16** (release)
+
+---
+
+## Hardware
+
+| Field | Value |
+|-------|-------|
+| **Machine** | MacBook Air (Mac17,3) — same M5 Air as P0-01 |
+| **Chip** | Apple M5 (10 cores) |
+| **Unified RAM** | 32 GB (`sysctl hw.memsize` = 34,359,738,368) |
+| **Bandwidth tier** | Tier-C (M-Base M5) |
+| **OS** | macOS 26.5 (Build 25F71) |
+| **48 GB tier** | **Not available** on this executor — Phase D skipped |
+
+---
+
+## Phase A — Environment prep
+
+### Contamination found & cleared
+
+| Issue | Action |
+|-------|--------|
+| `macprovider-cli` on port **61919** (`qwen3-coder-30b-a3b-instruct`, coordinator-attached) | `kill -TERM` before Phase B; autotune `--drain` on each run |
+| Heavy historical swap (~18 GB used at task start) | Cleared after stopping provider; swap fell to ~1.5 GB before gpt-oss |
+| `node` on port **8080** (`antseed` buyer) | Left running (does not bind 18080); noted in snapshot |
+
+### Environment snapshot — before Phase B (gpt-oss)
+
+| Field | Value |
+|-------|-------|
+| `machdep.cpu.brand_string` | Apple M5 |
+| `hw.memsize` | 34359738368 |
+| `memory_pressure` (system free %) | **90%** |
+| `pgrep -c macprovider-cli` | **0** |
+| `vm.swapusage` | total 3072 MB, used **1516 MB**, free 1556 MB |
+| UTC timestamp | **2026-07-07T07:13:50Z** |
+| Assessment | **clean** (no macprovider providers; adequate free RAM) |
+
+### Environment snapshot — before Phase C (Gemma-4)
+
+| Field | Value |
+|-------|-------|
+| `pgrep -lf macprovider-cli` | qwen3-coder respawned on 61919 (coordinator relaunch) — cleared by `--drain` at autotune start |
+| `vm.swapusage` | total 4096 MB, used **2523 MB**, free 1573 MB |
+| `system_used_gb` (vm_stat) | **18.27 GB** used / 13.73 GB free |
+| UTC timestamp | **2026-07-07T07:29:05Z** |
+| Assessment | **acceptable** — post–gpt-oss residue; autotune completed without OOM |
+
+### Environment snapshot — after Phase C (Gemma-4)
+
+| Field | Value |
+|-------|-------|
+| `vm.swapusage` | total 4096 MB, used **2359 MB**, free 1737 MB (Δ used **−164 MB** — no swap blowout) |
+| `system_used_gb` (vm_stat) | **23.75 GB** used / 8.25 GB free |
+| UTC timestamp | **2026-07-07T07:44:36Z** |
+| OOM during run | **N** — autotune exit 0, recommendation emitted |
+
+**Logs:** `/tmp/p1-01-gpt-oss-autotune.log`, `/tmp/p1-01-gemma4-autotune.log`  
+**Autotune DB:** `/Users/augstar/.config/macprovider/autotune.sqlite`
+
+---
+
+## Phase B — Environment sanity check (gpt-oss GATE)
+
+**Command:**
+
+```bash
+cd phase3-binary
+./.build/release/macprovider-cli autotune \
+  --candidate-models mlx-community/gpt-oss-20b-MXFP4-Q8 \
+  --drain --verbose --port 18080 --stage1-replicates 3
+```
+
+**Catalog anchor:** M5 ~16.7 tok/s measured; live `min_sustained_tps: 15` (`autotune-candidates.json` → `openai/gpt-oss-20b`)
+
+| Metric | Value | Pass? |
+|--------|-------|-------|
+| **gpt-oss median TPS** | **18.3** tokens/sec | **PASS** (≥ 12) |
+| **gpt-oss p95 TTFT ms** | **1589.9** ms | **PASS** (catalog advisory 2500 ms) |
+| Environment snapshot | attached above | **clean** |
+| **run_id** | `E8BCAE39-E937-4528-A4B0-BDDF46E76C9D` | |
+| Duration | 2026-07-07T07:13:53Z → 07:29:00Z (~15 min) | |
+
+**Sanity verdict: PASS** — proceed to Gemma-4 bench.
+
+Probe shape (from DB): `target_context=2000`, `measured_prompt_tokens=1600`, `max_tokens=64`, `stage1_replicates=3`, `stage2_replicates=3`.
+
+---
+
+## Phase C — Gemma-4 bench (32 GB M5)
+
+**Command:**
+
+```bash
+./.build/release/macprovider-cli autotune \
+  --candidate-models mlx-community/gemma-4-26b-a4b-it-4bit \
+  --drain --verbose --port 18080 --stage1-replicates 3
+```
+
+| Metric | Value |
+|--------|-------|
+| **Median sustained TPS** | **12.5** tokens/sec |
+| **p95 TTFT ms** | **2610.7** ms |
+| **Replicates** | 3 (Stage2 kept trial) |
+| **Recommended knobs** | `kv_bits=8`, `max-batch=1`, `max-context=2000` |
+| **OOM / swap blowout** | **N** — swap used decreased 2523 → 2359 MB over run |
+| **Load failures** | **0** (3/3 Stage2 trials completed) |
+| **run_id** | `F5C77B30-ACA4-401F-8CE8-C37ACB48F530` |
+| Duration | 2026-07-07T07:29:06Z → 07:44:23Z (~15 min) |
+
+### Memory corroboration (P0-01 parity)
+
+| Check | P0-01 (memory task) | P1-01 (this bench) |
+|-------|---------------------|---------------------|
+| On-disk weights | ~15 GB | same cache path |
+| Idle resident Δ | ~15 GB | not re-measured idle (autotune loads/unloads); post-run system used +5.5 GB vs pre-Gemma baseline |
+| Fits 32 GB without OOM | PASS | **PASS** |
+
+P0-01 memory finding (~15 GB resident, 28 GB `min_ram_gb` recommendation) **stands**. This task replaces only the TPS figure.
+
+### Stage2 replicate detail (Gemma, kept trial bold)
+
+| Trial TPS | p95 TTFT ms | Kept |
+|-----------|-------------|------|
+| 8.48 | 18,583 | |
+| 8.67 | 4,201 | |
+| 8.49 | 4,036 | |
+| 10.45 | 4,072 | |
+| **12.53** | **2,611** | **1** |
+| 9.48 | 3,605 | |
+
+Median of kept Stage2 configuration: **12.5 tok/s** (autotune recommendation emitter).
+
+---
+
+## Supersedes P0-01 TPS — explicit retirement
+
+| Source | TPS | Status |
+|--------|-----|--------|
+| **P0-01** dev serve probe (port 61919 contamination, single 64-token sample) | **~7.7 tok/s** | **RETIRED — do not use for catalog gates** |
+| **P1-01** Stage1/autotune clean machine (this artifact) | **12.5 tok/s median** | **Authoritative for gate proposal** |
+
+The ~7.7 figure reflected a contaminated single-sample decode under a concurrent qwen3-coder provider, not Stage1 median sustained throughput. Catalog `min_sustained_tps` must derive from **12.5**, not 7.7.
+
+---
+
+## Comparison — gpt-oss vs Gemma (same machine, same session)
+
+| Model | MLX repo ID | Median TPS | p95 TTFT ms | Catalog gate TPS | Ratio Gemma/gpt-oss |
+|-------|-------------|------------|-------------|------------------|---------------------|
+| **gpt-oss-20b** (control) | `mlx-community/gpt-oss-20b-MXFP4-Q8` | **18.3** | 1589.9 | 15 | 1.00 |
+| **Gemma-4 26B A4B** | `mlx-community/gemma-4-26b-a4b-it-4bit` | **12.5** | 2610.7 | *(proposed 10)* | **0.68** |
+
+Gemma delivers ~68% of gpt-oss sustained throughput on this 32 GB M5 box — consistent with MoE active-param / memory-bandwidth class, and well above the retired P0-01 single-sample figure.
+
+---
+
+## Optional Phase D — 48 GB tier
+
+**Not executed.** Executor hardware is 32 GB M5 Air only. G1 note: runbook G1 prefers ≥2 RAM tiers for catalog publish; this artifact satisfies the **32 GB bench + gate proposal** slice of P1-01. A follow-on session on 48 GB M-Pro should repeat Phase A–C with identical protocol.
+
+---
+
+## Phase E — Proposed catalog row (advisory only)
+
+**Catalog key:** `google-gemma-4-26b-a4b-it`  
+**Do not publish in this task** — implementation belongs to P1-03.
+
+```json
+{
+  "google-gemma-4-26b-a4b-it": {
+    "model_id": "mlx-community/gemma-4-26b-a4b-it-4bit",
+    "min_ram_gb": 28,
+    "min_bandwidth_tier": "C",
+    "bench_gate": {
+      "min_sustained_tps": 10,
+      "max_4k_ttft_ms": 3000
+    },
+    "runtime_status": "draft_pending_P1-03",
+    "notes": "P1-01 M5 32GB autotune median 12.5 tok/s, p95 TTFT 2611 ms. min_sustained_tps=10 (~80% of measured, mirrors gpt-oss 16.7→15 downgrade headroom). min_ram_gb=28 from P0-01 ~15GB resident + autotune memoryGB-4 gate. Retired P0-01 ~7.7 tok/s."
+  }
+}
+```
+
+### Gate rationale
+
+| Field | Proposed | Rationale |
+|-------|----------|-----------|
+| `min_ram_gb` | **28** | P0-01 measured ~15 GB resident; passes `memoryGB − 4` on 32 GB. Conservative operator tier remains **32 GB** for multi-app Macs. |
+| `min_sustained_tps` | **10** | 75% of measured 12.5 → 9.4; rounded to **10** with cold-start headroom (gpt-oss pattern: measured 16.7 → gate 15). Never 7.7. |
+| `max_4k_ttft_ms` | **3000** | Measured p95 2611 ms + ~400 ms headroom; aligns with baked Gemma row. |
+| `min_bandwidth_tier` | **C** | M-Base M5 bench PASS at Tier-C; no evidence Tier-B required. |
+
+**ModelFit:** Not used for MoE gate derivation (P0-01 false comfort/rejection documented).
+
+---
+
+## G1 verdict
+
+| Criterion | Result |
+|-----------|--------|
+| gpt-oss sanity ≥ 12 tok/s | **PASS** (18.3) |
+| Gemma median TPS on clean 32 GB | **PASS** (12.5) |
+| No OOM / load failure | **PASS** |
+| Proposed gates justified | **PASS** |
+| ≥2 RAM tiers | **PARTIAL** — 32 GB only; 48 GB deferred |
+
+### **P1-01: PASS**
+
+**Artifact:** `beta/catalog-expansion/P1-gemma4-bench-matrix.md`  
+**Proposed gates:** `min_sustained_tps: 10`, `min_ram_gb: 28` (32 GB conservative tier noted)

--- a/specs/PLAN_MODEL_CATALOG_EXPANSION_RUNBOOK.md
+++ b/specs/PLAN_MODEL_CATALOG_EXPANSION_RUNBOOK.md
@@ -1,0 +1,610 @@
+# PLAN — Model Catalog Expansion Runbook
+
+**Version:** 0.1.9  
+**Date:** 2026-07-07  
+**Status:** ACTIVE — execution plan (not normative spec)  
+**Source analysis:** Model-catalog expansion exploration (2026-07-07 Cursor session)  
+**Pinned session role:** This document is the **single plan-of-record**. Executor agents update task status here; the pinned planning session verifies gates and revises sequencing.
+
+---
+
+## How to run this plan
+
+1. **Pinned session (this chat):** verify P0 evidence, approve phase transitions, update version/status in this file.
+2. **Executor agents (separate chats):** one agent per task ID below. Each agent:
+   - Works in a **fresh worktree** off `origin/main` if making code/catalog changes (`CLAUDE.md` § worktree isolation).
+   - Reads only its task section + prerequisites.
+   - Produces the listed **Artifacts** under `beta/catalog-expansion/` (create dir on first run).
+   - Updates the **Status tracker** table at the bottom of this file (or posts artifact paths back to pinned session for update).
+3. **Do not skip P0.** Phases P1–P4 assume P0 gates are GREEN or explicitly WAIVED with rationale in `beta/catalog-expansion/P0_SUMMARY.md`.
+
+### Artifact layout
+
+```
+beta/catalog-expansion/
+  P0_SUMMARY.md                 # rollup after P0-01..05
+  P0-01-moe-memory-parity.md
+  P0-02-tier2-catalog-snapshot.md
+  P0-02-tier2-catalog-snapshot-rerun.md
+  P0-03-hf-weights-audit.md
+  P0-04-gemma4-template-probe.md
+  P0-05-nemotron-model-type.md
+  P0-06-tier2-republish.md
+  P1-gemma4-bench-matrix.md
+  P1-gemma4-catalog-rollout.md
+  P2-small-tier-catalog.md
+  P3-vlm-decision.md
+  P4-flagship-bench.md
+```
+
+---
+
+## Decision gates (master)
+
+| Gate | Requires | Blocks |
+|------|----------|--------|
+| **G0** | All P0 tasks GREEN or WAIVED | P1 runtime bench |
+| **G1** | P1 bench PASS on ≥2 RAM tiers | Gemma-4 catalog publish |
+| **G2** | G1 + rate-card + tier-2 hash signed | Prod recommendable |
+| **G3** | P2 artifacts + G2 stable 48h | Small-tier publish |
+| **G4** | P3 decision record (VLM yes/no) | Any VLM engine work |
+| **G5** | P4 bench on Tier-A hardware | Flagship catalog rows |
+
+---
+
+# P0 — Resolve unverified assumptions (run first)
+
+> **Goal:** Turn exploration §9 unknowns into evidence before catalog or engine bets.
+
+---
+
+## P0-01 — MLX MoE memory parity (ml-explore vs Darkbloom fork)
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P0-01` |
+| **Question** | Does MacProvider’s pinned `mlx-swift-lm` 3.31.4 (`ml-explore`, rev `bd4b7434`) exhibit comparable **resident MoE RAM** to Darkbloom’s post-v0.7.4 fork (fused gate+up cache deleted; ~8–15 GiB reclaimed per `digests/2026-07-06.md`)? |
+| **Prerequisites** | `phase3-binary` builds; one 32 GB Mac available |
+| **Read-only on** | `d-inference` / Layr-Labs source (**forbidden** per clean-room) |
+
+### Procedure
+
+1. On a 32 GB Mac, load **`mlx-community/gemma-4-26b-a4b-it-4bit`** via MacProvider serve path or minimal `swift run` harness using `LLMModelFactory.shared.loadContainer` (same as `ModelRuntime.swift:1887`).
+2. Record **RSS / MLX active memory** at idle after load and after one 4K-token generation (use Activity Monitor + provider logs, or `memory_pressure` snapshot).
+3. Repeat with **`mlx-community/gpt-oss-20b-MXFP4-Q8`** (already in live catalog) as control.
+4. Compare resident GB to RESEARCH_226 estimates (Gemma ~14–16 GB, gpt-oss ~11 GB) and catalog `min_ram_gb` (24–28).
+5. Document whether load fits **32 GB with ≥4 GB headroom** (MacProvider autotune gate: `memoryGB - 4`, `AutotuneRecommend.swift:898`).
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | Gemma-4 resident ≤18 GB measured; 32 GB Mac passes load + 4K gen without swap |
+| **YELLOW** | Resident 18–22 GB; fits 32 GB tight but fails 24 GB — document min_ram_gb recommendation |
+| **RED** | OOM or swap on 32 GB; resident >22 GB — **blocks P1** until MLX pin upgrade or admission fix |
+
+### Artifacts
+
+- `beta/catalog-expansion/P0-01-moe-memory-parity.md` — table: model, quant, measured resident GB, chip, RAM tier, pass/fail
+
+**TPS caveat:** Resident RAM conclusions are reliable; **~7.7 tok/s Gemma TPS is not** — see P1-01 contamination caveat. P0-01 executor noted dev-provider contention and gpt-oss depression vs catalog anchor (~16.7 vs ~9–11).
+
+---
+
+## P0-02 — Production tier-2 catalog snapshot
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P0-02` |
+| **Question** | What models are in **production** `tier2-catalog.json` and do they match live `autotune-candidates.json`? |
+| **Prerequisites** | Coordinator read access or operator can curl production static URLs |
+
+### Procedure
+
+1. Fetch live autotune catalog: `https://coordinator.streamvc.live/static/autotune-candidates.json` (see `AutotuneRecommend.swift:749`).
+2. Obtain production tier-2 catalog:
+   - **Preferred:** read-only from Pearl VPS `/opt/macprovider/tier2-catalog.json` (`coordinator.yaml:202`), OR
+   - `GET https://coordinator.streamvc.live/catalog/current` / pubkey endpoints per `buyer/server.go`.
+3. Diff: catalog keys, `model_id`, `sha256`, `min_ram_gb` per `tier2/catalog.go:32–40`.
+4. Note whether `google-gemma-4-26b-a4b-it` or Gemma MLX IDs appear in tier-2 but not autotune (split-brain risk).
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | Artifact lists all 7 live recommendable keys + hashes; no orphan tier-2-only rows without explanation |
+| **YELLOW** | Tier-2 unreachable but autotune verified — WAIVED for catalog add with “tier-2 pending” note |
+| **RED** | Hash mismatch between deployed provider snapshot and tier-2 for a **live** model — fix before new publishes |
+
+### Artifacts
+
+- `beta/catalog-expansion/P0-02-tier2-catalog-snapshot.md` — redacted snapshot table (no secrets)
+
+---
+
+## P0-03 — HuggingFace MLX weight availability (flagship candidates)
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P0-03` |
+| **Question** | Do MLX-ready quantized weights exist for **`gpt-oss-120b`**, **`gemma-4-31b-4bit`**, **`qwen3-next-80b-a3b`**? |
+| **Prerequisites** | Network read to huggingface.co / mlx-community |
+
+### Procedure
+
+1. For each target, search `mlx-community/*` repos (and `lmstudio-community/*` as fallback).
+2. Record per repo: revision, total `*.safetensors` size, `config.json` → `model_type`, license.
+3. Cross-check `model_type` against `LLMTypeRegistry` (`LLMModelFactory.swift:26–87`).
+4. Flag repos with weights but **wrong/missing `model_type`** (needs-arch-work despite files).
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | ≥1 repo per target with matching `model_type` and size estimate |
+| **YELLOW** | Weights exist but `model_type` unverified or community-only — OK for P4 bench only |
+| **RED** | No MLX weights found — remove from P4 until weights exist |
+
+### Artifacts
+
+- `beta/catalog-expansion/P0-03-hf-weights-audit.md`
+
+---
+
+## P0-04 — Gemma-4 chat template / OpenAI API compatibility
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P0-04` |
+| **Question** | Does Gemma-4 produce correct chat completions through MacProvider’s OpenAI-compatible path after `mlx-swift-lm` 3.x migration? |
+| **Prerequisites** | P0-01 not RED; local model snapshot or HF download |
+
+### Procedure
+
+1. Load `mlx-community/gemma-4-26b-a4b-it-4bit` via `macprovider-cli serve` (or Malibu agent path).
+2. Send `POST /v1/chat/completions` with:
+   - Single-turn user message
+   - Multi-turn system+user+assistant
+   - Tool-free JSON-style prompt (smoke)
+3. Check: no template leakage (`<start_of_turn>`, raw special tokens in output), stop tokens fire, reasonable length.
+4. Compare tokenizer path: `#huggingFaceTokenizerLoader()` (`ModelRuntime.swift:1887–1890`) — note any `extraEOSTokens` need per `supported-models.md` Gemma section.
+5. If Darkbloom reference clone available, compare **behavioral** (not source) output shape only on same prompt — optional.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | Clean assistant text, stable stops, no crash on 3 prompt shapes |
+| **YELLOW** | Minor formatting quirks; document workaround (e.g. `extraEOSTokens`) |
+| **RED** | Garbled output, crash, or empty completions — **blocks P1** until template fix |
+
+### Artifacts
+
+- `beta/catalog-expansion/P0-04-gemma4-template-probe.md` — request/response samples (truncated)
+
+---
+
+## P0-05 — Nemotron-3-Nano `model_type` in config.json
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P0-05` |
+| **Question** | Which `model_type` does `mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit` declare, and does `LLMTypeRegistry` cover it? |
+| **Prerequisites** | HF repo metadata or local snapshot from live catalog revision `832f602e…` |
+
+### Procedure
+
+1. Read `config.json` from HF repo at catalog revision (`autotune-candidates.json` nemotron row).
+2. Confirm `LLMTypeRegistry.shared.contains(modelType)` — registry at `LLMModelFactory.swift:26–87`; candidate types: `nemotron_h`, `afmoe`, `qwen3_moe`, etc.
+3. If live serve already works (catalog says “runtime validated”), document observed load path as evidence.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | `model_type` identified and registered; load succeeds |
+| **RED** | `unsupportedModelType` at load — catalog row is falsely “recommendable”; hotfix required |
+
+### Artifacts
+
+- `beta/catalog-expansion/P0-05-nemotron-model-type.md`
+
+---
+
+## P0-06 — Tier-2 catalog republish (remediation from P0-02 RED)
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P0-06` |
+| **Trigger** | P0-02 RED |
+| **Goal** | Bring production tier-2 (`macprovider-tier2-model-catalog-2026-05-31`) in line with live autotune `published-2026-07-06-mbase-lite` |
+| **Prerequisites** | Operator signing key; `scripts/sign-catalog.go`; Pearl deploy access |
+
+### Procedure
+
+1. Build new tier-2 manifest with **all 7** live recommendable `model_id` + `sha256` + `min_ram_gb` from `autotune-candidates.json`.
+2. **Remove or deprecate** legacy tier-2-only rows: `Qwen2.5-7B`, `Qwen2.5-Coder-7B` (unless operator explicitly keeps as non-autotune aliases).
+3. Fix **Llama-3.2-3B** hash: autotune `3975387f…7216a` (rev `7f0dc925`) replaces tier-2 `0baf1371…fe2fe`.
+4. Sign with Ed25519 (`sign-catalog.go`); deploy to `/opt/macprovider/tier2-catalog.json`; verify `GET /catalog/current` returns new `catalog_id` + issued_at.
+5. Re-run **P0-02** → target GREEN.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | P0-02 re-run GREEN; 7/7 autotune models in tier-2 with matching SHA |
+| **RED** | Deploy or signature failure |
+
+### Artifacts
+
+- `beta/catalog-expansion/P0-06-tier2-republish.md` — new catalog_id, deploy timestamp, P0-02 re-run link
+
+**Blocks:** P1-03, P2 publishes, G2.
+
+---
+
+## P0 rollup — `P0_SUMMARY.md`
+
+Executor agent after P0-01..05:
+
+1. Write `beta/catalog-expansion/P0_SUMMARY.md` with gate table (GREEN/YELLOW/RED per task).
+2. Recommend **G0: PROCEED / HOLD / WAIVE-list**.
+3. Post summary to pinned session for sign-off.
+
+**Pinned session action:** Update Status tracker; bump plan version if gates change.
+
+---
+
+# P1 — Unblock Gemma-4-26B-A4B (highest leverage)
+
+> **Goal:** Move `google-gemma-4-26b-a4b-it` from `blocked` → `recommendable`; Darkbloom + OpenRouter parity.  
+> **Requires:** G0 PROCEED; P0-01 not RED; P0-04 not RED.
+
+---
+
+## P1-01 — Hardware bench matrix
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P1-01` |
+| **Machines** | 32 GB (M-Base, required) + 48 GB (M-Pro, optional) — minimum **1 clean run on 32 GB** |
+| **Tooling** | Stage1 probe path (`Stage1Iterator.swift:379–537`) or `macprovider-cli autotune` — **not** ad-hoc single-shot scripts |
+
+### Contamination caveat (from P0-01 — pinned session 2026-07-07)
+
+P0-01 **GREEN stands for memory** (~15 GB resident, 32 GB load PASS) but its **~7.7 tok/s Gemma TPS is low-confidence** and must **not** be used to set catalog `min_sustained_tps`.
+
+| P0-01 issue | Impact |
+|-------------|--------|
+| Dev provider (`qwen3-coder-30b` on port 61919) running alongside bench | Possible GPU/CPU contention |
+| gpt-oss control ~9–11 tok/s vs catalog anchor **~16.7 tok/s** on M5 (`autotune-candidates.json` notes) | Environment or probe-shape mismatch — **depressed TPS likely** |
+| Single rough sample, 64 decode tokens after 4K prefill | Not comparable to Stage1 **median** sustained TPS |
+| No CPU/thermal/process snapshot recorded | Cannot rule out background load |
+
+**P1-01 must produce fresh TPS under a clean machine protocol below.**
+
+### Environment prep (mandatory before any TPS number)
+
+1. **Quit all other `macprovider-cli serve` instances** (including dev providers on alternate ports).
+2. **Quit heavy apps** (browsers, other agents, node servers on inference ports).
+3. Record **before each run**:
+   - `memory_pressure` one-liner
+   - `ps aux \| head` or process count of `macprovider-cli`
+   - Chip + RAM GB + power mode if not on AC
+4. Prefer **release build** (`phase3-binary/.build/release/macprovider-cli`) per P0-01/P0-04.
+5. **Reboot optional** but recommended if prior session loaded large models (memory fragmentation).
+
+### gpt-oss sanity check (gate before locking Gemma bench gates)
+
+On the **same 32 GB machine**, before or interleaved with Gemma benches:
+
+1. Run Stage1/autotune probe on **`mlx-community/gpt-oss-20b-MXFP4-Q8`** (live catalog control).
+2. Compare **median sustained TPS** to published anchor: catalog notes cite **~16.7 tok/s** cold-start on M5; live `min_sustained_tps: 15` (`autotune-candidates.json`).
+3. **Sanity PASS:** gpt-oss median TPS ≥ **12** (≥75% of catalog 15 gate) on clean machine.
+4. **Sanity FAIL:** gpt-oss still <12 → **fix environment and re-run**; do not publish Gemma `min_sustained_tps` until sanity PASS.
+
+Document sanity result in artifact § "Environment sanity check".
+
+### Procedure
+
+1. Confirm **gpt-oss sanity PASS** (above).
+2. Bench **`mlx-community/gemma-4-26b-a4b-it-4bit`**: **median** TPS, p95 4K TTFT via Stage1/autotune (≥3 probe iterations if manual).
+3. On 32 GB: confirm no OOM/swap; cross-check P0-01 resident ~15 GB if memory logged.
+4. Optional 48 GB tier for headroom / concurrency signal.
+5. Set proposed Gemma `min_sustained_tps` as **advisory** — typically **≤ gpt-oss median on same box** or ~75% of measured Gemma median (same pattern as gpt-oss 30→15 M-Base downgrade). **Do not copy P0-01 ~7.7.**
+6. Proposed `min_ram_gb`: **28** from P0-01 (memory-based); operator may choose 32 conservative.
+7. Record `ModelFit.evaluate` for awareness only — **do not derive gates from ModelFit** for MoE (`P0-01`).
+
+### Pass / fail (G1)
+
+| Result | Criteria |
+|--------|----------|
+| **PASS** | gpt-oss sanity PASS + Gemma median TPS documented on clean 32 GB + no OOM; proposed gates justified vs measured medians |
+| **FAIL** | gpt-oss sanity FAIL (environment) OR Gemma OOM on 32 GB OR cannot reproduce load after 3 attempts |
+
+### Artifacts
+
+- `beta/catalog-expansion/P1-gemma4-bench-matrix.md` — must include: environment snapshot, gpt-oss sanity table, Gemma median TPS, proposed `min_sustained_tps` / `min_ram_gb`, explicit statement that P0-01 ~7.7 was superseded
+
+---
+
+## P1-02 — Rate card + pricing row
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P1-02` |
+| **Prerequisites** | P1-01 PASS; operator pricing target |
+| **Files** | `phase4-coordinator/dist/coordinator.yaml` rewards.rate_card; `scripts/sign-catalog.go` rate card signing if applicable |
+
+### Procedure
+
+1. Add `google-gemma-4-26b-a4b-it` (or normalized key per `billing/formula.go:65–88`) to rate card.
+2. Anchor to RESEARCH_226 / Darkbloom live (~$0.33/M OR market undercut — operator choice).
+3. Document prompt/completion credits in artifact; **do not deploy** until P1-03 signed.
+
+### Artifacts
+
+- Section in `P1-gemma4-catalog-rollout.md` (pricing table)
+
+---
+
+## P1-03 — Catalog + tier-2 + static publish
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P1-03` |
+| **Prerequisites** | P1-01 PASS, P1-02 approved, P0-02 GREEN |
+| **Touch list** | `phase3-binary/dist/static/autotune-candidates.json`, `demand-rank.json`, baked fallback `AutotuneRecommend.swift:1934–1935`, tier-2 catalog, coordinator static deploy |
+
+### Procedure
+
+1. Add live row:
+   - `model_id`: `mlx-community/gemma-4-26b-a4b-it-4bit` (or QAT variant if P0-01 favors it)
+   - `min_ram_gb`: from P1-01 (likely 28–32)
+   - `min_bandwidth_tier`: `C` or `B` from bench
+   - `runtime_status`: `recommendable`
+   - `model_revision`, `model_sha256`: from HF snapshot
+2. Remove `blocked` from baked fallback; align baked/live.
+3. Add demand-rank row (`demand_weight` ~0.5–0.6; RESEARCH_226 rank ~22).
+4. Compute SHA-256 manifest hash; sign tier-2 entry (`tier2/catalog.go`, `sign-catalog.go`).
+5. Re-sign autotune static v4 Ed25519 (`AutotuneRecommend.swift:684–687`).
+6. Run tests: `AutotuneRecommendSimulateTests`, billing route snapshot tests.
+
+### Pass / fail (G2)
+
+| Result | Criteria |
+|--------|----------|
+| **PASS** | Static JSON live; tier-2 hash verifies; autotune recommends Gemma on eligible hardware |
+| **FAIL** | Signature, hash, or simulate test failure |
+
+### Artifacts
+
+- `beta/catalog-expansion/P1-gemma4-catalog-rollout.md` — PR link, catalog version string, deploy checklist
+
+---
+
+## P1-04 — Optional QAT variant follow-up
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P1-04` |
+| **When** | After P1-03 stable OR if P0-01 shows QAT fits 24 GB better |
+| **Model** | `gemma-4-26b-qat-4bit` (Darkbloom prod id pattern) |
+
+Separate catalog key or quant suffix — operator decision. Lower priority than P1-03 text-only 4bit.
+
+---
+
+# P2 — Cheap catalog wins (parallel after G1)
+
+> **Goal:** Widen supply without engine changes.  
+> **Requires:** G2 for coordination deploy; can prep PRs during P1.
+
+---
+
+## P2-01 — Qwen3-30B-A3B general (non-coder)
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P2-01` |
+| **MLX ID** | `mlx-community/Qwen3-30B-A3B-4bit` (verify HF name in P0-03 style) |
+| **Catalog key** | `qwen3-30b-a3b` |
+| **Basis** | Coder row `qwen3-coder-30b-a3b-instruct` (`autotune-candidates.json`) — clone gates |
+
+### Tasks
+
+1. Bench on 28–32 GB (expect similar to coder MoE).
+2. Add rate card row (RESEARCH_227 lane).
+3. Publish autotune + tier-2 + demand-rank.
+
+**Effort:** trivial variant.
+
+---
+
+## P2-02 — Small-tier dense (pick one or both)
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P2-02` |
+| **Candidates** | `mlx-community/Qwen3-8B-4bit`, `mlx-community/Qwen2.5-7B-Instruct-4bit`, `SmolLM3` if weights found |
+| **Target tier** | 12–16 GB (`min_ram_gb` 8–12) |
+| **Rationale** | Only `llama-3.1-8b` + `llama-3.2-3b` serve small tier today |
+
+### Tasks
+
+1. Stage1 bench on 16 GB Mac.
+2. Rate card: match small-dense lane (`llama-3.1-8b` pricing in `coordinator.yaml:179–186`).
+3. Publish catalog rows.
+
+---
+
+## P2-03 — Baked/live drift cleanup
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P2-03` |
+| **Issue** | Baked fallback diverges from live on `qwen3-32b` min_ram (32 vs 48), `qwen2.5-coder` (64 vs 48) per `AutotuneRecommend.swift:1913–1929` |
+
+Align baked JSON with live after P1/P2 publishes to avoid offline autotune surprises.
+
+---
+
+# P3 — VLM decision (planning only in this runbook)
+
+> **Goal:** Go/no-go on multimodal before any engine sprint.  
+> **Does not require** G2; requires operator input.
+
+---
+
+## P3-01 — Decision record
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P3-01` |
+| **Output** | `beta/catalog-expansion/P3-vlm-decision.md` |
+
+### Questions to answer
+
+1. Is multimodal required for competitive parity with Darkbloom Gemma-4 VLM in **2026 Q3**?
+2. If yes: first VLM target — **Gemma-4 VLM** (`VLMTypeRegistry` `gemma4`, `VLMModelFactory.swift:98–99`) vs **Qwen2.5-VL-3B** (smaller scope)?
+3. API shape: image in `/v1/chat/completions` messages vs separate endpoint?
+4. Accept engine work: integrate `VLMModelFactory` into `ModelRuntime` (today **LLM-only**, `ModelRuntime.swift:1887`).
+
+### Outcomes
+
+| Decision | Next work (out of this runbook) |
+|----------|--------------------------------|
+| **VLM yes** | Spawn `BUILD_SPEC_VLM_ENGINE.md` — estimated multi-week |
+| **VLM no** | Defer P3 engine; text-only depth through P4 |
+
+**Gate G4:** P3-01 signed by operator.
+
+---
+
+# P4 — Flagship tier (Tier-A hardware)
+
+> **Goal:** Evidence before catalog commits for 64 GB+ MoE flagships.  
+> **Requires:** G0; P0-03 GREEN for targets; physical Tier-A box.
+
+---
+
+## P4-01 — Bench `gpt-oss-120b`
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P4-01` |
+| **Arch** | `gpt_oss` (Y) |
+| **Est. resident** | 60–70 GB 4bit (RESEARCH_226) |
+| **Min machine** | M4 Max 64 GB or M3 Ultra 96 GB |
+
+Document TPS, OOM boundary, KV at 4K/8K. **No catalog row** unless PASS on ≥1 production-class Tier-A machine.
+
+---
+
+## P4-02 — Bench `qwen3-next-80b-a3b`
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P4-02` |
+| **Arch** | `qwen3_next` (Y) |
+| **Est. resident** | 40–45 GB 4bit |
+
+Same procedure as P4-01.
+
+---
+
+## P4-03 — Optional `gemma-4-31b` dense
+
+| Field | Value |
+|-------|-------|
+| **ID** | `P4-03` |
+| **When** | P0-03 confirms weights + P1 Gemma-4 stable |
+| **Tier** | 48 GB |
+
+Lower priority than P4-01/02 unless OpenRouter demand priority shifts.
+
+**Gate G5:** P4-01 or P4-02 PASS → operator approves flagship catalog PR.
+
+---
+
+# P5 — Explicit deferrals (no tasks until arch/weights land)
+
+| Item | Revisit when |
+|------|----------------|
+| DeepSeek-V4 | `deepseek_v4` appears in `LLMTypeRegistry` |
+| Llama 4 | `llama4` registered in mlx-swift-lm pin |
+| MiniMax-M2.7 / Qwen3-235B | Tier-S fleet (192 GB+) exists |
+| Multi-model co-residency | Product asks concurrent full-size models; needs scheduler design |
+| Mixtral-8x22B, DBRX | Never unless demand recovers |
+
+---
+
+# Executor agent prompt template
+
+Paste into a **new** Cursor agent session (one per task):
+
+```
+You are executing task {TASK_ID} from the MacProvider catalog expansion runbook.
+
+Read: specs/PLAN_MODEL_CATALOG_EXPANSION_RUNBOOK.md § {TASK_ID}
+Rules: CLAUDE.md worktree isolation; read-only unless task requires catalog/code changes.
+Deliver: artifacts listed in task section under beta/catalog-expansion/
+Do NOT update this plan unless asked — post artifact paths and PASS/FAIL for pinned session.
+```
+
+---
+
+# Status tracker
+
+> **Maintained by:** executor agents + pinned planning session.  
+> Last updated: 2026-07-07 (P1 DONE, G2 CLOSED — #461 merged)
+
+| Task ID | Phase | Status | Gate | Artifact | Notes |
+|---------|-------|--------|------|----------|-------|
+| P0-01 | P0 | **`GREEN`** | G0 | `beta/catalog-expansion/P0-01-moe-memory-parity.md` | 32 GB M5: Gemma-4 ~15 GB resident; suggest `min_ram_gb: 28` |
+| P0-02 | P0 | **`GREEN`** (rerun) | G0 | `P0-02-tier2-catalog-snapshot-rerun.md` | Initial RED; fixed by P0-06 |
+| P0-03 | P0 | **`GREEN`** | G0 | `beta/catalog-expansion/P0-03-hf-weights-audit.md` | Flagship HF weights confirmed |
+| P0-04 | P0 | **`GREEN`** | G0 | `beta/catalog-expansion/P0-04-gemma4-template-probe.md` | Chat API clean; streaming OK; no template fix needed |
+| P0-05 | P0 | **`GREEN`** | G0 | `beta/catalog-expansion/P0-05-nemotron-model-type.md` | `nemotron_h` registry match |
+| P0-06 | P0 | **`GREEN`** | G2 | `beta/catalog-expansion/P0-06-tier2-republish.md` | Tier-2 `2026-07-07` live |
+| P0 rollup | P0 | **`DONE`** | **G0** | `beta/catalog-expansion/P0_SUMMARY.md` | **G0 PROCEED** |
+| P1-01 | P1 | **`PASS`** | G1 | `beta/catalog-expansion/P1-gemma4-bench-matrix.md` | Clean M5: gpt-oss 18.3 TPS sanity; Gemma **12.5** median (supersedes P0-01 7.7); gates `min_sustained_tps:10`, `min_ram_gb:28` |
+| P1-02 | P1 | **`DONE`** | G2 | `beta/catalog-expansion/P1-gemma4-catalog-rollout.md` | Rate card $0.240/M + alias; merged #461 |
+| P1-03 | P1 | **`PASS`** | G2 | `beta/catalog-expansion/P1-gemma4-catalog-rollout.md` | `published-2026-07-07-p1-gemma` live; 8 models; prod + #461 |
+| P1-04 | P1 | `READY` | — | — | Optional QAT variant; after P1 soak |
+| P1 rollup | P1 | **`DONE`** | **G2** | `beta/catalog-expansion/P1-gemma4-catalog-rollout.md` | **G2 CLOSED** |
+| P2-01 | P2 | `BLOCKED` | G3 | — | Needs G2 stable 48h |
+| P2-02 | P2 | `BLOCKED` | G3 | — | Needs G2 stable 48h |
+| P2-03 | P2 | `BLOCKED` | G3 | — | Baked/live drift |
+| P3-01 | P3 | `PENDING` | G4 | — | Operator decision |
+| P4-01 | P4 | `BLOCKED` | G5 | — | P0-03 GREEN; needs Tier-A HW bench |
+| P4-02 | P4 | `BLOCKED` | G5 | — | P0-03 GREEN; needs Tier-A HW bench |
+| P4-03 | P4 | `BLOCKED` | G5 | — | P0-03 GREEN (`gemma-4-31b-it-4bit` 18.4 GB); needs P1 stable + 48 GB bench |
+
+### Gate summary
+
+| Gate | Status | Signed off |
+|------|--------|------------|
+| G0 | **`CLOSED — PROCEED`** | 2026-07-07 |
+| G1 | **`PASS`** (32 GB only; 48 GB tier deferred) | 2026-07-07 |
+| G2 | **`CLOSED — PASS`** — Gemma-4 prod recommendable; #461 merged | 2026-07-07 |
+| G3 | `OPEN` — needs G2 stable 48h | — |
+| G4 | `OPEN` | — |
+| G5 | `OPEN` | — |
+
+---
+
+## Changelog
+
+| Version | Date | Change |
+|---------|------|--------|
+| 0.1 | 2026-07-07 | Initial runbook from catalog expansion exploration §9–10 |
+| 0.1.1 | 2026-07-07 | P0-05 GREEN — nemotron_h registry confirmed |
+| 0.1.2 | 2026-07-07 | P0-02 RED — tier-2/autotune split-brain; added P0-06 remediation |
+| 0.1.3 | 2026-07-07 | P0-03 GREEN — flagship HF weights confirmed for P4 |
+| 0.1.4 | 2026-07-07 | P0-06 GREEN + P0-02 rerun GREEN — tier-2 `2026-07-07` live, 7/7 aligned |
+| 0.1.5 | 2026-07-07 | P0-01 GREEN — Gemma-4 ~15 GB on 32 GB M5; P0-04 + P1-01 unblocked |
+| 0.1.6 | 2026-07-07 | P0-04 GREEN + G0 CLOSED — `P0_SUMMARY.md`; P1-01 unblocked |
+| 0.1.7 | 2026-07-07 | P1-01: P0-01 TPS contamination caveat + mandatory gpt-oss sanity check |
+| 0.1.8 | 2026-07-07 | P1-01 PASS — Gemma 12.5 TPS / gates 10+28; gpt-oss sanity 18.3 |
+| 0.1.9 | 2026-07-07 | P1 DONE + G2 CLOSED — commit P0/P1 artifacts; #461 merged |


### PR DESCRIPTION
## Summary

- Commit P0 exploration artifacts (`P0-01` through `P0-06`, `P0_SUMMARY.md`) and P1-01 bench matrix under `beta/catalog-expansion/`.
- Add `specs/PLAN_MODEL_CATALOG_EXPANSION_RUNBOOK.md` v0.1.9 with status tracker updated: **P1 DONE**, **G2 CLOSED** (#461).

## Test plan

- [x] Docs-only change; no code paths touched
- [x] Artifact paths match runbook layout section


Made with [Cursor](https://cursor.com)