### PR TITLE
perf(T0): decode-bench harness and baseline matrix

### DIFF
--- a/audits/2026-07-07/bench-snapshots/gpt-oss-20b-MXFP4-Q8.json
+++ b/audits/2026-07-07/bench-snapshots/gpt-oss-20b-MXFP4-Q8.json
@@ -1,0 +1,75 @@
+{
+  "bf16WeightsEnvFlag" : false,
+  "compiledDecodeEnvFlag" : false,
+  "decodeTokensTarget" : 256,
+  "label" : "baseline",
+  "mlxSwiftLMPin" : "mlxlm-3.31.4",
+  "modelID" : "mlx-community\/gpt-oss-20b-MXFP4-Q8",
+  "modelTag" : "gpt-oss-20b-MXFP4-Q8",
+  "prefillTokensTarget" : 512,
+  "runs" : 5,
+  "samples" : [
+    {
+      "decodeSeconds" : 3.3594330549240112,
+      "decodeTPS" : 27.087903974338424,
+      "decodeTokensActual" : 92,
+      "isWarmup" : false,
+      "prefillSeconds" : 2.0565290451049805,
+      "prefillTPS" : 283.00110877854894,
+      "promptTokensActual" : 582,
+      "ttftSeconds" : 2.0565290451049805
+    },
+    {
+      "decodeSeconds" : 3.320088028907776,
+      "decodeTPS" : 27.408911814286043,
+      "decodeTokensActual" : 92,
+      "isWarmup" : false,
+      "prefillSeconds" : 1.6526238918304443,
+      "prefillTPS" : 352.16724318040536,
+      "promptTokensActual" : 582,
+      "ttftSeconds" : 1.6526238918304443
+    },
+    {
+      "decodeSeconds" : 3.5016870498657227,
+      "decodeTPS" : 25.98747366743968,
+      "decodeTokensActual" : 92,
+      "isWarmup" : false,
+      "prefillSeconds" : 1.8523600101470947,
+      "prefillTPS" : 314.1937835042032,
+      "promptTokensActual" : 582,
+      "ttftSeconds" : 1.8523600101470947
+    },
+    {
+      "decodeSeconds" : 3.459913969039917,
+      "decodeTPS" : 26.30123200006946,
+      "decodeTokensActual" : 92,
+      "isWarmup" : false,
+      "prefillSeconds" : 1.824733018875122,
+      "prefillTPS" : 318.9507692247388,
+      "promptTokensActual" : 582,
+      "ttftSeconds" : 1.824733018875122
+    },
+    {
+      "decodeSeconds" : 3.780601978302002,
+      "decodeTPS" : 24.070240803521777,
+      "decodeTokensActual" : 92,
+      "isWarmup" : false,
+      "prefillSeconds" : 1.8837080001831055,
+      "prefillTPS" : 308.96508373029513,
+      "promptTokensActual" : 582,
+      "ttftSeconds" : 1.8837080001831055
+    }
+  ],
+  "schemaVersion" : 1,
+  "timestamp" : "2026-07-07T13:05:13Z",
+  "warmup" : {
+    "decodeSeconds" : 2.655717968940735,
+    "decodeTPS" : 34.26568674244293,
+    "decodeTokensActual" : 92,
+    "isWarmup" : true,
+    "prefillSeconds" : 40.080121994018555,
+    "prefillTPS" : 14.520913885612824,
+    "promptTokensActual" : 582,
+    "ttftSeconds" : 40.080121994018555
+  }
+}

--- a/audits/2026-07-07/bench-snapshots/qwen2.5-7b-instruct-4bit.json
+++ b/audits/2026-07-07/bench-snapshots/qwen2.5-7b-instruct-4bit.json
@@ -1,0 +1,75 @@
+{
+  "bf16WeightsEnvFlag" : false,
+  "compiledDecodeEnvFlag" : false,
+  "decodeTokensTarget" : 256,
+  "label" : "baseline",
+  "mlxSwiftLMPin" : "mlxlm-3.31.4",
+  "modelID" : "mlx-community\/Qwen2.5-7B-Instruct-4bit",
+  "modelTag" : "Qwen2.5-7B-Instruct-4bit",
+  "prefillTokensTarget" : 512,
+  "runs" : 5,
+  "samples" : [
+    {
+      "decodeSeconds" : 1.5138959884643555,
+      "decodeTPS" : 27.082441800766645,
+      "decodeTokensActual" : 42,
+      "isWarmup" : false,
+      "prefillSeconds" : 1.311108946800232,
+      "prefillTPS" : 413.39051291103897,
+      "promptTokensActual" : 542,
+      "ttftSeconds" : 1.311108946800232
+    },
+    {
+      "decodeSeconds" : 1.491129994392395,
+      "decodeTPS" : 27.495926011941474,
+      "decodeTokensActual" : 42,
+      "isWarmup" : false,
+      "prefillSeconds" : 1.3220479488372803,
+      "prefillTPS" : 409.97000182684764,
+      "promptTokensActual" : 542,
+      "ttftSeconds" : 1.3220479488372803
+    },
+    {
+      "decodeSeconds" : 1.5276840925216675,
+      "decodeTPS" : 26.838009376875466,
+      "decodeTokensActual" : 42,
+      "isWarmup" : false,
+      "prefillSeconds" : 1.168774962425232,
+      "prefillTPS" : 463.73341098558353,
+      "promptTokensActual" : 542,
+      "ttftSeconds" : 1.168774962425232
+    },
+    {
+      "decodeSeconds" : 1.4986538887023926,
+      "decodeTPS" : 27.357884504940493,
+      "decodeTokensActual" : 42,
+      "isWarmup" : false,
+      "prefillSeconds" : 1.2371230125427246,
+      "prefillTPS" : 438.1132631960331,
+      "promptTokensActual" : 542,
+      "ttftSeconds" : 1.2371230125427246
+    },
+    {
+      "decodeSeconds" : 1.5384360551834106,
+      "decodeTPS" : 26.65044144139746,
+      "decodeTokensActual" : 42,
+      "isWarmup" : false,
+      "prefillSeconds" : 1.2882949113845825,
+      "prefillTPS" : 420.71112383537303,
+      "promptTokensActual" : 542,
+      "ttftSeconds" : 1.2882949113845825
+    }
+  ],
+  "schemaVersion" : 1,
+  "timestamp" : "2026-07-07T13:03:38Z",
+  "warmup" : {
+    "decodeSeconds" : 1.5773829221725464,
+    "decodeTPS" : 25.992420371541908,
+    "decodeTokensActual" : 42,
+    "isWarmup" : true,
+    "prefillSeconds" : 0.9367130994796753,
+    "prefillTPS" : 578.6190033010852,
+    "promptTokensActual" : 542,
+    "ttftSeconds" : 0.9367130994796753
+  }
+}

--- a/audits/2026-07-07/decode-bench-harness/README.md
+++ b/audits/2026-07-07/decode-bench-harness/README.md
@@ -1,0 +1,15 @@
+# audits/2026-07-07/decode-bench-harness
+
+Artifact directory for T0-01 decode-bench harness — sample JSON snapshots.
+
+**Status:** Awaiting bench run (T0-02 operator window).
+
+See `beta/throughput-engineering/T0-01-decode-bench-harness.md` §6 for
+deferred-run instructions. JSON snapshots will be added here after the
+production provider maintenance window.
+
+Expected filename pattern:
+```
+baseline-Qwen2.5-7B-Instruct-4bit-mlxlm-3.31.4-<ISO8601>.json
+baseline-gpt-oss-20b-MXFP4-Q8-mlxlm-3.31.4-<ISO8601>.json
+```

--- a/beta/throughput-engineering/DEFERRED.md
+++ b/beta/throughput-engineering/DEFERRED.md
@@ -1,0 +1,18 @@
+# Throughput — explicit non-adopts
+
+**Date:** 2026-07-07  
+**Source:** T0-03 egress profile + exploration classifier  
+**Status:** ACTIVE unless live PERF_TRACE returns YELLOW/RED
+
+| Item | Bucket | Reason | Re-open trigger |
+|------|--------|--------|-----------------|
+| #479 NWConnection transport | C | No serial outbound pipeline; `BlockingChunkBuffer` + direct `sendFrame` | T0-03 live trace RED (>15% egress) |
+| #480 ChunkBatcher / AsyncStream bypass | C | Inbound AsyncStream only; chunks not on outbound AsyncStream | Same |
+| #476 shutdown actor hop | C | Structure not present | — |
+| #475 serial WS outbound | C | Not present | — |
+| v0.6.26 TCP_NODELAY | C | Requires NWConnection | #479 adopted |
+| #483 DH precompute | B (N/A) | Session HKDF already (`Tier2ProviderSession.swift:79-100`) | — |
+| bf16 weight cast | — | Net-negative on M5 (`audits/2026-06-30/perf-mlx-engine.md`) | New hardware evidence |
+| Layr-Labs fork submodule | — | Clean-room; use ml-explore pins | Never by default |
+
+**T0-03 verdict:** MAINTAIN DEFER for NWConnection cluster (structural GREEN, medium-high confidence).

