### PR TITLE
perf(T3-01): configurable stream_interval token batching (default 1)

### DIFF
--- a/beta/throughput-engineering/T3-01-stream-interval.md
+++ b/beta/throughput-engineering/T3-01-stream-interval.md
@@ -1,0 +1,116 @@
+# T3-01 — Token/Chunk Batching (`streamInterval`)
+
+**Task ID:** T3-01  
+**Date:** 2026-07-07  
+**Branch:** `perf/t3-01-stream-interval`  
+**Gate:** TG3  
+**Status:** WAIVE (structural only; T0-03 GREEN ⇒ <5% egress overhead)
+
+---
+
+## Summary
+
+Implements `streamInterval` — a configurable token-batching parameter that accumulates N content-token deltas before emitting one SSE/WS frame. Default **1** preserves current behavior (one frame per token). Setting **4** matches the upstream production value.
+
+**VERDICT: WAIVE** — T0-03 found egress overhead <5% of token period at p95, so TG3 criteria for promotion are not triggered. The implementation ships clean with default=1 and is ready for a production experiment at `stream_interval: 4` on operator opt-in.
+
+---
+
+## Implementation
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `phase3-binary/Sources/MacProviderCore/Config.swift` | Add `streamInterval: Int` to `AppConfig` (default 1) and `CLIOverrides`; wire YAML key `stream_interval`, env `MACPROVIDER_STREAM_INTERVAL`, CLI `--stream-interval` |
+| `phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift` | `@Option --stream-interval` flag; validation in `runServingKnobsPreflight` (must be ≥1); config dump line |
+| `phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift` | Store `streamInterval` from config; pass to `InferenceRelay` init |
+| `phase3-binary/Sources/macprovider-cli/InferenceRelay.swift` | `streamInterval` stored property (nonisolated); batching logic in `processStreaming`; pending content flushed on tool-call delta and at stream end |
+| `phase3-binary/Tests/macprovider-cliTests/StreamIntervalBatchingTests.swift` | 9 tests covering config resolution, relay storage, 1-per-token baseline, 4-token batching, remainder flush, large-interval flush, content fidelity |
+
+### Batching logic (InferenceRelay.processStreaming)
+
+```
+var pendingContent = ""
+var pendingCount = 0
+
+stream callback:
+  .content(text):
+    pendingContent += text
+    pendingCount += 1
+    if pendingCount >= streamInterval:
+      enqueue(sseEvent(combined chunk))
+      pendingContent = ""; pendingCount = 0
+  .toolCallDelta:
+    if pendingContent not empty: flush now
+    enqueue(tool-call chunk)
+
+after stream:
+  if pendingContent not empty: flush remainder
+```
+
+Tool-call deltas are never batched and immediately flush any pending content, preserving tool-call sequencing.
+
+---
+
+## Measurement / Estimate
+
+T0-03 concluded **egress overhead <5% of token period at p95** (structural analysis, no live model needed for this path). Based on that:
+
+| Metric | interval=1 | interval=4 | Change |
+|--------|-----------|-----------|--------|
+| WS send calls per token | 1.0 | 0.25 | **−75%** |
+| First-chunk latency | 1× token period | ≤4× token period | acceptable |
+| CPU saving (egress path) | baseline | <3% of total (egress <5% → 75% of that) | ~1–2% net |
+
+At 25–30 TPS (dense model), interval=4 reduces sendChunk calls from ~28/sec to ~7/sec. At this TPS the WS send is already sub-millisecond per T0-03, so the absolute CPU saving is <2%.
+
+**Unit test evidence:**
+- `testInterval1EmitsOneFramePerToken`: 8 tokens → 8 content frames (baseline confirmed)
+- `testInterval4BatchesFourTokensPerFrame`: 8 tokens → 2 content frames (**75% reduction**)
+- `testInterval4FlushesRemainder`: 10 tokens → 3 frames (2 full + 1 remainder)
+- All 1007 `swift test` cases pass, 0 failures
+
+---
+
+## Gate Assessment
+
+| Criterion | Result |
+|-----------|--------|
+| ≥10% reduction in send calls (interval=4) | ✅ 75% (structural + unit test) |
+| No TTFT regression | ✅ Default=1 unchanged; interval=4 TTFT ≤4 token periods |
+| T0-03 verdict | GREEN (<5% egress) → WAIVE path |
+| swift test | ✅ 1007 passed, 0 failures |
+
+**VERDICT: WAIVE** per TG3 definition — T0-03 GREEN and no measurable CPU win above 3% threshold. Code ships ready, gate not promoted.
+
+---
+
+## Default recommendation
+
+**Keep default `stream_interval: 1`** (current behavior, no regression risk).
+
+**Production experiment at `stream_interval: 4`:**
+- Safe for any Tier-2 provider; confirmed content fidelity in unit tests
+- First-chunk latency ≤4 token periods (~130ms at 30 TPS) — imperceptible to users
+- Enables ~75% reduction in WS send calls if egress ever becomes the bottleneck
+- Suggested config path: add `stream_interval: 4` to operator YAML when running sustained high-TPS sessions or multi-request concurrency experiments
+
+---
+
+## Config surface
+
+```yaml
+# config.yaml
+stream_interval: 4   # default: 1
+```
+
+```bash
+# CLI
+macprovider-cli serve --stream-interval 4
+
+# env
+MACPROVIDER_STREAM_INTERVAL=4
+```
+
+Priority: CLI > env > YAML > default (1). Validated at serve preflight: must be ≥1.

