### PR TITLE
perf(T2-01): compiled decode scaffolding (MACPROVIDER_COMPILED_DECODE, default OFF)

### DIFF
--- a/beta/throughput-engineering/T2-01-compiled-decode-wire-in.md
+++ b/beta/throughput-engineering/T2-01-compiled-decode-wire-in.md
@@ -1,0 +1,193 @@
+# T2-01 — MLX.compile() Decode Wire-In
+
+**Date:** 2026-07-07  
+**Branch:** `perf/t2-01-compiled-decode`  
+**Runbook:** `specs/PLAN_THROUGHPUT_ENGINEERING_RUNBOOK.md` § T2-01  
+**Verdict:** YELLOW
+
+---
+
+## Summary
+
+The environment-flag wire-in is complete. `MACPROVIDER_COMPILED_DECODE=1` gates the
+`MLX.compile()`-wrapped decode path in both `DecodeBenchCommand` and `ModelRuntime`.
+The compiled binary builds clean, all 968 unit tests pass, and the env-flag/helper
+tests are wired in `ScaffoldTests.swift`.
+
+**However, the correctness gate fails.** The compiled path produces incorrect token
+sequences (repeating 4-token loops) on Qwen2.5-7B-Instruct-4bit. Root cause is a
+fundamental incompatibility between `MLX.compile()` and `KVCacheSimple` in
+mlx-swift-lm 3.31.4 (see below). Performance numbers from the compiled path are
+therefore not valid and are reported as INVALID.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `phase3-binary/Sources/macprovider-cli/CompiledDecode.swift` | **New.** Ported from `perf/mlx-compile-bf16`. `CompiledDecode` enum (env-flag), `KVCacheUpdatableAdapter`, `CompiledDecodeStep` class. |
+| `phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift` | Added `import MLX`, dynamic env-flag read, `runCompiledOnce()` function with manual prefill + compiled decode loop. |
+| `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift` | Env-flag check + stderr log in `stream()`. Full production wire-in deferred to follow-up (correctness gate not passed). |
+| `phase3-binary/Tests/macprovider-cliTests/ScaffoldTests.swift` | `CompiledDecodeFlagTests` (5 tests) + `DecodeBenchHelperTests` (6 tests). All pass. |
+
+---
+
+## Build & Test
+
+```
+swift build -c release  →  Build complete (macprovider-cli)
+swift test              →  968 tests, 8 skipped, 0 failures
+```
+
+---
+
+## Correctness Check — Qwen2.5-7B-Instruct-4bit
+
+**Setup:** `--prefill-tokens 512 --decode-tokens 64 --runs 1`  
+**Uncompiled (baseline):** stopped at token 42 (EOS `<|im_end|>` = ID 151645 hit)  
+**Compiled:** emitted 64 tokens (hit `maxTokens`; EOS never triggered)
+
+**Debug trace (compiled path, steps 1–63):**
+
+```
+firstTok=40  eosIds=[151645]
+step1=3535  step2=11  step3=432  step4=4977  step5=1075
+step6=11    step7=432  step8=4977  step9=1075
+step10=11   step11=432  step12=4977  step13=1075
+... (pattern repeats identically to step63)
+```
+
+**Result: FAIL — token-ID equality not achieved.**
+
+---
+
+## Root Cause: `KVCacheSimple.offset` Is a Swift `Int`
+
+`MLX.compile()` builds a graph at trace time. All Swift `Int` values used as array
+slice indices are embedded as **constants** in the compiled graph. They are not
+`MLXArray`s, so MLX does not treat them as variable inputs and never recompiles
+when they change.
+
+`KVCacheSimple.update()` computes:
+
+```swift
+let previous = self.offset          // Swift Int → embedded as constant at trace time
+self.offset += keys.dim(2)
+self.keys?[.ellipsis, previous ..< self.offset, 0...] = keys  // constant-indexed write
+let returnedKeys = self.keys![.ellipsis, ..<self.offset, 0...]  // constant-indexed read
+```
+
+Consequences when the compiled graph is **reused** across decode steps:
+
+1. **Write position is frozen** at the offset from trace time. Every decode step
+   overwrites the same cache slot.
+2. **Attention window is frozen** at the length from trace time. The model always
+   attends to the same fixed number of positions, regardless of how many tokens
+   have been generated.
+
+This causes the model to generate from an effectively static context window,
+producing the observed infinite-loop token pattern.
+
+### Why recompile doesn't save us
+
+MLX's `shapeless: false` triggers recompilation on **input array shape changes**, not
+on integer-constant changes. The cache offset value is not an MLXArray — it's a Swift
+`Int` — so shape-gated recompile cannot detect its change. Each recompile captures a
+new constant for the current offset, but reuses the graph (and its constants) for all
+subsequent calls with matching input shapes.
+
+In practice:
+- **Call 1** (offset 512 → 513): shape change 512→768 triggers recompile; compiled
+  graph has `previous=512` baked in.
+- **Call 2** (offset 513 → 514): shape stable (768); graph from call 1 reused;
+  still writes to position 512. Wrong.
+- **Call 3+**: same graph, same wrong position → repetition loop.
+
+### Fix path
+
+`KVCacheSimple.offset` must be stored as an `MLXArray` (or computed from one) so
+that index arithmetic is a node in the computation graph rather than a constant.
+This requires a change to mlx-swift-lm; it cannot be fixed in macprovider-cli.
+
+**Tracking:** File an issue against mlx-swift-lm requesting MLXArray-based offset in
+`KVCacheSimple`. Until resolved, `MACPROVIDER_COMPILED_DECODE=1` must not be used
+for production inference.
+
+---
+
+## Performance Numbers
+
+Compiled-path numbers are reported for completeness but are **INVALID** (model is
+repeating tokens rather than generating real output):
+
+| Path | Model | prefill TPS p50 | decode TPS p50 | decodeTokensActual |
+|------|-------|-----------------|----------------|--------------------|
+| Baseline (uncompiled) | Qwen2.5-7B-4bit | 447.4 | 28.2 | 42 (EOS) |
+| Compiled (INVALID) | Qwen2.5-7B-4bit | 506.7 | 27.0 | 64 (loop) |
+
+No valid TPS delta can be reported. Perf benchmarks deferred to T2-01 follow-up
+after correctness is established.
+
+---
+
+## gpt-oss-20b
+
+Not attempted. Correctness gate failed on Qwen2.5-7B; loading a 20B model before
+the root cause is resolved would not provide useful signal.
+
+---
+
+## Gemma-4 (MoE)
+
+Not attempted. Correctness gate failed at Qwen2.5-7B stage. Additionally,
+`mlx-swift-lm 3.31.4` MoE key compatibility is a known blocker (referenced in
+runbook). Status: **WAIVE** (both pre-existing blocker and correctness gate failure).
+
+---
+
+## Pass/Fail vs Runbook Criteria
+
+| Criterion | Result |
+|-----------|--------|
+| Env flag wired (default OFF) | PASS |
+| `CompiledDecode.swift` ported | PASS |
+| `DecodeBenchCommand` honors flag | PASS |
+| `ModelRuntime.stream()` honors flag | PASS (log; full wire-in deferred) |
+| Unit tests green | PASS (968/968) |
+| Release build clean | PASS |
+| Qwen2.5-7B greedy token-ID equality | **FAIL** |
+| gpt-oss-20b token-ID equality | **SKIP** |
+| Gemma-4 | **WAIVE** |
+| perf TPS delta (Qwen + gpt-oss) | **INVALID** |
+
+---
+
+## Verdict: YELLOW
+
+Infrastructure complete; correctness gate fails due to a fundamental incompatibility
+between `MLX.compile()` and `KVCacheSimple.offset` in mlx-swift-lm 3.31.4. The
+`MACPROVIDER_COMPILED_DECODE` flag must remain **OFF by default** and must not be
+enabled in production until the offset fix lands in mlx-swift-lm. PR is ready to
+open for the infrastructure changes; perf and correctness verification are blocked
+on the upstream fix.
+
+---
+
+## PR Readiness
+
+- Branch: `perf/t2-01-compiled-decode` (pushed to `origin`)
+- Tests: green (968 pass, 0 fail)
+- No changes to runbook, billing, gateway, or any sensitive path
+- PR can be opened; reviewer should note the correctness caveat in the PR body
+
+---
+
+## Next Steps
+
+1. File issue on mlx-swift-lm: "MLXArray-based `KVCacheSimple.offset` for
+   `MLX.compile()` compatibility"
+2. Once upstream fix is available: bump mlx-swift-lm pin, re-run T2-01 correctness
+   check, then proceed to perf benchmarks
+3. Full production `stream()` wire-in (currently log-only) in follow-up PR after
+   correctness is confirmed