--- a/beta/throughput-engineering/T0-01-decode-bench-harness.md
+++ b/beta/throughput-engineering/T0-01-decode-bench-harness.md
@@ -1,0 +1,238 @@
+# T0-01 — Decode-Bench Harness
+
+**Status:** GREEN — build + tests pass; bench run deferred (see §5)  
+**Task ID:** T0-01  
+**Branch:** `perf/decode-bench-harness`  
+**Worktree:** `/Users/augstar/macprovider-throughput-t0-01`  
+**Date:** 2026-07-07  
+**Executor:** Cursor agent
+
+---
+
+## 1. Objective
+
+Restore the `decode-bench` subcommand on `main` without `CompiledDecode`,
+bf16 cast, or any `ModelRuntime` wire-ins. This is the harness-only landing
+that unblocks T0-02 (baseline matrix).
+
+---
+
+## 2. Source
+
+Cherry-ported from `origin/perf/mlx-compile-bf16` commit `aa10847`
+(`perf(provider): MLX compile()+bf16 decode-engine scaffolding`).
+
+**Files added:**
+- `phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift` (new)
+
+**Files modified:**
+- `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift` — added
+  `DecodeBenchCommand.self` to subcommands list
+
+**Files NOT ported (by design):**
+- `CompiledDecode.swift` — T2-01 scope
+- `WeightCast.swift` — DEFERRED (bf16 confirmed net-negative on M-series, `perf-mlx-engine.md`)
+- `ModelRuntime.swift` changes — no bf16/compile wire-in in T0-01
+
+---
+
+## 3. CLI shape
+
+```bash
+macprovider-cli decode-bench \
+  --model mlx-community/Qwen2.5-7B-Instruct-4bit \
+  --prefill-tokens 512 \
+  --decode-tokens 256 \
+  --runs 5 \
+  --output state/perf/baseline-qwen-2025-07-07.json
+```
+
+Full `--help` output:
+
+```
+OVERVIEW: Run a pure-decode benchmark for a target model (T0-01 of throughput runbook).
+
+USAGE: macprovider-cli decode-bench [--model <model>] [--decode-tokens <decode-tokens>]
+       [--prefill-tokens <prefill-tokens>] [--runs <runs>] [--label <label>]
+       [--output <output>] [--output-dir <output-dir>] [--stdout-only]
+
+OPTIONS:
+  --model <model>              HuggingFace model ID or local path. Falls back to MACPROVIDER_MODEL.
+  --decode-tokens <decode-tokens>   Number of decode tokens to generate per run. Default 256.
+  --prefill-tokens <prefill-tokens> Approximate prefill token target. Default 512.
+  --runs <runs>                Number of timed runs (after a single warmup). Default 3.
+  --label <label>              Label suffix for auto-generated output filenames.
+  --output <output>            Full output path for JSON result file.
+  --output-dir <output-dir>    Output directory for auto-generated JSON (default: state/perf/).
+  --stdout-only                Skip writing the JSON file to disk.
+```
+
+---
+
+## 4. TPS semantics
+
+**Generation-only TPS** — denominator excludes TTFT.
+
+Matching `Stage1Iterator.swift` v1.7.8 Track A4 semantics (commit comment
+`"v1.7.8 Track A4: measure generation-only throughput"`):
+
+```
+generationElapsed = endAt - firstTokenAt   // first token is TTFT boundary
+decodeTPS = (generationTokens - 1) / generationElapsed
+```
+
+The `-1` subtracts the boundary token counted at TTFT. The `Stage1Iterator`
+equivalent counts SSE `deltaCount` starting from `firstTokenAt != nil`, which
+achieves the same exclusion at the SSE streaming layer.
+
+This matches the semantics that `min_sustained_tps` catalog gates express
+(warm-generation throughput, not whole-request throughput).
+
+---
+
+## 5. Build + test results
+
+**System:**
+- Chip: Apple M5
+- RAM: 32 GB
+- macOS: 26.5
+- `macprovider-cli` version: 1.8.19
+- `mlx-swift-lm` pin: 3.31.4
+- `mlx-swift` pin: 0.31.6
+
+**Build:**
+```
+swift build -c release   # in phase3-binary/
+Build complete!  (562.6s)   exit_code: 0
+```
+
+Warnings observed: pre-existing Swift 6 Sendable / `GenerateResult` warnings
+in `ModelRuntime.swift`. No new warnings introduced by this PR.
+
+**Tests:**
+```
+swift test               # in phase3-binary/
+Executed 946 tests, with 8 tests skipped and 0 failures (0 unexpected)
+exit_code: 0
+```
+
+---
+
+## 6. Bench run attempt
+
+**Status: DEFERRED — active production provider**
+
+Attempted to locate cached models for a dry-run benchmark:
+
+| Model | Cache state |
+|-------|-------------|
+| `mlx-community/Qwen2.5-7B-Instruct-4bit` | refs only (no snapshots) — NOT available |
+| `mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit` | refs only — NOT available |
+| `mlx-community/gpt-oss-20b-MXFP4-Q8` | snapshots present (20B, 3-shard) |
+| `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` | snapshots present (30B) |
+
+At bench time, `live.streamvc.macprovider` was **running** (launchctl state=running,
+PID 64586). Per `.cursor/rules/autotune-benchmarks.mdc`, running decode-bench
+concurrently with the production 30B model on 32 GB risks GPU/RAM contention
+and MLX crashes.
+
+**Decision:** Defer bench run to T0-02 operator window when production provider
+can be temporarily drained. Build + tests are GREEN, satisfying the T0-01
+pass criterion.
+
+**To run the bench (after draining production provider):**
+```bash
+# 1. Drain production provider (bench will run a separate model instance)
+launchctl bootout "gui/$(id -u)/live.streamvc.macprovider" 2>/dev/null || true
+
+# 2. Run bench
+.build/arm64-apple-macosx/release/macprovider-cli decode-bench \
+  --model mlx-community/Qwen2.5-7B-Instruct-4bit \
+  --prefill-tokens 512 \
+  --decode-tokens 256 \
+  --runs 5 \
+  --output state/perf/baseline-qwen25-7b-mlxlm-3.31.4.json
+
+# 3. Restore production provider
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/live.streamvc.macprovider.plist 2>/dev/null || true
+launchctl kickstart -k "gui/$(id -u)/live.streamvc.macprovider"
+```
+
+JSON output will be committed to `audits/2026-07-07/decode-bench-harness/` in T0-02.
+
+---
+
+## 7. Metallib note
+
+The `mlx-swift_Cmlx.bundle` pattern from `audits/2026-06-30/perf-mlx-engine.md`
+(manually copying the bundle next to the release binary) was required in that
+bench session because it used a standalone release binary extracted from the
+package. In the worktree's `.build/arm64-apple-macosx/release/` tree, SPM
+places the `phase3-binary_macprovider-cli.bundle` adjacent to the binary;
+MLX resolves Metal shaders via the bundle at that path.
+
+For the T0-02 bench run (production or operator-extracted binary), apply the
+same `mlx-swift_Cmlx.bundle` copy step if running outside the `.build/` tree.
+
+---
+
+## 8. JSON output schema (reference)
+
+```json
+{
+  "bf16WeightsEnvFlag": false,
+  "compiledDecodeEnvFlag": false,
+  "decodeTokensTarget": 256,
+  "label": "baseline",
+  "mlxSwiftLMPin": "mlxlm-3.31.4",
+  "modelID": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+  "modelTag": "Qwen2.5-7B-Instruct-4bit",
+  "prefillTokensTarget": 512,
+  "runs": 3,
+  "samples": [
+    {
+      "decodeSeconds": 8.76,
+      "decodeTPS": 29.1,
+      "decodeTokensActual": 256,
+      "isWarmup": false,
+      "prefillSeconds": 1.87,
+      "prefillTPS": 273.0,
+      "promptTokensActual": 512,
+      "ttftSeconds": 1.87
+    }
+  ],
+  "schemaVersion": 1,
+  "timestamp": "2026-07-07T...",
+  "warmup": { "..." }
+}
+```
+
+Fields `bf16WeightsEnvFlag` and `compiledDecodeEnvFlag` are always `false`
+in this T0-01 harness. T2-01 will introduce compiled decode and flip
+`compiledDecodeEnvFlag` when `MACPROVIDER_COMPILED_DECODE=1`.
+
+---
+
+## 9. Pass / fail
+
+| Criterion | Result |
+|-----------|--------|
+| CLI subcommand registers and shows help | PASS |
+| `swift build -c release` exits 0 | PASS |
+| `swift test` exits 0 (946 tests, 0 failures) | PASS |
+| Bench run on M-series with JSON output | DEFERRED — production provider active |
+| No CompiledDecode / WeightCast / ModelRuntime bf16 wire-in | PASS |
+
+**VERDICT: GREEN** — build + tests pass; bench run deferred to T0-02 operator window.
+
+---
+
+## 10. Blockers for T0-02
+
+None from harness side. T0-02 needs:
+1. A maintenance window with `live.streamvc.macprovider` drained
+2. `mlx-community/Qwen2.5-7B-Instruct-4bit` downloaded (not yet cached locally)
+3. `mlx-community/gemma-4-26b-a4b-it-4bit` downloaded (not yet cached)
+4. Same for `mlx-community/gpt-oss-20b-MXFP4-Q8` — weights ARE cached; can use immediately
+
+`gpt-oss-20b` bench can start as soon as provider is drained.

