### PR TITLE
Pearl nginx scripts for download.malibu.tech (Sparkle host)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -748,13 +748,18 @@ jobs:
       - name: Publish Malibu latest.dmg
         env:
           GH_TOKEN: ${{ github.token }}
-          MALIBU_DOWNLOAD_BUCKET: ${{ secrets.MALIBU_DOWNLOAD_BUCKET }}
-          MALIBU_DOWNLOAD_ENDPOINT: ${{ secrets.MALIBU_DOWNLOAD_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.MALIBU_DOWNLOAD_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.MALIBU_DOWNLOAD_AWS_SECRET_ACCESS_KEY }}
+          MALIBU_DOWNLOAD_VPS_HOST: ${{ secrets.MALIBU_DOWNLOAD_VPS_HOST }}
+          MALIBU_DOWNLOAD_SSH_KEY: ${{ secrets.MALIBU_DOWNLOAD_SSH_KEY }}
         shell: bash
         run: |
           set -euo pipefail
+          if [ -n "${MALIBU_DOWNLOAD_SSH_KEY:-}" ]; then
+            key_file="$(mktemp)"
+            trap 'rm -f "$key_file"' EXIT
+            printf '%s\n' "$MALIBU_DOWNLOAD_SSH_KEY" > "$key_file"
+            chmod 600 "$key_file"
+            export MALIBU_DOWNLOAD_SSH_KEY="$key_file"
+          fi
           bash scripts/publish-malibu-latest-dmg.sh "${{ steps.version.outputs.tag }}"
 
       - name: Verify published Tier-2 Release assets

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ test-dist:
 	bash scripts/test-install-provider-id-preserve.sh
 	bash scripts/test-install-launchd-enable.sh
 	bash scripts/test-watchdog-inline-drift.sh
+	bash scripts/test-malibu-download-publish.sh
 
 vet: vet-coordinator vet-gateway vet-integration
 

--- a/beta/MALIBU_WORKSTREAM.md
+++ b/beta/MALIBU_WORKSTREAM.md
@@ -36,6 +36,7 @@ repo.
 
 | ID | Shipped | PR / release | Notes |
 |---|---|---|---|