--- a/phase3-binary/Sources/macprovider-cli/CompiledDecode.swift
+++ b/phase3-binary/Sources/macprovider-cli/CompiledDecode.swift
@@ -1,0 +1,145 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+/// Per-token decode forward wrapped in `MLX.compile()`, gated by
+/// `MACPROVIDER_COMPILED_DECODE`. Ported from `perf/mlx-compile-bf16` for
+/// T2-01 of `specs/PLAN_THROUGHPUT_ENGINEERING_RUNBOOK.md`.
+///
+/// Compile-with-state correctness rules followed here:
+///   * Per-token input shape is fixed at `[1, 1]` (B=1). The compiler
+///     traces the graph for this shape; prefill (variable input length)
+///     is NOT wrapped.
+///   * `[KVCache]` is passed as `inputs:` AND `outputs:` to compile() so
+///     the in-place mutations performed by `cache.update(keys:values:)`
+///     are threaded through the compiled function rather than captured
+///     at trace time. `KVCacheSimple.innerState()` returns its
+///     `[keys, values]` MLXArrays; the `Updatable` conformance carries
+///     that mutation across calls.
+///   * Model weights are read-only inside the compiled function. We do
+///     NOT pass `model` in `inputs:` — MLX traces module parameters as
+///     constants on first call, which is exactly what we want for
+///     decode (weights don't change per step).
+enum CompiledDecode {
+    /// `1`, `true`, or `yes` (case-insensitive) enables compile()-wrapped
+    /// decode forward.
+    static let envFlag = "MACPROVIDER_COMPILED_DECODE"
+
+    static func isEnabledByEnvironment(
+        _ env: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard let raw = env[envFlag]?.trimmingCharacters(in: .whitespaces).lowercased() else {
+            return false
+        }
+        return raw == "1" || raw == "true" || raw == "yes"
+    }
+}
+
+/// `Updatable` adapter that forwards to a `KVCache`'s `innerState()`.
+///
+/// `KVCache` conforms to `Evaluatable` (same shape as `Updatable`), but
+/// the two protocols are distinct in mlx-swift's type system. Rather
+/// than declare retroactive `Updatable` conformance on the upstream
+/// `BaseKVCache` (which the strict-concurrency build setting would flag),
+/// we wrap each cache in this lightweight adapter at the compile() call
+/// site. The adapter holds the cache by reference, so subsequent
+/// `cache.update(keys:values:)` mutations are visible to MLX through
+/// `innerState()` on the next compiled-function call.
+private final class KVCacheUpdatableAdapter: Updatable {
+    private let cache: KVCache
+    init(_ cache: KVCache) { self.cache = cache }
+    func innerState() -> [MLXArray] { cache.innerState() }
+}
+
+/// A compiled per-token decode step bound to a specific `(model, cache)`
+/// pair. Construction is cheap (no compile work yet); the first invocation
+/// triggers the MLX trace + compile. Subsequent calls reuse the compiled
+/// graph as long as the input shape is unchanged.
+///
+/// Lifetime: a single `CompiledDecodeStep` belongs to one generation
+/// request. The compiled closure captures the specific cache array
+/// identity, so do not reuse one step across two different KV caches.
+/// Discard at end-of-request.
+///
+/// **Cache-state precondition (when `enabled: true`):** construct AFTER
+/// prefill has populated the KV cache. `KVCacheSimple.innerState()`
+/// returns `[]` for an empty cache and `[keys, values]` once
+/// `update(...)` has run. `MLX.compile()` reads the `inputs:` /
+/// `outputs:` state on every call; a step constructed against an empty
+/// cache and then used after prefill would see the state-array count
+/// change between calls, which risks silent recompile or — worse —
+/// reuse of a traced graph that never threaded the cache (decode
+/// reads stale KV state, producing wrong tokens). The initializer
+/// asserts this when `enabled == true`. The runtime wire-in must
+/// construct the step AFTER prefill, not before. See
+/// `audits/2026-06-30/perf-mlx-compile-bf16-audit.md` ADV-1.
+final class CompiledDecodeStep {
+    /// The original (uncompiled) per-token forward. Used (a) for
+    /// correctness comparison in tests, and (b) as the no-op fallback
+    /// when compile is disabled.
+    private let uncompiled: (MLXArray) -> MLXArray
+
+    /// The compiled wrapper; `nil` when `enabled == false`.
+    private let compiled: ((MLXArray) -> MLXArray)?
+
+    let enabled: Bool
+
+    /// - Parameters:
+    ///   - model: the loaded `LanguageModel`. Treated as having
+    ///     read-only weights for the duration of generation.
+    ///   - cache: the `[KVCache]` for the in-flight request. The same
+    ///     instances must be reused across every call to `step(_:)`
+    ///     — the compiled graph threads their `innerState()` through.
+    ///   - enabled: when `false`, `step(_:)` invokes the uncompiled
+    ///     forward directly. When `true`, the compiled wrapper is used.
+    init(
+        model: any LanguageModel,
+        cache: [KVCache],
+        enabled: Bool
+    ) {
+        let forward: (MLXArray) -> MLXArray = { token in
+            // `[1,1]` shape: token IDs for B=1 decode. The model's
+            // `callAsFunction(_ inputs: MLXArray, cache: [KVCache]?)`
+            // overload returns the next-step logits as `[1, 1, vocab]`.
+            model(token, cache: cache.isEmpty ? nil : cache)
+        }
+        self.uncompiled = forward
+        self.enabled = enabled
+
+        if enabled {
+            // Precondition (ADV-1): cache MUST have populated state when
+            // we construct the compiled wrapper. An empty `innerState()`
+            // would cause `MLX.compile()` to trace with a zero-length
+            // state array; once prefill populates `[keys, values]`, the
+            // compiled graph's state shape no longer matches subsequent
+            // calls, risking silent recompile or stale-state reads.
+            precondition(
+                cache.allSatisfy { !$0.innerState().isEmpty },
+                "CompiledDecodeStep requires a populated KV cache — construct AFTER prefill, not before. See `audits/2026-06-30/perf-mlx-compile-bf16-audit.md` ADV-1."
+            )
+            let updatables: [any Updatable] = cache.map { KVCacheUpdatableAdapter($0) }
+            // Same KV-cache arrays are read from AND written to by
+            // `cache.update(...)` inside the model's attention layer.
+            // Passing them in both `inputs:` and `outputs:` is the
+            // canonical compile-with-mutable-state pattern.
+            self.compiled = MLX.compile(
+                inputs: updatables,
+                outputs: updatables,
+                shapeless: false,
+                forward
+            )
+        } else {
+            self.compiled = nil
+        }
+    }
+
+    /// Run one decode step. `token` is the previous-token ID as a
+    /// `[1, 1]` MLXArray. Returns logits of shape `[1, 1, vocab]`.
+    func step(_ token: MLXArray) -> MLXArray {
+        if let compiled {
+            return compiled(token)
+        }
+        return uncompiled(token)
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import MLX
 import MLXLLM
 import MLXLMCommon
 import MacProviderCore
@@ -85,11 +86,11 @@ struct DecodeBenchCommand: AsyncParsableCommand {
             throw ExitCode(2)
         }
 
-        // T0-01 harness: compiled decode and bf16 cast are NOT wired.
-        // These flags are always false here; T2-01 will introduce the
-        // compiled path and flip them when the env vars are set.
+        let env = ProcessInfo.processInfo.environment
+        // bf16 cast is NOT in T2-01 scope — WeightCast lands separately.
         let bf16Enabled = false
-        let compiledEnabled = false
+        // T2-01: honor MACPROVIDER_COMPILED_DECODE; default OFF.
+        let compiledEnabled = CompiledDecode.isEnabledByEnvironment(env)
 
         // Reuse the serve runtime's model load path so the bench sees the
         // same dtype histogram and same KVCache wiring it would in prod.
@@ -121,12 +122,22 @@ struct DecodeBenchCommand: AsyncParsableCommand {
         var samples: [BenchSampleResult] = []
         for runIndex in 0..<(runs + 1) {
             let isWarmup = runIndex == 0
-            let sample = try await runOnce(
-                container: container,
-                prompt: prompt,
-                maxTokens: decodeTokens,
-                isWarmup: isWarmup
-            )
+            let sample: BenchSampleResult
+            if compiledEnabled {
+                sample = try await runCompiledOnce(
+                    container: container,
+                    prompt: prompt,
+                    maxTokens: decodeTokens,
+                    isWarmup: isWarmup
+                )
+            } else {
+                sample = try await runOnce(
+                    container: container,
+                    prompt: prompt,
+                    maxTokens: decodeTokens,
+                    isWarmup: isWarmup
+                )
+            }
             if isWarmup {
                 warmupSample = sample
             } else {
@@ -198,6 +209,122 @@ struct DecodeBenchCommand: AsyncParsableCommand {
     }
 
     // MARK: - One sample
+
+    /// Compiled decode loop using `CompiledDecodeStep`.
+    ///
+    /// Runs prefill via the standard `model.prepare()` path (handles chunked
+    /// prefill correctly), then transitions to `MLX.compile()`-wrapped
+    /// per-token forwards for the decode phase.
+    ///
+    /// Token sampling is greedy (temperature=0, argMax) to match the
+    /// correctness gate — compiled and uncompiled should produce identical
+    /// token IDs for the same prompt.
+    private func runCompiledOnce(
+        container: ModelContainer,
+        prompt: String,
+        maxTokens: Int,
+        isWarmup: Bool
+    ) async throws -> BenchSampleResult {
+        let prefillStart = Date()
+        nonisolated(unsafe) var firstTokenAt: Date? = nil
+        var promptTokensCount = 0
+        var decodedTokenCount = 0
+
+        try await container.perform { context in
+            let input = UserInput(chat: [.user(prompt)])
+            let lmInput = try await context.processor.prepare(input: input)
+            promptTokensCount = lmInput.text.tokens.size
+
+            let parameters = GenerateParameters(maxTokens: maxTokens, temperature: 0.0, topP: 1.0)
+            // Create the cache separately so we hold a reference to the same
+            // KVCache instances the model will mutate during prefill. After
+            // prepare() returns, innerState() will be non-empty and we can
+            // safely construct CompiledDecodeStep.
+            let cache = context.model.newCache(parameters: parameters)
+
+            // Prefill: model.prepare() handles chunked prefill internally.
+            // `.tokens` → need one more model call for the remaining token chunk.
+            // `.logits` → first-token logits are already available.
+            let firstTokenArray: MLXArray
+            switch try context.model.prepare(lmInput, cache: cache, windowSize: parameters.prefillStepSize) {
+            case .tokens(let textInput):
+                // Process the remaining prefix tokens to get first-token logits.
+                // `withPreparedCache` is a no-op when sequenceLengths is nil
+                // (unbatched 1-D token array); still called for correctness parity
+                // with TokenIterator.step().
+                let output = withPreparedCache(cache, lengths: textInput.sequenceLengths) {
+                    context.model(textInput[text: .newAxis], cache: cache.isEmpty ? nil : cache, state: nil)
+                }
+                eval(output.logits)
+                firstTokenArray = argMax(output.logits[0..., -1, 0...], axis: -1)
+
+            case .logits(let output):
+                eval(output.logits)
+                firstTokenArray = argMax(output.logits[0..., -1, 0...], axis: -1)
+            }
+
+            eval(firstTokenArray)
+            // Force cache synchronization: evaluating the logits covers most
+            // of the computation graph, but an explicit cache eval matches what
+            // LLMModel.prepare() does and satisfies ADV-1 (non-empty innerState
+            // precondition in CompiledDecodeStep).
+            eval(cache)
+            firstTokenAt = Date()
+
+            // Cache is now populated with the prefill + first decode forward.
+            // Constructing CompiledDecodeStep here satisfies ADV-1 (populated
+            // cache precondition from CompiledDecode.swift).
+            let step = CompiledDecodeStep(model: context.model, cache: cache, enabled: true)
+
+            // Build EOS set: mirrors buildStopTokenIds() from mlx-swift-lm Evaluate.swift.
+            // Must include extraEOSTokens (string→ID) so chat templates that use tokens
+            // like "<|im_end|>" (Qwen) are correctly recognised as stop tokens.
+            var eosIds: Set<Int> = context.configuration.eosTokenIds
+            if let tokEOS = context.tokenizer.eosTokenId { eosIds.insert(tokEOS) }
+            if let unkID = context.tokenizer.unknownTokenId { eosIds.insert(unkID) }
+            for token in context.configuration.extraEOSTokens {
+                if let id = context.tokenizer.convertTokenToId(token) { eosIds.insert(id) }
+            }
+
+            decodedTokenCount = 1  // count first token
+            var currentToken = firstTokenArray.reshaped(1, 1)
+
+            for _ in 1 ..< maxTokens {
+                // compiled step: model(currentToken [1,1], cache:) → logits [1,1,vocab]
+                let logits = step.step(currentToken)
+                eval(logits)
+                let nextToken = argMax(logits[0..., -1, 0...], axis: -1)
+                eval(nextToken)
+                let tokenId = nextToken.item(Int.self)
+                if eosIds.contains(tokenId) { break }
+                currentToken = nextToken.reshaped(1, 1)
+                decodedTokenCount += 1
+            }
+
+            // Synchronize stream before returning — mirrors TokenIterator's
+            // Stream().synchronize() call to avoid scheduler tear-down assertions.
+            Stream().synchronize()
+        }
+
+        let endAt = Date()
+        let prefillEnd = firstTokenAt ?? endAt
+        let prefillElapsed = max(prefillEnd.timeIntervalSince(prefillStart), 0.001)
+        let decodeElapsed = max(endAt.timeIntervalSince(prefillEnd), 0.001)
+        let prefillTPS = Double(promptTokensCount) / prefillElapsed
+        // -1: first token is the TTFT boundary token, not counted in decode TPS
+        let decodeTPS = Double(max(decodedTokenCount - 1, 0)) / decodeElapsed
+
+        return BenchSampleResult(
+            isWarmup: isWarmup,
+            promptTokensActual: promptTokensCount,
+            decodeTokensActual: decodedTokenCount,
+            prefillSeconds: prefillElapsed,
+            decodeSeconds: decodeElapsed,
+            ttftSeconds: prefillElapsed,
+            prefillTPS: prefillTPS,
+            decodeTPS: decodeTPS
+        )
+    }
 
     private func runOnce(
         container: ModelContainer,

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -1413,6 +1413,18 @@ actor ModelRuntime: ModelRuntimeServing {
             throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
         }
 
+        // T2-01: compiled decode env-flag wire-in. When enabled, the
+        // decode-bench path uses MLX.compile()-wrapped per-token forwards
+        // (see DecodeBenchCommand.runCompiledOnce). Full production stream()
+        // wire-in is deferred to a follow-up PR after bench correctness is
+        // confirmed via T2-01 artifact. The flag is read here so it appears
+        // in inference logs and the serve path is ready to branch on it.
+        let compiledDecodeEnabled = CompiledDecode.isEnabledByEnvironment()
+        if compiledDecodeEnabled {
+            let line = "event=compiled_decode_enabled status=stream_path_deferred flag=\(CompiledDecode.envFlag)\n"
+            FileHandle.standardError.write(Data(line.utf8))
+        }
+
         let maxContextTokens = maxContextTokens
         let kvBitsOverride = kvBitsOverride
         let conversationCache = conversationCache

--- a/phase3-binary/Tests/macprovider-cliTests/ScaffoldTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ScaffoldTests.swift
@@ -1,3 +1,79 @@
-// XCTest is not present in the current CommandLineTools-only environment.
-// Step-level verification uses CLI smoke tests until an XCTest-capable
-// toolchain is available.
+import XCTest
+@testable import macprovider_cli
+
+/// Unit tests for `CompiledDecode` env-flag parsing.
+/// Ported from `perf/mlx-compile-bf16` as part of T2-01 (T2-01-compiled-decode-wire-in).
+///
+/// Live `CompiledDecodeStep` correctness (greedy token-ID equality) requires
+/// a real loaded model and is covered by the manual bench in
+/// `beta/throughput-engineering/T2-01-compiled-decode-wire-in.md`.
+final class CompiledDecodeFlagTests: XCTestCase {
+    func testEnvFlagAcceptsCommonTruthyForms() {
+        XCTAssertTrue(CompiledDecode.isEnabledByEnvironment(["MACPROVIDER_COMPILED_DECODE": "1"]))
+        XCTAssertTrue(CompiledDecode.isEnabledByEnvironment(["MACPROVIDER_COMPILED_DECODE": "true"]))
+        XCTAssertTrue(CompiledDecode.isEnabledByEnvironment(["MACPROVIDER_COMPILED_DECODE": "TRUE"]))
+        XCTAssertTrue(CompiledDecode.isEnabledByEnvironment(["MACPROVIDER_COMPILED_DECODE": "yes"]))
+        XCTAssertTrue(CompiledDecode.isEnabledByEnvironment(["MACPROVIDER_COMPILED_DECODE": " 1 "]))
+    }
+
+    func testEnvFlagDefaultsOff() {
+        XCTAssertFalse(CompiledDecode.isEnabledByEnvironment([:]))
+        XCTAssertFalse(CompiledDecode.isEnabledByEnvironment(["MACPROVIDER_COMPILED_DECODE": "0"]))
+        XCTAssertFalse(CompiledDecode.isEnabledByEnvironment(["MACPROVIDER_COMPILED_DECODE": "false"]))
+        XCTAssertFalse(CompiledDecode.isEnabledByEnvironment(["MACPROVIDER_COMPILED_DECODE": ""]))
+        XCTAssertFalse(CompiledDecode.isEnabledByEnvironment(["MACPROVIDER_COMPILED_DECODE": "maybe"]))
+    }
+
+    func testEnvFlagIsDefaultOff_LiveEnvironment() {
+        // Verify the env-flag lookup in the live process environment defaults to false
+        // when the variable is not set. This is the safety check that ensures production
+        // serve starts without compiled decode unless the operator explicitly opts in.
+        let env = ProcessInfo.processInfo.environment
+        if env[CompiledDecode.envFlag] == nil {
+            XCTAssertFalse(CompiledDecode.isEnabledByEnvironment())
+        }
+    }
+}
+
+/// Unit tests for `DecodeBench` helper functions.
+final class DecodeBenchHelperTests: XCTestCase {
+    func testPercentileP50OnThreeRunsReturnsMiddle() {
+        XCTAssertEqual(decodeBenchPercentileTPS([10.0, 30.0, 20.0], p: 0.5), 20.0)
+    }
+
+    func testPercentileP50OnEmptyReturnsZero() {
+        XCTAssertEqual(decodeBenchPercentileTPS([], p: 0.5), 0.0)
+    }
+
+    func testPercentileP100OnFourRunsReturnsMax() {
+        XCTAssertEqual(decodeBenchPercentileTPS([1.0, 2.0, 3.0, 4.0], p: 1.0), 4.0)
+    }
+
+    func testPinTagIsNonEmpty() {
+        XCTAssertFalse(decodeBenchMLXPinTag().isEmpty)
+    }
+
+    func testSanitizeFilenameComponentRejectsPathTraversal() {
+        XCTAssertEqual(decodeBenchSanitizeFilenameComponent("../etc/passwd"), "etc_passwd")
+        XCTAssertEqual(decodeBenchSanitizeFilenameComponent("..\\windows"), "windows")
+        XCTAssertEqual(decodeBenchSanitizeFilenameComponent("a/b/c"), "a_b_c")
+    }
+
+    func testSanitizeFilenameComponentKeepsSafeChars() {
+        XCTAssertEqual(decodeBenchSanitizeFilenameComponent("baseline"), "baseline")
+        XCTAssertEqual(
+            decodeBenchSanitizeFilenameComponent("Qwen2.5-32B-Instruct-4bit"),
+            "Qwen2.5-32B-Instruct-4bit"
+        )
+        XCTAssertEqual(decodeBenchSanitizeFilenameComponent("compiled_on"), "compiled_on")
+    }
+
+    func testSanitizeFilenameComponentHandlesEdgeCases() {
+        XCTAssertEqual(decodeBenchSanitizeFilenameComponent(""), "unlabeled")
+        XCTAssertEqual(decodeBenchSanitizeFilenameComponent("///"), "unlabeled")
+        XCTAssertEqual(decodeBenchSanitizeFilenameComponent("..."), "unlabeled")
+        // 100-char input gets capped to 80.
+        let long = String(repeating: "x", count: 100)
+        XCTAssertEqual(decodeBenchSanitizeFilenameComponent(long).count, 80)
+    }
+}


### PR DESCRIPTION
## Summary
- Port `CompiledDecode.swift` from `perf/mlx-compile-bf16` — env-flag gated compiled decode step + `KVCacheUpdatableAdapter`.
- Wire `decode-bench` compiled path when `MACPROVIDER_COMPILED_DECODE=1`.
- Log flag in `ModelRuntime.stream()`; full runtime wire-in deferred.
- Add scaffold unit tests for env flag helpers.

## Test plan
- [x] `swift test` — 968 tests pass
- [ ] **Do not enable in production** — correctness gate FAILED on Qwen2.5-7B: `MLX.compile()` + `KVCacheSimple.offset` (Swift `Int`) bakes cache position into graph → token repetition loop instead of EOS

## Notes
- Flag defaults **OFF**. No production behavior change unless env set.
- Fix blocked on upstream: KV cache offset must be graph-traceable (`MLXArray`), likely same mlx-swift-lm release as Gemma MoE (#364).
- Artifact: `beta/throughput-engineering/T2-01-compiled-decode-wire-in.md`
- Merge after #469 (T2-02) to reduce conflict risk on `DecodeBenchCommand.swift`.


Made with [Cursor](https://cursor.com)