--- a/beta/throughput-engineering/T0-02-baseline-matrix.json
+++ b/beta/throughput-engineering/T0-02-baseline-matrix.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 1,
+  "task_id": "T0-02",
+  "verdict": "YELLOW",
+  "verdict_reason": "2 of 3 required models complete without swap; Gemma-4-26b blocked by mlx-swift-lm 3.31.4 Gemma4 MoE architecture gap (see blocker section).",
+  "run_date": "2026-07-07",
+  "hardware": {
+    "chip": "Apple M5",
+    "model": "MacBook Air (Mac17,3)",
+    "ram_gb": 32,
+    "macos": "26.5 (Build 25F71)",
+    "macprovider_cli_version": "1.8.19",
+    "mlx_swift_pin": "0.31.6 (rev 0bb916c67f4b)",
+    "mlx_swift_lm_pin": "3.31.4 (rev bd4b7434e6bd)",
+    "bench_binary": "phase3-binary/.build/release/macprovider-cli (swift build -c release)",
+    "metallib_source": "built from mlx-swift 0.31.6 checkout via scripts/build-mlx-metallib.sh",
+    "production_provider_during_bench": "STOPPED — live.streamvc.macprovider (PID 71387, qwen3-coder-30b-a3b-instruct on port 61919) was safely bootout via launchctl before bench; restored after."
+  },
+  "swap_observed": false,
+  "models": [
+    {
+      "model_id": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+      "role": "dense_control",
+      "status": "GREEN",
+      "decode_tps_p50": 27.1,
+      "prefill_tps_p50": 420.7,
+      "ttft_ms_p50": 1288,
+      "decode_tokens_actual_p50": 42,
+      "prefill_tokens_actual": 542,
+      "runs": 5,
+      "prior_baseline_tps": 29.21,
+      "prior_baseline_note": "2026-06-30 / mlx-swift-lm 2.29.1 on same M5 hardware",
+      "delta_vs_prior_pct": -7.2,
+      "red_threshold_pct": 10.0,
+      "verdict": "GREEN — within 10% of prior baseline; prefill +53.7% faster on newer MLX",
+      "snapshot_path": "audits/2026-07-07/bench-snapshots/qwen2.5-7b-instruct-4bit.json",
+      "bandwidth_model_note": "Implied M5 bandwidth: 27.1 * 7B * 0.5B/param / 0.8 = 118.6 GB/s (consistent with M5 MBA peak)"
+    },
+    {
+      "model_id": "mlx-community/gpt-oss-20b-MXFP4-Q8",
+      "role": "moe_control",
+      "status": "GREEN",
+      "decode_tps_p50": 26.3,
+      "prefill_tps_p50": 314.2,
+      "ttft_ms_p50": 1853,
+      "decode_tokens_actual_p50": 92,
+      "prefill_tokens_actual": 582,
+      "runs": 5,
+      "catalog_min_sustained_tps": 12.0,
+      "catalog_target_met": true,
+      "verdict": "GREEN — 26.3 TPS vs 12 TPS catalog floor; well above threshold",
+      "snapshot_path": "audits/2026-07-07/bench-snapshots/gpt-oss-20b-MXFP4-Q8.json",
+      "bandwidth_model": {
+        "formula": "decode_tps ≈ bandwidth_GBps * 0.8 / (active_params * 0.5625 / 1e9)",
+        "bandwidth_GBps_derived": 118.6,
+        "measured_tps": 26.3,
+        "implied_active_params_B": 6.42,
+        "total_params_B": 20.0,
+        "active_fraction_pct": 32.1,
+        "note": "6.4B implied active of 20B total; consistent with MoE top-k routing (e.g. top-2 of N experts where active expert mass ≈ 6.4B)"
+      }
+    },
+    {
+      "model_id": "mlx-community/gemma-4-26b-a4b-it-4bit",
+      "role": "moe_primary",
+      "status": "YELLOW",
+      "decode_tps_p50": null,
+      "prefill_tps_p50": null,
+      "ttft_ms_p50": null,
+      "verdict": "YELLOW — BLOCKED: mlx-swift-lm 3.31.4 fails to load Gemma4 MoE (unhandled keys: experts, router, post_feedforward_layernorm_1/2, pre_feedforward_layernorm_2 in Gemma4DecoderLayer)",
+      "snapshot_path": null,
+      "blocker": {
+        "error": "Unhandled keys [\"experts\", \"post_feedforward_layernorm_1\", \"post_feedforward_layernorm_2\", \"pre_feedforward_layernorm_2\", \"router\"] in language_model.model.layers.0 in Gemma4Model.Gemma4TextModel.Gemma4TextModelInner.Gemma4DecoderLayer",
+        "root_cause": "mlx-swift-lm 3.31.4 Gemma4 model class lacks MoE expert/router wiring — architecture added in a later release",
+        "fix": "T1-01 pin bump to mlx-swift-lm ≥ version with Gemma4 MoE support",
+        "catalog_impact": "P1-Gemma catalog TPS gate cannot be measured until T1-01 is complete"
+      },
+      "bandwidth_model_predicted": {
+        "formula": "decode_tps ≈ bandwidth_GBps * 0.8 / (active_params * 0.5625 / 1e9)",
+        "architecture": "Gemma4 MoE: 30 layers, 128 experts per layer, top-8 active, hidden=2816, moe_intermediate_size=704",
+        "total_params_B": 26.0,
+        "active_params_estimate_B": 3.97,
+        "active_params_derivation": "Attention (1.04B) + active-MoE-FFN (1.47B = 23.5B_expert * 8/128) + embeddings (1.48B) ≈ 3.97B",
+        "predicted_tps_at_118_GBps": "~42 TPS (predicted; not measured — harness must re-run after T1-01)",
+        "note": "High predicted TPS because MoE sparsity means only 15% of expert weights read per token"
+      }
+    }
+  ],
+  "tg0_status": {
+    "harness_ready": true,
+    "baseline_json_committed": true,
+    "reference_hardware_documented": true,
+    "verdict": "YELLOW — 2/3 models complete; Gemma4 MoE blocked on current pin. PROCEED to T1-01 (pin bump) which unblocks Gemma4 baseline re-measure. Dense control (Qwen) and MoE control (gpt-oss) are sufficient baselines to gate T1-01 correctness check.",
+    "proceed_to_t1": true,
+    "proceed_condition": "T1-01 must include Gemma4 re-measure as T1-02 precondition"
+  },
+  "metallib_fix_note": "First bench attempt used production binary's mlx-swift_Cmlx.bundle (compiled for a different MLX version). Correct metallib was built from mlx-swift 0.31.6 checkout using scripts/build-mlx-metallib.sh. Without this fix, Qwen showed 12.4 TPS (mismatched Metal shaders). With version-matched metallib: 27.1 TPS. Metallib mismatch produces wrong (not absent) shaders — Metal does not error out, just runs suboptimally."
+}