+| **P4** | 2026-07-07 | (infra PR pending) | `download.malibu.tech` on Pearl nginx + name.com DNS; Sparkle + `latest.dmg` live |
 | **P2b** | 2026-07-07 | v1.8.19 (#459 + release) | Autotune feeds on buyer mux `/v1/*`; Pearl deploy + Sparkle release |
 | **P2a** | 2026-07-07 | #458 | Autotune `--recommend`/`--apply` hardening |
 | **R1** | 2026-07-07 | v1.8.18 (#457) | Sparkle live + dashboard stats clipping fix |
@@ -52,8 +53,20 @@ repo.
 
 | Path | What it updates |
 |---|---|
-| **Sparkle** (`Check for Updates…`) | Whole `Malibu.app` bundle via `appcast.xml` |
+| **Sparkle** (`Check for Updates…`) | Whole `Malibu.app` bundle via `https://download.malibu.tech/appcast.xml` |
 | **CLI self-update** | Disabled under `--managed-by malibu-app` |
+
+### Download host (P4 — live)
+
+Pearl VPS nginx static host. DNS: `download.malibu.tech` **A** → `159.223.165.194`.
+
+Operator scripts (repo):
+
+1. `bash scripts/setup-malibu-download-pearl.sh` — nginx + Let's Encrypt + docroot
+2. `bash scripts/publish-malibu-latest-dmg.sh vX.Y.Z` — after GitHub release tag
+3. `bash scripts/verify-malibu-download.sh`
+
+GitHub Actions secrets: `MALIBU_DOWNLOAD_VPS_HOST`, `MALIBU_DOWNLOAD_SSH_KEY`.
 
 ### SPEC-025 phases vs this file
 
@@ -61,5 +74,5 @@ repo.
 |---|---|
 | P2 signing / `.dmg` | Done |
 | P3 Sparkle | Live (v1.8.19) |
-| P4 landing page | Not started |
+| P4 landing page | **Partial** — download endpoint live; `malibu.tech/host` HTML redesign + troubleshoot page not started |
 | P5+ WalletConnect, Homebrew | Backlog |

--- a/beta/MALIBU_WORKSTREAM.md
+++ b/beta/MALIBU_WORKSTREAM.md
@@ -36,7 +36,7 @@ repo.
 
 | ID | Shipped | PR / release | Notes |
 |---|---|---|---|
-| **P4** | 2026-07-07 | (infra PR pending) | `download.malibu.tech` on Pearl nginx + name.com DNS; Sparkle + `latest.dmg` live |
+| **P4** | 2026-07-07 | #465 | `download.malibu.tech` on Pearl nginx + name.com DNS; Sparkle + `latest.dmg` live |
 | **P2b** | 2026-07-07 | v1.8.19 (#459 + release) | Autotune feeds on buyer mux `/v1/*`; Pearl deploy + Sparkle release |
 | **P2a** | 2026-07-07 | #458 | Autotune `--recommend`/`--apply` hardening |
 | **R1** | 2026-07-07 | v1.8.18 (#457) | Sparkle live + dashboard stats clipping fix |

--- a/scripts/dist/nginx-download.malibu.tech.conf
+++ b/scripts/dist/nginx-download.malibu.tech.conf
@@ -1,0 +1,46 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name download.malibu.tech;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name download.malibu.tech;
+
+    ssl_certificate /etc/letsencrypt/live/download.malibu.tech/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/download.malibu.tech/privkey.pem;
+
+    root /var/www/malibu-download;
+
+    location = /appcast.xml {
+        default_type application/xml;
+        add_header Cache-Control "public, max-age=300" always;
+        try_files $uri =404;
+    }
+
+    location ~* \.dmg$ {
+        default_type application/octet-stream;
+        add_header Cache-Control "public, max-age=300" always;
+        try_files $uri =404;
+    }
+
+    location ~* \.sha256$ {
+        default_type text/plain;
+        add_header Cache-Control "public, max-age=300" always;
+        try_files $uri =404;
+    }
+
+    location / {
+        return 404;
+    }
+}

--- a/scripts/publish-malibu-latest-dmg.sh
+++ b/scripts/publish-malibu-latest-dmg.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
-# Publish Malibu-{tag}.dmg to the download.malibu.tech bucket and refresh latest.dmg.
+# Publish Malibu-{tag}.dmg to download.malibu.tech (Pearl VPS nginx docroot).
 #
-# Requires operator credentials for the object store backing download.malibu.tech.
-# Example (Cloudflare R2 via awscli-compatible endpoint):
+# Downloads release assets from GitHub, copies to Pearl via SSH, and refreshes
+# latest.dmg + appcast.xml for Sparkle.
 #
-#   export MALIBU_DOWNLOAD_ENDPOINT="https://<account>.r2.cloudflarestorage.com"
-#   export MALIBU_DOWNLOAD_BUCKET="malibu-download"
-#   export AWS_ACCESS_KEY_ID=...
-#   export AWS_SECRET_ACCESS_KEY=...
-#   bash scripts/publish-malibu-latest-dmg.sh v1.8.13
+# Usage:
+#   bash scripts/publish-malibu-latest-dmg.sh v1.8.19
 #
-# Without object-store credentials this script prints the GitHub Release URL to
-# wire manually in Cloudflare (redirect latest.dmg → versioned asset).
+# Environment:
+#   MALIBU_DOWNLOAD_VPS_HOST  default 159.223.165.194
+#   MALIBU_DOWNLOAD_SSH_KEY   default ~/.ssh/pearl_operator_ed25519
+#   MALIBU_DOWNLOAD_VPS_USER  default root
+#   MALIBU_DOWNLOAD_WEBROOT   default /var/www/malibu-download
+#   VERIFY_MALIBU_DOWNLOAD=1   run verify-malibu-download.sh after upload
 
 set -euo pipefail
 
@@ -27,6 +28,11 @@ repo="${GITHUB_REPOSITORY:-Augustas11/macprovider}"
 dmg_name="Malibu-${tag}.dmg"
 versioned_key="Malibu-${tag}.dmg"
 latest_key="latest.dmg"
+
+VPS_HOST="${MALIBU_DOWNLOAD_VPS_HOST:-159.223.165.194}"
+SSH_KEY="${MALIBU_DOWNLOAD_SSH_KEY:-$HOME/.ssh/pearl_operator_ed25519}"
+VPS_USER="${MALIBU_DOWNLOAD_VPS_USER:-root}"
+WEBROOT="${MALIBU_DOWNLOAD_WEBROOT:-/var/www/malibu-download}"
 
 work="$(mktemp -d "${TMPDIR:-/tmp}/malibu-publish.XXXXXX")"
 cleanup() { rm -rf "$work"; }
@@ -45,38 +51,51 @@ asset="$work/$dmg_name"
 sha256="$(shasum -a 256 "$asset" | awk '{print $1}')"
 printf '%s  %s\n' "$sha256" "$dmg_name" > "$work/${dmg_name}.sha256"
 
-if [[ -z "${MALIBU_DOWNLOAD_BUCKET:-}" ]]; then
+if [[ ! -f "$SSH_KEY" ]]; then
   cat <<EOF
-[publish-malibu-latest-dmg] No MALIBU_DOWNLOAD_BUCKET set — manual step required.
+[publish-malibu-latest-dmg] No SSH key at $SSH_KEY — manual step required.
 
-1. Upload $dmg_name to download.malibu.tech as:
-     $versioned_key
+1. Run: bash scripts/setup-malibu-download-pearl.sh
+2. Upload $dmg_name to ${WEBROOT} on Pearl as:
+     ${versioned_key}
+     ${latest_key}
+     appcast.xml
      SHA-256: $sha256
-2. Point https://download.malibu.tech/latest.dmg at that object (redirect or copy).
-3. GitHub Release asset (fallback):
+3. name.com DNS: download.malibu.tech A -> ${VPS_HOST}
+4. GitHub Release fallback:
      https://github.com/$repo/releases/download/$tag/$dmg_name
 EOF
   exit 0
 fi
 
-command -v aws >/dev/null 2>&1 || die "aws CLI required when MALIBU_DOWNLOAD_BUCKET is set"
+SSH="ssh -i $SSH_KEY -o ConnectTimeout=15 -p 22 $VPS_USER@$VPS_HOST"
+SCP="scp -i $SSH_KEY -P 22"
 
-aws_args=()
-if [[ -n "${MALIBU_DOWNLOAD_ENDPOINT:-}" ]]; then
-  aws_args+=(--endpoint-url "$MALIBU_DOWNLOAD_ENDPOINT")
-fi
-
-aws s3 cp "$asset" "s3://${MALIBU_DOWNLOAD_BUCKET}/${versioned_key}" "${aws_args[@]}"
-aws s3 cp "$asset" "s3://${MALIBU_DOWNLOAD_BUCKET}/${latest_key}" "${aws_args[@]}"
-aws s3 cp "$work/${dmg_name}.sha256" "s3://${MALIBU_DOWNLOAD_BUCKET}/${dmg_name}.sha256" "${aws_args[@]}"
-
+$SSH "install -d -o www-data -g www-data -m 0755 $WEBROOT"
+$SCP "$asset" "$VPS_USER@$VPS_HOST:/tmp/malibu-${versioned_key}" >/dev/null
+$SCP "$work/${dmg_name}.sha256" "$VPS_USER@$VPS_HOST:/tmp/malibu-${dmg_name}.sha256" >/dev/null
 appcast="$work/appcast.xml"
 if [[ -f "$appcast" ]]; then
-  aws s3 cp "$appcast" "s3://${MALIBU_DOWNLOAD_BUCKET}/appcast.xml" "${aws_args[@]}"
-  printf '[publish-malibu-latest-dmg] ok: appcast.xml published\n'
+  $SCP "$appcast" "$VPS_USER@$VPS_HOST:/tmp/malibu-appcast.xml" >/dev/null
 else
-  printf '[publish-malibu-latest-dmg] WARN: appcast.xml missing from release %s — Sparkle feed unchanged\n' "$tag" >&2
+  printf '[publish-malibu-latest-dmg] WARN: appcast.xml missing from release %s\n' "$tag" >&2
 fi
 
-printf '[publish-malibu-latest-dmg] ok: s3://%s/%s and latest.dmg (sha256=%s)\n' \
-  "$MALIBU_DOWNLOAD_BUCKET" "$versioned_key" "$sha256"
+$SSH "set -e
+  install -o www-data -g www-data -m 0644 /tmp/malibu-${versioned_key} ${WEBROOT}/${versioned_key}
+  install -o www-data -g www-data -m 0644 /tmp/malibu-${versioned_key} ${WEBROOT}/${latest_key}
+  install -o www-data -g www-data -m 0644 /tmp/malibu-${dmg_name}.sha256 ${WEBROOT}/${dmg_name}.sha256
+  rm -f /tmp/malibu-${versioned_key} /tmp/malibu-${dmg_name}.sha256
+  if [ -f /tmp/malibu-appcast.xml ]; then
+    install -o www-data -g www-data -m 0644 /tmp/malibu-appcast.xml ${WEBROOT}/appcast.xml
+    rm -f /tmp/malibu-appcast.xml
+  fi
+"
+
+printf '[publish-malibu-latest-dmg] ok: %s/%s + latest.dmg on Pearl (sha256=%s)\n' \
+  "$WEBROOT" "$versioned_key" "$sha256"
+
+if [[ "${VERIFY_MALIBU_DOWNLOAD:-0}" == "1" ]]; then
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+  bash "$script_dir/verify-malibu-download.sh"
+fi

--- a/scripts/setup-malibu-download-pearl.sh
+++ b/scripts/setup-malibu-download-pearl.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# One-time (re-runnable) provisioning for download.malibu.tech on Pearl VPS.
+#
+# DNS lives at name.com (malibu.tech NS). Add before certbot can succeed:
+#   download.malibu.tech  A  159.223.165.194  TTL 300
+#
+# Installs nginx vhost + Let's Encrypt cert + /var/www/malibu-download docroot.
+# Publish release assets with scripts/publish-malibu-latest-dmg.sh.
+#
+# Usage:
+#   bash scripts/setup-malibu-download-pearl.sh
+#
+# Environment:
+#   SSH_KEY    default ~/.ssh/pearl_operator_ed25519
+#   VPS_HOST   default 159.223.165.194
+#   VPS_USER   default root
+#   DOMAIN     default download.malibu.tech
+#   EMAIL      default augstar@gmail.com
+#   SKIP_DNS_WAIT=1   install nginx/docroot without waiting for public DNS
+#   PUBLISH_TAG=v1.8.19  run publish-malibu-latest-dmg.sh after setup
+
+set -euo pipefail
+
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/pearl_operator_ed25519}"
+VPS_HOST="${VPS_HOST:-159.223.165.194}"
+VPS_USER="${VPS_USER:-root}"
+DOMAIN="${DOMAIN:-download.malibu.tech}"
+EMAIL="${EMAIL:-augstar@gmail.com}"
+PUBLISH_TAG="${PUBLISH_TAG:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NGINX_SITE="$SCRIPT_DIR/dist/nginx-download.malibu.tech.conf"
+
+[[ -f "$NGINX_SITE" ]] || { echo "missing $NGINX_SITE" >&2; exit 1; }
+[[ -f "$SSH_KEY" ]] || { echo "missing SSH key: $SSH_KEY" >&2; exit 1; }
+
+SSH="ssh -i $SSH_KEY -o ConnectTimeout=10 -p 22 $VPS_USER@$VPS_HOST"
+SCP="scp -i $SSH_KEY -P 22"
+
+log() { printf '[setup-malibu-download-pearl] %s\n' "$*"; }
+
+dns_ready() {
+  local ip
+  for resolver in '' '@ns1jlp.name.com' '@8.8.8.8' '@1.1.1.1'; do
+    if [[ -z "$resolver" ]]; then
+      ip="$(dig +short "$DOMAIN" A 2>/dev/null | head -1)"
+    else
+      ip="$(dig +short "$DOMAIN" A "${resolver#@}" 2>/dev/null | head -1)"
+    fi
+    [[ "$ip" == "$VPS_HOST" ]] && return 0
+  done
+  return 1
+}
+
+print_namecom_dns() {
+  cat <<EOF
+
+name.com DNS — use the **malibu.tech** zone (NOT streamvc.live):
+  Host: download
+  Type: A
+  Answer: ${VPS_HOST}
+  TTL: 300
+
+Malibu Sparkle checks https://download.malibu.tech/appcast.xml (not download.streamvc.live).
+
+Verify: dig +short ${DOMAIN} @8.8.8.8
+EOF
+}
+
+log "step 1/7: confirm SSH"
+$SSH 'hostname >/dev/null && echo ok' >/dev/null
+
+log "step 2/7: DNS check"
+if dns_ready; then
+  log "  ${DOMAIN} resolves to ${VPS_HOST}"
+else
+  print_namecom_dns
+  if [[ "${SKIP_DNS_WAIT:-0}" != "1" ]]; then
+    log "waiting for public DNS (up to ~5 min; set SKIP_DNS_WAIT=1 to install nginx only)"
+    for i in $(seq 1 30); do
+      if dns_ready; then
+        log "  DNS ready"
+        break
+      fi
+      [[ "$i" = 30 ]] && {
+        log "DNS still missing — continuing with nginx/docroot only (no cert yet)"
+        SKIP_CERT=1
+        break
+      }
+      sleep 10
+    done
+  else
+    log "  SKIP_DNS_WAIT=1 — skipping DNS wait"
+    SKIP_CERT=1
+  fi
+fi
+
+log "step 3/7: ensure certbot + docroot on Pearl"
+$SSH "set -e
+  DEBIAN_FRONTEND=noninteractive apt-get update -qq
+  DEBIAN_FRONTEND=noninteractive apt-get install -qq -y certbot python3-certbot-nginx nginx >/dev/null || true
+  install -d -o www-data -g www-data -m 0755 /var/www/html
+  install -d -o www-data -g www-data -m 0755 /var/www/malibu-download
+"
+
+log "step 4/7: upload nginx site + install port-80 stub"
+$SCP "$NGINX_SITE" "$VPS_USER@$VPS_HOST:/tmp/nginx-malibu-download.conf" >/dev/null
+$SSH "set -e
+  if [ ! -f /etc/letsencrypt/live/$DOMAIN/fullchain.pem ]; then
+    cat > /etc/nginx/sites-available/$DOMAIN <<'NGINX_STUB'
+server {
+    listen 80;
+    listen [::]:80;
+    server_name $DOMAIN;
+    root /var/www/malibu-download;
+    location /.well-known/acme-challenge/ { root /var/www/html; }
+    location = /appcast.xml {
+        default_type application/xml;
+        try_files \$uri =404;
+    }
+    location ~* \\.dmg\$ {
+        default_type application/octet-stream;
+        try_files \$uri =404;
+    }
+    location ~* \\.sha256\$ {
+        default_type text/plain;
+        try_files \$uri =404;
+    }
+    location / { return 404; }
+}
+NGINX_STUB
+    ln -sf /etc/nginx/sites-available/$DOMAIN /etc/nginx/sites-enabled/$DOMAIN
+    nginx -t && systemctl reload nginx
+  fi
+"
+
+if [[ "${SKIP_CERT:-0}" != "1" ]] && dns_ready; then
+  log "step 5/7: obtain Let's Encrypt cert (webroot)"
+  $SSH "set -e
+    if [ -f /etc/letsencrypt/live/$DOMAIN/fullchain.pem ]; then
+      echo '  cert already present'
+    else
+      certbot certonly --webroot -w /var/www/html -d $DOMAIN --non-interactive --agree-tos --email $EMAIL
+    fi
+  "
+
+  log "step 6/7: install full TLS vhost"
+  $SSH "set -e
+    install -o root -g root -m 0644 /tmp/nginx-malibu-download.conf /etc/nginx/sites-available/$DOMAIN
+    rm -f /tmp/nginx-malibu-download.conf
+    ln -sf /etc/nginx/sites-available/$DOMAIN /etc/nginx/sites-enabled/$DOMAIN
+    nginx -t && systemctl reload nginx
+  "
+else
+  log "step 5-6/7: skipped TLS (add name.com A record, then re-run without SKIP_DNS_WAIT)"
+  $SSH "rm -f /tmp/nginx-malibu-download.conf" || true
+fi
+
+log "step 7/7: verify Pearl endpoint"
+if curl -fsS --max-time 15 --resolve "$DOMAIN:443:$VPS_HOST" "https://$DOMAIN/appcast.xml" >/dev/null 2>&1; then
+  log "  https://${DOMAIN}/appcast.xml reachable via Pearl TLS"
+elif curl -fsS --max-time 15 --resolve "$DOMAIN:80:$VPS_HOST" "http://$DOMAIN/" >/dev/null 2>&1; then
+  log "  HTTP stub on Pearl OK — TLS pending name.com A record + certbot re-run"
+else
+  log "  Pearl docroot ready; run publish-malibu-latest-dmg.sh after DNS"
+fi
+
+if [[ -n "$PUBLISH_TAG" ]]; then
+  bash "$SCRIPT_DIR/publish-malibu-latest-dmg.sh" "$PUBLISH_TAG"
+fi
+
+log "DONE. After DNS + cert: bash scripts/publish-malibu-latest-dmg.sh vX.Y.Z && bash scripts/verify-malibu-download.sh"

--- a/scripts/test-malibu-download-publish.sh
+++ b/scripts/test-malibu-download-publish.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SETUP="$ROOT/scripts/setup-malibu-download-pearl.sh"
+PUBLISH="$ROOT/scripts/publish-malibu-latest-dmg.sh"
+VERIFY="$ROOT/scripts/verify-malibu-download.sh"
+NGINX="$ROOT/scripts/dist/nginx-download.malibu.tech.conf"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+for f in "$SETUP" "$PUBLISH" "$VERIFY"; do
+  [[ -f "$f" ]] || fail "missing $f"
+  bash -n "$f" || fail "bash -n $f"
+done
+[[ -f "$NGINX" ]] || fail "missing $NGINX"
+
+grep -q 'setup-malibu-download-pearl.sh' "$PUBLISH" ||
+  grep -q 'Pearl' "$PUBLISH" ||
+  fail 'publish script should target Pearl VPS'
+
+grep -q 'MALIBU_DOWNLOAD_WEBROOT' "$PUBLISH" ||
+  fail 'publish script should use MALIBU_DOWNLOAD_WEBROOT'
+
+grep -q 'appcast.xml' "$PUBLISH" ||
+  fail 'publish script must upload appcast.xml'
+
+grep -q 'name.com' "$SETUP" ||
+  fail 'setup script should document name.com DNS'
+
+grep -q 'malibu-download' "$NGINX" ||
+  fail 'nginx config should serve /var/www/malibu-download'
+
+grep -q "'/appcast.xml'" "$VERIFY" ||
+  fail 'verify script should probe appcast.xml'
+
+echo "PASS: malibu download publish scripts present"

--- a/scripts/verify-malibu-download.sh
+++ b/scripts/verify-malibu-download.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Smoke-test the public Malibu download host (Sparkle + landing page).
+#
+# Usage:
+#   bash scripts/verify-malibu-download.sh
+#   MALIBU_DOWNLOAD_HOST=download.malibu.tech bash scripts/verify-malibu-download.sh
+#   MALIBU_DOWNLOAD_RESOLVE_IP=159.223.165.194  # when name.com DNS still propagating
+
+set -euo pipefail
+
+HOST="${MALIBU_DOWNLOAD_HOST:-download.malibu.tech}"
+RESOLVE_IP="${MALIBU_DOWNLOAD_RESOLVE_IP:-}"
+RESOLVE_IP="${MALIBU_DOWNLOAD_RESOLVE_IP:-159.223.165.194}"
+BASE="https://${HOST}"
+
+fail() {
+  printf '[verify-malibu-download] FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+curl_args=( -fsS --max-time 25 )
+if ! curl "${curl_args[@]}" "${BASE}/appcast.xml" >/dev/null 2>&1; then
+  curl_args+=( --resolve "${HOST}:443:${RESOLVE_IP}" )
+fi
+
+check_http() {
+  local path="$1" want="$2"
+  local body status
+  body="$(mktemp "${TMPDIR:-/tmp}/malibu-dl.XXXXXX")"
+  status="$(curl "${curl_args[@]}" -o "$body" -w '%{http_code}' "${BASE}${path}")" || fail "${path} unreachable"
+  [[ "$status" == "$want" ]] || fail "${path} status=${status} want=${want} body=$(head -c 200 "$body")"
+  rm -f "$body"
+  printf '  ok: %s -> %s\n' "$path" "$status"
+}
+
+printf '[verify-malibu-download] probing %s\n' "$BASE"
+check_http '/appcast.xml' '200'
+check_http '/latest.dmg' '200'
+
+appcast="$(curl "${curl_args[@]}" "${BASE}/appcast.xml")"
+echo "$appcast" | grep -q '<rss' || fail 'appcast.xml is not Sparkle RSS'
+echo "$appcast" | grep -q 'download.malibu.tech' || fail 'appcast missing download.malibu.tech URLs'
+
+printf '[verify-malibu-download] PASS\n'


### PR DESCRIPTION
## Summary
- Add `setup-malibu-download-pearl.sh`, `verify-malibu-download.sh`, and nginx vhost for `download.malibu.tech` on Pearl (Let's Encrypt + static docroot).
- Rework `publish-malibu-latest-dmg.sh` to SCP release assets to Pearl via SSH (replacing the unused R2 path).
- Wire `release.yml` to `MALIBU_DOWNLOAD_VPS_HOST` + `MALIBU_DOWNLOAD_SSH_KEY` secrets for post-tag publish.
- Add `scripts/test-malibu-download-publish.sh` to `make test-dist`; sync `MALIBU_WORKSTREAM.md` (P4 done).

## Live status
Already provisioned on Pearl (TLS + v1.8.19 assets). This PR lands the operator/CI scripts so future releases are repeatable.

## Test plan
- [x] `bash scripts/test-malibu-download-publish.sh`
- [x] `curl https://download.malibu.tech/appcast.xml` → 200
- [x] `curl https://download.malibu.tech/latest.dmg` → 200
- [x] Malibu **Check for Updates** succeeds on operator Mac
