### PR TITLE
fix(cli): soften catalog provenance envelope gate on serve start

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -365,10 +365,10 @@ struct ServeCommand: AsyncParsableCommand {
 
         let catalog = await staticInputs.loadCandidateCatalog()
         let actualCatalogHash = AutotuneStaticInputs.candidateCatalogSHA256(bytes: catalog.selectedBytes)
-        guard catalog.value.version == version, actualCatalogHash == storedCatalogHash else {
-            FileHandle.standardError.write(Data("model catalog provenance is stale; rerun autotune --recommend --apply\n".utf8))
-            throw ExitCode(2)
-        }
+        // Row admission against the *current* signed catalog is the security gate.
+        // The stored model_catalog_version/hash envelope records which autotune --apply
+        // revision wrote config.yaml; a coordinator catalog publish that only adds or
+        // edits unrelated rows must not crash-loop providers whose model row is unchanged.
         guard let row = catalog.value.rows[key],
               (requireRecommendable ? row.runtimeStatus == "recommendable" : ["candidate", "listed", "recommendable"].contains(row.runtimeStatus)),
               row.modelID == modelID,
@@ -378,6 +378,16 @@ struct ServeCommand: AsyncParsableCommand {
         else {
             FileHandle.standardError.write(Data("model artifact is not admitted by the signed candidate catalog\n".utf8))
             throw ExitCode(2)
+        }
+        if catalog.value.version != version || actualCatalogHash != storedCatalogHash {
+            let storedPrefix = String(storedCatalogHash.prefix(8))
+            let currentPrefix = String(actualCatalogHash.prefix(8))
+            FileHandle.standardError.write(Data(
+                ("model catalog provenance envelope is stale (stored \(version)/\(storedPrefix)…, "
+                    + "current \(catalog.value.version)/\(currentPrefix)…); "
+                    + "row still admitted — run macprovider-cli autotune --recommend --apply to refresh config\n")
+                .utf8
+            ))
         }
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
@@ -236,6 +236,63 @@ final class ServeCommandTests: XCTestCase {
         }
     }
 
+    func testCoordinatorJoinAcceptsCatalogBoundSnapshotWithStaleProvenanceEnvelope() async throws {
+        let hub = try tempDir()
+        let resolver = CachedModelArtifactResolver(hubRoot: hub)
+        let key = "test-model"
+        let modelID = "test/model"
+        let revision = String(repeating: "1", count: 40)
+        let snapshot = resolver.snapshotURL(modelID: modelID, revision: revision)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("model.safetensors"))
+        try Data("{}".utf8).write(to: snapshot.appendingPathComponent("config.json"))
+        let artifactSHA = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        let currentCatalogJSON = """
+        {"version":"current-catalog","generated_at":"2026-07-07T12:00:00Z","source":"operator_curated_autotune_candidate_catalog","rows":{"\(key)":{"model_id":"\(modelID)","model_revision":"\(revision)","model_sha256":"\(artifactSHA)","min_ram_gb":1,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":1,"max_4k_ttft_ms":1000},"runtime_status":"recommendable"}}}
+        """
+        let rateCardJSON = """
+        {"version":"test-rate-card","generated_at":"2026-07-07T12:00:00Z","usd_per_million_credits":1.0,"rows":{"\(key)":{"prompt_rate_per_mtok":1,"completion_rate_per_mtok":1,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
+        """
+        let catalogBytes = Data(currentCatalogJSON.utf8)
+        let rateCardBytes = Data(rateCardJSON.utf8)
+        let staticInputs = AutotuneStaticInputs(
+            fetch: { url in
+                switch url.path {
+                case "/v1/rate-card":
+                    return rateCardBytes
+                case "/v1/autotune-candidates", "/v1/demand-rank":
+                    return catalogBytes
+                default:
+                    break
+                }
+                if url.path.hasSuffix(".sig") {
+                    return Data(#"{"key_id":"streamvc-autotune-static-v4","alg":"ed25519","signature":"AA=="}"#.utf8)
+                }
+                return catalogBytes
+            },
+            verifySignature: { _, _ in true },
+            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-07-07T12:00:00Z")! }
+        )
+        var config = AppConfig.defaults()
+        config.model = key
+        config.modelArtifactPath = snapshot.path
+        config.modelArtifactSHA256 = artifactSHA
+        config.modelCatalogKey = key
+        config.modelCatalogModelID = modelID
+        config.modelCatalogRevision = revision
+        config.modelCatalogSHA256 = artifactSHA
+        // Simulate config written by an older autotune --apply against a prior catalog publish.
+        config.modelCatalogVersion = "prior-catalog"
+        config.modelCatalogHash = String(repeating: "a", count: 64)
+
+        try await ServeCommand.runModelArtifactPreflight(
+            config,
+            joiningCoordinator: true,
+            staticInputs: staticInputs,
+            artifactResolver: resolver
+        )
+    }
+
     func testCoordinatorJoinRejectsPublicModelKeyMismatchForCatalogBoundSnapshot() async throws {
         do {
             try await assertCatalogBoundSnapshotPreflight(

--- a/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
@@ -17,10 +17,11 @@ enum ProviderLogDiagnostics {
     private static let rules: [Rule] = [
         Rule(
             id: "stale_model_catalog",
-            needle: "model catalog provenance is stale",
+            needle: "model catalog provenance envelope is stale",
             userMessage:
-                "Model catalog is out of date for this Mac. Update Malibu to the latest release, "
-                + "or run: macprovider-cli autotune --recommend --apply"
+                "Model catalog was republished since autotune last wrote config. "
+                + "Serving continues while your model row is still admitted; "
+                + "run: macprovider-cli autotune --recommend --apply to refresh provenance."
         ),
         Rule(
             id: "catalog_admission",

--- a/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
@@ -5,7 +5,7 @@ final class ProviderLogDiagnosticsTests: XCTestCase {
     func testDiagnoseStaleCatalogProvenance() {
         let finding = ProviderLogDiagnostics.diagnose(lines: [
             "loading config",
-            "model catalog provenance is stale; rerun autotune --recommend --apply",
+            "model catalog provenance envelope is stale (stored",
         ])
 
         XCTAssertEqual(finding?.id, "stale_model_catalog")
@@ -15,7 +15,7 @@ final class ProviderLogDiagnosticsTests: XCTestCase {
     func testDiagnosePrefersMostRecentMatchingLine() {
         let finding = ProviderLogDiagnostics.diagnose(lines: [
             "model artifact hash mismatch for /tmp/old",
-            "model catalog provenance is stale; rerun autotune --recommend --apply",
+            "model catalog provenance envelope is stale (stored",
         ])
 
         XCTAssertEqual(finding?.id, "stale_model_catalog")


### PR DESCRIPTION
## Summary
- Stop crash-looping serve when coordinator republishes the candidate catalog but the configured model row is still admitted
- Keep row-level catalog admission as the hard security gate; treat stale `model_catalog_version`/`model_catalog_hash` as a warning only
- Update Malibu log diagnostics to match the new warning text

## Test plan
- [x] `swift test --filter ServeCommandTests.testCoordinatorJoinAcceptsCatalogBoundSnapshotWithStaleProvenanceEnvelope`
- [x] Provider verified healthy on operator Mac after manual config patch


Made with [Cursor](https://cursor.com)