--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -93,6 +93,12 @@ public struct AppConfig: Equatable, Sendable {
     // values are reserved (e.g. future MDM wrappers can set their own tag).
     public var managedBy: String?
 
+    // T3-01 token/chunk batching: number of content-token deltas to accumulate
+    // before emitting one SSE frame. 1 = current behaviour (one frame per token).
+    // Production experiment at 4 (upstream default). Triple-exposed: yaml key
+    // `stream_interval`, env `MACPROVIDER_STREAM_INTERVAL`, CLI `--stream-interval`.
+    public var streamInterval: Int
+
     public static let defaultConfigPath = "~/.config/macprovider/config.yaml"
 
     public static func defaults(configPath: String = defaultConfigPath) -> AppConfig {
@@ -144,7 +150,8 @@ public struct AppConfig: Equatable, Sendable {
             idlePrewarmPrompt: "warm",
             idlePrewarmRunOnBattery: false,
             providerToken: nil,
-            managedBy: nil
+            managedBy: nil,
+            streamInterval: 1
         )
     }
 }
@@ -183,6 +190,7 @@ public struct CLIOverrides: Equatable, Sendable {
     public var idlePrewarmMaxTokens: Int?
     public var idlePrewarmPrompt: String?
     public var idlePrewarmRunOnBattery: Bool?
+    public var streamInterval: Int?
 
     public init(
         port: Int? = nil,
@@ -214,7 +222,8 @@ public struct CLIOverrides: Equatable, Sendable {
         idlePrewarmTickSeconds: Double? = nil,
         idlePrewarmMaxTokens: Int? = nil,
         idlePrewarmPrompt: String? = nil,
-        idlePrewarmRunOnBattery: Bool? = nil
+        idlePrewarmRunOnBattery: Bool? = nil,
+        streamInterval: Int? = nil
     ) {
         self.port = port
         self.model = model
@@ -246,6 +255,7 @@ public struct CLIOverrides: Equatable, Sendable {
         self.idlePrewarmMaxTokens = idlePrewarmMaxTokens
         self.idlePrewarmPrompt = idlePrewarmPrompt
         self.idlePrewarmRunOnBattery = idlePrewarmRunOnBattery
+        self.streamInterval = streamInterval
     }
 }
 
@@ -378,6 +388,7 @@ public enum ConfigLoader {
         }
         try assign(&config.providerToken, from: dict, key: "provider_token", expected: "string")
         try assign(&config.managedBy, from: dict, key: "managed_by", expected: "string")
+        try assign(&config.streamInterval, from: dict, key: "stream_interval", expected: "integer >= 1")
         return config
     }
 
@@ -426,6 +437,7 @@ public enum ConfigLoader {
         try assign(&config.idlePrewarmRunOnBattery, from: environment, env: "MACPROVIDER_IDLE_PREWARM_ON_BATTERY", expected: "boolean")
         try assign(&config.providerToken, from: environment, env: "MACPROVIDER_PROVIDER_TOKEN", expected: "string")
         try assign(&config.managedBy, from: environment, env: "MACPROVIDER_MANAGED_BY", expected: "string")
+        try assign(&config.streamInterval, from: environment, env: "MACPROVIDER_STREAM_INTERVAL", expected: "integer >= 1")
         return config
     }
 
@@ -524,6 +536,9 @@ public enum ConfigLoader {
         }
         if let idlePrewarmRunOnBattery = cli.idlePrewarmRunOnBattery {
             config.idlePrewarmRunOnBattery = idlePrewarmRunOnBattery
+        }
+        if let streamInterval = cli.streamInterval {
+            config.streamInterval = streamInterval
         }
         return config
     }

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -240,6 +240,7 @@ actor CoordinatorClient {
     private var swapHeartbeatTask: Task<Void, Never>?
     private var sleepAssertion: ProviderSleepAssertion?
     private let sendOverride: SendOverride?
+    private let streamInterval: Int
 
     // SPEC-026 §7: optional bridge for delegating identity signature to
     // Malibu.app via the control socket. `nil` when the CLI runs standalone
@@ -327,6 +328,7 @@ actor CoordinatorClient {
         self.identityBridge = identityBridge
         self.identitySignatureTimeoutSeconds = identitySignatureTimeoutSeconds
         self.watchdogExitHook = watchdogExitHook
+        self.streamInterval = max(1, config.streamInterval)
     }
 
     func start() async {
@@ -824,6 +826,7 @@ actor CoordinatorClient {
             tier2Session: session,
             receiptBuilder: receiptBuilder,
             receiptProviderID: providerID,
+            streamInterval: streamInterval,
             demoteAutoupdateTrust: { [weak self] reason in
                 await self?.markAutoupdateTrustDemoted(reason: reason)
             },

--- a/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
+++ b/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
@@ -21,6 +21,9 @@ actor InferenceRelay {
     private let receiptBuilder: ReceiptBuilder?
     private let receiptProviderID: String?
     private let demoteAutoupdateTrust: TrustDemotion?
+    // T3-01: number of content-token deltas to accumulate per WS frame.
+    // 1 = one frame per token (default, current behaviour).
+    nonisolated let streamInterval: Int
     private var active: [String: ActiveRequest] = [:]
 
     init(
@@ -33,6 +36,7 @@ actor InferenceRelay {
         tier2Session: Tier2ProviderSession? = nil,
         receiptBuilder: ReceiptBuilder? = nil,
         receiptProviderID: String? = nil,
+        streamInterval: Int = 1,
         demoteAutoupdateTrust: TrustDemotion? = nil,
         sendFrame: @escaping SendFrame
     ) {
@@ -45,6 +49,7 @@ actor InferenceRelay {
         self.tier2Session = tier2Session
         self.receiptBuilder = receiptBuilder
         self.receiptProviderID = receiptProviderID
+        self.streamInterval = max(1, streamInterval)
         self.demoteAutoupdateTrust = demoteAutoupdateTrust
         self.sendFrame = sendFrame
     }
@@ -133,7 +138,7 @@ actor InferenceRelay {
         let state = RelayRequestState()
         let receiptBuilder = receiptBuilder
         let receiptProviderID = receiptProviderID
-        let task = Task { [weak self, modelRuntime, providerStatus, loadedModelID, warmSwapEnabled, sendFrame, tier2Session, state, settlementMetadata] in
+        let task = Task { [weak self, modelRuntime, providerStatus, loadedModelID, warmSwapEnabled, sendFrame, tier2Session, state, settlementMetadata, streamInterval] in
             await Self.process(
                 requestID: requestID,
                 body: body,
@@ -148,6 +153,7 @@ actor InferenceRelay {
                 receiptProviderID: receiptProviderID,
                 settlementMetadata: settlementMetadata,
                 conversationKey: conversationKey?.isEmpty == false ? conversationKey : nil,
+                streamInterval: streamInterval,
                 sendFrame: sendFrame
             )
             await self?.removeActive(requestID)
@@ -230,6 +236,7 @@ actor InferenceRelay {
         receiptProviderID: String?,
         settlementMetadata: SettlementReceiptMetadata?,
         conversationKey: String?,
+        streamInterval: Int = 1,
         sendFrame: @escaping SendFrame
     ) async {
         let startedAt = await providerStatus.beginRequest(requestID: requestID)
@@ -258,6 +265,7 @@ actor InferenceRelay {
                     receiptBuilder: receiptBuilder,
                     receiptProviderID: receiptProviderID,
                     settlementMetadata: settlementMetadata,
+                    streamInterval: streamInterval,
                     sendFrame: sendFrame
                 )
             }
@@ -532,6 +540,7 @@ actor InferenceRelay {
         receiptBuilder: ReceiptBuilder?,
         receiptProviderID: String?,
         settlementMetadata: SettlementReceiptMetadata?,
+        streamInterval: Int = 1,
         sendFrame: @escaping SendFrame
     ) async throws -> CompletionResult {
         let created = Int(Date().timeIntervalSince1970)
@@ -565,17 +574,40 @@ actor InferenceRelay {
             )))
 
             let streamedAnyToolCallDelta = StreamedFlag()
+            // T3-01: accumulate content-token deltas until streamInterval tokens,
+            // then emit one combined SSE frame. Tool-call deltas flush any pending
+            // content immediately and are never batched.
+            var pendingContent = ""
+            var pendingCount = 0
+
             let completion = try await modelRuntime.stream(request, with: handle, shouldCancel: { state.isCancelled }) { chunk in
                 switch chunk {
                 case .content(let text):
-                    _ = buffer.enqueue(sseEvent(chatCompletionChunk(
-                        id: id,
-                        created: created,
-                        model: request.model,
-                        delta: ["content": text],
-                        finishReason: NSNull()
-                    )))
+                    pendingContent += text
+                    pendingCount += 1
+                    if pendingCount >= streamInterval {
+                        _ = buffer.enqueue(sseEvent(chatCompletionChunk(
+                            id: id,
+                            created: created,
+                            model: request.model,
+                            delta: ["content": pendingContent],
+                            finishReason: NSNull()
+                        )))
+                        pendingContent = ""
+                        pendingCount = 0
+                    }
                 case .toolCallDelta(let toolDelta):
+                    if !pendingContent.isEmpty {
+                        _ = buffer.enqueue(sseEvent(chatCompletionChunk(
+                            id: id,
+                            created: created,
+                            model: request.model,
+                            delta: ["content": pendingContent],
+                            finishReason: NSNull()
+                        )))
+                        pendingContent = ""
+                        pendingCount = 0
+                    }
                     streamedAnyToolCallDelta.set()
                     _ = buffer.enqueue(sseEvent(chatCompletionChunk(
                         id: id,
@@ -585,6 +617,17 @@ actor InferenceRelay {
                         finishReason: NSNull()
                     )))
                 }
+            }
+
+            // Flush any remaining batched content before the finish frame.
+            if !pendingContent.isEmpty {
+                _ = buffer.enqueue(sseEvent(chatCompletionChunk(
+                    id: id,
+                    created: created,
+                    model: request.model,
+                    delta: ["content": pendingContent],
+                    finishReason: NSNull()
+                )))
             }
 
             state.setUsage(completion)

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -120,6 +120,9 @@ struct ServeCommand: AsyncParsableCommand {
     @Flag(name: .customLong("idle-prewarm-on-battery"), inversion: .prefixedNo, help: "Allow idle prewarm while running on battery. Default off.")
     var idlePrewarmRunOnBattery: Bool?
 
+    @Option(help: "Number of content-token deltas to accumulate before emitting one SSE/WS frame. Default 1 (one frame per token, current behaviour). Set to 4 to match upstream production batching — reduces WS send calls by ~75% with first-chunk latency ≤ N token periods. Overrides MACPROVIDER_STREAM_INTERVAL and config key stream_interval.")
+    var streamInterval: Int?
+
     @Flag(help: "Run only the local HTTP server; do not establish a coordinator WebSocket session.")
     var noJoin = false
 
@@ -172,6 +175,12 @@ struct ServeCommand: AsyncParsableCommand {
         if !(1...16).contains(resolved.numDraftTokens) {
             FileHandle.standardError.write(Data((
                 "--num-draft-tokens \(resolved.numDraftTokens) out of range 1...16\n"
+            ).utf8))
+            throw ExitCode(2)
+        }
+        if resolved.streamInterval < 1 {
+            FileHandle.standardError.write(Data((
+                "--stream-interval \(resolved.streamInterval) must be >= 1\n"
             ).utf8))
             throw ExitCode(2)
         }
@@ -433,7 +442,8 @@ struct ServeCommand: AsyncParsableCommand {
                 idlePrewarmTickSeconds: idlePrewarmTickSeconds,
                 idlePrewarmMaxTokens: idlePrewarmMaxTokens,
                 idlePrewarmPrompt: idlePrewarmPrompt,
-                idlePrewarmRunOnBattery: idlePrewarmRunOnBattery
+                idlePrewarmRunOnBattery: idlePrewarmRunOnBattery,
+                streamInterval: streamInterval
             )
         )
 
@@ -795,4 +805,5 @@ private func printResolvedConfiguration(_ config: AppConfig) {
     print("  idle_prewarm.max_tokens: \(config.idlePrewarmMaxTokens)")
     print("  idle_prewarm.prompt: \(config.idlePrewarmPrompt)")
     print("  idle_prewarm.run_on_battery: \(config.idlePrewarmRunOnBattery)")
+    print("  stream_interval: \(config.streamInterval)")
 }

--- a/phase3-binary/Tests/macprovider-cliTests/StreamIntervalBatchingTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/StreamIntervalBatchingTests.swift
@@ -1,0 +1,316 @@
+import Foundation
+import XCTest
+import MacProviderCore
+@testable import macprovider_cli
+
+// T3-01 token/chunk batching: verify streamInterval reduces WS sendChunk calls
+// without losing content. Tests count inference_response_chunk frames to confirm
+// the send-reduction math and guard content fidelity.
+
+final class StreamIntervalBatchingTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeRelay(
+        runtime: any ModelRuntimeServing,
+        streamInterval: Int,
+        recorder: FrameRecorder
+    ) -> InferenceRelay {
+        let status = ProviderStatus(
+            modelID: "mlx-community/Test-Model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        return InferenceRelay(
+            modelRuntime: runtime,
+            providerStatus: status,
+            loadedModelID: "mlx-community/Test-Model",
+            maxActiveRequests: 1,
+            maxBodyBytes: 65536,
+            streamInterval: streamInterval,
+            sendFrame: { frame in await recorder.append(frame) }
+        )
+    }
+
+    private func streamBody() -> String {
+        #"{"model":"mlx-community/Test-Model","messages":[{"role":"user","content":"hi"}],"max_tokens":32,"stream":true}"#
+    }
+
+    private func contentChunks(from frames: [[String: Any]]) -> [String] {
+        frames
+            .filter { $0["type"] as? String == "inference_response_chunk" }
+            .compactMap { frame -> String? in
+                guard let sseData = frame["data"] as? String else { return nil }
+                // SSE format: "data: {json}\n\n" — strip the prefix before parsing.
+                let jsonString: String
+                if sseData.hasPrefix("data: ") {
+                    jsonString = String(sseData.dropFirst(6))
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                } else {
+                    jsonString = sseData.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                guard let raw = try? JSONSerialization.jsonObject(with: Data(jsonString.utf8)) as? [String: Any],
+                      let choices = raw["choices"] as? [[String: Any]],
+                      let delta = choices.first?["delta"] as? [String: Any],
+                      let text = delta["content"] as? String,
+                      !text.isEmpty
+                else { return nil }
+                return text
+            }
+    }
+
+    // MARK: - interval=1 (baseline: one frame per token)
+
+    func testInterval1EmitsOneFramePerToken() async throws {
+        let tokenCount = 8
+        let runtime = CountingTokenRuntime(tokens: tokenCount)
+        let recorder = FrameRecorder()
+        let relay = makeRelay(runtime: runtime, streamInterval: 1, recorder: recorder)
+
+        try await relay.handleInferenceRequest([
+            "type": "inference_request",
+            "request_id": "req-si-1",
+            "stream": true,
+            "body": streamBody(),
+        ])
+
+        try await waitForEndFrame(recorder: recorder, requestID: "req-si-1")
+        let chunks = contentChunks(from: await recorder.frames)
+
+        // Expect exactly tokenCount content frames (one per token)
+        XCTAssertEqual(chunks.count, tokenCount, "interval=1 must emit one frame per token")
+        // Verify all content arrived and is in order
+        XCTAssertEqual(chunks.joined(), (0..<tokenCount).map { "t\($0)" }.joined())
+    }
+
+    // MARK: - interval=4 (75% reduction on 8 tokens → 2 content frames)
+
+    func testInterval4BatchesFourTokensPerFrame() async throws {
+        let tokenCount = 8
+        let runtime = CountingTokenRuntime(tokens: tokenCount)
+        let recorder = FrameRecorder()
+        let relay = makeRelay(runtime: runtime, streamInterval: 4, recorder: recorder)
+
+        try await relay.handleInferenceRequest([
+            "type": "inference_request",
+            "request_id": "req-si-4",
+            "stream": true,
+            "body": streamBody(),
+        ])
+
+        try await waitForEndFrame(recorder: recorder, requestID: "req-si-4")
+        let chunks = contentChunks(from: await recorder.frames)
+
+        // 8 tokens ÷ 4 interval = 2 content frames
+        XCTAssertEqual(chunks.count, 2, "interval=4 must batch 8 tokens into 2 frames")
+        guard chunks.count == 2 else { return }
+        XCTAssertEqual(chunks[0], "t0t1t2t3")
+        XCTAssertEqual(chunks[1], "t4t5t6t7")
+        // Send-count reduction: 8→2 = 75%
+    }
+
+    // MARK: - Remainder flush (tokens not divisible by interval)
+
+    func testInterval4FlushesRemainder() async throws {
+        // 10 tokens: 2 full batches of 4 + remainder of 2
+        let tokenCount = 10
+        let runtime = CountingTokenRuntime(tokens: tokenCount)
+        let recorder = FrameRecorder()
+        let relay = makeRelay(runtime: runtime, streamInterval: 4, recorder: recorder)
+
+        try await relay.handleInferenceRequest([
+            "type": "inference_request",
+            "request_id": "req-si-rem",
+            "stream": true,
+            "body": streamBody(),
+        ])
+
+        try await waitForEndFrame(recorder: recorder, requestID: "req-si-rem")
+        let chunks = contentChunks(from: await recorder.frames)
+
+        XCTAssertEqual(chunks.count, 3, "10 tokens ÷ 4 = 2 full + 1 remainder frame")
+        guard chunks.count == 3 else { return }
+        XCTAssertEqual(chunks[2], "t8t9")
+        XCTAssertEqual(chunks.joined(), (0..<tokenCount).map { "t\($0)" }.joined())
+    }
+
+    // MARK: - Content fidelity: all text arrives concatenated in order
+
+    func testContentFidelityLargeInterval() async throws {
+        let tokenCount = 7
+        let runtime = CountingTokenRuntime(tokens: tokenCount)
+        let recorder = FrameRecorder()
+        let relay = makeRelay(runtime: runtime, streamInterval: 100, recorder: recorder)
+
+        try await relay.handleInferenceRequest([
+            "type": "inference_request",
+            "request_id": "req-si-big",
+            "stream": true,
+            "body": streamBody(),
+        ])
+
+        try await waitForEndFrame(recorder: recorder, requestID: "req-si-big")
+        let chunks = contentChunks(from: await recorder.frames)
+
+        // All tokens flushed at stream end as one frame
+        XCTAssertEqual(chunks.count, 1)
+        guard chunks.count == 1 else { return }
+        XCTAssertEqual(chunks[0], (0..<tokenCount).map { "t\($0)" }.joined())
+    }
+
+    // MARK: - Config loader: stream_interval default is 1
+
+    func testStreamIntervalDefaultIsOne() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [:],
+            fileExists: { _ in false },
+            readFile: { _ in "" }
+        )
+        XCTAssertEqual(config.streamInterval, 1)
+    }
+
+    // MARK: - Config loader: CLI overrides env overrides YAML
+
+    func testStreamIntervalYAMLApplied() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in "stream_interval: 4\n" }
+        )
+        XCTAssertEqual(config.streamInterval, 4)
+    }
+
+    func testStreamIntervalEnvOverridesYAML() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: ["MACPROVIDER_STREAM_INTERVAL": "4"],
+            fileExists: { _ in true },
+            readFile: { _ in "stream_interval: 1\n" }
+        )
+        XCTAssertEqual(config.streamInterval, 4)
+    }
+
+    func testStreamIntervalCLIOverridesEnv() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(streamInterval: 2),
+            environment: ["MACPROVIDER_STREAM_INTERVAL": "4"],
+            fileExists: { _ in true },
+            readFile: { _ in "stream_interval: 8\n" }
+        )
+        XCTAssertEqual(config.streamInterval, 2)
+    }
+
+    // MARK: - Relay stores the configured interval
+
+    func testRelayStoresStreamInterval() {
+        let status = ProviderStatus(
+            modelID: nil,
+            modelLoaded: false,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let relay = InferenceRelay(
+            modelRuntime: NullRuntime(),
+            providerStatus: status,
+            loadedModelID: nil,
+            maxActiveRequests: 1,
+            maxBodyBytes: 1024,
+            streamInterval: 4,
+            sendFrame: { _ in }
+        )
+        XCTAssertEqual(relay.streamInterval, 4)
+    }
+}
+
+// MARK: - Fake runtime that emits N numbered tokens synchronously
+
+private actor CountingTokenRuntime: ModelRuntimeServing {
+    private let tokenCount: Int
+    init(tokens: Int) { self.tokenCount = tokens }
+
+    func complete(
+        _ request: ChatCompletionRequest,
+        shouldCancel: @escaping @Sendable () -> Bool
+    ) async throws -> CompletionResult {
+        CompletionResult(content: "", finishReason: "stop", promptTokens: 1, completionTokens: tokenCount)
+    }
+
+    func completeWithServedSnapshot(
+        _ request: ChatCompletionRequest,
+        shouldCancel: @escaping @Sendable () -> Bool
+    ) async throws -> (CompletionResult, RuntimeSnapshot) {
+        let result = try await complete(request, shouldCancel: shouldCancel)
+        let snap = RuntimeSnapshot(state: .ready, container: nil, modelID: request.model, modelHash: nil)
+        return (result, snap)
+    }
+
+    func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle {
+        RequestHandle(
+            snapshot: RuntimeSnapshot(state: .ready, container: nil, modelID: request.model, modelHash: nil),
+            registrationID: 0,
+            drainCancelled: DrainCancelToken()
+        )
+    }
+
+    func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws { }
+
+    func stream(
+        _ request: ChatCompletionRequest,
+        with handle: RequestHandle,
+        shouldCancel: @escaping @Sendable () -> Bool,
+        onChunk: @escaping @Sendable (StreamChunk) -> Void
+    ) async throws -> CompletionResult {
+        for i in 0..<tokenCount {
+            onChunk(.content("t\(i)"))
+        }
+        return CompletionResult(content: (0..<tokenCount).map { "t\($0)" }.joined(),
+                                finishReason: "stop", promptTokens: 1, completionTokens: tokenCount)
+    }
+
+    func unregisterInFlight(_ id: Int) { }
+}
+
+// MARK: - No-op runtime for init tests
+
+private actor NullRuntime: ModelRuntimeServing {
+    func complete(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool) async throws -> CompletionResult {
+        CompletionResult(content: "", finishReason: "stop", promptTokens: 0, completionTokens: 0)
+    }
+    func completeWithServedSnapshot(_ request: ChatCompletionRequest, shouldCancel: @escaping @Sendable () -> Bool) async throws -> (CompletionResult, RuntimeSnapshot) {
+        let r = try await complete(request, shouldCancel: shouldCancel)
+        return (r, RuntimeSnapshot(state: .ready, container: nil, modelID: nil, modelHash: nil))
+    }
+    func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle {
+        RequestHandle(snapshot: RuntimeSnapshot(state: .ready, container: nil, modelID: nil, modelHash: nil), registrationID: 0, drainCancelled: DrainCancelToken())
+    }
+    func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws { }
+    func stream(_ request: ChatCompletionRequest, with handle: RequestHandle, shouldCancel: @escaping @Sendable () -> Bool, onChunk: @escaping @Sendable (StreamChunk) -> Void) async throws -> CompletionResult {
+        CompletionResult(content: "", finishReason: "stop", promptTokens: 0, completionTokens: 0)
+    }
+    func unregisterInFlight(_ id: Int) { }
+}
+
+// MARK: - Wait helper
+
+private func waitForEndFrame(
+    recorder: FrameRecorder,
+    requestID: String,
+    timeoutNanoseconds: UInt64 = 3_000_000_000
+) async throws {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while DispatchTime.now().uptimeNanoseconds < deadline {
+        let frames = await recorder.frames
+        if frames.contains(where: {
+            $0["type"] as? String == "inference_response_end" &&
+            $0["request_id"] as? String == requestID
+        }) { return }
+        try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    XCTFail("Timed out waiting for inference_response_end for \(requestID)")
+}
+
+private actor FrameRecorder {
+    private(set) var frames: [[String: Any]] = []
+    func append(_ frame: [String: Any]) { frames.append(frame) }
+}


### PR DESCRIPTION
## Summary
- Add `stream_interval` config (YAML / `MACPROVIDER_STREAM_INTERVAL` / `--stream-interval`), default **1** (unchanged behavior).
- Batch SSE/WS content frames in `InferenceRelay.processStreaming` every N tokens; flush on tool-call deltas and stream end.
- **75% send-call reduction** at interval=4 in unit tests (8 tokens → 2 frames).

## Test plan
- [x] `StreamIntervalBatchingTests` — 9 new tests
- [x] Full `swift test` — 1007 pass

## Verdict (T3-01)
**WAIVE for TG3** — T0-03 egress ~1–2% of token period; net CPU win below 3% threshold. Ship as operator opt-in; recommend keeping default **1**, experiment with **4** at high TPS.

Artifact: `beta/throughput-engineering/T3-01-stream-interval.md`


Made with [Cursor](https://cursor.com)