### PR TITLE
feat(proof-of-weights): W1 inventory and W2 autotune hello gate

### DIFF
--- a/docs/research/proof-of-weights-w1-inventory.md
+++ b/docs/research/proof-of-weights-w1-inventory.md
@@ -1,0 +1,71 @@
+# Proof of Weights — W1 catalog artifact bind inventory
+
+**Date:** 2026-07-08  
+**Runbook:** `ops/runbooks/proof-of-weights-implementation.md` §3  
+**Scope:** Session B W1 audit only (implementation hardening tracked separately)
+
+---
+
+## Seam map (confirmed in tree)
+
+| Component | Path | Role |
+|-----------|------|------|
+| Provider manifest hash | `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift` `modelWeightArtifactManifestHash` | SHA-256 over safetensors manifest at load |
+| Coordinator catalog verify | `phase4-coordinator/internal/tier2/catalog.go` `VerifyProviderHash` | Five-state hash enum at hello + heartbeat |
+| WS admission hash stamp | `phase4-coordinator/internal/ws/server.go` `prepareProviderAdmission` | Sets `pool.Provider.HashStatus` at connect |
+| Buyer routing exclusion | `phase4-coordinator/internal/buyer/server.go` `Tier2Decision` + `routing/filter.go` | `ReasonTier2HashMismatch` / `ReasonTier2HashRequired` |
+| Warm-swap re-verify | `phase4-coordinator/internal/pool/provider.go` `ApplyHeartbeat` SPEC-011 path | Re-runs heartbeat hash verifier on model/hash drift |
+| Settlement bind | SPEC-015 v0.4 `expected_catalog_model_hash` in receipt + coordinator settlement verifier | Quarantine on mismatch |
+| Buyer observe field | `phase3-binary/.../InferenceRelay.swift` `macprovider_model_hash_observed` | Audit trail, not gating |
+| Explorer / quarantine visibility | `phase4-coordinator/internal/billing/endpoints.go` settlement reason filters | `model_hash_mismatch`, `expected_catalog_model_hash_mismatch` |
+
+---
+
+## Audit: hash mismatch → routing exclude
+
+**Finding: no allow path for mismatch when tier2 model hash is active.**
+
+- `tier2.IsHashPredicateFailure` returns true for `hash_mismatch` and `hash_invalid` unconditionally (`catalog.go:682-687`).
+- Buyer `Tier2Decision` maps those to `ReasonTier2HashMismatch` (`buyer/server.go:6195-6197`).
+- `routing.EligibleCandidates` excludes mismatched providers; mismatch vector surfaced in `HashMismatches` for observability (`routing/filter.go`).
+- `/poolz` tier2 eligibility uses the same predicate (`ws/server.go:3042`).
+- Tier2 audit log emits `decision=exclude` for mismatch (`catalog.go:705-706`).
+
+**Gap (LOW):** optional coordinator metric `model_hash_mismatch_total` from runbook §3.1 not yet present — routing exclusion works without it.
+
+---
+
+## Audit: settlement quarantine on hash mismatch
+
+**Finding: phase7-verify + coordinator settlement path quarantine mismatches.**
+
+- Verifier reason `model_hash_mismatch` when receipt hash ≠ catalog sha256 (`phase7-verify/internal/verify/catalog_check.go`).
+- v0.4 settlement adds `expected_catalog_model_hash_mismatch` when pinned catalog body diverges (`settlement_verifier.go`, `phase7-verify/internal/verify/settlement.go`).
+- Explorer SQL surfaces both reasons in quarantine views (`billing/endpoints.go:936`).
+- Fixture coverage: `TestCatalogCheckModelHashMismatch`, v0.4 negative fixtures `negative_receipt_model_hash_mismatch`.
+
+---
+
+## Operator catalog pin workflow (documented)
+
+1. Edit signed tier-2 catalog JSON + rate-card model rows in git (operator PR).
+2. Deploy coordinator with updated `tier2.catalog_path` / hot-reload (SIGHUP).
+3. Providers run `macprovider-cli autotune --recommend --apply` so `model_catalog_*` + `model_artifact_sha256` match the pinned row.
+4. Hello carries `model_hash` from live manifest; coordinator verifies against catalog via `VerifyProviderHash`.
+5. Mismatch → no buyer traffic; settlement receipts quarantine if hash diverges at payout time.
+
+---
+
+## W1 success criteria status
+
+| Criterion | Status |
+|-----------|--------|
+| Mismatch provider never receives buyer traffic for pinned catalog row | ✅ Enforced via tier2 routing predicate |
+| Quarantined receipts visible in operator explorer | ✅ Settlement reason filters present |
+| Optional mismatch metric | ⬜ Not implemented (carry LOW) |
+
+---
+
+## Handoff to W2
+
+W1 seams are wired; W2 adds **capacity ceiling** via verified autotune hardware-evidence at WS hello (`internal/autotune` hello gate). OPoI model-class probes remain Session A / W3.

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/augstar/macprovider-coordinator/internal/audit"
 	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/autotune"
 	"github.com/augstar/macprovider-coordinator/internal/billing"
 	"github.com/augstar/macprovider-coordinator/internal/buyer"
 	"github.com/augstar/macprovider-coordinator/internal/config"
@@ -124,6 +125,14 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "autotune feeds: %v\n", err)
 		os.Exit(1)