--- a/beta/throughput-engineering/T0_SUMMARY.md
+++ b/beta/throughput-engineering/T0_SUMMARY.md
@@ -1,0 +1,91 @@
+# T0 rollup — Throughput measurement foundation
+
+**Date:** 2026-07-07  
+**Plan:** `specs/PLAN_THROUGHPUT_ENGINEERING_RUNBOOK.md`  
+**Gate:** **TG0 PROCEED** (YELLOW — 2/3 baseline models; Gemma deferred to T1-01)
+
+---
+
+## Task verdicts
+
+| Task ID | Verdict | Branch / worktree | Artifact |
+|---------|---------|---------------------|----------|
+| T0-01 | **GREEN** | `perf/decode-bench-harness` @ `../macprovider-throughput-t0-01` | `T0-01-decode-bench-harness.md` (on branch) |
+| T0-02 | **YELLOW** | same branch | `T0-02-baseline-matrix.json` + `audits/2026-07-07/bench-snapshots/*.json` (on branch) |
+| T0-03 | **GREEN (structural)** | `perf/egress-trace-t0-03` @ `../macprovider-throughput-t0-03` | `T0-03-egress-profile.md` (on branch) |
+
+---
+
+## Reference hardware (T0-02)
+
+| Field | Value |
+|-------|-------|
+| Machine | MacBook Air (Mac17,3), Apple **M5**, **32 GB** |
+| macOS | 26.5 (25F71) |
+| MLX pins | `mlx-swift` **0.31.6**, `mlx-swift-lm` **3.31.4** |
+| Bench binary | `phase3-binary/.build/release/macprovider-cli` |
+| Metallib | **Must match pin** — built via `scripts/build-mlx-metallib.sh` from mlx-swift 0.31.6 checkout |
+
+---
+
+## Baseline matrix (p50, generation-only decode TPS)
+
+| Model | Role | Decode TPS | Prefill TPS | TTFT | Verdict |
+|-------|------|------------|-------------|------|---------|
+| `Qwen2.5-7B-Instruct-4bit` | Dense control | **27.1** | 420.7 | 1.29s | GREEN (−7.2% vs Jun-30 29.2; within 10%) |
+| `gpt-oss-20b-MXFP4-Q8` | MoE control | **26.3** | 314.2 | 1.85s | GREEN (vs 12 TPS catalog floor) |
+| `gemma-4-26b-a4b-it-4bit` | MoE primary | — | — | — | **BLOCKED** on pin 3.31.4 |
+
+**Swap:** none (production provider stopped via `launchctl bootout` for bench window, restored after).
+
+---
+
+## Key decisions (pinned session)
+
+### D-T0-1 — TG0 closes as PROCEED (YELLOW)
+
+Harness is validated; dense + gpt-oss baselines are sufficient to gate **T1-01 pin bump** (token-exact regression on Qwen). Gemma-4 baseline is a **hard precondition for T1-02**, not TG0.
+
+### D-T0-2 — Gemma-4 blocked on current mlx-swift-lm pin
+
+`Gemma4DecoderLayer` fails on MoE keys (`experts`, `router`, …). Fix is **T1-01**, not a MacProvider provider patch. Bandwidth model predicts **~42 TPS** at ~3.97B active params once loadable — **unverified**.
+
+### D-T0-3 — Metallib version match is load-bearing (elevates T1-03)
+
+Mismatched production metallib produced **12.4 TPS** on Qwen (wrong shaders, no error). Version-matched build restored **27.1 TPS**. **T1-03 is a merge gate**, not optional packaging polish.
+
+### D-T0-4 — NWConnection cluster stays DEFER
+
+T0-03 structural analysis: `BlockingChunkBuffer` decouples decode from WS send; estimated egress **~1–2%** of token period at catalog TPS. Live `MACPROVIDER_PERF_TRACE=1` run optional before T1; does not block TG0.
+
+### D-T0-5 — PR merge order for T0 code
+
+1. **`perf/decode-bench-harness`** — `DecodeBenchCommand` + T0-02 audit snapshots (harness value)
+2. **`perf/egress-trace-t0-03`** — gated trace (can merge independently or stack after #1)
+
+---
+
+## gpt-oss MoE sparsity note
+
+Implied **6.4B active** of 20B total at 26.3 TPS → MoE routing appears sparse on current stack. Useful sanity check for post-bump Gemma comparison in T1-02.
+
+---
+
+## TG0 recommendation
+
+**PROCEED to T1-01** with conditions:
+
+| Condition | Owner |
+|-----------|-------|
+| Merge T0-01 harness PR | Operator |
+| T1-01 includes Gemma4 load fix via lm pin bump | T1-01 executor |
+| T1-02 re-runs full 3-model matrix post-bump | T1-02 executor |
+| T1-03 verifies metallib from bumped checkout | T1-03 executor |
+
+---
+
+## Next tasks (spawn order)
+
+1. **T1-01** — MLX pin bump (`perf/mlx-0.32-bump` worktree)
+2. **T1-03** — can parallel metallib rebuild once pin chosen
+3. **T1-02** — blocked until T1-01 merged

--- a/phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift
@@ -1,0 +1,334 @@
+import ArgumentParser
+import Foundation
+import MLXLLM
+import MLXLMCommon
+import MacProviderCore
+
+/// `decode-bench` — pure decode-loop benchmark, no coordinator, no WS.
+///
+/// T0-01 of `specs/PLAN_THROUGHPUT_ENGINEERING_RUNBOOK.md`. Loads the same
+/// `LLMModelFactory` / `MLXLMCommon` path the serve runtime uses, runs
+/// a fixed-length prefill + decode, and reports prefill TPS, decode TPS
+/// (p50 across N runs after one warmup), and decode wall time as JSON.
+///
+/// TPS semantics (generation-only): denominator is time from first generated
+/// token to last, excluding TTFT (prefill wall-clock). Matches
+/// `Stage1Iterator.swift` v1.7.8 Track A4 semantics — "generation-only
+/// throughput" where `generationElapsed = endedAt - firstTokenAt`.
+///
+/// Does NOT wire CompiledDecode or bf16 weight cast — harness only.
+/// Those are T2-01 scope. The JSON output records `compiledDecodeEnvFlag`
+/// and `bf16WeightsEnvFlag` as `false` so downstream tooling has a stable
+/// schema to diff against T2-01 results.
+struct DecodeBenchCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "decode-bench",
+        abstract: "Run a pure-decode benchmark for a target model (T0-01 of throughput runbook).",
+        discussion: """
+            Decoupled from the coordinator and WS paths. Measures prefill TPS
+            and steady-state decode TPS over a fixed prompt + token budget.
+
+            TPS semantics: generation-only (excludes TTFT), matching Stage1Iterator
+            v1.7.8 Track A4 semantics.
+            """
+    )
+
+    @Option(help: "HuggingFace model ID or local path. Falls back to MACPROVIDER_MODEL.")
+    var model: String?
+
+    @Option(
+        name: .customLong("decode-tokens"),
+        help: "Number of decode tokens to generate per run. Default 256."
+    )
+    var decodeTokens: Int = 256
+
+    @Option(
+        name: .customLong("prefill-tokens"),
+        help: "Approximate prefill token target. The fixture prompt is replicated until token count meets/exceeds this. Default 512."
+    )
+    var prefillTokens: Int = 512
+
+    @Option(help: "Number of timed runs (after a single warmup). Default 3.")
+    var runs: Int = 3
+
+    @Option(
+        help: "Optional label suffix for auto-generated output filenames (e.g. 'baseline'). Default 'baseline'."
+    )
+    var label: String = "baseline"
+
+    @Option(
+        help: "Full output path for JSON result file. When set, writes to this exact path instead of the auto-generated state/perf/ path."
+    )
+    var output: String?
+
+    @Option(
+        name: .customLong("output-dir"),
+        help: "Output directory for auto-generated JSON result files. Ignored when --output is set. Default 'state/perf/'."
+    )
+    var outputDir: String = "state/perf"
+
+    @Flag(help: "Skip writing the JSON file to disk; print to stdout only.")
+    var stdoutOnly: Bool = false
+
+    func run() async throws {
+        guard let modelID = model ?? ProcessInfo.processInfo.environment["MACPROVIDER_MODEL"],
+              !modelID.isEmpty else {
+            FileHandle.standardError.write(Data(
+                "decode-bench: --model is required (or set MACPROVIDER_MODEL)\n".utf8
+            ))
+            throw ExitCode(2)
+        }
+        guard decodeTokens > 0, prefillTokens > 0, runs > 0 else {
+            FileHandle.standardError.write(Data(
+                "decode-bench: --decode-tokens, --prefill-tokens, --runs must all be > 0\n".utf8
+            ))
+            throw ExitCode(2)
+        }
+
+        // T0-01 harness: compiled decode and bf16 cast are NOT wired.
+        // These flags are always false here; T2-01 will introduce the
+        // compiled path and flip them when the env vars are set.
+        let bf16Enabled = false
+        let compiledEnabled = false
+
+        // Reuse the serve runtime's model load path so the bench sees the
+        // same dtype histogram and same KVCache wiring it would in prod.
+        let runtime = try await ModelRuntime(modelID: modelID)
+        guard await runtime.isLoaded else {
+            FileHandle.standardError.write(Data(
+                "decode-bench: failed to load model \(modelID)\n".utf8
+            ))
+            throw ExitCode(1)
+        }
+
+        let snapshot = await runtime.currentSnapshot()
+        guard let container = snapshot.container else {
+            FileHandle.standardError.write(Data(
+                "decode-bench: runtime has no container post-load\n".utf8
+            ))
+            throw ExitCode(1)
+        }
+
+        // Build a prompt that prefills to roughly the requested token count.
+        // We don't try to hit the exact target — `prefillTokensActual` in
+        // the output records what we got, which is what the analyst needs.
+        let basePrompt = "Summarize the following technical document. "
+        let replications = max(1, prefillTokens / 8)
+        let prompt = String(repeating: basePrompt, count: replications)
+
+        // One warmup run, then `runs` timed runs.
+        var warmupSample: BenchSampleResult?
+        var samples: [BenchSampleResult] = []
+        for runIndex in 0..<(runs + 1) {
+            let isWarmup = runIndex == 0
+            let sample = try await runOnce(
+                container: container,
+                prompt: prompt,
+                maxTokens: decodeTokens,
+                isWarmup: isWarmup
+            )
+            if isWarmup {
+                warmupSample = sample
+            } else {
+                samples.append(sample)
+            }
+        }
+
+        let pin = decodeBenchMLXPinTag()
+        let modelTag = modelID
+            .split(separator: "/")
+            .last
+            .map(String.init) ?? "model"
+
+        var tsFormatter = ISO8601DateFormatter()
+        tsFormatter.formatOptions = [.withInternetDateTime, .withTimeZone]
+        let ts = tsFormatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
+
+        let report = BenchReport(
+            schemaVersion: 1,
+            label: label,
+            modelID: modelID,
+            modelTag: modelTag,
+            mlxSwiftLMPin: pin,
+            prefillTokensTarget: prefillTokens,
+            decodeTokensTarget: decodeTokens,
+            runs: runs,
+            warmup: warmupSample,
+            samples: samples,
+            bf16WeightsEnvFlag: bf16Enabled,
+            compiledDecodeEnvFlag: compiledEnabled,
+            timestamp: ISO8601DateFormatter().string(from: Date())
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let json = try encoder.encode(report)
+        FileHandle.standardOutput.write(json)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+
+        let p50Decode = decodeBenchPercentileTPS(samples.map(\.decodeTPS), p: 0.5)
+        let p50Prefill = decodeBenchPercentileTPS(samples.map(\.prefillTPS), p: 0.5)
+        FileHandle.standardError.write(Data((
+            "decode-bench: model=\(modelTag) pin=\(pin) " +
+            "prefill_tps_p50=\(decodeBenchFormatTPS(p50Prefill)) " +
+            "decode_tps_p50=\(decodeBenchFormatTPS(p50Decode)) " +
+            "bf16=\(bf16Enabled) compiled=\(compiledEnabled) runs=\(runs)\n"
+        ).utf8))
+
+        guard !stdoutOnly else { return }
+
+        let fileURL: URL
+        if let explicitPath = output {
+            fileURL = URL(fileURLWithPath: explicitPath)
+            if let parent = fileURL.deletingLastPathComponent() as URL?, parent.path != "/" {
+                try FileManager.default.createDirectory(
+                    at: parent, withIntermediateDirectories: true
+                )
+            }
+        } else {
+            let dir = URL(fileURLWithPath: outputDir, isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let safeLabel = decodeBenchSanitizeFilenameComponent(label)
+            let safeModelTag = decodeBenchSanitizeFilenameComponent(modelTag)
+            let filename = "\(safeLabel)-\(safeModelTag)-\(pin)-\(ts).json"
+            fileURL = dir.appendingPathComponent(filename)
+        }
+        try json.write(to: fileURL, options: [.atomic])
+        FileHandle.standardError.write(Data("decode-bench: wrote \(fileURL.path)\n".utf8))
+    }
+
+    // MARK: - One sample
+
+    private func runOnce(
+        container: ModelContainer,
+        prompt: String,
+        maxTokens: Int,
+        isWarmup: Bool
+    ) async throws -> BenchSampleResult {
+        let prefillStart = Date()
+        // Capture first-token timestamp from inside the generate callback.
+        // `nonisolated(unsafe)` is needed because the closure is @Sendable
+        // (container.perform isolates to the ModelContext actor) but we
+        // only write once (first token) and read after await returns.
+        nonisolated(unsafe) var firstTokenAt: Date? = nil
+        var promptTokens = 0
+        var generationTokens = 0
+        try await container.perform { context in
+            let input = UserInput(chat: [.user(prompt)])
+            let lmInput = try await context.processor.prepare(input: input)
+            promptTokens = lmInput.text.tokens.size
+            let parameters = GenerateParameters(
+                maxTokens: maxTokens,
+                temperature: 0.0,
+                topP: 1.0
+            )
+            let result: GenerateResult = try generate(
+                input: lmInput,
+                parameters: parameters,
+                context: context
+            ) { tokens in
+                if firstTokenAt == nil, !tokens.isEmpty {
+                    firstTokenAt = Date()
+                }
+                return GenerateDisposition.more
+            }
+            generationTokens = result.generationTokenCount
+        }
+        let endAt = Date()
+        let prefillEnd = firstTokenAt ?? endAt
+        let prefillElapsed = max(prefillEnd.timeIntervalSince(prefillStart), 0.001)
+        // Generation-only elapsed time: from first generated token to last.
+        // Matches Stage1Iterator.swift v1.7.8 Track A4 semantics —
+        // denominator excludes TTFT so catalog `min_sustained_tps` gates apply.
+        let decodeElapsed = max(endAt.timeIntervalSince(prefillEnd), 0.001)
+        let prefillTPS = Double(promptTokens) / prefillElapsed
+        // Subtract 1 because the first token is the TTFT boundary token,
+        // not a "generated beyond prefill" token.
+        let decodeTPS = Double(max(generationTokens - 1, 0)) / decodeElapsed
+
+        return BenchSampleResult(
+            isWarmup: isWarmup,
+            promptTokensActual: promptTokens,
+            decodeTokensActual: generationTokens,
+            prefillSeconds: prefillElapsed,
+            decodeSeconds: decodeElapsed,
+            ttftSeconds: prefillElapsed,
+            prefillTPS: prefillTPS,
+            decodeTPS: decodeTPS
+        )
+    }
+}
+
+// MARK: - Helpers (module-level, prefixed to avoid collision)
+
+/// The mlx-swift-lm pin tag used for benchmark output filenames so a
+/// future operator can disambiguate runs taken on different pins.
+/// Source of truth: `phase3-binary/Package.resolved` — update when pin bumps.
+func decodeBenchMLXPinTag() -> String {
+    return "mlxlm-3.31.4"
+}
+
+/// Nearest-rank percentile for small `runs` budgets (3–5).
+/// For `runs == 3`, p50 is the middle element after sort.
+func decodeBenchPercentileTPS(_ values: [Double], p: Double) -> Double {
+    guard !values.isEmpty else { return 0 }
+    let sorted = values.sorted()
+    let rank = max(0, min(sorted.count - 1, Int((p * Double(sorted.count - 1)).rounded())))
+    return sorted[rank]
+}
+
+func decodeBenchFormatTPS(_ v: Double) -> String {
+    String(format: "%.1f", v)
+}
+
+/// Reduce an operator-supplied string to a basename-safe slug.
+/// Prevents path-traversal sequences (`../`) from reaching the output path.
+func decodeBenchSanitizeFilenameComponent(_ input: String) -> String {
+    let allowed: Set<Character> = Set(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
+    )
+    var out = String()
+    out.reserveCapacity(input.count)
+    var lastWasUnderscore = false
+    for ch in input {
+        if allowed.contains(ch) {
+            out.append(ch)
+            lastWasUnderscore = (ch == "_")
+        } else if !lastWasUnderscore {
+            out.append("_")
+            lastWasUnderscore = true
+        }
+    }
+    let trimmed = out.trimmingCharacters(in: CharacterSet(charactersIn: "_."))
+    let capped = String(trimmed.prefix(80))
+    return capped.isEmpty ? "unlabeled" : capped
+}
+
+// MARK: - Wire schema
+
+struct BenchSampleResult: Codable, Sendable {
+    let isWarmup: Bool
+    let promptTokensActual: Int
+    let decodeTokensActual: Int
+    let prefillSeconds: TimeInterval
+    let decodeSeconds: TimeInterval
+    let ttftSeconds: TimeInterval
+    let prefillTPS: Double
+    let decodeTPS: Double
+}
+
+struct BenchReport: Codable, Sendable {
+    let schemaVersion: Int
+    let label: String
+    let modelID: String
+    let modelTag: String
+    let mlxSwiftLMPin: String
+    let prefillTokensTarget: Int
+    let decodeTokensTarget: Int
+    let runs: Int
+    let warmup: BenchSampleResult?
+    let samples: [BenchSampleResult]
+    let bf16WeightsEnvFlag: Bool
+    let compiledDecodeEnvFlag: Bool
+    let timestamp: String
+}

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -11,7 +11,7 @@ struct MacProviderCLI: AsyncParsableCommand {
         commandName: "macprovider-cli",
         abstract: "OpenAI-compatible Mac Provider inference CLI.",
         version: CoordinatorClient.binaryVersion,
-        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, RotateKeyCommand.self, Spec028CanaryCommand.self],
+        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, RotateKeyCommand.self, Spec028CanaryCommand.self, DecodeBenchCommand.self],
         defaultSubcommand: ServeCommand.self
     )
 }

--- a/specs/PLAN_THROUGHPUT_ENGINEERING_RUNBOOK.md
+++ b/specs/PLAN_THROUGHPUT_ENGINEERING_RUNBOOK.md
@@ -1,0 +1,581 @@
+# PLAN — MacProvider Throughput Engineering Runbook
+
+**Version:** 0.1.2  
+**Date:** 2026-07-07  
+**Status:** ACTIVE — **T0 complete (TG0 PROCEED)**; ready for T1  
+**Source analysis:** Throughput engineering exploration (2026-07-07 Cursor session)  
+**Pinned session role:** Single plan-of-record for MLX/engine/egress throughput work. Executor agents update task status here; the pinned planning session verifies gates and revises sequencing.
+
+**Relationship to other plans**
+
+| Plan | Overlap |
+|------|---------|
+| `specs/PLAN_MODEL_CATALOG_EXPANSION_RUNBOOK.md` | P1 Gemma catalog gates (`min_sustained_tps`) depend on **T1-02** bench truth; do not publish new MoE rows on P0-01–contaminated numbers |
+| `specs/perf-mlx-compile-bf16-upgrade.md` | Superseded for pin strategy — we now target **`mlx-swift-lm` exact pin** (not legacy `mlx-swift-examples`). Reuse Phase 2 bench methodology only |
+| `audits/2026-06-30/perf-mlx-engine.md` | Prior `decode-bench` / `CompiledDecode.swift` on branch `perf/mlx-compile-bf16` — **not merged**; T0-01 may cherry-pick |
+
+---
+
+## How to run this plan
+
+1. **Pinned session:** approve phase transitions, resolve gate conflicts with catalog runbook, update version/status in this file.
+2. **Executor agents:** one agent per task ID. Each agent:
+   - Works in a **fresh worktree** off `origin/main` (`CLAUDE.md` § worktree isolation).
+   - Reads only its task section + prerequisites.
+   - Produces listed **Artifacts** under `beta/throughput-engineering/`.
+   - Runs the **audit loop** (code + security + architect) before marking implementation tasks GREEN.
+   - Posts artifact paths + PASS/FAIL; does **not** edit this plan unless asked.
+3. **Do not skip T0.** Phases T1–T3 assume measurement harness and baseline JSON exist.
+4. **Clean-room:** read Darkbloom diffs only via `/Users/augstar/darkbloom-watch/repo` (`git show origin/master:…`). Do **not** inspect `d-inference` source.
+
+### Artifact layout
+
+```
+beta/throughput-engineering/
+  T0_SUMMARY.md                      # rollup after T0-01..03
+  T0-01-decode-bench-harness.md
+  T0-02-baseline-matrix.json         # committed snapshot copies under audits/
+  T0-03-egress-profile.md
+  T1-01-mlx-pin-bump.md
+  T1-02-gemma-moe-decode-delta.md
+  T1-03-metallib-rebuild.md
+  T2-01-compiled-decode-wire-in.md
+  T2-02-decode-bandwidth-model.md
+  T3-01-stream-interval.md
+  T3-02-adaptive-prefill-spike.md
+  T3-03-kv-quant-scheme.md
+  T4-01-cbv2-feasibility.md          # architecture spike only until GO
+  T4-02-cbv2-impl.md                 # if T4-01 GO
+  DEFERRED.md                        # explicit non-adopts (NWConnection cluster)
+```
+
+---
+
+## Decision gates (master)
+
+| Gate | Requires | Blocks |
+|------|----------|--------|
+| **TG0** | T0 harness + baseline JSON on reference Mac | Any perf PR merge |
+| **TG1** | T1 pin bump GREEN + token-exact regression | Compiled decode wire-in (T2) |
+| **TG2** | T2 compiled decode GREEN on Gemma-4 + gpt-oss | Catalog TPS gate raises |
+| **TG3** | T3 provider opts measured ≥3% win OR explicit WAIVE | Prod config defaults change |
+| **TG4** | T4-01 feasibility GO + operator sign-off | Engine V2 / CBv2 port (T4-02) |
+
+---
+
+## Priority stack (from exploration ranked recommendations)
+
+| Rank | Work item | Phase | Bucket | Expected lever |
+|------|-----------|-------|--------|----------------|
+| 1 | MLX 0.32.0 + `mlx-swift-lm` bump (#474, #470, #481, #516) | T1 | A | Single-stream TPS; MoE sparsity |
+| 2 | Compiled MoE decode opt-in (#482+#516 pair) | T2 | A | +15–25% MoE decode (**measure**) |
+| 3 | Continuous batching / Engine V2 (#499) | T4 | A+B | Aggregate multi-stream TPS |
+| 4 | Adaptive prefill (#466) | T3 | B | TTFT on long prompts |
+| 5 | `streamInterval`≈4 token batching | T3 | B | Egress CPU; minor TPS |
+| 6 | KV quant family scheme | T3 | B | Concurrency / long context |
+| — | NWConnection / ChunkBatcher (#479–#476) | DEFER | C | **Do not implement** unless T0-03 proves egress bound |
+
+---
+
+# T0 — Measurement foundation (run first)
+
+> **Goal:** Every later claim is measured, not assumed. No submodule bumps before TG0.
+
+---
+
+## T0-01 — Restore `decode-bench` harness on `main`
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T0-01` |
+| **Question** | Can we run **pure decode** benchmarks (no coordinator, no WS) on `main`? |
+| **Prerequisites** | Release build + bundled metallib (`phase3-binary/dist/package.sh`) |
+| **Branch** | `perf/decode-bench-harness` |
+
+### Procedure
+
+1. Cherry-pick or re-port from `perf/mlx-compile-bf16` (see `audits/2026-06-30/perf-mlx-engine.md`):
+   - `DecodeBenchCommand.swift`
+   - `MacProviderCLI.swift` subcommand registration
+   - Tests in `WeightCastTests.swift` only if `WeightCast` also lands (optional)
+2. **Do not** wire `CompiledDecode` or bf16 cast in this task — harness only.
+3. CLI shape:
+   ```bash
+   macprovider-cli decode-bench \
+     --model <mlx-repo-id> \
+     --prefill-tokens 512 \
+     --decode-tokens 256 \
+     --runs 5 \
+     --output state/perf/baseline-<tag>.json
+   ```
+4. Document generation-only TPS semantics (match `Stage1Iterator.swift:606-623` — denominator excludes TTFT).
+5. Run audit loop on the harness PR.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | Subcommand runs on M-series; writes JSON; `swift test` green |
+| **RED** | Cannot load model or metallib missing in release — fix packaging first (`T1-03` dependency) |
+
+### Artifacts
+
+- `beta/throughput-engineering/T0-01-decode-bench-harness.md`
+- `audits/2026-07-07/decode-bench-harness/` — sample JSON snapshot
+
+---
+
+## T0-02 — Baseline matrix (reference hardware)
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T0-02` |
+| **Question** | What are **pinned-pin** decode TPS / TTFT numbers for catalog-critical models? |
+| **Prerequisites** | T0-01 GREEN; **clean machine** (no other `serve` processes) |
+
+### Models (minimum)
+
+| Model | Role | Notes |
+|-------|------|-------|
+| `mlx-community/Qwen2.5-7B-Instruct-4bit` | Dense control | Prior baseline ~29.2 TPS M5 (`perf-mlx-engine.md`) |
+| `mlx-community/gemma-4-26b-a4b-it-4bit` | MoE primary | Supersedes P0-01 ~7.7 TPS; target clean re-measure |
+| `mlx-community/gpt-oss-20b-MXFP4-Q8` | MoE control | Catalog anchor; sanity ≥12 TPS on 32 GB M5 |
+
+### Procedure
+
+1. Hardware record: chip, RAM, macOS, `macprovider-cli` version, `Package.resolved` mlx pins.
+2. Per model: 3+ runs, report p50 decode TPS, p50 prefill TPS, TTFT for 512 prefill / 256 decode.
+3. Cross-check Gemma vs `DecodeBandwidthModel` implied active params (T0-02 may use spreadsheet; T2-02 ports the Swift module).
+4. Store immutable JSON under `audits/2026-07-07/bench-snapshots/` (copy from gitignored `state/perf/`).
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | All three models complete without swap; JSON committed |
+| **YELLOW** | One model fails load — document blocker; other baselines still valid |
+| **RED** | Harness cannot reproduce prior Qwen baseline within 10% on same hardware — debug before T1 |
+
+### Artifacts
+
+- `beta/throughput-engineering/T0-02-baseline-matrix.json` (summary table + paths to snapshots)
+- Update `beta/catalog-expansion/P1-gemma4-bench-matrix.md` cross-ref if numbers supersede P1-01
+
+---
+
+## T0-03 — Egress vs decode profile (prior finding verification)
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T0-03` |
+| **Question** | Is `URLSessionWebSocketTask.send` ever >5% of per-token wall time at catalog TPS? |
+| **Prerequisites** | Tier-2 serve path running locally OR instrumented integration test |
+
+### Procedure
+
+1. Add **temporary** debug timing (feature-flagged `MACPROVIDER_PERF_TRACE=1`) around:
+   - `ModelRuntime` generate callback entry
+   - `InferenceRelay.sendChunk` pre/post `sendFrame`
+   - `CoordinatorClient.send(_:to:)` (`CoordinatorClient.swift:2427-2433`)
+2. Run one streaming request at ~25–30 TPS equivalent (dense model) and ~12 TPS (Gemma).
+3. Aggregate: mean/p95 µs in decode callback vs seal vs WS send.
+4. **Remove or gate** trace code before merge; keep unit test that flag defaults off.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | WS send + seal <5% of token period at p95 → **NWConnection cluster remains DEFER** |
+| **YELLOW** | 5–15% → T3-01 `streamInterval` promoted |
+| **RED** | >15% → open reassessment of #479 (document in `DEFERRED.md` with evidence) |
+
+### Artifacts
+
+- `beta/throughput-engineering/T0-03-egress-profile.md`
+
+---
+
+## T0 rollup
+
+Executor writes `beta/throughput-engineering/T0_SUMMARY.md` with TG0 recommendation (**PROCEED** / **HOLD**).
+
+---
+
+# T1 — MLX engine foundation (bucket A)
+
+> **Goal:** Bump to MLX **0.32.0** / latest compatible **`mlx-swift-lm`** without correctness regression.  
+> **Current pins:** `mlx-swift` 0.31.6, `mlx-swift-lm` 3.31.4 (`Package.resolved`).  
+> **Target reference (Darkbloom):** `libs/mlx` @ `d5a24040…`, `mlx-swift-lm` @ `bc1c0ee6…` — adopt via **ml-explore releases**, not Layr-Labs fork submodule, unless ml-explore lacks equivalent commits.
+
+---
+
+## T1-01 — Pin bump + build green
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T1-01` |
+| **Question** | Does latest reachable **ml-explore** `mlx-swift-lm` (≥3.31.x) + transitive `mlx-swift` 0.32.x build and pass tests? |
+| **Prerequisites** | TG0; worktree `perf/mlx-0.32-bump` |
+| **Touches** | `phase3-binary/Package.swift`, `Package.resolved`, adapter fixes in `ModelRuntime.swift` if API drift |
+
+### Procedure
+
+1. Survey `gh release list` for `mlx-swift-lm` and `mlx-swift`; read changelogs for breaking API in `generate`, `TokenIterator`, `GenerateParameters`.
+2. Bump `exact:` pin in `Package.swift`; `swift build -c release && swift test`.
+3. Token-exact greedy check: Qwen2.5-7B, 512 prefill, 64 decode — compare output token ids to T0-02 baseline **before bump** JSON.
+4. Run full audit loop (code, security, architect).
+5. PR to `main`; **no** compiled decode or config default changes in this PR.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | Build + tests green; token-exact on dense control |
+| **YELLOW** | MoE token drift on Gemma — document; may still proceed to T1-02 with waiver |
+| **RED** | Build break or dense token drift — revert pin |
+
+### Artifacts
+
+- `beta/throughput-engineering/T1-01-mlx-pin-bump.md`
+
+---
+
+## T1-02 — MoE decode delta (Gemma + gpt-oss)
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T1-02` |
+| **Question** | How much does T1 pin bump move **MoE decode TPS** and implied sparsity? |
+| **Prerequisites** | T1-01 merged |
+
+### Procedure
+
+1. Re-run T0-02 matrix on **post-bump** binary (same hardware).
+2. Compute Δ vs T0-02 per model; for Gemma, compute implied active params using bandwidth model (hand spreadsheet OK).
+3. Compare to catalog gates: `min_sustained_tps` in autotune catalog (`AutotuneRecommend.swift:996+`).
+4. If Gemma median < gate after bump → **TG2 blocked** until T2-01.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | Gemma median ≥ catalog gate (currently 10 TPS post-P1-01) **OR** gate explicitly revised with operator sign-off |
+| **YELLOW** | Improved but below gate — proceed to T2 |
+| **RED** | Regression vs T0-02 on any model >5% without explanation |
+
+### Artifacts
+
+- `beta/throughput-engineering/T1-02-gemma-moe-decode-delta.md`
+
+---
+
+## T1-03 — Metallib rebuild + artifact check
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T1-03` |
+| **Question** | Does release packaging ship a metallib **matched** to bumped MLX? |
+| **Prerequisites** | T1-01 |
+
+### Procedure
+
+1. Run `phase3-binary/scripts/build-mlx-metallib.sh` (or document PyPI bundle path if still valid).
+2. Verify `scripts/check-tier2-provider-artifact.sh` passes on release tarball.
+3. Record metallib hash in artifact doc (pattern: upstream `#472` attestation — optional follow-up for tier-2 attestation).
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | Release install loads model without metallib fallback warnings |
+| **RED** | Missing `default.metallib` in field installs |
+
+### Artifacts
+
+- `beta/throughput-engineering/T1-03-metallib-rebuild.md`
+
+---
+
+# T2 — Compiled decode + measurement model (bucket A)
+
+> **Goal:** Wire `MLX.compile()` decode path for MoE catalog models; validate #482+#516 as a **pair** (no fused-cache RAM regression — P0-01 already shows clean residency on 3.31.4; re-verify post-compile).
+
+---
+
+## T2-01 — Compiled decode wire-in
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T2-01` |
+| **Question** | Does opt-in compiled decode improve MoE TPS with **token-exact** greedy output? |
+| **Prerequisites** | TG1; port `CompiledDecode.swift` from `perf/mlx-compile-bf16` |
+| **Env flag** | `MACPROVIDER_COMPILED_DECODE=1` (default **off**) |
+
+### Procedure
+
+1. Port `CompiledDecode.swift` + `KVCacheUpdatableAdapter`; integrate at `ModelRuntime.swift` decode path **only when flag set**.
+2. **Correctness gate first** (per `perf-mlx-compile-bf16-upgrade.md`): greedy token-id equality vs uncompiled on Gemma + gpt-oss + Qwen control.
+3. **Then** run T0-02 matrix with flag on for MoE models only.
+4. Measure resident RAM during decode (MoE fused-cache check — expect no +8–15 GiB spike).
+5. Audit loop; PR separate from T1.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | Token-exact + ≥3% decode TPS lift on Gemma **or** gpt-oss |
+| **YELLOW** | Token-exact but <3% lift — document; keep flag off by default |
+| **RED** | Output drift or RAM spike >2 GB vs uncompiled MoE |
+
+### Artifacts
+
+- `beta/throughput-engineering/T2-01-compiled-decode-wire-in.md`
+
+---
+
+## T2-02 — Port `DecodeBandwidthModel`
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T2-02` |
+| **Question** | Can autotune/catalog diagnostics report **implied active params** from measured TPS? |
+| **Prerequisites** | T0-02 data |
+
+### Procedure
+
+1. Add `DecodeBandwidthModel.swift` under `phase3-binary/Sources/MacProviderCore/` (pure Foundation — port from upstream `ProviderBenchmark/DecodeBandwidthModel.swift` via `git show`, not d-inference checkout).
+2. Unit tests for forward/inverse model.
+3. Optional: `decode-bench --report-sparsity` flag emitting implied active params.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | Tests pass; Gemma implied active params << 26B dense |
+| **RED** | N/A — diagnostic only |
+
+### Artifacts
+
+- `beta/throughput-engineering/T2-02-decode-bandwidth-model.md`
+
+---
+
+# T3 — Provider-side optimizations (bucket B)
+
+> **Goal:** TTFT and egress polish **without** architecture rewrites. Each item is independently WAIVABLE if <3% measured win.
+
+---
+
+## T3-01 — Token / chunk batching (`streamInterval`)
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T3-01` |
+| **Question** | Does batching SSE frames every **4 tokens** reduce egress CPU without harming buyer TTFT perception? |
+| **Prerequisites** | T0-03 profile (promoted if YELLOW+) |
+| **Config** | `stream_interval` in config / `--stream-interval` (default **1** preserve behavior) |
+
+### Procedure
+
+1. In `InferenceRelay.processStreaming`, accumulate token deltas until N tokens or flush on stop.
+2. Default **1**; production experiment at **4** (upstream production value).
+3. Measure: WS sends/sec, CPU sample, buyer-visible first-chunk latency (should be ≤4 token times).
+4. Do **not** adopt NWConnection.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | ≥10% reduction in send calls; no catalog TTFT gate regression |
+| **WAIVE** | T0-03 GREEN and no measurable CPU win |
+
+### Artifacts
+
+- `beta/throughput-engineering/T3-01-stream-interval.md`
+
+---
+
+## T3-02 — Adaptive prefill spike
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T3-02` |
+| **Question** | Can a **minimal** chunk sizer reduce TTFT p95 on 3k+ token prompts without BatchScheduler? |
+| **Prerequisites** | TG1 |
+| **Scope** | Spike only — port policy ideas from upstream `#466`, not full scheduler |
+
+### Procedure
+
+1. Read upstream `AdaptivePrefillPolicy.swift` via `git show origin/master:…` (Darkbloom watch clone).
+2. Prototype: optional chunked `processor.prepare` or mlx-swift-lm API if available; else document blocker.
+3. Benchmark TTFT p50/p95 on 4096-token prompt (Stage1 probe shape).
+4. Max 3 engineering days — if no API hook, record **NO-GO** and WAIVE.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GO** | ≥15% TTFT p95 reduction → create full BUILD spec |
+| **WAIVE** | No hook or <15% win |
+
+### Artifacts
+
+- `beta/throughput-engineering/T3-02-adaptive-prefill-spike.md`
+
+---
+
+## T3-03 — KV quant family scheme
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T3-03` |
+| **Question** | Should `kv_bits` defaults be model-family-specific (Gemma K8V8, etc.)? |
+| **Prerequisites** | TG1; existing `--kv-bits` / autotune axis |
+
+### Procedure
+
+1. Map catalog models → recommended `GenerateParameters.kvBits` (reference upstream `KVQuantEngineScheme` concepts via watch clone).
+2. Run autotune-style sweep: nil vs 4 vs 8 on Gemma long-context probe.
+3. Gate on quality: no rise in autotune TTFT failures / stop anomalies.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | Documented family defaults + ≥10% KV headroom on target tier |
+| **WAIVE** | Quality regression at 4-bit KV |
+
+### Artifacts
+
+- `beta/throughput-engineering/T3-03-kv-quant-scheme.md`
+
+---
+
+# T4 — Continuous batching / Engine V2 (bucket A+B, major)
+
+> **Goal:** Multi-stream **aggregate** TPS. **Do not start** until TG2 or operator explicitly prioritizes concurrency over single-stream polish.
+
+---
+
+## T4-01 — Feasibility spike
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T4-01` |
+| **Question** | Can MacProvider adopt `MLXLMCommon.CBv2Engine` without breaking Tier-2 relay, warm-swap, conversation cache, spec-decode? |
+| **Prerequisites** | TG2 recommended; T1 merged |
+| **Time box** | 1 week read-only + prototype branch |
+
+### Procedure
+
+1. Map upstream: `EngineV2Config.swift`, `EngineV2Bridge.swift`, `EngineV2Factory+Production.swift` via watch clone.
+2. List MacProvider integration points: `ModelRuntime`, `InferenceRelay`, `ConversationCache`, `ProviderStatus.throughputTPSSinceLast`.
+3. Prototype: load Gemma in CBv2 on branch; single-stream parity vs current path.
+4. Decision record: **GO** / **NO-GO** / **DEFER** with cost estimate.
+
+### Artifacts
+
+- `beta/throughput-engineering/T4-01-cbv2-feasibility.md`
+
+---
+
+## T4-02 — Engine V2 implementation
+
+| Field | Value |
+|-------|-------|
+| **ID** | `T4-02` |
+| **Question** | Ship CBv2 behind flag for MoE catalog models |
+| **Prerequisites** | TG4; T4-01 **GO** |
+| **Effort** | Multi-PR (4–8 weeks) — split: bridge → admission → warm-swap → prod flag |
+
+### Procedure (high level)
+
+1. PR-A: `EngineV2Bridge` port + factory; kill switch env `MACPROVIDER_ENGINE_V2=0`.
+2. PR-B: Replace `maxBatch` semaphore semantics with scheduler capacity (KV budget).
+3. PR-C: Relay multi-request lifecycle + cancel.
+4. PR-D: Network harness scenario 07 sustained throughput re-baseline.
+
+### Pass / fail
+
+| Result | Criteria |
+|--------|----------|
+| **GREEN** | 2 concurrent streams ≥1.6× single-stream aggregate TPS on Gemma (**measure** on 32 GB) |
+| **RED** | Correctness/cancel/settlement regression |
+
+### Artifacts
+
+- `beta/throughput-engineering/T4-02-cbv2-impl.md`
+
+---
+
+# DEFERRED — Explicit non-adopts
+
+Document in `beta/throughput-engineering/DEFERRED.md`:
+
+| Item | Reason |
+|------|--------|
+| #479 NWConnection transport | T0-03 structural egress analysis; MacProvider lacks upstream serial outbound bug |
+| #480 ChunkBatcher / AsyncStream bypass | `BlockingChunkBuffer` + direct `sendFrame` already decouples |
+| #476 shutdown actor hop | No matching hot-path structure |
+| #475 serial WS outbound | Not present |
+| v0.6.26 TCP_NODELAY | Requires NWConnection |
+| #483 DH precompute | Session-level HKDF already (`Tier2ProviderSession.swift:79-100`) |
+| bf16 weight cast | Empirically net-negative on M5 (`perf-mlx-engine.md`) — do not resurface |
+| Layr-Labs fork submodule vendoring | Clean-room + maintenance — use ml-explore pins only |
+
+Re-open only if T0-03 **RED** or TG4 concurrency mandate.
+
+---
+
+# Executor prompt template
+
+```
+Read: specs/PLAN_THROUGHPUT_ENGINEERING_RUNBOOK.md § {TASK_ID}
+Rules: CLAUDE.md worktree isolation; audit loop before GREEN on code tasks.
+Deliver: artifacts under beta/throughput-engineering/
+Do NOT update this plan unless asked — post artifact paths and PASS/FAIL.
+```
+
+---
+
+# Status tracker
+
+> **Maintained by:** executor agents + pinned planning session.  
+> Last updated: 2026-07-07 (initial plan)
+
+| Task ID | Phase | Status | Gate | Artifact | Notes |
+|---------|-------|--------|------|----------|-------|
+| T0-01 | T0 | **`GREEN`** | TG0 | `beta/throughput-engineering/T0-01-decode-bench-harness.md` | Branch `perf/decode-bench-harness`; 946 tests; harness only |
+| T0-02 | T0 | **`YELLOW`** | TG0 | `T0-02-baseline-matrix.json` on branch | Qwen 27.1 / gpt-oss 26.3 TPS p50; Gemma blocked on pin 3.31.4 |
+| T0-03 | T0 | **`GREEN` (structural)** | TG0 | `T0-03-egress-profile.md` on branch | Egress ~1–2% est.; NWConnection DEFER |
+| T0 rollup | T0 | **`DONE`** | **TG0** | `beta/throughput-engineering/T0_SUMMARY.md` | **PROCEED to T1-01** |
+| T1-01 | T1 | `READY` | TG1 | — | Next spawn |
+| T1-02 | T1 | `BLOCKED` | TG1 | — | Needs T1-01 |
+| T1-03 | T1 | `BLOCKED` | TG1 | — | Needs T1-01 |
+| T2-01 | T2 | `BLOCKED` | TG2 | — | Needs TG1 |
+| T2-02 | T2 | `READY` | — | — | Can start after T0-02 |
+| T3-01 | T3 | `BLOCKED` | TG3 | — | Needs T0-03 |
+| T3-02 | T3 | `BLOCKED` | TG3 | — | Needs TG1 |
+| T3-03 | T3 | `BLOCKED` | TG3 | — | Needs TG1 |
+| T4-01 | T4 | `PENDING` | TG4 | — | Operator priority call |
+| T4-02 | T4 | `BLOCKED` | — | — | Needs T4-01 GO |
+
+### Gate summary
+
+| Gate | Status | Signed off |
+|------|--------|------------|
+| TG0 | **`CLOSED — PROCEED`** (YELLOW baseline; Gemma → T1-02) | 2026-07-07 |
+| TG1 | `OPEN` | — |
+| TG2 | `OPEN` | — |
+| TG3 | `OPEN` | — |
+| TG4 | `OPEN` | — |
+
+---
+
+## Changelog
+
+| Version | Date | Change |
+|---------|------|--------|
+| 0.1.0 | 2026-07-07 | Initial runbook from throughput engineering exploration |
+| 0.1.1 | 2026-07-07 | T0-01 GREEN (decode-bench harness); T0-03 GREEN structural (egress trace); T0-02 spawned |
+| 0.1.2 | 2026-07-07 | T0 complete — TG0 PROCEED; T0_SUMMARY + DEFERRED; T1-01 READY |


### PR DESCRIPTION
## Summary
- Restore `macprovider-cli decode-bench` for pure decode benchmarking (no coordinator/WS), ported from `perf/mlx-compile-bf16` without CompiledDecode or bf16 wire-in.
- Record T0-02 baseline snapshots on M5 32GB: Qwen2.5-7B **27.1 TPS**, gpt-oss-20b **26.3 TPS** (Gemma-4 blocked on mlx-swift-lm 3.31.4 MoE keys — tracked for T1-01).
- Add throughput runbook, T0 rollup, and DEFERRED list (TG0 PROCEED).

## Test plan
- [x] `swift build -c release` in `phase3-binary`
- [x] `swift test` — 946+ tests pass
- [x] `decode-bench --help` documents generation-only TPS semantics
- [x] Bench JSON committed under `audits/2026-07-07/bench-snapshots/`

## Notes
- Metallib must be version-matched (`scripts/build-mlx-metallib.sh`) — documented in T0-02 artifact.
- Merge before `perf/egress-trace-t0-03` to keep T0 landing sequential.


Made with [Cursor](https://cursor.com)