+	}
+	var autotuneCatalog *autotune.Catalog
+	if len(autotuneFeeds.AutotuneCandidatesJSON) > 0 {
+		autotuneCatalog, err = autotune.ParseCatalog(autotuneFeeds.AutotuneCandidatesJSON)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "autotune candidate catalog: %v\n", err)
+			os.Exit(1)
+		}
 	}
 	providerhttp.Init(cfg.ProviderHTTP.TimeoutS)
 
@@ -398,6 +407,19 @@ func main() {
 		}
 		wsOpts = append(wsOpts, providerws.WithIdentitySignatureStore(onboardingStore))
 		wsOpts = append(wsOpts, providerws.WithProviderAuthPolicyAdminStore(onboardingStore))
+	}
+	if cfg.ProofOfWeights.RequireAutotuneHelloGate {
+		if autotuneCatalog == nil {
+			logger.Fatal().Msg("proof_of_weights.require_autotune_hello_gate requires autotune candidate catalog feeds")
+		}
+		if onboardingStore == nil || onboardingStore.DB() == nil {
+			logger.Fatal().Msg("proof_of_weights.require_autotune_hello_gate requires onboarding postgres store")
+		}
+		wsOpts = append(wsOpts, providerws.WithAutotuneHelloGate(autotuneCatalog, autotune.NewPGEvidenceStore(onboardingStore.DB())))
+		logger.Info().
+			Int("autotune_evidence_ttl_days", cfg.ProofOfWeights.AutotuneEvidenceTTLDays).
+			Str("autotune_catalog_version", autotuneCatalog.Version).
+			Msg("proof-of-weights autotune hello gate enabled")
 	}
 	if cfg.Auth.RequireProviderTokens {
 		logger.Info().

--- a/phase4-coordinator/internal/autotune/catalog.go
+++ b/phase4-coordinator/internal/autotune/catalog.go
@@ -1,0 +1,119 @@
+package autotune
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+)
+
+const candidateCatalogSource = "operator_curated_autotune_candidate_catalog"
+
+type BenchGate struct {
+	MinSustainedTPS float64 `json:"min_sustained_tps"`
+	Max4KTTFTMS     int     `json:"max_4k_ttft_ms"`
+}
+
+type Row struct {
+	ModelID          string    `json:"model_id"`
+	ModelRevision    string    `json:"model_revision,omitempty"`
+	ModelSHA256      string    `json:"model_sha256,omitempty"`
+	MinRAMGB         int       `json:"min_ram_gb"`
+	MinBandwidthTier string    `json:"min_bandwidth_tier"`
+	BenchGate        BenchGate `json:"bench_gate"`
+	RuntimeStatus    string    `json:"runtime_status"`
+}
+
+type Catalog struct {
+	Version    string
+	SHA256     string
+	RawJSON    []byte
+	rowsByKey  map[string]Row
+	keysByModel map[string][]string
+}
+
+func ParseCatalog(rawJSON []byte) (*Catalog, error) {
+	if len(rawJSON) == 0 {
+		return nil, fmt.Errorf("autotune candidate catalog is empty")
+	}
+	var envelope struct {
+		Version string          `json:"version"`
+		Source  string          `json:"source"`
+		Rows    map[string]Row  `json:"rows"`
+	}
+	if err := json.Unmarshal(rawJSON, &envelope); err != nil {
+		return nil, fmt.Errorf("parse autotune candidate catalog: %w", err)
+	}
+	if envelope.Source != candidateCatalogSource {
+		return nil, fmt.Errorf("autotune candidate catalog source must be %q", candidateCatalogSource)
+	}
+	if strings.TrimSpace(envelope.Version) == "" {
+		return nil, fmt.Errorf("autotune candidate catalog version is required")
+	}
+	if len(envelope.Rows) == 0 {
+		return nil, fmt.Errorf("autotune candidate catalog rows are required")
+	}
+	sum := sha256.Sum256(rawJSON)
+	keysByModel := make(map[string][]string, len(envelope.Rows))
+	for key, row := range envelope.Rows {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("autotune candidate catalog row key is required")
+		}
+		if strings.TrimSpace(row.ModelID) == "" {
+			return nil, fmt.Errorf("autotune candidate catalog row %q model_id is required", key)
+		}
+		if row.MinRAMGB < 0 {
+			return nil, fmt.Errorf("autotune candidate catalog row %q min_ram_gb must be >= 0", key)
+		}
+		if math.IsNaN(row.BenchGate.MinSustainedTPS) || math.IsInf(row.BenchGate.MinSustainedTPS, 0) || row.BenchGate.MinSustainedTPS < 0 {
+			return nil, fmt.Errorf("autotune candidate catalog row %q min_sustained_tps is invalid", key)
+		}
+		if row.BenchGate.Max4KTTFTMS < 0 {
+			return nil, fmt.Errorf("autotune candidate catalog row %q max_4k_ttft_ms must be >= 0", key)
+		}
+		normalizedModelID := normalizeModelID(row.ModelID)
+		keysByModel[normalizedModelID] = append(keysByModel[normalizedModelID], key)
+	}
+	return &Catalog{
+		Version:     envelope.Version,
+		SHA256:      hex.EncodeToString(sum[:]),
+		RawJSON:     append([]byte(nil), rawJSON...),
+		rowsByKey:   envelope.Rows,
+		keysByModel: keysByModel,
+	}, nil
+}
+
+func (c *Catalog) Row(key string) (Row, bool) {
+	if c == nil {
+		return Row{}, false
+	}
+	row, ok := c.rowsByKey[key]
+	return row, ok
+}
+
+func (c *Catalog) HighestClaimedTier(modelID string) (key string, row Row, ok bool) {
+	if c == nil {
+		return "", Row{}, false
+	}
+	keys := c.keysByModel[normalizeModelID(modelID)]
+	if len(keys) == 0 {
+		return "", Row{}, false
+	}
+	bestKey := keys[0]
+	bestRow := c.rowsByKey[bestKey]
+	for _, candidateKey := range keys[1:] {
+		candidate := c.rowsByKey[candidateKey]
+		if candidate.MinRAMGB > bestRow.MinRAMGB {
+			bestKey = candidateKey
+			bestRow = candidate
+		}
+	}
+	return bestKey, bestRow, true
+}
+
+func normalizeModelID(modelID string) string {
+	return strings.ToLower(strings.TrimSpace(modelID))
+}

--- a/phase4-coordinator/internal/autotune/evidence.go
+++ b/phase4-coordinator/internal/autotune/evidence.go
@@ -1,0 +1,33 @@
+package autotune
+
+import (
+	"context"
+	"time"
+)
+
+type VerifiedBenchmark struct {
+	ModelKey                string
+	ModelID                 string
+	SustainedTPS            float64
+	TTFTMS                  int
+	SwapDetected            bool
+	ThermalThrottleDetected bool
+	ArtifactSHA256          string
+	CandidateCatalogSHA256  string
+}
+
+type VerifiedEvidence struct {
+	GeneratedAt              time.Time
+	CandidateCatalogSHA256   string
+	Benchmarks               []VerifiedBenchmark
+}
+
+type EvidenceStore interface {
+	LatestVerified(ctx context.Context, providerID string, ttl time.Duration) (VerifiedEvidence, bool, error)
+}
+
+type AdmissionCap struct {
+	ModelKey string
+	ModelID  string
+	MinRAMGB int
+}

--- a/phase4-coordinator/internal/autotune/evidence_pg.go
+++ b/phase4-coordinator/internal/autotune/evidence_pg.go
@@ -1,0 +1,96 @@
+package autotune
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type PGEvidenceStore struct {
+	db  *sql.DB
+	now func() time.Time
+}
+
+func NewPGEvidenceStore(db *sql.DB) *PGEvidenceStore {
+	return &PGEvidenceStore{db: db, now: time.Now}
+}
+
+func (s *PGEvidenceStore) LatestVerified(ctx context.Context, providerID string, ttl time.Duration) (VerifiedEvidence, bool, error) {
+	if s == nil || s.db == nil {
+		return VerifiedEvidence{}, false, errors.New("autotune evidence store is nil")
+	}
+	providerID = strings.TrimSpace(providerID)
+	if providerID == "" {
+		return VerifiedEvidence{}, false, errors.New("provider_id is required")
+	}
+	if ttl <= 0 {
+		return VerifiedEvidence{}, false, errors.New("evidence ttl must be > 0")
+	}
+	now := time.Now().UTC()
+	if s.now != nil {
+		now = s.now().UTC()
+	}
+	cutoff := now.Add(-ttl)
+
+	var rawEvidence []byte
+	var generatedAt time.Time
+	err := s.db.QueryRowContext(ctx, `
+SELECT generated_at, evidence
+  FROM hardware_verification_jobs
+ WHERE provider_id = $1
+   AND status = 'verified'
+   AND generated_at >= $2
+ ORDER BY generated_at DESC, id DESC
+ LIMIT 1`, providerID, cutoff).Scan(&generatedAt, &rawEvidence)
+	if errors.Is(err, sql.ErrNoRows) {
+		return VerifiedEvidence{}, false, nil
+	}
+	if err != nil {
+		return VerifiedEvidence{}, false, fmt.Errorf("load verified autotune evidence: %w", err)
+	}
+	evidence, err := decodeVerifiedEvidence(rawEvidence, generatedAt)
+	if err != nil {
+		return VerifiedEvidence{}, false, err
+	}
+	return evidence, true, nil
+}
+
+func decodeVerifiedEvidence(raw []byte, generatedAt time.Time) (VerifiedEvidence, error) {
+	var payload struct {
+		CandidateCatalogSHA256 string `json:"candidate_catalog_sha256"`
+		Benchmarks             []struct {
+			ModelKey                string  `json:"model_key"`
+			ModelID                 string  `json:"model_id"`
+			SustainedTPS            float64 `json:"sustained_tps"`
+			TTFTMS                  int     `json:"ttft_ms"`
+			SwapDetected            bool    `json:"swap_detected"`
+			ThermalThrottleDetected bool    `json:"thermal_throttle_detected"`
+			ArtifactSHA256          string  `json:"artifact_sha256"`
+			CandidateCatalogSHA256  string  `json:"candidate_catalog_sha256"`
+		} `json:"benchmarks"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return VerifiedEvidence{}, fmt.Errorf("decode verified autotune evidence: %w", err)
+	}
+	out := VerifiedEvidence{
+		GeneratedAt:            generatedAt.UTC(),
+		CandidateCatalogSHA256: strings.TrimSpace(payload.CandidateCatalogSHA256),
+	}
+	for _, b := range payload.Benchmarks {
+		out.Benchmarks = append(out.Benchmarks, VerifiedBenchmark{
+			ModelKey:                strings.TrimSpace(b.ModelKey),
+			ModelID:                 strings.TrimSpace(b.ModelID),
+			SustainedTPS:            b.SustainedTPS,
+			TTFTMS:                  b.TTFTMS,
+			SwapDetected:            b.SwapDetected,
+			ThermalThrottleDetected: b.ThermalThrottleDetected,
+			ArtifactSHA256:          strings.TrimSpace(b.ArtifactSHA256),
+			CandidateCatalogSHA256:  strings.TrimSpace(b.CandidateCatalogSHA256),
+		})
+	}
+	return out, nil
+}

--- a/phase4-coordinator/internal/autotune/gate.go
+++ b/phase4-coordinator/internal/autotune/gate.go
@@ -1,0 +1,99 @@
+package autotune
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+type HelloGateDecision struct {
+	Allowed              bool
+	Reason               string
+	MaxAdmittedModelKey  string
+	MaxAdmittedModelID   string
+	MaxAdmittedMinRAMGB  int
+	ClaimedModelKey      string
+	ClaimedMinRAMGB      int
+}
+
+func ResolveMaxAdmission(catalog *Catalog, evidence VerifiedEvidence) (AdmissionCap, error) {
+	if catalog == nil {
+		return AdmissionCap{}, fmt.Errorf("autotune catalog is nil")
+	}
+	if strings.TrimSpace(evidence.CandidateCatalogSHA256) == "" {
+		return AdmissionCap{}, fmt.Errorf("verified evidence missing candidate_catalog_sha256")
+	}
+	if !strings.EqualFold(strings.TrimSpace(evidence.CandidateCatalogSHA256), catalog.SHA256) {
+		return AdmissionCap{}, fmt.Errorf("verified evidence candidate_catalog_sha256 mismatch")
+	}
+	var cap AdmissionCap
+	for _, benchmark := range evidence.Benchmarks {
+		row, ok := catalog.Row(benchmark.ModelKey)
+		if !ok {
+			continue
+		}
+		if !benchmarkPassesGate(benchmark, row, evidence.CandidateCatalogSHA256) {
+			continue
+		}
+		if row.MinRAMGB >= cap.MinRAMGB {
+			cap = AdmissionCap{
+				ModelKey: benchmark.ModelKey,
+				ModelID:  row.ModelID,
+				MinRAMGB: row.MinRAMGB,
+			}
+		}
+	}
+	if cap.ModelKey == "" {
+		return AdmissionCap{}, fmt.Errorf("verified evidence has no passing benchmark rows")
+	}
+	return cap, nil
+}
+
+func EvaluateHelloGate(catalog *Catalog, evidence VerifiedEvidence, helloModelID string) HelloGateDecision {
+	decision := HelloGateDecision{Allowed: true}
+	cap, err := ResolveMaxAdmission(catalog, evidence)
+	if err != nil {
+		decision.Allowed = false
+		decision.Reason = "autotune_evidence_invalid"
+		return decision
+	}
+	decision.MaxAdmittedModelKey = cap.ModelKey
+	decision.MaxAdmittedModelID = cap.ModelID
+	decision.MaxAdmittedMinRAMGB = cap.MinRAMGB
+
+	claimedKey, claimedRow, ok := catalog.HighestClaimedTier(helloModelID)
+	if !ok {
+		decision.Allowed = false
+		decision.Reason = "autotune_model_uncatalogued"
+		return decision
+	}
+	decision.ClaimedModelKey = claimedKey
+	decision.ClaimedMinRAMGB = claimedRow.MinRAMGB
+	if claimedRow.MinRAMGB > cap.MinRAMGB {
+		decision.Allowed = false
+		decision.Reason = "autotune_model_cap_exceeded"
+	}
+	return decision
+}
+
+func benchmarkPassesGate(benchmark VerifiedBenchmark, row Row, catalogSHA256 string) bool {
+	if benchmark.ThermalThrottleDetected {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(benchmark.CandidateCatalogSHA256), strings.TrimSpace(catalogSHA256)) {
+		return false
+	}
+	if strings.TrimSpace(benchmark.ModelID) != "" && !strings.EqualFold(strings.TrimSpace(benchmark.ModelID), strings.TrimSpace(row.ModelID)) {
+		return false
+	}
+	if strings.TrimSpace(benchmark.ArtifactSHA256) != "" && !strings.EqualFold(strings.TrimSpace(benchmark.ArtifactSHA256), strings.TrimSpace(row.ModelSHA256)) {
+		return false
+	}
+	if math.IsNaN(benchmark.SustainedTPS) || math.IsInf(benchmark.SustainedTPS, 0) || benchmark.SustainedTPS < row.BenchGate.MinSustainedTPS {
+		return false
+	}
+	if benchmark.TTFTMS > row.BenchGate.Max4KTTFTMS {
+		return false
+	}
+	return true
+}

--- a/phase4-coordinator/internal/autotune/gate_test.go
+++ b/phase4-coordinator/internal/autotune/gate_test.go
@@ -1,0 +1,104 @@
+package autotune_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/autotune"
+)
+
+func TestParseCatalogFromDistStatic(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join("..", "..", "..", "phase3-binary", "dist", "static", "autotune-candidates.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	catalog, err := autotune.ParseCatalog(raw)
+	if err != nil {
+		t.Fatalf("ParseCatalog: %v", err)
+	}
+	if catalog.Version == "" {
+		t.Fatal("catalog version is empty")
+	}
+	if len(catalog.SHA256) != 64 {
+		t.Fatalf("catalog sha256 len = %d, want 64", len(catalog.SHA256))
+	}
+	if _, _, ok := catalog.HighestClaimedTier("mlx-community/Qwen3-8B-4bit"); !ok {
+		t.Fatal("expected qwen3-8b model_id lookup")
+	}
+}
+
+func TestEvaluateHelloGateUnderTierAllowedOverTierRejected(t *testing.T) {
+	t.Parallel()
+	catalog := mustCatalog(t, `{
+		"version":"test",
+		"generated_at":"2026-07-08T00:00:00Z",
+		"source":"operator_curated_autotune_candidate_catalog",
+		"rows":{
+			"small":{"model_id":"mlx-community/Llama-3.2-3B-Instruct-4bit","model_revision":"7f0dc925e0d0afb0322d96f9255cfddf2ba5636e","model_sha256":"3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a","min_ram_gb":4,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":15,"max_4k_ttft_ms":2500},"runtime_status":"recommendable"},
+			"large":{"model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","model_revision":"6e302ea604ad9ab206367e2c501d1571023e7b6d","model_sha256":"10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0","min_ram_gb":28,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":20,"max_4k_ttft_ms":3000},"runtime_status":"recommendable"}
+		}
+	}`)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{
+			{
+				ModelKey:               "small",
+				ModelID:                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+				SustainedTPS:           20,
+				TTFTMS:                 1000,
+				ArtifactSHA256:         "3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a",
+				CandidateCatalogSHA256: catalog.SHA256,
+			},
+		},
+	}
+	allowed := autotune.EvaluateHelloGate(catalog, evidence, "mlx-community/Llama-3.2-3B-Instruct-4bit")
+	if !allowed.Allowed || allowed.MaxAdmittedModelKey != "small" {
+		t.Fatalf("under-tier hello: %+v", allowed)
+	}
+	rejected := autotune.EvaluateHelloGate(catalog, evidence, "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit")
+	if rejected.Allowed || rejected.Reason != "autotune_model_cap_exceeded" {
+		t.Fatalf("over-tier hello: %+v", rejected)
+	}
+}
+
+func TestEvaluateHelloGateRejectsThermalThrottle(t *testing.T) {
+	t.Parallel()
+	catalog := mustCatalog(t, `{
+		"version":"test",
+		"generated_at":"2026-07-08T00:00:00Z",
+		"source":"operator_curated_autotune_candidate_catalog",
+		"rows":{
+			"small":{"model_id":"mlx-community/Llama-3.2-3B-Instruct-4bit","model_revision":"7f0dc925e0d0afb0322d96f9255cfddf2ba5636e","model_sha256":"3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a","min_ram_gb":4,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":15,"max_4k_ttft_ms":2500},"runtime_status":"recommendable"}
+		}
+	}`)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{
+			{
+				ModelKey:                "small",
+				ModelID:                 "mlx-community/Llama-3.2-3B-Instruct-4bit",
+				SustainedTPS:            20,
+				TTFTMS:                  1000,
+				ThermalThrottleDetected: true,
+				ArtifactSHA256:          "3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a",
+				CandidateCatalogSHA256:  catalog.SHA256,
+			},
+		},
+	}
+	decision := autotune.EvaluateHelloGate(catalog, evidence, "mlx-community/Llama-3.2-3B-Instruct-4bit")
+	if decision.Allowed || decision.Reason != "autotune_evidence_invalid" {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func mustCatalog(t *testing.T, raw string) *autotune.Catalog {
+	t.Helper()
+	catalog, err := autotune.ParseCatalog([]byte(raw))
+	if err != nil {
+		t.Fatalf("ParseCatalog: %v", err)
+	}
+	return catalog
+}

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -59,8 +59,17 @@ type Config struct {
 	Stats                        StatsConfig                  `yaml:"stats"`
 	Onboarding                   OnboardingConfig             `yaml:"onboarding"`
 	AutotuneFeeds                AutotuneFeedsConfig          `yaml:"autotune"`
+	ProofOfWeights               ProofOfWeightsConfig       `yaml:"proof_of_weights"`
 	Proxy                        ProxyConfig                  `yaml:"proxy"`
 	Providers                    []ProviderConfig             `yaml:"providers"`
+}
+
+// ProofOfWeightsConfig gates Session B integrity controls. Defaults keep
+// legacy self-declared hello model_id behavior until the operator enables
+// the autotune hello gate explicitly.
+type ProofOfWeightsConfig struct {
+	RequireAutotuneHelloGate bool `yaml:"require_autotune_hello_gate"`
+	AutotuneEvidenceTTLDays  int  `yaml:"autotune_evidence_ttl_days"`
 }
 
 type CoordinatorConfig struct {
@@ -679,6 +688,10 @@ func Default() Config {
 			ProvisionalQuotaPerHour:         100,
 			ProvisionalTierWeight:           0.3,
 			ProvisionalRetentionDays:        30,
+		},
+		ProofOfWeights: ProofOfWeightsConfig{
+			RequireAutotuneHelloGate: false,
+			AutotuneEvidenceTTLDays:  30,
 		},
 		Tier2: Tier2Config{
 			ObserveEnabled:                 false,
@@ -1340,6 +1353,9 @@ func (c Config) Validate() error {
 	if err := c.validateAutotuneFeeds(); err != nil {
 		return err
 	}
+	if err := c.validateProofOfWeights(); err != nil {
+		return err
+	}
 	if _, ok := c.Rewards.RateCard["default"]; !ok {
 		return fmt.Errorf("rewards.rate_card must contain default")
 	}
@@ -1366,6 +1382,27 @@ func (c Config) Validate() error {
 				return fmt.Errorf("provider %q endpoint_url must be a valid https URL (http allowed only for 127.0.0.1/localhost)", p.ProviderID)
 			}
 		}
+	}
+	return nil
+}
+
+func (c Config) validateProofOfWeights() error {
+	p := c.ProofOfWeights
+	if p.AutotuneEvidenceTTLDays < 0 {
+		return fmt.Errorf("proof_of_weights.autotune_evidence_ttl_days must be >= 0")
+	}
+	if !p.RequireAutotuneHelloGate {
+		return nil
+	}
+	if p.AutotuneEvidenceTTLDays <= 0 {
+		return fmt.Errorf("proof_of_weights.autotune_evidence_ttl_days must be > 0 when require_autotune_hello_gate is true")
+	}
+	a := c.AutotuneFeeds
+	if strings.TrimSpace(a.AutotuneCandidatesPath) == "" || strings.TrimSpace(a.AutotuneCandidatesSigPath) == "" {
+		return fmt.Errorf("proof_of_weights.require_autotune_hello_gate requires autotune.autotune_candidates_path and autotune.autotune_candidates_sig_path")
+	}
+	if !c.Onboarding.AppTrackRegisterEnabled || strings.TrimSpace(c.Onboarding.PostgresDSN) == "" {
+		return fmt.Errorf("proof_of_weights.require_autotune_hello_gate requires onboarding.app_track_register_enabled and onboarding.postgres_dsn")
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/config/proof_of_weights_test.go
+++ b/phase4-coordinator/internal/config/proof_of_weights_test.go
@@ -1,0 +1,24 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+)
+
+func TestValidateProofOfWeightsRequiresFeedsAndOnboarding(t *testing.T) {
+	cfg := config.Default()
+	cfg.Auth.OperatorKey = "test-operator-key"
+	cfg.ProofOfWeights.RequireAutotuneHelloGate = true
+	cfg.ProofOfWeights.AutotuneEvidenceTTLDays = 30
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "autotune.autotune_candidates_path") {
+		t.Fatalf("Validate() = %v, want autotune feed requirement", err)
+	}
+
+	cfg.AutotuneFeeds.AutotuneCandidatesPath = "/tmp/autotune-candidates.json"
+	cfg.AutotuneFeeds.AutotuneCandidatesSigPath = "/tmp/autotune-candidates.json.sig"
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "onboarding.app_track_register_enabled") {
+		t.Fatalf("Validate() = %v, want onboarding requirement", err)
+	}
+}

--- a/phase4-coordinator/internal/onboarding/store_pg.go
+++ b/phase4-coordinator/internal/onboarding/store_pg.go
@@ -91,6 +91,15 @@ func (s *PGStore) Close() error {
 	return err
 }
 
+// DB exposes the primary onboarding postgres handle for read-only consumers
+// such as the proof-of-weights autotune hello gate.
+func (s *PGStore) DB() *sql.DB {
+	if s == nil {
+		return nil
+	}
+	return s.db
+}
+
 func (s *PGStore) Smoke(ctx context.Context) error {
 	if s == nil || s.db == nil {
 		return errors.New("onboarding postgres store is nil")

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -161,6 +161,11 @@ type Provider struct {
 	// AttestationStatus and from verified stats hardware inventory: it can make
 	// cores/bandwidth visible without claiming hardware attestation.
 	HardwareCapacity *ProviderHardwareCapacity `json:"hardware_capacity,omitempty"`
+	// Proof of Weights W2 — coordinator-side autotune hello gate cap derived
+	// from latest verified hardware-evidence benchmarks. Empty when gate off
+	// or provider admitted before W2 rollout.
+	MaxAdmittedModelKey string `json:"max_admitted_model_class,omitempty"`
+	MaxAdmittedModelID  string `json:"max_admitted_model_id,omitempty"`
 
 	// SPEC-002 v1.3.5 §3.X.1 — populated from v2 auth_request initial-stage
 	// supported_models[] per SPEC-010 v1.5 R-3.3.1; nil for the L-1 baseline.

--- a/phase4-coordinator/internal/ws/autotune_hello_gate_test.go
+++ b/phase4-coordinator/internal/ws/autotune_hello_gate_test.go
@@ -1,0 +1,147 @@
+package ws_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/autotune"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
+	gobwas "github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+)
+
+type stubAutotuneEvidence struct {
+	evidence autotune.VerifiedEvidence
+	ok       bool
+	err      error
+}
+
+func (s stubAutotuneEvidence) LatestVerified(context.Context, string, time.Duration) (autotune.VerifiedEvidence, bool, error) {
+	return s.evidence, s.ok, s.err
+}
+
+func TestAutotuneHelloGateRejectsOverTierClaim(t *testing.T) {
+	catalog := mustAutotuneCatalog(t)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{
+			{
+				ModelKey:               "small",
+				ModelID:                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+				SustainedTPS:           20,
+				TTFTMS:                 1000,
+				ArtifactSHA256:         "3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a",
+				CandidateCatalogSHA256: catalog.SHA256,
+			},
+		},
+	}
+	h := newProviderHarnessWithServerOptions(t, nil, []providerws.Option{
+		providerws.WithAutotuneHelloGate(catalog, stubAutotuneEvidence{evidence: evidence, ok: true}),
+	}, func(cfg *config.Config) {
+		cfg.ProofOfWeights.RequireAutotuneHelloGate = true
+		cfg.ProofOfWeights.AutotuneEvidenceTTLDays = 30
+	})
+	defer h.HTTP.Close()
+
+	hello := validHello("m4-anon")
+	hello["model_id"] = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"
+	code, reason := sendHelloExpectClose(t, h.HTTP.URL, hello)
+	if code != providerws.CloseInvalidHello || reason != "autotune_model_cap_exceeded" {
+		t.Fatalf("code=%d reason=%q", code, reason)
+	}
+}
+
+func TestAutotuneHelloGateAllowsUnderTierClaim(t *testing.T) {
+	catalog := mustAutotuneCatalog(t)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{
+			{
+				ModelKey:               "small",
+				ModelID:                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+				SustainedTPS:           20,
+				TTFTMS:                 1000,
+				ArtifactSHA256:         "3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a",
+				CandidateCatalogSHA256: catalog.SHA256,
+			},
+		},
+	}
+	h := newProviderHarnessWithServerOptions(t, nil, []providerws.Option{
+		providerws.WithAutotuneHelloGate(catalog, stubAutotuneEvidence{evidence: evidence, ok: true}),
+	}, func(cfg *config.Config) {
+		cfg.ProofOfWeights.RequireAutotuneHelloGate = true
+		cfg.ProofOfWeights.AutotuneEvidenceTTLDays = 30
+	})
+	defer h.HTTP.Close()
+
+	hello := validHello("m4-anon")
+	hello["model_id"] = "mlx-community/Llama-3.2-3B-Instruct-4bit"
+	conn, _, _, err := gobwas.Dial(context.Background(), wsURL(h.HTTP.URL))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	if err := wsutil.WriteClientText(conn, mustJSON(hello)); err != nil {
+		t.Fatalf("write hello: %v", err)
+	}
+	payload, op, err := wsutil.ReadServerData(conn)
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+	if op != gobwas.OpText {
+		t.Fatalf("op = %v, want text", op)
+	}
+	var ack map[string]any
+	if err := json.Unmarshal(payload, &ack); err != nil {
+		t.Fatalf("ack json: %v", err)
+	}
+	if ack["type"] != "hello_ack" {
+		t.Fatalf("ack type = %v", ack["type"])
+	}
+	provider, ok := h.Registry.Resolve("m4-anon", ack["assigned_id"].(string))
+	if !ok {
+		t.Fatal("provider not registered")
+	}
+	if provider.MaxAdmittedModelKey != "small" {
+		t.Fatalf("MaxAdmittedModelKey = %q, want small", provider.MaxAdmittedModelKey)
+	}
+	if provider.MaxAdmittedModelID != "mlx-community/Llama-3.2-3B-Instruct-4bit" {
+		t.Fatalf("MaxAdmittedModelID = %q", provider.MaxAdmittedModelID)
+	}
+}
+
+func TestAutotuneHelloGateRejectsMissingEvidence(t *testing.T) {
+	catalog := mustAutotuneCatalog(t)
+	h := newProviderHarnessWithServerOptions(t, nil, []providerws.Option{
+		providerws.WithAutotuneHelloGate(catalog, stubAutotuneEvidence{ok: false}),
+	}, func(cfg *config.Config) {
+		cfg.ProofOfWeights.RequireAutotuneHelloGate = true
+		cfg.ProofOfWeights.AutotuneEvidenceTTLDays = 30
+	})
+	defer h.HTTP.Close()
+
+	code, reason := sendHelloExpectClose(t, h.HTTP.URL, validHello("m4-anon"))
+	if code != providerws.CloseInvalidHello || reason != "autotune_evidence_required" {
+		t.Fatalf("code=%d reason=%q", code, reason)
+	}
+}
+
+func mustAutotuneCatalog(t *testing.T) *autotune.Catalog {
+	t.Helper()
+	catalog, err := autotune.ParseCatalog([]byte(`{
+		"version":"test",
+		"generated_at":"2026-07-08T00:00:00Z",
+		"source":"operator_curated_autotune_candidate_catalog",
+		"rows":{
+			"small":{"model_id":"mlx-community/Llama-3.2-3B-Instruct-4bit","model_revision":"7f0dc925e0d0afb0322d96f9255cfddf2ba5636e","model_sha256":"3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a","min_ram_gb":4,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":15,"max_4k_ttft_ms":2500},"runtime_status":"recommendable"},
+			"large":{"model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","model_revision":"6e302ea604ad9ab206367e2c501d1571023e7b6d","model_sha256":"10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0","min_ram_gb":28,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":20,"max_4k_ttft_ms":3000},"runtime_status":"recommendable"}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseCatalog: %v", err)
+	}
+	return catalog
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/autotune"
 )
 
 const (
@@ -86,6 +87,8 @@ type Server struct {
 	// want isolation from the package-singleton; nil means "use
 	// tier2.Default()". M3-8d (audit TEST-4). See s.catalogRef().
 	catalog            *tier2.Catalog
+	autotuneCatalog    *autotune.Catalog
+	autotuneEvidence   autotune.EvidenceStore
 	identitySignatures IdentitySignatureStore
 	authPolicyAdmin    ProviderAuthPolicyAdminStore
 	idlePrewarm        IdlePrewarmRecorder
@@ -189,6 +192,17 @@ type Option func(*Server)
 func WithCatalog(c *tier2.Catalog) Option {
 	return func(s *Server) {
 		s.catalog = c
+	}
+}
+
+// WithAutotuneHelloGate wires Session B proof-of-weights capacity ceiling
+// inputs. When cfg.ProofOfWeights.RequireAutotuneHelloGate is true, hello
+// admission consults catalog + verified hardware-evidence before registering
+// the provider.
+func WithAutotuneHelloGate(catalog *autotune.Catalog, store autotune.EvidenceStore) Option {
+	return func(s *Server) {
+		s.autotuneCatalog = catalog
+		s.autotuneEvidence = store
 	}
 }
 
@@ -1178,6 +1192,48 @@ func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hell
 			tier2.LogHashRequiredProviderExcluded(s.log, hello.ProviderID, assignedID, hello.ModelID, hello.ModelHash, hashStatus)
 		}
 	}
+	maxAdmittedModelKey := ""
+	maxAdmittedModelID := ""
+	if s.cfg.ProofOfWeights.RequireAutotuneHelloGate {
+		if s.autotuneCatalog == nil || s.autotuneEvidence == nil {
+			s.log.Error().Str("provider_id", hello.ProviderID).Msg("autotune hello gate enabled but dependencies are not wired")
+			s.close(conn, CloseInvalidHello, "autotune_gate_unavailable")
+			return nil, false
+		}
+		ttl := time.Duration(s.cfg.ProofOfWeights.AutotuneEvidenceTTLDays) * 24 * time.Hour
+		evidence, ok, err := s.autotuneEvidence.LatestVerified(context.Background(), hello.ProviderID, ttl)
+		if err != nil {
+			s.log.Warn().Err(err).Str("provider_id", hello.ProviderID).Msg("autotune hello gate evidence lookup failed")
+			s.close(conn, CloseInvalidHello, "autotune_gate_unavailable")
+			return nil, false
+		}
+		if !ok {
+			s.log.Info().
+				Str("provider_id", hello.ProviderID).
+				Str("event", "autotune_evidence_required").
+				Str("model_id", hello.ModelID).
+				Msg("autotune hello gate rejected connect without verified hardware evidence")
+			s.close(conn, CloseInvalidHello, "autotune_evidence_required")
+			return nil, false
+		}
+		decision := autotune.EvaluateHelloGate(s.autotuneCatalog, evidence, hello.ModelID)
+		if !decision.Allowed {
+			s.log.Info().
+				Str("provider_id", hello.ProviderID).
+				Str("event", decision.Reason).
+				Str("model_id", hello.ModelID).
+				Str("claimed_model_key", decision.ClaimedModelKey).
+				Str("max_admitted_model_class", decision.MaxAdmittedModelKey).
+				Str("max_admitted_model_id", decision.MaxAdmittedModelID).
+				Int("claimed_min_ram_gb", decision.ClaimedMinRAMGB).
+				Int("max_admitted_min_ram_gb", decision.MaxAdmittedMinRAMGB).
+				Msg("autotune hello gate rejected provider model claim")
+			s.close(conn, CloseInvalidHello, decision.Reason)
+			return nil, false
+		}
+		maxAdmittedModelKey = decision.MaxAdmittedModelKey
+		maxAdmittedModelID = decision.MaxAdmittedModelID
+	}
 	initialState := pool.StateReady
 	if s.cfg.Pool.WarmupGateEnabled {
 		initialState = pool.StateDegraded
@@ -1206,6 +1262,8 @@ func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hell
 		BinaryVersion:         hello.BinaryVersion,
 		ModelHash:             hello.ModelHash,
 		HashStatus:            hashStatus,
+		MaxAdmittedModelKey:   maxAdmittedModelKey,
+		MaxAdmittedModelID:    maxAdmittedModelID,
 	}, true
 }
 


### PR DESCRIPTION
## Summary
- Add W1 inventory audit documenting existing catalog hash enforcement seams (routing exclude, settlement quarantine) in `docs/research/proof-of-weights-w1-inventory.md`.
- Implement W2 autotune hello gate: coordinator rejects WS hello when claimed `model_id` exceeds verified hardware-evidence bench cap; exposes `max_admitted_model_class` / `max_admitted_model_id` on provider records.
- Gate is config-flagged off by default (`proof_of_weights.require_autotune_hello_gate: false`) for safe rollback.

## Test plan
- [x] `go test ./internal/autotune/ ./internal/config/ ./internal/ws/ -run 'Autotune|ProofOfWeights|ParseCatalogFromDist'`
- [x] `go build ./cmd/coordinator/`
- [ ] Enable `proof_of_weights.require_autotune_hello_gate: true` on staging after hardware verifier promotes evidence
- [ ] Lab: provider with 8B bench evidence rejected on 30B hello; under-tier hello admitted


Made with [Cursor](https://cursor.com)